### PR TITLE
fix: handle single-package release artifacts

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -349,7 +349,7 @@ jobs:
       contents: write # Create immutable package tags and GitHub releases.
       id-token: write # Exchange a short-lived npm trusted-publishing credential.
     # The repository owner publishes this versioned shared contract.
-    uses: stella/.github/.github/workflows/npm-independent-release.yml@v1.5.0 # zizmor: ignore[unpinned-uses]
+    uses: stella/.github/.github/workflows/npm-independent-release.yml@v1.5.1 # zizmor: ignore[unpinned-uses]
     with:
       artifact-pattern: npm-tarball-*
       package-files: ${{ needs.pack.outputs.package_files }}


### PR DESCRIPTION
## Summary

- update the shared release contract to v1.5.1
- accept the flat extraction layout used for a single package artifact
- retain exact artifact-count and one-tarball-per-artifact validation

## Validation

- shared action: 23 tests passed
- caller pre-push format, i18n, and TypeScript checks passed

CC on behalf of sok0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package publishing process to use the latest approved release workflow version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->