### PR TITLE
feat: add not-applicable playbook review verdict

### DIFF
--- a/apps/api/src/handlers/playbooks/verdict-tiers.ts
+++ b/apps/api/src/handlers/playbooks/verdict-tiers.ts
@@ -1,31 +1,39 @@
 import type { OptionColor, PropertyContent } from "@/api/db/schema-validators";
 
-// The four compliance tiers a verdict cell can hold, ordered worst-known-best
-// to worst. A graded position materializes a single-select property whose
-// options are exactly these tiers; the verdict engine writes one of them per
-// in-scope document.
+// The verdict states a graded cell can hold. The first four form the compliance
+// ladder, ordered best to worst (`compliant` -> `missing`). `not-applicable` is
+// deliberately outside that ladder: it means the position does not pertain to
+// this document at all, so it is neither a pass nor a flagged gap and is excluded
+// from the compliance denominator (see `computeRiskRollup`). A graded position
+// materializes a single-select property whose options are exactly these states;
+// the verdict engine writes one of them per in-scope document.
 export const VERDICT_TIERS = [
   "compliant",
   "fallback",
   "deviation",
   "missing",
+  "not-applicable",
 ] as const;
 
 export type VerdictTier = (typeof VERDICT_TIERS)[number];
 
 // Named preset colors (see `OptionColor`): green = on-standard, amber = an
 // accepted fallback, red = a deviation to flag, gray = nothing extracted.
