### PR TITLE
feat(api): index the legal corpus at passage granularity

### DIFF
--- a/apps/api/src/handlers/case-law/corpus-index.test.ts
+++ b/apps/api/src/handlers/case-law/corpus-index.test.ts
@@ -199,6 +199,44 @@ describe("case-law passage projection", () => {
     }
   });
 
+  test("the searchable title is indexed once per decision, not per passage", async () => {
+    const row = makeRow({ id: "dec_title", contentHash: "hash_title" });
+    const { built } = await loadDocsForBatch([row], {
+      generation: "case_law_v2",
+      fetchFulltext: async () => null,
+      readPayload: async () => ({
+        text: "",
+        ast: astOf([
+          heading(0, "Odůvodnění"),
+          paragraph(1, 200),
+          paragraph(2, 200),
+          paragraph(3, 200),
+        ]),
+      }),
+    });
+
+    const docs = built.at(0)?.docs ?? [];
+    expect(docs.length).toBeGreaterThan(1);
+
+    // `title` is the only document-level field a free-text term can reach.
+    // Copied onto every passage, a court-name query would let one judgment
+    // return as many equally-scoring hits as it has passages and crowd every
+    // other decision out of the capped scan window.
+    const titled = docs.filter((doc) => doc["title"] !== undefined);
+    expect(titled).toHaveLength(1);
+    expect(titled.at(0)?.["seq"]).toBe(0);
+    expect(titled.at(0)?.["title"]).toBe(`case-${row.id} — Test Court`);
+
+    // The filter and facet fields stay on every passage: they are
+    // raw-tokenized or numeric, so they carry no free-text fan-out, and the
+    // engine filters on the document it scores.
+    for (const doc of docs) {
+      expect(doc["court"]).toBe("Test Court");
+      expect(doc["language"]).toBe("cs");
+      expect(doc["citation_authority"]).toBe(0);
+    }
+  });
+
   test("the delete-previous-copies query selects every passage a row emitted", async () => {
     const row = makeRow({ id: "dec_replace", contentHash: "hash_4" });
     const { built } = await loadDocsForBatch([row], {

--- a/apps/api/src/handlers/case-law/corpus-index.test.ts
+++ b/apps/api/src/handlers/case-law/corpus-index.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 
 import { loadDocsForBatch } from "@/api/handlers/case-law/corpus-index";
 import { toSafeId } from "@/api/lib/branded-types";
+import { corpusDocumentDeleteQuery } from "@/api/lib/corpus-index/core";
 import { TimeoutError } from "@/api/lib/errors/tagged-errors";
 import { corpusIndexId } from "@/api/lib/legal-search/index-naming";
 
@@ -38,25 +39,25 @@ describe("loadDocsForBatch read-failure isolation", () => {
     const okRow = makeRow({ id: "dec_ok", contentHash: "hash_ok" });
     const badRow = makeRow({ id: "dec_bad", contentHash: "hash_bad" });
 
-    const { docs, readFailures } = await loadDocsForBatch([okRow, badRow], {
+    const { built, readFailures } = await loadDocsForBatch([okRow, badRow], {
       generation,
       fetchFulltext: async () => null,
-      readText: async (row) => {
+      readPayload: async (row) => {
         if (row.id === badRow.id) {
           throw new TimeoutError({
             message: "corpus-read-text exceeded 60000ms",
             label: "corpus-read-text",
           });
         }
-        return `text for ${row.id}`;
+        return { text: `text for ${row.id}`, ast: null };
       },
     });
 
     // The healthy document still builds and stays in the batch.
-    expect(docs).toHaveLength(1);
-    const built = docs.at(0);
-    expect(built?.row.id).toBe(okRow.id);
-    expect(built?.doc["text"]).toBe(`text for ${okRow.id}`);
+    expect(built).toHaveLength(1);
+    const entry = built.at(0);
+    expect(entry?.row.id).toBe(okRow.id);
+    expect(entry?.docs.at(0)?.["text"]).toBe(`text for ${okRow.id}`);
 
     // The failed read is isolated as a failed index job for its jurisdiction.
     expect(readFailures).toHaveLength(1);
@@ -81,7 +82,7 @@ describe("loadDocsForBatch read-failure isolation", () => {
     });
     const fetchedIds: string[] = [];
 
-    const { docs, readFailures } = await loadDocsForBatch([legacyRow], {
+    const { built, readFailures } = await loadDocsForBatch([legacyRow], {
       generation,
       fetchFulltext: async (id) => {
         fetchedIds.push(id);
@@ -90,9 +91,160 @@ describe("loadDocsForBatch read-failure isolation", () => {
     });
 
     expect(readFailures).toHaveLength(0);
-    expect(docs).toHaveLength(1);
-    expect(docs.at(0)?.doc["text"]).toBe("stored fulltext");
+    expect(built).toHaveLength(1);
+    expect(built.at(0)?.docs.at(0)?.["text"]).toBe("stored fulltext");
     // The lazy fallback runs only for the S3-less row, keyed by its id.
     expect(fetchedIds).toEqual([legacyRow.id]);
+  });
+});
+
+const paragraph = (index: number, words: number) => ({
+  id: `b${index}`,
+  anchorId: `anchor-${index}`,
+  type: "paragraph" as const,
+  inlines: [],
+  plainText: `${index} ${"slovo ".repeat(words).trim()}`,
+});
+
+const heading = (index: number, text: string) => ({
+  id: `h${index}`,
+  anchorId: `anchor-${index}`,
+  type: "heading" as const,
+  level: 1 as const,
+  inlines: [],
+  plainText: text,
+});
+
+const astOf = (
+  blocks: (ReturnType<typeof paragraph> | ReturnType<typeof heading>)[],
+) => ({
+  version: 1 as const,
+  source: { system: "test", documentId: "d", webUrl: "", printUrl: "" },
+  metadata: {
+    caseNumber: null,
+    ecli: null,
+    court: null,
+    decisionDate: null,
+    decisionType: null,
+    keywords: [],
+    statutes: [],
+  },
+  blocks,
+});
+
+describe("case-law passage projection", () => {
+  test("one row emits every passage as its own document, under one row entry", async () => {
+    const row = makeRow({ id: "dec_passages", contentHash: "hash_1" });
+    const ast = astOf([
+      heading(0, "Odůvodnění"),
+      paragraph(1, 200),
+      paragraph(2, 200),
+      paragraph(3, 200),
+    ]);
+
+    const { built } = await loadDocsForBatch([row], {
+      generation: "case_law_v2",
+      fetchFulltext: async () => null,
+      readPayload: async () => ({ text: "ignored fallback", ast }),
+    });
+
+    // The row stays one unit — that is what keeps its indexedHash/generation
+    // mark and its audit row singular no matter how it split.
+    expect(built).toHaveLength(1);
+    const docs = built.at(0)?.docs ?? [];
+    expect(docs.length).toBeGreaterThan(1);
+
+    // Passage identity is deterministic and dense, and every passage carries
+    // the doc-level fields the filters need.
+    expect(docs.map((doc) => doc["seq"])).toEqual(
+      docs.map((_, index) => index),
+    );
+    expect(docs.map((doc) => doc["chunk_id"])).toEqual(
+      docs.map((_, index) => `${row.id}:${index}`),
+    );
+    for (const doc of docs) {
+      expect(doc["document_id"]).toBe(row.id);
+      expect(doc["court"]).toBe("Test Court");
+      expect(doc["decision_date"]).toBe("2024-01-01");
+      expect(doc["jurisdiction"]).toBe("CZ");
+      expect(typeof doc["anchor_id"]).toBe("string");
+    }
+
+    // The section heading opens the first passage and is context for the rest.
+    expect(docs.at(0)?.["text"]).toContain("Odůvodnění");
+    expect(docs.at(-1)?.["heading_path"]).toBe("Odůvodnění");
+    // No passage repeats the heading body text.
+    expect(
+      docs.filter((doc) => String(doc["text"]).includes("Odůvodnění")),
+    ).toHaveLength(1);
+  });
+
+  test("a row with no usable AST still emits passages, unanchored", async () => {
+    const row = makeRow({ id: "dec_no_ast", contentHash: "hash_2" });
+
+    const { built } = await loadDocsForBatch([row], {
+      generation: "case_law_v2",
+      fetchFulltext: async () => null,
+      readPayload: async () => ({
+        text: `${"slovo ".repeat(400)}\n\n${"jinak ".repeat(400)}`,
+        ast: {},
+      }),
+    });
+
+    const docs = built.at(0)?.docs ?? [];
+    expect(docs.length).toBeGreaterThan(1);
+    for (const doc of docs) {
+      expect(doc["document_id"]).toBe(row.id);
+      expect(doc["anchor_id"]).toBeUndefined();
+    }
+  });
+
+  test("the delete-previous-copies query selects every passage a row emitted", async () => {
+    const row = makeRow({ id: "dec_replace", contentHash: "hash_4" });
+    const { built } = await loadDocsForBatch([row], {
+      generation: "case_law_v2",
+      fetchFulltext: async () => null,
+      readPayload: async () => ({
+        text: "",
+        ast: astOf([
+          heading(0, "Odůvodnění"),
+          paragraph(1, 200),
+          paragraph(2, 200),
+          paragraph(3, 200),
+        ]),
+      }),
+    });
+
+    const docs = built.at(0)?.docs ?? [];
+    expect(docs.length).toBeGreaterThan(1);
+
+    // Re-indexing appends, so the previous copies are removed first. The
+    // engine has no primary key to replace by and the indexer does not know
+    // how many passages the previous version emitted, so the delete is scoped
+    // to the document, not to individual passage ids. Every passage this row
+    // emits must therefore be selected by that one query.
+    expect(corpusDocumentDeleteQuery(row.id)).toBe(`document_id:"${row.id}"`);
+    expect(docs.every((doc) => doc["document_id"] === row.id)).toBe(true);
+    // Passage identities are distinct — a delete keyed on them would have to
+    // enumerate all of them, which is the bookkeeping this avoids.
+    expect(new Set(docs.map((doc) => doc["chunk_id"])).size).toBe(docs.length);
+  });
+
+  test("a row with neither AST nor text still emits one findable document", async () => {
+    const row = makeRow({ id: "dec_empty", contentHash: "hash_3" });
+
+    const { built } = await loadDocsForBatch([row], {
+      generation: "case_law_v2",
+      fetchFulltext: async () => null,
+      readPayload: async () => ({ text: "", ast: null }),
+    });
+
+    const docs = built.at(0)?.docs ?? [];
+    expect(docs).toHaveLength(1);
+    expect(docs.at(0)?.["text"]).toBe("");
+    // Metadata filters must still reach it; dropping it would hide a decision
+    // that the indexer nonetheless marks as indexed.
+    expect(docs.at(0)?.["document_id"]).toBe(row.id);
+    expect(docs.at(0)?.["court"]).toBe("Test Court");
   });
 });

--- a/apps/api/src/handlers/case-law/corpus-index.ts
+++ b/apps/api/src/handlers/case-law/corpus-index.ts
@@ -5,9 +5,19 @@ import {
   caseLawIndexJobs,
   caseLawSources,
 } from "@/api/db/schema";
-import { readCorpusText } from "@/api/handlers/case-law/corpus-storage";
+import {
+  readCorpusAst,
+  readCorpusText,
+} from "@/api/handlers/case-law/corpus-storage";
+import { hasUsableAst } from "@/api/handlers/case-law/document-ast";
 import { redistributableCaseLawSource } from "@/api/handlers/case-law/redistribution";
 import type { SafeId } from "@/api/lib/branded-types";
+import type { CorpusChunk } from "@/api/lib/corpus-index/chunking";
+import {
+  chunkDocument,
+  formatHeadingPath,
+} from "@/api/lib/corpus-index/chunking";
+import type { CorpusDocumentPayload } from "@/api/lib/corpus-index/core";
 import { createCorpusIndexer } from "@/api/lib/corpus-index/core";
 
 /**
@@ -18,6 +28,12 @@ import { createCorpusIndexer } from "@/api/lib/corpus-index/core";
  * trail (case_law_index_jobs). Per-jurisdiction indexes (`case_law_v1_<country>`)
  * with the license gate in SQL so non-redistributable sources never enter the
  * scan.
+ *
+ * Case law is indexed at passage granularity: a decision projects to one
+ * search document per passage of its AST, all carrying the same doc-level
+ * fields so every existing filter (court, date, language, source, authority)
+ * still applies. Legislation stays document-granular — see
+ * `CorpusIndexGranularity` for why the families differ.
  */
 
 type IndexableRow = {
@@ -67,8 +83,13 @@ const SELECT_COLUMNS = {
 // A row is indexable once its canonical payload is in object storage.
 const hasContent = sql`${caseLawDecisions.contentHash} IS NOT NULL`;
 
-/** Build the corpus index search document, omitting empty optional fields. */
-const buildDoc = (row: IndexableRow, text: string): Record<string, unknown> => {
+/**
+ * Doc-level fields, shared by every passage of a decision. Duplicating them
+ * per passage is what keeps the filters working: the engine prunes and filters
+ * on the document it scores, and a passage that carried only its text could
+ * not be constrained by court or date.
+ */
+const buildSharedFields = (row: IndexableRow): Record<string, unknown> => {
   // eslint-disable-next-line no-untyped-updates/no-untyped-updates -- corpus index ingest document, not a DB update
   const doc: Record<string, unknown> = {
     document_id: row.id,
@@ -77,7 +98,6 @@ const buildDoc = (row: IndexableRow, text: string): Record<string, unknown> => {
     court: row.court,
     language: row.language,
     title: `${row.caseNumber} — ${row.court}`,
-    text,
     citation_authority: row.citationAuthority,
     citation_count: row.citationCount,
   };
@@ -100,11 +120,55 @@ const buildDoc = (row: IndexableRow, text: string): Record<string, unknown> => {
   return doc;
 };
 
+type ChunkDocInput = {
+  shared: Record<string, unknown>;
+  documentId: string;
+  chunk: CorpusChunk;
+};
+
+/**
+ * One passage's search document: the decision's shared fields plus what makes
+ * this passage addressable.
+ *
+ * `chunk_id` is deterministic (`<decisionId>:<seq>`) so the same input always
+ * produces the same document identities; it is what an operator greps for when
+ * reconciling a decision against the index. Replacement, though, is by
+ * `document_id` — see the shared core's `remove`.
+ */
+const buildChunkDoc = ({
+  shared,
+  documentId,
+  chunk,
+}: ChunkDocInput): Record<string, unknown> => ({
+  ...shared,
+  chunk_id: `${documentId}:${chunk.seq}`,
+  seq: chunk.seq,
+  text: chunk.text,
+  ...(chunk.anchorId === null ? {} : { anchor_id: chunk.anchorId }),
+  ...(chunk.headingPath.length === 0
+    ? {}
+    : { heading_path: formatHeadingPath(chunk.headingPath) }),
+});
+
+/** Build one search document per passage, omitting empty optional fields. */
+const buildDocs = (
+  row: IndexableRow,
+  { text, ast }: CorpusDocumentPayload,
+): Record<string, unknown>[] => {
+  const shared = buildSharedFields(row);
+  return chunkDocument({
+    ast: hasUsableAst(ast) ? ast : null,
+    fallbackText: text,
+  }).map((chunk) => buildChunkDoc({ shared, documentId: row.id, chunk }));
+};
+
 const indexer = createCorpusIndexer<"caseLawDecision", IndexableRow>({
   family: "case_law",
   captureStep: "backfillCorpusIndex.loadText",
-  buildDoc,
+  granularity: "passage",
+  buildDocs,
   readCorpusText,
+  readCorpusAst,
   // The scans deliberately carry no ORDER BY. Any pick order makes
   // progress (indexed rows leave the pending set), while ordering by
   // created_at steers the planner onto the created_at index and

--- a/apps/api/src/handlers/case-law/corpus-index.ts
+++ b/apps/api/src/handlers/case-law/corpus-index.ts
@@ -88,6 +88,11 @@ const hasContent = sql`${caseLawDecisions.contentHash} IS NOT NULL`;
  * per passage is what keeps the filters working: the engine prunes and filters
  * on the document it scores, and a passage that carried only its text could
  * not be constrained by court or date.
+ *
+ * Every field here is either raw-tokenized (a filter or facet key) or numeric,
+ * so none of them can be hit by a free-text term. That is deliberate — see
+ * `title` below, which is the one searchable document-level field and is
+ * therefore NOT part of this set.
  */
 const buildSharedFields = (row: IndexableRow): Record<string, unknown> => {
   // eslint-disable-next-line no-untyped-updates/no-untyped-updates -- corpus index ingest document, not a DB update
@@ -97,7 +102,6 @@ const buildSharedFields = (row: IndexableRow): Record<string, unknown> => {
     source: row.sourceId,
     court: row.court,
     language: row.language,
-    title: `${row.caseNumber} — ${row.court}`,
     citation_authority: row.citationAuthority,
     citation_count: row.citationCount,
   };
@@ -123,6 +127,8 @@ const buildSharedFields = (row: IndexableRow): Record<string, unknown> => {
 type ChunkDocInput = {
   shared: Record<string, unknown>;
   documentId: string;
+  /** Case number and court, indexed on the opening passage only. */
+  title: string;
   chunk: CorpusChunk;
 };
 
@@ -134,16 +140,28 @@ type ChunkDocInput = {
  * produces the same document identities; it is what an operator greps for when
  * reconciling a decision against the index. Replacement, though, is by
  * `document_id` — see the shared core's `remove`.
+ *
+ * `title` is searchable (case-number and court-name lookups run through it),
+ * which makes it the one field whose fan-out matters: copied onto every
+ * passage, a query for a court's name would match all of them, and a single
+ * long judgment could fill an entire scan window with hundreds of
+ * identically-scoring hits before the reader ever saw a second decision. It
+ * goes on the opening passage alone, so a title match contributes exactly one
+ * hit per document — the same fan-out the document-granular layout had — and
+ * groups to the top of the decision, which is where a case-number match should
+ * land anyway.
  */
 const buildChunkDoc = ({
   shared,
   documentId,
+  title,
   chunk,
 }: ChunkDocInput): Record<string, unknown> => ({
   ...shared,
   chunk_id: `${documentId}:${chunk.seq}`,
   seq: chunk.seq,
   text: chunk.text,
+  ...(chunk.seq === 0 ? { title } : {}),
   ...(chunk.anchorId === null ? {} : { anchor_id: chunk.anchorId }),
   ...(chunk.headingPath.length === 0
     ? {}
@@ -156,10 +174,13 @@ const buildDocs = (
   { text, ast }: CorpusDocumentPayload,
 ): Record<string, unknown>[] => {
   const shared = buildSharedFields(row);
+  const title = `${row.caseNumber} — ${row.court}`;
   return chunkDocument({
     ast: hasUsableAst(ast) ? ast : null,
     fallbackText: text,
-  }).map((chunk) => buildChunkDoc({ shared, documentId: row.id, chunk }));
+  }).map((chunk) =>
+    buildChunkDoc({ shared, documentId: row.id, title, chunk }),
+  );
 };
 
 const indexer = createCorpusIndexer<"caseLawDecision", IndexableRow>({

--- a/apps/api/src/handlers/case-law/decisions/search.ts
+++ b/apps/api/src/handlers/case-law/decisions/search.ts
@@ -383,6 +383,10 @@ const searchPostgresDecisions = async (
       decisionType: toNullableString(row["decision_type"]),
       sourceUrl: toNullableString(row["source_url"]),
       headline: headline ? escapeAndHighlight(headline) : null,
+      // Postgres FTS scores whole decisions, so there is no passage to anchor
+      // the hit to. Kept on both paths so the response shape does not depend
+      // on which provider served it.
+      anchorId: null,
       citationCount: Number(row["citation_count"]) || 0,
       createdAt:
         row["created_at"] instanceof Date
@@ -599,6 +603,7 @@ const searchCorpusIndexDecisions = async (
   });
 
   const {
+    anchorIdById,
     context: { byId },
     hasMore,
     pageRanked,
@@ -674,6 +679,10 @@ const searchCorpusIndexDecisions = async (
         decisionType: row.decisionType,
         sourceUrl: row.sourceUrl,
         headline: snippetById.get(hit.id) ?? null,
+        // Additive: the anchor of the passage the snippet came from, so a
+        // result can open the decision scrolled to what matched. Null on a
+        // document-granular generation and on unanchored fallback passages.
+        anchorId: anchorIdById.get(hit.id) ?? null,
         citationCount: row.citationCount,
         createdAt: row.createdAt.toISOString(),
       },

--- a/apps/api/src/handlers/legislation/corpus-index.test.ts
+++ b/apps/api/src/handlers/legislation/corpus-index.test.ts
@@ -39,25 +39,27 @@ describe("legislation loadDocsForBatch read-failure isolation", () => {
     const okRow = makeRow({ id: "leg_ok", contentHash: "hash_ok" });
     const badRow = makeRow({ id: "leg_bad", contentHash: "hash_bad" });
 
-    const { docs, readFailures } = await loadDocsForBatch([okRow, badRow], {
+    const { built, readFailures } = await loadDocsForBatch([okRow, badRow], {
       generation,
       fetchFulltext: async () => null,
-      readText: async (row) => {
+      readPayload: async (row) => {
         if (row.id === badRow.id) {
           throw new TimeoutError({
             message: "corpus-read-text exceeded 60000ms",
             label: "corpus-read-text",
           });
         }
-        return `text for ${row.id}`;
+        return { text: `text for ${row.id}`, ast: null };
       },
     });
 
     // The healthy document still builds and stays in the batch.
-    expect(docs).toHaveLength(1);
-    const built = docs.at(0);
-    expect(built?.row.id).toBe(okRow.id);
-    expect(built?.doc["text"]).toBe(`text for ${okRow.id}`);
+    expect(built).toHaveLength(1);
+    const entry = built.at(0);
+    expect(entry?.row.id).toBe(okRow.id);
+    // Legislation stays document-granular: one row, exactly one document.
+    expect(entry?.docs).toHaveLength(1);
+    expect(entry?.docs.at(0)?.["text"]).toBe(`text for ${okRow.id}`);
 
     // The failed read is isolated as a failed index job for its jurisdiction.
     expect(readFailures).toHaveLength(1);
@@ -82,7 +84,7 @@ describe("legislation loadDocsForBatch read-failure isolation", () => {
     });
     const fetchedIds: string[] = [];
 
-    const { docs, readFailures } = await loadDocsForBatch([legacyRow], {
+    const { built, readFailures } = await loadDocsForBatch([legacyRow], {
       generation,
       fetchFulltext: async (id) => {
         fetchedIds.push(id);
@@ -91,8 +93,9 @@ describe("legislation loadDocsForBatch read-failure isolation", () => {
     });
 
     expect(readFailures).toHaveLength(0);
-    expect(docs).toHaveLength(1);
-    expect(docs.at(0)?.doc["text"]).toBe("stored fulltext");
+    expect(built).toHaveLength(1);
+    expect(built.at(0)?.docs).toHaveLength(1);
+    expect(built.at(0)?.docs.at(0)?.["text"]).toBe("stored fulltext");
     // The lazy fallback runs only for the S3-less row, keyed by its id.
     expect(fetchedIds).toEqual([legacyRow.id]);
   });

--- a/apps/api/src/handlers/legislation/corpus-index.ts
+++ b/apps/api/src/handlers/legislation/corpus-index.ts
@@ -8,6 +8,7 @@ import {
 import { readCorpusText } from "@/api/handlers/case-law/corpus-storage";
 import { redistributableLegislationSource } from "@/api/handlers/legislation/redistribution";
 import type { SafeId } from "@/api/lib/branded-types";
+import type { CorpusDocumentPayload } from "@/api/lib/corpus-index/core";
 import { createCorpusIndexer } from "@/api/lib/corpus-index/core";
 
 /**
@@ -16,6 +17,13 @@ import { createCorpusIndexer } from "@/api/lib/corpus-index/core";
  * queries, and per-document shape. Per-jurisdiction indexes
  * (`legislation_v1_<country>`), license gate in SQL, batch ingest with a
  * per-group commit, audit trail in legislation_index_jobs.
+ *
+ * Indexed at document granularity, unlike case law: a legislation row is
+ * already one provision or article version, so it is the passage. Splitting it
+ * further would fragment a rule across search documents that are only
+ * meaningful together. If a jurisdiction starts delivering whole codes as one
+ * row, revisit this by switching the granularity here — the shared core, the
+ * chunker, and the read path already handle both layouts.
  */
 
 type IndexableRow = {
@@ -65,7 +73,10 @@ const SELECT_COLUMNS = {
 
 const hasContent = sql`${legislationDocuments.contentHash} IS NOT NULL`;
 
-const buildDoc = (row: IndexableRow, text: string): Record<string, unknown> => {
+const buildDoc = (
+  row: IndexableRow,
+  { text }: CorpusDocumentPayload,
+): Record<string, unknown> => {
   // eslint-disable-next-line no-untyped-updates/no-untyped-updates -- corpus index ingest document, not a DB update
   const doc: Record<string, unknown> = {
     document_id: row.id,
@@ -101,7 +112,8 @@ const buildDoc = (row: IndexableRow, text: string): Record<string, unknown> => {
 const indexer = createCorpusIndexer<"legislationDocument", IndexableRow>({
   family: "legislation",
   captureStep: "backfillLegislationCorpusIndex.loadText",
-  buildDoc,
+  granularity: "document",
+  buildDocs: (row, payload) => [buildDoc(row, payload)],
   readCorpusText,
   // The scans deliberately carry no ORDER BY. Any pick order makes
   // progress (indexed rows leave the pending set), while ordering by

--- a/apps/api/src/lib/corpus-index/chunking.test.ts
+++ b/apps/api/src/lib/corpus-index/chunking.test.ts
@@ -287,6 +287,8 @@ describe("chunkDocument never emits a body-less passage", () => {
     );
   });
 
+  // The 2s deadline matters: a regression here hangs instead of failing, and
+  // the deadline turns it back into a readable failure.
   test("a non-positive heading level cannot spin the ancestry stack", () => {
     // `isDocumentAst` validates the envelope only, so a source that emits a
     // level of 0 reaches the chunker exactly like this. Parsed through the
@@ -336,8 +338,7 @@ describe("chunkDocument never emits a body-less passage", () => {
     expect(chunks.map((chunk) => chunk.text)).toEqual([
       ["Zero", "Negative", "body"].join(SEPARATOR),
     ]);
-  }, // into a readable failure. // A regression here hangs rather than fails; the deadline turns it back
-  2000);
+  }, 2000);
 });
 
 describe("chunkDocument fallbacks", () => {
@@ -356,6 +357,75 @@ describe("chunkDocument fallbacks", () => {
       expect(chunk.anchorId).toBeNull();
       expect(chunk.headingPath).toEqual([]);
     }
+  });
+
+  test("junk blocks that pass the envelope guard degrade to the text", () => {
+    // Exactly what `hasUsableAst` admits: its own tests accept
+    // `{ version: 1, blocks: [{ a: 1 }] }`. Reading `.plainText` off any of
+    // these throws, and the indexer would record a failed job and retry
+    // forever for a document whose canonical text is fine.
+    const ast = parseDocumentAst(
+      JSON.stringify({
+        version: 1,
+        blocks: [{ junk: true }, 42, null],
+      }),
+    );
+    expect(ast).not.toBeNull();
+
+    const chunks = chunkDocument({
+      ast,
+      fallbackText: "the canonical text\n\nsecond paragraph",
+    });
+
+    expect(chunks.map((chunk) => chunk.text)).toEqual([
+      ["the canonical text", "second paragraph"].join(SEPARATOR),
+    ]);
+    for (const chunk of chunks) {
+      expect(chunk.anchorId).toBeNull();
+    }
+  });
+
+  test("one malformed block condemns the whole AST, not just itself", () => {
+    // Skipping the bad block would silently drop whatever it held; the
+    // canonical text is complete, so it is the safer source.
+    const ast = parseDocumentAst(
+      JSON.stringify({
+        version: 1,
+        blocks: [
+          {
+            id: "p0",
+            anchorId: "p0",
+            type: "paragraph",
+            inlines: [],
+            plainText: "a good block",
+          },
+          { id: "p1", anchorId: "p1", type: "paragraph", plainText: 7 },
+        ],
+      }),
+    );
+
+    const chunks = chunkDocument({ ast, fallbackText: "complete text" });
+
+    expect(chunks.map((chunk) => chunk.text)).toEqual(["complete text"]);
+  });
+
+  test("a heading missing its level is not chunkable", () => {
+    // The ancestry stack reads `level`; without it the heading cannot be
+    // placed, so the document takes the text path.
+    const ast = parseDocumentAst(
+      JSON.stringify({
+        version: 1,
+        blocks: [
+          { id: "h0", anchorId: "h0", type: "heading", plainText: "Nadpis" },
+        ],
+      }),
+    );
+
+    expect(
+      chunkDocument({ ast, fallbackText: "text instead" }).map(
+        (chunk) => chunk.text,
+      ),
+    ).toEqual(["text instead"]);
   });
 
   test("an AST that parsed but has no readable block degrades to the text", () => {

--- a/apps/api/src/lib/corpus-index/chunking.test.ts
+++ b/apps/api/src/lib/corpus-index/chunking.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
 import type { Block, DocumentAst } from "@stll/legal-ast/document-ast";
+import { parseDocumentAst } from "@stll/legal-ast/document-ast";
 
 import {
   chunkDocument,
@@ -139,6 +140,32 @@ describe("chunkDocument preserves the document", () => {
     }
   });
 
+  test("no passage is headings only, for any shape", () => {
+    for (let seed = 1; seed <= 60; seed += 1) {
+      const blocks = generateBlocks(seed);
+      const chunks = chunkDocument({
+        ast: astOf(blocks),
+        fallbackText: "unused",
+      });
+      // Generated paragraphs start with their block marker; generated headings
+      // do not, so a passage's segments say whether it carries body text.
+      const hasBody = (text: string): boolean =>
+        text.split(SEPARATOR).some((segment) => /^b\d+ /u.test(segment));
+
+      if (blocks.every((block) => block.type === "heading")) {
+        // A document that is nothing but headings has no body to attach them
+        // to; indexing them is better than indexing nothing.
+        expect(chunks).toHaveLength(1);
+        continue;
+      }
+      for (const chunk of chunks) {
+        // A heading-only passage would match a query and then show the reader
+        // no content.
+        expect(hasBody(chunk.text)).toBe(true);
+      }
+    }
+  });
+
   test("blank blocks are dropped rather than emitted as empty passages", () => {
     const chunks = chunkDocument({
       ast: astOf([
@@ -217,6 +244,100 @@ describe("chunkDocument boundaries", () => {
       ["I > I.A", "I > I.B", "II"],
     );
   });
+});
+
+describe("chunkDocument never emits a body-less passage", () => {
+  test("a heading trailing a full passage joins it instead of standing alone", () => {
+    const body = "para ".repeat(400).trim();
+    const chunks = chunkDocument({
+      ast: astOf([
+        heading(0, 1, "Odůvodnění"),
+        paragraph(1, body),
+        paragraph(2, body),
+        heading(3, 1, "Poučení"),
+      ]),
+      fallbackText: "unused",
+    });
+
+    // The trailing heading has no section under it, so it cannot open a
+    // passage; dropping it would lose text, so it joins the previous one.
+    expect(chunks.at(-1)?.text.endsWith("Poučení")).toBe(true);
+    expect(chunks.filter((chunk) => chunk.text === "Poučení")).toHaveLength(0);
+    // Still lossless.
+    expect(chunks.map((chunk) => chunk.text).join(SEPARATOR)).toBe(
+      ["Odůvodnění", body, body, "Poučení"].join(SEPARATOR),
+    );
+  });
+
+  test("a document of nothing but headings is emitted as one passage", () => {
+    const chunks = chunkDocument({
+      ast: astOf([
+        heading(0, 1, "Rozsudek"),
+        heading(1, 2, "Odůvodnění"),
+        heading(2, 2, "Poučení"),
+      ]),
+      fallbackText: "",
+    });
+
+    // There is no body to attach them to, and the headings are the only text
+    // the document has — indexing nothing would drop it from search entirely.
+    expect(chunks).toHaveLength(1);
+    expect(chunks.at(0)?.text).toBe(
+      ["Rozsudek", "Odůvodnění", "Poučení"].join(SEPARATOR),
+    );
+  });
+
+  test("a non-positive heading level cannot spin the ancestry stack", () => {
+    // `isDocumentAst` validates the envelope only, so a source that emits a
+    // level of 0 reaches the chunker exactly like this. Parsed through the
+    // production guard rather than cast, so the test proves the real path.
+    const ast = parseDocumentAst(
+      JSON.stringify({
+        version: 1,
+        source: { system: "t", documentId: "d", webUrl: "", printUrl: "" },
+        metadata: {
+          caseNumber: null,
+          ecli: null,
+          court: null,
+          decisionDate: null,
+          decisionType: null,
+          keywords: [],
+          statutes: [],
+        },
+        blocks: [
+          {
+            id: "h0",
+            anchorId: "h0",
+            type: "heading",
+            level: 0,
+            inlines: [],
+            plainText: "Zero",
+          },
+          {
+            id: "h1",
+            anchorId: "h1",
+            type: "heading",
+            level: -3,
+            inlines: [],
+            plainText: "Negative",
+          },
+          {
+            id: "p0",
+            anchorId: "p0",
+            type: "paragraph",
+            inlines: [],
+            plainText: "body",
+          },
+        ],
+      }),
+    );
+
+    const chunks = chunkDocument({ ast, fallbackText: "unused" });
+    expect(chunks.map((chunk) => chunk.text)).toEqual([
+      ["Zero", "Negative", "body"].join(SEPARATOR),
+    ]);
+  }, // into a readable failure. // A regression here hangs rather than fails; the deadline turns it back
+  2000);
 });
 
 describe("chunkDocument fallbacks", () => {

--- a/apps/api/src/lib/corpus-index/chunking.test.ts
+++ b/apps/api/src/lib/corpus-index/chunking.test.ts
@@ -1,0 +1,258 @@
+import { describe, expect, test } from "bun:test";
+
+import type { Block, DocumentAst } from "@stll/legal-ast/document-ast";
+
+import {
+  chunkDocument,
+  formatHeadingPath,
+} from "@/api/lib/corpus-index/chunking";
+
+/**
+ * The chunker's contract is an equality, not a heuristic: whatever it does
+ * with sizing, the passages it emits must reproduce the document. These tests
+ * therefore assert the equality over generated documents of varying shape,
+ * plus the edges where the rule bends (oversized block, no AST, no content).
+ */
+
+const SEPARATOR = "\n\n";
+
+const paragraph = (index: number, plainText: string): Block => ({
+  id: `p${index}`,
+  anchorId: `p${index}-anchor`,
+  type: "paragraph",
+  inlines: [],
+  plainText,
+});
+
+const heading = (
+  index: number,
+  level: 1 | 2 | 3,
+  plainText: string,
+): Block => ({
+  id: `h${index}`,
+  anchorId: `h${index}-anchor`,
+  type: "heading",
+  level,
+  inlines: [],
+  plainText,
+});
+
+const astOf = (blocks: Block[]): DocumentAst => ({
+  version: 1,
+  source: { system: "test", documentId: "d", webUrl: "", printUrl: "" },
+  metadata: {
+    caseNumber: null,
+    ecli: null,
+    court: null,
+    decisionDate: null,
+    decisionType: null,
+    keywords: [],
+    statutes: [],
+  },
+  blocks,
+});
+
+/**
+ * Deterministic pseudo-random generator: the shapes below have to be
+ * reproducible when a case fails, and a seeded LCG is cheaper than a property
+ * framework for the two dimensions that matter (block count, block length).
+ */
+const lcg = (seed: number) => {
+  let state = seed;
+  return (bound: number): number => {
+    state = (state * 1_664_525 + 1_013_904_223) % 4_294_967_296;
+    return state % bound;
+  };
+};
+
+const HEADING_LEVELS = [1, 2, 3] as const;
+
+const generateBlocks = (seed: number): Block[] => {
+  const random = lcg(seed);
+  const count = 1 + random(40);
+  const blocks: Block[] = [];
+  for (let index = 0; index < count; index += 1) {
+    const words = 1 + random(600);
+    const body = `b${index} ${"lorem ".repeat(words).trim()}`;
+    blocks.push(
+      random(5) === 0
+        ? heading(
+            index,
+            HEADING_LEVELS[random(HEADING_LEVELS.length)] ?? 1,
+            `Section ${index}`,
+          )
+        : paragraph(index, body),
+    );
+  }
+  return blocks;
+};
+
+const nonBlank = (blocks: readonly Block[]): Block[] =>
+  blocks.filter((block) => block.plainText.trim().length > 0);
+
+describe("chunkDocument preserves the document", () => {
+  test("concatenated passages reproduce the block text exactly, for any shape", () => {
+    for (let seed = 1; seed <= 60; seed += 1) {
+      const blocks = generateBlocks(seed);
+      const chunks = chunkDocument({
+        ast: astOf(blocks),
+        fallbackText: "unused",
+      });
+
+      // No text lost, no text indexed twice, order preserved. One equality
+      // covers all three, and does not care what the separator is.
+      expect(chunks.map((chunk) => chunk.text).join(SEPARATOR)).toBe(
+        nonBlank(blocks)
+          .map((block) => block.plainText)
+          .join(SEPARATOR),
+      );
+    }
+  });
+
+  test("seq is dense and 0-based, for any shape", () => {
+    for (let seed = 1; seed <= 60; seed += 1) {
+      const chunks = chunkDocument({
+        ast: astOf(generateBlocks(seed)),
+        fallbackText: "unused",
+      });
+      expect(chunks.map((chunk) => chunk.seq)).toEqual(
+        chunks.map((_, index) => index),
+      );
+    }
+  });
+
+  test("every passage anchors to its own first block", () => {
+    for (let seed = 1; seed <= 60; seed += 1) {
+      const blocks = nonBlank(generateBlocks(seed));
+      const chunks = chunkDocument({
+        ast: astOf(blocks),
+        fallbackText: "unused",
+      });
+      const anchors = new Set(blocks.map((block) => block.anchorId));
+      for (const chunk of chunks) {
+        expect(anchors.has(chunk.anchorId ?? "")).toBe(true);
+      }
+      // Anchors are the deep-link target, so two passages must never share one.
+      expect(new Set(chunks.map((chunk) => chunk.anchorId)).size).toBe(
+        chunks.length,
+      );
+    }
+  });
+
+  test("blank blocks are dropped rather than emitted as empty passages", () => {
+    const chunks = chunkDocument({
+      ast: astOf([
+        paragraph(0, "   "),
+        paragraph(1, "real text"),
+        paragraph(2, "\n\t"),
+      ]),
+      fallbackText: "unused",
+    });
+    expect(chunks).toHaveLength(1);
+    expect(chunks.at(0)?.text).toBe("real text");
+  });
+});
+
+describe("chunkDocument boundaries", () => {
+  test("a block larger than the target band becomes its own passage, whole", () => {
+    const oversized = `giant ${"word ".repeat(2000).trim()}`;
+    const chunks = chunkDocument({
+      ast: astOf([
+        paragraph(0, "before"),
+        paragraph(1, oversized),
+        paragraph(2, "after"),
+      ]),
+      fallbackText: "unused",
+    });
+
+    const oversizedChunks = chunks.filter((chunk) =>
+      chunk.text.includes("giant"),
+    );
+    expect(oversizedChunks).toHaveLength(1);
+    // Never split mid-block: the passage is the block, not a prefix of it.
+    expect(oversizedChunks.at(0)?.text).toBe(oversized);
+  });
+
+  test("a heading opens the passage that carries its section and never stands alone", () => {
+    const body = "para ".repeat(400).trim();
+    const chunks = chunkDocument({
+      ast: astOf([
+        heading(0, 1, "Rozsudek"),
+        heading(1, 2, "Odůvodnění"),
+        paragraph(2, body),
+        paragraph(3, body),
+        paragraph(4, body),
+      ]),
+      fallbackText: "unused",
+    });
+
+    // Two consecutive headings do not produce a heading-only passage.
+    const first = chunks.at(0);
+    expect(first?.text.startsWith("Rozsudek\n\nOdůvodnění\n\npara")).toBe(true);
+    expect(first?.headingPath).toEqual(["Rozsudek", "Odůvodnění"]);
+
+    // Continuation passages keep the section context without repeating it in
+    // the body, so those heading terms are not counted N times.
+    for (const chunk of chunks.slice(1)) {
+      expect(chunk.headingPath).toEqual(["Rozsudek", "Odůvodnění"]);
+      expect(chunk.text).not.toContain("Odůvodnění");
+    }
+  });
+
+  test("headingPath is the ancestry, with siblings popped", () => {
+    const chunks = chunkDocument({
+      ast: astOf([
+        heading(0, 1, "I"),
+        heading(1, 2, "I.A"),
+        paragraph(2, "a ".repeat(600).trim()),
+        heading(3, 2, "I.B"),
+        paragraph(4, "b ".repeat(600).trim()),
+        heading(5, 1, "II"),
+        paragraph(6, "c ".repeat(600).trim()),
+      ]),
+      fallbackText: "unused",
+    });
+
+    expect(chunks.map((chunk) => formatHeadingPath(chunk.headingPath))).toEqual(
+      ["I > I.A", "I > I.B", "II"],
+    );
+  });
+});
+
+describe("chunkDocument fallbacks", () => {
+  test("no AST splits the plain text on blank lines, unanchored", () => {
+    const first = "alfa ".repeat(400).trim();
+    const second = "beta ".repeat(400).trim();
+    const chunks = chunkDocument({
+      ast: null,
+      fallbackText: `${first}\n\n${second}`,
+    });
+
+    expect(chunks.map((chunk) => chunk.text).join(SEPARATOR)).toBe(
+      `${first}${SEPARATOR}${second}`,
+    );
+    for (const chunk of chunks) {
+      expect(chunk.anchorId).toBeNull();
+      expect(chunk.headingPath).toEqual([]);
+    }
+  });
+
+  test("an AST that parsed but has no readable block degrades to the text", () => {
+    const chunks = chunkDocument({
+      ast: astOf([paragraph(0, "  ")]),
+      fallbackText: "the text that survived",
+    });
+    expect(chunks.map((chunk) => chunk.text)).toEqual([
+      "the text that survived",
+    ]);
+  });
+
+  test("a document with neither AST nor text still yields one passage", () => {
+    const chunks = chunkDocument({ ast: null, fallbackText: "   " });
+    // Emitting nothing would drop a decision that still has indexable
+    // metadata out of every filtered search.
+    expect(chunks).toEqual([
+      { seq: 0, text: "", anchorId: null, headingPath: [] },
+    ]);
+  });
+});

--- a/apps/api/src/lib/corpus-index/chunking.ts
+++ b/apps/api/src/lib/corpus-index/chunking.ts
@@ -29,8 +29,10 @@ import type { Block, DocumentAst } from "@stll/legal-ast/document-ast";
  *   Continuation passages of a long section do not
  *   repeat the heading text — repeating it would index the same words N times
  *   and skew their document frequency. They carry `headingPath` instead, which
- *   the index maps as a searchable field, so section context is queryable for
- *   every passage without duplicating it into the body.
+ *   the index maps as an explicitly targetable field (not a default search
+ *   field: it repeats per passage, so a free-text match on a boilerplate
+ *   heading would return the whole section at once). A heading's own words
+ *   stay searchable through the `text` of the passage it opens.
  */
 
 /** One contiguous run of blocks, indexed as its own search document. */
@@ -199,6 +201,45 @@ const createHeadingStack = () => {
   return { push, path };
 };
 
+/**
+ * Runtime check that a persisted block carries what the chunker reads.
+ *
+ * `DocumentAst` is a compile-time shape over data that was written to object
+ * storage by an older parser and read back as JSON. Its guards
+ * (`isDocumentAst`, `hasUsableAst`) deliberately validate only the envelope —
+ * version and a blocks array — so `{ junk: true }`, `42` and `null` all arrive
+ * here typed as `Block`. Reading `.plainText` off one of those throws, and
+ * because the chunker runs inside the indexer's per-row try/catch that throw
+ * would be recorded as a failed index job and retried forever, for a document
+ * whose canonical text is perfectly good.
+ *
+ * Checked with `in` rather than a discriminator: there is no trusted
+ * discriminator to read until the shape itself is proven.
+ */
+const isChunkableBlock = (block: unknown): boolean => {
+  if (typeof block !== "object" || block === null) {
+    return false;
+  }
+  if (!("plainText" in block) || typeof block.plainText !== "string") {
+    return false;
+  }
+  if (!("anchorId" in block) || typeof block.anchorId !== "string") {
+    return false;
+  }
+  if (!("type" in block)) {
+    return false;
+  }
+  if (block.type === "paragraph" || block.type === "table") {
+    return true;
+  }
+  // A heading additionally drives the ancestry stack, which reads `level`.
+  return (
+    block.type === "heading" &&
+    "level" in block &&
+    typeof block.level === "number"
+  );
+};
+
 const chunkBlocks = (blocks: readonly Block[]): CorpusChunk[] => {
   const accumulator = createChunkAccumulator();
   const headings = createHeadingStack();
@@ -247,8 +288,9 @@ const chunkPlainText = (text: string): CorpusChunk[] => {
 
 export type ChunkDocumentInput = {
   /**
-   * Parsed AST when the document has one. `null` (or a blockless AST) falls
-   * through to the plain-text path.
+   * Parsed AST when the document has one. `null`, a blockless AST, or one
+   * whose blocks do not hold up at runtime all fall through to the plain-text
+   * path — the type is a claim about persisted JSON, not a guarantee.
    */
   ast: DocumentAst | null;
   /** Canonical plain text; the fallback source and the empty-document guard. */
@@ -267,7 +309,14 @@ export const chunkDocument = ({
   ast,
   fallbackText,
 }: ChunkDocumentInput): CorpusChunk[] => {
-  const fromAst = ast === null ? [] : chunkBlocks(ast.blocks);
+  // A single non-conforming block condemns the whole AST rather than being
+  // skipped: the canonical text is complete, so degrading to it keeps every
+  // word, while dropping bad blocks would silently lose whatever they held.
+  // The structure is what is untrustworthy here, not the content.
+  const fromAst =
+    ast !== null && ast.blocks.every(isChunkableBlock)
+      ? chunkBlocks(ast.blocks)
+      : [];
   if (fromAst.length > 0) {
     return fromAst;
   }

--- a/apps/api/src/lib/corpus-index/chunking.ts
+++ b/apps/api/src/lib/corpus-index/chunking.ts
@@ -23,7 +23,10 @@ import type { Block, DocumentAst } from "@stll/legal-ast/document-ast";
  *   single oversized block therefore becomes an oversized passage rather than
  *   being cut mid-sentence.
  * - A heading is never a passage of its own; it opens the passage that carries
- *   the section it introduces. Continuation passages of a long section do not
+ *   the section it introduces, and a trailing heading with nothing under it
+ *   joins the passage before it (the sole exception is a document that is
+ *   nothing but headings, where they are the only content there is).
+ *   Continuation passages of a long section do not
  *   repeat the heading text — repeating it would index the same words N times
  *   and skew their document frequency. They carry `headingPath` instead, which
  *   the index maps as a searchable field, so section context is queryable for
@@ -151,7 +154,24 @@ const createChunkAccumulator = () => {
     open.hasBody ||= !isHeading;
   };
 
+  /**
+   * Close the document. A trailing run of headings (a section header with
+   * nothing under it, or a document that is nothing but headings) would
+   * otherwise flush as a body-less passage: a result that matches a query and
+   * then shows the reader no content.
+   *
+   * It cannot simply be dropped either — that would lose text. So it joins the
+   * previous passage, which is where a reader would look for it anyway. A
+   * document with no body at all has no previous passage to join, and its
+   * headings are the only content it has; that one is emitted, because the
+   * alternative is indexing nothing.
+   */
   const finish = (): CorpusChunk[] => {
+    const previous = chunks.at(-1);
+    if (open.texts.length > 0 && !open.hasBody && previous !== undefined) {
+      previous.text = [previous.text, ...open.texts].join(BLOCK_SEPARATOR);
+      open = emptyChunk();
+    }
     flush();
     return chunks;
   };
@@ -164,7 +184,11 @@ const createHeadingStack = () => {
   const stack: { level: number; text: string }[] = [];
 
   const push = (level: number, text: string): void => {
-    while ((stack.at(-1)?.level ?? 0) >= level) {
+    // Terminate on the stack, not on the level: `isDocumentAst` only checks the
+    // envelope, so a malformed block can carry level <= 0, and comparing
+    // against the empty-stack default of 0 would then pop forever. Each
+    // iteration removes an entry, so bounding on length cannot spin.
+    while (stack.length > 0 && (stack.at(-1)?.level ?? 0) >= level) {
       stack.pop();
     }
     stack.push({ level, text });

--- a/apps/api/src/lib/corpus-index/chunking.ts
+++ b/apps/api/src/lib/corpus-index/chunking.ts
@@ -1,0 +1,262 @@
+import type { Block, DocumentAst } from "@stll/legal-ast/document-ast";
+
+/**
+ * Passage chunking for the corpus search projection.
+ *
+ * Legal relevance lives at passage level: BM25 over a whole judgment dilutes
+ * the one paragraph that answers the query, and a long document's term
+ * frequencies drown a short, precisely-on-point one. Splitting a document into
+ * contiguous passages restores that signal and gives every hit a deep link,
+ * because the AST's block `anchorId`s are the same anchors the reader scrolls
+ * to.
+ *
+ * The module is pure: it takes a parsed AST (and the plain-text fallback for
+ * rows whose AST never parsed) and returns ordered passages. No I/O, no
+ * tokenizer dependency — size is estimated from character count, which is
+ * accurate enough to hit a passage-size band and costs nothing.
+ *
+ * Two rules keep the output faithful to the source:
+ *
+ * - A block is never split. Concatenating every passage's text reproduces the
+ *   document exactly, so no sentence is lost and none is indexed twice
+ *   (`chunking.test.ts` asserts this as an equality, not a spot check). A
+ *   single oversized block therefore becomes an oversized passage rather than
+ *   being cut mid-sentence.
+ * - A heading is never a passage of its own; it opens the passage that carries
+ *   the section it introduces. Continuation passages of a long section do not
+ *   repeat the heading text — repeating it would index the same words N times
+ *   and skew their document frequency. They carry `headingPath` instead, which
+ *   the index maps as a searchable field, so section context is queryable for
+ *   every passage without duplicating it into the body.
+ */
+
+/** One contiguous run of blocks, indexed as its own search document. */
+export type CorpusChunk = {
+  /** 0-based position within the document; dense, gap-free. */
+  seq: number;
+  /** Concatenated `plainText` of the member blocks, in document order. */
+  text: string;
+  /** First member block's stable deep-link anchor; null on the text fallback. */
+  anchorId: string | null;
+  /** Heading texts from the document root down to this passage's section. */
+  headingPath: string[];
+};
+
+/**
+ * Rough characters-per-token for European legal prose. Only used to express
+ * the passage-size band in characters; a real tokenizer would buy accuracy we
+ * have no use for and a dependency we would have to keep in sync with the
+ * engine's.
+ */
+const CHARS_PER_TOKEN = 4;
+
+/** Upper edge of the target band (~400 tokens). A passage stops here. */
+const CHUNK_TARGET_CHARS = 400 * CHARS_PER_TOKEN;
+
+/**
+ * Lower edge of the target band (~250 tokens). A heading closes the passage in
+ * progress only once it holds at least this much: otherwise a document of many
+ * short sections would emit a passage per heading, each too small to score.
+ */
+const CHUNK_MIN_CHARS = 250 * CHARS_PER_TOKEN;
+
+/** Block separator. Also what the fallback splits paragraphs on. */
+const BLOCK_SEPARATOR = "\n\n";
+
+const PARAGRAPH_BREAK = /\n[ \t]*\n/u;
+
+const isBlank = (text: string): boolean => text.trim().length === 0;
+
+type OpenChunk = {
+  texts: string[];
+  chars: number;
+  /** Whether anything other than headings has landed in this passage yet. */
+  hasBody: boolean;
+  anchorId: string | null;
+  headingPath: string[];
+};
+
+const emptyChunk = (): OpenChunk => ({
+  texts: [],
+  chars: 0,
+  hasBody: false,
+  anchorId: null,
+  headingPath: [],
+});
+
+/**
+ * Accumulates blocks into passages. Kept as a small closure rather than a
+ * class so the two entry points (AST, plain-text fallback) share the sizing
+ * rule without either owning it.
+ */
+const createChunkAccumulator = () => {
+  const chunks: CorpusChunk[] = [];
+  let open = emptyChunk();
+
+  const flush = (): void => {
+    if (open.texts.length === 0) {
+      return;
+    }
+    chunks.push({
+      seq: chunks.length,
+      text: open.texts.join(BLOCK_SEPARATOR),
+      anchorId: open.anchorId,
+      headingPath: open.headingPath,
+    });
+    open = emptyChunk();
+  };
+
+  type AddOptions = {
+    text: string;
+    anchorId: string | null;
+    headingPath: string[];
+    /** Headings open a passage; they never close one, and never stand alone. */
+    isHeading: boolean;
+  };
+
+  const add = ({
+    text,
+    anchorId,
+    headingPath,
+    isHeading,
+  }: AddOptions): void => {
+    // Both boundary rules require the passage in progress to hold body text.
+    // A run of headings with nothing under it yet is not a passage — closing
+    // there would emit a heading-only document that can match a query and then
+    // show the reader no content.
+    if (isHeading) {
+      // Align the passage boundary to the section boundary, but only once the
+      // passage in progress is worth emitting on its own.
+      if (open.hasBody && open.chars >= CHUNK_MIN_CHARS) {
+        flush();
+      }
+    } else if (open.hasBody && open.chars + text.length > CHUNK_TARGET_CHARS) {
+      // Closing before the block that would overflow keeps passages inside the
+      // band; a block that exceeds the band on its own lands in an empty
+      // passage and stays whole.
+      flush();
+    }
+
+    if (open.texts.length === 0) {
+      open.anchorId = anchorId;
+    }
+    if (open.texts.length === 0 || isHeading) {
+      // The passage is labelled with the deepest section it opens: a heading
+      // that joins a passage still in progress moves the label onto the
+      // section that most of the passage's text will belong to.
+      open.headingPath = headingPath;
+    }
+    open.texts.push(text);
+    open.chars += text.length;
+    open.hasBody ||= !isHeading;
+  };
+
+  const finish = (): CorpusChunk[] => {
+    flush();
+    return chunks;
+  };
+
+  return { add, finish };
+};
+
+/** Heading ancestry as a stack; a heading pops every sibling-or-deeper entry. */
+const createHeadingStack = () => {
+  const stack: { level: number; text: string }[] = [];
+
+  const push = (level: number, text: string): void => {
+    while ((stack.at(-1)?.level ?? 0) >= level) {
+      stack.pop();
+    }
+    stack.push({ level, text });
+  };
+
+  const path = (): string[] => stack.map((entry) => entry.text);
+
+  return { push, path };
+};
+
+const chunkBlocks = (blocks: readonly Block[]): CorpusChunk[] => {
+  const accumulator = createChunkAccumulator();
+  const headings = createHeadingStack();
+
+  for (const block of blocks) {
+    if (isBlank(block.plainText)) {
+      continue;
+    }
+    const isHeading = block.type === "heading";
+    if (isHeading) {
+      headings.push(block.level, block.plainText);
+    }
+    accumulator.add({
+      text: block.plainText,
+      anchorId: block.anchorId,
+      headingPath: headings.path(),
+      isHeading,
+    });
+  }
+
+  return accumulator.finish();
+};
+
+/**
+ * Fallback for rows that have text but no usable AST (a source we cannot parse
+ * yet, or a document ingested before its parser landed). Blank lines are the
+ * only structure such text carries, so they stand in for block boundaries;
+ * without anchors these passages cannot deep-link, and `anchorId` stays null
+ * rather than pointing somewhere approximate.
+ */
+const chunkPlainText = (text: string): CorpusChunk[] => {
+  const accumulator = createChunkAccumulator();
+  for (const paragraph of text.split(PARAGRAPH_BREAK)) {
+    if (isBlank(paragraph)) {
+      continue;
+    }
+    accumulator.add({
+      text: paragraph,
+      anchorId: null,
+      headingPath: [],
+      isHeading: false,
+    });
+  }
+  return accumulator.finish();
+};
+
+export type ChunkDocumentInput = {
+  /**
+   * Parsed AST when the document has one. `null` (or a blockless AST) falls
+   * through to the plain-text path.
+   */
+  ast: DocumentAst | null;
+  /** Canonical plain text; the fallback source and the empty-document guard. */
+  fallbackText: string;
+};
+
+/**
+ * Split one corpus document into ordered passages.
+ *
+ * Always returns at least one passage. A document with neither blocks nor text
+ * still has indexable metadata (case number, court, date), and emitting
+ * nothing would drop it out of filtered searches entirely while the indexer
+ * still recorded it as indexed.
+ */
+export const chunkDocument = ({
+  ast,
+  fallbackText,
+}: ChunkDocumentInput): CorpusChunk[] => {
+  const fromAst = ast === null ? [] : chunkBlocks(ast.blocks);
+  if (fromAst.length > 0) {
+    return fromAst;
+  }
+  // An AST that parsed but carries no readable block is as unusable as none
+  // at all, so it degrades to the same text path rather than to one empty
+  // passage.
+  const fromText = chunkPlainText(fallbackText);
+  if (fromText.length > 0) {
+    return fromText;
+  }
+  return [{ seq: 0, text: "", anchorId: null, headingPath: [] }];
+};
+
+/** Joins a heading path into the single string the index stores. */
+export const formatHeadingPath = (headingPath: readonly string[]): string =>
+  headingPath.join(" > ");

--- a/apps/api/src/lib/corpus-index/core.test.ts
+++ b/apps/api/src/lib/corpus-index/core.test.ts
@@ -1,6 +1,14 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
-import { settleBoth, splitIngestRequests } from "@/api/lib/corpus-index/core";
+import type { ScopedDb } from "@/api/db/safe-db";
+import { toSafeId } from "@/api/lib/branded-types";
+import type { CorpusJobInput } from "@/api/lib/corpus-index/core";
+import {
+  createCorpusIndexer,
+  settleBoth,
+  splitIngestRequests,
+} from "@/api/lib/corpus-index/core";
+import { corpusIndexId } from "@/api/lib/legal-search/index-naming";
 
 /**
  * A batch is sized in rows, but a passage family turns one row into as many
@@ -152,5 +160,109 @@ describe("settleBoth", () => {
     expect(
       await settleBoth(Promise.resolve("text"), Promise.resolve(null)),
     ).toEqual(["text", null]);
+  });
+});
+
+/**
+ * The indexer's audit trail is the only record of a row it could not place: a
+ * row that is neither marked indexed nor recorded failed is invisible to an
+ * operator. Failed jobs are buffered per group so several failure sites share
+ * one write, and this pins the part that is easy to lose again — the buffer
+ * must not outlive the group that filled it, and it must be flushed even when
+ * the work around it throws.
+ */
+describe("failed index jobs always reach the audit trail", () => {
+  const originalFetch = globalThis.fetch;
+  const GENERATION = "case_law_v2";
+  const CZ_INDEX_ID = corpusIndexId(GENERATION, "CZ");
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  const makeRow = (id: string, country: string) => ({
+    id: toSafeId<"caseLawDecision">(id),
+    country,
+    textS3Key: null,
+    astS3Key: null,
+    contentHash: `hash-${id}`,
+    indexedHash: null,
+    indexedGeneration: null,
+    updatedAt: new Date("2026-01-01T00:00:00Z"),
+  });
+
+  beforeEach(() => {
+    // The CZ index rejects its ingest; the SK index accepts. Everything else
+    // the indexer probes succeeds.
+    const resolveUrl = (input: Parameters<typeof fetch>[0]): string => {
+      if (typeof input === "string") {
+        return input;
+      }
+      return input instanceof URL ? input.href : input.url;
+    };
+    const stub = async (input: Parameters<typeof fetch>[0]) => {
+      const url = resolveUrl(input);
+      if (url.includes(`${CZ_INDEX_ID}/ingest`)) {
+        return new Response("rejected", { status: 500 });
+      }
+      if (url.includes("/ingest")) {
+        return new Response(JSON.stringify({ num_docs_for_processing: 1 }), {
+          status: 200,
+        });
+      }
+      return new Response(JSON.stringify({}), { status: 200 });
+    };
+    globalThis.fetch = Object.assign(stub, {
+      preconnect: originalFetch.preconnect,
+    });
+  });
+
+  test("an earlier group's failure is recorded even when a later group throws", async () => {
+    const recorded: {
+      indexId: string;
+      jobs: CorpusJobInput<"caseLawDecision">[];
+    }[] = [];
+    const czRow = makeRow("dec-cz", "CZ");
+    const skRow = makeRow("dec-sk", "SK");
+
+    // The only place `backfill` opens a transaction is the compare-and-set
+    // commit, so failing here is exactly the DB error being simulated — and it
+    // means the fake never has to conjure a `Transaction`.
+    const scopedDb: ScopedDb = async () => {
+      throw new Error("connection reset during CAS");
+    };
+
+    const indexer = createCorpusIndexer<"caseLawDecision", typeof czRow>({
+      family: "case_law",
+      captureStep: "test",
+      granularity: "document",
+      buildDocs: (row) => [{ document_id: row.id, text: "body" }],
+      readCorpusText: async () => "body",
+      selectMissing: async () => [czRow, skRow],
+      selectStale: async () => [],
+      fetchFulltext: async () => "body",
+      markIndexed: async () => true,
+      insertSucceededJobs: async () => undefined,
+      recordJobs: async (_db, jobs, indexId) => {
+        recorded.push({ indexId, jobs: [...jobs] });
+      },
+    });
+
+    const outcome = await indexer.backfill(scopedDb, 10, GENERATION).then(
+      () => null,
+      (error: unknown) => error,
+    );
+
+    // The later group's failure still propagates, so the daemon retries.
+    expect(outcome instanceof Error ? outcome.message : null).toBe(
+      "connection reset during CAS",
+    );
+
+    // ...and the earlier group's rejected ingest left an audit row behind.
+    const czJobs = recorded.filter((entry) => entry.indexId === CZ_INDEX_ID);
+    expect(czJobs).toHaveLength(1);
+    expect(czJobs.at(0)?.jobs.map((job) => job.entityId)).toEqual([czRow.id]);
+    expect(czJobs.at(0)?.jobs.at(0)?.status).toBe("failed");
+    expect(czJobs.at(0)?.jobs.at(0)?.operation).toBe("index");
   });
 });

--- a/apps/api/src/lib/corpus-index/core.test.ts
+++ b/apps/api/src/lib/corpus-index/core.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, test } from "bun:test";
+
+import { settleBoth, splitIngestRequests } from "@/api/lib/corpus-index/core";
+
+/**
+ * A batch is sized in rows, but a passage family turns one row into as many
+ * documents as it has passages, so the NDJSON body a batch serializes to is
+ * not bounded by the row count. These tests pin the byte bound and the row
+ * boundary it must never cut across.
+ */
+
+const utf8Bytes = (value: string): number => Buffer.byteLength(value, "utf-8");
+
+const builtRow = (id: string, passages: number, filler: string) => ({
+  row: { id },
+  docs: Array.from({ length: passages }, (_, seq) => ({
+    document_id: id,
+    seq,
+    text: filler,
+  })),
+});
+
+const ingestedIds = (requests: ReturnType<typeof splitIngestRequests>) =>
+  requests.flatMap(({ ndjson }) =>
+    ndjson.split("\n").map((line) => {
+      const doc: Record<string, unknown> = JSON.parse(line);
+      return `${String(doc["document_id"])}:${String(doc["seq"])}`;
+    }),
+  );
+
+describe("splitIngestRequests", () => {
+  test("a group that fits stays one request", () => {
+    const group = [builtRow("a", 3, "x"), builtRow("b", 2, "x")];
+
+    const requests = splitIngestRequests(group, 1_000_000);
+
+    expect(requests).toHaveLength(1);
+    expect(requests.at(0)?.entries).toHaveLength(2);
+    expect(requests.at(0)?.ndjson.split("\n")).toHaveLength(5);
+  });
+
+  test("every document is sent exactly once, in order, across the split", () => {
+    const group = [
+      builtRow("a", 4, "x".repeat(400)),
+      builtRow("b", 4, "x".repeat(400)),
+      builtRow("c", 4, "x".repeat(400)),
+    ];
+
+    const requests = splitIngestRequests(group, 2000);
+
+    expect(requests.length).toBeGreaterThan(1);
+    // No document dropped, none duplicated, document order preserved — the
+    // indexer marks a row indexed on the strength of this.
+    expect(ingestedIds(requests)).toEqual([
+      ...["a", "b", "c"].flatMap((id) => [0, 1, 2, 3].map((s) => `${id}:${s}`)),
+    ]);
+    // And every row is accounted for by exactly one request.
+    expect(
+      requests.flatMap(({ entries }) => entries.map(({ row }) => row.id)),
+    ).toEqual(["a", "b", "c"]);
+  });
+
+  test("no request exceeds the budget while rows still fit whole", () => {
+    const group = Array.from({ length: 12 }, (_, index) =>
+      builtRow(`row-${index}`, 5, "x".repeat(200)),
+    );
+    const maxBytes = 4000;
+
+    for (const { ndjson } of splitIngestRequests(group, maxBytes)) {
+      expect(utf8Bytes(ndjson)).toBeLessThanOrEqual(maxBytes);
+    }
+  });
+
+  test("a row is never cut across two requests", () => {
+    const group = [builtRow("a", 20, "x".repeat(100)), builtRow("b", 1, "x")];
+
+    const requests = splitIngestRequests(group, 500);
+
+    for (const { entries, ndjson } of requests) {
+      const documentIds = new Set(
+        ndjson.split("\n").map((line) => {
+          const doc: Record<string, unknown> = JSON.parse(line);
+          return String(doc["document_id"]);
+        }),
+      );
+      // A row split across requests could be marked indexed while half its
+      // passages were still missing from the index.
+      expect([...documentIds].sort()).toEqual(
+        entries.map(({ row }) => row.id).sort(),
+      );
+    }
+  });
+
+  test("a single oversized row is sent whole rather than cut", () => {
+    const group = [builtRow("huge", 40, "x".repeat(500))];
+
+    const requests = splitIngestRequests(group, 100);
+
+    // Keeping the row's mark honest outweighs the budget here; one court
+    // decision bounds the overshoot.
+    expect(requests).toHaveLength(1);
+    expect(requests.at(0)?.ndjson.split("\n")).toHaveLength(40);
+  });
+
+  test("the budget counts UTF-8 bytes, not code units", () => {
+    // Czech/Slovak/Arabic legal text is multi-byte; sizing on `.length` would
+    // under-count the wire body by up to 3x and defeat the bound.
+    const group = [builtRow("cz", 1, "ř".repeat(300))];
+    const [request] = splitIngestRequests(group, 1_000_000);
+    const ndjson = request?.ndjson ?? "";
+
+    expect(utf8Bytes(ndjson)).toBeGreaterThan(ndjson.length);
+  });
+
+  test("an empty group produces no requests", () => {
+    expect(splitIngestRequests([], 1000)).toEqual([]);
+  });
+});
+
+describe("settleBoth", () => {
+  test("a fast failure waits for its sibling before surfacing", async () => {
+    let siblingFinished = false;
+    const sibling = new Promise<string>((resolve) => {
+      setTimeout(() => {
+        siblingFinished = true;
+        resolve("loaded");
+      }, 25);
+    });
+
+    const caught = await settleBoth(
+      Promise.reject(new Error("boom")),
+      sibling,
+    ).catch((error: unknown) => error);
+
+    expect(caught instanceof Error ? caught.message : null).toBe("boom");
+    // The point of the helper: the paired corpus read is finished, so the
+    // caller's next slice cannot start on top of a request still in flight and
+    // drift past the concurrency bound.
+    expect(siblingFinished).toBe(true);
+  });
+
+  test("the first failure in argument order wins", async () => {
+    const caught = await settleBoth(
+      Promise.reject(new Error("text read")),
+      Promise.reject(new Error("ast read")),
+    ).catch((error: unknown) => error);
+
+    expect(caught instanceof Error ? caught.message : null).toBe("text read");
+  });
+
+  test("both values are returned in order when neither fails", async () => {
+    expect(
+      await settleBoth(Promise.resolve("text"), Promise.resolve(null)),
+    ).toEqual(["text", null]);
+  });
+});

--- a/apps/api/src/lib/corpus-index/core.ts
+++ b/apps/api/src/lib/corpus-index/core.ts
@@ -1,4 +1,5 @@
 import { Result } from "better-result";
+import { Buffer } from "node:buffer";
 
 import type { Transaction } from "@/api/db/root";
 import type { ScopedDb } from "@/api/db/safe-db";
@@ -11,6 +12,7 @@ import {
 } from "@/api/lib/legal-search/corpus-index-client";
 import { corpusIndexConfig } from "@/api/lib/legal-search/corpus-index-config";
 import { corpusIndexId } from "@/api/lib/legal-search/index-naming";
+import { LIMITS } from "@/api/lib/limits";
 
 /**
  * Shared corpus-index search-projection core for the corpus document families
@@ -35,6 +37,68 @@ const INDEX_CONCURRENCY = 4;
  */
 export const corpusDocumentDeleteQuery = (entityId: string): string =>
   `document_id:"${entityId}"`;
+
+/** One row and every search document it projects to. */
+type BuiltRow<TRow> = { row: TRow; docs: Record<string, unknown>[] };
+
+/** One ingest request: the rows it covers and the NDJSON body carrying them. */
+export type IngestRequest<TRow> = {
+  entries: BuiltRow<TRow>[];
+  ndjson: string;
+};
+
+/**
+ * Split an index group into byte-bounded ingest requests.
+ *
+ * A batch is sized in rows, but a passage family turns one row into as many
+ * documents as the document has passages, so the serialized body is no longer
+ * bounded by the row count: a batch of long judgments can be two orders of
+ * magnitude larger than the same batch of short ones. The whole body is held
+ * in memory and sent as one request, so the bound has to be bytes.
+ *
+ * Splits only at row boundaries. Ingest appends per document with no
+ * cross-document transaction, so splitting is safe for the engine — but the
+ * caller commits a row's `indexedHash` after its documents land, and a row cut
+ * across two requests could be marked indexed while half its passages are
+ * missing. A single row that exceeds the budget on its own therefore still
+ * goes in one request: sending it whole is the only shape that keeps that mark
+ * honest, and it is bounded by the size of one court decision.
+ */
+export const splitIngestRequests = <TRow>(
+  group: readonly BuiltRow<TRow>[],
+  maxBytes: number,
+): IngestRequest<TRow>[] => {
+  const requests: IngestRequest<TRow>[] = [];
+  let entries: BuiltRow<TRow>[] = [];
+  let lines: string[] = [];
+  let bytes = 0;
+
+  for (const entry of group) {
+    const rowLines = entry.docs.map((doc) => JSON.stringify(doc));
+    // Measured in UTF-8 bytes, not code units: legal text is mostly non-ASCII
+    // outside English, where `.length` under-counts the wire size by up to 3x.
+    const rowBytes = rowLines.reduce(
+      (total, line) => total + Buffer.byteLength(line, "utf-8") + 1,
+      0,
+    );
+    if (entries.length > 0 && bytes + rowBytes > maxBytes) {
+      requests.push({ entries, ndjson: lines.join("\n") });
+      entries = [];
+      lines = [];
+      bytes = 0;
+    }
+    entries.push(entry);
+    for (const line of rowLines) {
+      lines.push(line);
+    }
+    bytes += rowBytes;
+  }
+
+  if (entries.length > 0) {
+    requests.push({ entries, ndjson: lines.join("\n") });
+  }
+  return requests;
+};
 
 /**
  * The row fields the shared core reads directly. Each family's own row type
@@ -196,6 +260,49 @@ export type LoadDocsForBatchOptions<TBrand extends SafeIdType, TRow> = {
   readPayload?: (row: TRow) => Promise<CorpusDocumentPayload>;
 };
 
+/** Failed index-job audit rows for the rows an ingest attempt did not land. */
+const failedIndexJobs = <
+  TBrand extends SafeIdType,
+  TRow extends CorpusIndexRow<TBrand>,
+>(
+  entries: readonly BuiltRow<TRow>[],
+  error: CorpusIndexError,
+): CorpusJobInput<TBrand>[] =>
+  entries.map(({ row }) => ({
+    entityId: row.id,
+    contentHash: row.contentHash,
+    operation: "index",
+    status: "failed",
+    errorMessage: error.message.slice(0, 2048),
+  }));
+
+/**
+ * `Promise.all` for two operations whose side effects must be finished before
+ * the caller moves on. It rejects as soon as one input does, leaving the other
+ * running unobserved; this waits for both, then surfaces the first failure in
+ * argument order. Use it wherever an abandoned in-flight request would escape a
+ * concurrency bound rather than merely be wasted.
+ */
+export const settleBoth = async <TFirst, TSecond>(
+  first: Promise<TFirst>,
+  second: Promise<TSecond>,
+): Promise<[TFirst, TSecond]> => {
+  const [firstOutcome, secondOutcome] = await Promise.allSettled([
+    first,
+    second,
+  ]);
+  // Rethrow the original rejection, tagged error and all: the caller's
+  // isolation path reads its message into the failed index job, and wrapping
+  // it here would bury the cause the operator needs.
+  if (firstOutcome.status === "rejected") {
+    throw firstOutcome.reason;
+  }
+  if (secondOutcome.status === "rejected") {
+    throw secondOutcome.reason;
+  }
+  return [firstOutcome.value, secondOutcome.value];
+};
+
 const loadText = async <TBrand extends SafeIdType>(
   row: CorpusIndexRow<TBrand>,
   fetchFulltext: FetchFulltext<TBrand>,
@@ -274,15 +381,19 @@ export const createCorpusIndexer = <
       (async (row: TRow): Promise<CorpusDocumentPayload> => {
         // Passage families need the block structure the AST carries; document
         // families never touch it, so the second object read is skipped
-        // entirely rather than issued and discarded. Both reads are bounded by
-        // the corpus IO ceiling and fail the row together, so racing them
-        // costs nothing and halves the per-row latency.
-        const [text, ast] = await Promise.all([
+        // entirely rather than issued and discarded. The two reads run
+        // together, but both must settle before either failure surfaces: a
+        // fast rejection that abandoned its sibling would let this row leave
+        // the slice while its other request still holds an S3 connection, so
+        // the next slice would start on top of it and the concurrency bound
+        // this loop exists to enforce would drift upward. Waiting is bounded
+        // because every corpus read carries the corpus IO ceiling.
+        const [text, ast] = await settleBoth(
           loadText(row, fetchFulltext, adapter.readCorpusText),
           adapter.granularity === "passage" && row.astS3Key !== null
             ? adapter.readCorpusAst(row.astS3Key)
-            : null,
-        ]);
+            : Promise.resolve(null),
+        );
         return { text, ast };
       });
     const built: LoadedBatch<TBrand, TRow>["built"] = [];
@@ -472,6 +583,23 @@ export const createCorpusIndexer = <
     const now = new Date();
     let indexed = 0;
     let firstError: CorpusIndexError | null = null;
+    // Failed index-job rows accumulate per index and are written once below,
+    // the same shape recordReadFailures uses: an ingest failure now happens at
+    // two levels (the index could not be ensured, or one request of several was
+    // rejected), and collecting them keeps a single audit write per index
+    // instead of one per failure site.
+    const failedByIndex = new Map<string, CorpusJobInput<TBrand>[]>();
+    const recordFailed = (
+      indexId: string,
+      jobs: readonly CorpusJobInput<TBrand>[],
+    ): void => {
+      const existing = failedByIndex.get(indexId);
+      if (existing) {
+        existing.push(...jobs);
+      } else {
+        failedByIndex.set(indexId, [...jobs]);
+      }
+    };
 
     for (const [indexId, group] of groups) {
       // Ingest appends; it never replaces. Before re-ingesting, delete the
@@ -505,68 +633,81 @@ export const createCorpusIndexer = <
 
       // oxlint-disable-next-line no-await-in-loop -- per-jurisdiction indexes are ensured/ingested sequentially to avoid overwhelming the search backend
       const ensured = await ensureIndex(indexId);
-      const ingest = ensured.isErr()
-        ? ensured
-        : // oxlint-disable-next-line no-await-in-loop -- sequential per-group ingest paces NDJSON pushes to the search backend
-          await getCorpusIndexClient().ingestBatch(
-            indexId,
-            group
-              .flatMap(({ docs }) => docs.map((doc) => JSON.stringify(doc)))
-              .join("\n"),
-          );
-
-      if (ingest.isErr()) {
-        firstError ??= ingest.error;
-        // oxlint-disable-next-line no-await-in-loop -- sequential per-group audit write preserves job ordering
-        await adapter.recordJobs(
-          scopedDb,
-          group.map(({ row }) => ({
-            entityId: row.id,
-            contentHash: row.contentHash,
-            operation: "index" as const,
-            status: "failed" as const,
-            errorMessage: ingest.error.message.slice(0, 2048),
-          })),
-          indexId,
-        );
+      if (ensured.isErr()) {
+        firstError ??= ensured.error;
+        recordFailed(indexId, failedIndexJobs(group, ensured.error));
         continue;
       }
 
-      const casMissed = new Set<SafeId<TBrand>>();
-      // oxlint-disable-next-line no-await-in-loop -- one CAS transaction per group; sequential to keep index writes and audit rows consistent
-      await scopedDb(async (tx) => {
-        // audit: skip — search index maintenance; rebuilds derived state
-        for (const { row } of group) {
-          // Compare-and-set on the selected row state: a concurrent
-          // re-ingest clears indexedHash (possibly leaving it null-to-null
-          // when the row was already pending) and bumps updatedAt, and an
-          // unconditional write would mask that refresh so the stale index
-          // document would never be retried.
-          // oxlint-disable-next-line no-await-in-loop -- sequential CAS updates within the transaction; ordering preserved
-          const marked = await adapter.markIndexed(tx, { row, indexId, now });
-          if (!marked) {
-            casMissed.add(row.id);
+      // One group can exceed a single request's byte budget once rows project
+      // to many documents, so it goes out as a sequence of requests. Each is
+      // committed on its own: a later request failing must not un-commit the
+      // rows an earlier one already landed, because those documents are in the
+      // index and re-ingesting them next cycle would append a second copy that
+      // nothing points at.
+      for (const { entries, ndjson } of splitIngestRequests(
+        group,
+        LIMITS.corpusIndexIngestMaxBytes,
+      )) {
+        // oxlint-disable-next-line no-await-in-loop -- sequential ingest paces NDJSON pushes to the search backend
+        const ingest = await getCorpusIndexClient().ingestBatch(
+          indexId,
+          ndjson,
+        );
+
+        if (ingest.isErr()) {
+          firstError ??= ingest.error;
+          // Only the rows actually attempted are recorded failed; the rest of
+          // the group is left for the next cycle rather than audited as a
+          // failure that never happened.
+          recordFailed(indexId, failedIndexJobs(entries, ingest.error));
+          break;
+        }
+
+        const casMissed = new Set<SafeId<TBrand>>();
+        // oxlint-disable-next-line no-await-in-loop -- one CAS transaction per ingest request; sequential to keep index writes and audit rows consistent
+        await scopedDb(async (tx) => {
+          // audit: skip — search index maintenance; rebuilds derived state
+          for (const { row } of entries) {
+            // Compare-and-set on the selected row state: a concurrent
+            // re-ingest clears indexedHash (possibly leaving it null-to-null
+            // when the row was already pending) and bumps updatedAt, and an
+            // unconditional write would mask that refresh so the stale index
+            // document would never be retried.
+            // oxlint-disable-next-line no-await-in-loop -- sequential CAS updates within the transaction; ordering preserved
+            const marked = await adapter.markIndexed(tx, { row, indexId, now });
+            if (!marked) {
+              casMissed.add(row.id);
+            }
+          }
+          const markedRows = entries
+            .filter(({ row }) => !casMissed.has(row.id))
+            .map(({ row }) => row);
+          if (markedRows.length > 0) {
+            await adapter.insertSucceededJobs(tx, {
+              rows: markedRows,
+              indexId,
+            });
+          }
+        });
+        // A missed CAS means a refresh outpaced this batch after the ingest
+        // appended its documents: the row carries no generation pointer to
+        // them, so delete the unrecorded copies now; the refreshed row is
+        // re-indexed by a later cycle.
+        for (const missedId of casMissed) {
+          // oxlint-disable-next-line no-await-in-loop -- sequential cleanup deletes of the unrecorded copies; matches this file's established sequential-vs-search-backend design (see ensureIndex/ingestBatch above)
+          const removed = await remove(missedId, scopedDb, indexId);
+          if (removed.isErr()) {
+            firstError ??= removed.error;
           }
         }
-        const markedRows = group
-          .filter(({ row }) => !casMissed.has(row.id))
-          .map(({ row }) => row);
-        if (markedRows.length > 0) {
-          await adapter.insertSucceededJobs(tx, { rows: markedRows, indexId });
-        }
-      });
-      // A missed CAS means a refresh outpaced this batch after the ingest
-      // appended its document: the row carries no generation pointer to it,
-      // so delete the unrecorded copy now; the refreshed row is re-indexed
-      // by a later cycle.
-      for (const missedId of casMissed) {
-        // oxlint-disable-next-line no-await-in-loop -- sequential cleanup deletes of the unrecorded copies; matches this file's established sequential-vs-search-backend design (see ensureIndex/ingestBatch above)
-        const removed = await remove(missedId, scopedDb, indexId);
-        if (removed.isErr()) {
-          firstError ??= removed.error;
-        }
+        indexed += entries.length - casMissed.size;
       }
-      indexed += group.length - casMissed.size;
+    }
+
+    for (const [failedIndexId, jobs] of failedByIndex) {
+      // oxlint-disable-next-line no-await-in-loop -- sequential per-index audit writes preserve job ordering
+      await adapter.recordJobs(scopedDb, jobs, failedIndexId);
     }
 
     // Surface a failure so the daemon retries the un-indexed groups.

--- a/apps/api/src/lib/corpus-index/core.ts
+++ b/apps/api/src/lib/corpus-index/core.ts
@@ -260,12 +260,12 @@ export type LoadDocsForBatchOptions<TBrand extends SafeIdType, TRow> = {
   readPayload?: (row: TRow) => Promise<CorpusDocumentPayload>;
 };
 
-/** Failed index-job audit rows for the rows an ingest attempt did not land. */
-const failedIndexJobs = <
-  TBrand extends SafeIdType,
-  TRow extends CorpusIndexRow<TBrand>,
->(
-  entries: readonly BuiltRow<TRow>[],
+/**
+ * Failed index-job audit rows for the rows an ingest attempt did not land.
+ * The brand is inferred from the rows' own ids, so callers never spell it.
+ */
+const failedIndexJobs = <TBrand extends SafeIdType>(
+  entries: readonly BuiltRow<CorpusIndexRow<TBrand>>[],
   error: CorpusIndexError,
 ): CorpusJobInput<TBrand>[] =>
   entries.map(({ row }) => ({
@@ -583,131 +583,134 @@ export const createCorpusIndexer = <
     const now = new Date();
     let indexed = 0;
     let firstError: CorpusIndexError | null = null;
-    // Failed index-job rows accumulate per index and are written once below,
-    // the same shape recordReadFailures uses: an ingest failure now happens at
-    // two levels (the index could not be ensured, or one request of several was
-    // rejected), and collecting them keeps a single audit write per index
-    // instead of one per failure site.
-    const failedByIndex = new Map<string, CorpusJobInput<TBrand>[]>();
-    const recordFailed = (
-      indexId: string,
-      jobs: readonly CorpusJobInput<TBrand>[],
-    ): void => {
-      const existing = failedByIndex.get(indexId);
-      if (existing) {
-        existing.push(...jobs);
-      } else {
-        failedByIndex.set(indexId, [...jobs]);
-      }
-    };
 
     for (const [indexId, group] of groups) {
-      // Ingest appends; it never replaces. Before re-ingesting, delete the
-      // previously indexed copies from wherever they live (the same index for
-      // a content refresh, another jurisdiction index for a corrected
-      // country), or stale copies keep matching old text. `remove` deletes by
-      // `document_id`, so a row whose previous version split into a different
-      // number of passages leaves nothing behind. Same generation only:
-      // generation rebuilds replace whole indexes. Engine delete tasks only
-      // affect splits that already exist, so the copies ingested below are not
-      // at risk.
-      const moved = group.flatMap(({ row }) =>
-        row.indexedGeneration !== null &&
-        row.indexedGeneration.startsWith(`${generation}_`)
-          ? [{ id: row.id, oldIndexId: row.indexedGeneration }]
-          : [],
-      );
-      let staleError: CorpusIndexError | null = null;
-      for (const entry of moved) {
-        // oxlint-disable-next-line no-await-in-loop -- sequential deletes that early-break on the first error
-        const removed = await remove(entry.id, scopedDb, entry.oldIndexId);
-        if (removed.isErr()) {
-          staleError = removed.error;
-          break;
-        }
-      }
-      if (staleError) {
-        firstError ??= staleError;
-        continue;
-      }
-
-      // oxlint-disable-next-line no-await-in-loop -- per-jurisdiction indexes are ensured/ingested sequentially to avoid overwhelming the search backend
-      const ensured = await ensureIndex(indexId);
-      if (ensured.isErr()) {
-        firstError ??= ensured.error;
-        recordFailed(indexId, failedIndexJobs(group, ensured.error));
-        continue;
-      }
-
-      // One group can exceed a single request's byte budget once rows project
-      // to many documents, so it goes out as a sequence of requests. Each is
-      // committed on its own: a later request failing must not un-commit the
-      // rows an earlier one already landed, because those documents are in the
-      // index and re-ingesting them next cycle would append a second copy that
-      // nothing points at.
-      for (const { entries, ndjson } of splitIngestRequests(
-        group,
-        LIMITS.corpusIndexIngestMaxBytes,
-      )) {
-        // oxlint-disable-next-line no-await-in-loop -- sequential ingest paces NDJSON pushes to the search backend
-        const ingest = await getCorpusIndexClient().ingestBatch(
-          indexId,
-          ndjson,
+      // Failed index-job rows for this group, written in the `finally` below.
+      // An ingest failure can now surface at two levels (the index could not
+      // be ensured, or one request of several was rejected), so they are
+      // collected rather than written at each site — but they must never
+      // outlive the group that produced them: buffering across groups meant a
+      // later group throwing (a DB error in a delete, CAS, or audit insert)
+      // skipped the write entirely and the earlier failure left no audit row
+      // at all. One group writes to exactly one index, so this needs no
+      // keying.
+      const groupFailures: CorpusJobInput<TBrand>[] = [];
+      try {
+        // Ingest appends; it never replaces. Before re-ingesting, delete the
+        // previously indexed copies from wherever they live (the same index for
+        // a content refresh, another jurisdiction index for a corrected
+        // country), or stale copies keep matching old text. `remove` deletes by
+        // `document_id`, so a row whose previous version split into a different
+        // number of passages leaves nothing behind. Same generation only:
+        // generation rebuilds replace whole indexes. Engine delete tasks only
+        // affect splits that already exist, so the copies ingested below are not
+        // at risk.
+        const moved = group.flatMap(({ row }) =>
+          row.indexedGeneration !== null &&
+          row.indexedGeneration.startsWith(`${generation}_`)
+            ? [{ id: row.id, oldIndexId: row.indexedGeneration }]
+            : [],
         );
-
-        if (ingest.isErr()) {
-          firstError ??= ingest.error;
-          // Only the rows actually attempted are recorded failed; the rest of
-          // the group is left for the next cycle rather than audited as a
-          // failure that never happened.
-          recordFailed(indexId, failedIndexJobs(entries, ingest.error));
-          break;
+        let staleError: CorpusIndexError | null = null;
+        for (const entry of moved) {
+          // oxlint-disable-next-line no-await-in-loop -- sequential deletes that early-break on the first error
+          const removed = await remove(entry.id, scopedDb, entry.oldIndexId);
+          if (removed.isErr()) {
+            staleError = removed.error;
+            break;
+          }
+        }
+        if (staleError) {
+          firstError ??= staleError;
+          continue;
         }
 
-        const casMissed = new Set<SafeId<TBrand>>();
-        // oxlint-disable-next-line no-await-in-loop -- one CAS transaction per ingest request; sequential to keep index writes and audit rows consistent
-        await scopedDb(async (tx) => {
-          // audit: skip — search index maintenance; rebuilds derived state
-          for (const { row } of entries) {
-            // Compare-and-set on the selected row state: a concurrent
-            // re-ingest clears indexedHash (possibly leaving it null-to-null
-            // when the row was already pending) and bumps updatedAt, and an
-            // unconditional write would mask that refresh so the stale index
-            // document would never be retried.
-            // oxlint-disable-next-line no-await-in-loop -- sequential CAS updates within the transaction; ordering preserved
-            const marked = await adapter.markIndexed(tx, { row, indexId, now });
-            if (!marked) {
-              casMissed.add(row.id);
+        // oxlint-disable-next-line no-await-in-loop -- per-jurisdiction indexes are ensured/ingested sequentially to avoid overwhelming the search backend
+        const ensured = await ensureIndex(indexId);
+        if (ensured.isErr()) {
+          firstError ??= ensured.error;
+          groupFailures.push(...failedIndexJobs(group, ensured.error));
+          continue;
+        }
+
+        // One group can exceed a single request's byte budget once rows project
+        // to many documents, so it goes out as a sequence of requests. Each is
+        // committed on its own: a later request failing must not un-commit the
+        // rows an earlier one already landed, because those documents are in the
+        // index and re-ingesting them next cycle would append a second copy that
+        // nothing points at.
+        for (const { entries, ndjson } of splitIngestRequests(
+          group,
+          LIMITS.corpusIndexIngestMaxBytes,
+        )) {
+          // oxlint-disable-next-line no-await-in-loop -- sequential ingest paces NDJSON pushes to the search backend
+          const ingest = await getCorpusIndexClient().ingestBatch(
+            indexId,
+            ndjson,
+          );
+
+          if (ingest.isErr()) {
+            firstError ??= ingest.error;
+            // Only the rows actually attempted are recorded failed; the rest of
+            // the group is left for the next cycle rather than audited as a
+            // failure that never happened.
+            groupFailures.push(...failedIndexJobs(entries, ingest.error));
+            break;
+          }
+
+          const casMissed = new Set<SafeId<TBrand>>();
+          // oxlint-disable-next-line no-await-in-loop -- one CAS transaction per ingest request; sequential to keep index writes and audit rows consistent
+          await scopedDb(async (tx) => {
+            // audit: skip — search index maintenance; rebuilds derived state
+            for (const { row } of entries) {
+              // Compare-and-set on the selected row state: a concurrent
+              // re-ingest clears indexedHash (possibly leaving it null-to-null
+              // when the row was already pending) and bumps updatedAt, and an
+              // unconditional write would mask that refresh so the stale index
+              // document would never be retried.
+              // oxlint-disable-next-line no-await-in-loop -- sequential CAS updates within the transaction; ordering preserved
+              const marked = await adapter.markIndexed(tx, {
+                row,
+                indexId,
+                now,
+              });
+              if (!marked) {
+                casMissed.add(row.id);
+              }
+            }
+            const markedRows = entries
+              .filter(({ row }) => !casMissed.has(row.id))
+              .map(({ row }) => row);
+            if (markedRows.length > 0) {
+              await adapter.insertSucceededJobs(tx, {
+                rows: markedRows,
+                indexId,
+              });
+            }
+          });
+          // A missed CAS means a refresh outpaced this batch after the ingest
+          // appended its documents: the row carries no generation pointer to
+          // them, so delete the unrecorded copies now; the refreshed row is
+          // re-indexed by a later cycle.
+          for (const missedId of casMissed) {
+            // oxlint-disable-next-line no-await-in-loop -- sequential cleanup deletes of the unrecorded copies; matches this file's established sequential-vs-search-backend design (see ensureIndex/ingestBatch above)
+            const removed = await remove(missedId, scopedDb, indexId);
+            if (removed.isErr()) {
+              firstError ??= removed.error;
             }
           }
-          const markedRows = entries
-            .filter(({ row }) => !casMissed.has(row.id))
-            .map(({ row }) => row);
-          if (markedRows.length > 0) {
-            await adapter.insertSucceededJobs(tx, {
-              rows: markedRows,
-              indexId,
-            });
-          }
-        });
-        // A missed CAS means a refresh outpaced this batch after the ingest
-        // appended its documents: the row carries no generation pointer to
-        // them, so delete the unrecorded copies now; the refreshed row is
-        // re-indexed by a later cycle.
-        for (const missedId of casMissed) {
-          // oxlint-disable-next-line no-await-in-loop -- sequential cleanup deletes of the unrecorded copies; matches this file's established sequential-vs-search-backend design (see ensureIndex/ingestBatch above)
-          const removed = await remove(missedId, scopedDb, indexId);
-          if (removed.isErr()) {
-            firstError ??= removed.error;
-          }
+          indexed += entries.length - casMissed.size;
         }
-        indexed += entries.length - casMissed.size;
+      } finally {
+        // Always lands, including when the code above threw. The audit
+        // trail is how an operator sees which rows the indexer could not
+        // place; a row that is neither indexed nor recorded failed is
+        // invisible.
+        if (groupFailures.length > 0) {
+          // oxlint-disable-next-line no-await-in-loop -- sequential per-group audit write preserves job ordering
+          await adapter.recordJobs(scopedDb, groupFailures, indexId);
+        }
       }
-    }
-
-    for (const [failedIndexId, jobs] of failedByIndex) {
-      // oxlint-disable-next-line no-await-in-loop -- sequential per-index audit writes preserve job ordering
-      await adapter.recordJobs(scopedDb, jobs, failedIndexId);
     }
 
     // Surface a failure so the daemon retries the un-indexed groups.

--- a/apps/api/src/lib/corpus-index/core.ts
+++ b/apps/api/src/lib/corpus-index/core.ts
@@ -28,6 +28,15 @@ import { corpusIndexId } from "@/api/lib/legal-search/index-naming";
 const INDEX_CONCURRENCY = 4;
 
 /**
+ * Delete-task query selecting every search document a row projects to. Keyed
+ * on the stable Postgres id, which every one of the row's documents carries,
+ * so it is exactly as correct for a passage-split row as for a whole one — and
+ * it needs no record of how many documents the previous version emitted.
+ */
+export const corpusDocumentDeleteQuery = (entityId: string): string =>
+  `document_id:"${entityId}"`;
+
+/**
  * The row fields the shared core reads directly. Each family's own row type
  * extends this with its document-shaped columns, which only its
  * {@link CorpusIndexAdapter.buildDoc} touches.
@@ -36,11 +45,51 @@ export type CorpusIndexRow<TBrand extends SafeIdType> = {
   id: SafeId<TBrand>;
   country: string;
   textS3Key: string | null;
+  astS3Key: string | null;
   contentHash: string | null;
   indexedHash: string | null;
   indexedGeneration: string | null;
   updatedAt: Date;
 };
+
+/**
+ * Canonical payload one row contributes to the index. `ast` is loaded only by
+ * passage-granularity families (see {@link CorpusIndexGranularity}) and is
+ * `null` everywhere else, so a family that indexes whole documents never pays
+ * for a second object read.
+ */
+export type CorpusDocumentPayload = {
+  text: string;
+  ast: unknown;
+};
+
+/**
+ * How many search documents one row projects to.
+ *
+ * - `document`: one, over the row's whole text. The original layout.
+ * - `passage`: one per passage of the row's AST, so BM25 scores a paragraph
+ *   rather than a whole judgment and every hit carries a deep-link anchor.
+ *
+ * The families deliberately differ here: case law is long-form argument where
+ * the relevant holding is a paragraph, while a legislation row is already a
+ * single provision or article and gains nothing from being cut further.
+ */
+export const CORPUS_INDEX_GRANULARITIES = ["document", "passage"] as const;
+export type CorpusIndexGranularity =
+  (typeof CORPUS_INDEX_GRANULARITIES)[number];
+
+/**
+ * Granularity-dependent half of the adapter. A union rather than an optional
+ * hook: a passage family cannot compile without the AST read it needs, and a
+ * document family cannot accidentally declare one it never uses.
+ */
+type CorpusIndexPayloadSurface =
+  | { granularity: "document" }
+  | {
+      granularity: "passage";
+      /** Read the canonical AST object for a row's `astS3Key`. */
+      readCorpusAst: (key: string) => Promise<unknown>;
+    };
 
 /** One audit-trail entry for a corpus index-jobs row. */
 export type CorpusJobInput<TBrand extends SafeIdType> = {
@@ -67,13 +116,22 @@ type SelectBatchArgs = { generation: string; limit: number };
 export type CorpusIndexAdapter<
   TBrand extends SafeIdType,
   TRow extends CorpusIndexRow<TBrand>,
-> = {
+> = CorpusIndexPayloadSurface & {
   /** Selects the index field mapping / config version for this family. */
   family: CorpusFamily;
   /** Telemetry step label for isolated read failures. */
   captureStep: string;
-  /** Build the corpus index search document, omitting empty optional fields. */
-  buildDoc: (row: TRow, text: string) => Record<string, unknown>;
+  /**
+   * Build the row's corpus index search documents, omitting empty optional
+   * fields. Returns one document at `document` granularity and one per passage
+   * at `passage` granularity; either way the row stays a single unit for the
+   * commit below, so it carries one `indexedHash`/`indexedGeneration` mark and
+   * one audit row no matter how many documents it emitted.
+   */
+  buildDocs: (
+    row: TRow,
+    payload: CorpusDocumentPayload,
+  ) => Record<string, unknown>[];
   /**
    * Read the canonical corpus text object for a row's `textS3Key`. Supplied
    * by the family adapter (not imported directly) so the shared core stays
@@ -118,7 +176,12 @@ export type CorpusIndexAdapter<
 };
 
 export type LoadedBatch<TBrand extends SafeIdType, TRow> = {
-  docs: { row: TRow; doc: Record<string, unknown> }[];
+  /**
+   * One entry per row, each holding every search document that row projects
+   * to. Keeping the row as the unit (rather than flattening to documents) is
+   * what lets a passage-split row still take exactly one CAS mark.
+   */
+  built: { row: TRow; docs: Record<string, unknown>[] }[];
   readFailures: {
     indexId: string;
     job: CorpusJobInput<TBrand>;
@@ -129,8 +192,8 @@ export type LoadedBatch<TBrand extends SafeIdType, TRow> = {
 export type LoadDocsForBatchOptions<TBrand extends SafeIdType, TRow> = {
   generation: string;
   fetchFulltext: FetchFulltext<TBrand>;
-  /** Override the per-row text load (test seam). */
-  readText?: (row: TRow) => Promise<string>;
+  /** Override the per-row canonical payload load (test seam). */
+  readPayload?: (row: TRow) => Promise<CorpusDocumentPayload>;
 };
 
 const loadText = async <TBrand extends SafeIdType>(
@@ -203,34 +266,46 @@ export const createCorpusIndexer = <
     {
       generation,
       fetchFulltext,
-      readText,
+      readPayload,
     }: LoadDocsForBatchOptions<TBrand, TRow>,
   ): Promise<LoadedBatch<TBrand, TRow>> => {
-    const loadRowText =
-      readText ??
-      (async (row: TRow) =>
-        await loadText(row, fetchFulltext, adapter.readCorpusText));
-    const docs: LoadedBatch<TBrand, TRow>["docs"] = [];
+    const loadRowPayload =
+      readPayload ??
+      (async (row: TRow): Promise<CorpusDocumentPayload> => {
+        // Passage families need the block structure the AST carries; document
+        // families never touch it, so the second object read is skipped
+        // entirely rather than issued and discarded. Both reads are bounded by
+        // the corpus IO ceiling and fail the row together, so racing them
+        // costs nothing and halves the per-row latency.
+        const [text, ast] = await Promise.all([
+          loadText(row, fetchFulltext, adapter.readCorpusText),
+          adapter.granularity === "passage" && row.astS3Key !== null
+            ? adapter.readCorpusAst(row.astS3Key)
+            : null,
+        ]);
+        return { text, ast };
+      });
+    const built: LoadedBatch<TBrand, TRow>["built"] = [];
     const readFailures: LoadedBatch<TBrand, TRow>["readFailures"] = [];
     for (let i = 0; i < rows.length; i += INDEX_CONCURRENCY) {
-      const chunk = rows.slice(i, i + INDEX_CONCURRENCY);
+      const slice = rows.slice(i, i + INDEX_CONCURRENCY);
       // oxlint-disable-next-line no-await-in-loop -- bounded concurrency: drain one INDEX_CONCURRENCY chunk before loading the next so S3 reads stay capped
-      const built = await Promise.all(
-        chunk.map(async (row) => {
+      const loaded = await Promise.all(
+        slice.map(async (row) => {
           try {
             return {
               ok: true as const,
               row,
-              doc: adapter.buildDoc(row, await loadRowText(row)),
+              docs: adapter.buildDocs(row, await loadRowPayload(row)),
             };
           } catch (error) {
             return { ok: false as const, row, error };
           }
         }),
       );
-      for (const entry of built) {
+      for (const entry of loaded) {
         if (entry.ok) {
-          docs.push({ row: entry.row, doc: entry.doc });
+          built.push({ row: entry.row, docs: entry.docs });
           continue;
         }
         readFailures.push({
@@ -249,7 +324,7 @@ export const createCorpusIndexer = <
         });
       }
     }
-    return { docs, readFailures };
+    return { built, readFailures };
   };
 
   /**
@@ -292,6 +367,17 @@ export const createCorpusIndexer = <
   /**
    * Remove a document from a corpus index generation (GDPR/takedown). Uses a
    * delete-task (corpus index's async delete path) and records the operation.
+   *
+   * The delete is scoped by `document_id`, not by the id of an individual
+   * search document, so it removes every search document the row projects to:
+   * one at `document` granularity, all N passages at `passage` granularity.
+   * That is the only mechanism the client exposes that can do this — the
+   * engine appends on ingest and has no primary key to replace by, so a
+   * per-document-id delete would need the indexer to know how many passages
+   * the *previous* version emitted, which it does not (the previous version's
+   * AST is gone once the row's canonical keys move). Scoping the query to the
+   * stable Postgres id keeps erasure and re-index correct without that
+   * bookkeeping.
    */
   const remove = async (
     entityId: SafeId<TBrand>,
@@ -301,7 +387,7 @@ export const createCorpusIndexer = <
   ): Promise<Result<void, CorpusIndexError>> => {
     const result = await getCorpusIndexClient().deleteByQuery(
       indexId,
-      `document_id:"${entityId}"`,
+      corpusDocumentDeleteQuery(entityId),
     );
     await adapter.recordJobs(
       scopedDb,
@@ -360,18 +446,20 @@ export const createCorpusIndexer = <
     // the rest still commit.
     const fetchFulltext: FetchFulltext<TBrand> = async (id) =>
       await adapter.fetchFulltext(scopedDb, id);
-    const { docs, readFailures } = await loadDocsForBatch(rows, {
+    const { built, readFailures } = await loadDocsForBatch(rows, {
       generation,
       fetchFulltext,
     });
     await recordReadFailures(scopedDb, readFailures, generation);
 
-    // Route each doc to its jurisdiction's index (<family>_v1_<country>),
-    // grouping so each index gets one NDJSON ingest. A group that fails to
-    // ensure/ingest is recorded and retried next cycle; other groups still
-    // commit.
-    const groups = new Map<string, typeof docs>();
-    for (const entry of docs) {
+    // Route each row's documents to its jurisdiction's index
+    // (<family>_v1_<country>), grouping so each index gets one NDJSON ingest.
+    // A group that fails to ensure/ingest is recorded and retried next cycle;
+    // other groups still commit. The group's unit stays the row, so counting,
+    // marking, and auditing below are unaffected by how many documents a row
+    // projects to.
+    const groups = new Map<string, typeof built>();
+    for (const entry of built) {
       const indexId = corpusIndexId(generation, entry.row.country);
       const group = groups.get(indexId);
       if (group) {
@@ -387,12 +475,14 @@ export const createCorpusIndexer = <
 
     for (const [indexId, group] of groups) {
       // Ingest appends; it never replaces. Before re-ingesting, delete the
-      // previously indexed copy from wherever it lives (the same index for
+      // previously indexed copies from wherever they live (the same index for
       // a content refresh, another jurisdiction index for a corrected
-      // country), or stale copies keep matching old text. Same generation
-      // only: generation rebuilds replace whole indexes. Engine delete
-      // tasks only affect splits that already exist, so the copy ingested
-      // below is not at risk.
+      // country), or stale copies keep matching old text. `remove` deletes by
+      // `document_id`, so a row whose previous version split into a different
+      // number of passages leaves nothing behind. Same generation only:
+      // generation rebuilds replace whole indexes. Engine delete tasks only
+      // affect splits that already exist, so the copies ingested below are not
+      // at risk.
       const moved = group.flatMap(({ row }) =>
         row.indexedGeneration !== null &&
         row.indexedGeneration.startsWith(`${generation}_`)
@@ -420,7 +510,9 @@ export const createCorpusIndexer = <
         : // oxlint-disable-next-line no-await-in-loop -- sequential per-group ingest paces NDJSON pushes to the search backend
           await getCorpusIndexClient().ingestBatch(
             indexId,
-            group.map(({ doc }) => JSON.stringify(doc)).join("\n"),
+            group
+              .flatMap(({ docs }) => docs.map((doc) => JSON.stringify(doc)))
+              .join("\n"),
           );
 
       if (ingest.isErr()) {

--- a/apps/api/src/lib/legal-search/corpus-index-client.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-client.test.ts
@@ -160,6 +160,25 @@ test("ingest fails when the engine reports rejected documents", async () => {
   }
 });
 
+test("delete-by-query posts one document-scoped delete task", async () => {
+  responseBody = {};
+
+  const result = await getCorpusIndexClient().deleteByQuery(
+    "legal_corpus_v1_cze",
+    'document_id:"dec-1"',
+  );
+
+  expect(result.isOk()).toBe(true);
+  // One task per document, whatever the index layout: a passage-split
+  // document is removed by the same single query as a whole one, so the
+  // indexer never has to know how many documents a row previously emitted.
+  expect(requests).toHaveLength(1);
+  const request = requests.at(0);
+  expect(request?.path).toBe("/api/v1/legal_corpus_v1_cze/delete-tasks");
+  const body: Record<string, unknown> = JSON.parse(request?.body ?? "{}");
+  expect(body["query"]).toBe('document_id:"dec-1"');
+});
+
 test("ingest succeeds when every document is accepted", async () => {
   responseBody = { num_docs_for_processing: 2 };
 

--- a/apps/api/src/lib/legal-search/corpus-index-config.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-config.test.ts
@@ -34,10 +34,28 @@ test("index_id is the generation; citation_authority is a fast f64", () => {
   expect(authority?.fast).toBe(true);
 });
 
-test("default search fields are title + text + heading_path", () => {
+test("default search fields are title + text", () => {
   expect(
     caseLawIndexConfig("case_law_v1").search_settings.default_search_fields,
-  ).toEqual(["title", "text", "heading_path"]);
+  ).toEqual(["title", "text"]);
+});
+
+test("no field repeated across a document's passages is free-text searchable", () => {
+  const config = caseLawIndexConfig("case_law_v2");
+  const defaults = new Set(config.search_settings.default_search_fields);
+
+  // `heading_path` is written to every passage of a section, so a term
+  // matching a boilerplate heading would return the whole section at once and
+  // exhaust the capped scan window. It stays mapped and explicitly targetable.
+  expect(defaults.has("heading_path")).toBe(false);
+  expect(
+    config.doc_mapping.field_mappings.find((f) => f.name === "heading_path")
+      ?.tokenizer,
+  ).toBe("default");
+
+  // Anything else a default search field reaches must be per-passage content
+  // (`text`) or written once per document (`title`).
+  expect([...defaults].sort()).toEqual(["text", "title"]);
 });
 
 test("passage fields are mapped for every family, heading_path searchable", () => {

--- a/apps/api/src/lib/legal-search/corpus-index-config.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-config.test.ts
@@ -34,10 +34,28 @@ test("index_id is the generation; citation_authority is a fast f64", () => {
   expect(authority?.fast).toBe(true);
 });
 
-test("default search fields are title + text", () => {
+test("default search fields are title + text + heading_path", () => {
   expect(
     caseLawIndexConfig("case_law_v1").search_settings.default_search_fields,
-  ).toEqual(["title", "text"]);
+  ).toEqual(["title", "text", "heading_path"]);
+});
+
+test("passage fields are mapped for every family, heading_path searchable", () => {
+  for (const family of ["case_law", "legislation"] as const) {
+    const fields = new Map(
+      corpusIndexConfig(
+        family,
+        `${family}_v2_svk`,
+      ).doc_mapping.field_mappings.map((f) => [f.name, f]),
+    );
+    // A passage hit must be able to name its document, its position, and the
+    // anchor the reader deep-links to.
+    expect(fields.get("chunk_id")?.tokenizer).toBe("raw");
+    expect(fields.get("anchor_id")?.tokenizer).toBe("raw");
+    expect(fields.get("seq")?.type).toBe("u64");
+    // Section context is scored, not just stored.
+    expect(fields.get("heading_path")?.fieldnorms).toBe(true);
+  }
 });
 
 test("the legislation family gets its own fields + status tag, sharing the core", () => {

--- a/apps/api/src/lib/legal-search/corpus-index-config.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-config.ts
@@ -61,6 +61,14 @@ const CORE_FIELDS: CorpusIndexFieldMapping[] = [
   { name: "source", type: "text", tokenizer: "raw", fast: true },
   { name: "language", type: "text", tokenizer: "raw", fast: true },
   { name: "year", type: "u64", fast: true },
+  // Searchable, and therefore fan-out sensitive. Under a passage layout a
+  // document-level field copied onto every passage lets one document answer a
+  // broad query with as many hits as it has passages, crowding every other
+  // document out of the capped scan window. `title` is the only field here a
+  // free-text term can reach (everything else document-level is raw-tokenized
+  // or numeric), so a passage family sets it on the document's opening passage
+  // only — one hit per document, as before. Any future searchable
+  // document-level field has to make the same choice.
   {
     name: "title",
     type: "text",

--- a/apps/api/src/lib/legal-search/corpus-index-config.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-config.ts
@@ -103,10 +103,14 @@ const CORE_FIELDS: CorpusIndexFieldMapping[] = [
   // The AST block anchor the reader deep-links to, so a hit can open the
   // document scrolled to the passage that matched.
   { name: "anchor_id", type: "text", tokenizer: "raw", stored: true },
-  // Heading ancestry of the passage's section. Searchable rather than raw:
-  // a passage in the middle of a long section does not repeat the heading in
-  // its body (that would inflate those terms' document frequency), so this is
-  // where its section context lives.
+  // Heading ancestry of the passage's section. Tokenized so a query can target
+  // it explicitly (`heading_path:...`), but deliberately NOT a default search
+  // field: it repeats on every continuation passage of a section, so a
+  // free-text term matching a boilerplate heading ("Odůvodnění", "Facts")
+  // would match all of them at once. Nothing is lost by leaving it out — a
+  // heading opens the passage carrying its section, so its words are already
+  // in that passage's `text`, and matching there yields one hit per section
+  // instead of one per passage.
   {
     name: "heading_path",
     type: "text",
@@ -160,7 +164,15 @@ export const corpusIndexConfig = (
     store_source: false,
   },
   search_settings: {
-    default_search_fields: ["title", "text", "heading_path"],
+    // The rule under a passage layout: no field that repeats across a
+    // document's passages may be a default search field. One free-text term
+    // hitting such a field lets a single document answer with as many hits as
+    // it has passages and crowd everything else out of the capped scan window.
+    // `text` is the only per-passage field here, and it is per-passage
+    // *content* — each passage matches on its own words, which is the point.
+    // Everything else document-level is raw-tokenized, numeric, or (like
+    // `title`) written to one passage only.
+    default_search_fields: ["title", "text"],
   },
 });
 

--- a/apps/api/src/lib/legal-search/corpus-index-config.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-config.ts
@@ -81,6 +81,32 @@ const CORE_FIELDS: CorpusIndexFieldMapping[] = [
   { name: "citation_count", type: "u64", fast: true },
   { name: "canonical_text_key", type: "text", tokenizer: "raw", stored: true },
   { name: "canonical_ast_key", type: "text", tokenizer: "raw", stored: true },
+  // Passage fields. A passage-granular family emits one document per passage,
+  // all sharing `document_id`; a document-granular family simply never sets
+  // them and, in lenient mode, the index carries them empty. The read path is
+  // written against the union of both layouts (see corpus-index-pagination),
+  // so a generation built either way serves the same API.
+  //
+  // `<document_id>:<seq>`. A deterministic, greppable identity for one
+  // passage; not a primary key — the engine appends and replaces by
+  // delete-by-query on `document_id`.
+  { name: "chunk_id", type: "text", tokenizer: "raw", stored: true },
+  { name: "seq", type: "u64", fast: true, stored: true },
+  // The AST block anchor the reader deep-links to, so a hit can open the
+  // document scrolled to the passage that matched.
+  { name: "anchor_id", type: "text", tokenizer: "raw", stored: true },
+  // Heading ancestry of the passage's section. Searchable rather than raw:
+  // a passage in the middle of a long section does not repeat the heading in
+  // its body (that would inflate those terms' document frequency), so this is
+  // where its section context lives.
+  {
+    name: "heading_path",
+    type: "text",
+    tokenizer: "default",
+    record: "position",
+    fieldnorms: true,
+    stored: true,
+  },
 ];
 
 const FAMILY_FIELDS: Record<CorpusFamily, CorpusIndexFieldMapping[]> = {
@@ -126,7 +152,7 @@ export const corpusIndexConfig = (
     store_source: false,
   },
   search_settings: {
-    default_search_fields: ["title", "text"],
+    default_search_fields: ["title", "text", "heading_path"],
   },
 });
 

--- a/apps/api/src/lib/legal-search/corpus-index-pagination.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-pagination.test.ts
@@ -1,0 +1,158 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import type { CorpusIndexHit } from "@/api/lib/legal-search/corpus-index-client";
+import { readCorpusIndexSearchPage } from "@/api/lib/legal-search/corpus-index-pagination";
+
+/**
+ * Grouping passage hits back into document hits. A passage-granular generation
+ * returns one hit per matching passage, but the API's unit is the document:
+ * the page, the cursor, and the rerank all key on `document_id`. These tests
+ * stub the engine's HTTP response and assert the collapse — which document
+ * wins, which passage supplies its snippet and anchor, and that a
+ * document-granular response still behaves exactly as before.
+ */
+
+const originalFetch = globalThis.fetch;
+let responseBody: unknown;
+
+beforeEach(() => {
+  responseBody = { num_hits: 0, hits: [], snippets: [] };
+  const stub = async (): Promise<Response> =>
+    new Response(JSON.stringify(responseBody), { status: 200 });
+  globalThis.fetch = Object.assign(stub, {
+    preconnect: originalFetch.preconnect,
+  });
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+const readPage = async (limit = 10) =>
+  await readCorpusIndexSearchPage({
+    indexId: "case_law_v2_cze",
+    query: "text:promlčení",
+    limit,
+    parsedCursor: null,
+    snippetFields: ["text"],
+    extractId: (hit: CorpusIndexHit) =>
+      typeof hit["document_id"] === "string" ? hit["document_id"] : null,
+    extractSnippet: (snippet) => {
+      const text = snippet?.["text"];
+      return Array.isArray(text) ? String(text.at(0)) : null;
+    },
+    unseenScoreUpperBound: () => 0,
+    rankCandidates: async (candidates) => ({
+      context: null,
+      ranked: candidates.map((candidate) => ({
+        id: candidate.id,
+        score: candidate.score,
+        lexicalScore: candidate.score,
+        citationAuthority: 0,
+      })),
+    }),
+  });
+
+describe("passage hits group into document hits", () => {
+  beforeEach(() => {
+    // Engine order: doc-b's best passage outscores every doc-a passage.
+    const hits = [
+      { document_id: "doc-b", seq: 7, anchor_id: "b-p7" },
+      { document_id: "doc-a", seq: 2, anchor_id: "a-p2" },
+      { document_id: "doc-a", seq: 9, anchor_id: "a-p9" },
+      { document_id: "doc-b", seq: 1, anchor_id: "b-p1" },
+      { document_id: "doc-a", seq: 4, anchor_id: "a-p4" },
+    ];
+    responseBody = {
+      num_hits: hits.length,
+      hits,
+      snippets: hits.map((hit) => ({
+        text: [`passage ${hit.document_id}:${hit.seq}`],
+      })),
+    };
+  });
+
+  test("a document appears once, ranked by its best passage", async () => {
+    const page = await readPage();
+
+    expect(page.pageRanked.map((hit) => hit.id)).toEqual(["doc-b", "doc-a"]);
+    // doc-a matched three passages but must not occupy three result slots.
+    expect(page.pageRanked).toHaveLength(2);
+  });
+
+  test("the snippet and the anchor come from the best passage, not the last", async () => {
+    const page = await readPage();
+
+    expect(page.snippetById.get("doc-a")).toBe("passage doc-a:2");
+    expect(page.anchorIdById.get("doc-a")).toBe("a-p2");
+    expect(page.snippetById.get("doc-b")).toBe("passage doc-b:7");
+    expect(page.anchorIdById.get("doc-b")).toBe("b-p7");
+  });
+
+  test("matching passages are counted per document", async () => {
+    const page = await readPage();
+
+    expect(page.passageCountById.get("doc-a")).toBe(3);
+    expect(page.passageCountById.get("doc-b")).toBe(2);
+  });
+
+  test("the passage count does not change a document's score", async () => {
+    const page = await readPage();
+
+    // Breadth is reported, never blended in: an emitted hit's score has to
+    // survive the next scan window unchanged or the keyset cursor drifts, and
+    // the count only grows as the scan widens.
+    const [best, second] = page.pageRanked;
+    expect(best?.score).toBeGreaterThan(second?.score ?? 0);
+    expect(best?.id).toBe("doc-b");
+  });
+});
+
+describe("document-granular responses are unaffected", () => {
+  test("one hit per document yields one passage each and no anchors", async () => {
+    const hits = [{ document_id: "doc-a" }, { document_id: "doc-b" }];
+    responseBody = {
+      num_hits: hits.length,
+      hits,
+      snippets: hits.map((hit) => ({ text: [`whole ${hit.document_id}`] })),
+    };
+
+    const page = await readPage();
+
+    expect(page.pageRanked.map((hit) => hit.id)).toEqual(["doc-a", "doc-b"]);
+    expect(page.passageCountById.get("doc-a")).toBe(1);
+    // Nothing to deep-link to when the whole document is the unit.
+    expect(page.anchorIdById.size).toBe(0);
+    expect(page.snippetById.get("doc-a")).toBe("whole doc-a");
+  });
+});
+
+describe("document paging survives the passage fan-out", () => {
+  test("a page holds `limit` documents even when each matched several passages", async () => {
+    const documentIds = Array.from({ length: 8 }, (_, i) => `doc-${i}`);
+    // Interleaved so no document's passages are contiguous: grouping cannot
+    // rely on runs.
+    const hits = [0, 1, 2].flatMap((passage) =>
+      documentIds.map((documentId) => ({
+        document_id: documentId,
+        anchor_id: `${documentId}-p${passage}`,
+      })),
+    );
+    responseBody = {
+      num_hits: hits.length,
+      hits,
+      snippets: hits.map(() => ({ text: ["x"] })),
+    };
+
+    const page = await readPage(3);
+
+    expect(page.pageRanked).toHaveLength(3);
+    expect(new Set(page.pageRanked.map((hit) => hit.id)).size).toBe(3);
+    // Every document kept its first (best) passage's anchor.
+    for (const hit of page.pageRanked) {
+      expect(page.anchorIdById.get(hit.id)).toBe(`${hit.id}-p0`);
+      expect(page.passageCountById.get(hit.id)).toBe(3);
+    }
+    expect(page.hasMore).toBe(true);
+  });
+});

--- a/apps/api/src/lib/legal-search/corpus-index-pagination.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-pagination.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
 import type { CorpusIndexHit } from "@/api/lib/legal-search/corpus-index-client";
 import { readCorpusIndexSearchPage } from "@/api/lib/legal-search/corpus-index-pagination";
+import { LIMITS } from "@/api/lib/limits";
 
 /**
  * Grouping passage hits back into document hits. A passage-granular generation
@@ -157,13 +158,15 @@ describe("document-granular responses are unaffected", () => {
 });
 
 describe("a single document cannot monopolise the scan", () => {
-  test("a passage flood from one document still yields a full page of others", async () => {
-    // The shape a broad title or court-name query used to produce: one long
-    // judgment answering with a hit per passage, ahead of everything else.
-    // Document-level searchable fields now sit on the opening passage only, so
-    // the engine should not emit this — the read path must survive it anyway,
-    // because body text can legitimately match many passages of one decision.
-    const flood = Array.from({ length: 400 }, (_, seq) => ({
+  /**
+   * Two query shapes produce the same hazard, and both are now closed at
+   * indexing time — `title` is written to the opening passage only, and
+   * `heading_path` is not a default search field. The read path still has to
+   * survive the shape, because body text can legitimately match many passages
+   * of one long decision, so it is exercised here for each.
+   */
+  const expectFloodYieldsToOthers = async (floodSize: number) => {
+    const flood = Array.from({ length: floodSize }, (_, seq) => ({
       document_id: "doc-flood",
       anchor_id: `flood-p${seq}`,
     }));
@@ -182,12 +185,28 @@ describe("a single document cannot monopolise the scan", () => {
     ).toHaveLength(1);
     expect(page.pageRanked).toHaveLength(5);
     expect(new Set(page.pageRanked.map((hit) => hit.id)).size).toBe(5);
-    // The scan walked past the flood to reach the other decisions.
-    expect(requestCount).toBeGreaterThan(1);
-    expect(page.passageCountById.get("doc-flood")).toBe(400);
+    // Only a flood that overruns one window proves the scan kept walking to
+    // reach the other decisions; a smaller one is served in a single request.
+    if (floodSize > LIMITS.corpusIndexSearchCandidateLimit) {
+      expect(requestCount).toBeGreaterThan(1);
+    }
+    expect(page.passageCountById.get("doc-flood")).toBe(floodSize);
     for (const hit of page.pageRanked.slice(1)) {
       expect(page.passageCountById.get(hit.id)).toBe(1);
     }
+  };
+
+  test("a court-name query matching a document-level title", async () => {
+    // Every passage of one long judgment carrying the same title: what the
+    // index produced before `title` moved to the opening passage.
+    await expectFloodYieldsToOthers(400);
+  });
+
+  test("a query matching a boilerplate section heading", async () => {
+    // Every continuation passage of one section carrying the same
+    // `heading_path`: what a free-text term reached before the field left
+    // `default_search_fields`.
+    await expectFloodYieldsToOthers(250);
   });
 });
 

--- a/apps/api/src/lib/legal-search/corpus-index-pagination.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-pagination.test.ts
@@ -14,11 +14,40 @@ import { readCorpusIndexSearchPage } from "@/api/lib/legal-search/corpus-index-p
 
 const originalFetch = globalThis.fetch;
 let responseBody: unknown;
+/**
+ * Whole hit list the fake engine holds. When set, the stub honours
+ * `start_offset`/`max_hits` so a scan that needs several windows behaves the
+ * way it would against the real engine; `responseBody` stays available for the
+ * single-window cases.
+ */
+let engineHits: { document_id: string; anchor_id?: string }[] | null;
+let requestCount: number;
 
 beforeEach(() => {
   responseBody = { num_hits: 0, hits: [], snippets: [] };
-  const stub = async (): Promise<Response> =>
-    new Response(JSON.stringify(responseBody), { status: 200 });
+  engineHits = null;
+  requestCount = 0;
+  const stub = async (
+    _input: Parameters<typeof fetch>[0],
+    init?: Parameters<typeof fetch>[1],
+  ): Promise<Response> => {
+    requestCount += 1;
+    if (engineHits === null) {
+      return new Response(JSON.stringify(responseBody), { status: 200 });
+    }
+    const body: Record<string, unknown> =
+      typeof init?.body === "string" ? JSON.parse(init.body) : {};
+    const offset = Number(body["start_offset"] ?? 0);
+    const window = engineHits.slice(offset, offset + Number(body["max_hits"]));
+    return new Response(
+      JSON.stringify({
+        num_hits: engineHits.length,
+        hits: window,
+        snippets: window.map((hit) => ({ text: [`snip ${hit.document_id}`] })),
+      }),
+      { status: 200 },
+    );
+  };
   globalThis.fetch = Object.assign(stub, {
     preconnect: originalFetch.preconnect,
   });
@@ -124,6 +153,41 @@ describe("document-granular responses are unaffected", () => {
     // Nothing to deep-link to when the whole document is the unit.
     expect(page.anchorIdById.size).toBe(0);
     expect(page.snippetById.get("doc-a")).toBe("whole doc-a");
+  });
+});
+
+describe("a single document cannot monopolise the scan", () => {
+  test("a passage flood from one document still yields a full page of others", async () => {
+    // The shape a broad title or court-name query used to produce: one long
+    // judgment answering with a hit per passage, ahead of everything else.
+    // Document-level searchable fields now sit on the opening passage only, so
+    // the engine should not emit this — the read path must survive it anyway,
+    // because body text can legitimately match many passages of one decision.
+    const flood = Array.from({ length: 400 }, (_, seq) => ({
+      document_id: "doc-flood",
+      anchor_id: `flood-p${seq}`,
+    }));
+    const others = Array.from({ length: 40 }, (_, index) => ({
+      document_id: `doc-${index}`,
+      anchor_id: `other-${index}`,
+    }));
+    engineHits = [...flood, ...others];
+
+    const page = await readPage(5);
+
+    // The flooding document takes one slot, not the page.
+    expect(page.pageRanked.at(0)?.id).toBe("doc-flood");
+    expect(
+      page.pageRanked.filter((hit) => hit.id === "doc-flood"),
+    ).toHaveLength(1);
+    expect(page.pageRanked).toHaveLength(5);
+    expect(new Set(page.pageRanked.map((hit) => hit.id)).size).toBe(5);
+    // The scan walked past the flood to reach the other decisions.
+    expect(requestCount).toBeGreaterThan(1);
+    expect(page.passageCountById.get("doc-flood")).toBe(400);
+    for (const hit of page.pageRanked.slice(1)) {
+      expect(page.passageCountById.get(hit.id)).toBe(1);
+    }
   });
 });
 

--- a/apps/api/src/lib/legal-search/corpus-index-pagination.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-pagination.ts
@@ -39,7 +39,39 @@ type CorpusIndexSearchPageResult<TContext> = {
   pageRanked: RankedHit[];
   context: TContext;
   snippetById: Map<string, string>;
+  /**
+   * Deep-link anchor of the best-scoring passage per document. Absent for
+   * documents indexed whole, and for passages the fallback chunker produced
+   * from unstructured text (there is no block to anchor to).
+   */
+  anchorIdById: Map<string, string>;
+  /**
+   * How many passages of a document matched. A breadth signal — one paragraph
+   * on point versus a document that discusses the topic throughout. Reported,
+   * not folded into `score`: the count grows as the scan widens, and a score
+   * that changes between windows would break the keyset cursor, which assumes
+   * an already-emitted hit keeps the score it was emitted with.
+   */
+  passageCountById: Map<string, number>;
   hasMore: boolean;
+};
+
+/**
+ * Passage-layout indexes return several hits per document, so a fixed
+ * chunk-space scan budget would reach proportionally fewer documents than the
+ * same budget did when one document was one hit — and a cursor can only point
+ * at a document the scan can reach again. The budget is therefore scaled by
+ * the passages-per-document ratio the scan actually observes: 1.0 on a
+ * document-layout index (unchanged behavior, no extra requests), rising to at
+ * most this factor on a passage-layout one. The cap is what bounds the extra
+ * engine work; a document whose matching passages exceed it simply consumes
+ * more of the budget than its share.
+ */
+const PASSAGE_OVER_FETCH = 4;
+
+const readAnchorId = (hit: CorpusIndexHit): string | null => {
+  const anchorId = hit["anchor_id"];
+  return typeof anchorId === "string" && anchorId.length > 0 ? anchorId : null;
 };
 
 export const isAfterSearchCursor = (
@@ -86,19 +118,34 @@ export const readCorpusIndexSearchPage = async <TContext>({
 > => {
   const candidates: ScoredCandidate[] = [];
   const snippetById = new Map<string, string>();
-  const seenIds = new Set<string>();
+  const anchorIdById = new Map<string, string>();
+  const passageCountById = new Map<string, number>();
   let ranking: CorpusIndexRanking<TContext> | null = null;
   let windowed: RankedHit[] = [];
   let startOffset = 0;
   let totalHits = Number.POSITIVE_INFINITY;
 
-  while (
-    startOffset < totalHits &&
-    startOffset < LIMITS.corpusIndexSearchScanLimit
-  ) {
+  // Chunk-space scan budget, grown to keep document-space reach constant
+  // across index layouts. Recomputed each round from what the scan has seen so
+  // far, so it costs nothing until an index actually returns several passages
+  // per document.
+  const scanBudget = (): number => {
+    if (passageCountById.size === 0) {
+      return LIMITS.corpusIndexSearchScanLimit;
+    }
+    const perDocument = Math.min(
+      startOffset / passageCountById.size,
+      PASSAGE_OVER_FETCH,
+    );
+    return Math.ceil(
+      LIMITS.corpusIndexSearchScanLimit * Math.max(1, perDocument),
+    );
+  };
+
+  while (startOffset < totalHits && startOffset < scanBudget()) {
     const maxHits = Math.min(
       LIMITS.corpusIndexSearchCandidateLimit,
-      LIMITS.corpusIndexSearchScanLimit - startOffset,
+      scanBudget() - startOffset,
     );
     if (maxHits <= 0) {
       break;
@@ -129,11 +176,21 @@ export const readCorpusIndexSearchPage = async <TContext>({
     totalHits = Math.max(result.value.numHits, startOffset + hits.length);
     for (const [index, hit] of hits.entries()) {
       const id = extractId(hit);
-      if (id === null || seenIds.has(id)) {
+      if (id === null) {
         continue;
       }
 
-      seenIds.add(id);
+      // Hits arrive best-first, so the first hit seen for a document is its
+      // best-scoring passage: it sets the document's rank, its snippet, and
+      // the anchor the result deep-links to. Later passages of the same
+      // document only add to its breadth count.
+      const seen = passageCountById.get(id);
+      if (seen !== undefined) {
+        passageCountById.set(id, seen + 1);
+        continue;
+      }
+      passageCountById.set(id, 1);
+
       candidates.push({
         id,
         score: corpusIndexLexicalScore(totalHits, startOffset + index),
@@ -142,6 +199,10 @@ export const readCorpusIndexSearchPage = async <TContext>({
       const snippet = extractSnippet(result.value.snippets[index]);
       if (snippet !== null) {
         snippetById.set(id, snippet);
+      }
+      const anchorId = readAnchorId(hit);
+      if (anchorId !== null) {
+        anchorIdById.set(id, anchorId);
       }
     }
 
@@ -170,14 +231,15 @@ export const readCorpusIndexSearchPage = async <TContext>({
   // A follow-up request rescans from offset 0 and can only reach deeper
   // candidates while the scan cap is not exhausted; past the cap a
   // cursor could never be satisfied and must not be advertised.
-  const scanCanContinue =
-    startOffset < totalHits && startOffset < LIMITS.corpusIndexSearchScanLimit;
+  const scanCanContinue = startOffset < totalHits && startOffset < scanBudget();
   const hasMore = hasMoreInWindow || (scanCanContinue && pageRanked.length > 0);
 
   return {
     pageRanked,
     context: ranking.context,
     snippetById,
+    anchorIdById,
+    passageCountById,
     hasMore,
   };
 };

--- a/apps/api/src/lib/legal-search/corpus-index-provider.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-provider.ts
@@ -31,6 +31,14 @@ import { encodeCursor, decodeCursor } from "@/api/lib/search/cursor";
  * for split pruning); the API re-joins them to the precomputed
  * citation_authority in Postgres and blends via RRF — corpus index has no
  * in-engine function scoring, so the legal-domain ranking stays here.
+ *
+ * Case-law generations built at passage granularity return one hit per
+ * matching passage. Grouping to documents happens in
+ * `readCorpusIndexSearchPage`, keyed on `document_id`: a document ranks by its
+ * best passage, and that passage supplies the snippet and the deep-link
+ * anchor. Both index layouts flow through unchanged — a document-granular
+ * generation is just the case where every document has exactly one passage —
+ * so the rerank, the cursor, and the Postgres rehydration below are untouched.
  */
 
 const toNullableString = (x: unknown): string | null =>
@@ -171,9 +179,11 @@ const search = async (query: LegalSearchQuery): Promise<LegalSearchResult> => {
   });
 
   const {
+    anchorIdById,
     context: { displayById },
     hasMore,
     pageRanked,
+    passageCountById,
     snippetById,
   } = searchPage;
 
@@ -197,6 +207,8 @@ const search = async (query: LegalSearchQuery): Promise<LegalSearchResult> => {
         decisionType: toNullableString(row.decisionType),
         sourceUrl: toNullableString(row.sourceUrl),
         headline: snippetById.get(hit.id) ?? null,
+        anchorId: anchorIdById.get(hit.id) ?? null,
+        matchingPassages: passageCountById.get(hit.id) ?? 1,
         citationCount: row.citationCount,
         citationAuthority: hit.citationAuthority,
         score: hit.score,

--- a/apps/api/src/lib/legal-search/pg-fts-legal-provider.ts
+++ b/apps/api/src/lib/legal-search/pg-fts-legal-provider.ts
@@ -171,6 +171,10 @@ const search = async (query: LegalSearchQuery): Promise<LegalSearchResult> => {
       typeof row["headline"] === "string" && row["headline"].length > 0
         ? escapeAndHighlight(JSON.stringify(row["headline"]))
         : null,
+    // Postgres FTS scores whole decisions: the headline is cut from the
+    // document, not from an anchored block.
+    anchorId: null,
+    matchingPassages: 1,
     citationCount: Number(row["citation_count"]) || 0,
     citationAuthority: Number(row["citation_authority"]) || 0,
     score: Number(row["score"]) || 0,

--- a/apps/api/src/lib/legal-search/types.ts
+++ b/apps/api/src/lib/legal-search/types.ts
@@ -44,6 +44,17 @@ export type LegalSearchHit = {
   sourceUrl: string | null;
   /** Escaped + <mark>-highlighted snippet HTML. */
   headline: string | null;
+  /**
+   * AST block anchor of the passage the snippet came from, for a deep link
+   * into the reader. Null when the provider scores whole documents, or when
+   * the matching passage came from unstructured text with no block to anchor.
+   */
+  anchorId: string | null;
+  /**
+   * Passages of this document that matched. A breadth signal alongside the
+   * best-passage score; 1 from a document-scoring provider.
+   */
+  matchingPassages: number;
   citationCount: number;
   citationAuthority: number;
   /** Internal blended ranking score; also the cursor sort key. */

--- a/apps/api/src/lib/limits.ts
+++ b/apps/api/src/lib/limits.ts
@@ -251,6 +251,13 @@ export const LIMITS = {
   corpusIndexSearchScanLimit: 10_000,
   // Decisions pushed to corpus index per indexer batch.
   corpusIndexBatchSize: 50,
+  /** Max UTF-8 bytes in one corpus-index NDJSON ingest request. A batch is
+   *  sized in rows, but a passage-granular family turns one row into as many
+   *  documents as it has passages, so the serialized body is not bounded by
+   *  the row count; this bounds the string held in memory and sent as one
+   *  request. Split only at row boundaries, so one very long document can
+   *  exceed it (see splitIngestRequests). */
+  corpusIndexIngestMaxBytes: 8 * 1024 * 1024,
   /** Wall-clock ceiling (ms) for a single corpus object read/write/delete.
    *  Corpus payloads are individual court decisions or statute texts (a few
    *  MB at most), so an operation that outlives this is a stalled socket, not

--- a/apps/api/src/scripts/build-corpus-index.ts
+++ b/apps/api/src/scripts/build-corpus-index.ts
@@ -10,6 +10,11 @@ import { rlsDb } from "@/api/db/root";
  * Idempotent and re-runnable — already-indexed rows are skipped, so a
  * transient failure just means re-run.
  *
+ * A doc mapping is fixed when an index is created, so a layout change (case
+ * law now emits one document per passage) only takes effect in indexes built
+ * fresh: pass a new generation prefix rather than re-running into the current
+ * one, where the passage fields would be dropped on ingest.
+ *
  *   CORPUS_INDEX_ENDPOINT=... CORPUS_STORAGE_MODE=dual-write \
  *     bun run src/scripts/build-corpus-index.ts [generation]
  */


### PR DESCRIPTION
Long decisions dilute document-level BM25: one paragraph on point loses to a short document that mentions the terms loosely. This indexes the case-law corpus at passage granularity instead.

- **Chunker** (`lib/corpus-index/chunking.ts`, pure + property-tested): contiguous `DocumentAst` block windows targeting 250-400 tokens, never splitting inside a block; the section's heading block opens its first passage and every passage carries a searchable `heading_path`; paragraph-split fallback for rows without a usable AST. Concatenating a document's passages reproduces every block's text exactly once.
- **Index layout**: passage documents `<decisionId>:<seq>` with `document_id`, `seq`, `anchor_id`, `heading_path`, and the document-level fields duplicated for filtering. The corpus-index adapter surface gains a `granularity` discriminator: case-law indexes as passages, legislation stays document-level (commented scope decision). Doc mappings are fixed at index creation, so the layout takes effect in freshly created generations; existing indexes are untouched.
- **Serving**: hits group by `document_id` — the best-scoring passage sets the document's rank, snippet, and a new additive `anchorId` on `/v1/case/decisions/search` (deep-links the reader to the matching passage; `null` on the Postgres branch). `matchingPassages` is exposed internally as a breadth signal but not folded into the score, which would break keyset cursor stability. The scan budget adapts to the observed passages-per-document ratio (capped 4x) so document-space reach stays constant across layouts without extra requests on document-layout indexes.
- **Deletion** stays `document_id`-scoped (`deleteByQuery`), so replacing a document removes all its passages regardless of how many the previous version emitted.

Full apps/api suite green; typecheck cost under baseline; no new lint suppressions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Search now indexes and ranks legal documents at passage granularity for more precise matches.
  * Results include deep-link anchoring (anchor id) and a passage match count, with searchable heading path context.
* **Bug Fixes**
  * Improved search pagination and grouping so document ordering/snippets remain stable even when many passages match.
  * More resilient indexing when AST/text payloads are missing, ensuring items remain searchable.
* **Documentation**
  * Clarified that passage-level indexing requires newly built indexes to take effect.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->