### PR TITLE
fix(cli): require complete template fills by default

### DIFF
--- a/apps/api/src/handlers/templates/template-fill-completion.test.ts
+++ b/apps/api/src/handlers/templates/template-fill-completion.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test";
+import fc from "fast-check";
+
+import {
+  decideTemplateFillCompletion,
+  TEMPLATE_FILL_COMPLETION_MODES,
+} from "@/api/handlers/templates/template-fill-completion";
+
+describe("template fill completion policy", () => {
+  test("accepts exactly complete fills by default and partial fills by explicit policy", () => {
+    fc.assert(
+      fc.property(
+        fc.array(fc.string({ minLength: 1 }), { maxLength: 30 }),
+        fc.constantFrom(...TEMPLATE_FILL_COMPLETION_MODES),
+        (unmatchedPlaceholders, mode) => {
+          const decision = decideTemplateFillCompletion({
+            mode,
+            unmatchedPlaceholders,
+          });
+
+          if (unmatchedPlaceholders.length === 0) {
+            expect(decision).toEqual({ type: "complete" });
+            return;
+          }
+
+          expect(decision.type).toBe(
+            mode === "allow_partial" ? "accepted_partial" : "rejected_partial",
+          );
+          if (decision.type === "complete") {
+            throw new Error("a non-empty placeholder list cannot be complete");
+          }
+          expect([...decision.unmatchedPlaceholders]).toEqual(
+            unmatchedPlaceholders,
+          );
+          expect(decision.unmatchedPlaceholders.length).toBeGreaterThan(0);
+        },
+      ),
+    );
+  });
+});

--- a/apps/api/src/handlers/templates/template-fill-completion.ts
+++ b/apps/api/src/handlers/templates/template-fill-completion.ts
@@ -1,0 +1,59 @@
+export const TEMPLATE_FILL_COMPLETION_MODES = [
+  "require_complete",
+  "allow_partial",
+] as const;
+
+export type TemplateFillCompletionMode =
+  (typeof TEMPLATE_FILL_COMPLETION_MODES)[number];
+
+export const DEFAULT_TEMPLATE_FILL_COMPLETION_MODE =
+  "require_complete" satisfies TemplateFillCompletionMode;
+
+type NonEmptyPlaceholders = readonly [string, ...string[]];
+
+type TemplateFillCompletionDecision =
+  | { type: "complete" }
+  | {
+      type: "accepted_partial";
+      unmatchedPlaceholders: NonEmptyPlaceholders;
+    }
+  | {
+      type: "rejected_partial";
+      unmatchedPlaceholders: NonEmptyPlaceholders;
+    };
+
+type DecideTemplateFillCompletionOptions = {
+  mode: TemplateFillCompletionMode;
+  unmatchedPlaceholders: readonly string[];
+};
+
+/**
+ * Turn renderer diagnostics plus the caller's declared policy into a closed
+ * decision. Partial-success and partial-error states both carry a statically
+ * non-empty placeholder list; an empty list can only produce `complete`.
+ */
+export const decideTemplateFillCompletion = ({
+  mode,
+  unmatchedPlaceholders,
+}: DecideTemplateFillCompletionOptions): TemplateFillCompletionDecision => {
+  const firstPlaceholder = unmatchedPlaceholders.at(0);
+  if (firstPlaceholder === undefined) {
+    return { type: "complete" };
+  }
+
+  const nonEmptyPlaceholders: NonEmptyPlaceholders = [
+    firstPlaceholder,
+    ...unmatchedPlaceholders.slice(1),
+  ];
+  if (mode === "allow_partial") {
+    return {
+      type: "accepted_partial",
+      unmatchedPlaceholders: nonEmptyPlaceholders,
+    };
+  }
+
+  return {
+    type: "rejected_partial",
+    unmatchedPlaceholders: nonEmptyPlaceholders,
+  };
+};

--- a/apps/api/src/mcp/__snapshots__/registry-quality.test.ts.snap
+++ b/apps/api/src/mcp/__snapshots__/registry-quality.test.ts.snap
@@ -597,7 +597,7 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "name": "fill_template",
     "scope": "stella:templates",
     "access": "write",
