### PR TITLE
fix(case-law): run the first citation-authority recompute at startup

### DIFF
--- a/apps/api/src/handlers/case-law/citation-authority.ts
+++ b/apps/api/src/handlers/case-law/citation-authority.ts
@@ -158,3 +158,20 @@ export const tryRecomputeCitationAuthorityForAll = async (
   }
   return await recomputeCitationAuthorityForAll(tx, options);
 };
+
+/**
+ * Blocking variant for callers that have just changed the citation graph
+ * (the citation-resolution script): an in-flight recompute may hold a
+ * snapshot from before those changes, so skipping would leave them
+ * unreflected until the next scheduled pass. Waiting for the lock and
+ * recomputing afterwards guarantees the caller's changes are covered.
+ */
+export const recomputeCitationAuthorityForAllExclusive = async (
+  tx: CitationAuthorityTx,
+  options: RecomputeCitationAuthorityOptions = {},
+): Promise<number> => {
+  await tx.execute(
+    sql`SELECT pg_advisory_xact_lock(hashtext('case_law_citation_authority_recompute'))`,
+  );
+  return await recomputeCitationAuthorityForAll(tx, options);
+};

--- a/apps/api/src/handlers/case-law/citation-authority.ts
+++ b/apps/api/src/handlers/case-law/citation-authority.ts
@@ -148,7 +148,7 @@ export const tryRecomputeCitationAuthorityForAll = async (
   options: RecomputeCitationAuthorityOptions = {},
 ): Promise<number | null> => {
   const lockResult: unknown = await tx.execute(
-    sql`SELECT pg_try_advisory_xact_lock(hashtext('case_law_citation_authority_recompute')) AS locked`,
+    sql`SELECT pg_try_advisory_xact_lock(hashtext('case_law'), hashtext('citation_authority_recompute')) AS locked`,
   );
   const lockRow: unknown = Array.isArray(lockResult)
     ? lockResult.at(0)
@@ -171,7 +171,7 @@ export const recomputeCitationAuthorityForAllExclusive = async (
   options: RecomputeCitationAuthorityOptions = {},
 ): Promise<number> => {
   await tx.execute(
-    sql`SELECT pg_advisory_xact_lock(hashtext('case_law_citation_authority_recompute'))`,
+    sql`SELECT pg_advisory_xact_lock(hashtext('case_law'), hashtext('citation_authority_recompute'))`,
   );
   return await recomputeCitationAuthorityForAll(tx, options);
 };

--- a/apps/api/src/handlers/case-law/citation-authority.ts
+++ b/apps/api/src/handlers/case-law/citation-authority.ts
@@ -45,14 +45,16 @@ type CitationAuthorityTx = {
   execute: (query: SQL) => Promise<unknown>;
 };
 
+type RecomputeCitationAuthorityOptions = {
+  now?: Date;
+  courtWeightEntries?: CourtWeightEntry[] | undefined;
+};
+
 const SECONDS_PER_YEAR = 365.25 * 86_400;
 
 export const recomputeCitationAuthorityForAll = async (
   tx: CitationAuthorityTx,
-  options: {
-    now?: Date;
-    courtWeightEntries?: CourtWeightEntry[] | undefined;
-  } = {},
+  options: RecomputeCitationAuthorityOptions = {},
 ): Promise<number> => {
   const nowExpr = options.now
     ? sql`${options.now.toISOString()}::timestamptz`
@@ -131,4 +133,28 @@ export const recomputeCitationAuthorityForAll = async (
     return 0;
   }
   return firstRow["n"];
+};
+
+/**
+ * Try-locked variant for periodic daemon recomputes. Overlapping
+ * processes (a rolling deployment, a restart racing a still-draining
+ * task) would otherwise queue duplicate whole-corpus updates behind each
+ * other's row locks; the advisory try-lock lets exactly one proceed and
+ * the rest return null ("another process is recomputing") instead of
+ * blocking. The lock is transaction-scoped, so it releases with the tx.
+ */
+export const tryRecomputeCitationAuthorityForAll = async (
+  tx: CitationAuthorityTx,
+  options: RecomputeCitationAuthorityOptions = {},
+): Promise<number | null> => {
+  const lockResult: unknown = await tx.execute(
+    sql`SELECT pg_try_advisory_xact_lock(hashtext('case_law_citation_authority_recompute')) AS locked`,
+  );
+  const lockRow: unknown = Array.isArray(lockResult)
+    ? lockResult.at(0)
+    : undefined;
+  if (!isRecord(lockRow) || lockRow["locked"] !== true) {
+    return null;
+  }
+  return await recomputeCitationAuthorityForAll(tx, options);
 };

--- a/apps/api/src/scripts/resolve-citations.ts
+++ b/apps/api/src/scripts/resolve-citations.ts
@@ -24,7 +24,7 @@ import {
   caseLawDecisions,
   caseLawPolarityRules,
 } from "@/api/db/schema";
-import { tryRecomputeCitationAuthorityForAll } from "@/api/handlers/case-law/citation-authority";
+import { recomputeCitationAuthorityForAllExclusive } from "@/api/handlers/case-law/citation-authority";
 import { loadCourtWeightEntriesForSql } from "@/api/handlers/case-law/court-weights";
 import { extractContext } from "@/api/handlers/case-law/polarity/context";
 import { SEED_RULES } from "@/api/handlers/case-law/polarity/seed-rules";
@@ -699,19 +699,16 @@ if (!REPORT_ONLY) {
   if (!DRY_RUN) {
     console.log("\n=== RECOMPUTING CITATION AUTHORITY ===");
     const courtWeightEntries = await loadCourtWeightEntriesForSql();
+    // Blocking on purpose: the citations this script just resolved must be
+    // reflected before it exits, and a concurrent recompute may hold a
+    // snapshot from before those commits.
     const updated = await rootDb.transaction(
       async (tx) =>
-        await tryRecomputeCitationAuthorityForAll(tx, { courtWeightEntries }),
+        await recomputeCitationAuthorityForAllExclusive(tx, {
+          courtWeightEntries,
+        }),
     );
-    if (updated === null) {
-      console.log(
-        "Citation authority refresh skipped: another process is recomputing; the fresh values land when it commits.",
-      );
-    } else {
-      console.log(
-        `Citation authority refreshed for ${updated} cited decisions.`,
-      );
-    }
+    console.log(`Citation authority refreshed for ${updated} cited decisions.`);
   }
 }
 

--- a/apps/api/src/scripts/resolve-citations.ts
+++ b/apps/api/src/scripts/resolve-citations.ts
@@ -24,7 +24,7 @@ import {
   caseLawDecisions,
   caseLawPolarityRules,
 } from "@/api/db/schema";
-import { recomputeCitationAuthorityForAll } from "@/api/handlers/case-law/citation-authority";
+import { tryRecomputeCitationAuthorityForAll } from "@/api/handlers/case-law/citation-authority";
 import { loadCourtWeightEntriesForSql } from "@/api/handlers/case-law/court-weights";
 import { extractContext } from "@/api/handlers/case-law/polarity/context";
 import { SEED_RULES } from "@/api/handlers/case-law/polarity/seed-rules";
@@ -701,9 +701,17 @@ if (!REPORT_ONLY) {
     const courtWeightEntries = await loadCourtWeightEntriesForSql();
     const updated = await rootDb.transaction(
       async (tx) =>
-        await recomputeCitationAuthorityForAll(tx, { courtWeightEntries }),
+        await tryRecomputeCitationAuthorityForAll(tx, { courtWeightEntries }),
     );
-    console.log(`Citation authority refreshed for ${updated} cited decisions.`);
+    if (updated === null) {
+      console.log(
+        "Citation authority refresh skipped: another process is recomputing; the fresh values land when it commits.",
+      );
+    } else {
+      console.log(
+        `Citation authority refreshed for ${updated} cited decisions.`,
+      );
+    }
   }
 }
 

