### PR TITLE
feat: add normalized registry records

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -1,7 +1,8 @@
 # Changesets
 
 Pull requests that change the shipped source of `@stll/cli`,
-`@stll/conditions`, `@stll/template-conditions`, or `@stll/docx-utils` must
+`@stll/business-registries`, `@stll/conditions`,
+`@stll/country-codes`, `@stll/template-conditions`, or `@stll/docx-utils` must
 include a Changeset describing the user-visible change and its semver impact.
 
 Run `bun run changeset`, select the affected package(s), and commit the generated

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -10,8 +10,6 @@
   "ignore": [
     "@stll/api",
     "@stll/boe",
-    "@stll/business-registries",
-    "@stll/country-codes",
     "@stll/infosoud",
     "@stll/locales",
     "@stll/text-normalize"

--- a/.changeset/quiet-registry-clients.md
+++ b/.changeset/quiet-registry-clients.md
@@ -1,0 +1,7 @@
+---
+"@stll/business-registries": minor
+---
+
+Add browser-safe clients for Switzerland's Zefix API and Croatia's court
+register, plus explicit normalized entity and search-result projections for
+the Czech, Slovak, British, Polish, French, Swiss, and Croatian adapters.

--- a/.changeset/quiet-registry-clients.md
+++ b/.changeset/quiet-registry-clients.md
@@ -7,3 +7,5 @@ Add browser-safe clients for Switzerland's Zefix API and Croatia's court
 register, plus explicit normalized entity and search-result projections for
 the Czech, Slovak, British, Polish, French, Swiss, and Croatian adapters.
 Publish the canonical country-code types consumed by the registry package.
+Canonicalize registry dates, preserve historical date precision, and reject
+invalid identifiers before branding them.

--- a/.changeset/quiet-registry-clients.md
+++ b/.changeset/quiet-registry-clients.md
@@ -1,7 +1,9 @@
 ---
 "@stll/business-registries": minor
+"@stll/country-codes": patch
 ---
 
 Add browser-safe clients for Switzerland's Zefix API and Croatia's court
 register, plus explicit normalized entity and search-result projections for
 the Czech, Slovak, British, Polish, French, Swiss, and Croatian adapters.
+Publish the canonical country-code types consumed by the registry package.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,14 @@ jobs:
             packages/cli/src/**
             packages/cli/skills/**
             packages/cli/tsconfig.build.json
+            packages/business-registries/README.md
+            packages/business-registries/package.json
+            packages/business-registries/src/**
+            packages/business-registries/tsconfig.build.json
+            packages/country-codes/README.md
+            packages/country-codes/package.json
+            packages/country-codes/src/**
+            packages/country-codes/tsconfig.build.json
             packages/conditions/README.md
             packages/conditions/package.json
             packages/conditions/src/**
@@ -101,6 +109,10 @@ jobs:
             bun.lock
             packages/cli/CHANGELOG.md
             packages/cli/package.json
+            packages/business-registries/CHANGELOG.md
+            packages/business-registries/package.json
+            packages/country-codes/CHANGELOG.md
+            packages/country-codes/package.json
             packages/conditions/CHANGELOG.md
             packages/conditions/package.json
             packages/template-conditions/CHANGELOG.md
@@ -109,6 +121,8 @@ jobs:
             packages/docx-utils/package.json
           package-files: |
             packages/cli/package.json
+            packages/business-registries/package.json
+            packages/country-codes/package.json
             packages/conditions/package.json
             packages/template-conditions/package.json
             packages/docx-utils/package.json

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -20,6 +20,8 @@ on:
     paths:
       # Changesets owns these files, so ordinary manifest maintenance cannot
       # accidentally start a release transaction.
+      - packages/business-registries/CHANGELOG.md
+      - packages/country-codes/CHANGELOG.md
       - packages/conditions/CHANGELOG.md
       - packages/template-conditions/CHANGELOG.md
       - packages/docx-utils/CHANGELOG.md
@@ -33,6 +35,8 @@ on:
         type: choice
         options:
           - all
+          - business-registries
+          - country-codes
           - conditions
           - template-conditions
           - docx-utils
@@ -163,10 +167,10 @@ jobs:
           if [[ "$EVENT_NAME" == "workflow_run" ]]; then
             pkgs=(cli)
           elif [[ "$EVENT_NAME" == "push" ]]; then
-            pkgs=(conditions template-conditions docx-utils)
+            pkgs=(country-codes business-registries conditions template-conditions docx-utils)
           else
             case "$MANUAL_PACKAGE" in
-              all) pkgs=(conditions template-conditions docx-utils cli) ;;
+              all) pkgs=(country-codes business-registries conditions template-conditions docx-utils cli) ;;
               *) pkgs=("$MANUAL_PACKAGE") ;;
             esac
           fi
@@ -284,6 +288,24 @@ jobs:
         with:
           name: npm-tarball-conditions
           path: release-artifacts/conditions/
+          retention-days: 1
+          if-no-files-found: error
+
+      - name: Upload business-registries tarball
+        if: contains(fromJSON(steps.pack.outputs.packages), 'business-registries')
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: npm-tarball-business-registries
+          path: release-artifacts/business-registries/
+          retention-days: 1
+          if-no-files-found: error
+
+      - name: Upload country-codes tarball
+        if: contains(fromJSON(steps.pack.outputs.packages), 'country-codes')
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: npm-tarball-country-codes
+          path: release-artifacts/country-codes/
           retention-days: 1
           if-no-files-found: error
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -32,11 +32,13 @@ pre-push:
   parallel: false
   commands:
     typecheck:
+      # Root scripts and tooling configs are outside Turbo's package graph;
+      # check them explicitly so pre-push matches the CI typecheck boundary.
       # Scoped to packages changed vs. origin/main plus their dependents
       # (turbo `...[ref]` filter). tsgo itself still runs project-wide
       # within each selected package, but unaffected packages are skipped
       # entirely instead of being walked for cache decisions.
-      run: bun run typecheck "--filter=...[origin/main]" --concurrency=2
+      run: bun run typecheck:repo && bun run typecheck "--filter=...[origin/main]" --concurrency=2
     # Lint runs in CI on every push (~10-15 min full-monorepo). Keeping
     # it on pre-push too added another ~15-18 min of waiting that
     # duplicated the CI signal, so the local hook drops it. The

--- a/packages/business-registries/README.md
+++ b/packages/business-registries/README.md
@@ -28,11 +28,13 @@ await ares.lookupByIco("27082440");
 
 ## Supported registries
 
-| Subpath  | Jurisdiction   | Registry                                                                                                                      |
-| -------- | -------------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| `/ares`  | Czech Republic | [ARES](https://ares.gov.cz) — public open API                                                                                 |
-| `/brreg` | Norway         | [Brønnøysundregistrene](https://data.brreg.no/enhetsregisteret/api/docs/index.html) — public open API                         |
-| `/denue` | Mexico         | [INEGI DENUE](https://www.inegi.org.mx/servicios/api_denue.html) — official establishment / economic-unit API; token required |
+| Subpath   | Jurisdiction   | Registry                                                                                                                      |
+| --------- | -------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `/ares`   | Czech Republic | [ARES](https://ares.gov.cz) — public open API                                                                                 |
+| `/brreg`  | Norway         | [Brønnøysundregistrene](https://data.brreg.no/enhetsregisteret/api/docs/index.html) — public open API                         |
+| `/denue`  | Mexico         | [INEGI DENUE](https://www.inegi.org.mx/servicios/api_denue.html) — official establishment / economic-unit API; token required |
+| `/sudreg` | Croatia        | [Sudski registar](https://sudreg.pravosudje.hr) — public company lookup                                                       |
+| `/zefix`  | Switzerland    | [Zefix](https://www.zefix.ch) — public commercial-register search API                                                         |
 
 More jurisdictions land per-PR; see the package README on the main branch for
 the current list.
@@ -49,6 +51,11 @@ Every registry client follows the same contract:
   failure mode.
 - Pure parsers exposed alongside the client so consumers can ingest cached or
   mocked raw payloads without hitting the network.
+
+Adapters also export `toNormalizedEntity` and `toNormalizedSearchResult`
+projections where a domain model is available. Each optional normalized field is
+a discriminated value: it contains data when available, or records that the field
+was not loaded or is not supported by that adapter. These states cannot overlap.
 
 Live integration tests live in `*.test.ts` files guarded by
 `SMOKE_TEST=1` so the unit suite stays offline-safe.

--- a/packages/business-registries/package.json
+++ b/packages/business-registries/package.json
@@ -47,81 +47,21 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
-    ".": {
-      "bun": "./src/index.ts",
-      "types": "./src/index.ts",
-      "import": "./dist/index.js"
-    },
-    "./ares": {
-      "bun": "./src/ares/index.ts",
-      "types": "./src/ares/index.ts",
-      "import": "./dist/ares/index.js"
-    },
-    "./brreg": {
-      "bun": "./src/brreg/index.ts",
-      "types": "./src/brreg/index.ts",
-      "import": "./dist/brreg/index.js"
-    },
-    "./companies-house": {
-      "bun": "./src/companies-house/index.ts",
-      "types": "./src/companies-house/index.ts",
-      "import": "./dist/companies-house/index.js"
-    },
-    "./denue": {
-      "bun": "./src/denue/index.ts",
-      "types": "./src/denue/index.ts",
-      "import": "./dist/denue/index.js"
-    },
-    "./edgar": {
-      "bun": "./src/edgar/index.ts",
-      "types": "./src/edgar/index.ts",
-      "import": "./dist/edgar/index.js"
-    },
-    "./gcis": {
-      "bun": "./src/gcis/index.ts",
-      "types": "./src/gcis/index.ts",
-      "import": "./dist/gcis/index.js"
-    },
-    "./krs": {
-      "bun": "./src/krs/index.ts",
-      "types": "./src/krs/index.ts",
-      "import": "./dist/krs/index.js"
-    },
-    "./orsr": {
-      "bun": "./src/orsr/index.ts",
-      "types": "./src/orsr/index.ts",
-      "import": "./dist/orsr/index.js"
-    },
-    "./prh": {
-      "bun": "./src/prh/index.ts",
-      "types": "./src/prh/index.ts",
-      "import": "./dist/prh/index.js"
-    },
-    "./recherche-entreprises": {
-      "bun": "./src/recherche-entreprises/index.ts",
-      "types": "./src/recherche-entreprises/index.ts",
-      "import": "./dist/recherche-entreprises/index.js"
-    },
-    "./vies": {
-      "bun": "./src/vies/index.ts",
-      "types": "./src/vies/index.ts",
-      "import": "./dist/vies/index.js"
-    },
-    "./shared": {
-      "bun": "./src/shared/index.ts",
-      "types": "./src/shared/index.ts",
-      "import": "./dist/shared/index.js"
-    },
-    "./sudreg": {
-      "bun": "./src/sudreg/index.ts",
-      "types": "./src/sudreg/index.ts",
-      "import": "./dist/sudreg/index.js"
-    },
-    "./zefix": {
-      "bun": "./src/zefix/index.ts",
-      "types": "./src/zefix/index.ts",
-      "import": "./dist/zefix/index.js"
-    }
+    ".": "./src/index.ts",
+    "./ares": "./src/ares/index.ts",
+    "./brreg": "./src/brreg/index.ts",
+    "./companies-house": "./src/companies-house/index.ts",
+    "./denue": "./src/denue/index.ts",
+    "./edgar": "./src/edgar/index.ts",
+    "./gcis": "./src/gcis/index.ts",
+    "./krs": "./src/krs/index.ts",
+    "./orsr": "./src/orsr/index.ts",
+    "./prh": "./src/prh/index.ts",
+    "./recherche-entreprises": "./src/recherche-entreprises/index.ts",
+    "./vies": "./src/vies/index.ts",
+    "./shared": "./src/shared/index.ts",
+    "./sudreg": "./src/sudreg/index.ts",
+    "./zefix": "./src/zefix/index.ts"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/business-registries/package.json
+++ b/packages/business-registries/package.json
@@ -21,8 +21,10 @@
     "registry",
     "sec",
     "sirene",
+    "sudreg",
     "vat",
-    "vies"
+    "vies",
+    "zefix"
   ],
   "homepage": "https://github.com/stella/stella/tree/main/packages/business-registries",
   "bugs": {
@@ -109,6 +111,16 @@
       "bun": "./src/shared/index.ts",
       "types": "./src/shared/index.ts",
       "import": "./dist/shared/index.js"
+    },
+    "./sudreg": {
+      "bun": "./src/sudreg/index.ts",
+      "types": "./src/sudreg/index.ts",
+      "import": "./dist/sudreg/index.js"
+    },
+    "./zefix": {
+      "bun": "./src/zefix/index.ts",
+      "types": "./src/zefix/index.ts",
+      "import": "./dist/zefix/index.js"
     }
   },
   "publishConfig": {

--- a/packages/business-registries/src/ares/index.ts
+++ b/packages/business-registries/src/ares/index.ts
@@ -9,6 +9,8 @@ export {
   AresValidationError,
 } from "./errors.js";
 export { parseAddress, parseResRecord, parseSearchEntry } from "./parse.js";
+export { toNormalizedEntity, toNormalizedSearchResult } from "./normalized.js";
+export type { NormalizeAresOptions } from "./normalized.js";
 export type {
   AresAddress,
   AresBodyMember,

--- a/packages/business-registries/src/ares/normalized.test.ts
+++ b/packages/business-registries/src/ares/normalized.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test } from "bun:test";
+
+import { toNormalizedEntity, toNormalizedSearchResult } from "./normalized.js";
+import type { AresCompany } from "./types.js";
+
+const company: AresCompany = {
+  ico: "27082440",
+  name: "Example a.s.",
+  legalForm: "121",
+  address: {
+    street: "Example Street",
+    houseNumber: "1",
+    orientationNumber: "2",
+    orientationLetter: "A",
+    municipalityPart: "District",
+    municipality: "Prague",
+    postalCode: "11000",
+    district: "Prague",
+    country: "Česká republika",
+    textAddress: "Example Street 1/2A, Prague",
+  },
+  dateEstablished: "2003-08-26",
+  dateRegistered: "2003-08-26",
+  czNace: [],
+  registryUrl: "https://ares.gov.cz/ekonomicke-subjekty?ico=27082440",
+  status: "AKTIVNI",
+  courtFile: { court: "Městský soud v Praze", section: "B", insert: "8573" },
+  shareCapital: "10 000 000 Kc",
+  statutoryBodies: [
+    {
+      organName: "Představenstvo",
+      members: [
+        {
+          name: "Alex Example",
+          role: "člen",
+          address: null,
+          since: "2024-01-01",
+        },
+      ],
+    },
+  ],
+  actingClause: "Two members act jointly.",
+};
+
+describe("ARES normalized projection", () => {
+  test("preserves rich registry fields and declares unsupported fields", () => {
+    const entity = toNormalizedEntity(company, { vrLoaded: true });
+    expect(entity.registryId.scheme).toBe("CZ-ICO");
+    expect(String(entity.registryId.value)).toBe("27082440");
+    expect(entity.registryRecord).toMatchObject({
+      availability: "available",
+      value: { reference: "B 8573 Městský soud v Praze" },
+    });
+    expect(entity.keyPeople).toMatchObject({
+      availability: "available",
+      value: [{ people: [{ name: "Alex Example" }] }],
+    });
+    expect(entity.shareCapital).toMatchObject({
+      availability: "available",
+      value: { text: "10 000 000 Kc" },
+    });
+    expect(entity.nameWithoutLegalForm).toEqual({
+      availability: "not-supported",
+    });
+    expect(entity.shareCapitalPaid).toEqual({
+      availability: "not-supported",
+    });
+  });
+
+  test("does not confuse skipped enrichment with absent registry data", () => {
+    const entity = toNormalizedEntity(company, { vrLoaded: false });
+    expect(entity.keyPeople).toEqual({ availability: "not-loaded" });
+    expect(entity.registryRecord).toEqual({ availability: "not-loaded" });
+    expect(entity.actingClause).toEqual({ availability: "not-loaded" });
+  });
+
+  test("makes sparse search-result coverage explicit", () => {
+    const result = toNormalizedSearchResult({
+      ico: company.ico,
+      name: company.name,
+      address: company.address?.textAddress ?? null,
+    });
+    expect(result).toMatchObject({
+      address: {
+        availability: "available",
+        value: company.address?.textAddress,
+      },
+      legalForm: { availability: "not-supported" },
+      registryUrl: { availability: "not-supported" },
+      status: { availability: "not-supported" },
+    });
+  });
+});

--- a/packages/business-registries/src/ares/normalized.ts
+++ b/packages/business-registries/src/ares/normalized.ts
@@ -1,7 +1,7 @@
 import {
   availableField,
-  fromValidatedRegistryIdentifier,
   notLoadedField,
+  toValidatedRegistryIdentifier,
   unsupportedField,
 } from "../shared/normalized.js";
 import type {
@@ -11,6 +11,7 @@ import type {
   NormalizedRegistrySearchResult,
 } from "../shared/normalized.js";
 import type { AresAddress, AresCompany, AresSearchResult } from "./types.js";
+import { validateIco } from "./validation.js";
 
 const normalizeAddress = (address: AresAddress): NormalizedRegistryAddress => ({
   streetName: address.street,
@@ -55,7 +56,11 @@ export const toNormalizedEntity = (
   options: NormalizeAresOptions,
 ): NormalizedRegistryEntity => ({
   country: "CZ",
-  registryId: fromValidatedRegistryIdentifier("CZ-ICO", company.ico),
+  registryId: toValidatedRegistryIdentifier({
+    scheme: "CZ-ICO",
+    value: company.ico,
+    validate: validateIco,
+  }),
   identifiers: [],
   name: company.name,
   nameWithoutLegalForm: unsupportedField(),
@@ -108,7 +113,11 @@ export const toNormalizedSearchResult = (
   result: AresSearchResult,
 ): NormalizedRegistrySearchResult => ({
   country: "CZ",
-  registryId: fromValidatedRegistryIdentifier("CZ-ICO", result.ico),
+  registryId: toValidatedRegistryIdentifier({
+    scheme: "CZ-ICO",
+    value: result.ico,
+    validate: validateIco,
+  }),
   name: result.name,
   legalForm: unsupportedField(),
   status: unsupportedField(),

--- a/packages/business-registries/src/ares/normalized.ts
+++ b/packages/business-registries/src/ares/normalized.ts
@@ -1,0 +1,117 @@
+import {
+  availableField,
+  fromValidatedRegistryIdentifier,
+  notLoadedField,
+  unsupportedField,
+} from "../shared/normalized.js";
+import type {
+  NormalizedRegistryAddress,
+  NormalizedRegistryEntity,
+  NormalizedRegistryKeyPeopleGroup,
+  NormalizedRegistrySearchResult,
+} from "../shared/normalized.js";
+import type { AresAddress, AresCompany, AresSearchResult } from "./types.js";
+
+const normalizeAddress = (address: AresAddress): NormalizedRegistryAddress => ({
+  streetName: address.street,
+  houseNumber: address.houseNumber,
+  orientationNumber: address.orientationNumber,
+  orientationLetter: address.orientationLetter,
+  municipalityPart: address.municipalityPart,
+  municipality: address.municipality,
+  postalCode: address.postalCode,
+  county: address.district,
+  stateName: address.country,
+  textAddress: address.textAddress,
+});
+
+const normalizeKeyPeople = (
+  company: AresCompany,
+): NormalizedRegistryKeyPeopleGroup[] =>
+  company.statutoryBodies.map((body) => ({
+    name: body.organName,
+    people: body.members.map((member) => ({
+      name: member.name,
+      nameWithTitles: null,
+      position: member.role,
+      organName: body.organName,
+      since: member.since,
+      address: member.address,
+      citizenship: null,
+      birthDate: null,
+      identifier: null,
+      share: null,
+      link: null,
+    })),
+  }));
+
+export type NormalizeAresOptions = {
+  /** Whether the separate commercial-register enrichment was loaded. */
+  vrLoaded: boolean;
+};
+
+export const toNormalizedEntity = (
+  company: AresCompany,
+  options: NormalizeAresOptions,
+): NormalizedRegistryEntity => ({
+  country: "CZ",
+  registryId: fromValidatedRegistryIdentifier("CZ-ICO", company.ico),
+  identifiers: [],
+  name: company.name,
+  nameWithoutLegalForm: unsupportedField(),
+  legalForm: availableField(
+    company.legalForm ? { code: company.legalForm, label: null } : null,
+  ),
+  status: unsupportedField(),
+  statusDetail: company.status,
+  address: availableField(
+    company.address ? normalizeAddress(company.address) : null,
+  ),
+  creationDate: availableField(company.dateEstablished),
+  registrationDate: availableField(company.dateRegistered),
+  removalDate: unsupportedField(),
+  registryRecord: options.vrLoaded
+    ? availableField(
+        company.courtFile
+          ? {
+              courtName: company.courtFile.court,
+              section: company.courtFile.section,
+              idNumber: company.courtFile.insert,
+              reference: [
+                company.courtFile.section,
+                company.courtFile.insert,
+                company.courtFile.court,
+              ].join(" "),
+            }
+          : null,
+      )
+    : notLoadedField(),
+  keyPeople: options.vrLoaded
+    ? availableField(normalizeKeyPeople(company))
+    : notLoadedField(),
+  shareCapital: options.vrLoaded
+    ? availableField(
+        company.shareCapital
+          ? { text: company.shareCapital, amount: null, currency: null }
+          : null,
+      )
+    : notLoadedField(),
+  shareCapitalPaid: unsupportedField(),
+  actingClause: options.vrLoaded
+    ? availableField(company.actingClause)
+    : notLoadedField(),
+  registryUrl: availableField(company.registryUrl),
+  warnings: unsupportedField(),
+});
+
+export const toNormalizedSearchResult = (
+  result: AresSearchResult,
+): NormalizedRegistrySearchResult => ({
+  country: "CZ",
+  registryId: fromValidatedRegistryIdentifier("CZ-ICO", result.ico),
+  name: result.name,
+  legalForm: unsupportedField(),
+  status: unsupportedField(),
+  address: availableField(result.address),
+  registryUrl: unsupportedField(),
+});

