### PR TITLE
fix(cli): namespace generated capabilities

### DIFF
--- a/docs/capability-coverage.md
+++ b/docs/capability-coverage.md
@@ -18,49 +18,49 @@ here as its CLI form). Projected from the same handler enumeration that builds
 
 ## billing-codes
 
-| Capability             | Access             | Scope                | Feature              | Reachable via                                  |
-| ---------------------- | ------------------ | -------------------- | -------------------- | ---------------------------------------------- |
-| `billing-codes.create` | write              | stella:billing_write | FEATURE_TIME_BILLING | generic invoke → `stella billing-codes create` |
-| `billing-codes.delete` | write, destructive | stella:billing_write | FEATURE_TIME_BILLING | generic invoke → `stella billing-codes delete` |
-| `billing-codes.list`   | read               | stella:read          | FEATURE_TIME_BILLING | generic invoke → `stella billing-codes list`   |
-| `billing-codes.update` | write              | stella:billing_write | FEATURE_TIME_BILLING | generic invoke → `stella billing-codes update` |
+| Capability             | Access             | Scope                | Feature              | Reachable via                                             |
+| ---------------------- | ------------------ | -------------------- | -------------------- | --------------------------------------------------------- |
+| `billing-codes.create` | write              | stella:billing_write | FEATURE_TIME_BILLING | generic invoke → `stella capability billing-codes create` |
+| `billing-codes.delete` | write, destructive | stella:billing_write | FEATURE_TIME_BILLING | generic invoke → `stella capability billing-codes delete` |
+| `billing-codes.list`   | read               | stella:read          | FEATURE_TIME_BILLING | generic invoke → `stella capability billing-codes list`   |
+| `billing-codes.update` | write              | stella:billing_write | FEATURE_TIME_BILLING | generic invoke → `stella capability billing-codes update` |
 
 ## case-law
 
-| Capability                     | Access             | Scope                | Feature            | Reachable via                                          |
-| ------------------------------ | ------------------ | -------------------- | ------------------ | ------------------------------------------------------ |
-| `case-law.analysis.generate`   | write              | stella:matters_write | FEATURE_PUBLIC_LAW | generic invoke → `stella case-law analysis generate`   |
-| `case-law.ingestion.status`    | read               | stella:read          | FEATURE_PUBLIC_LAW | generic invoke → `stella case-law ingestion status`    |
-| `case-law.matter-links.create` | write              | stella:matters_write | FEATURE_PUBLIC_LAW | generic invoke → `stella case-law matter-links create` |
-| `case-law.matter-links.delete` | write, destructive | stella:matters_write | FEATURE_PUBLIC_LAW | generic invoke → `stella case-law matter-links delete` |
-| `case-law.matter-links.list`   | read               | stella:read          | FEATURE_PUBLIC_LAW | generic invoke → `stella case-law matter-links list`   |
+| Capability                     | Access             | Scope                | Feature            | Reachable via                                                     |
+| ------------------------------ | ------------------ | -------------------- | ------------------ | ----------------------------------------------------------------- |
+| `case-law.analysis.generate`   | write              | stella:matters_write | FEATURE_PUBLIC_LAW | generic invoke → `stella capability case-law analysis-generate`   |
+| `case-law.ingestion.status`    | read               | stella:read          | FEATURE_PUBLIC_LAW | generic invoke → `stella capability case-law ingestion-status`    |
+| `case-law.matter-links.create` | write              | stella:matters_write | FEATURE_PUBLIC_LAW | generic invoke → `stella capability case-law matter-links-create` |
+| `case-law.matter-links.delete` | write, destructive | stella:matters_write | FEATURE_PUBLIC_LAW | generic invoke → `stella capability case-law matter-links-delete` |
+| `case-law.matter-links.list`   | read               | stella:read          | FEATURE_PUBLIC_LAW | generic invoke → `stella capability case-law matter-links-list`   |
 
 ## catalogue
 
-| Capability                 | Access | Scope         | Feature | Reachable via                                      |
-| -------------------------- | ------ | ------------- | ------- | -------------------------------------------------- |
-| `catalogue.install-skill`  | write  | stella:skills | —       | generic invoke → `stella catalogue install-skill`  |
-| `catalogue.list-catalogue` | read   | stella:skills | —       | generic invoke → `stella catalogue list-catalogue` |
+| Capability                 | Access | Scope         | Feature | Reachable via                                                 |
+| -------------------------- | ------ | ------------- | ------- | ------------------------------------------------------------- |
+| `catalogue.install-skill`  | write  | stella:skills | —       | generic invoke → `stella capability catalogue install-skill`  |
+| `catalogue.list-catalogue` | read   | stella:skills | —       | generic invoke → `stella capability catalogue list-catalogue` |
 
 ## chat
 
-| Capability                | Access             | Scope       | Feature | Reachable via                                     |
-| ------------------------- | ------------------ | ----------- | ------- | ------------------------------------------------- |
-| `chat.delete-thread`      | write, destructive | stella:chat | —       | generic invoke → `stella chat delete-thread`      |
-| `chat.get-messages`       | read               | stella:chat | —       | generic invoke → `stella chat get-messages`       |
-| `chat.get-older-messages` | read               | stella:chat | —       | generic invoke → `stella chat get-older-messages` |
-| `chat.get-threads`        | read               | stella:chat | —       | generic invoke → `stella chat get-threads`        |
-| `chat.rename-thread`      | write              | stella:chat | —       | generic invoke → `stella chat rename-thread`      |
-| `chat.update-thread`      | write              | stella:chat | —       | generic invoke → `stella chat update-thread`      |
+| Capability                | Access             | Scope       | Feature | Reachable via                                                |
+| ------------------------- | ------------------ | ----------- | ------- | ------------------------------------------------------------ |
+| `chat.delete-thread`      | write, destructive | stella:chat | —       | generic invoke → `stella capability chat delete-thread`      |
+| `chat.get-messages`       | read               | stella:chat | —       | generic invoke → `stella capability chat get-messages`       |
+| `chat.get-older-messages` | read               | stella:chat | —       | generic invoke → `stella capability chat get-older-messages` |
+| `chat.get-threads`        | read               | stella:chat | —       | generic invoke → `stella capability chat get-threads`        |
+| `chat.rename-thread`      | write              | stella:chat | —       | generic invoke → `stella capability chat rename-thread`      |
+| `chat.update-thread`      | write              | stella:chat | —       | generic invoke → `stella capability chat update-thread`      |
 
 ## clauses
 
 | Capability                      | Access             | Scope                  | Feature | Reachable via                                                        |
 | ------------------------------- | ------------------ | ---------------------- | ------- | -------------------------------------------------------------------- |
-| `clauses.categories-create`     | write              | stella:knowledge_write | —       | generic invoke → `stella clauses categories-create`                  |
-| `clauses.categories-delete`     | write, destructive | stella:knowledge_write | —       | generic invoke → `stella clauses categories-delete`                  |
+| `clauses.categories-create`     | write              | stella:knowledge_write | —       | generic invoke → `stella capability clauses categories-create`       |
+| `clauses.categories-delete`     | write, destructive | stella:knowledge_write | —       | generic invoke → `stella capability clauses categories-delete`       |
 | `clauses.categories-list`       | read               | stella:read            | —       | covered by `list_clauses`                                            |
-| `clauses.categories-update`     | write              | stella:knowledge_write | —       | generic invoke → `stella clauses categories-update`                  |
+| `clauses.categories-update`     | write              | stella:knowledge_write | —       | generic invoke → `stella capability clauses categories-update`       |
 | `clauses.create`                | write              | stella:knowledge_write | —       | curated tool `save_clause`                                           |
 | `clauses.delete`                | write, destructive | stella:knowledge_write | —       | curated tool `delete_clause`                                         |
 | `clauses.export`                | read               | stella:read            | —       | generic invoke: file I/O — not runnable via CLI/JSON (describe only) |
@@ -68,221 +68,221 @@ here as its CLI form). Projected from the same handler enumeration that builds
 | `clauses.import`                | write              | stella:knowledge_write | —       | generic invoke: file I/O — not runnable via CLI/JSON (describe only) |
 | `clauses.list`                  | read               | stella:read            | —       | curated tool `list_clauses`                                          |
 | `clauses.read-version`          | read               | stella:read            | —       | covered by `list_clauses`                                            |
-| `clauses.rewrite`               | write              | stella:knowledge_write | —       | generic invoke → `stella clauses rewrite`                            |
-| `clauses.template-slot-preview` | read               | stella:read            | —       | generic invoke → `stella clauses template-slot-preview`              |
+| `clauses.rewrite`               | write              | stella:knowledge_write | —       | generic invoke → `stella capability clauses rewrite`                 |
+| `clauses.template-slot-preview` | read               | stella:read            | —       | generic invoke → `stella capability clauses template-slot-preview`   |
 | `clauses.update`                | write              | stella:knowledge_write | —       | covered by `save_clause`                                             |
-| `clauses.variants-create`       | write              | stella:knowledge_write | —       | generic invoke → `stella clauses variants-create`                    |
-| `clauses.variants-delete`       | write, destructive | stella:knowledge_write | —       | generic invoke → `stella clauses variants-delete`                    |
+| `clauses.variants-create`       | write              | stella:knowledge_write | —       | generic invoke → `stella capability clauses variants-create`         |
+| `clauses.variants-delete`       | write, destructive | stella:knowledge_write | —       | generic invoke → `stella capability clauses variants-delete`         |
 | `clauses.variants-list`         | read               | stella:read            | —       | covered by `list_clauses`                                            |
-| `clauses.variants-update`       | write              | stella:knowledge_write | —       | generic invoke → `stella clauses variants-update`                    |
-| `clauses.versions-diff`         | read               | stella:read            | —       | generic invoke → `stella clauses versions-diff`                      |
-| `clauses.versions-restore`      | write              | stella:knowledge_write | —       | generic invoke → `stella clauses versions-restore`                   |
-| `clauses.versions-summarize`    | write              | stella:knowledge_write | —       | generic invoke → `stella clauses versions-summarize`                 |
+| `clauses.variants-update`       | write              | stella:knowledge_write | —       | generic invoke → `stella capability clauses variants-update`         |
+| `clauses.versions-diff`         | read               | stella:read            | —       | generic invoke → `stella capability clauses versions-diff`           |
+| `clauses.versions-restore`      | write              | stella:knowledge_write | —       | generic invoke → `stella capability clauses versions-restore`        |
+| `clauses.versions-summarize`    | write              | stella:knowledge_write | —       | generic invoke → `stella capability clauses versions-summarize`      |
 
 ## contacts
 
-| Capability                            | Access             | Scope                | Feature | Reachable via                             |
-| ------------------------------------- | ------------------ | -------------------- | ------- | ----------------------------------------- |
-| `contacts.business-registries-lookup` | read               | stella:read          | —       | curated tool `lookup_business_registry`   |
-| `contacts.create`                     | write              | stella:matters_write | —       | curated tool `save_contact`               |
-| `contacts.delete`                     | write, destructive | stella:matters_write | —       | curated tool `delete_contact`             |
-| `contacts.get`                        | read               | stella:read          | —       | curated tool `read_contact`               |
-| `contacts.list`                       | read               | stella:read          | —       | generic invoke → `stella contacts list`   |
-| `contacts.search`                     | read               | stella:read          | —       | generic invoke → `stella contacts search` |
-| `contacts.update`                     | write              | stella:matters_write | —       | covered by `save_contact`                 |
+| Capability                            | Access             | Scope                | Feature | Reachable via                                        |
+| ------------------------------------- | ------------------ | -------------------- | ------- | ---------------------------------------------------- |
+| `contacts.business-registries-lookup` | read               | stella:read          | —       | curated tool `lookup_business_registry`              |
+| `contacts.create`                     | write              | stella:matters_write | —       | curated tool `save_contact`                          |
+| `contacts.delete`                     | write, destructive | stella:matters_write | —       | curated tool `delete_contact`                        |
+| `contacts.get`                        | read               | stella:read          | —       | curated tool `read_contact`                          |
+| `contacts.list`                       | read               | stella:read          | —       | generic invoke → `stella capability contacts list`   |
+| `contacts.search`                     | read               | stella:read          | —       | generic invoke → `stella capability contacts search` |
+| `contacts.update`                     | write              | stella:matters_write | —       | covered by `save_contact`                            |
 
 ## document-types
 
