### PR TITLE
chore: guard against lockfile workspace-version drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,6 +184,16 @@ jobs:
         if: needs.ci-changes.outputs.package_checks_required == 'true'
         run: bun run lint:ws
 
+      - name: Lockfile workspace-version guard
+        # `bun.lock` caches each workspace's `name`/`version`; `bun install`
+        # (frozen or not) never rewrites that cache when only a workspace's
+        # own package.json version changes, and `bun pm pack`/`bun publish`
+        # read the stale cached version when resolving a dependent's
+        # `workspace:^`/`workspace:~` range at publish time. Catches drift
+        # before a published @stll/* package ships a wrong dependency range.
+        if: needs.ci-changes.outputs.package_checks_required == 'true'
+        run: bun scripts/check-lockfile-workspace-versions.ts
+
       - name: Policy evidence
         run: bun run policies:check
 

--- a/scripts/check-lockfile-workspace-versions.ts
+++ b/scripts/check-lockfile-workspace-versions.ts
@@ -67,23 +67,29 @@ const workspaceDirs = (await Promise.all(workspaceGlobs.map(dirsForGlob)))
 const lockText = await Bun.file(path.join(ROOT, "bun.lock")).text();
 
 // bun.lock is JSON-with-trailing-commas ("JSONC"-flavored), not strict JSON,
