### PR TITLE
fix: render changelog prose as paragraphs

### DIFF
--- a/apps/landing/src/lib/changelog-markdown.test.ts
+++ b/apps/landing/src/lib/changelog-markdown.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "bun:test";
+
+import { parseChangelogMarkdown } from "./changelog-markdown";
+
+describe("changelog Markdown paragraphs", () => {
+  test("treats consecutive source lines as one prose paragraph", () => {
+    expect(
+      parseChangelogMarkdown(
+        [
+          "This builds on our vision that everything in stella is controllable by humans",
+          "and machines alike, as we blend the two in legal work.",
+          "",
+          "Document review now includes exact-passage citation highlights.",
+        ].join("\n"),
+      ),
+    ).toEqual([
+      {
+        text: "This builds on our vision that everything in stella is controllable by humans and machines alike, as we blend the two in legal work.",
+        type: "paragraph",
+      },
+      {
+        text: "Document review now includes exact-passage citation highlights.",
+        type: "paragraph",
+      },
+    ]);
+  });
+
+  test("keeps prose separate from headings, lists, and videos", () => {
+    expect(
+      parseChangelogMarkdown(
+        [
+          "# Release title",
+          "A summary wrapped",
+          "across two lines.",
+          "- First change",
+          "- Second change",
+          '<video controls src="https://example.com/demo.mp4"></video>',
+        ].join("\n"),
+      ),
+    ).toEqual([
+      { level: 1, text: "Release title", type: "heading" },
+      { text: "A summary wrapped across two lines.", type: "paragraph" },
+      { items: ["First change", "Second change"], type: "list" },
+      { src: "https://example.com/demo.mp4", type: "video" },
+    ]);
+  });
+});

--- a/apps/landing/src/lib/changelog-markdown.ts
+++ b/apps/landing/src/lib/changelog-markdown.ts
@@ -1,0 +1,90 @@
+export type ChangelogMarkdownBlock =
+  | { level: 1 | 2 | 3; text: string; type: "heading" }
+  | { items: string[]; type: "list" }
+  | { text: string; type: "paragraph" }
+  | { src: string; type: "video" };
+
+const HTML_VIDEO_PATTERN =
+  /^<video\b[^>]*\bsrc=["']([^"']+)["'][^>]*><\/video>$/iu;
+const MARKDOWN_VIDEO_PATTERN = /^!\[[^\]]*\]\((https:\/\/[^)\s]+)\)$/u;
+
+const parseHeading = (line: string) => {
+  if (line.startsWith("### ")) {
+    return { level: 3 as const, text: line.slice(4) };
+  }
+  if (line.startsWith("## ")) {
+    return { level: 2 as const, text: line.slice(3) };
+  }
+  if (line.startsWith("# ")) {
+    return { level: 1 as const, text: line.slice(2) };
+  }
+  return null;
+};
+
+export const parseChangelogMarkdown = (body: string) => {
+  const blocks: ChangelogMarkdownBlock[] = [];
+  let paragraphLines: string[] = [];
+  let listItems: string[] = [];
+
+  const closeParagraph = () => {
+    if (paragraphLines.length === 0) {
+      return;
+    }
+
+    blocks.push({ text: paragraphLines.join(" "), type: "paragraph" });
+    paragraphLines = [];
+  };
+
+  const closeList = () => {
+    if (listItems.length === 0) {
+      return;
+    }
+
+    blocks.push({ items: listItems, type: "list" });
+    listItems = [];
+  };
+
+  for (const rawLine of body.split("\n")) {
+    const line = rawLine.trim();
+    if (!line) {
+      closeParagraph();
+      closeList();
+      continue;
+    }
+
+    const htmlVideoSrc = HTML_VIDEO_PATTERN.exec(line)?.[1];
+    const markdownVideoSrc = MARKDOWN_VIDEO_PATTERN.exec(line)?.[1];
+    const videoSrc = htmlVideoSrc ?? markdownVideoSrc;
+    if (videoSrc) {
+      closeParagraph();
+      closeList();
+      blocks.push({ src: videoSrc, type: "video" });
+      continue;
+    }
+
+    const heading = parseHeading(line);
+    if (heading) {
+      closeParagraph();
+      closeList();
+      blocks.push({
+        level: heading.level,
+        text: heading.text,
+        type: "heading",
+      });
+      continue;
+    }
+
+    if (line.startsWith("- ")) {
+      closeParagraph();
+      listItems.push(line.slice(2));
+      continue;
+    }
+
+    closeList();
+    paragraphLines.push(line);
+  }
+
+  closeParagraph();
+  closeList();
+  return blocks;
+};

