### PR TITLE
feat(cli): document nested input contracts

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -462,6 +462,7 @@
       "dependencies": {
         "@stricli/core": "^1.2.9",
         "better-result": "catalog:",
+        "re2-wasm": "^1.0.2",
         "valibot": "catalog:",
       },
       "devDependencies": {
@@ -4083,6 +4084,8 @@
     "range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
 
     "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
+
+    "re2-wasm": ["re2-wasm@1.0.2", "", {}, "sha512-VXUdgSiUrE/WZXn6gUIVVIsg0+Hp6VPZPOaHCay+OuFKy6u/8ktmeNEf+U5qSA8jzGGFsg8jrDNu1BeHpz2pJA=="],
 
     "react": ["react@19.2.7", "", {}, "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ=="],
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -50,6 +50,7 @@
   "dependencies": {
     "@stricli/core": "^1.2.9",
     "better-result": "catalog:",
+    "re2-wasm": "^1.0.2",
     "valibot": "catalog:"
   },
   "devDependencies": {

--- a/packages/cli/src/build-cli-tree.ts
+++ b/packages/cli/src/build-cli-tree.ts
@@ -200,15 +200,25 @@ const fullDescription = ({
   if (contract === undefined || contract.fields.length === 0) {
     return undefined;
   }
-  return [
+  const lines = [
     brief,
     "",
     "--input JSON fields (explicit value flags override matching JSON paths):",
     ...contract.fields.map((line) => `  ${line}`),
-    "",
-    "Complete JSON example:",
-    `  ${formatInputExample(contract.example)}`,
-  ].join("\n");
+  ];
+  if (contract.example.status === "complete") {
+    lines.push(
+      "",
+      "Complete JSON example:",
+      `  ${formatInputExample(contract.example.value)}`,
+    );
+  } else {
+    lines.push(
+      "",
+      "JSON example unavailable; compose --input from the fields above and validate with --dry-run.",
+    );
+  }
+  return lines.join("\n");
 };
 
 const buildLeafCommand = (spec: LeafCommandSpec): RoutingTarget => {

--- a/packages/cli/src/build-cli-tree.ts
+++ b/packages/cli/src/build-cli-tree.ts
@@ -215,7 +215,7 @@ const fullDescription = ({
   } else {
     lines.push(
       "",
-      "JSON example unavailable; compose --input from the fields above and validate with --dry-run.",
+      "JSON example unavailable; compose --input from the fields above.",
     );
   }
   return lines.join("\n");

--- a/packages/cli/src/build-cli-tree.ts
+++ b/packages/cli/src/build-cli-tree.ts
@@ -15,6 +15,10 @@ import type {
 } from "@stricli/core";
 
 import type { Context } from "./context.js";
+import {
+  buildInputContractHelp,
+  formatInputExample,
+} from "./input-contract-help.js";
 import type { ResourceLeafSpec, ResourceNode } from "./resource-types.js";
 import type {
   CapabilityLeafSpec,
@@ -174,10 +178,55 @@ const leafBrief = (spec: LeafCommandSpec): string => {
   return `Run the ${spec.toolName} tool${inputHint}`;
 };
 
+const fullDescription = ({
+  brief,
+  inputSchema,
+  inputOnly,
+  requiredPaths,
+}: {
+  brief: string;
+  inputSchema: Record<string, unknown> | undefined;
+  inputOnly: readonly string[];
+  requiredPaths: readonly string[];
+}): string | undefined => {
+  if (inputSchema === undefined) {
+    return undefined;
+  }
+  const contract = buildInputContractHelp({
+    schema: inputSchema,
+    inputOnly,
+    requiredPaths,
+  });
+  if (contract === undefined || contract.fields.length === 0) {
+    return undefined;
+  }
+  return [
+    brief,
+    "",
+    "--input JSON fields (explicit value flags override matching JSON paths):",
+    ...contract.fields.map((line) => `  ${line}`),
+    "",
+    "Complete JSON example:",
+    `  ${formatInputExample(contract.example)}`,
+  ].join("\n");
+};
+
 const buildLeafCommand = (spec: LeafCommandSpec): RoutingTarget => {
   const flags = buildLeafFlags(spec);
+  const brief = leafBrief(spec);
+  const description = fullDescription({
+    brief,
+    inputSchema: spec.inputSchema,
+    inputOnly: spec.inputOnly,
+    requiredPaths: spec.flags
+      .filter((flag) => flag.required)
+      .map((flag) => flag.prop),
+  });
   const builderArgs = {
-    docs: { brief: leafBrief(spec) },
+    docs: {
+      brief,
+      ...(description === undefined ? {} : { fullDescription: description }),
+    },
     parameters: { flags },
     func: async function func(
       this: Context,
@@ -276,8 +325,20 @@ const buildCapabilityLeafCommand = (
   spec: CapabilityLeafSpec,
 ): RoutingTarget => {
   const flags = buildCapabilityLeafFlags(spec);
+  const brief = capabilityLeafBrief(spec);
+  const description = fullDescription({
+    brief,
+    inputSchema: spec.inputSchema,
+    inputOnly: spec.inputOnly,
+    requiredPaths: spec.flags
+      .filter((flag) => flag.required)
+      .map((flag) => `${flag.part}.${flag.partPath}`),
+  });
   const builderArgs = {
-    docs: { brief: capabilityLeafBrief(spec) },
+    docs: {
+      brief,
+      ...(description === undefined ? {} : { fullDescription: description }),
+    },
     parameters: { flags },
     func: async function func(
       this: Context,

--- a/packages/cli/src/cli-commands.test.ts
+++ b/packages/cli/src/cli-commands.test.ts
@@ -645,6 +645,37 @@ describe("error tiers -> exit codes (S4)", () => {
 });
 
 describe("help surfaces --input for inputOnly tools", () => {
+  test("template fill --help renders its free-map shape and a complete example", async () => {
+    const server = startMockServer(() => ({ toolPayload: {} }));
+    const result = await runCli({
+      args: ["template", "fill", "--help"],
+      url: server.url,
+      token: makeToken(["templates"]),
+    });
+    server.stop();
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("values.<key>  any JSON value  required");
+    expect(result.stdout).toContain(
+      `--input '{"template_id":"xxxxx","values":{"key":"value"}}'`,
+    );
+  });
+
+  test("uploads create --help renders every union branch from the schema", async () => {
+    const server = startMockServer(() => ({ toolPayload: {} }));
+    const result = await runCli({
+      args: ["uploads", "create", "--help"],
+      url: server.url,
+      token: WRITE,
+    });
+    server.stop();
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('purpose = "entity_create"');
+    expect(result.stdout).toContain('purpose = "entity_version"');
+    expect(result.stdout).toContain('purpose = "agent_skill"');
+    expect(result.stdout).toContain("body.sha256Hex  string  required");
+    expect(result.stdout).toContain('"params":{"workspaceId":"xxxxx"}');
+  });
+
   test("template save --help documents the --input-only fields", async () => {
     const server = startMockServer(() => ({ toolPayload: {} }));
     const result = await runCli({

--- a/packages/cli/src/generate-capability-tree.test.ts
+++ b/packages/cli/src/generate-capability-tree.test.ts
@@ -77,6 +77,28 @@ describe("capabilityCommandPath", () => {
 });
 
 describe("deriveCapabilityLeaf: flags", () => {
+  test("property-less dynamic maps make the whole input part input-only", () => {
+    const dynamicSchemas = [
+      { type: "object", additionalProperties: { type: "string" } },
+      {
+        type: "object",
+        patternProperties: { "^meta-": { type: "string" } },
+      },
+    ];
+
+    for (const body of dynamicSchemas) {
+      const { spec } = deriveCapabilityLeaf(
+        entry({
+          id: "metadata.replace",
+          inputSchema: { body },
+        }),
+      );
+
+      expect(spec.flags).toHaveLength(0);
+      expect(spec.inputOnly).toEqual(["body"]);
+    }
+  });
+
   test("scalar body props become bare flags routed to input.body", () => {
     const { spec } = deriveCapabilityLeaf(
       entry({

--- a/packages/cli/src/generate-capability-tree.test.ts
+++ b/packages/cli/src/generate-capability-tree.test.ts
@@ -99,6 +99,24 @@ describe("deriveCapabilityLeaf: flags", () => {
     }
   });
 
+  test("property-less oneOf bodies make the whole input part input-only", () => {
+    const { spec } = deriveCapabilityLeaf(
+      entry({
+        id: "events.create",
+        inputSchema: {
+          body: {
+            oneOf: [
+              objectSchema({ type: { type: "string", const: "created" } }),
+              objectSchema({ type: { type: "string", const: "deleted" } }),
+            ],
+          },
+        },
+      }),
+    );
+
+    expect(spec.inputOnly).toEqual(["body"]);
+  });
+
   test("scalar body props become bare flags routed to input.body", () => {
     const { spec } = deriveCapabilityLeaf(
       entry({

--- a/packages/cli/src/generate-capability-tree.test.ts
+++ b/packages/cli/src/generate-capability-tree.test.ts
@@ -99,6 +99,30 @@ describe("deriveCapabilityLeaf: flags", () => {
     }
   });
 
+  test("allOf-inherited dynamic maps make the whole input part input-only", () => {
+    const { spec } = deriveCapabilityLeaf(
+      entry({
+        id: "metadata.replace",
+        inputSchema: {
+          body: {
+            allOf: [
+              {
+                allOf: [
+                  {
+                    patternProperties: { "^meta-": { type: "string" } },
+                  },
+                ],
+              },
+            ],
+          },
+        },
+      }),
+    );
+
+    expect(spec.flags).toHaveLength(0);
+    expect(spec.inputOnly).toEqual(["body"]);
+  });
+
   test("property-less oneOf bodies make the whole input part input-only", () => {
     const { spec } = deriveCapabilityLeaf(
       entry({

--- a/packages/cli/src/generate-capability-tree.test.ts
+++ b/packages/cli/src/generate-capability-tree.test.ts
@@ -117,6 +117,33 @@ describe("deriveCapabilityLeaf: flags", () => {
     expect(spec.inputOnly).toEqual(["body"]);
   });
 
+  test("mixed alternative and dynamic-map bodies keep flags plus the input contract", () => {
+    const mixedSchemas = [
+      {
+        ...objectSchema({ token: { type: "string" } }, ["token"]),
+        anyOf: [
+          objectSchema({ kind: { type: "string", const: "a" } }, ["kind"]),
+        ],
+      },
+      {
+        ...objectSchema({ token: { type: "string" } }, ["token"]),
+        patternProperties: { "^meta-": { type: "string" } },
+      },
+    ];
+
+    for (const body of mixedSchemas) {
+      const { spec } = deriveCapabilityLeaf(
+        entry({
+          id: "events.create",
+          inputSchema: { body },
+        }),
+      );
+
+      expect(flagByCli(spec, "--token")).toBeDefined();
+      expect(spec.inputOnly).toEqual(["body"]);
+    }
+  });
+
   test("scalar body props become bare flags routed to input.body", () => {
     const { spec } = deriveCapabilityLeaf(
       entry({

--- a/packages/cli/src/generate-capability-tree.ts
+++ b/packages/cli/src/generate-capability-tree.ts
@@ -125,6 +125,11 @@ const requiredSet = (schema: JsonSchema | undefined): ReadonlySet<string> => {
   return new Set(raw.filter((r): r is string => typeof r === "string"));
 };
 
+const hasDynamicObjectKeys = (schema: JsonSchema): boolean =>
+  schema["additionalProperties"] === true ||
+  isRecord(schema["additionalProperties"]) ||
+  isRecord(schema["patternProperties"]);
+
 /**
  * The input part carrying the `cursor`+`limit` pagination pair (query wins over
  * body when both somehow declare it), or `undefined` for a non-paginated
@@ -169,7 +174,7 @@ const candidatesForPart = ({
   if (
     schema !== undefined &&
     Object.keys(properties).length === 0 &&
-    (Array.isArray(schema["anyOf"]) || schema["additionalProperties"] === true)
+    (Array.isArray(schema["anyOf"]) || hasDynamicObjectKeys(schema))
   ) {
     inputOnly.push(part);
   }

--- a/packages/cli/src/generate-capability-tree.ts
+++ b/packages/cli/src/generate-capability-tree.ts
@@ -130,6 +130,9 @@ const hasDynamicObjectKeys = (schema: JsonSchema): boolean =>
   isRecord(schema["additionalProperties"]) ||
   isRecord(schema["patternProperties"]);
 
+const hasSchemaAlternatives = (schema: JsonSchema): boolean =>
+  Array.isArray(schema["anyOf"]) || Array.isArray(schema["oneOf"]);
+
 /**
  * The input part carrying the `cursor`+`limit` pagination pair (query wins over
  * body when both somehow declare it), or `undefined` for a non-paginated
@@ -174,7 +177,7 @@ const candidatesForPart = ({
   if (
     schema !== undefined &&
     Object.keys(properties).length === 0 &&
-    (Array.isArray(schema["anyOf"]) || hasDynamicObjectKeys(schema))
+    (hasSchemaAlternatives(schema) || hasDynamicObjectKeys(schema))
   ) {
     inputOnly.push(part);
   }

--- a/packages/cli/src/generate-capability-tree.ts
+++ b/packages/cli/src/generate-capability-tree.ts
@@ -166,6 +166,13 @@ const candidatesForPart = ({
   inputOnly: string[];
 }): Candidate[] => {
   const properties = propertyMap(schema);
+  if (
+    schema !== undefined &&
+    Object.keys(properties).length === 0 &&
+    (Array.isArray(schema["anyOf"]) || schema["additionalProperties"] === true)
+  ) {
+    inputOnly.push(part);
+  }
   const required = requiredSet(schema);
   const candidates: Candidate[] = [];
   for (const [prop, propSchema] of Object.entries(properties)) {

--- a/packages/cli/src/generate-capability-tree.ts
+++ b/packages/cli/src/generate-capability-tree.ts
@@ -174,11 +174,10 @@ const candidatesForPart = ({
   inputOnly: string[];
 }): Candidate[] => {
   const properties = propertyMap(schema);
-  if (
+  const wholePartInputOnly =
     schema !== undefined &&
-    Object.keys(properties).length === 0 &&
-    (hasSchemaAlternatives(schema) || hasDynamicObjectKeys(schema))
-  ) {
+    (hasSchemaAlternatives(schema) || hasDynamicObjectKeys(schema));
+  if (wholePartInputOnly) {
     inputOnly.push(part);
   }
   const required = requiredSet(schema);
@@ -189,7 +188,9 @@ const candidatesForPart = ({
     }
     const classification = classifyProp(prop, propSchema);
     if (classification.kind === "input-only") {
-      inputOnly.push(`${part}.${prop}`);
+      if (!wholePartInputOnly) {
+        inputOnly.push(`${part}.${prop}`);
+      }
       continue;
     }
     const specs =

--- a/packages/cli/src/generate-capability-tree.ts
+++ b/packages/cli/src/generate-capability-tree.ts
@@ -133,6 +133,20 @@ const hasDynamicObjectKeys = (schema: JsonSchema): boolean =>
 const hasSchemaAlternatives = (schema: JsonSchema): boolean =>
   Array.isArray(schema["anyOf"]) || Array.isArray(schema["oneOf"]);
 
+const requiresWholePartInput = (schema: JsonSchema): boolean => {
+  if (hasSchemaAlternatives(schema) || hasDynamicObjectKeys(schema)) {
+    return true;
+  }
+  const intersections = schema["allOf"];
+  return (
+    Array.isArray(intersections) &&
+    intersections.some(
+      (intersection) =>
+        isRecord(intersection) && requiresWholePartInput(intersection),
+    )
+  );
+};
+
 /**
  * The input part carrying the `cursor`+`limit` pagination pair (query wins over
  * body when both somehow declare it), or `undefined` for a non-paginated
@@ -175,8 +189,7 @@ const candidatesForPart = ({
 }): Candidate[] => {
   const properties = propertyMap(schema);
   const wholePartInputOnly =
-    schema !== undefined &&
-    (hasSchemaAlternatives(schema) || hasDynamicObjectKeys(schema));
+    schema !== undefined && requiresWholePartInput(schema);
   if (wholePartInputOnly) {
     inputOnly.push(part);
   }

--- a/packages/cli/src/generated/route-map.ts
+++ b/packages/cli/src/generated/route-map.ts
@@ -58608,7 +58608,7 @@ export const generatedRouteMap: RouteNode = {
                 partPath: "workspaceId",
               },
             ],
-            inputOnly: [],
+            inputOnly: ["body"],
             paginated: false,
             destructive: false,
             scope: "matters_write",

--- a/packages/cli/src/input-contract-help.test.ts
+++ b/packages/cli/src/input-contract-help.test.ts
@@ -598,6 +598,74 @@ describe("--input contract help", () => {
     expect(rendered).toContain("events[].reason  string  required");
   });
 
+  test("documents array item variants inherited through allOf", () => {
+    const schema: JsonSchema = {
+      type: "object",
+      properties: {
+        events: {
+          type: "array",
+          items: {
+            type: "object",
+            allOf: [
+              {
+                anyOf: [
+                  {
+                    properties: { type: { const: "created" } },
+                    required: ["type"],
+                  },
+                  {
+                    properties: { type: { const: "deleted" } },
+                    required: ["type"],
+                  },
+                ],
+              },
+            ],
+          },
+        },
+      },
+      required: ["events"],
+    };
+
+    const help = buildInputContractHelp({ schema, inputOnly: ["events"] });
+
+    expect(
+      help?.fields.some((line) =>
+        line.includes('events[].type  "created"  required'),
+      ),
+    ).toBe(true);
+    expect(
+      help?.fields.some((line) =>
+        line.includes('events[].type  "deleted"  required'),
+      ),
+    ).toBe(true);
+  });
+
+  test("documents array item maps inherited through allOf", () => {
+    const schema: JsonSchema = {
+      type: "object",
+      properties: {
+        events: {
+          type: "array",
+          items: {
+            type: "object",
+            allOf: [
+              {
+                patternProperties: { "^meta-": { type: "string" } },
+              },
+            ],
+          },
+        },
+      },
+      required: ["events"],
+    };
+
+    const help = buildInputContractHelp({ schema, inputOnly: ["events"] });
+
+    expect(help?.fields).toContain(
+      "  events[].<key>  string; key matches ^meta-  required",
+    );
+  });
+
   test("derives nested requiredness from the field's immediate parent", () => {
     const schema: JsonSchema = {
       type: "object",

--- a/packages/cli/src/input-contract-help.test.ts
+++ b/packages/cli/src/input-contract-help.test.ts
@@ -125,6 +125,32 @@ describe("--input contract help", () => {
       `--input '{"value":"client'\\''s"}'`,
     );
   });
+
+  test("synthesizes examples that satisfy anchored scalar patterns", () => {
+    const patterns = [
+      "^BOE-[A-Z]-\\d{4}-\\d+$",
+      "^[0-9A-Fa-f]{6}$",
+      "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+      "^[A-Za-z0-9]{7}$",
+      "^[A-Za-z]{2}$",
+      "^\\d+$",
+      "^\\d{8}$",
+    ];
+
+    for (const pattern of patterns) {
+      const schema: JsonSchema = {
+        type: "object",
+        properties: { value: { type: "string", pattern } },
+        required: ["value"],
+      };
+      const help = buildInputContractHelp({
+        schema,
+        inputOnly: ["value"],
+      });
+
+      expect(validateAgainstSchema(schema, help?.example).valid).toBe(true);
+    }
+  });
 });
 
 type GeneratedLeaf = Exclude<RouteNode, { kind: "route" }>;

--- a/packages/cli/src/input-contract-help.test.ts
+++ b/packages/cli/src/input-contract-help.test.ts
@@ -151,6 +151,19 @@ describe("--input contract help", () => {
       expect(validateAgainstSchema(schema, help?.example).valid).toBe(true);
     }
   });
+
+  test("falls back to a generic example for an invalid schema pattern", () => {
+    const help = buildInputContractHelp({
+      schema: {
+        type: "object",
+        properties: { value: { type: "string", pattern: "[" } },
+        required: ["value"],
+      },
+      inputOnly: ["value"],
+    });
+
+    expect(help?.example).toEqual({ value: "xxxxx" });
+  });
 });
 
 type GeneratedLeaf = Exclude<RouteNode, { kind: "route" }>;

--- a/packages/cli/src/input-contract-help.test.ts
+++ b/packages/cli/src/input-contract-help.test.ts
@@ -762,6 +762,31 @@ describe("--input contract help", () => {
     });
   });
 
+  test("documents and exemplifies typeless dynamic maps through allOf", () => {
+    const schema: JsonSchema = {
+      type: "object",
+      properties: {
+        body: {
+          allOf: [
+            {
+              patternProperties: { "^meta-": { type: "string" } },
+            },
+          ],
+        },
+      },
+      required: ["body"],
+    };
+
+    const help = buildInputContractHelp({ schema, inputOnly: ["body"] });
+
+    expect(help?.fields).toContain(
+      "body.<key>  string; key matches ^meta-  required",
+    );
+    expect(completeExample(help)).toEqual({
+      body: { "meta-key": "xxxxx" },
+    });
+  });
+
   test.each([
     [
       { additionalProperties: true },

--- a/packages/cli/src/input-contract-help.test.ts
+++ b/packages/cli/src/input-contract-help.test.ts
@@ -608,6 +608,31 @@ describe("--input contract help", () => {
     expect(completeExample(help)).toEqual({ metadata: { key: "xxxxx" } });
   });
 
+  test("documents and exemplifies dynamic keys beside named properties", () => {
+    const schema: JsonSchema = {
+      type: "object",
+      properties: {
+        body: {
+          type: "object",
+          properties: { token: { type: "string" } },
+          patternProperties: { "^meta-": { type: "string" } },
+          required: ["token"],
+        },
+      },
+      required: ["body"],
+    };
+
+    const help = buildInputContractHelp({ schema, inputOnly: ["body"] });
+
+    expect(help?.fields).toContain("  body.token  string  required");
+    expect(help?.fields).toContain(
+      "  body.<key>  string; key matches ^meta-  required",
+    );
+    expect(completeExample(help)).toEqual({
+      body: { token: "xxxxx", "meta-key": "xxxxx" },
+    });
+  });
+
   test("shell-quotes apostrophes in generated examples", () => {
     expect(formatInputExample({ value: "client's" })).toBe(
       `--input '{"value":"client'\\''s"}'`,

--- a/packages/cli/src/input-contract-help.test.ts
+++ b/packages/cli/src/input-contract-help.test.ts
@@ -75,6 +75,29 @@ describe("--input contract help", () => {
     expect(rendered).toContain("body.entityId  string  required");
   });
 
+  test("documents oneOf branches with a schema-valid example", () => {
+    const schema: JsonSchema = {
+      type: "object",
+      properties: {
+        value: {
+          oneOf: [
+            { type: "string", const: "first" },
+            { type: "string", const: "second" },
+          ],
+        },
+      },
+      required: ["value"],
+    };
+
+    const help = buildInputContractHelp({
+      schema,
+      inputOnly: ["value"],
+    });
+
+    expect(help?.fields.join("\n")).toContain("one of 2 variants");
+    expect(validateAgainstSchema(schema, help?.example).valid).toBe(true);
+  });
+
   test("documents every branch of an array item union", () => {
     const schema: JsonSchema = {
       type: "object",

--- a/packages/cli/src/input-contract-help.test.ts
+++ b/packages/cli/src/input-contract-help.test.ts
@@ -8,6 +8,16 @@ import {
 import { validateAgainstSchema } from "./json-schema-validate.js";
 import type { JsonSchema, RouteNode } from "./route-types.js";
 
+const completeExample = (
+  help: ReturnType<typeof buildInputContractHelp>,
+): Record<string, unknown> => {
+  expect(help?.example.status).toBe("complete");
+  if (help?.example.status !== "complete") {
+    throw new Error("Expected a complete input example");
+  }
+  return help.example.value;
+};
+
 describe("--input contract help", () => {
   test("renders free maps with a deterministic valid example", () => {
     const schema: JsonSchema = {
@@ -32,11 +42,13 @@ describe("--input contract help", () => {
     expect(help?.fields).toEqual([
       "values.<key>  any JSON value  required — Map of field path to value.",
     ]);
-    expect(help?.example).toEqual({
+    expect(completeExample(help)).toEqual({
       template_id: "xxxxx",
       values: { key: "value" },
     });
-    expect(validateAgainstSchema(schema, help?.example).valid).toBe(true);
+    expect(validateAgainstSchema(schema, completeExample(help)).valid).toBe(
+      true,
+    );
   });
 
   test("documents every branch of a discriminated upload body", () => {
@@ -95,7 +107,9 @@ describe("--input contract help", () => {
     });
 
     expect(help?.fields.join("\n")).toContain("one of 2 variants");
-    expect(validateAgainstSchema(schema, help?.example).valid).toBe(true);
+    expect(validateAgainstSchema(schema, completeExample(help)).valid).toBe(
+      true,
+    );
   });
 
   test("renders and satisfies simultaneous anyOf and oneOf constraints", () => {
@@ -124,7 +138,9 @@ describe("--input contract help", () => {
 
     expect(fields).toContain("anyOf: one of 2 variants");
     expect(fields).toContain("oneOf: one of 2 variants");
-    expect(validateAgainstSchema(schema, help?.example).valid).toBe(true);
+    expect(validateAgainstSchema(schema, completeExample(help)).valid).toBe(
+      true,
+    );
   });
 
   test("bounds composed example search without materializing branch products", () => {
@@ -148,7 +164,79 @@ describe("--input contract help", () => {
       inputOnly: ["value"],
     });
 
-    expect(validateAgainstSchema(schema, help?.example).valid).toBe(true);
+    expect(validateAgainstSchema(schema, completeExample(help)).valid).toBe(
+      true,
+    );
+  });
+
+  test("marks capped composed examples unavailable instead of claiming completeness", () => {
+    const schema: JsonSchema = {
+      type: "object",
+      properties: {
+        value: {
+          anyOf: [{ type: "string", const: "match" }],
+          oneOf: [
+            ...Array.from({ length: 64 }, (_, index) => ({
+              type: "string",
+              const: `other-${index}`,
+            })),
+            { type: "string", const: "match" },
+          ],
+        },
+      },
+      required: ["value"],
+    };
+
+    const help = buildInputContractHelp({ schema, inputOnly: ["value"] });
+
+    expect(help?.example).toEqual({ status: "unavailable" });
+  });
+
+  test("renders required object fields declared only through allOf", () => {
+    const schema: JsonSchema = {
+      type: "object",
+      properties: {
+        tool: {
+          type: "object",
+          allOf: [
+            {
+              type: "object",
+              properties: {
+                prompt: { type: "string" },
+                dependencies: {
+                  type: "array",
+                  items: { type: "string" },
+                },
+              },
+              required: ["prompt", "dependencies"],
+            },
+          ],
+        },
+      },
+      required: ["tool"],
+    };
+
+    const help = buildInputContractHelp({ schema, inputOnly: ["tool"] });
+    const fields = help?.fields.join("\n") ?? "";
+
+    expect(fields).toContain("tool.prompt  string  required");
+    expect(fields).toContain("tool.dependencies  array<string>  required");
+  });
+
+  test("does not mislabel nested scalar allOf schemas as objects", () => {
+    const schema: JsonSchema = {
+      type: "object",
+      properties: {
+        value: {
+          allOf: [{ allOf: [{ type: "string" }] }],
+        },
+      },
+      required: ["value"],
+    };
+
+    const help = buildInputContractHelp({ schema, inputOnly: ["value"] });
+
+    expect(help?.fields).toEqual(["value  string  required"]);
   });
 
   test("documents every branch of an array item union", () => {
@@ -236,7 +324,7 @@ describe("--input contract help", () => {
     });
 
     expect(help?.fields).toEqual(["metadata.<key>  string  required"]);
-    expect(help?.example).toEqual({ metadata: { key: "xxxxx" } });
+    expect(completeExample(help)).toEqual({ metadata: { key: "xxxxx" } });
   });
 
   test("shell-quotes apostrophes in generated examples", () => {
@@ -267,11 +355,13 @@ describe("--input contract help", () => {
         inputOnly: ["value"],
       });
 
-      expect(validateAgainstSchema(schema, help?.example).valid).toBe(true);
+      expect(validateAgainstSchema(schema, completeExample(help)).valid).toBe(
+        true,
+      );
     }
   });
 
-  test("falls back to a generic example for an invalid schema pattern", () => {
+  test("does not advertise a complete example for an invalid schema pattern", () => {
     const help = buildInputContractHelp({
       schema: {
         type: "object",
@@ -281,7 +371,7 @@ describe("--input contract help", () => {
       inputOnly: ["value"],
     });
 
-    expect(help?.example).toEqual({ value: "xxxxx" });
+    expect(help?.example).toEqual({ status: "unavailable" });
   });
 });
 
@@ -307,7 +397,8 @@ describe("generated --input help invariants", () => {
         }
         if (help !== undefined) {
           expect(
-            validateAgainstSchema(node.spec.inputSchema, help.example).valid,
+            validateAgainstSchema(node.spec.inputSchema, completeExample(help))
+              .valid,
           ).toBe(true);
         }
         continue;
@@ -327,7 +418,7 @@ describe("generated --input help invariants", () => {
       }
       const validation = validateAgainstSchema(
         node.spec.inputSchema,
-        help?.example,
+        completeExample(help),
       );
       if (!validation.valid) {
         throw new Error(

--- a/packages/cli/src/input-contract-help.test.ts
+++ b/packages/cli/src/input-contract-help.test.ts
@@ -75,6 +75,49 @@ describe("--input contract help", () => {
     expect(rendered).toContain("body.entityId  string  required");
   });
 
+  test("documents every branch of an array item union", () => {
+    const schema: JsonSchema = {
+      type: "object",
+      properties: {
+        events: {
+          type: "array",
+          items: {
+            anyOf: [
+              {
+                type: "object",
+                properties: {
+                  type: { type: "string", const: "created" },
+                  createdAt: { type: "string" },
+                },
+                required: ["type", "createdAt"],
+              },
+              {
+                type: "object",
+                properties: {
+                  type: { type: "string", const: "deleted" },
+                  reason: { type: "string" },
+                },
+                required: ["type", "reason"],
+              },
+            ],
+          },
+        },
+      },
+      required: ["events"],
+    };
+
+    const help = buildInputContractHelp({
+      schema,
+      inputOnly: ["events"],
+    });
+    const rendered = help?.fields.join("\n") ?? "";
+
+    expect(rendered).toContain('variant 1, type = "created"');
+    expect(rendered).toContain("events[].createdAt  string  required");
+    expect(rendered).toContain('variant 2, type = "deleted"');
+    expect(rendered).toContain("events[].reason  string  required");
+  });
+
   test("derives nested requiredness from the field's immediate parent", () => {
     const schema: JsonSchema = {
       type: "object",

--- a/packages/cli/src/input-contract-help.test.ts
+++ b/packages/cli/src/input-contract-help.test.ts
@@ -659,6 +659,57 @@ describe("--input contract help", () => {
     });
   });
 
+  test.each([
+    [
+      { additionalProperties: true },
+      { patternProperties: { "^meta-": { type: "string" } } },
+    ],
+    [
+      { patternProperties: { "^meta-": { type: "string" } } },
+      { additionalProperties: true },
+    ],
+  ])("exemplifies composed maps independently of allOf order", (...allOf) => {
+    const schema: JsonSchema = {
+      type: "object",
+      properties: {
+        body: { type: "object", allOf },
+      },
+      required: ["body"],
+    };
+
+    const help = buildInputContractHelp({ schema, inputOnly: ["body"] });
+
+    expect(completeExample(help)).toEqual({
+      body: { "meta-key": "xxxxx" },
+    });
+  });
+
+  test("documents inherited named fields beside inherited dynamic keys", () => {
+    const schema: JsonSchema = {
+      type: "object",
+      properties: {
+        body: {
+          type: "object",
+          allOf: [
+            {
+              properties: { token: { type: "string" } },
+              required: ["token"],
+              patternProperties: { "^meta-": { type: "string" } },
+            },
+          ],
+        },
+      },
+      required: ["body"],
+    };
+
+    const help = buildInputContractHelp({ schema, inputOnly: ["body"] });
+
+    expect(help?.fields).toContain("  body.token  string  required");
+    expect(help?.fields).toContain(
+      "  body.<key>  string; key matches ^meta-  required",
+    );
+  });
+
   test("shell-quotes apostrophes in generated examples", () => {
     expect(formatInputExample({ value: "client's" })).toBe(
       `--input '{"value":"client'\\''s"}'`,

--- a/packages/cli/src/input-contract-help.test.ts
+++ b/packages/cli/src/input-contract-help.test.ts
@@ -223,6 +223,34 @@ describe("--input contract help", () => {
     expect(fields).toContain("tool.dependencies  array<string>  required");
   });
 
+  test("merges requiredness across parent and sibling allOf branches", () => {
+    const schema: JsonSchema = {
+      type: "object",
+      properties: {
+        tool: {
+          type: "object",
+          required: ["prompt"],
+          allOf: [
+            {
+              type: "object",
+              properties: {
+                prompt: { type: "string" },
+                dependencies: { type: "array", items: { type: "string" } },
+              },
+            },
+            { type: "object", required: ["dependencies"] },
+          ],
+        },
+      },
+    };
+
+    const help = buildInputContractHelp({ schema, inputOnly: ["tool"] });
+    const fields = help?.fields.join("\n") ?? "";
+
+    expect(fields).toContain("tool.prompt  string  required");
+    expect(fields).toContain("tool.dependencies  array<string>  required");
+  });
+
   test("does not mislabel nested scalar allOf schemas as objects", () => {
     const schema: JsonSchema = {
       type: "object",

--- a/packages/cli/src/input-contract-help.test.ts
+++ b/packages/cli/src/input-contract-help.test.ts
@@ -304,6 +304,41 @@ describe("--input contract help", () => {
     expect(fields).toContain("body.token  string  required");
   });
 
+  test("renders alternative variants inherited through nested allOf", () => {
+    const schema: JsonSchema = {
+      type: "object",
+      properties: {
+        body: {
+          type: "object",
+          allOf: [
+            {
+              allOf: [
+                {
+                  anyOf: [
+                    {
+                      properties: { kind: { const: "first" } },
+                      required: ["kind"],
+                    },
+                    {
+                      properties: { kind: { const: "second" } },
+                      required: ["kind"],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    };
+
+    const help = buildInputContractHelp({ schema, inputOnly: ["body"] });
+    const fields = help?.fields.join("\n") ?? "";
+
+    expect(fields).toContain('body.kind  "first"  required');
+    expect(fields).toContain('body.kind  "second"  required');
+  });
+
   test("renders direct sibling fields alongside alternative variants", () => {
     const schema: JsonSchema = {
       type: "object",

--- a/packages/cli/src/input-contract-help.test.ts
+++ b/packages/cli/src/input-contract-help.test.ts
@@ -633,6 +633,32 @@ describe("--input contract help", () => {
     });
   });
 
+  test("documents dynamic keys inherited through allOf", () => {
+    const schema: JsonSchema = {
+      type: "object",
+      properties: {
+        body: {
+          type: "object",
+          allOf: [
+            {
+              patternProperties: { "^meta-": { type: "string" } },
+            },
+          ],
+        },
+      },
+      required: ["body"],
+    };
+
+    const help = buildInputContractHelp({ schema, inputOnly: ["body"] });
+
+    expect(help?.fields).toContain(
+      "body.<key>  string; key matches ^meta-  required",
+    );
+    expect(completeExample(help)).toEqual({
+      body: { "meta-key": "xxxxx" },
+    });
+  });
+
   test("shell-quotes apostrophes in generated examples", () => {
     expect(formatInputExample({ value: "client's" })).toBe(
       `--input '{"value":"client'\\''s"}'`,

--- a/packages/cli/src/input-contract-help.test.ts
+++ b/packages/cli/src/input-contract-help.test.ts
@@ -251,6 +251,259 @@ describe("--input contract help", () => {
     expect(fields).toContain("tool.dependencies  array<string>  required");
   });
 
+  test("marks an input-only root required through nested allOf", () => {
+    const schema: JsonSchema = {
+      type: "object",
+      properties: {
+        body: {
+          type: "object",
+          additionalProperties: true,
+        },
+      },
+      allOf: [{ allOf: [{ required: ["body"] }] }],
+    };
+
+    const help = buildInputContractHelp({ schema, inputOnly: ["body"] });
+
+    expect(help?.fields).toEqual(["body.<key>  any JSON value  required"]);
+  });
+
+  test("renders shared allOf fields alongside alternative variants", () => {
+    const schema: JsonSchema = {
+      type: "object",
+      properties: {
+        body: {
+          type: "object",
+          anyOf: [
+            {
+              type: "object",
+              properties: { kind: { const: "first" } },
+              required: ["kind"],
+            },
+            {
+              type: "object",
+              properties: { kind: { const: "second" } },
+              required: ["kind"],
+            },
+          ],
+          allOf: [
+            {
+              properties: { token: { type: "string" } },
+            },
+            { required: ["token"] },
+          ],
+        },
+      },
+    };
+
+    const help = buildInputContractHelp({ schema, inputOnly: ["body"] });
+    const fields = help?.fields.join("\n") ?? "";
+
+    expect(fields).toContain('body.kind  "first"  required');
+    expect(fields).toContain('body.kind  "second"  required');
+    expect(fields).toContain("body.token  string  required");
+  });
+
+  test("renders direct sibling fields alongside alternative variants", () => {
+    const schema: JsonSchema = {
+      type: "object",
+      properties: {
+        body: {
+          type: "object",
+          properties: { token: { type: "string" } },
+          required: ["token"],
+          anyOf: [
+            {
+              properties: { kind: { const: "first" } },
+              required: ["kind"],
+            },
+            {
+              properties: { kind: { const: "second" } },
+              required: ["kind"],
+            },
+          ],
+        },
+      },
+    };
+
+    const help = buildInputContractHelp({ schema, inputOnly: ["body"] });
+    const fields = help?.fields.join("\n") ?? "";
+
+    expect(fields).toContain('body.kind  "first"  required');
+    expect(fields).toContain('body.kind  "second"  required');
+    expect(fields).toContain("body.token  string  required");
+  });
+
+  test("searches every branch of a single alternative group for a valid example", () => {
+    const schema: JsonSchema = {
+      type: "object",
+      properties: {
+        value: {
+          anyOf: [{ const: "wrong" }, { const: "right" }],
+          allOf: [{ const: "right" }],
+        },
+      },
+      required: ["value"],
+    };
+
+    const help = buildInputContractHelp({ schema, inputOnly: ["value"] });
+
+    expect(completeExample(help)).toEqual({ value: "right" });
+  });
+
+  test("carries parent numeric bounds into an Elysia integer branch", () => {
+    const schema: JsonSchema = {
+      type: "object",
+      properties: {
+        size: {
+          anyOf: [{ type: "string", format: "integer" }, { type: "number" }],
+          minimum: 1,
+        },
+      },
+      required: ["size"],
+    };
+
+    const help = buildInputContractHelp({ schema, inputOnly: ["size"] });
+
+    expect(completeExample(help)).toEqual({ size: "1" });
+  });
+
+  test("recursively composes constraints on overlapping object properties", () => {
+    const schema: JsonSchema = {
+      type: "object",
+      properties: {
+        body: {
+          type: "object",
+          properties: {
+            code: { type: "string", minLength: 5 },
+          },
+          required: ["code"],
+          anyOf: [
+            {
+              properties: {
+                code: { type: "string", pattern: "^a+$" },
+              },
+            },
+          ],
+        },
+      },
+      required: ["body"],
+    };
+
+    const help = buildInputContractHelp({ schema, inputOnly: ["body"] });
+
+    expect(completeExample(help)).toEqual({ body: { code: "aaaaa" } });
+  });
+
+  test("preserves parent and branch allOf constraints on nested properties", () => {
+    const schema: JsonSchema = {
+      type: "object",
+      properties: {
+        body: {
+          type: "object",
+          properties: {
+            code: {
+              allOf: [{ type: "string", minLength: 5 }],
+            },
+          },
+          required: ["code"],
+          anyOf: [
+            {
+              properties: {
+                code: {
+                  allOf: [{ type: "string", pattern: "^a+$" }],
+                },
+              },
+            },
+          ],
+        },
+      },
+      required: ["body"],
+    };
+
+    const help = buildInputContractHelp({ schema, inputOnly: ["body"] });
+
+    expect(completeExample(help)).toEqual({ body: { code: "aaaaa" } });
+  });
+
+  test("preserves intersecting direct patterns on nested properties", () => {
+    const schema: JsonSchema = {
+      type: "object",
+      properties: {
+        body: {
+          type: "object",
+          properties: {
+            code: { type: "string", pattern: "^a", minLength: 5 },
+          },
+          required: ["code"],
+          anyOf: [
+            {
+              properties: {
+                code: { type: "string", pattern: "z$" },
+              },
+            },
+          ],
+        },
+      },
+      required: ["body"],
+    };
+
+    const help = buildInputContractHelp({ schema, inputOnly: ["body"] });
+
+    expect(completeExample(help)).toEqual({ body: { code: "aaaaz" } });
+  });
+
+  test("marks an impossible bounded pattern intersection unavailable", () => {
+    const schema: JsonSchema = {
+      type: "object",
+      properties: {
+        body: {
+          type: "object",
+          properties: {
+            code: { type: "string", pattern: "^a$", maxLength: 1 },
+          },
+          required: ["code"],
+          anyOf: [
+            {
+              properties: {
+                code: { type: "string", pattern: "^b$" },
+              },
+            },
+          ],
+        },
+      },
+      required: ["body"],
+    };
+
+    const help = buildInputContractHelp({ schema, inputOnly: ["body"] });
+
+    expect(help?.example).toEqual({ status: "unavailable" });
+  });
+
+  test("normalizes compatible prefix and suffix intersections by specificity", () => {
+    const schema: JsonSchema = {
+      type: "object",
+      properties: {
+        prefix: {
+          type: "string",
+          allOf: [{ pattern: "^a" }, { pattern: "^ab" }],
+        },
+        suffix: {
+          type: "string",
+          allOf: [{ pattern: "a$" }, { pattern: "ba$" }],
+        },
+      },
+      required: ["prefix", "suffix"],
+    };
+
+    const help = buildInputContractHelp({
+      schema,
+      inputOnly: ["prefix", "suffix"],
+    });
+
+    expect(completeExample(help)).toEqual({ prefix: "ab", suffix: "ba" });
+  });
+
   test("does not mislabel nested scalar allOf schemas as objects", () => {
     const schema: JsonSchema = {
       type: "object",

--- a/packages/cli/src/input-contract-help.test.ts
+++ b/packages/cli/src/input-contract-help.test.ts
@@ -98,6 +98,35 @@ describe("--input contract help", () => {
     expect(validateAgainstSchema(schema, help?.example).valid).toBe(true);
   });
 
+  test("renders and satisfies simultaneous anyOf and oneOf constraints", () => {
+    const schema: JsonSchema = {
+      type: "object",
+      properties: {
+        value: {
+          anyOf: [
+            { type: "string", pattern: "^a" },
+            { type: "string", pattern: "^b" },
+          ],
+          oneOf: [
+            { type: "string", const: "apple" },
+            { type: "string", const: "banana" },
+          ],
+        },
+      },
+      required: ["value"],
+    };
+
+    const help = buildInputContractHelp({
+      schema,
+      inputOnly: ["value"],
+    });
+    const fields = help?.fields.join("\n") ?? "";
+
+    expect(fields).toContain("anyOf: one of 2 variants");
+    expect(fields).toContain("oneOf: one of 2 variants");
+    expect(validateAgainstSchema(schema, help?.example).valid).toBe(true);
+  });
+
   test("documents every branch of an array item union", () => {
     const schema: JsonSchema = {
       type: "object",

--- a/packages/cli/src/input-contract-help.test.ts
+++ b/packages/cli/src/input-contract-help.test.ts
@@ -710,6 +710,35 @@ describe("--input contract help", () => {
     );
   });
 
+  test.each(["anyOf", "oneOf"] as const)(
+    "documents shared dynamic keys beside %s variants",
+    (keyword) => {
+      const schema: JsonSchema = {
+        type: "object",
+        properties: {
+          body: {
+            type: "object",
+            [keyword]: [
+              {
+                type: "object",
+                properties: { kind: { const: "a", type: "string" } },
+                required: ["kind"],
+              },
+            ],
+            patternProperties: { "^meta-": { type: "string" } },
+          },
+        },
+        required: ["body"],
+      };
+
+      const help = buildInputContractHelp({ schema, inputOnly: ["body"] });
+
+      expect(help?.fields).toContain(
+        "  body.<key>  string; key matches ^meta-  required",
+      );
+    },
+  );
+
   test("shell-quotes apostrophes in generated examples", () => {
     expect(formatInputExample({ value: "client's" })).toBe(
       `--input '{"value":"client'\\''s"}'`,

--- a/packages/cli/src/input-contract-help.test.ts
+++ b/packages/cli/src/input-contract-help.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, test } from "bun:test";
+
+import { generatedRouteMap } from "./generated/route-map.js";
+import {
+  buildInputContractHelp,
+  formatInputExample,
+} from "./input-contract-help.js";
+import { validateAgainstSchema } from "./json-schema-validate.js";
+import type { JsonSchema, RouteNode } from "./route-types.js";
+
+describe("--input contract help", () => {
+  test("renders free maps with a deterministic valid example", () => {
+    const schema: JsonSchema = {
+      type: "object",
+      properties: {
+        template_id: { type: "string" },
+        values: {
+          type: "object",
+          description: "Map of field path to value.",
+          additionalProperties: true,
+        },
+      },
+      required: ["template_id", "values"],
+    };
+
+    const help = buildInputContractHelp({
+      schema,
+      inputOnly: ["values"],
+      requiredPaths: ["template_id"],
+    });
+
+    expect(help?.fields).toEqual([
+      "values.<key>  any JSON value  required — Map of field path to value.",
+    ]);
+    expect(help?.example).toEqual({
+      template_id: "xxxxx",
+      values: { key: "value" },
+    });
+    expect(validateAgainstSchema(schema, help?.example).valid).toBe(true);
+  });
+
+  test("documents every branch of a discriminated upload body", () => {
+    const schema: JsonSchema = {
+      type: "object",
+      properties: {
+        body: {
+          anyOf: [
+            {
+              type: "object",
+              properties: {
+                purpose: { type: "string", const: "entity_create" },
+                propertyId: { type: "string" },
+              },
+              required: ["purpose", "propertyId"],
+            },
+            {
+              type: "object",
+              properties: {
+                purpose: { type: "string", const: "entity_version" },
+                entityId: { type: "string" },
+              },
+              required: ["purpose", "entityId"],
+            },
+          ],
+        },
+      },
+    };
+
+    const help = buildInputContractHelp({ schema, inputOnly: ["body"] });
+    const rendered = help?.fields.join("\n") ?? "";
+
+    expect(rendered).toContain('variant 1, purpose = "entity_create"');
+    expect(rendered).toContain("body.propertyId  string  required");
+    expect(rendered).toContain('variant 2, purpose = "entity_version"');
+    expect(rendered).toContain("body.entityId  string  required");
+  });
+
+  test("derives nested requiredness from the field's immediate parent", () => {
+    const schema: JsonSchema = {
+      type: "object",
+      properties: {
+        body: {
+          type: "object",
+          properties: {
+            requiredObject: { type: "object", additionalProperties: true },
+            optionalObject: { type: "object", additionalProperties: true },
+          },
+          required: ["requiredObject"],
+        },
+      },
+    };
+
+    const help = buildInputContractHelp({
+      schema,
+      inputOnly: ["body.requiredObject", "body.optionalObject"],
+    });
+
+    expect(help?.fields.at(0)).toContain("required");
+    expect(help?.fields.at(1)).toContain("optional");
+  });
+
+  test("documents pattern-property objects as maps", () => {
+    const schema: JsonSchema = {
+      type: "object",
+      properties: {
+        metadata: {
+          type: "object",
+          patternProperties: { "^(.*)$": { type: "string" } },
+        },
+      },
+      required: ["metadata"],
+    };
+
+    const help = buildInputContractHelp({
+      schema,
+      inputOnly: ["metadata"],
+    });
+
+    expect(help?.fields).toEqual(["metadata.<key>  string  required"]);
+    expect(help?.example).toEqual({ metadata: { key: "xxxxx" } });
+  });
+
+  test("shell-quotes apostrophes in generated examples", () => {
+    expect(formatInputExample({ value: "client's" })).toBe(
+      `--input '{"value":"client'\\''s"}'`,
+    );
+  });
+});
+
+type GeneratedLeaf = Exclude<RouteNode, { kind: "route" }>;
+
+const generatedLeaves = (node: RouteNode): GeneratedLeaf[] => {
+  if (node.kind !== "route") {
+    return [node];
+  }
+  return Object.values(node.children).flatMap(generatedLeaves);
+};
+
+describe("generated --input help invariants", () => {
+  test("every input-only path is documented from its originating schema", () => {
+    for (const node of generatedLeaves(generatedRouteMap)) {
+      if (node.kind === "leaf") {
+        const help = buildInputContractHelp({
+          schema: node.spec.inputSchema,
+          inputOnly: node.spec.inputOnly,
+        });
+        for (const path of node.spec.inputOnly) {
+          expect(help?.fields.some((line) => line.includes(path))).toBe(true);
+        }
+        if (help !== undefined) {
+          expect(
+            validateAgainstSchema(node.spec.inputSchema, help.example).valid,
+          ).toBe(true);
+        }
+        continue;
+      }
+      if (
+        node.spec.inputSchema === undefined ||
+        node.spec.inputOnly.length === 0
+      ) {
+        continue;
+      }
+      const help = buildInputContractHelp({
+        schema: node.spec.inputSchema,
+        inputOnly: node.spec.inputOnly,
+      });
+      for (const path of node.spec.inputOnly) {
+        expect(help?.fields.some((line) => line.includes(path))).toBe(true);
+      }
+      const validation = validateAgainstSchema(
+        node.spec.inputSchema,
+        help?.example,
+      );
+      if (!validation.valid) {
+        throw new Error(
+          `${node.spec.capabilityId} generated invalid example at ${validation.path}: ${validation.message}`,
+        );
+      }
+    }
+  });
+});

--- a/packages/cli/src/input-contract-help.test.ts
+++ b/packages/cli/src/input-contract-help.test.ts
@@ -127,6 +127,30 @@ describe("--input contract help", () => {
     expect(validateAgainstSchema(schema, help?.example).valid).toBe(true);
   });
 
+  test("bounds composed example search without materializing branch products", () => {
+    const variants = Array.from({ length: 1000 }, (_, index) => ({
+      type: "string",
+      const: `value-${index}`,
+    }));
+    const schema: JsonSchema = {
+      type: "object",
+      properties: {
+        value: {
+          anyOf: variants,
+          oneOf: variants,
+        },
+      },
+      required: ["value"],
+    };
+
+    const help = buildInputContractHelp({
+      schema,
+      inputOnly: ["value"],
+    });
+
+    expect(validateAgainstSchema(schema, help?.example).valid).toBe(true);
+  });
+
   test("documents every branch of an array item union", () => {
     const schema: JsonSchema = {
       type: "object",

--- a/packages/cli/src/input-contract-help.ts
+++ b/packages/cli/src/input-contract-help.ts
@@ -1,4 +1,5 @@
 import type { JsonSchema } from "./route-types.js";
+import { compileSchemaPattern } from "./schema-pattern.js";
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value);
@@ -343,7 +344,11 @@ const patternExample = (pattern: string): string | undefined => {
   }
 
   const example = tokens.join("");
-  return new RegExp(pattern, "u").test(example) ? example : undefined;
+  const compiled = compileSchemaPattern(pattern);
+  if (compiled.status === "invalid") {
+    return undefined;
+  }
+  return compiled.regex.test(example) ? example : undefined;
 };
 
 const stringExample = (schema: JsonSchema): string => {

--- a/packages/cli/src/input-contract-help.ts
+++ b/packages/cli/src/input-contract-help.ts
@@ -51,6 +51,14 @@ type AlternativeGroup = {
   variants: readonly JsonSchema[];
 };
 
+const MAX_COMPOSED_EXAMPLE_CANDIDATES = 64;
+
+type ExampleSearchResult =
+  | { status: "found"; example: unknown }
+  | { status: "not-found" };
+
+const exampleNotFound: ExampleSearchResult = { status: "not-found" };
+
 const alternativeGroupsOf = (schema: JsonSchema): AlternativeGroup[] => {
   const groups: AlternativeGroup[] = [];
   for (const keyword of ["anyOf", "oneOf"] as const) {
@@ -65,6 +73,44 @@ const alternativeGroupsOf = (schema: JsonSchema): AlternativeGroup[] => {
 const allOf = (schema: JsonSchema): readonly JsonSchema[] => {
   const variants = schema["allOf"];
   return Array.isArray(variants) ? variants.filter(isRecord) : [];
+};
+
+const findComposedExample = (
+  schema: JsonSchema,
+  base: JsonSchema,
+  groups: readonly AlternativeGroup[],
+): ExampleSearchResult => {
+  let candidatesRemaining = MAX_COMPOSED_EXAMPLE_CANDIDATES;
+  const selection: JsonSchema[] = [];
+
+  const search = (groupIndex: number): ExampleSearchResult => {
+    if (candidatesRemaining === 0) {
+      return exampleNotFound;
+    }
+    const group = groups[groupIndex];
+    if (group !== undefined) {
+      for (const variant of group.variants) {
+        selection.push(variant);
+        const result = search(groupIndex + 1);
+        selection.pop();
+        if (result.status === "found" || candidatesRemaining === 0) {
+          return result;
+        }
+      }
+      return exampleNotFound;
+    }
+
+    candidatesRemaining -= 1;
+    const candidate = exampleFor({
+      ...base,
+      allOf: [...allOf(base), ...selection],
+    });
+    return validateAgainstSchema(schema, candidate).valid
+      ? { status: "found", example: candidate }
+      : exampleNotFound;
+  };
+
+  return search(0);
 };
 
 const mapValueSchema = (schema: JsonSchema): JsonSchema | undefined => {
@@ -435,25 +481,10 @@ const exampleFor = (schema: JsonSchema): unknown => {
     });
   }
   if (alternativeGroups.length > 1) {
-    let combinations: JsonSchema[][] = [[]];
-    for (const group of alternativeGroups) {
-      const next: JsonSchema[][] = [];
-      for (const combination of combinations) {
-        for (const variant of group.variants) {
-          next.push([...combination, variant]);
-        }
-      }
-      combinations = next;
-    }
     const base = { ...schema, anyOf: undefined, oneOf: undefined };
-    for (const combination of combinations) {
-      const candidate = exampleFor({
-        ...base,
-        allOf: [...allOf(base), ...combination],
-      });
-      if (validateAgainstSchema(schema, candidate).valid) {
-        return candidate;
-      }
+    const result = findComposedExample(schema, base, alternativeGroups);
+    if (result.status === "found") {
+      return result.example;
     }
     return exampleFor(base);
   }

--- a/packages/cli/src/input-contract-help.ts
+++ b/packages/cli/src/input-contract-help.ts
@@ -1,3 +1,4 @@
+import { validateAgainstSchema } from "./json-schema-validate.js";
 import type { JsonSchema } from "./route-types.js";
 import { compileSchemaPattern } from "./schema-pattern.js";
 
@@ -45,14 +46,20 @@ const descriptionOf = (schema: JsonSchema): string | undefined => {
   return normalized.length === 0 ? undefined : normalized;
 };
 
-const alternativesOf = (schema: JsonSchema): readonly JsonSchema[] => {
+type AlternativeGroup = {
+  keyword: "anyOf" | "oneOf";
+  variants: readonly JsonSchema[];
+};
+
+const alternativeGroupsOf = (schema: JsonSchema): AlternativeGroup[] => {
+  const groups: AlternativeGroup[] = [];
   for (const keyword of ["anyOf", "oneOf"] as const) {
     const variants = schema[keyword];
     if (Array.isArray(variants)) {
-      return variants.filter(isRecord);
+      groups.push({ keyword, variants: variants.filter(isRecord) });
     }
   }
-  return [];
+  return groups;
 };
 
 const allOf = (schema: JsonSchema): readonly JsonSchema[] => {
@@ -138,27 +145,29 @@ const renderSchema = ({
   indent: number;
   lines: string[];
 }): void => {
-  const variants = alternativesOf(schema);
-  if (variants.length > 0) {
-    lines.push(
-      lineFor({
-        path,
-        type: `one of ${variants.length} variants`,
-        required,
-        description: descriptionOf(schema),
-        indent,
-      }),
-    );
-    for (const [index, variant] of variants.entries()) {
-      const label = variantLabel(variant, index);
-      lines.push(`${"  ".repeat(indent + 1)}${label}:`);
-      renderSchema({
-        path,
-        schema: variant,
-        required,
-        indent: indent + 2,
-        lines,
-      });
+  const alternativeGroups = alternativeGroupsOf(schema);
+  if (alternativeGroups.length > 0) {
+    for (const { keyword, variants } of alternativeGroups) {
+      lines.push(
+        lineFor({
+          path,
+          type: `${keyword}: one of ${variants.length} variants`,
+          required,
+          description: descriptionOf(schema),
+          indent,
+        }),
+      );
+      for (const [index, variant] of variants.entries()) {
+        const label = variantLabel(variant, index);
+        lines.push(`${"  ".repeat(indent + 1)}${label}:`);
+        renderSchema({
+          path,
+          schema: variant,
+          required,
+          indent: indent + 2,
+          lines,
+        });
+      }
     }
     return;
   }
@@ -176,7 +185,10 @@ const renderSchema = ({
         indent,
       }),
     );
-    if (itemSchema !== undefined && alternativesOf(itemSchema).length > 0) {
+    if (
+      itemSchema !== undefined &&
+      alternativeGroupsOf(itemSchema).length > 0
+    ) {
       renderSchema({
         path: `${path}[]`,
         schema: itemSchema,
@@ -412,19 +424,49 @@ const exampleFor = (schema: JsonSchema): unknown => {
   if (Array.isArray(enumValues) && enumValues.length > 0) {
     return enumValues.at(0);
   }
-  const variants = alternativesOf(schema);
-  if (variants.length > 0) {
-    const variant = variants.at(0) ?? {};
+  const alternativeGroups = alternativeGroupsOf(schema);
+  if (alternativeGroups.length === 1) {
+    const group = alternativeGroups.at(0);
+    const variant = group?.variants.at(0) ?? {};
     return exampleFor({
       ...schema,
-      anyOf: undefined,
-      oneOf: undefined,
+      [group?.keyword ?? "anyOf"]: undefined,
       ...variant,
     });
   }
+  if (alternativeGroups.length > 1) {
+    let combinations: JsonSchema[][] = [[]];
+    for (const group of alternativeGroups) {
+      const next: JsonSchema[][] = [];
+      for (const combination of combinations) {
+        for (const variant of group.variants) {
+          next.push([...combination, variant]);
+        }
+      }
+      combinations = next;
+    }
+    const base = { ...schema, anyOf: undefined, oneOf: undefined };
+    for (const combination of combinations) {
+      const candidate = exampleFor({
+        ...base,
+        allOf: [...allOf(base), ...combination],
+      });
+      if (validateAgainstSchema(schema, candidate).valid) {
+        return candidate;
+      }
+    }
+    return exampleFor(base);
+  }
   const intersections = allOf(schema);
   if (intersections.length > 0) {
-    const result = exampleFor({ ...schema, allOf: undefined });
+    const baseSchema = { ...schema, allOf: undefined };
+    const result = exampleFor(baseSchema);
+    for (const intersection of intersections) {
+      const candidate = exampleFor(intersection);
+      if (validateAgainstSchema(schema, candidate).valid) {
+        return candidate;
+      }
+    }
     const objectResult = isRecord(result) ? result : {};
     for (const intersection of intersections) {
       const example = exampleFor(intersection);

--- a/packages/cli/src/input-contract-help.ts
+++ b/packages/cli/src/input-contract-help.ts
@@ -85,6 +85,13 @@ const allOf = (schema: JsonSchema): readonly JsonSchema[] => {
   return Array.isArray(variants) ? variants.filter(isRecord) : [];
 };
 
+const alternativeGroupsAcrossAllOf = (
+  schema: JsonSchema,
+): AlternativeGroup[] => [
+  ...alternativeGroupsOf(schema),
+  ...allOf(schema).flatMap(alternativeGroupsAcrossAllOf),
+];
+
 const describesObject = (schema: JsonSchema): boolean =>
   schemaTypes(schema).includes("object") ||
   Object.keys(propertiesOf(schema)).length > 0 ||
@@ -263,7 +270,7 @@ const renderSchema = ({
   indent: number;
   lines: string[];
 }): void => {
-  const alternativeGroups = alternativeGroupsOf(schema);
+  const alternativeGroups = alternativeGroupsAcrossAllOf(schema);
   if (alternativeGroups.length > 0) {
     for (const { keyword, variants } of alternativeGroups) {
       lines.push(

--- a/packages/cli/src/input-contract-help.ts
+++ b/packages/cli/src/input-contract-help.ts
@@ -53,6 +53,11 @@ const anyOf = (schema: JsonSchema): readonly JsonSchema[] => {
   return variants.filter(isRecord);
 };
 
+const allOf = (schema: JsonSchema): readonly JsonSchema[] => {
+  const variants = schema["allOf"];
+  return Array.isArray(variants) ? variants.filter(isRecord) : [];
+};
+
 const mapValueSchema = (schema: JsonSchema): JsonSchema | undefined => {
   const additional = schema["additionalProperties"];
   if (additional === true) {
@@ -400,7 +405,19 @@ const exampleFor = (schema: JsonSchema): unknown => {
   const variants = anyOf(schema);
   if (variants.length > 0) {
     const variant = variants.at(0) ?? {};
-    return exampleFor({ ...schema, ...variant, anyOf: undefined });
+    return exampleFor({ ...schema, anyOf: undefined, ...variant });
+  }
+  const intersections = allOf(schema);
+  if (intersections.length > 0) {
+    const result = exampleFor({ ...schema, allOf: undefined });
+    const objectResult = isRecord(result) ? result : {};
+    for (const intersection of intersections) {
+      const example = exampleFor(intersection);
+      if (isRecord(example)) {
+        Object.assign(objectResult, example);
+      }
+    }
+    return objectResult;
   }
   const types = schemaTypes(schema);
   const defaultValue = schema["default"];

--- a/packages/cli/src/input-contract-help.ts
+++ b/packages/cli/src/input-contract-help.ts
@@ -92,9 +92,15 @@ const alternativeGroupsAcrossAllOf = (
   ...allOf(schema).flatMap(alternativeGroupsAcrossAllOf),
 ];
 
+const hasDirectDynamicObjectKeys = (schema: JsonSchema): boolean =>
+  schema["additionalProperties"] === true ||
+  isRecord(schema["additionalProperties"]) ||
+  isRecord(schema["patternProperties"]);
+
 const describesObject = (schema: JsonSchema): boolean =>
   schemaTypes(schema).includes("object") ||
   Object.keys(propertiesOf(schema)).length > 0 ||
+  hasDirectDynamicObjectKeys(schema) ||
   allOf(schema).some(describesObject);
 
 const hasNamedPropertiesAcrossAllOf = (schema: JsonSchema): boolean =>
@@ -350,12 +356,13 @@ const renderSchema = ({
 
   const properties = propertiesOf(schema);
   const intersections = allOf(schema);
+  const mapEntries = mapEntrySchemas(schema);
   if (
     types.includes("object") ||
     Object.keys(properties).length > 0 ||
-    intersections.some(describesObject)
+    intersections.some(describesObject) ||
+    mapEntries.length > 0
   ) {
-    const mapEntries = mapEntrySchemas(schema);
     const freeMap =
       mapEntries.length > 0 && !hasNamedPropertiesAcrossAllOf(schema);
     if (freeMap) {
@@ -956,10 +963,7 @@ const exampleFor = (schema: JsonSchema): unknown => {
   ) {
     return defaultValue;
   }
-  if (
-    types.includes("object") ||
-    Object.keys(propertiesOf(schema)).length > 0
-  ) {
+  if (describesObject(schema)) {
     const result: Record<string, unknown> = {};
     for (const name of requiredOf(schema)) {
       const child = propertiesOf(schema)[name];

--- a/packages/cli/src/input-contract-help.ts
+++ b/packages/cli/src/input-contract-help.ts
@@ -75,6 +75,11 @@ const allOf = (schema: JsonSchema): readonly JsonSchema[] => {
   return Array.isArray(variants) ? variants.filter(isRecord) : [];
 };
 
+const describesObject = (schema: JsonSchema): boolean =>
+  schemaTypes(schema).includes("object") ||
+  Object.keys(propertiesOf(schema)).length > 0 ||
+  allOf(schema).some(describesObject);
+
 const findComposedExample = (
   schema: JsonSchema,
   base: JsonSchema,
@@ -148,6 +153,16 @@ const scalarTypeLabel = (schema: JsonSchema): string => {
   const types = schemaTypes(schema);
   if (types.length > 0) {
     return types.join(" | ");
+  }
+  const intersectionTypes = [
+    ...new Set(
+      allOf(schema)
+        .map(scalarTypeLabel)
+        .filter((label) => label !== "any JSON value"),
+    ),
+  ];
+  if (intersectionTypes.length > 0) {
+    return intersectionTypes.join(" & ");
   }
   return "any JSON value";
 };
@@ -257,7 +272,12 @@ const renderSchema = ({
   }
 
   const properties = propertiesOf(schema);
-  if (types.includes("object") || Object.keys(properties).length > 0) {
+  const intersections = allOf(schema);
+  if (
+    types.includes("object") ||
+    Object.keys(properties).length > 0 ||
+    intersections.some(describesObject)
+  ) {
     const mapValue = mapValueSchema(schema);
     const freeMap =
       mapValue !== undefined && Object.keys(properties).length === 0;
@@ -307,6 +327,9 @@ const renderObjectChildren = ({
       indent,
       lines,
     });
+  }
+  for (const intersection of allOf(schema)) {
+    renderObjectChildren({ path, schema: intersection, indent, lines });
   }
 };
 
@@ -588,9 +611,13 @@ const setExamplePath = (
   }
 };
 
+type InputContractExample =
+  | { status: "complete"; value: Record<string, unknown> }
+  | { status: "unavailable" };
+
 export type InputContractHelp = {
   fields: readonly string[];
-  example: Record<string, unknown>;
+  example: InputContractExample;
 };
 
 /** Quote a generated JSON example as one POSIX-shell argument. */
@@ -636,5 +663,10 @@ export const buildInputContractHelp = ({
   for (const path of [...inputOnly, ...requiredPaths]) {
     setExamplePath(schema, example, path);
   }
-  return { fields, example };
+  return {
+    fields,
+    example: validateAgainstSchema(schema, example).valid
+      ? { status: "complete", value: example }
+      : { status: "unavailable" },
+  };
 };

--- a/packages/cli/src/input-contract-help.ts
+++ b/packages/cli/src/input-contract-help.ts
@@ -90,6 +90,10 @@ const describesObject = (schema: JsonSchema): boolean =>
   Object.keys(propertiesOf(schema)).length > 0 ||
   allOf(schema).some(describesObject);
 
+const hasNamedPropertiesAcrossAllOf = (schema: JsonSchema): boolean =>
+  Object.keys(propertiesOf(schema)).length > 0 ||
+  allOf(schema).some(hasNamedPropertiesAcrossAllOf);
+
 const findComposedExample = (
   schema: JsonSchema,
   base: JsonSchema,
@@ -334,7 +338,7 @@ const renderSchema = ({
   ) {
     const mapEntries = mapEntrySchemas(schema);
     const freeMap =
-      mapEntries.length > 0 && Object.keys(properties).length === 0;
+      mapEntries.length > 0 && !hasNamedPropertiesAcrossAllOf(schema);
     if (freeMap) {
       renderMapEntries({
         path,

--- a/packages/cli/src/input-contract-help.ts
+++ b/packages/cli/src/input-contract-help.ts
@@ -324,7 +324,8 @@ const renderSchema = ({
     );
     if (
       itemSchema !== undefined &&
-      alternativeGroupsOf(itemSchema).length > 0
+      (alternativeGroupsAcrossAllOf(itemSchema).length > 0 ||
+        mapEntrySchemas(itemSchema).length > 0)
     ) {
       renderSchema({
         path: `${path}[]`,
@@ -335,7 +336,7 @@ const renderSchema = ({
       });
     } else if (
       itemSchema !== undefined &&
-      Object.keys(propertiesOf(itemSchema)).length > 0
+      hasNamedPropertiesAcrossAllOf(itemSchema)
     ) {
       renderObjectChildren({
         path: `${path}[]`,

--- a/packages/cli/src/input-contract-help.ts
+++ b/packages/cli/src/input-contract-help.ts
@@ -267,6 +267,85 @@ const pathRequired = (schema: JsonSchema, path: string): boolean => {
   return false;
 };
 
+const characterForClass = (characterClass: string): string | undefined => {
+  if (characterClass.includes("0-9")) {
+    return "0";
+  }
+  if (characterClass.includes("A-Z")) {
+    return "A";
+  }
+  if (characterClass.includes("a-z")) {
+    return "a";
+  }
+  return characterClass.at(0);
+};
+
+const patternExample = (pattern: string): string | undefined => {
+  if (!pattern.startsWith("^") || !pattern.endsWith("$")) {
+    return undefined;
+  }
+
+  const body = pattern.slice(1, -1);
+  const tokens: string[] = [];
+  for (let index = 0; index < body.length; index += 1) {
+    const character = body[index];
+    if (character === undefined) {
+      return undefined;
+    }
+
+    let token: string;
+    if (character === "[") {
+      const end = body.indexOf("]", index + 1);
+      if (end === -1) {
+        return undefined;
+      }
+      const classCharacter = characterForClass(body.slice(index + 1, end));
+      if (classCharacter === undefined) {
+        return undefined;
+      }
+      token = classCharacter;
+      index = end;
+    } else if (character === "\\") {
+      const escaped = body[index + 1];
+      if (escaped === undefined) {
+        return undefined;
+      }
+      token = escaped === "d" ? "0" : escaped;
+      index += 1;
+    } else if ("().|".includes(character)) {
+      return undefined;
+    } else {
+      token = character;
+    }
+
+    const remainder = body.slice(index + 1);
+    const exact = /^\{(\d+)\}/u.exec(remainder);
+    if (exact !== null) {
+      tokens.push(token.repeat(Number(exact[1])));
+      index += exact[0].length;
+      continue;
+    }
+    if (remainder.startsWith("+")) {
+      tokens.push(token);
+      index += 1;
+      continue;
+    }
+    if (remainder.startsWith("?")) {
+      tokens.push(token);
+      index += 1;
+      continue;
+    }
+    if (remainder.startsWith("*")) {
+      index += 1;
+      continue;
+    }
+    tokens.push(token);
+  }
+
+  const example = tokens.join("");
+  return new RegExp(pattern, "u").test(example) ? example : undefined;
+};
+
 const stringExample = (schema: JsonSchema): string => {
   const format = schema["format"];
   if (format === "date") {
@@ -282,6 +361,12 @@ const stringExample = (schema: JsonSchema): string => {
   const pattern = schema["pattern"];
   if (typeof pattern === "string" && pattern.includes("[0-9a-fA-F]{8}")) {
     return "00000000-0000-4000-8000-000000000000";
+  }
+  if (typeof pattern === "string") {
+    const example = patternExample(pattern);
+    if (example !== undefined) {
+      return example;
+    }
   }
   const source = schema["source"];
   if (source === "^[0-9a-f]{64}$") {

--- a/packages/cli/src/input-contract-help.ts
+++ b/packages/cli/src/input-contract-help.ts
@@ -149,6 +149,9 @@ const mapEntrySchemas = (schema: JsonSchema): MapEntrySchema[] => {
   } else if (isRecord(additional)) {
     entries.push({ valueSchema: additional });
   }
+  for (const intersection of allOf(schema)) {
+    entries.push(...mapEntrySchemas(intersection));
+  }
   return entries;
 };
 

--- a/packages/cli/src/input-contract-help.ts
+++ b/packages/cli/src/input-contract-help.ts
@@ -45,12 +45,14 @@ const descriptionOf = (schema: JsonSchema): string | undefined => {
   return normalized.length === 0 ? undefined : normalized;
 };
 
-const anyOf = (schema: JsonSchema): readonly JsonSchema[] => {
-  const variants = schema["anyOf"];
-  if (!Array.isArray(variants)) {
-    return [];
+const alternativesOf = (schema: JsonSchema): readonly JsonSchema[] => {
+  for (const keyword of ["anyOf", "oneOf"] as const) {
+    const variants = schema[keyword];
+    if (Array.isArray(variants)) {
+      return variants.filter(isRecord);
+    }
   }
-  return variants.filter(isRecord);
+  return [];
 };
 
 const allOf = (schema: JsonSchema): readonly JsonSchema[] => {
@@ -136,7 +138,7 @@ const renderSchema = ({
   indent: number;
   lines: string[];
 }): void => {
-  const variants = anyOf(schema);
+  const variants = alternativesOf(schema);
   if (variants.length > 0) {
     lines.push(
       lineFor({
@@ -174,7 +176,7 @@ const renderSchema = ({
         indent,
       }),
     );
-    if (itemSchema !== undefined && anyOf(itemSchema).length > 0) {
+    if (itemSchema !== undefined && alternativesOf(itemSchema).length > 0) {
       renderSchema({
         path: `${path}[]`,
         schema: itemSchema,
@@ -410,10 +412,15 @@ const exampleFor = (schema: JsonSchema): unknown => {
   if (Array.isArray(enumValues) && enumValues.length > 0) {
     return enumValues.at(0);
   }
-  const variants = anyOf(schema);
+  const variants = alternativesOf(schema);
   if (variants.length > 0) {
     const variant = variants.at(0) ?? {};
-    return exampleFor({ ...schema, anyOf: undefined, ...variant });
+    return exampleFor({
+      ...schema,
+      anyOf: undefined,
+      oneOf: undefined,
+      ...variant,
+    });
   }
   const intersections = allOf(schema);
   if (intersections.length > 0) {

--- a/packages/cli/src/input-contract-help.ts
+++ b/packages/cli/src/input-contract-help.ts
@@ -288,6 +288,17 @@ const renderSchema = ({
       }
     }
     renderObjectChildren({ path, schema, indent: indent + 1, lines });
+    const mapEntries = mapEntrySchemas(schema);
+    if (mapEntries.length > 0) {
+      renderMapEntries({
+        path,
+        entries: mapEntries,
+        required,
+        description: descriptionOf(schema),
+        indent: indent + 1,
+        lines,
+      });
+    }
     return;
   }
 

--- a/packages/cli/src/input-contract-help.ts
+++ b/packages/cli/src/input-contract-help.ts
@@ -29,6 +29,16 @@ const requiredOf = (schema: JsonSchema): ReadonlySet<string> => {
   );
 };
 
+const requiredAcrossAllOf = (schema: JsonSchema): ReadonlySet<string> => {
+  const required = new Set(requiredOf(schema));
+  for (const intersection of allOf(schema)) {
+    for (const name of requiredAcrossAllOf(intersection)) {
+      required.add(name);
+    }
+  }
+  return required;
+};
+
 const schemaTypes = (schema: JsonSchema): readonly string[] => {
   const type = schema["type"];
   if (Array.isArray(type)) {
@@ -312,13 +322,18 @@ const renderObjectChildren = ({
   schema,
   indent,
   lines,
+  inheritedRequired = new Set(),
 }: {
   path: string;
   schema: JsonSchema;
   indent: number;
   lines: string[];
+  inheritedRequired?: ReadonlySet<string>;
 }): void => {
-  const required = requiredOf(schema);
+  const required = new Set([
+    ...inheritedRequired,
+    ...requiredAcrossAllOf(schema),
+  ]);
   for (const [name, child] of Object.entries(propertiesOf(schema))) {
     renderSchema({
       path: `${path}.${name}`,
@@ -329,7 +344,13 @@ const renderObjectChildren = ({
     });
   }
   for (const intersection of allOf(schema)) {
-    renderObjectChildren({ path, schema: intersection, indent, lines });
+    renderObjectChildren({
+      path,
+      schema: intersection,
+      indent,
+      lines,
+      inheritedRequired: required,
+    });
   }
 };
 

--- a/packages/cli/src/input-contract-help.ts
+++ b/packages/cli/src/input-contract-help.ts
@@ -1,0 +1,445 @@
+import type { JsonSchema } from "./route-types.js";
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const propertiesOf = (schema: JsonSchema): Record<string, JsonSchema> => {
+  const properties = schema["properties"];
+  if (!isRecord(properties)) {
+    return {};
+  }
+  const result: Record<string, JsonSchema> = {};
+  for (const [name, child] of Object.entries(properties)) {
+    if (isRecord(child)) {
+      result[name] = child;
+    }
+  }
+  return result;
+};
+
+const requiredOf = (schema: JsonSchema): ReadonlySet<string> => {
+  const required = schema["required"];
+  if (!Array.isArray(required)) {
+    return new Set();
+  }
+  return new Set(
+    required.filter((name): name is string => typeof name === "string"),
+  );
+};
+
+const schemaTypes = (schema: JsonSchema): readonly string[] => {
+  const type = schema["type"];
+  if (Array.isArray(type)) {
+    return type.filter((entry): entry is string => typeof entry === "string");
+  }
+  return typeof type === "string" ? [type] : [];
+};
+
+const descriptionOf = (schema: JsonSchema): string | undefined => {
+  const description = schema["description"];
+  if (typeof description !== "string") {
+    return undefined;
+  }
+  const normalized = description.replace(/\s+/gu, " ").trim();
+  return normalized.length === 0 ? undefined : normalized;
+};
+
+const anyOf = (schema: JsonSchema): readonly JsonSchema[] => {
+  const variants = schema["anyOf"];
+  if (!Array.isArray(variants)) {
+    return [];
+  }
+  return variants.filter(isRecord);
+};
+
+const mapValueSchema = (schema: JsonSchema): JsonSchema | undefined => {
+  const additional = schema["additionalProperties"];
+  if (additional === true) {
+    return {};
+  }
+  if (isRecord(additional)) {
+    return additional;
+  }
+  const patterns = schema["patternProperties"];
+  if (!isRecord(patterns)) {
+    return undefined;
+  }
+  const first = Object.values(patterns).find(isRecord);
+  return first;
+};
+
+const scalarTypeLabel = (schema: JsonSchema): string => {
+  const constant = schema["const"];
+  if (
+    typeof constant === "string" ||
+    typeof constant === "number" ||
+    typeof constant === "boolean"
+  ) {
+    return JSON.stringify(constant);
+  }
+  const enumValues = schema["enum"];
+  if (Array.isArray(enumValues) && enumValues.length > 0) {
+    return enumValues.map((value) => JSON.stringify(value)).join(" | ");
+  }
+  if (schema["type"] === "RegExp" || typeof schema["source"] === "string") {
+    return "string";
+  }
+  const types = schemaTypes(schema);
+  if (types.length > 0) {
+    return types.join(" | ");
+  }
+  return "any JSON value";
+};
+
+const variantLabel = (schema: JsonSchema, index: number): string => {
+  for (const [name, child] of Object.entries(propertiesOf(schema))) {
+    if (child["const"] !== undefined) {
+      return `variant ${index + 1}, ${name} = ${JSON.stringify(child["const"])}`;
+    }
+  }
+  return `variant ${index + 1}`;
+};
+
+const lineFor = ({
+  path,
+  type,
+  required,
+  description,
+  indent,
+}: {
+  path: string;
+  type: string;
+  required: boolean;
+  description: string | undefined;
+  indent: number;
+}): string => {
+  const suffix = description === undefined ? "" : ` — ${description}`;
+  return `${"  ".repeat(indent)}${path}  ${type}  ${required ? "required" : "optional"}${suffix}`;
+};
+
+const renderSchema = ({
+  path,
+  schema,
+  required,
+  indent,
+  lines,
+}: {
+  path: string;
+  schema: JsonSchema;
+  required: boolean;
+  indent: number;
+  lines: string[];
+}): void => {
+  const variants = anyOf(schema);
+  if (variants.length > 0) {
+    lines.push(
+      lineFor({
+        path,
+        type: `one of ${variants.length} variants`,
+        required,
+        description: descriptionOf(schema),
+        indent,
+      }),
+    );
+    for (const [index, variant] of variants.entries()) {
+      const label = variantLabel(variant, index);
+      lines.push(`${"  ".repeat(indent + 1)}${label}:`);
+      renderSchema({
+        path,
+        schema: variant,
+        required,
+        indent: indent + 2,
+        lines,
+      });
+    }
+    return;
+  }
+
+  const types = schemaTypes(schema);
+  if (types.includes("array")) {
+    const items = schema["items"];
+    const itemSchema = isRecord(items) ? items : undefined;
+    lines.push(
+      lineFor({
+        path,
+        type: `array<${itemSchema === undefined ? "any JSON value" : scalarTypeLabel(itemSchema)}>`,
+        required,
+        description: descriptionOf(schema),
+        indent,
+      }),
+    );
+    if (
+      itemSchema !== undefined &&
+      Object.keys(propertiesOf(itemSchema)).length > 0
+    ) {
+      renderObjectChildren({
+        path: `${path}[]`,
+        schema: itemSchema,
+        indent: indent + 1,
+        lines,
+      });
+    }
+    return;
+  }
+
+  const properties = propertiesOf(schema);
+  if (types.includes("object") || Object.keys(properties).length > 0) {
+    const mapValue = mapValueSchema(schema);
+    const freeMap =
+      mapValue !== undefined && Object.keys(properties).length === 0;
+    lines.push(
+      lineFor({
+        path: freeMap ? `${path}.<key>` : path,
+        type: freeMap ? scalarTypeLabel(mapValue) : "object",
+        required,
+        description: descriptionOf(schema),
+        indent,
+      }),
+    );
+    if (!freeMap) {
+      renderObjectChildren({ path, schema, indent: indent + 1, lines });
+    }
+    return;
+  }
+
+  lines.push(
+    lineFor({
+      path,
+      type: scalarTypeLabel(schema),
+      required,
+      description: descriptionOf(schema),
+      indent,
+    }),
+  );
+};
+
+const renderObjectChildren = ({
+  path,
+  schema,
+  indent,
+  lines,
+}: {
+  path: string;
+  schema: JsonSchema;
+  indent: number;
+  lines: string[];
+}): void => {
+  const required = requiredOf(schema);
+  for (const [name, child] of Object.entries(propertiesOf(schema))) {
+    renderSchema({
+      path: `${path}.${name}`,
+      schema: child,
+      required: required.has(name),
+      indent,
+      lines,
+    });
+  }
+};
+
+const schemaAtPath = (
+  schema: JsonSchema,
+  path: string,
+): JsonSchema | undefined => {
+  let current = schema;
+  for (const segment of path.split(".")) {
+    const child = propertiesOf(current)[segment];
+    if (child === undefined) {
+      return undefined;
+    }
+    current = child;
+  }
+  return current;
+};
+
+const pathRequired = (schema: JsonSchema, path: string): boolean => {
+  const segments = path.split(".");
+  let parent = schema;
+  for (const [index, segment] of segments.entries()) {
+    if (index === segments.length - 1) {
+      return requiredOf(parent).has(segment);
+    }
+    const child = propertiesOf(parent)[segment];
+    if (child === undefined) {
+      return false;
+    }
+    parent = child;
+  }
+  return false;
+};
+
+const stringExample = (schema: JsonSchema): string => {
+  const format = schema["format"];
+  if (format === "date") {
+    return "2026-01-01";
+  }
+  if (format === "date-time") {
+    return "2026-01-01T00:00:00.000Z";
+  }
+  if (format === "integer") {
+    const minimum = schema["minimum"];
+    return String(typeof minimum === "number" ? minimum : 0);
+  }
+  const pattern = schema["pattern"];
+  if (typeof pattern === "string" && pattern.includes("[0-9a-fA-F]{8}")) {
+    return "00000000-0000-4000-8000-000000000000";
+  }
+  const source = schema["source"];
+  if (source === "^[0-9a-f]{64}$") {
+    return "0".repeat(64);
+  }
+  const minLength = schema["minLength"];
+  const maxLength = schema["maxLength"];
+  const preferredLength =
+    typeof minLength === "number" ? Math.max(1, minLength) : 5;
+  const length =
+    typeof maxLength === "number"
+      ? Math.min(preferredLength, maxLength)
+      : preferredLength;
+  return "x".repeat(length);
+};
+
+const exampleFor = (schema: JsonSchema): unknown => {
+  const constant = schema["const"];
+  if (constant !== undefined) {
+    return constant;
+  }
+  const enumValues = schema["enum"];
+  if (Array.isArray(enumValues) && enumValues.length > 0) {
+    return enumValues.at(0);
+  }
+  const variants = anyOf(schema);
+  if (variants.length > 0) {
+    const variant = variants.at(0) ?? {};
+    return exampleFor({ ...schema, ...variant, anyOf: undefined });
+  }
+  const types = schemaTypes(schema);
+  const defaultValue = schema["default"];
+  if (
+    defaultValue !== undefined &&
+    ((types.includes("string") && typeof defaultValue === "string") ||
+      (types.includes("number") && typeof defaultValue === "number") ||
+      (types.includes("integer") &&
+        typeof defaultValue === "number" &&
+        Number.isInteger(defaultValue)) ||
+      (types.includes("boolean") && typeof defaultValue === "boolean"))
+  ) {
+    return defaultValue;
+  }
+  if (
+    types.includes("object") ||
+    Object.keys(propertiesOf(schema)).length > 0
+  ) {
+    const result: Record<string, unknown> = {};
+    for (const name of requiredOf(schema)) {
+      const child = propertiesOf(schema)[name];
+      if (child !== undefined) {
+        result[name] = exampleFor(child);
+      }
+    }
+    const mapValue = mapValueSchema(schema);
+    if (mapValue !== undefined) {
+      result["key"] = exampleFor(mapValue);
+    }
+    return result;
+  }
+  if (types.includes("array")) {
+    const items = schema["items"];
+    const minimum = schema["minItems"];
+    const count = typeof minimum === "number" ? Math.max(1, minimum) : 1;
+    const value = isRecord(items) ? exampleFor(items) : "value";
+    return Array.from({ length: count }, () => value);
+  }
+  if (types.includes("integer") || types.includes("number")) {
+    const minimum = schema["minimum"];
+    return typeof minimum === "number" ? minimum : 0;
+  }
+  if (types.includes("boolean")) {
+    return false;
+  }
+  if (types.includes("null")) {
+    return null;
+  }
+  if (types.length === 0 && typeof schema["source"] !== "string") {
+    return "value";
+  }
+  return stringExample(schema);
+};
+
+const setExamplePath = (
+  schema: JsonSchema,
+  target: Record<string, unknown>,
+  path: string,
+): void => {
+  const segments = path.split(".");
+  let current = target;
+  let currentSchema = schema;
+  for (const segment of segments) {
+    const childSchema = propertiesOf(currentSchema)[segment];
+    if (childSchema === undefined) {
+      return;
+    }
+    const existing = current[segment];
+    if (isRecord(existing)) {
+      current = existing;
+      currentSchema = childSchema;
+      continue;
+    }
+    const example = exampleFor(childSchema);
+    current[segment] = example;
+    if (isRecord(example)) {
+      current = example;
+      currentSchema = childSchema;
+    }
+  }
+};
+
+export type InputContractHelp = {
+  fields: readonly string[];
+  example: Record<string, unknown>;
+};
+
+/** Quote a generated JSON example as one POSIX-shell argument. */
+export const formatInputExample = (example: Record<string, unknown>): string =>
+  `--input '${JSON.stringify(example).replaceAll("'", `'\\''`)}'`;
+
+/**
+ * Render the schema subtrees that cannot be expressed as scalar CLI flags and
+ * produce a deterministic, schema-derived full-input example. Both artifacts
+ * come from the validation schema, so help cannot drift into a hand-authored
+ * second contract.
+ */
+export const buildInputContractHelp = ({
+  schema,
+  inputOnly,
+  requiredPaths = [],
+}: {
+  schema: JsonSchema;
+  inputOnly: readonly string[];
+  requiredPaths?: readonly string[];
+}): InputContractHelp | undefined => {
+  if (inputOnly.length === 0) {
+    return undefined;
+  }
+
+  const fields: string[] = [];
+  for (const path of inputOnly) {
+    const fieldSchema = schemaAtPath(schema, path);
+    if (fieldSchema === undefined) {
+      continue;
+    }
+    renderSchema({
+      path,
+      schema: fieldSchema,
+      required: pathRequired(schema, path),
+      indent: 0,
+      lines: fields,
+    });
+  }
+
+  const rootExample = exampleFor(schema);
+  const example = isRecord(rootExample) ? rootExample : {};
+  for (const path of [...inputOnly, ...requiredPaths]) {
+    setExamplePath(schema, example, path);
+  }
+  return { fields, example };
+};

--- a/packages/cli/src/input-contract-help.ts
+++ b/packages/cli/src/input-contract-help.ts
@@ -240,6 +240,7 @@ const renderSchema = ({
         });
       }
     }
+    renderObjectChildren({ path, schema, indent: indent + 1, lines });
     return;
   }
 
@@ -374,7 +375,7 @@ const pathRequired = (schema: JsonSchema, path: string): boolean => {
   let parent = schema;
   for (const [index, segment] of segments.entries()) {
     if (index === segments.length - 1) {
-      return requiredOf(parent).has(segment);
+      return requiredAcrossAllOf(parent).has(segment);
     }
     const child = propertiesOf(parent)[segment];
     if (child === undefined) {
@@ -468,6 +469,201 @@ const patternExample = (pattern: string): string | undefined => {
   return compiled.regex.test(example) ? example : undefined;
 };
 
+const boundedPatternExample = (
+  schema: JsonSchema,
+  pattern: string,
+): string | undefined => {
+  const example = patternExample(pattern);
+  if (example === undefined) {
+    return undefined;
+  }
+  const points = Array.from(example);
+  const minLength =
+    typeof schema["minLength"] === "number" ? schema["minLength"] : 0;
+  const maxLength =
+    typeof schema["maxLength"] === "number"
+      ? schema["maxLength"]
+      : Number.POSITIVE_INFINITY;
+  const candidates = [example];
+  const last = points.at(-1);
+  if (points.length < minLength && last !== undefined) {
+    candidates.push(
+      [
+        ...points,
+        ...Array.from({ length: minLength - points.length }, () => last),
+      ].join(""),
+    );
+    candidates.push(
+      Array.from(
+        { length: minLength },
+        (_, index) => points[index % points.length],
+      ).join(""),
+    );
+  }
+  if (points.length > maxLength) {
+    candidates.push(points.slice(0, maxLength).join(""));
+  }
+  const compiled = compileSchemaPattern(pattern);
+  if (compiled.status === "invalid") {
+    return undefined;
+  }
+  return candidates.find((candidate) => {
+    const length = Array.from(candidate).length;
+    return (
+      length >= minLength &&
+      length <= maxLength &&
+      compiled.regex.test(candidate)
+    );
+  });
+};
+
+const patternsAcrossAllOf = (schema: JsonSchema): string[] => {
+  const patterns: string[] = [];
+  const pattern = schema["pattern"];
+  if (typeof pattern === "string") {
+    patterns.push(pattern);
+  }
+  for (const intersection of allOf(schema)) {
+    patterns.push(...patternsAcrossAllOf(intersection));
+  }
+  return patterns;
+};
+
+const literalPatternFragment = (pattern: string): string | undefined => {
+  const body = pattern.replace(/^\^/u, "").replace(/\$$/u, "");
+  let fragment = "";
+  for (let index = 0; index < body.length; index += 1) {
+    const character = body[index];
+    if (character === undefined) {
+      return undefined;
+    }
+    if (character === "\\") {
+      const escaped = body[index + 1];
+      if (escaped === undefined || "dDsSwWbB".includes(escaped)) {
+        return undefined;
+      }
+      fragment += escaped;
+      index += 1;
+      continue;
+    }
+    if ("[](){}.*+?|".includes(character)) {
+      return undefined;
+    }
+    fragment += character;
+  }
+  return fragment.length === 0 ? undefined : fragment;
+};
+
+const numericKeywordAcrossAllOf = (
+  schema: JsonSchema,
+  keyword: "minLength" | "maxLength",
+  select: "lower" | "upper",
+): number | undefined => {
+  const values: number[] = [];
+  const direct = schema[keyword];
+  if (typeof direct === "number") {
+    values.push(direct);
+  }
+  for (const intersection of allOf(schema)) {
+    const nested = numericKeywordAcrossAllOf(intersection, keyword, select);
+    if (nested !== undefined) {
+      values.push(nested);
+    }
+  }
+  if (values.length === 0) {
+    return undefined;
+  }
+  return select === "lower" ? Math.max(...values) : Math.min(...values);
+};
+
+const mostSpecificAnchor = (
+  fragments: readonly string[],
+  side: "prefix" | "suffix",
+): string | undefined => {
+  const longest = fragments.toSorted(
+    (left, right) => right.length - left.length,
+  )[0];
+  if (longest === undefined) {
+    return "";
+  }
+  const compatible = fragments.every((fragment) =>
+    side === "prefix"
+      ? longest.startsWith(fragment)
+      : longest.endsWith(fragment),
+  );
+  return compatible ? longest : undefined;
+};
+
+const patternIntersectionExample = (schema: JsonSchema): string | undefined => {
+  const patterns = [...new Set(patternsAcrossAllOf(schema))];
+  if (patterns.length < 2) {
+    return undefined;
+  }
+  const compiled = patterns.map((pattern) => compileSchemaPattern(pattern));
+  if (compiled.some((entry) => entry.status === "invalid")) {
+    return undefined;
+  }
+  const fragments = patterns.map(literalPatternFragment);
+  if (fragments.some((fragment) => fragment === undefined)) {
+    return undefined;
+  }
+  const prefixes: string[] = [];
+  const middles: string[] = [];
+  const suffixes: string[] = [];
+  for (const [index, pattern] of patterns.entries()) {
+    const fragment = fragments[index];
+    if (fragment === undefined) {
+      return undefined;
+    }
+    if (pattern.startsWith("^")) {
+      prefixes.push(fragment);
+    } else if (pattern.endsWith("$")) {
+      suffixes.push(fragment);
+    } else {
+      middles.push(fragment);
+    }
+  }
+  const prefix = mostSpecificAnchor(prefixes, "prefix");
+  const suffix = mostSpecificAnchor(suffixes, "suffix");
+  if (prefix === undefined || suffix === undefined) {
+    return undefined;
+  }
+  let anchored = `${prefix}${suffix}`;
+  if (prefix.endsWith(suffix)) {
+    anchored = prefix;
+  } else if (suffix.startsWith(prefix)) {
+    anchored = suffix;
+  }
+  const candidates = [
+    `${prefix}${middles.join("")}${suffix}`,
+    `${anchored}${middles.join("")}`,
+    fragments.join(""),
+    fragments.toReversed().join(""),
+  ];
+  const minLength = numericKeywordAcrossAllOf(schema, "minLength", "lower");
+  const maxLength = numericKeywordAcrossAllOf(schema, "maxLength", "upper");
+  const baseLength = Array.from(candidates[0] ?? "").length;
+  if (minLength !== undefined && baseLength < minLength) {
+    const fillerSource = prefix || middles.at(-1) || suffix;
+    const filler = Array.from(fillerSource).at(-1);
+    if (filler !== undefined) {
+      candidates.unshift(
+        `${prefix}${middles.join("")}${filler.repeat(minLength - baseLength)}${suffix}`,
+      );
+    }
+  }
+  return candidates.find((candidate) => {
+    const length = Array.from(candidate).length;
+    return (
+      (minLength === undefined || length >= minLength) &&
+      (maxLength === undefined || length <= maxLength) &&
+      compiled.every(
+        (entry) => entry.status === "valid" && entry.regex.test(candidate),
+      )
+    );
+  });
+};
+
 const stringExample = (schema: JsonSchema): string => {
   const format = schema["format"];
   if (format === "date") {
@@ -485,7 +681,7 @@ const stringExample = (schema: JsonSchema): string => {
     return "00000000-0000-4000-8000-000000000000";
   }
   if (typeof pattern === "string") {
-    const example = patternExample(pattern);
+    const example = boundedPatternExample(schema, pattern);
     if (example !== undefined) {
       return example;
     }
@@ -505,6 +701,88 @@ const stringExample = (schema: JsonSchema): string => {
   return "x".repeat(length);
 };
 
+const stricterLowerBound = (
+  left: unknown,
+  right: unknown,
+): number | undefined => {
+  const bounds = [left, right].filter(
+    (value): value is number => typeof value === "number",
+  );
+  return bounds.length === 0 ? undefined : Math.max(...bounds);
+};
+
+const stricterUpperBound = (
+  left: unknown,
+  right: unknown,
+): number | undefined => {
+  const bounds = [left, right].filter(
+    (value): value is number => typeof value === "number",
+  );
+  return bounds.length === 0 ? undefined : Math.min(...bounds);
+};
+
+const combineSchemasForExample = (
+  parent: JsonSchema,
+  branch: JsonSchema,
+): JsonSchema => {
+  const combined: JsonSchema = { ...parent, ...branch };
+  for (const keyword of ["minimum", "minLength", "minItems"] as const) {
+    const bound = stricterLowerBound(parent[keyword], branch[keyword]);
+    if (bound !== undefined) {
+      combined[keyword] = bound;
+    }
+  }
+  for (const keyword of ["maximum", "maxLength", "maxItems"] as const) {
+    const bound = stricterUpperBound(parent[keyword], branch[keyword]);
+    if (bound !== undefined) {
+      combined[keyword] = bound;
+    }
+  }
+
+  const parentProperties = propertiesOf(parent);
+  const properties = { ...parentProperties };
+  for (const [name, branchProperty] of Object.entries(propertiesOf(branch))) {
+    const parentProperty = parentProperties[name];
+    properties[name] =
+      parentProperty === undefined
+        ? branchProperty
+        : combineSchemasForExample(parentProperty, branchProperty);
+  }
+  if (Object.keys(properties).length > 0) {
+    combined["properties"] = properties;
+  }
+  const required = new Set([...requiredOf(parent), ...requiredOf(branch)]);
+  if (required.size > 0) {
+    combined["required"] = [...required];
+  }
+  const intersections = [...allOf(parent), ...allOf(branch)];
+  const parentPattern = parent["pattern"];
+  const branchPattern = branch["pattern"];
+  if (
+    typeof parentPattern === "string" &&
+    typeof branchPattern === "string" &&
+    parentPattern !== branchPattern
+  ) {
+    combined["pattern"] = undefined;
+    intersections.push({ pattern: parentPattern }, { pattern: branchPattern });
+  }
+  if (intersections.length > 0) {
+    combined["allOf"] = intersections;
+  }
+  return combined;
+};
+
+const collapseAllOfForExample = (schema: JsonSchema): JsonSchema => {
+  let combined: JsonSchema = { ...schema, allOf: undefined };
+  for (const intersection of allOf(schema)) {
+    combined = combineSchemasForExample(
+      combined,
+      collapseAllOfForExample(intersection),
+    );
+  }
+  return combined;
+};
+
 const exampleFor = (schema: JsonSchema): unknown => {
   const constant = schema["const"];
   if (constant !== undefined) {
@@ -515,16 +793,7 @@ const exampleFor = (schema: JsonSchema): unknown => {
     return enumValues.at(0);
   }
   const alternativeGroups = alternativeGroupsOf(schema);
-  if (alternativeGroups.length === 1) {
-    const group = alternativeGroups.at(0);
-    const variant = group?.variants.at(0) ?? {};
-    return exampleFor({
-      ...schema,
-      [group?.keyword ?? "anyOf"]: undefined,
-      ...variant,
-    });
-  }
-  if (alternativeGroups.length > 1) {
+  if (alternativeGroups.length > 0) {
     const base = { ...schema, anyOf: undefined, oneOf: undefined };
     const result = findComposedExample(schema, base, alternativeGroups);
     if (result.status === "found") {
@@ -534,10 +803,26 @@ const exampleFor = (schema: JsonSchema): unknown => {
   }
   const intersections = allOf(schema);
   if (intersections.length > 0) {
+    const patternCandidate = patternIntersectionExample(schema);
+    if (
+      patternCandidate !== undefined &&
+      validateAgainstSchema(schema, patternCandidate).valid
+    ) {
+      return patternCandidate;
+    }
+    const collapsed = collapseAllOfForExample(schema);
+    if (allOf(collapsed).length === 0) {
+      const composedCandidate = exampleFor(collapsed);
+      if (validateAgainstSchema(schema, composedCandidate).valid) {
+        return composedCandidate;
+      }
+    }
     const baseSchema = { ...schema, allOf: undefined };
     const result = exampleFor(baseSchema);
     for (const intersection of intersections) {
-      const candidate = exampleFor(intersection);
+      const candidate = exampleFor(
+        combineSchemasForExample(baseSchema, intersection),
+      );
       if (validateAgainstSchema(schema, candidate).valid) {
         return candidate;
       }

--- a/packages/cli/src/input-contract-help.ts
+++ b/packages/cli/src/input-contract-help.ts
@@ -174,7 +174,15 @@ const renderSchema = ({
         indent,
       }),
     );
-    if (
+    if (itemSchema !== undefined && anyOf(itemSchema).length > 0) {
+      renderSchema({
+        path: `${path}[]`,
+        schema: itemSchema,
+        required: true,
+        indent: indent + 1,
+        lines,
+      });
+    } else if (
       itemSchema !== undefined &&
       Object.keys(propertiesOf(itemSchema)).length > 0
     ) {

--- a/packages/cli/src/input-contract-help.ts
+++ b/packages/cli/src/input-contract-help.ts
@@ -128,20 +128,28 @@ const findComposedExample = (
   return search(0);
 };
 
-const mapValueSchema = (schema: JsonSchema): JsonSchema | undefined => {
+type MapEntrySchema = {
+  keyPattern?: string;
+  valueSchema: JsonSchema;
+};
+
+const mapEntrySchemas = (schema: JsonSchema): MapEntrySchema[] => {
+  const entries: MapEntrySchema[] = [];
+  const patterns = schema["patternProperties"];
+  if (isRecord(patterns)) {
+    for (const [keyPattern, valueSchema] of Object.entries(patterns)) {
+      if (isRecord(valueSchema)) {
+        entries.push({ keyPattern, valueSchema });
+      }
+    }
+  }
   const additional = schema["additionalProperties"];
   if (additional === true) {
-    return {};
+    entries.push({ valueSchema: {} });
+  } else if (isRecord(additional)) {
+    entries.push({ valueSchema: additional });
   }
-  if (isRecord(additional)) {
-    return additional;
-  }
-  const patterns = schema["patternProperties"];
-  if (!isRecord(patterns)) {
-    return undefined;
-  }
-  const first = Object.values(patterns).find(isRecord);
-  return first;
+  return entries;
 };
 
 const scalarTypeLabel = (schema: JsonSchema): string => {
@@ -201,6 +209,38 @@ const lineFor = ({
 }): string => {
   const suffix = description === undefined ? "" : ` — ${description}`;
   return `${"  ".repeat(indent)}${path}  ${type}  ${required ? "required" : "optional"}${suffix}`;
+};
+
+const renderMapEntries = ({
+  path,
+  entries,
+  required,
+  description,
+  indent,
+  lines,
+}: {
+  path: string;
+  entries: readonly MapEntrySchema[];
+  required: boolean;
+  description: string | undefined;
+  indent: number;
+  lines: string[];
+}): void => {
+  for (const { keyPattern, valueSchema } of entries) {
+    const valueType = scalarTypeLabel(valueSchema);
+    lines.push(
+      lineFor({
+        path: `${path}.<key>`,
+        type:
+          keyPattern === undefined || keyPattern === "^(.*)$"
+            ? valueType
+            : `${valueType}; key matches ${keyPattern}`,
+        required,
+        description,
+        indent,
+      }),
+    );
+  }
 };
 
 const renderSchema = ({
@@ -289,20 +329,39 @@ const renderSchema = ({
     Object.keys(properties).length > 0 ||
     intersections.some(describesObject)
   ) {
-    const mapValue = mapValueSchema(schema);
+    const mapEntries = mapEntrySchemas(schema);
     const freeMap =
-      mapValue !== undefined && Object.keys(properties).length === 0;
+      mapEntries.length > 0 && Object.keys(properties).length === 0;
+    if (freeMap) {
+      renderMapEntries({
+        path,
+        entries: mapEntries,
+        required,
+        description: descriptionOf(schema),
+        indent,
+        lines,
+      });
+      return;
+    }
     lines.push(
       lineFor({
-        path: freeMap ? `${path}.<key>` : path,
-        type: freeMap ? scalarTypeLabel(mapValue) : "object",
+        path,
+        type: "object",
         required,
         description: descriptionOf(schema),
         indent,
       }),
     );
-    if (!freeMap) {
-      renderObjectChildren({ path, schema, indent: indent + 1, lines });
+    renderObjectChildren({ path, schema, indent: indent + 1, lines });
+    if (mapEntries.length > 0) {
+      renderMapEntries({
+        path,
+        entries: mapEntries,
+        required,
+        description: descriptionOf(schema),
+        indent: indent + 1,
+        lines,
+      });
     }
     return;
   }
@@ -552,6 +611,28 @@ const literalPatternFragment = (pattern: string): string | undefined => {
     fragment += character;
   }
   return fragment.length === 0 ? undefined : fragment;
+};
+
+const keyExampleForPattern = (pattern: string): string | undefined => {
+  const compiled = compileSchemaPattern(pattern);
+  if (compiled.status === "invalid") {
+    return undefined;
+  }
+  const bounded = boundedPatternExample({}, pattern);
+  const fragment = literalPatternFragment(pattern);
+  const candidates = [
+    bounded,
+    fragment === undefined ? undefined : `${fragment}key`,
+    fragment,
+    "key",
+    "meta-key",
+    "x",
+    "0",
+  ];
+  return candidates.find(
+    (candidate): candidate is string =>
+      candidate !== undefined && compiled.regex.test(candidate),
+  );
 };
 
 const numericKeywordAcrossAllOf = (
@@ -860,9 +941,15 @@ const exampleFor = (schema: JsonSchema): unknown => {
         result[name] = exampleFor(child);
       }
     }
-    const mapValue = mapValueSchema(schema);
-    if (mapValue !== undefined) {
-      result["key"] = exampleFor(mapValue);
+    const mapEntry = mapEntrySchemas(schema).at(0);
+    if (mapEntry !== undefined) {
+      const key =
+        mapEntry.keyPattern === undefined
+          ? "key"
+          : keyExampleForPattern(mapEntry.keyPattern);
+      if (key !== undefined) {
+        result[key] = exampleFor(mapEntry.valueSchema);
+      }
     }
     return result;
   }

--- a/packages/cli/src/json-schema-validate.test.ts
+++ b/packages/cli/src/json-schema-validate.test.ts
@@ -127,6 +127,29 @@ describe("validateAgainstSchema (interpreted, no codegen)", () => {
     ).toBe(false);
   });
 
+  test("requires exactly one matching oneOf branch", () => {
+    const schema = objectSchema({
+      value: {
+        oneOf: [
+          { type: "string", pattern: "^a" },
+          { type: "string", pattern: "z$" },
+        ],
+      },
+    });
+
+    expect(validateAgainstSchema(schema, { value: "apple" }).valid).toBe(true);
+    expect(validateAgainstSchema(schema, { value: "middle" })).toEqual({
+      valid: false,
+      path: "value",
+      message: "value must match exactly one schema (matched 0)",
+    });
+    expect(validateAgainstSchema(schema, { value: "az" })).toEqual({
+      valid: false,
+      path: "value",
+      message: "value must match exactly one schema (matched 2)",
+    });
+  });
+
   test("enforces string length and pattern constraints", () => {
     const schema = objectSchema({
       lawId: {

--- a/packages/cli/src/json-schema-validate.test.ts
+++ b/packages/cli/src/json-schema-validate.test.ts
@@ -82,6 +82,18 @@ describe("validateAgainstSchema (interpreted, no codegen)", () => {
     ).toBe(false);
   });
 
+  test("returns a validation issue for an invalid schema pattern", () => {
+    const schema = objectSchema({
+      value: { type: "string", pattern: "[" },
+    });
+
+    expect(validateAgainstSchema(schema, { value: "anything" })).toEqual({
+      valid: false,
+      path: "value",
+      message: "schema contains an invalid string pattern",
+    });
+  });
+
   test("validates arrays and their items with minItems", () => {
     const schema = objectSchema({
       jurisdictions: {

--- a/packages/cli/src/json-schema-validate.test.ts
+++ b/packages/cli/src/json-schema-validate.test.ts
@@ -177,6 +177,45 @@ describe("validateAgainstSchema (interpreted, no codegen)", () => {
     ).toBe(false);
   });
 
+  test("applies typeless scalar and array assertions inside compositions", () => {
+    const cases = [
+      {
+        schema: { type: "string", allOf: [{ pattern: "^ab" }] },
+        valid: "abc",
+        invalid: "xyz",
+      },
+      {
+        schema: {
+          type: "number",
+          anyOf: [{ minimum: 10 }, { maximum: -10 }],
+        },
+        valid: 12,
+        invalid: 0,
+      },
+      {
+        schema: {
+          type: "array",
+          oneOf: [{ minItems: 2 }, { maxItems: 0 }],
+        },
+        valid: [1, 2],
+        invalid: [1],
+      },
+      {
+        schema: {
+          type: "array",
+          allOf: [{ items: { type: "string" } }],
+        },
+        valid: ["value"],
+        invalid: [1],
+      },
+    ] as const;
+
+    for (const { schema, valid, invalid } of cases) {
+      expect(validateAgainstSchema(schema, valid).valid).toBe(true);
+      expect(validateAgainstSchema(schema, invalid).valid).toBe(false);
+    }
+  });
+
   test("enforces typeless object constraints nested through allOf", () => {
     const schema = {
       allOf: [

--- a/packages/cli/src/json-schema-validate.test.ts
+++ b/packages/cli/src/json-schema-validate.test.ts
@@ -127,6 +127,25 @@ describe("validateAgainstSchema (interpreted, no codegen)", () => {
     ).toBe(false);
   });
 
+  test("enforces typeless object constraints nested through allOf", () => {
+    const schema = {
+      allOf: [
+        {
+          allOf: [{ required: ["dependencies"] }],
+        },
+      ],
+    };
+
+    expect(validateAgainstSchema(schema, {}).valid).toBe(false);
+    expect(
+      validateAgainstSchema(schema, { dependencies: ["matter"] }).valid,
+    ).toBe(true);
+    // Object-only keywords do not turn a typeless schema into an object type.
+    expect(validateAgainstSchema(schema, "unconstrained scalar").valid).toBe(
+      true,
+    );
+  });
+
   test("preserves explicit object closure inside allOf branches", () => {
     const closedBranch = {
       allOf: [
@@ -155,6 +174,47 @@ describe("validateAgainstSchema (interpreted, no codegen)", () => {
         second: "two",
       }).valid,
     ).toBe(true);
+  });
+
+  test("implicitly closed objects accept allOf-declared properties only", () => {
+    const composed = {
+      ...objectSchema({ base: { type: "string" } }, ["base"]),
+      allOf: [objectSchema({ composed: { type: "number" } }, ["composed"])],
+    };
+
+    expect(
+      validateAgainstSchema(composed, { base: "value", composed: 1 }).valid,
+    ).toBe(true);
+    expect(
+      validateAgainstSchema(composed, { base: "value", unexpected: 1 }).valid,
+    ).toBe(false);
+
+    expect(
+      validateAgainstSchema(
+        { ...composed, additionalProperties: false },
+        { base: "value", composed: 1 },
+      ).valid,
+    ).toBe(false);
+  });
+
+  test("allOf-only objects close over the union of branch properties", () => {
+    const composed = {
+      allOf: [
+        objectSchema({ first: { type: "string" } }, ["first"]),
+        objectSchema({ second: { type: "number" } }, ["second"]),
+      ],
+    };
+
+    expect(
+      validateAgainstSchema(composed, { first: "value", second: 1 }).valid,
+    ).toBe(true);
+    expect(
+      validateAgainstSchema(composed, {
+        first: "value",
+        second: 1,
+        unexpected: true,
+      }).valid,
+    ).toBe(false);
   });
 
   test("requires exactly one matching oneOf branch", () => {
@@ -285,6 +345,70 @@ describe("validateAgainstSchema (interpreted, no codegen)", () => {
     expect(
       validateAgainstSchema(schema, { values: { anything: 1, x: "y" } }).valid,
     ).toBe(true);
+  });
+
+  test("validates matching pattern properties before additional properties", () => {
+    const schema = {
+      type: "object",
+      patternProperties: {
+        "^x-": { type: "string" },
+      },
+      additionalProperties: false,
+    };
+
+    expect(validateAgainstSchema(schema, { "x-name": "valid" }).valid).toBe(
+      true,
+    );
+    expect(validateAgainstSchema(schema, { "x-name": 42 }).valid).toBe(false);
+    expect(validateAgainstSchema(schema, { other: "value" }).valid).toBe(false);
+
+    const composed = {
+      type: "object",
+      properties: {
+        "x-name": { type: "string", minLength: 5 },
+      },
+      patternProperties: {
+        "^x-": { type: "string" },
+        name$: { type: "string", pattern: "^valid$" },
+      },
+      additionalProperties: false,
+    };
+    expect(validateAgainstSchema(composed, { "x-name": "valid" }).valid).toBe(
+      true,
+    );
+    expect(validateAgainstSchema(composed, { "x-name": "wrong" }).valid).toBe(
+      false,
+    );
+  });
+
+  test("rejects malformed pattern properties even for an empty object", () => {
+    expect(
+      validateAgainstSchema(
+        {
+          type: "object",
+          patternProperties: { "[": { type: "string" } },
+        },
+        {},
+      ).valid,
+    ).toBe(false);
+    expect(
+      validateAgainstSchema(
+        {
+          type: "object",
+          patternProperties: { "^x-": "not-a-schema" },
+        },
+        {},
+      ).valid,
+    ).toBe(false);
+    expect(
+      validateAgainstSchema(
+        {
+          type: "object",
+          patternProperties: "not-an-object",
+        },
+        {},
+      ).valid,
+    ).toBe(false);
   });
 
   test("rejects an unknown property against a closed object", () => {

--- a/packages/cli/src/json-schema-validate.test.ts
+++ b/packages/cli/src/json-schema-validate.test.ts
@@ -66,20 +66,36 @@ describe("validateAgainstSchema (interpreted, no codegen)", () => {
     const schema = objectSchema({
       lawId: {
         type: "string",
-        minLength: 12,
+        minLength: 13,
         maxLength: 32,
         pattern: "^BOE-[A-Z]-\\d{4}-\\d+$",
       },
     });
 
-    expect(validateAgainstSchema(schema, { lawId: "BOE-A-2026-1" }).valid).toBe(
-      true,
-    );
-    expect(validateAgainstSchema(schema, { lawId: "xxxxx" }).valid).toBe(false);
     expect(
-      validateAgainstSchema(schema, { lawId: `BOE-A-2026-${"1".repeat(30)}` })
-        .valid,
+      validateAgainstSchema(schema, { lawId: "BOE-A-2026-12" }).valid,
+    ).toBe(true);
+    expect(validateAgainstSchema(schema, { lawId: "BOE-A-2026-1" }).valid).toBe(
+      false,
+    );
+    expect(
+      validateAgainstSchema(schema, { lawId: "xxxxxxxxxxxxx" }).valid,
     ).toBe(false);
+    expect(
+      validateAgainstSchema(schema, {
+        lawId: `BOE-A-2026-${"1".repeat(30)}`,
+      }).valid,
+    ).toBe(false);
+  });
+
+  test("counts minLength and maxLength in Unicode code points", () => {
+    const schema = objectSchema({
+      value: { type: "string", minLength: 2, maxLength: 2 },
+    });
+
+    expect(validateAgainstSchema(schema, { value: "😀a" }).valid).toBe(true);
+    expect(validateAgainstSchema(schema, { value: "😀" }).valid).toBe(false);
+    expect(validateAgainstSchema(schema, { value: "😀ab" }).valid).toBe(false);
   });
 
   test("returns a validation issue for an invalid schema pattern", () => {

--- a/packages/cli/src/json-schema-validate.test.ts
+++ b/packages/cli/src/json-schema-validate.test.ts
@@ -62,6 +62,71 @@ describe("validateAgainstSchema (interpreted, no codegen)", () => {
     expect(validateAgainstSchema(schema, { type: "robot" }).valid).toBe(false);
   });
 
+  test("validates discriminated anyOf branches and const values", () => {
+    const schema = objectSchema({
+      body: {
+        anyOf: [
+          {
+            type: "object",
+            properties: {
+              purpose: { type: "string", const: "entity_create" },
+              propertyId: { type: "string" },
+            },
+            required: ["purpose", "propertyId"],
+          },
+          {
+            type: "object",
+            properties: {
+              purpose: { type: "string", const: "entity_version" },
+              entityId: { type: "string" },
+            },
+            required: ["purpose", "entityId"],
+          },
+        ],
+      },
+    });
+
+    expect(
+      validateAgainstSchema(schema, {
+        body: { purpose: "entity_create", propertyId: "p1" },
+      }).valid,
+    ).toBe(true);
+    expect(
+      validateAgainstSchema(schema, {
+        body: { purpose: "entity_create" },
+      }).valid,
+    ).toBe(false);
+    expect(
+      validateAgainstSchema(schema, {
+        body: { purpose: "unknown", propertyId: "p1" },
+      }).valid,
+    ).toBe(false);
+  });
+
+  test("requires every allOf branch and compares structured const values", () => {
+    const schema = {
+      allOf: [
+        objectSchema({ version: { type: "number", const: 1 } }, ["version"]),
+        objectSchema({
+          config: { const: { enabled: true, labels: ["a", "b"] } },
+        }),
+      ],
+    };
+
+    expect(
+      validateAgainstSchema(schema, {
+        version: 1,
+        config: { labels: ["a", "b"], enabled: true },
+      }).valid,
+    ).toBe(true);
+    expect(
+      validateAgainstSchema(schema, {
+        version: 2,
+        config: { labels: ["a", "b"], enabled: true },
+      }).valid,
+    ).toBe(false);
+  });
+
   test("enforces string length and pattern constraints", () => {
     const schema = objectSchema({
       lawId: {
@@ -108,6 +173,19 @@ describe("validateAgainstSchema (interpreted, no codegen)", () => {
       path: "value",
       message: "schema contains an invalid string pattern",
     });
+  });
+
+  test("validates serialized RegExp schemas with the shared safe engine", () => {
+    const schema = objectSchema({
+      checksum: { type: "RegExp", source: "^[0-9a-f]{64}$", flags: "u" },
+    });
+
+    expect(
+      validateAgainstSchema(schema, { checksum: "0".repeat(64) }).valid,
+    ).toBe(true);
+    expect(validateAgainstSchema(schema, { checksum: "nope" }).valid).toBe(
+      false,
+    );
   });
 
   test("validates arrays and their items with minItems", () => {

--- a/packages/cli/src/json-schema-validate.test.ts
+++ b/packages/cli/src/json-schema-validate.test.ts
@@ -127,6 +127,36 @@ describe("validateAgainstSchema (interpreted, no codegen)", () => {
     ).toBe(false);
   });
 
+  test("preserves explicit object closure inside allOf branches", () => {
+    const closedBranch = {
+      allOf: [
+        {
+          ...objectSchema({ allowed: { type: "string" } }),
+          additionalProperties: false,
+        },
+      ],
+    };
+    expect(
+      validateAgainstSchema(closedBranch, {
+        allowed: "yes",
+        unexpected: true,
+      }).valid,
+    ).toBe(false);
+
+    const siblingProperties = {
+      allOf: [
+        objectSchema({ first: { type: "string" } }, ["first"]),
+        objectSchema({ second: { type: "string" } }, ["second"]),
+      ],
+    };
+    expect(
+      validateAgainstSchema(siblingProperties, {
+        first: "one",
+        second: "two",
+      }).valid,
+    ).toBe(true);
+  });
+
   test("requires exactly one matching oneOf branch", () => {
     const schema = objectSchema({
       value: {

--- a/packages/cli/src/json-schema-validate.test.ts
+++ b/packages/cli/src/json-schema-validate.test.ts
@@ -62,6 +62,26 @@ describe("validateAgainstSchema (interpreted, no codegen)", () => {
     expect(validateAgainstSchema(schema, { type: "robot" }).valid).toBe(false);
   });
 
+  test("enforces string length and pattern constraints", () => {
+    const schema = objectSchema({
+      lawId: {
+        type: "string",
+        minLength: 12,
+        maxLength: 32,
+        pattern: "^BOE-[A-Z]-\\d{4}-\\d+$",
+      },
+    });
+
+    expect(validateAgainstSchema(schema, { lawId: "BOE-A-2026-1" }).valid).toBe(
+      true,
+    );
+    expect(validateAgainstSchema(schema, { lawId: "xxxxx" }).valid).toBe(false);
+    expect(
+      validateAgainstSchema(schema, { lawId: `BOE-A-2026-${"1".repeat(30)}` })
+        .valid,
+    ).toBe(false);
+  });
+
   test("validates arrays and their items with minItems", () => {
     const schema = objectSchema({
       jurisdictions: {

--- a/packages/cli/src/json-schema-validate.test.ts
+++ b/packages/cli/src/json-schema-validate.test.ts
@@ -429,6 +429,61 @@ describe("validateAgainstSchema (interpreted, no codegen)", () => {
     expect(validateAgainstSchema(composed, { "x-name": "wrong" }).valid).toBe(
       false,
     );
+
+    const implicitlyClosed = {
+      type: "object",
+      patternProperties: { "^x-": { type: "string" } },
+    };
+    expect(
+      validateAgainstSchema(implicitlyClosed, { "x-name": "valid" }).valid,
+    ).toBe(true);
+    expect(
+      validateAgainstSchema(implicitlyClosed, { other: "value" }).valid,
+    ).toBe(false);
+  });
+
+  test("composes matching branch pattern and additional-property schemas", () => {
+    const schema = {
+      type: "object",
+      properties: { token: { type: "boolean" } },
+      required: ["token"],
+      anyOf: [
+        {
+          type: "object",
+          properties: { kind: { type: "string", const: "pattern" } },
+          patternProperties: { "^x-": { type: "number" } },
+          required: ["kind"],
+        },
+        {
+          type: "object",
+          properties: { kind: { type: "string", const: "map" } },
+          additionalProperties: { type: "boolean" },
+          required: ["kind"],
+        },
+      ],
+    };
+
+    expect(
+      validateAgainstSchema(schema, {
+        token: true,
+        kind: "pattern",
+        "x-score": 1,
+      }).valid,
+    ).toBe(true);
+    expect(
+      validateAgainstSchema(schema, {
+        token: true,
+        kind: "map",
+        enabled: true,
+      }).valid,
+    ).toBe(true);
+    expect(
+      validateAgainstSchema(schema, {
+        token: true,
+        kind: "pattern",
+        enabled: true,
+      }).valid,
+    ).toBe(false);
   });
 
   test("rejects malformed pattern properties even for an empty object", () => {

--- a/packages/cli/src/json-schema-validate.test.ts
+++ b/packages/cli/src/json-schema-validate.test.ts
@@ -177,15 +177,22 @@ describe("validateAgainstSchema (interpreted, no codegen)", () => {
 
   test("validates serialized RegExp schemas with the shared safe engine", () => {
     const schema = objectSchema({
-      checksum: { type: "RegExp", source: "^[0-9a-f]{64}$", flags: "u" },
+      checksum: { type: "RegExp", source: "^[0-9a-f]{64}$", flags: "iu" },
     });
 
     expect(
-      validateAgainstSchema(schema, { checksum: "0".repeat(64) }).valid,
+      validateAgainstSchema(schema, { checksum: "A".repeat(64) }).valid,
     ).toBe(true);
     expect(validateAgainstSchema(schema, { checksum: "nope" }).valid).toBe(
       false,
     );
+
+    const invalidFlags = objectSchema({
+      checksum: { type: "RegExp", source: ".*", flags: "x" },
+    });
+    expect(
+      validateAgainstSchema(invalidFlags, { checksum: "anything" }).valid,
+    ).toBe(false);
   });
 
   test("validates arrays and their items with minItems", () => {

--- a/packages/cli/src/json-schema-validate.test.ts
+++ b/packages/cli/src/json-schema-validate.test.ts
@@ -103,6 +103,56 @@ describe("validateAgainstSchema (interpreted, no codegen)", () => {
     ).toBe(false);
   });
 
+  test("composes shared object fields with matching alternative branches", () => {
+    for (const keyword of ["anyOf", "oneOf"] as const) {
+      const schema = {
+        type: "object",
+        properties: { token: { type: "string" } },
+        required: ["token"],
+        [keyword]: [
+          objectSchema(
+            {
+              kind: { type: "string", const: "a" },
+              aValue: { type: "number" },
+            },
+            ["kind", "aValue"],
+          ),
+          objectSchema(
+            {
+              kind: { type: "string", const: "b" },
+              bValue: { type: "boolean" },
+            },
+            ["kind", "bValue"],
+          ),
+        ],
+      };
+
+      expect(
+        validateAgainstSchema(schema, {
+          token: "shared",
+          kind: "a",
+          aValue: 1,
+        }).valid,
+      ).toBe(true);
+      expect(
+        validateAgainstSchema(schema, {
+          token: "shared",
+          kind: "a",
+          aValue: 1,
+          bValue: true,
+        }).valid,
+      ).toBe(false);
+      expect(
+        validateAgainstSchema(schema, {
+          token: "shared",
+          kind: "a",
+          aValue: 1,
+          unexpected: true,
+        }).valid,
+      ).toBe(false);
+    }
+  });
+
   test("requires every allOf branch and compares structured const values", () => {
     const schema = {
       allOf: [

--- a/packages/cli/src/json-schema-validate.ts
+++ b/packages/cli/src/json-schema-validate.ts
@@ -122,7 +122,11 @@ const validateRegExpString = (
   if (typeof source !== "string") {
     return fail(path, "RegExp schema is missing its source");
   }
-  const compiled = compileSchemaPattern(source);
+  const flags = schema["flags"];
+  if (flags !== undefined && typeof flags !== "string") {
+    return fail(path, "RegExp schema flags must be a string");
+  }
+  const compiled = compileSchemaPattern(source, flags);
   if (compiled.status === "invalid") {
     return fail(path, "RegExp schema contains an invalid source");
   }

--- a/packages/cli/src/json-schema-validate.ts
+++ b/packages/cli/src/json-schema-validate.ts
@@ -229,9 +229,10 @@ const validateObject = (
       continue;
     }
     if (
-      additionalSchema !== true &&
-      !allowUnknownProperties &&
-      (additionalSchema === false || Object.keys(properties).length > 0)
+      additionalSchema === false ||
+      (additionalSchema !== true &&
+        !allowUnknownProperties &&
+        Object.keys(properties).length > 0)
     ) {
       return fail(childPath, "unknown property");
     }

--- a/packages/cli/src/json-schema-validate.ts
+++ b/packages/cli/src/json-schema-validate.ts
@@ -44,9 +44,21 @@ const enumValues = (schema: JsonSchema): readonly unknown[] | undefined =>
 
 const applicatorKeywords = ["allOf", "anyOf", "oneOf"] as const;
 
-const hasPropertiesAcrossCompositions = (schema: JsonSchema): boolean => {
+const hasOwnPropertySurface = (schema: JsonSchema): boolean => {
   const properties = schema["properties"];
-  if (isPlainObject(properties) && Object.keys(properties).length > 0) {
+  const patternProperties = schema["patternProperties"];
+  const additionalProperties = schema["additionalProperties"];
+  return (
+    (isPlainObject(properties) && Object.keys(properties).length > 0) ||
+    (isPlainObject(patternProperties) &&
+      Object.keys(patternProperties).length > 0) ||
+    additionalProperties === true ||
+    isPlainObject(additionalProperties)
+  );
+};
+
+const hasPropertiesAcrossCompositions = (schema: JsonSchema): boolean => {
+  if (hasOwnPropertySurface(schema)) {
     return true;
   }
   return applicatorKeywords.some((keyword) => {
@@ -61,14 +73,34 @@ const hasPropertiesAcrossCompositions = (schema: JsonSchema): boolean => {
   });
 };
 
+const propertyAcceptedByOwnObjectKeywords = (
+  schema: JsonSchema,
+  property: string,
+): boolean => {
+  const properties = schema["properties"];
+  if (isPlainObject(properties) && Object.hasOwn(properties, property)) {
+    return true;
+  }
+  const patternProperties = schema["patternProperties"];
+  if (isPlainObject(patternProperties)) {
+    for (const pattern of Object.keys(patternProperties)) {
+      const compiled = compileSchemaPattern(pattern);
+      if (compiled.status === "valid" && compiled.regex.test(property)) {
+        return true;
+      }
+    }
+  }
+  const additionalProperties = schema["additionalProperties"];
+  return additionalProperties === true || isPlainObject(additionalProperties);
+};
+
 const propertyDeclaredAcrossMatchingCompositions = (
   schema: JsonSchema,
   property: string,
   value: Record<string, unknown>,
   path: string,
 ): boolean => {
-  const properties = schema["properties"];
-  if (isPlainObject(properties) && Object.hasOwn(properties, property)) {
+  if (propertyAcceptedByOwnObjectKeywords(schema, property)) {
     return true;
   }
   const intersections = schema["allOf"];

--- a/packages/cli/src/json-schema-validate.ts
+++ b/packages/cli/src/json-schema-validate.ts
@@ -40,9 +40,17 @@ const validateString = (
   value: string,
   path: string,
 ): ValidationResult => {
+  const minLength = schema["minLength"];
+  if (typeof minLength === "number" && value.length < minLength) {
+    return fail(path, `string shorter than minLength ${minLength}`);
+  }
   const maxLength = schema["maxLength"];
   if (typeof maxLength === "number" && value.length > maxLength) {
     return fail(path, `string longer than maxLength ${maxLength}`);
+  }
+  const pattern = schema["pattern"];
+  if (typeof pattern === "string" && !new RegExp(pattern, "u").test(value)) {
+    return fail(path, `string does not match pattern ${pattern}`);
   }
   return ok;
 };

--- a/packages/cli/src/json-schema-validate.ts
+++ b/packages/cli/src/json-schema-validate.ts
@@ -42,12 +42,13 @@ const validateString = (
   value: string,
   path: string,
 ): ValidationResult => {
+  const codePointLength = Array.from(value).length;
   const minLength = schema["minLength"];
-  if (typeof minLength === "number" && value.length < minLength) {
+  if (typeof minLength === "number" && codePointLength < minLength) {
     return fail(path, `string shorter than minLength ${minLength}`);
   }
   const maxLength = schema["maxLength"];
-  if (typeof maxLength === "number" && value.length > maxLength) {
+  if (typeof maxLength === "number" && codePointLength > maxLength) {
     return fail(path, `string longer than maxLength ${maxLength}`);
   }
   const pattern = schema["pattern"];

--- a/packages/cli/src/json-schema-validate.ts
+++ b/packages/cli/src/json-schema-validate.ts
@@ -7,8 +7,13 @@
 // this closed shape set, and it structurally cannot run generated code.
 
 import { compileSchemaPattern } from "./schema-pattern.js";
+import type { CompiledSchemaPattern } from "./schema-pattern.js";
 
 type JsonSchema = Record<string, unknown>;
+type ValidCompiledSchemaPattern = Extract<
+  CompiledSchemaPattern,
+  { status: "valid" }
+>;
 
 /** A validation outcome: valid, or the failing JSON path plus a message. */
 export type ValidationResult =
@@ -36,6 +41,61 @@ const isPlainObject = (value: unknown): value is Record<string, unknown> =>
 
 const enumValues = (schema: JsonSchema): readonly unknown[] | undefined =>
   Array.isArray(schema["enum"]) ? schema["enum"] : undefined;
+
+const propertyDeclaredAcrossAllOf = (
+  schema: JsonSchema,
+  property: string,
+): boolean => {
+  const properties = schema["properties"];
+  if (isPlainObject(properties) && Object.hasOwn(properties, property)) {
+    return true;
+  }
+  const intersections = schema["allOf"];
+  return (
+    Array.isArray(intersections) &&
+    intersections.some(
+      (intersection) =>
+        isPlainObject(intersection) &&
+        propertyDeclaredAcrossAllOf(intersection, property),
+    )
+  );
+};
+
+const hasPropertiesAcrossAllOf = (schema: JsonSchema): boolean => {
+  const properties = schema["properties"];
+  if (isPlainObject(properties) && Object.keys(properties).length > 0) {
+    return true;
+  }
+  const intersections = schema["allOf"];
+  return (
+    Array.isArray(intersections) &&
+    intersections.some(
+      (intersection) =>
+        isPlainObject(intersection) && hasPropertiesAcrossAllOf(intersection),
+    )
+  );
+};
+
+const hasObjectConstraintsAcrossAllOf = (schema: JsonSchema): boolean => {
+  const required = schema["required"];
+  if (
+    hasPropertiesAcrossAllOf(schema) ||
+    Object.hasOwn(schema, "patternProperties") ||
+    (Array.isArray(required) && required.length > 0) ||
+    Object.hasOwn(schema, "additionalProperties")
+  ) {
+    return true;
+  }
+  const intersections = schema["allOf"];
+  return (
+    Array.isArray(intersections) &&
+    intersections.some(
+      (intersection) =>
+        isPlainObject(intersection) &&
+        hasObjectConstraintsAcrossAllOf(intersection),
+    )
+  );
+};
 
 const jsonValuesEqual = (left: unknown, right: unknown): boolean => {
   if (Object.is(left, right)) {
@@ -200,6 +260,33 @@ const validateObject = (
   const properties = isPlainObject(schema["properties"])
     ? schema["properties"]
     : {};
+  const rawPatternProperties = schema["patternProperties"];
+  if (
+    rawPatternProperties !== undefined &&
+    !isPlainObject(rawPatternProperties)
+  ) {
+    return fail(path, "patternProperties must be an object");
+  }
+  const patternProperties = isPlainObject(rawPatternProperties)
+    ? rawPatternProperties
+    : {};
+  const compiledPatternProperties: {
+    pattern: ValidCompiledSchemaPattern;
+    schema: JsonSchema;
+  }[] = [];
+  for (const [pattern, patternSchema] of Object.entries(patternProperties)) {
+    if (!isPlainObject(patternSchema)) {
+      return fail(path, "patternProperties contains a non-object schema");
+    }
+    const compiled = compileSchemaPattern(pattern);
+    if (compiled.status === "invalid") {
+      return fail(path, "schema contains an invalid property pattern");
+    }
+    compiledPatternProperties.push({
+      pattern: compiled,
+      schema: patternSchema,
+    });
+  }
   const required = Array.isArray(schema["required"]) ? schema["required"] : [];
   for (const key of required) {
     if (typeof key === "string" && value[key] === undefined) {
@@ -213,11 +300,25 @@ const validateObject = (
   for (const [key, child] of Object.entries(value)) {
     const childSchema = properties[key];
     const childPath = path === "" ? key : `${path}.${key}`;
+    let declared = false;
     if (isPlainObject(childSchema)) {
       const result = validateValue(childSchema, child, childPath);
       if (!result.valid) {
         return result;
       }
+      declared = true;
+    }
+    for (const patternProperty of compiledPatternProperties) {
+      if (!patternProperty.pattern.regex.test(key)) {
+        continue;
+      }
+      const result = validateValue(patternProperty.schema, child, childPath);
+      if (!result.valid) {
+        return result;
+      }
+      declared = true;
+    }
+    if (declared) {
       continue;
     }
     const additionalSchema = schema["additionalProperties"];
@@ -229,10 +330,19 @@ const validateObject = (
       continue;
     }
     if (
+      additionalSchema !== false &&
+      propertyDeclaredAcrossAllOf(schema, key)
+    ) {
+      // The matching allOf branch already validated this value. The CLI's
+      // implicit default-closed policy composes declared properties, while an
+      // explicit additionalProperties:false remains strictly branch-local.
+      continue;
+    }
+    if (
       additionalSchema === false ||
       (additionalSchema !== true &&
         !allowUnknownProperties &&
-        Object.keys(properties).length > 0)
+        hasPropertiesAcrossAllOf(schema))
     ) {
       return fail(childPath, "unknown property");
     }
@@ -284,6 +394,9 @@ const validateValue = (
 
   const types = schemaTypes(schema);
   if (types.length === 0) {
+    if (isPlainObject(value) && hasObjectConstraintsAcrossAllOf(schema)) {
+      return validateObject(schema, value, path, allowUnknownProperties);
+    }
     // A schema with no `type` (e.g. set_field_value.content.value) accepts any
     // JSON value; applicators, const, and enum above may still constrain it.
     return ok;

--- a/packages/cli/src/json-schema-validate.ts
+++ b/packages/cli/src/json-schema-validate.ts
@@ -61,7 +61,7 @@ const jsonValuesEqual = (left: unknown, right: unknown): boolean => {
 };
 
 const validateSchemaList = (
-  keyword: "allOf" | "anyOf",
+  keyword: "allOf" | "anyOf" | "oneOf",
   branches: readonly unknown[],
   value: unknown,
   path: string,
@@ -77,6 +77,17 @@ const validateSchemaList = (
       }
     }
     return ok;
+  }
+  if (keyword === "oneOf") {
+    let matches = 0;
+    for (const branch of branches) {
+      if (isPlainObject(branch) && validateValue(branch, value, path).valid) {
+        matches += 1;
+      }
+    }
+    return matches === 1
+      ? ok
+      : fail(path, `value must match exactly one schema (matched ${matches})`);
   }
   for (const branch of branches) {
     if (isPlainObject(branch) && validateValue(branch, value, path).valid) {
@@ -252,6 +263,14 @@ const validateValue = (
   const anyOf = schema["anyOf"];
   if (Array.isArray(anyOf)) {
     const result = validateSchemaList("anyOf", anyOf, value, path);
+    if (!result.valid) {
+      return result;
+    }
+  }
+
+  const oneOf = schema["oneOf"];
+  if (Array.isArray(oneOf)) {
+    const result = validateSchemaList("oneOf", oneOf, value, path);
     if (!result.valid) {
       return result;
     }

--- a/packages/cli/src/json-schema-validate.ts
+++ b/packages/cli/src/json-schema-validate.ts
@@ -42,6 +42,19 @@ const isPlainObject = (value: unknown): value is Record<string, unknown> =>
 const enumValues = (schema: JsonSchema): readonly unknown[] | undefined =>
   Array.isArray(schema["enum"]) ? schema["enum"] : undefined;
 
+const hasAnyKeyword = (
+  schema: JsonSchema,
+  keywords: readonly string[],
+): boolean => keywords.some((keyword) => Object.hasOwn(schema, keyword));
+
+const STRING_ASSERTION_KEYWORDS = [
+  "minLength",
+  "maxLength",
+  "pattern",
+] as const;
+const NUMBER_ASSERTION_KEYWORDS = ["minimum", "maximum"] as const;
+const ARRAY_ASSERTION_KEYWORDS = ["minItems", "maxItems", "items"] as const;
+
 const applicatorKeywords = ["allOf", "anyOf", "oneOf"] as const;
 
 const hasOwnPropertySurface = (schema: JsonSchema): boolean => {
@@ -466,6 +479,24 @@ const validateValue = (
 
   const types = schemaTypes(schema);
   if (types.length === 0) {
+    if (
+      typeof value === "string" &&
+      hasAnyKeyword(schema, STRING_ASSERTION_KEYWORDS)
+    ) {
+      return validateString(schema, value, path);
+    }
+    if (
+      typeof value === "number" &&
+      hasAnyKeyword(schema, NUMBER_ASSERTION_KEYWORDS)
+    ) {
+      return validateNumber(schema, value, path, false);
+    }
+    if (
+      Array.isArray(value) &&
+      hasAnyKeyword(schema, ARRAY_ASSERTION_KEYWORDS)
+    ) {
+      return validateArray(schema, value, path);
+    }
     if (
       isPlainObject(value) &&
       hasObjectConstraintsAcrossCompositions(schema)

--- a/packages/cli/src/json-schema-validate.ts
+++ b/packages/cli/src/json-schema-validate.ts
@@ -6,6 +6,8 @@
 // hand-rolled walker is simpler and lighter than a general-purpose library for
 // this closed shape set, and it structurally cannot run generated code.
 
+import { compileSchemaPattern } from "./schema-pattern.js";
+
 type JsonSchema = Record<string, unknown>;
 
 /** A validation outcome: valid, or the failing JSON path plus a message. */
@@ -49,8 +51,14 @@ const validateString = (
     return fail(path, `string longer than maxLength ${maxLength}`);
   }
   const pattern = schema["pattern"];
-  if (typeof pattern === "string" && !new RegExp(pattern, "u").test(value)) {
-    return fail(path, `string does not match pattern ${pattern}`);
+  if (typeof pattern === "string") {
+    const compiled = compileSchemaPattern(pattern);
+    if (compiled.status === "invalid") {
+      return fail(path, "schema contains an invalid string pattern");
+    }
+    if (!compiled.regex.test(value)) {
+      return fail(path, `string does not match pattern ${pattern}`);
+    }
   }
   return ok;
 };

--- a/packages/cli/src/json-schema-validate.ts
+++ b/packages/cli/src/json-schema-validate.ts
@@ -37,6 +37,55 @@ const isPlainObject = (value: unknown): value is Record<string, unknown> =>
 const enumValues = (schema: JsonSchema): readonly unknown[] | undefined =>
   Array.isArray(schema["enum"]) ? schema["enum"] : undefined;
 
+const jsonValuesEqual = (left: unknown, right: unknown): boolean => {
+  if (Object.is(left, right)) {
+    return true;
+  }
+  if (Array.isArray(left) && Array.isArray(right)) {
+    return (
+      left.length === right.length &&
+      left.every((value, index) => jsonValuesEqual(value, right[index]))
+    );
+  }
+  if (!isPlainObject(left) || !isPlainObject(right)) {
+    return false;
+  }
+  const leftKeys = Object.keys(left);
+  if (leftKeys.length !== Object.keys(right).length) {
+    return false;
+  }
+  return leftKeys.every(
+    (key) =>
+      Object.hasOwn(right, key) && jsonValuesEqual(left[key], right[key]),
+  );
+};
+
+const validateSchemaList = (
+  keyword: "allOf" | "anyOf",
+  branches: readonly unknown[],
+  value: unknown,
+  path: string,
+): ValidationResult => {
+  if (keyword === "allOf") {
+    for (const branch of branches) {
+      if (!isPlainObject(branch)) {
+        return fail(path, "allOf contains a non-object schema");
+      }
+      const result = validateValue(branch, value, path, true);
+      if (!result.valid) {
+        return result;
+      }
+    }
+    return ok;
+  }
+  for (const branch of branches) {
+    if (isPlainObject(branch) && validateValue(branch, value, path).valid) {
+      return ok;
+    }
+  }
+  return fail(path, "value does not match any allowed schema");
+};
+
 const validateString = (
   schema: JsonSchema,
   value: string,
@@ -62,6 +111,24 @@ const validateString = (
     }
   }
   return ok;
+};
+
+const validateRegExpString = (
+  schema: JsonSchema,
+  value: string,
+  path: string,
+): ValidationResult => {
+  const source = schema["source"];
+  if (typeof source !== "string") {
+    return fail(path, "RegExp schema is missing its source");
+  }
+  const compiled = compileSchemaPattern(source);
+  if (compiled.status === "invalid") {
+    return fail(path, "RegExp schema contains an invalid source");
+  }
+  return compiled.regex.test(value)
+    ? ok
+    : fail(path, `string does not match pattern ${source}`);
 };
 
 const validateNumber = (
@@ -113,12 +180,11 @@ const validateObject = (
   schema: JsonSchema,
   value: Record<string, unknown>,
   path: string,
+  allowUnknownProperties: boolean,
 ): ValidationResult => {
   const properties = isPlainObject(schema["properties"])
     ? schema["properties"]
     : {};
-  const allowsAdditional = schema["additionalProperties"] === true;
-
   const required = Array.isArray(schema["required"]) ? schema["required"] : [];
   for (const key of required) {
     if (typeof key === "string" && value[key] === undefined) {
@@ -139,7 +205,19 @@ const validateObject = (
       }
       continue;
     }
-    if (!allowsAdditional && Object.keys(properties).length > 0) {
+    const additionalSchema = schema["additionalProperties"];
+    if (isPlainObject(additionalSchema)) {
+      const result = validateValue(additionalSchema, child, childPath);
+      if (!result.valid) {
+        return result;
+      }
+      continue;
+    }
+    if (
+      additionalSchema !== true &&
+      !allowUnknownProperties &&
+      (additionalSchema === false || Object.keys(properties).length > 0)
+    ) {
       return fail(childPath, "unknown property");
     }
   }
@@ -150,7 +228,31 @@ const validateValue = (
   schema: JsonSchema,
   value: unknown,
   path: string,
+  allowUnknownProperties = false,
 ): ValidationResult => {
+  if (
+    Object.hasOwn(schema, "const") &&
+    !jsonValuesEqual(schema["const"], value)
+  ) {
+    return fail(path, `value must equal ${JSON.stringify(schema["const"])}`);
+  }
+
+  const allOf = schema["allOf"];
+  if (Array.isArray(allOf)) {
+    const result = validateSchemaList("allOf", allOf, value, path);
+    if (!result.valid) {
+      return result;
+    }
+  }
+
+  const anyOf = schema["anyOf"];
+  if (Array.isArray(anyOf)) {
+    const result = validateSchemaList("anyOf", anyOf, value, path);
+    if (!result.valid) {
+      return result;
+    }
+  }
+
   const values = enumValues(schema);
   if (values && !values.includes(value)) {
     return fail(path, `value is not one of ${JSON.stringify(values)}`);
@@ -159,7 +261,7 @@ const validateValue = (
   const types = schemaTypes(schema);
   if (types.length === 0) {
     // A schema with no `type` (e.g. set_field_value.content.value) accepts any
-    // JSON value; only its enum (checked above) constrains it.
+    // JSON value; applicators, const, and enum above may still constrain it.
     return ok;
   }
 
@@ -171,6 +273,9 @@ const validateValue = (
 
   if (types.includes("string") && typeof value === "string") {
     return validateString(schema, value, path);
+  }
+  if (types.includes("RegExp") && typeof value === "string") {
+    return validateRegExpString(schema, value, path);
   }
   if (types.includes("integer") && typeof value === "number") {
     return validateNumber(schema, value, path, true);
@@ -185,7 +290,7 @@ const validateValue = (
     return validateArray(schema, value, path);
   }
   if (types.includes("object") && isPlainObject(value)) {
-    return validateObject(schema, value, path);
+    return validateObject(schema, value, path, allowUnknownProperties);
   }
 
   return fail(path, `expected ${types.join("|")}`);

--- a/packages/cli/src/json-schema-validate.ts
+++ b/packages/cli/src/json-schema-validate.ts
@@ -42,59 +42,93 @@ const isPlainObject = (value: unknown): value is Record<string, unknown> =>
 const enumValues = (schema: JsonSchema): readonly unknown[] | undefined =>
   Array.isArray(schema["enum"]) ? schema["enum"] : undefined;
 
-const propertyDeclaredAcrossAllOf = (
+const applicatorKeywords = ["allOf", "anyOf", "oneOf"] as const;
+
+const hasPropertiesAcrossCompositions = (schema: JsonSchema): boolean => {
+  const properties = schema["properties"];
+  if (isPlainObject(properties) && Object.keys(properties).length > 0) {
+    return true;
+  }
+  return applicatorKeywords.some((keyword) => {
+    const branches = schema[keyword];
+    return (
+      Array.isArray(branches) &&
+      branches.some(
+        (branch) =>
+          isPlainObject(branch) && hasPropertiesAcrossCompositions(branch),
+      )
+    );
+  });
+};
+
+const propertyDeclaredAcrossMatchingCompositions = (
   schema: JsonSchema,
   property: string,
+  value: Record<string, unknown>,
+  path: string,
 ): boolean => {
   const properties = schema["properties"];
   if (isPlainObject(properties) && Object.hasOwn(properties, property)) {
     return true;
   }
   const intersections = schema["allOf"];
-  return (
+  if (
     Array.isArray(intersections) &&
     intersections.some(
       (intersection) =>
         isPlainObject(intersection) &&
-        propertyDeclaredAcrossAllOf(intersection, property),
+        propertyDeclaredAcrossMatchingCompositions(
+          intersection,
+          property,
+          value,
+          path,
+        ),
     )
-  );
-};
-
-const hasPropertiesAcrossAllOf = (schema: JsonSchema): boolean => {
-  const properties = schema["properties"];
-  if (isPlainObject(properties) && Object.keys(properties).length > 0) {
+  ) {
     return true;
   }
-  const intersections = schema["allOf"];
-  return (
-    Array.isArray(intersections) &&
-    intersections.some(
-      (intersection) =>
-        isPlainObject(intersection) && hasPropertiesAcrossAllOf(intersection),
-    )
-  );
+  return (["anyOf", "oneOf"] as const).some((keyword) => {
+    const branches = schema[keyword];
+    return (
+      Array.isArray(branches) &&
+      branches.some(
+        (branch) =>
+          isPlainObject(branch) &&
+          validateValue(branch, value, path, true).valid &&
+          propertyDeclaredAcrossMatchingCompositions(
+            branch,
+            property,
+            value,
+            path,
+          ),
+      )
+    );
+  });
 };
 
-const hasObjectConstraintsAcrossAllOf = (schema: JsonSchema): boolean => {
+const hasObjectConstraintsAcrossCompositions = (
+  schema: JsonSchema,
+): boolean => {
   const required = schema["required"];
   if (
-    hasPropertiesAcrossAllOf(schema) ||
+    hasPropertiesAcrossCompositions(schema) ||
     Object.hasOwn(schema, "patternProperties") ||
     (Array.isArray(required) && required.length > 0) ||
     Object.hasOwn(schema, "additionalProperties")
   ) {
     return true;
   }
-  const intersections = schema["allOf"];
-  return (
-    Array.isArray(intersections) &&
-    intersections.some(
-      (intersection) =>
-        isPlainObject(intersection) &&
-        hasObjectConstraintsAcrossAllOf(intersection),
-    )
-  );
+  return applicatorKeywords.some((keyword) => {
+    const branches = schema[keyword];
+    return (
+      Array.isArray(branches) &&
+      branches.some(
+        (branch) =>
+          isPlainObject(branch) &&
+          hasObjectConstraintsAcrossCompositions(branch),
+      )
+    );
+  });
 };
 
 const jsonValuesEqual = (left: unknown, right: unknown): boolean => {
@@ -141,7 +175,10 @@ const validateSchemaList = (
   if (keyword === "oneOf") {
     let matches = 0;
     for (const branch of branches) {
-      if (isPlainObject(branch) && validateValue(branch, value, path).valid) {
+      if (
+        isPlainObject(branch) &&
+        validateValue(branch, value, path, true).valid
+      ) {
         matches += 1;
       }
     }
@@ -150,7 +187,10 @@ const validateSchemaList = (
       : fail(path, `value must match exactly one schema (matched ${matches})`);
   }
   for (const branch of branches) {
-    if (isPlainObject(branch) && validateValue(branch, value, path).valid) {
+    if (
+      isPlainObject(branch) &&
+      validateValue(branch, value, path, true).valid
+    ) {
       return ok;
     }
   }
@@ -331,9 +371,9 @@ const validateObject = (
     }
     if (
       additionalSchema !== false &&
-      propertyDeclaredAcrossAllOf(schema, key)
+      propertyDeclaredAcrossMatchingCompositions(schema, key, value, path)
     ) {
-      // The matching allOf branch already validated this value. The CLI's
+      // A matching composition branch already validated this value. The CLI's
       // implicit default-closed policy composes declared properties, while an
       // explicit additionalProperties:false remains strictly branch-local.
       continue;
@@ -342,7 +382,7 @@ const validateObject = (
       additionalSchema === false ||
       (additionalSchema !== true &&
         !allowUnknownProperties &&
-        hasPropertiesAcrossAllOf(schema))
+        hasPropertiesAcrossCompositions(schema))
     ) {
       return fail(childPath, "unknown property");
     }
@@ -394,7 +434,10 @@ const validateValue = (
 
   const types = schemaTypes(schema);
   if (types.length === 0) {
-    if (isPlainObject(value) && hasObjectConstraintsAcrossAllOf(schema)) {
+    if (
+      isPlainObject(value) &&
+      hasObjectConstraintsAcrossCompositions(schema)
+    ) {
       return validateObject(schema, value, path, allowUnknownProperties);
     }
     // A schema with no `type` (e.g. set_field_value.content.value) accepts any

--- a/packages/cli/src/registry-trust.test.ts
+++ b/packages/cli/src/registry-trust.test.ts
@@ -122,6 +122,43 @@ describe("validateFetchedToolsList: rule 2 (meta-schema)", () => {
       expect(validateFetchedToolsList(body([tool])).ok).toBe(false);
     }
   });
+
+  test("schema constraints cannot hide inside applicator branches", () => {
+    const applicators = ["anyOf", "allOf", "oneOf", "prefixItems"];
+    for (const keyword of applicators) {
+      const tool = validTool({
+        inputSchema: {
+          type: "object",
+          properties: {
+            value: { [keyword]: [{ type: "string", pattern: "[" }] },
+          },
+        },
+      });
+      expect(validateFetchedToolsList(body([tool])).ok).toBe(false);
+    }
+  });
+
+  test("serialized RegExp flags are validated with their source", () => {
+    const valid = validTool({
+      inputSchema: {
+        type: "object",
+        properties: {
+          value: { type: "RegExp", source: "^[a-f]+$", flags: "iu" },
+        },
+      },
+    });
+    const invalid = validTool({
+      inputSchema: {
+        type: "object",
+        properties: {
+          value: { type: "RegExp", source: "^[a-f]+$", flags: "x" },
+        },
+      },
+    });
+
+    expect(validateFetchedToolsList(body([valid])).ok).toBe(true);
+    expect(validateFetchedToolsList(body([invalid])).ok).toBe(false);
+  });
 });
 
 describe("validateFetchedToolsList: rule 3 (size/depth caps)", () => {

--- a/packages/cli/src/registry-trust.test.ts
+++ b/packages/cli/src/registry-trust.test.ts
@@ -109,6 +109,7 @@ describe("validateFetchedToolsList: rule 2 (meta-schema)", () => {
         properties: {},
         patternProperties: { "(?": { type: "string" } },
       },
+      { type: "RegExp", source: "[" },
     ];
 
     for (const child of invalidPatterns) {

--- a/packages/cli/src/registry-trust.test.ts
+++ b/packages/cli/src/registry-trust.test.ts
@@ -165,6 +165,37 @@ describe("validateFetchedToolsList: rule 2 (meta-schema)", () => {
     }
   });
 
+  test("unimplemented structural schema keywords fail closed", () => {
+    const unsupportedKeywords = [
+      ["$defs", { child: { type: "string" } }],
+      ["$ref", "#/definitions/child"],
+      ["contains", { const: "sentinel" }],
+      ["definitions", { child: { type: "string" } }],
+      ["dependentSchemas", { mode: { required: ["value"] } }],
+      ["else", { required: ["fallback"] }],
+      ["if", { required: ["mode"] }],
+      ["not", { const: "forbidden" }],
+      ["propertyNames", { pattern: "^safe-" }],
+      ["then", { required: ["value"] }],
+      ["unevaluatedItems", { type: "string" }],
+      ["unevaluatedProperties", false],
+    ] as const;
+
+    for (const [keyword, constraint] of unsupportedKeywords) {
+      const tool = validTool({
+        inputSchema: {
+          type: "object",
+          properties: { value: { [keyword]: constraint } },
+        },
+      });
+
+      expect(validateFetchedToolsList(body([tool]))).toEqual({
+        ok: false,
+        violation: `tool list_matters: ${keyword} schema constraints are unsupported`,
+      });
+    }
+  });
+
   test("unsupported subschema shapes fail closed in every traversed container", () => {
     const invalidChildren = [
       { anyOf: [true] },
@@ -291,14 +322,14 @@ describe("validateFetchedToolsList: rule 4 (no executable content)", () => {
     expect(validateFetchedToolsList(body([tool])).ok).toBe(false);
   });
 
-  test("a local #/ $ref is accepted", () => {
+  test("a local #/ $ref is rejected until the interpreter resolves it", () => {
     const tool = validTool({
       inputSchema: {
         type: "object",
         properties: { x: { $ref: "#/definitions/y" } },
       },
     });
-    expect(validateFetchedToolsList(body([tool])).ok).toBe(true);
+    expect(validateFetchedToolsList(body([tool])).ok).toBe(false);
   });
 });
 

--- a/packages/cli/src/registry-trust.test.ts
+++ b/packages/cli/src/registry-trust.test.ts
@@ -100,6 +100,27 @@ describe("validateFetchedToolsList: rule 2 (meta-schema)", () => {
     const tool = validTool({ annotations: { readOnlyHint: "yes" } });
     expect(validateFetchedToolsList(body([tool])).ok).toBe(false);
   });
+
+  test("invalid schema regex patterns are rejected at the trust boundary", () => {
+    const invalidPatterns = [
+      { type: "string", pattern: "[" },
+      {
+        type: "object",
+        properties: {},
+        patternProperties: { "(?": { type: "string" } },
+      },
+    ];
+
+    for (const child of invalidPatterns) {
+      const tool = validTool({
+        inputSchema: {
+          type: "object",
+          properties: { value: child },
+        },
+      });
+      expect(validateFetchedToolsList(body([tool])).ok).toBe(false);
+    }
+  });
 });
 
 describe("validateFetchedToolsList: rule 3 (size/depth caps)", () => {

--- a/packages/cli/src/registry-trust.test.ts
+++ b/packages/cli/src/registry-trust.test.ts
@@ -124,7 +124,7 @@ describe("validateFetchedToolsList: rule 2 (meta-schema)", () => {
   });
 
   test("schema constraints cannot hide inside applicator branches", () => {
-    const applicators = ["anyOf", "allOf", "oneOf", "prefixItems"];
+    const applicators = ["anyOf", "allOf", "oneOf"];
     for (const keyword of applicators) {
       const tool = validTool({
         inputSchema: {
@@ -138,6 +138,33 @@ describe("validateFetchedToolsList: rule 2 (meta-schema)", () => {
     }
   });
 
+  test("unsupported tuple array schemas fail closed", () => {
+    const unsupportedTuples = [
+      {
+        schema: { prefixItems: [{ type: "string" }, { type: "integer" }] },
+        violation: "prefixItems tuple schemas are unsupported",
+      },
+      {
+        schema: { items: [{ type: "string" }, { type: "integer" }] },
+        violation: "array-valued items tuple schemas are unsupported",
+      },
+    ];
+
+    for (const { schema, violation } of unsupportedTuples) {
+      const tool = validTool({
+        inputSchema: {
+          type: "object",
+          properties: { value: { type: "array", ...schema } },
+        },
+      });
+
+      expect(validateFetchedToolsList(body([tool]))).toEqual({
+        ok: false,
+        violation: `tool list_matters: ${violation}`,
+      });
+    }
+  });
+
   test("unsupported subschema shapes fail closed in every traversed container", () => {
     const invalidChildren = [
       { anyOf: [true] },
@@ -147,7 +174,7 @@ describe("validateFetchedToolsList: rule 2 (meta-schema)", () => {
       { patternProperties: { ".*": "not-a-schema" } },
       { patternProperties: [] },
       { additionalProperties: "not-a-schema" },
-      { items: [null] },
+      { items: null },
       { $defs: { child: false } },
     ];
 

--- a/packages/cli/src/registry-trust.test.ts
+++ b/packages/cli/src/registry-trust.test.ts
@@ -138,6 +138,27 @@ describe("validateFetchedToolsList: rule 2 (meta-schema)", () => {
     }
   });
 
+  test("unsupported subschema shapes fail closed in every traversed container", () => {
+    const invalidChildren = [
+      { anyOf: [true] },
+      { allOf: ["not-a-schema"] },
+      { properties: { child: 42 } },
+      { patternProperties: { ".*": "not-a-schema" } },
+      { items: [null] },
+      { $defs: { child: false } },
+    ];
+
+    for (const child of invalidChildren) {
+      const tool = validTool({
+        inputSchema: {
+          type: "object",
+          properties: { value: child },
+        },
+      });
+      expect(validateFetchedToolsList(body([tool])).ok).toBe(false);
+    }
+  });
+
   test("serialized RegExp flags are validated with their source", () => {
     const valid = validTool({
       inputSchema: {

--- a/packages/cli/src/registry-trust.test.ts
+++ b/packages/cli/src/registry-trust.test.ts
@@ -29,7 +29,7 @@ describe("validateFetchedToolsList: rule 1 (interpreted, no eval)", () => {
       inputSchema: {
         type: "object",
         properties: {
-          x: { type: "string", format: "email", pattern: ".*" },
+          x: { type: "string", pattern: ".*" },
         },
       },
     });
@@ -171,8 +171,11 @@ describe("validateFetchedToolsList: rule 2 (meta-schema)", () => {
       ["$ref", "#/definitions/child"],
       ["contains", { const: "sentinel" }],
       ["definitions", { child: { type: "string" } }],
+      ["dependencies", { mode: ["value"] }],
+      ["dependentRequired", { mode: ["value"] }],
       ["dependentSchemas", { mode: { required: ["value"] } }],
       ["else", { required: ["fallback"] }],
+      ["format", "email"],
       ["if", { required: ["mode"] }],
       ["not", { const: "forbidden" }],
       ["propertyNames", { pattern: "^safe-" }],
@@ -194,6 +197,21 @@ describe("validateFetchedToolsList: rule 2 (meta-schema)", () => {
         violation: `tool list_matters: ${keyword} schema constraints are unsupported`,
       });
     }
+  });
+
+  test("unknown schema vocabulary fails closed by default", () => {
+    const tool = validTool({
+      inputSchema: {
+        type: "object",
+        properties: { value: { futureConstraint: true } },
+      },
+    });
+
+    expect(validateFetchedToolsList(body([tool]))).toEqual({
+      ok: false,
+      violation:
+        "tool list_matters: futureConstraint schema constraints are unsupported",
+    });
   });
 
   test("unsupported subschema shapes fail closed in every traversed container", () => {

--- a/packages/cli/src/registry-trust.test.ts
+++ b/packages/cli/src/registry-trust.test.ts
@@ -143,7 +143,10 @@ describe("validateFetchedToolsList: rule 2 (meta-schema)", () => {
       { anyOf: [true] },
       { allOf: ["not-a-schema"] },
       { properties: { child: 42 } },
+      { properties: [] },
       { patternProperties: { ".*": "not-a-schema" } },
+      { patternProperties: [] },
+      { additionalProperties: "not-a-schema" },
       { items: [null] },
       { $defs: { child: false } },
     ];

--- a/packages/cli/src/registry-trust.ts
+++ b/packages/cli/src/registry-trust.ts
@@ -13,6 +13,7 @@ import { Result } from "better-result";
 import { createHash } from "node:crypto";
 
 import type { RegistryToolListing } from "./route-types.js";
+import { compileSchemaPattern } from "./schema-pattern.js";
 
 // --- Size / depth caps (spec S5.5 rule 3), named constants, not literals. ---
 /** Reject a whole fetched body larger than this (bytes). */
@@ -97,12 +98,35 @@ const walkSchema = (schema: unknown, depth: number): string | undefined => {
     return `enum larger than ${MAX_ENUM}`;
   }
 
+  const pattern = schema["pattern"];
+  if (pattern !== undefined) {
+    if (typeof pattern !== "string") {
+      return "schema pattern must be a string";
+    }
+    if (compileSchemaPattern(pattern).status === "invalid") {
+      return "schema pattern is invalid";
+    }
+  }
+
   const properties = schema["properties"];
   if (isRecord(properties)) {
     if (Object.keys(properties).length > MAX_PROPS) {
       return `properties object larger than ${MAX_PROPS}`;
     }
     for (const child of Object.values(properties)) {
+      const violation = walkSchema(child, depth + 1);
+      if (violation !== undefined) {
+        return violation;
+      }
+    }
+  }
+
+  const patternProperties = schema["patternProperties"];
+  if (isRecord(patternProperties)) {
+    for (const [childPattern, child] of Object.entries(patternProperties)) {
+      if (compileSchemaPattern(childPattern).status === "invalid") {
+        return "patternProperties contains an invalid pattern";
+      }
       const violation = walkSchema(child, depth + 1);
       if (violation !== undefined) {
         return violation;

--- a/packages/cli/src/registry-trust.ts
+++ b/packages/cli/src/registry-trust.ts
@@ -59,6 +59,30 @@ const isRecord = (value: unknown): value is Record<string, unknown> =>
 const isUnknownArray = (value: unknown): value is readonly unknown[] =>
   Array.isArray(value);
 
+const SCHEMA_ARRAY_KEYWORDS = [
+  "allOf",
+  "anyOf",
+  "oneOf",
+  "prefixItems",
+] as const;
+
+const SCHEMA_SINGLE_KEYWORDS = [
+  "contains",
+  "else",
+  "if",
+  "not",
+  "propertyNames",
+  "then",
+  "unevaluatedItems",
+  "unevaluatedProperties",
+] as const;
+
+const SCHEMA_MAP_KEYWORDS = [
+  "$defs",
+  "definitions",
+  "dependentSchemas",
+] as const;
+
 /** Pull the `tools` array from a tools/list body (bare, `{tools}`, or envelope). */
 const extractTools = (parsed: unknown): readonly unknown[] | undefined => {
   if (isUnknownArray(parsed)) {
@@ -110,11 +134,68 @@ const walkSchema = (schema: unknown, depth: number): string | undefined => {
 
   if (schema["type"] === "RegExp") {
     const source = schema["source"];
+    const flags = schema["flags"];
     if (
       typeof source !== "string" ||
-      compileSchemaPattern(source).status === "invalid"
+      (flags !== undefined && typeof flags !== "string") ||
+      compileSchemaPattern(
+        source,
+        typeof flags === "string" ? flags : undefined,
+      ).status === "invalid"
     ) {
-      return "RegExp schema source is invalid";
+      return "RegExp schema source or flags are invalid";
+    }
+  }
+
+  for (const keyword of SCHEMA_ARRAY_KEYWORDS) {
+    const branches = schema[keyword];
+    if (branches === undefined) {
+      continue;
+    }
+    if (!isUnknownArray(branches)) {
+      return `${keyword} must be an array`;
+    }
+    for (const branch of branches) {
+      if (typeof branch !== "boolean" && !isRecord(branch)) {
+        return `${keyword} contains an invalid schema`;
+      }
+      const violation = walkSchema(branch, depth + 1);
+      if (violation !== undefined) {
+        return violation;
+      }
+    }
+  }
+
+  for (const keyword of SCHEMA_SINGLE_KEYWORDS) {
+    const child = schema[keyword];
+    if (child === undefined) {
+      continue;
+    }
+    if (typeof child !== "boolean" && !isRecord(child)) {
+      return `${keyword} must be a schema`;
+    }
+    const violation = walkSchema(child, depth + 1);
+    if (violation !== undefined) {
+      return violation;
+    }
+  }
+
+  for (const keyword of SCHEMA_MAP_KEYWORDS) {
+    const children = schema[keyword];
+    if (children === undefined) {
+      continue;
+    }
+    if (!isRecord(children)) {
+      return `${keyword} must be an object`;
+    }
+    for (const child of Object.values(children)) {
+      if (typeof child !== "boolean" && !isRecord(child)) {
+        return `${keyword} contains an invalid schema`;
+      }
+      const violation = walkSchema(child, depth + 1);
+      if (violation !== undefined) {
+        return violation;
+      }
     }
   }
 

--- a/packages/cli/src/registry-trust.ts
+++ b/packages/cli/src/registry-trust.ts
@@ -200,6 +200,9 @@ const walkSchema = (schema: unknown, depth: number): string | undefined => {
   }
 
   const properties = schema["properties"];
+  if (properties !== undefined && !isRecord(properties)) {
+    return "properties must be an object";
+  }
   if (isRecord(properties)) {
     if (Object.keys(properties).length > MAX_PROPS) {
       return `properties object larger than ${MAX_PROPS}`;
@@ -216,6 +219,9 @@ const walkSchema = (schema: unknown, depth: number): string | undefined => {
   }
 
   const patternProperties = schema["patternProperties"];
+  if (patternProperties !== undefined && !isRecord(patternProperties)) {
+    return "patternProperties must be an object";
+  }
   if (isRecord(patternProperties)) {
     for (const [childPattern, child] of Object.entries(patternProperties)) {
       if (compileSchemaPattern(childPattern).status === "invalid") {
@@ -252,6 +258,13 @@ const walkSchema = (schema: unknown, depth: number): string | undefined => {
   }
 
   const additional = schema["additionalProperties"];
+  if (
+    additional !== undefined &&
+    typeof additional !== "boolean" &&
+    !isRecord(additional)
+  ) {
+    return "additionalProperties must be a boolean or schema";
+  }
   if (isRecord(additional)) {
     return walkSchema(additional, depth + 1);
   }

--- a/packages/cli/src/registry-trust.ts
+++ b/packages/cli/src/registry-trust.ts
@@ -156,7 +156,7 @@ const walkSchema = (schema: unknown, depth: number): string | undefined => {
       return `${keyword} must be an array`;
     }
     for (const branch of branches) {
-      if (typeof branch !== "boolean" && !isRecord(branch)) {
+      if (!isRecord(branch)) {
         return `${keyword} contains an invalid schema`;
       }
       const violation = walkSchema(branch, depth + 1);
@@ -171,7 +171,7 @@ const walkSchema = (schema: unknown, depth: number): string | undefined => {
     if (child === undefined) {
       continue;
     }
-    if (typeof child !== "boolean" && !isRecord(child)) {
+    if (!isRecord(child)) {
       return `${keyword} must be a schema`;
     }
     const violation = walkSchema(child, depth + 1);
@@ -189,7 +189,7 @@ const walkSchema = (schema: unknown, depth: number): string | undefined => {
       return `${keyword} must be an object`;
     }
     for (const child of Object.values(children)) {
-      if (typeof child !== "boolean" && !isRecord(child)) {
+      if (!isRecord(child)) {
         return `${keyword} contains an invalid schema`;
       }
       const violation = walkSchema(child, depth + 1);
@@ -205,6 +205,9 @@ const walkSchema = (schema: unknown, depth: number): string | undefined => {
       return `properties object larger than ${MAX_PROPS}`;
     }
     for (const child of Object.values(properties)) {
+      if (!isRecord(child)) {
+        return "properties contains an invalid schema";
+      }
       const violation = walkSchema(child, depth + 1);
       if (violation !== undefined) {
         return violation;
@@ -218,6 +221,9 @@ const walkSchema = (schema: unknown, depth: number): string | undefined => {
       if (compileSchemaPattern(childPattern).status === "invalid") {
         return "patternProperties contains an invalid pattern";
       }
+      if (!isRecord(child)) {
+        return "patternProperties contains an invalid schema";
+      }
       const violation = walkSchema(child, depth + 1);
       if (violation !== undefined) {
         return violation;
@@ -228,11 +234,16 @@ const walkSchema = (schema: unknown, depth: number): string | undefined => {
   const items = schema["items"];
   if (Array.isArray(items)) {
     for (const item of items) {
+      if (!isRecord(item)) {
+        return "items contains an invalid schema";
+      }
       const violation = walkSchema(item, depth + 1);
       if (violation !== undefined) {
         return violation;
       }
     }
+  } else if (items !== undefined && !isRecord(items)) {
+    return "items must be a schema or schema array";
   } else if (isRecord(items)) {
     const violation = walkSchema(items, depth + 1);
     if (violation !== undefined) {

--- a/packages/cli/src/registry-trust.ts
+++ b/packages/cli/src/registry-trust.ts
@@ -61,11 +61,44 @@ const isUnknownArray = (value: unknown): value is readonly unknown[] =>
 
 const SCHEMA_ARRAY_KEYWORDS = ["allOf", "anyOf", "oneOf"] as const;
 
+// This is intentionally an allowlist, not only a list of known-dangerous
+// keywords. The fetched registry is executable CLI configuration: a new JSON
+// Schema keyword must not become trusted until validation and help implement
+// the same semantics.
+const SUPPORTED_SCHEMA_KEYWORDS: ReadonlySet<string> = new Set([
+  "additionalProperties",
+  "allOf",
+  "anyOf",
+  "const",
+  "default",
+  "description",
+  "enum",
+  "examples",
+  "flags",
+  "items",
+  "maxItems",
+  "maxLength",
+  "maximum",
+  "minItems",
+  "minLength",
+  "minimum",
+  "oneOf",
+  "pattern",
+  "patternProperties",
+  "properties",
+  "required",
+  "source",
+  "title",
+  "type",
+]);
+
 const UNSUPPORTED_SCHEMA_KEYWORDS = [
   "$defs",
   "$ref",
   "contains",
   "definitions",
+  "dependencies",
+  "dependentRequired",
   "dependentSchemas",
   "else",
   "if",
@@ -111,6 +144,12 @@ const walkSchema = (schema: unknown, depth: number): string | undefined => {
 
   for (const keyword of UNSUPPORTED_SCHEMA_KEYWORDS) {
     if (schema[keyword] !== undefined) {
+      return `${keyword} schema constraints are unsupported`;
+    }
+  }
+
+  for (const keyword of Object.keys(schema)) {
+    if (!SUPPORTED_SCHEMA_KEYWORDS.has(keyword)) {
       return `${keyword} schema constraints are unsupported`;
     }
   }

--- a/packages/cli/src/registry-trust.ts
+++ b/packages/cli/src/registry-trust.ts
@@ -59,12 +59,7 @@ const isRecord = (value: unknown): value is Record<string, unknown> =>
 const isUnknownArray = (value: unknown): value is readonly unknown[] =>
   Array.isArray(value);
 
-const SCHEMA_ARRAY_KEYWORDS = [
-  "allOf",
-  "anyOf",
-  "oneOf",
-  "prefixItems",
-] as const;
+const SCHEMA_ARRAY_KEYWORDS = ["allOf", "anyOf", "oneOf"] as const;
 
 const SCHEMA_SINGLE_KEYWORDS = [
   "contains",
@@ -110,6 +105,10 @@ const walkSchema = (schema: unknown, depth: number): string | undefined => {
   }
   if (!isRecord(schema)) {
     return undefined;
+  }
+
+  if (schema["prefixItems"] !== undefined) {
+    return "prefixItems tuple schemas are unsupported";
   }
 
   const ref = schema["$ref"];
@@ -239,17 +238,9 @@ const walkSchema = (schema: unknown, depth: number): string | undefined => {
 
   const items = schema["items"];
   if (Array.isArray(items)) {
-    for (const item of items) {
-      if (!isRecord(item)) {
-        return "items contains an invalid schema";
-      }
-      const violation = walkSchema(item, depth + 1);
-      if (violation !== undefined) {
-        return violation;
-      }
-    }
+    return "array-valued items tuple schemas are unsupported";
   } else if (items !== undefined && !isRecord(items)) {
-    return "items must be a schema or schema array";
+    return "items must be a schema";
   } else if (isRecord(items)) {
     const violation = walkSchema(items, depth + 1);
     if (violation !== undefined) {

--- a/packages/cli/src/registry-trust.ts
+++ b/packages/cli/src/registry-trust.ts
@@ -26,7 +26,7 @@ export const MAX_TOOLS = 200;
 // The deepest baked-in schema is `save_template` (depth 7); the largest enum is
 // `set_practice_jurisdictions` (250). Both were raised from their spec S5.5
 // starting values (depth 6, enum 200) once the real registry exceeded them.
-/** Reject an `inputSchema` nested deeper than this (also catches `$ref` cycles). */
+/** Reject an `inputSchema` nested deeper than this. */
 export const MAX_SCHEMA_DEPTH = 8;
 /** Reject a single tool whose serialized `inputSchema` exceeds this (bytes). */
 export const MAX_TOOL_SCHEMA_BYTES: number = 64 * 1024; // 64 KiB
@@ -61,8 +61,12 @@ const isUnknownArray = (value: unknown): value is readonly unknown[] =>
 
 const SCHEMA_ARRAY_KEYWORDS = ["allOf", "anyOf", "oneOf"] as const;
 
-const SCHEMA_SINGLE_KEYWORDS = [
+const UNSUPPORTED_SCHEMA_KEYWORDS = [
+  "$defs",
+  "$ref",
   "contains",
+  "definitions",
+  "dependentSchemas",
   "else",
   "if",
   "not",
@@ -70,12 +74,6 @@ const SCHEMA_SINGLE_KEYWORDS = [
   "then",
   "unevaluatedItems",
   "unevaluatedProperties",
-] as const;
-
-const SCHEMA_MAP_KEYWORDS = [
-  "$defs",
-  "definitions",
-  "dependentSchemas",
 ] as const;
 
 /** Pull the `tools` array from a tools/list body (bare, `{tools}`, or envelope). */
@@ -95,8 +93,8 @@ const extractTools = (parsed: unknown): readonly unknown[] | undefined => {
 
 /**
  * Walk one `inputSchema` subtree enforcing the depth/enum/props caps and the
- * no-remote-`$ref` rule. Interpreted recursion with an explicit depth counter;
- * the depth cap bounds resolution and catches any `$ref` cycle (rule 4).
+ * supported schema-vocabulary rule. Interpreted recursion with an explicit
+ * depth counter bounds registry-controlled work.
  * Returns a violation string, or `undefined` when the subtree is within bounds.
  */
 const walkSchema = (schema: unknown, depth: number): string | undefined => {
@@ -111,9 +109,10 @@ const walkSchema = (schema: unknown, depth: number): string | undefined => {
     return "prefixItems tuple schemas are unsupported";
   }
 
-  const ref = schema["$ref"];
-  if (ref !== undefined && (typeof ref !== "string" || !ref.startsWith("#/"))) {
-    return "only local #/... $ref is allowed";
+  for (const keyword of UNSUPPORTED_SCHEMA_KEYWORDS) {
+    if (schema[keyword] !== undefined) {
+      return `${keyword} schema constraints are unsupported`;
+    }
   }
 
   const enumValues = schema["enum"];
@@ -159,39 +158,6 @@ const walkSchema = (schema: unknown, depth: number): string | undefined => {
         return `${keyword} contains an invalid schema`;
       }
       const violation = walkSchema(branch, depth + 1);
-      if (violation !== undefined) {
-        return violation;
-      }
-    }
-  }
-
-  for (const keyword of SCHEMA_SINGLE_KEYWORDS) {
-    const child = schema[keyword];
-    if (child === undefined) {
-      continue;
-    }
-    if (!isRecord(child)) {
-      return `${keyword} must be a schema`;
-    }
-    const violation = walkSchema(child, depth + 1);
-    if (violation !== undefined) {
-      return violation;
-    }
-  }
-
-  for (const keyword of SCHEMA_MAP_KEYWORDS) {
-    const children = schema[keyword];
-    if (children === undefined) {
-      continue;
-    }
-    if (!isRecord(children)) {
-      return `${keyword} must be an object`;
-    }
-    for (const child of Object.values(children)) {
-      if (!isRecord(child)) {
-        return `${keyword} contains an invalid schema`;
-      }
-      const violation = walkSchema(child, depth + 1);
       if (violation !== undefined) {
         return violation;
       }

--- a/packages/cli/src/registry-trust.ts
+++ b/packages/cli/src/registry-trust.ts
@@ -108,6 +108,16 @@ const walkSchema = (schema: unknown, depth: number): string | undefined => {
     }
   }
 
+  if (schema["type"] === "RegExp") {
+    const source = schema["source"];
+    if (
+      typeof source !== "string" ||
+      compileSchemaPattern(source).status === "invalid"
+    ) {
+      return "RegExp schema source is invalid";
+    }
+  }
+
   const properties = schema["properties"];
   if (isRecord(properties)) {
     if (Object.keys(properties).length > MAX_PROPS) {

--- a/packages/cli/src/run-capability-command.test.ts
+++ b/packages/cli/src/run-capability-command.test.ts
@@ -298,6 +298,22 @@ describe("runCapabilityCommand: flag -> invoke_capability payload", () => {
     const spec = capSpec({
       capabilityId: "uploads.create",
       flags: [stringFlag("--workspace", "params", "workspaceId", true)],
+      inputSchema: {
+        type: "object",
+        additionalProperties: false,
+        properties: {
+          body: {
+            type: "object",
+            additionalProperties: false,
+            properties: { purpose: { type: "string" } },
+          },
+          params: {
+            type: "object",
+            additionalProperties: false,
+            properties: { workspaceId: { type: "string" } },
+          },
+        },
+      },
     });
     const tty = makeTtyContext({
       serverUrl: server.url,
@@ -328,6 +344,17 @@ describe("runCapabilityCommand: flag -> invoke_capability payload", () => {
     const spec = capSpec({
       capabilityId: "uploads.create",
       flags: [stringFlag("--workspace", "params", "workspaceId", true)],
+      inputSchema: {
+        type: "object",
+        additionalProperties: false,
+        properties: {
+          params: {
+            type: "object",
+            additionalProperties: false,
+            properties: { workspaceId: { type: "string" } },
+          },
+        },
+      },
     });
     const tty = makeTtyContext({
       serverUrl: server.url,

--- a/packages/cli/src/schema-pattern.test.ts
+++ b/packages/cli/src/schema-pattern.test.ts
@@ -17,4 +17,19 @@ describe("compileSchemaPattern", () => {
   test("returns an invalid result for unsupported syntax", () => {
     expect(compileSchemaPattern("[")).toEqual({ status: "invalid" });
   });
+
+  test("preserves serialized flags and always enables Unicode mode", () => {
+    const compiled = compileSchemaPattern("^[a-f]+$", "i");
+
+    expect(compiled.status).toBe("valid");
+    if (compiled.status === "valid") {
+      expect(compiled.regex.flags).toContain("i");
+      expect(compiled.regex.flags).toContain("u");
+      expect(compiled.regex.test("ABCDEF")).toBe(true);
+    }
+  });
+
+  test("rejects unsupported serialized flags", () => {
+    expect(compileSchemaPattern("value", "x")).toEqual({ status: "invalid" });
+  });
 });

--- a/packages/cli/src/schema-pattern.test.ts
+++ b/packages/cli/src/schema-pattern.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from "bun:test";
+import { RE2 } from "re2-wasm";
+
+import { compileSchemaPattern } from "./schema-pattern.js";
+
+describe("compileSchemaPattern", () => {
+  test("uses the linear-time RE2 engine for nested repetition", () => {
+    const compiled = compileSchemaPattern("^(a+)+$");
+
+    expect(compiled.status).toBe("valid");
+    if (compiled.status === "valid") {
+      expect(compiled.regex).toBeInstanceOf(RE2);
+      expect(compiled.regex.test(`${"a".repeat(10_000)}!`)).toBe(false);
+    }
+  });
+
+  test("returns an invalid result for unsupported syntax", () => {
+    expect(compileSchemaPattern("[")).toEqual({ status: "invalid" });
+  });
+});

--- a/packages/cli/src/schema-pattern.ts
+++ b/packages/cli/src/schema-pattern.ts
@@ -1,13 +1,15 @@
+import { RE2 } from "re2-wasm";
+
 export type CompiledSchemaPattern =
-  | { status: "valid"; regex: RegExp }
+  | { status: "valid"; regex: RE2 }
   | { status: "invalid" };
 
-/** Compile an untrusted JSON-Schema pattern without allowing SyntaxError out. */
+/** Compile untrusted schema patterns with a linear-time engine, never V8. */
 export const compileSchemaPattern = (
   pattern: string,
 ): CompiledSchemaPattern => {
   try {
-    return { status: "valid", regex: new RegExp(pattern, "u") };
+    return { status: "valid", regex: new RE2(pattern, "u") };
   } catch {
     return { status: "invalid" };
   }

--- a/packages/cli/src/schema-pattern.ts
+++ b/packages/cli/src/schema-pattern.ts
@@ -4,12 +4,30 @@ export type CompiledSchemaPattern =
   | { status: "valid"; regex: RE2 }
   | { status: "invalid" };
 
+const SUPPORTED_FLAGS: ReadonlySet<string> = new Set("dgimsuy");
+
+const flagsAreSupported = (flags: string): boolean => {
+  const seen = new Set<string>();
+  for (const flag of flags) {
+    if (!SUPPORTED_FLAGS.has(flag) || seen.has(flag)) {
+      return false;
+    }
+    seen.add(flag);
+  }
+  return true;
+};
+
 /** Compile untrusted schema patterns with a linear-time engine, never V8. */
 export const compileSchemaPattern = (
   pattern: string,
+  flags = "",
 ): CompiledSchemaPattern => {
+  if (!flagsAreSupported(flags)) {
+    return { status: "invalid" };
+  }
   try {
-    return { status: "valid", regex: new RE2(pattern, "u") };
+    const unicodeFlags = flags.includes("u") ? flags : `${flags}u`;
+    return { status: "valid", regex: new RE2(pattern, unicodeFlags) };
   } catch {
     return { status: "invalid" };
   }

--- a/packages/cli/src/schema-pattern.ts
+++ b/packages/cli/src/schema-pattern.ts
@@ -1,0 +1,14 @@
+export type CompiledSchemaPattern =
+  | { status: "valid"; regex: RegExp }
+  | { status: "invalid" };
+
+/** Compile an untrusted JSON-Schema pattern without allowing SyntaxError out. */
+export const compileSchemaPattern = (
+  pattern: string,
+): CompiledSchemaPattern => {
+  try {
+    return { status: "valid", regex: new RegExp(pattern, "u") };
+  } catch {
+    return { status: "invalid" };
+  }
+};


### PR DESCRIPTION
## What

- Render nested `--input` field paths, types, requiredness, descriptions, and union variants in ordinary command help.
- Generate complete shell-safe JSON examples from the same schemas used for CLI validation.
- Recognize union-shaped capability bodies as input-only contracts, including the presigned upload flow.
- Add generated-tree invariants covering documentation and example validation.

## Why

Complex capability inputs were previously summarized as field names without their accepted JSON shape. Some union-shaped bodies were not identified as input-only at all, leaving callers to discover the contract through validation failures.

This stacks on #1317. Validated with `bun run verify`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI `--help` now renders schema-derived `--input` field documentation and deterministic “complete JSON example” output, including union variants and map-style (free-map/pattern-map) inputs.
* **Bug Fixes**
  * Improved JSON Schema validation: Unicode code point `minLength`/`maxLength`, stricter `pattern`/`patternProperties` handling, `const`/`anyOf`/`oneOf` correctness, and safer `RegExp` string validation (including flag checks).
* **Tests**
  * Added end-to-end and unit coverage for help rendering, example generation/quoting, schema validation behaviour, and pattern compilation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->