### PR TITLE
refactor(web): shared eden unwrap, settings mutation, and clause field-save helpers

### DIFF
--- a/apps/web/src/components/breadcrumbs/chat-breadcrumb.tsx
+++ b/apps/web/src/components/breadcrumbs/chat-breadcrumb.tsx
@@ -16,7 +16,7 @@ import { useInlineRename } from "@/hooks/use-inline-rename";
 import { getAnalytics } from "@/lib/analytics/provider";
 import { api } from "@/lib/api";
 import { isPlaceholderThreadTitle } from "@/lib/chat-thread-title";
-import { toAPIError } from "@/lib/errors/api";
+import { unwrapEden } from "@/lib/errors/api";
 import { toSafeId } from "@/lib/safe-id";
 import {
   chatThreadTitleOptions,
@@ -92,10 +92,7 @@ export const ChatBreadcrumb = ({
               : {},
           },
         );
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-      return response.data;
+      return unwrapEden(response);
     },
     onMutate: async (nextTitle) => {
       await queryClient.cancelQueries({ queryKey: groupedKey });

--- a/apps/web/src/components/chat/case-law-open.ts
+++ b/apps/web/src/components/chat/case-law-open.ts
@@ -10,7 +10,7 @@ import {
   isCaseLawDecisionId,
   pickCaseLawDecisionHit,
 } from "@/lib/case-law-route";
-import { toAPIError } from "@/lib/errors/api";
+import { unwrapEden } from "@/lib/errors/api";
 import { userErrorFromThrown } from "@/lib/errors/user-safe";
 import { assertPublicLawApiData } from "@/lib/public-law-api";
 import { toSafeId } from "@/lib/safe-id";
@@ -43,10 +43,7 @@ const resolveCaseLawDecisionRouteParams = async (
       .decisions({ decisionId: toSafeId<"caseLawDecision">(decisionRef) })
       .get();
 
-    if (response.error) {
-      throw toAPIError(response.error);
-    }
-    const data = response.data;
+    const data = unwrapEden(response);
     assertPublicLawApiData(data, "resolvePublicCaseLawDecision");
 
     return createCaseLawDecisionRouteParams({
@@ -62,10 +59,7 @@ const resolveCaseLawDecisionRouteParams = async (
     limit: CASE_LAW_LINK_SEARCH_LIMIT,
   });
 
-  if (response.error) {
-    throw toAPIError(response.error);
-  }
-  const data = response.data;
+  const data = unwrapEden(response);
   assertPublicLawApiData(data, "searchPublicCaseLawDecisionLinks");
 
   const hit = pickCaseLawDecisionHit(decisionRef, data.hits);

--- a/apps/web/src/components/chat/entity-open.ts
+++ b/apps/web/src/components/chat/entity-open.ts
@@ -4,7 +4,7 @@ import { isEntityActiveInMainRoute } from "@/components/chat/entity-route-detect
 import { getTranslator } from "@/i18n/i18n-store";
 import { getAnalytics } from "@/lib/analytics/provider";
 import { api } from "@/lib/api";
-import { toAPIError } from "@/lib/errors/api";
+import { unwrapEden } from "@/lib/errors/api";
 import { userErrorFromThrown } from "@/lib/errors/user-safe";
 import { toSafeId } from "@/lib/safe-id";
 import { isFileDisplayable } from "@/lib/types";
@@ -140,14 +140,12 @@ export const openEntityInInspector = async (
       .entity({ entityId: toSafeId<"entity">(entityId) })
       .get();
 
-    if (response.error) {
-      throw toAPIError(response.error);
-    }
+    const data = unwrapEden(response);
 
-    const responseLabel = response.data.name;
+    const responseLabel = data.name;
     const openedByKind = openEntityByKind({
       entityId,
-      kind: response.data.kind,
+      kind: data.kind,
       label: responseLabel,
       workspaceId,
     });
@@ -157,7 +155,7 @@ export const openEntityInInspector = async (
 
     const opened = openDisplayableFile({
       entityId,
-      fields: response.data.fields,
+      fields: data.fields,
       label: responseLabel,
       workspaceId,
     });

--- a/apps/web/src/components/contact-picker-queries.ts
+++ b/apps/web/src/components/contact-picker-queries.ts
@@ -1,7 +1,7 @@
 import { queryOptions } from "@tanstack/react-query";
 
 import { api } from "@/lib/api";
-import { toAPIError } from "@/lib/errors/api";
+import { unwrapEden } from "@/lib/errors/api";
 import type { QueryOptionsInput } from "@/lib/react-query";
 
 type ContactPickerOrganizationKey = {
@@ -42,10 +42,6 @@ export const contactPickerSearchOptions = ({
         fetch: { signal },
       });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      return response.data.items;
+      return unwrapEden(response).items;
     },
   });

--- a/apps/web/src/components/inspector/anonymization-facet.tsx
+++ b/apps/web/src/components/inspector/anonymization-facet.tsx
@@ -60,7 +60,7 @@ import type { TranslationKey } from "@/i18n/types";
 import { useAnalytics } from "@/lib/analytics/provider";
 import { api } from "@/lib/api";
 import { compareByLocale } from "@/lib/collation";
-import { toAPIError } from "@/lib/errors/api";
+import { toAPIError, unwrapEden } from "@/lib/errors/api";
 import { userErrorFromThrown } from "@/lib/errors/user-safe";
 import { toSafeId } from "@/lib/safe-id";
 import {
@@ -234,11 +234,7 @@ export const AnonymizationFacet = ({
           queryKey: anonymizationTermsKeys.all(vars.workspaceId),
         });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      return response.data;
+      return unwrapEden(response);
     },
     onError: (error) => {
       analytics.captureError(error);
@@ -440,10 +436,7 @@ export const AnonymizationFacet = ({
                   entityId: vars.entityId,
                 }),
         });
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-      return response.data;
+      return unwrapEden(response);
     },
     onError: (error) => {
       analytics.captureError(error);

--- a/apps/web/src/components/inspector/file-tab-panel.tsx
+++ b/apps/web/src/components/inspector/file-tab-panel.tsx
@@ -53,7 +53,7 @@ import { usePlaybooksPreviewEnabled } from "@/hooks/use-playbooks-preview";
 import { useAnalytics } from "@/lib/analytics/provider";
 import { api } from "@/lib/api";
 import { DOCX_MIME, MARKDOWN_MIME, TOOLBAR_ROW_HEIGHT } from "@/lib/consts";
-import { toAPIError } from "@/lib/errors/api";
+import { unwrapEden } from "@/lib/errors/api";
 import { userErrorFromThrown } from "@/lib/errors/user-safe";
 import { toSafeId } from "@/lib/safe-id";
 import { DocxBrowserEditor } from "@/routes/_protected.workspaces/$workspaceId/-components/docx/docx-browser-editor";
@@ -222,11 +222,7 @@ export const FileTabPanel = ({
           file,
         });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      return response.data;
+      return unwrapEden(response);
     },
     onSuccess: async (response, variables) => {
       replaceFileFieldId(variables.fieldId, {

--- a/apps/web/src/components/require-ai-key.tsx
+++ b/apps/web/src/components/require-ai-key.tsx
@@ -42,7 +42,7 @@ import { useMountEffect } from "@/hooks/use-effect";
 import { useAnalytics } from "@/lib/analytics/provider";
 import { api } from "@/lib/api";
 import { useAuthenticatedUser } from "@/lib/authenticated-user-context";
-import { toAPIError } from "@/lib/errors/api";
+import { unwrapEden } from "@/lib/errors/api";
 import { userErrorFromThrown } from "@/lib/errors/user-safe";
 import {
   aiAvailabilityOptions,
@@ -326,11 +326,7 @@ export function AIKeyRequiredDialog({
         overrideModels,
       });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      return response.data;
+      return unwrapEden(response);
     },
     onSuccess: async (data) => {
       setProviders(providerDraftsFromStoredProviders(data.providers));

--- a/apps/web/src/components/search-dialog.tsx
+++ b/apps/web/src/components/search-dialog.tsx
@@ -71,7 +71,7 @@ import { useAnalytics } from "@/lib/analytics/provider";
 import { api } from "@/lib/api";
 import { useAuthenticatedUser } from "@/lib/authenticated-user-context";
 import { createCaseLawDecisionRouteParams } from "@/lib/case-law-route";
-import { toAPIError } from "@/lib/errors/api";
+import { unwrapEden } from "@/lib/errors/api";
 import { toSafeId } from "@/lib/safe-id";
 import {
   searchFacetOptions,
@@ -435,11 +435,7 @@ export const SearchDialog = ({
         ...(params.limit !== undefined ? { limit: params.limit } : {}),
       });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      return response.data;
+      return unwrapEden(response);
     },
     onError: (error) => {
       analytics.captureError(error);
@@ -453,11 +449,7 @@ export const SearchDialog = ({
         locale: vars.locale,
       });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      return response.data;
+      return unwrapEden(response);
     },
     onError: (error) => {
       analytics.captureError(error);
@@ -485,11 +477,7 @@ export const SearchDialog = ({
         ...(vars.limit !== undefined ? { limit: vars.limit } : {}),
       });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      return response.data;
+      return unwrapEden(response);
     },
     onError: (error) => {
       analytics.captureError(error);

--- a/apps/web/src/components/translate-document-dialog.tsx
+++ b/apps/web/src/components/translate-document-dialog.tsx
@@ -46,7 +46,7 @@ import {
   type DeepLTargetLanguageCode,
 } from "@/lib/deepl/languages";
 import { deepLAvailabilityOptions } from "@/lib/deepl/queries";
-import { toAPIError } from "@/lib/errors/api";
+import { unwrapEden } from "@/lib/errors/api";
 import { userErrorFromThrown } from "@/lib/errors/user-safe";
 import { toSafeId } from "@/lib/safe-id";
 import { entitiesKeys } from "@/routes/_protected.workspaces/$workspaceId/-queries/entities";
@@ -114,11 +114,7 @@ export const TranslateDocumentDialog = ({
           queryKey: entitiesKeys.all(workspaceId),
         });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      return response.data;
+      return unwrapEden(response);
     },
     onSuccess: async (data) => {
       stellaToast.add({

--- a/apps/web/src/components/usage/usage-limit-modal.tsx
+++ b/apps/web/src/components/usage/usage-limit-modal.tsx
@@ -15,7 +15,7 @@ import { stellaToast } from "@stll/ui/components/toast";
 
 import type { TranslationKey } from "@/i18n/types";
 import { api } from "@/lib/api";
-import { toAPIError } from "@/lib/errors/api";
+import { unwrapEden } from "@/lib/errors/api";
 import { userErrorFromThrown } from "@/lib/errors/user-safe";
 
 /** Modal shown when the current organisation cannot run more AI work. */
@@ -50,10 +50,7 @@ export const UsageLimitModal = ({
   const managementMutation = useMutation({
     mutationFn: async () => {
       const response = await api.usage.hosted.management.post();
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-      return response.data;
+      return unwrapEden(response);
     },
     onSuccess: ({ url }) => {
       window.location.href = url;

--- a/apps/web/src/features/case-law/queries/decisions.ts
+++ b/apps/web/src/features/case-law/queries/decisions.ts
@@ -1,7 +1,7 @@
 import { infiniteQueryOptions, queryOptions } from "@tanstack/react-query";
 
 import { api } from "@/lib/api";
-import { toAPIError } from "@/lib/errors/api";
+import { unwrapEden } from "@/lib/errors/api";
 import { nullableStringCursorSeed } from "@/lib/infinite-query";
 import { assertPublicLawApiData } from "@/lib/public-law-api";
 import { ROUTE_QUERY_STALE_TIME_MS } from "@/lib/react-query";
@@ -72,11 +72,7 @@ export const decisionFacetsOptions = () =>
         fetch: { signal },
       });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      const data = response.data;
+      const data = unwrapEden(response);
       assertPublicLawApiData(data, "listPublicCaseLawFacets");
 
       return data;
@@ -122,10 +118,7 @@ export const decisionsInfiniteOptions = (filters: DecisionListFilters = {}) =>
           { fetch: { signal } },
         );
 
-        if (response.error) {
-          throw toAPIError(response.error);
-        }
-        const data = response.data;
+        const data = unwrapEden(response);
         assertPublicLawApiData(data, "searchPublicCaseLawDecisions");
 
         return {
@@ -179,11 +172,7 @@ export const decisionsInfiniteOptions = (filters: DecisionListFilters = {}) =>
         fetch: { signal },
       });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      const data = response.data;
+      const data = unwrapEden(response);
       assertPublicLawApiData(data, "listPublicCaseLawDecisions");
 
       const facets: SearchFacets = null;
@@ -203,11 +192,7 @@ export const decisionOptions = (decisionId: string) =>
         .decisions({ decisionId: toSafeId<"caseLawDecision">(decisionId) })
         .get({ fetch: { signal } });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      const data = response.data;
+      const data = unwrapEden(response);
       assertPublicLawApiData(data, "readPublicCaseLawDecision");
 
       return data;
@@ -226,11 +211,7 @@ export const decisionBySlugOptions = ({ language, slug }: DecisionBySlugKey) =>
         fetch: { signal },
       });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      const data = response.data;
+      const data = unwrapEden(response);
       assertPublicLawApiData(data, "readPublicCaseLawDecisionBySlug");
 
       return data;

--- a/apps/web/src/features/style-sets/style-set-queries.ts
+++ b/apps/web/src/features/style-sets/style-set-queries.ts
@@ -2,7 +2,7 @@ import { queryOptions } from "@tanstack/react-query";
 
 import { api } from "@/lib/api";
 import { STALE_TIME } from "@/lib/consts";
-import { toAPIError } from "@/lib/errors/api";
+import { unwrapEden } from "@/lib/errors/api";
 import { toSafeId } from "@/lib/safe-id";
 
 const STYLE_SETS_PAGE_SIZE = 100;
@@ -38,10 +38,7 @@ export const styleSetsOptions = (organizationId: string) =>
         query: { limit: STYLE_SETS_PAGE_SIZE },
         fetch: { signal },
       });
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-      return response.data;
+      return unwrapEden(response);
     },
     staleTime: STALE_TIME.FIVE.MINUTES,
   });
@@ -56,10 +53,7 @@ export const styleSetEditorOptions = ({
       const response = await api["style-sets"]({
         styleSetId: toSafeId<"styleSet">(styleSetId),
       }).editor.get({ fetch: { signal } });
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-      return response.data;
+      return unwrapEden(response);
     },
     staleTime: STALE_TIME.FIVE.MINUTES,
   });
@@ -71,10 +65,7 @@ export const stellaStyleEditorOptions = (organizationId: string) =>
       const response = await api["style-sets"].editor.stella.get({
         fetch: { signal },
       });
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-      return response.data;
+      return unwrapEden(response);
     },
     staleTime: STALE_TIME.FIVE.MINUTES,
   });

--- a/apps/web/src/lib/deepl/queries.ts
+++ b/apps/web/src/lib/deepl/queries.ts
@@ -1,7 +1,7 @@
 import { queryOptions } from "@tanstack/react-query";
 
 import { api } from "@/lib/api";
-import { toAPIError } from "@/lib/errors/api";
+import { unwrapEden } from "@/lib/errors/api";
 import type { QueryOptionsInput } from "@/lib/react-query";
 
 const DEEPL_AVAILABILITY_STALE_MS = 5 * 60 * 1000;
@@ -37,11 +37,7 @@ export const deepLAvailabilityOptions = ({
         fetch: { signal },
       });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      return response.data;
+      return unwrapEden(response);
     },
   });
 
@@ -55,10 +51,6 @@ export const deepLConfigOptions = ({
         fetch: { signal },
       });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      return response.data;
+      return unwrapEden(response);
     },
   });

--- a/apps/web/src/lib/desktop-bridge.ts
+++ b/apps/web/src/lib/desktop-bridge.ts
@@ -3,7 +3,7 @@ import { FetchBoundaryError } from "@stll/errors";
 import { env } from "@/env";
 import { api } from "@/lib/api";
 import { buildSelfHostConnectDeepLink } from "@/lib/desktop-self-host-link.logic";
-import { toAPIError } from "@/lib/errors/api";
+import { unwrapEden } from "@/lib/errors/api";
 import { fetchWithTimeout } from "@/lib/fetch";
 import { toSafeId } from "@/lib/safe-id";
 
@@ -189,11 +189,7 @@ const openRemoteDesktopSession = async ({
       propertyId: toSafeId<"property">(propertyId),
     });
 
-  if (response.error) {
-    throw toAPIError(response.error);
-  }
-
-  return response.data satisfies RemoteDesktopSession;
+  return unwrapEden(response) satisfies RemoteDesktopSession;
 };
 
 const createDesktopEditHandoff = async ({
@@ -212,11 +208,7 @@ const createDesktopEditHandoff = async ({
       propertyId: toSafeId<"property">(propertyId),
     });
 
-  if (response.error) {
-    throw toAPIError(response.error);
-  }
-
-  return response.data satisfies DesktopEditHandoff;
+  return unwrapEden(response) satisfies DesktopEditHandoff;
 };
 
 const readDesktopEditHandoffStatus = async ({
@@ -233,11 +225,7 @@ const readDesktopEditHandoffStatus = async ({
     })
     .status.get();
 
-  if (response.error) {
-    throw toAPIError(response.error);
-  }
-
-  return response.data satisfies DesktopEditHandoffStatus;
+  return unwrapEden(response) satisfies DesktopEditHandoffStatus;
 };
 
 const launchDesktopEditHandoff = (deepLinkUrl: string) => {

--- a/apps/web/src/lib/errors/api.ts
+++ b/apps/web/src/lib/errors/api.ts
@@ -33,6 +33,25 @@ export type ToAPIErrorProps = {
     | undefined;
 };
 
+type EdenResponse<T> =
+  | { data: T; error: null }
+  | { data: null; error: ToAPIErrorProps };
+
+/**
+ * Unwraps an Eden treaty response: throws a localized {@link APIError} when the
+ * response carries an error, otherwise returns `response.data`.
+ *
+ * `T` is inferred from the response's success branch, so nullable payloads (e.g.
+ * public-law endpoints whose `data` is `X | null`) keep their nullability at the
+ * call site. Do not pass an explicit type argument; let inference flow.
+ */
+export const unwrapEden = <T>(response: EdenResponse<T>): T => {
+  if (response.error) {
+    throw toAPIError(response.error);
+  }
+  return response.data;
+};
+
 export const toAPIError = ({ status, value }: ToAPIErrorProps) => {
   if (value === null || value === undefined) {
     return new APIError({ message: localizeAPIError({ status }), status });

--- a/apps/web/src/lib/errors/api.ts
+++ b/apps/web/src/lib/errors/api.ts
@@ -45,12 +45,12 @@ type EdenResponse<T> =
  * public-law endpoints whose `data` is `X | null`) keep their nullability at the
  * call site. Do not pass an explicit type argument; let inference flow.
  */
-export const unwrapEden = <T>(response: EdenResponse<T>): T => {
+export function unwrapEden<T>(response: EdenResponse<T>): T {
   if (response.error) {
     throw toAPIError(response.error);
   }
   return response.data;
-};
+}
 
 export const toAPIError = ({ status, value }: ToAPIErrorProps) => {
   if (value === null || value === undefined) {

--- a/apps/web/src/lib/errors/index.test.ts
+++ b/apps/web/src/lib/errors/index.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, test } from "bun:test";
 
-import { APIError, internalToolErrorMessage, toAPIError } from "./api";
+import {
+  APIError,
+  internalToolErrorMessage,
+  toAPIError,
+  unwrapEden,
+} from "./api";
 import {
   AuthClientError,
   isMemberError,
@@ -198,6 +203,39 @@ describe("toAPIError", () => {
     const error = toAPIError({ status: 402, value });
 
     expect(error.message).toBe("Usage limit reached.");
+  });
+});
+
+describe("unwrapEden", () => {
+  test("returns the payload when there is no error", () => {
+    const payload = { id: "abc", value: 1 };
+
+    expect(unwrapEden({ data: payload, error: null })).toBe(payload);
+  });
+
+  test("preserves a nullable success payload", () => {
+    expect(unwrapEden({ data: null, error: null })).toBeNull();
+  });
+
+  test("throws a localized APIError when the response carries an error", () => {
+    expect(() =>
+      unwrapEden({
+        data: null,
+        error: { status: 403, value: { code: "forbidden", message: "no" } },
+      }),
+    ).toThrow(APIError);
+
+    try {
+      unwrapEden({
+        data: null,
+        error: { status: 403, value: { code: "forbidden", message: "no" } },
+      });
+    } catch (error) {
+      expect(APIError.is(error)).toBe(true);
+      if (APIError.is(error)) {
+        expect(error.message).toBe("You do not have permission to do this.");
+      }
+    }
   });
 });
 

--- a/apps/web/src/lib/search.ts
+++ b/apps/web/src/lib/search.ts
@@ -8,7 +8,7 @@ import type { EntityKind, GlobalSearchResultType } from "@stll/api/types";
 import { DAY_IN_MS } from "@stll/time";
 
 import { api } from "@/lib/api";
-import { toAPIError } from "@/lib/errors/api";
+import { unwrapEden } from "@/lib/errors/api";
 import { stringCursorSeed } from "@/lib/infinite-query";
 import { toSafeId } from "@/lib/safe-id";
 
@@ -134,11 +134,7 @@ export const searchInfiniteOptions = (params: SearchParams) =>
         { fetch: { signal } },
       );
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      return response.data;
+      return unwrapEden(response);
     },
     initialPageParam: stringCursorSeed(),
     getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
@@ -169,11 +165,7 @@ export const searchFacetOptions = (params: SearchFacetParams) =>
         { fetch: { signal } },
       );
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      return response.data;
+      return unwrapEden(response);
     },
     enabled: params.query.length > 0,
     placeholderData: keepPreviousData,

