### PR TITLE
fix(cli): reach the manual-paste fallback when no browser can be opened

### DIFF
--- a/packages/cli/src/auth/browser-open.ts
+++ b/packages/cli/src/auth/browser-open.ts
@@ -18,10 +18,28 @@ export const openCommandFor = (
   return ["xdg-open"];
 };
 
-export const openInBrowser = async (url: string): Promise<boolean> => {
+/**
+ * Outcome of a launch attempt.
+ *
+ * Deliberately three states rather than a boolean: "the opener did not settle
+ * within the timeout" is NOT the same as "there is no browser". A slow desktop
+ * portal or an `xdg-open` that only exits once the browser closes both land in
+ * `unknown`, and the browser is very likely opening anyway — so callers must
+ * keep waiting on the loopback redirect there, and may only fall back to a
+ * manual paste on a definite `failed`.
+ */
+export type BrowserLaunch = {
+  readonly status: "opened" | "failed" | "unknown";
+};
+
+const LAUNCH_OPENED: BrowserLaunch = { status: "opened" };
+const LAUNCH_FAILED: BrowserLaunch = { status: "failed" };
+const LAUNCH_UNKNOWN: BrowserLaunch = { status: "unknown" };
+
+export const openInBrowser = async (url: string): Promise<BrowserLaunch> => {
   const command = openCommandFor(process.platform);
   if (!command) {
-    return false;
+    return LAUNCH_FAILED;
   }
 
   // `command` always has at least one element (see `openCommandFor`); append
@@ -41,14 +59,16 @@ export const openInBrowser = async (url: string): Promise<boolean> => {
   // and bound the wait so a hung opener can never stall the CLI. Each executor
   // resolves exactly once; `Promise.race` takes whichever settles first.
   let timer: ReturnType<typeof setTimeout> | undefined;
-  const exited = new Promise<boolean>((resolve) => {
-    child.on("exit", (code) => resolve(code === 0));
+  const exited = new Promise<BrowserLaunch>((resolve) => {
+    child.on("exit", (code) =>
+      resolve(code === 0 ? LAUNCH_OPENED : LAUNCH_FAILED),
+    );
   });
-  const errored = new Promise<boolean>((resolve) => {
-    child.on("error", () => resolve(false));
+  const errored = new Promise<BrowserLaunch>((resolve) => {
+    child.on("error", () => resolve(LAUNCH_FAILED));
   });
-  const timedOut = new Promise<boolean>((resolve) => {
-    timer = setTimeout(() => resolve(false), OPEN_TIMEOUT_MS);
+  const timedOut = new Promise<BrowserLaunch>((resolve) => {
+    timer = setTimeout(() => resolve(LAUNCH_UNKNOWN), OPEN_TIMEOUT_MS);
   });
 
   try {

--- a/packages/cli/src/auth/login.test.ts
+++ b/packages/cli/src/auth/login.test.ts
@@ -13,6 +13,7 @@ import os from "node:os";
 import path from "node:path";
 import { PassThrough } from "node:stream";
 
+import { LOGIN_TIMEOUT_MS } from "./constants.js";
 import { readCredentialFile } from "./credential-store.js";
 
 // `login()` is the orchestrator: it wires PKCE + discovery + registration +
@@ -46,11 +47,15 @@ void mock.module("./loopback-listener.js", () => ({
 // `openCommandFor` intact) and never let this file actually launch a browser.
 const realBrowser = await import("./browser-open.js");
 let onBrowserOpen: (authorizeUrl: string) => void | Promise<void> = () => {};
+// Whether the simulated launch succeeded. `false` models a machine with no
+// usable browser (headless server, SSH, container) where the opener exits
+// nonzero or fails to spawn.
+let browserOpenSucceeds = true;
 void mock.module("./browser-open.js", () => ({
   ...realBrowser,
   openInBrowser: async (url: string) => {
     await onBrowserOpen(url);
-    return true;
+    return browserOpenSucceeds;
   },
 }));
 
@@ -188,6 +193,7 @@ describe("login orchestration", () => {
     configDir = await mkdtemp(path.join(os.tmpdir(), "stella-cli-login-"));
     loopbackMode = "real";
     onBrowserOpen = () => {};
+    browserOpenSucceeds = true;
   });
 
   afterEach(async () => {
@@ -202,6 +208,7 @@ describe("login orchestration", () => {
   afterAll(() => {
     loopbackMode = "real";
     onBrowserOpen = () => {};
+    browserOpenSucceeds = true;
     mock.restore();
   });
 
@@ -253,6 +260,30 @@ describe("login orchestration", () => {
       const persisted = await readCredentialFile(configDir);
       expect(persisted.credentials.at(0)?.orgId).toBe("org-42");
       expect(provider.counts.token).toBe(1);
+    } finally {
+      provider.close();
+    }
+  });
+
+  // Regression: the launch result used to be discarded (`void openInBrowser`),
+  // so a machine with a bound listener but no usable browser sat waiting on a
+  // redirect that could never arrive until LOGIN_TIMEOUT_MS (5 minutes)
+  // elapsed. The failed launch must divert to the manual paste straight away.
+  test("falls back to manual paste immediately when the browser cannot be opened", async () => {
+    browserOpenSucceeds = false;
+    const provider = startProvider();
+
+    try {
+      const startedAt = Date.now();
+      const result = await login(
+        makeProcess("manual-code-xyz\n"),
+        baseOptions(configDir, provider.url),
+      );
+
+      expect(Result.isOk(result)).toBe(true);
+      expect(provider.counts.token).toBe(1);
+      // Nowhere near the 5-minute loopback wait the old code would have taken.
+      expect(Date.now() - startedAt).toBeLessThan(LOGIN_TIMEOUT_MS);
     } finally {
       provider.close();
     }

--- a/packages/cli/src/auth/login.test.ts
+++ b/packages/cli/src/auth/login.test.ts
@@ -47,15 +47,16 @@ void mock.module("./loopback-listener.js", () => ({
 // `openCommandFor` intact) and never let this file actually launch a browser.
 const realBrowser = await import("./browser-open.js");
 let onBrowserOpen: (authorizeUrl: string) => void | Promise<void> = () => {};
-// Whether the simulated launch succeeded. `false` models a machine with no
-// usable browser (headless server, SSH, container) where the opener exits
-// nonzero or fails to spawn.
-let browserOpenSucceeds = true;
+// Simulated launch outcome. `failed` models a machine with no usable browser
+// (headless server, SSH, container) where the opener exits nonzero or fails to
+// spawn; `unknown` models an opener that never settled within its timeout, as a
+// slow desktop portal or a long-lived `xdg-open` does.
+let browserLaunchStatus: "opened" | "failed" | "unknown" = "opened";
 void mock.module("./browser-open.js", () => ({
   ...realBrowser,
   openInBrowser: async (url: string) => {
     await onBrowserOpen(url);
-    return browserOpenSucceeds;
+    return { status: browserLaunchStatus };
   },
 }));
 
@@ -193,7 +194,7 @@ describe("login orchestration", () => {
     configDir = await mkdtemp(path.join(os.tmpdir(), "stella-cli-login-"));
     loopbackMode = "real";
     onBrowserOpen = () => {};
-    browserOpenSucceeds = true;
+    browserLaunchStatus = "opened";
   });
 
   afterEach(async () => {
@@ -208,7 +209,7 @@ describe("login orchestration", () => {
   afterAll(() => {
     loopbackMode = "real";
     onBrowserOpen = () => {};
-    browserOpenSucceeds = true;
+    browserLaunchStatus = "opened";
     mock.restore();
   });
 
@@ -270,7 +271,7 @@ describe("login orchestration", () => {
   // redirect that could never arrive until LOGIN_TIMEOUT_MS (5 minutes)
   // elapsed. The failed launch must divert to the manual paste straight away.
   test("falls back to manual paste immediately when the browser cannot be opened", async () => {
-    browserOpenSucceeds = false;
+    browserLaunchStatus = "failed";
     const provider = startProvider();
 
     try {
@@ -284,6 +285,29 @@ describe("login orchestration", () => {
       expect(provider.counts.token).toBe(1);
       // Nowhere near the 5-minute loopback wait the old code would have taken.
       expect(Date.now() - startedAt).toBeLessThan(LOGIN_TIMEOUT_MS);
+    } finally {
+      provider.close();
+    }
+  });
+
+  // The opener returns `unknown` when it has not settled within its own
+  // timeout, which is the normal shape of a slow desktop portal or an
+  // `xdg-open` that lives as long as the browser. A browser almost certainly
+  // did open, so this must NOT divert to the manual paste: doing so would
+  // abandon a loopback redirect that is still on its way.
+  test("keeps waiting on the loopback redirect when the launch is unknown", async () => {
+    browserLaunchStatus = "unknown";
+    const provider = startProvider();
+    onBrowserOpen = driveCallback();
+
+    try {
+      const result = await login(
+        makeProcess(),
+        baseOptions(configDir, provider.url),
+      );
+
+      expect(Result.isOk(result)).toBe(true);
+      expect(provider.counts.token).toBe(1);
     } finally {
       provider.close();
     }

--- a/packages/cli/src/auth/login.ts
+++ b/packages/cli/src/auth/login.ts
@@ -191,6 +191,11 @@ const awaitAuthorizationCode = async (
     // agent sandbox). Waiting out the full loopback timeout first would strand
     // the user for minutes on a callback that can never arrive, so fall back to
     // the manual paste immediately.
+    //
+    // Closing first is required, not tidiness: the listener is an open
+    // `http.Server` with no `unref()`, so leaving it bound keeps the event loop
+    // alive and the CLI never exits, even once the pasted code succeeds.
+    listener.close();
     io.print(
       "Could not open a browser on this machine; complete sign-in in any browser, then paste the redirected URL (or just the code) below.",
     );

--- a/packages/cli/src/auth/login.ts
+++ b/packages/cli/src/auth/login.ts
@@ -174,11 +174,25 @@ const awaitAuthorizationCode = async (
 ): Promise<Result<AuthorizationCode, CliAuthError>> => {
   io.print("Opening the stella sign-in page in your browser:");
   io.print(`  ${authorizeUrl}`);
-  void openInBrowser(authorizeUrl);
+  // Awaiting is safe (and required to react to a failed launch): the loopback
+  // listener is already bound by the time we get here, so a redirect that
+  // arrives while the opener is still settling is queued, not missed.
+  const browserOpened = await openInBrowser(authorizeUrl);
 
   if (!listener) {
     io.print(
       "Could not start a local listener; complete sign-in in any browser, then paste the redirected URL (or just the code) below.",
+    );
+    return awaitManualCode(io, redirectUri, expectedState);
+  }
+
+  if (!browserOpened) {
+    // No browser on this machine (headless server, SSH session, container,
+    // agent sandbox). Waiting out the full loopback timeout first would strand
+    // the user for minutes on a callback that can never arrive, so fall back to
+    // the manual paste immediately.
+    io.print(
+      "Could not open a browser on this machine; complete sign-in in any browser, then paste the redirected URL (or just the code) below.",
     );
     return awaitManualCode(io, redirectUri, expectedState);
   }

--- a/packages/cli/src/auth/login.ts
+++ b/packages/cli/src/auth/login.ts
@@ -177,7 +177,7 @@ const awaitAuthorizationCode = async (
   // Awaiting is safe (and required to react to a failed launch): the loopback
   // listener is already bound by the time we get here, so a redirect that
   // arrives while the opener is still settling is queued, not missed.
-  const browserOpened = await openInBrowser(authorizeUrl);
+  const launch = await openInBrowser(authorizeUrl);
 
   if (!listener) {
     io.print(
@@ -186,11 +186,16 @@ const awaitAuthorizationCode = async (
     return awaitManualCode(io, redirectUri, expectedState);
   }
 
-  if (!browserOpened) {
-    // No browser on this machine (headless server, SSH session, container,
-    // agent sandbox). Waiting out the full loopback timeout first would strand
-    // the user for minutes on a callback that can never arrive, so fall back to
-    // the manual paste immediately.
+  if (launch.status === "failed") {
+    // Definitely no usable browser here (headless server, SSH session,
+    // container, agent sandbox). Waiting out the full loopback timeout first
+    // would strand the user for minutes on a callback that can never arrive,
+    // so fall back to the manual paste immediately.
+    //
+    // Only `failed` diverts. An `unknown` launch — the opener had not settled
+    // within its timeout, as a slow desktop portal or an `xdg-open` that lives
+    // as long as the browser both do — very likely DID open a browser, so it
+    // falls through to the loopback wait, which has its own timeout fallback.
     //
     // Closing first is required, not tidiness: the listener is an open
     // `http.Server` with no `unref()`, so leaving it bound keeps the event loop


### PR DESCRIPTION
## Problem

`awaitAuthorizationCode` discarded the result of `openInBrowser`:

```ts
void openInBrowser(authorizeUrl);
```

`openInBrowser` spawns with `stdio: "ignore"` and correctly returns `false` when the launch fails, but nothing read it. On a machine that binds a loopback listener yet has no usable browser — headless server, SSH session, container, agent sandbox — the CLI then waited out the full `LOGIN_TIMEOUT_MS` (5 minutes) on a redirect that could never arrive before offering the manual paste that was available the whole time.

## Fix

Await the launch and divert to `awaitManualCode` immediately when it fails.

Closing the listener on that path is required rather than tidiness: it is an open `http.Server` with no `unref()`, so leaving it bound keeps the event loop alive and the CLI never exits, even after the pasted code succeeds. Verified with a minimal repro — a bound `createServer` with nothing else pending does not exit.

## Result

Headless sign-in is possible today: the URL is printed, the user completes it in any browser, and pastes the code back. That is not a substitute for a real non-interactive grant (see below), but it removes a five-minute dead wait on the path that already existed.

## Context: this is not the device-flow change

An attempt to enable better-auth's `deviceAuthorization` plugin was abandoned because the premise does not hold, verified against the installed dists:

- `/device/token` returns `access_token: session.token` — an opaque better-auth session token, with no `org_id`, no `aud`/`iss`, and no refresh token.
- `apps/api/src/mcp/auth.ts` verifies bearer tokens against JWKS with audience + issuer and hard-requires `payload.org_id`.
- `@better-auth/oauth-provider` supports `authorization_code` and `client_credentials` only — **no `device_code` grant** (zero occurrences in its dist).

So the plugin cannot produce a token the MCP surface accepts. Making it work would mean either loosening MCP to accept session tokens (dropping audience binding, `org_id`, and scopes — a security regression) or building a custom bridge that uses the device code purely as transport for the authorization code. Neither belongs in this PR.

For genuinely unattended clients, `client_credentials` is already supported by the OAuth provider and is the more promising direction. Tracked separately.