### PR TITLE
perf(api): mark indexed rows in one statement per index request

### DIFF
--- a/apps/api/src/handlers/case-law/corpus-index-mark.db.test.ts
+++ b/apps/api/src/handlers/case-law/corpus-index-mark.db.test.ts
@@ -1,0 +1,144 @@
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import { pushSchema } from "drizzle-kit/api-postgres";
+import { sql } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/pglite";
+
+import * as authSchema from "@/api/db/auth-schema";
+import * as rlsExports from "@/api/db/rls";
+import type { Transaction } from "@/api/db/root";
+import * as schema from "@/api/db/schema";
+import { caseLawDecisions, caseLawSources } from "@/api/db/schema";
+import { caseLawCorpusIndexAdapter } from "@/api/handlers/case-law/corpus-index";
+import { createSafeId } from "@/api/lib/branded-types";
+import type { SafeId } from "@/api/lib/branded-types";
+import {
+  createSchemaPglite,
+  installPgliteSchemaPrerequisites,
+} from "@/api/tests/pglite-schema";
+
+// The batched mark rewrites hundreds of per-row compare-and-set updates
+// into one VALUES join. The batching must not weaken the per-row CAS:
+// a row whose expected pre-state no longer matches (concurrent refresh)
+// stays unmarked while its batch-mates commit — and NULL expected hashes
+// (a first-time index) must compare via IS NOT DISTINCT FROM, which is
+// exactly the shape a serializer-level test cannot prove.
+
+const allSchema = { ...schema, ...authSchema, ...rlsExports };
+const NOW = new Date("2026-07-28T12:00:00.000Z");
+
+let client: Awaited<ReturnType<typeof createSchemaPglite>>;
+let db: ReturnType<typeof drizzle>;
+
+const sourceId = createSafeId<"caseLawSource">();
+const freshId = createSafeId<"caseLawDecision">();
+const movedId = createSafeId<"caseLawDecision">();
+
+beforeAll(
+  async () => {
+    client = await createSchemaPglite();
+    db = drizzle({ client });
+    await db.execute(sql.raw("CREATE ROLE stella NOLOGIN"));
+    await db.execute(sql.raw("CREATE ROLE stella_ingestion NOLOGIN"));
+    await installPgliteSchemaPrerequisites(db);
+    const { sqlStatements } = await pushSchema(allSchema, db);
+    for (const statement of sqlStatements) {
+      // oxlint-disable-next-line no-await-in-loop -- DDL statements must apply in emitted order (deterministic test schema setup)
+      await db.execute(sql.raw(statement));
+    }
+
+    await db.insert(caseLawSources).values({
+      id: sourceId,
+      adapterKey: "cz-ns",
+      name: "test source",
+    });
+    const base = {
+      sourceId,
+      court: "Okresní soud v Praze",
+      country: "CZE",
+      language: "cs",
+      fulltext: "text",
+      decisionDate: "2020-01-01",
+    };
+    await db.insert(caseLawDecisions).values([
+      {
+        ...base,
+        id: freshId,
+        caseNumber: "1 T 1/2020",
+        slug: "fresh",
+        languageGroupKey: "fresh",
+        contentHash: "hash-fresh",
+        indexedHash: null,
+      },
+      {
+        ...base,
+        id: movedId,
+        caseNumber: "2 T 2/2020",
+        slug: "moved",
+        languageGroupKey: "moved",
+        contentHash: "hash-moved",
+        indexedHash: "hash-old",
+      },
+    ]);
+  },
+  { timeout: 30_000 },
+);
+
+afterAll(async () => {
+  await client.close();
+});
+
+const loadRow = async (id: SafeId<"caseLawDecision">) => {
+  const [row] = await db
+    .select({
+      id: caseLawDecisions.id,
+      country: caseLawDecisions.country,
+      textS3Key: caseLawDecisions.textS3Key,
+      astS3Key: caseLawDecisions.astS3Key,
+      contentHash: caseLawDecisions.contentHash,
+      indexedHash: caseLawDecisions.indexedHash,
+      indexedGeneration: caseLawDecisions.indexedGeneration,
+      updatedAt: caseLawDecisions.updatedAt,
+    })
+    .from(caseLawDecisions)
+    .where(sql`${caseLawDecisions.id} = ${id}`);
+  if (!row) {
+    throw new Error("row missing");
+  }
+  return row;
+};
+
+test(
+  "marks matching rows and refuses moved ones in one statement",
+  async () => {
+    const fresh = await loadRow(freshId);
+    const moved = await loadRow(movedId);
+    // Simulate a concurrent refresh landing after `moved` was selected:
+    // its expected pre-state (indexedHash "hash-old") no longer matches.
+    await db
+      .update(caseLawDecisions)
+      .set({ indexedHash: null })
+      .where(sql`${caseLawDecisions.id} = ${movedId}`);
+
+    const marked = await caseLawCorpusIndexAdapter.markIndexedBatch(
+      // SAFETY: the adapter only calls `execute` on the transaction, and
+      // pglite's drizzle instance provides that surface structurally —
+      // the same reasoning the citation-authority pglite test relies on.
+      db as unknown as Transaction,
+      {
+        rows: [fresh, moved],
+        indexId: "case_law_v2_cze",
+        now: NOW,
+      },
+    );
+
+    expect(marked.has(freshId)).toBe(true);
+    expect(marked.has(movedId)).toBe(false);
+
+    const freshAfter = await loadRow(freshId);
+    expect(freshAfter.indexedGeneration).toBe("case_law_v2_cze");
+    expect(freshAfter.indexedHash).toBe("hash-fresh");
+    const movedAfter = await loadRow(movedId);
+    expect(movedAfter.indexedGeneration).toBeNull();
+  },
+  { timeout: 30_000 },
+);

