### PR TITLE
fix: initialize registry validation in browsers

### DIFF
--- a/.changeset/quiet-lions-validate.md
+++ b/.changeset/quiet-lions-validate.md
@@ -1,0 +1,5 @@
+---
+"@stll/business-registries": patch
+---
+
+Use the browser-safe stdnum runtime for registry identifier validation and expose an explicit browser initializer.

--- a/bun.lock
+++ b/bun.lock
@@ -429,7 +429,7 @@
       "version": "0.2.0",
       "dependencies": {
         "@stll/country-codes": "workspace:*",
-        "@stll/stdnum": "^2.1.5",
+        "@stll/stdnum": "^2.3.0",
       },
       "devDependencies": {
         "@stll/typescript-config": "workspace:*",
@@ -2129,19 +2129,19 @@
 
     "@stll/skills": ["@stll/skills@workspace:packages/skills"],
 
-    "@stll/stdnum": ["@stll/stdnum@2.1.5", "", { "optionalDependencies": { "@stll/stdnum-darwin-arm64": "2.1.5", "@stll/stdnum-darwin-x64": "2.1.5", "@stll/stdnum-linux-arm64-gnu": "2.1.5", "@stll/stdnum-linux-x64-gnu": "2.1.5", "@stll/stdnum-wasm": "2.1.5", "@stll/stdnum-win32-x64-msvc": "2.1.5" } }, "sha512-pBuYYInCkPRiR5Ye5vWfYZF7NS/2jszkq83EBFWMHXWNucirrdsYKELThX0GplQvZYSKO5L7WZXlBEWfuEJKig=="],
+    "@stll/stdnum": ["@stll/stdnum@2.3.0", "", { "optionalDependencies": { "@stll/stdnum-darwin-arm64": "2.3.0", "@stll/stdnum-darwin-x64": "2.3.0", "@stll/stdnum-linux-arm64-gnu": "2.3.0", "@stll/stdnum-linux-x64-gnu": "2.3.0", "@stll/stdnum-wasm": "2.3.0", "@stll/stdnum-win32-x64-msvc": "2.3.0" } }, "sha512-yI0gzhLj26RcYSmGSv0Z2wI4UT1Hpcnkmn8zbLwHaV17KDNPSxvuYdl9Ar+dF64cPO2Cs/22bbKAc9lUPGjx2w=="],
 
-    "@stll/stdnum-darwin-arm64": ["@stll/stdnum-darwin-arm64@2.1.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-rU4TtXszq8h1XS298QtnM45zkT34eFWJV84+MfZ8zJGYnFOM6ksrV9sAoLbau1PmAR1FdjrbIcHr04UxINadDQ=="],
+    "@stll/stdnum-darwin-arm64": ["@stll/stdnum-darwin-arm64@2.3.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-b7jNmjRuj+DYTTEZ2VPjl82vPX4esBDGBuYgurVl6i0QCjtDgIHZnbaejpGj1JWViVdqID0DGa/5oHwWoWL3Eg=="],
 
-    "@stll/stdnum-darwin-x64": ["@stll/stdnum-darwin-x64@2.1.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-FGIxWerh8E4ZF+8ion30NYKU7zd+ms5TdGy+OeeMUjMjpnFdghSWi1ROpBiYlPIEAfeN88SA2AKxKgRP86VRgA=="],
+    "@stll/stdnum-darwin-x64": ["@stll/stdnum-darwin-x64@2.3.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-Mqn3fzYTnt98VD1RtBmEqvQCGGv3AsU2FnZ2xfOQi279VUaC9VyqJRnJkM9o+iO4Se3Ld7/9fqkJ/9oQHIjIcA=="],
 
-    "@stll/stdnum-linux-arm64-gnu": ["@stll/stdnum-linux-arm64-gnu@2.1.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-CWNohzM0ycikWekBPMzH5Dn/FtBMDOSHy0RClaVLhPY1BNmAqGzCW3Im71M15njPJW9eUj1dRqEiOBczKxLm3A=="],
+    "@stll/stdnum-linux-arm64-gnu": ["@stll/stdnum-linux-arm64-gnu@2.3.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-j1p2NoL+CTTf82d6L3oHIYcIumSL8hPPEOs06PwXBo8OrnO8watgHkM8YuhFRKlQUmYd5w3/VoF4HisnYGrl8w=="],
 
-    "@stll/stdnum-linux-x64-gnu": ["@stll/stdnum-linux-x64-gnu@2.1.5", "", { "os": "linux", "cpu": "x64" }, "sha512-TexVKL4Xwm3+pbFPqka1Df7dWcm8cr8TTipPTo0xFvS02M3I96BvfaOrQbNuoAeaKWciwYXMWtUxXqSmkcttrg=="],
+    "@stll/stdnum-linux-x64-gnu": ["@stll/stdnum-linux-x64-gnu@2.3.0", "", { "os": "linux", "cpu": "x64" }, "sha512-CZqTDm2r+Pp7s2kvUi7dlHr0qHsSd3KiGnQIiaGVEWlKJqB8O0loLmnv6ZfLYfWgiQWcCTs0qTLFTyfqUYIrfQ=="],
 
-    "@stll/stdnum-wasm": ["@stll/stdnum-wasm@2.1.5", "", {}, "sha512-ioEAn1hP3POIRmuNq723qvvrQOVbvfuRb9ydUFamnFB26QxJ/uGwmnHMzgfdvkhnzgTM7CRr7JoXdxWPVTXHKA=="],
+    "@stll/stdnum-wasm": ["@stll/stdnum-wasm@2.3.0", "", {}, "sha512-VyJ5yYJPyVBQmNLDNKtAK4WIiH4S9hY8AYZGlNTg9Zkg44KrQRbUi1edcWdhn2wq9iDXGnzofEIYHiIvcUdvng=="],
 
-    "@stll/stdnum-win32-x64-msvc": ["@stll/stdnum-win32-x64-msvc@2.1.5", "", { "os": "win32", "cpu": "x64" }, "sha512-Mr/TMdLr3amm3lDbN+kZk8onHhVr1G98mV5HwL3VD4/vGIPP8SjQ1R6NsPetZU/xGiZvsaMqc/JCKN36KbZL6g=="],
+    "@stll/stdnum-win32-x64-msvc": ["@stll/stdnum-win32-x64-msvc@2.3.0", "", { "os": "win32", "cpu": "x64" }, "sha512-q3cIeZlYzPlKZupDiqXCsvyJ8AouECQ9yD0iqNiVn4IE689GsWk5MJ521K89ZZA52m2eDKbz5BUBtlq3l05zlg=="],
 
     "@stll/template-conditions": ["@stll/template-conditions@workspace:packages/template-conditions"],
 

--- a/packages/business-registries/README.md
+++ b/packages/business-registries/README.md
@@ -26,6 +26,19 @@ import { ares } from "@stll/business-registries";
 await ares.lookupByIco("27082440");
 ```
 
+Browser applications initialize the validation runtime once during startup. Calls
+are safe to share when several features initialize concurrently:
+
+```ts
+import { initialize } from "@stll/business-registries/browser";
+
+await initialize();
+```
+
+Registry identifier validators stay synchronous after initialization. Calling one
+before the runtime is ready throws `StdnumNotInitializedError`, also exported from
+the `/browser` subpath.
+
 ## Supported registries
 
 | Subpath   | Jurisdiction   | Registry                                                                                                                      |

--- a/packages/business-registries/package.json
+++ b/packages/business-registries/package.json
@@ -49,6 +49,7 @@
   "exports": {
     ".": "./src/index.ts",
     "./ares": "./src/ares/index.ts",
+    "./browser": "./src/browser.ts",
     "./brreg": "./src/brreg/index.ts",
     "./companies-house": "./src/companies-house/index.ts",
     "./denue": "./src/denue/index.ts",
@@ -79,7 +80,7 @@
   },
   "dependencies": {
     "@stll/country-codes": "workspace:*",
-    "@stll/stdnum": "^2.1.5"
+    "@stll/stdnum": "^2.3.0"
   },
   "devDependencies": {
     "@stll/typescript-config": "workspace:*",

--- a/packages/business-registries/src/browser.test.ts
+++ b/packages/business-registries/src/browser.test.ts
@@ -1,0 +1,13 @@
+import { expect, test } from "bun:test";
+
+import { validateIco } from "./ares/validation.js";
+import { initialize } from "./browser.js";
+
+test("browser initialization is shared and makes validators ready", async () => {
+  const first = initialize();
+  const second = initialize();
+
+  expect(second).toBe(first);
+  await first;
+  expect(validateIco("27082440")).toBe(true);
+});

--- a/packages/business-registries/src/browser.test.ts
+++ b/packages/business-registries/src/browser.test.ts
@@ -1,13 +1,46 @@
 import { expect, test } from "bun:test";
 
-import { validateIco } from "./ares/validation.js";
-import { initialize } from "./browser.js";
+test("browser initialization gates and readies validators", async () => {
+  const child = Bun.spawn({
+    cmd: [
+      process.execPath,
+      "--conditions=browser",
+      "-e",
+      `
+        import { validateIco } from "@stll/business-registries/ares";
+        import {
+          initialize,
+          StdnumNotInitializedError,
+        } from "@stll/business-registries/browser";
 
-test("browser initialization is shared and makes validators ready", async () => {
-  const first = initialize();
-  const second = initialize();
+        let rejected = false;
+        try {
+          validateIco("27082440");
+        } catch (error) {
+          rejected = error instanceof StdnumNotInitializedError;
+        }
+        if (!rejected) {
+          throw new Error("Expected validation to require browser initialization");
+        }
 
-  expect(second).toBe(first);
-  await first;
-  expect(validateIco("27082440")).toBe(true);
+        const first = initialize();
+        const second = initialize();
+        if (first !== second) {
+          throw new Error("Expected concurrent initialization to share one promise");
+        }
+        await first;
+        if (!validateIco("27082440")) {
+          throw new Error("Expected validation to work after browser initialization");
+        }
+      `,
+    ],
+    stderr: "pipe",
+  });
+  const [exitCode, stderr] = await Promise.all([
+    child.exited,
+    new Response(child.stderr).text(),
+  ]);
+
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
 });

--- a/packages/business-registries/src/browser.ts
+++ b/packages/business-registries/src/browser.ts
@@ -1,0 +1,1 @@
+export { initialize, StdnumNotInitializedError } from "@stll/stdnum/browser";


### PR DESCRIPTION
## Summary

- consume `@stll/stdnum` 2.3.0 for registry identifier validation
- expose an explicit `/browser` initializer and typed pre-initialization error
- document the browser startup contract and add a patch changeset

## Verification

- `bun test packages/business-registries/src` (503 passed, 36 skipped)
- `bun --filter @stll/business-registries typecheck`
- `bun --filter @stll/business-registries lint`
- `bun --filter @stll/business-registries build`
- `bun --filter @stll/business-registries pack:dry-run`
- packed standalone consumer built with Vite 8 and executed in Chrome: typed failure before initialization, concurrent initialization sharing, and synchronous validation after initialization
- affected monorepo lint, format, typecheck, tests, and structural guards via `bun run verify`

CC on behalf of jan-kubica

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added browser support for business registry validation.
  * Added an `initialize()` API, safely shareable across concurrent calls.
  * Registry validators become synchronous once initialization completes.
  * Added a clear error when validation is attempted before initialization.

* **Documentation**
  * Documented browser setup, initialization behaviour, and the exported initialization error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->