### PR TITLE
fix(playbooks): preserve complete review verdicts

### DIFF
--- a/apps/api/src/handlers/playbooks/review.test.ts
+++ b/apps/api/src/handlers/playbooks/review.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, mock, test } from "bun:test";
+
+import type { ReviewFinding } from "@/api/handlers/playbooks/review-grade";
+import type { AuditRecorder } from "@/api/lib/audit-log";
+import { toSafeId } from "@/api/lib/branded-types";
+import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
+import { createScopedDbMock } from "@/api/tests/scoped-db-mock";
+
+const findings: ReviewFinding[] = [
+  {
+    positionId: "compliant",
+    issue: "Compliant position",
+    severity: "low",
+    verdict: "compliant",
+    extracted: null,
+    rationale: null,
+    citations: [],
+    fix: null,
+  },
+  {
+    positionId: "fallback",
+    issue: "Fallback position",
+    severity: "medium",
+    verdict: "fallback",
+    extracted: null,
+    rationale: null,
+    citations: [],
+    fix: null,
+  },
+  {
+    positionId: "deviation",
+    issue: "Deviating position",
+    severity: "high",
+    verdict: "deviation",
+    extracted: null,
+    rationale: null,
+    citations: [],
+    fix: null,
+  },
+  {
+    positionId: "missing",
+    issue: "Missing position",
+    severity: "blocker",
+    verdict: "missing",
+    extracted: null,
+    rationale: null,
+    citations: [],
+    fix: null,
+  },
+  {
+    positionId: "extract",
+    issue: "Extract-only position",
+    severity: "low",
+    verdict: null,
+    extracted: { text: "30 days", value: "30 days" },
+    rationale: null,
+    citations: [],
+    fix: null,
+  },
+];
+
+const buildFindingsMock = mock(async () => findings);
+
+void mock.module("@/api/handlers/playbooks/review-grade", () => ({
+  buildFindings: buildFindingsMock,
+}));
+
+// The handler performs its normal provider-availability preflight before it
+// reaches the mocked grading boundary. Supply inert instance credentials so
+// the test exercises the review response contract without a live AI call.
+process.env["AI_PROVIDER"] = "google";
+process.env["GOOGLE_GENERATIVE_AI_API_KEY"] = "test";
+
+const { default: reviewPlaybook } =
+  await import("@/api/handlers/playbooks/review");
+
+type ReviewContext = Parameters<typeof reviewPlaybook.handler>[0];
+
+const organizationId = toSafeId<"organization">(
+  "00000000-0000-0000-0000-000000000001",
+);
+const workspaceId = toSafeId<"workspace">(
+  "00000000-0000-0000-0000-000000000002",
+);
+const userId = toSafeId<"user">("00000000-0000-0000-0000-000000000003");
+const playbookId = toSafeId<"playbookDefinition">(
+  "00000000-0000-0000-0000-000000000004",
+);
+const entityId = toSafeId<"entity">("00000000-0000-0000-0000-000000000005");
+const entityVersionId = toSafeId<"entityVersion">(
+  "00000000-0000-0000-0000-000000000006",
+);
+const fileFieldId = toSafeId<"field">("00000000-0000-0000-0000-000000000007");
+
+describe("single-document playbook review", () => {
+  test("returns every review result so the client can compute complete totals", async () => {
+    let auditedReview: unknown;
+    const recordAuditEvent: AuditRecorder = async (_tx, event) => {
+      const auditEvent = Array.isArray(event) ? event.at(0) : event;
+      auditedReview = auditEvent?.changes?.["review"]?.new;
+    };
+    const { safeDb, scopedDb } = createScopedDbMock({
+      query: {
+        playbookDefinitions: {
+          findFirst: async () => ({
+            scope: null,
+            positions: {
+              version: 2 as const,
+              items: [
+                {
+                  mode: "extract" as const,
+                  sourceId: "00000000-0000-0000-0000-000000000008",
+                  issue: "Manual review",
+                  ask: {
+                    question: "",
+                    content: { version: 1 as const, type: "text" as const },
+                  },
+                  enabled: true,
+                },
+              ],
+            },
+          }),
+        },
+        entities: {
+          findFirst: async () => ({
+            id: entityId,
+            currentVersion: {
+              id: entityVersionId,
+              fields: [
+                {
+                  id: fileFieldId,
+                  propertyId: toSafeId<"property">(
+                    "00000000-0000-0000-0000-000000000009",
+                  ),
+                  content: {
+                    version: 1 as const,
+                    type: "file" as const,
+                    id: "00000000-0000-0000-0000-000000000010",
+                    fileName: "contract.pdf",
+                    mimeType: "application/pdf",
+                    sizeBytes: 1024,
+                    encrypted: false,
+                    sha256Hex: "a".repeat(64),
+                    pdfFileId: null,
+                  },
+                },
+              ],
+            },
+          }),
+        },
+      },
+    });
+
+    const result = await reviewPlaybook.handler(
+      asTestRaw<ReviewContext>({
+        body: { entityId, fileFieldId },
+        createAuditRecorder: () => recordAuditEvent,
+        memberRole: { role: "owner" },
+        orgAIConfig: null,
+        params: { playbookId, workspaceId },
+        promptCachingEnabled: false,
+        recordAuditEvent,
+        request: new Request(
+          `https://example.test/workspaces/${workspaceId}/playbooks/${playbookId}/review`,
+        ),
+        route: "/workspaces/:workspaceId/playbooks/:playbookId/review",
+        safeDb,
+        scopedDb,
+        session: { activeOrganizationId: organizationId },
+        user: { id: userId },
+        workspaceId,
+      }),
+    );
+
+    expect(result).toEqual(findings);
+    expect(auditedReview).toEqual({
+      documentId: entityId,
+      findingCount: findings.length,
+    });
+  });
+});

