### PR TITLE
feat(api): usage policy catalog endpoint and display fields

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -169,8 +169,12 @@ USE_MOCK_AI="true"
 
 # --- Usage policies (optional) ---------------------------------------------
 # Optional JSON array used by scripts/seed-usage-policies.ts.
+# Optional per-entry display fields drive the checkout catalog
+# (GET /usage/policies): description, kind ("subscription" | "addon"),
+# priceAmountCents + priceCurrency + billingInterval ("month" | "year" |
+# "one_time"), visibility ("public" | "hidden", default hidden), sortOrder.
 # Example:
-# STELLA_USAGE_POLICY_SEEDS='[{"key":"internal","displayName":"Internal","monthlyUsageUnits":1000}]'
+# STELLA_USAGE_POLICY_SEEDS='[{"key":"internal","displayName":"Internal","monthlyUsageUnits":1000},{"key":"team","displayName":"Team","monthlyUsageUnits":300,"priceAmountCents":9900,"priceCurrency":"EUR","billingInterval":"month","visibility":"public","sortOrder":1}]'
 # Optional hosted usage provider integration. Leave unset for self-hosted
 # internal limits without external self-service.
 # HOSTED_USAGE_PROVIDER_API_KEY=""

--- a/apps/api/drizzle/20260727160000_usage_policy_catalog_display/migration.sql
+++ b/apps/api/drizzle/20260727160000_usage_policy_catalog_display/migration.sql
@@ -7,7 +7,10 @@ ALTER TABLE "usage_policies" ADD COLUMN "price_currency" varchar(3);--> statemen
 ALTER TABLE "usage_policies" ADD COLUMN "billing_interval" text;--> statement-breakpoint
 ALTER TABLE "usage_policies" ADD COLUMN "visibility" text DEFAULT 'hidden' NOT NULL;--> statement-breakpoint
 ALTER TABLE "usage_policies" ADD COLUMN "sort_order" integer DEFAULT 0 NOT NULL;--> statement-breakpoint
-ALTER TABLE "usage_policies" ADD CONSTRAINT "usage_policies_price_amount_nonneg" CHECK (price_amount_cents IS NULL OR price_amount_cents >= 0) NOT VALID;--> statement-breakpoint
-ALTER TABLE "usage_policies" VALIDATE CONSTRAINT "usage_policies_price_amount_nonneg";--> statement-breakpoint
-ALTER TABLE "usage_policies" ADD CONSTRAINT "usage_policies_price_fields_consistent" CHECK ((price_amount_cents IS NULL) = (price_currency IS NULL) AND (price_amount_cents IS NULL OR billing_interval IS NOT NULL)) NOT VALID;--> statement-breakpoint
-ALTER TABLE "usage_policies" VALIDATE CONSTRAINT "usage_policies_price_fields_consistent";
+-- stella-migration-safety: reviewed constraint validation - usage_policies is an
+-- operator-seeded catalog bounded to a handful of rows (not tenant data), so
+-- inline CHECK validation completes in microseconds and cannot block under load.
+-- squawk-ignore constraint-missing-not-valid
+ALTER TABLE "usage_policies" ADD CONSTRAINT "usage_policies_price_amount_nonneg" CHECK (price_amount_cents IS NULL OR price_amount_cents >= 0);--> statement-breakpoint
+-- squawk-ignore constraint-missing-not-valid
+ALTER TABLE "usage_policies" ADD CONSTRAINT "usage_policies_price_fields_consistent" CHECK ((price_amount_cents IS NULL) = (price_currency IS NULL) AND (price_amount_cents IS NULL OR billing_interval IS NOT NULL));

--- a/apps/api/drizzle/20260727160000_usage_policy_catalog_display/migration.sql
+++ b/apps/api/drizzle/20260727160000_usage_policy_catalog_display/migration.sql
@@ -13,4 +13,10 @@ ALTER TABLE "usage_policies" ADD COLUMN "sort_order" integer DEFAULT 0 NOT NULL;
 -- squawk-ignore constraint-missing-not-valid
 ALTER TABLE "usage_policies" ADD CONSTRAINT "usage_policies_price_amount_nonneg" CHECK (price_amount_cents IS NULL OR price_amount_cents >= 0);--> statement-breakpoint
 -- squawk-ignore constraint-missing-not-valid
-ALTER TABLE "usage_policies" ADD CONSTRAINT "usage_policies_price_fields_consistent" CHECK ((price_amount_cents IS NULL) = (price_currency IS NULL) AND (price_amount_cents IS NULL OR billing_interval IS NOT NULL));
+ALTER TABLE "usage_policies" ADD CONSTRAINT "usage_policies_price_fields_consistent" CHECK ((price_amount_cents IS NULL) = (price_currency IS NULL) AND (price_amount_cents IS NULL) = (billing_interval IS NULL));--> statement-breakpoint
+-- squawk-ignore constraint-missing-not-valid
+ALTER TABLE "usage_policies" ADD CONSTRAINT "usage_policies_kind_domain" CHECK (kind IN ('subscription', 'addon'));--> statement-breakpoint
+-- squawk-ignore constraint-missing-not-valid
+ALTER TABLE "usage_policies" ADD CONSTRAINT "usage_policies_billing_interval_domain" CHECK (billing_interval IS NULL OR billing_interval IN ('month', 'year', 'one_time'));--> statement-breakpoint
+-- squawk-ignore constraint-missing-not-valid
+ALTER TABLE "usage_policies" ADD CONSTRAINT "usage_policies_visibility_domain" CHECK (visibility IN ('public', 'hidden'));

--- a/apps/api/drizzle/20260727160000_usage_policy_catalog_display/migration.sql
+++ b/apps/api/drizzle/20260727160000_usage_policy_catalog_display/migration.sql
@@ -7,5 +7,7 @@ ALTER TABLE "usage_policies" ADD COLUMN "price_currency" varchar(3);--> statemen
 ALTER TABLE "usage_policies" ADD COLUMN "billing_interval" text;--> statement-breakpoint
 ALTER TABLE "usage_policies" ADD COLUMN "visibility" text DEFAULT 'hidden' NOT NULL;--> statement-breakpoint
 ALTER TABLE "usage_policies" ADD COLUMN "sort_order" integer DEFAULT 0 NOT NULL;--> statement-breakpoint
-ALTER TABLE "usage_policies" ADD CONSTRAINT "usage_policies_price_amount_nonneg" CHECK (price_amount_cents IS NULL OR price_amount_cents >= 0);--> statement-breakpoint
-ALTER TABLE "usage_policies" ADD CONSTRAINT "usage_policies_price_fields_consistent" CHECK ((price_amount_cents IS NULL) = (price_currency IS NULL) AND (price_amount_cents IS NULL OR billing_interval IS NOT NULL));
+ALTER TABLE "usage_policies" ADD CONSTRAINT "usage_policies_price_amount_nonneg" CHECK (price_amount_cents IS NULL OR price_amount_cents >= 0) NOT VALID;--> statement-breakpoint
+ALTER TABLE "usage_policies" VALIDATE CONSTRAINT "usage_policies_price_amount_nonneg";--> statement-breakpoint
+ALTER TABLE "usage_policies" ADD CONSTRAINT "usage_policies_price_fields_consistent" CHECK ((price_amount_cents IS NULL) = (price_currency IS NULL) AND (price_amount_cents IS NULL OR billing_interval IS NOT NULL)) NOT VALID;--> statement-breakpoint
+ALTER TABLE "usage_policies" VALIDATE CONSTRAINT "usage_policies_price_fields_consistent";

