### PR TITLE
fix: exclude private workspaces from releases

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,6 +7,9 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
+  "privatePackages": {
+    "version": false
+  },
   "ignore": [
     "@stll/api",
     "@stll/boe",

--- a/scripts/check-api-cli-contract.test.ts
+++ b/scripts/check-api-cli-contract.test.ts
@@ -37,6 +37,25 @@ const expectSubset = (
 };
 
 describe("API and CLI release contract", () => {
+  test("private workspaces stay outside Changesets releases", async () => {
+    const config: unknown = await Bun.file(
+      new URL("../.changeset/config.json", import.meta.url),
+    ).json();
+
+    expect(isRecord(config)).toBe(true);
+    if (!isRecord(config)) {
+      throw new TypeError("Changesets config is not an object");
+    }
+
+    const privatePackages = config["privatePackages"];
+    expect(isRecord(privatePackages)).toBe(true);
+    if (!isRecord(privatePackages)) {
+      throw new TypeError("Changesets private package config is not an object");
+    }
+
+    expect(privatePackages["version"]).toBe(false);
+  });
+
   test("the server advertises the contract version implemented by the CLI", () => {
     expect(STELLA_MCP_API_CONTRACT_VERSION).toBe(
       CLI_SUPPORTED_API_CONTRACT_VERSION,


### PR DESCRIPTION
## Summary

- disable Changesets version and changelog updates for private workspace packages
- add a release-contract regression guard for the repository setting

Changesets documents private-package versioning as enabled by default; setting `privatePackages.version` to `false` keeps application workspaces outside package release plans while preserving normal releases for public packages: https://github.com/changesets/changesets/blob/main/docs/config-file-options.md#privatepackages-object-or-false

## Verification

- `bun run verify`
- `bun run changeset:version` against the current pending changesets with changelog rendering disabled locally: public package versions changed, while private workspace versions and changelogs remained untouched

CC on behalf of sok0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Private packages will no longer be automatically versioned during Changesets releases.

* **Tests**
  * Added validation to ensure release configuration continues to exclude private packages from versioning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->