### PR TITLE
feat(ui): display active member role badge in user menu

### DIFF
--- a/apps/web/src/components/sidebar-user-menu.tsx
+++ b/apps/web/src/components/sidebar-user-menu.tsx
@@ -108,7 +108,7 @@ export function SidebarUserMenu({ user }: SidebarUserMenuProps) {
                     <div className="flex min-w-0 items-center gap-1.5">
                       <BidiText
                         as="span"
-                        className="truncate text-sm font-medium"
+                        className="min-w-0 truncate text-sm font-medium"
                       >
                         {user.name}
                       </BidiText>
@@ -132,7 +132,7 @@ export function SidebarUserMenu({ user }: SidebarUserMenuProps) {
                   <div className="flex min-w-0 items-center gap-1.5">
                     <BidiText
                       as="span"
-                      className="truncate text-sm font-medium"
+                      className="min-w-0 truncate text-sm font-medium"
                       direction={user.email ? "ltr" : "auto"}
                     >
                       {user.email || t("common.user")}

--- a/apps/web/src/components/sidebar-user-menu.tsx
+++ b/apps/web/src/components/sidebar-user-menu.tsx
@@ -44,6 +44,7 @@ import {
   useI18nStore,
 } from "@/i18n/i18n-store";
 import { getInitials } from "@/lib/get-initials";
+import { roleOptions } from "@/routes/-queries";
 import { organizationSummaryOptions } from "@/routes/_protected.organization/-queries";
 
 const CHANGELOG_URL = "https://stll.app/changelog";
@@ -73,6 +74,7 @@ export function SidebarUserMenu({ user }: SidebarUserMenuProps) {
   const { data: organization } = useChromeQuery(
     organizationSummaryOptions(user.activeOrganizationId),
   );
+  const { data: role } = useChromeQuery(roleOptions);
 
   const displayName = user.name ?? user.email;
   const orgName = organization?.name;
@@ -103,12 +105,19 @@ export function SidebarUserMenu({ user }: SidebarUserMenuProps) {
               <div className="flex min-w-0 flex-col justify-center">
                 {user.name ? (
                   <>
-                    <BidiText
-                      as="span"
-                      className="truncate text-sm font-medium"
-                    >
-                      {user.name}
-                    </BidiText>
+                    <div className="flex min-w-0 items-center gap-1.5">
+                      <BidiText
+                        as="span"
+                        className="truncate text-sm font-medium"
+                      >
+                        {user.name}
+                      </BidiText>
+                      {role && (
+                        <span className="bg-muted text-muted-foreground inline-flex shrink-0 items-center rounded-md px-1.5 py-0.5 text-[0.625rem] font-medium select-none">
+                          {t(`organization.roles.${role}`)}
+                        </span>
+                      )}
+                    </div>
                     {user.email && (
                       <BidiText
                         as="span"
@@ -120,13 +129,20 @@ export function SidebarUserMenu({ user }: SidebarUserMenuProps) {
                     )}
                   </>
                 ) : (
-                  <BidiText
-                    as="span"
-                    className="truncate text-sm font-medium"
-                    direction={user.email ? "ltr" : "auto"}
-                  >
-                    {user.email || t("common.user")}
-                  </BidiText>
+                  <div className="flex min-w-0 items-center gap-1.5">
+                    <BidiText
+                      as="span"
+                      className="truncate text-sm font-medium"
+                      direction={user.email ? "ltr" : "auto"}
+                    >
+                      {user.email || t("common.user")}
+                    </BidiText>
+                    {role && (
+                      <span className="bg-muted text-muted-foreground inline-flex shrink-0 items-center rounded-md px-1.5 py-0.5 text-[0.625rem] font-medium select-none">
+                        {t(`organization.roles.${role}`)}
+                      </span>
+                    )}
+                  </div>
                 )}
               </div>
               <ChevronsUpDownIcon className="ms-auto size-4 opacity-50" />
@@ -137,7 +153,16 @@ export function SidebarUserMenu({ user }: SidebarUserMenuProps) {
           {orgName && (
             <>
               <MenuGroup>
-                <MenuGroupLabel className="text-sm">{orgName}</MenuGroupLabel>
+                <MenuGroupLabel className="pb-1 text-sm">
+                  {orgName}
+                </MenuGroupLabel>
+                {role && (
+                  <div className="px-2 pb-1.5">
+                    <span className="bg-muted text-muted-foreground inline-flex items-center rounded-md px-1.5 py-0.5 text-[0.6875rem] font-medium select-none">
+                      {t(`organization.roles.${role}`)}
+                    </span>
+                  </div>
+                )}
               </MenuGroup>
               <MenuSeparator />
             </>


### PR DESCRIPTION
## Proposed change
Displays the active organization role badge for the current user session in `SidebarUserMenu`.

- Fetches active member role using `useChromeQuery(roleOptions)`
- Renders a badge next to the user name/email in the sidebar trigger
- Renders a badge below the active organization name in the user menu popover

Closes #1138

## Checklist

<!--
  Put into **bold** for each item the appropriate option.
  Then mark the item with an `x` like so:
  `- [ ] BUILD ASSURANCE | Confirm that your code builds correctly and without any errors or warnings.
-->

<img width="332" height="306" alt="image" src="https://github.com/user-attachments/assets/cbd42a2d-d6f1-4b11-92dc-a0f465313d78" />


- [ ] BUILD ASSURANCE | Code builds correctly and without any errors or warnings.
- [ ] TESTING | Changes tested, including in different conditions (dark mode, language, narrow screen, etc).
- [ ] DARK MODE SUPPORT | User can use the webapp in dark mode. Make sure your changes are visible in both light and dark mode.
- [x] ISSUE LINKED | Link an issue to this PR (not by mentioning it in the description, but by using the GitHub issue linking feature)
- [x] SCREENSHOT INCLUDED | If relevant, please include a screenshot / video of the functionality added (allows for a quick check of minor ux changes)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a role label to the sidebar user menu.
  * Role information is now shown beside the user’s name and in the expanded menu, where available.

* **Style**
  * Updated the user menu layout and organisation label styling for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->