-    "description": "Fill a template with values and return the assembled document text plus the filled DOCX as base64. Call list_templates with a template_id first to learn the field paths. 'values' maps each field path to its value, e.g. {\\"tenant.name\\": \\"ACME Sp. z o.o.\\", \\"signing_date\\": \\"2026-06-08\\"}. Registry lookups, composite fields, formula fields, and AI-fillable fields are resolved automatically; AI-fillable fields are drafted when you omit them. Value keys that do not match template fields fail by default; set allow_unused_values only when extra keys are intentional. Returns the rendered text and any placeholders left unfilled.",
+    "description": "Fill a template and return text plus the DOCX as base64. First call list_templates with template_id for field paths, then pass values as a path-to-value map (for example, {\\"tenant.name\\":\\"ACME\\"}). Registry, composite, formula, and AI fields resolve automatically. Unknown keys fail unless allow_unused_values is true; unfilled placeholders fail unless completion_mode is allow_partial. Successful output includes completionStatus.",
     "annotations": {
       "idempotentHint": false,
       "openWorldHint": true
@@ -617,6 +617,15 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
         "allow_unused_values": {
           "type": "boolean",
           "description": "Allow value keys that do not match template fields. Defaults to false so misspelled field paths fail loudly."
+        },
+        "completion_mode": {
+          "type": "string",
+          "enum": [
+            "require_complete",
+            "allow_partial"
+          ],
+          "description": "Require every placeholder by default; use allow_partial only for an intentionally incomplete document.",
+          "default": "require_complete"
         }
       },
       "required": [

--- a/apps/api/src/mcp/template-tools.test.ts
+++ b/apps/api/src/mcp/template-tools.test.ts
@@ -479,14 +479,14 @@ describe("MCP template tools", () => {
     ]);
   });
 
