### PR TITLE
feat(api): persist extraction run lifecycle

### DIFF
--- a/apps/api/drizzle/20260722195738_extraction_runs/migration.sql
+++ b/apps/api/drizzle/20260722195738_extraction_runs/migration.sql
@@ -11,7 +11,7 @@ CREATE TABLE "extraction_runs" (
 	"total" integer DEFAULT 0 NOT NULL,
 	"completed" integer DEFAULT 0 NOT NULL,
 	"error_code" varchar(128),
-	"started_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"started_at" timestamp with time zone,
 	"finished_at" timestamp with time zone,
 	"created_at" timestamp DEFAULT now() NOT NULL,
 	"updated_at" timestamp DEFAULT now() NOT NULL,

--- a/apps/api/drizzle/20260722195738_extraction_runs/migration.sql
+++ b/apps/api/drizzle/20260722195738_extraction_runs/migration.sql
@@ -27,7 +27,7 @@ ALTER TABLE "extraction_runs" ADD CONSTRAINT "extraction_runs_organization_id_or
 ALTER TABLE "extraction_runs" ADD CONSTRAINT "extraction_runs_workspace_id_workspaces_id_fkey" FOREIGN KEY ("workspace_id") REFERENCES "workspaces"("id") ON DELETE CASCADE;--> statement-breakpoint
 ALTER TABLE "extraction_runs" ADD CONSTRAINT "extraction_runs_requested_by_user_id_fkey" FOREIGN KEY ("requested_by") REFERENCES "user"("id") ON DELETE SET NULL;--> statement-breakpoint
 CREATE INDEX "extraction_runs_workspace_created_idx" ON "extraction_runs" ("workspace_id", "created_at" DESC NULLS LAST, "id");--> statement-breakpoint
-CREATE INDEX "extraction_runs_workspace_active_idx" ON "extraction_runs" ("workspace_id", "updated_at") WHERE "status" IN ('planning', 'running', 'finalizing');--> statement-breakpoint
+CREATE INDEX "extraction_runs_active_updated_idx" ON "extraction_runs" ("updated_at", "workspace_id") WHERE "status" IN ('planning', 'running', 'finalizing');--> statement-breakpoint
 GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE "extraction_runs" TO stella;--> statement-breakpoint
 CREATE POLICY "extraction_runs_workspace_select" ON "extraction_runs" AS PERMISSIVE FOR SELECT TO "stella" USING ((CASE
   WHEN workspace_id = ANY(

--- a/apps/api/drizzle/20260722195738_extraction_runs/migration.sql
+++ b/apps/api/drizzle/20260722195738_extraction_runs/migration.sql
@@ -29,7 +29,7 @@ ALTER TABLE "extraction_runs" ADD CONSTRAINT "extraction_runs_requested_by_user_
 CREATE INDEX "extraction_runs_workspace_created_idx" ON "extraction_runs" ("workspace_id", "created_at" DESC NULLS LAST, "id");--> statement-breakpoint
 CREATE INDEX "extraction_runs_workspace_active_idx" ON "extraction_runs" ("workspace_id", "updated_at") WHERE "status" IN ('planning', 'running', 'finalizing');--> statement-breakpoint
 GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE "extraction_runs" TO stella;--> statement-breakpoint
-CREATE POLICY "workspace_select" ON "extraction_runs" AS PERMISSIVE FOR SELECT TO "stella" USING (CASE
+CREATE POLICY "extraction_runs_workspace_select" ON "extraction_runs" AS PERMISSIVE FOR SELECT TO "stella" USING ((CASE
   WHEN workspace_id = ANY(
     COALESCE(
       NULLIF(
@@ -46,8 +46,10 @@ CREATE POLICY "workspace_select" ON "extraction_runs" AS PERMISSIVE FOR SELECT T
     SELECT aw.authorized_workspace_id
     FROM public.stella_authorized_workspaces aw
   )
-END);--> statement-breakpoint
-CREATE POLICY "workspace_insert" ON "extraction_runs" AS PERMISSIVE FOR INSERT TO "stella" WITH CHECK (CASE
+END) AND organization_id = (SELECT current_setting(
+  'app.organization_id', true
+)));--> statement-breakpoint
+CREATE POLICY "extraction_runs_workspace_insert" ON "extraction_runs" AS PERMISSIVE FOR INSERT TO "stella" WITH CHECK ((CASE
   WHEN workspace_id = ANY(
     COALESCE(
       NULLIF(
@@ -64,8 +66,10 @@ CREATE POLICY "workspace_insert" ON "extraction_runs" AS PERMISSIVE FOR INSERT T
     SELECT aw.authorized_workspace_id
     FROM public.stella_authorized_workspaces aw
   )
-END);--> statement-breakpoint
-CREATE POLICY "workspace_update" ON "extraction_runs" AS PERMISSIVE FOR UPDATE TO "stella" USING (CASE
+END) AND organization_id = (SELECT current_setting(
+  'app.organization_id', true
+)));--> statement-breakpoint
+CREATE POLICY "extraction_runs_workspace_update" ON "extraction_runs" AS PERMISSIVE FOR UPDATE TO "stella" USING ((CASE
   WHEN workspace_id = ANY(
     COALESCE(
       NULLIF(
@@ -82,8 +86,10 @@ CREATE POLICY "workspace_update" ON "extraction_runs" AS PERMISSIVE FOR UPDATE T
     SELECT aw.authorized_workspace_id
     FROM public.stella_authorized_workspaces aw
   )
-END);--> statement-breakpoint
-CREATE POLICY "workspace_delete" ON "extraction_runs" AS PERMISSIVE FOR DELETE TO "stella" USING (CASE
+END) AND organization_id = (SELECT current_setting(
+  'app.organization_id', true
+)));--> statement-breakpoint
+CREATE POLICY "extraction_runs_workspace_delete" ON "extraction_runs" AS PERMISSIVE FOR DELETE TO "stella" USING ((CASE
   WHEN workspace_id = ANY(
     COALESCE(
       NULLIF(
@@ -100,11 +106,6 @@ CREATE POLICY "workspace_delete" ON "extraction_runs" AS PERMISSIVE FOR DELETE T
     SELECT aw.authorized_workspace_id
     FROM public.stella_authorized_workspaces aw
   )
-END);--> statement-breakpoint
-CREATE POLICY "extraction_runs_organization_scope" ON "extraction_runs" AS RESTRICTIVE FOR ALL TO "stella" USING (organization_id =
-  (SELECT current_setting(
-    'app.organization_id', true
-  ))) WITH CHECK (organization_id =
-  (SELECT current_setting(
-    'app.organization_id', true
-  )));
+END) AND organization_id = (SELECT current_setting(
+  'app.organization_id', true
+)));

--- a/apps/api/drizzle/20260722195738_extraction_runs/migration.sql
+++ b/apps/api/drizzle/20260722195738_extraction_runs/migration.sql
@@ -1,0 +1,110 @@
+SET lock_timeout = '1s';--> statement-breakpoint
+SET statement_timeout = '5s';--> statement-breakpoint
+CREATE TABLE "extraction_runs" (
+	"id" uuid PRIMARY KEY,
+	"organization_id" varchar(128) NOT NULL,
+	"workspace_id" uuid NOT NULL,
+	"requested_by" text,
+	"scope" text NOT NULL,
+	"execution_version" integer DEFAULT 1 NOT NULL,
+	"status" text DEFAULT 'planning' NOT NULL,
+	"total" integer DEFAULT 0 NOT NULL,
+	"completed" integer DEFAULT 0 NOT NULL,
+	"error_code" varchar(128),
+	"started_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"finished_at" timestamp with time zone,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "extraction_runs_execution_version_positive_check" CHECK ("execution_version" > 0),
+	CONSTRAINT "extraction_runs_scope_values_check" CHECK ("scope" IN ('workspace', 'entities', 'properties', 'cells')),
+	CONSTRAINT "extraction_runs_status_values_check" CHECK ("status" IN ('planning', 'running', 'finalizing', 'completed', 'failed', 'skipped')),
+	CONSTRAINT "extraction_runs_progress_nonnegative_check" CHECK ("total" >= 0 AND "completed" >= 0),
+	CONSTRAINT "extraction_runs_completed_within_total_check" CHECK ("completed" <= "total")
+);
+--> statement-breakpoint
+ALTER TABLE "extraction_runs" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+ALTER TABLE "extraction_runs" ADD CONSTRAINT "extraction_runs_organization_id_organization_id_fkey" FOREIGN KEY ("organization_id") REFERENCES "organization"("id") ON DELETE CASCADE;--> statement-breakpoint
+ALTER TABLE "extraction_runs" ADD CONSTRAINT "extraction_runs_workspace_id_workspaces_id_fkey" FOREIGN KEY ("workspace_id") REFERENCES "workspaces"("id") ON DELETE CASCADE;--> statement-breakpoint
+ALTER TABLE "extraction_runs" ADD CONSTRAINT "extraction_runs_requested_by_user_id_fkey" FOREIGN KEY ("requested_by") REFERENCES "user"("id") ON DELETE SET NULL;--> statement-breakpoint
+CREATE INDEX "extraction_runs_workspace_created_idx" ON "extraction_runs" ("workspace_id", "created_at" DESC NULLS LAST, "id");--> statement-breakpoint
+CREATE INDEX "extraction_runs_workspace_active_idx" ON "extraction_runs" ("workspace_id", "updated_at") WHERE "status" IN ('planning', 'running', 'finalizing');--> statement-breakpoint
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE "extraction_runs" TO stella;--> statement-breakpoint
+CREATE POLICY "workspace_select" ON "extraction_runs" AS PERMISSIVE FOR SELECT TO "stella" USING (CASE
+  WHEN workspace_id = ANY(
+    COALESCE(
+      NULLIF(
+        (SELECT pg_catalog.current_setting(
+          'app.workspace_ids', true
+        )),
+        ''
+      )::uuid[],
+      ARRAY[]::uuid[]
+    )
+  )
+  THEN true
+  ELSE workspace_id IN (
+    SELECT aw.authorized_workspace_id
+    FROM public.stella_authorized_workspaces aw
+  )
+END);--> statement-breakpoint
+CREATE POLICY "workspace_insert" ON "extraction_runs" AS PERMISSIVE FOR INSERT TO "stella" WITH CHECK (CASE
+  WHEN workspace_id = ANY(
+    COALESCE(
+      NULLIF(
+        (SELECT pg_catalog.current_setting(
+          'app.workspace_ids', true
+        )),
+        ''
+      )::uuid[],
+      ARRAY[]::uuid[]
+    )
+  )
+  THEN true
+  ELSE workspace_id IN (
+    SELECT aw.authorized_workspace_id
+    FROM public.stella_authorized_workspaces aw
+  )
+END);--> statement-breakpoint
+CREATE POLICY "workspace_update" ON "extraction_runs" AS PERMISSIVE FOR UPDATE TO "stella" USING (CASE
+  WHEN workspace_id = ANY(
+    COALESCE(
+      NULLIF(
+        (SELECT pg_catalog.current_setting(
+          'app.workspace_ids', true
+        )),
+        ''
+      )::uuid[],
+      ARRAY[]::uuid[]
+    )
+  )
+  THEN true
+  ELSE workspace_id IN (
+    SELECT aw.authorized_workspace_id
+    FROM public.stella_authorized_workspaces aw
+  )
+END);--> statement-breakpoint
+CREATE POLICY "workspace_delete" ON "extraction_runs" AS PERMISSIVE FOR DELETE TO "stella" USING (CASE
+  WHEN workspace_id = ANY(
+    COALESCE(
+      NULLIF(
+        (SELECT pg_catalog.current_setting(
+          'app.workspace_ids', true
+        )),
+        ''
+      )::uuid[],
+      ARRAY[]::uuid[]
+    )
+  )
+  THEN true
+  ELSE workspace_id IN (
+    SELECT aw.authorized_workspace_id
+    FROM public.stella_authorized_workspaces aw
+  )
+END);--> statement-breakpoint
+CREATE POLICY "extraction_runs_organization_scope" ON "extraction_runs" AS RESTRICTIVE FOR ALL TO "stella" USING (organization_id =
+  (SELECT current_setting(
+    'app.organization_id', true
+  ))) WITH CHECK (organization_id =
+  (SELECT current_setting(
+    'app.organization_id', true
+  )));

--- a/apps/api/src/db/rls.ts
+++ b/apps/api/src/db/rls.ts
@@ -252,6 +252,39 @@ export const wsPolicies = () => [
   }),
 ];
 
+const workspaceOrganizationCheck = sql`(
+  ${workspaceCheck} AND ${organizationCheck}
+)`;
+
+/**
+ * Workspace policies for tables that also persist an organization
+ * discriminator. Requiring both scopes in every command prevents a valid
+ * workspace pin from authorizing a row whose organization_id was corrupted or
+ * supplied from another tenant.
+ */
+export const wsOrganizationPolicies = (tableName: string) => [
+  p.pgPolicy(`${tableName}_workspace_select`, {
+    for: "select",
+    to: stella,
+    using: workspaceOrganizationCheck,
+  }),
+  p.pgPolicy(`${tableName}_workspace_insert`, {
+    for: "insert",
+    to: stella,
+    withCheck: workspaceOrganizationCheck,
+  }),
+  p.pgPolicy(`${tableName}_workspace_update`, {
+    for: "update",
+    to: stella,
+    using: workspaceOrganizationCheck,
+  }),
+  p.pgPolicy(`${tableName}_workspace_delete`, {
+    for: "delete",
+    to: stella,
+    using: workspaceOrganizationCheck,
+  }),
+];
+
 export const orgPolicies = () => [
   p.pgPolicy("organization_select", {
     for: "select",

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -10,6 +10,7 @@ export * from "./schema/case-law";
 export * from "./schema/legislation";
 export * from "./schema/chat";
 export * from "./schema/docx-suggestions";
+export * from "./schema/extraction-runs";
 export * from "./schema/flows";
 export * from "./schema/mcp";
 export * from "./schema/files-views";

--- a/apps/api/src/db/schema/common.ts
+++ b/apps/api/src/db/schema/common.ts
@@ -32,6 +32,7 @@ import {
   userPolicies,
   workspaceIdCheck,
   workspaceViewTemplatePolicies,
+  wsOrganizationPolicies,
   wsPolicies,
 } from "@/api/db/rls";
 import type {
@@ -387,6 +388,7 @@ export {
   userPolicies,
   workspaceIdCheck,
   workspaceViewTemplatePolicies,
+  wsOrganizationPolicies,
   wsPolicies,
 };
 

--- a/apps/api/src/db/schema/extraction-runs.ts
+++ b/apps/api/src/db/schema/extraction-runs.ts
@@ -1,0 +1,115 @@
+import { sql } from "drizzle-orm";
+
+import {
+  organization,
+  organizationCheck,
+  p,
+  pUuid,
+  safeOrganizationId,
+  safeWorkspaceId,
+  stella,
+  user,
+  wsPolicies,
+} from "./common";
+import { workspaces } from "./contacts";
+
+export const EXTRACTION_RUN_STATUSES = [
+  "planning",
+  "running",
+  "finalizing",
+  "completed",
+  "failed",
+  "skipped",
+] as const;
+export type ExtractionRunStatus = (typeof EXTRACTION_RUN_STATUSES)[number];
+
+export const EXTRACTION_RUN_SCOPES = [
+  "workspace",
+  "entities",
+  "properties",
+  "cells",
+] as const;
+export type ExtractionRunScope = (typeof EXTRACTION_RUN_SCOPES)[number];
+
+/**
+ * Durable lifecycle metadata for tabular-review extraction. Redis and BullMQ
+ * remain the hot execution path; this row is the tenant-scoped source for run
+ * history, coarse progress, terminal state, and recovery diagnostics. It never
+ * stores prompts, source material, generated answers, or document identifiers.
+ */
+export const extractionRuns = p.pgTable(
+  "extraction_runs",
+  {
+    id: pUuid<"extractionRun">().primaryKey(),
+    organizationId: safeOrganizationId("organization_id")
+      .notNull()
+      .references(() => organization.id, { onDelete: "cascade" }),
+    workspaceId: safeWorkspaceId("workspace_id")
+      .notNull()
+      .references(() => workspaces.id, { onDelete: "cascade" }),
+    requestedBy: p
+      .text("requested_by")
+      .references(() => user.id, { onDelete: "set null" }),
+    scope: p.text({ enum: EXTRACTION_RUN_SCOPES }).notNull(),
+    executionVersion: p.integer("execution_version").notNull().default(1),
+    status: p
+      .text({ enum: EXTRACTION_RUN_STATUSES })
+      .notNull()
+      .default("planning"),
+    total: p.integer().notNull().default(0),
+    completed: p.integer().notNull().default(0),
+    errorCode: p.varchar("error_code", { length: 128 }),
+    startedAt: p
+      .timestamp("started_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    finishedAt: p.timestamp("finished_at", { withTimezone: true }),
+    createdAt: p.timestamp("created_at").notNull().defaultNow(),
+    updatedAt: p
+      .timestamp("updated_at")
+      .notNull()
+      .defaultNow()
+      .$onUpdate(() => new Date()),
+  },
+  (table) => [
+    p
+      .index("extraction_runs_workspace_created_idx")
+      .on(table.workspaceId, table.createdAt.desc(), table.id),
+    p
+      .index("extraction_runs_workspace_active_idx")
+      .on(table.workspaceId, table.updatedAt)
+      .where(sql`${table.status} IN ('planning', 'running', 'finalizing')`),
+    p.check(
+      "extraction_runs_execution_version_positive_check",
+      sql`${table.executionVersion} > 0`,
+    ),
+    p.check(
+      "extraction_runs_scope_values_check",
+      sql`${table.scope} IN ('workspace', 'entities', 'properties', 'cells')`,
+    ),
+    p.check(
+      "extraction_runs_status_values_check",
+      sql`${table.status} IN ('planning', 'running', 'finalizing', 'completed', 'failed', 'skipped')`,
+    ),
+    p.check(
+      "extraction_runs_progress_nonnegative_check",
+      sql`${table.total} >= 0 AND ${table.completed} >= 0`,
+    ),
+    p.check(
+      "extraction_runs_completed_within_total_check",
+      sql`${table.completed} <= ${table.total}`,
+    ),
+    ...wsPolicies(),
+    // Workspace authorization is necessary but not sufficient for a table
+    // that also carries organization_id. Keep the org discriminator aligned
+    // with the transaction even if a root-only writer is later exposed through
+    // an RLS-scoped path.
+    p.pgPolicy("extraction_runs_organization_scope", {
+      as: "restrictive",
+      for: "all",
+      to: stella,
+      using: organizationCheck,
+      withCheck: organizationCheck,
+    }),
+  ],
+);

--- a/apps/api/src/db/schema/extraction-runs.ts
+++ b/apps/api/src/db/schema/extraction-runs.ts
@@ -71,8 +71,8 @@ export const extractionRuns = p.pgTable(
       .index("extraction_runs_workspace_created_idx")
       .on(table.workspaceId, table.createdAt.desc(), table.id),
     p
-      .index("extraction_runs_workspace_active_idx")
-      .on(table.workspaceId, table.updatedAt)
+      .index("extraction_runs_active_updated_idx")
+      .on(table.updatedAt, table.workspaceId)
       .where(sql`${table.status} IN ('planning', 'running', 'finalizing')`),
     p.check(
       "extraction_runs_execution_version_positive_check",

--- a/apps/api/src/db/schema/extraction-runs.ts
+++ b/apps/api/src/db/schema/extraction-runs.ts
@@ -57,10 +57,7 @@ export const extractionRuns = p.pgTable(
     total: p.integer().notNull().default(0),
     completed: p.integer().notNull().default(0),
     errorCode: p.varchar("error_code", { length: 128 }),
-    startedAt: p
-      .timestamp("started_at", { withTimezone: true })
-      .notNull()
-      .defaultNow(),
+    startedAt: p.timestamp("started_at", { withTimezone: true }),
     finishedAt: p.timestamp("finished_at", { withTimezone: true }),
     createdAt: p.timestamp("created_at").notNull().defaultNow(),
     updatedAt: p

--- a/apps/api/src/db/schema/extraction-runs.ts
+++ b/apps/api/src/db/schema/extraction-runs.ts
@@ -2,14 +2,12 @@ import { sql } from "drizzle-orm";
 
 import {
   organization,
-  organizationCheck,
   p,
   pUuid,
   safeOrganizationId,
   safeWorkspaceId,
-  stella,
   user,
-  wsPolicies,
+  wsOrganizationPolicies,
 } from "./common";
 import { workspaces } from "./contacts";
 
@@ -99,17 +97,6 @@ export const extractionRuns = p.pgTable(
       "extraction_runs_completed_within_total_check",
       sql`${table.completed} <= ${table.total}`,
     ),
-    ...wsPolicies(),
-    // Workspace authorization is necessary but not sufficient for a table
-    // that also carries organization_id. Keep the org discriminator aligned
-    // with the transaction even if a root-only writer is later exposed through
-    // an RLS-scoped path.
-    p.pgPolicy("extraction_runs_organization_scope", {
-      as: "restrictive",
-      for: "all",
-      to: stella,
-      using: organizationCheck,
-      withCheck: organizationCheck,
-    }),
+    ...wsOrganizationPolicies("extraction_runs"),
   ],
 );

--- a/apps/api/src/lib/branded-types.ts
+++ b/apps/api/src/lib/branded-types.ts
@@ -44,6 +44,7 @@ export type SafeIdType =
   | "entityVersionAiSummary"
   | "entityVersion"
   | "expense"
+  | "extractionRun"
   | "field"
   | "flowDefinition"
   | "flowRun"

--- a/apps/api/src/lib/extraction-runs/root-store.ts
+++ b/apps/api/src/lib/extraction-runs/root-store.ts
@@ -1,0 +1,5 @@
+import { rootDb } from "@/api/db/root";
+
+import { createExtractionRunStore } from "./store";
+
+export const extractionRunStore = createExtractionRunStore(rootDb);

--- a/apps/api/src/lib/extraction-runs/store.test.ts
+++ b/apps/api/src/lib/extraction-runs/store.test.ts
@@ -124,11 +124,14 @@ describe("extraction run store contract", () => {
       total: 0,
       workspaceId,
     });
+    expect(run.startedAt).toBeNull();
   });
 
   test("syncs absolute progress monotonically and bounds it to the target", async () => {
     const key = await createRun();
     await store.start({ ...key, total: 5 });
+
+    expect((await readRun(key.id)).startedAt).not.toBeNull();
 
     await store.syncProgress({ ...key, completed: 3, total: 5 });
     await store.syncProgress({ ...key, completed: 1, total: 5 });
@@ -174,6 +177,16 @@ describe("extraction run store contract", () => {
       status: "running",
       total: 2,
     });
+  });
+
+  test("recovers a missed start write from the first absolute progress snapshot", async () => {
+    const key = await createRun();
+
+    await store.syncProgress({ ...key, completed: 1, total: 3 });
+
+    const run = await readRun(key.id);
+    expect(run).toMatchObject({ completed: 1, status: "running", total: 3 });
+    expect(run.startedAt).not.toBeNull();
   });
 
   test("keeps terminal states immutable under late delivery", async () => {
@@ -301,5 +314,26 @@ describe("extraction run store contract", () => {
     expect(await readRun(otherWorkspace.id)).toMatchObject({
       status: "planning",
     });
+  });
+
+  test("finds stale active workspaces for recovery without returning terminal runs", async () => {
+    const stale = await createRun();
+    const recent = await createRun();
+    const terminal = await createRun();
+    await store.start({ ...terminal, total: 1 });
+    await store.complete(terminal);
+
+    await testDb
+      .update(extractionRuns)
+      .set({ updatedAt: new Date("2026-01-01T00:00:00.000Z") })
+      .where(eq(extractionRuns.id, stale.id));
+
+    const workspaceIds = await store.listStaleActiveWorkspaceIds({
+      before: new Date("2026-01-02T00:00:00.000Z"),
+      limit: 10,
+    });
+
+    expect(workspaceIds).toEqual([workspaceId]);
+    expect(await readRun(recent.id)).toMatchObject({ status: "planning" });
   });
 });

--- a/apps/api/src/lib/extraction-runs/store.test.ts
+++ b/apps/api/src/lib/extraction-runs/store.test.ts
@@ -6,7 +6,7 @@ import {
   expect,
   test,
 } from "bun:test";
-import { eq, sql } from "drizzle-orm";
+import { eq, inArray, sql } from "drizzle-orm";
 
 import { organization, user } from "@/api/db/auth-schema";
 import type { ScopedDb } from "@/api/db/safe-db";
@@ -72,7 +72,11 @@ afterAll(async () => {
 });
 
 beforeEach(async () => {
-  await testDb.delete(extractionRuns);
+  await testDb
+    .delete(extractionRuns)
+    .where(
+      inArray(extractionRuns.workspaceId, [workspaceId, otherWorkspaceId]),
+    );
 });
 
 const createRun = async (

--- a/apps/api/src/lib/extraction-runs/store.test.ts
+++ b/apps/api/src/lib/extraction-runs/store.test.ts
@@ -6,10 +6,12 @@ import {
   expect,
   test,
 } from "bun:test";
-import { eq } from "drizzle-orm";
+import { eq, sql } from "drizzle-orm";
 
 import { organization, user } from "@/api/db/auth-schema";
+import type { ScopedDb } from "@/api/db/safe-db";
 import { extractionRuns, workspaces } from "@/api/db/schema";
+import { createScopedDb } from "@/api/db/scoped";
 import { createSafeId } from "@/api/lib/branded-types";
 import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
 import { getTestDb, releaseTestDb } from "@/api/tests/security/test-utils";
@@ -210,6 +212,58 @@ describe("extraction run store contract", () => {
       status: "planning",
       total: 0,
     });
+  });
+
+  test("requires both workspace and organization scope for app-role writes", async () => {
+    const policyResult = await testDb.execute<{
+      cmd: string;
+      policyName: string;
+      usingExpression: string | null;
+      withCheckExpression: string | null;
+    }>(sql`
+      SELECT
+        cmd,
+        policyname AS "policyName",
+        qual AS "usingExpression",
+        with_check AS "withCheckExpression"
+      FROM pg_catalog.pg_policies
+      WHERE tablename = 'extraction_runs'
+    `);
+    expect(policyResult.rows).toHaveLength(4);
+    for (const policy of policyResult.rows) {
+      const expression =
+        policy.cmd === "INSERT"
+          ? policy.withCheckExpression
+          : policy.usingExpression;
+      expect(expression).toContain("organization_id");
+      expect(expression).toContain("app.organization_id");
+      expect(expression).toContain("workspace_id");
+    }
+
+    const scopedDb = asTestRaw<ScopedDb>(
+      createScopedDb(testDb, [workspaceId], organizationId, userId),
+    );
+    const runId = createSafeId<"extractionRun">();
+
+    const rejection: unknown = await scopedDb(async (tx) => {
+      await tx.insert(extractionRuns).values({
+        id: runId,
+        organizationId: otherOrganizationId,
+        workspaceId,
+        requestedBy: userId,
+        scope: "workspace",
+      });
+    }).then(
+      () => null,
+      (error: unknown) => error,
+    );
+
+    expect(rejection).toBeInstanceOf(Error);
+    const [inserted] = await testDb
+      .select({ id: extractionRuns.id })
+      .from(extractionRuns)
+      .where(eq(extractionRuns.id, runId));
+    expect(inserted).toBeUndefined();
   });
 
   test("skips only planning runs", async () => {

--- a/apps/api/src/lib/extraction-runs/store.test.ts
+++ b/apps/api/src/lib/extraction-runs/store.test.ts
@@ -211,6 +211,33 @@ describe("extraction run store contract", () => {
     expect(run.finishedAt).not.toBeNull();
   });
 
+  test("records an entity failure without finishing until all work drains", async () => {
+    const key = await createRun();
+    await store.start({ ...key, total: 2 });
+
+    await store.recordFailure({ ...key, errorCode: "ProviderFailed" });
+
+    expect(await readRun(key.id)).toMatchObject({
+      completed: 0,
+      errorCode: "ProviderFailed",
+      finishedAt: null,
+      status: "running",
+      total: 2,
+    });
+
+    await store.syncProgress({ ...key, completed: 2, total: 2 });
+    await store.complete(key);
+
+    const run = await readRun(key.id);
+    expect(run).toMatchObject({
+      completed: 2,
+      errorCode: "ProviderFailed",
+      status: "failed",
+      total: 2,
+    });
+    expect(run.finishedAt).not.toBeNull();
+  });
+
   test("requires the complete tenant key for every run mutation", async () => {
     const key = await createRun();
 

--- a/apps/api/src/lib/extraction-runs/store.test.ts
+++ b/apps/api/src/lib/extraction-runs/store.test.ts
@@ -1,0 +1,251 @@
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+import { eq } from "drizzle-orm";
+
+import { organization, user } from "@/api/db/auth-schema";
+import { extractionRuns, workspaces } from "@/api/db/schema";
+import { createSafeId } from "@/api/lib/branded-types";
+import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
+import { getTestDb, releaseTestDb } from "@/api/tests/security/test-utils";
+import type { TestDatabase } from "@/api/tests/security/test-utils";
+
+import { createExtractionRunStore, type ExtractionRunDb } from "./store";
+
+let testDb: TestDatabase;
+let store: ReturnType<typeof createExtractionRunStore>;
+
+const organizationId = createSafeId<"organization">();
+const otherOrganizationId = createSafeId<"organization">();
+const workspaceId = createSafeId<"workspace">();
+const otherWorkspaceId = createSafeId<"workspace">();
+const userId = createSafeId<"user">();
+
+beforeAll(async () => {
+  testDb = await getTestDb();
+  store = createExtractionRunStore(asTestRaw<ExtractionRunDb>(testDb));
+
+  await testDb.insert(organization).values([
+    {
+      id: organizationId,
+      name: "Extraction run org",
+      slug: `extraction-runs-${organizationId}`,
+      createdAt: new Date(),
+    },
+    {
+      id: otherOrganizationId,
+      name: "Other extraction run org",
+      slug: `extraction-runs-${otherOrganizationId}`,
+      createdAt: new Date(),
+    },
+  ]);
+  await testDb.insert(user).values({
+    id: userId,
+    name: "Extraction run user",
+    email: `${userId}@test.local`,
+  });
+  await testDb.insert(workspaces).values([
+    {
+      id: workspaceId,
+      organizationId,
+      name: "Extraction matter",
+      reference: "EXTRACT",
+    },
+    {
+      id: otherWorkspaceId,
+      organizationId: otherOrganizationId,
+      name: "Other extraction matter",
+      reference: "OTHER",
+    },
+  ]);
+});
+
+afterAll(async () => {
+  await releaseTestDb();
+});
+
+beforeEach(async () => {
+  await testDb.delete(extractionRuns);
+});
+
+const createRun = async (
+  id = createSafeId<"extractionRun">(),
+  overrides: Partial<{
+    organizationId: typeof organizationId;
+    workspaceId: typeof workspaceId;
+  }> = {},
+) => {
+  const key = {
+    id,
+    organizationId: overrides.organizationId ?? organizationId,
+    workspaceId: overrides.workspaceId ?? workspaceId,
+  };
+  await store.create({
+    ...key,
+    requestedBy: userId,
+    scope: "workspace",
+  });
+  return key;
+};
+
+const readRun = async (
+  id: ReturnType<typeof createSafeId<"extractionRun">>,
+) => {
+  const [run] = await testDb
+    .select()
+    .from(extractionRuns)
+    .where(eq(extractionRuns.id, id));
+  if (!run) {
+    throw new Error(`Expected extraction run ${id} to exist`);
+  }
+  return run;
+};
+
+describe("extraction run store contract", () => {
+  test("creates tenant-scoped planning metadata without workflow payloads", async () => {
+    const key = await createRun();
+
+    const run = await readRun(key.id);
+
+    expect(run).toMatchObject({
+      completed: 0,
+      executionVersion: 1,
+      organizationId,
+      requestedBy: userId,
+      scope: "workspace",
+      status: "planning",
+      total: 0,
+      workspaceId,
+    });
+  });
+
+  test("syncs absolute progress monotonically and bounds it to the target", async () => {
+    const key = await createRun();
+    await store.start({ ...key, total: 5 });
+
+    await store.syncProgress({ ...key, completed: 3, total: 5 });
+    await store.syncProgress({ ...key, completed: 1, total: 5 });
+    expect(await readRun(key.id)).toMatchObject({
+      completed: 3,
+      status: "running",
+      total: 5,
+    });
+
+    await store.syncProgress({ ...key, completed: 7, total: 5 });
+    expect(await readRun(key.id)).toMatchObject({
+      completed: 5,
+      status: "finalizing",
+      total: 5,
+    });
+  });
+
+  test("rejects invalid counters before issuing a database mutation", async () => {
+    const key = await createRun();
+
+    const invalidTotal: unknown = await store.start({ ...key, total: -1 }).then(
+      () => null,
+      (error: unknown) => error,
+    );
+    expect(invalidTotal).toBeInstanceOf(Error);
+    expect(invalidTotal instanceof Error ? invalidTotal.message : "").toBe(
+      "total must be a nonnegative safe integer",
+    );
+    await store.start({ ...key, total: 2 });
+    const invalidCompleted: unknown = await store
+      .syncProgress({ ...key, completed: Number.NaN, total: 2 })
+      .then(
+        () => null,
+        (error: unknown) => error,
+      );
+    expect(invalidCompleted).toBeInstanceOf(Error);
+    expect(
+      invalidCompleted instanceof Error ? invalidCompleted.message : "",
+    ).toBe("completed must be a nonnegative safe integer");
+
+    expect(await readRun(key.id)).toMatchObject({
+      completed: 0,
+      status: "running",
+      total: 2,
+    });
+  });
+
+  test("keeps terminal states immutable under late delivery", async () => {
+    const key = await createRun();
+    await store.start({ ...key, total: 2 });
+    await store.complete(key);
+
+    await store.syncProgress({ ...key, completed: 1, total: 2 });
+    await store.fail({ ...key, errorCode: "LateFailure" });
+
+    const run = await readRun(key.id);
+    expect(run).toMatchObject({
+      completed: 2,
+      errorCode: null,
+      status: "completed",
+      total: 2,
+    });
+    expect(run.finishedAt).not.toBeNull();
+  });
+
+  test("requires the complete tenant key for every run mutation", async () => {
+    const key = await createRun();
+
+    await store.start({
+      ...key,
+      organizationId: otherOrganizationId,
+      total: 4,
+    });
+    await store.fail({
+      ...key,
+      workspaceId: otherWorkspaceId,
+      errorCode: "WrongTenant",
+    });
+
+    expect(await readRun(key.id)).toMatchObject({
+      status: "planning",
+      total: 0,
+    });
+  });
+
+  test("skips only planning runs", async () => {
+    const planning = await createRun();
+    const running = await createRun();
+    await store.start({ ...running, total: 1 });
+
+    await store.skip(planning);
+    await store.skip(running);
+
+    expect(await readRun(planning.id)).toMatchObject({ status: "skipped" });
+    expect(await readRun(running.id)).toMatchObject({ status: "running" });
+  });
+
+  test("orphan recovery fails only active runs in its workspace", async () => {
+    const planning = await createRun();
+    const completed = await createRun();
+    await store.start({ ...completed, total: 1 });
+    await store.complete(completed);
+    const otherWorkspace = await createRun(createSafeId<"extractionRun">(), {
+      organizationId: otherOrganizationId,
+      workspaceId: otherWorkspaceId,
+    });
+
+    await store.failActiveForWorkspace({
+      errorCode: "ExtractionRunOrphaned",
+      workspaceId,
+    });
+
+    expect(await readRun(planning.id)).toMatchObject({
+      errorCode: "ExtractionRunOrphaned",
+      status: "failed",
+    });
+    expect(await readRun(completed.id)).toMatchObject({ status: "completed" });
+    expect(await readRun(otherWorkspace.id)).toMatchObject({
+      status: "planning",
+    });
+  });
+});

--- a/apps/api/src/lib/extraction-runs/store.ts
+++ b/apps/api/src/lib/extraction-runs/store.ts
@@ -159,14 +159,36 @@ export const createExtractionRunStore = (db: ExtractionRunDb) => ({
       .update(extractionRuns)
       .set({
         completed: sql`${extractionRuns.total}`,
-        errorCode: null,
         finishedAt: new Date(),
-        status: "completed",
+        status: sql`CASE
+          WHEN ${extractionRuns.errorCode} IS NULL THEN 'completed'
+          ELSE 'failed'
+        END`,
       })
       .where(
         and(
           runKeyPredicate({ id, organizationId, workspaceId }),
           inArray(extractionRuns.status, ["running", "finalizing"]),
+        ),
+      );
+  },
+
+  recordFailure: async ({
+    errorCode,
+    id,
+    organizationId,
+    workspaceId,
+  }: FinishExtractionRunOptions): Promise<void> => {
+    const normalizedErrorCode = normalizeErrorCode(errorCode);
+    await db
+      .update(extractionRuns)
+      .set({
+        errorCode: sql`COALESCE(${extractionRuns.errorCode}, ${normalizedErrorCode})`,
+      })
+      .where(
+        and(
+          runKeyPredicate({ id, organizationId, workspaceId }),
+          inArray(extractionRuns.status, ACTIVE_EXTRACTION_RUN_STATUSES),
         ),
       );
   },

--- a/apps/api/src/lib/extraction-runs/store.ts
+++ b/apps/api/src/lib/extraction-runs/store.ts
@@ -1,10 +1,11 @@
 import { panic } from "better-result";
-import { and, eq, inArray, sql } from "drizzle-orm";
+import { and, eq, inArray, lte, or, sql } from "drizzle-orm";
 
-import { rootDb } from "@/api/db/root";
+import type { rootDb } from "@/api/db/root";
 import { extractionRuns } from "@/api/db/schema";
 import type { ExtractionRunScope } from "@/api/db/schema";
 import type { SafeId } from "@/api/lib/branded-types";
+import { brandPersistedWorkspaceId } from "@/api/lib/safe-id-boundaries";
 
 const ACTIVE_EXTRACTION_RUN_STATUSES = [
   "planning",
@@ -41,6 +42,11 @@ type FinishExtractionRunOptions = ExtractionRunKey & {
 type FailActiveExtractionRunsOptions = {
   errorCode: string;
   workspaceId: SafeId<"workspace">;
+};
+
+type ListStaleActiveWorkspaceIdsOptions = {
+  before: Date;
+  limit: number;
 };
 
 const runKeyPredicate = ({
@@ -96,7 +102,7 @@ export const createExtractionRunStore = (db: ExtractionRunDb) => ({
     const validatedTotal = requireNonnegativeInteger(total, "total");
     await db
       .update(extractionRuns)
-      .set({ status: "running", total: validatedTotal })
+      .set({ startedAt: new Date(), status: "running", total: validatedTotal })
       .where(
         and(
           runKeyPredicate({ id, organizationId, workspaceId }),
@@ -122,17 +128,24 @@ export const createExtractionRunStore = (db: ExtractionRunDb) => ({
       .update(extractionRuns)
       .set({
         completed: sql`GREATEST(${extractionRuns.completed}, ${boundedCompleted})`,
+        startedAt: sql`COALESCE(${extractionRuns.startedAt}, NOW())`,
         status: sql`CASE
-          WHEN GREATEST(${extractionRuns.completed}, ${boundedCompleted}) >= ${extractionRuns.total}
+          WHEN GREATEST(${extractionRuns.completed}, ${boundedCompleted}) >= ${validatedTotal}
           THEN 'finalizing'
-          ELSE ${extractionRuns.status}
+          ELSE 'running'
         END`,
+        total: validatedTotal,
       })
       .where(
         and(
           runKeyPredicate({ id, organizationId, workspaceId }),
-          eq(extractionRuns.total, validatedTotal),
-          inArray(extractionRuns.status, ["running", "finalizing"]),
+          or(
+            eq(extractionRuns.status, "planning"),
+            and(
+              eq(extractionRuns.total, validatedTotal),
+              inArray(extractionRuns.status, ["running", "finalizing"]),
+            ),
+          ),
         ),
       );
   },
@@ -153,7 +166,7 @@ export const createExtractionRunStore = (db: ExtractionRunDb) => ({
       .where(
         and(
           runKeyPredicate({ id, organizationId, workspaceId }),
-          inArray(extractionRuns.status, ACTIVE_EXTRACTION_RUN_STATUSES),
+          inArray(extractionRuns.status, ["running", "finalizing"]),
         ),
       );
   },
@@ -213,6 +226,25 @@ export const createExtractionRunStore = (db: ExtractionRunDb) => ({
         ),
       );
   },
-});
 
-export const extractionRunStore = createExtractionRunStore(rootDb);
+  listStaleActiveWorkspaceIds: async ({
+    before,
+    limit,
+  }: ListStaleActiveWorkspaceIdsOptions): Promise<SafeId<"workspace">[]> => {
+    const validatedLimit = requireNonnegativeInteger(limit, "limit");
+    if (validatedLimit === 0) {
+      return [];
+    }
+    const rows = await db
+      .selectDistinct({ workspaceId: extractionRuns.workspaceId })
+      .from(extractionRuns)
+      .where(
+        and(
+          inArray(extractionRuns.status, ACTIVE_EXTRACTION_RUN_STATUSES),
+          lte(extractionRuns.updatedAt, before),
+        ),
+      )
+      .limit(validatedLimit);
+    return rows.map((row) => brandPersistedWorkspaceId(row.workspaceId));
+  },
+});

--- a/apps/api/src/lib/extraction-runs/store.ts
+++ b/apps/api/src/lib/extraction-runs/store.ts
@@ -1,0 +1,218 @@
+import { panic } from "better-result";
+import { and, eq, inArray, sql } from "drizzle-orm";
+
+import { rootDb } from "@/api/db/root";
+import { extractionRuns } from "@/api/db/schema";
+import type { ExtractionRunScope } from "@/api/db/schema";
+import type { SafeId } from "@/api/lib/branded-types";
+
+const ACTIVE_EXTRACTION_RUN_STATUSES = [
+  "planning",
+  "running",
+  "finalizing",
+] as const;
+
+export type ExtractionRunDb = typeof rootDb;
+
+type ExtractionRunKey = {
+  id: SafeId<"extractionRun">;
+  organizationId: SafeId<"organization">;
+  workspaceId: SafeId<"workspace">;
+};
+
+type CreateExtractionRunOptions = ExtractionRunKey & {
+  requestedBy: SafeId<"user">;
+  scope: ExtractionRunScope;
+};
+
+type StartExtractionRunOptions = ExtractionRunKey & {
+  total: number;
+};
+
+type SyncExtractionRunProgressOptions = ExtractionRunKey & {
+  completed: number;
+  total: number;
+};
+
+type FinishExtractionRunOptions = ExtractionRunKey & {
+  errorCode?: string;
+};
+
+type FailActiveExtractionRunsOptions = {
+  errorCode: string;
+  workspaceId: SafeId<"workspace">;
+};
+
+const runKeyPredicate = ({
+  id,
+  organizationId,
+  workspaceId,
+}: ExtractionRunKey) =>
+  and(
+    eq(extractionRuns.id, id),
+    eq(extractionRuns.organizationId, organizationId),
+    eq(extractionRuns.workspaceId, workspaceId),
+  );
+
+const requireNonnegativeInteger = (value: number, label: string): number => {
+  if (!Number.isSafeInteger(value) || value < 0) {
+    return panic(`${label} must be a nonnegative safe integer`);
+  }
+  return value;
+};
+
+const normalizeErrorCode = (errorCode: string | undefined): string =>
+  (errorCode ?? "ExtractionRunFailed").slice(0, 128);
+
+/**
+ * Postgres lifecycle store for extraction orchestration. Every mutation is
+ * tenant-keyed and terminal states are immutable. Progress accepts absolute
+ * Redis SCARD snapshots and advances monotonically, so repeated or out-of-order
+ * delivery cannot double-count or move a run backwards.
+ */
+export const createExtractionRunStore = (db: ExtractionRunDb) => ({
+  create: async ({
+    id,
+    organizationId,
+    requestedBy,
+    scope,
+    workspaceId,
+  }: CreateExtractionRunOptions): Promise<void> => {
+    await db.insert(extractionRuns).values({
+      id,
+      organizationId,
+      requestedBy,
+      scope,
+      workspaceId,
+    });
+  },
+
+  start: async ({
+    id,
+    organizationId,
+    total,
+    workspaceId,
+  }: StartExtractionRunOptions): Promise<void> => {
+    const validatedTotal = requireNonnegativeInteger(total, "total");
+    await db
+      .update(extractionRuns)
+      .set({ status: "running", total: validatedTotal })
+      .where(
+        and(
+          runKeyPredicate({ id, organizationId, workspaceId }),
+          eq(extractionRuns.status, "planning"),
+        ),
+      );
+  },
+
+  syncProgress: async ({
+    completed,
+    id,
+    organizationId,
+    total,
+    workspaceId,
+  }: SyncExtractionRunProgressOptions): Promise<void> => {
+    const validatedTotal = requireNonnegativeInteger(total, "total");
+    const validatedCompleted = requireNonnegativeInteger(
+      completed,
+      "completed",
+    );
+    const boundedCompleted = Math.min(validatedCompleted, validatedTotal);
+    await db
+      .update(extractionRuns)
+      .set({
+        completed: sql`GREATEST(${extractionRuns.completed}, ${boundedCompleted})`,
+        status: sql`CASE
+          WHEN GREATEST(${extractionRuns.completed}, ${boundedCompleted}) >= ${extractionRuns.total}
+          THEN 'finalizing'
+          ELSE ${extractionRuns.status}
+        END`,
+      })
+      .where(
+        and(
+          runKeyPredicate({ id, organizationId, workspaceId }),
+          eq(extractionRuns.total, validatedTotal),
+          inArray(extractionRuns.status, ["running", "finalizing"]),
+        ),
+      );
+  },
+
+  complete: async ({
+    id,
+    organizationId,
+    workspaceId,
+  }: ExtractionRunKey): Promise<void> => {
+    await db
+      .update(extractionRuns)
+      .set({
+        completed: sql`${extractionRuns.total}`,
+        errorCode: null,
+        finishedAt: new Date(),
+        status: "completed",
+      })
+      .where(
+        and(
+          runKeyPredicate({ id, organizationId, workspaceId }),
+          inArray(extractionRuns.status, ACTIVE_EXTRACTION_RUN_STATUSES),
+        ),
+      );
+  },
+
+  skip: async ({
+    id,
+    organizationId,
+    workspaceId,
+  }: ExtractionRunKey): Promise<void> => {
+    await db
+      .update(extractionRuns)
+      .set({ finishedAt: new Date(), status: "skipped" })
+      .where(
+        and(
+          runKeyPredicate({ id, organizationId, workspaceId }),
+          eq(extractionRuns.status, "planning"),
+        ),
+      );
+  },
+
+  fail: async ({
+    errorCode,
+    id,
+    organizationId,
+    workspaceId,
+  }: FinishExtractionRunOptions): Promise<void> => {
+    await db
+      .update(extractionRuns)
+      .set({
+        errorCode: normalizeErrorCode(errorCode),
+        finishedAt: new Date(),
+        status: "failed",
+      })
+      .where(
+        and(
+          runKeyPredicate({ id, organizationId, workspaceId }),
+          inArray(extractionRuns.status, ACTIVE_EXTRACTION_RUN_STATUSES),
+        ),
+      );
+  },
+
+  failActiveForWorkspace: async ({
+    errorCode,
+    workspaceId,
+  }: FailActiveExtractionRunsOptions): Promise<void> => {
+    await db
+      .update(extractionRuns)
+      .set({
+        errorCode: normalizeErrorCode(errorCode),
+        finishedAt: new Date(),
+        status: "failed",
+      })
+      .where(
+        and(
+          eq(extractionRuns.workspaceId, workspaceId),
+          inArray(extractionRuns.status, ACTIVE_EXTRACTION_RUN_STATUSES),
+        ),
+      );
+  },
+});
+
+export const extractionRunStore = createExtractionRunStore(rootDb);

--- a/apps/api/src/lib/safe-id-boundaries.ts
+++ b/apps/api/src/lib/safe-id-boundaries.ts
@@ -73,6 +73,10 @@ export const brandPersistedFlowDefinitionId = (
 export const brandPersistedFlowRunId = (flowRunId: string): SafeId<"flowRun"> =>
   toSafeId<"flowRun">(flowRunId);
 
+export const brandPersistedExtractionRunId = (
+  extractionRunId: string,
+): SafeId<"extractionRun"> => toSafeId<"extractionRun">(extractionRunId);
+
 export const brandPersistedUserFileId = (
   userFileId: string,
 ): SafeId<"userFile"> => toSafeId<"userFile">(userFileId);

--- a/apps/api/src/lib/workflow-queue.ts
+++ b/apps/api/src/lib/workflow-queue.ts
@@ -1068,8 +1068,9 @@ const recoverOrphanedWorkflow = async ({
 
 type ReconcileOrphanedWorkflowsOptions = {
   // Boot passes `true` to also sweep the DB for `pending` cells whose
-  // lock already lapsed via TTL; periodic ticks pass `false` and rely on
-  // the cheap lock scan alone.
+  // lock already lapsed via TTL. Every tick still performs the bounded,
+  // indexed stale-run scan because a captured terminal ledger-write failure
+  // can leave no Redis or pending-cell recovery signal.
   scanPendingCells: boolean;
 };
 
@@ -1086,12 +1087,11 @@ export const reconcileOrphanedWorkflows = async ({
   const pendingWorkspaceIds = scanPendingCells
     ? await selectWorkspacesWithPendingCells()
     : await selectWorkspacesWithPendingCells(lockedWorkspaceIds);
-  const staleActiveWorkspaceIds = scanPendingCells
-    ? await extractionRunStore.listStaleActiveWorkspaceIds({
-        before: new Date(Date.now() - RUNNING_LOCK_TTL_SEC * 1000),
-        limit: STALE_ACTIVE_RUN_SCAN_LIMIT,
-      })
-    : [];
+  const staleActiveWorkspaceIds =
+    await extractionRunStore.listStaleActiveWorkspaceIds({
+      before: new Date(Date.now() - RUNNING_LOCK_TTL_SEC * 1000),
+      limit: STALE_ACTIVE_RUN_SCAN_LIMIT,
+    });
 
   const candidateWorkspaceIds = [
     ...lockedWorkspaceIds,

--- a/apps/api/src/lib/workflow-queue.ts
+++ b/apps/api/src/lib/workflow-queue.ts
@@ -10,6 +10,7 @@ import { rootDb } from "@/api/db/root";
 import type { SafeDb, ScopedDb } from "@/api/db/safe-db";
 import {
   cellMetadata,
+  type ExtractionRunScope,
   fields,
   justifications,
   properties,
@@ -35,6 +36,7 @@ import {
   errorSystemFields,
   errorTag,
 } from "@/api/lib/errors/utils";
+import { extractionRunStore } from "@/api/lib/extraction-runs/store";
 import { LIMITS } from "@/api/lib/limits";
 import { logger } from "@/api/lib/observability/logger";
 import {
@@ -44,6 +46,7 @@ import {
 } from "@/api/lib/redis-client";
 import { createRootSafeDb, createRootScopedDb } from "@/api/lib/root-scoped-db";
 import {
+  brandPersistedExtractionRunId,
   brandPersistedEntityId,
   brandPersistedPropertyId,
   brandPersistedUserId,
@@ -320,6 +323,27 @@ type StartWorkflowResult = {
   status: "started" | "already-running" | "skipped" | "failed";
 };
 
+const extractionRunScope = ({
+  entityIds,
+  propertyIds,
+}: {
+  entityIds: StartWorkflowArgs["entityIds"] | undefined;
+  propertyIds: StartWorkflowArgs["propertyIds"] | undefined;
+}): ExtractionRunScope => {
+  const hasEntities = entityIds !== undefined && entityIds.length > 0;
+  const hasProperties = propertyIds !== undefined && propertyIds.length > 0;
+  if (hasEntities && hasProperties) {
+    return "cells";
+  }
+  if (hasProperties) {
+    return "properties";
+  }
+  if (hasEntities) {
+    return "entities";
+  }
+  return "workspace";
+};
+
 type EnqueueEntityJobsArgs = {
   entityIds: readonly SafeId<"entity">[];
   executionPlan: ExecutionLevel[];
@@ -450,7 +474,9 @@ export const startWorkflow = async ({
   serviceTier = "standard",
 }: StartWorkflowArgs): Promise<StartWorkflowResult> => {
   const redis = getRedis();
-  const requestId = Bun.randomUUIDv7();
+  const requestId = createSafeId<"extractionRun">();
+  const runKey = { id: requestId, organizationId, workspaceId };
+  let runCreated = false;
 
   // Check if already running (atomic check-and-set). The TTL is the
   // safety net for an uncleanly-killed worker; tuned tight enough that
@@ -474,6 +500,16 @@ export const startWorkflow = async ({
   );
 
   try {
+    await extractionRunStore.create({
+      ...runKey,
+      requestedBy: userId,
+      scope: extractionRunScope({
+        entityIds: inputEntityIds,
+        propertyIds: inputPropertyIds,
+      }),
+    });
+    runCreated = true;
+
     const executionPlanData = await getExecutionPlanData(workspaceId, scopedDb);
 
     // Property-status freshness is an optimization for full-workspace
@@ -507,6 +543,7 @@ export const startWorkflow = async ({
     );
 
     if (!hasWork) {
+      await extractionRunStore.skip(runKey);
       await clearWorkflowRunState(redis, workspaceId);
       return { status: "skipped" };
     }
@@ -556,6 +593,7 @@ export const startWorkflow = async ({
     const targetCount = targetEntityIds.length;
 
     if (targetCount === 0) {
+      await extractionRunStore.skip(runKey);
       await clearWorkflowRunState(redis, workspaceId);
       return { status: "skipped" };
     }
@@ -628,6 +666,8 @@ export const startWorkflow = async ({
       );
     }
 
+    await extractionRunStore.start({ ...runKey, total: targetCount });
+
     // Broadcast running status
     broadcastWorkflowStatus(workspaceId, true);
 
@@ -670,6 +710,11 @@ export const startWorkflow = async ({
 
     return { status: "started" };
   } catch (error: unknown) {
+    if (runCreated) {
+      await extractionRunStore
+        .fail({ ...runKey, errorCode: errorTag(error) })
+        .catch((runError: unknown) => captureError(runError, { workspaceId }));
+    }
     await clearWorkflowRunState(redis, workspaceId);
     broadcastWorkflowStatus(workspaceId, false);
     captureError(error, { workspaceId });
@@ -983,6 +1028,13 @@ const recoverOrphanedWorkflow = async ({
       ),
     )
     .returning({ id: fields.id });
+
+  await extractionRunStore
+    .failActiveForWorkspace({
+      errorCode: "ExtractionRunOrphaned",
+      workspaceId,
+    })
+    .catch((error: unknown) => captureError(error, { workspaceId }));
 
   // Then release the run-state so retries / new runs stop hitting the
   // "a workflow is already running" 409.
@@ -1963,6 +2015,16 @@ const onEntityCompleted = async ({
     return;
   }
 
+  await extractionRunStore
+    .syncProgress({
+      completed: result.completed,
+      id: brandPersistedExtractionRunId(requestId),
+      organizationId,
+      total: result.total,
+      workspaceId,
+    })
+    .catch((error: unknown) => captureError(error, { workspaceId }));
+
   if (result.completed >= result.total) {
     await finishWorkflow(workspaceId, organizationId, userId, requestId);
     return;
@@ -2131,6 +2193,14 @@ const finishWorkflow = async (
       captureError(error, { workspaceId });
     }
   }
+
+  await extractionRunStore
+    .complete({
+      id: brandPersistedExtractionRunId(requestId),
+      organizationId,
+      workspaceId,
+    })
+    .catch((error: unknown) => captureError(error, { workspaceId }));
 
   // Clean up Redis state
   await clearWorkflowRunState(redis, workspaceId);

--- a/apps/api/src/lib/workflow-queue.ts
+++ b/apps/api/src/lib/workflow-queue.ts
@@ -1259,7 +1259,7 @@ const handleWorkflowJobFailed = (
         },
       );
       await extractionRunStore
-        .fail({
+        .recordFailure({
           id: brandPersistedExtractionRunId(data.requestId),
           organizationId: branded.organizationId,
           workspaceId: branded.workspaceId,

--- a/apps/api/src/lib/workflow-queue.ts
+++ b/apps/api/src/lib/workflow-queue.ts
@@ -36,7 +36,7 @@ import {
   errorSystemFields,
   errorTag,
 } from "@/api/lib/errors/utils";
-import { extractionRunStore } from "@/api/lib/extraction-runs/store";
+import { extractionRunStore } from "@/api/lib/extraction-runs/root-store";
 import { LIMITS } from "@/api/lib/limits";
 import { logger } from "@/api/lib/observability/logger";
 import {
@@ -476,7 +476,6 @@ export const startWorkflow = async ({
   const redis = getRedis();
   const requestId = createSafeId<"extractionRun">();
   const runKey = { id: requestId, organizationId, workspaceId };
-  let runCreated = false;
 
   // Check if already running (atomic check-and-set). The TTL is the
   // safety net for an uncleanly-killed worker; tuned tight enough that
@@ -499,17 +498,22 @@ export const startWorkflow = async ({
     RUNNING_LOCK_TTL_SEC,
   );
 
-  try {
-    await extractionRunStore.create({
+  const createdRunKey = await extractionRunStore
+    .create({
       ...runKey,
       requestedBy: userId,
       scope: extractionRunScope({
         entityIds: inputEntityIds,
         propertyIds: inputPropertyIds,
       }),
+    })
+    .then(() => runKey)
+    .catch((error: unknown) => {
+      captureError(error, { workspaceId });
+      return undefined;
     });
-    runCreated = true;
 
+  try {
     const executionPlanData = await getExecutionPlanData(workspaceId, scopedDb);
 
     // Property-status freshness is an optimization for full-workspace
@@ -543,7 +547,11 @@ export const startWorkflow = async ({
     );
 
     if (!hasWork) {
-      await extractionRunStore.skip(runKey);
+      if (createdRunKey) {
+        await extractionRunStore
+          .skip(createdRunKey)
+          .catch((error: unknown) => captureError(error, { workspaceId }));
+      }
       await clearWorkflowRunState(redis, workspaceId);
       return { status: "skipped" };
     }
@@ -593,7 +601,11 @@ export const startWorkflow = async ({
     const targetCount = targetEntityIds.length;
 
     if (targetCount === 0) {
-      await extractionRunStore.skip(runKey);
+      if (createdRunKey) {
+        await extractionRunStore
+          .skip(createdRunKey)
+          .catch((error: unknown) => captureError(error, { workspaceId }));
+      }
       await clearWorkflowRunState(redis, workspaceId);
       return { status: "skipped" };
     }
@@ -666,7 +678,11 @@ export const startWorkflow = async ({
       );
     }
 
-    await extractionRunStore.start({ ...runKey, total: targetCount });
+    if (createdRunKey) {
+      await extractionRunStore
+        .start({ ...createdRunKey, total: targetCount })
+        .catch((error: unknown) => captureError(error, { workspaceId }));
+    }
 
     // Broadcast running status
     broadcastWorkflowStatus(workspaceId, true);
@@ -710,9 +726,9 @@ export const startWorkflow = async ({
 
     return { status: "started" };
   } catch (error: unknown) {
-    if (runCreated) {
+    if (createdRunKey) {
       await extractionRunStore
-        .fail({ ...runKey, errorCode: errorTag(error) })
+        .fail({ ...createdRunKey, errorCode: errorTag(error) })
         .catch((runError: unknown) => captureError(runError, { workspaceId }));
     }
     await clearWorkflowRunState(redis, workspaceId);
@@ -738,6 +754,7 @@ export const startWorkflow = async ({
 // heals whatever the previous one left behind.
 
 const RECONCILE_INTERVAL_MS = 60 * 1000;
+const STALE_ACTIVE_RUN_SCAN_LIMIT = 1000;
 // Settle window before acting. A workflow that has just taken its
 // `running` lock but not yet enqueued its first entity batch would look
 // orphaned for a moment; we re-confirm against a fresh job snapshot after
@@ -1069,8 +1086,18 @@ export const reconcileOrphanedWorkflows = async ({
   const pendingWorkspaceIds = scanPendingCells
     ? await selectWorkspacesWithPendingCells()
     : await selectWorkspacesWithPendingCells(lockedWorkspaceIds);
+  const staleActiveWorkspaceIds = scanPendingCells
+    ? await extractionRunStore.listStaleActiveWorkspaceIds({
+        before: new Date(Date.now() - RUNNING_LOCK_TTL_SEC * 1000),
+        limit: STALE_ACTIVE_RUN_SCAN_LIMIT,
+      })
+    : [];
 
-  const candidateWorkspaceIds = [...lockedWorkspaceIds, ...pendingWorkspaceIds];
+  const candidateWorkspaceIds = [
+    ...lockedWorkspaceIds,
+    ...pendingWorkspaceIds,
+    ...staleActiveWorkspaceIds,
+  ];
   if (candidateWorkspaceIds.length === 0) {
     return;
   }
@@ -1091,7 +1118,13 @@ export const reconcileOrphanedWorkflows = async ({
     return;
   }
 
-  const pendingWorkspaceIdSet = new Set(pendingWorkspaceIds);
+  // Either pending cells or a durable active row older than the maximum lock
+  // lifetime is sufficient recovery evidence. The latter closes the process-
+  // death window before planning has produced cells or enqueued its first job.
+  const recoveryEvidenceWorkspaceIdSet = new Set([
+    ...pendingWorkspaceIds,
+    ...staleActiveWorkspaceIds,
+  ]);
   const initialRequestIds = await readWorkflowRequestIds(
     redis,
     orphanCandidates,
@@ -1123,7 +1156,7 @@ export const reconcileOrphanedWorkflows = async ({
     currentRequestIds,
     initialRequestIds,
     liveWorkspaceIds: confirmed.workspaceIds,
-    pendingWorkspaceIds: pendingWorkspaceIdSet,
+    pendingWorkspaceIds: recoveryEvidenceWorkspaceIdSet,
     recoveryWorkspaceIds,
   });
 
@@ -1218,6 +1251,19 @@ const handleWorkflowJobFailed = (
           });
         },
       );
+      await extractionRunStore
+        .fail({
+          id: brandPersistedExtractionRunId(data.requestId),
+          organizationId: branded.organizationId,
+          workspaceId: branded.workspaceId,
+          errorCode: errorTag(error),
+        })
+        .catch((runError: unknown) =>
+          captureError(runError, {
+            workspaceId: data.workspaceId,
+            entityId: data.entityId,
+          }),
+        );
       await onEntityCompleted({
         workspaceId: branded.workspaceId,
         organizationId: branded.organizationId,

--- a/apps/api/src/lib/workflow-queue.ts
+++ b/apps/api/src/lib/workflow-queue.ts
@@ -83,6 +83,7 @@ import {
 import {
   isCurrentWorkflowRequestState,
   parseRunningLockWorkspaceId,
+  selectExpiredStaleRunWorkspaceIds,
   selectOrphanWorkspaceIds,
   selectRecoverableOrphanWorkspaceIds,
   selectRunningLockReservation,
@@ -1118,13 +1119,6 @@ export const reconcileOrphanedWorkflows = async ({
     return;
   }
 
-  // Either pending cells or a durable active row older than the maximum lock
-  // lifetime is sufficient recovery evidence. The latter closes the process-
-  // death window before planning has produced cells or enqueued its first job.
-  const recoveryEvidenceWorkspaceIdSet = new Set([
-    ...pendingWorkspaceIds,
-    ...staleActiveWorkspaceIds,
-  ]);
   const initialRequestIds = await readWorkflowRequestIds(
     redis,
     orphanCandidates,
@@ -1144,6 +1138,19 @@ export const reconcileOrphanedWorkflows = async ({
   const [currentRequestIds, currentRunningValues] = await Promise.all([
     readWorkflowRequestIds(redis, orphanCandidates),
     readWorkflowRunningValues(redis, orphanCandidates),
+  ]);
+  // Pending cells are immediate recovery evidence. A stale durable row is
+  // evidence only once both Redis state keys have actually expired: flex runs
+  // can legitimately extend their lock beyond the row-age threshold before
+  // their first queue job exists.
+  const expiredStaleWorkspaceIds = selectExpiredStaleRunWorkspaceIds({
+    currentRequestIds,
+    currentRunningValues,
+    staleWorkspaceIds: staleActiveWorkspaceIds,
+  });
+  const recoveryEvidenceWorkspaceIdSet = new Set([
+    ...pendingWorkspaceIds,
+    ...expiredStaleWorkspaceIds,
   ]);
   const recoveryWorkspaceIds = new Set<string>();
   for (const workspaceId of orphanCandidates) {

--- a/apps/api/src/lib/workflow/orphan-recovery.test.ts
+++ b/apps/api/src/lib/workflow/orphan-recovery.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "bun:test";
 import {
   isCurrentWorkflowRequestState,
   parseRunningLockWorkspaceId,
+  selectExpiredStaleRunWorkspaceIds,
   selectOrphanWorkspaceIds,
   selectRecoverableOrphanWorkspaceIds,
   selectRunningLockReservation,
@@ -10,6 +11,26 @@ import {
 
 const LEGACY_RUNNING_LOCK_VALUE = "1";
 const RECOVERY_LOCK_VALUE = "recovery";
+
+describe("selectExpiredStaleRunWorkspaceIds", () => {
+  test("uses stale rows only after both Redis run-state keys expire", () => {
+    expect(
+      selectExpiredStaleRunWorkspaceIds({
+        currentRequestIds: new Map([
+          ["expired", null],
+          ["planning", "request-planning"],
+          ["partial-expiry", "request-partial"],
+        ]),
+        currentRunningValues: new Map([
+          ["expired", null],
+          ["planning", "request-planning"],
+          ["partial-expiry", null],
+        ]),
+        staleWorkspaceIds: ["expired", "planning", "partial-expiry", "expired"],
+      }),
+    ).toEqual(["expired"]);
+  });
+});
 
 describe("parseRunningLockWorkspaceId", () => {
   test("extracts the workspace id from a running-lock key", () => {

--- a/apps/api/src/lib/workflow/orphan-recovery.ts
+++ b/apps/api/src/lib/workflow/orphan-recovery.ts
@@ -25,6 +25,12 @@ type RecoverableOrphanSelectionInput = OrphanSelectionInput & {
   recoveryWorkspaceIds: ReadonlySet<string>;
 };
 
+type ExpiredStaleRunSelectionInput = {
+  currentRequestIds: ReadonlyMap<string, string | null>;
+  currentRunningValues: ReadonlyMap<string, string | null>;
+  staleWorkspaceIds: readonly string[];
+};
+
 type CurrentWorkflowRequestStateInput = {
   currentRequestId: string | null;
   legacyRunningLockValue: string;
@@ -110,6 +116,32 @@ export const selectRecoverableOrphanWorkspaceIds = ({
   }
 
   return recoverable;
+};
+
+/**
+ * A stale durable row is recovery evidence only after both Redis run-state
+ * keys have actually expired. A large workflow can legitimately extend its
+ * lock beyond the durable row's age before its first job is enqueued.
+ */
+export const selectExpiredStaleRunWorkspaceIds = ({
+  currentRequestIds,
+  currentRunningValues,
+  staleWorkspaceIds,
+}: ExpiredStaleRunSelectionInput): string[] => {
+  const expired: string[] = [];
+  const seen = new Set<string>();
+  for (const workspaceId of staleWorkspaceIds) {
+    if (seen.has(workspaceId)) {
+      continue;
+    }
+    seen.add(workspaceId);
+    const requestId = currentRequestIds.get(workspaceId) ?? null;
+    const runningValue = currentRunningValues.get(workspaceId) ?? null;
+    if (requestId === null && runningValue === null) {
+      expired.push(workspaceId);
+    }
+  }
+  return expired;
 };
 
 export const isCurrentWorkflowRequestState = ({


### PR DESCRIPTION
## Summary

- add a tenant-scoped `extraction_runs` lifecycle ledger for tabular-review extraction
- synchronize absolute Redis completion snapshots monotonically and keep terminal states immutable under late or retried delivery
- connect planning, start, progress, completion, failure, skip, and orphan recovery to the existing BullMQ/Redis workflow
- recover stale active rows whose Redis lock and pre-queue recovery signals have expired
- keep ledger writes fail-open so a transient Postgres observability failure cannot stop BullMQ execution; later progress snapshots repair a missed start transition
- store metadata only: no prompts, source documents, generated answers, or entity identifiers
- require workspace and organization scope together for every app-role policy

## Why

This borrows the useful durability boundary from TanStack Workflow without adopting its pre-alpha runtime or replacing Stella's established BullMQ/Redis execution path. Postgres becomes the durable lifecycle/history layer; Redis remains the hot coordination and idempotent completion layer.

## Reliability details

- accurate nullable `startedAt`, written only when execution begins
- exhausted entity retries make the durable run terminally failed while existing per-entity cleanup continues
- stale planning/running/finalizing rows become orphan-recovery candidates after the maximum Redis lock lifetime
- root-backed store initialization is split from the injected factory, avoiding production pool side effects in tests and reusable imports

## Verification

- `bun --filter @stll/api typecheck`
- type-aware oxlint and oxfmt on changed API files
- extraction store, workflow queue, and orphan-recovery suites (32 passing / 67 assertions)
- RLS coverage suite (10 passing / 1334 assertions)
- `bash scripts/check-migrations.sh`
- migration `check` and `apply-fresh` GitHub jobs
- full pre-commit and pre-push format/lint/i18n/typecheck hooks

The optional `.ai/shared` submodule is not initialized in the clean worktree, so its sync check was skipped by the pre-push hook.

