### PR TITLE
fix(api): let the corpus-index scans use the selective index

### DIFF
--- a/apps/api/src/handlers/case-law/corpus-index.ts
+++ b/apps/api/src/handlers/case-law/corpus-index.ts
@@ -1,4 +1,4 @@
-import { and, asc, eq, isNull, or, sql } from "drizzle-orm";
+import { and, eq, isNull, or, sql } from "drizzle-orm";
 
 import {
   caseLawDecisions,
@@ -105,6 +105,11 @@ const indexer = createCorpusIndexer<"caseLawDecision", IndexableRow>({
   captureStep: "backfillCorpusIndex.loadText",
   buildDoc,
   readCorpusText,
+  // The scans deliberately carry no ORDER BY. Any pick order makes
+  // progress (indexed rows leave the pending set), while ordering by
+  // created_at steers the planner onto the created_at index and
+  // row-by-row heap filtering; the selective content-hash index is what
+  // these scans need.
   selectMissing: async (scopedDb, { generation, limit }) =>
     await scopedDb((tx) =>
       tx
@@ -124,7 +129,6 @@ const indexer = createCorpusIndexer<"caseLawDecision", IndexableRow>({
             ),
           ),
         )
-        .orderBy(asc(caseLawDecisions.createdAt))
         .limit(limit),
     ),
   selectStale: async (scopedDb, { generation, limit }) =>
@@ -144,7 +148,6 @@ const indexer = createCorpusIndexer<"caseLawDecision", IndexableRow>({
             sql`${caseLawDecisions.indexedHash} IS DISTINCT FROM ${caseLawDecisions.contentHash}`,
           ),
         )
-        .orderBy(asc(caseLawDecisions.createdAt))
         .limit(limit),
     ),
   fetchFulltext: async (scopedDb, id) => {

--- a/apps/api/src/handlers/legislation/corpus-index.ts
+++ b/apps/api/src/handlers/legislation/corpus-index.ts
@@ -1,4 +1,4 @@
-import { and, asc, eq, isNull, or, sql } from "drizzle-orm";
+import { and, eq, isNull, or, sql } from "drizzle-orm";
 
 import {
   legislationDocuments,
@@ -103,6 +103,11 @@ const indexer = createCorpusIndexer<"legislationDocument", IndexableRow>({
   captureStep: "backfillLegislationCorpusIndex.loadText",
   buildDoc,
   readCorpusText,
+  // The scans deliberately carry no ORDER BY. Any pick order makes
+  // progress (indexed rows leave the pending set), while ordering by
+  // created_at steers the planner onto the created_at index and
+  // row-by-row heap filtering; the selective content-hash index is what
+  // these scans need.
   selectMissing: async (scopedDb, { generation, limit }) =>
     await scopedDb((tx) =>
       tx
@@ -122,7 +127,6 @@ const indexer = createCorpusIndexer<"legislationDocument", IndexableRow>({
             ),
           ),
         )
-        .orderBy(asc(legislationDocuments.createdAt))
         .limit(limit),
     ),
   selectStale: async (scopedDb, { generation, limit }) =>
@@ -142,7 +146,6 @@ const indexer = createCorpusIndexer<"legislationDocument", IndexableRow>({
             sql`${legislationDocuments.indexedHash} IS DISTINCT FROM ${legislationDocuments.contentHash}`,
           ),
         )
-        .orderBy(asc(legislationDocuments.createdAt))
         .limit(limit),
     ),
   fetchFulltext: async (scopedDb, id) => {


### PR DESCRIPTION
The corpus-index backfill scans (`selectMissing`/`selectStale` for both the case-law and legislation families) ordered by `created_at`. With a `LIMIT` on top, the planner satisfies the sort via the `created_at` index and filters row by row with random heap fetches; when `content_hash IS NOT NULL` matches only a small fraction of a large table, accumulating even one batch exceeds any reasonable statement timeout, so the scan never returns and the backfill loop makes no progress. The plain-`EXPLAIN` cost looks tiny because of the `LIMIT`, which is what hid this.

Pick order carries no correctness weight: every marked row leaves the pending set, so any order converges. Dropping the `ORDER BY` lets the planner use the existing `(indexed_hash, content_hash)` index, which serves the actual predicate.

Verified against a representative dataset: the ordered query cancels on statement timeout; the identical query without the sort returns in seconds via the content-hash index.