--- a/packages/business-registries/src/companies-house/index.ts
+++ b/packages/business-registries/src/companies-house/index.ts
@@ -20,6 +20,8 @@ export {
   parseSearchItem,
   parseSearchResponse,
 } from "./parse.js";
+export { toNormalizedEntity, toNormalizedSearchResult } from "./normalized.js";
+export type { NormalizeCompaniesHouseOptions } from "./normalized.js";
 export type {
   CompaniesHouseAccounts,
   CompaniesHouseAddress,

--- a/packages/business-registries/src/companies-house/normalized.test.ts
+++ b/packages/business-registries/src/companies-house/normalized.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "bun:test";
+
+import companyFixture from "./__fixtures__/company-tesco.json" with { type: "json" };
+import officersFixture from "./__fixtures__/officers-tesco.json" with { type: "json" };
+import searchFixture from "./__fixtures__/search-tesco.json" with { type: "json" };
+import { toNormalizedEntity, toNormalizedSearchResult } from "./normalized.js";
+import {
+  parseCompanyProfile,
+  parseOfficersResponse,
+  parseSearchResponse,
+} from "./parse.js";
+import type {
+  CompaniesHouseRawCompanyProfile,
+  CompaniesHouseRawOfficersResponse,
+  CompaniesHouseRawSearchResponse,
+} from "./types.js";
+
+/* eslint-disable typescript-eslint/no-unsafe-type-assertion -- captured official fixtures */
+const companyRaw = companyFixture as unknown as CompaniesHouseRawCompanyProfile;
+const officersRaw =
+  officersFixture as unknown as CompaniesHouseRawOfficersResponse;
+const searchRaw = searchFixture as unknown as CompaniesHouseRawSearchResponse;
+/* eslint-enable typescript-eslint/no-unsafe-type-assertion */
+
+describe("Companies House normalized projection", () => {
+  test("distinguishes separately loaded officers from unsupported fields", () => {
+    const company = parseCompanyProfile(companyRaw);
+    const withoutOfficers = toNormalizedEntity(company);
+    expect(withoutOfficers.keyPeople).toEqual({ availability: "not-loaded" });
+
+    const withOfficers = toNormalizedEntity(company, {
+      officers: parseOfficersResponse(officersRaw),
+    });
+    expect(withOfficers.keyPeople.availability).toBe("available");
+    if (withOfficers.keyPeople.availability !== "available") {
+      return;
+    }
+    expect(withOfficers.keyPeople.value[0]?.people.length).toBeGreaterThan(0);
+    const datedOfficer = withOfficers.keyPeople.value[0]?.people.find(
+      (person) => person.birthDate !== null,
+    );
+    expect(datedOfficer?.birthDate?.precision).toBe("month");
+    expect(withOfficers.shareCapital).toEqual({
+      availability: "not-supported",
+    });
+  });
+
+  test("keeps status, address, legal form, and URL in search rows", () => {
+    const first = parseSearchResponse(searchRaw)[0];
+    expect(first).toBeDefined();
+    if (!first) {
+      return;
+    }
+    const result = toNormalizedSearchResult(first);
+    expect(result.registryId.scheme).toBe("GB-CRN");
+    expect(result).toMatchObject({
+      address: { availability: "available" },
+      legalForm: { availability: "available" },
+      registryUrl: { availability: "available" },
+      status: { availability: "available" },
+    });
+  });
+});

--- a/packages/business-registries/src/companies-house/normalized.test.ts
+++ b/packages/business-registries/src/companies-house/normalized.test.ts
@@ -60,4 +60,58 @@ describe("Companies House normalized projection", () => {
       status: { availability: "available" },
     });
   });
+
+  test("does not present a historical appointment bound as an exact date", () => {
+    const company = parseCompanyProfile(companyRaw);
+    const sourceOfficer = parseOfficersResponse(officersRaw).at(0);
+    expect(sourceOfficer).toBeDefined();
+    if (!sourceOfficer) {
+      return;
+    }
+    const entity = toNormalizedEntity(company, {
+      officers: [
+        {
+          ...sourceOfficer,
+          appointedOn: null,
+          appointedBefore: "1992-01-01",
+        },
+      ],
+    });
+    expect(entity.keyPeople.availability).toBe("available");
+    if (entity.keyPeople.availability !== "available") {
+      return;
+    }
+    expect(entity.keyPeople.value.at(0)?.people.at(0)?.since).toBeNull();
+  });
+
+  test("preserves a known cessation date for removed companies", () => {
+    const company = parseCompanyProfile(companyRaw);
+    const removedAt = "2015-05-05";
+    expect(
+      toNormalizedEntity({
+        ...company,
+        status: { type: "removed" },
+        dateOfCessation: removedAt,
+      }).status,
+    ).toEqual({
+      availability: "available",
+      value: { type: "deleted", at: removedAt },
+    });
+
+    const searchResult = parseSearchResponse(searchRaw).at(0);
+    expect(searchResult).toBeDefined();
+    if (!searchResult) {
+      return;
+    }
+    expect(
+      toNormalizedSearchResult({
+        ...searchResult,
+        status: { type: "removed" },
+        dateOfCessation: removedAt,
+      }).status,
+    ).toEqual({
+      availability: "available",
+      value: { type: "deleted", at: removedAt },
+    });
+  });
 });

