### PR TITLE
feat(api): operator endpoint for recent account registrations

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -139,6 +139,14 @@ USE_MOCK_AI="true"
 # Generate with: openssl rand -base64 32
 # SELFHOST_BOOTSTRAP_TOKEN=""
 
+# --- Operator observability -------------------------------------------------
+# Optional. Bearer token for GET /operator/registrations, which lets an
+# instance operator list recent account registrations (id, email, name,
+# createdAt) without opening a database shell. Unset disables the endpoint;
+# requests then return 404. Use a long random value (32+ chars).
+# Generate with: openssl rand -hex 32
+# OPERATOR_METRICS_TOKEN=""
+
 # --- Launch feature flags (optional, default-off) ---------------------------
 # Each flag gates server-side routes for the corresponding feature. Pair with
 # the VITE_FEATURE_* twin on the web app to also hide UI when disabled.

--- a/apps/api/drizzle/20260719172000_user_created_at_index/migration.sql
+++ b/apps/api/drizzle/20260719172000_user_created_at_index/migration.sql
@@ -1,3 +1,5 @@
+SET lock_timeout = '2s';
+--> statement-breakpoint
 SET statement_timeout = '0';
 --> statement-breakpoint
 -- squawk-ignore transaction-nesting

--- a/apps/api/drizzle/20260719172000_user_created_at_index/migration.sql
+++ b/apps/api/drizzle/20260719172000_user_created_at_index/migration.sql
@@ -1,0 +1,13 @@
+SET statement_timeout = '0';
+--> statement-breakpoint
+-- squawk-ignore transaction-nesting
+COMMIT;
+--> statement-breakpoint
+-- stella-migration-safety: reviewed destructive-change - retry cleanup drops only this migration's index if a cancelled concurrent build left an invalid index behind; no table data is removed.
+DROP INDEX CONCURRENTLY IF EXISTS "user_createdAt_idx";
+--> statement-breakpoint
+-- squawk-ignore prefer-robust-stmts
+CREATE INDEX CONCURRENTLY "user_createdAt_idx" ON "user" USING btree ("created_at","id");
+--> statement-breakpoint
+-- squawk-ignore transaction-nesting, ban-uncommitted-transaction
+BEGIN;

--- a/apps/api/src/db/auth-schema.ts
+++ b/apps/api/src/db/auth-schema.ts
@@ -37,7 +37,12 @@ export const user = pgTable(
       .$onUpdate(() => /* @__PURE__ */ new Date())
       .notNull(),
   },
-  () => [...authUserPolicies()],
+  (table) => [
+    // Keyset pagination over registrations (operator observability)
+    // orders by (created_at, id); without this the read is a table scan.
+    index("user_createdAt_idx").on(table.createdAt, table.id),
+    ...authUserPolicies(),
+  ],
 );
 
 type AuthUserColumnNameByField = Record<