-| Capability               | Access             | Scope                | Feature | Reachable via                                    |
-| ------------------------ | ------------------ | -------------------- | ------- | ------------------------------------------------ |
-| `document-types.create`  | write              | stella:matters_write | —       | generic invoke → `stella document-types create`  |
-| `document-types.delete`  | write, destructive | stella:matters_write | —       | generic invoke → `stella document-types delete`  |
-| `document-types.list`    | read               | stella:read          | —       | generic invoke → `stella document-types list`    |
-| `document-types.reorder` | write              | stella:matters_write | —       | generic invoke → `stella document-types reorder` |
-| `document-types.update`  | write              | stella:matters_write | —       | generic invoke → `stella document-types update`  |
+| Capability               | Access             | Scope                | Feature | Reachable via                                               |
+| ------------------------ | ------------------ | -------------------- | ------- | ----------------------------------------------------------- |
+| `document-types.create`  | write              | stella:matters_write | —       | generic invoke → `stella capability document-types create`  |
+| `document-types.delete`  | write, destructive | stella:matters_write | —       | generic invoke → `stella capability document-types delete`  |
+| `document-types.list`    | read               | stella:read          | —       | generic invoke → `stella capability document-types list`    |
+| `document-types.reorder` | write              | stella:matters_write | —       | generic invoke → `stella capability document-types reorder` |
+| `document-types.update`  | write              | stella:matters_write | —       | generic invoke → `stella capability document-types update`  |
 
 ## entities
 
-| Capability                            | Access             | Scope                  | Feature | Reachable via                                                        |
-| ------------------------------------- | ------------------ | ---------------------- | ------- | -------------------------------------------------------------------- |
-| `entities.check-stamp`                | read               | stella:read            | —       | generic invoke: file I/O — not runnable via CLI/JSON (describe only) |
-| `entities.clip`                       | write              | stella:matters_write   | —       | generic invoke → `stella entities clip`                              |
-| `entities.compare-versions`           | read               | stella:read            | —       | generic invoke → `stella entities compare-versions`                  |
-| `entities.copy-to-workspace`          | write, destructive | stella:matters_write   | —       | generic invoke → `stella entities copy-to-workspace`                 |
-| `entities.create`                     | write              | stella:documents_write | —       | curated tool `save_document`                                         |
-| `entities.create-blank-document`      | write              | stella:documents_write | —       | generic invoke → `stella entities create-blank-document`             |
-| `entities.create-from-legal-source`   | write              | stella:matters_write   | —       | generic invoke → `stella entities create-from-legal-source`          |
-| `entities.delete`                     | write, destructive | stella:documents_write | —       | curated tool `delete_document`                                       |
-| `entities.delete-version`             | write, destructive | stella:documents_write | —       | covered by `delete_document`                                         |
-| `entities.download-zip`               | read               | stella:read            | —       | generic invoke: file I/O — not runnable via CLI/JSON (describe only) |
-| `entities.duplicate`                  | write              | stella:matters_write   | —       | generic invoke → `stella entities duplicate`                         |
-| `entities.get`                        | read               | stella:read            | —       | curated tool `read_document`                                         |
-| `entities.list`                       | read               | stella:read            | —       | curated tool `list_documents`                                        |
-| `entities.list-files`                 | read               | stella:read            | —       | covered by `list_documents`                                          |
-| `entities.list-folders`               | read               | stella:read            | —       | covered by `list_documents`                                          |
-| `entities.move`                       | write              | stella:documents_write | —       | covered by `save_document`                                           |
-| `entities.organize-suggestions`       | write              | stella:matters_write   | —       | generic invoke → `stella entities organize-suggestions`              |
-| `entities.read-filesystem-tree`       | read               | stella:read            | —       | covered by `list_documents`                                          |
-| `entities.read-summaries`             | read               | stella:read            | —       | covered by `list_documents`                                          |
-| `entities.read-summaries-count`       | read               | stella:read            | —       | covered by `list_documents`                                          |
-| `entities.read-version-by-id`         | read               | stella:read            | —       | covered by `read_document`                                           |
-| `entities.read-versions`              | read               | stella:read            | —       | covered by `read_document`                                           |
-| `entities.read-window`                | read               | stella:read            | —       | covered by `read_content_across_matters`                             |
-| `entities.rename`                     | write              | stella:documents_write | —       | covered by `save_document`                                           |
-| `entities.restore-version`            | write              | stella:matters_write   | —       | generic invoke → `stella entities restore-version`                   |
-| `entities.translate`                  | write              | stella:matters_write   | —       | generic invoke → `stella entities translate`                         |
-| `entities.update-version-description` | write              | stella:documents_write | —       | covered by `save_document`                                           |
-| `entities.update-version-label`       | write              | stella:documents_write | —       | covered by `save_document`                                           |
-| `entities.upload`                     | write              | stella:matters_write   | —       | generic invoke: file I/O — not runnable via CLI/JSON (describe only) |
-| `entities.upload-version`             | write              | stella:matters_write   | —       | generic invoke: file I/O — not runnable via CLI/JSON (describe only) |
-| `entities.version-diff`               | read               | stella:read            | —       | covered by `read_document`                                           |
-| `entities.version-summarize`          | write              | stella:matters_write   | —       | generic invoke → `stella entities version-summarize`                 |
+| Capability                            | Access             | Scope                  | Feature | Reachable via                                                          |
+| ------------------------------------- | ------------------ | ---------------------- | ------- | ---------------------------------------------------------------------- |
+| `entities.check-stamp`                | read               | stella:read            | —       | generic invoke: file I/O — not runnable via CLI/JSON (describe only)   |
+| `entities.clip`                       | write              | stella:matters_write   | —       | generic invoke → `stella capability entities clip`                     |
+| `entities.compare-versions`           | read               | stella:read            | —       | generic invoke → `stella capability entities compare-versions`         |
+| `entities.copy-to-workspace`          | write, destructive | stella:matters_write   | —       | generic invoke → `stella capability entities copy-to-workspace`        |
+| `entities.create`                     | write              | stella:documents_write | —       | curated tool `save_document`                                           |
+| `entities.create-blank-document`      | write              | stella:documents_write | —       | generic invoke → `stella capability entities create-blank-document`    |
+| `entities.create-from-legal-source`   | write              | stella:matters_write   | —       | generic invoke → `stella capability entities create-from-legal-source` |
+| `entities.delete`                     | write, destructive | stella:documents_write | —       | curated tool `delete_document`                                         |
+| `entities.delete-version`             | write, destructive | stella:documents_write | —       | covered by `delete_document`                                           |
+| `entities.download-zip`               | read               | stella:read            | —       | generic invoke: file I/O — not runnable via CLI/JSON (describe only)   |
+| `entities.duplicate`                  | write              | stella:matters_write   | —       | generic invoke → `stella capability entities duplicate`                |
+| `entities.get`                        | read               | stella:read            | —       | curated tool `read_document`                                           |
+| `entities.list`                       | read               | stella:read            | —       | curated tool `list_documents`                                          |
+| `entities.list-files`                 | read               | stella:read            | —       | covered by `list_documents`                                            |
+| `entities.list-folders`               | read               | stella:read            | —       | covered by `list_documents`                                            |
+| `entities.move`                       | write              | stella:documents_write | —       | covered by `save_document`                                             |
+| `entities.organize-suggestions`       | write              | stella:matters_write   | —       | generic invoke → `stella capability entities organize-suggestions`     |
+| `entities.read-filesystem-tree`       | read               | stella:read            | —       | covered by `list_documents`                                            |
+| `entities.read-summaries`             | read               | stella:read            | —       | covered by `list_documents`                                            |
+| `entities.read-summaries-count`       | read               | stella:read            | —       | covered by `list_documents`                                            |
+| `entities.read-version-by-id`         | read               | stella:read            | —       | covered by `read_document`                                             |
+| `entities.read-versions`              | read               | stella:read            | —       | covered by `read_document`                                             |
+| `entities.read-window`                | read               | stella:read            | —       | covered by `read_content_across_matters`                               |
+| `entities.rename`                     | write              | stella:documents_write | —       | covered by `save_document`                                             |
+| `entities.restore-version`            | write              | stella:matters_write   | —       | generic invoke → `stella capability entities restore-version`          |
+| `entities.translate`                  | write              | stella:matters_write   | —       | generic invoke → `stella capability entities translate`                |
+| `entities.update-version-description` | write              | stella:documents_write | —       | covered by `save_document`                                             |
+| `entities.update-version-label`       | write              | stella:documents_write | —       | covered by `save_document`                                             |
+| `entities.upload`                     | write              | stella:matters_write   | —       | generic invoke: file I/O — not runnable via CLI/JSON (describe only)   |
+| `entities.upload-version`             | write              | stella:matters_write   | —       | generic invoke: file I/O — not runnable via CLI/JSON (describe only)   |
+| `entities.version-diff`               | read               | stella:read            | —       | covered by `read_document`                                             |
+| `entities.version-summarize`          | write              | stella:matters_write   | —       | generic invoke → `stella capability entities version-summarize`        |
 
 ## expenses
 
-| Capability        | Access             | Scope                | Feature              | Reachable via                             |
-| ----------------- | ------------------ | -------------------- | -------------------- | ----------------------------------------- |
-| `expenses.create` | write              | stella:billing_write | FEATURE_TIME_BILLING | generic invoke → `stella expenses create` |
-| `expenses.delete` | write, destructive | stella:billing_write | FEATURE_TIME_BILLING | generic invoke → `stella expenses delete` |
-| `expenses.list`   | read               | stella:read          | FEATURE_TIME_BILLING | generic invoke → `stella expenses list`   |
-| `expenses.update` | write              | stella:billing_write | FEATURE_TIME_BILLING | generic invoke → `stella expenses update` |
+| Capability        | Access             | Scope                | Feature              | Reachable via                                        |
+| ----------------- | ------------------ | -------------------- | -------------------- | ---------------------------------------------------- |
+| `expenses.create` | write              | stella:billing_write | FEATURE_TIME_BILLING | generic invoke → `stella capability expenses create` |
+| `expenses.delete` | write, destructive | stella:billing_write | FEATURE_TIME_BILLING | generic invoke → `stella capability expenses delete` |
+| `expenses.list`   | read               | stella:read          | FEATURE_TIME_BILLING | generic invoke → `stella capability expenses list`   |
+| `expenses.update` | write              | stella:billing_write | FEATURE_TIME_BILLING | generic invoke → `stella capability expenses update` |
 
 ## fields
 
-| Capability                    | Access | Scope                  | Feature | Reachable via                                         |
-| ----------------------------- | ------ | ---------------------- | ------- | ----------------------------------------------------- |
-| `fields.mark-column-flag`     | write  | stella:matters_write   | —       | generic invoke → `stella fields mark-column-flag`     |
-| `fields.update-cell-metadata` | write  | stella:matters_write   | —       | generic invoke → `stella fields update-cell-metadata` |
-| `fields.upsert-by-id`         | write  | stella:documents_write | —       | curated tool `set_field_value`                        |
+| Capability                    | Access | Scope                  | Feature | Reachable via                                                    |
+| ----------------------------- | ------ | ---------------------- | ------- | ---------------------------------------------------------------- |
+| `fields.mark-column-flag`     | write  | stella:matters_write   | —       | generic invoke → `stella capability fields mark-column-flag`     |
+| `fields.update-cell-metadata` | write  | stella:matters_write   | —       | generic invoke → `stella capability fields update-cell-metadata` |
+| `fields.upsert-by-id`         | write  | stella:documents_write | —       | curated tool `set_field_value`                                   |
 
 ## flows
 
-| Capability         | Access             | Scope                | Feature | Reachable via                              |
-| ------------------ | ------------------ | -------------------- | ------- | ------------------------------------------ |
-| `flows.create`     | write              | stella:matters_write | —       | generic invoke → `stella flows create`     |
-| `flows.delete`     | write, destructive | stella:matters_write | —       | generic invoke → `stella flows delete`     |
-| `flows.get`        | read               | stella:read          | —       | generic invoke → `stella flows get`        |
-| `flows.list`       | read               | stella:read          | —       | generic invoke → `stella flows list`       |
-| `flows.run-cancel` | write              | stella:matters_write | —       | generic invoke → `stella flows run-cancel` |
-| `flows.run-detail` | read               | stella:read          | —       | generic invoke → `stella flows run-detail` |
-| `flows.run-list`   | read               | stella:read          | —       | generic invoke → `stella flows run-list`   |
-| `flows.run-review` | write              | stella:matters_write | —       | generic invoke → `stella flows run-review` |
-| `flows.run-start`  | write              | stella:matters_write | —       | generic invoke → `stella flows run-start`  |
-| `flows.update`     | write              | stella:matters_write | —       | generic invoke → `stella flows update`     |
+| Capability         | Access             | Scope                | Feature | Reachable via                                         |
+| ------------------ | ------------------ | -------------------- | ------- | ----------------------------------------------------- |
+| `flows.create`     | write              | stella:matters_write | —       | generic invoke → `stella capability flows create`     |
+| `flows.delete`     | write, destructive | stella:matters_write | —       | generic invoke → `stella capability flows delete`     |
+| `flows.get`        | read               | stella:read          | —       | generic invoke → `stella capability flows get`        |
+| `flows.list`       | read               | stella:read          | —       | generic invoke → `stella capability flows list`       |
+| `flows.run-cancel` | write              | stella:matters_write | —       | generic invoke → `stella capability flows run-cancel` |
+| `flows.run-detail` | read               | stella:read          | —       | generic invoke → `stella capability flows run-detail` |
+| `flows.run-list`   | read               | stella:read          | —       | generic invoke → `stella capability flows run-list`   |
+| `flows.run-review` | write              | stella:matters_write | —       | generic invoke → `stella capability flows run-review` |
+| `flows.run-start`  | write              | stella:matters_write | —       | generic invoke → `stella capability flows run-start`  |
+| `flows.update`     | write              | stella:matters_write | —       | generic invoke → `stella capability flows update`     |
 
 ## invoices
 
