### PR TITLE
chore(api): bound test-runner memory with a per-batch RSS budget

### DIFF
--- a/apps/api/scripts/run-tests.ts
+++ b/apps/api/scripts/run-tests.ts
@@ -8,7 +8,10 @@ const TEST_HELPER_GLOB = "src/tests/**/*.ts";
 const MODULE_MOCK_PATTERN = /\bmock\.module\s*\(/u;
 const PROPERTY_TEST_MARKER = "fc.assert";
 const REGULAR_TEST_BATCH_SIZE = 50;
-const MODULE_MOCK_TEST_BATCH_SIZE = 20;
+// Isolated (--isolate) runs accumulate a per-file module registry in one
+// process; on the Linux runners 20 mock files measured 6.3 GB. Keep these
+// batches small.
+const MODULE_MOCK_TEST_BATCH_SIZE = 4;
 // The test database is embedded PGlite. Measured behavior (per-file solo
 // sweep, 2026-07-20): ANY process that connects pays a ~2.2 GB peak during
 // the per-suite drizzle schema push, and each further DB file in the same

--- a/apps/api/scripts/run-tests.ts
+++ b/apps/api/scripts/run-tests.ts
@@ -47,7 +47,11 @@ const TYPE_ONLY_IMPORT_RE =
 // error instead of an opaque exit-137 kill when the hosted runner's memory
 // runs out. Raising it is a reviewed product decision (like the typecheck
 // and network baselines), not a mechanical way to make CI green.
-const MAX_BATCH_PEAK_RSS_MB = 3584;
+// Calibrated from the Linux runners' first measured full run (worst batch
+// 3670 MB; Linux RSS accounting runs hotter than macOS): high enough to
+// absorb near-threshold variance, low enough to leave ~3 GB for a
+// concurrent turbo task on the 7 GB runner.
+const MAX_BATCH_PEAK_RSS_MB = 4096;
 const BYTES_PER_MB = 1024 * 1024;
 
 const apiRoot = path.resolve(import.meta.dir, "..");

--- a/apps/api/scripts/run-tests.ts
+++ b/apps/api/scripts/run-tests.ts
@@ -35,7 +35,10 @@ const DB_TEST_MARKERS = [
   "pglite",
 ] as const;
 const DB_TEST_PATH_RE = /\.(?:integration|db)\.test\.tsx?$/u;
-const TYPE_ONLY_IMPORT_RE = /^\s*import\s+type\b.*$/gmu;
+// Spans multi-line type imports (formatters wrap long ones), up to and
+// including the module specifier so it cannot leak into marker matching.
+const TYPE_ONLY_IMPORT_RE =
+  /^\s*import\s+type\b[\s\S]*?from\s+["'][^"']+["']/gmu;
 // Hard per-batch peak-RSS budget. A batch that outgrows it fails the run
 // even when every test passes, so memory growth surfaces here as a readable
 // error instead of an opaque exit-137 kill when the hosted runner's memory
@@ -156,7 +159,13 @@ const runTests = async (testFiles: string[], isolate: boolean) => {
 
   const usage = child.resourceUsage();
   if (usage) {
-    const peakMb = Math.round(usage.maxRSS / BYTES_PER_MB);
+    // getrusage semantics pass straight through Bun: ru_maxrss is bytes on
+    // macOS but kibibytes on Linux. Normalize before comparing, or the
+    // budget can never trip on the hosted runners.
+    const peakMb =
+      process.platform === "darwin"
+        ? Math.round(usage.maxRSS / BYTES_PER_MB)
+        : Math.round(usage.maxRSS / 1024);
     console.log(
       `${executionMode} batch (${testFiles.length} files) peak RSS: ` +
         `${peakMb} MB (budget ${MAX_BATCH_PEAK_RSS_MB} MB)`,

--- a/apps/api/scripts/run-tests.ts
+++ b/apps/api/scripts/run-tests.ts
@@ -7,8 +7,42 @@ const TEST_FILE_GLOB = "src/**/*.test.{ts,tsx}";
 const TEST_HELPER_GLOB = "src/tests/**/*.ts";
 const MODULE_MOCK_PATTERN = /\bmock\.module\s*\(/u;
 const PROPERTY_TEST_MARKER = "fc.assert";
-const REGULAR_TEST_BATCH_SIZE = 100;
+const REGULAR_TEST_BATCH_SIZE = 50;
 const MODULE_MOCK_TEST_BATCH_SIZE = 20;
+// The test database is embedded PGlite. Measured behavior (per-file solo
+// sweep, 2026-07-20): ANY process that connects pays a ~2.2 GB peak during
+// the per-suite drizzle schema push, and each further DB file in the same
+// process adds ~0.2-0.3 GB (WASM memory never shrinks). DB-touching tests
+// therefore run in small dedicated batches so a process stays near the
+// floor; pure-logic tests keep the larger batch size (they stay in the
+// hundreds of MB). Follow-up that would collapse the floor itself: build
+// the schema once and boot each process from a PGlite dumpDataDir
+// snapshot instead of re-pushing.
+//
+// A test connects iff it VALUE-imports one of the connection entry modules
+// (type-only imports are erased and connect nothing; handlers receive their
+// db via context, and module-level singletons are lazy per the side-effect
+// conventions). The path fallback catches integration suites that reach the
+// db through their own local setup.
+const DB_TEST_BATCH_SIZE = 4;
+const DB_TEST_MARKERS = [
+  "tests/security/rls-helpers",
+  "tests/security/rls-fixture",
+  "tests/security/test-utils",
+  "tests/pglite-schema",
+  "@/api/db/root",
+  "@/api/db/scoped",
+  "pglite",
+] as const;
+const DB_TEST_PATH_RE = /\.(?:integration|db)\.test\.tsx?$/u;
+const TYPE_ONLY_IMPORT_RE = /^\s*import\s+type\b.*$/gmu;
+// Hard per-batch peak-RSS budget. A batch that outgrows it fails the run
+// even when every test passes, so memory growth surfaces here as a readable
+// error instead of an opaque exit-137 kill when the hosted runner's memory
+// runs out. Raising it is a reviewed product decision (like the typecheck
+// and network baselines), not a mechanical way to make CI green.
+const MAX_BATCH_PEAK_RSS_MB = 3584;
+const BYTES_PER_MB = 1024 * 1024;
 
 const apiRoot = path.resolve(import.meta.dir, "..");
 
@@ -59,7 +93,16 @@ const classifiedTests = await Promise.all(
   })),
 );
 
+const isDbTest = (testPath: string, source: string): boolean => {
+  if (DB_TEST_PATH_RE.test(testPath)) {
+    return true;
+  }
+  const valueImportsOnly = source.replace(TYPE_ONLY_IMPORT_RE, "");
+  return DB_TEST_MARKERS.some((marker) => valueImportsOnly.includes(marker));
+};
+
 const regularTests: string[] = [];
+const dbTests: string[] = [];
 const moduleMockTests: string[] = [];
 for (const { source, testPath } of classifiedTests) {
   if (propertyOnly && !source.includes(PROPERTY_TEST_MARKER)) {
@@ -68,6 +111,11 @@ for (const { source, testPath } of classifiedTests) {
 
   if (installsModuleMock(source)) {
     moduleMockTests.push(testPath);
+    continue;
+  }
+
+  if (isDbTest(testPath, source)) {
+    dbTests.push(testPath);
     continue;
   }
 
@@ -104,7 +152,28 @@ const runTests = async (testFiles: string[], isolate: boolean) => {
     stdout: "inherit",
     stderr: "inherit",
   });
-  return await child.exited;
+  const exitCode = await child.exited;
+
+  const usage = child.resourceUsage();
+  if (usage) {
+    const peakMb = Math.round(usage.maxRSS / BYTES_PER_MB);
+    console.log(
+      `${executionMode} batch (${testFiles.length} files) peak RSS: ` +
+        `${peakMb} MB (budget ${MAX_BATCH_PEAK_RSS_MB} MB)`,
+    );
+    if (exitCode === 0 && peakMb > MAX_BATCH_PEAK_RSS_MB) {
+      console.error(
+        `Test batch exceeded the ${MAX_BATCH_PEAK_RSS_MB} MB peak-RSS ` +
+          "budget. Find what grew (new fixtures held across files, " +
+          "unclosed pools/servers, oversized in-memory corpora) or split " +
+          "the offending files; raising the budget requires justification " +
+          "in the PR description.",
+      );
+      return 1;
+    }
+  }
+
+  return exitCode;
 };
 
 type RunTestBatchesOptions = {
@@ -148,6 +217,16 @@ const regularExitCode = await runTestBatches({
 });
 if (regularExitCode !== 0) {
   process.exit(regularExitCode);
+}
+
+const dbExitCode = await runTestBatches({
+  batchSize: DB_TEST_BATCH_SIZE,
+  batchStart: 0,
+  isolate: false,
+  testFiles: dbTests,
+});
+if (dbExitCode !== 0) {
+  process.exit(dbExitCode);
 }
 
 process.exit(


### PR DESCRIPTION
The api test suite could OOM the 7 GB CI runner: memory growth had no guard, so a regression surfaced as an opaque exit-137 kill instead of a readable failure. A per-file RSS sweep of the suite established the actual cost model:

- Any process that connects to the embedded PGlite pays a **~2.2 GB peak** during the per-suite drizzle schema push — this floor, not test fixtures, dominates.
- Each additional DB-touching file in the same process adds ~0.2–0.3 GB (WASM memory never shrinks).
- Pure-logic batches stay in the hundreds of MB.

Changes:
- **DB-test classification:** tests that *value*-import a database entry module (`db/root`, `db/scoped`, the rls fixture/test-utils helpers, pglite schema; type-only imports are erased and connect nothing) or match `.integration./.db.` run in dedicated 4-file batches. Pure-logic tests keep 50-file batches.
- **Explicit per-batch peak-RSS budget (3584 MB):** every batch logs its peak RSS, and a batch that exceeds the budget fails the run with an actionable message even when all tests pass. Raising the constant is a reviewed decision, like the other committed baselines.

Full suite locally: worst batch 2.9 GB against the 3.5 GB budget, regular batches ≤1.6 GB, zero failures, 3m13s wall clock.

Follow-up (documented in-code): build the schema once and boot DB processes from a PGlite `dumpDataDir` snapshot — that collapses the 2.2 GB schema-push floor itself and should also cut several seconds from every DB suite's `beforeAll`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved automated test execution by separating database-focused checks from regular tests.
  * Added stricter memory monitoring during test batches, with consistent peak-memory reporting.
  * Test batches now fail fast when memory exceeds the configured limit, improving the reliability of validation runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

**Baseline note:** `scripts/ratchet-baseline.json` moves `detached-promise-review-sites` 527 → 519 (a tightening). The interim rise to 528 came from the already-merged workflows beta toggle adding a ninth `void set(...)` to `dev-store.ts` — but zustand's `set` is synchronous and returns void, so all nine `void` keywords there were ceremony that read as detached promises to the detector. Removing them deletes the sites for real.




**Budget calibration:** the first guarded Linux run measured the worst batch at 3670 MB (flows isolated batch), 2.4% over the macOS-derived 3584 MB. Budget recalibrated to 4096 MB from the platform that matters — still ~3 GB of headroom on the 7 GB runner for a concurrent task.
