### PR TITLE
feat(api): read_content_across_matters serves folio markdown (converge document read)

### DIFF
--- a/apps/api/src/handlers/chat/chat-prompt.ts
+++ b/apps/api/src/handlers/chat/chat-prompt.ts
@@ -790,8 +790,8 @@ const buildActiveFilePrompt = ({
 
   return [
     `ACTIVE FILE: The user is viewing "${safeName}" (entity ref ${entityRef}) in the inspector sidebar.`,
-    `DEFAULT SCOPE: While an active file is set, treat it as the sole subject of any open-ended question ("what's going on", "summarize this", "what does it say", "explain", and similar). Read its contents with \`read.getMatterEntityContents\` using \`matterRefs: ["${matterRef}"]\` and \`entityRefs: ["${entityRef}"]\`, and answer ONLY from that file.`,
-    `LONG-DOCUMENT LOOKUPS: \`read.getMatterEntityContents\` only returns the START of the document (server truncates long files). If the user asks where, whether, or how a specific term/phrase appears — definitions ("how is X defined?"), citations ("does it mention Y?"), references ("which section covers Z?") — call \`read.searchInEntityContent\` with that term as \`query\` instead. It scans the FULL document and returns matching snippets in document order, so an Index entry pointing to "Article I" never blocks you from finding the actual definition. Treat \`totalHits\` as a lower bound when \`totalHitsCapped\` is true.`,
+    `DEFAULT SCOPE: While an active file is set, treat it as the sole subject of any open-ended question ("what's going on", "summarize this", "what does it say", "explain", and similar). Read its contents by calling \`execute_typescript\` with \`external_read_content_across_matters({ entity_id: "${entityRef}" })\`, and answer ONLY from that file.`,
+    `LONG-DOCUMENT LOOKUPS: \`external_read_content_across_matters\` returns the document as Markdown (headings, tables, and lists preserved) for DOCX files, or plain text otherwise, one truncated window at a time starting from the beginning. If the answer is not in the first window, call it again with \`cursor\` set to the previous response's \`nextCursor\` to keep reading further into the document — page through until you find it or \`nextCursor\` comes back null.`,
     "DIRECT FILE FALLBACK: If the latest user message includes the active file as a direct attachment, inspect that attachment directly before answering. Do not claim the file has no extracted text when a direct attachment is available for this turn.",
     activeFile.supportsDocxEdits
       ? "`create-document` creates a separate new DOCX from legal-source directives. Do NOT use it to edit, rewrite, replace, save, or make a new version of the active file. If live DOCX editing is available below, use `apply-active-docx-edits`; otherwise explain that the document must be opened for editing first. Never create a substitute document."
@@ -799,8 +799,8 @@ const buildActiveFilePrompt = ({
     activeFile.supportsDocxEdits
       ? buildActiveDocxEditPrompt(activeFile, toolAvailability)
       : "",
-    `Do NOT call matter-wide retrieval (\`read.searchMatterDocuments\`, \`read.listMatterEntities\`, or \`read.getMatterEntities\`) for these open-ended questions — the user does not want answers synthesised from other files in the matter. The chat history is always available; reference earlier turns directly without re-fetching.`,
-    `Widen the scope to the rest of the matter ONLY when the user explicitly asks (e.g., "compare with the other contracts", "search across the matter", or names another document). When that happens, the matter-wide retrieval functions above are allowed again; scope them to \`matterRefs: ["${matterRef}"]\` as usual.`,
+    `Do NOT call matter-wide retrieval (\`external_search_across_matters\` or \`external_list_documents\`) for these open-ended questions — the user does not want answers synthesised from other files in the matter. The chat history is always available; reference earlier turns directly without re-fetching.`,
+    `Widen the scope to the rest of the matter ONLY when the user explicitly asks (e.g., "compare with the other contracts", "search across the matter", or names another document). When that happens, the matter-wide retrieval functions above are allowed again; scope \`external_list_documents\` calls to \`matter_id: "${matterRef}"\` as usual.`,
   ]
     .filter((section) => section.length > 0)
     .join("\n");

--- a/apps/api/src/handlers/chat/chat-prompt.ts
+++ b/apps/api/src/handlers/chat/chat-prompt.ts
@@ -799,8 +799,8 @@ const buildActiveFilePrompt = ({
     activeFile.supportsDocxEdits
       ? buildActiveDocxEditPrompt(activeFile, toolAvailability)
       : "",
-    `Do NOT call matter-wide retrieval (\`external_search_across_matters\` or \`external_list_documents\`) for these open-ended questions — the user does not want answers synthesised from other files in the matter. The chat history is always available; reference earlier turns directly without re-fetching.`,
-    `Widen the scope to the rest of the matter ONLY when the user explicitly asks (e.g., "compare with the other contracts", "search across the matter", or names another document). When that happens, the matter-wide retrieval functions above are allowed again; scope \`external_list_documents\` calls to \`matter_id: "${matterRef}"\` as usual.`,
+    `Do NOT call matter-wide retrieval (\`external_list_documents\`) for these open-ended questions — the user does not want answers synthesised from other files in the matter. The chat history is always available; reference earlier turns directly without re-fetching.`,
+    `Widen the scope to the rest of the matter ONLY when the user explicitly asks (e.g., "compare with the other contracts", "search across the matter", or names another document). When that happens, call \`external_list_documents\` scoped to \`matter_id: "${matterRef}"\` to find the other files, then read each with \`external_read_content_across_matters\`. \`external_search_across_matters\` has no matter filter and searches every matter you can access — do not use it for "the rest of this matter" follow-ups; it is only appropriate if the user explicitly asks to search beyond this matter.`,
   ]
     .filter((section) => section.length > 0)
     .join("\n");

--- a/apps/api/src/handlers/entities/get.test.ts
+++ b/apps/api/src/handlers/entities/get.test.ts
@@ -1,0 +1,64 @@
+import { Result } from "better-result";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { readEntityByIdHandler } from "@/api/handlers/entities/get";
+import { toSafeId } from "@/api/lib/branded-types";
+import { createScopedDbMock } from "@/api/tests/scoped-db-mock";
+
+const findFirstMock = mock();
+
+describe("readEntityByIdHandler", () => {
+  beforeEach(() => {
+    findFirstMock.mockReset();
+    findFirstMock.mockResolvedValue({
+      kind: "document",
+      name: "Share Purchase Agreement",
+      currentVersion: {
+        id: "entity_version_1",
+        fields: [
+          {
+            id: "field_1",
+            propertyId: "property_1",
+            content: { type: "file" },
+          },
+        ],
+      },
+    });
+  });
+
+  test("orders the current version's fields by id, matching processExtraction, so 'first file field' selection is deterministic", async () => {
+    const { safeDb } = createScopedDbMock({
+      query: { entities: { findFirst: findFirstMock } },
+    });
+
+    const result = await Result.gen(() =>
+      readEntityByIdHandler({
+        safeDb,
+        workspaceId: toSafeId("ws_1"),
+        entityId: toSafeId("entity_1"),
+      }),
+    );
+
+    expect(Result.isOk(result)).toBe(true);
+    expect(findFirstMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        with: expect.objectContaining({
+          currentVersion: expect.objectContaining({
+            with: expect.objectContaining({
+              // The `fields` table has no createdAt/position column; `id` is
+              // a Bun.randomUUIDv7() primary key (time-ordered), so ordering
+              // by it is the only way to get a stable "first field" across
+              // repeated reads. `processExtraction` (process-extraction.ts)
+              // MUST request the exact same ordering on the same relation,
+              // or `findExtractionFileField` could resolve to a different
+              // "first" field there than it does here.
+              fields: expect.objectContaining({
+                orderBy: { id: "asc" },
+              }),
+            }),
+          }),
+        }),
+      }),
+    );
+  });
+});

--- a/apps/api/src/handlers/entities/get.ts
+++ b/apps/api/src/handlers/entities/get.ts
@@ -6,6 +6,7 @@ import type { HandlerConfig } from "@/api/lib/api-handlers";
 import type { SafeId } from "@/api/lib/branded-types";
 import { tSafeId, workspaceParams } from "@/api/lib/custom-schema";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
+import { LIMITS } from "@/api/lib/limits";
 
 const readEntityByIdParamsSchema = workspaceParams({
   entityId: tSafeId("entity", { description: "Document entity ID" }),
@@ -48,10 +49,20 @@ export const readEntityByIdHandler = async function* ({
           currentVersion: {
             columns: { id: true },
             with: {
-              // SAFETY: fields of one entity version, bounded by
-              // properties-per-workspace (LIMITS.propertiesCount).
+              // Fields of one entity version: at most one row per property
+              // (fields_property_id_entity_version_id_key), so this is
+              // structurally bounded by properties-per-workspace; `limit`
+              // pins that same bound explicitly for the lint rule below.
+              // `id` is a Bun.randomUUIDv7() primary key (time-ordered), so
+              // ordering by it gives a stable field-creation order. This
+              // MUST match the ordering `processExtraction` applies to the
+              // same relation -- both feed `findExtractionFileField`'s
+              // "first file field" selection, which must resolve to the
+              // SAME field wherever it runs (see findExtractionFileField).
               fields: {
                 columns: { id: true, propertyId: true, content: true },
+                orderBy: { id: "asc" },
+                limit: LIMITS.propertiesCount,
               },
             },
           },

--- a/apps/api/src/lib/limits.ts
+++ b/apps/api/src/lib/limits.ts
@@ -219,6 +219,11 @@ export const LIMITS = {
   extractedContentMaxChars: 500_000,
   /** Hard timeout (ms) for the sandboxed extraction subprocess. */
   extractionTimeoutMs: 30_000,
+  /** Wall-clock ceiling (ms) for the live DOCX-to-Markdown read path in
+   *  `read_content_across_matters`: the S3 file fetch plus the in-process
+   *  folio conversion of a single document. Mirrors `extractionTimeoutMs`'s
+   *  budget for the same class of work (one document-sized file). */
+  docxMarkdownConversionTimeoutMs: 30_000,
   clauseExportLimit: 500,
   clauseImportBatchLimit: 200,
   templateFillsRetentionDays: 365,

--- a/apps/api/src/lib/search/process-extraction.test.ts
+++ b/apps/api/src/lib/search/process-extraction.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, mock, test } from "bun:test";
+
+import { toSafeId } from "@/api/lib/branded-types";
+
+// `processExtraction` reads through the `rootDb` module-level singleton
+// directly (no injected `safeDb`), so the query call is captured by mocking
+// that module, matching the established pattern (see
+// apps/api/src/lib/folio-collab-sessions.test.ts). Resolving `findFirst`
+// with `null` (entity not found) short-circuits the function right after
+// the query, before it would otherwise reach S3/search-provider calls this
+// test does not need to stub.
+const findFirstMock = mock(async () => null);
+
+void mock.module("@/api/db/root", () => ({
+  rootDb: { query: { entities: { findFirst: findFirstMock } } },
+}));
+
+const { processExtraction } =
+  await import("@/api/lib/search/process-extraction");
+
+describe("processExtraction", () => {
+  test("orders the current version's fields by id, matching readEntityByIdHandler, so 'first file field' selection is deterministic", async () => {
+    await processExtraction(toSafeId("entity_1"));
+
+    expect(findFirstMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        with: expect.objectContaining({
+          currentVersion: expect.objectContaining({
+            with: expect.objectContaining({
+              // The `fields` table has no createdAt/position column; `id`
+              // is a Bun.randomUUIDv7() primary key (time-ordered), so
+              // ordering by it is the only way to get a stable "first
+              // field" across repeated reads. `readEntityByIdHandler`
+              // (handlers/entities/get.ts) MUST request the exact same
+              // ordering on the same relation, or `findExtractionFileField`
+              // could resolve to a different "first" field there than it
+              // does here.
+              fields: expect.objectContaining({
+                orderBy: { id: "asc" },
+              }),
+            }),
+          }),
+        }),
+      }),
+    );
+  });
+});

--- a/apps/api/src/lib/search/process-extraction.ts
+++ b/apps/api/src/lib/search/process-extraction.ts
@@ -22,18 +22,8 @@ import {
   resolveExtractionMimeType,
 } from "@/api/lib/search/extract-content";
 import { getSearchProvider } from "@/api/lib/search/provider";
+import { findExtractionFileField } from "@/api/lib/search/types";
 import { PDF_MIME_TYPE } from "@/api/mime-types";
-
-const findFileField = (
-  fields: { content: FieldContent }[],
-): Extract<FieldContent, { type: "file" }> | null => {
-  for (const field of fields) {
-    if (field.content.type === "file") {
-      return field.content;
-    }
-  }
-  return null;
-};
 
 /**
  * Choose which S3 object to extract text from.
@@ -97,7 +87,7 @@ export const processExtraction = async (
   const version =
     entity.currentVersion ?? panic("Entity has no currentVersion");
 
-  const fileField = findFileField(version.fields);
+  const fileField = findExtractionFileField(version.fields);
   const canExtract = fileField && !fileField.encrypted;
 
   if (canExtract) {

--- a/apps/api/src/lib/search/process-extraction.ts
+++ b/apps/api/src/lib/search/process-extraction.ts
@@ -16,6 +16,7 @@ import { captureError } from "@/api/lib/analytics/capture";
 import type { SafeId } from "@/api/lib/branded-types";
 import { toSafeId } from "@/api/lib/branded-types";
 import { encryptContent } from "@/api/lib/content-encryption";
+import { LIMITS } from "@/api/lib/limits";
 import { getS3 } from "@/api/lib/s3";
 import {
   extractFileText,
@@ -73,7 +74,21 @@ export const processExtraction = async (
       currentVersion: {
         columns: { id: true },
         with: {
-          fields: { columns: { content: true } },
+          // Fields of one entity version: at most one row per property
+          // (fields_property_id_entity_version_id_key), so this is
+          // structurally bounded by properties-per-workspace; `limit` pins
+          // that same bound explicitly for the lint rule below.
+          // `id` is a Bun.randomUUIDv7() primary key (time-ordered), so
+          // ordering by it gives a stable field-creation order. This MUST
+          // match the ordering `readEntityByIdHandler` applies to the same
+          // relation -- both feed `findExtractionFileField`'s "first file
+          // field" selection, which must resolve to the SAME field
+          // wherever it runs (see findExtractionFileField).
+          fields: {
+            columns: { content: true },
+            orderBy: { id: "asc" },
+            limit: LIMITS.propertiesCount,
+          },
         },
       },
     },

--- a/apps/api/src/lib/search/types.ts
+++ b/apps/api/src/lib/search/types.ts
@@ -2,7 +2,7 @@ import { panic } from "better-result";
 
 import { ENTITY_KINDS } from "@/api/db/schema";
 import type { ContactType } from "@/api/db/schema";
-import type { EntityKind } from "@/api/db/schema-validators";
+import type { EntityKind, FieldContent } from "@/api/db/schema-validators";
 import type { SafeId } from "@/api/lib/branded-types";
 
 /** Narrow an unknown value to a valid EntityKind. */
@@ -13,6 +13,26 @@ export const parseEntityKind = (value: unknown): EntityKind => {
     panic(`Invalid entity kind: ${s}`);
   }
   return match;
+};
+
+/**
+ * The file the extraction pipeline reads text from for an entity's current
+ * version: the first field (in field order) whose content is a file. Shared
+ * by `processExtraction` (which writes `extractedContent`) and any reader
+ * that must resolve to the SAME source file `extractedContent` was produced
+ * from -- e.g. a live-conversion path must never pick a different field's
+ * file than the one the cached plaintext (and search hits referencing it)
+ * came from.
+ */
+export const findExtractionFileField = (
+  fields: readonly { content: FieldContent }[],
+): Extract<FieldContent, { type: "file" }> | null => {
+  for (const field of fields) {
+    if (field.content.type === "file") {
+      return field.content;
+    }
+  }
+  return null;
 };
 
 type SearchQueryBase = {

--- a/apps/api/src/lib/search/types.ts
+++ b/apps/api/src/lib/search/types.ts
@@ -23,6 +23,14 @@ export const parseEntityKind = (value: unknown): EntityKind => {
  * from -- e.g. a live-conversion path must never pick a different field's
  * file than the one the cached plaintext (and search hits referencing it)
  * came from.
+ *
+ * CONTRACT: `fields` must arrive pre-sorted into a stable, deterministic
+ * order -- this function does not sort. The `fields` table has no
+ * `createdAt`/position column, so every caller loading this relation MUST
+ * apply `orderBy: { id: "asc" }` (field ids are `Bun.randomUUIDv7()`, so
+ * ascending id order is ascending creation order). Without an explicit
+ * `orderBy`, Postgres/Drizzle give no ordering guarantee, and two callers
+ * could observe different "first" fields for the same version.
  */
 export const findExtractionFileField = (
   fields: readonly { content: FieldContent }[],

--- a/apps/api/src/mcp/__snapshots__/registry-quality.test.ts.snap
+++ b/apps/api/src/mcp/__snapshots__/registry-quality.test.ts.snap
@@ -203,7 +203,7 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "name": "read_content_across_matters",
     "scope": "stella:read",
     "access": "read",
-    "description": "Read extracted text from a document found anywhere in your accessible matters. Use after search_across_matters. Long documents are returned in windows; pass the returned nextCursor back as cursor to read more.",
+    "description": "Read a document's content, found anywhere in your accessible matters. DOCX files are converted to Markdown with structure preserved (headings, tables, lists); other formats return their extracted plain text. Use after search_across_matters. Long documents are returned in windows; pass the returned nextCursor back as cursor to read more.",
     "annotations": {
       "readOnlyHint": true,
       "openWorldHint": false
@@ -2531,7 +2531,7 @@ exports[`MCP registry quality (anonymized surface) tool surface snapshot (name, 
     "name": "read_content_across_matters",
     "scope": "stella:read_anonymized",
     "access": "read",
-    "description": "Read extracted text from a document found anywhere in your accessible matters. Use after search_across_matters. Long documents are returned in windows; pass the returned nextCursor back as cursor to read more.",
+    "description": "Read a document's content, found anywhere in your accessible matters. DOCX files are converted to Markdown with structure preserved (headings, tables, lists); other formats return their extracted plain text. Use after search_across_matters. Long documents are returned in windows; pass the returned nextCursor back as cursor to read more.",
     "annotations": {
       "readOnlyHint": true,
       "openWorldHint": false

--- a/apps/api/src/mcp/stella-tools.ts
+++ b/apps/api/src/mcp/stella-tools.ts
@@ -48,6 +48,7 @@ import {
 import { decodeCursor } from "@/api/lib/search/cursor";
 import { getSearchProvider } from "@/api/lib/search/provider";
 import { findExtractionFileField } from "@/api/lib/search/types";
+import { withTimeout } from "@/api/lib/with-timeout";
 import type { McpRequestContext } from "@/api/mcp/context";
 import {
   defineTextFieldSpec,
@@ -1215,6 +1216,25 @@ type LoadCurrentVersionDocxMarkdownProps = {
 };
 
 /**
+ * `not-docx`: the current version's extraction file (see below) is
+ * confirmed NOT a DOCX (or the version has no file at all) -- stable across
+ * every read of this entity, so the caller can always use plaintext with no
+ * cursor-consistency risk.
+ *
+ * `unavailable`: the file IS a DOCX (or its identity could not even be
+ * confirmed -- e.g. a transient entity/fields lookup failure) but Markdown
+ * could not be produced for THIS call (S3 read failed, conversion errored,
+ * or the attempt timed out). Unlike `not-docx`, this is not a stable fact
+ * about the document -- a retry could succeed -- so the caller must not
+ * treat it as equivalent to `not-docx` once a cursor is already in flight
+ * (see `handleReadContentAcrossMattersTool`).
+ */
+type DocxMarkdownOutcome =
+  | { kind: "not-docx" }
+  | { kind: "markdown"; text: string }
+  | { kind: "unavailable" };
+
+/**
  * Convert the entity's CURRENT version file to folio's structure-preserving
  * Markdown, but only when it is a DOCX. Reuses `readEntityByIdHandler` — the
  * same TOCTOU-safe entity+currentVersion+fields lookup `read_document` uses
@@ -1226,45 +1246,57 @@ type LoadCurrentVersionDocxMarkdownProps = {
  * DOCX instead would let an auxiliary DOCX field outrank the entity's actual
  * indexed file (e.g. a PDF system file with an unrelated DOCX attachment),
  * returning markdown for a different document than the plaintext fallback
- * and search results describe. Returns `null` (never throws) when that file
- * is not a DOCX or the conversion fails, so the caller falls back to the
- * cached plaintext extraction of the SAME file instead of failing the read.
+ * and search results describe.
+ *
+ * The S3 read and conversion are bounded by `docxMarkdownConversionTimeoutMs`
+ * (`withTimeout`) so a stalled fetch or hung conversion cannot hang the
+ * request; a timeout is reported as `unavailable`, same as any other
+ * conversion failure.
  */
 const loadCurrentVersionDocxMarkdown = async ({
   context,
   entityId,
   workspaceId,
-}: LoadCurrentVersionDocxMarkdownProps): Promise<string | null> => {
+}: LoadCurrentVersionDocxMarkdownProps): Promise<DocxMarkdownOutcome> => {
   const entityResult = await Result.gen(() =>
     readEntityByIdHandler({ safeDb: context.safeDb, workspaceId, entityId }),
   );
   if (Result.isError(entityResult)) {
-    return null;
+    return { kind: "unavailable" };
   }
 
   const file = findExtractionFileField(entityResult.value.fields);
   if (!isDocxFileContent(file)) {
-    return null;
+    return { kind: "not-docx" };
   }
 
   const markdownResult = await Result.tryPromise({
-    try: async () => {
-      const buffer = await getS3()
-        .file(
-          createFileKey({
-            organizationId: context.organizationId,
-            workspaceId,
-            fileId: file.id,
-            mimeType: DOCX_MIME_TYPE,
-          }),
-        )
-        .arrayBuffer();
-      return await docxToMarkdown(buffer);
-    },
+    try: async () =>
+      await withTimeout(
+        async () => {
+          const buffer = await getS3()
+            .file(
+              createFileKey({
+                organizationId: context.organizationId,
+                workspaceId,
+                fileId: file.id,
+                mimeType: DOCX_MIME_TYPE,
+              }),
+            )
+            .arrayBuffer();
+          return await docxToMarkdown(buffer);
+        },
+        {
+          label: "read_content_across_matters:docx-to-markdown",
+          timeoutMs: LIMITS.docxMarkdownConversionTimeoutMs,
+        },
+      ),
     catch: (cause) => cause,
   });
 
-  return Result.isError(markdownResult) ? null : markdownResult.value;
+  return Result.isError(markdownResult)
+    ? { kind: "unavailable" }
+    : { kind: "markdown", text: markdownResult.value };
 };
 
 const handleReadContentAcrossMattersTool: McpToolHandler = async ({
@@ -1317,16 +1349,42 @@ const handleReadContentAcrossMattersTool: McpToolHandler = async ({
   );
 
   const workspaceId = row.entity.workspaceId;
-  const markdown = await loadCurrentVersionDocxMarkdown({
+  const docxOutcome = await loadCurrentVersionDocxMarkdown({
     context,
     entityId,
     workspaceId,
   });
+
   // Prefer the live DOCX-to-Markdown conversion (headings, tables, lists
   // preserved) whenever the current version holds a DOCX file; every other
-  // format (PDF, images, non-document entities, or a conversion failure)
-  // falls back to the plain text already extracted at ingestion.
-  const text = markdown ?? plaintext;
+  // format (PDF, images, non-document entities) uses the plain text already
+  // extracted at ingestion.
+  //
+  // `cursor` (the char offset windowed below) is only ever valid against the
+  // ONE text representation it was issued against. On a first read
+  // (`cursor === undefined`) nothing has been issued yet, so a conversion
+  // failure can safely fall back to plaintext. On a paginated read, the
+  // caller's cursor already encodes an offset into whatever the first read
+  // served; if the live conversion becomes `unavailable` mid-stream, silently
+  // switching to plaintext (or vice versa) would slice a different text than
+  // the cursor was computed against, producing skipped or duplicated
+  // content. Surface a retryable error instead of guessing.
+  let text: string;
+  if (docxOutcome.kind === "markdown") {
+    text = docxOutcome.text;
+  } else if (docxOutcome.kind === "not-docx") {
+    text = plaintext;
+  } else if (cursor === undefined) {
+    text = plaintext;
+  } else {
+    return structuredErrorResult({
+      code: "internal_error",
+      message:
+        "Could not continue reading this document's Markdown conversion.",
+      hint: "Retry the request with the same cursor.",
+      retryable: true,
+    });
+  }
 
   // Carry the FULL text and window it in the egress pipeline, so an
   // anonymized read redacts the whole document before slicing (slicing raw text

--- a/apps/api/src/mcp/stella-tools.ts
+++ b/apps/api/src/mcp/stella-tools.ts
@@ -47,6 +47,7 @@ import {
 } from "@/api/lib/safe-id-boundaries";
 import { decodeCursor } from "@/api/lib/search/cursor";
 import { getSearchProvider } from "@/api/lib/search/provider";
+import { findExtractionFileField } from "@/api/lib/search/types";
 import type { McpRequestContext } from "@/api/mcp/context";
 import {
   defineTextFieldSpec,
@@ -1196,17 +1197,16 @@ const toIsoDateString = (value: unknown): string | null => {
 
 type DocxFieldContent = Extract<FieldContent, { type: "file" }>;
 
+// SAFETY: `content` is a NOT NULL jsonb column, but that only forbids a SQL
+// NULL -- a stored JSON `null` literal still reads back as JS `null` here,
+// so the predicate must not dereference `.type` before checking for it.
 const isDocxFileContent = (
-  content: FieldContent,
+  content: FieldContent | null | undefined,
 ): content is DocxFieldContent =>
-  content.type === "file" && content.mimeType === DOCX_MIME_TYPE;
-
-const findCurrentVersionDocxFile = (
-  fieldList: readonly { content: FieldContent }[],
-): DocxFieldContent | undefined =>
-  fieldList.find((field): field is { content: DocxFieldContent } =>
-    isDocxFileContent(field.content),
-  )?.content;
+  content !== null &&
+  content !== undefined &&
+  content.type === "file" &&
+  content.mimeType === DOCX_MIME_TYPE;
 
 type LoadCurrentVersionDocxMarkdownProps = {
   context: McpRequestContext;
@@ -1215,13 +1215,20 @@ type LoadCurrentVersionDocxMarkdownProps = {
 };
 
 /**
- * Convert the entity's CURRENT version DOCX file (if any) to folio's
- * structure-preserving Markdown. Reuses `readEntityByIdHandler` — the same
- * TOCTOU-safe entity+currentVersion+fields lookup `read_document` uses — so
- * this shares its auth boundary and never re-derives entity access. Returns
- * `null` (never throws) when the current version holds no DOCX file or the
- * conversion fails, so the caller can fall back to the cached plaintext
- * extraction instead of failing the whole read.
+ * Convert the entity's CURRENT version file to folio's structure-preserving
+ * Markdown, but only when it is a DOCX. Reuses `readEntityByIdHandler` — the
+ * same TOCTOU-safe entity+currentVersion+fields lookup `read_document` uses
+ * — so this shares its auth boundary and never re-derives entity access.
+ *
+ * File selection uses `findExtractionFileField`, the SAME first-file-field
+ * selection `processExtraction` uses to produce the cached `extractedContent`
+ * plaintext (and what search hits reference). Scanning fields for the first
+ * DOCX instead would let an auxiliary DOCX field outrank the entity's actual
+ * indexed file (e.g. a PDF system file with an unrelated DOCX attachment),
+ * returning markdown for a different document than the plaintext fallback
+ * and search results describe. Returns `null` (never throws) when that file
+ * is not a DOCX or the conversion fails, so the caller falls back to the
+ * cached plaintext extraction of the SAME file instead of failing the read.
  */
 const loadCurrentVersionDocxMarkdown = async ({
   context,
@@ -1235,8 +1242,8 @@ const loadCurrentVersionDocxMarkdown = async ({
     return null;
   }
 
-  const file = findCurrentVersionDocxFile(entityResult.value.fields);
-  if (!file) {
+  const file = findExtractionFileField(entityResult.value.fields);
+  if (!isDocxFileContent(file)) {
     return null;
   }
 

--- a/apps/api/src/mcp/stella-tools.ts
+++ b/apps/api/src/mcp/stella-tools.ts
@@ -1,16 +1,24 @@
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { Result } from "better-result";
 import { and, desc, eq, sql } from "drizzle-orm";
 import * as v from "valibot";
 
 import { COUNTRY_CODES } from "@stll/country-codes";
+import { docxToMarkdown } from "@stll/folio-core/server";
 import { roles } from "@stll/permissions";
 
 import type { PracticeJurisdiction } from "@/api/db/schema";
 import { workspaces } from "@/api/db/schema";
-import type { ContactEmail, ContactPhone } from "@/api/db/schema-validators";
+import type {
+  ContactEmail,
+  ContactPhone,
+  FieldContent,
+} from "@/api/db/schema-validators";
 import { readDecisionHandler } from "@/api/handlers/case-law/decisions/get";
 import { searchDecisionsHandler } from "@/api/handlers/case-law/decisions/search";
 import { hasUsableAst } from "@/api/handlers/case-law/document-ast";
+import { readEntityByIdHandler } from "@/api/handlers/entities/get";
+import { createFileKey } from "@/api/handlers/files/utils";
 import {
   normalizePracticeJurisdictions,
   upsertPracticeJurisdictions,
@@ -30,6 +38,7 @@ import {
   encodePaginationCursor,
   isUuidPaginationCursorPart,
 } from "@/api/lib/pagination";
+import { getS3 } from "@/api/lib/s3";
 import {
   brandPersistedCaseLawDecisionId,
   brandPersistedCaseLawSourceId,
@@ -73,6 +82,7 @@ import {
   textResult,
   validationErrorResult,
 } from "@/api/mcp/tool-utils";
+import { DOCX_MIME_TYPE } from "@/api/mime-types";
 
 const MCP_CONTENT_MAX_CHARS = 8000;
 // Page size for each citation list on read_case_law_decision. The decision
@@ -552,9 +562,11 @@ export const STELLA_TOOL_DEFINITIONS = [
   {
     annotations: { readOnlyHint: true, openWorldHint: false },
     description:
-      "Read extracted text from a document found anywhere in your accessible " +
-      "matters. Use after search_across_matters. Long documents are returned " +
-      "in windows; pass the returned nextCursor back as cursor to read more.",
+      "Read a document's content, found anywhere in your accessible matters. " +
+      "DOCX files are converted to Markdown with structure preserved " +
+      "(headings, tables, lists); other formats return their extracted plain " +
+      "text. Use after search_across_matters. Long documents are returned in " +
+      "windows; pass the returned nextCursor back as cursor to read more.",
     inputSchema: {
       type: "object",
       properties: {
@@ -1182,6 +1194,72 @@ const toIsoDateString = (value: unknown): string | null => {
   return null;
 };
 
+type DocxFieldContent = Extract<FieldContent, { type: "file" }>;
+
+const isDocxFileContent = (
+  content: FieldContent,
+): content is DocxFieldContent =>
+  content.type === "file" && content.mimeType === DOCX_MIME_TYPE;
+
+const findCurrentVersionDocxFile = (
+  fieldList: readonly { content: FieldContent }[],
+): DocxFieldContent | undefined =>
+  fieldList.find((field): field is { content: DocxFieldContent } =>
+    isDocxFileContent(field.content),
+  )?.content;
+
+type LoadCurrentVersionDocxMarkdownProps = {
+  context: McpRequestContext;
+  entityId: ReturnType<typeof brandPersistedEntityId>;
+  workspaceId: McpRequestContext["accessibleWorkspaceIds"][number];
+};
+
+/**
+ * Convert the entity's CURRENT version DOCX file (if any) to folio's
+ * structure-preserving Markdown. Reuses `readEntityByIdHandler` — the same
+ * TOCTOU-safe entity+currentVersion+fields lookup `read_document` uses — so
+ * this shares its auth boundary and never re-derives entity access. Returns
+ * `null` (never throws) when the current version holds no DOCX file or the
+ * conversion fails, so the caller can fall back to the cached plaintext
+ * extraction instead of failing the whole read.
+ */
+const loadCurrentVersionDocxMarkdown = async ({
+  context,
+  entityId,
+  workspaceId,
+}: LoadCurrentVersionDocxMarkdownProps): Promise<string | null> => {
+  const entityResult = await Result.gen(() =>
+    readEntityByIdHandler({ safeDb: context.safeDb, workspaceId, entityId }),
+  );
+  if (Result.isError(entityResult)) {
+    return null;
+  }
+
+  const file = findCurrentVersionDocxFile(entityResult.value.fields);
+  if (!file) {
+    return null;
+  }
+
+  const markdownResult = await Result.tryPromise({
+    try: async () => {
+      const buffer = await getS3()
+        .file(
+          createFileKey({
+            organizationId: context.organizationId,
+            workspaceId,
+            fileId: file.id,
+            mimeType: DOCX_MIME_TYPE,
+          }),
+        )
+        .arrayBuffer();
+      return await docxToMarkdown(buffer);
+    },
+    catch: (cause) => cause,
+  });
+
+  return Result.isError(markdownResult) ? null : markdownResult.value;
+};
+
 const handleReadContentAcrossMattersTool: McpToolHandler = async ({
   args,
   context,
@@ -1232,17 +1310,28 @@ const handleReadContentAcrossMattersTool: McpToolHandler = async ({
   );
 
   const workspaceId = row.entity.workspaceId;
-  // Carry the FULL decrypted text and window it in the egress pipeline, so an
+  const markdown = await loadCurrentVersionDocxMarkdown({
+    context,
+    entityId,
+    workspaceId,
+  });
+  // Prefer the live DOCX-to-Markdown conversion (headings, tables, lists
+  // preserved) whenever the current version holds a DOCX file; every other
+  // format (PDF, images, non-document entities, or a conversion failure)
+  // falls back to the plain text already extracted at ingestion.
+  const text = markdown ?? plaintext;
+
+  // Carry the FULL text and window it in the egress pipeline, so an
   // anonymized read redacts the whole document before slicing (slicing raw text
   // first could split an entity name across the window boundary and leak its
   // prefix). Default mode leaves name/text as-is and windows the same way.
   const initialNextCursor = (): string | null => null;
   const payload = {
-    charCount: plaintext.length,
+    charCount: text.length,
     entityId,
     kind: row.entity.kind,
     name: row.entity.name,
-    text: plaintext,
+    text,
     truncated: false,
     nextCursor: initialNextCursor(),
     workspaceId,

--- a/apps/api/src/mcp/tools.test.ts
+++ b/apps/api/src/mcp/tools.test.ts
@@ -5,6 +5,8 @@ import JSZip from "jszip";
 import { env } from "@/api/env";
 import type { AuditRecorder } from "@/api/lib/audit-log";
 import { toSafeId } from "@/api/lib/branded-types";
+import { TimeoutError } from "@/api/lib/errors/tagged-errors";
+import { encodePaginationCursor } from "@/api/lib/pagination";
 import type { McpRequestContext } from "@/api/mcp/context";
 import { DOCX_MIME_TYPE } from "@/api/mime-types";
 import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
@@ -55,6 +57,17 @@ const s3FileMock = mock(() => ({ arrayBuffer: s3ArrayBufferMock }));
 
 void mock.module("@/api/lib/s3", () => ({
   getS3: () => ({ file: s3FileMock }),
+}));
+
+// Default passthrough: just await the wrapped operation, so every existing
+// test exercises the real S3-read-and-convert logic unchanged. Individual
+// tests override this with `mockImplementationOnce` to simulate the
+// operation timing out, without an actual wall-clock wait.
+const withTimeoutMock = mock(
+  async (operation: () => Promise<unknown>) => await operation(),
+);
+void mock.module("@/api/lib/with-timeout", () => ({
+  withTimeout: withTimeoutMock,
 }));
 
 const anonymizeTextFieldsMock = mock();
@@ -572,6 +585,7 @@ describe("OpenAI-compatible MCP tools", () => {
     readDecisionHandlerMock.mockReset();
     s3FileMock.mockClear();
     s3ArrayBufferMock.mockClear();
+    withTimeoutMock.mockClear();
   });
 
   afterAll(() => {
@@ -1550,6 +1564,82 @@ describe("OpenAI-compatible MCP tools", () => {
     expect(parseToolPayload(result)).toMatchObject({
       text: "Full document text",
     });
+  });
+
+  test("read_content_across_matters returns a retryable error instead of switching representation when a paginated DOCX conversion fails", async () => {
+    s3ArrayBufferMock.mockImplementationOnce(async () => {
+      throw new Error("S3 read failed");
+    });
+    const context = createContext({
+      accessibleWorkspaceIds: ["ws_1", "ws_3"],
+      scopedDb: createScopedDb([], createExtractedContentRow(), [
+        {
+          type: "file",
+          id: "file_1",
+          fileName: "agreement.docx",
+          mimeType: DOCX_MIME_TYPE,
+        },
+      ]),
+    });
+
+    // Simulates a client mid-pagination: a cursor already encodes an offset
+    // into whatever representation the (unseen) first read served. This
+    // call's conversion attempt fails; the tool must not guess by silently
+    // falling back to plaintext, which could be a different length/content
+    // than the Markdown the cursor was computed against (skipped/duplicated
+    // content).
+    const result = await handleMcpToolCall({
+      args: { entity_id: "entity_1", cursor: encodePaginationCursor([5]) },
+      context,
+      toolName: "read_content_across_matters",
+    });
+
+    expectErrorEnvelope(result, {
+      code: "internal_error",
+      message:
+        "Could not continue reading this document's Markdown conversion.",
+      hint: "Retry the request with the same cursor.",
+      retryable: true,
+    });
+  });
+
+  test("read_content_across_matters treats a DOCX conversion timeout the same as any other conversion failure", async () => {
+    withTimeoutMock.mockImplementationOnce(async () => {
+      throw new TimeoutError({
+        message: "docx-to-markdown timed out",
+        label: "read_content_across_matters:docx-to-markdown",
+        timeoutMs: 30_000,
+      });
+    });
+    const context = createContext({
+      accessibleWorkspaceIds: ["ws_1", "ws_3"],
+      scopedDb: createScopedDb([], createExtractedContentRow(), [
+        {
+          type: "file",
+          id: "file_1",
+          fileName: "agreement.docx",
+          mimeType: DOCX_MIME_TYPE,
+        },
+      ]),
+    });
+
+    // First read: a timeout is funneled through the exact same
+    // `Result.tryPromise` catch as any other conversion failure, so it
+    // still falls back to the cached plaintext rather than hanging or
+    // erroring the whole request.
+    const result = await handleMcpToolCall({
+      args: { entity_id: "entity_1" },
+      context,
+      toolName: "read_content_across_matters",
+    });
+
+    expect(parseToolPayload(result)).toMatchObject({
+      text: "Full document text",
+    });
+    expect(withTimeoutMock).toHaveBeenCalledWith(
+      expect.any(Function),
+      expect.objectContaining({ timeoutMs: expect.any(Number) }),
+    );
   });
 
   test("search anonymizes titles in anonymized mode", async () => {

--- a/apps/api/src/mcp/tools.test.ts
+++ b/apps/api/src/mcp/tools.test.ts
@@ -460,9 +460,14 @@ const DEFAULT_CURRENT_VERSION_FILE_CONTENT: MockFieldContent = {
 const createScopedDb = (
   rows: unknown[] = [],
   extractedContentRow: ExtractedContentRow | null = null,
-  // The current version's sole field content; pass a DOCX `FieldContent` to
-  // exercise the live docx-to-markdown branch.
-  currentVersionFileContent: MockFieldContent = DEFAULT_CURRENT_VERSION_FILE_CONTENT,
+  // The current version's field contents, in field order. Pass a DOCX
+  // `FieldContent` as the sole entry to exercise the live docx-to-markdown
+  // branch, or list a non-DOCX field before a DOCX one to exercise the
+  // "first file field wins" selection (mirroring `processExtraction`, which
+  // produced `extractedContentRow`'s plaintext from that same first field).
+  currentVersionFields: MockFieldContent[] = [
+    DEFAULT_CURRENT_VERSION_FILE_CONTENT,
+  ],
 ) =>
   asTestRaw<McpRequestContext["scopedDb"] & ReturnType<typeof mock>>(
     mock(
@@ -488,13 +493,11 @@ const createScopedDb = (
                   name: extractedContentRow.entity.name,
                   currentVersion: {
                     id: "entity_version_1",
-                    fields: [
-                      {
-                        id: "field_1",
-                        propertyId: "property_1",
-                        content: currentVersionFileContent,
-                      },
-                    ],
+                    fields: currentVersionFields.map((content, index) => ({
+                      id: `field_${index + 1}`,
+                      propertyId: `property_${index + 1}`,
+                      content,
+                    })),
                   },
                 };
               },
@@ -1447,12 +1450,14 @@ describe("OpenAI-compatible MCP tools", () => {
   test("read_content_across_matters returns folio Markdown when the current version holds a DOCX file", async () => {
     const context = createContext({
       accessibleWorkspaceIds: ["ws_1", "ws_3"],
-      scopedDb: createScopedDb([], createExtractedContentRow(), {
-        type: "file",
-        id: "file_1",
-        fileName: "agreement.docx",
-        mimeType: DOCX_MIME_TYPE,
-      }),
+      scopedDb: createScopedDb([], createExtractedContentRow(), [
+        {
+          type: "file",
+          id: "file_1",
+          fileName: "agreement.docx",
+          mimeType: DOCX_MIME_TYPE,
+        },
+      ]),
     });
     const result = await handleMcpToolCall({
       args: { entity_id: "entity_1" },
@@ -1480,18 +1485,61 @@ describe("OpenAI-compatible MCP tools", () => {
     expect(text).not.toContain("Full document text");
   });
 
+  test("read_content_across_matters selects the SAME file the extraction pipeline indexed, not just any DOCX field", async () => {
+    // The current version's first file field (the one `processExtraction`
+    // would extract `extractedContentRow`'s plaintext from) is a non-DOCX
+    // system document; a later auxiliary field happens to hold a DOCX. The
+    // markdown branch must not scan past the first file field looking for a
+    // DOCX -- doing so would return a different document than the plaintext
+    // fallback and search hits reference.
+    const context = createContext({
+      accessibleWorkspaceIds: ["ws_1", "ws_3"],
+      scopedDb: createScopedDb([], createExtractedContentRow(), [
+        {
+          type: "file",
+          id: "file_system",
+          fileName: "agreement.pdf",
+          mimeType: "application/pdf",
+        },
+        {
+          type: "file",
+          id: "file_auxiliary",
+          fileName: "exhibit.docx",
+          mimeType: DOCX_MIME_TYPE,
+        },
+      ]),
+    });
+    const result = await handleMcpToolCall({
+      args: { entity_id: "entity_1" },
+      context,
+      toolName: "read_content_across_matters",
+    });
+
+    const payload = parseToolPayload(result);
+    // Falls back to the cached plaintext of the SYSTEM file, never the
+    // auxiliary DOCX's converted markdown.
+    expect(payload).toMatchObject({ text: "Full document text" });
+    if (!isRecord(payload) || typeof payload["text"] !== "string") {
+      throw new Error("Expected payload.text to be a string");
+    }
+    expect(payload["text"]).not.toContain("# Agreement");
+    expect(s3FileMock).not.toHaveBeenCalled();
+  });
+
   test("read_content_across_matters falls back to plaintext when docx-to-markdown conversion fails", async () => {
     s3ArrayBufferMock.mockImplementationOnce(async () => {
       throw new Error("S3 read failed");
     });
     const context = createContext({
       accessibleWorkspaceIds: ["ws_1", "ws_3"],
-      scopedDb: createScopedDb([], createExtractedContentRow(), {
-        type: "file",
-        id: "file_1",
-        fileName: "agreement.docx",
-        mimeType: DOCX_MIME_TYPE,
-      }),
+      scopedDb: createScopedDb([], createExtractedContentRow(), [
+        {
+          type: "file",
+          id: "file_1",
+          fileName: "agreement.docx",
+          mimeType: DOCX_MIME_TYPE,
+        },
+      ]),
     });
     const result = await handleMcpToolCall({
       args: { entity_id: "entity_1" },

--- a/apps/api/src/mcp/tools.test.ts
+++ b/apps/api/src/mcp/tools.test.ts
@@ -1,12 +1,61 @@
 import { Result } from "better-result";
 import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import JSZip from "jszip";
 
 import { env } from "@/api/env";
 import type { AuditRecorder } from "@/api/lib/audit-log";
 import { toSafeId } from "@/api/lib/branded-types";
 import type { McpRequestContext } from "@/api/mcp/context";
+import { DOCX_MIME_TYPE } from "@/api/mime-types";
 import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
 import { toSafeDbMock } from "@/api/tests/scoped-db-mock";
+
+/**
+ * Minimal DOCX with a Heading1 paragraph, a two-row table, and a body
+ * paragraph, for exercising `docxToMarkdown`'s real (unmocked) conversion in
+ * `read_content_across_matters`'s markdown branch.
+ */
+const makeDocxBytes = async () => {
+  const zip = new JSZip();
+  zip.file(
+    "word/document.xml",
+    `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+<w:body>
+  <w:p><w:pPr><w:pStyle w:val="Heading1"/></w:pPr><w:r><w:t>Agreement</w:t></w:r></w:p>
+  <w:tbl>
+    <w:tr>
+      <w:tc><w:p><w:r><w:t>Party</w:t></w:r></w:p></w:tc>
+      <w:tc><w:p><w:r><w:t>Role</w:t></w:r></w:p></w:tc>
+    </w:tr>
+    <w:tr>
+      <w:tc><w:p><w:r><w:t>Acme s.r.o.</w:t></w:r></w:p></w:tc>
+      <w:tc><w:p><w:r><w:t>Seller</w:t></w:r></w:p></w:tc>
+    </w:tr>
+  </w:tbl>
+  <w:p><w:r><w:t>Signed below.</w:t></w:r></w:p>
+</w:body></w:document>`,
+  );
+  zip.file(
+    "[Content_Types].xml",
+    `<?xml version="1.0" encoding="UTF-8"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="xml" ContentType="application/xml"/>
+</Types>`,
+  );
+  const bytes = await zip.generateAsync({ type: "uint8array" });
+  return bytes.buffer.slice(
+    bytes.byteOffset,
+    bytes.byteOffset + bytes.byteLength,
+  );
+};
+
+const s3ArrayBufferMock = mock(async () => await makeDocxBytes());
+const s3FileMock = mock(() => ({ arrayBuffer: s3ArrayBufferMock }));
+
+void mock.module("@/api/lib/s3", () => ({
+  getS3: () => ({ file: s3FileMock }),
+}));
 
 const anonymizeTextFieldsMock = mock();
 const loadAnonymizationGazetteerEntriesMock = mock();
@@ -345,6 +394,8 @@ type MockEntityFindFirstInput = {
   };
 };
 
+type MockFieldContent = { type: string; [key: string]: unknown };
+
 type MockMcpTransaction = {
   query: {
     entities: {
@@ -356,7 +407,7 @@ type MockMcpTransaction = {
           fields: {
             id: string;
             propertyId: string;
-            content: { type: string };
+            content: MockFieldContent;
           }[];
         } | null;
       } | null>;
@@ -367,7 +418,7 @@ type MockMcpTransaction = {
     fields: {
       findMany: () => Promise<
         {
-          content: { type: string };
+          content: MockFieldContent;
           id: string;
           propertyId: string;
         }[]
@@ -400,9 +451,18 @@ const createExtractedContentRow = ({
   workspaceId,
 });
 
+// Non-DOCX file stub (no `mimeType`) so every pre-existing `createScopedDb`
+// caller keeps exercising the plaintext fallback path unchanged.
+const DEFAULT_CURRENT_VERSION_FILE_CONTENT: MockFieldContent = {
+  type: "file",
+};
+
 const createScopedDb = (
   rows: unknown[] = [],
   extractedContentRow: ExtractedContentRow | null = null,
+  // The current version's sole field content; pass a DOCX `FieldContent` to
+  // exercise the live docx-to-markdown branch.
+  currentVersionFileContent: MockFieldContent = DEFAULT_CURRENT_VERSION_FILE_CONTENT,
 ) =>
   asTestRaw<McpRequestContext["scopedDb"] & ReturnType<typeof mock>>(
     mock(
@@ -432,7 +492,7 @@ const createScopedDb = (
                       {
                         id: "field_1",
                         propertyId: "property_1",
-                        content: { type: "file" },
+                        content: currentVersionFileContent,
                       },
                     ],
                   },
@@ -507,6 +567,8 @@ describe("OpenAI-compatible MCP tools", () => {
     decryptContentMock.mockResolvedValue("Full document text");
     searchDecisionsHandlerMock.mockReset();
     readDecisionHandlerMock.mockReset();
+    s3FileMock.mockClear();
+    s3ArrayBufferMock.mockClear();
   });
 
   afterAll(() => {
@@ -1379,6 +1441,66 @@ describe("OpenAI-compatible MCP tools", () => {
       truncated: false,
       nextCursor: null,
       workspaceId: "ws_1",
+    });
+  });
+
+  test("read_content_across_matters returns folio Markdown when the current version holds a DOCX file", async () => {
+    const context = createContext({
+      accessibleWorkspaceIds: ["ws_1", "ws_3"],
+      scopedDb: createScopedDb([], createExtractedContentRow(), {
+        type: "file",
+        id: "file_1",
+        fileName: "agreement.docx",
+        mimeType: DOCX_MIME_TYPE,
+      }),
+    });
+    const result = await handleMcpToolCall({
+      args: { entity_id: "entity_1" },
+      context,
+      toolName: "read_content_across_matters",
+    });
+
+    const payload = parseToolPayload(result);
+    expect(payload).toMatchObject({
+      entityId: "entity_1",
+      kind: "document",
+      name: "Share Purchase Agreement",
+      workspaceId: "ws_1",
+    });
+    if (!isRecord(payload) || typeof payload["text"] !== "string") {
+      throw new Error("Expected payload.text to be a string");
+    }
+    const { text } = payload;
+    // Headings and tables survive the conversion; the cached plaintext
+    // extraction is not what gets served once markdown conversion succeeds.
+    expect(text).toContain("# Agreement");
+    expect(text).toContain("| Party | Role |");
+    expect(text).toContain("| Acme s.r.o. | Seller |");
+    expect(text).toContain("Signed below.");
+    expect(text).not.toContain("Full document text");
+  });
+
+  test("read_content_across_matters falls back to plaintext when docx-to-markdown conversion fails", async () => {
+    s3ArrayBufferMock.mockImplementationOnce(async () => {
+      throw new Error("S3 read failed");
+    });
+    const context = createContext({
+      accessibleWorkspaceIds: ["ws_1", "ws_3"],
+      scopedDb: createScopedDb([], createExtractedContentRow(), {
+        type: "file",
+        id: "file_1",
+        fileName: "agreement.docx",
+        mimeType: DOCX_MIME_TYPE,
+      }),
+    });
+    const result = await handleMcpToolCall({
+      args: { entity_id: "entity_1" },
+      context,
+      toolName: "read_content_across_matters",
+    });
+
+    expect(parseToolPayload(result)).toMatchObject({
+      text: "Full document text",
     });
   });
 

--- a/packages/cli/src/generated/registry-snapshot.json
+++ b/packages/cli/src/generated/registry-snapshot.json
@@ -207,7 +207,7 @@
       "windowedText": true
     },
     "name": "read_content_across_matters",
-    "description": "Read extracted text from a document found anywhere in your accessible matters. Use after search_across_matters. Long documents are returned in windows; pass the returned nextCursor back as cursor to read more.",
+    "description": "Read a document's content, found anywhere in your accessible matters. DOCX files are converted to Markdown with structure preserved (headings, tables, lists); other formats return their extracted plain text. Use after search_across_matters. Long documents are returned in windows; pass the returned nextCursor back as cursor to read more.",
     "inputSchema": {
       "type": "object",
       "properties": {


### PR DESCRIPTION
## Summary

Converges the chat agent's document-read onto a single, best-fidelity path instead of adding a parallel markdown-read tool.

**Note on the PR title / original ask**: the read function this PR upgrades is `read_content_across_matters` (exposed to the sandboxed model as `external_read_content_across_matters` via `execute_typescript`), not a function literally named `getMatterEntityContents`. That name — along with `read.searchInEntityContent`, `read.searchMatterDocuments`, `read.listMatterEntities`, and `read.getMatterEntities` — was the naming scheme of the hand-written chat sandbox manifests that #1018 retired in favor of registry-projected code-mode tools; none of them exist on the current read surface. The chat system prompt's active-file section had not been updated when #1018 landed and still referenced those dead names, so the model was being told to call functions that error out — fixed here as a separate commit.

- `read_content_across_matters` (`apps/api/src/mcp/stella-tools.ts`) now converts a DOCX current version live via `docxToMarkdown` (`@stll/folio-core/server`) — headings, tables, and lists preserved — instead of only serving the plaintext extracted at ingestion time. Non-DOCX entities, and any DOCX conversion failure, fall back to the existing cached plaintext unchanged.
- The truncation/windowing budget (`MCP_CONTENT_MAX_CHARS` = 8000 chars, cursor-based paging) and the auth boundary are untouched: the new `loadCurrentVersionDocxMarkdown` helper reuses `read_document`'s own TOCTOU-safe `readEntityByIdHandler` lookup rather than inventing a new one.
- Regenerates the committed CLI registry snapshot and the MCP registry-quality snapshot for the updated tool description.
- Fixes the chat system prompt's active-file section (`chat-prompt.ts`) to reference the real current tool names and to describe the Markdown output; the old prompt also referenced a whole-document full-text-search tool that no longer exists, so that guidance is replaced with the real cursor-paging mechanism.
- Supersedes draft PR #1299 (`feat/agent-read-document`, `read_workspace_document`), which added a parallel server tool doing the same `docxToMarkdown` conversion. Closed in favor of this single-path upgrade; its branch is deleted.

## Test plan

- [x] `bun --filter @stll/api typecheck`
- [x] `bun --bun oxlint -c oxlint.config.ts --deny-warnings --type-aware` on changed files
- [x] `bunx oxfmt` on changed files
- [x] `bun test` (direct, not batched) on `src/mcp/`, `src/handlers/chat/chat-prompt.test.ts`, `src/handlers/chat/tools/registry-adapter/`, and `packages/cli` — all green
- [x] New test: a minimal DOCX (Heading1 + table) round-tripped through the real `docxToMarkdown`, asserting the served `text` contains `# Agreement` and a markdown table, and that the cached-plaintext fallback still fires when the DOCX conversion fails
- [x] `bun scripts/ratchet.ts` — no metric increased

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved responses to open-ended questions when an active file is selected, with better long-document handling and clearer scope control.
  - DOCX documents are now converted to structured Markdown (including headings and tables) when read.
- **Bug Fixes**
  - Ensured consistent file selection by ordering and field limits for entity field retrieval.
  - More reliable handling when DOCX conversion fails, including safer behaviour during paginated reads.
- **Tests**
  - Added end-to-end coverage for DOCX conversion, fallbacks, and pagination error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->