### PR TITLE
fix(auth): stop stale-session 403 from crashing the account page

### DIFF
--- a/apps/api/src/lib/auth.test.ts
+++ b/apps/api/src/lib/auth.test.ts
@@ -412,4 +412,12 @@ describe("session freshness", () => {
     // `freshAge` comment in auth.ts. If this fails, the footgun is back.
     expect(getAuth().options.session.freshAge).toBe(0);
   });
+
+  test("the other freshness-gated endpoint (unlink-account) stays disabled", () => {
+    // `freshAge: 0` is only safe because the one other freshness-gated endpoint
+    // Better Auth mounts, `/unlink-account`, is not a Stella feature and is
+    // disabled. If it were re-exposed, relaxing freshAge would let an old
+    // session unlink a provider. Keep these two decisions coupled.
+    expect(getAuth().options.disabledPaths).toContain("/unlink-account");
+  });
 });

--- a/apps/api/src/lib/auth.test.ts
+++ b/apps/api/src/lib/auth.test.ts
@@ -11,6 +11,7 @@ import {
 import { member, organization, user } from "@/api/db/auth-schema";
 import { contacts, workspaceMembers, workspaces } from "@/api/db/schema";
 import {
+  getAuth,
   isSixDigitOtpBody,
   isTwoFactorRedirectResponse,
   resolveMemberAuthorization,
@@ -398,5 +399,17 @@ describe("isSixDigitOtpBody", () => {
     expect(isSixDigitOtpBody({ otp: "12345" })).toBe(false);
     expect(isSixDigitOtpBody({ otp: "1234567" })).toBe(false);
     expect(isSixDigitOtpBody({ otp: "12a456" })).toBe(false);
+  });
+});
+
+describe("session freshness", () => {
+  test("freshAge stays disabled so day-old sessions can read list-sessions", () => {
+    // Better Auth defaults `freshAge` to 1 day and gates `list-sessions` (the
+    // account page's active-sessions read) against `session.createdAt`, which
+    // `updateAge` never refreshes — so any login older than a day would 403 and
+    // blank the profile page. It must stay 0; genuinely sensitive flows are
+    // gated by Stella's own OTP/two-factor, not this global knob. See the
+    // `freshAge` comment in auth.ts. If this fails, the footgun is back.
+    expect(getAuth().options.session?.freshAge).toBe(0);
   });
 });

--- a/apps/api/src/lib/auth.test.ts
+++ b/apps/api/src/lib/auth.test.ts
@@ -410,6 +410,6 @@ describe("session freshness", () => {
     // blank the profile page. It must stay 0; genuinely sensitive flows are
     // gated by Stella's own OTP/two-factor, not this global knob. See the
     // `freshAge` comment in auth.ts. If this fails, the footgun is back.
-    expect(getAuth().options.session?.freshAge).toBe(0);
+    expect(getAuth().options.session.freshAge).toBe(0);
   });
 });