--- a/apps/landing/src/pages/changelog.astro
+++ b/apps/landing/src/pages/changelog.astro
@@ -294,6 +294,8 @@ const previewReleaseSlugs = getChangelogReleases().map((release) => release.slug
   </style>
 
   <script>
+    import { parseChangelogMarkdown } from "../lib/changelog-markdown";
+
     type GitHubRelease = {
       body: string | null;
       draft: boolean;
@@ -453,30 +455,10 @@ const previewReleaseSlugs = getChangelogReleases().map((release) => release.slug
 
     const renderMarkdownFragment = (body: string) => {
       const fragment = document.createDocumentFragment();
-      let currentList: HTMLUListElement | null = null;
 
-      const closeList = () => {
-        if (currentList) {
-          fragment.append(currentList);
-          currentList = null;
-        }
-      };
-
-      for (const rawLine of body.split("\n")) {
-        const line = rawLine.trim();
-        if (!line) {
-          closeList();
-          continue;
-        }
-
-        const htmlVideoSrc = line.match(
-          /^<video\b[^>]*\bsrc=["']([^"']+)["'][^>]*><\/video>$/iu,
-        )?.[1];
-        const markdownVideoSrc = line.match(/^!\[[^\]]*\]\((https:\/\/[^)\s]+)\)$/u)?.[1];
-        const videoSrc = htmlVideoSrc ?? markdownVideoSrc;
-        if (videoSrc) {
-          closeList();
-          const safeSrc = safeHttpsUrl(videoSrc);
+      for (const block of parseChangelogMarkdown(body)) {
+        if (block.type === "video") {
+          const safeSrc = safeHttpsUrl(block.src);
           if (!safeSrc) {continue;}
 
           const video = document.createElement("video");
@@ -487,47 +469,29 @@ const previewReleaseSlugs = getChangelogReleases().map((release) => release.slug
           continue;
         }
 
-        if (line.startsWith("# ")) {
-          closeList();
-          const heading = document.createElement("h2");
-          heading.textContent = line.slice(2);
+        if (block.type === "heading") {
+          const heading = document.createElement(block.level === 1 ? "h2" : "h3");
+          heading.textContent = block.text;
           fragment.append(heading);
           continue;
         }
 
-        if (line.startsWith("## ")) {
-          closeList();
-          const heading = document.createElement("h3");
-          heading.textContent = line.slice(3);
-          fragment.append(heading);
-          continue;
-        }
-
-        if (line.startsWith("### ")) {
-          closeList();
-          const heading = document.createElement("h3");
-          heading.textContent = line.slice(4);
-          fragment.append(heading);
-          continue;
-        }
-
-        if (line.startsWith("- ")) {
-          if (!currentList) {
-            currentList = document.createElement("ul");
+        if (block.type === "list") {
+          const list = document.createElement("ul");
+          for (const text of block.items) {
+            const item = document.createElement("li");
+            appendTextWithInlineMarkdown(item, text);
+            list.append(item);
           }
-          const item = document.createElement("li");
-          appendTextWithInlineMarkdown(item, line.slice(2));
-          currentList.append(item);
+          fragment.append(list);
           continue;
         }
 
-        closeList();
         const paragraph = document.createElement("p");
-        appendTextWithInlineMarkdown(paragraph, line);
+        appendTextWithInlineMarkdown(paragraph, block.text);
         fragment.append(paragraph);
       }
 
-      closeList();
       return fragment;
     };
 

--- a/apps/landing/tsconfig.json
+++ b/apps/landing/tsconfig.json
@@ -4,6 +4,7 @@
   "exclude": ["dist"],
   "compilerOptions": {
     "jsx": "react-jsx",
-    "jsxImportSource": "react"
+    "jsxImportSource": "react",
+    "types": ["bun"]
   }
 }


### PR DESCRIPTION
## Summary

Join soft-wrapped changelog source lines into prose paragraphs while preserving blank-line boundaries, headings, lists, and video blocks.

Extract the Markdown block parser into tested logic so source formatting cannot leak into the rendered release layout again.