### PR TITLE
fix(docx): preserve declared nested loop scopes

### DIFF
--- a/apps/api/src/handlers/docx/block-directives-properties.test.ts
+++ b/apps/api/src/handlers/docx/block-directives-properties.test.ts
@@ -23,6 +23,7 @@ import {
 import { discoverTemplate } from "./discover-template";
 import { paragraphText, W_NS } from "./ooxml";
 import { fillTemplate } from "./patch-template";
+import type { TemplateDataValue } from "./types";
 
 setDefaultTimeout(30_000);
 
@@ -211,6 +212,65 @@ describe("property: nested objects in #each items resolve", () => {
         },
       ),
       propertyConfig({ numRuns: 30 }),
+    );
+  });
+});
+
+describe("property: declared nested loop paths stay condition aliases", () => {
+  test("conditions resolve the current row at every generated nesting depth", () => {
+    const nestedPath = fc.array(identifier, { minLength: 2, maxLength: 4 });
+    const conditionRows = fc
+      .array(fc.boolean(), { minLength: 1, maxLength: 6 })
+      .filter((values) => values.includes(true));
+
+    fc.assert(
+      fc.property(
+        nestedPath,
+        identifier,
+        conditionRows,
+        (segments, conditionField, enabledValues) => {
+          const paths = segments.map((_, index) =>
+            segments.slice(0, index + 1).join("."),
+          );
+          const deepestPath = paths.at(-1);
+          const rootPath = segments.at(0);
+          if (!deepestPath || !rootPath) {
+            throw new Error(
+              "Nested paths always contain at least two segments",
+            );
+          }
+
+          const templateParts = paths.map((path) => P(`{{#each ${path}}}`));
+          templateParts.push(
+            P(`{{#if ${deepestPath}.${conditionField}}}`),
+            P("visible"),
+            P("{{/if}}"),
+          );
+          templateParts.push(...paths.toReversed().map(() => P("{{/each}}")));
+
+          let rows: TemplateDataValue[] = enabledValues.map((enabled) => ({
+            [conditionField]: enabled,
+          }));
+          for (let index = segments.length - 1; index > 0; index--) {
+            const segment = segments[index];
+            if (!segment) {
+              throw new Error("Generated path segments are never missing");
+            }
+            rows = [{ [segment]: rows }];
+          }
+
+          const body = parseBody(WRAP(templateParts.join("")));
+          processBlockDirectives(body, { [rootPath]: rows });
+
+          const rendered = body
+            .getElementsByTagNameNS(W_NS, "p")
+            .map(paragraphText);
+          expect(rendered).toEqual(
+            enabledValues.filter(Boolean).map(() => "visible"),
+          );
+        },
+      ),
+      propertyConfig({ numRuns: 50 }),
     );
   });
 });

--- a/apps/api/src/handlers/docx/block-directives-properties.test.ts
+++ b/apps/api/src/handlers/docx/block-directives-properties.test.ts
@@ -273,6 +273,68 @@ describe("property: declared nested loop paths stay condition aliases", () => {
       propertyConfig({ numRuns: 50 }),
     );
   });
