### PR TITLE
fix(api): claim scheduler jobs just in time

### DIFF
--- a/apps/api/src/lib/scheduler/runner.test.ts
+++ b/apps/api/src/lib/scheduler/runner.test.ts
@@ -202,10 +202,9 @@ describe("bounded scheduler sweeps", () => {
 
     expect(result).toEqual({
       acquired: 2,
-      deadlineReached: false,
       failed: 0,
-      remainingMayExist: true,
       skipped: 0,
+      stoppedBecause: "limitReached",
       succeeded: 2,
     });
     expect((await readJob("c.job")).lockedBy).toBeNull();
@@ -230,10 +229,9 @@ describe("bounded scheduler sweeps", () => {
 
     expect(result).toEqual({
       acquired: 1,
-      deadlineReached: true,
       failed: 0,
-      remainingMayExist: true,
       skipped: 0,
+      stoppedBecause: "deadlineReached",
       succeeded: 1,
     });
     expect((await readJob("b.job")).lockedBy).toBeNull();
@@ -249,10 +247,9 @@ describe("bounded scheduler sweeps", () => {
 
     expect(result).toEqual({
       acquired: 0,
-      deadlineReached: false,
       failed: 0,
-      remainingMayExist: false,
       skipped: 0,
+      stoppedBecause: "drained",
       succeeded: 0,
     });
   });
@@ -533,6 +530,7 @@ describe("per-job runtime ceiling", () => {
       acquired: 1,
       failed: 0,
       skipped: 0,
+      stoppedBecause: "aborted",
       succeeded: 1,
     });
 
@@ -573,6 +571,7 @@ describe("per-job runtime ceiling", () => {
       acquired: 1,
       failed: 0,
       skipped: 1,
+      stoppedBecause: "aborted",
       succeeded: 0,
     });
     // The task never started, and the lease was released cleanly.

--- a/apps/api/src/lib/scheduler/runner.test.ts
+++ b/apps/api/src/lib/scheduler/runner.test.ts
@@ -15,7 +15,7 @@ import { getTestDb, releaseTestDb } from "@/api/tests/security/test-utils";
 import type { TestDatabase } from "@/api/tests/security/test-utils";
 
 import {
-  acquireDueJobs,
+  acquireNextDueJob,
   finishRunFailure,
   finishRunSkipped,
   finishRunSuccess,
@@ -137,31 +137,124 @@ const abortSignalWhenRunInserted = (
     },
   });
 
-describe("acquireDueJobs claim exclusivity", () => {
+describe("acquireNextDueJob claim exclusivity", () => {
   test("two interleaved passes never claim the same job", async () => {
     await seedJob();
 
-    const first = await acquireDueJobs({
+    const first = await acquireNextDueJob({
       db,
       leaseMs: LEASE_MS,
-      limit: 10,
       runnerId: "runner-a",
     });
-    const second = await acquireDueJobs({
+    const second = await acquireNextDueJob({
       db,
       leaseMs: LEASE_MS,
-      limit: 10,
       runnerId: "runner-b",
     });
 
-    expect(first.map((job) => job.id)).toEqual(["test.job"]);
-    expect(second).toEqual([]);
+    expect(first?.id).toBe("test.job");
+    expect(second).toBeNull();
 
     const job = await readJob("test.job");
     // lockedBy carries the per-acquisition lease token (runnerId prefix plus a
     // unique suffix), not the bare runnerId.
     expect(job.lockedBy).toMatch(/^runner-a#/u);
-    expect(first.at(0)?.lockedBy).toBe(job.lockedBy);
+    expect(first?.lockedBy).toBe(job.lockedBy);
+  });
+});
+
+describe("bounded scheduler sweeps", () => {
+  test("claims each job immediately before execution", async () => {
+    await seedJob({ id: "a.job", task: "test.observe" });
+    await seedJob({ id: "b.job", task: "test.observe" });
+
+    let secondJobWasUnlocked = false;
+    const registry = registryOf("test.observe", async ({ job }) => {
+      if (job.id !== "a.job") {
+        return;
+      }
+      secondJobWasUnlocked = (await readJob("b.job")).lockedBy === null;
+    });
+
+    const result = await runSchedulerOnce({
+      db,
+      leaseMs: LEASE_MS,
+      registry,
+      runnerId: "runner-a",
+    });
+
+    expect(result).toMatchObject({ acquired: 2, succeeded: 2 });
+    expect(secondJobWasUnlocked).toBe(true);
+  });
+
+  test("stops at the job limit and reports that work may remain", async () => {
+    await seedJob({ id: "a.job" });
+    await seedJob({ id: "b.job" });
+    await seedJob({ id: "c.job" });
+
+    const result = await runSchedulerOnce({
+      db,
+      leaseMs: LEASE_MS,
+      limit: 2,
+      registry: noopRegistry,
+      runnerId: "runner-a",
+    });
+
+    expect(result).toEqual({
+      acquired: 2,
+      deadlineReached: false,
+      failed: 0,
+      remainingMayExist: true,
+      skipped: 0,
+      succeeded: 2,
+    });
+    expect((await readJob("c.job")).lockedBy).toBeNull();
+  });
+
+  test("stops claiming at the sweep deadline", async () => {
+    await seedJob({ id: "a.job", task: "test.advance-clock" });
+    await seedJob({ id: "b.job", task: "test.advance-clock" });
+
+    let currentTime = 0;
+    const registry = registryOf("test.advance-clock", () => {
+      currentTime = 100;
+    });
+    const result = await runSchedulerOnce({
+      db,
+      leaseMs: LEASE_MS,
+      maxSweepDurationMs: 50,
+      now: () => currentTime,
+      registry,
+      runnerId: "runner-a",
+    });
+
+    expect(result).toEqual({
+      acquired: 1,
+      deadlineReached: true,
+      failed: 0,
+      remainingMayExist: true,
+      skipped: 0,
+      succeeded: 1,
+    });
+    expect((await readJob("b.job")).lockedBy).toBeNull();
+  });
+
+  test("reports a fully drained sweep", async () => {
+    const result = await runSchedulerOnce({
+      db,
+      leaseMs: LEASE_MS,
+      registry: noopRegistry,
+      runnerId: "runner-a",
+    });
+
+    expect(result).toEqual({
+      acquired: 0,
+      deadlineReached: false,
+      failed: 0,
+      remainingMayExist: false,
+      skipped: 0,
+      succeeded: 0,
+    });
   });
 });
 

--- a/apps/api/src/lib/scheduler/runner.ts
+++ b/apps/api/src/lib/scheduler/runner.ts
@@ -55,9 +55,8 @@ type RunSchedulerOnceOptions = {
 type RunSchedulerOnceResult = {
   acquired: number;
   failed: number;
-  deadlineReached: boolean;
-  remainingMayExist: boolean;
   skipped: number;
+  stoppedBecause: "aborted" | "deadlineReached" | "drained" | "limitReached";
   succeeded: number;
 };
 
@@ -97,22 +96,20 @@ export const runSchedulerOnce = async ({
   const deadline = now() + maxSweepDurationMs;
   const result: RunSchedulerOnceResult = {
     acquired: 0,
-    deadlineReached: false,
     failed: 0,
-    remainingMayExist: false,
     skipped: 0,
+    stoppedBecause: "drained",
     succeeded: 0,
   };
 
   while (result.acquired < limit) {
     if (signal?.aborted) {
-      result.remainingMayExist = true;
+      result.stoppedBecause = "aborted";
       break;
     }
 
     if (now() >= deadline) {
-      result.deadlineReached = true;
-      result.remainingMayExist = true;
+      result.stoppedBecause = "deadlineReached";
       break;
     }
 
@@ -149,7 +146,7 @@ export const runSchedulerOnce = async ({
   }
 
   if (result.acquired >= limit) {
-    result.remainingMayExist = true;
+    result.stoppedBecause = "limitReached";
   }
 
   return result;
@@ -279,7 +276,7 @@ export const acquireNextDueJob = async ({
       .where(and(eq(schedulerJobs.id, candidate.id), dueJobPredicate(now)))
       .returning();
 
-    return job ?? null;
+    return job ?? panic("Locked scheduler job disappeared before lease update");
   });
 };
 

--- a/apps/api/src/lib/scheduler/runner.ts
+++ b/apps/api/src/lib/scheduler/runner.ts
@@ -1,5 +1,5 @@
 import { panic } from "better-result";
-import { and, asc, eq, inArray, isNull, lte, or } from "drizzle-orm";
+import { and, asc, eq, isNull, lte, or } from "drizzle-orm";
 import type { PgUpdateSetSource } from "drizzle-orm/pg-core";
 
 import { rootDb } from "@/api/db/root";
@@ -23,6 +23,7 @@ import type {
 const DEFAULT_POLL_INTERVAL_MS = 60_000;
 const DEFAULT_LEASE_MS = 30 * 60_000;
 const DEFAULT_JOB_LIMIT = 10;
+const DEFAULT_SWEEP_DURATION_MS = 55_000;
 const MIN_LEASE_MS = 3 * DEFAULT_POLL_INTERVAL_MS;
 
 // Hard upper bound on how long a single task may run. The lease heartbeat
@@ -45,6 +46,8 @@ type RunSchedulerOnceOptions = {
   limit?: number;
   leaseMs?: number;
   maxRuntimeMs?: number;
+  maxSweepDurationMs?: number;
+  now?: () => number;
   registry?: SchedulerTaskRegistry;
   signal?: AbortSignal;
 };
@@ -52,6 +55,8 @@ type RunSchedulerOnceOptions = {
 type RunSchedulerOnceResult = {
   acquired: number;
   failed: number;
+  deadlineReached: boolean;
+  remainingMayExist: boolean;
   skipped: number;
   succeeded: number;
 };
@@ -71,83 +76,80 @@ export const runSchedulerOnce = async ({
   leaseMs = DEFAULT_LEASE_MS,
   limit = DEFAULT_JOB_LIMIT,
   maxRuntimeMs = DEFAULT_MAX_RUNTIME_MS,
+  maxSweepDurationMs = DEFAULT_SWEEP_DURATION_MS,
+  now = Date.now,
   registry = createSchedulerTaskRegistry(),
   runnerId = defaultRunnerId(),
   signal,
 }: RunSchedulerOnceOptions = {}): Promise<RunSchedulerOnceResult> => {
+  if (!Number.isInteger(limit) || limit < 1) {
+    return panic("Scheduler job limit must be a positive integer");
+  }
+
   if (!Number.isInteger(maxRuntimeMs) || maxRuntimeMs < 1) {
     return panic("Scheduler job runtime ceiling must be a positive integer");
   }
 
-  const jobs = await acquireDueJobs({ db, leaseMs, limit, runnerId });
+  if (!Number.isInteger(maxSweepDurationMs) || maxSweepDurationMs < 1) {
+    return panic("Scheduler sweep duration must be a positive integer");
+  }
+
+  const deadline = now() + maxSweepDurationMs;
   const result: RunSchedulerOnceResult = {
-    acquired: jobs.length,
+    acquired: 0,
+    deadlineReached: false,
     failed: 0,
+    remainingMayExist: false,
     skipped: 0,
     succeeded: 0,
   };
-  if (jobs.length === 0) {
-    return result;
+
+  while (result.acquired < limit) {
+    if (signal?.aborted) {
+      result.remainingMayExist = true;
+      break;
+    }
+
+    if (now() >= deadline) {
+      result.deadlineReached = true;
+      result.remainingMayExist = true;
+      break;
+    }
+
+    // Claim immediately before execution. A pass never leases work it cannot
+    // start yet, so another scheduler replica remains free to process it.
+    // oxlint-disable-next-line no-await-in-loop -- sequential claim-and-run is the scheduler's fairness boundary
+    const job = await acquireNextDueJob({ db, leaseMs, runnerId });
+    if (!job) {
+      break;
+    }
+    result.acquired += 1;
+
+    // oxlint-disable-next-line no-await-in-loop -- scheduler jobs intentionally run one at a time per replica
+    const status = await runJob({
+      db,
+      job,
+      leaseMs,
+      maxRuntimeMs,
+      registry,
+      runnerId,
+      signal,
+    });
+    if (status === "success") {
+      result.succeeded += 1;
+      continue;
+    }
+
+    if (status === "skipped") {
+      result.skipped += 1;
+      continue;
+    }
+
+    result.failed += 1;
   }
 
-  const unstartedTokens = new Set(jobs.map(leaseTokenOf));
-  const unstartedHeartbeat = startUnstartedJobsHeartbeat({
-    db,
-    leaseMs,
-    leaseTokens: unstartedTokens,
-    runnerId,
-    signal,
-  });
-
-  try {
-    for (const [index, job] of jobs.entries()) {
-      if (signal?.aborted) {
-        const unstartedJobs = jobs.slice(index);
-        // oxlint-disable-next-line no-await-in-loop -- runs once before the break on abort; jobs are drained sequentially
-        await releaseUnstartedJobs({
-          db,
-          jobs: unstartedJobs,
-        });
-        result.skipped += unstartedJobs.length;
-        break;
-      }
-
-      // oxlint-disable-next-line no-await-in-loop -- jobs run sequentially; lease renewal must precede this job's run
-      const leasedJob = await renewJobLeaseBeforeStart({
-        db,
-        job,
-        leaseMs,
-      });
-      unstartedTokens.delete(leaseTokenOf(job));
-      if (!leasedJob) {
-        result.skipped += 1;
-        continue;
-      }
-
-      // oxlint-disable-next-line no-await-in-loop -- scheduler runs leased jobs one at a time, in order, honouring the abort signal
-      const status = await runJob({
-        db,
-        job: leasedJob,
-        leaseMs,
-        maxRuntimeMs,
-        registry,
-        runnerId,
-        signal,
-      });
-      if (status === "success") {
-        result.succeeded += 1;
-        continue;
-      }
-
-      if (status === "skipped") {
-        result.skipped += 1;
-        continue;
-      }
-
-      result.failed += 1;
-    }
-  } finally {
-    unstartedHeartbeat.stop();
+  if (result.acquired >= limit) {
+    result.remainingMayExist = true;
   }
 
   return result;
@@ -237,41 +239,37 @@ export const startSchedulerLoop = ({
   };
 };
 
-type AcquireDueJobsOptions = {
+type AcquireNextDueJobOptions = {
   db: SchedulerDb;
   runnerId: string;
-  limit: number;
   leaseMs: number;
 };
 
-export const acquireDueJobs = async ({
+export const acquireNextDueJob = async ({
   db,
   leaseMs,
-  limit,
   runnerId,
-}: AcquireDueJobsOptions): Promise<SchedulerJob[]> => {
-  if (!Number.isInteger(limit) || limit < 1) {
-    return panic("Scheduler job limit must be a positive integer");
-  }
-
+}: AcquireNextDueJobOptions): Promise<SchedulerJob | null> => {
   if (!Number.isInteger(leaseMs) || leaseMs < MIN_LEASE_MS) {
     return panic("Scheduler lease must be at least three poll intervals");
   }
 
   const now = new Date();
   const leaseExpiresAt = new Date(now.getTime() + leaseMs);
-  const candidates = await db
-    .select()
-    .from(schedulerJobs)
-    .where(dueJobPredicate(now))
-    .orderBy(asc(schedulerJobs.nextRunAt), asc(schedulerJobs.id))
-    .limit(limit);
-  const acquired: SchedulerJob[] = [];
+  return await db.transaction(async (tx) => {
+    const [candidate] = await tx
+      .select()
+      .from(schedulerJobs)
+      .where(dueJobPredicate(now))
+      .orderBy(asc(schedulerJobs.nextRunAt), asc(schedulerJobs.id))
+      .limit(1)
+      .for("update", { skipLocked: true });
+    if (!candidate) {
+      return null;
+    }
 
-  for (const candidate of candidates) {
     const leaseToken = acquireLeaseToken(runnerId);
-    // oxlint-disable-next-line no-db-await-in-loop/no-db-await-in-loop, no-await-in-loop -- sequential conditional locking preserves due-order acquisition
-    const [job] = await db
+    const [job] = await tx
       .update(schedulerJobs)
       .set({
         lockedAt: now,
@@ -281,116 +279,8 @@ export const acquireDueJobs = async ({
       .where(and(eq(schedulerJobs.id, candidate.id), dueJobPredicate(now)))
       .returning();
 
-    if (job) {
-      acquired.push(job);
-    }
-  }
-
-  return acquired;
-};
-
-type ReleaseUnstartedJobsOptions = {
-  db: SchedulerDb;
-  jobs: SchedulerJob[];
-};
-
-const releaseUnstartedJobs = async ({
-  db,
-  jobs,
-}: ReleaseUnstartedJobsOptions): Promise<void> => {
-  if (jobs.length === 0) {
-    return;
-  }
-
-  // Lease tokens are globally unique, so matching the acquired token set targets
-  // exactly the rows this pass still holds.
-  await db
-    .update(schedulerJobs)
-    .set({
-      lockedAt: null,
-      lockedBy: null,
-      lockedUntil: null,
-    })
-    .where(inArray(schedulerJobs.lockedBy, jobs.map(leaseTokenOf)));
-};
-
-type RenewJobLeaseBeforeStartOptions = {
-  db: SchedulerDb;
-  job: SchedulerJob;
-  leaseMs: number;
-};
-
-const renewJobLeaseBeforeStart = async ({
-  db,
-  job,
-  leaseMs,
-}: RenewJobLeaseBeforeStartOptions): Promise<SchedulerJob | null> => {
-  const leaseToken = leaseTokenOf(job);
-  const now = new Date();
-  const [leasedJob] = await db
-    .update(schedulerJobs)
-    .set({
-      lockedAt: now,
-      lockedUntil: new Date(now.getTime() + leaseMs),
-    })
-    .where(
-      and(eq(schedulerJobs.id, job.id), eq(schedulerJobs.lockedBy, leaseToken)),
-    )
-    .returning();
-
-  return leasedJob ?? null;
-};
-
-type StartUnstartedJobsHeartbeatOptions = {
-  db: SchedulerDb;
-  leaseMs: number;
-  leaseTokens: Set<string>;
-  runnerId: string;
-  signal: AbortSignal | undefined;
-};
-
-const startUnstartedJobsHeartbeat = ({
-  db,
-  leaseMs,
-  leaseTokens,
-  runnerId,
-  signal,
-}: StartUnstartedJobsHeartbeatOptions): LeaseHeartbeat => {
-  const intervalMs = Math.max(
-    DEFAULT_POLL_INTERVAL_MS,
-    Math.floor(leaseMs / 3),
-  );
-
-  const renew = async () => {
-    if (signal?.aborted || leaseTokens.size === 0) {
-      return;
-    }
-
-    await db
-      .update(schedulerJobs)
-      .set({
-        lockedUntil: new Date(Date.now() + leaseMs),
-      })
-      .where(inArray(schedulerJobs.lockedBy, [...leaseTokens]));
-  };
-
-  const timer = setInterval(() => {
-    detached(
-      renew().catch((error: unknown) => {
-        logger.warn("scheduler.unstarted_lease_heartbeat_failed", {
-          "scheduler.runner_id": runnerId,
-          "error.type": errorTag(error),
-        });
-      }),
-      "startUnstartedJobsHeartbeat",
-    );
-  }, intervalMs);
-
-  return {
-    stop: () => {
-      clearInterval(timer);
-    },
-  };
+    return job ?? null;
+  });
 };
 
 const dueJobPredicate = (now: Date) =>


### PR DESCRIPTION
## Summary

- claim one due scheduler job immediately before execution using a transactional `FOR UPDATE SKIP LOCKED` selection
- bound each scheduler pass by both job count and a 55-second claim deadline
- report whether the deadline was reached and whether more work may remain
- remove batch reservation and heartbeats for jobs the runner has not started

## Why

The scheduler executes jobs sequentially but previously leased a full batch up front. That prevented other replicas from processing those unstarted jobs and required a separate heartbeat/release path. Just-in-time claims keep ownership aligned with execution and make each pass explicitly bounded.

## Verification

- scheduler runner test suite (20 tests)
- API typecheck
- targeted type-aware oxlint
- targeted oxfmt check
- repository pre-push format and i18n checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scheduler reliability by claiming the next due job immediately before execution.
  * Strengthened claim exclusivity so concurrent runs don’t override each other’s locks.
  * Refined sweep stop behaviour and reporting for aborted runs.

* **Improvements**
  * Added bounded sweep controls with configurable sweep deadlines and execution limits.
  * More accurate sweep outcomes when draining fully, hitting limits, or reaching the deadline.

* **Tests**
  * Expanded scheduler sweep and exclusivity coverage, updating expected stop reasons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->