### PR TITLE
fix: synchronize E2E readiness with product state

### DIFF
--- a/.ai/local/agents.md
+++ b/.ai/local/agents.md
@@ -87,3 +87,13 @@ only the non-obvious caveats for this environment.
   checked in the CI typecheck job. Reseeding either baseline
   (`--write` / `--write-baseline`) must be justified in the PR description;
   it is not a mechanical way to make CI green.
+
+## End-to-End Tests
+
+- Browser navigation must name `waitUntil: "commit"` or
+  `waitUntil: "domcontentloaded"`, then synchronize on the specific UI that
+  makes the route ready. Never use the default `load` event as application
+  readiness; `navigation-policy.unit.spec.ts` enforces this for every E2E spec.
+- A successful HTTP response is not necessarily completion of the user action
+  that issued it. Wait for the product's visible completion state before
+  asserting settled UI or navigating away.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -473,3 +473,13 @@ only the non-obvious caveats for this environment.
   checked in the CI typecheck job. Reseeding either baseline
   (`--write` / `--write-baseline`) must be justified in the PR description;
   it is not a mechanical way to make CI green.
+
+## End-to-End Tests
+
+- Browser navigation must name `waitUntil: "commit"` or
+  `waitUntil: "domcontentloaded"`, then synchronize on the specific UI that
+  makes the route ready. Never use the default `load` event as application
+  readiness; `navigation-policy.unit.spec.ts` enforces this for every E2E spec.
+- A successful HTTP response is not necessarily completion of the user action
+  that issued it. Wait for the product's visible completion state before
+  asserting settled UI or navigating away.

--- a/apps/web/e2e/helpers/app-shell.ts
+++ b/apps/web/e2e/helpers/app-shell.ts
@@ -1,0 +1,9 @@
+import type { Page } from "@playwright/test";
+
+/**
+ * Locate primary app navigation by shell ownership and destination. Route
+ * content can repeat the same link in breadcrumbs, so a page-wide accessible
+ * name is not a readiness signal for the shell.
+ */
+export const appShellNavigationLink = (page: Page, path: `/${string}`) =>
+  page.locator('[data-slot="sidebar"]').locator(`a[href="${path}"]`);

--- a/apps/web/e2e/specs/app-shell-readiness.unit.spec.ts
+++ b/apps/web/e2e/specs/app-shell-readiness.unit.spec.ts
@@ -1,0 +1,16 @@
+import { expect, test } from "@playwright/test";
+
+import { appShellNavigationLink } from "../helpers/app-shell";
+
+test.use({ storageState: { cookies: [], origins: [] } });
+
+test("app shell readiness is owned by sidebar navigation", async ({ page }) => {
+  await page.setContent(`
+    <aside data-slot="sidebar"><a href="/chat">Chat</a></aside>
+    <nav aria-label="Breadcrumb"><a href="/chat">Chat</a></nav>
+  `);
+
+  const chatNavigation = appShellNavigationLink(page, "/chat");
+  await expect(chatNavigation).toHaveCount(1);
+  await expect(chatNavigation).toBeVisible();
+});

