### PR TITLE
fix(web): drop redundant void operators in the dev store

### DIFF
--- a/apps/web/src/lib/dev-store.ts
+++ b/apps/web/src/lib/dev-store.ts
@@ -48,31 +48,31 @@ export const useDevStore = create<State & Actions>()(
       simulateSlowLoad: false,
 
       setTanstackDevtools: (tanstackDevtools) => {
-        void set({ tanstackDevtools });
+        set({ tanstackDevtools });
       },
       setSourceInspector: (sourceInspector) => {
-        void set({ sourceInspector });
+        set({ sourceInspector });
       },
       setChatModelId: (chatModelId) => {
-        void set({ chatModelId });
+        set({ chatModelId });
       },
       setReactGrab: (reactGrab) => {
-        void set({ reactGrab });
+        set({ reactGrab });
       },
       setPublicLawPreview: (publicLawPreview) => {
-        void set({ publicLawPreview });
+        set({ publicLawPreview });
       },
       setPlaybooksPreview: (playbooksPreview) => {
-        void set({ playbooksPreview });
+        set({ playbooksPreview });
       },
       setWorkflowsPreview: (workflowsPreview) => {
-        void set({ workflowsPreview });
+        set({ workflowsPreview });
       },
       setTimeBillingPreview: (timeBillingPreview) => {
-        void set({ timeBillingPreview });
+        set({ timeBillingPreview });
       },
       setSimulateSlowLoad: (simulateSlowLoad) => {
-        void set({ simulateSlowLoad });
+        set({ simulateSlowLoad });
       },
     }),
     {

--- a/scripts/ratchet-baseline.json
+++ b/scripts/ratchet-baseline.json
@@ -329,7 +329,7 @@
     "files": {}
   },
   "detached-promise-review-sites": {
-    "count": 527,
+    "count": 519,
     "files": {
       "apps/api/src/handlers/case-law/analysis/generate.ts": 1,
       "apps/api/src/handlers/chat/send-message.ts": 2,
@@ -398,7 +398,6 @@
       "apps/web/src/features/case-law/components/case-viewer/decision-workspace.tsx": 4,
       "apps/web/src/hooks/use-external-file-drop.ts": 1,
       "apps/web/src/i18n/i18n-store.ts": 1,
-      "apps/web/src/lib/dev-store.ts": 8,
       "apps/web/src/lib/pdf/hooks/use-pdf-document.ts": 1,
       "apps/web/src/lib/prompts/use-saved-prompts.ts": 1,
       "apps/web/src/lib/react-query.ts": 1,


### PR DESCRIPTION
## Problem

`main` is currently red on the ratchet guard:

```
detached-promise-review-sites: 527 -> 528 (+1)
    apps/web/src/lib/dev-store.ts: 8 -> 9
```

A ninth toggle was added to the dev store following the file's existing `void set({ ... })` shape, without the baseline moving with it. This blocks every open PR, since the guard runs against the whole repo rather than the diff.

## Fix

zustand's `set` is synchronous and returns `void`, so the operator is a no-op here and the sites it marks are not detached promises at all. Removing it across the file is the honest fix rather than reseeding the baseline to absorb the increase.

The metric drops **527 -> 519**; the baseline is updated to lock that in, per the guidance that a ratchet should be tightened after a fix rather than loosened to accommodate one.

## Verification

```
$ bun scripts/ratchet.ts --check
ratchet --check: OK. 12 metric(s) at or below baseline.
```

Lint is clean on the touched file. Behaviour is unchanged: every call site was already discarding a `void` return.