### PR TITLE
feat(case-law): drain the ingestion daemon on SIGTERM

### DIFF
--- a/apps/legal-atlas-runner/src/runners/case-law-ingest.ts
+++ b/apps/legal-atlas-runner/src/runners/case-law-ingest.ts
@@ -142,11 +142,13 @@ process.on("unhandledRejection", (reason) => {
  * even when a loop is mid-sleep on a long interval.
  */
 let draining = false;
+/** Read via a call so per-site flow analysis cannot misjudge the flag. */
+const isDraining = (): boolean => draining;
 const DRAIN_FORCE_EXIT_MS = 90_000;
 
 const drainOnSigterm = (): void => {
   process.on("SIGTERM", () => {
-    if (draining) {
+    if (isDraining()) {
       return;
     }
     draining = true;
@@ -666,7 +668,7 @@ const runAdapterLoop = async ({ adapterKey, name }: SourceDef) => {
   let idleCycles = 0;
 
   while (true) {
-    if (draining) {
+    if (isDraining()) {
       return;
     }
     try {
@@ -676,6 +678,12 @@ const runAdapterLoop = async ({ adapterKey, name }: SourceDef) => {
       // released before the inter-cycle delay, so idle adapters free the slot.
       // oxlint-disable-next-line no-await-in-loop -- continuous daemon: one cycle at a time per adapter so the persisted cursor advances in order
       await cycleSemaphore.acquire();
+      // A loop that queued on acquire() passed the drain check before the
+      // signal arrived; hand the slot back instead of starting a new cycle.
+      if (isDraining()) {
+        cycleSemaphore.release();
+        return;
+      }
       let cycle: CycleResult;
       // Hard wall-clock backstop on the held slot. runOneCycle has awaits that
       // ignore the per-cycle abort signal (the source lookup before it is
@@ -867,12 +875,12 @@ export const runCaseLawIngest = async (
   // Health loop: heartbeat + S3 credential refresh.
   const healthLoop = (async () => {
     while (true) {
-      if (draining) {
+      if (isDraining()) {
         return;
       }
       // oxlint-disable-next-line no-await-in-loop -- fixed-interval health poll; the loop must wait HEALTH_INTERVAL_MS between heartbeats, so this await is intentionally sequential
       await Bun.sleep(HEALTH_INTERVAL_MS);
-      if (draining) {
+      if (isDraining()) {
         return;
       }
       writeHeartbeat();
@@ -898,12 +906,12 @@ export const runCaseLawIngest = async (
   // timeout so long texts don't block other work.
   const searchIndexLoop = (async () => {
     while (true) {
-      if (draining) {
+      if (isDraining()) {
         return;
       }
       // oxlint-disable-next-line no-await-in-loop -- fixed-interval backfill poll; the loop must wait SEARCH_INDEX_INTERVAL_MS between batches, so this await is intentionally sequential
       await Bun.sleep(SEARCH_INDEX_INTERVAL_MS);
-      if (draining) {
+      if (isDraining()) {
         return;
       }
       try {
@@ -936,7 +944,7 @@ export const runCaseLawIngest = async (
   const citationAuthorityLoop = (async () => {
     await Bun.sleep(CITATION_AUTHORITY_STARTUP_DELAY_MS);
     while (true) {
-      if (draining) {
+      if (isDraining()) {
         return;
       }
       let recomputed = false;
@@ -989,12 +997,12 @@ export const runCaseLawIngest = async (
     const generation = envBase.LEGAL_SEARCH_INDEX_GENERATION;
     logInfo(`[corpus-index] Enabled for generation ${generation}`);
     while (true) {
-      if (draining) {
+      if (isDraining()) {
         return;
       }
       // oxlint-disable-next-line no-await-in-loop -- fixed-interval backfill poll; the loop must wait CORPUS_INDEX_INTERVAL_MS between batches, so this await is intentionally sequential
       await Bun.sleep(CORPUS_INDEX_INTERVAL_MS);
-      if (draining) {
+      if (isDraining()) {
         return;
       }
       try {
@@ -1027,12 +1035,12 @@ export const runCaseLawIngest = async (
   // corpus daemon maintains both families' search projections.
   const legislationSearchIndexLoop = (async () => {
     while (true) {
-      if (draining) {
+      if (isDraining()) {
         return;
       }
       // oxlint-disable-next-line no-await-in-loop -- fixed-interval backfill poll; the loop must wait SEARCH_INDEX_INTERVAL_MS between batches, so this await is intentionally sequential
       await Bun.sleep(SEARCH_INDEX_INTERVAL_MS);
-      if (draining) {
+      if (isDraining()) {
         return;
       }
       try {
@@ -1070,12 +1078,12 @@ export const runCaseLawIngest = async (
     const generation = corpusGeneration("legislation");
     logInfo(`[legislation-corpus-index] Enabled for generation ${generation}`);
     while (true) {
-      if (draining) {
+      if (isDraining()) {
         return;
       }
       // oxlint-disable-next-line no-await-in-loop -- fixed-interval backfill poll; the loop must wait CORPUS_INDEX_INTERVAL_MS between batches, so this await is intentionally sequential
       await Bun.sleep(CORPUS_INDEX_INTERVAL_MS);
-      if (draining) {
+      if (isDraining()) {
         return;
       }
       try {

--- a/apps/legal-atlas-runner/src/runners/case-law-ingest.ts
+++ b/apps/legal-atlas-runner/src/runners/case-law-ingest.ts
@@ -132,6 +132,32 @@ process.on("unhandledRejection", (reason) => {
   process.exit(1);
 });
 
+/**
+ * Orchestrator-driven task replacement (a deployment, a rescheduled task)
+ * delivers SIGTERM with a bounded kill deadline. Draining finishes the
+ * work already in flight but starts nothing new: every write path is
+ * checkpointed or content-addressed, so abandoned work is safe, but
+ * finishing it avoids redoing the same page on the next start. The
+ * force-exit timer ends the process ahead of the orchestrator's SIGKILL
+ * even when a loop is mid-sleep on a long interval.
+ */
+let draining = false;
+const DRAIN_FORCE_EXIT_MS = 90_000;
+
+const drainOnSigterm = (): void => {
+  process.on("SIGTERM", () => {
+    if (draining) {
+      return;
+    }
+    draining = true;
+    logInfo("[daemon] SIGTERM received; draining (no new work will start)");
+    setTimeout(() => {
+      logInfo("[daemon] Drain window elapsed; exiting");
+      process.exit(0);
+    }, DRAIN_FORCE_EXIT_MS).unref();
+  });
+};
+
 type SourceDef = {
   adapterKey: string;
   name: string;
@@ -640,6 +666,9 @@ const runAdapterLoop = async ({ adapterKey, name }: SourceDef) => {
   let idleCycles = 0;
 
   while (true) {
+    if (draining) {
+      return;
+    }
     try {
       // Bound concurrent cycles: the fetch/enrich/parse phase runs outside
       // the DB-write slot, so without this every source crawls its backlog
@@ -823,6 +852,7 @@ export const runCaseLawIngest = async (
 
   // All adapters: independent concurrent loops.
   daemonMode = true;
+  drainOnSigterm();
   logInfo("Ingestion daemon started.");
   startEventLoopWatchdog();
   await refreshS3();
@@ -837,8 +867,14 @@ export const runCaseLawIngest = async (
   // Health loop: heartbeat + S3 credential refresh.
   const healthLoop = (async () => {
     while (true) {
+      if (draining) {
+        return;
+      }
       // oxlint-disable-next-line no-await-in-loop -- fixed-interval health poll; the loop must wait HEALTH_INTERVAL_MS between heartbeats, so this await is intentionally sequential
       await Bun.sleep(HEALTH_INTERVAL_MS);
+      if (draining) {
+        return;
+      }
       writeHeartbeat();
       try {
         if (isS3Stale()) {
@@ -862,8 +898,14 @@ export const runCaseLawIngest = async (
   // timeout so long texts don't block other work.
   const searchIndexLoop = (async () => {
     while (true) {
+      if (draining) {
+        return;
+      }
       // oxlint-disable-next-line no-await-in-loop -- fixed-interval backfill poll; the loop must wait SEARCH_INDEX_INTERVAL_MS between batches, so this await is intentionally sequential
       await Bun.sleep(SEARCH_INDEX_INTERVAL_MS);
+      if (draining) {
+        return;
+      }
       try {
         // oxlint-disable-next-line no-await-in-loop -- one bounded backfill batch per interval; the next poll only runs after this batch completes
         const indexed = await runWithHardDeadline(
@@ -894,6 +936,9 @@ export const runCaseLawIngest = async (
   const citationAuthorityLoop = (async () => {
     await Bun.sleep(CITATION_AUTHORITY_STARTUP_DELAY_MS);
     while (true) {
+      if (draining) {
+        return;
+      }
       let recomputed = false;
       try {
         // oxlint-disable-next-line no-await-in-loop -- one full recompute per interval; the next poll only runs after this recompute completes
@@ -944,8 +989,14 @@ export const runCaseLawIngest = async (
     const generation = envBase.LEGAL_SEARCH_INDEX_GENERATION;
     logInfo(`[corpus-index] Enabled for generation ${generation}`);
     while (true) {
+      if (draining) {
+        return;
+      }
       // oxlint-disable-next-line no-await-in-loop -- fixed-interval backfill poll; the loop must wait CORPUS_INDEX_INTERVAL_MS between batches, so this await is intentionally sequential
       await Bun.sleep(CORPUS_INDEX_INTERVAL_MS);
+      if (draining) {
+        return;
+      }
       try {
         // oxlint-disable-next-line no-await-in-loop -- one bounded backfill batch per interval; the next poll only runs after this batch completes
         const indexed = await runWithHardDeadline(
@@ -976,8 +1027,14 @@ export const runCaseLawIngest = async (
   // corpus daemon maintains both families' search projections.
   const legislationSearchIndexLoop = (async () => {
     while (true) {
+      if (draining) {
+        return;
+      }
       // oxlint-disable-next-line no-await-in-loop -- fixed-interval backfill poll; the loop must wait SEARCH_INDEX_INTERVAL_MS between batches, so this await is intentionally sequential
       await Bun.sleep(SEARCH_INDEX_INTERVAL_MS);
+      if (draining) {
+        return;
+      }
       try {
         // oxlint-disable-next-line no-await-in-loop -- one bounded backfill batch per interval; the next poll only runs after this batch completes
         const indexed = await runWithHardDeadline(
@@ -1013,8 +1070,14 @@ export const runCaseLawIngest = async (
     const generation = corpusGeneration("legislation");
     logInfo(`[legislation-corpus-index] Enabled for generation ${generation}`);
     while (true) {
+      if (draining) {
+        return;
+      }
       // oxlint-disable-next-line no-await-in-loop -- fixed-interval backfill poll; the loop must wait CORPUS_INDEX_INTERVAL_MS between batches, so this await is intentionally sequential
       await Bun.sleep(CORPUS_INDEX_INTERVAL_MS);
+      if (draining) {
+        return;
+      }
       try {
         // oxlint-disable-next-line no-await-in-loop -- one bounded backfill batch per interval; the next poll only runs after this batch completes
         const indexed = await runWithHardDeadline(


### PR DESCRIPTION
The ingestion daemon had no SIGTERM handling: a task replacement killed it mid-cycle, and the next start redid whatever page was in flight. Every write path is checkpointed or content-addressed, so an abrupt stop is safe — but it is not free.

On SIGTERM the daemon now drains: adapter loops stop before acquiring a new cycle slot, the backfill/index/recompute loops bail at their iteration boundaries (including right after their interval sleep, so a signal that lands mid-sleep does not buy one more batch), and in-flight work gets to finish. A 90-second force-exit timer (`unref`'d) ends the process ahead of the orchestrator's kill deadline even when a loop is sleeping on a long interval, and once every loop returns the process exits naturally sooner.

Single-adapter (one-shot) mode is unchanged; the handler is installed only when daemon mode starts.