--- a/apps/legal-atlas-runner/src/runners/case-law-ingest.ts
+++ b/apps/legal-atlas-runner/src/runners/case-law-ingest.ts
@@ -21,7 +21,7 @@ import { panic } from "better-result";
 
 import { caseLawIngestionEvents } from "@/api/db/schema";
 import { envBase } from "@/api/env-base";
-import { recomputeCitationAuthorityForAll } from "@/api/handlers/case-law/citation-authority";
+import { tryRecomputeCitationAuthorityForAll } from "@/api/handlers/case-law/citation-authority";
 import { ADAPTER_KEYS, MAX_CYCLE_MS } from "@/api/handlers/case-law/consts";
 import { backfillCorpusIndex } from "@/api/handlers/case-law/corpus-index";
 import { getAdapter } from "@/api/handlers/case-law/ingestion/adapters/adapter-registry";
@@ -141,8 +141,13 @@ const SEARCH_INDEX_BATCH_SIZE = 20;
 const SEARCH_INDEX_DRAIN_CONCURRENCY = 4;
 const CORPUS_INDEX_INTERVAL_MS = 15_000;
 // Citation authority decays slowly; a periodic full recompute keeps the
-// materialized ranking signal fresh without per-cycle cost.
+// materialized ranking signal fresh without per-cycle cost. The first
+// recompute runs shortly after startup rather than a full interval in: a
+// process whose lifetime is shorter than the interval would otherwise
+// never recompute at all. The startup delay keeps a process that exits
+// quickly after boot from adding a whole-corpus recompute to every start.
 const CITATION_AUTHORITY_INTERVAL_MS = 6 * 60 * 60 * 1000;
