### PR TITLE
fix(mcp): repair the better-auth doc source and surface failed sources

### DIFF
--- a/.claude/mcp/server.ts
+++ b/.claude/mcp/server.ts
@@ -628,7 +628,7 @@ server.tool(
       );
       const failureNote =
         failedSourceNames.length > 0
-          ? `\n\nNote: could not fetch ${failedSourceNames.join(", ")}; results exclude ${failedSourceNames.length === 1 ? "it" : "them"}.`
+          ? `Note: could not fetch ${failedSourceNames.join(", ")}; results exclude ${failedSourceNames.length === 1 ? "it" : "them"}.`
           : "";
 
       for (const { value } of successfulSources) {
@@ -671,18 +671,24 @@ server.tool(
           content: [
             {
               type: "text" as const,
-              text: `No matching documentation pages found for "${query}".${failureNote}`,
+              text: `No matching documentation pages found for "${query}".${failureNote.length > 0 ? ` ${failureNote}` : ""}`,
             },
           ],
         };
       }
 
+      // The note rides as its own content block rather than being appended to
+      // the JSON text: a caller parsing the results block must still get valid
+      // JSON, so the warning cannot be concatenated onto it.
       return {
         content: [
           {
             type: "text" as const,
-            text: `${JSON.stringify(limitedResults, null, 2)}${failureNote}`,
+            text: JSON.stringify(limitedResults, null, 2),
           },
+          ...(failureNote.length > 0
+            ? [{ type: "text" as const, text: failureNote }]
+            : []),
         ],
       };
     } catch (error) {

--- a/.claude/mcp/server.ts
+++ b/.claude/mcp/server.ts
@@ -23,7 +23,7 @@ const SOURCES: Record<string, string> = {
   Zod: "https://zod.dev/llms.txt",
   TipTap: "https://tiptap.dev/llms.txt",
   Bun: "https://bun.sh/llms.txt",
-  BetterAuth: "https://www.better-auth.com/llms.txt",
+  BetterAuth: "https://better-auth.com/llms.txt",
   Turborepo: "https://turborepo.dev/llms.txt",
   Rivet: "https://rivet.dev/llms.txt",
   PostHog: "https://posthog.com/llms.txt",
@@ -33,6 +33,10 @@ const SOURCES: Record<string, string> = {
 
 const HOST_ALIASES: Record<string, string[]> = {
   "bun.sh": ["bun.com", "www.bun.com"],
+  // Docs link to the `www.` host, which 307s back to the apex. Both must be
+  // allowlisted or the redirect hop fails `validateAllowedUrl` and the source
+  // silently indexes nothing.
+  "better-auth.com": ["www.better-auth.com"],
 };
 
 const DEFAULT_MAX_RESULTS = 3;
@@ -612,6 +616,21 @@ server.tool(
         throw new Error("Could not fetch any selected documentation indexes");
       }
 
+      // A source that fails to fetch is dropped from the search silently, which
+      // makes a broken entry indistinguishable from one that simply has no
+      // match: the index looks configured while contributing nothing. Name the
+      // casualties in the response so a misconfigured source is visible rather
+      // than inferred from suspiciously empty results.
+      const failedSourceNames = settledSources.flatMap((source, index) =>
+        source.status === "rejected"
+          ? [selectedSources[index]?.name ?? "unknown"]
+          : [],
+      );
+      const failureNote =
+        failedSourceNames.length > 0
+          ? `\n\nNote: could not fetch ${failedSourceNames.join(", ")}; results exclude ${failedSourceNames.length === 1 ? "it" : "them"}.`
+          : "";
+
       for (const { value } of successfulSources) {
         const { name, indexText, indexUrl } = value;
         for (const entry of parseIndexEntries({
@@ -652,7 +671,7 @@ server.tool(
           content: [
             {
               type: "text" as const,
-              text: `No matching documentation pages found for "${query}".`,
+              text: `No matching documentation pages found for "${query}".${failureNote}`,
             },
           ],
         };
@@ -662,7 +681,7 @@ server.tool(
         content: [
           {
             type: "text" as const,
-            text: JSON.stringify(limitedResults, null, 2),
+            text: `${JSON.stringify(limitedResults, null, 2)}${failureNote}`,
           },
         ],
       };


### PR DESCRIPTION
## Problem

`BetterAuth` was configured as `https://www.better-auth.com/llms.txt`. That host 307s to the apex:

```
HTTP/2 307
location: https://better-auth.com/llms.txt
```

`fetchAllowedUrl` follows redirects but re-runs `validateAllowedUrl` on **every hop**, against an allowlist derived from the `SOURCES` hostnames. `www.better-auth.com` was allowlisted; the redirect target `better-auth.com` was not. Reproduced directly:

```
OLD CONFIG FAILED: Blocked: better-auth.com is not a configured doc source
```

So the source has been indexing **nothing** since it was added.

## Fix

- Point the source at the canonical apex and alias the `www` host, matching the existing `bun.sh` → `bun.com` precedent for the same apex/www split.
- Name any sources that failed to fetch in the search response, on both the empty-results and results-returned paths, so a broken source is visible rather than inferred from suspiciously empty output.

## Verification

```
fetched bytes: 22447
mentions api-key plugin: true
```

The old configuration fails as diagnosed; the new one fetches and contains the content that was missing. MCP tests: 5 pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved documentation search reliability when the documentation site redirects between supported hostnames.
  * Search results now clearly indicate when one or more documentation sources could not be reached.
  * Added fetch failure details to empty search responses and returned results where relevant.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->