### PR TITLE
chore: reject unreachable code and unused labels

### DIFF
--- a/apps/api/src/handlers/entities/query-entities.ts
+++ b/apps/api/src/handlers/entities/query-entities.ts
@@ -536,8 +536,8 @@ const parseCursorValue = (
       return isValidTimestampCursorValue(value) ? value : null;
     }
     default: {
-      const exhaustive: never = key.type;
-      return exhaustive;
+      key.type satisfies never;
+      return null;
     }
   }
 };

--- a/apps/api/src/handlers/entities/query-entities.ts
+++ b/apps/api/src/handlers/entities/query-entities.ts
@@ -535,9 +535,11 @@ const parseCursorValue = (
       }
       return isValidTimestampCursorValue(value) ? value : null;
     }
+    default: {
+      const exhaustive: never = key.type;
+      return exhaustive;
+    }
   }
-
-  return null;
 };
 
 const cursorValueSql = (key: EntitySortKey, value: number | string): SQL => {

--- a/apps/api/src/handlers/hosted-usage-webhook/receive.ts
+++ b/apps/api/src/handlers/hosted-usage-webhook/receive.ts
@@ -270,8 +270,8 @@ const dispatchEvent = async (
     case "allocation.created":
       return await handleHostedAllocation({ tx, payload: event.data, eventId });
     default: {
-      const exhaustive: never = event;
-      return exhaustive;
+      event satisfies never;
+      return { kind: "ignored", reason: "unhandled event type" };
     }
   }
 };

--- a/apps/api/src/handlers/hosted-usage-webhook/receive.ts
+++ b/apps/api/src/handlers/hosted-usage-webhook/receive.ts
@@ -269,6 +269,9 @@ const dispatchEvent = async (
       });
     case "allocation.created":
       return await handleHostedAllocation({ tx, payload: event.data, eventId });
+    default: {
+      const exhaustive: never = event;
+      return exhaustive;
+    }
   }
-  return { kind: "ignored", reason: "unhandled event type" };
 };

--- a/apps/web/src/routes/_protected.tsx
+++ b/apps/web/src/routes/_protected.tsx
@@ -606,8 +606,8 @@ const getInspectorTabWorkspaceId = (
     case "view":
       return undefined;
     default: {
-      const exhaustive: never = tab;
-      return exhaustive;
+      tab satisfies never;
+      return undefined;
     }
   }
 };

--- a/apps/web/src/routes/_protected.tsx
+++ b/apps/web/src/routes/_protected.tsx
@@ -605,10 +605,11 @@ const getInspectorTabWorkspaceId = (
     case "skill-resource":
     case "view":
       return undefined;
+    default: {
+      const exhaustive: never = tab;
+      return exhaustive;
+    }
   }
-
-  const exhaustive: never = tab;
-  return exhaustive;
 };
 
 /**

--- a/apps/web/src/routes/_protected.workspaces/-filters/column-filter-button.tsx
+++ b/apps/web/src/routes/_protected.workspaces/-filters/column-filter-button.tsx
@@ -59,8 +59,8 @@ export const ColumnFilterButton = ({
       case "createdAt":
         return filters.createdAt !== undefined;
       default: {
-        const exhaustive: never = columnId;
-        return exhaustive;
+        columnId satisfies never;
+        return false;
       }
     }
   })();

--- a/apps/web/src/routes/_protected.workspaces/-filters/column-filter-button.tsx
+++ b/apps/web/src/routes/_protected.workspaces/-filters/column-filter-button.tsx
@@ -58,9 +58,11 @@ export const ColumnFilterButton = ({
         return filters.lastActivityAt !== undefined;
       case "createdAt":
         return filters.createdAt !== undefined;
+      default: {
+        const exhaustive: never = columnId;
+        return exhaustive;
+      }
     }
-    columnId satisfies never;
-    return false;
   })();
 
   return (

--- a/apps/web/src/routes/_protected.workspaces/-filters/filter-pipeline.ts
+++ b/apps/web/src/routes/_protected.workspaces/-filters/filter-pipeline.ts
@@ -100,8 +100,8 @@ const resolveDateRange = (
       return { fromMs, toMs };
     }
     default: {
-      const exhaustive: never = filter.preset;
-      return exhaustive;
+      filter.preset satisfies never;
+      return null;
     }
   }
 };
@@ -141,8 +141,8 @@ const passesLeadFilter = (
     case "user":
       return workspace.leadUserId === filter.userId;
     default: {
-      const exhaustive: never = filter;
-      return exhaustive;
+      filter satisfies never;
+      return false;
     }
   }
 };

--- a/apps/web/src/routes/_protected.workspaces/-filters/filter-pipeline.ts
+++ b/apps/web/src/routes/_protected.workspaces/-filters/filter-pipeline.ts
@@ -99,9 +99,11 @@ const resolveDateRange = (
         : Number.POSITIVE_INFINITY;
       return { fromMs, toMs };
     }
+    default: {
+      const exhaustive: never = filter.preset;
+      return exhaustive;
+    }
   }
-  filter.preset satisfies never;
-  return null;
 };
 
 const passesDateFilter = (
@@ -138,9 +140,11 @@ const passesLeadFilter = (
       return workspace.leadUserId === null;
     case "user":
       return workspace.leadUserId === filter.userId;
+    default: {
+      const exhaustive: never = filter;
+      return exhaustive;
+    }
   }
-  filter satisfies never;
-  return false;
 };
 
 export const isMattersFiltersActive = (filters: MattersFilters): boolean =>

--- a/packages/typescript-config/base.json
+++ b/packages/typescript-config/base.json
@@ -3,6 +3,8 @@
   "display": "stella base",
   "compilerOptions": {
     "allowJs": true,
+    "allowUnreachableCode": false,
+    "allowUnusedLabels": false,
     "checkJs": true,
     "esModuleInterop": true,
     "skipLibCheck": true,


### PR DESCRIPTION
## Proposed change

Enable TypeScript compiler errors for unreachable code and unused labels in the shared base configuration.

Replace the six existing unreachable fallbacks with explicit never branches inside their exhaustive switches. This preserves compile-time exhaustiveness while satisfying the stricter compiler setting.

## Checklist

- [x] **BUILD ASSURANCE** | API and web typechecks pass without errors.
- [x] **TESTING** | API lint, targeted type-aware web lint, API typecheck, and full web typecheck pass.
- [x] **NOT APPLICABLE** | No visual changes requiring dark-mode verification.
- [x] **NOT APPLICABLE** | No linked issue.
- [x] **NOT APPLICABLE** | No screenshot needed for compiler-only changes.