### PR TITLE
fix(deps): patch URI and SVG advisories

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -672,10 +672,12 @@
     "@emnapi/core": "1.9.1",
     "@emnapi/runtime": "1.9.1",
     "@stll/folio-core": "0.15.0",
+    "fast-uri": "3.1.3",
     "lucide-react": "1.24.0",
     "prosemirror-model": "1.25.11",
     "prosemirror-transform": "1.12.0",
     "prosemirror-view": "1.42.1",
+    "svgo": "4.0.2",
   },
   "catalog": {
     "@base-ui/react": "1.6.0",
@@ -2739,7 +2741,7 @@
 
     "fast-string-width": ["fast-string-width@3.0.2", "", { "dependencies": { "fast-string-truncated-width": "^3.0.2" } }, "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg=="],
 
-    "fast-uri": ["fast-uri@3.1.0", "", {}, "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="],
+    "fast-uri": ["fast-uri@3.1.3", "", {}, "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg=="],
 
     "fast-wrap-ansi": ["fast-wrap-ansi@0.2.0", "", { "dependencies": { "fast-string-width": "^3.0.2" } }, "sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w=="],
 
@@ -3713,7 +3715,7 @@
 
     "sucrase": ["sucrase@3.35.1", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.2", "commander": "^4.0.0", "lines-and-columns": "^1.1.6", "mz": "^2.7.0", "pirates": "^4.0.1", "tinyglobby": "^0.2.11", "ts-interface-checker": "^0.1.9" }, "bin": { "sucrase": "bin/sucrase", "sucrase-node": "bin/sucrase-node" } }, "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw=="],
 
-    "svgo": ["svgo@4.0.1", "", { "dependencies": { "commander": "^11.1.0", "css-select": "^5.1.0", "css-tree": "^3.0.1", "css-what": "^6.1.0", "csso": "^5.0.5", "picocolors": "^1.1.1", "sax": "^1.5.0" }, "bin": "./bin/svgo.js" }, "sha512-XDpWUOPC6FEibaLzjfe0ucaV0YrOjYotGJO1WpF0Zd+n6ZGEQUsSugaoLq9QkEZtAfQIxT42UChcssDVPP3+/w=="],
+    "svgo": ["svgo@4.0.2", "", { "dependencies": { "commander": "^11.1.0", "css-select": "^5.1.0", "css-tree": "^3.0.1", "css-what": "^6.1.0", "csso": "^5.0.5", "picocolors": "^1.1.1", "sax": "^1.5.0" }, "bin": "./bin/svgo.js" }, "sha512-ekx94z1rRc5LDi6oSUaeRnYhd0UOJxdtQCL2rF8xpWxD3TPAsISWOrxezqGovqS38GRZOdpDfvQe3ts6F7nsng=="],
 
     "tagged-tag": ["tagged-tag@1.0.0", "", {}, "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng=="],
 

--- a/package.json
+++ b/package.json
@@ -81,10 +81,12 @@
     "@emnapi/core": "1.9.1",
     "@emnapi/runtime": "1.9.1",
     "@stll/folio-core": "0.15.0",
+    "fast-uri": "3.1.3",
     "lucide-react": "1.24.0",
     "prosemirror-model": "1.25.11",
     "prosemirror-transform": "1.12.0",
-    "prosemirror-view": "1.42.1"
+    "prosemirror-view": "1.42.1",
+    "svgo": "4.0.2"
   },
   "packageManager": "bun@1.3.14",
   "catalog": {

--- a/scripts/dependency-audit-baseline.json
+++ b/scripts/dependency-audit-baseline.json
@@ -17,20 +17,6 @@
       "reason": "Transitive; defu merges internal config objects, not untrusted input."
     },
     {
-      "id": "GHSA-v39h-62p7-jpjc",
-      "severity": "high",
-      "package": "fast-uri",
-      "title": "fast-uri host confusion via percent-encoded authority delimiters",
-      "reason": "Transitive URI parser in tooling; outbound fetches use the SSRF-guarded resolver, not fast-uri."
-    },
-    {
-      "id": "GHSA-q3j6-qgpj-74h6",
-      "severity": "high",
-      "package": "fast-uri",
-      "title": "fast-uri path traversal via percent-encoded dot segments",
-      "reason": "See GHSA-v39h-62p7-jpjc."
-    },
-    {
       "id": "GHSA-88fw-hqm2-52qc",
       "severity": "high",
       "package": "hono",


### PR DESCRIPTION
## Summary

- pin `fast-uri` to the patched 3.1.3 release
- pin `svgo` to the patched 4.0.2 release
- remove the two superseded `fast-uri` audit-baseline entries

## Validation

- `bun scripts/dependency-audit.ts --check`
- lockfile workspace-version guard
- affected-workspace pre-push formatting, localization, and typecheck gates