### PR TITLE
fix: make staging deployment platform-aware

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -493,6 +493,12 @@ jobs:
       - name: Test staging deployment watcher
         run: bash scripts/watch-github-run.test.sh
 
+      # The web compiler uses native Rolldown bindings, while the deployed
+      # container is ARM64. Keep build and runtime dependency architectures
+      # separated in the Docker stage graph.
+      - name: Test web container platform boundary
+        run: bun test scripts/check-web-docker-platform.test.ts
+
       # Release ordering is a safety property. This test has no workspace
       # dependencies, so it remains runnable when a PR changes only workflows
       # and the dependency install above is intentionally skipped.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -487,6 +487,12 @@ jobs:
       - name: Test release-channel script
         run: bash scripts/release-channel.test.sh
 
+      # The staging caller must outlive the infra job it dispatches, while
+      # rotating its short-lived GitHub App credential. This also tests that
+      # slow API calls consume a wall-clock deadline rather than extending it.
+      - name: Test staging deployment watcher
+        run: bash scripts/watch-github-run.test.sh
+
       # Release ordering is a safety property. This test has no workspace
       # dependencies, so it remains runnable when a PR changes only workflows
       # and the dependency install above is intentionally skipped.

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -22,11 +22,9 @@ jobs:
     name: Build + deploy staging
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-24.04-arm
-    # Headroom for a cache-miss image build (~15-25 min) plus the
-    # watcher budget below (45 min). Keep this strictly greater than
-    # build + watcher so the job's own timeout never guillotines the
-    # watcher before it can read the infra run's real conclusion.
-    timeout-minutes: 90
+    # Checked by scripts/watch-github-run.test.sh against the build and
+    # watcher budgets in deploy-staging-watch-config.sh.
+    timeout-minutes: 180
     permissions:
       contents: read
       packages: write
@@ -91,7 +89,7 @@ jobs:
           subject-digest: ${{ steps.build.outputs.digest }}
 
       - name: Mint App token for the infra repo
-        id: app-token
+        id: initial-app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           client-id: ${{ vars.STELLA_RELEASE_APP_CLIENT_ID }}
@@ -100,14 +98,17 @@ jobs:
           repositories: stella-infra
           permission-actions: write
 
-      - name: Dispatch and watch staging promote
+      - name: Dispatch staging promote
+        id: dispatch
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ steps.initial-app-token.outputs.token }}
           INFRA_REPO: ${{ github.repository_owner }}/stella-infra
           RELEASE_REF: ${{ steps.ref.outputs.release_ref }}
           GIT_SHA: ${{ github.sha }}
           IMAGE_DIGEST: ${{ steps.build.outputs.digest }}
         run: |
+          source scripts/deploy-staging-watch-config.sh
+          dispatch_epoch="$(date +%s)"
           dispatched_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           expected_title="Promote ${RELEASE_REF} → staging"
           run_id=""
@@ -191,70 +192,81 @@ jobs:
             exit 1
           fi
 
-          watch_run_with_retry() {
-            local run_id="$1"
-            # Budget is bounded by the GitHub App installation token's
-            # hard 1-hour lifetime: GH_TOKEN is minted in the prior step
-            # and `gh run view` against the infra repo needs it, so
-            # polling past ~1h starts hitting auth failures that this
-            # loop miscounts as transient errors and bails on after only
-            # ~2 min (max_consecutive_errors), masking the infra run's
-            # real status. Stay well under the hour: 270 x 10s = 45 min,
-            # which still covers a realistic promote (image import +
-            # migrate + terraform + a couple of ECS stabilize cycles run
-            # well under that) and far outlasts the old 30-min budget
-            # that gave up before a slow deploy could report its
-            # conclusion. A promote that hangs near the infra job's own
-            # 60-min timeout is surfaced as a watcher timeout here rather
-            # than chased past token expiry. Do NOT raise past ~55 min
-            # without first refreshing the App token inside the loop.
-            local max_attempts=270
-            local sleep_seconds=10
-            local max_consecutive_errors=12
-            local consecutive_errors=0
+          queue_deadline_epoch=$((dispatch_epoch + INFRA_PROMOTE_QUEUE_TIMEOUT_SECONDS))
+          phase_deadline_epoch=$((dispatch_epoch + INFRA_WATCH_TOKEN_PHASE_SECONDS))
+          {
+            echo "run_id=${run_id}"
+            echo "queue_deadline_epoch=${queue_deadline_epoch}"
+            echo "phase_deadline_epoch=${phase_deadline_epoch}"
+          } >> "$GITHUB_OUTPUT"
 
-            echo "Watching infra run ${run_id}..."
-            for attempt in $(seq 1 "$max_attempts"); do
-              if ! run_state="$(
-                gh run view "$run_id" \
-                  --repo "$INFRA_REPO" \
-                  --json status,conclusion,url \
-                  --jq '[.status, (.conclusion // ""), .url] | @tsv' 2>&1
-              )"; then
-                consecutive_errors=$((consecutive_errors + 1))
-                echo "::warning::Could not read infra run status (${consecutive_errors}/${max_consecutive_errors} transient errors): ${run_state}" >&2
-                if (( consecutive_errors >= max_consecutive_errors )); then
-                  echo "::error::Giving up after repeated GitHub API errors while watching infra run ${run_id}." >&2
-                  return 1
-                fi
-                sleep "$sleep_seconds"
-                continue
-              fi
+      - name: Watch staging promote
+        id: initial-watch
+        env:
+          GH_TOKEN: ${{ steps.initial-app-token.outputs.token }}
+          INFRA_REPO: ${{ github.repository_owner }}/stella-infra
+        run: |
+          source scripts/deploy-staging-watch-config.sh
+          bash scripts/watch-github-run.sh \
+            "${{ steps.dispatch.outputs.run_id }}" \
+            0 \
+            "${{ steps.dispatch.outputs.queue_deadline_epoch }}" \
+            "${{ steps.dispatch.outputs.phase_deadline_epoch }}"
 
