### PR TITLE
fix(cli): normalize omitted optional template fields

### DIFF
--- a/apps/api/src/handlers/templates/template-fill-service.ts
+++ b/apps/api/src/handlers/templates/template-fill-service.ts
@@ -53,7 +53,10 @@ import {
   findUnusedTemplateValueKeys,
   isFillableTemplateInputField,
 } from "./template-input-contract";
-
+import {
+  applyOmittedOptionalPlaceholderDefaults,
+  isTemplateFieldRequired,
+} from "./template-optional-defaults";
 // Data a template is filled with: open-ended field-path → value map (paths come
 // from the template's manifest/markers, not a fixed entity), patched in place
 // with resolved clause slots and AI-drafted fields before fill.
@@ -157,7 +160,7 @@ export const describeStoredTemplate = async ({
           path: field.path,
           label: field.label ?? null,
           inputType: field.inputType ?? "text",
-          required: field.required ?? false,
+          required: isTemplateFieldRequired(field),
           hint: field.hint ?? null,
           options: field.options ?? null,
           formats:
@@ -309,9 +312,13 @@ const fillTemplateDocxWithPolicy = async <TRejection = never>({
   const loaded = source;
   const { templateId } = source;
   const manifest = await readManifest(loaded.buffer);
+  let strictInputPlaceholders: string[] | null = null;
 
   if (unusedValuePolicy === "reject") {
     const discovered = await discoverTemplate(loaded.buffer);
+    strictInputPlaceholders = discovered.placeholders.map(
+      (placeholder) => placeholder.name,
+    );
     const rawInputSources = collectRawTemplateInputSources({
       fields: discovered.fields,
       placeholderPaths: discovered.placeholders.map(
@@ -464,6 +471,16 @@ const fillTemplateDocxWithPolicy = async <TRejection = never>({
     adaptedPaths = adapted.adaptedPaths;
   }
 
+  const optionalDefaults =
+    manifest === null || strictInputPlaceholders === null
+      ? { defaultedPaths: [], values: record }
+      : applyOmittedOptionalPlaceholderDefaults({
+          fields: manifest.fields,
+          placeholderPaths: strictInputPlaceholders,
+          values: record,
+        });
+  record = optionalDefaults.values;
+
   if (!isTemplateData(record)) {
     return {
       error:
@@ -487,7 +504,9 @@ const fillTemplateDocxWithPolicy = async <TRejection = never>({
     // Adapted stubs no longer match a marker (each occurrence was already
     // substituted), so they are not "unused" in any user-meaningful sense.
     unusedValues: result.unusedValues.filter(
-      (name) => !adaptedPaths.includes(name),
+      (name) =>
+        !adaptedPaths.includes(name) &&
+        !optionalDefaults.defaultedPaths.includes(name),
     ),
     structureErrors: result.structureErrors,
   };

--- a/apps/api/src/handlers/templates/template-optional-defaults.test.ts
+++ b/apps/api/src/handlers/templates/template-optional-defaults.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, test } from "bun:test";
+import fc from "fast-check";
+
+import {
+  applyOmittedOptionalPlaceholderDefaults,
+  isTemplateFieldRequired,
+} from "./template-optional-defaults";
+
+const fieldPath = fc.stringMatching(/^[a-z][a-z0-9_]{0,15}$/u);
+
+describe("optional template placeholder defaults", () => {
+  test("defaults exactly omitted optional placeholders and is idempotent", () => {
+    fc.assert(
+      fc.property(
+        fc.uniqueArray(fieldPath, { maxLength: 30 }),
+        fc.dictionary(fieldPath, fc.string()),
+        fc.uniqueArray(fieldPath, { maxLength: 30 }),
+        fc.uniqueArray(fieldPath, { maxLength: 30 }),
+        fc.uniqueArray(fieldPath, { maxLength: 30 }),
+        (
+          paths,
+          submittedValues,
+          requiredPaths,
+          placeholderPaths,
+          derivedPaths,
+        ) => {
+          const required = new Set(requiredPaths);
+          const placeholders = new Set(placeholderPaths);
+          const derived = new Set(derivedPaths);
+          const fields = paths.map((path) => ({
+            path,
+            required: required.has(path),
+            source: derived.has(path) ? { type: "matter" } : undefined,
+          }));
+          const first = applyOmittedOptionalPlaceholderDefaults({
+            fields,
+            placeholderPaths,
+            values: submittedValues,
+          });
+
+          const expectedDefaulted = paths.filter(
+            (path) =>
+              !required.has(path) &&
+              !derived.has(path) &&
+              placeholders.has(path) &&
+              submittedValues[path] === undefined,
+          );
+          expect(first.defaultedPaths).toEqual(expectedDefaulted);
+          for (const path of paths) {
+            if (submittedValues[path] !== undefined) {
+              expect(first.values[path]).toBe(submittedValues[path]);
+            } else if (expectedDefaulted.includes(path)) {
+              expect(first.values[path]).toBe("");
+            } else {
+              expect(first.values[path]).toBeUndefined();
+            }
+          }
+
+          expect(
+            applyOmittedOptionalPlaceholderDefaults({
+              fields,
+              placeholderPaths,
+              values: first.values,
+            }),
+          ).toEqual({ defaultedPaths: [], values: first.values });
+        },
+      ),
+    );
+  });
+
+  test("reads legacy validation.required through one shared rule", () => {
+    expect(
+      isTemplateFieldRequired({
+        path: "legacy",
+        validation: { required: true },
+      }),
+    ).toBe(true);
+    expect(
+      isTemplateFieldRequired({
+        path: "explicit",
+        required: false,
+        validation: { required: true },
+      }),
+    ).toBe(false);
+  });
+
+  test("never masks an unresolved derived placeholder", () => {
+    const derivedFields = [
+      { path: "formula", formula: "subtotal * tax" },
+      { path: "condition", condition: "amount > 0" },
+      { path: "conditionAst", conditionAst: { type: "literal" } },
+      { path: "source", source: { type: "matter" } },
+    ];
+
+    expect(
+      applyOmittedOptionalPlaceholderDefaults({
+        fields: derivedFields,
+        placeholderPaths: derivedFields.map((field) => field.path),
+        values: {},
+      }),
+    ).toEqual({ defaultedPaths: [], values: {} });
+  });
+});

--- a/apps/api/src/handlers/templates/template-optional-defaults.ts
+++ b/apps/api/src/handlers/templates/template-optional-defaults.ts
@@ -1,0 +1,67 @@
+import { resolvePath } from "@stll/template-conditions";
+
+type TemplateFieldRequiredness = {
+  condition?: unknown;
+  conditionAst?: unknown;
+  formula?: unknown;
+  path: string;
+  required?: boolean | undefined;
+  source?: unknown;
+  validation?: { required?: boolean | undefined } | undefined;
+};
+
+type ApplyOmittedOptionalPlaceholderDefaultsOptions = {
+  fields: readonly TemplateFieldRequiredness[];
+  placeholderPaths: Iterable<string>;
+  values: Record<string, unknown>;
+};
+
+type OptionalPlaceholderDefaults = {
+  defaultedPaths: string[];
+  values: Record<string, unknown>;
+};
+
+export const isTemplateFieldRequired = (
+  field: TemplateFieldRequiredness,
+): boolean => field.required ?? field.validation?.required ?? false;
+
+const isUserEnteredField = (field: TemplateFieldRequiredness): boolean =>
+  field.formula === undefined &&
+  field.condition === undefined &&
+  field.conditionAst === undefined &&
+  field.source === undefined;
+
+/**
+ * Give omitted optional scalar placeholders their form-equivalent empty value.
+ * The web form already submits an empty string for an optional empty input;
+ * machine callers commonly omit the key instead. Normalizing both forms here
+ * keeps every fill boundary on the same contract and prevents an optional
+ * field from leaking a raw `{{marker}}` into an otherwise complete document.
+ *
+ * Only exact placeholder paths are defaulted. Condition drivers, arrays, and
+ * parent objects are intentionally left to the block/manifest pipeline.
+ */
+export const applyOmittedOptionalPlaceholderDefaults = ({
+  fields,
+  placeholderPaths,
+  values,
+}: ApplyOmittedOptionalPlaceholderDefaultsOptions): OptionalPlaceholderDefaults => {
+  const placeholders = new Set(placeholderPaths);
+  const defaultedPaths: string[] = [];
+  const normalized = { ...values };
+
+  for (const field of fields) {
+    if (
+      !isUserEnteredField(field) ||
+      isTemplateFieldRequired(field) ||
+      !placeholders.has(field.path) ||
+      resolvePath(field.path, normalized) !== undefined
+    ) {
+      continue;
+    }
+    normalized[field.path] = "";
+    defaultedPaths.push(field.path);
+  }
+
+  return { defaultedPaths, values: normalized };
+};

--- a/apps/api/src/mcp/__snapshots__/registry-quality.test.ts.snap
+++ b/apps/api/src/mcp/__snapshots__/registry-quality.test.ts.snap
@@ -573,7 +573,7 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "name": "list_templates",
     "scope": "stella:templates",
     "access": "read",
-    "description": "List the document templates in this organization (NDAs, powers of attorney, leases), or describe one template's fillable fields. Omit template_id to list templates: each template's id, name, field count, tags, and usage guidance (whenToUse / whenNotToUse); prefer a template whose whenToUse matches the request and skip any whose whenNotToUse applies. Pass template_id to return that template's full field configuration (path, label, inputType, required, hint, options, optionsFrom, aiPrompt / aiAdapt, date format, composite parts, registry-lookup formats) plus its named conditions and formula fields; feed the same shape to save_template to update it.",
+    "description": "List the document templates in this organization (NDAs, powers of attorney, leases), or describe one template's fillable fields. Omit template_id to list templates: each template's id, name, field count, tags, and usage guidance (whenToUse / whenNotToUse); prefer a template whose whenToUse matches the request and skip any whose whenNotToUse applies. Pass template_id to return that template's full field configuration (path, label, inputType, required, hint, options, optionsFrom, aiPrompt / aiAdapt, date format, composite parts, registry-lookup formats) plus its named conditions and formula fields; feed the same shape to save_template to update it. \`required\` controls form validation; omitted optional scalar placeholders render blank.",
     "annotations": {
       "readOnlyHint": true,
       "openWorldHint": false
@@ -2660,7 +2660,7 @@ exports[`MCP registry quality (anonymized surface) tool surface snapshot (name, 
     "name": "list_templates",
     "scope": "stella:templates_anonymized",
     "access": "read",
-    "description": "List the document templates in this organization (NDAs, powers of attorney, leases), or describe one template's fillable fields. Omit template_id to list templates: each template's id, name, field count, tags, and usage guidance (whenToUse / whenNotToUse); prefer a template whose whenToUse matches the request and skip any whose whenNotToUse applies. Pass template_id to return that template's full field configuration (path, label, inputType, required, hint, options, optionsFrom, aiPrompt / aiAdapt, date format, composite parts, registry-lookup formats) plus its named conditions and formula fields; feed the same shape to save_template to update it.",
+    "description": "List the document templates in this organization (NDAs, powers of attorney, leases), or describe one template's fillable fields. Omit template_id to list templates: each template's id, name, field count, tags, and usage guidance (whenToUse / whenNotToUse); prefer a template whose whenToUse matches the request and skip any whose whenNotToUse applies. Pass template_id to return that template's full field configuration (path, label, inputType, required, hint, options, optionsFrom, aiPrompt / aiAdapt, date format, composite parts, registry-lookup formats) plus its named conditions and formula fields; feed the same shape to save_template to update it. \`required\` controls form validation; omitted optional scalar placeholders render blank.",
     "annotations": {
       "readOnlyHint": true,
       "openWorldHint": false

--- a/apps/api/src/mcp/template-tools.test.ts
+++ b/apps/api/src/mcp/template-tools.test.ts
@@ -554,6 +554,39 @@ describe("MCP template tools", () => {
     );
   });
 
+  test("fill_template returns every missing path while bounding its summary", async () => {
+    const unmatchedPlaceholders = Array.from(
+      { length: 12 },
+      (_, index) => `field_${index}`,
+    );
+    fillStoredTemplateWithTextStrictMock.mockResolvedValue({
+      templateName: "Lease",
+      fileName: "lease.docx",
+      buffer: Buffer.from("partial"),
+      text: "Partial lease",
+      unmatchedPlaceholders,
+      unusedValues: [],
+    });
+
+    const result = await handleMcpToolCall({
+      args: { template_id: "t1", values: {} },
+      context: createContext(),
+      toolName: "fill_template",
+    });
+
+    expect(validationEnvelope(result)).toEqual(
+      expect.objectContaining({
+        message:
+          "Template fill incomplete; unmatched placeholders: field_0, field_1, field_2, field_3, field_4, field_5, field_6, field_7, field_8, field_9 (2 more omitted)",
+        issues: unmatchedPlaceholders.map((placeholder) => ({
+          path: `values.${placeholder}`,
+          message: "Template placeholder was not filled",
+        })),
+        hint: expect.stringContaining("CLI: template list --template-id ID"),
+      }),
+    );
+  });
+
   test("fill_template returns partial output only after an explicit completion policy", async () => {
     fillStoredTemplateWithTextStrictMock.mockResolvedValue({
       templateName: "Lease",

--- a/apps/api/src/mcp/template-tools.ts
+++ b/apps/api/src/mcp/template-tools.ts
@@ -377,7 +377,8 @@ export const TEMPLATE_TOOL_DEFINITIONS = [
       "configuration (path, label, inputType, required, hint, options, " +
       "optionsFrom, aiPrompt / aiAdapt, date format, composite parts, " +
       "registry-lookup formats) plus its named conditions and formula fields; " +
-      "feed the same shape to save_template to update it.",
+      "feed the same shape to save_template to update it. `required` controls " +
+      "form validation; omitted optional scalar placeholders render blank.",
     inputSchema: {
       type: "object",
       properties: {
@@ -744,11 +745,11 @@ const handleFillTemplateTool: McpToolHandler = async ({ args, context }) => {
     return structuredErrorResult({
       code: "validation_error",
       message: `Unused template value keys: ${preview.join(", ")}${suffix}`,
-      issues: preview.map((key) => ({
+      issues: filled.inputRejection.keys.map((key) => ({
         path: `values.${key}`,
         message: "Value key does not match a template field",
       })),
-      hint: "Correct the value keys using list_templates detail mode, or set allow_unused_values to true when the extra keys are intentional.",
+      hint: "Call list_templates with template_id (CLI: template list --template-id ID) and correct the value keys, or set allow_unused_values to true when the extra keys are intentional.",
     });
   }
 
@@ -782,11 +783,11 @@ const handleFillTemplateTool: McpToolHandler = async ({ args, context }) => {
     return structuredErrorResult({
       code: "validation_error",
       message: `Template fill incomplete; unmatched placeholders: ${preview.join(", ")}${suffix}`,
-      issues: preview.map((placeholder) => ({
+      issues: completion.unmatchedPlaceholders.map((placeholder) => ({
         path: `values.${placeholder}`,
         message: "Template placeholder was not filled",
       })),
-      hint: "Use list_templates detail mode to provide the missing values, or set completion_mode to allow_partial when an incomplete document is intentional.",
+      hint: "Call list_templates with template_id (CLI: template list --template-id ID) and provide the missing values, or set completion_mode to allow_partial when an incomplete document is intentional.",
     });
   }
 

--- a/packages/cli/src/generated/registry-snapshot.json
+++ b/packages/cli/src/generated/registry-snapshot.json
@@ -577,7 +577,7 @@
       "singleReadWhen": "template_id"
     },
     "name": "list_templates",
-    "description": "List the document templates in this organization (NDAs, powers of attorney, leases), or describe one template's fillable fields. Omit template_id to list templates: each template's id, name, field count, tags, and usage guidance (whenToUse / whenNotToUse); prefer a template whose whenToUse matches the request and skip any whose whenNotToUse applies. Pass template_id to return that template's full field configuration (path, label, inputType, required, hint, options, optionsFrom, aiPrompt / aiAdapt, date format, composite parts, registry-lookup formats) plus its named conditions and formula fields; feed the same shape to save_template to update it.",
+    "description": "List the document templates in this organization (NDAs, powers of attorney, leases), or describe one template's fillable fields. Omit template_id to list templates: each template's id, name, field count, tags, and usage guidance (whenToUse / whenNotToUse); prefer a template whose whenToUse matches the request and skip any whose whenNotToUse applies. Pass template_id to return that template's full field configuration (path, label, inputType, required, hint, options, optionsFrom, aiPrompt / aiAdapt, date format, composite parts, registry-lookup formats) plus its named conditions and formula fields; feed the same shape to save_template to update it. `required` controls form validation; omitted optional scalar placeholders render blank.",
     "inputSchema": {
       "type": "object",
       "properties": {


### PR DESCRIPTION
## Summary

- normalize omitted optional scalar placeholders to the same empty value the web form submits, so `required: false` no longer contradicts complete CLI/MCP fills
- centralize legacy/current required-field interpretation and use it in template detail output
- return every structured missing/unused path while keeping human summaries bounded, with exact MCP and CLI recovery syntax
- add a fast-check invariant for arbitrary field, placeholder, and submitted-value combinations

## Verification

- `bun --env-file=apps/api/.env test apps/api/src/handlers/templates/template-optional-defaults.test.ts apps/api/src/mcp/template-tools.test.ts apps/api/src/mcp/registry-quality.test.ts` (58 pass)
- lint and typecheck delegated to CI due local machine load

CC on behalf of jan-kubica