### PR TITLE
feat(web): show durable extraction progress

### DIFF
--- a/apps/api/drizzle/20260723043000_extraction_runs_read_only/migration.sql
+++ b/apps/api/drizzle/20260723043000_extraction_runs_read_only/migration.sql
@@ -1,0 +1,9 @@
+SET lock_timeout = '1s';--> statement-breakpoint
+SET statement_timeout = '5s';--> statement-breakpoint
+-- stella-migration-safety: reviewed destructive-change - drops only app-role RLS policies and replaces them below with restrictive deny policies; rollback recreates the prior tenant-scoped policies
+DROP POLICY "extraction_runs_workspace_insert" ON "extraction_runs";--> statement-breakpoint
+DROP POLICY "extraction_runs_workspace_update" ON "extraction_runs";--> statement-breakpoint
+DROP POLICY "extraction_runs_workspace_delete" ON "extraction_runs";--> statement-breakpoint
+CREATE POLICY "extraction_runs_no_insert" ON "extraction_runs" AS RESTRICTIVE FOR INSERT TO "stella" WITH CHECK (false);--> statement-breakpoint
+CREATE POLICY "extraction_runs_no_update" ON "extraction_runs" AS RESTRICTIVE FOR UPDATE TO "stella" USING (false);--> statement-breakpoint
+CREATE POLICY "extraction_runs_no_delete" ON "extraction_runs" AS RESTRICTIVE FOR DELETE TO "stella" USING (false);

--- a/apps/api/src/db/rls.ts
+++ b/apps/api/src/db/rls.ts
@@ -285,6 +285,37 @@ export const wsOrganizationPolicies = (tableName: string) => [
   }),
 ];
 
