### PR TITLE
fix(cli): reject unused template values

### DIFF
--- a/apps/api/src/handlers/docx/adapt-ai-fields.ts
+++ b/apps/api/src/handlers/docx/adapt-ai-fields.ts
@@ -22,7 +22,7 @@ import { placeholderPattern, resolvePath } from "@stll/template-conditions";
 
 import { arrayOrEmpty } from "@/api/lib/array";
 
-import { HEADER_FOOTER_RE } from "./ooxml";
+import { templateContentPartPaths } from "./ooxml";
 import { partParagraphTexts, patchXmlPartPerOccurrence } from "./rich-patch";
 import type { FieldMeta } from "./types";
 
@@ -91,11 +91,7 @@ export const adaptAiFields = async ({
   const zip = await JSZip.loadAsync(buffer);
   // Sorted for a deterministic occurrence order; the patch pass below walks
   // the same list, so occurrence indices always line up with extraction.
-  const partNames = Object.keys(zip.files)
-    .filter(
-      (name) => name === "word/document.xml" || HEADER_FOOTER_RE.test(name),
-    )
-    .sort();
+  const partNames = templateContentPartPaths(Object.keys(zip.files));
   // Each part is read independently; `Promise.all(map(...))` preserves the
   // sorted `partNames` order in the result regardless of completion order, so
   // the patch pass below still sees `parts` in the same order extraction used.

--- a/apps/api/src/handlers/docx/block-directives.test.ts
+++ b/apps/api/src/handlers/docx/block-directives.test.ts
@@ -932,6 +932,32 @@ describe("processBlockDirectives — loops", () => {
     });
   });
 
