### PR TITLE
feat: enforce semantic Result consumption

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -574,6 +574,16 @@ jobs:
           [[ -z "$AFFECTED_FLAG" ]] || args+=("$AFFECTED_FLAG")
           bun run typecheck -- "${args[@]}"
 
+      - name: Result consumption
+        env:
+          AFFECTED_FLAG: ${{ steps.affected.outputs.flag }}
+        run: |
+          if [[ -z "$AFFECTED_FLAG" ]]; then
+            bun run check:result-consumption -- --all
+          else
+            bun run check:result-consumption -- --base "$TURBO_SCM_BASE"
+          fi
+
   # Typecheck-cost baseline guard. What silently rots is the compiler's
   # workload: an annotation-heavy or inference-exploding pattern in a hot
   # generic path (Eden surface, route trees, query options) lands as

--- a/apps/api/src/handlers/case-law/ingestion/adapters/health-check.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/health-check.ts
@@ -159,7 +159,9 @@ export const checkAdapterHealth = async (
       };
     }
 
-    const page = result.unwrap();
+    const page = result.unwrap(
+      "Adapter page result was checked for a health-check error",
+    );
     const fields = ALL_CHECKED_FIELDS.map((f) => checkField(page.decisions, f));
 
     // Determine status

--- a/apps/api/src/handlers/case-law/ingestion/adapters/update-fixtures.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/update-fixtures.ts
@@ -71,7 +71,9 @@ const updateAdapter = async (
       };
     }
 
-    const page = result.unwrap();
+    const page = result.unwrap(
+      "Adapter page result was checked for an ingestion error",
+    );
     const record: FixtureRecord = {
       adapter: adapterKey,
       recordedAt: new Date().toISOString(),

--- a/apps/api/src/handlers/chat/tools/execute/execute-tool-function.ts
+++ b/apps/api/src/handlers/chat/tools/execute/execute-tool-function.ts
@@ -80,7 +80,7 @@ export const createToolFunction = <
       phase: "input",
       schema: contract.input,
       value: rawInput,
-    }).unwrap();
+    }).unwrap("Tool input must satisfy its registered contract");
 
     signal.throwIfAborted();
 
@@ -98,8 +98,10 @@ export const createToolFunction = <
       contractName: contract.name,
       phase: "output",
       schema: contract.output,
-      value: handlerResult.unwrap(),
-    }).unwrap();
+      value: handlerResult.unwrap(
+        "Tool execution must succeed before output validation",
+      ),
+    }).unwrap("Tool output must satisfy its registered contract");
   },
   functionSchema: contract.schema,
   inputSchema: contract.input,

--- a/apps/api/src/handlers/entities/delete.ts
+++ b/apps/api/src/handlers/entities/delete.ts
@@ -109,6 +109,7 @@ export const deleteEntitiesHandler = async function* ({
       organizationId,
       workspaceId,
     }),
+    "Entity file cleanup must succeed before deleting database records",
   );
 
   // Cascade: entities → entityVersions → fields →

--- a/apps/api/src/handlers/style-sets/storage.ts
+++ b/apps/api/src/handlers/style-sets/storage.ts
@@ -122,6 +122,7 @@ export const createStoredStyleSet = async ({
                 cause,
               }),
           }),
+          "Rejected style set package cleanup failed",
         );
       }
     }
@@ -384,6 +385,7 @@ export const replaceStoredStyleSet = async ({
                 cause,
               }),
           }),
+          "Replacement style set package cleanup failed",
         );
       }
     }

--- a/apps/api/src/handlers/templates/delete.ts
+++ b/apps/api/src/handlers/templates/delete.ts
@@ -59,7 +59,10 @@ const deleteTemplateHandler = async function* ({
     s3Keys.add(v.s3Key);
   }
 
-  Result.unwrap(await deleteS3Keys([...s3Keys]));
+  Result.unwrap(
+    await deleteS3Keys([...s3Keys]),
+    "Template file cleanup must succeed before deleting database records",
+  );
 
   yield* Result.await(
     safeDb(async (tx) => {

--- a/apps/api/src/handlers/workspaces/delete.ts
+++ b/apps/api/src/handlers/workspaces/delete.ts
@@ -156,7 +156,9 @@ export const deleteWorkspaceHandler = async function* ({
         fileRows: fileRefs,
         organizationId,
         workspaceId,
-      }).then((result) => Result.unwrap(result)),
+      }).then((result) =>
+        Result.unwrap(result, "Workspace entity file cleanup failed"),
+      ),
     );
   }
 
