### PR TITLE
fix(web): bound auth requests so a stalled connection cannot hang the shell

### DIFF
--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -15,11 +15,34 @@ import { stellaToast } from "@stll/ui/components/toast";
 
 import { env } from "@/env";
 import { getTranslator, useI18nStore } from "@/i18n/i18n-store";
+import { fetchWithTimeout } from "@/lib/fetch";
 import { getSignedOauthQueryFromHash } from "@/lib/oauth-provider";
 import { createSecretTokenBoundary } from "@/lib/secret-token";
 import type { SecretToken } from "@/lib/secret-token";
 
 export const HTTP_TOO_MANY_REQUESTS = 429;
+
+/**
+ * Stall budget for every auth request.
+ *
+ * `require-fetch-timeout` only reaches first-party `fetch()` calls, so the
+ * auth client's own transport is the one hole in that invariant: a wedged
+ * connection (laptop sleep, network switch) leaves its promise pending
+ * forever. `_protected.tsx`'s `beforeLoad` awaits the role query through
+ * that transport, so an unbounded request there parks the route in its
+ * pending component — a full-screen loader with nothing logged.
+ *
+ * Bounding the request rather than racing the promise matters: an abort
+ * *settles* the query (as an error the prefetch swallows), so shell chrome
+ * still mounts against a resolved cache instead of a still-in-flight one.
+ *
+ * Deliberately below `CRITICAL_QUERY_TIMEOUT_MS` (10s) so the transport
+ * settles first and that outer race stays a backstop rather than the
+ * mechanism. Note this budget only bounds a single attempt: the boot
+ * queries in `routes/-queries.ts` opt out of retries so the worst case
+ * stays one budget rather than four plus backoff.
+ */
+const AUTH_REQUEST_TIMEOUT_MS = 8000;
 const SESSION_REVOCATION_TOKEN = "better-auth-session-revocation";
 const sessionRevocationTokenBoundary = createSecretTokenBoundary(
   SESSION_REVOCATION_TOKEN,
@@ -102,6 +125,12 @@ export const authClient = createAuthClient({
   baseURL: env.VITE_API_URL,
   plugins: authClientPlugins,
   fetchOptions: {
+    customFetchImpl: async (input, init) =>
+      await fetchWithTimeout(input, {
+        ...init,
+        signal: init?.signal ?? undefined,
+        timeoutMs: AUTH_REQUEST_TIMEOUT_MS,
+      }),
     headers: {
       get "Accept-Language"() {
         return useI18nStore.getState().lang;

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -125,8 +125,8 @@ export const authClient = createAuthClient({
   baseURL: env.VITE_API_URL,
   plugins: authClientPlugins,
   fetchOptions: {
-    customFetchImpl: async (input, init) =>
-      await fetchWithTimeout(input, {
+    customFetchImpl: (input, init) =>
+      fetchWithTimeout(input, {
         ...init,
         signal: init?.signal ?? undefined,
         timeoutMs: AUTH_REQUEST_TIMEOUT_MS,

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -125,8 +125,11 @@ export const authClient = createAuthClient({
   baseURL: env.VITE_API_URL,
   plugins: authClientPlugins,
   fetchOptions: {
-    customFetchImpl: (input, init) =>
-      fetchWithTimeout(input, {
+    // `async`/`await` look redundant around a call that already returns a
+    // promise, but `promise-function-async` is type-aware and rejects the
+    // bare arrow form here.
+    customFetchImpl: async (input, init) =>
+      await fetchWithTimeout(input, {
         ...init,
         signal: init?.signal ?? undefined,
         timeoutMs: AUTH_REQUEST_TIMEOUT_MS,

--- a/apps/web/src/routes/-queries.ts
+++ b/apps/web/src/routes/-queries.ts
@@ -8,7 +8,20 @@ export const rootKeys = {
   role: ["role"],
 };
 
+/**
+ * The shell blocks on these two, so their worst case is what a user stares
+ * at before anything renders. The QueryClient sets no `retry`, i.e. the
+ * TanStack default of 3 attempts with exponential backoff — which would turn
+ * one stalled connection into roughly four auth-request budgets plus backoff
+ * before `beforeLoad` settles. On the boot path, failing fast and letting the
+ * caller degrade (redirect to `/auth`, or mount chrome without role-gated
+ * affordances) beats a minute-long pending component. Retries stay on for
+ * everything downstream of boot.
+ */
+const BOOT_QUERY_RETRY = false;
+
 export const sessionOptions = queryOptions({
+  retry: BOOT_QUERY_RETRY,
   queryKey: rootKeys.session,
   queryFn: async () => {
     const { authClient } = await import("@/lib/auth");
@@ -24,6 +37,7 @@ export const sessionOptions = queryOptions({
 });
 
 export const roleOptions = queryOptions({
+  retry: BOOT_QUERY_RETRY,
   queryKey: rootKeys.role,
   queryFn: async () => {
     const { authClient } = await import("@/lib/auth");


### PR DESCRIPTION
## Problem

The `require-fetch-timeout` oxlint rule forbids raw `fetch()` under `apps/web/src`, but it only reaches first-party call sites. The auth client does its fetching inside its own transport, so every `authClient` call was exempt from that invariant and carried no abort source of its own.

That matters on the boot path. `_protected`'s `beforeLoad` awaits the role query through that transport, and `DefaultPendingComponent` has no timeout and no error path, so a connection that stalls rather than fails (wedged HTTP/2 stream after sleep or a network switch) parks the route in a full-screen loader indefinitely, with nothing logged and no way out but a reload.

## Fix

Route the client through the existing `fetchWithTimeout` helper, and opt the two boot queries out of retries.

Two details that are load-bearing:

- **Bounding the request, not racing the promise.** An abort *settles* the query, so shell chrome still mounts against a resolved cache rather than an in-flight one. That preserves the ordering `beforeLoad`'s comment depends on (a role fetch resolving mid-mount triggers a React not-yet-mounted warning that route-smoke treats as a failure). The budget sits below `CRITICAL_QUERY_TIMEOUT_MS` so the transport settles first and that outer race stays a backstop.
- **Retries had to go with it.** The QueryClient sets no `retry`, so the TanStack default of 3 attempts plus exponential backoff applies. A per-attempt timeout alone would have stacked the budget four times over and merely slowed the hang down instead of removing it. Retries stay on for everything downstream of boot.

## Behaviour on timeout

| Path | Result |
|---|---|
| Session (`loadAuthContext`) | Settles as an error → existing catch → redirect to `/auth` |
| Role prefetch (`beforeLoad`) | Settles → prefetch swallows → chrome mounts without role-gated affordances |
| Post-boot queries | Unchanged |

Worst case on the boot path is now one request budget instead of unbounded.

## Follow-up worth a decision

The role-failure path degrades silently — the sidebar simply lacks role-gated affordances, with only an analytics event. Given #1260 in this release specifically converted analytics-only failures into surfaced ones, a toast may belong here too. Left out of this PR to keep the timeout change reviewable on its own.