-// so a plain JSON.parse fails on it. Rather than hand-roll a tolerant parser
-// for the whole file (risking mis-parsing the many base64 `sha512-...`
-// strings that legitimately contain `//`), extract just the one shape we
-// need directly: the `"<workspace path>": { "name": ..., "version": ...,
-// "dependencies": { ... }, ... }` block bun emits per workspace entry.
-// Anchor on the block's own indentation and match everything up to the `}`
-// that closes at that same indentation, rather than stopping at the first
-// `}`: a nested map (`dependencies`, `devDependencies`, `bin`, ...) closing
-// before `version` would otherwise truncate the capture and hide the field.
+// so a plain JSON.parse fails on it as-is. Trailing commas only ever appear
+// directly before a closing `}`/`]`, and that exact sequence cannot occur
+// inside any of bun.lock's own string values (workspace paths, package
+// names/versions/specifiers, or the base64 `sha512-...` integrity hashes),
+// so stripping them is a safe, structure-preserving normalize. Parsing the
+// whole file once and reading `workspaces[dir].version` from the resulting
+// object is immune to bun's key ordering or nested-object shape — unlike a
+// per-block regex, there is no block to mis-extract.
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const parsedLock: unknown = JSON.parse(lockText.replace(/,(\s*[}\]])/gu, "$1"));
+if (!isRecord(parsedLock) || !isRecord(parsedLock.workspaces)) {
+  panic("bun.lock did not parse into the expected { workspaces: {...} } shape");
+}
+const { workspaces: lockWorkspaces } = parsedLock;
+
 const versionForWorkspace = (workspaceDir: string): string | null => {
-  const escaped = workspaceDir.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
-  const blockRe = new RegExp(`^(\\s*)"${escaped}":\\s*\\{([^]*?)^\\1\\}`, "mu");
-  const block = blockRe.exec(lockText)?.[2];
-  if (!block) {
+  const entry = lockWorkspaces[workspaceDir];
+  if (!isRecord(entry) || typeof entry.version !== "string") {
     return null;
   }
-  return /"version":\s*"([^"]+)"/u.exec(block)?.[1] ?? null;
+  return entry.version;
 };
 
 const mismatchForWorkspace = async (

--- a/scripts/check-lockfile-workspace-versions.ts
+++ b/scripts/check-lockfile-workspace-versions.ts
@@ -70,16 +70,16 @@ const lockText = await Bun.file(path.join(ROOT, "bun.lock")).text();
 // so a plain JSON.parse fails on it. Rather than hand-roll a tolerant parser
 // for the whole file (risking mis-parsing the many base64 `sha512-...`
 // strings that legitimately contain `//`), extract just the one shape we
-// need directly: the `"<workspace path>": { "name": ..., "version": ... }`
-// block bun emits per workspace entry. bun always writes `name` and
-// `version` first in that block, before any nested `dependencies` /
-// `devDependencies` / `bin` maps, so matching up to the *first* `}` (rather
-// than balancing braces) is safe: it always captures past the version field
-// even when it stops short of the block's real close.
+// need directly: the `"<workspace path>": { "name": ..., "version": ...,
+// "dependencies": { ... }, ... }` block bun emits per workspace entry.
+// Anchor on the block's own indentation and match everything up to the `}`
+// that closes at that same indentation, rather than stopping at the first
+// `}`: a nested map (`dependencies`, `devDependencies`, `bin`, ...) closing
+// before `version` would otherwise truncate the capture and hide the field.
 const versionForWorkspace = (workspaceDir: string): string | null => {
   const escaped = workspaceDir.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
-  const blockRe = new RegExp(`"${escaped}":\\s*\\{([^}]*)\\}`, "u");
-  const block = blockRe.exec(lockText)?.[1];
+  const blockRe = new RegExp(`^(\\s*)"${escaped}":\\s*\\{([^]*?)^\\1\\}`, "mu");
+  const block = blockRe.exec(lockText)?.[2];
   if (!block) {
     return null;
   }

--- a/scripts/check-lockfile-workspace-versions.ts
+++ b/scripts/check-lockfile-workspace-versions.ts
@@ -1,0 +1,138 @@
+#!/usr/bin/env bun
+// CI gate: catches stale workspace `"version"` fields cached in bun.lock.
+//
+// Why this exists: `bun install` (even non-frozen) does NOT rewrite the
+// `"version"` field bun.lock records for an already-present workspace entry
+// when only that package's own package.json version changed — it only
+// re-resolves dependency ranges. `bun install --frozen-lockfile` (what CI
+// runs everywhere) validates that the dependency graph still satisfies the
+// lockfile; it does not compare workspace self-versions either. So neither
+// the normal install path nor the frozen-lockfile CI gate ever notices a
+// workspace's recorded version drifting behind its package.json — and
+// `bun pm pack` / `bun publish` reads the *lockfile's* cached version when
+// resolving `workspace:^` / `workspace:~` ranges for a dependent's published
+// manifest, so a stale entry silently ships a wrong dependency range. Stella
+// publishes ~10 versioned `@stll/*` workspace packages, so it carries this
+// exposure even though it has no changesets-driven version bump script.
+//
+// The only fix once it drifts is `rm bun.lock && bun install` (a full
+// regenerate). This script cross-checks every workspace package.json
+// `version` against the version bun.lock has cached for that workspace, so
+// the drift itself gets caught in CI instead of silently persisting.
+//
+// Workspace directories are derived from the root package.json `workspaces`
+// globs (`apps/*`, `packages/*`), not hardcoded, so a new workspace root
+// (or a renamed one) is picked up automatically.
+
+import { panic } from "better-result";
+import { readdir } from "node:fs/promises";
+import path from "node:path";
+
+const ROOT = path.resolve(import.meta.dir, "..");
+
+const readJson = async (filePath: string): Promise<Record<string, unknown>> =>
+  JSON.parse(await Bun.file(filePath).text());
+
+// The root `workspaces` field only ever uses single-level globs of the shape
+// `<dir>/*` in this repo (`apps/*`, `packages/*`). Resolve each to its
+// immediate subdirectories rather than hand-rolling a general glob matcher.
+const globParent = (glob: string): string => {
+  if (!glob.endsWith("/*")) {
+    panic(`unsupported workspaces glob "${glob}": expected "<dir>/*"`);
+  }
+  return glob.slice(0, -"/*".length);
+};
+
+const rootPkg = await readJson(path.join(ROOT, "package.json"));
+const workspaceGlobs = Array.isArray(rootPkg.workspaces)
+  ? rootPkg.workspaces.filter(
+      (glob): glob is string => typeof glob === "string",
+    )
+  : panic("root package.json is missing a `workspaces` array");
+
+const dirsForGlob = async (glob: string): Promise<string[]> => {
+  const parent = globParent(glob);
+  const entries = await readdir(path.join(ROOT, parent), {
+    withFileTypes: true,
+  });
+  return entries
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => `${parent}/${entry.name}`);
+};
+
+const workspaceDirs = (await Promise.all(workspaceGlobs.map(dirsForGlob)))
+  .flat()
+  .sort();
+
+const lockText = await Bun.file(path.join(ROOT, "bun.lock")).text();
+
+// bun.lock is JSON-with-trailing-commas ("JSONC"-flavored), not strict JSON,
+// so a plain JSON.parse fails on it. Rather than hand-roll a tolerant parser
+// for the whole file (risking mis-parsing the many base64 `sha512-...`
+// strings that legitimately contain `//`), extract just the one shape we
+// need directly: the `"<workspace path>": { "name": ..., "version": ... }`
+// block bun emits per workspace entry. bun always writes `name` and
+// `version` first in that block, before any nested `dependencies` /
+// `devDependencies` / `bin` maps, so matching up to the *first* `}` (rather
+// than balancing braces) is safe: it always captures past the version field
+// even when it stops short of the block's real close.
+const versionForWorkspace = (workspaceDir: string): string | null => {
+  const escaped = workspaceDir.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
+  const blockRe = new RegExp(`"${escaped}":\\s*\\{([^}]*)\\}`, "u");
+  const block = blockRe.exec(lockText)?.[1];
+  if (!block) {
+    return null;
+  }
+  return /"version":\s*"([^"]+)"/u.exec(block)?.[1] ?? null;
+};
+
+const mismatchForWorkspace = async (
+  workspaceDir: string,
+): Promise<string | null> => {
+  const pkgPath = path.join(ROOT, workspaceDir, "package.json");
+  if (!(await Bun.file(pkgPath).exists())) {
+    return null;
+  }
+
+  const pkg = await readJson(pkgPath);
+  const { name, version } = pkg;
+  if (typeof name !== "string" || typeof version !== "string") {
+    return null;
+  }
+
+  const lockedVersion = versionForWorkspace(workspaceDir);
+  if (lockedVersion === null) {
+    return `${name} (${workspaceDir}): no bun.lock entry found`;
+  }
+  if (lockedVersion !== version) {
+    return `${name} (${workspaceDir}): package.json is ${version}, bun.lock has ${lockedVersion}`;
+  }
+  return null;
+};
+
+const mismatches = (
+  await Promise.all(workspaceDirs.map(mismatchForWorkspace))
+).filter((mismatch): mismatch is string => mismatch !== null);
+
+if (mismatches.length > 0) {
+  console.error(
+    [
+      "bun.lock workspace-version drift detected:",
+      "",
+      ...mismatches.map((line) => `  - ${line}`),
+      "",
+      "A plain `bun install` will not fix this (it doesn't rewrite cached",
+      "workspace versions for entries that already exist). Regenerate the",
+      "lockfile instead:",
+      "",
+      "    rm bun.lock && bun install",
+      "",
+      "Then commit the refreshed bun.lock.",
+    ].join("\n"),
+  );
+  process.exit(1);
+}
+
+console.log(
+  "bun.lock workspace-version check: all workspace versions match. OK.",
+);

