### PR TITLE
feat(api): hosted usage provider binding

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -177,6 +177,13 @@ USE_MOCK_AI="true"
 # HOSTED_USAGE_PROVIDER_BASE_URL=""
 # HOSTED_USAGE_WEBHOOK_SECRET=""
 # HOSTED_USAGE_WEBHOOK_SECRET_PREVIOUS=""
+# Concrete provider binding: "neutral" (default) speaks the
+# provider-agnostic contract directly; "polar" translates Polar's checkout,
+# customer-session, and subscription/order webhooks. For Polar, point
+# HOSTED_USAGE_PROVIDER_BASE_URL at https://sandbox-api.polar.sh (or
+# https://api.polar.sh in production) and set the secrets above to your
+# Polar API token / webhook signing secret.
+# HOSTED_USAGE_PROVIDER="neutral"
 
 # --- Redis / Valkey ---------------------------------------------------------
 # Required. Used for cross-instance SSE broadcasts and rate-limit counters.

--- a/apps/api/drizzle/20260727190000_usage_entitlements_last_event_at/migration.sql
+++ b/apps/api/drizzle/20260727190000_usage_entitlements_last_event_at/migration.sql
@@ -1,0 +1,3 @@
+SET lock_timeout = '1s';--> statement-breakpoint
+SET statement_timeout = '5s';--> statement-breakpoint
+ALTER TABLE "usage_entitlements" ADD COLUMN "hosted_last_event_at" timestamp with time zone;

--- a/apps/api/src/db/schema/usage.ts
+++ b/apps/api/src/db/schema/usage.ts
@@ -85,6 +85,18 @@ export const usageEntitlements = p.pgTable(
     hostedAccountRef: p.text("hosted_account_ref"),
     hostedEntitlementExternalId: p.text("hosted_entitlement_external_id"),
     /**
+     * Provider-reported occurrence time of the last applied lifecycle
+     * event. Webhook deliveries can arrive out of order (independent
+     * retry backoff per event); dispatch skips events strictly older
+     * than this so a stale `active` retry cannot resurrect an
+     * entitlement that a newer `revoked` already terminated. Null when
+     * the provider payload carries no timestamp (ordering then remains
+     * delivery-order, as before).
+     */
+    hostedLastEventAt: p.timestamp("hosted_last_event_at", {
+      withTimezone: true,
+    }),
+    /**
      * True when hosted access is scheduled to end but remains
      * usable until `current_period_end`. UI surfaces it as
      * "Ends on <date>" instead of bare "Cancelled". Mirrors the

--- a/apps/api/src/env.ts
+++ b/apps/api/src/env.ts
@@ -341,6 +341,17 @@ const envApi = createEnv({
       v.pipe(v.string(), v.minLength(8)),
     ),
     HOSTED_USAGE_PROVIDER_BASE_URL: v.optional(v.pipe(v.string(), v.url())),
+    /**
+     * Selects how hosted usage provider API calls and webhook events are
+     * shaped. `neutral` (default) speaks the provider-agnostic contract
+     * directly. `polar` translates Polar's native checkout /
+     * customer-session API and `subscription.*` / `order.*` webhook events
+     * to and from that contract (see lib/hosted-usage-provider/polar).
+     */
+    HOSTED_USAGE_PROVIDER: v.optional(
+      v.picklist(["neutral", "polar"]),
+      "neutral",
+    ),
 
     /** Enables pre-flight usage-limit enforcement when true. */
     USAGE_ENFORCEMENT_ENABLED: featureFlagSchema,

--- a/apps/api/src/handlers/hosted-usage-webhook/dispatch.test.ts
+++ b/apps/api/src/handlers/hosted-usage-webhook/dispatch.test.ts
@@ -700,3 +700,97 @@ describe("dispatch — handleHostedAllocation", () => {
     });
   });
 });
+
+describe("dispatch — out-of-order provider events", () => {
+  test("a stale retry cannot resurrect a newer revocation", async () => {
+    await withRolledBackTx(async (tx) => {
+      const fx = await setupFixture(tx);
+
+      const first = await handleHostedEntitlementUpsert({
+        tx,
+        eventId: "evt_active_t1",
+        payload: buildEntitlementPayload(fx, {
+          occurred_at: "2026-07-01T10:00:00.000Z",
+        }),
+      });
+      expect(first.kind).toBe("applied");
+
+      const revoked = await handleUsageEntitlementStatusChange({
+        tx,
+        eventId: "evt_revoked_t3",
+        eventKind: "revoked",
+        payload: buildEntitlementPayload(fx, {
+          occurred_at: "2026-07-03T10:00:00.000Z",
+        }),
+      });
+      expect(revoked.kind).toBe("applied");
+
+      const stale = await handleHostedEntitlementUpsert({
+        tx,
+        eventId: "evt_update_t2_retry",
+        payload: buildEntitlementPayload(fx, {
+          occurred_at: "2026-07-02T10:00:00.000Z",
+        }),
+      });
+      expect(stale.kind).toBe("ignored");
+
+      const rows = await tx
+        .select({ status: usageEntitlements.status })
+        .from(usageEntitlements)
+        .where(eq(usageEntitlements.organizationId, fx.organizationId));
+      expect(rows.at(0)?.status).toBe("cancelled");
+    });
+  });
+
+  test("a stale revocation retry does not regress a newer state", async () => {
+    await withRolledBackTx(async (tx) => {
+      const fx = await setupFixture(tx);
+
+      const first = await handleHostedEntitlementUpsert({
+        tx,
+        eventId: "evt_active_t2",
+        payload: buildEntitlementPayload(fx, {
+          occurred_at: "2026-07-02T10:00:00.000Z",
+        }),
+      });
+      expect(first.kind).toBe("applied");
+
+      const staleRevoke = await handleUsageEntitlementStatusChange({
+        tx,
+        eventId: "evt_revoked_t1_retry",
+        eventKind: "revoked",
+        payload: buildEntitlementPayload(fx, {
+          occurred_at: "2026-07-01T10:00:00.000Z",
+        }),
+      });
+      expect(staleRevoke.kind).toBe("ignored");
+
+      const rows = await tx
+        .select({ status: usageEntitlements.status })
+        .from(usageEntitlements)
+        .where(eq(usageEntitlements.organizationId, fx.organizationId));
+      expect(rows.at(0)?.status).toBe("active");
+    });
+  });
+
+  test("events without timestamps keep delivery-order semantics", async () => {
+    await withRolledBackTx(async (tx) => {
+      const fx = await setupFixture(tx);
+
+      const first = await handleHostedEntitlementUpsert({
+        tx,
+        eventId: "evt_no_ts_1",
+        payload: buildEntitlementPayload(fx),
+      });
+      expect(first.kind).toBe("applied");
+
+      const second = await handleUsageEntitlementStatusChange({
+        tx,
+        eventId: "evt_no_ts_2",
+        eventKind: "revoked",
+        payload: buildEntitlementPayload(fx),
+      });
+      expect(second.kind).toBe("applied");
+    });
+  });
+});

