### PR TITLE
fix(api): downgrade recoverable Bun-adapter Redis poll blip to warn

### DIFF
--- a/apps/api/src/lib/errors/utils.ts
+++ b/apps/api/src/lib/errors/utils.ts
@@ -156,7 +156,7 @@ const errorClassName = (error: Error): string => {
   return "Error";
 };
 
-const safeErrorCode = (error: Error): string | undefined =>
+export const safeErrorCode = (error: Error): string | undefined =>
   safeErrorStringProperty(error, "code");
 
 const safeErrorMessage = (error: Error): string | undefined =>

--- a/apps/api/src/lib/redis-client.test.ts
+++ b/apps/api/src/lib/redis-client.test.ts
@@ -9,8 +9,11 @@ void mock.module("bullmq", () => ({
   },
 }));
 
-const { connectWithColdStartRetries, createBullMqConnection } =
-  await import("@/api/lib/redis-client");
+const {
+  connectWithColdStartRetries,
+  createBullMqConnection,
+  isRecoverableRedisPollError,
+} = await import("@/api/lib/redis-client");
 
 describe("BullMQ Redis connection", () => {
   test("lets BullMQ own connection startup", () => {
@@ -60,5 +63,35 @@ describe("connectWithColdStartRetries", () => {
     // Identity check: the retries-exhausted rethrow must preserve the
     // original error object, not wrap it.
     expect(caught).toBe(originalError);
+  });
+});
+
+describe("isRecoverableRedisPollError", () => {
+  const withCode = (code: string): Error =>
+    Object.assign(new Error(code), { code });
+
+  test("classifies the Bun-adapter poll blip as recoverable", () => {
+    expect(
+      isRecoverableRedisPollError(withCode("ERR_REDIS_INVALID_RESPONSE")),
+    ).toBe(true);
+  });
+
+  test("leaves any other error to surface loudly", () => {
+    // A real outage (wrong code) and a message-only lookalike must NOT be
+    // downgraded, or a genuine failure would be silenced.
+    expect(isRecoverableRedisPollError(withCode("ECONNREFUSED"))).toBe(false);
+    expect(isRecoverableRedisPollError(new Error("Failed to read data"))).toBe(
+      false,
+    );
+  });
+
+  test("never matches non-Error values", () => {
+    expect(isRecoverableRedisPollError("ERR_REDIS_INVALID_RESPONSE")).toBe(
+      false,
+    );
+    expect(isRecoverableRedisPollError(undefined)).toBe(false);
+    expect(
+      isRecoverableRedisPollError({ code: "ERR_REDIS_INVALID_RESPONSE" }),
+    ).toBe(false);
   });
 });

--- a/apps/api/src/lib/redis-client.ts
+++ b/apps/api/src/lib/redis-client.ts
@@ -3,9 +3,21 @@ import { type BunRedisRawClient, createBunRedisClient } from "bullmq";
 import { type RedisOptions, RedisClient, sleep } from "bun";
 
 import { env } from "@/api/env";
-import { connectionErrorFields } from "@/api/lib/errors/utils";
+import { connectionErrorFields, safeErrorCode } from "@/api/lib/errors/utils";
 import { logger } from "@/api/lib/observability/logger";
 import { redisConnectionOptions } from "@/api/lib/redis-options";
+
+// Bun's experimental BullMQ Redis adapter intermittently fails to parse a reply
+// on a worker's idle blocking poll, surfacing an opaque
+// `ERR_REDIS_INVALID_RESPONSE` ("Failed to read data") roughly every few
+// seconds. It is self-recovering — the worker keeps draining jobs — so callers
+// must not treat it as a real outage. A persistent Redis outage manifests as
+// different codes / reconnection failures, which stay unclassified here.
+const RECOVERABLE_REDIS_POLL_ERROR_CODE = "ERR_REDIS_INVALID_RESPONSE";
+
+export const isRecoverableRedisPollError = (error: unknown): boolean =>
+  error instanceof Error &&
+  safeErrorCode(error) === RECOVERABLE_REDIS_POLL_ERROR_CODE;
 
 class ConfiguredRedisClient extends RedisClient implements BunRedisRawClient {
   readonly #connectHandlers = new Set<() => void>();

--- a/apps/api/src/lib/workflow-queue.ts
+++ b/apps/api/src/lib/workflow-queue.ts
@@ -40,6 +40,7 @@ import { logger } from "@/api/lib/observability/logger";
 import {
   createBullMqConnection,
   createRedisClient,
+  isRecoverableRedisPollError,
 } from "@/api/lib/redis-client";
 import { createRootSafeDb, createRootScopedDb } from "@/api/lib/root-scoped-db";
 import {
@@ -1182,6 +1183,11 @@ const handleWorkflowJobFailed = (
   );
 };
 
+// The Bun-adapter poll blip (see `isRecoverableRedisPollError`) recurs every
+// few seconds, so warn once per interval rather than per occurrence, carrying
+// the tally so a rising real problem is still visible.
+const REDIS_POLL_WARN_INTERVAL_MS = 60 * 1000;
+
 const createWorkflowWorker = ({
   concurrency,
   queueClass,
@@ -1202,7 +1208,28 @@ const createWorkflowWorker = ({
   );
 
   worker.on("failed", handleWorkflowJobFailed);
+  // Per-worker rate-limit state for the recoverable Bun-adapter poll blip:
+  // count every occurrence but emit at most one warn per interval, carrying
+  // the tally so a rising real problem is still visible.
+  let redisPollBlipsSinceWarn = 0;
+  let redisPollLastWarnAtMs = 0;
   worker.on("error", (error) => {
+    if (isRecoverableRedisPollError(error)) {
+      redisPollBlipsSinceWarn += 1;
+      const nowMs = Date.now();
+      if (nowMs - redisPollLastWarnAtMs < REDIS_POLL_WARN_INTERVAL_MS) {
+        return;
+      }
+      redisPollLastWarnAtMs = nowMs;
+      logger.warn("workflow.worker_redis_poll_blip", {
+        ...connectionErrorFields(error),
+        queueClass,
+        queueName,
+        blipsSinceLastWarn: String(redisPollBlipsSinceWarn),
+      });
+      redisPollBlipsSinceWarn = 0;
+      return;
+    }
     logger.error("workflow.worker_error", {
       ...connectionErrorFields(error),
       queueClass,


### PR DESCRIPTION
## What

The workflow BullMQ workers use Bun's experimental native Redis adapter. On a worker's idle blocking poll, Bun's RESP parser intermittently fails on a reply and surfaces an opaque `ERR_REDIS_INVALID_RESPONSE` ("Failed to read data") every few seconds. The worker keeps draining jobs — it is self-recovering — but the `worker.on("error")` handler logged every occurrence at `error`, so a benign, recurring transient looked like a real Redis outage in the logs.

## Change

- Add `isRecoverableRedisPollError()` in `redis-client.ts`: a precise, code-only classifier for this transient (`ERR_REDIS_INVALID_RESPONSE`).
- In the workflow worker's error handler, route that specific error to a **rate-limited `warn`** (`workflow.worker_redis_poll_blip`), mirroring the existing `redis.cold_start_reconnect` warn, and carry a `blipsSinceLastWarn` tally so a rising rate is still visible. Every other worker error keeps logging at `error`.
- Export `safeErrorCode` from `errors/utils.ts` for the classifier.

The match is intentionally code-only: a genuine outage surfaces as a different code / repeated reconnection failures and stays at `error`, so this only reclassifies the known-recoverable poll blip.

## Tests

`redis-client.test.ts` pins the classification: matching code → recoverable; a wrong code, a message-only lookalike, and non-`Error` values are all left to surface at `error`.