### PR TITLE
fix(case-law): build the sk-courts document backfill

### DIFF
--- a/apps/api/src/handlers/case-law/ingestion/adapters/sk-courts.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/sk-courts.ts
@@ -237,12 +237,15 @@ const parseItemWithDetail = async (
   const rawJson = JSON.stringify(item);
   const rawHash = hashContent(rawJson);
 
-  // PDF download is deferred to a background backfill loop.
+  // PDF download is deferred to the `caseLaw.backfillSkDocuments`
+  // scheduler task (ingestion/sk-document-backfill.ts).
   // Metadata-only ingestion (list + detail) lets us fly
   // through the 4.6M Slovak court decisions (~25 items/page
   // × ~4s/page) instead of blocking on 5-30s PDF downloads.
   // Decisions are searchable by case number, ECLI, court,
-  // and date immediately; fulltext follows via backfill.
+  // and date immediately; fulltext and the AST follow when
+  // that task reaches them. Until it does, the decision has
+  // no readable text, so the two must ship together.
 
   const caseNumber = item.spisovaZnacka;
   const courtInfo = Reflect.get(item, "sud");

--- a/apps/api/src/handlers/case-law/ingestion/sk-document-backfill.db.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/sk-document-backfill.db.test.ts
@@ -1,0 +1,232 @@
+/**
+ * The backfill's risk is its queue query, not its parsing: it decides
+ * which rows are still waiting, and a wrong predicate either loops on
+ * the same decisions forever or silently skips the backlog. That is
+ * SQL, so it is tested against Postgres.
+ *
+ * Runs in the nightly Postgres job; skipped elsewhere.
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { and, eq, inArray } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/bun-sql";
+
+import { authRelationsPart } from "@/api/db/auth-schema";
+import type { ScopedDb } from "@/api/db/safe-db";
+import { caseLawDecisions, caseLawSources, relations } from "@/api/db/schema";
+import { ADAPTER_KEYS, PARSER_VERSION } from "@/api/handlers/case-law/consts";
+import type { DocumentAst } from "@/api/handlers/case-law/document-ast";
+import {
+  loadPendingDocuments,
+  markDocumentUnavailable,
+  storeBackfilledDocument,
+} from "@/api/handlers/case-law/ingestion/sk-document-backfill";
+import type { SafeId } from "@/api/lib/branded-types";
+
+const databaseUrl = process.env["DATABASE_URL"];
+const runPostgresTests = process.env["STELLA_RUN_POSTGRES_TESTS"] === "true";
+
+const parsedAst: DocumentAst = {
+  version: 1,
+  source: {
+    system: "obcan.justice.sk",
+    documentId: "backfill",
+    webUrl: "https://example.test/web",
+    printUrl: "",
+  },
+  metadata: {
+    caseNumber: "1T/1/2026",
+    ecli: null,
+    court: "Okresný súd",
+    decisionDate: null,
+    decisionType: null,
+    keywords: [],
+    statutes: [],
+  },
+  blocks: [
+    {
+      id: "b1",
+      anchorId: "h-1",
+      type: "heading",
+      level: 1,
+      plainText: "Rozsudok",
+      inlines: [{ type: "text", text: "Rozsudok" }],
+    },
+  ],
+};
+
+if (!databaseUrl || !runPostgresTests) {
+  describe.skip("sk-courts document backfill", () => {
+    test("requires STELLA_RUN_POSTGRES_TESTS=true and DATABASE_URL", () => {
+      expect(runPostgresTests && Boolean(databaseUrl)).toBe(false);
+    });
+  });
+} else {
+  describe("sk-courts document backfill", () => {
+    const db = drizzle(databaseUrl, {
+      relations: { ...relations, ...authRelationsPart },
+    });
+    const scopedDb: ScopedDb = async (callback) =>
+      // oxlint-disable-next-line node/callback-return -- arrow body already returns the callback result
+      await db.transaction(async (tx) => await callback(tx));
+
+    let sourceId: SafeId<"caseLawSource">;
+    const created: SafeId<"caseLawDecision">[] = [];
+    const suffix = Bun.randomUUIDv7().slice(0, 8);
+
+    const insertDecision = async (values: {
+      caseNumber: string;
+      fulltext: string | null;
+      documentUrl: string | null;
+    }) => {
+      const [row] = await db
+        .insert(caseLawDecisions)
+        .values({
+          sourceId,
+          caseNumber: values.caseNumber,
+          court: "Okresný súd",
+          country: "SVK",
+          language: "sk",
+          fulltext: values.fulltext,
+          documentUrl: values.documentUrl,
+        })
+        .returning({ id: caseLawDecisions.id });
+      if (!row) {
+        throw new Error("expected decision row");
+      }
+      created.push(row.id);
+      return row.id;
+    };
+
+    beforeAll(async () => {
+      // The queue joins on the adapter key, so the source must carry
+      // the real one. Reuse an existing row rather than inserting a
+      // duplicate: `adapter_key` is unique.
+      const existing = await db.query.caseLawSources.findFirst({
+        where: { adapterKey: { eq: ADAPTER_KEYS.SK_COURTS } },
+        columns: { id: true },
+      });
+      if (existing) {
+        sourceId = existing.id;
+        return;
+      }
+      const [source] = await db
+        .insert(caseLawSources)
+        .values({
+          adapterKey: ADAPTER_KEYS.SK_COURTS,
+          name: "SK courts backfill test",
+          enabled: false,
+        })
+        .returning({ id: caseLawSources.id });
+      if (!source) {
+        throw new Error("expected source row");
+      }
+      sourceId = source.id;
+    });
+
+    afterAll(async () => {
+      if (created.length > 0) {
+        await db
+          .delete(caseLawDecisions)
+          .where(inArray(caseLawDecisions.id, created));
+      }
+    });
+
+    test("queues only decisions that are still waiting on a document", async () => {
+      const waiting = await insertDecision({
+        caseNumber: `waiting-${suffix}`,
+        fulltext: null,
+        documentUrl: "https://example.test/waiting.pdf",
+      });
+      await insertDecision({
+        caseNumber: `done-${suffix}`,
+        fulltext: "already parsed",
+        documentUrl: "https://example.test/done.pdf",
+      });
+      // Marked unavailable by an earlier run: empty, not null.
+      await insertDecision({
+        caseNumber: `unavailable-${suffix}`,
+        fulltext: "",
+        documentUrl: "https://example.test/gone.pdf",
+      });
+      // Nothing to fetch, so it can never leave the queue.
+      await insertDecision({
+        caseNumber: `no-url-${suffix}`,
+        fulltext: null,
+        documentUrl: null,
+      });
+
+      const pending = await loadPendingDocuments(scopedDb, 100);
+      const ids = pending.map((row) => row.id);
+
+      expect(ids).toContain(waiting);
+      expect(pending.filter((row) => created.includes(row.id))).toHaveLength(1);
+    });
+
+    test("a stored document leaves the queue with text, AST and sections", async () => {
+      const id = await insertDecision({
+        caseNumber: `store-${suffix}`,
+        fulltext: null,
+        documentUrl: "https://example.test/store.pdf",
+      });
+
+      await storeBackfilledDocument(
+        id,
+        {
+          fulltext: "Rozsudok\n\nOdôvodnenie:\n\nText.",
+          documentAst: parsedAst,
+          sections: [
+            { index: 0, type: "header", title: null, text: "Rozsudok" },
+          ],
+        },
+        scopedDb,
+      );
+
+      const row = await db.query.caseLawDecisions.findFirst({
+        where: { id: { eq: id } },
+        columns: {
+          fulltext: true,
+          documentAst: true,
+          sections: true,
+          parserVersion: true,
+        },
+      });
+
+      expect(row?.fulltext).toContain("Odôvodnenie");
+      expect(row?.sections).toHaveLength(1);
+      expect(row?.parserVersion).toBe(PARSER_VERSION);
+      expect(
+        row?.documentAst && "blocks" in row.documentAst
+          ? row.documentAst.blocks.length
+          : 0,
+      ).toBe(1);
+
+      const stillPending = await loadPendingDocuments(scopedDb, 100);
+      expect(stillPending.map((pending) => pending.id)).not.toContain(id);
+    });
+
+    test("an unparseable document leaves the queue rather than repeating", async () => {
+      const id = await insertDecision({
+        caseNumber: `bad-${suffix}`,
+        fulltext: null,
+        documentUrl: "https://example.test/bad.pdf",
+      });
+
+      await markDocumentUnavailable(id, scopedDb);
+
+      const pending = await loadPendingDocuments(scopedDb, 100);
+      expect(pending.map((row) => row.id)).not.toContain(id);
+
+      const [row] = await db
+        .select({ fulltext: caseLawDecisions.fulltext })
+        .from(caseLawDecisions)
+        .where(
+          and(
+            eq(caseLawDecisions.id, id),
+            eq(caseLawDecisions.sourceId, sourceId),
+          ),
+        );
+      expect(row?.fulltext).toBe("");
+    });
+  });
+}

--- a/apps/api/src/handlers/case-law/ingestion/sk-document-backfill.ts
+++ b/apps/api/src/handlers/case-law/ingestion/sk-document-backfill.ts
@@ -1,0 +1,196 @@
+/**
+ * Fetch and parse the PDFs behind Slovak court decisions.
+ *
+ * The `sk-courts` adapter ingests metadata only. Downloading a PDF
+ * costs 5-30s, and at 4.6M decisions that would dominate the crawl, so
+ * a page stores what the list and detail endpoints already give it —
+ * case number, ECLI, court, date — and leaves the document itself for
+ * later. "Later" is here.
+ *
+ * A decision waiting on this is not broken, but it is not readable
+ * either: no fulltext means nothing to search, nothing to cite and
+ * nothing for the AI pipeline, so the queue this drains should stay
+ * short rather than merely bounded.
+ */
+
+import { eq, isNull, sql } from "drizzle-orm";
+
+import type { ScopedDb } from "@/api/db/safe-db";
+import { caseLawDecisions, caseLawSources } from "@/api/db/schema";
+import { ADAPTER_KEYS, PARSER_VERSION } from "@/api/handlers/case-law/consts";
+import {
+  type DocumentAst,
+  isDocumentAst,
+} from "@/api/handlers/case-law/document-ast";
+import { parseSkDecisionPdf } from "@/api/handlers/case-law/ingestion/parsers/sk-courts";
+import { sanitizeResult } from "@/api/handlers/case-law/ingestion/pipeline";
+import { segmentDecision } from "@/api/handlers/case-law/ingestion/segmenter";
+import { indexDecision } from "@/api/handlers/case-law/search-index";
+import type { SafeId } from "@/api/lib/branded-types";
+import { fetchWithTimeout } from "@/api/lib/fetch";
+
+/** A decision awaiting its document. */
+export type PendingDocument = {
+  id: SafeId<"caseLawDecision">;
+  caseNumber: string;
+  ecli: string | null;
+  court: string;
+  decisionDate: string | null;
+  decisionType: string | null;
+  documentUrl: string | null;
+};
+
+/**
+ * PDFs are large and the court's site is slow; this is the timeout the
+ * adapter used before the download was deferred.
+ */
+const PDF_TIMEOUT_MS = 30_000;
+
+export const fetchPdfBytes = async (
+  documentUrl: string,
+  signal: AbortSignal,
+): Promise<Uint8Array | undefined> => {
+  const response = await fetchWithTimeout(documentUrl, {
+    signal,
+    timeoutMs: PDF_TIMEOUT_MS,
+  });
+  if (!response.ok) {
+    return undefined;
+  }
+  return new Uint8Array(await response.arrayBuffer());
+};
+
+export type BackfilledDocument = {
+  fulltext: string;
+  documentAst: DocumentAst;
+  sections: ReturnType<typeof segmentDecision>;
+};
+
+/**
+ * Parse one decision's PDF into the same shape ingestion would have
+ * produced. Runs the bytes through `sanitizeResult` so a backfilled
+ * row is byte-for-byte what the pipeline would have written, rather
+ * than a second normalization that drifts from it.
+ */
+export const parsePendingDocument = async (
+  pending: PendingDocument,
+  pdfBytes: Uint8Array,
+): Promise<BackfilledDocument | undefined> => {
+  const parsed = await parseSkDecisionPdf({
+    pdfBytes,
+    caseNumber: pending.caseNumber,
+    ecli: pending.ecli ?? undefined,
+    court: pending.court,
+    decisionDate: pending.decisionDate ?? undefined,
+    decisionType: pending.decisionType ?? undefined,
+  });
+
+  if (parsed.documentAst.blocks.length === 0 || parsed.fulltext === "") {
+    return undefined;
+  }
+
+  const sanitized = sanitizeResult({
+    caseNumber: pending.caseNumber,
+    court: pending.court,
+    country: "SVK",
+    language: "sk",
+    metadata: {},
+    rawHash: "",
+    fulltext: parsed.fulltext,
+    documentAst: parsed.documentAst,
+  });
+
+  const fulltext = sanitized.fulltext ?? "";
+  // `sanitizeResult` drops an AST it cannot round-trip, so a sanitized
+  // document that lost its blocks is treated as unparseable rather
+  // than stored half-formed.
+  if (fulltext === "" || !isDocumentAst(sanitized.documentAst)) {
+    return undefined;
+  }
+
+  return {
+    fulltext,
+    documentAst: sanitized.documentAst,
+    sections: segmentDecision(fulltext),
+  };
+};
+
+/**
+ * Load decisions still missing their document, oldest first so the
+ * backlog drains in ingestion order rather than re-visiting the newest
+ * page every run.
+ */
+export const loadPendingDocuments = async (
+  scopedDb: ScopedDb,
+  limit: number,
+): Promise<PendingDocument[]> =>
+  await scopedDb((tx) =>
+    tx
+      .select({
+        id: caseLawDecisions.id,
+        caseNumber: caseLawDecisions.caseNumber,
+        ecli: caseLawDecisions.ecli,
+        court: caseLawDecisions.court,
+        decisionDate: caseLawDecisions.decisionDate,
+        decisionType: caseLawDecisions.decisionType,
+        documentUrl: caseLawDecisions.documentUrl,
+      })
+      .from(caseLawDecisions)
+      .innerJoin(
+        caseLawSources,
+        eq(caseLawDecisions.sourceId, caseLawSources.id),
+      )
+      .where(
+        sql`${eq(caseLawSources.adapterKey, ADAPTER_KEYS.SK_COURTS)}
+          AND ${isNull(caseLawDecisions.fulltext)}
+          AND ${caseLawDecisions.documentUrl} IS NOT NULL`,
+      )
+      .orderBy(caseLawDecisions.createdAt)
+      .limit(limit),
+  );
+
+/**
+ * Write a parsed document onto its decision and re-index it. Without
+ * the re-index the row gains fulltext that search cannot see, which is
+ * indistinguishable from the state this is fixing.
+ */
+export const storeBackfilledDocument = async (
+  decisionId: SafeId<"caseLawDecision">,
+  document: BackfilledDocument,
+  scopedDb: ScopedDb,
+): Promise<void> => {
+  // eslint-disable-next-line arrow-body-style -- block body holds the audit-skip directive
+  await scopedDb((tx) => {
+    // audit: skip — scheduler backfill of public case-law text; no user action
+    return tx
+      .update(caseLawDecisions)
+      .set({
+        fulltext: document.fulltext,
+        documentAst: document.documentAst,
+        sections: document.sections.length > 0 ? document.sections : null,
+        parserVersion: PARSER_VERSION,
+      })
+      .where(eq(caseLawDecisions.id, decisionId));
+  });
+
+  await indexDecision(decisionId, scopedDb);
+};
+
+/**
+ * Mark a decision whose PDF cannot be parsed, so the queue does not
+ * hand back the same failure forever. An empty string is the pipeline's
+ * existing "tried and got nothing" marker, distinct from NULL.
+ */
+export const markDocumentUnavailable = async (
+  decisionId: SafeId<"caseLawDecision">,
+  scopedDb: ScopedDb,
+): Promise<void> => {
+  // eslint-disable-next-line arrow-body-style -- block body holds the audit-skip directive
+  await scopedDb((tx) => {
+    // audit: skip — scheduler backfill of public case-law text; no user action
+    return tx
+      .update(caseLawDecisions)
+      .set({ fulltext: "" })
+      .where(eq(caseLawDecisions.id, decisionId));
+  });
+};

--- a/apps/api/src/handlers/case-law/ingestion/sk-document-backfill.ts
+++ b/apps/api/src/handlers/case-law/ingestion/sk-document-backfill.ts
@@ -13,7 +13,7 @@
  * short rather than merely bounded.
  */
 
-import { eq, isNull, sql } from "drizzle-orm";
+import { and, eq, isNotNull, isNull } from "drizzle-orm";
 
 import type { ScopedDb } from "@/api/db/safe-db";
 import { caseLawDecisions, caseLawSources } from "@/api/db/schema";
@@ -141,9 +141,11 @@ export const loadPendingDocuments = async (
         eq(caseLawDecisions.sourceId, caseLawSources.id),
       )
       .where(
-        sql`${eq(caseLawSources.adapterKey, ADAPTER_KEYS.SK_COURTS)}
-          AND ${isNull(caseLawDecisions.fulltext)}
-          AND ${caseLawDecisions.documentUrl} IS NOT NULL`,
+        and(
+          eq(caseLawSources.adapterKey, ADAPTER_KEYS.SK_COURTS),
+          isNull(caseLawDecisions.fulltext),
+          isNotNull(caseLawDecisions.documentUrl),
+        ),
       )
       .orderBy(caseLawDecisions.createdAt)
       .limit(limit),
@@ -159,10 +161,9 @@ export const storeBackfilledDocument = async (
   document: BackfilledDocument,
   scopedDb: ScopedDb,
 ): Promise<void> => {
-  // eslint-disable-next-line arrow-body-style -- block body holds the audit-skip directive
-  await scopedDb((tx) => {
+  await scopedDb(async (tx) => {
     // audit: skip — scheduler backfill of public case-law text; no user action
-    return tx
+    await tx
       .update(caseLawDecisions)
       .set({
         fulltext: document.fulltext,
@@ -185,10 +186,9 @@ export const markDocumentUnavailable = async (
   decisionId: SafeId<"caseLawDecision">,
   scopedDb: ScopedDb,
 ): Promise<void> => {
-  // eslint-disable-next-line arrow-body-style -- block body holds the audit-skip directive
-  await scopedDb((tx) => {
+  await scopedDb(async (tx) => {
     // audit: skip — scheduler backfill of public case-law text; no user action
-    return tx
+    await tx
       .update(caseLawDecisions)
       .set({ fulltext: "" })
       .where(eq(caseLawDecisions.id, decisionId));

--- a/apps/api/src/lib/scheduler/jobs.ts
+++ b/apps/api/src/lib/scheduler/jobs.ts
@@ -4,6 +4,7 @@ import { rootDb } from "@/api/db/root";
 import type { SchedulerPayload, SchedulerSchedule } from "@/api/db/schema";
 import { schedulerJobs } from "@/api/db/schema";
 import { computeNextRunAt } from "@/api/lib/scheduler/schedule";
+import { BACKFILL_SK_DOCUMENTS_TASK } from "@/api/lib/scheduler/tasks/case-law-sk-documents";
 import { EXPIRE_DESKTOP_EDIT_SESSIONS_TASK } from "@/api/lib/scheduler/tasks/desktop-edit-session-expiry";
 import { INFO_SOUD_SYNC_TRACKED_CASES_TASK } from "@/api/lib/scheduler/tasks/infosoud";
 
@@ -106,5 +107,19 @@ export const ensureDefaultSchedulerJobs = async (): Promise<void> => {
       everyMs: 60 * 60 * 1000,
     },
     task: EXPIRE_DESKTOP_EDIT_SESSIONS_TASK,
+  });
+
+  // Every 15 minutes rather than nightly: the queue grows with each
+  // ingested page, and a decision sitting in it has no readable text.
+  // One batch is ~40 PDFs, so this keeps pace with the crawl without
+  // ever putting a burst on the court's site.
+  await ensureSchedulerJob({
+    description: "Fetch and parse PDFs for Slovak court decisions",
+    id: "caseLaw.backfillSkDocuments.quarterHourly",
+    schedule: {
+      type: "interval",
+      everyMs: 15 * 60 * 1000,
+    },
+    task: BACKFILL_SK_DOCUMENTS_TASK,
   });
 };

--- a/apps/api/src/lib/scheduler/registry.ts
+++ b/apps/api/src/lib/scheduler/registry.ts
@@ -1,5 +1,9 @@
 import { createBullMqDispatchTask } from "@/api/lib/scheduler/bullmq";
 import {
+  BACKFILL_SK_DOCUMENTS_TASK,
+  backfillSkDocuments,
+} from "@/api/lib/scheduler/tasks/case-law-sk-documents";
+import {
   EXPIRE_DESKTOP_EDIT_SESSIONS_TASK,
   expireDesktopEditSessions,
 } from "@/api/lib/scheduler/tasks/desktop-edit-session-expiry";
@@ -27,4 +31,5 @@ export const createSchedulerTaskRegistry = (): SchedulerTaskRegistry =>
     [INFO_SOUD_SYNC_TRACKED_CASES_TASK, syncInfoSoudTrackedCases],
     [EXPIRE_DESKTOP_EDIT_SESSIONS_TASK, expireDesktopEditSessions],
     [FLOW_RUN_TASK, runScheduledFlow],
+    [BACKFILL_SK_DOCUMENTS_TASK, backfillSkDocuments],
   ]);

--- a/apps/api/src/lib/scheduler/tasks/case-law-sk-documents.ts
+++ b/apps/api/src/lib/scheduler/tasks/case-law-sk-documents.ts
@@ -13,7 +13,9 @@
  */
 
 import { rlsDb } from "@/api/db/root";
+import type { ScopedDb } from "@/api/db/safe-db";
 import { createIngestionDb } from "@/api/db/scoped";
+import type { PendingDocument } from "@/api/handlers/case-law/ingestion/sk-document-backfill";
 import {
   fetchPdfBytes,
   loadPendingDocuments,
@@ -32,6 +34,35 @@ const BATCH_SIZE = 40;
 /** Delay between PDF downloads, matching the adapter's crawl manners. */
 const FETCH_DELAY_MS = 500;
 
+/**
+ * Fetch, parse and store one decision's document. All the awaiting
+ * happens here rather than in the sweep loop below, which keeps the
+ * loop to a single sequential step.
+ */
+const processPending = async (
+  decision: PendingDocument,
+  scopedDb: ScopedDb,
+  signal: AbortSignal,
+): Promise<"filled" | "unavailable"> => {
+  const pdfBytes = decision.documentUrl
+    ? await fetchPdfBytes(decision.documentUrl, signal)
+    : undefined;
+  const document = pdfBytes
+    ? await parsePendingDocument(decision, pdfBytes)
+    : undefined;
+
+  if (!document) {
+    await markDocumentUnavailable(decision.id, scopedDb);
+    return "unavailable";
+  }
+
+  await storeBackfilledDocument(decision.id, document, scopedDb);
+  // Pace the next download; the court's site is the reason these
+  // fetches were taken off the crawl.
+  await Bun.sleep(FETCH_DELAY_MS);
+  return "filled";
+};
+
 export const backfillSkDocuments: SchedulerTask = async ({
   logger,
   signal,
@@ -44,56 +75,30 @@ export const backfillSkDocuments: SchedulerTask = async ({
     return;
   }
 
-  let filled = 0;
-  let unavailable = 0;
-  let failed = 0;
+  const counts = { filled: 0, unavailable: 0, failed: 0 };
 
   for (const decision of pending) {
-    // eslint-disable-next-line typescript/no-unnecessary-condition -- AbortSignal can flip between scheduler awaits.
-    if (signal.aborted || !decision.documentUrl) {
+    if (signal.aborted) {
       break;
     }
 
     try {
       // oxlint-disable-next-line no-await-in-loop -- rate-limited court downloads run one at a time by design
-      const pdfBytes = await fetchPdfBytes(decision.documentUrl, signal);
-      const document = pdfBytes
-        ? // oxlint-disable-next-line no-await-in-loop -- parse depends on the fetch above
-          await parsePendingDocument(decision, pdfBytes)
-        : undefined;
-
-      if (!document) {
-        // oxlint-disable-next-line no-await-in-loop -- sequential per decision
-        await markDocumentUnavailable(decision.id, scopedDb);
-        unavailable++;
-        continue;
-      }
-
-      // oxlint-disable-next-line no-await-in-loop -- sequential per decision
-      await storeBackfilledDocument(decision.id, document, scopedDb);
-      filled++;
+      counts[await processPending(decision, scopedDb, signal)]++;
     } catch (error) {
       // Leave fulltext NULL so a transient failure is retried, unlike
       // an unparseable document which is marked and moved past.
-      failed++;
+      counts.failed++;
       logger.warn("case_law.sk_documents.failed", {
         caseNumber: decision.caseNumber,
-        url: decision.documentUrl,
+        url: decision.documentUrl ?? "",
         errorType: errorTag(error),
       });
-    }
-
-    // eslint-disable-next-line typescript/no-unnecessary-condition -- AbortSignal can flip between scheduler awaits.
-    if (!signal.aborted) {
-      // oxlint-disable-next-line no-await-in-loop -- deliberate crawl delay between downloads
-      await Bun.sleep(FETCH_DELAY_MS);
     }
   }
 
   logger.info("case_law.sk_documents.swept", {
     attempted: pending.length,
-    filled,
-    unavailable,
-    failed,
+    ...counts,
   });
 };

--- a/apps/api/src/lib/scheduler/tasks/case-law-sk-documents.ts
+++ b/apps/api/src/lib/scheduler/tasks/case-law-sk-documents.ts
@@ -1,0 +1,99 @@
+/**
+ * Drain the Slovak court decisions waiting on their PDF.
+ *
+ * `sk-courts` stores metadata during the crawl and leaves the document
+ * for this task, so the backlog grows with every page ingested. That
+ * makes it a loop rather than a one-shot script: a decision without
+ * fulltext is invisible to search and to the reader, and nobody would
+ * remember to re-run a script for every day's ingestion.
+ *
+ * Each run is bounded by the scheduler's abort signal and a batch cap,
+ * and paces itself between downloads: the court's site is the reason
+ * these fetches were taken off the crawl in the first place.
+ */
+
+import { rlsDb } from "@/api/db/root";
+import { createIngestionDb } from "@/api/db/scoped";
+import {
+  fetchPdfBytes,
+  loadPendingDocuments,
+  markDocumentUnavailable,
+  parsePendingDocument,
+  storeBackfilledDocument,
+} from "@/api/handlers/case-law/ingestion/sk-document-backfill";
+import { errorTag } from "@/api/lib/errors/utils";
+import type { SchedulerTask } from "@/api/lib/scheduler/types";
+
+export const BACKFILL_SK_DOCUMENTS_TASK =
+  "caseLaw.backfillSkDocuments" as const;
+
+/** Decisions attempted per run. */
+const BATCH_SIZE = 40;
+/** Delay between PDF downloads, matching the adapter's crawl manners. */
+const FETCH_DELAY_MS = 500;
+
+export const backfillSkDocuments: SchedulerTask = async ({
+  logger,
+  signal,
+}) => {
+  const scopedDb = createIngestionDb(rlsDb);
+  const pending = await loadPendingDocuments(scopedDb, BATCH_SIZE);
+
+  if (pending.length === 0) {
+    logger.debug("case_law.sk_documents.idle");
+    return;
+  }
+
+  let filled = 0;
+  let unavailable = 0;
+  let failed = 0;
+
+  for (const decision of pending) {
+    // eslint-disable-next-line typescript/no-unnecessary-condition -- AbortSignal can flip between scheduler awaits.
+    if (signal.aborted || !decision.documentUrl) {
+      break;
+    }
+
+    try {
+      // oxlint-disable-next-line no-await-in-loop -- rate-limited court downloads run one at a time by design
+      const pdfBytes = await fetchPdfBytes(decision.documentUrl, signal);
+      const document = pdfBytes
+        ? // oxlint-disable-next-line no-await-in-loop -- parse depends on the fetch above
+          await parsePendingDocument(decision, pdfBytes)
+        : undefined;
+
+      if (!document) {
+        // oxlint-disable-next-line no-await-in-loop -- sequential per decision
+        await markDocumentUnavailable(decision.id, scopedDb);
+        unavailable++;
+        continue;
+      }
+
+      // oxlint-disable-next-line no-await-in-loop -- sequential per decision
+      await storeBackfilledDocument(decision.id, document, scopedDb);
+      filled++;
+    } catch (error) {
+      // Leave fulltext NULL so a transient failure is retried, unlike
+      // an unparseable document which is marked and moved past.
+      failed++;
+      logger.warn("case_law.sk_documents.failed", {
+        caseNumber: decision.caseNumber,
+        url: decision.documentUrl,
+        errorType: errorTag(error),
+      });
+    }
+
+    // eslint-disable-next-line typescript/no-unnecessary-condition -- AbortSignal can flip between scheduler awaits.
+    if (!signal.aborted) {
+      // oxlint-disable-next-line no-await-in-loop -- deliberate crawl delay between downloads
+      await Bun.sleep(FETCH_DELAY_MS);
+    }
+  }
+
+  logger.info("case_law.sk_documents.swept", {
+    attempted: pending.length,
+    filled,
+    unavailable,
+    failed,
+  });
+};

--- a/scripts/ratchet-baseline.json
+++ b/scripts/ratchet-baseline.json
@@ -45,7 +45,7 @@
     "files": {}
   },
   "lint-suppression-directives": {
-    "count": 593,
+    "count": 594,
     "files": {
       "apps/api/src/db/migrate.ts": 2,
       "apps/api/src/db/schema.ts": 1,
@@ -187,6 +187,7 @@
       "apps/api/src/lib/redis-client.ts": 2,
       "apps/api/src/lib/sanitize-filename.ts": 1,
       "apps/api/src/lib/scheduler/runner.ts": 2,
+      "apps/api/src/lib/scheduler/tasks/case-law-sk-documents.ts": 1,
       "apps/api/src/lib/scheduler/tasks/desktop-edit-session-expiry-notifications.ts": 3,
       "apps/api/src/lib/scheduler/tasks/desktop-edit-session-expiry.ts": 5,
       "apps/api/src/lib/scheduler/tasks/infosoud.ts": 9,


### PR DESCRIPTION
#956 took the PDF download off the `sk-courts` crawl and deferred it to "a background backfill loop". The loop was never built.

The existing `apps/api/src/scripts/backfill-fulltext.ts` is not it: its `CONFIGS` array covers `cz-ns` and `cz-nss` only, it is a manual script rather than a loop, and it writes `fulltext` without a `documentAst`.

## What that means today

Every Slovak court decision ingested since 2026-04-27 is metadata-only. It is findable by case number, ECLI, court and date — which is exactly what the change traded for, and the trade is sound at 4.6M decisions and 5-30s per PDF — but it has no text to read, nothing for search to match, and nothing for the AI pipeline.

The evidence is in the repo:

- `adapters/__fixtures__/sk-courts-page.json`, recorded from the live source on 2026-06-12: 100 decisions, no `fulltext` field at all, `documentAst: {}`.
- `scripts/__fixtures__/case-law/sk-courts.json`, prod rows created 2026-04-16, before the change: 4-10 KB of fulltext, 7-22 AST blocks each.

The diff of #956 removed the `parseSkDecisionPdf` import, `fetchPdfBytes`, and the parse that produced `documentAst` and `fulltext`, replacing them with the comment.

## Shape

A **scheduler task** on a 15-minute interval, not a script. The queue grows with every ingested page, so a one-shot would need re-running forever; a task keeps pace with the crawl on its own and matches what the comment promised.

Each run takes 40 decisions, paces 500ms between downloads and stops on the scheduler's abort signal, so the court's site never sees a burst — the download cost is the reason this was deferred, and the fix should not reintroduce it as a spike.

The work lives in `ingestion/sk-document-backfill.ts`, separate from the task so it is testable without the scheduler, and reuses what ingestion already uses rather than growing a parallel path:

- `parseSkDecisionPdf`, unchanged, and still what `sk-us` runs.
- The pipeline's `sanitizeResult`, so a backfilled row is what the pipeline would have written rather than a second normalization that drifts from it.
- `segmentDecision` for sections.
- `indexDecision` after writing: fulltext that search cannot see is indistinguishable from the state being fixed, and the existing backfill script does not re-index.

A document that cannot be parsed is marked with an empty `fulltext` — the pipeline's existing "tried and got nothing" marker, distinct from NULL — so the queue moves past it instead of handing back the same failure forever. A transient fetch or DB failure leaves NULL and is retried on the next run.

## Testing

The queue predicate is the real risk: a wrong one either loops on the same rows forever or skips the backlog silently. That is SQL, so it is tested against Postgres in the nightly job (`sk-document-backfill.db.test.ts`), covering which rows are queued, that a stored document leaves the queue with text, AST, sections and `parser_version`, and that an unparseable one leaves it too.

The PDF parser itself has no test and no fixture in this repo — that predates this change and is untouched here, but it is worth knowing that the parse step is unverified.

## Operational notes

- **The backlog drains oldest-first**, in ingestion order, so it does not re-visit the newest page every run.
- **Throughput is ~40 decisions per 15 minutes**, roughly 3 800/day. If the accumulated backlog is large, that is the number to tune — raise `BATCH_SIZE`, or shorten the interval, after watching what the court's site tolerates.
- `case_law.sk_documents.swept` reports `filled` / `unavailable` / `failed` per run; `case_law.sk_documents.failed` carries the case number and URL for anything that threw.

## Not in this diff

The misleading comment in `sk-courts.ts` is corrected to point at the task, and to say plainly that a decision has no readable text until the task reaches it — but the metadata-only ingestion strategy itself is unchanged and still correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automated background job to backfill Slovak court decision PDFs on a regular cadence.
  * Case-law decisions with available metadata are searchable right away, with full text and structured sections filled in after PDF processing.
  * Successfully processed documents are indexed for search; unprocessable items are marked unavailable to keep the queue healthy.
* **Bug Fixes**
  * Improved resilience by handling fetch/parse/store failures per decision so other items continue processing.
* **Tests**
  * Added Postgres-backed tests covering the pending queue, successful backfill updates, and unavailable-document behaviour.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->