+/**
+ * Tenant-scoped read access for root-owned history tables. Explicit restrictive
+ * write policies keep the rows immutable even if a future permissive policy is
+ * added accidentally.
+ */
+export const wsOrganizationReadOnlyPolicies = (tableName: string) => [
+  p.pgPolicy(`${tableName}_workspace_select`, {
+    for: "select",
+    to: stella,
+    using: workspaceOrganizationCheck,
+  }),
+  p.pgPolicy(`${tableName}_no_insert`, {
+    as: "restrictive",
+    for: "insert",
+    to: stella,
+    withCheck: sql`false`,
+  }),
+  p.pgPolicy(`${tableName}_no_update`, {
+    as: "restrictive",
+    for: "update",
+    to: stella,
+    using: sql`false`,
+  }),
+  p.pgPolicy(`${tableName}_no_delete`, {
+    as: "restrictive",
+    for: "delete",
+    to: stella,
+    using: sql`false`,
+  }),
+];
+
 export const orgPolicies = () => [
   p.pgPolicy("organization_select", {
     for: "select",

--- a/apps/api/src/db/schema/common.ts
+++ b/apps/api/src/db/schema/common.ts
@@ -33,6 +33,7 @@ import {
   workspaceIdCheck,
   workspaceViewTemplatePolicies,
   wsOrganizationPolicies,
+  wsOrganizationReadOnlyPolicies,
   wsPolicies,
 } from "@/api/db/rls";
 import type {
@@ -389,6 +390,7 @@ export {
   workspaceIdCheck,
   workspaceViewTemplatePolicies,
   wsOrganizationPolicies,
+  wsOrganizationReadOnlyPolicies,
   wsPolicies,
 };
 

--- a/apps/api/src/db/schema/extraction-runs.ts
+++ b/apps/api/src/db/schema/extraction-runs.ts
@@ -7,7 +7,7 @@ import {
   safeOrganizationId,
   safeWorkspaceId,
   user,
-  wsOrganizationPolicies,
+  wsOrganizationReadOnlyPolicies,
 } from "./common";
 import { workspaces } from "./contacts";
 
@@ -94,6 +94,6 @@ export const extractionRuns = p.pgTable(
       "extraction_runs_completed_within_total_check",
       sql`${table.completed} <= ${table.total}`,
     ),
-    ...wsOrganizationPolicies("extraction_runs"),
+    ...wsOrganizationReadOnlyPolicies("extraction_runs"),
   ],
 );

--- a/apps/api/src/handlers/workspaces/read-workflow-status.integration.test.ts
+++ b/apps/api/src/handlers/workspaces/read-workflow-status.integration.test.ts
@@ -1,0 +1,126 @@
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+import { eq } from "drizzle-orm";
+
+import type { ScopedDb } from "@/api/db/safe-db";
+import { extractionRuns } from "@/api/db/schema";
+import { createScopedDb } from "@/api/db/scoped";
+import { createSafeId } from "@/api/lib/branded-types";
+import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
+import {
+  getRlsFixture,
+  releaseRlsFixture,
+} from "@/api/tests/security/rls-fixture";
+import type { TestIds } from "@/api/tests/security/rls-helpers";
+import type { TestDatabase } from "@/api/tests/security/test-utils";
+
+import { readWorkflowHandler } from "./read-workflow-status";
+
+let testDb: TestDatabase;
+let ids: TestIds;
+let scopedDb: ScopedDb;
+
+beforeAll(async () => {
+  const fixture = await getRlsFixture();
+  testDb = fixture.testDb;
+  ids = fixture.ids;
+  scopedDb = asTestRaw<ScopedDb>(
+    createScopedDb(testDb, [ids.wsA1], ids.orgA, ids.userA1),
+  );
+});
+
+afterEach(async () => {
+  await testDb
+    .delete(extractionRuns)
+    .where(eq(extractionRuns.workspaceId, ids.wsA1));
+});
+
+afterAll(async () => {
+  await releaseRlsFixture();
+});
+
+describe("read workflow status", () => {
+  test("returns the latest tenant-scoped durable run with Redis compatibility state", async () => {
+    const olderRunId = createSafeId<"extractionRun">();
+    const latestRunId = createSafeId<"extractionRun">();
+    await testDb.insert(extractionRuns).values([
+      {
+        id: olderRunId,
+        organizationId: ids.orgA,
+        workspaceId: ids.wsA1,
+        requestedBy: ids.userA1,
+        scope: "workspace",
+        status: "completed",
+        total: 2,
+        completed: 2,
+        createdAt: new Date("2026-01-01T00:00:00.000Z"),
+      },
+      {
+        id: latestRunId,
+        organizationId: ids.orgA,
+        workspaceId: ids.wsA1,
+        requestedBy: ids.userA1,
+        scope: "properties",
+        status: "running",
+        total: 5,
+        completed: 3,
+        createdAt: new Date("2026-01-02T00:00:00.000Z"),
+      },
+    ]);
+
+    const result = await readWorkflowHandler({
+      organizationId: ids.orgA,
+      readRunningState: async () => await Promise.resolve(true),
+      scopedDb,
+      workspaceId: ids.wsA1,
+    });
+
+    expect(result).toMatchObject({
+      running: true,
+      run: {
+        completed: 3,
+        executionVersion: 1,
+        id: latestRunId,
+        scope: "properties",
+        status: "running",
+        total: 5,
+      },
+    });
+  });
+
+  test("returns no run when the organization discriminator does not match", async () => {
+    await testDb.insert(extractionRuns).values({
+      id: createSafeId<"extractionRun">(),
+      organizationId: ids.orgA,
+      workspaceId: ids.wsA1,
+      requestedBy: ids.userA1,
+      scope: "workspace",
+    });
+
+    const result = await readWorkflowHandler({
+      organizationId: ids.orgB,
+      readRunningState: async () => await Promise.resolve(false),
+      scopedDb,
+      workspaceId: ids.wsA1,
+    });
+
+    expect(result).toEqual({ running: false, run: null });
+  });
+
+  test("returns a null durable run before the first extraction", async () => {
+    const result = await readWorkflowHandler({
+      organizationId: ids.orgA,
+      readRunningState: async () => await Promise.resolve(false),
+      scopedDb,
+      workspaceId: ids.wsA1,
+    });
+
+    expect(result).toEqual({ running: false, run: null });
+  });
+});

--- a/apps/api/src/handlers/workspaces/read-workflow-status.ts
+++ b/apps/api/src/handlers/workspaces/read-workflow-status.ts
@@ -1,15 +1,56 @@
 import { Result } from "better-result";
+import { and, desc, eq } from "drizzle-orm";
 
+import type { ScopedDb } from "@/api/db/safe-db";
+import { extractionRuns } from "@/api/db/schema";
 import { createSafeHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
 import type { SafeId } from "@/api/lib/branded-types";
 import { isWorkflowRunning } from "@/api/lib/workflow-queue";
 
-export const readWorkflowHandler = async (
-  workspaceId: SafeId<"workspace">,
-) => ({
-  running: await isWorkflowRunning(workspaceId),
-});
+type ReadWorkflowHandlerOptions = {
+  organizationId: SafeId<"organization">;
+  scopedDb: ScopedDb;
+  workspaceId: SafeId<"workspace">;
+  readRunningState?: typeof isWorkflowRunning;
+};
+
+export const readWorkflowHandler = async ({
+  organizationId,
+  scopedDb,
+  workspaceId,
+  readRunningState = isWorkflowRunning,
+}: ReadWorkflowHandlerOptions) => {
+  const [running, latestRun] = await Promise.all([
+    readRunningState(workspaceId),
+    scopedDb(async (tx) => {
+      const [run] = await tx
+        .select({
+          completed: extractionRuns.completed,
+          errorCode: extractionRuns.errorCode,
+          executionVersion: extractionRuns.executionVersion,
+          finishedAt: extractionRuns.finishedAt,
+          id: extractionRuns.id,
+          scope: extractionRuns.scope,
+          startedAt: extractionRuns.startedAt,
+          status: extractionRuns.status,
+          total: extractionRuns.total,
+        })
+        .from(extractionRuns)
+        .where(
+          and(
+            eq(extractionRuns.organizationId, organizationId),
+            eq(extractionRuns.workspaceId, workspaceId),
+          ),
+        )
+        .orderBy(desc(extractionRuns.createdAt), desc(extractionRuns.id))
+        .limit(1);
+      return run ?? null;
+    }),
+  ]);
+
+  return { running, run: latestRun };
+};
 
 const config = {
   permissions: { workspace: ["read"] },
@@ -19,9 +60,16 @@ const config = {
 
 const readWorkflow = createSafeHandler(
   config,
-  async function* ({ workspaceId }) {
+  async function* ({ scopedDb, session, workspaceId }) {
     const response = yield* Result.await(
-      Result.tryPromise(async () => await readWorkflowHandler(workspaceId)),
+      Result.tryPromise(
+        async () =>
+          await readWorkflowHandler({
+            organizationId: session.activeOrganizationId,
+            scopedDb,
+            workspaceId,
+          }),
+      ),
     );
 
     return Result.ok(response);

--- a/apps/api/src/lib/extraction-runs/store.test.ts
+++ b/apps/api/src/lib/extraction-runs/store.test.ts
@@ -258,7 +258,7 @@ describe("extraction run store contract", () => {
     });
   });
 
-  test("requires both workspace and organization scope for app-role writes", async () => {
+  test("allows tenant-scoped reads but denies app-role history writes", async () => {
     const policyResult = await testDb.execute<{
       cmd: string;
       policyName: string;
@@ -273,26 +273,40 @@ describe("extraction run store contract", () => {
       FROM pg_catalog.pg_policies
       WHERE tablename = 'extraction_runs'
     `);
-    expect(policyResult.rows).toHaveLength(4);
-    for (const policy of policyResult.rows) {
-      const expression =
-        policy.cmd === "INSERT"
-          ? policy.withCheckExpression
-          : policy.usingExpression;
-      expect(expression).toContain("organization_id");
-      expect(expression).toContain("app.organization_id");
-      expect(expression).toContain("workspace_id");
-    }
-
     const scopedDb = asTestRaw<ScopedDb>(
       createScopedDb(testDb, [workspaceId], organizationId, userId),
     );
+    const existing = await createRun();
+    const visible = await scopedDb((tx) =>
+      tx
+        .select({ id: extractionRuns.id })
+        .from(extractionRuns)
+        .where(eq(extractionRuns.id, existing.id)),
+    );
+    expect(visible).toEqual([{ id: existing.id }]);
+
+    expect(policyResult.rows).toHaveLength(4);
+    const selectPolicy = policyResult.rows.find(
+      (policy) => policy.cmd === "SELECT",
+    );
+    expect(selectPolicy?.usingExpression).toContain("organization_id");
+    expect(selectPolicy?.usingExpression).toContain("app.organization_id");
+    expect(selectPolicy?.usingExpression).toContain("workspace_id");
+    for (const command of ["INSERT", "UPDATE", "DELETE"]) {
+      const policy = policyResult.rows.find((row) => row.cmd === command);
+      expect(
+        command === "INSERT"
+          ? policy?.withCheckExpression
+          : policy?.usingExpression,
+      ).toBe("false");
+    }
+
     const runId = createSafeId<"extractionRun">();
 
     const rejection: unknown = await scopedDb(async (tx) => {
       await tx.insert(extractionRuns).values({
         id: runId,
-        organizationId: otherOrganizationId,
+        organizationId,
         workspaceId,
         requestedBy: userId,
         scope: "workspace",

--- a/apps/api/src/tests/security/rls-coverage.test.ts
+++ b/apps/api/src/tests/security/rls-coverage.test.ts
@@ -80,6 +80,9 @@ describe("policy coverage", () => {
     "usage_entitlements",
     "usage_allocations",
     "usage_events",
+    // Root-owned lifecycle history is tenant-readable but app-role immutable;
+    // its dedicated assertion below covers the restrictive write policies.
+    "extraction_runs",
     // Control-plane auth table: same trust tier as oauth_client /
     // agent_registration. It carries organization_id/user_id columns but is
     // not tenant-scoped — it has a deny-all RLS policy plus REVOKE ALL from
@@ -306,6 +309,35 @@ describe("policy coverage", () => {
       const denyPolicy = denyPolicies.at(0);
       expect(denyPolicy?.permissive).toBe(false);
       expect(denyPolicy?.using_expr).toBe("false");
+    }
+  });
+
+  test("extraction run history is read-only for stella", async () => {
+    const policies = await fetchStellaPolicies(testDb);
+    const runPolicies = policies.filter(
+      (policy) => policy.table_name === "extraction_runs",
+    );
+    const selectPolicy = runPolicies.find(
+      (policy) => policy.policy_name === "extraction_runs_workspace_select",
+    );
+
+    expect(selectPolicy?.command).toBe("r");
+    expect(selectPolicy?.using_expr).toContain("workspace_id");
+    expect(selectPolicy?.using_expr).toContain(SETTING_WORKSPACE_IDS);
+    expect(selectPolicy?.using_expr).toContain("organization_id");
+    expect(selectPolicy?.using_expr).toContain(SETTING_ORGANIZATION_ID);
+
+    for (const [policyName, command, expression] of [
+      ["extraction_runs_no_insert", "a", "check_expr"],
+      ["extraction_runs_no_update", "w", "using_expr"],
+      ["extraction_runs_no_delete", "d", "using_expr"],
+    ] as const) {
+      const denyPolicy = runPolicies.find(
+        (policy) => policy.policy_name === policyName,
+      );
+      expect(denyPolicy?.command).toBe(command);
+      expect(denyPolicy?.permissive).toBe(false);
+      expect(denyPolicy?.[expression]).toBe("false");
     }
   });
 

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/extraction-run-progress.logic.test.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/extraction-run-progress.logic.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "bun:test";
+
+import { hasActiveExtractionProgress } from "./extraction-run-progress.logic";
+
+describe("extraction run progress", () => {
+  test.each(["planning", "running", "finalizing"])(
+    "shows counters for an active %s run",
+    (status) => {
+      expect(hasActiveExtractionProgress({ status, total: 2 })).toBe(true);
+    },
+  );
+
+  test.each(["completed", "failed", "skipped"])(
+    "does not reuse counters from a historical %s run",
+    (status) => {
+      expect(hasActiveExtractionProgress({ status, total: 2 })).toBe(false);
+    },
+  );
+
+  test("uses the loading state when the durable row or total is unavailable", () => {
+    expect(hasActiveExtractionProgress(null)).toBe(false);
+    expect(hasActiveExtractionProgress({ status: "running", total: 0 })).toBe(
+      false,
+    );
+  });
+});

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/extraction-run-progress.logic.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/extraction-run-progress.logic.ts
@@ -1,0 +1,13 @@
+type ExtractionRunProgressState = {
+  status: string;
+  total: number;
+};
+
+export const hasActiveExtractionProgress = (
+  run: ExtractionRunProgressState | null,
+): run is ExtractionRunProgressState =>
+  run !== null &&
+  run.total > 0 &&
+  (run.status === "planning" ||
+    run.status === "running" ||
+    run.status === "finalizing");

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/extraction-run-progress.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/extraction-run-progress.tsx
@@ -3,6 +3,8 @@ import { useTranslations } from "use-intl";
 
 import { useWorkflowStatus } from "@/routes/_protected.workspaces/$workspaceId/-queries/workspace";
 
+import { hasActiveExtractionProgress } from "./extraction-run-progress.logic";
+
 type ExtractionRunProgressProps = {
   workspaceId: string;
 };
@@ -17,7 +19,7 @@ export const ExtractionRunProgress = ({
   }
 
   const run = data.run;
-  const hasProgress = run !== null && run.total > 0;
+  const hasProgress = hasActiveExtractionProgress(run);
 
   return (
     <div

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/extraction-run-progress.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/extraction-run-progress.tsx
@@ -1,0 +1,43 @@
+import { LoaderCircleIcon, SparklesIcon } from "lucide-react";
+import { useTranslations } from "use-intl";
+
+import { useWorkflowStatus } from "@/routes/_protected.workspaces/$workspaceId/-queries/workspace";
+
+type ExtractionRunProgressProps = {
+  workspaceId: string;
+};
+
+export const ExtractionRunProgress = ({
+  workspaceId,
+}: ExtractionRunProgressProps) => {
+  const t = useTranslations();
+  const { data } = useWorkflowStatus(workspaceId);
+  if (!data?.running) {
+    return null;
+  }
+
+  const run = data.run;
+  const hasProgress = run !== null && run.total > 0;
+
+  return (
+    <div
+      aria-label={
+        hasProgress
+          ? `${t("common.loading")} ${run.completed} / ${run.total}`
+          : t("common.loading")
+      }
+      className="bg-muted text-muted-foreground flex h-7 shrink-0 items-center gap-1.5 rounded-md px-2 text-xs tabular-nums"
+      role="status"
+    >
+      {run?.status === "finalizing" ? (
+        <SparklesIcon aria-hidden="true" className="size-3.5" />
+      ) : (
+        <LoaderCircleIcon
+          aria-hidden="true"
+          className="size-3.5 animate-spin"
+        />
+      )}
+      {hasProgress ? `${run.completed} / ${run.total}` : t("common.loading")}
+    </div>
+  );
+};

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-toolbar.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-toolbar.tsx
@@ -68,6 +68,7 @@ import {
 } from "@/routes/_protected.knowledge/-queries";
 import { BulkAddColumns } from "@/routes/_protected.workspaces/$workspaceId/-components/bulk-add-columns";
 import { ExistingFileOrganizerDialog } from "@/routes/_protected.workspaces/$workspaceId/-components/existing-file-organizer-dialog";
+import { ExtractionRunProgress } from "@/routes/_protected.workspaces/$workspaceId/-components/extraction-run-progress";
 import { isGroupableProperty } from "@/routes/_protected.workspaces/$workspaceId/-components/kanban/kanban-view.logic";
 import { PropertyIcon } from "@/routes/_protected.workspaces/$workspaceId/-components/property-helpers";
 import { RowActions } from "@/routes/_protected.workspaces/$workspaceId/-components/row-actions";
@@ -126,6 +127,8 @@ export const ViewToolbar = ({ view, workspaceId }: ViewToolbarProps) => {
 
   return (
     <div className="flex min-w-0 shrink-0 [scrollbar-width:none] flex-nowrap items-center gap-1 overflow-x-auto px-2 py-1 [-ms-overflow-style:none] md:ms-auto md:flex-wrap md:justify-end md:overflow-visible [&::-webkit-scrollbar]:hidden">
+      <ExtractionRunProgress workspaceId={workspaceId} />
+
       {view.layout.type === "filesystem" && folderState.hasFolders && (
         <>
           <FolderExpandToggle

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/workspace.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/workspace.ts
@@ -42,7 +42,8 @@ type WorkflowKey = { workspaceId: string };
 type WorkflowTargetCountOptionsInput =
   QueryOptionsInput<WorkflowTargetCountKey>;
 
-const WORKFLOW_DEFAULT_STATUS = { running: false } as const;
+const WORKFLOW_DEFAULT_STATUS = { run: null, running: false } as const;
+const WORKFLOW_STATUS_POLL_INTERVAL_MS = 2000;
 
 export const workflowOptions = ({ key }: { key: WorkflowKey }) =>
   queryOptions({
@@ -119,6 +120,13 @@ export const useIsWorkflowRunning = (inputWorkspaceId?: string) => {
 
   return data ?? false;
 };
+
+export const useWorkflowStatus = (workspaceId: string) =>
+  useQuery({
+    ...workflowOptions({ key: { workspaceId } }),
+    refetchInterval: (query) =>
+      query.state.data?.running ? WORKFLOW_STATUS_POLL_INTERVAL_MS : false,
+  });
 
 type JustificationsOptionsInput = QueryOptionsInput<JustificationsKey>;
 

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/workspace.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/workspace.ts
@@ -42,7 +42,6 @@ type WorkflowKey = { workspaceId: string };
 type WorkflowTargetCountOptionsInput =
   QueryOptionsInput<WorkflowTargetCountKey>;
 
-const WORKFLOW_DEFAULT_STATUS = { run: null, running: false } as const;
 const WORKFLOW_STATUS_POLL_INTERVAL_MS = 2000;
 
 export const workflowOptions = ({ key }: { key: WorkflowKey }) =>
@@ -53,13 +52,7 @@ export const workflowOptions = ({ key }: { key: WorkflowKey }) =>
         .workspaces({ workspaceId: toSafeId<"workspace">(key.workspaceId) })
         .workflow.get({ fetch: { signal } });
 
-      if (response.error) {
-        // Workflow actor may be unavailable (cold start, timeout).
-        // Return safe default instead of crashing the page.
-        return WORKFLOW_DEFAULT_STATUS;
-      }
-
-      return response.data;
+      return unwrapEden(response);
     },
   });
 


### PR DESCRIPTION
## Summary

- extend the existing workflow-status response without breaking its `running` compatibility field
- return the newest tenant-scoped extraction run with status, scope, execution version, timestamps, error code, and absolute progress
- show `completed / total` in the workspace toolbar while extraction is active
- poll one shared query every two seconds only while Redis reports an active run; terminal state stops polling

## Stack

Depends on #1340, which introduces the durable `extraction_runs` ledger and orchestration writes. Review this PR as the read-model/UI slice; its GitHub base is `codex/durable-workflow-runs`, so the diff contains only this behavior.

## Verification

- `bun --filter @stll/api typecheck`
- `bun --smol test --preload ./src/tests/setup-env.ts src/handlers/workspaces/read-workflow-status.integration.test.ts` (3 passing under real scoped RLS)
- changed-file oxfmt and type-aware oxlint
- full pre-commit and pre-push format/lint/i18n/typecheck hooks, including API, web, and E2E TypeScript projects
- GitHub build, lint, typecheck, baseline, and test lanes passed on the previous stack head
- the unrelated Template Studio E2E failure passed on a single retry with no code change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an extraction-run progress indicator to the workspace toolbar.
  - Shows loading/finalising messaging, and displays completed/total counts when progress is active.
  - Workflow status now includes the latest extraction run details and refreshes automatically while running.
- **Bug Fixes**
  - Improved workflow status scoping to ensure correct tenant/organisation behaviour.
  - Enforced read-only access for extraction-run history while keeping permitted reads.
- **Tests**
  - Expanded integration and logic tests for workflow status, progress detection, and read-only access controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->