### PR TITLE
feat(ui): add organization switcher in sidebar user menu

### DIFF
--- a/apps/web/src/components/sidebar-user-menu.tsx
+++ b/apps/web/src/components/sidebar-user-menu.tsx
@@ -301,13 +301,6 @@ function OrganizationMenuSection({
         });
 
         if (error) {
-          stellaToast.add({
-            title: userErrorFromThrown(
-              toAuthClientError(error),
-              t("errors.actionFailed"),
-            ),
-            type: "error",
-          });
           throw toAuthClientError(error);
         }
 
@@ -315,6 +308,10 @@ function OrganizationMenuSection({
         await navigate({ to: "/", replace: true });
       },
       onError: (error) => {
+        stellaToast.add({
+          title: userErrorFromThrown(error, t("errors.actionFailed")),
+          type: "error",
+        });
         analytics.captureError(error);
       },
     });

--- a/apps/web/src/components/sidebar-user-menu.tsx
+++ b/apps/web/src/components/sidebar-user-menu.tsx
@@ -1,5 +1,7 @@
+import { useMutation } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
 import {
+  BuildingIcon,
   ChevronsUpDownIcon,
   GlobeIcon,
   LogOutIcon,
@@ -30,6 +32,7 @@ import {
   MenuSubTrigger,
   MenuTrigger,
 } from "@stll/ui/components/menu";
+import { stellaToast } from "@stll/ui/components/toast";
 import { cn } from "@stll/ui/lib/utils";
 
 import { DevSidebarGroup } from "@/components/dev-sidebar-group";
@@ -37,13 +40,18 @@ import { SidebarMenuItem, useSidebar } from "@/components/sidebar";
 import { PALETTES, THEMES, useTheme } from "@/components/theme-provider";
 import Tooltip from "@/components/tooltip";
 import { useChromeQuery } from "@/hooks/use-chrome-query";
+import { useInvalidateSession } from "@/hooks/use-invalidate-session";
 import { useSignOut } from "@/hooks/use-sign-out";
 import {
   LANG_ENDONYMS,
   supportedLanguages,
   useI18nStore,
 } from "@/i18n/i18n-store";
+import { useAnalytics } from "@/lib/analytics/provider";
+import { authClient } from "@/lib/auth";
 import { detached } from "@/lib/detached";
+import { toAuthClientError } from "@/lib/errors/auth";
+import { userErrorFromThrown } from "@/lib/errors/user-safe";
 import { getInitials } from "@/lib/get-initials";
 import { roleOptions } from "@/routes/-queries";
 import { organizationSummaryOptions } from "@/routes/_protected.organization/-queries";
@@ -76,6 +84,34 @@ export function SidebarUserMenu({ user }: SidebarUserMenuProps) {
     organizationSummaryOptions(user.activeOrganizationId),
   );
   const { data: role } = useChromeQuery(roleOptions);
+  const { data: organizations } = authClient.useListOrganizations();
+  const invalidateSession = useInvalidateSession();
+  const analytics = useAnalytics();
+
+  const { isPending: isSwitchPending, mutate: switchOrg } = useMutation({
+    mutationFn: async (organizationId: string) => {
+      const { error } = await authClient.organization.setActive({
+        organizationId,
+      });
+
+      if (error) {
+        stellaToast.add({
+          title: userErrorFromThrown(
+            toAuthClientError(error),
+            t("errors.actionFailed"),
+          ),
+          type: "error",
+        });
+        throw toAuthClientError(error);
+      }
+
+      await invalidateSession.mutateAsync();
+      await navigate({ to: "/", replace: true });
+    },
+    onError: (error) => {
+      analytics.captureError(error);
+    },
+  });
 
   const displayName = user.name ?? user.email;
   const orgName = organization?.name;
@@ -153,18 +189,53 @@ export function SidebarUserMenu({ user }: SidebarUserMenuProps) {
         <MenuPopup align="end" className="w-56" side="top" sideOffset={8}>
           {orgName && (
             <>
-              <MenuGroup>
-                <MenuGroupLabel className="pb-1 text-sm">
-                  {orgName}
-                </MenuGroupLabel>
-                {role && (
-                  <div className="px-2 pb-1.5">
-                    <span className="bg-muted text-muted-foreground inline-flex items-center rounded-md px-1.5 py-0.5 text-[0.6875rem] font-medium select-none">
-                      {t(`organization.roles.${role}`)}
-                    </span>
-                  </div>
-                )}
-              </MenuGroup>
+              {organizations && organizations.length > 1 ? (
+                <MenuSub>
+                  <MenuSubTrigger>
+                    <BuildingIcon />
+                    {orgName}
+                  </MenuSubTrigger>
+                  <MenuSubPopup>
+                    <MenuGroup>
+                      <MenuGroupLabel>
+                        {t("organization.switchOrganization")}
+                      </MenuGroupLabel>
+                      <MenuRadioGroup value={user.activeOrganizationId}>
+                        {organizations.map((org) => (
+                          <MenuRadioItem
+                            key={org.id}
+                            disabled={
+                              isSwitchPending ||
+                              org.id === user.activeOrganizationId
+                            }
+                            onClick={() => {
+                              if (org.id !== user.activeOrganizationId) {
+                                switchOrg(org.id);
+                              }
+                            }}
+                            value={org.id}
+                          >
+                            {org.name}
+                          </MenuRadioItem>
+                        ))}
+                      </MenuRadioGroup>
+                    </MenuGroup>
+                  </MenuSubPopup>
+                </MenuSub>
+              ) : (
+                <MenuGroup>
+                  <MenuGroupLabel className="pb-1 text-sm">
+                    {orgName}
+                  </MenuGroupLabel>
+                </MenuGroup>
+              )}
+              {role && (
+                <div className="px-2 pb-1.5">
+                  <span className="bg-muted text-muted-foreground inline-flex items-center rounded-md px-1.5 py-0.5 text-[0.6875rem] font-medium select-none">
+                    {t(`organization.roles.${role}`)}
+                  </span>
+                </div>
+              )}
               <MenuSeparator />
             </>
           )}

--- a/apps/web/src/components/sidebar-user-menu.tsx
+++ b/apps/web/src/components/sidebar-user-menu.tsx
@@ -49,12 +49,13 @@ import {
 } from "@/i18n/i18n-store";
 import { useAnalytics } from "@/lib/analytics/provider";
 import { authClient } from "@/lib/auth";
+import type { Role } from "@/lib/auth";
 import { detached } from "@/lib/detached";
 import { toAuthClientError } from "@/lib/errors/auth";
 import { userErrorFromThrown } from "@/lib/errors/user-safe";
 import { getInitials } from "@/lib/get-initials";
 import { roleOptions } from "@/routes/-queries";
-import { organizationSummaryOptions } from "@/routes/_protected.organization/-queries";
+import { organizationListOptions } from "@/routes/_protected.organization/-queries";
 
 const CHANGELOG_URL = "https://stll.app/changelog";
 const isDev = import.meta.env.DEV;
@@ -80,41 +81,9 @@ export function SidebarUserMenu({ user }: SidebarUserMenuProps) {
   const { theme, setTheme, palette, setPalette } = useTheme();
   const lang = useI18nStore((s) => s.lang);
   const setLang = useI18nStore((s) => s.setLang);
-  const { data: organization } = useChromeQuery(
-    organizationSummaryOptions(user.activeOrganizationId),
-  );
   const { data: role } = useChromeQuery(roleOptions);
-  const { data: organizations } = authClient.useListOrganizations();
-  const invalidateSession = useInvalidateSession();
-  const analytics = useAnalytics();
-
-  const { isPending: isSwitchPending, mutate: switchOrg } = useMutation({
-    mutationFn: async (organizationId: string) => {
-      const { error } = await authClient.organization.setActive({
-        organizationId,
-      });
-
-      if (error) {
-        stellaToast.add({
-          title: userErrorFromThrown(
-            toAuthClientError(error),
-            t("errors.actionFailed"),
-          ),
-          type: "error",
-        });
-        throw toAuthClientError(error);
-      }
-
-      await invalidateSession.mutateAsync();
-      await navigate({ to: "/", replace: true });
-    },
-    onError: (error) => {
-      analytics.captureError(error);
-    },
-  });
 
   const displayName = user.name ?? user.email;
-  const orgName = organization?.name;
 
   return (
     <SidebarMenuItem>
@@ -187,58 +156,10 @@ export function SidebarUserMenu({ user }: SidebarUserMenuProps) {
           )}
         </Tooltip>
         <MenuPopup align="end" className="w-56" side="top" sideOffset={8}>
-          {orgName && (
-            <>
-              {organizations && organizations.length > 1 ? (
-                <MenuSub>
-                  <MenuSubTrigger>
-                    <BuildingIcon />
-                    {orgName}
-                  </MenuSubTrigger>
-                  <MenuSubPopup>
-                    <MenuGroup>
-                      <MenuGroupLabel>
-                        {t("organization.switchOrganization")}
-                      </MenuGroupLabel>
-                      <MenuRadioGroup value={user.activeOrganizationId}>
-                        {organizations.map((org) => (
-                          <MenuRadioItem
-                            key={org.id}
-                            disabled={
-                              isSwitchPending ||
-                              org.id === user.activeOrganizationId
-                            }
-                            onClick={() => {
-                              if (org.id !== user.activeOrganizationId) {
-                                switchOrg(org.id);
-                              }
-                            }}
-                            value={org.id}
-                          >
-                            {org.name}
-                          </MenuRadioItem>
-                        ))}
-                      </MenuRadioGroup>
-                    </MenuGroup>
-                  </MenuSubPopup>
-                </MenuSub>
-              ) : (
-                <MenuGroup>
-                  <MenuGroupLabel className="pb-1 text-sm">
-                    {orgName}
-                  </MenuGroupLabel>
-                </MenuGroup>
-              )}
-              {role && (
-                <div className="px-2 pb-1.5">
-                  <span className="bg-muted text-muted-foreground inline-flex items-center rounded-md px-1.5 py-0.5 text-[0.6875rem] font-medium select-none">
-                    {t(`organization.roles.${role}`)}
-                  </span>
-                </div>
-              )}
-              <MenuSeparator />
-            </>
-          )}
+          <OrganizationMenuSection
+            activeOrganizationId={user.activeOrganizationId}
+            role={role}
+          />
           <MenuItem
             onClick={() => {
               detached(
@@ -348,5 +269,138 @@ export function SidebarUserMenu({ user }: SidebarUserMenuProps) {
         </MenuPopup>
       </Menu>
     </SidebarMenuItem>
+  );
+}
+
+type OrganizationMenuSectionProps = {
+  activeOrganizationId: string;
+  role: Role | undefined;
+};
+
+/** Active organization block at the top of the user menu: a plain label for
+ * single-organization users, a switcher sub-menu for everyone else.
+ *
+ * Owns the organization list query rather than taking it as a prop so the
+ * sidebar reads the active organization and the switchable ones from one cache
+ * entry, and therefore one `organization/list` request per route. */
+function OrganizationMenuSection({
+  activeOrganizationId,
+  role,
+}: OrganizationMenuSectionProps) {
+  const t = useTranslations();
+  const navigate = useNavigate();
+  const analytics = useAnalytics();
+  const invalidateSession = useInvalidateSession();
+  const { data: organizations } = useChromeQuery(organizationListOptions);
+
+  const { isPending: isSwitchPending, mutate: switchOrganization } =
+    useMutation({
+      mutationFn: async (organizationId: string) => {
+        const { error } = await authClient.organization.setActive({
+          organizationId,
+        });
+
+        if (error) {
+          stellaToast.add({
+            title: userErrorFromThrown(
+              toAuthClientError(error),
+              t("errors.actionFailed"),
+            ),
+            type: "error",
+          });
+          throw toAuthClientError(error);
+        }
+
+        await invalidateSession.mutateAsync();
+        await navigate({ to: "/", replace: true });
+      },
+      onError: (error) => {
+        analytics.captureError(error);
+      },
+    });
+
+  const activeOrganization = organizations?.find(
+    (organization) => organization.id === activeOrganizationId,
+  );
+
+  if (!(organizations && activeOrganization)) {
+    return null;
+  }
+
+  if (organizations.length < 2) {
+    return (
+      <>
+        <MenuGroup>
+          <MenuGroupLabel className="pb-1 text-sm">
+            <BidiText as="span" className="min-w-0 truncate">
+              {activeOrganization.name}
+            </BidiText>
+          </MenuGroupLabel>
+          <OrganizationRoleBadge role={role} />
+        </MenuGroup>
+        <MenuSeparator />
+      </>
+    );
+  }
+
+  return (
+    <>
+      <MenuSub>
+        <MenuSubTrigger>
+          <BuildingIcon />
+          <BidiText as="span" className="min-w-0 truncate">
+            {activeOrganization.name}
+          </BidiText>
+        </MenuSubTrigger>
+        <MenuSubPopup>
+          <MenuGroup>
+            <MenuGroupLabel>
+              {t("organization.switchOrganization")}
+            </MenuGroupLabel>
+            <MenuRadioGroup value={activeOrganizationId}>
+              {organizations.map((organization) => (
+                <MenuRadioItem
+                  key={organization.id}
+                  disabled={isSwitchPending}
+                  onClick={() => {
+                    if (organization.id !== activeOrganizationId) {
+                      switchOrganization(organization.id);
+                    }
+                  }}
+                  value={organization.id}
+                >
+                  <BidiText as="span" className="min-w-0 truncate">
+                    {organization.name}
+                  </BidiText>
+                </MenuRadioItem>
+              ))}
+            </MenuRadioGroup>
+          </MenuGroup>
+        </MenuSubPopup>
+      </MenuSub>
+      {role && (
+        <MenuGroup>
+          <OrganizationRoleBadge role={role} />
+        </MenuGroup>
+      )}
+      <MenuSeparator />
+    </>
+  );
+}
+
+/** The signed-in user's role in the active organization. */
+function OrganizationRoleBadge({ role }: { role: Role | undefined }) {
+  const t = useTranslations();
+
+  if (!role) {
+    return null;
+  }
+
+  return (
+    <div className="px-2 pb-1.5">
+      <span className="bg-muted text-muted-foreground inline-flex items-center rounded-md px-1.5 py-0.5 text-[0.6875rem] font-medium select-none">
+        {t(`organization.roles.${role}`)}
+      </span>
+    </div>
   );
 }

--- a/apps/web/src/i18n/langs/ar.json
+++ b/apps/web/src/i18n/langs/ar.json
@@ -2301,7 +2301,8 @@
       "owner": "المالك"
     },
     "settings": "إعدادات المؤسسة",
-    "settingsDescription": "عدّل اسم مؤسستك والمعرّف"
+    "settingsDescription": "عدّل اسم مؤسستك والمعرّف",
+    "switchOrganization": "تبديل المؤسسة"
   },
   "search": {
     "aiRefine": "تحسين الاستعلام باستخدام AI",

--- a/apps/web/src/i18n/langs/cs.json
+++ b/apps/web/src/i18n/langs/cs.json
@@ -2301,7 +2301,8 @@
       "owner": "Vlastník"
     },
     "settings": "Nastavení organizace",
-    "settingsDescription": "Upravte název a slug organizace"
+    "settingsDescription": "Upravte název a slug organizace",
+    "switchOrganization": "Přepnout organizaci"
   },
   "search": {
     "aiRefine": "Vylepšit dotaz pomocí AI",

--- a/apps/web/src/i18n/langs/de.json
+++ b/apps/web/src/i18n/langs/de.json
@@ -2301,7 +2301,8 @@
       "owner": "Eigentümer"
     },
     "settings": "Organisationseinstellungen",
-    "settingsDescription": "Name und Slug der Organisation bearbeiten"
+    "settingsDescription": "Name und Slug der Organisation bearbeiten",
+    "switchOrganization": "Organisation wechseln"
   },
   "search": {
     "aiRefine": "Suchanfrage mit KI verbessern",

--- a/apps/web/src/i18n/langs/en.json
+++ b/apps/web/src/i18n/langs/en.json
@@ -2301,7 +2301,8 @@
       "owner": "Owner"
     },
     "settings": "Organization settings",
-    "settingsDescription": "Edit your organization name and slug"
+    "settingsDescription": "Edit your organization name and slug",
+    "switchOrganization": "Switch organization"
   },
   "search": {
     "aiRefine": "Improve query with AI",

--- a/apps/web/src/i18n/langs/es.json
+++ b/apps/web/src/i18n/langs/es.json
@@ -2301,7 +2301,8 @@
       "owner": "Propietario"
     },
     "settings": "Configuración de la organización",
