### PR TITLE
perf(api): make the corpus index backfill viable for bulk builds

### DIFF
--- a/apps/api/src/lib/corpus-index/core.ts
+++ b/apps/api/src/lib/corpus-index/core.ts
@@ -591,7 +591,16 @@ export const createCorpusIndexer = <
             limit: staleLimit,
           });
 
-    const rows: TRow[] = [...missing, ...stale];
+    let rows: TRow[] = [...missing, ...stale];
+    if (rows.length === 0 && dutyDue && missingLimit < batchSize) {
+      // A stale-only duty batch that found nothing must not report zero —
+      // callers treat zero as completion. Fall back to a full missing
+      // selection so the duty batch costs at most one extra query.
+      rows = await adapter.selectMissing(scopedDb, {
+        generation,
+        limit: batchSize,
+      });
+    }
     if (rows.length === 0) {
       return 0;
     }

--- a/apps/api/src/lib/corpus-index/core.ts
+++ b/apps/api/src/lib/corpus-index/core.ts
@@ -258,6 +258,12 @@ export type LoadDocsForBatchOptions<TBrand extends SafeIdType, TRow> = {
   fetchFulltext: FetchFulltext<TBrand>;
   /** Override the per-row canonical payload load (test seam). */
   readPayload?: (row: TRow) => Promise<CorpusDocumentPayload>;
+  /**
+   * Concurrent canonical-object reads per chunk. The daemon default keeps
+   * S3 pressure low next to live traffic; a dedicated bulk build may raise
+   * it, since the build task is the only reader of its corpus prefix.
+   */
+  readConcurrency?: number;
 };
 
 /**
@@ -374,6 +380,7 @@ export const createCorpusIndexer = <
       generation,
       fetchFulltext,
       readPayload,
+      readConcurrency = INDEX_CONCURRENCY,
     }: LoadDocsForBatchOptions<TBrand, TRow>,
   ): Promise<LoadedBatch<TBrand, TRow>> => {
     const loadRowPayload =
@@ -398,8 +405,8 @@ export const createCorpusIndexer = <
       });
     const built: LoadedBatch<TBrand, TRow>["built"] = [];
     const readFailures: LoadedBatch<TBrand, TRow>["readFailures"] = [];
-    for (let i = 0; i < rows.length; i += INDEX_CONCURRENCY) {
-      const slice = rows.slice(i, i + INDEX_CONCURRENCY);
+    for (let i = 0; i < rows.length; i += readConcurrency) {
+      const slice = rows.slice(i, i + readConcurrency);
       // oxlint-disable-next-line no-await-in-loop -- bounded concurrency: drain one INDEX_CONCURRENCY chunk before loading the next so S3 reads stay capped
       const loaded = await Promise.all(
         slice.map(async (row) => {
@@ -529,6 +536,7 @@ export const createCorpusIndexer = <
     scopedDb: ScopedDb,
     batchSize: number,
     generation: string,
+    options: { readConcurrency?: number } = {},
   ): Promise<number> => {
     const staleReserved = Math.max(1, Math.floor(batchSize / 4));
     const missingLimit = Math.max(1, batchSize - staleReserved);
@@ -538,7 +546,16 @@ export const createCorpusIndexer = <
       limit: missingLimit,
     });
 
-    const staleLimit = batchSize - missing.length;
+    // The stale scan runs only once the missing backlog stops filling its
+    // quota. Its predicate (hash mismatch within the current generation)
+    // has no covering index, so against a generation with a large missing
+    // backlog — a fresh generation build being the extreme — it is a long
+    // scan that returns nothing, paid on every batch. Stale rows are
+    // re-indexes of content the index already serves in some version;
+    // deferring them behind the missing drain is self-limiting, because
+    // the drain itself empties the backlog that defers them.
+    const staleLimit =
+      missing.length >= missingLimit ? 0 : batchSize - missing.length;
     const stale =
       staleLimit <= 0
         ? []
@@ -560,6 +577,9 @@ export const createCorpusIndexer = <
     const { built, readFailures } = await loadDocsForBatch(rows, {
       generation,
       fetchFulltext,
+      ...(options.readConcurrency === undefined
+        ? {}
+        : { readConcurrency: options.readConcurrency }),
     });
     await recordReadFailures(scopedDb, readFailures, generation);
 

--- a/apps/api/src/lib/corpus-index/core.ts
+++ b/apps/api/src/lib/corpus-index/core.ts
@@ -28,6 +28,9 @@ import { LIMITS } from "@/api/lib/limits";
  */
 
 const INDEX_CONCURRENCY = 4;