--- a/apps/api/src/handlers/hosted-usage-webhook/dispatch.ts
+++ b/apps/api/src/handlers/hosted-usage-webhook/dispatch.ts
@@ -68,7 +68,9 @@ type ExistingEntitlement = {
  * The neutral schema already validates ISO shape; the NaN check is a
  * boundary guard only.
  */
-const parseOccurredAt = (payload: { occurred_at?: string }): Date | null => {
+const parseOccurredAt = (payload: {
+  occurred_at?: string | undefined;
+}): Date | null => {
   if (payload.occurred_at === undefined) {
     return null;
   }

--- a/apps/api/src/handlers/hosted-usage-webhook/dispatch.ts
+++ b/apps/api/src/handlers/hosted-usage-webhook/dispatch.ts
@@ -60,7 +60,47 @@ type ExistingEntitlement = {
   organizationId: SafeId<"organization">;
   source: "hosted" | "manual";
   usagePolicyId: SafeId<"usagePolicy">;
+  hostedLastEventAt: Date | null;
 };
+
+/**
+ * Provider-reported occurrence time, or null when absent/unparseable.
+ * The neutral schema already validates ISO shape; the NaN check is a
+ * boundary guard only.
+ */
+const parseOccurredAt = (payload: { occurred_at?: string }): Date | null => {
+  if (payload.occurred_at === undefined) {
+    return null;
+  }
+  const parsed = new Date(payload.occurred_at);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+};
+
+/**
+ * A delivery is stale when it is strictly older than the last applied
+ * event. Retries invert ordering (each event backs off independently),
+ * and applying an old `active` after a newer `revoked` would resurrect
+ * a terminated entitlement. Equal or missing timestamps apply as
+ * before: idempotent updates are harmless and providers without the
+ * field keep delivery-order semantics.
+ */
+const isStaleProviderEvent = (
+  existing: ExistingEntitlement,
+  occurredAt: Date | null,
+): boolean =>
+  occurredAt !== null &&
+  existing.hostedLastEventAt !== null &&
+  occurredAt < existing.hostedLastEventAt;
+
+const lastEventPatch = (
+  existing: ExistingEntitlement,
+  occurredAt: Date | null,
+): { hostedLastEventAt?: Date } =>
+  occurredAt !== null &&
+  (existing.hostedLastEventAt === null ||
+    occurredAt > existing.hostedLastEventAt)
+    ? { hostedLastEventAt: occurredAt }
+    : {};
 
 const findEntitlementByHostedExternalId = async (
   tx: Transaction,
@@ -72,6 +112,7 @@ const findEntitlementByHostedExternalId = async (
       organizationId: usageEntitlements.organizationId,
       source: usageEntitlements.source,
       usagePolicyId: usageEntitlements.usagePolicyId,
+      hostedLastEventAt: usageEntitlements.hostedLastEventAt,
     })
     .from(usageEntitlements)
     .where(
@@ -115,6 +156,7 @@ const findEntitlementByHostedAccountRef = async (
       organizationId: usageEntitlements.organizationId,
       source: usageEntitlements.source,
       usagePolicyId: usageEntitlements.usagePolicyId,
+      hostedLastEventAt: usageEntitlements.hostedLastEventAt,
     })
     .from(usageEntitlements)
     .where(eq(usageEntitlements.hostedAccountRef, hostedAccountRef))
@@ -176,6 +218,7 @@ export const handleHostedEntitlementUpsert = async ({
   }
 
   const seats = payload.quantity ?? 1;
+  const occurredAt = parseOccurredAt(payload);
   const existingByProvider = await findEntitlementByHostedExternalId(
     tx,
     payload.id,
@@ -195,6 +238,12 @@ export const handleHostedEntitlementUpsert = async ({
       return {
         kind: "ignored",
         reason: "matching entitlement is manually managed",
+      };
+    }
+    if (isStaleProviderEvent(existingByProvider, occurredAt)) {
+      return {
+        kind: "ignored",
+        reason: "stale provider event (older than last applied event)",
       };
     }
     if (
@@ -236,6 +285,7 @@ export const handleHostedEntitlementUpsert = async ({
         hostedAccountRef: payload.account_ref,
         hostedEntitlementExternalId: payload.id,
         cancelAtPeriodEnd: payload.cancel_at_period_end ?? false,
+        ...lastEventPatch(existingByProvider, occurredAt),
       })
       .where(eq(usageEntitlements.id, existingByProvider.id));
     await recordWebhookAuditEvent({
@@ -271,6 +321,12 @@ export const handleHostedEntitlementUpsert = async ({
           reason: "metadata organization_id mismatches local account mapping",
         };
       }
+      if (isStaleProviderEvent(existingByAccountRef, occurredAt)) {
+        return {
+          kind: "ignored",
+          reason: "stale provider event (older than last applied event)",
+        };
+      }
       ownerOrganizationId = existingByAccountRef.organizationId;
       await tx
         .update(usageEntitlements)
@@ -283,6 +339,7 @@ export const handleHostedEntitlementUpsert = async ({
           hostedAccountRef: payload.account_ref,
           hostedEntitlementExternalId: payload.id,
           cancelAtPeriodEnd: payload.cancel_at_period_end ?? false,
+          ...lastEventPatch(existingByAccountRef, occurredAt),
         })
         .where(eq(usageEntitlements.id, existingByAccountRef.id));
       await recordWebhookAuditEvent({
@@ -320,6 +377,7 @@ export const handleHostedEntitlementUpsert = async ({
           hostedAccountRef: payload.account_ref,
           hostedEntitlementExternalId: payload.id,
           cancelAtPeriodEnd: payload.cancel_at_period_end ?? false,
+          hostedLastEventAt: occurredAt,
           source: "hosted",
         })
         .returning({ id: usageEntitlements.id });
@@ -409,6 +467,13 @@ export const handleUsageEntitlementStatusChange = async ({
       reason: "entitlement is manually managed",
     };
   }
+  const occurredAt = parseOccurredAt(payload);
+  if (isStaleProviderEvent(existing, occurredAt)) {
+    return {
+      kind: "ignored",
+      reason: "stale provider event (older than last applied event)",
+    };
+  }
   const update =
     eventKind === "canceled"
       ? {
@@ -418,7 +483,7 @@ export const handleUsageEntitlementStatusChange = async ({
       : { status: "cancelled" as const, cancelAtPeriodEnd: false };
   await tx
     .update(usageEntitlements)
-    .set(update)
+    .set({ ...update, ...lastEventPatch(existing, occurredAt) })
     .where(eq(usageEntitlements.id, existing.id));
   await recordWebhookAuditEvent({
     tx,

--- a/apps/api/src/handlers/hosted-usage-webhook/event-schemas.ts
+++ b/apps/api/src/handlers/hosted-usage-webhook/event-schemas.ts
@@ -74,6 +74,13 @@ const providerEntitlementSchema = v.object({
   cancel_at_period_end: v.optional(v.boolean()),
   metadata: v.optional(providerMetadataSchema),
   quantity: v.optional(positiveIntSchema),
+  /**
+   * Provider-reported occurrence time of this lifecycle event
+   * (ISO 8601). Optional: providers without it keep delivery-order
+   * semantics. When present, dispatch uses it to reject stale
+   * out-of-order retries (see `usage_entitlements.hosted_last_event_at`).
+   */
+  occurred_at: v.optional(v.pipe(v.string(), v.isoTimestamp())),
 });
 
 const providerAllocationSchema = v.object({

--- a/apps/api/src/handlers/hosted-usage-webhook/receive.ts
+++ b/apps/api/src/handlers/hosted-usage-webhook/receive.ts
@@ -37,10 +37,13 @@ import type { DispatchOutcome } from "@/api/handlers/hosted-usage-webhook/dispat
 import {
   hostedUsageUnknownEventEnvelopeSchema,
   hostedUsageWebhookEventSchema,
-  isHostedUsageHandledEventType,
 } from "@/api/handlers/hosted-usage-webhook/event-schemas";
 import { captureError } from "@/api/lib/analytics/capture";
-import { getWebhookSecret } from "@/api/lib/hosted-usage-provider/config";
+import {
+  getHostedUsageProviderKind,
+  getWebhookSecret,
+} from "@/api/lib/hosted-usage-provider/config";
+import { normalizeProviderEvent } from "@/api/lib/hosted-usage-provider/provider-event-normalizer";
 import { verifyWebhookSignature } from "@/api/lib/hosted-usage-provider/verify-signature";
 import {
   insertWebhookEventInTx,
@@ -124,13 +127,27 @@ export const receiveHostedUsageWebhook = async (
   }
   const payload = parsedJson;
 
-  // Validate the strict schema for the events we actually handle
-  // BEFORE opening a transaction. Unknown event types are recorded
-  // in their own tiny transaction (insert with result="ignored")
-  // and acknowledged so the provider stops retrying.
-  const strict = v.safeParse(hostedUsageWebhookEventSchema, parsedJson);
+  // Translate the (already authenticated) body into the neutral event
+  // contract before validating it. For the neutral provider this is a
+  // pass-through; the Polar adapter renames `subscription.*` / `order.*`
+  // events into `entitlement.*` / `allocation.*`. We record the native
+  // event type and original payload for audit, and dispatch on the
+  // normalised event.
+  //
+  // Validation happens BEFORE opening a transaction. Unknown event types
+  // are recorded in their own tiny transaction (insert with
+  // result="ignored") and acknowledged so the provider stops retrying.
+  const normalized = normalizeProviderEvent(
+    parsedJson,
+    envelope.type,
+    getHostedUsageProviderKind(),
+  );
+  const strict = v.safeParse(
+    hostedUsageWebhookEventSchema,
+    normalized.candidate,
+  );
   if (!strict.success) {
-    if (isHostedUsageHandledEventType(envelope.type)) {
+    if (normalized.handled) {
       return respond(400, "Malformed payload for handled event type");
     }
     await persistUnknownEventType({

--- a/apps/api/src/handlers/usage/create-hosted-setup.ts
+++ b/apps/api/src/handlers/usage/create-hosted-setup.ts
@@ -119,9 +119,13 @@ const createHostedSetup = createSafeRootHandler(
     // client-supplied success URL would turn the trusted hosted-setup
     // flow into an open redirect toward an arbitrary origin.
     const usageSettingsUrl = `${baseUrl}/settings/organization/usage`;
-    const externalAccountRef = dbResult.accountRef
-      ? undefined
-      : hostedExternalAccountRef(session.activeOrganizationId);
+    // Always send the org-derived external customer ref. Polar's checkout
+    // API links the resulting customer by external id, so it is required
+    // there; the neutral provider still receives the existing account_ref
+    // alongside it and can prefer that when present.
+    const externalAccountRef = hostedExternalAccountRef(
+      session.activeOrganizationId,
+    );
 
     const sessionResult = await createHostedSetupSession({
       credentials,

--- a/apps/api/src/lib/hosted-usage-provider/client.test.ts
+++ b/apps/api/src/lib/hosted-usage-provider/client.test.ts
@@ -4,6 +4,8 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import {
   createHostedManagementSession,
   createHostedSetupSession,
+  createPolarManagementSession,
+  createPolarSetupSession,
   HostedUsageProviderApiError,
 } from "@/api/lib/hosted-usage-provider/client";
 
@@ -246,5 +248,100 @@ describe("createHostedManagementSession", () => {
     if (Result.isError(result)) {
       expect(result.error.status).toBe(404);
     }
+  });
+});
+
+describe("createPolarSetupSession", () => {
+  test("POSTs to /v1/checkouts/ with products array and external_customer_id", async () => {
+    let calledUrl: string | URL | Request | undefined;
+    let calledInit: RequestInit | undefined;
+    installFetch(async (url, init) => {
+      calledUrl = url;
+      calledInit = init;
+      return okResponse({
+        id: "checkout_abc",
+        url: "https://buy.polar.test/abc",
+        client_secret: "cs_x",
+      });
+    });
+
+    const result = await createPolarSetupSession({
+      credentials,
+      policyRef: "prod_pro",
+      externalAccountRef: "stella_org_org_test_001",
+      successUrl: "https://app.stella.test/settings",
+      returnUrl: "https://app.stella.test/settings/organization/usage",
+      metadata: {
+        organization_id: "org_test_001",
+        usage_policy_id: "plan_test_001",
+      },
+    });
+
+    expect(Result.isOk(result)).toBe(true);
+    if (Result.isOk(result)) {
+      expect(result.value.id).toBe("checkout_abc");
+      expect(result.value.url).toBe("https://buy.polar.test/abc");
+    }
+    expect(urlToString(calledUrl)).toBe(
+      "https://sandbox.provider.test/v1/checkouts/",
+    );
+    const body = readJsonRequestBody(calledInit?.body);
+    expect(body["products"]).toEqual(["prod_pro"]);
+    expect(body["external_customer_id"]).toBe("stella_org_org_test_001");
+    expect(body["success_url"]).toBe("https://app.stella.test/settings");
+    // The Polar request body must not leak the neutral contract's field names.
+    expect("policy_refs" in body).toBe(false);
+    expect("account_ref" in body).toBe(false);
+  });
+
+  test("surfaces non-2xx as HostedUsageProviderApiError", async () => {
+    installFetch(async () => new Response("unprocessable", { status: 422 }));
+
+    const result = await createPolarSetupSession({
+      credentials,
+      policyRef: "prod_pro",
+      externalAccountRef: "stella_org_x",
+      successUrl: "https://app.stella.test/settings",
+      metadata: { organization_id: "org", usage_policy_id: "pol" },
+    });
+
+    expect(Result.isError(result)).toBe(true);
+    if (Result.isError(result)) {
+      expect(result.error.status).toBe(422);
+    }
+  });
+});
+
+describe("createPolarManagementSession", () => {
+  test("POSTs customer_id to /v1/customer-sessions/ and reads customer_portal_url", async () => {
+    let calledUrl: string | URL | Request | undefined;
+    let calledInit: RequestInit | undefined;
+    installFetch(async (url, init) => {
+      calledUrl = url;
+      calledInit = init;
+      return okResponse({
+        token: "tok_x",
+        customer_portal_url: "https://portal.polar.test/cus_abc",
+      });
+    });
+
+    const result = await createPolarManagementSession({
+      credentials,
+      accountRef: "cus_abc",
+      returnUrl: "https://app.stella.test/settings/organization/usage",
+    });
+
+    expect(Result.isOk(result)).toBe(true);
+    if (Result.isOk(result)) {
+      expect(result.value.url).toBe("https://portal.polar.test/cus_abc");
+    }
+    expect(urlToString(calledUrl)).toBe(
+      "https://sandbox.provider.test/v1/customer-sessions/",
+    );
+    const body = readJsonRequestBody(calledInit?.body);
+    expect(body["customer_id"]).toBe("cus_abc");
+    expect(body["return_url"]).toBe(
+      "https://app.stella.test/settings/organization/usage",
+    );
   });
 });

--- a/apps/api/src/lib/hosted-usage-provider/client.ts
+++ b/apps/api/src/lib/hosted-usage-provider/client.ts
@@ -179,12 +179,12 @@ export const createPolarSetupSession = async ({
     },
   });
 
-export const createHostedSetupSession = (
+export const createHostedSetupSession = async (
   input: CreateHostedSetupInput,
 ): Promise<Result<CreateHostedSetupResult, HostedUsageProviderApiError>> =>
   getHostedUsageProviderKind() === "polar"
-    ? createPolarSetupSession(input)
-    : createNeutralSetupSession(input);
+    ? await createPolarSetupSession(input)
+    : await createNeutralSetupSession(input);
 
 type CreateHostedManagementInput = {
   credentials: HostedUsageProviderApiCredentials;
@@ -302,11 +302,11 @@ export const createPolarManagementSession = async ({
     },
   });
 
-export const createHostedManagementSession = (
+export const createHostedManagementSession = async (
   input: CreateHostedManagementInput,
 ): Promise<
   Result<CreateHostedManagementResult, HostedUsageProviderApiError>
 > =>
   getHostedUsageProviderKind() === "polar"
-    ? createPolarManagementSession(input)
-    : createNeutralManagementSession(input);
+    ? await createPolarManagementSession(input)
+    : await createNeutralManagementSession(input);

--- a/apps/api/src/lib/hosted-usage-provider/client.ts
+++ b/apps/api/src/lib/hosted-usage-provider/client.ts
@@ -3,7 +3,10 @@
 import { Result, TaggedError } from "better-result";
 
 import { fetchWithTimeout } from "@/api/lib/fetch";
-import type { HostedUsageProviderApiCredentials } from "@/api/lib/hosted-usage-provider/config";
+import {
+  getHostedUsageProviderKind,
+  type HostedUsageProviderApiCredentials,
+} from "@/api/lib/hosted-usage-provider/config";
 
 const REQUEST_TIMEOUT_MS = 10_000;
 
@@ -66,7 +69,7 @@ const readStringField = (
   });
 };
 
-export const createHostedSetupSession = async ({
+const createNeutralSetupSession = async ({
   credentials,
   policyRef,
   accountRef,
@@ -121,6 +124,68 @@ export const createHostedSetupSession = async ({
     },
   });
 
+export const createPolarSetupSession = async ({
+  credentials,
+  policyRef,
+  externalAccountRef,
+  returnUrl,
+  successUrl,
+  metadata,
+}: CreateHostedSetupInput): Promise<
+  Result<CreateHostedSetupResult, HostedUsageProviderApiError>
+> =>
+  await Result.tryPromise({
+    try: async () => {
+      const response = await fetchWithTimeout(
+        `${credentials.baseUrl}/v1/checkouts/`,
+        {
+          method: "POST",
+          headers: {
+            authorization: `Bearer ${credentials.apiKey}`,
+            "content-type": "application/json",
+          },
+          body: JSON.stringify({
+            products: [policyRef],
+            // Polar links the resulting customer by external id, so the
+            // org-scoped ref keeps repeat checkouts attached to one customer.
+            external_customer_id: externalAccountRef,
+            success_url: successUrl,
+            return_url: returnUrl,
+            metadata,
+          }),
+          timeoutMs: REQUEST_TIMEOUT_MS,
+        },
+      );
+      if (!response.ok) {
+        throw new HostedUsageProviderApiError({
+          message: `Hosted setup session returned ${response.status}`,
+          status: response.status,
+        });
+      }
+      const json = await readJsonRecord(response, "Hosted setup session");
+      return {
+        id: readStringField(json, "id", "Hosted setup session"),
+        url: readStringField(json, "url", "Hosted setup session"),
+      };
+    },
+    catch: (cause) => {
+      if (cause instanceof HostedUsageProviderApiError) {
+        return cause;
+      }
+      return new HostedUsageProviderApiError({
+        message: "Hosted setup session failed",
+        cause,
+      });
+    },
+  });
+
+export const createHostedSetupSession = (
+  input: CreateHostedSetupInput,
+): Promise<Result<CreateHostedSetupResult, HostedUsageProviderApiError>> =>
+  getHostedUsageProviderKind() === "polar"
+    ? createPolarSetupSession(input)
+    : createNeutralSetupSession(input);
+
 type CreateHostedManagementInput = {
   credentials: HostedUsageProviderApiCredentials;
   accountRef: string;
@@ -131,7 +196,7 @@ type CreateHostedManagementResult = {
   url: string;
 };
 
-export const createHostedManagementSession = async ({
+const createNeutralManagementSession = async ({
   credentials,
   accountRef,
   returnUrl,
@@ -183,3 +248,65 @@ export const createHostedManagementSession = async ({
       });
     },
   });
+
+export const createPolarManagementSession = async ({
+  credentials,
+  accountRef,
+  returnUrl,
+}: CreateHostedManagementInput): Promise<
+  Result<CreateHostedManagementResult, HostedUsageProviderApiError>
+> =>
+  await Result.tryPromise({
+    try: async () => {
+      const response = await fetchWithTimeout(
+        `${credentials.baseUrl}/v1/customer-sessions/`,
+        {
+          method: "POST",
+          headers: {
+            authorization: `Bearer ${credentials.apiKey}`,
+            "content-type": "application/json",
+          },
+          body: JSON.stringify({
+            customer_id: accountRef,
+            return_url: returnUrl,
+          }),
+          timeoutMs: REQUEST_TIMEOUT_MS,
+        },
+      );
+      if (!response.ok) {
+        throw new HostedUsageProviderApiError({
+          message: `Hosted usage management session returned ${response.status}`,
+          status: response.status,
+        });
+      }
+      const json = await readJsonRecord(
+        response,
+        "Hosted usage management session",
+      );
+      return {
+        url: readStringField(
+          json,
+          "customer_portal_url",
+          "Hosted usage management session",
+        ),
+      };
+    },
+    catch: (cause) => {
+      if (cause instanceof HostedUsageProviderApiError) {
+        return cause;
+      }
+      return new HostedUsageProviderApiError({
+        message: "Hosted usage management session failed",
+        cause,
+      });
+    },
+  });
+
+export const createHostedManagementSession = (
+  input: CreateHostedManagementInput,
+): Promise<
+  Result<CreateHostedManagementResult, HostedUsageProviderApiError>
+> =>
+  getHostedUsageProviderKind() === "polar"
+    ? createPolarManagementSession(input)
+    : createNeutralManagementSession(input);

--- a/apps/api/src/lib/hosted-usage-provider/config.ts
+++ b/apps/api/src/lib/hosted-usage-provider/config.ts
@@ -42,3 +42,13 @@ export const getApiCredentials =
       baseUrl: env.HOSTED_USAGE_PROVIDER_BASE_URL,
     };
   };
+
+export type HostedUsageProviderKind = "neutral" | "polar";
+
+/**
+ * Which concrete provider binding shapes outbound API calls and inbound
+ * webhook events. `neutral` keeps the provider-agnostic contract; `polar`
+ * routes through the Polar adapter in `lib/hosted-usage-provider/polar`.
+ */
+export const getHostedUsageProviderKind = (): HostedUsageProviderKind =>
+  env.HOSTED_USAGE_PROVIDER;

--- a/apps/api/src/lib/hosted-usage-provider/polar/events.test.ts
+++ b/apps/api/src/lib/hosted-usage-provider/polar/events.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, test } from "bun:test";
+import * as v from "valibot";
+
+import { hostedUsageWebhookEventSchema } from "@/api/handlers/hosted-usage-webhook/event-schemas";
+import { normalizePolarEvent } from "@/api/lib/hosted-usage-provider/polar/events";
+import { normalizeProviderEvent } from "@/api/lib/hosted-usage-provider/provider-event-normalizer";
+
+const polarSubscription = (overrides: Record<string, unknown> = {}) => ({
+  id: "sub_123",
+  status: "active",
+  customer_id: "cus_abc",
+  product_id: "prod_pro",
+  current_period_start: "2026-06-01T00:00:00Z",
+  current_period_end: "2026-07-01T00:00:00Z",
+  cancel_at_period_end: false,
+  seats: 3,
+  metadata: {
+    organization_id: "org_1",
+    usage_policy_id: "pol_1",
+    seat_user_id: "user_1",
+  },
+  ...overrides,
+});
+
+const polarOrder = (overrides: Record<string, unknown> = {}) => ({
+  id: "ord_1",
+  status: "paid",
+  paid: true,
+  billing_reason: "purchase",
+  net_amount: 5000,
+  currency: "usd",
+  customer_id: "cus_abc",
+  product_id: "prod_pack",
+  subscription_id: null,
+  metadata: { organization_id: "org_1", usage_policy_id: "pol_pack" },
+  ...overrides,
+});
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null;
+
+const expectRecord = (value: unknown): Record<string, unknown> => {
+  if (!isRecord(value)) {
+    throw new Error("candidate was not an object");
+  }
+  return value;
+};
+
+describe("normalizePolarEvent — subscription lifecycle", () => {
+  const cases = [
+    { native: "subscription.created", neutral: "entitlement.created" },
+    { native: "subscription.active", neutral: "entitlement.active" },
+    { native: "subscription.updated", neutral: "entitlement.updated" },
+    { native: "subscription.past_due", neutral: "entitlement.updated" },
+    { native: "subscription.uncanceled", neutral: "entitlement.updated" },
+    { native: "subscription.canceled", neutral: "entitlement.canceled" },
+    { native: "subscription.revoked", neutral: "entitlement.revoked" },
+  ] as const;
+
+  for (const { native, neutral } of cases) {
+    test(`${native} -> ${neutral}, renames fields, validates against neutral schema`, () => {
+      const data = polarSubscription();
+      const result = normalizePolarEvent({ type: native, data }, native);
+
+      expect(result.handled).toBe(true);
+      const candidate = expectRecord(result.candidate);
+      expect(candidate["type"]).toBe(neutral);
+      const mapped = expectRecord(candidate["data"]);
+      expect(mapped["account_ref"]).toBe("cus_abc");
+      expect(mapped["policy_ref"]).toBe("prod_pro");
+      expect(mapped["quantity"]).toBe(3);
+      expect(mapped["current_period_start"]).toBe("2026-06-01T00:00:00Z");
+      expect(mapped["cancel_at_period_end"]).toBe(false);
+
+      // The mapped candidate must satisfy the strict neutral schema that
+      // dispatch.ts relies on; this is the contract the whole binding hangs on.
+      expect(
+        v.safeParse(hostedUsageWebhookEventSchema, result.candidate).success,
+      ).toBe(true);
+    });
+  }
+
+  test("omits quantity when Polar seats is null so dispatch defaults to one", () => {
+    const result = normalizePolarEvent(
+      { type: "subscription.active", data: polarSubscription({ seats: null }) },
+      "subscription.active",
+    );
+    const mapped = expectRecord(expectRecord(result.candidate)["data"]);
+    expect(mapped["quantity"]).toBeUndefined();
+    expect(
+      v.safeParse(hostedUsageWebhookEventSchema, result.candidate).success,
+    ).toBe(true);
+  });
+
+  test("a handled subscription event with no data stays handled (forces 400/retry)", () => {
+    const result = normalizePolarEvent(
+      { type: "subscription.active" },
+      "subscription.active",
+    );
+    expect(result.handled).toBe(true);
+    expect(
+      v.safeParse(hostedUsageWebhookEventSchema, result.candidate).success,
+    ).toBe(false);
+  });
+});
+
+describe("normalizePolarEvent — orders", () => {
+  test("one-time purchase order.paid -> allocation.created (addon)", () => {
+    const result = normalizePolarEvent(
+      { type: "order.paid", data: polarOrder() },
+      "order.paid",
+    );
+    expect(result.handled).toBe(true);
+    const candidate = expectRecord(result.candidate);
+    expect(candidate["type"]).toBe("allocation.created");
+    const mapped = expectRecord(candidate["data"]);
+    expect(mapped["allocation_reason"]).toBe("addon");
+    expect(mapped["account_ref"]).toBe("cus_abc");
+    expect(mapped["policy_ref"]).toBe("prod_pack");
+    expect(mapped["amount"]).toBe(5000);
+    expect(
+      v.safeParse(hostedUsageWebhookEventSchema, result.candidate).success,
+    ).toBe(true);
+  });
+
+  test("subscription renewal order.paid is ignored (subscription.* owns the period)", () => {
+    const result = normalizePolarEvent(
+      {
+        type: "order.paid",
+        data: polarOrder({
+          billing_reason: "subscription_cycle",
+          subscription_id: "sub_123",
+        }),
+      },
+      "order.paid",
+    );
+    expect(result.handled).toBe(false);
+  });
+});
+
+describe("normalizePolarEvent — unmapped events", () => {
+  for (const native of [
+    "customer.created",
+    "checkout.updated",
+    "benefit_grant.created",
+    "order.refunded",
+  ]) {
+    test(`${native} is ignored and passed through unchanged`, () => {
+      const raw = { type: native, data: { id: "x" } };
+      const result = normalizePolarEvent(raw, native);
+      expect(result.handled).toBe(false);
+      expect(result.candidate).toBe(raw);
+    });
+  }
+});
+
+describe("normalizeProviderEvent — kind selection", () => {
+  test("neutral kind passes the body through and mirrors the handled set", () => {
+    const neutralEvent = {
+      type: "entitlement.active",
+      data: {
+        id: "ent_1",
+        status: "active",
+        account_ref: "cus_abc",
+        policy_ref: "prod_pro",
+        current_period_start: "2026-06-01T00:00:00Z",
+        current_period_end: "2026-07-01T00:00:00Z",
+      },
+    };
+    const handled = normalizeProviderEvent(
+      neutralEvent,
+      "entitlement.active",
+      "neutral",
+    );
+    expect(handled.candidate).toBe(neutralEvent);
+    expect(handled.handled).toBe(true);
+
+    const unknown = normalizeProviderEvent({ type: "x.y" }, "x.y", "neutral");
+    expect(unknown.handled).toBe(false);
+  });
+
+  test("polar kind delegates to the Polar mapper", () => {
+    const result = normalizeProviderEvent(
+      { type: "subscription.revoked", data: polarSubscription() },
+      "subscription.revoked",
+      "polar",
+    );
+    expect(result.handled).toBe(true);
+    expect(expectRecord(result.candidate)["type"]).toBe("entitlement.revoked");
+  });
+});

--- a/apps/api/src/lib/hosted-usage-provider/polar/events.test.ts
+++ b/apps/api/src/lib/hosted-usage-provider/polar/events.test.ts
@@ -189,3 +189,80 @@ describe("normalizeProviderEvent — kind selection", () => {
     expect(expectRecord(result.candidate)["type"]).toBe("entitlement.revoked");
   });
 });
+
+describe("normalizePolarEvent — order.paid fail-loud branches", () => {
+  test("missing data stays handled so strict parsing rejects (retry)", () => {
+    const raw = { type: "order.paid" };
+    const result = normalizePolarEvent(raw, "order.paid");
+    expect(result.handled).toBe(true);
+    expect(
+      v.safeParse(hostedUsageWebhookEventSchema, result.candidate).success,
+    ).toBe(false);
+  });
+
+  test("unrecognized billing shape stays handled (fail loud)", () => {
+    const result = normalizePolarEvent(
+      {
+        type: "order.paid",
+        data: polarOrder({ billing_reason: 42, subscription_id: "sub_1" }),
+      },
+      "order.paid",
+    );
+    expect(result.handled).toBe(true);
+    expect(
+      v.safeParse(hostedUsageWebhookEventSchema, result.candidate).success,
+    ).toBe(false);
+  });
+
+  test("renewal without a subscription id is not silently ignored", () => {
+    const result = normalizePolarEvent(
+      {
+        type: "order.paid",
+        data: polarOrder({
+          billing_reason: "subscription_cycle",
+          subscription_id: null,
+        }),
+      },
+      "order.paid",
+    );
+    expect(result.handled).toBe(true);
+  });
+});
+
+describe("normalizePolarEvent — occurred_at ordering signal", () => {
+  const mappedData = (overrides: Record<string, unknown>) => {
+    const result = normalizePolarEvent(
+      {
+        type: "subscription.updated",
+        data: polarSubscription(overrides),
+      },
+      "subscription.updated",
+    );
+    expect(result.handled).toBe(true);
+    expect(
+      v.safeParse(hostedUsageWebhookEventSchema, result.candidate).success,
+    ).toBe(true);
+    return expectRecord(expectRecord(result.candidate)["data"]);
+  };
+
+  test("modified_at maps to occurred_at", () => {
+    const mapped = mappedData({
+      created_at: "2026-06-01T00:00:00Z",
+      modified_at: "2026-06-15T12:00:00Z",
+    });
+    expect(mapped["occurred_at"]).toBe("2026-06-15T12:00:00Z");
+  });
+
+  test("falls back to created_at when modified_at is null", () => {
+    const mapped = mappedData({
+      created_at: "2026-06-01T00:00:00Z",
+      modified_at: null,
+    });
+    expect(mapped["occurred_at"]).toBe("2026-06-01T00:00:00Z");
+  });
+
+  test("omitted when the provider sends no usable timestamp", () => {
+    const mapped = mappedData({ modified_at: null });
+    expect(mapped["occurred_at"]).toBeUndefined();
+  });
+});

--- a/apps/api/src/lib/hosted-usage-provider/polar/events.ts
+++ b/apps/api/src/lib/hosted-usage-provider/polar/events.ts
@@ -68,6 +68,14 @@ const handledEntitlement = (
       // neutral schema/dispatch default of one seat applies. Seat-based
       // subscriptions carry a positive integer.
       quantity: typeof data["seats"] === "number" ? data["seats"] : undefined,
+      // Ordering signal for out-of-order retries. `modified_at` is null
+      // on a fresh subscription; fall back to `created_at`.
+      occurred_at:
+        typeof data["modified_at"] === "string"
+          ? data["modified_at"]
+          : typeof data["created_at"] === "string"
+            ? data["created_at"]
+            : undefined,
     },
   },
   handled: true,
@@ -101,6 +109,16 @@ const isOneTimePurchase = (data: Record<string, unknown>): boolean =>
   data["billing_reason"] === "purchase" &&
   (data["subscription_id"] === null || data["subscription_id"] === undefined);
 
+// Only a structurally valid renewal order may be ignored: the matching
+// subscription.* event owns the period, so acknowledging the order is
+// safe. Anything else that is neither a valid purchase nor a valid
+// renewal must FAIL LOUD (stay handled so strict parsing produces
+// 400/retry) instead of silently acknowledging a paid event.
+const isSubscriptionRenewalOrder = (data: Record<string, unknown>): boolean =>
+  typeof data["billing_reason"] === "string" &&
+  data["billing_reason"].startsWith("subscription_") &&
+  typeof data["subscription_id"] === "string";
+
 export const normalizePolarEvent = (
   raw: unknown,
   nativeType: string,
@@ -124,10 +142,22 @@ export const normalizePolarEvent = (
       return handledEntitlement("entitlement.canceled", data ?? {});
     case "subscription.revoked":
       return handledEntitlement("entitlement.revoked", data ?? {});
-    case "order.paid":
-      return data && isOneTimePurchase(data)
-        ? handledAllocation(data)
-        : ignored(raw);
+    case "order.paid": {
+      if (data === null) {
+        // Cannot distinguish a purchase from a renewal without `data`;
+        // stay handled so the strict neutral schema rejects it and the
+        // provider retries, rather than silently dropping a paid add-on.
+        return { candidate: raw, handled: true };
+      }
+      if (isOneTimePurchase(data)) {
+        return handledAllocation(data);
+      }
+      if (isSubscriptionRenewalOrder(data)) {
+        return ignored(raw);
+      }
+      // Unrecognized billing shape on a paid order: fail loud.
+      return { candidate: raw, handled: true };
+    }
     default:
       return ignored(raw);
   }

--- a/apps/api/src/lib/hosted-usage-provider/polar/events.ts
+++ b/apps/api/src/lib/hosted-usage-provider/polar/events.ts
@@ -1,0 +1,133 @@
+/**
+ * Translates Polar's native webhook events into the provider-neutral
+ * event contract consumed by `dispatch.ts`.
+ *
+ * Polar emits `subscription.*` and `order.*` events whose `data` is a
+ * Polar `Subscription` / `Order` object. The neutral contract
+ * (`event-schemas.ts`) expects `entitlement.*` / `allocation.*` events
+ * with `account_ref` / `policy_ref` fields. Only the event name and three
+ * field names differ; every other field name already matches, so this
+ * module reshapes rather than re-validates — the strict neutral schema in
+ * `event-schemas.ts` validates the result.
+ *
+ * Field map (Polar Subscription -> neutral entitlement payload):
+ *   customer_id  -> account_ref      product_id -> policy_ref
+ *   seats        -> quantity         (all other fields keep their names)
+ *
+ * Lifecycle map:
+ *   subscription.created                 -> entitlement.created
+ *   subscription.active                  -> entitlement.active
+ *   subscription.updated|past_due|       -> entitlement.updated
+ *     uncanceled
+ *   subscription.canceled                -> entitlement.canceled  (scheduled; cancel_at_period_end)
+ *   subscription.revoked                 -> entitlement.revoked    (immediate)
+ *   order.paid (one-time purchase only)  -> allocation.created     (add-on credit pack)
+ *
+ * Subscription renewal orders are intentionally ignored: the matching
+ * `subscription.*` event already owns the period and its idempotent
+ * periodic allocation, so mapping renewal orders to allocations would
+ * double-grant.
+ */
+
+import type { NormalizedProviderEvent } from "@/api/lib/hosted-usage-provider/provider-event-normalizer";
+import { isRecord } from "@/api/lib/type-guards";
+
+/** Polar subscription/order event types this adapter maps. */
+export const POLAR_HANDLED_EVENT_TYPES = [
+  "subscription.created",
+  "subscription.active",
+  "subscription.updated",
+  "subscription.past_due",
+  "subscription.uncanceled",
+  "subscription.canceled",
+  "subscription.revoked",
+  "order.paid",
+] as const;
+
+const ignored = (raw: unknown): NormalizedProviderEvent => ({
+  candidate: raw,
+  handled: false,
+});
+
+const handledEntitlement = (
+  type: string,
+  data: Record<string, unknown>,
+): NormalizedProviderEvent => ({
+  candidate: {
+    type,
+    data: {
+      id: data["id"],
+      status: data["status"],
+      account_ref: data["customer_id"],
+      policy_ref: data["product_id"],
+      current_period_start: data["current_period_start"],
+      current_period_end: data["current_period_end"],
+      cancel_at_period_end: data["cancel_at_period_end"],
+      metadata: data["metadata"],
+      // Polar `seats` is null for non-seat subscriptions; omit it so the
+      // neutral schema/dispatch default of one seat applies. Seat-based
+      // subscriptions carry a positive integer.
+      quantity: typeof data["seats"] === "number" ? data["seats"] : undefined,
+    },
+  },
+  handled: true,
+});
+
+const handledAllocation = (
+  data: Record<string, unknown>,
+): NormalizedProviderEvent => ({
+  candidate: {
+    type: "allocation.created",
+    data: {
+      id: data["id"],
+      account_ref: data["customer_id"],
+      policy_ref: data["product_id"],
+      // dispatch only acts on add-on allocations; one-time purchase orders
+      // are exactly that.
+      allocation_reason: "addon",
+      amount:
+        typeof data["net_amount"] === "number" ? data["net_amount"] : undefined,
+      currency: data["currency"],
+      metadata: data["metadata"],
+    },
+  },
+  handled: true,
+});
+
+// A one-time purchase has billing_reason "purchase" and no parent
+// subscription; renewal orders carry a subscription_id and a
+// subscription_* billing reason.
+const isOneTimePurchase = (data: Record<string, unknown>): boolean =>
+  data["billing_reason"] === "purchase" && data["subscription_id"] == null;
+
+export const normalizePolarEvent = (
+  raw: unknown,
+  nativeType: string,
+): NormalizedProviderEvent => {
+  // `data` may be absent on a malformed delivery. For a handled
+  // subscription type we still mark the event handled and reshape an empty
+  // object: the strict neutral schema then rejects it and `receive.ts`
+  // returns 400 so the provider retries, rather than silently acking a
+  // broken event we were meant to act on.
+  const data = isRecord(raw) && isRecord(raw["data"]) ? raw["data"] : null;
+  switch (nativeType) {
+    case "subscription.created":
+      return handledEntitlement("entitlement.created", data ?? {});
+    case "subscription.active":
+      return handledEntitlement("entitlement.active", data ?? {});
+    case "subscription.updated":
+    case "subscription.past_due":
+    case "subscription.uncanceled":
+      return handledEntitlement("entitlement.updated", data ?? {});
+    case "subscription.canceled":
+      return handledEntitlement("entitlement.canceled", data ?? {});
+    case "subscription.revoked":
+      return handledEntitlement("entitlement.revoked", data ?? {});
+    case "order.paid":
+      return data && isOneTimePurchase(data)
+        ? handledAllocation(data)
+        : ignored(raw);
+    default:
+      return ignored(raw);
+  }
+};

--- a/apps/api/src/lib/hosted-usage-provider/polar/events.ts
+++ b/apps/api/src/lib/hosted-usage-provider/polar/events.ts
@@ -98,7 +98,8 @@ const handledAllocation = (
 // subscription; renewal orders carry a subscription_id and a
 // subscription_* billing reason.
 const isOneTimePurchase = (data: Record<string, unknown>): boolean =>
-  data["billing_reason"] === "purchase" && data["subscription_id"] == null;
+  data["billing_reason"] === "purchase" &&
+  (data["subscription_id"] === null || data["subscription_id"] === undefined);
 
 export const normalizePolarEvent = (
   raw: unknown,

--- a/apps/api/src/lib/hosted-usage-provider/polar/events.ts
+++ b/apps/api/src/lib/hosted-usage-provider/polar/events.ts
@@ -49,6 +49,17 @@ const ignored = (raw: unknown): NormalizedProviderEvent => ({
   handled: false,
 });
 
+// Ordering signal for out-of-order retries. `modified_at` is null on a
+// fresh subscription; fall back to `created_at`.
+const occurredAtOf = (data: Record<string, unknown>): string | undefined => {
+  if (typeof data["modified_at"] === "string") {
+    return data["modified_at"];
+  }
+  return typeof data["created_at"] === "string"
+    ? data["created_at"]
+    : undefined;
+};
+
 const handledEntitlement = (
   type: string,
   data: Record<string, unknown>,
@@ -68,14 +79,7 @@ const handledEntitlement = (
       // neutral schema/dispatch default of one seat applies. Seat-based
       // subscriptions carry a positive integer.
       quantity: typeof data["seats"] === "number" ? data["seats"] : undefined,
-      // Ordering signal for out-of-order retries. `modified_at` is null
-      // on a fresh subscription; fall back to `created_at`.
-      occurred_at:
-        typeof data["modified_at"] === "string"
-          ? data["modified_at"]
-          : typeof data["created_at"] === "string"
-            ? data["created_at"]
-            : undefined,
+      occurred_at: occurredAtOf(data),
     },
   },
   handled: true,

--- a/apps/api/src/lib/hosted-usage-provider/provider-event-normalizer.ts
+++ b/apps/api/src/lib/hosted-usage-provider/provider-event-normalizer.ts
@@ -1,0 +1,41 @@
+/**
+ * Maps an authenticated, raw webhook body into the provider-neutral
+ * event shape that `event-schemas.ts` validates and `dispatch.ts`
+ * consumes.
+ *
+ * The signature/dedup/dispatch pipeline is provider-agnostic; this is the
+ * single seam where a concrete provider's native event names and payload
+ * field names are translated. Normalisation runs after signature
+ * verification and before strict schema validation in `receive.ts`.
+ */
+
+import { isHostedUsageHandledEventType } from "@/api/handlers/hosted-usage-webhook/event-schemas";
+import type { HostedUsageProviderKind } from "@/api/lib/hosted-usage-provider/config";
+import { normalizePolarEvent } from "@/api/lib/hosted-usage-provider/polar/events";
+
+export type NormalizedProviderEvent = {
+  /** The object to validate against `hostedUsageWebhookEventSchema`. */
+  candidate: unknown;
+  /**
+   * Whether a strict-parse failure of `candidate` should be treated as a
+   * malformed *handled* event (-> 400 so the provider retries) rather than
+   * an unhandled event type (-> recorded `ignored` + 200). This keeps the
+   * neutral pipeline's fail-loud guarantee for events we are meant to act
+   * on, even though the recorded native event type (e.g. `subscription.active`)
+   * is not itself one of the neutral handled types.
+   */
+  handled: boolean;
+};
+
+export const normalizeProviderEvent = (
+  raw: unknown,
+  nativeType: string,
+  kind: HostedUsageProviderKind,
+): NormalizedProviderEvent => {
+  if (kind === "polar") {
+    return normalizePolarEvent(raw, nativeType);
+  }
+  // Neutral provider: the body is already in the neutral contract, so the
+  // candidate is the raw body and "handled" mirrors the neutral type set.
+  return { candidate: raw, handled: isHostedUsageHandledEventType(nativeType) };
+};

--- a/apps/api/src/lib/hosted-usage-provider/verify-signature.test.ts
+++ b/apps/api/src/lib/hosted-usage-provider/verify-signature.test.ts
@@ -67,6 +67,31 @@ describe("verifyWebhookSignature", () => {
     expect(result.ok).toBe(true);
   });
 
+  test("accepts a vendor-prefixed (polar_whs_) serialized secret", () => {
+    const secretBytes = Buffer.from(
+      "vendor-prefixed-webhook-secret-32-b",
+      "utf-8",
+    );
+    const serializedSecret = `polar_whs_${secretBytes.toString("base64")}`;
+    const id = "evt_vendor_secret_001";
+    const timestamp = "1717400000";
+    const body = `{"type":"entitlement.created","id":"sub_vendor"}`;
+    const signature = signWithKey(secretBytes, id, timestamp, body);
+
+    const result = verifyWebhookSignature({
+      secrets: [serializedSecret],
+      rawBody: body,
+      headers: {
+        id,
+        timestamp,
+        signature: `v1,${signature}`,
+      },
+      nowSeconds: 1_717_400_000,
+    });
+
+    expect(result.ok).toBe(true);
+  });
+
   test("rejects request missing webhook-id header", () => {
     const headers = validHeaders();
     const result = verifyWebhookSignature({

--- a/apps/api/src/lib/hosted-usage-provider/verify-signature.ts
+++ b/apps/api/src/lib/hosted-usage-provider/verify-signature.ts
@@ -103,13 +103,22 @@ export const verifyWebhookSignature = ({
 
 type HmacKey = string | Buffer;
 
+// Some providers hand out Standard-Webhooks secrets under a vendor
+// prefix (e.g. `polar_whs_<base64>`) instead of the spec's `whsec_`.
+// Both wrap the same base64 key bytes; decode either.
+const VENDOR_WEBHOOK_SECRET_PREFIXES = ["polar_whs_"] as const;
+
 const parseWebhookSecret = (secret: string): HmacKey | null => {
   const trimmed = secret.trim();
-  if (!trimmed.startsWith(STANDARD_WEBHOOK_SECRET_PREFIX)) {
+  const prefix = [
+    STANDARD_WEBHOOK_SECRET_PREFIX,
+    ...VENDOR_WEBHOOK_SECRET_PREFIXES,
+  ].find((candidate) => trimmed.startsWith(candidate));
+  if (prefix === undefined) {
     return secret;
   }
 
-  const encoded = trimmed.slice(STANDARD_WEBHOOK_SECRET_PREFIX.length);
+  const encoded = trimmed.slice(prefix.length);
   if (!isBase64Secret(encoded)) {
     return null;
   }


### PR DESCRIPTION
Adds a concrete binding for the hosted usage provider behind the existing provider-neutral core, selected via `HOSTED_USAGE_PROVIDER` (default `neutral`, dark). Provider webhook events are normalized to the neutral `entitlement.*`/`allocation.*` schema before strict parsing; setup/management sessions call the provider's checkout and customer-session endpoints. No behavior change with default env; fail-loud parsing preserved; covered by the existing suites plus new event-mapping tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for selecting a hosted-usage provider, including Neutral and Polar modes.
  * Added Polar checkout and customer portal session support.
  * Added translation of Polar subscription and one-time purchase events into the standard usage event format.
* **Bug Fixes**
  * Improved webhook validation and handling of malformed or unknown provider events.
  * Hosted setup sessions now consistently include the organisation’s external account reference.
* **Tests**
  * Added coverage for Polar sessions, event translation, validation, and API error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->