-| Capability                | Access             | Scope                | Feature              | Reachable via                                     |
-| ------------------------- | ------------------ | -------------------- | -------------------- | ------------------------------------------------- |
-| `invoices.add-entries`    | write              | stella:billing_write | FEATURE_TIME_BILLING | generic invoke → `stella invoices add-entries`    |
-| `invoices.create`         | write              | stella:billing_write | FEATURE_TIME_BILLING | generic invoke → `stella invoices create`         |
-| `invoices.delete`         | write, destructive | stella:billing_write | FEATURE_TIME_BILLING | generic invoke → `stella invoices delete`         |
-| `invoices.get`            | read               | stella:read          | FEATURE_TIME_BILLING | covered by `list_invoices`                        |
-| `invoices.list`           | read               | stella:read          | FEATURE_TIME_BILLING | curated tool `list_invoices`                      |
-| `invoices.remove-entries` | write              | stella:billing_write | FEATURE_TIME_BILLING | generic invoke → `stella invoices remove-entries` |
-| `invoices.transition`     | write              | stella:billing_write | FEATURE_TIME_BILLING | generic invoke → `stella invoices transition`     |
-| `invoices.update`         | write              | stella:billing_write | FEATURE_TIME_BILLING | generic invoke → `stella invoices update`         |
+| Capability                | Access             | Scope                | Feature              | Reachable via                                                |
+| ------------------------- | ------------------ | -------------------- | -------------------- | ------------------------------------------------------------ |
+| `invoices.add-entries`    | write              | stella:billing_write | FEATURE_TIME_BILLING | generic invoke → `stella capability invoices add-entries`    |
+| `invoices.create`         | write              | stella:billing_write | FEATURE_TIME_BILLING | generic invoke → `stella capability invoices create`         |
+| `invoices.delete`         | write, destructive | stella:billing_write | FEATURE_TIME_BILLING | generic invoke → `stella capability invoices delete`         |
+| `invoices.get`            | read               | stella:read          | FEATURE_TIME_BILLING | covered by `list_invoices`                                   |
+| `invoices.list`           | read               | stella:read          | FEATURE_TIME_BILLING | curated tool `list_invoices`                                 |
+| `invoices.remove-entries` | write              | stella:billing_write | FEATURE_TIME_BILLING | generic invoke → `stella capability invoices remove-entries` |
+| `invoices.transition`     | write              | stella:billing_write | FEATURE_TIME_BILLING | generic invoke → `stella capability invoices transition`     |
+| `invoices.update`         | write              | stella:billing_write | FEATURE_TIME_BILLING | generic invoke → `stella capability invoices update`         |
 
 ## legislation
 
-| Capability                      | Access | Scope       | Feature            | Reachable via                                           |
-| ------------------------------- | ------ | ----------- | ------------------ | ------------------------------------------------------- |
-| `legislation.boe-get-law`       | read   | stella:read | FEATURE_PUBLIC_LAW | covered by `search_legislation`                         |
-| `legislation.boe-law-structure` | read   | stella:read | FEATURE_PUBLIC_LAW | covered by `search_legislation`                         |
-| `legislation.boe-related-laws`  | read   | stella:read | FEATURE_PUBLIC_LAW | covered by `search_legislation`                         |
-| `legislation.boe-search`        | read   | stella:read | FEATURE_PUBLIC_LAW | curated tool `search_legislation`                       |
-| `legislation.boe-text-block`    | read   | stella:read | FEATURE_PUBLIC_LAW | covered by `search_legislation`                         |
-| `legislation.borme-summary`     | read   | stella:read | FEATURE_PUBLIC_LAW | generic invoke → `stella legislation borme-summary`     |
-| `legislation.get`               | read   | stella:read | FEATURE_PUBLIC_LAW | generic invoke → `stella legislation get`               |
-| `legislation.search`            | read   | stella:read | FEATURE_PUBLIC_LAW | generic invoke → `stella capability legislation search` |
+| Capability                      | Access | Scope       | Feature            | Reachable via                                                  |
+| ------------------------------- | ------ | ----------- | ------------------ | -------------------------------------------------------------- |
+| `legislation.boe-get-law`       | read   | stella:read | FEATURE_PUBLIC_LAW | covered by `search_legislation`                                |
+| `legislation.boe-law-structure` | read   | stella:read | FEATURE_PUBLIC_LAW | covered by `search_legislation`                                |
+| `legislation.boe-related-laws`  | read   | stella:read | FEATURE_PUBLIC_LAW | covered by `search_legislation`                                |
+| `legislation.boe-search`        | read   | stella:read | FEATURE_PUBLIC_LAW | curated tool `search_legislation`                              |
+| `legislation.boe-text-block`    | read   | stella:read | FEATURE_PUBLIC_LAW | covered by `search_legislation`                                |
+| `legislation.borme-summary`     | read   | stella:read | FEATURE_PUBLIC_LAW | generic invoke → `stella capability legislation borme-summary` |
+| `legislation.get`               | read   | stella:read | FEATURE_PUBLIC_LAW | generic invoke → `stella capability legislation get`           |
+| `legislation.search`            | read   | stella:read | FEATURE_PUBLIC_LAW | generic invoke → `stella capability legislation search`        |
 
 ## organization-settings
 
-| Capability                                             | Access | Scope              | Feature | Reachable via                                                                  |
-| ------------------------------------------------------ | ------ | ------------------ | ------- | ------------------------------------------------------------------------------ |
-| `organization-settings.get`                            | read   | stella:admin_read  | —       | generic invoke → `stella organization-settings get`                            |
-| `organization-settings.preview`                        | read   | stella:admin_read  | —       | generic invoke → `stella organization-settings preview`                        |
-| `organization-settings.read-ai-availability`           | read   | stella:admin_read  | —       | generic invoke → `stella organization-settings read-ai-availability`           |
-| `organization-settings.read-anonymization-blacklist`   | read   | stella:admin_read  | —       | generic invoke → `stella organization-settings read-anonymization-blacklist`   |
-| `organization-settings.read-deepl-availability`        | read   | stella:admin_read  | —       | generic invoke → `stella organization-settings read-deepl-availability`        |
-| `organization-settings.update`                         | write  | stella:admin_write | —       | covered by `manage_organization`                                               |
-| `organization-settings.update-anonymization-blacklist` | write  | stella:admin_write | —       | generic invoke → `stella organization-settings update-anonymization-blacklist` |
-| `organization-settings.update-practice-jurisdictions`  | write  | stella:admin_write | —       | curated tool `set_practice_jurisdictions`                                      |
+| Capability                                             | Access | Scope              | Feature | Reachable via                                                                             |
+| ------------------------------------------------------ | ------ | ------------------ | ------- | ----------------------------------------------------------------------------------------- |
+| `organization-settings.get`                            | read   | stella:admin_read  | —       | generic invoke → `stella capability organization-settings get`                            |
+| `organization-settings.preview`                        | read   | stella:admin_read  | —       | generic invoke → `stella capability organization-settings preview`                        |
+| `organization-settings.read-ai-availability`           | read   | stella:admin_read  | —       | generic invoke → `stella capability organization-settings read-ai-availability`           |
+| `organization-settings.read-anonymization-blacklist`   | read   | stella:admin_read  | —       | generic invoke → `stella capability organization-settings read-anonymization-blacklist`   |
+| `organization-settings.read-deepl-availability`        | read   | stella:admin_read  | —       | generic invoke → `stella capability organization-settings read-deepl-availability`        |
+| `organization-settings.update`                         | write  | stella:admin_write | —       | covered by `manage_organization`                                                          |
+| `organization-settings.update-anonymization-blacklist` | write  | stella:admin_write | —       | generic invoke → `stella capability organization-settings update-anonymization-blacklist` |
+| `organization-settings.update-practice-jurisdictions`  | write  | stella:admin_write | —       | curated tool `set_practice_jurisdictions`                                                 |
 
 ## playbooks
 
-| Capability                  | Access             | Scope                  | Feature | Reachable via                                       |
-| --------------------------- | ------------------ | ---------------------- | ------- | --------------------------------------------------- |
-| `playbooks.approve`         | write              | stella:knowledge_write | —       | generic invoke → `stella playbooks approve`         |
-| `playbooks.auto-run`        | write              | stella:knowledge_write | —       | generic invoke → `stella playbooks auto-run`        |
-| `playbooks.create`          | write              | stella:knowledge_write | —       | generic invoke → `stella playbooks create`          |
-| `playbooks.delete`          | write, destructive | stella:knowledge_write | —       | generic invoke → `stella playbooks delete`          |
-| `playbooks.from-starter`    | write              | stella:knowledge_write | —       | generic invoke → `stella playbooks from-starter`    |
-| `playbooks.get`             | read               | stella:read            | —       | covered by `list_playbooks`                         |
-| `playbooks.list`            | read               | stella:read            | —       | curated tool `list_playbooks`                       |
-| `playbooks.list-starters`   | read               | stella:read            | —       | generic invoke → `stella playbooks list-starters`   |
-| `playbooks.list-versions`   | read               | stella:read            | —       | generic invoke → `stella playbooks list-versions`   |
-| `playbooks.restore-version` | write              | stella:knowledge_write | —       | generic invoke → `stella playbooks restore-version` |
-| `playbooks.review`          | read               | stella:read            | —       | generic invoke → `stella playbooks review`          |
-| `playbooks.run`             | write              | stella:knowledge_write | —       | curated tool `run_playbook`                         |
-| `playbooks.update`          | write              | stella:knowledge_write | —       | generic invoke → `stella playbooks update`          |
+| Capability                  | Access             | Scope                  | Feature | Reachable via                                                  |
+| --------------------------- | ------------------ | ---------------------- | ------- | -------------------------------------------------------------- |
+| `playbooks.approve`         | write              | stella:knowledge_write | —       | generic invoke → `stella capability playbooks approve`         |
+| `playbooks.auto-run`        | write              | stella:knowledge_write | —       | generic invoke → `stella capability playbooks auto-run`        |
+| `playbooks.create`          | write              | stella:knowledge_write | —       | generic invoke → `stella capability playbooks create`          |
+| `playbooks.delete`          | write, destructive | stella:knowledge_write | —       | generic invoke → `stella capability playbooks delete`          |
+| `playbooks.from-starter`    | write              | stella:knowledge_write | —       | generic invoke → `stella capability playbooks from-starter`    |
+| `playbooks.get`             | read               | stella:read            | —       | covered by `list_playbooks`                                    |
+| `playbooks.list`            | read               | stella:read            | —       | curated tool `list_playbooks`                                  |
+| `playbooks.list-starters`   | read               | stella:read            | —       | generic invoke → `stella capability playbooks list-starters`   |
+| `playbooks.list-versions`   | read               | stella:read            | —       | generic invoke → `stella capability playbooks list-versions`   |
+| `playbooks.restore-version` | write              | stella:knowledge_write | —       | generic invoke → `stella capability playbooks restore-version` |
+| `playbooks.review`          | read               | stella:read            | —       | generic invoke → `stella capability playbooks review`          |
+| `playbooks.run`             | write              | stella:knowledge_write | —       | curated tool `run_playbook`                                    |
+| `playbooks.update`          | write              | stella:knowledge_write | —       | generic invoke → `stella capability playbooks update`          |
 
 ## properties
 
-| Capability                  | Access             | Scope                | Feature | Reachable via                                       |
-| --------------------------- | ------------------ | -------------------- | ------- | --------------------------------------------------- |
-| `properties.create`         | write              | stella:matters_write | —       | generic invoke → `stella properties create`         |
-| `properties.create-batch`   | write              | stella:matters_write | —       | generic invoke → `stella properties create-batch`   |
-| `properties.delete`         | write, destructive | stella:matters_write | —       | generic invoke → `stella properties delete`         |
-| `properties.list`           | read               | stella:read          | —       | curated tool `list_properties`                      |
-| `properties.preview`        | read               | stella:read          | —       | generic invoke → `stella properties preview`        |
-| `properties.suggest-prompt` | write              | stella:matters_write | —       | generic invoke → `stella properties suggest-prompt` |
-| `properties.update`         | write              | stella:matters_write | —       | generic invoke → `stella properties update`         |
+| Capability                  | Access             | Scope                | Feature | Reachable via                                                  |
+| --------------------------- | ------------------ | -------------------- | ------- | -------------------------------------------------------------- |
+| `properties.create`         | write              | stella:matters_write | —       | generic invoke → `stella capability properties create`         |
+| `properties.create-batch`   | write              | stella:matters_write | —       | generic invoke → `stella capability properties create-batch`   |
+| `properties.delete`         | write, destructive | stella:matters_write | —       | generic invoke → `stella capability properties delete`         |
+| `properties.list`           | read               | stella:read          | —       | curated tool `list_properties`                                 |
+| `properties.preview`        | read               | stella:read          | —       | generic invoke → `stella capability properties preview`        |
+| `properties.suggest-prompt` | write              | stella:matters_write | —       | generic invoke → `stella capability properties suggest-prompt` |
+| `properties.update`         | write              | stella:matters_write | —       | generic invoke → `stella capability properties update`         |
 
 ## rates
 