--- a/apps/api/src/handlers/playbooks/review.ts
+++ b/apps/api/src/handlers/playbooks/review.ts
@@ -317,15 +317,6 @@ const reviewPlaybook = createSafeHandler(
       usageMetering,
     });
 
-    // Only actionable verdicts are surfaced as review findings. Compliant,
-    // fallback (an accepted alternative), and extract-only (no verdict)
-    // positions are not issues, so the inspector shows "No issues found" when a
-    // document satisfies the playbook instead of rendering non-issue cards.
-    const findings = gradedFindings.filter(
-      (finding) =>
-        finding.verdict === "deviation" || finding.verdict === "missing",
-    );
-
     yield* Result.await(
       safeDb(async (tx) => {
         await recordAuditEvent(tx, {
@@ -335,7 +326,10 @@ const reviewPlaybook = createSafeHandler(
           changes: {
             review: {
               old: null,
-              new: { documentId: body.entityId, findingCount: findings.length },
+              new: {
+                documentId: body.entityId,
+                findingCount: gradedFindings.length,
+              },
             },
           },
         });
@@ -343,7 +337,11 @@ const reviewPlaybook = createSafeHandler(
       }),
     );
 
-    return Result.ok(findings);
+    // Preserve the complete review result at the API boundary. The inspector
+    // derives its risk denominator and verdict breakdown from every reviewed
+    // position, then filters the visible issue list separately. Dropping
+    // compliant or fallback verdicts here makes those totals incomplete.
+    return Result.ok(gradedFindings);
   },
 );
 

--- a/apps/web/src/components/inspector/playbook-facet.tsx
+++ b/apps/web/src/components/inspector/playbook-facet.tsx
@@ -53,7 +53,10 @@ import type {
   PlaybookVerdict,
 } from "@/components/ai-suggestions/playbook-review-store";
 import type { OverallRisk } from "@/components/inspector/playbook-risk-rollup";
-import { computeRiskRollup } from "@/components/inspector/playbook-risk-rollup";
+import {
+  computeRiskRollup,
+  isFlaggedPlaybookFinding,
+} from "@/components/inspector/playbook-risk-rollup";
 import { useExternalSyncEffect } from "@/hooks/use-effect";
 import { useFormatter } from "@/i18n/formatting-context";
 import { useAnalytics } from "@/lib/analytics/provider";