+// `not-applicable` shares the neutral gray swatch (it is not a risk signal); the
+// review surface distinguishes the two neutrals visually (a dashed chip for
+// not-applicable vs the solid muted chip for missing).
 export const VERDICT_TIER_COLORS = {
   compliant: "green",
   fallback: "amber",
   deviation: "red",
   missing: "gray",
+  "not-applicable": "gray",
 } as const satisfies Record<VerdictTier, OptionColor>;
 
 /**
- * The single-select content shared by every verdict property: the four tiers
- * as named-color options, with no fallback (a verdict is always written
- * explicitly, including `missing`).
+ * The single-select content shared by every verdict property: every verdict
+ * state as a named-color option, with no fallback (a verdict is always written
+ * explicitly, including `missing` and `not-applicable`).
  */
 export const buildVerdictContent = (): PropertyContent => ({
   version: 1,

--- a/apps/api/src/lib/workflow/verdict-engine.ts
+++ b/apps/api/src/lib/workflow/verdict-engine.ts
@@ -148,8 +148,13 @@ export const TIER_MATCH_SYSTEM_PROMPT =
   'the [rank N] of the option it matched. Choose "deviation" when the value ' +
   'violates a red-line rule; set matched to { kind: "redLine", rank } with ' +
   'the [rank N] of the violated rule. Also choose "deviation" when the value ' +
-  "satisfies none of the tiers, and omit matched. Judge by legal substance and " +
-  "effect, not wording. Give a short one-sentence rationale.";
+  'satisfies none of the tiers, and omit matched. Choose "not-applicable" only ' +
+  "when the issue does not pertain to this contract at all, meaning the extracted " +
+  "value shows the document is a different kind of agreement or the topic is " +
+  "structurally out of scope, so it counts neither for nor against compliance; " +
+  "omit matched. Do not use not-applicable merely because a clause is absent " +
+  '(that is a "missing" gap). Judge by legal substance and effect, not wording. ' +
+  "Give a short one-sentence rationale.";
 
 export const buildTierMatchUserMessage = ({
   tiers,
@@ -195,7 +200,7 @@ export const buildTierMatchUserMessage = ({
 };
 
 const tierMatchSchema = v.strictObject({
-  tier: v.picklist(["compliant", "fallback", "deviation"]),
+  tier: v.picklist(["compliant", "fallback", "deviation", "not-applicable"]),
   rationale: v.pipe(v.string(), v.maxLength(1000)),
   matched: v.optional(
     v.strictObject({

--- a/apps/web/src/components/ai-suggestions/playbook-review-store.ts
+++ b/apps/web/src/components/ai-suggestions/playbook-review-store.ts
@@ -31,7 +31,11 @@ export type PlaybookVerdict =
   | "compliant"
   | "fallback"
   | "deviation"
-  | "missing";
+  | "missing"
+  // Outside the compliance ladder: the position does not pertain to this
+  // document, so it is neither a pass nor a flagged gap and is excluded from the
+  // compliance denominator (see `computeRiskRollup`).
+  | "not-applicable";
 
 export type PlaybookCitation = { blockId: string; text: string };
 export type PlaybookFindingFix = {

--- a/apps/web/src/components/inspector/playbook-facet.tsx
+++ b/apps/web/src/components/inspector/playbook-facet.tsx
@@ -586,6 +586,7 @@ const RISK_BREAKDOWN_ORDER: readonly PlaybookVerdict[] = [
   "missing",
   "fallback",
   "compliant",
+  "not-applicable",
 ];
 
 const RiskSummaryCard = ({
@@ -632,6 +633,25 @@ const RiskSummaryCard = ({
           total: String(rollup.totalPositions),
         })}
       </p>
+
+      {rollup.compliance.ratio !== null && (
+        <p className="text-muted-foreground text-xs">
+          <span className="text-foreground-strong-muted">
+            {t("knowledge.playbooks.risk.complianceLabel")}
+          </span>{" "}
+          <span className="text-foreground tabular-nums">
+            {format.number(rollup.compliance.ratio, { style: "percent" })}
+          </span>
+          {rollup.compliance.notApplicable > 0 && (
+            <span>
+              {" "}
+              {t("knowledge.playbooks.risk.notApplicableExcluded", {
+                count: String(rollup.compliance.notApplicable),
+              })}
+            </span>
+          )}
+        </p>
+      )}
 
       {rollup.flaggedCount > 0 && (
         <ul className="flex flex-wrap gap-x-3 gap-y-1">
@@ -1062,6 +1082,7 @@ const useVerdictLabels = (): Record<PlaybookVerdict, string> => {
     fallback: t("knowledge.playbooks.verdict.fallback"),
     deviation: t("knowledge.playbooks.verdict.deviation"),
     missing: t("knowledge.playbooks.verdict.missing"),
+    "not-applicable": t("knowledge.playbooks.verdict.notApplicable"),
   };
 };
 
@@ -1150,6 +1171,9 @@ const verdictDotClass = (verdict: PlaybookVerdict): string => {
       return "bg-destructive";
     case "missing":
       return "bg-muted-foreground";
+    // Neutral, distinct from missing: not-applicable is out of scope, not a gap.
+    case "not-applicable":
+      return "bg-border";
     default:
       verdict satisfies never;
       return "";
@@ -1160,6 +1184,10 @@ const VERDICT_CHIP_COMPLIANT = "border-success/30 text-success";
 const VERDICT_CHIP_FALLBACK = "border-warning/30 text-warning-foreground";
 const VERDICT_CHIP_DEVIATION = "border-destructive/30 text-destructive";
 const VERDICT_CHIP_MISSING = "border-border text-muted-foreground";
+// A dashed neutral chip so not-applicable reads as "out of scope" rather than a
+// solid-bordered missing gap.
+const VERDICT_CHIP_NOT_APPLICABLE =
+  "border-dashed border-border text-muted-foreground";
 
 const verdictChipClass = (verdict: PlaybookVerdict): string => {
   switch (verdict) {
@@ -1171,6 +1199,8 @@ const verdictChipClass = (verdict: PlaybookVerdict): string => {
       return VERDICT_CHIP_DEVIATION;
     case "missing":
       return VERDICT_CHIP_MISSING;
+    case "not-applicable":
+      return VERDICT_CHIP_NOT_APPLICABLE;
     default:
       verdict satisfies never;
       return "";

--- a/apps/web/src/components/inspector/playbook-risk-rollup.test.ts
+++ b/apps/web/src/components/inspector/playbook-risk-rollup.test.ts
@@ -134,16 +134,100 @@ describe("computeRiskRollup — counts", () => {
       finding({ positionId: "3", severity: "low", verdict: "missing" }),
       finding({ positionId: "4", severity: "low", verdict: "compliant" }),
       finding({ positionId: "5", severity: "medium", verdict: null }),
+      finding({
+        positionId: "6",
+        severity: "blocker",
+        verdict: "not-applicable",
+      }),
     ]);
 
-    expect(rollup.totalPositions).toBe(5);
+    expect(rollup.totalPositions).toBe(6);
+    // A not-applicable position (even at blocker severity) is never flagged.
     expect(rollup.flaggedCount).toBe(3);
     expect(rollup.verdictCounts).toEqual({
       compliant: 1,
       fallback: 1,
       deviation: 1,
       missing: 1,
+      "not-applicable": 1,
     });
+  });
+
+  test("a not-applicable position is never a flag or a top issue", () => {
+    const rollup = computeRiskRollup([
+      finding({
+        positionId: "na",
+        severity: "blocker",
+        verdict: "not-applicable",
+      }),
+    ]);
+    expect(rollup.overallRisk).toBe("none");
+    expect(rollup.flaggedCount).toBe(0);
+    expect(rollup.topIssues).toHaveLength(0);
+    expect(
+      isFlaggedPlaybookFinding(
+        finding({ positionId: "na", verdict: "not-applicable" }),
+      ),
+    ).toBe(false);
+  });
+});
+
+// The score-math invariants: a not-applicable position must never enter the
+// denominator (a document that legitimately omits a topic is not penalized),
+// while a `missing` gap must stay in it (a real omission counts against
+// compliance). `met` = compliant + fallback; `notMet` = deviation + missing.
+describe("computeRiskRollup — compliance score", () => {
+  test("excludes not-applicable from the denominator but keeps missing in it", () => {
+    const rollup = computeRiskRollup([
+      finding({ positionId: "1", verdict: "compliant" }),
+      finding({ positionId: "2", verdict: "fallback" }),
+      finding({ positionId: "3", verdict: "deviation" }),
+      finding({ positionId: "4", verdict: "missing" }),
+      finding({ positionId: "5", verdict: "not-applicable" }),
+      finding({ positionId: "6", verdict: "not-applicable" }),
+      // Extract-only positions carry no verdict and are excluded too.
+      finding({ positionId: "7", verdict: null }),
+    ]);
+
+    // met = compliant + fallback = 2; notMet = deviation + missing = 2.
+    expect(rollup.compliance.met).toBe(2);
+    expect(rollup.compliance.notMet).toBe(2);
+    // Denominator excludes the two not-applicable and the one extract-only.
+    expect(rollup.compliance.scored).toBe(4);
+    expect(rollup.compliance.notApplicable).toBe(2);
+    expect(rollup.compliance.ratio).toBe(0.5);
+  });
+
+  test("marking a flagged position not-applicable raises the score by shrinking the denominator", () => {
+    const withMissing = computeRiskRollup([
+      finding({ positionId: "1", verdict: "compliant" }),
+      finding({ positionId: "2", verdict: "missing" }),
+    ]);
+    // 1 met / 2 scored.
+    expect(withMissing.compliance.ratio).toBe(0.5);
+
+    const asNotApplicable = computeRiskRollup([
+      finding({ positionId: "1", verdict: "compliant" }),
+      finding({ positionId: "2", verdict: "not-applicable" }),
+    ]);
+    // The same position, now out of scope, leaves 1 met / 1 scored.
+    expect(asNotApplicable.compliance.scored).toBe(1);
+    expect(asNotApplicable.compliance.ratio).toBe(1);
+  });
+
+  test("ratio is null when nothing is scored (all not-applicable or extract-only)", () => {
+    const rollup = computeRiskRollup([
+      finding({ positionId: "1", verdict: "not-applicable" }),
+      finding({ positionId: "2", verdict: null }),
+    ]);
+    expect(rollup.compliance.scored).toBe(0);
+    expect(rollup.compliance.ratio).toBeNull();
+  });
+
+  test("empty findings produce a null ratio, not a divide-by-zero", () => {
+    const rollup = computeRiskRollup([]);
+    expect(rollup.compliance.ratio).toBeNull();
+    expect(rollup.compliance.scored).toBe(0);
   });
 });
 

--- a/apps/web/src/components/inspector/playbook-risk-rollup.ts
+++ b/apps/web/src/components/inspector/playbook-risk-rollup.ts
@@ -22,16 +22,18 @@ import { SEVERITY_ORDER } from "@/components/ai-suggestions/playbook-review-stor
 
 export type OverallRisk = "critical" | "high" | "medium" | "low" | "none";
 
-// A compliant or unset (extract-only positions carry no verdict) finding has
-// nothing worth raising with the counterparty; only these three verdicts are
-// ever "flagged".
-const FLAGGED_VERDICTS: readonly PlaybookVerdict[] = Object.freeze([
-  "deviation",
-  "fallback",
-  "missing",
-]);
+// A compliant, not-applicable, or unset (extract-only positions carry no
+// verdict) finding has nothing worth raising with the counterparty; only these
+// three verdicts are ever "flagged".
+const FLAGGED_VERDICTS = ["deviation", "fallback", "missing"] as const;
 
-type FlaggedVerdict = Exclude<PlaybookVerdict, "compliant">;
+// Derive the flagged set from the tuple rather than `Exclude<..., "compliant">`:
+// the latter would wrongly pull in `not-applicable`, which is not a flag.
+type FlaggedVerdict = (typeof FLAGGED_VERDICTS)[number];
+
+const FLAGGED_VERDICT_SET: ReadonlySet<PlaybookVerdict> = new Set(
+  FLAGGED_VERDICTS,
+);
 
 export type FlaggedPlaybookFinding = PlaybookFinding & {
   verdict: FlaggedVerdict;
@@ -46,12 +48,68 @@ export type RiskTopIssue = {
   verdict: FlaggedVerdict;
 };
 
+// A Met / Not-met / Not-applicable compliance score over the reviewed positions.
+// `scored` is the denominator and deliberately EXCLUDES `not-applicable` (the
+// position does not pertain to this document) and extract-only findings (no
+// verdict), so a document that legitimately omits a topic is not penalized.
+// `met` counts `compliant` + `fallback` (a fallback is pre-approved, if
+// non-ideal, language); `notMet` counts `deviation` + `missing` (a real gap
+// stays in the denominator). `ratio` is null when nothing was scored.
+export type ComplianceScore = {
+  met: number;
+  notMet: number;
+  scored: number;
+  notApplicable: number;
+  ratio: number | null;
+};
+
+const MET_VERDICTS: ReadonlySet<PlaybookVerdict> = new Set<PlaybookVerdict>([
+  "compliant",
+  "fallback",
+]);
+const NOT_MET_VERDICTS: ReadonlySet<PlaybookVerdict> = new Set<PlaybookVerdict>(
+  ["deviation", "missing"],
+);
+
 export type RiskRollup = {
   overallRisk: OverallRisk;
   totalPositions: number;
   flaggedCount: number;
   verdictCounts: RiskVerdictCounts;
+  compliance: ComplianceScore;
   topIssues: readonly RiskTopIssue[];
+};
+
+const computeCompliance = (
+  findings: readonly PlaybookFinding[],
+): ComplianceScore => {
+  let met = 0;
+  let notMet = 0;
+  let notApplicable = 0;
+  for (const { verdict } of findings) {
+    if (verdict === null) {
+      continue;
+    }
+    if (verdict === "not-applicable") {
+      notApplicable += 1;
+      continue;
+    }
+    if (MET_VERDICTS.has(verdict)) {
+      met += 1;
+      continue;
+    }
+    if (NOT_MET_VERDICTS.has(verdict)) {
+      notMet += 1;
+    }
+  }
+  const scored = met + notMet;
+  return {
+    met,
+    notMet,
+    scored,
+    notApplicable,
+    ratio: scored === 0 ? null : met / scored,
+  };
 };
 
 const TOP_ISSUES_LIMIT = 5;
@@ -59,7 +117,7 @@ const TOP_ISSUES_LIMIT = 5;
 export const isFlaggedPlaybookFinding = (
   finding: PlaybookFinding,
 ): finding is FlaggedPlaybookFinding =>
-  finding.verdict !== null && FLAGGED_VERDICTS.includes(finding.verdict);
+  finding.verdict !== null && FLAGGED_VERDICT_SET.has(finding.verdict);
 
 export const computeRiskRollup = (
   findings: readonly PlaybookFinding[],
@@ -71,6 +129,7 @@ export const computeRiskRollup = (
     fallback: 0,
     deviation: 0,
     missing: 0,
+    "not-applicable": 0,
   };
   for (const finding of findings) {
     if (finding.verdict !== null) {
@@ -97,6 +156,7 @@ export const computeRiskRollup = (
     totalPositions: findings.length,
     flaggedCount: flagged.length,
     verdictCounts,
+    compliance: computeCompliance(findings),
     topIssues,
   };
 };

--- a/apps/web/src/components/inspector/playbook-risk-rollup.ts
+++ b/apps/web/src/components/inspector/playbook-risk-rollup.ts
@@ -24,16 +24,18 @@ export type OverallRisk = "critical" | "high" | "medium" | "low" | "none";
 
 // A compliant, not-applicable, or unset (extract-only positions carry no
 // verdict) finding has nothing worth raising with the counterparty; only these
-// three verdicts are ever "flagged".
-const FLAGGED_VERDICTS = ["deviation", "fallback", "missing"] as const;
+// three verdicts are ever "flagged". Frozen readonly array (not a `Set`) so the
+// membership check reads a widened `PlaybookVerdict`, matching the file's
+// original immutable-collection shape.
+const FLAGGED_VERDICTS: readonly PlaybookVerdict[] = Object.freeze([
+  "deviation",
+  "fallback",
+  "missing",
+]);
 
-// Derive the flagged set from the tuple rather than `Exclude<..., "compliant">`:
-// the latter would wrongly pull in `not-applicable`, which is not a flag.
-type FlaggedVerdict = (typeof FLAGGED_VERDICTS)[number];
-
-const FLAGGED_VERDICT_SET: ReadonlySet<PlaybookVerdict> = new Set(
-  FLAGGED_VERDICTS,
-);
+// The flagged verdicts as a type. `not-applicable` is excluded alongside
+// `compliant`: neither is a flag.
+type FlaggedVerdict = Exclude<PlaybookVerdict, "compliant" | "not-applicable">;
 
 export type FlaggedPlaybookFinding = PlaybookFinding & {
   verdict: FlaggedVerdict;
@@ -63,14 +65,6 @@ export type ComplianceScore = {
   ratio: number | null;
 };
 
-const MET_VERDICTS: ReadonlySet<PlaybookVerdict> = new Set<PlaybookVerdict>([
-  "compliant",
-  "fallback",
-]);
-const NOT_MET_VERDICTS: ReadonlySet<PlaybookVerdict> = new Set<PlaybookVerdict>(
-  ["deviation", "missing"],
-);
-
 export type RiskRollup = {
   overallRisk: OverallRisk;
   totalPositions: number;
@@ -86,20 +80,27 @@ const computeCompliance = (
   let met = 0;
   let notMet = 0;
   let notApplicable = 0;
+  // A switch (not module-level Set membership) classifies each verdict, so the
+  // exhaustiveness check forces every future verdict to declare which bucket it
+  // falls in and no long-lived mutable collection is created at module scope.
   for (const { verdict } of findings) {
-    if (verdict === null) {
-      continue;
-    }
-    if (verdict === "not-applicable") {
-      notApplicable += 1;
-      continue;
-    }
-    if (MET_VERDICTS.has(verdict)) {
-      met += 1;
-      continue;
-    }
-    if (NOT_MET_VERDICTS.has(verdict)) {
-      notMet += 1;
+    switch (verdict) {
+      // Extract-only positions carry no verdict; excluded from the score.
+      case null:
+        break;
+      case "compliant":
+      case "fallback":
+        met += 1;
+        break;
+      case "deviation":
+      case "missing":
+        notMet += 1;
+        break;
+      case "not-applicable":
+        notApplicable += 1;
+        break;
+      default:
+        verdict satisfies never;
     }
   }
   const scored = met + notMet;
@@ -117,7 +118,7 @@ const TOP_ISSUES_LIMIT = 5;
 export const isFlaggedPlaybookFinding = (
   finding: PlaybookFinding,
 ): finding is FlaggedPlaybookFinding =>
-  finding.verdict !== null && FLAGGED_VERDICT_SET.has(finding.verdict);
+  finding.verdict !== null && FLAGGED_VERDICTS.includes(finding.verdict);
 
 export const computeRiskRollup = (
   findings: readonly PlaybookFinding[],

--- a/apps/web/src/i18n/langs/ar.json
+++ b/apps/web/src/i18n/langs/ar.json
@@ -1927,9 +1927,9 @@
         "violatedRedLine": "الخط الأحمر المخالف:"
       },
       "risk": {
-        "complianceLabel": "Compliance",
+        "complianceLabel": "الامتثال",
         "flaggedCount": "{flagged} of {total} positions flagged",
-        "notApplicableExcluded": "({count} not applicable, excluded)",
+        "notApplicableExcluded": "({count} غير قابلة للتطبيق، مستبعدة)",
         "riskLevel": {
           "critical": "Critical",
           "high": "High",
@@ -1971,7 +1971,7 @@
         "deviation": "انحراف",
         "fallback": "بديل",
         "missing": "مفقود",
-        "notApplicable": "Not applicable"
+        "notApplicable": "غير قابل للتطبيق"
       },
       "versions": {
         "confirmRestore": "Your current draft will be replaced with this version's content.",

--- a/apps/web/src/i18n/langs/ar.json
+++ b/apps/web/src/i18n/langs/ar.json
@@ -1927,7 +1927,9 @@
         "violatedRedLine": "الخط الأحمر المخالف:"
       },
       "risk": {
+        "complianceLabel": "Compliance",
         "flaggedCount": "{flagged} of {total} positions flagged",
+        "notApplicableExcluded": "({count} not applicable, excluded)",
         "riskLevel": {
           "critical": "Critical",
           "high": "High",
@@ -1968,7 +1970,8 @@
         "compliant": "مطابِق",
         "deviation": "انحراف",
         "fallback": "بديل",
-        "missing": "مفقود"
+        "missing": "مفقود",
+        "notApplicable": "Not applicable"
       },
       "versions": {
         "confirmRestore": "Your current draft will be replaced with this version's content.",

--- a/apps/web/src/i18n/langs/cs.json
+++ b/apps/web/src/i18n/langs/cs.json
@@ -1927,7 +1927,9 @@
         "violatedRedLine": "Porušuje nepřijatelné pravidlo:"
       },
       "risk": {
+        "complianceLabel": "Compliance",
         "flaggedCount": "{flagged} of {total} positions flagged",
+        "notApplicableExcluded": "({count} not applicable, excluded)",
         "riskLevel": {
           "critical": "Critical",
           "high": "High",
@@ -1968,7 +1970,8 @@
         "compliant": "Vyhovuje",
         "deviation": "Odchylka",
         "fallback": "Náhradní znění",
-        "missing": "Chybí"
+        "missing": "Chybí",
+        "notApplicable": "Not applicable"
       },
       "versions": {
         "confirmRestore": "Your current draft will be replaced with this version's content.",

--- a/apps/web/src/i18n/langs/cs.json
+++ b/apps/web/src/i18n/langs/cs.json
@@ -1927,9 +1927,9 @@
         "violatedRedLine": "Porušuje nepřijatelné pravidlo:"
       },
       "risk": {
-        "complianceLabel": "Compliance",
+        "complianceLabel": "Soulad",
         "flaggedCount": "{flagged} of {total} positions flagged",
-        "notApplicableExcluded": "({count} not applicable, excluded)",
+        "notApplicableExcluded": "({count} nerelevantní, vyloučeno)",
         "riskLevel": {
           "critical": "Critical",
           "high": "High",
@@ -1971,7 +1971,7 @@
         "deviation": "Odchylka",
         "fallback": "Náhradní znění",
         "missing": "Chybí",
-        "notApplicable": "Not applicable"
+        "notApplicable": "Nerelevantní"
       },
       "versions": {
         "confirmRestore": "Your current draft will be replaced with this version's content.",

--- a/apps/web/src/i18n/langs/de.json
+++ b/apps/web/src/i18n/langs/de.json
@@ -1927,9 +1927,9 @@
         "violatedRedLine": "Verstößt gegen rote Linie:"
       },
       "risk": {
-        "complianceLabel": "Compliance",
+        "complianceLabel": "Konformität",
         "flaggedCount": "{flagged} of {total} positions flagged",
-        "notApplicableExcluded": "({count} not applicable, excluded)",
+        "notApplicableExcluded": "({count} nicht zutreffend, ausgeschlossen)",
         "riskLevel": {
           "critical": "Critical",
           "high": "High",
@@ -1971,7 +1971,7 @@
         "deviation": "Abweichung",
         "fallback": "Alternative",
         "missing": "Fehlt",
-        "notApplicable": "Not applicable"
+        "notApplicable": "Nicht zutreffend"
       },
       "versions": {
         "confirmRestore": "Your current draft will be replaced with this version's content.",

--- a/apps/web/src/i18n/langs/de.json
+++ b/apps/web/src/i18n/langs/de.json
@@ -1927,7 +1927,9 @@
         "violatedRedLine": "Verstößt gegen rote Linie:"
       },
       "risk": {
+        "complianceLabel": "Compliance",
         "flaggedCount": "{flagged} of {total} positions flagged",
+        "notApplicableExcluded": "({count} not applicable, excluded)",
         "riskLevel": {
           "critical": "Critical",
           "high": "High",
@@ -1968,7 +1970,8 @@
         "compliant": "Konform",
         "deviation": "Abweichung",
         "fallback": "Alternative",
-        "missing": "Fehlt"
+        "missing": "Fehlt",
+        "notApplicable": "Not applicable"
       },
       "versions": {
         "confirmRestore": "Your current draft will be replaced with this version's content.",

--- a/apps/web/src/i18n/langs/en.json
+++ b/apps/web/src/i18n/langs/en.json
@@ -1927,7 +1927,9 @@
         "violatedRedLine": "Violates red line:"
       },
       "risk": {
+        "complianceLabel": "Compliance",
         "flaggedCount": "{flagged} of {total} positions flagged",
+        "notApplicableExcluded": "({count} not applicable, excluded)",
         "riskLevel": {
           "critical": "Critical",
           "high": "High",
@@ -1968,7 +1970,8 @@
         "compliant": "Compliant",
         "deviation": "Deviation",
         "fallback": "Fallback",
-        "missing": "Missing"
+        "missing": "Missing",
+        "notApplicable": "Not applicable"
       },
       "versions": {
         "confirmRestore": "Your current draft will be replaced with this version's content.",

--- a/apps/web/src/i18n/langs/es.json
+++ b/apps/web/src/i18n/langs/es.json
@@ -1927,7 +1927,9 @@
         "violatedRedLine": "Viola la línea roja:"
       },
       "risk": {
+        "complianceLabel": "Compliance",
         "flaggedCount": "{flagged} of {total} positions flagged",
+        "notApplicableExcluded": "({count} not applicable, excluded)",
         "riskLevel": {
           "critical": "Critical",
           "high": "High",
@@ -1968,7 +1970,8 @@
         "compliant": "Conforme",
         "deviation": "Desviación",
         "fallback": "Alternativa",
-        "missing": "Ausente"
+        "missing": "Ausente",
+        "notApplicable": "Not applicable"
       },
       "versions": {
         "confirmRestore": "Your current draft will be replaced with this version's content.",

--- a/apps/web/src/i18n/langs/es.json
+++ b/apps/web/src/i18n/langs/es.json
@@ -1927,9 +1927,9 @@
         "violatedRedLine": "Viola la línea roja:"
       },
       "risk": {
-        "complianceLabel": "Compliance",
+        "complianceLabel": "Cumplimiento",
         "flaggedCount": "{flagged} of {total} positions flagged",
-        "notApplicableExcluded": "({count} not applicable, excluded)",
+        "notApplicableExcluded": "({count} no aplicables, excluidas)",
         "riskLevel": {
           "critical": "Critical",
           "high": "High",
@@ -1971,7 +1971,7 @@
         "deviation": "Desviación",
         "fallback": "Alternativa",
         "missing": "Ausente",
-        "notApplicable": "Not applicable"
+        "notApplicable": "No aplicable"
       },
       "versions": {
         "confirmRestore": "Your current draft will be replaced with this version's content.",

--- a/apps/web/src/i18n/langs/et.json
+++ b/apps/web/src/i18n/langs/et.json
@@ -1927,9 +1927,9 @@
         "violatedRedLine": "Rikutud punane joon:"
       },
       "risk": {
-        "complianceLabel": "Compliance",
+        "complianceLabel": "Vastavus",
         "flaggedCount": "{flagged} of {total} positions flagged",
-        "notApplicableExcluded": "({count} not applicable, excluded)",
+        "notApplicableExcluded": "({count} ei kohaldu, välja jäetud)",
         "riskLevel": {
           "critical": "Critical",
           "high": "High",
@@ -1971,7 +1971,7 @@
         "deviation": "Kõrvalekalle",
         "fallback": "Alternatiiv",
         "missing": "Puudub",
-        "notApplicable": "Not applicable"
+        "notApplicable": "Ei kohaldu"
       },
       "versions": {
         "confirmRestore": "Your current draft will be replaced with this version's content.",

--- a/apps/web/src/i18n/langs/et.json
+++ b/apps/web/src/i18n/langs/et.json
@@ -1927,7 +1927,9 @@
         "violatedRedLine": "Rikutud punane joon:"
       },
       "risk": {
+        "complianceLabel": "Compliance",
         "flaggedCount": "{flagged} of {total} positions flagged",
+        "notApplicableExcluded": "({count} not applicable, excluded)",
         "riskLevel": {
           "critical": "Critical",
           "high": "High",
@@ -1968,7 +1970,8 @@
         "compliant": "Vastav",
         "deviation": "Kõrvalekalle",
         "fallback": "Alternatiiv",
-        "missing": "Puudub"
+        "missing": "Puudub",
+        "notApplicable": "Not applicable"
       },
       "versions": {
         "confirmRestore": "Your current draft will be replaced with this version's content.",

--- a/apps/web/src/i18n/langs/fr.json
+++ b/apps/web/src/i18n/langs/fr.json
@@ -1927,9 +1927,9 @@
         "violatedRedLine": "Viole la ligne rouge :"
       },
       "risk": {
-        "complianceLabel": "Compliance",
+        "complianceLabel": "Conformité",
         "flaggedCount": "{flagged} of {total} positions flagged",
-        "notApplicableExcluded": "({count} not applicable, excluded)",
+        "notApplicableExcluded": "({count} non applicable, exclu)",
         "riskLevel": {
           "critical": "Critical",
           "high": "High",
@@ -1971,7 +1971,7 @@
         "deviation": "Écart",
         "fallback": "Alternative",
         "missing": "Absent",
-        "notApplicable": "Not applicable"
+        "notApplicable": "Non applicable"
       },
       "versions": {
         "confirmRestore": "Your current draft will be replaced with this version's content.",

--- a/apps/web/src/i18n/langs/fr.json
+++ b/apps/web/src/i18n/langs/fr.json
@@ -1927,7 +1927,9 @@
         "violatedRedLine": "Viole la ligne rouge :"
       },
       "risk": {
+        "complianceLabel": "Compliance",
         "flaggedCount": "{flagged} of {total} positions flagged",
+        "notApplicableExcluded": "({count} not applicable, excluded)",
         "riskLevel": {
           "critical": "Critical",
           "high": "High",
@@ -1968,7 +1970,8 @@
         "compliant": "Conforme",
         "deviation": "Écart",
         "fallback": "Alternative",
-        "missing": "Absent"
+        "missing": "Absent",
+        "notApplicable": "Not applicable"
       },
       "versions": {
         "confirmRestore": "Your current draft will be replaced with this version's content.",

--- a/apps/web/src/i18n/langs/hu.json
+++ b/apps/web/src/i18n/langs/hu.json
@@ -1927,7 +1927,9 @@
         "violatedRedLine": "Nem elfogadható szabályt sért:"
       },
       "risk": {
+        "complianceLabel": "Compliance",
         "flaggedCount": "{flagged} of {total} positions flagged",
+        "notApplicableExcluded": "({count} not applicable, excluded)",
         "riskLevel": {
           "critical": "Critical",
           "high": "High",
@@ -1968,7 +1970,8 @@
         "compliant": "Megfelel",
         "deviation": "Eltérés",
         "fallback": "Alternatív megfogalmazás",
-        "missing": "Hiányzik"
+        "missing": "Hiányzik",
+        "notApplicable": "Not applicable"
       },
       "versions": {
         "confirmRestore": "Your current draft will be replaced with this version's content.",

--- a/apps/web/src/i18n/langs/hu.json
+++ b/apps/web/src/i18n/langs/hu.json
@@ -1927,9 +1927,9 @@
         "violatedRedLine": "Nem elfogadható szabályt sért:"
       },
       "risk": {
-        "complianceLabel": "Compliance",
+        "complianceLabel": "Megfelelőség",
         "flaggedCount": "{flagged} of {total} positions flagged",
-        "notApplicableExcluded": "({count} not applicable, excluded)",
+        "notApplicableExcluded": "({count} nem alkalmazható, kizárva)",
         "riskLevel": {
           "critical": "Critical",
           "high": "High",
@@ -1971,7 +1971,7 @@
         "deviation": "Eltérés",
         "fallback": "Alternatív megfogalmazás",
         "missing": "Hiányzik",
-        "notApplicable": "Not applicable"
+        "notApplicable": "Nem alkalmazható"
       },
       "versions": {
         "confirmRestore": "Your current draft will be replaced with this version's content.",

--- a/apps/web/src/i18n/langs/lt.json
+++ b/apps/web/src/i18n/langs/lt.json
@@ -1927,9 +1927,9 @@
         "violatedRedLine": "Pažeista raudona linija:"
       },
       "risk": {
-        "complianceLabel": "Compliance",
+        "complianceLabel": "Atitiktis",
         "flaggedCount": "{flagged} of {total} positions flagged",
-        "notApplicableExcluded": "({count} not applicable, excluded)",
+        "notApplicableExcluded": "({count} netaikoma, neįtraukta)",
         "riskLevel": {
           "critical": "Critical",
           "high": "High",
@@ -1971,7 +1971,7 @@
         "deviation": "Nukrypimas",
         "fallback": "Alternatyva",
         "missing": "Trūksta",
-        "notApplicable": "Not applicable"
+        "notApplicable": "Netaikoma"
       },
       "versions": {
         "confirmRestore": "Your current draft will be replaced with this version's content.",

--- a/apps/web/src/i18n/langs/lt.json
+++ b/apps/web/src/i18n/langs/lt.json
@@ -1927,7 +1927,9 @@
         "violatedRedLine": "Pažeista raudona linija:"
       },
       "risk": {
+        "complianceLabel": "Compliance",
         "flaggedCount": "{flagged} of {total} positions flagged",
+        "notApplicableExcluded": "({count} not applicable, excluded)",
         "riskLevel": {
           "critical": "Critical",
           "high": "High",
@@ -1968,7 +1970,8 @@
         "compliant": "Atitinka",
         "deviation": "Nukrypimas",
         "fallback": "Alternatyva",
-        "missing": "Trūksta"
+        "missing": "Trūksta",
+        "notApplicable": "Not applicable"
       },
       "versions": {
         "confirmRestore": "Your current draft will be replaced with this version's content.",

--- a/apps/web/src/i18n/langs/lv.json
+++ b/apps/web/src/i18n/langs/lv.json
@@ -1927,9 +1927,9 @@
         "violatedRedLine": "Pārkāptā sarkanā līnija:"
       },
       "risk": {
-        "complianceLabel": "Compliance",
+        "complianceLabel": "Atbilstība",
         "flaggedCount": "{flagged} of {total} positions flagged",
-        "notApplicableExcluded": "({count} not applicable, excluded)",
+        "notApplicableExcluded": "({count} nav piemērojams, izslēgts)",
         "riskLevel": {
           "critical": "Critical",
           "high": "High",
@@ -1971,7 +1971,7 @@
         "deviation": "Novirze",
         "fallback": "Alternatīva",
         "missing": "Trūkst",
-        "notApplicable": "Not applicable"
+        "notApplicable": "Nav piemērojams"
       },
       "versions": {
         "confirmRestore": "Your current draft will be replaced with this version's content.",

--- a/apps/web/src/i18n/langs/lv.json
+++ b/apps/web/src/i18n/langs/lv.json
@@ -1927,7 +1927,9 @@
         "violatedRedLine": "Pārkāptā sarkanā līnija:"
       },
       "risk": {
+        "complianceLabel": "Compliance",
         "flaggedCount": "{flagged} of {total} positions flagged",
+        "notApplicableExcluded": "({count} not applicable, excluded)",
         "riskLevel": {
           "critical": "Critical",
           "high": "High",
@@ -1968,7 +1970,8 @@
         "compliant": "Atbilst",
         "deviation": "Novirze",
         "fallback": "Alternatīva",
-        "missing": "Trūkst"
+        "missing": "Trūkst",
+        "notApplicable": "Not applicable"
       },
       "versions": {
         "confirmRestore": "Your current draft will be replaced with this version's content.",

--- a/apps/web/src/i18n/langs/messages.gen.ts
+++ b/apps/web/src/i18n/langs/messages.gen.ts
@@ -1930,7 +1930,9 @@ type Messages = {
         "violatedRedLine": "Violates red line:";
       };
       "risk": {
+        "complianceLabel": "Compliance";
         "flaggedCount": "{flagged} of {total} positions flagged";
+        "notApplicableExcluded": "({count} not applicable, excluded)";
         "riskLevel": {
           "critical": "Critical";
           "high": "High";
@@ -1972,6 +1974,7 @@ type Messages = {
         "deviation": "Deviation";
         "fallback": "Fallback";
         "missing": "Missing";
+        "notApplicable": "Not applicable";
       };
       "versions": {
         "confirmRestore": "Your current draft will be replaced with this version's content.";

--- a/apps/web/src/i18n/langs/pl.json
+++ b/apps/web/src/i18n/langs/pl.json
@@ -1927,9 +1927,9 @@
         "violatedRedLine": "Narusza nieakceptowalną regułę:"
       },
       "risk": {
-        "complianceLabel": "Compliance",
+        "complianceLabel": "Zgodność",
         "flaggedCount": "{flagged} of {total} positions flagged",
-        "notApplicableExcluded": "({count} not applicable, excluded)",
+        "notApplicableExcluded": "({count} nie dotyczy, wykluczono)",
         "riskLevel": {
           "critical": "Critical",
           "high": "High",
@@ -1971,7 +1971,7 @@
         "deviation": "Odstępstwo",
         "fallback": "Alternatywne brzmienie",
         "missing": "Brak",
-        "notApplicable": "Not applicable"
+        "notApplicable": "Nie dotyczy"
       },
       "versions": {
         "confirmRestore": "Your current draft will be replaced with this version's content.",

--- a/apps/web/src/i18n/langs/pl.json
+++ b/apps/web/src/i18n/langs/pl.json
@@ -1927,7 +1927,9 @@
         "violatedRedLine": "Narusza nieakceptowalną regułę:"
       },
       "risk": {
+        "complianceLabel": "Compliance",
         "flaggedCount": "{flagged} of {total} positions flagged",
+        "notApplicableExcluded": "({count} not applicable, excluded)",
         "riskLevel": {
           "critical": "Critical",
           "high": "High",
@@ -1968,7 +1970,8 @@
         "compliant": "Zgodne",
         "deviation": "Odstępstwo",
         "fallback": "Alternatywne brzmienie",
-        "missing": "Brak"
+        "missing": "Brak",
+        "notApplicable": "Not applicable"
       },
       "versions": {
         "confirmRestore": "Your current draft will be replaced with this version's content.",

--- a/apps/web/src/i18n/langs/pt-BR.json
+++ b/apps/web/src/i18n/langs/pt-BR.json
@@ -1927,9 +1927,9 @@
         "violatedRedLine": "Viola a linha vermelha:"
       },
       "risk": {
-        "complianceLabel": "Compliance",
+        "complianceLabel": "Conformidade",
         "flaggedCount": "{flagged} of {total} positions flagged",
-        "notApplicableExcluded": "({count} not applicable, excluded)",
+        "notApplicableExcluded": "({count} não aplicável, excluídas)",
         "riskLevel": {
           "critical": "Critical",
           "high": "High",
@@ -1971,7 +1971,7 @@
         "deviation": "Desvio",
         "fallback": "Alternativa",
         "missing": "Ausente",
-        "notApplicable": "Not applicable"
+        "notApplicable": "Não aplicável"
       },
       "versions": {
         "confirmRestore": "Your current draft will be replaced with this version's content.",

--- a/apps/web/src/i18n/langs/pt-BR.json
+++ b/apps/web/src/i18n/langs/pt-BR.json
@@ -1927,7 +1927,9 @@
         "violatedRedLine": "Viola a linha vermelha:"
       },
       "risk": {
+        "complianceLabel": "Compliance",
         "flaggedCount": "{flagged} of {total} positions flagged",
+        "notApplicableExcluded": "({count} not applicable, excluded)",
         "riskLevel": {
           "critical": "Critical",
           "high": "High",
@@ -1968,7 +1970,8 @@
         "compliant": "Conforme",
         "deviation": "Desvio",
         "fallback": "Alternativa",
-        "missing": "Ausente"
+        "missing": "Ausente",
+        "notApplicable": "Not applicable"
       },
       "versions": {
         "confirmRestore": "Your current draft will be replaced with this version's content.",

--- a/apps/web/src/i18n/langs/sk.json
+++ b/apps/web/src/i18n/langs/sk.json
@@ -1927,7 +1927,9 @@
         "violatedRedLine": "Porušuje neprijateľné pravidlo:"
       },
       "risk": {
+        "complianceLabel": "Compliance",
         "flaggedCount": "{flagged} of {total} positions flagged",
+        "notApplicableExcluded": "({count} not applicable, excluded)",
         "riskLevel": {
           "critical": "Critical",
           "high": "High",
@@ -1968,7 +1970,8 @@
         "compliant": "Vyhovuje",
         "deviation": "Odchýlka",
         "fallback": "Náhradné znenie",
-        "missing": "Chýba"
+        "missing": "Chýba",
+        "notApplicable": "Not applicable"
       },
       "versions": {
         "confirmRestore": "Your current draft will be replaced with this version's content.",

--- a/apps/web/src/i18n/langs/sk.json
+++ b/apps/web/src/i18n/langs/sk.json
@@ -1927,9 +1927,9 @@
         "violatedRedLine": "Porušuje neprijateľné pravidlo:"
       },
       "risk": {
-        "complianceLabel": "Compliance",
+        "complianceLabel": "Súlad",
         "flaggedCount": "{flagged} of {total} positions flagged",
-        "notApplicableExcluded": "({count} not applicable, excluded)",
+        "notApplicableExcluded": "({count} neaplikovateľné, vylúčené)",
         "riskLevel": {
           "critical": "Critical",
           "high": "High",
@@ -1971,7 +1971,7 @@
         "deviation": "Odchýlka",
         "fallback": "Náhradné znenie",
         "missing": "Chýba",
-        "notApplicable": "Not applicable"
+        "notApplicable": "Neaplikovateľné"
       },
       "versions": {
         "confirmRestore": "Your current draft will be replaced with this version's content.",


### PR DESCRIPTION
## What

Adds `not-applicable` as a first-class playbook-review verdict alongside
`compliant` / `fallback` / `deviation` / `missing`, and a compliance score
that excludes it from the denominator.

`not-applicable` sits outside the compliance ladder: a reviewed position that
does not pertain to the document is neither a pass nor a flagged gap. A binary
met/not-met model graded such a position `missing` (a flagged gap), which drove
a legitimately-absent topic to inflate the risk badge and the flagged count. A
document that legitimately omits a topic should not be penalized for it.

## Changes

- **Verdict enum** (`verdict-tiers.ts`): add `not-applicable`. Verdict values
  live in JSONB single-select property content, not a Postgres enum column, so
  this is additive with **no migration**. (Were a verdict ever promoted to a
  real column, it would need `text({ enum })` plus a DB CHECK per the DB
  conventions.) The materialized verdict property gains the option automatically.
- **Grader** (`verdict-engine.ts`): add `not-applicable` to the tier-match
  picklist and one prompt instruction so the state is genuinely reachable. It
  carries no matched reference and produces no suggested edit (`buildFix`
  already gates on `deviation` / `missing`).
- **Rollup** (`playbook-risk-rollup.ts`): `not-applicable` is never flagged and
  never a top issue. New `ComplianceScore { met, notMet, scored, notApplicable,
  ratio }` where the denominator `scored` excludes `not-applicable` and
  extract-only positions, `met = compliant + fallback`, `notMet = deviation +
  missing`, and `ratio` is `null` when nothing was scored. `FlaggedVerdict` now
  derives from the flagged tuple instead of `Exclude<…, "compliant">`, which
  would have wrongly pulled in `not-applicable`.
- **UI** (`playbook-facet.tsx`): exhaustive `switch` arms for the new verdict, a
  distinct dashed neutral chip (out-of-scope, not a gap), and a compliance line
  in the review risk summary. `TranslationKey` labels added and synced.

## Tests

`playbook-risk-rollup.test.ts` proves the score math:
- `not-applicable` is excluded from the denominator while `missing` stays in it.
- Re-marking a `missing` position `not-applicable` raises the ratio by shrinking
  the denominator (1/2 → 1/1).
- `ratio` is `null` when nothing is scored (all not-applicable / extract-only /
  empty), never a divide-by-zero.
- `not-applicable` is never flagged or a top issue, at any severity.

## Deferred

- Author-controlled applicability: an optional position whose absence grades
  `not-applicable` instead of `missing` (deterministic, no model call).
- Inferring `not-applicable` on absent extraction (would add a model call to a
  currently-deterministic path).

Whether `fallback` counts as `met` is a product decision encoded in one
predicate; flip it if the score should treat a pre-approved fallback as a
partial deviation.