### PR TITLE
fix(cli): make generated array flags optional at the parse layer

### DIFF
--- a/packages/cli/src/build-cli-tree.test.ts
+++ b/packages/cli/src/build-cli-tree.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "bun:test";
+
+import { buildFlag } from "./build-cli-tree.js";
+import type { FlagSpec } from "./route-types.js";
+
+const flagSpec = (overrides: Partial<FlagSpec>): FlagSpec => ({
+  flag: "example",
+  prop: "example",
+  kind: "string",
+  required: false,
+  repeatable: false,
+  ...overrides,
+});
+
+// Every generated value flag must be optional at the stricli layer: a field can
+// always be supplied via --input, and required-ness is enforced after the
+// --input/flag merge against the JSON schema. A *required* stricli flag rejects
+// the whole command when the field is omitted — the bug that made optional array
+// flags like --assignee-ids unusable when left off. This pins the class so no
+// flag kind (present or future) can regress into requiring a value.
+describe("buildFlag optionality invariant", () => {
+  const cases: FlagSpec[] = [
+    flagSpec({ kind: "string", required: false }),
+    flagSpec({ kind: "string", required: true }),
+    flagSpec({ kind: "int", required: true, min: 0, max: 10 }),
+    flagSpec({ kind: "enum", required: true, enum: ["a", "b"] }),
+    flagSpec({ kind: "boolean", required: false }),
+    // The regression case: an optional repeatable array field.
+    flagSpec({ kind: "string-array", required: false, repeatable: true }),
+    // Even a required array is optional at the stricli layer.
+    flagSpec({ kind: "int-array", required: true, repeatable: true }),
+  ];
+
+  test("every generated value flag is optional", () => {
+    for (const spec of cases) {
+      expect(buildFlag(spec).optional).toBe(true);
+    }
+  });
+
+  test("repeatable fields become variadic, non-repeatable do not", () => {
+    const variadic = buildFlag(
+      flagSpec({ kind: "string-array", repeatable: true }),
+    ) as Record<string, unknown>;
+    expect(variadic).toMatchObject({ kind: "parsed", variadic: true });
+
+    const scalar = buildFlag(flagSpec({ kind: "string" })) as Record<
+      string,
+      unknown
+    >;
+    expect(scalar.variadic).toBeUndefined();
+  });
+
+  test("boolean fields build a boolean flag", () => {
+    const boolean = buildFlag(flagSpec({ kind: "boolean" })) as Record<
+      string,
+      unknown
+    >;
+    expect(boolean).toMatchObject({ kind: "boolean", optional: true });
+  });
+});

