### PR TITLE
fix(cli): keep generated flags parser-safe

### DIFF
--- a/packages/cli/src/build-cli-tree.test.ts
+++ b/packages/cli/src/build-cli-tree.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, test } from "bun:test";
 
 import { buildFlag } from "./build-cli-tree.js";
-import type { FlagSpec } from "./route-types.js";
+import { flagKey } from "./flag-name.js";
+import { generatedRouteMap } from "./generated/route-map.js";
+import type { FlagSpec, RouteNode } from "./route-types.js";
 
 const flagSpec = (overrides: Partial<FlagSpec>): FlagSpec => ({
   flag: "example",
@@ -56,5 +58,22 @@ describe("buildFlag optionality invariant", () => {
       unknown
     >;
     expect(boolean).toMatchObject({ kind: "boolean", optional: true });
+  });
+});
+
+const generatedFlags = (node: RouteNode): FlagSpec[] => {
+  if (node.kind === "leaf" || node.kind === "capability-leaf") {
+    return [...node.spec.flags];
+  }
+  return Object.values(node.children).flatMap(generatedFlags);
+};
+
+describe("generated flag parser conformance", () => {
+  test("every generated long flag has a Stricli-supported key", () => {
+    for (const spec of generatedFlags(generatedRouteMap)) {
+      // Stricli reserves one-character names for aliases. Its long-flag scanner
+      // requires a letter followed by at least one supported character.
+      expect(flagKey(spec)).toMatch(/^[a-z][a-zA-Z0-9]+$/u);
+    }
   });
 });

--- a/packages/cli/src/cli-commands.test.ts
+++ b/packages/cli/src/cli-commands.test.ts
@@ -233,6 +233,24 @@ describe("auth and scope gating (S4)", () => {
   });
 });
 
