### PR TITLE
fix: keep GitHub attribution non-notifying

### DIFF
--- a/.agents/skills/rabbit-round/SKILL.md
+++ b/.agents/skills/rabbit-round/SKILL.md
@@ -19,9 +19,13 @@ state, and stops. Do not schedule future runs from inside this skill.
    # Get PR number for this branch
    gh pr view --json number -q '.number'
 
-   # Get current GitHub username (for CC attribution)
+   # Get current GitHub username (for plain-text CC attribution)
    gh api user --jq '.login'
    ```
+
+   Every published reply must end with `CC on behalf of {username}`. Keep the
+   username as plain text: never prefix it with `@` or turn it into a link,
+   because that would trigger a GitHub mention notification.
 
 2. **Fetch all bot comments** - Prefer GraphQL for review threads to only process unresolved ones:
 
@@ -80,7 +84,7 @@ state, and stops. Do not schedule future runs from inside this skill.
      -X POST \
      -f body="[response]
 
-   CC on behalf of @{username}" \
+   CC on behalf of {username}" \
      -f commit_id="{commit_sha}" \
      -f path="{file_path}" \
      -F in_reply_to={comment_id}
@@ -93,7 +97,7 @@ state, and stops. Do not schedule future runs from inside this skill.
      -X POST \
      -f body="[response]
 
-   CC on behalf of @{username}"
+   CC on behalf of {username}"
    ```
 
 5. **Resolve addressed bot review threads** using GraphQL (never resolve human
@@ -243,14 +247,16 @@ state, and stops. Do not schedule future runs from inside this skill.
 
 ## Response Templates
 
-Reply format: Put the response first, then sign with `CC on behalf of @{username}`.
+Reply format: Put the response first, then sign with
+`CC on behalf of {username}`. Substitute the current GitHub username without
+an `@` prefix or profile link.
 
 **Accepting:**
 
 ```text
 Accepted and implemented. [Brief description of change].
 
-CC on behalf of @username
+CC on behalf of username
 ```
 
 **Accepting with modification:**
@@ -258,7 +264,7 @@ CC on behalf of @username
 ```text
 Agreed with the principle. Implementing with a slight modification: [explain].
 
-CC on behalf of @username
+CC on behalf of username
 ```
 
 **Pushing back:**
@@ -267,7 +273,7 @@ CC on behalf of @username
 Pushing back on this. [Reason]. Our convention is [explain pattern/reference
 CLAUDE.md].
 
-CC on behalf of @username
+CC on behalf of username
 ```
 
 **Already addressed:**
@@ -275,5 +281,5 @@ CC on behalf of @username
 ```text
 Already addressed in commit [hash]. [Brief description].
 
-CC on behalf of @username
+CC on behalf of username
 ```

--- a/.ai/local-skills/rabbit-round/SKILL.md
+++ b/.ai/local-skills/rabbit-round/SKILL.md
@@ -19,9 +19,13 @@ state, and stops. Do not schedule future runs from inside this skill.
    # Get PR number for this branch
    gh pr view --json number -q '.number'
 
-   # Get current GitHub username (for CC attribution)
+   # Get current GitHub username (for plain-text CC attribution)
    gh api user --jq '.login'
    ```
+
+   Every published reply must end with `CC on behalf of {username}`. Keep the
+   username as plain text: never prefix it with `@` or turn it into a link,
+   because that would trigger a GitHub mention notification.
 
 2. **Fetch all bot comments** - Prefer GraphQL for review threads to only process unresolved ones:
 
@@ -80,7 +84,7 @@ state, and stops. Do not schedule future runs from inside this skill.
      -X POST \
      -f body="[response]
 
-   CC on behalf of @{username}" \
+   CC on behalf of {username}" \
      -f commit_id="{commit_sha}" \
      -f path="{file_path}" \
      -F in_reply_to={comment_id}
@@ -93,7 +97,7 @@ state, and stops. Do not schedule future runs from inside this skill.
      -X POST \
      -f body="[response]
 
-   CC on behalf of @{username}"
+   CC on behalf of {username}"
    ```
 
 5. **Resolve addressed bot review threads** using GraphQL (never resolve human
@@ -243,14 +247,16 @@ state, and stops. Do not schedule future runs from inside this skill.
 
 ## Response Templates
 
-Reply format: Put the response first, then sign with `CC on behalf of @{username}`.
+Reply format: Put the response first, then sign with
+`CC on behalf of {username}`. Substitute the current GitHub username without
+an `@` prefix or profile link.
 
 **Accepting:**
 
 ```text
 Accepted and implemented. [Brief description of change].
 
-CC on behalf of @username
+CC on behalf of username
 ```
 
 **Accepting with modification:**
@@ -258,7 +264,7 @@ CC on behalf of @username
 ```text
 Agreed with the principle. Implementing with a slight modification: [explain].
 
-CC on behalf of @username
+CC on behalf of username
 ```
 
 **Pushing back:**
@@ -267,7 +273,7 @@ CC on behalf of @username
 Pushing back on this. [Reason]. Our convention is [explain pattern/reference
 CLAUDE.md].
 
-CC on behalf of @username
+CC on behalf of username
 ```
 
 **Already addressed:**
@@ -275,5 +281,5 @@ CC on behalf of @username
 ```text
 Already addressed in commit [hash]. [Brief description].
 
-CC on behalf of @username
+CC on behalf of username
 ```

--- a/.claude/commands/rabbit-round.md
+++ b/.claude/commands/rabbit-round.md
@@ -14,9 +14,13 @@ state, and stops. Do not schedule future runs from inside this skill.
    # Get PR number for this branch
    gh pr view --json number -q '.number'
 
-   # Get current GitHub username (for CC attribution)
+   # Get current GitHub username (for plain-text CC attribution)
    gh api user --jq '.login'
    ```
+
+   Every published reply must end with `CC on behalf of {username}`. Keep the
+   username as plain text: never prefix it with `@` or turn it into a link,
+   because that would trigger a GitHub mention notification.
 
 2. **Fetch all bot comments** - Prefer GraphQL for review threads to only process unresolved ones:
 
@@ -75,7 +79,7 @@ state, and stops. Do not schedule future runs from inside this skill.
      -X POST \
      -f body="[response]
 
-   CC on behalf of @{username}" \
+   CC on behalf of {username}" \
      -f commit_id="{commit_sha}" \
      -f path="{file_path}" \
      -F in_reply_to={comment_id}
@@ -88,7 +92,7 @@ state, and stops. Do not schedule future runs from inside this skill.
      -X POST \
      -f body="[response]
 
-   CC on behalf of @{username}"
+   CC on behalf of {username}"
    ```
 
 5. **Resolve addressed bot review threads** using GraphQL (never resolve human
@@ -238,14 +242,16 @@ state, and stops. Do not schedule future runs from inside this skill.
 
 ## Response Templates
 
-Reply format: Put the response first, then sign with `CC on behalf of @{username}`.
+Reply format: Put the response first, then sign with
+`CC on behalf of {username}`. Substitute the current GitHub username without
+an `@` prefix or profile link.
 
 **Accepting:**
 
 ```text
 Accepted and implemented. [Brief description of change].
 
-CC on behalf of @username
+CC on behalf of username
 ```
 
 **Accepting with modification:**
@@ -253,7 +259,7 @@ CC on behalf of @username
 ```text
 Agreed with the principle. Implementing with a slight modification: [explain].
 
-CC on behalf of @username
+CC on behalf of username
 ```
 
 **Pushing back:**
@@ -262,7 +268,7 @@ CC on behalf of @username
 Pushing back on this. [Reason]. Our convention is [explain pattern/reference
 CLAUDE.md].
 
-CC on behalf of @username
+CC on behalf of username
 ```
 
 **Already addressed:**
@@ -270,5 +276,5 @@ CC on behalf of @username
 ```text
 Already addressed in commit [hash]. [Brief description].
 
-CC on behalf of @username
+CC on behalf of username
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,8 +33,10 @@ details unless they are already public in the repository.
 
 ## GitHub Interactions
 
-- When commenting on GitHub (PRs, issues), include "CC on behalf of @username" where
-  username is the GitHub handle of the person who requested the comment.
+- When commenting on GitHub (PRs, issues), append `CC on behalf of username`, where
+  `username` is the GitHub handle of the person who requested the comment. Keep the
+  handle as plain text: never prefix it with `@` or link the account, because the
+  attribution must not trigger a GitHub mention notification.
 - This repository (including PRs, commits, comments) is public. Never include
   marketing language, internal business context, pricing, competitive analysis, user
   identities, conversation specifics, or security architecture beyond what the diff


### PR DESCRIPTION
Render automated `CC on behalf of` attribution as plain text while preserving the initiating GitHub username. Update the local review workflow and regenerated agent instructions to prevent attribution footers from creating account notifications.

Depends on stella/ai-shared#21.

CC on behalf of jan-kubica