### PR TITLE
feat: add registry request cancellation

### DIFF
--- a/.changeset/calm-registry-cancellation.md
+++ b/.changeset/calm-registry-cancellation.md
@@ -1,0 +1,7 @@
+---
+"@stll/business-registries": minor
+---
+
+Add optional request cancellation to the ARES, Zefix,
+recherche-entreprises, SUDREG, and KRS clients while preserving each
+request's timeout.

--- a/packages/business-registries/src/ares/client.test.ts
+++ b/packages/business-registries/src/ares/client.test.ts
@@ -7,13 +7,17 @@ const SKIP_LIVE = process.env["SMOKE_TEST"] !== "1";
 
 type SearchRequestCapture = {
   pocet: unknown;
+  signal: AbortSignal | null | undefined;
 };
 
 const captureSearchRequest = (): {
   captured: SearchRequestCapture;
   restore: () => void;
 } => {
-  const captured: SearchRequestCapture = { pocet: undefined };
+  const captured: SearchRequestCapture = {
+    pocet: undefined,
+    signal: undefined,
+  };
   const originalFetch = globalThis.fetch;
   const stub = async (
     _input: URL | RequestInfo,
@@ -24,6 +28,7 @@ const captureSearchRequest = (): {
       // eslint-disable-next-line typescript-eslint/no-unsafe-type-assertion -- request body built by client.ts's own JSON.stringify(payload); shape asserted by the expectations below
       JSON.parse(rawBody) as Record<string, unknown>;
     captured.pocet = payload["pocet"];
+    captured.signal = init?.signal;
     return new Response(
       JSON.stringify({ pocetCelkem: 0, ekonomickeSubjekty: [] }),
       { status: 200, headers: { "Content-Type": "application/json" } },
@@ -164,5 +169,17 @@ describe("searchByName limit clamping", () => {
 
     await searchByName("Alza", { limit: 0 });
     expect(ctx.captured.pocet).toBe(1);
+  });
+
+  test("forwards caller cancellation", async () => {
+    const ctx = captureSearchRequest();
+    restore = ctx.restore;
+    const controller = new AbortController();
+
+    const search = searchByName("Alza", { signal: controller.signal });
+    expect(ctx.captured.signal?.aborted).toBe(false);
+    controller.abort();
+    expect(ctx.captured.signal?.aborted).toBe(true);
+    await search;
   });
 });

--- a/packages/business-registries/src/ares/client.ts
+++ b/packages/business-registries/src/ares/client.ts
@@ -1,5 +1,9 @@
 import { isRecord } from "../shared/guards.js";
-import { performRegistryRequest, readRegistryJson } from "../shared/http.js";
+import {
+  performRegistryRequest,
+  readRegistryJson,
+  type RegistryClientOptions,
+} from "../shared/http.js";
 import { clampSearchLimit } from "../shared/search.js";
 import {
   AresAPIError,
@@ -160,13 +164,20 @@ const readAresJson = async <T>(
       }),
   });
 
