### PR TITLE
fix(web): give the account settings sections one heading pattern

### DIFF
--- a/apps/web/src/routes/_protected.settings/-components/account/sessions-card.tsx
+++ b/apps/web/src/routes/_protected.settings/-components/account/sessions-card.tsx
@@ -18,7 +18,12 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@stll/ui/components/dialog";
-import { Frame } from "@stll/ui/components/frame";
+import {
+  Frame,
+  FrameHeader,
+  FramePanel,
+  FrameTitle,
+} from "@stll/ui/components/frame";
 import {
   Table,
   TableBody,
@@ -54,13 +59,16 @@ export const SessionsCard = () => {
   const hasOtherSessions = sessions.some((s) => s.id !== currentSessionId);
 
   return (
-    <div className="flex flex-col gap-4">
-      {hasOtherSessions && (
-        <div className="flex justify-end">
-          <RevokeAllDialog />
-        </div>
-      )}
-      <Frame>
+    <Frame>
+      <FrameHeader>
+        <FrameTitle>{t("common.sessions")}</FrameTitle>
+      </FrameHeader>
+      <FramePanel>
+        {hasOtherSessions && (
+          <div className="flex justify-end p-4 pb-0">
+            <RevokeAllDialog />
+          </div>
+        )}
         <Table>
           <TableHeader>
             <TableRow>
@@ -115,8 +123,8 @@ export const SessionsCard = () => {
             )}
           </TableBody>
         </Table>
-      </Frame>
-    </div>
+      </FramePanel>
+    </Frame>
   );
 };
 

--- a/apps/web/src/routes/_protected.settings/-components/account/sessions-card.tsx
+++ b/apps/web/src/routes/_protected.settings/-components/account/sessions-card.tsx
@@ -63,7 +63,10 @@ export const SessionsCard = () => {
       <FrameHeader>
         <FrameTitle>{t("common.sessions")}</FrameTitle>
       </FrameHeader>
-      <FramePanel>
+      {/* `p-0`: FramePanel pads by 5 for prose-style panels, which would inset
+          the table. The rows carry their own cell padding, so the panel only
+          needs to supply the card surface. */}
+      <FramePanel className="p-0">
         {hasOtherSessions && (
           <div className="flex justify-end p-4 pb-0">
             <RevokeAllDialog />

--- a/apps/web/src/routes/_protected.settings/account.profile.tsx
+++ b/apps/web/src/routes/_protected.settings/account.profile.tsx
@@ -488,12 +488,7 @@ function ProfilePageBody() {
 
       <TwoFactorCard />
 
-      <section className="flex flex-col gap-2">
-        <h2 className="text-muted-foreground px-1 text-xs font-medium tracking-wide uppercase">
-          {t("common.sessions")}
-        </h2>
-        <SessionsCard />
-      </section>
+      <SessionsCard />
 
       <Frame className="border-destructive/32">
         <FrameHeader>


### PR DESCRIPTION
## Problem

The account profile page mixed two section styles at the same nesting level:

- Three `Frame` sections carrying a `FrameTitle` (profile, two-factor, danger zone)
- One bespoke `<section>` wrapping `SessionsCard` in an uppercase `text-xs` micro-label

The wrapper existed because `SessionsCard` rendered a bare `Frame` with no header of its own. The result is siblings that read as different ranks, so the page has no consistent hierarchy.

## Fix

Move the title into `SessionsCard` as a `FrameTitle` so it matches the sections around it, and drop the wrapper. No new translation keys: the existing `common.sessions` moves into the card.

## Scope

Deliberately limited to this page. `organization.members.tsx` uses the uppercase label consistently throughout (8 occurrences), so it is internally coherent — the profile page was the one mixing both patterns. Unifying the two patterns repo-wide is a separate design decision, not this fix.

## Testing

Settings → Profile. The Sessions section now carries the same title treatment as the sections above and below it; the revoke-all action and the sessions table are unchanged.