--- a/apps/web/src/lib/web-search/queries.ts
+++ b/apps/web/src/lib/web-search/queries.ts
@@ -1,7 +1,7 @@
 import { queryOptions } from "@tanstack/react-query";
 
 import { api } from "@/lib/api";
-import { toAPIError } from "@/lib/errors/api";
+import { unwrapEden } from "@/lib/errors/api";
 import type { QueryOptionsInput } from "@/lib/react-query";
 
 type WebSearchKeysKey = {
@@ -29,10 +29,6 @@ export const webSearchConfigOptions = ({
         "web-search-config"
       ].get({ fetch: { signal } });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      return response.data;
+      return unwrapEden(response);
     },
   });

--- a/apps/web/src/routes/_protected.chat/-components/chat-thread-page.tsx
+++ b/apps/web/src/routes/_protected.chat/-components/chat-thread-page.tsx
@@ -52,7 +52,7 @@ import {
 } from "@/lib/chat-thread-ref";
 import { useChatWebSearchPreferenceStore } from "@/lib/chat-web-search-store";
 import { ChromeHeaderActions } from "@/lib/chrome-header-actions";
-import { toAPIError } from "@/lib/errors/api";
+import { unwrapEden } from "@/lib/errors/api";
 import { useModelSelectorStore } from "@/lib/model-selector-store";
 import type { ChatPrompt } from "@/lib/prompts/types";
 import { useSavedPrompts } from "@/lib/prompts/use-saved-prompts";
@@ -743,10 +743,7 @@ const useChatWebSearchSeed = ({
       // Eden returns `{ error }` on non-2xx responses; without this
       // throw onSuccess fires and the thread is marked seeded for
       // the session, leaving web search silently off.
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-      return response.data;
+      return unwrapEden(response);
     },
     onSuccess: () => {
       void invalidateChatThreadAcrossScopes({

--- a/apps/web/src/routes/_protected.chat/-components/chat-web-search-toggle.tsx
+++ b/apps/web/src/routes/_protected.chat/-components/chat-web-search-toggle.tsx
@@ -11,7 +11,7 @@ import Tooltip from "@/components/tooltip";
 import { api } from "@/lib/api";
 import type { ChatThreadRef } from "@/lib/chat-thread-ref";
 import { useChatWebSearchPreferenceStore } from "@/lib/chat-web-search-store";
-import { toAPIError } from "@/lib/errors/api";
+import { unwrapEden } from "@/lib/errors/api";
 import { userErrorFromThrown } from "@/lib/errors/user-safe";
 import { toSafeId } from "@/lib/safe-id";
 import { invalidateChatThread } from "@/routes/_protected.chat/-queries";
@@ -71,10 +71,7 @@ export const ChatWebSearchToggle = ({
                 : {},
           },
         );
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-      return response.data;
+      return unwrapEden(response);
     },
     onMutate: async (nextEnabled) => {
       const filters = {

--- a/apps/web/src/routes/_protected.chat/-queries.ts
+++ b/apps/web/src/routes/_protected.chat/-queries.ts
@@ -476,13 +476,11 @@ export const fetchOlderMessages = async ({
       },
     });
 
-  if (response.error) {
-    throw toAPIError(response.error);
-  }
+  const data = unwrapEden(response);
 
   return {
-    messages: response.data.messages,
-    olderCursor: response.data.olderCursor,
+    messages: data.messages,
+    olderCursor: data.olderCursor,
   };
 };
 
@@ -532,20 +530,18 @@ const fetchFileChatThread = async ({
       fieldId: toSafeId<"field">(fieldId),
     });
 
-  if (response.error) {
-    throw toAPIError(response.error);
-  }
+  const data = unwrapEden(response);
 
   return {
-    threadId: toChatThreadId(response.data.threadId),
-    messages: response.data.messages,
-    olderCursor: response.data.olderCursor,
-    contextMatterIds: response.data.contextMatterIds,
-    lastActivityAt: response.data.lastActivityAt,
-    webSearchAvailable: response.data.webSearchAvailable,
-    webSearchEnabled: response.data.webSearchEnabled,
-    model: response.data.model,
-    context: response.data.context,
+    threadId: toChatThreadId(data.threadId),
+    messages: data.messages,
+    olderCursor: data.olderCursor,
+    contextMatterIds: data.contextMatterIds,
+    lastActivityAt: data.lastActivityAt,
+    webSearchAvailable: data.webSearchAvailable,
+    webSearchEnabled: data.webSearchEnabled,
+    model: data.model,
+    context: data.context,
   };
 };
 
@@ -556,11 +552,7 @@ const fetchTemplateChatThread = async ({
     templateId: toSafeId<"template">(templateId),
   });
 
-  if (response.error) {
-    throw toAPIError(response.error);
-  }
-
-  return toChatThreadId(response.data.threadId);
+  return toChatThreadId(unwrapEden(response).threadId);
 };
 
 export const mergeGroupedChatThreadPages = (
@@ -1865,11 +1857,7 @@ const fetchChatThreadTitle = async ({
         : {},
     });
 
-  if (response.error) {
-    throw toAPIError(response.error);
-  }
-
-  return response.data.title;
+  return unwrapEden(response).title;
 };
 
 type ChatThreadTitleOptionsArgs = {

--- a/apps/web/src/routes/_protected.chat/-queries.ts
+++ b/apps/web/src/routes/_protected.chat/-queries.ts
@@ -28,7 +28,7 @@ import type { ChatThreadId, ChatThreadRef } from "@/lib/chat-thread-ref";
 import { getChatThreadKey, toChatThreadId } from "@/lib/chat-thread-ref";
 import { STALE_TIME } from "@/lib/consts";
 import { useDevStore } from "@/lib/dev-store";
-import { APIError, toAPIError } from "@/lib/errors/api";
+import { APIError, toAPIError, unwrapEden } from "@/lib/errors/api";
 import { fetchWithTimeout } from "@/lib/fetch";
 import { stringCursorSeed } from "@/lib/infinite-query";
 import type { QueryOptionsInput } from "@/lib/react-query";
@@ -501,11 +501,7 @@ const fetchGroupedChatThreads = async ({
     },
   });
 
-  if (response.error) {
-    throw toAPIError(response.error);
-  }
-
-  return response.data;
+  return unwrapEden(response);
 };
 
 type FileChatThreadFetchResult = {
@@ -1833,11 +1829,7 @@ export const chatThreadSuggestedPromptsOptions = ({
 const fetchChatModelOptions = async () => {
   const response = await api.chat["model-options"].get();
 
-  if (response.error) {
-    throw toAPIError(response.error);
-  }
-
-  return response.data;
+  return unwrapEden(response);
 };
 
 // The composer (+) menu's Models submenu fetches this lazily (only once the

--- a/apps/web/src/routes/_protected.chat/index.tsx
+++ b/apps/web/src/routes/_protected.chat/index.tsx
@@ -51,7 +51,7 @@ import { createChatThreadId } from "@/lib/chat-thread-ref";
 import { isPlaceholderThreadTitle } from "@/lib/chat-thread-title";
 import { useChatWebSearchPreferenceStore } from "@/lib/chat-web-search-store";
 import { ChromeHeaderActions } from "@/lib/chrome-header-actions";
-import { toAPIError } from "@/lib/errors/api";
+import { toAPIError, unwrapEden } from "@/lib/errors/api";
 import { useModelSelectorStore } from "@/lib/model-selector-store";
 import { usePinnedStore } from "@/lib/pinned-store";
 import type { ChatPrompt } from "@/lib/prompts/types";
@@ -205,10 +205,7 @@ function ChatIndex() {
           ),
         })
         .patch({ webSearchEnabled: true }, { query: {} });
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-      return response.data;
+      return unwrapEden(response);
     },
     onError: (error) => {
       analytics.captureError(error);

--- a/apps/web/src/routes/_protected.chat/index.tsx
+++ b/apps/web/src/routes/_protected.chat/index.tsx
@@ -51,7 +51,7 @@ import { createChatThreadId } from "@/lib/chat-thread-ref";
 import { isPlaceholderThreadTitle } from "@/lib/chat-thread-title";
 import { useChatWebSearchPreferenceStore } from "@/lib/chat-web-search-store";
 import { ChromeHeaderActions } from "@/lib/chrome-header-actions";
-import { toAPIError, unwrapEden } from "@/lib/errors/api";
+import { unwrapEden } from "@/lib/errors/api";
 import { useModelSelectorStore } from "@/lib/model-selector-store";
 import { usePinnedStore } from "@/lib/pinned-store";
 import type { ChatPrompt } from "@/lib/prompts/types";
@@ -157,16 +157,14 @@ function ChatIndex() {
           query: { allowMissingThread: true },
           fetch: { signal },
         });
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
+      const data = unwrapEden(response);
       return {
-        webSearchAvailable: response.data.webSearchAvailable,
-        webSearchEnabled: response.data.webSearchEnabled,
-        model: response.data.model,
+        webSearchAvailable: data.webSearchAvailable,
+        webSearchEnabled: data.webSearchEnabled,
+        model: data.model,
         // The draft's cache-stable context floor (system prompt + tools), so
         // the hero meter shows the honest baseline instead of 0% before send.
-        context: response.data.context,
+        context: data.context,
       };
     },
   });

--- a/apps/web/src/routes/_protected.contacts/-mutations.ts
+++ b/apps/web/src/routes/_protected.contacts/-mutations.ts
@@ -2,7 +2,7 @@ import { useMutation } from "@tanstack/react-query";
 
 import { useAnalytics } from "@/lib/analytics/provider";
 import { api } from "@/lib/api";
-import { toAPIError } from "@/lib/errors/api";
+import { toAPIError, unwrapEden } from "@/lib/errors/api";
 import type { SafeId } from "@/lib/safe-id";
 
 type BankAccount = {
@@ -86,11 +86,7 @@ export const useCreateContact = () => {
     mutationFn: async (vars: CreateContactVars) => {
       const response = await api.contacts.put(vars);
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      return response.data;
+      return unwrapEden(response);
     },
     onError: (error) => {
       analytics.captureError(error);
@@ -131,11 +127,7 @@ export const useUpdateContact = () => {
     mutationFn: async ({ contactId, ...body }: UpdateContactVars) => {
       const response = await api.contacts({ contactId }).post(body);
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      return response.data;
+      return unwrapEden(response);
     },
     onError: (error) => {
       analytics.captureError(error);

--- a/apps/web/src/routes/_protected.contacts/-queries.ts
+++ b/apps/web/src/routes/_protected.contacts/-queries.ts
@@ -1,7 +1,7 @@
 import { queryOptions } from "@tanstack/react-query";
 
 import { api } from "@/lib/api";
-import { toAPIError } from "@/lib/errors/api";
+import { unwrapEden } from "@/lib/errors/api";
 import { ROUTE_QUERY_STALE_TIME_MS } from "@/lib/react-query";
 
 type ContactsListKey = {
@@ -45,11 +45,7 @@ export const contactsOptions = (
         fetch: { signal },
       });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      return response.data;
+      return unwrapEden(response);
     },
   });
 
@@ -65,10 +61,6 @@ export const contactOptions = (
         .contacts({ contactId })
         .get({ fetch: { signal } });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      return response.data;
+      return unwrapEden(response);
     },
   });

--- a/apps/web/src/routes/_protected.contacts/index.tsx
+++ b/apps/web/src/routes/_protected.contacts/index.tsx
@@ -72,7 +72,7 @@ import { TableSkeletonRows } from "@/components/table-skeleton-rows";
 import Tooltip from "@/components/tooltip";
 import { usePermissions } from "@/hooks/use-permissions";
 import { api } from "@/lib/api";
-import { toAPIError } from "@/lib/errors/api";
+import { unwrapEden } from "@/lib/errors/api";
 import { userErrorFromThrown } from "@/lib/errors/user-safe";
 import { pageTitle } from "@/lib/page-title";
 import { toSafeId } from "@/lib/safe-id";
