### PR TITLE
fix: normalize current Companies House officers

### DIFF
--- a/.changeset/tidy-current-officers.md
+++ b/.changeset/tidy-current-officers.md
@@ -1,0 +1,5 @@
+---
+"@stll/business-registries": minor
+---
+
+Group normalized Companies House officers by role and omit resigned appointments from the current key-people field.

--- a/packages/business-registries/src/companies-house/normalized.test.ts
+++ b/packages/business-registries/src/companies-house/normalized.test.ts
@@ -36,9 +36,9 @@ describe("Companies House normalized projection", () => {
       return;
     }
     expect(withOfficers.keyPeople.value[0]?.people.length).toBeGreaterThan(0);
-    const datedOfficer = withOfficers.keyPeople.value[0]?.people.find(
-      (person) => person.birthDate !== null,
-    );
+    const datedOfficer = withOfficers.keyPeople.value
+      .flatMap(({ people }) => people)
+      .find((person) => person.birthDate !== null);
     expect(datedOfficer?.birthDate?.precision).toBe("month");
     expect(withOfficers.shareCapital).toEqual({
       availability: "not-supported",
@@ -82,6 +82,89 @@ describe("Companies House normalized projection", () => {
       return;
     }
     expect(entity.keyPeople.value.at(0)?.people.at(0)?.since).toBeNull();
+  });
+
+  test("groups current officers by role and excludes resigned appointments", () => {
+    const company = parseCompanyProfile(companyRaw);
+    const sourceOfficer = parseOfficersResponse(officersRaw).at(0);
+    expect(sourceOfficer).toBeDefined();
+    if (!sourceOfficer) {
+      return;
+    }
+    const entity = toNormalizedEntity(company, {
+      officers: [
+        sourceOfficer,
+        {
+          ...sourceOfficer,
+          name: "Former officer",
+          resignedOn: "2020-01-01",
+          isResigned: true,
+        },
+        {
+          ...sourceOfficer,
+          name: "Current secretary",
+          role: {
+            code: "synthetic-distinct-role",
+            title: "Company secretary",
+          },
+        },
+        {
+          ...sourceOfficer,
+          name: "Localized title",
+          role: {
+            code: sourceOfficer.role.code,
+            title: "Localized display title",
+          },
+        },
+        {
+          ...sourceOfficer,
+          name: "Same title, distinct code",
+          role: {
+            code: "synthetic-same-title-role",
+            title: "Company secretary",
+          },
+        },
+      ],
+    });
+
+    expect(entity.keyPeople.availability).toBe("available");
+    if (entity.keyPeople.availability !== "available") {
+      return;
+    }
+    expect(entity.keyPeople.value).toHaveLength(3);
+    expect(entity.keyPeople.value.at(0)).toMatchObject({
+      name: sourceOfficer.role.code,
+      people: [
+        expect.objectContaining({
+          name: sourceOfficer.name,
+          organName: null,
+          position: sourceOfficer.role.title ?? sourceOfficer.role.code,
+        }),
+        expect.objectContaining({
+          name: "Localized title",
+          position: "Localized display title",
+        }),
+      ],
+    });
+    expect(entity.keyPeople.value.at(1)).toMatchObject({
+      name: "Company secretary",
+      people: [
+        expect.objectContaining({
+          name: "Current secretary",
+          organName: null,
+          position: "Company secretary",
+        }),
+      ],
+    });
+    expect(entity.keyPeople.value.at(2)).toMatchObject({
+      name: "Company secretary",
+      people: [expect.objectContaining({ name: "Same title, distinct code" })],
+    });
+    expect(
+      entity.keyPeople.value.flatMap(({ people }) =>
+        people.map(({ name }) => name),
+      ),
+    ).not.toContain("Former officer");
   });
 
   test("preserves a known cessation date for removed companies", () => {

--- a/packages/business-registries/src/companies-house/normalized.ts
+++ b/packages/business-registries/src/companies-house/normalized.ts
@@ -7,6 +7,7 @@ import {
 import type {
   NormalizedRegistryAddress,
   NormalizedRegistryEntity,
+  NormalizedRegistryKeyPeopleGroup,
   NormalizedRegistryKeyPerson,
   NormalizedRegistrySearchResult,
 } from "../shared/normalized.js";
@@ -71,12 +72,15 @@ const normalizeAddress = (
   textAddress: address.textAddress,
 });
 
+const officerRole = (officer: CompaniesHouseOfficer): string =>
+  officer.role.title ?? officer.role.code;
+
 const normalizeOfficer = (
   officer: CompaniesHouseOfficer,
 ): NormalizedRegistryKeyPerson => ({
   name: officer.name,
   nameWithTitles: null,
-  position: officer.role.title ?? officer.role.code,
+  position: officerRole(officer),
   organName: null,
   // `appointedBefore` is only an upper bound for historical records, not an
   // exact appointment date. The normalized `since` field carries exact dates.
@@ -93,6 +97,27 @@ const normalizeOfficer = (
   share: null,
   link: null,
 });
+
+const normalizeCurrentOfficers = (
+  officers: CompaniesHouseOfficer[],
+): NormalizedRegistryKeyPeopleGroup[] => {
+  const groups = new Map<string, NormalizedRegistryKeyPeopleGroup>();
+  for (const officer of officers) {
+    if (officer.isResigned) {
+      continue;
+    }
+    const group = groups.get(officer.role.code);
+    if (group) {
+      group.people.push(normalizeOfficer(officer));
+      continue;
+    }
+    groups.set(officer.role.code, {
+      name: officerRole(officer),
+      people: [normalizeOfficer(officer)],
+    });
+  }
+  return Array.from(groups.values());
+};
 
 export type NormalizeCompaniesHouseOptions = {
   /** Officers returned by the separate Companies House officers endpoint. */
@@ -129,9 +154,7 @@ export const toNormalizedEntity = (
   removalDate: availableField(company.dateOfCessation),
   registryRecord: unsupportedField(),
   keyPeople: options?.officers
-    ? availableField([
-        { name: null, people: options.officers.map(normalizeOfficer) },
-      ])
+    ? availableField(normalizeCurrentOfficers(options.officers))
     : notLoadedField(),
   shareCapital: unsupportedField(),
   shareCapitalPaid: unsupportedField(),


### PR DESCRIPTION
## Summary

- omit resigned appointments from normalized current key people
- group officers by registry role while preserving source order
- retain the normalized role on each person

## Validation

- 67 package tests passed; 3 live tests skipped
- native TypeScript typecheck
- type-aware Oxlint and Oxfmt

CC on behalf of jan-kubica

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Companies House current key people are now grouped by role.
  * Officer role names are displayed using the available role title or code.
* **Bug Fixes**
  * Resigned officer appointments are excluded from current key people results.
  * Improved handling of officers loaded separately from unsupported fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->