### PR TITLE
fix: dev structured-output mock, citation anchoring, and studio prefill

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -421,6 +421,15 @@ jobs:
           bun test
           scripts/check-api-deployment.test.ts
 
+      # The api test runner only globs `src/**`, so this seed-side regression
+      # guard (it imports `createMockDocx` and the Export Review citation
+      # seeds) needs an explicit invocation to run in CI, like the scripts
+      # tests above. Gated on workspace checks so it is skipped on
+      # workflow-only PRs where dependencies are not installed.
+      - name: Test seed citation-anchor guard
+        if: needs.ci-changes.outputs.package_checks_required == 'true'
+        run: bun test apps/api/scripts/seed-dev.test.ts
+
       - name: Test API and CLI contract invariants
         if: needs.ci-changes.outputs.package_checks_required == 'true'
         run: >-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -428,7 +428,9 @@ jobs:
       # workflow-only PRs where dependencies are not installed.
       - name: Test seed citation-anchor guard
         if: needs.ci-changes.outputs.package_checks_required == 'true'
-        run: bun test apps/api/scripts/seed-dev.test.ts
+        run: >-
+          bun test --preload ./apps/api/src/tests/setup-env.ts
+          apps/api/scripts/seed-dev.test.ts
 
       - name: Test API and CLI contract invariants
         if: needs.ci-changes.outputs.package_checks_required == 'true'

--- a/apps/api/scripts/seed-dev.test.ts
+++ b/apps/api/scripts/seed-dev.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  buildExportReviewCitationSeeds,
+  buildExportReviewDocumentText,
+  buildExportReviewMetadata,
+  createMockDocx,
+} from "./seed-dev";
+
+// Reproduces the non-empty-block walk folio's DOCX extractor performs (see
+// the `blockIndex` doc comment on `ExportReviewCitationSeed` in
+// seed-dev.ts): the leading title paragraph is block 1, then one block per
+// non-blank line of the body text, blank lines uncounted.
+const nonEmptyBlockTexts = (title: string, bodyText: string): string[] =>
+  [title, ...bodyText.split("\n")].filter((line) => line.trim().length > 0);
+
+// Parses the actual bytes `createMockDocx` produces back into its paragraph
+// text list, so the guard exercises the real generator instead of only
+// re-deriving the same layout by hand.
+const paragraphTextsFromDocx = async (docx: Buffer): Promise<string[]> => {
+  const JSZip = (await import("jszip")).default;
+  const zip = await JSZip.loadAsync(docx);
+  const documentXml = await zip.file("word/document.xml")?.async("string");
+  if (documentXml === undefined) {
+    throw new Error("seeded docx is missing word/document.xml");
+  }
+
+  const paragraphs = documentXml.match(/<w:p>.*?<\/w:p>/gu) ?? [];
+  return paragraphs.map((paragraph) => {
+    const textRuns = paragraph.match(/<w:t[^>]*>.*?<\/w:t>/gu) ?? [];
+    return textRuns
+      .map((run) => run.replace(/<w:t[^>]*>|<\/w:t>/gu, ""))
+      .join("")
+      .replaceAll("&quot;", '"')
+      .replaceAll("&apos;", "'")
+      .replaceAll("&lt;", "<")
+      .replaceAll("&gt;", ">")
+      .replaceAll("&amp;", "&");
+  });
+};
+
+describe("Export Review citation seeds", () => {
+  test("every docx-folio citation's blockIndex points at the paragraph containing its quote", async () => {
+    const index = 0;
+    const metadata = buildExportReviewMetadata(index);
+    const fileName = "Sample_Export_Review_Contract.docx";
+    const title = fileName.replace(/\.\w+$/u, "").replaceAll("_", " ");
+    const bodyText = buildExportReviewDocumentText(fileName, index);
+
+    const docx = await createMockDocx(title, bodyText);
+    const paragraphs = await paragraphTextsFromDocx(docx);
+    const nonEmptyParagraphs = paragraphs.filter(
+      (text) => text.trim().length > 0,
+    );
+
+    // Sanity-check the DOCX parsing itself against a plain-text
+    // reconstruction of the same title + body before trusting it below.
+    expect(nonEmptyParagraphs).toEqual(nonEmptyBlockTexts(title, bodyText));
+
+    const citationSeeds = buildExportReviewCitationSeeds(metadata);
+    expect(citationSeeds.length).toBeGreaterThan(0);
+
+    for (const seed of citationSeeds) {
+      const paragraphText = nonEmptyParagraphs.at(seed.blockIndex - 1);
+      expect(paragraphText).toContain(seed.quote);
+    }
+  });
+});

--- a/apps/api/scripts/seed-dev.ts
+++ b/apps/api/scripts/seed-dev.ts
@@ -586,7 +586,9 @@ const addDays = (date: Date, days: number): string => {
   return copy.toISOString().slice(0, 10);
 };
 