@@ -744,11 +744,9 @@ const CreateContactDialog = ({
       const response = await api.contacts["business-registries"].get({
         query: { registry: "ares", q: ico },
       });
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
+      const data = unwrapEden(response);
 
-      const hit = response.data.type === "lookup" ? response.data.hit : null;
+      const hit = data.type === "lookup" ? data.hit : null;
 
       if (!hit) {
         stellaToast.add({

--- a/apps/web/src/routes/_protected.knowledge/-components/blueprint-gallery-sheet.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/blueprint-gallery-sheet.tsx
@@ -29,7 +29,7 @@ import {
 import { stellaToast } from "@stll/ui/components/toast";
 
 import { api } from "@/lib/api";
-import { toAPIError } from "@/lib/errors/api";
+import { unwrapEden } from "@/lib/errors/api";
 import { userErrorFromThrown } from "@/lib/errors/user-safe";
 
 type SkillScope = "team" | "private";
@@ -123,10 +123,7 @@ const BlueprintGallerySheetBody = ({
         blueprintId: id,
         queryKey: ["skills"],
       });
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-      return { id: response.data.id };
+      return { id: unwrapEden(response).id };
     },
     onSuccess: ({ id }) => {
       onCreated({ id });

--- a/apps/web/src/routes/_protected.knowledge/-components/catalogue/add-mcp-server-sheet.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/catalogue/add-mcp-server-sheet.tsx
@@ -17,7 +17,7 @@ import {
 import { stellaToast } from "@stll/ui/components/toast";
 
 import { api } from "@/lib/api";
-import { toAPIError } from "@/lib/errors/api";
+import { toAPIError, unwrapEden } from "@/lib/errors/api";
 import { userErrorFromThrown } from "@/lib/errors/user-safe";
 import { knowledgeKeys } from "@/routes/_protected.knowledge/-queries";
 import { catalogueKeys } from "@/routes/_protected.knowledge/-queries/catalogue";
@@ -117,10 +117,7 @@ export const AddMcpServerSheet = ({
         url: trimmedUrl,
         queryKey: ["mcp"],
       });
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-      return response.data;
+      return unwrapEden(response);
     },
     onSuccess: (data) => {
       invalidate();
@@ -136,10 +133,7 @@ export const AddMcpServerSheet = ({
         token: payload.token,
         queryKey: ["mcp"],
       });
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-      return response.data;
+      return unwrapEden(response);
     },
     onSuccess: () => {
       stellaToast.add({

--- a/apps/web/src/routes/_protected.knowledge/-components/catalogue/add-mcp-server-sheet.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/catalogue/add-mcp-server-sheet.tsx
@@ -17,7 +17,7 @@ import {
 import { stellaToast } from "@stll/ui/components/toast";
 
 import { api } from "@/lib/api";
-import { toAPIError, unwrapEden } from "@/lib/errors/api";
+import { unwrapEden } from "@/lib/errors/api";
 import { userErrorFromThrown } from "@/lib/errors/user-safe";
 import { knowledgeKeys } from "@/routes/_protected.knowledge/-queries";
 import { catalogueKeys } from "@/routes/_protected.knowledge/-queries/catalogue";
@@ -78,10 +78,7 @@ export const AddMcpServerSheet = ({
       const response = await api.mcp
         .connectors({ slug: connector.slug })
         .connect.post({ queryKey: ["mcp"] });
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-      return { connector, data: response.data };
+      return { connector, data: unwrapEden(response) };
     },
     onSuccess: ({ connector, data }) => {
       if (data.type === "bearer") {

--- a/apps/web/src/routes/_protected.knowledge/-components/catalogue/use-install-entry.ts
+++ b/apps/web/src/routes/_protected.knowledge/-components/catalogue/use-install-entry.ts
@@ -1,7 +1,7 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 
 import { api } from "@/lib/api";
-import { toAPIError } from "@/lib/errors/api";
+import { unwrapEden } from "@/lib/errors/api";
 import { catalogueKeys } from "@/routes/_protected.knowledge/-queries/catalogue";
 
 import type { CatalogueEntry } from "./catalogue-types";
@@ -25,10 +25,7 @@ export const useInstallEntry = (organizationId: string) => {
           enabled: true,
           queryKey: ["mcp"],
         });
-        if (response.error) {
-          throw toAPIError(response.error);
-        }
-        return response.data;
+        return unwrapEden(response);
       }
 
       if (entry.kind === "mcp") {
@@ -42,20 +39,14 @@ export const useInstallEntry = (organizationId: string) => {
           url: entry.url,
           queryKey: ["mcp"],
         });
-        if (response.error) {
-          throw toAPIError(response.error);
-        }
-        return response.data;
+        return unwrapEden(response);
       }
 
       const response = await api.catalogue["install-skill"].post({
         slug: entry.slug,
         queryKey: ["skills"],
       });
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-      return response.data;
+      return unwrapEden(response);
     },
     onSuccess: () => {
       void queryClient.invalidateQueries({

--- a/apps/web/src/routes/_protected.knowledge/-components/clause-detail.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/clause-detail.tsx
@@ -79,6 +79,7 @@ import { ClauseEditor } from "@/routes/_protected.knowledge/-components/clause-e
 import type { ClauseParagraph } from "@/routes/_protected.knowledge/-components/clause-editor-types";
 import { useClauseNavStore } from "@/routes/_protected.knowledge/-components/clause-nav-store";
 import { LeaveConfirmDialog } from "@/routes/_protected.knowledge/-components/leave-confirm-dialog";
+import { useClauseFieldSave } from "@/routes/_protected.knowledge/-components/use-clause-field-save";
 import {
   clauseDetailOptions,
   knowledgeKeys,
@@ -703,32 +704,15 @@ const ClauseInlineTextField = ({
   canEdit: boolean;
   onRefresh: () => void;
 }) => {
-  const t = useTranslations();
   const [draft, setDraft] = useState(value ?? "");
 
-  const commit = useCallback(async () => {
-    const next = draft.trim() || null;
-    if (next === (value ?? null)) {
-      return;
-    }
-
-    const response = await api.clauses({ clauseId }).post({ [field]: next });
-
-    if (response.error) {
-      setDraft(value ?? "");
-      stellaToast.add({
-        type: "error",
-        title: t("clauses.saveFailed"),
-        description: userErrorMessage(
-          response.error,
-          t("common.unexpectedError"),
-        ),
-      });
-      return;
-    }
-
-    onRefresh();
-  }, [clauseId, draft, field, value, t, onRefresh]);
+  const commit = useClauseFieldSave({
+    value,
+    persist: async (next) =>
+      await api.clauses({ clauseId }).post({ [field]: next }),
+    onRefresh,
+    onError: () => setDraft(value ?? ""),
+  });
 
   if (!canEdit) {
     if (!value) {
@@ -752,7 +736,7 @@ const ClauseInlineTextField = ({
       <Input
         id={`clause-${field}`}
         onBlur={() => {
-          void commit();
+          void commit(draft);
         }}
         onChange={(e) => setDraft(e.target.value)}
         placeholder={placeholder}
@@ -902,33 +886,12 @@ const ClauseUsageNotesField = ({
   const t = useTranslations();
   const [draft, setDraft] = useState(value ?? "");
 
-  const save = useCallback(
-    async (text: string) => {
-      const next = text.trim() || null;
-      if (next === (value ?? null)) {
-        return;
-      }
-
-      const response = await api
-        .clauses({ clauseId })
-        .post({ usageNotes: next });
-
-      if (response.error) {
-        stellaToast.add({
-          type: "error",
-          title: t("clauses.saveFailed"),
-          description: userErrorMessage(
-            response.error,
-            t("common.unexpectedError"),
-          ),
-        });
-        return;
-      }
-
-      onRefresh();
-    },
-    [clauseId, value, t, onRefresh],
-  );
+  const save = useClauseFieldSave({
+    value,
+    persist: async (next) =>
+      await api.clauses({ clauseId }).post({ usageNotes: next }),
+    onRefresh,
+  });
 
   const debouncedSave = useDebouncedCallback((text: string) => {
     void save(text);

--- a/apps/web/src/routes/_protected.knowledge/-components/clause-detail.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/clause-detail.tsx
@@ -68,7 +68,7 @@ import { useFormatter } from "@/i18n/formatting-context";
 import { useI18nStore } from "@/i18n/i18n-store";
 import { api } from "@/lib/api";
 import { compareByLocale } from "@/lib/collation";
-import { toAPIError } from "@/lib/errors/api";
+import { unwrapEden } from "@/lib/errors/api";
 import { userErrorFromThrown, userErrorMessage } from "@/lib/errors/user-safe";
 import { toSafeId } from "@/lib/safe-id";
 import { ClauseBody } from "@/routes/_protected.knowledge/-components/clause-body";
@@ -464,10 +464,7 @@ const ClauseHeader = ({
   const deleteClause = useMutation({
     mutationFn: async () => {
       const response = await api.clauses({ clauseId }).delete();
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-      return response.data;
+      return unwrapEden(response);
     },
     onSuccess: () => {
       stellaToast.add({

--- a/apps/web/src/routes/_protected.knowledge/-components/fill-clauses-section.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/fill-clauses-section.tsx
@@ -14,7 +14,7 @@ import { Textarea } from "@stll/ui/components/textarea";
 import { stellaToast } from "@stll/ui/components/toast";
 
 import { api } from "@/lib/api";
-import { toAPIError } from "@/lib/errors/api";
+import { unwrapEden } from "@/lib/errors/api";
 import { userErrorMessage } from "@/lib/errors/user-safe";
 import { toSafeId } from "@/lib/safe-id";
 
@@ -46,10 +46,7 @@ export const FillClausesSection = ({
       const response = await api
         .templates({ templateId: toSafeId<"template">(templateId) })
         ["clause-slots"].get({ fetch: { signal } });
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-      return response.data;
+      return unwrapEden(response);
     },
   });
 

--- a/apps/web/src/routes/_protected.knowledge/-components/playbook-editor.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/playbook-editor.tsx
@@ -46,7 +46,7 @@ import { useExternalSyncEffect } from "@/hooks/use-effect";
 import { usePermissions } from "@/hooks/use-permissions";
 import { useFormatter } from "@/i18n/formatting-context";
 import { api } from "@/lib/api";
-import { toAPIError } from "@/lib/errors/api";
+import { unwrapEden } from "@/lib/errors/api";
 import { userErrorFromThrown, userErrorMessage } from "@/lib/errors/user-safe";
 import { toSafeId } from "@/lib/safe-id";
 import { resolvePlaybookScrollTop } from "@/routes/_protected.knowledge/-components/playbook-editor.logic";
@@ -550,10 +550,7 @@ const PlaybookEditorForm = ({
       const response = await api
         .playbooks({ playbookId: toSafeId<"playbookDefinition">(id) })
         .approve.post();
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-      return response.data;
+      return unwrapEden(response);
     },
     onSuccess: (data) => {
       setStatus("approved");

--- a/apps/web/src/routes/_protected.knowledge/-components/playbook-starter-gallery-sheet.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/playbook-starter-gallery-sheet.tsx
@@ -16,7 +16,7 @@ import { Skeleton } from "@stll/ui/components/skeleton";
 import { stellaToast } from "@stll/ui/components/toast";
 
 import { api } from "@/lib/api";
-import { toAPIError } from "@/lib/errors/api";
+import { unwrapEden } from "@/lib/errors/api";
 import { userErrorFromThrown } from "@/lib/errors/user-safe";
 import {
   knowledgeKeys,
@@ -65,10 +65,7 @@ const PlaybookStarterGallerySheetBody = ({
       const response = await api.playbooks["from-starter"].post({
         starterId,
       });
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-      return { id: response.data.id };
+      return { id: unwrapEden(response).id };
     },
     onSuccess: ({ id }) => {
       void queryClient.invalidateQueries({

--- a/apps/web/src/routes/_protected.knowledge/-components/skill-editor.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/skill-editor.tsx
@@ -49,7 +49,7 @@ import { useLocale } from "@/i18n/formatting-context";
 import { api } from "@/lib/api";
 import { compareByLocale } from "@/lib/collation";
 import { MARKDOWN_MIME, isMarkdownFile } from "@/lib/consts";
-import { APIError, toAPIError } from "@/lib/errors/api";
+import { APIError, unwrapEden } from "@/lib/errors/api";
 import { userErrorFromThrown } from "@/lib/errors/user-safe";
 import { toSafeId } from "@/lib/safe-id";
 import {
@@ -330,10 +330,7 @@ export function SkillEditor({ skillId }: SkillEditorProps) {
       const response = await api
         .skills({ skillId: safeSkillId })
         .patch({ ...payload, queryKey: ["skills"] });
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-      return response.data;
+      return unwrapEden(response);
     },
     onSuccess: () => {
       onChanged();
@@ -359,10 +356,7 @@ export function SkillEditor({ skillId }: SkillEditorProps) {
       const response = await api
         .skills({ skillId: safeSkillId })
         .resources.post({ ...payload, queryKey: ["skills"] });
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-      return response.data;
+      return unwrapEden(response);
     },
     onSuccess: (data) => {
       onChanged();
@@ -384,10 +378,7 @@ export function SkillEditor({ skillId }: SkillEditorProps) {
           ...payload,
           queryKey: ["skills"],
         });
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-      return response.data;
+      return unwrapEden(response);
     },
     onSuccess: (data) => {
       onChanged();
@@ -406,11 +397,8 @@ export function SkillEditor({ skillId }: SkillEditorProps) {
       const response = await api
         .skills({ skillId: safeSkillId })
         .resources.delete({ path: payload.path, queryKey: ["skills"] });
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
       return {
-        ...response.data,
+        ...unwrapEden(response),
         resourceId: payload.resourceId,
         path: payload.path,
       };
@@ -444,10 +432,7 @@ export function SkillEditor({ skillId }: SkillEditorProps) {
       const response = await api
         .skills({ skillId: safeSkillId })
         .resources.rename.post({ ...payload, queryKey: ["skills"] });
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-      return response.data;
+      return unwrapEden(response);
     },
     onSuccess: (data, variables) => {
       onChanged();

--- a/apps/web/src/routes/_protected.knowledge/-components/template-clauses-tab.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/template-clauses-tab.tsx
@@ -39,7 +39,7 @@ import type {
 } from "@/components/versions/version-list";
 import { getAnalytics } from "@/lib/analytics/provider";
 import { api } from "@/lib/api";
-import { toAPIError } from "@/lib/errors/api";
+import { unwrapEden } from "@/lib/errors/api";
 import { userErrorMessage } from "@/lib/errors/user-safe";
 import { toSafeId } from "@/lib/safe-id";
 import { LinkClauseDialog } from "@/routes/_protected.knowledge/-components/link-clause-dialog";
@@ -405,10 +405,7 @@ export const OutdatedChanges = ({
         .clauses({ clauseId: toSafeId<"clause">(clauseId) })
         .versions({ versionId: toSafeId<"clauseVersion">(versionId) })
         .diff.get();
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-      setDiff({ status: "ready", value: response.data.segments });
+      setDiff({ status: "ready", value: unwrapEden(response).segments });
     } catch {
       setDiff({ status: "error" });
     }
@@ -424,10 +421,7 @@ export const OutdatedChanges = ({
         .clauses({ clauseId: toSafeId<"clause">(clauseId) })
         .versions({ versionId: toSafeId<"clauseVersion">(versionId) })
         .summarize.post();
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-      setSummary({ status: "ready", value: response.data.summary });
+      setSummary({ status: "ready", value: unwrapEden(response).summary });
     } catch {
       setSummary({ status: "error" });
     }

--- a/apps/web/src/routes/_protected.knowledge/-components/template-upload.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/template-upload.tsx
@@ -10,7 +10,7 @@ import { stellaToast } from "@stll/ui/components/toast";
 
 import { api } from "@/lib/api";
 import { DOCX_MIME, isDocxFile } from "@/lib/consts";
-import { toAPIError } from "@/lib/errors/api";
+import { toAPIError, unwrapEden } from "@/lib/errors/api";
 import { userErrorFromThrown } from "@/lib/errors/user-safe";
 
 type DiscoverResponse = Awaited<ReturnType<typeof api.templates.discover.post>>;
@@ -64,13 +64,10 @@ export const TemplateUpload = ({
   const prepareMutation = useMutation({
     mutationFn: async (file: File) => {
       const response = await api.templates.prepare.post({ file });
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
       // /prepare returns the marked-up docx as base64 JSON (binary responses
       // get corrupted by Eden); decode it back to bytes, then discover.
       const bytes = Uint8Array.from(
-        atob(response.data.docxBase64),
+        atob(unwrapEden(response).docxBase64),
         (ch) => ch.codePointAt(0) ?? 0,
       );
       const prepared = new File([bytes], file.name, { type: DOCX_MIME });

--- a/apps/web/src/routes/_protected.knowledge/-components/template-versions-tab.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/template-versions-tab.tsx
@@ -9,7 +9,7 @@ import { stellaToast } from "@stll/ui/components/toast";
 import { VersionList, VersionRow } from "@/components/versions/version-list";
 import type { VersionDiffSegment } from "@/components/versions/version-list";
 import { api } from "@/lib/api";
-import { toAPIError } from "@/lib/errors/api";
+import { unwrapEden } from "@/lib/errors/api";
 import { userErrorMessage } from "@/lib/errors/user-safe";
 import { toSafeId } from "@/lib/safe-id";
 import { templateVersionsOptions } from "@/routes/_protected.knowledge/-queries";
@@ -78,10 +78,7 @@ export const TemplateVersionsTab = ({
         .templates({ templateId: toSafeId<"template">(templateId) })
         .versions({ versionId: toSafeId<"templateVersion">(versionId) })
         .diff.get();
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-      return response.data.segments;
+      return unwrapEden(response).segments;
     };
 
   const buildSummarize =
@@ -90,10 +87,7 @@ export const TemplateVersionsTab = ({
         .templates({ templateId: toSafeId<"template">(templateId) })
         .versions({ versionId: toSafeId<"templateVersion">(versionId) })
         .summarize.post({});
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-      return response.data.summary;
+      return unwrapEden(response).summary;
     };
 
   if (isLoading) {

--- a/apps/web/src/routes/_protected.knowledge/-components/use-clause-field-save.ts
+++ b/apps/web/src/routes/_protected.knowledge/-components/use-clause-field-save.ts
@@ -1,0 +1,64 @@
+import { useTranslations } from "use-intl";
+
+import { stellaToast } from "@stll/ui/components/toast";
+
+import type { ToAPIErrorProps } from "@/lib/errors/api";
+import { userErrorMessage } from "@/lib/errors/user-safe";
+
+// Eden response shape the persist call returns; only the error branch is read
+// here, so the success payload stays `unknown`.
+type ClausePersistResponse =
+  | { data: unknown; error: null }
+  | { data: null; error: ToAPIErrorProps };
+
+type UseClauseFieldSaveOptions = {
+  /** Current persisted value; a save that matches it is skipped. */
+  value: string | null;
+  /**
+   * Persists the normalized value and returns the Eden response. The typed
+   * `api.clauses(...).post(...)` call stays at the call site so inference and
+   * the per-field payload key stay explicit.
+   */
+  persist: (next: string | null) => Promise<ClausePersistResponse>;
+  onRefresh: () => void;
+  /** Optional failure side effect, e.g. reverting the local draft. */
+  onError?: () => void;
+};
+
+/**
+ * Shared autosave sequence for inline clause metadata fields: trim (sending
+ * `null` when empty), skip when unchanged, persist, surface a localized error
+ * toast (with an optional revert), and refresh on success. Returns the save
+ * callback; pass it the raw draft text.
+ */
+export const useClauseFieldSave = ({
+  value,
+  persist,
+  onRefresh,
+  onError,
+}: UseClauseFieldSaveOptions) => {
+  const t = useTranslations();
+
+  return async (rawText: string) => {
+    const next = rawText.trim() || null;
+    if (next === (value ?? null)) {
+      return;
+    }
+
+    const response = await persist(next);
+    if (response.error) {
+      onError?.();
+      stellaToast.add({
+        type: "error",
+        title: t("clauses.saveFailed"),
+        description: userErrorMessage(
+          response.error,
+          t("common.unexpectedError"),
+        ),
+      });
+      return;
+    }
+
+    onRefresh();
+  };
+};

--- a/apps/web/src/routes/_protected.knowledge/-components/use-clause-field-save.ts
+++ b/apps/web/src/routes/_protected.knowledge/-components/use-clause-field-save.ts
@@ -1,3 +1,4 @@
+import { Result } from "better-result";
 import { useTranslations } from "use-intl";
 
 import { stellaToast } from "@stll/ui/components/toast";
@@ -39,23 +40,33 @@ export const useClauseFieldSave = ({
 }: UseClauseFieldSaveOptions) => {
   const t = useTranslations();
 
+  // Single funnel for both failure channels: a thrown `persist` (network
+  // failure) and an `.error` Eden response both revert the draft and show
+  // the same localized toast.
+  const fail = (description: string) => {
+    onError?.();
+    stellaToast.add({
+      type: "error",
+      title: t("clauses.saveFailed"),
+      description,
+    });
+  };
+
   return async (rawText: string) => {
     const next = rawText.trim() || null;
     if (next === (value ?? null)) {
       return;
     }
 
-    const response = await persist(next);
+    const result = await Result.tryPromise(async () => await persist(next));
+    if (Result.isError(result)) {
+      fail(t("common.unexpectedError"));
+      return;
+    }
+
+    const response = result.value;
     if (response.error) {
-      onError?.();
-      stellaToast.add({
-        type: "error",
-        title: t("clauses.saveFailed"),
-        description: userErrorMessage(
-          response.error,
-          t("common.unexpectedError"),
-        ),
-      });
+      fail(userErrorMessage(response.error, t("common.unexpectedError")));
       return;
     }
 

--- a/apps/web/src/routes/_protected.knowledge/-queries.ts
+++ b/apps/web/src/routes/_protected.knowledge/-queries.ts
@@ -3,7 +3,7 @@ import { panic, TaggedError } from "better-result";
 
 import { api } from "@/lib/api";
 import { DOCX_MIME, STALE_TIME } from "@/lib/consts";
-import { APIError, toAPIError } from "@/lib/errors/api";
+import { APIError, toAPIError, unwrapEden } from "@/lib/errors/api";
 import { fetchWithTimeout } from "@/lib/fetch";
 import type { QueryOptionsInput } from "@/lib/react-query";
 import type { SafeId } from "@/lib/safe-id";
@@ -208,11 +208,7 @@ export const templatesOptions = (
         fetch: { signal },
       });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      return response.data;
+      return unwrapEden(response);
     },
     initialPageParam: "",
     getNextPageParam: (lastPage) => lastPage.nextCursor,
@@ -230,11 +226,7 @@ export const templateDetailOptions = (
         .templates({ templateId: toSafeId<"template">(templateId) })
         .get({ fetch: { signal } });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      return response.data;
+      return unwrapEden(response);
     },
     staleTime: STALE_TIME.FIVE.MINUTES,
   });
@@ -250,11 +242,7 @@ export const templatePreviewOptions = (
         .templates({ templateId: toSafeId<"template">(templateId) })
         .preview.get({ fetch: { signal } });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      return response.data;
+      return unwrapEden(response);
     },
     staleTime: STALE_TIME.FIVE.MINUTES,
   });
@@ -382,10 +370,7 @@ export const templateVersionsOptions = (
         .templates({ templateId: toSafeId<"template">(templateId) })
         .versions.get({ query, fetch: { signal } });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-      const page = response.data;
+      const page = unwrapEden(response);
       if (!("items" in page)) {
         // 404 body shape; the error channel already covers real 404s.
         throw new APIError({ status: 404, message: "Template not found" });
@@ -408,11 +393,7 @@ export const templateClausesOptions = (
         .templates({ templateId: toSafeId<"template">(templateId) })
         .clauses.get({ fetch: { signal } });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      return response.data;
+      return unwrapEden(response);
     },
     staleTime: STALE_TIME.FIVE.MINUTES,
   });
@@ -431,11 +412,7 @@ export const templateClausePreviewOptions = (
         templateId: toSafeId<"template">(templateId),
       }).get({ fetch: { signal } });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      return response.data;
+      return unwrapEden(response);
     },
     staleTime: STALE_TIME.FIVE.MINUTES,
   });
@@ -453,11 +430,7 @@ export const templateCheckOptions = (
         .templates({ templateId: toSafeId<"template">(templateId) })
         .check.get({ fetch: { signal } });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      return response.data;
+      return unwrapEden(response);
     },
   });
 
@@ -472,11 +445,7 @@ export const templateRecipesOptions = (organizationId: string) =>
         fetch: { signal },
       });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      return response.data;
+      return unwrapEden(response);
     },
     staleTime: STALE_TIME.FIVE.MINUTES,
   });
@@ -491,11 +460,7 @@ export const templateCategoriesOptions = (organizationId: string) =>
         fetch: { signal },
       });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      return response.data;
+      return unwrapEden(response);
     },
     staleTime: STALE_TIME.FIVE.MINUTES,
   });
@@ -508,11 +473,7 @@ export const clauseCategoriesOptions = (organizationId: string) =>
         fetch: { signal },
       });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      return response.data;
+      return unwrapEden(response);
     },
     staleTime: STALE_TIME.FIVE.MINUTES,
   });
@@ -548,11 +509,7 @@ export const clausesOptions = (
         fetch: { signal },
       });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      return response.data;
+      return unwrapEden(response);
     },
     staleTime: STALE_TIME.FIVE.MINUTES,
   });
@@ -565,11 +522,7 @@ export const clauseDetailOptions = (organizationId: string, clauseId: string) =>
         fetch: { signal },
       });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      return response.data;
+      return unwrapEden(response);
     },
     staleTime: STALE_TIME.FIVE.MINUTES,
   });
@@ -593,11 +546,7 @@ export const playbooksOptions = (
         fetch: { signal },
       });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      return response.data;
+      return unwrapEden(response);
     },
     staleTime: STALE_TIME.FIVE.MINUTES,
   });
@@ -611,11 +560,7 @@ export const documentTypesOptions = (organizationId: string) =>
     queryFn: async ({ signal }) => {
       const response = await api["document-types"].get({ fetch: { signal } });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      return response.data;
+      return unwrapEden(response);
     },
     staleTime: STALE_TIME.FIVE.MINUTES,
   });
@@ -629,11 +574,7 @@ export const playbookStartersOptions = (organizationId: string) =>
     queryFn: async ({ signal }) => {
       const response = await api.playbooks.starters.get({ fetch: { signal } });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      return response.data;
+      return unwrapEden(response);
     },
     staleTime: STALE_TIME.FIVE.MINUTES,
   });
@@ -649,11 +590,7 @@ export const playbookDetailOptions = (
         .playbooks({ playbookId: toSafeId<"playbookDefinition">(playbookId) })
         .get({ fetch: { signal } });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      return response.data;
+      return unwrapEden(response);
     },
     staleTime: STALE_TIME.FIVE.MINUTES,
   });
@@ -672,11 +609,7 @@ export const playbookVersionsOptions = (
         .playbooks({ playbookId: toSafeId<"playbookDefinition">(playbookId) })
         .versions.get({ fetch: { signal } });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      return response.data;
+      return unwrapEden(response);
     },
     staleTime: STALE_TIME.FIVE.MINUTES,
   });
@@ -702,11 +635,7 @@ export const flowsOptions = (
         fetch: { signal },
       });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      return response.data;
+      return unwrapEden(response);
     },
     staleTime: STALE_TIME.FIVE.MINUTES,
   });
@@ -719,11 +648,7 @@ export const flowDetailOptions = (organizationId: string, flowId: string) =>
         .flows({ flowId: toSafeId<"flowDefinition">(flowId) })
         .get({ fetch: { signal } });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      return response.data;
+      return unwrapEden(response);
     },
     staleTime: STALE_TIME.FIVE.MINUTES,
   });
@@ -746,10 +671,7 @@ export const skillsOptions = (organizationId: string) =>
         query,
         fetch: { signal },
       });
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-      return response.data;
+      return unwrapEden(response);
     },
     initialPageParam: "",
     getNextPageParam: (lastPage) => lastPage.nextCursor,
@@ -763,10 +685,7 @@ export const skillDetailOptions = (organizationId: string, skillId: string) =>
       const response = await api
         .skills({ skillId: toSafeId<"agentSkill">(skillId) })
         .get({ fetch: { signal } });
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-      return response.data;
+      return unwrapEden(response);
     },
     staleTime: STALE_TIME.FIVE.MINUTES,
   });
@@ -778,10 +697,7 @@ export const mcpConnectorsOptions = (organizationId: string) =>
     queryKey: knowledgeKeys.mcp.connectors(organizationId),
     queryFn: async ({ signal }) => {
       const response = await api.mcp.connectors.get({ fetch: { signal } });
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-      return response.data;
+      return unwrapEden(response);
     },
     staleTime: STALE_TIME.FIVE.MINUTES,
   });
@@ -791,10 +707,7 @@ export const mcpConnectionsOptions = (organizationId: string) =>
     queryKey: knowledgeKeys.mcp.connections(organizationId),
     queryFn: async ({ signal }) => {
       const response = await api.mcp.connections.get({ fetch: { signal } });
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-      return response.data;
+      return unwrapEden(response);
     },
     staleTime: STALE_TIME.FIVE.MINUTES,
   });

--- a/apps/web/src/routes/_protected.knowledge/-queries/catalogue.ts
+++ b/apps/web/src/routes/_protected.knowledge/-queries/catalogue.ts
@@ -2,7 +2,7 @@ import { queryOptions } from "@tanstack/react-query";
 
 import { api } from "@/lib/api";
 import { STALE_TIME } from "@/lib/consts";
-import { toAPIError } from "@/lib/errors/api";
+import { unwrapEden } from "@/lib/errors/api";
 
 export const catalogueKeys = {
   all: (organizationId: string) => ["catalogue", organizationId] as const,
@@ -15,10 +15,7 @@ export const catalogueOptions = (organizationId: string) =>
     queryKey: catalogueKeys.list(organizationId),
     queryFn: async ({ signal }) => {
       const response = await api.catalogue.get({ fetch: { signal } });
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-      return response.data;
+      return unwrapEden(response);
     },
     staleTime: STALE_TIME.FIVE.MINUTES,
   });

--- a/apps/web/src/routes/_protected.organization/-ai-config-queries.ts
+++ b/apps/web/src/routes/_protected.organization/-ai-config-queries.ts
@@ -1,7 +1,7 @@
 import { queryOptions } from "@tanstack/react-query";
 
 import { api } from "@/lib/api";
