### PR TITLE
fix(web): isolate test environment

### DIFF
--- a/apps/web/bunfig.toml
+++ b/apps/web/bunfig.toml
@@ -1,0 +1,2 @@
+[test]
+preload = ["./src/test-setup.ts"]

--- a/apps/web/src/lib/analytics/posthog.test.ts
+++ b/apps/web/src/lib/analytics/posthog.test.ts
@@ -72,12 +72,6 @@ Object.defineProperty(globalThis, "__APP_COMMIT_SHA__", {
   value: "abc123",
 });
 
-void mock.module("@/env", () => ({
-  env: {
-    VITE_POSTHOG_LOCAL_DEBUG: true,
-  },
-}));
-
 void mock.module("posthog-js", () => ({
   posthog: posthogMock,
 }));

--- a/apps/web/src/test-setup.ts
+++ b/apps/web/src/test-setup.ts
@@ -1,0 +1,5 @@
+// Tests must never inherit a developer deployment URL. A single preload owns
+// this process-wide value so test files can restore it safely.
+Object.assign(import.meta.env, {
+  VITE_API_URL: "http://localhost:3001",
+});


### PR DESCRIPTION
## Summary

- preload a deterministic API URL for the Bun web-test process
- remove a partial `@/env` module mock that leaked into later test files
- keep production environment validation unchanged

## Validation

- `bun --filter @stll/web test` (1,058 passed)
- `bun --filter @stll/web lint`
- `bun --filter @stll/web typecheck`
- affected-workspace pre-push formatting, localization, and typecheck gates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Standardised the test environment by loading shared setup before tests run.
  * Ensured tests use a local API endpoint instead of developer-specific deployment URLs.
  * Updated analytics tests to run without relying on local debug environment settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->