### PR TITLE
chore(types): enforce repository typecheck coverage

### DIFF
--- a/.claude/mcp/fetch-allowed-url.ts
+++ b/.claude/mcp/fetch-allowed-url.ts
@@ -4,7 +4,10 @@ const MAX_REDIRECTS = 5;
 
 type FetchAllowedUrlProps = {
   allowedHosts: ReadonlySet<string>;
-  fetchImpl?: typeof fetch;
+  fetchImpl?: (
+    input: string | URL | Request,
+    init?: RequestInit,
+  ) => Promise<Response>;
   maxResponseBytes?: number;
   timeoutMs?: number;
   url: string;
@@ -33,6 +36,7 @@ export const fetchAllowedUrl = async ({
   for (let requestIndex = 0; requestIndex <= MAX_REDIRECTS; requestIndex += 1) {
     validateAllowedUrl(currentUrl, allowedHosts);
 
+    // oxlint-disable-next-line no-await-in-loop -- redirects are sequential and share one timeout budget
     const response = await fetchImpl(currentUrl, {
       redirect: "manual",
       signal,
@@ -42,6 +46,7 @@ export const fetchAllowedUrl = async ({
       if (!response.ok) {
         throw new Error(`${response.status} ${response.statusText}`);
       }
+      // oxlint-disable-next-line no-await-in-loop -- terminal response belongs to the current redirect hop
       return await readLimitedText({
         maxBytes: maxResponseBytes,
         response,
@@ -100,6 +105,7 @@ const readLimitedText = async ({
   let totalBytes = 0;
 
   while (true) {
+    // oxlint-disable-next-line no-await-in-loop -- streams must be consumed in order with a cumulative byte limit
     const { done, value } = await reader.read();
     if (done) {
       break;
@@ -107,6 +113,7 @@ const readLimitedText = async ({
 
     totalBytes += value.byteLength;
     if (totalBytes > maxBytes) {
+      // oxlint-disable-next-line no-await-in-loop -- cancel at the exact chunk that crosses the limit
       await reader.cancel();
       throw new Error("Documentation response exceeds size limit");
     }

--- a/.claude/mcp/server.ts
+++ b/.claude/mcp/server.ts
@@ -1,7 +1,6 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-// eslint-disable-next-line no-restricted-imports -- MCP SDK tool schemas use zod.
-import { z } from "zod";
+import { z } from "zod/v3";
 
 import {
   fetchAllowedUrl,
@@ -78,9 +77,27 @@ type DocChunk = {
   score: number;
 };
 
-server.tool(
+type ToolResult = {
+  content: { type: "text"; text: string }[];
+  isError?: boolean;
+};
+
+type RegisterInputTool = <InputSchema extends z.ZodTypeAny>(
+  name: string,
+  config: { description: string; inputSchema: InputSchema },
+  callback: (input: z.infer<InputSchema>) => ToolResult | Promise<ToolResult>,
+) => unknown;
+
+// The SDK's Zod 3/4 compatibility overload exceeds TypeScript's instantiation
+// depth in a clean install. Keep schema inference and handlers checked on this
+// side of a narrow boundary while preserving registerTool's runtime behavior.
+const registerInputTool = server.registerTool.bind(
+  server,
+) as unknown as RegisterInputTool;
+
+server.registerTool(
   "list_doc_sources",
-  "List available library documentation sources",
+  { description: "List available library documentation sources" },
   () => ({
     content: Object.entries(SOURCES).map(([name, url]) => ({
       type: "text" as const,
@@ -556,10 +573,12 @@ const splitIntoChunks = (pageText: string) => {
   return [{ heading: DEFAULT_HEADING, text: fallbackText }];
 };
 
-server.tool(
+registerInputTool(
   "fetch_docs",
-  "Fetch a llms.txt index or a specific doc page URL",
-  { url: z.string().url() },
+  {
+    description: "Fetch a llms.txt index or a specific doc page URL",
+    inputSchema: z.object({ url: z.string().url() }),
+  },
   async ({ url }) => {
     try {
       return {
@@ -582,13 +601,16 @@ server.tool(
   },
 );
 
-server.tool(
+registerInputTool(
   "search_docs",
-  "Search configured doc indexes and return only the top matching pages",
   {
-    query: z.string().min(2),
-    sources: z.array(z.string()).optional(),
-    maxResults: z.number().int().min(1).max(MAX_RESULTS_LIMIT).optional(),
+    description:
+      "Search configured doc indexes and return only the top matching pages",
+    inputSchema: z.object({
+      query: z.string().min(2),
+      sources: z.array(z.string()).optional(),
+      maxResults: z.number().int().min(1).max(MAX_RESULTS_LIMIT).optional(),
+    }),
   },
   async ({ query, sources, maxResults }) => {
     try {
@@ -706,13 +728,16 @@ server.tool(
   },
 );
 
-server.tool(
+registerInputTool(
   "fetch_doc_chunks",
-  "Fetch only the most relevant chunks from a doc page for a given query",
   {
-    url: z.string().url(),
-    query: z.string().min(2),
-    maxChunks: z.number().int().min(1).max(MAX_CHUNKS_LIMIT).optional(),
+    description:
+      "Fetch only the most relevant chunks from a doc page for a given query",
+    inputSchema: z.object({
+      url: z.string().url(),
+      query: z.string().min(2),
+      maxChunks: z.number().int().min(1).max(MAX_CHUNKS_LIMIT).optional(),
+    }),
   },
   async ({ url, query, maxChunks }) => {
     try {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -553,6 +553,14 @@ jobs:
           cd ../web
           cp .env.example .env
 
+      - name: Typecheck coverage
+        # Loaders can execute a TypeScript file that belongs to no project in
+        # the turbo typecheck graph. Compare every repository source with the
+        # compiler's own --listFilesOnly output so none bypass typechecking.
+        run: |
+          bun scripts/typecheck-coverage.ts --self-test
+          bun scripts/typecheck-coverage.ts
+
       - name: Compute affected flag
         id: affected
         env:
@@ -573,6 +581,7 @@ jobs:
           args=()
           [[ -z "$AFFECTED_FLAG" ]] || args+=("$AFFECTED_FLAG")
           bun run typecheck -- "${args[@]}"
+          bun run typecheck:repo
 
       - name: Result consumption
         env:

--- a/.oxlint-plugins/icon-button-requires-tooltip.ts
+++ b/.oxlint-plugins/icon-button-requires-tooltip.ts
@@ -327,7 +327,7 @@ const hasTooltip = (node: unknown): boolean => {
         return true;
       }
     }
-    current = current.parent;
+    current = isAstNode(current.parent) ? current.parent : null;
   }
   return false;
 };

--- a/.oxlint-plugins/no-prompt-boundary-casts.ts
+++ b/.oxlint-plugins/no-prompt-boundary-casts.ts
@@ -1185,7 +1185,7 @@ export default {
         }
         const promptBoundaryTypeNames = new Set(PROMPT_BOUNDARY_TYPES);
         const namedTypeAnnotations = new Map();
-        const assertionNodes = [];
+        const assertionNodes: unknown[] = [];
 
         function check(node) {
           if (

--- a/.oxlint-plugins/no-raw-route-query-client.ts
+++ b/.oxlint-plugins/no-raw-route-query-client.ts
@@ -135,7 +135,11 @@ export default {
       create(context) {
         const genericHelperAliases = new Map();
         const pendingComponentNames = new Set();
-        const pendingQueryHookCalls = [];
+        const pendingQueryHookCalls: {
+          component: string;
+          hook: string;
+          node: unknown;
+        }[] = [];
         const queryHookAliases = new Set();
         const routeQueryHelperNamespaces = new Set();
         const tanstackQueryNamespaces = new Set();

--- a/.oxlint-plugins/no-raw-stored-json.ts
+++ b/.oxlint-plugins/no-raw-stored-json.ts
@@ -36,20 +36,18 @@
 // via `oxlint.config.ts` `excludeFiles`, since it is the one place raw
 // `JSON.parse` on a persisted string is intentional.
 
+import { panic } from "better-result";
+
 import { isIdentifier, unwrapExpression } from "./utils.ts";
 
 const STORAGE_IDENTIFIERS = new Set(["localStorage", "sessionStorage"]);
 
 // Peel a TSNonNullExpression on top of the shared TS-wrapper unwrapper, so
 // `localStorage.getItem("k")!` is still recognized.
-const peel = (node: unknown): unknown => {
+const peel = (node: unknown): ReturnType<typeof unwrapExpression> => {
   const unwrapped = unwrapExpression(node);
-  if (
-    typeof unwrapped === "object" &&
-    unwrapped !== null &&
-    (unwrapped as { type?: unknown }).type === "TSNonNullExpression"
-  ) {
-    return peel((unwrapped as { expression: unknown }).expression);
+  if (unwrapped?.type === "TSNonNullExpression") {
+    return peel(unwrapped.expression);
   }
   return unwrapped;
 };
@@ -64,46 +62,35 @@ const mentionsStorageIdentifier = (node: unknown): boolean => {
   if (isIdentifier(current)) {
     return STORAGE_IDENTIFIERS.has(current.name);
   }
-  if (
-    typeof current !== "object" ||
-    current === null ||
-    (current as { type?: unknown }).type !== "MemberExpression"
-  ) {
+  if (current?.type !== "MemberExpression") {
     return false;
   }
-  const member = current as { computed?: unknown; property: unknown };
   if (
-    member.computed === false &&
-    isIdentifier(member.property) &&
-    STORAGE_IDENTIFIERS.has(member.property.name)
+    current.computed === false &&
+    isIdentifier(current.property) &&
+    STORAGE_IDENTIFIERS.has(current.property.name)
   ) {
     return true;
   }
-  return mentionsStorageIdentifier((current as { object: unknown }).object);
+  return mentionsStorageIdentifier(current.object);
 };
 
 // True for `<expr>.getItem(...)` where `<expr>`'s chain mentions
 // localStorage/sessionStorage.
 const isStorageGetItemCall = (node: unknown): boolean => {
   const current = peel(node);
+  if (current?.type !== "CallExpression") {
+    return false;
+  }
+  const callee = peel(current.callee);
   if (
-    typeof current !== "object" ||
-    current === null ||
-    (current as { type?: unknown }).type !== "CallExpression"
+    callee?.type !== "MemberExpression" ||
+    callee.computed !== false ||
+    !isIdentifier(callee.property, "getItem")
   ) {
     return false;
   }
-  const callee = (current as { callee: unknown }).callee;
-  if (
-    typeof callee !== "object" ||
-    callee === null ||
-    (callee as { type?: unknown }).type !== "MemberExpression" ||
-    (callee as { computed?: unknown }).computed !== false ||
-    !isIdentifier((callee as { property: unknown }).property, "getItem")
-  ) {
-    return false;
-  }
-  return mentionsStorageIdentifier((callee as { object: unknown }).object);
+  return mentionsStorageIdentifier(callee.object);
 };
 
 const isJsonParseCallee = (callee: unknown): boolean =>
@@ -141,14 +128,15 @@ export default {
         const storageVarStack: Scope[] = [createScope()];
 
         const currentScope = (): Scope =>
-          storageVarStack.at(-1) ?? storageVarStack[0]!;
+          storageVarStack.at(-1) ??
+          panic("storage scope stack must never be empty");
 
         const collectBoundNames = (pattern, names: Set<string>) => {
           const current = peel(pattern);
           if (!current || typeof current !== "object") {
             return;
           }
-          if (current.type === "Identifier") {
+          if (isIdentifier(current)) {
             names.add(current.name);
             return;
           }
@@ -161,15 +149,27 @@ export default {
             return;
           }
           if (current.type === "ArrayPattern") {
-            for (const element of current.elements) {
+            const elements = Array.isArray(current.elements)
+              ? current.elements
+              : [];
+            for (const element of elements) {
               collectBoundNames(element, names);
             }
             return;
           }
           if (current.type === "ObjectPattern") {
-            for (const property of current.properties) {
+            const properties = Array.isArray(current.properties)
+              ? current.properties
+              : [];
+            for (const property of properties) {
+              const currentProperty = peel(property);
+              if (!currentProperty) {
+                continue;
+              }
               collectBoundNames(
-                property.type === "Property" ? property.value : property,
+                currentProperty.type === "Property"
+                  ? currentProperty.value
+                  : currentProperty,
                 names,
               );
             }
@@ -223,12 +223,8 @@ export default {
             // Look through a `?? "..."` / `|| "..."` fallback: the storage
             // read is the left operand (`JSON.parse(raw ?? "null")`).
             let candidate = peel(arg);
-            while (
-              typeof candidate === "object" &&
-              candidate !== null &&
-              (candidate as { type?: unknown }).type === "LogicalExpression"
-            ) {
-              candidate = peel((candidate as { left: unknown }).left);
+            while (candidate?.type === "LogicalExpression") {
+              candidate = peel(candidate.left);
             }
             let trackedVariable = false;
             if (isIdentifier(candidate)) {

--- a/.oxlint-plugins/no-raw-user-id-schema.ts
+++ b/.oxlint-plugins/no-raw-user-id-schema.ts
@@ -73,7 +73,7 @@ export default {
       },
       create(context) {
         let hasValidateOrgUserId = false;
-        const ownerFieldNodes = [];
+        const ownerFieldNodes: { name: string; node: unknown }[] = [];
 
         const checkProperty = (node) => {
           const name = getPropertyName(node.key);

--- a/.oxlint-plugins/no-spread-input-in-query-key.ts
+++ b/.oxlint-plugins/no-spread-input-in-query-key.ts
@@ -53,7 +53,8 @@ const isAllowedCompositionSpread = (node) => {
     return false;
   }
   if (unwrapped.type === "MemberExpression") {
-    return rootIdentifier(unwrapped.object)?.name.endsWith("Keys") === true;
+    const root = rootIdentifier(unwrapped.object);
+    return isIdentifier(root) && root.name.endsWith("Keys");
   }
   if (unwrapped.type === "CallExpression") {
     return isAllowedCompositionSpread(unwrapped.callee);
@@ -74,6 +75,9 @@ const isExplicitObjectSpreadValue = (node) => {
     return false;
   }
   if (unwrapped.type === "ObjectExpression") {
+    if (!Array.isArray(unwrapped.properties)) {
+      return false;
+    }
     return unwrapped.properties.every((property) => {
       if (property?.type === "SpreadElement") {
         return isExplicitObjectSpreadValue(property.argument);
@@ -254,7 +258,10 @@ export default {
             return;
           }
           if (value.type === "ArrayExpression") {
-            for (const element of value.elements) {
+            const elements = Array.isArray(value.elements)
+              ? value.elements
+              : [];
+            for (const element of elements) {
               if (isLeakySpread(element)) {
                 context.report({
                   node: element,
@@ -269,7 +276,10 @@ export default {
           if (value.type !== "ObjectExpression") {
             return;
           }
-          for (const property of value.properties) {
+          const properties = Array.isArray(value.properties)
+            ? value.properties
+            : [];
+          for (const property of properties) {
             if (isLeakyObjectSpread(property)) {
               context.report({
                 node: property,

--- a/.oxlint-plugins/no-unbranded-ownership-id-param.ts
+++ b/.oxlint-plugins/no-unbranded-ownership-id-param.ts
@@ -94,10 +94,9 @@ const isKnownValidatedContextParam = (functionNode) => {
     return true;
   }
 
-  if (
-    parent.type === "Property" &&
-    CONTEXT_TYPED_PROPERTY_NAMES.has(getIdentifierName(parent.key))
-  ) {
+  const propertyName =
+    parent.type === "Property" ? getIdentifierName(parent.key) : null;
+  if (propertyName !== null && CONTEXT_TYPED_PROPERTY_NAMES.has(propertyName)) {
     return true;
   }
 

--- a/.oxlint-plugins/no-workspace-field-value-drift.ts
+++ b/.oxlint-plugins/no-workspace-field-value-drift.ts
@@ -1,5 +1,7 @@
 import {
+  type AstNode,
   getPropertyName,
+  isAstNode,
   isIdentifier,
   isStringLiteral,
   unwrapExpression,
@@ -16,9 +18,10 @@ const DISPLAY_FIELD_TYPES = new Set([
 
 const BIDI_TEXT_COMPONENTS = new Set(["BidiText", "UserText"]);
 
-const isMemberLike = (node) =>
-  node?.type === "MemberExpression" ||
-  node?.type === "OptionalMemberExpression";
+const isMemberLike = (node: unknown): node is AstNode =>
+  isAstNode(node) &&
+  (node.type === "MemberExpression" ||
+    node.type === "OptionalMemberExpression");
 
 const jsxElementName = (name) => {
   if (name?.type === "JSXIdentifier") {

--- a/.oxlint-plugins/require-loader-prefetch.ts
+++ b/.oxlint-plugins/require-loader-prefetch.ts
@@ -60,7 +60,7 @@
 // in prose comments inside `-components`/`-hooks`/`-queries` files.
 
 import { readFileSync } from "node:fs";
-import { join } from "node:path";
+import path from "node:path";
 
 import {
   getPropertyName,
@@ -148,7 +148,7 @@ const resolveColocatedImportBase = (filename, source) => {
     return null;
   }
   const aliasRoot = normalizedFilename.slice(0, routesIndex);
-  return join(aliasRoot, source.slice("@/".length));
+  return path.join(aliasRoot, source.slice("@/".length));
 };
 
 // Bounded, one-hop read: try the two extensions a colocated TS/TSX import can
@@ -156,7 +156,7 @@ const resolveColocatedImportBase = (filename, source) => {
 const readColocatedFile = (basePath) => {
   for (const extension of [".tsx", ".ts"]) {
     try {
-      return readFileSync(`${basePath}${extension}`, "utf8");
+      return readFileSync(`${basePath}${extension}`, "utf-8");
     } catch {
       // Try the next extension; if neither exists this is a shape the
       // simplified alias resolution can't handle (e.g. a directory index) —
@@ -228,10 +228,10 @@ export default {
       },
       create(context) {
         let isRouteFile = false;
-        let routeOptions = null;
-        const suspenseCalls = [];
+        let routeOptions: { properties: unknown } | null = null;
+        const suspenseCalls: { factory: string; node: unknown }[] = [];
         const referencedInLoader = new Set();
-        const colocatedImports = [];
+        const colocatedImports: { node: unknown; source: string }[] = [];
 
         return {
           CallExpression(node) {
@@ -280,7 +280,10 @@ export default {
               return;
             }
 
-            const hasLoader = routeOptions.properties.some(
+            const properties = Array.isArray(routeOptions.properties)
+              ? routeOptions.properties
+              : [];
+            const hasLoader = properties.some(
               (prop) =>
                 prop.type === "Property" &&
                 getPropertyName(prop.key) === LOADER_KEY,

--- a/.oxlint-plugins/require-query-signal.ts
+++ b/.oxlint-plugins/require-query-signal.ts
@@ -191,7 +191,8 @@ const isEdenApiCallee = (callee) => {
   if (unwrapped?.type !== "MemberExpression" || unwrapped.computed !== false) {
     return false;
   }
-  if (!HTTP_VERBS.has(getPropertyName(unwrapped.property))) {
+  const propertyName = getPropertyName(unwrapped.property);
+  if (propertyName === null || !HTTP_VERBS.has(propertyName)) {
     return false;
   }
   return rootIdentifier(unwrapped.object)?.name === "api";

--- a/.oxlint-plugins/utils.ts
+++ b/.oxlint-plugins/utils.ts
@@ -4,9 +4,9 @@
 // `unknown` so rule files can call them without per-call type ceremony or
 // shared type-import boilerplate.
 
-type AstNode = { type: string } & Record<string, unknown>;
+export type AstNode = { type: string } & Record<string, unknown>;
 
-const isAstNode = (node: unknown): node is AstNode =>
+export const isAstNode = (node: unknown): node is AstNode =>
   typeof node === "object" &&
   node !== null &&
   "type" in node &&
@@ -91,9 +91,9 @@ export const getCalleeName = (callee: unknown): string | null => {
 
 // Peel TS-only wrapping nodes so a shape check sees the underlying
 // expression. Returns the original node when no wrapping is present.
-export const unwrapExpression = (node: unknown): unknown => {
+export const unwrapExpression = (node: unknown): AstNode | null => {
   if (!isAstNode(node)) {
-    return node;
+    return null;
   }
   if (
     node.type === "TSAsExpression" ||

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -14,7 +14,7 @@
     "docker:reset-dev": "docker compose --profile dev down -v && docker compose --profile dev up -d",
     "docker:stop-dev": "docker compose --profile dev down",
     "clean": "git clean -xdf .cache .turbo node_modules",
-    "typecheck": "bun ../../packages/scripts/src/tsc-native.ts --noEmit && bun ../../packages/scripts/src/tsc-native.ts --noEmit -p tsconfig.contracts.json",
+    "typecheck": "bun ../../packages/scripts/src/tsc-native.ts --noEmit && bun ../../packages/scripts/src/tsc-native.ts --noEmit -p tsconfig.contracts.json && bun ../../packages/scripts/src/tsc-native.ts --noEmit -p tsconfig.scripts.json",
     "lint": "cd ../.. && bun --bun oxlint -c oxlint.config.ts --report-unused-disable-directives-severity=error --deny-warnings --type-aware apps/api",
     "lint:fix": "cd ../.. && bun --bun oxlint -c oxlint.config.ts --type-aware --fix apps/api",
     "format": "oxfmt .",

--- a/apps/api/scripts/ai-provider-canary-config.test.ts
+++ b/apps/api/scripts/ai-provider-canary-config.test.ts
@@ -60,13 +60,13 @@ describe("AI provider weekly rotation", () => {
         weeklyCanaryRotation({ provider, rotationIndex }),
       );
 
-      expect(rotations.map(({ modelId }) => modelId)).toEqual(models);
+      expect(rotations.map(({ modelId }) => modelId)).toEqual([...models]);
       expect(
         weeklyCanaryRotation({
           provider,
           rotationIndex: models.length,
         }).modelId,
-      ).toBe(models.at(0));
+      ).toBe(models[0]);
 
       for (const { modelId, modelRoles } of rotations) {
         expect(modelRoles.length).toBeGreaterThan(0);
@@ -91,7 +91,7 @@ describe("AI provider weekly rotation", () => {
         provider: "openai",
         rotationIndex: WEEKLY_TOOL_SHAPES.length,
       }).toolShape,
-    ).toBe(WEEKLY_TOOL_SHAPES.at(0));
+    ).toBe(WEEKLY_TOOL_SHAPES[0]);
   });
 
   test("rejects invalid rotation indexes", () => {

--- a/apps/api/scripts/apply-search-migration.ts
+++ b/apps/api/scripts/apply-search-migration.ts
@@ -27,7 +27,7 @@ const applyPgFtsMigration = async () => {
   `);
 
   const isGenerated =
-    colInfo.length > 0 && colInfo[0]?.is_generated === "ALWAYS";
+    colInfo.length > 0 && colInfo[0]?.["is_generated"] === "ALWAYS";
 
   if (isGenerated) {
     console.log("Migrating tsv from generated to regular column...");

--- a/apps/api/scripts/backfill-image-thumbnails.ts
+++ b/apps/api/scripts/backfill-image-thumbnails.ts
@@ -28,6 +28,7 @@ import {
   THUMBNAIL_MIME_TYPE,
 } from "@/api/handlers/files/image-derivative";
 import { createUserFileKey } from "@/api/handlers/files/utils";
+import type { SafeId } from "@/api/lib/branded-types";
 import { enqueueImageThumbnailOrMarkFailed } from "@/api/lib/file-derivative-queue";
 import { getS3 } from "@/api/lib/s3";
 import {
@@ -71,8 +72,10 @@ const backfillEntityFields = async (): Promise<number> => {
   let enqueued = 0;
 
   for (;;) {
-    // oxlint-disable-next-line no-await-in-loop -- sequential keyset pagination: next page cursor depends on this batch
-    const batch = await rootDb.execute<EntityFieldRow>(sql`
+    // Sequential keyset pagination: the next page cursor depends on this batch.
+    const batch: Iterable<EntityFieldRow> =
+      // oxlint-disable-next-line no-await-in-loop -- sequential keyset pagination: next page cursor depends on this batch
+      await rootDb.execute<EntityFieldRow>(sql`
       SELECT
         f.id AS field_id,
         f.content->>'mimeType' AS mime_type,
@@ -93,9 +96,9 @@ const backfillEntityFields = async (): Promise<number> => {
         ${cursor ? sql`AND f.id > ${cursor}` : sql``}
       ORDER BY f.id ASC
       LIMIT ${BATCH_SIZE}
-    `);
+      `);
 
-    const rows = [...batch];
+    const rows: EntityFieldRow[] = [...batch];
     if (rows.length === 0) {
       break;
     }
@@ -118,7 +121,7 @@ const backfillEntityFields = async (): Promise<number> => {
       enqueued += 1;
     }
 
-    const lastRow = rows.at(-1);
+    const lastRow: EntityFieldRow | undefined = rows.at(-1);
     if (!lastRow) {
       break;
     }
@@ -130,7 +133,7 @@ const backfillEntityFields = async (): Promise<number> => {
 };
 
 const backfillChatFiles = async (): Promise<number> => {
-  let cursor: string | null = null;
+  let cursor: SafeId<"userFile"> | null = null;
   let generated = 0;
 
   for (;;) {
@@ -179,7 +182,7 @@ const backfillChatFiles = async (): Promise<number> => {
       const thumbnailKey = createUserFileKey({
         fileId: thumbnailFileId,
         mimeType: THUMBNAIL_MIME_TYPE,
-        userId: row.userId,
+        userId: brandPersistedUserId(row.userId),
       });
       // oxlint-disable-next-line no-await-in-loop -- writes one thumbnail per row before patching the row; sequential keeps S3 write and DB update paired
       await getS3().write(thumbnailKey, thumbnail.value.webp);

--- a/apps/api/scripts/benchmark-chat-read-surface.ts
+++ b/apps/api/scripts/benchmark-chat-read-surface.ts
@@ -44,6 +44,11 @@ type BenchTrace = {
   tools: ToolTrace[];
 };
 
+type SimulatedCall = {
+  function: string;
+  result: SimulatedReadResult;
+};
+
 type SimulatedReadResult =
   | {
       items: unknown[];
@@ -51,10 +56,7 @@ type SimulatedReadResult =
       nextOffset?: number | null;
     }
   | {
-      calls: {
-        function: string;
-        result: SimulatedReadResult;
-      }[];
+      calls: SimulatedCall[];
     }
   | {
       error: string;
@@ -258,9 +260,9 @@ const parseSurface = (value: string | undefined): Surface | "all" => {
 const parseArgs = (): Args => {
   const args = process.argv.slice(2);
   const parsed: Args = {
-    json: process.env.AI_BENCH_JSON === "true",
-    repeats: parsePositiveInteger(process.env.AI_BENCH_REPEATS, 1),
-    surface: parseSurface(process.env.AI_BENCH_SURFACE),
+    json: process.env["AI_BENCH_JSON"] === "true",
+    repeats: parsePositiveInteger(process.env["AI_BENCH_REPEATS"], 1),
+    surface: parseSurface(process.env["AI_BENCH_SURFACE"]),
   };
 
   for (let i = 0; i < args.length; i++) {
@@ -301,7 +303,7 @@ const getBenchModel = async (): Promise<BenchModel | null> => {
     return null;
   }
 
-  const overrideModel = process.env.AI_BENCH_MODEL;
+  const overrideModel = process.env["AI_BENCH_MODEL"];
   if (overrideModel) {
     const info = getTanStackTextModelInfoForRole("fast", null, {
       organizationId: null,
@@ -337,15 +339,15 @@ const addTrace = ({
   name,
   trace,
 }: {
-  code?: string;
-  error?: string;
+  code?: string | undefined;
+  error?: string | undefined;
   input: unknown;
   name: string;
   trace: BenchTrace;
 }) => {
   trace.tools.push({
-    code,
-    error,
+    ...(code === undefined ? {} : { code }),
+    ...(error === undefined ? {} : { error }),
     input,
     name,
   });
@@ -507,7 +509,7 @@ const simulateSandbox = ({
     };
   }
 
-  const calls = [];
+  const calls: SimulatedCall[] = [];
   for (const name of functionNames) {
     const validationError = validateSimulatedCall({
       code,
@@ -533,15 +535,16 @@ const simulateSandbox = ({
     });
   }
 
+  const singleCall = calls.at(0);
+  const value =
+    calls.length === 1 && singleCall !== undefined
+      ? singleCall.result
+      : { calls };
+
   return {
     durationMs: 1,
     hostCalls: calls.length,
-    value:
-      calls.length === 1
-        ? calls[0]?.result
-        : {
-            calls,
-          },
+    value,
   };
 };
 

--- a/apps/api/scripts/export-capability-catalog.ts
+++ b/apps/api/scripts/export-capability-catalog.ts
@@ -45,8 +45,10 @@ import { parseCapabilityCatalog } from "../../../packages/cli/src/capability-cat
 import { buildCliRouteTree } from "../../../packages/cli/src/generate-capability-tree";
 import type { RouteNode } from "../../../packages/cli/src/route-types";
 import { CONTEXT_FIDELITY_WAIVERS } from "../src/mcp/capability-waivers";
+import type { McpToolDefinition } from "../src/mcp/tool-types";
 import {
   type CapabilityDispatchRecord,
+  type AccessResolution,
   capInputSchema,
   CANONICAL_ACTION_VERBS,
   CAPABILITY_ID_SEGMENT_PATTERN,
@@ -815,17 +817,19 @@ const buildCatalog = async (): Promise<BuildResult> => {
   // Covering-tool scopes for the under-claim check. Imported dynamically after
   // discovery so `setup-env` has already seeded the API env defaults the module
   // graph validates at load (same ordering as the coverage guard).
-  const { DEFAULT_MCP_TOOL_DEFINITIONS } =
+  const { DEFAULT_MCP_TOOL_DEFINITIONS: narrowToolDefinitions } =
     await import("../src/mcp/static-tool-definitions");
+  const toolDefinitions: readonly McpToolDefinition[] = narrowToolDefinitions;
   const toolScopeByName = new Map<string, string>(
-    DEFAULT_MCP_TOOL_DEFINITIONS.map((tool) => [tool.name, tool.scope]),
+    toolDefinitions.map((tool) => [tool.name, tool.scope]),
   );
   // Covering-tool feature flags: a tool/covered entry inherits its covering
   // tool's deployment gate mechanically (see DOMAIN_FEATURE for the rest).
   const toolFeatureByName = new Map<string, string>(
-    DEFAULT_MCP_TOOL_DEFINITIONS.flatMap((tool) =>
-      tool.feature === undefined ? [] : [[tool.name, tool.feature] as const],
-    ),
+    narrowToolDefinitions.flatMap((tool) => {
+      const feature = Reflect.get(tool, "feature");
+      return typeof feature === "string" ? [[tool.name, feature] as const] : [];
+    }),
   );
   // DOMAIN_FEATURE values are plain strings (the McpToolFeatureFlag key-of-env
   // type collapses outside the app tsconfig), so validate every flag against
@@ -962,7 +966,16 @@ const buildCatalog = async (): Promise<BuildResult> => {
     // cache-filling write). When declared it is authoritative; inference only
     // proposes, and the affirmation guard below refuses to ship an unaffirmed
     // read (which would resolve to a `stella:read`-reachable scope).
-    const declaredAccess = endpoint.config["access"];
+    const declaredAccessValue = endpoint.config["access"];
+    const declaredAccess =
+      declaredAccessValue === "read" || declaredAccessValue === "write"
+        ? declaredAccessValue
+        : undefined;
+    if (declaredAccessValue !== undefined && declaredAccess === undefined) {
+      errors.push(
+        `capability "${id}" declares invalid access ${JSON.stringify(declaredAccessValue)}; expected "read" or "write"`,
+      );
+    }
     const inferredAccess = resolveAccess({
       id,
       verbs,
@@ -970,7 +983,7 @@ const buildCatalog = async (): Promise<BuildResult> => {
       overrides: {},
       destructiveNameOptOuts: DESTRUCTIVE_NAME_OPT_OUTS,
     });
-    const accessResolution =
+    const accessResolution: AccessResolution =
       declaredAccess === undefined
         ? inferredAccess
         : {
@@ -1335,11 +1348,12 @@ const computeCliCommandPaths = async (
     return { cliCommandPathById, errors };
   }
 
-  const { DEFAULT_MCP_TOOL_DEFINITIONS } =
+  const { DEFAULT_MCP_TOOL_DEFINITIONS: narrowToolDefinitions } =
     await import("../src/mcp/static-tool-definitions");
   const { DEFAULT_MCP_CLI_ANNOTATIONS } =
     await import("../src/mcp/static-cli-metadata");
-  const listings = DEFAULT_MCP_TOOL_DEFINITIONS.map((tool) => {
+  const toolDefinitions: readonly McpToolDefinition[] = narrowToolDefinitions;
+  const listings = toolDefinitions.map((tool) => {
     const listing: {
       name: string;
       description: string;
@@ -1350,8 +1364,14 @@ const computeCliCommandPaths = async (
       description: tool.description,
       inputSchema: tool.inputSchema,
     };
-    if (tool.annotations !== undefined) {
-      listing.annotations = tool.annotations;
+    if (tool.annotations?.readOnlyHint !== undefined) {
+      listing.annotations = { readOnlyHint: tool.annotations.readOnlyHint };
+    }
+    if (tool.annotations?.destructiveHint !== undefined) {
+      listing.annotations = {
+        ...listing.annotations,
+        destructiveHint: tool.annotations.destructiveHint,
+      };
     }
     return listing;
   });

--- a/apps/api/scripts/lib/capability-catalog.ts
+++ b/apps/api/scripts/lib/capability-catalog.ts
@@ -977,15 +977,15 @@ type ImportedLocal = { importPath: string; exportName: string | undefined };
 const parseHandlerImports = (source: string): Map<string, ImportedLocal> => {
   const map = new Map<string, ImportedLocal>();
   for (const match of source.matchAll(ROUTE_IMPORT_STATEMENT)) {
-    const clause = match.groups?.clause?.trim() ?? "";
-    const importPath = match.groups?.path ?? "";
+    const clause = match.groups?.["clause"]?.trim() ?? "";
+    const importPath = match.groups?.["path"] ?? "";
     if (!clause.startsWith("{")) {
-      const defaultName = IDENTIFIER_HEAD.exec(clause)?.groups?.name;
+      const defaultName = IDENTIFIER_HEAD.exec(clause)?.groups?.["name"];
       if (defaultName !== undefined) {
         map.set(defaultName, { importPath, exportName: undefined });
       }
     }
-    const namedBody = NAMED_IMPORT_BLOCK.exec(clause)?.groups?.body;
+    const namedBody = NAMED_IMPORT_BLOCK.exec(clause)?.groups?.["body"];
     if (namedBody !== undefined) {
       for (const part of namedBody.split(",")) {
         const trimmed = part.trim();
@@ -993,11 +993,14 @@ const parseHandlerImports = (source: string): Map<string, ImportedLocal> => {
           continue;
         }
         const aliased = ALIASED_IMPORT.exec(trimmed)?.groups;
-        if (aliased?.orig !== undefined && aliased.alias !== undefined) {
-          map.set(aliased.alias, { importPath, exportName: aliased.orig });
+        if (aliased?.["orig"] !== undefined && aliased["alias"] !== undefined) {
+          map.set(aliased["alias"], {
+            importPath,
+            exportName: aliased["orig"],
+          });
           continue;
         }
-        const plain = PLAIN_IDENTIFIER.exec(trimmed)?.groups?.name;
+        const plain = PLAIN_IDENTIFIER.exec(trimmed)?.groups?.["name"];
         if (plain !== undefined) {
           map.set(plain, { importPath, exportName: plain });
         }
@@ -1039,7 +1042,7 @@ const hookGuardedIdsInFile = ({
       continue;
     }
     for (const mount of block.matchAll(ROUTE_HANDLER_MOUNT_PATTERN)) {
-      const local = mount.groups?.local;
+      const local = mount.groups?.["local"];
       const imported = local === undefined ? undefined : imports.get(local);
       const id =
         imported === undefined ? undefined : importToCapabilityId(imported);

--- a/apps/api/scripts/record-eu-ecj-fixtures.ts
+++ b/apps/api/scripts/record-eu-ecj-fixtures.ts
@@ -253,7 +253,7 @@ const recordParserFixtures = async (): Promise<void> => {
       // oxlint-disable-next-line no-await-in-loop -- one write per recorded variant
       await Bun.write(
         new URL(`${stem}.fmx.xml.gz`, PARSER_FIXTURES_DIR),
-        Bun.gzipSync(formex),
+        Bun.gzipSync(new Uint8Array(formex)),
       );
       log(`  ${stem}: XHTML + Formex`);
     }

--- a/apps/api/tsconfig.scripts.json
+++ b/apps/api/tsconfig.scripts.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "tsBuildInfoFile": "./.cache/tsbuildinfo.scripts.json"
+  },
+  "include": ["src", "scripts", "drizzle.config.ts", "../../types"]
+}

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "dev:web": "bun packages/scripts/src/dev-runner.ts dev:web",
     "typegen": "turbo run typegen",
     "typecheck": "turbo run typecheck",
+    "typecheck:repo": "bun packages/scripts/src/tsc-native.ts --noEmit -p tsconfig.scripts.json && bun packages/scripts/src/tsc-native.ts --noEmit -p tsconfig.tooling.json && bun packages/scripts/src/tsc-native.ts --noEmit -p tsconfig.oxlint-plugins.json",
     "secrets:check:staged": "bash scripts/check-staged-secrets.sh",
     "security:audit": "bun scripts/dependency-audit.ts --check",
     "security:audit:report": "bun scripts/dependency-audit.ts",

--- a/packages/scripts/tsconfig.json
+++ b/packages/scripts/tsconfig.json
@@ -8,6 +8,6 @@
       "@stll/ai-catalog": ["../ai-catalog/src/index.ts"]
     }
   },
-  "include": ["."],
+  "include": [".", "../../scripts/typecheck-coverage.ts"],
   "exclude": ["node_modules"]
 }

--- a/scripts/check-lockfile-workspace-versions.ts
+++ b/scripts/check-lockfile-workspace-versions.ts
@@ -44,8 +44,8 @@ const globParent = (glob: string): string => {
 };
 
 const rootPkg = await readJson(path.join(ROOT, "package.json"));
-const workspaceGlobs = Array.isArray(rootPkg.workspaces)
-  ? rootPkg.workspaces.filter(
+const workspaceGlobs = Array.isArray(rootPkg["workspaces"])
+  ? rootPkg["workspaces"].filter(
       (glob): glob is string => typeof glob === "string",
     )
   : panic("root package.json is missing a `workspaces` array");
@@ -79,17 +79,17 @@ const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value);
 
 const parsedLock: unknown = JSON.parse(lockText.replace(/,(\s*[}\]])/gu, "$1"));
-if (!isRecord(parsedLock) || !isRecord(parsedLock.workspaces)) {
+if (!isRecord(parsedLock) || !isRecord(parsedLock["workspaces"])) {
   panic("bun.lock did not parse into the expected { workspaces: {...} } shape");
 }
 const { workspaces: lockWorkspaces } = parsedLock;
 
 const versionForWorkspace = (workspaceDir: string): string | null => {
   const entry = lockWorkspaces[workspaceDir];
-  if (!isRecord(entry) || typeof entry.version !== "string") {
+  if (!isRecord(entry) || typeof entry["version"] !== "string") {
     return null;
   }
-  return entry.version;
+  return entry["version"];
 };
 
 const mismatchForWorkspace = async (

--- a/scripts/check-migration-safety.ts
+++ b/scripts/check-migration-safety.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env bun
 
 import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
-import { join } from "node:path";
+import path from "node:path";
 
 type Statement = {
   line: number;
@@ -64,12 +64,12 @@ const parseAcknowledgementCategory = (
 
 const MIN_ACKNOWLEDGEMENT_REASON_LENGTH = 12;
 const DEFAULT_MIGRATIONS_DIR = "apps/api/drizzle";
-const ALTER_TABLE_PATTERN = /\bALTER\s+TABLE\b/i;
+const ALTER_TABLE_PATTERN = /\bALTER\s+TABLE\b/iu;
 const ALTER_COLUMN_TYPE_PATTERN =
-  /\bALTER\s+(?:COLUMN\s+)?\S+\s+(?:SET\s+DATA\s+)?TYPE\b/i;
-const DO_BLOCK_DOLLAR_QUOTE_PREFIX_PATTERN = /\bDO(?:\s+LANGUAGE\s+\S+)?\s*$/i;
+  /\bALTER\s+(?:COLUMN\s+)?\S+\s+(?:SET\s+DATA\s+)?TYPE\b/iu;
+const DO_BLOCK_DOLLAR_QUOTE_PREFIX_PATTERN = /\bDO(?:\s+LANGUAGE\s+\S+)?\s*$/iu;
 const ROUTINE_DOLLAR_QUOTE_PREFIX_PATTERN =
-  /\bCREATE\s+(?:OR\s+REPLACE\s+)?(?:FUNCTION|PROCEDURE)\b[\s\S]*\b(?:AS|IS)\s*$/i;
+  /\bCREATE\s+(?:OR\s+REPLACE\s+)?(?:FUNCTION|PROCEDURE)\b[\s\S]*\b(?:AS|IS)\s*$/iu;
 
 const IDENTIFIER_CHARACTER_PATTERN = /[A-Za-z0-9_]/u;
 const IDENTIFIER_WORD_PATTERN = /^[A-Za-z0-9_]+/u;
@@ -213,26 +213,26 @@ const GUARDED_RULES: GuardedRule[] = [
     description: "drops a database object",
     category: "destructive-change",
     pattern:
-      /\bDROP\s+(?:DATABASE|EXTENSION|FUNCTION|INDEX|MATERIALIZED\s+VIEW|POLICY|SCHEMA|SEQUENCE|TABLE|TRIGGER|TYPE|VIEW)\b/i,
+      /\bDROP\s+(?:DATABASE|EXTENSION|FUNCTION|INDEX|MATERIALIZED\s+VIEW|POLICY|SCHEMA|SEQUENCE|TABLE|TRIGGER|TYPE|VIEW)\b/iu,
   },
   {
     id: "drop-column",
     description: "drops a table column",
     category: "destructive-change",
     pattern:
-      /\bALTER\s+TABLE\b[\s\S]*\bDROP\s+(?:COLUMN\s+)?(?:IF\s+EXISTS\s+)?(?!(?:CONSTRAINT|DEFAULT|NOT\s+NULL)\b)\S+/i,
+      /\bALTER\s+TABLE\b[\s\S]*\bDROP\s+(?:COLUMN\s+)?(?:IF\s+EXISTS\s+)?(?!(?:CONSTRAINT|DEFAULT|NOT\s+NULL)\b)\S+/iu,
   },
   {
     id: "drop-constraint",
     description: "drops a table constraint",
     category: "destructive-change",
-    pattern: /\bALTER\s+TABLE\b[\s\S]*\bDROP\s+CONSTRAINT\b/i,
+    pattern: /\bALTER\s+TABLE\b[\s\S]*\bDROP\s+CONSTRAINT\b/iu,
   },
   {
     id: "rename-table-or-column",
     description: "renames a table or column",
     category: "destructive-change",
-    pattern: /\bALTER\s+TABLE\b[\s\S]*\bRENAME\b/i,
+    pattern: /\bALTER\s+TABLE\b[\s\S]*\bRENAME\b/iu,
   },
   {
     id: "alter-column-type",
@@ -246,19 +246,19 @@ const GUARDED_RULES: GuardedRule[] = [
     id: "truncate-table",
     description: "truncates table data",
     category: "destructive-change",
-    pattern: /\bTRUNCATE\b/i,
+    pattern: /\bTRUNCATE\b/iu,
   },
   {
     id: "delete-data",
     description: "deletes table data",
     category: "destructive-change",
-    pattern: /\bDELETE\s+FROM\b/i,
+    pattern: /\bDELETE\s+FROM\b/iu,
   },
   {
     id: "disable-row-level-security",
     description: "disables row-level security",
     category: "destructive-change",
-    pattern: /\bALTER\s+TABLE\b[\s\S]*\bDISABLE\s+ROW\s+LEVEL\s+SECURITY\b/i,
+    pattern: /\bALTER\s+TABLE\b[\s\S]*\bDISABLE\s+ROW\s+LEVEL\s+SECURITY\b/iu,
   },
   {
     id: "unbounded-update",
@@ -278,7 +278,7 @@ const INVARIANT_RULES: InvariantRule[] = [
   {
     id: "on-conflict-column-target",
     description: "uses a column-target ON CONFLICT clause",
-    pattern: /\bON\s+CONFLICT\s*\([^)]*\)/i,
+    pattern: /\bON\s+CONFLICT\s*\([^)]*\)/iu,
     guidance:
       "Use ON CONFLICT ON CONSTRAINT for a named table constraint, or use WHERE NOT EXISTS when the arbiter is a partial unique index.",
   },
@@ -345,13 +345,13 @@ const isWhitespaceOnly = (value: string): boolean => value.trim().length === 0;
 
 const appendMasked = (value: string): string => (value === "\n" ? "\n" : " ");
 
-const maskText = (value: string): string => value.replace(/[^\n]/g, " ");
+const maskText = (value: string): string => value.replace(/[^\n]/gu, " ");
 
 const countNewlines = (value: string): number =>
-  value.match(/\n/g)?.length ?? 0;
+  value.match(/\n/gu)?.length ?? 0;
 
 const isIdentifierCharacter = (value: string): boolean =>
-  /[A-Za-z0-9_$]/.test(value);
+  /[A-Za-z0-9_$]/u.test(value);
 
 const hasEscapeStringPrefix = (source: string, quoteIndex: number): boolean => {
   const prefix = source[quoteIndex - 1] ?? "";
@@ -363,7 +363,7 @@ const hasEscapeStringPrefix = (source: string, quoteIndex: number): boolean => {
 };
 
 const readDollarQuoteTag = (source: string, index: number): string | null => {
-  const match = /^\$[A-Za-z_][A-Za-z0-9_]*\$|^\$\$/.exec(source.slice(index));
+  const match = /^\$[A-Za-z_][A-Za-z0-9_]*\$|^\$\$/u.exec(source.slice(index));
 
   return match?.[0] ?? null;
 };
@@ -622,7 +622,7 @@ const parseStatements = (source: string): Statement[] => {
           statements.push({
             line: bodyStartLine + statement.line - 1,
             text: statement.text,
-            deferred: bodyIsDeferred || statement.deferred,
+            ...(bodyIsDeferred || statement.deferred ? { deferred: true } : {}),
           });
         }
       }
@@ -638,7 +638,7 @@ const parseStatements = (source: string): Statement[] => {
       continue;
     }
 
-    if (isWhitespaceOnly(current) && !/\s/.test(char)) {
+    if (isWhitespaceOnly(current) && !/\s/u.test(char)) {
       currentLine = line;
     }
 
@@ -662,15 +662,15 @@ const collectMigrationFiles = (directory: string): string[] => {
   const files: string[] = [];
 
   for (const entry of readdirSync(directory, { withFileTypes: true })) {
-    const path = join(directory, entry.name);
+    const filePath = path.join(directory, entry.name);
 
     if (entry.isDirectory()) {
-      files.push(...collectMigrationFiles(path));
+      files.push(...collectMigrationFiles(filePath));
       continue;
     }
 
     if (entry.isFile() && entry.name.endsWith(".sql")) {
-      files.push(path);
+      files.push(filePath);
     }
   }
 

--- a/scripts/check-railway-smoke.ts
+++ b/scripts/check-railway-smoke.ts
@@ -60,7 +60,11 @@ const checkApiHealth = async (apiUrl: string, expectedCommit?: string) => {
   if (value["status"] !== "ok") {
     throw new RailwaySmokeError("API /health did not return status=ok");
   }
-  expectCommit({ value, expectedCommit, source: "API /health" });
+  expectCommit({
+    value,
+    ...(expectedCommit === undefined ? {} : { expectedCommit }),
+    source: "API /health",
+  });
 };
 
 const checkWebHealth = async (webUrl: string) => {
@@ -99,6 +103,7 @@ const throwError = (error: Error): never => {
 
 const runProbe = async (name: string, probe: () => Promise<void>) => {
   let lastError: Error | undefined;
+  // eslint-disable-next-line no-unreachable-loop -- the catch path explicitly continues after a failed probe; successful probes return.
   for (let attempt = 1; attempt <= PROBE_ATTEMPTS; attempt += 1) {
     try {
       // eslint-disable-next-line no-await-in-loop -- retry probes must observe the result before deciding whether to wait and try again.
@@ -116,6 +121,7 @@ const runProbe = async (name: string, probe: () => Promise<void>) => {
       console.log(`${name}: waiting (${attempt}/${PROBE_ATTEMPTS})`);
       // eslint-disable-next-line no-await-in-loop -- retries are intentionally sequential to give the deployment time to become healthy.
       await sleep(PROBE_DELAY_MS);
+      continue;
     }
   }
 

--- a/scripts/check-railway-template-draft.ts
+++ b/scripts/check-railway-template-draft.ts
@@ -95,7 +95,9 @@ const readManifestBuckets = (value: unknown): string[] => {
     return [];
   }
   if (!isRecord(value)) {
-    throw new RailwayTemplateDraftError(`${MANIFEST_PATH} buckets must be an object`);
+    throw new RailwayTemplateDraftError(
+      `${MANIFEST_PATH} buckets must be an object`,
+    );
   }
   return Object.keys(value);
 };
@@ -115,6 +117,10 @@ const readManifest = (): TemplateManifest => {
         `${MANIFEST_PATH} service ${serviceName} must be an object`,
       );
     }
+    const build = readServiceBuild(
+      service["build"],
+      `services.${serviceName}.build`,
+    );
     services[serviceName] = {
       requiredUserInputs: readStringRecord(
         service["requiredUserInputs"] ?? {},
@@ -124,10 +130,7 @@ const readManifest = (): TemplateManifest => {
         service["variables"] ?? {},
         `services.${serviceName}.variables`,
       ),
-      build: readServiceBuild(
-        service["build"],
-        `services.${serviceName}.build`,
-      ),
+      ...(build === undefined ? {} : { build }),
     };
   }
 

--- a/scripts/check-railway-template-shape.ts
+++ b/scripts/check-railway-template-shape.ts
@@ -273,7 +273,7 @@ const publicRailwayCopy = [
   ["Railway docs", railwayDoc],
   ["template README", templateReadme],
   ["README", readText("README.md")],
-];
+] satisfies readonly (readonly [label: string, text: string])[];
 // A referral code inside a deploy URL is standard marketplace practice; the
 // guard targets prose that discusses monetization, so URLs are stripped
 // before matching.

--- a/scripts/crawl-posture.ts
+++ b/scripts/crawl-posture.ts
@@ -317,7 +317,13 @@ const crawlPrefixConstantEntries = (
   if (declaration === null) {
     return [];
   }
-  return [...declaration[1].matchAll(QUOTED_STRING)].map((match) => match[1]);
+  const body = declaration[1];
+  if (body === undefined) {
+    return [];
+  }
+  return [...body.matchAll(QUOTED_STRING)].flatMap((match) =>
+    match[1] === undefined ? [] : [match[1]],
+  );
 };
 
 const isDirectory = (candidate: string): boolean =>
@@ -607,12 +613,16 @@ const checkMixed = (appDir: string, app: string): Violation[] => {
   // cannot bypass the single crawl-prefix allowlist.
   const constantSet = new Set(prefixes);
   for (const match of libSource.matchAll(ALLOW_PATH_LITERAL)) {
-    const prefix = allowPathToPrefix(match[1]);
+    const allowPath = match[1];
+    if (allowPath === undefined) {
+      continue;
+    }
+    const prefix = allowPathToPrefix(allowPath);
     if (!constantSet.has(prefix)) {
       violations.push({
         app,
         code: "mixed-allow-not-in-constant",
-        message: `${MIXED_ROBOTS_LIB} allows \`${match[1]}\`, whose prefix \`${prefix}\` is not in ${MIXED_CRAWL_PREFIX_CONST}.`,
+        message: `${MIXED_ROBOTS_LIB} allows \`${allowPath}\`, whose prefix \`${prefix}\` is not in ${MIXED_CRAWL_PREFIX_CONST}.`,
         fix: `add ${prefix} to ${MIXED_CRAWL_PREFIX_CONST} or remove the Allow line.`,
       });
     }
@@ -719,7 +729,7 @@ const checkAll = (appsRoot: string): CheckResult => {
 // --- Modes ------------------------------------------------------------------
 
 const summarize = (reports: readonly AppReport[]): string => {
-  const counts: Record<string, number> = {
+  const counts: Record<CrawlPosture | "invalid", number> = {
     public: 0,
     private: 0,
     mixed: 0,

--- a/scripts/ratchet.ts
+++ b/scripts/ratchet.ts
@@ -24,6 +24,7 @@
 // CI-only wiring lives in .github/workflows/ci.yml and scripts/verify.sh
 // alongside the other ratchet guards.
 
+import { panic } from "better-result";
 import {
   mkdirSync,
   mkdtempSync,
@@ -921,6 +922,9 @@ const RATCHET_METRICS: readonly RatchetMetric[] = [
 type MetricSnapshot = { count: number; files: Record<string, number> };
 type Baseline = Record<string, MetricSnapshot>;
 
+const requireSnapshot = (baseline: Baseline, id: string): MetricSnapshot =>
+  baseline[id] ?? panic(`ratchet metric ${id} is missing from the snapshot`);
+
 const scanMetric = (metric: RatchetMetric, root: string): MetricSnapshot => {
   const seen = new Set<string>();
   const perFile: Record<string, number> = {};
@@ -945,7 +949,8 @@ const scanMetric = (metric: RatchetMetric, root: string): MetricSnapshot => {
 
   const files: Record<string, number> = {};
   for (const rel of Object.keys(perFile).sort()) {
-    files[rel] = perFile[rel];
+    files[rel] =
+      perFile[rel] ?? panic(`ratchet count for ${rel} disappeared during scan`);
   }
   return { count, files };
 };
@@ -1032,7 +1037,7 @@ const runReport = (): number => {
   const showDetails = process.argv.includes("--details");
   console.log("ratchet: current metric counts (vs baseline)\n");
   for (const metric of RATCHET_METRICS) {
-    const c = current[metric.id];
+    const c = requireSnapshot(current, metric.id);
     const b = baseline[metric.id]?.count ?? 0;
     const delta = c.count - b;
     const sign = formatDelta(delta);
@@ -1054,7 +1059,7 @@ const runWrite = (): number => {
   writeBaseline(snapshot);
   console.log(`Wrote ratchet baseline to ${BASELINE_REL}:`);
   for (const metric of RATCHET_METRICS) {
-    const snap = snapshot[metric.id];
+    const snap = requireSnapshot(snapshot, metric.id);
     console.log(
       `  ${metric.id.padEnd(30)} ${String(snap.count).padStart(5)} across ${Object.keys(snap.files).length} file(s)`,
     );
@@ -1071,7 +1076,11 @@ const runCheck = (): number => {
 
   for (const metric of RATCHET_METRICS) {
     const base = baseline[metric.id] ?? { count: 0, files: {} };
-    const diff = diffMetric(metric.id, current[metric.id], base);
+    const diff = diffMetric(
+      metric.id,
+      requireSnapshot(current, metric.id),
+      base,
+    );
     if (diff.status === "regressed") {
       regressions.push(diff);
     }
@@ -1502,7 +1511,7 @@ const runSelfTest = (): number => {
 
     const snapshot = scanAll(root);
 
-    const asMetric = snapshot["as-casts"];
+    const asMetric = requireSnapshot(snapshot, "as-casts");
     if (asMetric.count !== EXPECTED_AS_CASTS) {
       failures.push(
         `as-casts counted ${asMetric.count}, expected ${EXPECTED_AS_CASTS}`,
@@ -1515,43 +1524,54 @@ const runSelfTest = (): number => {
       failures.push("as-casts did not exclude a .gen.ts file");
     }
 
-    const nullishMetric = snapshot["nullish-array-fallback"];
+    const nullishMetric = requireSnapshot(snapshot, "nullish-array-fallback");
     if (nullishMetric.count !== EXPECTED_NULLISH) {
       failures.push(
         `nullish-array-fallback counted ${nullishMetric.count}, expected ${EXPECTED_NULLISH}`,
       );
     }
 
-    const barrelMetric = snapshot["barrel-index-files"];
+    const barrelMetric = requireSnapshot(snapshot, "barrel-index-files");
     if (barrelMetric.count !== 2) {
       failures.push(
         `barrel-index-files counted ${barrelMetric.count}, expected 2`,
       );
     }
 
-    const directErrorMetric = snapshot["direct-error-message-display"];
+    const directErrorMetric = requireSnapshot(
+      snapshot,
+      "direct-error-message-display",
+    );
     if (directErrorMetric.count !== EXPECTED_DIRECT_ERROR) {
       failures.push(
         `direct-error-message-display counted ${directErrorMetric.count}, expected ${EXPECTED_DIRECT_ERROR}`,
       );
     }
 
-    const moduleCollectionsMetric =
-      snapshot["module-level-mutable-collections"];
+    const moduleCollectionsMetric = requireSnapshot(
+      snapshot,
+      "module-level-mutable-collections",
+    );
     if (moduleCollectionsMetric.count !== EXPECTED_MODULE_COLLECTIONS) {
       failures.push(
         `module-level-mutable-collections counted ${moduleCollectionsMetric.count}, expected ${EXPECTED_MODULE_COLLECTIONS}`,
       );
     }
 
-    const suppressionMetric = snapshot["raw-use-effect-suppressions"];
+    const suppressionMetric = requireSnapshot(
+      snapshot,
+      "raw-use-effect-suppressions",
+    );
     if (suppressionMetric.count !== EXPECTED_SUPPRESSIONS) {
       failures.push(
         `raw-use-effect-suppressions counted ${suppressionMetric.count}, expected ${EXPECTED_SUPPRESSIONS}`,
       );
     }
 
-    const lintSuppressionMetric = snapshot["lint-suppression-directives"];
+    const lintSuppressionMetric = requireSnapshot(
+      snapshot,
+      "lint-suppression-directives",
+    );
     if (lintSuppressionMetric.count !== EXPECTED_LINT_SUPPRESSIONS_TOTAL) {
       failures.push(
         `lint-suppression-directives counted ${lintSuppressionMetric.count}, expected ${EXPECTED_LINT_SUPPRESSIONS_TOTAL}`,
@@ -1566,21 +1586,30 @@ const runSelfTest = (): number => {
       );
     }
 
-    const tsSuppressionMetric = snapshot["ts-suppression-directives"];
+    const tsSuppressionMetric = requireSnapshot(
+      snapshot,
+      "ts-suppression-directives",
+    );
     if (tsSuppressionMetric.count !== EXPECTED_TS_SUPPRESSIONS) {
       failures.push(
         `ts-suppression-directives counted ${tsSuppressionMetric.count}, expected ${EXPECTED_TS_SUPPRESSIONS}`,
       );
     }
 
-    const detachedPromiseMetric = snapshot["detached-promise-review-sites"];
+    const detachedPromiseMetric = requireSnapshot(
+      snapshot,
+      "detached-promise-review-sites",
+    );
     if (detachedPromiseMetric.count !== EXPECTED_DETACHED_PROMISES) {
       failures.push(
         `detached-promise-review-sites counted ${detachedPromiseMetric.count}, expected ${EXPECTED_DETACHED_PROMISES}`,
       );
     }
 
-    const truncatedCapabilityMetric = snapshot["capability-schemas-truncated"];
+    const truncatedCapabilityMetric = requireSnapshot(
+      snapshot,
+      "capability-schemas-truncated",
+    );
     if (
       truncatedCapabilityMetric.count !== EXPECTED_TRUNCATED_CAPABILITY_SCHEMAS
     ) {
@@ -1589,15 +1618,20 @@ const runSelfTest = (): number => {
       );
     }
 
-    const fileTransportMetric =
-      snapshot["capability-file-transport-suppressed"];
+    const fileTransportMetric = requireSnapshot(
+      snapshot,
+      "capability-file-transport-suppressed",
+    );
     if (fileTransportMetric.count !== EXPECTED_FILE_TRANSPORT_SUPPRESSED) {
       failures.push(
         `capability-file-transport-suppressed counted ${fileTransportMetric.count}, expected ${EXPECTED_FILE_TRANSPORT_SUPPRESSED}`,
       );
     }
 
-    const readWriteScopeMetric = snapshot["read-capabilities-with-write-scope"];
+    const readWriteScopeMetric = requireSnapshot(
+      snapshot,
+      "read-capabilities-with-write-scope",
+    );
     if (
       readWriteScopeMetric.count !== EXPECTED_READ_CAPABILITIES_WITH_WRITE_SCOPE
     ) {
@@ -1606,8 +1640,10 @@ const runSelfTest = (): number => {
       );
     }
 
-    const missingDescriptionMetric =
-      snapshot["capabilities-without-description"];
+    const missingDescriptionMetric = requireSnapshot(
+      snapshot,
+      "capabilities-without-description",
+    );
     if (
       missingDescriptionMetric.count !==
       EXPECTED_CAPABILITIES_WITHOUT_DESCRIPTION
@@ -1617,14 +1653,20 @@ const runSelfTest = (): number => {
       );
     }
 
-    const crossHandlerMetric = snapshot["cross-handler-imports"];
+    const crossHandlerMetric = requireSnapshot(
+      snapshot,
+      "cross-handler-imports",
+    );
     if (crossHandlerMetric.count !== EXPECTED_CROSS_HANDLER) {
       failures.push(
         `cross-handler-imports counted ${crossHandlerMetric.count}, expected ${EXPECTED_CROSS_HANDLER}`,
       );
     }
 
-    const crossRouteMetric = snapshot["cross-route-private-imports"];
+    const crossRouteMetric = requireSnapshot(
+      snapshot,
+      "cross-route-private-imports",
+    );
     const expectedCrossRouteTotal =
       EXPECTED_CROSS_ROUTE_BETA +
       EXPECTED_CROSS_ROUTE_NESTED +
@@ -1645,7 +1687,10 @@ const runSelfTest = (): number => {
       );
     }
 
-    const crossFeatureMetric = snapshot["cross-feature-imports"];
+    const crossFeatureMetric = requireSnapshot(
+      snapshot,
+      "cross-feature-imports",
+    );
     if (crossFeatureMetric.count !== EXPECTED_CROSS_FEATURE) {
       failures.push(
         `cross-feature-imports counted ${crossFeatureMetric.count}, expected ${EXPECTED_CROSS_FEATURE}`,

--- a/scripts/sync-railway-template-source.ts
+++ b/scripts/sync-railway-template-source.ts
@@ -303,7 +303,11 @@ const resolveProject = async ({
   environment: string;
 }): Promise<ResolvedProject> => {
   if (auth.type === "project") {
-    return resolveProjectToken({ auth, environment, projectId });
+    return resolveProjectToken({
+      auth,
+      environment,
+      ...(projectId === undefined ? {} : { projectId }),
+    });
   }
 
   if (!projectId) {
@@ -636,7 +640,7 @@ const main = async () => {
   const projectId = project ?? process.env["RAILWAY_TEMPLATE_PROJECT_ID"];
   const resolvedProject = await resolveProject({
     auth,
-    projectId,
+    ...(projectId === undefined ? {} : { projectId }),
     environment:
       environment ??
       process.env["RAILWAY_TEMPLATE_ENVIRONMENT"] ??

--- a/scripts/typecheck-coverage.ts
+++ b/scripts/typecheck-coverage.ts
@@ -1,0 +1,254 @@
+#!/usr/bin/env bun
+
+// Typecheck coverage guard.
+//
+// A TypeScript file can run through Bun, Vite, Expo, or another loader without
+// belonging to any project that CI typechecks. `tsc --listFilesOnly` is the
+// compiler's source of truth for project membership, so this guard unions that
+// output across every CI typecheck project and rejects repository .ts/.tsx
+// files that are absent from the union.
+//
+// Oxlint fixtures are the sole explicit exemption because many contain
+// intentionally invalid source patterns that the rules must detect.
+//
+// Usage:
+//   bun scripts/typecheck-coverage.ts
+//   bun scripts/typecheck-coverage.ts --self-test
+
+import { panic } from "better-result";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import path from "node:path";
+
+const REPO_ROOT = path.resolve(import.meta.dir, "..");
+const TSC_NATIVE = "packages/scripts/src/tsc-native.ts";
+const WORKSPACE_PARENTS = ["apps", "packages"] as const;
+const EXEMPT_PREFIXES = [".oxlint-plugins/__fixtures__/"] as const;
+const PROJECT_ARGUMENT =
+  /(?:^|\s)(?:-p|--project)(?:\s+|=)(["']?)([^\s"';&]+)\1/gu;
+
+type Options = {
+  selfTest: boolean;
+};
+
+const parseArgs = (args: string[]): Options => {
+  let selfTest = false;
+
+  for (const argument of args) {
+    if (argument === "--self-test") {
+      selfTest = true;
+      continue;
+    }
+    panic(`Unknown argument: ${argument}`);
+  }
+
+  return { selfTest };
+};
+
+const normalizeRepoPath = (file: string): string =>
+  file.split(path.sep).join("/");
+
+const isTypeScriptFile = (file: string): boolean => /\.tsx?$/u.test(file);
+
+const isExempt = (file: string): boolean =>
+  EXEMPT_PREFIXES.some((prefix) => file.startsWith(prefix));
+
+const run = (command: string[]): string => {
+  const result = Bun.spawnSync(command, {
+    cwd: REPO_ROOT,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  if (result.exitCode !== 0) {
+    panic(
+      `Command failed (${result.exitCode}): ${command.join(" ")}\n${result.stderr.toString()}${result.stdout.toString()}`,
+    );
+  }
+  return result.stdout.toString();
+};
+
+const lines = (output: string): string[] =>
+  output
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+
+const supplementalProjects = (typecheckCommand: string): string[] => {
+  const projects: string[] = [];
+  for (const match of typecheckCommand.matchAll(PROJECT_ARGUMENT)) {
+    const project = match[2];
+    if (project) {
+      projects.push(project);
+    }
+  }
+  return projects;
+};
+
+const typecheckProjects = (): string[] => {
+  const projects = new Set<string>();
+
+  const addProject = (project: string, owner: string): void => {
+    const normalized = normalizeRepoPath(project);
+    if (!existsSync(path.join(REPO_ROOT, normalized))) {
+      panic(`${owner}'s typecheck script references missing ${project}`);
+    }
+    projects.add(normalized);
+  };
+
+  for (const parent of WORKSPACE_PARENTS) {
+    const parentPath = path.join(REPO_ROOT, parent);
+    for (const entry of readdirSync(parentPath, { withFileTypes: true })) {
+      if (!entry.isDirectory()) {
+        continue;
+      }
+
+      const workspace = path.join(parent, entry.name);
+      const packagePath = path.join(REPO_ROOT, workspace, "package.json");
+      if (!existsSync(packagePath)) {
+        continue;
+      }
+
+      const packageJson = JSON.parse(readFileSync(packagePath, "utf-8"));
+      const typecheck = packageJson.scripts?.typecheck;
+      if (typeof typecheck !== "string") {
+        continue;
+      }
+
+      addProject(path.join(workspace, "tsconfig.json"), workspace);
+
+      for (const project of supplementalProjects(typecheck)) {
+        addProject(path.join(workspace, project), workspace);
+      }
+    }
+  }
+
+  const rootPackage = JSON.parse(
+    readFileSync(path.join(REPO_ROOT, "package.json"), "utf-8"),
+  );
+  const repositoryTypecheck = rootPackage.scripts?.["typecheck:repo"];
+  if (typeof repositoryTypecheck !== "string") {
+    panic("root package.json must define the typecheck:repo script");
+  }
+  for (const project of supplementalProjects(repositoryTypecheck)) {
+    addProject(project, "typecheck:repo");
+  }
+
+  return [...projects].sort();
+};
+
+const coveredFiles = (projects: string[]): Set<string> => {
+  const covered = new Set<string>();
+
+  for (const project of projects) {
+    const output = run([
+      process.execPath,
+      TSC_NATIVE,
+      "-p",
+      project,
+      "--listFilesOnly",
+    ]);
+    for (const file of lines(output)) {
+      const relative = path.relative(REPO_ROOT, path.resolve(file));
+      if (relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative)) {
+        continue;
+      }
+      covered.add(normalizeRepoPath(relative));
+    }
+  }
+
+  return covered;
+};
+
+const repositoryTypeScriptFiles = (): Set<string> =>
+  new Set(
+    lines(
+      run([
+        "git",
+        "ls-files",
+        "--cached",
+        "--others",
+        "--exclude-standard",
+        "--",
+        "*.ts",
+        "*.tsx",
+      ]),
+    ).filter(isTypeScriptFile),
+  );
+
+const findUncovered = (
+  repositoryFiles: Set<string>,
+  covered: Set<string>,
+): string[] =>
+  [...repositoryFiles]
+    .filter((file) => !isExempt(file))
+    .filter((file) => !covered.has(file))
+    .sort();
+
+const assert = (condition: boolean, message: string): void => {
+  if (!condition) {
+    panic(message);
+  }
+};
+
+const selfTest = (): void => {
+  assert(isTypeScriptFile("src/new-file.ts"), "must recognize .ts files");
+  assert(isTypeScriptFile("src/env.d.ts"), "must recognize declaration files");
+  assert(isTypeScriptFile("src/view.tsx"), "must recognize .tsx files");
+  assert(!isTypeScriptFile("src/view.js"), "must ignore non-TypeScript files");
+
+  const parsed = supplementalProjects(
+    "tsc --noEmit -p tsconfig.test.json && tsc --project=e2e/tsconfig.json",
+  );
+  assert(
+    parsed.join(",") === "tsconfig.test.json,e2e/tsconfig.json",
+    "must discover supplemental typecheck projects",
+  );
+
+  const repository = new Set([
+    "src/covered.ts",
+    "src/missing.tsx",
+    ".oxlint-plugins/__fixtures__/intentionally-invalid.ts",
+  ]);
+  const covered = new Set(["src/covered.ts"]);
+  const uncovered = findUncovered(repository, covered);
+  assert(
+    uncovered.length === 1 && uncovered[0] === "src/missing.tsx",
+    "must reject an uncovered repository source while exempting oxlint fixtures",
+  );
+
+  console.log("typecheck-coverage --self-test: PASS");
+};
+
+const main = (): void => {
+  const options = parseArgs(process.argv.slice(2));
+  if (options.selfTest) {
+    selfTest();
+    return;
+  }
+
+  const projects = typecheckProjects();
+  const repositoryFiles = repositoryTypeScriptFiles();
+  const covered = coveredFiles(projects);
+  const uncovered = findUncovered(repositoryFiles, covered);
+
+  if (uncovered.length > 0) {
+    console.error(
+      "typecheck-coverage: TypeScript files belong to no CI typecheck project:\n",
+    );
+    for (const file of uncovered) {
+      console.error(`  - ${file}`);
+    }
+    console.error(
+      "\nAdd each file to the appropriate tsconfig include (and ensure that " +
+        "project is run by a CI typecheck script).",
+    );
+    process.exit(1);
+  }
+
+  const candidates = [...repositoryFiles].filter((file) => !isExempt(file));
+  console.log(
+    `typecheck-coverage: OK. ${candidates.length} TypeScript file(s) covered ` +
+      `by ${projects.length} typecheck project(s).`,
+  );
+};
+
+main();

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -107,10 +107,16 @@ run_typecheck() {
   # its own CI job (typecheck-baseline); its failures point at type-cost growth, not
   # type errors, so a green verify still matches a green typecheck.
   if [[ -n "$affected_flag" ]]; then
-    bun run typecheck -- --concurrency=1 "$affected_flag"
+    bun run typecheck -- --concurrency=1 "$affected_flag" || return 1
   else
-    bun run typecheck -- --concurrency=1
+    bun run typecheck -- --concurrency=1 || return 1
   fi
+  bun run typecheck:repo
+}
+
+run_typecheck_coverage() {
+  bun scripts/typecheck-coverage.ts --self-test || return 1
+  bun scripts/typecheck-coverage.ts
 }
 
 run_ratchet_guard() {
@@ -201,6 +207,7 @@ run_step "Release changelog guard" bash scripts/check-release-changelog.sh --bas
 run_step "Lint" run_lint
 run_step "Format" run_format
 run_step "Rust format" run_rust_format
+run_step "Typecheck coverage" run_typecheck_coverage
 run_step "Typecheck" run_typecheck
 if [[ -n "$affected_flag" ]]; then
   run_step "Result consumption" bun run check:result-consumption -- --base "$base_ref"

--- a/tsconfig.oxlint-plugins.json
+++ b/tsconfig.oxlint-plugins.json
@@ -1,0 +1,17 @@
+{
+  "extends": "@stll/typescript-config/base.json",
+  "compilerOptions": {
+    "allowImportingTsExtensions": true,
+    // Oxlint's JS-plugin runtime does not publish types for rule contexts or
+    // its dynamic ESTree nodes. Helpers still narrow external nodes from
+    // unknown; these two options preserve the runtime's callback/object API.
+    "noImplicitAny": false,
+    "noPropertyAccessFromIndexSignature": false,
+    "strict": true,
+    "strictNullChecks": true,
+    "types": ["bun"],
+    "useUnknownInCatchVariables": true
+  },
+  "include": [".oxlint-plugins/**/*.ts", "oxlint.config.ts"],
+  "exclude": [".oxlint-plugins/__fixtures__"]
+}

--- a/tsconfig.scripts.json
+++ b/tsconfig.scripts.json
@@ -1,0 +1,10 @@
+{
+  "extends": "@stll/typescript-config/base.json",
+  "compilerOptions": {
+    "paths": {
+      "@/api/*": ["./apps/api/src/*"]
+    },
+    "types": ["bun"]
+  },
+  "include": ["scripts/**/*.ts"]
+}

--- a/tsconfig.tooling.json
+++ b/tsconfig.tooling.json
@@ -1,0 +1,12 @@
+{
+  "extends": "@stll/typescript-config/base.json",
+  "compilerOptions": {
+    "allowImportingTsExtensions": true,
+    "types": ["bun"]
+  },
+  "include": [
+    ".claude/mcp/**/*.ts",
+    "apps/web/scripts/**/*.ts",
+    "packages/*/scripts/**/*.ts"
+  ]
+}


### PR DESCRIPTION
## Summary

- add supplemental typecheck projects for repository scripts, API scripts, tooling, and Oxlint plugins
- add a repository-wide coverage guard that compares every valid `.ts`/`.tsx` file with `tsc --listFilesOnly`
- wire the guard and supplemental projects into CI and local verification
- eliminate all uncovered valid TypeScript files; only intentionally invalid Oxlint fixtures are exempt

## Verification

- `bun run typecheck:repo`
- API supplemental typecheck project
- `bun scripts/typecheck-coverage.ts --self-test`
- `bun scripts/typecheck-coverage.ts` — 3,323/3,323 files covered across 43 projects
- pre-commit and pre-push hooks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added comprehensive TypeScript coverage checks to verification and continuous integration.
  - Added dedicated type-checking coverage for scripts, tooling, and development plugins.
  - Improved validation of migration files, templates, capability metadata, and repository configuration.

- **Bug Fixes**
  - Strengthened handling of malformed or unexpected data during analysis and validation.
  - Improved redirect, streaming, retry, and parser safety.

- **Refactor**
  - Updated documentation tool registration and improved internal type safety across development tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->