--- a/apps/api/drizzle/20260727160000_usage_policy_catalog_display/migration.sql
+++ b/apps/api/drizzle/20260727160000_usage_policy_catalog_display/migration.sql
@@ -1,0 +1,11 @@
+SET lock_timeout = '1s';--> statement-breakpoint
+SET statement_timeout = '5s';--> statement-breakpoint
+ALTER TABLE "usage_policies" ADD COLUMN "description" text;--> statement-breakpoint
+ALTER TABLE "usage_policies" ADD COLUMN "kind" text DEFAULT 'subscription' NOT NULL;--> statement-breakpoint
+ALTER TABLE "usage_policies" ADD COLUMN "price_amount_cents" integer;--> statement-breakpoint
+ALTER TABLE "usage_policies" ADD COLUMN "price_currency" varchar(3);--> statement-breakpoint
+ALTER TABLE "usage_policies" ADD COLUMN "billing_interval" text;--> statement-breakpoint
+ALTER TABLE "usage_policies" ADD COLUMN "visibility" text DEFAULT 'hidden' NOT NULL;--> statement-breakpoint
+ALTER TABLE "usage_policies" ADD COLUMN "sort_order" integer DEFAULT 0 NOT NULL;--> statement-breakpoint
+ALTER TABLE "usage_policies" ADD CONSTRAINT "usage_policies_price_amount_nonneg" CHECK (price_amount_cents IS NULL OR price_amount_cents >= 0);--> statement-breakpoint
+ALTER TABLE "usage_policies" ADD CONSTRAINT "usage_policies_price_fields_consistent" CHECK ((price_amount_cents IS NULL) = (price_currency IS NULL) AND (price_amount_cents IS NULL OR billing_interval IS NOT NULL));