--- a/apps/web/e2e/specs/chat-composer-during-stream.spec.ts
+++ b/apps/web/e2e/specs/chat-composer-during-stream.spec.ts
@@ -15,7 +15,10 @@ const SLOW_STREAM_MARKER = "Stream slowly please";
 test("composer draft survives typing while a response is streaming", async ({
   page,
 }) => {
-  await page.goto("/chat");
+  // A route is ready when its UI is ready, not when every cold Vite resource
+  // has fired the browser load event. Commit the document, then synchronize on
+  // the composer below.
+  await page.goto("/chat", { waitUntil: "commit" });
 
   // Route error boundary heading (apps/web/src/components/route-components.tsx:253,
   // title common.somethingWentWrong). Checked after every step below; declared

--- a/apps/web/e2e/specs/chat.spec.ts
+++ b/apps/web/e2e/specs/chat.spec.ts
@@ -7,7 +7,10 @@ import { expect, test } from "../helpers/test";
 test("chat composer sends a message and renders the assistant reply", async ({
   page,
 }) => {
-  await page.goto("/chat");
+  // A route is ready when its UI is ready, not when every cold Vite resource
+  // has fired the browser load event. Commit the document, then synchronize on
+  // the composer below.
+  await page.goto("/chat", { waitUntil: "commit" });
 
   // Route error boundary heading (apps/web/src/components/route-components.tsx:253,
   // title common.somethingWentWrong). Checked after every step below; declared

--- a/apps/web/e2e/specs/navigation-policy.unit.spec.ts
+++ b/apps/web/e2e/specs/navigation-policy.unit.spec.ts
@@ -1,0 +1,101 @@
+import { expect, test } from "@playwright/test";
+import { readdir, readFile } from "node:fs/promises";
+import path from "node:path";
+import ts from "typescript";
+
+const E2E_ROOT = path.resolve(import.meta.dirname, "..");
+const READINESS_LIFECYCLES = new Set(["commit", "domcontentloaded"]);
+
+test("route navigation waits for an explicit lifecycle before UI readiness", async () => {
+  const violations = (
+    await Promise.all((await specFiles(E2E_ROOT)).map(navigationViolations))
+  ).flat();
+
+  expect(violations).toEqual([]);
+});
+
+const specFiles = async (directory: string): Promise<string[]> => {
+  const entries = await readdir(directory, { withFileTypes: true });
+  return (
+    await Promise.all(
+      entries.map(async (entry) => {
+        const entryPath = path.join(directory, entry.name);
+        if (entry.isDirectory()) {
+          return await specFiles(entryPath);
+        }
+        if (
+          entry.name.endsWith(".spec.ts") ||
+          entry.name.endsWith(".spec.tsx")
+        ) {
+          return [entryPath];
+        }
+        return [];
+      }),
+    )
+  ).flat();
+};
+
+const navigationViolations = async (filePath: string): Promise<string[]> => {
+  const sourceText = await readFile(filePath, "utf-8");
+  const sourceFile = ts.createSourceFile(
+    filePath,
+    sourceText,
+    ts.ScriptTarget.Latest,
+    true,
+  );
+  const violations: string[] = [];
+
+  const visit = (node: ts.Node) => {
+    if (ts.isCallExpression(node) && isPageNavigation(node)) {
+      const lifecycle = navigationLifecycle(node);
+      if (!READINESS_LIFECYCLES.has(lifecycle ?? "")) {
+        const { line } = sourceFile.getLineAndCharacterOfPosition(
+          node.getStart(sourceFile),
+        );
+        violations.push(
+          `${path.relative(E2E_ROOT, filePath)}:${line + 1} uses ${
+            node.expression.name.text
+          } without waitUntil: "commit" or "domcontentloaded"`,
+        );
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+
+  visit(sourceFile);
+  return violations;
+};
+
+type PageNavigationCall = ts.CallExpression & {
+  expression: ts.PropertyAccessExpression & {
+    expression: ts.Identifier;
+  };
+};
+
+const isPageNavigation = (
+  call: ts.CallExpression,
+): call is PageNavigationCall =>
+  ts.isPropertyAccessExpression(call.expression) &&
+  ts.isIdentifier(call.expression.expression) &&
+  call.expression.expression.text === "page" &&
+  (call.expression.name.text === "goto" ||
+    call.expression.name.text === "reload");
+
+const navigationLifecycle = (call: PageNavigationCall): string | null => {
+  const method = call.expression.name.text;
+  const options = call.arguments.at(method === "goto" ? 1 : 0);
+  if (!options || !ts.isObjectLiteralExpression(options)) {
+    return null;
+  }
+  const waitUntil = options.properties.find(
+    (property) =>
+      ts.isPropertyAssignment(property) &&
+      property.name.getText() === "waitUntil",
+  );
+  if (!waitUntil || !ts.isPropertyAssignment(waitUntil)) {
+    return null;
+  }
+  return ts.isStringLiteral(waitUntil.initializer)
+    ? waitUntil.initializer.text
+    : null;
+};

--- a/apps/web/e2e/specs/smoke.spec.ts
+++ b/apps/web/e2e/specs/smoke.spec.ts
@@ -1,7 +1,11 @@
+import { appShellNavigationLink } from "../helpers/app-shell";
 import { expect, test } from "../helpers/test";
 
 test("authenticated session lands inside the app shell", async ({ page }) => {
-  await page.goto("/");
+  await page.goto("/", { waitUntil: "commit" });
+  await expect(appShellNavigationLink(page, "/chat")).toBeVisible({
+    timeout: 30_000,
+  });
   // Authenticated users never see /auth/*; the protected routes either render
   // or redirect deeper. toHaveURL auto-retries so client-side redirects can't
   // race a static URL assertion.

--- a/apps/web/e2e/specs/template-studio.spec.ts
+++ b/apps/web/e2e/specs/template-studio.spec.ts
@@ -70,6 +70,10 @@ test.describe("Template Studio", () => {
         exact: true,
         name: "Save",
       });
+      const saveCompleted = page.getByRole("heading", {
+        exact: true,
+        name: "Template saved",
+      });
       const saveResponse = page.waitForResponse(
         (response) =>
           response.request().method() === "POST" &&
@@ -80,6 +84,10 @@ test.describe("Template Studio", () => {
       );
       await saveButton.click();
       expect((await saveResponse).ok()).toBe(true);
+      // The response event precedes Eden response parsing and the page's
+      // dirty-state reconciliation. The success toast is the explicit product
+      // signal that the save action (including deferred clause renames) won.
+      await expect(saveCompleted).toBeVisible();
       await expect(saveButton).toHaveCount(0);
 
       await page.reload({ waitUntil: "domcontentloaded" });

--- a/apps/web/e2e/staging/staging-smoke.spec.ts
+++ b/apps/web/e2e/staging/staging-smoke.spec.ts
@@ -1,5 +1,7 @@
 import { expect, test } from "@playwright/test";
 
+import { appShellNavigationLink } from "../helpers/app-shell";
+
 // The smoke user mirrors the production default state: org owner,
 // no usage entitlement row, no AI provider config. Regressions that
 // only appear in that state must fail here, not in front of a user.
@@ -20,14 +22,15 @@ test.beforeEach(({ page }) => {
 });
 
 test("deployed app serves the authenticated shell", async ({ page }) => {
-  await page.goto("/");
+  await page.goto("/", { waitUntil: "commit" });
+  await expect(appShellNavigationLink(page, "/chat")).toBeVisible();
   await expect(page).not.toHaveURL(/\/auth(?:\/|$)/u);
 });
 
 test("chat thread page renders for an entitlement-less owner", async ({
   page,
 }) => {
-  await page.goto("/chat/new");
+  await page.goto("/chat/new", { waitUntil: "commit" });
   await expect(page).toHaveURL(/\/chat\/[0-9a-f-]+$/u);
 
   // The route error boundary replaces the thread UI wholesale; its
@@ -69,7 +72,7 @@ test("server-rendered public law pages hydrate cleanly", async ({ page }) => {
     pageErrors.push(error.message);
   });
 
-  await page.goto("/law/cases");
+  await page.goto("/law/cases", { waitUntil: "commit" });
   // Scoped to the decisions table: the shell sidebar also carries a
   // /law/cases nav link that a page-wide href filter could match.
   const firstDecision = page
@@ -83,7 +86,7 @@ test("server-rendered public law pages hydrate cleanly", async ({ page }) => {
 
   // Force a full server-rendered load of the decision page: client-side
   // navigation alone would never exercise the hydration path that broke.
-  await page.reload();
+  await page.reload({ waitUntil: "commit" });
 
   // Case numbers look like "6 Tdo 647/2017"; anchoring on the slash-year
   // tail keeps the regex linear.

--- a/apps/web/src/routes/_protected.knowledge/-components/template-studio-dirty.test.ts
+++ b/apps/web/src/routes/_protected.knowledge/-components/template-studio-dirty.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from "bun:test";
+
+import { hasUnsavedEditorChanges } from "@/routes/_protected.knowledge/-components/template-studio-dirty";
+
+describe("Template Studio document dirty state", () => {
+  test("reconciles a delayed editor notification against the current save state", () => {
+    let hasPendingChanges = true;
+    const editor = {
+      hasPendingChanges: () => hasPendingChanges,
+    };
+
+    expect(hasUnsavedEditorChanges(editor)).toBe(true);
+
+    // Folio debounces onChange. A notification queued by the edit can arrive
+    // after save has serialized the document and cleared its change markers.
+    hasPendingChanges = false;
+    expect(hasUnsavedEditorChanges(editor)).toBe(false);
+  });
+
+  test("does not treat editor initialization as an unsaved edit", () => {
+    expect(hasUnsavedEditorChanges(null)).toBe(false);
+  });
+});

--- a/apps/web/src/routes/_protected.knowledge/-components/template-studio-dirty.ts
+++ b/apps/web/src/routes/_protected.knowledge/-components/template-studio-dirty.ts
@@ -1,0 +1,12 @@
+import type { DocxEditorRef } from "@stll/folio-react";
+
+type PendingChangesReader = Pick<DocxEditorRef, "hasPendingChanges">;
+
+/**
+ * Folio batches document-change notifications. Read its current pending state
+ * when the notification arrives so a callback queued before save cannot make a
+ * fully serialized document dirty again after save clears its change markers.
+ */
+export const hasUnsavedEditorChanges = (
+  editor: PendingChangesReader | null,
+): boolean => editor?.hasPendingChanges() === true;

--- a/apps/web/src/routes/_protected.knowledge/-components/template-studio.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/template-studio.tsx
@@ -42,6 +42,7 @@ import {
   TEMPLATES_ROUTE_ID,
   templateStudioTabId,
 } from "@/routes/_protected.knowledge/-components/template-studio-constants";
+import { hasUnsavedEditorChanges } from "@/routes/_protected.knowledge/-components/template-studio-dirty";
 import {
   buildManifest,
   nextFreePath,
@@ -247,6 +248,11 @@ export const TemplateStudioPage = ({
   // Reactive twin of editorViewRef for children that re-render on view
   // creation (the floating AI bar needs a live prop, not a ref).
   const [liveEditorView, setLiveEditorView] = useState<EditorView | null>(null);
+  const handleEditorChange = useCallback(() => {
+    if (hasUnsavedEditorChanges(editorRef.current)) {
+      markDirty();
+    }
+  }, [markDirty]);
   // Right-click on selected text offers the structural gestures directly:
   // turn it into a {{field}}, or wrap it in a condition / loop block.
   const makeFieldContextItems = useMemo(
@@ -994,7 +1000,6 @@ export const TemplateStudioPage = ({
       }
 
       markSaved();
-      stellaToast.add({ title: t("templates.templateSaved"), type: "success" });
 
       // Flush deferred link-row slot renames now that the document (with its
       // already-rewritten {{@clause:...}} markers) is persisted, so the row
@@ -1099,6 +1104,12 @@ export const TemplateStudioPage = ({
           ),
         "handleSave",
       );
+      if (slotRenameErrorMessage === null) {
+        stellaToast.add({
+          title: t("templates.templateSaved"),
+          type: "success",
+        });
+      }
       // Report overall failure when a slot PATCH hard-failed: the document
       // itself saved, but "Save and leave" must stay in the Studio so the
       // still-pending steps (and their retry) are not discarded by the
@@ -1663,7 +1674,7 @@ export const TemplateStudioPage = ({
               documentBuffer={docBuffer}
               initialZoom={fitZoom}
               loadingIndicator={null}
-              onChange={markDirty}
+              onChange={handleEditorChange}
               onEditorViewReady={(view) => {
                 // Folio re-reports null on some re-renders; keep the last live
                 // view so selection syncing doesn't lose its reference.


### PR DESCRIPTION
## Summary

- decouple browser transport commit from named UI readiness and enforce explicit navigation lifecycles across E2E specs
- reconcile delayed Folio change notifications with the editor’s current pending-change state
- publish Template Studio success only after persistence and deferred clause-rename reconciliation, then synchronize the E2E assertion on that visible state

## Root causes

- The cold Vite server returned `/chat`, but the browser had not reached its global `load` event before the 20-second navigation deadline. The existing composer readiness assertion therefore never ran.
- Folio batches `onChange` notifications by 250 ms. A callback queued by the edit could arrive after save cleared Folio’s change markers and Template Studio called `markSaved()`, incorrectly making the saved session dirty again.
- A successful POST response event precedes Eden response parsing and Template Studio’s remaining save-state reconciliation.

## Structural safeguards

- an AST-backed policy test rejects future `page.goto`/`page.reload` calls without an explicit `commit` or `domcontentloaded` lifecycle
- E2E guidance in `AGENTS.md` requires named UI readiness and visible user-action completion states
- Template Studio reads Folio’s live `hasPendingChanges()` state when a delayed notification is delivered, so stale callbacks cannot re-dirty a completed save

No timeout was increased and no retry was added.

## Validation

- `bun run verify` (including 1,088 web tests across 147 files)
- `bun test apps/web/src/routes/_protected.knowledge/-components/template-studio-dirty.test.ts`
- `bun --filter @stll/web test:e2e -- e2e/specs/navigation-policy.unit.spec.ts`
- `bun packages/scripts/src/tsc-native.ts --noEmit -p apps/web/e2e/tsconfig.json`

CC on behalf of @jan-kubica

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Template Studio unsaved-change (dirty) detection to reflect pending edits accurately.
  - Template save confirmation (toast) now appears only after the UI’s post-save reconciliation completes successfully.

- **Tests**
  - Updated end-to-end navigation to synchronise using explicit readiness timing (`commit`/`domcontentloaded`) and to wait for visible completion states rather than successful HTTP responses.
  - Added automated checks to enforce consistent navigation readiness across E2E specs and validate app-shell navigation readiness.
  - Added coverage for unsaved editor changes behaviour.

- **Documentation**
  - Documented the required E2E navigation and completion synchronisation rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->