### PR TITLE
feat(scripts): ratchet capabilities that lose their schema to the byte cap

### DIFF
--- a/scripts/ratchet-baseline.json
+++ b/scripts/ratchet-baseline.json
@@ -756,6 +756,13 @@
       "apps/web/src/stores/config-store.ts": 2
     }
   },
+  "capability-schemas-truncated": {
+    "count": 6,
+    "files": {
+      "apps/api/src/mcp/generated/capability-catalog.json": 3,
+      "packages/cli/src/generated/capability-catalog.json": 3
+    }
+  },
   "cross-feature-imports": {
     "count": 0,
     "files": {}

--- a/scripts/ratchet.ts
+++ b/scripts/ratchet.ts
@@ -1181,7 +1181,8 @@ const SELF_TEST_CAPABILITY_CATALOG = `${JSON.stringify([
   { id: "gamma.update" },
   { id: "delta.delete", inputSchemaTruncated: true },
 ])}\n`;
-const EXPECTED_TRUNCATED_CAPABILITY_SCHEMAS = 2;
+// Two truncated entries in each of the two mirror fixtures.
+const EXPECTED_TRUNCATED_CAPABILITY_SCHEMAS = 4;
 
 const runSelfTest = (): number => {
   const failures: string[] = [];
@@ -1250,9 +1251,16 @@ const runSelfTest = (): number => {
       "apps/web/src/features/alpha/uses-beta.ts",
       SELF_TEST_CROSS_FEATURE,
     );
+    // Both mirrors, so each `include` glob is exercised rather than only the
+    // first: the metric's whole point is that the two artifacts stay in step.
     writeFixture(
       root,
       "packages/cli/src/generated/capability-catalog.json",
+      SELF_TEST_CAPABILITY_CATALOG,
+    );
+    writeFixture(
+      root,
+      "apps/api/src/mcp/generated/capability-catalog.json",
       SELF_TEST_CAPABILITY_CATALOG,
     );
     writeFixture(root, "apps/api/src/db/index.ts", "export const x = 1;\n");

--- a/scripts/ratchet.ts
+++ b/scripts/ratchet.ts
@@ -581,6 +581,30 @@ const countCrossSliceImports =
 
 // --- Metric table -----------------------------------------------------------
 
+// A capability whose input schema exceeded the exporter's byte cap
+// (`MAX_CAPABILITY_SCHEMA_BYTES` in apps/api/scripts/lib/capability-catalog.ts).
+// The exporter drops the schema and marks the entry, which silently costs that
+// capability its typed CLI flags and its MCP input schema — the command
+// degrades to an opaque `--input` JSON blob with no discoverable shape. Nothing
+// fails when this happens, so without a ratchet the untyped surface grows
+// unnoticed. Counting the committed artifacts (rather than re-running the
+// exporter) keeps the scan cheap and deterministic; both mirrors are included
+// so drift between them also shows up.
+const countTruncatedCapabilitySchemas = (content: string): number => {
+  const parsed: unknown = JSON.parse(content);
+  if (!Array.isArray(parsed)) {
+    return 0;
+  }
+  return parsed.filter(
+    (entry) =>
+      typeof entry === "object" &&
+      entry !== null &&
+      "inputSchemaTruncated" in entry &&
+      (entry as { inputSchemaTruncated?: unknown }).inputSchemaTruncated ===
+        true,
+  ).length;
+};
+
 type FileCounter = (content: string, file: string) => number;
 
 type RatchetMetric = {
@@ -689,6 +713,19 @@ const RATCHET_METRICS: readonly RatchetMetric[] = [
     include: ["apps/web/src/**/*.{ts,tsx}"],
     exclude: isExcludedSource,
     count: countCrossSliceImports(crossesRoutePrivate),
+  },
+  {
+    id: "capability-schemas-truncated",
+    description:
+      "capabilities whose input schema exceeded the exporter byte cap, losing typed CLI flags and MCP input schemas (counted across both committed catalog mirrors)",
+    include: [
+      "packages/cli/src/generated/capability-catalog.json",
+      "apps/api/src/mcp/generated/capability-catalog.json",
+    ],
+    // Generated artifacts are the subject here, so the shared source
+    // exclusions (which skip `.gen.`/generated paths) must not apply.
+    exclude: () => false,
+    count: countTruncatedCapabilitySchemas,
   },
   {
     id: "cross-feature-imports",
@@ -1136,6 +1173,16 @@ const writeFixture = (root: string, rel: string, content: string): void => {
   writeFileSync(full, content);
 };
 
+// Two truncated entries among four, plus shapes the counter must NOT count:
+// `inputSchemaTruncated: false`, and an entry that simply omits the field.
+const SELF_TEST_CAPABILITY_CATALOG = `${JSON.stringify([
+  { id: "alpha.create", inputSchemaTruncated: true },
+  { id: "beta.read", inputSchemaTruncated: false },
+  { id: "gamma.update" },
+  { id: "delta.delete", inputSchemaTruncated: true },
+])}\n`;
+const EXPECTED_TRUNCATED_CAPABILITY_SCHEMAS = 2;
+
 const runSelfTest = (): number => {
   const failures: string[] = [];
   const root = mkdtempSync(path.join(tmpdir(), "ratchet-selftest-"));
@@ -1202,6 +1249,11 @@ const runSelfTest = (): number => {
       root,
       "apps/web/src/features/alpha/uses-beta.ts",
       SELF_TEST_CROSS_FEATURE,
+    );
+    writeFixture(
+      root,
+      "packages/cli/src/generated/capability-catalog.json",
+      SELF_TEST_CAPABILITY_CATALOG,
     );
     writeFixture(root, "apps/api/src/db/index.ts", "export const x = 1;\n");
     writeFixture(root, "apps/web/src/lib/index.tsx", "export const y = 2;\n");
@@ -1290,6 +1342,15 @@ const runSelfTest = (): number => {
     if (detachedPromiseMetric.count !== EXPECTED_DETACHED_PROMISES) {
       failures.push(
         `detached-promise-review-sites counted ${detachedPromiseMetric.count}, expected ${EXPECTED_DETACHED_PROMISES}`,
+      );
+    }
+
+    const truncatedCapabilityMetric = snapshot["capability-schemas-truncated"];
+    if (
+      truncatedCapabilityMetric.count !== EXPECTED_TRUNCATED_CAPABILITY_SCHEMAS
+    ) {
+      failures.push(
+        `capability-schemas-truncated counted ${truncatedCapabilityMetric.count}, expected ${EXPECTED_TRUNCATED_CAPABILITY_SCHEMAS}`,
       );
     }
 


### PR DESCRIPTION
## Problem

`capInputSchema` (`apps/api/scripts/lib/capability-catalog.ts`) drops any capability input schema larger than `MAX_CAPABILITY_SCHEMA_BYTES` (64 KB) and marks the entry `inputSchemaTruncated`.

The consequence is not obvious from that code: a truncated capability loses its **typed CLI flags** and its **MCP input schema**. The command degrades to an opaque `--input` JSON blob, and `--help` cannot state the shape, so callers — humans and agents alike — have to already know it.

Nothing fails when this happens. There is no warning at export time and no check in CI, so the untyped surface can grow without anyone noticing.

## Current state

277 of 280 capabilities have usable schemas. Three do not:

- `views.create`
- `views.update`
- `view-templates.create`

## Guard

New `capability-schemas-truncated` ratchet metric, baseline **6** (three capabilities across both committed catalog mirrors — including both also catches drift between them). A fourth capability crossing the cap now fails CI; fixing one of the three ratchets the baseline down.

The metric counts committed artifacts rather than re-running the exporter, keeping the scan cheap and deterministic in line with the other metrics.

## Verification

Self-test passes, and covers the shapes the counter must **not** count (explicit `false`, and an entry omitting the field entirely):

```
$ bun scripts/ratchet.ts --self-test
ratchet --self-test: PASS
```

The guard was proven to fire, not just to pass — marking a fourth capability truncated produces:

```
ratchet --check: metric(s) rose above baseline:
  capability-schemas-truncated: 6 -> 7 (+1)
```

and reverting returns it to `OK. 13 metric(s) at or below baseline.`

## Not in scope

Fixing the three oversized schemas. This PR stops the bleeding; shrinking those schemas (or raising the cap deliberately) is separate work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added monitoring for truncated capability schemas in generated catalogues.
  * Updated baseline tracking to record six currently detected truncated schemas.
  * Expanded validation checks to ensure truncation counts remain accurate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->