+const CITATION_AUTHORITY_STARTUP_DELAY_MS = 5 * 60 * 1000;
 
 // Idle backoff: once an adapter is caught up (no new decisions
 // for IDLE_THRESHOLD consecutive cycles), poll once a day instead
@@ -874,21 +879,30 @@ export const runCaseLawIngest = async (
   // Citation-authority refresh loop: keeps the materialized ranking
   // signal current (also runs in the post-citation pass; this covers the
   // continuous daemon). Runs via the ingestion role outside the DB slot.
-  // The first recompute runs at startup: a process whose lifetime is
-  // shorter than the interval would otherwise never recompute at all.
+  // The try-locked recompute makes overlapping processes (a rolling
+  // deployment) skip instead of queueing duplicate whole-corpus updates.
   const citationAuthorityLoop = (async () => {
+    await Bun.sleep(CITATION_AUTHORITY_STARTUP_DELAY_MS);
     while (true) {
       try {
         // oxlint-disable-next-line no-await-in-loop -- one full recompute per interval; the next poll only runs after this recompute completes
         const courtWeightEntries = await loadCourtWeightEntries();
         // oxlint-disable-next-line no-await-in-loop -- one full recompute per interval; the next poll only runs after this recompute completes
         const updated = await ingestionDb(async (tx) => {
-          const count = await recomputeCitationAuthorityForAll(tx, {
+          const count = await tryRecomputeCitationAuthorityForAll(tx, {
             courtWeightEntries,
           });
           return count;
         });
-        logInfo(`[citation-authority] Recomputed (${updated} cited decisions)`);
+        if (updated === null) {
+          logInfo(
+            "[citation-authority] Skipped (recompute already running in another process)",
+          );
+        } else {
+          logInfo(
+            `[citation-authority] Recomputed (${updated} cited decisions)`,
+          );
+        }
       } catch (error) {
         const msg = error instanceof Error ? error.message : String(error);
         if (isTransientConnectionError(error)) {

--- a/apps/legal-atlas-runner/src/runners/case-law-ingest.ts
+++ b/apps/legal-atlas-runner/src/runners/case-law-ingest.ts
@@ -148,6 +148,11 @@ const CORPUS_INDEX_INTERVAL_MS = 15_000;
 // quickly after boot from adding a whole-corpus recompute to every start.
 const CITATION_AUTHORITY_INTERVAL_MS = 6 * 60 * 60 * 1000;
 const CITATION_AUTHORITY_STARTUP_DELAY_MS = 5 * 60 * 1000;
+// After a skipped (lock held elsewhere) or failed recompute, retry on a
+// short delay instead of waiting a full interval: the holder may have
+// exited before committing, and its replacement should not inherit a
+// six-hour gap.
+const CITATION_AUTHORITY_RETRY_DELAY_MS = 10 * 60 * 1000;
 
 // Idle backoff: once an adapter is caught up (no new decisions
 // for IDLE_THRESHOLD consecutive cycles), poll once a day instead
@@ -884,6 +889,7 @@ export const runCaseLawIngest = async (
   const citationAuthorityLoop = (async () => {
     await Bun.sleep(CITATION_AUTHORITY_STARTUP_DELAY_MS);
     while (true) {
+      let recomputed = false;
       try {
         // oxlint-disable-next-line no-await-in-loop -- one full recompute per interval; the next poll only runs after this recompute completes
         const courtWeightEntries = await loadCourtWeightEntries();
@@ -899,6 +905,7 @@ export const runCaseLawIngest = async (
             "[citation-authority] Skipped (recompute already running in another process)",
           );
         } else {
+          recomputed = true;
           logInfo(
             `[citation-authority] Recomputed (${updated} cited decisions)`,
           );
@@ -913,8 +920,12 @@ export const runCaseLawIngest = async (
           logError("[citation-authority] Recompute error:", error);
         }
       }
-      // oxlint-disable-next-line no-await-in-loop -- fixed-interval recompute poll; the loop must wait CITATION_AUTHORITY_INTERVAL_MS between recomputes, so this await is intentionally sequential
-      await Bun.sleep(CITATION_AUTHORITY_INTERVAL_MS);
+      // oxlint-disable-next-line no-await-in-loop -- fixed-interval recompute poll; the loop must wait between recomputes, so this await is intentionally sequential
+      await Bun.sleep(
+        recomputed
+          ? CITATION_AUTHORITY_INTERVAL_MS
+          : CITATION_AUTHORITY_RETRY_DELAY_MS,
+      );
     }
   })();
 

--- a/apps/legal-atlas-runner/src/runners/case-law-ingest.ts
+++ b/apps/legal-atlas-runner/src/runners/case-law-ingest.ts
@@ -874,10 +874,10 @@ export const runCaseLawIngest = async (
   // Citation-authority refresh loop: keeps the materialized ranking
   // signal current (also runs in the post-citation pass; this covers the
   // continuous daemon). Runs via the ingestion role outside the DB slot.
+  // The first recompute runs at startup: a process whose lifetime is
+  // shorter than the interval would otherwise never recompute at all.
   const citationAuthorityLoop = (async () => {
     while (true) {
-      // oxlint-disable-next-line no-await-in-loop -- fixed-interval recompute poll; the loop must wait CITATION_AUTHORITY_INTERVAL_MS between recomputes, so this await is intentionally sequential
-      await Bun.sleep(CITATION_AUTHORITY_INTERVAL_MS);
       try {
         // oxlint-disable-next-line no-await-in-loop -- one full recompute per interval; the next poll only runs after this recompute completes
         const courtWeightEntries = await loadCourtWeightEntries();
@@ -899,6 +899,8 @@ export const runCaseLawIngest = async (
           logError("[citation-authority] Recompute error:", error);
         }
       }
+      // oxlint-disable-next-line no-await-in-loop -- fixed-interval recompute poll; the loop must wait CITATION_AUTHORITY_INTERVAL_MS between recomputes, so this await is intentionally sequential
+      await Bun.sleep(CITATION_AUTHORITY_INTERVAL_MS);
     }
   })();
 


### PR DESCRIPTION
The citation-authority refresh loop waited a full `CITATION_AUTHORITY_INTERVAL_MS` (6 h) before its first recompute. A daemon process whose lifetime is shorter than the interval therefore never refreshed the materialized ranking signal; freshness depended on process uptime rather than on the configured cadence.

Run the recompute once at startup and keep the existing interval between subsequent runs. The recompute is idempotent and already runs outside the DB slot semaphore, so the reordering has no concurrency impact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved citation-authority refresh reliability when multiple processes run simultaneously.
  * Prevented overlapping recalculations and added faster retries when a refresh is skipped or encounters a temporary database issue.
  * Ensured citation-authority rankings are refreshed consistently after citations are resolved.
* **Performance**
  * Added startup timing and adaptive retry intervals to make background refreshes more responsive.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->