-| Capability             | Access             | Scope                | Feature              | Reachable via                                  |
-| ---------------------- | ------------------ | -------------------- | -------------------- | ---------------------------------------------- |
-| `rates.create`         | write              | stella:billing_write | FEATURE_TIME_BILLING | generic invoke → `stella rates create`         |
-| `rates.delete`         | write, destructive | stella:billing_write | FEATURE_TIME_BILLING | generic invoke → `stella rates delete`         |
-| `rates.entries-create` | write              | stella:billing_write | FEATURE_TIME_BILLING | generic invoke → `stella rates entries-create` |
-| `rates.entries-delete` | write, destructive | stella:billing_write | FEATURE_TIME_BILLING | generic invoke → `stella rates entries-delete` |
-| `rates.entries-read`   | read               | stella:read          | FEATURE_TIME_BILLING | generic invoke → `stella rates entries-read`   |
-| `rates.entries-update` | write              | stella:billing_write | FEATURE_TIME_BILLING | generic invoke → `stella rates entries-update` |
-| `rates.list`           | read               | stella:read          | FEATURE_TIME_BILLING | generic invoke → `stella rates list`           |
-| `rates.resolve`        | read               | stella:read          | FEATURE_TIME_BILLING | curated tool `resolve_rate`                    |
-| `rates.update`         | write              | stella:billing_write | FEATURE_TIME_BILLING | generic invoke → `stella rates update`         |
+| Capability             | Access             | Scope                | Feature              | Reachable via                                             |
+| ---------------------- | ------------------ | -------------------- | -------------------- | --------------------------------------------------------- |
+| `rates.create`         | write              | stella:billing_write | FEATURE_TIME_BILLING | generic invoke → `stella capability rates create`         |
+| `rates.delete`         | write, destructive | stella:billing_write | FEATURE_TIME_BILLING | generic invoke → `stella capability rates delete`         |
+| `rates.entries-create` | write              | stella:billing_write | FEATURE_TIME_BILLING | generic invoke → `stella capability rates entries-create` |
+| `rates.entries-delete` | write, destructive | stella:billing_write | FEATURE_TIME_BILLING | generic invoke → `stella capability rates entries-delete` |
+| `rates.entries-read`   | read               | stella:read          | FEATURE_TIME_BILLING | generic invoke → `stella capability rates entries-read`   |
+| `rates.entries-update` | write              | stella:billing_write | FEATURE_TIME_BILLING | generic invoke → `stella capability rates entries-update` |
+| `rates.list`           | read               | stella:read          | FEATURE_TIME_BILLING | generic invoke → `stella capability rates list`           |
+| `rates.resolve`        | read               | stella:read          | FEATURE_TIME_BILLING | curated tool `resolve_rate`                               |
+| `rates.update`         | write              | stella:billing_write | FEATURE_TIME_BILLING | generic invoke → `stella capability rates update`         |
 
 ## reports
 
-| Capability               | Access | Scope                | Feature | Reachable via                                    |
-| ------------------------ | ------ | -------------------- | ------- | ------------------------------------------------ |
-| `reports.clone-builtin`  | write  | stella:matters_write | —       | generic invoke → `stella reports clone-builtin`  |
-| `reports.export-view`    | write  | stella:matters_write | —       | generic invoke → `stella reports export-view`    |
-| `reports.list-exports`   | read   | stella:read          | —       | generic invoke → `stella reports list-exports`   |
-| `reports.list-templates` | read   | stella:read          | —       | generic invoke → `stella reports list-templates` |
-| `reports.read-export`    | write  | stella:matters_write | —       | generic invoke → `stella reports read-export`    |
+| Capability               | Access | Scope                | Feature | Reachable via                                               |
+| ------------------------ | ------ | -------------------- | ------- | ----------------------------------------------------------- |
+| `reports.clone-builtin`  | write  | stella:matters_write | —       | generic invoke → `stella capability reports clone-builtin`  |
+| `reports.export-view`    | write  | stella:matters_write | —       | generic invoke → `stella capability reports export-view`    |
+| `reports.list-exports`   | read   | stella:read          | —       | generic invoke → `stella capability reports list-exports`   |
+| `reports.list-templates` | read   | stella:read          | —       | generic invoke → `stella capability reports list-templates` |
+| `reports.read-export`    | write  | stella:matters_write | —       | generic invoke → `stella capability reports read-export`    |
 
 ## skills
 
 | Capability                 | Access             | Scope         | Feature | Reachable via                                                        |
 | -------------------------- | ------------------ | ------------- | ------- | -------------------------------------------------------------------- |
-| `skills.create`            | write              | stella:skills | —       | generic invoke → `stella skills create`                              |
-| `skills.delete`            | write, destructive | stella:skills | —       | generic invoke → `stella skills delete`                              |
-| `skills.from-blueprint`    | write              | stella:skills | —       | generic invoke → `stella skills from-blueprint`                      |
-| `skills.generate-draft`    | write              | stella:skills | —       | generic invoke → `stella skills generate-draft`                      |
-| `skills.get`               | read               | stella:skills | —       | generic invoke → `stella skills get`                                 |
-| `skills.import-url`        | write              | stella:skills | —       | generic invoke → `stella skills import-url`                          |
-| `skills.list`              | read               | stella:skills | —       | generic invoke → `stella skills list`                                |
-| `skills.list-commands`     | read               | stella:skills | —       | generic invoke → `stella skills list-commands`                       |
-| `skills.resources.create`  | write              | stella:skills | —       | generic invoke → `stella skills resources create`                    |
-| `skills.resources.delete`  | write, destructive | stella:skills | —       | generic invoke → `stella skills resources delete`                    |
-| `skills.resources.rename`  | write              | stella:skills | —       | generic invoke → `stella skills resources rename`                    |
-| `skills.resources.rewrite` | write              | stella:skills | —       | generic invoke → `stella skills resources rewrite`                   |
-| `skills.resources.update`  | write              | stella:skills | —       | generic invoke → `stella skills resources update`                    |
+| `skills.create`            | write              | stella:skills | —       | generic invoke → `stella capability skills create`                   |
+| `skills.delete`            | write, destructive | stella:skills | —       | generic invoke → `stella capability skills delete`                   |
+| `skills.from-blueprint`    | write              | stella:skills | —       | generic invoke → `stella capability skills from-blueprint`           |
+| `skills.generate-draft`    | write              | stella:skills | —       | generic invoke → `stella capability skills generate-draft`           |
+| `skills.get`               | read               | stella:skills | —       | generic invoke → `stella capability skills get`                      |
+| `skills.import-url`        | write              | stella:skills | —       | generic invoke → `stella capability skills import-url`               |
+| `skills.list`              | read               | stella:skills | —       | generic invoke → `stella capability skills list`                     |
+| `skills.list-commands`     | read               | stella:skills | —       | generic invoke → `stella capability skills list-commands`            |
+| `skills.resources.create`  | write              | stella:skills | —       | generic invoke → `stella capability skills resources-create`         |
+| `skills.resources.delete`  | write, destructive | stella:skills | —       | generic invoke → `stella capability skills resources-delete`         |
+| `skills.resources.rename`  | write              | stella:skills | —       | generic invoke → `stella capability skills resources-rename`         |
+| `skills.resources.rewrite` | write              | stella:skills | —       | generic invoke → `stella capability skills resources-rewrite`        |
+| `skills.resources.update`  | write              | stella:skills | —       | generic invoke → `stella capability skills resources-update`         |
 | `skills.resources.upload`  | write              | stella:skills | —       | generic invoke: file I/O — not runnable via CLI/JSON (describe only) |
-| `skills.seed`              | write              | stella:skills | —       | generic invoke → `stella skills seed`                                |
-| `skills.update`            | write              | stella:skills | —       | generic invoke → `stella skills update`                              |
+| `skills.seed`              | write              | stella:skills | —       | generic invoke → `stella capability skills seed`                     |
+| `skills.update`            | write              | stella:skills | —       | generic invoke → `stella capability skills update`                   |
 | `skills.upload`            | write              | stella:skills | —       | generic invoke: file I/O — not runnable via CLI/JSON (describe only) |
 
 ## style-sets
@@ -290,15 +290,15 @@ here as its CLI form). Projected from the same handler enumeration that builds
 | Capability                      | Access             | Scope            | Feature | Reachable via                                                        |
 | ------------------------------- | ------------------ | ---------------- | ------- | -------------------------------------------------------------------- |
 | `style-sets.create`             | write              | stella:templates | —       | generic invoke: file I/O — not runnable via CLI/JSON (describe only) |
-| `style-sets.create-from-editor` | write              | stella:templates | —       | generic invoke → `stella style-sets create-from-editor`              |
-| `style-sets.delete`             | write, destructive | stella:templates | —       | generic invoke → `stella style-sets delete`                          |
-| `style-sets.download`           | read               | stella:templates | —       | generic invoke → `stella style-sets download`                        |
-| `style-sets.list`               | read               | stella:templates | —       | generic invoke → `stella style-sets list`                            |
-| `style-sets.read-editor`        | read               | stella:templates | —       | generic invoke → `stella style-sets read-editor`                     |
-| `style-sets.read-stella-editor` | read               | stella:templates | —       | generic invoke → `stella style-sets read-stella-editor`              |
+| `style-sets.create-from-editor` | write              | stella:templates | —       | generic invoke → `stella capability style-sets create-from-editor`   |
+| `style-sets.delete`             | write, destructive | stella:templates | —       | generic invoke → `stella capability style-sets delete`               |
+| `style-sets.download`           | read               | stella:templates | —       | generic invoke → `stella capability style-sets download`             |
+| `style-sets.list`               | read               | stella:templates | —       | generic invoke → `stella capability style-sets list`                 |
+| `style-sets.read-editor`        | read               | stella:templates | —       | generic invoke → `stella capability style-sets read-editor`          |
+| `style-sets.read-stella-editor` | read               | stella:templates | —       | generic invoke → `stella capability style-sets read-stella-editor`   |
 | `style-sets.replace`            | write              | stella:templates | —       | generic invoke: file I/O — not runnable via CLI/JSON (describe only) |
-| `style-sets.update`             | write              | stella:templates | —       | generic invoke → `stella style-sets update`                          |
-| `style-sets.update-from-editor` | write              | stella:templates | —       | generic invoke → `stella style-sets update-from-editor`              |
+| `style-sets.update`             | write              | stella:templates | —       | generic invoke → `stella capability style-sets update`               |
+| `style-sets.update-from-editor` | write              | stella:templates | —       | generic invoke → `stella capability style-sets update-from-editor`   |
 
 ## tasks
 
@@ -316,34 +316,34 @@ here as its CLI form). Projected from the same handler enumeration that builds
 
 ## template-recipes
 
-| Capability                | Access             | Scope            | Feature | Reachable via                                     |
-| ------------------------- | ------------------ | ---------------- | ------- | ------------------------------------------------- |
-| `template-recipes.create` | write              | stella:templates | —       | generic invoke → `stella template-recipes create` |
-| `template-recipes.delete` | write, destructive | stella:templates | —       | generic invoke → `stella template-recipes delete` |
-| `template-recipes.list`   | read               | stella:templates | —       | generic invoke → `stella template-recipes list`   |
+| Capability                | Access             | Scope            | Feature | Reachable via                                                |
+| ------------------------- | ------------------ | ---------------- | ------- | ------------------------------------------------------------ |
+| `template-recipes.create` | write              | stella:templates | —       | generic invoke → `stella capability template-recipes create` |
+| `template-recipes.delete` | write, destructive | stella:templates | —       | generic invoke → `stella capability template-recipes delete` |
+| `template-recipes.list`   | read               | stella:templates | —       | generic invoke → `stella capability template-recipes list`   |
 
 ## templates
 
 | Capability                        | Access             | Scope            | Feature | Reachable via                                                        |
 | --------------------------------- | ------------------ | ---------------- | ------- | -------------------------------------------------------------------- |
