### PR TITLE
chore: enable React JSX key lint

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -829,6 +829,7 @@ export default defineConfig({
     {
       files: ["apps/web/src/**/*.{ts,tsx}"],
       rules: {
+        "react/jsx-key": "error",
         "react/no-array-index-key": "error",
         // Direct useEffect is banned; route external-system sync through
         // useMountEffect / useExternalSyncEffect. See /conventions-use-effect.


### PR DESCRIPTION
Enable react/jsx-key as an error for apps/web/src. This catches missing React list keys, which TypeScript does not diagnose, and the existing source tree is clean under the rule.

Validation:
- bun --bun oxlint -c oxlint.config.ts --deny-warnings apps/web/src
- pre-push format, i18n, and affected-package typecheck hooks

CC on behalf of jan-kubica

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved code quality checks for React components by detecting missing keys in JSX lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->