### PR TITLE
feat: distinguish verified and unverified AI citations

### DIFF
--- a/apps/api/scripts/seed-dev.ts
+++ b/apps/api/scripts/seed-dev.ts
@@ -3047,6 +3047,7 @@ const buildExportReviewJustificationContent = ({
               text: citationSeed.statement,
               citations: [
                 {
+                  citationStatus: "verified",
                   blockId: deriveBlockId({
                     paraId: null,
                     index: citationSeed.blockIndex,

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -64,6 +64,7 @@ export type {
   CentsAmount,
   DecisionSection,
   DocxFolioJustificationBlock,
+  DocxFolioJustificationCitation,
   DocumentAst,
   EmptyAst,
   EntityKind,

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -64,7 +64,6 @@ export type {
   CentsAmount,
   DecisionSection,
   DocxFolioJustificationBlock,
-  DocxFolioJustificationCitation,
   DocumentAst,
   EmptyAst,
   EntityKind,

--- a/apps/api/src/db/schema/common.ts
+++ b/apps/api/src/db/schema/common.ts
@@ -97,20 +97,25 @@ export type PdfBatesJustificationBlock = {
   }[];
 };
 
+/** A single DOCX citation, discriminated by whether its quote was
+ *  grounded against an allow-listed source block at extraction time.
+ *
+ *  - `verified`: the quote matched a real block. It carries the block's
+ *    literal text (rendered as the quote without re-parsing the DOCX)
+ *    and the `blockId` a folio editor scrolls to.
+ *  - `unverified`: the model produced a quote that matched no source
+ *    block. There is no navigable block, so only the model's raw text
+ *    is kept and the client renders it as a non-navigable hint. */
+export type DocxFolioJustificationCitation =
+  | { citationStatus: "verified"; blockId: string; text: string }
+  | { citationStatus: "unverified"; text: string };
+
 export type DocxFolioJustificationBlock = {
   kind: "docx-folio";
   fileFieldId: SafeId<"field">;
   statements: {
     text: string;
-    /** Each cite carries the block's literal text captured at
-     *  extraction time so the cell-click peek can render the quoted
-     *  source without re-parsing the DOCX or fetching anything else.
-     *  `blockId` lets a folio editor (Phase 2b) scroll to the same
-     *  paragraph the chat editor would. */
-    citations: {
-      blockId: string;
-      text: string;
-    }[];
+    citations: DocxFolioJustificationCitation[];
   }[];
 };
 

--- a/apps/api/src/handlers/playbooks/review-extract.ts
+++ b/apps/api/src/handlers/playbooks/review-extract.ts
@@ -131,6 +131,11 @@ const collectDocxCitations = (
     }
     for (const statement of block.statements) {
       for (const cite of statement.citations) {
+        // Only verified citations carry a navigable block id; unverified
+        // hints have no anchor for scroll or one-click fix.
+        if (cite.citationStatus === "unverified") {
+          continue;
+        }
         if (seen.has(cite.blockId)) {
           continue;
         }

--- a/apps/api/src/handlers/reports/build-report-data.test.ts
+++ b/apps/api/src/handlers/reports/build-report-data.test.ts
@@ -297,7 +297,13 @@ describe("assembleReportData", () => {
               statements: [
                 {
                   text: "stmt",
-                  citations: [{ blockId: "b1", text: "Clause 12.1 quoted." }],
+                  citations: [
+                    {
+                      citationStatus: "verified",
+                      blockId: "b1",
+                      text: "Clause 12.1 quoted.",
+                    },
+                  ],
                 },
               ],
             },

--- a/apps/api/src/handlers/reports/build-report-data.ts
+++ b/apps/api/src/handlers/reports/build-report-data.ts
@@ -230,7 +230,11 @@ const citationFromJustification = (
   for (const block of content.blocks) {
     if (block.kind === "docx-folio") {
       for (const statement of block.statements) {
-        const cite = statement.citations.find((c) => c.text.length > 0);
+        // A report quotes grounded source language only: skip unverified
+        // citations, whose text is the model's ungrounded hint.
+        const cite = statement.citations.find(
+          (c) => c.citationStatus !== "unverified" && c.text.length > 0,
+        );
         if (cite) {
           return cite.text;
         }

--- a/apps/api/src/handlers/reports/dd-report-template.test.ts
+++ b/apps/api/src/handlers/reports/dd-report-template.test.ts
@@ -220,6 +220,7 @@ describe("Due Diligence Report built-in template", () => {
                   text: "stmt",
                   citations: [
                     {
+                      citationStatus: "verified",
                       blockId: "b1",
                       text: "Clause 12.1: governed by Czech law.",
                     },

--- a/apps/api/src/lib/workflow/citation-normalize.test.ts
+++ b/apps/api/src/lib/workflow/citation-normalize.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  citationTextMatches,
+  normalizeForCitationMatch,
+} from "@/api/lib/workflow/citation-normalize";
+
+// Invisible or easily-confused code points are written as escapes so the
+// test stays reviewable and deterministic (an editor cannot silently eat
+// a literal zero-width space).
+const NBSP = " ";
+const NNBSP = " "; // narrow no-break space
+const EN_QUAD = " ";
+const HAIR_SPACE = " ";
+const MMSP = " "; // medium mathematical space
+const IDEOGRAPHIC_SPACE = "　";
+const NB_HYPHEN = "‑";
+const FIGURE_DASH = "‒";
+const EN_DASH = "–";
+const EM_DASH = "—";
+const MINUS = "−";
+const ZWSP = "​";
+const ZWNJ = "‌";
+const ZWJ = "‍";
+const WORD_JOINER = "⁠";
+const BOM = "﻿";
+const COMBINING_ACUTE = "́";
+const LEFT_DQUOTE = "“";
+const RIGHT_DQUOTE = "”";
+const RIGHT_SQUOTE = "’";
+const PRIME = "′";
+const DOUBLE_PRIME = "″";
+
+const normalizeEqual = (a: string, b: string): boolean =>
+  normalizeForCitationMatch(a, { caseFold: false }) ===
+  normalizeForCitationMatch(b, { caseFold: false });
+
+describe("normalizeForCitationMatch — whitespace class", () => {
+  const spaces: [string, string][] = [
+    ["regular space", " "],
+    ["non-breaking space", NBSP],
+    ["narrow no-break space", NNBSP],
+    ["en quad", EN_QUAD],
+    ["hair space", HAIR_SPACE],
+    ["medium math space", MMSP],
+    ["ideographic space", IDEOGRAPHIC_SPACE],
+    ["tab", "\t"],
+    ["newline", "\n"],
+  ];
+
+  for (const [name, sep] of spaces) {
+    test(`${name} compares equal to a plain space`, () => {
+      expect(normalizeEqual(`Section${sep}12`, "Section 12")).toBe(true);
+    });
+  }
+
+  test("collapses runs of mixed whitespace and trims the ends", () => {
+    expect(normalizeEqual("  Article  \t 4 \n", "Article 4")).toBe(true);
+  });
+});
+
+describe("normalizeForCitationMatch — hyphen/dash class", () => {
+  const dashes: [string, string][] = [
+    ["hyphen-minus", "-"],
+    ["non-breaking hyphen", NB_HYPHEN],
+    ["figure dash", FIGURE_DASH],
+    ["en dash", EN_DASH],
+    ["em dash", EM_DASH],
+    ["minus sign", MINUS],
+  ];
+
+  for (const [name, dash] of dashes) {
+    test(`${name} folds to a common dash`, () => {
+      expect(normalizeEqual(`co${dash}operate`, "co-operate")).toBe(true);
+    });
+  }
+});
+
+describe("normalizeForCitationMatch — quote/apostrophe class", () => {
+  test("curly and straight double quotes compare equal", () => {
+    expect(
+      normalizeEqual(
+        `${LEFT_DQUOTE}Force Majeure${RIGHT_DQUOTE}`,
+        '"Force Majeure"',
+      ),
+    ).toBe(true);
+  });
+
+  test("curly and straight apostrophes compare equal", () => {
+    expect(
+      normalizeEqual(`the party${RIGHT_SQUOTE}s duty`, "the party's duty"),
+    ).toBe(true);
+  });
+
+  test("primes fold to straight quotes", () => {
+    expect(normalizeEqual(`5${PRIME} margin`, "5' margin")).toBe(true);
+    expect(normalizeEqual(`5${DOUBLE_PRIME} margin`, '5" margin')).toBe(true);
+  });
+});
+
+describe("normalizeForCitationMatch — Unicode form (NFC/NFD)", () => {
+  test("composed and decomposed accented characters compare equal", () => {
+    const composed = "résumé"; // é as U+00E9
+    const decomposed = `re${COMBINING_ACUTE}sume${COMBINING_ACUTE}`; // e + U+0301
+    expect(composed).not.toBe(decomposed);
+    expect(normalizeEqual(composed, decomposed)).toBe(true);
+  });
+
+  test("folds to a canonical accent rather than stripping it to ASCII", () => {
+    const decomposed = `Z${COMBINING_ACUTE}urich`;
+    const normalized = normalizeForCitationMatch(decomposed, {
+      caseFold: false,
+    });
+    expect(normalized).toBe("Źurich".normalize("NFC"));
+    // The accent survives — it is not flattened away.
+    expect(normalized).not.toBe("Zurich");
+  });
+});
+
+describe("normalizeForCitationMatch — zero-width class", () => {
+  const zeroWidth: [string, string][] = [
+    ["zero-width space", ZWSP],
+    ["zero-width non-joiner", ZWNJ],
+    ["zero-width joiner", ZWJ],
+    ["word joiner", WORD_JOINER],
+    ["BOM", BOM],
+  ];
+
+  for (const [name, zw] of zeroWidth) {
+    test(`${name} is stripped without inserting a boundary`, () => {
+      expect(normalizeEqual(`Ver${zw}trag`, "Vertrag")).toBe(true);
+    });
+  }
+});
+
+describe("normalizeForCitationMatch — case folding", () => {
+  test("case-insensitive by default", () => {
+    expect(
+      normalizeForCitationMatch("The PARTY") ===
+        normalizeForCitationMatch("the party"),
+    ).toBe(true);
+  });
+
+  test("case-sensitive when disabled", () => {
+    expect(
+      normalizeForCitationMatch("The PARTY", { caseFold: false }) ===
+        normalizeForCitationMatch("the party", { caseFold: false }),
+    ).toBe(false);
+  });
+});
+
+describe("citationTextMatches — grounding decision", () => {
+  const source =
+    "The Seller shall indemnify the Buyer against all losses arising from a breach of this Agreement.";
+
+  test("a verbatim span of the block verifies", () => {
+    expect(citationTextMatches({ quote: "indemnify the Buyer", source })).toBe(
+      true,
+    );
+  });
+
+  test("an exact block match verifies", () => {
+    expect(citationTextMatches({ quote: source, source })).toBe(true);
+  });
+
+  test("text absent from the block does not verify", () => {
+    expect(
+      citationTextMatches({ quote: "terminate for convenience", source }),
+    ).toBe(false);
+  });
+
+  test("empty quote never verifies", () => {
+    expect(citationTextMatches({ quote: "   ", source })).toBe(false);
+  });
+
+  // The regression the feature exists to prevent: a genuine legal quote
+  // that differs from the stored block only by an NBSP, a curly
+  // apostrophe, a dash variant, and a decomposed accent must still verify.
+  test("real quote differing only by NBSP/curly-quote/dash/NFC still verifies", () => {
+    const block = `Le vendeur s${RIGHT_SQUOTE}engage à indemniser l${RIGHT_SQUOTE}acheteur${NBSP}${EM_DASH} sans délai${NBSP}${EM_DASH} de toute perte.`;
+    const quote = `s'engage à indemniser l'acheteur - sans de${COMBINING_ACUTE}lai - de toute perte`;
+    expect(citationTextMatches({ quote, source: block })).toBe(true);
+  });
+});

--- a/apps/api/src/lib/workflow/citation-normalize.ts
+++ b/apps/api/src/lib/workflow/citation-normalize.ts
@@ -1,0 +1,114 @@
+/**
+ * Canonical normalizer for deciding whether an AI citation's quoted
+ * text corresponds to real source content.
+ *
+ * A citation is *verified* when its quote matches an allow-listed
+ * source block and *unverified* when it matches nothing. That decision
+ * must never hinge on a cosmetic character difference: a non-breaking
+ * space, a curly apostrophe, an en dash, or a decomposed accent inside
+ * an otherwise-identical quote must still compare equal. Every
+ * comparison site routes through the single normalizer here so the
+ * folding rules can never drift per call site.
+ *
+ * The normalized form is for COMPARISON ONLY. The displayed citation
+ * always keeps its original characters — accents, spacing, and quotes
+ * are preserved verbatim for the reader; only the comparison key is
+ * folded.
+ */
+
+export type CitationNormalizeOptions = {
+  /**
+   * Fold case before comparing. Defaults to true: legal quotes are
+   * frequently re-cased ("The Party" vs "the party") without changing
+   * which source they point at. The displayed text is never lowered.
+   */
+  caseFold?: boolean;
+};
+
+// Zero-width code points carry no visible content but break naive
+// equality. Stripped outright (not spaced) so a zero-width joiner
+// sitting between two words does not manufacture a word boundary.
+// Written as escaped alternation rather than a character class: a class
+// containing a joiner trips no-misleading-character-class, and escapes
+// keep the invisible code points reviewable.
+//   U+200B ZERO WIDTH SPACE      U+200C ZERO WIDTH NON-JOINER
+//   U+200D ZERO WIDTH JOINER     U+2060 WORD JOINER
+//   U+FEFF ZERO WIDTH NO-BREAK SPACE (BOM)
+const ZERO_WIDTH = /\u200B|\u200C|\u200D|\u2060|\uFEFF/gu;
+
+// Dash-like separators folded to ASCII hyphen-minus. Legal text mixes
+// these freely (hyphenated terms, numeric ranges, minus signs):
+//   U+002D HYPHEN-MINUS        U+2010 HYPHEN
+//   U+2011 NON-BREAKING HYPHEN U+2012 FIGURE DASH
+//   U+2013 EN DASH             U+2014 EM DASH
+//   U+2015 HORIZONTAL BAR      U+2212 MINUS SIGN
+const DASHES = /[-‐‑‒–—―−]/gu;
+
+// Single-quote-like marks folded to a straight apostrophe:
+//   U+2018/U+2019 curly single quotes  U+201A/U+201B low/high-reversed
+//   U+2032 PRIME                        U+2035 REVERSED PRIME
+const SINGLE_QUOTES = /[‘’‚‛′‵]/gu;
+
+// Double-quote-like marks folded to a straight quotation mark:
+//   U+201C/U+201D curly double quotes  U+201E/U+201F low/high-reversed
+//   U+2033 DOUBLE PRIME                 U+2036 REVERSED DOUBLE PRIME
+const DOUBLE_QUOTES = /[“”„‟″‶]/gu;
+
+// Runs of any Unicode whitespace collapse to a single ASCII space.
+// The JS `\s` class already covers tab, newline, NBSP (U+00A0), narrow
+// no-break space (U+202F), the U+2000–U+200A range, U+205F, U+3000, and
+// the line/paragraph separators, so a dedicated space table is not
+// needed here — only the zero-width strip above, which `\s` omits.
+const WHITESPACE_RUN = /\s+/gu;
+
+/**
+ * Fold a string to its comparison key. Order matters: compose accents
+ * first (so "e" + combining acute and precomposed "é" converge), strip
+ * zero-width, fold dash/quote variants, then collapse whitespace and
+ * trim. Case folding, when enabled, runs last on the already-composed
+ * form.
+ */
+export const normalizeForCitationMatch = (
+  text: string,
+  { caseFold = true }: CitationNormalizeOptions = {},
+): string => {
+  const folded = text
+    .normalize("NFC")
+    .replace(ZERO_WIDTH, "")
+    .replace(DASHES, "-")
+    .replace(SINGLE_QUOTES, "'")
+    .replace(DOUBLE_QUOTES, '"')
+    .replace(WHITESPACE_RUN, " ")
+    .trim();
+  return caseFold ? folded.toLowerCase() : folded;
+};
+
+export type CitationTextMatchesOptions = CitationNormalizeOptions & {
+  quote: string;
+  source: string;
+};
+
+/**
+ * True when `quote` corresponds to `source` after normalization.
+ *
+ * A citation is often a span of a larger paragraph, so an exact match
+ * is tried first and then contiguous containment of the normalized
+ * quote within the normalized source. The match is deterministic and
+ * bounded — no fuzzy or edit-distance scoring — so a "verified" verdict
+ * always means the exact folded characters are present in the source.
+ */
+export const citationTextMatches = ({
+  quote,
+  source,
+  caseFold,
+}: CitationTextMatchesOptions): boolean => {
+  const normalizedQuote = normalizeForCitationMatch(quote, { caseFold });
+  if (normalizedQuote.length === 0) {
+    return false;
+  }
+  const normalizedSource = normalizeForCitationMatch(source, { caseFold });
+  if (normalizedQuote === normalizedSource) {
+    return true;
+  }
+  return normalizedSource.includes(normalizedQuote);
+};

--- a/apps/api/src/lib/workflow/citation-normalize.ts
+++ b/apps/api/src/lib/workflow/citation-normalize.ts
@@ -100,7 +100,7 @@ export type CitationTextMatchesOptions = CitationNormalizeOptions & {
 export const citationTextMatches = ({
   quote,
   source,
-  caseFold,
+  caseFold = true,
 }: CitationTextMatchesOptions): boolean => {
   const normalizedQuote = normalizeForCitationMatch(quote, { caseFold });
   if (normalizedQuote.length === 0) {

--- a/apps/api/src/lib/workflow/generate-batch.test.ts
+++ b/apps/api/src/lib/workflow/generate-batch.test.ts
@@ -234,6 +234,7 @@ describe("justifications", () => {
               text: "Docx fact.",
               citations: [
                 {
+                  citationStatus: "verified",
                   blockId: deriveBlockId({
                     paraId: null,
                     index: 42,

--- a/apps/api/src/lib/workflow/parse-justifications.test.ts
+++ b/apps/api/src/lib/workflow/parse-justifications.test.ts
@@ -151,8 +151,16 @@ describe("normalizeJustification — docx-folio branch", () => {
               {
                 text: "The defendant breached.",
                 citations: [
-                  { blockId: "AAAA0001", text: "First paragraph text." },
-                  { blockId: "seq-0002", text: "Second paragraph text." },
+                  {
+                    citationStatus: "verified",
+                    blockId: "AAAA0001",
+                    text: "First paragraph text.",
+                  },
+                  {
+                    citationStatus: "verified",
+                    blockId: "seq-0002",
+                    text: "Second paragraph text.",
+                  },
                 ],
               },
             ],
@@ -184,7 +192,11 @@ describe("normalizeJustification — docx-folio branch", () => {
               {
                 text: "claim",
                 citations: [
-                  { blockId: "AAAA0001", text: "First paragraph text." },
+                  {
+                    citationStatus: "verified",
+                    blockId: "AAAA0001",
+                    text: "First paragraph text.",
+                  },
                 ],
               },
             ],
@@ -204,10 +216,138 @@ describe("normalizeJustification — docx-folio branch", () => {
     ];
 
     // "BBBB9999" passes isFolioBlockId structurally but is absent from
-    // blocksById, and "seq-9999" is absent too — both dropped.
+    // blocksById, and "seq-9999" is absent too. Both are id-shaped tokens
+    // with no readable quote, so both drop and the statement is empty.
     expect(unwrap(normalizeJustification({ justification, filenames }))).toBe(
       null,
     );
+  });
+
+  test("surfaces an ungrounded prose quote as an unverified citation", () => {
+    const justification: AIJustificationOutput = [
+      {
+        file: "brief",
+        statements: [
+          {
+            text: "claim",
+            citations: ["The tenant waived all remedies."], // not in any block
+          },
+        ],
+      },
+    ];
+
+    expect(
+      unwrap(normalizeJustification({ justification, filenames })),
+    ).toEqual({
+      content: {
+        version: 1,
+        blocks: [
+          {
+            kind: "docx-folio",
+            fileFieldId: field("f-docx"),
+            statements: [
+              {
+                text: "claim",
+                citations: [
+                  {
+                    citationStatus: "unverified",
+                    text: "The tenant waived all remedies.",
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+      fileFieldIds: [field("f-docx")],
+    });
+  });
+
+  test("rescues a pasted quote that is a verbatim span of a block as verified", () => {
+    const justification: AIJustificationOutput = [
+      {
+        file: "brief",
+        // A span of "First paragraph text." — resolves to that block.
+        statements: [{ text: "claim", citations: ["First paragraph"] }],
+      },
+    ];
+
+    expect(
+      unwrap(normalizeJustification({ justification, filenames })),
+    ).toEqual({
+      content: {
+        version: 1,
+        blocks: [
+          {
+            kind: "docx-folio",
+            fileFieldId: field("f-docx"),
+            statements: [
+              {
+                text: "claim",
+                citations: [
+                  {
+                    citationStatus: "verified",
+                    blockId: "AAAA0001",
+                    text: "First paragraph text.",
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+      fileFieldIds: [field("f-docx")],
+    });
+  });
+
+  test("rescues a quote as verified despite dash and whitespace differences", () => {
+    const legalFilenames: JustificationFilenames = [
+      {
+        kind: "docx-folio",
+        original: "Lease.docx",
+        simplified: "lease",
+        fileFieldId: field("f-lease"),
+        // Stored block uses a non-breaking space and an en dash.
+        blocksById: new Map([
+          ["AAAA0009", "Rent is due on the first – no grace period."],
+        ]),
+      },
+    ];
+    const justification: AIJustificationOutput = [
+      {
+        file: "lease",
+        statements: [
+          {
+            // Quote uses a plain space and a hyphen — must still verify.
+            text: "claim",
+            citations: ["Rent is due on the first - no grace period."],
+          },
+        ],
+      },
+    ];
+
+    const result = unwrap(
+      normalizeJustification({
+        justification,
+        filenames: legalFilenames,
+      }),
+    );
+    expect(result).not.toBeNull();
+    if (result === null) {
+      throw new Error("expected a normalized justification");
+    }
+    const block = result.content.blocks.at(0);
+    expect(block?.kind).toBe("docx-folio");
+    if (block?.kind !== "docx-folio") {
+      throw new Error("expected a docx-folio block");
+    }
+    expect(block.statements.at(0)?.citations).toEqual([
+      {
+        citationStatus: "verified",
+        blockId: "AAAA0009",
+        text: "Rent is due on the first – no grace period.",
+      },
+    ]);
   });
 });
 

--- a/apps/api/src/lib/workflow/parse-justifications.ts
+++ b/apps/api/src/lib/workflow/parse-justifications.ts
@@ -1,14 +1,14 @@
 import { Result } from "better-result";
 
-import { isFolioBlockId } from "@stll/folio-core/server";
-
 import type {
   DocxFolioJustificationBlock,
+  DocxFolioJustificationCitation,
   JustificationBlock,
   JustificationContent,
   PdfBatesJustificationBlock,
 } from "@/api/db/schema";
 import type { SafeId } from "@/api/lib/branded-types";
+import { citationTextMatches } from "@/api/lib/workflow/citation-normalize";
 
 export type JustificationFilename = {
   original: string;
@@ -94,6 +94,77 @@ const buildPdfBlock = (
   return { kind: "pdf-bates", fileFieldId: file.fileFieldId, statements };
 };
 
+// Resolve a model-supplied quote to an allow-listed block by normalized
+// text match. A citation is frequently a span of a larger paragraph, so
+// this rescues quotes the model pasted verbatim (rather than by id) even
+// when a non-breaking space, curly quote, dash variant, or decomposed
+// accent differs from the stored block. Returns the FIRST matching block
+// so the resolved id is deterministic given a stable block order.
+type ResolvedBlock = { blockId: string; text: string };
+
+const resolveQuoteToBlock = (
+  quote: string,
+  blocksById: ReadonlyMap<string, string>,
+): ResolvedBlock | null => {
+  for (const [blockId, text] of blocksById) {
+    if (citationTextMatches({ quote, source: text })) {
+      return { blockId, text };
+    }
+  }
+  return null;
+};
+
+// Classify one raw citation string against the DOCX allow-list.
+//   - A string that is itself an allow-listed block id -> verified (embed
+//     the block's literal text so the client renders the quote without a
+//     document round-trip).
+//   - Otherwise, a string that reads as prose (contains whitespace) is
+//     treated as a pasted quote: matched to a block -> verified; matched
+//     to nothing -> unverified, kept as a non-navigable hint so a lawyer
+//     sees the model gestured at a source that isn't grounded.
+//   - A single opaque token that is neither an allow-listed id nor prose
+//     (a hallucinated/malformed id like `seq-9999`) carries no readable
+//     quote and cannot be grounded, so it is dropped.
+//
+// Note: `isFolioBlockId` is a structural refinement that accepts almost
+// any non-empty string as a possible paraId, so it cannot separate a real
+// id from a pasted quote. Allow-list membership is the true gate; a raw
+// blockId that is not in the map is exactly a hallucinated reference.
+type ClassifiedCitation = DocxFolioJustificationCitation | null;
+
+const classifyDocxCitation = (
+  raw: string,
+  blocksById: ReadonlyMap<string, string>,
+): ClassifiedCitation => {
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) {
+    return null;
+  }
+
+  const directText = blocksById.get(trimmed);
+  if (directText !== undefined) {
+    return { citationStatus: "verified", blockId: trimmed, text: directText };
+  }
+
+  // A prose gate (contains whitespace) keeps a short opaque token from
+  // spuriously matching a block via substring containment and from being
+  // surfaced as an ungrounded "quote".
+  if (!/\s/u.test(trimmed)) {
+    return null;
+  }
+
+  const resolved = resolveQuoteToBlock(trimmed, blocksById);
+  if (resolved) {
+    return {
+      citationStatus: "verified",
+      blockId: resolved.blockId,
+      text: resolved.text,
+    };
+  }
+
+  return { citationStatus: "unverified", text: trimmed };
+};
+
 const buildDocxBlock = (
   file: Extract<JustificationFilename, { kind: "docx-folio" }>,
   rawStatements: AIJustificationOutput[number]["statements"],
@@ -106,29 +177,31 @@ const buildDocxBlock = (
       continue;
     }
 
-    // Citations on a DOCX file are folio block IDs minted by
-    // `deriveBlockId` (paraId verbatim, or `seq-NNNN` fallback).
-    // Drop ids the model invented or that don't structurally pass
-    // the runtime check, then dedupe; embed the literal block text
-    // alongside each id so the frontend can render the quote
-    // without a round-trip to the document.
-    const seen = new Set<string>();
+    // Dedupe verified citations by resolved block id and unverified ones
+    // by their normalized-but-displayed raw text, so a statement never
+    // repeats the same source anchor or the same ungrounded hint.
+    const seenBlockIds = new Set<string>();
+    const seenUnverified = new Set<string>();
     const citations: DocxFolioJustificationBlock["statements"][number]["citations"] =
       [];
     for (const raw of statement.citations) {
-      const trimmed = raw.trim();
-      if (!isFolioBlockId(trimmed)) {
+      const classified = classifyDocxCitation(raw, file.blocksById);
+      if (classified === null) {
         continue;
       }
-      if (seen.has(trimmed)) {
+      if (classified.citationStatus === "verified") {
+        if (seenBlockIds.has(classified.blockId)) {
+          continue;
+        }
+        seenBlockIds.add(classified.blockId);
+        citations.push(classified);
         continue;
       }
-      const blockText = file.blocksById.get(trimmed);
-      if (blockText === undefined) {
+      if (seenUnverified.has(classified.text)) {
         continue;
       }
-      seen.add(trimmed);
-      citations.push({ blockId: trimmed, text: blockText });
+      seenUnverified.add(classified.text);
+      citations.push(classified);
     }
 
     if (citations.length === 0) {

--- a/apps/api/src/lib/workflow/parse-justifications.ts
+++ b/apps/api/src/lib/workflow/parse-justifications.ts
@@ -2,13 +2,17 @@ import { Result } from "better-result";
 
 import type {
   DocxFolioJustificationBlock,
-  DocxFolioJustificationCitation,
   JustificationBlock,
   JustificationContent,
   PdfBatesJustificationBlock,
 } from "@/api/db/schema";
 import type { SafeId } from "@/api/lib/branded-types";
 import { citationTextMatches } from "@/api/lib/workflow/citation-normalize";
+
+// The stored citation shape, derived from the block type so it stays in
+// lockstep without a second import from the schema barrel.
+type DocxFolioJustificationCitation =
+  DocxFolioJustificationBlock["statements"][number]["citations"][number];
 
 export type JustificationFilename = {
   original: string;

--- a/apps/web/src/components/inspector/document-ai-source-bar.tsx
+++ b/apps/web/src/components/inspector/document-ai-source-bar.tsx
@@ -262,9 +262,17 @@ export const DocumentAiSourceBar = ({
       return;
     }
     const firstDocxCitation = citations.find(
-      (citation) => citation.kind === "docx-folio",
+      (citation) =>
+        citation.kind === "docx-folio" &&
+        citation.citationStatus === "verified",
     );
-    if (!firstDocxCitation) {
+    // Narrowed by the predicate above; only a verified docx citation
+    // carries a navigable block id.
+    if (
+      !firstDocxCitation ||
+      firstDocxCitation.kind !== "docx-folio" ||
+      firstDocxCitation.citationStatus !== "verified"
+    ) {
       return;
     }
     scrolledForDocxJustificationRef.current = justificationId;
@@ -332,6 +340,11 @@ export const DocumentAiSourceBar = ({
   })();
   const handleCitationClick = (citation: Citation) => {
     if (citation.kind === "docx-folio") {
+      // Unverified citations render non-clickable, but the handler stays
+      // total: a missing block has nowhere to scroll.
+      if (citation.citationStatus === "unverified") {
+        return;
+      }
       requestBlockScroll({
         tabId: activeTab.id,
         blockId: citation.blockId,
@@ -581,6 +594,11 @@ const useFolioBlockPage = (blockId: string): number | null => {
 const SOURCE_CITATION_CHIP_CLASS =
   "border-border bg-muted/64 text-foreground-strong-muted hover:bg-muted hover:text-foreground hover:border-foreground/24 inline-flex shrink-0 items-center rounded-md border px-1.5 py-0.5 align-middle text-[10.5px] font-medium tracking-tight transition-colors";
 
+// Unverified: no border, no hover affordance, dashed underline so it
+// reads as plain text the reader must not trust as a source anchor.
+const UNVERIFIED_CITATION_CHIP_CLASS =
+  "text-muted-foreground inline-flex shrink-0 items-center gap-1 align-middle text-[10.5px] font-medium tracking-tight italic underline decoration-dotted underline-offset-2";
+
 const SourceCitationChip = ({
   citation,
   onClick,
@@ -588,6 +606,7 @@ const SourceCitationChip = ({
   citation: Citation;
   onClick: () => void;
 }) => {
+  const t = useTranslations();
   if (citation.kind === "pdf-bates") {
     return (
       <button
@@ -597,6 +616,17 @@ const SourceCitationChip = ({
       >
         p.&nbsp;{citation.pageNumber}
       </button>
+    );
+  }
+
+  if (citation.citationStatus === "unverified") {
+    return (
+      <span
+        className={UNVERIFIED_CITATION_CHIP_CLASS}
+        title={t("common.unverifiedCitationHint")}
+      >
+        {t("common.unverified")}
+      </span>
     );
   }
 

--- a/apps/web/src/components/inspector/document-ai-source-bar.tsx
+++ b/apps/web/src/components/inspector/document-ai-source-bar.tsx
@@ -261,18 +261,14 @@ export const DocumentAiSourceBar = ({
     if (scrolledForDocxJustificationRef.current === justificationId) {
       return;
     }
+    // The inferred type predicate narrows the result to a verified docx
+    // citation, the only kind that carries a navigable block id.
     const firstDocxCitation = citations.find(
       (citation) =>
         citation.kind === "docx-folio" &&
         citation.citationStatus === "verified",
     );
-    // Narrowed by the predicate above; only a verified docx citation
-    // carries a navigable block id.
-    if (
-      !firstDocxCitation ||
-      firstDocxCitation.kind !== "docx-folio" ||
-      firstDocxCitation.citationStatus !== "verified"
-    ) {
+    if (!firstDocxCitation) {
       return;
     }
     scrolledForDocxJustificationRef.current = justificationId;

--- a/apps/web/src/i18n/langs/ar.json
+++ b/apps/web/src/i18n/langs/ar.json
@@ -976,6 +976,8 @@
     "undo": "Undo",
     "unexpectedError": "حدث خطأ غير متوقع. يُرجى التواصل مع الدعم.",
     "unpin": "إلغاء التثبيت",
+    "unverified": "غير مُتحقَّق منه",
+    "unverifiedCitationHint": "تعذّر مطابقة هذا الاقتباس مع المستند المصدر.",
     "uploadFiles": "رفع الملفات",
     "urlIdentifier": "المعرّف",
     "urlIdentifierPlaceholder": "my-organization",

--- a/apps/web/src/i18n/langs/cs.json
+++ b/apps/web/src/i18n/langs/cs.json
@@ -976,6 +976,8 @@
     "undo": "Undo",
     "unexpectedError": "Došlo k neočekávané chybě. Kontaktujte podporu.",
     "unpin": "Odepnout",
+    "unverified": "Neověřeno",
+    "unverifiedCitationHint": "Tuto citaci se nepodařilo spárovat se zdrojovým dokumentem.",
     "uploadFiles": "Nahrát soubory",
     "urlIdentifier": "Slug",
     "urlIdentifierPlaceholder": "moje-organizace",

--- a/apps/web/src/i18n/langs/de.json
+++ b/apps/web/src/i18n/langs/de.json
@@ -976,6 +976,8 @@
     "undo": "Undo",
     "unexpectedError": "Ein unerwarteter Fehler ist aufgetreten. Bitte kontaktieren Sie den Support.",
     "unpin": "Lösen",
+    "unverified": "Nicht verifiziert",
+    "unverifiedCitationHint": "Dieses Zitat konnte dem Quelldokument nicht zugeordnet werden.",
     "uploadFiles": "Dateien hochladen",
     "urlIdentifier": "URL-Kennung",
     "urlIdentifierPlaceholder": "meine-organisation",

--- a/apps/web/src/i18n/langs/en.json
+++ b/apps/web/src/i18n/langs/en.json
@@ -976,6 +976,8 @@
     "undo": "Undo",
     "unexpectedError": "An unexpected error occurred. Please contact support.",
     "unpin": "Unpin",
+    "unverified": "Unverified",
+    "unverifiedCitationHint": "This quote could not be matched to the source document.",
     "uploadFiles": "Upload files",
     "urlIdentifier": "Slug",
     "urlIdentifierPlaceholder": "my-organization",

--- a/apps/web/src/i18n/langs/es.json
+++ b/apps/web/src/i18n/langs/es.json
@@ -976,6 +976,8 @@
     "undo": "Undo",
     "unexpectedError": "Se produjo un error inesperado. Contacte con soporte.",
     "unpin": "Desfijar",
+    "unverified": "Sin verificar",
+    "unverifiedCitationHint": "No se pudo asociar esta cita con el documento de origen.",
     "uploadFiles": "Subir archivos",
     "urlIdentifier": "Slug",
     "urlIdentifierPlaceholder": "mi-organizacion",

--- a/apps/web/src/i18n/langs/et.json
+++ b/apps/web/src/i18n/langs/et.json
@@ -976,6 +976,8 @@
     "undo": "Undo",
     "unexpectedError": "Ilmnes ootamatu viga. Palun pöörduge klienditoe poole.",
     "unpin": "Eemalda kinnitamine",
+    "unverified": "Kontrollimata",
+    "unverifiedCitationHint": "Seda tsitaati ei õnnestunud lähtedokumendiga sobitada.",
     "uploadFiles": "Laadi failid üles",
     "urlIdentifier": "Lühitunnus",
     "urlIdentifierPlaceholder": "minu-organisatsioon",

--- a/apps/web/src/i18n/langs/fr.json
+++ b/apps/web/src/i18n/langs/fr.json
@@ -976,6 +976,8 @@
     "undo": "Undo",
     "unexpectedError": "Une erreur inattendue est survenue. Veuillez contacter le support.",
     "unpin": "Désépingler",
+    "unverified": "Non vérifié",
+    "unverifiedCitationHint": "Cette citation n'a pas pu être associée au document source.",
     "uploadFiles": "Importer des fichiers",
     "urlIdentifier": "Identifiant URL",
     "urlIdentifierPlaceholder": "mon-organisation",

--- a/apps/web/src/i18n/langs/hu.json
+++ b/apps/web/src/i18n/langs/hu.json
@@ -976,6 +976,8 @@
     "undo": "Undo",
     "unexpectedError": "Váratlan hiba történt. Kérjük, lépjen kapcsolatba az ügyfélszolgálattal.",
     "unpin": "Rögzítés feloldása",
+    "unverified": "Nem ellenőrzött",
+    "unverifiedCitationHint": "Ezt az idézetet nem sikerült a forrásdokumentumhoz párosítani.",
     "uploadFiles": "Fájlok feltöltése",
     "urlIdentifier": "Azonosító (slug)",
     "urlIdentifierPlaceholder": "szervezetem",

--- a/apps/web/src/i18n/langs/lt.json
+++ b/apps/web/src/i18n/langs/lt.json
@@ -976,6 +976,8 @@
     "undo": "Undo",
     "unexpectedError": "Įvyko netikėta klaida. Susisiekite su palaikymo tarnyba.",
     "unpin": "Atsegti",
+    "unverified": "Nepatvirtinta",
+    "unverifiedCitationHint": "Nepavyko susieti šios citatos su šaltinio dokumentu.",
     "uploadFiles": "Įkelti failus",
     "urlIdentifier": "URL identifikatorius",
     "urlIdentifierPlaceholder": "mano-organizacija",

--- a/apps/web/src/i18n/langs/lv.json
+++ b/apps/web/src/i18n/langs/lv.json
@@ -976,6 +976,8 @@
     "undo": "Undo",
     "unexpectedError": "Radās neparedzēta kļūda. Lūdzu, sazinieties ar atbalsta dienestu.",
     "unpin": "Atspraust",
+    "unverified": "Nav pārbaudīts",
+    "unverifiedCitationHint": "Šo citātu neizdevās sasaistīt ar avota dokumentu.",
     "uploadFiles": "Augšupielādēt failus",
     "urlIdentifier": "Identifikators",
     "urlIdentifierPlaceholder": "mana-organizacija",

--- a/apps/web/src/i18n/langs/messages.gen.ts
+++ b/apps/web/src/i18n/langs/messages.gen.ts
@@ -979,6 +979,8 @@ type Messages = {
     "undo": "Undo";
     "unexpectedError": "An unexpected error occurred. Please contact support.";
     "unpin": "Unpin";
+    "unverified": "Unverified";
+    "unverifiedCitationHint": "This quote could not be matched to the source document.";
     "uploadFiles": "Upload files";
     "urlIdentifier": "Slug";
     "urlIdentifierPlaceholder": "my-organization";

--- a/apps/web/src/i18n/langs/pl.json
+++ b/apps/web/src/i18n/langs/pl.json
@@ -976,6 +976,8 @@
     "undo": "Undo",
     "unexpectedError": "Wystąpił nieoczekiwany błąd. Skontaktuj się z pomocą techniczną.",
     "unpin": "Odepnij",
+    "unverified": "Niezweryfikowane",
+    "unverifiedCitationHint": "Nie udało się dopasować tego cytatu do dokumentu źródłowego.",
     "uploadFiles": "Prześlij pliki",
     "urlIdentifier": "Slug",
     "urlIdentifierPlaceholder": "moja-organizacja",

--- a/apps/web/src/i18n/langs/pt-BR.json
+++ b/apps/web/src/i18n/langs/pt-BR.json
@@ -976,6 +976,8 @@
     "undo": "Undo",
     "unexpectedError": "Ocorreu um erro inesperado. Entre em contato com o suporte.",
     "unpin": "Desafixar",
+    "unverified": "Não verificado",
+    "unverifiedCitationHint": "Não foi possível associar esta citação ao documento de origem.",
     "uploadFiles": "Carregar arquivos",
     "urlIdentifier": "Slug",
     "urlIdentifierPlaceholder": "minha-organização",

--- a/apps/web/src/i18n/langs/sk.json
+++ b/apps/web/src/i18n/langs/sk.json
@@ -976,6 +976,8 @@
     "undo": "Undo",
     "unexpectedError": "Vyskytla sa neočakávaná chyba. Kontaktujte podporu.",
     "unpin": "Odopnúť",
+    "unverified": "Neoverené",
+    "unverifiedCitationHint": "Túto citáciu sa nepodarilo priradiť k zdrojovému dokumentu.",
     "uploadFiles": "Nahrať súbory",
     "urlIdentifier": "Slug",
     "urlIdentifierPlaceholder": "moja-organizacia",

--- a/apps/web/src/lib/citations.test.ts
+++ b/apps/web/src/lib/citations.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from "bun:test";
+
+import { iterateJustificationCitations } from "@/lib/citations";
+import type { JustificationContent } from "@/lib/types";
+
+describe("iterateJustificationCitations — docx-folio status threading", () => {
+  test("a verified citation yields a navigable blockId", () => {
+    const content: JustificationContent = {
+      version: 1,
+      blocks: [
+        {
+          kind: "docx-folio",
+          fileFieldId: "field-1",
+          statements: [
+            {
+              text: "The buyer indemnifies the seller.",
+              citations: [
+                {
+                  citationStatus: "verified",
+                  blockId: "AAAA0001",
+                  text: "The buyer indemnifies the seller.",
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    const citations = [...iterateJustificationCitations(content)];
+    expect(citations).toEqual([
+      {
+        kind: "docx-folio",
+        citationStatus: "verified",
+        fileFieldId: "field-1",
+        blockId: "AAAA0001",
+        text: "The buyer indemnifies the seller.",
+      },
+    ]);
+  });
+
+  test("an unverified citation yields no navigable target", () => {
+    const content: JustificationContent = {
+      version: 1,
+      blocks: [
+        {
+          kind: "docx-folio",
+          fileFieldId: "field-1",
+          statements: [
+            {
+              text: "claim",
+              citations: [
+                {
+                  citationStatus: "unverified",
+                  text: "The tenant waived all remedies.",
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    const citation = [...iterateJustificationCitations(content)].at(0);
+    expect(citation?.kind).toBe("docx-folio");
+    if (citation?.kind !== "docx-folio") {
+      throw new Error("expected a docx-folio citation");
+    }
+    expect(citation.citationStatus).toBe("unverified");
+    // The union has no `blockId` on the unverified branch — the click
+    // handlers key navigation off its presence, so an unverified citation
+    // is non-navigable by construction.
+    expect("blockId" in citation).toBe(false);
+  });
+});

--- a/apps/web/src/lib/citations.ts
+++ b/apps/web/src/lib/citations.ts
@@ -19,15 +19,32 @@ export type PdfBatesCitation = {
   pageNumber: number;
 };
 
-export type DocxFolioCitation = {
-  kind: "docx-folio";
-  fileFieldId: string;
-  blockId: string;
-  /** Captured at extraction time; the renderer shows it as a quote
-   *  so click-to-scroll is a navigation extra, not a prerequisite to
-   *  seeing the source. */
-  text: string;
-};
+/**
+ * A DOCX citation, discriminated by whether its quote was grounded
+ * against an allow-listed source block server-side.
+ *
+ * - `verified`: the quote matched a real block. It carries the block's
+ *   literal `text` (shown as the quote) and the `blockId` the renderer
+ *   navigates to; click-to-scroll is a navigation extra, not a
+ *   prerequisite to seeing the source.
+ * - `unverified`: the model's quote matched no source block. There is no
+ *   navigable block, so the renderer shows the raw `text` as a
+ *   non-clickable hint — an unverified citation is a hint, not a source.
+ */
+export type DocxFolioCitation =
+  | {
+      kind: "docx-folio";
+      citationStatus: "verified";
+      fileFieldId: string;
+      blockId: string;
+      text: string;
+    }
+  | {
+      kind: "docx-folio";
+      citationStatus: "unverified";
+      fileFieldId: string;
+      text: string;
+    };
 
 export type Citation = PdfBatesCitation | DocxFolioCitation;
 
@@ -57,8 +74,21 @@ export const iterateJustificationCitations = function* (
     }
     for (const statement of block.statements) {
       for (const citation of statement.citations) {
+        // Legacy justifications persisted before the verified/unverified
+        // split have no `citationStatus`; they were allow-listed at write
+        // time, so treat the absence as verified.
+        if (citation.citationStatus === "unverified") {
+          yield {
+            kind: "docx-folio",
+            citationStatus: "unverified",
+            fileFieldId: block.fileFieldId,
+            text: citation.text,
+          };
+          continue;
+        }
         yield {
           kind: "docx-folio",
+          citationStatus: "verified",
           fileFieldId: block.fileFieldId,
           blockId: citation.blockId,
           text: citation.text,

--- a/apps/web/src/lib/render-justification-content.tsx
+++ b/apps/web/src/lib/render-justification-content.tsx
@@ -92,17 +92,29 @@ export const renderJustificationContent = ({
       nodes.push(
         <Fragment key={`${statementKey}-text`}>{statement.text} </Fragment>,
       );
-      for (const [
-        citationIndex,
-        { blockId, text },
-      ] of statement.citations.entries()) {
-        const citation: Citation = {
-          kind: "docx-folio",
-          fileFieldId: block.fileFieldId,
-          blockId,
-          text,
-        };
-        consider(citation);
+      for (const [citationIndex, cite] of statement.citations.entries()) {
+        // Legacy rows without `citationStatus` were allow-listed at write
+        // time, so the absence resolves to a verified, navigable citation.
+        const citation: Citation =
+          cite.citationStatus === "unverified"
+            ? {
+                kind: "docx-folio",
+                citationStatus: "unverified",
+                fileFieldId: block.fileFieldId,
+                text: cite.text,
+              }
+            : {
+                kind: "docx-folio",
+                citationStatus: "verified",
+                fileFieldId: block.fileFieldId,
+                blockId: cite.blockId,
+                text: cite.text,
+              };
+        // An unverified citation has no navigable target, so it never
+        // seeds the peek's auto-scroll.
+        if (citation.citationStatus !== "unverified") {
+          consider(citation);
+        }
         const key = `${statementKey}-${citationIndex}`;
         nodes.push(renderCitation({ citation, key }));
       }

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -309,19 +309,25 @@ export type PdfBatesJustificationBlock = {
   }[];
 };
 
+/** A DOCX citation, discriminated by whether its quote was grounded
+ *  against an allow-listed source block server-side.
+ *
+ *  - `verified`: the quote matched a real block; carries the block's
+ *    literal text (rendered as the quote) and the `blockId` the folio
+ *    editor scrolls to.
+ *  - `unverified`: the model's quote matched no source block, so there
+ *    is no navigable block; the client renders the raw text as a
+ *    non-navigable hint. */
+export type DocxFolioJustificationCitation =
+  | { citationStatus: "verified"; blockId: string; text: string }
+  | { citationStatus: "unverified"; text: string };
+
 export type DocxFolioJustificationBlock = {
   kind: "docx-folio";
   fileFieldId: string;
   statements: {
     text: string;
-    /** Each cite carries the block's literal text captured at
-     *  extraction time so the cell-click peek can render the quoted
-     *  source without re-fetching anything. `blockId` matches the
-     *  folio editor's block IDs (Phase 2b: scroll-to-block). */
-    citations: {
-      blockId: string;
-      text: string;
-    }[];
+    citations: DocxFolioJustificationCitation[];
   }[];
 };
 

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/justification.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/justification.tsx
@@ -1,5 +1,6 @@
 import { useNavigate } from "@tanstack/react-router";
 import { produce } from "immer";
+import { useTranslations } from "use-intl";
 
 import { cn } from "@stll/ui/lib/utils";
 
@@ -146,12 +147,28 @@ type DocxQuoteProps = {
 };
 
 const DocxQuote = ({ citation }: DocxQuoteProps) => {
+  const t = useTranslations();
   const requestBlockScroll = useInspectorStore((s) => s.requestBlockScroll);
   const trimmed = citation.text.trim();
   const preview =
     trimmed.length > DOCX_CHIP_PREVIEW_CHARS
       ? `${trimmed.slice(0, DOCX_CHIP_PREVIEW_CHARS).trimEnd()}…`
       : trimmed || "¶";
+  if (citation.citationStatus === "unverified") {
+    // No navigable block: render the model's quote as plain, non-clickable
+    // text with an "unverified" affordance so it is never mistaken for a
+    // grounded source.
+    return (
+      <Tooltip
+        content={t("common.unverifiedCitationHint")}
+        render={
+          <span className="text-muted-foreground inline-flex max-w-[16rem] items-center gap-1 truncate align-baseline text-[11px] font-medium italic underline decoration-dotted underline-offset-2">
+            “{preview}” · {t("common.unverified")}
+          </span>
+        }
+      />
+    );
+  }
   return (
     <Tooltip
       content={trimmed || undefined}


### PR DESCRIPTION
## Verified vs unverified AI citations

Distinguishes, in the UI, a citation the AI grounded in real source content
from one it did not. A **verified** citation quotes text that actually
corresponds to an allow-listed source block and renders as a
clickable/navigable source reference (as today). An **unverified** citation
is a quote the model produced with no matching source: it renders as plain,
non-clickable text with a subtle "unverified" affordance so a reader is never
misled into trusting a citation that isn't grounded. An unverified citation is
a hint, not a source.

### Where the determination is computed

Server-side, at extraction time, in `parse-justifications.ts` — the one place
that already holds both the allow-list of real block ids and the source block
text. Each DOCX citation is classified as:

- **verified** when the cited string is itself an allow-listed block id, or
  when a pasted prose quote resolves (by normalized text match) to an
  allow-listed block. The block's literal text and its `blockId` are stored,
  so the client renders the quote and can navigate to it.
- **unverified** when a pasted prose quote matches no source block. The
  model's raw text is kept (no `blockId`) and surfaced as a non-navigable
  hint. Previously such citations were silently dropped.

The distinction is modelled as a discriminated union
(`citationStatus: "verified" | "unverified"`), not a boolean, and threaded
end-to-end: stored schema (`db/schema/common.ts`), the web citation union
(`lib/citations.ts` / `lib/types.ts`), and every renderer. Only verified
citations carry a navigable `blockId`, so an unverified citation cannot be
clicked through by construction. Reports and one-click-fix anchors consume
verified citations only.

### Normalization guarantees (the core of the change)

The verified/unverified decision must never hinge on a cosmetic character
difference. A single shared normalizer,
`apps/api/src/lib/workflow/citation-normalize.ts`, is the only comparison
point; the folding rules cannot drift per call site. It folds, for comparison
only (the displayed text always keeps its original characters):

- **Whitespace** — collapses runs to a single space and trims; treats
  non-breaking space (U+00A0), narrow no-break space (U+202F), the
  U+2000–U+200A range, U+205F, U+3000, tab, and newline as a normal space.
- **Hyphens/dashes** — folds hyphen-minus, hyphen (U+2010), non-breaking
  hyphen (U+2011), figure dash (U+2012), en dash (U+2013), em dash (U+2014),
  horizontal bar (U+2015), and minus sign (U+2212) to a common form.
- **Quotes/apostrophes** — folds curly single/double quotes
  (U+2018/U+2019/U+201C/U+201D), low/high variants, and primes to straight
  quotes.
- **Unicode form** — applies NFC so composed and decomposed accented
  characters compare equal (accents are preserved as characters, only the
  comparison key is canonicalized) — important for the international/legal
  corpus.
- **Zero-width** — strips U+200B/U+200C/U+200D, word joiner (U+2060), and BOM
  (U+FEFF) without inserting a boundary.
- **Case** — case-insensitive by default (configurable); never alters the
  displayed text.

Matching is exact-after-normalize first, then contiguous containment of the
normalized quote within a normalized source block (a citation is often a span
of a larger block). It is deterministic and bounded — no fuzzy/edit-distance
scoring — so "verified" always means the exact folded characters are present
in the source.

### UI

Verified citations render navigable (unchanged). Unverified citations render
as non-clickable plain text with an "unverified" label/tooltip, in both the
inspector source bar and the chat justification view. The label and hint are
translation keys (`common.unverified`, `common.unverifiedCitationHint`), added
across all supported languages.

### Tests

- `citation-normalize.test.ts` — per-class invariants (NBSP and the other
  Unicode spaces vs space, curly vs straight quotes, en/em/figure/nb dash vs
  hyphen, NFC composed vs decomposed accents, zero-width stripping, collapsed
  whitespace), plus a legal-text example (accents + NBSP + curly quote + dash)
  that must verify.
- `parse-justifications.test.ts` — a quote matching a block after
  normalization is verified; an ungrounded prose quote is unverified; a quote
  differing only by NBSP/dash still verifies; hallucinated id tokens are
  dropped.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added verified and unverified citation statuses for document quotations.
  * Unverified citations are clearly labelled and cannot be clicked or used for navigation.
  * Citation matching now tolerates differences in whitespace, punctuation, quotes, dashes and Unicode formatting.

* **Bug Fixes**
  * Reports and source navigation now use only verified citations.
  * Improved citation matching for pasted quotations and document text variations.

* **Tests**
  * Added coverage for citation verification, normalisation and non-navigable unverified citations.

* **Localisation**
  * Added translated labels and guidance for unverified citations across supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->