### PR TITLE
fix: permit release artifact verification

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -345,6 +345,7 @@ jobs:
       || (github.ref == 'refs/heads/main'
       && (github.event_name == 'push' || inputs.publish)))
     permissions:
+      actions: read # Verify exact artifacts when a release transaction is resumed.
       contents: write # Create immutable package tags and GitHub releases.
       id-token: write # Exchange a short-lived npm trusted-publishing credential.
     # The repository owner publishes this versioned shared contract.


### PR DESCRIPTION
## Summary

- grant the shared release job read access to workflow artifacts
- satisfy the v1.5.0 reusable-workflow permission contract
- keep build jobs unprivileged and publication scoped to the release job

## Validation

- pre-push format, i18n, and TypeScript checks
- manual dispatch previously failed at workflow startup before any job ran; this grants the exact missing permission

CC on behalf of sok0