--- a/apps/api/src/env.ts
+++ b/apps/api/src/env.ts
@@ -126,6 +126,14 @@ const envApi = createEnv({
      * "production" regardless of this value.
      */
     SMOKE_SESSION_SECRET: v.optional(v.pipe(v.string(), v.minLength(32))),
+    /**
+     * Bearer token for the operator registrations endpoint
+     * (handlers/operator): lets an instance operator list recent
+     * account registrations over HTTP instead of opening a database
+     * shell. Unset disables the endpoint entirely (requests return
+     * 404), mirroring how other optional operational surfaces behave.
+     */
+    OPERATOR_METRICS_TOKEN: v.optional(v.pipe(v.string(), v.minLength(32))),
     EMAIL_PROVIDER: v.pipe(
       v.optional(v.picklist(["ses", "smtp"])),
       v.transform(inferEmailProvider),

--- a/apps/api/src/handlers/operator/query.test.ts
+++ b/apps/api/src/handlers/operator/query.test.ts
@@ -1,0 +1,226 @@
+import { Result } from "better-result";
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { TransactionRollbackError } from "drizzle-orm";
+
+import { user } from "@/api/db/auth-schema";
+import type { Transaction } from "@/api/db/root";
+import type { SafeDb } from "@/api/db/safe-db";
+import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
+import type { TestDatabase } from "@/api/tests/security/test-utils";
+import { getTestDb, releaseTestDb } from "@/api/tests/security/test-utils";
+
+import {
+  authorizeOperatorAccess,
+  OPERATOR_REGISTRATIONS_MAX_LOOKBACK_DAYS,
+  queryRegistrationsPage,
+  validateRegistrationsFilter,
+} from "./query";
+
+const TOKEN = "operator-test-token-0123456789abcdef";
+
+describe("authorizeOperatorAccess", () => {
+  test("disabled when no token is configured, regardless of header", () => {
+    expect(
+      authorizeOperatorAccess({
+        configuredToken: undefined,
+        authorizationHeader: `Bearer ${TOKEN}`,
+      }),
+    ).toEqual({ status: "disabled" });
+  });
+
+  test("unauthorized on missing header, non-bearer scheme, or mismatch", () => {
+    const cases = [
+      null,
+      TOKEN,
+      `Basic ${TOKEN}`,
+      `Bearer ${TOKEN}x`,
+      "Bearer ",
+    ];
+    for (const authorizationHeader of cases) {
+      expect(
+        authorizeOperatorAccess({
+          configuredToken: TOKEN,
+          authorizationHeader,
+        }),
+      ).toEqual({ status: "unauthorized" });
+    }
+  });
+
+  test("authorized on exact bearer match", () => {
+    expect(
+      authorizeOperatorAccess({
+        configuredToken: TOKEN,
+        authorizationHeader: `Bearer ${TOKEN}`,
+      }),
+    ).toEqual({ status: "authorized" });
+  });
+});
+
+const daysAgo = (days: number): Date =>
+  new Date(Date.now() - days * 24 * 60 * 60 * 1000);
+
+describe("validateRegistrationsFilter", () => {
+  test("rejects a since older than the lookback window", () => {
+    const reason = validateRegistrationsFilter(
+      {
+        since: daysAgo(
+          OPERATOR_REGISTRATIONS_MAX_LOOKBACK_DAYS + 1,
+        ).toISOString(),
+      },
+      new Date(),
+    );
+    expect(reason).toBe(
+      `since must be within the last ${OPERATOR_REGISTRATIONS_MAX_LOOKBACK_DAYS} days`,
+    );
+  });
+
+  test("accepts a since inside the lookback window", () => {
+    expect(
+      validateRegistrationsFilter(
+        {
+          since: daysAgo(
+            OPERATOR_REGISTRATIONS_MAX_LOOKBACK_DAYS - 1,
+          ).toISOString(),
+        },
+        new Date(),
+      ),
+    ).toBeNull();
+  });
+
+  test("rejects a malformed cursor", () => {
+    expect(
+      validateRegistrationsFilter(
+        { since: daysAgo(1).toISOString(), cursor: "not-a-cursor" },
+        new Date(),
+      ),
+    ).toBe("Invalid cursor");
+  });
+});
+
+describe("queryRegistrationsPage", () => {
+  let testDb: TestDatabase;
+
+  beforeAll(async () => {
+    testDb = await getTestDb();
+  });
+
+  afterAll(async () => {
+    await releaseTestDb();
+  });
+
+  /** Seed + query inside one rolled-back transaction so the shared test
+   *  database keeps no rows from this suite. */
+  const withSeededRegistrations = async (
+    run: (safeDb: SafeDb) => Promise<void>,
+  ): Promise<void> => {
+    try {
+      await testDb.transaction(async (tx) => {
+        await tx.insert(user).values([
+          {
+            id: "op-reg-outside",
+            name: "Outside Window",
+            email: "op-reg-outside@example.test",
+            createdAt: daysAgo(30),
+          },
+          {
+            id: "op-reg-a",
+            name: "Registration A",
+            email: "op-reg-a@example.test",
+            createdAt: daysAgo(9),
+          },
+          {
+            id: "op-reg-b",
+            name: "Registration B",
+            email: "op-reg-b@example.test",
+            createdAt: daysAgo(8),
+          },
+          {
+            id: "op-reg-c",
+            name: "Registration C",
+            email: "op-reg-c@example.test",
+            createdAt: daysAgo(7),
+          },
+        ]);
+
+        const safeDb: SafeDb = async (fn) =>
+          await Result.tryPromise(
+            async () => await fn(asTestRaw<Transaction>(tx)),
+          );
+        await run(safeDb);
+        tx.rollback();
+      });
+    } catch (error) {
+      if (!(error instanceof TransactionRollbackError)) {
+        throw error;
+      }
+    }
+  };
+
+  const runPage = async (
+    safeDb: SafeDb,
+    query: { since: string; limit?: number; cursor?: string },
+  ) => {
+    const result = await Result.gen(() =>
+      queryRegistrationsPage({ safeDb, query }),
+    );
+    expect(Result.isOk(result)).toBe(true);
+    if (Result.isError(result)) {
+      throw result.error;
+    }
+    return result.value;
+  };
+
+  test("returns only accounts after since, oldest first, exactly four fields, and pages by cursor", async () => {
+    await withSeededRegistrations(async (safeDb) => {
+      const since = daysAgo(10).toISOString();
+
+      const firstPage = await runPage(safeDb, { since, limit: 2 });
+      expect(firstPage.limit).toBe(2);
+      expect(firstPage.items.map((item) => item.id)).toEqual([
+        "op-reg-a",
+        "op-reg-b",
+      ]);
+      expect(firstPage.nextCursor).not.toBeNull();
+      for (const item of firstPage.items) {
+        expect(Object.keys(item).sort()).toEqual([
+          "createdAt",
+          "email",
+          "id",
+          "name",
+        ]);
+      }
+      expect(firstPage.items.at(0)).toEqual({
+        id: "op-reg-a",
+        name: "Registration A",
+        email: "op-reg-a@example.test",
+        createdAt: expect.any(Date),
+      });
+
+      // The issued cursor passes the same validation callers run up front.
+      const cursor = firstPage.nextCursor;
+      if (cursor === null) {
+        throw new Error("expected a next cursor");
+      }
+      expect(
+        validateRegistrationsFilter({ since, cursor }, new Date()),
+      ).toBeNull();
+
+      const secondPage = await runPage(safeDb, { since, limit: 2, cursor });
+      expect(secondPage.items.at(0)?.id).toBe("op-reg-c");
+    });
+  });
+
+  test("returns no cursor when the window fits one page and excludes pre-since accounts", async () => {
+    await withSeededRegistrations(async (safeDb) => {
+      // A wide limit that still cannot reach op-reg-outside (before since).
+      const page = await runPage(safeDb, {
+        since: daysAgo(10).toISOString(),
+        limit: 50,
+      });
+      const ids = page.items.map((item) => item.id);
+      expect(ids).not.toContain("op-reg-outside");
+      expect(ids.slice(0, 3)).toEqual(["op-reg-a", "op-reg-b", "op-reg-c"]);
+      expect(page.nextCursor).toBeNull();
+    });
+  });
+});

--- a/apps/api/src/handlers/operator/query.test.ts
+++ b/apps/api/src/handlers/operator/query.test.ts
@@ -69,9 +69,10 @@ describe("validateRegistrationsFilter", () => {
       },
       new Date(),
     );
-    expect(reason).toBe(
-      `since must be within the last ${OPERATOR_REGISTRATIONS_MAX_LOOKBACK_DAYS} days`,
-    );
+    expect(reason).toEqual({
+      ok: false,
+      message: `since must be within the last ${OPERATOR_REGISTRATIONS_MAX_LOOKBACK_DAYS} days`,
+    });
   });
 
   test("accepts a since inside the lookback window", () => {
@@ -83,8 +84,30 @@ describe("validateRegistrationsFilter", () => {
           ).toISOString(),
         },
         new Date(),
-      ),
-    ).toBeNull();
+      ).ok,
+    ).toBe(true);
+  });
+
+  test("rejects a missing since", () => {
+    expect(validateRegistrationsFilter({}, new Date())).toEqual({
+      ok: false,
+      message: "since is required",
+    });
+  });
+
+  test("rejects a malformed since instead of bypassing the lookback check", () => {
+    expect(
+      validateRegistrationsFilter({ since: "not-a-date" }, new Date()),
+    ).toEqual({ ok: false, message: "since must be an ISO date-time" });
+  });
+
+  test("rejects a non-integer limit", () => {
+    expect(
+      validateRegistrationsFilter(
+        { since: daysAgo(1).toISOString(), limit: "many" },
+        new Date(),
+      ).ok,
+    ).toBe(false);
   });
 
   test("rejects a malformed cursor", () => {
@@ -93,7 +116,7 @@ describe("validateRegistrationsFilter", () => {
         { since: daysAgo(1).toISOString(), cursor: "not-a-cursor" },
         new Date(),
       ),
-    ).toBe("Invalid cursor");
+    ).toEqual({ ok: false, message: "Invalid cursor" });
   });
 });
 
