### PR TITLE
fix(case-law): treat a halted ingest cycle's completed pages as progress

### DIFF
--- a/apps/legal-atlas-runner/src/runners/case-law-ingest.ts
+++ b/apps/legal-atlas-runner/src/runners/case-law-ingest.ts
@@ -49,6 +49,11 @@ import {
   loadCourtWeightEntries,
 } from "../db";
 import { LEGAL_ATLAS_RUNNER_ENV } from "../env";
+import {
+  type CycleOutcome,
+  type CycleResult,
+  cycleMadeProgress,
+} from "./cycle-progress";
 
 const formatLogDetail = (detail: unknown): string => {
   if (detail === undefined) {
@@ -487,14 +492,6 @@ const daysAgoCursor = (n: number): string => {
   return date;
 };
 
-type CycleOutcome = "completed" | "failed" | "timeout";
-
-type CycleResult = {
-  outcome: CycleOutcome;
-  inserted: number;
-  pagesProcessed: number;
-};
-
 /**
  * Run a single ingestion cycle for one adapter.
  * "timeout" means the cycle hit MAX_CYCLE_MS but progress
@@ -652,18 +649,16 @@ const runAdapterLoop = async ({ adapterKey, name }: SourceDef) => {
         inFlightCycles.delete(adapterKey);
         cycleSemaphore.release();
       }
-      const { outcome, inserted, pagesProcessed } = cycle;
+      const { outcome, inserted } = cycle;
 
-      // Forward progress = a clean cycle, or a timeout that still advanced at
-      // least one page. A "failed" or a zero-page "timeout" is a stall; both
-      // grow the one streak, so an adapter alternating between them still
-      // reaches the alert.
-      const madeProgress =
-        outcome === "completed" ||
-        (outcome === "timeout" && pagesProcessed > 0);
+      // A stall is a cycle that moved nothing, whatever its outcome; a halt or
+      // a timeout that still walked pages advanced the cursor. Both stall
+      // shapes grow the one streak, so an adapter alternating between them
+      // still reaches the alert.
+      const madeProgress = cycleMadeProgress(cycle);
       noProgressStreak = madeProgress ? 0 : noProgressStreak + 1;
 
-      if (outcome === "failed") {
+      if (outcome === "failed" && !madeProgress) {
         backoffFailures++;
       } else {
         backoffFailures = 0;

--- a/apps/legal-atlas-runner/src/runners/case-law-ingest.ts
+++ b/apps/legal-atlas-runner/src/runners/case-law-ingest.ts
@@ -54,6 +54,7 @@ import {
   type CycleOutcome,
   type CycleResult,
   cycleMadeProgress,
+  cycleWasIdle,
 } from "./cycle-progress";
 
 const formatLogDetail = (detail: unknown): string => {
@@ -652,7 +653,7 @@ const runAdapterLoop = async ({ adapterKey, name }: SourceDef) => {
         inFlightCycles.delete(adapterKey);
         cycleSemaphore.release();
       }
-      const { outcome, inserted } = cycle;
+      const { outcome } = cycle;
 
       // A stall is a cycle that advanced no page, whatever its outcome; a halt
       // or a timeout that still walked pages moved the cursor.
@@ -663,23 +664,24 @@ const runAdapterLoop = async ({ adapterKey, name }: SourceDef) => {
         backoffFailures++;
       } else {
         backoffFailures = 0;
-        // Only "completed" outcomes count toward idle. A "timeout"
-        // means the cycle hit MAX_CYCLE_MS mid-work; the adapter is
-        // slow, not caught up, so leave idleCycles unchanged.
-        if (outcome === CYCLE_OUTCOME.COMPLETED) {
-          if (inserted > 0) {
-            if (idleCycles >= IDLE_THRESHOLD) {
-              logInfo(
-                `[${adapterKey}] New decisions found; resuming fast cadence`,
-              );
-            }
-            idleCycles = 0;
-          } else {
-            idleCycles++;
-            if (idleCycles === IDLE_THRESHOLD) {
-              logInfo(`[${adapterKey}] Caught up; switching to daily polling`);
-            }
+        // Idle means caught up with nothing to do, so only a clean cycle that
+        // found nothing counts toward it. Every other cycle reaching here
+        // moved through the source, and a halt or a timeout partway in is a
+        // source with work left rather than a quiet one: it has to clear the
+        // idle state, or the delay below parks a working adapter on the daily
+        // cadence for a day at a time.
+        if (cycleWasIdle(cycle)) {
+          idleCycles++;
+          if (idleCycles === IDLE_THRESHOLD) {
+            logInfo(`[${adapterKey}] Caught up; switching to daily polling`);
           }
+        } else {
+          if (idleCycles >= IDLE_THRESHOLD) {
+            logInfo(
+              `[${adapterKey}] New decisions found; resuming fast cadence`,
+            );
+          }
+          idleCycles = 0;
         }
       }
     } catch (error) {

--- a/apps/legal-atlas-runner/src/runners/case-law-ingest.ts
+++ b/apps/legal-atlas-runner/src/runners/case-law-ingest.ts
@@ -50,6 +50,7 @@ import {
 } from "../db";
 import { LEGAL_ATLAS_RUNNER_ENV } from "../env";
 import {
+  CYCLE_OUTCOME,
   type CycleOutcome,
   type CycleResult,
   cycleMadeProgress,
@@ -518,7 +519,7 @@ const runOneCycle = async (
   const startedAt = new Date();
   const t0 = performance.now();
 
-  let outcome: CycleOutcome = "completed";
+  let outcome: CycleOutcome = CYCLE_OUTCOME.COMPLETED;
   let errorMessage: string | null = null;
   let result: Awaited<ReturnType<typeof runIngestionPipeline>> | null = null;
 
@@ -541,11 +542,13 @@ const runOneCycle = async (
       logInfo(`[${adapterKey}] ${result.haltReason}`);
     } else if (result.haltReason) {
       outcome =
-        result.haltReason === "Cycle timeout exceeded" ? "timeout" : "failed";
+        result.haltReason === "Cycle timeout exceeded"
+          ? CYCLE_OUTCOME.TIMEOUT
+          : CYCLE_OUTCOME.FAILED;
       errorMessage = result.haltReason.slice(0, 2048);
     }
   } catch (error) {
-    outcome = "failed";
+    outcome = CYCLE_OUTCOME.FAILED;
     errorMessage =
       `[${errorTag(error)}] ${error instanceof Error ? error.message : String(error)}`.slice(
         0,
@@ -557,7 +560,7 @@ const runOneCycle = async (
 
   // DB status column only supports "completed" | "failed";
   // timeouts are recorded as "completed" (progress was made).
-  const dbStatus = outcome === "failed" ? "failed" : "completed";
+  const dbStatus = outcome === CYCLE_OUTCOME.FAILED ? "failed" : "completed";
 
   try {
     await ingestionDb(async (tx) => {
@@ -579,14 +582,14 @@ const runOneCycle = async (
     logError(`[${adapterKey}] Failed to write ingestion event:`, eventError);
   }
 
-  if (outcome === "completed") {
+  if (outcome === CYCLE_OUTCOME.COMPLETED) {
     logInfo(
       `[${adapterKey}] Inserted: ${result?.inserted ?? 0}, ` +
         `Skipped: ${result?.skipped ?? 0}, ` +
         `Pages: ${result?.pagesProcessed ?? 0}, ` +
         `Duration: ${durationMs}ms`,
     );
-  } else if (outcome === "timeout") {
+  } else if (outcome === CYCLE_OUTCOME.TIMEOUT) {
     logInfo(
       `[${adapterKey}] Timed out after ${durationMs}ms ` +
         `(inserted: ${result?.inserted ?? 0}, pages: ${result?.pagesProcessed ?? 0})`,
@@ -609,9 +612,9 @@ const runOneCycle = async (
 
 const runAdapterLoop = async ({ adapterKey, name }: SourceDef) => {
   /**
-   * Consecutive cycles with no forward progress — a hard failure OR a timeout
-   * that completed zero pages. A single streak so an adapter that alternates
-   * between the two (each of which would otherwise reset the other's counter)
+   * Consecutive cycles that advanced no page, whatever their outcome (see
+   * `cycleMadeProgress`). A single streak so an adapter alternating between
+   * stall shapes, each of which would otherwise reset the other's counter,
    * still reaches the sustained-failure alert.
    */
   let noProgressStreak = 0;
@@ -651,21 +654,19 @@ const runAdapterLoop = async ({ adapterKey, name }: SourceDef) => {
       }
       const { outcome, inserted } = cycle;
 
-      // A stall is a cycle that moved nothing, whatever its outcome; a halt or
-      // a timeout that still walked pages advanced the cursor. Both stall
-      // shapes grow the one streak, so an adapter alternating between them
-      // still reaches the alert.
+      // A stall is a cycle that advanced no page, whatever its outcome; a halt
+      // or a timeout that still walked pages moved the cursor.
       const madeProgress = cycleMadeProgress(cycle);
       noProgressStreak = madeProgress ? 0 : noProgressStreak + 1;
 
-      if (outcome === "failed" && !madeProgress) {
+      if (outcome === CYCLE_OUTCOME.FAILED && !madeProgress) {
         backoffFailures++;
       } else {
         backoffFailures = 0;
         // Only "completed" outcomes count toward idle. A "timeout"
         // means the cycle hit MAX_CYCLE_MS mid-work; the adapter is
         // slow, not caught up, so leave idleCycles unchanged.
-        if (outcome === "completed") {
+        if (outcome === CYCLE_OUTCOME.COMPLETED) {
           if (inserted > 0) {
             if (idleCycles >= IDLE_THRESHOLD) {
               logInfo(
@@ -693,8 +694,8 @@ const runAdapterLoop = async ({ adapterKey, name }: SourceDef) => {
       }
     }
 
-    // A run of no-progress cycles (failures and/or zero-page timeouts) means
-    // the source is stalled; surface it on the sustained-failure metric.
+    // A run of cycles that advanced no page means the source is stalled;
+    // surface it on the sustained-failure metric.
     if (noProgressStreak >= SUSTAINED_FAILURE_THRESHOLD) {
       logger.error("case_law.ingestion.sustained_failure", {
         adapterKey,

--- a/apps/legal-atlas-runner/src/runners/cycle-progress.test.ts
+++ b/apps/legal-atlas-runner/src/runners/cycle-progress.test.ts
@@ -1,52 +1,65 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  CYCLE_OUTCOME,
   type CycleOutcome,
-  type CycleResult,
   cycleMadeProgress,
 } from "./cycle-progress";
 
-const OUTCOMES = [
-  "completed",
-  "failed",
-  "timeout",
-] as const satisfies readonly CycleOutcome[];
+const OUTCOMES = Object.values(CYCLE_OUTCOME) satisfies readonly CycleOutcome[];
 
-/** Every combination of work a cycle can report having done. */
-const WORK = [
-  { inserted: 0, pagesProcessed: 1 },
-  { inserted: 1, pagesProcessed: 0 },
-  { inserted: 1, pagesProcessed: 1 },
-] as const;
+/** Rows written in a cycle, spanning none through many. */
+const INSERTED = [0, 1, 250] as const;
 
 describe("cycleMadeProgress", () => {
-  test("a cycle that walked a page or wrote a row is progress, however it ended", () => {
-    const stalls: CycleResult[] = [];
-    for (const outcome of OUTCOMES) {
-      for (const work of WORK) {
-        const cycle = { outcome, ...work };
-        if (!cycleMadeProgress(cycle)) {
-          stalls.push(cycle);
-        }
-      }
-    }
+  test("a cycle that advanced a page is progress, however it ended", () => {
+    const stalls = OUTCOMES.flatMap((outcome) =>
+      INSERTED.map((inserted) => ({ outcome, inserted, pagesProcessed: 1 })),
+    ).filter((cycle) => !cycleMadeProgress(cycle));
 
     expect(stalls).toEqual([]);
   });
 
-  test("only a cycle that moved nothing and did not complete is a stall", () => {
+  test("rows written without advancing a page are not progress", () => {
+    // A corpus-write failure parks the page and preserves the row's previous
+    // source hash, so the same decisions are rewritten on every retry. Counting
+    // that as progress would reset the streak and backoff forever.
+    const progressed = OUTCOMES.filter(
+      (outcome) => outcome !== CYCLE_OUTCOME.COMPLETED,
+    )
+      .flatMap((outcome) =>
+        INSERTED.filter((inserted) => inserted > 0).map((inserted) => ({
+          outcome,
+          inserted,
+          pagesProcessed: 0,
+        })),
+      )
+      .filter(cycleMadeProgress);
+
+    expect(progressed).toEqual([]);
+  });
+
+  test("a cycle that moved nothing and did not complete is a stall", () => {
     expect(
-      cycleMadeProgress({ outcome: "failed", inserted: 0, pagesProcessed: 0 }),
+      cycleMadeProgress({
+        outcome: CYCLE_OUTCOME.FAILED,
+        inserted: 0,
+        pagesProcessed: 0,
+      }),
     ).toBe(false);
     expect(
-      cycleMadeProgress({ outcome: "timeout", inserted: 0, pagesProcessed: 0 }),
+      cycleMadeProgress({
+        outcome: CYCLE_OUTCOME.TIMEOUT,
+        inserted: 0,
+        pagesProcessed: 0,
+      }),
     ).toBe(false);
   });
 
   test("a completed cycle with nothing to do is not a stall", () => {
     expect(
       cycleMadeProgress({
-        outcome: "completed",
+        outcome: CYCLE_OUTCOME.COMPLETED,
         inserted: 0,
         pagesProcessed: 0,
       }),

--- a/apps/legal-atlas-runner/src/runners/cycle-progress.test.ts
+++ b/apps/legal-atlas-runner/src/runners/cycle-progress.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  type CycleOutcome,
+  type CycleResult,
+  cycleMadeProgress,
+} from "./cycle-progress";
+
+const OUTCOMES = [
+  "completed",
+  "failed",
+  "timeout",
+] as const satisfies readonly CycleOutcome[];
+
+/** Every combination of work a cycle can report having done. */
+const WORK = [
+  { inserted: 0, pagesProcessed: 1 },
+  { inserted: 1, pagesProcessed: 0 },
+  { inserted: 1, pagesProcessed: 1 },
+] as const;
+
+describe("cycleMadeProgress", () => {
+  test("a cycle that walked a page or wrote a row is progress, however it ended", () => {
+    const stalls: CycleResult[] = [];
+    for (const outcome of OUTCOMES) {
+      for (const work of WORK) {
+        const cycle = { outcome, ...work };
+        if (!cycleMadeProgress(cycle)) {
+          stalls.push(cycle);
+        }
+      }
+    }
+
+    expect(stalls).toEqual([]);
+  });
+
+  test("only a cycle that moved nothing and did not complete is a stall", () => {
+    expect(
+      cycleMadeProgress({ outcome: "failed", inserted: 0, pagesProcessed: 0 }),
+    ).toBe(false);
+    expect(
+      cycleMadeProgress({ outcome: "timeout", inserted: 0, pagesProcessed: 0 }),
+    ).toBe(false);
+  });
+
+  test("a completed cycle with nothing to do is not a stall", () => {
+    expect(
+      cycleMadeProgress({
+        outcome: "completed",
+        inserted: 0,
+        pagesProcessed: 0,
+      }),
+    ).toBe(true);
+  });
+});

--- a/apps/legal-atlas-runner/src/runners/cycle-progress.test.ts
+++ b/apps/legal-atlas-runner/src/runners/cycle-progress.test.ts
@@ -4,6 +4,7 @@ import {
   CYCLE_OUTCOME,
   type CycleOutcome,
   cycleMadeProgress,
+  cycleWasIdle,
 } from "./cycle-progress";
 
 const OUTCOMES = Object.values(CYCLE_OUTCOME) satisfies readonly CycleOutcome[];
@@ -64,5 +65,44 @@ describe("cycleMadeProgress", () => {
         pagesProcessed: 0,
       }),
     ).toBe(true);
+  });
+});
+
+describe("cycleWasIdle", () => {
+  test("a cycle that halted or timed out is never idle", () => {
+    // Such a cycle stopped partway through a source that still has work.
+    // Reading it as quiet would hold an adapter on the daily cadence.
+    const idle = OUTCOMES.filter(
+      (outcome) => outcome !== CYCLE_OUTCOME.COMPLETED,
+    )
+      .flatMap((outcome) =>
+        INSERTED.flatMap((inserted) =>
+          [0, 1].map((pagesProcessed) => ({
+            outcome,
+            inserted,
+            pagesProcessed,
+          })),
+        ),
+      )
+      .filter(cycleWasIdle);
+
+    expect(idle).toEqual([]);
+  });
+
+  test("only a completed cycle that found nothing is idle", () => {
+    expect(
+      cycleWasIdle({
+        outcome: CYCLE_OUTCOME.COMPLETED,
+        inserted: 0,
+        pagesProcessed: 4,
+      }),
+    ).toBe(true);
+    expect(
+      cycleWasIdle({
+        outcome: CYCLE_OUTCOME.COMPLETED,
+        inserted: 1,
+        pagesProcessed: 4,
+      }),
+    ).toBe(false);
   });
 });

--- a/apps/legal-atlas-runner/src/runners/cycle-progress.ts
+++ b/apps/legal-atlas-runner/src/runners/cycle-progress.ts
@@ -48,3 +48,15 @@ export const cycleMadeProgress = ({
   pagesProcessed,
 }: CycleResult): boolean =>
   outcome === CYCLE_OUTCOME.COMPLETED || pagesProcessed > 0;
+
+/**
+ * Whether a cycle is evidence the source is caught up, which drives the idle
+ * (daily) polling cadence.
+ *
+ * Only a clean cycle that found nothing qualifies. A halt or a timeout means
+ * the cycle stopped partway through a source that still has work, so it must
+ * not read as quiet: an adapter already on the idle cadence would otherwise
+ * stay there, taking a day per page.
+ */
+export const cycleWasIdle = ({ outcome, inserted }: CycleResult): boolean =>
+  outcome === CYCLE_OUTCOME.COMPLETED && inserted === 0;

--- a/apps/legal-atlas-runner/src/runners/cycle-progress.ts
+++ b/apps/legal-atlas-runner/src/runners/cycle-progress.ts
@@ -1,0 +1,36 @@
+/**
+ * How an ingestion cycle ended, and whether that counts as forward progress.
+ *
+ * Kept free of the runner's DB and env imports so the classification can be
+ * exercised on its own.
+ */
+
+export type CycleOutcome = "completed" | "failed" | "timeout";
+
+export type CycleResult = {
+  outcome: CycleOutcome;
+  inserted: number;
+  pagesProcessed: number;
+};
+
+/**
+ * Forward progress is a property of the work a cycle did, not of how it
+ * ended.
+ *
+ * A cycle ends early whenever the pipeline sets a halt reason, and some halts
+ * follow real work: a page whose corpus writes partly failed holds its cursor
+ * and stops the cycle, but the pages before it advanced the cursor and their
+ * rows were written. Classifying that as a stall both raises the
+ * sustained-failure signal on a source that is ingesting normally and pins the
+ * adapter to the failure backoff, throttling the very source that is keeping
+ * up.
+ *
+ * A "completed" cycle counts even with nothing to show for it: an adapter that
+ * is caught up legitimately walks no pages and inserts nothing.
+ */
+export const cycleMadeProgress = ({
+  outcome,
+  inserted,
+  pagesProcessed,
+}: CycleResult): boolean =>
+  outcome === "completed" || pagesProcessed > 0 || inserted > 0;

--- a/apps/legal-atlas-runner/src/runners/cycle-progress.ts
+++ b/apps/legal-atlas-runner/src/runners/cycle-progress.ts
@@ -5,7 +5,13 @@
  * exercised on its own.
  */
 
-export type CycleOutcome = "completed" | "failed" | "timeout";
+export const CYCLE_OUTCOME = {
+  COMPLETED: "completed",
+  FAILED: "failed",
+  TIMEOUT: "timeout",
+} as const;
+
+export type CycleOutcome = (typeof CYCLE_OUTCOME)[keyof typeof CYCLE_OUTCOME];
 
 export type CycleResult = {
   outcome: CycleOutcome;
@@ -14,8 +20,8 @@ export type CycleResult = {
 };
 
 /**
- * Forward progress is a property of the work a cycle did, not of how it
- * ended.
+ * Forward progress is durable movement through the source, not how the cycle
+ * ended and not how much it wrote.
  *
  * A cycle ends early whenever the pipeline sets a halt reason, and some halts
  * follow real work: a page whose corpus writes partly failed holds its cursor
@@ -25,12 +31,20 @@ export type CycleResult = {
  * adapter to the failure backoff, throttling the very source that is keeping
  * up.
  *
+ * `pagesProcessed` is the durable marker because the pipeline increments it
+ * only after a page completes without halting, in the same step that advances
+ * the cursor. `inserted` deliberately does NOT count: a corpus-write failure
+ * preserves the row's previous source hash so the decision is reprocessed, so
+ * a page parked on a persistent failure reports rows written on every retry
+ * while the cursor never moves. Reading that as progress would reset the
+ * streak and the backoff forever, silencing the alert on the one case it
+ * exists to catch and hot-looping the adapter over a page it cannot pass.
+ *
  * A "completed" cycle counts even with nothing to show for it: an adapter that
  * is caught up legitimately walks no pages and inserts nothing.
  */
 export const cycleMadeProgress = ({
   outcome,
-  inserted,
   pagesProcessed,
 }: CycleResult): boolean =>
-  outcome === "completed" || pagesProcessed > 0 || inserted > 0;
+  outcome === CYCLE_OUTCOME.COMPLETED || pagesProcessed > 0;


### PR DESCRIPTION
## Proposed change

An ingestion cycle ends early whenever the pipeline sets a halt reason, and `runOneCycle` maps every halt except the decision cap and the cycle timeout to a `"failed"` outcome. The adapter loop then derived forward progress from that outcome alone:

```ts
const madeProgress =
  outcome === "completed" || (outcome === "timeout" && pagesProcessed > 0);
```

So a cycle that walked pages and inserted rows before halting was counted as a stall, because the `pagesProcessed` check was reachable only on the timeout branch.

Some halts follow real work. `pipeline.ts` sets `N corpus write failure(s); cursor held for retry` when a page's corpus writes partly failed, deliberately holding that page's cursor so the preserved source-hash retry stays reachable; the pages walked before it advanced the cursor normally and their rows were written. Two things follow from misreading that as no progress:

- `noProgressStreak` climbs on a source that is ingesting normally, up to `SUSTAINED_FAILURE_THRESHOLD`, so `case_law.ingestion.sustained_failure` reports a stall for a source that is keeping up. Since one failed corpus write per page is enough to halt, a source with a nonzero per-decision failure rate can reach the threshold indefinitely.
- `backoffFailures` grows every cycle, so `delayMs` escalates to the 60s ceiling and stays there, throttling the adapter that is doing the most work.

Classify progress by the work a cycle did rather than by how it ended, and only apply the failure backoff to a cycle that moved nothing. The predicate moves into its own module so it can be exercised without the runner's DB and env imports, which the "no module-level side effects in shared modules" rule would otherwise pull into the test. A `"completed"` cycle still counts with nothing to show for it, since an adapter that is caught up legitimately walks no pages and inserts nothing.

The `CycleOutcome` / `CycleResult` types move alongside the predicate that reads them; no behavior change there.

## Checklist

- [x] **BUILD ASSURANCE** | Code builds correctly and without any errors or warnings.
- [x] **TESTING** | Changes tested, including in different conditions (dark mode, language, narrow screen, etc).
- [ ] DARK MODE SUPPORT | Not applicable: no UI surface.
- [ ] ISSUE LINKED | No existing issue.
- [ ] SCREENSHOT INCLUDED | Not applicable: no UI surface.

`bun test apps/legal-atlas-runner/src/runners/cycle-progress.test.ts` passes, repo `lint` and `format` are clean, and the runner package typechecks. The new test covers the classification across every outcome and work combination rather than a single example, since the defect was one branch of the input class being unreachable.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XryPe3StMNVeA4dNETRywS)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ingestion cycle handling to distinguish genuine progress from stalled or unsuccessful cycles.
  * Reduced unnecessary backoff and idle handling when pages are processed or records are inserted.
  * Treats successfully completed cycles as progress, even when no new records are produced.

* **Tests**
  * Added coverage for completed, failed and timed-out cycles across different processing outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->