### PR TITLE
fix: validate usage token arithmetic

### DIFF
--- a/apps/api/src/lib/usage/unit-model.test.ts
+++ b/apps/api/src/lib/usage/unit-model.test.ts
@@ -172,10 +172,10 @@ describe("computeRawUsageMicroUnits", () => {
     expect(
       computeRawUsageMicroUnits({
         modelId: "unknown-model-name",
-        inputTokens: 20_000_000_001,
+        inputTokens: 9_007_199_254_740_938,
         outputTokens: 0,
       }),
-    ).toBe(10_000_000_001);
+    ).toBe(4_503_599_627_370_469);
   });
 });
 

--- a/apps/api/src/lib/usage/unit-model.test.ts
+++ b/apps/api/src/lib/usage/unit-model.test.ts
@@ -137,11 +137,7 @@ describe("computeRawUsageMicroUnits", () => {
       Number.NEGATIVE_INFINITY,
       Number.MAX_SAFE_INTEGER + 1,
     ];
-    const fields = [
-      "inputTokens",
-      "outputTokens",
-      "cacheReadTokens",
-    ] as const;
+    const fields = ["inputTokens", "outputTokens", "cacheReadTokens"] as const;
 
     for (const field of fields) {
       for (const invalidCount of invalidCounts) {

--- a/apps/api/src/lib/usage/unit-model.test.ts
+++ b/apps/api/src/lib/usage/unit-model.test.ts
@@ -127,6 +127,56 @@ describe("computeRawUsageMicroUnits", () => {
       }),
     ).toThrow();
   });
+
+  test("rejects every token field outside the non-negative safe-integer domain", () => {
+    const invalidCounts = [
+      -1,
+      0.5,
+      Number.NaN,
+      Number.POSITIVE_INFINITY,
+      Number.NEGATIVE_INFINITY,
+      Number.MAX_SAFE_INTEGER + 1,
+    ];
+    const fields = [
+      "inputTokens",
+      "outputTokens",
+      "cacheReadTokens",
+    ] as const;
+
+    for (const field of fields) {
+      for (const invalidCount of invalidCounts) {
+        expect(() =>
+          computeRawUsageMicroUnits({
+            modelId: "gemini-2.5-flash",
+            inputTokens: 100,
+            outputTokens: 100,
+            cacheReadTokens: 0,
+            [field]: invalidCount,
+          }),
+        ).toThrow();
+      }
+    }
+  });
+
+  test("rejects a computed amount outside the safe-integer domain", () => {
+    expect(() =>
+      computeRawUsageMicroUnits({
+        modelId: "unknown-model-name",
+        inputTokens: 0,
+        outputTokens: Number.MAX_SAFE_INTEGER,
+      }),
+    ).toThrow();
+  });
+
+  test("keeps rate scaling exact when the intermediate product is unsafe", () => {
+    expect(
+      computeRawUsageMicroUnits({
+        modelId: "unknown-model-name",
+        inputTokens: 20_000_000_001,
+        outputTokens: 0,
+      }),
+    ).toBe(10_000_000_001);
+  });
 });
 
 describe("usageUnitsFromTokens", () => {

--- a/apps/api/src/lib/usage/unit-model.ts
+++ b/apps/api/src/lib/usage/unit-model.ts
@@ -37,7 +37,24 @@ const FALLBACK_RATE: ModelRate = {
   outputPerMTok: 2_000_000,
 };
 
-const ONE_MILLION = 1_000_000;
+const ONE_MILLION_BIGINT = 1_000_000n;
+const MAX_SAFE_INTEGER_BIGINT = BigInt(Number.MAX_SAFE_INTEGER);
+
+const isNonNegativeSafeInteger = (value: number): boolean =>
+  Number.isSafeInteger(value) && value >= 0;
+
+const scaleTokenCost = (tokens: number, ratePerMTok: number): number => {
+  if (!isNonNegativeSafeInteger(ratePerMTok)) {
+    panic("usage rates must be non-negative safe integers");
+  }
+  const scaled =
+    (BigInt(tokens) * BigInt(ratePerMTok) + ONE_MILLION_BIGINT - 1n) /
+    ONE_MILLION_BIGINT;
+  if (scaled > MAX_SAFE_INTEGER_BIGINT) {
+    panic("computed usage component exceeds the safe integer range");
+  }
+  return Number(scaled);
+};
 
 type UsageInput = {
   modelId: string;
@@ -54,9 +71,8 @@ type UsageInput = {
 
 /**
  * Convert token usage into normalized micro-units using the
- * model's public rate table. Caller is responsible for passing
- * non-negative integers; provider adapters are responsible for
- * normalizing their token usage before calling this helper.
+ * model's public rate table. Provider token counts are validated here because
+ * this helper is the shared boundary before usage reaches the ledger.
  */
 export const computeRawUsageMicroUnits = ({
   modelId,
@@ -65,14 +81,14 @@ export const computeRawUsageMicroUnits = ({
   cacheReadTokens = 0,
 }: UsageInput): number => {
   if (
-    inputTokens < 0 ||
-    outputTokens < 0 ||
-    cacheReadTokens < 0 ||
-    cacheReadTokens > inputTokens
+    !isNonNegativeSafeInteger(inputTokens) ||
+    !isNonNegativeSafeInteger(outputTokens) ||
+    !isNonNegativeSafeInteger(cacheReadTokens)
   ) {
-    panic(
-      "computeRawUsageMicroUnits got negative or inconsistent token counts",
-    );
+    panic("usage token counts must be non-negative safe integers");
+  }
+  if (cacheReadTokens > inputTokens) {
+    panic("cached input tokens cannot exceed total input tokens");
   }
   const rate = resolveModelRate(
     getModelRate(modelId) ?? FALLBACK_RATE,
@@ -80,14 +96,14 @@ export const computeRawUsageMicroUnits = ({
   );
   const billedInputTokens = inputTokens - cacheReadTokens;
   const cachedRate = rate.cachedInputPerMTok ?? rate.inputPerMTok;
-  const inputCost = Math.ceil(
-    (billedInputTokens * rate.inputPerMTok) / ONE_MILLION,
-  );
-  const cacheCost = Math.ceil((cacheReadTokens * cachedRate) / ONE_MILLION);
-  const outputCost = Math.ceil(
-    (outputTokens * rate.outputPerMTok) / ONE_MILLION,
-  );
-  return inputCost + cacheCost + outputCost;
+  const inputCost = scaleTokenCost(billedInputTokens, rate.inputPerMTok);
+  const cacheCost = scaleTokenCost(cacheReadTokens, cachedRate);
+  const outputCost = scaleTokenCost(outputTokens, rate.outputPerMTok);
+  const rawUsageMicroUnits = inputCost + cacheCost + outputCost;
+  if (!Number.isSafeInteger(rawUsageMicroUnits)) {
+    panic("computed raw usage exceeds the safe integer range");
+  }
+  return rawUsageMicroUnits;
 };
 
 type UsageUnitsFromTokensInput = UsageInput & {


### PR DESCRIPTION
Validate provider token counts and keep usage arithmetic exact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved usage calculations to prevent rounding errors and preserve exact billing values.
  * Added validation for invalid, negative, fractional, non-finite, or excessively large token and rate values.
  * Added safeguards against calculations exceeding supported numeric limits.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->