-| `templates.binding-catalog`       | read               | stella:templates | —       | generic invoke → `stella templates binding-catalog`                  |
-| `templates.categories-create`     | write              | stella:templates | —       | generic invoke → `stella templates categories-create`                |
-| `templates.categories-delete`     | write, destructive | stella:templates | —       | generic invoke → `stella templates categories-delete`                |
-| `templates.categories-list`       | read               | stella:templates | —       | generic invoke → `stella templates categories-list`                  |
-| `templates.categories-update`     | write              | stella:templates | —       | generic invoke → `stella templates categories-update`                |
-| `templates.check`                 | read               | stella:templates | —       | generic invoke → `stella templates check`                            |
-| `templates.clause-slots`          | read               | stella:templates | —       | generic invoke → `stella templates clause-slots`                     |
-| `templates.clauses-link`          | write              | stella:templates | —       | generic invoke → `stella templates clauses-link`                     |
-| `templates.clauses-list`          | read               | stella:templates | —       | generic invoke → `stella templates clauses-list`                     |
-| `templates.clauses-slot-update`   | write              | stella:templates | —       | generic invoke → `stella templates clauses-slot-update`              |
-| `templates.clauses-sync`          | write              | stella:templates | —       | generic invoke → `stella templates clauses-sync`                     |
-| `templates.clauses-sync-all`      | write              | stella:templates | —       | generic invoke → `stella templates clauses-sync-all`                 |
-| `templates.clauses-unlink`        | write              | stella:templates | —       | generic invoke → `stella templates clauses-unlink`                   |
+| `templates.binding-catalog`       | read               | stella:templates | —       | generic invoke → `stella capability templates binding-catalog`       |
+| `templates.categories-create`     | write              | stella:templates | —       | generic invoke → `stella capability templates categories-create`     |
+| `templates.categories-delete`     | write, destructive | stella:templates | —       | generic invoke → `stella capability templates categories-delete`     |
+| `templates.categories-list`       | read               | stella:templates | —       | generic invoke → `stella capability templates categories-list`       |
+| `templates.categories-update`     | write              | stella:templates | —       | generic invoke → `stella capability templates categories-update`     |
+| `templates.check`                 | read               | stella:templates | —       | generic invoke → `stella capability templates check`                 |
+| `templates.clause-slots`          | read               | stella:templates | —       | generic invoke → `stella capability templates clause-slots`          |
+| `templates.clauses-link`          | write              | stella:templates | —       | generic invoke → `stella capability templates clauses-link`          |
+| `templates.clauses-list`          | read               | stella:templates | —       | generic invoke → `stella capability templates clauses-list`          |
+| `templates.clauses-slot-update`   | write              | stella:templates | —       | generic invoke → `stella capability templates clauses-slot-update`   |
+| `templates.clauses-sync`          | write              | stella:templates | —       | generic invoke → `stella capability templates clauses-sync`          |
+| `templates.clauses-sync-all`      | write              | stella:templates | —       | generic invoke → `stella capability templates clauses-sync-all`      |
+| `templates.clauses-unlink`        | write              | stella:templates | —       | generic invoke → `stella capability templates clauses-unlink`        |
 | `templates.create`                | write              | stella:templates | —       | curated tool `save_template`                                         |
-| `templates.create-blank`          | write              | stella:templates | —       | generic invoke → `stella templates create-blank`                     |
-| `templates.create-from-style-set` | write              | stella:templates | —       | generic invoke → `stella templates create-from-style-set`            |
+| `templates.create-blank`          | write              | stella:templates | —       | generic invoke → `stella capability templates create-blank`          |
+| `templates.create-from-style-set` | write              | stella:templates | —       | generic invoke → `stella capability templates create-from-style-set` |
 | `templates.create-from-styles`    | write              | stella:templates | —       | generic invoke: file I/O — not runnable via CLI/JSON (describe only) |
-| `templates.delete`                | write, destructive | stella:templates | —       | generic invoke → `stella templates delete`                           |
+| `templates.delete`                | write, destructive | stella:templates | —       | generic invoke → `stella capability templates delete`                |
 | `templates.discover`              | read               | stella:templates | —       | generic invoke: file I/O — not runnable via CLI/JSON (describe only) |
 | `templates.fill`                  | write              | stella:templates | —       | curated tool `fill_template`                                         |
 | `templates.fill-by-id`            | write              | stella:templates | —       | covered by `fill_template`                                           |
@@ -351,44 +351,44 @@ here as its CLI form). Projected from the same handler enumeration that builds
 | `templates.fill-to-workspace`     | write              | stella:templates | —       | covered by `fill_template`                                           |
 | `templates.get`                   | read               | stella:templates | —       | covered by `list_templates`                                          |
 | `templates.list`                  | read               | stella:templates | —       | curated tool `list_templates`                                        |
-| `templates.lookup-preview`        | read               | stella:templates | —       | generic invoke → `stella templates lookup-preview`                   |
+| `templates.lookup-preview`        | read               | stella:templates | —       | generic invoke → `stella capability templates lookup-preview`        |
 | `templates.manifest`              | read               | stella:templates | —       | generic invoke: file I/O — not runnable via CLI/JSON (describe only) |
 | `templates.prefill`               | write              | stella:templates | —       | generic invoke: file I/O — not runnable via CLI/JSON (describe only) |
 | `templates.prepare`               | write              | stella:templates | —       | generic invoke: file I/O — not runnable via CLI/JSON (describe only) |
-| `templates.preview`               | read               | stella:templates | —       | generic invoke → `stella templates preview`                          |
+| `templates.preview`               | read               | stella:templates | —       | generic invoke → `stella capability templates preview`               |
 | `templates.save-document`         | write              | stella:templates | —       | generic invoke: file I/O — not runnable via CLI/JSON (describe only) |
-| `templates.suggest-fields`        | write              | stella:templates | —       | generic invoke → `stella templates suggest-fields`                   |
-| `templates.update`                | write              | stella:templates | —       | generic invoke → `stella templates update`                           |
-| `templates.versions-diff`         | read               | stella:templates | —       | generic invoke → `stella templates versions-diff`                    |
-| `templates.versions-get`          | read               | stella:templates | —       | generic invoke → `stella templates versions-get`                     |
-| `templates.versions-list`         | read               | stella:templates | —       | generic invoke → `stella templates versions-list`                    |
-| `templates.versions-summarize`    | write              | stella:templates | —       | generic invoke → `stella templates versions-summarize`               |
+| `templates.suggest-fields`        | write              | stella:templates | —       | generic invoke → `stella capability templates suggest-fields`        |
+| `templates.update`                | write              | stella:templates | —       | generic invoke → `stella capability templates update`                |
+| `templates.versions-diff`         | read               | stella:templates | —       | generic invoke → `stella capability templates versions-diff`         |
+| `templates.versions-get`          | read               | stella:templates | —       | generic invoke → `stella capability templates versions-get`          |
+| `templates.versions-list`         | read               | stella:templates | —       | generic invoke → `stella capability templates versions-list`         |
+| `templates.versions-summarize`    | write              | stella:templates | —       | generic invoke → `stella capability templates versions-summarize`    |
 
 ## time-entries
 
 | Capability                  | Access             | Scope                | Feature              | Reachable via                                                        |
 | --------------------------- | ------------------ | -------------------- | -------------------- | -------------------------------------------------------------------- |
-| `time-entries.batch-delete` | write, destructive | stella:billing_write | FEATURE_TIME_BILLING | generic invoke → `stella time-entries batch-delete`                  |
-| `time-entries.batch-update` | write              | stella:billing_write | FEATURE_TIME_BILLING | generic invoke → `stella time-entries batch-update`                  |
+| `time-entries.batch-delete` | write, destructive | stella:billing_write | FEATURE_TIME_BILLING | generic invoke → `stella capability time-entries batch-delete`       |
+| `time-entries.batch-update` | write              | stella:billing_write | FEATURE_TIME_BILLING | generic invoke → `stella capability time-entries batch-update`       |
 | `time-entries.create`       | write              | stella:billing_write | FEATURE_TIME_BILLING | curated tool `save_time_entry`                                       |
 | `time-entries.delete`       | write, destructive | stella:billing_write | FEATURE_TIME_BILLING | curated tool `delete_time_entry`                                     |
-| `time-entries.export-csv`   | read               | stella:read          | FEATURE_TIME_BILLING | generic invoke → `stella time-entries export-csv`                    |
-| `time-entries.export-ledes` | read               | stella:read          | FEATURE_TIME_BILLING | generic invoke → `stella time-entries export-ledes`                  |
+| `time-entries.export-csv`   | read               | stella:read          | FEATURE_TIME_BILLING | generic invoke → `stella capability time-entries export-csv`         |
+| `time-entries.export-ledes` | read               | stella:read          | FEATURE_TIME_BILLING | generic invoke → `stella capability time-entries export-ledes`       |
 | `time-entries.export-pdf`   | read               | stella:read          | FEATURE_TIME_BILLING | generic invoke: file I/O — not runnable via CLI/JSON (describe only) |
 | `time-entries.get`          | read               | stella:read          | FEATURE_TIME_BILLING | covered by `list_time_entries`                                       |
 | `time-entries.list`         | read               | stella:read          | FEATURE_TIME_BILLING | curated tool `list_time_entries`                                     |
-| `time-entries.split`        | write              | stella:billing_write | FEATURE_TIME_BILLING | generic invoke → `stella time-entries split`                         |
-| `time-entries.timer-start`  | write              | stella:billing_write | FEATURE_TIME_BILLING | generic invoke → `stella time-entries timer-start`                   |
-| `time-entries.timer-stop`   | write              | stella:billing_write | FEATURE_TIME_BILLING | generic invoke → `stella time-entries timer-stop`                    |
+| `time-entries.split`        | write              | stella:billing_write | FEATURE_TIME_BILLING | generic invoke → `stella capability time-entries split`              |
+| `time-entries.timer-start`  | write              | stella:billing_write | FEATURE_TIME_BILLING | generic invoke → `stella capability time-entries timer-start`        |
+| `time-entries.timer-stop`   | write              | stella:billing_write | FEATURE_TIME_BILLING | generic invoke → `stella capability time-entries timer-stop`         |
 | `time-entries.update`       | write              | stella:billing_write | FEATURE_TIME_BILLING | covered by `save_time_entry`                                         |
 
 ## uploads
 
-| Capability       | Access             | Scope                | Feature | Reachable via                            |
-| ---------------- | ------------------ | -------------------- | ------- | ---------------------------------------- |
-| `uploads.create` | write              | stella:matters_write | —       | generic invoke → `stella uploads create` |
-| `uploads.delete` | write, destructive | stella:matters_write | —       | generic invoke → `stella uploads delete` |
-| `uploads.update` | write              | stella:matters_write | —       | generic invoke → `stella uploads update` |
+| Capability       | Access             | Scope                | Feature | Reachable via                                       |
+| ---------------- | ------------------ | -------------------- | ------- | --------------------------------------------------- |
+| `uploads.create` | write              | stella:matters_write | —       | generic invoke → `stella capability uploads create` |
+| `uploads.delete` | write, destructive | stella:matters_write | —       | generic invoke → `stella capability uploads delete` |
+| `uploads.update` | write              | stella:matters_write | —       | generic invoke → `stella capability uploads update` |
 
 ## usage
 
@@ -398,50 +398,50 @@ here as its CLI form). Projected from the same handler enumeration that builds
 
 ## view-templates
 
-| Capability              | Access             | Scope                | Feature | Reachable via                                   |
-| ----------------------- | ------------------ | -------------------- | ------- | ----------------------------------------------- |
-| `view-templates.create` | write              | stella:matters_write | —       | generic invoke → `stella view-templates create` |
-| `view-templates.delete` | write, destructive | stella:matters_write | —       | generic invoke → `stella view-templates delete` |
-| `view-templates.list`   | read               | stella:read          | —       | generic invoke → `stella view-templates list`   |
+| Capability              | Access             | Scope                | Feature | Reachable via                                              |
+| ----------------------- | ------------------ | -------------------- | ------- | ---------------------------------------------------------- |
+| `view-templates.create` | write              | stella:matters_write | —       | generic invoke → `stella capability view-templates create` |
+| `view-templates.delete` | write, destructive | stella:matters_write | —       | generic invoke → `stella capability view-templates delete` |
+| `view-templates.list`   | read               | stella:read          | —       | generic invoke → `stella capability view-templates list`   |
 
 ## views
 
 | Capability           | Access             | Scope                | Feature | Reachable via                                                        |
 | -------------------- | ------------------ | -------------------- | ------- | -------------------------------------------------------------------- |
-| `views.convert`      | write              | stella:matters_write | —       | generic invoke → `stella views convert`                              |
-| `views.create`       | write              | stella:matters_write | —       | generic invoke → `stella views create`                               |
-| `views.delete`       | write, destructive | stella:matters_write | —       | generic invoke → `stella views delete`                               |
-| `views.list`         | read               | stella:read          | —       | generic invoke → `stella views list`                                 |
-| `views.reorder`      | write              | stella:matters_write | —       | generic invoke → `stella views reorder`                              |
+| `views.convert`      | write              | stella:matters_write | —       | generic invoke → `stella capability views convert`                   |
+| `views.create`       | write              | stella:matters_write | —       | generic invoke → `stella capability views create`                    |
+| `views.delete`       | write, destructive | stella:matters_write | —       | generic invoke → `stella capability views delete`                    |
+| `views.list`         | read               | stella:read          | —       | generic invoke → `stella capability views list`                      |
+| `views.reorder`      | write              | stella:matters_write | —       | generic invoke → `stella capability views reorder`                   |
 | `views.table-export` | read               | stella:read          | —       | generic invoke: file I/O — not runnable via CLI/JSON (describe only) |
