### PR TITLE
fix(case-law): surface the cause of corpus write and backfill failures

### DIFF
--- a/apps/api/src/handlers/case-law/ingestion/pipeline.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/pipeline.test.ts
@@ -10,6 +10,7 @@ import { EMPTY_AST } from "@/api/handlers/case-law/ingestion/adapter";
 import type { IngestionResult } from "@/api/handlers/case-law/ingestion/adapter";
 import { czNsAdapter } from "@/api/handlers/case-law/ingestion/adapters/cz-ns";
 import {
+  corpusWriteErrorDetail,
   runIngestionPipeline,
   sanitizeResult,
 } from "@/api/handlers/case-law/ingestion/pipeline";
@@ -406,5 +407,28 @@ describe("runIngestionPipeline — empty-page cursor progress", () => {
     expect(result.pagesProcessed).toBe(1);
     expect(result.nextCursor).toBe("cursor-2");
     expect(persistedCursor).toBe("cursor-2");
+  });
+});
+
+describe("corpusWriteErrorDetail", () => {
+  test("keeps the cause when the outer message is long", () => {
+    const cause = new Error("connection reset by peer");
+    const outer = new Error(`Failed query: ${"select ".repeat(200)}`, {
+      cause,
+    });
+    const detail = corpusWriteErrorDetail(outer);
+    expect(detail).toContain("connection reset by peer");
+    expect(detail.length).toBeLessThanOrEqual(200 + 300 + 16);
+  });
+
+  test("bounds the cause independently of the outer message", () => {
+    const cause = new Error("x".repeat(1000));
+    const detail = corpusWriteErrorDetail(new Error("short", { cause }));
+    expect(detail.startsWith("short (cause: ")).toBe(true);
+    expect(detail.length).toBeLessThanOrEqual(200 + 300 + 16);
+  });
+
+  test("stringifies non-Error values", () => {
+    expect(corpusWriteErrorDetail("boom")).toBe("boom");
   });
 });

--- a/apps/api/src/handlers/case-law/ingestion/pipeline.ts
+++ b/apps/api/src/handlers/case-law/ingestion/pipeline.ts
@@ -93,6 +93,22 @@ type PipelineResult = {
 const databaseTimeoutHaltReason = (error: TimeoutError): string =>
   `Database timeout; cursor held for retry: ${error.message.slice(0, 200)}`;
 
+/**
+ * Bound the outer message and the cause separately: a wrapped driver
+ * error carries the full failed query in its outer message, which would
+ * otherwise consume the whole budget and truncate the cause — the part
+ * that says why the write failed.
+ */
+export const corpusWriteErrorDetail = (error: unknown): string => {
+  if (!(error instanceof Error)) {
+    return String(error).slice(0, 512);
+  }
+  const outer = error.message.slice(0, 200);
+  return error.cause instanceof Error
+    ? `${outer} (cause: ${error.cause.message.slice(0, 300)})`
+    : outer;
+};
+
 type ProcessResult = {
   inserted: boolean;
   searchVectorFailed: boolean;
@@ -568,10 +584,7 @@ export const processDecision = async (
         caseNumber: result.caseNumber,
         country: result.country,
         "error.type": errorTag(error),
-        "error.detail": (error instanceof Error
-          ? `${error.message}${error.cause instanceof Error ? ` (cause: ${error.cause.message})` : ""}`
-          : String(error)
-        ).slice(0, 512),
+        "error.detail": corpusWriteErrorDetail(error),
       });
       captureError(error, { decisionId, step: "processDecision.corpusWrite" });
       await preserveCorpusWriteRetry({

--- a/apps/api/src/handlers/case-law/ingestion/pipeline.ts
+++ b/apps/api/src/handlers/case-law/ingestion/pipeline.ts
@@ -561,6 +561,18 @@ export const processDecision = async (
       });
     } catch (error) {
       s3UploadFailed = true;
+      // The halt reason only carries a failure count; without this line the
+      // cause of a held cursor is invisible to an operator reading the log.
+      logger.error("case_law.ingestion.corpus_write_failed", {
+        decisionId,
+        caseNumber: result.caseNumber,
+        country: result.country,
+        "error.type": errorTag(error),
+        "error.detail": (error instanceof Error
+          ? `${error.message}${error.cause instanceof Error ? ` (cause: ${error.cause.message})` : ""}`
+          : String(error)
+        ).slice(0, 512),
+      });
       captureError(error, { decisionId, step: "processDecision.corpusWrite" });
       await preserveCorpusWriteRetry({
         decisionId,

--- a/apps/legal-atlas-runner/src/runners/case-law-ingest.ts
+++ b/apps/legal-atlas-runner/src/runners/case-law-ingest.ts
@@ -63,7 +63,12 @@ const formatLogDetail = (detail: unknown): string => {
   }
 
   if (detail instanceof Error) {
-    return detail.stack ?? detail.message;
+    const base = detail.stack ?? detail.message;
+    // Wrapped driver errors (e.g. DrizzleQueryError) carry the actual
+    // failure in `cause`; without it the log shows only the query text.
+    return detail.cause instanceof Error
+      ? `${base}\n[cause] ${detail.cause.stack ?? detail.cause.message}`
+      : base;
   }
 
   if (typeof detail === "string") {


### PR DESCRIPTION
Two diagnosability gaps in the ingestion daemon:

- A corpus object-storage write failure incremented a counter and surfaced only as `N corpus write failure(s); cursor held for retry` in the cycle halt reason. The exception itself went to error capture only, so a reader of the daemon's log cannot tell what actually failed. Log each failure as a structured `case_law.ingestion.corpus_write_failed` event with the error tag, message, and cause.
- `formatLogDetail` printed an `Error`'s stack, but wrapped driver errors (e.g. `DrizzleQueryError`) carry the underlying failure in `cause` — the log showed the failed query text and nothing else. Append the cause chain.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error logging for case-law ingestion failures.
  * Logs now include relevant decision details and clearer information about underlying causes.
  * Enhanced diagnostic details make corpus write failures easier to investigate and retry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->