### PR TITLE
fix(mcp): keep the anonymized tools/list tenant-neutral

### DIFF
--- a/apps/api/src/handlers/contacts/business-registries-lookup.ts
+++ b/apps/api/src/handlers/contacts/business-registries-lookup.ts
@@ -2,17 +2,13 @@ import { Result } from "better-result";
 import { t } from "elysia";
 
 import type { SafeDb, SafeDbError } from "@/api/db/safe-db";
-import {
-  getDisabledNativeToolSlugsFromSettingsRow,
-  isNativeToolEnabledForOrg,
-} from "@/api/handlers/mcp-connectors/catalog-metadata";
+import { isNativeToolEnabledForOrg } from "@/api/handlers/mcp-connectors/catalog-metadata";
 import { createSafeRootHandler } from "@/api/lib/api-handlers";
 import { arrayOrEmpty } from "@/api/lib/array";
 import type { SafeId } from "@/api/lib/branded-types";
 import {
   BUSINESS_REGISTRY_DISPATCH,
   BUSINESS_REGISTRY_SLUGS,
-  enabledRegistryHandlersForOrg,
   executeRegistryLookup,
 } from "@/api/lib/business-registries/dispatch";
 import type {
@@ -81,19 +77,16 @@ export const lookupBusinessRegistryShared = async ({
     nativeToolOverrides: settings?.nativeToolOverrides ?? {},
   });
   if (!enabled) {
-    // Self-correcting error: name the registries this org *can* reach so an
-    // agent recovers in one hop instead of guessing. Carried in the message
-    // because the MCP failure envelope forwards only `code` + `message`, not
-    // structured fields.
-    const enabledSlugs = enabledRegistryHandlersForOrg(
-      getDisabledNativeToolSlugsFromSettingsRow(settings ?? undefined),
-    ).map((enabledHandler) => enabledHandler.slug);
-    const enabledList =
-      enabledSlugs.length > 0 ? enabledSlugs.join(", ") : "none";
+    // Tenant-neutral denial: do NOT enumerate the org's enabled registries.
+    // This handler is shared by the anonymized MCP surface, whose tools/list is
+    // deliberately tenant-neutral; naming the enabled set here would leak the
+    // org's practice-jurisdiction / native-tool settings through tools/call.
+    // The default surface's narrowed tools/list already steers the agent to
+    // reachable registries.
     return Result.err(
       new HandlerError({
         status: 403,
-        message: `Registry '${registry}' is disabled for this organization. Registries enabled for this organization: ${enabledList}.`,
+        message: `Registry '${registry}' is disabled for this organization`,
       }),
     );
   }

--- a/apps/api/src/mcp/gateway/list-tools.test.ts
+++ b/apps/api/src/mcp/gateway/list-tools.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, test } from "bun:test";
+
+import type { McpRequestContext } from "@/api/mcp/context";
+import { listGatewayMcpToolDefinitions } from "@/api/mcp/gateway/list-tools";
+import type { McpToolDefinition } from "@/api/mcp/tool-types";
+import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
+
+// Only `enabledRegistrySlugs` drives the narrowing; the rest of the context is
+// unused on this path. `scopes: ["stella:read"]` grants the read-scoped lookup
+// tool while withholding stella:external_mcps / stella:skills, so the dynamic
+// gateway loaders never run and no DB is touched.
+const contextWith = (
+  enabledRegistrySlugs: readonly string[] | undefined,
+): McpRequestContext =>
+  asTestRaw<McpRequestContext>({ enabledRegistrySlugs, grantedScopes: [] });
+
+// Snapshot the advertised registry enum into a fresh array. The unresolved and
+// anonymized paths return the shared static definition by reference (correct:
+// they must not narrow), so callers must never hand that object to a mutating
+// matcher — copy the enum out and assert on the copy.
+const registryEnumOf = (
+  definitions: readonly McpToolDefinition[],
+): string[] => {
+  const registry = definitions.find(
+    (definition) => definition.name === "lookup_business_registry",
+  )?.inputSchema.properties?.["registry"];
+  if (
+    registry !== undefined &&
+    typeof registry === "object" &&
+    "enum" in registry &&
+    Array.isArray(registry.enum)
+  ) {
+    return [...registry.enum];
+  }
+  return [];
+};
+
+const hasLookupTool = (definitions: readonly McpToolDefinition[]): boolean =>
+  definitions.some(
+    (definition) => definition.name === "lookup_business_registry",
+  );
+
+describe("listGatewayMcpToolDefinitions business-registry narrowing", () => {
+  test("narrows the default-surface enum to the org's enabled registries", async () => {
+    const definitions = await listGatewayMcpToolDefinitions({
+      context: contextWith(["orsr", "vies"]),
+      mode: "default",
+      scopes: ["stella:read"],
+    });
+
+    expect(registryEnumOf(definitions)).toEqual(["orsr", "vies"]);
+  });
+
+  test("drops the tool on the default surface when no registry is enabled", async () => {
+    const definitions = await listGatewayMcpToolDefinitions({
+      context: contextWith([]),
+      mode: "default",
+      scopes: ["stella:read"],
+    });
+
+    expect(hasLookupTool(definitions)).toBe(false);
+  });
+
+  test("keeps the full enum when the enabled set is unresolved", async () => {
+    const definitions = await listGatewayMcpToolDefinitions({
+      context: contextWith(undefined),
+      mode: "default",
+      scopes: ["stella:read"],
+    });
+
+    const registryEnum = registryEnumOf(definitions);
+    expect(registryEnum).toContain("ares");
+    expect(registryEnum).toContain("vies");
+  });
+
+  test("never narrows the tenant-neutral anonymized projection", async () => {
+    // The anonymized tools/list must stay tenant-neutral: even when the context
+    // resolved a subset, the anonymized schema keeps the full enum so it cannot
+    // leak the org's practice-jurisdiction / native-tool settings.
+    const definitions = await listGatewayMcpToolDefinitions({
+      context: contextWith(["orsr", "vies"]),
+      mode: "anonymized",
+    });
+
+    const registryEnum = registryEnumOf(definitions);
+    expect(registryEnum).toContain("ares");
+    expect(registryEnum).toContain("vies");
+  });
+});