-    "settingsDescription": "Edite el nombre y el slug de su organización"
+    "settingsDescription": "Edite el nombre y el slug de su organización",
+    "switchOrganization": "Cambiar de organización"
   },
   "search": {
     "aiRefine": "Mejorar consulta con IA",

--- a/apps/web/src/i18n/langs/et.json
+++ b/apps/web/src/i18n/langs/et.json
@@ -2301,7 +2301,8 @@
       "owner": "Omanik"
     },
     "settings": "Organisatsiooni seaded",
-    "settingsDescription": "Muutke oma organisatsiooni nime ja slugi"
+    "settingsDescription": "Muutke oma organisatsiooni nime ja slugi",
+    "switchOrganization": "Vaheta organisatsiooni"
   },
   "search": {
     "aiRefine": "Täpsusta päringut AI-ga",

--- a/apps/web/src/i18n/langs/fr.json
+++ b/apps/web/src/i18n/langs/fr.json
@@ -2301,7 +2301,8 @@
       "owner": "Propriétaire"
     },
     "settings": "Paramètres de l'organisation",
-    "settingsDescription": "Modifier le nom et le slug de votre organisation"
+    "settingsDescription": "Modifier le nom et le slug de votre organisation",
+    "switchOrganization": "Changer d'organisation"
   },
   "search": {
     "aiRefine": "Améliorer la requête avec l’IA",

--- a/apps/web/src/i18n/langs/hu.json
+++ b/apps/web/src/i18n/langs/hu.json
@@ -2301,7 +2301,8 @@
       "owner": "Tulajdonos"
     },
     "settings": "Szervezet beállításai",