+
+  test("declared aliases preserve raw date values at every nesting depth", () => {
+    const nestedPath = fc.array(identifier, { minLength: 2, maxLength: 4 });
+    const years = fc
+      .array(fc.integer({ min: 2020, max: 2035 }), {
+        minLength: 1,
+        maxLength: 6,
+      })
+      .filter((values) => values.some((year) => year > 2028));
+
+    fc.assert(
+      fc.property(nestedPath, identifier, years, (segments, field, values) => {
+        const paths = segments.map((_, index) =>
+          segments.slice(0, index + 1).join("."),
+        );
+        const deepestPath = paths.at(-1);
+        const rootPath = segments.at(0);
+        if (!deepestPath || !rootPath) {
+          throw new Error("Nested paths always contain at least two segments");
+        }
+
+        const templateParts = paths.map((path) => P(`{{#each ${path}}}`));
+        templateParts.push(
+          P(`{{#if ${deepestPath}.${field} > "2028-01-01"}}`),
+          P("after"),
+          P("{{/if}}"),
+        );
+        templateParts.push(...paths.toReversed().map(() => P("{{/each}}")));
+
+        let rows: TemplateDataValue[] = values.map(() => ({
+          [field]: "1. ledna 2030",
+        }));
+        for (let index = segments.length - 1; index > 0; index--) {
+          const segment = segments[index];
+          if (!segment) {
+            throw new Error("Generated path segments are never missing");
+          }
+          rows = [{ [segment]: rows }];
+        }
+
+        const indexedDeepestPath = segments
+          .map((segment, index) => (index === 0 ? segment : `0.${segment}`))
+          .join(".");
+        const conditionValues: Record<string, string> = {};
+        for (const [index, year] of values.entries()) {
+          conditionValues[`${indexedDeepestPath}.${index}.${field}`] =
+            `${year}-01-01`;
+        }
+
+        const body = parseBody(WRAP(templateParts.join("")));
+        processBlockDirectives(body, { [rootPath]: rows }, { conditionValues });
+
+        const rendered = body
+          .getElementsByTagNameNS(W_NS, "p")
+          .map(paragraphText);
+        expect(rendered).toEqual(
+          values.filter((year) => year > 2028).map(() => "after"),
+        );
+      }),
+      propertyConfig({ numRuns: 50 }),
+    );
+  });
 });
 
 describe("property: arrays inside loop items are not recursed into", () => {

--- a/apps/api/src/handlers/docx/block-directives.ts
+++ b/apps/api/src/handlers/docx/block-directives.ts
@@ -790,9 +790,15 @@ export const processBlockDirectives = (
   // Build a loop iteration's evaluation context: `contextData` overlaid with
   // the item's own fields, the item under its array name (so `{{#each
   // arrayPath.sub}}` resolves), and the row's raw (pre-format) date overlay.
-  const loopIdentityByContext = new WeakMap<
+  type LoopScope = {
+    declaredPath: string;
+    identity: string;
+    valuePath: string;
+  };
+
+  const loopScopeByContext = new WeakMap<
     Record<string, unknown>,
-    ReadonlyMap<string, string>
+    ReadonlyMap<string, LoopScope>
   >();
 
   type BuildItemContextOptions = {
@@ -800,7 +806,72 @@ export const processBlockDirectives = (
     contextData: Record<string, unknown>;
     item: unknown;
     itemIdx: number;
-    loopIdentity: string;
+    scope: LoopScope;
+  };
+
+  type RegisterContextAliasesOptions = {
+    context: Record<string, unknown>;
+    path: string;
+    value: unknown;
+  };
+
+  const registerContextAliases = ({
+    context,
+    path,
+    value,
+  }: RegisterContextAliasesOptions): void => {
+    context[path] = value;
+    if (Array.isArray(value) || !isRecord(value) || isRichPatchValue(value)) {
+      return;
+    }
+    for (const [field, nestedValue] of Object.entries(value)) {
+      registerContextAliases({
+        context,
+        path: `${path}.${field}`,
+        value: nestedValue,
+      });
+    }
+  };
+
+  type RegisterNestedLoopScopesOptions = {
+    item: Record<string, unknown>;
+    itemContext: Record<string, unknown>;
+    itemIdx: number;
+    nestedLoopScopes: Map<string, LoopScope>;
+    scope: LoopScope;
+  };
+
+  const registerNestedLoopScopes = ({
+    item,
+    itemContext,
+    itemIdx,
+    nestedLoopScopes,
+    scope,
+  }: RegisterNestedLoopScopesOptions): void => {
+    const visit = (value: unknown, relativePath: string): void => {
+      if (Array.isArray(value)) {
+        const nestedScope = {
+          declaredPath: `${scope.declaredPath}.${relativePath}`,
+          identity: eachKey(scope.identity, itemIdx, relativePath),
+          valuePath: `${scope.valuePath}.${itemIdx}.${relativePath}`,
+        } satisfies LoopScope;
+        itemContext[nestedScope.identity] = value;
+        nestedLoopScopes.set(relativePath, nestedScope);
+        nestedLoopScopes.set(nestedScope.declaredPath, nestedScope);
+        nestedLoopScopes.set(nestedScope.identity, nestedScope);
+        return;
+      }
+      if (!isRecord(value) || isRichPatchValue(value)) {
+        return;
+      }
+      for (const [field, nestedValue] of Object.entries(value)) {
+        visit(nestedValue, `${relativePath}.${field}`);
+      }
+    };
+
+    for (const [field, value] of Object.entries(item)) {
+      visit(value, field);
+    }
   };
 
   const buildItemContext = ({
@@ -808,24 +879,37 @@ export const processBlockDirectives = (
     contextData,
     item,
     itemIdx,
-    loopIdentity,
+    scope,
   }: BuildItemContextOptions): Record<string, unknown> => {
     const itemContext: Record<string, unknown> = { ...contextData };
-    const nestedLoopIdentities = new Map<string, string>();
+    const nestedLoopScopes = new Map<string, LoopScope>();
     if (isRecord(item)) {
       Object.assign(itemContext, item);
       itemContext[arrayPath] = item;
+      registerContextAliases({
+        context: itemContext,
+        path: scope.declaredPath,
+        value: item,
+      });
       // A nested `{{#each arrayPath.sub}}` was rewritten to its per-item key
       // (see rewriteNestedEachExpr); expose the item's arrays under that key so
-      // the inner loop resolves them in the recursion.
-      for (const [field, value] of Object.entries(item)) {
-        if (Array.isArray(value)) {
-          const nestedLoopIdentity = eachKey(loopIdentity, itemIdx, field);
-          itemContext[nestedLoopIdentity] = value;
-          nestedLoopIdentities.set(field, nestedLoopIdentity);
-        }
-      }
-      applyRowRawOverlay(itemContext, conditionValues, arrayPath, itemIdx);
+      // the inner loop resolves them in the recursion. Each scope keeps its
+      // generated identity separate from the author-declared path and the
+      // indexed input path: rewriting one representation can never erase the
+      // other two.
+      registerNestedLoopScopes({
+        item,
+        itemContext,
+        itemIdx,
+        nestedLoopScopes,
+        scope,
+      });
+      applyRowRawOverlay(
+        itemContext,
+        conditionValues,
+        scope.valuePath,
+        itemIdx,
+      );
     } else if (
       typeof item === "string" ||
       typeof item === "number" ||
@@ -834,9 +918,11 @@ export const processBlockDirectives = (
       itemContext["value"] = item;
       itemContext[arrayPath] = { value: item };
       itemContext[`${arrayPath}.value`] = item;
+      itemContext[scope.declaredPath] = { value: item };
+      itemContext[`${scope.declaredPath}.value`] = item;
     }
-    if (nestedLoopIdentities.size > 0) {
-      loopIdentityByContext.set(itemContext, nestedLoopIdentities);
+    if (nestedLoopScopes.size > 0) {
+      loopScopeByContext.set(itemContext, nestedLoopScopes);
     }
     return itemContext;
   };
@@ -897,6 +983,7 @@ export const processBlockDirectives = (
     loopIdentity: string;
     openerP: slimdom.Element;
     row: slimdom.Element;
+    scope: LoopScope;
   };
 
   const expandRow = ({
@@ -908,6 +995,7 @@ export const processBlockDirectives = (
     loopIdentity,
     openerP,
     row,
+    scope,
   }: ExpandRowOptions): void => {
     const tbl = row.parentNode;
     if (!tbl || !isElement(tbl)) {
@@ -967,7 +1055,7 @@ export const processBlockDirectives = (
         contextData,
         item,
         itemIdx,
-        loopIdentity,
+        scope,
       });
       for (const paragraph of clonedContentParas) {
         processingContext.inlineDataByParagraph.set(paragraph, itemContext);
@@ -1015,6 +1103,7 @@ export const processBlockDirectives = (
     items,
     loopIdentity,
     openerP,
+    scope,
   }: ExpandBlockOptions): void => {
     const parent = openerP.parentNode;
     if (!parent || !isElement(parent)) {
@@ -1069,7 +1158,7 @@ export const processBlockDirectives = (
         contextData,
         item,
         itemIdx,
-        loopIdentity,
+        scope,
       });
       for (const paragraph of clonedParas) {
         processingContext.inlineDataByParagraph.set(paragraph, itemContext);
@@ -1125,9 +1214,12 @@ export const processBlockDirectives = (
   ): void => {
     const arrayData = resolvePath(block.arrayPath, contextData);
     const items = isUnknownArray(arrayData) ? arrayData : [];
-    const loopIdentity =
-      loopIdentityByContext.get(contextData)?.get(block.arrayPath) ??
-      block.arrayPath;
+    const scope = loopScopeByContext.get(contextData)?.get(block.arrayPath) ?? {
+      declaredPath: block.arrayPath,
+      identity: block.arrayPath,
+      valuePath: block.arrayPath,
+    };
+    const loopIdentity = scope.identity;
 
     const doc = bodyEl.ownerDocument;
     if (!doc) {
@@ -1157,6 +1249,7 @@ export const processBlockDirectives = (
         loopIdentity,
         openerP,
         row: openerRow,
+        scope,
       });
       return;
     }
@@ -1177,6 +1270,7 @@ export const processBlockDirectives = (
       items,
       loopIdentity,
       openerP,
+      scope,
     });
   };
 

--- a/apps/api/src/handlers/docx/block-directives.ts
+++ b/apps/api/src/handlers/docx/block-directives.ts
@@ -116,23 +116,39 @@ const isStringRecord = (v: unknown): v is Record<string, string> =>
  * an inner-loop `{{#if dob > "2028-01-01"}}` compares the original ISO date
  * rather than the localized display text the date step wrote into the row for
  * substitution. Raw values are stashed by field path under
- * `<arrayPath>.<index>.<subPath>` (see {@link CONDITION_RAW_VALUES}); each match
- * sets the bare item-relative sub-path, which the loop body's condition resolves
- * the same way it resolves the row's other fields.
+ * `<valuePath>.<index>.<subPath>` (see {@link CONDITION_RAW_VALUES}); each match
+ * publishes both the bare item-relative path and every qualified loop alias.
+ * Condition evaluation therefore sees the raw value regardless of whether the
+ * author used shorthand, the declared nested path, or a rewritten loop path.
  */
-const applyRowRawOverlay = (
-  itemContext: Record<string, unknown>,
-  rawValues: Record<string, string> | undefined,
-  arrayPath: string,
-  index: number,
-): void => {
+type ApplyRowRawOverlayOptions = {
+  aliasPaths: readonly string[];
+  index: number;
+  itemContext: Record<string, unknown>;
+  rawValues: Record<string, string> | undefined;
+  valuePath: string;
+};
+
+const applyRowRawOverlay = ({
+  aliasPaths,
+  index,
+  itemContext,
+  rawValues,
+  valuePath,
+}: ApplyRowRawOverlayOptions): void => {
   if (!rawValues) {
     return;
   }
-  const prefix = `${arrayPath}.${index}.`;
+  const prefix = `${valuePath}.${index}.`;
+  const uniqueAliasPaths = new Set(aliasPaths);
   for (const [key, raw] of Object.entries(rawValues)) {
-    if (key.startsWith(prefix)) {
-      itemContext[key.slice(prefix.length)] = raw;
+    if (!key.startsWith(prefix)) {
+      continue;
+    }
+    const relativePath = key.slice(prefix.length);
+    itemContext[relativePath] = raw;
+    for (const aliasPath of uniqueAliasPaths) {
+      itemContext[`${aliasPath}.${relativePath}`] = raw;
     }
   }
 };
@@ -904,12 +920,13 @@ export const processBlockDirectives = (
         nestedLoopScopes,
         scope,
       });
-      applyRowRawOverlay(
+      applyRowRawOverlay({
+        aliasPaths: [arrayPath, scope.declaredPath],
+        index: itemIdx,
         itemContext,
-        conditionValues,
-        scope.valuePath,
-        itemIdx,
-      );
+        rawValues: conditionValues,
+        valuePath: scope.valuePath,
+      });
     } else if (
       typeof item === "string" ||
       typeof item === "number" ||


### PR DESCRIPTION
Models each nested document loop with three explicit paths: the author-declared condition path, the synthetic substitution identity, and the indexed input-value path. The renderer now publishes declared-path aliases for the current row while preserving collision-free synthetic keys and raw-value overlays.

Adds a fast-check invariant over generated path depths, field names, and mixed row conditions. This catches the broader class where a rewrite changes substitution identity without preserving condition-evaluation scope.

CC on behalf of jan-kubica

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed nested DOCX `#each` behaviour so `#if` conditions evaluate against the correct current item at every nesting level.
  * Improved condition/row overlays to consider both item-relative paths and loop-alias-qualified paths during iteration.
* **Tests**
  * Added property-based test coverage for nested loop depths, boolean condition rows, and year-threshold comparisons using deepest-path aliasing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->