### PR TITLE
refactor: share API error normalization

### DIFF
--- a/apps/web/src/lib/errors/api.ts
+++ b/apps/web/src/lib/errors/api.ts
@@ -1,5 +1,8 @@
 import { TaggedError } from "better-result";
 
+import { normalizeApiError } from "@stll/api-contract";
+import type { ApiErrorInput } from "@stll/api-contract";
+
 import type { TranslationKey } from "@/i18n/types";
 import {
   STATUS_ERROR_KEYS,
@@ -15,23 +18,7 @@ export class APIError extends TaggedError("ApiError")<{
   details?: Record<string, unknown> | undefined;
 }>() {}
 
-export type ToAPIErrorProps = {
-  status: number;
-  value:
-    | string
-    | {
-        type: "validation";
-        on: string;
-        summary?: string;
-        message?: string;
-        found?: unknown;
-        property?: string;
-        expected?: string;
-      }
-    | { code?: string | undefined; type?: never; message: string }
-    | null
-    | undefined;
-};
+export type ToAPIErrorProps = ApiErrorInput;
 
 type EdenResponse<T> =
   | { data: T; error: null }
@@ -52,37 +39,17 @@ export function unwrapEden<T>(response: EdenResponse<T>): T {
   return response.data;
 }
 
-export const toAPIError = ({ status, value }: ToAPIErrorProps) => {
-  if (value === null || value === undefined) {
-    return new APIError({ message: localizeAPIError({ status }), status });
-  }
-  if (typeof value === "string") {
-    return new APIError({
-      message: localizeAPIError({ status }),
-      rawMessage: value,
-      status,
-    });
-  }
-  if (value.type === "validation") {
-    return new APIError({
-      code: API_ERROR_CODE.validation,
-      message: localizeAPIError({ code: API_ERROR_CODE.validation, status }),
-      rawMessage: JSON.stringify(value),
-      status,
-    });
-  }
-
-  const details = pickDetails(value);
+export const toAPIError = (input: ToAPIErrorProps) => {
+  const { code, details, rawMessage, status } = normalizeApiError(input);
   return new APIError({
-    ...(value.code ? { code: value.code } : {}),
+    ...(code === undefined ? {} : { code }),
+    ...(details === undefined ? {} : { details }),
+    ...(rawMessage === undefined ? {} : { rawMessage }),
     status,
-    message: localizeAPIError({ code: value.code, details, status }),
-    rawMessage: value.message,
-    ...(details ? { details } : {}),
+    message: localizeAPIError({ code, details, status }),
   });
 };
 
-const API_ERROR_CODE = { validation: "validation" } as const;
 const RAW_INTERNAL_TOOL_ERROR_CODE = {
   legalSourceStructuralRepairRequired:
     "legal_source_structural_repair_required",
@@ -164,14 +131,4 @@ const localizeAPIError = ({ code, details, status }: LocalizeAPIErrorInput) => {
     return translateError(USAGE_REJECTION_REASON_KEYS[details["reason"]]);
   }
   return translateError(STATUS_TO_KEY[status] ?? STATUS_ERROR_KEYS.unknown);
-};
-
-const KNOWN_TEXT_KEYS: readonly string[] = Object.freeze(["message", "code"]);
-const pickDetails = (
-  value: { message: string } & Record<string, unknown>,
-): Record<string, unknown> | undefined => {
-  const entries = Object.entries(value).filter(
-    ([key]) => !KNOWN_TEXT_KEYS.includes(key),
-  );
-  return entries.length === 0 ? undefined : Object.fromEntries(entries);
 };

--- a/packages/api-contract/src/error.test.ts
+++ b/packages/api-contract/src/error.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "bun:test";
+
+import { API_VALIDATION_ERROR_CODE, normalizeApiError } from "./error";
+
+describe("normalizeApiError", () => {
+  test("keeps an empty response status-only", () => {
+    expect(normalizeApiError({ status: 502, value: null })).toEqual({
+      status: 502,
+    });
+  });
+
+  test("preserves a string response as the raw message", () => {
+    expect(normalizeApiError({ status: 400, value: "Bad request" })).toEqual({
+      rawMessage: "Bad request",
+      status: 400,
+    });
+  });
+
+  test("classifies and serializes validation responses", () => {
+    expect(
+      normalizeApiError({
+        status: 422,
+        value: {
+          on: "body",
+          summary: "Invalid request",
+          type: "validation",
+        },
+      }),
+    ).toEqual({
+      code: API_VALIDATION_ERROR_CODE,
+      rawMessage:
+        '{"on":"body","summary":"Invalid request","type":"validation"}',
+      status: 422,
+    });
+  });
+
+  test("separates object codes, messages, and structured details", () => {
+    expect(
+      normalizeApiError({
+        status: 402,
+        value: {
+          code: "usage_limit_exceeded",
+          message: "Usage limit exceeded",
+          reason: "no_entitlement",
+        },
+      }),
+    ).toEqual({
+      code: "usage_limit_exceeded",
+      details: { reason: "no_entitlement" },
+      rawMessage: "Usage limit exceeded",
+      status: 402,
+    });
+  });
+});

--- a/packages/api-contract/src/error.test.ts
+++ b/packages/api-contract/src/error.test.ts
@@ -7,6 +7,9 @@ describe("normalizeApiError", () => {
     expect(normalizeApiError({ status: 502, value: null })).toEqual({
       status: 502,
     });
+    expect(normalizeApiError({ status: 502, value: undefined })).toEqual({
+      status: 502,
+    });
   });
 
   test("preserves a string response as the raw message", () => {

--- a/packages/api-contract/src/error.ts
+++ b/packages/api-contract/src/error.ts
@@ -1,0 +1,75 @@
+export const API_VALIDATION_ERROR_CODE = "validation" as const;
+
+export type ApiValidationErrorValue = {
+  expected?: string;
+  found?: unknown;
+  message?: string;
+  on: string;
+  property?: string;
+  summary?: string;
+  type: "validation";
+};
+
+export type ApiErrorObjectValue = {
+  code?: string | undefined;
+  message: string;
+  type?: never;
+} & Record<string, unknown>;
+
+export type ApiErrorValue =
+  | ApiErrorObjectValue
+  | ApiValidationErrorValue
+  | string
+  | null
+  | undefined;
+
+export type ApiErrorInput = {
+  status: number;
+  value: ApiErrorValue;
+};
+
+export type NormalizedApiError = {
+  code?: string;
+  details?: Record<string, unknown>;
+  rawMessage?: string;
+  status: number;
+};
+
+const ERROR_TEXT_KEYS = new Set(["code", "message"]);
+
+const pickErrorDetails = (
+  value: ApiErrorObjectValue,
+): Record<string, unknown> | undefined => {
+  const entries = Object.entries(value).filter(
+    ([key]) => !ERROR_TEXT_KEYS.has(key),
+  );
+  return entries.length === 0 ? undefined : Object.fromEntries(entries);
+};
+
+/** Normalizes transport errors without applying client-specific presentation. */
+export const normalizeApiError = ({
+  status,
+  value,
+}: ApiErrorInput): NormalizedApiError => {
+  if (value === null || value === undefined) {
+    return { status };
+  }
+  if (typeof value === "string") {
+    return { rawMessage: value, status };
+  }
+  if (value.type === "validation") {
+    return {
+      code: API_VALIDATION_ERROR_CODE,
+      rawMessage: JSON.stringify(value),
+      status,
+    };
+  }
+
+  const details = pickErrorDetails(value);
+  return {
+    ...(value.code === undefined ? {} : { code: value.code }),
+    ...(details === undefined ? {} : { details }),
+    rawMessage: value.message,
+    status,
+  };
+};

--- a/packages/api-contract/src/error.ts
+++ b/packages/api-contract/src/error.ts
@@ -7,7 +7,7 @@ export type ApiValidationErrorValue = {
   on: string;
   property?: string;
   summary?: string;
-  type: "validation";
+  type: typeof API_VALIDATION_ERROR_CODE;
 };
 
 export type ApiErrorObjectValue = {
@@ -57,7 +57,7 @@ export const normalizeApiError = ({
   if (typeof value === "string") {
     return { rawMessage: value, status };
   }
-  if (value.type === "validation") {
+  if (value.type === API_VALIDATION_ERROR_CODE) {
     return {
       code: API_VALIDATION_ERROR_CODE,
       rawMessage: JSON.stringify(value),

--- a/packages/api-contract/src/index.ts
+++ b/packages/api-contract/src/index.ts
@@ -3,6 +3,14 @@ export const STELLA_REST_API_CONTRACT_VERSION = 1 as const;
 
 export { CHAT_TOOL_SCOPE } from "./chat";
 export type { ChatSendRequest, SafeId } from "./chat";
+export { API_VALIDATION_ERROR_CODE, normalizeApiError } from "./error";
+export type {
+  ApiErrorInput,
+  ApiErrorObjectValue,
+  ApiErrorValue,
+  ApiValidationErrorValue,
+  NormalizedApiError,
+} from "./error";
 
 /** Path prefix shared by the REST router and direct-fetch clients. */
 export const STELLA_API_VERSION_PREFIX = "/v1" as const;


### PR DESCRIPTION
## Summary

- normalize HTTP and Eden error payloads in @stll/api-contract
- keep presentation and localization in the web adapter
- preserve raw messages and structured details with exact optional semantics

## Validation

- bun --filter @stll/api-contract typecheck
- bun --filter @stll/api-contract lint
- bun --filter @stll/api-contract test
- VITE_API_URL=http://localhost:3001 bun test apps/web/src/lib/errors/index.test.ts
- bun packages/scripts/src/tsc-native.ts --noEmit -p apps/web --pretty false
- pre-push affected-workspace formatting, localization, and typecheck gates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved API error normalisation for null/undefined, text messages, validation-shaped errors, and structured error objects.
  * Added shared exported utilities and types to keep error shapes consistent across the app.

* **Bug Fixes**
  * Updated error conversion to preserve message/details consistently and to localise output reliably.

* **Tests**
  * Added Bun test coverage for API error normalisation behaviours, including edge cases like `value: undefined`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->