-| `views.update`       | write              | stella:matters_write | —       | generic invoke → `stella views update`                               |
+| `views.update`       | write              | stella:matters_write | —       | generic invoke → `stella capability views update`                    |
 
 ## workspaces
 
-| Capability                                  | Access             | Scope                | Feature | Reachable via                                                       |
-| ------------------------------------------- | ------------------ | -------------------- | ------- | ------------------------------------------------------------------- |
-| `workspaces.anonymization-allowlist.create` | write              | stella:matters_write | —       | generic invoke → `stella workspaces anonymization-allowlist create` |
-| `workspaces.anonymization-allowlist.delete` | write, destructive | stella:matters_write | —       | generic invoke → `stella workspaces anonymization-allowlist delete` |
-| `workspaces.anonymization-allowlist.list`   | read               | stella:read          | —       | generic invoke → `stella workspaces anonymization-allowlist list`   |
-| `workspaces.anonymization-terms.create`     | write              | stella:matters_write | —       | generic invoke → `stella workspaces anonymization-terms create`     |
-| `workspaces.anonymization-terms.delete`     | write, destructive | stella:matters_write | —       | generic invoke → `stella workspaces anonymization-terms delete`     |
-| `workspaces.anonymization-terms.list`       | read               | stella:read          | —       | generic invoke → `stella workspaces anonymization-terms list`       |
-| `workspaces.archive`                        | write              | stella:matters_write | —       | covered by `save_matter`                                            |
-| `workspaces.cell-retry`                     | write              | stella:matters_write | —       | generic invoke → `stella workspaces cell-retry`                     |
-| `workspaces.create`                         | write              | stella:matters_write | —       | curated tool `save_matter`                                          |
-| `workspaces.delete`                         | write, destructive | stella:matters_write | —       | curated tool `delete_matter`                                        |
-| `workspaces.duplicate`                      | write              | stella:matters_write | —       | generic invoke → `stella workspaces duplicate`                      |
-| `workspaces.list`                           | read               | stella:read          | —       | curated tool `list_matters`                                         |
-| `workspaces.read-justifications`            | read               | stella:read          | —       | generic invoke → `stella workspaces read-justifications`            |
-| `workspaces.read-workflow-status`           | read               | stella:read          | —       | generic invoke → `stella workspaces read-workflow-status`           |
-| `workspaces.read-workflow-target-count`     | read               | stella:read          | —       | generic invoke → `stella workspaces read-workflow-target-count`     |
-| `workspaces.unarchive`                      | write              | stella:matters_write | —       | covered by `save_matter`                                            |
-| `workspaces.update`                         | write              | stella:matters_write | —       | covered by `save_matter`                                            |
-| `workspaces.workflow-start`                 | write              | stella:matters_write | —       | generic invoke → `stella workspaces workflow-start`                 |
-| `workspaces.workspace-contacts-create`      | write              | stella:matters_write | —       | curated tool `link_matter_contact`                                  |
-| `workspaces.workspace-contacts-delete`      | write, destructive | stella:matters_write | —       | covered by `link_matter_contact`                                    |
-| `workspaces.workspace-members-add`          | write              | stella:admin_write   | —       | curated tool `manage_organization`                                  |
-| `workspaces.workspace-members-remove`       | write, destructive | stella:admin_write   | —       | covered by `manage_organization`                                    |
+| Capability                                  | Access             | Scope                | Feature | Reachable via                                                                  |
+| ------------------------------------------- | ------------------ | -------------------- | ------- | ------------------------------------------------------------------------------ |
+| `workspaces.anonymization-allowlist.create` | write              | stella:matters_write | —       | generic invoke → `stella capability workspaces anonymization-allowlist-create` |
+| `workspaces.anonymization-allowlist.delete` | write, destructive | stella:matters_write | —       | generic invoke → `stella capability workspaces anonymization-allowlist-delete` |
+| `workspaces.anonymization-allowlist.list`   | read               | stella:read          | —       | generic invoke → `stella capability workspaces anonymization-allowlist-list`   |
+| `workspaces.anonymization-terms.create`     | write              | stella:matters_write | —       | generic invoke → `stella capability workspaces anonymization-terms-create`     |
+| `workspaces.anonymization-terms.delete`     | write, destructive | stella:matters_write | —       | generic invoke → `stella capability workspaces anonymization-terms-delete`     |
+| `workspaces.anonymization-terms.list`       | read               | stella:read          | —       | generic invoke → `stella capability workspaces anonymization-terms-list`       |
+| `workspaces.archive`                        | write              | stella:matters_write | —       | covered by `save_matter`                                                       |
+| `workspaces.cell-retry`                     | write              | stella:matters_write | —       | generic invoke → `stella capability workspaces cell-retry`                     |
+| `workspaces.create`                         | write              | stella:matters_write | —       | curated tool `save_matter`                                                     |
+| `workspaces.delete`                         | write, destructive | stella:matters_write | —       | curated tool `delete_matter`                                                   |
+| `workspaces.duplicate`                      | write              | stella:matters_write | —       | generic invoke → `stella capability workspaces duplicate`                      |
+| `workspaces.list`                           | read               | stella:read          | —       | curated tool `list_matters`                                                    |
+| `workspaces.read-justifications`            | read               | stella:read          | —       | generic invoke → `stella capability workspaces read-justifications`            |
+| `workspaces.read-workflow-status`           | read               | stella:read          | —       | generic invoke → `stella capability workspaces read-workflow-status`           |
+| `workspaces.read-workflow-target-count`     | read               | stella:read          | —       | generic invoke → `stella capability workspaces read-workflow-target-count`     |
+| `workspaces.unarchive`                      | write              | stella:matters_write | —       | covered by `save_matter`                                                       |
+| `workspaces.update`                         | write              | stella:matters_write | —       | covered by `save_matter`                                                       |
+| `workspaces.workflow-start`                 | write              | stella:matters_write | —       | generic invoke → `stella capability workspaces workflow-start`                 |
+| `workspaces.workspace-contacts-create`      | write              | stella:matters_write | —       | curated tool `link_matter_contact`                                             |
+| `workspaces.workspace-contacts-delete`      | write, destructive | stella:matters_write | —       | covered by `link_matter_contact`                                               |
+| `workspaces.workspace-members-add`          | write              | stella:admin_write   | —       | curated tool `manage_organization`                                             |
+| `workspaces.workspace-members-remove`       | write, destructive | stella:admin_write   | —       | covered by `manage_organization`                                               |
 
 ## Waived internal handlers
 

--- a/packages/cli/skills/stella-cli/SKILL.md
+++ b/packages/cli/skills/stella-cli/SKILL.md
@@ -16,9 +16,10 @@ metadata:
 # stella CLI
 
 `@stll/cli` is the command-line client for stella, an open-source legal
-workspace. Its command surface (`stella <domain> <action>`) is generated from
-the stella MCP tool registry, so it mirrors exactly the tools a stella server
-exposes. Every command works for humans, scripts, and agents alike.
+workspace. Curated tools use `stella <domain> <action>`; generated capability
+commands use `stella capability <domain> <action>`. Both surfaces are
+generated from the stella MCP tool registry, so they mirror exactly the tools
+a stella server exposes. Every command works for humans, scripts, and agents alike.
 
 ## Install
 
@@ -92,8 +93,8 @@ code (no envelope) still maps to 5; anything else falls to 4.
 Beyond the curated commands above, the CLI generates 262
 capability commands from the server's capability catalog: every safe handler
 that is not a curated tool, reached through the generic `invoke_capability`
-path. They follow the same `stella <domain> <action>` shape (a colliding
-capability drops under `stella capability <domain> <action>` instead).
+path. Every generated command lives at `stella capability <domain> <action>`;
+multi-segment capability actions are flattened with hyphens into `<action>`.
 
 - **Discover**: `stella capability list [--domain <d>] [--access read|write]`
   enumerates them (paginated); `stella capability describe <id>` prints one