+describe("generated capability flags", () => {
+  test("a descriptive long flag can target a terse query property", async () => {
+    const server = startMockServer(() => ({ toolPayload: { items: [] } }));
+    const result = await runCli({
+      args: ["contacts", "search", "--query", "agreement"],
+      url: server.url,
+      token: READ,
+    });
+    server.stop();
+    expect(result.exitCode).toBe(0);
+    expect(server.requests.at(0)?.params.name).toBe("invoke_capability");
+    expect(server.requests.at(0)?.params.arguments).toEqual({
+      capability: "contacts.search",
+      input: { query: { q: "agreement" } },
+    });
+  });
+});
+
 describe("list rendering and pagination (S4)", () => {
   test("matter list renders a table and hints the next cursor on stderr", async () => {
     const server = startMockServer(() => ({

--- a/packages/cli/src/flag-name.ts
+++ b/packages/cli/src/flag-name.ts
@@ -1,0 +1,9 @@
+import type { FlagSpec } from "./route-types.js";
+
+/** Stricli record key derived from the canonical public `--flag-name`. */
+export const flagKey = (spec: Pick<FlagSpec, "flag">): string =>
+  spec.flag
+    .slice(2)
+    .replace(/[._-](?<char>[a-z0-9])/gu, (_match, char: string) =>
+      char.toUpperCase(),
+    );

--- a/packages/cli/src/generate-capability-tree.test.ts
+++ b/packages/cli/src/generate-capability-tree.test.ts
@@ -149,6 +149,30 @@ describe("deriveCapabilityLeaf: flags", () => {
     expect(flagByCli(spec, "--body-query-version")?.part).toBe("body");
   });
 
+  test("flags with distinct spellings but one parser key are part-prefixed", () => {
+    // Stricli's allow-kebab-for-camel scanner normalizes both public spellings
+    // to `userId`. The generator must resolve the parser identity collision,
+    // not merely compare the rendered flag strings.
+    const { spec, flagCollisions } = deriveCapabilityLeaf(
+      entry({
+        id: "users.compare",
+        handlerKind: "root",
+        inputSchema: {
+          body: objectSchema({
+            user: objectSchema({ id: { type: "string" } }),
+          }),
+          query: objectSchema({ user_id: { type: "string" } }),
+        },
+      }),
+    );
+
+    expect(flagByCli(spec, "--user.id")).toBeUndefined();
+    expect(flagByCli(spec, "--user-id")).toBeUndefined();
+    expect(flagByCli(spec, "--body-user-id")?.partPath).toBe("user.id");
+    expect(flagByCli(spec, "--query-user-id")?.partPath).toBe("user_id");
+    expect(flagCollisions).toEqual(["--body-user-id", "--query-user-id"]);
+  });
+
   test("a prop colliding with the synthetic --workspace is part-prefixed", () => {
     const { spec } = deriveCapabilityLeaf(
       entry({

--- a/packages/cli/src/generate-capability-tree.ts
+++ b/packages/cli/src/generate-capability-tree.ts
@@ -199,6 +199,8 @@ const candidatesForPart = ({
 const prefixedFlag = (part: CapabilityPart, partPath: string): string =>
   `--${[part, ...partPath.split(".")].map((segment) => kebabCase(segment)).join("-")}`;
 
+const parserKeyForFlag = (flag: string): string => flagKey({ flag });
+
 type BuiltFlags = {
   flags: CapabilityFlagSpec[];
   flagCollisions: string[];
@@ -226,40 +228,42 @@ const resolveFlags = ({
   /** Names owned outside the candidates (the synthetic `--workspace`). */
   takenNames: ReadonlySet<string>;
 }): BuiltFlags => {
-  const byBaseFlag = new Map<string, number>();
+  const reservedParserKeys = new Set([...RESERVED_FLAGS].map(parserKeyForFlag));
+  const takenParserKeys = new Set([...takenNames].map(parserKeyForFlag));
+  const byBaseParserKey = new Map<string, number>();
   for (const candidate of candidates) {
-    byBaseFlag.set(
-      candidate.baseFlag,
-      (byBaseFlag.get(candidate.baseFlag) ?? 0) + 1,
-    );
+    const parserKey = parserKeyForFlag(candidate.baseFlag);
+    byBaseParserKey.set(parserKey, (byBaseParserKey.get(parserKey) ?? 0) + 1);
   }
   const resolved = candidates.map((candidate) => ({
     candidate,
     prefixed:
-      RESERVED_FLAGS.has(candidate.baseFlag) ||
-      takenNames.has(candidate.baseFlag) ||
-      (byBaseFlag.get(candidate.baseFlag) ?? 0) > 1,
+      reservedParserKeys.has(parserKeyForFlag(candidate.baseFlag)) ||
+      takenParserKeys.has(parserKeyForFlag(candidate.baseFlag)) ||
+      (byBaseParserKey.get(parserKeyForFlag(candidate.baseFlag)) ?? 0) > 1,
   }));
   const finalName = (entry: (typeof resolved)[number]): string =>
     entry.prefixed
       ? prefixedFlag(entry.candidate.part, entry.candidate.partPath)
       : entry.candidate.baseFlag;
 
-  // Global-uniqueness fixpoint: any final-name group of size > 1 (or hitting a
-  // taken name) prefixes all of its unprefixed members. Prefixing only flips
-  // false -> true, so the loop terminates.
+  // Global-uniqueness fixpoint: group by Stricli's parsed identity rather than
+  // public spelling. For example, `--user.id` and `--user-id` both parse as
+  // `userId` under allow-kebab-for-camel. Any duplicate identity (or identity
+  // owned outside the candidates) prefixes all unprefixed members. Prefixing
+  // only flips false -> true, so the loop terminates.
   let changed = true;
   while (changed) {
     changed = false;
     const groups = new Map<string, (typeof resolved)[number][]>();
     for (const entry of resolved) {
-      const name = finalName(entry);
-      const group = groups.get(name) ?? [];
+      const parserKey = parserKeyForFlag(finalName(entry));
+      const group = groups.get(parserKey) ?? [];
       group.push(entry);
-      groups.set(name, group);
+      groups.set(parserKey, group);
     }
-    for (const [name, group] of groups) {
-      if (group.length <= 1 && !takenNames.has(name)) {
+    for (const [parserKey, group] of groups) {
+      if (group.length <= 1 && !takenParserKeys.has(parserKey)) {
         continue;
       }
       for (const entry of group) {
@@ -278,9 +282,9 @@ const resolveFlags = ({
     const { candidate } = entry;
     const flag = finalName(entry);
     const source = `${candidate.part}.${candidate.partPath}`;
-    const parserKey = flagKey({ flag });
+    const parserKey = parserKeyForFlag(flag);
     const existing = seenParserKeys.get(parserKey);
-    if (existing !== undefined || takenNames.has(flag)) {
+    if (existing !== undefined || takenParserKeys.has(parserKey)) {
       throw new RouteGenerationError(
         `capability "${capabilityId}": flag ${flag} (from ${source}) collides at parser key ${parserKey} with ${existing ?? "a reserved leaf flag"} even after part-prefixing`,
       );

--- a/packages/cli/src/generate-capability-tree.ts
+++ b/packages/cli/src/generate-capability-tree.ts
@@ -12,6 +12,7 @@
 // <domain> <action>` instead.
 
 import { RESERVED_FLAGS, RESERVED_TOP_LEVEL_NAMES } from "./annotations.js";
+import { flagKey } from "./flag-name.js";
 import {
   classifyProp,
   generateRouteMap,
@@ -270,20 +271,21 @@ const resolveFlags = ({
     }
   }
 
-  const seen = new Map<string, string>();
+  const seenParserKeys = new Map<string, string>();
   const flags: CapabilityFlagSpec[] = [];
   const flagCollisions: string[] = [];
   for (const entry of resolved) {
     const { candidate } = entry;
     const flag = finalName(entry);
     const source = `${candidate.part}.${candidate.partPath}`;
-    const existing = seen.get(flag);
+    const parserKey = flagKey({ flag });
+    const existing = seenParserKeys.get(parserKey);
     if (existing !== undefined || takenNames.has(flag)) {
       throw new RouteGenerationError(
-        `capability "${capabilityId}": flag ${flag} (from ${source}) collides with ${existing ?? "a reserved leaf flag"} even after part-prefixing`,
+        `capability "${capabilityId}": flag ${flag} (from ${source}) collides at parser key ${parserKey} with ${existing ?? "a reserved leaf flag"} even after part-prefixing`,
       );
     }
-    seen.set(flag, source);
+    seenParserKeys.set(parserKey, source);
     if (entry.prefixed) {
       flagCollisions.push(flag);
     }

--- a/packages/cli/src/generate-route-map.test.ts
+++ b/packages/cli/src/generate-route-map.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 
 import { TOOL_ANNOTATIONS } from "./annotations.js";
 import {
+  classifyProp,
   generateRouteMap,
   RouteGenerationError,
 } from "./generate-route-map.js";
@@ -185,6 +186,26 @@ describe("generateRouteMap: discriminator split (S2)", () => {
 });
 
 describe("generateRouteMap: flag mapping (S3)", () => {
+  test("one-character query properties get a parser-safe long flag", () => {
+    expect(classifyProp("q", { type: "string" })).toEqual({
+      kind: "flag",
+      spec: {
+        flag: "--query",
+        prop: "q",
+        kind: "string",
+        repeatable: false,
+      },
+    });
+  });
+
+  test("unknown one-character properties fail codegen", () => {
+    for (const prop of "abcdefghijklmnoprstuvwxyz") {
+      expect(() => classifyProp(prop, { type: "string" })).toThrow(
+        RouteGenerationError,
+      );
+    }
+  });
+
   test("nullable-string props map to nullable-string flags", () => {
     const save = findLeaf(tree, ["contact", "save"]);
     expect(flagFor(save ?? errorSpec(), "--first-name")?.kind).toBe(
@@ -270,13 +291,13 @@ describe("generateRouteMap: collisions (S1)", () => {
     ).toThrow(RouteGenerationError);
   });
 
-  test("two props kebabbing to the same flag fail hard", () => {
+  test("two flags normalizing to the same parser key fail hard", () => {
     const bad: RegistryToolListing = {
       name: "save_matter",
       description: "d",
       inputSchema: {
         type: "object",
-        properties: { a_b: { type: "string" }, aB: { type: "string" } },
+        properties: { a_b: { type: "string" }, "a.b": { type: "string" } },
       },
     };
     expect(() =>

--- a/packages/cli/src/generate-route-map.ts
+++ b/packages/cli/src/generate-route-map.ts
@@ -7,6 +7,7 @@
 
 import { RESERVED_FLAGS, RESERVED_TOP_LEVEL_NAMES } from "./annotations.js";
 import { CliBaseError } from "./auth/errors.js";
+import { flagKey } from "./flag-name.js";
 import type {
   FlagSpec,
   JsonSchema,
@@ -77,6 +78,30 @@ export const kebabCase = (segment: string): string =>
     .replace(/_/gu, "-")
     .replace(/(?<lower>[a-z0-9])(?<upper>[A-Z])/gu, "$<lower>-$<upper>")
     .toLowerCase();
+
+const SINGLE_CHARACTER_FLAG_NAMES: Readonly<Record<string, string>> = {
+  q: "query",
+};
+
+/**
+ * Stricli reserves one-character names for aliases and only parses long flag
+ * names with at least two characters. Expand known terse schema properties to
+ * an authored long name; fail codegen for every unknown one-character property
+ * so help can never advertise a flag the parser will reject.
+ */
+const directFlagName = (prop: string): string => {
+  const name = kebabCase(prop);
+  if (name.length > 1) {
+    return `--${name}`;
+  }
+  const expanded = SINGLE_CHARACTER_FLAG_NAMES[name];
+  if (expanded === undefined) {
+    throw new RouteGenerationError(
+      `Schema property "${prop}" needs an explicit long CLI flag name`,
+    );
+  }
+  return `--${expanded}`;
+};
 
 export type PropSchema = Record<string, unknown>;
 
@@ -154,7 +179,7 @@ const classifyArrayItems = (
     return {
       kind: "flag",
       spec: {
-        flag: `--${kebabCase(prop)}`,
+        flag: directFlagName(prop),
         prop,
         kind: "enum-array",
         enum: itemEnum,
@@ -166,7 +191,7 @@ const classifyArrayItems = (
     return {
       kind: "flag",
       spec: {
-        flag: `--${kebabCase(prop)}`,
+        flag: directFlagName(prop),
         prop,
         kind: "string-array",
         repeatable: true,
@@ -177,7 +202,7 @@ const classifyArrayItems = (
     return {
       kind: "flag",
       spec: {
-        flag: `--${kebabCase(prop)}`,
+        flag: directFlagName(prop),
         prop,
         kind: "int-array",
         repeatable: true,
@@ -283,7 +308,7 @@ const classifyPropShape = (
     return {
       kind: "flag",
       spec: {
-        flag: `--${kebabCase(prop)}`,
+        flag: directFlagName(prop),
         prop,
         kind: "enum",
         enum: values,
@@ -296,7 +321,7 @@ const classifyPropShape = (
     return {
       kind: "flag",
       spec: {
-        flag: `--${kebabCase(prop)}`,
+        flag: directFlagName(prop),
         prop,
         kind: nullable ? "nullable-string" : "string",
         repeatable: false,
@@ -308,7 +333,7 @@ const classifyPropShape = (
     return {
       kind: "flag",
       spec: {
-        flag: `--${kebabCase(prop)}`,
+        flag: directFlagName(prop),
         prop,
         kind: "int",
         ...boundFields(schema),
@@ -321,7 +346,7 @@ const classifyPropShape = (
     return {
       kind: "flag",
       spec: {
-        flag: `--${kebabCase(prop)}`,
+        flag: directFlagName(prop),
         prop,
         kind: "number",
         ...boundFields(schema),
@@ -334,7 +359,7 @@ const classifyPropShape = (
     return {
       kind: "flag",
       spec: {
-        flag: `--${kebabCase(prop)}`,
+        flag: directFlagName(prop),
         prop,
         kind: "boolean",
         repeatable: false,
@@ -395,7 +420,7 @@ const buildFlags = ({
 }): BuiltFlags => {
   const flags: FlagSpec[] = [];
   const inputOnly: string[] = [];
-  const seenFlags = new Set<string>();
+  const seenFlagKeys = new Set<string>();
 
   const propNames =
     includeProps ?? Object.keys(properties).filter((p) => !skipProps.has(p));
@@ -424,12 +449,13 @@ const buildFlags = ({
           `Generated flag ${candidate.flag} (from prop ${candidate.prop}) collides with a reserved global flag`,
         );
       }
-      if (seenFlags.has(candidate.flag)) {
+      const parserKey = flagKey(candidate);
+      if (seenFlagKeys.has(parserKey)) {
         throw new RouteGenerationError(
-          `Flag ${candidate.flag} is generated twice within one command; add a flagRename annotation`,
+          `Flag ${candidate.flag} normalizes to duplicate parser key ${parserKey}; add a flagRename annotation`,
         );
       }
-      seenFlags.add(candidate.flag);
+      seenFlagKeys.add(parserKey);
       // A dot-path leaf is required only if the whole object prop is required
       // AND the child schema itself is required; the CLI keeps this simple by
       // treating dot-path leaves as optional (the server enforces sub-requiredness).

--- a/packages/cli/src/generated/route-map.ts
+++ b/packages/cli/src/generated/route-map.ts
@@ -6589,7 +6589,7 @@ export const generatedRouteMap: RouteNode = {
                 repeatable: false,
                 description:
                   "Filter clauses by a text query over title and body (list mode)",
-                flag: "--q",
+                flag: "--query",
                 prop: "q",
                 required: false,
                 part: "query",
@@ -7859,7 +7859,7 @@ export const generatedRouteMap: RouteNode = {
                 repeatable: false,
                 description:
                   "Canonical identifier (e.g. company number, VAT number) or company name",
-                flag: "--q",
+                flag: "--query",
                 prop: "q",
                 required: true,
                 part: "query",
@@ -8582,7 +8582,7 @@ export const generatedRouteMap: RouteNode = {
               {
                 kind: "string",
                 repeatable: false,
-                flag: "--q",
+                flag: "--query",
                 prop: "q",
                 required: false,
                 part: "query",
@@ -8653,7 +8653,7 @@ export const generatedRouteMap: RouteNode = {
               {
                 kind: "string",
                 repeatable: false,
-                flag: "--q",
+                flag: "--query",
                 prop: "q",
                 required: true,
                 part: "query",

--- a/packages/cli/src/route-types.ts
+++ b/packages/cli/src/route-types.ts
@@ -71,7 +71,9 @@ export type ToolAnnotation = {
 
 /** One generated CLI flag, derived from an `inputSchema` prop (spec S3). */
 export type FlagSpec = {
+  /** Canonical public long flag name, separate from its destination path. */
   flag: string;
+  /** Input destination path; it need not match the public flag name. */
   prop: string;
   kind:
     | "string"
@@ -120,13 +122,10 @@ export type CapabilityPart = "body" | "params" | "query";
 
 /**
  * One generated flag on a capability leaf: a `FlagSpec` tagged with the input
- * part it routes into. `FlagSpec.prop` drives the stricli flag identity (the
- * user-facing flag name), while `part` + `partPath` drive where the coerced
- * value lands inside the `invoke_capability` `input` object (`input[part]` at
- * `partPath`). For a flag whose bare name is unique they coincide; on a
- * cross-part or reserved-flag collision the generator part-prefixes `prop`
- * (e.g. `query.version` -> `--query-version`) while `partPath` stays the raw
- * property path (`version`).
+ * part it routes into. `FlagSpec.flag` is the canonical user-facing name;
+ * `part` + `partPath` drive where the coerced value lands inside the
+ * `invoke_capability` input object. `FlagSpec.prop` remains the unique local
+ * destination identity used while resolving cross-part collisions.
  */
 export type CapabilityFlagSpec = FlagSpec & {
   part: CapabilityPart;

--- a/packages/cli/src/run-leaf-command.test.ts
+++ b/packages/cli/src/run-leaf-command.test.ts
@@ -64,7 +64,7 @@ describe("buildArgsFromFlags variadic/--input overlay", () => {
     const spec = specWith([arrayFlag("assignee_ids")]);
     const result = await buildArgsFromFlags(
       spec,
-      { [flagKey({ prop: "assignee_ids" })]: [] },
+      { [flagKey({ flag: "--assignee-ids" })]: [] },
       { assignee_ids: ["from-input"] },
     );
     expect(result).toEqual({
@@ -77,7 +77,7 @@ describe("buildArgsFromFlags variadic/--input overlay", () => {
     const spec = specWith([arrayFlag("assignee_ids")]);
     const result = await buildArgsFromFlags(
       spec,
-      { [flagKey({ prop: "assignee_ids" })]: ["from-flag"] },
+      { [flagKey({ flag: "--assignee-ids" })]: ["from-flag"] },
       { assignee_ids: ["from-input"] },
     );
     expect(result).toEqual({ ok: true, args: { assignee_ids: ["from-flag"] } });
@@ -96,7 +96,7 @@ describe("buildArgsFromFlags (S3)", () => {
       },
     ]);
     const result = await buildArgsFromFlags(spec, {
-      [flagKey({ prop: "first_name" })]: "null",
+      [flagKey({ flag: "--first-name" })]: "null",
     });
     expect(result).toEqual({ ok: true, args: { first_name: null } });
   });
@@ -167,7 +167,7 @@ describe("buildArgsFromFlags (S3)", () => {
         repeatable: true,
       },
     ]);
-    const result = await buildArgsFromFlags(spec, { tags: ["a", "b"] });
+    const result = await buildArgsFromFlags(spec, { tag: ["a", "b"] });
     expect(result).toEqual({ ok: true, args: { tags: ["a", "b"] } });
   });
 

--- a/packages/cli/src/run-leaf-command.ts
+++ b/packages/cli/src/run-leaf-command.ts
@@ -12,6 +12,7 @@ import { text as readStreamText } from "node:stream/consumers";
 
 import { decodeAccessTokenClaims } from "./auth/jwt.js";
 import type { Context } from "./context.js";
+import { flagKey } from "./flag-name.js";
 import { validateAgainstSchema } from "./json-schema-validate.js";
 import {
   callTool,
@@ -38,11 +39,7 @@ import {
 } from "./output.js";
 import type { FlagSpec, LeafCommandSpec } from "./route-types.js";
 
-/** stricli flag record key for a FlagSpec: snake/dot path -> camelCase identifier. */
-export const flagKey = (spec: Pick<FlagSpec, "prop">): string =>
-  spec.prop.replace(/[._](?<char>[a-z0-9])/gu, (_match, char: string) =>
-    char.toUpperCase(),
-  );
+export { flagKey } from "./flag-name.js";
 
 /**
  * Whether a parsed flag value counts as caller-provided when overlaying flags


### PR DESCRIPTION
## What

- Generate parser-safe `--query` flags for terse `q` schema properties while preserving the server payload path.
- Derive Stricli keys from canonical public flag names instead of payload paths.
- Fail codegen on unsupported one-character flags and normalized parser-key collisions.
- Add generated-tree invariants and an end-to-end command regression.

## Why

Stricli reserves one-character names for aliases. The CLI could therefore advertise `--q` in help while rejecting it during parsing. Public flag identity and payload routing were also conflated, making a safe rename error-prone.

This stacks on #1316, which centralizes generated flag construction and fixes optional variadic parsing.

Validated with `bun run verify`.