@@ -175,7 +177,9 @@ export const deleteWorkspaceHandler = async function* ({
               ]
             : [file.s3Key],
         ),
-      ).then((result) => Result.unwrap(result)),
+      ).then((result) =>
+        Result.unwrap(result, "Workspace chat file cleanup failed"),
+      ),
     );
   }
 

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "check:model-catalog": "bun packages/scripts/src/model-catalog-upstream.ts",
     "canary:ai-provider": "bun --cwd apps/api canary:ai-provider",
     "check:auth-md-spec": "bun packages/scripts/src/auth-md-spec-drift.ts",
+    "check:result-consumption": "bun packages/scripts/src/result-consumption.ts",
     "check:railway-template-draft": "bun scripts/check-railway-template-draft.ts",
     "check:railway-template": "bun scripts/check-railway-template-shape.ts",
     "check:railway-template-source-runtime": "bun scripts/sync-railway-template-source.ts --check-rendered-credentials",

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -25,6 +25,7 @@
   },
   "devDependencies": {
     "@stll/typescript-config": "workspace:*",
-    "@types/bun": "catalog:"
+    "@types/bun": "catalog:",
+    "typescript": "catalog:"
   }
 }

--- a/packages/scripts/src/result-consumption.test.ts
+++ b/packages/scripts/src/result-consumption.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import ts from "typescript";
+
+import {
+  findResultWorkspaceConfigs,
+  scanResultConsumption,
+} from "./result-consumption";
+
+const createFixtureProgram = (
+  source: string,
+): {
+  readonly directory: string;
+  readonly program: ts.Program;
+} => {
+  const directory = mkdtempSync(path.join(import.meta.dir, ".result-test-"));
+  const sourceDirectory = path.join(directory, "src");
+  mkdirSync(sourceDirectory);
+  const file = path.join(sourceDirectory, "fixture.ts");
+  writeFileSync(file, source);
+
+  return {
+    directory,
+    program: ts.createProgram({
+      rootNames: [file],
+      options: {
+        module: ts.ModuleKind.Preserve,
+        moduleResolution: ts.ModuleResolutionKind.Bundler,
+        skipLibCheck: true,
+        strict: true,
+        target: ts.ScriptTarget.ESNext,
+      },
+    }),
+  };
+};
+
+const scanFixture = (source: string) => {
+  const { directory, program } = createFixtureProgram(source);
+  try {
+    return scanResultConsumption({ program, repositoryRoot: directory });
+  } finally {
+    rmSync(directory, { force: true, recursive: true });
+  }
+};
+
+describe("Result consumption guard", () => {
+  test("discovers workspaces that import Result", () => {
+    const repositoryRoot = path.resolve(import.meta.dir, "../../..");
+    const configs = findResultWorkspaceConfigs(repositoryRoot);
+
+    expect(
+      configs.has(path.join(repositoryRoot, "apps/api/tsconfig.json")),
+    ).toBe(true);
+    expect(
+      configs.has(path.join(repositoryRoot, "apps/web/tsconfig.json")),
+    ).toBe(true);
+    expect(
+      configs.has(path.join(repositoryRoot, "packages/cli/tsconfig.json")),
+    ).toBe(true);
+  });
+
+  test("detects discarded Results through helper aliases and chains", () => {
+    const diagnostics = scanFixture(`
+      import { Result, type Result as BetterResult } from "better-result";
+
+      const parse = (): BetterResult<number, string> => Result.ok(1);
+
+      parse();
+      parse().map((value) => value + 1);
+    `);
+
+    expect(diagnostics.map(({ rule }) => rule)).toEqual([
+      "unused-result",
+      "unused-result",
+    ]);
+  });
+
+  test("detects discarded awaited and nullable Results", () => {
+    const diagnostics = scanFixture(`
+      import { Result, type Result as BetterResult } from "better-result";
+
+      const load = async (): Promise<BetterResult<number, string>> => Result.ok(1);
+      const optional = (): BetterResult<number, string> | undefined => Result.ok(1);
+
+      async function run() {
+        await load();
+        optional();
+      }
+      void run;
+    `);
+
+    expect(diagnostics.map(({ rule }) => rule)).toEqual([
+      "unused-result",
+      "unused-result",
+    ]);
+  });
+
+  test("accepts Results that are returned, assigned, or matched", () => {
+    const diagnostics = scanFixture(`
+      import { Result, type Result as BetterResult } from "better-result";
+
+      const parse = (): BetterResult<number, string> => Result.ok(1);
+      let assigned = parse();
+      assigned = parse();
+      const forwarded = (): BetterResult<number, string> => parse();
+      parse().match({ ok: () => undefined, err: () => undefined });
+    `);
+
+    expect(diagnostics).toEqual([]);
+  });
+
+  test("requires invariant messages only on better-result unwrap calls", () => {
+    const diagnostics = scanFixture(`
+      import { Result, type Result as BetterResult } from "better-result";
+
+      const parse = (): BetterResult<number, string> => Result.ok(1);
+      parse().unwrap();
+      Result.unwrap(parse());
+      const message = "dynamic messages hide the invariant at the call site";
+      parse().unwrap(message);
+      parse().unwrap("parser result was checked above");
+      Result.unwrap(parse(), "parser result was checked above");
+
+      const unrelated = { unwrap: () => 1 };
+      unrelated.unwrap();
+    `);
+
+    expect(diagnostics.map(({ rule }) => rule)).toEqual([
+      "result-unwrap-requires-message",
+      "result-unwrap-requires-message",
+      "result-unwrap-requires-message",
+    ]);
+  });
+});

