### PR TITLE
fix(case-law): reach the SK Constitutional Court without OAuth2

### DIFF
--- a/apps/api/src/handlers/case-law/ingestion/adapters/sk-us.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/sk-us.ts
@@ -1,17 +1,21 @@
 /**
  * Slovak Constitutional Court (Ústavný súd SR) adapter.
  *
- * Fetches decisions from the ustavnysud.sk REST API.
- * The API is a Liferay DXP headless service requiring
- * OAuth2 client_credentials authentication.
+ * Fetches decisions from the ustavnysud.sk REST API, a
+ * Liferay DXP headless service. ~52,000 decisions from 1993
+ * to present.
  *
- * Search: POST /o/v1/dms/search
- * Auth:   POST /o/oauth2/token (client_credentials)
+ * Search: POST /o/v1/dms/search (no auth)
  * PDFs:   GET  /docDownload/{documentId} (no auth)
  *
- * The client_id and client_secret are public credentials
- * embedded in the court's JavaScript bundle for anonymous
- * browser access. ~52,000 decisions from 1993 to present.
+ * Both endpoints are open. The search endpoint previously sat
+ * behind an OAuth2 client_credentials application whose
+ * credentials the court shipped in its own JavaScript bundle;
+ * that application has since been removed, and the token
+ * endpoint now answers `invalid_client` for it. Send no
+ * `Authorization` header at all: the endpoint rejects a
+ * request carrying one it cannot verify, so a stale token is
+ * worse than none.
  *
  * The Liferay DMS search endpoint has an internal pagination
  * cap (~3,000 results per query). To access the full archive,
@@ -50,22 +54,7 @@ import { isRecord } from "@/api/lib/type-guards";
 
 const BASE_URL = "https://www.ustavnysud.sk";
 const SEARCH_URL = `${BASE_URL}/o/v1/dms/search`;
-const TOKEN_URL = `${BASE_URL}/o/oauth2/token`;
 const DOC_DOWNLOAD_URL = `${BASE_URL}/docDownload`;
-
-/**
- * Public OAuth2 client credentials embedded in the court's
- * JavaScript bundle. These are shipped to every browser
- * that visits the search page — not secret API keys.
- * Configurable via env vars for rotation without code change.
- */
-// gitleaks:allow -- public credentials from court's JS bundle
-const CLIENT_ID =
-  process.env["SK_US_CLIENT_ID"] ?? "id-fab237c0-55ad-9fdf-9b9f-976eef3cbd9";
-// gitleaks:allow -- public credentials from court's JS bundle
-const CLIENT_SECRET =
-  process.env["SK_US_CLIENT_SECRET"] ??
-  "secret-579e7b79-b5b2-b22d-c1b3-204386e0447e";
 
 const PAGE_SIZE = 10;
 