-              consecutive_errors=0
-              IFS=$'\t' read -r status conclusion url <<< "$run_state"
+      # Installation tokens have a hard one-hour lifetime. A new token lets the
+      # watcher outlive the child job's full timeout without exposing App keys to
+      # the polling script.
+      - name: Refresh App token for the infra repo
+        if: steps.initial-watch.outputs.state == 'pending'
+        id: refreshed-app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.STELLA_RELEASE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.STELLA_RELEASE_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: stella-infra
+          permission-actions: write
 
-              if [[ "$status" == "completed" ]]; then
-                if [[ "$conclusion" == "success" ]]; then
-                  echo "Infra run succeeded: ${url}"
-                  return 0
-                fi
+      - name: Continue watching staging promote
+        id: refreshed-watch
+        if: steps.initial-watch.outputs.state == 'pending'
+        env:
+          GH_TOKEN: ${{ steps.refreshed-app-token.outputs.token }}
+          INFRA_REPO: ${{ github.repository_owner }}/stella-infra
+        run: |
+          source scripts/deploy-staging-watch-config.sh
+          phase_deadline_epoch=$(($(date +%s) + INFRA_WATCH_TOKEN_PHASE_SECONDS))
+          bash scripts/watch-github-run.sh \
+            "${{ steps.dispatch.outputs.run_id }}" \
+            "${{ steps.initial-watch.outputs.watch_deadline_epoch }}" \
+            "${{ steps.dispatch.outputs.queue_deadline_epoch }}" \
+            "$phase_deadline_epoch"
 
-                echo "::error::Infra run completed with conclusion '${conclusion}': ${url}" >&2
-                return 1
-              fi
+      - name: Refresh App token for a queued staging promote
+        if: steps.refreshed-watch.outputs.state == 'pending'
+        id: final-app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.STELLA_RELEASE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.STELLA_RELEASE_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: stella-infra
+          permission-actions: write
 
-              if (( attempt == 1 || attempt % 6 == 0 )); then
-                echo "Infra run status: ${status} (${attempt}/${max_attempts})"
-              fi
-              sleep "$sleep_seconds"
-            done
-
-            echo "::error::Infra run ${run_id} did not complete within $((max_attempts * sleep_seconds / 60)) minutes." >&2
-            return 1
-          }
-
-          watch_run_with_retry "$run_id"
+      - name: Finish watching queued staging promote
+        if: steps.refreshed-watch.outputs.state == 'pending'
+        env:
+          GH_TOKEN: ${{ steps.final-app-token.outputs.token }}
+          INFRA_REPO: ${{ github.repository_owner }}/stella-infra
+        run: |
+          source scripts/deploy-staging-watch-config.sh
+          queue_deadline_epoch="${{ steps.dispatch.outputs.queue_deadline_epoch }}"
+          final_phase_deadline_epoch=$((queue_deadline_epoch + INFRA_WATCH_BUDGET_SECONDS))
+          bash scripts/watch-github-run.sh \
+            "${{ steps.dispatch.outputs.run_id }}" \
+            "${{ steps.refreshed-watch.outputs.watch_deadline_epoch }}" \
+            "${{ steps.dispatch.outputs.queue_deadline_epoch }}" \
+            "$final_phase_deadline_epoch"
 
   # Post-deploy verification: authenticate via the secret-guarded
   # /smoke/session endpoint and click through the deployed app so a

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -1,8 +1,15 @@
-# Pin to digest for supply-chain integrity (oven/bun:1.3.14-slim)
-FROM oven/bun:1.3.14-slim@sha256:d56a2534ffd262e92c12fd3249d3924d296d97086da773f821d7d0477435ea04 AS base
+# Pin to digest for supply-chain integrity (oven/bun:1.3.14-slim).
+# Compile on the native build host; only the runtime dependency tree and final
+# image belong to the deployment target. This keeps Rolldown and its native
+# binding off target-architecture emulation while preserving ARM64 runtime
+# dependencies such as sharp/canvas.
+FROM --platform=$BUILDPLATFORM oven/bun:1.3.14-slim@sha256:d56a2534ffd262e92c12fd3249d3924d296d97086da773f821d7d0477435ea04 AS build-base
 WORKDIR /app
 