+  test("primitive rows expose bare and qualified value conditions", () => {
+    const body = parseBody(
+      WRAP(
+        [
+          P("{{#each tags}}"),
+          P('{{#if value == "keep"}}'),
+          P("bare {{tags.value}}"),
+          P("{{/if}}"),
+          P('{{#if tags.value == "keep"}}'),
+          P("qualified {{tags.value}}"),
+          P("{{/if}}"),
+          P("{{/each}}"),
+        ].join(""),
+      ),
+    );
+    const { patchValues } = processBlockDirectives(body, {
+      tags: ["keep", "discard"],
+    });
+
+    expect(bodyTexts(body)).toEqual([
+      "bare {{__each_tags_0_value}}",
+      "qualified {{__each_tags_0_value}}",
+    ]);
+    expect(patchValues["__each_tags_0_value"]).toBe("keep");
+  });
+
   test("inner-loop condition compares a row's raw date, not the localized text", () => {
     const xml = WRAP(
       [

--- a/apps/api/src/handlers/docx/block-directives.test.ts
+++ b/apps/api/src/handlers/docx/block-directives.test.ts
@@ -958,6 +958,26 @@ describe("processBlockDirectives — loops", () => {
     expect(patchValues["__each_tags_0_value"]).toBe("keep");
   });
 
+  test("dotted primitive rows expose their qualified value condition", () => {
+    const body = parseBody(
+      WRAP(
+        [
+          P("{{#each deal.tags}}"),
+          P('{{#if deal.tags.value == "keep"}}'),
+          P("{{deal.tags.value}}"),
+          P("{{/if}}"),
+          P("{{/each}}"),
+        ].join(""),
+      ),
+    );
+    const { patchValues } = processBlockDirectives(body, {
+      deal: { tags: ["keep", "discard"] },
+    });
+
+    expect(bodyTexts(body)).toEqual(["{{__each_deal.tags_0_value}}"]);
+    expect(patchValues["__each_deal.tags_0_value"]).toBe("keep");
+  });
+
   test("inner-loop condition compares a row's raw date, not the localized text", () => {
     const xml = WRAP(
       [

--- a/apps/api/src/handlers/docx/block-directives.test.ts
+++ b/apps/api/src/handlers/docx/block-directives.test.ts
@@ -820,8 +820,7 @@ describe("processBlockDirectives — raw condition values overlay", () => {
     processBlockDirectives(
       body,
       { signing_date: "13. června 2028" },
-      undefined,
-      { signing_date: "2028-06-13" },
+      { conditionValues: { signing_date: "2028-06-13" } },
     );
 
     expect(bodyTexts(body)).toEqual(["After cutoff"]);
@@ -832,8 +831,7 @@ describe("processBlockDirectives — raw condition values overlay", () => {
     processBlockDirectives(
       body,
       { signing_date: "13. června 2020" },
-      undefined,
-      { signing_date: "2020-06-13" },
+      { conditionValues: { signing_date: "2020-06-13" } },
     );
 
     expect(bodyTexts(body)).toEqual(["Before cutoff"]);
@@ -877,7 +875,7 @@ describe("processBlockDirectives — raw condition values overlay", () => {
 
     // The same overlay drives condition evaluation against the formatted map.
     const body = parseBody(DATE_IF);
-    processBlockDirectives(body, values, undefined, overlay);
+    processBlockDirectives(body, values, { conditionValues: overlay });
     expect(bodyTexts(body)).toEqual(["After cutoff"]);
   });
 });
@@ -928,8 +926,12 @@ describe("processBlockDirectives — loops", () => {
     processBlockDirectives(
       body,
       { people: [{ dob: "13. června 2028" }, { dob: "1. ledna 2020" }] },
-      undefined,
-      { "people.0.dob": "2028-06-13", "people.1.dob": "2020-01-01" },
+      {
+        conditionValues: {
+          "people.0.dob": "2028-06-13",
+          "people.1.dob": "2020-01-01",
+        },
+      },
     );
 
     // Row 0 (2028-06-13 > 2028-01-01) keeps the line; row 1 (2020-01-01) drops

--- a/apps/api/src/handlers/docx/block-directives.test.ts
+++ b/apps/api/src/handlers/docx/block-directives.test.ts
@@ -909,6 +909,29 @@ describe("processBlockDirectives — loops", () => {
     expect(patchValues["__each_sellers_1_name"]).toBe("Bob");
   });
 
+  test("primitive rows share the contract-supported value representation", () => {
+    const body = parseBody(
+      WRAP([P("{{#each tags}}"), P("{{tags.value}}"), P("{{/each}}")].join("")),
+    );
+    const { patchValues } = processBlockDirectives(body, {
+      tags: ["one", 2, true],
+    });
+
+    expect(bodyTexts(body)).toEqual([
+      "{{__each_tags_0_value}}",
+      "{{__each_tags_1_value}}",
+      "{{__each_tags_2_value}}",
+    ]);
+    expect(patchValues).toMatchObject({
+      __each_tags_0: "one",
+      __each_tags_0_value: "one",
+      __each_tags_1: "2",
+      __each_tags_1_value: "2",
+      __each_tags_2: "true",
+      __each_tags_2_value: "true",
+    });
+  });
+
   test("inner-loop condition compares a row's raw date, not the localized text", () => {
     const xml = WRAP(
       [

--- a/apps/api/src/handlers/docx/block-directives.test.ts
+++ b/apps/api/src/handlers/docx/block-directives.test.ts
@@ -1301,6 +1301,34 @@ describe("processBlockDirectives — loop-scoped @num/@ref", () => {
     expect(numKeys).toHaveLength(3);
     expect(new Set(numKeys).size).toBe(3);
   });
+
+  test("primitive nested loop shorthand keeps patch values scoped per outer row", () => {
+    const xml = WRAP(
+      [
+        P("{{#each groups}}"),
+        P("{{#each subitems}}"),
+        P("{{subitems.value}}"),
+        P("{{/each}}"),
+        P("{{/each}}"),
+      ].join(""),
+    );
+    const body = parseBody(xml);
+    const { patchValues } = processBlockDirectives(body, {
+      groups: [{ subitems: ["first"] }, { subitems: ["second"] }],
+    });
+
+    expect(Object.values(patchValues)).toEqual([
+      "first",
+      "first",
+      "second",
+      "second",
+    ]);
+    expect(new Set(Object.keys(patchValues)).size).toBe(4);
+    expect(bodyTexts(body)).toEqual([
+      "{{__each___each_groups_0_subitems_0_value}}",
+      "{{__each___each_groups_1_subitems_0_value}}",
+    ]);
+  });
 });
 
 // ── Word list-numbering integrity ────────────────────────

--- a/apps/api/src/handlers/docx/block-directives.ts
+++ b/apps/api/src/handlers/docx/block-directives.ts
@@ -595,6 +595,24 @@ type ProcessResult = {
   errors: TemplateStructureError[];
 };
 
+export type DirectiveProcessingContext = {
+  inlineDataByParagraph: Map<slimdom.Element, Record<string, unknown>>;
+  nextEachExpansionId: () => number;
+};
+
+export const createDirectiveProcessingContext =
+  (): DirectiveProcessingContext => {
+    let eachExpansionId = 0;
+    return {
+      inlineDataByParagraph: new Map(),
+      nextEachExpansionId: () => {
+        const current = eachExpansionId;
+        eachExpansionId += 1;
+        return current;
+      },
+    };
+  };
+
 /**
  * Process block directives in a DOCX body element.
  *
@@ -604,18 +622,23 @@ type ProcessResult = {
  * Returns flattened patch values for loop-expanded
  * placeholders and any structural errors.
  */
+type ProcessBlockDirectivesOptions = {
+  conditionValues?: Record<string, string> | undefined;
+  namedConditions?: NamedCondition[] | undefined;
+  processingContext?: DirectiveProcessingContext;
+};
+
 export const processBlockDirectives = (
   body: slimdom.Element,
   data: TemplateData,
-  namedConditions?: NamedCondition[],
-  conditionValues?: Record<string, string>,
+  {
+    conditionValues,
+    namedConditions,
+    processingContext = createDirectiveProcessingContext(),
+  }: ProcessBlockDirectivesOptions = {},
 ): ProcessResult => {
   const patchValues: Record<string, RichPatchValue> = {};
   const allErrors: TemplateStructureError[] = [];
-
-  // Distinguishes sibling loops (possibly over the same array) so
-  // their iteration-scoped numbering keys can never collide.
-  let eachExpansionCount = 0;
 
   // Flatten top-level nested objects for value substitution.
   Object.assign(patchValues, flattenTemplateData(data));
@@ -875,8 +898,7 @@ export const processBlockDirectives = (
 
     const tokenMask = directEachBodyMask(contentParas);
     const localNumKeys = collectNumKeys(contentParas);
-    const expansionId = eachExpansionCount;
-    eachExpansionCount += 1;
+    const expansionId = processingContext.nextEachExpansionId();
 
     const finalRows: slimdom.Element[] = [];
     for (let itemIdx = 0; itemIdx < items.length; itemIdx++) {
@@ -907,16 +929,20 @@ export const processBlockDirectives = (
       });
       registerItem(item, block.arrayPath, itemIdx);
 
+      const itemContext = buildItemContext(
+        contextData,
+        item,
+        block.arrayPath,
+        itemIdx,
+      );
+      for (const paragraph of clonedContentParas) {
+        processingContext.inlineDataByParagraph.set(paragraph, itemContext);
+      }
+
       const hasNested = clonedContentParas.some((p) =>
         DIRECTIVE_RE.test(paragraphText(p)),
       );
       if (hasNested) {
-        const itemContext = buildItemContext(
-          contextData,
-          item,
-          block.arrayPath,
-          itemIdx,
-        );
         const tempBody = doc.createElementNS(W_NS, "w:body");
         const tempTbl = doc.createElementNS(W_NS, "w:tbl");
         tempBody.append(tempTbl);
@@ -972,8 +998,7 @@ export const processBlockDirectives = (
     const contentParas = paragraphsInUnits(contentUnits);
     const tokenMask = directEachBodyMask(contentParas);
     const localNumKeys = collectNumKeys(contentParas);
-    const expansionId = eachExpansionCount;
-    eachExpansionCount += 1;
+    const expansionId = processingContext.nextEachExpansionId();
 
     const finalUnits: slimdom.Element[] = [];
     for (let itemIdx = 0; itemIdx < items.length; itemIdx++) {
@@ -994,16 +1019,20 @@ export const processBlockDirectives = (
       });
       registerItem(item, block.arrayPath, itemIdx);
 
+      const itemContext = buildItemContext(
+        contextData,
+        item,
+        block.arrayPath,
+        itemIdx,
+      );
+      for (const paragraph of clonedParas) {
+        processingContext.inlineDataByParagraph.set(paragraph, itemContext);
+      }
+
       const hasNested = clonedParas.some((p) =>
         DIRECTIVE_RE.test(paragraphText(p)),
       );
       if (hasNested) {
-        const itemContext = buildItemContext(
-          contextData,
-          item,
-          block.arrayPath,
-          itemIdx,
-        );
         const tempBody = doc.createElementNS(W_NS, "w:body");
         for (const clone of clones) {
           tempBody.append(clone);

--- a/apps/api/src/handlers/docx/block-directives.ts
+++ b/apps/api/src/handlers/docx/block-directives.ts
@@ -790,13 +790,28 @@ export const processBlockDirectives = (
   // Build a loop iteration's evaluation context: `contextData` overlaid with
   // the item's own fields, the item under its array name (so `{{#each
   // arrayPath.sub}}` resolves), and the row's raw (pre-format) date overlay.
-  const buildItemContext = (
-    contextData: Record<string, unknown>,
-    item: unknown,
-    arrayPath: string,
-    itemIdx: number,
-  ): Record<string, unknown> => {
+  const loopIdentityByContext = new WeakMap<
+    Record<string, unknown>,
+    ReadonlyMap<string, string>
+  >();
+
+  type BuildItemContextOptions = {
+    arrayPath: string;
+    contextData: Record<string, unknown>;
+    item: unknown;
+    itemIdx: number;
+    loopIdentity: string;
+  };
+
+  const buildItemContext = ({
+    arrayPath,
+    contextData,
+    item,
+    itemIdx,
+    loopIdentity,
+  }: BuildItemContextOptions): Record<string, unknown> => {
     const itemContext: Record<string, unknown> = { ...contextData };
+    const nestedLoopIdentities = new Map<string, string>();
     if (isRecord(item)) {
       Object.assign(itemContext, item);
       itemContext[arrayPath] = item;
@@ -805,7 +820,9 @@ export const processBlockDirectives = (
       // the inner loop resolves them in the recursion.
       for (const [field, value] of Object.entries(item)) {
         if (Array.isArray(value)) {
-          itemContext[eachKey(arrayPath, itemIdx, field)] = value;
+          const nestedLoopIdentity = eachKey(loopIdentity, itemIdx, field);
+          itemContext[nestedLoopIdentity] = value;
+          nestedLoopIdentities.set(field, nestedLoopIdentity);
         }
       }
       applyRowRawOverlay(itemContext, conditionValues, arrayPath, itemIdx);
@@ -817,6 +834,9 @@ export const processBlockDirectives = (
       itemContext["value"] = item;
       itemContext[arrayPath] = { value: item };
       itemContext[`${arrayPath}.value`] = item;
+    }
+    if (nestedLoopIdentities.size > 0) {
+      loopIdentityByContext.set(itemContext, nestedLoopIdentities);
     }
     return itemContext;
   };
@@ -868,15 +888,27 @@ export const processBlockDirectives = (
 
   // Row-repeat: the opener/closer confined to one `w:tr`. Clone the row per
   // item, strip the marker paragraphs, and rewrite per item.
-  const expandRow = (
-    row: slimdom.Element,
-    openerP: slimdom.Element,
-    closerP: slimdom.Element,
-    block: EachBlock,
-    items: readonly unknown[],
-    contextData: Record<string, unknown>,
-    doc: slimdom.Document,
-  ): void => {
+  type ExpandRowOptions = {
+    block: EachBlock;
+    closerP: slimdom.Element;
+    contextData: Record<string, unknown>;
+    doc: slimdom.Document;
+    items: readonly unknown[];
+    loopIdentity: string;
+    openerP: slimdom.Element;
+    row: slimdom.Element;
+  };
+
+  const expandRow = ({
+    block,
+    closerP,
+    contextData,
+    doc,
+    items,
+    loopIdentity,
+    openerP,
+    row,
+  }: ExpandRowOptions): void => {
     const tbl = row.parentNode;
     if (!tbl || !isElement(tbl)) {
       return;
@@ -910,7 +942,11 @@ export const processBlockDirectives = (
         stripRowMarkerParagraph(closerClone, doc);
       }
 
-      rewriteEachPlaceholders(clonedRow, block.arrayPath, itemIdx);
+      rewriteEachPlaceholders(clonedRow, {
+        arrayPath: block.arrayPath,
+        index: itemIdx,
+        loopIdentity,
+      });
       rewriteNestedEachExpr(clonedRow, block.arrayPath, itemIdx);
       const clonedContentParas = clonedParas.filter((_, i) => !isMarker(i));
       rewriteContentParagraphs(clonedContentParas, {
@@ -920,14 +956,15 @@ export const processBlockDirectives = (
         itemIdx,
         itemCount: items.length,
       });
-      registerLoopItemPatchValues(patchValues, item, block.arrayPath, itemIdx);
+      registerLoopItemPatchValues(patchValues, item, loopIdentity, itemIdx);
 
-      const itemContext = buildItemContext(
+      const itemContext = buildItemContext({
+        arrayPath: block.arrayPath,
         contextData,
         item,
-        block.arrayPath,
         itemIdx,
-      );
+        loopIdentity,
+      });
       for (const paragraph of clonedContentParas) {
         processingContext.inlineDataByParagraph.set(paragraph, itemContext);
       }
@@ -964,14 +1001,17 @@ export const processBlockDirectives = (
 
   // Block repeat: opener/closer are block-level siblings. Clone every block
   // child (w:p AND w:tbl) between them as a unit per item.
-  const expandBlock = (
-    openerP: slimdom.Element,
-    closerP: slimdom.Element,
-    block: EachBlock,
-    items: readonly unknown[],
-    contextData: Record<string, unknown>,
-    doc: slimdom.Document,
-  ): void => {
+  type ExpandBlockOptions = Omit<ExpandRowOptions, "row">;
+
+  const expandBlock = ({
+    block,
+    closerP,
+    contextData,
+    doc,
+    items,
+    loopIdentity,
+    openerP,
+  }: ExpandBlockOptions): void => {
     const parent = openerP.parentNode;
     if (!parent || !isElement(parent)) {
       return;
@@ -1000,7 +1040,11 @@ export const processBlockDirectives = (
       const clonedParas = paragraphsInUnits(clones);
 
       for (const clone of clones) {
-        rewriteEachPlaceholders(clone, block.arrayPath, itemIdx);
+        rewriteEachPlaceholders(clone, {
+          arrayPath: block.arrayPath,
+          index: itemIdx,
+          loopIdentity,
+        });
         rewriteNestedEachExpr(clone, block.arrayPath, itemIdx);
       }
       rewriteContentParagraphs(clonedParas, {
@@ -1010,14 +1054,15 @@ export const processBlockDirectives = (
         itemIdx,
         itemCount: items.length,
       });
-      registerLoopItemPatchValues(patchValues, item, block.arrayPath, itemIdx);
+      registerLoopItemPatchValues(patchValues, item, loopIdentity, itemIdx);
 
-      const itemContext = buildItemContext(
+      const itemContext = buildItemContext({
+        arrayPath: block.arrayPath,
         contextData,
         item,
-        block.arrayPath,
         itemIdx,
-      );
+        loopIdentity,
+      });
       for (const paragraph of clonedParas) {
         processingContext.inlineDataByParagraph.set(paragraph, itemContext);
       }
@@ -1072,6 +1117,9 @@ export const processBlockDirectives = (
   ): void => {
     const arrayData = resolvePath(block.arrayPath, contextData);
     const items = isUnknownArray(arrayData) ? arrayData : [];
+    const loopIdentity =
+      loopIdentityByContext.get(contextData)?.get(block.arrayPath) ??
+      block.arrayPath;
 
     const doc = bodyEl.ownerDocument;
     if (!doc) {
@@ -1092,7 +1140,16 @@ export const processBlockDirectives = (
 
     // Row-repeat: both markers confined to the same table row.
     if (openerRow && openerRow === closerRow) {
-      expandRow(openerRow, openerP, closerP, block, items, contextData, doc);
+      expandRow({
+        block,
+        closerP,
+        contextData,
+        doc,
+        items,
+        loopIdentity,
+        openerP,
+        row: openerRow,
+      });
       return;
     }
 
@@ -1104,7 +1161,15 @@ export const processBlockDirectives = (
       return;
     }
 
-    expandBlock(openerP, closerP, block, items, contextData, doc);
+    expandBlock({
+      block,
+      closerP,
+      contextData,
+      doc,
+      items,
+      loopIdentity,
+      openerP,
+    });
   };
 
   process(body, conditionData);
@@ -1215,6 +1280,22 @@ export const rewriteEachPlaceholdersInText = (
   text: string,
   arrayPath: string,
   index: number,
+): string =>
+  rewriteEachPlaceholdersWithIdentity(text, {
+    arrayPath,
+    index,
+    loopIdentity: arrayPath,
+  });
+
+type RewriteEachPlaceholdersOptions = {
+  arrayPath: string;
+  index: number;
+  loopIdentity: string;
+};
+
+const rewriteEachPlaceholdersWithIdentity = (
+  text: string,
+  { arrayPath, index, loopIdentity }: RewriteEachPlaceholdersOptions,
 ): string => {
   const re = new RegExp(
     `\\{\\{${escapeRegExp(arrayPath)}\\.([.\\p{L}\\p{N}_-]+)\\}\\}`,
@@ -1222,7 +1303,7 @@ export const rewriteEachPlaceholdersInText = (
   );
   return text.replace(
     re,
-    (_match, field: string) => `{{${eachKey(arrayPath, index, field)}}}`,
+    (_match, field: string) => `{{${eachKey(loopIdentity, index, field)}}}`,
   );
 };
 
@@ -1232,11 +1313,10 @@ export const rewriteEachPlaceholdersInText = (
  */
 const rewriteEachPlaceholders = (
   root: slimdom.Element,
-  arrayPath: string,
-  index: number,
+  options: RewriteEachPlaceholdersOptions,
 ): void => {
   rewriteTextNodes(root, (text) =>
-    rewriteEachPlaceholdersInText(text, arrayPath, index),
+    rewriteEachPlaceholdersWithIdentity(text, options),
   );
 };
 

--- a/apps/api/src/handlers/docx/block-directives.ts
+++ b/apps/api/src/handlers/docx/block-directives.ts
@@ -816,6 +816,7 @@ export const processBlockDirectives = (
     ) {
       itemContext["value"] = item;
       itemContext[arrayPath] = { value: item };
+      itemContext[`${arrayPath}.value`] = item;
     }
     return itemContext;
   };

--- a/apps/api/src/handlers/docx/block-directives.ts
+++ b/apps/api/src/handlers/docx/block-directives.ts
@@ -809,6 +809,13 @@ export const processBlockDirectives = (
         }
       }
       applyRowRawOverlay(itemContext, conditionValues, arrayPath, itemIdx);
+    } else if (
+      typeof item === "string" ||
+      typeof item === "number" ||
+      typeof item === "boolean"
+    ) {
+      itemContext["value"] = item;
+      itemContext[arrayPath] = { value: item };
     }
     return itemContext;
   };

--- a/apps/api/src/handlers/docx/block-directives.ts
+++ b/apps/api/src/handlers/docx/block-directives.ts
@@ -947,7 +947,11 @@ export const processBlockDirectives = (
         index: itemIdx,
         loopIdentity,
       });
-      rewriteNestedEachExpr(clonedRow, block.arrayPath, itemIdx);
+      rewriteNestedEachExpr(clonedRow, {
+        arrayPath: block.arrayPath,
+        index: itemIdx,
+        loopIdentity,
+      });
       const clonedContentParas = clonedParas.filter((_, i) => !isMarker(i));
       rewriteContentParagraphs(clonedContentParas, {
         tokenMask,
@@ -1045,7 +1049,11 @@ export const processBlockDirectives = (
           index: itemIdx,
           loopIdentity,
         });
-        rewriteNestedEachExpr(clone, block.arrayPath, itemIdx);
+        rewriteNestedEachExpr(clone, {
+          arrayPath: block.arrayPath,
+          index: itemIdx,
+          loopIdentity,
+        });
       }
       rewriteContentParagraphs(clonedParas, {
         tokenMask,
@@ -1330,8 +1338,7 @@ const rewriteEachPlaceholders = (
  */
 const rewriteNestedEachExpr = (
   root: slimdom.Element,
-  arrayPath: string,
-  index: number,
+  { arrayPath, index, loopIdentity }: RewriteEachPlaceholdersOptions,
 ): void => {
   const re = new RegExp(
     `(\\{\\{\\s*#each\\s+)${escapeRegExp(arrayPath)}\\.([.\\p{L}\\p{N}_-]+)(\\s*\\}\\})`,
@@ -1341,7 +1348,7 @@ const rewriteNestedEachExpr = (
     text.replace(
       re,
       (_match, pre: string, sub: string, post: string) =>
-        `${pre}${eachKey(arrayPath, index, sub)}${post}`,
+        `${pre}${eachKey(loopIdentity, index, sub)}${post}`,
     ),
   );
 };

--- a/apps/api/src/handlers/docx/block-directives.ts
+++ b/apps/api/src/handlers/docx/block-directives.ts
@@ -813,21 +813,6 @@ export const processBlockDirectives = (
     return itemContext;
   };
 
-  // Register a loop item's values for later substitution (recursively for
-  // nested objects so deep paths like address.city resolve).
-  const registerItem = (
-    item: unknown,
-    arrayPath: string,
-    itemIdx: number,
-  ): void => {
-    if (isRecord(item)) {
-      registerItemPatchValues(patchValues, item, arrayPath, itemIdx, "");
-    } else if (typeof item === "string") {
-      // Simple array of strings: {{arrayPath.value}} or raw {{__each_arrayPath_N}}
-      patchValues[`__each_${arrayPath}_${itemIdx}`] = item;
-    }
-  };
-
   // Resolve `{{@index}}`/`{{@count}}` (innermost-loop only, via `tokenMask`)
   // and loop-scoped `{{@num:Key}}`/`{{@ref:Key}}` on a copy's content
   // paragraphs. Placeholder rewriting is done separately over whole units.
@@ -927,7 +912,7 @@ export const processBlockDirectives = (
         itemIdx,
         itemCount: items.length,
       });
-      registerItem(item, block.arrayPath, itemIdx);
+      registerLoopItemPatchValues(patchValues, item, block.arrayPath, itemIdx);
 
       const itemContext = buildItemContext(
         contextData,
@@ -1017,7 +1002,7 @@ export const processBlockDirectives = (
         itemIdx,
         itemCount: items.length,
       });
-      registerItem(item, block.arrayPath, itemIdx);
+      registerLoopItemPatchValues(patchValues, item, block.arrayPath, itemIdx);
 
       const itemContext = buildItemContext(
         contextData,
@@ -1127,6 +1112,30 @@ export const eachKey = (
   index: number,
   field: string,
 ): string => `__each_${arrayPath}_${index}_${field}`;
+
+/** Register every loop-item shape supported by the template input contract. */
+export const registerLoopItemPatchValues = (
+  patchValues: Record<string, RichPatchValue>,
+  item: unknown,
+  arrayPath: string,
+  itemIdx: number,
+): void => {
+  if (isRecord(item)) {
+    registerItemPatchValues(patchValues, item, arrayPath, itemIdx, "");
+    return;
+  }
+  if (
+    typeof item !== "string" &&
+    typeof item !== "number" &&
+    typeof item !== "boolean"
+  ) {
+    return;
+  }
+
+  const value = String(item);
+  patchValues[`__each_${arrayPath}_${itemIdx}`] = value;
+  patchValues[eachKey(arrayPath, itemIdx, "value")] = value;
+};
 
 /**
  * Recursively register patch values for an array item,

--- a/apps/api/src/handlers/docx/discover-clause-slots.ts
+++ b/apps/api/src/handlers/docx/discover-clause-slots.ts
@@ -12,7 +12,7 @@ import * as slimdom from "slimdom";
 
 import { clauseSlotPattern } from "@stll/template-conditions";
 
-import { HEADER_FOOTER_RE, paragraphText, W_NS } from "./ooxml";
+import { paragraphText, templateContentPartPaths, W_NS } from "./ooxml";
 
 // ── Types ────────────────────────────────────────────
 
@@ -74,25 +74,13 @@ export const discoverClauseSlots = async (
   const zip = await JSZip.loadAsync(docxBuffer);
   const slots = new Map<string, ClauseSlot>();
 
-  const docEntry = zip.file("word/document.xml");
-  if (!docEntry) {
-    return [];
-  }
-
-  const docXml = await docEntry.async("string");
-  scanParagraphs(slimdom.parseXmlDocument(docXml), slots);
-
-  const hfEntries = Object.keys(zip.files).filter((path) =>
-    HEADER_FOOTER_RE.test(path),
-  );
-
-  for (const path of hfEntries) {
+  for (const path of templateContentPartPaths(Object.keys(zip.files))) {
     const entry = zip.file(path);
     if (!entry) {
       continue;
     }
 
-    // oxlint-disable-next-line no-await-in-loop -- bounded memory while streaming docx parts; accumulates into shared slots map
+    // oxlint-disable-next-line no-await-in-loop -- bounded memory while streaming content parts; accumulates into shared slots map
     const xml = await entry.async("string");
     scanParagraphs(slimdom.parseXmlDocument(xml), slots);
   }

--- a/apps/api/src/handlers/docx/discover-placeholders.ts
+++ b/apps/api/src/handlers/docx/discover-placeholders.ts
@@ -14,7 +14,7 @@ import { placeholderPattern } from "@stll/template-conditions";
 
 import { compareCodepoint } from "@/api/lib/collation";
 
-import { HEADER_FOOTER_RE, paragraphText, W_NS } from "./ooxml";
+import { paragraphText, templateContentPartPaths, W_NS } from "./ooxml";
 import type { DiscoveredPlaceholder } from "./types";
 
 // Canonical pattern from @stll/template-conditions (markers.ts) — the single
@@ -59,27 +59,13 @@ export const discoverPlaceholders = async (
   const zip = await JSZip.loadAsync(docxBuffer);
   const counts = new Map<string, number>();
 
-  // Scan document body
-  const docEntry = zip.file("word/document.xml");
-  if (!docEntry) {
-    return [];
-  }
-
-  const docXml = await docEntry.async("string");
-  scanParagraphs(slimdom.parseXmlDocument(docXml), counts);
-
-  // Scan headers and footers
-  const hfEntries = Object.keys(zip.files).filter((path) =>
-    HEADER_FOOTER_RE.test(path),
-  );
-
-  for (const path of hfEntries) {
+  for (const path of templateContentPartPaths(Object.keys(zip.files))) {
     const entry = zip.file(path);
     if (!entry) {
       continue;
     }
 
-    // oxlint-disable-next-line no-await-in-loop -- bounded memory while streaming docx parts; accumulates into shared counts map
+    // oxlint-disable-next-line no-await-in-loop -- bounded memory while streaming content parts; accumulates into shared counts map
     const xml = await entry.async("string");
     scanParagraphs(slimdom.parseXmlDocument(xml), counts);
   }

--- a/apps/api/src/handlers/docx/discover-template.test.ts
+++ b/apps/api/src/handlers/docx/discover-template.test.ts
@@ -215,6 +215,49 @@ describe("discoverTemplate", () => {
     });
   });
 
+  test("preserves dotted condition-only inputs", async () => {
+    const xml = WRAP(
+      [P("{{#if client.has_spouse}}"), P("Spouse details"), P("{{/if}}")].join(
+        "",
+      ),
+    );
+    const buf = await makeDocx(xml);
+    const result = await discoverTemplate(buf);
+
+    expect(
+      result.fields.find((field) => field.path === "client.has_spouse"),
+    ).toEqual({
+      path: "client.has_spouse",
+      kind: "boolean",
+      count: 1,
+    });
+  });
+
+  test("nested loops expose condition inputs at every inherited row scope", async () => {
+    const xml = WRAP(
+      [
+        P("{{#each groups}}"),
+        P("{{#each groups.items}}"),
+        P("{{#if group_enabled}}"),
+        P("Item"),
+        P("{{/if}}"),
+        P("{{/each}}"),
+        P("{{/each}}"),
+      ].join(""),
+    );
+    const buf = await makeDocx(xml);
+    const result = await discoverTemplate(buf);
+
+    const groups = result.fields.find((field) => field.path === "groups");
+    const items = result.fields.find((field) => field.path === "groups.items");
+    expect(groups?.itemFields?.map((field) => field.path)).toContain(
+      "group_enabled",
+    );
+    expect(items?.itemFields?.map((field) => field.path)).toContain(
+      "group_enabled",
+    );
+  });
+
   test("nested object path infers object field", async () => {
     const xml = WRAP(
       [

--- a/apps/api/src/handlers/docx/discover-template.test.ts
+++ b/apps/api/src/handlers/docx/discover-template.test.ts
@@ -122,6 +122,24 @@ describe("discoverTemplate", () => {
     });
   });
 
+  test("condition-only paths join repeated row fields", async () => {
+    const xml = WRAP(
+      [
+        P("{{#each sellers}}"),
+        P("{{sellers.name}}{{#if sellers.is_company}} Ltd{{/if}}"),
+        P("{{/each}}"),
+      ].join(""),
+    );
+    const buf = await makeDocx(xml);
+    const result = await discoverTemplate(buf);
+
+    const sellers = result.fields.find((field) => field.path === "sellers");
+    expect(sellers?.itemFields?.map((field) => field.path).toSorted()).toEqual([
+      "is_company",
+      "name",
+    ]);
+  });
+
   test("nested object path infers object field", async () => {
     const xml = WRAP(
       [

--- a/apps/api/src/handlers/docx/discover-template.test.ts
+++ b/apps/api/src/handlers/docx/discover-template.test.ts
@@ -177,6 +177,44 @@ describe("discoverTemplate", () => {
     ]);
   });
 
+  test("block conditions nested in loops join repeated row fields", async () => {
+    const xml = WRAP(
+      [
+        P("{{#each sellers}}"),
+        P("{{sellers.name}}"),
+        P("{{#if is_company}}"),
+        P("Company"),
+        P("{{/if}}"),
+        P("{{/each}}"),
+      ].join(""),
+    );
+    const buf = await makeDocx(xml);
+    const result = await discoverTemplate(buf);
+
+    const sellers = result.fields.find((field) => field.path === "sellers");
+    expect(sellers?.itemFields?.map((field) => field.path).toSorted()).toEqual([
+      "is_company",
+      "name",
+    ]);
+  });
+
+  test("preserves dotted primitive loop roots", async () => {
+    const xml = WRAP(
+      [P("{{#each deal.tags}}"), P("{{deal.tags.value}}"), P("{{/each}}")].join(
+        "",
+      ),
+    );
+    const buf = await makeDocx(xml);
+    const result = await discoverTemplate(buf);
+
+    expect(result.fields.find((field) => field.path === "deal.tags")).toEqual({
+      path: "deal.tags",
+      kind: "array",
+      count: 2,
+      itemFields: [{ path: "value", kind: "string", count: 1 }],
+    });
+  });
+
   test("nested object path infers object field", async () => {
     const xml = WRAP(
       [

--- a/apps/api/src/handlers/docx/discover-template.test.ts
+++ b/apps/api/src/handlers/docx/discover-template.test.ts
@@ -146,6 +146,19 @@ describe("discoverTemplate", () => {
     });
   });
 
+  test("inline primitive loop exposes its value item field", async () => {
+    const xml = WRAP(P("Tags: {{#each tags}}{{tags.value}}, {{/each}}"));
+    const buf = await makeDocx(xml);
+    const result = await discoverTemplate(buf);
+
+    expect(result.fields.find((field) => field.path === "tags")).toEqual({
+      path: "tags",
+      kind: "array",
+      count: 1,
+      itemFields: [{ path: "value", kind: "string", count: 1 }],
+    });
+  });
+
   test("condition-only paths join repeated row fields", async () => {
     const xml = WRAP(
       [

--- a/apps/api/src/handlers/docx/discover-template.test.ts
+++ b/apps/api/src/handlers/docx/discover-template.test.ts
@@ -89,6 +89,30 @@ describe("discoverTemplate", () => {
     });
   });
 
+  test("inline condition discovery shares the canonical operator grammar", async () => {
+    const xml = WRAP(P('{{#if roles contains "admin"}}Administrator{{/if}}'));
+    const buf = await makeDocx(xml);
+    const result = await discoverTemplate(buf);
+
+    expect(result.fields).toEqual([
+      { path: "roles", kind: "string", count: 1 },
+    ]);
+  });
+
+  test("inline parse errors are part of template discovery", async () => {
+    const xml = WRAP(P("Buyer {{#if has_spouse}} and spouse"));
+    const buf = await makeDocx(xml);
+    const result = await discoverTemplate(buf);
+
+    expect(result.structureErrors).toEqual([
+      expect.objectContaining({
+        directive: "{{#if has_spouse}}",
+        paragraphIndex: 0,
+        source: "body",
+      }),
+    ]);
+  });
+
   test("loop infers array field with item fields", async () => {
     const xml = WRAP(
       [

--- a/apps/api/src/handlers/docx/discover-template.test.ts
+++ b/apps/api/src/handlers/docx/discover-template.test.ts
@@ -159,6 +159,33 @@ describe("discoverTemplate", () => {
     });
   });
 
+  test("inline loops inside block rows inherit the enclosing row path", async () => {
+    const xml = WRAP(
+      [
+        P("{{#each groups}}"),
+        P("Items: {{#each items}}{{items.name}}, {{/each}}"),
+        P("{{/each}}"),
+      ].join(""),
+    );
+    const result = await discoverTemplate(await makeDocx(xml));
+
+    expect(
+      result.fields.find((field) => field.path === "items"),
+    ).toBeUndefined();
+    expect(
+      result.fields.find((field) => field.path === "groups.items"),
+    ).toEqual({
+      path: "groups.items",
+      kind: "array",
+      count: 1,
+      itemFields: [{ path: "name", kind: "string", count: 1 }],
+    });
+    expect(result.placeholders).toContainEqual({
+      name: "groups.items.name",
+      count: 1,
+    });
+  });
+
   test("condition-only paths join repeated row fields", async () => {
     const xml = WRAP(
       [

--- a/apps/api/src/handlers/docx/discover-template.test.ts
+++ b/apps/api/src/handlers/docx/discover-template.test.ts
@@ -186,6 +186,36 @@ describe("discoverTemplate", () => {
     });
   });
 
+  test("nested block loop shorthand inherits the enclosing row path", async () => {
+    const xml = WRAP(
+      [
+        P("{{#each groups}}"),
+        P("{{groups.title}}"),
+        P("{{#each items}}"),
+        P("{{items.name}}"),
+        P("{{/each}}"),
+        P("{{/each}}"),
+      ].join(""),
+    );
+    const result = await discoverTemplate(await makeDocx(xml));
+
+    expect(
+      result.fields.find((field) => field.path === "items"),
+    ).toBeUndefined();
+    expect(
+      result.fields.find((field) => field.path === "groups.items"),
+    ).toEqual({
+      path: "groups.items",
+      kind: "array",
+      count: 1,
+      itemFields: [{ path: "name", kind: "string", count: 1 }],
+    });
+    expect(result.placeholders).toContainEqual({
+      name: "groups.items.name",
+      count: 1,
+    });
+  });
+
   test("condition-only paths join repeated row fields", async () => {
     const xml = WRAP(
       [

--- a/apps/api/src/handlers/docx/discover-template.test.ts
+++ b/apps/api/src/handlers/docx/discover-template.test.ts
@@ -358,6 +358,35 @@ describe("discoverTemplate", () => {
     expect(ukField?.visibleWhen).toBe("isUK");
   });
 
+  test("fields inside inline branches get visibleWhen", async () => {
+    const xml = WRAP(
+      P("{{#if has_spouse}}{{spouse.name}}{{#else}}{{single_name}}{{/if}}"),
+    );
+    const result = await discoverTemplate(await makeDocx(xml));
+
+    expect(
+      result.fields.find((field) => field.path === "spouse.name")?.visibleWhen,
+    ).toBe("has_spouse");
+    expect(
+      result.fields.find((field) => field.path === "single_name")?.visibleWhen,
+    ).toBe("!has_spouse");
+  });
+
+  test("inline visibility composes with its enclosing block", async () => {
+    const xml = WRAP(
+      [
+        P("{{#if is_person}}"),
+        P("{{#if has_spouse}}{{spouse.name}}{{/if}}"),
+        P("{{/if}}"),
+      ].join(""),
+    );
+    const result = await discoverTemplate(await makeDocx(xml));
+
+    expect(
+      result.fields.find((field) => field.path === "spouse.name")?.visibleWhen,
+    ).toBe("is_person and has_spouse");
+  });
+
   test("field outside #if has no visibleWhen", async () => {
     const xml = WRAP(
       [P("{{name}}"), P("{{#if isUK}}"), P("{{uk_number}}"), P("{{/if}}")].join(

--- a/apps/api/src/handlers/docx/discover-template.test.ts
+++ b/apps/api/src/handlers/docx/discover-template.test.ts
@@ -238,7 +238,7 @@ describe("discoverTemplate", () => {
       [
         P("{{#each groups}}"),
         P("{{#each groups.items}}"),
-        P("{{#if group_enabled}}"),
+        P("{{#if group_enabled and groups.is_master}}"),
         P("Item"),
         P("{{/if}}"),
         P("{{/each}}"),
@@ -250,12 +250,13 @@ describe("discoverTemplate", () => {
 
     const groups = result.fields.find((field) => field.path === "groups");
     const items = result.fields.find((field) => field.path === "groups.items");
-    expect(groups?.itemFields?.map((field) => field.path)).toContain(
+    expect(groups?.itemFields?.map((field) => field.path).toSorted()).toEqual([
       "group_enabled",
-    );
-    expect(items?.itemFields?.map((field) => field.path)).toContain(
+      "is_master",
+    ]);
+    expect(items?.itemFields?.map((field) => field.path)).toEqual([
       "group_enabled",
-    );
+    ]);
   });
 
   test("nested object path infers object field", async () => {

--- a/apps/api/src/handlers/docx/discover-template.test.ts
+++ b/apps/api/src/handlers/docx/discover-template.test.ts
@@ -75,6 +75,20 @@ describe("discoverTemplate", () => {
     expect(field?.kind).toBe("string");
   });
 
+  test("inline-only condition infers its boolean driver", async () => {
+    const xml = WRAP(
+      P("Buyer{{#if has_spouse}} and their spouse{{/if}} hereby agrees."),
+    );
+    const buf = await makeDocx(xml);
+    const result = await discoverTemplate(buf);
+
+    expect(result.fields.find((field) => field.path === "has_spouse")).toEqual({
+      path: "has_spouse",
+      kind: "boolean",
+      count: 1,
+    });
+  });
+
   test("loop infers array field with item fields", async () => {
     const xml = WRAP(
       [
@@ -94,6 +108,18 @@ describe("discoverTemplate", () => {
     const itemPaths = field?.itemFields?.map((f) => f.path);
     expect(itemPaths).toContain("name");
     expect(itemPaths).toContain("address");
+  });
+
+  test("inline static loop infers its array input", async () => {
+    const xml = WRAP(P("Parties: {{#each parties}}party; {{/each}}"));
+    const buf = await makeDocx(xml);
+    const result = await discoverTemplate(buf);
+
+    expect(result.fields.find((field) => field.path === "parties")).toEqual({
+      path: "parties",
+      kind: "array",
+      count: 1,
+    });
   });
 
   test("nested object path infers object field", async () => {

--- a/apps/api/src/handlers/docx/discover-template.ts
+++ b/apps/api/src/handlers/docx/discover-template.ts
@@ -126,6 +126,23 @@ const registerConditionFields = (
   }
 };
 
+const attachNestedArrayFields = (fields: FieldAccumulator): void => {
+  for (const path of fields.keys()) {
+    const separatorIndex = path.indexOf(".");
+    if (separatorIndex === -1) {
+      continue;
+    }
+
+    const rootPath = path.slice(0, separatorIndex);
+    const root = fields.get(rootPath);
+    if (root?.kind !== "array") {
+      continue;
+    }
+
+    root.itemPaths.add(path.slice(separatorIndex + 1));
+  }
+};
+
 // ── Condition map building ─────────────────────────────
 
 /**
@@ -444,6 +461,12 @@ const analyzeContainer = (
       registerField(fields, name, "string");
     }
   }
+
+  // A dotted field used only by a condition still belongs to a repeated
+  // row's input contract. Normalize every discovered descendant into its
+  // array root after all block, inline, and placeholder scans have run, so
+  // discovery order cannot change the contract.
+  attachNestedArrayFields(fields);
 
   return { fields, errors, placeholderCounts, fieldConditions };
 };

--- a/apps/api/src/handlers/docx/discover-template.ts
+++ b/apps/api/src/handlers/docx/discover-template.ts
@@ -139,6 +139,21 @@ const registerConditionFields = (
   visit(root);
 };
 
+const qualifyRowScopedPath = (
+  path: string,
+  rowPaths: readonly string[] = [],
+): string => {
+  if (
+    rowPaths.some(
+      (rowPath) => path === rowPath || path.startsWith(`${rowPath}.`),
+    )
+  ) {
+    return path;
+  }
+  const innermostRowPath = rowPaths.at(-1);
+  return innermostRowPath === undefined ? path : `${innermostRowPath}.${path}`;
+};
+
 // ── Condition map building ─────────────────────────────
 
 /**
@@ -446,6 +461,12 @@ const analyzeContainer = (
       end: number;
       start: number;
     }[] = [];
+    const inlineLoopScopes: {
+      declaredPath: string;
+      end: number;
+      scopedPath: string;
+      start: number;
+    }[] = [];
 
     const inline = parseInlineConditions(text);
     if (!inline.ok) {
@@ -457,8 +478,18 @@ const analyzeContainer = (
     } else {
       for (const group of inline.groups) {
         if (group.kind === "each") {
-          registerField(fields, group.arrayPath, "array");
-          const entry = fields.get(group.arrayPath);
+          const scopedPath = qualifyRowScopedPath(
+            group.arrayPath,
+            arrayScopes.get(i),
+          );
+          registerField(fields, scopedPath, "array");
+          inlineLoopScopes.push({
+            declaredPath: group.arrayPath,
+            end: group.contentEnd,
+            scopedPath,
+            start: group.contentStart,
+          });
+          const entry = fields.get(scopedPath);
           const content = text.slice(group.contentStart, group.contentEnd);
           const prefix = `${group.arrayPath}.`;
           for (const match of content.matchAll(PLACEHOLDER_RE)) {
@@ -496,15 +527,23 @@ const analyzeContainer = (
     }
 
     for (const match of text.matchAll(PLACEHOLDER_RE)) {
-      const name = match.groups?.["name"];
-      if (!name) {
+      const declaredName = match.groups?.["name"];
+      if (!declaredName) {
         continue;
       }
       // @-prefixed markers (@clause:, @num:, @ref:) are resolved at fill time,
       // not user-entered fields — keep them out of the discovered schema.
-      if (name.startsWith("@")) {
+      if (declaredName.startsWith("@")) {
         continue;
       }
+      const loopScope = inlineLoopScopes.find(
+        ({ end, start }) => start <= match.index && match.index < end,
+      );
+      const declaredLoopPrefix = `${loopScope?.declaredPath ?? ""}.`;
+      const name =
+        loopScope !== undefined && declaredName.startsWith(declaredLoopPrefix)
+          ? `${loopScope.scopedPath}.${declaredName.slice(declaredLoopPrefix.length)}`
+          : declaredName;
       placeholderCounts.set(name, (placeholderCounts.get(name) ?? 0) + 1);
 
       const inlineCondition = inlineBranchConditions.find(

--- a/apps/api/src/handlers/docx/discover-template.ts
+++ b/apps/api/src/handlers/docx/discover-template.ts
@@ -164,6 +164,44 @@ const negateExpr = (expr: string): string => {
   return `!${trimmed}`;
 };
 
+const wrapConjunctionPart = (expr: string): string =>
+  expr.includes(" or ") ? `(${expr})` : expr;
+
+const combineConditions = (
+  outer: string | undefined,
+  inner: string | undefined,
+): string | undefined => {
+  if (outer === undefined) {
+    return inner;
+  }
+  if (inner === undefined) {
+    return outer;
+  }
+  return `${wrapConjunctionPart(outer)} and ${wrapConjunctionPart(inner)}`;
+};
+
+const recordFieldCondition = (
+  fieldConditions: Map<string, string | null>,
+  name: string,
+  condition: string | undefined,
+): void => {
+  const existing = fieldConditions.get(name);
+  if (existing === null) {
+    return;
+  }
+  if (condition === undefined) {
+    fieldConditions.set(name, null);
+    return;
+  }
+  if (existing === undefined) {
+    fieldConditions.set(name, condition);
+    return;
+  }
+  if (existing !== condition) {
+    fieldConditions.set(name, null);
+  }
+};
+
 /**
  * Build a paragraph-index-to-condition map by walking
  * the flat directive list with a stack. Handles
@@ -403,6 +441,11 @@ const analyzeContainer = (
     }
     const text = paragraphText(para);
     const paraCondition = conditionMap.get(i);
+    const inlineBranchConditions: {
+      condition: string | undefined;
+      end: number;
+      start: number;
+    }[] = [];
 
     const inline = parseInlineConditions(text);
     if (!inline.ok) {
@@ -427,8 +470,27 @@ const analyzeContainer = (
           continue;
         }
 
+        const priorConditions: string[] = [];
         for (const branch of group.branches) {
           registerConditionFields(fields, branch.condition, arrayScopes.get(i));
+          const branchCondition =
+            branch.condition === ""
+              ? priorConditions.map(negateExpr).join(" and ")
+              : [
+                  ...priorConditions.map(negateExpr),
+                  wrapConjunctionPart(branch.condition),
+                ].join(" and ");
+          inlineBranchConditions.push({
+            condition: combineConditions(
+              paraCondition,
+              branchCondition || undefined,
+            ),
+            end: branch.contentEnd,
+            start: branch.contentStart,
+          });
+          if (branch.condition !== "") {
+            priorConditions.push(branch.condition);
+          }
         }
       }
     }
@@ -445,23 +507,14 @@ const analyzeContainer = (
       }
       placeholderCounts.set(name, (placeholderCounts.get(name) ?? 0) + 1);
 
-      // Track field condition visibility
-      const existing = fieldConditions.get(name);
-      if (existing === null) {
-        // Already seen outside a conditional; stays
-        // always visible
-      } else if (paraCondition === undefined) {
-        // This occurrence is outside any conditional
-        // → field is always visible
-        fieldConditions.set(name, null);
-      } else if (existing === undefined) {
-        // First occurrence, inside a conditional
-        fieldConditions.set(name, paraCondition);
-      } else if (existing !== paraCondition) {
-        // Seen in a different conditional branch;
-        // mark as always visible
-        fieldConditions.set(name, null);
-      }
+      const inlineCondition = inlineBranchConditions.find(
+        ({ end, start }) => start <= match.index && match.index < end,
+      )?.condition;
+      recordFieldCondition(
+        fieldConditions,
+        name,
+        inlineCondition ?? paraCondition,
+      );
 
       // Infer field kind from path structure
       if (name.includes(".")) {

--- a/apps/api/src/handlers/docx/discover-template.ts
+++ b/apps/api/src/handlers/docx/discover-template.ts
@@ -15,6 +15,7 @@ import { compareCodepoint } from "@/api/lib/collation";
 
 import { parseBlockTree, scanBlockDirectives } from "./block-directives";
 import { PLACEHOLDER_RE } from "./discover-placeholders";
+import { parseInlineConditions } from "./inline-conditions";
 import { HEADER_FOOTER_RE, paragraphText, W_NS } from "./ooxml";
 import type {
   DiscoveredField,
@@ -77,6 +78,51 @@ const kindPriority = (kind: TemplateFieldKind): number => {
       return 3;
     default:
       return 0;
+  }
+};
+
+const registerConditionFields = (
+  fields: FieldAccumulator,
+  condition: string,
+): void => {
+  if (condition === "") {
+    return;
+  }
+
+  // Group tokens by and/or to check comparisons per
+  // sub-expression. Uses the tokenizer (not string split)
+  // so `and`/`or` inside string literals are ignored.
+  type SubExpr = { paths: string[]; hasComparison: boolean };
+  const subExprs: SubExpr[] = [];
+  let current: SubExpr = { paths: [], hasComparison: false };
+  subExprs.push(current);
+
+  for (const match of condition.matchAll(CONDITION_TOKEN_RE)) {
+    const raw = match[0];
+    if (!raw) {
+      continue;
+    }
+    const ident = match.groups?.["ident"];
+
+    if (raw === "and" || raw === "or") {
+      current = { paths: [], hasComparison: false };
+      subExprs.push(current);
+    } else if (COMPARISON_OPS.has(raw)) {
+      current.hasComparison = true;
+    } else if (
+      ident &&
+      ident !== "true" &&
+      ident !== "false" &&
+      !NUMERIC_LITERAL_RE.test(ident)
+    ) {
+      current.paths.push(ident);
+    }
+  }
+
+  for (const { paths, hasComparison } of subExprs) {
+    for (const path of paths) {
+      registerField(fields, path, hasComparison ? "string" : "boolean");
+    }
   }
 };
 
@@ -308,45 +354,7 @@ const analyzeContainer = (
       // if block — extract condition variables as booleans
       // (or string if used in a comparison)
       for (const branch of block.branches) {
-        if (branch.condition === "") {
-          continue; // else
-        }
-
-        // Group tokens by and/or to check comparisons per
-        // sub-expression. Uses the tokenizer (not string split)
-        // so `and`/`or` inside string literals are ignored.
-        type SubExpr = { paths: string[]; hasComparison: boolean };
-        const subExprs: SubExpr[] = [];
-        let current: SubExpr = { paths: [], hasComparison: false };
-        subExprs.push(current);
-
-        for (const m of branch.condition.matchAll(CONDITION_TOKEN_RE)) {
-          const raw = m[0];
-          if (!raw) {
-            continue;
-          }
-          const ident = m.groups?.["ident"];
-
-          if (raw === "and" || raw === "or") {
-            current = { paths: [], hasComparison: false };
-            subExprs.push(current);
-          } else if (COMPARISON_OPS.has(raw)) {
-            current.hasComparison = true;
-          } else if (
-            ident &&
-            ident !== "true" &&
-            ident !== "false" &&
-            !NUMERIC_LITERAL_RE.test(ident)
-          ) {
-            current.paths.push(ident);
-          }
-        }
-
-        for (const { paths, hasComparison } of subExprs) {
-          for (const path of paths) {
-            registerField(fields, path, hasComparison ? "string" : "boolean");
-          }
-        }
+        registerConditionFields(fields, branch.condition);
       }
     }
   }
@@ -363,6 +371,29 @@ const analyzeContainer = (
     }
     const text = paragraphText(para);
     const paraCondition = conditionMap.get(i);
+
+    const inline = parseInlineConditions(text);
+    if (inline.ok) {
+      for (const group of inline.groups) {
+        if (group.kind === "if") {
+          for (const branch of group.branches) {
+            registerConditionFields(fields, branch.condition);
+          }
+          continue;
+        }
+
+        registerField(fields, group.arrayPath, "array");
+        const entry = fields.get(group.arrayPath);
+        const content = text.slice(group.contentStart, group.contentEnd);
+        const prefix = `${group.arrayPath}.`;
+        for (const match of content.matchAll(PLACEHOLDER_RE)) {
+          const name = match.groups?.["name"];
+          if (name?.startsWith(prefix)) {
+            entry?.itemPaths.add(name.slice(prefix.length));
+          }
+        }
+      }
+    }
 
     for (const match of text.matchAll(PLACEHOLDER_RE)) {
       const name = match.groups?.["name"];

--- a/apps/api/src/handlers/docx/discover-template.ts
+++ b/apps/api/src/handlers/docx/discover-template.ts
@@ -29,10 +29,13 @@ import type {
 
 // ── Field inference ──────────────────────────────────────
 
-type FieldAccumulator = Map<
-  string,
-  { kind: TemplateFieldKind; count: number; itemPaths: Set<string> }
->;
+type FieldInfo = {
+  kind: TemplateFieldKind;
+  count: number;
+  itemPaths: Set<string>;
+};
+
+type FieldAccumulator = Map<string, FieldInfo>;
 
 /**
  * Register a field path with an inferred kind. If the field
@@ -73,11 +76,25 @@ const kindPriority = (kind: TemplateFieldKind): number => {
 const registerConditionFields = (
   fields: FieldAccumulator,
   condition: string,
+  rowPath?: string | undefined,
 ): void => {
   const root = parseCondition(condition);
   if (!root) {
     return;
   }
+
+  const registerPath = (path: string, kind: "boolean" | "string"): void => {
+    registerField(fields, path, kind);
+    if (rowPath === undefined) {
+      return;
+    }
+    const rowPrefix = `${rowPath}.`;
+    const rowFieldPath = path.startsWith(rowPrefix)
+      ? path
+      : `${rowPrefix}${path}`;
+    registerField(fields, rowFieldPath, kind);
+    fields.get(rowPath)?.itemPaths.add(rowFieldPath.slice(rowPrefix.length));
+  };
 
   const visit = (node: ConditionNode): void => {
     if (node.type === "group") {
@@ -89,17 +106,16 @@ const registerConditionFields = (
 
     if (node.type === "compare") {
       if (node.left.type === "path") {
-        registerField(fields, node.left.path, "string");
+        registerPath(node.left.path, "string");
       }
       if (node.right.type === "path") {
-        registerField(fields, node.right.path, "string");
+        registerPath(node.right.path, "string");
       }
       return;
     }
 
     if (node.operand.type === "path") {
-      registerField(
-        fields,
+      registerPath(
         node.operand.path,
         node.op === "is_truthy" ? "boolean" : "string",
       );
@@ -107,23 +123,6 @@ const registerConditionFields = (
   };
 
   visit(root);
-};
-
-const attachNestedArrayFields = (fields: FieldAccumulator): void => {
-  for (const path of fields.keys()) {
-    const separatorIndex = path.indexOf(".");
-    if (separatorIndex === -1) {
-      continue;
-    }
-
-    const rootPath = path.slice(0, separatorIndex);
-    const root = fields.get(rootPath);
-    if (root?.kind !== "array") {
-      continue;
-    }
-
-    root.itemPaths.add(path.slice(separatorIndex + 1));
-  }
 };
 
 // ── Condition map building ─────────────────────────────
@@ -308,6 +307,35 @@ const analyzeContainer = (
   const { blocks, errors: parseErrors } = parseBlockTree(directives);
   errors.push(...parseErrors);
 
+  // Retain the full directive stream instead of relying on the flattened
+  // block result: nested blocks are intentionally consumed by parseBlockTree.
+  // The active loop path makes an unqualified condition available both as a
+  // global input and as a row-local input, matching the fill evaluator's
+  // global context overlaid with each row.
+  const arrayScopes = new Map<number, readonly string[]>();
+  const activeArrays: string[] = [];
+  const directiveByParagraph = new Map(
+    directives.map((directive) => [directive.paragraphIndex, directive]),
+  );
+  for (let i = 0; i < paragraphs.length; i++) {
+    const directive = directiveByParagraph.get(i);
+    if (directive?.kind === "endeach") {
+      activeArrays.pop();
+    }
+    if (directive?.kind === "if" || directive?.kind === "elseif") {
+      registerConditionFields(
+        fields,
+        directive.expression,
+        activeArrays.at(-1),
+      );
+    }
+    if (directive?.kind === "each") {
+      registerField(fields, directive.expression, "array");
+      activeArrays.push(directive.expression);
+    }
+    arrayScopes.set(i, [...activeArrays]);
+  }
+
   // Track which paragraph indices are directives (skip for
   // placeholder scanning)
   const directiveIndices = new Set<number>();
@@ -350,12 +378,6 @@ const analyzeContainer = (
           }
         }
       }
-    } else {
-      // if block — extract condition variables as booleans
-      // (or string if used in a comparison)
-      for (const branch of block.branches) {
-        registerConditionFields(fields, branch.condition);
-      }
     }
   }
 
@@ -396,7 +418,11 @@ const analyzeContainer = (
         }
 
         for (const branch of group.branches) {
-          registerConditionFields(fields, branch.condition);
+          registerConditionFields(
+            fields,
+            branch.condition,
+            arrayScopes.get(i)?.at(-1),
+          );
         }
       }
     }
@@ -448,14 +474,18 @@ const analyzeContainer = (
       }
       // Register the full path as string
       registerField(fields, name, "string");
+
+      const scopedArrayPaths = arrayScopes.get(i);
+      if (scopedArrayPaths !== undefined) {
+        for (const arrayPath of scopedArrayPaths) {
+          const prefix = `${arrayPath}.`;
+          if (name.startsWith(prefix)) {
+            fields.get(arrayPath)?.itemPaths.add(name.slice(prefix.length));
+          }
+        }
+      }
     }
   }
-
-  // A dotted field used only by a condition still belongs to a repeated
-  // row's input contract. Normalize every discovered descendant into its
-  // array root after all block, inline, and placeholder scans have run, so
-  // discovery order cannot change the contract.
-  attachNestedArrayFields(fields);
 
   return { fields, errors, placeholderCounts, fieldConditions };
 };
@@ -633,9 +663,11 @@ export const discoverTemplate = async (
   // Build DiscoveredField[]
   const discoveredFields: DiscoveredField[] = [];
   for (const [path, info] of fields) {
-    // Skip dotted subfields; they'll be nested under their
-    // parent array or object
-    if (path.includes(".")) {
+    // Dotted scalar fields are represented by their structural object root
+    // and by the placeholder list. Array roots remain first-class fields even
+    // when dotted: dropping them would erase the primitive-row contract for a
+    // valid loop such as `deal.tags`.
+    if (path.includes(".") && info.kind !== "array") {
       continue;
     }
 

--- a/apps/api/src/handlers/docx/discover-template.ts
+++ b/apps/api/src/handlers/docx/discover-template.ts
@@ -11,6 +11,8 @@
 import JSZip from "jszip";
 import * as slimdom from "slimdom";
 
+import { parseCondition, type ConditionNode } from "@stll/template-conditions";
+
 import { compareCodepoint } from "@/api/lib/collation";
 
 import { parseBlockTree, scanBlockDirectives } from "./block-directives";
@@ -24,19 +26,6 @@ import type {
   TemplateFieldKind,
   TemplateStructureError,
 } from "./types";
-
-// ── Condition expression analysis ────────────────────────
-
-/**
- * Extract variable paths referenced in a condition expression.
- * Strips string literals, operators, and keywords.
- */
-const CONDITION_TOKEN_RE =
-  /"(?:[^"\\]|\\.)*"|==|!=|>=|<=|>|<|!(?!=)|and\b|or\b|(?<ident>[\p{L}\p{N}_.]+)/gu;
-
-const NUMERIC_LITERAL_RE = /^[\d_]+$/u;
-
-const COMPARISON_OPS = new Set(["==", "!=", ">=", "<=", ">", "<"]);
 
 // ── Field inference ──────────────────────────────────────
 
@@ -85,45 +74,39 @@ const registerConditionFields = (
   fields: FieldAccumulator,
   condition: string,
 ): void => {
-  if (condition === "") {
+  const root = parseCondition(condition);
+  if (!root) {
     return;
   }
 
-  // Group tokens by and/or to check comparisons per
-  // sub-expression. Uses the tokenizer (not string split)
-  // so `and`/`or` inside string literals are ignored.
-  type SubExpr = { paths: string[]; hasComparison: boolean };
-  const subExprs: SubExpr[] = [];
-  let current: SubExpr = { paths: [], hasComparison: false };
-  subExprs.push(current);
-
-  for (const match of condition.matchAll(CONDITION_TOKEN_RE)) {
-    const raw = match[0];
-    if (!raw) {
-      continue;
+  const visit = (node: ConditionNode): void => {
+    if (node.type === "group") {
+      for (const child of node.children) {
+        visit(child);
+      }
+      return;
     }
-    const ident = match.groups?.["ident"];
 
-    if (raw === "and" || raw === "or") {
-      current = { paths: [], hasComparison: false };
-      subExprs.push(current);
-    } else if (COMPARISON_OPS.has(raw)) {
-      current.hasComparison = true;
-    } else if (
-      ident &&
-      ident !== "true" &&
-      ident !== "false" &&
-      !NUMERIC_LITERAL_RE.test(ident)
-    ) {
-      current.paths.push(ident);
+    if (node.type === "compare") {
+      if (node.left.type === "path") {
+        registerField(fields, node.left.path, "string");
+      }
+      if (node.right.type === "path") {
+        registerField(fields, node.right.path, "string");
+      }
+      return;
     }
-  }
 
-  for (const { paths, hasComparison } of subExprs) {
-    for (const path of paths) {
-      registerField(fields, path, hasComparison ? "string" : "boolean");
+    if (node.operand.type === "path") {
+      registerField(
+        fields,
+        node.operand.path,
+        node.op === "is_truthy" ? "boolean" : "string",
+      );
     }
-  }
+  };
+
+  visit(root);
 };
 
 const attachNestedArrayFields = (fields: FieldAccumulator): void => {
@@ -390,24 +373,30 @@ const analyzeContainer = (
     const paraCondition = conditionMap.get(i);
 
     const inline = parseInlineConditions(text);
-    if (inline.ok) {
+    if (!inline.ok) {
+      errors.push({
+        message: inline.message,
+        paragraphIndex: i,
+        directive: inline.directive,
+      });
+    } else {
       for (const group of inline.groups) {
-        if (group.kind === "if") {
-          for (const branch of group.branches) {
-            registerConditionFields(fields, branch.condition);
+        if (group.kind === "each") {
+          registerField(fields, group.arrayPath, "array");
+          const entry = fields.get(group.arrayPath);
+          const content = text.slice(group.contentStart, group.contentEnd);
+          const prefix = `${group.arrayPath}.`;
+          for (const match of content.matchAll(PLACEHOLDER_RE)) {
+            const name = match.groups?.["name"];
+            if (name?.startsWith(prefix)) {
+              entry?.itemPaths.add(name.slice(prefix.length));
+            }
           }
           continue;
         }
 
-        registerField(fields, group.arrayPath, "array");
-        const entry = fields.get(group.arrayPath);
-        const content = text.slice(group.contentStart, group.contentEnd);
-        const prefix = `${group.arrayPath}.`;
-        for (const match of content.matchAll(PLACEHOLDER_RE)) {
-          const name = match.groups?.["name"];
-          if (name?.startsWith(prefix)) {
-            entry?.itemPaths.add(name.slice(prefix.length));
-          }
+        for (const branch of group.branches) {
+          registerConditionFields(fields, branch.condition);
         }
       }
     }

--- a/apps/api/src/handlers/docx/discover-template.ts
+++ b/apps/api/src/handlers/docx/discover-template.ts
@@ -18,7 +18,12 @@ import { compareCodepoint } from "@/api/lib/collation";
 import { parseBlockTree, scanBlockDirectives } from "./block-directives";
 import { PLACEHOLDER_RE } from "./discover-placeholders";
 import { parseInlineConditions } from "./inline-conditions";
-import { HEADER_FOOTER_RE, paragraphText, W_NS } from "./ooxml";
+import {
+  MAIN_DOCUMENT_PART_PATH,
+  paragraphText,
+  templateContentPartPaths,
+  W_NS,
+} from "./ooxml";
 import type {
   DiscoveredField,
   DiscoveredPlaceholder,
@@ -565,9 +570,9 @@ const analyzeHeadersAndFooters = async (
 
   // Sort entries alphabetically to match the order used by
   // extractText (which assigns globally sequential indices).
-  const entries = Object.keys(zip.files)
-    .filter((path) => HEADER_FOOTER_RE.test(path))
-    .toSorted();
+  const entries = templateContentPartPaths(Object.keys(zip.files)).filter(
+    (path) => path !== MAIN_DOCUMENT_PART_PATH,
+  );
 
   // Track running paragraph counts per source so error indices
   // are relative to the combined section, not individual files.
@@ -628,7 +633,7 @@ export const discoverTemplate = async (
     structureErrors: [],
   };
 
-  const docEntry = zip.file("word/document.xml");
+  const docEntry = zip.file(MAIN_DOCUMENT_PART_PATH);
   if (!docEntry) {
     return emptyResult;
   }

--- a/apps/api/src/handlers/docx/discover-template.ts
+++ b/apps/api/src/handlers/docx/discover-template.ts
@@ -76,7 +76,7 @@ const kindPriority = (kind: TemplateFieldKind): number => {
 const registerConditionFields = (
   fields: FieldAccumulator,
   condition: string,
-  rowPath?: string | undefined,
+  rowPaths: readonly string[] = [],
 ): void => {
   const root = parseCondition(condition);
   if (!root) {
@@ -85,15 +85,24 @@ const registerConditionFields = (
 
   const registerPath = (path: string, kind: "boolean" | "string"): void => {
     registerField(fields, path, kind);
-    if (rowPath === undefined) {
+
+    const isQualifiedRowPath = rowPaths.some(
+      (rowPath) => path === rowPath || path.startsWith(`${rowPath}.`),
+    );
+    if (isQualifiedRowPath) {
+      for (const rowPath of rowPaths) {
+        const rowPrefix = `${rowPath}.`;
+        if (path.startsWith(rowPrefix)) {
+          fields.get(rowPath)?.itemPaths.add(path.slice(rowPrefix.length));
+        }
+      }
       return;
     }
-    const rowPrefix = `${rowPath}.`;
-    const rowFieldPath = path.startsWith(rowPrefix)
-      ? path
-      : `${rowPrefix}${path}`;
-    registerField(fields, rowFieldPath, kind);
-    fields.get(rowPath)?.itemPaths.add(rowFieldPath.slice(rowPrefix.length));
+
+    for (const rowPath of rowPaths) {
+      registerField(fields, `${rowPath}.${path}`, kind);
+      fields.get(rowPath)?.itemPaths.add(path);
+    }
   };
 
   const visit = (node: ConditionNode): void => {
@@ -323,11 +332,7 @@ const analyzeContainer = (
       activeArrays.pop();
     }
     if (directive?.kind === "if" || directive?.kind === "elseif") {
-      registerConditionFields(
-        fields,
-        directive.expression,
-        activeArrays.at(-1),
-      );
+      registerConditionFields(fields, directive.expression, activeArrays);
     }
     if (directive?.kind === "each") {
       registerField(fields, directive.expression, "array");
@@ -418,11 +423,7 @@ const analyzeContainer = (
         }
 
         for (const branch of group.branches) {
-          registerConditionFields(
-            fields,
-            branch.condition,
-            arrayScopes.get(i)?.at(-1),
-          );
+          registerConditionFields(fields, branch.condition, arrayScopes.get(i));
         }
       }
     }
@@ -662,12 +663,17 @@ export const discoverTemplate = async (
 
   // Build DiscoveredField[]
   const discoveredFields: DiscoveredField[] = [];
+  const arrayPaths = [...fields]
+    .filter(([, info]) => info.kind === "array")
+    .map(([path]) => path);
   for (const [path, info] of fields) {
-    // Dotted scalar fields are represented by their structural object root
-    // and by the placeholder list. Array roots remain first-class fields even
-    // when dotted: dropping them would erase the primitive-row contract for a
-    // valid loop such as `deal.tags`.
-    if (path.includes(".") && info.kind !== "array") {
+    // Repeated-row descendants are represented relative to their array root.
+    // Other dotted fields remain first-class: condition-only paths have no
+    // placeholder entry, and filtering them here would erase valid inputs.
+    const isRepeatedRowDescendant = arrayPaths.some((arrayPath) =>
+      path.startsWith(`${arrayPath}.`),
+    );
+    if (info.kind !== "array" && isRepeatedRowDescendant) {
       continue;
     }
 

--- a/apps/api/src/handlers/docx/discover-template.ts
+++ b/apps/api/src/handlers/docx/discover-template.ts
@@ -8,6 +8,7 @@
  * array, object) and `structureErrors` for mismatched blocks.
  */
 
+import { panic } from "better-result";
 import JSZip from "jszip";
 import * as slimdom from "slimdom";
 
@@ -152,6 +153,49 @@ const qualifyRowScopedPath = (
   }
   const innermostRowPath = rowPaths.at(-1);
   return innermostRowPath === undefined ? path : `${innermostRowPath}.${path}`;
+};
+
+type RowScope = {
+  declaredPath: string;
+  scopedPath: string;
+};
+
+const rowScopePaths = (rowScopes: readonly RowScope[]): string[] =>
+  rowScopes.map(({ scopedPath }) => scopedPath);
+
+const qualifyRowScopedPlaceholder = (
+  path: string,
+  rowScopes: readonly RowScope[],
+): string => {
+  if (
+    rowScopes.some(
+      ({ scopedPath }) =>
+        path === scopedPath || path.startsWith(`${scopedPath}.`),
+    )
+  ) {
+    return path;
+  }
+  for (const { declaredPath, scopedPath } of rowScopes.toReversed()) {
+    if (path === declaredPath) {
+      return scopedPath;
+    }
+    const declaredPrefix = `${declaredPath}.`;
+    if (path.startsWith(declaredPrefix)) {
+      return `${scopedPath}.${path.slice(declaredPrefix.length)}`;
+    }
+  }
+  return path;
+};
+
+const requireRowScopes = (
+  arrayScopes: ReadonlyMap<number, readonly RowScope[]>,
+  paragraphIndex: number,
+): readonly RowScope[] => {
+  const scopes = arrayScopes.get(paragraphIndex);
+  if (scopes === undefined) {
+    panic(`Missing loop scope for paragraph ${paragraphIndex}`);
+  }
+  return scopes;
 };
 
 // ── Condition map building ─────────────────────────────
@@ -379,8 +423,8 @@ const analyzeContainer = (
   // The active loop path makes an unqualified condition available both as a
   // global input and as a row-local input, matching the fill evaluator's
   // global context overlaid with each row.
-  const arrayScopes = new Map<number, readonly string[]>();
-  const activeArrays: string[] = [];
+  const arrayScopes = new Map<number, readonly RowScope[]>();
+  const activeArrays: RowScope[] = [];
   const directiveByParagraph = new Map(
     directives.map((directive) => [directive.paragraphIndex, directive]),
   );
@@ -390,11 +434,22 @@ const analyzeContainer = (
       activeArrays.pop();
     }
     if (directive?.kind === "if" || directive?.kind === "elseif") {
-      registerConditionFields(fields, directive.expression, activeArrays);
+      registerConditionFields(
+        fields,
+        directive.expression,
+        rowScopePaths(activeArrays),
+      );
     }
     if (directive?.kind === "each") {
-      registerField(fields, directive.expression, "array");
-      activeArrays.push(directive.expression);
+      const scopedPath = qualifyRowScopedPath(
+        directive.expression,
+        rowScopePaths(activeArrays),
+      );
+      registerField(fields, scopedPath, "array");
+      activeArrays.push({
+        declaredPath: directive.expression,
+        scopedPath,
+      });
     }
     arrayScopes.set(i, [...activeArrays]);
   }
@@ -415,10 +470,18 @@ const analyzeContainer = (
   // 2. Analyze blocks for field types
   for (const block of blocks) {
     if (block.kind === "each") {
-      registerField(fields, block.arrayPath, "array");
+      const blockScope = requireRowScopes(
+        arrayScopes,
+        block.contentStart - 1,
+      ).at(-1);
+      if (blockScope === undefined) {
+        panic(`Missing loop scope for block ${block.arrayPath}`);
+      }
+      const arrayPath = blockScope.scopedPath;
+      registerField(fields, arrayPath, "array");
 
       // Scan content paragraphs for item field references
-      const entry = fields.get(block.arrayPath);
+      const entry = fields.get(arrayPath);
       for (let i = block.contentStart; i < block.contentEnd; i++) {
         const para = paragraphs[i];
         if (!para) {
@@ -480,7 +543,7 @@ const analyzeContainer = (
         if (group.kind === "each") {
           const scopedPath = qualifyRowScopedPath(
             group.arrayPath,
-            arrayScopes.get(i),
+            rowScopePaths(requireRowScopes(arrayScopes, i)),
           );
           registerField(fields, scopedPath, "array");
           inlineLoopScopes.push({
@@ -503,7 +566,11 @@ const analyzeContainer = (
 
         const priorConditions: string[] = [];
         for (const branch of group.branches) {
-          registerConditionFields(fields, branch.condition, arrayScopes.get(i));
+          registerConditionFields(
+            fields,
+            branch.condition,
+            rowScopePaths(requireRowScopes(arrayScopes, i)),
+          );
           const branchCondition =
             branch.condition === ""
               ? priorConditions.map(negateExpr).join(" and ")
@@ -540,10 +607,15 @@ const analyzeContainer = (
         ({ end, start }) => start <= match.index && match.index < end,
       );
       const declaredLoopPrefix = `${loopScope?.declaredPath ?? ""}.`;
-      const name =
+      const inlineScopedName =
         loopScope !== undefined && declaredName.startsWith(declaredLoopPrefix)
           ? `${loopScope.scopedPath}.${declaredName.slice(declaredLoopPrefix.length)}`
           : declaredName;
+      const scopedArrayPaths = requireRowScopes(arrayScopes, i);
+      const name = qualifyRowScopedPlaceholder(
+        inlineScopedName,
+        scopedArrayPaths,
+      );
       placeholderCounts.set(name, (placeholderCounts.get(name) ?? 0) + 1);
 
       const inlineCondition = inlineBranchConditions.find(
@@ -573,9 +645,8 @@ const analyzeContainer = (
       // Register the full path as string
       registerField(fields, name, "string");
 
-      const scopedArrayPaths = arrayScopes.get(i);
-      if (scopedArrayPaths !== undefined) {
-        for (const arrayPath of scopedArrayPaths) {
+      if (scopedArrayPaths.length > 0) {
+        for (const { scopedPath: arrayPath } of scopedArrayPaths) {
           const prefix = `${arrayPath}.`;
           if (name.startsWith(prefix)) {
             fields.get(arrayPath)?.itemPaths.add(name.slice(prefix.length));

--- a/apps/api/src/handlers/docx/docx-integration.test.ts
+++ b/apps/api/src/handlers/docx/docx-integration.test.ts
@@ -463,6 +463,36 @@ describe("header and footer placeholders", () => {
     expect(`${headerXml}${footerXml}`).not.toContain("{{#");
     expect(result.structureErrors).toEqual([]);
   });
+
+  test("loop-local numbering keys stay unique across document parts", async () => {
+    const body = WRAP(
+      [
+        P("{{#each body_items}}"),
+        P("Body {{@num:clause}}"),
+        P("{{/each}}"),
+      ].join(""),
+    );
+    const header = HEADER_WRAP(P("Header"));
+    const footer = FOOTER_WRAP(
+      [
+        P("{{#each footer_items}}"),
+        P("Footer {{@num:clause}}"),
+        P("{{/each}}"),
+      ].join(""),
+    );
+    const buf = await makeDocxWithHeaderFooter(body, header, footer);
+
+    const result = await fillTemplate(buf, {
+      body_items: [{}],
+      footer_items: [{}],
+    });
+    const zip = await JSZip.loadAsync(result.buffer);
+    const bodyXml = await zip.file("word/document.xml")?.async("string");
+    const footerXml = await zip.file("word/footer1.xml")?.async("string");
+
+    expect(bodyXml).toContain("Body 1");
+    expect(footerXml).toContain("Footer 2");
+  });
 });
 
 // ── Split-run placeholders ───────────────────────────────

--- a/apps/api/src/handlers/docx/docx-integration.test.ts
+++ b/apps/api/src/handlers/docx/docx-integration.test.ts
@@ -431,6 +431,38 @@ describe("header and footer placeholders", () => {
     const result = await fillTemplate(buf, { name: "Alice" });
     expect(result.unmatchedPlaceholders).toContain("company");
   });
+
+  test("inline directives render in headers and footers without body directives", async () => {
+    const body = WRAP(P("Body only"));
+    const header = HEADER_WRAP(
+      P("Header {{#if show_header}}for {{name}}{{/if}}"),
+    );
+    const footer = FOOTER_WRAP(
+      P("Tags: {{#each tags}}{{tags.value}}; {{/each}}"),
+    );
+    const buf = await makeDocxWithHeaderFooter(body, header, footer);
+
+    const discovered = await discoverTemplate(buf);
+    expect(discovered.fields.map((field) => field.path)).toEqual([
+      "name",
+      "show_header",
+      "tags",
+    ]);
+
+    const result = await fillTemplate(buf, {
+      name: "Alice",
+      show_header: true,
+      tags: ["urgent", "signed"],
+    });
+    const zip = await JSZip.loadAsync(result.buffer);
+    const headerXml = await zip.file("word/header1.xml")?.async("string");
+    const footerXml = await zip.file("word/footer1.xml")?.async("string");
+    expect(headerXml).toContain("Alice");
+    expect(footerXml).toContain("urgent");
+    expect(footerXml).toContain("signed");
+    expect(`${headerXml}${footerXml}`).not.toContain("{{#");
+    expect(result.structureErrors).toEqual([]);
+  });
 });
 
 // ── Split-run placeholders ───────────────────────────────

--- a/apps/api/src/handlers/docx/inline-conditions.test.ts
+++ b/apps/api/src/handlers/docx/inline-conditions.test.ts
@@ -605,6 +605,26 @@ describe("fillTemplate with inline conditions", () => {
     );
   });
 
+  test("inline conditions inside block loops retain each row context", async () => {
+    const docx = await makeDocx(
+      WRAP(
+        P("{{#each sellers}}") +
+          P("{{sellers.name}}{{#if sellers.is_company}} Ltd{{/if}}.") +
+          P("{{/each}}"),
+      ),
+    );
+
+    const result = await fillTemplate(docx, {
+      sellers: [
+        { name: "Acme", is_company: true },
+        { name: "Alice", is_company: false },
+      ],
+    });
+
+    expect(result.structureErrors).toEqual([]);
+    expect(await documentText(result.buffer)).toBe("Acme Ltd.Alice.");
+  });
+
   test("surfaces inline structure errors through fillTemplate", async () => {
     const docx = await makeDocx(
       WRAP(P("Broken{{#if oops}} span without closer.")),

--- a/apps/api/src/handlers/docx/inline-conditions.test.ts
+++ b/apps/api/src/handlers/docx/inline-conditions.test.ts
@@ -625,6 +625,28 @@ describe("fillTemplate with inline conditions", () => {
     expect(await documentText(result.buffer)).toBe("Acme Ltd.Alice.");
   });
 
+  test("inline loops inside block rows use each row's nested array", async () => {
+    const docx = await makeDocx(
+      WRAP(
+        P("{{#each groups}}") +
+          P("Items: {{#each items}}{{items.name}}, {{/each}}") +
+          P("{{/each}}"),
+      ),
+    );
+
+    const result = await fillTemplate(docx, {
+      groups: [
+        { items: [{ name: "Alpha" }] },
+        { items: [{ name: "Beta" }, { name: "Gamma" }] },
+      ],
+    });
+
+    expect(result.structureErrors).toEqual([]);
+    expect(await documentText(result.buffer)).toBe(
+      "Items: Alpha, Items: Beta, Gamma, ",
+    );
+  });
+
   test("surfaces inline structure errors through fillTemplate", async () => {
     const docx = await makeDocx(
       WRAP(P("Broken{{#if oops}} span without closer.")),

--- a/apps/api/src/handlers/docx/inline-conditions.ts
+++ b/apps/api/src/handlers/docx/inline-conditions.ts
@@ -38,8 +38,8 @@
  *   block `{{#if}}`/`{{#each}}`. Inline directives do NOT see an enclosing
  *   block-loop iteration item: block loop expansion has already run when this
  *   pass executes.
- * - Like block directives, this pass covers word/document.xml only (not
- *   headers/footers), matching processBlockDirectives.
+ * - The caller runs this pass for the body and every header/footer content
+ *   part, matching discovery and scalar value replacement coverage.
  *
  * Whole-paragraph directive lines are skipped here: they are the block
  * engine's domain, and orphaned ones were already reported by

--- a/apps/api/src/handlers/docx/inline-conditions.ts
+++ b/apps/api/src/handlers/docx/inline-conditions.ts
@@ -67,8 +67,7 @@ import {
   collectNumKeysInText,
   createDirectiveProcessingContext,
   type DirectiveProcessingContext,
-  eachKey,
-  registerItemPatchValues,
+  registerLoopItemPatchValues,
   rewriteEachPlaceholdersInText,
   rewriteIterationTokensInText,
   scopeIterationNumberingInText,
@@ -120,9 +119,6 @@ type InlineParse =
   | { ok: false; message: string; directive: string };
 
 /** Narrow `unknown` to a non-array string-keyed record. */
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === "object" && value !== null && !Array.isArray(value);
-
 const EXCERPT_LENGTH = 60;
 
 /** Short paragraph excerpt so a structure error names the paragraph. */
@@ -397,19 +393,7 @@ const applyInlineEach = (
   const rewriteItem = (text: string, itemIdx: number): string => {
     const item = items[itemIdx];
     const itemValues: Record<string, RichPatchValue> = {};
-    if (isRecord(item)) {
-      registerItemPatchValues(itemValues, item, group.arrayPath, itemIdx, "");
-    } else if (
-      typeof item === "string" ||
-      typeof item === "number" ||
-      typeof item === "boolean"
-    ) {
-      // Primitive array: support the raw `{{__each_path_N}}` key (matching the
-      // block expander) and `{{path.value}}` so authors have a writable field.
-      const value = typeof item === "string" ? item : String(item);
-      itemValues[`__each_${group.arrayPath}_${itemIdx}`] = value;
-      itemValues[eachKey(group.arrayPath, itemIdx, "value")] = value;
-    }
+    registerLoopItemPatchValues(itemValues, item, group.arrayPath, itemIdx);
 
     let iteration = rewriteEachPlaceholdersInText(
       text,

--- a/apps/api/src/handlers/docx/inline-conditions.ts
+++ b/apps/api/src/handlers/docx/inline-conditions.ts
@@ -34,10 +34,9 @@
  * - A paragraph with a structure error is left untouched (its markers stay
  *   in the output) and only the first error per paragraph is reported.
  * - Conditions and array paths evaluate against the top-level template data
- *   plus the manifest's named conditions — the same context as a top-level
- *   block `{{#if}}`/`{{#each}}`. Inline directives do NOT see an enclosing
- *   block-loop iteration item: block loop expansion has already run when this
- *   pass executes.
+ *   plus the manifest's named conditions. Paragraphs cloned by a block loop
+ *   retain that iteration's inherited row context, matching nested block
+ *   condition semantics.
  * - The caller runs this pass for the body and every header/footer content
  *   part, matching discovery and scalar value replacement coverage.
  *
@@ -66,6 +65,8 @@ import {
 
 import {
   collectNumKeysInText,
+  createDirectiveProcessingContext,
+  type DirectiveProcessingContext,
   eachKey,
   registerItemPatchValues,
   rewriteEachPlaceholdersInText,
@@ -280,12 +281,11 @@ export const processInlineConditions = (
   body: slimdom.Element,
   data: Record<string, unknown>,
   namedConditions?: NamedCondition[],
+  options: { processingContext?: DirectiveProcessingContext } = {},
 ): TemplateStructureError[] => {
   const errors: TemplateStructureError[] = [];
-
-  // Distinguishes sibling inline loops so their iteration-scoped numbering
-  // keys can never collide (mirrors the block expander's eachExpansionCount).
-  let eachExpansionCount = 0;
+  const processingContext =
+    options.processingContext ?? createDirectiveProcessingContext();
 
   for (const [index, paragraph] of body
     .getElementsByTagNameNS(W_NS, "p")
@@ -318,16 +318,22 @@ export const processInlineConditions = (
     // offsets valid. `if` groups are plain string cuts; `each` groups splice
     // cloned run sequences (preserving body run formatting) at the run level.
     const ordered = [...parsed.groups].toSorted((a, b) => b.start - a.start);
+    const paragraphData =
+      processingContext.inlineDataByParagraph.get(paragraph) ?? data;
     for (const group of ordered) {
       if (group.kind === "each") {
-        applyInlineEach(paragraph, group, data, eachExpansionCount);
-        eachExpansionCount += 1;
+        applyInlineEach(
+          paragraph,
+          group,
+          paragraphData,
+          processingContext.nextEachExpansionId(),
+        );
         continue;
       }
       const winning = group.branches.find(
         (branch) =>
           branch.condition === "" ||
-          evaluateCondition(branch.condition, data, namedConditions),
+          evaluateCondition(branch.condition, paragraphData, namedConditions),
       );
       const cuts: { start: number; end: number; value: string }[] = [];
       if (winning) {

--- a/apps/api/src/handlers/docx/ooxml.test.ts
+++ b/apps/api/src/handlers/docx/ooxml.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, test } from "bun:test";
 import * as slimdom from "slimdom";
 
-import { collectExistingIds, createIdGenerator, W_NS } from "./ooxml";
+import {
+  collectExistingIds,
+  createIdGenerator,
+  templateContentPartPaths,
+  W_NS,
+} from "./ooxml";
 
 const WRAP = (body: string) =>
   `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
@@ -47,6 +52,27 @@ describe("collectExistingIds", () => {
     const ids = collectExistingIds(doc);
 
     expect(ids.has(999_999)).toBe(true);
+  });
+});
+
+describe("templateContentPartPaths", () => {
+  test("defines one deterministic scope for every template pipeline phase", () => {
+    expect(
+      templateContentPartPaths([
+        "word/styles.xml",
+        "word/header2.xml",
+        "word/document.xml",
+        "word/footer1.xml",
+        "word/header1.xml",
+        "word/_rels/document.xml.rels",
+        "word/header.xml",
+      ]),
+    ).toEqual([
+      "word/document.xml",
+      "word/footer1.xml",
+      "word/header1.xml",
+      "word/header2.xml",
+    ]);
   });
 });
 

--- a/apps/api/src/handlers/docx/ooxml.ts
+++ b/apps/api/src/handlers/docx/ooxml.ts
@@ -74,7 +74,21 @@ const INT32_MAX = 2_147_483_647;
  * values starting from 1, avoiding collisions with existing IDs.
  */
 /** Regex matching header and footer XML entry paths. */
-export const HEADER_FOOTER_RE = /^word\/(?:header|footer)\d+\.xml$/u;
+const HEADER_FOOTER_RE = /^word\/(?:header|footer)\d+\.xml$/u;
+
+export const MAIN_DOCUMENT_PART_PATH = "word/document.xml";
+
+/** Every WordprocessingML part whose authored template content is visible. */
+export const isTemplateContentPartPath = (path: string): boolean =>
+  path === MAIN_DOCUMENT_PART_PATH || HEADER_FOOTER_RE.test(path);
+
+/**
+ * Deterministic shared traversal scope for discovery, directive processing,
+ * value replacement, and AI adaptation. Keeping the scope in one function
+ * prevents one pipeline phase from silently supporting fewer document parts.
+ */
+export const templateContentPartPaths = (paths: Iterable<string>): string[] =>
+  [...paths].filter(isTemplateContentPartPath).toSorted();
 
 // ── Text helpers ─────────────────────────────────────────
 

--- a/apps/api/src/handlers/docx/patch-template.test.ts
+++ b/apps/api/src/handlers/docx/patch-template.test.ts
@@ -310,6 +310,27 @@ describe("fillTemplate — block directives e2e", () => {
     expect(joined).not.toContain("{{#each");
   });
 
+  test("nested primitive loop shorthand renders each outer row's values", async () => {
+    const docx = await makeDocx(
+      WRAP(
+        [
+          P("{{#each groups}}"),
+          P("{{#each subitems}}"),
+          P("{{subitems.value}}"),
+          P("{{/each}}"),
+          P("{{/each}}"),
+        ].join(""),
+      ),
+    );
+
+    const { buffer, unmatchedPlaceholders } = await fillTemplate(docx, {
+      groups: [{ subitems: ["first"] }, { subitems: ["second"] }],
+    });
+
+    expect(await extractTexts(buffer)).toEqual(["first", "second"]);
+    expect(unmatchedPlaceholders).toEqual([]);
+  });
+
   test("nested objects with dotted paths", async () => {
     const xml = WRAP(
       [

--- a/apps/api/src/handlers/docx/patch-template.test.ts
+++ b/apps/api/src/handlers/docx/patch-template.test.ts
@@ -331,6 +331,32 @@ describe("fillTemplate — block directives e2e", () => {
     expect(unmatchedPlaceholders).toEqual([]);
   });
 
+  test("three-level shorthand and qualified loops share scoped identities", async () => {
+    const docx = await makeDocx(
+      WRAP(
+        [
+          P("{{#each groups}}"),
+          P("{{#each items}}"),
+          P("{{#each items.subitems}}"),
+          P("{{items.subitems.value}}"),
+          P("{{/each}}"),
+          P("{{/each}}"),
+          P("{{/each}}"),
+        ].join(""),
+      ),
+    );
+
+    const { buffer, unmatchedPlaceholders } = await fillTemplate(docx, {
+      groups: [
+        { items: [{ subitems: ["first"] }] },
+        { items: [{ subitems: ["second"] }] },
+      ],
+    });
+
+    expect(await extractTexts(buffer)).toEqual(["first", "second"]);
+    expect(unmatchedPlaceholders).toEqual([]);
+  });
+
   test("nested objects with dotted paths", async () => {
     const xml = WRAP(
       [

--- a/apps/api/src/handlers/docx/patch-template.ts
+++ b/apps/api/src/handlers/docx/patch-template.ts
@@ -30,11 +30,16 @@ import {
   mightContainNumberingMarkers,
   resolveRefsInDoc,
 } from "./numbering";
-import { HEADER_FOOTER_RE, W_NS } from "./ooxml";
+import {
+  MAIN_DOCUMENT_PART_PATH,
+  templateContentPartPaths,
+  W_NS,
+} from "./ooxml";
 import { patchXmlPart } from "./rich-patch";
 import { readManifestFromZip, stripManifest } from "./template-manifest";
 import type {
   FillTemplateResult,
+  ParagraphSource,
   RichPatchValue,
   TemplateData,
   TemplateDataValue,
@@ -53,9 +58,7 @@ const fillTemplateWithValues = async (
   values: PatchValues,
 ): Promise<Buffer> => {
   const zip = await JSZip.loadAsync(data);
-  const partNames = Object.keys(zip.files).filter(
-    (name) => name === "word/document.xml" || HEADER_FOOTER_RE.test(name),
-  );
+  const partNames = templateContentPartPaths(Object.keys(zip.files));
 
   // Each part is read, patched, and written back independently — `values` is
   // read-only and `patchXmlPart` carries no cross-part counter (unlike the
@@ -82,14 +85,33 @@ const fillTemplateWithValues = async (
 };
 
 /**
- * Pre-process block directives in a DOCX ZIP. Checks whether
- * block directives exist; if not, returns `null` (caller should
- * fall back to `flattenTemplateData`). Otherwise evaluates
- * conditionals and loops, serializes the modified XML back
- * into the ZIP, and returns the modified buffer plus expanded
- * patch values.
+ * Pre-process block and inline directives in every authored content part.
+ * Returns `null` when no part has directives so callers retain the flatten-only
+ * fast path. Discovery and rendering share templateContentPartPaths, making
+ * supported document-part coverage a single invariant.
  */
-const preProcessBlockDirectives = async (
+const templatePartSource = (path: string): ParagraphSource => {
+  if (path === MAIN_DOCUMENT_PART_PATH) {
+    return "body";
+  }
+  if (path.startsWith("word/header")) {
+    return "header";
+  }
+  return "footer";
+};
+
+const templatePartContainer = (
+  doc: slimdom.Document,
+  source: ParagraphSource,
+): slimdom.Element | undefined => {
+  if (source === "body") {
+    return doc.getElementsByTagNameNS(W_NS, "body").at(0);
+  }
+  const localName = source === "header" ? "hdr" : "ftr";
+  return doc.getElementsByTagNameNS(W_NS, localName).at(0);
+};
+
+const preProcessTemplateDirectives = async (
   zip: JSZip,
   templateData: TemplateData,
   namedConditions?: NamedCondition[],
@@ -99,79 +121,85 @@ const preProcessBlockDirectives = async (
   expandedValues: Record<string, RichPatchValue>;
   structureErrors: TemplateStructureError[];
 } | null> => {
-  const docEntry = zip.file("word/document.xml");
-  if (!docEntry) {
+  const parts = (
+    await Promise.all(
+      templateContentPartPaths(Object.keys(zip.files)).map(async (path) => {
+        const entry = zip.file(path);
+        if (!entry) {
+          return undefined;
+        }
+        return { path, xml: await entry.async("string") };
+      }),
+    )
+  ).filter((part): part is { path: string; xml: string } => part !== undefined);
+  if (!parts.some(({ xml }) => HAS_BLOCK_DIRECTIVES_RE.test(xml))) {
     return null;
   }
 
-  const xml = await docEntry.async("string");
-
-  // Fast-path: skip DOM parsing if no block directives
-  if (!HAS_BLOCK_DIRECTIVES_RE.test(xml)) {
-    return null;
-  }
-
-  const doc = slimdom.parseXmlDocument(xml);
-  const body = doc.getElementsByTagNameNS(W_NS, "body").at(0);
-
-  if (!body) {
-    return null;
-  }
-
-  const { patchValues, errors } = processBlockDirectives(
-    body,
-    templateData,
-    namedConditions,
-    conditionValues,
-  );
-
-  // Inline conditional spans resolve after the block pass (whole-paragraph
-  // directives and loop expansion are settled, so every surviving paragraph
-  // is final) and before this DOM serializes — which places them before
-  // numbering, placeholder discovery, and {{path}} substitution below. That
-  // ordering keeps the downstream passes clean: markers and @num keys inside
-  // a cut span are removed before they could be numbered, reported as
-  // unmatched, or filled. AI per-occurrence adaptation (adaptAiFields) runs
-  // even earlier, at the fill boundary on the raw template buffer: its
-  // context extraction and per-occurrence patching must see the same buffer
-  // so occurrence indices stay aligned, and a rendering patched into a
-  // branch that this pass later cuts is simply removed with the branch.
-  // Inline `{{#if}}` spans evaluate against the same raw-value overlay as the
-  // block pass (see CONDITION_RAW_VALUES). processInlineConditions uses `data`
-  // only for condition tests and inline-loop array resolution — never for
-  // scalar substitution — so overlaying the formatted date paths with their raw
-  // ISO values is safe and does not affect rendered text.
+  const expandedValues = flattenTemplateData(templateData);
+  const structureErrors: TemplateStructureError[] = [];
   const inlineData =
     conditionValues && Object.keys(conditionValues).length > 0
       ? { ...templateData, ...conditionValues }
       : templateData;
-  const inlineErrors = processInlineConditions(
-    body,
-    inlineData,
-    namedConditions,
-  );
+  const paragraphOffsets: Record<ParagraphSource, number> = {
+    body: 0,
+    footer: 0,
+    header: 0,
+  };
+  const numberingXml =
+    (await zip.file("word/numbering.xml")?.async("string")) ?? null;
+  const validNumIds = collectValidNumIds(numberingXml);
 
-  // Loop expansion clones list paragraphs verbatim; prune numbering
-  // references that do not resolve in word/numbering.xml so the
-  // output renders identically in every consumer (Word ignores a
-  // dangling numId, other processors may not).
-  if (body.getElementsByTagNameNS(W_NS, "numPr").length > 0) {
-    const numberingXml =
-      (await zip.file("word/numbering.xml")?.async("string")) ?? null;
-    pruneDanglingNumPr(body, collectValidNumIds(numberingXml));
+  for (const { path, xml } of parts) {
+    const doc = slimdom.parseXmlDocument(xml);
+    const source = templatePartSource(path);
+    const container = templatePartContainer(doc, source);
+    if (!container) {
+      continue;
+    }
+
+    const paragraphCount = container.getElementsByTagNameNS(W_NS, "p").length;
+    const paragraphOffset = paragraphOffsets[source];
+    paragraphOffsets[source] += paragraphCount;
+    if (!HAS_BLOCK_DIRECTIVES_RE.test(xml)) {
+      continue;
+    }
+
+    const { patchValues, errors } = processBlockDirectives(
+      container,
+      templateData,
+      namedConditions,
+      conditionValues,
+    );
+    Object.assign(expandedValues, patchValues);
+    const inlineErrors = processInlineConditions(
+      container,
+      inlineData,
+      namedConditions,
+    );
+    for (const error of [...errors, ...inlineErrors]) {
+      structureErrors.push({
+        ...error,
+        paragraphIndex: error.paragraphIndex + paragraphOffset,
+        source,
+      });
+    }
+
+    if (container.getElementsByTagNameNS(W_NS, "numPr").length > 0) {
+      pruneDanglingNumPr(container, validNumIds);
+    }
+    zip.file(path, slimdom.serializeToWellFormedString(doc));
   }
 
-  // Serialize modified DOM back into the ZIP
-  const serialized = slimdom.serializeToWellFormedString(doc);
-  zip.file("word/document.xml", serialized);
   const modifiedBuf = await zip.generateAsync({
     type: "nodebuffer",
   });
 
   return {
     buffer: Buffer.from(modifiedBuf),
-    expandedValues: patchValues,
-    structureErrors: [...errors, ...inlineErrors],
+    expandedValues,
+    structureErrors,
   };
 };
 
@@ -208,7 +236,7 @@ export const fillTemplate = async (
     const conditionValues = readConditionRawValues(values);
     // Checks for block directives internally; returns null
     // when none are found
-    const result = await preProcessBlockDirectives(
+    const result = await preProcessTemplateDirectives(
       zip,
       values,
       namedConditions,
@@ -229,8 +257,8 @@ export const fillTemplate = async (
   }
 
   // Resolve clause cross-references / numbering across the body and every
-  // header/footer part — the same parts fillTemplateWithValues and
-  // discoverPlaceholders cover (`word/document.xml` || HEADER_FOOTER_RE) — after
+  // header/footer part — the same shared template-content parts used by value
+  // replacement and placeholder discovery — after
   // conditional removal, so clauses dropped by a {{#if}} are not numbered and
   // references to them stay unresolved. Numbering shares one counter space and
   // `@ref` must resolve across parts, so this is two-phase over a parsed DOM
@@ -241,12 +269,9 @@ export const fillTemplate = async (
   // that Word split across runs be seen and rewritten, the same way the
   // placeholder pipeline handles split markers.
   const numberingZip = await JSZip.loadAsync(data);
-  const numberingParts = [
-    "word/document.xml",
-    ...Object.keys(numberingZip.files).filter((name) =>
-      HEADER_FOOTER_RE.test(name),
-    ),
-  ];
+  const numberingParts = templateContentPartPaths(
+    Object.keys(numberingZip.files),
+  );
   const numberingDocs = new Map<string, slimdom.Document>();
   const numbers = new Map<string, number>();
 

--- a/apps/api/src/handlers/docx/patch-template.ts
+++ b/apps/api/src/handlers/docx/patch-template.ts
@@ -16,6 +16,7 @@ import type { NamedCondition } from "@stll/template-conditions";
 
 import {
   collectValidNumIds,
+  createDirectiveProcessingContext,
   flattenTemplateData,
   HAS_BLOCK_DIRECTIVES_RE,
   processBlockDirectives,
@@ -150,6 +151,7 @@ const preProcessTemplateDirectives = async (
   const numberingXml =
     (await zip.file("word/numbering.xml")?.async("string")) ?? null;
   const validNumIds = collectValidNumIds(numberingXml);
+  const processingContext = createDirectiveProcessingContext();
 
   for (const { path, xml } of parts) {
     const doc = slimdom.parseXmlDocument(xml);
@@ -169,14 +171,14 @@ const preProcessTemplateDirectives = async (
     const { patchValues, errors } = processBlockDirectives(
       container,
       templateData,
-      namedConditions,
-      conditionValues,
+      { conditionValues, namedConditions, processingContext },
     );
     Object.assign(expandedValues, patchValues);
     const inlineErrors = processInlineConditions(
       container,
       inlineData,
       namedConditions,
+      { processingContext },
     );
     for (const error of [...errors, ...inlineErrors]) {
       structureErrors.push({

--- a/apps/api/src/handlers/docx/template-manifest.test.ts
+++ b/apps/api/src/handlers/docx/template-manifest.test.ts
@@ -739,6 +739,37 @@ describe("mergeManifestWithDiscovery", () => {
     ]);
   });
 
+  test("keeps parent arrays when nested loop paths share their prefix", () => {
+    const discovery: DiscoveredTemplate = {
+      placeholders: [],
+      fields: [
+        {
+          path: "contracts",
+          kind: "array",
+          count: 1,
+          itemFields: [{ path: "name", kind: "string", count: 1 }],
+        },
+        {
+          path: "contracts.fields",
+          kind: "array",
+          count: 1,
+          itemFields: [{ path: "value", kind: "string", count: 1 }],
+        },
+      ],
+      structureErrors: [],
+    };
+
+    const resolved = mergeManifestWithDiscovery(null, discovery);
+
+    expect(resolved.map((field) => field.path).toSorted()).toEqual([
+      "contracts",
+      "contracts.fields",
+    ]);
+    expect(
+      resolved.find((field) => field.path === "contracts")?.itemFields,
+    ).toEqual([{ path: "name", kind: "string", count: 1 }]);
+  });
+
   test("keeps a lookup field as a leaf despite dotted format markers under it", () => {
     // {{company}} + {{company.full}} make discovery promote `company` to an
     // object and register `company.full` as a string. The lookup field is a

--- a/apps/api/src/handlers/docx/template-manifest.ts
+++ b/apps/api/src/handlers/docx/template-manifest.ts
@@ -1078,6 +1078,11 @@ export const mergeManifestWithDiscovery = (
     if (f.lookup !== undefined) {
       return true;
     }
+    // Arrays are value-bearing loop inputs, not structural namespace roots.
+    // A nested array path must not make its parent loop disappear.
+    if (f.kind === "array") {
+      return true;
+    }
     return !paths.some((p) => p !== f.path && p.startsWith(`${f.path}.`));
   });
 };

--- a/apps/api/src/handlers/templates/prepare-template.ts
+++ b/apps/api/src/handlers/templates/prepare-template.ts
@@ -16,11 +16,12 @@ import {
   type FieldSuggestion,
 } from "@/api/handlers/docx/apply-field-suggestions";
 import { extractText } from "@/api/handlers/docx/extract-text";
-import { HEADER_FOOTER_RE } from "@/api/handlers/docx/ooxml";
+import {
+  MAIN_DOCUMENT_PART_PATH,
+  templateContentPartPaths,
+} from "@/api/handlers/docx/ooxml";
 import { writeManifest } from "@/api/handlers/docx/template-manifest";
 import type { FieldMeta } from "@/api/handlers/docx/types";
-
-const DOCUMENT_PATH = "word/document.xml";
 
 export type SuggestFields = (
   documentText: string,
@@ -50,19 +51,15 @@ export const prepareTemplateFromDocument = async ({
   }
 
   const zip = await JSZip.loadAsync(buffer);
-  if (!zip.file(DOCUMENT_PATH)) {
+  if (!zip.file(MAIN_DOCUMENT_PART_PATH)) {
     return { buffer, fields: [], unapplied: suggestions };
   }
 
   // Rewrite the body and every header/footer part, matching the parts the rest
-  // of the pipeline covers (discoverPlaceholders / fillTemplateWithValues filter
-  // on `word/document.xml` || HEADER_FOOTER_RE). A literal that the model read
+  // of the pipeline covers through templateContentPartPaths. A literal the model read
   // from a letterhead or footer (extractText concatenates headers, body, and
   // footers into the prompt) is then rewritten where it actually lives.
-  const partNames = [
-    DOCUMENT_PATH,
-    ...Object.keys(zip.files).filter((name) => HEADER_FOOTER_RE.test(name)),
-  ];
+  const partNames = templateContentPartPaths(Object.keys(zip.files));
 
   // Merge results across parts: a field is added once per path, and a
   // suggestion is reported unapplied only when no part matched it. Running

--- a/apps/api/src/handlers/templates/template-fill-service.ts
+++ b/apps/api/src/handlers/templates/template-fill-service.ts
@@ -311,27 +311,41 @@ const fillTemplateDocxWithPolicy = async <TRejection = never>({
 
   if (unusedValuePolicy === "reject") {
     const discovered = await discoverTemplate(loaded.buffer);
+    const livePaths = [
+      ...discovered.fields.flatMap((field) => [
+        field.path,
+        ...(field.itemFields === undefined
+          ? []
+          : field.itemFields.map(
+              (itemField) => `${field.path}.${itemField.path}`,
+            )),
+      ]),
+      ...discovered.placeholders.map((placeholder) => placeholder.name),
+    ];
     const declaredKeys =
       manifest === null
         ? collectTemplateInputKeys({
-            discoveredFieldPaths: discovered.fields.flatMap((field) => [
-              field.path,
-              ...(field.itemFields === undefined
-                ? []
-                : field.itemFields.map(
-                    (itemField) => `${field.path}.${itemField.path}`,
-                  )),
-            ]),
-            manifestFieldPaths: [],
-            placeholderPaths: discovered.placeholders.map(
-              (placeholder) => placeholder.name,
-            ),
+            type: "raw",
+            livePaths,
           })
-        : new Set(
-            manifest.fields
+        : collectTemplateInputKeys({
+            type: "manifest",
+            derivedOutputPaths: manifest.fields.flatMap((field) => {
+              const paths = isFillableTemplateInputField(field)
+                ? []
+                : [field.path];
+              if (field.lookup !== undefined) {
+                for (const format of field.lookup.formats) {
+                  paths.push(`${field.path}.${format.key}`);
+                }
+              }
+              return paths;
+            }),
+            fillableFieldPaths: manifest.fields
               .filter(isFillableTemplateInputField)
               .map((field) => field.path),
-          );
+            livePaths,
+          });
     const unusedKeys = findUnusedTemplateValueKeys({
       declaredKeys,
       values,

--- a/apps/api/src/handlers/templates/template-fill-service.ts
+++ b/apps/api/src/handlers/templates/template-fill-service.ts
@@ -47,7 +47,10 @@ import type { SafeId } from "@/api/lib/branded-types";
 import { getS3 } from "@/api/lib/s3";
 import { buildBindingContext } from "@/api/lib/template-binding/build-binding-context";
 
-import { findUnusedTemplateValueKeys } from "./template-input-contract";
+import {
+  collectTemplateInputKeys,
+  findUnusedTemplateValueKeys,
+} from "./template-input-contract";
 
 // Data a template is filled with: open-ended field-path → value map (paths come
 // from the template's manifest/markers, not a fixed entity), patched in place
@@ -308,14 +311,19 @@ const fillTemplateDocxWithPolicy = async <TRejection = never>({
 > => {
   const loaded = source;
   const { templateId } = source;
+  const manifest = await readManifest(loaded.buffer);
 
   if (unusedValuePolicy === "reject") {
     const discovered = await discoverTemplate(loaded.buffer);
     const unusedKeys = findUnusedTemplateValueKeys({
-      declaredKeys: [
-        ...discovered.fields.map((field) => field.path),
-        ...discovered.placeholders.map((placeholder) => placeholder.name),
-      ],
+      declaredKeys: collectTemplateInputKeys({
+        discoveredFieldPaths: discovered.fields.map((field) => field.path),
+        manifestFieldPaths:
+          manifest === null ? [] : manifest.fields.map((field) => field.path),
+        placeholderPaths: discovered.placeholders.map(
+          (placeholder) => placeholder.name,
+        ),
+      }),
       values,
     });
     if (unusedKeys.length > 0) {
@@ -355,7 +363,6 @@ const fillTemplateDocxWithPolicy = async <TRejection = never>({
   // Draft AI-fillable fields (manifest fields with an aiPrompt) before fill.
   let fillBuffer = loaded.buffer;
   let adaptedPaths: readonly string[] = [];
-  const manifest = await readManifest(loaded.buffer);
   if (manifest) {
     // Resolve the data-binding context only when this fill targets a matter and
     // the manifest actually declares a bound field, so a transient fill or a

--- a/apps/api/src/handlers/templates/template-fill-service.ts
+++ b/apps/api/src/handlers/templates/template-fill-service.ts
@@ -50,6 +50,7 @@ import { buildBindingContext } from "@/api/lib/template-binding/build-binding-co
 import {
   collectTemplateInputKeys,
   findUnusedTemplateValueKeys,
+  isFillableTemplateInputField,
 } from "./template-input-contract";
 
 // Data a template is filled with: open-ended field-path → value map (paths come
@@ -150,12 +151,7 @@ export const describeStoredTemplate = async ({
     return {
       name: loaded.name,
       fields: manifest.fields
-        .filter(
-          (field) =>
-            field.formula === undefined &&
-            field.condition === undefined &&
-            field.conditionAst === undefined,
-        )
+        .filter(isFillableTemplateInputField)
         .map((field) => ({
           path: field.path,
           label: field.label ?? null,
@@ -315,22 +311,29 @@ const fillTemplateDocxWithPolicy = async <TRejection = never>({
 
   if (unusedValuePolicy === "reject") {
     const discovered = await discoverTemplate(loaded.buffer);
+    const declaredKeys =
+      manifest === null
+        ? collectTemplateInputKeys({
+            discoveredFieldPaths: discovered.fields.flatMap((field) => [
+              field.path,
+              ...(field.itemFields === undefined
+                ? []
+                : field.itemFields.map(
+                    (itemField) => `${field.path}.${itemField.path}`,
+                  )),
+            ]),
+            manifestFieldPaths: [],
+            placeholderPaths: discovered.placeholders.map(
+              (placeholder) => placeholder.name,
+            ),
+          })
+        : new Set(
+            manifest.fields
+              .filter(isFillableTemplateInputField)
+              .map((field) => field.path),
+          );
     const unusedKeys = findUnusedTemplateValueKeys({
-      declaredKeys: collectTemplateInputKeys({
-        discoveredFieldPaths: discovered.fields.flatMap((field) => [
-          field.path,
-          ...(field.itemFields === undefined
-            ? []
-            : field.itemFields.map(
-                (itemField) => `${field.path}.${itemField.path}`,
-              )),
-        ]),
-        manifestFieldPaths:
-          manifest === null ? [] : manifest.fields.map((field) => field.path),
-        placeholderPaths: discovered.placeholders.map(
-          (placeholder) => placeholder.name,
-        ),
-      }),
+      declaredKeys,
       values,
     });
     if (unusedKeys.length > 0) {

--- a/apps/api/src/handlers/templates/template-fill-service.ts
+++ b/apps/api/src/handlers/templates/template-fill-service.ts
@@ -310,8 +310,12 @@ const fillTemplateDocxWithPolicy = async <TRejection = never>({
   const { templateId } = source;
 
   if (unusedValuePolicy === "reject") {
-    const unusedKeys = await findUnusedTemplateValueKeys({
-      buffer: loaded.buffer,
+    const discovered = await discoverTemplate(loaded.buffer);
+    const unusedKeys = findUnusedTemplateValueKeys({
+      declaredKeys: [
+        ...discovered.fields.map((field) => field.path),
+        ...discovered.placeholders.map((placeholder) => placeholder.name),
+      ],
       values,
     });
     if (unusedKeys.length > 0) {

--- a/apps/api/src/handlers/templates/template-fill-service.ts
+++ b/apps/api/src/handlers/templates/template-fill-service.ts
@@ -37,6 +37,7 @@ import {
 import { resolveClauseSlots } from "@/api/handlers/docx/resolve-clause-slots";
 import { readManifest } from "@/api/handlers/docx/template-manifest";
 import type {
+  DiscoveredField,
   FieldDateFormat,
   FieldPart,
   InputType,
@@ -59,6 +60,29 @@ import {
 type FillValues = Record<string, unknown>;
 
 type UnusedValuePolicy = "allow" | "reject";
+
+const collectDiscoveredTerminalPaths = (
+  fields: readonly DiscoveredField[],
+): string[] => {
+  const terminalPaths: string[] = [];
+
+  const visit = (field: DiscoveredField, parentPath: string): void => {
+    const path = parentPath === "" ? field.path : `${parentPath}.${field.path}`;
+    if (field.kind !== "object" && field.kind !== "array") {
+      terminalPaths.push(path);
+    }
+    if (field.itemFields !== undefined) {
+      for (const itemField of field.itemFields) {
+        visit(itemField, path);
+      }
+    }
+  };
+
+  for (const field of fields) {
+    visit(field, "");
+  }
+  return terminalPaths;
+};
 
 type TemplateInputRejection = {
   type: "unused-values";
@@ -311,22 +335,15 @@ const fillTemplateDocxWithPolicy = async <TRejection = never>({
 
   if (unusedValuePolicy === "reject") {
     const discovered = await discoverTemplate(loaded.buffer);
-    const livePaths = [
-      ...discovered.fields.flatMap((field) => [
-        field.path,
-        ...(field.itemFields === undefined
-          ? []
-          : field.itemFields.map(
-              (itemField) => `${field.path}.${itemField.path}`,
-            )),
-      ]),
+    const terminalPaths = [
+      ...collectDiscoveredTerminalPaths(discovered.fields),
       ...discovered.placeholders.map((placeholder) => placeholder.name),
     ];
     const inputContract =
       manifest === null
         ? collectTemplateInputKeys({
             type: "raw",
-            livePaths,
+            terminalPaths,
           })
         : collectTemplateInputKeys({
             type: "manifest",
@@ -344,7 +361,7 @@ const fillTemplateDocxWithPolicy = async <TRejection = never>({
             fillableFieldPaths: manifest.fields
               .filter(isFillableTemplateInputField)
               .map((field) => field.path),
-            livePaths,
+            livePaths: terminalPaths,
           });
     const unusedKeys = findUnusedTemplateValueKeys({
       contract: inputContract,

--- a/apps/api/src/handlers/templates/template-fill-service.ts
+++ b/apps/api/src/handlers/templates/template-fill-service.ts
@@ -322,7 +322,7 @@ const fillTemplateDocxWithPolicy = async <TRejection = never>({
       ]),
       ...discovered.placeholders.map((placeholder) => placeholder.name),
     ];
-    const declaredKeys =
+    const inputContract =
       manifest === null
         ? collectTemplateInputKeys({
             type: "raw",
@@ -347,7 +347,7 @@ const fillTemplateDocxWithPolicy = async <TRejection = never>({
             livePaths,
           });
     const unusedKeys = findUnusedTemplateValueKeys({
-      declaredKeys,
+      contract: inputContract,
       values,
     });
     if (unusedKeys.length > 0) {

--- a/apps/api/src/handlers/templates/template-fill-service.ts
+++ b/apps/api/src/handlers/templates/template-fill-service.ts
@@ -317,7 +317,14 @@ const fillTemplateDocxWithPolicy = async <TRejection = never>({
     const discovered = await discoverTemplate(loaded.buffer);
     const unusedKeys = findUnusedTemplateValueKeys({
       declaredKeys: collectTemplateInputKeys({
-        discoveredFieldPaths: discovered.fields.map((field) => field.path),
+        discoveredFieldPaths: discovered.fields.flatMap((field) => [
+          field.path,
+          ...(field.itemFields === undefined
+            ? []
+            : field.itemFields.map(
+                (itemField) => `${field.path}.${itemField.path}`,
+              )),
+        ]),
         manifestFieldPaths:
           manifest === null ? [] : manifest.fields.map((field) => field.path),
         placeholderPaths: discovered.placeholders.map(

--- a/apps/api/src/handlers/templates/template-fill-service.ts
+++ b/apps/api/src/handlers/templates/template-fill-service.ts
@@ -37,7 +37,6 @@ import {
 import { resolveClauseSlots } from "@/api/handlers/docx/resolve-clause-slots";
 import { readManifest } from "@/api/handlers/docx/template-manifest";
 import type {
-  DiscoveredField,
   FieldDateFormat,
   FieldPart,
   InputType,
@@ -49,6 +48,7 @@ import { getS3 } from "@/api/lib/s3";
 import { buildBindingContext } from "@/api/lib/template-binding/build-binding-context";
 
 import {
+  collectRawTemplateTerminalPaths,
   collectTemplateInputKeys,
   findUnusedTemplateValueKeys,
   isFillableTemplateInputField,
@@ -60,29 +60,6 @@ import {
 type FillValues = Record<string, unknown>;
 
 type UnusedValuePolicy = "allow" | "reject";
-
-const collectDiscoveredTerminalPaths = (
-  fields: readonly DiscoveredField[],
-): string[] => {
-  const terminalPaths: string[] = [];
-
-  const visit = (field: DiscoveredField, parentPath: string): void => {
-    const path = parentPath === "" ? field.path : `${parentPath}.${field.path}`;
-    if (field.kind !== "object" && field.kind !== "array") {
-      terminalPaths.push(path);
-    }
-    if (field.itemFields !== undefined) {
-      for (const itemField of field.itemFields) {
-        visit(itemField, path);
-      }
-    }
-  };
-
-  for (const field of fields) {
-    visit(field, "");
-  }
-  return terminalPaths;
-};
 
 type TemplateInputRejection = {
   type: "unused-values";
@@ -335,10 +312,12 @@ const fillTemplateDocxWithPolicy = async <TRejection = never>({
 
   if (unusedValuePolicy === "reject") {
     const discovered = await discoverTemplate(loaded.buffer);
-    const terminalPaths = [
-      ...collectDiscoveredTerminalPaths(discovered.fields),
-      ...discovered.placeholders.map((placeholder) => placeholder.name),
-    ];
+    const terminalPaths = collectRawTemplateTerminalPaths({
+      fields: discovered.fields,
+      placeholderPaths: discovered.placeholders.map(
+        (placeholder) => placeholder.name,
+      ),
+    });
     const inputContract =
       manifest === null
         ? collectTemplateInputKeys({

--- a/apps/api/src/handlers/templates/template-fill-service.ts
+++ b/apps/api/src/handlers/templates/template-fill-service.ts
@@ -341,6 +341,7 @@ const fillTemplateDocxWithPolicy = async <TRejection = never>({
               .filter(isFillableTemplateInputField)
               .map((field) => field.path),
             livePaths: rawInputSources.terminalPaths,
+            arrayPaths: rawInputSources.arrayPaths,
             primitiveArrayPaths: rawInputSources.primitiveArrayPaths,
           });
     const unusedKeys = findUnusedTemplateValueKeys({

--- a/apps/api/src/handlers/templates/template-fill-service.ts
+++ b/apps/api/src/handlers/templates/template-fill-service.ts
@@ -47,10 +47,24 @@ import type { SafeId } from "@/api/lib/branded-types";
 import { getS3 } from "@/api/lib/s3";
 import { buildBindingContext } from "@/api/lib/template-binding/build-binding-context";
 
+import { findUnusedTemplateValueKeys } from "./template-input-contract";
+
 // Data a template is filled with: open-ended field-path → value map (paths come
 // from the template's manifest/markers, not a fixed entity), patched in place
 // with resolved clause slots and AI-drafted fields before fill.
 type FillValues = Record<string, unknown>;
+
+type UnusedValuePolicy = "allow" | "reject";
+
+type TemplateInputRejection = {
+  type: "unused-values";
+  keys: string[];
+};
+
+type FillRejection<TUsageRejection> =
+  | { error: string }
+  | { inputRejection: TemplateInputRejection }
+  | { usageRejection: TUsageRejection };
 
 const loadTemplate = async (
   templateId: SafeId<"template">,
@@ -264,6 +278,11 @@ type FillDocxOptions<TRejection = never> = Omit<
   source: FillTemplateSource;
 };
 
+type FillDocxWithPolicyOptions<TRejection = never> =
+  FillDocxOptions<TRejection> & {
+    unusedValuePolicy: UnusedValuePolicy;
+  };
+
 /**
  * Shared fill recipe over an already-loaded DOCX: resolve clause slots (stored
  * templates only), run the manifest fill steps (lookups, composites, formulas,
@@ -272,7 +291,7 @@ type FillDocxOptions<TRejection = never> = Omit<
  * fill below and the built-in report export, so a template fills identically at
  * every boundary.
  */
-export const fillTemplateDocx = async <TRejection = never>({
+const fillTemplateDocxWithPolicy = async <TRejection = never>({
   source,
   values,
   scopedDb,
@@ -283,11 +302,24 @@ export const fillTemplateDocx = async <TRejection = never>({
   adaptAiValue,
   assertUsageAvailable,
   workspaceId,
-}: FillDocxOptions<TRejection>): Promise<
-  FilledDocx | { error: string } | { usageRejection: TRejection }
+  unusedValuePolicy,
+}: FillDocxWithPolicyOptions<TRejection>): Promise<
+  FilledDocx | FillRejection<TRejection>
 > => {
   const loaded = source;
   const { templateId } = source;
+
+  if (unusedValuePolicy === "reject") {
+    const unusedKeys = await findUnusedTemplateValueKeys({
+      buffer: loaded.buffer,
+      values,
+    });
+    if (unusedKeys.length > 0) {
+      return {
+        inputRejection: { type: "unused-values", keys: unusedKeys },
+      };
+    }
+  }
 
   let record: FillValues = { ...values };
 
@@ -428,6 +460,27 @@ export const fillTemplateDocx = async <TRejection = never>({
   };
 };
 
+export const fillTemplateDocx = async <TRejection = never>(
+  options: FillDocxOptions<TRejection>,
+): Promise<FilledDocx | { error: string } | { usageRejection: TRejection }> => {
+  const filled = await fillTemplateDocxWithPolicy({
+    ...options,
+    unusedValuePolicy: "allow",
+  });
+  if ("inputRejection" in filled) {
+    panic("allow-policy template fill returned an input rejection");
+  }
+  return filled;
+};
+
+export const fillTemplateDocxStrict = async <TRejection = never>(
+  options: FillDocxOptions<TRejection>,
+): Promise<FilledDocx | FillRejection<TRejection>> =>
+  await fillTemplateDocxWithPolicy({
+    ...options,
+    unusedValuePolicy: "reject",
+  });
+
 /**
  * Load a stored template's DOCX from S3 and fill it via {@link fillTemplateDocx}.
  * Mirrors the fill-by-id route's pipeline so a stored template fills identically
@@ -486,19 +539,15 @@ export type FillTemplateWithDocxResult =
     }
   | { error: string };
 
-export const fillStoredTemplateWithText = async <TRejection = never>(
-  options: FillServiceOptions<TRejection>,
-): Promise<FillTemplateWithDocxResult | { usageRejection: TRejection }> => {
-  const filled = await fillStoredTemplateDocx(options);
-  if ("usageRejection" in filled) {
-    return filled;
-  }
-  if ("error" in filled) {
-    return filled;
-  }
+type FilledTemplateWithText = Exclude<
+  FillTemplateWithDocxResult,
+  { error: string }
+>;
 
+const withExtractedText = async (
+  filled: FilledDocx,
+): Promise<FilledTemplateWithText> => {
   const { paragraphs } = await extractText(filled.buffer);
-
   return {
     templateName: filled.templateName,
     fileName: filled.fileName,
@@ -510,6 +559,45 @@ export const fillStoredTemplateWithText = async <TRejection = never>(
     unmatchedPlaceholders: filled.unmatchedPlaceholders,
     unusedValues: filled.unusedValues,
   };
+};
+
+export const fillStoredTemplateWithText = async <TRejection = never>(
+  options: FillServiceOptions<TRejection>,
+): Promise<FillTemplateWithDocxResult | { usageRejection: TRejection }> => {
+  const filled = await fillStoredTemplateDocx(options);
+  if ("usageRejection" in filled) {
+    return filled;
+  }
+  if ("error" in filled) {
+    return filled;
+  }
+
+  return await withExtractedText(filled);
+};
+
+export const fillStoredTemplateWithTextStrict = async <TRejection = never>(
+  options: FillServiceOptions<TRejection>,
+): Promise<
+  | FillTemplateWithDocxResult
+  | { inputRejection: TemplateInputRejection }
+  | { usageRejection: TRejection }
+> => {
+  const loaded = await loadTemplate(options.templateId, options.scopedDb);
+  if (!loaded) {
+    return { error: "Template not found." };
+  }
+  const filled = await fillTemplateDocxStrict({
+    ...options,
+    source: { ...loaded, templateId: options.templateId },
+  });
+  if ("usageRejection" in filled || "inputRejection" in filled) {
+    return filled;
+  }
+  if ("error" in filled) {
+    return filled;
+  }
+
+  return await withExtractedText(filled);
 };
 
 export const fillStoredTemplate = async (

--- a/apps/api/src/handlers/templates/template-fill-service.ts
+++ b/apps/api/src/handlers/templates/template-fill-service.ts
@@ -48,7 +48,7 @@ import { getS3 } from "@/api/lib/s3";
 import { buildBindingContext } from "@/api/lib/template-binding/build-binding-context";
 
 import {
-  collectRawTemplateTerminalPaths,
+  collectRawTemplateInputSources,
   collectTemplateInputKeys,
   findUnusedTemplateValueKeys,
   isFillableTemplateInputField,
@@ -312,7 +312,7 @@ const fillTemplateDocxWithPolicy = async <TRejection = never>({
 
   if (unusedValuePolicy === "reject") {
     const discovered = await discoverTemplate(loaded.buffer);
-    const terminalPaths = collectRawTemplateTerminalPaths({
+    const rawInputSources = collectRawTemplateInputSources({
       fields: discovered.fields,
       placeholderPaths: discovered.placeholders.map(
         (placeholder) => placeholder.name,
@@ -322,7 +322,7 @@ const fillTemplateDocxWithPolicy = async <TRejection = never>({
       manifest === null
         ? collectTemplateInputKeys({
             type: "raw",
-            terminalPaths,
+            ...rawInputSources,
           })
         : collectTemplateInputKeys({
             type: "manifest",
@@ -340,7 +340,8 @@ const fillTemplateDocxWithPolicy = async <TRejection = never>({
             fillableFieldPaths: manifest.fields
               .filter(isFillableTemplateInputField)
               .map((field) => field.path),
-            livePaths: terminalPaths,
+            livePaths: rawInputSources.terminalPaths,
+            primitiveArrayPaths: rawInputSources.primitiveArrayPaths,
           });
     const unusedKeys = findUnusedTemplateValueKeys({
       contract: inputContract,

--- a/apps/api/src/handlers/templates/template-input-contract.test.ts
+++ b/apps/api/src/handlers/templates/template-input-contract.test.ts
@@ -4,7 +4,7 @@ import fc from "fast-check";
 import { propertyConfig } from "@stll/property-testing";
 
 import {
-  collectRawTemplateTerminalPaths,
+  collectRawTemplateInputSources,
   collectTemplateInputKeys,
   findUnusedTemplateValueKeys,
   isFillableTemplateInputField,
@@ -19,6 +19,7 @@ const contractFor = (
 ): TemplateInputContract => ({
   acceptedPaths: new Set(acceptedPaths),
   forbiddenPaths: new Set(),
+  primitiveArrayPaths: new Set(),
 });
 const DECLARED_CONTRACT = contractFor(DECLARED_KEYS);
 
@@ -35,20 +36,22 @@ describe("template input contract", () => {
   test("raw templates accept every live discovered path", () => {
     const contract = collectTemplateInputKeys({
       type: "raw",
+      primitiveArrayPaths: [],
       terminalPaths: ["client.name", "signature_date"],
     });
     expect(contract.acceptedPaths).toEqual(
       new Set(["client.name", "signature_date"]),
     );
     expect(contract.forbiddenPaths).toEqual(new Set());
+    expect(contract.primitiveArrayPaths).toEqual(new Set());
   });
 
   test("raw static loops accept an array root with no item fields", () => {
-    const terminalPaths = collectRawTemplateTerminalPaths({
+    const sources = collectRawTemplateInputSources({
       fields: [{ path: "rows", kind: "array", itemFields: [] }],
       placeholderPaths: [],
     });
-    const contract = collectTemplateInputKeys({ type: "raw", terminalPaths });
+    const contract = collectTemplateInputKeys({ type: "raw", ...sources });
     expect(
       findUnusedTemplateValueKeys({
         contract,
@@ -58,7 +61,7 @@ describe("template input contract", () => {
   });
 
   test("raw loops with item fields keep their array root recursion-only", () => {
-    const terminalPaths = collectRawTemplateTerminalPaths({
+    const sources = collectRawTemplateInputSources({
       fields: [
         {
           path: "rows",
@@ -68,8 +71,11 @@ describe("template input contract", () => {
       ],
       placeholderPaths: [],
     });
-    expect(terminalPaths).toEqual(["rows.name"]);
-    const contract = collectTemplateInputKeys({ type: "raw", terminalPaths });
+    expect(sources).toEqual({
+      primitiveArrayPaths: [],
+      terminalPaths: ["rows.name"],
+    });
+    const contract = collectTemplateInputKeys({ type: "raw", ...sources });
     expect(
       findUnusedTemplateValueKeys({
         contract,
@@ -78,11 +84,45 @@ describe("template input contract", () => {
     ).toEqual([]);
   });
 
+  test("raw value loops explicitly accept supported primitive rows", () => {
+    const sources = collectRawTemplateInputSources({
+      fields: [
+        {
+          path: "tags",
+          kind: "array",
+          itemFields: [{ path: "value", kind: "string" }],
+        },
+      ],
+      placeholderPaths: ["tags.value"],
+    });
+    expect(sources).toEqual({
+      primitiveArrayPaths: ["tags"],
+      terminalPaths: ["tags.value", "tags.value"],
+    });
+    const contract = collectTemplateInputKeys({ type: "raw", ...sources });
+
+    fc.assert(
+      fc.property(
+        fc.array(fc.oneof(fc.string(), fc.integer(), fc.boolean())),
+        (tags) => {
+          expect(
+            findUnusedTemplateValueKeys({ contract, values: { tags } }),
+          ).toEqual([]);
+        },
+      ),
+      propertyConfig(),
+    );
+    expect(
+      findUnusedTemplateValueKeys({ contract, values: { tags: [null] } }),
+    ).toEqual(["tags"]);
+  });
+
   test("manifest templates accept live descendants but exclude derived outputs", () => {
     const contract = collectTemplateInputKeys({
       type: "manifest",
       derivedOutputPaths: ["company.full", "rent_annual"],
       fillableFieldPaths: ["company", "rent"],
+      primitiveArrayPaths: [],
       livePaths: [
         "company",
         "company.full",
@@ -105,6 +145,7 @@ describe("template input contract", () => {
       type: "manifest",
       derivedOutputPaths: ["company.full"],
       fillableFieldPaths: ["company"],
+      primitiveArrayPaths: [],
       livePaths: ["company.full.address"],
     });
     expect(contract.acceptedPaths).toEqual(new Set(["company"]));
@@ -116,6 +157,7 @@ describe("template input contract", () => {
       type: "manifest",
       derivedOutputPaths: [],
       fillableFieldPaths: ["company"],
+      primitiveArrayPaths: [],
       livePaths: ["unlisted.value"],
     });
     expect(contract.acceptedPaths).toEqual(new Set(["company"]));
@@ -126,6 +168,7 @@ describe("template input contract", () => {
       type: "manifest",
       derivedOutputPaths: [],
       fillableFieldPaths: ["client.type", "rent"],
+      primitiveArrayPaths: [],
       livePaths: [],
     });
     expect(contract.acceptedPaths).toEqual(new Set(["client.type", "rent"]));
@@ -134,6 +177,7 @@ describe("template input contract", () => {
   test("raw and manifest input policies are discriminated", () => {
     const raw = collectTemplateInputKeys({
       type: "raw",
+      primitiveArrayPaths: [],
       terminalPaths: ["company.full"],
     });
     expect(raw.acceptedPaths).toEqual(new Set(["company.full"]));
@@ -141,6 +185,7 @@ describe("template input contract", () => {
       type: "manifest",
       derivedOutputPaths: ["company.full"],
       fillableFieldPaths: ["company"],
+      primitiveArrayPaths: [],
       livePaths: ["company.full"],
     });
     expect(manifest.acceptedPaths).toEqual(new Set(["company"]));
@@ -152,6 +197,7 @@ describe("template input contract", () => {
       type: "manifest",
       derivedOutputPaths: [],
       fillableFieldPaths: ["company"],
+      primitiveArrayPaths: [],
       livePaths: ["company.seat"],
     });
     expect(
@@ -171,6 +217,7 @@ describe("template input contract", () => {
   test("raw structural namespaces reject leaf values", () => {
     const contract = collectTemplateInputKeys({
       type: "raw",
+      primitiveArrayPaths: [],
       terminalPaths: ["company.name"],
     });
     expect(
@@ -192,6 +239,7 @@ describe("template input contract", () => {
       type: "manifest",
       derivedOutputPaths: ["company.seat"],
       fillableFieldPaths: ["company"],
+      primitiveArrayPaths: [],
       livePaths: ["company.seat"],
     });
     expect(
@@ -278,6 +326,7 @@ describe("template input contract", () => {
         contract: {
           acceptedPaths: new Set(["items"]),
           forbiddenPaths: new Set(["items.total"]),
+          primitiveArrayPaths: new Set(),
         },
         values: { items: ["invalid"] },
       }),

--- a/apps/api/src/handlers/templates/template-input-contract.test.ts
+++ b/apps/api/src/handlers/templates/template-input-contract.test.ts
@@ -117,6 +117,28 @@ describe("template input contract", () => {
     ).toEqual(["tags"]);
   });
 
+  test("raw dotted value loops preserve their nested primitive contract", () => {
+    const sources = collectRawTemplateInputSources({
+      fields: [
+        {
+          path: "deal.tags",
+          kind: "array",
+          itemFields: [{ path: "value", kind: "string" }],
+        },
+      ],
+      placeholderPaths: ["deal.tags.value"],
+    });
+    expect(sources.primitiveArrayPaths).toEqual(["deal.tags"]);
+
+    const contract = collectTemplateInputKeys({ type: "raw", ...sources });
+    expect(
+      findUnusedTemplateValueKeys({
+        contract,
+        values: { deal: { tags: ["urgent"] } },
+      }),
+    ).toEqual([]);
+  });
+
   test("manifest templates accept live descendants but exclude derived outputs", () => {
     const contract = collectTemplateInputKeys({
       type: "manifest",

--- a/apps/api/src/handlers/templates/template-input-contract.test.ts
+++ b/apps/api/src/handlers/templates/template-input-contract.test.ts
@@ -18,6 +18,7 @@ const contractFor = (
   acceptedPaths: Iterable<string>,
 ): TemplateInputContract => ({
   acceptedPaths: new Set(acceptedPaths),
+  arrayPaths: new Set(),
   forbiddenPaths: new Set(),
   primitiveArrayPaths: new Set(),
 });
@@ -36,6 +37,7 @@ describe("template input contract", () => {
   test("raw templates accept every live discovered path", () => {
     const contract = collectTemplateInputKeys({
       type: "raw",
+      arrayPaths: [],
       primitiveArrayPaths: [],
       terminalPaths: ["client.name", "signature_date"],
     });
@@ -72,6 +74,7 @@ describe("template input contract", () => {
       placeholderPaths: [],
     });
     expect(sources).toEqual({
+      arrayPaths: ["rows"],
       primitiveArrayPaths: [],
       terminalPaths: ["rows.name"],
     });
@@ -82,6 +85,23 @@ describe("template input contract", () => {
         values: { rows: [{ name: "Ada" }] },
       }),
     ).toEqual([]);
+    expect(
+      findUnusedTemplateValueKeys({
+        contract,
+        values: { "rows.name": "Ada" },
+      }),
+    ).toEqual(["rows.name"]);
+    fc.assert(
+      fc.property(
+        fc.jsonValue().filter((value) => !Array.isArray(value)),
+        (rows) => {
+          expect(
+            findUnusedTemplateValueKeys({ contract, values: { rows } }),
+          ).toEqual(["rows"]);
+        },
+      ),
+      propertyConfig(),
+    );
   });
 
   test("raw value loops explicitly accept supported primitive rows", () => {
@@ -96,6 +116,7 @@ describe("template input contract", () => {
       placeholderPaths: ["tags.value"],
     });
     expect(sources).toEqual({
+      arrayPaths: ["tags"],
       primitiveArrayPaths: ["tags"],
       terminalPaths: ["tags.value", "tags.value"],
     });
@@ -129,6 +150,7 @@ describe("template input contract", () => {
       placeholderPaths: ["deal.tags.value"],
     });
     expect(sources.primitiveArrayPaths).toEqual(["deal.tags"]);
+    expect(sources.arrayPaths).toEqual(["deal.tags"]);
 
     const contract = collectTemplateInputKeys({ type: "raw", ...sources });
     expect(
@@ -199,6 +221,7 @@ describe("template input contract", () => {
   test("manifest templates accept live descendants but exclude derived outputs", () => {
     const contract = collectTemplateInputKeys({
       type: "manifest",
+      arrayPaths: [],
       derivedOutputPaths: ["company.full", "rent_annual"],
       fillableFieldPaths: ["company", "rent"],
       primitiveArrayPaths: [],
@@ -222,6 +245,7 @@ describe("template input contract", () => {
   test("manifest derived subtrees cannot leak through deeper live markers", () => {
     const contract = collectTemplateInputKeys({
       type: "manifest",
+      arrayPaths: [],
       derivedOutputPaths: ["company.full"],
       fillableFieldPaths: ["company"],
       primitiveArrayPaths: [],
@@ -234,6 +258,7 @@ describe("template input contract", () => {
   test("manifest paths cannot be accepted outside a fillable root", () => {
     const contract = collectTemplateInputKeys({
       type: "manifest",
+      arrayPaths: [],
       derivedOutputPaths: [],
       fillableFieldPaths: ["company"],
       primitiveArrayPaths: [],
@@ -245,6 +270,7 @@ describe("template input contract", () => {
   test("manifest-only fillable fields remain accepted", () => {
     const contract = collectTemplateInputKeys({
       type: "manifest",
+      arrayPaths: [],
       derivedOutputPaths: [],
       fillableFieldPaths: ["client.type", "rent"],
       primitiveArrayPaths: [],
@@ -256,12 +282,14 @@ describe("template input contract", () => {
   test("raw and manifest input policies are discriminated", () => {
     const raw = collectTemplateInputKeys({
       type: "raw",
+      arrayPaths: [],
       primitiveArrayPaths: [],
       terminalPaths: ["company.full"],
     });
     expect(raw.acceptedPaths).toEqual(new Set(["company.full"]));
     const manifest = collectTemplateInputKeys({
       type: "manifest",
+      arrayPaths: [],
       derivedOutputPaths: ["company.full"],
       fillableFieldPaths: ["company"],
       primitiveArrayPaths: [],
@@ -274,6 +302,7 @@ describe("template input contract", () => {
   test("manifest nested live paths support flattened input", () => {
     const contract = collectTemplateInputKeys({
       type: "manifest",
+      arrayPaths: [],
       derivedOutputPaths: [],
       fillableFieldPaths: ["company"],
       primitiveArrayPaths: [],
@@ -296,6 +325,7 @@ describe("template input contract", () => {
   test("raw structural namespaces reject leaf values", () => {
     const contract = collectTemplateInputKeys({
       type: "raw",
+      arrayPaths: [],
       primitiveArrayPaths: [],
       terminalPaths: ["company.name"],
     });
@@ -316,6 +346,7 @@ describe("template input contract", () => {
   test("forbidden derived paths win through nested and flattened input", () => {
     const contract = collectTemplateInputKeys({
       type: "manifest",
+      arrayPaths: [],
       derivedOutputPaths: ["company.seat"],
       fillableFieldPaths: ["company"],
       primitiveArrayPaths: [],
@@ -404,12 +435,37 @@ describe("template input contract", () => {
       findUnusedTemplateValueKeys({
         contract: {
           acceptedPaths: new Set(["items"]),
+          arrayPaths: new Set(["items"]),
           forbiddenPaths: new Set(["items.total"]),
           primitiveArrayPaths: new Set(),
         },
         values: { items: ["invalid"] },
       }),
     ).toEqual(["items"]);
+  });
+
+  test("INVARIANT: loop descendants require their array container", () => {
+    fc.assert(
+      fc.property(
+        fc.constantFrom("name", "address.city", "value"),
+        fc.jsonValue(),
+        (field, value) => {
+          const path = `items.${field}`;
+          expect(
+            findUnusedTemplateValueKeys({
+              contract: {
+                acceptedPaths: new Set([path]),
+                arrayPaths: new Set(["items"]),
+                forbiddenPaths: new Set(),
+                primitiveArrayPaths: new Set(),
+              },
+              values: { [path]: value },
+            }),
+          ).toEqual([path]);
+        },
+      ),
+      propertyConfig(),
+    );
   });
 
   test("INVARIANT: value shape cannot change whether an unknown key is rejected", () => {

--- a/apps/api/src/handlers/templates/template-input-contract.test.ts
+++ b/apps/api/src/handlers/templates/template-input-contract.test.ts
@@ -1,46 +1,32 @@
 import { describe, expect, test } from "bun:test";
 import fc from "fast-check";
-import JSZip from "jszip";
 
 import { propertyConfig } from "@stll/property-testing";
 
 import { findUnusedTemplateValueKeys } from "./template-input-contract";
 
-const W_NS = "http://schemas.openxmlformats.org/wordprocessingml/2006/main";
-
-const makeTemplate = async (): Promise<Buffer> => {
-  const zip = new JSZip();
-  zip.file(
-    "word/document.xml",
-    `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
-      `<w:document xmlns:w="${W_NS}"><w:body>` +
-      `<w:p><w:r><w:t>{{name}}</w:t></w:r></w:p>` +
-      `<w:p><w:r><w:t>{{company.name}}</w:t></w:r></w:p>` +
-      `</w:body></w:document>`,
-  );
-  return await zip.generateAsync({ type: "nodebuffer" });
-};
+const DECLARED_KEYS = ["name", "company.name"] as const;
 
 describe("template input contract", () => {
-  test("accepts top-level and flattened declared paths", async () => {
+  test("accepts top-level and flattened declared paths", () => {
     expect(
-      await findUnusedTemplateValueKeys({
-        buffer: await makeTemplate(),
+      findUnusedTemplateValueKeys({
+        declaredKeys: DECLARED_KEYS,
         values: { name: "Ada", company: { name: "Stella" } },
       }),
     ).toEqual([]);
     expect(
-      await findUnusedTemplateValueKeys({
-        buffer: await makeTemplate(),
+      findUnusedTemplateValueKeys({
+        declaredKeys: DECLARED_KEYS,
         values: { "company.name": "Stella" },
       }),
     ).toEqual([]);
   });
 
-  test("rejects extra keys independently of every supported value type", async () => {
+  test("rejects extra keys independently of every supported value type", () => {
     expect(
-      await findUnusedTemplateValueKeys({
-        buffer: await makeTemplate(),
+      findUnusedTemplateValueKeys({
+        declaredKeys: DECLARED_KEYS,
         values: {
           name: "Ada",
           typoString: "value",
@@ -59,13 +45,21 @@ describe("template input contract", () => {
     ]);
   });
 
-  test("INVARIANT: value shape cannot change whether an unknown key is rejected", async () => {
-    const buffer = await makeTemplate();
-    await fc.assert(
-      fc.asyncProperty(fc.jsonValue(), async (value) => {
+  test("rejects unknown leaves inside declared namespaces", () => {
+    expect(
+      findUnusedTemplateValueKeys({
+        declaredKeys: DECLARED_KEYS,
+        values: { company: { name: "Stella", namme: "typo" } },
+      }),
+    ).toEqual(["company.namme"]);
+  });
+
+  test("INVARIANT: value shape cannot change whether an unknown key is rejected", () => {
+    fc.assert(
+      fc.property(fc.jsonValue(), (value) => {
         expect(
-          await findUnusedTemplateValueKeys({
-            buffer,
+          findUnusedTemplateValueKeys({
+            declaredKeys: DECLARED_KEYS,
             values: { unknown: value },
           }),
         ).toEqual(["unknown"]);

--- a/apps/api/src/handlers/templates/template-input-contract.test.ts
+++ b/apps/api/src/handlers/templates/template-input-contract.test.ts
@@ -70,7 +70,7 @@ describe("template input contract", () => {
           }),
         ).toEqual(["unknown"]);
       }),
-      propertyConfig,
+      propertyConfig(),
     );
   });
 });

--- a/apps/api/src/handlers/templates/template-input-contract.test.ts
+++ b/apps/api/src/handlers/templates/template-input-contract.test.ts
@@ -341,6 +341,14 @@ describe("template input contract", () => {
         values: { company: { name: "Acme" } },
       }),
     ).toEqual([]);
+    fc.assert(
+      fc.property(fc.array(fc.jsonValue()), (company) => {
+        expect(
+          findUnusedTemplateValueKeys({ contract, values: { company } }),
+        ).toEqual(["company"]);
+      }),
+      propertyConfig(),
+    );
   });
 
   test("forbidden derived paths win through nested and flattened input", () => {
@@ -415,7 +423,10 @@ describe("template input contract", () => {
   test("rejects unknown leaves inside repeated namespace rows", () => {
     expect(
       findUnusedTemplateValueKeys({
-        contract: contractFor(["sellers", "sellers.name"]),
+        contract: {
+          ...contractFor(["sellers", "sellers.name"]),
+          arrayPaths: new Set(["sellers"]),
+        },
         values: { sellers: [{ name: "Ada" }, { namme: "Grace" }] },
       }),
     ).toEqual(["sellers.namme"]);

--- a/apps/api/src/handlers/templates/template-input-contract.test.ts
+++ b/apps/api/src/handlers/templates/template-input-contract.test.ts
@@ -3,13 +3,28 @@ import fc from "fast-check";
 
 import { propertyConfig } from "@stll/property-testing";
 
-import { findUnusedTemplateValueKeys } from "./template-input-contract";
+import {
+  collectTemplateInputKeys,
+  findUnusedTemplateValueKeys,
+} from "./template-input-contract";
 
 // Discovery emits structural object roots as fields alongside terminal
 // placeholders, so production declares both `company` and `company.name`.
 const DECLARED_KEYS = ["name", "company", "company.name"] as const;
 
 describe("template input contract", () => {
+  test("combines discovery, placeholders, and manifest-only fields", () => {
+    expect(
+      collectTemplateInputKeys({
+        discoveredFieldPaths: ["client.name"],
+        manifestFieldPaths: ["rent", "rent_annual"],
+        placeholderPaths: ["signature_date"],
+      }),
+    ).toEqual(
+      new Set(["client.name", "rent", "rent_annual", "signature_date"]),
+    );
+  });
+
   test("accepts top-level and flattened declared paths", () => {
     expect(
       findUnusedTemplateValueKeys({
@@ -54,6 +69,15 @@ describe("template input contract", () => {
         values: { company: { name: "Stella", namme: "typo" } },
       }),
     ).toEqual(["company.namme"]);
+  });
+
+  test("rejects unknown leaves inside repeated namespace rows", () => {
+    expect(
+      findUnusedTemplateValueKeys({
+        declaredKeys: ["sellers", "sellers.name"],
+        values: { sellers: [{ name: "Ada" }, { namme: "Grace" }] },
+      }),
+    ).toEqual(["sellers.namme"]);
   });
 
   test("INVARIANT: value shape cannot change whether an unknown key is rejected", () => {

--- a/apps/api/src/handlers/templates/template-input-contract.test.ts
+++ b/apps/api/src/handlers/templates/template-input-contract.test.ts
@@ -6,6 +6,7 @@ import { propertyConfig } from "@stll/property-testing";
 import {
   collectTemplateInputKeys,
   findUnusedTemplateValueKeys,
+  isFillableTemplateInputField,
 } from "./template-input-contract";
 
 // Discovery emits structural object roots as fields alongside terminal
@@ -13,6 +14,15 @@ import {
 const DECLARED_KEYS = ["name", "company", "company.name"] as const;
 
 describe("template input contract", () => {
+  test("uses one fillable-field predicate for listing and strict input", () => {
+    expect(isFillableTemplateInputField({})).toBe(true);
+    expect(isFillableTemplateInputField({ formula: "rent * 12" })).toBe(false);
+    expect(isFillableTemplateInputField({ condition: "client.type" })).toBe(
+      false,
+    );
+    expect(isFillableTemplateInputField({ conditionAst: {} })).toBe(false);
+  });
+
   test("combines discovery, placeholders, and manifest-only fields", () => {
     expect(
       collectTemplateInputKeys({

--- a/apps/api/src/handlers/templates/template-input-contract.test.ts
+++ b/apps/api/src/handlers/templates/template-input-contract.test.ts
@@ -208,6 +208,27 @@ describe("template input contract", () => {
     ).toEqual(["sellers.namme"]);
   });
 
+  test("rejects primitive rows in an accepted-descendant namespace", () => {
+    expect(
+      findUnusedTemplateValueKeys({
+        contract: contractFor(["items.name"]),
+        values: { items: ["invalid"] },
+      }),
+    ).toEqual(["items"]);
+  });
+
+  test("rejects primitive rows in a forbidden-descendant namespace", () => {
+    expect(
+      findUnusedTemplateValueKeys({
+        contract: {
+          acceptedPaths: new Set(["items"]),
+          forbiddenPaths: new Set(["items.total"]),
+        },
+        values: { items: ["invalid"] },
+      }),
+    ).toEqual(["items"]);
+  });
+
   test("INVARIANT: value shape cannot change whether an unknown key is rejected", () => {
     fc.assert(
       fc.property(fc.jsonValue(), (value) => {

--- a/apps/api/src/handlers/templates/template-input-contract.test.ts
+++ b/apps/api/src/handlers/templates/template-input-contract.test.ts
@@ -4,6 +4,7 @@ import fc from "fast-check";
 import { propertyConfig } from "@stll/property-testing";
 
 import {
+  collectRawTemplateTerminalPaths,
   collectTemplateInputKeys,
   findUnusedTemplateValueKeys,
   isFillableTemplateInputField,
@@ -40,6 +41,41 @@ describe("template input contract", () => {
       new Set(["client.name", "signature_date"]),
     );
     expect(contract.forbiddenPaths).toEqual(new Set());
+  });
+
+  test("raw static loops accept an array root with no item fields", () => {
+    const terminalPaths = collectRawTemplateTerminalPaths({
+      fields: [{ path: "rows", kind: "array", itemFields: [] }],
+      placeholderPaths: [],
+    });
+    const contract = collectTemplateInputKeys({ type: "raw", terminalPaths });
+    expect(
+      findUnusedTemplateValueKeys({
+        contract,
+        values: { rows: [{}, {}] },
+      }),
+    ).toEqual([]);
+  });
+
+  test("raw loops with item fields keep their array root recursion-only", () => {
+    const terminalPaths = collectRawTemplateTerminalPaths({
+      fields: [
+        {
+          path: "rows",
+          kind: "array",
+          itemFields: [{ path: "name", kind: "string" }],
+        },
+      ],
+      placeholderPaths: [],
+    });
+    expect(terminalPaths).toEqual(["rows.name"]);
+    const contract = collectTemplateInputKeys({ type: "raw", terminalPaths });
+    expect(
+      findUnusedTemplateValueKeys({
+        contract,
+        values: { rows: [{ name: "Ada" }] },
+      }),
+    ).toEqual([]);
   });
 
   test("manifest templates accept live descendants but exclude derived outputs", () => {

--- a/apps/api/src/handlers/templates/template-input-contract.test.ts
+++ b/apps/api/src/handlers/templates/template-input-contract.test.ts
@@ -23,22 +23,102 @@ describe("template input contract", () => {
     expect(isFillableTemplateInputField({ conditionAst: {} })).toBe(false);
   });
 
-  test("combines discovery, placeholders, and manifest-only fields", () => {
+  test("raw templates accept every live discovered path", () => {
     expect(
       collectTemplateInputKeys({
-        discoveredFieldPaths: ["client.name"],
-        manifestFieldPaths: ["client.type", "rent", "rent_annual"],
-        placeholderPaths: ["signature_date"],
+        type: "raw",
+        livePaths: ["client.name", "signature_date"],
       }),
-    ).toEqual(
-      new Set([
-        "client.name",
-        "client.type",
-        "rent",
-        "rent_annual",
-        "signature_date",
-      ]),
-    );
+    ).toEqual(new Set(["client.name", "signature_date"]));
+  });
+
+  test("manifest templates accept live descendants but exclude derived outputs", () => {
+    expect(
+      collectTemplateInputKeys({
+        type: "manifest",
+        derivedOutputPaths: ["company.full", "rent_annual"],
+        fillableFieldPaths: ["company", "rent"],
+        livePaths: [
+          "company",
+          "company.full",
+          "company.seat",
+          "rent",
+          "rent_annual",
+          "unlisted",
+        ],
+      }),
+    ).toEqual(new Set(["company", "company.seat", "rent"]));
+  });
+
+  test("manifest derived subtrees cannot leak through deeper live markers", () => {
+    expect(
+      collectTemplateInputKeys({
+        type: "manifest",
+        derivedOutputPaths: ["company.full"],
+        fillableFieldPaths: ["company"],
+        livePaths: ["company.full.address"],
+      }),
+    ).toEqual(new Set(["company"]));
+  });
+
+  test("manifest paths cannot be accepted outside a fillable root", () => {
+    expect(
+      collectTemplateInputKeys({
+        type: "manifest",
+        derivedOutputPaths: [],
+        fillableFieldPaths: ["company"],
+        livePaths: ["unlisted.value"],
+      }),
+    ).toEqual(new Set(["company"]));
+  });
+
+  test("manifest-only fillable fields remain accepted", () => {
+    expect(
+      collectTemplateInputKeys({
+        type: "manifest",
+        derivedOutputPaths: [],
+        fillableFieldPaths: ["client.type", "rent"],
+        livePaths: [],
+      }),
+    ).toEqual(new Set(["client.type", "rent"]));
+  });
+
+  test("raw and manifest input policies are discriminated", () => {
+    expect(
+      collectTemplateInputKeys({
+        type: "raw",
+        livePaths: ["company.full"],
+      }),
+    ).toEqual(new Set(["company.full"]));
+    expect(
+      collectTemplateInputKeys({
+        type: "manifest",
+        derivedOutputPaths: ["company.full"],
+        fillableFieldPaths: ["company"],
+        livePaths: ["company.full"],
+      }),
+    ).toEqual(new Set(["company"]));
+  });
+
+  test("manifest nested live paths support flattened input", () => {
+    const declaredKeys = collectTemplateInputKeys({
+      type: "manifest",
+      derivedOutputPaths: [],
+      fillableFieldPaths: ["company"],
+      livePaths: ["company.seat"],
+    });
+    expect(
+      findUnusedTemplateValueKeys({
+        declaredKeys,
+        values: { "company.seat": "Prague" },
+      }),
+    ).toEqual([]);
+    expect(
+      findUnusedTemplateValueKeys({
+        declaredKeys,
+        values: { company: { namme: "typo" } },
+      }),
+    ).toEqual(["company.namme"]);
   });
 
   test("accepts top-level and flattened declared paths", () => {

--- a/apps/api/src/handlers/templates/template-input-contract.test.ts
+++ b/apps/api/src/handlers/templates/template-input-contract.test.ts
@@ -17,11 +17,17 @@ describe("template input contract", () => {
     expect(
       collectTemplateInputKeys({
         discoveredFieldPaths: ["client.name"],
-        manifestFieldPaths: ["rent", "rent_annual"],
+        manifestFieldPaths: ["client.type", "rent", "rent_annual"],
         placeholderPaths: ["signature_date"],
       }),
     ).toEqual(
-      new Set(["client.name", "rent", "rent_annual", "signature_date"]),
+      new Set([
+        "client.name",
+        "client.type",
+        "rent",
+        "rent_annual",
+        "signature_date",
+      ]),
     );
   });
 

--- a/apps/api/src/handlers/templates/template-input-contract.test.ts
+++ b/apps/api/src/handlers/templates/template-input-contract.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from "bun:test";
+import fc from "fast-check";
+import JSZip from "jszip";
+
+import { propertyConfig } from "@stll/property-testing";
+
+import { findUnusedTemplateValueKeys } from "./template-input-contract";
+
+const W_NS = "http://schemas.openxmlformats.org/wordprocessingml/2006/main";
+
+const makeTemplate = async (): Promise<Buffer> => {
+  const zip = new JSZip();
+  zip.file(
+    "word/document.xml",
+    `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+      `<w:document xmlns:w="${W_NS}"><w:body>` +
+      `<w:p><w:r><w:t>{{name}}</w:t></w:r></w:p>` +
+      `<w:p><w:r><w:t>{{company.name}}</w:t></w:r></w:p>` +
+      `</w:body></w:document>`,
+  );
+  return await zip.generateAsync({ type: "nodebuffer" });
+};
+
+describe("template input contract", () => {
+  test("accepts top-level and flattened declared paths", async () => {
+    expect(
+      await findUnusedTemplateValueKeys({
+        buffer: await makeTemplate(),
+        values: { name: "Ada", company: { name: "Stella" } },
+      }),
+    ).toEqual([]);
+    expect(
+      await findUnusedTemplateValueKeys({
+        buffer: await makeTemplate(),
+        values: { "company.name": "Stella" },
+      }),
+    ).toEqual([]);
+  });
+
+  test("rejects extra keys independently of every supported value type", async () => {
+    expect(
+      await findUnusedTemplateValueKeys({
+        buffer: await makeTemplate(),
+        values: {
+          name: "Ada",
+          typoString: "value",
+          typoNumber: 1,
+          typoBoolean: true,
+          typoArray: ["value"],
+          typoObject: { nested: "value" },
+        },
+      }),
+    ).toEqual([
+      "typoString",
+      "typoNumber",
+      "typoBoolean",
+      "typoArray",
+      "typoObject",
+    ]);
+  });
+
+  test("INVARIANT: value shape cannot change whether an unknown key is rejected", async () => {
+    const buffer = await makeTemplate();
+    await fc.assert(
+      fc.asyncProperty(fc.jsonValue(), async (value) => {
+        expect(
+          await findUnusedTemplateValueKeys({
+            buffer,
+            values: { unknown: value },
+          }),
+        ).toEqual(["unknown"]);
+      }),
+      propertyConfig,
+    );
+  });
+});

--- a/apps/api/src/handlers/templates/template-input-contract.test.ts
+++ b/apps/api/src/handlers/templates/template-input-contract.test.ts
@@ -34,7 +34,7 @@ describe("template input contract", () => {
   test("raw templates accept every live discovered path", () => {
     const contract = collectTemplateInputKeys({
       type: "raw",
-      livePaths: ["client.name", "signature_date"],
+      terminalPaths: ["client.name", "signature_date"],
     });
     expect(contract.acceptedPaths).toEqual(
       new Set(["client.name", "signature_date"]),
@@ -98,7 +98,7 @@ describe("template input contract", () => {
   test("raw and manifest input policies are discriminated", () => {
     const raw = collectTemplateInputKeys({
       type: "raw",
-      livePaths: ["company.full"],
+      terminalPaths: ["company.full"],
     });
     expect(raw.acceptedPaths).toEqual(new Set(["company.full"]));
     const manifest = collectTemplateInputKeys({
@@ -130,6 +130,25 @@ describe("template input contract", () => {
         values: { company: { namme: "typo" } },
       }),
     ).toEqual(["company.namme"]);
+  });
+
+  test("raw structural namespaces reject leaf values", () => {
+    const contract = collectTemplateInputKeys({
+      type: "raw",
+      terminalPaths: ["company.name"],
+    });
+    expect(
+      findUnusedTemplateValueKeys({
+        contract,
+        values: { company: "Acme" },
+      }),
+    ).toEqual(["company"]);
+    expect(
+      findUnusedTemplateValueKeys({
+        contract,
+        values: { company: { name: "Acme" } },
+      }),
+    ).toEqual([]);
   });
 
   test("forbidden derived paths win through nested and flattened input", () => {

--- a/apps/api/src/handlers/templates/template-input-contract.test.ts
+++ b/apps/api/src/handlers/templates/template-input-contract.test.ts
@@ -479,6 +479,25 @@ describe("template input contract", () => {
     );
   });
 
+  test("INVARIANT: nested loop descendants cannot flatten inside an outer row", () => {
+    fc.assert(
+      fc.property(fc.jsonValue(), (value) => {
+        expect(
+          findUnusedTemplateValueKeys({
+            contract: {
+              acceptedPaths: new Set(["groups.items.name"]),
+              arrayPaths: new Set(["groups", "groups.items"]),
+              forbiddenPaths: new Set(),
+              primitiveArrayPaths: new Set(),
+            },
+            values: { groups: [{ "items.name": value }] },
+          }),
+        ).toEqual(["groups.items.name"]);
+      }),
+      propertyConfig(),
+    );
+  });
+
   test("INVARIANT: value shape cannot change whether an unknown key is rejected", () => {
     fc.assert(
       fc.property(fc.jsonValue(), (value) => {

--- a/apps/api/src/handlers/templates/template-input-contract.test.ts
+++ b/apps/api/src/handlers/templates/template-input-contract.test.ts
@@ -5,7 +5,9 @@ import { propertyConfig } from "@stll/property-testing";
 
 import { findUnusedTemplateValueKeys } from "./template-input-contract";
 
-const DECLARED_KEYS = ["name", "company.name"] as const;
+// Discovery emits structural object roots as fields alongside terminal
+// placeholders, so production declares both `company` and `company.name`.
+const DECLARED_KEYS = ["name", "company", "company.name"] as const;
 
 describe("template input contract", () => {
   test("accepts top-level and flattened declared paths", () => {
@@ -63,6 +65,20 @@ describe("template input contract", () => {
             values: { unknown: value },
           }),
         ).toEqual(["unknown"]);
+      }),
+      propertyConfig(),
+    );
+  });
+
+  test("INVARIANT: terminal fields accept every JSON value shape", () => {
+    fc.assert(
+      fc.property(fc.jsonValue(), (value) => {
+        expect(
+          findUnusedTemplateValueKeys({
+            declaredKeys: DECLARED_KEYS,
+            values: { name: value },
+          }),
+        ).toEqual([]);
       }),
       propertyConfig(),
     );

--- a/apps/api/src/handlers/templates/template-input-contract.test.ts
+++ b/apps/api/src/handlers/templates/template-input-contract.test.ts
@@ -7,11 +7,19 @@ import {
   collectTemplateInputKeys,
   findUnusedTemplateValueKeys,
   isFillableTemplateInputField,
+  type TemplateInputContract,
 } from "./template-input-contract";
 
 // Discovery emits structural object roots as fields alongside terminal
 // placeholders, so production declares both `company` and `company.name`.
 const DECLARED_KEYS = ["name", "company", "company.name"] as const;
+const contractFor = (
+  acceptedPaths: Iterable<string>,
+): TemplateInputContract => ({
+  acceptedPaths: new Set(acceptedPaths),
+  forbiddenPaths: new Set(),
+});
+const DECLARED_CONTRACT = contractFor(DECLARED_KEYS);
 
 describe("template input contract", () => {
   test("uses one fillable-field predicate for listing and strict input", () => {
@@ -24,84 +32,87 @@ describe("template input contract", () => {
   });
 
   test("raw templates accept every live discovered path", () => {
-    expect(
-      collectTemplateInputKeys({
-        type: "raw",
-        livePaths: ["client.name", "signature_date"],
-      }),
-    ).toEqual(new Set(["client.name", "signature_date"]));
+    const contract = collectTemplateInputKeys({
+      type: "raw",
+      livePaths: ["client.name", "signature_date"],
+    });
+    expect(contract.acceptedPaths).toEqual(
+      new Set(["client.name", "signature_date"]),
+    );
+    expect(contract.forbiddenPaths).toEqual(new Set());
   });
 
   test("manifest templates accept live descendants but exclude derived outputs", () => {
-    expect(
-      collectTemplateInputKeys({
-        type: "manifest",
-        derivedOutputPaths: ["company.full", "rent_annual"],
-        fillableFieldPaths: ["company", "rent"],
-        livePaths: [
-          "company",
-          "company.full",
-          "company.seat",
-          "rent",
-          "rent_annual",
-          "unlisted",
-        ],
-      }),
-    ).toEqual(new Set(["company", "company.seat", "rent"]));
+    const contract = collectTemplateInputKeys({
+      type: "manifest",
+      derivedOutputPaths: ["company.full", "rent_annual"],
+      fillableFieldPaths: ["company", "rent"],
+      livePaths: [
+        "company",
+        "company.full",
+        "company.seat",
+        "rent",
+        "rent_annual",
+        "unlisted",
+      ],
+    });
+    expect(contract.acceptedPaths).toEqual(
+      new Set(["company", "company.seat", "rent"]),
+    );
+    expect(contract.forbiddenPaths).toEqual(
+      new Set(["company.full", "rent_annual"]),
+    );
   });
 
   test("manifest derived subtrees cannot leak through deeper live markers", () => {
-    expect(
-      collectTemplateInputKeys({
-        type: "manifest",
-        derivedOutputPaths: ["company.full"],
-        fillableFieldPaths: ["company"],
-        livePaths: ["company.full.address"],
-      }),
-    ).toEqual(new Set(["company"]));
+    const contract = collectTemplateInputKeys({
+      type: "manifest",
+      derivedOutputPaths: ["company.full"],
+      fillableFieldPaths: ["company"],
+      livePaths: ["company.full.address"],
+    });
+    expect(contract.acceptedPaths).toEqual(new Set(["company"]));
+    expect(contract.forbiddenPaths).toEqual(new Set(["company.full"]));
   });
 
   test("manifest paths cannot be accepted outside a fillable root", () => {
-    expect(
-      collectTemplateInputKeys({
-        type: "manifest",
-        derivedOutputPaths: [],
-        fillableFieldPaths: ["company"],
-        livePaths: ["unlisted.value"],
-      }),
-    ).toEqual(new Set(["company"]));
+    const contract = collectTemplateInputKeys({
+      type: "manifest",
+      derivedOutputPaths: [],
+      fillableFieldPaths: ["company"],
+      livePaths: ["unlisted.value"],
+    });
+    expect(contract.acceptedPaths).toEqual(new Set(["company"]));
   });
 
   test("manifest-only fillable fields remain accepted", () => {
-    expect(
-      collectTemplateInputKeys({
-        type: "manifest",
-        derivedOutputPaths: [],
-        fillableFieldPaths: ["client.type", "rent"],
-        livePaths: [],
-      }),
-    ).toEqual(new Set(["client.type", "rent"]));
+    const contract = collectTemplateInputKeys({
+      type: "manifest",
+      derivedOutputPaths: [],
+      fillableFieldPaths: ["client.type", "rent"],
+      livePaths: [],
+    });
+    expect(contract.acceptedPaths).toEqual(new Set(["client.type", "rent"]));
   });
 
   test("raw and manifest input policies are discriminated", () => {
-    expect(
-      collectTemplateInputKeys({
-        type: "raw",
-        livePaths: ["company.full"],
-      }),
-    ).toEqual(new Set(["company.full"]));
-    expect(
-      collectTemplateInputKeys({
-        type: "manifest",
-        derivedOutputPaths: ["company.full"],
-        fillableFieldPaths: ["company"],
-        livePaths: ["company.full"],
-      }),
-    ).toEqual(new Set(["company"]));
+    const raw = collectTemplateInputKeys({
+      type: "raw",
+      livePaths: ["company.full"],
+    });
+    expect(raw.acceptedPaths).toEqual(new Set(["company.full"]));
+    const manifest = collectTemplateInputKeys({
+      type: "manifest",
+      derivedOutputPaths: ["company.full"],
+      fillableFieldPaths: ["company"],
+      livePaths: ["company.full"],
+    });
+    expect(manifest.acceptedPaths).toEqual(new Set(["company"]));
+    expect(manifest.forbiddenPaths).toEqual(new Set(["company.full"]));
   });
 
   test("manifest nested live paths support flattened input", () => {
-    const declaredKeys = collectTemplateInputKeys({
+    const contract = collectTemplateInputKeys({
       type: "manifest",
       derivedOutputPaths: [],
       fillableFieldPaths: ["company"],
@@ -109,28 +120,49 @@ describe("template input contract", () => {
     });
     expect(
       findUnusedTemplateValueKeys({
-        declaredKeys,
+        contract,
         values: { "company.seat": "Prague" },
       }),
     ).toEqual([]);
     expect(
       findUnusedTemplateValueKeys({
-        declaredKeys,
+        contract,
         values: { company: { namme: "typo" } },
       }),
     ).toEqual(["company.namme"]);
   });
 
+  test("forbidden derived paths win through nested and flattened input", () => {
+    const contract = collectTemplateInputKeys({
+      type: "manifest",
+      derivedOutputPaths: ["company.seat"],
+      fillableFieldPaths: ["company"],
+      livePaths: ["company.seat"],
+    });
+    expect(
+      findUnusedTemplateValueKeys({
+        contract,
+        values: { company: { seat: "Prague" } },
+      }),
+    ).toEqual(["company.seat"]);
+    expect(
+      findUnusedTemplateValueKeys({
+        contract,
+        values: { "company.seat": "Prague" },
+      }),
+    ).toEqual(["company.seat"]);
+  });
+
   test("accepts top-level and flattened declared paths", () => {
     expect(
       findUnusedTemplateValueKeys({
-        declaredKeys: DECLARED_KEYS,
+        contract: DECLARED_CONTRACT,
         values: { name: "Ada", company: { name: "Stella" } },
       }),
     ).toEqual([]);
     expect(
       findUnusedTemplateValueKeys({
-        declaredKeys: DECLARED_KEYS,
+        contract: DECLARED_CONTRACT,
         values: { "company.name": "Stella" },
       }),
     ).toEqual([]);
@@ -139,7 +171,7 @@ describe("template input contract", () => {
   test("rejects extra keys independently of every supported value type", () => {
     expect(
       findUnusedTemplateValueKeys({
-        declaredKeys: DECLARED_KEYS,
+        contract: DECLARED_CONTRACT,
         values: {
           name: "Ada",
           typoString: "value",
@@ -161,7 +193,7 @@ describe("template input contract", () => {
   test("rejects unknown leaves inside declared namespaces", () => {
     expect(
       findUnusedTemplateValueKeys({
-        declaredKeys: DECLARED_KEYS,
+        contract: DECLARED_CONTRACT,
         values: { company: { name: "Stella", namme: "typo" } },
       }),
     ).toEqual(["company.namme"]);
@@ -170,7 +202,7 @@ describe("template input contract", () => {
   test("rejects unknown leaves inside repeated namespace rows", () => {
     expect(
       findUnusedTemplateValueKeys({
-        declaredKeys: ["sellers", "sellers.name"],
+        contract: contractFor(["sellers", "sellers.name"]),
         values: { sellers: [{ name: "Ada" }, { namme: "Grace" }] },
       }),
     ).toEqual(["sellers.namme"]);
@@ -181,7 +213,7 @@ describe("template input contract", () => {
       fc.property(fc.jsonValue(), (value) => {
         expect(
           findUnusedTemplateValueKeys({
-            declaredKeys: DECLARED_KEYS,
+            contract: DECLARED_CONTRACT,
             values: { unknown: value },
           }),
         ).toEqual(["unknown"]);
@@ -195,7 +227,7 @@ describe("template input contract", () => {
       fc.property(fc.jsonValue(), (value) => {
         expect(
           findUnusedTemplateValueKeys({
-            declaredKeys: DECLARED_KEYS,
+            contract: DECLARED_CONTRACT,
             values: { name: value },
           }),
         ).toEqual([]);

--- a/apps/api/src/handlers/templates/template-input-contract.test.ts
+++ b/apps/api/src/handlers/templates/template-input-contract.test.ts
@@ -139,6 +139,63 @@ describe("template input contract", () => {
     ).toEqual([]);
   });
 
+  test("raw dotted condition fields accept nested values and reject siblings", () => {
+    const sources = collectRawTemplateInputSources({
+      fields: [{ path: "client.has_spouse", kind: "boolean" }],
+      placeholderPaths: [],
+    });
+    const contract = collectTemplateInputKeys({ type: "raw", ...sources });
+
+    expect(
+      findUnusedTemplateValueKeys({
+        contract,
+        values: { client: { has_spouse: true } },
+      }),
+    ).toEqual([]);
+    expect(
+      findUnusedTemplateValueKeys({
+        contract,
+        values: { client: { has_spouse: true, typo: true } },
+      }),
+    ).toEqual(["client.typo"]);
+  });
+
+  test("nested loop contracts accept inherited outer-row condition fields", () => {
+    const sources = collectRawTemplateInputSources({
+      fields: [
+        {
+          path: "groups",
+          kind: "array",
+          itemFields: [{ path: "group_enabled", kind: "boolean" }],
+        },
+        {
+          path: "groups.items",
+          kind: "array",
+          itemFields: [{ path: "group_enabled", kind: "boolean" }],
+        },
+      ],
+      placeholderPaths: [],
+    });
+    const contract = collectTemplateInputKeys({ type: "raw", ...sources });
+
+    expect(
+      findUnusedTemplateValueKeys({
+        contract,
+        values: {
+          groups: [{ group_enabled: true, items: [{}, {}] }],
+        },
+      }),
+    ).toEqual([]);
+    expect(
+      findUnusedTemplateValueKeys({
+        contract,
+        values: {
+          groups: [{ group_enabled: true, typo: true, items: [{}] }],
+        },
+      }),
+    ).toEqual(["groups.typo"]);
+  });
+
   test("manifest templates accept live descendants but exclude derived outputs", () => {
     const contract = collectTemplateInputKeys({
       type: "manifest",

--- a/apps/api/src/handlers/templates/template-input-contract.test.ts
+++ b/apps/api/src/handlers/templates/template-input-contract.test.ts
@@ -138,6 +138,30 @@ describe("template input contract", () => {
     ).toEqual(["tags"]);
   });
 
+  test("raw loops only accept primitive rows when value is their sole field", () => {
+    const sources = collectRawTemplateInputSources({
+      fields: [
+        {
+          path: "tags",
+          kind: "array",
+          itemFields: [
+            { path: "value", kind: "string" },
+            { path: "label", kind: "string" },
+          ],
+        },
+      ],
+      placeholderPaths: ["tags.value", "tags.label"],
+    });
+    expect(sources.primitiveArrayPaths).toEqual([]);
+    const contract = collectTemplateInputKeys({ type: "raw", ...sources });
+    expect(
+      findUnusedTemplateValueKeys({
+        contract,
+        values: { tags: ["urgent"] },
+      }),
+    ).toEqual(["tags"]);
+  });
+
   test("raw dotted value loops preserve their nested primitive contract", () => {
     const sources = collectRawTemplateInputSources({
       fields: [

--- a/apps/api/src/handlers/templates/template-input-contract.ts
+++ b/apps/api/src/handlers/templates/template-input-contract.ts
@@ -3,6 +3,23 @@ type FindUnusedTemplateValueKeysOptions = {
   values: Record<string, unknown>;
 };
 
+type CollectTemplateInputKeysOptions = {
+  discoveredFieldPaths: Iterable<string>;
+  manifestFieldPaths: Iterable<string>;
+  placeholderPaths: Iterable<string>;
+};
+
+export const collectTemplateInputKeys = ({
+  discoveredFieldPaths,
+  manifestFieldPaths,
+  placeholderPaths,
+}: CollectTemplateInputKeysOptions): ReadonlySet<string> =>
+  new Set([
+    ...discoveredFieldPaths,
+    ...manifestFieldPaths,
+    ...placeholderPaths,
+  ]);
+
 /**
  * Compare submitted top-level or already-flattened keys with every value path
  * declared by the template. Value types are deliberately irrelevant: a typo
@@ -29,6 +46,18 @@ const findUnusedPaths = (
     if (pathHasDeclaredDescendant && isRecord(value)) {
       for (const unusedPath of findUnusedPaths(value, path, declaredKeys)) {
         unusedPaths.push(unusedPath);
+      }
+      continue;
+    }
+
+    if (pathHasDeclaredDescendant && Array.isArray(value)) {
+      for (const item of value) {
+        if (!isRecord(item)) {
+          continue;
+        }
+        for (const unusedPath of findUnusedPaths(item, path, declaredKeys)) {
+          unusedPaths.push(unusedPath);
+        }
       }
       continue;
     }

--- a/apps/api/src/handlers/templates/template-input-contract.ts
+++ b/apps/api/src/handlers/templates/template-input-contract.ts
@@ -6,11 +6,13 @@ type FindUnusedTemplateValueKeysOptions = {
 export type TemplateInputContract = {
   acceptedPaths: ReadonlySet<string>;
   forbiddenPaths: ReadonlySet<string>;
+  primitiveArrayPaths: ReadonlySet<string>;
 };
 
 type TemplateInputKeySources =
   | {
       type: "raw";
+      primitiveArrayPaths: Iterable<string>;
       terminalPaths: Iterable<string>;
     }
   | {
@@ -18,6 +20,7 @@ type TemplateInputKeySources =
       derivedOutputPaths: Iterable<string>;
       fillableFieldPaths: Iterable<string>;
       livePaths: Iterable<string>;
+      primitiveArrayPaths: Iterable<string>;
     };
 
 type TemplateInputField = {
@@ -37,16 +40,28 @@ type CollectRawTemplateTerminalPathsOptions = {
   placeholderPaths: Iterable<string>;
 };
 
-export const collectRawTemplateTerminalPaths = ({
+type RawTemplateInputSources = {
+  primitiveArrayPaths: string[];
+  terminalPaths: string[];
+};
+
+export const collectRawTemplateInputSources = ({
   fields,
   placeholderPaths,
-}: CollectRawTemplateTerminalPathsOptions): string[] => {
+}: CollectRawTemplateTerminalPathsOptions): RawTemplateInputSources => {
+  const primitiveArrayPaths: string[] = [];
   const terminalPaths = Array.from(placeholderPaths);
 
   const visit = (field: RawDiscoveredField, parentPath: string): void => {
     const path = parentPath === "" ? field.path : `${parentPath}.${field.path}`;
     const itemFields = field.itemFields;
     const hasItemFields = itemFields !== undefined && itemFields.length > 0;
+    if (
+      field.kind === "array" &&
+      itemFields?.some((itemField) => itemField.path === "value")
+    ) {
+      primitiveArrayPaths.push(path);
+    }
     if (field.kind !== "object" && (field.kind !== "array" || !hasItemFields)) {
       terminalPaths.push(path);
     }
@@ -60,7 +75,7 @@ export const collectRawTemplateTerminalPaths = ({
   for (const field of fields) {
     visit(field, "");
   }
-  return terminalPaths;
+  return { primitiveArrayPaths, terminalPaths };
 };
 
 export const isFillableTemplateInputField = (
@@ -77,6 +92,7 @@ export const collectTemplateInputKeys = (
     return {
       acceptedPaths: new Set(sources.terminalPaths),
       forbiddenPaths: new Set(),
+      primitiveArrayPaths: new Set(sources.primitiveArrayPaths),
     };
   }
 
@@ -92,7 +108,18 @@ export const collectTemplateInputKeys = (
     }
     acceptedPaths.add(livePath);
   }
-  return { acceptedPaths, forbiddenPaths: derivedOutputPaths };
+  const primitiveArrayPaths = new Set(
+    Array.from(sources.primitiveArrayPaths).filter(
+      (path) =>
+        isAtOrBelowAny(path, fillableFieldPaths) &&
+        !isAtOrBelowAny(path, derivedOutputPaths),
+    ),
+  );
+  return {
+    acceptedPaths,
+    forbiddenPaths: derivedOutputPaths,
+    primitiveArrayPaths,
+  };
 };
 
 const isAtOrBelowAny = (path: string, roots: ReadonlySet<string>): boolean =>
@@ -140,7 +167,12 @@ const findUnusedPaths = (
       let hasInvalidItem = false;
       for (const item of value) {
         if (!isRecord(item)) {
-          hasInvalidItem = true;
+          if (
+            !contract.primitiveArrayPaths.has(path) ||
+            !isTemplateLoopPrimitive(item)
+          ) {
+            hasInvalidItem = true;
+          }
           continue;
         }
         for (const unusedPath of findUnusedPaths(item, path, contract)) {
@@ -178,3 +210,10 @@ const hasDeclaredDescendant = (
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value);
+
+const isTemplateLoopPrimitive = (
+  value: unknown,
+): value is boolean | number | string =>
+  typeof value === "boolean" ||
+  typeof value === "number" ||
+  typeof value === "string";

--- a/apps/api/src/handlers/templates/template-input-contract.ts
+++ b/apps/api/src/handlers/templates/template-input-contract.ts
@@ -26,6 +26,43 @@ type TemplateInputField = {
   formula?: unknown;
 };
 
+type RawDiscoveredField = {
+  itemFields?: readonly RawDiscoveredField[];
+  kind: "array" | "boolean" | "object" | "string";
+  path: string;
+};
+
+type CollectRawTemplateTerminalPathsOptions = {
+  fields: readonly RawDiscoveredField[];
+  placeholderPaths: Iterable<string>;
+};
+
+export const collectRawTemplateTerminalPaths = ({
+  fields,
+  placeholderPaths,
+}: CollectRawTemplateTerminalPathsOptions): string[] => {
+  const terminalPaths = Array.from(placeholderPaths);
+
+  const visit = (field: RawDiscoveredField, parentPath: string): void => {
+    const path = parentPath === "" ? field.path : `${parentPath}.${field.path}`;
+    const itemFields = field.itemFields;
+    const hasItemFields = itemFields !== undefined && itemFields.length > 0;
+    if (field.kind !== "object" && (field.kind !== "array" || !hasItemFields)) {
+      terminalPaths.push(path);
+    }
+    if (itemFields !== undefined) {
+      for (const itemField of itemFields) {
+        visit(itemField, path);
+      }
+    }
+  };
+
+  for (const field of fields) {
+    visit(field, "");
+  }
+  return terminalPaths;
+};
+
 export const isFillableTemplateInputField = (
   field: TemplateInputField,
 ): boolean =>

--- a/apps/api/src/handlers/templates/template-input-contract.ts
+++ b/apps/api/src/handlers/templates/template-input-contract.ts
@@ -1,6 +1,11 @@
 type FindUnusedTemplateValueKeysOptions = {
-  declaredKeys: Iterable<string>;
+  contract: TemplateInputContract;
   values: Record<string, unknown>;
+};
+
+export type TemplateInputContract = {
+  acceptedPaths: ReadonlySet<string>;
+  forbiddenPaths: ReadonlySet<string>;
 };
 
 type TemplateInputKeySources =
@@ -30,9 +35,12 @@ export const isFillableTemplateInputField = (
 
 export const collectTemplateInputKeys = (
   sources: TemplateInputKeySources,
-): ReadonlySet<string> => {
+): TemplateInputContract => {
   if (sources.type === "raw") {
-    return new Set(sources.livePaths);
+    return {
+      acceptedPaths: new Set(sources.livePaths),
+      forbiddenPaths: new Set(),
+    };
   }
 
   const fillableFieldPaths = new Set(sources.fillableFieldPaths);
@@ -47,20 +55,14 @@ export const collectTemplateInputKeys = (
     }
     acceptedPaths.add(livePath);
   }
-  return acceptedPaths;
+  return { acceptedPaths, forbiddenPaths: derivedOutputPaths };
 };
 
 const isAtOrBelowAny = (path: string, roots: ReadonlySet<string>): boolean =>
   roots.has(path) || isBelowAny(path, roots);
 
-const isBelowAny = (path: string, roots: ReadonlySet<string>): boolean => {
-  for (const root of roots) {
-    if (path.startsWith(`${root}.`)) {
-      return true;
-    }
-  }
-  return false;
-};
+const isBelowAny = (path: string, roots: ReadonlySet<string>): boolean =>
+  Array.from(roots).some((root) => path.startsWith(`${root}.`));
 
 /**
  * Compare submitted top-level or already-flattened keys with every value path
@@ -68,43 +70,48 @@ const isBelowAny = (path: string, roots: ReadonlySet<string>): boolean => {
  * must be rejected consistently for strings, scalars, arrays, and objects.
  */
 export const findUnusedTemplateValueKeys = ({
-  declaredKeys,
+  contract,
   values,
-}: FindUnusedTemplateValueKeysOptions): string[] => {
-  const declaredKeySet = new Set(declaredKeys);
-  return findUnusedPaths(values, "", declaredKeySet);
-};
+}: FindUnusedTemplateValueKeysOptions): string[] =>
+  findUnusedPaths(values, "", contract);
 
 const findUnusedPaths = (
   values: Record<string, unknown>,
   parentPath: string,
-  declaredKeys: ReadonlySet<string>,
+  contract: TemplateInputContract,
 ): string[] => {
   const unusedPaths: string[] = [];
 
   for (const [key, value] of Object.entries(values)) {
     const path = parentPath === "" ? key : `${parentPath}.${key}`;
-    const pathHasDeclaredDescendant = hasDeclaredDescendant(path, declaredKeys);
-    if (pathHasDeclaredDescendant && isRecord(value)) {
-      for (const unusedPath of findUnusedPaths(value, path, declaredKeys)) {
+    if (isAtOrBelowAny(path, contract.forbiddenPaths)) {
+      unusedPaths.push(path);
+      continue;
+    }
+
+    const pathHasContractDescendant =
+      hasDeclaredDescendant(path, contract.acceptedPaths) ||
+      hasDeclaredDescendant(path, contract.forbiddenPaths);
+    if (pathHasContractDescendant && isRecord(value)) {
+      for (const unusedPath of findUnusedPaths(value, path, contract)) {
         unusedPaths.push(unusedPath);
       }
       continue;
     }
 
-    if (pathHasDeclaredDescendant && Array.isArray(value)) {
+    if (pathHasContractDescendant && Array.isArray(value)) {
       for (const item of value) {
         if (!isRecord(item)) {
           continue;
         }
-        for (const unusedPath of findUnusedPaths(item, path, declaredKeys)) {
+        for (const unusedPath of findUnusedPaths(item, path, contract)) {
           unusedPaths.push(unusedPath);
         }
       }
       continue;
     }
 
-    if (declaredKeys.has(path)) {
+    if (contract.acceptedPaths.has(path)) {
       continue;
     }
 

--- a/apps/api/src/handlers/templates/template-input-contract.ts
+++ b/apps/api/src/handlers/templates/template-input-contract.ts
@@ -66,7 +66,8 @@ export const collectRawTemplateInputSources = ({
     }
     if (
       field.kind === "array" &&
-      itemFields?.some((itemField) => itemField.path === "value")
+      itemFields?.length === 1 &&
+      itemFields[0]?.path === "value"
     ) {
       primitiveArrayPaths.push(path);
     }

--- a/apps/api/src/handlers/templates/template-input-contract.ts
+++ b/apps/api/src/handlers/templates/template-input-contract.ts
@@ -100,13 +100,18 @@ const findUnusedPaths = (
     }
 
     if (pathHasContractDescendant && Array.isArray(value)) {
+      let hasInvalidItem = false;
       for (const item of value) {
         if (!isRecord(item)) {
+          hasInvalidItem = true;
           continue;
         }
         for (const unusedPath of findUnusedPaths(item, path, contract)) {
           unusedPaths.push(unusedPath);
         }
+      }
+      if (hasInvalidItem) {
+        unusedPaths.push(path);
       }
       continue;
     }

--- a/apps/api/src/handlers/templates/template-input-contract.ts
+++ b/apps/api/src/handlers/templates/template-input-contract.ts
@@ -25,14 +25,15 @@ const findUnusedPaths = (
 
   for (const [key, value] of Object.entries(values)) {
     const path = parentPath === "" ? key : `${parentPath}.${key}`;
-    if (declaredKeys.has(path)) {
-      continue;
-    }
-
-    if (hasDeclaredDescendant(path, declaredKeys) && isRecord(value)) {
+    const pathHasDeclaredDescendant = hasDeclaredDescendant(path, declaredKeys);
+    if (pathHasDeclaredDescendant && isRecord(value)) {
       for (const unusedPath of findUnusedPaths(value, path, declaredKeys)) {
         unusedPaths.push(unusedPath);
       }
+      continue;
+    }
+
+    if (declaredKeys.has(path)) {
       continue;
     }
 

--- a/apps/api/src/handlers/templates/template-input-contract.ts
+++ b/apps/api/src/handlers/templates/template-input-contract.ts
@@ -5,17 +5,20 @@ type FindUnusedTemplateValueKeysOptions = {
 
 export type TemplateInputContract = {
   acceptedPaths: ReadonlySet<string>;
+  arrayPaths: ReadonlySet<string>;
   forbiddenPaths: ReadonlySet<string>;
   primitiveArrayPaths: ReadonlySet<string>;
 };
 
 type TemplateInputKeySources =
   | {
+      arrayPaths: Iterable<string>;
       type: "raw";
       primitiveArrayPaths: Iterable<string>;
       terminalPaths: Iterable<string>;
     }
   | {
+      arrayPaths: Iterable<string>;
       type: "manifest";
       derivedOutputPaths: Iterable<string>;
       fillableFieldPaths: Iterable<string>;
@@ -41,6 +44,7 @@ type CollectRawTemplateTerminalPathsOptions = {
 };
 
 type RawTemplateInputSources = {
+  arrayPaths: string[];
   primitiveArrayPaths: string[];
   terminalPaths: string[];
 };
@@ -49,6 +53,7 @@ export const collectRawTemplateInputSources = ({
   fields,
   placeholderPaths,
 }: CollectRawTemplateTerminalPathsOptions): RawTemplateInputSources => {
+  const arrayPaths: string[] = [];
   const primitiveArrayPaths: string[] = [];
   const terminalPaths = Array.from(placeholderPaths);
 
@@ -56,6 +61,9 @@ export const collectRawTemplateInputSources = ({
     const path = parentPath === "" ? field.path : `${parentPath}.${field.path}`;
     const itemFields = field.itemFields;
     const hasItemFields = itemFields !== undefined && itemFields.length > 0;
+    if (field.kind === "array") {
+      arrayPaths.push(path);
+    }
     if (
       field.kind === "array" &&
       itemFields?.some((itemField) => itemField.path === "value")
@@ -75,7 +83,7 @@ export const collectRawTemplateInputSources = ({
   for (const field of fields) {
     visit(field, "");
   }
-  return { primitiveArrayPaths, terminalPaths };
+  return { arrayPaths, primitiveArrayPaths, terminalPaths };
 };
 
 export const isFillableTemplateInputField = (
@@ -91,6 +99,7 @@ export const collectTemplateInputKeys = (
   if (sources.type === "raw") {
     return {
       acceptedPaths: new Set(sources.terminalPaths),
+      arrayPaths: new Set(sources.arrayPaths),
       forbiddenPaths: new Set(),
       primitiveArrayPaths: new Set(sources.primitiveArrayPaths),
     };
@@ -111,12 +120,22 @@ export const collectTemplateInputKeys = (
   const primitiveArrayPaths = new Set(
     Array.from(sources.primitiveArrayPaths).filter(
       (path) =>
-        isAtOrBelowAny(path, fillableFieldPaths) &&
+        (acceptedPaths.has(path) ||
+          hasDeclaredDescendant(path, acceptedPaths)) &&
+        !isAtOrBelowAny(path, derivedOutputPaths),
+    ),
+  );
+  const arrayPaths = new Set(
+    Array.from(sources.arrayPaths).filter(
+      (path) =>
+        (acceptedPaths.has(path) ||
+          hasDeclaredDescendant(path, acceptedPaths)) &&
         !isAtOrBelowAny(path, derivedOutputPaths),
     ),
   );
   return {
     acceptedPaths,
+    arrayPaths,
     forbiddenPaths: derivedOutputPaths,
     primitiveArrayPaths,
   };
@@ -149,6 +168,16 @@ const findUnusedPaths = (
   for (const [key, value] of Object.entries(values)) {
     const path = parentPath === "" ? key : `${parentPath}.${key}`;
     if (isAtOrBelowAny(path, contract.forbiddenPaths)) {
+      unusedPaths.push(path);
+      continue;
+    }
+
+    if (parentPath === "" && isBelowAny(path, contract.arrayPaths)) {
+      unusedPaths.push(path);
+      continue;
+    }
+
+    if (contract.arrayPaths.has(path) && !Array.isArray(value)) {
       unusedPaths.push(path);
       continue;
     }

--- a/apps/api/src/handlers/templates/template-input-contract.ts
+++ b/apps/api/src/handlers/templates/template-input-contract.ts
@@ -193,6 +193,10 @@ const findUnusedPaths = (
     }
 
     if (pathHasContractDescendant && Array.isArray(value)) {
+      if (!contract.arrayPaths.has(path)) {
+        unusedPaths.push(path);
+        continue;
+      }
       let hasInvalidItem = false;
       for (const item of value) {
         if (!isRecord(item)) {

--- a/apps/api/src/handlers/templates/template-input-contract.ts
+++ b/apps/api/src/handlers/templates/template-input-contract.ts
@@ -172,7 +172,7 @@ const findUnusedPaths = (
       continue;
     }
 
-    if (parentPath === "" && isBelowAny(path, contract.arrayPaths)) {
+    if (isFlattenedArrayDescendant(path, parentPath, contract.arrayPaths)) {
       unusedPaths.push(path);
       continue;
     }
@@ -235,6 +235,24 @@ const hasDeclaredDescendant = (
   const descendantPrefix = `${path}.`;
   for (const declaredKey of declaredKeys) {
     if (declaredKey.startsWith(descendantPrefix)) {
+      return true;
+    }
+  }
+  return false;
+};
+
+const isFlattenedArrayDescendant = (
+  path: string,
+  parentPath: string,
+  arrayPaths: ReadonlySet<string>,
+): boolean => {
+  const nestedArrayPrefix = parentPath === "" ? "" : `${parentPath}.`;
+  for (const arrayPath of arrayPaths) {
+    if (
+      arrayPath !== parentPath &&
+      arrayPath.startsWith(nestedArrayPrefix) &&
+      path.startsWith(`${arrayPath}.`)
+    ) {
       return true;
     }
   }

--- a/apps/api/src/handlers/templates/template-input-contract.ts
+++ b/apps/api/src/handlers/templates/template-input-contract.ts
@@ -11,7 +11,7 @@ export type TemplateInputContract = {
 type TemplateInputKeySources =
   | {
       type: "raw";
-      livePaths: Iterable<string>;
+      terminalPaths: Iterable<string>;
     }
   | {
       type: "manifest";
@@ -38,7 +38,7 @@ export const collectTemplateInputKeys = (
 ): TemplateInputContract => {
   if (sources.type === "raw") {
     return {
-      acceptedPaths: new Set(sources.livePaths),
+      acceptedPaths: new Set(sources.terminalPaths),
       forbiddenPaths: new Set(),
     };
   }

--- a/apps/api/src/handlers/templates/template-input-contract.ts
+++ b/apps/api/src/handlers/templates/template-input-contract.ts
@@ -9,6 +9,19 @@ type CollectTemplateInputKeysOptions = {
   placeholderPaths: Iterable<string>;
 };
 
+type TemplateInputField = {
+  condition?: unknown;
+  conditionAst?: unknown;
+  formula?: unknown;
+};
+
+export const isFillableTemplateInputField = (
+  field: TemplateInputField,
+): boolean =>
+  field.formula === undefined &&
+  field.condition === undefined &&
+  field.conditionAst === undefined;
+
 export const collectTemplateInputKeys = ({
   discoveredFieldPaths,
   manifestFieldPaths,

--- a/apps/api/src/handlers/templates/template-input-contract.ts
+++ b/apps/api/src/handlers/templates/template-input-contract.ts
@@ -1,0 +1,23 @@
+import { discoverTemplate } from "@/api/handlers/docx/discover-template";
+
+type FindUnusedTemplateValueKeysOptions = {
+  buffer: Buffer;
+  values: Record<string, unknown>;
+};
+
+/**
+ * Compare submitted top-level or already-flattened keys with every value path
+ * declared by the template. Value types are deliberately irrelevant: a typo
+ * must be rejected consistently for strings, scalars, arrays, and objects.
+ */
+export const findUnusedTemplateValueKeys = async ({
+  buffer,
+  values,
+}: FindUnusedTemplateValueKeysOptions): Promise<string[]> => {
+  const discovered = await discoverTemplate(buffer);
+  const declaredKeys = new Set([
+    ...discovered.fields.map((field) => field.path),
+    ...discovered.placeholders.map((placeholder) => placeholder.name),
+  ]);
+  return Object.keys(values).filter((key) => !declaredKeys.has(key));
+};

--- a/apps/api/src/handlers/templates/template-input-contract.ts
+++ b/apps/api/src/handlers/templates/template-input-contract.ts
@@ -3,11 +3,17 @@ type FindUnusedTemplateValueKeysOptions = {
   values: Record<string, unknown>;
 };
 
-type CollectTemplateInputKeysOptions = {
-  discoveredFieldPaths: Iterable<string>;
-  manifestFieldPaths: Iterable<string>;
-  placeholderPaths: Iterable<string>;
-};
+type TemplateInputKeySources =
+  | {
+      type: "raw";
+      livePaths: Iterable<string>;
+    }
+  | {
+      type: "manifest";
+      derivedOutputPaths: Iterable<string>;
+      fillableFieldPaths: Iterable<string>;
+      livePaths: Iterable<string>;
+    };
 
 type TemplateInputField = {
   condition?: unknown;
@@ -22,16 +28,39 @@ export const isFillableTemplateInputField = (
   field.condition === undefined &&
   field.conditionAst === undefined;
 
-export const collectTemplateInputKeys = ({
-  discoveredFieldPaths,
-  manifestFieldPaths,
-  placeholderPaths,
-}: CollectTemplateInputKeysOptions): ReadonlySet<string> =>
-  new Set([
-    ...discoveredFieldPaths,
-    ...manifestFieldPaths,
-    ...placeholderPaths,
-  ]);
+export const collectTemplateInputKeys = (
+  sources: TemplateInputKeySources,
+): ReadonlySet<string> => {
+  if (sources.type === "raw") {
+    return new Set(sources.livePaths);
+  }
+
+  const fillableFieldPaths = new Set(sources.fillableFieldPaths);
+  const derivedOutputPaths = new Set(sources.derivedOutputPaths);
+  const acceptedPaths = new Set(fillableFieldPaths);
+  for (const livePath of sources.livePaths) {
+    if (
+      isAtOrBelowAny(livePath, derivedOutputPaths) ||
+      !isBelowAny(livePath, fillableFieldPaths)
+    ) {
+      continue;
+    }
+    acceptedPaths.add(livePath);
+  }
+  return acceptedPaths;
+};
+
+const isAtOrBelowAny = (path: string, roots: ReadonlySet<string>): boolean =>
+  roots.has(path) || isBelowAny(path, roots);
+
+const isBelowAny = (path: string, roots: ReadonlySet<string>): boolean => {
+  for (const root of roots) {
+    if (path.startsWith(`${root}.`)) {
+      return true;
+    }
+  }
+  return false;
+};
 
 /**
  * Compare submitted top-level or already-flattened keys with every value path

--- a/apps/api/src/handlers/templates/template-input-contract.ts
+++ b/apps/api/src/handlers/templates/template-input-contract.ts
@@ -1,7 +1,5 @@
-import { discoverTemplate } from "@/api/handlers/docx/discover-template";
-
 type FindUnusedTemplateValueKeysOptions = {
-  buffer: Buffer;
+  declaredKeys: Iterable<string>;
   values: Record<string, unknown>;
 };
 
@@ -10,14 +8,52 @@ type FindUnusedTemplateValueKeysOptions = {
  * declared by the template. Value types are deliberately irrelevant: a typo
  * must be rejected consistently for strings, scalars, arrays, and objects.
  */
-export const findUnusedTemplateValueKeys = async ({
-  buffer,
+export const findUnusedTemplateValueKeys = ({
+  declaredKeys,
   values,
-}: FindUnusedTemplateValueKeysOptions): Promise<string[]> => {
-  const discovered = await discoverTemplate(buffer);
-  const declaredKeys = new Set([
-    ...discovered.fields.map((field) => field.path),
-    ...discovered.placeholders.map((placeholder) => placeholder.name),
-  ]);
-  return Object.keys(values).filter((key) => !declaredKeys.has(key));
+}: FindUnusedTemplateValueKeysOptions): string[] => {
+  const declaredKeySet = new Set(declaredKeys);
+  return findUnusedPaths(values, "", declaredKeySet);
 };
+
+const findUnusedPaths = (
+  values: Record<string, unknown>,
+  parentPath: string,
+  declaredKeys: ReadonlySet<string>,
+): string[] => {
+  const unusedPaths: string[] = [];
+
+  for (const [key, value] of Object.entries(values)) {
+    const path = parentPath === "" ? key : `${parentPath}.${key}`;
+    if (declaredKeys.has(path)) {
+      continue;
+    }
+
+    if (hasDeclaredDescendant(path, declaredKeys) && isRecord(value)) {
+      for (const unusedPath of findUnusedPaths(value, path, declaredKeys)) {
+        unusedPaths.push(unusedPath);
+      }
+      continue;
+    }
+
+    unusedPaths.push(path);
+  }
+
+  return unusedPaths;
+};
+
+const hasDeclaredDescendant = (
+  path: string,
+  declaredKeys: ReadonlySet<string>,
+): boolean => {
+  const descendantPrefix = `${path}.`;
+  for (const declaredKey of declaredKeys) {
+    if (declaredKey.startsWith(descendantPrefix)) {
+      return true;
+    }
+  }
+  return false;
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);

--- a/apps/api/src/mcp/__snapshots__/registry-quality.test.ts.snap
+++ b/apps/api/src/mcp/__snapshots__/registry-quality.test.ts.snap
@@ -597,7 +597,7 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "name": "fill_template",
     "scope": "stella:templates",
     "access": "write",
-    "description": "Fill a template with values and return the assembled document text plus the filled DOCX as base64. Call list_templates with a template_id first to learn the field paths. 'values' maps each field path to its value, e.g. {\\"tenant.name\\": \\"ACME Sp. z o.o.\\", \\"signing_date\\": \\"2026-06-08\\"}. Registry lookups, composite fields, formula fields, and AI-fillable fields are resolved automatically; AI-fillable fields are drafted when you omit them. Returns the rendered text and any placeholders left unfilled.",
+    "description": "Fill a template with values and return the assembled document text plus the filled DOCX as base64. Call list_templates with a template_id first to learn the field paths. 'values' maps each field path to its value, e.g. {\\"tenant.name\\": \\"ACME Sp. z o.o.\\", \\"signing_date\\": \\"2026-06-08\\"}. Registry lookups, composite fields, formula fields, and AI-fillable fields are resolved automatically; AI-fillable fields are drafted when you omit them. Value keys that do not match template fields fail by default; set allow_unused_values only when extra keys are intentional. Returns the rendered text and any placeholders left unfilled.",
     "annotations": {
       "idempotentHint": false,
       "openWorldHint": true
@@ -613,6 +613,10 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
           "type": "object",
           "description": "Map of field path to value.",
           "additionalProperties": true
+        },
+        "allow_unused_values": {
+          "type": "boolean",
+          "description": "Allow value keys that do not match template fields. Defaults to false so misspelled field paths fail loudly."
         }
       },
       "required": [

--- a/apps/api/src/mcp/template-tools.test.ts
+++ b/apps/api/src/mcp/template-tools.test.ts
@@ -519,6 +519,60 @@ describe("MCP template tools", () => {
     );
   });
 
+  test("fill_template rejects non-empty unused values by default", async () => {
+    fillStoredTemplateWithTextMock.mockResolvedValue({
+      templateName: "Lease",
+      fileName: "lease.docx",
+      buffer: Buffer.from("filled"),
+      text: "Lease",
+      unmatchedPlaceholders: [],
+      unusedValues: ["first", "second"],
+    });
+
+    const result = await handleMcpToolCall({
+      args: { template_id: "t1", values: { first: "value" } },
+      context: createContext(),
+      toolName: "fill_template",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(validationEnvelope(result)).toEqual(
+      expect.objectContaining({
+        code: "validation_error",
+        message: "Unused template value keys: first, second",
+      }),
+    );
+  });
+
+  test("fill_template permits intentional unused values only with an explicit override", async () => {
+    fillStoredTemplateWithTextMock.mockResolvedValue({
+      templateName: "Lease",
+      fileName: "lease.docx",
+      buffer: Buffer.from("filled"),
+      text: "Lease",
+      unmatchedPlaceholders: [],
+      unusedValues: ["intentional"],
+    });
+
+    const result = await handleMcpToolCall({
+      args: {
+        template_id: "t1",
+        values: { intentional: "value" },
+        allow_unused_values: true,
+      },
+      context: createContext(),
+      toolName: "fill_template",
+    });
+
+    expect(result.isError).not.toBe(true);
+    expect(parseToolPayload(result)).toEqual(
+      expect.objectContaining({ unusedValues: ["intentional"] }),
+    );
+    expect(recordTemplateFillMock).toHaveBeenCalledWith(
+      expect.objectContaining({ unusedCount: 1 }),
+    );
+  });
+
   test("fill_template surfaces an AI usage rejection as an error", async () => {
     // The fill service runs the usage preflight only when the template declares
     // AI fields; an over-quota org gets a rejection the MCP tool surfaces

--- a/apps/api/src/mcp/template-tools.test.ts
+++ b/apps/api/src/mcp/template-tools.test.ts
@@ -10,6 +10,7 @@ import { toSafeDbMock } from "@/api/tests/scoped-db-mock";
 
 const describeStoredTemplateMock = mock();
 const fillStoredTemplateWithTextMock = mock();
+const fillStoredTemplateWithTextStrictMock = mock();
 const createStoredTemplateMock = mock();
 const recordTemplateFillMock = mock();
 const configureTemplateFieldsMock = mock();
@@ -41,8 +42,11 @@ void mock.module("@/api/lib/anonymization-blacklist", () => ({
 void mock.module("@/api/handlers/templates/template-fill-service", () => ({
   describeStoredTemplate: describeStoredTemplateMock,
   fillStoredTemplateWithText: fillStoredTemplateWithTextMock,
+  fillStoredTemplateWithTextStrict: fillStoredTemplateWithTextStrictMock,
   fillStoredTemplate: mock(),
   fillStoredTemplateDocx: mock(),
+  fillTemplateDocx: mock(),
+  fillTemplateDocxStrict: mock(),
 }));
 
 void mock.module("@/api/handlers/templates/create-template-service", () => ({
@@ -168,6 +172,7 @@ describe("MCP template tools", () => {
   beforeEach(() => {
     describeStoredTemplateMock.mockReset();
     fillStoredTemplateWithTextMock.mockReset();
+    fillStoredTemplateWithTextStrictMock.mockReset();
     createStoredTemplateMock.mockReset();
     recordTemplateFillMock.mockReset();
     configureTemplateFieldsMock.mockReset();
@@ -476,7 +481,7 @@ describe("MCP template tools", () => {
 
   test("fill_template returns rendered text plus the DOCX as base64", async () => {
     const docxBytes = Buffer.from("PK filled docx bytes");
-    fillStoredTemplateWithTextMock.mockResolvedValue({
+    fillStoredTemplateWithTextStrictMock.mockResolvedValue({
       templateName: "Lease",
       fileName: "lease.docx",
       buffer: docxBytes,
@@ -491,7 +496,7 @@ describe("MCP template tools", () => {
       toolName: "fill_template",
     });
 
-    expect(fillStoredTemplateWithTextMock).toHaveBeenCalledWith(
+    expect(fillStoredTemplateWithTextStrictMock).toHaveBeenCalledWith(
       expect.objectContaining({
         templateId: "t1",
         values: { "tenant.name": "ACME" },
@@ -520,13 +525,11 @@ describe("MCP template tools", () => {
   });
 
   test("fill_template rejects non-empty unused values by default", async () => {
-    fillStoredTemplateWithTextMock.mockResolvedValue({
-      templateName: "Lease",
-      fileName: "lease.docx",
-      buffer: Buffer.from("filled"),
-      text: "Lease",
-      unmatchedPlaceholders: [],
-      unusedValues: ["first", "second"],
+    fillStoredTemplateWithTextStrictMock.mockResolvedValue({
+      inputRejection: {
+        type: "unused-values",
+        keys: ["first", "second"],
+      },
     });
 
     const result = await handleMcpToolCall({
@@ -542,6 +545,7 @@ describe("MCP template tools", () => {
         message: "Unused template value keys: first, second",
       }),
     );
+    expect(recordTemplateFillMock).not.toHaveBeenCalled();
   });
 
   test("fill_template permits intentional unused values only with an explicit override", async () => {
@@ -568,6 +572,8 @@ describe("MCP template tools", () => {
     expect(parseToolPayload(result)).toEqual(
       expect.objectContaining({ unusedValues: ["intentional"] }),
     );
+    expect(fillStoredTemplateWithTextMock).toHaveBeenCalled();
+    expect(fillStoredTemplateWithTextStrictMock).not.toHaveBeenCalled();
     expect(recordTemplateFillMock).toHaveBeenCalledWith(
       expect.objectContaining({ unusedCount: 1 }),
     );
@@ -577,7 +583,7 @@ describe("MCP template tools", () => {
     // The fill service runs the usage preflight only when the template declares
     // AI fields; an over-quota org gets a rejection the MCP tool surfaces
     // instead of spending model calls.
-    fillStoredTemplateWithTextMock.mockResolvedValue({
+    fillStoredTemplateWithTextStrictMock.mockResolvedValue({
       usageRejection: { message: "Monthly AI usage limit reached." },
     });
 

--- a/apps/api/src/mcp/template-tools.ts
+++ b/apps/api/src/mcp/template-tools.ts
@@ -405,8 +405,9 @@ export const TEMPLATE_TOOL_DEFINITIONS = [
       'e.g. {"tenant.name": "ACME Sp. z o.o.", "signing_date": "2026-06-08"}. ' +
       "Registry lookups, composite fields, formula fields, and AI-fillable " +
       "fields are resolved automatically; AI-fillable fields are drafted when " +
-      "you omit them. Returns the rendered text and any placeholders left " +
-      "unfilled.",
+      "you omit them. Value keys that do not match template fields fail by " +
+      "default; set allow_unused_values only when extra keys are intentional. " +
+      "Returns the rendered text and any placeholders left unfilled.",
     inputSchema: {
       type: "object",
       properties: {
@@ -415,6 +416,11 @@ export const TEMPLATE_TOOL_DEFINITIONS = [
           type: "object",
           description: "Map of field path to value.",
           additionalProperties: true,
+        },
+        allow_unused_values: {
+          type: "boolean",
+          description:
+            "Allow value keys that do not match template fields. Defaults to false so misspelled field paths fail loudly.",
         },
       },
       required: ["template_id", "values"],
@@ -622,6 +628,7 @@ const describeTemplateDetail: McpToolHandler = async ({ args, context }) => {
 const fillTemplateArgsSchema = v.strictObject({
   template_id: v.pipe(v.string(), v.minLength(1)),
   values: v.record(v.string(), v.unknown()),
+  allow_unused_values: v.optional(v.boolean()),
 });
 
 const handleFillTemplateTool: McpToolHandler = async ({ args, context }) => {
@@ -710,6 +717,23 @@ const handleFillTemplateTool: McpToolHandler = async ({ args, context }) => {
   }
   if ("error" in filled) {
     return errorResult(filled.error);
+  }
+  if (
+    filled.unusedValues.length > 0 &&
+    parsed.output.allow_unused_values !== true
+  ) {
+    const preview = filled.unusedValues.slice(0, 10);
+    const omitted = filled.unusedValues.length - preview.length;
+    const suffix = omitted > 0 ? ` (${omitted} more omitted)` : "";
+    return structuredErrorResult({
+      code: "validation_error",
+      message: `Unused template value keys: ${preview.join(", ")}${suffix}`,
+      issues: preview.map((key) => ({
+        path: `values.${key}`,
+        message: "Value key does not match a template field",
+      })),
+      hint: "Correct the value keys using list_templates detail mode, or set allow_unused_values to true when the extra keys are intentional.",
+    });
   }
 
   // Record the execution (fill row + EXECUTE audit) like the REST fill routes,

--- a/apps/api/src/mcp/template-tools.ts
+++ b/apps/api/src/mcp/template-tools.ts
@@ -20,6 +20,7 @@ import type { DescribeTemplateResult } from "@/api/handlers/templates/template-f
 import {
   describeStoredTemplate,
   fillStoredTemplateWithText,
+  fillStoredTemplateWithTextStrict,
 } from "@/api/handlers/templates/template-fill-service";
 import { loadOrgAIConfig } from "@/api/lib/ai-config-loader";
 import { captureError } from "@/api/lib/analytics/capture";
@@ -702,7 +703,11 @@ const handleFillTemplateTool: McpToolHandler = async ({ args, context }) => {
           })
       : undefined;
 
-  const filled = await fillStoredTemplateWithText({
+  const fillStoredTemplate =
+    parsed.output.allow_unused_values === true
+      ? fillStoredTemplateWithText
+      : fillStoredTemplateWithTextStrict;
+  const filled = await fillStoredTemplate({
     templateId: brandPersistedTemplateId(parsed.output.template_id),
     values: parsed.output.values,
     scopedDb: context.scopedDb,
@@ -718,12 +723,9 @@ const handleFillTemplateTool: McpToolHandler = async ({ args, context }) => {
   if ("error" in filled) {
     return errorResult(filled.error);
   }
-  if (
-    filled.unusedValues.length > 0 &&
-    parsed.output.allow_unused_values !== true
-  ) {
-    const preview = filled.unusedValues.slice(0, 10);
-    const omitted = filled.unusedValues.length - preview.length;
+  if ("inputRejection" in filled) {
+    const preview = filled.inputRejection.keys.slice(0, 10);
+    const omitted = filled.inputRejection.keys.length - preview.length;
     const suffix = omitted > 0 ? ` (${omitted} more omitted)` : "";
     return structuredErrorResult({
       code: "validation_error",

--- a/packages/cli/src/cli-commands.test.ts
+++ b/packages/cli/src/cli-commands.test.ts
@@ -704,6 +704,75 @@ describe("help surfaces --input for inputOnly tools", () => {
   });
 });
 
+describe("template fill unused-value validation", () => {
+  test("surfaces the tool's strict unused-value error", async () => {
+    const server = startMockServer(() => ({
+      toolPayload: {
+        error: {
+          code: "validation_error",
+          message: "Unused template value keys: typo",
+          issues: [
+            {
+              path: "values.typo",
+              message: "Value key does not match a template field",
+            },
+          ],
+          hint: "Correct the value keys or explicitly allow unused values.",
+        },
+      },
+      isError: true,
+    }));
+    const result = await runCli({
+      args: [
+        "template",
+        "fill",
+        "--template-id",
+        "template-1",
+        "--input",
+        '{"values":{"typo":"value"}}',
+      ],
+      url: server.url,
+      token: makeToken(["templates"]),
+    });
+    server.stop();
+
+    expect(result.exitCode).toBe(2);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("Unused template value keys: typo");
+    expect(server.requests).toHaveLength(1);
+  });
+
+  test("forwards the explicit unused-value override to the shared MCP tool", async () => {
+    const fillPayload = {
+      documentBase64: "ZmlsbGVk",
+      unusedValues: ["intentional"],
+    };
+    const server = startMockServer(() => ({ toolPayload: fillPayload }));
+    const result = await runCli({
+      args: [
+        "template",
+        "fill",
+        "--template-id",
+        "template-1",
+        "--input",
+        '{"values":{"intentional":"value"}}',
+        "--allow-unused-values",
+      ],
+      url: server.url,
+      token: makeToken(["templates"]),
+    });
+    server.stop();
+
+    expect(result.exitCode).toBe(0);
+    expect(JSON.parse(result.stdout)).toEqual(fillPayload);
+    expect(server.requests.at(0)?.params.arguments).toEqual({
+      template_id: "template-1",
+      values: { intentional: "value" },
+      allow_unused_values: true,
+    });
+  });
+});
+
 describe("organization discriminator split (S2/Phase 4)", () => {
   test("add-member injects action and forwards the flag args", async () => {
     const server = startMockServer(() => ({ toolPayload: { ok: true } }));

--- a/packages/cli/src/generated/registry-snapshot.json
+++ b/packages/cli/src/generated/registry-snapshot.json
@@ -603,7 +603,7 @@
       "scope": "templates"
     },
     "name": "fill_template",
-    "description": "Fill a template with values and return the assembled document text plus the filled DOCX as base64. Call list_templates with a template_id first to learn the field paths. 'values' maps each field path to its value, e.g. {\"tenant.name\": \"ACME Sp. z o.o.\", \"signing_date\": \"2026-06-08\"}. Registry lookups, composite fields, formula fields, and AI-fillable fields are resolved automatically; AI-fillable fields are drafted when you omit them. Returns the rendered text and any placeholders left unfilled.",
+    "description": "Fill a template with values and return the assembled document text plus the filled DOCX as base64. Call list_templates with a template_id first to learn the field paths. 'values' maps each field path to its value, e.g. {\"tenant.name\": \"ACME Sp. z o.o.\", \"signing_date\": \"2026-06-08\"}. Registry lookups, composite fields, formula fields, and AI-fillable fields are resolved automatically; AI-fillable fields are drafted when you omit them. Value keys that do not match template fields fail by default; set allow_unused_values only when extra keys are intentional. Returns the rendered text and any placeholders left unfilled.",
     "inputSchema": {
       "type": "object",
       "properties": {
@@ -615,6 +615,10 @@
           "type": "object",
           "description": "Map of field path to value.",
           "additionalProperties": true
+        },
+        "allow_unused_values": {
+          "type": "boolean",
+          "description": "Allow value keys that do not match template fields. Defaults to false so misspelled field paths fail loudly."
         }
       },
       "required": ["template_id", "values"]

--- a/packages/cli/src/generated/route-map.ts
+++ b/packages/cli/src/generated/route-map.ts
@@ -1693,6 +1693,15 @@ export const generatedRouteMap: RouteNode = {
                 description: "Template id, as returned by list_templates",
                 required: true,
               },
+              {
+                flag: "--allow-unused-values",
+                prop: "allow_unused_values",
+                kind: "boolean",
+                repeatable: false,
+                description:
+                  "Allow value keys that do not match template fields. Defaults to false so misspelled field paths fail loudly.",
+                required: false,
+              },
             ],
             inputOnly: ["values"],
             paginated: false,
@@ -1710,6 +1719,11 @@ export const generatedRouteMap: RouteNode = {
                   type: "object",
                   description: "Map of field path to value.",
                   additionalProperties: true,
+                },
+                allow_unused_values: {
+                  type: "boolean",
+                  description:
+                    "Allow value keys that do not match template fields. Defaults to false so misspelled field paths fail loudly.",
                 },
               },
               required: ["template_id", "values"],


### PR DESCRIPTION
## Summary

- reject template fill requests when supplied value keys do not match template fields
- expose an explicit `allow_unused_values` opt-out through the shared MCP schema and generated CLI flag
- preserve the complete web environment contract in the PostHog test mock so shared-process test order cannot erase unrelated env fields

## Why

A misspelled template field previously produced a successful document while silently reporting the key in `unusedValues`. The shared MCP handler now fails closed by default, so both MCP clients and the generated CLI get the same behavior. Intentional extra values remain possible through an explicit override.

## Structural coverage

- the validation lives at the shared MCP/API boundary rather than in one CLI command
- registry generation carries the override flag to the CLI automatically
- API tests pin strict-by-default and explicit-override behavior
- CLI harness tests pin structured error propagation and generated argument forwarding
- the environment mock derives from the real typed environment object instead of replacing it with a partial object

## Verification

- `bun run verify`

## Stack

- depends on #1320


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added strict validation to reject unused template value keys that don’t match template fields.
  * Updated the `fill_template` MCP tool to reject by default and added `allow_unused_values` to permit extra keys.
  * Added matching `--allow-unused-values` support to the CLI.
* **Bug Fixes**
  * Improved surfacing/propagation of validation and AI usage rejections across template filling workflows.
* **Tests**
  * Added/updated MCP, CLI, and template input contract tests for unused-value behaviour.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->