-import { toAPIError } from "@/lib/errors/api";
+import { unwrapEden } from "@/lib/errors/api";
 import { ROUTE_QUERY_STALE_TIME_MS } from "@/lib/react-query";
 import type { QueryOptionsInput } from "@/lib/react-query";
 
@@ -38,11 +38,7 @@ export const aiConfigOptions = ({ organizationId }: AIConfigOptionsInput) =>
         fetch: { signal },
       });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      return response.data;
+      return unwrapEden(response);
     },
     staleTime: ROUTE_QUERY_STALE_TIME_MS,
   });
@@ -64,11 +60,7 @@ export const aiAvailabilityOptions = ({
         fetch: { signal },
       });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      return response.data;
+      return unwrapEden(response);
     },
     staleTime: ROUTE_QUERY_STALE_TIME_MS,
   });

--- a/apps/web/src/routes/_protected.organization/-settings-queries.ts
+++ b/apps/web/src/routes/_protected.organization/-settings-queries.ts
@@ -1,7 +1,7 @@
 import { queryOptions } from "@tanstack/react-query";
 
 import { api } from "@/lib/api";
-import { toAPIError } from "@/lib/errors/api";
+import { unwrapEden } from "@/lib/errors/api";
 import { ROUTE_QUERY_STALE_TIME_MS } from "@/lib/react-query";
 
 export const organizationSettingsKeys = {
@@ -20,11 +20,7 @@ export const organizationSettingsOptions = (organizationId: string) =>
         fetch: { signal },
       });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      return response.data;
+      return unwrapEden(response);
     },
     staleTime: ROUTE_QUERY_STALE_TIME_MS,
   });

--- a/apps/web/src/routes/_protected.settings/-components/account/connected-apps-card.tsx
+++ b/apps/web/src/routes/_protected.settings/-components/account/connected-apps-card.tsx
@@ -34,7 +34,7 @@ import { stellaToast } from "@stll/ui/components/toast";
 import { getFormattingLocale } from "@/i18n/i18n-store";
 import { useAnalytics } from "@/lib/analytics/provider";
 import { api } from "@/lib/api";
