### PR TITLE
fix: allow generated private package metadata

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,8 @@ jobs:
             packages/docx-utils/tsconfig.build.json
             packages/docx-utils/tsdown.config.ts
           generated-paths: |
+            apps/web/CHANGELOG.md
+            apps/web/package.json
             bun.lock
             packages/cli/CHANGELOG.md
             packages/cli/package.json


### PR DESCRIPTION
Allow the version PR to update the private web workspace metadata that Changesets generates when its internal package dependencies advance. Runtime and source paths remain excluded from the generated-version exemption.\n\nCC on behalf of jan-kubica