--- a/packages/business-registries/src/companies-house/normalized.ts
+++ b/packages/business-registries/src/companies-house/normalized.ts
@@ -1,7 +1,7 @@
 import {
   availableField,
-  fromValidatedRegistryIdentifier,
   notLoadedField,
+  toValidatedRegistryIdentifier,
   unsupportedField,
 } from "../shared/normalized.js";
 import type {
@@ -18,8 +18,16 @@ import type {
   CompaniesHouseOfficer,
   CompaniesHouseSearchResult,
 } from "./types.js";
+import { validateCompanyNumber } from "./validation.js";
 
-const normalizeStatus = (status: CompaniesHouseEntityStatus): EntityStatus => {
+type NormalizeStatusOptions = {
+  removedAt: string | null;
+};
+
+const normalizeStatus = (
+  status: CompaniesHouseEntityStatus,
+  { removedAt }: NormalizeStatusOptions,
+): EntityStatus => {
   switch (status.type) {
     case "active":
     case "open":
@@ -32,7 +40,7 @@ const normalizeStatus = (status: CompaniesHouseEntityStatus): EntityStatus => {
     case "insolvency-proceedings":
       return { type: "bankruptcy" };
     case "removed":
-      return { type: "deleted", at: null };
+      return { type: "deleted", at: removedAt };
     case "administration":
     case "closed":
     case "converted-closed":
@@ -70,7 +78,9 @@ const normalizeOfficer = (
   nameWithTitles: null,
   position: officer.role.title ?? officer.role.code,
   organName: null,
-  since: officer.appointedOn ?? officer.appointedBefore,
+  // `appointedBefore` is only an upper bound for historical records, not an
+  // exact appointment date. The normalized `since` field carries exact dates.
+  since: officer.appointedOn,
   address: officer.address?.textAddress ?? null,
   citizenship: officer.nationality,
   birthDate: officer.dateOfBirth
@@ -94,14 +104,20 @@ export const toNormalizedEntity = (
   options?: NormalizeCompaniesHouseOptions,
 ): NormalizedRegistryEntity => ({
   country: "GB",
-  registryId: fromValidatedRegistryIdentifier("GB-CRN", company.companyNumber),
+  registryId: toValidatedRegistryIdentifier({
+    scheme: "GB-CRN",
+    value: company.companyNumber,
+    validate: validateCompanyNumber,
+  }),
   identifiers: [],
   name: company.name,
   nameWithoutLegalForm: unsupportedField(),
   legalForm: availableField(
     company.type ? { code: company.type, label: null } : null,
   ),
-  status: availableField(normalizeStatus(company.status)),
+  status: availableField(
+    normalizeStatus(company.status, { removedAt: company.dateOfCessation }),
+  ),
   statusDetail: company.statusDetail ?? company.status.type,
   address: availableField(
     company.registeredOfficeAddress
@@ -128,12 +144,18 @@ export const toNormalizedSearchResult = (
   result: CompaniesHouseSearchResult,
 ): NormalizedRegistrySearchResult => ({
   country: "GB",
-  registryId: fromValidatedRegistryIdentifier("GB-CRN", result.companyNumber),
+  registryId: toValidatedRegistryIdentifier({
+    scheme: "GB-CRN",
+    value: result.companyNumber,
+    validate: validateCompanyNumber,
+  }),
   name: result.name,
   legalForm: availableField(
     result.type ? { code: result.type, label: null } : null,
   ),
-  status: availableField(normalizeStatus(result.status)),
+  status: availableField(
+    normalizeStatus(result.status, { removedAt: result.dateOfCessation }),
+  ),
   address: availableField(result.address),
   registryUrl: availableField(result.registryUrl),
 });

--- a/packages/business-registries/src/companies-house/normalized.ts
+++ b/packages/business-registries/src/companies-house/normalized.ts
@@ -1,0 +1,139 @@
+import {
+  availableField,
+  fromValidatedRegistryIdentifier,
+  notLoadedField,
+  unsupportedField,
+} from "../shared/normalized.js";
+import type {
+  NormalizedRegistryAddress,
+  NormalizedRegistryEntity,
+  NormalizedRegistryKeyPerson,
+  NormalizedRegistrySearchResult,
+} from "../shared/normalized.js";
+import type { EntityStatus } from "../shared/status.js";
+import type {
+  CompaniesHouseAddress,
+  CompaniesHouseCompany,
+  CompaniesHouseEntityStatus,
+  CompaniesHouseOfficer,
+  CompaniesHouseSearchResult,
+} from "./types.js";
+
+const normalizeStatus = (status: CompaniesHouseEntityStatus): EntityStatus => {
+  switch (status.type) {
+    case "active":
+    case "open":
+    case "registered":
+      return { type: "active" };
+    case "dissolved":
+      return { type: "dissolved" };
+    case "liquidation":
+      return { type: "liquidating" };
+    case "insolvency-proceedings":
+      return { type: "bankruptcy" };
+    case "removed":
+      return { type: "deleted", at: null };
+    case "administration":
+    case "closed":
+    case "converted-closed":
+    case "receivership":
+    case "voluntary-arrangement":
+      return { type: "inactive" };
+    case "unknown":
+      return { type: "unknown" };
+    default: {
+      const unreachable: never = status;
+      return unreachable;
+    }
+  }
+};
+
+const normalizeAddress = (
+  address: CompaniesHouseAddress,
+): NormalizedRegistryAddress => ({
+  streetName: address.addressLine1,
+  houseNumber: address.premises,
+  orientationNumber: null,
+  orientationLetter: null,
+  municipalityPart: address.addressLine2,
+  municipality: address.locality,
+  postalCode: address.postalCode,
+  county: address.region,
+  stateName: address.country,
+  textAddress: address.textAddress,
+});
+
+const normalizeOfficer = (
+  officer: CompaniesHouseOfficer,
+): NormalizedRegistryKeyPerson => ({
+  name: officer.name,
+  nameWithTitles: null,
+  position: officer.role.title ?? officer.role.code,
+  organName: null,
+  since: officer.appointedOn ?? officer.appointedBefore,
+  address: officer.address?.textAddress ?? null,
+  citizenship: officer.nationality,
+  birthDate: officer.dateOfBirth
+    ? {
+        value: `${officer.dateOfBirth.year}-${String(officer.dateOfBirth.month).padStart(2, "0")}`,
+        precision: "month",
+      }
+    : null,
+  identifier: officer.identification?.registrationNumber ?? null,
+  share: null,
+  link: null,
+});
+
+export type NormalizeCompaniesHouseOptions = {
+  /** Officers returned by the separate Companies House officers endpoint. */
+  officers?: CompaniesHouseOfficer[];
+};
+
+export const toNormalizedEntity = (
+  company: CompaniesHouseCompany,
+  options?: NormalizeCompaniesHouseOptions,
+): NormalizedRegistryEntity => ({
+  country: "GB",
+  registryId: fromValidatedRegistryIdentifier("GB-CRN", company.companyNumber),
+  identifiers: [],
+  name: company.name,
+  nameWithoutLegalForm: unsupportedField(),
+  legalForm: availableField(
+    company.type ? { code: company.type, label: null } : null,
+  ),
+  status: availableField(normalizeStatus(company.status)),
+  statusDetail: company.statusDetail ?? company.status.type,
+  address: availableField(
+    company.registeredOfficeAddress
+      ? normalizeAddress(company.registeredOfficeAddress)
+      : null,
+  ),
+  creationDate: availableField(company.dateOfCreation),
+  registrationDate: unsupportedField(),
+  removalDate: availableField(company.dateOfCessation),
+  registryRecord: unsupportedField(),
+  keyPeople: options?.officers
+    ? availableField([
+        { name: null, people: options.officers.map(normalizeOfficer) },
+      ])
+    : notLoadedField(),
+  shareCapital: unsupportedField(),
+  shareCapitalPaid: unsupportedField(),
+  actingClause: unsupportedField(),
+  registryUrl: availableField(company.registryUrl),
+  warnings: unsupportedField(),
+});
+
+export const toNormalizedSearchResult = (
+  result: CompaniesHouseSearchResult,
+): NormalizedRegistrySearchResult => ({
+  country: "GB",
+  registryId: fromValidatedRegistryIdentifier("GB-CRN", result.companyNumber),
+  name: result.name,
+  legalForm: availableField(
+    result.type ? { code: result.type, label: null } : null,
+  ),
+  status: availableField(normalizeStatus(result.status)),
+  address: availableField(result.address),
+  registryUrl: availableField(result.registryUrl),
+});

--- a/packages/business-registries/src/index.ts
+++ b/packages/business-registries/src/index.ts
@@ -21,4 +21,6 @@ export * as orsr from "./orsr/index.js";
 export * as prh from "./prh/index.js";
 export * as rechercheEntreprises from "./recherche-entreprises/index.js";
 export * as shared from "./shared/index.js";
+export * as sudreg from "./sudreg/index.js";
 export * as vies from "./vies/index.js";
+export * as zefix from "./zefix/index.js";

--- a/packages/business-registries/src/krs/index.ts
+++ b/packages/business-registries/src/krs/index.ts
@@ -7,6 +7,7 @@ export {
   KrsValidationError,
 } from "./errors.js";
 export { parseAddress, parseEntity, parseStatus } from "./parse.js";
+export { toNormalizedEntity, toNormalizedSearchResult } from "./normalized.js";
 export type {
   KrsAddress,
   KrsEntity,

--- a/packages/business-registries/src/krs/index.ts
+++ b/packages/business-registries/src/krs/index.ts
@@ -28,4 +28,9 @@ export type {
   KrsRegisterCode,
   KrsRegisteredSeat,
 } from "./types.js";
-export { normalizeKrsNumber, validateKrsNumber } from "./validation.js";
+export {
+  normalizeKrsNumber,
+  validateKrsNumber,
+  validateNip,
+  validateRegon,
+} from "./validation.js";

--- a/packages/business-registries/src/krs/normalized.test.ts
+++ b/packages/business-registries/src/krs/normalized.test.ts
@@ -28,6 +28,10 @@ describe("KRS normalized projection", () => {
       expect(entity.shareCapital.value?.amount).not.toBeNull();
     }
     expect(entity.keyPeople).toEqual({ availability: "not-supported" });
+    expect(entity.registrationDate).toEqual({
+      availability: "available",
+      value: "2001-04-06",
+    });
   });
 
   test("can derive a normalized search row from a lookup entity", () => {
@@ -35,5 +39,14 @@ describe("KRS normalized projection", () => {
     expect(result.registryId.scheme).toBe("PL-KRS");
     expect(String(result.registryId.value)).toBe("0000006865");
     expect(result.status.availability).toBe("available");
+  });
+
+  test("does not expose invalid or ambiguous registry dates", () => {
+    const source = parseEntity(raw, "0000006865");
+    for (const registeredAt of ["31.02.2001", "2001-04-06", "unknown"]) {
+      expect(
+        toNormalizedEntity({ ...source, registeredAt }).registrationDate,
+      ).toEqual({ availability: "available", value: null });
+    }
   });
 });

--- a/packages/business-registries/src/krs/normalized.test.ts
+++ b/packages/business-registries/src/krs/normalized.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "bun:test";
+
+import fixture from "./__fixtures__/lookup-cd-projekt.json" with { type: "json" };
+import { toNormalizedEntity, toNormalizedSearchResult } from "./normalized.js";
+import { parseEntity } from "./parse.js";
+import type { KrsLookupResponse } from "./types.js";
+
+// SAFETY: captured official fixture is consumed by the defensive parser.
+// eslint-disable-next-line typescript-eslint/no-unsafe-type-assertion
+const raw = fixture as unknown as KrsLookupResponse;
+
+describe("KRS normalized projection", () => {
+  test("preserves alternate IDs, registry record, and structured capital", () => {
+    const entity = toNormalizedEntity(parseEntity(raw, "0000006865"));
+    expect(entity.identifiers.map((item) => item.scheme)).toEqual([
+      "PL-NIP",
+      "PL-REGON",
+    ]);
+    expect(entity.registryRecord).toMatchObject({
+      availability: "available",
+      value: { section: "RejP", idNumber: "0000006865" },
+    });
+    expect(entity.shareCapital).toMatchObject({
+      availability: "available",
+      value: { currency: "PLN" },
+    });
+    if (entity.shareCapital.availability === "available") {
+      expect(entity.shareCapital.value?.amount).not.toBeNull();
+    }
+    expect(entity.keyPeople).toEqual({ availability: "not-supported" });
+  });
+
+  test("can derive a normalized search row from a lookup entity", () => {
+    const result = toNormalizedSearchResult(parseEntity(raw, "0000006865"));
+    expect(result.registryId.scheme).toBe("PL-KRS");
+    expect(String(result.registryId.value)).toBe("0000006865");
+    expect(result.status.availability).toBe("available");
+  });
+});

--- a/packages/business-registries/src/krs/normalized.ts
+++ b/packages/business-registries/src/krs/normalized.ts
@@ -1,0 +1,111 @@
+import {
+  availableField,
+  fromValidatedRegistryIdentifier,
+  unsupportedField,
+} from "../shared/normalized.js";
+import type {
+  NormalizedRegistryAddress,
+  NormalizedRegistryEntity,
+  NormalizedRegistryIdentifier,
+  NormalizedRegistrySearchResult,
+} from "../shared/normalized.js";
+import type { EntityStatus } from "../shared/status.js";
+import type { KrsAddress, KrsEntity, KrsEntityStatus } from "./types.js";
+
+const normalizeStatus = (status: KrsEntityStatus): EntityStatus => {
+  switch (status.type) {
+    case "active":
+    case "bankruptcy":
+    case "dissolved":
+    case "liquidating":
+    case "unknown":
+      return status;
+    case "restructuring":
+      return { type: "inactive" };
+    default: {
+      const unreachable: never = status;
+      return unreachable;
+    }
+  }
+};
+
+const normalizeAddress = (address: KrsAddress): NormalizedRegistryAddress => ({
+  streetName: address.street,
+  houseNumber: null,
+  orientationNumber: null,
+  orientationLetter: null,
+  municipalityPart: null,
+  municipality: address.city,
+  postalCode: address.postalCode,
+  county: null,
+  stateName: address.country,
+  textAddress: address.textAddress,
+});
+
+export const toNormalizedEntity = (
+  entity: KrsEntity,
+): NormalizedRegistryEntity => {
+  const identifiers: NormalizedRegistryIdentifier[] = [];
+  if (entity.identifiers.nip) {
+    identifiers.push(
+      fromValidatedRegistryIdentifier("PL-NIP", entity.identifiers.nip),
+    );
+  }
+  if (entity.identifiers.regon) {
+    identifiers.push(
+      fromValidatedRegistryIdentifier("PL-REGON", entity.identifiers.regon),
+    );
+  }
+  return {
+    country: "PL",
+    registryId: fromValidatedRegistryIdentifier("PL-KRS", entity.krsNumber),
+    identifiers,
+    name: entity.name,
+    nameWithoutLegalForm: unsupportedField(),
+    legalForm: availableField(
+      entity.legalForm ? { code: null, label: entity.legalForm } : null,
+    ),
+    status: availableField(normalizeStatus(entity.status)),
+    statusDetail: entity.status.type,
+    address: availableField(
+      entity.address ? normalizeAddress(entity.address) : null,
+    ),
+    creationDate: unsupportedField(),
+    registrationDate: availableField(entity.registeredAt),
+    removalDate: unsupportedField(),
+    registryRecord: availableField({
+      courtName: null,
+      section: entity.register,
+      idNumber: entity.krsNumber,
+      reference: `${entity.register} ${entity.krsNumber}`,
+    }),
+    keyPeople: unsupportedField(),
+    shareCapital: availableField(
+      entity.shareCapital
+        ? {
+            text: `${entity.shareCapital.amount} ${entity.shareCapital.currency}`,
+            amount: entity.shareCapital.amount,
+            currency: entity.shareCapital.currency,
+          }
+        : null,
+    ),
+    shareCapitalPaid: unsupportedField(),
+    actingClause: unsupportedField(),
+    registryUrl: availableField(entity.registryUrl),
+    warnings: unsupportedField(),
+  };
+};
+
+export const toNormalizedSearchResult = (
+  entity: KrsEntity,
+): NormalizedRegistrySearchResult => ({
+  country: "PL",
+  registryId: fromValidatedRegistryIdentifier("PL-KRS", entity.krsNumber),
+  name: entity.name,
+  legalForm: availableField(
+    entity.legalForm ? { code: null, label: entity.legalForm } : null,
+  ),
+  status: availableField(normalizeStatus(entity.status)),
+  address: availableField(entity.address?.textAddress ?? null),
+  registryUrl: availableField(entity.registryUrl),
+});

--- a/packages/business-registries/src/krs/normalized.ts
+++ b/packages/business-registries/src/krs/normalized.ts
@@ -1,6 +1,6 @@
 import {
   availableField,
-  fromValidatedRegistryIdentifier,
+  toValidatedRegistryIdentifier,
   unsupportedField,
 } from "../shared/normalized.js";
 import type {
@@ -11,6 +11,7 @@ import type {
 } from "../shared/normalized.js";
 import type { EntityStatus } from "../shared/status.js";
 import type { KrsAddress, KrsEntity, KrsEntityStatus } from "./types.js";
+import { validateKrsNumber, validateNip, validateRegon } from "./validation.js";
 
 const normalizeStatus = (status: KrsEntityStatus): EntityStatus => {
   switch (status.type) {
@@ -42,23 +43,62 @@ const normalizeAddress = (address: KrsAddress): NormalizedRegistryAddress => ({
   textAddress: address.textAddress,
 });
 
+const POLISH_DATE = /^(?<day>\d{2})\.(?<month>\d{2})\.(?<year>\d{4})$/u;
+
+const normalizePolishDate = (value: string | null): string | null => {
+  if (!value) {
+    return null;
+  }
+  const groups = POLISH_DATE.exec(value)?.groups;
+  const daySource = groups?.["day"];
+  const monthSource = groups?.["month"];
+  const yearSource = groups?.["year"];
+  if (!daySource || !monthSource || !yearSource) {
+    return null;
+  }
+  const year = Number(yearSource);
+  const month = Number(monthSource);
+  const day = Number(daySource);
+  const date = new Date(Date.UTC(year, month - 1, day));
+  if (
+    date.getUTCFullYear() !== year ||
+    date.getUTCMonth() !== month - 1 ||
+    date.getUTCDate() !== day
+  ) {
+    return null;
+  }
+  return `${yearSource}-${monthSource}-${daySource}`;
+};
+
 export const toNormalizedEntity = (
   entity: KrsEntity,
 ): NormalizedRegistryEntity => {
   const identifiers: NormalizedRegistryIdentifier[] = [];
   if (entity.identifiers.nip) {
     identifiers.push(
-      fromValidatedRegistryIdentifier("PL-NIP", entity.identifiers.nip),
+      toValidatedRegistryIdentifier({
+        scheme: "PL-NIP",
+        value: entity.identifiers.nip,
+        validate: validateNip,
+      }),
     );
   }
   if (entity.identifiers.regon) {
     identifiers.push(
-      fromValidatedRegistryIdentifier("PL-REGON", entity.identifiers.regon),
+      toValidatedRegistryIdentifier({
+        scheme: "PL-REGON",
+        value: entity.identifiers.regon,
+        validate: validateRegon,
+      }),
     );
   }
   return {
     country: "PL",
-    registryId: fromValidatedRegistryIdentifier("PL-KRS", entity.krsNumber),
+    registryId: toValidatedRegistryIdentifier({
+      scheme: "PL-KRS",
+      value: entity.krsNumber,
+      validate: validateKrsNumber,
+    }),
     identifiers,
     name: entity.name,
     nameWithoutLegalForm: unsupportedField(),
@@ -71,7 +111,7 @@ export const toNormalizedEntity = (
       entity.address ? normalizeAddress(entity.address) : null,
     ),
     creationDate: unsupportedField(),
-    registrationDate: availableField(entity.registeredAt),
+    registrationDate: availableField(normalizePolishDate(entity.registeredAt)),
     removalDate: unsupportedField(),
     registryRecord: availableField({
       courtName: null,
@@ -100,7 +140,11 @@ export const toNormalizedSearchResult = (
   entity: KrsEntity,
 ): NormalizedRegistrySearchResult => ({
   country: "PL",
-  registryId: fromValidatedRegistryIdentifier("PL-KRS", entity.krsNumber),
+  registryId: toValidatedRegistryIdentifier({
+    scheme: "PL-KRS",
+    value: entity.krsNumber,
+    validate: validateKrsNumber,
+  }),
   name: entity.name,
   legalForm: availableField(
     entity.legalForm ? { code: null, label: entity.legalForm } : null,

--- a/packages/business-registries/src/krs/validation.test.ts
+++ b/packages/business-registries/src/krs/validation.test.ts
@@ -1,12 +1,30 @@
 import { describe, expect, test } from "bun:test";
 
-import { normalizeKrsNumber, validateKrsNumber } from "./validation.js";
+import {
+  normalizeKrsNumber,
+  validateKrsNumber,
+  validateNip,
+  validateRegon,
+} from "./validation.js";
 
 describe("normalizeKrsNumber", () => {
   test("strips whitespace", () => {
     expect(normalizeKrsNumber(" 0000006865 ")).toBe("0000006865");
     expect(normalizeKrsNumber("0000006865\n")).toBe("0000006865");
     expect(normalizeKrsNumber("0000 006 865")).toBe("0000006865");
+  });
+});
+
+describe("Polish alternate registry identifiers", () => {
+  test("validates NIP checksums", () => {
+    expect(validateNip("7342867148")).toBe(true);
+    expect(validateNip("7342867149")).toBe(false);
+  });
+
+  test("accepts national REGON values and their KRS zero-padded form", () => {
+    expect(validateRegon("492707333")).toBe(true);
+    expect(validateRegon("49270733300000")).toBe(true);
+    expect(validateRegon("49270733400000")).toBe(false);
   });
 });
 

--- a/packages/business-registries/src/krs/validation.ts
+++ b/packages/business-registries/src/krs/validation.ts
@@ -13,10 +13,30 @@
 // is ambiguous (could be an arbitrary numeric identifier), and the
 // dispatch layer keys on a shape match to choose lookup vs. search.
 
+import { validate as validateNipStdnum } from "@stll/stdnum/pl/nip";
+import {
+  compact as compactRegon,
+  validate as validateRegonStdnum,
+} from "@stll/stdnum/pl/regon";
+
 export const normalizeKrsNumber = (input: string): string =>
   input.trim().replaceAll(/\s/gu, "");
 
 export const validateKrsNumber = (input: string): boolean => {
   const compact = normalizeKrsNumber(input);
   return /^\d{10}$/u.test(compact);
+};
+
+export const validateNip = (input: string): boolean =>
+  validateNipStdnum(input).valid;
+
+export const validateRegon = (input: string): boolean => {
+  const compact = compactRegon(input);
+  if (validateRegonStdnum(compact).valid) {
+    return true;
+  }
+  return (
+    /^\d{9}0{5}$/u.test(compact) &&
+    validateRegonStdnum(compact.slice(0, 9)).valid
+  );
 };

--- a/packages/business-registries/src/orsr/index.ts
+++ b/packages/business-registries/src/orsr/index.ts
@@ -7,6 +7,7 @@ export {
   OrsrValidationError,
 } from "./errors.js";
 export { parseAddress, parseExtract, parseSearchHit } from "./parse.js";
+export { toNormalizedEntity, toNormalizedSearchResult } from "./normalized.js";
 export type {
   OrsrAddress,
   OrsrCompany,

--- a/packages/business-registries/src/orsr/normalized.test.ts
+++ b/packages/business-registries/src/orsr/normalized.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "bun:test";
+
+import { toNormalizedEntity, toNormalizedSearchResult } from "./normalized.js";
+import { parseExtract } from "./parse.js";
+import type { OrsrRawExtractResponse } from "./types.js";
+
+const readFixture = async (): Promise<OrsrRawExtractResponse> => {
+  const value: unknown = await Bun.file(
+    new URL("__fixtures__/extract-eset.json", import.meta.url),
+  ).json();
+  // SAFETY: captured registry fixture is consumed by the defensive parser.
+  // eslint-disable-next-line typescript-eslint/no-unsafe-type-assertion
+  return value as OrsrRawExtractResponse;
+};
+
+describe("ORSR normalized projection", () => {
+  test("preserves court, capital, acting, and grouped people", async () => {
+    const company = parseExtract(await readFixture());
+    expect(company).not.toBeNull();
+    if (!company) {
+      return;
+    }
+    const entity = toNormalizedEntity(company);
+    expect(entity.registryRecord).toMatchObject({
+      availability: "available",
+      value: { section: "Sro", idNumber: "3586" },
+    });
+    expect(entity.shareCapital).toMatchObject({
+      availability: "available",
+      value: { text: "140 000 EUR" },
+    });
+    expect(entity.shareCapitalPaid).toMatchObject({
+      availability: "available",
+      value: { text: "140 000 EUR" },
+    });
+    expect(entity.actingClause).toMatchObject({
+      availability: "available",
+    });
+    if (entity.actingClause.availability === "available") {
+      expect(entity.actingClause.value).toContain("V mene spoločnosti");
+    }
+    if (entity.keyPeople.availability === "available") {
+      expect(
+        entity.keyPeople.value.some((group) => group.name === "Spoločníci"),
+      ).toBe(true);
+    }
+    expect(entity.registrationDate).toEqual({
+      availability: "not-supported",
+    });
+  });
+
+  test("projects search rows without inventing unavailable status", () => {
+    const result = toNormalizedSearchResult({
+      ico: "31333532",
+      name: "ESET, spol. s r.o.",
+      address: "Einsteinova 24, Bratislava",
+    });
+    expect(result.status).toEqual({ availability: "not-supported" });
+  });
+});

--- a/packages/business-registries/src/orsr/normalized.ts
+++ b/packages/business-registries/src/orsr/normalized.ts
@@ -1,6 +1,6 @@
 import {
   availableField,
-  fromValidatedRegistryIdentifier,
+  toValidatedRegistryIdentifier,
   unsupportedField,
 } from "../shared/normalized.js";
 import type {
@@ -11,6 +11,7 @@ import type {
   NormalizedRegistrySearchResult,
 } from "../shared/normalized.js";
 import type { OrsrAddress, OrsrCompany, OrsrSearchResult } from "./types.js";
+import { validateIco } from "./validation.js";
 
 const normalizeAddress = (address: OrsrAddress): NormalizedRegistryAddress => ({
   streetName: address.street,
@@ -73,7 +74,11 @@ export const toNormalizedEntity = (
   company: OrsrCompany,
 ): NormalizedRegistryEntity => ({
   country: "SK",
-  registryId: fromValidatedRegistryIdentifier("SK-ICO", company.ico),
+  registryId: toValidatedRegistryIdentifier({
+    scheme: "SK-ICO",
+    value: company.ico,
+    validate: validateIco,
+  }),
   identifiers: [],
   name: company.name,
   nameWithoutLegalForm: unsupportedField(),
@@ -126,7 +131,11 @@ export const toNormalizedSearchResult = (
   result: OrsrSearchResult,
 ): NormalizedRegistrySearchResult => ({
   country: "SK",
-  registryId: fromValidatedRegistryIdentifier("SK-ICO", result.ico),
+  registryId: toValidatedRegistryIdentifier({
+    scheme: "SK-ICO",
+    value: result.ico,
+    validate: validateIco,
+  }),
   name: result.name,
   legalForm: unsupportedField(),
   status: unsupportedField(),

--- a/packages/business-registries/src/orsr/normalized.ts
+++ b/packages/business-registries/src/orsr/normalized.ts
@@ -1,0 +1,135 @@
+import {
+  availableField,
+  fromValidatedRegistryIdentifier,
+  unsupportedField,
+} from "../shared/normalized.js";
+import type {
+  NormalizedRegistryAddress,
+  NormalizedRegistryEntity,
+  NormalizedRegistryKeyPeopleGroup,
+  NormalizedRegistryKeyPerson,
+  NormalizedRegistrySearchResult,
+} from "../shared/normalized.js";
+import type { OrsrAddress, OrsrCompany, OrsrSearchResult } from "./types.js";
+
+const normalizeAddress = (address: OrsrAddress): NormalizedRegistryAddress => ({
+  streetName: address.street,
+  houseNumber: null,
+  orientationNumber: null,
+  orientationLetter: null,
+  municipalityPart: null,
+  municipality: address.city,
+  postalCode: address.postalCode,
+  county: null,
+  stateName: address.country,
+  textAddress: address.textAddress,
+});
+
+const normalizeKeyPeople = (
+  company: OrsrCompany,
+): NormalizedRegistryKeyPeopleGroup[] => {
+  const groups: NormalizedRegistryKeyPeopleGroup[] =
+    company.statutoryBodies.map((body) => ({
+      name: body.organName,
+      people: body.members.map((member) => ({
+        name: member.name,
+        nameWithTitles: null,
+        position: member.position,
+        organName: body.organName,
+        since: member.since,
+        address: member.address,
+        citizenship: null,
+        birthDate: null,
+        identifier: null,
+        share: null,
+        link: null,
+      })),
+    }));
+  const stakeholderGroups = new Map<string, NormalizedRegistryKeyPerson[]>();
+  for (const stakeholder of company.stakeholders) {
+    const people = stakeholderGroups.get(stakeholder.organName) ?? [];
+    people.push({
+      name: stakeholder.name,
+      nameWithTitles: null,
+      position: stakeholder.position,
+      organName: stakeholder.organName,
+      since: null,
+      address: stakeholder.address,
+      citizenship: null,
+      birthDate: null,
+      identifier: stakeholder.identifier,
+      share: stakeholder.share,
+      link: null,
+    });
+    stakeholderGroups.set(stakeholder.organName, people);
+  }
+  for (const [name, people] of stakeholderGroups) {
+    groups.push({ name, people });
+  }
+  return groups;
+};
+
+export const toNormalizedEntity = (
+  company: OrsrCompany,
+): NormalizedRegistryEntity => ({
+  country: "SK",
+  registryId: fromValidatedRegistryIdentifier("SK-ICO", company.ico),
+  identifiers: [],
+  name: company.name,
+  nameWithoutLegalForm: unsupportedField(),
+  legalForm: availableField(
+    company.legalForm ? { code: null, label: company.legalForm } : null,
+  ),
+  status: availableField(
+    company.status.type === "terminated"
+      ? { type: "dissolved" }
+      : company.status,
+  ),
+  statusDetail: company.status.type,
+  address: availableField(
+    company.address ? normalizeAddress(company.address) : null,
+  ),
+  creationDate: availableField(company.establishedAt),
+  registrationDate: unsupportedField(),
+  removalDate: availableField(company.terminatedAt),
+  registryRecord: availableField(
+    company.courtFile
+      ? {
+          courtName: company.courtFile.court,
+          section: company.courtFile.section,
+          idNumber: company.courtFile.insertNumber,
+          reference: [
+            company.courtFile.section,
+            company.courtFile.insertNumber,
+            company.courtFile.court,
+          ].join(" "),
+        }
+      : null,
+  ),
+  keyPeople: availableField(normalizeKeyPeople(company)),
+  shareCapital: availableField(
+    company.shareCapital
+      ? { text: company.shareCapital, amount: null, currency: null }
+      : null,
+  ),
+  shareCapitalPaid: availableField(
+    company.shareCapitalPaid
+      ? { text: company.shareCapitalPaid, amount: null, currency: null }
+      : null,
+  ),
+  actingClause: availableField(company.actingClause),
+  registryUrl: availableField(company.registryUrl),
+  warnings: unsupportedField(),
+});
+
+export const toNormalizedSearchResult = (
+  result: OrsrSearchResult,
+): NormalizedRegistrySearchResult => ({
+  country: "SK",
+  registryId: fromValidatedRegistryIdentifier("SK-ICO", result.ico),
+  name: result.name,
+  legalForm: unsupportedField(),
+  status: unsupportedField(),
+  address: availableField(result.address),
+  registryUrl: unsupportedField(),
+});

--- a/packages/business-registries/src/recherche-entreprises/index.ts
+++ b/packages/business-registries/src/recherche-entreprises/index.ts
@@ -12,6 +12,7 @@ export {
   parseEstablishment,
   parseSearchEntry,
 } from "./parse.js";
+export { toNormalizedEntity, toNormalizedSearchResult } from "./normalized.js";
 export type {
   RechercheEntreprisesAddress,
   RechercheEntreprisesCompany,

--- a/packages/business-registries/src/recherche-entreprises/normalized.test.ts
+++ b/packages/business-registries/src/recherche-entreprises/normalized.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "bun:test";
+
+import fixture from "./__fixtures__/lookup-siren-renault.json" with { type: "json" };
+import { toNormalizedEntity, toNormalizedSearchResult } from "./normalized.js";
+import { parseCompany, parseSearchEntry } from "./parse.js";
+import type { RechercheEntreprisesSearchResponse } from "./types.js";
+
+// SAFETY: captured official fixture is consumed by the defensive parser.
+// eslint-disable-next-line typescript-eslint/no-unsafe-type-assertion
+const raw = fixture as unknown as RechercheEntreprisesSearchResponse;
+
+describe("French registry normalized projection", () => {
+  test("preserves SIRET aliases, legal-form code, address, and directors", () => {
+    const source = raw.results[0];
+    expect(source).toBeDefined();
+    if (!source) {
+      return;
+    }
+    const entity = toNormalizedEntity(parseCompany(source));
+    expect(entity.registryId.scheme).toBe("FR-SIREN");
+    expect(entity.identifiers.some((item) => item.scheme === "FR-SIRET")).toBe(
+      true,
+    );
+    expect(entity.legalForm).toMatchObject({ availability: "available" });
+    if (entity.legalForm.availability === "available") {
+      expect(entity.legalForm.value?.code).not.toBeNull();
+    }
+    if (entity.address.availability === "available") {
+      expect(entity.address.value?.textAddress).not.toBeNull();
+    }
+    if (entity.keyPeople.availability === "available") {
+      expect(entity.keyPeople.value[0]?.people.length).toBeGreaterThan(0);
+    }
+    expect(entity.warnings).toEqual({ availability: "not-supported" });
+  });
+
+  test("declares fields absent from the thin search domain", () => {
+    const source = raw.results[0];
+    expect(source).toBeDefined();
+    if (!source) {
+      return;
+    }
+    const result = toNormalizedSearchResult(parseSearchEntry(source));
+    expect(result.status).toEqual({ availability: "not-supported" });
+    expect(result.registryUrl).toEqual({ availability: "not-supported" });
+  });
+});

--- a/packages/business-registries/src/recherche-entreprises/normalized.ts
+++ b/packages/business-registries/src/recherche-entreprises/normalized.ts
@@ -1,0 +1,151 @@
+import {
+  availableField,
+  fromValidatedRegistryIdentifier,
+  unsupportedField,
+} from "../shared/normalized.js";
+import type {
+  NormalizedRegistryAddress,
+  NormalizedRegistryEntity,
+  NormalizedRegistryIdentifier,
+  NormalizedRegistryKeyPerson,
+  NormalizedRegistrySearchResult,
+} from "../shared/normalized.js";
+import type { EntityStatus } from "../shared/status.js";
+import type {
+  RechercheEntreprisesAddress,
+  RechercheEntreprisesCompany,
+  RechercheEntreprisesDirector,
+  RechercheEntreprisesLegalEntityStatus,
+  RechercheEntreprisesSearchResult,
+} from "./types.js";
+
+const normalizeStatus = (
+  status: RechercheEntreprisesLegalEntityStatus,
+): EntityStatus => {
+  switch (status.type) {
+    case "active":
+    case "unknown":
+      return status;
+    case "ceased":
+      return { type: "dissolved" };
+    default: {
+      const unreachable: never = status;
+      return unreachable;
+    }
+  }
+};
+
+const normalizeAddress = (
+  address: RechercheEntreprisesAddress,
+): NormalizedRegistryAddress => ({
+  streetName: address.street,
+  houseNumber: null,
+  orientationNumber: null,
+  orientationLetter: null,
+  municipalityPart: null,
+  municipality: address.city,
+  postalCode: address.postalCode,
+  county: null,
+  stateName: address.country,
+  textAddress: address.textAddress,
+});
+
+const normalizeDirector = (
+  director: RechercheEntreprisesDirector,
+): NormalizedRegistryKeyPerson =>
+  director.type === "person"
+    ? {
+        name: director.fullName,
+        nameWithTitles: null,
+        position: director.role,
+        organName: null,
+        since: null,
+        address: null,
+        citizenship: null,
+        birthDate: director.birthYear
+          ? { value: director.birthYear, precision: "year" }
+          : null,
+        identifier: null,
+        share: null,
+        link: null,
+      }
+    : {
+        name: director.name,
+        nameWithTitles: null,
+        position: director.role,
+        organName: null,
+        since: null,
+        address: null,
+        citizenship: null,
+        birthDate: null,
+        identifier: director.siren,
+        share: null,
+        link: null,
+      };
+
+export const toNormalizedEntity = (
+  company: RechercheEntreprisesCompany,
+): NormalizedRegistryEntity => {
+  const identifiers: NormalizedRegistryIdentifier[] = [];
+  if (company.headOffice) {
+    identifiers.push(
+      fromValidatedRegistryIdentifier("FR-SIRET", company.headOffice.siret),
+    );
+  }
+  if (
+    company.matchedEstablishment &&
+    company.matchedEstablishment.siret !== company.headOffice?.siret
+  ) {
+    identifiers.push(
+      fromValidatedRegistryIdentifier(
+        "FR-SIRET",
+        company.matchedEstablishment.siret,
+      ),
+    );
+  }
+  return {
+    country: "FR",
+    registryId: fromValidatedRegistryIdentifier("FR-SIREN", company.siren),
+    identifiers,
+    name: company.name,
+    nameWithoutLegalForm: unsupportedField(),
+    legalForm: availableField(
+      company.legalFormCode
+        ? { code: company.legalFormCode, label: null }
+        : null,
+    ),
+    status: availableField(normalizeStatus(company.status)),
+    statusDetail: company.status.type,
+    address: availableField(
+      company.headOffice?.address
+        ? normalizeAddress(company.headOffice.address)
+        : null,
+    ),
+    creationDate: availableField(company.registeredAt),
+    registrationDate: unsupportedField(),
+    removalDate: availableField(company.ceasedAt),
+    registryRecord: unsupportedField(),
+    keyPeople: availableField(
+      company.directors.length > 0
+        ? [{ name: null, people: company.directors.map(normalizeDirector) }]
+        : [],
+    ),
+    shareCapital: unsupportedField(),
+    shareCapitalPaid: unsupportedField(),
+    actingClause: unsupportedField(),
+    registryUrl: availableField(company.registryUrl),
+    warnings: unsupportedField(),
+  };
+};
+
+export const toNormalizedSearchResult = (
+  result: RechercheEntreprisesSearchResult,
+): NormalizedRegistrySearchResult => ({
+  country: "FR",
+  registryId: fromValidatedRegistryIdentifier("FR-SIREN", result.siren),
+  name: result.name,
+  legalForm: unsupportedField(),
+  status: unsupportedField(),
+  address: availableField(result.address),
+  registryUrl: unsupportedField(),
+});

--- a/packages/business-registries/src/recherche-entreprises/normalized.ts
+++ b/packages/business-registries/src/recherche-entreprises/normalized.ts
@@ -1,6 +1,6 @@
 import {
   availableField,
-  fromValidatedRegistryIdentifier,
+  toValidatedRegistryIdentifier,
   unsupportedField,
 } from "../shared/normalized.js";
 import type {
@@ -18,6 +18,7 @@ import type {
   RechercheEntreprisesLegalEntityStatus,
   RechercheEntreprisesSearchResult,
 } from "./types.js";
+import { validateSiren, validateSiret } from "./validation.js";
 
 const normalizeStatus = (
   status: RechercheEntreprisesLegalEntityStatus,
@@ -89,7 +90,11 @@ export const toNormalizedEntity = (
   const identifiers: NormalizedRegistryIdentifier[] = [];
   if (company.headOffice) {
     identifiers.push(
-      fromValidatedRegistryIdentifier("FR-SIRET", company.headOffice.siret),
+      toValidatedRegistryIdentifier({
+        scheme: "FR-SIRET",
+        value: company.headOffice.siret,
+        validate: validateSiret,
+      }),
     );
   }
   if (
@@ -97,15 +102,20 @@ export const toNormalizedEntity = (
     company.matchedEstablishment.siret !== company.headOffice?.siret
   ) {
     identifiers.push(
-      fromValidatedRegistryIdentifier(
-        "FR-SIRET",
-        company.matchedEstablishment.siret,
-      ),
+      toValidatedRegistryIdentifier({
+        scheme: "FR-SIRET",
+        value: company.matchedEstablishment.siret,
+        validate: validateSiret,
+      }),
     );
   }
   return {
     country: "FR",
-    registryId: fromValidatedRegistryIdentifier("FR-SIREN", company.siren),
+    registryId: toValidatedRegistryIdentifier({
+      scheme: "FR-SIREN",
+      value: company.siren,
+      validate: validateSiren,
+    }),
     identifiers,
     name: company.name,
     nameWithoutLegalForm: unsupportedField(),
@@ -142,7 +152,11 @@ export const toNormalizedSearchResult = (
   result: RechercheEntreprisesSearchResult,
 ): NormalizedRegistrySearchResult => ({
   country: "FR",
-  registryId: fromValidatedRegistryIdentifier("FR-SIREN", result.siren),
+  registryId: toValidatedRegistryIdentifier({
+    scheme: "FR-SIREN",
+    value: result.siren,
+    validate: validateSiren,
+  }),
   name: result.name,
   legalForm: unsupportedField(),
   status: unsupportedField(),

--- a/packages/business-registries/src/shared/canonical-id.ts
+++ b/packages/business-registries/src/shared/canonical-id.ts
@@ -20,6 +20,9 @@ export const CANONICAL_ID_SCHEMES = [
   "GB-CRN",
   "FR-SIREN",
   "FR-SIRET",
+  "SK-ICO",
+  "CH-UID",
+  "HR-MBS",
   "BR-CNPJ",
 ] as const;
 

--- a/packages/business-registries/src/shared/errors.ts
+++ b/packages/business-registries/src/shared/errors.ts
@@ -19,6 +19,16 @@ export class RegistryUnavailableError extends RegistryError {
   }
 }
 
+export class RegistryValidationError extends RegistryError {
+  readonly scheme: string;
+
+  constructor(scheme: string) {
+    super(`Invalid ${scheme} registry identifier`);
+    this.name = "RegistryValidationError";
+    this.scheme = scheme;
+  }
+}
+
 // Not-found is intentionally NOT a class. JavaScript single inheritance
 // means a per-adapter class can extend either its adapter base
 // (AresError / BrregError, preserving `error instanceof AresError`

--- a/packages/business-registries/src/shared/index.ts
+++ b/packages/business-registries/src/shared/index.ts
@@ -12,5 +12,20 @@ export {
 } from "./errors.js";
 export type { EntityNotFound } from "./errors.js";
 export { clampSearchLimit } from "./search.js";
+export type {
+  NormalizedRegistryAddress,
+  NormalizedRegistryBirthDate,
+  NormalizedRegistryCapital,
+  NormalizedRegistryEntity,
+  NormalizedRegistryEntityFields,
+  NormalizedRegistryField,
+  NormalizedRegistryIdentifier,
+  NormalizedRegistryKeyPeopleGroup,
+  NormalizedRegistryKeyPerson,
+  NormalizedRegistryRecord,
+  NormalizedRegistrySearchFields,
+  NormalizedRegistrySearchResult,
+  NormalizedRegistryWarning,
+} from "./normalized.js";
 export type { EntityStatus } from "./status.js";
 export { mapEntityStatus } from "./status.js";

--- a/packages/business-registries/src/shared/index.ts
+++ b/packages/business-registries/src/shared/index.ts
@@ -1,6 +1,6 @@
 export type { RegistryAdapterShape, RegistryDescriptor } from "./adapter.js";
 export type { CanonicalId, KnownCanonicalIdScheme } from "./canonical-id.js";
-export { CANONICAL_ID_SCHEMES, unsafeBrand } from "./canonical-id.js";
+export { CANONICAL_ID_SCHEMES } from "./canonical-id.js";
 export {
   isEntityNotFound,
   RegistryAuthRequiredError,
@@ -9,6 +9,7 @@ export {
   RegistryLicenceIncompatibleError,
   RegistryRateLimitedError,
   RegistryUnavailableError,
+  RegistryValidationError,
 } from "./errors.js";
 export type { EntityNotFound } from "./errors.js";
 export { clampSearchLimit } from "./search.js";

--- a/packages/business-registries/src/shared/normalized.test.ts
+++ b/packages/business-registries/src/shared/normalized.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "bun:test";
+
+import { RegistryValidationError } from "./errors.js";
+import { toValidatedRegistryIdentifier } from "./normalized.js";
+
+describe("normalized registry identifiers", () => {
+  test("constructs a canonical identifier only after scheme validation", () => {
+    const identifier = toValidatedRegistryIdentifier({
+      scheme: "GB-CRN",
+      value: "00445790",
+      validate: (value) => /^\d{8}$/u.test(value),
+    });
+    expect(identifier.scheme).toBe("GB-CRN");
+    expect(String(identifier.value)).toBe("00445790");
+  });
+
+  test("rejects invalid identifiers without leaking their value", () => {
+    expect(() =>
+      toValidatedRegistryIdentifier({
+        scheme: "GB-CRN",
+        value: "secret-invalid-value",
+        validate: () => false,
+      }),
+    ).toThrow(RegistryValidationError);
+    try {
+      toValidatedRegistryIdentifier({
+        scheme: "GB-CRN",
+        value: "secret-invalid-value",
+        validate: () => false,
+      });
+    } catch (error) {
+      expect(String(error)).not.toContain("secret-invalid-value");
+    }
+  });
+});

--- a/packages/business-registries/src/shared/normalized.ts
+++ b/packages/business-registries/src/shared/normalized.ts
@@ -1,0 +1,147 @@
+import type { CountryCode } from "@stll/country-codes";
+
+import { unsafeBrand } from "./canonical-id.js";
+import type { CanonicalId, KnownCanonicalIdScheme } from "./canonical-id.js";
+import type { EntityStatus } from "./status.js";
+
+export type NormalizedRegistryIdentifier<
+  Scheme extends KnownCanonicalIdScheme = KnownCanonicalIdScheme,
+> = {
+  [CurrentScheme in Scheme]: {
+    scheme: CurrentScheme;
+    value: CanonicalId<CurrentScheme>;
+  };
+}[Scheme];
+
+/**
+ * Project an identifier from an adapter's validated, canonical domain model.
+ *
+ * Raw upstream values must pass through the adapter parser before reaching this
+ * boundary. Keeping the brand operation here prevents individual projectors from
+ * using unchecked assertions.
+ */
+export const fromValidatedRegistryIdentifier = <
+  Scheme extends KnownCanonicalIdScheme,
+>(
+  scheme: Scheme,
+  validatedValue: string,
+): NormalizedRegistryIdentifier<Scheme> => ({
+  scheme,
+  value: unsafeBrand<Scheme>(validatedValue),
+});
+
+export type NormalizedRegistryAddress = {
+  streetName: string | null;
+  houseNumber: string | null;
+  orientationNumber: string | null;
+  orientationLetter: string | null;
+  municipalityPart: string | null;
+  municipality: string | null;
+  postalCode: string | null;
+  county: string | null;
+  stateName: string | null;
+  textAddress: string | null;
+};
+
+export type NormalizedRegistryRecord = {
+  courtName: string | null;
+  section: string | null;
+  idNumber: string | null;
+  reference: string | null;
+};
+
+export type NormalizedRegistryBirthDate = {
+  value: string;
+  precision: "day" | "month" | "year";
+};
+
+export type NormalizedRegistryKeyPerson = {
+  name: string;
+  nameWithTitles: string | null;
+  position: string | null;
+  organName: string | null;
+  since: string | null;
+  address: string | null;
+  citizenship: string | null;
+  birthDate: NormalizedRegistryBirthDate | null;
+  identifier: string | null;
+  share: string | null;
+  link: string | null;
+};
+
+export type NormalizedRegistryKeyPeopleGroup = {
+  name: string | null;
+  people: NormalizedRegistryKeyPerson[];
+};
+
+export type NormalizedRegistryCapital = {
+  text: string;
+  amount: string | null;
+  currency: string | null;
+};
+
+export type NormalizedRegistryWarning = {
+  code: string;
+};
+
+export type NormalizedRegistryField<Value> =
+  | { availability: "available"; value: Value }
+  | { availability: "not-loaded" }
+  | { availability: "not-supported" };
+
+export const availableField = <Value>(
+  value: Value,
+): NormalizedRegistryField<Value> => ({ availability: "available", value });
+
+export const notLoadedField = (): NormalizedRegistryField<never> => ({
+  availability: "not-loaded",
+});
+
+export const unsupportedField = (): NormalizedRegistryField<never> => ({
+  availability: "not-supported",
+});
+
+export type NormalizedRegistryEntityFields = {
+  actingClause: NormalizedRegistryField<string | null>;
+  address: NormalizedRegistryField<NormalizedRegistryAddress | null>;
+  creationDate: NormalizedRegistryField<string | null>;
+  keyPeople: NormalizedRegistryField<NormalizedRegistryKeyPeopleGroup[]>;
+  legalForm: NormalizedRegistryField<{
+    code: string | null;
+    label: string | null;
+  } | null>;
+  nameWithoutLegalForm: NormalizedRegistryField<string | null>;
+  registrationDate: NormalizedRegistryField<string | null>;
+  registryRecord: NormalizedRegistryField<NormalizedRegistryRecord | null>;
+  registryUrl: NormalizedRegistryField<string | null>;
+  removalDate: NormalizedRegistryField<string | null>;
+  shareCapital: NormalizedRegistryField<NormalizedRegistryCapital | null>;
+  shareCapitalPaid: NormalizedRegistryField<NormalizedRegistryCapital | null>;
+  status: NormalizedRegistryField<EntityStatus>;
+  warnings: NormalizedRegistryField<NormalizedRegistryWarning[]>;
+};
+
+export type NormalizedRegistryEntity = {
+  country: CountryCode;
+  registryId: NormalizedRegistryIdentifier;
+  identifiers: NormalizedRegistryIdentifier[];
+  name: string;
+  /** Upstream status text, retained even when no normalized status is available. */
+  statusDetail: string | null;
+} & NormalizedRegistryEntityFields;
+
+export type NormalizedRegistrySearchFields = {
+  address: NormalizedRegistryField<string | null>;
+  legalForm: NormalizedRegistryField<{
+    code: string | null;
+    label: string | null;
+  } | null>;
+  registryUrl: NormalizedRegistryField<string | null>;
+  status: NormalizedRegistryField<EntityStatus>;
+};
+
+export type NormalizedRegistrySearchResult = {
+  country: CountryCode;
+  registryId: NormalizedRegistryIdentifier;
+  name: string;
+} & NormalizedRegistrySearchFields;

--- a/packages/business-registries/src/shared/normalized.ts
+++ b/packages/business-registries/src/shared/normalized.ts
@@ -2,6 +2,7 @@ import type { CountryCode } from "@stll/country-codes";
 
 import { unsafeBrand } from "./canonical-id.js";
 import type { CanonicalId, KnownCanonicalIdScheme } from "./canonical-id.js";
+import { RegistryValidationError } from "./errors.js";
 import type { EntityStatus } from "./status.js";
 
 export type NormalizedRegistryIdentifier<
@@ -13,22 +14,33 @@ export type NormalizedRegistryIdentifier<
   };
 }[Scheme];
 
-/**
- * Project an identifier from an adapter's validated, canonical domain model.
- *
- * Raw upstream values must pass through the adapter parser before reaching this
- * boundary. Keeping the brand operation here prevents individual projectors from
- * using unchecked assertions.
- */
-export const fromValidatedRegistryIdentifier = <
+type ValidatedRegistryIdentifierOptions<Scheme extends KnownCanonicalIdScheme> =
+  {
+    scheme: Scheme;
+    value: string;
+    validate: (value: string) => boolean;
+  };
+
+/** Validate the adapter boundary before constructing a canonical identifier. */
+export const toValidatedRegistryIdentifier = <
+  Scheme extends KnownCanonicalIdScheme,
+>({
+  scheme,
+  value,
+  validate,
+}: ValidatedRegistryIdentifierOptions<Scheme>): NormalizedRegistryIdentifier<Scheme> => {
+  if (!validate(value)) {
+    throw new RegistryValidationError(scheme);
+  }
+  return { scheme, value: unsafeBrand<Scheme>(value) };
+};
+
+export const fromCanonicalRegistryIdentifier = <
   Scheme extends KnownCanonicalIdScheme,
 >(
   scheme: Scheme,
-  validatedValue: string,
-): NormalizedRegistryIdentifier<Scheme> => ({
-  scheme,
-  value: unsafeBrand<Scheme>(validatedValue),
-});
+  value: CanonicalId<Scheme>,
+): NormalizedRegistryIdentifier<Scheme> => ({ scheme, value });
 
 export type NormalizedRegistryAddress = {
   streetName: string | null;

--- a/packages/business-registries/src/sudreg/__fixtures__/company.html
+++ b/packages/business-registries/src/sudreg/__fixtures__/company.html
@@ -1,0 +1,45 @@
+<!doctype html>
+<html lang="hr">
+  <body>
+    <div id="div_kat_0">
+      <h2 class="srn-kat-title">MBS</h2>
+      <table class="srn-l1-table">
+        <tr>
+          <td>080000014</td>
+        </tr>
+      </table>
+    </div>
+    <div id="div_kat_100000">
+      <h2 class="srn-kat-title">Tvrtka</h2>
+      <table class="srn-l1-table">
+        <tr>
+          <td>PRIMJER DIONIČKO DRUŠTVO &amp; PARTNERI</td>
+        </tr>
+      </table>
+    </div>
+    <div id="div_kat_600000">
+      <h2 class="srn-kat-title">Sjedište/adresa</h2>
+      <table class="srn-l1-table">
+        <tr>
+          <td>Zagreb (Grad Zagreb)<br />Trg primjera 10/2 A</td>
+        </tr>
+      </table>
+    </div>
+    <div id="div_kat_655000">
+      <h2 class="srn-kat-title">Temeljni kapital</h2>
+      <table class="srn-l1-table">
+        <tr>
+          <td>850.068.230,00 euro</td>
+        </tr>
+      </table>
+    </div>
+    <div id="div_kat_656000">
+      <h2 class="srn-kat-title">Pravni oblik</h2>
+      <table class="srn-l1-table">
+        <tr>
+          <td>dioničko društvo</td>
+        </tr>
+      </table>
+    </div>
+  </body>
+</html>

--- a/packages/business-registries/src/sudreg/client.test.ts
+++ b/packages/business-registries/src/sudreg/client.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { lookupByMbs } from "./client.js";
+import { SudregAPIError, SudregValidationError } from "./errors.js";
+
+const SKIP_LIVE = process.env["SMOKE_TEST"] !== "1";
+const FIXTURE = new URL("__fixtures__/company.html", import.meta.url);
+
+const requestUrl = (input: URL | Request | string): string => {
+  if (typeof input === "string") {
+    return input;
+  }
+  return input instanceof URL ? input.href : input.url;
+};
+
+const installFetchStub = (
+  handler: (input: URL | Request | string) => Promise<Response>,
+) => {
+  const original = globalThis.fetch;
+  globalThis.fetch = Object.assign(
+    async (input: URL | Request | string) => handler(input),
+    { preconnect: original.preconnect },
+  );
+  return () => {
+    globalThis.fetch = original;
+  };
+};
+
+describe.skipIf(SKIP_LIVE)("SUDREG live", () => {
+  test("looks up a filed Croatian company", async () => {
+    const company = await lookupByMbs("080000014");
+    expect(company?.mbs).toBe("080000014");
+    expect(company?.name.length).toBeGreaterThan(0);
+  });
+
+  test("accepts the alternate official name heading", async () => {
+    const company = await lookupByMbs("050023577");
+    expect(company?.mbs).toBe("050023577");
+    expect(company?.name).toBe("Dom za starije i nemoćne osobe Slavonski Brod");
+  });
+});
+
+describe("SUDREG client", () => {
+  let restore = () => {};
+  afterEach(() => {
+    restore();
+    restore = () => {};
+  });
+
+  test("fetches and parses a company page", async () => {
+    const fixture = await Bun.file(FIXTURE).text();
+    let url = "";
+    restore = installFetchStub(async (input) => {
+      url = requestUrl(input);
+      return new Response(fixture, {
+        status: 200,
+        headers: { "Content-Type": "text/html" },
+      });
+    });
+
+    const company = await lookupByMbs("080 000 014");
+    expect(company?.name).toContain("PRIMJER");
+    expect(url).toContain("p28_sbt_mbs=080000014");
+  });
+
+  test("returns null on an HTTP 404", async () => {
+    restore = installFetchStub(async () => new Response("", { status: 404 }));
+    expect(lookupByMbs("080000014")).resolves.toBeNull();
+  });
+
+  test("rejects malformed MBS values before fetch", () => {
+    expect(lookupByMbs("80000014")).rejects.toBeInstanceOf(
+      SudregValidationError,
+    );
+    expect(lookupByMbs("08000001A")).rejects.toBeInstanceOf(
+      SudregValidationError,
+    );
+  });
+
+  test("wraps upstream failures", async () => {
+    restore = installFetchStub(
+      async () => new Response("maintenance", { status: 503 }),
+    );
+    expect(lookupByMbs("080000014")).rejects.toBeInstanceOf(SudregAPIError);
+  });
+});

--- a/packages/business-registries/src/sudreg/client.ts
+++ b/packages/business-registries/src/sudreg/client.ts
@@ -1,0 +1,55 @@
+import { performRegistryRequest } from "../shared/http.js";
+import {
+  SudregAPIError,
+  SudregRequestError,
+  SudregValidationError,
+} from "./errors.js";
+import { parseCompanyPage } from "./parse.js";
+import type { SudregCompany } from "./types.js";
+import { normalizeMbs, validateMbs } from "./validation.js";
+
+const companyUrl = (mbs: string): string =>
+  `https://sudreg.pravosudje.hr/ords/r/esudreg/public/28?p28_sbt_mbs=${encodeURIComponent(mbs)}`;
+
+export const lookupByMbs = async (
+  mbsInput: string,
+): Promise<SudregCompany | null> => {
+  const mbs = normalizeMbs(mbsInput);
+  if (!validateMbs(mbs)) {
+    throw new SudregValidationError(`Invalid Croatian MBS: ${mbsInput}`);
+  }
+  const url = companyUrl(mbs);
+  const response = await performRegistryRequest({
+    url,
+    init: { headers: { Accept: "text/html" } },
+    wrapRequestError: (cause) =>
+      new SudregRequestError(url, "SUDREG request failed", { cause }),
+  });
+  if (response.status === 404) {
+    return null;
+  }
+  if (!response.ok) {
+    throw new SudregAPIError({
+      message: `SUDREG ${response.status}: ${response.statusText}`,
+      httpStatus: response.status,
+    });
+  }
+
+  let html: string;
+  try {
+    html = await response.text();
+  } catch (error) {
+    throw new SudregAPIError({
+      message: "SUDREG response body was unreadable",
+      httpStatus: response.status,
+      cause: error,
+    });
+  }
+  if (html.trim().length === 0) {
+    throw new SudregAPIError({
+      message: "SUDREG returned an empty response",
+      httpStatus: response.status,
+    });
+  }
+  return parseCompanyPage(html, mbs);
+};

--- a/packages/business-registries/src/sudreg/errors.ts
+++ b/packages/business-registries/src/sudreg/errors.ts
@@ -1,0 +1,50 @@
+import { RegistryError } from "../shared/errors.js";
+
+export class SudregError extends RegistryError {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "SudregError";
+  }
+}
+
+export class SudregAPIError extends SudregError {
+  readonly httpStatus: number;
+
+  constructor({
+    cause,
+    message,
+    httpStatus,
+  }: {
+    cause?: unknown;
+    message: string;
+    httpStatus: number;
+  }) {
+    super(message, { cause });
+    this.name = "SudregAPIError";
+    this.httpStatus = httpStatus;
+  }
+}
+
+export class SudregParseError extends SudregError {
+  constructor(message: string) {
+    super(message);
+    this.name = "SudregParseError";
+  }
+}
+
+export class SudregValidationError extends SudregError {
+  constructor(message: string) {
+    super(message);
+    this.name = "SudregValidationError";
+  }
+}
+
+export class SudregRequestError extends SudregError {
+  readonly url: string;
+
+  constructor(url: string, message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "SudregRequestError";
+    this.url = url;
+  }
+}

--- a/packages/business-registries/src/sudreg/index.ts
+++ b/packages/business-registries/src/sudreg/index.ts
@@ -1,0 +1,12 @@
+export { lookupByMbs } from "./client.js";
+export {
+  SudregAPIError,
+  SudregError,
+  SudregParseError,
+  SudregRequestError,
+  SudregValidationError,
+} from "./errors.js";
+export { parseAddress, parseCompanyPage } from "./parse.js";
+export { toNormalizedEntity, toNormalizedSearchResult } from "./normalized.js";
+export type { SudregAddress, SudregCompany, SudregWarning } from "./types.js";
+export { normalizeMbs, validateMbs } from "./validation.js";

--- a/packages/business-registries/src/sudreg/normalized.test.ts
+++ b/packages/business-registries/src/sudreg/normalized.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "bun:test";
+
+import { toNormalizedEntity, toNormalizedSearchResult } from "./normalized.js";
+import { parseCompanyPage } from "./parse.js";
+
+describe("SUDREG normalized projection", () => {
+  test("preserves address, capital, legal form, URL, and warnings", async () => {
+    const html = await Bun.file(
+      new URL("__fixtures__/company.html", import.meta.url),
+    ).text();
+    const company = parseCompanyPage(html, "080000014");
+    expect(company).not.toBeNull();
+    if (!company) {
+      return;
+    }
+    company.warnings.push({ type: "unexpected-address-format" });
+    const entity = toNormalizedEntity(company);
+    expect(entity.registryId.scheme).toBe("HR-MBS");
+    expect(String(entity.registryId.value)).toBe("080000014");
+    expect(entity.address).toMatchObject({
+      availability: "available",
+      value: { houseNumber: "10" },
+    });
+    expect(entity.shareCapital).toMatchObject({
+      availability: "available",
+      value: { text: "850.068.230,00 euro" },
+    });
+    expect(entity.warnings).toEqual({
+      availability: "available",
+      value: [{ code: "unexpected-address-format" }],
+    });
+    expect(entity.status).toEqual({ availability: "not-supported" });
+  });
+
+  test("derives a search row without inventing status", async () => {
+    const html = await Bun.file(
+      new URL("__fixtures__/company.html", import.meta.url),
+    ).text();
+    const company = parseCompanyPage(html, "080000014");
+    expect(company).not.toBeNull();
+    if (!company) {
+      return;
+    }
+    const result = toNormalizedSearchResult(company);
+    expect(result.status).toEqual({ availability: "not-supported" });
+  });
+});

--- a/packages/business-registries/src/sudreg/normalized.ts
+++ b/packages/business-registries/src/sudreg/normalized.ts
@@ -1,6 +1,6 @@
 import {
   availableField,
-  fromValidatedRegistryIdentifier,
+  toValidatedRegistryIdentifier,
   unsupportedField,
 } from "../shared/normalized.js";
 import type {
@@ -9,6 +9,7 @@ import type {
   NormalizedRegistrySearchResult,
 } from "../shared/normalized.js";
 import type { SudregAddress, SudregCompany } from "./types.js";
+import { validateMbs } from "./validation.js";
 
 const normalizeAddress = (
   address: SudregAddress,
@@ -29,7 +30,11 @@ export const toNormalizedEntity = (
   company: SudregCompany,
 ): NormalizedRegistryEntity => ({
   country: "HR",
-  registryId: fromValidatedRegistryIdentifier("HR-MBS", company.mbs),
+  registryId: toValidatedRegistryIdentifier({
+    scheme: "HR-MBS",
+    value: company.mbs,
+    validate: validateMbs,
+  }),
   identifiers: [],
   name: company.name,
   nameWithoutLegalForm: unsupportedField(),
@@ -63,7 +68,11 @@ export const toNormalizedSearchResult = (
   company: SudregCompany,
 ): NormalizedRegistrySearchResult => ({
   country: "HR",
-  registryId: fromValidatedRegistryIdentifier("HR-MBS", company.mbs),
+  registryId: toValidatedRegistryIdentifier({
+    scheme: "HR-MBS",
+    value: company.mbs,
+    validate: validateMbs,
+  }),
   name: company.name,
   legalForm: availableField(
     company.legalForm ? { code: null, label: company.legalForm } : null,

--- a/packages/business-registries/src/sudreg/normalized.ts
+++ b/packages/business-registries/src/sudreg/normalized.ts
@@ -1,0 +1,74 @@
+import {
+  availableField,
+  fromValidatedRegistryIdentifier,
+  unsupportedField,
+} from "../shared/normalized.js";
+import type {
+  NormalizedRegistryAddress,
+  NormalizedRegistryEntity,
+  NormalizedRegistrySearchResult,
+} from "../shared/normalized.js";
+import type { SudregAddress, SudregCompany } from "./types.js";
+
+const normalizeAddress = (
+  address: SudregAddress,
+): NormalizedRegistryAddress => ({
+  streetName: address.street,
+  houseNumber: address.houseNumber,
+  orientationNumber: address.orientationNumber,
+  orientationLetter: address.orientationLetter,
+  municipalityPart: address.municipalityPart,
+  municipality: address.municipality,
+  postalCode: null,
+  county: null,
+  stateName: null,
+  textAddress: address.textAddress,
+});
+
+export const toNormalizedEntity = (
+  company: SudregCompany,
+): NormalizedRegistryEntity => ({
+  country: "HR",
+  registryId: fromValidatedRegistryIdentifier("HR-MBS", company.mbs),
+  identifiers: [],
+  name: company.name,
+  nameWithoutLegalForm: unsupportedField(),
+  legalForm: availableField(
+    company.legalForm ? { code: null, label: company.legalForm } : null,
+  ),
+  status: unsupportedField(),
+  statusDetail: null,
+  address: availableField(
+    company.address ? normalizeAddress(company.address) : null,
+  ),
+  creationDate: unsupportedField(),
+  registrationDate: unsupportedField(),
+  removalDate: unsupportedField(),
+  registryRecord: unsupportedField(),
+  keyPeople: unsupportedField(),
+  shareCapital: availableField(
+    company.shareCapital
+      ? { text: company.shareCapital, amount: null, currency: null }
+      : null,
+  ),
+  shareCapitalPaid: unsupportedField(),
+  actingClause: unsupportedField(),
+  registryUrl: availableField(company.registryUrl),
+  warnings: availableField(
+    company.warnings.map((warning) => ({ code: warning.type })),
+  ),
+});
+
+export const toNormalizedSearchResult = (
+  company: SudregCompany,
+): NormalizedRegistrySearchResult => ({
+  country: "HR",
+  registryId: fromValidatedRegistryIdentifier("HR-MBS", company.mbs),
+  name: company.name,
+  legalForm: availableField(
+    company.legalForm ? { code: null, label: company.legalForm } : null,
+  ),
+  status: unsupportedField(),
+  address: availableField(company.address?.textAddress ?? null),
+  registryUrl: availableField(company.registryUrl),
+});

--- a/packages/business-registries/src/sudreg/parse.test.ts
+++ b/packages/business-registries/src/sudreg/parse.test.ts
@@ -58,6 +58,23 @@ describe("SUDREG parser", () => {
     });
   });
 
+  test.each([
+    ["Ilica 12A", "12", null, "A"],
+    ["Ilica 12/2A", "12", "2", "A"],
+    ["Ilica 12/V", "12", null, "V"],
+    ["Ilica 12/2 A", "12", "2", "A"],
+  ])(
+    "parses compact Croatian street number %s",
+    (line, houseNumber, orientationNumber, orientationLetter) => {
+      expect(parseAddress(`Zagreb\n${line}`).address).toMatchObject({
+        street: "Ilica",
+        houseNumber,
+        orientationNumber,
+        orientationLetter,
+      });
+    },
+  );
+
   test("accepts the alternate official company-name heading", () => {
     expect(
       parseCompanyPage(

--- a/packages/business-registries/src/sudreg/parse.test.ts
+++ b/packages/business-registries/src/sudreg/parse.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, test } from "bun:test";
+
+import { SudregParseError } from "./errors.js";
+import { parseAddress, parseCompanyPage } from "./parse.js";
+
+const FIXTURE = new URL("__fixtures__/company.html", import.meta.url);
+
+describe("SUDREG parser", () => {
+  test("parses the registry sections without a DOM implementation", async () => {
+    const html = await Bun.file(FIXTURE).text();
+    expect(parseCompanyPage(html, "080000014")).toEqual({
+      mbs: "080000014",
+      name: "PRIMJER DIONIČKO DRUŠTVO & PARTNERI",
+      address: {
+        street: "Trg primjera",
+        houseNumber: "10",
+        orientationNumber: "2",
+        orientationLetter: "A",
+        municipalityPart: "Zagreb",
+        municipality: "Zagreb",
+        textAddress: "Zagreb (Grad Zagreb), Trg primjera 10/2 A",
+      },
+      shareCapital: "850.068.230,00 euro",
+      legalForm: "dioničko društvo",
+      warnings: [],
+      registryUrl:
+        "https://sudreg.pravosudje.hr/ords/r/esudreg/public/28?p28_sbt_mbs=080000014",
+    });
+  });
+
+  test("handles a municipality without a Grad or Općina wrapper", () => {
+    expect(parseAddress("Rijeka\nUlica lipa 12")).toEqual({
+      address: {
+        street: "Ulica lipa",
+        houseNumber: "12",
+        orientationNumber: null,
+        orientationLetter: null,
+        municipalityPart: null,
+        municipality: "Rijeka",
+        textAddress: "Rijeka, Ulica lipa 12",
+      },
+      warnings: [],
+    });
+  });
+
+  test("parses a roman orientation suffix without losing the street", () => {
+    expect(parseAddress("Rijeka\nUlica lipa 12/V")).toEqual({
+      address: {
+        street: "Ulica lipa",
+        houseNumber: "12",
+        orientationNumber: null,
+        orientationLetter: "V",
+        municipalityPart: null,
+        municipality: "Rijeka",
+        textAddress: "Rijeka, Ulica lipa 12/V",
+      },
+      warnings: [],
+    });
+  });
+
+  test("accepts the alternate official company-name heading", () => {
+    expect(
+      parseCompanyPage(
+        '<h2 class="srn-kat-title">MBS</h2><table><tr><td>050023577</td></tr></table><h2 class="srn-kat-title">Naziv</h2><table><tr><td>PRIMJER d.o.o.</td></tr></table>',
+        "050023577",
+      )?.name,
+    ).toBe("PRIMJER d.o.o.");
+  });
+
+  test("rejects a response for a different registry identifier", () => {
+    expect(() =>
+      parseCompanyPage(
+        '<h2 class="srn-kat-title">MBS</h2><table><tr><td>080000014</td></tr></table><h2 class="srn-kat-title">Tvrtka</h2><table><tr><td>PRIMJER d.o.o.</td></tr></table>',
+        "050023577",
+      ),
+    ).toThrow(SudregParseError);
+  });
+
+  test("surfaces a warning instead of guessing an unknown parenthesized address", () => {
+    expect(parseAddress("Zagreb (nepoznato)\nIlica 1").warnings).toEqual([
+      { type: "unexpected-address-format" },
+    ]);
+  });
+
+  test("returns null for the registry not-found sentinel", () => {
+    expect(
+      parseCompanyPage(
+        "U sudskom registru nije evidentirano društvo sa zadanim matičnim brojem",
+        "080015009",
+      ),
+    ).toBeNull();
+  });
+
+  test("fails loudly when the response no longer contains the company name", () => {
+    expect(() =>
+      parseCompanyPage(
+        '<h2 class="srn-kat-title">MBS</h2><table><tr><td>080000014</td></tr></table>',
+        "080000014",
+      ),
+    ).toThrow(SudregParseError);
+  });
+});

--- a/packages/business-registries/src/sudreg/parse.ts
+++ b/packages/business-registries/src/sudreg/parse.ts
@@ -1,0 +1,181 @@
+import { SudregParseError } from "./errors.js";
+import type { SudregAddress, SudregCompany, SudregWarning } from "./types.js";
+
+const NOT_FOUND_TEXT =
+  "U sudskom registru nije evidentirano društvo sa zadanim matičnim brojem";
+const SECTION_HEADING_PATTERN =
+  /<h2\b[^>]*class=["'][^"']*\bsrn-kat-title\b[^"']*["'][^>]*>(?<title>[\s\S]*?)<\/h2>/giu;
+const TABLE_CELL_PATTERN = /<td\b[^>]*>(?<value>[\s\S]*?)<\/td>/iu;
+const TAG_PATTERN = /<[^>]+>/gu;
+const BREAK_PATTERN = /<br\s*\/?\s*>/giu;
+const NAMED_ENTITIES: Record<string, string> = {
+  amp: "&",
+  apos: "'",
+  gt: ">",
+  lt: "<",
+  nbsp: " ",
+  quot: '"',
+};
+const ENTITY_PATTERN = /&(?<entity>#x[\da-f]+|#\d+|[a-z]+);/giu;
+
+const decodeHtmlEntities = (value: string): string => {
+  let decoded = "";
+  let cursor = 0;
+  for (const match of value.matchAll(ENTITY_PATTERN)) {
+    const index = match.index;
+    const entity = match.groups?.["entity"];
+    if (entity === undefined) {
+      continue;
+    }
+    decoded += value.slice(cursor, index);
+    if (entity.toLowerCase().startsWith("#x")) {
+      decoded += String.fromCodePoint(Number.parseInt(entity.slice(2), 16));
+    } else if (entity.startsWith("#")) {
+      decoded += String.fromCodePoint(Number.parseInt(entity.slice(1), 10));
+    } else {
+      decoded += NAMED_ENTITIES[entity.toLowerCase()] ?? match[0];
+    }
+    cursor = index + match[0].length;
+  }
+  return decoded + value.slice(cursor);
+};
+
+const htmlToText = (value: string): string =>
+  decodeHtmlEntities(
+    value.replaceAll(BREAK_PATTERN, "\n").replaceAll(TAG_PATTERN, ""),
+  )
+    .split("\n")
+    .map((line) => line.replaceAll(/\s+/gu, " ").trim())
+    .filter((line) => line.length > 0)
+    .join("\n");
+
+const extractSection = (
+  html: string,
+  titles: string | readonly string[],
+): string | null => {
+  const acceptedTitles = new Set(
+    typeof titles === "string" ? [titles] : titles,
+  );
+  SECTION_HEADING_PATTERN.lastIndex = 0;
+  for (const match of html.matchAll(SECTION_HEADING_PATTERN)) {
+    const rawTitle = match.groups?.["title"];
+    if (!rawTitle || !acceptedTitles.has(htmlToText(rawTitle))) {
+      continue;
+    }
+    const sectionStart = match.index + match[0].length;
+    const sectionEnd = html.indexOf("</div>", sectionStart);
+    const section = html.slice(
+      sectionStart,
+      sectionEnd === -1 ? html.length : sectionEnd,
+    );
+    const cell = TABLE_CELL_PATTERN.exec(section);
+    return cell?.groups?.["value"] ? htmlToText(cell.groups["value"]) : null;
+  }
+  return null;
+};
+
+const parseStreet = (
+  line: string,
+): Pick<
+  SudregAddress,
+  "street" | "houseNumber" | "orientationNumber" | "orientationLetter"
+> => {
+  const numberMatch =
+    /(?:^|\s)(?<houseNumber>\d+)(?:(?:\s*\/\s*(?<orientationNumber>\d+)(?:\s*(?<orientationLetter>[a-z]))?)|(?:\s*\/\s*(?<slashLetter>[a-z]))|(?:\s*(?<houseLetter>[a-z])))?$/iu.exec(
+      line,
+    );
+  if (!numberMatch?.groups) {
+    return {
+      street: line || null,
+      houseNumber: null,
+      orientationNumber: null,
+      orientationLetter: null,
+    };
+  }
+  const street = line.slice(0, numberMatch.index).trim();
+  return {
+    street: street || null,
+    houseNumber: numberMatch.groups["houseNumber"] ?? null,
+    orientationNumber: numberMatch.groups["orientationNumber"] ?? null,
+    orientationLetter:
+      numberMatch.groups["orientationLetter"] ??
+      numberMatch.groups["slashLetter"] ??
+      numberMatch.groups["houseLetter"] ??
+      null,
+  };
+};
+
+export const parseAddress = (
+  text: string,
+): { address: SudregAddress | null; warnings: SudregWarning[] } => {
+  const lines = text
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+  const municipalityLine = lines.at(0);
+  if (!municipalityLine) {
+    return { address: null, warnings: [] };
+  }
+
+  const municipalityMatch =
+    /^(?<part>.*?)\s*\((?:Grad|Općina)\s+(?<municipality>[^)]+)\)$/u.exec(
+      municipalityLine,
+    );
+  const municipality =
+    municipalityMatch?.groups?.["municipality"] ?? municipalityLine;
+  const municipalityPart = municipalityMatch?.groups?.["part"] || null;
+  const unexpectedMunicipality =
+    municipalityLine.includes("(") && municipalityMatch === null;
+  const street = parseStreet(lines.at(1) ?? "");
+
+  return {
+    address: {
+      ...street,
+      municipalityPart,
+      municipality,
+      textAddress: lines.join(", "),
+    },
+    warnings: unexpectedMunicipality
+      ? [{ type: "unexpected-address-format" }]
+      : [],
+  };
+};
+
+const buildRegistryUrl = (mbs: string): string =>
+  `https://sudreg.pravosudje.hr/ords/r/esudreg/public/28?p28_sbt_mbs=${encodeURIComponent(mbs)}`;
+
+export const parseCompanyPage = (
+  html: string,
+  requestedMbs: string,
+): SudregCompany | null => {
+  if (html.includes(NOT_FOUND_TEXT)) {
+    return null;
+  }
+
+  const mbs = extractSection(html, "MBS") ?? requestedMbs;
+  if (mbs !== requestedMbs) {
+    throw new SudregParseError(
+      `SUDREG returned MBS ${mbs} for requested MBS ${requestedMbs}`,
+    );
+  }
+  const name = extractSection(html, ["Tvrtka", "Naziv"]);
+  if (!name) {
+    throw new SudregParseError(
+      "SUDREG response did not contain a company name",
+    );
+  }
+  const addressText = extractSection(html, "Sjedište/adresa");
+  const parsedAddress = addressText
+    ? parseAddress(addressText)
+    : { address: null, warnings: [] };
+
+  return {
+    mbs,
+    name,
+    address: parsedAddress.address,
+    shareCapital: extractSection(html, "Temeljni kapital"),
+    legalForm: extractSection(html, "Pravni oblik"),
+    warnings: parsedAddress.warnings,
+    registryUrl: buildRegistryUrl(mbs),
+  };
+};

--- a/packages/business-registries/src/sudreg/parse.ts
+++ b/packages/business-registries/src/sudreg/parse.ts
@@ -134,7 +134,8 @@ const parseStreet = (
   SudregAddress,
   "street" | "houseNumber" | "orientationNumber" | "orientationLetter"
 > => {
-  const suffixMatch = /^(?<houseNumber>\d+)(?:\/(?<orientation>[\da-z]+))?$/iu;
+  const suffixMatch =
+    /^(?<houseNumber>\d+)(?<houseLetter>[a-z])?(?:\/(?:(?<orientationNumber>\d+)(?<orientationLetter>[a-z]+)?|(?<orientationLetterOnly>[a-z]+)))?$/iu;
   const words = line.split(/\s+/u);
   const lastWord = words.at(-1) ?? "";
   const precedingWord = words.at(-2) ?? "";
@@ -156,18 +157,17 @@ const parseStreet = (
     separateLetter ? precedingWord : lastWord,
   );
   const street = line.slice(0, suffixStart).trim();
-  const orientation = numberMatch.groups["orientation"] ?? null;
-  let orientationLetter: string | null = null;
-  if (separateLetter) {
-    orientationLetter = lastWord;
-  } else if (orientation && /^[a-z]+$/iu.test(orientation)) {
-    orientationLetter = orientation;
-  }
+  const orientationNumber = numberMatch.groups["orientationNumber"] ?? null;
+  const orientationLetter = separateLetter
+    ? lastWord
+    : (numberMatch.groups["orientationLetter"] ??
+      numberMatch.groups["orientationLetterOnly"] ??
+      numberMatch.groups["houseLetter"] ??
+      null);
   return {
     street: street || null,
     houseNumber: numberMatch.groups["houseNumber"] ?? null,
-    orientationNumber:
-      orientation && /^\d+$/u.test(orientation) ? orientation : null,
+    orientationNumber,
     orientationLetter,
   };
 };

--- a/packages/business-registries/src/sudreg/parse.ts
+++ b/packages/business-registries/src/sudreg/parse.ts
@@ -3,11 +3,6 @@ import type { SudregAddress, SudregCompany, SudregWarning } from "./types.js";
 
 const NOT_FOUND_TEXT =
   "U sudskom registru nije evidentirano društvo sa zadanim matičnim brojem";
-const SECTION_HEADING_PATTERN =
-  /<h2\b[^>]*class=["'][^"']*\bsrn-kat-title\b[^"']*["'][^>]*>(?<title>[\s\S]*?)<\/h2>/giu;
-const TABLE_CELL_PATTERN = /<td\b[^>]*>(?<value>[\s\S]*?)<\/td>/iu;
-const TAG_PATTERN = /<[^>]+>/gu;
-const BREAK_PATTERN = /<br\s*\/?\s*>/giu;
 const NAMED_ENTITIES: Record<string, string> = {
   amp: "&",
   apos: "'",
@@ -40,38 +35,97 @@ const decodeHtmlEntities = (value: string): string => {
   return decoded + value.slice(cursor);
 };
 
+const withoutHtmlTags = (value: string): string => {
+  let text = "";
+  let cursor = 0;
+  while (cursor < value.length) {
+    const tagStart = value.indexOf("<", cursor);
+    if (tagStart === -1) {
+      return text + value.slice(cursor);
+    }
+    text += value.slice(cursor, tagStart);
+    const tagEnd = value.indexOf(">", tagStart + 1);
+    if (tagEnd === -1) {
+      return text + value.slice(tagStart);
+    }
+    const tag = value
+      .slice(tagStart + 1, tagEnd)
+      .trim()
+      .toLowerCase();
+    if (tag === "br" || tag === "br/" || tag.startsWith("br ")) {
+      text += "\n";
+    }
+    cursor = tagEnd + 1;
+  }
+  return text;
+};
+
 const htmlToText = (value: string): string =>
-  decodeHtmlEntities(
-    value.replaceAll(BREAK_PATTERN, "\n").replaceAll(TAG_PATTERN, ""),
-  )
+  decodeHtmlEntities(withoutHtmlTags(value))
     .split("\n")
     .map((line) => line.replaceAll(/\s+/gu, " ").trim())
     .filter((line) => line.length > 0)
     .join("\n");
 
-const extractSection = (
-  html: string,
-  titles: string | readonly string[],
-): string | null => {
-  const acceptedTitles = new Set(
-    typeof titles === "string" ? [titles] : titles,
-  );
-  SECTION_HEADING_PATTERN.lastIndex = 0;
-  for (const match of html.matchAll(SECTION_HEADING_PATTERN)) {
-    const rawTitle = match.groups?.["title"];
-    if (!rawTitle || !acceptedTitles.has(htmlToText(rawTitle))) {
+const attributeValue = (openingTag: string, name: string): string | null => {
+  const lower = openingTag.toLowerCase();
+  const marker = `${name.toLowerCase()}=`;
+  const markerStart = lower.indexOf(marker);
+  if (markerStart === -1) {
+    return null;
+  }
+  const valueStart = markerStart + marker.length;
+  const quote = openingTag[valueStart];
+  if (quote !== '"' && quote !== "'") {
+    return null;
+  }
+  const valueEnd = openingTag.indexOf(quote, valueStart + 1);
+  return valueEnd === -1 ? null : openingTag.slice(valueStart + 1, valueEnd);
+};
+
+const hasClass = (openingTag: string, className: string): boolean =>
+  attributeValue(openingTag, "class")?.split(/\s+/u).includes(className) ??
+  false;
+
+const extractSections = (html: string): ReadonlyMap<string, string> => {
+  const sections = new Map<string, string>();
+  const lower = html.toLowerCase();
+  let cursor = 0;
+  while (cursor < html.length) {
+    const headingStart = lower.indexOf("<h2", cursor);
+    if (headingStart === -1) {
+      break;
+    }
+    const openingEnd = html.indexOf(">", headingStart + 3);
+    if (openingEnd === -1) {
+      break;
+    }
+    const closingStart = lower.indexOf("</h2>", openingEnd + 1);
+    if (closingStart === -1) {
+      break;
+    }
+    cursor = closingStart + 5;
+    if (!hasClass(html.slice(headingStart, openingEnd + 1), "srn-kat-title")) {
       continue;
     }
-    const sectionStart = match.index + match[0].length;
-    const sectionEnd = html.indexOf("</div>", sectionStart);
-    const section = html.slice(
-      sectionStart,
-      sectionEnd === -1 ? html.length : sectionEnd,
-    );
-    const cell = TABLE_CELL_PATTERN.exec(section);
-    return cell?.groups?.["value"] ? htmlToText(cell.groups["value"]) : null;
+    const title = htmlToText(html.slice(openingEnd + 1, closingStart));
+    const sectionEnd = lower.indexOf("</div>", cursor);
+    const boundedEnd = sectionEnd === -1 ? html.length : sectionEnd;
+    const cellStart = lower.indexOf("<td", cursor);
+    if (cellStart === -1 || cellStart >= boundedEnd) {
+      continue;
+    }
+    const cellOpeningEnd = html.indexOf(">", cellStart + 3);
+    if (cellOpeningEnd === -1 || cellOpeningEnd >= boundedEnd) {
+      continue;
+    }
+    const cellEnd = lower.indexOf("</td>", cellOpeningEnd + 1);
+    if (cellEnd === -1 || cellEnd > boundedEnd) {
+      continue;
+    }
+    sections.set(title, htmlToText(html.slice(cellOpeningEnd + 1, cellEnd)));
   }
-  return null;
+  return sections;
 };
 
 const parseStreet = (
@@ -80,10 +134,16 @@ const parseStreet = (
   SudregAddress,
   "street" | "houseNumber" | "orientationNumber" | "orientationLetter"
 > => {
-  const numberMatch =
-    /(?:^|\s)(?<houseNumber>\d+)(?:(?:\s*\/\s*(?<orientationNumber>\d+)(?:\s*(?<orientationLetter>[a-z]))?)|(?:\s*\/\s*(?<slashLetter>[a-z]))|(?:\s*(?<houseLetter>[a-z])))?$/iu.exec(
-      line,
-    );
+  const suffixMatch = /^(?<houseNumber>\d+)(?:\/(?<orientation>[\da-z]+))?$/iu;
+  const words = line.split(/\s+/u);
+  const lastWord = words.at(-1) ?? "";
+  const precedingWord = words.at(-2) ?? "";
+  const separateLetter = /^[a-z]$/iu.test(lastWord);
+  const suffix = (separateLetter ? precedingWord : lastWord).replaceAll(
+    /\s/gu,
+    "",
+  );
+  const numberMatch = suffixMatch.exec(suffix);
   if (!numberMatch?.groups) {
     return {
       street: line || null,
@@ -92,16 +152,23 @@ const parseStreet = (
       orientationLetter: null,
     };
   }
-  const street = line.slice(0, numberMatch.index).trim();
+  const suffixStart = line.lastIndexOf(
+    separateLetter ? precedingWord : lastWord,
+  );
+  const street = line.slice(0, suffixStart).trim();
+  const orientation = numberMatch.groups["orientation"] ?? null;
+  let orientationLetter: string | null = null;
+  if (separateLetter) {
+    orientationLetter = lastWord;
+  } else if (orientation && /^[a-z]+$/iu.test(orientation)) {
+    orientationLetter = orientation;
+  }
   return {
     street: street || null,
     houseNumber: numberMatch.groups["houseNumber"] ?? null,
-    orientationNumber: numberMatch.groups["orientationNumber"] ?? null,
-    orientationLetter:
-      numberMatch.groups["orientationLetter"] ??
-      numberMatch.groups["slashLetter"] ??
-      numberMatch.groups["houseLetter"] ??
-      null,
+    orientationNumber:
+      orientation && /^\d+$/u.test(orientation) ? orientation : null,
+    orientationLetter,
   };
 };
 
@@ -117,15 +184,23 @@ export const parseAddress = (
     return { address: null, warnings: [] };
   }
 
-  const municipalityMatch =
-    /^(?<part>.*?)\s*\((?:Grad|Općina)\s+(?<municipality>[^)]+)\)$/u.exec(
-      municipalityLine,
-    );
-  const municipality =
-    municipalityMatch?.groups?.["municipality"] ?? municipalityLine;
-  const municipalityPart = municipalityMatch?.groups?.["part"] || null;
+  const wrapperStart = municipalityLine.lastIndexOf(" (");
+  const wrapper =
+    wrapperStart === -1 || !municipalityLine.endsWith(")")
+      ? null
+      : municipalityLine.slice(wrapperStart + 2, -1);
+  let municipality = municipalityLine;
+  if (wrapper?.startsWith("Grad ") === true) {
+    municipality = wrapper.slice(5);
+  } else if (wrapper?.startsWith("Općina ") === true) {
+    municipality = wrapper.slice(7);
+  }
+  const municipalityPart =
+    municipality === municipalityLine
+      ? null
+      : municipalityLine.slice(0, wrapperStart).trim() || null;
   const unexpectedMunicipality =
-    municipalityLine.includes("(") && municipalityMatch === null;
+    municipalityLine.includes("(") && municipality === municipalityLine;
   const street = parseStreet(lines.at(1) ?? "");
 
   return {
@@ -152,19 +227,20 @@ export const parseCompanyPage = (
     return null;
   }
 
-  const mbs = extractSection(html, "MBS") ?? requestedMbs;
+  const sections = extractSections(html);
+  const mbs = sections.get("MBS") ?? requestedMbs;
   if (mbs !== requestedMbs) {
     throw new SudregParseError(
       `SUDREG returned MBS ${mbs} for requested MBS ${requestedMbs}`,
     );
   }
-  const name = extractSection(html, ["Tvrtka", "Naziv"]);
+  const name = sections.get("Tvrtka") ?? sections.get("Naziv");
   if (!name) {
     throw new SudregParseError(
       "SUDREG response did not contain a company name",
     );
   }
-  const addressText = extractSection(html, "Sjedište/adresa");
+  const addressText = sections.get("Sjedište/adresa") ?? null;
   const parsedAddress = addressText
     ? parseAddress(addressText)
     : { address: null, warnings: [] };
@@ -173,8 +249,8 @@ export const parseCompanyPage = (
     mbs,
     name,
     address: parsedAddress.address,
-    shareCapital: extractSection(html, "Temeljni kapital"),
-    legalForm: extractSection(html, "Pravni oblik"),
+    shareCapital: sections.get("Temeljni kapital") ?? null,
+    legalForm: sections.get("Pravni oblik") ?? null,
     warnings: parsedAddress.warnings,
     registryUrl: buildRegistryUrl(mbs),
   };

--- a/packages/business-registries/src/sudreg/types.ts
+++ b/packages/business-registries/src/sudreg/types.ts
@@ -1,0 +1,23 @@
+export type SudregAddress = {
+  street: string | null;
+  houseNumber: string | null;
+  orientationNumber: string | null;
+  orientationLetter: string | null;
+  municipalityPart: string | null;
+  municipality: string | null;
+  textAddress: string;
+};
+
+export type SudregWarning = {
+  type: "unexpected-address-format";
+};
+
+export type SudregCompany = {
+  mbs: string;
+  name: string;
+  address: SudregAddress | null;
+  shareCapital: string | null;
+  legalForm: string | null;
+  warnings: SudregWarning[];
+  registryUrl: string;
+};

--- a/packages/business-registries/src/sudreg/validation.test.ts
+++ b/packages/business-registries/src/sudreg/validation.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "bun:test";
+
+import { normalizeMbs, validateMbs } from "./validation.js";
+
+describe("Croatian MBS validation", () => {
+  test("normalizes whitespace while preserving leading zeroes", () => {
+    expect(normalizeMbs("080 000 014")).toBe("080000014");
+  });
+
+  test("accepts only nine ASCII digits", () => {
+    expect(validateMbs("080000014")).toBe(true);
+    expect(validateMbs("80000014")).toBe(false);
+    expect(validateMbs("08000001A")).toBe(false);
+    expect(validateMbs("٠٨٠٠٠٠٠١٤")).toBe(false);
+  });
+});

--- a/packages/business-registries/src/sudreg/validation.ts
+++ b/packages/business-registries/src/sudreg/validation.ts
@@ -1,0 +1,5 @@
+export const normalizeMbs = (input: string): string =>
+  input.trim().replaceAll(/\s/gu, "");
+
+export const validateMbs = (input: string): boolean =>
+  /^\d{9}$/u.test(normalizeMbs(input));

--- a/packages/business-registries/src/zefix/__fixtures__/search-swiss-re.json
+++ b/packages/business-registries/src/zefix/__fixtures__/search-swiss-re.json
@@ -1,0 +1,24 @@
+{
+  "list": [
+    {
+      "name": "Swiss Re AG",
+      "ehraid": 1009345,
+      "uid": "CHE191546434",
+      "uidFormatted": "CHE-191.546.434",
+      "chid": "CH02030361838",
+      "chidFormatted": "CH-020-3036183-8",
+      "legalSeatId": 261,
+      "legalSeat": "Zürich",
+      "registerOfficeId": 20,
+      "legalFormId": 3,
+      "status": "EXISTIEREND",
+      "shabDate": "2026-05-08",
+      "deleteDate": null,
+      "cantonalExcerptWeb": "https://zh.chregister.ch/cr-portal/auszug/auszug.xhtml?uid=CHE-191.546.434"
+    }
+  ],
+  "hasMoreResults": false,
+  "offset": 0,
+  "maxEntries": 2,
+  "maxOffset": null
+}

--- a/packages/business-registries/src/zefix/client.test.ts
+++ b/packages/business-registries/src/zefix/client.test.ts
@@ -1,0 +1,147 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { lookupByUid, searchByName } from "./client.js";
+import { ZefixAPIError, ZefixValidationError } from "./errors.js";
+import type { ZefixRawFirm, ZefixSearchResponse } from "./types.js";
+
+const SKIP_LIVE = process.env["SMOKE_TEST"] !== "1";
+const FIXTURE = new URL("__fixtures__/search-swiss-re.json", import.meta.url);
+
+const readFixture = async (): Promise<ZefixSearchResponse> => {
+  const value: unknown = await Bun.file(FIXTURE).json();
+  // SAFETY: the captured response is checked by the client shape guard.
+  // eslint-disable-next-line typescript-eslint/no-unsafe-type-assertion
+  return value as ZefixSearchResponse;
+};
+
+const installFetchStub = (
+  handler: (
+    input: URL | Request | string,
+    init?: RequestInit,
+  ) => Promise<Response>,
+) => {
+  const original = globalThis.fetch;
+  globalThis.fetch = Object.assign(
+    async (input: URL | Request | string, init?: RequestInit) =>
+      handler(input, init),
+    { preconnect: original.preconnect },
+  );
+  return () => {
+    globalThis.fetch = original;
+  };
+};
+
+describe.skipIf(SKIP_LIVE)("Zefix live", () => {
+  test("looks up Swiss Re by UID", async () => {
+    const company = await lookupByUid("CHE-191.546.434");
+    expect(company?.name).toBe("Swiss Re AG");
+    expect(company?.status).toEqual({ type: "active" });
+  });
+});
+
+describe("Zefix client", () => {
+  let restore = () => {};
+  afterEach(() => {
+    restore();
+    restore = () => {};
+  });
+
+  test("looks up and normalizes a formatted UID", async () => {
+    const fixture = await readFixture();
+    let body = "";
+    restore = installFetchStub(async (_input, init) => {
+      body = typeof init?.body === "string" ? init.body : "";
+      return new Response(JSON.stringify(fixture), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+
+    const company = await lookupByUid("CHE-191.546.434");
+    expect(company).toEqual({
+      uid: "191546434",
+      uidFormatted: "CHE-191.546.434",
+      name: "Swiss Re AG",
+      legalSeat: "Zürich",
+      legalFormId: 3,
+      status: { type: "active" },
+      registryUrl:
+        "https://zh.chregister.ch/cr-portal/auszug/auszug.xhtml?uid=CHE-191.546.434",
+    });
+    expect(JSON.parse(body)).toMatchObject({
+      name: "191546434",
+      maxEntries: 2,
+    });
+  });
+
+  test("returns null for the registry no-result envelope", async () => {
+    restore = installFetchStub(
+      async () =>
+        new Response(
+          JSON.stringify({ error: { code: "API.ZFR.SEARCH.NORESULT" } }),
+          { status: 404, headers: { "Content-Type": "application/json" } },
+        ),
+    );
+    expect(lookupByUid("191546434")).resolves.toBeNull();
+  });
+
+  test("does not accept a fuzzy nonmatching hit for ID lookup", async () => {
+    const fixture = await readFixture();
+    const list: ZefixRawFirm[] = [];
+    for (const entry of fixture.list ?? []) {
+      list.push({
+        ...entry,
+        uid: "CHE116281710",
+        uidFormatted: "CHE-116.281.710",
+      });
+    }
+    restore = installFetchStub(
+      async () =>
+        new Response(
+          JSON.stringify({
+            ...fixture,
+            list,
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+    );
+    expect(lookupByUid("191546434")).resolves.toBeNull();
+  });
+
+  test("searches by name and forwards a bounded result count", async () => {
+    const fixture = await readFixture();
+    let body = "";
+    restore = installFetchStub(async (_input, init) => {
+      body = typeof init?.body === "string" ? init.body : "";
+      return new Response(JSON.stringify(fixture), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+    const companies = await searchByName("Swiss Re", { limit: 500 });
+    expect(companies).toHaveLength(1);
+    expect(companies[0]?.uid).toBe("191546434");
+    expect(JSON.parse(body)).toMatchObject({
+      name: "Swiss Re",
+      maxEntries: 50,
+    });
+  });
+
+  test("rejects invalid UIDs and empty names before fetch", () => {
+    expect(lookupByUid("CHE-191.546.435")).rejects.toBeInstanceOf(
+      ZefixValidationError,
+    );
+    expect(searchByName("  ")).rejects.toBeInstanceOf(ZefixValidationError);
+  });
+
+  test("wraps malformed successful payloads", async () => {
+    restore = installFetchStub(
+      async () =>
+        new Response("not json", {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    );
+    expect(lookupByUid("191546434")).rejects.toBeInstanceOf(ZefixAPIError);
+  });
+});

--- a/packages/business-registries/src/zefix/client.test.ts
+++ b/packages/business-registries/src/zefix/client.test.ts
@@ -58,8 +58,12 @@ describe("Zefix client", () => {
     });
 
     const company = await lookupByUid("CHE-191.546.434");
-    expect(company).toEqual({
-      uid: "191546434",
+    expect(company).not.toBeNull();
+    if (!company) {
+      return;
+    }
+    expect(String(company.uid)).toBe("191546434");
+    expect(company).toMatchObject({
       uidFormatted: "CHE-191.546.434",
       name: "Swiss Re AG",
       legalSeat: "Zürich",
@@ -120,7 +124,7 @@ describe("Zefix client", () => {
     });
     const companies = await searchByName("Swiss Re", { limit: 500 });
     expect(companies).toHaveLength(1);
-    expect(companies[0]?.uid).toBe("191546434");
+    expect(String(companies.at(0)?.uid)).toBe("191546434");
     expect(JSON.parse(body)).toMatchObject({
       name: "Swiss Re",
       maxEntries: 50,
@@ -138,6 +142,17 @@ describe("Zefix client", () => {
     restore = installFetchStub(
       async () =>
         new Response("not json", {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    );
+    expect(lookupByUid("191546434")).rejects.toBeInstanceOf(ZefixAPIError);
+  });
+
+  test("rejects a successful response without a result list", async () => {
+    restore = installFetchStub(
+      async () =>
+        new Response(JSON.stringify({}), {
           status: 200,
           headers: { "Content-Type": "application/json" },
         }),

--- a/packages/business-registries/src/zefix/client.ts
+++ b/packages/business-registries/src/zefix/client.ts
@@ -1,0 +1,152 @@
+import { isRecord } from "../shared/guards.js";
+import { performRegistryRequest } from "../shared/http.js";
+import { clampSearchLimit } from "../shared/search.js";
+import {
+  ZefixAPIError,
+  ZefixRequestError,
+  ZefixValidationError,
+} from "./errors.js";
+import { parseFirm, parseSearchEntry } from "./parse.js";
+import type {
+  ZefixCompany,
+  ZefixRawFirm,
+  ZefixSearchResponse,
+  ZefixSearchResult,
+} from "./types.js";
+import { normalizeUid, validateUid } from "./validation.js";
+
+const SEARCH_URL = "https://www.zefix.ch/ZefixREST/api/v1/firm/search.json";
+const NO_RESULT_CODE = "API.ZFR.SEARCH.NORESULT";
+const DEFAULT_SEARCH_LIMIT = 50;
+const MAX_SEARCH_LIMIT = 50;
+
+const isOptionalString = (value: unknown): boolean =>
+  value === undefined || value === null || typeof value === "string";
+
+const isZefixRawFirm = (value: unknown): value is ZefixRawFirm =>
+  isRecord(value) &&
+  isOptionalString(value["name"]) &&
+  isOptionalString(value["uid"]) &&
+  isOptionalString(value["uidFormatted"]);
+
+const isZefixSearchResponse = (value: unknown): value is ZefixSearchResponse =>
+  isRecord(value) &&
+  (value["list"] === undefined ||
+    (Array.isArray(value["list"]) && value["list"].every(isZefixRawFirm))) &&
+  (value["error"] === undefined || isRecord(value["error"]));
+
+const getErrorCode = (value: unknown): string | null => {
+  if (!isRecord(value) || !isRecord(value["error"])) {
+    return null;
+  }
+  return typeof value["error"]["code"] === "string"
+    ? value["error"]["code"]
+    : null;
+};
+
+const zefixSearch = async (
+  nameOrId: string,
+  maxEntries: number,
+): Promise<ZefixSearchResponse | null> => {
+  const response = await performRegistryRequest({
+    url: SEARCH_URL,
+    init: {
+      method: "POST",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        languageKey: "en",
+        maxEntries,
+        offset: 0,
+        name: nameOrId,
+        searchType: "exact",
+      }),
+    },
+    wrapRequestError: (cause) =>
+      new ZefixRequestError(SEARCH_URL, "Zefix request failed", { cause }),
+  });
+
+  let body: unknown;
+  try {
+    body = await response.json();
+  } catch (error) {
+    throw new ZefixAPIError({
+      message: `Zefix ${response.status}: invalid JSON payload`,
+      httpStatus: response.status,
+      cause: error,
+    });
+  }
+
+  const errorCode = getErrorCode(body);
+  if (response.status === 404 && errorCode === NO_RESULT_CODE) {
+    return null;
+  }
+  if (!response.ok) {
+    throw new ZefixAPIError({
+      message: `Zefix ${response.status}: ${errorCode ?? response.statusText}`,
+      httpStatus: response.status,
+      upstreamCode: errorCode,
+    });
+  }
+  if (!isZefixSearchResponse(body)) {
+    throw new ZefixAPIError({
+      message: "Zefix returned an unexpected response shape",
+      httpStatus: response.status,
+    });
+  }
+  return body;
+};
+
+export const lookupByUid = async (
+  uidInput: string,
+): Promise<ZefixCompany | null> => {
+  const uid = normalizeUid(uidInput);
+  if (!validateUid(uid)) {
+    throw new ZefixValidationError(`Invalid Swiss UID: ${uidInput}`);
+  }
+
+  const response = await zefixSearch(uid, 2);
+  if (!response?.list) {
+    return null;
+  }
+  for (const entry of response.list) {
+    const company = parseFirm(entry);
+    if (company?.uid === uid) {
+      return company;
+    }
+  }
+  return null;
+};
+
+export type SearchOptions = {
+  /** Maximum number of results. @default 50 */
+  limit?: number;
+};
+
+export const searchByName = async (
+  name: string,
+  options?: SearchOptions,
+): Promise<ZefixSearchResult[]> => {
+  const trimmed = name.trim();
+  if (trimmed.length === 0) {
+    throw new ZefixValidationError("Search name must not be empty");
+  }
+  const limit = clampSearchLimit(
+    options?.limit ?? DEFAULT_SEARCH_LIMIT,
+    MAX_SEARCH_LIMIT,
+  );
+  const response = await zefixSearch(trimmed, limit);
+  if (!response?.list) {
+    return [];
+  }
+  const results: ZefixSearchResult[] = [];
+  for (const entry of response.list) {
+    const result = parseSearchEntry(entry);
+    if (result) {
+      results.push(result);
+    }
+  }
+  return results;
+};

--- a/packages/business-registries/src/zefix/client.ts
+++ b/packages/business-registries/src/zefix/client.ts
@@ -29,10 +29,16 @@ const isZefixRawFirm = (value: unknown): value is ZefixRawFirm =>
   isOptionalString(value["uid"]) &&
   isOptionalString(value["uidFormatted"]);
 
-const isZefixSearchResponse = (value: unknown): value is ZefixSearchResponse =>
+type ZefixSuccessfulSearchResponse = ZefixSearchResponse & {
+  list: ZefixRawFirm[];
+};
+
+const isZefixSearchResponse = (
+  value: unknown,
+): value is ZefixSuccessfulSearchResponse =>
   isRecord(value) &&
-  (value["list"] === undefined ||
-    (Array.isArray(value["list"]) && value["list"].every(isZefixRawFirm))) &&
+  Array.isArray(value["list"]) &&
+  value["list"].every(isZefixRawFirm) &&
   (value["error"] === undefined || isRecord(value["error"]));
 
 const getErrorCode = (value: unknown): string | null => {
@@ -47,7 +53,7 @@ const getErrorCode = (value: unknown): string | null => {
 const zefixSearch = async (
   nameOrId: string,
   maxEntries: number,
-): Promise<ZefixSearchResponse | null> => {
+): Promise<ZefixSuccessfulSearchResponse | null> => {
   const response = await performRegistryRequest({
     url: SEARCH_URL,
     init: {
@@ -108,7 +114,7 @@ export const lookupByUid = async (
   }
 
   const response = await zefixSearch(uid, 2);
-  if (!response?.list) {
+  if (!response) {
     return null;
   }
   for (const entry of response.list) {
@@ -138,7 +144,7 @@ export const searchByName = async (
     MAX_SEARCH_LIMIT,
   );
   const response = await zefixSearch(trimmed, limit);
-  if (!response?.list) {
+  if (!response) {
     return [];
   }
   const results: ZefixSearchResult[] = [];

--- a/packages/business-registries/src/zefix/errors.ts
+++ b/packages/business-registries/src/zefix/errors.ts
@@ -1,0 +1,47 @@
+import { RegistryError } from "../shared/errors.js";
+
+export class ZefixError extends RegistryError {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "ZefixError";
+  }
+}
+
+export class ZefixAPIError extends ZefixError {
+  readonly httpStatus: number;
+  readonly upstreamCode: string | null;
+
+  constructor({
+    cause,
+    message,
+    httpStatus,
+    upstreamCode,
+  }: {
+    cause?: unknown;
+    message: string;
+    httpStatus: number;
+    upstreamCode?: string | null;
+  }) {
+    super(message, { cause });
+    this.name = "ZefixAPIError";
+    this.httpStatus = httpStatus;
+    this.upstreamCode = upstreamCode ?? null;
+  }
+}
+
+export class ZefixValidationError extends ZefixError {
+  constructor(message: string) {
+    super(message);
+    this.name = "ZefixValidationError";
+  }
+}
+
+export class ZefixRequestError extends ZefixError {
+  readonly url: string;
+
+  constructor(url: string, message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "ZefixRequestError";
+    this.url = url;
+  }
+}

--- a/packages/business-registries/src/zefix/index.ts
+++ b/packages/business-registries/src/zefix/index.ts
@@ -1,0 +1,18 @@
+export { lookupByUid, searchByName } from "./client.js";
+export type { SearchOptions } from "./client.js";
+export {
+  ZefixAPIError,
+  ZefixError,
+  ZefixRequestError,
+  ZefixValidationError,
+} from "./errors.js";
+export { parseFirm, parseSearchEntry } from "./parse.js";
+export { toNormalizedEntity, toNormalizedSearchResult } from "./normalized.js";
+export type {
+  ZefixCompany,
+  ZefixCompanyStatus,
+  ZefixRawFirm,
+  ZefixSearchResponse,
+  ZefixSearchResult,
+} from "./types.js";
+export { formatUid, normalizeUid, validateUid } from "./validation.js";

--- a/packages/business-registries/src/zefix/normalized.test.ts
+++ b/packages/business-registries/src/zefix/normalized.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "bun:test";
+
+import fixture from "./__fixtures__/search-swiss-re.json" with { type: "json" };
+import { toNormalizedEntity, toNormalizedSearchResult } from "./normalized.js";
+import { parseFirm, parseSearchEntry } from "./parse.js";
+import type { ZefixSearchResponse } from "./types.js";
+
+// SAFETY: captured official fixture is consumed by the defensive parser.
+// eslint-disable-next-line typescript-eslint/no-unsafe-type-assertion
+const raw = fixture as unknown as ZefixSearchResponse;
+
+describe("Zefix normalized projection", () => {
+  test("preserves the canonical UID, seat, status, and legal-form code", () => {
+    const company = raw.list?.[0] ? parseFirm(raw.list[0]) : null;
+    expect(company).not.toBeNull();
+    if (!company) {
+      return;
+    }
+    const entity = toNormalizedEntity(company);
+    expect(entity.registryId.scheme).toBe("CH-UID");
+    expect(String(entity.registryId.value)).toBe("191546434");
+    expect(entity.identifiers).toEqual([]);
+    if (entity.address.availability === "available") {
+      expect(entity.address.value?.municipality).not.toBeNull();
+    }
+    expect(entity.keyPeople).toEqual({ availability: "not-supported" });
+  });
+
+  test("projects the same fixture into the common search contract", () => {
+    const result = raw.list?.[0] ? parseSearchEntry(raw.list[0]) : null;
+    expect(result).not.toBeNull();
+    if (!result) {
+      return;
+    }
+    expect(toNormalizedSearchResult(result).status.availability).toBe(
+      "available",
+    );
+  });
+});

--- a/packages/business-registries/src/zefix/normalized.ts
+++ b/packages/business-registries/src/zefix/normalized.ts
@@ -1,0 +1,90 @@
+import {
+  availableField,
+  fromValidatedRegistryIdentifier,
+  unsupportedField,
+} from "../shared/normalized.js";
+import type {
+  NormalizedRegistryEntity,
+  NormalizedRegistrySearchResult,
+} from "../shared/normalized.js";
+import type { EntityStatus } from "../shared/status.js";
+import type {
+  ZefixCompany,
+  ZefixCompanyStatus,
+  ZefixSearchResult,
+} from "./types.js";
+
+const normalizeStatus = (status: ZefixCompanyStatus): EntityStatus => {
+  switch (status.type) {
+    case "active":
+      return status;
+    case "deleted":
+      return { type: "deleted", at: status.deletedAt };
+    case "unknown":
+      return { type: "unknown" };
+    default: {
+      const unreachable: never = status;
+      return unreachable;
+    }
+  }
+};
+
+export const toNormalizedEntity = (
+  company: ZefixCompany,
+): NormalizedRegistryEntity => ({
+  country: "CH",
+  registryId: fromValidatedRegistryIdentifier("CH-UID", company.uid),
+  identifiers: [],
+  name: company.name,
+  nameWithoutLegalForm: unsupportedField(),
+  legalForm: availableField(
+    company.legalFormId === null
+      ? null
+      : { code: String(company.legalFormId), label: null },
+  ),
+  status: availableField(normalizeStatus(company.status)),
+  statusDetail:
+    company.status.type === "unknown"
+      ? company.status.upstreamValue
+      : company.status.type,
+  address: availableField(
+    company.legalSeat
+      ? {
+          streetName: null,
+          houseNumber: null,
+          orientationNumber: null,
+          orientationLetter: null,
+          municipalityPart: null,
+          municipality: company.legalSeat,
+          postalCode: null,
+          county: null,
+          stateName: null,
+          textAddress: company.legalSeat,
+        }
+      : null,
+  ),
+  creationDate: unsupportedField(),
+  registrationDate: unsupportedField(),
+  removalDate: availableField(
+    company.status.type === "deleted" ? company.status.deletedAt : null,
+  ),
+  registryRecord: unsupportedField(),
+  keyPeople: unsupportedField(),
+  shareCapital: unsupportedField(),
+  shareCapitalPaid: unsupportedField(),
+  actingClause: unsupportedField(),
+  registryUrl: availableField(company.registryUrl),
+  warnings: unsupportedField(),
+});
+
+export const toNormalizedSearchResult = (
+  result: ZefixSearchResult,
+): NormalizedRegistrySearchResult => ({
+  country: "CH",
+  registryId: fromValidatedRegistryIdentifier("CH-UID", result.uid),
+  name: result.name,
+  legalForm: unsupportedField(),
+  status: availableField(normalizeStatus(result.status)),
+  address: availableField(result.legalSeat),
+  registryUrl: availableField(result.registryUrl),
+});

--- a/packages/business-registries/src/zefix/normalized.ts
+++ b/packages/business-registries/src/zefix/normalized.ts
@@ -1,6 +1,6 @@
 import {
   availableField,
-  fromValidatedRegistryIdentifier,
+  fromCanonicalRegistryIdentifier,
   unsupportedField,
 } from "../shared/normalized.js";
 import type {
@@ -33,7 +33,7 @@ export const toNormalizedEntity = (
   company: ZefixCompany,
 ): NormalizedRegistryEntity => ({
   country: "CH",
-  registryId: fromValidatedRegistryIdentifier("CH-UID", company.uid),
+  registryId: fromCanonicalRegistryIdentifier("CH-UID", company.uid),
   identifiers: [],
   name: company.name,
   nameWithoutLegalForm: unsupportedField(),
@@ -81,7 +81,7 @@ export const toNormalizedSearchResult = (
   result: ZefixSearchResult,
 ): NormalizedRegistrySearchResult => ({
   country: "CH",
-  registryId: fromValidatedRegistryIdentifier("CH-UID", result.uid),
+  registryId: fromCanonicalRegistryIdentifier("CH-UID", result.uid),
   name: result.name,
   legalForm: unsupportedField(),
   status: availableField(normalizeStatus(result.status)),

--- a/packages/business-registries/src/zefix/parse.test.ts
+++ b/packages/business-registries/src/zefix/parse.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, test } from "bun:test";
+
+import { parseFirm } from "./parse.js";
+
+describe("Zefix parser", () => {
+  test("rejects a nine-digit UID with an invalid checksum", () => {
+    expect(
+      parseFirm({
+        name: "Invalid UID AG",
+        uidFormatted: "CHE-191.546.435",
+      }),
+    ).toBeNull();
+  });
+});

--- a/packages/business-registries/src/zefix/parse.ts
+++ b/packages/business-registries/src/zefix/parse.ts
@@ -1,0 +1,60 @@
+import { trimToNull } from "../shared/strings.js";
+import type {
+  ZefixCompany,
+  ZefixCompanyStatus,
+  ZefixRawFirm,
+  ZefixSearchResult,
+} from "./types.js";
+import { formatUid, normalizeUid } from "./validation.js";
+
+const parseStatus = (raw: ZefixRawFirm): ZefixCompanyStatus => {
+  const status = trimToNull(raw.status)?.toUpperCase() ?? null;
+  if (status === "EXISTIEREND") {
+    return { type: "active" };
+  }
+  if (status === "GELOESCHT") {
+    return { type: "deleted", deletedAt: trimToNull(raw.deleteDate) };
+  }
+  return { type: "unknown", upstreamValue: status };
+};
+
+export const parseFirm = (raw: ZefixRawFirm): ZefixCompany | null => {
+  const uidSource = trimToNull(raw.uidFormatted) ?? trimToNull(raw.uid);
+  const name = trimToNull(raw.name);
+  if (!uidSource || !name) {
+    return null;
+  }
+  const uid = normalizeUid(uidSource);
+  if (!/^\d{9}$/u.test(uid)) {
+    return null;
+  }
+  return {
+    uid,
+    uidFormatted: trimToNull(raw.uidFormatted) ?? formatUid(uid),
+    name,
+    legalSeat: trimToNull(raw.legalSeat),
+    legalFormId:
+      typeof raw.legalFormId === "number" && Number.isFinite(raw.legalFormId)
+        ? raw.legalFormId
+        : null,
+    status: parseStatus(raw),
+    registryUrl: trimToNull(raw.cantonalExcerptWeb),
+  };
+};
+
+export const parseSearchEntry = (
+  raw: ZefixRawFirm,
+): ZefixSearchResult | null => {
+  const company = parseFirm(raw);
+  if (!company) {
+    return null;
+  }
+  return {
+    uid: company.uid,
+    uidFormatted: company.uidFormatted,
+    name: company.name,
+    legalSeat: company.legalSeat,
+    status: company.status,
+    registryUrl: company.registryUrl,
+  };
+};

--- a/packages/business-registries/src/zefix/parse.ts
+++ b/packages/business-registries/src/zefix/parse.ts
@@ -5,7 +5,7 @@ import type {
   ZefixRawFirm,
   ZefixSearchResult,
 } from "./types.js";
-import { formatUid, normalizeUid } from "./validation.js";
+import { formatUid, parseUid } from "./validation.js";
 
 const parseStatus = (raw: ZefixRawFirm): ZefixCompanyStatus => {
   const status = trimToNull(raw.status)?.toUpperCase() ?? null;
@@ -24,8 +24,8 @@ export const parseFirm = (raw: ZefixRawFirm): ZefixCompany | null => {
   if (!uidSource || !name) {
     return null;
   }
-  const uid = normalizeUid(uidSource);
-  if (!/^\d{9}$/u.test(uid)) {
+  const uid = parseUid(uidSource);
+  if (!uid) {
     return null;
   }
   return {

--- a/packages/business-registries/src/zefix/types.ts
+++ b/packages/business-registries/src/zefix/types.ts
@@ -1,0 +1,52 @@
+export type ZefixRawFirm = {
+  name?: string;
+  ehraid?: number;
+  uid?: string;
+  uidFormatted?: string;
+  chid?: string;
+  chidFormatted?: string;
+  legalSeatId?: number;
+  legalSeat?: string;
+  registerOfficeId?: number;
+  legalFormId?: number;
+  status?: string;
+  shabDate?: string;
+  deleteDate?: string | null;
+  cantonalExcerptWeb?: string;
+};
+
+export type ZefixSearchResponse = {
+  list?: ZefixRawFirm[];
+  hasMoreResults?: boolean;
+  offset?: number;
+  maxEntries?: number;
+  maxOffset?: number | null;
+  error?: {
+    code?: string;
+    message?: string;
+  };
+};
+
+export type ZefixCompanyStatus =
+  | { type: "active" }
+  | { type: "deleted"; deletedAt: string | null }
+  | { type: "unknown"; upstreamValue: string | null };
+
+export type ZefixCompany = {
+  uid: string;
+  uidFormatted: string;
+  name: string;
+  legalSeat: string | null;
+  legalFormId: number | null;
+  status: ZefixCompanyStatus;
+  registryUrl: string | null;
+};
+
+export type ZefixSearchResult = {
+  uid: string;
+  uidFormatted: string;
+  name: string;
+  legalSeat: string | null;
+  status: ZefixCompanyStatus;
+  registryUrl: string | null;
+};

--- a/packages/business-registries/src/zefix/types.ts
+++ b/packages/business-registries/src/zefix/types.ts
@@ -1,3 +1,5 @@
+import type { SwissUid } from "./validation.js";
+
 export type ZefixRawFirm = {
   name?: string;
   ehraid?: number;
@@ -33,7 +35,7 @@ export type ZefixCompanyStatus =
   | { type: "unknown"; upstreamValue: string | null };
 
 export type ZefixCompany = {
-  uid: string;
+  uid: SwissUid;
   uidFormatted: string;
   name: string;
   legalSeat: string | null;
@@ -43,7 +45,7 @@ export type ZefixCompany = {
 };
 
 export type ZefixSearchResult = {
-  uid: string;
+  uid: SwissUid;
   uidFormatted: string;
   name: string;
   legalSeat: string | null;

--- a/packages/business-registries/src/zefix/validation.test.ts
+++ b/packages/business-registries/src/zefix/validation.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, test } from "bun:test";
 
-import { formatUid, normalizeUid, validateUid } from "./validation.js";
+import {
+  formatUid,
+  normalizeUid,
+  parseUid,
+  validateUid,
+} from "./validation.js";
 
 describe("Swiss UID validation", () => {
   test("normalizes common registry spellings", () => {
@@ -13,6 +18,11 @@ describe("Swiss UID validation", () => {
     expect(validateUid("CHE-191.546.434")).toBe(true);
     expect(validateUid("CHE-191.546.435")).toBe(false);
     expect(validateUid("not-a-uid-191546434")).toBe(false);
+  });
+
+  test("brands only checksum-valid canonical values", () => {
+    expect(String(parseUid("CHE-191.546.434"))).toBe("191546434");
+    expect(parseUid("CHE-191.546.435")).toBeNull();
   });
 
   test("formats canonical digits", () => {

--- a/packages/business-registries/src/zefix/validation.test.ts
+++ b/packages/business-registries/src/zefix/validation.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from "bun:test";
+
+import { formatUid, normalizeUid, validateUid } from "./validation.js";
+
+describe("Swiss UID validation", () => {
+  test("normalizes common registry spellings", () => {
+    expect(normalizeUid("CHE-191.546.434")).toBe("191546434");
+    expect(normalizeUid("CHE 191 546 434")).toBe("191546434");
+    expect(normalizeUid("191546434")).toBe("191546434");
+  });
+
+  test("checks the modulo-11 digit", () => {
+    expect(validateUid("CHE-191.546.434")).toBe(true);
+    expect(validateUid("CHE-191.546.435")).toBe(false);
+    expect(validateUid("not-a-uid-191546434")).toBe(false);
+  });
+
+  test("formats canonical digits", () => {
+    expect(formatUid("191546434")).toBe("CHE-191.546.434");
+  });
+});

--- a/packages/business-registries/src/zefix/validation.ts
+++ b/packages/business-registries/src/zefix/validation.ts
@@ -1,0 +1,34 @@
+import {
+  compact as compactSwissUid,
+  format as formatSwissUid,
+  validate as validateSwissUid,
+} from "@stll/stdnum/ch/uid";
+
+const OPTIONAL_PREFIX_UID = /^(?:CHE[-.\s]?)?(?<digits>(?:\d[-.\s]?){9})$/iu;
+
+const withSwissPrefix = (input: string): string => {
+  const trimmed = input.trim().toUpperCase();
+  const match = OPTIONAL_PREFIX_UID.exec(trimmed);
+  if (!match?.groups) {
+    return trimmed;
+  }
+  const digits = match.groups["digits"]?.replaceAll(/[-.\s]/gu, "") ?? "";
+  return `CHE${digits}`;
+};
+
+const withoutSwissPrefix = (compact: string): string =>
+  compact.startsWith("CHE") ? compact.slice(3) : compact;
+
+export const normalizeUid = (input: string): string =>
+  withoutSwissPrefix(compactSwissUid(withSwissPrefix(input)));
+
+export const validateUid = (input: string): boolean =>
+  validateSwissUid(withSwissPrefix(input)).valid;
+
+export const formatUid = (input: string): string => {
+  const prefixed = withSwissPrefix(input);
+  if (!validateSwissUid(prefixed).valid) {
+    return input.trim();
+  }
+  return formatSwissUid(prefixed);
+};

--- a/packages/business-registries/src/zefix/validation.ts
+++ b/packages/business-registries/src/zefix/validation.ts
@@ -4,6 +4,10 @@ import {
   validate as validateSwissUid,
 } from "@stll/stdnum/ch/uid";
 
+import { type CanonicalId, unsafeBrand } from "../shared/canonical-id.js";
+
+export type SwissUid = CanonicalId<"CH-UID">;
+
 const OPTIONAL_PREFIX_UID = /^(?:CHE[-.\s]?)?(?<digits>(?:\d[-.\s]?){9})$/iu;
 
 const withSwissPrefix = (input: string): string => {
@@ -22,8 +26,15 @@ const withoutSwissPrefix = (compact: string): string =>
 export const normalizeUid = (input: string): string =>
   withoutSwissPrefix(compactSwissUid(withSwissPrefix(input)));
 
-export const validateUid = (input: string): boolean =>
-  validateSwissUid(withSwissPrefix(input)).valid;
+export const parseUid = (input: string): SwissUid | null => {
+  const prefixed = withSwissPrefix(input);
+  if (!validateSwissUid(prefixed).valid) {
+    return null;
+  }
+  return unsafeBrand<"CH-UID">(withoutSwissPrefix(compactSwissUid(prefixed)));
+};
+
+export const validateUid = (input: string): boolean => parseUid(input) !== null;
 
 export const formatUid = (input: string): string => {
   const prefixed = withSwissPrefix(input);

--- a/packages/country-codes/package.json
+++ b/packages/country-codes/package.json
@@ -29,11 +29,7 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
-    ".": {
-      "types": "./src/index.ts",
-      "bun": "./src/index.ts",
-      "import": "./dist/index.js"
-    }
+    ".": "./src/index.ts"
   },
   "publishConfig": {
     "access": "public"

--- a/scripts/check-api-cli-contract.test.ts
+++ b/scripts/check-api-cli-contract.test.ts
@@ -100,12 +100,12 @@ describe("API and CLI release contract", () => {
     );
     const manifests = new Map(
       await Promise.all(
-        SHARED_NPM_PACKAGES.map(async (packageName) => [
-          packageName,
-          await Bun.file(
+        SHARED_NPM_PACKAGES.map(async (packageName) => {
+          const manifest: unknown = await Bun.file(
             new URL(`../packages/${packageName}/package.json`, import.meta.url),
-          ).json(),
-        ]),
+          ).json();
+          return [packageName, manifest] as const;
+        }),
       ),
     );
 
@@ -124,11 +124,12 @@ describe("API and CLI release contract", () => {
       if (!isRecord(manifest)) {
         throw new TypeError(`${packageName} package manifest is not an object`);
       }
-      expect(isRecord(manifest.exports)).toBe(true);
-      if (!isRecord(manifest.exports)) {
+      const packageExports = manifest["exports"];
+      expect(isRecord(packageExports)).toBe(true);
+      if (!isRecord(packageExports)) {
         throw new TypeError(`${packageName} exports is not an object`);
       }
-      for (const target of Object.values(manifest.exports)) {
+      for (const target of Object.values(packageExports)) {
         expect(typeof target).toBe("string");
         if (typeof target !== "string") {
           throw new TypeError(`${packageName} has a non-string export target`);

--- a/scripts/check-api-cli-contract.test.ts
+++ b/scripts/check-api-cli-contract.test.ts
@@ -17,6 +17,17 @@ import {
 } from "../packages/cli/src/auth/constants";
 import { CLI_SUPPORTED_API_CONTRACT_VERSION } from "../packages/cli/src/compatibility";
 
+const SHARED_NPM_PACKAGES = [
+  "business-registries",
+  "country-codes",
+  "conditions",
+  "template-conditions",
+  "docx-utils",
+] as const;
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
 const expectSubset = (
   subset: readonly string[],
   superset: readonly string[],
@@ -76,21 +87,54 @@ describe("API and CLI release contract", () => {
   });
 
   test("shared package publishing uses Changesets release signals", async () => {
-    const publishWorkflow = await Bun.file(
-      new URL("../.github/workflows/publish-npm.yml", import.meta.url),
-    ).text();
+    const [changesetConfig, ciWorkflow, publishWorkflow] = await Promise.all([
+      Bun.file(new URL("../.changeset/config.json", import.meta.url)).text(),
+      Bun.file(new URL("../.github/workflows/ci.yml", import.meta.url)).text(),
+      Bun.file(
+        new URL("../.github/workflows/publish-npm.yml", import.meta.url),
+      ).text(),
+    ]);
     const pushTrigger = publishWorkflow.slice(
       0,
       publishWorkflow.indexOf("  workflow_run:"),
     );
+    const manifests = new Map(
+      await Promise.all(
+        SHARED_NPM_PACKAGES.map(async (packageName) => [
+          packageName,
+          await Bun.file(
+            new URL(`../packages/${packageName}/package.json`, import.meta.url),
+          ).json(),
+        ]),
+      ),
+    );
 
-    for (const packageName of [
-      "conditions",
-      "template-conditions",
-      "docx-utils",
-    ]) {
+    for (const packageName of SHARED_NPM_PACKAGES) {
       expect(pushTrigger).toContain(`packages/${packageName}/CHANGELOG.md`);
       expect(pushTrigger).not.toContain(`packages/${packageName}/package.json`);
+      expect(ciWorkflow).toContain(`packages/${packageName}/src/**`);
+      expect(ciWorkflow).toContain(`packages/${packageName}/CHANGELOG.md`);
+      expect(ciWorkflow).toContain(`packages/${packageName}/package.json`);
+      expect(publishWorkflow).toContain(`- ${packageName}`);
+      expect(publishWorkflow).toContain(`npm-tarball-${packageName}`);
+      expect(changesetConfig).not.toContain(`"@stll/${packageName}"`);
+
+      const manifest: unknown = manifests.get(packageName);
+      expect(isRecord(manifest)).toBe(true);
+      if (!isRecord(manifest)) {
+        throw new TypeError(`${packageName} package manifest is not an object`);
+      }
+      expect(isRecord(manifest.exports)).toBe(true);
+      if (!isRecord(manifest.exports)) {
+        throw new TypeError(`${packageName} exports is not an object`);
+      }
+      for (const target of Object.values(manifest.exports)) {
+        expect(typeof target).toBe("string");
+        if (typeof target !== "string") {
+          throw new TypeError(`${packageName} has a non-string export target`);
+        }
+        expect(target).toMatch(/^\.\/src\/.*\.ts$/u);
+      }
     }
   });
 });


### PR DESCRIPTION
## Summary

- add browser-safe Zefix and SUDREG clients
- add normalized entity and search projections for seven registry adapters
- make optional field availability and payload mutually exclusive
- use canonical branded identifiers and the shared Swiss UID validator
- enroll the registry and country-code packages in the shared Changesets release path
- guard release-package configuration and source export shape from drifting

## Validation

- 483 package tests
- package typecheck, lint, format, build, and release-pack dry run
- live Zefix and SUDREG smoke tests
- release-contract and repository ratchet guards
- pre-push affected-workspace typecheck and formatting

CC on behalf of jan-kubica