+/** Run the stale scan at least once per this many batches under a full
+ *  missing backlog (see the duty-cycle note in `backfill`). */
+const STALE_SCAN_DUTY_CYCLE = 20;
 
 /**
  * Delete-task query selecting every search document a row projects to. Keyed
@@ -532,6 +535,8 @@ export const createCorpusIndexer = <
    * quarter of the batch for stale so re-indexes are not starved by a
    * missing-doc backlog. Returns the number indexed.
    */
+  let staleSkips = 0;
+
   const backfill = async (
     scopedDb: ScopedDb,
     batchSize: number,
@@ -546,16 +551,21 @@ export const createCorpusIndexer = <
       limit: missingLimit,
     });
 
-    // The stale scan runs only once the missing backlog stops filling its
+    // The stale scan is duty-cycled while the missing backlog fills its
     // quota. Its predicate (hash mismatch within the current generation)
     // has no covering index, so against a generation with a large missing
     // backlog — a fresh generation build being the extreme — it is a long
-    // scan that returns nothing, paid on every batch. Stale rows are
-    // re-indexes of content the index already serves in some version;
-    // deferring them behind the missing drain is self-limiting, because
-    // the drain itself empties the backlog that defers them.
+    // scan that often returns nothing, paid on every batch. Stale rows
+    // are re-indexes of content the index already serves in some version,
+    // so they can wait — but not forever: ingestion can keep the missing
+    // backlog full indefinitely, so every STALE_SCAN_DUTY_CYCLEth batch
+    // still runs the scan with its reserve, bounding staleness instead of
+    // trading it away.
     const staleLimit =
-      missing.length >= missingLimit ? 0 : batchSize - missing.length;
+      missing.length >= missingLimit && staleSkips < STALE_SCAN_DUTY_CYCLE - 1
+        ? 0
+        : batchSize - missing.length;
+    staleSkips = staleLimit === 0 ? staleSkips + 1 : 0;
     const stale =
       staleLimit <= 0
         ? []