-FROM base AS install-inputs
+FROM --platform=$TARGETPLATFORM oven/bun:1.3.14-slim@sha256:d56a2534ffd262e92c12fd3249d3924d296d97086da773f821d7d0477435ea04 AS runtime-base
+WORKDIR /app
+
+FROM build-base AS install-inputs
 # Preserve Bun's committed root lockfile and full workspace manifest map.
 # Turbo's pruned bun.lock is a generated approximation and can drift from
 # Bun's catalog/resolution semantics.
@@ -16,7 +23,7 @@ RUN mkdir -p /json && \
       -not -path '*/node_modules/*' \
       -exec cp --parents -t /json/ {} +
 
-FROM base AS pruner
+FROM build-base AS pruner
 # Keep in sync with the turbo version in the root package.json.
 RUN bun install -g turbo@2.10.5
 COPY . .
@@ -28,14 +35,14 @@ COPY . .
 # transitive workspace graph (@stll/web -> @stll/api -> ...) changes.
 RUN turbo prune @stll/web --docker
 
-FROM base AS deps
+FROM build-base AS deps
 COPY --from=install-inputs /json/ .
 RUN bun install --filter @stll/web --frozen-lockfile --ignore-scripts --network-concurrency=8
 
 # Runtime install: the SSR server bundle (dist/server/server.js) externalises
 # its imports, so they must resolve from `dependencies` alone with
 # devDependencies stripped. The web-build CI job boot-smokes this same install.
-FROM base AS deps-prod
+FROM runtime-base AS deps-prod
 COPY --from=install-inputs /json/ .
 RUN bun install --filter @stll/web --production --frozen-lockfile --ignore-scripts --network-concurrency=8
 