-  test("fill_template returns rendered text plus the DOCX as base64", async () => {
+  test("fill_template returns a complete rendered document plus the DOCX as base64", async () => {
     const docxBytes = Buffer.from("PK filled docx bytes");
     fillStoredTemplateWithTextStrictMock.mockResolvedValue({
       templateName: "Lease",
       fileName: "lease.docx",
       buffer: docxBytes,
       text: "Lease between ACME and Tenant.",
-      unmatchedPlaceholders: ["landlord.signature"],
+      unmatchedPlaceholders: [],
       unusedValues: [],
     });
 
@@ -506,10 +506,11 @@ describe("MCP template tools", () => {
     expect(parseToolPayload(result)).toEqual({
       templateName: "Lease",
       fileName: "lease.docx",
+      completionStatus: "complete",
       text: "Lease between ACME and Tenant.",
       truncated: false,
       docxBase64: docxBytes.toString("base64"),
-      unmatchedPlaceholders: ["landlord.signature"],
+      unmatchedPlaceholders: [],
       unusedValues: [],
     });
     // The execution is recorded (fill row + audit) so agent fills are audited.
@@ -518,8 +519,66 @@ describe("MCP template tools", () => {
         templateId: "t1",
         organizationId: toSafeId<"organization">("org_1"),
         format: "docx",
-        unmatchedCount: 1,
+        unmatchedCount: 0,
         unusedCount: 0,
+      }),
+    );
+  });
+
+  test("fill_template rejects unmatched placeholders by default", async () => {
+    fillStoredTemplateWithTextStrictMock.mockResolvedValue({
+      templateName: "Lease",
+      fileName: "lease.docx",
+      buffer: Buffer.from("partial"),
+      text: "Lease between ACME and {{landlord.signature}}.",
+      unmatchedPlaceholders: ["landlord.signature"],
+      unusedValues: [],
+    });
+
+    const result = await handleMcpToolCall({
+      args: { template_id: "t1", values: { "tenant.name": "ACME" } },
+      context: createContext(),
+      toolName: "fill_template",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(validationEnvelope(result)).toEqual(
+      expect.objectContaining({
+        code: "validation_error",
+        message:
+          "Template fill incomplete; unmatched placeholders: landlord.signature",
+      }),
+    );
+    expect(recordTemplateFillMock).toHaveBeenCalledWith(
+      expect.objectContaining({ unmatchedCount: 1 }),
+    );
+  });
+
+  test("fill_template returns partial output only after an explicit completion policy", async () => {
+    fillStoredTemplateWithTextStrictMock.mockResolvedValue({
+      templateName: "Lease",
+      fileName: "lease.docx",
+      buffer: Buffer.from("partial"),
+      text: "Lease between ACME and {{landlord.signature}}.",
+      unmatchedPlaceholders: ["landlord.signature"],
+      unusedValues: [],
+    });
+
+    const result = await handleMcpToolCall({
+      args: {
+        template_id: "t1",
+        values: { "tenant.name": "ACME" },
+        completion_mode: "allow_partial",
+      },
+      context: createContext(),
+      toolName: "fill_template",
+    });
+
+    expect(result.isError).not.toBe(true);
+    expect(parseToolPayload(result)).toEqual(
+      expect.objectContaining({
+        completionStatus: "partial",
+        unmatchedPlaceholders: ["landlord.signature"],
       }),
     );
   });

--- a/apps/api/src/mcp/template-tools.ts
+++ b/apps/api/src/mcp/template-tools.ts
@@ -405,17 +405,13 @@ export const TEMPLATE_TOOL_DEFINITIONS = [
   },
   {
     description:
-      "Fill a template with values and return the assembled document text plus " +
-      "the filled DOCX as base64. Call list_templates with a template_id first " +
-      "to learn the field paths. 'values' maps each field path to its value, " +
-      'e.g. {"tenant.name": "ACME Sp. z o.o.", "signing_date": "2026-06-08"}. ' +
-      "Registry lookups, composite fields, formula fields, and AI-fillable " +
-      "fields are resolved automatically; AI-fillable fields are drafted when " +
-      "you omit them. Value keys that do not match template fields fail by " +
-      "default; set allow_unused_values only when extra keys are intentional. " +
-      "Unfilled placeholders fail by default; set completion_mode to " +
-      "allow_partial only when an incomplete document is intentional. Returns " +
-      "the rendered text and completionStatus.",
+      "Fill a template and return text plus the DOCX as base64. First call " +
+      "list_templates with template_id for field paths, then pass values as a " +
+      'path-to-value map (for example, {"tenant.name":"ACME"}). Registry, ' +
+      "composite, formula, and AI fields resolve automatically. Unknown keys " +
+      "fail unless allow_unused_values is true; unfilled placeholders fail " +
+      "unless completion_mode is allow_partial. Successful output includes " +
+      "completionStatus.",
     inputSchema: {
       type: "object",
       properties: {
@@ -432,7 +428,7 @@ export const TEMPLATE_TOOL_DEFINITIONS = [
         },
         completion_mode: {
           ...enumProp(
-            "Whether every placeholder must be filled. Defaults to require_complete; use allow_partial only when an incomplete document is intentional.",
+            "Require every placeholder by default; use allow_partial only for an intentionally incomplete document.",
             TEMPLATE_FILL_COMPLETION_MODES,
           ),
           default: DEFAULT_TEMPLATE_FILL_COMPLETION_MODE,

--- a/apps/api/src/mcp/template-tools.ts
+++ b/apps/api/src/mcp/template-tools.ts
@@ -15,6 +15,11 @@ import { INPUT_TYPES, isFieldMeta } from "@/api/handlers/docx/types";
 import { configureTemplateFields } from "@/api/handlers/templates/configure-template-fields-service";
 import { createStoredTemplate } from "@/api/handlers/templates/create-template-service";
 import { recordTemplateFill } from "@/api/handlers/templates/record-use";
+import {
+  decideTemplateFillCompletion,
+  DEFAULT_TEMPLATE_FILL_COMPLETION_MODE,
+  TEMPLATE_FILL_COMPLETION_MODES,
+} from "@/api/handlers/templates/template-fill-completion";
 import type { DescribeTemplateResult } from "@/api/handlers/templates/template-fill-service";
 import {
   describeStoredTemplate,
@@ -408,7 +413,9 @@ export const TEMPLATE_TOOL_DEFINITIONS = [
       "fields are resolved automatically; AI-fillable fields are drafted when " +
       "you omit them. Value keys that do not match template fields fail by " +
       "default; set allow_unused_values only when extra keys are intentional. " +
-      "Returns the rendered text and any placeholders left unfilled.",
+      "Unfilled placeholders fail by default; set completion_mode to " +
+      "allow_partial only when an incomplete document is intentional. Returns " +
+      "the rendered text and completionStatus.",
     inputSchema: {
       type: "object",
       properties: {
@@ -422,6 +429,13 @@ export const TEMPLATE_TOOL_DEFINITIONS = [
           type: "boolean",
           description:
             "Allow value keys that do not match template fields. Defaults to false so misspelled field paths fail loudly.",
+        },
+        completion_mode: {
+          ...enumProp(
+            "Whether every placeholder must be filled. Defaults to require_complete; use allow_partial only when an incomplete document is intentional.",
+            TEMPLATE_FILL_COMPLETION_MODES,
+          ),
+          default: DEFAULT_TEMPLATE_FILL_COMPLETION_MODE,
         },
       },
       required: ["template_id", "values"],
@@ -630,6 +644,10 @@ const fillTemplateArgsSchema = v.strictObject({
   template_id: v.pipe(v.string(), v.minLength(1)),
   values: v.record(v.string(), v.unknown()),
   allow_unused_values: v.optional(v.boolean()),
+  completion_mode: v.optional(
+    v.picklist(TEMPLATE_FILL_COMPLETION_MODES),
+    DEFAULT_TEMPLATE_FILL_COMPLETION_MODE,
+  ),
 });
 
 const handleFillTemplateTool: McpToolHandler = async ({ args, context }) => {
@@ -757,9 +775,32 @@ const handleFillTemplateTool: McpToolHandler = async ({ args, context }) => {
     )
     .catch(captureError);
 
+  const completion = decideTemplateFillCompletion({
+    mode: parsed.output.completion_mode,
+    unmatchedPlaceholders: filled.unmatchedPlaceholders,
+  });
+  if (completion.type === "rejected_partial") {
+    const preview = completion.unmatchedPlaceholders.slice(0, 10);
+    const omitted = completion.unmatchedPlaceholders.length - preview.length;
+    const suffix = omitted > 0 ? ` (${omitted} more omitted)` : "";
+    return structuredErrorResult({
+      code: "validation_error",
+      message: `Template fill incomplete; unmatched placeholders: ${preview.join(", ")}${suffix}`,
+      issues: preview.map((placeholder) => ({
+        path: `values.${placeholder}`,
+        message: "Template placeholder was not filled",
+      })),
+      hint: "Use list_templates detail mode to provide the missing values, or set completion_mode to allow_partial when an incomplete document is intentional.",
+    });
+  }
+
+  const completionStatus =
+    completion.type === "complete" ? "complete" : "partial";
+
   const truncated = filled.text.length > TEMPLATE_FILL_TEXT_MAX_CHARS;
 
   return textResult({
+    completionStatus,
     templateName: filled.templateName,
     fileName: filled.fileName,
     text: truncated

--- a/packages/cli/src/cli-commands.test.ts
+++ b/packages/cli/src/cli-commands.test.ts
@@ -852,6 +852,9 @@ describe("help surfaces --input for inputOnly tools", () => {
     server.stop();
     expect(result.exitCode).toBe(0);
     expect(result.stdout).toContain("values.<key>  any JSON value  required");
+    expect(result.stdout).toContain("--completion-mode");
+    expect(result.stdout).toContain("require_complete");
+    expect(result.stdout).toContain("allow_partial");
     expect(result.stdout).toContain(
       `--input '{"template_id":"xxxxx","values":{"key":"value"}}'`,
     );
@@ -901,7 +904,7 @@ describe("help surfaces --input for inputOnly tools", () => {
   });
 });
 
-describe("template fill unused-value validation", () => {
+describe("template fill strictness policies", () => {
   test("surfaces the tool's strict unused-value error", async () => {
     const server = startMockServer(() => ({
       toolPayload: {
@@ -966,6 +969,37 @@ describe("template fill unused-value validation", () => {
       template_id: "template-1",
       values: { intentional: "value" },
       allow_unused_values: true,
+    });
+  });
+
+  test("forwards the explicit partial-completion policy to the shared MCP tool", async () => {
+    const server = startMockServer(() => ({
+      toolPayload: {
+        completionStatus: "partial",
+        unmatchedPlaceholders: ["signature"],
+      },
+    }));
+    const result = await runCli({
+      args: [
+        "template",
+        "fill",
+        "--template-id",
+        "template-1",
+        "--input",
+        '{"values":{"name":"ACME"}}',
+        "--completion-mode",
+        "allow_partial",
+      ],
+      url: server.url,
+      token: makeToken(["templates"]),
+    });
+    server.stop();
+
+    expect(result.exitCode).toBe(0);
+    expect(server.requests.at(0)?.params.arguments).toEqual({
+      template_id: "template-1",
+      values: { name: "ACME" },
+      completion_mode: "allow_partial",
     });
   });
 });

--- a/packages/cli/src/generated/registry-snapshot.json
+++ b/packages/cli/src/generated/registry-snapshot.json
@@ -603,7 +603,7 @@
       "scope": "templates"
     },
     "name": "fill_template",
-    "description": "Fill a template with values and return the assembled document text plus the filled DOCX as base64. Call list_templates with a template_id first to learn the field paths. 'values' maps each field path to its value, e.g. {\"tenant.name\": \"ACME Sp. z o.o.\", \"signing_date\": \"2026-06-08\"}. Registry lookups, composite fields, formula fields, and AI-fillable fields are resolved automatically; AI-fillable fields are drafted when you omit them. Value keys that do not match template fields fail by default; set allow_unused_values only when extra keys are intentional. Returns the rendered text and any placeholders left unfilled.",
+    "description": "Fill a template with values and return the assembled document text plus the filled DOCX as base64. Call list_templates with a template_id first to learn the field paths. 'values' maps each field path to its value, e.g. {\"tenant.name\": \"ACME Sp. z o.o.\", \"signing_date\": \"2026-06-08\"}. Registry lookups, composite fields, formula fields, and AI-fillable fields are resolved automatically; AI-fillable fields are drafted when you omit them. Value keys that do not match template fields fail by default; set allow_unused_values only when extra keys are intentional. Unfilled placeholders fail by default; set completion_mode to allow_partial only when an incomplete document is intentional. Returns the rendered text and completionStatus.",
     "inputSchema": {
       "type": "object",
       "properties": {
@@ -619,6 +619,12 @@
         "allow_unused_values": {
           "type": "boolean",
           "description": "Allow value keys that do not match template fields. Defaults to false so misspelled field paths fail loudly."
+        },
+        "completion_mode": {
+          "type": "string",
+          "enum": ["require_complete", "allow_partial"],
+          "description": "Whether every placeholder must be filled. Defaults to require_complete; use allow_partial only when an incomplete document is intentional.",
+          "default": "require_complete"
         }
       },
       "required": ["template_id", "values"]

--- a/packages/cli/src/generated/registry-snapshot.json
+++ b/packages/cli/src/generated/registry-snapshot.json
@@ -603,7 +603,7 @@
       "scope": "templates"
     },
     "name": "fill_template",
-    "description": "Fill a template with values and return the assembled document text plus the filled DOCX as base64. Call list_templates with a template_id first to learn the field paths. 'values' maps each field path to its value, e.g. {\"tenant.name\": \"ACME Sp. z o.o.\", \"signing_date\": \"2026-06-08\"}. Registry lookups, composite fields, formula fields, and AI-fillable fields are resolved automatically; AI-fillable fields are drafted when you omit them. Value keys that do not match template fields fail by default; set allow_unused_values only when extra keys are intentional. Unfilled placeholders fail by default; set completion_mode to allow_partial only when an incomplete document is intentional. Returns the rendered text and completionStatus.",
+    "description": "Fill a template and return text plus the DOCX as base64. First call list_templates with template_id for field paths, then pass values as a path-to-value map (for example, {\"tenant.name\":\"ACME\"}). Registry, composite, formula, and AI fields resolve automatically. Unknown keys fail unless allow_unused_values is true; unfilled placeholders fail unless completion_mode is allow_partial. Successful output includes completionStatus.",
     "inputSchema": {
       "type": "object",
       "properties": {
@@ -623,7 +623,7 @@
         "completion_mode": {
           "type": "string",
           "enum": ["require_complete", "allow_partial"],
-          "description": "Whether every placeholder must be filled. Defaults to require_complete; use allow_partial only when an incomplete document is intentional.",
+          "description": "Require every placeholder by default; use allow_partial only for an intentionally incomplete document.",
           "default": "require_complete"
         }
       },


### PR DESCRIPTION
## Summary

- make `fill_template` fail closed when rendered placeholders remain
- add explicit `completion_mode: require_complete | allow_partial` shared by MCP and generated CLI flags
- model completion decisions as a discriminated union with a non-empty partial-placeholder type
- cover the policy with fast-check plus MCP and CLI contract tests

CC on behalf of jan-kubica

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added template completion policies: require complete fills or allow partial fills.
  - `fill_template` now reports whether a result is complete or partial and lists unmatched placeholders.
  - Added CLI support for `template fill --completion-mode`, including help documentation.

- **Bug Fixes**
  - Incomplete template fills are now rejected by default with clear validation details.
  - Partial results can be explicitly accepted when the allow-partial option is selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->