--- a/apps/api/src/lib/corpus-index/core.ts
+++ b/apps/api/src/lib/corpus-index/core.ts
@@ -386,6 +386,13 @@ export const createCorpusIndexer = <
       readConcurrency = INDEX_CONCURRENCY,
     }: LoadDocsForBatchOptions<TBrand, TRow>,
   ): Promise<LoadedBatch<TBrand, TRow>> => {
+    // The stride drives the chunk loop; anything below 1 (or non-finite)
+    // would stall or skip rows, so it is clamped rather than trusted.
+    // Counted in rows: a passage row issues up to two object reads, so the
+    // in-flight request ceiling is twice this value.
+    const stride = Number.isFinite(readConcurrency)
+      ? Math.max(1, Math.floor(readConcurrency))
+      : INDEX_CONCURRENCY;
     const loadRowPayload =
       readPayload ??
       (async (row: TRow): Promise<CorpusDocumentPayload> => {
@@ -408,8 +415,8 @@ export const createCorpusIndexer = <
       });
     const built: LoadedBatch<TBrand, TRow>["built"] = [];
     const readFailures: LoadedBatch<TBrand, TRow>["readFailures"] = [];
-    for (let i = 0; i < rows.length; i += readConcurrency) {
-      const slice = rows.slice(i, i + readConcurrency);
+    for (let i = 0; i < rows.length; i += stride) {
+      const slice = rows.slice(i, i + stride);
       // oxlint-disable-next-line no-await-in-loop -- bounded concurrency: drain one INDEX_CONCURRENCY chunk before loading the next so S3 reads stay capped
       const loaded = await Promise.all(
         slice.map(async (row) => {
@@ -561,10 +568,14 @@ export const createCorpusIndexer = <
     // backlog full indefinitely, so every STALE_SCAN_DUTY_CYCLEth batch
     // still runs the scan with its reserve, bounding staleness instead of
     // trading it away.
+    // A due duty batch always grants the stale scan at least one slot —
+    // batchSize 1 would otherwise leave staleLimit at zero on the due
+    // batch and the counter would grow without the scan ever running.
+    const dutyDue = staleSkips >= STALE_SCAN_DUTY_CYCLE - 1;
     const staleLimit =
-      missing.length >= missingLimit && staleSkips < STALE_SCAN_DUTY_CYCLE - 1
+      missing.length >= missingLimit && !dutyDue
         ? 0
-        : batchSize - missing.length;
+        : Math.max(batchSize - missing.length, dutyDue ? 1 : 0);
     staleSkips = staleLimit === 0 ? staleSkips + 1 : 0;
     const stale =
       staleLimit <= 0

--- a/apps/api/src/lib/corpus-index/core.ts
+++ b/apps/api/src/lib/corpus-index/core.ts
@@ -551,12 +551,22 @@ export const createCorpusIndexer = <
     options: { readConcurrency?: number } = {},
   ): Promise<number> => {
     const staleReserved = Math.max(1, Math.floor(batchSize / 4));
-    const missingLimit = Math.max(1, batchSize - staleReserved);
+    // A due duty batch cedes one missing slot up front so granting the
+    // stale scan capacity below cannot push the batch past its requested
+    // size (batchSize 1 becomes a stale-only batch on the due call).
+    const dutyDue = staleSkips >= STALE_SCAN_DUTY_CYCLE - 1;
+    const missingLimit = Math.max(
+      dutyDue ? 0 : 1,
+      batchSize - staleReserved - (dutyDue ? 1 : 0),
+    );
 
-    const missing = await adapter.selectMissing(scopedDb, {
-      generation,
-      limit: missingLimit,
-    });
+    const missing =
+      missingLimit === 0
+        ? []
+        : await adapter.selectMissing(scopedDb, {
+            generation,
+            limit: missingLimit,
+          });
 
     // The stale scan is duty-cycled while the missing backlog fills its
     // quota. Its predicate (hash mismatch within the current generation)
@@ -568,14 +578,10 @@ export const createCorpusIndexer = <
     // backlog full indefinitely, so every STALE_SCAN_DUTY_CYCLEth batch
     // still runs the scan with its reserve, bounding staleness instead of
     // trading it away.
-    // A due duty batch always grants the stale scan at least one slot —
-    // batchSize 1 would otherwise leave staleLimit at zero on the due
-    // batch and the counter would grow without the scan ever running.
-    const dutyDue = staleSkips >= STALE_SCAN_DUTY_CYCLE - 1;
     const staleLimit =
       missing.length >= missingLimit && !dutyDue
         ? 0
-        : Math.max(batchSize - missing.length, dutyDue ? 1 : 0);
+        : batchSize - missing.length;
     staleSkips = staleLimit === 0 ? staleSkips + 1 : 0;
     const stale =
       staleLimit <= 0

--- a/apps/legal-atlas-runner/src/runners/case-law-corpus-storage-backfill.ts
+++ b/apps/legal-atlas-runner/src/runners/case-law-corpus-storage-backfill.ts
@@ -112,10 +112,13 @@ const parseArgs = (argv: readonly string[]): ParseResult => {
       if (!parsed.ok) {
         return parsed;
       }
+      const requestedBatch = parsed.options.caseLawLimit ?? 0;
+      if (requestedBatch <= 0) {
+        return { ok: false, message: `${arg} must be a positive integer` };
+      }
       // Cap keeps one batch's payload and CAS fan-out bounded even when an
       // operator asks for more.
-      options.indexBatchSize =
-        Math.min(parsed.options.caseLawLimit ?? 0, 1000) || null;
+      options.indexBatchSize = Math.min(requestedBatch, 1000);
       i += 1;
       continue;
     }
@@ -124,8 +127,13 @@ const parseArgs = (argv: readonly string[]): ParseResult => {
       if (!parsed.ok) {
         return parsed;
       }
-      options.indexReadConcurrency =
-        Math.min(parsed.options.caseLawLimit ?? 0, 32) || null;
+      const requestedReads = parsed.options.caseLawLimit ?? 0;
+      if (requestedReads <= 0) {
+        return { ok: false, message: `${arg} must be a positive integer` };
+      }
+      // Half the row cap: a passage row issues up to two object reads, so
+      // this bounds in-flight requests at twice the value.
+      options.indexReadConcurrency = Math.min(requestedReads, 16);
       i += 1;
       continue;
     }

--- a/apps/legal-atlas-runner/src/runners/case-law-corpus-storage-backfill.ts
+++ b/apps/legal-atlas-runner/src/runners/case-law-corpus-storage-backfill.ts
@@ -44,6 +44,8 @@ type LegislationBackfillRow = {
 
 type BackfillOptions = {
   caseLawLimit: number | null;
+  indexBatchSize: number | null;
+  indexReadConcurrency: number | null;
   legislationLimit: number | null;
 };
 
@@ -82,6 +84,8 @@ const parseLimit = (name: string, value: string | undefined): ParseResult => {
 const parseArgs = (argv: readonly string[]): ParseResult => {
   const options: BackfillOptions = {
     caseLawLimit: null,
+    indexBatchSize: null,
+    indexReadConcurrency: null,
     legislationLimit: null,
   };
 
@@ -98,6 +102,28 @@ const parseArgs = (argv: readonly string[]): ParseResult => {
       continue;
     }
 
+    if (arg === "--index-batch-size") {
+      const parsed = parseLimit(arg, argv.at(i + 1));
+      if (!parsed.ok) {
+        return parsed;
+      }
+      // Cap keeps one batch's payload and CAS fan-out bounded even when an
+      // operator asks for more.
+      options.indexBatchSize =
+        Math.min(parsed.options.caseLawLimit ?? 0, 1000) || null;
+      i += 1;
+      continue;
+    }
+    if (arg === "--index-read-concurrency") {
+      const parsed = parseLimit(arg, argv.at(i + 1));
+      if (!parsed.ok) {
+        return parsed;
+      }
+      options.indexReadConcurrency =
+        Math.min(parsed.options.caseLawLimit ?? 0, 32) || null;
+      i += 1;
+      continue;
+    }
     if (arg === "--case-law-limit") {
       const parsed = parseLimit(arg, argv.at(i + 1));
       if (!parsed.ok) {
@@ -215,11 +241,15 @@ type BackfillResult = {
   failed: number;
 };
 
-const nextBatchSize = (limit: number | null, attempted: number): number => {
+const nextBatchSize = (
+  limit: number | null,
+  attempted: number,
+  size: number = BATCH_SIZE,
+): number => {
   if (limit === null) {
-    return BATCH_SIZE;
+    return size;
   }
-  return Math.min(BATCH_SIZE, Math.max(0, limit - attempted));
+  return Math.min(size, Math.max(0, limit - attempted));
 };
 
 // Long backfills outlive temporary AWS credentials; refresh the shared
@@ -365,12 +395,17 @@ type IndexBackfillResult = {
 
 const backfillCaseLawIndex = async (
   limit: number | null,
+  bulk: { indexBatchSize: number | null; indexReadConcurrency: number | null },
 ): Promise<IndexBackfillResult> => {
   const generation = corpusGeneration("case_law");
   let indexed = 0;
 
   while (true) {
-    const batchSize = nextBatchSize(limit, indexed);
+    const batchSize = nextBatchSize(
+      limit,
+      indexed,
+      bulk.indexBatchSize ?? undefined,
+    );
     if (batchSize === 0) {
       break;
     }
@@ -378,7 +413,14 @@ const backfillCaseLawIndex = async (
     await refreshStaleS3();
 
     // oxlint-disable-next-line no-await-in-loop -- batches drain a queue sequentially; the next iteration only proceeds once this batch's count is known
-    const count = await backfillCorpusIndex(ingestionDb, batchSize, generation);
+    const count = await backfillCorpusIndex(
+      ingestionDb,
+      batchSize,
+      generation,
+      {
+        readConcurrency: bulk.indexReadConcurrency ?? undefined,
+      },
+    );
     if (count === 0) {
       break;
     }
@@ -468,7 +510,10 @@ export const runLegalCorpusIndexBackfill = async (
   );
 
   try {
-    const caseLaw = await backfillCaseLawIndex(parsed.options.caseLawLimit);
+    const caseLaw = await backfillCaseLawIndex(parsed.options.caseLawLimit, {
+      indexBatchSize: parsed.options.indexBatchSize,
+      indexReadConcurrency: parsed.options.indexReadConcurrency,
+    });
     const legislation = await backfillLegislationIndex(
       parsed.options.legislationLimit,
     );

--- a/apps/legal-atlas-runner/src/runners/case-law-corpus-storage-backfill.ts
+++ b/apps/legal-atlas-runner/src/runners/case-law-corpus-storage-backfill.ts
@@ -439,12 +439,17 @@ const backfillCaseLawIndex = async (
 
 const backfillLegislationIndex = async (
   limit: number | null,
+  bulk: { indexBatchSize: number | null; indexReadConcurrency: number | null },
 ): Promise<IndexBackfillResult> => {
   const generation = corpusGeneration("legislation");
   let indexed = 0;
 
   while (true) {
-    const batchSize = nextBatchSize(limit, indexed);
+    const batchSize = nextBatchSize(
+      limit,
+      indexed,
+      bulk.indexBatchSize ?? BATCH_SIZE,
+    );
     if (batchSize === 0) {
       break;
     }
@@ -456,6 +461,9 @@ const backfillLegislationIndex = async (
       ingestionDb,
       batchSize,
       generation,
+      bulk.indexReadConcurrency === null
+        ? {}
+        : { readConcurrency: bulk.indexReadConcurrency },
     );
     if (count === 0) {
       break;
@@ -521,6 +529,10 @@ export const runLegalCorpusIndexBackfill = async (
     });
     const legislation = await backfillLegislationIndex(
       parsed.options.legislationLimit,
+      {
+        indexBatchSize: parsed.options.indexBatchSize,
+        indexReadConcurrency: parsed.options.indexReadConcurrency,
+      },
     );
 
     logInfo(

--- a/apps/legal-atlas-runner/src/runners/case-law-corpus-storage-backfill.ts
+++ b/apps/legal-atlas-runner/src/runners/case-law-corpus-storage-backfill.ts
@@ -77,7 +77,12 @@ const parseLimit = (name: string, value: string | undefined): ParseResult => {
 
   return {
     ok: true,
-    options: { caseLawLimit: parsed, legislationLimit: parsed },
+    options: {
+      caseLawLimit: parsed,
+      indexBatchSize: null,
+      indexReadConcurrency: null,
+      legislationLimit: parsed,
+    },
   };
 };
 
@@ -417,9 +422,9 @@ const backfillCaseLawIndex = async (
       ingestionDb,
       batchSize,
       generation,
-      {
-        readConcurrency: bulk.indexReadConcurrency ?? undefined,
-      },
+      bulk.indexReadConcurrency === null
+        ? {}
+        : { readConcurrency: bulk.indexReadConcurrency },
     );
     if (count === 0) {
       break;


### PR DESCRIPTION
Building a fresh index generation via the backfill paid a long stale-scan on every batch: the stale predicate (hash mismatch within the current generation) has no covering index, and against a generation whose missing backlog is large — a fresh generation build being the extreme — the scan walks a huge table to return nothing, dominating the batch cost by an order of magnitude.

- The stale scan now runs only when the missing backlog stops filling its quota. Deferring re-indexes behind the missing drain is self-limiting: the drain itself empties the backlog that defers them, at which point stale selection resumes with its reserve.
- The corpus-index backfill script gains `--index-batch-size` (cap 1000) and `--index-read-concurrency` (cap 32), threaded through as explicit options; the daemon's defaults are unchanged.

Corpus-index suites pass; typecheck clean in both packages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional controls for index batch size and read concurrency when running legal corpus backfills.
  * Added validation and safe limits for the new command-line settings.

* **Performance**
  * Improved large-scale index backfills by allowing read workloads and batch sizes to be tuned.

* **Bug Fixes**
  * Improved stale-record scanning so it runs regularly, even when there is a large backlog of missing records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->