### PR TITLE
fix: keep release lockfile resolutions stable

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "build": "turbo build",
     "changeset": "changeset",
-    "changeset:version": "changeset version && bun scripts/sync-lockfile-workspace-versions.ts",
+    "changeset:version": "bun scripts/sync-lockfile-workspace-versions.ts --check-entries && changeset version && bun scripts/sync-lockfile-workspace-versions.ts",
     "dev": "bun packages/scripts/src/dev-runner.ts dev",
     "dev:all": "turbo dev",
     "dev:api": "bun packages/scripts/src/dev-runner.ts dev:api",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "build": "turbo build",
     "changeset": "changeset",
-    "changeset:version": "changeset version && rm -f bun.lock && bun install",
+    "changeset:version": "changeset version && bun scripts/sync-lockfile-workspace-versions.ts",
     "dev": "bun packages/scripts/src/dev-runner.ts dev",
     "dev:all": "turbo dev",
     "dev:api": "bun packages/scripts/src/dev-runner.ts dev:api",

--- a/scripts/check-lockfile-workspace-versions.ts
+++ b/scripts/check-lockfile-workspace-versions.ts
@@ -15,8 +15,8 @@
 // publishes ~10 versioned `@stll/*` workspace packages, so it carries this
 // exposure even though it has no changesets-driven version bump script.
 //
-// The only fix once it drifts is `rm bun.lock && bun install` (a full
-// regenerate). This script cross-checks every workspace package.json
+// The safe fix is the targeted workspace-version synchronizer. This script
+// cross-checks every workspace package.json
 // `version` against the version bun.lock has cached for that workspace, so
 // the drift itself gets caught in CI instead of silently persisting.
 //
@@ -131,10 +131,10 @@ if (mismatches.length > 0) {
       ...mismatches.map((line) => `  - ${line}`),
       "",
       "A plain `bun install` will not fix this (it doesn't rewrite cached",
-      "workspace versions for entries that already exist). Regenerate the",
-      "lockfile instead:",
+      "workspace versions for entries that already exist). Synchronize the",
+      "cached self-versions without re-resolving unrelated dependencies:",
       "",
-      "    rm bun.lock && bun install",
+      "    bun scripts/sync-lockfile-workspace-versions.ts",
       "",
       "Then commit the refreshed bun.lock.",
     ].join("\n"),

--- a/scripts/check-lockfile-workspace-versions.ts
+++ b/scripts/check-lockfile-workspace-versions.ts
@@ -21,8 +21,8 @@
 // the drift itself gets caught in CI instead of silently persisting.
 //
 // Workspace directories are derived from the root package.json `workspaces`
-// globs (`apps/*`, `packages/*`), not hardcoded, so a new workspace root
-// (or a renamed one) is picked up automatically.
+// entries, not hardcoded, so a new workspace root (or a renamed one) is
+// picked up automatically.
 
 import { panic } from "better-result";
 import { readdir } from "node:fs/promises";
@@ -33,12 +33,11 @@ const ROOT = path.resolve(import.meta.dir, "..");
 const readJson = async (filePath: string): Promise<Record<string, unknown>> =>
   JSON.parse(await Bun.file(filePath).text());
 