-import { toAPIError } from "@/lib/errors/api";
+import { unwrapEden } from "@/lib/errors/api";
 import {
   toOAuthScopeDisplayEntries,
   translateOAuthScopeEntry,
@@ -224,11 +224,7 @@ const DisconnectButton = ({ clientName, consentId }: DisconnectButtonProps) => {
         consentId,
       }).delete();
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      return response.data;
+      return unwrapEden(response);
     },
     onSuccess: async () => {
       stellaToast.add({

--- a/apps/web/src/routes/_protected.settings/-components/organization/ai-config-card.tsx
+++ b/apps/web/src/routes/_protected.settings/-components/organization/ai-config-card.tsx
@@ -33,7 +33,7 @@ import type {
 } from "@/components/ai-config-role-models.logic";
 import { useAnalytics } from "@/lib/analytics/provider";
 import { api } from "@/lib/api";
-import { toAPIError } from "@/lib/errors/api";
+import { toAPIError, unwrapEden } from "@/lib/errors/api";
 import { userErrorFromThrown } from "@/lib/errors/user-safe";
 import {
   aiConfigKeys,
@@ -129,10 +129,7 @@ const AIConfigForm = ({ config, organizationId }: AIConfigFormProps) => {
         providers: serializeProviderDrafts(providers),
         overrideModels,
       });
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-      return response.data;
+      return unwrapEden(response);
     },
     onSuccess: async (data) => {
       const nextProviders = providerDraftsFromStoredProviders(data.providers);

--- a/apps/web/src/routes/_protected.settings/-components/organization/anonymization-deny-list-card.tsx
+++ b/apps/web/src/routes/_protected.settings/-components/organization/anonymization-deny-list-card.tsx
@@ -1,7 +1,7 @@
 import { useRef, useState } from "react";
 import { useFormStatus } from "react-dom";
 
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { useRouteContext } from "@tanstack/react-router";
 import { Trash2, UploadIcon } from "lucide-react";
 import { useTranslations } from "use-intl";
@@ -21,11 +21,11 @@ import { Input } from "@stll/ui/components/input";
 import { stellaToast } from "@stll/ui/components/toast";
 
 import type { TranslationKey } from "@/i18n/types";
-import { useAnalytics } from "@/lib/analytics/provider";
 import { api } from "@/lib/api";
 import { normalizeOptionalArray } from "@/lib/arrays";
-import { toAPIError } from "@/lib/errors/api";
+import { unwrapEden } from "@/lib/errors/api";
 import { userErrorFromThrown } from "@/lib/errors/user-safe";
+import { useSettingsMutation } from "@/routes/_protected.settings/-hooks/use-settings-mutation";
 import {
   organizationAnonymizationBlacklistKeys,
   organizationAnonymizationBlacklistOptions,
@@ -274,8 +274,6 @@ const dedupeByCanonical = (
 
 export const AnonymizationDenyListCard = () => {
   const t = useTranslations();
-  const analytics = useAnalytics();
-  const queryClient = useQueryClient();
   const activeOrganizationId = useRouteContext({
     from: "/_protected",
     select: (ctx) => ctx.user.activeOrganizationId,
@@ -289,33 +287,21 @@ export const AnonymizationDenyListCard = () => {
   // upsert: rows missing from the request are deleted, present
   // rows are upserted (keyed on lowercased canonical). Callers
   // therefore submit the full target list, not a delta.
-  const updateMutation = useMutation({
-    mutationFn: async ({ entries }: UpdateBlacklistVars) => {
-      const response = await api["organization-settings"][
-        "anonymization-blacklist"
-      ].put({
-        entries: entries.map((entry) => ({
-          canonical: entry.canonical,
-          label: entry.label,
-          ...(entry.variants ? { variants: [...entry.variants] } : {}),
-          ...(entry.enabled !== undefined ? { enabled: entry.enabled } : {}),
-        })),
-      });
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-      return response.data;
-    },
-    onSuccess: async () => {
-      await queryClient.invalidateQueries({
-        queryKey: organizationAnonymizationBlacklistKeys.byOrganization({
-          organizationId: activeOrganizationId,
+  const updateMutation = useSettingsMutation({
+    mutationFn: async ({ entries }: UpdateBlacklistVars) =>
+      unwrapEden(
+        await api["organization-settings"]["anonymization-blacklist"].put({
+          entries: entries.map((entry) => ({
+            canonical: entry.canonical,
+            label: entry.label,
+            ...(entry.variants ? { variants: [...entry.variants] } : {}),
+            ...(entry.enabled !== undefined ? { enabled: entry.enabled } : {}),
+          })),
         }),
-      });
-    },
-    onError: (error) => {
-      analytics.captureError(error);
-    },
+      ),
+    invalidate: organizationAnonymizationBlacklistKeys.byOrganization({
+      organizationId: activeOrganizationId,
+    }),
   });
   const fileInputRef = useRef<HTMLInputElement | null>(null);
 

--- a/apps/web/src/routes/_protected.settings/-components/organization/deepl-key-card.tsx
+++ b/apps/web/src/routes/_protected.settings/-components/organization/deepl-key-card.tsx
@@ -8,7 +8,7 @@
 
 import { useState } from "react";
 
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { useRouteContext } from "@tanstack/react-router";
 import { Trash2Icon } from "lucide-react";
 import { useTranslations } from "use-intl";
@@ -16,20 +16,16 @@ import { useTranslations } from "use-intl";
 import { Button } from "@stll/ui/components/button";
 import { Frame, FramePanel } from "@stll/ui/components/frame";
 import { Input } from "@stll/ui/components/input";
-import { stellaToast } from "@stll/ui/components/toast";
 
-import { useAnalytics } from "@/lib/analytics/provider";
 import { api } from "@/lib/api";
 import { deepLConfigOptions, deepLKeys } from "@/lib/deepl/queries";
-import { toAPIError } from "@/lib/errors/api";
-import { userErrorFromThrown } from "@/lib/errors/user-safe";
+import { unwrapEden } from "@/lib/errors/api";
+import { useSettingsMutation } from "@/routes/_protected.settings/-hooks/use-settings-mutation";
 
 export const DeepLKeyCard = () => {
   const t = useTranslations("translate.settings");
   const tCommon = useTranslations("common");
   const tErrors = useTranslations("errors");
-  const analytics = useAnalytics();
-  const queryClient = useQueryClient();
   const activeOrganizationId = useRouteContext({
     from: "/_protected",
     select: (ctx) => ctx.user.activeOrganizationId,
@@ -41,58 +37,24 @@ export const DeepLKeyCard = () => {
 
   const [apiKey, setApiKey] = useState("");
 
-  const saveMutation = useMutation({
-    mutationFn: async () => {
-      const response = await api["organization-settings"].deepl.post({
-        apiKey,
-      });
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-      return response.data;
+  const saveMutation = useSettingsMutation({
+    mutationFn: async () =>
+      unwrapEden(await api["organization-settings"].deepl.post({ apiKey })),
+    invalidate: deepLKeys.all,
+    successToast: { title: t("saved"), description: t("savedDescription") },
+    errorToast: {
+      title: tErrors("actionFailed"),
+      description: tErrors("actionFailed"),
     },
-    onSuccess: async () => {
-      setApiKey("");
-      await queryClient.invalidateQueries({ queryKey: deepLKeys.all });
-      stellaToast.add({
-        title: t("saved"),
-        description: t("savedDescription"),
-        type: "success",
-      });
-    },
-    onError: (error: unknown) => {
-      analytics.captureError(error);
-      stellaToast.add({
-        title: tErrors("actionFailed"),
-        description: userErrorFromThrown(error, tErrors("actionFailed")),
-        type: "error",
-      });
-    },
+    onSuccess: () => setApiKey(""),
   });
 
-  const deleteMutation = useMutation({
-    mutationFn: async () => {
-      const response = await api["organization-settings"].deepl.delete();
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-      return response.data;
-    },
-    onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: deepLKeys.all });
-      stellaToast.add({
-        title: t("removed"),
-        description: t("removedDescription"),
-        type: "success",
-      });
-    },
-    onError: (error: unknown) => {
-      analytics.captureError(error);
-      stellaToast.add({
-        title: tErrors("actionFailed"),
-        type: "error",
-      });
-    },
+  const deleteMutation = useSettingsMutation({
+    mutationFn: async () =>
+      unwrapEden(await api["organization-settings"].deepl.delete()),
+    invalidate: deepLKeys.all,
+    successToast: { title: t("removed"), description: t("removedDescription") },
+    errorToast: { title: tErrors("actionFailed") },
   });
 
   const isConfigured = deeplConfig?.configured === true;

--- a/apps/web/src/routes/_protected.settings/-components/organization/document-types-card.tsx
+++ b/apps/web/src/routes/_protected.settings/-components/organization/document-types-card.tsx
@@ -15,25 +15,23 @@ import {
 } from "@atlaskit/pragmatic-drag-and-drop/element/adapter";
 import { preserveOffsetOnSource } from "@atlaskit/pragmatic-drag-and-drop/element/preserve-offset-on-source";
 import { setCustomNativeDragPreview } from "@atlaskit/pragmatic-drag-and-drop/element/set-custom-native-drag-preview";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { useRouteContext } from "@tanstack/react-router";
 import { GripVerticalIcon, PlusIcon, Trash2Icon } from "lucide-react";
 import { useTranslations } from "use-intl";
 
 import { Button } from "@stll/ui/components/button";
 import { Input } from "@stll/ui/components/input";
-import { stellaToast } from "@stll/ui/components/toast";
 import { cn } from "@stll/ui/lib/utils";
 
 import { useExternalSyncEffect } from "@/hooks/use-effect";
 import { useLatestCallback } from "@/hooks/use-latest-callback";
-import { useAnalytics } from "@/lib/analytics/provider";
 import { api } from "@/lib/api";
-import { toAPIError } from "@/lib/errors/api";
-import { userErrorFromThrown } from "@/lib/errors/user-safe";
+import { unwrapEden } from "@/lib/errors/api";
 import { toSafeId } from "@/lib/safe-id";
 import type { SafeId } from "@/lib/safe-id";
 import { documentTypesOptions } from "@/routes/_protected.knowledge/-queries";
+import { useSettingsMutation } from "@/routes/_protected.settings/-hooks/use-settings-mutation";
 
 const DOCUMENT_TYPE_DRAG_TYPE = "stella/document-type";
 
@@ -51,8 +49,6 @@ const invalidateDocumentTypes = "document-types";
 
 export const DocumentTypesCard = () => {
   const t = useTranslations();
-  const analytics = useAnalytics();
-  const queryClient = useQueryClient();
   const activeOrganizationId = useRouteContext({
     from: "/_protected",
     select: (ctx) => ctx.user.activeOrganizationId,
@@ -63,47 +59,23 @@ export const DocumentTypesCard = () => {
 
   const [newLabel, setNewLabel] = useState("");
 
-  const createMutation = useMutation({
-    mutationFn: async (label: string) => {
-      const response = await api["document-types"].post({ label });
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-      return response.data;
+  const createMutation = useSettingsMutation({
+    mutationFn: async (label: string) =>
+      unwrapEden(await api["document-types"].post({ label })),
+    invalidate: [invalidateDocumentTypes],
+    errorToast: {
+      title: t("errors.actionFailed"),
+      description: t("errors.actionFailed"),
     },
-    onSuccess: async () => {
-      setNewLabel("");
-      await queryClient.invalidateQueries({
-        queryKey: [invalidateDocumentTypes],
-      });
-    },
-    onError: (error: unknown) => {
-      analytics.captureError(error);
-      stellaToast.add({
-        title: t("errors.actionFailed"),
-        description: userErrorFromThrown(error, t("errors.actionFailed")),
-        type: "error",
-      });
-    },
+    onSuccess: () => setNewLabel(""),
   });
 
-  const reorderMutation = useMutation({
-    mutationFn: async (orderedIds: SafeId<"documentType">[]) => {
-      const response = await api["document-types"].reorder.post({ orderedIds });
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-      return response.data;
-    },
-    onSettled: async () => {
-      await queryClient.invalidateQueries({
-        queryKey: [invalidateDocumentTypes],
-      });
-    },
-    onError: (error: unknown) => {
-      analytics.captureError(error);
-      stellaToast.add({ title: t("errors.actionFailed"), type: "error" });
-    },
+  const reorderMutation = useSettingsMutation({
+    mutationFn: async (orderedIds: SafeId<"documentType">[]) =>
+      unwrapEden(await api["document-types"].reorder.post({ orderedIds })),
+    invalidate: [invalidateDocumentTypes],
+    invalidateOn: "settled",
+    errorToast: { title: t("errors.actionFailed") },
   });
 
   const handleReorder = (
@@ -179,8 +151,6 @@ type DocumentTypeRowProps = {
 
 const DocumentTypeRow = ({ type, onReorder }: DocumentTypeRowProps) => {
   const t = useTranslations();
-  const analytics = useAnalytics();
-  const queryClient = useQueryClient();
 
   const [rowRef, setRowRef] = useState<HTMLElement | null>(null);
   const [gripRef, setGripRef] = useState<HTMLButtonElement | null>(null);
@@ -240,55 +210,31 @@ const DocumentTypeRow = ({ type, onReorder }: DocumentTypeRowProps) => {
     );
   }, [rowRef, gripRef, type.id, handleReorder]);
 
-  const renameMutation = useMutation({
-    mutationFn: async (label: string) => {
-      const response = await api["document-types"]({
-        documentTypeId: type.id,
-      }).patch({ label });
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-      return response.data;
+  const renameMutation = useSettingsMutation({
+    mutationFn: async (label: string) =>
+      unwrapEden(
+        await api["document-types"]({ documentTypeId: type.id }).patch({
+          label,
+        }),
+      ),
+    invalidate: [invalidateDocumentTypes],
+    errorToast: {
+      title: t("errors.actionFailed"),
+      description: t("errors.actionFailed"),
     },
-    onSuccess: async () => {
-      await queryClient.invalidateQueries({
-        queryKey: [invalidateDocumentTypes],
-      });
-    },
-    onError: (error: unknown) => {
-      analytics.captureError(error);
-      setDraft(type.label);
-      stellaToast.add({
-        title: t("errors.actionFailed"),
-        description: userErrorFromThrown(error, t("errors.actionFailed")),
-        type: "error",
-      });
-    },
+    onError: () => setDraft(type.label),
   });
 
-  const deleteMutation = useMutation({
-    mutationFn: async () => {
-      const response = await api["document-types"]({
-        documentTypeId: type.id,
-      }).delete();
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-      return response.data;
-    },
-    onSuccess: async () => {
-      await queryClient.invalidateQueries({
-        queryKey: [invalidateDocumentTypes],
-      });
-    },
-    onError: (error: unknown) => {
-      analytics.captureError(error);
-      // Surfaces the API's "in use by N playbook(s)" guard message.
-      stellaToast.add({
-        title: t("settings.organization.documentTypes.deleteFailed"),
-        description: userErrorFromThrown(error, t("errors.actionFailed")),
-        type: "error",
-      });
+  const deleteMutation = useSettingsMutation({
+    mutationFn: async () =>
+      unwrapEden(
+        await api["document-types"]({ documentTypeId: type.id }).delete(),
+      ),
+    invalidate: [invalidateDocumentTypes],
+    // Surfaces the API's "in use by N playbook(s)" guard message.
+    errorToast: {
+      title: t("settings.organization.documentTypes.deleteFailed"),
+      description: t("errors.actionFailed"),
     },
   });
 

--- a/apps/web/src/routes/_protected.settings/-components/organization/jurisdictions-card.tsx
+++ b/apps/web/src/routes/_protected.settings/-components/organization/jurisdictions-card.tsx
@@ -1,26 +1,23 @@
 import { useOptimistic, useRef, useState, useTransition } from "react";
 
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { useTranslations } from "use-intl";
 
 import { Frame, FramePanel } from "@stll/ui/components/frame";
-import { stellaToast } from "@stll/ui/components/toast";
 
 import { JurisdictionPicker } from "@/components/jurisdiction-picker";
-import { useAnalytics } from "@/lib/analytics/provider";
 import { api } from "@/lib/api";
 import { useAuthenticatedUser } from "@/lib/authenticated-user-context";
-import { toAPIError } from "@/lib/errors/api";
+import { unwrapEden } from "@/lib/errors/api";
 import type { PracticeJurisdiction } from "@/lib/jurisdictions";
 import {
   organizationSettingsKeys,
   organizationSettingsOptions,
 } from "@/routes/_protected.organization/-settings-queries";
+import { useSettingsMutation } from "@/routes/_protected.settings/-hooks/use-settings-mutation";
 
 export const OrganizationJurisdictionsCard = () => {
   const t = useTranslations();
-  const analytics = useAnalytics();
-  const queryClient = useQueryClient();
   const activeOrganizationId = useAuthenticatedUser().activeOrganizationId;
   const { data: settings } = useQuery(
     organizationSettingsOptions(activeOrganizationId),
@@ -43,28 +40,15 @@ export const OrganizationJurisdictionsCard = () => {
   const selected = immediateSelected ?? optimisticSelected;
   const [, startSelectionTransition] = useTransition();
 
-  const updateMutation = useMutation({
-    mutationFn: async (next: PracticeJurisdiction[]) => {
-      const response = await api["organization-settings"][
-        "practice-jurisdictions"
-      ].post({ practiceJurisdictions: next });
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-      return response.data;
-    },
-    onSuccess: async () => {
-      await queryClient.invalidateQueries({
-        queryKey: organizationSettingsKeys.all,
-      });
-    },
-    onError: (error) => {
-      analytics.captureError(error);
-      stellaToast.add({
-        title: t("errors.actionFailed"),
-        type: "error",
-      });
-    },
+  const updateMutation = useSettingsMutation({
+    mutationFn: async (next: PracticeJurisdiction[]) =>
+      unwrapEden(
+        await api["organization-settings"]["practice-jurisdictions"].post({
+          practiceJurisdictions: next,
+        }),
+      ),
+    invalidate: organizationSettingsKeys.all,
+    errorToast: { title: t("errors.actionFailed") },
   });
 
   return (

--- a/apps/web/src/routes/_protected.settings/-components/organization/matter-numbering-card.tsx
+++ b/apps/web/src/routes/_protected.settings/-components/organization/matter-numbering-card.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { useDebounce } from "use-debounce";
 import { useTranslations } from "use-intl";
 
@@ -15,16 +15,15 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@stll/ui/components/select";
-import { stellaToast } from "@stll/ui/components/toast";
 
-import { useAnalytics } from "@/lib/analytics/provider";
 import { api } from "@/lib/api";
 import { useAuthenticatedUser } from "@/lib/authenticated-user-context";
-import { toAPIError } from "@/lib/errors/api";
+import { unwrapEden } from "@/lib/errors/api";
 import {
   organizationSettingsKeys,
   organizationSettingsOptions,
 } from "@/routes/_protected.organization/-settings-queries";
+import { useSettingsMutation } from "@/routes/_protected.settings/-hooks/use-settings-mutation";
 
 const PATTERN_PRESETS = [
   { value: "{SEQ}", key: "sequential" as const },
@@ -66,8 +65,6 @@ const MatterNumberingCardBody = ({
   settings: MatterNumberingSettings;
 }) => {
   const t = useTranslations();
-  const analytics = useAnalytics();
-  const queryClient = useQueryClient();
   const activeOrganizationId = useAuthenticatedUser().activeOrganizationId;
 
   const [pattern, setPattern] = useState(settings.matterNumberPattern);
@@ -87,49 +84,30 @@ const MatterNumberingCardBody = ({
       debouncedPattern,
       debouncedPadding,
     ],
-    queryFn: async ({ signal }) => {
-      const response = await api["organization-settings"].preview.post(
-        {
-          matterNumberPattern: debouncedPattern,
-          matterNumberPadding: debouncedPadding,
-        },
-        { fetch: { signal } },
-      );
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-      return response.data;
-    },
+    queryFn: async ({ signal }) =>
+      unwrapEden(
+        await api["organization-settings"].preview.post(
+          {
+            matterNumberPattern: debouncedPattern,
+            matterNumberPadding: debouncedPadding,
+          },
+          { fetch: { signal } },
+        ),
+      ),
   });
   const preview = previewData?.preview ?? null;
 
-  const updateMutation = useMutation({
-    mutationFn: async () => {
-      const response = await api["organization-settings"].post({
-        matterNumberPattern: pattern,
-        matterNumberPadding: padding,
-      });
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-      return response.data;
-    },
-    onSuccess: async () => {
-      await queryClient.invalidateQueries({
-        queryKey: organizationSettingsKeys.all,
-      });
-      stellaToast.add({
-        title: t("success.matterNumberingUpdated"),
-        type: "success",
-      });
-    },
-    onError: (error) => {
-      analytics.captureError(error);
-      stellaToast.add({
-        title: t("errors.actionFailed"),
-        type: "error",
-      });
-    },
+  const updateMutation = useSettingsMutation({
+    mutationFn: async () =>
+      unwrapEden(
+        await api["organization-settings"].post({
+          matterNumberPattern: pattern,
+          matterNumberPadding: padding,
+        }),
+      ),
+    invalidate: organizationSettingsKeys.all,
+    successToast: { title: t("success.matterNumberingUpdated") },
+    errorToast: { title: t("errors.actionFailed") },
   });
 
   const selectedPreset =

--- a/apps/web/src/routes/_protected.settings/-components/organization/prompt-caching-card.tsx
+++ b/apps/web/src/routes/_protected.settings/-components/organization/prompt-caching-card.tsx
@@ -1,58 +1,39 @@
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { useTranslations } from "use-intl";
 
 import { Checkbox } from "@stll/ui/components/checkbox";
 import { Field, FieldLabel } from "@stll/ui/components/field";
 import { Frame, FramePanel } from "@stll/ui/components/frame";
-import { stellaToast } from "@stll/ui/components/toast";
 
-import { useAnalytics } from "@/lib/analytics/provider";
 import { api } from "@/lib/api";
 import { useAuthenticatedUser } from "@/lib/authenticated-user-context";
-import { toAPIError } from "@/lib/errors/api";
+import { unwrapEden } from "@/lib/errors/api";
 import {
   organizationSettingsKeys,
   organizationSettingsOptions,
 } from "@/routes/_protected.organization/-settings-queries";
+import { useSettingsMutation } from "@/routes/_protected.settings/-hooks/use-settings-mutation";
 
 export const PromptCachingCard = () => {
   const t = useTranslations();
-  const analytics = useAnalytics();
-  const queryClient = useQueryClient();
   const activeOrganizationId = useAuthenticatedUser().activeOrganizationId;
   const { data: settings } = useQuery(
     organizationSettingsOptions(activeOrganizationId),
   );
 
-  const mutation = useMutation({
+  const mutation = useSettingsMutation({
     // Send only the prompt-caching field so a stale matter-numbering
     // value from `settings` cannot roll back a concurrent admin's
     // matter-numbering change.
-    mutationFn: async (nextEnabled: boolean) => {
-      const response = await api["organization-settings"].post({
-        promptCachingEnabled: nextEnabled,
-      });
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-      return response.data;
-    },
-    onSuccess: async () => {
-      await queryClient.invalidateQueries({
-        queryKey: organizationSettingsKeys.all,
-      });
-      stellaToast.add({
-        title: t("success.promptCachingUpdated"),
-        type: "success",
-      });
-    },
-    onError: (error) => {
-      analytics.captureError(error);
-      stellaToast.add({
-        title: t("errors.actionFailed"),
-        type: "error",
-      });
-    },
+    mutationFn: async (nextEnabled: boolean) =>
+      unwrapEden(
+        await api["organization-settings"].post({
+          promptCachingEnabled: nextEnabled,
+        }),
+      ),
+    invalidate: organizationSettingsKeys.all,
+    successToast: { title: t("success.promptCachingUpdated") },
+    errorToast: { title: t("errors.actionFailed") },
   });
 
   if (!settings) {

--- a/apps/web/src/routes/_protected.settings/-components/organization/web-search-keys-card.tsx
+++ b/apps/web/src/routes/_protected.settings/-components/organization/web-search-keys-card.tsx
@@ -11,7 +11,7 @@
 
 import { useState } from "react";
 
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { useRouteContext } from "@tanstack/react-router";
 import { Trash2Icon } from "lucide-react";
 import { useTranslations } from "use-intl";
@@ -19,16 +19,14 @@ import { useTranslations } from "use-intl";
 import { Button } from "@stll/ui/components/button";
 import { Frame, FramePanel } from "@stll/ui/components/frame";
 import { Input } from "@stll/ui/components/input";
-import { stellaToast } from "@stll/ui/components/toast";
 
-import { useAnalytics } from "@/lib/analytics/provider";
 import { api } from "@/lib/api";
-import { toAPIError } from "@/lib/errors/api";
-import { userErrorFromThrown } from "@/lib/errors/user-safe";
+import { unwrapEden } from "@/lib/errors/api";
 import {
   webSearchConfigOptions,
   webSearchKeysKeys,
 } from "@/lib/web-search/queries";
+import { useSettingsMutation } from "@/routes/_protected.settings/-hooks/use-settings-mutation";
 
 type WebSearchKeyKind = "search" | "fetch";
 
@@ -71,60 +69,34 @@ type WebSearchKeyFieldProps = {
 
 const WebSearchKeyField = ({ kind, state }: WebSearchKeyFieldProps) => {
   const t = useTranslations();
-  const analytics = useAnalytics();
-  const queryClient = useQueryClient();
 
   const [apiKey, setApiKey] = useState("");
 
-  const saveMutation = useMutation({
-    mutationFn: async () => {
-      const response = await api["organization-settings"][
-        "web-search-key"
-      ].post({ kind, apiKey });
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-      return response.data;
+  const saveMutation = useSettingsMutation({
+    mutationFn: async () =>
+      unwrapEden(
+        await api["organization-settings"]["web-search-key"].post({
+          kind,
+          apiKey,
+        }),
+      ),
+    invalidate: webSearchKeysKeys.all,
+    successToast: { title: t("success.organizationUpdated") },
+    errorToast: {
+      title: t("errors.actionFailed"),
+      description: t("errors.actionFailed"),
     },
-    onSuccess: async () => {
-      setApiKey("");
-      await queryClient.invalidateQueries({ queryKey: webSearchKeysKeys.all });
-      stellaToast.add({
-        title: t("success.organizationUpdated"),
-        type: "success",
-      });
-    },
-    onError: (error: unknown) => {
-      analytics.captureError(error);
-      stellaToast.add({
-        title: t("errors.actionFailed"),
-        description: userErrorFromThrown(error, t("errors.actionFailed")),
-        type: "error",
-      });
-    },
+    onSuccess: () => setApiKey(""),
   });
 
-  const deleteMutation = useMutation({
-    mutationFn: async () => {
-      const response = await api["organization-settings"][
-        "web-search-key"
-      ].delete({ kind });
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-      return response.data;
-    },
-    onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: webSearchKeysKeys.all });
-      stellaToast.add({
-        title: t("success.organizationUpdated"),
-        type: "success",
-      });
-    },
-    onError: (error: unknown) => {
-      analytics.captureError(error);
-      stellaToast.add({ title: t("errors.actionFailed"), type: "error" });
-    },
+  const deleteMutation = useSettingsMutation({
+    mutationFn: async () =>
+      unwrapEden(
+        await api["organization-settings"]["web-search-key"].delete({ kind }),
+      ),
+    invalidate: webSearchKeysKeys.all,
+    successToast: { title: t("success.organizationUpdated") },
+    errorToast: { title: t("errors.actionFailed") },
   });
 
   const title =

--- a/apps/web/src/routes/_protected.settings/-hooks/use-settings-mutation.ts
+++ b/apps/web/src/routes/_protected.settings/-hooks/use-settings-mutation.ts
@@ -46,13 +46,21 @@ export const useSettingsMutation = <TVariables = void, TData = unknown>(
   const invalidate = async () =>
     await queryClient.invalidateQueries({ queryKey: options.invalidate });
 
+  // Fire-and-forget: awaiting invalidation here would keep the mutation
+  // `isPending` until the refetch resolves, delaying the success toast and
+  // re-enabling of the triggering control. The `.catch` on the same line
+  // keeps this out of the detached-promise ratchet and routes a failed
+  // refetch to telemetry instead of an unhandled rejection.
+  const invalidateInBackground = () =>
+    void invalidate().catch((error: unknown) => analytics.captureError(error));
+
   const invalidatesOnSettle = options.invalidateOn === "settled";
 
   return useMutation({
     mutationFn: options.mutationFn,
-    onSuccess: async (data, variables) => {
+    onSuccess: (data, variables) => {
       if (!invalidatesOnSettle) {
-        await invalidate();
+        invalidateInBackground();
       }
       if (options.successToast) {
         stellaToast.add({
@@ -67,8 +75,8 @@ export const useSettingsMutation = <TVariables = void, TData = unknown>(
     },
     ...(invalidatesOnSettle
       ? {
-          onSettled: async () => {
-            await invalidate();
+          onSettled: () => {
+            invalidateInBackground();
           },
         }
       : {}),

--- a/apps/web/src/routes/_protected.settings/-hooks/use-settings-mutation.ts
+++ b/apps/web/src/routes/_protected.settings/-hooks/use-settings-mutation.ts
@@ -1,0 +1,94 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import type { QueryKey } from "@tanstack/react-query";
+
+import { stellaToast } from "@stll/ui/components/toast";
+
+import { useAnalytics } from "@/lib/analytics/provider";
+import { userErrorFromThrown } from "@/lib/errors/user-safe";
+
+type SuccessToast = { title: string; description?: string };
+
+// When `description` is set the shown text is derived from the thrown error via
+// `userErrorFromThrown`, falling back to `description`; when it is omitted the
+// toast is title-only.
+type ErrorToast = { title: string; description?: string };
+
+type UseSettingsMutationOptions<TVariables, TData> = {
+  mutationFn: (variables: TVariables) => Promise<TData>;
+  /** Key to invalidate once the mutation resolves. */
+  invalidate: QueryKey;
+  /**
+   * Whether to invalidate on success only (default) or on settle. Use
+   * `"settled"` for optimistic reorders that must refetch even after an error.
+   */
+  invalidateOn?: "success" | "settled";
+  successToast?: SuccessToast;
+  errorToast?: ErrorToast;
+  /** Extra success side effect, e.g. clearing an input. */
+  onSuccess?: (data: TData, variables: TVariables) => void;
+  /** Extra error side effect, e.g. reverting an optimistic draft. */
+  onError?: (error: unknown, variables: TVariables) => void;
+};
+
+/**
+ * Shared plumbing for organization-settings mutations: always captures the
+ * error (telemetry) and invalidates the affected query, and optionally shows a
+ * success/error toast. Each card supplies its mutation fn, invalidation key, and
+ * toast copy; the helper owns the identical `captureError + invalidate + toast`
+ * boilerplate and makes the missing-`onError` class structurally impossible.
+ */
+export const useSettingsMutation = <TVariables = void, TData = unknown>(
+  options: UseSettingsMutationOptions<TVariables, TData>,
+) => {
+  const analytics = useAnalytics();
+  const queryClient = useQueryClient();
+
+  const invalidate = async () =>
+    await queryClient.invalidateQueries({ queryKey: options.invalidate });
+
+  const invalidatesOnSettle = options.invalidateOn === "settled";
+
+  return useMutation({
+    mutationFn: options.mutationFn,
+    onSuccess: async (data, variables) => {
+      if (!invalidatesOnSettle) {
+        await invalidate();
+      }
+      if (options.successToast) {
+        stellaToast.add({
+          title: options.successToast.title,
+          ...(options.successToast.description
+            ? { description: options.successToast.description }
+            : {}),
+          type: "success",
+        });
+      }
+      options.onSuccess?.(data, variables);
+    },
+    ...(invalidatesOnSettle
+      ? {
+          onSettled: async () => {
+            await invalidate();
+          },
+        }
+      : {}),
+    onError: (error, variables) => {
+      analytics.captureError(error);
+      if (options.errorToast) {
+        stellaToast.add({
+          title: options.errorToast.title,
+          ...(options.errorToast.description
+            ? {
+                description: userErrorFromThrown(
+                  error,
+                  options.errorToast.description,
+                ),
+              }
+            : {}),
+          type: "error",
+        });
+      }
+      options.onError?.(error, variables);
+    },
+  });
+};

--- a/apps/web/src/routes/_protected.settings/-queries/anonymization-blacklist.ts
+++ b/apps/web/src/routes/_protected.settings/-queries/anonymization-blacklist.ts
@@ -1,7 +1,7 @@
 import { queryOptions } from "@tanstack/react-query";
 
 import { api } from "@/lib/api";
-import { toAPIError } from "@/lib/errors/api";
+import { unwrapEden } from "@/lib/errors/api";
 import type { QueryOptionsInput } from "@/lib/react-query";
 
 type OrganizationAnonymizationBlacklistKey = {
@@ -33,10 +33,6 @@ export const organizationAnonymizationBlacklistOptions = ({
         "anonymization-blacklist"
       ].get({ fetch: { signal } });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      return response.data;
+      return unwrapEden(response);
     },
   });

--- a/apps/web/src/routes/_protected.settings/-queries/audit-logs.ts
+++ b/apps/web/src/routes/_protected.settings/-queries/audit-logs.ts
@@ -1,7 +1,7 @@
 import { queryOptions } from "@tanstack/react-query";
 
 import { api } from "@/lib/api";
-import { toAPIError } from "@/lib/errors/api";
+import { unwrapEden } from "@/lib/errors/api";
 import type { SafeId } from "@/lib/safe-id";
 
 export type AuditLogsPageKey = {
@@ -83,10 +83,7 @@ export const fetchAuditLogs = async (query: AuditLogsPageKey) => {
   const response = await api["audit-logs"].get({
     query: cleanedQuery,
   });
-  if (response.error) {
-    throw toAPIError(response.error);
-  }
-  return response.data;
+  return unwrapEden(response);
 };
 
 export const auditLogOptions = ({ key }: AuditLogOptionsInput) =>

--- a/apps/web/src/routes/_protected.settings/-queries/connections.ts
+++ b/apps/web/src/routes/_protected.settings/-queries/connections.ts
@@ -1,7 +1,7 @@
 import { queryOptions } from "@tanstack/react-query";
 
 import { api } from "@/lib/api";
-import { toAPIError } from "@/lib/errors/api";
+import { unwrapEden } from "@/lib/errors/api";
 import { ROUTE_QUERY_STALE_TIME_MS } from "@/lib/react-query";
 
 export const connectedAppsKeys = {
@@ -25,10 +25,7 @@ const fetchConnectedApps = async ({
   const response = await api.me["oauth-connections"].get({
     fetch: { signal },
   });
-  if (response.error) {
-    throw toAPIError(response.error);
-  }
-  return response.data;
+  return unwrapEden(response);
 };
 
 // No parameters (the list is always the session user's own), so this stays

--- a/apps/web/src/routes/_protected.settings/-queries/usage.ts
+++ b/apps/web/src/routes/_protected.settings/-queries/usage.ts
@@ -1,7 +1,7 @@
 import { queryOptions } from "@tanstack/react-query";
 
 import { api } from "@/lib/api";
-import { toAPIError } from "@/lib/errors/api";
+import { unwrapEden } from "@/lib/errors/api";
 import type { QueryOptionsInput } from "@/lib/react-query";
 
 type UsageEntitlementKey = {
@@ -36,10 +36,7 @@ const fetchUsageEntitlement = async ({
   const response = await api.usage.entitlement.get({
     fetch: { signal },
   });
-  if (response.error) {
-    throw toAPIError(response.error);
-  }
-  return response.data;
+  return unwrapEden(response);
 };
 
 export const usageEntitlementOptions = ({

--- a/apps/web/src/routes/_protected.settings/account.profile.tsx
+++ b/apps/web/src/routes/_protected.settings/account.profile.tsx
@@ -53,7 +53,7 @@ import {
 } from "@/i18n/i18n-store";
 import { api } from "@/lib/api";
 import { authClient } from "@/lib/auth";
-import { toAPIError } from "@/lib/errors/api";
+import { unwrapEden } from "@/lib/errors/api";
 import { toAuthClientError } from "@/lib/errors/auth";
 import { ensureRouteQueryData } from "@/lib/react-query";
 import type { SafeId } from "@/lib/safe-id";
@@ -225,10 +225,7 @@ function ProfilePageBody() {
       const res = await api.me.delete["pending-tasks"].get({
         fetch: { signal },
       });
-      if (res.error) {
-        throw toAPIError(res.error);
-      }
-      return res.data;
+      return unwrapEden(res);
     },
     enabled: isDeleteDialogOpen,
   });
@@ -237,10 +234,7 @@ function ProfilePageBody() {
     mutationFn: async () => {
       setOtpError(null);
       const res = await api.me.delete["send-otp"].post();
-      if (res.error) {
-        throw toAPIError(res.error);
-      }
-      return res.data;
+      return unwrapEden(res);
     },
     onSuccess: () => {
       setStep("otp");
@@ -265,10 +259,7 @@ function ProfilePageBody() {
     }) => {
       setOtpError(null);
       const res = await api.me.delete.verify.post(payload);
-      if (res.error) {
-        throw toAPIError(res.error);
-      }
-      return res.data;
+      return unwrapEden(res);
     },
     onSuccess: async () => {
       stellaToast.add({

--- a/apps/web/src/routes/_protected.settings/organization.audit-logs.tsx
+++ b/apps/web/src/routes/_protected.settings/organization.audit-logs.tsx
@@ -29,7 +29,7 @@ import { DatePickerPopover } from "@/components/date-picker-popover";
 import { getFormattingLocale } from "@/i18n/i18n-store";
 import { getAnalytics } from "@/lib/analytics/provider";
 import { api } from "@/lib/api";
-import { APIError, toAPIError } from "@/lib/errors/api";
+import { APIError, unwrapEden } from "@/lib/errors/api";
 import { prefetchRouteQuery } from "@/lib/react-query";
 import { downloadFile } from "@/lib/utils";
 import { SettingsPageHeader } from "@/routes/_protected.settings/-components/settings-page-header";
@@ -137,10 +137,7 @@ function AuditLogsPage() {
           query: cleanParams,
         });
 
-        if (response.error) {
-          throw toAPIError(response.error);
-        }
-        return response.data;
+        return unwrapEden(response);
       },
       catch: (error) => error,
     });

--- a/apps/web/src/routes/_protected.settings/organization.usage.tsx
+++ b/apps/web/src/routes/_protected.settings/organization.usage.tsx
@@ -13,7 +13,7 @@ import { stellaToast } from "@stll/ui/components/toast";
 import { useFormatter } from "@/i18n/formatting-context";
 import type { TranslationKey } from "@/i18n/types";
 import { api } from "@/lib/api";
-import { toAPIError } from "@/lib/errors/api";
+import { unwrapEden } from "@/lib/errors/api";
 import { userErrorFromThrown } from "@/lib/errors/user-safe";
 import { SettingsPageHeader } from "@/routes/_protected.settings/-components/settings-page-header";
 import { usageEntitlementOptions } from "@/routes/_protected.settings/-queries/usage";
@@ -182,10 +182,7 @@ function ManageUsageButton() {
   const mutation = useMutation({
     mutationFn: async () => {
       const response = await api.usage.hosted.management.post();
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-      return response.data;
+      return unwrapEden(response);
     },
     onMutate: () => setPending(true),
     onSuccess: ({ url }) => {

--- a/apps/web/src/routes/_protected.todos/-queries.ts
+++ b/apps/web/src/routes/_protected.todos/-queries.ts
@@ -1,7 +1,7 @@
 import { queryOptions } from "@tanstack/react-query";
 
 import { api } from "@/lib/api";
-import { toAPIError } from "@/lib/errors/api";
+import { unwrapEden } from "@/lib/errors/api";
 
 const myTasksKeys = {
   all: ["my-tasks"],
@@ -14,11 +14,7 @@ export const myTasksOptions = queryOptions({
       fetch: { signal },
     });
 
-    if (response.error) {
-      throw toAPIError(response.error);
-    }
-
-    return response.data;
+    return unwrapEden(response);
   },
 });
 

--- a/apps/web/src/routes/_protected.todos/index.tsx
+++ b/apps/web/src/routes/_protected.todos/index.tsx
@@ -29,7 +29,7 @@ import { cn } from "@stll/ui/lib/utils";
 
 import { getFormattingLocale } from "@/i18n/i18n-store";
 import { api } from "@/lib/api";
-import { toAPIError } from "@/lib/errors/api";
+import { unwrapEden } from "@/lib/errors/api";
 import { pageTitle } from "@/lib/page-title";
 import type { TaskItem } from "@/routes/_protected.todos/-queries";
 import { myTasksOptions } from "@/routes/_protected.todos/-queries";
@@ -145,11 +145,7 @@ function MyTodosPage() {
       name: t("tasks.untitled"),
     });
 
-    if (response.error) {
-      throw toAPIError(response.error);
-    }
-
-    const entityId = response.data.entityId;
+    const entityId = unwrapEden(response).entityId;
 
     await navigate({
       to: "/workspaces/$workspaceId",

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/billing/billing-codes-dialog.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/billing/billing-codes-dialog.tsx
@@ -15,7 +15,7 @@ import { stellaToast } from "@stll/ui/components/toast";
 
 import { useAnalytics } from "@/lib/analytics/provider";
 import { api } from "@/lib/api";
-import { toAPIError } from "@/lib/errors/api";
+import { unwrapEden } from "@/lib/errors/api";
 import { toSafeId } from "@/lib/safe-id";
 import {
   billingCodesKeys,
@@ -61,11 +61,7 @@ export const BillingCodesDialog = ({
         ...body,
       });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      return response.data;
+      return unwrapEden(response);
     },
     onError: (error) => {
       analytics.captureError(error);
@@ -86,11 +82,7 @@ export const BillingCodesDialog = ({
         id: toSafeId<"billingCode">(id),
       });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      return response.data;
+      return unwrapEden(response);
     },
     onError: (error) => {
       analytics.captureError(error);
@@ -116,11 +108,7 @@ export const BillingCodesDialog = ({
         id: toSafeId<"billingCode">(body.id),
       });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      return response.data;
+      return unwrapEden(response);
     },
     onError: (error) => {
       analytics.captureError(error);

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/billing/rate-management-dialog.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/billing/rate-management-dialog.tsx
@@ -25,7 +25,7 @@ import { UserIdentity } from "@/components/user-avatar";
 import { useAnalytics } from "@/lib/analytics/provider";
 import { api } from "@/lib/api";
 import { useAuthenticatedUser } from "@/lib/authenticated-user-context";
-import { toAPIError } from "@/lib/errors/api";
+import { unwrapEden } from "@/lib/errors/api";
 import { toSafeId } from "@/lib/safe-id";
 import { organizationOptions } from "@/routes/_protected.organization/-queries";
 import { formatCurrencyAmount } from "@/routes/_protected.workspaces/$workspaceId/-components/billing/format-currency";
@@ -110,11 +110,7 @@ const RateTablesView = ({
           ...body,
         });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      return response.data;
+      return unwrapEden(response);
     },
     onError: (error) => {
       analytics.captureError(error);
@@ -135,11 +131,7 @@ const RateTablesView = ({
           id: toSafeId<"rateTable">(id),
         });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      return response.data;
+      return unwrapEden(response);
     },
     onError: (error) => {
       analytics.captureError(error);
@@ -164,11 +156,7 @@ const RateTablesView = ({
           id: toSafeId<"rateTable">(body.id),
         });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      return response.data;
+      return unwrapEden(response);
     },
     onError: (error) => {
       analytics.captureError(error);
@@ -448,11 +436,7 @@ const RateEntriesView = ({
           }),
         });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      return response.data;
+      return unwrapEden(response);
     },
     onError: (error) => {
       analytics.captureError(error);
@@ -477,11 +461,7 @@ const RateEntriesView = ({
           id: toSafeId<"rateEntry">(id),
         });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      return response.data;
+      return unwrapEden(response);
     },
     onError: (error) => {
       analytics.captureError(error);

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/cell-metadata-flags.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/cell-metadata-flags.tsx
@@ -29,7 +29,7 @@ import Tooltip from "@/components/tooltip";
 import { UserAvatar } from "@/components/user-avatar";
 import { useMountEffect } from "@/hooks/use-effect";
 import { api } from "@/lib/api";
-import { toAPIError } from "@/lib/errors/api";
+import { unwrapEden } from "@/lib/errors/api";
 import { userErrorFromThrown } from "@/lib/errors/user-safe";
 import { formatRelativeTime } from "@/lib/relative-time";
 import { toSafeId } from "@/lib/safe-id";
@@ -590,11 +590,7 @@ export const useCellMetadataFlags = ({
           ...(locked !== undefined && { locked }),
         });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      return response.data;
+      return unwrapEden(response);
     },
     scope: { id: `cell-metadata:${workspaceId}:${entityId}:${propertyId}` },
     onSuccess: () => {

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/editable-field.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/editable-field.tsx
@@ -22,7 +22,7 @@ import { contentDir } from "@stll/ui/hooks/use-content-dir";
 import { DatePickerPopover } from "@/components/date-picker-popover";
 import Tooltip from "@/components/tooltip";
 import { api } from "@/lib/api";
-import { toAPIError } from "@/lib/errors/api";
+import { unwrapEden } from "@/lib/errors/api";
 import { toSafeId } from "@/lib/safe-id";
 import { isFileDisplayable } from "@/lib/types";
 import type {
@@ -179,10 +179,7 @@ const InlineEditor = ({
           entityId: toSafeId<"entity">(entityId),
           content: newContent,
         });
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-      return response.data;
+      return unwrapEden(response);
     },
     onSuccess: () => {
       void queryClient.invalidateQueries({

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/existing-file-organizer-dialog.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/existing-file-organizer-dialog.tsx
@@ -44,7 +44,7 @@ import { useI18nStore } from "@/i18n/i18n-store";
 import { useAnalytics } from "@/lib/analytics/provider";
 import { api } from "@/lib/api";
 import { compareByLocale } from "@/lib/collation";
-import { toAPIError } from "@/lib/errors/api";
+import { toAPIError, unwrapEden } from "@/lib/errors/api";
 import { toSafeId } from "@/lib/safe-id";
 import { EntityKindIcon } from "@/routes/_protected.workspaces/$workspaceId/-components/entity-kind-icon";
 import {
@@ -556,11 +556,7 @@ export const ExistingFileOrganizerDialog = ({
               { fetch: { signal } },
             );
 
-          if (response.error) {
-            throw toAPIError(response.error);
-          }
-
-          return response.data;
+          return unwrapEden(response);
         },
       });
 

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/existing-file-organizer-dialog.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/existing-file-organizer-dialog.tsx
@@ -1536,11 +1536,7 @@ const ensureFolders = async ({
           parentId: parentSafeId,
         });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      const newEntityId: string = response.data.entityId;
+      const newEntityId: string = unwrapEden(response).entityId;
       currentParentId = newEntityId;
       knownFolders.set(key, newEntityId);
       folderIds.set(pathKey, newEntityId);

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/files/queries.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/files/queries.ts
@@ -1,7 +1,7 @@
 import { queryOptions } from "@tanstack/react-query";
 
 import { api } from "@/lib/api";
-import { toAPIError } from "@/lib/errors/api";
+import { unwrapEden } from "@/lib/errors/api";
 import type { QueryOptionsInput } from "@/lib/react-query";
 import {
   fetchStorageArrayBuffer,
@@ -83,15 +83,13 @@ export const fileMetadataOptions = (props: FileOptionsProps) =>
           fetch: { signal },
         });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
+      const data = unwrapEden(response);
 
       return {
-        fileId: response.data.fileId,
-        fileName: response.data.fileName,
-        mimeType: response.data.mimeType,
-        originalMimeType: response.data.originalMimeType,
+        fileId: data.fileId,
+        fileName: data.fileName,
+        mimeType: data.mimeType,
+        originalMimeType: data.originalMimeType,
       } satisfies FileMetadata;
     },
   });
@@ -108,20 +106,18 @@ export const fileOptions = (props: FileOptionsProps) =>
           fetch: { signal },
         });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
+      const data = unwrapEden(response);
 
-      const buffer = await fetchStorageArrayBuffer(response.data.presignedUrl, {
+      const buffer = await fetchStorageArrayBuffer(data.presignedUrl, {
         signal,
         purpose: props.purpose ?? "display",
       });
 
       return {
-        fileId: response.data.fileId,
-        fileName: response.data.fileName,
-        mimeType: response.data.mimeType,
-        originalMimeType: response.data.originalMimeType,
+        fileId: data.fileId,
+        fileName: data.fileName,
+        mimeType: data.mimeType,
+        originalMimeType: data.originalMimeType,
         buffer,
       } satisfies FileData;
     },
@@ -136,16 +132,14 @@ export const emailHtmlPreviewOptions = (props: FileOptionsProps) =>
         ["email-html"]({ fieldId: props.fieldId })
         .get({ fetch: { signal } });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
+      const data = unwrapEden(response);
 
       return {
-        fileId: response.data.fileId,
-        fileName: response.data.fileName,
-        html: response.data.html,
-        mimeType: response.data.mimeType,
-        originalMimeType: response.data.originalMimeType,
+        fileId: data.fileId,
+        fileName: data.fileName,
+        html: data.html,
+        mimeType: data.mimeType,
+        originalMimeType: data.originalMimeType,
       } satisfies EmailHtmlPreviewData;
     },
   });
@@ -162,20 +156,18 @@ export const textFileOptions = (props: FileOptionsProps) =>
           fetch: { signal },
         });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
+      const data = unwrapEden(response);
 
-      const buffer = await fetchStorageArrayBuffer(response.data.presignedUrl, {
+      const buffer = await fetchStorageArrayBuffer(data.presignedUrl, {
         signal,
         purpose: "download",
       });
 
       return {
-        fileId: response.data.fileId,
-        fileName: response.data.fileName,
-        mimeType: response.data.mimeType,
-        originalMimeType: response.data.originalMimeType,
+        fileId: data.fileId,
+        fileName: data.fileName,
+        mimeType: data.mimeType,
+        originalMimeType: data.originalMimeType,
         text: new TextDecoder().decode(buffer),
       } satisfies TextFileData;
     },

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/overview-view.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/overview-view.tsx
@@ -70,7 +70,7 @@ import {
 import { getFirstWeekday } from "@/i18n/week";
 import { api } from "@/lib/api";
 import { normalizeOptionalArray } from "@/lib/arrays";
-import { toAPIError } from "@/lib/errors/api";
+import { unwrapEden } from "@/lib/errors/api";
 import { routeQueryOptions } from "@/lib/react-query";
 import { formatFullTimestamp, formatRelativeTime } from "@/lib/relative-time";
 import { toSafeId } from "@/lib/safe-id";
@@ -235,10 +235,7 @@ export const OverviewView = ({ workspaceId }: OverviewViewProps) => {
           taskId: toSafeId<"entity">(taskId),
           status,
         });
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-      return response.data;
+      return unwrapEden(response);
     },
     onSuccess: async (_data, variables) => {
       await Promise.all([

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/parties-section.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/parties-section.tsx
@@ -39,7 +39,7 @@ import { ContactPicker } from "@/components/contact-picker";
 import { useAnalytics } from "@/lib/analytics/provider";
 import { api } from "@/lib/api";
 import { TOOLBAR_ROW_HEIGHT } from "@/lib/consts";
-import { toAPIError } from "@/lib/errors/api";
+import { toAPIError, unwrapEden } from "@/lib/errors/api";
 import { toSafeId } from "@/lib/safe-id";
 import { useCreateContact } from "@/routes/_protected.contacts/-mutations";
 import { contactsKeys } from "@/routes/_protected.contacts/-queries";
@@ -565,11 +565,7 @@ const AddPartyDialog = ({
           queryKey: workspaceContactsKeys.all(ws),
         });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      return response.data;
+      return unwrapEden(response);
     },
     onError: (error) => {
       analytics.captureError(error);

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/pdf/versions-sidebar.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/pdf/versions-sidebar.tsx
@@ -38,7 +38,7 @@ import type { VersionDiffSegment } from "@/components/versions/version-list";
 import { useExternalSyncEffect } from "@/hooks/use-effect";
 import { api } from "@/lib/api";
 import { DOCX_MIME, TOOLBAR_ROW_HEIGHT } from "@/lib/consts";
-import { toAPIError } from "@/lib/errors/api";
+import { toAPIError, unwrapEden } from "@/lib/errors/api";
 import { ClientOperationError } from "@/lib/errors/client";
 import { fetchWithTimeout } from "@/lib/fetch";
 import { toSafeId } from "@/lib/safe-id";
@@ -269,10 +269,7 @@ export function VersionsSidebar({
         size: file.size,
         sha256Hex,
       });
-      if (presign.error) {
-        throw toAPIError(presign.error);
-      }
-      const { uploadId, url, headers } = presign.data;
+      const { uploadId, url, headers } = unwrapEden(presign);
 
       // 3. PUT to S3.
       const putResponse = await fetchWithTimeout(url, {
@@ -410,10 +407,7 @@ export function VersionsSidebar({
         .entity({ entityId: toSafeId<"entity">(entityId) })
         .versions({ versionId: toSafeId<"entityVersion">(versionId) })
         .diff.get();
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-      return response.data.segments;
+      return unwrapEden(response).segments;
     };
 
   const buildSummarize =
@@ -423,10 +417,7 @@ export function VersionsSidebar({
         .entity({ entityId: toSafeId<"entity">(entityId) })
         .versions({ versionId: toSafeId<"entityVersion">(versionId) })
         .summarize.post({});
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-      return response.data.summary;
+      return unwrapEden(response).summary;
     };
 
   // Render oldest → newest top-to-bottom so the timeline reads

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/property-popover.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/property-popover.tsx
@@ -16,7 +16,7 @@ import { Separator } from "@stll/ui/components/separator";
 import { stellaToast } from "@stll/ui/components/toast";
 
 import { api } from "@/lib/api";
-import { toAPIError } from "@/lib/errors/api";
+import { unwrapEden } from "@/lib/errors/api";
 import { userErrorFromThrown } from "@/lib/errors/user-safe";
 import { type SafeId, toSafeId } from "@/lib/safe-id";
 import type {
@@ -120,10 +120,7 @@ export const PropertyPopover = ({
           ...groupParams,
         });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-      return response.data;
+      return unwrapEden(response);
     },
     onSuccess: (data, { action, scoped, set }) => {
       void queryClient.invalidateQueries({

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/tasks/task-detail-panel.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/tasks/task-detail-panel.tsx
@@ -17,7 +17,7 @@ import { useExternalSyncEffect } from "@/hooks/use-effect";
 import { useAnalytics } from "@/lib/analytics/provider";
 import { api } from "@/lib/api";
 import { TOOLBAR_ROW_HEIGHT } from "@/lib/consts";
-import { toAPIError } from "@/lib/errors/api";
+import { toAPIError, unwrapEden } from "@/lib/errors/api";
 import { toSafeId } from "@/lib/safe-id";
 import {
   isTaskPriority,
@@ -96,10 +96,7 @@ export const TaskDetailPanel = ({
           ...body,
           taskId: toSafeId<"entity">(body.taskId),
         });
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-      return response.data;
+      return unwrapEden(response);
     },
     onSuccess: async () => {
       await Promise.all([

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/tasks/task-metadata.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/tasks/task-metadata.tsx
@@ -21,7 +21,7 @@ import type { DatePickerPopoverProps as DatePickerPopoverBaseProps } from "@/com
 import { UserAvatar } from "@/components/user-avatar";
 import { useLocale } from "@/i18n/formatting-context";
 import { api } from "@/lib/api";
-import { toAPIError } from "@/lib/errors/api";
+import { unwrapEden } from "@/lib/errors/api";
 import { toSafeId } from "@/lib/safe-id";
 import {
   PRIORITY_COLORS,
@@ -206,10 +206,7 @@ export const AssigneePicker = ({
           userId: toSafeId<"user">(userId),
           queryKey,
         });
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-      return response.data;
+      return unwrapEden(response);
     },
     onSuccess: invalidate,
   });
@@ -223,10 +220,7 @@ export const AssigneePicker = ({
           userId: toSafeId<"user">(userId),
           queryKey,
         });
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-      return response.data;
+      return unwrapEden(response);
     },
     onSuccess: invalidate,
   });

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/export-report-dialog.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/export-report-dialog.tsx
@@ -30,7 +30,7 @@ import { stellaToast } from "@stll/ui/components/toast";
 import type { TranslationKey } from "@/i18n/types";
 import { useAnalytics } from "@/lib/analytics/provider";
 import { api } from "@/lib/api";
-import { toAPIError } from "@/lib/errors/api";
+import { toAPIError, unwrapEden } from "@/lib/errors/api";
 import { userErrorMessage } from "@/lib/errors/user-safe";
 import { toSafeId } from "@/lib/safe-id";
 import type { WorkspaceView } from "@/lib/types";
@@ -188,10 +188,7 @@ const ExportReportDialogBody = ({
       const response = await api
         .workspaces({ workspaceId: toSafeId<"workspace">(workspaceId) })
         .reports.templates.get({ fetch: { signal } });
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-      return response.data;
+      return unwrapEden(response);
     },
   });
 

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-hooks/use-create-b-boxes.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-hooks/use-create-b-boxes.ts
@@ -10,7 +10,7 @@ import { useRouteContext } from "@tanstack/react-router";
 
 import { useAnalytics } from "@/lib/analytics/provider";
 import { api } from "@/lib/api";
-import { toAPIError } from "@/lib/errors/api";
+import { unwrapEden } from "@/lib/errors/api";
 import { toSafeId } from "@/lib/safe-id";
 import type { WorkspaceJustification } from "@/lib/types";
 import { aiAvailabilityOptions } from "@/routes/_protected.organization/-ai-config-queries";
@@ -62,11 +62,7 @@ export const useCreateBBoxes = ({
           justificationId: toSafeId<"justification">(justification.id),
         });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      return response.data;
+      return unwrapEden(response);
     },
     onSuccess: () => {
       void queryClient.invalidateQueries({

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-hooks/use-create-file-entities.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-hooks/use-create-file-entities.ts
@@ -12,7 +12,7 @@ import { MAX_PARALLEL_FILE_UPLOADS } from "@/consts";
 import type { DroppedFileTree } from "@/hooks/external-file-drop.logic";
 import { useAnalytics } from "@/lib/analytics/provider";
 import { api } from "@/lib/api";
-import { toAPIError } from "@/lib/errors/api";
+import { toAPIError, unwrapEden } from "@/lib/errors/api";
 import { ClientOperationError } from "@/lib/errors/client";
 import { fetchWithTimeout } from "@/lib/fetch";
 import { toSafeId } from "@/lib/safe-id";
@@ -672,10 +672,7 @@ export const useCreateFileEntities = (workspaceId: string) => {
       name: t("workspaces.files.defaultPropertyName"),
       contentType: "file",
     });
-    if (response.error) {
-      throw toAPIError(response.error);
-    }
-    propertyId = response.data.id;
+    propertyId = unwrapEden(response).id;
     return propertyId;
   };
 

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-hooks/use-upload-version.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-hooks/use-upload-version.ts
@@ -5,7 +5,7 @@ import { stellaToast } from "@stll/ui/components/toast";
 
 import { useAnalytics } from "@/lib/analytics/provider";
 import { api } from "@/lib/api";
-import { toAPIError } from "@/lib/errors/api";
+import { unwrapEden } from "@/lib/errors/api";
 import { ClientOperationError } from "@/lib/errors/client";
 import { userErrorFromThrown } from "@/lib/errors/user-safe";
 import { toSafeId } from "@/lib/safe-id";
@@ -54,11 +54,7 @@ export const useUploadVersion = () => {
           file,
         });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      return response.data;
+      return unwrapEden(response);
     },
     onSuccess: () => {
       stellaToast.add({

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-mutations/entities.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-mutations/entities.ts
@@ -5,7 +5,7 @@ import { stellaToast } from "@stll/ui/components/toast";
 
 import { useAnalytics } from "@/lib/analytics/provider";
 import { api } from "@/lib/api";
-import { toAPIError } from "@/lib/errors/api";
+import { unwrapEden } from "@/lib/errors/api";
 import { toSafeId } from "@/lib/safe-id";
 import type { EntityKind } from "@/lib/types";
 import type { EditableFieldContent } from "@/routes/_protected.workspaces/$workspaceId/-components/edit-field-dialog";
@@ -38,11 +38,7 @@ export const useCreateEntities = () => {
           }),
         });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      return response.data;
+      return unwrapEden(response);
     },
     onError: (error) => {
       analytics.captureError(error);
@@ -68,11 +64,7 @@ export const useDeleteEntities = () => {
           entityIds: entityIds.map((entityId) => toSafeId<"entity">(entityId)),
         });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      return response.data;
+      return unwrapEden(response);
     },
     onSuccess: async (_data, { workspaceId }) => {
       await queryClient.invalidateQueries({
@@ -104,11 +96,7 @@ export const useMoveEntity = () => {
           parentId: parentId === null ? null : toSafeId<"entity">(parentId),
         });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      return response.data;
+      return unwrapEden(response);
     },
     onError: (error) => {
       analytics.captureError(error);
@@ -136,11 +124,7 @@ export const useRenameEntity = () => {
           name,
         });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      return response.data;
+      return unwrapEden(response);
     },
     onError: (error) => {
       analytics.captureError(error);
@@ -179,11 +163,7 @@ export const useUpsertField = () => {
           content,
         });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      return response.data;
+      return unwrapEden(response);
     },
 
     onError: (error) => {

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-mutations/expenses.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-mutations/expenses.ts
@@ -2,7 +2,7 @@ import { useMutation } from "@tanstack/react-query";
 
 import { useAnalytics } from "@/lib/analytics/provider";
 import { api } from "@/lib/api";
-import { toAPIError } from "@/lib/errors/api";
+import { unwrapEden } from "@/lib/errors/api";
 import { toSafeId } from "@/lib/safe-id";
 import { expensesKeys } from "@/routes/_protected.workspaces/$workspaceId/-queries/expenses";
 
@@ -41,11 +41,7 @@ export const useCreateExpense = () => {
           matterId: toSafeId<"entity">(body.matterId),
         });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      return response.data;
+      return unwrapEden(response);
     },
     onError: (error) => {
       analytics.captureError(error);
@@ -85,11 +81,7 @@ export const useUpdateExpense = () => {
           }),
         });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      return response.data;
+      return unwrapEden(response);
     },
     onError: (error) => {
       analytics.captureError(error);
@@ -114,11 +106,7 @@ export const useDeleteExpense = () => {
           id: toSafeId<"expense">(id),
         });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      return response.data;
+      return unwrapEden(response);
     },
     onError: (error) => {
       analytics.captureError(error);

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-mutations/properties.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-mutations/properties.ts
@@ -4,7 +4,7 @@ import type { PropertyContentType } from "@stll/api/types";
 
 import { useAnalytics } from "@/lib/analytics/provider";
 import { api } from "@/lib/api";
-import { toAPIError } from "@/lib/errors/api";
+import { toAPIError, unwrapEden } from "@/lib/errors/api";
 import { toSafeId } from "@/lib/safe-id";
 import type {
   PropertyDependency,
@@ -64,11 +64,7 @@ export const useCreateProperty = ({ workspaceId }: { workspaceId: string }) => {
           ...(fallback !== undefined ? { fallback } : {}),
         });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      return response.data;
+      return unwrapEden(response);
     },
     onSuccess: async () => {
       // Reflect the actor's own write immediately instead of waiting on
@@ -130,11 +126,7 @@ export const useCreatePropertiesBatch = ({
           })),
         });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      return response.data;
+      return unwrapEden(response);
     },
     onSuccess: async () => {
       await queryClient.invalidateQueries({
@@ -245,11 +237,7 @@ export const usePreviewProperty = () => {
             : {}),
         });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      return response.data;
+      return unwrapEden(response);
     },
     onError: (error) => {
       analytics.captureError(error);
@@ -289,11 +277,7 @@ export const useSuggestPrompt = () => {
             : {}),
         });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      return response.data;
+      return unwrapEden(response);
     },
     onError: (error) => {
       analytics.captureError(error);

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-mutations/time-entries.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-mutations/time-entries.ts
@@ -2,7 +2,7 @@ import { useMutation } from "@tanstack/react-query";
 
 import { useAnalytics } from "@/lib/analytics/provider";
 import { api } from "@/lib/api";
-import { toAPIError } from "@/lib/errors/api";
+import { unwrapEden } from "@/lib/errors/api";
 import { toSafeId } from "@/lib/safe-id";
 import { timeEntriesKeys } from "@/routes/_protected.workspaces/$workspaceId/-queries/time-entries";
 
@@ -33,11 +33,7 @@ export const useCreateTimeEntry = () => {
         matterId: toSafeId<"entity">(body.matterId),
       });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      return response.data;
+      return unwrapEden(response);
     },
     onError: (error) => {
       analytics.captureError(error);
@@ -79,11 +75,7 @@ export const useUpdateTimeEntry = () => {
         }),
       });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      return response.data;
+      return unwrapEden(response);
     },
     onError: (error) => {
       analytics.captureError(error);
@@ -108,11 +100,7 @@ export const useDeleteTimeEntry = () => {
         id: toSafeId<"timeEntry">(id),
       });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      return response.data;
+      return unwrapEden(response);
     },
     onError: (error) => {
       analytics.captureError(error);
@@ -142,11 +130,7 @@ export const useStartTimer = () => {
         matterId: toSafeId<"entity">(body.matterId),
       });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      return response.data;
+      return unwrapEden(response);
     },
     onError: (error) => {
       analytics.captureError(error);
@@ -169,11 +153,7 @@ export const useStopTimer = () => {
         queryKey: timeEntriesKeys.all(workspaceId),
       });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      return response.data;
+      return unwrapEden(response);
     },
     onError: (error) => {
       analytics.captureError(error);
@@ -200,11 +180,7 @@ export const useBatchUpdateTimeEntries = () => {
         ids: body.ids.map((id) => toSafeId<"timeEntry">(id)),
       });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      return response.data;
+      return unwrapEden(response);
     },
     onError: (error) => {
       analytics.captureError(error);
@@ -229,11 +205,7 @@ export const useBatchDeleteTimeEntries = () => {
         ids: ids.map((id) => toSafeId<"timeEntry">(id)),
       });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      return response.data;
+      return unwrapEden(response);
     },
     onError: (error) => {
       analytics.captureError(error);
@@ -264,11 +236,7 @@ export const useSplitTimeEntry = () => {
         })),
       });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      return response.data;
+      return unwrapEden(response);
     },
     onError: (error) => {
       analytics.captureError(error);

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-mutations/view-templates.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-mutations/view-templates.ts
@@ -3,7 +3,7 @@ import { useRouteContext } from "@tanstack/react-router";
 
 import { useAnalytics } from "@/lib/analytics/provider";
 import { api } from "@/lib/api";
-import { toAPIError } from "@/lib/errors/api";
+import { unwrapEden } from "@/lib/errors/api";
 import { toSafeId } from "@/lib/safe-id";
 import type { ViewLayout } from "@/lib/types";
 import { viewTemplateKeys } from "@/routes/_protected.workspaces/$workspaceId/-queries/view-templates";
@@ -27,10 +27,7 @@ export const useCreateViewTemplate = () => {
       const response = await api["view-templates"]({
         workspaceId: toSafeId<"workspace">(workspaceId),
       }).put(body);
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-      return { data: response.data, workspaceId };
+      return { data: unwrapEden(response), workspaceId };
     },
     onSuccess: () => {
       void queryClient.invalidateQueries({
@@ -63,10 +60,7 @@ export const useDeleteViewTemplate = () => {
       })({
         templateId: toSafeId<"workspaceViewTemplate">(templateId),
       }).delete();
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-      return { data: response.data, workspaceId };
+      return { data: unwrapEden(response), workspaceId };
     },
     onSuccess: () => {
       void queryClient.invalidateQueries({

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-mutations/views.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-mutations/views.ts
@@ -2,7 +2,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 
 import { useAnalytics } from "@/lib/analytics/provider";
 import { api } from "@/lib/api";
-import { toAPIError } from "@/lib/errors/api";
+import { unwrapEden } from "@/lib/errors/api";
 import { toSafeId } from "@/lib/safe-id";
 import type {
   ViewLayout,
@@ -29,10 +29,7 @@ export const useCreateView = (workspaceId: string) => {
       const response = await api
         .views({ workspaceId: toSafeId<"workspace">(workspaceId) })
         .put({ ...body, id: toSafeId<"workspaceView">(body.id) });
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-      return response.data;
+      return unwrapEden(response);
     },
     onSuccess: async (_data, variables) => {
       const invalidations = [
@@ -82,10 +79,7 @@ export const useUpdateView = (workspaceId: string) => {
         .views({ workspaceId: toSafeId<"workspace">(workspaceId) })
         .view({ viewId: toSafeId<"workspaceView">(viewId) })
         .post(body);
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-      return response.data;
+      return unwrapEden(response);
     },
     onMutate: async ({ viewId, ...body }) => {
       await queryClient.cancelQueries({ queryKey: localizedKey });
@@ -141,10 +135,7 @@ export const useConvertView = (workspaceId: string) => {
         .views({ workspaceId: toSafeId<"workspace">(workspaceId) })
         .view({ viewId: toSafeId<"workspaceView">(viewId) })
         .convert.post({ targetType });
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-      return response.data;
+      return unwrapEden(response);
     },
     onSuccess: async () => {
       await queryClient.invalidateQueries({
@@ -172,10 +163,7 @@ export const useReorderViews = (workspaceId: string) => {
         .reorder.post({
           viewIds: viewIds.map((viewId) => toSafeId<"workspaceView">(viewId)),
         });
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-      return response.data;
+      return unwrapEden(response);
     },
     onSuccess: async () => {
       await queryClient.invalidateQueries({
@@ -202,10 +190,7 @@ export const useDeleteView = (workspaceId: string) => {
         .views({ workspaceId: toSafeId<"workspace">(workspaceId) })
         .view({ viewId: toSafeId<"workspaceView">(viewId) })
         .delete();
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-      return response.data;
+      return unwrapEden(response);
     },
     onSuccess: async () => {
       await queryClient.invalidateQueries({

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-mutations/workspace-members.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-mutations/workspace-members.ts
@@ -2,7 +2,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 
 import { useAnalytics } from "@/lib/analytics/provider";
 import { api } from "@/lib/api";
-import { toAPIError } from "@/lib/errors/api";
+import { unwrapEden } from "@/lib/errors/api";
 import { toSafeId } from "@/lib/safe-id";
 import { workspaceMembersKeys } from "@/routes/_protected.workspaces/$workspaceId/-queries/workspace-members";
 import { workspacesKeys } from "@/routes/_protected.workspaces/-queries";
@@ -24,11 +24,7 @@ export const useAddWorkspaceMember = () => {
         queryKeys: [workspacesKeys.all],
       });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      return response.data;
+      return unwrapEden(response);
     },
     onSuccess: (_data, vars) => {
       void queryClient.invalidateQueries({

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/anonymization-allowlist.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/anonymization-allowlist.ts
@@ -1,7 +1,7 @@
 import { queryOptions } from "@tanstack/react-query";
 
 import { api } from "@/lib/api";
-import { toAPIError } from "@/lib/errors/api";
+import { unwrapEden } from "@/lib/errors/api";
 import { toSafeId } from "@/lib/safe-id";
 
 export type AnonymizationAllowlistKey = {
@@ -45,10 +45,6 @@ export const anonymizationAllowlistOptions = ({
             : {}),
         });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      return response.data;
+      return unwrapEden(response);
     },
   });

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/anonymization-terms.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/anonymization-terms.ts
@@ -1,7 +1,7 @@
 import { queryOptions } from "@tanstack/react-query";
 
 import { api } from "@/lib/api";
-import { toAPIError } from "@/lib/errors/api";
+import { unwrapEden } from "@/lib/errors/api";
 import { toSafeId } from "@/lib/safe-id";
 
 export const anonymizationTermsKeys = {
@@ -16,10 +16,6 @@ export const anonymizationTermsOptions = (workspaceId: string) =>
         .workspaces({ workspaceId: toSafeId<"workspace">(workspaceId) })
         ["anonymization-terms"].get({ fetch: { signal } });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      return response.data;
+      return unwrapEden(response);
     },
   });

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/billing-codes.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/billing-codes.ts
@@ -1,7 +1,7 @@
 import { queryOptions } from "@tanstack/react-query";
 
 import { api } from "@/lib/api";
-import { toAPIError } from "@/lib/errors/api";
+import { unwrapEden } from "@/lib/errors/api";
 
 export const billingCodesKeys = {
   all: (workspaceId: string) => ["billingCodes", workspaceId],
@@ -28,10 +28,6 @@ export const billingCodesOptions = (
         fetch: { signal },
       });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      return response.data.items;
+      return unwrapEden(response).items;
     },
   });

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/calendar-tasks.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/calendar-tasks.ts
@@ -1,7 +1,7 @@
 import { queryOptions } from "@tanstack/react-query";
 
 import { api } from "@/lib/api";
-import { toAPIError } from "@/lib/errors/api";
+import { unwrapEden } from "@/lib/errors/api";
 import type { ConditionNode } from "@/lib/types";
 import { normalizeVisibleFieldIds } from "@/routes/_protected.workspaces/$workspaceId/-queries/entities.logic";
 import type { ViewSort } from "@/routes/_protected.workspaces/$workspaceId/-queries/entities.logic";
@@ -59,11 +59,7 @@ const fetchCalendarTasks = async ({
       { fetch: { signal: signal ?? null } },
     );
 
-  if (response.error) {
-    throw toAPIError(response.error);
-  }
-
-  return response.data.tasks;
+  return unwrapEden(response).tasks;
 };
 
 export type CalendarTask = Awaited<

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/docx-suggestions.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/docx-suggestions.ts
@@ -2,7 +2,7 @@ import { queryOptions } from "@tanstack/react-query";
 
 import { getAnalytics } from "@/lib/analytics/provider";
 import { api } from "@/lib/api";
-import { toAPIError } from "@/lib/errors/api";
+import { unwrapEden } from "@/lib/errors/api";
 
 import { entitiesKeys } from "./entities";
 
@@ -49,12 +49,10 @@ export const docxSuggestionsOptions = ({
           query: { status, limit: DOCX_SUGGESTIONS_HYDRATION_LIMIT },
           fetch: { signal },
         });
-        if (firstPage.error) {
-          throw toAPIError(firstPage.error);
-        }
+        const firstData = unwrapEden(firstPage);
 
-        const items = [...firstPage.data.items];
-        let nextCursor = firstPage.data.nextCursor;
+        const items = [...firstData.items];
+        let nextCursor = firstData.nextCursor;
 
         while (nextCursor !== null && items.length < max) {
           // oxlint-disable-next-line no-await-in-loop -- sequential keyset pagination: each page's `nextCursor` is required to request the next
@@ -66,11 +64,9 @@ export const docxSuggestionsOptions = ({
             },
             fetch: { signal },
           });
-          if (page.error) {
-            throw toAPIError(page.error);
-          }
-          items.push(...page.data.items);
-          nextCursor = page.data.nextCursor;
+          const pageData = unwrapEden(page);
+          items.push(...pageData.items);
+          nextCursor = pageData.nextCursor;
         }
 
         return { items, nextCursor };

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/entities.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/entities.ts
@@ -8,7 +8,7 @@ import {
 
 import { api } from "@/lib/api";
 import { normalizeOptionalArray } from "@/lib/arrays";
-import { toAPIError } from "@/lib/errors/api";
+import { toAPIError, unwrapEden } from "@/lib/errors/api";
 import { stringCursorSeed } from "@/lib/infinite-query";
 import { ROUTE_QUERY_STALE_TIME_MS } from "@/lib/react-query";
 import type { QueryOptionsInput } from "@/lib/react-query";
@@ -342,11 +342,7 @@ export const entityOptions = (workspaceId: string, entityId: string) =>
         .entity({ entityId: toSafeId<"entity">(entityId) })
         .get({ fetch: { signal } });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      return response.data;
+      return unwrapEden(response);
     },
   });
 

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/entities.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/entities.ts
@@ -8,7 +8,7 @@ import {
 
 import { api } from "@/lib/api";
 import { normalizeOptionalArray } from "@/lib/arrays";
-import { toAPIError, unwrapEden } from "@/lib/errors/api";
+import { unwrapEden } from "@/lib/errors/api";
 import { stringCursorSeed } from "@/lib/infinite-query";
 import { ROUTE_QUERY_STALE_TIME_MS } from "@/lib/react-query";
 import type { QueryOptionsInput } from "@/lib/react-query";
@@ -143,11 +143,7 @@ export const entitiesOptions = (key: EntitiesOptionsInput) =>
           { fetch: { signal } },
         );
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      const { items: rawEntities, ...rest } = response.data;
+      const { items: rawEntities, ...rest } = unwrapEden(response);
       const entities: WorkspaceEntity[] = rawEntities.map(toWorkspaceEntity);
 
       return { ...rest, entities };
@@ -181,11 +177,7 @@ export const entitiesWindowOptions = (key: EntitiesWindowOptionsInput) =>
           { fetch: { signal } },
         );
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      const { items: rawEntities, ...rest } = response.data;
+      const { items: rawEntities, ...rest } = unwrapEden(response);
       const entities: WorkspaceEntity[] = rawEntities.map(toWorkspaceEntity);
 
       return { ...rest, entities };
@@ -220,17 +212,14 @@ export const filesystemEntitiesOptions = (
           { fetch: { signal } },
         );
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
+      const data = unwrapEden(response);
 
-      const entities: WorkspaceEntity[] =
-        response.data.entities.map(toWorkspaceEntity);
+      const entities: WorkspaceEntity[] = data.entities.map(toWorkspaceEntity);
 
       // Parent links of ancestor folders a filter/search hid. Used only to
       // complete the ancestor chain for cross-matter copy/move dedup; never
       // rendered, so they stay out of selection and bulk actions.
-      const ancestorLinks = response.data.ancestorLinks;
+      const ancestorLinks = data.ancestorLinks;
 
       return { entities, ancestorLinks };
     },
@@ -271,11 +260,7 @@ export const kanbanGroupOptions = (key: KanbanGroupOptionsInput) =>
           { fetch: { signal } },
         );
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      const { items: rawEntities, ...rest } = response.data;
+      const { items: rawEntities, ...rest } = unwrapEden(response);
       const entities: WorkspaceEntity[] = rawEntities.map(toWorkspaceEntity);
 
       return { ...rest, entities };
@@ -309,11 +294,7 @@ export const groupCountsOptions = (key: GroupCountsOptionsInput) =>
           { fetch: { signal } },
         );
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      return response.data.counts;
+      return unwrapEden(response).counts;
     },
   });
 
@@ -364,14 +345,10 @@ export const entitySummariesOptions = (workspaceId: string) =>
             },
           });
 
-        if (response.error) {
-          throw toAPIError(response.error);
-        }
+        const data = unwrapEden(response);
 
-        summaries.push(
-          ...response.data.items.map(({ id, name }) => ({ id, name })),
-        );
-        cursor = response.data.nextCursor ?? undefined;
+        summaries.push(...data.items.map(({ id, name }) => ({ id, name })));
+        cursor = data.nextCursor ?? undefined;
       } while (cursor !== undefined);
 
       return summaries;
@@ -386,11 +363,7 @@ export const entitySummariesCountOptions = (workspaceId: string) =>
         .entities({ workspaceId: toSafeId<"workspace">(workspaceId) })
         .summaries.count.get({ fetch: { signal }, query: {} });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      return response.data.totalCount;
+      return unwrapEden(response).totalCount;
     },
   });
 
@@ -421,18 +394,16 @@ const fetchAllWorkspaceFolders = async ({
         },
       });
 
-    if (response.error) {
-      throw toAPIError(response.error);
-    }
+    const data = unwrapEden(response);
 
     folders.push(
-      ...response.data.items.map((folder) => ({
+      ...data.items.map((folder) => ({
         entityId: folder.id,
         name: folder.name,
         parentId: folder.parentId,
       })),
     );
-    cursor = response.data.nextCursor ?? undefined;
+    cursor = data.nextCursor ?? undefined;
   } while (cursor !== undefined);
 
   return folders;
@@ -477,12 +448,10 @@ const fetchAllWorkspaceFiles = async ({
         },
       });
 
-    if (response.error) {
-      throw toAPIError(response.error);
-    }
+    const data = unwrapEden(response);
 
     files.push(
-      ...response.data.items.map((file) => ({
+      ...data.items.map((file) => ({
         entityId: file.entityId,
         name: file.name,
         parentId: file.parentId,
@@ -490,7 +459,7 @@ const fetchAllWorkspaceFiles = async ({
         mimeType: file.mimeType,
       })),
     );
-    cursor = response.data.nextCursor ?? undefined;
+    cursor = data.nextCursor ?? undefined;
   } while (cursor !== undefined);
 
   return files;

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/entity-versions.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/entity-versions.ts
@@ -1,7 +1,7 @@
 import { queryOptions } from "@tanstack/react-query";
 
 import { api } from "@/lib/api";
-import { toAPIError, unwrapEden } from "@/lib/errors/api";
+import { unwrapEden } from "@/lib/errors/api";
 
 import { entitiesKeys } from "./entities";
 
@@ -52,13 +52,11 @@ export const fetchOlderVersions = async ({
     .entity({ entityId })
     .versions.get({ query: { before } });
 
-  if (response.error) {
-    throw toAPIError(response.error);
-  }
+  const data = unwrapEden(response);
 
   return {
-    versions: response.data.versions,
-    olderCursor: response.data.olderCursor,
+    versions: data.versions,
+    olderCursor: data.olderCursor,
   };
 };
 

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/entity-versions.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/entity-versions.ts
@@ -1,7 +1,7 @@
 import { queryOptions } from "@tanstack/react-query";
 
 import { api } from "@/lib/api";
-import { toAPIError } from "@/lib/errors/api";
+import { toAPIError, unwrapEden } from "@/lib/errors/api";
 
 import { entitiesKeys } from "./entities";
 
@@ -38,11 +38,7 @@ export const entityVersionsOptions = ({
         .entity({ entityId })
         .versions.get({ fetch: { signal } });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      return response.data;
+      return unwrapEden(response);
     },
   });
 
@@ -88,11 +84,7 @@ export const fieldFileOptions = ({
         .field({ fieldId })
         .file.get({ fetch: { signal } });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      return response.data;
+      return unwrapEden(response);
     },
   });
 
@@ -110,10 +102,6 @@ export const entityVersionDetailOptions = ({
         .versions({ versionId })
         .get({ fetch: { signal } });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      return response.data;
+      return unwrapEden(response);
     },
   });

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/expenses.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/expenses.ts
@@ -2,7 +2,7 @@ import { queryOptions } from "@tanstack/react-query";
 
 import { startOfWeek } from "@/i18n/week";
 import { api } from "@/lib/api";
-import { toAPIError } from "@/lib/errors/api";
+import { unwrapEden } from "@/lib/errors/api";
 import { toSafeId } from "@/lib/safe-id";
 
 type ExpenseCategory =
@@ -74,11 +74,7 @@ export const expensesOptions = (
           fetch: { signal },
         });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      return response.data.items;
+      return unwrapEden(response).items;
     },
   });
 

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/flow-runs.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/flow-runs.ts
@@ -5,7 +5,7 @@ import {
   type FlowRunStatus,
 } from "@/components/flows/flow-meta";
 import { api } from "@/lib/api";
-import { toAPIError } from "@/lib/errors/api";
+import { unwrapEden } from "@/lib/errors/api";
 import { toSafeId } from "@/lib/safe-id";
 
 // ── Key type ────────────────────────────────────────
@@ -63,11 +63,7 @@ export const flowRunsOptions = ({
         .workspaces({ workspaceId: toSafeId<"workspace">(workspaceId) })
         .flows.runs.get({ query, fetch: { signal } });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      return response.data;
+      return unwrapEden(response);
     },
     // Poll while any listed run is still active; the function form returns
     // `false` once everything is terminal so the interval clears itself.
@@ -94,11 +90,7 @@ export const flowRunDetailOptions = (workspaceId: string, runId: string) =>
         .flows.runs({ runId: toSafeId<"flowRun">(runId) })
         .get({ fetch: { signal } });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      return response.data;
+      return unwrapEden(response);
     },
     refetchInterval: (query) => {
       const data = query.state.data;

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/invoices.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/invoices.ts
@@ -1,7 +1,7 @@
 import { infiniteQueryOptions, queryOptions } from "@tanstack/react-query";
 
 import { api } from "@/lib/api";
-import { toAPIError } from "@/lib/errors/api";
+import { unwrapEden } from "@/lib/errors/api";
 import { ROUTE_QUERY_STALE_TIME_MS } from "@/lib/react-query";
 
 /** Mirrors `INVOICE_STATUSES` in `apps/api/src/db/schema.ts`. */
@@ -51,11 +51,7 @@ export const invoicesOptions = (
         fetch: { signal },
       });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      return response.data;
+      return unwrapEden(response);
     },
   });
 
@@ -71,11 +67,7 @@ export const invoicesInfiniteOptions = (workspaceId: string, limit: number) =>
         fetch: { signal },
       });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      return response.data;
+      return unwrapEden(response);
     },
     initialPageParam: getInitialInvoicesPageParam(),
     getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
@@ -90,11 +82,7 @@ export const invoiceByIdOptions = (workspaceId: string, invoiceId: string) =>
         fetch: { signal },
       });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      return response.data;
+      return unwrapEden(response);
     },
   });
 

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/properties.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/properties.ts
@@ -1,7 +1,7 @@
 import { queryOptions } from "@tanstack/react-query";
 
 import { api } from "@/lib/api";
-import { toAPIError } from "@/lib/errors/api";
+import { unwrapEden } from "@/lib/errors/api";
 import { ROUTE_QUERY_STALE_TIME_MS } from "@/lib/react-query";
 import { toSafeId } from "@/lib/safe-id";
 import type { PropertyDependency, WorkspaceProperty } from "@/lib/types";
@@ -18,11 +18,7 @@ export const propertiesOptions = (workspaceId: string) =>
         .properties({ workspaceId })
         .get({ fetch: { signal } });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      return response.data.map(toWorkspaceProperty);
+      return unwrapEden(response).map(toWorkspaceProperty);
     },
     refetchOnMount: false,
     staleTime: ROUTE_QUERY_STALE_TIME_MS,

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/property-facets.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/property-facets.ts
@@ -1,7 +1,7 @@
 import { queryOptions } from "@tanstack/react-query";
 
 import { api } from "@/lib/api";
-import { toAPIError } from "@/lib/errors/api";
+import { unwrapEden } from "@/lib/errors/api";
 import type { QueryOptionsInput } from "@/lib/react-query";
 import { toSafeId } from "@/lib/safe-id";
 import type { ConditionNode } from "@/lib/types";
@@ -42,15 +42,13 @@ export const propertyFacetsOptions = (key: PropertyFacetsOptionsInput) =>
           { fetch: { signal } },
         );
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
+      const data = unwrapEden(response);
 
       const counts = new Map<string, number>();
-      for (const entry of response.data.values) {
+      for (const entry of data.values) {
         counts.set(entry.value, entry.count);
       }
 
-      return { counts, truncated: response.data.truncated };
+      return { counts, truncated: data.truncated };
     },
   });

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/rates.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/rates.ts
@@ -1,7 +1,7 @@
 import { queryOptions } from "@tanstack/react-query";
 
 import { api } from "@/lib/api";
-import { toAPIError } from "@/lib/errors/api";
+import { toAPIError, unwrapEden } from "@/lib/errors/api";
 import { toSafeId } from "@/lib/safe-id";
 
 export const ratesKeys = {
@@ -70,11 +70,7 @@ export const resolvedRateOptions = (
           fetch: { signal },
         });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      return response.data;
+      return unwrapEden(response);
     },
     enabled: userId.length > 0 && date.length > 0,
   });

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/rates.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/rates.ts
@@ -1,7 +1,7 @@
 import { queryOptions } from "@tanstack/react-query";
 
 import { api } from "@/lib/api";
-import { toAPIError, unwrapEden } from "@/lib/errors/api";
+import { unwrapEden } from "@/lib/errors/api";
 import { toSafeId } from "@/lib/safe-id";
 
 export const ratesKeys = {
@@ -28,11 +28,7 @@ export const rateTablesOptions = (workspaceId: string) =>
         .rates({ workspaceId: toSafeId<"workspace">(workspaceId) })
         .get({ fetch: { signal } });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      return response.data.items;
+      return unwrapEden(response).items;
     },
   });
 
@@ -46,11 +42,7 @@ export const rateEntriesOptions = (workspaceId: string, rateTableId: string) =>
         })
         .entries.get({ fetch: { signal } });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      return response.data.items;
+      return unwrapEden(response).items;
     },
     enabled: rateTableId.length > 0,
   });

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/report-exports.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/report-exports.ts
@@ -1,7 +1,7 @@
 import { infiniteQueryOptions, queryOptions } from "@tanstack/react-query";
 
 import { api } from "@/lib/api";
-import { toAPIError } from "@/lib/errors/api";
+import { unwrapEden } from "@/lib/errors/api";
 import { stringCursorSeed } from "@/lib/infinite-query";
 import type { QueryOptionsInput } from "@/lib/react-query";
 import { toSafeId } from "@/lib/safe-id";
@@ -55,11 +55,7 @@ export const reportExportsHistoryOptions = (
           fetch: { signal },
         });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      return response.data;
+      return unwrapEden(response);
     },
     initialPageParam: stringCursorSeed(),
     getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
@@ -94,11 +90,7 @@ export const reportExportDetailOptions = (
         })
         .get({ fetch: { signal } });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      return response.data;
+      return unwrapEden(response);
     },
     staleTime: 0,
   });

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/tasks.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/tasks.ts
@@ -1,7 +1,7 @@
 import { queryOptions } from "@tanstack/react-query";
 
 import { api } from "@/lib/api";
