### PR TITLE
fix(api): represent text file attachments as text and gate document parts by model modality

### DIFF
--- a/apps/api/src/handlers/chat/attachment-modality.test.ts
+++ b/apps/api/src/handlers/chat/attachment-modality.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  TEXT_CSV_MIME_TYPE,
+  TEXT_MARKDOWN_MIME_TYPE,
+  TEXT_PLAIN_MIME_TYPE,
+} from "@/api/handlers/chat/attachment-validation";
+import { DOCX_MIME_TYPE, PDF_MIME_TYPE } from "@/api/mime-types";
+
+const { modelAcceptsDocumentAttachment } =
+  await import("@/api/handlers/chat/attachment-modality");
+
+// A vision Mistral model: PDF-capable (via document_url) but no textual
+// document support. This is the case that crashed the chat stream.
+const MISTRAL_VISION = {
+  provider: "mistral",
+  modelId: "mistral-medium-latest",
+} as const;
+// A document-capable Anthropic model: accepts both PDF and textual documents.
+const ANTHROPIC_DOC = {
+  provider: "anthropic",
+  modelId: "claude-sonnet-4-6",
+} as const;
+
+describe("modelAcceptsDocumentAttachment", () => {
+  test("allows a PDF to a Mistral vision model but refuses a textual document", () => {
+    expect(
+      modelAcceptsDocumentAttachment({
+        model: MISTRAL_VISION,
+        mimeType: PDF_MIME_TYPE,
+      }),
+    ).toBe(true);
+    for (const mimeType of [
+      TEXT_PLAIN_MIME_TYPE,
+      TEXT_CSV_MIME_TYPE,
+      TEXT_MARKDOWN_MIME_TYPE,
+    ]) {
+      expect(
+        modelAcceptsDocumentAttachment({ model: MISTRAL_VISION, mimeType }),
+      ).toBe(false);
+    }
+  });
+
+  test("allows both PDF and textual documents to a document-capable model", () => {
+    expect(
+      modelAcceptsDocumentAttachment({
+        model: ANTHROPIC_DOC,
+        mimeType: PDF_MIME_TYPE,
+      }),
+    ).toBe(true);
+    expect(
+      modelAcceptsDocumentAttachment({
+        model: ANTHROPIC_DOC,
+        mimeType: TEXT_PLAIN_MIME_TYPE,
+      }),
+    ).toBe(true);
+  });
+
+  test("never treats a raw docx as a valid document part", () => {
+    // Raw docx reaching dispatch means it was not extracted upstream; no
+    // adapter accepts it, so it must be refused for every model.
+    for (const model of [MISTRAL_VISION, ANTHROPIC_DOC]) {
+      expect(
+        modelAcceptsDocumentAttachment({ model, mimeType: DOCX_MIME_TYPE }),
+      ).toBe(false);
+    }
+  });
+});

--- a/apps/api/src/handlers/chat/attachment-modality.ts
+++ b/apps/api/src/handlers/chat/attachment-modality.ts
@@ -1,0 +1,45 @@
+import {
+  TEXT_CSV_MIME_TYPE,
+  TEXT_MARKDOWN_MIME_TYPE,
+  TEXT_PLAIN_MIME_TYPE,
+} from "@/api/handlers/chat/attachment-validation";
+import {
+  modelAcceptsPdfDocumentInput,
+  modelAcceptsTextualDocumentInput,
+} from "@/api/lib/tanstack-ai-models";
+import type { ResolvedTanStackTextModel } from "@/api/lib/tanstack-ai-models";
+import { PDF_MIME_TYPE } from "@/api/mime-types";
+
+const TEXTUAL_DOCUMENT_MIME_TYPES: ReadonlySet<string> = new Set([
+  TEXT_PLAIN_MIME_TYPE,
+  TEXT_CSV_MIME_TYPE,
+  TEXT_MARKDOWN_MIME_TYPE,
+]);
+
+/**
+ * Whether a chat model can receive a hydrated `document` attachment of the
+ * given mime type as a content part without the provider adapter throwing.
+ *
+ * A PDF needs PDF document input; an extracted textual document (text/plain,
+ * csv, markdown) needs textual document input, which Mistral's `document_url`
+ * path does not provide. Any other mime — notably a raw docx that reached
+ * dispatch without being extracted — is never a valid document part, so it is
+ * refused rather than handed to an adapter that cannot map it. The chat send
+ * gate uses this to reject before dispatch, turning an adapter-level crash
+ * into a clean 422 (and keeping a document off a fallback that would crash).
+ */
+export const modelAcceptsDocumentAttachment = ({
+  model,
+  mimeType,
+}: {
+  model: Pick<ResolvedTanStackTextModel, "modelId" | "provider">;
+  mimeType: string;
+}): boolean => {
+  if (mimeType === PDF_MIME_TYPE) {
+    return modelAcceptsPdfDocumentInput(model);
+  }
+  if (TEXTUAL_DOCUMENT_MIME_TYPES.has(mimeType)) {
+    return modelAcceptsTextualDocumentInput(model);
+  }
+  return false;
+};

