### PR TITLE
fix(mcp): narrow business-registry tool to org-enabled registries

### DIFF
--- a/apps/api/src/handlers/chat/tools/chat-tools.ts
+++ b/apps/api/src/handlers/chat/tools/chat-tools.ts
@@ -93,7 +93,7 @@ import type { OrgAIConfig } from "@/api/lib/ai-config";
 import type { AuditRecorder } from "@/api/lib/audit-log";
 import type { AccessibleWorkspace } from "@/api/lib/auth";
 import type { SafeId } from "@/api/lib/branded-types";
-import { getDeployAvailableRegistryHandlers } from "@/api/lib/business-registries/dispatch";
+import { enabledRegistryHandlersForOrg } from "@/api/lib/business-registries/dispatch";
 import type { ResolvedWebSearchProviders } from "@/api/lib/web-search/select-provider";
 
 export const WEB_SEARCH_NATIVE_TOOL_SLUG = "web-search";
@@ -604,12 +604,9 @@ export const getChatTools = (props: GetChatToolsProps): ChatToolMap => {
   // first (e.g. EDGAR requires EDGAR_USER_AGENT), then by org-level
   // native-tool enablement. Empty list means the tool isn't
   // registered at all (no dead picker for the model).
-  const businessRegistryJurisdictions = getDeployAvailableRegistryHandlers()
-    .filter(
-      (handler) =>
-        !(disabledNativeToolSlugs?.includes(handler.nativeToolSlug) ?? false),
-    )
-    .map((handler) => handler.country);
+  const businessRegistryJurisdictions = enabledRegistryHandlersForOrg(
+    disabledNativeToolSlugs,
+  ).map((handler) => handler.country);
   const businessRegistryTools = createBusinessRegistryTools({
     enabledJurisdictions: businessRegistryJurisdictions,
   });

--- a/apps/api/src/handlers/contacts/business-registries-lookup.ts
+++ b/apps/api/src/handlers/contacts/business-registries-lookup.ts
@@ -2,13 +2,17 @@ import { Result } from "better-result";
 import { t } from "elysia";
 
 import type { SafeDb, SafeDbError } from "@/api/db/safe-db";
-import { isNativeToolEnabledForOrg } from "@/api/handlers/mcp-connectors/catalog-metadata";
+import {
+  getDisabledNativeToolSlugsFromSettingsRow,
+  isNativeToolEnabledForOrg,
+} from "@/api/handlers/mcp-connectors/catalog-metadata";
 import { createSafeRootHandler } from "@/api/lib/api-handlers";
 import { arrayOrEmpty } from "@/api/lib/array";
 import type { SafeId } from "@/api/lib/branded-types";
 import {
   BUSINESS_REGISTRY_DISPATCH,
   BUSINESS_REGISTRY_SLUGS,
+  enabledRegistryHandlersForOrg,
   executeRegistryLookup,
 } from "@/api/lib/business-registries/dispatch";
 import type {
@@ -77,10 +81,19 @@ export const lookupBusinessRegistryShared = async ({
     nativeToolOverrides: settings?.nativeToolOverrides ?? {},
   });
   if (!enabled) {
+    // Self-correcting error: name the registries this org *can* reach so an
+    // agent recovers in one hop instead of guessing. Carried in the message
+    // because the MCP failure envelope forwards only `code` + `message`, not
+    // structured fields.
+    const enabledSlugs = enabledRegistryHandlersForOrg(
+      getDisabledNativeToolSlugsFromSettingsRow(settings ?? undefined),
+    ).map((enabledHandler) => enabledHandler.slug);
+    const enabledList =
+      enabledSlugs.length > 0 ? enabledSlugs.join(", ") : "none";
     return Result.err(
       new HandlerError({
         status: 403,
-        message: `Registry '${registry}' is disabled for this organization`,
+        message: `Registry '${registry}' is disabled for this organization. Registries enabled for this organization: ${enabledList}.`,
       }),
     );
   }

--- a/apps/api/src/lib/business-registries/dispatch.ts
+++ b/apps/api/src/lib/business-registries/dispatch.ts
@@ -1461,6 +1461,25 @@ export const getDeployAvailableRegistryHandlers = (): RegistryHandler[] =>
     handler.isDeployAvailable(),
   );
 
+/**
+ * Registry handlers this organization may actually call: shipped on this
+ * deployment AND enabled for the org (per-adapter native-tool enablement,
+ * expressed here as the set of *disabled* native-tool slugs the caller has
+ * already resolved from `organization_settings`).
+ *
+ * Both advertisement surfaces derive their options from this single source:
+ * the in-app chat tool's `jurisdiction` enum (via `handler.country`) and the
+ * external MCP tool's `registry` enum (via `handler.slug`). Neither can then
+ * advertise a registry the call-time gate would reject with a 403.
+ */
+export const enabledRegistryHandlersForOrg = (
+  disabledNativeToolSlugs: readonly string[] | undefined,
+): RegistryHandler[] =>
+  getDeployAvailableRegistryHandlers().filter(
+    (handler) =>
+      !(disabledNativeToolSlugs?.includes(handler.nativeToolSlug) ?? false),
+  );
+
 export const isBusinessRegistryNativeToolDeployAvailable = (
   nativeToolSlug: string,
 ): boolean => {

--- a/apps/api/src/mcp/context.ts
+++ b/apps/api/src/mcp/context.ts
@@ -1,4 +1,4 @@
-import { panic } from "better-result";
+import { panic, Result } from "better-result";
 import { eq } from "drizzle-orm";
 
 import { rlsDb } from "@/api/db/root";
@@ -8,11 +8,14 @@ import {
   createMembershipSafeDb,
   createMembershipScopedDb,
 } from "@/api/db/scoped";
+import { getDisabledNativeToolSlugsFromSettingsRow } from "@/api/handlers/mcp-connectors/catalog-metadata";
 import { createAuditRecorder } from "@/api/lib/audit-log";
 import type { AuditRecorder } from "@/api/lib/audit-log";
 import { resolveMemberAuthorization } from "@/api/lib/auth";
 import type { AccessibleWorkspace } from "@/api/lib/auth";
 import type { SafeId } from "@/api/lib/branded-types";
+import { enabledRegistryHandlersForOrg } from "@/api/lib/business-registries/dispatch";
+import type { BusinessRegistrySlug } from "@/api/lib/business-registries/dispatch";
 import { isMemberRole } from "@/api/lib/member-roles";
 import type { MemberRole } from "@/api/lib/member-roles";
 import {
@@ -58,6 +61,19 @@ export type McpRequestContext = {
    * empty list (it never dispatches the generic path).
    */
   grantedScopes: readonly string[];
+  /**
+   * Registry slugs this org may actually call (deployment-shipped AND enabled
+   * for the org). The `lookup_business_registry` list projection narrows its
+   * `registry` enum to these and drops the tool when empty, mirroring the
+   * in-app chat tool so the MCP surface never advertises a registry the
+   * call-time gate would 403. Computed once here from `organization_settings`.
+   *
+   * `undefined` means "not resolved" (a synthetic/test context, or a settings
+   * read fault): the projection then leaves the full enum advertised and the
+   * call-time gate stays the backstop. It is NOT the same as an empty array,
+   * which means the org can reach no registry and the tool is dropped.
+   */
+  enabledRegistrySlugs?: readonly BusinessRegistrySlug[] | undefined;
   memberRole: MemberRole;
   organizationId: SafeId<"organization">;
   /**
@@ -176,6 +192,24 @@ export const resolveMcpSessionContext = async (
   };
   const requestDatabaseScope = createOperationDatabaseScope();
 
+  // Resolve the org's reachable registries once, so the tools/list projection
+  // can narrow the `lookup_business_registry` enum synchronously. On a read
+  // fault, leave it unresolved (undefined) rather than dropping the tool.
+  const settingsResult = await requestDatabaseScope.safeDb((tx) =>
+    tx.query.organizationSettings.findFirst({
+      where: { organizationId: { eq: organizationId } },
+      columns: { practiceJurisdictions: true, nativeToolOverrides: true },
+    }),
+  );
+  const enabledRegistrySlugs: readonly BusinessRegistrySlug[] | undefined =
+    Result.isError(settingsResult)
+      ? undefined
+      : enabledRegistryHandlersForOrg(
+          getDisabledNativeToolSlugsFromSettingsRow(
+            settingsResult.value ?? undefined,
+          ),
+        ).map((handler) => handler.slug);
+
   return {
     accessibleWorkspaceIds: usableWorkspaceIds,
     accessibleWorkspaceIdSet: workspaceAccessBoundary.accessibleWorkspaceIdSet,
@@ -184,6 +218,7 @@ export const resolveMcpSessionContext = async (
     ),
     accessibleWorkspaces: usableWorkspaces,
     createOperationDatabaseScope,
+    enabledRegistrySlugs,
     grantedScopes: session.scopes,
     memberRole,
     organizationId,

--- a/apps/api/src/mcp/gateway/list-tools.ts
+++ b/apps/api/src/mcp/gateway/list-tools.ts
@@ -26,6 +26,7 @@ import type {
   McpToolFeatureFlag,
   ToolScope,
 } from "@/api/mcp/tool-types";
+import { enumProp } from "@/api/mcp/tool-utils";
 
 /**
  * A feature-gated tool is advertised and dispatchable only when its deployment
@@ -59,6 +60,57 @@ const externalMcpToolAccess = (
   readOnlyHint: boolean | undefined,
 ): McpToolAccess => (readOnlyHint === true ? "read" : "write");
 
+const LOOKUP_BUSINESS_REGISTRY_TOOL_NAME = "lookup_business_registry";
+
+/**
+ * Narrow the `lookup_business_registry` tool's `registry` enum to the
+ * registries this org can actually reach (`context.enabledRegistrySlugs`,
+ * resolved once at context bootstrap), and drop the tool entirely when none
+ * are. Mirrors the in-app chat tool, so the external MCP surface can no longer
+ * advertise a registry whose call-time gate would 403 — the same defect the
+ * chat tool already avoids.
+ *
+ * `enabledRegistrySlugs === undefined` means the set was not resolved (a
+ * synthetic/test context, or a bootstrap settings-read fault): leave the full
+ * enum advertised and let the call-time gate stay the backstop.
+ */
+const narrowBusinessRegistryTool = (
+  context: McpRequestContext,
+  definitions: McpToolDefinition[],
+): McpToolDefinition[] => {
+  const enabledSlugs = context.enabledRegistrySlugs;
+  if (enabledSlugs === undefined) {
+    return definitions;
+  }
+
+  const index = definitions.findIndex(
+    (definition) => definition.name === LOOKUP_BUSINESS_REGISTRY_TOOL_NAME,
+  );
+  const definition = definitions[index];
+  if (definition === undefined) {
+    return definitions;
+  }
+
+  if (enabledSlugs.length === 0) {
+    return definitions.filter((_definition, i) => i !== index);
+  }
+
+  return definitions.map((current, i) =>
+    i === index
+      ? {
+          ...definition,
+          inputSchema: {
+            ...definition.inputSchema,
+            properties: {
+              ...definition.inputSchema.properties,
+              registry: enumProp("Business register to query", enabledSlugs),
+            },
+          },
+        }
+      : current,
+  );
+};
+
 export const listGatewayMcpToolDefinitions = async ({
   context,
   mode,
@@ -68,11 +120,12 @@ export const listGatewayMcpToolDefinitions = async ({
   mode: McpMode;
   scopes?: readonly string[];
 }): Promise<McpToolDefinition[]> => {
-  const definitions = listStaticMcpToolDefinitions(mode).filter(
+  const staticDefinitions = listStaticMcpToolDefinitions(mode).filter(
     (definition) =>
       hasGrantedScope(scopes, definition.scope) &&
       isMcpToolFeatureEnabled(definition.feature),
   );
+  const definitions = narrowBusinessRegistryTool(context, staticDefinitions);
   if (mode === "anonymized") {
     return definitions;
   }

--- a/apps/api/src/mcp/tools.test.ts
+++ b/apps/api/src/mcp/tools.test.ts
@@ -757,6 +757,45 @@ describe("OpenAI-compatible MCP tools", () => {
     ]);
   });
 
+  describe("lookup_business_registry org narrowing", () => {
+    const registryTool = async (context: McpRequestContext) =>
+      (await listMcpTools(context)).find(
+        (tool) => tool.name === "lookup_business_registry",
+      );
+
+    test("narrows the registry enum to the org's enabled registries", async () => {
+      const tool = await registryTool({
+        ...createContext(),
+        enabledRegistrySlugs: ["orsr", "vies"],
+      });
+
+      expect(tool?.inputSchema.properties?.["registry"]).toEqual({
+        type: "string",
+        enum: ["orsr", "vies"],
+        description: "Business register to query",
+      });
+    });
+
+    test("drops the tool when the org can reach no registry", async () => {
+      const tool = await registryTool({
+        ...createContext(),
+        enabledRegistrySlugs: [],
+      });
+
+      expect(tool).toBeUndefined();
+    });
+
+    test("leaves the full enum when the enabled set is unresolved", async () => {
+      const tool = await registryTool(createContext());
+
+      // A context that never resolved its reachable registries (test/synthetic
+      // or a bootstrap read fault) keeps the full advertisement.
+      expect(tool?.inputSchema.properties?.["registry"]).toMatchObject({
+        enum: expect.arrayContaining(["ares", "vies"]),
+      });
+    });
+  });
+
   test("remaps case-law tools to anonymized scopes", async () => {
     expect(
       (


### PR DESCRIPTION
## Problem

The MCP `lookup_business_registry` tool advertised **every** registry in its `registry` enum regardless of which registries the organization has enabled. An agent could select a disabled registry and only discover the block at call time (a 403), wasting a turn.

The in-app chat tool (`business_registry_lookup`) already narrows its `jurisdiction` enum to the enabled set and omits the tool when none apply. This brings the MCP surface to parity so neither surface advertises a registry the call-time gate would reject.

## Changes

- Add a shared `enabledRegistryHandlersForOrg` resolver in `dispatch.ts`. The chat tool, the MCP `tools/list` projection, and the call-time gate all derive their options from this single source.
- Resolve the org's reachable registries once at MCP context bootstrap (`resolveMcpSessionContext`) into `enabledRegistrySlugs`. The `tools/list` projection narrows the enum to them synchronously and drops the tool entirely when none are enabled. An unresolved set (synthetic/test context or a read fault) leaves the full enum advertised, with the call-time gate as backstop.
- Make the call-time 403 self-correcting by naming the registries the organization can reach, so an agent recovers in one hop. Carried in the message because the MCP failure envelope forwards only `code` and `message`.

## Behavior note

Every registry is jurisdiction-gated, so an organization with no practice jurisdictions configured no longer sees the MCP tool — matching the existing chat-tool behavior for such orgs.