### PR TITLE
chore: bump .ai/shared to 4d72cc8 and re-sync

### DIFF
--- a/.agents/skills/product-think/SKILL.md
+++ b/.agents/skills/product-think/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: product-think
-description: 'Shape a feature or problem before implementation. Use this when the request is still fuzzy, when several solutions are possible, or when execution risks outrunning product clarity.'
+description: "Shape a feature or problem before implementation. Use this when the request is still fuzzy, when several solutions are possible, or when execution risks outrunning product clarity."
 ---
 
 # Product Think

--- a/.agents/skills/regression-hunt/SKILL.md
+++ b/.agents/skills/regression-hunt/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: regression-hunt
-description: 'Track down a behavior that used to work and now fails, changed, or regressed. Use this when a bug report points to a recent breakage, especially when the cause is not obvious yet.'
+description: "Track down a behavior that used to work and now fails, changed, or regressed. Use this when a bug report points to a recent breakage, especially when the cause is not obvious yet."
 ---
 
 # Regression Hunt
@@ -14,6 +14,7 @@ especially when the cause is not obvious yet.
 $ARGUMENTS — A short description of what regressed.
 
 Helpful extras when available:
+
 - failing test name or file
 - error message or log line
 - expected vs actual behavior
@@ -141,7 +142,7 @@ Preference:
    Either prepend `--inspect-brk` to the test command inside your
    package script temporarily, or invoke directly while replicating the
    flags the script wires — e.g. `bun --inspect-brk test --preload
-   ./setup.ts <file-path>`. Open the printed `devtools://` URL in
+./setup.ts <file-path>`. Open the printed `devtools://` URL in
    Chrome, set one breakpoint at the suspected fault. One breakpoint
    beats ten logs.
 2. Targeted logs at the boundaries that distinguish hypotheses.
@@ -179,7 +180,7 @@ for DB regressions — then bisect. Measure first, fix second.
 ### 10. Post-mortem
 
 Ask: **what would have prevented this regression?** Make this
-recommendation *after* the fix is in — you have more information now than
+recommendation _after_ the fix is in — you have more information now than
 when you started.
 
 Lenses to apply:

--- a/.claude/commands/regression-hunt.md
+++ b/.claude/commands/regression-hunt.md
@@ -9,6 +9,7 @@ especially when the cause is not obvious yet.
 $ARGUMENTS — A short description of what regressed.
 
 Helpful extras when available:
+
 - failing test name or file
 - error message or log line
 - expected vs actual behavior
@@ -136,7 +137,7 @@ Preference:
    Either prepend `--inspect-brk` to the test command inside your
    package script temporarily, or invoke directly while replicating the
    flags the script wires — e.g. `bun --inspect-brk test --preload
-   ./setup.ts <file-path>`. Open the printed `devtools://` URL in
+./setup.ts <file-path>`. Open the printed `devtools://` URL in
    Chrome, set one breakpoint at the suspected fault. One breakpoint
    beats ten logs.
 2. Targeted logs at the boundaries that distinguish hypotheses.
@@ -174,7 +175,7 @@ for DB regressions — then bisect. Measure first, fix second.
 ### 10. Post-mortem
 
 Ask: **what would have prevented this regression?** Make this
-recommendation *after* the fix is in — you have more information now than
+recommendation _after_ the fix is in — you have more information now than
 when you started.
 
 Lenses to apply:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,10 @@ details unless they are already public in the repository.
 - Never manually reformat code you did not semantically change (auto-formatter output
   from `bun run format` is fine to include)
 - Vary punctuation: prefer colons, semicolons, commas, and parentheses over em dashes
+- Omit needless words. Vigorous writing is concise: a sentence should contain no
+  unnecessary words, a paragraph no unnecessary sentences, for the same reason that a
+  drawing should have no unnecessary lines and a machine no unnecessary parts. Applies
+  to comments, commits, PRs, and docs.
 - Prefer explicit over implicit; when a backend endpoint accepts a discriminator
   (e.g., `?type=document|file`), thread it through the full stack (URL params,
   component props) instead of hardcoding a default on the frontend


### PR DESCRIPTION
Advances the `.ai/shared` submodule `0628952` → `4d72cc8`:
- #22 distribute shared Rust lint policy
- #23 concision writing principle
- #24 format sources with oxfmt + add format CI check

Re-ran `sync-ai` so the generated `AGENTS.md` / `.agents/skills` / `.claude/commands` match the new source (`sync-ai:check` passes).