### PR TITLE
feat: refine chat tool activity

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -102,6 +102,7 @@
     "lucide-react": "catalog:",
     "pdfjs-dist": "^6.1.200",
     "posthog-js": "^1.399.4",
+    "prism-react-renderer": "^2.4.1",
     "prosemirror-commands": "^1.7.1",
     "prosemirror-history": "^1.5.0",
     "prosemirror-keymap": "^1.2.3",

--- a/apps/web/src/components/chat/tool-call-card.tsx
+++ b/apps/web/src/components/chat/tool-call-card.tsx
@@ -1,17 +1,10 @@
 import { useState } from "react";
 
 import { useQuery } from "@tanstack/react-query";
-import {
-  ChevronDownIcon,
-  CodeIcon,
-  CircleHelpIcon,
-  FileTextIcon,
-  LibraryIcon,
-  SearchIcon,
-  UserIcon,
-} from "lucide-react";
-import { useTranslations } from "use-intl";
+import { ChevronRightIcon, CircleHelpIcon } from "lucide-react";
+import { useFormatter, useTranslations } from "use-intl";
 
+import { DirectionalIcon } from "@stll/ui/components/directional-icon";
 import {
   Popover,
   PopoverPopup,
@@ -24,8 +17,13 @@ import {
   getChatToolTitleKey,
   isRunningToolPart,
 } from "@/components/chat/chat-ui-tools";
+import { ToolCallCodeBlock } from "@/components/chat/tool-call-code-block";
+import {
+  advanceToolCallTiming,
+  createToolCallTiming,
+} from "@/components/chat/tool-call-timing.logic";
 import Tooltip from "@/components/tooltip";
-import { sanitizeHref } from "@/lib/sanitize-href";
+import { useExternalSyncEffect } from "@/hooks/use-effect";
 import { mcpConnectorsOptions } from "@/routes/_protected.knowledge/-queries";
 import { useInspectorStore } from "@/routes/_protected.workspaces/$workspaceId/-components/inspector/inspector-store";
 
@@ -306,54 +304,32 @@ const getMcpToolInfo = (toolName: string): McpToolInfo | null => {
   return { connectorSlug: connector };
 };
 
-const NATIVE_TOOL_BRANDS: Record<string, { slug: string; brand: string }> = {
+const NATIVE_TOOL_BRANDS: Record<string, string> = {
   // Historical aliases for chat history that predates the unified
   // `business_registry_lookup` tool. New turns route through the
   // unified tool; the per-jurisdiction brand is resolved at render
   // time from the call input rather than from the tool name.
-  ares_lookup_company: { slug: "ares", brand: "ARES" },
-  ares_search_companies: { slug: "ares", brand: "ARES" },
-};
-
-const TOOL_ICONS: Record<string, typeof SearchIcon> = {
-  "ask-user": CircleHelpIcon,
-  "describe-stella-api": CircleHelpIcon,
-  "describe-stella-function": CircleHelpIcon,
-  discover_tools: CircleHelpIcon,
-  execute_typescript: CodeIcon,
-  "execute-typescript": CodeIcon,
-  "run-stella-query": CodeIcon,
-  "load-skill": LibraryIcon,
-  "read-contact": UserIcon,
-  "read-skill-resource": FileTextIcon,
-  "create-current-skill-resource": FileTextIcon,
-  "update-current-skill-body": FileTextIcon,
-  "update-current-skill-resource": FileTextIcon,
+  ares_lookup_company: "ARES",
+  ares_search_companies: "ARES",
 };
 
 type CatalogEntry = {
   brand: string;
-  iconHref: string | undefined;
 };
 
 type CatalogItem = {
   slug: string;
   displayName: string;
-  description: string;
-  url: string;
-  iconUrl: string | null;
 };
 
 const findCatalogEntry = ({
   toolName,
   mcpToolInfo,
   connectors,
-  nativeTools,
 }: {
   toolName: string;
   mcpToolInfo: McpToolInfo | null;
   connectors: CatalogItem[];
-  nativeTools: CatalogItem[];
 }): CatalogEntry | null => {
   if (mcpToolInfo !== null) {
     const connector = connectors.find(
@@ -365,52 +341,44 @@ const findCatalogEntry = ({
     }
     return {
       brand: connector.displayName,
-      iconHref: resolveIconHref(connector),
     };
   }
 
-  const native = NATIVE_TOOL_BRANDS[toolName];
-  if (native === undefined) {
+  const nativeBrand = NATIVE_TOOL_BRANDS[toolName];
+  if (nativeBrand === undefined) {
     return null;
   }
-  const tool = nativeTools.find((item) => item.slug === native.slug);
   return {
-    brand: native.brand,
-    iconHref: tool === undefined ? undefined : resolveIconHref(tool),
+    brand: nativeBrand,
   };
-};
-
-const resolveIconHref = (item: CatalogItem): string | undefined => {
-  const raw = item.iconUrl ?? fallbackIconUrl(item.url);
-  return raw === undefined ? undefined : sanitizeHref(raw);
 };
 
 export const ToolCallCard = ({
   activeOrganizationId,
+  durationMs,
   part,
   showDetails,
 }: {
   activeOrganizationId: string;
+  /** Known elapsed time, used by persisted callers and visual fixtures. */
+  durationMs?: number;
   part: ToolPart;
-  /** Show expandable raw output (dev mode). */
+  /** Open rich tool details initially in development surfaces. */
   showDetails?: boolean;
 }) => {
   const t = useTranslations();
+  const format = useFormatter();
   const name = part.name;
   const mcpToolInfo = getMcpToolInfo(name);
-  const hasCatalogEntry =
-    mcpToolInfo !== null || NATIVE_TOOL_BRANDS[name] !== undefined;
   const { data: catalogData } = useQuery({
     ...mcpConnectorsOptions(activeOrganizationId),
-    enabled: hasCatalogEntry,
+    enabled: mcpToolInfo !== null,
   });
   const connectors = catalogData ? catalogData.connectors : [];
-  const nativeTools = catalogData ? catalogData.nativeTools : [];
   const catalogEntry = findCatalogEntry({
     toolName: name,
     mcpToolInfo,
     connectors,
-    nativeTools,
   });
   const [expanded, setExpanded] = useState(() =>
     Boolean(
@@ -420,7 +388,6 @@ export const ToolCallCard = ({
         isSkillResourceOutputToolName(name)),
     ),
   );
-  const Icon = TOOL_ICONS[name] ?? SearchIcon;
   const label = catalogEntry?.brand ?? t(getChatToolTitleKey(name));
   const subtitle = getToolSubtitle({
     formatCharacterCount: (count) =>
@@ -430,6 +397,27 @@ export const ToolCallCard = ({
   });
 
   const isLoading = isRunningToolPart(part);
+  const [timing, setTiming] = useState(() =>
+    createToolCallTiming({ durationMs, isRunning: isLoading, now: Date.now() }),
+  );
+  useExternalSyncEffect(() => {
+    setTiming((current) =>
+      advanceToolCallTiming({
+        current,
+        durationMs,
+        isRunning: isLoading,
+        now: Date.now(),
+      }),
+    );
+  }, [durationMs, isLoading]);
+  const elapsed =
+    timing.status === "finished" && timing.durationMs !== undefined
+      ? format.number(Math.max(1, Math.round(timing.durationMs / 1000)), {
+          style: "unit",
+          unit: "second",
+          unitDisplay: "narrow",
+        })
+      : null;
   const hasOutput = part.output !== undefined;
   // A tool-call rewritten to the terminal "error" state at hydration (its
   // stream died mid call, so it never produced an `output.error`) still
@@ -451,28 +439,31 @@ export const ToolCallCard = ({
     showMcpExactCall ||
     codeToolSource !== undefined ||
     showCodeToolOutput ||
-    (showDetails && toolInput !== undefined) ||
-    (showDetails && hasOutput);
+    toolInput !== undefined ||
+    hasOutput;
   const headerOpensSkillResource = skillResourceOutput !== undefined;
   const headerInteractive = headerOpensSkillResource || canExpand;
 
   return (
-    <div className="my-1 text-xs">
+    <div className="my-0.5 max-w-xl text-sm">
       <Tooltip
         content={errorMessage}
         render={
           <div
             className={cn(
-              "bg-muted/30 inline-flex max-w-full items-center gap-1.5 rounded-md px-2 py-1 align-top",
+              "group/tool-step hover:bg-muted/35 focus-within:bg-muted/35 flex max-w-full items-center rounded-lg transition-colors duration-150",
+              expanded && "bg-muted/25 rounded-b-none",
               hasError &&
-                "bg-destructive/10 border-destructive/60 text-destructive border",
+                "bg-destructive/10 text-destructive hover:bg-destructive/15",
             )}
           />
         }
       >
         <button
           className={cn(
-            "flex min-w-0 items-center gap-1.5 text-start",
+            "flex min-h-11 min-w-0 flex-1 items-center gap-2 px-2 text-start transition-colors duration-150",
+            !hasError &&
+              "text-muted-foreground group-hover/tool-step:text-foreground-muted",
             !headerInteractive && "cursor-default",
           )}
           onClick={() => {
@@ -501,23 +492,33 @@ export const ToolCallCard = ({
           }}
           type="button"
         >
-          <ToolCallLeadingIcon
-            Icon={Icon}
-            iconHref={catalogEntry?.iconHref}
-            isLoading={isLoading}
-          />
-          <span className="min-w-0 truncate">
-            <span className="font-medium">{label}</span>
+          <span
+            className={cn(
+              "min-w-0 truncate",
+              isLoading &&
+                "animate-skeleton motion-reduce:text-muted-foreground bg-[linear-gradient(90deg,var(--color-foreground-ghost)_35%,var(--color-muted-foreground)_50%,var(--color-foreground-ghost)_65%)] bg-[length:250%_100%] bg-clip-text text-transparent motion-reduce:animate-none rtl:[animation-name:skeleton-rtl]",
+            )}
+          >
+            <span>{label}</span>
             {subtitle && (
-              <span className="text-muted-foreground ms-1.5">{subtitle}</span>
+              <span
+                className={cn("ms-1.5", !isLoading && "text-foreground-ghost")}
+              >
+                {subtitle}
+              </span>
             )}
           </span>
+          {elapsed && (
+            <span className="text-foreground-ghost shrink-0 text-xs font-normal tabular-nums">
+              {elapsed}
+            </span>
+          )}
         </button>
         {mcpToolInfo !== null && (
           <Popover>
             <PopoverTrigger
               aria-label={t("knowledge.mcp.whatIsAnMcpServer")}
-              className="text-muted-foreground hover:text-foreground focus-visible:ring-ring/50 shrink-0 rounded focus-visible:ring-2 focus-visible:outline-none"
+              className="text-muted-foreground hover:text-foreground focus-visible:ring-ring/50 flex size-11 shrink-0 items-center justify-center rounded focus-visible:ring-2 focus-visible:outline-none"
             >
               <CircleHelpIcon className="size-3" />
             </PopoverTrigger>
@@ -530,20 +531,25 @@ export const ToolCallCard = ({
             </PopoverPopup>
           </Popover>
         )}
-        {canExpand && (!headerOpensSkillResource || showDetails) && (
+        {canExpand && (
           <button
             aria-label={t("chat.toolCall.toggleDetails")}
-            className="text-muted-foreground hover:text-foreground focus-visible:ring-ring/50 shrink-0 rounded focus-visible:ring-2 focus-visible:outline-none"
+            className={cn(
+              "text-muted-foreground hover:text-foreground focus-visible:ring-ring/50 flex size-11 shrink-0 items-center justify-center rounded opacity-0 transition-opacity duration-150 group-hover/tool-step:opacity-100 focus-visible:opacity-100 focus-visible:ring-2 focus-visible:outline-none",
+              expanded && "opacity-100",
+            )}
             onClick={() => {
               setExpanded((e) => !e);
             }}
             type="button"
           >
-            <ChevronDownIcon
+            <DirectionalIcon
               className={cn(
-                "size-3 transition-transform",
-                expanded && "rotate-180",
+                "size-3.5 transition-transform duration-150",
+                expanded && "rotate-90",
               )}
+              flip={!expanded}
+              icon={ChevronRightIcon}
             />
           </button>
         )}
@@ -552,37 +558,47 @@ export const ToolCallCard = ({
         (showMcpExactCall ||
           codeToolSource !== undefined ||
           showCodeToolOutput ||
-          (showDetails && toolInput !== undefined) ||
-          (showDetails && hasOutput)) && (
-          <div className="space-y-2 border-t px-2 py-1.5">
+          toolInput !== undefined ||
+          hasOutput) && (
+          <div className="bg-muted/25 space-y-3 rounded-b-lg px-3 pt-1 pb-3">
             {showMcpExactCall && (
               <div>
                 <div className="text-muted-foreground mb-1 text-[11px] font-medium">
                   {t("chat.toolCall.exactCall")}
                 </div>
-                <pre className="text-muted-foreground max-h-40 overflow-auto font-mono text-[11px] whitespace-pre-wrap">
-                  {`${name}\n${JSON.stringify(toolInput, null, 2)}`}
-                </pre>
+                <ToolCallCodeBlock
+                  code={JSON.stringify(
+                    { input: toolInput, tool: name },
+                    null,
+                    2,
+                  )}
+                  language="json"
+                />
               </div>
             )}
-            {showDetails && toolInput !== undefined && (
-              <div>
-                <div className="text-muted-foreground mb-1 text-[11px] font-medium">
-                  {t("chat.toolCall.input")}
+            {!showMcpExactCall &&
+              codeToolSource === undefined &&
+              toolInput !== undefined && (
+                <div>
+                  <div className="text-muted-foreground mb-1 text-[11px] font-medium">
+                    {t("chat.toolCall.input")}
+                  </div>
+                  <ToolCallCodeBlock
+                    code={JSON.stringify(toolInput, null, 2)}
+                    language="json"
+                  />
                 </div>
-                <pre className="text-muted-foreground max-h-40 overflow-auto font-mono text-[11px] whitespace-pre-wrap">
-                  {JSON.stringify(toolInput, null, 2)}
-                </pre>
-              </div>
-            )}
+              )}
             {codeToolSource !== undefined && (
               <div>
                 <div className="text-muted-foreground mb-1 text-[11px] font-medium">
                   {t("chat.toolCall.sourceCode")}
                 </div>
-                <pre className="bg-background/60 text-foreground max-h-96 overflow-auto rounded border px-2 py-1.5 font-mono text-[11px] whitespace-pre-wrap">
-                  {codeToolSource}
-                </pre>
+                <ToolCallCodeBlock
+                  code={codeToolSource}
+                  language="typescript"
+                  lineNumbers
+                />
               </div>
             )}
             {codeToolLogs.length > 0 && (
@@ -590,27 +606,27 @@ export const ToolCallCard = ({
                 <div className="text-muted-foreground mb-1 text-[11px] font-medium">
                   {t("chat.toolCall.consoleLogs")}
                 </div>
-                <pre className="bg-background/60 text-muted-foreground max-h-40 overflow-auto rounded border px-2 py-1.5 font-mono text-[11px] whitespace-pre-wrap">
-                  {codeToolLogs.join("\n")}
-                </pre>
+                <ToolCallCodeBlock
+                  code={codeToolLogs.join("\n")}
+                  language="text"
+                />
               </div>
             )}
-            {hasOutput &&
-              (showDetails || showCodeToolOutput) &&
-              "output" in part && (
-                <div>
-                  <div className="text-muted-foreground mb-1 text-[11px] font-medium">
-                    {t("chat.toolCall.output")}
-                  </div>
-                  <pre className="text-muted-foreground max-h-40 overflow-auto font-mono text-[11px] whitespace-pre-wrap">
-                    {JSON.stringify(part.output, null, 2)}
-                  </pre>
+            {hasOutput && "output" in part && (
+              <div>
+                <div className="text-muted-foreground mb-1 text-[11px] font-medium">
+                  {t("chat.toolCall.output")}
                 </div>
-              )}
+                <ToolCallCodeBlock
+                  code={JSON.stringify(part.output, null, 2)}
+                  language="json"
+                />
+              </div>
+            )}
           </div>
         )}
       {hasError && errorMessage && (
-        <p className="text-destructive mt-1 max-w-xl px-2 py-1 text-[11px] leading-relaxed whitespace-pre-wrap">
+        <p className="text-destructive max-w-xl px-2 py-1 text-[11px] leading-relaxed whitespace-pre-wrap">
           {errorMessage}
         </p>
       )}
@@ -638,51 +654,5 @@ const getToolOutputError = (output: unknown): string | undefined => {
   return undefined;
 };
 
-function ToolCallLeadingIcon({
-  Icon,
-  iconHref,
-  isLoading,
-}: {
-  Icon: typeof SearchIcon;
-  iconHref?: string | undefined;
-  isLoading: boolean;
-}) {
-  if (iconHref) {
-    return (
-      <span className="bg-background relative flex size-4 shrink-0 items-center justify-center rounded-sm border">
-        <img
-          alt=""
-          className={cn(
-            "size-3 rounded-[2px] object-contain",
-            isLoading && "opacity-70",
-          )}
-          height={12}
-          src={iconHref}
-          width={12}
-        />
-        {isLoading && (
-          <span className="border-foreground/20 border-t-foreground absolute -inset-0.5 animate-spin rounded-sm border" />
-        )}
-      </span>
-    );
-  }
-
-  if (isLoading) {
-    return (
-      <div className="border-foreground/20 border-t-foreground size-3 animate-spin rounded-full border" />
-    );
-  }
-
-  return <Icon className="text-muted-foreground size-3 shrink-0" />;
-}
-
 const sanitizeMcpToolNamePart = (value: string): string =>
   value.replace(/[^a-zA-Z0-9_-]/gu, "_");
-
-const fallbackIconUrl = (rawUrl: string): string | undefined => {
-  try {
-    return new URL("/favicon.ico", rawUrl).toString();
-  } catch {
-    return undefined;
-  }
-};

--- a/apps/web/src/components/chat/tool-call-code-block.tsx
+++ b/apps/web/src/components/chat/tool-call-code-block.tsx
@@ -1,0 +1,141 @@
+import { CopyIcon } from "lucide-react";
+import { Highlight } from "prism-react-renderer";
+import type { PrismTheme, Token } from "prism-react-renderer";
+import { useTranslations } from "use-intl";
+
+import { Button } from "@stll/ui/components/button";
+import { stellaToast } from "@stll/ui/components/toast";
+
+import { detached } from "@/lib/detached";
+
+const TOOL_CODE_THEME = {
+  plain: {
+    backgroundColor: "transparent",
+    color: "var(--color-foreground)",
+  },
+  styles: [
+    {
+      types: ["comment", "prolog", "doctype", "cdata"],
+      style: { color: "var(--color-muted-foreground)", fontStyle: "italic" },
+    },
+    {
+      types: ["punctuation"],
+      style: { color: "var(--color-foreground-muted)" },
+    },
+    {
+      types: ["keyword", "operator", "atrule"],
+      style: { color: "var(--color-destructive)" },
+    },
+    {
+      types: ["function", "class-name", "builtin"],
+      style: { color: "var(--color-primary)" },
+    },
+    {
+      types: ["string", "char", "attr-value"],
+      style: { color: "var(--color-info)" },
+    },
+    {
+      types: ["number", "boolean", "constant", "symbol"],
+      style: { color: "var(--color-warning)" },
+    },
+    {
+      types: ["property", "tag", "selector", "attr-name"],
+      style: { color: "var(--color-success)" },
+    },
+  ],
+} satisfies PrismTheme;
+
+export const ToolCallCodeBlock = ({
+  code,
+  language,
+  lineNumbers = false,
+}: {
+  code: string;
+  language: "json" | "text" | "typescript";
+  lineNumbers?: boolean;
+}) => {
+  const t = useTranslations();
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(code);
+      stellaToast.add({ title: t("common.copied"), type: "success" });
+    } catch {
+      stellaToast.add({ title: t("errors.actionFailed"), type: "error" });
+    }
+  };
+
+  return (
+    <div className="bg-background/50 overflow-hidden rounded-lg border">
+      <div className="text-muted-foreground flex h-9 items-center justify-between px-2.5 text-[11px]">
+        <span className="font-mono lowercase">{language}</span>
+        <Button
+          aria-label={t("common.copy")}
+          className="text-muted-foreground"
+          onClick={() => {
+            detached(handleCopy(), "ToolCallCodeBlock");
+          }}
+          size="icon-xs"
+          type="button"
+          variant="ghost"
+        >
+          <CopyIcon className="size-3.5" />
+        </Button>
+      </div>
+      <Highlight code={code} language={language} theme={TOOL_CODE_THEME}>
+        {({ getLineProps, getTokenProps, tokens }) => {
+          const keyedLines = addStableKeys(tokens);
+
+          return (
+            <pre className="max-h-96 overflow-auto px-3 pb-3 font-mono text-xs leading-5">
+              {keyedLines.map(
+                ({ key, line, lineNumber, tokens: lineTokens }) => (
+                  <div key={key} {...getLineProps({ line })}>
+                    {lineNumbers && (
+                      <span className="text-foreground-ghost me-4 inline-block w-5 text-end tabular-nums select-none">
+                        {lineNumber}
+                      </span>
+                    )}
+                    {lineTokens.map(({ key: tokenKey, token }) => (
+                      <span key={tokenKey} {...getTokenProps({ token })} />
+                    ))}
+                  </div>
+                ),
+              )}
+            </pre>
+          );
+        }}
+      </Highlight>
+    </div>
+  );
+};
+
+const addStableKeys = (lines: Token[][]) => {
+  const lineOccurrences = new Map<string, number>();
+  let lineNumber = 0;
+
+  return lines.map((line) => {
+    lineNumber += 1;
+    const lineSignature = line.map(getTokenSignature).join("|");
+    const lineOccurrence = lineOccurrences.get(lineSignature) ?? 0;
+    lineOccurrences.set(lineSignature, lineOccurrence + 1);
+    const tokenOccurrences = new Map<string, number>();
+    const keyedTokens = line.map((token) => {
+      const signature = getTokenSignature(token);
+      const occurrence = tokenOccurrences.get(signature) ?? 0;
+      tokenOccurrences.set(signature, occurrence + 1);
+
+      return { key: `${signature}:${occurrence}`, token };
+    });
+
+    return {
+      key: `${lineSignature}:${lineOccurrence}`,
+      line,
+      lineNumber,
+      tokens: keyedTokens,
+    };
+  });
+};
+
+const getTokenSignature = ({ content, types }: Token): string =>
+  `${types.join(".")}:${content}`;

--- a/apps/web/src/components/chat/tool-call-code-block.tsx
+++ b/apps/web/src/components/chat/tool-call-code-block.tsx
@@ -92,7 +92,7 @@ export const ToolCallCodeBlock = ({
         style={TOOL_CODE_THEME.plain}
       >
         {keyedLines.map(({ key, lineNumber, tokens: lineTokens }) => (
-          <div key={key}>
+          <span className="block" key={key}>
             {shouldShowLineNumbers && (
               <span className="text-foreground-ghost me-4 inline-block w-5 text-end tabular-nums select-none">
                 {lineNumber}
@@ -103,7 +103,7 @@ export const ToolCallCodeBlock = ({
                 {token.content}
               </span>
             ))}
-          </div>
+          </span>
         ))}
       </pre>
     </div>

--- a/apps/web/src/components/chat/tool-call-code-block.tsx
+++ b/apps/web/src/components/chat/tool-call-code-block.tsx
@@ -1,5 +1,7 @@
+import type { CSSProperties } from "react";
+
 import { CopyIcon } from "lucide-react";
-import { Highlight } from "prism-react-renderer";
+import { Prism, useTokenize } from "prism-react-renderer";
 import type { PrismTheme, Token } from "prism-react-renderer";
 import { useTranslations } from "use-intl";
 
@@ -48,13 +50,16 @@ const TOOL_CODE_THEME = {
 export const ToolCallCodeBlock = ({
   code,
   language,
-  lineNumbers = false,
+  lineNumbers,
 }: {
   code: string;
   language: "json" | "text" | "typescript";
   lineNumbers?: boolean;
 }) => {
   const t = useTranslations();
+  const shouldShowLineNumbers = lineNumbers ?? false;
+  const tokens = useTokenize({ code, language, prism: Prism });
+  const keyedLines = addStableKeys(tokens);
 
   const handleCopy = async () => {
     try {
@@ -82,30 +87,25 @@ export const ToolCallCodeBlock = ({
           <CopyIcon className="size-3.5" />
         </Button>
       </div>
-      <Highlight code={code} language={language} theme={TOOL_CODE_THEME}>
-        {({ getLineProps, getTokenProps, tokens }) => {
-          const keyedLines = addStableKeys(tokens);
-
-          return (
-            <pre className="max-h-96 overflow-auto px-3 pb-3 font-mono text-xs leading-5">
-              {keyedLines.map(
-                ({ key, line, lineNumber, tokens: lineTokens }) => (
-                  <div key={key} {...getLineProps({ line })}>
-                    {lineNumbers && (
-                      <span className="text-foreground-ghost me-4 inline-block w-5 text-end tabular-nums select-none">
-                        {lineNumber}
-                      </span>
-                    )}
-                    {lineTokens.map(({ key: tokenKey, token }) => (
-                      <span key={tokenKey} {...getTokenProps({ token })} />
-                    ))}
-                  </div>
-                ),
-              )}
-            </pre>
-          );
-        }}
-      </Highlight>
+      <pre
+        className="max-h-96 overflow-auto px-3 pb-3 font-mono text-xs leading-5"
+        style={TOOL_CODE_THEME.plain}
+      >
+        {keyedLines.map(({ key, lineNumber, tokens: lineTokens }) => (
+          <div key={key}>
+            {shouldShowLineNumbers && (
+              <span className="text-foreground-ghost me-4 inline-block w-5 text-end tabular-nums select-none">
+                {lineNumber}
+              </span>
+            )}
+            {lineTokens.map(({ key: tokenKey, token }) => (
+              <span key={tokenKey} style={getTokenStyle(token)}>
+                {token.content}
+              </span>
+            ))}
+          </div>
+        ))}
+      </pre>
     </div>
   );
 };
@@ -139,3 +139,15 @@ const addStableKeys = (lines: Token[][]) => {
 
 const getTokenSignature = ({ content, types }: Token): string =>
   `${types.join(".")}:${content}`;
+
+const getTokenStyle = ({ types }: Token) => {
+  const style: CSSProperties = {};
+
+  for (const themeEntry of TOOL_CODE_THEME.styles) {
+    if (themeEntry.types.some((type) => types.includes(type))) {
+      Object.assign(style, themeEntry.style);
+    }
+  }
+
+  return style;
+};

--- a/apps/web/src/components/chat/tool-call-timing.logic.test.ts
+++ b/apps/web/src/components/chat/tool-call-timing.logic.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  advanceToolCallTiming,
+  createToolCallTiming,
+} from "@/components/chat/tool-call-timing.logic";
+
+describe("tool-call timing", () => {
+  test("freezes the elapsed time when a running call finishes", () => {
+    const running = createToolCallTiming({
+      durationMs: undefined,
+      isRunning: true,
+      now: 1000,
+    });
+    const finished = advanceToolCallTiming({
+      current: running,
+      durationMs: undefined,
+      isRunning: false,
+      now: 3450,
+    });
+
+    expect(finished).toEqual({ status: "finished", durationMs: 2450 });
+    expect(
+      advanceToolCallTiming({
+        current: finished,
+        durationMs: undefined,
+        isRunning: false,
+        now: 9000,
+      }),
+    ).toBe(finished);
+  });
+
+  test("uses a known duration for an already-finished call", () => {
+    expect(
+      createToolCallTiming({
+        durationMs: 8000,
+        isRunning: false,
+        now: 20_000,
+      }),
+    ).toEqual({ status: "finished", durationMs: 8000 });
+  });
+});

--- a/apps/web/src/components/chat/tool-call-timing.logic.test.ts
+++ b/apps/web/src/components/chat/tool-call-timing.logic.test.ts
@@ -39,4 +39,15 @@ describe("tool-call timing", () => {
       }),
     ).toEqual({ status: "finished", durationMs: 8000 });
   });
+
+  test("replaces an estimated duration when the precise duration arrives", () => {
+    expect(
+      advanceToolCallTiming({
+        current: { status: "finished", durationMs: 2450 },
+        durationMs: 2312,
+        isRunning: false,
+        now: 9000,
+      }),
+    ).toEqual({ status: "finished", durationMs: 2312 });
+  });
 });

--- a/apps/web/src/components/chat/tool-call-timing.logic.ts
+++ b/apps/web/src/components/chat/tool-call-timing.logic.ts
@@ -36,6 +36,10 @@ export const advanceToolCallTiming = ({
   }
 
   if (current.status === "finished") {
+    if (durationMs !== undefined && durationMs !== current.durationMs) {
+      return { status: "finished", durationMs };
+    }
+
     return current;
   }
 

--- a/apps/web/src/components/chat/tool-call-timing.logic.ts
+++ b/apps/web/src/components/chat/tool-call-timing.logic.ts
@@ -1,0 +1,46 @@
+export type ToolCallTiming =
+  | { status: "running"; startedAt: number }
+  | { status: "finished"; durationMs: number | undefined };
+
+export const createToolCallTiming = ({
+  durationMs,
+  isRunning,
+  now,
+}: {
+  durationMs: number | undefined;
+  isRunning: boolean;
+  now: number;
+}): ToolCallTiming => {
+  if (isRunning) {
+    return { status: "running", startedAt: now };
+  }
+
+  return { status: "finished", durationMs };
+};
+
+export const advanceToolCallTiming = ({
+  current,
+  durationMs,
+  isRunning,
+  now,
+}: {
+  current: ToolCallTiming;
+  durationMs: number | undefined;
+  isRunning: boolean;
+  now: number;
+}): ToolCallTiming => {
+  if (isRunning) {
+    return current.status === "running"
+      ? current
+      : { status: "running", startedAt: now };
+  }
+
+  if (current.status === "finished") {
+    return current;
+  }
+
+  return {
+    status: "finished",
+    durationMs: durationMs ?? Math.max(0, now - current.startedAt),
+  };
+};

--- a/apps/web/src/routes/dev/-components/ui-playground.tsx
+++ b/apps/web/src/routes/dev/-components/ui-playground.tsx
@@ -4,19 +4,16 @@ import type * as React from "react";
 import {
   ArchiveIcon,
   BellIcon,
-  CheckIcon,
   ChevronDownIcon,
   ClockIcon,
   CopyIcon,
   FileTextIcon,
   FilterIcon,
   LinkIcon,
-  LoaderIcon,
   MailIcon,
   SearchIcon,
   SettingsIcon,
   ShieldIcon,
-  SquarePenIcon,
   Trash2Icon,
   UserIcon,
 } from "lucide-react";
@@ -187,18 +184,14 @@ import {
   TooltipTrigger,
 } from "@stll/ui/components/tooltip";
 
-import {
-  Message,
-  MessageContent,
-  MessageResponse,
-} from "@/components/ai-elements/message";
 import { ChatApprovalContext } from "@/components/chat/chat-approval-context";
 import { ChatMattersContext } from "@/components/chat/chat-matters-context";
-import {
-  ChatErrorMessage,
-  ChatThreadMessages,
-} from "@/components/chat/chat-thread-messages";
-import type { PersistedChatMessage } from "@/components/chat/chat-ui-tools";
+import { ChatThreadMessages } from "@/components/chat/chat-thread-messages";
+import type {
+  ChatToolCallPart,
+  PersistedChatMessage,
+} from "@/components/chat/chat-ui-tools";
+import { ToolCallCard } from "@/components/chat/tool-call-card";
 import { DatePickerPopover } from "@/components/date-picker-popover";
 import { AIKeyRequiredDialog } from "@/components/require-ai-key";
 import { detached } from "@/lib/detached";
@@ -1181,22 +1174,16 @@ export function UiPlayground() {
           <TabsPanel value="chat">
             <PlaygroundGrid>
               <PlaygroundSection
+                description="Production streaming-step rows. Hover to reveal the disclosure control; expand a row to inspect its input and output."
+                title="Tool activity"
+              >
+                <ToolActivityPlayground />
+              </PlaygroundSection>
+              <PlaygroundSection
                 description="Production chat renderer sample. Use this to review shared assistant response controls."
                 title="Shared renderer"
               >
                 <SharedChatRendererSample />
-              </PlaygroundSection>
-              <PlaygroundSection
-                description="Existing assistant + user bubble types from the standalone chat panel. We need to lift each into the unified file-anchored chat (Phase C)."
-                title="Chat bubbles"
-              >
-                <ChatBubbleSink />
-              </PlaygroundSection>
-              <PlaygroundSection
-                description="One row per bubble type that exists today and isn't in the unified chat yet."
-                title="Inventory"
-              >
-                <ChatBubbleInventory />
               </PlaygroundSection>
             </PlaygroundGrid>
           </TabsPanel>
@@ -1355,337 +1342,78 @@ function SharedChatRendererSample() {
   );
 }
 
-/**
- * Mock chat bubbles — rendered with hand-built JSX so we don't have
- * to construct AI-SDK `ChatMessage` fixtures that match the strict
- * tool schemas. These reproduce the visual surface of every bubble
- * type so we can review them in one place; the actual production
- * renderer (ChatThreadMessages) still drives real chat.
- */
-function ChatBubbleSink() {
+const COMPLETED_TOOL_STEP = {
+  type: "tool-call",
+  id: "playground-tool-complete",
+  name: "search-chat-history",
+  arguments: JSON.stringify({ query: "indemnity survival period" }),
+  state: "complete",
+  input: { query: "indemnity survival period" },
+  output: {
+    query: "indemnity survival period",
+    results: [
+      {
+        messageId: "playground-message-indemnity",
+        role: "assistant",
+        excerpt: "The playbook uses a 36-month survival period.",
+        createdAt: "2026-07-21T10:30:00.000Z",
+      },
+    ],
+  },
+} satisfies ChatToolCallPart;
+
+const COMPLETED_CODE_TOOL_STEP = {
+  type: "tool-call",
+  id: "playground-tool-complete-second",
+  name: "execute_typescript",
+  arguments: JSON.stringify({
+    typescriptCode:
+      "const matches = await searchWorkspace({ query: 'environmental indemnity carve-outs' });",
+  }),
+  state: "complete",
+  input: {
+    typescriptCode: `const matches = await searchWorkspace({
+  query: "environmental indemnity carve-outs",
+  limit: 5,
+});
+
+return matches.map(({ title, excerpt }) => ({ title, excerpt }));`,
+  },
+  output: {
+    logs: ["Found 3 matching clauses", "Normalized citations"],
+    value: [
+      { title: "Indemnity playbook", excerpt: "Excluded from the general cap" },
+    ],
+  },
+} satisfies ChatToolCallPart;
+
+const RUNNING_TOOL_STEP = {
+  type: "tool-call",
+  id: "playground-tool-running",
+  name: "search-chat-history",
+  arguments: JSON.stringify({ query: "closing conditions" }),
+  state: "input-complete",
+  input: { query: "closing conditions" },
+} satisfies ChatToolCallPart;
+
+function ToolActivityPlayground() {
   return (
-    <div className="bg-popover/40 flex max-h-[70dvh] flex-col gap-6 overflow-y-auto rounded-2xl border p-4">
-      <Message from="user">
-        <MessageContent>
-          <span className="whitespace-pre-wrap">
-            Summarise the SPA in matter Acme/EnerGo and flag the indemnity
-            exposure.
-          </span>
-        </MessageContent>
-      </Message>
-
-      <Message from="assistant">
-        <MessageContent>
-          <MessageResponse>
-            {[
-              "**Summary.** The SPA is a share purchase between Acme Holdings and EnerGo Distribuce, dated 1 Feb 2025.",
-              "",
-              "Key terms:",
-              "- Purchase price: EUR 50,000,000 with EUR 5,000,000 escrow.",
-              "- Closing conditional on antitrust clearance.",
-              "- Caps and baskets are aggressive vs. our standard playbook (5% / 0.1%).",
-              "",
-              "I'd rate the indemnity exposure **medium** — the carve-outs for tax and environmental are wider than typical.",
-            ].join("\n")}
-          </MessageResponse>
-        </MessageContent>
-      </Message>
-
-      <Message from="user">
-        <MessageContent>
-          <span className="whitespace-pre-wrap">
-            Compare the indemnity clause against my version of the playbook.
-          </span>
-          <button
-            type="button"
-            className="text-muted-foreground bg-muted/60 hover:bg-muted inline-flex w-fit items-center gap-1.5 rounded-md border px-2 py-1 text-xs"
-          >
-            <FileTextIcon className="size-3" />
-            indemnity-playbook.pdf
-          </button>
-        </MessageContent>
-      </Message>
-
-      <Message from="assistant">
-        <MessageContent>
-          <MessageResponse>
-            {`Cross-checked against your playbook. The SPA's indemnity in §8.2 sets a survival period of 24 months — your standard is 36.`}
-          </MessageResponse>
-          <button
-            type="button"
-            className="text-info hover:bg-info/10 inline-flex w-fit items-center gap-1 rounded-md px-1.5 py-0.5 text-xs no-underline"
-          >
-            <FileTextIcon className="size-3" />
-            EnerGo SPA Final.docx
-          </button>
-        </MessageContent>
-      </Message>
-
-      <ApprovalCardMock
-        title="Create document"
-        description="EnerGo SPA Final — redline §8.2.docx"
-        path="Drafts/"
+    <div className="flex flex-col">
+      <ToolCallCard
+        activeOrganizationId="playground"
+        durationMs={8000}
+        part={COMPLETED_TOOL_STEP}
       />
-
-      <UpdateFieldsCardMock />
-
-      <AskUserCardMock />
-
-      <ToolCallMock />
-
-      <ChatErrorMock />
-
-      <Message from="assistant">
-        <MessageContent>
-          <MessageResponse>
-            {`Czech labour code §52 lists six redundancy grounds — restructuring is one. The relevant case is **30 Cdo 161/2024**.`}
-          </MessageResponse>
-          <div className="flex flex-wrap gap-1.5 pt-1">
-            <SourceChipMock label="30 Cdo 161/2024" kind="case-law" />
-            <SourceChipMock
-              label="EnerGo SPA Final.docx · §8.2"
-              kind="entity"
-            />
-          </div>
-        </MessageContent>
-      </Message>
-
-      <Message from="assistant">
-        <MessageContent>
-          <span className="text-muted-foreground inline-flex items-center gap-2 text-xs">
-            <LoaderIcon
-              className="text-foreground-ghost size-3 animate-spin"
-              aria-hidden="true"
-            />
-            Thinking…
-          </span>
-        </MessageContent>
-      </Message>
+      <ToolCallCard
+        activeOrganizationId="playground"
+        durationMs={2000}
+        part={COMPLETED_CODE_TOOL_STEP}
+        showDetails
+      />
+      <ToolCallCard
+        activeOrganizationId="playground"
+        part={RUNNING_TOOL_STEP}
+      />
     </div>
-  );
-}
-
-function ApprovalCardMock(props: {
-  title: string;
-  description: string;
-  path: string;
-}) {
-  return (
-    <Message from="assistant">
-      <MessageContent className="max-w-[460px]">
-        <MessageResponse>
-          {`I can draft a redline reverting §8.2 to a 36-month survival. Approve to create.`}
-        </MessageResponse>
-        <div className="flex flex-col gap-2.5 rounded-lg border p-3">
-          <div className="flex items-center gap-2">
-            <SquarePenIcon
-              className="text-muted-foreground size-4"
-              aria-hidden="true"
-            />
-            <div className="flex flex-col">
-              <span className="text-sm font-medium">{props.title}</span>
-              <span className="text-muted-foreground text-xs">
-                {props.path}
-                {props.description}
-              </span>
-            </div>
-          </div>
-          <div className="flex items-center gap-1.5">
-            <Button size="xs">Approve</Button>
-            <Button size="xs" variant="outline">
-              Deny
-            </Button>
-            <Button size="xs" variant="ghost" className="ms-auto">
-              Always allow
-            </Button>
-          </div>
-        </div>
-      </MessageContent>
-    </Message>
-  );
-}
-
-function UpdateFieldsCardMock() {
-  return (
-    <Message from="assistant">
-      <MessageContent className="max-w-[460px]">
-        <MessageResponse>
-          {`I extracted the closing date and parties. Update the matter record?`}
-        </MessageResponse>
-        <div className="flex flex-col gap-2.5 rounded-lg border p-3">
-          <div className="flex items-center gap-2">
-            <SettingsIcon
-              className="text-muted-foreground size-4"
-              aria-hidden="true"
-            />
-            <span className="text-sm font-medium">Update entity fields</span>
-          </div>
-          <ul className="text-muted-foreground flex flex-col gap-1 text-xs">
-            <li>
-              <span className="font-medium">Closing</span>: 2025-04-30
-            </li>
-            <li>
-              <span className="font-medium">Parties</span>: Acme Holdings;
-              EnerGo Distribuce
-            </li>
-          </ul>
-          <div className="flex items-center gap-1.5">
-            <Button size="xs">Approve</Button>
-            <Button size="xs" variant="outline">
-              Deny
-            </Button>
-          </div>
-        </div>
-      </MessageContent>
-    </Message>
-  );
-}
-
-function AskUserCardMock() {
-  return (
-    <Message from="assistant">
-      <MessageContent className="max-w-[460px]">
-        <MessageResponse>
-          {`Two of the schedules reference different governing-law clauses. Which one should I treat as canonical?`}
-        </MessageResponse>
-        <div className="flex flex-col gap-2 rounded-lg border p-3">
-          <span className="text-muted-foreground text-xs">
-            Schedule 4 says English law; Schedule 7 says Czech law with English
-            seat. Which governs?
-          </span>
-          <div className="flex flex-col gap-1.5">
-            <Button size="xs" variant="outline">
-              English law (Schedule 4)
-            </Button>
-            <Button size="xs" variant="outline">
-              Czech law, English seat (Schedule 7)
-            </Button>
-            <Button size="xs" variant="outline">
-              Other / I'll explain in chat
-            </Button>
-          </div>
-        </div>
-      </MessageContent>
-    </Message>
-  );
-}
-
-function ToolCallMock() {
-  return (
-    <Message from="assistant">
-      <MessageContent className="max-w-[460px]">
-        <MessageResponse>
-          {`Pulled the redlines from version history.`}
-        </MessageResponse>
-        <div className="bg-muted/40 flex flex-col gap-1.5 rounded-md border p-2 text-xs">
-          <div className="flex items-center gap-1.5">
-            <CheckIcon className="text-success size-3" aria-hidden="true" />
-            <span className="text-muted-foreground">search-entities</span>
-          </div>
-          <ul className="text-muted-foreground ms-4 list-disc">
-            <li>SPA v3 (final).docx</li>
-            <li>SPA v2 (Smith comments).docx</li>
-          </ul>
-        </div>
-      </MessageContent>
-    </Message>
-  );
-}
-
-// Mirrors `AIErrorKind` in apps/api/src/lib/ai-error.ts. The
-// backend returns one of these strings on the chat stream's error
-// channel; passing them as `error.message` exercises the real
-// translation path the user will see.
-const CHAT_ERROR_VARIANTS = [
-  { label: "Generic", message: "unknown" },
-  { label: "Quota exhausted", message: "quota_exhausted" },
-  { label: "Provider billing", message: "provider_billing" },
-  { label: "Provider unavailable", message: "provider_unavailable" },
-] as const;
-
-function ChatErrorMock() {
-  return (
-    <div className="flex flex-col gap-3">
-      {CHAT_ERROR_VARIANTS.map((variant) => (
-        <div className="flex flex-col gap-1" key={variant.message}>
-          <div className="text-muted-foreground text-[10px] uppercase">
-            {variant.label}
-          </div>
-          <ChatErrorMessage
-            error={new Error(variant.message)}
-            isGenerating={false}
-            onResend={() => {
-              /* no-op in playground */
-            }}
-          />
-        </div>
-      ))}
-    </div>
-  );
-}
-
-function SourceChipMock(props: { label: string; kind: "case-law" | "entity" }) {
-  return (
-    <button
-      type="button"
-      className="text-info bg-info/10 hover:bg-info/15 inline-flex items-center gap-1 rounded-md px-2 py-0.5 text-xs"
-    >
-      <span className="bg-info inline-block size-1.5 rounded-full" />
-      <span className="text-muted-foreground text-[10px] uppercase">
-        {props.kind === "case-law" ? "case" : "doc"}
-      </span>
-      <span className="text-foreground">{props.label}</span>
-    </button>
-  );
-}
-
-const CHAT_BUBBLE_INVENTORY_ROWS: { name: string; status: string }[] = [
-  { name: "User text", status: "✓ unified" },
-  { name: "User file attachment", status: "✗ not in unified" },
-  { name: "Assistant text + markdown", status: "✓ unified (Streamdown)" },
-  {
-    name: "Assistant with entity-mention links",
-    status: "✗ not in unified",
-  },
-  {
-    name: "Tool-approval card (create-document)",
-    status: "✗ not in unified",
-  },
-  {
-    name: "Tool-approval card (update-entity-fields)",
-    status: "✗ not in unified",
-  },
-  { name: "Ask-user card", status: "✗ not in unified" },
-  {
-    name: "Tool-call result card (non-approval)",
-    status: "✗ not in unified",
-  },
-  { name: "Chat send error", status: "✓ unified" },
-  {
-    name: "Source chips (case-law + entity)",
-    status: "partial — own model",
-  },
-  { name: "Thinking indicator", status: "partial — simpler spinner" },
-  { name: "Edit-suggestion review queue", status: "✓ unified only" },
-  {
-    name: "In-document citations (folio + pdf)",
-    status: "✓ unified only",
-  },
-];
-
-function ChatBubbleInventory() {
-  const rows = CHAT_BUBBLE_INVENTORY_ROWS;
-  return (
-    <ul className="text-sm">
-      {rows.map((row) => (
-        <li
-          key={row.name}
-          className="border-border/50 flex items-center justify-between gap-2 border-b py-2 last:border-b-0"
-        >
-          <span>{row.name}</span>
-          <span className="text-muted-foreground text-xs">{row.status}</span>
-        </li>
-      ))}
-    </ul>
   );
 }

--- a/bun.lock
+++ b/bun.lock
@@ -291,6 +291,7 @@
         "lucide-react": "catalog:",
         "pdfjs-dist": "^6.1.200",
         "posthog-js": "^1.399.4",
+        "prism-react-renderer": "^2.4.1",
         "prosemirror-commands": "^1.7.1",
         "prosemirror-history": "^1.5.0",
         "prosemirror-keymap": "^1.2.3",
@@ -2127,6 +2128,8 @@
 
     "@types/nodemailer": ["@types/nodemailer@8.0.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-PxpaInm8V1JQDd4j0ds5HfvWQk8JupS1C0Picb96QJsrrRDjBH+DlK7L4ZdNSqNULhiZRQHc40nLVShaGxXAMw=="],
 
+    "@types/prismjs": ["@types/prismjs@1.26.6", "", {}, "sha512-vqlvI7qlMvcCBbVe0AKAb4f97//Hy0EBTaiW8AalRnG/xAN5zOiWWyrNqNXeq8+KAuvRewjCVY1+IPxk4RdNYw=="],
+
     "@types/react": ["@types/react@19.2.17", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw=="],
 
     "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
@@ -3390,6 +3393,8 @@
     "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
 
     "prettier": ["prettier@3.8.1", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg=="],
+
+    "prism-react-renderer": ["prism-react-renderer@2.4.1", "", { "dependencies": { "@types/prismjs": "^1.26.0", "clsx": "^2.0.0" }, "peerDependencies": { "react": ">=16.0.0" } }, "sha512-ey8Ls/+Di31eqzUxC46h8MksNuGx/n0AAC8uKpwFau4RPDYLuE3EXTp8N8G2vX2N7UC/+IXeNUnlWBGGcAG+Ig=="],
 
     "prismjs": ["prismjs@1.30.0", "", {}, "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw=="],
 


### PR DESCRIPTION
## Summary
- restyle streaming tool activity as subtle status rows with elapsed time, shimmer, and hover/focus disclosure
- render expandable TypeScript and JSON details with syntax highlighting and copy controls
- expose the production components in the UX kitchen sink and remove stale hand-built chat mocks and migration inventory

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added syntax-highlighted code blocks for tool inputs, outputs, source code and logs.
  * Added one-click copying for displayed code, with confirmation feedback.
  * Tool activity now shows elapsed time for running and completed actions.
* **Improvements**
  * Redesigned tool-call cards with clearer expand/collapse controls and loading states.
  * Updated tool details layout for more consistent presentation of code and results.
  * Added a dedicated tool activity showcase for completed and in-progress actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->