--- a/scripts/check-web-docker-platform.test.ts
+++ b/scripts/check-web-docker-platform.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, test } from "bun:test";
+
+type DockerStage = {
+  body: string;
+  name: string;
+  parent: string;
+  platform: string | undefined;
+};
+
+const dockerfilePath = new URL("../apps/web/Dockerfile", import.meta.url);
+const dockerfile = await Bun.file(dockerfilePath).text();
+const stages = parseStages(dockerfile);
+const stagesByName = new Map(stages.map((stage) => [stage.name, stage]));
+
+describe("web container platform boundary", () => {
+  test("runs the JavaScript toolchain on the native build platform", () => {
+    for (const stageName of ["install-inputs", "pruner", "deps", "builder"]) {
+      expect(resolvePlatform(stageName)).toBe("$BUILDPLATFORM");
+    }
+
+    const compilerStage = stages.find((stage) =>
+      stage.body.includes("bun --filter @stll/web build"),
+    );
+    expect(compilerStage?.name).toBe("builder");
+    expect(resolvePlatform(compilerStage?.name ?? "")).toBe("$BUILDPLATFORM");
+  });
+
+  test("installs production native dependencies for the target runtime", () => {
+    expect(resolvePlatform("deps-prod")).toBe("$TARGETPLATFORM");
+    expect(resolvePlatform("runner")).toBe("$TARGETPLATFORM");
+    expect(stagesByName.get("deps-prod")?.body).toContain(
+      "bun install --filter @stll/web --production",
+    );
+  });
+
+  test("copies only architecture-independent build output across platforms", () => {
+    const runner = stagesByName.get("runner");
+    expect(runner?.parent).toBe("deps-prod");
+    expect(runner?.body).toContain(
+      "COPY --chown=stella:stella --from=builder /app/apps/web/dist ./apps/web/dist",
+    );
+    expect(runner?.body).not.toMatch(/--from=builder .*node_modules/u);
+
+    const crossPlatformCopies = stages.flatMap((stage) => {
+      const destinationPlatform = resolvePlatform(stage.name);
+      return stage.body
+        .split("\n")
+        .filter((line) => line.startsWith("COPY "))
+        .flatMap((line) => {
+          const sourceName = /--from=([^\s]+)/u.exec(line)?.at(1);
+          if (!sourceName || !stagesByName.has(sourceName)) {
+            return [];
+          }
+          if (resolvePlatform(sourceName) === destinationPlatform) {
+            return [];
+          }
+          return [`${stage.name}: ${line}`];
+        });
+    });
+    expect(crossPlatformCopies).toEqual([
+      "deps-prod: COPY --from=install-inputs /json/ .",
+      "runner: COPY --chown=stella:stella --from=pruner /app/out/full/ .",
+      "runner: COPY --chown=stella:stella --from=builder /app/apps/web/dist ./apps/web/dist",
+    ]);
+  });
+
+  test("uses the same pinned multi-architecture base for build and runtime", () => {
+    const buildBase = stagesByName.get("build-base");
+    const runtimeBase = stagesByName.get("runtime-base");
+    expect(buildBase?.parent).toBe(runtimeBase?.parent);
+    expect(buildBase?.parent).toContain("@sha256:");
+  });
+});
+
+function parseStages(source: string): DockerStage[] {
+  const parsed: DockerStage[] = [];
+  let current: DockerStage | undefined;
+
+  for (const line of source.split("\n")) {
+    const from =
+      /^FROM(?:\s+--platform=(\S+))?\s+(\S+)\s+AS\s+(\S+)\s*$/iu.exec(line);
+    if (from) {
+      current = {
+        body: "",
+        name: from.at(3) ?? "",
+        parent: from.at(2) ?? "",
+        platform: from.at(1),
+      };
+      parsed.push(current);
+      continue;
+    }
+
+    if (current) {
+      current.body += `${line}\n`;
+    }
+  }
+
+  return parsed;
+}
+
+function resolvePlatform(stageName: string, seen = new Set<string>()): string {
+  if (seen.has(stageName)) {
+    throw new Error(`Docker stage cycle at ${stageName}`);
+  }
+  seen.add(stageName);
+
+  const stage = stagesByName.get(stageName);
+  if (!stage) {
+    throw new Error(`Unknown Docker stage: ${stageName}`);
+  }
+  if (stage.platform) {
+    return stage.platform;
+  }
+  if (!stagesByName.has(stage.parent)) {
+    throw new Error(`Docker stage ${stageName} has no explicit platform root`);
+  }
+
+  return resolvePlatform(stage.parent, seen);
+}

--- a/scripts/deploy-staging-watch-config.sh
+++ b/scripts/deploy-staging-watch-config.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+# The infra promote job owns a 60-minute timeout. The caller must keep watching
+# beyond that boundary so it can report the child's terminal conclusion instead
+# of manufacturing an earlier timeout of its own.
+readonly INFRA_PROMOTE_TIMEOUT_SECONDS=3600
+readonly INFRA_WATCH_MARGIN_SECONDS=600
+
+# Infra concurrency permits one running promote and one pending successor. A
+# caller may therefore wait for the running 60-minute job before its own child
+# starts. Bound that distinct queue state with the same ten-minute headroom.
+readonly INFRA_PROMOTE_QUEUE_TIMEOUT_SECONDS=4200
+
+# GitHub App installation tokens expire after one hour. Rotate before then;
+# every phase carries forward the deadline derived from the child job start.
+readonly INFRA_WATCH_TOKEN_PHASE_SECONDS=3000
+readonly INFRA_WATCH_POLL_SECONDS=10
+readonly INFRA_WATCH_MAX_CONSECUTIVE_ERRORS=12
+export INFRA_WATCH_POLL_SECONDS INFRA_WATCH_MAX_CONSECUTIVE_ERRORS
+
+readonly STAGING_IMAGE_BUILD_BUDGET_SECONDS=1500
+readonly STAGING_DEPLOY_JOB_TIMEOUT_MINUTES=180
+
+readonly INFRA_WATCH_BUDGET_SECONDS=$((
+  INFRA_PROMOTE_TIMEOUT_SECONDS + INFRA_WATCH_MARGIN_SECONDS
+))
+readonly INFRA_MAX_CALLER_WAIT_SECONDS=$((
+  INFRA_PROMOTE_QUEUE_TIMEOUT_SECONDS + INFRA_WATCH_BUDGET_SECONDS
+))
+export INFRA_WATCH_BUDGET_SECONDS

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -225,6 +225,7 @@ run_step "Knip production deps" run_knip
 run_step "Test" run_test
 run_step "Bridge-version guard self-test" bash scripts/check-bridge-version.test.sh
 run_step "Release-channel self-test" bash scripts/release-channel.test.sh