--- a/apps/api/src/lib/auth.ts
+++ b/apps/api/src/lib/auth.ts
@@ -549,6 +549,18 @@ const createAuth = () => {
       expiresIn: SESSION_LIFETIME_SECONDS,
       updateAge: SESSION_UPDATE_AGE_SECONDS,
       storeSessionInDatabase: true,
+      // Disable Better Auth's session-freshness gate. It defaults to 1 day
+      // (`create-context.mjs`: `freshAge ?? 3600 * 24`) and compares against
+      // `session.createdAt`, which `updateAge` never refreshes — so every
+      // session older than a day fails it. The only freshness-gated endpoint
+      // Stella actually exposes is `list-sessions` (a read: viewing your own
+      // active sessions), which the account page loads eagerly; the gate turned
+      // that into a 403 for any day-old login and crashed the page. Genuinely
+      // sensitive flows are gated by Stella's own controls (OTP-verified
+      // account deletion, TOTP two-factor), not by this global freshness knob,
+      // so `0` removes the footgun without weakening anything real. Guarded by
+      // the freshAge invariant in `auth.test.ts`.
+      freshAge: 0,
     },
     advanced: {
       ...(authCookiePrefix ? { cookiePrefix: authCookiePrefix } : {}),

--- a/apps/api/src/lib/auth.ts
+++ b/apps/api/src/lib/auth.ts
@@ -527,6 +527,14 @@ const createAuth = () => {
       "/api-key/delete",
       "/api-key/get",
       "/api-key/list",
+      // Account unlinking is not a Stella feature: there is no UI and no
+      // server-side `auth.api.unlinkAccount` caller. Better Auth still mounts
+      // `/unlink-account` and protects it with `freshSessionMiddleware`, so
+      // once `session.freshAge` is 0 (below) that freshness no longer applies.
+      // Rather than let an unused, state-changing endpoint stay reachable with
+      // weaker protection, disable the path outright — removing the surface is
+      // strictly stronger than the freshness it used to carry.
+      "/unlink-account",
     ],
     user: {
       additionalFields: {
@@ -552,14 +560,17 @@ const createAuth = () => {
       // Disable Better Auth's session-freshness gate. It defaults to 1 day
       // (`create-context.mjs`: `freshAge ?? 3600 * 24`) and compares against
       // `session.createdAt`, which `updateAge` never refreshes — so every
-      // session older than a day fails it. The only freshness-gated endpoint
-      // Stella actually exposes is `list-sessions` (a read: viewing your own
-      // active sessions), which the account page loads eagerly; the gate turned
-      // that into a 403 for any day-old login and crashed the page. Genuinely
-      // sensitive flows are gated by Stella's own controls (OTP-verified
-      // account deletion, TOTP two-factor), not by this global freshness knob,
-      // so `0` removes the footgun without weakening anything real. Guarded by
-      // the freshAge invariant in `auth.test.ts`.
+      // session older than a day fails it. Two endpoints use it: `list-sessions`
+      // and `unlink-account`. `list-sessions` is a read (viewing your own active
+      // sessions) that the account page loads eagerly, so the gate turned it
+      // into a 403 for any day-old login and crashed the page; and revoking a
+      // session — the actual sensitive action — is not freshness-gated anyway,
+      // so gating only the read made no sense. `unlink-account` is unused and is
+      // disabled in `disabledPaths` above, so nothing reachable relies on this
+      // knob. Genuinely sensitive flows use Stella's own controls (OTP-verified
+      // account deletion, TOTP two-factor). `0` removes the footgun without
+      // weakening anything real. Guarded by the freshAge invariant in
+      // `auth.test.ts`.
       freshAge: 0,
     },
     advanced: {

--- a/apps/web/src/routes/_protected.settings/-components/account/sessions-card.tsx
+++ b/apps/web/src/routes/_protected.settings/-components/account/sessions-card.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import type { PropsWithChildren } from "react";
 
 import {
   useMutation,
@@ -24,6 +25,7 @@ import {
   FramePanel,
   FrameTitle,
 } from "@stll/ui/components/frame";
+import { Skeleton } from "@stll/ui/components/skeleton";
 import {
   Table,
   TableBody,
@@ -34,6 +36,7 @@ import {
 } from "@stll/ui/components/table";
 import { stellaToast } from "@stll/ui/components/toast";
 
+import { QuerySuspenseBoundary } from "@/components/query-suspense-boundary";
 import { useAnalytics } from "@/lib/analytics/provider";
 import { authClient, revokeAuthSession } from "@/lib/auth";
 import type { SessionRevocationToken } from "@/lib/auth";
@@ -49,7 +52,65 @@ import {
 
 const MISSING_VALUE = "-";
 
-export const SessionsCard = () => {
+// Contain this card's data dependency behind its own boundary. It suspends on
+// `list-sessions`, a secondary read that is independent of the rest of the
+// account page; without this, any failure of that one query (an auth error, a
+// rate-limit hit, a network blip) would propagate to the route's error boundary
+// and blank the entire profile page instead of just this card.
+export const SessionsCard = () => (
+  <QuerySuspenseBoundary
+    area="account.sessions"
+    errorFallback={({ reset }) => <SessionsCardError onRetry={reset} />}
+    suspenseFallback={<SessionsCardSkeleton />}
+  >
+    <SessionsCardContent />
+  </QuerySuspenseBoundary>
+);
+
+const SessionsCardFrame = ({ children }: PropsWithChildren) => {
+  const t = useTranslations();
+  return (
+    <Frame>
+      <FrameHeader>
+        <FrameTitle>{t("common.sessions")}</FrameTitle>
+      </FrameHeader>
+      {children}
+    </Frame>
+  );
+};
+
+const SessionsCardSkeleton = () => (
+  <SessionsCardFrame>
+    <FramePanel className="flex flex-col gap-3 p-4">
+      {["a", "b", "c"].map((key) => (
+        <div className="flex items-center justify-between gap-4" key={key}>
+          <Skeleton className="h-4 w-40" />
+          <Skeleton className="h-4 w-24" />
+          <Skeleton className="h-4 w-20" />
+          <Skeleton className="h-5 w-16 rounded-md" />
+        </div>
+      ))}
+    </FramePanel>
+  </SessionsCardFrame>
+);
+
+const SessionsCardError = ({ onRetry }: { onRetry: () => void }) => {
+  const t = useTranslations();
+  return (
+    <SessionsCardFrame>
+      <FramePanel className="flex flex-col items-start gap-3 p-4">
+        <p className="text-muted-foreground text-sm">
+          {t("common.somethingWentWrong")}
+        </p>
+        <Button onClick={onRetry} size="sm" variant="outline">
+          {t("common.retry")}
+        </Button>
+      </FramePanel>
+    </SessionsCardFrame>
+  );
+};
+
+const SessionsCardContent = () => {
   const t = useTranslations();
   const [{ data: sessions }, { data: currentSession }] = useSuspenseQueries({
     queries: [sessionsOptions, sessionOptions],


### PR DESCRIPTION
## What

Fixes a 0.6.0 regression: the account **Profile** page (`/settings/account/profile`) shows "Something went wrong" for any session older than ~1 day.

## Root cause

Better Auth's `/list-sessions` endpoint is gated by `freshSessionMiddleware`, which 403s (`SESSION_NOT_FRESH`) when `session.createdAt` is older than `session.freshAge`. `freshAge` defaults to **1 day** (`create-context.mjs`: `freshAge ?? 3600 * 24`) and is compared against `createdAt`, which `updateAge` never refreshes. Stella never set `freshAge`, so every session whose *login* was more than a day ago got a 403.

`SessionsCard` loads `list-sessions` via `useSuspenseQueries`, so that 403 threw up to the route error boundary and blanked the whole page. Unauthenticated requests correctly return 401; only aged-but-valid sessions hit the 403, which is why it looked session-specific.

## Fix

1. **`session.freshAge: 0`** (`apps/api/src/lib/auth.ts`). `list-sessions` is the only freshness-gated endpoint Stella exposes — `change-email`, `unlink-account`, and Better Auth's own `delete-user` are unused, and account deletion / two-factor are gated by Stella's own OTP. Notably `revoke-session` (the actual sensitive action) uses `sensitiveSessionMiddleware`, **not** freshness — so gating only the *read* was inconsistent. Disabling freshness removes the footgun with no real security change.

2. **Backend invariant test** (`auth.test.ts`) asserting `freshAge === 0`, so the Better Auth default can't silently return.

3. **Frontend containment** (`sessions-card.tsx`): wrap the card's data dependency in its own `QuerySuspenseBoundary` so any failure (auth, rate-limit, network) degrades to a card-level error with retry instead of blanking the page. Built into the card, so it holds for every consumer — this closes the broader class "a secondary card's query failure crashes the route".

## Follow-up (not in this PR)

Logs show *"Better Auth can't determine client IP → single shared rate-limit bucket"*: all auth paths share one global bucket across users, so `list-sessions` can 429 under light load. Fix is `advanced.ipAddress.trustedProxies` / `ipAddressHeaders` for the ALB's `X-Forwarded-For`. Left out here (proxy-trust config needs its own verification); the frontend boundary above now contains any 429 from it regardless.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Session management now remains accessible for older active sessions, preventing unnecessary session-age restrictions.
  * Improved reliability when loading account sessions.

* **User Experience**
  * Added a clear loading state while session details are retrieved.
  * Added an error state with a retry option if session loading fails.
  * Preserved the existing sessions card layout and presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->