--- a/apps/api/src/mcp/gateway/list-tools.ts
+++ b/apps/api/src/mcp/gateway/list-tools.ts
@@ -68,7 +68,8 @@ const LOOKUP_BUSINESS_REGISTRY_TOOL_NAME = "lookup_business_registry";
  * resolved once at context bootstrap), and drop the tool entirely when none
  * are. Mirrors the in-app chat tool, so the external MCP surface can no longer
  * advertise a registry whose call-time gate would 403 — the same defect the
- * chat tool already avoids.
+ * chat tool already avoids. Applied only to the default surface; the
+ * anonymized projection stays tenant-neutral and is never narrowed.
  *
  * `enabledRegistrySlugs === undefined` means the set was not resolved (a
  * synthetic/test context, or a bootstrap settings-read fault): leave the full
@@ -125,10 +126,14 @@ export const listGatewayMcpToolDefinitions = async ({
       hasGrantedScope(scopes, definition.scope) &&
       isMcpToolFeatureEnabled(definition.feature),
   );
-  const definitions = narrowBusinessRegistryTool(context, staticDefinitions);
+  // The anonymized tools/list is a tenant-neutral pure projection (see
+  // mcp/README.md): keep every tool's schema intact. Per-org registry
+  // narrowing runs only on the default surface, or the anonymized schema
+  // would leak the org's practice-jurisdiction / native-tool settings.
   if (mode === "anonymized") {
-    return definitions;
+    return staticDefinitions;
   }
+  const definitions = narrowBusinessRegistryTool(context, staticDefinitions);
 
   if (hasGrantedScope(scopes, "stella:external_mcps")) {
     for (const tool of await listGatewayExternalMcpTools({ context })) {


### PR DESCRIPTION
## Problem

Follow-up to #1350. The per-org business-registry enum narrowing ran before the anonymized return path in `listGatewayMcpToolDefinitions`, so the anonymized `tools/list` schema revealed the organization's practice-jurisdiction / native-tool settings: it advertised only the org's enabled registries (e.g. `orsr`/`vies`), or dropped the tool entirely. The anonymized projection is documented as a tenant-neutral pure projection where every tool keeps its schema.

## Change

- Narrow the `registry` enum only on the default surface. The anonymized mode returns the static projection untouched; the call-time gate remains the backstop there.
- Add gateway-level coverage: default narrow, default drop when nothing is enabled, unresolved fallback keeps the full enum, and the anonymized invariant.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Business registry options are now correctly limited to enabled registries in the standard tool view.
  * The anonymised tool view now consistently displays the complete registry selection.
  * The business registry lookup tool is omitted when no registries are enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->