--- a/packages/scripts/src/result-consumption.ts
+++ b/packages/scripts/src/result-consumption.ts
@@ -1,0 +1,430 @@
+import { panic } from "better-result";
+import { execFileSync } from "node:child_process";
+import path from "node:path";
+import ts from "typescript";
+
+const SOURCE_DIRECTORY = `${path.sep}src${path.sep}`;
+const BETTER_RESULT_PACKAGE = `${path.sep}better-result${path.sep}`;
+const RESULT_VARIANTS = new Set(["Err", "Ok"]);
+const TEST_FILE_PATTERN = /(?:\.test\.|\.spec\.|\/tests\/|\/__tests__\/)/u;
+const RESULT_IMPORT_PATTERN =
+  /import\s+(?:type\s+)?\{[^}]*\bResult\b[^}]*\}\s*from\s*["']better-result["']/su;
+
+export type ResultConsumptionDiagnostic = {
+  readonly column: number;
+  readonly file: string;
+  readonly line: number;
+  readonly message: string;
+  readonly rule: "result-unwrap-requires-message" | "unused-result";
+};
+
+type ScanProgramOptions = {
+  readonly program: ts.Program;
+  readonly repositoryRoot: string;
+  readonly sourceFiles?: ReadonlySet<string>;
+};
+
+export const scanResultConsumption = ({
+  program,
+  repositoryRoot,
+  sourceFiles,
+}: ScanProgramOptions): ResultConsumptionDiagnostic[] => {
+  const checker = program.getTypeChecker();
+  const diagnostics: ResultConsumptionDiagnostic[] = [];
+
+  for (const sourceFile of program.getSourceFiles()) {
+    if (
+      !isProductSourceFile(sourceFile, repositoryRoot) ||
+      (sourceFiles !== undefined && !sourceFiles.has(sourceFile.fileName))
+    ) {
+      continue;
+    }
+
+    const visit = (node: ts.Node): void => {
+      if (ts.isExpressionStatement(node)) {
+        const discarded = unwrapDiscardedExpression(node.expression);
+        if (
+          !isAssignmentExpression(discarded) &&
+          isResultType(checker.getTypeAtLocation(discarded))
+        ) {
+          diagnostics.push(
+            createDiagnostic({
+              node: discarded,
+              repositoryRoot,
+              rule: "unused-result",
+              message:
+                "This better-result Result is discarded. Return, assign, yield, or explicitly consume it.",
+            }),
+          );
+        }
+      }
+
+      if (ts.isCallExpression(node) && isUnwrapWithoutMessage(node, checker)) {
+        diagnostics.push(
+          createDiagnostic({
+            node,
+            repositoryRoot,
+            rule: "result-unwrap-requires-message",
+            message:
+              "Unwrapping a Result requires a non-empty literal invariant message.",
+          }),
+        );
+      }
+
+      ts.forEachChild(node, visit);
+    };
+
+    visit(sourceFile);
+  }
+
+  return diagnostics;
+};
+
+const isAssignmentExpression = (expression: ts.Expression): boolean =>
+  ts.isBinaryExpression(expression) &&
+  expression.operatorToken.kind >= ts.SyntaxKind.FirstAssignment &&
+  expression.operatorToken.kind <= ts.SyntaxKind.LastAssignment;
+
+const isProductSourceFile = (
+  sourceFile: ts.SourceFile,
+  repositoryRoot: string,
+): boolean => {
+  if (sourceFile.isDeclarationFile) {
+    return false;
+  }
+
+  const relative = path.relative(repositoryRoot, sourceFile.fileName);
+  if (relative.startsWith("..") || path.isAbsolute(relative)) {
+    return false;
+  }
+
+  const normalized = path.normalize(sourceFile.fileName);
+  return (
+    normalized.includes(SOURCE_DIRECTORY) &&
+    !TEST_FILE_PATTERN.test(normalized.replaceAll(path.sep, "/"))
+  );
+};
+
+const unwrapDiscardedExpression = (
+  expression: ts.Expression,
+): ts.Expression => {
+  if (
+    ts.isParenthesizedExpression(expression) ||
+    ts.isAsExpression(expression) ||
+    ts.isSatisfiesExpression(expression) ||
+    ts.isNonNullExpression(expression)
+  ) {
+    return unwrapDiscardedExpression(expression.expression);
+  }
+
+  if (ts.isVoidExpression(expression)) {
+    return unwrapDiscardedExpression(expression.expression);
+  }
+
+  return expression;
+};
+
+const isResultType = (type: ts.Type): boolean => {
+  if (type.isUnion()) {
+    return type.types.some(isResultType);
+  }
+
+  const symbol = type.aliasSymbol ?? type.getSymbol();
+  if (symbol === undefined || !RESULT_VARIANTS.has(symbol.getName())) {
+    return false;
+  }
+
+  return symbol.declarations?.some(isBetterResultDeclaration) === true;
+};
+
+const isBetterResultDeclaration = (declaration: ts.Declaration): boolean =>
+  path
+    .normalize(declaration.getSourceFile().fileName)
+    .includes(BETTER_RESULT_PACKAGE);
+
+const isUnwrapWithoutMessage = (
+  call: ts.CallExpression,
+  checker: ts.TypeChecker,
+): boolean => {
+  const signature = checker.getResolvedSignature(call);
+  if (
+    signature === undefined ||
+    signature.declaration === undefined ||
+    !isBetterResultDeclaration(signature.declaration)
+  ) {
+    return false;
+  }
+
+  const callee = call.expression;
+  if (!ts.isPropertyAccessExpression(callee) || callee.name.text !== "unwrap") {
+    return false;
+  }
+
+  const messageArgumentIndex = signature.getParameters().length === 2 ? 1 : 0;
+  const message = call.arguments.at(messageArgumentIndex);
+  return (
+    message === undefined ||
+    !ts.isStringLiteralLike(message) ||
+    message.text.trim().length === 0
+  );
+};
+
+type CreateDiagnosticOptions = {
+  readonly message: string;
+  readonly node: ts.Node;
+  readonly repositoryRoot: string;
+  readonly rule: ResultConsumptionDiagnostic["rule"];
+};
+
+const createDiagnostic = ({
+  message,
+  node,
+  repositoryRoot,
+  rule,
+}: CreateDiagnosticOptions): ResultConsumptionDiagnostic => {
+  const sourceFile = node.getSourceFile();
+  const position = sourceFile.getLineAndCharacterOfPosition(node.getStart());
+  return {
+    column: position.character + 1,
+    file: path.relative(repositoryRoot, sourceFile.fileName),
+    line: position.line + 1,
+    message,
+    rule,
+  };
+};
+
+type CreateProgramOptions = {
+  readonly configPath: string;
+  readonly rootNames?: readonly string[];
+};
+
+const createProgram = ({
+  configPath,
+  rootNames,
+}: CreateProgramOptions): ts.Program => {
+  const configFile = ts.readConfigFile(configPath, (file) =>
+    ts.sys.readFile(file),
+  );
+  if (configFile.error !== undefined) {
+    panic(ts.flattenDiagnosticMessageText(configFile.error.messageText, "\n"));
+  }
+
+  const parsed = ts.parseJsonConfigFileContent(
+    configFile.config,
+    ts.sys,
+    path.dirname(configPath),
+    undefined,
+    configPath,
+  );
+  if (parsed.errors.length > 0) {
+    panic(
+      parsed.errors
+        .map(({ messageText }) =>
+          ts.flattenDiagnosticMessageText(messageText, "\n"),
+        )
+        .join("\n"),
+    );
+  }
+
+  const options = {
+    rootNames:
+      rootNames === undefined
+        ? parsed.fileNames
+        : [
+            ...rootNames,
+            ...parsed.fileNames.filter((file) => file.endsWith(".d.ts")),
+          ],
+    options: parsed.options,
+  };
+  if (parsed.projectReferences === undefined) {
+    return ts.createProgram(options);
+  }
+  return ts.createProgram({
+    ...options,
+    projectReferences: parsed.projectReferences,
+  });
+};
+
+type CliOptions =
+  | { readonly mode: "all" }
+  | { readonly base: string; readonly mode: "changed" };
+
+const parseCliOptions = (): CliOptions => {
+  if (process.argv.includes("--all")) {
+    return { mode: "all" };
+  }
+
+  const baseIndex = process.argv.indexOf("--base");
+  const explicitBase =
+    baseIndex === -1 ? undefined : process.argv.at(baseIndex + 1);
+  if (baseIndex !== -1 && explicitBase === undefined) {
+    panic("--base requires a git ref");
+  }
+  return {
+    base: explicitBase ?? process.env["TURBO_SCM_BASE"] ?? "origin/main",
+    mode: "changed",
+  };
+};
+
+const gitLines = (
+  repositoryRoot: string,
+  args: readonly string[],
+): string[] => {
+  const output = execFileSync("git", args, {
+    cwd: repositoryRoot,
+    encoding: "utf-8",
+  });
+  return output.split("\n").filter(Boolean);
+};
+
+const changedSourceFiles = (repositoryRoot: string, base: string): string[] => {
+  const files = new Set([
+    ...gitLines(repositoryRoot, [
+      "diff",
+      "--name-only",
+      "--diff-filter=ACMR",
+      `${base}...HEAD`,
+    ]),
+    ...gitLines(repositoryRoot, [
+      "diff",
+      "--name-only",
+      "--diff-filter=ACMR",
+      "HEAD",
+    ]),
+    ...gitLines(repositoryRoot, ["ls-files", "--others", "--exclude-standard"]),
+  ]);
+
+  return [...files]
+    .filter((file) => /^(?:apps|packages)\/[^/]+\/src\/.*\.tsx?$/u.test(file))
+    .filter((file) => !TEST_FILE_PATTERN.test(file))
+    .map((file) => path.join(repositoryRoot, file))
+    .sort();
+};
+
+const workspaceConfig = (
+  repositoryRoot: string,
+  sourceFile: string,
+): string | null => {
+  const [parent, workspace] = path
+    .relative(repositoryRoot, sourceFile)
+    .split(path.sep);
+  if (parent === undefined || workspace === undefined) {
+    return null;
+  }
+  const config = path.join(repositoryRoot, parent, workspace, "tsconfig.json");
+  return ts.sys.fileExists(config) ? config : null;
+};
+
+const groupChangedFilesByConfig = (
+  repositoryRoot: string,
+  files: readonly string[],
+): Map<string, string[]> => {
+  const grouped = new Map<string, string[]>();
+  for (const file of files) {
+    const config = workspaceConfig(repositoryRoot, file);
+    if (config === null) {
+      continue;
+    }
+    const group = grouped.get(config) ?? [];
+    group.push(file);
+    grouped.set(config, group);
+  }
+  return grouped;
+};
+
+export const findResultWorkspaceConfigs = (
+  repositoryRoot: string,
+): Map<string, undefined> => {
+  const configs = new Map<string, undefined>();
+  for (const parent of ["apps", "packages"]) {
+    const parentDirectory = path.join(repositoryRoot, parent);
+    for (const workspace of ts.sys.getDirectories(parentDirectory)) {
+      const workspaceDirectory = path.join(parentDirectory, workspace);
+      const sourceDirectory = path.join(workspaceDirectory, "src");
+      if (!ts.sys.directoryExists(sourceDirectory)) {
+        continue;
+      }
+      const sourceFiles = ts.sys.readDirectory(sourceDirectory, [
+        ".ts",
+        ".tsx",
+      ]);
+      if (
+        !sourceFiles.some((sourceFile) => {
+          const source = ts.sys.readFile(sourceFile);
+          return source !== undefined && RESULT_IMPORT_PATTERN.test(source);
+        })
+      ) {
+        continue;
+      }
+      const config = path.join(workspaceDirectory, "tsconfig.json");
+      if (ts.sys.fileExists(config)) {
+        configs.set(config, undefined);
+      }
+    }
+  }
+  return configs;
+};
+
+const run = (): number => {
+  const repositoryRoot = path.resolve(import.meta.dir, "../../..");
+  const cli = parseCliOptions();
+  const changedFiles =
+    cli.mode === "changed"
+      ? changedSourceFiles(repositoryRoot, cli.base)
+      : undefined;
+  if (changedFiles?.length === 0) {
+    console.log("result-consumption: no changed product TypeScript files");
+    return 0;
+  }
+
+  const diagnosticsByLocation = new Map<string, ResultConsumptionDiagnostic>();
+
+  const projects =
+    changedFiles === undefined
+      ? findResultWorkspaceConfigs(repositoryRoot)
+      : groupChangedFilesByConfig(repositoryRoot, changedFiles);
+
+  for (const [configPath, rootNames] of projects) {
+    const program =
+      rootNames === undefined
+        ? createProgram({ configPath })
+        : createProgram({ configPath, rootNames });
+    const diagnostics =
+      rootNames === undefined
+        ? scanResultConsumption({ program, repositoryRoot })
+        : scanResultConsumption({
+            program,
+            repositoryRoot,
+            sourceFiles: new Set(rootNames),
+          });
+    for (const diagnostic of diagnostics) {
+      const key = `${diagnostic.file}:${diagnostic.line}:${diagnostic.column}:${diagnostic.rule}`;
+      diagnosticsByLocation.set(key, diagnostic);
+    }
+  }
+
+  const diagnostics = [...diagnosticsByLocation.values()].sort((a, b) =>
+    `${a.file}:${a.line}:${a.column}`.localeCompare(
+      `${b.file}:${b.line}:${b.column}`,
+    ),
+  );
+  for (const diagnostic of diagnostics) {
+    console.error(
+      `${diagnostic.file}:${diagnostic.line}:${diagnostic.column} ${diagnostic.message} [${diagnostic.rule}]`,
+    );
+  }
+
+  if (diagnostics.length > 0) {
+    console.error(
+      `result-consumption: ${diagnostics.length} violation(s) found.`,
+    );
+    return 1;
+  }
+
+  console.log(`result-consumption: OK (${projects.size} project(s) checked)`);
+  return 0;
+};
+
+if (import.meta.main) {
+  process.exitCode = run();
+}

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -202,6 +202,11 @@ run_step "Lint" run_lint
 run_step "Format" run_format
 run_step "Rust format" run_rust_format
 run_step "Typecheck" run_typecheck
+if [[ -n "$affected_flag" ]]; then
+  run_step "Result consumption" bun run check:result-consumption -- --base "$base_ref"
+else
+  run_step "Result consumption" bun run check:result-consumption -- --all
+fi
 run_step "React Compiler bailout guard" bun scripts/rc-bailouts.ts --check
 run_step "Ratchet guard" run_ratchet_guard
 run_step "Crawl posture guard" run_crawl_posture_guard


### PR DESCRIPTION
## Summary

- add a TypeScript compiler-API guard that rejects discarded better-result Result values, including helper aliases, chains, awaited calls, and nullable unions
- require non-empty literal invariant messages at better-result unwrap boundaries and document the existing production sites
- run the changed-file guard in pull-request CI and retain a full audit mode for workflow dispatch and local verification
- cover workspace discovery, semantic consumption, accepted consumption patterns, and unwrap behavior with focused tests

## Why a compiler check

Oxlint JavaScript plugins do not receive TypeScript type information. The existing name-based plugin remains a fast syntactic guard; this check follows inferred return types so helper functions returning Result cannot be silently discarded.

## Verification

- bun run lint
- bun run format
- bun run typecheck
- bun run test
- bun run check:result-consumption -- --all
- security audit: no critical or high findings in the changed surface