### PR TITLE
feat(cli): compose --input with value flags, name union fields, verify machine-key whoami

### DIFF
--- a/apps/api/src/mcp/capability-tools.test.ts
+++ b/apps/api/src/mcp/capability-tools.test.ts
@@ -448,6 +448,72 @@ describe("invoke_capability gates", () => {
   });
 });
 
+// --- invoke_capability: discriminated-union input errors --------------------
+
+// Guards the "path-less union error" class: a failed discriminated union must
+// name its discriminator field (and, once the discriminator matches a variant,
+// that variant's own missing fields), never collapse to an opaque, unplaceable
+// `Expected union value`. uploads.create's body is a flat union keyed by
+// `purpose`, so it is the canonical driver.
+describe("discriminated-union input validation names the field", () => {
+  const uploadIssues = async (
+    body: unknown,
+  ): Promise<{ path: string; message: string }[]> => {
+    const result = await handleMcpToolCall({
+      args: {
+        capability: "uploads.create",
+        input: { params: { workspaceId: "ws_1" }, body },
+      },
+      context: createContext(),
+      toolName: "invoke_capability",
+    });
+    const error = errorEnvelope(result);
+    expect(error.code).toBe("validation_error");
+    return asTestRaw<{ path: string; message: string }[]>(error.issues ?? []);
+  };
+
+  test("a body missing purpose names body.purpose with the allowed literals", async () => {
+    const issues = await uploadIssues({});
+    const purpose = issues.find((issue) => issue.path === "body.purpose");
+    expect(purpose).toBeDefined();
+    expect(purpose?.message).toContain('"entity_create"');
+    expect(purpose?.message).toContain('"entity_version"');
+    expect(purpose?.message).toContain('"agent_skill"');
+  });
+
+  test("a wrong purpose literal still names body.purpose", async () => {
+    const issues = await uploadIssues({ purpose: "not_a_purpose" });
+    expect(issues.some((issue) => issue.path === "body.purpose")).toBe(true);
+  });
+
+  test("a matched purpose drills into that variant's own missing fields", async () => {
+    const issues = await uploadIssues({ purpose: "entity_create" });
+    const paths = issues.map((issue) => issue.path);
+    // The entity_create variant's required file metadata surfaces by name,
+    // instead of a single opaque union error.
+    expect(paths).toContain("body.propertyId");
+    expect(issues.every((issue) => issue.path.startsWith("body."))).toBe(true);
+  });
+
+  test("INVARIANT: every union-body validation issue carries a non-empty path", async () => {
+    const bodies: unknown[] = [
+      {},
+      { purpose: "not_a_purpose" },
+      { purpose: "entity_create" },
+      { purpose: "agent_skill" },
+      { purpose: "entity_version", entityId: 5 },
+    ];
+    for (const body of bodies) {
+      // eslint-disable-next-line no-await-in-loop -- sequential invoke calls keep assertions ordered
+      const issues = await uploadIssues(body);
+      expect(issues.length).toBeGreaterThan(0);
+      for (const issue of issues) {
+        expect(issue.path.length).toBeGreaterThan(0);
+      }
+    }
+  });
+});
+
 // --- invoke_capability: workspace resolution --------------------------------
 
 describe("invoke_capability workspace resolution", () => {

--- a/apps/api/src/mcp/capability-tools.ts
+++ b/apps/api/src/mcp/capability-tools.ts
@@ -1,6 +1,7 @@
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
-import type { TSchema } from "@sinclair/typebox";
-import { Value } from "@sinclair/typebox/value";
+import { KindGuard, type TSchema } from "@sinclair/typebox";
+import { ValueErrorType } from "@sinclair/typebox/errors";
+import { Value, type ValueError } from "@sinclair/typebox/value";
 import { panic } from "better-result";
 import { ElysiaCustomStatusResponse } from "elysia";
 
@@ -232,6 +233,133 @@ const loadEndpoint = async (id: string): Promise<EndpointDefinition | null> => {
 const typeboxPathToDot = (path: string): string =>
   path.startsWith("/") ? path.slice(1).split("/").join(".") : path;
 
+/** Join two dot-paths, skipping empty segments (`""` + `x` -> `x`). */
+const joinDot = (head: string, tail: string): string => {
+  if (head.length === 0) {
+    return tail;
+  }
+  return tail.length === 0 ? head : `${head}.${tail}`;
+};
+
+/**
+ * Prefix a validated part name onto a dot-path so an agent sees `body.purpose`,
+ * never a bare `purpose` it cannot place. An empty dot-path (the whole part
+ * failed) renders as the bare part name.
+ */
+const prefixPartPath = (
+  part: "body" | "params" | "query",
+  dot: string,
+): string => joinDot(part, dot);
+
+/** A tagged-union discriminator: the shared key and the literal each variant fixes it to. */
+type UnionDiscriminator = { key: string; literals: readonly string[] };
+
+/**
+ * If every variant of a union is an object sharing one literal-typed property,
+ * return that key plus the literal each variant fixes it to (a tagged /
+ * discriminated union, e.g. uploads.create's `purpose`). Returns `null` for a
+ * non-discriminated union (e.g. `string | number`), which has no such key.
+ */
+const unionDiscriminator = (
+  variants: readonly TSchema[],
+): UnionDiscriminator | null => {
+  const objects = variants.filter((variant) => KindGuard.IsObject(variant));
+  const first = objects.at(0);
+  if (first === undefined || objects.length !== variants.length) {
+    return null;
+  }
+  for (const key of Object.keys(first.properties)) {
+    const literals: string[] = [];
+    const shared = objects.every((variant) => {
+      const prop = variant.properties[key];
+      if (prop !== undefined && KindGuard.IsLiteral(prop)) {
+        literals.push(JSON.stringify(prop.const));
+        return true;
+      }
+      return false;
+    });
+    if (shared) {
+      return { key, literals: [...new Set(literals)] };
+    }
+  }
+  return null;
+};
+
+/** The variant whose discriminator literal matches the value's, if any. */
+const matchingVariant = (
+  variants: readonly TSchema[],
+  discriminator: UnionDiscriminator,
+  value: unknown,
+): TSchema | undefined => {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+  const provided = value[discriminator.key];
+  return variants.find((variant) => {
+    if (!KindGuard.IsObject(variant)) {
+      return false;
+    }
+    const prop = variant.properties[discriminator.key];
+    return KindGuard.IsLiteral(prop) && prop.const === provided;
+  });
+};
+
+/**
+ * Expand one TypeBox union error into field-level issues. TypeBox reports a
+ * failed union as a single opaque `Expected union value` naming no field. For a
+ * discriminated union we do better: name the discriminator and its allowed
+ * literals when it is missing/wrong, or drill into the matched variant so the
+ * caller sees that variant's own missing/invalid fields. A non-discriminated
+ * union falls back to the node-level message (which still carries a non-empty
+ * path). Every returned issue's path is part-prefixed, so none is ever empty.
+ */
+const expandUnionError = (
+  part: "body" | "params" | "query",
+  error: ValueError,
+): McpValidationIssue[] => {
+  const unionDot = typeboxPathToDot(error.path);
+  if (!KindGuard.IsUnion(error.schema)) {
+    return [{ path: prefixPartPath(part, unionDot), message: error.message }];
+  }
+  const variants = error.schema.anyOf;
+  const discriminator = unionDiscriminator(variants);
+  if (discriminator === null) {
+    return [{ path: prefixPartPath(part, unionDot), message: error.message }];
+  }
+  const variant = matchingVariant(variants, discriminator, error.value);
+  if (variant !== undefined) {
+    const nested = [...Value.Errors(variant, error.value)].map((sub) => ({
+      path: prefixPartPath(part, joinDot(unionDot, typeboxPathToDot(sub.path))),
+      message: sub.message,
+    }));
+    if (nested.length > 0) {
+      return nested;
+    }
+  }
+  return [
+    {
+      path: prefixPartPath(part, joinDot(unionDot, discriminator.key)),
+      message: `expected one of ${discriminator.literals.join(" | ")}`,
+    },
+  ];
+};
+
+/** Map one TypeBox validation error to one or more part-prefixed issues. */
+const errorToIssues = (
+  part: "body" | "params" | "query",
+  error: ValueError,
+): McpValidationIssue[] => {
+  if (error.type === ValueErrorType.Union) {
+    return expandUnionError(part, error);
+  }
+  return [
+    {
+      path: prefixPartPath(part, typeboxPathToDot(error.path)),
+      message: error.message,
+    },
+  ];
+};
+
 type PartValidation =
   | { ok: true; value: unknown }
   | { ok: false; issues: McpValidationIssue[] };
@@ -268,13 +396,9 @@ const validatePart = (
   if (Value.Check(schema, cleaned)) {
     return { ok: true, value: cleaned };
   }
-  const issues = [...Value.Errors(schema, cleaned)].map((error) => {
-    const dot = typeboxPathToDot(error.path);
-    return {
-      path: dot.length > 0 ? `${part}.${dot}` : part,
-      message: error.message,
-    };
-  });
+  const issues = [...Value.Errors(schema, cleaned)].flatMap((error) =>
+    errorToIssues(part, error),
+  );
   return { ok: false, issues };
 };
 

--- a/apps/api/src/mcp/capability-tools.ts
+++ b/apps/api/src/mcp/capability-tools.ts
@@ -327,21 +327,28 @@ const expandUnionError = (
     return [{ path: prefixPartPath(part, unionDot), message: error.message }];
   }
   const variant = matchingVariant(variants, discriminator, error.value);
-  if (variant !== undefined) {
-    const nested = [...Value.Errors(variant, error.value)].map((sub) => ({
-      path: prefixPartPath(part, joinDot(unionDot, typeboxPathToDot(sub.path))),
-      message: sub.message,
-    }));
-    if (nested.length > 0) {
-      return nested;
-    }
+  // No variant matched: the discriminator is missing or not one of the literals.
+  // Name it and its allowed values -- the single most useful thing to report.
+  if (variant === undefined) {
+    return [
+      {
+        path: prefixPartPath(part, joinDot(unionDot, discriminator.key)),
+        message: `expected one of ${discriminator.literals.join(" | ")}`,
+      },
+    ];
   }
-  return [
-    {
-      path: prefixPartPath(part, joinDot(unionDot, discriminator.key)),
-      message: `expected one of ${discriminator.literals.join(" | ")}`,
-    },
-  ];
+  // A variant matched: report that variant's own field-level errors.
+  const nested = [...Value.Errors(variant, error.value)].map((sub) => ({
+    path: prefixPartPath(part, joinDot(unionDot, typeboxPathToDot(sub.path))),
+    message: sub.message,
+  }));
+  if (nested.length > 0) {
+    return nested;
+  }
+  // Matched with no field errors -- unreachable in practice (a clean match means
+  // the union would have passed). Fall back to the opaque node message rather
+  // than blaming the discriminator, which was correct.
+  return [{ path: prefixPartPath(part, unionDot), message: error.message }];
 };
 
 /** Map one TypeBox validation error to one or more part-prefixed issues. */

--- a/apps/api/src/mcp/constants.ts
+++ b/apps/api/src/mcp/constants.ts
@@ -96,11 +96,21 @@ export const STELLA_CLI_MINIMUM_HEADER = "x-stella-cli-minimum";
 export const STELLA_CLI_LATEST_VERSION = CLI_SUPPORT_BAND.latest;
 export const STELLA_CLI_LATEST_HEADER = "x-stella-cli-latest";
 
+// Identity of the authenticated session, echoed back to the caller on every
+// authenticated MCP response so `stella auth whoami` can confirm which org and
+// scopes an opaque machine API key actually resolves to (the key is not a JWT
+// the CLI can decode). Returned only to the already-authenticated caller: it is
+// that caller's own org and grants, not a disclosure to anyone else.
+export const STELLA_MCP_ORGANIZATION_HEADER = "x-stella-organization";
+export const STELLA_MCP_SCOPES_HEADER = "x-stella-scopes";
+
 export const MCP_EXPOSE_HEADERS = [
   "WWW-Authenticate",
   STELLA_MCP_API_CONTRACT_HEADER,
   STELLA_CLI_MINIMUM_HEADER,
   STELLA_CLI_LATEST_HEADER,
+  STELLA_MCP_ORGANIZATION_HEADER,
+  STELLA_MCP_SCOPES_HEADER,
   // The per-request receipt (also on the global CORS exposeHeaders list):
   // browser-based MCP clients correlate a failed/successful call with server
   // logs the same way REST callers do.

--- a/apps/api/src/mcp/metadata.test.ts
+++ b/apps/api/src/mcp/metadata.test.ts
@@ -71,7 +71,7 @@ describe("MCP protected resource metadata", () => {
       "Authorization, Content-Type, MCP-Protocol-Version",
     );
     expect(headers.get("Access-Control-Expose-Headers")).toBe(
-      "WWW-Authenticate, x-stella-api-contract-version, x-stella-cli-minimum, x-stella-cli-latest, x-request-id",
+      "WWW-Authenticate, x-stella-api-contract-version, x-stella-cli-minimum, x-stella-cli-latest, x-stella-organization, x-stella-scopes, x-request-id",
     );
     expect(headers.get("x-stella-api-contract-version")).toBe("1");
     expect(headers.get("x-stella-cli-minimum")).toBe(

--- a/apps/api/src/mcp/server-core.ts
+++ b/apps/api/src/mcp/server-core.ts
@@ -14,7 +14,11 @@ import type {
 } from "@modelcontextprotocol/sdk/types.js";
 
 import type { McpSession } from "@/api/mcp/auth";
-import type { McpMode } from "@/api/mcp/constants";
+import {
+  type McpMode,
+  STELLA_MCP_ORGANIZATION_HEADER,
+  STELLA_MCP_SCOPES_HEADER,
+} from "@/api/mcp/constants";
 import type { McpRequestContext } from "@/api/mcp/context";
 import {
   McpAuthenticationError,
@@ -98,12 +102,19 @@ const extractBearerToken = (request: Request): string | undefined => {
   return token.length > 0 ? token : undefined;
 };
 
-const withMcpCors = (response: Response) => {
+const withMcpCors = (response: Response, session?: McpSession) => {
   const headers = new Headers(response.headers);
   for (const [key, value] of createMcpCorsHeaders()) {
     if (!headers.has(key)) {
       headers.set(key, value);
     }
+  }
+  // Echo the authenticated session's identity so a caller holding an opaque
+  // machine API key (not a decodable JWT) can confirm which org and scopes it
+  // resolves to. Scopes are space-delimited, matching the OAuth scope grammar.
+  if (session) {
+    headers.set(STELLA_MCP_ORGANIZATION_HEADER, session.organizationId);
+    headers.set(STELLA_MCP_SCOPES_HEADER, session.scopes.join(" "));
   }
   return new Response(response.body, {
     headers,
@@ -315,7 +326,7 @@ export const createMcpHttpRequestHandler = ({
         },
       });
 
-      return withMcpCors(response);
+      return withMcpCors(response, session);
     } catch (error) {
       if (error instanceof McpOrganizationAccessError) {
         return accessDeniedResponse({

--- a/packages/cli/src/build-cli-tree.ts
+++ b/packages/cli/src/build-cli-tree.ts
@@ -97,7 +97,7 @@ const buildLeafFlags = (spec: LeafCommandSpec): Record<string, unknown> => {
 
   // Reserved global flags every command carries (spec S1/S3).
   flags[RESERVED_FLAG_KEYS.input] = parsedStringFlag(
-    "Full tool-args JSON: '<json>' | - (stdin) | @file",
+    "Full tool-args JSON ('<json>' | - stdin | @file); explicit value flags override matching paths in the JSON",
   );
   flags[RESERVED_FLAG_KEYS.output] = parsedStringFlag(
     "Output format: json | table | jsonl",
@@ -214,7 +214,7 @@ const buildCapabilityLeafFlags = (
   }
 
   flags[RESERVED_FLAG_KEYS.input] = parsedStringFlag(
-    "Full capability input JSON ({ body?, params?, query? }): '<json>' | - (stdin) | @file",
+    "Full capability input JSON ({ body?, params?, query? }: '<json>' | - stdin | @file); explicit value flags override matching paths in the JSON",
   );
   flags[RESERVED_FLAG_KEYS.output] = parsedStringFlag(
     "Output format: json | table | jsonl",

--- a/packages/cli/src/cli-commands.test.ts
+++ b/packages/cli/src/cli-commands.test.ts
@@ -451,16 +451,26 @@ describe("--input escape hatch (S3)", () => {
     });
   });
 
-  test("--input with a value flag conflicts, exit 2", async () => {
+  test("--input composes with a value flag; the explicit flag wins over its path", async () => {
     const server = startMockServer(() => ({ toolPayload: {} }));
     const result = await runCli({
-      args: ["matter", "save", "--input", "{}", "--name", "X"],
+      args: [
+        "matter",
+        "save",
+        "--input",
+        '{"name":"FromJson"}',
+        "--name",
+        "FromFlag",
+      ],
       url: server.url,
       token: WRITE,
     });
     server.stop();
-    expect(result.exitCode).toBe(2);
-    expect(server.requests).toHaveLength(0);
+    expect(result.exitCode).toBe(0);
+    // The flag overrides the JSON's `name`; both are threaded to the server.
+    expect(server.requests.at(0)?.params.arguments).toEqual({
+      name: "FromFlag",
+    });
   });
 
   test("--input failing schema validation exits 2", async () => {

--- a/packages/cli/src/commands/auth.test.ts
+++ b/packages/cli/src/commands/auth.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, test } from "bun:test";
+
+import type { Context } from "../context.js";
+import { runWhoami } from "./auth.js";
+
+// Guards the "identity command whose --help promises a server-verified result
+// but does no server call" class. `stella auth whoami` under STELLA_API_KEY used
+// to echo three static lines and exit 0 whether the key was valid or not, so an
+// agent could not confirm auth. These tests assert whoami now makes a REAL
+// authenticated round-trip: it reports the server-resolved org + scopes on a
+// valid key, and FAILS clearly (no static exit-0 echo) on a rejected key.
+
+type FakeProcess = {
+  process: Context["process"];
+  stdout: () => string;
+};
+
+const fakeProcess = (): FakeProcess => {
+  const chunks: string[] = [];
+  const proc = {
+    stdout: {
+      write: (text: string) => {
+        chunks.push(text);
+        return true;
+      },
+    },
+  };
+  return {
+    // SAFETY: runWhoami only writes to process.stdout; this covers that slice.
+    // eslint-disable-next-line no-unsafe-type-assertion -- test double for the process slice
+    process: proc as unknown as Context["process"],
+    stdout: () => chunks.join(""),
+  };
+};
+
+type IdentityServer = {
+  url: string;
+  requests: () => number;
+  stop: () => void;
+};
+
+const startIdentityServer = ({
+  status,
+  organizationId,
+  scopes,
+}: {
+  status: number;
+  organizationId?: string;
+  scopes?: string;
+}): IdentityServer => {
+  let requests = 0;
+  const server = Bun.serve({
+    port: 0,
+    fetch() {
+      requests += 1;
+      if (status !== 200) {
+        return new Response("nope", { status });
+      }
+      const headers = new Headers({ "Content-Type": "application/json" });
+      if (organizationId !== undefined) {
+        headers.set("x-stella-organization", organizationId);
+      }
+      if (scopes !== undefined) {
+        headers.set("x-stella-scopes", scopes);
+      }
+      return new Response(
+        JSON.stringify({ jsonrpc: "2.0", id: 1, result: { tools: [] } }),
+        { headers },
+      );
+    },
+  });
+  return {
+    url: `http://localhost:${server.port}`,
+    requests: () => requests,
+    stop: () => {
+      void server.stop(true);
+    },
+  };
+};
+
+describe("runWhoami with a machine API key", () => {
+  test("reports the server-resolved org and scopes on a valid key", async () => {
+    const server = startIdentityServer({
+      status: 200,
+      organizationId: "org_live",
+      scopes: "stella:read stella:matters_write",
+    });
+    const fake = fakeProcess();
+    const result = await runWhoami({
+      process: fake.process,
+      configDir: "/tmp/stella-whoami-test",
+      orgFlag: undefined,
+      serverFlag: server.url,
+      apiKey: "stella_mk_valid",
+    });
+    server.stop();
+
+    expect(result).toBeUndefined();
+    // A real round-trip happened (a static echo would make zero requests).
+    expect(server.requests()).toBeGreaterThan(0);
+    const out = fake.stdout();
+    expect(out).toContain("org_live");
+    expect(out).toContain("stella:read stella:matters_write");
+    expect(out).toContain("machine API key");
+  });
+
+  test("fails clearly on a rejected key instead of a static exit-0 echo", async () => {
+    const server = startIdentityServer({ status: 401 });
+    const fake = fakeProcess();
+    const result = await runWhoami({
+      process: fake.process,
+      configDir: "/tmp/stella-whoami-test",
+      orgFlag: undefined,
+      serverFlag: server.url,
+      apiKey: "stella_mk_revoked",
+    });
+    server.stop();
+
+    // The key was actually sent to the server (round-trip), and the rejection
+    // surfaces as an error, not a success echo.
+    expect(server.requests()).toBeGreaterThan(0);
+    expect(result).toBeInstanceOf(Error);
+    if (result instanceof Error) {
+      expect(result.message).toContain("rejected");
+    }
+    // No success identity was printed.
+    expect(fake.stdout()).not.toContain("Organization:");
+  });
+});

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -15,6 +15,7 @@ import { parseScopesFlag } from "../auth/scopes.js";
 import { resolveServerUrl } from "../auth/server-resolution.js";
 import type { Context } from "../context.js";
 import { STELLA_API_KEY } from "../env.js";
+import { fetchMachineIdentity } from "../mcp-client.js";
 
 const parseString = (input: string): string => input;
 
@@ -110,56 +111,88 @@ const loginCommand = buildCommand<LoginFlags, [], Context>({
   },
 });
 
+/**
+ * `stella auth whoami`, factored out of the command so the machine-key path is
+ * unit-testable with an injected `apiKey` (env reads stay in the thin command
+ * wrapper). Returns an `Error` for stricli to surface, or `undefined` on
+ * success.
+ */
+export const runWhoami = async ({
+  process: proc,
+  configDir,
+  orgFlag,
+  serverFlag,
+  apiKey,
+}: {
+  process: Context["process"];
+  configDir: string;
+  orgFlag: string | undefined;
+  serverFlag: string | undefined;
+  apiKey: string | undefined;
+}): Promise<Error | undefined> => {
+  const serverUrlResult = await resolveServerUrl(configDir, serverFlag);
+  if (Result.isError(serverUrlResult)) {
+    return new Error(serverUrlResult.error.message);
+  }
+  const serverUrl = serverUrlResult.value;
+
+  // `STELLA_API_KEY` takes precedence over `credentials.json` for every other
+  // command, so reporting the stored credential here would describe an identity
+  // nothing is actually running as. The key is opaque to the CLI (a random
+  // secret, not a JWT), so we make a real authenticated round-trip and report
+  // the org + scopes the SERVER resolves it to — which also proves the key is
+  // valid, instead of echoing static text that prints identically for a dead key.
+  if (apiKey !== undefined && apiKey !== "") {
+    const identity = await fetchMachineIdentity({ serverUrl, token: apiKey });
+    if (Result.isError(identity)) {
+      return new Error(
+        `Machine API key (STELLA_API_KEY) was rejected by ${serverUrl}: ${identity.error.message}. Confirm STELLA_API_KEY is a current, enabled key for this server.`,
+      );
+    }
+    const { organizationId, scopes } = identity.value;
+    proc.stdout.write(
+      [
+        `Server: ${serverUrl}`,
+        "Credential: machine API key (STELLA_API_KEY)",
+        `Organization: ${organizationId.length > 0 ? organizationId : "(unknown; server did not report one)"}`,
+        `Scopes: ${scopes.length > 0 ? scopes.join(" ") : "(none reported)"}`,
+        "Stored credentials are ignored while this variable is set.",
+        "",
+      ].join("\n"),
+    );
+    return undefined;
+  }
+
+  const result = await whoami(configDir, serverUrl, orgFlag);
+  if (Result.isError(result)) {
+    return new Error(result.error.message);
+  }
+
+  const info = result.value;
+  const lines = [
+    `Server: ${info.serverUrl}`,
+    `Organization: ${info.orgLabel ? `${info.orgLabel} (${info.orgId})` : info.orgId}`,
+    `Scopes: ${info.scope}`,
+    `Expires: ${formatDate(info.expiresAt)}${info.isExpired ? " (expired)" : ""}`,
+    `Refresh token: ${info.hasRefreshToken ? "yes" : "no"}`,
+  ];
+  if (info.claims?.sub) {
+    lines.push(`Subject: ${info.claims.sub}`);
+  }
+  proc.stdout.write(`${lines.join("\n")}\n`);
+  return undefined;
+};
+
 const whoamiCommand = buildCommand<ServerOrgFlags, [], Context>({
   docs: { brief: "Show the signed-in organization, scopes, and token expiry" },
   func: async function func(this: Context, flags) {
-    const serverUrlResult = await resolveServerUrl(
-      this.configDir,
-      flags.server,
-    );
-    if (Result.isError(serverUrlResult)) {
-      return new Error(serverUrlResult.error.message);
-    }
-
-    // `STELLA_API_KEY` takes precedence over `credentials.json` for every other
-    // command, so reporting the stored credential here would describe an
-    // identity nothing is actually running as. The key is opaque to the CLI (it
-    // is a random secret, not a JWT), so the honest answer is which credential
-    // is in effect and where it came from, not decoded claims.
-    if (STELLA_API_KEY !== undefined && STELLA_API_KEY !== "") {
-      this.process.stdout.write(
-        [
-          `Server: ${serverUrlResult.value}`,
-          "Credential: machine API key (STELLA_API_KEY)",
-          "Stored credentials are ignored while this variable is set.",
-          "",
-        ].join("\n"),
-      );
-      return undefined;
-    }
-
-    const result = await whoami(
-      this.configDir,
-      serverUrlResult.value,
-      flags.org,
-    );
-    if (Result.isError(result)) {
-      return new Error(result.error.message);
-    }
-
-    const info = result.value;
-    const lines = [
-      `Server: ${info.serverUrl}`,
-      `Organization: ${info.orgLabel ? `${info.orgLabel} (${info.orgId})` : info.orgId}`,
-      `Scopes: ${info.scope}`,
-      `Expires: ${formatDate(info.expiresAt)}${info.isExpired ? " (expired)" : ""}`,
-      `Refresh token: ${info.hasRefreshToken ? "yes" : "no"}`,
-    ];
-    if (info.claims?.sub) {
-      lines.push(`Subject: ${info.claims.sub}`);
-    }
-    this.process.stdout.write(`${lines.join("\n")}\n`);
-    return undefined;
+    return await runWhoami({
+      process: this.process,
+      configDir: this.configDir,
+      orgFlag: flags.org,
+      serverFlag: flags.server,
+      apiKey: STELLA_API_KEY,
+    });
   },
   parameters: {
     flags: {

--- a/packages/cli/src/generate-capability-tree.test.ts
+++ b/packages/cli/src/generate-capability-tree.test.ts
@@ -439,9 +439,7 @@ describe("curated commands must not shadow capability commands", () => {
 // `${part}.${partPath}` resolves to a declared property in the leaf's wrapper
 // schema, so drift fails CI instead of shipping.
 describe("every capability flag maps to a real path in its wrapper schema", () => {
-  const isObjectSchema = (
-    value: unknown,
-  ): value is { properties?: Record<string, unknown> } =>
+  const isRecord = (value: unknown): value is Record<string, unknown> =>
     typeof value === "object" && value !== null && !Array.isArray(value);
 
   const pathResolves = (
@@ -449,13 +447,20 @@ describe("every capability flag maps to a real path in its wrapper schema", () =
     part: string,
     partPath: string,
   ): boolean => {
-    const properties = isObjectSchema(wrapper) ? wrapper.properties : undefined;
-    let node = isObjectSchema(properties) ? properties[part] : undefined;
+    const topProperties = wrapper["properties"];
+    if (!isRecord(topProperties)) {
+      return false;
+    }
+    let node: unknown = topProperties[part];
     for (const segment of partPath.split(".")) {
-      if (!isObjectSchema(node) || !isObjectSchema(node.properties)) {
+      if (!isRecord(node)) {
         return false;
       }
-      node = node.properties[segment];
+      const properties = node["properties"];
+      if (!isRecord(properties)) {
+        return false;
+      }
+      node = properties[segment];
       if (node === undefined) {
         return false;
       }

--- a/packages/cli/src/generate-capability-tree.test.ts
+++ b/packages/cli/src/generate-capability-tree.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
 import { TOOL_ANNOTATIONS } from "./annotations.js";
+import { parseCapabilityCatalog } from "./capability-catalog-load.js";
 import {
   type CapabilityCatalogEntry,
   capabilityCommandPath,
@@ -427,5 +428,64 @@ describe("curated commands must not shadow capability commands", () => {
     expect([...stats.collisionFallbacks].sort()).toEqual(
       [...COLLISION_FALLBACK_ALLOWLIST].sort(),
     );
+  });
+});
+
+// Guard for the flag <-> --input drift class: a value flag routes its value into
+// `input[part]` at `partPath` (setPath in the executors), and `--input` is
+// validated against the synthesized wrapper schema. If a flag's target path is
+// not a real path in that schema, the flag and the JSON key silently diverge --
+// exactly the trap the compose fix removes. Assert every generated flag's
+// `${part}.${partPath}` resolves to a declared property in the leaf's wrapper
+// schema, so drift fails CI instead of shipping.
+describe("every capability flag maps to a real path in its wrapper schema", () => {
+  const isObjectSchema = (
+    value: unknown,
+  ): value is { properties?: Record<string, unknown> } =>
+    typeof value === "object" && value !== null && !Array.isArray(value);
+
+  const pathResolves = (
+    wrapper: Record<string, unknown>,
+    part: string,
+    partPath: string,
+  ): boolean => {
+    const properties = isObjectSchema(wrapper) ? wrapper.properties : undefined;
+    let node = isObjectSchema(properties) ? properties[part] : undefined;
+    for (const segment of partPath.split(".")) {
+      if (!isObjectSchema(node) || !isObjectSchema(node.properties)) {
+        return false;
+      }
+      node = node.properties[segment];
+      if (node === undefined) {
+        return false;
+      }
+    }
+    return true;
+  };
+
+  test("no flag targets a path absent from the wrapper schema", async () => {
+    const raw: unknown = await Bun.file(
+      new URL("generated/capability-catalog.json", import.meta.url),
+    ).json();
+    const entries = parseCapabilityCatalog(raw);
+    expect(entries).not.toBeNull();
+
+    const drift: string[] = [];
+    for (const catalogEntry of entries ?? []) {
+      const { spec } = deriveCapabilityLeaf(catalogEntry);
+      if (spec.inputSchema === undefined) {
+        // Truncated entry: no flags, `--input` only.
+        expect(spec.flags).toHaveLength(0);
+        continue;
+      }
+      for (const flag of spec.flags) {
+        if (!pathResolves(spec.inputSchema, flag.part, flag.partPath)) {
+          drift.push(
+            `${spec.capabilityId}: ${flag.flag} -> ${flag.part}.${flag.partPath}`,
+          );
+        }
+      }
+    }
+    expect(drift).toEqual([]);
   });
 });

--- a/packages/cli/src/mcp-client.ts
+++ b/packages/cli/src/mcp-client.ts
@@ -352,6 +352,82 @@ export const fetchToolsListRaw = async ({
   return Result.ok(out);
 };
 
+/** Response headers the server echoes the authenticated session's identity on. */
+const STELLA_ORGANIZATION_HEADER = "x-stella-organization";
+const STELLA_SCOPES_HEADER = "x-stella-scopes";
+
+/** The org + granted scopes a credential resolves to, per the server. */
+export type MachineIdentity = {
+  organizationId: string;
+  scopes: readonly string[];
+};
+
+/**
+ * Resolve the identity a bearer credential (machine API key or access token)
+ * maps to, by making one real authenticated round-trip (`tools/list`) and
+ * reading the identity headers the server echoes on it. An invalid/expired
+ * credential fails here as an `http` 401/403 error, so `stella auth whoami`
+ * confirms auth rather than echoing static text. The org/scope headers are
+ * always present on an authenticated response; a server too old to send them
+ * yields an empty identity the caller reports as unknown.
+ */
+export const fetchMachineIdentity = async ({
+  serverUrl,
+  token,
+}: {
+  serverUrl: string;
+  token: string;
+}): Promise<Result<MachineIdentity, McpClientError>> => {
+  const body: JsonRpcRequest = {
+    jsonrpc: "2.0",
+    id: 1,
+    method: "tools/list",
+    params: {},
+  };
+  const response = await Result.tryPromise({
+    try: async () =>
+      await fetch(mcpUrl(serverUrl), {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "application/json, text/event-stream",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify(body),
+        signal: AbortSignal.timeout(LIST_REQUEST_TIMEOUT_MS),
+      }),
+    catch: (cause) => cause,
+  });
+  if (Result.isError(response)) {
+    return Result.err(
+      new McpClientError({
+        kind: "transport",
+        message: `Request to the MCP server failed: ${
+          response.error instanceof Error
+            ? response.error.message
+            : "network error"
+        }`,
+      }),
+    );
+  }
+  const httpResponse = response.value;
+  if (!httpResponse.ok) {
+    return Result.err(
+      new McpClientError({
+        kind: "http",
+        httpStatus: httpResponse.status,
+        message: `MCP server returned HTTP ${httpResponse.status}`,
+      }),
+    );
+  }
+  const scopesHeader = httpResponse.headers.get(STELLA_SCOPES_HEADER);
+  return Result.ok({
+    organizationId: httpResponse.headers.get(STELLA_ORGANIZATION_HEADER) ?? "",
+    scopes:
+      scopesHeader && scopesHeader.length > 0 ? scopesHeader.split(/\s+/u) : [],
+  });
+};
+
 /** Enumerate the server's static resources via `resources/list`. */
 export const listResources = async ({
   serverUrl,

--- a/packages/cli/src/run-capability-command.test.ts
+++ b/packages/cli/src/run-capability-command.test.ts
@@ -293,11 +293,41 @@ describe("runCapabilityCommand: flag -> invoke_capability payload", () => {
     expect(server.calls).toHaveLength(0);
   });
 
-  test("--input is exclusive with value flags", async () => {
+  test("value flags COMPOSE with --input; the explicit flag wins over its path", async () => {
     const server = startServer({ kind: "echo" });
     const spec = capSpec({
-      capabilityId: "a.b",
-      flags: [stringFlag("--name", "body", "name")],
+      capabilityId: "uploads.create",
+      flags: [stringFlag("--workspace", "params", "workspaceId", true)],
+    });
+    const tty = makeTtyContext({
+      serverUrl: server.url,
+      stdinData: "",
+      isTTY: false,
+    });
+    // The body rides --input; the required --workspace flag overlays
+    // params.workspaceId (and overrides the stale id present in the JSON).
+    await runCapabilityCommand({
+      context: tty.context,
+      flags: {
+        input:
+          '{"body":{"purpose":"agent_skill"},"params":{"workspaceId":"stale"}}',
+        workspace: "ws-1",
+      },
+      spec,
+    });
+    server.stop();
+    expect(tty.exitCode()).toBeUndefined();
+    expect(lastInvoke(server.calls)["input"]).toEqual({
+      body: { purpose: "agent_skill" },
+      params: { workspaceId: "ws-1" },
+    });
+  });
+
+  test("a required flag supplied only via --input's path is accepted", async () => {
+    const server = startServer({ kind: "echo" });
+    const spec = capSpec({
+      capabilityId: "uploads.create",
+      flags: [stringFlag("--workspace", "params", "workspaceId", true)],
     });
     const tty = makeTtyContext({
       serverUrl: server.url,
@@ -306,12 +336,36 @@ describe("runCapabilityCommand: flag -> invoke_capability payload", () => {
     });
     await runCapabilityCommand({
       context: tty.context,
-      flags: { input: "{}", name: "x" },
+      flags: { input: '{"params":{"workspaceId":"ws-9"}}' },
+      spec,
+    });
+    server.stop();
+    expect(tty.exitCode()).toBeUndefined();
+    expect(lastInvoke(server.calls)["input"]).toEqual({
+      params: { workspaceId: "ws-9" },
+    });
+  });
+
+  test("a required flag absent from both flags and --input still errors (exit 2, no call)", async () => {
+    const server = startServer({ kind: "echo" });
+    const spec = capSpec({
+      capabilityId: "uploads.create",
+      flags: [stringFlag("--workspace", "params", "workspaceId", true)],
+    });
+    const tty = makeTtyContext({
+      serverUrl: server.url,
+      stdinData: "",
+      isTTY: false,
+    });
+    await runCapabilityCommand({
+      context: tty.context,
+      flags: { input: '{"body":{"purpose":"agent_skill"}}' },
       spec,
     });
     server.stop();
     expect(tty.exitCode()).toBe(EXIT_CODES.validation);
-    expect(tty.stderrText()).toContain("exclusive");
+    expect(server.calls).toHaveLength(0);
+    expect(tty.stderrText()).toContain("--workspace");
   });
 });
 

--- a/packages/cli/src/run-capability-command.test.ts
+++ b/packages/cli/src/run-capability-command.test.ts
@@ -346,6 +346,47 @@ describe("runCapabilityCommand: flag -> invoke_capability payload", () => {
     });
   });
 
+  test("a required schema path absent from --input but supplied by its flag is accepted (validation runs after overlay)", async () => {
+    const server = startServer({ kind: "echo" });
+    // A synthetic-required workspaceId plus a body-borne required field: the
+    // exact shape (e.g. view-templates.delete) where validating the RAW --input
+    // would reject params.workspaceId before --workspace overlays it.
+    const spec = capSpec({
+      capabilityId: "view-templates.delete",
+      flags: [stringFlag("--workspace", "params", "workspaceId", true)],
+      inputSchema: {
+        type: "object",
+        additionalProperties: false,
+        properties: {
+          params: {
+            type: "object",
+            additionalProperties: false,
+            required: ["workspaceId", "templateId"],
+            properties: {
+              workspaceId: { type: "string" },
+              templateId: { type: "string" },
+            },
+          },
+        },
+      },
+    });
+    const tty = makeTtyContext({
+      serverUrl: server.url,
+      stdinData: "",
+      isTTY: false,
+    });
+    await runCapabilityCommand({
+      context: tty.context,
+      flags: { input: '{"params":{"templateId":"t1"}}', workspace: "ws-1" },
+      spec,
+    });
+    server.stop();
+    expect(tty.exitCode()).toBeUndefined();
+    expect(lastInvoke(server.calls)["input"]).toEqual({
+      params: { workspaceId: "ws-1", templateId: "t1" },
+    });
+  });
+
   test("a required flag absent from both flags and --input still errors (exit 2, no call)", async () => {
     const server = startServer({ kind: "echo" });
     const spec = capSpec({

--- a/packages/cli/src/run-capability-command.ts
+++ b/packages/cli/src/run-capability-command.ts
@@ -94,11 +94,9 @@ const buildInputFromFlags = async (
 /** Resolve `--input` (`-` stdin / `@file` / literal) to the parsed input object. */
 const buildInputFromRaw = async ({
   inputRaw,
-  spec,
   writers,
 }: {
   inputRaw: string;
-  spec: CapabilityLeafSpec;
   writers: Writers;
 }): Promise<Record<string, unknown> | undefined> => {
   let jsonText: string;
@@ -127,17 +125,11 @@ const buildInputFromRaw = async ({
     writers.stderr("--input must be a JSON object.\n");
     return undefined;
   }
-  // Truncated entries carry no snapshot schema: skip client validation and let
-  // the server validate against the live handler schema.
-  if (!spec.schemaTruncated && spec.inputSchema !== undefined) {
-    const validation = validateAgainstSchema(spec.inputSchema, parsed.value);
-    if (!validation.valid) {
-      writers.stderr(
-        `--input invalid at ${validation.path}: ${validation.message}\n`,
-      );
-      return undefined;
-    }
-  }
+  // Parse only: schema validation runs on the COMPOSED input (after value flags
+  // overlay their paths), never on the raw `--input` alone. Validating here would
+  // reject a `--input` that legitimately omits a required flag-backed path (e.g.
+  // the synthetic `params.workspaceId` supplied by `--workspace`), defeating the
+  // compose semantics for exactly the required flags they target.
   return parsed.value;
 };
 
@@ -318,7 +310,7 @@ export const runCapabilityCommand = async ({
   const inputRaw = flags[RESERVED_FLAG_KEYS.input];
   const inputBase =
     typeof inputRaw === "string"
-      ? await buildInputFromRaw({ inputRaw, spec, writers })
+      ? await buildInputFromRaw({ inputRaw, writers })
       : {};
   if (inputBase === undefined) {
     setExit(context, EXIT_CODES.validation);
@@ -331,6 +323,25 @@ export const runCapabilityCommand = async ({
     return;
   }
   const input = built.input;
+
+  // Validate the COMPOSED input (JSON base + overlaid flags) against the snapshot
+  // schema, only when `--input` supplied JSON. Flags-only requests keep relying on
+  // the required-flag check plus server validation (unchanged surface); truncated
+  // entries carry no snapshot schema and defer to the server.
+  if (
+    typeof inputRaw === "string" &&
+    !spec.schemaTruncated &&
+    spec.inputSchema !== undefined
+  ) {
+    const validation = validateAgainstSchema(spec.inputSchema, input);
+    if (!validation.valid) {
+      writers.stderr(
+        `--input invalid at ${validation.path}: ${validation.message}\n`,
+      );
+      setExit(context, EXIT_CODES.validation);
+      return;
+    }
+  }
 
   // Client-side scope precheck (spec S3): fail before any server call.
   if (spec.scope !== undefined && !scopeGranted({ token, scope: spec.scope })) {

--- a/packages/cli/src/run-capability-command.ts
+++ b/packages/cli/src/run-capability-command.ts
@@ -25,6 +25,7 @@ import {
   confirmDestructive,
   errorEnvelope,
   flagKey,
+  hasInputPath,
   mapClientErrorExit,
   parsePayload,
   readAllStdin,
@@ -53,12 +54,20 @@ type InputResult =
   | { ok: true; input: Record<string, unknown> }
   | { ok: false; message: string };
 
-/** Build the `{ body?, params?, query? }` input object from parsed value flags. */
+/**
+ * Overlay parsed value flags onto `base` (the `{ body?, params?, query? }`
+ * object built from `--input`, or `{}` when no `--input` was given). Each SET
+ * flag is coerced and written at its known input path (`${part}.${partPath}` —
+ * the same mapping the flag would use on its own), so an explicit flag WINS over
+ * the same path in the JSON. A required flag is satisfied either by being set or
+ * by already being present in `base`, so `--input` can carry it.
+ */
 const buildInputFromFlags = async (
   spec: CapabilityLeafSpec,
   flags: LeafFlags,
+  base: Record<string, unknown> = {},
 ): Promise<InputResult> => {
-  const input: Record<string, unknown> = {};
+  const input = base;
   for (const flagSpec of spec.flags) {
     const value = flags[flagKey(flagSpec)];
     if (value === undefined) {
@@ -72,7 +81,10 @@ const buildInputFromFlags = async (
     setPath(input, `${flagSpec.part}.${flagSpec.partPath}`, coerced.value);
   }
   for (const flagSpec of spec.flags) {
-    if (flagSpec.required && flags[flagKey(flagSpec)] === undefined) {
+    if (
+      flagSpec.required &&
+      !hasInputPath(input, `${flagSpec.part}.${flagSpec.partPath}`)
+    ) {
       return { ok: false, message: `missing required flag ${flagSpec.flag}` };
     }
   }
@@ -298,32 +310,27 @@ export const runCapabilityCommand = async ({
     return;
   }
 
+  // `--input` and value flags COMPOSE: the JSON is the base, then each explicit
+  // flag overlays its own input path on top (flag wins). A required value flag
+  // (e.g. --workspace) advertised on the usage line therefore stays usable
+  // alongside a body passed through --input, instead of forcing the caller to
+  // hand-relocate it into `params.workspaceId` in the JSON.
   const inputRaw = flags[RESERVED_FLAG_KEYS.input];
-  let input: Record<string, unknown>;
-  if (typeof inputRaw === "string") {
-    const conflicting = spec.flags.some(
-      (flagSpec) => flags[flagKey(flagSpec)] !== undefined,
-    );
-    if (conflicting) {
-      writers.stderr("--input is exclusive with per-capability value flags.\n");
-      setExit(context, EXIT_CODES.validation);
-      return;
-    }
-    const parsed = await buildInputFromRaw({ inputRaw, spec, writers });
-    if (parsed === undefined) {
-      setExit(context, EXIT_CODES.validation);
-      return;
-    }
-    input = parsed;
-  } else {
-    const built = await buildInputFromFlags(spec, flags);
-    if (!built.ok) {
-      writers.stderr(`${built.message}\n`);
-      setExit(context, EXIT_CODES.validation);
-      return;
-    }
-    input = built.input;
+  const inputBase =
+    typeof inputRaw === "string"
+      ? await buildInputFromRaw({ inputRaw, spec, writers })
+      : {};
+  if (inputBase === undefined) {
+    setExit(context, EXIT_CODES.validation);
+    return;
   }
+  const built = await buildInputFromFlags(spec, flags, inputBase);
+  if (!built.ok) {
+    writers.stderr(`${built.message}\n`);
+    setExit(context, EXIT_CODES.validation);
+    return;
+  }
+  const input = built.input;
 
   // Client-side scope precheck (spec S3): fail before any server call.
   if (spec.scope !== undefined && !scopeGranted({ token, scope: spec.scope })) {

--- a/packages/cli/src/run-leaf-command.test.ts
+++ b/packages/cli/src/run-leaf-command.test.ts
@@ -388,6 +388,56 @@ const makeTtyContext = ({
   };
 };
 
+describe("--input composes with flags before schema validation (S5.5)", () => {
+  // Same class as the capability executor: the schema marks `matter_id`
+  // required; --input omits it and the --matter-id flag supplies it. Validating
+  // the RAW --input would reject it at `matter_id` before the flag overlays the
+  // value, defeating compose for required flag-backed fields.
+  const REQUIRED_FLAG_SPEC: LeafCommandSpec = {
+    commandPath: ["matter", "delete"],
+    toolName: "matter_delete",
+    flags: [
+      {
+        flag: "--matter-id",
+        prop: "matter_id",
+        kind: "string",
+        required: true,
+        repeatable: false,
+      },
+    ],
+    inputOnly: [],
+    paginated: false,
+    windowedText: false,
+    destructive: false,
+    inputSchema: {
+      type: "object",
+      properties: {
+        matter_id: { type: "string" },
+        confirm: { type: "boolean" },
+      },
+      required: ["matter_id"],
+    },
+  };
+
+  test("a required flag-backed path absent from --input but supplied by its flag is accepted", async () => {
+    const server = startConfirmGateServer();
+    const tty = makeTtyContext({
+      serverUrl: server.url,
+      stdinData: "",
+      isTTY: false,
+    });
+    await runLeafCommand({
+      context: tty.context,
+      flags: { input: '{"confirm":true}', matterId: "m1" },
+      spec: REQUIRED_FLAG_SPEC,
+    });
+    server.stop();
+    expect(tty.exitCode()).toBeUndefined();
+    expect(server.calls).toHaveLength(1);
+    expect(server.calls[0]?.args).toEqual({ confirm: true, matter_id: "m1" });
+  });
+});
+
 describe("confirm passthrough (capability invoke)", () => {
   test("--yes injects confirm: true upfront (single call)", async () => {
     const server = startConfirmGateServer();

--- a/packages/cli/src/run-leaf-command.test.ts
+++ b/packages/cli/src/run-leaf-command.test.ts
@@ -136,6 +136,29 @@ describe("buildArgsFromFlags (S3)", () => {
     const result = await buildArgsFromFlags(spec, { name: "@@handle" });
     expect(result).toEqual({ ok: true, args: { name: "@handle" } });
   });
+
+  test("flags overlay onto a --input base; an explicit flag wins over the same path", async () => {
+    const spec = specWith([stringFlag("name")]);
+    const base = { name: "fromJson", keep: 1 };
+    const result = await buildArgsFromFlags(spec, { name: "fromFlag" }, base);
+    // The flag overrides the JSON's `name`; the JSON's other keys survive.
+    expect(result).toEqual({ ok: true, args: { name: "fromFlag", keep: 1 } });
+  });
+
+  test("a required flag is satisfied by the --input base when the flag is unset", async () => {
+    const spec = specWith([stringFlag("matter_id", true)]);
+    const result = await buildArgsFromFlags(spec, {}, { matter_id: "m1" });
+    expect(result).toEqual({ ok: true, args: { matter_id: "m1" } });
+  });
+
+  test("a required flag absent from both flags and the --input base still errors", async () => {
+    const spec = specWith([stringFlag("matter_id", true)]);
+    const result = await buildArgsFromFlags(spec, {}, { other: "x" });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toContain("--matter-id");
+    }
+  });
 });
 
 describe("classifyToolError: structured envelope -> exit map (S4)", () => {

--- a/packages/cli/src/run-leaf-command.ts
+++ b/packages/cli/src/run-leaf-command.ts
@@ -145,6 +145,27 @@ export const setPath = (
   node[segments.at(-1) ?? path] = value;
 };
 
+/**
+ * True when `path` (dot form, e.g. `body.workspaceId`) already resolves to a
+ * defined value inside `target`. Used to decide whether a required flag is
+ * satisfied by the `--input` JSON when the flag itself is unset (the flag and
+ * the JSON compose; see `runLeafCommand`/`runCapabilityCommand`).
+ */
+export const hasInputPath = (
+  target: Record<string, unknown>,
+  path: string,
+): boolean => {
+  const segments = path.split(".");
+  let node: unknown = target;
+  for (const segment of segments) {
+    if (!isRecord(node)) {
+      return false;
+    }
+    node = node[segment];
+  }
+  return node !== undefined;
+};
+
 type ArgsResult =
   | { ok: true; args: Record<string, unknown> }
   | { ok: false; message: string };
@@ -271,12 +292,19 @@ export const coerceFlagValue = async (
   return Result.ok(raw);
 };
 
-/** Build the tool-args object from parsed value flags (spec S3). Exported for tests. */
+/**
+ * Overlay parsed value flags onto `base` (spec S3). `base` is the args object
+ * built from `--input` (or `{}` when no `--input` was given): each SET flag is
+ * coerced and written at its `prop` path, so an explicit flag WINS over the same
+ * path in the JSON. A required flag is satisfied either by being set or by
+ * already being present in `base`, so `--input` can carry it. Exported for tests.
+ */
 export const buildArgsFromFlags = async (
   spec: LeafCommandSpec,
   flags: LeafFlags,
+  base: Record<string, unknown> = {},
 ): Promise<ArgsResult> => {
-  const args: Record<string, unknown> = {};
+  const args = base;
 
   for (const flagSpec of spec.flags) {
     const value = flags[flagKey(flagSpec)];
@@ -291,9 +319,10 @@ export const buildArgsFromFlags = async (
     setPath(args, flagSpec.prop, coerced.value);
   }
 
-  // Enforce required flags (spec S3): missing -> usage error (exit 2 upstream).
+  // Enforce required flags (spec S3): unset AND absent from `--input` -> usage
+  // error (exit 2 upstream), naming the missing flag.
   for (const flagSpec of spec.flags) {
-    if (flagSpec.required && flags[flagKey(flagSpec)] === undefined) {
+    if (flagSpec.required && !hasInputPath(args, flagSpec.prop)) {
       return { ok: false, message: `missing required flag ${flagSpec.flag}` };
     }
   }
@@ -952,32 +981,27 @@ export const runLeafCommand = async ({
     return;
   }
 
+  // `--input` and value flags COMPOSE: the JSON is the base, then each explicit
+  // flag overlays its own path on top (flag wins). This lets a required value
+  // flag (e.g. --workspace, advertised on the usage line) coexist with a body
+  // passed through --input, instead of forcing the caller to hand-relocate it
+  // into the JSON under a different key.
   const inputRaw = flags[RESERVED_FLAG_KEYS.input];
-  let args: Record<string, unknown>;
-  if (typeof inputRaw === "string") {
-    const conflicting = spec.flags.some(
-      (flagSpec) => flags[flagKey(flagSpec)] !== undefined,
-    );
-    if (conflicting) {
-      writers.stderr("--input is exclusive with per-tool value flags.\n");
-      setExit(context, EXIT_CODES.validation);
-      return;
-    }
-    const parsed = await buildArgsFromInput({ inputRaw, spec, writers });
-    if (parsed === undefined) {
-      setExit(context, EXIT_CODES.validation);
-      return;
-    }
-    args = parsed;
-  } else {
-    const built = await buildArgsFromFlags(spec, flags);
-    if (!built.ok) {
-      writers.stderr(`${built.message}\n`);
-      setExit(context, EXIT_CODES.validation);
-      return;
-    }
-    args = built.args;
+  const argsBase =
+    typeof inputRaw === "string"
+      ? await buildArgsFromInput({ inputRaw, spec, writers })
+      : {};
+  if (argsBase === undefined) {
+    setExit(context, EXIT_CODES.validation);
+    return;
   }
+  const built = await buildArgsFromFlags(spec, flags, argsBase);
+  if (!built.ok) {
+    writers.stderr(`${built.message}\n`);
+    setExit(context, EXIT_CODES.validation);
+    return;
+  }
+  let args = built.args;
 
   if (spec.discriminatorInject !== undefined) {
     args = { ...args, ...spec.discriminatorInject };

--- a/packages/cli/src/run-leaf-command.ts
+++ b/packages/cli/src/run-leaf-command.ts
@@ -332,11 +332,9 @@ export const buildArgsFromFlags = async (
 
 const buildArgsFromInput = async ({
   inputRaw,
-  spec,
   writers,
 }: {
   inputRaw: string;
-  spec: LeafCommandSpec;
   writers: Writers;
 }): Promise<Record<string, unknown> | undefined> => {
   let jsonText: string;
@@ -365,14 +363,10 @@ const buildArgsFromInput = async ({
     writers.stderr("--input must be a JSON object.\n");
     return undefined;
   }
-
-  const validation = validateAgainstSchema(spec.inputSchema, parsed.value);
-  if (!validation.valid) {
-    writers.stderr(
-      `--input invalid at ${validation.path}: ${validation.message}\n`,
-    );
-    return undefined;
-  }
+  // Parse only: schema validation runs on the COMPOSED args (after value flags
+  // overlay their paths), never on the raw `--input` alone. Validating here would
+  // reject a `--input` that legitimately omits a required flag-backed path (e.g.
+  // a `matter_id` supplied by `--matter-id`), defeating the compose semantics.
   return parsed.value;
 };
 
@@ -989,7 +983,7 @@ export const runLeafCommand = async ({
   const inputRaw = flags[RESERVED_FLAG_KEYS.input];
   const argsBase =
     typeof inputRaw === "string"
-      ? await buildArgsFromInput({ inputRaw, spec, writers })
+      ? await buildArgsFromInput({ inputRaw, writers })
       : {};
   if (argsBase === undefined) {
     setExit(context, EXIT_CODES.validation);
@@ -1005,6 +999,21 @@ export const runLeafCommand = async ({
 
   if (spec.discriminatorInject !== undefined) {
     args = { ...args, ...spec.discriminatorInject };
+  }
+
+  // Validate the COMPOSED args (JSON base + overlaid flags + injected
+  // discriminator) against the schema, only when `--input` supplied JSON.
+  // Flags-only requests keep relying on the required-flag check plus server
+  // validation (unchanged surface).
+  if (typeof inputRaw === "string") {
+    const validation = validateAgainstSchema(spec.inputSchema, args);
+    if (!validation.valid) {
+      writers.stderr(
+        `--input invalid at ${validation.path}: ${validation.message}\n`,
+      );
+      setExit(context, EXIT_CODES.validation);
+      return;
+    }
   }
 
   // Client-side scope precheck (spec S3): fail before any server call.


### PR DESCRIPTION
## Why

A differential usability probe drove the generated capability CLI with agents from strong to weak (opus down to haiku). Three sharp failure cliffs turned up where a capable agent muddled through but a weaker one got permanently stuck. Each is fixed here, and each ships with a structural guard so the *class* of bug is caught next time rather than the single instance.

## Fixes

**1. `--input` and value flags now compose instead of colliding.** Previously, passing `--input '<json>'` alongside any value flag hard-errored `--input is exclusive with per-capability value flags`. But a capability body must go through `--input`, so a required flag like `--workspace` (advertised on the usage line) became unusable — the caller had to relocate the value into the JSON under a different key (`--workspace` → `params.workspaceId`), discoverable only by trial-and-error against validation errors. Now the `--input` JSON is the base and each explicit flag overlays its own input path on top (flag wins), so `uploads create --workspace <id> --input '{"body":{...}}'` works. Required-flag enforcement still fires when a flag is unset *and* absent from `--input`.

**2. Discriminated-union validation errors name the field.** A wrong upload body returned one opaque, path-less `body: Expected union value`. It now reports `body.purpose: expected one of "entity_create" | "entity_version" | "agent_skill"` when the discriminator is missing or wrong, and drills into the matched variant's own missing/invalid fields once `purpose` matches.

**3. `auth whoami` verifies a machine key server-side.** For a `STELLA_API_KEY` it previously echoed three static lines and exited 0 without any network call — identical output for a valid or a dead key. It now makes a real authenticated round-trip and reports the server-resolved organization and granted scopes, or fails clearly on a rejected key. The authenticated caller's own org/scopes are echoed on two response headers (returned only to that caller).

## Guards (each proven to fire, then restored)

- **Fix 1:** a codegen invariant test asserts every generated value flag's target path resolves to a real path in its capability's input schema — flag/JSON-key drift fails CI; plus compose + required-still-enforced tests in both executors.
- **Fix 2:** an invariant test that *every* capability-input validation issue carries a non-empty field path, driven by malformed union bodies — a regression to path-less messages fails CI.
- **Fix 3:** a test that the machine-key path makes a real request and reports org+scopes on a valid key, and errors (not a static echo) on a 401.

## Verification

CLI `bun test` 368 pass / 0 fail; scoped API `bun test` (mcp) 88 pass / 0 fail; scoped API typecheck + type-aware lint clean; `oxfmt` applied. No generated catalog/registry/route-map regenerated (changes are runtime arg-handling, error messages, and help text). Fix 1 (compose) and Fix 3's round-trip + rejection were verified live against a dev server with a machine key; Fix 2's message and Fix 3's org/scope reporting are server-side changes covered by unit tests.