+run_step "Staging watcher self-test" bash scripts/watch-github-run.test.sh
 run_step "API release contract self-test" bun test \
   --preload ./apps/api/src/tests/setup-env.ts \
   scripts/check-api-cli-contract.test.ts \

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -226,6 +226,8 @@ run_step "Test" run_test
 run_step "Bridge-version guard self-test" bash scripts/check-bridge-version.test.sh
 run_step "Release-channel self-test" bash scripts/release-channel.test.sh
 run_step "Staging watcher self-test" bash scripts/watch-github-run.test.sh
+run_step "Web container platform self-test" bun test \
+  scripts/check-web-docker-platform.test.ts
 run_step "API release contract self-test" bun test \
   --preload ./apps/api/src/tests/setup-env.ts \
   scripts/check-api-cli-contract.test.ts \

--- a/scripts/watch-github-run.sh
+++ b/scripts/watch-github-run.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage="usage: watch-github-run.sh RUN_ID WATCH_DEADLINE_EPOCH QUEUE_DEADLINE_EPOCH PHASE_DEADLINE_EPOCH"
+run_id="${1:?$usage}"
+watch_deadline_epoch="${2:?$usage}"
+queue_deadline_epoch="${3:?$usage}"
+phase_deadline_epoch="${4:?$usage}"
+
+: "${INFRA_REPO:?INFRA_REPO must name the repository containing the run}"
+: "${GITHUB_OUTPUT:?GITHUB_OUTPUT must name the step output file}"
+
+: "${INFRA_WATCH_POLL_SECONDS:?source deploy-staging-watch-config.sh before invoking this script}"
+: "${INFRA_WATCH_MAX_CONSECUTIVE_ERRORS:?source deploy-staging-watch-config.sh before invoking this script}"
+: "${INFRA_WATCH_BUDGET_SECONDS:?source deploy-staging-watch-config.sh before invoking this script}"
+
+for integer in \
+  "$run_id" \
+  "$watch_deadline_epoch" \
+  "$queue_deadline_epoch" \
+  "$phase_deadline_epoch"; do
+  if [[ ! "$integer" =~ ^[0-9]+$ ]]; then
+    echo "::error::Watcher arguments must be non-negative integers." >&2
+    exit 1
+  fi
+done
+
+poll_seconds="$INFRA_WATCH_POLL_SECONDS"
+max_consecutive_errors="$INFRA_WATCH_MAX_CONSECUTIVE_ERRORS"
+consecutive_errors=0
+next_status_log_epoch=0
+
+write_state() {
+  {
+    printf 'state=%s\n' "$1"
+    printf 'watch_deadline_epoch=%s\n' "$watch_deadline_epoch"
+  } >> "$GITHUB_OUTPUT"
+}
+
+echo "Watching infra run ${run_id}..."
+while true; do
+  now="$(date +%s)"
+  if (( watch_deadline_epoch > 0 && now >= watch_deadline_epoch )); then
+    echo "::error::Infra run ${run_id} did not complete before the watch deadline." >&2
+    exit 1
+  fi
+  if (( watch_deadline_epoch == 0 && now >= queue_deadline_epoch )); then
+    echo "::error::Infra run ${run_id} did not start before the queue deadline." >&2
+    exit 1
+  fi
+  if (( now >= phase_deadline_epoch )); then
+    echo "Watch phase ended with the infra run still active; refreshing credentials."
+    write_state pending
+    exit 0
+  fi
+
+  if (( watch_deadline_epoch == 0 )); then
+    run_fields='[.status, (.conclusion // ""), .url, (.jobs[0].status // ""), (.jobs[0].startedAt // "")] | join("|")'
+    run_json_fields='status,conclusion,url,jobs'
+  else
+    run_fields='[.status, (.conclusion // ""), .url, "", ""] | join("|")'
+    run_json_fields='status,conclusion,url'
+  fi
+
+  if ! run_state="$(
+    gh run view "$run_id" \
+      --repo "$INFRA_REPO" \
+      --json "$run_json_fields" \
+      --jq "$run_fields" 2>&1
+  )"; then
+    consecutive_errors=$((consecutive_errors + 1))
+    echo "::warning::Could not read infra run status (${consecutive_errors}/${max_consecutive_errors} transient errors): ${run_state}" >&2
+    if (( consecutive_errors >= max_consecutive_errors )); then
+      echo "::error::Giving up after repeated GitHub API errors while watching infra run ${run_id}." >&2
+      exit 1
+    fi
+  else
+    consecutive_errors=0
+    IFS='|' read -r status conclusion url job_status job_started_at <<< "$run_state"
+
+    if [[ "$status" == "completed" ]]; then
+      if [[ "$conclusion" == "success" ]]; then
+        echo "Infra run succeeded: ${url}"
+        write_state succeeded
+        exit 0
+      fi
+
+      echo "::error::Infra run completed with conclusion '${conclusion}': ${url}" >&2
+      exit 1
+    fi
+
+    if (( watch_deadline_epoch == 0 )) \
+      && [[ "$job_status" != "queued" ]] \
+      && [[ -n "$job_started_at" ]] \
+      && [[ "$job_started_at" != 0001-* ]]; then
+      job_started_epoch="$(date --date="$job_started_at" +%s)"
+      watch_deadline_epoch=$((job_started_epoch + INFRA_WATCH_BUDGET_SECONDS))
+      echo "Infra job started at ${job_started_at}; watching through epoch ${watch_deadline_epoch}."
+    fi
+
+    now="$(date +%s)"
+    if (( now >= next_status_log_epoch )); then
+      echo "Infra run status: ${status}; job status: ${job_status:-unknown}"
+      next_status_log_epoch=$((now + 60))
+    fi
+  fi
+
+  # Re-read the clock after the API request. A slow request consumes budget;
+  # it must not buy the loop another full sleep or another polling attempt.
+  now="$(date +%s)"
+  next_boundary="$phase_deadline_epoch"
+  if (( watch_deadline_epoch > 0 && watch_deadline_epoch < next_boundary )); then
+    next_boundary="$watch_deadline_epoch"
+  fi
+  if (( watch_deadline_epoch == 0 && queue_deadline_epoch < next_boundary )); then
+    next_boundary="$queue_deadline_epoch"
+  fi
+  remaining_seconds=$((next_boundary - now))
+  if (( remaining_seconds <= 0 )); then
+    continue
+  fi
+
+  sleep_seconds="$poll_seconds"
+  if (( remaining_seconds < sleep_seconds )); then
+    sleep_seconds="$remaining_seconds"
+  fi
+  sleep "$sleep_seconds"
+done