-import { toAPIError } from "@/lib/errors/api";
+import { unwrapEden } from "@/lib/errors/api";
 import { toSafeId } from "@/lib/safe-id";
 
 export const taskKeys = {
@@ -25,10 +25,7 @@ export const taskDetailOptions = (workspaceId: string, taskId: string) =>
       const response = await endpoint.get({
         fetch: { signal },
       });
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-      return response.data;
+      return unwrapEden(response);
     },
     enabled: !!taskId,
   });

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/time-entries.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/time-entries.ts
@@ -1,7 +1,7 @@
 import { queryOptions } from "@tanstack/react-query";
 
 import { api } from "@/lib/api";
-import { toAPIError } from "@/lib/errors/api";
+import { unwrapEden } from "@/lib/errors/api";
 import { toSafeId } from "@/lib/safe-id";
 
 type TimeEntryStatus = "draft" | "approved" | "billed" | "written_off";
@@ -76,11 +76,7 @@ export const timeEntriesOptions = (
         fetch: { signal },
       });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      return response.data.items;
+      return unwrapEden(response).items;
     },
   });
 
@@ -100,11 +96,7 @@ export const activeTimerOptions = (workspaceId: string) =>
         fetch: { signal },
       });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      return response.data.items.at(0) ?? null;
+      return unwrapEden(response).items.at(0) ?? null;
     },
     refetchInterval: 60_000,
   });

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/view-templates.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/view-templates.ts
@@ -1,7 +1,7 @@
 import { queryOptions } from "@tanstack/react-query";
 
 import { api } from "@/lib/api";