-const aresGet = async <T>(
-  url: string,
-  isExpectedShape: (value: unknown) => value is T,
-): Promise<T | null> => {
+type AresGetOptions<T> = RegistryClientOptions & {
+  url: string;
+  isExpectedShape: (value: unknown) => value is T;
+};
+
+const aresGet = async <T>({
+  url,
+  isExpectedShape,
+  signal,
+}: AresGetOptions<T>): Promise<T | null> => {
   const response = await performRegistryRequest({
     url,
     init: { headers: { Accept: "application/json" } },
+    signal,
     wrapRequestError: (cause) =>
       new AresRequestError(url, "ARES request failed", { cause }),
   });
@@ -196,11 +207,16 @@ const aresGet = async <T>(
   return readAresJson(response, isExpectedShape);
 };
 
-const aresPost = async <T>(
-  url: string,
-  payload: unknown,
-  isExpectedShape: (value: unknown) => value is T,
-): Promise<T> => {
+type AresPostOptions<T> = AresGetOptions<T> & {
+  payload: unknown;
+};
+
+const aresPost = async <T>({
+  url,
+  payload,
+  isExpectedShape,
+  signal,
+}: AresPostOptions<T>): Promise<T> => {
   const response = await performRegistryRequest({
     url,
     init: {
@@ -211,6 +227,7 @@ const aresPost = async <T>(
       },
       body: JSON.stringify(payload),
     },
+    signal,
     wrapRequestError: (cause) =>
       new AresRequestError(url, "ARES request failed", { cause }),
   });
@@ -226,7 +243,7 @@ const aresPost = async <T>(
 // Public API
 // ---------------------------------------------------------------------------
 
-export type LookupOptions = {
+export type LookupOptions = RegistryClientOptions & {
   /**
    * Whether to fetch VR (commercial register) data for enrichment.
    * Adds statutory bodies, share capital, court file, acting clause.
@@ -259,9 +276,17 @@ export const lookupByIco = async (
   const includeVr = options?.includeVr ?? true;
 
   // Fetch RES (always) and VR (optionally, in parallel)
-  const resPromise = aresGet(`${RES_URL}/${normalized}`, isAresResResponse);
+  const resPromise = aresGet({
+    url: `${RES_URL}/${normalized}`,
+    isExpectedShape: isAresResResponse,
+    signal: options?.signal,
+  });
   const vrPromise = includeVr
-    ? aresGet(`${VR_URL}/${normalized}`, isAresVrResponse)
+    ? aresGet({
+        url: `${VR_URL}/${normalized}`,
+        isExpectedShape: isAresVrResponse,
+        signal: options?.signal,
+      })
     : null;
 
   const [resData, vrData] = await Promise.all([
@@ -287,7 +312,7 @@ export const lookupByIco = async (
   return company;
 };
 
-export type SearchOptions = {
+export type SearchOptions = RegistryClientOptions & {
   /** Maximum number of results. @default 50 */
   limit?: number;
 };
@@ -318,7 +343,12 @@ export const searchByName = async (
     pocet: limit,
   };
 
-  const data = await aresPost(SEARCH_URL, payload, isAresSearchResponse);
+  const data = await aresPost({
+    url: SEARCH_URL,
+    payload,
+    isExpectedShape: isAresSearchResponse,
+    signal: options?.signal,
+  });
 
   return data.ekonomickeSubjekty.flatMap((entry) =>
     entry.ico ? [parseSearchEntry(entry)] : [],

--- a/packages/business-registries/src/krs/client.test.ts
+++ b/packages/business-registries/src/krs/client.test.ts
@@ -28,11 +28,15 @@ const urlString = (input: URL | Request | string): string => {
 };
 
 const installFetchStub = (
-  handler: (input: URL | Request | string) => Promise<Response>,
+  handler: (
+    input: URL | Request | string,
+    init?: RequestInit,
+  ) => Promise<Response>,
 ) => {
   const original = globalThis.fetch;
   globalThis.fetch = Object.assign(
-    async (input: URL | Request | string) => handler(input),
+    async (input: URL | Request | string, init?: RequestInit) =>
+      handler(input, init),
     { preconnect: original.preconnect },
   );
   return () => {
@@ -85,16 +89,25 @@ describe("lookupByKrsNumber (fixture)", () => {
   test("parses the live CD Projekt payload via the RejP probe", async () => {
     const body = await readFixture("lookup-cd-projekt.json");
     const seen: string[] = [];
-    restore = installFetchStub(async (input) => {
+    let signal: AbortSignal | null | undefined;
+    restore = installFetchStub(async (input, init) => {
       const url = urlString(input);
       seen.push(url);
+      signal = init?.signal;
       return new Response(JSON.stringify(body), {
         status: 200,
         headers: { "Content-Type": "application/json" },
       });
     });
 
-    const entity = await lookupByKrsNumber("0000006865");
+    const controller = new AbortController();
+    const lookup = lookupByKrsNumber("0000006865", {
+      signal: controller.signal,
+    });
+    expect(signal?.aborted).toBe(false);
+    controller.abort();
+    expect(signal?.aborted).toBe(true);
+    const entity = await lookup;
     expect(entity).not.toBeNull();
     expect(entity?.name).toBe("CD PROJEKT SPÓŁKA AKCYJNA");
     // Pin the URL shape so a refactor cannot silently drift the

--- a/packages/business-registries/src/krs/client.ts
+++ b/packages/business-registries/src/krs/client.ts
@@ -1,5 +1,8 @@
 import { isRecord } from "../shared/guards.js";
-import { performRegistryRequest } from "../shared/http.js";
+import {
+  performRegistryRequest,
+  type RegistryClientOptions,
+} from "../shared/http.js";
 import { KrsAPIError, KrsRequestError, KrsValidationError } from "./errors.js";
 import { parseEntity } from "./parse.js";
 import type {
@@ -11,8 +14,6 @@ import type {
 import { normalizeKrsNumber, validateKrsNumber } from "./validation.js";
 
 const BASE = "https://api-krs.ms.gov.pl/api/krs";
-
-const TIMEOUT_MS = 10_000;
 
 // Default probe order: Rejestr Przedsiębiorców (companies) first,
 // Stowarzyszeń (associations) second. The same KRS number lives in
@@ -130,13 +131,12 @@ E2Efv4WstK2tBZQIgx51F9NxO5NQI1mg7TyRVJ12AMXDuDjb
 
 /** Bun extends RequestInit with a `tls` option that standard lib types do
  *  not model; the runtime guard below scopes its use to Bun. */
-type BunTlsRequestInit = RequestInit & {
+type BunTlsRequestInit = Omit<RequestInit, "signal"> & {
   tls?: { ca: string[] };
 };
 
-const krsFetchOptions = (): RequestInit => {
+const krsFetchOptions = (): Omit<RequestInit, "signal"> => {
   const base: BunTlsRequestInit = {
-    signal: AbortSignal.timeout(TIMEOUT_MS),
     headers: { Accept: "application/json" },
   };
   if (typeof Bun === "undefined") {
@@ -148,6 +148,7 @@ const krsFetchOptions = (): RequestInit => {
 
 const krsGet = async (
   url: string,
+  signal?: AbortSignal,
 ): Promise<{ status: number; body: KrsLookupResponse | null }> => {
   // KRS pins Certum CA certs via Bun's non-standard `tls` fetch option
   // (see krsFetchOptions); it is passed straight through the shared
@@ -155,6 +156,7 @@ const krsGet = async (
   const response = await performRegistryRequest({
     url,
     init: krsFetchOptions(),
+    signal,
     wrapRequestError: (error) => {
       const suffix = error instanceof Error ? `: ${error.message}` : "";
       return new KrsRequestError(url, `KRS request failed${suffix}`, {
@@ -218,7 +220,7 @@ const buildLookupUrl = (
   return `${BASE}/OdpisAktualny/${krsNumber}?${params.toString()}`;
 };
 
-export type LookupOptions = {
+export type LookupOptions = RegistryClientOptions & {
   /**
    * Restrict the probe to a single sub-register. By default the
    * client probes Rejestr Przedsiębiorców (`RejP`) first and falls
@@ -259,7 +261,10 @@ export const lookupByKrsNumber = async (
     options?.register === undefined ? REGISTER_PROBE_ORDER : [options.register];
   for (const register of registers) {
     // oxlint-disable-next-line no-await-in-loop -- sequential sub-register probe, return on first hit, fall through on 404
-    const { status, body } = await krsGet(buildLookupUrl(normalized, register));
+    const { status, body } = await krsGet(
+      buildLookupUrl(normalized, register),
+      options?.signal,
+    );
     if (status === 404 || !body?.odpis) {
       continue;
     }

--- a/packages/business-registries/src/recherche-entreprises/client.test.ts
+++ b/packages/business-registries/src/recherche-entreprises/client.test.ts
@@ -23,11 +23,15 @@ const readFixture = async (
 };
 
 const installFetchStub = (
-  handler: (input: URL | Request | string) => Promise<Response>,
+  handler: (
+    input: URL | Request | string,
+    init?: RequestInit,
+  ) => Promise<Response>,
 ) => {
   const original = globalThis.fetch;
   globalThis.fetch = Object.assign(
-    async (input: URL | Request | string) => handler(input),
+    async (input: URL | Request | string, init?: RequestInit) =>
+      handler(input, init),
     { preconnect: original.preconnect },
   );
   return () => {
@@ -83,15 +87,23 @@ describe("lookupBySiren (fixture)", () => {
 
   test("parses the live RENAULT SAS SIREN payload", async () => {
     const body = await readFixture("lookup-siren-renault.json");
-    restore = installFetchStub(
-      async () =>
-        new Response(JSON.stringify(body), {
-          status: 200,
-          headers: { "Content-Type": "application/json" },
-        }),
-    );
+    let signal: AbortSignal | null | undefined;
+    restore = installFetchStub(async (_input, init) => {
+      signal = init?.signal;
+      return new Response(JSON.stringify(body), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
 
-    const company = await lookupBySiren("780129987");
+    const controller = new AbortController();
+    const lookup = lookupBySiren("780129987", {
+      signal: controller.signal,
+    });
+    expect(signal?.aborted).toBe(false);
+    controller.abort();
+    expect(signal?.aborted).toBe(true);
+    const company = await lookup;
     expect(company).not.toBeNull();
     expect(company?.siren).toBe("780129987");
     expect(company?.name).toBe("RENAULT SAS");

--- a/packages/business-registries/src/recherche-entreprises/client.ts
+++ b/packages/business-registries/src/recherche-entreprises/client.ts
@@ -1,5 +1,9 @@
 import { isRecord } from "../shared/guards.js";
-import { performRegistryRequest, readRegistryJson } from "../shared/http.js";
+import {
+  performRegistryRequest,
+  readRegistryJson,
+  type RegistryClientOptions,
+} from "../shared/http.js";
 import { clampSearchLimit } from "../shared/search.js";
 import {
   RechercheEntreprisesAPIError,
@@ -73,10 +77,12 @@ const parseErrorBody = (value: unknown): RechercheEntreprisesErrorResponse => {
 
 const rechercheEntreprisesGet = async (
   url: string,
+  signal?: AbortSignal,
 ): Promise<RechercheEntreprisesSearchResponse> => {
   const response = await performRegistryRequest({
     url,
     init: { headers: { Accept: "application/json" } },
+    signal,
     wrapRequestError: (cause) =>
       new RechercheEntreprisesRequestError(
         url,
@@ -137,8 +143,11 @@ const rechercheEntreprisesGet = async (
  * @throws {RechercheEntreprisesAPIError} on upstream errors
  * @throws {RechercheEntreprisesRequestError} on network failures
  */
+export type LookupOptions = RegistryClientOptions;
+
 export const lookupBySiren = async (
   siren: string,
+  options?: LookupOptions,
 ): Promise<RechercheEntreprisesCompany | null> => {
   const normalized = normalizeSiren(siren);
   if (!validateSiren(normalized)) {
@@ -147,6 +156,7 @@ export const lookupBySiren = async (
   const params = new URLSearchParams({ q: normalized });
   const data = await rechercheEntreprisesGet(
     `${SEARCH_URL}?${params.toString()}`,
+    options?.signal,
   );
   const hit = data.results.at(0);
   // Belt-and-braces: the search endpoint matches `q` against any
@@ -177,6 +187,7 @@ export const lookupBySiren = async (
  */
 export const lookupBySiret = async (
   siret: string,
+  options?: LookupOptions,
 ): Promise<RechercheEntreprisesCompany | null> => {
   const normalized = normalizeSiren(siret);
   if (!validateSiret(normalized)) {
@@ -185,6 +196,7 @@ export const lookupBySiret = async (
   const params = new URLSearchParams({ q: normalized });
   const data = await rechercheEntreprisesGet(
     `${SEARCH_URL}?${params.toString()}`,
+    options?.signal,
   );
   // SIRET = SIREN (first 9) + NIC (last 5). Require BOTH the unité
   // légale's SIREN to match the SIRET prefix AND the establishment
@@ -206,7 +218,7 @@ export const lookupBySiret = async (
   return parseCompany(hit, normalized);
 };
 
-export type SearchOptions = {
+export type SearchOptions = RegistryClientOptions & {
   /**
    * Maximum number of results. Upstream caps each page at 25 — values
    * above are silently clamped down. @default 25
@@ -241,6 +253,7 @@ export const searchByName = async (
   });
   const data = await rechercheEntreprisesGet(
     `${SEARCH_URL}?${params.toString()}`,
+    options?.signal,
   );
   return data.results.slice(0, perPage).map(parseSearchEntry);
 };

--- a/packages/business-registries/src/recherche-entreprises/index.ts
+++ b/packages/business-registries/src/recherche-entreprises/index.ts
@@ -1,5 +1,5 @@
 export { lookupBySiren, lookupBySiret, searchByName } from "./client.js";
-export type { SearchOptions } from "./client.js";
+export type { LookupOptions, SearchOptions } from "./client.js";
 export {
   RechercheEntreprisesAPIError,
   RechercheEntreprisesError,

--- a/packages/business-registries/src/shared/http.test.ts
+++ b/packages/business-registries/src/shared/http.test.ts
@@ -28,11 +28,15 @@ const isShape = (value: unknown): value is Shape =>
   isRecord(value) && value["ok"] === true;
 
 const installFetchStub = (
-  handler: (input: URL | Request | string) => Promise<Response>,
+  handler: (
+    input: URL | Request | string,
+    init?: RequestInit,
+  ) => Promise<Response>,
 ): (() => void) => {
   const original = globalThis.fetch;
   globalThis.fetch = Object.assign(
-    async (input: URL | Request | string) => handler(input),
+    async (input: URL | Request | string, init?: RequestInit) =>
+      handler(input, init),
     { preconnect: original.preconnect },
   );
   return () => {
@@ -45,6 +49,27 @@ const jsonResponse = (body: unknown, status = 200): Response =>
     status,
     headers: { "Content-Type": "application/json" },
   });
+
+const rejectWithSignalReason = (
+  signal: AbortSignal,
+  reject: (reason: Error) => void,
+): void => {
+  const reason: unknown = signal.reason;
+  reject(
+    reason instanceof Error
+      ? reason
+      : new Error("The request was aborted", { cause: reason }),
+  );
+};
+
+const captureThrown = async (promise: Promise<unknown>): Promise<unknown> => {
+  try {
+    await promise;
+  } catch (error) {
+    return error;
+  }
+  return undefined;
+};
 
 let restore: (() => void) | null = null;
 afterEach(() => {
@@ -73,13 +98,14 @@ describe("performRegistryRequest", () => {
     restore = installFetchStub(async () => {
       throw new Error("The operation timed out");
     });
-    expect(
+    const error = await captureThrown(
       performRegistryRequest({
         url: "https://example.test",
         wrapRequestError: (cause) =>
           new RequestMarkerError("wrapped", { cause }),
       }),
-    ).rejects.toBeInstanceOf(RequestMarkerError);
+    );
+    expect(error).toBeInstanceOf(RequestMarkerError);
   });
 
   test("returns the raw response on success", async () => {
@@ -89,6 +115,87 @@ describe("performRegistryRequest", () => {
       wrapRequestError: (cause) => new RequestMarkerError("wrapped", { cause }),
     });
     expect(response.status).toBe(200);
+  });
+
+  test("composes caller cancellation with the mandatory timeout", async () => {
+    const controller = new AbortController();
+    const reason = new DOMException("cancelled", "AbortError");
+    let requestSignal: AbortSignal | null | undefined;
+    restore = installFetchStub(async (_input, init) => {
+      const signal = init?.signal;
+      if (!signal) {
+        throw new Error("Missing request signal");
+      }
+      requestSignal = signal;
+      await new Promise<void>((_resolve, reject) => {
+        signal.addEventListener(
+          "abort",
+          () => rejectWithSignalReason(signal, reject),
+          { once: true },
+        );
+      });
+      return jsonResponse({ ok: true });
+    });
+
+    const request = performRegistryRequest({
+      url: "https://example.test",
+      signal: controller.signal,
+      wrapRequestError: (cause) => new RequestMarkerError("wrapped", { cause }),
+    });
+
+    expect(requestSignal).toBeInstanceOf(AbortSignal);
+    expect(requestSignal?.aborted).toBe(false);
+    controller.abort(reason);
+    expect(requestSignal?.aborted).toBe(true);
+    expect(await captureThrown(request)).toBe(reason);
+  });
+
+  test("removes caller listeners after the request settles", async () => {
+    const controller = new AbortController();
+    let requestSignal: AbortSignal | null | undefined;
+    restore = installFetchStub(async (_input, init) => {
+      requestSignal = init?.signal;
+      return jsonResponse({ ok: true });
+    });
+
+    await performRegistryRequest({
+      url: "https://example.test",
+      signal: controller.signal,
+      wrapRequestError: (cause) => new RequestMarkerError("wrapped", { cause }),
+    });
+
+    controller.abort();
+    expect(requestSignal?.aborted).toBe(false);
+  });
+
+  test("retains the timeout and maps it as a transport failure", async () => {
+    restore = installFetchStub(async (_input, init) => {
+      const signal = init?.signal;
+      if (!signal) {
+        throw new Error("Missing request signal");
+      }
+      await new Promise<void>((_resolve, reject) => {
+        signal.addEventListener(
+          "abort",
+          () => rejectWithSignalReason(signal, reject),
+          { once: true },
+        );
+      });
+      return jsonResponse({ ok: true });
+    });
+
+    const error = await captureThrown(
+      performRegistryRequest({
+        url: "https://example.test",
+        timeoutMs: 1,
+        wrapRequestError: (cause) =>
+          new RequestMarkerError("wrapped", { cause }),
+      }),
+    );
+    expect(error).toMatchObject({
+      name: "RequestMarkerError",
+      cause: { name: "TimeoutError" },
+    });
   });
 });
 
@@ -103,26 +210,28 @@ describe("readRegistryJson", () => {
     expect(body).toEqual({ ok: true });
   });
 
-  test("maps a non-JSON body to the parse error", () => {
-    expect(
+  test("maps a non-JSON body to the parse error", async () => {
+    const error = await captureThrown(
       readRegistryJson({
         response: new Response("<html>not json</html>", { status: 200 }),
         isExpectedShape: isShape,
         wrapParseError: (cause) => new ParseMarkerError("parse", { cause }),
         wrapShapeError: () => new ShapeMarkerError("shape"),
       }),
-    ).rejects.toBeInstanceOf(ParseMarkerError);
+    );
+    expect(error).toBeInstanceOf(ParseMarkerError);
   });
 
-  test("maps an unexpected shape to the shape error", () => {
-    expect(
+  test("maps an unexpected shape to the shape error", async () => {
+    const error = await captureThrown(
       readRegistryJson({
         response: jsonResponse({ nope: 1 }),
         isExpectedShape: isShape,
         wrapParseError: (cause) => new ParseMarkerError("parse", { cause }),
         wrapShapeError: () => new ShapeMarkerError("shape"),
       }),
-    ).rejects.toBeInstanceOf(ShapeMarkerError);
+    );
+    expect(error).toBeInstanceOf(ShapeMarkerError);
   });
 });
 
@@ -133,53 +242,57 @@ describe("registryFetch", () => {
     expect(result).toEqual({ ok: true });
   });
 
-  test("wraps a transport failure via wrapRequestError", () => {
+  test("wraps a transport failure via wrapRequestError", async () => {
     restore = installFetchStub(async () => {
       throw new Error("timed out");
     });
-    expect(registryFetch(baseOptions)).rejects.toBeInstanceOf(
-      RequestMarkerError,
-    );
+    const error = await captureThrown(registryFetch(baseOptions));
+    expect(error).toBeInstanceOf(RequestMarkerError);
   });
 
-  test("delegates a non-OK status to onErrorResponse (throws)", () => {
+  test("delegates a non-OK status to onErrorResponse (throws)", async () => {
     restore = installFetchStub(async () => jsonResponse({ error: true }, 500));
-    expect(registryFetch(baseOptions)).rejects.toBeInstanceOf(ApiMarkerError);
+    const error = await captureThrown(registryFetch(baseOptions));
+    expect(error).toBeInstanceOf(ApiMarkerError);
   });
 
-  test("lets onErrorResponse resolve a not-found status to null", () => {
+  test("lets onErrorResponse resolve a not-found status to null", async () => {
     restore = installFetchStub(async () => jsonResponse({ error: true }, 404));
-    expect(registryFetch(baseOptions)).resolves.toBeNull();
+    expect(await registryFetch(baseOptions)).toBeNull();
   });
 
-  test("maps a malformed 2xx JSON body to the parse error", () => {
+  test("maps a malformed 2xx JSON body to the parse error", async () => {
     restore = installFetchStub(async () => new Response("}{", { status: 200 }));
-    expect(registryFetch(baseOptions)).rejects.toBeInstanceOf(ParseMarkerError);
+    const error = await captureThrown(registryFetch(baseOptions));
+    expect(error).toBeInstanceOf(ParseMarkerError);
   });
 
-  test("maps an unexpected 2xx shape to the shape error", () => {
+  test("maps an unexpected 2xx shape to the shape error", async () => {
     restore = installFetchStub(async () => jsonResponse({ nope: true }));
-    expect(registryFetch(baseOptions)).rejects.toBeInstanceOf(ShapeMarkerError);
+    const error = await captureThrown(registryFetch(baseOptions));
+    expect(error).toBeInstanceOf(ShapeMarkerError);
   });
 
-  test("routes a 429 to onRateLimited when provided, before onErrorResponse", () => {
+  test("routes a 429 to onRateLimited when provided, before onErrorResponse", async () => {
     restore = installFetchStub(async () => jsonResponse({ error: true }, 429));
     class RateMarkerError extends Error {
       override name = "RateMarkerError";
     }
-    expect(
+    const error = await captureThrown(
       registryFetch({
         ...baseOptions,
         onRateLimited: () => {
           throw new RateMarkerError("rate limited");
         },
       }),
-    ).rejects.toBeInstanceOf(RateMarkerError);
+    );
+    expect(error).toBeInstanceOf(RateMarkerError);
   });
 
-  test("falls back to onErrorResponse for a 429 when onRateLimited is absent", () => {
+  test("falls back to onErrorResponse for a 429 when onRateLimited is absent", async () => {
     restore = installFetchStub(async () => jsonResponse({ error: true }, 429));
-    expect(registryFetch(baseOptions)).rejects.toBeInstanceOf(ApiMarkerError);
+    const error = await captureThrown(registryFetch(baseOptions));
+    expect(error).toBeInstanceOf(ApiMarkerError);
   });
 });
 

--- a/packages/business-registries/src/shared/http.ts
+++ b/packages/business-registries/src/shared/http.ts
@@ -20,18 +20,64 @@ import { RegistryRateLimitedError } from "./errors.js";
 /** Default per-request timeout. Every adapter used 10s. */
 export const DEFAULT_REGISTRY_TIMEOUT_MS = 10_000;
 
+/** Request controls shared by public registry lookup and search options. */
+export type RegistryClientOptions = {
+  /** Cancel the in-flight request without disabling its timeout. */
+  signal?: AbortSignal | undefined;
+};
+
 export type RegistryRequestOptions = {
   url: string;
   /**
-   * Extra fetch options (method, body, headers, and Bun-only `tls`).
-   * Spread after the timeout signal so a caller can override the signal
-   * or add a custom trust store — KRS pins Certum CA certs this way.
+   * Extra fetch options (method, body, headers, and Bun-only `tls`). The
+   * signal is a separate field so callers cannot accidentally replace the
+   * mandatory timeout — KRS passes its custom trust store through here.
    */
-  init?: RequestInit;
+  init?: Omit<RequestInit, "signal">;
+  /** Cancel the request without disabling its timeout. */
+  signal?: AbortSignal | undefined;
   /** @default DEFAULT_REGISTRY_TIMEOUT_MS */
   timeoutMs?: number;
   /** Map a transport/timeout failure into the adapter's RequestError. */
   wrapRequestError: (cause: unknown) => Error;
+};
+
+type RegistryRequestSignal = {
+  signal: AbortSignal;
+  dispose: () => void;
+};
+
+const noSignalListeners = (): void => undefined;
+
+const createRegistryRequestSignal = (
+  callerSignal: AbortSignal | undefined,
+  timeoutMs: number,
+): RegistryRequestSignal => {
+  if (callerSignal?.aborted) {
+    return { signal: callerSignal, dispose: noSignalListeners };
+  }
+  const timeoutSignal = AbortSignal.timeout(timeoutMs);
+  if (!callerSignal) {
+    return { signal: timeoutSignal, dispose: noSignalListeners };
+  }
+
+  const controller = new AbortController();
+  const dispose = (): void => {
+    callerSignal.removeEventListener("abort", abortFromCaller);
+    timeoutSignal.removeEventListener("abort", abortFromTimeout);
+  };
+  const abortFromCaller = (): void => {
+    controller.abort(callerSignal.reason);
+    dispose();
+  };
+  const abortFromTimeout = (): void => {
+    controller.abort(timeoutSignal.reason);
+    dispose();
+  };
+  callerSignal.addEventListener("abort", abortFromCaller, { once: true });
+  timeoutSignal.addEventListener("abort", abortFromTimeout, { once: true });
+
+  return { signal: controller.signal, dispose };
 };
 
 /**
@@ -44,15 +90,23 @@ export type RegistryRequestOptions = {
 export const performRegistryRequest = async (
   options: RegistryRequestOptions,
 ): Promise<Response> => {
+  const requestSignal = createRegistryRequestSignal(
+    options.signal,
+    options.timeoutMs ?? DEFAULT_REGISTRY_TIMEOUT_MS,
+  );
   try {
     return await fetch(options.url, {
-      signal: AbortSignal.timeout(
-        options.timeoutMs ?? DEFAULT_REGISTRY_TIMEOUT_MS,
-      ),
       ...options.init,
+      signal: requestSignal.signal,
     });
   } catch (error) {
+    // Caller cancellation is control flow, not a registry transport failure.
+    // Preserve its reason so consumers can distinguish it from timeouts and
+    // network errors, which retain the adapter-specific error mapping below.
+    options.signal?.throwIfAborted();
     throw options.wrapRequestError(error);
+  } finally {
+    requestSignal.dispose();
   }
 };
 

--- a/packages/business-registries/src/shared/index.ts
+++ b/packages/business-registries/src/shared/index.ts
@@ -12,6 +12,7 @@ export {
   RegistryValidationError,
 } from "./errors.js";
 export type { EntityNotFound } from "./errors.js";
+export type { RegistryClientOptions } from "./http.js";
 export { clampSearchLimit } from "./search.js";
 export type {
   NormalizedRegistryAddress,

--- a/packages/business-registries/src/sudreg/client.test.ts
+++ b/packages/business-registries/src/sudreg/client.test.ts
@@ -14,11 +14,15 @@ const requestUrl = (input: URL | Request | string): string => {
 };
 
 const installFetchStub = (
-  handler: (input: URL | Request | string) => Promise<Response>,
+  handler: (
+    input: URL | Request | string,
+    init?: RequestInit,
+  ) => Promise<Response>,
 ) => {
   const original = globalThis.fetch;
   globalThis.fetch = Object.assign(
-    async (input: URL | Request | string) => handler(input),
+    async (input: URL | Request | string, init?: RequestInit) =>
+      handler(input, init),
     { preconnect: original.preconnect },
   );
   return () => {
@@ -50,15 +54,24 @@ describe("SUDREG client", () => {
   test("fetches and parses a company page", async () => {
     const fixture = await Bun.file(FIXTURE).text();
     let url = "";
-    restore = installFetchStub(async (input) => {
+    let signal: AbortSignal | null | undefined;
+    restore = installFetchStub(async (input, init) => {
       url = requestUrl(input);
+      signal = init?.signal;
       return new Response(fixture, {
         status: 200,
         headers: { "Content-Type": "text/html" },
       });
     });
 
-    const company = await lookupByMbs("080 000 014");
+    const controller = new AbortController();
+    const lookup = lookupByMbs("080 000 014", {
+      signal: controller.signal,
+    });
+    expect(signal?.aborted).toBe(false);
+    controller.abort();
+    expect(signal?.aborted).toBe(true);
+    const company = await lookup;
     expect(company?.name).toContain("PRIMJER");
     expect(url).toContain("p28_sbt_mbs=080000014");
   });

--- a/packages/business-registries/src/sudreg/client.ts
+++ b/packages/business-registries/src/sudreg/client.ts
@@ -1,4 +1,7 @@
-import { performRegistryRequest } from "../shared/http.js";
+import {
+  performRegistryRequest,
+  type RegistryClientOptions,
+} from "../shared/http.js";
 import {
   SudregAPIError,
   SudregRequestError,
@@ -11,8 +14,11 @@ import { normalizeMbs, validateMbs } from "./validation.js";
 const companyUrl = (mbs: string): string =>
   `https://sudreg.pravosudje.hr/ords/r/esudreg/public/28?p28_sbt_mbs=${encodeURIComponent(mbs)}`;
 
+export type LookupOptions = RegistryClientOptions;
+
 export const lookupByMbs = async (
   mbsInput: string,
+  options?: LookupOptions,
 ): Promise<SudregCompany | null> => {
   const mbs = normalizeMbs(mbsInput);
   if (!validateMbs(mbs)) {
@@ -22,6 +28,7 @@ export const lookupByMbs = async (
   const response = await performRegistryRequest({
     url,
     init: { headers: { Accept: "text/html" } },
+    signal: options?.signal,
     wrapRequestError: (cause) =>
       new SudregRequestError(url, "SUDREG request failed", { cause }),
   });

--- a/packages/business-registries/src/sudreg/index.ts
+++ b/packages/business-registries/src/sudreg/index.ts
@@ -1,4 +1,5 @@
 export { lookupByMbs } from "./client.js";
+export type { LookupOptions } from "./client.js";
 export {
   SudregAPIError,
   SudregError,

--- a/packages/business-registries/src/zefix/client.test.ts
+++ b/packages/business-registries/src/zefix/client.test.ts
@@ -49,15 +49,24 @@ describe("Zefix client", () => {
   test("looks up and normalizes a formatted UID", async () => {
     const fixture = await readFixture();
     let body = "";
+    let signal: AbortSignal | null | undefined;
     restore = installFetchStub(async (_input, init) => {
       body = typeof init?.body === "string" ? init.body : "";
+      signal = init?.signal;
       return new Response(JSON.stringify(fixture), {
         status: 200,
         headers: { "Content-Type": "application/json" },
       });
     });
 
-    const company = await lookupByUid("CHE-191.546.434");
+    const controller = new AbortController();
+    const lookup = lookupByUid("CHE-191.546.434", {
+      signal: controller.signal,
+    });
+    expect(signal?.aborted).toBe(false);
+    controller.abort();
+    expect(signal?.aborted).toBe(true);
+    const company = await lookup;
     expect(company).not.toBeNull();
     if (!company) {
       return;

--- a/packages/business-registries/src/zefix/client.ts
+++ b/packages/business-registries/src/zefix/client.ts
@@ -1,5 +1,8 @@
 import { isRecord } from "../shared/guards.js";
-import { performRegistryRequest } from "../shared/http.js";
+import {
+  performRegistryRequest,
+  type RegistryClientOptions,
+} from "../shared/http.js";
 import { clampSearchLimit } from "../shared/search.js";
 import {
   ZefixAPIError,
@@ -50,10 +53,16 @@ const getErrorCode = (value: unknown): string | null => {
     : null;
 };
 
-const zefixSearch = async (
-  nameOrId: string,
-  maxEntries: number,
-): Promise<ZefixSuccessfulSearchResponse | null> => {
+type ZefixSearchOptions = RegistryClientOptions & {
+  nameOrId: string;
+  maxEntries: number;
+};
+
+const zefixSearch = async ({
+  nameOrId,
+  maxEntries,
+  signal,
+}: ZefixSearchOptions): Promise<ZefixSuccessfulSearchResponse | null> => {
   const response = await performRegistryRequest({
     url: SEARCH_URL,
     init: {
@@ -70,6 +79,7 @@ const zefixSearch = async (
         searchType: "exact",
       }),
     },
+    signal,
     wrapRequestError: (cause) =>
       new ZefixRequestError(SEARCH_URL, "Zefix request failed", { cause }),
   });
@@ -105,15 +115,22 @@ const zefixSearch = async (
   return body;
 };
 
+export type LookupOptions = RegistryClientOptions;
+
 export const lookupByUid = async (
   uidInput: string,
+  options?: LookupOptions,
 ): Promise<ZefixCompany | null> => {
   const uid = normalizeUid(uidInput);
   if (!validateUid(uid)) {
     throw new ZefixValidationError(`Invalid Swiss UID: ${uidInput}`);
   }
 
-  const response = await zefixSearch(uid, 2);
+  const response = await zefixSearch({
+    nameOrId: uid,
+    maxEntries: 2,
+    signal: options?.signal,
+  });
   if (!response) {
     return null;
   }
@@ -126,7 +143,7 @@ export const lookupByUid = async (
   return null;
 };
 
-export type SearchOptions = {
+export type SearchOptions = RegistryClientOptions & {
   /** Maximum number of results. @default 50 */
   limit?: number;
 };
@@ -143,7 +160,11 @@ export const searchByName = async (
     options?.limit ?? DEFAULT_SEARCH_LIMIT,
     MAX_SEARCH_LIMIT,
   );
-  const response = await zefixSearch(trimmed, limit);
+  const response = await zefixSearch({
+    nameOrId: trimmed,
+    maxEntries: limit,
+    signal: options?.signal,
+  });
   if (!response) {
     return [];
   }

--- a/packages/business-registries/src/zefix/index.ts
+++ b/packages/business-registries/src/zefix/index.ts
@@ -1,5 +1,5 @@
 export { lookupByUid, searchByName } from "./client.js";
-export type { SearchOptions } from "./client.js";
+export type { LookupOptions, SearchOptions } from "./client.js";
 export {
   ZefixAPIError,
   ZefixError,


### PR DESCRIPTION
Add optional AbortSignal support to the browser-accessible registry clients while retaining the shared mandatory timeout. The shared request boundary now composes cancellation without relying on newer AbortSignal.any support and cleans up listeners after settlement.

Includes cancellation coverage for ARES, Zefix, recherche-entreprises, SUDREG, and KRS, plus a package changeset.

CC on behalf of jan-kubica

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional request cancellation across company registry lookups and searches.
  * Callers can now cancel in-progress requests while retaining existing timeout behaviour.
  * Exposed shared lookup options for supported registry integrations.

* **Bug Fixes**
  * Improved handling of cancellation, timeouts, rate limits and request errors.
  * Ensured request cleanup after completion to prevent lingering cancellation listeners.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->