--- a/scripts/watch-github-run.test.sh
+++ b/scripts/watch-github-run.test.sh
@@ -1,0 +1,231 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+watch_script="$repo_root/scripts/watch-github-run.sh"
+config_script="$repo_root/scripts/deploy-staging-watch-config.sh"
+workflow="$repo_root/.github/workflows/deploy-staging.yml"
+pass=0
+fail=0
+
+assert_eq() {
+  local name="$1" expected="$2" actual="$3"
+  if [[ "$actual" == "$expected" ]]; then
+    pass=$((pass + 1))
+    printf '  ✓ %s\n' "$name"
+    return
+  fi
+
+  fail=$((fail + 1))
+  printf '  ✗ %s (expected %q, got %q)\n' "$name" "$expected" "$actual"
+}
+
+setup_mocks() {
+  test_dir="$(mktemp -d)"
+  mock_bin="$test_dir/bin"
+  mkdir -p "$mock_bin"
+  printf '1000\n' > "$test_dir/clock"
+  printf '0\n' > "$test_dir/calls"
+  : > "$test_dir/output"
+
+  cat > "$mock_bin/date" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$1" == --date=* ]]; then
+  printf '%s\n' "$WATCH_TEST_JOB_STARTED_EPOCH"
+  exit 0
+fi
+cat "$WATCH_TEST_CLOCK"
+EOF
+  cat > "$mock_bin/sleep" <<'EOF'
+#!/usr/bin/env bash
+now="$(cat "$WATCH_TEST_CLOCK")"
+printf '%s\n' "$((now + $1))" > "$WATCH_TEST_CLOCK"
+EOF
+  cat > "$mock_bin/gh" <<'EOF'
+#!/usr/bin/env bash
+calls="$(cat "$WATCH_TEST_CALLS")"
+calls=$((calls + 1))
+printf '%s\n' "$calls" > "$WATCH_TEST_CALLS"
+
+if [[ -n "${WATCH_TEST_API_SECONDS:-}" ]]; then
+  now="$(cat "$WATCH_TEST_CLOCK")"
+  printf '%s\n' "$((now + WATCH_TEST_API_SECONDS))" > "$WATCH_TEST_CLOCK"
+fi
+
+case "$WATCH_TEST_MODE" in
+  active) printf 'in_progress||https://example.invalid/run|in_progress|2026-01-01T00:00:00Z\n' ;;
+  queued) printf 'queued||https://example.invalid/run|queued|\n' ;;
+  success) printf 'completed|success|https://example.invalid/run|completed|2026-01-01T00:00:00Z\n' ;;
+  failure) printf 'completed|failure|https://example.invalid/run|completed|2026-01-01T00:00:00Z\n' ;;
+  api-error) printf 'temporary error\n' >&2; exit 1 ;;
+esac
+EOF
+  chmod +x "$mock_bin/date" "$mock_bin/sleep" "$mock_bin/gh"
+}
+
+run_watch() {
+  local deadline="$1" queue_deadline="$2" phase_deadline="$3"
+  PATH="$mock_bin:$PATH" \
+    GITHUB_OUTPUT="$test_dir/output" \
+    INFRA_REPO=stella/stella-infra \
+    INFRA_WATCH_POLL_SECONDS=10 \
+    INFRA_WATCH_MAX_CONSECUTIVE_ERRORS=3 \
+    INFRA_WATCH_BUDGET_SECONDS=30 \
+    WATCH_TEST_CLOCK="$test_dir/clock" \
+    WATCH_TEST_CALLS="$test_dir/calls" \
+    WATCH_TEST_MODE="$WATCH_TEST_MODE" \
+    WATCH_TEST_API_SECONDS="${WATCH_TEST_API_SECONDS:-}" \
+    WATCH_TEST_JOB_STARTED_EPOCH="${WATCH_TEST_JOB_STARTED_EPOCH:-1000}" \
+    bash "$watch_script" \
+      123 "$deadline" "$queue_deadline" "$phase_deadline" >/dev/null 2>&1
+}
+
+cleanup_mocks() {
+  rm -rf "$test_dir"
+  unset \
+    test_dir \
+    mock_bin \
+    WATCH_TEST_MODE \
+    WATCH_TEST_API_SECONDS \
+    WATCH_TEST_JOB_STARTED_EPOCH
+}
+
+echo "Running staging watcher tests..."
+
+setup_mocks
+WATCH_TEST_MODE=active
+run_watch 1100 1200 1030
+assert_eq \
+  "active run ends phase as pending" \
+  $'state=pending\nwatch_deadline_epoch=1100' \
+  "$(cat "$test_dir/output")"
+assert_eq "phase uses elapsed time" "3" "$(cat "$test_dir/calls")"
+cleanup_mocks
+
+setup_mocks
+WATCH_TEST_MODE=active
+WATCH_TEST_API_SECONDS=9
+run_watch 1100 1200 1030
+assert_eq "API latency consumes the phase budget" "2" "$(cat "$test_dir/calls")"
+assert_eq "latency cannot overshoot the phase deadline" "1030" "$(cat "$test_dir/clock")"
+cleanup_mocks
+
+setup_mocks
+WATCH_TEST_MODE=success
+run_watch 1100 1200 1030
+assert_eq \
+  "successful child is terminal" \
+  $'state=succeeded\nwatch_deadline_epoch=1100' \
+  "$(cat "$test_dir/output")"
+cleanup_mocks
+
+setup_mocks
+WATCH_TEST_MODE=failure
+run_watch 1100 1200 1030
+assert_eq "failed child fails watcher" "1" "$?"
+cleanup_mocks
+
+setup_mocks
+WATCH_TEST_MODE=active
+run_watch 1025 1200 1100
+assert_eq "overall deadline fails an active child" "1" "$?"
+assert_eq "overall deadline is not rounded to a poll" "1025" "$(cat "$test_dir/clock")"
+cleanup_mocks
+
+setup_mocks
+WATCH_TEST_MODE=queued
+run_watch 0 1025 1100
+assert_eq "queued child has its own bounded deadline" "1" "$?"
+assert_eq "queue deadline is exact" "1025" "$(cat "$test_dir/clock")"
+cleanup_mocks
+
+setup_mocks
+WATCH_TEST_MODE=active
+WATCH_TEST_JOB_STARTED_EPOCH=995
+run_watch 0 1100 1010
+assert_eq \
+  "child deadline is anchored to actual job start" \
+  $'state=pending\nwatch_deadline_epoch=1025' \
+  "$(cat "$test_dir/output")"
+cleanup_mocks
+
+setup_mocks
+WATCH_TEST_MODE=api-error
+run_watch 1100 1200 1090
+assert_eq "repeated API errors fail closed" "1" "$?"
+assert_eq "API error limit is bounded" "3" "$(cat "$test_dir/calls")"
+cleanup_mocks
+
+# This is the cross-file architecture guard. The config is the only source of
+# watch durations; the workflow sources it, rotates credentials between phases,
+# and its job timeout must retain headroom for build plus the full watch budget.
+source "$config_script"
+assert_eq \
+  "infra child timeout contract remains 60 minutes" \
+  "3600" \
+  "$INFRA_PROMOTE_TIMEOUT_SECONDS"
+if (( INFRA_WATCH_BUDGET_SECONDS > INFRA_PROMOTE_TIMEOUT_SECONDS )); then
+  pass=$((pass + 1))
+  printf '  ✓ watcher outlives child timeout\n'
+else
+  fail=$((fail + 1))
+  printf '  ✗ watcher must outlive child timeout\n'
+fi
+assert_eq "watcher has explicit ten-minute margin" "600" "$INFRA_WATCH_MARGIN_SECONDS"
+assert_eq \
+  "queue covers one child timeout plus margin" \
+  "$INFRA_WATCH_BUDGET_SECONDS" \
+  "$INFRA_PROMOTE_QUEUE_TIMEOUT_SECONDS"
+
+if (( INFRA_WATCH_TOKEN_PHASE_SECONDS <= 3000 )); then
+  pass=$((pass + 1))
+  printf '  ✓ credentials rotate at least ten minutes before expiry\n'
+else
+  fail=$((fail + 1))
+  printf '  ✗ credential phase must retain ten minutes of expiry headroom\n'
+fi
+
+if (( 3 * INFRA_WATCH_TOKEN_PHASE_SECONDS > INFRA_MAX_CALLER_WAIT_SECONDS )); then
+  pass=$((pass + 1))
+  printf '  ✓ three credential phases cover the maximum caller wait\n'
+else
+  fail=$((fail + 1))
+  printf '  ✗ credential phases do not cover the maximum caller wait\n'
+fi
+
+workflow_job_timeout="$(
+  awk '/name: Build \+ deploy staging/{in_job=1} in_job && /timeout-minutes:/{print $2; exit}' "$workflow"
+)"
+assert_eq \
+  "workflow timeout matches checked config" \
+  "$STAGING_DEPLOY_JOB_TIMEOUT_MINUTES" \
+  "$workflow_job_timeout"
+
+minimum_job_seconds=$((STAGING_IMAGE_BUILD_BUDGET_SECONDS + INFRA_MAX_CALLER_WAIT_SECONDS))
+if (( workflow_job_timeout * 60 > minimum_job_seconds )); then
+  pass=$((pass + 1))
+  printf '  ✓ workflow job cannot preempt its build and watcher budgets\n'
+else
+  fail=$((fail + 1))
+  printf '  ✗ workflow job timeout must exceed build plus watcher budgets\n'
+fi
+
+for required_pattern in \
+  'source scripts/deploy-staging-watch-config.sh' \
+  'queue_deadline_epoch=$((dispatch_epoch + INFRA_PROMOTE_QUEUE_TIMEOUT_SECONDS))' \
+  'name: Refresh App token for the infra repo' \
+  'name: Refresh App token for a queued staging promote' \
+  'steps.initial-watch.outputs.state == '\''pending'\''' \
+  'steps.refreshed-watch.outputs.state == '\''pending'\''' \
+  'bash scripts/watch-github-run.sh'; do
+  if grep -Fq "$required_pattern" "$workflow"; then
+    pass=$((pass + 1))
+    printf '  ✓ workflow invariant: %s\n' "$required_pattern"
+  else
+    fail=$((fail + 1))
+    printf '  ✗ workflow invariant missing: %s\n' "$required_pattern"
+  fi
+done
+
+printf '\nResults: %s passed, %s failed\n' "$pass" "$fail"
+(( fail == 0 ))


### PR DESCRIPTION
## Summary

- compile the web image on Docker `BUILDPLATFORM`, while installing production dependencies and assembling the runtime on `TARGETPLATFORM`
- replace poll-count staging waits with child-start and queue wall-clock deadlines that outlive the infra job contract
- rotate short-lived GitHub App credentials across bounded watch phases
- enforce the stage boundary, cross-platform copy allowlist, timeout arithmetic, and credential coverage in CI

## Validation

- full local `bun run verify`: 1,088 web tests across 147 files, affected lint/typecheck, and all repository guards
- 28 staging watcher clock/contract tests
- 4 Docker stage-graph/platform tests
- focused type-aware oxlint and oxfmt
- Bash syntax, YAML parse, secret scan, and pre-push affected typecheck

CC on behalf of jan-kubica