-// The root `workspaces` field only ever uses single-level globs of the shape
-// `<dir>/*` in this repo (`apps/*`, `packages/*`). Resolve each to its
-// immediate subdirectories rather than hand-rolling a general glob matcher.
 const globParent = (glob: string): string => {
-  if (!glob.endsWith("/*")) {
-    panic(`unsupported workspaces glob "${glob}": expected "<dir>/*"`);
+  if (!glob.endsWith("/*") || glob.slice(0, -2).includes("*")) {
+    panic(
+      `unsupported workspaces glob "${glob}": expected a literal path or "<dir>/*"`,
+    );
   }
   return glob.slice(0, -"/*".length);
 };
@@ -51,6 +50,9 @@ const workspaceGlobs = Array.isArray(rootPkg["workspaces"])
   : panic("root package.json is missing a `workspaces` array");
 
 const dirsForGlob = async (glob: string): Promise<string[]> => {
+  if (!glob.includes("*")) {
+    return [glob];
+  }
   const parent = globParent(glob);
   const entries = await readdir(path.join(ROOT, parent), {
     withFileTypes: true,
@@ -96,13 +98,13 @@ const mismatchForWorkspace = async (
   workspaceDir: string,
 ): Promise<string | null> => {
   const pkgPath = path.join(ROOT, workspaceDir, "package.json");
-  // A directory matched by a workspace glob is not necessarily a real
-  // workspace: skip it (rather than crash the guard) if its package.json is
-  // missing or fails to parse.
-  const pkg = await readJson(pkgPath).catch(() => null);
-  if (pkg === null) {
+  // A directory matched by a workspace glob is not necessarily a package.
+  // Absence is expected; malformed or unreadable manifests must fail loudly.
+  const packageFile = Bun.file(pkgPath);
+  if (!(await packageFile.exists())) {
     return null;
   }
+  const pkg: Record<string, unknown> = JSON.parse(await packageFile.text());
 
   const { name, version } = pkg;
   if (typeof name !== "string" || typeof version !== "string") {

--- a/scripts/lockfile-workspace-versions.test.ts
+++ b/scripts/lockfile-workspace-versions.test.ts
@@ -47,6 +47,41 @@ describe("workspace version lockfile synchronization", () => {
   it("rejects a missing workspace instead of editing a nested lookalike", () => {
     expect(() =>
       syncLockfileWorkspaceVersions(fixture, { "packages/missing": "1.0.0" }),
-    ).toThrow('bun.lock is missing property "packages/missing"');
+    ).toThrow("bun.lock has no workspace entry for packages/missing");
+  });
+
+  it("preserves every unrelated byte for escaped replacement values", () => {
+    let state = 24_301;
+    const random = (): number => {
+      state = (state * 16_807) % 2_147_483_647;
+      return state;
+    };
+    const alphabet = ['"', "\\", "-", ".", "0", "9", "a", "Z"];
+
+    for (let iteration = 0; iteration < 256; iteration += 1) {
+      const length = 1 + (random() % 24);
+      let version = "";
+      for (let index = 0; index < length; index += 1) {
+        const character = alphabet.at(random() % alphabet.length);
+        if (character === undefined) {
+          throw new Error("random alphabet index is out of bounds");
+        }
+        version += character;
+      }
+      const actual = syncLockfileWorkspaceVersions(fixture, {
+        "packages/example": version,
+      });
+      const expected = fixture.replace(
+        '"version": "1.2.3"',
+        () => `"version": ${JSON.stringify(version)}`,
+      );
+
+      expect(actual).toBe(expected);
+      expect(
+        syncLockfileWorkspaceVersions(actual, {
+          "packages/example": version,
+        }),
+      ).toBe(actual);
+    }
   });
 });

--- a/scripts/lockfile-workspace-versions.test.ts
+++ b/scripts/lockfile-workspace-versions.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "bun:test";
+
+import { syncLockfileWorkspaceVersions } from "./lockfile-workspace-versions";
+
+const fixture = `{
+  "lockfileVersion": 1,
+  "workspaces": {
+    "apps/web": {
+      "name": "@stll/web",
+      "version": "0.0.0",
+      "dependencies": {
+        "packages/example": "workspace:*"
+      },
+    },
+    "packages/example": {
+      "dependencies": {},
+      "version": "1.2.3",
+      "name": "@stll/example",
+    },
+  },
+  "packages": {
+    "packages/example": ["unrelated@1.0.0"],
+  },
+}
+`;
+
+describe("workspace version lockfile synchronization", () => {
+  it("changes only direct workspace version values", () => {
+    const actual = syncLockfileWorkspaceVersions(fixture, {
+      "apps/web": "0.0.1",
+      "packages/example": "2.0.0",
+    });
+
+    expect(actual).toBe(
+      fixture
+        .replace('"version": "0.0.0"', '"version": "0.0.1"')
+        .replace('"version": "1.2.3"', '"version": "2.0.0"'),
+    );
+  });
+
+  it("is idempotent", () => {
+    const versions = { "apps/web": "0.0.1", "packages/example": "2.0.0" };
+    const once = syncLockfileWorkspaceVersions(fixture, versions);
+    expect(syncLockfileWorkspaceVersions(once, versions)).toBe(once);
+  });
+
+  it("rejects a missing workspace instead of editing a nested lookalike", () => {
+    expect(() =>
+      syncLockfileWorkspaceVersions(fixture, { "packages/missing": "1.0.0" }),
+    ).toThrow('bun.lock is missing property "packages/missing"');
+  });
+});

--- a/scripts/lockfile-workspace-versions.ts
+++ b/scripts/lockfile-workspace-versions.ts
@@ -42,6 +42,7 @@ const directPropertyValue = (
   text: string,
   objectStart: number,
   property: string,
+  missingMessage?: string,
 ): number => {
   if (text[objectStart] !== "{") {
     throw new TypeError(`expected object at offset ${objectStart}`);
@@ -69,7 +70,8 @@ const directPropertyValue = (
     index += 1;
   }
   throw new TypeError(
-    `bun.lock is missing property ${JSON.stringify(property)}`,
+    missingMessage ??
+      `bun.lock is missing property ${JSON.stringify(property)}`,
   );
 };
 
@@ -108,6 +110,7 @@ export const syncLockfileWorkspaceVersions = (
         lockText,
         workspacesStart,
         workspace,
+        `bun.lock has no workspace entry for ${workspace}`,
       );
       if (lockText[workspaceStart] !== "{") {
         throw new TypeError(

--- a/scripts/lockfile-workspace-versions.ts
+++ b/scripts/lockfile-workspace-versions.ts
@@ -1,0 +1,137 @@
+type WorkspaceVersions = Readonly<Record<string, string>>;
+
+type StringToken = {
+  end: number;
+  start: number;
+  value: string;
+};
+
+const skipWhitespace = (text: string, start: number): number => {
+  let index = start;
+  while (index < text.length && /\s/u.test(text[index] ?? "")) {
+    index += 1;
+  }
+  return index;
+};
+
+const stringTokenAt = (text: string, start: number): StringToken => {
+  if (text[start] !== '"') {
+    throw new TypeError(`expected JSON string at offset ${start}`);
+  }
+  let index = start + 1;
+  while (index < text.length) {
+    const character = text[index];
+    if (character === "\\") {
+      index += 2;
+      continue;
+    }
+    if (character === '"') {
+      const end = index + 1;
+      return {
+        end,
+        start,
+        value: JSON.parse(text.slice(start, end)),
+      };
+    }
+    index += 1;
+  }
+  throw new TypeError(`unterminated JSON string at offset ${start}`);
+};
+
+const directPropertyValue = (
+  text: string,
+  objectStart: number,
+  property: string,
+): number => {
+  if (text[objectStart] !== "{") {
+    throw new TypeError(`expected object at offset ${objectStart}`);
+  }
+  let depth = 1;
+  let index = objectStart + 1;
+  while (index < text.length && depth > 0) {
+    const character = text[index];
+    if (character === '"') {
+      const token = stringTokenAt(text, index);
+      if (depth === 1) {
+        const colon = skipWhitespace(text, token.end);
+        if (text[colon] === ":" && token.value === property) {
+          return skipWhitespace(text, colon + 1);
+        }
+      }
+      index = token.end;
+      continue;
+    }
+    if (character === "{" || character === "[") {
+      depth += 1;
+    } else if (character === "}" || character === "]") {
+      depth -= 1;
+    }
+    index += 1;
+  }
+  throw new TypeError(
+    `bun.lock is missing property ${JSON.stringify(property)}`,
+  );
+};
+
+const rootObjectStart = (text: string): number => {
+  const start = skipWhitespace(text, 0);
+  if (text[start] !== "{") {
+    throw new TypeError("bun.lock must contain a root object");
+  }
+  return start;
+};
+
+/**
+ * Updates only workspace self-versions in Bun's text lockfile.
+ *
+ * Bun does not refresh these cached values on an ordinary install. Recreating the
+ * whole lockfile does, but also re-resolves unrelated dependency ranges. Walking
+ * the JSON structure lets a release change exactly the intended version strings
+ * while preserving every dependency resolution byte-for-byte.
+ */
+export const syncLockfileWorkspaceVersions = (
+  lockText: string,
+  workspaceVersions: WorkspaceVersions,
+): string => {
+  const rootStart = rootObjectStart(lockText);
+  const workspacesStart = directPropertyValue(
+    lockText,
+    rootStart,
+    "workspaces",
+  );
+  if (lockText[workspacesStart] !== "{") {
+    throw new TypeError("bun.lock workspaces property must be an object");
+  }
+  const replacements = Object.entries(workspaceVersions).map(
+    ([workspace, version]) => {
+      const workspaceStart = directPropertyValue(
+        lockText,
+        workspacesStart,
+        workspace,
+      );
+      if (lockText[workspaceStart] !== "{") {
+        throw new TypeError(
+          `bun.lock workspace ${workspace} must be an object`,
+        );
+      }
+      const versionStart = directPropertyValue(
+        lockText,
+        workspaceStart,
+        "version",
+      );
+      const token = stringTokenAt(lockText, versionStart);
+      return {
+        end: token.end,
+        start: token.start,
+        value: JSON.stringify(version),
+      };
+    },
+  );
+
+  replacements.sort((left, right) => right.start - left.start);
+  let output = lockText;
+  for (const replacement of replacements) {
+    output = `${output.slice(0, replacement.start)}${replacement.value}${output.slice(replacement.end)}`;
+  }
+  return output;
+};

--- a/scripts/sync-lockfile-workspace-versions.ts
+++ b/scripts/sync-lockfile-workspace-versions.ts
@@ -1,0 +1,69 @@
+#!/usr/bin/env bun
+
+import { panic } from "better-result";
+import { readdir } from "node:fs/promises";
+import path from "node:path";
+
+import { syncLockfileWorkspaceVersions } from "./lockfile-workspace-versions";
+
+const ROOT = path.resolve(import.meta.dir, "..");
+
+const readJson = async (filePath: string): Promise<Record<string, unknown>> =>
+  JSON.parse(await Bun.file(filePath).text());
+
+const rootPackage = await readJson(path.join(ROOT, "package.json"));
+const workspaceGlobs = Array.isArray(rootPackage["workspaces"])
+  ? rootPackage["workspaces"].filter(
+      (workspace): workspace is string => typeof workspace === "string",
+    )
+  : panic("root package.json is missing a `workspaces` array");
+
+const workspaceParent = (workspaceGlob: string): string => {
+  if (!workspaceGlob.endsWith("/*")) {
+    panic(`unsupported workspaces glob ${workspaceGlob}: expected <dir>/*`);
+  }
+  return workspaceGlob.slice(0, -2);
+};
+
+const workspaceDirectories = (
+  await Promise.all(
+    workspaceGlobs.map(async (workspaceGlob) => {
+      const parent = workspaceParent(workspaceGlob);
+      const entries = await readdir(path.join(ROOT, parent), {
+        withFileTypes: true,
+      });
+      return entries
+        .filter((entry) => entry.isDirectory())
+        .map((entry) => `${parent}/${entry.name}`);
+    }),
+  )
+)
+  .flat()
+  .sort();
+
+const workspaceVersions = Object.fromEntries(
+  (
+    await Promise.all(
+      workspaceDirectories.map(async (workspace) => {
+        const packageJson = await readJson(
+          path.join(ROOT, workspace, "package.json"),
+        ).catch(() => null);
+        if (
+          packageJson === null ||
+          typeof packageJson["version"] !== "string"
+        ) {
+          return null;
+        }
+        return [workspace, packageJson["version"]] as const;
+      }),
+    )
+  ).filter((entry): entry is readonly [string, string] => entry !== null),
+);
+
+const lockPath = path.join(ROOT, "bun.lock");
+const before = await Bun.file(lockPath).text();
+const after = syncLockfileWorkspaceVersions(before, workspaceVersions);
+await Bun.write(lockPath, after);
+console.log(
+  `Synchronized ${Object.keys(workspaceVersions).length} workspace versions.`,
+);

--- a/scripts/sync-lockfile-workspace-versions.ts
+++ b/scripts/sync-lockfile-workspace-versions.ts
@@ -19,8 +19,13 @@ const workspaceGlobs = Array.isArray(rootPackage["workspaces"])
   : panic("root package.json is missing a `workspaces` array");
 
 const workspaceParent = (workspaceGlob: string): string => {
-  if (!workspaceGlob.endsWith("/*")) {
-    panic(`unsupported workspaces glob ${workspaceGlob}: expected <dir>/*`);
+  if (
+    !workspaceGlob.endsWith("/*") ||
+    workspaceGlob.slice(0, -2).includes("*")
+  ) {
+    panic(
+      `unsupported workspaces glob ${workspaceGlob}: expected a literal path or <dir>/*`,
+    );
   }
   return workspaceGlob.slice(0, -2);
 };
@@ -28,6 +33,9 @@ const workspaceParent = (workspaceGlob: string): string => {
 const workspaceDirectories = (
   await Promise.all(
     workspaceGlobs.map(async (workspaceGlob) => {
+      if (!workspaceGlob.includes("*")) {
+        return [workspaceGlob];
+      }
       const parent = workspaceParent(workspaceGlob);
       const entries = await readdir(path.join(ROOT, parent), {
         withFileTypes: true,
@@ -45,13 +53,15 @@ const workspaceVersions = Object.fromEntries(
   (
     await Promise.all(
       workspaceDirectories.map(async (workspace) => {
-        const packageJson = await readJson(
-          path.join(ROOT, workspace, "package.json"),
-        ).catch(() => null);
-        if (
-          packageJson === null ||
-          typeof packageJson["version"] !== "string"
-        ) {
+        const packagePath = path.join(ROOT, workspace, "package.json");
+        const packageFile = Bun.file(packagePath);
+        if (!(await packageFile.exists())) {
+          return null;
+        }
+        const packageJson: Record<string, unknown> = JSON.parse(
+          await packageFile.text(),
+        );
+        if (typeof packageJson["version"] !== "string") {
           return null;
         }
         return [workspace, packageJson["version"]] as const;
@@ -63,7 +73,10 @@ const workspaceVersions = Object.fromEntries(
 const lockPath = path.join(ROOT, "bun.lock");
 const before = await Bun.file(lockPath).text();
 const after = syncLockfileWorkspaceVersions(before, workspaceVersions);
-await Bun.write(lockPath, after);
-console.log(
-  `Synchronized ${Object.keys(workspaceVersions).length} workspace versions.`,
-);
+const entryCount = Object.keys(workspaceVersions).length;
+if (process.argv.includes("--check-entries")) {
+  console.log(`Verified ${entryCount} bun.lock workspace entries.`);
+} else {
+  await Bun.write(lockPath, after);
+  console.log(`Synchronized ${entryCount} workspace versions.`);
+}


### PR DESCRIPTION
## Summary

- update only cached workspace self-versions after Changesets bumps packages
- preserve every unrelated dependency resolution instead of recreating the full Bun lockfile
- add structural and idempotence tests for the targeted lockfile edit

## Validation

- `bun test scripts/lockfile-workspace-versions.test.ts`
- `bun run typecheck:repo`
- Oxlint and oxfmt on changed files
- verified the current version-package changes produce exactly three lockfile version-line changes

CC on behalf of jan-kubica

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved synchronisation of workspace package versions in the Bun lockfile.
  * Lockfile updates now preserve unrelated content and avoid unnecessary regeneration.
  * Added validation to detect missing workspace entries and prevent incorrect updates.

* **Chores**
  * Updated the versioning workflow to automatically synchronise lockfile workspace versions.
  * Improved guidance when workspace version drift is detected.

* **Tests**
  * Added coverage for accurate, repeatable, and safely scoped lockfile updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->