### PR TITLE
docs: clarify persisted domain value constraints

### DIFF
--- a/.agents/skills/conventions-db/SKILL.md
+++ b/.agents/skills/conventions-db/SKILL.md
@@ -12,6 +12,14 @@ migrations.
 
 - Schema lives in `/apps/api/src/db/schema.ts`
 - Use Drizzle migrations (`bun run db:push`)
+- For closed persisted domain values, define one named `as const` value list and
+  pass it to Drizzle with `text({ enum: VALUES })`. This provides insert/select
+  inference without introducing a TypeScript or PostgreSQL enum.
+- Drizzle's `{ enum: VALUES }` and `.$type<T>()` are compile-time-only; neither
+  validates stored values. Add an explicit database `CHECK` when an invalid value
+  could compromise lifecycle, billing, authorization, audit, or workflow invariants.
+- Reserve `.$type<T>()` for branded or structured types. Use a native PostgreSQL
+  enum only when the value set is genuinely permanent.
 - Cascade deletes for workspace-owned resources
 - Restrict deletes for file references (prevent orphaning)
 - When writing multi-delete transactions, trace the FK graph

--- a/.ai/local-skills/conventions-db/SKILL.md
+++ b/.ai/local-skills/conventions-db/SKILL.md
@@ -12,6 +12,14 @@ migrations.
 
 - Schema lives in `/apps/api/src/db/schema.ts`
 - Use Drizzle migrations (`bun run db:push`)
+- For closed persisted domain values, define one named `as const` value list and
+  pass it to Drizzle with `text({ enum: VALUES })`. This provides insert/select
+  inference without introducing a TypeScript or PostgreSQL enum.
+- Drizzle's `{ enum: VALUES }` and `.$type<T>()` are compile-time-only; neither
+  validates stored values. Add an explicit database `CHECK` when an invalid value
+  could compromise lifecycle, billing, authorization, audit, or workflow invariants.
+- Reserve `.$type<T>()` for branded or structured types. Use a native PostgreSQL
+  enum only when the value set is genuinely permanent.
 - Cascade deletes for workspace-owned resources
 - Restrict deletes for file references (prevent orphaning)
 - When writing multi-delete transactions, trace the FK graph

--- a/.ai/local/agents.md
+++ b/.ai/local/agents.md
@@ -3,6 +3,16 @@
 **Monorepo:** `apps/api` (Elysia backend, Bun), `apps/web` (React + Vite frontend),
 shared packages in `packages/`. Use Glob/Grep to explore.
 
+## Database Domain Values
+
+- For closed persisted domain values, use one named `as const` value list with
+  Drizzle `text({ enum: VALUES })`; do not use TypeScript enums or native PostgreSQL
+  enums for evolving state.
+- Drizzle enum inference and `.$type<T>()` do not validate stored values. Add a
+  database `CHECK` when an invalid value could compromise lifecycle, billing,
+  authorization, audit, or workflow invariants. Reserve `.$type<T>()` for branded
+  or structured types.
+
 ## Workspace Layout
 
 - `apps/*` contains runnable applications only.

--- a/.claude/commands/conventions-db.md
+++ b/.claude/commands/conventions-db.md
@@ -7,6 +7,14 @@ migrations.
 
 - Schema lives in `/apps/api/src/db/schema.ts`
 - Use Drizzle migrations (`bun run db:push`)
+- For closed persisted domain values, define one named `as const` value list and
+  pass it to Drizzle with `text({ enum: VALUES })`. This provides insert/select
+  inference without introducing a TypeScript or PostgreSQL enum.
+- Drizzle's `{ enum: VALUES }` and `.$type<T>()` are compile-time-only; neither
+  validates stored values. Add an explicit database `CHECK` when an invalid value
+  could compromise lifecycle, billing, authorization, audit, or workflow invariants.
+- Reserve `.$type<T>()` for branded or structured types. Use a native PostgreSQL
+  enum only when the value set is genuinely permanent.
 - Cascade deletes for workspace-owned resources
 - Restrict deletes for file references (prevent orphaning)
 - When writing multi-delete transactions, trace the FK graph

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -389,6 +389,16 @@ oxlint (ultracite preset) + oxfmt. To suppress a rule:
 **Monorepo:** `apps/api` (Elysia backend, Bun), `apps/web` (React + Vite frontend),
 shared packages in `packages/`. Use Glob/Grep to explore.
 
+## Database Domain Values
+
+- For closed persisted domain values, use one named `as const` value list with
+  Drizzle `text({ enum: VALUES })`; do not use TypeScript enums or native PostgreSQL
+  enums for evolving state.
+- Drizzle enum inference and `.$type<T>()` do not validate stored values. Add a
+  database `CHECK` when an invalid value could compromise lifecycle, billing,
+  authorization, audit, or workflow invariants. Reserve `.$type<T>()` for branded
+  or structured types.
+
 ## Workspace Layout
 
 - `apps/*` contains runnable applications only.


### PR DESCRIPTION
## Proposed change

Standardize Stella guidance for closed persisted domain values:

- use named `as const` lists with Drizzle `text({ enum: VALUES })`
- treat Drizzle enum inference and `.$type<T>()` as compile-time-only
- require database `CHECK` constraints for lifecycle, billing, authorization, audit, and workflow invariants
- reserve native PostgreSQL enums for genuinely permanent value sets
- regenerate agent and command mirrors from the source guidance

## Checklist

- [x] **BUILD ASSURANCE** | Documentation and generated guidance pass repository checks.
- [x] **TESTING** | `bun run sync-ai:check`; pre-push format, i18n, and affected typecheck hooks passed.
- [x] **DARK MODE SUPPORT** | Not applicable; no UI changes.
- [x] **ISSUE LINKED** | Not applicable; convention clarification requested directly.
- [x] **SCREENSHOT INCLUDED** | Not applicable; no UI changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for modelling closed, persisted domain values with named value lists.
  * Clarified that type inference alone does not validate stored database values.
  * Added recommendations for database `CHECK` constraints where invalid values could affect critical workflows.
  * Clarified when to use branded types or native PostgreSQL enums.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->