--- a/apps/api/src/handlers/chat/chat-message-parts.ts
+++ b/apps/api/src/handlers/chat/chat-message-parts.ts
@@ -80,6 +80,9 @@ export const isChatAttachmentPart = (
   "value" in part["source"] &&
   typeof part["source"]["value"] === "string";
 
+export const isChatDocumentPart = (part: unknown): part is ChatAttachmentPart =>
+  isChatAttachmentPart(part) && part.type === "document";
+
 export const getChatAttachmentUrl = (part: ChatAttachmentPart): string =>
   part.source.value;
 

--- a/apps/api/src/handlers/chat/stream-chat.ts
+++ b/apps/api/src/handlers/chat/stream-chat.ts
@@ -25,10 +25,13 @@ import {
 import type { ChatSendMode } from "@stll/anonymize-chat";
 
 import type { SafeDb, SafeDbError } from "@/api/db/safe-db";
+import { modelAcceptsDocumentAttachment } from "@/api/handlers/chat/attachment-modality";
 import {
+  getChatAttachmentMimeType,
   getUserFileIdFromAttachmentPart,
   isChatPart,
   isChatAttachmentPart,
+  isChatDocumentPart,
 } from "@/api/handlers/chat/chat-message-parts";
 import type {
   ChatSafePrompt,
@@ -215,7 +218,37 @@ export const streamChat = async ({
     orgAIConfig,
     role: "chat",
   });
-  const fallbackModel =
+
+  // Provider adapters accept different document formats: the Mistral adapter
+  // takes a PDF `document` part (via `document_url`) but throws on a textual
+  // one, and no adapter accepts a raw docx. A document attachment reaches the
+  // model as a `document` part, and `resolveEffectiveChatModelId` selects the
+  // chat model without gating by modality, so reject here — before dispatch —
+  // any document whose format the model cannot ingest, rather than let the
+  // adapter crash the stream.
+  const documentAttachmentMimeTypes = preparedMessages.value.flatMap(
+    (message) =>
+      message.parts.filter(isChatDocumentPart).map(getChatAttachmentMimeType),
+  );
+  const modelRejectsAnyDocument = (model: ResolvedTanStackTextModel): boolean =>
+    documentAttachmentMimeTypes.some(
+      (mimeType) => !modelAcceptsDocumentAttachment({ model, mimeType }),
+    );
+
+  if (modelRejectsAnyDocument(primaryModel)) {
+    // A plain 422, NOT a third-party-boundary refusal: that code is the sole
+    // trigger for the "send without anonymization" retry, which cannot fix a
+    // model that simply cannot read the attachment's format.
+    return new Response(
+      JSON.stringify({
+        message:
+          "This model cannot read one of the attached documents. Remove the attachment or switch to a model that supports it.",
+      }),
+      { status: 422, headers: { "Content-Type": "application/json" } },
+    );
+  }
+
+  const resolvedFallbackModel =
     devModelId === undefined
       ? resolveFallbackTextModel({
           organizationId,
@@ -224,6 +257,13 @@ export const streamChat = async ({
           threadId,
         })
       : null;
+  // Drop a fallback that would crash on a document the primary accepted; a
+  // failover must not resurrect the modality mismatch.
+  const fallbackModel =
+    resolvedFallbackModel !== null &&
+    modelRejectsAnyDocument(resolvedFallbackModel)
+      ? null
+      : resolvedFallbackModel;
   const abortController = abortControllerFromSignal(abortSignal);
   const modelTools = chatToolMapToArray(
     prepareToolsForThirdParty({ boundary: thirdPartyBoundary, tools }),

--- a/apps/api/src/handlers/chat/upload-files.test.ts
+++ b/apps/api/src/handlers/chat/upload-files.test.ts
@@ -1,5 +1,6 @@
 import { panic, Result } from "better-result";
 import { beforeEach, describe, expect, mock, test } from "bun:test";
+import JSZip from "jszip";
 
 import { CHAT_SEND_MODE } from "@stll/anonymize-chat";
 
@@ -10,13 +11,10 @@ import {
   TEXT_MARKDOWN_MIME_TYPE,
   TEXT_PLAIN_MIME_TYPE,
 } from "@/api/handlers/chat/attachment-validation";
-import {
-  createChatAttachmentPart,
-  getChatAttachmentUrl,
-} from "@/api/handlers/chat/chat-message-parts";
+import { createChatAttachmentPart } from "@/api/handlers/chat/chat-message-parts";
 import type { PersistableChatMessage } from "@/api/handlers/chat/types";
 import { toSafeId } from "@/api/lib/branded-types";
-import { parseDataUrl, toDataUrl } from "@/api/lib/data-url";
+import { toDataUrl } from "@/api/lib/data-url";
 import { DatabaseError } from "@/api/lib/errors/tagged-errors";
 import { DOCX_MIME_TYPE, PDF_MIME_TYPE } from "@/api/mime-types";
 import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
@@ -28,6 +26,30 @@ const arrayBufferMock = mock(async () =>
     fileBytes.byteOffset + fileBytes.byteLength,
   ),
 );
+
+/** Minimal DOCX with a heading and a body paragraph, for extraction tests. */
+const makeDocxBytes = async (): Promise<Uint8Array> => {
+  const zip = new JSZip();
+  zip.file(
+    "word/document.xml",
+    `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+<w:body>
+  <w:p><w:pPr><w:pStyle w:val="Heading1"/></w:pPr><w:r><w:t>Agreement</w:t></w:r></w:p>
+  <w:p><w:r><w:t>Jan Novak signs here.</w:t></w:r></w:p>
+</w:body></w:document>`,
+  );
+  zip.file(
+    "[Content_Types].xml",
+    `<?xml version="1.0" encoding="UTF-8"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="xml" ContentType="application/xml"/>
+</Types>`,
+  );
+  // Copy into a fresh ArrayBuffer-backed view so `.buffer` is an ArrayBuffer
+  // (not ArrayBufferLike) for the S3 arrayBuffer mock's return type.
+  return new Uint8Array(await zip.generateAsync({ type: "uint8array" }));
+};
 const fileMock = mock(() => ({ arrayBuffer: arrayBufferMock }));
 const writeMock = mock(async () => undefined);
 const s3DeleteMock = mock(async () => undefined);
@@ -60,7 +82,7 @@ describe("chat attachment hydration", () => {
     expect(canHydrateFilePartAsPlainText(PDF_MIME_TYPE)).toBe(false);
   });
 
-  test("coerces text-like attachments to plain text for anonymized sends", async () => {
+  test("coerces text-like attachments to a text content part (universal, never modality-gated)", async () => {
     const result = await hydrateFilePart({
       fileName: "contacts.csv",
       mimeType: TEXT_CSV_MIME_TYPE,
@@ -73,28 +95,15 @@ describe("chat attachment hydration", () => {
       throw result.error;
     }
 
+    // A `text` part, not a `document` part: text needs no adapter modality
+    // support, so it can never trip the document gate or crash a stream.
     expect(result.value).toMatchObject({
       type: "anonymizable",
       part: {
-        metadata: { filename: "contacts.csv" },
-        source: { mimeType: TEXT_PLAIN_MIME_TYPE },
-        type: "document",
+        type: "text",
+        content: 'Attached file "contacts.csv":\n\nJan Novak,Acme',
       },
     });
-    if (result.value.type !== "anonymizable") {
-      throw new Error("Expected anonymizable attachment hydration");
-    }
-    const parsed = parseDataUrl({
-      expectedMimeType: TEXT_PLAIN_MIME_TYPE,
-      maxBytes: 1024,
-      url: getChatAttachmentUrl(result.value.part),
-    });
-
-    expect(Result.isOk(parsed)).toBe(true);
-    if (Result.isError(parsed)) {
-      throw parsed.error;
-    }
-    expect(new TextDecoder().decode(parsed.value.bytes)).toBe("Jan Novak,Acme");
   });
 
   test("blocks non-extractable attachments before reading bytes in anonymized mode", async () => {
@@ -135,27 +144,47 @@ describe("chat attachment hydration", () => {
     });
   });
 
-  test("raw override bypasses DOCX text extraction and sends the original file", async () => {
-    const result = await hydrateFilePart({
-      fileName: "draft.docx",
-      mimeType: DOCX_MIME_TYPE,
-      sendMode: CHAT_SEND_MODE.rawOverride,
-      s3Key: "user/file",
-    });
+  // Regression: a raw docx byte stream is not a valid content part for any
+  // provider adapter — the previous rawOverride short-circuit shipped it
+  // anyway, crashing the stream. A docx must ALWAYS be reduced to extracted
+  // text, in both send modes, never sent as raw bytes.
+  test.each([CHAT_SEND_MODE.rawOverride, CHAT_SEND_MODE.anonymized])(
+    "extracts DOCX to text and never ships raw bytes (%s mode)",
+    async (sendMode) => {
+      const docxBytes = await makeDocxBytes();
+      arrayBufferMock.mockImplementationOnce(async () => {
+        const arrayBuffer = new ArrayBuffer(docxBytes.byteLength);
+        new Uint8Array(arrayBuffer).set(docxBytes);
+        return arrayBuffer;
+      });
 
-    expect(Result.isOk(result)).toBe(true);
-    if (Result.isError(result)) {
-      throw result.error;
-    }
-    expect(result.value).toMatchObject({
-      type: "rawOverride",
-      part: {
-        metadata: { filename: "draft.docx" },
-        source: { mimeType: DOCX_MIME_TYPE },
-        type: "document",
-      },
-    });
-  });
+      const result = await hydrateFilePart({
+        fileName: "draft.docx",
+        mimeType: DOCX_MIME_TYPE,
+        sendMode,
+        s3Key: "user/file",
+      });
+
+      expect(Result.isOk(result)).toBe(true);
+      if (Result.isError(result)) {
+        throw result.error;
+      }
+      // A `text` part carrying the extracted text — never a raw docx part and
+      // never a `document` part, so it is universal across provider adapters.
+      expect(result.value.type).toBe("anonymizable");
+      if (
+        result.value.type !== "anonymizable" ||
+        result.value.part.type !== "text"
+      ) {
+        throw new Error("Expected extracted DOCX text as a text content part");
+      }
+      const extracted = result.value.part.content;
+      // Folio markdown extraction preserves structure (heading -> `#`).
+      expect(extracted).toContain('Attached file "draft.docx":');
+      expect(extracted).toContain("# Agreement");
+      expect(extracted).toContain("Jan Novak signs here.");
+    },
+  );
 
   test("cleans up already uploaded files when a later attachment fails", async () => {
     const valuesMock = mock(async () => undefined);

--- a/apps/api/src/handlers/chat/upload-files.ts
+++ b/apps/api/src/handlers/chat/upload-files.ts
@@ -18,6 +18,7 @@ import {
 } from "@/api/handlers/chat/attachment-validation";
 import {
   createChatAttachmentPart,
+  createChatTextPart,
   getChatAttachmentFilename,
   getChatAttachmentMimeType,
   getChatAttachmentUrl,
@@ -45,13 +46,14 @@ import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import { getScanWarnings, scanFile } from "@/api/lib/file-scan/scan";
 import { FILE_SIZE_LIMITS, LIMITS } from "@/api/lib/limits";
 import { getS3 } from "@/api/lib/s3";
-import { DOCX_EXT_RE, sanitizeFilename } from "@/api/lib/sanitize-filename";
+import { sanitizeFilename } from "@/api/lib/sanitize-filename";
 import { DOCX_MIME_TYPE } from "@/api/mime-types";
 
-import { extractText } from "../docx/extract-text";
+import { extractMarkdown } from "../docx/extract-text";
 import type {
   ChatAttachmentPart,
   ChatMessage,
+  ChatPart,
   PersistableChatMessage,
 } from "./types";
 
@@ -245,7 +247,10 @@ type HydrateFilePartProps = {
 
 export type HydratedFilePart =
   | {
-      part: ChatAttachmentPart;
+      // A text-extractable attachment (docx/txt/csv/md) hydrated to a `text`
+      // content part, or any part that carries anonymizable text. Text is
+      // universal across provider adapters, so this is never modality-gated.
+      part: ChatPart;
       type: "anonymizable";
     }
   | {
@@ -292,6 +297,20 @@ export const createRawChatFilePart = ({
     url: toDataUrl(bytes, mimeType),
   });
 
+/**
+ * Wraps extracted attachment text with a filename header so the model has the
+ * same context a `document` part's filename metadata used to carry. The header
+ * is provider-bound context, not user-facing UI; the user still sees the
+ * attachment chip from the persisted reference part.
+ */
+const attachmentText = ({
+  fileName,
+  content,
+}: {
+  fileName: string;
+  content: string;
+}): string => `Attached file "${fileName}":\n\n${content}`;
+
 export const hydrateFilePart = async ({
   fileName,
   mimeType,
@@ -316,6 +335,75 @@ export const hydrateFilePart = async ({
     );
     const bytes = new Uint8Array(buffer);
 
+    // Text-extractable formats are ALWAYS reduced to a `text` content part
+    // before dispatch. Text is universal across provider adapters, so it is
+    // never modality-gated and never crashes a stream (unlike a `document`
+    // part, which the Mistral adapter rejects unless it is a PDF). rawOverride
+    // ("anonymization off") means "skip anonymization", NOT "ship raw bytes":
+    // no adapter ingests raw docx/csv/md. Only genuine binary formats (image,
+    // PDF) are sent raw, in the fallthrough below. Ordering is load-bearing —
+    // a rawOverride short-circuit placed before these branches (the previous
+    // shape) made the extraction dead code whenever anonymization was off (the
+    // default), shipping raw docx that every adapter rejects. The persisted
+    // `userfile://` reference part (see `uploadMessageFiles`) still renders the
+    // attachment chip; only the provider-bound copy becomes text.
+    if (DIRECT_TEXT_MIME_TYPES.has(mimeType)) {
+      return Result.ok<HydratedFilePart>({
+        part: createChatTextPart(
+          attachmentText({
+            fileName,
+            // Cap like the DOCX branch: a text/csv/md attachment can be up to
+            // the full upload size, and the model context budget is bounded.
+            content: new TextDecoder()
+              .decode(bytes)
+              .slice(0, LIMITS.chatContextFileMaxChars),
+          }),
+        ),
+        type: "anonymizable",
+      });
+    }
+
+    if (mimeType === DOCX_MIME_TYPE) {
+      // Use folio's structure-preserving Markdown extraction (headings,
+      // tables, lists) rather than a flat paragraph join: document structure
+      // is high-signal context for the model reading a legal document.
+      const markdown = yield* Result.await(
+        Result.tryPromise({
+          try: async () =>
+            (await extractMarkdown(bytes)).slice(
+              0,
+              LIMITS.chatContextFileMaxChars,
+            ),
+          catch: (cause) =>
+            new ChatError({
+              message: "Failed to extract text from chat DOCX attachment",
+              cause,
+            }),
+        }),
+      );
+
+      const text = markdown.trim();
+      if (!text) {
+        if (requiresPlainText) {
+          return Result.ok<HydratedFilePart>(createBlockedHydratedFilePart());
+        }
+        return Result.err(
+          new HandlerError({
+            status: 422,
+            message: "Chat DOCX attachment did not contain extractable text",
+          }),
+        );
+      }
+
+      return Result.ok<HydratedFilePart>({
+        part: createChatTextPart(attachmentText({ fileName, content: text })),
+        type: "anonymizable",
+      });
+    }
+
+    // Remaining formats are genuine binary (image, PDF). Anonymized mode
+    // blocked them above (they cannot be reduced to plain text), so only
+    // rawOverride reaches here; send them raw for the model to ingest natively.
     if (sendMode === CHAT_SEND_MODE.rawOverride) {
       return Result.ok<HydratedFilePart>({
         part: createRawChatFilePart({ bytes, fileName, mimeType }),
@@ -323,64 +411,7 @@ export const hydrateFilePart = async ({
       });
     }
 
-    if (DIRECT_TEXT_MIME_TYPES.has(mimeType)) {
-      return Result.ok<HydratedFilePart>({
-        part: createChatAttachmentPart({
-          filename: fileName,
-          mimeType: TEXT_PLAIN_MIME_TYPE,
-          url: toDataUrl(bytes, TEXT_PLAIN_MIME_TYPE),
-        }),
-        type: "anonymizable",
-      });
-    }
-
-    if (mimeType !== DOCX_MIME_TYPE) {
-      return Result.ok<HydratedFilePart>(createBlockedHydratedFilePart());
-    }
-
-    const extractedText = yield* Result.await(
-      Result.tryPromise({
-        try: async () => {
-          const extracted = await extractText(bytes);
-
-          return extracted.paragraphs
-            .flatMap((paragraph) => {
-              const trimmed = paragraph.text.trim();
-              return trimmed ? [trimmed] : [];
-            })
-            .join("\n")
-            .slice(0, LIMITS.chatContextFileMaxChars);
-        },
-        catch: (cause) =>
-          new ChatError({
-            message: "Failed to extract text from chat DOCX attachment",
-            cause,
-          }),
-      }),
-    );
-
-    const text = extractedText.trim();
-
-    if (!text) {
-      if (requiresPlainText) {
-        return Result.ok<HydratedFilePart>(createBlockedHydratedFilePart());
-      }
-      return Result.err(
-        new HandlerError({
-          status: 422,
-          message: "Chat DOCX attachment did not contain extractable text",
-        }),
-      );
-    }
-
-    return Result.ok<HydratedFilePart>({
-      part: createChatAttachmentPart({
-        filename: toDocxTextFilename({ filename: fileName }),
-        mimeType: TEXT_PLAIN_MIME_TYPE,
-        url: toDataUrl(Buffer.from(text, "utf-8"), TEXT_PLAIN_MIME_TYPE),
-      }),
-      type: "anonymizable",
-    });
+    return Result.ok<HydratedFilePart>(createBlockedHydratedFilePart());
   });
 
 type UploadUserFileInput = {
@@ -628,12 +659,3 @@ const parseMessageFileDataUrl = ({ part }: ParseMessageFileDataUrlProps) => {
     mimeType: parseResult.value.mimeType,
   });
 };
-
-type ToDocxTextFilenameProps = {
-  filename: string;
-};
-
-const toDocxTextFilename = ({ filename }: ToDocxTextFilenameProps) =>
-  DOCX_EXT_RE.test(filename)
-    ? filename.replace(DOCX_EXT_RE, ".txt")
-    : `${filename}.txt`;

--- a/apps/api/src/handlers/docx/extract-text.test.ts
+++ b/apps/api/src/handlers/docx/extract-text.test.ts
@@ -332,4 +332,23 @@ describe("extractMarkdown", () => {
 
     expect(result).toBe("- Bullet item\n1. First ordered\n2. Second ordered");
   });
+
+  test("extracts paragraphs wrapped in block-level content controls", async () => {
+    // Legal templates bind fields with `w:sdt` content controls; the body
+    // content lives inside `w:sdtContent`. Dropping it would extract an empty
+    // or partial document.
+    const xml = WRAP(
+      `<w:p><w:pPr><w:pStyle w:val="Heading1"/></w:pPr><w:r><w:t>Agreement</w:t></w:r></w:p>
+       <w:sdt>
+         <w:sdtPr><w:alias w:val="Party"/></w:sdtPr>
+         <w:sdtContent>
+           <w:p><w:r><w:t>Controlled clause text.</w:t></w:r></w:p>
+         </w:sdtContent>
+       </w:sdt>`,
+    );
+    const buf = await makeDocx(xml);
+    const result = await extractMarkdown(buf);
+
+    expect(result).toBe("# Agreement\nControlled clause text.");
+  });
 });

--- a/apps/api/src/handlers/docx/extract-text.ts
+++ b/apps/api/src/handlers/docx/extract-text.ts
@@ -509,6 +509,23 @@ const containerToMarkdown = (
       }
       continue;
     }
+
+    // Block-level content controls (`w:sdt > w:sdtContent`) wrap real body
+    // content — legal templates use them heavily for bound fields. Recurse
+    // into the content so controlled paragraphs/tables are not dropped;
+    // nested content controls are handled by the recursive call.
+    if (child.localName === "sdt" && child.namespaceURI === W_NS) {
+      for (const sdtChild of child.childNodes) {
+        if (
+          isElement(sdtChild) &&
+          sdtChild.localName === "sdtContent" &&
+          sdtChild.namespaceURI === W_NS
+        ) {
+          lines.push(...containerToMarkdown(sdtChild, numbering));
+        }
+      }
+      continue;
+    }
   }
 
   return lines;

--- a/apps/api/src/lib/tanstack-ai-models.test.ts
+++ b/apps/api/src/lib/tanstack-ai-models.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  BYOK_DOCUMENT_INPUT_MODEL_OPTIONS,
   BYOK_MODEL_OPTIONS,
+  CHAT_PDF_ATTACHMENT_MODEL_OPTIONS,
   getModelReasoningEfforts,
   MODEL_ROLES,
   supportsTemperature,
@@ -42,6 +44,8 @@ const {
   isAllowedBYOKModelForRole,
   isDeferredServiceTierAvailableForRole,
   isTanStackAIProviderSupported,
+  modelAcceptsPdfDocumentInput,
+  modelAcceptsTextualDocumentInput,
   requireTanStackAIAvailableForRole,
   resolveEffectiveServiceTierForProvider,
   resolveTanStackAIProviderSupport,
@@ -153,6 +157,85 @@ describe("isAllowedBYOKModel", () => {
         role: "pdf",
       }),
     ).toBe(true);
+  });
+});
+
+describe("chat document-attachment capability", () => {
+  // The chat-send document-attachment gate (stream-chat.ts) rejects a document
+  // attachment before dispatch when the resolved model's adapter would throw
+  // on it, because some adapters (e.g. Mistral) map only a subset of document
+  // formats and crash on the rest. The gate is only correct if these predicates
+  // match the catalog's typed capability sets for EVERY offered model, not just
+  // the ones we happened to think of. Iterating the whole catalog turns "add a
+  // model/provider without wiring its document modality" into a test failure
+  // rather than a latent crash: a new model defaults to not document-capable
+  // (safe), and these properties pin that to the catalog.
+  test.each([...TANSTACK_AI_PROVIDERS])(
+    "pins textual + PDF document capability for every offered %s model to the catalog",
+    (provider) => {
+      const textualCapable: readonly string[] =
+        BYOK_DOCUMENT_INPUT_MODEL_OPTIONS[provider];
+      const pdfCapable: readonly string[] =
+        CHAT_PDF_ATTACHMENT_MODEL_OPTIONS[provider];
+      for (const modelId of BYOK_MODEL_OPTIONS[provider]) {
+        expect(modelAcceptsTextualDocumentInput({ provider, modelId })).toBe(
+          textualCapable.includes(modelId),
+        );
+        expect(modelAcceptsPdfDocumentInput({ provider, modelId })).toBe(
+          pdfCapable.includes(modelId),
+        );
+        // Superset invariant: anything that takes a textual document also
+        // takes a PDF one. A model that accepted text but not PDF would be a
+        // catalog bug (the gate would send it a PDF it cannot read).
+        if (modelAcceptsTextualDocumentInput({ provider, modelId })) {
+          expect(modelAcceptsPdfDocumentInput({ provider, modelId })).toBe(
+            true,
+          );
+        }
+      }
+    },
+  );
+
+  test("Mistral vision models accept PDF but not textual documents; other Mistral models accept neither", () => {
+    // Mistral's document_url path (patched in from the upstream document-input
+    // change) takes PDF only, and Mistral is deliberately not a pdf-role
+    // provider, so textual documents must never route to it.
+    expect(BYOK_DOCUMENT_INPUT_MODEL_OPTIONS.mistral).toHaveLength(0);
+    const mistralPdfModels: readonly string[] =
+      CHAT_PDF_ATTACHMENT_MODEL_OPTIONS.mistral;
+    for (const modelId of BYOK_MODEL_OPTIONS.mistral) {
+      expect(
+        modelAcceptsTextualDocumentInput({ provider: "mistral", modelId }),
+      ).toBe(false);
+      expect(
+        modelAcceptsPdfDocumentInput({ provider: "mistral", modelId }),
+      ).toBe(mistralPdfModels.includes(modelId));
+    }
+    expect(
+      modelAcceptsPdfDocumentInput({
+        provider: "mistral",
+        modelId: "mistral-large-latest",
+      }),
+    ).toBe(false);
+    expect(
+      modelAcceptsPdfDocumentInput({
+        provider: "mistral",
+        modelId: "mistral-medium-latest",
+      }),
+    ).toBe(true);
+  });
+
+  test("both predicates fail closed for an unrecognized provider", () => {
+    expect(
+      // @ts-expect-error -- exercising the runtime fail-closed guard for a
+      // provider outside the BYOK catalog union.
+      modelAcceptsTextualDocumentInput({ provider: "acme", modelId: "x" }),
+    ).toBe(false);
+    expect(
+      // @ts-expect-error -- exercising the runtime fail-closed guard for a
+      // provider outside the BYOK catalog union.
+      modelAcceptsPdfDocumentInput({ provider: "acme", modelId: "x" }),
+    ).toBe(false);
   });
 });
 

--- a/apps/api/src/lib/tanstack-ai-models.ts
+++ b/apps/api/src/lib/tanstack-ai-models.ts
@@ -26,6 +26,7 @@ import {
   DEFAULT_MODELS,
   isBYOKModelRoleSupported,
   isBYOKProviderRoleSupported,
+  isChatPdfAttachmentModelSupported,
   resolveReasoningEffort,
   supportsTemperature,
 } from "@stll/ai-catalog";
@@ -193,6 +194,38 @@ export type ResolvedTanStackTextModelInfo = Pick<
 export const isBYOKProvider = (
   provider: AIProvider,
 ): provider is BYOKProvider => provider in BYOK_MODEL_OPTIONS;
+
+/**
+ * Whether a resolved model can accept a PDF `document` content part in chat.
+ * The Mistral text adapter accepts PDF via `document_url` but throws on textual
+ * documents; other document-capable providers accept both. See
+ * `CHAT_PDF_ATTACHMENT_MODEL_OPTIONS`. Fail closed: an unrecognized provider is
+ * treated as not PDF-capable.
+ */
+export const modelAcceptsPdfDocumentInput = (
+  model: Pick<ResolvedTanStackTextModel, "modelId" | "provider">,
+): boolean =>
+  isBYOKProvider(model.provider) &&
+  isChatPdfAttachmentModelSupported({
+    provider: model.provider,
+    modelId: model.modelId,
+  });
+
+/**
+ * Whether a resolved model can accept a textual `document` content part
+ * (extracted docx / txt / csv / md) in chat. This is the pdf-role document set
+ * (`BYOK_DOCUMENT_INPUT_MODEL_OPTIONS`), which excludes Mistral because its
+ * `document_url` path handles PDF only. Fail closed on unrecognized providers.
+ */
+export const modelAcceptsTextualDocumentInput = (
+  model: Pick<ResolvedTanStackTextModel, "modelId" | "provider">,
+): boolean =>
+  isBYOKProvider(model.provider) &&
+  isBYOKModelRoleSupported({
+    provider: model.provider,
+    modelId: model.modelId,
+    role: "pdf",
+  });
 
 export const isAllowedBYOKModel = (
   provider: AIProvider,

--- a/packages/ai-catalog/src/index.test.ts
+++ b/packages/ai-catalog/src/index.test.ts
@@ -7,6 +7,8 @@ import {
   BYOK_DEFAULT_MODELS,
   BYOK_DOCUMENT_INPUT_MODEL_OPTIONS,
   BYOK_MODEL_OPTIONS,
+  CHAT_PDF_ATTACHMENT_MODEL_OPTIONS,
+  isChatPdfAttachmentModelSupported,
   CONTEXT_WINDOW_TOKENS,
   DEFAULT_CONTEXT_WINDOW_TOKENS,
   getContextWindowTokens,
@@ -78,6 +80,42 @@ describe("BYOK provider role support", () => {
     expect(
       isBYOKProviderRoleSupported({ provider: "mistral", role: "pdf" }),
     ).toBe(false);
+  });
+
+  test("PDF chat attachments accept a superset that adds Mistral vision models", () => {
+    // Distinct from the pdf ROLE: this set only answers whether a PDF chat
+    // attachment survives the adapter. Mistral is intentionally absent from
+    // the pdf role above but its vision models accept PDF chat attachments, so
+    // the chat-attachment set is a strict superset for Mistral and identical
+    // elsewhere.
+    for (const provider of TANSTACK_AI_PROVIDERS) {
+      const roleModels: readonly string[] =
+        BYOK_DOCUMENT_INPUT_MODEL_OPTIONS[provider];
+      const attachmentModels: readonly string[] =
+        CHAT_PDF_ATTACHMENT_MODEL_OPTIONS[provider];
+      for (const modelId of roleModels) {
+        expect(attachmentModels).toContain(modelId);
+      }
+    }
+    expect(CHAT_PDF_ATTACHMENT_MODEL_OPTIONS.mistral).toContain(
+      "mistral-medium-latest",
+    );
+    expect(
+      isChatPdfAttachmentModelSupported({
+        provider: "mistral",
+        modelId: "mistral-medium-latest",
+      }),
+    ).toBe(true);
+    expect(
+      isChatPdfAttachmentModelSupported({
+        provider: "mistral",
+        modelId: "mistral-large-latest",
+      }),
+    ).toBe(false);
+    // Every Mistral PDF-attachment model must actually be offered to users.
+    for (const modelId of CHAT_PDF_ATTACHMENT_MODEL_OPTIONS.mistral) {
+      expect(BYOK_MODEL_OPTIONS.mistral).toContain(modelId);
+    }
   });
 
   test("does not route PDF flows through Bedrock text-only models", () => {

--- a/packages/ai-catalog/src/index.ts
+++ b/packages/ai-catalog/src/index.ts
@@ -319,6 +319,42 @@ export const isBYOKModelRoleSupported = ({
 };
 
 /**
+ * Models whose provider adapter can receive a PDF `document` content part in a
+ * chat turn without throwing. This is a narrower, runtime question than the
+ * pdf ROLE (`BYOK_DOCUMENT_INPUT_MODEL_OPTIONS`, which curates model selection
+ * for PDF-processing flows): it only asks "will the chat stream survive this
+ * attachment." The Mistral text adapter maps PDF `document` parts to
+ * `document_url` (patched in via the upstream document-input change), so its
+ * vision models accept PDF attachments even though Mistral is deliberately not
+ * offered as a pdf-role provider. Mistral's `document_url` takes PDF but NOT
+ * textual documents (docx/txt/csv/md), so those still gate on
+ * `BYOK_DOCUMENT_INPUT_MODEL_OPTIONS` (which excludes Mistral). Superset
+ * invariant: every pdf-role document model also accepts a PDF chat attachment.
+ */
+export const CHAT_PDF_ATTACHMENT_MODEL_OPTIONS = {
+  ...BYOK_DOCUMENT_INPUT_MODEL_OPTIONS,
+  mistral: [
+    "mistral-medium-latest",
+    "mistral-small-latest",
+    "pixtral-large-latest",
+  ],
+} as const satisfies {
+  [TProvider in BYOKProvider]: readonly BYOKModelIdByProvider[TProvider][];
+};
+
+export const isChatPdfAttachmentModelSupported = ({
+  provider,
+  modelId,
+}: {
+  provider: BYOKProvider;
+  modelId: string;
+}): boolean => {
+  const supportedModels: readonly string[] =
+    CHAT_PDF_ATTACHMENT_MODEL_OPTIONS[provider];
+  return supportedModels.includes(modelId);
+};
+
+/**
  * Whether a model id is currently offered for this provider+role: it
  * must be in the curated catalog for the provider AND satisfy the
  * role's input-modality constraint (PDF needs a document-capable

--- a/patches/@tanstack%2Fai-mistral@0.2.2.patch
+++ b/patches/@tanstack%2Fai-mistral@0.2.2.patch
@@ -1,5 +1,5 @@
 diff --git a/dist/esm/adapters/text.js b/dist/esm/adapters/text.js
-index f9627b9..cbe700a 100644
+index f9627b9147623292d8f17153be3138e539957d20..438a1b3ab2bcc8808543bef8835b177ca32ab039 100644
 --- a/dist/esm/adapters/text.js
 +++ b/dist/esm/adapters/text.js
 @@ -1,15 +1,16 @@
@@ -90,8 +90,23 @@ index f9627b9..cbe700a 100644
            } catch {
              partialInput = {};
            }
+@@ -665,8 +673,13 @@ class MistralTextAdapter extends BaseTextAdapter {
+         imageUrl: imageMetadata?.detail ? { url: imageUrl, detail: imageMetadata.detail } : imageUrl
+       };
+     }
++    if (part.type === "document") {
++      const documentValue = part.source.value;
++      const documentUrl = part.source.type === "data" && !documentValue.startsWith("data:") ? `data:${part.source.mimeType};base64,${documentValue}` : documentValue;
++      return { type: "document_url", documentUrl };
++    }
+     throw new Error(
+-      `Mistral text adapter does not support content part of type '${part.type}'. Supported types: text, image. Use a vision-capable model (pixtral-large-latest, pixtral-12b-2409, mistral-medium-latest, or mistral-small-latest) for images.`
++      `Mistral text adapter does not support content part of type '${part.type}'. Supported types: text, image, document. Use a vision-capable model (mistral-medium-latest or mistral-small-latest) for images and documents.`
+     );
+   }
+   /**
 diff --git a/dist/esm/tools/function-tool.js b/dist/esm/tools/function-tool.js
-index bc00221..27fa02f 100644
+index bc0022117d0291720e7ef32054b00a372b9562ab..27fa02fecb2ab7fee2335cfdaff65132884946d1 100644
 --- a/dist/esm/tools/function-tool.js
 +++ b/dist/esm/tools/function-tool.js
 @@ -1,4 +1,4 @@
@@ -119,7 +134,7 @@ index bc00221..27fa02f 100644
    };
  }
 diff --git a/dist/esm/utils/schema-converter.js b/dist/esm/utils/schema-converter.js
-index 2d0f3c4..a944a72 100644
+index 2d0f3c4c8ebd9ab94d1eed248c178921b8e5a9b3..a944a72894ec47e6cec63cb8d5f69163456895f2 100644
 --- a/dist/esm/utils/schema-converter.js
 +++ b/dist/esm/utils/schema-converter.js
 @@ -1,73 +1,120 @@
@@ -371,7 +386,7 @@ index 2d0f3c4..a944a72 100644
  };
  //# sourceMappingURL=schema-converter.js.map
 diff --git a/package.json b/package.json
-index cf9eb73..e19941a 100644
+index cf9eb735c761dbef8386acd4bf3b3aa26e194f37..e19941abb0e89d4bc6ad40f40f7c3e6355ad6261 100644
 --- a/package.json
 +++ b/package.json
 @@ -42,7 +42,8 @@


### PR DESCRIPTION
## Problem

Chat file attachments are hydrated into AI content parts before being sent to the model. Two issues in that path:

1. **Text-extractable formats were sent as `document` parts** (or, in the default non-anonymized mode, as raw bytes). `createChatAttachmentPart` types any non-image mime as `type: "document"`, so docx/txt/csv/md all became `document` parts — and a `document` part carrying non-PDF bytes is not valid input for several provider adapters. Depending on the selected model, such an attachment could fail the chat stream.
2. **No modality gate.** Chat model selection never checked whether the resolved model can actually ingest an attachment's format, so an incompatible pairing reached the adapter and threw.

The raw-send path made it worse: the `rawOverride` branch returned before the extraction code, so whenever anonymization was off (the default), a docx was shipped as raw bytes that no adapter reads.

## Change

- **Text-extractable attachments (docx/txt/csv/md) are always reduced to a `text` content part**, in both send modes, using folio's structure-preserving Markdown extraction (`extractMarkdown` — headings, tables, lists) instead of a flat paragraph join. Text is universal across provider adapters, so these attachments are never modality-gated and cannot crash a stream. The separately-persisted `userfile://` reference part still renders the attachment chip in the UI; only the provider-bound copy changes.
- **Genuine `document` (PDF) attachments are gated by the resolved model's input modality** before dispatch: a model that cannot ingest the format gets a clean `422`, and a fallback model that would also reject it is dropped so a failover cannot re-introduce the mismatch.
- **Mistral vision models now accept PDF `document` input** (adopts [TanStack/ai#912](https://github.com/TanStack/ai/pull/912) as a local patch until release). This is exposed through a chat-attachment capability set (`CHAT_PDF_ATTACHMENT_MODEL_OPTIONS`) kept **distinct** from the pdf-role catalog, so it does not turn Mistral into a pdf-role provider elsewhere in the app.

## Why it's structurally safe going forward

- Text-extractable content is now *text*, so it can never be a modality mismatch — the only `document` parts reaching a model are PDFs, which are gated.
- A **catalog-wide property test** pins every offered model's document capability (textual + PDF) to the typed catalog, with a superset invariant, so adding a model/provider without wiring its modality fails the test instead of shipping a latent crash.
- Extraction tests assert text-extractable attachments become `text` parts (never raw/`document`) in both modes; gate tests cover the PDF/textual/refused matrix.

## Tests
`@stll/ai-catalog` and the affected `@stll/api` suites pass (property, gate, extraction, and the existing hydration/boundary tests).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added gated support for PDF and text document attachments on compatible chat models, including selected Mistral models.
  - DOCX uploads are consistently reduced to extracted, readable text before being sent.

- **Bug Fixes**
  - Unsupported attachment MIME types are rejected before chat generation begins (HTTP 422).
  - Improved failover so fallback models don’t retry with attachments they can’t handle.
  - Enhanced extracted-text handling, including preservation of filenames and correct empty-content behaviour.

- **Tests**
  - Added/updated coverage for document-attachment capability gating and DOCX extraction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->