-const buildExportReviewMetadata = (index: number): ExportReviewMetadata => {
+export const buildExportReviewMetadata = (
+  index: number,
+): ExportReviewMetadata => {
   const documentType = at(
     EXPORT_REVIEW_DOCUMENT_TYPES,
     index % EXPORT_REVIEW_DOCUMENT_TYPES.length,
@@ -641,7 +643,7 @@ const buildExportReviewMetadata = (index: number): ExportReviewMetadata => {
   };
 };
 
-const buildExportReviewDocumentText = (
+export const buildExportReviewDocumentText = (
   fileName: string,
   index: number,
 ): string => {
@@ -2924,70 +2926,101 @@ type ExportReviewCitationSeed = {
   fieldSuffix: string;
   statement: string;
   quote: string;
+  /**
+   * The citation's 1-based position in folio's non-empty-block walk
+   * (`getSequentialFolioBlockIdIndex`/`deriveBlockId` in
+   * `@stll/folio-core/types/block-id`), fixed to this field's line in the
+   * `createMockDocx(title, buildExportReviewDocumentText(...))` layout: a
+   * leading title block (1), then one block per non-blank line of
+   * `buildExportReviewDocumentText`'s template, blank lines uncounted.
+   * Keep this in sync with that template — every docx-folio citation below
+   * only resolves to an exact-passage highlight (vs. a degraded block
+   * flash) when this points at the paragraph that actually contains
+   * `quote`.
+   */
+  blockIndex: number;
 };
 
-const buildExportReviewCitationSeeds = (
+export const buildExportReviewCitationSeeds = (
   metadata: ExportReviewMetadata,
 ): ExportReviewCitationSeed[] => [
   {
     fieldSuffix: "document-type",
     statement: `Document type extracted as ${metadata.documentType}.`,
     quote: `Document type: ${metadata.documentType}`,
+    blockIndex: 4,
   },
   {
     fieldSuffix: "counterparty",
     statement: `Counterparty extracted as ${metadata.counterparty}.`,
     quote: `Counterparty: ${metadata.counterparty}`,
+    blockIndex: 5,
   },
   {
     fieldSuffix: "jurisdiction",
     statement: `Jurisdiction extracted as ${metadata.jurisdiction}.`,
     quote: `Jurisdiction: ${metadata.jurisdiction}`,
+    blockIndex: 6,
   },
   {
     fieldSuffix: "governing-law",
     statement: `Governing law extracted as ${metadata.governingLaw}.`,
     quote: `Governing law: ${metadata.governingLaw}`,
+    blockIndex: 7,
   },
   {
     fieldSuffix: "effective-date",
     statement: `Effective date extracted as ${metadata.effectiveDate}.`,
     quote: `Effective date: ${metadata.effectiveDate}`,
+    blockIndex: 8,
   },
   {
     fieldSuffix: "expiry-date",
     statement: `Expiry date extracted as ${metadata.expiryDate}.`,
     quote: `Expiry date: ${metadata.expiryDate}`,
+    blockIndex: 9,
   },
   {
     fieldSuffix: "contract-value",
     statement: `Contract value extracted as EUR ${metadata.contractValue}.`,
     quote: `Contract value: EUR ${metadata.contractValue}`,
+    blockIndex: 10,
   },
   {
     fieldSuffix: "risk-level",
     statement: `Risk level classified as ${metadata.riskLevel}.`,
     quote: `Risk level: ${metadata.riskLevel}`,
+    blockIndex: 11,
   },
   {
     fieldSuffix: "evidence-quality",
     statement: `Evidence quality classified as ${metadata.evidenceQuality}.`,
     quote: `Evidence quality: ${metadata.evidenceQuality}`,
+    // Position 12 is "Review status: ..." (not a citation field); evidence
+    // quality is the next line.
+    blockIndex: 13,
   },
   {
     fieldSuffix: "tags",
     statement: `Tags extracted as ${metadata.tags.join(", ")}.`,
     quote: `Tags: ${metadata.tags.join(", ")}`,
+    blockIndex: 14,
   },
   {
     fieldSuffix: "key-obligation",
     statement: "Key obligation extracted from the obligation section.",
     quote: metadata.keyObligation,
+    // Position 15 is the "Key obligation:" heading; the obligation text
+    // itself is the next line.
+    blockIndex: 16,
   },
   {
     fieldSuffix: "risk-finding",
     statement: "Risk finding extracted from the risk section.",
     quote: metadata.riskFinding,
+    // Position 17 is the "Risk finding:" heading; the finding text itself
+    // is the next line.
+    blockIndex: 18,
   },
 ];
 
@@ -3016,7 +3049,7 @@ const buildExportReviewJustificationContent = ({
                 {
                   blockId: deriveBlockId({
                     paraId: null,
-                    index: metadata.pageNumber,
+                    index: citationSeed.blockIndex,
                     taken: new Set(),
                   }),
                   text: citationSeed.quote,

--- a/apps/api/src/dev/register-mock-ai.test.ts
+++ b/apps/api/src/dev/register-mock-ai.test.ts
@@ -15,10 +15,20 @@ import { toTanStackValibotSchema } from "@/api/lib/tanstack-ai-schema";
 // `convertSchemaForStructuredOutput` (called by the real `chat()` engine
 // immediately before invoking the adapter) applies internally; `{
 // forStructuredOutput: true }` reproduces it exactly.
-const structuredOutputSchemaFor = (schema: v.GenericSchema): unknown => {
+// The mock runs under whichever provider `resolveProvider` picks (Google by
+// default), and each provider's projection encodes nullability differently:
+// OpenAI keeps an `anyOf` null branch, Google lowers it to `nullable: true`.
+// The guards run through both so the synthesizer is covered on the actual
+// default path, not just OpenAI.
+const PROVIDERS = ["openai", "google"] as const;
+
+const structuredOutputSchemaFor = (
+  schema: v.GenericSchema,
+  provider: (typeof PROVIDERS)[number],
+): unknown => {
   const tanStackSchema = toTanStackValibotSchema(
     schema,
-    providerSafeJsonSchemaOptionsForTanStackProvider("openai"),
+    providerSafeJsonSchemaOptionsForTanStackProvider(provider),
   );
   return convertSchemaToJsonSchema(tanStackSchema, {
     forStructuredOutput: true,
@@ -55,8 +65,10 @@ const deriveAskSchema = v.strictObject({
 });
 
 // A schema shape none of the curated fixtures recognize: a nested object, an
-// array, an enum, a required-nullable leaf, and a genuinely optional leaf,
-// all in one place.
+// array, an enum, and a required-nullable leaf. Nullable-required (not
+// optional) mirrors real structured-output schemas — OpenAI strict output
+// rejects optional properties — so this parses under both provider
+// projections.
 const novelSchema = v.strictObject({
   title: v.pipe(v.string(), v.maxLength(200)),
   priority: v.picklist(["low", "medium", "high"]),
@@ -66,43 +78,77 @@ const novelSchema = v.strictObject({
     createdBy: v.string(),
     reviewed: v.boolean(),
   }),
-  optionalNote: v.optional(v.string()),
+});
+
+// A required-nullable ISO-date leaf: the `"mock"` string primitive fails
+// `v.isoDate()`, so only synthesizing `null` for a nullable field keeps this
+// parseable. Under the Google projection the field arrives as
+// `nullable: true` rather than an `anyOf` null branch.
+const nullableIsoDateSchema = v.strictObject({
+  when: v.nullable(v.pipe(v.string(), v.isoDate())),
+});
+
+// A genuinely optional (not nullable) field: valid to omit, invalid as null.
+// The OpenAI projection keeps enough signal (a widened `["type","null"]`
+// array) to recover the optionality and omit the key.
+const optionalFieldSchema = v.strictObject({
+  required: v.string(),
+  note: v.optional(v.string()),
 });
 
 const genericSynthesisBattery = [
   ["real templates/prefill schema", prefillOutputSchema],
   ["novel nested/array/enum/nullable schema", novelSchema],
+  ["required-nullable ISO-date schema", nullableIsoDateSchema],
 ] as const;
 
 describe("mockStructuredData", () => {
   // This is the class guard for the `{}` fallback bug: every schema a
   // structured-output caller might send (not just the two curated fixtures
-  // below) must come back as something the caller's own `v.parse` accepts.
-  test.each(genericSynthesisBattery)(
-    "synthesizes a value satisfying the %s",
-    (_name, schema) => {
-      const data = mockStructuredData(structuredOutputSchemaFor(schema));
-      expect(() => v.parse(schema, data)).not.toThrow();
-    },
-  );
+  // below) must come back as something the caller's own `v.parse` accepts —
+  // under either provider projection.
+  for (const provider of PROVIDERS) {
+    test.each(genericSynthesisBattery)(
+      `synthesizes a value satisfying the %s (${provider})`,
+      (_name, schema) => {
+        const data = mockStructuredData(
+          structuredOutputSchemaFor(schema, provider),
+        );
+        expect(() => v.parse(schema, data)).not.toThrow();
+      },
+    );
+  }
+
+  // A nullable field carrying a format constraint must synthesize as null, not
+  // a mock string that fails the constraint (guards the Google `nullable: true`
+  // path that a mock string silently broke).
+  test("synthesizes a constrained nullable field as null", () => {
+    const data = mockStructuredData(
+      structuredOutputSchemaFor(nullableIsoDateSchema, "google"),
+    );
+    expect(v.parse(nullableIsoDateSchema, data)).toEqual({ when: null });
+  });
 
   test("omits a genuinely optional field instead of inventing a value", () => {
-    const data = mockStructuredData(structuredOutputSchemaFor(novelSchema));
-    const parsed = v.parse(novelSchema, data);
-    expect(parsed).not.toHaveProperty("optionalNote");
-    expect(parsed.assignee).toBeNull();
-    expect(parsed.tags).toEqual([]);
+    const data = mockStructuredData(
+      structuredOutputSchemaFor(optionalFieldSchema, "openai"),
+    );
+    const parsed = v.parse(optionalFieldSchema, data);
+    expect(parsed).not.toHaveProperty("note");
+    expect(parsed.required).toBe("mock");
   });
 
   test("synthesizes the templates/prefill schema as an empty field list", () => {
     const data = mockStructuredData(
-      structuredOutputSchemaFor(prefillOutputSchema),
+      structuredOutputSchemaFor(prefillOutputSchema, "openai"),
     );
     expect(v.parse(prefillOutputSchema, data)).toEqual({ fields: [] });
   });
 
   test("keeps the curated playbook.verdict tier-match fixture", () => {
-    const data = mockStructuredData(structuredOutputSchemaFor(tierMatchSchema));
+    const data = mockStructuredData(
+      structuredOutputSchemaFor(tierMatchSchema, "openai"),
+    );
     expect(v.parse(tierMatchSchema, data)).toEqual({
       tier: "deviation",
       rationale: "Mock verdict.",
@@ -110,7 +156,9 @@ describe("mockStructuredData", () => {
   });
 
   test("keeps the curated playbook.derive-ask fixture", () => {
-    const data = mockStructuredData(structuredOutputSchemaFor(deriveAskSchema));
+    const data = mockStructuredData(
+      structuredOutputSchemaFor(deriveAskSchema, "openai"),
+    );
     expect(v.parse(deriveAskSchema, data)).toEqual({
       question: "What does the contract say about this issue?",
       contentType: "text",

--- a/apps/api/src/dev/register-mock-ai.test.ts
+++ b/apps/api/src/dev/register-mock-ai.test.ts
@@ -1,0 +1,129 @@
+import { convertSchemaToJsonSchema } from "@tanstack/ai";
+import { describe, expect, test } from "bun:test";
+import * as v from "valibot";
+
+import { mockStructuredData } from "@/api/dev/register-mock-ai";
+import { providerSafeJsonSchemaOptionsForTanStackProvider } from "@/api/lib/provider-safe-json-schema";
+import { toTanStackValibotSchema } from "@/api/lib/tanstack-ai-schema";
+
+// Runs a Valibot schema through the exact pipeline
+// `generateTanStackObjectForRole` / `streamTanStackObjectForRole`
+// (apps/api/src/lib/tanstack-ai-generate.ts) apply before any adapter's
+// `structuredOutput` sees `outputSchema`: Valibot -> TanStack's Standard JSON
+// Schema wrapper -> provider-safe projection -> TanStack's own
+// `forStructuredOutput` widening. That widening step is what
+// `convertSchemaForStructuredOutput` (called by the real `chat()` engine
+// immediately before invoking the adapter) applies internally; `{
+// forStructuredOutput: true }` reproduces it exactly.
+const structuredOutputSchemaFor = (schema: v.GenericSchema): unknown => {
+  const tanStackSchema = toTanStackValibotSchema(
+    schema,
+    providerSafeJsonSchemaOptionsForTanStackProvider("openai"),
+  );
+  return convertSchemaToJsonSchema(tanStackSchema, {
+    forStructuredOutput: true,
+  });
+};
+
+// Mirrors apps/api/src/handlers/templates/prefill.ts's `prefillOutputSchema`.
+const prefillOutputSchema = v.strictObject({
+  fields: v.array(
+    v.strictObject({
+      id: v.string(),
+      value: v.nullable(v.string()),
+      sourceSnippet: v.nullable(v.string()),
+    }),
+  ),
+});
+
+// Mirrors apps/api/src/lib/workflow/verdict-engine.ts's `tierMatchSchema`.
+const tierMatchSchema = v.strictObject({
+  tier: v.picklist(["compliant", "fallback", "deviation"]),
+  rationale: v.pipe(v.string(), v.maxLength(1000)),
+  matched: v.optional(
+    v.strictObject({
+      kind: v.picklist(["fallback", "redLine"]),
+      rank: v.number(),
+    }),
+  ),
+});
+
+// Mirrors apps/api/src/handlers/playbooks/derive-ask.ts's `deriveAskSchema`.
+const deriveAskSchema = v.strictObject({
+  question: v.pipe(v.string(), v.maxLength(1000)),
+  contentType: v.picklist(["text", "date", "int"]),
+});
+
+// A schema shape none of the curated fixtures recognize: a nested object, an
+// array, an enum, a required-nullable leaf, and a genuinely optional leaf,
+// all in one place.
+const novelSchema = v.strictObject({
+  title: v.pipe(v.string(), v.maxLength(200)),
+  priority: v.picklist(["low", "medium", "high"]),
+  tags: v.array(v.string()),
+  assignee: v.nullable(v.string()),
+  metadata: v.strictObject({
+    createdBy: v.string(),
+    reviewed: v.boolean(),
+  }),
+  optionalNote: v.optional(v.string()),
+});
+
+const genericSynthesisBattery = [
+  ["real templates/prefill schema", prefillOutputSchema],
+  ["novel nested/array/enum/nullable schema", novelSchema],
+] as const;
+
+describe("mockStructuredData", () => {
+  // This is the class guard for the `{}` fallback bug: every schema a
+  // structured-output caller might send (not just the two curated fixtures
+  // below) must come back as something the caller's own `v.parse` accepts.
+  test.each(genericSynthesisBattery)(
+    "synthesizes a value satisfying the %s",
+    (_name, schema) => {
+      const data = mockStructuredData(structuredOutputSchemaFor(schema));
+      expect(() => v.parse(schema, data)).not.toThrow();
+    },
+  );
+
+  test("omits a genuinely optional field instead of inventing a value", () => {
+    const data = mockStructuredData(structuredOutputSchemaFor(novelSchema));
+    const parsed = v.parse(novelSchema, data);
+    expect(parsed).not.toHaveProperty("optionalNote");
+    expect(parsed.assignee).toBeNull();
+    expect(parsed.tags).toEqual([]);
+  });
+
+  test("synthesizes the templates/prefill schema as an empty field list", () => {
+    const data = mockStructuredData(
+      structuredOutputSchemaFor(prefillOutputSchema),
+    );
+    expect(v.parse(prefillOutputSchema, data)).toEqual({ fields: [] });
+  });
+
+  test("keeps the curated playbook.verdict tier-match fixture", () => {
+    const data = mockStructuredData(structuredOutputSchemaFor(tierMatchSchema));
+    expect(v.parse(tierMatchSchema, data)).toEqual({
+      tier: "deviation",
+      rationale: "Mock verdict.",
+    });
+  });
+
+  test("keeps the curated playbook.derive-ask fixture", () => {
+    const data = mockStructuredData(structuredOutputSchemaFor(deriveAskSchema));
+    expect(v.parse(deriveAskSchema, data)).toEqual({
+      question: "What does the contract say about this issue?",
+      contentType: "text",
+    });
+  });
+
+  test("throws rather than silently returning an unsatisfiable schema", () => {
+    expect(() =>
+      mockStructuredData({
+        type: "object",
+        properties: { odd: {} },
+        required: ["odd"],
+      }),
+    ).toThrow();
+  });
+});

--- a/apps/api/src/dev/register-mock-ai.ts
+++ b/apps/api/src/dev/register-mock-ai.ts
@@ -7,6 +7,7 @@ import type {
   TextPart,
   TokenUsage,
 } from "@tanstack/ai";
+import { panic } from "better-result";
 
 import { isMockAI } from "@/api/consts";
 import { registerTanStackMockTextAdapterFactory } from "@/api/lib/tanstack-ai-models";
@@ -167,20 +168,20 @@ const createMockTextAdapter = (modelId: string): AnyTextAdapter => ({
   },
 });
 
-// The default `{}` fails any strict valibot schema, so the playbook grade/derive
-// paths have no working dev mock. Return a minimal schema-valid object for the
-// two playbook structured-output features (keyed off the JSON-schema property
-// set, since the adapter never sees the feature name), and keep `{}` for every
-// other structured-output caller.
-const mockStructuredData = (outputSchema: unknown): Record<string, unknown> => {
-  const properties =
-    typeof outputSchema === "object" &&
-    outputSchema !== null &&
-    "properties" in outputSchema &&
-    typeof outputSchema.properties === "object" &&
-    outputSchema.properties !== null
-      ? outputSchema.properties
-      : {};
+// Two playbook structured-output features have curated fixtures below because
+// their semantic *values* matter (a grade, a derived question) beyond mere
+// schema validity. Every other structured-output caller falls through to
+// `synthesizeJsonSchemaObject`, which walks the JSON schema TanStack hands the
+// adapter (already converted from the caller's Valibot schema, see
+// `generateTanStackObjectForRole` in tanstack-ai-generate.ts) and builds the
+// minimal value that satisfies it. Returning `{}` here previously passed
+// schema validation to the caller's `v.parse`, which throws on any missing
+// required field — every new structured-output feature was born broken
+// under the documented `USE_MOCK_AI=true` dev default.
+export const mockStructuredData = (
+  outputSchema: unknown,
+): Record<string, unknown> => {
+  const properties = jsonSchemaProperties(outputSchema);
 
   // playbook.verdict — tier-match. Return a plain "deviation" with no `matched`
   // so the object is valid regardless of whether the prompt listed fallbacks.
@@ -196,7 +197,166 @@ const mockStructuredData = (outputSchema: unknown): Record<string, unknown> => {
     };
   }
 
-  return {};
+  return synthesizeJsonSchemaObject(outputSchema);
+};
+
+const jsonSchemaProperties = (outputSchema: unknown): JsonSchemaNode => {
+  if (
+    !isJsonSchemaNode(outputSchema) ||
+    !isJsonSchemaNode(outputSchema["properties"])
+  ) {
+    return {};
+  }
+  return outputSchema["properties"];
+};
+
+type JsonSchemaNode = Record<string, unknown>;
+
+const isJsonSchemaNode = (value: unknown): value is JsonSchemaNode =>
+  typeof value === "object" && value !== null;
+
+// `Array.isArray` narrows an `unknown` argument to `any[]`, not `unknown[]`
+// (a long-standing TypeScript lib.d.ts gap), which would otherwise leak `any`
+// into every caller below.
+const isUnknownArray = (value: unknown): value is unknown[] =>
+  Array.isArray(value);
+
+// A branch list (`anyOf`/`oneOf`) that contains an explicit `{ type: "null" }`
+// member is how Valibot's `v.nullable()` reaches the mock: a genuinely
+// nullable, still-required field. Synthesizing `null` is always valid for it.
+const hasExplicitNullBranch = (node: JsonSchemaNode): boolean => {
+  const branches = node["anyOf"] ?? node["oneOf"];
+  if (!isUnknownArray(branches)) {
+    return false;
+  }
+  return branches.some(
+    (branch) => isJsonSchemaNode(branch) && isNullOnlyType(branch["type"]),
+  );
+};
+
+const isNullOnlyType = (type: unknown): boolean =>
+  type === "null" || (isUnknownArray(type) && type.every((t) => t === "null"));
+
+// TanStack's `forStructuredOutput` conversion (`convertSchemaForStructuredOutput`,
+// applied to every schema before an adapter's `structuredOutput` sees it)
+// widens originally-optional properties into `required` entries whose `type`
+// gains a `"null"` member (e.g. `"string"` -> `["string", "null"]`), tracked in
+// a `nullWideningMap` the caller uses to undo the widening once the real
+// provider replies. The mock never receives that map, so this is the only
+// signal left that a property was optional in the original Valibot schema:
+// unlike `v.nullable()` (an `anyOf`/`oneOf` null branch, see above), the
+// widening mutates `type` in place. Detecting it lets the synthesized object
+// omit the key, matching what the original schema actually requires.
+const isWidenedOptional = (node: JsonSchemaNode): boolean => {
+  const type = node["type"];
+  if (!isUnknownArray(type) || !type.includes("null")) {
+    return false;
+  }
+  return (
+    type.some((t) => t !== "null") &&
+    node["anyOf"] === undefined &&
+    node["oneOf"] === undefined
+  );
+};
+
+const primaryType = (type: unknown): string | undefined => {
+  if (typeof type === "string") {
+    return type;
+  }
+  if (isUnknownArray(type)) {
+    return type.find((t): t is string => typeof t === "string" && t !== "null");
+  }
+  return undefined;
+};
+
+const synthesisFailure = (node: unknown): never =>
+  panic(
+    "mock AI adapter cannot synthesise structured output for this schema; " +
+      `add a fixture in register-mock-ai.ts (schema node: ${JSON.stringify(node)})`,
+  );
+
+// Generic JSON-schema-shaped value synthesis: walks `outputSchema` and builds
+// the minimal value that satisfies it, so any structured-output caller — not
+// just the two curated playbook fixtures above — gets a schema-valid mock
+// response instead of `{}`.
+const synthesizeJsonSchemaValue = (node: unknown): unknown => {
+  if (!isJsonSchemaNode(node)) {
+    return synthesisFailure(node);
+  }
+
+  if ("const" in node) {
+    return node["const"];
+  }
+
+  if (isUnknownArray(node["enum"]) && node["enum"].length > 0) {
+    return node["enum"][0];
+  }
+
+  if (hasExplicitNullBranch(node)) {
+    return null;
+  }
+
+  switch (primaryType(node["type"])) {
+    case "object":
+      return synthesizeJsonSchemaObject(node);
+    case "array":
+      return synthesizeJsonSchemaArray(node);
+    case "string":
+      return "mock";
+    case "number":
+    case "integer":
+      return 0;
+    case "boolean":
+      return false;
+    case "null":
+      return null;
+    default:
+      return synthesisFailure(node);
+  }
+};
+
+const synthesizeJsonSchemaObject = (node: unknown): Record<string, unknown> => {
+  if (!isJsonSchemaNode(node)) {
+    return synthesisFailure(node);
+  }
+
+  const properties = isJsonSchemaNode(node["properties"])
+    ? node["properties"]
+    : {};
+  const required = isUnknownArray(node["required"]) ? node["required"] : [];
+
+  const result: Record<string, unknown> = {};
+  for (const [key, propertySchema] of Object.entries(properties)) {
+    if (!isJsonSchemaNode(propertySchema)) {
+      continue;
+    }
+    if (isWidenedOptional(propertySchema)) {
+      continue;
+    }
+    if (hasExplicitNullBranch(propertySchema)) {
+      result[key] = null;
+      continue;
+    }
+    if (!required.includes(key)) {
+      continue;
+    }
+    result[key] = synthesizeJsonSchemaValue(propertySchema);
+  }
+  return result;
+};
+
+const synthesizeJsonSchemaArray = (node: JsonSchemaNode): unknown[] => {
+  const minItems = typeof node["minItems"] === "number" ? node["minItems"] : 0;
+  if (minItems <= 0) {
+    return [];
+  }
+
+  const itemsSchema = isUnknownArray(node["items"])
+    ? node["items"].at(0)
+    : node["items"];
+  return Array.from({ length: minItems }, () =>
+    synthesizeJsonSchemaValue(itemsSchema),
+  );
 };
 
 if (isMockAI()) {

--- a/apps/api/src/dev/register-mock-ai.ts
+++ b/apps/api/src/dev/register-mock-ai.ts
@@ -237,6 +237,20 @@ const hasExplicitNullBranch = (node: JsonSchemaNode): boolean => {
 const isNullOnlyType = (type: unknown): boolean =>
   type === "null" || (isUnknownArray(type) && type.every((t) => t === "null"));
 
+// A field is nullable to the mock through either of two encodings, depending
+// on which provider the pipeline projected the schema for before handing it
+// over (the mock runs under whatever provider `resolveProvider` picks, which
+// defaults to Google when `AI_PROVIDER` is unset): an OpenAI-style `anyOf`
+// null branch, or a Google-style `nullable: true` flag
+// (provider-safe-json-schema.ts lowers null unions to `nullable`). Real
+// structured-output schemas make nullable members `required` rather than
+// optional (OpenAI strict output rejects optional properties), so `null` is
+// the correct minimal value — and, unlike the `"string"` primitive, it also
+// satisfies a nullable field that carries a format constraint (e.g. an ISO
+// date), which a mock string would fail.
+const isNullable = (node: JsonSchemaNode): boolean =>
+  hasExplicitNullBranch(node) || node["nullable"] === true;
+
 // TanStack's `forStructuredOutput` conversion (`convertSchemaForStructuredOutput`,
 // applied to every schema before an adapter's `structuredOutput` sees it)
 // widens originally-optional properties into `required` entries whose `type`
@@ -292,7 +306,7 @@ const synthesizeJsonSchemaValue = (node: unknown): unknown => {
     return node["enum"][0];
   }
 
-  if (hasExplicitNullBranch(node)) {
+  if (isNullable(node)) {
     return null;
   }
 
@@ -333,7 +347,7 @@ const synthesizeJsonSchemaObject = (node: unknown): Record<string, unknown> => {
     if (isWidenedOptional(propertySchema)) {
       continue;
     }
-    if (hasExplicitNullBranch(propertySchema)) {
+    if (isNullable(propertySchema)) {
       result[key] = null;
       continue;
     }

--- a/apps/web/src/routes/_protected.knowledge/-components/template-studio-inspector.test.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/template-studio-inspector.test.tsx
@@ -1,0 +1,60 @@
+import type { ReactNode } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { describe, expect, test } from "bun:test";
+import { IntlProvider } from "use-intl";
+
+import { FormattingProvider } from "@/i18n/formatting-context";
+import messages from "@/i18n/langs/en.json";
+import type Messages from "@/i18n/langs/messages.gen";
+import { TemplateForm } from "@/routes/_protected.knowledge/-components/template-form";
+
+// Regression guard for the Template Studio Fill tab having no AI prefill
+// entry point: Studio's TemplateForm call now passes `prefill={{}}` (see
+// template-studio-inspector.tsx's TemplateFillFacet), the same way
+// use-template-dialog.tsx does for the matter "Use template" flow. This
+// renders TemplateForm with that exact prop combination and asserts the
+// real TemplatePrefillPanel mounts, not just a static pointer to it.
+const renderWithProviders = (children: ReactNode) =>
+  renderToStaticMarkup(
+    <QueryClientProvider client={new QueryClient()}>
+      <IntlProvider
+        locale="en"
+        // SAFETY: mirrors the app provider boundary; locale files are
+        // checked separately, and use-intl preserves English literal
+        // values in the generated Messages type.
+        // eslint-disable-next-line typescript/no-unsafe-type-assertion
+        messages={messages as Messages}
+        timeZone="UTC"
+      >
+        <FormattingProvider locale="en" timeZone="UTC">
+          {children}
+        </FormattingProvider>
+      </IntlProvider>
+    </QueryClientProvider>,
+  );
+
+describe("Template Studio Fill tab prefill", () => {
+  test("renders the AI prefill panel when given Studio's fill-form props", () => {
+    const html = renderWithProviders(
+      <TemplateForm
+        conditions={[]}
+        fields={[]}
+        fileName="Sample_Contract.docx"
+        onBack={() => undefined}
+        onDone={() => undefined}
+        prefill={{}}
+        structureErrors={[]}
+        templateId="template-1"
+      />,
+    );
+
+    // The panel's always-visible header, not just its expanded contents
+    // (expansion is client-side state that a static render can't exercise).
+    expect(html).toContain(messages.templates.prefillTitle);
+    // No matter context in Studio, so the matter-documents picker must not
+    // be offered — only upload/paste-text.
+    expect(html).not.toContain(messages.templates.prefillMatterDocuments);
+  });
+});

--- a/apps/web/src/routes/_protected.knowledge/-components/template-studio-inspector.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/template-studio-inspector.tsx
@@ -493,6 +493,11 @@ export const TemplateFillFacet = ({
           setFillValues(values);
           pushFillPreview(values, discovered.fields, clausePreview?.slotTexts);
         }}
+        // No matter context here (Studio previews the fill form in
+        // isolation), so the panel offers only its upload/paste-text
+        // sources — never the matter-documents picker, which needs a
+        // workspaceId this facet doesn't have.
+        prefill={{}}
         saveTarget={fillSaveTarget}
         structureErrors={discovered.structureErrors}
         templateId={templateId}


### PR DESCRIPTION
Three independent fixes, each a case where a fallback silently produced plausible-but-wrong output instead of failing loudly. Each commit carries its own regression guard and can be reviewed (or dropped) on its own.

## `fix(dev)`: the structured-output mock synthesises any schema

`mockStructuredData()` recognised only two curated playbook schemas and returned `{}` for everything else. Strict-valibot callers (e.g. template prefill) then `v.parse` that `{}` and throw, so any new structured-output feature 500s under the documented `USE_MOCK_AI=true` dev default.

The mock now keeps the two curated fixtures (their values carry meaning) and otherwise walks the converted JSON schema to build the minimal value that satisfies it: objects recurse into required properties, arrays honour `minItems`, enums/`const` take the first value, and a genuinely nullable field (a null branch in `anyOf`/`oneOf`) is distinguished from a widened-optional one (a `null`-augmented `type`) so the key is nulled vs omitted correctly. A node that genuinely can't be satisfied now `panic()`s with an actionable message instead of silently returning `{}`.

**Guard:** `register-mock-ai.test.ts` runs the real prefill schema plus a novel nested/array/enum/nullable schema through the actual conversion pipeline and asserts `v.parse` succeeds for each, and that the two curated fixtures still return their values.

## `fix(seed)`: demo citations anchor to the quoted paragraph

Export Review demo citations derived their folio `blockId` from a cosmetic page number, unrelated to where the quote sits in the generated document. Folio block ids are a 1-based walk over non-empty paragraphs, so the exact-passage highlight resolved to the wrong paragraph. Citations now anchor to the paragraph that actually contains the quote.

**Guard:** `seed-dev.test.ts` generates the document via `createMockDocx`, parses `word/document.xml` back into its paragraph list, and asserts each citation's block index lands on the paragraph containing its quote.

## `fix(templates)`: AI prefill is reachable from the Template Studio Fill tab

The Studio Fill tab rendered `TemplateForm` without the `prefill` prop, so AI "Prefill from documents" (upload / paste-text sources) had no entry point there. `TemplatePrefillPanel` is gated only on `prefill` + `templateId`, both already present in Studio's server-fill form, so enabling it is one prop. No workspace id is passed, so the matter-documents source stays hidden and only upload/paste are offered.

**Guard:** `template-studio-inspector.test.tsx` renders the form with Studio's exact prop shape and asserts the prefill panel appears while the matter-documents picker does not.

---

Tests: api suite green (mock + seed), web component test green, oxlint clean on the touched files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved citation placement in generated DOCX documents so each quote resolves to the correct paragraph.
  - Updated Template Studio’s Fill tab to render the prefill panel with the correct (non–matter-document) options.
  - Enhanced mock AI structured-output generation to produce schema-valid results across more schema shapes.
- **Tests**
  - Added DOCX citation mapping coverage, expanded mock AI schema handling tests, and a regression test for Template Studio prefill rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->