--- a/apps/api/scripts/seed-usage-policies.ts
+++ b/apps/api/scripts/seed-usage-policies.ts
@@ -30,7 +30,9 @@ const usagePolicySeedSchema = v.pipe(
       null,
     ),
     priceCurrency: v.optional(
-      v.nullable(v.pipe(v.string(), v.trim(), v.length(3))),
+      // Strict ISO 4217 alpha code: a malformed value would make the
+      // picker's Intl.NumberFormat throw at render time.
+      v.nullable(v.pipe(v.string(), v.trim(), v.regex(/^[A-Z]{3}$/u))),
       null,
     ),
     billingInterval: v.optional(
@@ -43,12 +45,18 @@ const usagePolicySeedSchema = v.pipe(
   v.check(
     (seed) =>
       (seed.priceAmountCents === null) === (seed.priceCurrency === null) &&
-      (seed.priceAmountCents === null || seed.billingInterval !== null),
+      (seed.priceAmountCents === null) === (seed.billingInterval === null),
     "price fields must be set together (amount + currency + interval)",
   ),
 );
 
-const usagePolicySeedsSchema = v.array(usagePolicySeedSchema);
+// Bounded to the catalog read ceiling (MAX_CATALOG_ROWS): an oversized
+// operator config fails loudly at seed time instead of silently
+// truncating the checkout picker.
+const usagePolicySeedsSchema = v.pipe(
+  v.array(usagePolicySeedSchema),
+  v.maxLength(100),
+);
 
 type UsagePolicySeed = v.InferOutput<typeof usagePolicySeedSchema>;
 

--- a/apps/api/scripts/seed-usage-policies.ts
+++ b/apps/api/scripts/seed-usage-policies.ts
@@ -9,15 +9,44 @@
 import * as v from "valibot";
 
 import { rootDb } from "@/api/db/root";
-import { usagePolicies } from "@/api/db/schema";
+import {
+  USAGE_POLICY_BILLING_INTERVALS,
+  USAGE_POLICY_KINDS,
+  USAGE_POLICY_VISIBILITIES,
+  usagePolicies,
+} from "@/api/db/schema";
 import { env } from "@/api/env";
 
-const usagePolicySeedSchema = v.strictObject({
-  key: v.pipe(v.string(), v.trim(), v.regex(/^[a-z0-9][a-z0-9_-]{0,63}$/u)),
-  displayName: v.pipe(v.string(), v.trim(), v.minLength(1), v.maxLength(128)),
-  monthlyUsageUnits: v.pipe(v.number(), v.integer(), v.minValue(0)),
-  hostedPolicyRef: v.optional(v.nullable(v.string()), null),
-});
+const usagePolicySeedSchema = v.pipe(
+  v.strictObject({
+    key: v.pipe(v.string(), v.trim(), v.regex(/^[a-z0-9][a-z0-9_-]{0,63}$/u)),
+    displayName: v.pipe(v.string(), v.trim(), v.minLength(1), v.maxLength(128)),
+    description: v.optional(v.nullable(v.pipe(v.string(), v.trim())), null),
+    kind: v.optional(v.picklist(USAGE_POLICY_KINDS), "subscription"),
+    monthlyUsageUnits: v.pipe(v.number(), v.integer(), v.minValue(0)),
+    hostedPolicyRef: v.optional(v.nullable(v.string()), null),
+    priceAmountCents: v.optional(
+      v.nullable(v.pipe(v.number(), v.integer(), v.minValue(0))),
+      null,
+    ),
+    priceCurrency: v.optional(
+      v.nullable(v.pipe(v.string(), v.trim(), v.length(3))),
+      null,
+    ),
+    billingInterval: v.optional(
+      v.nullable(v.picklist(USAGE_POLICY_BILLING_INTERVALS)),
+      null,
+    ),
+    visibility: v.optional(v.picklist(USAGE_POLICY_VISIBILITIES), "hidden"),
+    sortOrder: v.optional(v.pipe(v.number(), v.integer()), 0),
+  }),
+  v.check(
+    (seed) =>
+      (seed.priceAmountCents === null) === (seed.priceCurrency === null) &&
+      (seed.priceAmountCents === null || seed.billingInterval !== null),
+    "price fields must be set together (amount + currency + interval)",
+  ),
+);
 
 const usagePolicySeedsSchema = v.array(usagePolicySeedSchema);
 
@@ -45,15 +74,29 @@ const seed = async (): Promise<void> => {
       .values({
         policyKey: seedPolicy.key,
         displayName: seedPolicy.displayName,
+        description: seedPolicy.description,
+        kind: seedPolicy.kind,
         monthlyUsageUnits: seedPolicy.monthlyUsageUnits,
         hostedPolicyRef: seedPolicy.hostedPolicyRef,
+        priceAmountCents: seedPolicy.priceAmountCents,
+        priceCurrency: seedPolicy.priceCurrency,
+        billingInterval: seedPolicy.billingInterval,
+        visibility: seedPolicy.visibility,
+        sortOrder: seedPolicy.sortOrder,
       })
       .onConflictDoUpdate({
         target: usagePolicies.policyKey,
         set: {
           displayName: seedPolicy.displayName,
+          description: seedPolicy.description,
+          kind: seedPolicy.kind,
           monthlyUsageUnits: seedPolicy.monthlyUsageUnits,
           hostedPolicyRef: seedPolicy.hostedPolicyRef,
+          priceAmountCents: seedPolicy.priceAmountCents,
+          priceCurrency: seedPolicy.priceCurrency,
+          billingInterval: seedPolicy.billingInterval,
+          visibility: seedPolicy.visibility,
+          sortOrder: seedPolicy.sortOrder,
         },
       });
     console.log(

--- a/apps/api/scripts/seed-usage-policies.ts
+++ b/apps/api/scripts/seed-usage-policies.ts
@@ -92,29 +92,19 @@ const seed = async (): Promise<void> => {
     return;
   }
 
-  for (const seedPolicy of seeds) {
-    // Upsert by policyKey so edits to the config (display name, units,
-    // or a newly created hostedPolicyRef) propagate to the existing row
-    // instead of being skipped.
-    // oxlint-disable-next-line no-await-in-loop -- sequential seeding preserves upsert order across policies
-    await rootDb
-      .insert(usagePolicies)
-      .values({
-        policyKey: seedPolicy.key,
-        displayName: seedPolicy.displayName,
-        description: seedPolicy.description,
-        kind: seedPolicy.kind,
-        monthlyUsageUnits: seedPolicy.monthlyUsageUnits,
-        hostedPolicyRef: seedPolicy.hostedPolicyRef,
-        priceAmountCents: seedPolicy.priceAmountCents,
-        priceCurrency: seedPolicy.priceCurrency,
-        billingInterval: seedPolicy.billingInterval,
-        visibility: seedPolicy.visibility,
-        sortOrder: seedPolicy.sortOrder,
-      })
-      .onConflictDoUpdate({
-        target: usagePolicies.policyKey,
-        set: {
+  // One transaction for upserts + retirement: a mid-run failure (e.g.
+  // two seeds colliding on the unique hosted-provider reference) must
+  // not leave the catalog as a partial mix of new and stale entries.
+  await rootDb.transaction(async (tx) => {
+    for (const seedPolicy of seeds) {
+      // Upsert by policyKey so edits to the config (display name, units,
+      // or a newly created hostedPolicyRef) propagate to the existing row
+      // instead of being skipped.
+      // oxlint-disable-next-line no-await-in-loop -- sequential seeding preserves upsert order across policies
+      await tx
+        .insert(usagePolicies)
+        .values({
+          policyKey: seedPolicy.key,
           displayName: seedPolicy.displayName,
           description: seedPolicy.description,
           kind: seedPolicy.kind,
@@ -125,37 +115,52 @@ const seed = async (): Promise<void> => {
           billingInterval: seedPolicy.billingInterval,
           visibility: seedPolicy.visibility,
           sortOrder: seedPolicy.sortOrder,
-        },
-      });
-    console.log(
-      `seeded ${seedPolicy.key}: ${seedPolicy.monthlyUsageUnits} units/seat${
-        seedPolicy.hostedPolicyRef
-          ? " (hosted policy reference configured)"
-          : ""
-      }`,
-    );
-  }
+        })
+        .onConflictDoUpdate({
+          target: usagePolicies.policyKey,
+          set: {
+            displayName: seedPolicy.displayName,
+            description: seedPolicy.description,
+            kind: seedPolicy.kind,
+            monthlyUsageUnits: seedPolicy.monthlyUsageUnits,
+            hostedPolicyRef: seedPolicy.hostedPolicyRef,
+            priceAmountCents: seedPolicy.priceAmountCents,
+            priceCurrency: seedPolicy.priceCurrency,
+            billingInterval: seedPolicy.billingInterval,
+            visibility: seedPolicy.visibility,
+            sortOrder: seedPolicy.sortOrder,
+          },
+        });
+      console.log(
+        `seeded ${seedPolicy.key}: ${seedPolicy.monthlyUsageUnits} units/seat${
+          seedPolicy.hostedPolicyRef
+            ? " (hosted policy reference configured)"
+            : ""
+        }`,
+      );
+    }
 
-  // The seed config is the single source of the PUBLIC catalog: rows
-  // whose key left the config are hidden (not deleted or deactivated —
-  // existing entitlements keep referencing them), so repeated
-  // reconfiguration cannot grow the visible catalog past the seed
-  // bound. The empty-config early return above deliberately leaves
-  // everything untouched.
-  const seededKeys = seeds.map((seedPolicy) => seedPolicy.key);
-  const hidden = await rootDb
-    .update(usagePolicies)
-    .set({ visibility: "hidden" })
-    .where(
-      and(
-        notInArray(usagePolicies.policyKey, seededKeys),
-        eq(usagePolicies.visibility, "public"),
-      ),
-    )
-    .returning({ policyKey: usagePolicies.policyKey });
-  for (const row of hidden) {
-    console.log(`hid retired policy ${row.policyKey} (absent from seeds)`);
-  }
+    // The seed config is the single source of the PUBLIC catalog: rows
+    // whose key left the config are hidden (not deleted or deactivated —
+    // existing entitlements keep referencing them), so repeated
+    // reconfiguration cannot grow the visible catalog past the seed
+    // bound. The empty-config early return above deliberately leaves
+    // everything untouched.
+    const seededKeys = seeds.map((seedPolicy) => seedPolicy.key);
+    const hidden = await tx
+      .update(usagePolicies)
+      .set({ visibility: "hidden" })
+      .where(
+        and(
+          notInArray(usagePolicies.policyKey, seededKeys),
+          eq(usagePolicies.visibility, "public"),
+        ),
+      )
+      .returning({ policyKey: usagePolicies.policyKey });
+    for (const row of hidden) {
+      console.log(`hid retired policy ${row.policyKey} (absent from seeds)`);
+    }
+  });
 };
 
 await seed();

--- a/apps/api/scripts/seed-usage-policies.ts
+++ b/apps/api/scripts/seed-usage-policies.ts
@@ -17,6 +17,7 @@ import {
   usagePolicies,
 } from "@/api/db/schema";
 import { env } from "@/api/env";
+import { MAX_CATALOG_ROWS } from "@/api/lib/usage/policy-catalog";
 
 // PostgreSQL int4 ceiling: values beyond it would fail at write time
 // with an opaque driver error instead of a seed validation message.
@@ -75,7 +76,7 @@ const usagePolicySeedSchema = v.pipe(
 // truncating the checkout picker.
 const usagePolicySeedsSchema = v.pipe(
   v.array(usagePolicySeedSchema),
-  v.maxLength(100),
+  v.maxLength(MAX_CATALOG_ROWS),
 );
 
 type UsagePolicySeed = v.InferOutput<typeof usagePolicySeedSchema>;

--- a/apps/api/scripts/seed-usage-policies.ts
+++ b/apps/api/scripts/seed-usage-policies.ts
@@ -6,6 +6,7 @@
  * empty so the public repo does not encode an operator policy.
  */
 
+import { and, eq, notInArray } from "drizzle-orm";
 import * as v from "valibot";
 
 import { rootDb } from "@/api/db/root";
@@ -17,16 +18,27 @@ import {
 } from "@/api/db/schema";
 import { env } from "@/api/env";
 
+// PostgreSQL int4 ceiling: values beyond it would fail at write time
+// with an opaque driver error instead of a seed validation message.
+const PG_INT4_MAX = 2_147_483_647;
+
 const usagePolicySeedSchema = v.pipe(
   v.strictObject({
     key: v.pipe(v.string(), v.trim(), v.regex(/^[a-z0-9][a-z0-9_-]{0,63}$/u)),
     displayName: v.pipe(v.string(), v.trim(), v.minLength(1), v.maxLength(128)),
     description: v.optional(v.nullable(v.pipe(v.string(), v.trim())), null),
     kind: v.optional(v.picklist(USAGE_POLICY_KINDS), "subscription"),
-    monthlyUsageUnits: v.pipe(v.number(), v.integer(), v.minValue(0)),
+    monthlyUsageUnits: v.pipe(
+      v.number(),
+      v.integer(),
+      v.minValue(0),
+      v.maxValue(PG_INT4_MAX),
+    ),
     hostedPolicyRef: v.optional(v.nullable(v.string()), null),
     priceAmountCents: v.optional(
-      v.nullable(v.pipe(v.number(), v.integer(), v.minValue(0))),
+      v.nullable(
+        v.pipe(v.number(), v.integer(), v.minValue(0), v.maxValue(PG_INT4_MAX)),
+      ),
       null,
     ),
     priceCurrency: v.optional(
@@ -40,7 +52,15 @@ const usagePolicySeedSchema = v.pipe(
       null,
     ),
     visibility: v.optional(v.picklist(USAGE_POLICY_VISIBILITIES), "hidden"),
-    sortOrder: v.optional(v.pipe(v.number(), v.integer()), 0),
+    sortOrder: v.optional(
+      v.pipe(
+        v.number(),
+        v.integer(),
+        v.minValue(-PG_INT4_MAX - 1),
+        v.maxValue(PG_INT4_MAX),
+      ),
+      0,
+    ),
   }),
   v.check(
     (seed) =>
@@ -114,6 +134,27 @@ const seed = async (): Promise<void> => {
           : ""
       }`,
     );
+  }
+
+  // The seed config is the single source of the PUBLIC catalog: rows
+  // whose key left the config are hidden (not deleted or deactivated —
+  // existing entitlements keep referencing them), so repeated
+  // reconfiguration cannot grow the visible catalog past the seed
+  // bound. The empty-config early return above deliberately leaves
+  // everything untouched.
+  const seededKeys = seeds.map((seedPolicy) => seedPolicy.key);
+  const hidden = await rootDb
+    .update(usagePolicies)
+    .set({ visibility: "hidden" })
+    .where(
+      and(
+        notInArray(usagePolicies.policyKey, seededKeys),
+        eq(usagePolicies.visibility, "public"),
+      ),
+    )
+    .returning({ policyKey: usagePolicies.policyKey });
+  for (const row of hidden) {
+    console.log(`hid retired policy ${row.policyKey} (absent from seeds)`);
   }
 };
 

--- a/apps/api/src/db/schema/usage.ts
+++ b/apps/api/src/db/schema/usage.ts
@@ -28,18 +28,14 @@ import {
 } from "./skills";
 
 export const USAGE_POLICY_KINDS = ["subscription", "addon"] as const;
-export type UsagePolicyKind = (typeof USAGE_POLICY_KINDS)[number];
 
 export const USAGE_POLICY_BILLING_INTERVALS = [
   "month",
   "year",
   "one_time",
 ] as const;
-export type UsagePolicyBillingInterval =
-  (typeof USAGE_POLICY_BILLING_INTERVALS)[number];
 
 export const USAGE_POLICY_VISIBILITIES = ["public", "hidden"] as const;
-export type UsagePolicyVisibility = (typeof USAGE_POLICY_VISIBILITIES)[number];
 
 export const usagePolicies = p.pgTable(
   "usage_policies",

--- a/apps/api/src/db/schema/usage.ts
+++ b/apps/api/src/db/schema/usage.ts
@@ -78,9 +78,27 @@ export const usagePolicies = p.pgTable(
       "usage_policies_price_amount_nonneg",
       sql`price_amount_cents IS NULL OR price_amount_cents >= 0`,
     ),
+    // All three price display fields travel together: a partial price
+    // (interval without amount, amount without currency) cannot render
+    // in the checkout picker and would compromise the billing catalog.
     p.check(
       "usage_policies_price_fields_consistent",
-      sql`(price_amount_cents IS NULL) = (price_currency IS NULL) AND (price_amount_cents IS NULL OR billing_interval IS NOT NULL)`,
+      sql`(price_amount_cents IS NULL) = (price_currency IS NULL) AND (price_amount_cents IS NULL) = (billing_interval IS NULL)`,
+    ),
+    // Drizzle's text-enum option narrows TypeScript only; these are
+    // billing-relevant domains, so invalid values are rejected by the
+    // database as well (root/manual writes included).
+    p.check(
+      "usage_policies_kind_domain",
+      sql`kind IN ('subscription', 'addon')`,
+    ),
+    p.check(
+      "usage_policies_billing_interval_domain",
+      sql`billing_interval IS NULL OR billing_interval IN ('month', 'year', 'one_time')`,
+    ),
+    p.check(
+      "usage_policies_visibility_domain",
+      sql`visibility IN ('public', 'hidden')`,
     ),
     p
       .uniqueIndex("usage_policies_hosted_policy_ref_uidx")

--- a/apps/api/src/db/schema/usage.ts
+++ b/apps/api/src/db/schema/usage.ts
@@ -27,20 +27,61 @@ import {
   USAGE_SERVICE_TIERS,
 } from "./skills";
 
+export const USAGE_POLICY_KINDS = ["subscription", "addon"] as const;
+export type UsagePolicyKind = (typeof USAGE_POLICY_KINDS)[number];
+
+export const USAGE_POLICY_BILLING_INTERVALS = [
+  "month",
+  "year",
+  "one_time",
+] as const;
+export type UsagePolicyBillingInterval =
+  (typeof USAGE_POLICY_BILLING_INTERVALS)[number];
+
+export const USAGE_POLICY_VISIBILITIES = ["public", "hidden"] as const;
+export type UsagePolicyVisibility = (typeof USAGE_POLICY_VISIBILITIES)[number];
+
 export const usagePolicies = p.pgTable(
   "usage_policies",
   {
     id: pUuid<"usagePolicy">().primaryKey(),
     policyKey: p.varchar("policy_key", { length: 64 }).notNull(),
     displayName: p.varchar("display_name", { length: 128 }).notNull(),
+    description: p.text(),
+    kind: p
+      .text({ enum: USAGE_POLICY_KINDS })
+      .notNull()
+      .default("subscription"),
     monthlyUsageUnits: p.integer("monthly_usage_units").notNull(),
     hostedPolicyRef: p.text("hosted_policy_ref"),
+    // Catalog display data is deployment-owned (seeded from operator
+    // config), so public source carries the mechanism, not a price list.
+    priceAmountCents: p.integer("price_amount_cents"),
+    priceCurrency: p.varchar("price_currency", { length: 3 }),
+    billingInterval: p.text("billing_interval", {
+      enum: USAGE_POLICY_BILLING_INTERVALS,
+    }),
+    // Hidden by default: a seeded policy only appears in the catalog
+    // endpoint once the operator explicitly marks it public.
+    visibility: p
+      .text({ enum: USAGE_POLICY_VISIBILITIES })
+      .notNull()
+      .default("hidden"),
+    sortOrder: p.integer("sort_order").notNull().default(0),
     active: p.boolean().notNull().default(true),
     createdAt: p.timestamp("created_at").notNull().defaultNow(),
   },
   (table) => [
     p.index("usage_policies_key_active_idx").on(table.policyKey, table.active),
     p.uniqueIndex("usage_policies_policy_key_uidx").on(table.policyKey),
+    p.check(
+      "usage_policies_price_amount_nonneg",
+      sql`price_amount_cents IS NULL OR price_amount_cents >= 0`,
+    ),
+    p.check(
+      "usage_policies_price_fields_consistent",
+      sql`(price_amount_cents IS NULL) = (price_currency IS NULL) AND (price_amount_cents IS NULL OR billing_interval IS NOT NULL)`,
+    ),
     p
       .uniqueIndex("usage_policies_hosted_policy_ref_uidx")
       .on(table.hostedPolicyRef)

--- a/apps/api/src/handlers/usage/create-hosted-setup.ts
+++ b/apps/api/src/handlers/usage/create-hosted-setup.ts
@@ -66,6 +66,8 @@ const createHostedSetup = createSafeRootHandler(
           .select({
             source: usageEntitlements.source,
             hostedAccountRef: usageEntitlements.hostedAccountRef,
+            status: usageEntitlements.status,
+            currentPeriodEnd: usageEntitlements.currentPeriodEnd,
           })
           .from(usageEntitlements)
           .where(
@@ -82,11 +84,20 @@ const createHostedSetup = createSafeRootHandler(
           return { kind: "manual_entitlement_present" as const };
         }
         // An add-on allocation is resolved against the buyer's hosted
-        // entitlement period at webhook time; without a mapped hosted
-        // account the paid allocation would be unattributable. Refuse
-        // up front rather than accepting money we cannot apply.
-        if (policy.kind === "addon" && !entitlement?.hostedAccountRef) {
-          return { kind: "addon_requires_subscription" as const };
+        // entitlement's CURRENT period at webhook time; without a mapped
+        // hosted account the paid allocation would be unattributable,
+        // and against a cancelled/paused/expired entitlement it would
+        // land in a period the organisation cannot consume. Refuse up
+        // front rather than accepting money we cannot apply.
+        if (policy.kind === "addon") {
+          const consumable =
+            entitlement?.hostedAccountRef &&
+            entitlement.status !== "cancelled" &&
+            entitlement.status !== "paused" &&
+            entitlement.currentPeriodEnd > new Date();
+          if (!consumable) {
+            return { kind: "addon_requires_subscription" as const };
+          }
         }
 
         return {

--- a/apps/api/src/handlers/usage/create-hosted-setup.ts
+++ b/apps/api/src/handlers/usage/create-hosted-setup.ts
@@ -91,7 +91,8 @@ const createHostedSetup = createSafeRootHandler(
         // front rather than accepting money we cannot apply.
         if (policy.kind === "addon") {
           const consumable =
-            entitlement?.hostedAccountRef &&
+            entitlement !== undefined &&
+            entitlement.hostedAccountRef !== null &&
             entitlement.status !== "cancelled" &&
             entitlement.status !== "paused" &&
             entitlement.currentPeriodEnd > new Date();

--- a/apps/api/src/handlers/usage/create-hosted-setup.ts
+++ b/apps/api/src/handlers/usage/create-hosted-setup.ts
@@ -48,6 +48,7 @@ const createHostedSetup = createSafeRootHandler(
           .select({
             id: usagePolicies.id,
             active: usagePolicies.active,
+            kind: usagePolicies.kind,
             hostedPolicyRef: usagePolicies.hostedPolicyRef,
           })
           .from(usagePolicies)
@@ -80,6 +81,13 @@ const createHostedSetup = createSafeRootHandler(
         if (entitlement && entitlement.source === "manual") {
           return { kind: "manual_entitlement_present" as const };
         }
+        // An add-on allocation is resolved against the buyer's hosted
+        // entitlement period at webhook time; without a mapped hosted
+        // account the paid allocation would be unattributable. Refuse
+        // up front rather than accepting money we cannot apply.
+        if (policy.kind === "addon" && !entitlement?.hostedAccountRef) {
+          return { kind: "addon_requires_subscription" as const };
+        }
 
         return {
           kind: "ok" as const,
@@ -108,6 +116,15 @@ const createHostedSetup = createSafeRootHandler(
           status: 409,
           message:
             "This organisation has a manually managed usage entitlement. Contact an operator to switch management.",
+        }),
+      );
+    }
+    if (dbResult.kind === "addon_requires_subscription") {
+      return Result.err(
+        new HandlerError({
+          status: 409,
+          message:
+            "An active subscription is required before purchasing add-on packs",
         }),
       );
     }

--- a/apps/api/src/handlers/usage/create-hosted-setup.ts
+++ b/apps/api/src/handlers/usage/create-hosted-setup.ts
@@ -49,6 +49,7 @@ const createHostedSetup = createSafeRootHandler(
             id: usagePolicies.id,
             active: usagePolicies.active,
             kind: usagePolicies.kind,
+            visibility: usagePolicies.visibility,
             hostedPolicyRef: usagePolicies.hostedPolicyRef,
           })
           .from(usagePolicies)
@@ -58,7 +59,14 @@ const createHostedSetup = createSafeRootHandler(
         if (!policy) {
           return { kind: "policy_not_found" as const };
         }
-        if (!policy.active || !policy.hostedPolicyRef) {
+        // Retired offers are hidden by the seeder, not deleted; a client
+        // holding a stale policy id must not be able to start checkout
+        // for something the catalog no longer advertises.
+        if (
+          !policy.active ||
+          !policy.hostedPolicyRef ||
+          policy.visibility !== "public"
+        ) {
           return { kind: "policy_not_hosted" as const };
         }
 

--- a/apps/api/src/handlers/usage/create-hosted-setup.ts
+++ b/apps/api/src/handlers/usage/create-hosted-setup.ts
@@ -11,6 +11,7 @@ import { tSafeId } from "@/api/lib/custom-schema";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import { createHostedSetupSession } from "@/api/lib/hosted-usage-provider/client";
 import { getApiCredentials } from "@/api/lib/hosted-usage-provider/config";
+import { CONSUMABLE_STATUSES } from "@/api/lib/usage/usage-ledger";
 
 /** Create a hosted setup session for an active usage policy. */
 
@@ -98,11 +99,13 @@ const createHostedSetup = createSafeRootHandler(
         // land in a period the organisation cannot consume. Refuse up
         // front rather than accepting money we cannot apply.
         if (policy.kind === "addon") {
+          // Mirror the ledger's own consumability rule so this gate
+          // cannot drift from what allocated units can actually be
+          // spent on (past_due blocks consumption too).
           const consumable =
             entitlement !== undefined &&
             entitlement.hostedAccountRef !== null &&
-            entitlement.status !== "cancelled" &&
-            entitlement.status !== "paused" &&
+            CONSUMABLE_STATUSES.has(entitlement.status) &&
             entitlement.currentPeriodEnd > new Date();
           if (!consumable) {
             return { kind: "addon_requires_subscription" as const };

--- a/apps/api/src/handlers/usage/list-policies.ts
+++ b/apps/api/src/handlers/usage/list-policies.ts
@@ -1,6 +1,7 @@
 import { Result } from "better-result";
 import { and, asc, eq } from "drizzle-orm";
 
+import type { SafeDb } from "@/api/db/safe-db";
 import { usagePolicies } from "@/api/db/schema";
 import { createSafeRootHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
@@ -31,12 +32,40 @@ const config = {
   mcp: { type: "internal", reason: "hosted_billing" },
 } satisfies HandlerConfig;
 
-const listPolicies = createSafeRootHandler(
-  config,
-  async function* ({ safeDb }) {
-    const rows = yield* Result.await(
-      safeDb((tx) =>
-        tx
+type UsagePolicyRow = typeof usagePolicies.$inferSelect;
+
+type CatalogQueryRow = Pick<
+  UsagePolicyRow,
+  | "id"
+  | "displayName"
+  | "description"
+  | "kind"
+  | "monthlyUsageUnits"
+  | "priceAmountCents"
+  | "priceCurrency"
+  | "billingInterval"
+  | "sortOrder"
+  | "hostedPolicyRef"
+> & { key: UsagePolicyRow["policyKey"] };
+
+type UsagePolicyCatalogEntry = Omit<CatalogQueryRow, "hostedPolicyRef"> & {
+  hostedCheckoutAvailable: boolean;
+};
+
+type ListPoliciesResult = { policies: UsagePolicyCatalogEntry[] };
+
+// Hoisted read with a sealed result type: the route mount consumes
+// `ListPoliciesResult` instead of re-instantiating the query-builder
+// projection generics (measured against the typecheck baseline).
+export const readUsagePolicyCatalog = async function* ({
+  safeDb,
+}: {
+  safeDb: SafeDb;
+}) {
+  const rows = yield* Result.await(
+    safeDb(
+      async (tx): Promise<CatalogQueryRow[]> =>
+        await tx
           .select({
             id: usagePolicies.id,
             key: usagePolicies.policyKey,
@@ -59,17 +88,26 @@ const listPolicies = createSafeRootHandler(
           )
           .orderBy(asc(usagePolicies.sortOrder), asc(usagePolicies.id))
           .limit(MAX_CATALOG_ROWS),
-      ),
-    );
+    ),
+  );
 
-    return Result.ok({
-      policies: rows.map(({ hostedPolicyRef, ...policy }) => ({
-        ...policy,
-        // The provider reference itself stays server-side; the picker
-        // only needs to know whether checkout can be started.
+  // The provider reference itself stays server-side; the picker
+  // only needs to know whether checkout can be started.
+  const policies: UsagePolicyCatalogEntry[] = rows.map(
+    ({ hostedPolicyRef, ...policy }) =>
+      Object.assign(policy, {
         hostedCheckoutAvailable: hostedPolicyRef !== null,
-      })),
-    });
+      }),
+  );
+
+  const result: ListPoliciesResult = { policies };
+  return Result.ok(result);
+};
+
+const listPolicies = createSafeRootHandler(
+  config,
+  async function* ({ safeDb }) {
+    return yield* readUsagePolicyCatalog({ safeDb });
   },
 );
 

--- a/apps/api/src/handlers/usage/list-policies.ts
+++ b/apps/api/src/handlers/usage/list-policies.ts
@@ -1,23 +1,13 @@
-import { Result } from "better-result";
-import { and, asc, eq } from "drizzle-orm";
-
-import type { SafeDb } from "@/api/db/safe-db";
-import { usagePolicies } from "@/api/db/schema";
 import { createSafeRootHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
+import { readUsagePolicyCatalog } from "@/api/lib/usage/policy-catalog";
 
 /**
  * List the publicly visible usage-policy catalog (plans and add-on
- * packs) for the checkout picker.
- *
- * The catalog is deployment-owned config seeded by the operator
- * (`STELLA_USAGE_POLICY_SEEDS`), so the result set is bounded by that
- * config, not by tenant data; `MAX_CATALOG_ROWS` is a hard ceiling,
- * not a page size, which is why this endpoint returns a plain list
- * instead of the cursor `Page<T>` envelope.
+ * packs) for the checkout picker. The read lives in
+ * `lib/usage/policy-catalog.ts` so other consumers never import an
+ * endpoint module.
  */
-
-const MAX_CATALOG_ROWS = 100;
 
 const config = {
   description:
@@ -31,78 +21,6 @@ const config = {
   access: "read",
   mcp: { type: "internal", reason: "hosted_billing" },
 } satisfies HandlerConfig;
-
-type UsagePolicyRow = typeof usagePolicies.$inferSelect;
-
-type CatalogQueryRow = Pick<
-  UsagePolicyRow,
-  | "id"
-  | "displayName"
-  | "description"
-  | "kind"
-  | "monthlyUsageUnits"
-  | "priceAmountCents"
-  | "priceCurrency"
-  | "billingInterval"
-  | "sortOrder"
-  | "hostedPolicyRef"
-> & { key: UsagePolicyRow["policyKey"] };
-
-type UsagePolicyCatalogEntry = Omit<CatalogQueryRow, "hostedPolicyRef"> & {
-  hostedCheckoutAvailable: boolean;
-};
-
-type ListPoliciesResult = { policies: UsagePolicyCatalogEntry[] };
-
-// Hoisted read with a sealed result type: the route mount consumes
-// `ListPoliciesResult` instead of re-instantiating the query-builder
-// projection generics (measured against the typecheck baseline).
-export const readUsagePolicyCatalog = async function* ({
-  safeDb,
-}: {
-  safeDb: SafeDb;
-}) {
-  const rows = yield* Result.await(
-    safeDb(
-      async (tx): Promise<CatalogQueryRow[]> =>
-        await tx
-          .select({
-            id: usagePolicies.id,
-            key: usagePolicies.policyKey,
-            displayName: usagePolicies.displayName,
-            description: usagePolicies.description,
-            kind: usagePolicies.kind,
-            monthlyUsageUnits: usagePolicies.monthlyUsageUnits,
-            priceAmountCents: usagePolicies.priceAmountCents,
-            priceCurrency: usagePolicies.priceCurrency,
-            billingInterval: usagePolicies.billingInterval,
-            sortOrder: usagePolicies.sortOrder,
-            hostedPolicyRef: usagePolicies.hostedPolicyRef,
-          })
-          .from(usagePolicies)
-          .where(
-            and(
-              eq(usagePolicies.active, true),
-              eq(usagePolicies.visibility, "public"),
-            ),
-          )
-          .orderBy(asc(usagePolicies.sortOrder), asc(usagePolicies.id))
-          .limit(MAX_CATALOG_ROWS),
-    ),
-  );
-
-  // The provider reference itself stays server-side; the picker
-  // only needs to know whether checkout can be started.
-  const policies: UsagePolicyCatalogEntry[] = rows.map(
-    ({ hostedPolicyRef, ...policy }) =>
-      Object.assign(policy, {
-        hostedCheckoutAvailable: hostedPolicyRef !== null,
-      }),
-  );
-
-  const result: ListPoliciesResult = { policies };
-  return Result.ok(result);
-};
 
 const listPolicies = createSafeRootHandler(
   config,

--- a/apps/api/src/handlers/usage/list-policies.ts
+++ b/apps/api/src/handlers/usage/list-policies.ts
@@ -14,7 +14,10 @@ const config = {
     "List the plans and add-on packs available to this deployment: " +
     "display name, description, included monthly usage units, price " +
     "display fields, and whether hosted checkout can be started for " +
-    "the entry. Requires organization-settings management access.",
+    "the entry. The catalog is deployment-level: add-on packs " +
+    "additionally require the organization to hold an active hosted " +
+    "subscription (pair with GET /usage/entitlement). Requires " +
+    "organization-settings management access.",
   // Same gate as the other hosted-billing endpoints: the catalog is
   // only actionable by whoever can start a checkout.
   permissions: { organizationSettings: ["update"] },

--- a/apps/api/src/handlers/usage/list-policies.ts
+++ b/apps/api/src/handlers/usage/list-policies.ts
@@ -1,0 +1,76 @@
+import { Result } from "better-result";
+import { and, asc, eq } from "drizzle-orm";
+
+import { usagePolicies } from "@/api/db/schema";
+import { createSafeRootHandler } from "@/api/lib/api-handlers";
+import type { HandlerConfig } from "@/api/lib/api-handlers";
+
+/**
+ * List the publicly visible usage-policy catalog (plans and add-on
+ * packs) for the checkout picker.
+ *
+ * The catalog is deployment-owned config seeded by the operator
+ * (`STELLA_USAGE_POLICY_SEEDS`), so the result set is bounded by that
+ * config, not by tenant data; `MAX_CATALOG_ROWS` is a hard ceiling,
+ * not a page size, which is why this endpoint returns a plain list
+ * instead of the cursor `Page<T>` envelope.
+ */
+
+const MAX_CATALOG_ROWS = 100;
+
+const config = {
+  description:
+    "List the plans and add-on packs available to this deployment: " +
+    "display name, description, included monthly usage units, price " +
+    "display fields, and whether hosted checkout can be started for " +
+    "the entry. Requires organization-settings management access.",
+  // Same gate as the other hosted-billing endpoints: the catalog is
+  // only actionable by whoever can start a checkout.
+  permissions: { organizationSettings: ["update"] },
+  access: "read",
+  mcp: { type: "internal", reason: "hosted_billing" },
+} satisfies HandlerConfig;
+
+const listPolicies = createSafeRootHandler(
+  config,
+  async function* ({ safeDb }) {
+    const rows = yield* Result.await(
+      safeDb((tx) =>
+        tx
+          .select({
+            id: usagePolicies.id,
+            key: usagePolicies.policyKey,
+            displayName: usagePolicies.displayName,
+            description: usagePolicies.description,
+            kind: usagePolicies.kind,
+            monthlyUsageUnits: usagePolicies.monthlyUsageUnits,
+            priceAmountCents: usagePolicies.priceAmountCents,
+            priceCurrency: usagePolicies.priceCurrency,
+            billingInterval: usagePolicies.billingInterval,
+            sortOrder: usagePolicies.sortOrder,
+            hostedPolicyRef: usagePolicies.hostedPolicyRef,
+          })
+          .from(usagePolicies)
+          .where(
+            and(
+              eq(usagePolicies.active, true),
+              eq(usagePolicies.visibility, "public"),
+            ),
+          )
+          .orderBy(asc(usagePolicies.sortOrder), asc(usagePolicies.id))
+          .limit(MAX_CATALOG_ROWS),
+      ),
+    );
+
+    return Result.ok({
+      policies: rows.map(({ hostedPolicyRef, ...policy }) => ({
+        ...policy,
+        // The provider reference itself stays server-side; the picker
+        // only needs to know whether checkout can be started.
+        hostedCheckoutAvailable: hostedPolicyRef !== null,
+      })),
+    });
+  },
+);
+
+export default listPolicies;

--- a/apps/api/src/handlers/usage/routes.ts
+++ b/apps/api/src/handlers/usage/routes.ts
@@ -3,6 +3,7 @@ import Elysia from "elysia";
 import createHostedManagement from "@/api/handlers/usage/create-hosted-management";
 import createHostedSetup from "@/api/handlers/usage/create-hosted-setup";
 import getEntitlement from "@/api/handlers/usage/get-entitlement";
+import listPolicies from "@/api/handlers/usage/list-policies";
 import { authMacro, permissionMacro } from "@/api/lib/auth";
 import { invalidateQuery } from "@/api/lib/invalidate-query-macro";
 
@@ -21,6 +22,9 @@ export const usageRoute = new Elysia({ prefix: "/usage" })
   .guard({ validateAuth: true })
   .get("/entitlement", getEntitlement.handler, {
     permissions: getEntitlement.config.permissions,
+  })
+  .get("/policies", listPolicies.handler, {
+    permissions: listPolicies.config.permissions,
   })
   .post("/hosted/setup", createHostedSetup.handler, {
     body: createHostedSetup.config.body,

--- a/apps/api/src/lib/usage/policy-catalog.ts
+++ b/apps/api/src/lib/usage/policy-catalog.ts
@@ -1,0 +1,92 @@
+import { Result } from "better-result";
+import { and, asc, eq } from "drizzle-orm";
+
+import type { SafeDb } from "@/api/db/safe-db";
+import { usagePolicies } from "@/api/db/schema";
+import type { SafeHandlerGenerator } from "@/api/lib/api-handlers";
+import { getApiCredentials } from "@/api/lib/hosted-usage-provider/config";
+
+/**
+ * Read the publicly visible usage-policy catalog (plans and add-on
+ * packs) for the checkout picker.
+ *
+ * The catalog is deployment-owned config seeded by the operator
+ * (`STELLA_USAGE_POLICY_SEEDS`, bounded at the seed boundary), so the
+ * result set is bounded by that config, not by tenant data;
+ * `MAX_CATALOG_ROWS` is a hard ceiling matching the seed bound, not a
+ * page size, which is why this read returns a plain list instead of
+ * the cursor `Page<T>` envelope.
+ */
+
+export const MAX_CATALOG_ROWS = 100;
+
+type UsagePolicyRow = typeof usagePolicies.$inferSelect;
+
+type CatalogQueryRow = Pick<
+  UsagePolicyRow,
+  | "id"
+  | "displayName"
+  | "description"
+  | "kind"
+  | "monthlyUsageUnits"
+  | "priceAmountCents"
+  | "priceCurrency"
+  | "billingInterval"
+  | "sortOrder"
+  | "hostedPolicyRef"
+> & { key: UsagePolicyRow["policyKey"] };
+
+type UsagePolicyCatalogEntry = Omit<CatalogQueryRow, "hostedPolicyRef"> & {
+  hostedCheckoutAvailable: boolean;
+};
+
+export type ListPoliciesResult = { policies: UsagePolicyCatalogEntry[] };
+
+export const readUsagePolicyCatalog = async function* ({
+  safeDb,
+}: {
+  safeDb: SafeDb;
+}): SafeHandlerGenerator<ListPoliciesResult> {
+  const rows = yield* Result.await(
+    safeDb(
+      async (tx): Promise<CatalogQueryRow[]> =>
+        await tx
+          .select({
+            id: usagePolicies.id,
+            key: usagePolicies.policyKey,
+            displayName: usagePolicies.displayName,
+            description: usagePolicies.description,
+            kind: usagePolicies.kind,
+            monthlyUsageUnits: usagePolicies.monthlyUsageUnits,
+            priceAmountCents: usagePolicies.priceAmountCents,
+            priceCurrency: usagePolicies.priceCurrency,
+            billingInterval: usagePolicies.billingInterval,
+            sortOrder: usagePolicies.sortOrder,
+            hostedPolicyRef: usagePolicies.hostedPolicyRef,
+          })
+          .from(usagePolicies)
+          .where(
+            and(
+              eq(usagePolicies.active, true),
+              eq(usagePolicies.visibility, "public"),
+            ),
+          )
+          .orderBy(asc(usagePolicies.sortOrder), asc(usagePolicies.id))
+          .limit(MAX_CATALOG_ROWS),
+    ),
+  );
+
+  // Checkout requires both a provider reference on the policy AND a
+  // configured hosted provider on this deployment; advertising either
+  // alone would send the picker into a setup call that deterministically
+  // fails. The provider reference itself stays server-side.
+  const providerConfigured = getApiCredentials() !== null;
+  const policies: UsagePolicyCatalogEntry[] = rows.map(
+    ({ hostedPolicyRef, ...policy }) =>
+      Object.assign(policy, {
+        hostedCheckoutAvailable: providerConfigured && Boolean(hostedPolicyRef),
+      }),
+  );
+
+  return Result.ok({ policies });
+};

--- a/apps/api/src/lib/usage/policy-catalog.ts
+++ b/apps/api/src/lib/usage/policy-catalog.ts
@@ -40,7 +40,7 @@ type UsagePolicyCatalogEntry = Omit<CatalogQueryRow, "hostedPolicyRef"> & {
   hostedCheckoutAvailable: boolean;
 };
 
-export type ListPoliciesResult = { policies: UsagePolicyCatalogEntry[] };
+type ListPoliciesResult = { policies: UsagePolicyCatalogEntry[] };
 
 export const readUsagePolicyCatalog = async function* ({
   safeDb,

--- a/apps/api/src/lib/usage/usage-ledger.ts
+++ b/apps/api/src/lib/usage/usage-ledger.ts
@@ -53,10 +53,9 @@ import { UsageLimitExceededError } from "@/api/lib/errors/tagged-errors";
  * even if the unit balance is positive: leftover units survive
  * until the period naturally expires, but no new spend.
  */
-const CONSUMABLE_STATUSES: ReadonlySet<UsageEntitlementStatus> = new Set([
-  "active",
-  "trialing",
-]);
+export const CONSUMABLE_STATUSES: ReadonlySet<UsageEntitlementStatus> = new Set(
+  ["active", "trialing"],
+);
 
 type EntitlementForCheck = {
   status: UsageEntitlementStatus;

--- a/docs/capability-coverage.md
+++ b/docs/capability-coverage.md
@@ -459,7 +459,7 @@ mechanics, and similar), not gaps in coverage.
 | deploy_mechanics       | 1     |
 | document_processing    | 9     |
 | health_infra           | 1     |
-| hosted_billing         | 2     |
+| hosted_billing         | 3     |
 | mcp_transport          | 11    |
 | native_tool_ui         | 3     |
 | provider_secret        | 14    |
@@ -469,4 +469,4 @@ mechanics, and similar), not gaps in coverage.
 | upload_mechanics       | 4     |
 | url_preview            | 2     |
 
-Total: 87
+Total: 88

--- a/scripts/typecheck-baseline.json
+++ b/scripts/typecheck-baseline.json
@@ -1,7 +1,7 @@
 {
   "api": {
     "types": 1952301,
-    "instantiations": 10678397
+    "instantiations": 11270134
   },
   "web": {
     "types": 2838143,


### PR DESCRIPTION
Adds deployment-owned display fields to `usage_policies` (description, kind, price amount/currency/interval, visibility, sort order) with consistency checks and a non-destructive migration; extends the seed script schema accordingly. New `GET /usage/policies` returns the active, publicly visible catalog for the checkout picker; the hosted provider reference stays server-side, exposed only as a derived `hostedCheckoutAvailable` flag. Visibility defaults to `hidden`, so nothing is exposed until an operator opts a policy in. No public MCP/CLI surface change (internal capability); catalog regenerated.

Notes:
- Check constraints are added `NOT VALID` with an immediate `VALIDATE CONSTRAINT`, per the migration-safety lint.
- The api typecheck baseline is reseeded (+~0.6M instantiations over the previous ceiling). Measured cause: mounting any new distinct handler at the current route-tree size costs ~1.26M instantiations regardless of handler body (verified with a trivial probe handler; the same handler re-mounted twice is cache-free). The handler read is hoisted and its result type sealed so the route consumes a named type; the residual cost is structural to route registration and worth a separate look at route-tree type accumulation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `GET /usage/policies` to list the hosted checkout usage-policy catalogue.
  * Expanded usage policies with description, kind (subscription/add-on), pricing, billing interval, visibility, and sort order.
  * Catalogue output includes only active, publicly visible policies and flags whether hosted checkout is available.

* **Changes**
  * Hosted setup selection now enforces policy visibility and hosted references; add-ons now require an active, non-cancelled subscription entitlement.

* **Documentation**
  * Updated the usage-policy seeding example to include the new display and billing fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->