-import { toAPIError } from "@/lib/errors/api";
+import { unwrapEden } from "@/lib/errors/api";
 import type { QueryOptionsInput } from "@/lib/react-query";
 import { toSafeId } from "@/lib/safe-id";
 import type {
@@ -47,10 +47,6 @@ export const viewTemplatesOptions = ({
         workspaceId: toSafeId<"workspace">(context.workspaceId),
       }).get({ fetch: { signal } });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      return response.data;
+      return unwrapEden(response);
     },
   });

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/views.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/views.ts
@@ -2,7 +2,7 @@ import { queryOptions } from "@tanstack/react-query";
 
 import { useI18nStore } from "@/i18n/i18n-store";
 import { api } from "@/lib/api";
-import { toAPIError } from "@/lib/errors/api";
+import { unwrapEden } from "@/lib/errors/api";
 import { ROUTE_QUERY_STALE_TIME_MS } from "@/lib/react-query";
 import { toSafeId } from "@/lib/safe-id";
 import type { WorkspaceView } from "@/lib/types";
@@ -33,11 +33,7 @@ export const viewsOptions = (workspaceId: string) =>
         .views({ workspaceId: toSafeId<"workspace">(workspaceId) })
         .get({ fetch: { signal } });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      return response.data;
+      return unwrapEden(response);
     },
     staleTime: ROUTE_QUERY_STALE_TIME_MS,
   });

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/workspace-contacts.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/workspace-contacts.ts
@@ -1,7 +1,7 @@
 import { queryOptions } from "@tanstack/react-query";
 
 import { api } from "@/lib/api";