@@ -113,54 +102,6 @@ const parseCursor = (cursor: string | null): YearCursor => {
 
 const encodeCursor = (c: YearCursor): string => `${c.year}:${c.offset}`;
 
-// ── OAuth2 token management ──────────────────────────────
-
-type CachedToken = { value: string; expiresAt: number };
-let cachedToken: CachedToken | null = null;
-
-const invalidateToken = (): void => {
-  cachedToken = null;
-};
-
-const getToken = async (signal?: AbortSignal): Promise<string> => {
-  if (cachedToken && Date.now() < cachedToken.expiresAt) {
-    return cachedToken.value;
-  }
-
-  const response = await fetchWithTimeout(TOKEN_URL, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/x-www-form-urlencoded",
-      "User-Agent": INGESTION_USER_AGENT,
-    },
-    body: `grant_type=client_credentials&client_id=${CLIENT_ID}&client_secret=${CLIENT_SECRET}`,
-    signal,
-    timeoutMs: ADAPTER_TIMEOUT.REQUEST,
-  });
-
-  if (!response.ok) {
-    throw new FetchBoundaryError({
-      url: TOKEN_URL,
-      status: response.status,
-      statusText: response.statusText,
-      message: `SK ÚS OAuth2 token failed: ${response.status}`,
-    });
-  }
-
-  const data = await response.json();
-  if (!isTokenResponse(data)) {
-    panic("SK ÚS OAuth2 token returned an invalid payload");
-  }
-
-  // Cache with 30s safety margin
-  cachedToken = {
-    value: data.access_token,
-    expiresAt: Date.now() + (data.expires_in - 30) * 1000,
-  };
-
-  return data.access_token;
-};
-
 // ── Search API types ─────────────────────────────────────
 
 type SearchDocument = {
@@ -199,13 +140,6 @@ type SearchResponse = {
   documents: SearchDocument[];
   numFound: number;
 };
-
-const isTokenResponse = (
-  value: unknown,
-): value is { access_token: string; expires_in: number } =>
-  isRecord(value) &&
-  typeof value["access_token"] === "string" &&
-  typeof value["expires_in"] === "number";
 
 /**
  * Validate only the response envelope. Individual document
@@ -376,13 +310,10 @@ const executeSearch = async (
   offset: number,
   signal?: AbortSignal,
 ): Promise<SearchResponse | null> => {
-  const token = await getToken(signal);
-
   const response = await fetchWithTimeout(SEARCH_URL, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
-      Authorization: `Bearer ${token}`,
       "User-Agent": INGESTION_USER_AGENT,
     },
     body: JSON.stringify({
@@ -411,9 +342,9 @@ const executeSearch = async (
   });
 
   if (!response.ok) {
-    if (response.status === 401 || response.status === 403) {
-      invalidateToken();
-    }
+    // A 401/403 here means the court put the endpoint back behind
+    // authentication. There is no credential to refresh — the adapter
+    // needs a real one — so surface it rather than retrying blind.
     throw new FetchBoundaryError({
       url: SEARCH_URL,
       status: response.status,
@@ -428,7 +359,6 @@ const executeSearch = async (
 
   const data = await response.json();
   if (!isSearchResponse(data)) {
-    invalidateToken();
     const preview = JSON.stringify(data).slice(0, 200);
     panic(`SK ÚS search returned an invalid payload: ${preview}`);
   }
@@ -464,7 +394,8 @@ export const skUsAdapter: SourceAdapter = {
           if (error instanceof DOMException) {
             throw error;
           }
-          // Retry once with a fresh token
+          // One retry: the DMS search is intermittently flaky under
+          // load. An abort is not retried (handled above).
           data = await executeSearch(year, offset, signal);
         }
 

--- a/apps/api/src/handlers/case-law/ingestion/adapters/sk-us.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/sk-us.ts
@@ -305,6 +305,14 @@ const parseDocument = async (
 
 // ── Search helper ───────────────────────────────────────
 
+/** HTTP statuses that mean "authenticate", which this adapter cannot. */
+const AUTH_FAILURE_STATUSES = new Set([401, 403]);
+
+const isAuthFailure = (error: unknown): boolean =>
+  error instanceof FetchBoundaryError &&
+  error.status !== undefined &&
+  AUTH_FAILURE_STATUSES.has(error.status);
+
 const executeSearch = async (
   year: number,
   offset: number,
@@ -392,6 +400,13 @@ export const skUsAdapter: SourceAdapter = {
           data = await executeSearch(year, offset, signal);
         } catch (error) {
           if (error instanceof DOMException) {
+            throw error;
+          }
+          // A 401/403 is the court putting the endpoint back behind
+          // authentication, not a flaky request. There is no credential
+          // to refresh, so an identical second attempt can only fail the
+          // same way: surface it instead of doubling the traffic.
+          if (isAuthFailure(error)) {
             throw error;
           }
           // One retry: the DMS search is intermittently flaky under

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -1277,7 +1277,6 @@ export default defineConfig({
           {
             allowedFiles: [
               "apps/api/src/db-url.ts",
-              "apps/api/src/handlers/case-law/ingestion/adapters/sk-us.ts",
               "apps/api/src/handlers/case-law/ingestion/adapters/utils.ts",
               "apps/api/src/handlers/health/routes.ts",
               "apps/api/src/server.ts",


### PR DESCRIPTION
The `sk-us` adapter authenticated against the court's DMS search with an OAuth2 client_credentials application whose id and secret the court published in its own JavaScript bundle, carried here as defaults. That application no longer exists — the token endpoint answers `invalid_client` — so every cycle failed at the token step before issuing a single search.

Replacing the credentials is not the fix, because the endpoint is now open:

- `POST /o/v1/dms/search` unauthenticated returns the full result set, paginates (verified at `start=1500`), and covers 1993 through the current year.
- `GET /docDownload/{documentId}` was already unauthenticated and still is.

So the token flow goes away rather than being re-credentialed.

Sending no `Authorization` header is load-bearing, not incidental: a request carrying a header the endpoint cannot verify is rejected with 401, so an unusable token is strictly worse than none. Consequently a 401/403 now means the court has put the endpoint back behind authentication — which needs a real credential, not a token refresh — and it is surfaced instead of retried.

Also removes the adapter's two `process.env` reads along with the credentials, so it no longer needs its entry in the `forbid-process-env-outside-env-ts` allowlist. Leaving a stale entry there would silently permit future direct env reads in this file.

## Verification

Ran the adapter against the live API for the `2024:0` cursor: 10 decisions returned, each with fulltext (11-16 KB) and a parsed AST (38-51 blocks), ECLI and dates populated, cursor advancing to `2024:10`.

`bun run test` in `apps/api` (case-law and security suites included).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Slovak Constitutional Court case-law retrieval by removing unnecessary token-based authentication.
  * Requests no longer include authorization headers when calling publicly accessible search and PDF endpoints.
  * Updated handling of access failures to surface authentication problems immediately, while preserving retry for intermittent non-auth search issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->