@@ -158,10 +181,14 @@ describe("queryRegistrationsPage", () => {
 
   const runPage = async (
     safeDb: SafeDb,
-    query: { since: string; limit?: number; cursor?: string },
+    query: { since: string; limit?: string; cursor?: string },
   ) => {
+    const validated = validateRegistrationsFilter(query, new Date());
+    if (!validated.ok) {
+      throw new Error(validated.message);
+    }
     const result = await Result.gen(() =>
-      queryRegistrationsPage({ safeDb, query }),
+      queryRegistrationsPage({ safeDb, filter: validated.filter }),
     );
     expect(Result.isOk(result)).toBe(true);
     if (Result.isError(result)) {
@@ -174,7 +201,7 @@ describe("queryRegistrationsPage", () => {
     await withSeededRegistrations(async (safeDb) => {
       const since = daysAgo(10).toISOString();
 
-      const firstPage = await runPage(safeDb, { since, limit: 2 });
+      const firstPage = await runPage(safeDb, { since, limit: "2" });
       expect(firstPage.limit).toBe(2);
       expect(firstPage.items.map((item) => item.id)).toEqual([
         "op-reg-a",
@@ -202,10 +229,10 @@ describe("queryRegistrationsPage", () => {
         throw new Error("expected a next cursor");
       }
       expect(
-        validateRegistrationsFilter({ since, cursor }, new Date()),
-      ).toBeNull();
+        validateRegistrationsFilter({ since, cursor }, new Date()).ok,
+      ).toBe(true);
 
-      const secondPage = await runPage(safeDb, { since, limit: 2, cursor });
+      const secondPage = await runPage(safeDb, { since, limit: "2", cursor });
       expect(secondPage.items.at(0)?.id).toBe("op-reg-c");
     });
   });
@@ -215,7 +242,7 @@ describe("queryRegistrationsPage", () => {
       // A wide limit that still cannot reach op-reg-outside (before since).
       const page = await runPage(safeDb, {
         since: daysAgo(10).toISOString(),
-        limit: 50,
+        limit: "50",
       });
       const ids = page.items.map((item) => item.id);
       expect(ids).not.toContain("op-reg-outside");

--- a/apps/api/src/handlers/operator/query.ts
+++ b/apps/api/src/handlers/operator/query.ts
@@ -5,6 +5,9 @@ import { t } from "elysia";
 import type { Static } from "elysia";
 import { timingSafeEqual } from "node:crypto";
 
+import { DAY_IN_MS } from "@stll/time";
+
+// eslint-disable-next-line security-guards/no-unscoped-user-query -- operator observability is deliberately instance-wide: the endpoint is token-gated at the deployment level and lists registrations across the whole instance, so there is no organization to scope by.
 import { user } from "@/api/db/auth-schema";
 import type { SafeDb } from "@/api/db/safe-db";
 import { createTimestampIdCursorCodec } from "@/api/lib/db-pagination";
@@ -19,8 +22,7 @@ import { brandPersistedUserId } from "@/api/lib/safe-id-boundaries";
  */
 export const OPERATOR_REGISTRATIONS_MAX_LOOKBACK_DAYS = 90;
 
-const MAX_LOOKBACK_MS =
-  OPERATOR_REGISTRATIONS_MAX_LOOKBACK_DAYS * 24 * 60 * 60 * 1000;
+const MAX_LOOKBACK_MS = OPERATOR_REGISTRATIONS_MAX_LOOKBACK_DAYS * DAY_IN_MS;
 
 /** Better Auth user ids are text (not UUIDs); mirror `tUserId`'s bounds. */
 const isUserIdCursorPart = (value: unknown): value is string =>
@@ -152,6 +154,8 @@ export const validateRegistrationsFilter = (
  * `since`, oldest first, keyset-paged on `(created_at, id)`. Callers must
  * invoke `validateRegistrationsFilter` first. Returns only the four
  * operator-visible fields (id, email, name, createdAt).
+ *
+ * @yields SafeDb errors out to the safe-handler runner.
  */
 export const queryRegistrationsPage = async function* ({
   safeDb,

--- a/apps/api/src/handlers/operator/query.ts
+++ b/apps/api/src/handlers/operator/query.ts
@@ -1,0 +1,172 @@
+import { Result } from "better-result";
+import type { SQL } from "drizzle-orm";
+import { and, asc, gte } from "drizzle-orm";
+import { t } from "elysia";
+import type { Static } from "elysia";
+import { timingSafeEqual } from "node:crypto";
+
+import { user } from "@/api/db/auth-schema";
+import type { SafeDb } from "@/api/db/safe-db";
+import { tPaginationLimit } from "@/api/lib/custom-schema";
+import { createTimestampIdCursorCodec } from "@/api/lib/db-pagination";
+import { LIMITS } from "@/api/lib/limits";
+import { createCursorPage } from "@/api/lib/pagination";
+import { brandPersistedUserId } from "@/api/lib/safe-id-boundaries";
+
+/**
+ * Registrations older than this cannot be listed. The endpoint exists for
+ * operational visibility into recent sign-ups, not as a bulk account-export
+ * surface, so the readable window stays deliberately short.
+ */
+export const OPERATOR_REGISTRATIONS_MAX_LOOKBACK_DAYS = 90;
+
+const MAX_LOOKBACK_MS =
+  OPERATOR_REGISTRATIONS_MAX_LOOKBACK_DAYS * 24 * 60 * 60 * 1000;
+
+/** Better Auth user ids are text (not UUIDs); mirror `tUserId`'s bounds. */
+const isUserIdCursorPart = (value: unknown): value is string =>
+  typeof value === "string" && value.length >= 1 && value.length <= 128;
+
+const registrationCursor = createTimestampIdCursorCodec({
+  column: user.createdAt,
+  brandId: brandPersistedUserId,
+  isIdPart: isUserIdCursorPart,
+});
+
+export const readRegistrationsQuerySchema = t.Object({
+  since: t.String({ format: "date-time" }),
+  limit: t.Optional(tPaginationLimit(LIMITS.operatorRegistrationsPageSizeMax)),
+  cursor: t.Optional(t.String()),
+});
+
+export type ReadRegistrationsQuery = Static<
+  typeof readRegistrationsQuerySchema
+>;
+
+const BEARER_PREFIX = "Bearer ";
+
+type AuthorizeOperatorAccessOptions = {
+  /** The deployment's configured token; undefined when the feature is off. */
+  configuredToken: string | undefined;
+  /** Raw `Authorization` request header, if any. */
+  authorizationHeader: string | null;
+};
+
+export type OperatorAccess =
+  | { status: "disabled" }
+  | { status: "unauthorized" }
+  | { status: "authorized" };
+
+/**
+ * Gate for the operator endpoints. No configured token means the feature is
+ * off (`disabled` → the route reports 404, like other unconfigured
+ * operational surfaces). Token comparison is constant-time over sha256
+ * digests so neither length nor prefix leaks.
+ */
+export const authorizeOperatorAccess = ({
+  configuredToken,
+  authorizationHeader,
+}: AuthorizeOperatorAccessOptions): OperatorAccess => {
+  if (!configuredToken) {
+    return { status: "disabled" };
+  }
+  if (
+    authorizationHeader === null ||
+    !authorizationHeader.startsWith(BEARER_PREFIX)
+  ) {
+    return { status: "unauthorized" };
+  }
+  const presented = authorizationHeader.slice(BEARER_PREFIX.length);
+  const configuredDigest = new Bun.CryptoHasher("sha256")
+    .update(configuredToken)
+    .digest();
+  const presentedDigest = new Bun.CryptoHasher("sha256")
+    .update(presented)
+    .digest();
+  return timingSafeEqual(configuredDigest, presentedDigest)
+    ? { status: "authorized" }
+    : { status: "unauthorized" };
+};
+
+/**
+ * Replicates every 400 the read path rejects on before any query runs
+ * (`since` outside the lookback window, malformed cursor). Returns the
+ * human-readable reason, or null when the filter is valid.
+ */
+export const validateRegistrationsFilter = (
+  query: ReadRegistrationsQuery,
+  now: Date,
+): string | null => {
+  const since = new Date(query.since);
+  if (now.getTime() - since.getTime() > MAX_LOOKBACK_MS) {
+    return `since must be within the last ${OPERATOR_REGISTRATIONS_MAX_LOOKBACK_DAYS} days`;
+  }
+  if (query.cursor && !registrationCursor.decode(query.cursor)) {
+    return "Invalid cursor";
+  }
+  return null;
+};
+
+/**
+ * Runs the validated registrations listing: accounts created at or after
+ * `since`, oldest first, keyset-paged on `(created_at, id)`. Callers must
+ * invoke `validateRegistrationsFilter` first. Returns only the four
+ * operator-visible fields (id, email, name, createdAt).
+ */
+export const queryRegistrationsPage = async function* ({
+  safeDb,
+  query,
+}: {
+  safeDb: SafeDb;
+  query: ReadRegistrationsQuery;
+}) {
+  const limit = query.limit ?? LIMITS.operatorRegistrationsPageSizeDefault;
+
+  const conditions: SQL[] = [gte(user.createdAt, new Date(query.since))];
+  if (query.cursor) {
+    const cursor = registrationCursor.decode(query.cursor);
+    if (cursor) {
+      const cursorCondition = registrationCursor.keysetAfter({
+        cursor,
+        idColumn: user.id,
+        direction: "ascending",
+      });
+      if (cursorCondition) {
+        conditions.push(cursorCondition);
+      }
+    }
+  }
+
+  const rows = yield* Result.await(
+    safeDb(
+      async (tx) =>
+        await tx
+          .select({
+            id: user.id,
+            email: user.email,
+            name: user.name,
+            createdAt: user.createdAt,
+            createdAtCursor:
+              registrationCursor.cursorValue.as("created_at_cursor"),
+          })
+          .from(user)
+          .where(and(...conditions))
+          .orderBy(asc(user.createdAt), asc(user.id))
+          .limit(limit + 1),
+    ),
+  );
+
+  const page = createCursorPage({
+    rows,
+    limit,
+    cursorForItem: (item) =>
+      registrationCursor.encode(item.createdAtCursor, item.id),
+  });
+
+  return Result.ok({
+    ...page,
+    items: page.items.map(
+      ({ createdAtCursor: _createdAtCursor, ...item }) => item,
+    ),
+  });
+};

--- a/apps/api/src/handlers/operator/query.ts
+++ b/apps/api/src/handlers/operator/query.ts
@@ -7,7 +7,6 @@ import { timingSafeEqual } from "node:crypto";
 
 import { user } from "@/api/db/auth-schema";
 import type { SafeDb } from "@/api/db/safe-db";
-import { tPaginationLimit } from "@/api/lib/custom-schema";
 import { createTimestampIdCursorCodec } from "@/api/lib/db-pagination";
 import { LIMITS } from "@/api/lib/limits";
 import { createCursorPage } from "@/api/lib/pagination";
@@ -33,9 +32,16 @@ const registrationCursor = createTimestampIdCursorCodec({
   isIdPart: isUserIdCursorPart,
 });
 
+/**
+ * Route-level schema is deliberately permissive: Elysia validates the query
+ * before the handler's token gate runs, so a strict schema would emit 422s
+ * to unauthenticated probes — leaking both the endpoint's existence (which
+ * must read as 404 while unconfigured) and its parameter shape. All real
+ * validation happens post-authorization in `validateRegistrationsFilter`.
+ */
 export const readRegistrationsQuerySchema = t.Object({
-  since: t.String({ format: "date-time" }),
-  limit: t.Optional(tPaginationLimit(LIMITS.operatorRegistrationsPageSizeMax)),
+  since: t.Optional(t.String()),
+  limit: t.Optional(t.String()),
   cursor: t.Optional(t.String()),
 });
 
@@ -93,18 +99,52 @@ export const authorizeOperatorAccess = ({
  * (`since` outside the lookback window, malformed cursor). Returns the
  * human-readable reason, or null when the filter is valid.
  */
+export type RegistrationsFilter = {
+  since: Date;
+  limit: number;
+  cursor: string | undefined;
+};
+
+export type RegistrationsFilterResult =
+  | { ok: true; filter: RegistrationsFilter }
+  | { ok: false; message: string };
+
 export const validateRegistrationsFilter = (
   query: ReadRegistrationsQuery,
   now: Date,
-): string | null => {
+): RegistrationsFilterResult => {
+  if (query.since === undefined) {
+    return { ok: false, message: "since is required" };
+  }
   const since = new Date(query.since);
+  if (Number.isNaN(since.getTime())) {
+    return { ok: false, message: "since must be an ISO date-time" };
+  }
   if (now.getTime() - since.getTime() > MAX_LOOKBACK_MS) {
-    return `since must be within the last ${OPERATOR_REGISTRATIONS_MAX_LOOKBACK_DAYS} days`;
+    return {
+      ok: false,
+      message: `since must be within the last ${OPERATOR_REGISTRATIONS_MAX_LOOKBACK_DAYS} days`,
+    };
   }
-  if (query.cursor && !registrationCursor.decode(query.cursor)) {
-    return "Invalid cursor";
+  let limit: number = LIMITS.operatorRegistrationsPageSizeDefault;
+  if (query.limit !== undefined) {
+    const parsed = Number(query.limit);
+    if (
+      !Number.isInteger(parsed) ||
+      parsed < 1 ||
+      parsed > LIMITS.operatorRegistrationsPageSizeMax
+    ) {
+      return {
+        ok: false,
+        message: `limit must be an integer between 1 and ${LIMITS.operatorRegistrationsPageSizeMax}`,
+      };
+    }
+    limit = parsed;
   }
-  return null;
+  if (query.cursor !== undefined && !registrationCursor.decode(query.cursor)) {
+    return { ok: false, message: "Invalid cursor" };
+  }
+  return { ok: true, filter: { since, limit, cursor: query.cursor } };
 };
 
 /**
@@ -115,16 +155,16 @@ export const validateRegistrationsFilter = (
  */
 export const queryRegistrationsPage = async function* ({
   safeDb,
-  query,
+  filter,
 }: {
   safeDb: SafeDb;
-  query: ReadRegistrationsQuery;
+  filter: RegistrationsFilter;
 }) {
-  const limit = query.limit ?? LIMITS.operatorRegistrationsPageSizeDefault;
+  const { limit } = filter;
 
-  const conditions: SQL[] = [gte(user.createdAt, new Date(query.since))];
-  if (query.cursor) {
-    const cursor = registrationCursor.decode(query.cursor);
+  const conditions: SQL[] = [gte(user.createdAt, filter.since)];
+  if (filter.cursor) {
+    const cursor = registrationCursor.decode(filter.cursor);
     if (cursor) {
       const cursorCondition = registrationCursor.keysetAfter({
         cursor,

--- a/apps/api/src/handlers/operator/read-registrations.test.ts
+++ b/apps/api/src/handlers/operator/read-registrations.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, test } from "bun:test";
+import Elysia from "elysia";
+
+import { createScopedDbMock } from "@/api/tests/scoped-db-mock";
+
+import { OPERATOR_REGISTRATIONS_MAX_LOOKBACK_DAYS } from "./query";
+import { createReadRegistrationsEndpoint } from "./read-registrations";
+
+const TOKEN = "operator-test-token-0123456789abcdef";
+
+const daysAgo = (days: number): Date =>
+  new Date(Date.now() - days * 24 * 60 * 60 * 1000);
+
+type MockRow = {
+  id: string;
+  email: string;
+  name: string;
+  createdAt: Date;
+  createdAtCursor: string;
+};
+
+const mockRow = (id: string): MockRow => ({
+  id,
+  email: `${id}@example.test`,
+  name: `User ${id}`,
+  createdAt: daysAgo(2),
+  createdAtCursor: "2026-07-10T12:00:00.000000",
+});
+
+const buildApp = ({
+  configuredToken,
+  rows = [],
+}: {
+  configuredToken: string | undefined;
+  rows?: MockRow[];
+}) => {
+  const { safeDb } = createScopedDbMock({
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          orderBy: () => ({
+            limit: async () => rows,
+          }),
+        }),
+      }),
+    }),
+  });
+  const endpoint = createReadRegistrationsEndpoint({
+    getConfiguredToken: () => configuredToken,
+    safeDb,
+  });
+  return new Elysia({ prefix: "/operator" }).get(
+    "/registrations",
+    endpoint.handler,
+    endpoint.config,
+  );
+};
+
+const registrationsRequest = (
+  params: Record<string, string>,
+  headers: Record<string, string> = {},
+): Request =>
+  new Request(
+    `http://localhost/operator/registrations?${new URLSearchParams(params)}`,
+    { headers },
+  );
+
+describe("GET /operator/registrations", () => {
+  test("404 when no token is configured, even with a credential presented", async () => {
+    const app = buildApp({ configuredToken: undefined });
+    const response = await app.handle(
+      registrationsRequest(
+        { since: daysAgo(1).toISOString() },
+        { authorization: `Bearer ${TOKEN}` },
+      ),
+    );
+    expect(response.status).toBe(404);
+  });
+
+  test("401 with the standard error envelope on a wrong token", async () => {
+    const app = buildApp({ configuredToken: TOKEN });
+    const response = await app.handle(
+      registrationsRequest(
+        { since: daysAgo(1).toISOString() },
+        { authorization: `Bearer ${TOKEN}-wrong` },
+      ),
+    );
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({
+      message: "Invalid operator token",
+    });
+  });
+
+  test("401 when the credential is missing entirely", async () => {
+    const app = buildApp({ configuredToken: TOKEN });
+    const response = await app.handle(
+      registrationsRequest({ since: daysAgo(1).toISOString() }),
+    );
+    expect(response.status).toBe(401);
+  });
+
+  test("400 when since is older than the lookback window", async () => {
+    const app = buildApp({ configuredToken: TOKEN });
+    const response = await app.handle(
+      registrationsRequest(
+        {
+          since: daysAgo(
+            OPERATOR_REGISTRATIONS_MAX_LOOKBACK_DAYS + 1,
+          ).toISOString(),
+        },
+        { authorization: `Bearer ${TOKEN}` },
+      ),
+    );
+    expect(response.status).toBe(400);
+  });
+
+  test("200 with the Page envelope and exactly four item fields on a correct token", async () => {
+    const app = buildApp({
+      configuredToken: TOKEN,
+      rows: [mockRow("op-route-a"), mockRow("op-route-b")],
+    });
+    const response = await app.handle(
+      registrationsRequest(
+        { since: daysAgo(1).toISOString(), limit: "2" },
+        { authorization: `Bearer ${TOKEN}` },
+      ),
+    );
+    expect(response.status).toBe(200);
+
+    const page = (await response.json()) as {
+      items: Record<string, unknown>[];
+      nextCursor: string | null;
+      limit: number;
+    };
+    expect(page.limit).toBe(2);
+    // Two rows for limit 2 means no third row was fetched: last page.
+    expect(page.nextCursor).toBeNull();
+    expect(page.items.map((item) => item["id"])).toEqual([
+      "op-route-a",
+      "op-route-b",
+    ]);
+    for (const item of page.items) {
+      expect(Object.keys(item).sort()).toEqual([
+        "createdAt",
+        "email",
+        "id",
+        "name",
+      ]);
+    }
+  });
+
+  test("emits a nextCursor when more rows exist than the requested limit", async () => {
+    const app = buildApp({
+      configuredToken: TOKEN,
+      rows: [
+        mockRow("op-route-a"),
+        mockRow("op-route-b"),
+        mockRow("op-route-c"),
+      ],
+    });
+    const response = await app.handle(
+      registrationsRequest(
+        { since: daysAgo(1).toISOString(), limit: "2" },
+        { authorization: `Bearer ${TOKEN}` },
+      ),
+    );
+    expect(response.status).toBe(200);
+
+    const page = (await response.json()) as {
+      items: unknown[];
+      nextCursor: string | null;
+    };
+    expect(page.items).toHaveLength(2);
+    expect(page.nextCursor).not.toBeNull();
+  });
+});

--- a/apps/api/src/handlers/operator/read-registrations.test.ts
+++ b/apps/api/src/handlers/operator/read-registrations.test.ts
@@ -77,6 +77,31 @@ describe("GET /operator/registrations", () => {
     expect(response.status).toBe(404);
   });
 
+  test("404 on an unconfigured deployment even when the query is malformed — schema validation must never run before the token gate", async () => {
+    const app = buildApp({ configuredToken: undefined });
+    const response = await app.handle(registrationsRequest({}, {}));
+    expect(response.status).toBe(404);
+  });
+
+  test("401 (not 422) on a wrong token with a malformed query — parameter shape must not leak to unauthenticated probes", async () => {
+    const app = buildApp({ configuredToken: TOKEN });
+    const response = await app.handle(
+      registrationsRequest(
+        { since: "not-a-date", limit: "many" },
+        { authorization: "Bearer wrong" },
+      ),
+    );
+    expect(response.status).toBe(401);
+  });
+
+  test("400 when since is missing on an authorized request", async () => {
+    const app = buildApp({ configuredToken: TOKEN });
+    const response = await app.handle(
+      registrationsRequest({}, { authorization: `Bearer ${TOKEN}` }),
+    );
+    expect(response.status).toBe(400);
+  });
+
   test("401 with the standard error envelope on a wrong token", async () => {
     const app = buildApp({ configuredToken: TOKEN });
     const response = await app.handle(

--- a/apps/api/src/handlers/operator/read-registrations.test.ts
+++ b/apps/api/src/handlers/operator/read-registrations.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import Elysia from "elysia";
+import * as v from "valibot";
 
 import { createScopedDbMock } from "@/api/tests/scoped-db-mock";
 
@@ -7,6 +8,12 @@ import { OPERATOR_REGISTRATIONS_MAX_LOOKBACK_DAYS } from "./query";
 import { createReadRegistrationsEndpoint } from "./read-registrations";
 
 const TOKEN = "operator-test-token-0123456789abcdef";
+
+const pageBodySchema = v.object({
+  items: v.array(v.record(v.string(), v.unknown())),
+  nextCursor: v.nullable(v.string()),
+  limit: v.number(),
+});
 
 const daysAgo = (days: number): Date =>
   new Date(Date.now() - days * 24 * 60 * 60 * 1000);
@@ -61,7 +68,7 @@ const registrationsRequest = (
   headers: Record<string, string> = {},
 ): Request =>
   new Request(
-    `http://localhost/operator/registrations?${new URLSearchParams(params)}`,
+    `http://localhost/operator/registrations?${new URLSearchParams(params).toString()}`,
     { headers },
   );
 
@@ -152,11 +159,7 @@ describe("GET /operator/registrations", () => {
     );
     expect(response.status).toBe(200);
 
-    const page = (await response.json()) as {
-      items: Record<string, unknown>[];
-      nextCursor: string | null;
-      limit: number;
-    };
+    const page = v.parse(pageBodySchema, await response.json());
     expect(page.limit).toBe(2);
     // Two rows for limit 2 means no third row was fetched: last page.
     expect(page.nextCursor).toBeNull();
@@ -191,10 +194,7 @@ describe("GET /operator/registrations", () => {
     );
     expect(response.status).toBe(200);
 
-    const page = (await response.json()) as {
-      items: unknown[];
-      nextCursor: string | null;
-    };
+    const page = v.parse(pageBodySchema, await response.json());
     expect(page.items).toHaveLength(2);
     expect(page.nextCursor).not.toBeNull();
   });

--- a/apps/api/src/handlers/operator/read-registrations.ts
+++ b/apps/api/src/handlers/operator/read-registrations.ts
@@ -1,0 +1,89 @@
+import { Result } from "better-result";
+
+import { rootDb } from "@/api/db/root";
+import type { SafeDb } from "@/api/db/safe-db";
+import { env } from "@/api/env";
+import { createSafeTokenHandler } from "@/api/lib/api-handlers";
+import type { TokenHandlerConfig } from "@/api/lib/api-handlers";
+import { HandlerError } from "@/api/lib/errors/tagged-errors";
+import { logger } from "@/api/lib/observability/logger";
+
+import {
+  authorizeOperatorAccess,
+  queryRegistrationsPage,
+  readRegistrationsQuerySchema,
+  validateRegistrationsFilter,
+} from "./query";
+
+const config = {
+  mcp: { type: "internal", reason: "health_infra" },
+  query: readRegistrationsQuerySchema,
+} satisfies TokenHandlerConfig;
+
+/**
+ * The Better Auth `user` table is instance-wide infrastructure with no
+ * workspace/organization scoping, so the read goes through the owner-level
+ * handle (the same handle Better Auth itself uses), wrapped in the SafeDb
+ * contract for structured error capture.
+ */
+const rootSafeDb: SafeDb = async (fn) =>
+  await Result.tryPromise(async () => await rootDb.transaction(fn));
+
+export type ReadRegistrationsDeps = {
+  getConfiguredToken: () => string | undefined;
+  safeDb: SafeDb;
+};
+
+/**
+ * Operator observability: recent account registrations on this instance.
+ * Self-hosting is first-class, and operators need to see who signed up
+ * recently (e.g. to confirm invited colleagues completed registration)
+ * without opening a database shell.
+ *
+ * Access model mirrors the smoke endpoint: the route only functions when
+ * `OPERATOR_METRICS_TOKEN` is configured (unset → 404, indistinguishable
+ * from a missing feature), and the caller must present the token as a
+ * bearer credential (mismatch → 401). The dependency seam exists so tests
+ * can exercise the full route without a live database or env mutation.
+ */
+export const createReadRegistrationsEndpoint = ({
+  getConfiguredToken,
+  safeDb,
+}: ReadRegistrationsDeps) =>
+  createSafeTokenHandler(config, async function* ({ query, request }) {
+    const access = authorizeOperatorAccess({
+      configuredToken: getConfiguredToken(),
+      authorizationHeader: request.headers.get("authorization"),
+    });
+    if (access.status === "disabled") {
+      return Result.err(
+        new HandlerError({ status: 404, message: "Not available" }),
+      );
+    }
+    if (access.status === "unauthorized") {
+      return Result.err(
+        new HandlerError({ status: 401, message: "Invalid operator token" }),
+      );
+    }
+
+    const invalid = validateRegistrationsFilter(query, new Date());
+    if (invalid !== null) {
+      return Result.err(new HandlerError({ status: 400, message: invalid }));
+    }
+
+    const page = yield* queryRegistrationsPage({ safeDb, query });
+    if (Result.isOk(page)) {
+      // Counts only: registration emails/names must never reach logs.
+      logger.info("operator.registrations_read", {
+        "operator.item_count": page.value.items.length,
+      });
+    }
+    return page;
+  });
+
+const readRegistrations = createReadRegistrationsEndpoint({
+  getConfiguredToken: () => env.OPERATOR_METRICS_TOKEN,
+  safeDb: rootSafeDb,
+});
+
+export default readRegistrations;

--- a/apps/api/src/handlers/operator/read-registrations.ts
+++ b/apps/api/src/handlers/operator/read-registrations.ts
@@ -3,10 +3,10 @@ import { Result } from "better-result";
 import type { SafeDb } from "@/api/db/safe-db";
 import { env } from "@/api/env";
 import { createSafeTokenHandler } from "@/api/lib/api-handlers";
-import { operatorReadDb } from "@/api/lib/operator-read-db";
 import type { TokenHandlerConfig } from "@/api/lib/api-handlers";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import { logger } from "@/api/lib/observability/logger";
+import { operatorReadDb } from "@/api/lib/operator-read-db";
 
 import {
   authorizeOperatorAccess,

--- a/apps/api/src/handlers/operator/read-registrations.ts
+++ b/apps/api/src/handlers/operator/read-registrations.ts
@@ -66,12 +66,17 @@ export const createReadRegistrationsEndpoint = ({
       );
     }
 
-    const invalid = validateRegistrationsFilter(query, new Date());
-    if (invalid !== null) {
-      return Result.err(new HandlerError({ status: 400, message: invalid }));
+    const validated = validateRegistrationsFilter(query, new Date());
+    if (!validated.ok) {
+      return Result.err(
+        new HandlerError({ status: 400, message: validated.message }),
+      );
     }
 
-    const page = yield* queryRegistrationsPage({ safeDb, query });
+    const page = yield* queryRegistrationsPage({
+      safeDb,
+      filter: validated.filter,
+    });
     if (Result.isOk(page)) {
       // Counts only: registration emails/names must never reach logs.
       logger.info("operator.registrations_read", {

--- a/apps/api/src/handlers/operator/read-registrations.ts
+++ b/apps/api/src/handlers/operator/read-registrations.ts
@@ -1,9 +1,9 @@
 import { Result } from "better-result";
 
-import { rootDb } from "@/api/db/root";
 import type { SafeDb } from "@/api/db/safe-db";
 import { env } from "@/api/env";
 import { createSafeTokenHandler } from "@/api/lib/api-handlers";
+import { operatorReadDb } from "@/api/lib/operator-read-db";
 import type { TokenHandlerConfig } from "@/api/lib/api-handlers";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import { logger } from "@/api/lib/observability/logger";
@@ -19,15 +19,6 @@ const config = {
   mcp: { type: "internal", reason: "health_infra" },
   query: readRegistrationsQuerySchema,
 } satisfies TokenHandlerConfig;
-
-/**
- * The Better Auth `user` table is instance-wide infrastructure with no
- * workspace/organization scoping, so the read goes through the owner-level
- * handle (the same handle Better Auth itself uses), wrapped in the SafeDb
- * contract for structured error capture.
- */
-const rootSafeDb: SafeDb = async (fn) =>
-  await Result.tryPromise(async () => await rootDb.transaction(fn));
 
 export type ReadRegistrationsDeps = {
   getConfiguredToken: () => string | undefined;
@@ -88,7 +79,7 @@ export const createReadRegistrationsEndpoint = ({
 
 const readRegistrations = createReadRegistrationsEndpoint({
   getConfiguredToken: () => env.OPERATOR_METRICS_TOKEN,
-  safeDb: rootSafeDb,
+  safeDb: operatorReadDb,
 });
 
 export default readRegistrations;

--- a/apps/api/src/handlers/operator/routes.ts
+++ b/apps/api/src/handlers/operator/routes.ts
@@ -1,0 +1,15 @@
+import Elysia from "elysia";
+
+import readRegistrations from "@/api/handlers/operator/read-registrations";
+
+/**
+ * Operator observability routes. Not session-authed: the handler authorizes
+ * itself from the `OPERATOR_METRICS_TOKEN` bearer credential and reports 404
+ * whenever that token is not configured, so the surface does not exist on
+ * deployments that have not opted in.
+ */
+export const operatorRoute = new Elysia({ prefix: "/operator" }).get(
+  "/registrations",
+  readRegistrations.handler,
+  readRegistrations.config,
+);

--- a/apps/api/src/lib/api-handlers.ts
+++ b/apps/api/src/lib/api-handlers.ts
@@ -126,7 +126,7 @@ export type McpCapabilityReason =
  * - `account_lifecycle`: account deletion / lifecycle flows.
  * - `hosted_billing`: hosted-billing checkout / setup / management plumbing.
  * - `mcp_transport`: the MCP transport / connector routes themselves.
- * - `health_infra`: health and smoke endpoints.
+ * - `health_infra`: health, smoke, and operator observability endpoints.
  * - `chat_thread_ui`: chat-thread UI chrome reads (breadcrumb title lookup);
  *   the rename operation is a `capability` under the same reason.
  * - `provider_secret`: writes/probes of provider API keys and secrets (AI

--- a/apps/api/src/lib/db-pagination.ts
+++ b/apps/api/src/lib/db-pagination.ts
@@ -154,6 +154,12 @@ export type TimestampIdCursorCodec<Id> = {
 type TimestampIdCursorCodecOptions<Id> = {
   column: SQLWrapper;
   brandId: (id: string) => Id;
+  /**
+   * Validates the raw decoded id part before branding. Defaults to the UUID
+   * guard; tables with non-UUID primary keys (e.g. Better Auth text ids)
+   * supply their own guard so their cursors round-trip.
+   */
+  isIdPart?: (value: unknown) => value is string;
 };
 
 // Accepts the canonical base64url JSON tuple and, as a fallback, the legacy
@@ -177,6 +183,7 @@ const timestampIdCursorTuple = (cursor: string): [unknown, unknown] | null => {
 export const createTimestampIdCursorCodec = <Id>({
   column,
   brandId,
+  isIdPart = isUuidPaginationCursorPart,
 }: TimestampIdCursorCodecOptions<Id>): TimestampIdCursorCodec<Id> => ({
   cursorValue: pgTimestampCursorValue(column),
   keysetAfter: ({ cursor, idColumn, direction }) => {
@@ -202,7 +209,7 @@ export const createTimestampIdCursorCodec = <Id>({
     }
     const [rawTimestamp, rawId] = tuple;
     const timestamp = parsePgTimestampCursorValue(rawTimestamp);
-    if (timestamp === null || !isUuidPaginationCursorPart(rawId)) {
+    if (timestamp === null || !isIdPart(rawId)) {
       return null;
     }
     return { timestamp, id: brandId(rawId) };

--- a/apps/api/src/lib/limits.ts
+++ b/apps/api/src/lib/limits.ts
@@ -186,6 +186,9 @@ export const LIMITS = {
   reportExportsPageSizeMax: 100,
   auditLogPageSizeDefault: 50,
   auditLogPageSizeMax: 200,
+  /** Page sizes for the operator recent-registrations listing. */
+  operatorRegistrationsPageSizeDefault: 50,
+  operatorRegistrationsPageSizeMax: 200,
   contactsCount: 10_000,
   contactsPageSizeDefault: 50,
   contactsPageSizeMax: 100,

--- a/apps/api/src/lib/operator-read-db.ts
+++ b/apps/api/src/lib/operator-read-db.ts
@@ -1,0 +1,23 @@
+import { Result } from "better-result";
+import { sql } from "drizzle-orm";
+
+import { rootDb } from "@/api/db/root";
+import type { SafeDb } from "@/api/db/safe-db";
+
+/**
+ * Read-only, instance-wide access boundary for operator observability
+ * reads. The Better Auth `user` table is instance infrastructure with no
+ * workspace/organization scoping, so these reads go through the
+ * owner-level handle; the wrapper pins the transaction read-only so this
+ * surface structurally cannot write, and handlers never touch `rootDb`
+ * directly.
+ */
+export const operatorReadDb: SafeDb = async (fn) =>
+  await Result.tryPromise(
+    async () =>
+      await rootDb.transaction(async (tx) => {
+        await tx.execute(sql`SET TRANSACTION READ ONLY`);
+
+        return await fn(tx);
+      }),
+  );

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -48,6 +48,7 @@ import { legislationRoute } from "@/api/handlers/legislation/routes";
 import { mcpConnectorsRoute } from "@/api/handlers/mcp-connectors/routes";
 import { mcpRoute } from "@/api/handlers/mcp/routes";
 import { meRoute } from "@/api/handlers/me/routes";
+import { operatorRoute } from "@/api/handlers/operator/routes";
 import { organizationSettingsRoute } from "@/api/handlers/organization-settings/routes";
 import { playbooksRoute } from "@/api/handlers/playbooks/routes";
 import { playbookRunsRoute } from "@/api/handlers/playbooks/run-route";
@@ -428,6 +429,7 @@ const api = new Elysia()
   .use(feedbackPublicRoute)
   .use(devPublicRoute)
   .use(smokeRoute)
+  .use(operatorRoute)
   .mount(getAuth().handler)
   .group("/v1", (app) =>
     app

--- a/apps/api/src/tests/security/cross-tenant-coverage.test.ts
+++ b/apps/api/src/tests/security/cross-tenant-coverage.test.ts
@@ -78,6 +78,9 @@ const CROSS_TENANT_WAIVERS: Record<string, WaiverReason> = {
   auth: WAIVER_REASON.noTenantReadSurface,
   dev: WAIVER_REASON.noTenantReadSurface,
   "external-preview": WAIVER_REASON.noTenantReadSurface,
+  // Deployment-token-gated instance observability; reads the instance-wide
+  // registration list, so there is no per-tenant boundary to isolate.
+  operator: WAIVER_REASON.noTenantReadSurface,
   feedback: WAIVER_REASON.noTenantReadSurface,
   "folio-collab": WAIVER_REASON.noTenantReadSurface,
   health: WAIVER_REASON.noTenantReadSurface,

--- a/docs/capability-coverage.md
+++ b/docs/capability-coverage.md
@@ -449,6 +449,7 @@ mechanics, and similar), not gaps in coverage.
 | compound_consent | 1 |
 | deploy_mechanics | 1 |
 | document_processing | 9 |
+| health_infra | 1 |
 | hosted_billing | 2 |
 | mcp_transport | 11 |
 | native_tool_ui | 3 |
@@ -459,4 +460,4 @@ mechanics, and similar), not gaps in coverage.
 | upload_mechanics | 7 |
 | url_preview | 2 |
 
-Total: 85
+Total: 86

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -235,6 +235,50 @@ STELLA_API_HOST_PORT=8080 docker compose --env-file apps/api/.env -f docker-comp
 - S3-compatible object storage (AWS S3, MinIO, Cloudflare R2)
 - 2 GB RAM minimum
 
+## Operator observability
+
+Instance operators sometimes need to confirm that recent account
+registrations went through — for example after inviting colleagues — without
+opening a database shell. The API exposes a token-gated, read-only endpoint
+for exactly that:
+
+```
+GET /operator/registrations?since=<ISO 8601 date-time>&limit=<n>
+Authorization: Bearer <OPERATOR_METRICS_TOKEN>
+```
+
+- `since` (required): return accounts created at or after this instant. Must
+  be within the last 90 days.
+- `limit` (optional): page size, default 50, maximum 200.
+- `cursor` (optional): opaque pagination cursor from a previous response.
+
+The response is the standard page envelope with only four fields per account:
+
+```json
+{
+  "items": [
+    {
+      "id": "…",
+      "email": "…",
+      "name": "…",
+      "createdAt": "2026-07-18T09:30:00.000Z"
+    }
+  ],
+  "nextCursor": null,
+  "limit": 50
+}
+```
+
+Enable it by setting `OPERATOR_METRICS_TOKEN` in `apps/api/.env` to a long
+random value (32+ characters, e.g. `openssl rand -hex 32`). When the variable
+is unset the endpoint is disabled and returns 404; a wrong token returns 401.
+Example:
+
+```bash
+curl -H "Authorization: Bearer $OPERATOR_METRICS_TOKEN" \
+  "https://api.stella.example.com/operator/registrations?since=2026-07-01T00:00:00Z"
+```
+
 ## Stay informed about updates
 
 stella publishes a [GitHub Release](https://github.com/stella/stella/releases)


### PR DESCRIPTION
Self-hosting is first-class, and instance operators currently have no way to see recent account registrations (e.g., confirming invited colleagues completed sign-up) without opening a database shell. Adds `GET /operator/registrations?since=<ISO>&limit=<n>`: token-gated via a new optional `OPERATOR_METRICS_TOKEN` (unset → 404, feature disabled; bearer mismatch → 401 with constant-time comparison over sha256 digests, mirroring the smoke endpoint), returning only `{id, email, name, createdAt}` in the standard `Page<T>` cursor envelope (default 50, max 200, ascending keyset on `(created_at, id)`).

Guardrails: `since` is required and bounded to a 90-day lookback so the surface cannot act as a bulk account export; access is logged with an item count only (no PII, no token); the endpoint declares `mcp: {type: "internal"}`. `createTimestampIdCursorCodec` gained an optional id-part guard since Better Auth ids are text, not UUIDs.

Note: `user.created_at` is unindexed; the bounded window keeps the scan cheap at current sizes, and an index is the scaling fix if this surface grows. Docs: new operator-observability section in `docs/self-hosting.md` + `.env.example` entry. 14 new tests (route statuses, field shape, since-filter, cursor round-trip via PGlite).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a token-protected, read-only endpoint for operators to view recent account registrations.
  * Supports `since` filtering (max lookback), configurable `limit`, and cursor-based pagination.
  * Returns `id`, `email`, `name`, and `createdAt`; returns **404** when the metrics token is not configured, **401** for invalid credentials.
* **Documentation**
  * Documented the operator observability endpoint in self-hosting guidance, including query/response shape and examples.
* **Performance**
  * Added a database index to improve registration listing and pagination.
* **Tests**
  * Added coverage for endpoint authorization, validation, and paging behaviour.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->