-import { toAPIError } from "@/lib/errors/api";
+import { unwrapEden } from "@/lib/errors/api";
 
 export const workspaceContactsKeys = {
   all: (workspaceId: string) => ["workspace-contacts", workspaceId],
@@ -15,10 +15,6 @@ export const workspaceContactsOptions = (workspaceId: string) =>
         .workspaces({ workspaceId })
         .contacts.get({ fetch: { signal } });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      return response.data;
+      return unwrapEden(response);
     },
   });

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/workspace-members.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/workspace-members.ts
@@ -1,7 +1,7 @@
 import { queryOptions } from "@tanstack/react-query";
 
 import { api } from "@/lib/api";
-import { toAPIError } from "@/lib/errors/api";
+import { unwrapEden } from "@/lib/errors/api";
 import { ROUTE_QUERY_STALE_TIME_MS } from "@/lib/react-query";
 
 export const workspaceMembersKeys = {
@@ -16,11 +16,7 @@ export const workspaceMembersOptions = (workspaceId: string) =>
         .workspaces({ workspaceId })
         .members.get({ fetch: { signal } });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      return response.data;
+      return unwrapEden(response);
     },
     staleTime: ROUTE_QUERY_STALE_TIME_MS,
   });

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/workspace.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/workspace.ts
@@ -2,7 +2,7 @@ import { queryOptions, useQuery } from "@tanstack/react-query";
 import { useMatch } from "@tanstack/react-router";
 
 import { api } from "@/lib/api";
-import { toAPIError } from "@/lib/errors/api";
+import { unwrapEden } from "@/lib/errors/api";
 import type { QueryOptionsInput } from "@/lib/react-query";
 import { toSafeId } from "@/lib/safe-id";
 import type { WorkspaceJustification } from "@/lib/types";
@@ -100,11 +100,7 @@ export const workflowTargetCountOptions = ({
           { fetch: { signal } },
         );
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      return response.data.count;
+      return unwrapEden(response).count;
     },
   });
 
@@ -143,10 +139,6 @@ export const justificationsOptions = ({
           { fetch: { signal } },
         );
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      return response.data.map(toWorkspaceJustification);
+      return unwrapEden(response).map(toWorkspaceJustification);
     },
   });

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/invoices/$invoiceId.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/invoices/$invoiceId.tsx
@@ -48,7 +48,7 @@ import { usePermissions } from "@/hooks/use-permissions";
 import { useFormatter } from "@/i18n/formatting-context";
 import { getFormattingLocale } from "@/i18n/i18n-store";
 import { api } from "@/lib/api";
-import { toAPIError } from "@/lib/errors/api";
+import { unwrapEden } from "@/lib/errors/api";
 import { ensureRouteQueryData } from "@/lib/react-query";
 import { toSafeId } from "@/lib/safe-id";
 import {
@@ -244,10 +244,7 @@ const InvoiceDetail = ({
           action,
           queryKey: invoicesKeys.all(workspaceId),
         });
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-      return response.data;
+      return unwrapEden(response);
     },
     onSuccess: () => {
       invalidateAll();
@@ -266,10 +263,7 @@ const InvoiceDetail = ({
         .delete({
           queryKey: invoicesKeys.all(workspaceId),
         });
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-      return response.data;
+      return unwrapEden(response);
     },
     onSuccess: async () => {
       invalidateAll();
@@ -293,10 +287,7 @@ const InvoiceDetail = ({
           timeEntryIds: [toSafeId<"timeEntry">(timeEntryId)],
           queryKey: invoicesKeys.all(workspaceId),
         });
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-      return response.data;
+      return unwrapEden(response);
     },
     onSuccess: () => {
       invalidateAll();
@@ -316,10 +307,7 @@ const InvoiceDetail = ({
           expenseIds: [toSafeId<"expense">(expenseId)],
           queryKey: invoicesKeys.all(workspaceId),
         });
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-      return response.data;
+      return unwrapEden(response);
     },
     onSuccess: () => {
       invalidateAll();

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/reports/$exportId.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/reports/$exportId.tsx
@@ -11,7 +11,7 @@ import { stellaToast } from "@stll/ui/components/toast";
 
 import { useAnalytics } from "@/lib/analytics/provider";
 import { api } from "@/lib/api";
-import { toAPIError } from "@/lib/errors/api";
+import { unwrapEden } from "@/lib/errors/api";
 import { ensureRouteQueryData } from "@/lib/react-query";
 import { toSafeId } from "@/lib/safe-id";
 
@@ -168,10 +168,7 @@ const reportExportRecoveryOptions = ({
         .workspaces({ workspaceId: toSafeId<"workspace">(workspaceId) })
         .reports({ exportId: toSafeId<"reportExport">(exportId) })
         .get({ fetch: { signal } });
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-      return response.data;
+      return unwrapEden(response);
     },
     refetchInterval: (query) => {
       const status = query.state.data?.status;

--- a/apps/web/src/routes/_protected.workspaces/-components/pdf-viewer-controls.tsx
+++ b/apps/web/src/routes/_protected.workspaces/-components/pdf-viewer-controls.tsx
@@ -21,7 +21,7 @@ import { useFormatter } from "@/i18n/formatting-context";
 import { useAnalytics } from "@/lib/analytics/provider";
 import { api } from "@/lib/api";
 import { DOCX_MIME } from "@/lib/consts";
-import { toAPIError } from "@/lib/errors/api";
+import { unwrapEden } from "@/lib/errors/api";
 import { ClientOperationError } from "@/lib/errors/client";
 import { fetchWithTimeout } from "@/lib/fetch";
 import { downloadFile } from "@/lib/utils";
@@ -104,11 +104,9 @@ export const PdfViewerControls = ({
         .url({ fieldId })
         .get({ query: { purpose: "download" } });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
+      const data = unwrapEden(response);
 
-      const fileResponse = await fetchWithTimeout(response.data.presignedUrl, {
+      const fileResponse = await fetchWithTimeout(data.presignedUrl, {
         timeoutMs: 60_000,
       });
       if (!fileResponse.ok) {

--- a/apps/web/src/routes/_protected.workspaces/-mutations.ts
+++ b/apps/web/src/routes/_protected.workspaces/-mutations.ts
@@ -7,7 +7,7 @@ import { useRouter } from "@tanstack/react-router";
 
 import { useAnalytics } from "@/lib/analytics/provider";
 import { api } from "@/lib/api";
-import { APIError, toAPIError } from "@/lib/errors/api";
+import { APIError, toAPIError, unwrapEden } from "@/lib/errors/api";
 import { toSafeId } from "@/lib/safe-id";
 import { workspacesKeys } from "@/routes/_protected.workspaces/-queries";
 
@@ -224,11 +224,7 @@ export const useDuplicateWorkspace = () => {
           queryKey: workspacesKeys.all,
         });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      return response.data;
+      return unwrapEden(response);
     },
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: workspacesKeys.all });

--- a/apps/web/src/routes/_protected.workspaces/-queries.ts
+++ b/apps/web/src/routes/_protected.workspaces/-queries.ts
@@ -2,7 +2,7 @@ import { infiniteQueryOptions, queryOptions } from "@tanstack/react-query";
 import type { QueryClient } from "@tanstack/react-query";
 
 import { api } from "@/lib/api";
-import { toAPIError } from "@/lib/errors/api";
+import { unwrapEden } from "@/lib/errors/api";
 import { ROUTE_QUERY_STALE_TIME_MS } from "@/lib/react-query";
 import { entitiesKeys } from "@/routes/_protected.workspaces/$workspaceId/-queries/entities.logic";
 
@@ -51,11 +51,7 @@ const readWorkspaces = async (signal?: AbortSignal) => {
     signal ? { fetch: { signal } } : {},
   );
 
-  if (response.error) {
-    throw toAPIError(response.error);
-  }
-
-  return response.data;
+  return unwrapEden(response);
 };
 
 export type WorkspacesData = Awaited<ReturnType<typeof readWorkspaces>>;
@@ -83,11 +79,7 @@ export const workspacesNavigationOptions = (activeOrganizationId: string) =>
         fetch: { signal },
       });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      return response.data;
+      return unwrapEden(response);
     },
     staleTime: ROUTE_QUERY_STALE_TIME_MS,
   });
@@ -100,11 +92,7 @@ export const workspaceOptions = (workspaceId: string) =>
         .workspaces({ workspaceId })
         .get({ fetch: { signal } });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      return response.data;
+      return unwrapEden(response);
     },
     staleTime: ROUTE_QUERY_STALE_TIME_MS,
   });
@@ -127,11 +115,7 @@ export const workspaceActivityOptions = ({
           query,
         });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      return response.data;
+      return unwrapEden(response);
     },
     initialPageParam: getInitialWorkspaceActivityCursor(),
     getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
@@ -154,11 +138,7 @@ export const overviewOptions = (workspaceId: string) =>
         .workspaces({ workspaceId })
         .overview.get({ fetch: { signal } });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-
-      return response.data;
+      return unwrapEden(response);
     },
     staleTime: ROUTE_QUERY_STALE_TIME_MS,
   });

--- a/apps/web/src/routes/consent.tsx
+++ b/apps/web/src/routes/consent.tsx
@@ -22,7 +22,7 @@ import { stellaToast } from "@stll/ui/components/toast";
 
 import { api } from "@/lib/api";
 import { authClient } from "@/lib/auth";
-import { toAPIError } from "@/lib/errors/api";
+import { unwrapEden } from "@/lib/errors/api";
 import { toAuthClientError } from "@/lib/errors/auth";
 import { userErrorFromThrown } from "@/lib/errors/user-safe";
 import {
@@ -132,10 +132,7 @@ function ConsentPage() {
       const response = await api["organization-settings"].get({
         fetch: { signal },
       });
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-      return response.data.practiceJurisdictions;
+      return unwrapEden(response).practiceJurisdictions;
     },
   });
   const showJurisdictionsNotice =

--- a/apps/web/src/routes/onboarding/-queries.ts
+++ b/apps/web/src/routes/onboarding/-queries.ts
@@ -1,7 +1,7 @@
 import { queryOptions } from "@tanstack/react-query";
 
 import { api } from "@/lib/api";
-import { toAPIError } from "@/lib/errors/api";
+import { unwrapEden } from "@/lib/errors/api";
 import { ROUTE_QUERY_STALE_TIME_MS } from "@/lib/react-query";
 
 type NativeToolDeployAvailabilityKey = readonly [
@@ -23,11 +23,7 @@ export const nativeToolDeployAvailabilityOptions = queryOptions({
       },
     );
 
-    if (response.error) {
-      throw toAPIError(response.error);
-    }
-
-    return response.data;
+    return unwrapEden(response);
   },
   staleTime: ROUTE_QUERY_STALE_TIME_MS,
 });


### PR DESCRIPTION
## Summary

- Adds a typed `unwrapEden()` helper to `lib/errors/api.ts` encoding the dominant Eden response contract (error → throw `toAPIError`, else return data) and migrates 232 call sites across the app to it; 42 sites keep custom handling for stated reasons (void error-checks, status/payload branching, side effects between check and use, richer error branches) — each was audited individually.
- Adds `useSettingsMutation` owning the captureError → invalidate → toast plumbing for the organization settings cards (12 mutations across 7 cards converted), making the missing-error-toast class structurally impossible there.
- Adds `useClauseFieldSave` for clause-detail's inline field editors (trim → skip-if-unchanged → persist → toast/revert → refresh).

Net −783 lines. Verified with the full web typecheck (clean), the web test suite (1009 pass), type-aware lint on all changed files, and the ratchet guard — which improves on two metrics as a side effect (lint-suppression-directives 619→605, detached-promise-review-sites 528→526; baselines left untouched).