### PR TITLE
fix: publish packages only from release metadata

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -18,9 +18,11 @@ on:
   push:
     branches: [main]
     paths:
-      - packages/conditions/package.json
-      - packages/template-conditions/package.json
-      - packages/docx-utils/package.json
+      # Changesets owns these files, so ordinary manifest maintenance cannot
+      # accidentally start a release transaction.
+      - packages/conditions/CHANGELOG.md
+      - packages/template-conditions/CHANGELOG.md
+      - packages/docx-utils/CHANGELOG.md
   workflow_run: # zizmor: ignore[dangerous-triggers] the release tag and SHA are revalidated before the release job receives id-token
     workflows: ["Release Artifacts"]
     types: [completed]

--- a/scripts/check-api-cli-contract.test.ts
+++ b/scripts/check-api-cli-contract.test.ts
@@ -68,7 +68,7 @@ describe("API and CLI release contract", () => {
     expect(releaseWorkflow).toContain("name: release-source-receipt");
     expect(publishWorkflow).toContain('gh run download "$UPSTREAM_RUN_ID"');
     expect(publishWorkflow).toContain(
-      "UPSTREAM_RELEASE_REF: ${{ needs.release-trigger.outputs.release_ref }}",
+      `UPSTREAM_RELEASE_REF: \${{ needs.release-trigger.outputs.release_ref }}`,
     );
     expect(publishWorkflow).not.toContain(
       "github.event.workflow_run.head_branch",

--- a/scripts/check-api-cli-contract.test.ts
+++ b/scripts/check-api-cli-contract.test.ts
@@ -74,4 +74,23 @@ describe("API and CLI release contract", () => {
       "github.event.workflow_run.head_branch",
     );
   });
+
+  test("shared package publishing uses Changesets release signals", async () => {
+    const publishWorkflow = await Bun.file(
+      new URL("../.github/workflows/publish-npm.yml", import.meta.url),
+    ).text();
+    const pushTrigger = publishWorkflow.slice(
+      0,
+      publishWorkflow.indexOf("  workflow_run:"),
+    );
+
+    for (const packageName of [
+      "conditions",
+      "template-conditions",
+      "docx-utils",
+    ]) {
+      expect(pushTrigger).toContain(`packages/${packageName}/CHANGELOG.md`);
+      expect(pushTrigger).not.toContain(`packages/${packageName}/package.json`);
+    }
+  });
 });


### PR DESCRIPTION
## Summary

- trigger npm publishing from Changesets-owned package changelogs instead of package manifest edits
- enforce that automatic publish paths cannot regress to package.json
- satisfy the release contract lint on the TS7/Oxc main baseline

## Validation

- bun install --frozen-lockfile
- targeted release contract tests (5 passed)
- actionlint
- zizmor
- git diff --check

The custom npm publishing workflow and package matrix are otherwise unchanged.

CC on behalf of @jan-kubica