--- a/scripts/check-lockfile-workspace-versions.ts
+++ b/scripts/check-lockfile-workspace-versions.ts
@@ -96,11 +96,14 @@ const mismatchForWorkspace = async (
   workspaceDir: string,
 ): Promise<string | null> => {
   const pkgPath = path.join(ROOT, workspaceDir, "package.json");
-  if (!(await Bun.file(pkgPath).exists())) {
+  // A directory matched by a workspace glob is not necessarily a real
+  // workspace: skip it (rather than crash the guard) if its package.json is
+  // missing or fails to parse.
+  const pkg = await readJson(pkgPath).catch(() => null);
+  if (pkg === null) {
     return null;
   }
 
-  const pkg = await readJson(pkgPath);
   const { name, version } = pkg;
   if (typeof name !== "string" || typeof version !== "string") {
     return null;

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -193,6 +193,7 @@ run_test() {
 
 run_step "AI skill sync" bash scripts/sync-ai-skills.sh --check
 run_step "Workspace hygiene" bun run lint:ws
+run_step "Lockfile workspace-version guard" bun scripts/check-lockfile-workspace-versions.ts
 run_step "Policy evidence" bun run policies:check
 run_step "Railway template shape" bun run check:railway-template
 run_step "i18n" bun run i18n:check


### PR DESCRIPTION
## Summary
- `bun.lock` caches each workspace's `name`/`version`, but `bun install` (even `--frozen-lockfile`, what CI runs) never validates that cached version against the workspace's own `package.json` — it only re-resolves dependency ranges. `bun pm pack`/`bun publish` read the *lockfile's* cached version when resolving a dependent's `workspace:^`/`workspace:~` range at publish time, so a stale cached version can silently ship a wrong dependency range in a published package.
- stella publishes ~10 versioned `@stll/*` workspace packages (boe, cli, business-registries, conditions, docx-utils, template-conditions, country-codes, infosoud, locales, text-normalize) via `workspace:` deps, so it carries this exposure.
- Adds `scripts/check-lockfile-workspace-versions.ts`: derives workspace directories from the root `package.json` `workspaces` globs (`apps/*`, `packages/*`), extracts each workspace's cached version out of `bun.lock` via regex (the lockfile is JSONC-flavored, not strict JSON), and fails when it disagrees with the package's own `package.json` version.
- Wires the guard into the `ci-checks` job, right after the existing "Workspace hygiene" step — cheap, no build required.
- Ran the guard against the current committed lockfile first: **no drift found**, all workspace versions already match; the lockfile did not need regeneration.

## Test plan
- [x] `bun scripts/check-lockfile-workspace-versions.ts` passes against the current lockfile
- [x] Manually injected a version mismatch into a scratch copy of `bun.lock` and confirmed the script exits 1 and reports it, then restored the real lockfile
- [x] `bun --bun oxlint -c oxlint.config.ts --deny-warnings --type-aware scripts/check-lockfile-workspace-versions.ts` clean
- [x] `bunx oxfmt scripts/check-lockfile-workspace-versions.ts` clean
- [x] `actionlint .github/workflows/ci.yml` clean
- [x] pre-push hook (format, i18n, typecheck) passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added an automated check to detect inconsistent workspace versions in the lockfile.
  * CI now reports affected workspaces and provides steps to resolve version mismatches before merging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->