### PR TITLE
fix(case-law): share one stored-document definition across trim, queue, and refresh

### DIFF
--- a/apps/api/src/handlers/case-law/corpus-storage.test.ts
+++ b/apps/api/src/handlers/case-law/corpus-storage.test.ts
@@ -134,10 +134,20 @@ describe("empty corpus payload hashes", () => {
    * matches nothing.
    */
   test("cover the empty shapes a metadata-first ingest writes", () => {
-    expect([...EMPTY_CORPUS_CONTENT_HASHES]).toEqual([
+    // The two shapes the pipeline itself writes stay pinned by value; the
+    // matrix additionally covers legacy column shapes the backfill copies
+    // verbatim (stored `[]` sections, a valid AST with no blocks).
+    expect(EMPTY_CORPUS_CONTENT_HASHES).toContain(
       "38c18e8567ab7eb43737fbcb0b460cc715edc003359f072526757949857ba315",
+    );
+    expect(EMPTY_CORPUS_CONTENT_HASHES).toContain(
       "c21295bcba9c492b8fa6894ee2fcd6ca93b825ea61fc4965d00f41ea611071e2",
-    ]);
+    );
+    expect(EMPTY_CORPUS_CONTENT_HASHES).toHaveLength(4);
+    expect(new Set(EMPTY_CORPUS_CONTENT_HASHES).size).toBe(4);
+    expect(EMPTY_CORPUS_CONTENT_HASHES).toContain(
+      corpusContentHash({ text: "", sections: [], ast: null }),
+    );
   });
 
   test("a payload carrying a document hashes to none of them", () => {

--- a/apps/api/src/handlers/case-law/corpus-storage.ts
+++ b/apps/api/src/handlers/case-law/corpus-storage.ts
@@ -107,14 +107,31 @@ export const corpusContentHash = ({
  *
  * Derived rather than written down, so a change to the hash function or
  * to the empty shapes cannot leave a stale constant behind. `null` and
- * `""` text hash alike (the hasher coalesces), so the two variants here
- * are the AST ones: the `EMPTY_AST` placeholder adapters use, and no AST
- * at all.
+ * `""` text hash alike (the hasher coalesces), so the variants are the
+ * cross product of the empty sections shapes (none, or a stored `[]`)
+ * with the empty AST shapes (the `EMPTY_AST` placeholder, none at all,
+ * or a structurally valid AST with no blocks) — every payload a corpus
+ * writer can produce for a row that carries no document, including
+ * legacy column shapes the backfill copies verbatim.
  */
-export const EMPTY_CORPUS_CONTENT_HASHES: readonly string[] = [
-  corpusContentHash({ text: null, sections: null, ast: EMPTY_AST }),
-  corpusContentHash({ text: null, sections: null, ast: null }),
+const EMPTY_SECTION_SHAPES: readonly (DecisionSection[] | null)[] = [null, []];
+// A full `DocumentAst` with an empty `blocks` array is NOT representable
+// here: it carries per-document `source`/`metadata`, so its hash is
+// row-specific and no constant can name it. Such a row (empty text, empty
+// blocks, populated envelope) is judged by the Postgres-side structural
+// predicate instead; the hash constants cover every payload whose empty
+// shape is content-independent.
+const EMPTY_AST_SHAPES: readonly (DocumentAst | EmptyAst | null)[] = [
+  EMPTY_AST,
+  null,
 ];
+
+export const EMPTY_CORPUS_CONTENT_HASHES: readonly string[] =
+  EMPTY_SECTION_SHAPES.flatMap((sections) =>
+    EMPTY_AST_SHAPES.map((ast) =>
+      corpusContentHash({ text: null, sections, ast }),
+    ),
+  );
 
 type WriteCorpusInput = CorpusPayload & {
   documentId: string;

--- a/apps/api/src/handlers/case-law/corpus-storage.ts
+++ b/apps/api/src/handlers/case-law/corpus-storage.ts
@@ -109,10 +109,11 @@ export const corpusContentHash = ({
  * to the empty shapes cannot leave a stale constant behind. `null` and
  * `""` text hash alike (the hasher coalesces), so the variants are the
  * cross product of the empty sections shapes (none, or a stored `[]`)
- * with the empty AST shapes (the `EMPTY_AST` placeholder, none at all,
- * or a structurally valid AST with no blocks) — every payload a corpus
- * writer can produce for a row that carries no document, including
- * legacy column shapes the backfill copies verbatim.
+ * with the constant empty AST shapes (the `EMPTY_AST` placeholder, or
+ * none at all). A structurally valid AST with no blocks is deliberately
+ * NOT here — its envelope carries per-document metadata, so its hash is
+ * row-specific and no constant can name it; those rows are recognised
+ * structurally instead (see stored-payload.ts).
  */
 const EMPTY_SECTION_SHAPES: readonly (DecisionSection[] | null)[] = [null, []];
 // A full `DocumentAst` with an empty `blocks` array is NOT representable

--- a/apps/api/src/handlers/case-law/corpus-storage.ts
+++ b/apps/api/src/handlers/case-law/corpus-storage.ts
@@ -64,7 +64,7 @@ export const corpusKeys = ({
   };
 };
 
-type CorpusPayload = {
+export type CorpusPayload = {
   text: string | null;
   sections: DecisionSection[] | null;
   ast: DocumentAst | EmptyAst | null;

--- a/apps/api/src/handlers/case-law/decisions/document-state.test.ts
+++ b/apps/api/src/handlers/case-law/decisions/document-state.test.ts
@@ -26,6 +26,7 @@ type Scenario = {
   documentUrl?: string | null;
   corpusServed?: boolean;
   contentHash?: string | null;
+  pgAstPresent?: boolean;
   resolvedFulltext?: string | null;
   readTextColumnWritten?: () => Promise<boolean | null>;
 };
@@ -36,6 +37,7 @@ const state = async (scenario: Scenario) =>
     documentUrl: "https://example.test/decision.pdf",
     corpusServed: false,
     contentHash: null,
+    pgAstPresent: false,
     resolvedFulltext: null,
     readTextColumnWritten: noColumnRead,
     ...scenario,
@@ -80,6 +82,35 @@ describe("document state", () => {
         resolvedFulltext: "",
       }),
     ).toEqual({ documentPending: false, documentUnavailable: false });
+  });
+
+  test("a surviving AST artifact marks the corpus copy as verbatim empty", async () => {
+    // The hash is this row's own, so no constant can name it — but the
+    // trim, which is what nulls the payload columns, refuses a row whose
+    // objects do not hold what the columns hold. An AST column that
+    // survived therefore means the objects mirror an empty payload, and
+    // the decision is still waiting for its document.
+    expect(
+      await state({
+        corpusServed: true,
+        contentHash: REAL_HASH,
+        pgAstPresent: true,
+        resolvedFulltext: "",
+        readTextColumnWritten: async () => await Promise.resolve(false),
+      }),
+    ).toEqual({ documentPending: true, documentUnavailable: false });
+
+    // The same row, once its document has been fetched and marked
+    // unavailable, is terminal rather than pending.
+    expect(
+      await state({
+        corpusServed: true,
+        contentHash: REAL_HASH,
+        pgAstPresent: true,
+        resolvedFulltext: "",
+        readTextColumnWritten: async () => await Promise.resolve(true),
+      }),
+    ).toEqual({ documentPending: false, documentUnavailable: true });
   });
 
   test("an empty corpus payload falls back to what the column says", async () => {

--- a/apps/api/src/handlers/case-law/decisions/document-state.test.ts
+++ b/apps/api/src/handlers/case-law/decisions/document-state.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Which of three states a decision's document is in decides whether a
+ * reader's request fetches it, reports it missing, or does nothing. The
+ * inputs come from three places that disagree about what "empty" means:
+ * a NULL text column (never fetched), an empty one (fetched, the source
+ * had nothing), and an empty corpus payload (written before the
+ * document existed), and under canonical storage the columns are empty
+ * for every decision by design.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { EMPTY_CORPUS_CONTENT_HASHES } from "@/api/handlers/case-law/corpus-storage";
+import { resolveDocumentState } from "@/api/handlers/case-law/decisions/get";
+
+const REAL_HASH = "a-real-content-hash";
+const EMPTY_HASH = EMPTY_CORPUS_CONTENT_HASHES.at(0) ?? "";
+
+/** Fails the test if the state is decided by re-reading the column. */
+const noColumnRead = async (): Promise<boolean | null> => {
+  throw new Error("the column was read where the row already answers");
+};
+
+type Scenario = {
+  hasReadableDocument?: boolean;
+  documentUrl?: string | null;
+  corpusServed?: boolean;
+  contentHash?: string | null;
+  resolvedFulltext?: string | null;
+  readTextColumnWritten?: () => Promise<boolean | null>;
+};
+
+const state = async (scenario: Scenario) =>
+  await resolveDocumentState({
+    hasReadableDocument: false,
+    documentUrl: "https://example.test/decision.pdf",
+    corpusServed: false,
+    contentHash: null,
+    resolvedFulltext: null,
+    readTextColumnWritten: noColumnRead,
+    ...scenario,
+  });
+
+describe("document state", () => {
+  test("a decision that read as a document is neither", async () => {
+    expect(await state({ hasReadableDocument: true })).toEqual({
+      documentPending: false,
+      documentUnavailable: false,
+    });
+  });
+
+  test("a decision with nothing to fetch is neither", async () => {
+    expect(await state({ documentUrl: null })).toEqual({
+      documentPending: false,
+      documentUnavailable: false,
+    });
+  });
+
+  test("served from the columns, NULL is pending and empty is terminal", async () => {
+    expect(await state({ resolvedFulltext: null })).toEqual({
+      documentPending: true,
+      documentUnavailable: false,
+    });
+    expect(await state({ resolvedFulltext: "" })).toEqual({
+      documentPending: false,
+      documentUnavailable: true,
+    });
+  });
+
+  test("a trimmed decision whose objects hold a document is neither", async () => {
+    // Canonical storage: the columns are empty by design and the hash
+    // says object storage has the document. A payload that then fails to
+    // arrive is an object-storage failure the read raises, not a
+    // document waiting to be fetched — and nothing here needs the
+    // column, so it is not read.
+    expect(
+      await state({
+        corpusServed: true,
+        contentHash: REAL_HASH,
+        resolvedFulltext: "",
+      }),
+    ).toEqual({ documentPending: false, documentUnavailable: false });
+  });
+
+  test("an empty corpus payload falls back to what the column says", async () => {
+    // Both states wrote the same empty objects, so only the row can say
+    // whether the fetch has happened.
+    expect(
+      await state({
+        corpusServed: true,
+        contentHash: EMPTY_HASH,
+        resolvedFulltext: "",
+        readTextColumnWritten: async () => await Promise.resolve(false),
+      }),
+    ).toEqual({ documentPending: true, documentUnavailable: false });
+
+    expect(
+      await state({
+        corpusServed: true,
+        contentHash: EMPTY_HASH,
+        resolvedFulltext: "",
+        readTextColumnWritten: async () => await Promise.resolve(true),
+      }),
+    ).toEqual({ documentPending: false, documentUnavailable: true });
+  });
+
+  test("a row that vanished under the read is neither", async () => {
+    expect(
+      await state({
+        corpusServed: true,
+        contentHash: EMPTY_HASH,
+        readTextColumnWritten: async () => await Promise.resolve(null),
+      }),
+    ).toEqual({ documentPending: false, documentUnavailable: false });
+  });
+});

--- a/apps/api/src/handlers/case-law/decisions/get.ts
+++ b/apps/api/src/handlers/case-law/decisions/get.ts
@@ -265,6 +265,7 @@ export const readDecisionHandler = async (
       decision.textS3Key !== null &&
       decision.contentHash !== null,
     contentHash: decision.contentHash,
+    pgAstPresent: decision.documentAst !== null,
     resolvedFulltext: fulltext,
     readTextColumnWritten: async () => {
       const [row] = await caseLawDb((tx) =>
@@ -379,6 +380,11 @@ export type ResolveDocumentStateInput = {
   /** Whether the payload above came from object storage. */
   corpusServed: boolean;
   contentHash: string | null;
+  /**
+   * Whether the row's own `document_ast` column still holds anything.
+   * A trimmed, corpus-served decision has every payload column nulled.
+   */
+  pgAstPresent: boolean;
   resolvedFulltext: string | null;
   /**
    * Reads the row's own text column as a boolean — has it ever been
@@ -407,27 +413,39 @@ type DocumentState = {
  *
  * The states this has to separate, and what each answers:
  *
- * | pg text | content hash | resolved   | state       |
- * | ------- | ------------ | ---------- | ----------- |
- * | NULL    | none         | nothing    | pending     |
- * | ''      | none         | ''         | unavailable |
- * | text    | none         | document   | served      |
- * | NULL    | empty shape  | ''         | pending     |
- * | ''      | empty shape  | ''         | unavailable |
- * | NULL    | a document   | document   | served      |
- * | text    | a document   | document   | served      |
+ * | pg text | pg ast | content hash | resolved | state       |
+ * | ------- | ------ | ------------ | -------- | ----------- |
+ * | NULL    | any    | none         | nothing  | pending     |
+ * | ''      | any    | none         | ''       | unavailable |
+ * | text    | any    | none         | document | served      |
+ * | NULL    | any    | empty shape  | ''       | pending     |
+ * | ''      | any    | empty shape  | ''       | unavailable |
+ * | NULL    | NULL   | row-specific | document | served      |
+ * | text    | any    | row-specific | document | served      |
+ * | NULL    | present| row-specific | ''       | pending     |
  *
  * The sixth row is a trimmed canonical decision: its columns are empty
  * by design and object storage holds the document, so it is neither
  * pending nor unavailable — and if its payload failed to arrive, that is
  * an object-storage failure the read raises rather than a document
  * waiting to be fetched.
+ *
+ * The last row is what separates that from a decision whose objects
+ * merely mirror an empty payload. A row-specific hash proves only that
+ * the objects are this row's, not that they hold anything: an empty
+ * DocumentAst envelope carries the decision's own metadata and hashes
+ * to a value no constant can name. The trim is what nulls the columns,
+ * and it refuses a row whose objects do not hold what the columns hold,
+ * so a surviving AST artifact means the corpus copy is verbatim empty
+ * rather than served — the same discriminator the queue's pending gate
+ * uses.
  */
 export const resolveDocumentState = async ({
   hasReadableDocument,
   documentUrl,
   corpusServed,
   contentHash,
+  pgAstPresent,
   resolvedFulltext,
   readTextColumnWritten,
 }: ResolveDocumentStateInput): Promise<DocumentState> => {
@@ -442,7 +460,7 @@ export const resolveDocumentState = async ({
     };
   }
 
-  if (corpusCarriesDocument(contentHash)) {
+  if (corpusCarriesDocument(contentHash) && !pgAstPresent) {
     return { documentPending: false, documentUnavailable: false };
   }
 

--- a/apps/api/src/handlers/case-law/decisions/get.ts
+++ b/apps/api/src/handlers/case-law/decisions/get.ts
@@ -18,6 +18,7 @@ import {
 import { hasUsableAst } from "@/api/handlers/case-law/document-ast";
 import type { EmptyAst } from "@/api/handlers/case-law/ingestion/adapter";
 import { redistributableCaseLawSource } from "@/api/handlers/case-law/redistribution";
+import { corpusCarriesDocument } from "@/api/handlers/case-law/stored-payload";
 import type { SafeId } from "@/api/lib/branded-types";
 import type { CaseLawPublicReadDb } from "@/api/lib/case-law-public-read-db";
 import { LIMITS } from "@/api/lib/limits";
@@ -263,9 +264,20 @@ export const readDecisionHandler = async (
       corpusReadEnabled() &&
       decision.textS3Key !== null &&
       decision.contentHash !== null,
+    contentHash: decision.contentHash,
     resolvedFulltext: fulltext,
-    decisionId,
-    caseLawDb,
+    readTextColumnWritten: async () => {
+      const [row] = await caseLawDb((tx) =>
+        tx
+          .select({
+            written: sql<boolean>`${caseLawDecisions.fulltext} IS NOT NULL`,
+          })
+          .from(caseLawDecisions)
+          .where(eq(caseLawDecisions.id, decisionId))
+          .limit(1),
+      );
+      return row?.written ?? null;
+    },
   });
 
   return {
@@ -360,15 +372,20 @@ const resolveAst = async ({
   });
 };
 
-type ResolveDocumentStateInput = {
+export type ResolveDocumentStateInput = {
   /** Whether the read resolved something a reader can actually read. */
   hasReadableDocument: boolean;
   documentUrl: string | null;
   /** Whether the payload above came from object storage. */
   corpusServed: boolean;
+  contentHash: string | null;
   resolvedFulltext: string | null;
-  decisionId: SafeId<"caseLawDecision">;
-  caseLawDb: CaseLawPublicReadDb;
+  /**
+   * Reads the row's own text column as a boolean — has it ever been
+   * fetched — without pulling the document across. Called only where
+   * nothing else can tell the two empty states apart.
+   */
+  readTextColumnWritten: () => Promise<boolean | null>;
 };
 
 type DocumentState = {
@@ -385,16 +402,34 @@ type DocumentState = {
  * object storage served it, it is not — a metadata-first ingest writes
  * an empty payload, and an empty payload reads back as an empty string
  * whichever of the two states wrote it — so the column is re-read as a
- * boolean, without the document itself, and only for a decision that
- * resolved to nothing at all.
+ * boolean, without the document itself, and only where the content hash
+ * says the objects are one of those empty shapes.
+ *
+ * The states this has to separate, and what each answers:
+ *
+ * | pg text | content hash | resolved   | state       |
+ * | ------- | ------------ | ---------- | ----------- |
+ * | NULL    | none         | nothing    | pending     |
+ * | ''      | none         | ''         | unavailable |
+ * | text    | none         | document   | served      |
+ * | NULL    | empty shape  | ''         | pending     |
+ * | ''      | empty shape  | ''         | unavailable |
+ * | NULL    | a document   | document   | served      |
+ * | text    | a document   | document   | served      |
+ *
+ * The sixth row is a trimmed canonical decision: its columns are empty
+ * by design and object storage holds the document, so it is neither
+ * pending nor unavailable — and if its payload failed to arrive, that is
+ * an object-storage failure the read raises rather than a document
+ * waiting to be fetched.
  */
-const resolveDocumentState = async ({
+export const resolveDocumentState = async ({
   hasReadableDocument,
   documentUrl,
   corpusServed,
+  contentHash,
   resolvedFulltext,
-  decisionId,
-  caseLawDb,
+  readTextColumnWritten,
 }: ResolveDocumentStateInput): Promise<DocumentState> => {
   if (hasReadableDocument || documentUrl === null) {
     return { documentPending: false, documentUnavailable: false };
@@ -407,19 +442,15 @@ const resolveDocumentState = async ({
     };
   }
 
-  const [row] = await caseLawDb((tx) =>
-    tx
-      .select({
-        fetched: sql<boolean>`${caseLawDecisions.fulltext} IS NOT NULL`,
-      })
-      .from(caseLawDecisions)
-      .where(eq(caseLawDecisions.id, decisionId))
-      .limit(1),
-  );
+  if (corpusCarriesDocument(contentHash)) {
+    return { documentPending: false, documentUnavailable: false };
+  }
+
+  const written = await readTextColumnWritten();
 
   return {
-    documentPending: row?.fetched === false,
-    documentUnavailable: row?.fetched === true,
+    documentPending: written === false,
+    documentUnavailable: written === true,
   };
 };
 

--- a/apps/api/src/handlers/case-law/ingestion/pipeline-refresh.db.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/pipeline-refresh.db.test.ts
@@ -16,7 +16,7 @@
  */
 
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
-import { inArray } from "drizzle-orm";
+import { eq, inArray } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/bun-sql";
 
 import { authRelationsPart } from "@/api/db/auth-schema";
@@ -120,6 +120,28 @@ if (!databaseUrl || !runPostgresTests) {
       return row.id;
     };
 
+    /** A decision the queue has not reached: metadata, and no document. */
+    const insertEmptyDecision = async (caseNumber: string) => {
+      const [row] = await db
+        .insert(caseLawDecisions)
+        .values({
+          sourceId,
+          caseNumber,
+          court: "Okresný súd",
+          country: "SVK",
+          language: "sk",
+          documentUrl: "https://example.test/refresh.pdf",
+          metadata: { judge: "Old Judge" },
+          sourceHash: "hash-before",
+        })
+        .returning({ id: caseLawDecisions.id });
+      if (!row) {
+        throw new Error("expected decision row");
+      }
+      created.push(row.id);
+      return row.id;
+    };
+
     /** What the adapter returns for a decision it has no document for. */
     const metadataOnlyResult = (caseNumber: string): IngestionResult => ({
       caseNumber,
@@ -213,6 +235,55 @@ if (!databaseUrl || !runPostgresTests) {
       // The metadata this refresh actually carried did land.
       expect(row?.metadata).toMatchObject({ judge: "New Judge" });
       expect(row?.decisionType).toBe("rozsudok");
+      expect(row?.sourceHash).toBe("hash-after");
+    });
+
+    test("a document landing mid-refresh is not overwritten by the refresh", async () => {
+      // The window the guard closes: the refresh reads a decision with
+      // no document, a backfill commits one while it is deciding, and
+      // the write that follows would put the empty payload over it. The
+      // condition rides in the payload write's WHERE, so the row that
+      // acquired a document simply falls out of scope.
+      const caseNumber = `refresh-race-${suffix}`;
+      const id = await insertEmptyDecision(caseNumber);
+
+      let transactions = 0;
+      const racingDb: ScopedDb = async (callback) => {
+        transactions += 1;
+        // Transactions in order: the decision lookup, the check for a
+        // stored document, then the row write. Injecting as the third
+        // opens exactly the window the guard closes — the check has
+        // already answered "no document", and the write is next.
+        if (transactions === 3) {
+          await db
+            .update(caseLawDecisions)
+            .set({
+              fulltext: STORED_TEXT,
+              documentAst: storedAst,
+              sections: [
+                { index: 0, type: "header", title: null, text: "Rozsudok" },
+              ],
+            })
+            .where(eq(caseLawDecisions.id, id));
+        }
+        return await scopedDb(callback);
+      };
+
+      await processDecision(metadataOnlyResult(caseNumber), sourceId, racingDb);
+
+      // If the sequence ever changes, the injection no longer lands in
+      // the window and this test would pass without exercising it.
+      expect(transactions).toBe(3);
+
+      const row = await readDecision(id);
+      expect(row?.fulltext).toBe(STORED_TEXT);
+      expect(
+        row?.documentAst && "blocks" in row.documentAst
+          ? row.documentAst.blocks.length
+          : 0,
+      ).toBe(1);
+      // The metadata this refresh carried is unconditional and lands.
+      expect(row?.metadata).toMatchObject({ judge: "New Judge" });
       expect(row?.sourceHash).toBe("hash-after");
     });
 

--- a/apps/api/src/handlers/case-law/ingestion/pipeline.ts
+++ b/apps/api/src/handlers/case-law/ingestion/pipeline.ts
@@ -1,5 +1,5 @@
 import { Result, panic } from "better-result";
-import { and, eq, sql } from "drizzle-orm";
+import { and, eq, notInArray, sql } from "drizzle-orm";
 
 import { collapseSpacedLetters } from "@stll/text-normalize";
 
@@ -47,6 +47,7 @@ import {
   stripDangerousChars,
 } from "@/api/handlers/case-law/ingestion/sanitize";
 import { segmentDecision } from "@/api/handlers/case-law/ingestion/segmenter";
+import { pgPayloadCarriesDocument } from "@/api/handlers/case-law/stored-payload";
 import type { DecisionSection } from "@/api/handlers/case-law/types";
 import { captureError } from "@/api/lib/analytics/capture";
 import type { SafeId } from "@/api/lib/branded-types";
@@ -385,14 +386,28 @@ const discardPartialCorpusWrite = async (
 };
 
 /**
- * Whether this decision already holds a document.
+ * SQL for "this row holds a document", in the columns or in the corpus
+ * objects its hash names. The row write below carries this in its WHERE,
+ * where it is evaluated with the write and cannot go stale.
+ */
+const rowHoldsDocument = sql<boolean>`(
+  ${pgPayloadCarriesDocument}
+  or (
+    ${caseLawDecisions.contentHash} is not null
+    and ${notInArray(caseLawDecisions.contentHash, [...EMPTY_CORPUS_CONTENT_HASHES])}
+  )
+)`;
+
+/**
+ * The same question, asked ahead of the write. Answered as a boolean
+ * rather than by pulling the payload across: the text can be megabytes
+ * and this runs inside the crawl.
  *
- * Asked only when the incoming result carries none, and answered as
- * booleans rather than by pulling the payload across: the text can be
- * megabytes and this runs inside the crawl. Three places can hold it —
- * the text column, the AST column, and, for a row whose canonical
- * payload lives in object storage, a content hash that is not one of
- * the empty-payload hashes.
+ * This answer is advisory: it decides whether to spend a corpus write
+ * and whether to report an empty decision, neither of which can be made
+ * conditional inside the row update. The guarantee that a document is
+ * not overwritten lives in that update's WHERE clause, so a backfill
+ * committing between this read and the write loses nothing.
  */
 const hasStoredDocument = async (
   decisionId: SafeId<"caseLawDecision">,
@@ -400,26 +415,13 @@ const hasStoredDocument = async (
 ): Promise<boolean> => {
   const [row] = await scopedDb((tx) =>
     tx
-      .select({
-        hasText: sql<boolean>`coalesce(${caseLawDecisions.fulltext}, '') <> ''`,
-        hasAst: sql<boolean>`coalesce(jsonb_array_length(case when jsonb_typeof(${caseLawDecisions.documentAst} -> 'blocks') = 'array' then ${caseLawDecisions.documentAst} -> 'blocks' else '[]'::jsonb end), 0) > 0`,
-        contentHash: caseLawDecisions.contentHash,
-      })
+      .select({ holdsDocument: rowHoldsDocument })
       .from(caseLawDecisions)
       .where(eq(caseLawDecisions.id, decisionId))
       .limit(1),
   );
 
-  if (!row) {
-    return false;
-  }
-
-  return (
-    row.hasText ||
-    row.hasAst ||
-    (row.contentHash !== null &&
-      !EMPTY_CORPUS_CONTENT_HASHES.includes(row.contentHash))
-  );
+  return row?.holdsDocument === true;
 };
 
 const planCorpusWrite = async ({
@@ -615,9 +617,12 @@ export const processDecision = async (
   // carries may replace one: the metadata is updated and the payload,
   // its object-storage pointers and the citations drawn from it are left
   // as they are.
+  const incomingCarriesDocument = Boolean(
+    result.fulltext || hasUsableAst(result.documentAst),
+  );
   const preserveStoredDocument =
     existing !== undefined &&
-    !(result.fulltext || hasUsableAst(result.documentAst)) &&
+    !incomingCarriesDocument &&
     (await hasStoredDocument(existing.id, scopedDb));
 
   // Parsers report their own quality through `validateAndLog`, but a
@@ -736,6 +741,18 @@ export const processDecision = async (
     await scopedDb(async (tx) => {
       // audit: skip — background case-law ingestion pipeline; public case-law data, not user actions
       if (existing) {
+        // A refresh with no document of its own may not overwrite one,
+        // and whether the row has one can change between the check above
+        // and this write. So the payload columns move to their own
+        // statement, carrying the condition in the WHERE where it is
+        // evaluated with the write: a backfill that commits in between
+        // takes the update out of scope instead of losing to it. The
+        // metadata is unconditional either way, so a refresh that
+        // declines to touch the payload still lands and still advances
+        // the source hash.
+        const payloadNeedsGuard =
+          !incomingCarriesDocument && Object.keys(payloadColumns).length > 0;
+
         await tx
           .update(caseLawDecisions)
           .set({
@@ -746,7 +763,7 @@ export const processDecision = async (
             languageGroupKey,
             decisionDate: result.decisionDate,
             decisionType: result.decisionType,
-            ...payloadColumns,
+            ...(payloadNeedsGuard ? {} : payloadColumns),
             sourceUrl: result.sourceUrl,
             documentUrl: result.documentUrl,
             metadata: result.metadata,
@@ -766,9 +783,21 @@ export const processDecision = async (
           })
           .where(eq(caseLawDecisions.id, existing.id));
 
+        if (payloadNeedsGuard) {
+          await tx
+            .update(caseLawDecisions)
+            .set(payloadColumns)
+            .where(
+              and(
+                eq(caseLawDecisions.id, existing.id),
+                sql`not ${rowHoldsDocument}`,
+              ),
+            );
+        }
+
         // Citations are read out of the document, so a refresh that
         // carries no document has nothing to say about them either.
-        if (preserveStoredDocument) {
+        if (!incomingCarriesDocument) {
           return;
         }
 

--- a/apps/api/src/handlers/case-law/ingestion/pipeline.ts
+++ b/apps/api/src/handlers/case-law/ingestion/pipeline.ts
@@ -934,6 +934,14 @@ export const processDecision = async (
             and(
               eq(caseLawDecisions.id, decisionId),
               sql`${caseLawDecisions.sourceHash} IS NOT DISTINCT FROM ${persistedSourceHash}`,
+              // An empty mirror must not re-point the keys over a row that
+              // gained a document between the stored-document check and this
+              // update: hydration does not advance the source hash, so the
+              // CAS above cannot see it. A mirror that carries the document
+              // is exempt — it is the newer payload by definition.
+              incomingCarriesDocument
+                ? undefined
+                : sql`NOT ${pgPayloadCarriesDocument}`,
             ),
           );
       });

--- a/apps/api/src/handlers/case-law/ingestion/sk-document-backfill.db.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/sk-document-backfill.db.test.ts
@@ -16,6 +16,7 @@ import { authRelationsPart } from "@/api/db/auth-schema";
 import type { ScopedDb } from "@/api/db/safe-db";
 import { caseLawDecisions, caseLawSources, relations } from "@/api/db/schema";
 import { ADAPTER_KEYS, PARSER_VERSION } from "@/api/handlers/case-law/consts";
+import { EMPTY_CORPUS_CONTENT_HASHES } from "@/api/handlers/case-law/corpus-storage";
 import type { DocumentAst } from "@/api/handlers/case-law/document-ast";
 import {
   claimDocumentFetch,
@@ -125,6 +126,8 @@ if (!databaseUrl || !runPostgresTests) {
       documentFetchRequestedAt?: Date;
       documentFetchAttemptedAt?: Date;
       documentFetchAttempts?: number;
+      sourceHash?: string;
+      contentHash?: string;
     }) => {
       const [row] = await db
         .insert(caseLawDecisions)
@@ -140,6 +143,8 @@ if (!databaseUrl || !runPostgresTests) {
           documentFetchRequestedAt: values.documentFetchRequestedAt,
           documentFetchAttemptedAt: values.documentFetchAttemptedAt,
           documentFetchAttempts: values.documentFetchAttempts,
+          sourceHash: values.sourceHash,
+          contentHash: values.contentHash,
         })
         .returning({ id: caseLawDecisions.id });
       if (!row) {
@@ -376,8 +381,8 @@ if (!databaseUrl || !runPostgresTests) {
 
       // A reader on one replica and the scheduler on another reach the
       // same decision: exactly one may fetch it.
-      expect(await claimDocumentFetch(id, scopedDb)).toBe(true);
-      expect(await claimDocumentFetch(id, scopedDb)).toBe(false);
+      expect((await claimDocumentFetch(id, scopedDb)).status).toBe("claimed");
+      expect((await claimDocumentFetch(id, scopedDb)).status).toBe("held");
 
       const afterClaims = await readFetchState(id);
       expect(afterClaims?.documentFetchAttempts).toBe(1);
@@ -393,7 +398,7 @@ if (!databaseUrl || !runPostgresTests) {
         documentFetchAttempts: 1,
       });
 
-      expect(await claimDocumentFetch(id, scopedDb)).toBe(true);
+      expect((await claimDocumentFetch(id, scopedDb)).status).toBe("claimed");
       expect((await readFetchState(id))?.documentFetchAttempts).toBe(2);
     });
 
@@ -404,7 +409,101 @@ if (!databaseUrl || !runPostgresTests) {
         documentUrl: "https://example.test/claim-filled.pdf",
       });
 
-      expect(await claimDocumentFetch(id, scopedDb)).toBe(false);
+      expect((await claimDocumentFetch(id, scopedDb)).status).toBe("held");
+    });
+
+    test("a trimmed decision is not queued for a fetch it already had", async () => {
+      // Canonical storage plus the column trim: the text column is NULL
+      // by design and object storage holds the document. Reading NULL as
+      // "never fetched" would put the whole drained corpus back in the
+      // queue.
+      const trimmed = await insertDecision({
+        caseNumber: `trimmed-${suffix}`,
+        fulltext: null,
+        documentUrl: "https://example.test/trimmed.pdf",
+        contentHash: "a-real-content-hash",
+      });
+      // Written before its document existed: the objects are the empty
+      // shapes, so this one is still waiting.
+      const emptyObjects = await insertDecision({
+        caseNumber: `empty-objects-${suffix}`,
+        fulltext: null,
+        documentUrl: "https://example.test/empty-objects.pdf",
+        contentHash: EMPTY_CORPUS_CONTENT_HASHES.at(0) ?? "",
+      });
+
+      const queue = await loadPendingDocuments(scopedDb, QUEUE_READ_LIMIT);
+
+      expect(onlyThese(queue, [trimmed, emptyObjects])).toEqual([emptyObjects]);
+    });
+
+    test("the store applies only while the claimed source hash holds", async () => {
+      const id = await insertDecision({
+        caseNumber: `pin-${suffix}`,
+        fulltext: null,
+        documentUrl: "https://example.test/pin.pdf",
+        sourceHash: "hash-at-claim",
+      });
+      const document = {
+        fulltext: "Rozsudok\n\nOdôvodnenie:\n\nText.",
+        documentAst: parsedAst,
+        sections: [],
+      };
+
+      // The source refreshed the decision while the document was being
+      // fetched, so what was parsed describes a row that no longer
+      // exists in that form.
+      await db
+        .update(caseLawDecisions)
+        .set({ sourceHash: "hash-after-refresh" })
+        .where(eq(caseLawDecisions.id, id));
+
+      await storeBackfilledDocument({
+        decision: pendingFor(id),
+        document,
+        scopedDb,
+        claimedSourceHash: "hash-at-claim",
+      });
+
+      expect(
+        (
+          await db.query.caseLawDecisions.findFirst({
+            where: { id: { eq: id } },
+            columns: { fulltext: true },
+          })
+        )?.fulltext,
+      ).toBeNull();
+
+      // Fetched again against the row as it now stands, the same
+      // document stores.
+      await storeBackfilledDocument({
+        decision: pendingFor(id),
+        document,
+        scopedDb,
+        claimedSourceHash: "hash-after-refresh",
+      });
+
+      expect(
+        (
+          await db.query.caseLawDecisions.findFirst({
+            where: { id: { eq: id } },
+            columns: { fulltext: true },
+          })
+        )?.fulltext,
+      ).toContain("Odôvodnenie");
+    });
+
+    test("the claim carries the source hash the store has to pin", async () => {
+      const id = await insertDecision({
+        caseNumber: `claim-hash-${suffix}`,
+        fulltext: null,
+        documentUrl: "https://example.test/claim-hash.pdf",
+        sourceHash: "hash-at-claim",
+      });
+
+      const claim = await claimDocumentFetch(id, scopedDb);
+
+      expect(claim).toEqual({ status: "claimed", sourceHash: "hash-at-claim" });
     });
 
     test("a run just attempted is left alone until its cooldown passes", async () => {

--- a/apps/api/src/handlers/case-law/ingestion/sk-document-backfill.ts
+++ b/apps/api/src/handlers/case-law/ingestion/sk-document-backfill.ts
@@ -224,6 +224,12 @@ export const pendingDocumentPredicate = and(
   or(
     isNull(caseLawDecisions.contentHash),
     inArray(caseLawDecisions.contentHash, [...EMPTY_CORPUS_CONTENT_HASHES]),
+    // A row whose corpus hash is row-specific but whose Postgres AST
+    // column is still present is a legacy empty-envelope copy, not a
+    // corpus-served document: a trimmed (corpus-served) row has had every
+    // payload column nulled, so a surviving AST artifact marks the corpus
+    // object as a verbatim copy of a payload that carries no document.
+    isNotNull(caseLawDecisions.documentAst),
   ),
 );
 
@@ -504,7 +510,7 @@ export const storeBackfilledDocument = async ({
   scopedDb,
   writeCorpus = corpusDocumentWriter(),
   claimedSourceHash,
-}: StoreBackfilledDocumentOptions): Promise<void> => {
+}: StoreBackfilledDocumentOptions): Promise<"stored" | "superseded"> => {
   const sections = document.sections.length > 0 ? document.sections : null;
   const corpus =
     writeCorpus === null
@@ -517,9 +523,9 @@ export const storeBackfilledDocument = async ({
           ast: document.documentAst,
         });
 
-  await scopedDb(async (tx) => {
+  const stored = await scopedDb(async (tx) => {
     // audit: skip — scheduler backfill of public case-law text; no user action
-    await tx
+    const applied = await tx
       .update(caseLawDecisions)
       .set({
         fulltext: document.fulltext,
@@ -543,10 +549,17 @@ export const storeBackfilledDocument = async ({
             ? undefined
             : sql`${caseLawDecisions.sourceHash} IS NOT DISTINCT FROM ${claimedSourceHash}`,
         ),
-      );
+      )
+      .returning({ id: caseLawDecisions.id });
+    return applied.length > 0;
   });
 
   await indexDecision(decision.id, scopedDb);
+  // A missed compare-and-set is a superseded store, not a stored document:
+  // the source moved while this fetch was in flight, and the queue's next
+  // pass fetches the current version. Reporting it as stored would count a
+  // document that is not there.
+  return stored ? "stored" : "superseded";
 };
 
 /**
@@ -687,7 +700,9 @@ export const markDocumentUnavailable = async (
 export type DecisionDocumentOutcome =
   | { status: "filled"; document: BackfilledDocument }
   | { status: "unavailable" }
-  | { status: "claimed" };
+  | { status: "claimed" }
+  /** The source moved mid-fetch; the queue's next pass fetches the current version. */
+  | { status: "superseded" };
 
 /**
  * Wall-clock budget for the whole unit. The download has its own
@@ -727,12 +742,15 @@ const runDecisionDocumentFetch = async ({
     return { status: "unavailable" };
   }
 
-  await storeBackfilledDocument({
+  const stored = await storeBackfilledDocument({
     decision,
     document,
     scopedDb,
     claimedSourceHash: claim.sourceHash,
   });
+  if (stored === "superseded") {
+    return { status: "superseded" };
+  }
   return { status: "filled", document };
 };
 

--- a/apps/api/src/handlers/case-law/ingestion/sk-document-backfill.ts
+++ b/apps/api/src/handlers/case-law/ingestion/sk-document-backfill.ts
@@ -27,6 +27,7 @@ import {
   eq,
   gt,
   gte,
+  inArray,
   isNotNull,
   isNull,
   lt,
@@ -38,7 +39,10 @@ import type { ScopedDb } from "@/api/db/safe-db";
 import { caseLawDecisions } from "@/api/db/schema";
 import { corpusStorageMode } from "@/api/env-base";
 import { ADAPTER_KEYS, PARSER_VERSION } from "@/api/handlers/case-law/consts";
-import { writeCorpusDocument } from "@/api/handlers/case-law/corpus-storage";
+import {
+  EMPTY_CORPUS_CONTENT_HASHES,
+  writeCorpusDocument,
+} from "@/api/handlers/case-law/corpus-storage";
 import {
   type DocumentAst,
   isDocumentAst,
@@ -193,13 +197,34 @@ const outsideFetchCooldown = or(
 );
 
 /**
- * A decision whose document has not been fetched yet: no text, and
- * something to fetch. An empty string is the "tried and got nothing"
- * marker and is deliberately not NULL, so it leaves the queue.
+ * A decision whose document has not been fetched yet: nothing readable
+ * anywhere, and something to fetch. An empty string is the "tried and
+ * got nothing" marker and is deliberately not NULL, so it leaves the
+ * queue.
+ *
+ * A NULL text column is not enough on its own. Under canonical storage
+ * the payload lives in object storage and the column trim nulls the
+ * columns by design, so every drained decision would read as pending
+ * again and the queue would re-fetch the whole corpus forever. The
+ * content hash is what distinguishes the two: absent (nothing was ever
+ * written to object storage) or one of the empty shapes (written before
+ * the document existed) means there is still nothing to read.
+ *
+ * The hash test is a residual filter: the partial indexes behind the two
+ * tiers are predicated on the text column and the document URL only,
+ * because an index predicate would have to spell the hashes out as
+ * literals and could then drift from these. Under the deployed storage
+ * mode nothing carries a hash, so the filter costs nothing; a canonical
+ * cutover should revisit it, since a fully drained corpus would leave
+ * the scan walking trimmed rows to conclude the queue is empty.
  */
 export const pendingDocumentPredicate = and(
   isNull(caseLawDecisions.fulltext),
   isNotNull(caseLawDecisions.documentUrl),
+  or(
+    isNull(caseLawDecisions.contentHash),
+    inArray(caseLawDecisions.contentHash, [...EMPTY_CORPUS_CONTENT_HASHES]),
+  ),
 );
 
 /** Pending, asked for by a reader, and still within its retry budget. */
@@ -436,6 +461,14 @@ export type StoreBackfilledDocumentOptions = {
    * first. Production passes nothing.
    */
   writeCorpus?: typeof writeCorpusDocument | null;
+  /**
+   * The row's source hash when the fetch was claimed. The store applies
+   * only while it still holds: a source refresh that lands mid-fetch has
+   * rewritten the decision this document was parsed for, so the document
+   * is dropped and the queue fetches it again against the new state.
+   * Omitted by callers with no claim of their own (the repair scripts).
+   */
+  claimedSourceHash?: string | null;
 };
 
 /**
@@ -470,6 +503,7 @@ export const storeBackfilledDocument = async ({
   document,
   scopedDb,
   writeCorpus = corpusDocumentWriter(),
+  claimedSourceHash,
 }: StoreBackfilledDocumentOptions): Promise<void> => {
   const sections = document.sections.length > 0 ? document.sections : null;
   const corpus =
@@ -505,6 +539,9 @@ export const storeBackfilledDocument = async ({
         and(
           eq(caseLawDecisions.id, decision.id),
           sql`coalesce(${caseLawDecisions.fulltext}, '') = ''`,
+          claimedSourceHash === undefined
+            ? undefined
+            : sql`${caseLawDecisions.sourceHash} IS NOT DISTINCT FROM ${claimedSourceHash}`,
         ),
       );
   });
@@ -556,10 +593,20 @@ const CLAIM_TTL_SECONDS = 120;
  * Claiming also counts the attempt, before the attempt is made, so a
  * worker that dies mid-download still leaves a record of having tried.
  */
+/**
+ * A won claim, carrying the source hash the row had when it was won.
+ * The store pins that hash, so a source refresh landing mid-fetch takes
+ * the store out of scope rather than being overwritten by a document
+ * parsed from what the source used to say.
+ */
+export type DocumentFetchClaim =
+  | { status: "claimed"; sourceHash: string | null }
+  | { status: "held" };
+
 export const claimDocumentFetch = async (
   decisionId: SafeId<"caseLawDecision">,
   scopedDb: ScopedDb,
-): Promise<boolean> =>
+): Promise<DocumentFetchClaim> =>
   await scopedDb(async (tx) => {
     const lockResult: unknown = await tx.execute(
       sql`SELECT pg_try_advisory_xact_lock(hashtext('case_law'), hashtext(${decisionId})) AS locked`,
@@ -568,7 +615,7 @@ export const claimDocumentFetch = async (
       ? lockResult.at(0)
       : undefined;
     if (!isRecord(lockRow) || lockRow["locked"] !== true) {
-      return false;
+      return { status: "held" };
     }
 
     // Raw statement rather than the query builder: the claim has to
@@ -588,10 +635,21 @@ export const claimDocumentFetch = async (
           OR document_fetch_attempted_at
              < now() - ${`${CLAIM_TTL_SECONDS} seconds`}::interval
         )
-      RETURNING id
+      RETURNING source_hash AS "sourceHash"
     `);
 
-    return Array.isArray(claimed) && claimed.length > 0;
+    const claimedRow: unknown = Array.isArray(claimed)
+      ? claimed.at(0)
+      : undefined;
+    if (!isRecord(claimedRow)) {
+      return { status: "held" };
+    }
+
+    const sourceHash = claimedRow["sourceHash"];
+    return {
+      status: "claimed",
+      sourceHash: typeof sourceHash === "string" ? sourceHash : null,
+    };
   });
 
 /**
@@ -652,7 +710,8 @@ const runDecisionDocumentFetch = async ({
   scopedDb,
   signal,
 }: FetchDecisionDocumentOptions): Promise<DecisionDocumentOutcome> => {
-  if (!(await claimDocumentFetch(decision.id, scopedDb))) {
+  const claim = await claimDocumentFetch(decision.id, scopedDb);
+  if (claim.status === "held") {
     return { status: "claimed" };
   }
 
@@ -668,7 +727,12 @@ const runDecisionDocumentFetch = async ({
     return { status: "unavailable" };
   }
 
-  await storeBackfilledDocument({ decision, document, scopedDb });
+  await storeBackfilledDocument({
+    decision,
+    document,
+    scopedDb,
+    claimedSourceHash: claim.sourceHash,
+  });
   return { status: "filled", document };
 };
 

--- a/apps/api/src/handlers/case-law/stored-payload.ts
+++ b/apps/api/src/handlers/case-law/stored-payload.ts
@@ -1,0 +1,54 @@
+/**
+ * One definition of "this decision holds a document", shared by
+ * everything that has to decide whether a payload is safe to overwrite,
+ * safe to drop, or still worth fetching.
+ *
+ * The question is asked in three places that must agree — the ingestion
+ * refresh, the deferred-document queue, and the column trim — and each
+ * of them destroys or re-fetches a document when it gets the answer
+ * wrong. It is answered without reading the payload: the text can be
+ * megabytes, and two of the three callers ask it inside a loop.
+ */
+
+import { sql } from "drizzle-orm";
+import type { SQL } from "drizzle-orm";
+
+import { caseLawDecisions } from "@/api/db/schema";
+import { EMPTY_CORPUS_CONTENT_HASHES } from "@/api/handlers/case-law/corpus-storage";
+
+/**
+ * A jsonb array's length, or 0 for anything that is not an array.
+ * `jsonb_array_length` raises on a non-array, and these columns hold
+ * `{}` (the empty-AST placeholder) as often as they hold a document.
+ */
+const jsonbArrayLength = (column: SQL | typeof caseLawDecisions.sections) =>
+  sql`coalesce(jsonb_array_length(case when jsonb_typeof(${column}) = 'array' then ${column} else '[]'::jsonb end), 0)`;
+
+/**
+ * Whether the row's own Postgres columns hold a document.
+ *
+ * An empty string is the "fetched, and the source had nothing" marker
+ * rather than a document, and `{}` is the placeholder an adapter without
+ * a parser emits, so neither counts.
+ */
+export const pgPayloadCarriesDocument: SQL<boolean> = sql<boolean>`(
+  coalesce(${caseLawDecisions.fulltext}, '') <> ''
+  or ${jsonbArrayLength(sql`${caseLawDecisions.documentAst} -> 'blocks'`)} > 0
+  or ${jsonbArrayLength(caseLawDecisions.sections)} > 0
+)`;
+
+/**
+ * Whether a content hash names the payload a metadata-first ingest
+ * writes before the document exists. Such objects are present, keyed and
+ * readable, and hold nothing — so their existence proves only that the
+ * corpus was written to, never that it holds a document.
+ */
+export const namesEmptyCorpusPayload = (contentHash: string | null): boolean =>
+  contentHash !== null && EMPTY_CORPUS_CONTENT_HASHES.includes(contentHash);
+
+/**
+ * Whether object storage holds a document for this row: it has been
+ * written to, and what it holds is not one of the empty shapes.
+ */
+export const corpusCarriesDocument = (contentHash: string | null): boolean =>
+  contentHash !== null && !namesEmptyCorpusPayload(contentHash);

--- a/apps/api/src/handlers/case-law/stored-payload.ts
+++ b/apps/api/src/handlers/case-law/stored-payload.ts
@@ -14,7 +14,9 @@ import { sql } from "drizzle-orm";
 import type { SQL } from "drizzle-orm";
 
 import { caseLawDecisions } from "@/api/db/schema";
+import type { CorpusPayload } from "@/api/handlers/case-law/corpus-storage";
 import { EMPTY_CORPUS_CONTENT_HASHES } from "@/api/handlers/case-law/corpus-storage";
+import { hasUsableAst } from "@/api/handlers/case-law/document-ast";
 
 /**
  * A jsonb array's length, or 0 for anything that is not an array.
@@ -36,6 +38,19 @@ export const pgPayloadCarriesDocument: SQL<boolean> = sql<boolean>`(
   or ${jsonbArrayLength(sql`${caseLawDecisions.documentAst} -> 'blocks'`)} > 0
   or ${jsonbArrayLength(caseLawDecisions.sections)} > 0
 )`;
+
+/**
+ * The same question as `pgPayloadCarriesDocument`, asked of a payload
+ * already in hand rather than of a row. The two must agree: this one
+ * judges what the trim is about to delete, that one filters rows the
+ * trim and the ingestion refresh never load.
+ */
+export const payloadCarriesDocument = ({
+  text,
+  sections,
+  ast,
+}: CorpusPayload): boolean =>
+  (text ?? "") !== "" || hasUsableAst(ast) || (sections?.length ?? 0) > 0;
 
 /**
  * Whether a content hash names the payload a metadata-first ingest

--- a/apps/api/src/lib/scheduler/tasks/case-law-sk-documents.ts
+++ b/apps/api/src/lib/scheduler/tasks/case-law-sk-documents.ts
@@ -50,9 +50,10 @@ const processPending = async (
 ): Promise<DecisionDocumentOutcome["status"]> => {
   const outcome = await fetchDecisionDocument({ decision, scopedDb, signal });
 
-  if (outcome.status === "filled") {
+  if (outcome.status === "filled" || outcome.status === "superseded") {
     // Pace the next download; the court's site is the reason these
-    // fetches were taken off the crawl.
+    // fetches were taken off the crawl. A superseded store consumed a
+    // download just the same.
     await Bun.sleep(FETCH_DELAY_MS);
   }
 
@@ -74,7 +75,13 @@ export const backfillSkDocuments: SchedulerTask = async ({
   // `claimed` is a decision another worker — a second scheduler run, or
   // a reader on any replica — is already fetching, so this run moves on
   // without downloading it again.
-  const counts = { filled: 0, unavailable: 0, claimed: 0, failed: 0 };
+  const counts = {
+    filled: 0,
+    unavailable: 0,
+    claimed: 0,
+    superseded: 0,
+    failed: 0,
+  };
 
   for (const decision of pending) {
     if (signal.aborted) {

--- a/apps/api/src/scripts/corpus-column-trim-plan.test.ts
+++ b/apps/api/src/scripts/corpus-column-trim-plan.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "bun:test";
 
-import { EMPTY_CORPUS_CONTENT_HASHES } from "@/api/handlers/case-law/corpus-storage";
+import type { DocumentAst } from "@stll/legal-ast/document-ast";
+
+import type { CorpusPayload } from "@/api/handlers/case-law/corpus-storage";
 import {
   columnTrimGate,
   corpusObjectState,
@@ -8,11 +10,44 @@ import {
   planColumnTrim,
 } from "@/api/scripts/corpus-column-trim-plan";
 
-/** A row whose objects hold the document they are supposed to hold. */
-const populated = {
-  contentHash: "real-content-hash",
-  columns: "document",
-} as const;
+const documentAst = (blocks: DocumentAst["blocks"]): DocumentAst => ({
+  version: 1,
+  source: {
+    system: "obcan.justice.sk",
+    documentId: "trim",
+    webUrl: "https://example.test/web",
+    printUrl: "",
+  },
+  metadata: {
+    caseNumber: "1T/3/2026",
+    ecli: null,
+    court: "Okresný súd",
+    decisionDate: null,
+    decisionType: null,
+    keywords: [],
+    statutes: [],
+  },
+  blocks,
+});
+
+/** What a hydrated decision's Postgres columns hold. */
+const storedDocument: CorpusPayload = {
+  text: "Rozsudok\n\nOdôvodnenie:\n\nText.",
+  sections: [{ index: 0, type: "header", title: null, text: "Rozsudok" }],
+  ast: documentAst([
+    {
+      id: "b1",
+      anchorId: "h-1",
+      type: "heading",
+      level: 1,
+      plainText: "Rozsudok",
+      inlines: [{ type: "text", text: "Rozsudok" }],
+    },
+  ]),
+};
+
+/** A row whose objects hold exactly what its columns hold. */
+const mirrored = { columnPayload: storedDocument } as const;
 
 describe("corpusObjectState", () => {
   test("a recorded key is only verified once the object is found", () => {
@@ -25,13 +60,22 @@ describe("corpusObjectState", () => {
   test("a missing key is never verified, whatever the bucket says", () => {
     expect(corpusObjectState({ key: null, exists: true })).toBe("key-missing");
   });
+
+  test("a present object holding something else is not verified", () => {
+    expect(
+      corpusObjectState({ key: "k", exists: true, matchesColumn: false }),
+    ).toBe("content-mismatch");
+    expect(
+      corpusObjectState({ key: "k", exists: true, matchesColumn: true }),
+    ).toBe("verified");
+  });
 });
 
 describe("planColumnTrim", () => {
   test("trims only when all three objects are verified", () => {
     expect(
       planColumnTrim({
-        ...populated,
+        ...mirrored,
         text: "verified",
         sections: "verified",
         ast: "verified",
@@ -48,61 +92,73 @@ describe("planColumnTrim", () => {
       ["verified", "verified", "key-missing"],
       ["key-missing", "key-missing", "key-missing"],
     ] as const) {
-      expect(planColumnTrim({ ...populated, text, sections, ast }).type).toBe(
+      expect(planColumnTrim({ ...mirrored, text, sections, ast }).type).toBe(
         "skip",
       );
     }
   });
 
-  test("verified but empty objects cannot take the columns' document", () => {
-    // The objects exist, are keyed and are readable, and hold nothing:
-    // a metadata-first ingest wrote them before the document arrived.
-    // Trimming here would delete the only copy that has the document.
-    const decision = planColumnTrim({
-      text: "verified",
-      sections: "verified",
-      ast: "verified",
-      contentHash: EMPTY_CORPUS_CONTENT_HASHES.at(0) ?? "",
-      columns: "document",
-    });
+  test("an object holding something else cannot take the document", () => {
+    // Whatever the object turned out to hold — one of the constant
+    // empty shapes, a row-specific empty envelope no fixed hash can
+    // name, or an older version of this decision — the comparison
+    // against the column is what rejects it, and the reason says so.
+    for (const mismatched of ["text", "sections", "ast"] as const) {
+      const decision = planColumnTrim({
+        text: "verified",
+        sections: "verified",
+        ast: "verified",
+        ...mirrored,
+        [mismatched]: "content-mismatch",
+      });
 
-    expect(decision.type).toBe("skip");
-    expect(decision.type === "skip" ? decision.reason : "").toContain(
-      "empty payload",
-    );
+      expect(decision.type).toBe("skip");
+      expect(decision.type === "skip" ? decision.reason : "").toContain(
+        "does not hold what the columns hold",
+      );
+    }
   });
 
-  test("empty objects over empty columns have nothing to lose", () => {
-    for (const contentHash of EMPTY_CORPUS_CONTENT_HASHES) {
+  test("columns holding no document need only presence", () => {
+    for (const columnPayload of [
+      { text: null, sections: null, ast: null },
+      { text: "", sections: null, ast: {} },
+      // An envelope with no blocks is not a document either.
+      { text: "", sections: [], ast: documentAst([]) },
+    ] satisfies CorpusPayload[]) {
       expect(
         planColumnTrim({
           text: "verified",
           sections: "verified",
           ast: "verified",
-          contentHash,
-          columns: "empty",
+          columnPayload,
         }),
       ).toEqual({ type: "trim" });
+      // Nothing to lose, so a mismatch does not block it either.
+      expect(
+        planColumnTrim({
+          text: "content-mismatch",
+          sections: "verified",
+          ast: "verified",
+          columnPayload,
+        }),
+      ).toEqual({ type: "trim" });
+      // A missing object still does: nothing proves the row was ever
+      // written to object storage.
+      expect(
+        planColumnTrim({
+          text: "object-missing",
+          sections: "verified",
+          ast: "verified",
+          columnPayload,
+        }).type,
+      ).toBe("skip");
     }
-  });
-
-  test("a row that was never written to object storage still trims on its hash", () => {
-    // No hash at all is not an empty-payload hash: the object states are
-    // what gate this row, and they are verified.
-    expect(
-      planColumnTrim({
-        text: "verified",
-        sections: "verified",
-        ast: "verified",
-        contentHash: null,
-        columns: "document",
-      }),
-    ).toEqual({ type: "trim" });
   });
 
   test("the skip reason names every object's state", () => {
     const decision = planColumnTrim({
-      ...populated,
+      ...mirrored,
       text: "verified",
       sections: "object-missing",
       ast: "verified",

--- a/apps/api/src/scripts/corpus-column-trim-plan.test.ts
+++ b/apps/api/src/scripts/corpus-column-trim-plan.test.ts
@@ -1,11 +1,18 @@
 import { describe, expect, test } from "bun:test";
 
+import { EMPTY_CORPUS_CONTENT_HASHES } from "@/api/handlers/case-law/corpus-storage";
 import {
   columnTrimGate,
   corpusObjectState,
   parseColumnTrimArgs,
   planColumnTrim,
 } from "@/api/scripts/corpus-column-trim-plan";
+
+/** A row whose objects hold the document they are supposed to hold. */
+const populated = {
+  contentHash: "real-content-hash",
+  columns: "document",
+} as const;
 
 describe("corpusObjectState", () => {
   test("a recorded key is only verified once the object is found", () => {
@@ -24,6 +31,7 @@ describe("planColumnTrim", () => {
   test("trims only when all three objects are verified", () => {
     expect(
       planColumnTrim({
+        ...populated,
         text: "verified",
         sections: "verified",
         ast: "verified",
@@ -40,12 +48,61 @@ describe("planColumnTrim", () => {
       ["verified", "verified", "key-missing"],
       ["key-missing", "key-missing", "key-missing"],
     ] as const) {
-      expect(planColumnTrim({ text, sections, ast }).type).toBe("skip");
+      expect(planColumnTrim({ ...populated, text, sections, ast }).type).toBe(
+        "skip",
+      );
     }
+  });
+
+  test("verified but empty objects cannot take the columns' document", () => {
+    // The objects exist, are keyed and are readable, and hold nothing:
+    // a metadata-first ingest wrote them before the document arrived.
+    // Trimming here would delete the only copy that has the document.
+    const decision = planColumnTrim({
+      text: "verified",
+      sections: "verified",
+      ast: "verified",
+      contentHash: EMPTY_CORPUS_CONTENT_HASHES.at(0) ?? "",
+      columns: "document",
+    });
+
+    expect(decision.type).toBe("skip");
+    expect(decision.type === "skip" ? decision.reason : "").toContain(
+      "empty payload",
+    );
+  });
+
+  test("empty objects over empty columns have nothing to lose", () => {
+    for (const contentHash of EMPTY_CORPUS_CONTENT_HASHES) {
+      expect(
+        planColumnTrim({
+          text: "verified",
+          sections: "verified",
+          ast: "verified",
+          contentHash,
+          columns: "empty",
+        }),
+      ).toEqual({ type: "trim" });
+    }
+  });
+
+  test("a row that was never written to object storage still trims on its hash", () => {
+    // No hash at all is not an empty-payload hash: the object states are
+    // what gate this row, and they are verified.
+    expect(
+      planColumnTrim({
+        text: "verified",
+        sections: "verified",
+        ast: "verified",
+        contentHash: null,
+        columns: "document",
+      }),
+    ).toEqual({ type: "trim" });
   });
 
   test("the skip reason names every object's state", () => {
     const decision = planColumnTrim({
+      ...populated,
       text: "verified",
       sections: "object-missing",
       ast: "verified",

--- a/apps/api/src/scripts/corpus-column-trim-plan.test.ts
+++ b/apps/api/src/scripts/corpus-column-trim-plan.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "bun:test";
 import type { DocumentAst } from "@stll/legal-ast/document-ast";
 
 import type { CorpusPayload } from "@/api/handlers/case-law/corpus-storage";
+import { EMPTY_CORPUS_CONTENT_HASHES } from "@/api/handlers/case-law/corpus-storage";
 import {
   columnTrimGate,
   corpusObjectState,
@@ -47,18 +48,37 @@ const storedDocument: CorpusPayload = {
 };
 
 /** A row whose objects hold exactly what its columns hold. */
-const mirrored = { columnPayload: storedDocument } as const;
+const mirrored = {
+  columnPayload: storedDocument,
+  contentHash: "a-row-specific-hash",
+} as const;
 
 describe("corpusObjectState", () => {
   test("a recorded key is only verified once the object is found", () => {
-    expect(corpusObjectState({ key: "k", exists: true })).toBe("verified");
-    expect(corpusObjectState({ key: "k", exists: false })).toBe(
-      "object-missing",
-    );
+    expect(
+      corpusObjectState({
+        key: "k",
+        exists: true,
+        matchesColumn: "not-checked",
+      }),
+    ).toBe("verified");
+    expect(
+      corpusObjectState({
+        key: "k",
+        exists: false,
+        matchesColumn: "not-checked",
+      }),
+    ).toBe("object-missing");
   });
 
   test("a missing key is never verified, whatever the bucket says", () => {
-    expect(corpusObjectState({ key: null, exists: true })).toBe("key-missing");
+    expect(
+      corpusObjectState({
+        key: null,
+        exists: true,
+        matchesColumn: "not-checked",
+      }),
+    ).toBe("key-missing");
   });
 
   test("a present object holding something else is not verified", () => {
@@ -119,12 +139,11 @@ describe("planColumnTrim", () => {
     }
   });
 
-  test("columns holding no document need only presence", () => {
+  test("columns holding no document trim only when the hash is a known empty", () => {
+    const emptyHash = EMPTY_CORPUS_CONTENT_HASHES[0] ?? "";
     for (const columnPayload of [
       { text: null, sections: null, ast: null },
       { text: "", sections: null, ast: {} },
-      // An envelope with no blocks is not a document either.
-      { text: "", sections: [], ast: documentAst([]) },
     ] satisfies CorpusPayload[]) {
       expect(
         planColumnTrim({
@@ -132,18 +151,10 @@ describe("planColumnTrim", () => {
           sections: "verified",
           ast: "verified",
           columnPayload,
+          contentHash: emptyHash,
         }),
       ).toEqual({ type: "trim" });
-      // Nothing to lose, so a mismatch does not block it either.
-      expect(
-        planColumnTrim({
-          text: "content-mismatch",
-          sections: "verified",
-          ast: "verified",
-          columnPayload,
-        }),
-      ).toEqual({ type: "trim" });
-      // A missing object still does: nothing proves the row was ever
+      // A missing object still blocks: nothing proves the row was ever
       // written to object storage.
       expect(
         planColumnTrim({
@@ -151,9 +162,22 @@ describe("planColumnTrim", () => {
           sections: "verified",
           ast: "verified",
           columnPayload,
+          contentHash: emptyHash,
         }).type,
       ).toBe("skip");
     }
+    // A row-specific hash over empty columns is the verbatim empty-envelope
+    // copy: trimming would strand the row for the fetch queue, which
+    // recognises it by the surviving AST artifact.
+    expect(
+      planColumnTrim({
+        text: "verified",
+        sections: "verified",
+        ast: "verified",
+        columnPayload: { text: "", sections: [], ast: documentAst([]) },
+        contentHash: "a-row-specific-hash",
+      }).type,
+    ).toBe("skip");
   });
 
   test("the skip reason names every object's state", () => {

--- a/apps/api/src/scripts/corpus-column-trim-plan.ts
+++ b/apps/api/src/scripts/corpus-column-trim-plan.ts
@@ -1,4 +1,5 @@
-import { namesEmptyCorpusPayload } from "@/api/handlers/case-law/stored-payload";
+import type { CorpusPayload } from "@/api/handlers/case-law/corpus-storage";
+import { payloadCarriesDocument } from "@/api/handlers/case-law/stored-payload";
 import type { CorpusStorageMode } from "@/api/lib/corpus-storage-mode";
 
 /**
@@ -9,48 +10,54 @@ import type { CorpusStorageMode } from "@/api/lib/corpus-storage-mode";
 
 /** How a single corpus object stands relative to the row that names it. */
 export const CORPUS_OBJECT_STATES = [
-  /** The row records a key and the object is present in the bucket. */
+  /** Present, and holding what the row's column holds. */
   "verified",
   /** The row records no key, so nothing proves the payload was ever written. */
   "key-missing",
   /** The row records a key but the bucket has no object under it. */
   "object-missing",
+  /** Present, and holding something other than what the column holds. */
+  "content-mismatch",
 ] as const;
 
 export type CorpusObjectState = (typeof CORPUS_OBJECT_STATES)[number];
 
 type CorpusObjectStateInput = {
   key: string | null;
-  /** Result of the bucket existence check; ignored when `key` is null. */
+  /** Result of the bucket lookup; ignored when `key` is null. */
   exists: boolean;
+  /**
+   * Whether the object holds what the column holds. Left undefined
+   * where the column holds nothing worth proving, which is the only
+   * case presence alone settles.
+   */
+  matchesColumn?: boolean;
 };
 
 export const corpusObjectState = ({
   key,
   exists,
+  matchesColumn,
 }: CorpusObjectStateInput): CorpusObjectState => {
   if (key === null) {
     return "key-missing";
   }
-  return exists ? "verified" : "object-missing";
+  if (!exists) {
+    return "object-missing";
+  }
+  return matchesColumn === false ? "content-mismatch" : "verified";
 };
 
 export type ColumnTrimDecision =
   | { type: "trim" }
   | { type: "skip"; reason: string };
 
-/** What the row's own Postgres columns hold. */
-export const COLUMN_PAYLOAD_STATES = ["document", "empty"] as const;
-
-export type ColumnPayloadState = (typeof COLUMN_PAYLOAD_STATES)[number];
-
 type ColumnTrimInput = {
   text: CorpusObjectState;
   sections: CorpusObjectState;
   ast: CorpusObjectState;
-  /** The row's content hash, which says what the objects hold. */
-  contentHash: string | null;
-  columns: ColumnPayloadState;
+  /** What the Postgres columns hold, which is what the trim deletes. */
+  columnPayload: CorpusPayload;
 };
 
 /**
@@ -63,39 +70,53 @@ type ColumnTrimInput = {
  * was never written by the corpus writer. Keys are content-addressed,
  * which makes an existence check a sufficient verification.
  *
- * Present is not the same as populated. A metadata-first ingest writes
- * all three objects before the document exists, so a row can pass every
- * existence check while object storage holds nothing: the content hash
- * is what tells the two apart. Where the objects are those empty shapes
- * and the columns hold the document — a decision hydrated after that
- * ingest, whose corpus objects were never rewritten — trimming would
- * delete the only real copy. That row is skipped until the objects are
- * repaired (`backfill-corpus-storage.ts --include-stale-empty`).
+ * Present is not the same as holding this row's document. A
+ * metadata-first ingest writes all three objects before the document
+ * exists, so a row can pass every existence check while object storage
+ * holds nothing; and the shapes it writes are not all constants — a
+ * DocumentAst envelope with no blocks carries the decision's own
+ * metadata, so no fixed hash can name it. Enumerating the empty shapes
+ * therefore cannot close this: what the trim needs is the positive
+ * proof, that object storage holds exactly what it is about to delete.
+ *
+ * That proof is the objects' own content, compared against the columns.
+ * The row's content hash cannot stand in for it: the hash was taken of
+ * the payload as written, and the columns come back through jsonb,
+ * which normalises key order — re-hashing a read never reproduces the
+ * hash of the write. Comparing the decompressed objects is the same
+ * question asked where it can be answered, and it fails every way of
+ * holding nothing and every way of holding some other version alike.
+ * A mismatch leaves the row to the repair pass
+ * (`backfill-corpus-storage.ts --include-stale-empty`).
+ *
+ * Columns that hold no document are exempt from the content check:
+ * there is nothing to lose, so presence is all they need.
  */
 export const planColumnTrim = ({
   text,
   sections,
   ast,
-  contentHash,
-  columns,
+  columnPayload,
 }: ColumnTrimInput): ColumnTrimDecision => {
-  if (text !== "verified" || sections !== "verified" || ast !== "verified") {
-    return {
-      type: "skip",
-      reason: `text=${text} sections=${sections} ast=${ast}`,
-    };
+  const states = { text, sections, ast };
+  const unusable = Object.entries(states).filter(([, state]) =>
+    payloadCarriesDocument(columnPayload)
+      ? state !== "verified"
+      : state === "key-missing" || state === "object-missing",
+  );
+
+  if (unusable.length === 0) {
+    return { type: "trim" };
   }
 
-  if (namesEmptyCorpusPayload(contentHash) && columns === "document") {
-    return {
-      type: "skip",
-      reason:
-        "objects hold the empty payload while the columns hold the document; " +
-        "repair the objects first (backfill-corpus-storage --include-stale-empty)",
-    };
-  }
-
-  return { type: "trim" };
+  const detail = `text=${text} sections=${sections} ast=${ast}`;
+  return {
+    type: "skip",
+    reason: unusable.some(([, state]) => state === "content-mismatch")
+      ? `object storage does not hold what the columns hold (${detail}); ` +
+        "repair the objects first (backfill-corpus-storage --include-stale-empty)"
+      : detail,
+  };
 };
 
 export type ColumnTrimGate =

--- a/apps/api/src/scripts/corpus-column-trim-plan.ts
+++ b/apps/api/src/scripts/corpus-column-trim-plan.ts
@@ -1,5 +1,8 @@
 import type { CorpusPayload } from "@/api/handlers/case-law/corpus-storage";
-import { payloadCarriesDocument } from "@/api/handlers/case-law/stored-payload";
+import {
+  namesEmptyCorpusPayload,
+  payloadCarriesDocument,
+} from "@/api/handlers/case-law/stored-payload";
 import type { CorpusStorageMode } from "@/api/lib/corpus-storage-mode";
 
 /**
@@ -27,11 +30,12 @@ type CorpusObjectStateInput = {
   /** Result of the bucket lookup; ignored when `key` is null. */
   exists: boolean;
   /**
-   * Whether the object holds what the column holds. Left undefined
-   * where the column holds nothing worth proving, which is the only
-   * case presence alone settles.
+   * Whether the object holds what the column holds, or "not-checked"
+   * where the column holds nothing worth proving — the only case
+   * presence alone settles. Spelled out rather than optional so an
+   * omitted comparison cannot silently pass a destructive gate.
    */
-  matchesColumn?: boolean;
+  matchesColumn: boolean | "not-checked";
 };
 
 export const corpusObjectState = ({
@@ -45,7 +49,9 @@ export const corpusObjectState = ({
   if (!exists) {
     return "object-missing";
   }
-  return matchesColumn === false ? "content-mismatch" : "verified";
+  return matchesColumn === true || matchesColumn === "not-checked"
+    ? "verified"
+    : "content-mismatch";
 };
 
 export type ColumnTrimDecision =
@@ -58,6 +64,8 @@ type ColumnTrimInput = {
   ast: CorpusObjectState;
   /** What the Postgres columns hold, which is what the trim deletes. */
   columnPayload: CorpusPayload;
+  /** The row's stored corpus content hash, for the empty-constant test. */
+  contentHash: string | null;
 };
 
 /**
@@ -97,7 +105,24 @@ export const planColumnTrim = ({
   sections,
   ast,
   columnPayload,
+  contentHash,
 }: ColumnTrimInput): ColumnTrimDecision => {
+  // A row that holds no document anywhere must keep its columns: the
+  // fetch queue recognises a verbatim empty copy by the surviving
+  // Postgres AST artifact, so trimming it would strand the row —
+  // unreadable, yet excluded from fetching. Pure-constant empties are
+  // exempt (the queue admits their hashes directly).
+  if (
+    !payloadCarriesDocument(columnPayload) &&
+    !namesEmptyCorpusPayload(contentHash)
+  ) {
+    return {
+      type: "skip",
+      reason:
+        "columns hold no document and the corpus hash is row-specific; " +
+        "trimming would strand the row for the fetch queue",
+    };
+  }
   const states = { text, sections, ast };
   const unusable = Object.entries(states).filter(([, state]) =>
     payloadCarriesDocument(columnPayload)
@@ -114,7 +139,9 @@ export const planColumnTrim = ({
     type: "skip",
     reason: unusable.some(([, state]) => state === "content-mismatch")
       ? `object storage does not hold what the columns hold (${detail}); ` +
-        "repair the objects first (backfill-corpus-storage --include-stale-empty)"
+        "empty copies are repaired by backfill-corpus-storage " +
+        "--include-stale-empty, version skew by the next ingest refresh " +
+        "of the row (the mirror rewrites the objects); re-run the trim after"
       : detail,
   };
 };

--- a/apps/api/src/scripts/corpus-column-trim-plan.ts
+++ b/apps/api/src/scripts/corpus-column-trim-plan.ts
@@ -1,3 +1,4 @@
+import { namesEmptyCorpusPayload } from "@/api/handlers/case-law/stored-payload";
 import type { CorpusStorageMode } from "@/api/lib/corpus-storage-mode";
 
 /**
@@ -38,10 +39,18 @@ export type ColumnTrimDecision =
   | { type: "trim" }
   | { type: "skip"; reason: string };
 
+/** What the row's own Postgres columns hold. */
+export const COLUMN_PAYLOAD_STATES = ["document", "empty"] as const;
+
+export type ColumnPayloadState = (typeof COLUMN_PAYLOAD_STATES)[number];
+
 type ColumnTrimInput = {
   text: CorpusObjectState;
   sections: CorpusObjectState;
   ast: CorpusObjectState;
+  /** The row's content hash, which says what the objects hold. */
+  contentHash: string | null;
+  columns: ColumnPayloadState;
 };
 
 /**
@@ -53,19 +62,40 @@ type ColumnTrimInput = {
  * by object storage carries all three keys; a missing one means the row
  * was never written by the corpus writer. Keys are content-addressed,
  * which makes an existence check a sufficient verification.
+ *
+ * Present is not the same as populated. A metadata-first ingest writes
+ * all three objects before the document exists, so a row can pass every
+ * existence check while object storage holds nothing: the content hash
+ * is what tells the two apart. Where the objects are those empty shapes
+ * and the columns hold the document — a decision hydrated after that
+ * ingest, whose corpus objects were never rewritten — trimming would
+ * delete the only real copy. That row is skipped until the objects are
+ * repaired (`backfill-corpus-storage.ts --include-stale-empty`).
  */
 export const planColumnTrim = ({
   text,
   sections,
   ast,
+  contentHash,
+  columns,
 }: ColumnTrimInput): ColumnTrimDecision => {
-  if (text === "verified" && sections === "verified" && ast === "verified") {
-    return { type: "trim" };
+  if (text !== "verified" || sections !== "verified" || ast !== "verified") {
+    return {
+      type: "skip",
+      reason: `text=${text} sections=${sections} ast=${ast}`,
+    };
   }
-  return {
-    type: "skip",
-    reason: `text=${text} sections=${sections} ast=${ast}`,
-  };
+
+  if (namesEmptyCorpusPayload(contentHash) && columns === "document") {
+    return {
+      type: "skip",
+      reason:
+        "objects hold the empty payload while the columns hold the document; " +
+        "repair the objects first (backfill-corpus-storage --include-stale-empty)",
+    };
+  }
+
+  return { type: "trim" };
 };
 
 export type ColumnTrimGate =

--- a/apps/api/src/scripts/corpus-column-trim.ts
+++ b/apps/api/src/scripts/corpus-column-trim.ts
@@ -128,11 +128,15 @@ const checkObject = async (
   compareContent: boolean,
 ): Promise<CorpusObjectState> => {
   if (key === null) {
-    return corpusObjectState({ key, exists: false });
+    return corpusObjectState({
+      key,
+      exists: false,
+      matchesColumn: "not-checked",
+    });
   }
   const exists = await corpusObjectExists(key);
   if (!exists || !compareContent) {
-    return corpusObjectState({ key, exists });
+    return corpusObjectState({ key, exists, matchesColumn: "not-checked" });
   }
   return corpusObjectState({
     key,
@@ -192,7 +196,13 @@ const trimRow = async (row: TrimRow): Promise<void> => {
       ),
     ]);
 
-    const decision = planColumnTrim({ text, sections, ast, columnPayload });
+    const decision = planColumnTrim({
+      text,
+      sections,
+      ast,
+      columnPayload,
+      contentHash: row.contentHash,
+    });
 
     if (decision.type === "skip") {
       skipped += 1;

--- a/apps/api/src/scripts/corpus-column-trim.ts
+++ b/apps/api/src/scripts/corpus-column-trim.ts
@@ -7,23 +7,40 @@ import type { SQL } from "drizzle-orm";
  * storage, and remove their pg-fts projection (a canonical row is served
  * by the corpus index, so the tsvector row is dead weight).
  *
- * Every object is verified present before anything is nulled, the update
- * is compare-and-set against the row state it read, and the scan is
- * keyset-paginated, so the run is idempotent and safe to repeat.
+ * A row is only trimmed once object storage is proven to hold exactly
+ * what is about to be deleted: every object is read back, decompressed
+ * and compared against the column it stands in for. That costs the scan
+ * both payloads — the columns from Postgres and the objects from the
+ * bucket — which is the right trade for a one-off pass whose mistakes
+ * are unrecoverable. Batches stay small and keyset-paginated for it.
+ * Rows whose columns hold no document skip the comparison: presence is
+ * all they need, because there is nothing to lose. The update is
+ * compare-and-set against the row state it read, so the run is
+ * idempotent and safe to repeat.
  *
  *   CORPUS_STORAGE_MODE=canonical LEGAL_CORPUS_S3_BUCKET=... \
  *     bun run src/scripts/corpus-column-trim.ts [--limit N] [--dry-run] [--force]
  */
+import type { DocumentAst } from "@stll/legal-ast/document-ast";
+
 import { rlsDb } from "@/api/db/root";
 import { caseLawDecisions, caseLawSearchDocuments } from "@/api/db/schema";
 import { createIngestionDb } from "@/api/db/scoped";
 import { corpusStorageMode } from "@/api/env-base";
-import { pgPayloadCarriesDocument } from "@/api/handlers/case-law/stored-payload";
+import {
+  readCorpusAst,
+  readCorpusSections,
+  readCorpusText,
+} from "@/api/handlers/case-law/corpus-storage";
+import type { EmptyAst } from "@/api/handlers/case-law/ingestion/adapter";
+import { payloadCarriesDocument } from "@/api/handlers/case-law/stored-payload";
+import type { DecisionSection } from "@/api/handlers/case-law/types";
 import { captureError } from "@/api/lib/analytics/capture";
 import type { SafeId } from "@/api/lib/branded-types";
 import { LIMITS } from "@/api/lib/limits";
 import { getCorpusS3, refreshCorpusS3, refreshS3 } from "@/api/lib/s3";
 import { withTimeout } from "@/api/lib/with-timeout";
+import type { CorpusObjectState } from "@/api/scripts/corpus-column-trim-plan";
 import {
   columnTrimGate,
   corpusObjectState,
@@ -40,8 +57,10 @@ type TrimRow = {
   normalizedS3Key: string | null;
   astS3Key: string | null;
   contentHash: string | null;
-  /** Whether the columns this run would null hold a document. */
-  columnsCarryDocument: boolean;
+  /** The payload this run would delete, which it has to hash first. */
+  fulltext: string | null;
+  sections: DecisionSection[] | null;
+  documentAst: DocumentAst | EmptyAst | null;
   updatedAt: Date;
 };
 
@@ -95,29 +114,85 @@ const corpusObjectExists = async (key: string): Promise<boolean> =>
     timeoutMs: LIMITS.corpusObjectIoTimeoutMs,
   });
 
+type ObjectCheck = {
+  key: string | null;
+  /**
+   * Reads the object and answers whether it holds what the column
+   * holds. Not called where the column holds no document.
+   */
+  matchesColumn: () => Promise<boolean>;
+};
+
+const checkObject = async (
+  { key, matchesColumn }: ObjectCheck,
+  compareContent: boolean,
+): Promise<CorpusObjectState> => {
+  if (key === null) {
+    return corpusObjectState({ key, exists: false });
+  }
+  const exists = await corpusObjectExists(key);
+  if (!exists || !compareContent) {
+    return corpusObjectState({ key, exists });
+  }
+  return corpusObjectState({
+    key,
+    exists,
+    matchesColumn: await matchesColumn(),
+  });
+};
+
 const trimRow = async (row: TrimRow): Promise<void> => {
   try {
-    // Every object whose column this run nulls has to be checked, sections
-    // included: `writeCorpusDocument` always writes a sections object, so
-    // its absence means the row is not actually backed by object storage.
-    const [textExists, sectionsExists, astExists] = await Promise.all([
-      row.textS3Key === null ? false : corpusObjectExists(row.textS3Key),
-      row.normalizedS3Key === null
-        ? false
-        : corpusObjectExists(row.normalizedS3Key),
-      row.astS3Key === null ? false : corpusObjectExists(row.astS3Key),
+    const columnPayload = {
+      text: row.fulltext,
+      sections: row.sections,
+      ast: row.documentAst,
+    };
+    // Every object whose column this run nulls has to be checked,
+    // sections included: `writeCorpusDocument` always writes a sections
+    // object, so its absence means the row is not actually backed by
+    // object storage. Where the columns hold a document, presence is not
+    // enough and the object's content is compared with the column's;
+    // `Bun.deepEquals` rather than a serialization, because the columns
+    // come back through jsonb with their keys reordered.
+    const compareContent = payloadCarriesDocument(columnPayload);
+    const [text, sections, ast] = await Promise.all([
+      checkObject(
+        {
+          key: row.textS3Key,
+          matchesColumn: async () =>
+            row.textS3Key !== null &&
+            (await readCorpusText(row.textS3Key)) === (row.fulltext ?? ""),
+        },
+        compareContent,
+      ),
+      checkObject(
+        {
+          key: row.normalizedS3Key,
+          matchesColumn: async () =>
+            row.normalizedS3Key !== null &&
+            Bun.deepEquals(
+              await readCorpusSections(row.normalizedS3Key),
+              row.sections ?? null,
+            ),
+        },
+        compareContent,
+      ),
+      checkObject(
+        {
+          key: row.astS3Key,
+          matchesColumn: async () =>
+            row.astS3Key !== null &&
+            Bun.deepEquals(
+              await readCorpusAst(row.astS3Key),
+              row.documentAst ?? null,
+            ),
+        },
+        compareContent,
+      ),
     ]);
 
-    const decision = planColumnTrim({
-      text: corpusObjectState({ key: row.textS3Key, exists: textExists }),
-      sections: corpusObjectState({
-        key: row.normalizedS3Key,
-        exists: sectionsExists,
-      }),
-      ast: corpusObjectState({ key: row.astS3Key, exists: astExists }),
-      contentHash: row.contentHash,
-      columns: row.columnsCarryDocument ? "document" : "empty",
-    });
+    const decision = planColumnTrim({ text, sections, ast, columnPayload });
 
     if (decision.type === "skip") {
       skipped += 1;
@@ -190,7 +265,9 @@ while (true) {
         normalizedS3Key: caseLawDecisions.normalizedS3Key,
         astS3Key: caseLawDecisions.astS3Key,
         contentHash: caseLawDecisions.contentHash,
-        columnsCarryDocument: pgPayloadCarriesDocument,
+        fulltext: caseLawDecisions.fulltext,
+        sections: caseLawDecisions.sections,
+        documentAst: caseLawDecisions.documentAst,
         updatedAt: caseLawDecisions.updatedAt,
       })
       .from(caseLawDecisions)

--- a/apps/api/src/scripts/corpus-column-trim.ts
+++ b/apps/api/src/scripts/corpus-column-trim.ts
@@ -18,6 +18,7 @@ import { rlsDb } from "@/api/db/root";
 import { caseLawDecisions, caseLawSearchDocuments } from "@/api/db/schema";
 import { createIngestionDb } from "@/api/db/scoped";
 import { corpusStorageMode } from "@/api/env-base";
+import { pgPayloadCarriesDocument } from "@/api/handlers/case-law/stored-payload";
 import { captureError } from "@/api/lib/analytics/capture";
 import type { SafeId } from "@/api/lib/branded-types";
 import { LIMITS } from "@/api/lib/limits";
@@ -39,6 +40,8 @@ type TrimRow = {
   normalizedS3Key: string | null;
   astS3Key: string | null;
   contentHash: string | null;
+  /** Whether the columns this run would null hold a document. */
+  columnsCarryDocument: boolean;
   updatedAt: Date;
 };
 
@@ -112,6 +115,8 @@ const trimRow = async (row: TrimRow): Promise<void> => {
         exists: sectionsExists,
       }),
       ast: corpusObjectState({ key: row.astS3Key, exists: astExists }),
+      contentHash: row.contentHash,
+      columns: row.columnsCarryDocument ? "document" : "empty",
     });
 
     if (decision.type === "skip") {
@@ -185,6 +190,7 @@ while (true) {
         normalizedS3Key: caseLawDecisions.normalizedS3Key,
         astS3Key: caseLawDecisions.astS3Key,
         contentHash: caseLawDecisions.contentHash,
+        columnsCarryDocument: pgPayloadCarriesDocument,
         updatedAt: caseLawDecisions.updatedAt,
       })
       .from(caseLawDecisions)


### PR DESCRIPTION
Four call sites answered "does this decision hold a document" with four different predicates; this centralizes the definition (`stored-payload.ts`: empty text, `{}` ASTs and empty sections are placeholders, not documents) and closes the gaps between them:

- **Column trim**: a row whose corpus objects exist but name an empty payload while the Postgres columns hold the document is skipped (the objects' existence is not proof of content); verified-empty over empty columns still trims. The scan supplies the column state as a SQL boolean — no payload transfer.
- **Deferred-document queue**: pending now also requires that the corpus carries no document, so rows whose columns are cleared after a corpus cutover do not re-enter the fetch queue; the read side short-circuits on the same test, which also removes a per-read column query for corpus-served rows. The full state table lives in the resolver's docblock.
- **Refresh preservation**: the payload columns move to their own UPDATE whose WHERE carries the preservation predicate, making check and write one statement — a concurrent hydration commit can no longer be overwritten by a metadata-only refresh. Metadata and source-hash advancement stay unconditional. Citations skip on the same incoming-carries-no-document test.
- **Fetched-byte stores** pin the sourceHash read at claim time in their CAS, so a source that changed mid-flight invalidates the store and the queue retries.

The mid-refresh race test injects at the row-write transaction and asserts the transaction count — it fails with the WHERE guard removed and passes with it. 398 DB-backed tests pass from a from-scratch-migrated database; guards clean, no baseline reseeds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented document refreshes and backfills from overwriting newly arrived content.
  * Improved handling of empty, unavailable, pending and superseded case-law documents.
  * Reduced duplicate document-fetch work when content is already stored.

* **Improvements**
  * Added stronger verification before removing database copies of corpus content.
  * Trim operations now detect mismatched stored content and skip unsafe changes.
  * Processing reports now separately track superseded documents for clearer operational visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->