### PR TITLE
fix(api): validate token-route input after authorization, structurally

### DIFF
--- a/apps/api/src/handlers/folio-collab/authorize.ts
+++ b/apps/api/src/handlers/folio-collab/authorize.ts
@@ -1,33 +1,41 @@
 import { Result } from "better-result";
-import { t } from "elysia";
 
 import type { TokenHandlerConfig } from "@/api/lib/api-handlers";
 import { createSafeTokenHandler } from "@/api/lib/api-handlers";
-import { tSafeId } from "@/api/lib/custom-schema";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import { authorizeFolioCollabSession } from "@/api/lib/folio-collab-sessions";
+import {
+  permissiveBodySchema,
+  validatePostAuth,
+} from "@/api/lib/permissive-route-schema";
+
+import {
+  folioCollabSessionCredentialsSchema,
+  folioCollabSessionNotFoundError,
+} from "./session-credentials";
 
 const config = {
   mcp: { type: "internal", reason: "session_token_exchange" },
-  body: t.Object({
-    sessionId: tSafeId("folioCollabSession"),
-    token: t.String({ minLength: 64, maxLength: 64 }),
-  }),
+  body: permissiveBodySchema({ keys: ["sessionId", "token"] }),
 } satisfies TokenHandlerConfig;
 
 const authorizeFolioCollabSessionHandler = createSafeTokenHandler(
   config,
   // eslint-disable-next-line require-yield -- token auth returns a plain Promise; nothing to Result.await
-  async function* ({ body: { sessionId, token } }) {
+  async function* ({ body }) {
+    const credentials = validatePostAuth(
+      folioCollabSessionCredentialsSchema,
+      body,
+    );
+    if (!credentials.ok) {
+      return Result.err(folioCollabSessionNotFoundError());
+    }
+    const { sessionId, token } = credentials.value;
+
     const authorized = await authorizeFolioCollabSession({ sessionId, token });
 
     if (authorized.status === "missing") {
-      return Result.err(
-        new HandlerError({
-          status: 404,
-          message: "Collaborative edit session not found.",
-        }),
-      );
+      return Result.err(folioCollabSessionNotFoundError());
     }
     if (authorized.status === "token-expired") {
       return Result.err(

--- a/apps/api/src/handlers/folio-collab/authorize.ts
+++ b/apps/api/src/handlers/folio-collab/authorize.ts
@@ -2,17 +2,9 @@ import { Result } from "better-result";
 
 import type { TokenHandlerConfig } from "@/api/lib/api-handlers";
 import { createSafeTokenHandler } from "@/api/lib/api-handlers";
-import { HandlerError } from "@/api/lib/errors/tagged-errors";
-import { authorizeFolioCollabSession } from "@/api/lib/folio-collab-sessions";
-import {
-  permissiveBodySchema,
-  validatePostAuth,
-} from "@/api/lib/permissive-route-schema";
+import { permissiveBodySchema } from "@/api/lib/permissive-route-schema";
 
-import {
-  folioCollabSessionCredentialsSchema,
-  folioCollabSessionNotFoundError,
-} from "./session-credentials";
+import { authorizeFolioCollabCredentials } from "./session-credentials";
 
 const config = {
   mcp: { type: "internal", reason: "session_token_exchange" },
@@ -21,40 +13,10 @@ const config = {
 
 const authorizeFolioCollabSessionHandler = createSafeTokenHandler(
   config,
-  // eslint-disable-next-line require-yield -- token auth returns a plain Promise; nothing to Result.await
   async function* ({ body }) {
-    const credentials = validatePostAuth(
-      folioCollabSessionCredentialsSchema,
-      body,
+    const { session: value } = yield* Result.await(
+      authorizeFolioCollabCredentials(body),
     );
-    if (!credentials.ok) {
-      return Result.err(folioCollabSessionNotFoundError());
-    }
-    const { sessionId, token } = credentials.value;
-
-    const authorized = await authorizeFolioCollabSession({ sessionId, token });
-
-    if (authorized.status === "missing") {
-      return Result.err(folioCollabSessionNotFoundError());
-    }
-    if (authorized.status === "token-expired") {
-      return Result.err(
-        new HandlerError({
-          status: 401,
-          message: "Collaborative edit token expired.",
-        }),
-      );
-    }
-    if (authorized.status === "permission-revoked") {
-      return Result.err(
-        new HandlerError({
-          status: 403,
-          message: "Collaborative edit permission revoked.",
-        }),
-      );
-    }
-
-    const { value } = authorized;
     return Result.ok({
       canEdit: value.canEdit,
       roomName: value.sessionId,

--- a/apps/api/src/handlers/folio-collab/cancel.ts
+++ b/apps/api/src/handlers/folio-collab/cancel.ts
@@ -1,6 +1,5 @@
 import { Result } from "better-result";
 import { and, eq } from "drizzle-orm";
-import { t } from "elysia";
 
 import { folioCollabSessions } from "@/api/db/schema";
 import type { TokenHandlerConfig } from "@/api/lib/api-handlers";
@@ -10,7 +9,6 @@ import {
   AUDIT_RESOURCE_TYPE,
   createAuditRecorder,
 } from "@/api/lib/audit-log";
-import { tSafeId } from "@/api/lib/custom-schema";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import {
   authorizeFolioCollabSession,
@@ -18,39 +16,44 @@ import {
   deleteFolioCollabStoredSessionFiles,
 } from "@/api/lib/folio-collab-sessions";
 import type { FolioCollabStoredSessionFile } from "@/api/lib/folio-collab-sessions";
+import {
+  permissiveBodySchema,
+  permissiveRouteSchema,
+  validatePostAuth,
+} from "@/api/lib/permissive-route-schema";
 import { broadcast } from "@/api/lib/sse";
+
+import {
+  folioCollabSessionCredentialsSchema,
+  folioCollabSessionNotFoundError,
+} from "./session-credentials";
 
 const config = {
   mcp: { type: "internal", reason: "session_token_exchange" },
-  params: t.Object({
-    sessionId: tSafeId("folioCollabSession"),
-  }),
-  body: t.Object({
-    token: t.String({ minLength: 64, maxLength: 64 }),
-  }),
+  params: permissiveRouteSchema({ keys: ["sessionId"] }),
+  body: permissiveBodySchema({ keys: ["token"] }),
 } satisfies TokenHandlerConfig;
 
 const cancelFolioCollabSession = createSafeTokenHandler(
   config,
   // eslint-disable-next-line require-yield -- token auth + scopedDb returns plain Promises; nothing to Result.await
-  async function* ({
-    body: { token },
-    params: { sessionId },
-    request,
-    server,
-  }) {
+  async function* ({ body, params, request, server }) {
+    const credentials = validatePostAuth(folioCollabSessionCredentialsSchema, {
+      sessionId: params.sessionId,
+      token: body?.token,
+    });
+    if (!credentials.ok) {
+      return Result.err(folioCollabSessionNotFoundError());
+    }
+    const { sessionId, token } = credentials.value;
+
     const authorizedSession = await authorizeFolioCollabSession({
       sessionId,
       token,
     });
 
     if (authorizedSession.status === "missing") {
-      return Result.err(
-        new HandlerError({
-          status: 404,
-          message: "Collaborative edit session not found.",
-        }),
-      );
+      return Result.err(folioCollabSessionNotFoundError());
     }
     if (authorizedSession.status === "token-expired") {
       return Result.err(

--- a/apps/api/src/handlers/folio-collab/cancel.ts
+++ b/apps/api/src/handlers/folio-collab/cancel.ts
@@ -11,7 +11,6 @@ import {
 } from "@/api/lib/audit-log";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import {
-  authorizeFolioCollabSession,
   collectFolioCollabStoredSessionFiles,
   deleteFolioCollabStoredSessionFiles,
 } from "@/api/lib/folio-collab-sessions";
@@ -19,14 +18,10 @@ import type { FolioCollabStoredSessionFile } from "@/api/lib/folio-collab-sessio
 import {
   permissiveBodySchema,
   permissiveRouteSchema,
-  validatePostAuth,
 } from "@/api/lib/permissive-route-schema";
 import { broadcast } from "@/api/lib/sse";
 
-import {
-  folioCollabSessionCredentialsSchema,
-  folioCollabSessionNotFoundError,
-} from "./session-credentials";
+import { authorizeFolioCollabCredentials } from "./session-credentials";
 
 const config = {
   mcp: { type: "internal", reason: "session_token_exchange" },
@@ -36,44 +31,21 @@ const config = {
 
 const cancelFolioCollabSession = createSafeTokenHandler(
   config,
-  // eslint-disable-next-line require-yield -- token auth + scopedDb returns plain Promises; nothing to Result.await
   async function* ({ body, params, request, server }) {
-    const credentials = validatePostAuth(folioCollabSessionCredentialsSchema, {
-      sessionId: params.sessionId,
-      token: body?.token,
-    });
-    if (!credentials.ok) {
-      return Result.err(folioCollabSessionNotFoundError());
-    }
-    const { sessionId, token } = credentials.value;
-
-    const authorizedSession = await authorizeFolioCollabSession({
+    const { session: authorizedSession } = yield* Result.await(
+      authorizeFolioCollabCredentials({
+        sessionId: params.sessionId,
+        token: body?.token,
+      }),
+    );
+    const {
+      canEdit,
+      organizationId,
+      scopedDb,
       sessionId,
-      token,
-    });
-
-    if (authorizedSession.status === "missing") {
-      return Result.err(folioCollabSessionNotFoundError());
-    }
-    if (authorizedSession.status === "token-expired") {
-      return Result.err(
-        new HandlerError({
-          status: 401,
-          message: "Collaborative edit token expired.",
-        }),
-      );
-    }
-    if (authorizedSession.status === "permission-revoked") {
-      return Result.err(
-        new HandlerError({
-          status: 403,
-          message: "Collaborative edit permission revoked.",
-        }),
-      );
-    }
-
-    const { canEdit, organizationId, scopedDb, userId, workspaceId } =
-      authorizedSession.value;
+      userId,
+      workspaceId,
+    } = authorizedSession;
 
     if (!canEdit) {
       return Result.err(

--- a/apps/api/src/handlers/folio-collab/checkpoint.ts
+++ b/apps/api/src/handlers/folio-collab/checkpoint.ts
@@ -14,7 +14,6 @@ import {
 } from "@/api/lib/audit-log";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import { scanFile } from "@/api/lib/file-scan/scan";
-import { authorizeFolioCollabSession } from "@/api/lib/folio-collab-sessions";
 import { FILE_SIZE_LIMITS } from "@/api/lib/limits";
 import {
   permissiveBodySchema,
@@ -25,10 +24,7 @@ import { getS3 } from "@/api/lib/s3";
 import { broadcast } from "@/api/lib/sse";
 import { DOCX_MIME_TYPE } from "@/api/mime-types";
 
-import {
-  folioCollabSessionCredentialsSchema,
-  folioCollabSessionNotFoundError,
-} from "./session-credentials";
+import { authorizeFolioCollabCredentials } from "./session-credentials";
 
 const config = {
   mcp: { type: "internal", reason: "session_token_exchange" },
@@ -36,7 +32,10 @@ const config = {
   // The multipart file part is undeclared here on purpose: the permissive
   // schema passes it through untouched and the strict schema below checks
   // it after authorization.
-  body: permissiveBodySchema({ keys: ["token"] }),
+  body: permissiveBodySchema({
+    keys: ["token"],
+    passthroughKeys: ["file"],
+  }),
 } satisfies TokenHandlerConfig;
 
 /** Validated after authorization; see `permissive-route-schema.ts`. */
@@ -48,44 +47,22 @@ const strictBodySchema = t.Object({
 
 const checkpointFolioCollabSession = createSafeTokenHandler(
   config,
-  // eslint-disable-next-line require-yield -- token auth + scopedDb returns plain Promises; nothing to Result.await
   async function* ({ body, params, request, server }) {
-    const credentials = validatePostAuth(folioCollabSessionCredentialsSchema, {
-      sessionId: params.sessionId,
-      token: body?.token,
-    });
-    if (!credentials.ok) {
-      return Result.err(folioCollabSessionNotFoundError());
-    }
-    const { sessionId, token } = credentials.value;
-
-    const authorizedSession = await authorizeFolioCollabSession({
+    const { session: authorizedSession } = yield* Result.await(
+      authorizeFolioCollabCredentials({
+        sessionId: params.sessionId,
+        token: body?.token,
+      }),
+    );
+    const {
+      canEdit,
+      fileName,
+      organizationId,
+      scopedDb,
       sessionId,
-      token,
-    });
-
-    if (authorizedSession.status === "missing") {
-      return Result.err(folioCollabSessionNotFoundError());
-    }
-    if (authorizedSession.status === "token-expired") {
-      return Result.err(
-        new HandlerError({
-          status: 401,
-          message: "Collaborative edit token expired.",
-        }),
-      );
-    }
-    if (authorizedSession.status === "permission-revoked") {
-      return Result.err(
-        new HandlerError({
-          status: 403,
-          message: "Collaborative edit permission revoked.",
-        }),
-      );
-    }
-
-    const { canEdit, fileName, organizationId, scopedDb, userId, workspaceId } =
-      authorizedSession.value;
+      userId,
+      workspaceId,
+    } = authorizedSession;
 
     if (!canEdit) {
       return Result.err(

--- a/apps/api/src/handlers/folio-collab/checkpoint.ts
+++ b/apps/api/src/handlers/folio-collab/checkpoint.ts
@@ -12,46 +12,52 @@ import {
   AUDIT_RESOURCE_TYPE,
   createAuditRecorder,
 } from "@/api/lib/audit-log";
-import { tSafeId } from "@/api/lib/custom-schema";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import { scanFile } from "@/api/lib/file-scan/scan";
 import { authorizeFolioCollabSession } from "@/api/lib/folio-collab-sessions";
 import { FILE_SIZE_LIMITS } from "@/api/lib/limits";
+import {
+  permissiveBodySchema,
+  permissiveRouteSchema,
+  validatePostAuth,
+} from "@/api/lib/permissive-route-schema";
 import { getS3 } from "@/api/lib/s3";
 import { broadcast } from "@/api/lib/sse";
 import { DOCX_MIME_TYPE } from "@/api/mime-types";
 
+import {
+  folioCollabSessionCredentialsSchema,
+  folioCollabSessionNotFoundError,
+} from "./session-credentials";
+
 const config = {
   mcp: { type: "internal", reason: "session_token_exchange" },
-  params: t.Object({
-    sessionId: tSafeId("folioCollabSession"),
-  }),
-  body: t.Object({
-    file: t.File({
-      maxSize: FILE_SIZE_LIMITS.document,
-    }),
-    token: t.String({ minLength: 64, maxLength: 64 }),
-  }),
+  params: permissiveRouteSchema({ keys: ["sessionId"] }),
+  // The multipart file part is undeclared here on purpose: the permissive
+  // schema passes it through untouched and the strict schema below checks
+  // it after authorization.
+  body: permissiveBodySchema({ keys: ["token"] }),
 } satisfies TokenHandlerConfig;
+
+/** Validated after authorization; see `permissive-route-schema.ts`. */
+const strictBodySchema = t.Object({
+  file: t.File({
+    maxSize: FILE_SIZE_LIMITS.document,
+  }),
+});
 
 const checkpointFolioCollabSession = createSafeTokenHandler(
   config,
   // eslint-disable-next-line require-yield -- token auth + scopedDb returns plain Promises; nothing to Result.await
-  async function* ({
-    body: { file, token },
-    params: { sessionId },
-    request,
-    server,
-  }) {
-    if (file.type !== DOCX_MIME_TYPE) {
-      return Result.err(
-        new HandlerError({
-          status: 400,
-          message:
-            "Collaborative checkpoints currently support only DOCX files.",
-        }),
-      );
+  async function* ({ body, params, request, server }) {
+    const credentials = validatePostAuth(folioCollabSessionCredentialsSchema, {
+      sessionId: params.sessionId,
+      token: body?.token,
+    });
+    if (!credentials.ok) {
+      return Result.err(folioCollabSessionNotFoundError());
     }
+    const { sessionId, token } = credentials.value;
 
     const authorizedSession = await authorizeFolioCollabSession({
       sessionId,
@@ -59,12 +65,7 @@ const checkpointFolioCollabSession = createSafeTokenHandler(
     });
 
     if (authorizedSession.status === "missing") {
-      return Result.err(
-        new HandlerError({
-          status: 404,
-          message: "Collaborative edit session not found.",
-        }),
-      );
+      return Result.err(folioCollabSessionNotFoundError());
     }
     if (authorizedSession.status === "token-expired") {
       return Result.err(
@@ -91,6 +92,24 @@ const checkpointFolioCollabSession = createSafeTokenHandler(
         new HandlerError({
           status: 403,
           message: "Collaborative edit is read-only.",
+        }),
+      );
+    }
+
+    const validatedBody = validatePostAuth(strictBodySchema, body);
+    if (!validatedBody.ok) {
+      return Result.err(
+        new HandlerError({ status: 422, message: validatedBody.message }),
+      );
+    }
+    const { file } = validatedBody.value;
+
+    if (file.type !== DOCX_MIME_TYPE) {
+      return Result.err(
+        new HandlerError({
+          status: 400,
+          message:
+            "Collaborative checkpoints currently support only DOCX files.",
         }),
       );
     }

--- a/apps/api/src/handlers/folio-collab/finalize.ts
+++ b/apps/api/src/handlers/folio-collab/finalize.ts
@@ -1,6 +1,5 @@
 import { panic, Result } from "better-result";
 import { and, eq } from "drizzle-orm";
-import { t } from "elysia";
 
 import {
   entities,
@@ -33,23 +32,28 @@ import {
 } from "@/api/lib/audit-log";
 import { createSafeId } from "@/api/lib/branded-types";
 import type { SafeId } from "@/api/lib/branded-types";
-import { tSafeId } from "@/api/lib/custom-schema";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import { enqueuePdfDerivativeOrMarkFailed } from "@/api/lib/file-derivative-queue";
 import { authorizeFolioCollabSession } from "@/api/lib/folio-collab-sessions";
+import {
+  permissiveBodySchema,
+  permissiveRouteSchema,
+  validatePostAuth,
+} from "@/api/lib/permissive-route-schema";
 import { getS3 } from "@/api/lib/s3";
 import { processExtraction } from "@/api/lib/search/process-extraction";
 import { broadcast } from "@/api/lib/sse";
 import { DOCX_MIME_TYPE } from "@/api/mime-types";
 
+import {
+  folioCollabSessionCredentialsSchema,
+  folioCollabSessionNotFoundError,
+} from "./session-credentials";
+
 const config = {
   mcp: { type: "internal", reason: "session_token_exchange" },
-  params: t.Object({
-    sessionId: tSafeId("folioCollabSession"),
-  }),
-  body: t.Object({
-    token: t.String({ minLength: 64, maxLength: 64 }),
-  }),
+  params: permissiveRouteSchema({ keys: ["sessionId"] }),
+  body: permissiveBodySchema({ keys: ["token"] }),
 } satisfies TokenHandlerConfig;
 
 type FinalizeResult =
@@ -68,24 +72,23 @@ const finalizeFolioCollabSession = createSafeTokenHandler<
 >(
   config,
   // eslint-disable-next-line require-yield -- token auth + scopedDb returns plain Promises; nothing to Result.await
-  async function* ({
-    body: { token },
-    params: { sessionId },
-    request,
-    server,
-  }) {
+  async function* ({ body, params, request, server }) {
+    const credentials = validatePostAuth(folioCollabSessionCredentialsSchema, {
+      sessionId: params.sessionId,
+      token: body?.token,
+    });
+    if (!credentials.ok) {
+      return Result.err(folioCollabSessionNotFoundError());
+    }
+    const { sessionId, token } = credentials.value;
+
     const authorizedSession = await authorizeFolioCollabSession({
       sessionId,
       token,
     });
 
     if (authorizedSession.status === "missing") {
-      return Result.err(
-        new HandlerError({
-          status: 404,
-          message: "Collaborative edit session not found.",
-        }),
-      );
+      return Result.err(folioCollabSessionNotFoundError());
     }
     if (authorizedSession.status === "token-expired") {
       return Result.err(
@@ -166,12 +169,7 @@ const finalizeFolioCollabSession = createSafeTokenHandler<
     });
 
     if (!sessionPreview) {
-      return Result.err(
-        new HandlerError({
-          status: 404,
-          message: "Collaborative edit session not found.",
-        }),
-      );
+      return Result.err(folioCollabSessionNotFoundError());
     }
 
     if (sessionPreview.status !== "open") {

--- a/apps/api/src/handlers/folio-collab/finalize.ts
+++ b/apps/api/src/handlers/folio-collab/finalize.ts
@@ -34,11 +34,9 @@ import { createSafeId } from "@/api/lib/branded-types";
 import type { SafeId } from "@/api/lib/branded-types";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import { enqueuePdfDerivativeOrMarkFailed } from "@/api/lib/file-derivative-queue";
-import { authorizeFolioCollabSession } from "@/api/lib/folio-collab-sessions";
 import {
   permissiveBodySchema,
   permissiveRouteSchema,
-  validatePostAuth,
 } from "@/api/lib/permissive-route-schema";
 import { getS3 } from "@/api/lib/s3";
 import { processExtraction } from "@/api/lib/search/process-extraction";
@@ -46,7 +44,7 @@ import { broadcast } from "@/api/lib/sse";
 import { DOCX_MIME_TYPE } from "@/api/mime-types";
 
 import {
-  folioCollabSessionCredentialsSchema,
+  authorizeFolioCollabCredentials,
   folioCollabSessionNotFoundError,
 } from "./session-credentials";
 
@@ -69,92 +67,212 @@ type FinalizeResult =
 const finalizeFolioCollabSession = createSafeTokenHandler<
   typeof config,
   FinalizeResult
->(
-  config,
-  // eslint-disable-next-line require-yield -- token auth + scopedDb returns plain Promises; nothing to Result.await
-  async function* ({ body, params, request, server }) {
-    const credentials = validatePostAuth(folioCollabSessionCredentialsSchema, {
+>(config, async function* ({ body, params, request, server }) {
+  const { session: authorizedSession } = yield* Result.await(
+    authorizeFolioCollabCredentials({
       sessionId: params.sessionId,
       token: body?.token,
+    }),
+  );
+  const { canEdit, organizationId, scopedDb, sessionId, userId, workspaceId } =
+    authorizedSession;
+
+  const recordAuditEvent = createAuditRecorder({
+    organizationId,
+    workspaceId,
+    userId,
+    request,
+    server,
+  });
+
+  if (!canEdit) {
+    return Result.err(
+      new HandlerError({
+        status: 403,
+        message: "Collaborative edit is read-only.",
+      }),
+    );
+  }
+
+  const deleteS3Key = async (key: string, context: Record<string, string>) => {
+    await getS3()
+      .delete(key)
+      .catch((error: unknown) => {
+        captureError(error, context);
+      });
+  };
+
+  // Phase A: non-locking read. entity_versions rows are immutable
+  // once written, so reading the base version outside the heavy
+  // write txn is safe; the session row may move under us, but we
+  // re-verify inside the write txn before we commit any rows.
+  const sessionPreview = await scopedDb(async (tx) => {
+    const rows = await tx
+      .select({
+        baseVersionId: folioCollabSessions.baseVersionId,
+        docxCheckpointFileId: folioCollabSessions.docxCheckpointFileId,
+        docxCheckpointScanWarnings:
+          folioCollabSessions.docxCheckpointScanWarnings,
+        docxCheckpointSha256Hex: folioCollabSessions.docxCheckpointSha256Hex,
+        docxCheckpointSizeBytes: folioCollabSessions.docxCheckpointSizeBytes,
+        docxCheckpointUpdatedAt: folioCollabSessions.docxCheckpointUpdatedAt,
+        entityId: folioCollabSessions.entityId,
+        fileName: folioCollabSessions.fileName,
+        propertyId: folioCollabSessions.propertyId,
+        status: folioCollabSessions.status,
+      })
+      .from(folioCollabSessions)
+      .where(
+        and(
+          eq(folioCollabSessions.id, sessionId),
+          eq(folioCollabSessions.workspaceId, workspaceId),
+        ),
+      )
+      .limit(1);
+    return rows.at(0);
+  });
+
+  if (!sessionPreview) {
+    return Result.err(folioCollabSessionNotFoundError());
+  }
+
+  if (sessionPreview.status !== "open") {
+    return Result.err(
+      new HandlerError({
+        status: 409,
+        message: "Collaborative edit session is already closed.",
+      }),
+    );
+  }
+
+  const checkpointSha256Hex = sessionPreview.docxCheckpointSha256Hex;
+  const checkpointSizeBytes = sessionPreview.docxCheckpointSizeBytes;
+  if (
+    checkpointSha256Hex === null ||
+    checkpointSizeBytes === null ||
+    sessionPreview.docxCheckpointUpdatedAt === null
+  ) {
+    await scopedDb(async (tx) => {
+      await tx
+        .update(folioCollabSessions)
+        .set({ closedAt: new Date(), status: "cancelled" })
+        .where(eq(folioCollabSessions.id, sessionId));
+      await recordAuditEvent(tx, {
+        action: AUDIT_ACTION.UPDATE,
+        resourceType: AUDIT_RESOURCE_TYPE.FOLIO_COLLAB_SESSION,
+        resourceId: sessionId,
+        changes: { status: { old: "open", new: "cancelled" } },
+        metadata: { reason: "no-checkpoint" },
+      });
     });
-    if (!credentials.ok) {
-      return Result.err(folioCollabSessionNotFoundError());
-    }
-    const { sessionId, token } = credentials.value;
+    return Result.ok({ outcome: "no_changes" as const });
+  }
 
-    const authorizedSession = await authorizeFolioCollabSession({
-      sessionId,
-      token,
+  const checkpointKey = createFileKey({
+    fileId: sessionPreview.docxCheckpointFileId,
+    mimeType: DOCX_MIME_TYPE,
+    organizationId,
+    workspaceId,
+  });
+
+  const baseVersion = await scopedDb(
+    async (tx) =>
+      await tx.query.entityVersions.findFirst({
+        where: {
+          entityId: { eq: sessionPreview.entityId },
+          id: { eq: sessionPreview.baseVersionId },
+          workspaceId: { eq: workspaceId },
+        },
+        columns: { versionNumber: true },
+        with: {
+          fields: { columns: { content: true, propertyId: true } },
+        },
+      }),
+  );
+
+  if (!baseVersion) {
+    return Result.err(
+      new HandlerError({
+        status: 409,
+        message: "Base entity version not found.",
+      }),
+    );
+  }
+
+  const baseFileField = findDocxFieldForProperty({
+    fieldEntries: baseVersion.fields,
+    propertyId: sessionPreview.propertyId,
+  });
+
+  if (!baseFileField) {
+    return Result.err(
+      new HandlerError({
+        status: 409,
+        message:
+          "Collaborative edit session source file is no longer available.",
+      }),
+    );
+  }
+
+  if (checkpointSha256Hex === baseFileField.sha256Hex) {
+    await scopedDb(async (tx) => {
+      await tx
+        .update(folioCollabSessions)
+        .set({ closedAt: new Date(), status: "cancelled" })
+        .where(eq(folioCollabSessions.id, sessionId));
+      await recordAuditEvent(tx, {
+        action: AUDIT_ACTION.UPDATE,
+        resourceType: AUDIT_RESOURCE_TYPE.FOLIO_COLLAB_SESSION,
+        resourceId: sessionId,
+        changes: { status: { old: "open", new: "cancelled" } },
+        metadata: { reason: "checkpoint-matches-base" },
+      });
     });
+    await deleteS3Key(checkpointKey, { checkpointKey, sessionId });
+    return Result.ok({ outcome: "no_changes" as const });
+  }
 
-    if (authorizedSession.status === "missing") {
-      return Result.err(folioCollabSessionNotFoundError());
-    }
-    if (authorizedSession.status === "token-expired") {
-      return Result.err(
-        new HandlerError({
-          status: 401,
-          message: "Collaborative edit token expired.",
-        }),
-      );
-    }
-    if (authorizedSession.status === "permission-revoked") {
-      return Result.err(
-        new HandlerError({
-          status: 403,
-          message: "Collaborative edit permission revoked.",
-        }),
-      );
-    }
+  // Phase B: heavy IO + DOCX validation, all OUTSIDE the txn. The
+  // source bytes are written to S3 before we open the txn; any
+  // commit failure rolls them back via uploadedKeys.
+  const checkpointBuffer = await getS3().file(checkpointKey).arrayBuffer();
+  const validation = await validateDocxBuffer(checkpointBuffer);
+  if (!validation.valid) {
+    return Result.err(
+      new HandlerError({
+        status: 422,
+        message: `Document validation failed: ${validation.error}`,
+      }),
+    );
+  }
 
-    const { canEdit, organizationId, scopedDb, userId, workspaceId } =
-      authorizedSession.value;
+  const storedBytes = new Uint8Array(checkpointBuffer);
+  const nextVersionId = createSafeId<"entityVersion">();
+  const sourceFileId = allocateFileObject();
+  const sourceKey = createFileKey({
+    fileId: sourceFileId,
+    mimeType: DOCX_MIME_TYPE,
+    organizationId,
+    workspaceId,
+  });
+  const uploadedKeys: string[] = [sourceKey];
+  let shouldRollbackUploadedKeys = true;
+  const rollbackUploadedKeys = async () => {
+    await Promise.all(
+      uploadedKeys.map(
+        async (key) => await deleteS3Key(key, { rollbackKey: key, sessionId }),
+      ),
+    );
+  };
 
-    const recordAuditEvent = createAuditRecorder({
-      organizationId,
-      workspaceId,
-      userId,
-      request,
-      server,
-    });
+  try {
+    await getS3().write(sourceKey, storedBytes);
 
-    if (!canEdit) {
-      return Result.err(
-        new HandlerError({
-          status: 403,
-          message: "Collaborative edit is read-only.",
-        }),
-      );
-    }
-
-    const deleteS3Key = async (
-      key: string,
-      context: Record<string, string>,
-    ) => {
-      await getS3()
-        .delete(key)
-        .catch((error: unknown) => {
-          captureError(error, context);
-        });
-    };
-
-    // Phase A: non-locking read. entity_versions rows are immutable
-    // once written, so reading the base version outside the heavy
-    // write txn is safe; the session row may move under us, but we
-    // re-verify inside the write txn before we commit any rows.
-    const sessionPreview = await scopedDb(async (tx) => {
-      const rows = await tx
+    // Phase C: txn — lock + verify state hasn't drifted + write rows.
+    const result = await scopedDb(async (tx) => {
+      const lockedSessions = await tx
         .select({
-          baseVersionId: folioCollabSessions.baseVersionId,
-          docxCheckpointFileId: folioCollabSessions.docxCheckpointFileId,
-          docxCheckpointScanWarnings:
-            folioCollabSessions.docxCheckpointScanWarnings,
           docxCheckpointSha256Hex: folioCollabSessions.docxCheckpointSha256Hex,
-          docxCheckpointSizeBytes: folioCollabSessions.docxCheckpointSizeBytes,
-          docxCheckpointUpdatedAt: folioCollabSessions.docxCheckpointUpdatedAt,
-          entityId: folioCollabSessions.entityId,
-          fileName: folioCollabSessions.fileName,
-          propertyId: folioCollabSessions.propertyId,
           status: folioCollabSessions.status,
         })
         .from(folioCollabSessions)
@@ -164,416 +282,255 @@ const finalizeFolioCollabSession = createSafeTokenHandler<
             eq(folioCollabSessions.workspaceId, workspaceId),
           ),
         )
-        .limit(1);
-      return rows.at(0);
-    });
+        .for("update");
 
-    if (!sessionPreview) {
-      return Result.err(folioCollabSessionNotFoundError());
-    }
-
-    if (sessionPreview.status !== "open") {
-      return Result.err(
-        new HandlerError({
-          status: 409,
-          message: "Collaborative edit session is already closed.",
-        }),
-      );
-    }
-
-    const checkpointSha256Hex = sessionPreview.docxCheckpointSha256Hex;
-    const checkpointSizeBytes = sessionPreview.docxCheckpointSizeBytes;
-    if (
-      checkpointSha256Hex === null ||
-      checkpointSizeBytes === null ||
-      sessionPreview.docxCheckpointUpdatedAt === null
-    ) {
-      await scopedDb(async (tx) => {
-        await tx
-          .update(folioCollabSessions)
-          .set({ closedAt: new Date(), status: "cancelled" })
-          .where(eq(folioCollabSessions.id, sessionId));
-        await recordAuditEvent(tx, {
-          action: AUDIT_ACTION.UPDATE,
-          resourceType: AUDIT_RESOURCE_TYPE.FOLIO_COLLAB_SESSION,
-          resourceId: sessionId,
-          changes: { status: { old: "open", new: "cancelled" } },
-          metadata: { reason: "no-checkpoint" },
-        });
-      });
-      return Result.ok({ outcome: "no_changes" as const });
-    }
-
-    const checkpointKey = createFileKey({
-      fileId: sessionPreview.docxCheckpointFileId,
-      mimeType: DOCX_MIME_TYPE,
-      organizationId,
-      workspaceId,
-    });
-
-    const baseVersion = await scopedDb(
-      async (tx) =>
-        await tx.query.entityVersions.findFirst({
-          where: {
-            entityId: { eq: sessionPreview.entityId },
-            id: { eq: sessionPreview.baseVersionId },
-            workspaceId: { eq: workspaceId },
-          },
-          columns: { versionNumber: true },
-          with: {
-            fields: { columns: { content: true, propertyId: true } },
-          },
-        }),
-    );
-
-    if (!baseVersion) {
-      return Result.err(
-        new HandlerError({
-          status: 409,
-          message: "Base entity version not found.",
-        }),
-      );
-    }
-
-    const baseFileField = findDocxFieldForProperty({
-      fieldEntries: baseVersion.fields,
-      propertyId: sessionPreview.propertyId,
-    });
-
-    if (!baseFileField) {
-      return Result.err(
-        new HandlerError({
-          status: 409,
-          message:
-            "Collaborative edit session source file is no longer available.",
-        }),
-      );
-    }
-
-    if (checkpointSha256Hex === baseFileField.sha256Hex) {
-      await scopedDb(async (tx) => {
-        await tx
-          .update(folioCollabSessions)
-          .set({ closedAt: new Date(), status: "cancelled" })
-          .where(eq(folioCollabSessions.id, sessionId));
-        await recordAuditEvent(tx, {
-          action: AUDIT_ACTION.UPDATE,
-          resourceType: AUDIT_RESOURCE_TYPE.FOLIO_COLLAB_SESSION,
-          resourceId: sessionId,
-          changes: { status: { old: "open", new: "cancelled" } },
-          metadata: { reason: "checkpoint-matches-base" },
-        });
-      });
-      await deleteS3Key(checkpointKey, { checkpointKey, sessionId });
-      return Result.ok({ outcome: "no_changes" as const });
-    }
-
-    // Phase B: heavy IO + DOCX validation, all OUTSIDE the txn. The
-    // source bytes are written to S3 before we open the txn; any
-    // commit failure rolls them back via uploadedKeys.
-    const checkpointBuffer = await getS3().file(checkpointKey).arrayBuffer();
-    const validation = await validateDocxBuffer(checkpointBuffer);
-    if (!validation.valid) {
-      return Result.err(
-        new HandlerError({
-          status: 422,
-          message: `Document validation failed: ${validation.error}`,
-        }),
-      );
-    }
-
-    const storedBytes = new Uint8Array(checkpointBuffer);
-    const nextVersionId = createSafeId<"entityVersion">();
-    const sourceFileId = allocateFileObject();
-    const sourceKey = createFileKey({
-      fileId: sourceFileId,
-      mimeType: DOCX_MIME_TYPE,
-      organizationId,
-      workspaceId,
-    });
-    const uploadedKeys: string[] = [sourceKey];
-    let shouldRollbackUploadedKeys = true;
-    const rollbackUploadedKeys = async () => {
-      await Promise.all(
-        uploadedKeys.map(
-          async (key) =>
-            await deleteS3Key(key, { rollbackKey: key, sessionId }),
-        ),
-      );
-    };
-
-    try {
-      await getS3().write(sourceKey, storedBytes);
-
-      // Phase C: txn — lock + verify state hasn't drifted + write rows.
-      const result = await scopedDb(async (tx) => {
-        const lockedSessions = await tx
-          .select({
-            docxCheckpointSha256Hex:
-              folioCollabSessions.docxCheckpointSha256Hex,
-            status: folioCollabSessions.status,
-          })
-          .from(folioCollabSessions)
-          .where(
-            and(
-              eq(folioCollabSessions.id, sessionId),
-              eq(folioCollabSessions.workspaceId, workspaceId),
-            ),
-          )
-          .for("update");
-
-        const editSession = lockedSessions.at(0);
-        if (!editSession) {
-          return {
-            error: {
-              statusCode: 404 as const,
-              message: "Collaborative edit session not found.",
-            },
-          } as const;
-        }
-        if (editSession.status !== "open") {
-          return {
-            error: {
-              statusCode: 409 as const,
-              message: "Collaborative edit session is already closed.",
-            },
-          } as const;
-        }
-        if (editSession.docxCheckpointSha256Hex !== checkpointSha256Hex) {
-          return {
-            error: {
-              statusCode: 409 as const,
-              message: "Collaborative edit checkpoint changed during finalize.",
-            },
-          } as const;
-        }
-
-        const lockedEntities = await tx
-          .select({
-            currentVersionId: entities.currentVersionId,
-            docSequence: entities.docSequence,
-          })
-          .from(entities)
-          .where(
-            and(
-              eq(entities.id, sessionPreview.entityId),
-              eq(entities.workspaceId, workspaceId),
-            ),
-          )
-          .for("update");
-
-        const entity = lockedEntities.at(0);
-        if (!entity) {
-          return {
-            error: {
-              statusCode: 404 as const,
-              message: "Entity not found.",
-            },
-          } as const;
-        }
-
-        if (entity.currentVersionId !== sessionPreview.baseVersionId) {
-          await tx
-            .update(folioCollabSessions)
-            .set({ closedAt: new Date(), status: "cancelled" })
-            .where(eq(folioCollabSessions.id, sessionId));
-
-          await recordAuditEvent(tx, {
-            action: AUDIT_ACTION.UPDATE,
-            resourceType: AUDIT_RESOURCE_TYPE.FOLIO_COLLAB_SESSION,
-            resourceId: sessionId,
-            changes: { status: { old: "open", new: "cancelled" } },
-            metadata: { reason: "base-version-drift" },
-          });
-
-          return {
-            deleteCheckpoint: true,
-            error: {
-              statusCode: 409 as const,
-              message:
-                "This document changed in stella while collaborative editing was open.",
-            },
-          } as const;
-        }
-
-        const workspace = await tx.query.workspaces.findFirst({
-          where: { id: { eq: workspaceId } },
-          columns: { reference: true },
-        });
-
-        // MAX over all versions (incl. tombstoned) under the session + entity
-        // locks, not baseVersion + 1: the divergence check confirms the base is
-        // still current, but a higher tombstoned version can still exist, and
-        // base + 1 would reuse its number. See nextEntityVersionNumber.
-        const nextVersionNumber = await nextEntityVersionNumber(tx, {
-          entityId: sessionPreview.entityId,
-          workspaceId,
-        });
-
-        const nextVersionStamp = buildVersionStamp({
-          docSequence: entity.docSequence,
-          versionNumber: nextVersionNumber,
-          workspaceReference:
-            workspace?.reference ??
-            panic(
-              "Workspace not found for finalized collaborative edit session",
-            ),
-        });
-
-        await tx.insert(entityVersions).values({
-          entityId: sessionPreview.entityId,
-          id: nextVersionId,
-          stamp: nextVersionStamp.stamp,
-          verificationCode: nextVersionStamp.verificationCode,
-          versionNumber: nextVersionNumber,
-          workspaceId,
-        });
-
-        const clonedFields = cloneFieldsForRevision({
-          currentFields: baseVersion.fields,
-          entityVersionId: nextVersionId,
-          propertyId: sessionPreview.propertyId,
-          replacementContent: fileContentWithMintedObject({
-            encrypted: false,
-            fileName: sessionPreview.fileName,
-            id: sourceFileId,
-            mimeType: DOCX_MIME_TYPE,
-            pdfFileId: null,
-            pdfDerivative: pdfDerivativeStateForFile({
-              encrypted: false,
-              mimeType: DOCX_MIME_TYPE,
-            }),
-            sha256Hex: checkpointSha256Hex,
-            sizeBytes: checkpointSizeBytes,
-            type: "file",
-            version: 1,
-            ...(sessionPreview.docxCheckpointScanWarnings !== null && {
-              scanWarnings: sessionPreview.docxCheckpointScanWarnings,
-            }),
-          }),
-          workspaceId,
-        });
-
-        const insertedFields = await tx
-          .insert(fields)
-          .values(clonedFields)
-          .returning({ id: fields.id, propertyId: fields.propertyId });
-
-        const nextField = insertedFields.find(
-          (field) => field.propertyId === sessionPreview.propertyId,
-        );
-
-        await tx
-          .update(entities)
-          .set({
-            currentVersionId: nextVersionId,
-            lastEditedBy: userId,
-            updatedAt: new Date(),
-          })
-          .where(eq(entities.id, sessionPreview.entityId));
-
-        await tx
-          .update(workspaces)
-          .set({ lastActivityAt: new Date() })
-          .where(eq(workspaces.id, workspaceId));
-
-        await tx
-          .update(folioCollabSessions)
-          .set({
-            closedAt: new Date(),
-            finalizedVersionId: nextVersionId,
-            status: "finalized",
-          })
-          .where(eq(folioCollabSessions.id, sessionId));
-
-        await recordAuditEvent(tx, [
-          {
-            action: AUDIT_ACTION.CREATE,
-            resourceType: AUDIT_RESOURCE_TYPE.ENTITY_VERSION,
-            resourceId: nextVersionId,
-            metadata: {
-              entityId: sessionPreview.entityId,
-              versionNumber: nextVersionNumber,
-              source: "folio-collab-finalize",
-              sessionId,
-            },
-          },
-          {
-            action: AUDIT_ACTION.UPDATE,
-            resourceType: AUDIT_RESOURCE_TYPE.ENTITY,
-            resourceId: sessionPreview.entityId,
-            changes: {
-              currentVersionId: {
-                old: sessionPreview.baseVersionId,
-                new: nextVersionId,
-              },
-            },
-            metadata: { source: "folio-collab-finalize", sessionId },
-          },
-          {
-            action: AUDIT_ACTION.UPDATE,
-            resourceType: AUDIT_RESOURCE_TYPE.FOLIO_COLLAB_SESSION,
-            resourceId: sessionId,
-            changes: {
-              status: { old: "open", new: "finalized" },
-              finalizedVersionId: { old: null, new: nextVersionId },
-            },
-          },
-        ]);
-
+      const editSession = lockedSessions.at(0);
+      if (!editSession) {
         return {
-          entityId: sessionPreview.entityId,
-          fieldId:
-            nextField?.id ??
-            panic(
-              "Finalized collaborative edit session field was not inserted",
-            ),
-          outcome: "finalized" as const,
-          versionId: nextVersionId,
-          versionNumber: nextVersionNumber,
+          error: {
+            statusCode: 404 as const,
+            message: "Collaborative edit session not found.",
+          },
         } as const;
-      });
-
-      if ("error" in result) {
-        await rollbackUploadedKeys();
-        if ("deleteCheckpoint" in result) {
-          await deleteS3Key(checkpointKey, { checkpointKey, sessionId });
-        }
-        return Result.err(
-          new HandlerError({
-            status: result.error.statusCode,
-            message: result.error.message,
-          }),
-        );
+      }
+      if (editSession.status !== "open") {
+        return {
+          error: {
+            statusCode: 409 as const,
+            message: "Collaborative edit session is already closed.",
+          },
+        } as const;
+      }
+      if (editSession.docxCheckpointSha256Hex !== checkpointSha256Hex) {
+        return {
+          error: {
+            statusCode: 409 as const,
+            message: "Collaborative edit checkpoint changed during finalize.",
+          },
+        } as const;
       }
 
-      shouldRollbackUploadedKeys = false;
-      await deleteS3Key(checkpointKey, { checkpointKey, sessionId });
+      const lockedEntities = await tx
+        .select({
+          currentVersionId: entities.currentVersionId,
+          docSequence: entities.docSequence,
+        })
+        .from(entities)
+        .where(
+          and(
+            eq(entities.id, sessionPreview.entityId),
+            eq(entities.workspaceId, workspaceId),
+          ),
+        )
+        .for("update");
 
-      broadcast(workspaceId, {
-        type: "invalidate-query",
-        data: ["entities", workspaceId],
+      const entity = lockedEntities.at(0);
+      if (!entity) {
+        return {
+          error: {
+            statusCode: 404 as const,
+            message: "Entity not found.",
+          },
+        } as const;
+      }
+
+      if (entity.currentVersionId !== sessionPreview.baseVersionId) {
+        await tx
+          .update(folioCollabSessions)
+          .set({ closedAt: new Date(), status: "cancelled" })
+          .where(eq(folioCollabSessions.id, sessionId));
+
+        await recordAuditEvent(tx, {
+          action: AUDIT_ACTION.UPDATE,
+          resourceType: AUDIT_RESOURCE_TYPE.FOLIO_COLLAB_SESSION,
+          resourceId: sessionId,
+          changes: { status: { old: "open", new: "cancelled" } },
+          metadata: { reason: "base-version-drift" },
+        });
+
+        return {
+          deleteCheckpoint: true,
+          error: {
+            statusCode: 409 as const,
+            message:
+              "This document changed in stella while collaborative editing was open.",
+          },
+        } as const;
+      }
+
+      const workspace = await tx.query.workspaces.findFirst({
+        where: { id: { eq: workspaceId } },
+        columns: { reference: true },
       });
 
-      await processCollaborativeEditDerivatives({
-        entityId: result.entityId,
-        fieldId: result.fieldId,
-        organizationId,
-        scopedDb,
-        userId,
-        versionId: result.versionId,
+      // MAX over all versions (incl. tombstoned) under the session + entity
+      // locks, not baseVersion + 1: the divergence check confirms the base is
+      // still current, but a higher tombstoned version can still exist, and
+      // base + 1 would reuse its number. See nextEntityVersionNumber.
+      const nextVersionNumber = await nextEntityVersionNumber(tx, {
+        entityId: sessionPreview.entityId,
         workspaceId,
       });
 
-      return Result.ok(result);
-    } catch (error) {
-      if (shouldRollbackUploadedKeys) {
-        await rollbackUploadedKeys();
+      const nextVersionStamp = buildVersionStamp({
+        docSequence: entity.docSequence,
+        versionNumber: nextVersionNumber,
+        workspaceReference:
+          workspace?.reference ??
+          panic("Workspace not found for finalized collaborative edit session"),
+      });
+
+      await tx.insert(entityVersions).values({
+        entityId: sessionPreview.entityId,
+        id: nextVersionId,
+        stamp: nextVersionStamp.stamp,
+        verificationCode: nextVersionStamp.verificationCode,
+        versionNumber: nextVersionNumber,
+        workspaceId,
+      });
+
+      const clonedFields = cloneFieldsForRevision({
+        currentFields: baseVersion.fields,
+        entityVersionId: nextVersionId,
+        propertyId: sessionPreview.propertyId,
+        replacementContent: fileContentWithMintedObject({
+          encrypted: false,
+          fileName: sessionPreview.fileName,
+          id: sourceFileId,
+          mimeType: DOCX_MIME_TYPE,
+          pdfFileId: null,
+          pdfDerivative: pdfDerivativeStateForFile({
+            encrypted: false,
+            mimeType: DOCX_MIME_TYPE,
+          }),
+          sha256Hex: checkpointSha256Hex,
+          sizeBytes: checkpointSizeBytes,
+          type: "file",
+          version: 1,
+          ...(sessionPreview.docxCheckpointScanWarnings !== null && {
+            scanWarnings: sessionPreview.docxCheckpointScanWarnings,
+          }),
+        }),
+        workspaceId,
+      });
+
+      const insertedFields = await tx
+        .insert(fields)
+        .values(clonedFields)
+        .returning({ id: fields.id, propertyId: fields.propertyId });
+
+      const nextField = insertedFields.find(
+        (field) => field.propertyId === sessionPreview.propertyId,
+      );
+
+      await tx
+        .update(entities)
+        .set({
+          currentVersionId: nextVersionId,
+          lastEditedBy: userId,
+          updatedAt: new Date(),
+        })
+        .where(eq(entities.id, sessionPreview.entityId));
+
+      await tx
+        .update(workspaces)
+        .set({ lastActivityAt: new Date() })
+        .where(eq(workspaces.id, workspaceId));
+
+      await tx
+        .update(folioCollabSessions)
+        .set({
+          closedAt: new Date(),
+          finalizedVersionId: nextVersionId,
+          status: "finalized",
+        })
+        .where(eq(folioCollabSessions.id, sessionId));
+
+      await recordAuditEvent(tx, [
+        {
+          action: AUDIT_ACTION.CREATE,
+          resourceType: AUDIT_RESOURCE_TYPE.ENTITY_VERSION,
+          resourceId: nextVersionId,
+          metadata: {
+            entityId: sessionPreview.entityId,
+            versionNumber: nextVersionNumber,
+            source: "folio-collab-finalize",
+            sessionId,
+          },
+        },
+        {
+          action: AUDIT_ACTION.UPDATE,
+          resourceType: AUDIT_RESOURCE_TYPE.ENTITY,
+          resourceId: sessionPreview.entityId,
+          changes: {
+            currentVersionId: {
+              old: sessionPreview.baseVersionId,
+              new: nextVersionId,
+            },
+          },
+          metadata: { source: "folio-collab-finalize", sessionId },
+        },
+        {
+          action: AUDIT_ACTION.UPDATE,
+          resourceType: AUDIT_RESOURCE_TYPE.FOLIO_COLLAB_SESSION,
+          resourceId: sessionId,
+          changes: {
+            status: { old: "open", new: "finalized" },
+            finalizedVersionId: { old: null, new: nextVersionId },
+          },
+        },
+      ]);
+
+      return {
+        entityId: sessionPreview.entityId,
+        fieldId:
+          nextField?.id ??
+          panic("Finalized collaborative edit session field was not inserted"),
+        outcome: "finalized" as const,
+        versionId: nextVersionId,
+        versionNumber: nextVersionNumber,
+      } as const;
+    });
+
+    if ("error" in result) {
+      await rollbackUploadedKeys();
+      if ("deleteCheckpoint" in result) {
+        await deleteS3Key(checkpointKey, { checkpointKey, sessionId });
       }
-      throw error;
+      return Result.err(
+        new HandlerError({
+          status: result.error.statusCode,
+          message: result.error.message,
+        }),
+      );
     }
-  },
-);
+
+    shouldRollbackUploadedKeys = false;
+    await deleteS3Key(checkpointKey, { checkpointKey, sessionId });
+
+    broadcast(workspaceId, {
+      type: "invalidate-query",
+      data: ["entities", workspaceId],
+    });
+
+    await processCollaborativeEditDerivatives({
+      entityId: result.entityId,
+      fieldId: result.fieldId,
+      organizationId,
+      scopedDb,
+      userId,
+      versionId: result.versionId,
+      workspaceId,
+    });
+
+    return Result.ok(result);
+  } catch (error) {
+    if (shouldRollbackUploadedKeys) {
+      await rollbackUploadedKeys();
+    }
+    throw error;
+  }
+});
 
 export default finalizeFolioCollabSession;
 

--- a/apps/api/src/handlers/folio-collab/refresh-token.ts
+++ b/apps/api/src/handlers/folio-collab/refresh-token.ts
@@ -3,19 +3,10 @@ import { Result } from "better-result";
 import type { TokenHandlerConfig } from "@/api/lib/api-handlers";
 import { createSafeTokenHandler } from "@/api/lib/api-handlers";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
-import {
-  authorizeFolioCollabSession,
-  refreshFolioCollabToken as refreshStoredFolioCollabToken,
-} from "@/api/lib/folio-collab-sessions";
-import {
-  permissiveBodySchema,
-  validatePostAuth,
-} from "@/api/lib/permissive-route-schema";
+import { refreshFolioCollabToken as refreshStoredFolioCollabToken } from "@/api/lib/folio-collab-sessions";
+import { permissiveBodySchema } from "@/api/lib/permissive-route-schema";
 
-import {
-  folioCollabSessionCredentialsSchema,
-  folioCollabSessionNotFoundError,
-} from "./session-credentials";
+import { authorizeFolioCollabCredentials } from "./session-credentials";
 
 const config = {
   mcp: { type: "internal", reason: "session_token_exchange" },
@@ -24,40 +15,10 @@ const config = {
 
 const refreshFolioCollabToken = createSafeTokenHandler(
   config,
-  // eslint-disable-next-line require-yield -- token auth + scopedDb returns plain Promises; nothing to Result.await
   async function* ({ body }) {
-    const credentials = validatePostAuth(
-      folioCollabSessionCredentialsSchema,
-      body,
+    const { session: value, token } = yield* Result.await(
+      authorizeFolioCollabCredentials(body),
     );
-    if (!credentials.ok) {
-      return Result.err(folioCollabSessionNotFoundError());
-    }
-    const { sessionId, token } = credentials.value;
-
-    const authorized = await authorizeFolioCollabSession({ sessionId, token });
-
-    if (authorized.status === "missing") {
-      return Result.err(folioCollabSessionNotFoundError());
-    }
-    if (authorized.status === "token-expired") {
-      return Result.err(
-        new HandlerError({
-          status: 401,
-          message: "Collaborative edit token expired.",
-        }),
-      );
-    }
-    if (authorized.status === "permission-revoked") {
-      return Result.err(
-        new HandlerError({
-          status: 403,
-          message: "Collaborative edit permission revoked.",
-        }),
-      );
-    }
-
-    const { value } = authorized;
     const refreshed = await value.scopedDb(
       async (tx) =>
         await refreshStoredFolioCollabToken({

--- a/apps/api/src/handlers/folio-collab/refresh-token.ts
+++ b/apps/api/src/handlers/folio-collab/refresh-token.ts
@@ -1,36 +1,44 @@
 import { Result } from "better-result";
-import { t } from "elysia";
 
 import type { TokenHandlerConfig } from "@/api/lib/api-handlers";
 import { createSafeTokenHandler } from "@/api/lib/api-handlers";
-import { tSafeId } from "@/api/lib/custom-schema";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import {
   authorizeFolioCollabSession,
   refreshFolioCollabToken as refreshStoredFolioCollabToken,
 } from "@/api/lib/folio-collab-sessions";
+import {
+  permissiveBodySchema,
+  validatePostAuth,
+} from "@/api/lib/permissive-route-schema";
+
+import {
+  folioCollabSessionCredentialsSchema,
+  folioCollabSessionNotFoundError,
+} from "./session-credentials";
 
 const config = {
   mcp: { type: "internal", reason: "session_token_exchange" },
-  body: t.Object({
-    sessionId: tSafeId("folioCollabSession"),
-    token: t.String({ minLength: 64, maxLength: 64 }),
-  }),
+  body: permissiveBodySchema({ keys: ["sessionId", "token"] }),
 } satisfies TokenHandlerConfig;
 
 const refreshFolioCollabToken = createSafeTokenHandler(
   config,
   // eslint-disable-next-line require-yield -- token auth + scopedDb returns plain Promises; nothing to Result.await
-  async function* ({ body: { sessionId, token } }) {
+  async function* ({ body }) {
+    const credentials = validatePostAuth(
+      folioCollabSessionCredentialsSchema,
+      body,
+    );
+    if (!credentials.ok) {
+      return Result.err(folioCollabSessionNotFoundError());
+    }
+    const { sessionId, token } = credentials.value;
+
     const authorized = await authorizeFolioCollabSession({ sessionId, token });
 
     if (authorized.status === "missing") {
-      return Result.err(
-        new HandlerError({
-          status: 404,
-          message: "Collaborative edit session not found.",
-        }),
-      );
+      return Result.err(folioCollabSessionNotFoundError());
     }
     if (authorized.status === "token-expired") {
       return Result.err(

--- a/apps/api/src/handlers/folio-collab/session-credentials.ts
+++ b/apps/api/src/handlers/folio-collab/session-credentials.ts
@@ -1,0 +1,37 @@
+import { t } from "elysia";
+
+import { tSafeId } from "@/api/lib/custom-schema";
+import { HandlerError } from "@/api/lib/errors/tagged-errors";
+
+/**
+ * Folio-collab room tokens are two concatenated 32-char parts (see
+ * `createFolioCollabToken` in `lib/folio-collab-sessions.ts`).
+ */
+const FOLIO_COLLAB_TOKEN_LENGTH = 64;
+
+/**
+ * Strict shape of the credential pair every folio-collab session endpoint
+ * authorizes itself from. The route schemas are deliberately permissive
+ * (see `lib/permissive-route-schema.ts`), so each handler applies this
+ * schema itself as the first step of its credential check: a request whose
+ * credentials do not even have the right shape must be indistinguishable
+ * from one carrying unknown credentials.
+ */
+export const folioCollabSessionCredentialsSchema = t.Object({
+  sessionId: tSafeId("folioCollabSession"),
+  token: t.String({
+    minLength: FOLIO_COLLAB_TOKEN_LENGTH,
+    maxLength: FOLIO_COLLAB_TOKEN_LENGTH,
+  }),
+});
+
+/**
+ * The response for a session that cannot be authorized: unknown session,
+ * unknown token, or credentials that are not even well-formed. One shared
+ * construction so all three cases stay byte-identical on the wire.
+ */
+export const folioCollabSessionNotFoundError = () =>
+  new HandlerError({
+    status: 404,
+    message: "Collaborative edit session not found.",
+  });

--- a/apps/api/src/handlers/folio-collab/session-credentials.ts
+++ b/apps/api/src/handlers/folio-collab/session-credentials.ts
@@ -1,7 +1,13 @@
+import { Result } from "better-result";
 import { t } from "elysia";
 
 import { tSafeId } from "@/api/lib/custom-schema";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
+import {
+  authorizeFolioCollabSession,
+  type AuthorizedFolioCollabSession,
+} from "@/api/lib/folio-collab-sessions";
+import { validatePostAuth } from "@/api/lib/permissive-route-schema";
 
 /**
  * Folio-collab room tokens are two concatenated 32-char parts (see
@@ -35,3 +41,52 @@ export const folioCollabSessionNotFoundError = () =>
     status: 404,
     message: "Collaborative edit session not found.",
   });
+
+/**
+ * Validates and authorizes the shared folio-collab credential pair. Keeping
+ * every auth-shaped response here prevents the token routes from drifting
+ * into observably different behavior for malformed, missing, or revoked
+ * credentials.
+ */
+export const authorizeFolioCollabCredentials = async (
+  rawCredentials: unknown,
+): Promise<
+  Result<
+    { session: AuthorizedFolioCollabSession; token: string },
+    HandlerError<401 | 403 | 404>
+  >
+> => {
+  const credentials = validatePostAuth(
+    folioCollabSessionCredentialsSchema,
+    rawCredentials,
+  );
+  if (!credentials.ok) {
+    return Result.err(folioCollabSessionNotFoundError());
+  }
+
+  const authorized = await authorizeFolioCollabSession(credentials.value);
+  if (authorized.status === "missing") {
+    return Result.err(folioCollabSessionNotFoundError());
+  }
+  if (authorized.status === "token-expired") {
+    return Result.err(
+      new HandlerError({
+        status: 401,
+        message: "Collaborative edit token expired.",
+      }),
+    );
+  }
+  if (authorized.status === "permission-revoked") {
+    return Result.err(
+      new HandlerError({
+        status: 403,
+        message: "Collaborative edit permission revoked.",
+      }),
+    );
+  }
+
+  return Result.ok({
+    session: authorized.value,
+    token: credentials.value.token,
+  });
+};

--- a/apps/api/src/handlers/folio-collab/snapshot-load.ts
+++ b/apps/api/src/handlers/folio-collab/snapshot-load.ts
@@ -2,20 +2,10 @@ import { Result } from "better-result";
 
 import type { TokenHandlerConfig } from "@/api/lib/api-handlers";
 import { createSafeTokenHandler } from "@/api/lib/api-handlers";
-import { HandlerError } from "@/api/lib/errors/tagged-errors";
-import {
-  authorizeFolioCollabSession,
-  loadFolioCollabSnapshot,
-} from "@/api/lib/folio-collab-sessions";
-import {
-  permissiveBodySchema,
-  validatePostAuth,
-} from "@/api/lib/permissive-route-schema";
+import { loadFolioCollabSnapshot } from "@/api/lib/folio-collab-sessions";
+import { permissiveBodySchema } from "@/api/lib/permissive-route-schema";
 
-import {
-  folioCollabSessionCredentialsSchema,
-  folioCollabSessionNotFoundError,
-} from "./session-credentials";
+import { authorizeFolioCollabCredentials } from "./session-credentials";
 
 const config = {
   mcp: { type: "internal", reason: "session_token_exchange" },
@@ -24,41 +14,13 @@ const config = {
 
 const loadFolioCollabSnapshotHandler = createSafeTokenHandler(
   config,
-  // eslint-disable-next-line require-yield -- token auth returns a plain Promise; nothing to Result.await
   async function* ({ body }) {
-    const credentials = validatePostAuth(
-      folioCollabSessionCredentialsSchema,
-      body,
+    const { session: value } = yield* Result.await(
+      authorizeFolioCollabCredentials(body),
     );
-    if (!credentials.ok) {
-      return Result.err(folioCollabSessionNotFoundError());
-    }
-    const { sessionId, token } = credentials.value;
-
-    const authorized = await authorizeFolioCollabSession({ sessionId, token });
-
-    if (authorized.status === "missing") {
-      return Result.err(folioCollabSessionNotFoundError());
-    }
-    if (authorized.status === "token-expired") {
-      return Result.err(
-        new HandlerError({
-          status: 401,
-          message: "Collaborative edit token expired.",
-        }),
-      );
-    }
-    if (authorized.status === "permission-revoked") {
-      return Result.err(
-        new HandlerError({
-          status: 403,
-          message: "Collaborative edit permission revoked.",
-        }),
-      );
-    }
 
     return Result.ok({
-      snapshotBase64: await loadFolioCollabSnapshot(authorized.value),
+      snapshotBase64: await loadFolioCollabSnapshot(value),
     });
   },
 );

--- a/apps/api/src/handlers/folio-collab/snapshot-load.ts
+++ b/apps/api/src/handlers/folio-collab/snapshot-load.ts
@@ -1,36 +1,44 @@
 import { Result } from "better-result";
-import { t } from "elysia";
 
 import type { TokenHandlerConfig } from "@/api/lib/api-handlers";
 import { createSafeTokenHandler } from "@/api/lib/api-handlers";
-import { tSafeId } from "@/api/lib/custom-schema";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import {
   authorizeFolioCollabSession,
   loadFolioCollabSnapshot,
 } from "@/api/lib/folio-collab-sessions";
+import {
+  permissiveBodySchema,
+  validatePostAuth,
+} from "@/api/lib/permissive-route-schema";
+
+import {
+  folioCollabSessionCredentialsSchema,
+  folioCollabSessionNotFoundError,
+} from "./session-credentials";
 
 const config = {
   mcp: { type: "internal", reason: "session_token_exchange" },
-  body: t.Object({
-    sessionId: tSafeId("folioCollabSession"),
-    token: t.String({ minLength: 64, maxLength: 64 }),
-  }),
+  body: permissiveBodySchema({ keys: ["sessionId", "token"] }),
 } satisfies TokenHandlerConfig;
 
 const loadFolioCollabSnapshotHandler = createSafeTokenHandler(
   config,
   // eslint-disable-next-line require-yield -- token auth returns a plain Promise; nothing to Result.await
-  async function* ({ body: { sessionId, token } }) {
+  async function* ({ body }) {
+    const credentials = validatePostAuth(
+      folioCollabSessionCredentialsSchema,
+      body,
+    );
+    if (!credentials.ok) {
+      return Result.err(folioCollabSessionNotFoundError());
+    }
+    const { sessionId, token } = credentials.value;
+
     const authorized = await authorizeFolioCollabSession({ sessionId, token });
 
     if (authorized.status === "missing") {
-      return Result.err(
-        new HandlerError({
-          status: 404,
-          message: "Collaborative edit session not found.",
-        }),
-      );
+      return Result.err(folioCollabSessionNotFoundError());
     }
     if (authorized.status === "token-expired") {
       return Result.err(

--- a/apps/api/src/handlers/folio-collab/snapshot-store.ts
+++ b/apps/api/src/handlers/folio-collab/snapshot-store.ts
@@ -3,7 +3,6 @@ import { t } from "elysia";
 
 import type { TokenHandlerConfig } from "@/api/lib/api-handlers";
 import { createSafeTokenHandler } from "@/api/lib/api-handlers";
-import { tSafeId } from "@/api/lib/custom-schema";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import {
   authorizeFolioCollabSession,
@@ -11,31 +10,47 @@ import {
   FOLIO_COLLAB_SNAPSHOT_MAX_BYTES,
   storeFolioCollabSnapshot,
 } from "@/api/lib/folio-collab-sessions";
+import {
+  permissiveBodySchema,
+  validatePostAuth,
+} from "@/api/lib/permissive-route-schema";
+
+import {
+  folioCollabSessionCredentialsSchema,
+  folioCollabSessionNotFoundError,
+} from "./session-credentials";
 
 const config = {
   mcp: { type: "internal", reason: "session_token_exchange" },
-  body: t.Object({
-    sessionId: tSafeId("folioCollabSession"),
-    snapshotBase64: t.String({
-      maxLength: FOLIO_COLLAB_SNAPSHOT_MAX_BASE64_LENGTH,
-    }),
-    token: t.String({ minLength: 64, maxLength: 64 }),
+  body: permissiveBodySchema({
+    keys: ["sessionId", "snapshotBase64", "token"],
   }),
 } satisfies TokenHandlerConfig;
+
+/** Validated after authorization; see `permissive-route-schema.ts`. */
+const strictBodySchema = t.Object({
+  snapshotBase64: t.String({
+    maxLength: FOLIO_COLLAB_SNAPSHOT_MAX_BASE64_LENGTH,
+  }),
+});
 
 const storeFolioCollabSnapshotHandler = createSafeTokenHandler(
   config,
   // eslint-disable-next-line require-yield -- token auth returns a plain Promise; nothing to Result.await
-  async function* ({ body: { sessionId, snapshotBase64, token } }) {
+  async function* ({ body }) {
+    const credentials = validatePostAuth(
+      folioCollabSessionCredentialsSchema,
+      body,
+    );
+    if (!credentials.ok) {
+      return Result.err(folioCollabSessionNotFoundError());
+    }
+    const { sessionId, token } = credentials.value;
+
     const authorized = await authorizeFolioCollabSession({ sessionId, token });
 
     if (authorized.status === "missing") {
-      return Result.err(
-        new HandlerError({
-          status: 404,
-          message: "Collaborative edit session not found.",
-        }),
-      );
+      return Result.err(folioCollabSessionNotFoundError());
     }
     if (authorized.status === "token-expired") {
       return Result.err(
@@ -63,6 +78,14 @@ const storeFolioCollabSnapshotHandler = createSafeTokenHandler(
         }),
       );
     }
+
+    const validatedBody = validatePostAuth(strictBodySchema, body);
+    if (!validatedBody.ok) {
+      return Result.err(
+        new HandlerError({ status: 422, message: validatedBody.message }),
+      );
+    }
+    const { snapshotBase64 } = validatedBody.value;
 
     const snapshotBytes = Buffer.from(snapshotBase64, "base64");
     if (snapshotBytes.byteLength > FOLIO_COLLAB_SNAPSHOT_MAX_BYTES) {

--- a/apps/api/src/handlers/folio-collab/snapshot-store.ts
+++ b/apps/api/src/handlers/folio-collab/snapshot-store.ts
@@ -5,7 +5,6 @@ import type { TokenHandlerConfig } from "@/api/lib/api-handlers";
 import { createSafeTokenHandler } from "@/api/lib/api-handlers";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import {
-  authorizeFolioCollabSession,
   FOLIO_COLLAB_SNAPSHOT_MAX_BASE64_LENGTH,
   FOLIO_COLLAB_SNAPSHOT_MAX_BYTES,
   storeFolioCollabSnapshot,
@@ -15,10 +14,7 @@ import {
   validatePostAuth,
 } from "@/api/lib/permissive-route-schema";
 
-import {
-  folioCollabSessionCredentialsSchema,
-  folioCollabSessionNotFoundError,
-} from "./session-credentials";
+import { authorizeFolioCollabCredentials } from "./session-credentials";
 
 const config = {
   mcp: { type: "internal", reason: "session_token_exchange" },
@@ -36,40 +32,10 @@ const strictBodySchema = t.Object({
 
 const storeFolioCollabSnapshotHandler = createSafeTokenHandler(
   config,
-  // eslint-disable-next-line require-yield -- token auth returns a plain Promise; nothing to Result.await
   async function* ({ body }) {
-    const credentials = validatePostAuth(
-      folioCollabSessionCredentialsSchema,
-      body,
+    const { session: value } = yield* Result.await(
+      authorizeFolioCollabCredentials(body),
     );
-    if (!credentials.ok) {
-      return Result.err(folioCollabSessionNotFoundError());
-    }
-    const { sessionId, token } = credentials.value;
-
-    const authorized = await authorizeFolioCollabSession({ sessionId, token });
-
-    if (authorized.status === "missing") {
-      return Result.err(folioCollabSessionNotFoundError());
-    }
-    if (authorized.status === "token-expired") {
-      return Result.err(
-        new HandlerError({
-          status: 401,
-          message: "Collaborative edit token expired.",
-        }),
-      );
-    }
-    if (authorized.status === "permission-revoked") {
-      return Result.err(
-        new HandlerError({
-          status: 403,
-          message: "Collaborative edit permission revoked.",
-        }),
-      );
-    }
-
-    const { value } = authorized;
     if (!value.canEdit) {
       return Result.err(
         new HandlerError({

--- a/apps/api/src/handlers/folio-collab/validation-order.test.ts
+++ b/apps/api/src/handlers/folio-collab/validation-order.test.ts
@@ -78,6 +78,12 @@ describe("folio-collab probes with malformed bodies never see validation errors"
       await expectAuthShapedNotFound(
         jsonRequest(path, { sessionId: true, token: {} }),
       );
+      // Non-object JSON roots must also reach the handler. An object-only
+      // route schema would reject these before credential authorization.
+      await expectAuthShapedNotFound(jsonRequest(path, null));
+      await expectAuthShapedNotFound(jsonRequest(path, []));
+      await expectAuthShapedNotFound(jsonRequest(path, 0));
+      await expectAuthShapedNotFound(jsonRequest(path, "probe"));
       // Unknown extra keys alongside malformed credentials.
       await expectAuthShapedNotFound(
         jsonRequest(path, { token: "x", probe: "1", admin: "true" }),
@@ -111,6 +117,10 @@ describe("folio-collab probes with malformed bodies never see validation errors"
       await expectAuthShapedNotFound(jsonRequest(path, { token: "short" }));
       await expectAuthShapedNotFound(jsonRequest(path, { token: 0 }));
       await expectAuthShapedNotFound(jsonRequest(path, { token: [] }));
+      await expectAuthShapedNotFound(jsonRequest(path, null));
+      await expectAuthShapedNotFound(jsonRequest(path, []));
+      await expectAuthShapedNotFound(jsonRequest(path, 0));
+      await expectAuthShapedNotFound(jsonRequest(path, "probe"));
     },
   );
 

--- a/apps/api/src/handlers/folio-collab/validation-order.test.ts
+++ b/apps/api/src/handlers/folio-collab/validation-order.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, test } from "bun:test";
+import Elysia from "elysia";
+
+import { folioCollabRoute } from "@/api/handlers/folio-collab/routes";
+
+// The folio-collab session endpoints authorize themselves from a
+// caller-supplied credential pair (sessionId + token). Their route schemas
+// are deliberately permissive, so framework validation can never answer a
+// probe before the handler's own credential check: a request with malformed
+// credentials must be byte-identical to one with unknown credentials (404),
+// never a 422 that leaks parameter shape. These tests never present a
+// well-formed credential pair, so no request reaches the database.
+
+const app = new Elysia().use(folioCollabRoute);
+
+const VALID_UUID = "0198c0de-0000-4000-8000-000000000000";
+const WELL_FORMED_TOKEN = "a".repeat(64);
+
+const NOT_FOUND_BODY = { message: "Collaborative edit session not found." };
+
+const jsonRequest = (path: string, body: unknown): Request =>
+  new Request(`http://localhost${path}`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+
+const expectAuthShapedNotFound = async (request: Request) => {
+  const response = await app.handle(request);
+  expect(response.status).toBe(404);
+  // The handler's own auth failure, not an Elysia validation error
+  // (which would carry `type: "validation"` and the schema summary).
+  expect(await response.json()).toEqual(NOT_FOUND_BODY);
+};
+
+const bodyCredentialPaths = [
+  "/folio-collab-sessions/authorize",
+  "/folio-collab-sessions/refresh-token",
+  "/folio-collab-sessions/snapshot/load",
+  "/folio-collab-sessions/snapshot/store",
+];
+
+const paramCredentialPaths = [
+  `/folio-collab-sessions/${VALID_UUID}/cancel`,
+  `/folio-collab-sessions/${VALID_UUID}/checkpoint`,
+  `/folio-collab-sessions/${VALID_UUID}/finalize`,
+];
+
+const garbageParamPaths = [
+  "/folio-collab-sessions/not-a-uuid/cancel",
+  "/folio-collab-sessions/not-a-uuid/checkpoint",
+  "/folio-collab-sessions/not-a-uuid/finalize",
+];
+
+describe("folio-collab probes with malformed bodies never see validation errors", () => {
+  test.each(bodyCredentialPaths)(
+    "POST %s: malformed credential bodies answer 404, not 422",
+    async (path) => {
+      // No body at all.
+      await expectAuthShapedNotFound(
+        new Request(`http://localhost${path}`, { method: "POST" }),
+      );
+      // Empty object: credentials absent.
+      await expectAuthShapedNotFound(jsonRequest(path, {}));
+      // Token of the wrong length.
+      await expectAuthShapedNotFound(
+        jsonRequest(path, { sessionId: VALID_UUID, token: "short" }),
+      );
+      // Session id that is not even a UUID.
+      await expectAuthShapedNotFound(
+        jsonRequest(path, { sessionId: "garbage", token: WELL_FORMED_TOKEN }),
+      );
+      // Unknown extra keys alongside malformed credentials.
+      await expectAuthShapedNotFound(
+        jsonRequest(path, { token: "x", probe: "1", admin: "true" }),
+      );
+      // Unparseable JSON.
+      await expectAuthShapedNotFound(
+        new Request(`http://localhost${path}`, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: "{not json",
+        }),
+      );
+      // Non-JSON content type.
+      await expectAuthShapedNotFound(
+        new Request(`http://localhost${path}`, {
+          method: "POST",
+          headers: { "content-type": "text/plain" },
+          body: "garbage",
+        }),
+      );
+    },
+  );
+
+  test.each(paramCredentialPaths)(
+    "POST %s: malformed token bodies answer 404, not 422",
+    async (path) => {
+      await expectAuthShapedNotFound(
+        new Request(`http://localhost${path}`, { method: "POST" }),
+      );
+      await expectAuthShapedNotFound(jsonRequest(path, {}));
+      await expectAuthShapedNotFound(jsonRequest(path, { token: "short" }));
+    },
+  );
+
+  test.each(garbageParamPaths)(
+    "POST %s: a non-UUID session id in the path answers 404, not 422",
+    async (path) => {
+      await expectAuthShapedNotFound(
+        jsonRequest(path, { token: WELL_FORMED_TOKEN }),
+      );
+    },
+  );
+
+  test("checkpoint: a multipart probe without a valid token answers 404 before any file handling", async () => {
+    const form = new FormData();
+    form.append("token", "short");
+    form.append(
+      "file",
+      new File([new Uint8Array([0x50, 0x4b])], "probe.docx", {
+        type: "application/zip",
+      }),
+    );
+    await expectAuthShapedNotFound(
+      new Request(
+        `http://localhost/folio-collab-sessions/${VALID_UUID}/checkpoint`,
+        { method: "POST", body: form },
+      ),
+    );
+  });
+});

--- a/apps/api/src/handlers/folio-collab/validation-order.test.ts
+++ b/apps/api/src/handlers/folio-collab/validation-order.test.ts
@@ -70,6 +70,14 @@ describe("folio-collab probes with malformed bodies never see validation errors"
       await expectAuthShapedNotFound(
         jsonRequest(path, { sessionId: "garbage", token: WELL_FORMED_TOKEN }),
       );
+      // Non-string JSON values must reach the handler too; otherwise the
+      // permissive route schema itself leaks a 422 before authorization.
+      await expectAuthShapedNotFound(
+        jsonRequest(path, { sessionId: [], token: 0 }),
+      );
+      await expectAuthShapedNotFound(
+        jsonRequest(path, { sessionId: true, token: {} }),
+      );
       // Unknown extra keys alongside malformed credentials.
       await expectAuthShapedNotFound(
         jsonRequest(path, { token: "x", probe: "1", admin: "true" }),
@@ -101,6 +109,8 @@ describe("folio-collab probes with malformed bodies never see validation errors"
       );
       await expectAuthShapedNotFound(jsonRequest(path, {}));
       await expectAuthShapedNotFound(jsonRequest(path, { token: "short" }));
+      await expectAuthShapedNotFound(jsonRequest(path, { token: 0 }));
+      await expectAuthShapedNotFound(jsonRequest(path, { token: [] }));
     },
   );
 

--- a/apps/api/src/handlers/operator/query.ts
+++ b/apps/api/src/handlers/operator/query.ts
@@ -1,7 +1,6 @@
 import { Result } from "better-result";
 import type { SQL } from "drizzle-orm";
 import { and, asc, gte } from "drizzle-orm";
-import { t } from "elysia";
 import type { Static } from "elysia";
 import { timingSafeEqual } from "node:crypto";
 
@@ -13,6 +12,7 @@ import type { SafeDb } from "@/api/db/safe-db";
 import { createTimestampIdCursorCodec } from "@/api/lib/db-pagination";
 import { LIMITS } from "@/api/lib/limits";
 import { createCursorPage } from "@/api/lib/pagination";
+import { permissiveRouteSchema } from "@/api/lib/permissive-route-schema";
 import { brandPersistedUserId } from "@/api/lib/safe-id-boundaries";
 
 /**
@@ -39,12 +39,11 @@ const registrationCursor = createTimestampIdCursorCodec({
  * before the handler's token gate runs, so a strict schema would emit 422s
  * to unauthenticated probes — leaking both the endpoint's existence (which
  * must read as 404 while unconfigured) and its parameter shape. All real
- * validation happens post-authorization in `validateRegistrationsFilter`.
+ * validation happens post-authorization in `validateRegistrationsFilter`;
+ * the branded helper is the only schema shape `TokenHandlerConfig` accepts.
  */
-export const readRegistrationsQuerySchema = t.Object({
-  since: t.Optional(t.String()),
-  limit: t.Optional(t.String()),
-  cursor: t.Optional(t.String()),
+export const readRegistrationsQuerySchema = permissiveRouteSchema({
+  keys: ["since", "limit", "cursor"],
 });
 
 export type ReadRegistrationsQuery = Static<

--- a/apps/api/src/handlers/operator/read-registrations.test.ts
+++ b/apps/api/src/handlers/operator/read-registrations.test.ts
@@ -101,6 +101,20 @@ describe("GET /operator/registrations", () => {
     expect(response.status).toBe(401);
   });
 
+  test("unknown query parameters on a probe never yield validation errors", async () => {
+    const unconfigured = buildApp({ configuredToken: undefined });
+    const unconfiguredResponse = await unconfigured.handle(
+      registrationsRequest({ probe: "1", admin: "true" }),
+    );
+    expect(unconfiguredResponse.status).toBe(404);
+
+    const configured = buildApp({ configuredToken: TOKEN });
+    const configuredResponse = await configured.handle(
+      registrationsRequest({ probe: "1", admin: "true" }),
+    );
+    expect(configuredResponse.status).toBe(401);
+  });
+
   test("400 when since is missing on an authorized request", async () => {
     const app = buildApp({ configuredToken: TOKEN });
     const response = await app.handle(

--- a/apps/api/src/lib/api-handlers.ts
+++ b/apps/api/src/lib/api-handlers.ts
@@ -38,6 +38,7 @@ import {
 import { logger } from "@/api/lib/observability/logger";
 import { getRequestContext } from "@/api/lib/observability/request-context";
 import { hasMemberPermission } from "@/api/lib/permission-authorization";
+import type { AnyPermissiveRouteSchema } from "@/api/lib/permissive-route-schema";
 import {
   getTanStackTextModelInfoForRole,
   resolveEffectiveServiceTierForProvider,
@@ -815,7 +816,22 @@ export const createSafeSessionHandler = <
 ): SafeHandlerDefinition<TConfig, SessionHandlerContext<TConfig>, TResult> =>
   createSafeDirectHandler(config, handler);
 
-export type TokenHandlerConfig = InputSchema & {
+/**
+ * Config for self-authorizing (token) routes. The `body`, `query`, and
+ * `params` slots only accept the branded permissive schemas from
+ * `permissive-route-schema.ts`: Elysia runs route-schema validation before
+ * the handler's own credential check, so a strict schema here would answer
+ * unauthenticated probes with 422s that leak endpoint existence and
+ * parameter shape. Handlers declare their strict schema separately and
+ * apply it after authorization via `validatePostAuth`.
+ */
+export type TokenHandlerConfig = Omit<
+  InputSchema,
+  "body" | "query" | "params"
+> & {
+  body?: AnyPermissiveRouteSchema;
+  query?: AnyPermissiveRouteSchema;
+  params?: AnyPermissiveRouteSchema;
   mcp: McpExposure;
 };
 

--- a/apps/api/src/lib/permissive-route-schema.ts
+++ b/apps/api/src/lib/permissive-route-schema.ts
@@ -1,0 +1,158 @@
+import type { TOptional, TSchema, TUnsafe } from "@sinclair/typebox";
+import { Value } from "@sinclair/typebox/value";
+import type { Static } from "elysia";
+import { t } from "elysia";
+
+/**
+ * Route schemas for self-authorizing (token) routes.
+ *
+ * Elysia validates route schemas before the handler runs. On a route that
+ * authorizes itself from a caller-supplied credential, a strict route schema
+ * therefore answers unauthenticated probes with 422 validation errors,
+ * leaking the endpoint's existence (breaking 404-when-unconfigured
+ * semantics) and its parameter shape. The contract enforced here:
+ *
+ * 1. The route schema is *permissive*: every declared property is an
+ *    optional plain string and unknown properties pass through untouched,
+ *    so framework validation cannot reject a request before the handler's
+ *    own credential check runs.
+ * 2. The handler declares its strict schema separately and applies it via
+ *    {@link validatePostAuth} only after authorization has succeeded.
+ *
+ * `TokenHandlerConfig` only accepts the branded schema types produced by
+ * the factories below, so attaching a hand-built strict schema to a token
+ * route is a compile error; the runtime marker makes a cast visible to the
+ * token-route meta-test in `tests/security`.
+ */
+
+declare const permissiveRouteSchemaBrand: unique symbol;
+
+type PermissiveBrand = { readonly [permissiveRouteSchemaBrand]: true };
+
+/**
+ * Runtime counterpart of the compile-time brand. The factories stamp this
+ * symbol on every schema they produce; the token-route meta-test asserts it
+ * on each `createSafeTokenHandler` config, so bypassing the type with a
+ * cast still fails a test.
+ */
+export const PERMISSIVE_ROUTE_SCHEMA_MARKER: unique symbol = Symbol.for(
+  "stella.permissiveRouteSchema",
+);
+
+type PermissiveStatic<TKeys extends string> = Partial<Record<TKeys, string>>;
+
+/**
+ * Permissive schema for the `query` and `params` slots of a token route.
+ * These slots always materialize as an object at runtime, so no optional
+ * wrapper is needed.
+ */
+export type PermissiveRouteSchema<TKeys extends string = never> = TUnsafe<
+  PermissiveStatic<TKeys>
+> &
+  PermissiveBrand;
+
+/**
+ * Permissive schema for the `body` slot of a token route. Optional at the
+ * root so a probe with no body (or an unparseable one) reaches the handler
+ * instead of failing framework validation.
+ */
+export type PermissiveBodySchema<TKeys extends string = never> = TOptional<
+  TUnsafe<PermissiveStatic<TKeys>>
+> &
+  PermissiveBrand;
+
+/**
+ * Any schema a token-route config slot accepts: produced by one of the
+ * factories in this module, never hand-built.
+ */
+export type AnyPermissiveRouteSchema = TSchema & PermissiveBrand;
+
+type PermissiveRouteSchemaOptions<TKeys extends readonly string[]> = {
+  /**
+   * Property names the handler reads (typed `string | undefined`).
+   * Properties outside this list still pass validation; the handler's
+   * post-auth strict schema is the only authority on shape.
+   */
+  keys: TKeys;
+};
+
+const buildPermissiveObject = (keys: readonly string[]) => {
+  const properties: Record<string, TSchema> = {};
+  for (const key of keys) {
+    properties[key] = t.Optional(t.String());
+  }
+  // additionalProperties: true keeps Elysia's normalization from stripping
+  // undeclared fields (e.g. a multipart file part), so the handler can
+  // validate them post-auth.
+  return t.Object(properties, { additionalProperties: true });
+};
+
+const stampMarker = (schema: TSchema) => {
+  Object.defineProperty(schema, PERMISSIVE_ROUTE_SCHEMA_MARKER, {
+    value: true,
+  });
+};
+
+/**
+ * Permissive schema for a token route's `query` or `params` slot: every
+ * listed key is an optional plain string, everything else passes through.
+ */
+export const permissiveRouteSchema = <const TKeys extends readonly string[]>({
+  keys,
+}: PermissiveRouteSchemaOptions<TKeys>): PermissiveRouteSchema<
+  TKeys[number]
+> => {
+  const schema = buildPermissiveObject(keys);
+  stampMarker(schema);
+  // SAFETY: the brand exists only at the type level; this is its single
+  // construction point and the runtime object is exactly the permissive
+  // t.Object the type describes (every property TOptional<TString>).
+  // eslint-disable-next-line typescript/no-unsafe-type-assertion -- see SAFETY above
+  return schema as unknown as PermissiveRouteSchema<TKeys[number]>;
+};
+
+/**
+ * Permissive schema for a token route's `body` slot. Root-optional so a
+ * missing or unparseable body cannot produce a framework validation error;
+ * the handler sees `null`/`undefined` and fails its own credential check
+ * instead.
+ */
+export const permissiveBodySchema = <const TKeys extends readonly string[]>({
+  keys,
+}: PermissiveRouteSchemaOptions<TKeys>): PermissiveBodySchema<
+  TKeys[number]
+> => {
+  const schema = t.Optional(buildPermissiveObject(keys));
+  stampMarker(schema);
+  // SAFETY: same single-construction-point brand cast as
+  // permissiveRouteSchema; the runtime object is the optional-wrapped
+  // permissive t.Object the type describes.
+  // eslint-disable-next-line typescript/no-unsafe-type-assertion -- see SAFETY above
+  return schema as unknown as PermissiveBodySchema<TKeys[number]>;
+};
+
+export type PostAuthValidation<TStrict extends TSchema> =
+  | { ok: true; value: Static<TStrict> }
+  | { ok: false; message: string };
+
+/**
+ * Applies a token route's strict schema to the raw (permissively routed)
+ * value. Call this only after the handler's credential check has passed;
+ * for credential fields themselves, a failure must map to the same
+ * response as an unknown credential so malformed and unknown credentials
+ * stay indistinguishable.
+ */
+export const validatePostAuth = <TStrict extends TSchema>(
+  strictSchema: TStrict,
+  rawValue: unknown,
+): PostAuthValidation<TStrict> => {
+  if (Value.Check(strictSchema, rawValue)) {
+    return { ok: true, value: rawValue };
+  }
+  const firstError = Value.Errors(strictSchema, rawValue).First();
+  if (!firstError) {
+    return { ok: false, message: "Invalid request" };
+  }
+  const path = firstError.path === "" ? "value" : firstError.path;
+  return { ok: false, message: `${path}: ${firstError.message}` };
+};

--- a/apps/api/src/lib/permissive-route-schema.ts
+++ b/apps/api/src/lib/permissive-route-schema.ts
@@ -13,10 +13,10 @@ import { t } from "elysia";
  * leaking the endpoint's existence (breaking 404-when-unconfigured
  * semantics) and its parameter shape. The contract enforced here:
  *
- * 1. The route schema is *permissive*: every declared property is an
- *    optional plain string and unknown properties pass through untouched,
- *    so framework validation cannot reject a request before the handler's
- *    own credential check runs.
+ * 1. The route schema is *permissive*: query/param properties are optional
+ *    plain strings, while bodies accept any root value, so framework
+ *    validation cannot reject a request before the handler's own credential
+ *    check runs.
  * 2. The handler declares its strict schema separately and applies it via
  *    {@link validatePostAuth} only after authorization has succeeded.
  *
@@ -101,17 +101,6 @@ const buildPermissiveObject = (keys: readonly string[]) => {
   return t.Object(properties, { additionalProperties: true });
 };
 
-const buildPermissiveBodyObject = (keys: readonly string[]) => {
-  const properties: Record<string, TSchema> = {};
-  for (const key of keys) {
-    // Body credential fields must accept every JSON value here. Their real
-    // types are checked by the handler after authorization; using t.String()
-    // would let arrays, numbers, or booleans trigger a pre-auth 422.
-    properties[key] = t.Optional(t.Any());
-  }
-  return t.Object(properties, { additionalProperties: true });
-};
-
 /**
  * Permissive schema for a token route's `query` or `params` slot: every
  * listed key is an optional plain string, everything else passes through.
@@ -125,22 +114,22 @@ export const permissiveRouteSchema = <const TKeys extends readonly string[]>({
   );
 
 /**
- * Permissive schema for a token route's `body` slot. Root-optional so a
- * missing or unparseable body cannot produce a framework validation error;
- * the handler sees `null`/`undefined` and fails its own credential check
- * instead.
+ * Permissive schema for a token route's `body` slot. The runtime schema
+ * accepts every root value so missing, malformed, or non-object probes cannot
+ * produce a framework validation error. The unsafe static type still exposes
+ * only the fields each handler reads; strict shape checks happen post-auth.
  */
 export const permissiveBodySchema = <
   const TStringKeys extends readonly string[],
   const TPassthroughKeys extends readonly string[] = [],
 >(
-  options: PermissiveRouteSchemaOptions<TStringKeys, TPassthroughKeys>,
+  _options: PermissiveRouteSchemaOptions<TStringKeys, TPassthroughKeys>,
 ): PermissiveBodySchema<TStringKeys[number], TPassthroughKeys[number]> =>
   Object.assign(
     t.Optional(
       Type.Unsafe<
         PermissiveBodyStatic<TStringKeys[number] | TPassthroughKeys[number]>
-      >(buildPermissiveBodyObject(options.keys)),
+      >(t.Any()),
     ),
     { [PERMISSIVE_ROUTE_SCHEMA_MARKER]: true } satisfies PermissiveBrand,
   );

--- a/apps/api/src/lib/permissive-route-schema.ts
+++ b/apps/api/src/lib/permissive-route-schema.ts
@@ -1,4 +1,5 @@
 import type { TOptional, TSchema, TUnsafe } from "@sinclair/typebox";
+import { Type } from "@sinclair/typebox";
 import { Value } from "@sinclair/typebox/value";
 import type { Static } from "elysia";
 import { t } from "elysia";
@@ -25,10 +26,6 @@ import { t } from "elysia";
  * token-route meta-test in `tests/security`.
  */
 
-declare const permissiveRouteSchemaBrand: unique symbol;
-
-type PermissiveBrand = { readonly [permissiveRouteSchemaBrand]: true };
-
 /**
  * Runtime counterpart of the compile-time brand. The factories stamp this
  * symbol on every schema they produce; the token-route meta-test asserts it
@@ -39,7 +36,15 @@ export const PERMISSIVE_ROUTE_SCHEMA_MARKER: unique symbol = Symbol.for(
   "stella.permissiveRouteSchema",
 );
 
+type PermissiveBrand = {
+  readonly [PERMISSIVE_ROUTE_SCHEMA_MARKER]: true;
+};
+
 type PermissiveStatic<TKeys extends string> = Partial<Record<TKeys, string>>;
+
+type PermissiveBodyStatic<TKeys extends string> = Partial<
+  Record<TKeys, unknown>
+>;
 
 /**
  * Permissive schema for the `query` and `params` slots of a token route.
@@ -56,9 +61,10 @@ export type PermissiveRouteSchema<TKeys extends string = never> = TUnsafe<
  * root so a probe with no body (or an unparseable one) reaches the handler
  * instead of failing framework validation.
  */
-export type PermissiveBodySchema<TKeys extends string = never> = TOptional<
-  TUnsafe<PermissiveStatic<TKeys>>
-> &
+export type PermissiveBodySchema<
+  TStringKeys extends string = never,
+  TPassthroughKeys extends string = never,
+> = TOptional<TUnsafe<PermissiveBodyStatic<TStringKeys | TPassthroughKeys>>> &
   PermissiveBrand;
 
 /**
@@ -67,13 +73,21 @@ export type PermissiveBodySchema<TKeys extends string = never> = TOptional<
  */
 export type AnyPermissiveRouteSchema = TSchema & PermissiveBrand;
 
-type PermissiveRouteSchemaOptions<TKeys extends readonly string[]> = {
+type PermissiveRouteSchemaOptions<
+  TStringKeys extends readonly string[],
+  TPassthroughKeys extends readonly string[] = [],
+> = {
   /**
    * Property names the handler reads (typed `string | undefined`).
    * Properties outside this list still pass validation; the handler's
    * post-auth strict schema is the only authority on shape.
    */
-  keys: TKeys;
+  keys: TStringKeys;
+  /**
+   * Non-string fields the generated client must accept without validating
+   * before authorization (for example, a multipart file part).
+   */
+  passthroughKeys?: TPassthroughKeys;
 };
 
 const buildPermissiveObject = (keys: readonly string[]) => {
@@ -87,10 +101,15 @@ const buildPermissiveObject = (keys: readonly string[]) => {
   return t.Object(properties, { additionalProperties: true });
 };
 
-const stampMarker = (schema: TSchema) => {
-  Object.defineProperty(schema, PERMISSIVE_ROUTE_SCHEMA_MARKER, {
-    value: true,
-  });
+const buildPermissiveBodyObject = (keys: readonly string[]) => {
+  const properties: Record<string, TSchema> = {};
+  for (const key of keys) {
+    // Body credential fields must accept every JSON value here. Their real
+    // types are checked by the handler after authorization; using t.String()
+    // would let arrays, numbers, or booleans trigger a pre-auth 422.
+    properties[key] = t.Optional(t.Any());
+  }
+  return t.Object(properties, { additionalProperties: true });
 };
 
 /**
@@ -99,17 +118,11 @@ const stampMarker = (schema: TSchema) => {
  */
 export const permissiveRouteSchema = <const TKeys extends readonly string[]>({
   keys,
-}: PermissiveRouteSchemaOptions<TKeys>): PermissiveRouteSchema<
-  TKeys[number]
-> => {
-  const schema = buildPermissiveObject(keys);
-  stampMarker(schema);
-  // SAFETY: the brand exists only at the type level; this is its single
-  // construction point and the runtime object is exactly the permissive
-  // t.Object the type describes (every property TOptional<TString>).
-  // eslint-disable-next-line typescript/no-unsafe-type-assertion -- see SAFETY above
-  return schema as unknown as PermissiveRouteSchema<TKeys[number]>;
-};
+}: PermissiveRouteSchemaOptions<TKeys>): PermissiveRouteSchema<TKeys[number]> =>
+  Object.assign(
+    Type.Unsafe<PermissiveStatic<TKeys[number]>>(buildPermissiveObject(keys)),
+    { [PERMISSIVE_ROUTE_SCHEMA_MARKER]: true } satisfies PermissiveBrand,
+  );
 
 /**
  * Permissive schema for a token route's `body` slot. Root-optional so a
@@ -117,19 +130,20 @@ export const permissiveRouteSchema = <const TKeys extends readonly string[]>({
  * the handler sees `null`/`undefined` and fails its own credential check
  * instead.
  */
-export const permissiveBodySchema = <const TKeys extends readonly string[]>({
-  keys,
-}: PermissiveRouteSchemaOptions<TKeys>): PermissiveBodySchema<
-  TKeys[number]
-> => {
-  const schema = t.Optional(buildPermissiveObject(keys));
-  stampMarker(schema);
-  // SAFETY: same single-construction-point brand cast as
-  // permissiveRouteSchema; the runtime object is the optional-wrapped
-  // permissive t.Object the type describes.
-  // eslint-disable-next-line typescript/no-unsafe-type-assertion -- see SAFETY above
-  return schema as unknown as PermissiveBodySchema<TKeys[number]>;
-};
+export const permissiveBodySchema = <
+  const TStringKeys extends readonly string[],
+  const TPassthroughKeys extends readonly string[] = [],
+>(
+  options: PermissiveRouteSchemaOptions<TStringKeys, TPassthroughKeys>,
+): PermissiveBodySchema<TStringKeys[number], TPassthroughKeys[number]> =>
+  Object.assign(
+    t.Optional(
+      Type.Unsafe<
+        PermissiveBodyStatic<TStringKeys[number] | TPassthroughKeys[number]>
+      >(buildPermissiveBodyObject(options.keys)),
+    ),
+    { [PERMISSIVE_ROUTE_SCHEMA_MARKER]: true } satisfies PermissiveBrand,
+  );
 
 export type PostAuthValidation<TStrict extends TSchema> =
   | { ok: true; value: Static<TStrict> }
@@ -141,6 +155,10 @@ export type PostAuthValidation<TStrict extends TSchema> =
  * for credential fields themselves, a failure must map to the same
  * response as an unknown credential so malformed and unknown credentials
  * stay indistinguishable.
+ *
+ * `Value.Check` does not perform Elysia's route-level coercion. Callers whose
+ * strict schemas expect numbers or booleans from query, params, or headers
+ * must normalize those string inputs explicitly before validating them.
  */
 export const validatePostAuth = <TStrict extends TSchema>(
   strictSchema: TStrict,

--- a/apps/api/src/tests/security/token-route-validation.test.ts
+++ b/apps/api/src/tests/security/token-route-validation.test.ts
@@ -1,0 +1,112 @@
+import { OptionalKind } from "@sinclair/typebox";
+import { describe, expect, test } from "bun:test";
+import { readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+import { PERMISSIVE_ROUTE_SCHEMA_MARKER } from "@/api/lib/permissive-route-schema";
+
+// Meta-test: routes built with `createSafeTokenHandler` authorize themselves
+// from a caller-supplied credential, so Elysia's route-schema validation must
+// never be able to answer a request before the handler's credential check
+// runs. `TokenHandlerConfig` enforces at the type level that the `body`,
+// `query`, and `params` slots only accept the branded permissive schemas from
+// `permissive-route-schema.ts`; this test enforces the same invariant at
+// runtime via the marker symbol those factories stamp, so a type-level bypass
+// (a cast) is still a visible failure. It enumerates handler modules from the
+// filesystem (like `cross-tenant-coverage.test.ts` enumerates domains), so a
+// new token route is covered the moment it lands.
+
+const handlersDir = path.resolve(import.meta.dir, "../../handlers");
+
+/** Recursively collect handler source files that use the token factory. */
+const collectTokenHandlerFiles = (dir: string): string[] => {
+  const files: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const entryPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...collectTokenHandlerFiles(entryPath));
+      continue;
+    }
+    if (!entry.name.endsWith(".ts") || entry.name.endsWith(".test.ts")) {
+      continue;
+    }
+    // Bare identifier, not `createSafeTokenHandler(`: explicit type
+    // arguments (`createSafeTokenHandler<...>(...)`) must match too.
+    if (readFileSync(entryPath, "utf-8").includes("createSafeTokenHandler")) {
+      files.push(entryPath);
+    }
+  }
+  return files.sort();
+};
+
+const tokenHandlerFiles = collectTokenHandlerFiles(handlersDir);
+
+const VALIDATED_SLOTS = ["body", "query", "params"] as const;
+
+type EndpointLike = {
+  config: Record<string, unknown>;
+  handler: unknown;
+};
+
+const isEndpointLike = (value: unknown): value is EndpointLike =>
+  typeof value === "object" &&
+  value !== null &&
+  "config" in value &&
+  typeof Reflect.get(value, "config") === "object" &&
+  Reflect.get(value, "config") !== null &&
+  "handler" in value &&
+  typeof Reflect.get(value, "handler") === "function";
+
+const endpointsOf = (module: Record<string, unknown>): EndpointLike[] =>
+  Object.values(module).filter(isEndpointLike);
+
+/** Reads a symbol property off a schema value without asserting its type. */
+const symbolPropertyOf = (schema: unknown, symbol: symbol): unknown =>
+  typeof schema === "object" && schema !== null
+    ? Reflect.get(schema, symbol)
+    : undefined;
+
+describe("token-route validation order guard", () => {
+  test("the filesystem scan finds the known token-route modules", () => {
+    // Anchors prove the source-text heuristic still matches reality; if the
+    // factory is renamed, this test must be updated alongside it.
+    expect(tokenHandlerFiles).toContainEqual(
+      path.join(handlersDir, "operator/read-registrations.ts"),
+    );
+    expect(tokenHandlerFiles).toContainEqual(
+      path.join(handlersDir, "folio-collab/authorize.ts"),
+    );
+  });
+
+  test.each(tokenHandlerFiles)(
+    "%s only attaches branded permissive route schemas",
+    async (file) => {
+      const module: Record<string, unknown> = await import(file);
+      const endpoints = endpointsOf(module);
+      // Every module using the factory must export the endpoint it builds;
+      // an unexported endpoint cannot be wired into a route anyway.
+      expect(endpoints.length).toBeGreaterThan(0);
+
+      for (const endpoint of endpoints) {
+        for (const slot of VALIDATED_SLOTS) {
+          const schema = endpoint.config[slot];
+          if (schema === undefined) {
+            continue;
+          }
+          // The runtime marker only exists on schemas built by the
+          // permissive-route-schema factories; a hand-built or casted strict
+          // schema fails here even though it may have satisfied the types.
+          expect(symbolPropertyOf(schema, PERMISSIVE_ROUTE_SCHEMA_MARKER)).toBe(
+            true,
+          );
+        }
+        const bodySchema = endpoint.config["body"];
+        if (bodySchema !== undefined) {
+          // Body schemas must be root-optional so a body-less probe cannot
+          // produce a framework validation error either.
+          expect(symbolPropertyOf(bodySchema, OptionalKind)).toBe("Optional");
+        }
+      }
+    },
+  );
+});


### PR DESCRIPTION
Routes that authorize themselves from a caller-supplied credential must never let framework schema validation answer before the credential check: a strict route schema turns unauthenticated malformed probes into 422s that reveal the endpoint's existence and parameter shape.

This makes the mistake structurally impossible rather than individually fixed:
- `TokenHandlerConfig`'s `query`/`body`/`params` slots now only accept **branded permissive schemas** from `permissiveRouteSchema`/`permissiveBodySchema` (all-optional-string shapes; a hand-built strict schema is a compile error). Strict validation runs post-auth via `validatePostAuth` (TypeBox `Value`).
- All 8 token-route handlers (folio-collab ×7, operator) migrated. Valid-request behavior is byte-identical; malformed-credential probes now receive the same 404/403 envelope as unknown credentials instead of validation detail (full status-change table in the first commit body).
- A security meta-test enumerates every `createSafeTokenHandler` call site and asserts the brand (runtime marker) on all attached schemas, with anchor tests pinning the known domains — a future token route with a strict schema fails CI even if types are cast around.
- 21 new probe/meta tests; 460 tests green across the touched suites.

Known residual (deliberate, flagged for review): a JSON body probe sending a declared key with a non-string type still gets a framework 422 — it no longer reveals constraints or required-ness, and closing it fully would require schemas whose static type lies about their runtime shape. Two `SAFETY`-commented brand casts exist at the schema constructors (branding is unimplementable without them).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security & Access**
  * Authorisation for collaborative editing endpoints is now consistently delegated to credential checks, with consistent not-found responses for malformed or incomplete credentials.
* **Validation**
  * Token-route requests use permissive pre-auth schemas, with strict validation applied only after successful authentication/authorisation (including uploads and snapshot payloads).
  * Operator query validation is made permissive to avoid premature framework validation for unauthenticated probes.
* **Tests**
  * Added suites to ensure validation order and token-route schema invariants are enforced, plus additional coverage for malformed credentials, JSON, query parameters, content types, and multipart uploads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->