-    "settingsDescription": "Szervezet nevének és slugjának szerkesztése"
+    "settingsDescription": "Szervezet nevének és slugjának szerkesztése",
+    "switchOrganization": "Szervezet váltása"
   },
   "search": {
     "aiRefine": "Keresés javítása AI-val",

--- a/apps/web/src/i18n/langs/lt.json
+++ b/apps/web/src/i18n/langs/lt.json
@@ -2301,7 +2301,8 @@
       "owner": "Savininkas"
     },
     "settings": "Organizacijos nustatymai",
-    "settingsDescription": "Redaguokite organizacijos pavadinimą ir slug"
+    "settingsDescription": "Redaguokite organizacijos pavadinimą ir slug",
+    "switchOrganization": "Pakeisti organizaciją"
   },
   "search": {
     "aiRefine": "Patobulinti užklausą su DI",

--- a/apps/web/src/i18n/langs/lv.json
+++ b/apps/web/src/i18n/langs/lv.json
@@ -2301,7 +2301,8 @@
       "owner": "Īpašnieks"
     },
     "settings": "Organizācijas iestatījumi",
-    "settingsDescription": "Rediģēt organizācijas nosaukumu un slug"
+    "settingsDescription": "Rediģēt organizācijas nosaukumu un slug",
+    "switchOrganization": "Mainīt organizāciju"
   },
   "search": {
     "aiRefine": "Uzlabot vaicājumu ar AI",

--- a/apps/web/src/i18n/langs/messages.gen.ts
+++ b/apps/web/src/i18n/langs/messages.gen.ts
@@ -2305,6 +2305,7 @@ type Messages = {
     };
     "settings": "Organization settings";
     "settingsDescription": "Edit your organization name and slug";
+    "switchOrganization": "Switch organization";
   };
   "search": {
     "aiRefine": "Improve query with AI";

--- a/apps/web/src/i18n/langs/pl.json
+++ b/apps/web/src/i18n/langs/pl.json
@@ -2301,7 +2301,8 @@
       "owner": "Właściciel"
     },
     "settings": "Ustawienia organizacji",
