### PR TITLE
feat(api): add read_workspace_document chat tool

### DIFF
--- a/apps/api/src/handlers/chat/tools/chat-tools.ts
+++ b/apps/api/src/handlers/chat/tools/chat-tools.ts
@@ -46,6 +46,10 @@ import {
 import { createInfosoudTools } from "@/api/handlers/chat/tools/infosoud-tools";
 import { createOrgTools } from "@/api/handlers/chat/tools/org-tools";
 import {
+  createReadWorkspaceDocumentTools,
+  READ_WORKSPACE_DOCUMENT_TOOL_NAME,
+} from "@/api/handlers/chat/tools/read-workspace-document-tools";
+import {
   buildChatWriteTools,
   type ChatRegistryWriteToolMap,
 } from "@/api/handlers/chat/tools/registry-write-tools";
@@ -164,6 +168,9 @@ type InfosoudTools = ReturnType<typeof createInfosoudTools>;
 type ActiveDocxEditTools = ReturnType<typeof createActiveDocxEditTools>;
 type FolioAgentDocTools = ReturnType<typeof createFolioAgentDocTools>;
 type CreateDocumentTools = ReturnType<typeof createCreateDocumentTools>;
+type ReadWorkspaceDocumentTools = ReturnType<
+  typeof createReadWorkspaceDocumentTools
+>;
 type WebSearchTools = ReturnType<typeof createWebSearchTools>;
 type ChatHistoryTools = ReturnType<typeof createChatHistoryTools>;
 type CurrentSkillEditToolName =
@@ -190,6 +197,7 @@ type BuiltInChatTools = OrgTools &
   ActiveDocxEditTools &
   FolioAgentDocTools &
   CreateDocumentTools &
+  ReadWorkspaceDocumentTools &
   WebSearchTools &
   ChatHistoryTools &
   TemplateTools &
@@ -384,6 +392,11 @@ const BUILT_IN_CHAT_TOOL_POLICY_KINDS = {
   list_templates: CHAT_TOOL_POLICY_KIND.internal,
   "load-skill": CHAT_TOOL_POLICY_KIND.internal,
   [READ_DOCUMENT_TOOL_NAME]: CHAT_TOOL_POLICY_KIND.internal,
+  // Server-executed, read-only document read: resolves an entity/version id
+  // to a DOCX buffer under the caller's authorized workspaces and returns
+  // Markdown, so it runs immediately without per-call approval — same class
+  // as compare_versions.
+  [READ_WORKSPACE_DOCUMENT_TOOL_NAME]: CHAT_TOOL_POLICY_KIND.internal,
   "read-skill-resource": CHAT_TOOL_POLICY_KIND.internal,
   [SEARCH_CHAT_HISTORY_TOOL_NAME]: CHAT_TOOL_POLICY_KIND.internal,
   suggest_template_fields: CHAT_TOOL_POLICY_KIND.internal,
@@ -604,6 +617,19 @@ export const getChatTools = (props: GetChatToolsProps): ChatToolMap => {
           toolWorkspaceIds,
         });
 
+  // Server-executed document-read tool: reads any authorized document by
+  // entity/version id, converted to Markdown. Gated on a non-empty
+  // workspace set only — unlike `versionCompareTools`, it is not tied to
+  // the active file, so it works from any chat surface with matter access.
+  const readWorkspaceDocumentTools =
+    toolWorkspaceIds.length === 0
+      ? {}
+      : createReadWorkspaceDocumentTools({
+          safeDb,
+          organizationId,
+          toolWorkspaceIds,
+        });
+
   const registryWriteTools =
     toolWorkspaceIds.length === 0
       ? {}
@@ -665,6 +691,7 @@ export const getChatTools = (props: GetChatToolsProps): ChatToolMap => {
       ...activeDocxEditTools,
       ...folioAgentDocTools,
       ...versionCompareTools,
+      ...readWorkspaceDocumentTools,
       ...webSearchTools,
       ...registryWriteTools,
       ...externalChatTools,

--- a/apps/api/src/handlers/chat/tools/read-workspace-document-tools.test.ts
+++ b/apps/api/src/handlers/chat/tools/read-workspace-document-tools.test.ts
@@ -1,0 +1,248 @@
+import { Result } from "better-result";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import JSZip from "jszip";
+
+import type { Transaction } from "@/api/db/root";
+import type { SafeDb } from "@/api/db/safe-db";
+import { resolveToolWorkspaceIds } from "@/api/handlers/chat/tools/authorized-workspace-ids";
+import { toSafeId, type SafeId } from "@/api/lib/branded-types";
+import { DOCX_MIME_TYPE } from "@/api/mime-types";
+import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
+
+const organizationId = toSafeId<"organization">(
+  "11111111-1111-4111-8111-111111111111",
+);
+const workspaceId = toSafeId<"workspace">(
+  "22222222-2222-4222-8222-222222222222",
+);
+const entityId = "55555555-5555-4555-8555-555555555555";
+const currentVersionId = toSafeId<"entityVersion">(
+  "33333333-3333-4333-8333-333333333333",
+);
+const otherVersionId = "44444444-4444-4444-8444-444444444444";
+const fileId = "66666666-6666-4666-8666-666666666666";
+
+const toolWorkspaceIds = resolveToolWorkspaceIds({
+  pinnedIds: [],
+  accessibleWorkspaceIds: [workspaceId],
+});
+
+/** Minimal DOCX with a heading and a body paragraph, for markdown extraction. */
+const makeDocxBytes = async (): Promise<Uint8Array> => {
+  const zip = new JSZip();
+  zip.file(
+    "word/document.xml",
+    `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+<w:body>
+  <w:p><w:pPr><w:pStyle w:val="Heading1"/></w:pPr><w:r><w:t>Agreement</w:t></w:r></w:p>
+  <w:p><w:r><w:t>Jan Novak signs here.</w:t></w:r></w:p>
+</w:body></w:document>`,
+  );
+  zip.file(
+    "[Content_Types].xml",
+    `<?xml version="1.0" encoding="UTF-8"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="xml" ContentType="application/xml"/>
+</Types>`,
+  );
+  // Copy into a fresh ArrayBuffer-backed view so `.buffer` is an ArrayBuffer
+  // (not ArrayBufferLike) for the S3 arrayBuffer mock's return type.
+  return new Uint8Array(await zip.generateAsync({ type: "uint8array" }));
+};
+
+const arrayBufferMock = mock(async () => {
+  const bytes = await makeDocxBytes();
+  return bytes.buffer.slice(
+    bytes.byteOffset,
+    bytes.byteOffset + bytes.byteLength,
+  );
+});
+const fileMock = mock(() => ({ arrayBuffer: arrayBufferMock }));
+
+void mock.module("@/api/lib/s3", () => ({
+  getS3: () => ({ file: fileMock }),
+}));
+
+const { createReadWorkspaceDocumentTools, READ_WORKSPACE_DOCUMENT_TOOL_NAME } =
+  await import("./read-workspace-document-tools");
+
+const mockDocxFieldContent = {
+  version: 1,
+  type: "file",
+  id: fileId,
+  fileName: "document.docx",
+  mimeType: DOCX_MIME_TYPE,
+  sizeBytes: 1,
+  encrypted: true,
+  sha256Hex: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  pdfFileId: null,
+} as const;
+
+type MockEntity = { currentVersionId: SafeId<"entityVersion"> | null };
+type MockVersion = {
+  workspaceId: typeof workspaceId;
+  fields: { content: typeof mockDocxFieldContent }[];
+};
+
+const createSafeDb = ({
+  entitiesById = {},
+  versionsById = {},
+}: {
+  entitiesById?: Record<string, MockEntity | undefined>;
+  versionsById?: Record<string, MockVersion | undefined>;
+}): SafeDb => {
+  const tx = {
+    query: {
+      entities: {
+        findFirst: async ({ where }: { where: { id: { eq: string } } }) =>
+          entitiesById[where.id.eq],
+      },
+      entityVersions: {
+        findFirst: async ({ where }: { where: { id: { eq: string } } }) =>
+          versionsById[where.id.eq],
+      },
+    },
+  };
+  return async (callback) =>
+    // oxlint-disable-next-line node/callback-return -- result must be wrapped in Result.ok, not returned raw
+    Result.ok(await callback(asTestRaw<Transaction>(tx)));
+};
+
+const getExecute = (safeDb: SafeDb) => {
+  const tools = createReadWorkspaceDocumentTools({
+    safeDb,
+    organizationId,
+    toolWorkspaceIds,
+  });
+  const tool = tools[READ_WORKSPACE_DOCUMENT_TOOL_NAME];
+  const execute = tool.execute;
+  if (!execute) {
+    throw new Error("read_workspace_document must be server-executed");
+  }
+  return execute;
+};
+
+const runAndCaptureMessage = async (
+  execute: ReturnType<typeof getExecute>,
+  input: { entityId: string; versionId?: string },
+) => {
+  try {
+    await execute(input, asTestRaw<Parameters<typeof execute>[1]>({}));
+  } catch (error) {
+    return error instanceof Error ? error.message : String(error);
+  }
+  throw new Error("Expected read_workspace_document to reject");
+};
+
+describe("createReadWorkspaceDocumentTools", () => {
+  beforeEach(() => {
+    arrayBufferMock.mockClear();
+    fileMock.mockClear();
+  });
+
+  test("registers a single server-executed read_workspace_document tool", () => {
+    const tools = createReadWorkspaceDocumentTools({
+      safeDb: createSafeDb({}),
+      organizationId,
+      toolWorkspaceIds,
+    });
+    expect(Object.keys(tools)).toEqual([READ_WORKSPACE_DOCUMENT_TOOL_NAME]);
+    expect(
+      tools[READ_WORKSPACE_DOCUMENT_TOOL_NAME].needsApproval,
+    ).toBeUndefined();
+    expect(tools[READ_WORKSPACE_DOCUMENT_TOOL_NAME].execute).toBeDefined();
+  });
+
+  test("reads the current version's DOCX as markdown when no versionId is given", async () => {
+    const execute = getExecute(
+      createSafeDb({
+        entitiesById: { [entityId]: { currentVersionId } },
+        versionsById: {
+          [currentVersionId]: {
+            workspaceId,
+            fields: [{ content: mockDocxFieldContent }],
+          },
+        },
+      }),
+    );
+
+    const result = await execute(
+      { entityId },
+      asTestRaw<Parameters<typeof execute>[1]>({}),
+    );
+
+    expect(result.markdown).toContain("Agreement");
+    expect(result.markdown).toContain("Jan Novak signs here.");
+  });
+
+  test("reads an explicit version's DOCX as markdown, bypassing the entity lookup", async () => {
+    const execute = getExecute(
+      createSafeDb({
+        // No entity row registered: an explicit versionId must never touch
+        // `tx.query.entities`.
+        versionsById: {
+          [otherVersionId]: {
+            workspaceId,
+            fields: [{ content: mockDocxFieldContent }],
+          },
+        },
+      }),
+    );
+
+    const result = await execute(
+      { entityId, versionId: otherVersionId },
+      asTestRaw<Parameters<typeof execute>[1]>({}),
+    );
+
+    expect(result.markdown).toContain("Agreement");
+  });
+
+  test("rejects a document not found in the caller's authorized workspaces", async () => {
+    const message = await runAndCaptureMessage(
+      getExecute(createSafeDb({ entitiesById: { [entityId]: undefined } })),
+      { entityId },
+    );
+    expect(message).toMatch(/document was not found in your workspaces/iu);
+  });
+
+  test("rejects a document with no current version", async () => {
+    const message = await runAndCaptureMessage(
+      getExecute(
+        createSafeDb({
+          entitiesById: { [entityId]: { currentVersionId: null } },
+        }),
+      ),
+      { entityId },
+    );
+    expect(message).toMatch(/no current version to read/iu);
+  });
+
+  test("rejects a version not found in the caller's authorized workspaces", async () => {
+    const message = await runAndCaptureMessage(
+      getExecute(
+        createSafeDb({
+          entitiesById: { [entityId]: { currentVersionId } },
+          versionsById: { [currentVersionId]: undefined },
+        }),
+      ),
+      { entityId },
+    );
+    expect(message).toMatch(
+      /document version was not found in your workspaces/iu,
+    );
+  });
+
+  test("rejects a version with no DOCX file", async () => {
+    const message = await runAndCaptureMessage(
+      getExecute(
+        createSafeDb({
+          entitiesById: { [entityId]: { currentVersionId } },
+          versionsById: { [currentVersionId]: { workspaceId, fields: [] } },
+        }),
+      ),
+      { entityId },
+    );
+    expect(message).toMatch(/does not contain a DOCX file/iu);
+  });
+});

--- a/apps/api/src/handlers/chat/tools/read-workspace-document-tools.ts
+++ b/apps/api/src/handlers/chat/tools/read-workspace-document-tools.ts
@@ -1,0 +1,252 @@
+import { toolDefinition } from "@tanstack/ai";
+import { Result } from "better-result";
+import * as v from "valibot";
+
+import { docxToMarkdown } from "@stll/folio-core/server";
+
+import type { SafeDb } from "@/api/db/safe-db";
+import type { FieldContent } from "@/api/db/schema-validators";
+import type { AuthorizedToolWorkspaceIds } from "@/api/handlers/chat/tools/authorized-workspace-ids";
+import { toTanStackToolSchema } from "@/api/handlers/chat/tools/tanstack-tool-schema";
+import { createFileKey } from "@/api/handlers/files/utils";
+import type { SafeId } from "@/api/lib/branded-types";
+import { ChatToolError } from "@/api/lib/errors/tagged-errors";
+import { LIMITS } from "@/api/lib/limits";
+import { getS3 } from "@/api/lib/s3";
+import {
+  brandPersistedEntityId,
+  brandPersistedEntityVersionId,
+} from "@/api/lib/safe-id-boundaries";
+import { DOCX_MIME_TYPE } from "@/api/mime-types";
+
+export const READ_WORKSPACE_DOCUMENT_TOOL_NAME = "read_workspace_document";
+
+const readWorkspaceDocumentInputSchema = v.strictObject({
+  entityId: v.pipe(
+    v.string(),
+    v.uuid(),
+    v.description("Entity id of the document to read."),
+  ),
+  versionId: v.optional(
+    v.pipe(
+      v.string(),
+      v.uuid(),
+      v.description(
+        "Specific entity version id to read. Omit to read the document's " +
+          "current version.",
+      ),
+    ),
+  ),
+});
+
+const readWorkspaceDocumentOutputSchema = v.strictObject({
+  markdown: v.pipe(
+    v.string(),
+    v.description(
+      `The document's DOCX content converted to Markdown (headings, tables, ` +
+        `lists, and content controls preserved), capped at ` +
+        `${String(LIMITS.chatContextFileMaxChars)} characters.`,
+    ),
+  ),
+});
+
+type CreateReadWorkspaceDocumentToolsProps = {
+  safeDb: SafeDb;
+  organizationId: SafeId<"organization">;
+  // The access boundary for this tool: an entity or version whose workspace
+  // is not in this list is treated as not found, so a model can never read a
+  // document outside the caller's authorized workspaces.
+  toolWorkspaceIds: AuthorizedToolWorkspaceIds;
+};
+
+type ResolvedDocumentDocx = {
+  workspaceId: SafeId<"workspace">;
+  fileId: string;
+};
+
+const isDocxFileContent = (
+  content: FieldContent,
+): content is Extract<FieldContent, { type: "file" }> =>
+  content.type === "file" && content.mimeType === DOCX_MIME_TYPE;
+
+/**
+ * Resolve an entity id (with no version id given) to its current version id,
+ * enforcing that the entity lives in one of the caller's authorized
+ * workspaces. Throws a `ChatToolError` when the entity is unknown, sits
+ * outside the authorized set, or has no current version.
+ */
+const resolveCurrentVersionId = async (
+  safeDb: SafeDb,
+  toolWorkspaceIds: AuthorizedToolWorkspaceIds,
+  entityId: SafeId<"entity">,
+): Promise<SafeId<"entityVersion">> => {
+  const entity = await safeDb((tx) =>
+    tx.query.entities.findFirst({
+      where: {
+        id: { eq: entityId },
+        workspaceId: { in: toolWorkspaceIds },
+      },
+      columns: { currentVersionId: true },
+    }),
+  );
+
+  if (Result.isError(entity)) {
+    throw new ChatToolError({
+      message: "Failed to look up the document.",
+      cause: entity.error,
+    });
+  }
+  if (!entity.value) {
+    throw new ChatToolError({
+      message: "The document was not found in your workspaces.",
+    });
+  }
+  if (!entity.value.currentVersionId) {
+    throw new ChatToolError({
+      message: "The document has no current version to read.",
+    });
+  }
+
+  return entity.value.currentVersionId;
+};
+
+/**
+ * Resolve one entity version id to its DOCX file, enforcing that the version
+ * lives in one of the caller's authorized workspaces and belongs to the
+ * given entity. Throws a `ChatToolError` (surfaced to the model) when the
+ * version is unknown, sits outside the authorized set, or holds no DOCX file
+ * — never leaking which of those it was beyond "not found in your
+ * workspaces".
+ */
+const resolveDocumentDocx = async (
+  safeDb: SafeDb,
+  toolWorkspaceIds: AuthorizedToolWorkspaceIds,
+  entityId: SafeId<"entity">,
+  versionId: SafeId<"entityVersion">,
+): Promise<ResolvedDocumentDocx> => {
+  // Read the version and its fields in one tombstone-checked query. Reading
+  // fields separately after the version's `deletedAt IS NULL` check would
+  // leave a TOCTOU window: a tombstone landing between the two reads would
+  // still hand a withdrawn version's DOCX to the model.
+  const version = await safeDb((tx) =>
+    tx.query.entityVersions.findFirst({
+      where: {
+        id: { eq: versionId },
+        entityId: { eq: entityId },
+        workspaceId: { in: toolWorkspaceIds },
+        // Tombstoned versions are withdrawn: never resolvable for AI reads.
+        deletedAt: { isNull: true },
+      },
+      columns: { workspaceId: true },
+      with: { fields: { columns: { content: true } } },
+    }),
+  );
+
+  if (Result.isError(version)) {
+    throw new ChatToolError({
+      message: "Failed to look up the document version.",
+      cause: version.error,
+    });
+  }
+  if (!version.value) {
+    throw new ChatToolError({
+      message: "The document version was not found in your workspaces.",
+    });
+  }
+
+  const file = version.value.fields
+    .map((field) => field.content)
+    .find(isDocxFileContent);
+
+  if (!file) {
+    throw new ChatToolError({
+      message: "The document version does not contain a DOCX file.",
+    });
+  }
+
+  return { workspaceId: version.value.workspaceId, fileId: file.id };
+};
+
+const loadDocumentDocxBuffer = async (
+  organizationId: SafeId<"organization">,
+  resolved: ResolvedDocumentDocx,
+): Promise<ArrayBuffer> =>
+  await getS3()
+    .file(
+      createFileKey({
+        organizationId,
+        workspaceId: resolved.workspaceId,
+        fileId: resolved.fileId,
+        mimeType: DOCX_MIME_TYPE,
+      }),
+    )
+    .arrayBuffer();
+
+/**
+ * Server-executed `read_workspace_document` chat tool: read a workspace
+ * document's DOCX content as Markdown. Resolves an entity id (and optional
+ * version id, defaulting to the current version) to an S3 DOCX buffer after
+ * validating it belongs to one of the caller's authorized workspaces, then
+ * returns folio's structure-preserving Markdown extraction (headings,
+ * tables, lists, content controls), capped at
+ * `LIMITS.chatContextFileMaxChars`.
+ *
+ * Distinct from the folio-agents `read_document` tool registered in
+ * `folio-agent-tools.ts`: that one is client-executed against the *live
+ * DOCX editor* for the active file only, gated on `hasActiveDocxFileClient`.
+ * This tool is server-executed and can read any authorized document by id
+ * — including documents other than the one currently open — so it is
+ * always registered when the caller has at least one accessible workspace.
+ *
+ * Read-only, so classified `CHAT_TOOL_POLICY_KIND.internal` (no approval) in
+ * `chat-tools.ts`.
+ */
+export const createReadWorkspaceDocumentTools = ({
+  safeDb,
+  organizationId,
+  toolWorkspaceIds,
+}: CreateReadWorkspaceDocumentToolsProps) => ({
+  [READ_WORKSPACE_DOCUMENT_TOOL_NAME]: toolDefinition({
+    name: READ_WORKSPACE_DOCUMENT_TOOL_NAME,
+    description:
+      "Read a workspace document's content as Markdown, converted from its " +
+      "DOCX file with structure preserved (headings, tables, lists, content " +
+      "controls). Pass the document's entity id; optionally pass a specific " +
+      "entityVersionId to read a past version instead of the current one. " +
+      "Use this to pull any authorized document into context on demand — " +
+      "not only the one the user currently has open.",
+    inputSchema: toTanStackToolSchema(readWorkspaceDocumentInputSchema),
+    outputSchema: toTanStackToolSchema(readWorkspaceDocumentOutputSchema),
+  }).server(async ({ entityId, versionId }) => {
+    const brandedEntityId = brandPersistedEntityId(entityId);
+    const brandedVersionId =
+      versionId === undefined
+        ? await resolveCurrentVersionId(
+            safeDb,
+            toolWorkspaceIds,
+            brandedEntityId,
+          )
+        : brandPersistedEntityVersionId(versionId);
+
+    const resolved = await resolveDocumentDocx(
+      safeDb,
+      toolWorkspaceIds,
+      brandedEntityId,
+      brandedVersionId,
+    );
+
+    const buffer = await loadDocumentDocxBuffer(organizationId, resolved);
+
+    let markdown: string;
+    try {
+      markdown = await docxToMarkdown(buffer);
+    } catch (error) {
+      throw new ChatToolError({
+        message: "Failed to convert the document to Markdown.",
+        cause: error,
+      });
+    }
+
+    return { markdown: markdown.slice(0, LIMITS.chatContextFileMaxChars) };
+  }),
+});


### PR DESCRIPTION
## Summary
- Adds a server-executed `read_workspace_document` chat tool that reads a workspace document's DOCX content as Markdown (folio's `docxToMarkdown`), so the agent can pull any authorized document into context on demand.
- Input: `{ entityId, versionId? }` (`versionId` optional, defaults to the entity's current version). Resolution follows the same TOCTOU-guarded, workspace-authorized pattern as `compare_versions` (`version-compare-tools.ts`): the version query requires `workspaceId IN toolWorkspaceIds` and `deletedAt IS NULL` in a single read, and the DOCX field lookup happens in the same round trip.
- Output is capped at `LIMITS.chatContextFileMaxChars`.
- Classified `internal` (read-only, no per-call approval) and registered whenever the caller has at least one accessible workspace — not tied to the active file, unlike `compare_versions`.
- Distinct from the folio-agents `read_document` tool (`folio-agent-tools.ts`): that one is client-executed against the *live DOCX editor* for the active file only. This tool is server-executed and can read any authorized document by id.

## Test plan
- [x] `bun --filter @stll/api typecheck`
- [x] `bun test --preload ./src/tests/setup-env.ts src/handlers/chat/tools/read-workspace-document-tools.test.ts` (7 pass)
- [x] `oxlint --deny-warnings --type-aware` on changed files
- [x] `oxfmt` on changed files