### PR TITLE
fix(ci): wire the backfill Postgres suite and allowlist agent commits

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -40,6 +40,6 @@ jobs:
       )
     uses: stella/.github/.github/workflows/cla.yml@44c8092f11c2f454916c320aa7d2144c173329d8
     with:
-      allowlist: dependabot[bot],renovate[bot],github-actions[bot],google-labs-jules[bot],cursoragent
+      allowlist: dependabot[bot],renovate[bot],github-actions[bot],google-labs-jules[bot],cursoragent,claude
     secrets:
       CLA_APP_PRIVATE_KEY: ${{ secrets.CLA_APP_PRIVATE_KEY }}

--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -112,6 +112,7 @@ jobs:
           bun test --preload ./src/tests/setup-env.ts
           src/db/root.test.ts
           src/handlers/case-law/ingestion/pipeline.db.test.ts
+          src/handlers/case-law/ingestion/sk-document-backfill.db.test.ts
 
   # Upstream-API drift canary for the CJEU adapter. Hits live Cellar SPARQL +
   # EUR-Lex endpoints, so a failure most often means an upstream schema/endpoint


### PR DESCRIPTION
## Proposed change

Two CI-only changes; no product code.

**Nightly Postgres coverage.** `sk-document-backfill.db.test.ts` declares
`STELLA_RUN_POSTGRES_TESTS`, but no workflow ran it with that gate set. The suite
therefore never executed anywhere: `bun run test` takes its skip branch, and the
nightly Postgres job listed only the other two files. That is what the
`ci-gate-coverage` convention test reports, and it is currently red on `main`.

The file's own header already says it runs in the nightly Postgres job, so the
wiring was the missing piece rather than the intent. Adding it to the gated step
restores the convention and, more to the point, starts running three tests that
were dead. It calls no `mock.module`, so the shared process that step already
relies on still holds.

**CLA allowlist.** Commits authored by the `claude` account fail the CLA check,
which verifies every committer on a pull request. That account cannot clear the
check itself: a signing comment records the commenter's signature, not the commit
author's. It joins the other non-human committers already on the list. This is a
standing exemption for that author, not a one-off for a single PR.

## Checklist

- [x] **BUILD ASSURANCE** | Code builds correctly and without any errors or warnings.
- [x] **TESTING** | Changes tested, including in different conditions (dark mode, language, narrow screen, etc).
- [ ] DARK MODE SUPPORT | Not applicable: no UI surface.
- [ ] ISSUE LINKED | No existing issue.
- [ ] SCREENSHOT INCLUDED | Not applicable: no UI surface.

Checked against a throwaway `postgres:18.3` with migrations applied through the
shipped `src/db/migrate.ts` entrypoint: the three gated suites pass together
(6 tests), the backfill suite alone runs 3 real tests rather than its skip
branch, and `packages/property-testing` is green (9 tests).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded nightly database-backed testing to include an additional case-law document ingestion scenario.

* **Chores**
  * Updated automated contribution agreement checks to recognise an additional approved automation account.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->