### PR TITLE
fix(api): fetch CJEU full text from Cellar

### DIFF
--- a/apps/api/scripts/run-tests.ts
+++ b/apps/api/scripts/run-tests.ts
@@ -7,6 +7,8 @@ const TEST_FILE_GLOB = "src/**/*.test.{ts,tsx}";
 const TEST_HELPER_GLOB = "src/tests/**/*.ts";
 const MODULE_MOCK_PATTERN = /\bmock\.module\s*\(/u;
 const PROPERTY_TEST_MARKER = "fc.assert";
+const REGULAR_TEST_BATCH_SIZE = 100;
+const MODULE_MOCK_TEST_BATCH_SIZE = 20;
 
 const apiRoot = path.resolve(import.meta.dir, "..");
 
@@ -80,8 +82,8 @@ const runTests = async (testFiles: string[], isolate: boolean) => {
   const executionMode = isolate ? "isolated" : "shared-process";
   console.log(`Running ${testFiles.length} ${executionMode} API test files`);
 
-  // The shared batch loads hundreds of API test modules. Prefer more frequent
-  // garbage collection so it stays within the hosted runner's memory budget.
+  // Each batch loads many graph-heavy API modules. Prefer more frequent garbage
+  // collection so it stays within the hosted runner's memory budget.
   const command = [
     process.execPath,
     "--smol",
@@ -105,9 +107,54 @@ const runTests = async (testFiles: string[], isolate: boolean) => {
   return await child.exited;
 };
 
-const regularExitCode = await runTests(regularTests, false);
+type RunTestBatchesOptions = {
+  batchSize: number;
+  batchStart: number;
+  isolate: boolean;
+  testFiles: string[];
+};
+
+const runTestBatches = async ({
+  batchSize,
+  batchStart,
+  isolate,
+  testFiles,
+}: RunTestBatchesOptions): Promise<number> => {
+  if (batchStart >= testFiles.length) {
+    return 0;
+  }
+
+  const batch = testFiles.slice(batchStart, batchStart + batchSize);
+  const exitCode = await runTests(batch, isolate);
+  if (exitCode !== 0) {
+    return exitCode;
+  }
+
+  return runTestBatches({
+    batchSize,
+    batchStart: batchStart + batchSize,
+    isolate,
+    testFiles,
+  });
+};
+
+// A fresh process per test batch makes module memory reclaimable. One
+// process for the full suite grows until the hosted runner terminates it.
+const regularExitCode = await runTestBatches({
+  batchSize: REGULAR_TEST_BATCH_SIZE,
+  batchStart: 0,
+  isolate: false,
+  testFiles: regularTests,
+});
 if (regularExitCode !== 0) {
   process.exit(regularExitCode);
 }
 
-process.exit(await runTests(moduleMockTests, true));
+process.exit(
+  await runTestBatches({
+    batchSize: MODULE_MOCK_TEST_BATCH_SIZE,
+    batchStart: 0,
+    isolate: true,
+    testFiles: moduleMockTests,
+  }),
+);

--- a/apps/api/scripts/run-tests.ts
+++ b/apps/api/scripts/run-tests.ts
@@ -80,7 +80,15 @@ const runTests = async (testFiles: string[], isolate: boolean) => {
   const executionMode = isolate ? "isolated" : "shared-process";
   console.log(`Running ${testFiles.length} ${executionMode} API test files`);
 
-  const command = [process.execPath, "test", "--preload", preloadPath];
+  // The shared batch loads hundreds of API test modules. Prefer more frequent
+  // garbage collection so it stays within the hosted runner's memory budget.
+  const command = [
+    process.execPath,
+    "--smol",
+    "test",
+    "--preload",
+    preloadPath,
+  ];
   if (isolate) {
     command.push("--isolate");
   }

--- a/apps/api/src/handlers/case-law/ingestion/adapters/eu-ecj.smoke.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/eu-ecj.smoke.test.ts
@@ -14,13 +14,16 @@ import { describe, expect, test } from "bun:test";
 import { euEcjAdapter } from "@/api/handlers/case-law/ingestion/adapters/eu-ecj";
 
 const SKIP = process.env["SMOKE_TEST"] !== "1";
+const ECJ_SMOKE_TIMEOUT_MS = 6 * 60 * 1000;
 
 describe.skipIf(SKIP)("euEcjAdapter smoke (live)", () => {
   test(
     "fetches at least one decision from a known date",
     async () => {
-      // 2024-01-18 is known to have ECJ decisions
-      const result = await euEcjAdapter.fetchPage("2024-01-18", {});
+      // 2024-01-31 has one known ECJ decision. Keeping the live fixture day
+      // small exercises every language manifestation without downloading a
+      // full high-volume judgment day.
+      const result = await euEcjAdapter.fetchPage("2024-01-31", {});
 
       if (!Result.isOk(result)) {
         throw new Error(`Expected Ok, got: ${result.error.message}`);
@@ -28,7 +31,7 @@ describe.skipIf(SKIP)("euEcjAdapter smoke (live)", () => {
       const page = result.value;
 
       expect(page.decisions.length).toBeGreaterThan(0);
-      expect(page.nextCursor).toBe("2024-01-19");
+      expect(page.nextCursor).toBe("2024-02-01");
 
       // Structural checks on each decision
       for (const d of page.decisions) {
@@ -53,6 +56,6 @@ describe.skipIf(SKIP)("euEcjAdapter smoke (live)", () => {
           `${withText.length} with fulltext`,
       );
     },
-    { timeout: 60_000 },
+    { timeout: ECJ_SMOKE_TIMEOUT_MS },
   );
 });

--- a/apps/api/src/handlers/case-law/ingestion/adapters/eu-ecj.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/eu-ecj.test.ts
@@ -2,10 +2,7 @@ import { Result } from "better-result";
 /* eslint-disable typescript-eslint/promise-function-async -- fetch mock callbacks return Promise.resolve without being async */
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
-import {
-  ECJ_LANGUAGES,
-  celexToCaseNumber,
-} from "@/api/handlers/case-law/ingestion/adapters/eu-ecj";
+import { celexToCaseNumber } from "@/api/handlers/case-law/ingestion/adapters/eu-ecj";
 import { asFetchMock } from "@/api/tests/helpers/test-tool-set";
 
 import sparqlFixture from "./__fixtures__/eu-ecj-sparql.json";
@@ -13,6 +10,52 @@ import sparqlFixture from "./__fixtures__/eu-ecj-sparql.json";
 const fulltextHtml = await Bun.file(
   new URL("__fixtures__/eu-ecj-fulltext-en.html", import.meta.url),
 ).text();
+
+const CELLAR_RESOURCE_PREFIX = "http://publications.europa.eu/resource/cellar/";
+const EN_MANIFESTATION_ID = "5980acd6-b5e4-11ee-b164-01aa75ed71a1.0011.05";
+const FR_MANIFESTATION_ID = "5980acd6-b5e4-11ee-b164-01aa75ed71a1.0012.05";
+const DE_MANIFESTATION_ID = "5980acd6-b5e4-11ee-b164-01aa75ed71a1.0013.05";
+
+type SparqlFixtureBinding = (typeof sparqlFixture.results.bindings)[number];
+
+type WithManifestationOptions = {
+  cellarLanguage: string;
+  manifestationId: string;
+};
+
+const withManifestation = (
+  binding: SparqlFixtureBinding,
+  { cellarLanguage, manifestationId }: WithManifestationOptions,
+) => ({
+  ...binding,
+  language: {
+    type: "uri",
+    value: `http://publications.europa.eu/resource/authority/language/${cellarLanguage}`,
+  },
+  manifestation: {
+    type: "uri",
+    value: `${CELLAR_RESOURCE_PREFIX}${manifestationId}`,
+  },
+});
+
+const firstFixtureBinding = sparqlFixture.results.bindings.at(0);
+const secondFixtureBinding = sparqlFixture.results.bindings.at(1);
+if (!firstFixtureBinding || !secondFixtureBinding) {
+  throw new TypeError("Expected at least two CJEU SPARQL fixture bindings");
+}
+
+const enBinding = withManifestation(firstFixtureBinding, {
+  cellarLanguage: "ENG",
+  manifestationId: EN_MANIFESTATION_ID,
+});
+const frBinding = withManifestation(firstFixtureBinding, {
+  cellarLanguage: "FRA",
+  manifestationId: FR_MANIFESTATION_ID,
+});
+const deBinding = withManifestation(firstFixtureBinding, {
+  cellarLanguage: "DEU",
+  manifestationId: DE_MANIFESTATION_ID,
+});
 
 // -- celexToCaseNumber --
 
@@ -55,7 +98,6 @@ describe("celexToCaseNumber", () => {
 
 describe("euEcjAdapter.fetchPage", () => {
   const originalFetch = globalThis.fetch;
-  const LANG_COUNT = ECJ_LANGUAGES.length;
 
   const originalSleep = Bun.sleep;
 
@@ -71,7 +113,29 @@ describe("euEcjAdapter.fetchPage", () => {
   test(
     "parses SPARQL + HTML into multi-lang decisions",
     async () => {
-      const bindings = sparqlFixture.results.bindings.slice(0, 2);
+      const secondDecision = withManifestation(
+        {
+          ...secondFixtureBinding,
+          type: {
+            type: "uri",
+            value: "http://publications.europa.eu/ontology/cdm#order_cjeu",
+          },
+        },
+        {
+          cellarLanguage: "ENG",
+          manifestationId: "5f978357-b5e4-11ee-b164-01aa75ed71a1.0001.05",
+        },
+      );
+      const duplicateEnBinding = withManifestation(firstFixtureBinding, {
+        cellarLanguage: "ENG",
+        manifestationId: "5f978357-b5e4-11ee-b164-01aa75ed71a1.0002.05",
+      });
+      const bindings = [
+        enBinding,
+        duplicateEnBinding,
+        frBinding,
+        secondDecision,
+      ];
       globalThis.fetch = asFetchMock(
         mock((url: string) => {
           const urlStr = url;
@@ -92,7 +156,7 @@ describe("euEcjAdapter.fetchPage", () => {
             );
           }
 
-          if (urlStr.includes("eur-lex.europa.eu")) {
+          if (urlStr.includes("publications.europa.eu/resource/cellar/")) {
             return Promise.resolve(
               new Response(fulltextHtml, {
                 status: 200,
@@ -117,16 +181,15 @@ describe("euEcjAdapter.fetchPage", () => {
       }
       const page = result.value;
 
-      const bindingCount = bindings.length;
-      expect(page.decisions).toHaveLength(bindingCount * LANG_COUNT);
+      expect(page.decisions).toHaveLength(3);
       expect(page.nextCursor).toBe("2024-01-19");
 
-      // Verify first binding (C-128/21) produced all languages
+      // Verify the two discovered manifestations for C-128/21.
       const langs = page.decisions
         .filter((d) => d.caseNumber === "C-128/21")
         .map((d) => d.language)
         .sort();
-      expect(langs).toEqual(ECJ_LANGUAGES.map((l) => l.toLowerCase()).sort());
+      expect(langs).toEqual(["en", "fr"]);
 
       const first = page.decisions[0];
       if (!first) {
@@ -135,20 +198,21 @@ describe("euEcjAdapter.fetchPage", () => {
       expect(first.caseNumber).toBe("C-128/21");
       expect(first.ecli).toBe("ECLI:EU:C:2024:49");
       expect(first.court).toBe("Court of Justice");
-      expect(first.language).toBe("bg");
+      expect(first.language).toBe("en");
       expect(first.decisionDate).toBe("2024-01-18");
       expect(first.decisionType).toBe("judgment");
       expect(first.documentUrl).toBe(
-        "https://eur-lex.europa.eu/legal-content/BG/TXT/HTML/?uri=CELEX:62021CJ0128",
+        `https://publications.europa.eu/resource/cellar/${EN_MANIFESTATION_ID}/DOC_1`,
       );
       expect(first.sourceUrl).toBe(
-        "https://eur-lex.europa.eu/legal-content/BG/ALL/?uri=CELEX:62021CJ0128",
+        "https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:62021CJ0128",
       );
       expect(first.metadata).toEqual({ celex: "62021CJ0128" });
       expect(first.fulltext?.length).toBeGreaterThan(100);
       expect(first.rawHash).toHaveLength(64);
       expect(first.documentAst).toEqual({});
       expect(first.sourceRaw).toBeUndefined();
+      expect(page.decisions[2]?.decisionType).toBe("order");
     },
     { timeout: 30_000 },
   );
@@ -206,7 +270,7 @@ describe("euEcjAdapter.fetchPage", () => {
         if (urlStr.includes("sparql")) {
           const fixture = {
             results: {
-              bindings: [sparqlFixture.results.bindings[0]],
+              bindings: [enBinding, frBinding, deBinding],
             },
           };
           return Promise.resolve(
@@ -216,8 +280,11 @@ describe("euEcjAdapter.fetchPage", () => {
           );
         }
 
-        // Only EN and FR return fulltext
-        if (urlStr.includes("/EN/") || urlStr.includes("/FR/")) {
+        // Only the EN and FR Cellar manifestations return fulltext.
+        if (
+          urlStr.includes(EN_MANIFESTATION_ID) ||
+          urlStr.includes(FR_MANIFESTATION_ID)
+        ) {
           return Promise.resolve(
             new Response(fulltextHtml, {
               status: 200,
@@ -254,7 +321,7 @@ describe("euEcjAdapter.fetchPage", () => {
         if (urlStr.includes("sparql")) {
           const fixture = {
             results: {
-              bindings: [sparqlFixture.results.bindings[0]],
+              bindings: [enBinding],
             },
           };
           return Promise.resolve(
@@ -288,7 +355,7 @@ describe("euEcjAdapter.fetchPage", () => {
         if (urlStr.includes("sparql")) {
           const fixture = {
             results: {
-              bindings: [sparqlFixture.results.bindings[0]],
+              bindings: [enBinding],
             },
           };
           return Promise.resolve(
@@ -298,8 +365,7 @@ describe("euEcjAdapter.fetchPage", () => {
           );
         }
 
-        // Only EN
-        if (urlStr.includes("/EN/")) {
+        if (urlStr.includes(EN_MANIFESTATION_ID)) {
           return Promise.resolve(
             new Response(fulltextHtml, {
               status: 200,
@@ -326,6 +392,48 @@ describe("euEcjAdapter.fetchPage", () => {
     }
     expect(d.language).toBe("en");
     expect(d.sourceUrl).toContain("/EN/");
-    expect(d.documentUrl).toContain("/EN/");
+    expect(d.documentUrl).toBe(
+      `https://publications.europa.eu/resource/cellar/${EN_MANIFESTATION_ID}/DOC_1`,
+    );
+  });
+
+  test("rejects a manifestation URL outside the Cellar origin", async () => {
+    let externalFetches = 0;
+    globalThis.fetch = asFetchMock(
+      mock((url: string) => {
+        if (url.includes("sparql")) {
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({
+                results: {
+                  bindings: [
+                    {
+                      ...enBinding,
+                      manifestation: {
+                        type: "uri",
+                        value: "https://attacker.example/document",
+                      },
+                    },
+                  ],
+                },
+              }),
+              { status: 200 },
+            ),
+          );
+        }
+        externalFetches += 1;
+        return Promise.resolve(new Response(fulltextHtml, { status: 200 }));
+      }),
+    );
+
+    const { euEcjAdapter } =
+      await import("@/api/handlers/case-law/ingestion/adapters/eu-ecj");
+    const result = await euEcjAdapter.fetchPage("2024-01-18", {});
+
+    if (!Result.isOk(result)) {
+      throw new TypeError("Expected Ok result");
+    }
+    expect(result.value.decisions).toHaveLength(0);
+    expect(externalFetches).toBe(0);
   });
 });

--- a/apps/api/src/handlers/case-law/ingestion/adapters/eu-ecj.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/eu-ecj.ts
@@ -461,11 +461,7 @@ export const euEcjAdapter: SourceAdapter = {
             continue;
           }
 
-          if (
-            previousCelex &&
-            previousCelex !== celex &&
-            !abortSignal.aborted
-          ) {
+          if (previousCelex && previousCelex !== celex) {
             // oxlint-disable-next-line no-await-in-loop -- deliberate crawl delay between decisions; language variants within one decision remain contiguous and unslept
             await Bun.sleep(500);
           }

--- a/apps/api/src/handlers/case-law/ingestion/adapters/eu-ecj.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/eu-ecj.ts
@@ -34,7 +34,8 @@ import { isRecord } from "@/api/lib/type-guards";
  * Flow:
  * 1. SPARQL query with date filter to list ECLIs + CELEX
  *    numbers for the cursor date range.
- * 2. For each decision, fetch fulltext from EUR-Lex HTML.
+ * 2. For each available language, fetch the XHTML manifestation directly
+ *    from Cellar's machine-to-machine content endpoint.
  *
  * Cursor format: ISO date string (YYYY-MM-DD). Each page
  * covers one day; null cursor starts 7 days ago.
@@ -45,6 +46,11 @@ import { isRecord } from "@/api/lib/type-guards";
  */
 
 const SPARQL_URL = "https://publications.europa.eu/webapi/rdf/sparql";
+const CELLAR_RESOURCE_PREFIX = "http://publications.europa.eu/resource/cellar/";
+const CELLAR_LANGUAGE_PREFIX =
+  "http://publications.europa.eu/resource/authority/language/";
+const CELLAR_MANIFESTATION_ID =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.\d{4}\.\d{2}$/u;
 
 /**
  * All 24 official EU languages. EUR-Lex publishes CJEU
@@ -80,13 +86,34 @@ export const ECJ_LANGUAGES = [
 
 type EcjLanguage = (typeof ECJ_LANGUAGES)[number];
 
-const eurLexHtmlUrl = (lang: EcjLanguage, celex: string) =>
-  `https://eur-lex.europa.eu/legal-content/${lang}` +
-  `/TXT/HTML/?uri=CELEX:${celex}`;
-
 const eurLexSourceUrl = (lang: EcjLanguage, celex: string) =>
   `https://eur-lex.europa.eu/legal-content/${lang}` +
   `/ALL/?uri=CELEX:${celex}`;
+
+const toEcjLanguage = (languageUri: string): EcjLanguage | undefined => {
+  if (!languageUri.startsWith(CELLAR_LANGUAGE_PREFIX)) {
+    return undefined;
+  }
+  const cellarCode = languageUri.slice(CELLAR_LANGUAGE_PREFIX.length);
+  if (!/^[A-Z]{3}$/u.test(cellarCode)) {
+    return undefined;
+  }
+  const language = new Intl.Locale(
+    cellarCode.toLowerCase(),
+  ).language.toUpperCase();
+  return ECJ_LANGUAGES.find((supported) => supported === language);
+};
+
+const toCellarContentUrl = (manifestationUri: string): string | undefined => {
+  if (!manifestationUri.startsWith(CELLAR_RESOURCE_PREFIX)) {
+    return undefined;
+  }
+  const manifestationId = manifestationUri.slice(CELLAR_RESOURCE_PREFIX.length);
+  if (!CELLAR_MANIFESTATION_ID.test(manifestationId)) {
+    return undefined;
+  }
+  return `https://publications.europa.eu/resource/cellar/${manifestationId}/DOC_1`;
+};
 
 // -- SPARQL --
 
@@ -100,6 +127,8 @@ type SparqlResult = {
   date: SparqlBinding;
   celex: SparqlBinding;
   type: SparqlBinding;
+  language: SparqlBinding;
+  manifestation: SparqlBinding;
 };
 
 type SparqlResponse = {
@@ -118,7 +147,9 @@ const isSparqlResult = (value: unknown): value is SparqlResult =>
   isSparqlBinding(value["ecli"]) &&
   isSparqlBinding(value["date"]) &&
   isSparqlBinding(value["celex"]) &&
-  isSparqlBinding(value["type"]);
+  isSparqlBinding(value["type"]) &&
+  isSparqlBinding(value["language"]) &&
+  isSparqlBinding(value["manifestation"]);
 
 const isSparqlResponse = (value: unknown): value is SparqlResponse =>
   isRecord(value) &&
@@ -131,7 +162,10 @@ const SPARQL_LIMIT = 10_000;
 const CDM_TYPE_MAP: Record<string, string> = {
   "http://publications.europa.eu/ontology/cdm#judgement": "judgment",
   "http://publications.europa.eu/ontology/cdm#order": "order",
+  "http://publications.europa.eu/ontology/cdm#order_cjeu": "order",
   "http://publications.europa.eu/ontology/cdm#opinion_advocate_general":
+    "opinion",
+  "http://publications.europa.eu/ontology/cdm#opinion_advocate-general":
     "opinion",
 };
 
@@ -162,21 +196,28 @@ const queryDecisions = async ({
 
   const query = `
 PREFIX cdm: <http://publications.europa.eu/ontology/cdm#>
-SELECT DISTINCT ?ecli ?date ?celex ?type
+SELECT DISTINCT ?ecli ?date ?celex ?type ?language ?manifestation
 WHERE {
   ?doc cdm:case-law_ecli ?ecli .
   ?doc cdm:work_date_document ?date .
   ?doc cdm:resource_legal_id_celex ?celex .
   ?doc a ?type .
+  ?expression cdm:expression_belongs_to_work ?doc .
+  ?expression cdm:expression_uses_language ?language .
+  ?manifestation cdm:manifestation_manifests_expression ?expression .
+  ?manifestation cdm:manifestation_type ?manifestationType .
   FILTER(?type IN (
     cdm:judgement,
     cdm:order,
-    cdm:opinion_advocate_general
+    cdm:order_cjeu,
+    cdm:opinion_advocate_general,
+    cdm:opinion_advocate-general
   ))
+  FILTER(STR(?manifestationType) = "xhtml")
   FILTER(STR(?date) >= "${dateFrom}")
   FILTER(STR(?date) <= "${dateTo}")
 }
-ORDER BY ASC(?date) ASC(?celex)
+ORDER BY ASC(?date) ASC(?celex) ASC(?language)
 LIMIT ${SPARQL_LIMIT}`.trim();
 
   const response = await fetchWithTimeout(SPARQL_URL, {
@@ -261,16 +302,24 @@ export const celexToCaseNumber = (celex: string): string => {
 // -- Fulltext --
 
 /**
- * Fetch fulltext from EUR-Lex HTML endpoint.
+ * Fetch fulltext from a validated Cellar XHTML content stream.
  * Returns stripped text or undefined on failure.
  */
-const fetchFulltext = async (
-  celex: string,
-  lang: EcjLanguage,
-  signal: AbortSignal,
-): Promise<string | undefined> => {
+type FetchFulltextOptions = {
+  contentUrl: string;
+  celex: string;
+  lang: EcjLanguage;
+  signal: AbortSignal;
+};
+
+const fetchFulltext = async ({
+  contentUrl,
+  celex,
+  lang,
+  signal,
+}: FetchFulltextOptions): Promise<string | undefined> => {
   try {
-    const response = await fetchWithTimeout(eurLexHtmlUrl(lang, celex), {
+    const response = await fetchWithTimeout(contentUrl, {
       signal,
       timeoutMs: ADAPTER_TIMEOUT.REQUEST,
       headers: { "User-Agent": INGESTION_USER_AGENT },
@@ -369,6 +418,8 @@ export const euEcjAdapter: SourceAdapter = {
         });
 
         const decisions: IngestionResult[] = [];
+        const completedVariants = new Set<string>();
+        let previousCelex: string | undefined;
 
         // 2. Process each SPARQL result
         for (const binding of bindings) {
@@ -377,57 +428,72 @@ export const euEcjAdapter: SourceAdapter = {
           const date = binding.date.value;
           const caseNumber = celexToCaseNumber(celex);
           const decisionType = CDM_TYPE_MAP[binding.type.value] ?? "unknown";
+          const lang = toEcjLanguage(binding.language.value);
+          const documentUrl = toCellarContentUrl(binding.manifestation.value);
+
+          if (!lang || !documentUrl) {
+            continue;
+          }
+
+          const variantKey = `${celex}:${lang}`;
+          if (completedVariants.has(variantKey)) {
+            continue;
+          }
+
+          if (
+            previousCelex &&
+            previousCelex !== celex &&
+            !abortSignal.aborted
+          ) {
+            // oxlint-disable-next-line no-await-in-loop -- deliberate crawl delay between decisions; language variants within one decision remain contiguous and unslept
+            await Bun.sleep(500);
+          }
+          previousCelex = celex;
 
           const court = ecli.includes(":T:")
             ? "General Court"
             : "Court of Justice";
 
-          // 3. Fetch fulltext in each language
-          for (const lang of ECJ_LANGUAGES) {
-            // oxlint-disable-next-line no-await-in-loop -- rate-limited external call: EUR-Lex fulltext fetches are throttled (minRequestIntervalMs) per adapter, so per-language requests stay sequential rather than fanning out
-            const fulltext = await fetchFulltext(
-              celex,
-              lang,
-              AbortSignal.any([
-                abortSignal,
-                AbortSignal.timeout(ADAPTER_TIMEOUT.REQUEST),
-              ]),
-            );
+          // 3. Fetch the language-specific XHTML stream from Cellar. The
+          // human-facing EUR-Lex HTML endpoint is WAF-protected and may return
+          // a challenge instead of document content to server-side callers.
+          // oxlint-disable-next-line no-await-in-loop -- rate-limited external calls stay sequential instead of fanning out across every language manifestation
+          const fulltext = await fetchFulltext({
+            contentUrl: documentUrl,
+            celex,
+            lang,
+            signal: AbortSignal.any([
+              abortSignal,
+              AbortSignal.timeout(ADAPTER_TIMEOUT.REQUEST),
+            ]),
+          });
 
-            // Skip languages where text is unavailable
-            if (!fulltext) {
-              continue;
-            }
-
-            const langLower = lang.toLowerCase();
-            const raw = `${celex}|${ecli}|${date}|${langLower}|${fulltext}`;
-
-            decisions.push({
-              caseNumber,
-              ecli,
-              court,
-              country: "EU",
-              language: langLower,
-              decisionDate: date,
-              decisionType,
-              fulltext,
-              sourceUrl: eurLexSourceUrl(lang, celex),
-              documentUrl: eurLexHtmlUrl(lang, celex),
-              metadata: { celex },
-              rawHash: hashContent(raw),
-              parserVersion: PARSER_VERSION,
-              // Court-specific AST parsing is not available for EUR-Lex yet.
-              documentAst: EMPTY_AST,
-              sourceRaw: undefined,
-            });
+          if (!fulltext) {
+            continue;
           }
 
-          // Rate-limit per decision (not per language) to
-          // keep total sleep within the page timeout budget.
-          if (!abortSignal.aborted) {
-            // oxlint-disable-next-line no-await-in-loop -- deliberate crawl delay between sequential per-decision fetches against EUR-Lex
-            await Bun.sleep(500);
-          }
+          const langLower = lang.toLowerCase();
+          const raw = `${celex}|${ecli}|${date}|${langLower}|${fulltext}`;
+
+          decisions.push({
+            caseNumber,
+            ecli,
+            court,
+            country: "EU",
+            language: langLower,
+            decisionDate: date,
+            decisionType,
+            fulltext,
+            sourceUrl: eurLexSourceUrl(lang, celex),
+            documentUrl,
+            metadata: { celex },
+            rawHash: hashContent(raw),
+            parserVersion: PARSER_VERSION,
+            // Court-specific AST parsing is not available for Cellar yet.
+            documentAst: EMPTY_AST,
+            sourceRaw: undefined,
+          });
+          completedVariants.add(variantKey);
         }
 
         // If the page was aborted mid-iteration, retry

--- a/apps/api/src/handlers/case-law/ingestion/adapters/eu-ecj.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/eu-ecj.ts
@@ -49,8 +49,11 @@ const SPARQL_URL = "https://publications.europa.eu/webapi/rdf/sparql";
 const CELLAR_RESOURCE_PREFIX = "http://publications.europa.eu/resource/cellar/";
 const CELLAR_LANGUAGE_PREFIX =
   "http://publications.europa.eu/resource/authority/language/";
+// Digit runs are unbounded on purpose: Cellar's version/manifestation
+// padding is an upstream detail, and the charset alone already rules out
+// path traversal in the URL we build from this.
 const CELLAR_MANIFESTATION_ID =
-  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.\d{4}\.\d{2}$/u;
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.\d+\.\d+$/u;
 
 /**
  * All 24 official EU languages. EUR-Lex publishes CJEU
@@ -90,6 +93,11 @@ const eurLexSourceUrl = (lang: EcjLanguage, celex: string) =>
   `https://eur-lex.europa.eu/legal-content/${lang}` +
   `/ALL/?uri=CELEX:${celex}`;
 
+// Intl.Locale construction is not free and SPARQL pages repeat the same
+// 24 language URIs thousands of times during backfills; memoize per
+// Cellar code (misses included).
+const ecjLanguageCache = new Map<string, EcjLanguage | undefined>();
+
 const toEcjLanguage = (languageUri: string): EcjLanguage | undefined => {
   if (!languageUri.startsWith(CELLAR_LANGUAGE_PREFIX)) {
     return undefined;
@@ -98,10 +106,15 @@ const toEcjLanguage = (languageUri: string): EcjLanguage | undefined => {
   if (!/^[A-Z]{3}$/u.test(cellarCode)) {
     return undefined;
   }
+  if (ecjLanguageCache.has(cellarCode)) {
+    return ecjLanguageCache.get(cellarCode);
+  }
   const language = new Intl.Locale(
     cellarCode.toLowerCase(),
   ).language.toUpperCase();
-  return ECJ_LANGUAGES.find((supported) => supported === language);
+  const resolved = ECJ_LANGUAGES.find((supported) => supported === language);
+  ecjLanguageCache.set(cellarCode, resolved);
+  return resolved;
 };
 
 const toCellarContentUrl = (manifestationUri: string): string | undefined => {
@@ -110,6 +123,11 @@ const toCellarContentUrl = (manifestationUri: string): string | undefined => {
   }
   const manifestationId = manifestationUri.slice(CELLAR_RESOURCE_PREFIX.length);
   if (!CELLAR_MANIFESTATION_ID.test(manifestationId)) {
+    // A Cellar-prefixed URI that fails validation means the upstream ID
+    // format changed; surface it instead of silently dropping the variant.
+    logger.warn("case_law.ingestion.unexpected_cellar_manifestation_id", {
+      manifestationUri,
+    });
     return undefined;
   }
   return `https://publications.europa.eu/resource/cellar/${manifestationId}/DOC_1`;
@@ -423,6 +441,9 @@ export const euEcjAdapter: SourceAdapter = {
 
         // 2. Process each SPARQL result
         for (const binding of bindings) {
+          if (abortSignal.aborted) {
+            break;
+          }
           const celex = binding.celex.value;
           const ecli = binding.ecli.value;
           const date = binding.date.value;


### PR DESCRIPTION
## Summary

- discover language-specific XHTML manifestations in the Cellar SPARQL query
- fetch full text from validated HTTPS Cellar content streams instead of the WAF-protected EUR-Lex page
- recognize current Cellar order and advocate-general opinion types
- deduplicate repeated CELEX/language manifestations after a successful fetch
- use a low-volume known date for the nightly live smoke test

## Root cause

[Nightly Full Test run 29719294978](https://github.com/stella/stella/actions/runs/29719294978) timed out in the live CJEU smoke suite. The human-facing EUR-Lex HTML endpoint now returns an AWS WAF challenge to server-side callers, so the adapter could no longer obtain full text. Cellar's documented machine-to-machine XHTML content stream remains available.

Manifestation URIs from SPARQL are validated against the expected Cellar UUID/expression/manifestation shape and converted to a fixed `https://publications.europa.eu` URL before fetching; arbitrary upstream URLs are never followed.

## Verification

- `bun test --preload ./src/tests/setup-env.ts src/handlers/case-law/ingestion/adapters/eu-ecj.test.ts` (15 passed)
- live smoke suite with `SMOKE_TEST=1` (22 language decisions with full text; passed in 9.7s)
- `bun --filter @stll/api typecheck`
- `bun --filter @stll/api lint`
- `bun scripts/ratchet.ts --check`
- pre-push format, i18n, and affected typecheck gates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved European Court of Justice case-law ingestion with more reliable multilingual decision retrieval.
  - Decisions now link directly to validated Cellar XHTML documents while retaining their EUR-Lex source references.
  - Added support for additional decision types, including CJEU orders and Advocate General opinions.
  - Duplicate language variants are removed, and unavailable or invalid document references are safely skipped.

- **Bug Fixes**
  - Prevented retrieval from unauthorised external document locations.
  - Improved handling of language-specific document URLs and full-text extraction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->