-    "settingsDescription": "Edytuj nazwę i slug organizacji"
+    "settingsDescription": "Edytuj nazwę i slug organizacji",
+    "switchOrganization": "Przełącz organizację"
   },
   "search": {
     "aiRefine": "Ulepsz zapytanie z AI",

--- a/apps/web/src/i18n/langs/pt-BR.json
+++ b/apps/web/src/i18n/langs/pt-BR.json
@@ -2301,7 +2301,8 @@
       "owner": "Proprietário"
     },
     "settings": "Configurações da organização",
-    "settingsDescription": "Edite o nome e o slug da sua organização"
+    "settingsDescription": "Edite o nome e o slug da sua organização",
+    "switchOrganization": "Mudar de organização"
   },
   "search": {
     "aiRefine": "Melhore a consulta com IA",

--- a/apps/web/src/i18n/langs/sk.json
+++ b/apps/web/src/i18n/langs/sk.json
@@ -2301,7 +2301,8 @@
       "owner": "Vlastník"
     },
     "settings": "Nastavenia organizácie",
-    "settingsDescription": "Upravte názov a slug organizácie"
+    "settingsDescription": "Upravte názov a slug organizácie",
+    "switchOrganization": "Prepnúť organizáciu"
   },
   "search": {
     "aiRefine": "Vylepšiť dotaz pomocou AI",

--- a/apps/web/src/routes/_protected.organization/-queries.ts
+++ b/apps/web/src/routes/_protected.organization/-queries.ts
@@ -5,37 +5,38 @@ import { toAuthClientError } from "@/lib/errors/auth";
 import { ROUTE_QUERY_STALE_TIME_MS } from "@/lib/react-query";
 import { ORGANIZATION_MEMBERS_LIMIT } from "@/routes/_protected.organization/-consts";
 
+const ORGANIZATION_KEY_ROOT = ["organization"];
+
 export const organizationKeys = {
-  all: ["organization", "full"],
+  root: ORGANIZATION_KEY_ROOT,
+  all: [...ORGANIZATION_KEY_ROOT, "full"],
   byOrganization: (organizationId: string) => [
     ...organizationKeys.all,
     organizationId,
   ],
-  summaries: ["organization", "summary"],
-  summary: (organizationId: string) => [
-    ...organizationKeys.summaries,
-    organizationId,
-  ],
+  list: [...ORGANIZATION_KEY_ROOT, "list"],
 };
 
-export const organizationSummaryOptions = (organizationId: string) =>
-  queryOptions({
-    queryKey: organizationKeys.summary(organizationId),
-    queryFn: async () => {
-      const result = await authClient.organization.list();
+/** Every organization the signed-in user belongs to.
+ *
+ * Single source for both the sidebar's active-organization label and its
+ * organization switcher: `organization/list` returns the whole membership
+ * list, so keying it per organization would issue one identical request per
+ * consumer and blow the per-route network baseline. Consumers narrow to the
+ * active organization client-side. */
+export const organizationListOptions = queryOptions({
+  queryKey: organizationKeys.list,
+  queryFn: async () => {
+    const result = await authClient.organization.list();
 
-      if (result.error) {
-        throw toAuthClientError(result.error);
-      }
+    if (result.error) {
+      throw toAuthClientError(result.error);
+    }
 
-      return (
-        result.data.find(
-          (organization) => organization.id === organizationId,
-        ) ?? null
-      );
-    },
-    staleTime: ROUTE_QUERY_STALE_TIME_MS,
-  });
+    return result.data;
+  },
+  staleTime: ROUTE_QUERY_STALE_TIME_MS,
+});
 
 export const organizationOptions = (organizationId: string) =>
   queryOptions({

--- a/apps/web/src/routes/_protected.settings/-components/organization/profile-card.tsx
+++ b/apps/web/src/routes/_protected.settings/-components/organization/profile-card.tsx
@@ -75,7 +75,7 @@ export const OrganizationProfileCard = () => {
       throw toAuthClientError(result.error);
     }
 
-    await queryClient.invalidateQueries({ queryKey: organizationKeys.all });
+    await queryClient.invalidateQueries({ queryKey: organizationKeys.root });
     form.reset({ name: pendingName });
     stellaToast.add({
       title: t("success.organizationUpdated"),


### PR DESCRIPTION
## Proposed change
Replace the static organization label in the sidebar user menu with a sub-menu listing all of the user's registered organizations. This allows users to switch active organizations via `authClient.organization.setActive()`, followed by session invalidation and navigation back to the root route.

- Added `organization.switchOrganization` translation keys across all locales.
- Integrated `authClient.useListOrganizations()` and `authClient.organization.setActive()` in `SidebarUserMenu`.
- Replaced the static header with a interactive `MenuSub` list selector when multiple organizations exist.

<img width="492" height="212" alt="image" src="https://github.com/user-attachments/assets/9d9fbdaf-7a17-4554-b5c3-d0cc962ffff1" />

Closes: #1137

## Checklist

<!--
  Put into **bold** for each item the appropriate option.
  Then mark the item with an `x` like so:
  `- [ ] BUILD ASSURANCE | Confirm that your code builds correctly and without any errors or warnings.
-->

- [x] BUILD ASSURANCE | Code builds correctly and without any errors or warnings.
- [x] TESTING | Changes tested, including in different conditions (dark mode, language, narrow screen, etc).
- [x] DARK MODE SUPPORT | User can use the webapp in dark mode. Make sure your changes are visible in both light and dark mode.
- [x] ISSUE LINKED | Link an issue to this PR (not by mentioning it in the description, but by using the GitHub issue linking feature)
- [x] SCREENSHOT INCLUDED | If relevant, please include a screenshot / video of the functionality added (allows for a quick check of minor ux changes)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added organisation switching to the sidebar user menu.
  - Users with one organisation see a simple organisation label; users with multiple can select the active organisation.
  - Switching refreshes the session and returns users to the home page.
- **Bug Fixes**
  - Improved error feedback if organisation switching fails.
- **Localisation**
  - Added translated “switch organisation” labels across supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->