### PR TITLE
fix: use shared version PR identity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,7 +127,6 @@ jobs:
             packages/template-conditions/package.json
             packages/docx-utils/package.json
           version-file: bun.lock
-          version-pr-author: "stella-release-deployer[bot]"
 
   ci-changes:
     needs: trust-check


### PR DESCRIPTION
Use the generated-version policy identity supplied by the shared release contract instead of overriding it locally. This keeps the release PR exemption aligned with the bot that maintains the branch.\n\nCC on behalf of jan-kubica

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated release workflow configuration.
  * No user-facing functionality or product behaviour has changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->