--- a/packages/cli/src/cli-commands.test.ts
+++ b/packages/cli/src/cli-commands.test.ts
@@ -348,7 +348,7 @@ describe("generated capability flags", () => {
   test("a descriptive long flag can target a terse query property", async () => {
     const server = startMockServer(() => ({ toolPayload: { items: [] } }));
     const result = await runCli({
-      args: ["contacts", "search", "--query", "agreement"],
+      args: ["capability", "contacts", "search", "--query", "agreement"],
       url: server.url,
       token: READ,
     });
@@ -774,7 +774,7 @@ describe("help surfaces --input for inputOnly tools", () => {
   test("uploads create --help renders every union branch from the schema", async () => {
     const server = startMockServer(() => ({ toolPayload: {} }));
     const result = await runCli({
-      args: ["uploads", "create", "--help"],
+      args: ["capability", "uploads", "create", "--help"],
       url: server.url,
       token: WRITE,
     });

--- a/packages/cli/src/cli-commands.test.ts
+++ b/packages/cli/src/cli-commands.test.ts
@@ -290,6 +290,51 @@ describe("one-command document upload", () => {
     expect(result.stdout).toContain("computes its SHA-256 checksum");
     expect(server.requests).toHaveLength(0);
   });
+
+  test("finalize failures print the canonical namespaced retry command", async () => {
+    const uploadDir = await mkdtemp(path.join(tmpdir(), "stella-upload-"));
+    tempDirs.push(uploadDir);
+    const filePath = path.join(uploadDir, "agreement.txt");
+    await writeFile(filePath, "agreement body");
+    let putUrl = "";
+    const server = startMockServer(
+      (request, index) => {
+        const capability = request.params.arguments?.["capability"];
+        if (index === 0 && capability === "uploads.create") {
+          return {
+            toolPayload: {
+              uploadId: "upload-1",
+              url: putUrl,
+              headers: { "content-type": "text/plain" },
+            },
+          };
+        }
+        return { toolPayload: { message: "finalize failed" }, isError: true };
+      },
+      () => new Response(null, { status: 200 }),
+    );
+    putUrl = `${server.url}/presigned/upload-1`;
+
+    const result = await runCli({
+      args: [
+        "upload",
+        "--workspace",
+        "workspace-1",
+        "--file",
+        filePath,
+        "--property-id",
+        "property-file",
+      ],
+      url: server.url,
+      token: WRITE,
+    });
+    server.stop();
+
+    expect(result.stderr).toContain(
+      "stella capability uploads update --workspace-id workspace-1 --upload-id upload-1",
+    );
+    expect(result.stderr).not.toContain("stella uploads update");
+  });
 });
 
 describe("auth and scope gating (S4)", () => {

--- a/packages/cli/src/codegen.ts
+++ b/packages/cli/src/codegen.ts
@@ -221,13 +221,8 @@ const { tree: routeMap, stats: capabilityStats } = buildCliRouteTree({
   entries: catalogEntries,
 });
 process.stderr.write(
-  `Capability tree: ${capabilityStats.generated} leaves generated, ${capabilityStats.suppressed} suppressed (file input/output), ${capabilityStats.collisionFallbacks.length} collision fallback(s), ${capabilityStats.flagCollisions.length} flag collision(s)\n`,
+  `Capability tree: ${capabilityStats.generated} namespaced leaves generated, ${capabilityStats.suppressed} suppressed (file input/output), ${capabilityStats.flagCollisions.length} flag collision(s)\n`,
 );
-if (capabilityStats.collisionFallbacks.length > 0) {
-  process.stderr.write(
-    `  collision fallbacks -> capability <domain> <action>: ${capabilityStats.collisionFallbacks.join(", ")}\n`,
-  );
-}
 if (capabilityStats.flagCollisions.length > 0) {
   process.stderr.write(
     `  flag collisions (part-prefixed): ${capabilityStats.flagCollisions

--- a/packages/cli/src/commands/upload.ts
+++ b/packages/cli/src/commands/upload.ts
@@ -3,6 +3,7 @@ import type { Command } from "@stricli/core";
 import { Result } from "better-result";
 
 import type { Context } from "../context.js";
+import { formatCapabilityCommand } from "../generate-capability-tree.js";
 import { EXIT_CODES } from "../mcp-constants.js";
 import {
   mapClientErrorExit,
@@ -123,7 +124,7 @@ export const uploadCommand: Command<Context> = buildCommand<
     }
     renderNestedFailure({ context: this, failure: uploaded.error.failure });
     writers.stderr(
-      `hint: retry finalization with 'stella uploads update --workspace-id ${flags.workspace} --upload-id ${uploaded.error.uploadId}'\n`,
+      `hint: retry finalization with '${formatCapabilityCommand("uploads.update")} --workspace-id ${flags.workspace} --upload-id ${uploaded.error.uploadId}'\n`,
     );
   },
   parameters: {

--- a/packages/cli/src/generate-capability-tree.test.ts
+++ b/packages/cli/src/generate-capability-tree.test.ts
@@ -58,21 +58,35 @@ const leafAt = (
 };
 
 describe("capabilityCommandPath", () => {
-  test("kebab-cases each dotted segment, including a camelCase leaf", () => {
+  test("namespaces and kebab-cases every capability at a fixed depth", () => {
     expect(capabilityCommandPath("time-entries.create")).toEqual([
+      "capability",
       "time-entries",
       "create",
     ]);
     expect(capabilityCommandPath("skills.resources.upload")).toEqual([
+      "capability",
       "skills",
-      "resources",
-      "upload",
+      "resources-upload",
     ]);
     expect(
       capabilityCommandPath(
         "entities.legacy-summaries.readLegacySummariesCount",
       ),
-    ).toEqual(["entities", "legacy-summaries", "read-legacy-summaries-count"]);
+    ).toEqual([
+      "capability",
+      "entities",
+      "legacy-summaries-read-legacy-summaries-count",
+    ]);
+  });
+
+  test("rejects ids without both a domain and action", () => {
+    expect(() => capabilityCommandPath("entities")).toThrow(
+      /must contain a domain and action/u,
+    );
+    expect(() => capabilityCommandPath("entities..read")).toThrow(
+      /must contain a domain and action/u,
+    );
   });
 });
 
@@ -382,7 +396,7 @@ describe("deriveCapabilityLeaf: pagination + suppression + truncation", () => {
   });
 });
 
-describe("insertCapabilities: merge + collisions", () => {
+describe("insertCapabilities: namespaced merge", () => {
   test("suppresses file-input/output entries but generates the rest", () => {
     const { stats } = insertCapabilities({
       tree: { kind: "route", children: {} },
@@ -397,7 +411,7 @@ describe("insertCapabilities: merge + collisions", () => {
     expect(stats.suppressedIds).toEqual(["b.upload", "c.export"]);
   });
 
-  test("a curated command wins; the capability drops under `capability ...`", () => {
+  test("a curated root command and namespaced capability never compete", () => {
     // Curated tree already owns `legislation search`.
     const curated: RouteNode = {
       kind: "route",
@@ -422,21 +436,20 @@ describe("insertCapabilities: merge + collisions", () => {
         },
       },
     };
-    const { tree, stats } = insertCapabilities({
+    const { tree } = insertCapabilities({
       tree: curated,
       entries: [entry({ id: "legislation.search" })],
     });
-    expect(stats.collisionFallbacks).toEqual(["legislation.search"]);
     // Curated leaf untouched.
     expect(leafAt(tree, ["legislation", "search"])).toBeUndefined();
-    // Capability relocated under the `capability` group.
+    // Capability always lives under the `capability` group.
     expect(
       leafAt(tree, ["capability", "legislation", "search"])?.capabilityId,
     ).toBe("legislation.search");
   });
 
-  test("a reserved hand-wired namespace forces the capability fallback", () => {
-    const { tree, stats } = insertCapabilities({
+  test("a hand-wired root namespace cannot capture a capability domain", () => {
+    const { tree } = insertCapabilities({
       tree: { kind: "route", children: {} },
       entries: [entry({ id: "upload.create" })],
     });
@@ -445,23 +458,21 @@ describe("insertCapabilities: merge + collisions", () => {
     expect(leafAt(tree, ["capability", "upload", "create"])?.capabilityId).toBe(
       "upload.create",
     );
-    expect(stats.collisionFallbacks).toEqual(["upload.create"]);
   });
 
-  test("a capability that is a prefix of another falls back rather than clobbering", () => {
-    const { tree, stats } = insertCapabilities({
+  test("prefix capability ids coexist at fixed-depth action paths", () => {
+    const { tree } = insertCapabilities({
       tree: { kind: "route", children: {} },
       entries: [
         entry({ id: "entities.read-summaries" }),
         entry({ id: "entities.read-summaries.count" }),
       ],
     });
-    expect(leafAt(tree, ["entities", "read-summaries"])?.capabilityId).toBe(
-      "entities.read-summaries",
-    );
-    expect(stats.collisionFallbacks).toContain("entities.read-summaries.count");
     expect(
-      leafAt(tree, ["capability", "entities", "read-summaries", "count"])
+      leafAt(tree, ["capability", "entities", "read-summaries"])?.capabilityId,
+    ).toBe("entities.read-summaries");
+    expect(
+      leafAt(tree, ["capability", "entities", "read-summaries-count"])
         ?.capabilityId,
     ).toBe("entities.read-summaries.count");
   });
@@ -493,34 +504,16 @@ describe("insertCapabilities: against the real curated tree + catalog", () => {
 });
 
 /**
- * Namespaces where a curated, hand-written command still shares a top-level name
- * with generated capability commands. Each entry means a caller typing
- * `stella <namespace> …` cannot tell whether they get a named MCP tool or the
- * generic `invoke_capability` path — the exact drift this guard exists to stop.
- *
- * The list may only SHRINK: it is seeded with the four namespaces that were
- * already split when the guard landed, and is ratcheted by
- * `cli-shadowed-namespaces` in `scripts/ratchet.ts`. Adding a curated command in
- * a namespace a capability occupies fails this test rather than silently landing.
+ * Ratcheted by `cli-shadowed-namespaces` in `scripts/ratchet.ts`. This stays
+ * empty because the generator makes root-level capability leaves impossible.
  */
-const SHADOWED_NAMESPACE_ALLOWLIST: readonly string[] = [
-  "capability",
-  "case-law",
-  "legislation",
-  "usage",
-];
-
-/**
- * Capabilities whose natural command path is taken by a curated command, so they
- * are relocated under `stella capability <domain> <action>`. A relocation is a
- * symptom of the same shadowing problem, so it is pinned rather than merely counted.
- */
-const COLLISION_FALLBACK_ALLOWLIST: readonly string[] = ["legislation.search"];
+const SHADOWED_NAMESPACE_ALLOWLIST: readonly string[] = [];
 
 describe("curated commands must not shadow capability commands", () => {
   const namespacesByKind = (node: RouteNode) => {
     const curated = new Set<string>();
     const capability = new Set<string>();
+    const capabilityPaths: string[][] = [];
     const walk = (current: RouteNode, path: readonly string[]): void => {
       if (current.kind === "route") {
         for (const [segment, child] of Object.entries(current.children)) {
@@ -532,13 +525,18 @@ describe("curated commands must not shadow capability commands", () => {
       if (top === undefined) {
         return;
       }
-      (current.kind === "leaf" ? curated : capability).add(top);
+      if (current.kind === "leaf") {
+        curated.add(top);
+        return;
+      }
+      capability.add(top);
+      capabilityPaths.push([...path]);
     };
     walk(node, []);
-    return { capability, curated };
+    return { capability, capabilityPaths, curated };
   };
 
-  test("no curated command occupies a namespace a capability occupies", async () => {
+  test("every generated capability stays at one fixed-depth namespace", async () => {
     const catalog: CapabilityCatalogEntry[] = await Bun.file(
       new URL("generated/capability-catalog.json", import.meta.url),
     ).json();
@@ -549,13 +547,21 @@ describe("curated commands must not shadow capability commands", () => {
       entries: catalog,
       tree: generateRouteMap(listings, TOOL_ANNOTATIONS),
     });
-    const { capability, curated } = namespacesByKind(tree);
-    const shadowed = [...curated].filter((ns) => capability.has(ns)).sort();
+    const { capability, capabilityPaths, curated } = namespacesByKind(tree);
+    const shadowed = [...curated]
+      .filter((namespace) =>
+        namespace === "capability" ? false : capability.has(namespace),
+      )
+      .sort();
 
+    expect([...capability]).toEqual(["capability"]);
+    expect(
+      capabilityPaths.every(
+        (path) => path.length === 3 && path.at(0) === "capability",
+      ),
+    ).toBe(true);
     expect(shadowed).toEqual([...SHADOWED_NAMESPACE_ALLOWLIST].sort());
-    expect([...stats.collisionFallbacks].sort()).toEqual(
-      [...COLLISION_FALLBACK_ALLOWLIST].sort(),
-    );
+    expect(stats.generated).toBeGreaterThan(0);
   });
 });
 

--- a/packages/cli/src/generate-capability-tree.test.ts
+++ b/packages/cli/src/generate-capability-tree.test.ts
@@ -5,6 +5,7 @@ import { parseCapabilityCatalog } from "./capability-catalog-load.js";
 import {
   type CapabilityCatalogEntry,
   capabilityCommandPath,
+  formatCapabilityCommand,
   deriveCapabilityLeaf,
   insertCapabilities,
 } from "./generate-capability-tree.js";
@@ -58,6 +59,12 @@ const leafAt = (
 };
 
 describe("capabilityCommandPath", () => {
+  test("formats executable guidance from the same typed path", () => {
+    expect(formatCapabilityCommand("uploads.update")).toBe(
+      "stella capability uploads update",
+    );
+  });
+
   test("namespaces and kebab-cases every capability at a fixed depth", () => {
     expect(capabilityCommandPath("time-entries.create")).toEqual([
       "capability",

--- a/packages/cli/src/generate-capability-tree.ts
+++ b/packages/cli/src/generate-capability-tree.ts
@@ -3,13 +3,14 @@
 // into the SAME `RouteNode` tree the curated 44-tool commands live in. Pure and
 // deterministic: same catalog + curated tree -> byte-identical merged tree.
 //
-// Every non-suppressed catalog entry becomes a `stella <domain> <action>` leaf
+// Every non-suppressed catalog entry becomes a
+// `stella capability <domain> <action>` leaf
 // whose executor calls the generic `invoke_capability` tool. Entries with
 // `requiresFileInput`/`returnsFileResponse` are suppressed (they can never
 // succeed through the JSON generic path) but stay reachable via
-// `stella capability describe` for discovery. Curated commands win every path
-// collision; a colliding capability leaf drops under `stella capability
-// <domain> <action>` instead.
+// `stella capability describe` for discovery. Keeping every generic capability
+// below one namespace makes it impossible for a future catalog domain to
+// recreate a parallel root command group beside the curated CLI.
 
 import { RESERVED_FLAGS, RESERVED_TOP_LEVEL_NAMES } from "./annotations.js";
 import { flagKey } from "./flag-name.js";
@@ -57,8 +58,6 @@ export type CapabilityTreeStats = {
   /** Entries suppressed for file input/output (unreachable through generic invoke). */
   suppressed: number;
   suppressedIds: readonly string[];
-  /** Capability ids relocated under `capability <domain> <action>` on a collision. */
-  collisionFallbacks: readonly string[];
   /** Per-flag cross-part/reserved collisions resolved by part-prefixing. */
   flagCollisions: readonly { id: string; flag: string }[];
 };
@@ -94,9 +93,30 @@ const toolScopeOf = (scope: string): ToolScope | undefined => {
   return isToolScope(bare) ? bare : undefined;
 };
 
-/** The command path for a capability id: kebab every dot-separated segment. */
-export const capabilityCommandPath = (id: string): readonly string[] =>
-  id.split(".").map((segment) => kebabCase(segment));
+/**
+ * The namespaced command path for a capability id. The domain stays grouped,
+ * while every remaining id segment is flattened into one action. Fixed-depth
+ * paths make prefix ids (for example `entities.read` and
+ * `entities.read.count`) representable without a leaf/route collision.
+ */
+export const capabilityCommandPath = (id: string): readonly string[] => {
+  const [rawDomain, ...rawAction] = id.split(".");
+  if (
+    rawDomain === undefined ||
+    rawDomain.length === 0 ||
+    rawAction.length === 0 ||
+    rawAction.some((segment) => segment.length === 0)
+  ) {
+    throw new RouteGenerationError(
+      `capability "${id}" must contain a domain and action`,
+    );
+  }
+  return [
+    "capability",
+    kebabCase(rawDomain),
+    rawAction.map((segment) => kebabCase(segment)).join("-"),
+  ];
+};
 
 const propertyMap = (
   schema: JsonSchema | undefined,
@@ -534,10 +554,9 @@ const insertAt = (
 };
 
 /**
- * Merge every non-suppressed capability into `tree` (mutated in place and
- * returned). Curated commands win: a capability whose natural path collides
- * drops under `capability <domain> <action>`; if even that collides the codegen
- * fails hard (a real ambiguity a reviewer must resolve).
+ * Merge every non-suppressed capability into the dedicated `capability`
+ * namespace (mutating and returning `tree`). Any collision fails generation;
+ * generic capability leaves can never leak back into a root domain.
  */
 export const insertCapabilities = ({
   tree,
@@ -547,7 +566,6 @@ export const insertCapabilities = ({
   entries: readonly CapabilityCatalogEntry[];
 }): { tree: RouteNode; stats: CapabilityTreeStats } => {
   const suppressedIds: string[] = [];
-  const collisionFallbacks: string[] = [];
   const flagCollisions: { id: string; flag: string }[] = [];
   let generated = 0;
 
@@ -564,23 +582,12 @@ export const insertCapabilities = ({
     for (const flag of collisions) {
       flagCollisions.push({ id: entry.id, flag });
     }
-    const natural = spec.commandPath;
-    if (canInsert(tree, natural)) {
-      insertAt(tree, natural, { kind: "capability-leaf", spec });
-      generated += 1;
-      continue;
-    }
-    const fallback = ["capability", ...natural];
-    if (!canInsert(tree, fallback)) {
+    if (!canInsert(tree, spec.commandPath)) {
       throw new RouteGenerationError(
-        `capability "${entry.id}" collides at both ${natural.join(" ")} and capability ${natural.join(" ")}`,
+        `capability "${entry.id}" collides at ${spec.commandPath.join(" ")}`,
       );
     }
-    collisionFallbacks.push(entry.id);
-    insertAt(tree, fallback, {
-      kind: "capability-leaf",
-      spec: { ...spec, commandPath: fallback },
-    });
+    insertAt(tree, spec.commandPath, { kind: "capability-leaf", spec });
     generated += 1;
   }
 
@@ -590,7 +597,6 @@ export const insertCapabilities = ({
       generated,
       suppressed: suppressedIds.length,
       suppressedIds,
-      collisionFallbacks,
       flagCollisions,
     },
   };

--- a/packages/cli/src/generate-capability-tree.ts
+++ b/packages/cli/src/generate-capability-tree.ts
@@ -65,6 +65,9 @@ export type CapabilityTreeStats = {
 /** The three input parts, in the deterministic order flags are emitted. */
 const PARTS: readonly CapabilityPart[] = ["params", "body", "query"];
 
+/** The single root beneath which all generated capability commands live. */
+const CAPABILITY_NAMESPACE = "capability";
+
 /** Valid `ToolScope` strings, for mapping a catalog `stella:*` scope to a precheck. */
 const TOOL_SCOPES: ReadonlySet<string> = new Set<ToolScope>([
   "read",
@@ -112,7 +115,7 @@ export const capabilityCommandPath = (id: string): readonly string[] => {
     );
   }
   return [
-    "capability",
+    CAPABILITY_NAMESPACE,
     kebabCase(rawDomain),
     rawAction.map((segment) => kebabCase(segment)).join("-"),
   ];

--- a/packages/cli/src/generate-capability-tree.ts
+++ b/packages/cli/src/generate-capability-tree.ts
@@ -66,7 +66,7 @@ export type CapabilityTreeStats = {
 const PARTS: readonly CapabilityPart[] = ["params", "body", "query"];
 
 /** The single root beneath which all generated capability commands live. */
-const CAPABILITY_NAMESPACE = "capability";
+export const CAPABILITY_NAMESPACE = "capability";
 
 /** Valid `ToolScope` strings, for mapping a catalog `stella:*` scope to a precheck. */
 const TOOL_SCOPES: ReadonlySet<string> = new Set<ToolScope>([

--- a/packages/cli/src/generate-capability-tree.ts
+++ b/packages/cli/src/generate-capability-tree.ts
@@ -68,6 +68,15 @@ const PARTS: readonly CapabilityPart[] = ["params", "body", "query"];
 /** The single root beneath which all generated capability commands live. */
 export const CAPABILITY_NAMESPACE = "capability";
 
+export type CapabilityCommandPath = readonly [
+  typeof CAPABILITY_NAMESPACE,
+  string,
+  string,
+];
+
+export type FormattedCapabilityCommand =
+  `stella ${typeof CAPABILITY_NAMESPACE} ${string} ${string}`;
+
 /** Valid `ToolScope` strings, for mapping a catalog `stella:*` scope to a precheck. */
 const TOOL_SCOPES: ReadonlySet<string> = new Set<ToolScope>([
   "read",
@@ -102,7 +111,7 @@ const toolScopeOf = (scope: string): ToolScope | undefined => {
  * paths make prefix ids (for example `entities.read` and
  * `entities.read.count`) representable without a leaf/route collision.
  */
-export const capabilityCommandPath = (id: string): readonly string[] => {
+export const capabilityCommandPath = (id: string): CapabilityCommandPath => {
   const [rawDomain, ...rawAction] = id.split(".");
   if (
     rawDomain === undefined ||
@@ -119,6 +128,14 @@ export const capabilityCommandPath = (id: string): readonly string[] => {
     kebabCase(rawDomain),
     rawAction.map((segment) => kebabCase(segment)).join("-"),
   ];
+};
+
+/** Render the exact executable command prefix for one capability id. */
+export const formatCapabilityCommand = (
+  id: string,
+): FormattedCapabilityCommand => {
+  const [namespace, domain, action] = capabilityCommandPath(id);
+  return `stella ${namespace} ${domain} ${action}`;
 };
 
 const propertyMap = (

--- a/packages/cli/src/generate-skill.test.ts
+++ b/packages/cli/src/generate-skill.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
 import { TOOL_ANNOTATIONS } from "./annotations.js";
+import { CAPABILITY_NAMESPACE } from "./generate-capability-tree.js";
 import { generateCliSkill, SKILL_NAME } from "./generate-skill.js";
 import type { RegistryToolListing } from "./route-types.js";
 
@@ -41,6 +42,8 @@ describe("generateCliSkill (TanStack Intent)", () => {
     expect(skill).toContain("237");
     expect(skill).toContain("stella capability list");
     expect(skill).toContain("stella capability describe");
+    expect(skill).toContain(`stella ${CAPABILITY_NAMESPACE} <domain> <action>`);
+    expect(skill).not.toContain("a colliding capability drops under");
     expect(skill).toContain("--dry-run");
   });
 

--- a/packages/cli/src/generate-skill.ts
+++ b/packages/cli/src/generate-skill.ts
@@ -8,6 +8,7 @@
 
 import { panic } from "better-result";
 
+import { CAPABILITY_NAMESPACE } from "./generate-capability-tree.js";
 import { generateRouteMap } from "./generate-route-map.js";
 import { EXIT_CODES } from "./mcp-constants.js";
 import type {
@@ -150,8 +151,8 @@ const renderCapabilitySection = (summary: CapabilitySkillSummary): string =>
     `Beyond the curated commands above, the CLI generates ${summary.commandCount}`,
     "capability commands from the server's capability catalog: every safe handler",
     "that is not a curated tool, reached through the generic `invoke_capability`",
-    "path. They follow the same `stella <domain> <action>` shape (a colliding",
-    "capability drops under `stella capability <domain> <action>` instead).",
+    `path. Every generated command lives at \`stella ${CAPABILITY_NAMESPACE} <domain> <action>\`;`,
+    "multi-segment capability actions are flattened with hyphens into `<action>`.",
     "",
     "- **Discover**: `stella capability list [--domain <d>] [--access read|write]`",
     "  enumerates them (paginated); `stella capability describe <id>` prints one",
@@ -204,9 +205,10 @@ export const generateCliSkill = (
     "# stella CLI",
     "",
     "`@stll/cli` is the command-line client for stella, an open-source legal",
-    "workspace. Its command surface (`stella <domain> <action>`) is generated from",
-    "the stella MCP tool registry, so it mirrors exactly the tools a stella server",
-    "exposes. Every command works for humans, scripts, and agents alike.",
+    "workspace. Curated tools use `stella <domain> <action>`; generated capability",
+    `commands use \`stella ${CAPABILITY_NAMESPACE} <domain> <action>\`. Both surfaces are`,
+    "generated from the stella MCP tool registry, so they mirror exactly the tools",
+    "a stella server exposes. Every command works for humans, scripts, and agents alike.",
     "",
     "## Install",
     "",

--- a/packages/cli/src/upload-document.test.ts
+++ b/packages/cli/src/upload-document.test.ts
@@ -193,6 +193,23 @@ describe("document upload state machine", () => {
     expect(capabilities).toEqual(["properties.list"]);
   });
 
+  test("missing file properties point to the canonical capability command", async () => {
+    const dependencies = createDependencies({
+      invoke: async () => ({ status: "ok", payload: [] }),
+    });
+
+    const result = await uploadDocument({ dependencies, input: uploadInput });
+
+    expect(Result.isError(result)).toBe(true);
+    if (Result.isError(result)) {
+      expect(result.error).toEqual(
+        expect.objectContaining({
+          message: expect.stringContaining("stella capability properties list"),
+        }),
+      );
+    }
+  });
+
   test("a failed PUT always aborts the reservation and never finalizes", async () => {
     const calls: InvocationCall[] = [];
     const dependencies = createDependencies({
@@ -225,6 +242,34 @@ describe("document upload state machine", () => {
     expect(
       calls.some(({ capability }) => capability === "uploads.update"),
     ).toBe(false);
+  });
+
+  test("failed cleanup points to the canonical capability command", async () => {
+    const dependencies = createDependencies({
+      invoke: async (capability) =>
+        capability === "uploads.create"
+          ? { status: "ok", payload: reservation }
+          : {
+              status: "tool-error",
+              result: { isError: true, content: [] },
+            },
+      put: async () => Result.err("PUT rejected"),
+    });
+
+    const result = await uploadDocument({
+      dependencies,
+      input: { ...uploadInput, propertyId: "file-property" },
+    });
+
+    expect(Result.isError(result)).toBe(true);
+    if (Result.isError(result) && result.error.type === "put") {
+      expect(result.error.cleanupWarning).toContain(
+        "stella capability uploads delete",
+      );
+      expect(result.error.cleanupWarning).not.toContain(
+        "stella uploads delete",
+      );
+    }
   });
 
   test("a malformed reservation with a known id is abandoned", async () => {

--- a/packages/cli/src/upload-document.ts
+++ b/packages/cli/src/upload-document.ts
@@ -4,6 +4,7 @@ import { open } from "node:fs/promises";
 import path from "node:path";
 
 import { inferFileMimeType } from "./file-mime-type.js";
+import { formatCapabilityCommand } from "./generate-capability-tree.js";
 import type { CallToolResult, McpClientError } from "./mcp-client.js";
 import { callTool } from "./mcp-client.js";
 import { parsePayload } from "./run-leaf-command.js";
@@ -265,8 +266,7 @@ const resolveFilePropertyId = async ({
   if (filePropertyIds.length === 0) {
     return Result.err({
       type: "server-response",
-      message:
-        "No file property exists in this matter; pass --property-id after inspecting 'stella properties list'",
+      message: `No file property exists in this matter; pass --property-id after inspecting '${formatCapabilityCommand(UPLOAD_CAPABILITIES.listProperties)}'`,
     });
   }
   return Result.err({
@@ -322,7 +322,7 @@ const abortUpload = async ({
   );
   return aborted.status === "ok"
     ? undefined
-    : `Cleanup failed for reserved upload ${uploadId}; run 'stella uploads delete --workspace-id ${workspaceId} --upload-id ${uploadId} --yes'`;
+    : `Cleanup failed for reserved upload ${uploadId}; run '${formatCapabilityCommand(UPLOAD_CAPABILITIES.abort)} --workspace-id ${workspaceId} --upload-id ${uploadId} --yes'`;
 };
 
 /**

--- a/scripts/ratchet-baseline.json
+++ b/scripts/ratchet-baseline.json
@@ -583,10 +583,8 @@
     }
   },
   "cli-shadowed-namespaces": {
-    "count": 4,
-    "files": {
-      "packages/cli/src/generate-capability-tree.test.ts": 4
-    }
+    "count": 0,
+    "files": {}
   },
   "cross-feature-imports": {
     "count": 0,


### PR DESCRIPTION
## Summary

- keep curated, task-oriented CLI commands at the root and move every generic registry capability below `stella capability <domain> <action>`
- flatten multi-segment capability actions to a fixed-depth command path, so prefix IDs cannot collide as leaf-versus-route nodes
- update generated routes and capability coverage documentation to the canonical paths
- reduce and lock the `cli-shadowed-namespaces` ratchet from 4 to 0

## Structural safeguards

- the capability path constructor always returns the dedicated namespace and rejects malformed IDs
- insertion fails hard on any namespaced collision; it never falls back to a second root surface
- real-catalog invariants assert every generated capability has exactly one fixed-depth `capability` path
- prefix-ID coverage proves both a capability and its dotted descendant remain representable

## Verification

- `bun run verify`
- 403 CLI tests pass
- root `stella --help` now exposes only curated domain groups plus the single `capability` namespace

Stacked on #1324.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Generic CLI capability commands are now consistently accessed via `stella capability <domain> <action>`, with standardised hyphenated action names for multi-segment actions.

- **Documentation**
  - Regenerated capability coverage tables and updated CLI skill documentation to reflect the unified command structure.

- **Bug Fixes**
  - Improved capability command-path generation and validation for incomplete identifiers.
  - Updated upload failure guidance (including retry hints and cleanup messages) to use canonical `stella capability ...` commands.

- **Tests**
  - Extended CLI and upload-related end-to-end tests to cover the updated messaging and command formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->