### PR TITLE
chore: tidy page views and id properties

### DIFF
--- a/apps/web/src/app-providers.tsx
+++ b/apps/web/src/app-providers.tsx
@@ -154,13 +154,7 @@ const AnalyticsAuthIdentity = () => {
       return;
     }
 
-    analytics.identifyUser({
-      email: authStatus.user.email,
-      id: authStatus.user.id,
-      ...(authStatus.user.name === undefined
-        ? {}
-        : { name: authStatus.user.name }),
-    });
+    analytics.identifyUser({ id: authStatus.user.id });
   }, [analytics, authStatus]);
 
   return null;

--- a/apps/web/src/lib/analytics/posthog.test.ts
+++ b/apps/web/src/lib/analytics/posthog.test.ts
@@ -274,25 +274,7 @@ describe("PostHog browser analytics adapter", () => {
     });
   });
 
-  test("identifies users with optional person properties", () => {
-    const { analytics } = createPostHogAnalytics(
-      "phc_test",
-      "https://posthog.test",
-    );
-
-    analytics.identifyUser({
-      id: "user_123",
-      email: "user@example.com",
-      name: "Ada Lovelace",
-    });
-
-    expect(identifyMock).toHaveBeenCalledWith("user_123", {
-      email: "user@example.com",
-      name: "Ada Lovelace",
-    });
-  });
-
-  test("passes missing identity properties through as undefined", () => {
+  test("identifies users by stable id without person properties", () => {
     const { analytics } = createPostHogAnalytics(
       "phc_test",
       "https://posthog.test",
@@ -300,10 +282,7 @@ describe("PostHog browser analytics adapter", () => {
 
     analytics.identifyUser({ id: "user_123" });
 
-    expect(identifyMock).toHaveBeenCalledWith("user_123", {
-      email: undefined,
-      name: undefined,
-    });
+    expect(identifyMock).toHaveBeenCalledWith("user_123");
   });
 
   test("identifies the same user only once per browser app session", () => {
@@ -312,8 +291,8 @@ describe("PostHog browser analytics adapter", () => {
       "https://posthog.test",
     );
 
-    analytics.identifyUser({ id: "user_123", email: "first@example.com" });
-    analytics.identifyUser({ id: "user_123", email: "second@example.com" });
+    analytics.identifyUser({ id: "user_123" });
+    analytics.identifyUser({ id: "user_123" });
 
     expect(identifyMock).toHaveBeenCalledTimes(1);
     expect(resetMock).not.toHaveBeenCalled();
@@ -329,10 +308,7 @@ describe("PostHog browser analytics adapter", () => {
     analytics.identifyUser({ id: "user_456" });
 
     expect(resetMock).toHaveBeenCalledTimes(1);
-    expect(identifyMock).toHaveBeenNthCalledWith(2, "user_456", {
-      email: undefined,
-      name: undefined,
-    });
+    expect(identifyMock).toHaveBeenNthCalledWith(2, "user_456");
   });
 
   test("reset can be limited to identified sessions", () => {

--- a/apps/web/src/lib/analytics/posthog.ts
+++ b/apps/web/src/lib/analytics/posthog.ts
@@ -203,10 +203,11 @@ export const createPostHogAnalytics = (
         posthog.reset();
       }
 
-      posthog.identify(user.id, {
-        email: user.email,
-        name: user.name,
-      });
+      // Identify by the stable user id only. Profile attributes such as
+      // name and email already live server-side keyed by this id, so
+      // duplicating them into PostHog person properties adds no analytical
+      // value and only widens the person-property surface.
+      posthog.identify(user.id);
     },
     reset: ({ onlyIfIdentified } = {}) => {
       if (onlyIfIdentified && !posthog._isIdentified()) {

--- a/apps/web/src/lib/analytics/types.ts
+++ b/apps/web/src/lib/analytics/types.ts
@@ -24,6 +24,4 @@ export type PageViewedProperties = {
 
 export type AnalyticsUserIdentity = {
   id: string;
-  email?: string;
-  name?: string;
 };

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -48,10 +48,16 @@ export function getRouter() {
     defaultPendingMinMs: 300,
   });
 
-  router.subscribe("onResolved", ({ toLocation }) => {
-    analyticsValue.analytics.capturePageViewed({
-      path: toLocation.pathname,
-    });
+  router.subscribe("onResolved", () => {
+    // Report the matched route template (e.g. `/workspaces/$workspaceId`),
+    // not the resolved pathname. Templates aggregate into a small, stable
+    // set of routes; resolved paths embed per-resource ids that fragment
+    // every navigation into a unique path and defeat page-view grouping.
+    const path = router.state.matches.at(-1)?.fullPath;
+    if (path === undefined) {
+      return;
+    }
+    analyticsValue.analytics.capturePageViewed({ path });
   });
 
   setupRouterSsrQueryIntegration({


### PR DESCRIPTION
Two small analytics tidy-ups on the web client.

**Page views** — report the matched route template (`/workspaces/$workspaceId/$viewId`) instead of the resolved pathname. Resolved paths embed per-resource ids, so every navigation was a distinct path and page-view grouping was effectively unusable; templates collapse the stream to the small set of real routes and aggregate cleanly. Uses `router.state.matches.at(-1)?.fullPath`, matching how the codebase reads matched routes elsewhere.

**Identity** — identify by the stable user id only. Name and email already live server-side keyed by that id, so duplicating them into person properties added no analytical value. `AnalyticsUserIdentity` is narrowed to `{ id }`, so the extra properties can't be reintroduced without a type change surfacing in review.

Tests updated; 15/15 pass.