@@ -466,9 +469,12 @@ const ResultsView = ({
   const t = useTranslations();
   const format = useFormatter();
   const severityLabels = useSeverityLabels();
+  const flaggedFindings = findings.filter(isFlaggedPlaybookFinding);
 
   const groups = SEVERITY_ORDER.flatMap((severity) => {
-    const items = findings.filter((finding) => finding.severity === severity);
+    const items = flaggedFindings.filter(
+      (finding) => finding.severity === severity,
+    );
     if (items.length === 0) {
       return [];
     }
@@ -496,12 +502,7 @@ const ResultsView = ({
       </header>
 
       {findings.length === 0 ? (
-        <div className="flex flex-1 flex-col items-center justify-center gap-1 px-6 text-center">
-          <CheckIcon className="text-success mb-1 size-5" />
-          <p className="text-foreground text-sm font-medium">
-            {t("knowledge.playbooks.review.noFindings")}
-          </p>
-        </div>
+        <NoReviewIssues />
       ) : (
         <div className="flex-1 overflow-y-auto px-2 py-2">
           <RiskSummaryCard
@@ -546,8 +547,21 @@ const ResultsView = ({
               </ul>
             </section>
           ))}
+          {flaggedFindings.length === 0 && <NoReviewIssues />}
         </div>
       )}
+    </div>
+  );
+};
+
+const NoReviewIssues = () => {
+  const t = useTranslations();
+  return (
+    <div className="flex flex-1 flex-col items-center justify-center gap-1 px-6 py-8 text-center">
+      <CheckIcon className="text-success mb-1 size-5" />
+      <p className="text-foreground text-sm font-medium">
+        {t("knowledge.playbooks.review.noFindings")}
+      </p>
     </div>
   );
 };

--- a/apps/web/src/components/inspector/playbook-risk-rollup.test.ts
+++ b/apps/web/src/components/inspector/playbook-risk-rollup.test.ts
@@ -5,7 +5,10 @@ import type {
   PlaybookSeverity,
 } from "@/components/ai-suggestions/playbook-review-store";
 
-import { computeRiskRollup } from "./playbook-risk-rollup";
+import {
+  computeRiskRollup,
+  isFlaggedPlaybookFinding,
+} from "./playbook-risk-rollup";
 
 // A large input space (any combination of severity x verdict across an
 // unbounded number of positions) makes per-example assertions weak;
@@ -141,6 +144,24 @@ describe("computeRiskRollup — counts", () => {
       deviation: 1,
       missing: 1,
     });
+  });
+});
+
+describe("review issue selection", () => {
+  test("keeps fallback and violations while hiding compliant and extract-only results", () => {
+    const findings = [
+      finding({ positionId: "compliant", verdict: "compliant" }),
+      finding({ positionId: "fallback", verdict: "fallback" }),
+      finding({ positionId: "deviation", verdict: "deviation" }),
+      finding({ positionId: "missing", verdict: "missing" }),
+      finding({ positionId: "extract", verdict: null }),
+    ];
+
+    expect(
+      findings
+        .filter(isFlaggedPlaybookFinding)
+        .map((result) => result.positionId),
+    ).toEqual(["fallback", "deviation", "missing"]);
   });
 });
 

--- a/apps/web/src/components/inspector/playbook-risk-rollup.ts
+++ b/apps/web/src/components/inspector/playbook-risk-rollup.ts
@@ -33,7 +33,9 @@ const FLAGGED_VERDICTS: readonly PlaybookVerdict[] = Object.freeze([
 
 type FlaggedVerdict = Exclude<PlaybookVerdict, "compliant">;
 
-type FlaggedFinding = PlaybookFinding & { verdict: FlaggedVerdict };
+export type FlaggedPlaybookFinding = PlaybookFinding & {
+  verdict: FlaggedVerdict;
+};
 
 export type RiskVerdictCounts = Record<PlaybookVerdict, number>;
 
@@ -54,13 +56,15 @@ export type RiskRollup = {
 
 const TOP_ISSUES_LIMIT = 5;
 
-const isFlagged = (finding: PlaybookFinding): finding is FlaggedFinding =>
+export const isFlaggedPlaybookFinding = (
+  finding: PlaybookFinding,
+): finding is FlaggedPlaybookFinding =>
   finding.verdict !== null && FLAGGED_VERDICTS.includes(finding.verdict);
 
 export const computeRiskRollup = (
   findings: readonly PlaybookFinding[],
 ): RiskRollup => {
-  const flagged = findings.filter(isFlagged);
+  const flagged = findings.filter(isFlaggedPlaybookFinding);
 
   const verdictCounts: RiskVerdictCounts = {
     compliant: 0,
@@ -114,7 +118,7 @@ export const computeRiskRollup = (
 //      handled above).
 //   5. "none" — nothing flagged.
 const computeOverallRisk = (
-  flagged: readonly FlaggedFinding[],
+  flagged: readonly FlaggedPlaybookFinding[],
 ): OverallRisk => {
   const hasBlockerViolation = flagged.some(
     (finding) =>


### PR DESCRIPTION
## Summary

- return the complete single-document review result so risk totals include compliant, fallback, and extract-only positions
- keep the inspector issue list actionable by filtering cards with the shared flagged-verdict predicate
- align the audit finding count with the returned response and add API/UI regression coverage

## Verification

- bun run lint
- bun run format
- bun run typecheck
- playbook API regression: 1 passed
- risk rollup regression: 18 passed
- bun run security:audit: no new high/critical advisories
- pre-push format, i18n, and changed-package typecheck hooks passed

## Known local suite issue

The full bun run test reaches the changed playbook tests successfully, but its first shared API batch reports three unrelated usage-metering failures in api-handlers.test.ts and analytics/tanstack-ai.test.ts. All three pass when those files are rerun in a fresh process with the same local test environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Review results now retain all assessed findings, while the inspector highlights only actionable issues.
  * Risk summaries and severity groupings now exclude compliant and extract-only findings.
  * Added clearer empty states when reviews have no findings or no flagged issues.
* **Bug Fixes**
  * Audit records now report the total number of findings assessed.
* **Tests**
  * Added coverage for review results, audit details, flagged issue selection and risk roll-ups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->