--- a/packages/cli/src/build-cli-tree.test.ts
+++ b/packages/cli/src/build-cli-tree.test.ts
@@ -47,7 +47,7 @@ describe("buildFlag optionality invariant", () => {
       string,
       unknown
     >;
-    expect(scalar.variadic).toBeUndefined();
+    expect(scalar["variadic"]).toBeUndefined();
   });
 
   test("boolean fields build a boolean flag", () => {

--- a/packages/cli/src/build-cli-tree.ts
+++ b/packages/cli/src/build-cli-tree.ts
@@ -35,11 +35,29 @@ type RoutingTarget = Command<Context> | RouteMap<Context>;
 
 const identity = (value: string): string => value;
 
+/**
+ * Every generated value flag is OPTIONAL at the stricli layer, and this shared
+ * return type makes that non-negotiable: a flag builder that forgets
+ * `optional: true` is a type error, not a runtime surprise. The invariant holds
+ * because any field can instead be supplied through `--input`, and required-ness
+ * is enforced after the `--input`/flag merge against the JSON schema. A required
+ * stricli flag would reject the whole command the moment the field is omitted —
+ * exactly the bug that made optional array flags (e.g. `--assignee-ids`)
+ * unusable when left off.
+ */
+type OptionalStricliFlag = { readonly optional: true };
+
 const parsedStringFlag = (brief: string) =>
   ({ brief, kind: "parsed", optional: true, parse: identity }) as const;
 
 const variadicFlag = (brief: string) =>
-  ({ brief, kind: "parsed", variadic: true, parse: identity }) as const;
+  ({
+    brief,
+    kind: "parsed",
+    variadic: true,
+    optional: true,
+    parse: identity,
+  }) as const;
 
 const booleanFlag = (brief: string, withNegated: boolean) =>
   ({ brief, kind: "boolean", optional: true, withNegated }) as const;
@@ -70,6 +88,23 @@ const mechanicalFlagFacts = (spec: FlagSpec): string => {
   return parts.join(" ");
 };
 
+/**
+ * Build the stricli flag for one capability/tool input field. The single
+ * construction site for both the tool and capability command builders, so the
+ * optional-at-the-stricli-layer invariant cannot drift between them. The return
+ * annotation enforces it for every branch.
+ */
+export const buildFlag = (flagSpec: FlagSpec): OptionalStricliFlag => {
+  const brief = flagBrief(flagSpec);
+  if (flagSpec.kind === "boolean") {
+    return booleanFlag(brief, true);
+  }
+  if (flagSpec.repeatable) {
+    return variadicFlag(brief);
+  }
+  return parsedStringFlag(brief);
+};
+
 const hasLimitProp = (spec: LeafCommandSpec): boolean => {
   const properties = spec.inputSchema["properties"];
   if (typeof properties !== "object" || properties === null) {
@@ -82,17 +117,7 @@ const buildLeafFlags = (spec: LeafCommandSpec): Record<string, unknown> => {
   const flags: Record<string, unknown> = {};
 
   for (const flagSpec of spec.flags) {
-    const key = flagKey(flagSpec);
-    const brief = flagBrief(flagSpec);
-    if (flagSpec.kind === "boolean") {
-      flags[key] = booleanFlag(brief, true);
-      continue;
-    }
-    if (flagSpec.repeatable) {
-      flags[key] = variadicFlag(brief);
-      continue;
-    }
-    flags[key] = parsedStringFlag(brief);
+    flags[flagKey(flagSpec)] = buildFlag(flagSpec);
   }
 
   // Reserved global flags every command carries (spec S1/S3).
@@ -200,17 +225,7 @@ const buildCapabilityLeafFlags = (
   const flags: Record<string, unknown> = {};
 
   for (const flagSpec of spec.flags) {
-    const key = flagKey(flagSpec);
-    const brief = flagBrief(flagSpec);
-    if (flagSpec.kind === "boolean") {
-      flags[key] = booleanFlag(brief, true);
-      continue;
-    }
-    if (flagSpec.repeatable) {
-      flags[key] = variadicFlag(brief);
-      continue;
-    }
-    flags[key] = parsedStringFlag(brief);
+    flags[flagKey(flagSpec)] = buildFlag(flagSpec);
   }
 
   flags[RESERVED_FLAG_KEYS.input] = parsedStringFlag(

--- a/packages/cli/src/run-capability-command.ts
+++ b/packages/cli/src/run-capability-command.ts
@@ -25,6 +25,7 @@ import {
   confirmDestructive,
   errorEnvelope,
   flagKey,
+  flagValueProvided,
   hasInputPath,
   mapClientErrorExit,
   parsePayload,
@@ -70,7 +71,7 @@ const buildInputFromFlags = async (
   const input = base;
   for (const flagSpec of spec.flags) {
     const value = flags[flagKey(flagSpec)];
-    if (value === undefined) {
+    if (!flagValueProvided(flagSpec, value)) {
       continue;
     }
     // eslint-disable-next-line no-await-in-loop -- @file/@- reads must stay sequential

--- a/packages/cli/src/run-leaf-command.test.ts
+++ b/packages/cli/src/run-leaf-command.test.ts
@@ -10,6 +10,7 @@ import {
   classifyToolError,
   errorEnvelope,
   flagKey,
+  flagValueProvided,
   readRequestReceipt,
   requestIdLine,
   reservedFlagUsageError,
@@ -33,6 +34,54 @@ const stringFlag = (prop: string, required = false): FlagSpec => ({
   kind: "string",
   required,
   repeatable: false,
+});
+
+const arrayFlag = (prop: string): FlagSpec => ({
+  flag: `--${prop.replace(/_/gu, "-")}`,
+  prop,
+  kind: "string-array",
+  required: false,
+  repeatable: true,
+});
+
+describe("flagValueProvided", () => {
+  test("scalar flags are provided iff not undefined (including empty string)", () => {
+    expect(flagValueProvided(stringFlag("name"), undefined)).toBe(false);
+    expect(flagValueProvided(stringFlag("name"), "Ada")).toBe(true);
+    expect(flagValueProvided(stringFlag("name"), "")).toBe(true);
+  });
+
+  test("an omitted variadic ([]) is treated as not provided", () => {
+    // Stricli parses an omitted optional variadic flag to [], and the CLI
+    // cannot pass an explicit empty array, so [] always means "left off".
+    expect(flagValueProvided(arrayFlag("assignee_ids"), [])).toBe(false);
+    expect(flagValueProvided(arrayFlag("assignee_ids"), ["u1"])).toBe(true);
+  });
+});
+
+describe("buildArgsFromFlags variadic/--input overlay", () => {
+  test("an omitted variadic flag does not overwrite a base array", async () => {
+    const spec = specWith([arrayFlag("assignee_ids")]);
+    const result = await buildArgsFromFlags(
+      spec,
+      { [flagKey({ prop: "assignee_ids" })]: [] },
+      { assignee_ids: ["from-input"] },
+    );
+    expect(result).toEqual({
+      ok: true,
+      args: { assignee_ids: ["from-input"] },
+    });
+  });
+
+  test("a supplied variadic flag overlays the base array", async () => {
+    const spec = specWith([arrayFlag("assignee_ids")]);
+    const result = await buildArgsFromFlags(
+      spec,
+      { [flagKey({ prop: "assignee_ids" })]: ["from-flag"] },
+      { assignee_ids: ["from-input"] },
+    );
+    expect(result).toEqual({ ok: true, args: { assignee_ids: ["from-flag"] } });
+  });
 });
 
 describe("buildArgsFromFlags (S3)", () => {

--- a/packages/cli/src/run-leaf-command.ts
+++ b/packages/cli/src/run-leaf-command.ts
@@ -44,6 +44,25 @@ export const flagKey = (spec: Pick<FlagSpec, "prop">): string =>
     char.toUpperCase(),
   );
 
+/**
+ * Whether a parsed flag value counts as caller-provided when overlaying flags
+ * onto `--input`. A scalar flag is provided iff it is not `undefined`. An
+ * omitted optional variadic flag parses to `[]` (Stricli) rather than
+ * `undefined`, and the CLI has no way to pass an explicit empty array, so an
+ * empty repeatable value means "left off" — treating it as provided would
+ * overwrite an array supplied through `--input` with `[]`. Both command
+ * executors route through here so they cannot diverge on this.
+ */
+export const flagValueProvided = (
+  flagSpec: Pick<FlagSpec, "repeatable">,
+  value: unknown,
+): boolean => {
+  if (value === undefined) {
+    return false;
+  }
+  return !(flagSpec.repeatable && Array.isArray(value) && value.length === 0);
+};
+
 /** Reserved global flag keys present on generated commands (spec S1/S3). */
 export const RESERVED_FLAG_KEYS = {
   input: "input",
@@ -308,7 +327,7 @@ export const buildArgsFromFlags = async (
 
   for (const flagSpec of spec.flags) {
     const value = flags[flagKey(flagSpec)];
-    if (value === undefined) {
+    if (!flagValueProvided(flagSpec, value)) {
       continue;
     }
     // eslint-disable-next-line no-await-in-loop -- @file/@- reads must stay sequential


### PR DESCRIPTION
## What

Generated value flags are meant to be optional at the stricli parse layer: any field can be supplied via `--input`, and required-ness is enforced *after* the `--input`/flag merge against the JSON schema. The scalar (`parsedStringFlag`) and boolean (`booleanFlag`) builders set `optional: true`, but the variadic (array) builder did not — so every generated array flag was treated as required-with-a-value.

Result: omitting a documented-optional array flag failed at parse time. Repro:

```
$ stella tasks create --workspace <id> --name "x" --status open --priority medium
Expected input for flag --assignee-ids
```

`--assignee-ids` is `(optional) string-array repeatable` in `--help`, yet leaving it off was rejected.

## Fix + class guard

- Add `optional: true` to the variadic builder. Per stricli, an optional variadic flag parses to `[]` when omitted.
- Centralize per-flag construction in a single `buildFlag()` used by **both** the tool and capability command builders (removing two divergent copies of the same loop), and annotate its return type so a builder that forgets `optional: true` is a **compile error**, not a runtime surprise.
- Guard test asserts every generated flag kind — scalar, boolean, optional array, required array — is optional at the parse layer.

## Verification

`--assignee-ids` omitted now creates the task; `--help` still shows it `(optional) string-array repeatable`. `bun test src/build-cli-tree.test.ts src/generate-route-map.test.ts` → 30 pass.