### PR TITLE
feat(onboarding): suggest practice jurisdictions from the signup country

### DIFF
--- a/apps/api/drizzle/20260727170000_user_detected_country/migration.sql
+++ b/apps/api/drizzle/20260727170000_user_detected_country/migration.sql
@@ -1,0 +1,4 @@
+SET lock_timeout = '1s';--> statement-breakpoint
+SET statement_timeout = '5s';--> statement-breakpoint
+ALTER TABLE "user" ADD COLUMN "detected_country" text;--> statement-breakpoint
+GRANT SELECT (detected_country) ON TABLE "user" TO stella;

--- a/apps/api/src/db/auth-schema.ts
+++ b/apps/api/src/db/auth-schema.ts
@@ -29,6 +29,10 @@ export const user = pgTable(
     timezoneId: text("timezone_id").default("UTC").notNull(),
     preferredName: text("preferred_name"),
     wordEditShortcut: text("word_edit_shortcut"),
+    // ISO 3166-1 alpha-2 code captured from the edge at signup; seeds the
+    // practice-jurisdiction suggestion in onboarding. Null when the edge
+    // did not advertise a country (local dev, self-hosted without a proxy).
+    detectedCountry: text("detected_country"),
     twoFactorEnabled: boolean("two_factor_enabled").default(false).notNull(),
     deletedAt: timestamp("deleted_at"),
     createdAt: timestamp("created_at").defaultNow().notNull(),
@@ -65,6 +69,7 @@ export const AUTH_USER_STELLA_SELECT_COLUMNS = {
   timezoneId: "timezone_id",
   preferredName: "preferred_name",
   wordEditShortcut: "word_edit_shortcut",
+  detectedCountry: "detected_country",
   twoFactorEnabled: "two_factor_enabled",
   deletedAt: "deleted_at",
   createdAt: "created_at",

--- a/apps/api/src/handlers/operator/query.test.ts
+++ b/apps/api/src/handlers/operator/query.test.ts
@@ -211,6 +211,7 @@ describe("queryRegistrationsPage", () => {
       for (const item of firstPage.items) {
         expect(Object.keys(item).sort()).toEqual([
           "createdAt",
+          "detectedCountry",
           "email",
           "id",
           "name",
@@ -220,6 +221,7 @@ describe("queryRegistrationsPage", () => {
         id: "op-reg-a",
         name: "Registration A",
         email: "op-reg-a@example.test",
+        detectedCountry: null,
         createdAt: expect.any(Date),
       });
 

--- a/apps/api/src/handlers/operator/query.ts
+++ b/apps/api/src/handlers/operator/query.ts
@@ -188,6 +188,7 @@ export const queryRegistrationsPage = async function* ({
             id: user.id,
             email: user.email,
             name: user.name,
+            detectedCountry: user.detectedCountry,
             createdAt: user.createdAt,
             createdAtCursor:
               registrationCursor.cursorValue.as("created_at_cursor"),

--- a/apps/api/src/handlers/operator/read-registrations.test.ts
+++ b/apps/api/src/handlers/operator/read-registrations.test.ts
@@ -22,6 +22,7 @@ type MockRow = {
   id: string;
   email: string;
   name: string;
+  detectedCountry: string | null;
   createdAt: Date;
   createdAtCursor: string;
 };
@@ -30,6 +31,7 @@ const mockRow = (id: string): MockRow => ({
   id,
   email: `${id}@example.test`,
   name: `User ${id}`,
+  detectedCountry: null,
   createdAt: daysAgo(2),
   createdAtCursor: "2026-07-10T12:00:00.000000",
 });
@@ -160,7 +162,7 @@ describe("GET /operator/registrations", () => {
     expect(response.status).toBe(400);
   });
 
-  test("200 with the Page envelope and exactly four item fields on a correct token", async () => {
+  test("200 with the Page envelope and exactly five item fields on a correct token", async () => {
     const app = buildApp({
       configuredToken: TOKEN,
       rows: [mockRow("op-route-a"), mockRow("op-route-b")],
@@ -184,6 +186,7 @@ describe("GET /operator/registrations", () => {
     for (const item of page.items) {
       expect(Object.keys(item).sort()).toEqual([
         "createdAt",
+        "detectedCountry",
         "email",
         "id",
         "name",

--- a/apps/api/src/lib/auth.ts
+++ b/apps/api/src/lib/auth.ts
@@ -41,6 +41,7 @@ import { toSafeId } from "@/api/lib/branded-types";
 import type { SafeId } from "@/api/lib/branded-types";
 import { verifyConfirmationOtp } from "@/api/lib/confirmation-otp";
 import { isUuid, tUuid } from "@/api/lib/custom-schema";
+import { detectedCountryFromRequestContext } from "@/api/lib/detected-country";
 import { DEV_INSPECTOR_ORIGINS, frontendOrigins } from "@/api/lib/dev-origins";
 import { stashDevOtp } from "@/api/lib/dev-otp-store";
 import {
@@ -551,6 +552,13 @@ const createAuth = () => {
           type: "string",
           required: false,
         },
+        // Server-owned: captured from the edge's viewer-country header in
+        // the user-create hook below; client input is ignored.
+        detectedCountry: {
+          type: "string",
+          required: false,
+          input: false,
+        },
       },
     },
     session: {
@@ -616,7 +624,7 @@ const createAuth = () => {
     databaseHooks: {
       user: {
         create: {
-          before: async (user) => {
+          before: async (user, ctx) => {
             validateTimezoneId(user["timezoneId"]);
             // Email-OTP and some social providers leave `name` blank.
             // The `notNull` schema constraint allows empty strings, which
@@ -625,7 +633,10 @@ const createAuth = () => {
             // Then trim `preferredName` / `wordEditShortcut` (Word author /
             // initials prefs) before persisting.
             const data = normalizeUserPreferences(ensureDisplayName(user));
-            return await Promise.resolve({ data });
+            const detectedCountry = detectedCountryFromRequestContext(ctx);
+            return await Promise.resolve({
+              data: detectedCountry ? { ...data, detectedCountry } : data,
+            });
           },
         },
         update: {

--- a/apps/api/src/lib/detected-country.test.ts
+++ b/apps/api/src/lib/detected-country.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  detectedCountryFromRequestContext,
+  VIEWER_COUNTRY_HEADER,
+} from "@/api/lib/detected-country";
+
+const contextWithHeader = (value: string) => ({
+  request: new Request("https://api.example.test/sign-up", {
+    headers: { [VIEWER_COUNTRY_HEADER]: value },
+  }),
+});
+
+describe("detectedCountryFromRequestContext", () => {
+  test("accepts a known ISO code and normalizes case", () => {
+    expect(detectedCountryFromRequestContext(contextWithHeader("cz"))).toBe(
+      "CZ",
+    );
+    expect(detectedCountryFromRequestContext(contextWithHeader("US"))).toBe(
+      "US",
+    );
+  });
+
+  test.each(["ZZ", "A1", "EU", "", "Czechia"])(
+    "rejects the non-ISO edge value %j",
+    (value) => {
+      expect(
+        detectedCountryFromRequestContext(contextWithHeader(value)),
+      ).toBeUndefined();
+    },
+  );
+
+  test("returns undefined without a request context or header", () => {
+    expect(detectedCountryFromRequestContext(undefined)).toBeUndefined();
+    expect(
+      detectedCountryFromRequestContext({
+        request: new Request("https://api.example.test/sign-up"),
+      }),
+    ).toBeUndefined();
+  });
+
+  test("falls back to bare headers when no request is present", () => {
+    expect(
+      detectedCountryFromRequestContext({
+        headers: new Headers({ [VIEWER_COUNTRY_HEADER]: "SK" }),
+      }),
+    ).toBe("SK");
+  });
+});

--- a/apps/api/src/lib/detected-country.ts
+++ b/apps/api/src/lib/detected-country.ts
@@ -1,0 +1,33 @@
+import { type CountryCode, isCountryCode } from "@stll/country-codes";
+
+/**
+ * Added by the CDN at the edge when the distribution's origin request
+ * policy forwards CloudFront's generated headers. Absent when the API is
+ * reached directly (local dev, tests, self-hosted deployments without a
+ * geo-aware proxy), in which case no country is recorded.
+ */
+export const VIEWER_COUNTRY_HEADER = "cloudfront-viewer-country";
+
+type RequestContextLike = {
+  request?: Request;
+  headers?: Headers;
+};
+
+/**
+ * Resolve the signup country advertised by the edge, used to suggest
+ * practice jurisdictions during onboarding. Returns undefined for any
+ * value that is not a known ISO 3166-1 alpha-2 code (CloudFront also
+ * emits pseudo-codes such as "ZZ" for unknown locations).
+ */
+export const detectedCountryFromRequestContext = (
+  ctx: RequestContextLike | undefined,
+): CountryCode | undefined => {
+  const raw =
+    ctx?.request?.headers.get(VIEWER_COUNTRY_HEADER) ??
+    ctx?.headers?.get(VIEWER_COUNTRY_HEADER);
+  if (!raw) {
+    return undefined;
+  }
+  const candidate = raw.toUpperCase();
+  return isCountryCode(candidate) ? candidate : undefined;
+};

--- a/apps/api/src/lib/detected-country.ts
+++ b/apps/api/src/lib/detected-country.ts
@@ -9,8 +9,8 @@ import { type CountryCode, isCountryCode } from "@stll/country-codes";
 export const VIEWER_COUNTRY_HEADER = "cloudfront-viewer-country";
 
 type RequestContextLike = {
-  request?: Request;
-  headers?: Headers;
+  request?: Request | undefined;
+  headers?: Headers | undefined;
 };
 
 /**
@@ -20,7 +20,7 @@ type RequestContextLike = {
  * emits pseudo-codes such as "ZZ" for unknown locations).
  */
 export const detectedCountryFromRequestContext = (
-  ctx: RequestContextLike | undefined,
+  ctx: RequestContextLike | null | undefined,
 ): CountryCode | undefined => {
   const raw =
     ctx?.request?.headers.get(VIEWER_COUNTRY_HEADER) ??

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -111,6 +111,7 @@ const authClientPlugins = [
       preferredName: { type: "string", required: false },
       timezoneId: { type: "string" },
       wordEditShortcut: { type: "string", required: false },
+      detectedCountry: { type: "string", required: false },
     },
   }),
   defineBetterAuthClientPlugin(oauthProviderClient()),

--- a/apps/web/src/lib/jurisdictions.ts
+++ b/apps/web/src/lib/jurisdictions.ts
@@ -101,14 +101,25 @@ export const countryName = (
 export const suggestedCountryCodes = ({
   email,
   locale,
+  detectedCountry,
 }: {
   email: string;
   locale: string;
+  /**
+   * Country recorded server-side at signup from the edge's geo header.
+   * Ranked above the locale and email heuristics because it reflects
+   * where the person actually registered from.
+   */
+  detectedCountry?: string | null;
 }): CountryCode[] => {
   const suggestions: string[] = [];
   const regionFromLocale =
     LOCALE_REGION_PATTERN.exec(locale)?.groups?.["region"];
   const emailTld = email.split(".").at(-1)?.toLowerCase();
+
+  if (detectedCountry) {
+    suggestions.push(detectedCountry.toUpperCase());
+  }
 
   if (regionFromLocale) {
     suggestions.push(regionFromLocale.toUpperCase());

--- a/apps/web/src/lib/jurisdictions.ts
+++ b/apps/web/src/lib/jurisdictions.ts
@@ -110,7 +110,7 @@ export const suggestedCountryCodes = ({
    * Ranked above the locale and email heuristics because it reflects
    * where the person actually registered from.
    */
-  detectedCountry?: string | null;
+  detectedCountry?: string | null | undefined;
 }): CountryCode[] => {
   const suggestions: string[] = [];
   const regionFromLocale =

--- a/apps/web/src/routes/onboarding/-components/onboarding-wizard.tsx
+++ b/apps/web/src/routes/onboarding/-components/onboarding-wizard.tsx
@@ -127,6 +127,7 @@ export const OnboardingWizard = () => {
   const suggestedCountryCodes = getSuggestedCountryCodes({
     email: userEmail,
     locale: navigatorLocale,
+    detectedCountry: sessionData?.user.detectedCountry,
   });
   const [jurisdictionSuggestionApplied, setJurisdictionSuggestionApplied] =
     useState(false);


### PR DESCRIPTION
The onboarding jurisdiction step currently guesses a default from `navigator.language` and the email TLD, which misses most freemail signups. This captures the CDN's `CloudFront-Viewer-Country` header at signup into a server-owned `user.detected_country` field and ranks it first in the suggestion order.

- `detectedCountry` additional field is `input: false` (server-owned; client and provider input ignored) and only persisted when the header carries a real ISO 3166-1 alpha-2 code — CloudFront pseudo-codes (`ZZ`) and absent headers (local dev, self-hosted without a geo-aware proxy) leave it null.
- Migration adds the nullable column plus the `stella`-role column grant (the Better Auth adapter reads full user rows during session resolution).
- `suggestedCountryCodes` ranks detected country > locale region > email TLD; the wizard passes it from the session.
- The operator registrations endpoint now returns the field, so self-hosting operators can see which jurisdictions their signups need; item-shape tests updated.

Requires the CDN to forward CloudFront's generated headers to the api origin (deployed separately); until then the header is absent and behavior is unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatically detects a user’s country during signup when a reliable country signal is available.
  * Uses the detected country to improve country suggestions during onboarding.
  * Includes the detected country in operator registration records where available.
* **Bug Fixes**
  * Ignores invalid, missing, or unsupported country values to prevent inaccurate suggestions.
* **Tests**
  * Added coverage for country detection, validation, and updated registration response payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->