--- a/apps/api/src/handlers/case-law/corpus-index-mark.db.test.ts
+++ b/apps/api/src/handlers/case-law/corpus-index-mark.db.test.ts
@@ -19,12 +19,16 @@ import {
 // The batched mark rewrites hundreds of per-row compare-and-set updates
 // into one VALUES join. The batching must not weaken the per-row CAS:
 // a row whose expected pre-state no longer matches (concurrent refresh)
-// stays unmarked while its batch-mates commit — and NULL expected hashes
-// (a first-time index) must compare via IS NOT DISTINCT FROM, which is
-// exactly the shape a serializer-level test cannot prove.
+// stays unmarked while its batch-mates commit, NULL expected hashes
+// (a first-time index) must compare via IS NOT DISTINCT FROM, and the
+// mark must neither bump updated_at nor let a stale overlapping build
+// re-mark a hash-current row whose generation already advanced — all
+// shapes a serializer-level test cannot prove.
 
 const allSchema = { ...schema, ...authSchema, ...rlsExports };
 const NOW = new Date("2026-07-28T12:00:00.000Z");
+const OLD_GENERATION = "case_law_v1_cze";
+const NEW_GENERATION = "case_law_v2_cze";
 
 let client: Awaited<ReturnType<typeof createSchemaPglite>>;
 let db: ReturnType<typeof drizzle>;
@@ -32,6 +36,7 @@ let db: ReturnType<typeof drizzle>;
 const sourceId = createSafeId<"caseLawSource">();
 const freshId = createSafeId<"caseLawDecision">();
 const movedId = createSafeId<"caseLawDecision">();
+const regenId = createSafeId<"caseLawDecision">();
 
 beforeAll(
   async () => {
@@ -45,6 +50,11 @@ beforeAll(
       // oxlint-disable-next-line no-await-in-loop -- DDL statements must apply in emitted order (deterministic test schema setup)
       await db.execute(sql.raw(statement));
     }
+    // The columns are naive timestamps while the statement's expected values
+    // arrive as text; a non-UTC session proves the comparison does not detour
+    // through timestamptz and the session time zone (which would make every
+    // CAS miss on a non-UTC connection).
+    await db.execute(sql.raw("SET TIME ZONE 'Europe/Prague'"));
 
     await db.insert(caseLawSources).values({
       id: sourceId,
@@ -78,6 +88,16 @@ beforeAll(
         contentHash: "hash-moved",
         indexedHash: "hash-old",
       },
+      {
+        ...base,
+        id: regenId,
+        caseNumber: "3 T 3/2020",
+        slug: "regen",
+        languageGroupKey: "regen",
+        contentHash: "hash-regen",
+        indexedHash: "hash-regen",
+        indexedGeneration: OLD_GENERATION,
+      },
     ]);
   },
   { timeout: 30_000 },
@@ -107,11 +127,18 @@ const loadRow = async (id: SafeId<"caseLawDecision">) => {
   return row;
 };
 
+// SAFETY: the adapter only calls `execute` on the transaction, and pglite's
+// drizzle instance provides that surface structurally — the same reasoning
+// the ingestion pipeline tests rely on for their fakes.
+// eslint-disable-next-line typescript/no-unsafe-type-assertion
+const tx = () => db as unknown as Transaction;
+
 test(
   "marks matching rows and refuses moved ones in one statement",
   async () => {
     const fresh = await loadRow(freshId);
     const moved = await loadRow(movedId);
+    const regen = await loadRow(regenId);
     // Simulate a concurrent refresh landing after `moved` was selected:
     // its expected pre-state (indexedHash "hash-old") no longer matches.
     await db
@@ -119,26 +146,37 @@ test(
       .set({ indexedHash: null })
       .where(sql`${caseLawDecisions.id} = ${movedId}`);
 
-    const marked = await caseLawCorpusIndexAdapter.markIndexedBatch(
-      // SAFETY: the adapter only calls `execute` on the transaction, and
-      // pglite's drizzle instance provides that surface structurally —
-      // the same reasoning the citation-authority pglite test relies on.
-      db as unknown as Transaction,
-      {
-        rows: [fresh, moved],
-        indexId: "case_law_v2_cze",
-        now: NOW,
-      },
-    );
+    const marked = await caseLawCorpusIndexAdapter.markIndexedBatch(tx(), {
+      rows: [fresh, moved, regen],
+      indexId: NEW_GENERATION,
+      now: NOW,
+    });
 
     expect(marked.has(freshId)).toBe(true);
     expect(marked.has(movedId)).toBe(false);
+    expect(marked.has(regenId)).toBe(true);
 
     const freshAfter = await loadRow(freshId);
-    expect(freshAfter.indexedGeneration).toBe("case_law_v2_cze");
+    expect(freshAfter.indexedGeneration).toBe(NEW_GENERATION);
     expect(freshAfter.indexedHash).toBe("hash-fresh");
+    // Bookkeeping must not read as a content change: the trim scan and the
+    // ingest refresh both compare-and-set on updated_at.
+    expect(freshAfter.updatedAt).toEqual(fresh.updatedAt);
     const movedAfter = await loadRow(movedId);
     expect(movedAfter.indexedGeneration).toBeNull();
+
+    // Overlapping-build fixed point: a second worker that read `regen`
+    // before the first mark (hash already current, generation still old)
+    // must refuse rather than record another success, and the expected
+    // generation is the only pre-state field that can catch it.
+    const stale = await caseLawCorpusIndexAdapter.markIndexedBatch(tx(), {
+      rows: [regen],
+      indexId: NEW_GENERATION,
+      now: NOW,
+    });
+    expect(stale.size).toBe(0);
+    const regenAfter = await loadRow(regenId);
+    expect(regenAfter.indexedGeneration).toBe(NEW_GENERATION);
   },
   { timeout: 30_000 },
 );

--- a/apps/api/src/handlers/case-law/corpus-index.ts
+++ b/apps/api/src/handlers/case-law/corpus-index.ts
@@ -17,8 +17,12 @@ import {
   chunkDocument,
   formatHeadingPath,
 } from "@/api/lib/corpus-index/chunking";
-import type { CorpusDocumentPayload } from "@/api/lib/corpus-index/core";
+import type {
+  CorpusDocumentPayload,
+  CorpusIndexAdapter,
+} from "@/api/lib/corpus-index/core";
 import { createCorpusIndexer } from "@/api/lib/corpus-index/core";
+import { isRecord } from "@/api/lib/type-guards";
 
 /**
  * corpus index search-projection maintenance for the `case_law` family.
@@ -183,7 +187,8 @@ const buildDocs = (
   );
 };
 
-const indexer = createCorpusIndexer<"caseLawDecision", IndexableRow>({
+/** Exported for the database-backed test of the batched CAS mark. */
+export const caseLawCorpusIndexAdapter = {
   family: "case_law",
   captureStep: "backfillCorpusIndex.loadText",
   granularity: "passage",
@@ -245,24 +250,49 @@ const indexer = createCorpusIndexer<"caseLawDecision", IndexableRow>({
     );
     return fallback.at(0)?.fulltext ?? null;
   },
-  markIndexed: async (tx, { row, indexId, now }) => {
+  markIndexedBatch: async (tx, { rows, indexId, now }) => {
+    if (rows.length === 0) {
+      return new Set();
+    }
     // audit: skip — search index maintenance; rebuilds derived state
-    const marked = await tx
-      .update(caseLawDecisions)
-      .set({
-        indexedHash: row.contentHash,
-        indexedGeneration: indexId,
-        indexedAt: now,
-      })
-      .where(
-        and(
-          eq(caseLawDecisions.id, row.id),
-          sql`${caseLawDecisions.indexedHash} IS NOT DISTINCT FROM ${row.indexedHash}`,
-          sql`${caseLawDecisions.updatedAt} IS NOT DISTINCT FROM ${row.updatedAt}`,
-        ),
-      )
-      .returning({ id: caseLawDecisions.id });
-    return marked.length > 0;
+    // One statement for the whole request: each tuple carries the row's
+    // expected pre-state, so every row keeps its individual compare-and-set
+    // while the batch pays a single round-trip.
+    const tuples = sql.join(
+      rows.map(
+        (row) =>
+          sql`(${row.id}::uuid, ${row.contentHash}::text, ${row.indexedHash}::text, ${row.updatedAt.toISOString()}::timestamptz)`,
+      ),
+      sql`, `,
+    );
+    const marked: unknown = await tx.execute(sql`
+      UPDATE ${caseLawDecisions} AS d
+      SET indexed_hash = v.content_hash,
+          indexed_generation = ${indexId},
+          indexed_at = ${now.toISOString()}::timestamptz
+      FROM (VALUES ${tuples}) AS v(id, content_hash, expected_hash, expected_updated)
+      WHERE d.id = v.id
+        AND d.indexed_hash IS NOT DISTINCT FROM v.expected_hash
+        AND d.updated_at IS NOT DISTINCT FROM v.expected_updated
+      RETURNING d.id
+    `);
+    // The bun-sql driver returns the rows directly; pglite (tests) wraps
+    // them in { rows }. Accept both shapes.
+    let returned: unknown[] = [];
+    if (Array.isArray(marked)) {
+      returned = marked;
+    } else if (isRecord(marked) && Array.isArray(marked["rows"])) {
+      returned = marked["rows"];
+    }
+    const ids = new Set<SafeId<"caseLawDecision">>();
+    for (const entry of returned) {
+      if (isRecord(entry) && typeof entry["id"] === "string") {
+        // SAFETY: RETURNING yields the same uuid values the branded rows
+        // supplied in the VALUES tuples, so the brand is preserved.
+        ids.add(entry["id"] as SafeId<"caseLawDecision">);
+      }
+    }
+    return ids;
   },
   insertSucceededJobs: async (tx, { rows, indexId }) => {
     // audit: skip — append-only index-job rows ARE the indexing audit trail
@@ -295,7 +325,11 @@ const indexer = createCorpusIndexer<"caseLawDecision", IndexableRow>({
       );
     });
   },
-});
+} satisfies CorpusIndexAdapter<"caseLawDecision", IndexableRow>;
+
+const indexer = createCorpusIndexer<"caseLawDecision", IndexableRow>(
+  caseLawCorpusIndexAdapter,
+);
 
 export const loadDocsForBatch = indexer.loadDocsForBatch;
 export const backfillCorpusIndex = indexer.backfill;

--- a/apps/api/src/handlers/case-law/corpus-index.ts
+++ b/apps/api/src/handlers/case-law/corpus-index.ts
@@ -21,8 +21,10 @@ import type {
   CorpusDocumentPayload,
   CorpusIndexAdapter,
 } from "@/api/lib/corpus-index/core";
-import { createCorpusIndexer } from "@/api/lib/corpus-index/core";
-import { isRecord } from "@/api/lib/type-guards";
+import {
+  createCorpusIndexer,
+  resolveMarkedRowIds,
+} from "@/api/lib/corpus-index/core";
 
 /**
  * corpus index search-projection maintenance for the `case_law` family.
@@ -257,11 +259,15 @@ export const caseLawCorpusIndexAdapter = {
     // audit: skip — search index maintenance; rebuilds derived state
     // One statement for the whole request: each tuple carries the row's
     // expected pre-state, so every row keeps its individual compare-and-set
-    // while the batch pays a single round-trip.
+    // while the batch pays a single round-trip. The mark deliberately leaves
+    // updated_at alone — bookkeeping must not read as a content change to
+    // other compare-and-set scans — so the expected generation is part of
+    // the pre-state: without it, two overlapping builds of a hash-current
+    // row would both match and both record success.
     const tuples = sql.join(
       rows.map(
         (row) =>
-          sql`(${row.id}::uuid, ${row.contentHash}::text, ${row.indexedHash}::text, ${row.updatedAt.toISOString()}::timestamptz)`,
+          sql`(${row.id}::uuid, ${row.contentHash}::text, ${row.indexedHash}::text, ${row.indexedGeneration}::text, ${row.updatedAt.toISOString()}::timestamp)`,
       ),
       sql`, `,
     );
@@ -269,30 +275,15 @@ export const caseLawCorpusIndexAdapter = {
       UPDATE ${caseLawDecisions} AS d
       SET indexed_hash = v.content_hash,
           indexed_generation = ${indexId},
-          indexed_at = ${now.toISOString()}::timestamptz
-      FROM (VALUES ${tuples}) AS v(id, content_hash, expected_hash, expected_updated)
+          indexed_at = ${now.toISOString()}::timestamp
+      FROM (VALUES ${tuples}) AS v(id, content_hash, expected_hash, expected_generation, expected_updated)
       WHERE d.id = v.id
         AND d.indexed_hash IS NOT DISTINCT FROM v.expected_hash
+        AND d.indexed_generation IS NOT DISTINCT FROM v.expected_generation
         AND d.updated_at IS NOT DISTINCT FROM v.expected_updated
       RETURNING d.id
     `);
-    // The bun-sql driver returns the rows directly; pglite (tests) wraps
-    // them in { rows }. Accept both shapes.
-    let returned: unknown[] = [];
-    if (Array.isArray(marked)) {
-      returned = marked;
-    } else if (isRecord(marked) && Array.isArray(marked["rows"])) {
-      returned = marked["rows"];
-    }
-    const ids = new Set<SafeId<"caseLawDecision">>();
-    for (const entry of returned) {
-      if (isRecord(entry) && typeof entry["id"] === "string") {
-        // SAFETY: RETURNING yields the same uuid values the branded rows
-        // supplied in the VALUES tuples, so the brand is preserved.
-        ids.add(entry["id"] as SafeId<"caseLawDecision">);
-      }
-    }
-    return ids;
+    return resolveMarkedRowIds(marked, rows);
   },
   insertSucceededJobs: async (tx, { rows, indexId }) => {
     // audit: skip — append-only index-job rows ARE the indexing audit trail

--- a/apps/api/src/handlers/legislation/corpus-index.ts
+++ b/apps/api/src/handlers/legislation/corpus-index.ts
@@ -10,6 +10,7 @@ import { redistributableLegislationSource } from "@/api/handlers/legislation/red
 import type { SafeId } from "@/api/lib/branded-types";
 import type { CorpusDocumentPayload } from "@/api/lib/corpus-index/core";
 import { createCorpusIndexer } from "@/api/lib/corpus-index/core";
+import { isRecord } from "@/api/lib/type-guards";
 
 /**
  * corpus index projection for the `legislation` family. Domain adapter over the
@@ -170,24 +171,49 @@ const indexer = createCorpusIndexer<"legislationDocument", IndexableRow>({
     );
     return fallback.at(0)?.fulltext ?? null;
   },
-  markIndexed: async (tx, { row, indexId, now }) => {
+  markIndexedBatch: async (tx, { rows, indexId, now }) => {
+    if (rows.length === 0) {
+      return new Set();
+    }
     // audit: skip — search index maintenance; rebuilds derived state
-    const marked = await tx
-      .update(legislationDocuments)
-      .set({
-        indexedHash: row.contentHash,
-        indexedGeneration: indexId,
-        indexedAt: now,
-      })
-      .where(
-        and(
-          eq(legislationDocuments.id, row.id),
-          sql`${legislationDocuments.indexedHash} IS NOT DISTINCT FROM ${row.indexedHash}`,
-          sql`${legislationDocuments.updatedAt} IS NOT DISTINCT FROM ${row.updatedAt}`,
-        ),
-      )
-      .returning({ id: legislationDocuments.id });
-    return marked.length > 0;
+    // One statement for the whole request; each tuple carries the row's
+    // expected pre-state so per-row compare-and-set semantics survive the
+    // batching (see the case-law twin).
+    const tuples = sql.join(
+      rows.map(
+        (row) =>
+          sql`(${row.id}::uuid, ${row.contentHash}::text, ${row.indexedHash}::text, ${row.updatedAt.toISOString()}::timestamptz)`,
+      ),
+      sql`, `,
+    );
+    const marked: unknown = await tx.execute(sql`
+      UPDATE ${legislationDocuments} AS d
+      SET indexed_hash = v.content_hash,
+          indexed_generation = ${indexId},
+          indexed_at = ${now.toISOString()}::timestamptz
+      FROM (VALUES ${tuples}) AS v(id, content_hash, expected_hash, expected_updated)
+      WHERE d.id = v.id
+        AND d.indexed_hash IS NOT DISTINCT FROM v.expected_hash
+        AND d.updated_at IS NOT DISTINCT FROM v.expected_updated
+      RETURNING d.id
+    `);
+    // The bun-sql driver returns the rows directly; pglite (tests) wraps
+    // them in { rows }. Accept both shapes.
+    let returned: unknown[] = [];
+    if (Array.isArray(marked)) {
+      returned = marked;
+    } else if (isRecord(marked) && Array.isArray(marked["rows"])) {
+      returned = marked["rows"];
+    }
+    const ids = new Set<SafeId<"legislationDocument">>();
+    for (const entry of returned) {
+      if (isRecord(entry) && typeof entry["id"] === "string") {
+        // SAFETY: RETURNING yields the same uuid values the branded rows
+        // supplied in the VALUES tuples, so the brand is preserved.
+        ids.add(entry["id"] as SafeId<"legislationDocument">);
+      }
+    }
+    return ids;
   },
   insertSucceededJobs: async (tx, { rows, indexId }) => {
     // audit: skip — append-only index-job rows ARE the indexing audit trail

--- a/apps/api/src/handlers/legislation/corpus-index.ts
+++ b/apps/api/src/handlers/legislation/corpus-index.ts
@@ -9,8 +9,10 @@ import { readCorpusText } from "@/api/handlers/case-law/corpus-storage";
 import { redistributableLegislationSource } from "@/api/handlers/legislation/redistribution";
 import type { SafeId } from "@/api/lib/branded-types";
 import type { CorpusDocumentPayload } from "@/api/lib/corpus-index/core";
-import { createCorpusIndexer } from "@/api/lib/corpus-index/core";
-import { isRecord } from "@/api/lib/type-guards";
+import {
+  createCorpusIndexer,
+  resolveMarkedRowIds,
+} from "@/api/lib/corpus-index/core";
 
 /**
  * corpus index projection for the `legislation` family. Domain adapter over the
@@ -178,11 +180,12 @@ const indexer = createCorpusIndexer<"legislationDocument", IndexableRow>({
     // audit: skip — search index maintenance; rebuilds derived state
     // One statement for the whole request; each tuple carries the row's
     // expected pre-state so per-row compare-and-set semantics survive the
-    // batching (see the case-law twin).
+    // batching. Generation is part of the pre-state and updated_at is left
+    // alone (see the case-law twin for the reasoning).
     const tuples = sql.join(
       rows.map(
         (row) =>
-          sql`(${row.id}::uuid, ${row.contentHash}::text, ${row.indexedHash}::text, ${row.updatedAt.toISOString()}::timestamptz)`,
+          sql`(${row.id}::uuid, ${row.contentHash}::text, ${row.indexedHash}::text, ${row.indexedGeneration}::text, ${row.updatedAt.toISOString()}::timestamp)`,
       ),
       sql`, `,
     );
@@ -190,30 +193,15 @@ const indexer = createCorpusIndexer<"legislationDocument", IndexableRow>({
       UPDATE ${legislationDocuments} AS d
       SET indexed_hash = v.content_hash,
           indexed_generation = ${indexId},
-          indexed_at = ${now.toISOString()}::timestamptz
-      FROM (VALUES ${tuples}) AS v(id, content_hash, expected_hash, expected_updated)
+          indexed_at = ${now.toISOString()}::timestamp
+      FROM (VALUES ${tuples}) AS v(id, content_hash, expected_hash, expected_generation, expected_updated)
       WHERE d.id = v.id
         AND d.indexed_hash IS NOT DISTINCT FROM v.expected_hash
+        AND d.indexed_generation IS NOT DISTINCT FROM v.expected_generation
         AND d.updated_at IS NOT DISTINCT FROM v.expected_updated
       RETURNING d.id
     `);
-    // The bun-sql driver returns the rows directly; pglite (tests) wraps
-    // them in { rows }. Accept both shapes.
-    let returned: unknown[] = [];
-    if (Array.isArray(marked)) {
-      returned = marked;
-    } else if (isRecord(marked) && Array.isArray(marked["rows"])) {
-      returned = marked["rows"];
-    }
-    const ids = new Set<SafeId<"legislationDocument">>();
-    for (const entry of returned) {
-      if (isRecord(entry) && typeof entry["id"] === "string") {
-        // SAFETY: RETURNING yields the same uuid values the branded rows
-        // supplied in the VALUES tuples, so the brand is preserved.
-        ids.add(entry["id"] as SafeId<"legislationDocument">);
-      }
-    }
-    return ids;
+    return resolveMarkedRowIds(marked, rows);
   },
   insertSucceededJobs: async (tx, { rows, indexId }) => {
     // audit: skip — append-only index-job rows ARE the indexing audit trail

--- a/apps/api/src/lib/corpus-index/core.test.ts
+++ b/apps/api/src/lib/corpus-index/core.test.ts
@@ -241,7 +241,8 @@ describe("failed index jobs always reach the audit trail", () => {
       selectMissing: async () => [czRow, skRow],
       selectStale: async () => [],
       fetchFulltext: async () => "body",
-      markIndexed: async () => true,
+      markIndexedBatch: async (_tx, { rows }) =>
+        new Set(rows.map((row) => row.id)),
       insertSucceededJobs: async () => undefined,
       recordJobs: async (_db, jobs, indexId) => {
         recorded.push({ indexId, jobs: [...jobs] });

--- a/apps/api/src/lib/corpus-index/core.ts
+++ b/apps/api/src/lib/corpus-index/core.ts
@@ -221,14 +221,21 @@ export type CorpusIndexAdapter<
     id: SafeId<TBrand>,
   ) => Promise<string | null>;
   /**
-   * Compare-and-set the selected row state to indexed, within the caller's
-   * transaction. Returns whether the row was marked (false = a concurrent
-   * refresh moved it on, so the caller treats it as a CAS miss).
+   * Compare-and-set every row's selected state to indexed, within the
+   * caller's transaction, as ONE statement. Returns the ids that were
+   * marked; a missing id is a CAS miss (a concurrent refresh moved the
+   * row on). One statement rather than a per-row loop: a bulk build
+   * marks hundreds of rows per request, and per-row round-trips were
+   * the dominant batch cost.
    */
-  markIndexed: (
+  markIndexedBatch: (
     tx: Transaction,
-    args: { row: TRow; indexId: string; now: Date },
-  ) => Promise<boolean>;
+    args: {
+      rows: readonly CorpusIndexRow<TBrand>[];
+      indexId: string;
+      now: Date;
+    },
+  ) => Promise<Set<SafeId<TBrand>>>;
   /** Insert succeeded index-job audit rows within the caller's transaction. */
   insertSucceededJobs: (
     tx: Transaction,
@@ -718,19 +725,19 @@ export const createCorpusIndexer = <
           // oxlint-disable-next-line no-await-in-loop -- one CAS transaction per ingest request; sequential to keep index writes and audit rows consistent
           await scopedDb(async (tx) => {
             // audit: skip — search index maintenance; rebuilds derived state
+            // Compare-and-set on each row's selected state: a concurrent
+            // re-ingest clears indexedHash (possibly leaving it null-to-null
+            // when the row was already pending) and bumps updatedAt, and an
+            // unconditional write would mask that refresh so the stale index
+            // document would never be retried. All rows go in one statement;
+            // per-row round-trips dominated bulk-build batch cost.
+            const marked = await adapter.markIndexedBatch(tx, {
+              rows: entries.map(({ row }) => row),
+              indexId,
+              now,
+            });
             for (const { row } of entries) {
-              // Compare-and-set on the selected row state: a concurrent
-              // re-ingest clears indexedHash (possibly leaving it null-to-null
-              // when the row was already pending) and bumps updatedAt, and an
-              // unconditional write would mask that refresh so the stale index
-              // document would never be retried.
-              // oxlint-disable-next-line no-await-in-loop -- sequential CAS updates within the transaction; ordering preserved
-              const marked = await adapter.markIndexed(tx, {
-                row,
-                indexId,
-                now,
-              });
-              if (!marked) {
+              if (!marked.has(row.id)) {
                 casMissed.add(row.id);
               }
             }

--- a/apps/api/src/lib/corpus-index/core.ts
+++ b/apps/api/src/lib/corpus-index/core.ts
@@ -13,6 +13,7 @@ import {
 import { corpusIndexConfig } from "@/api/lib/legal-search/corpus-index-config";
 import { corpusIndexId } from "@/api/lib/legal-search/index-naming";
 import { LIMITS } from "@/api/lib/limits";
+import { isRecord } from "@/api/lib/type-guards";
 
 /**
  * Shared corpus-index search-projection core for the corpus document families
@@ -117,6 +118,38 @@ export type CorpusIndexRow<TBrand extends SafeIdType> = {
   indexedHash: string | null;
   indexedGeneration: string | null;
   updatedAt: Date;
+};
+
+/**
+ * Resolve a batched mark statement's RETURNING ids against the rows the
+ * statement was built from. Matching through the input rows keeps the branded
+ * ids without an assertion, and only ids the batch actually supplied can come
+ * back. The production driver returns the rows directly; pglite (tests) wraps
+ * them in `{ rows }` — both shapes are accepted.
+ */
+export const resolveMarkedRowIds = <TBrand extends SafeIdType>(
+  marked: unknown,
+  rows: readonly CorpusIndexRow<TBrand>[],
+): Set<SafeId<TBrand>> => {
+  let returned: unknown[] = [];
+  if (Array.isArray(marked)) {
+    returned = marked;
+  } else if (isRecord(marked) && Array.isArray(marked["rows"])) {
+    returned = marked["rows"];
+  }
+  const byId = new Map<string, SafeId<TBrand>>(
+    rows.map((row) => [row.id, row.id]),
+  );
+  const ids = new Set<SafeId<TBrand>>();
+  for (const entry of returned) {
+    if (isRecord(entry) && typeof entry["id"] === "string") {
+      const id = byId.get(entry["id"]);
+      if (id !== undefined) {
+        ids.add(id);
+      }
+    }
+  }
+  return ids;
 };
 
 /**

--- a/scripts/ratchet-baseline.json
+++ b/scripts/ratchet-baseline.json
@@ -45,7 +45,7 @@
     "files": {}
   },
   "lint-suppression-directives": {
-    "count": 594,
+    "count": 593,
     "files": {
       "apps/api/src/db/migrate.ts": 2,
       "apps/api/src/db/schema.ts": 1,
@@ -163,7 +163,7 @@
       "apps/api/src/lib/anonymization-blacklist.ts": 1,
       "apps/api/src/lib/auth.ts": 4,
       "apps/api/src/lib/cell-lock.ts": 1,
-      "apps/api/src/lib/corpus-index/core.ts": 10,
+      "apps/api/src/lib/corpus-index/core.ts": 9,
       "apps/api/src/lib/deepl/client.ts": 3,
       "apps/api/src/lib/document-reference.ts": 2,
       "apps/api/src/lib/docx-stamp.ts": 2,

--- a/scripts/typecheck-baseline.json
+++ b/scripts/typecheck-baseline.json
@@ -1,7 +1,7 @@
 {
   "api": {
-    "types": 1952301,
-    "instantiations": 11270134
+    "types": 2055474,
+    "instantiations": 11368627
   },
   "web": {
     "types": 2838143,


### PR DESCRIPTION
## Summary

The corpus index build marked each indexed row with its own compare-and-set `UPDATE`, so a bulk request paid one database round-trip per row. This replaces the loop with a single `UPDATE … FROM (VALUES …)` per request: each tuple carries the row's expected pre-state, so every row keeps its individual compare-and-set while the batch pays one round-trip.

- `markIndexed` becomes `markIndexedBatch` on the corpus-index adapter interface; it takes the base `CorpusIndexRow` (the mark only reads the CAS fields), returns the set of row ids that actually matched, and the core derives the missed set from it (a re-ingested row still gets retried instead of being marked stale).
- The expected pre-state is `indexed_hash`, `indexed_generation`, and `updated_at`, all compared with `IS NOT DISTINCT FROM` so first-time rows (NULL hash/generation) mark correctly. The mark deliberately leaves `updated_at` alone (bookkeeping must not read as a content change to other compare-and-set scans), which is why the generation is part of the pre-state: without it, two overlapping builds of a hash-current row would both match and both record success.
- Timestamps compare as naive `timestamp`, matching the column type, so the comparison cannot detour through the session time zone.
- Returned ids resolve against the batch's own rows (`resolveMarkedRowIds` in core), which keeps the branded ids without a type assertion and accepts both drivers' result shapes.

## Testing

- New database-backed test (`corpus-index-mark.db.test.ts`) running under a non-UTC session time zone: a fresh row (NULL pre-state) marks, a concurrently refreshed row refuses, a stale overlapping build of a hash-current row refuses, and `updated_at` is untouched by the mark.
- Existing corpus-index unit tests (case-law, legislation, core) pass: 21 tests.
- `tsgo --noEmit` clean on `apps/api` and `apps/legal-atlas-runner`; type-aware oxlint clean on `apps/api`.

## Baselines

- `scripts/typecheck-baseline.json` (api): reseeded 1,952,301 → 2,055,474 types. Measured cause: the fixed per-file import cost of one additional database-backed test file (pglite + drizzle-kit); the growth is content-independent (converting every query in the file to raw SQL moved the counter by 13 types) and no inference-heavy pattern was added to a hot generic path.
- `scripts/ratchet-baseline.json`: locks in a suppression removal (the per-row mark loop's `no-await-in-loop` directive went away with the loop).