### PR TITLE
fix: update independent npm release workflow

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -348,7 +348,7 @@ jobs:
       contents: write # Create immutable package tags and GitHub releases.
       id-token: write # Exchange a short-lived npm trusted-publishing credential.
     # The repository owner publishes this versioned shared contract.
-    uses: stella/.github/.github/workflows/npm-independent-release.yml@v1.2.0 # zizmor: ignore[unpinned-uses]
+    uses: stella/.github/.github/workflows/npm-independent-release.yml@v1.5.0 # zizmor: ignore[unpinned-uses]
     with:
       artifact-pattern: npm-tarball-*
       package-files: ${{ needs.pack.outputs.package_files }}


### PR DESCRIPTION
## Summary

- update the shared independent-package release contract to v1.5.0
- use the release-state implementation that discovers draft releases during staging
- retain resumable artifact verification from the versioned shared workflow

## Validation

- pre-push format, i18n, and TypeScript checks
- the one-line caller change remains pinned to a versioned shared workflow

CC on behalf of sok0