### PR TITLE
perf(api): index the corpus indexer's pending scan

### DIFF
--- a/apps/api/drizzle/20260729010000_corpus_index_pending_partial_idx/migration.sql
+++ b/apps/api/drizzle/20260729010000_corpus_index_pending_partial_idx/migration.sql
@@ -1,0 +1,47 @@
+SET lock_timeout = '1s';--> statement-breakpoint
+SET statement_timeout = '5s';--> statement-breakpoint
+
+-- The corpus indexer's missing scan selects rows whose indexed_generation is
+-- unset (or belongs to an older generation). Neither predicate is served by an
+-- index, so every selection pays a heap scan that grows with each row already
+-- marked; on the full corpus that starves both bulk builds and the daemon's
+-- steady-state loop. The partial index below covers the dominant arm
+-- (never-indexed rows) and stays proportional to the remaining work: it
+-- shrinks toward empty as the build completes.
+--
+-- Drizzle wraps pending migrations in one transaction, while PostgreSQL
+-- requires CREATE INDEX CONCURRENTLY to run outside a transaction block.
+-- Split the migrator transaction, lift the timeouts for the concurrent builds
+-- (which are expected to outlive a 5s statement_timeout and take no lock those
+-- timeouts guard), then restore and reopen a transaction for Drizzle's
+-- migration row. Same shape as 20260720140000_machine_api_keys_org_index.
+-- squawk-ignore transaction-nesting
+COMMIT;
+--> statement-breakpoint
+SET statement_timeout = 0;
+--> statement-breakpoint
+SET lock_timeout = 0;
+--> statement-breakpoint
+
+-- stella-migration-safety: reviewed destructive-change - drops only this
+-- migration's own index by name before recreating it. A cancelled concurrent
+-- build leaves an INVALID index behind, and IF NOT EXISTS would then skip
+-- recreating it; dropping first means a retry cannot record the migration
+-- while the scan is unindexed.
+DROP INDEX CONCURRENTLY IF EXISTS "case_law_decisions_corpus_pending_idx";
+--> statement-breakpoint
+-- squawk-ignore prefer-robust-stmts
+CREATE INDEX CONCURRENTLY "case_law_decisions_corpus_pending_idx" ON "case_law_decisions" ("id") WHERE "content_hash" IS NOT NULL AND "indexed_generation" IS NULL;
+--> statement-breakpoint
+
+-- stella-migration-safety: reviewed destructive-change - same reasoning as
+-- the index above, for the legislation twin.
+DROP INDEX CONCURRENTLY IF EXISTS "legislation_documents_corpus_pending_idx";
+--> statement-breakpoint
+-- squawk-ignore prefer-robust-stmts
+CREATE INDEX CONCURRENTLY "legislation_documents_corpus_pending_idx" ON "legislation_documents" ("id") WHERE "content_hash" IS NOT NULL AND "indexed_generation" IS NULL;
+--> statement-breakpoint
+SET lock_timeout = '1s';
+--> statement-breakpoint
+-- squawk-ignore transaction-nesting, ban-uncommitted-transaction
+BEGIN;

--- a/apps/api/drizzle/20260729010000_corpus_index_pending_partial_idx/migration.sql
+++ b/apps/api/drizzle/20260729010000_corpus_index_pending_partial_idx/migration.sql
@@ -41,6 +41,8 @@ DROP INDEX CONCURRENTLY IF EXISTS "legislation_documents_corpus_pending_idx";
 -- squawk-ignore prefer-robust-stmts
 CREATE INDEX CONCURRENTLY "legislation_documents_corpus_pending_idx" ON "legislation_documents" ("id") WHERE "content_hash" IS NOT NULL AND "indexed_generation" IS NULL;
 --> statement-breakpoint
+SET statement_timeout = '5s';
+--> statement-breakpoint
 SET lock_timeout = '1s';
 --> statement-breakpoint
 -- squawk-ignore transaction-nesting, ban-uncommitted-transaction

--- a/apps/api/src/db/schema/case-law.ts
+++ b/apps/api/src/db/schema/case-law.ts
@@ -183,6 +183,16 @@ export const caseLawDecisions = p.pgTable(
     // (mirrors backfillSearchIndex): rows whose indexedHash differs
     // from contentHash, or were never indexed.
     p.index("case_law_decisions_indexed_idx").on(t.indexedHash, t.contentHash),
+    // Pending set for the corpus indexer's missing scan. Partial on the
+    // un-indexed predicate so the index stays proportional to the remaining
+    // work, not the corpus: without it the scan's cost grows with every row
+    // already marked, which starved bulk builds and the daemon loop alike.
+    p
+      .index("case_law_decisions_corpus_pending_idx")
+      .on(t.id)
+      .where(
+        sql`${t.contentHash} is not null and ${t.indexedGeneration} is null`,
+      ),
     // Deferred-document queue, priority tier: decisions a reader asked
     // for, oldest request first. Partial on the pending predicate, so
     // the index stays proportional to the queue, not to the corpus.

--- a/apps/api/src/db/schema/legislation.ts
+++ b/apps/api/src/db/schema/legislation.ts
@@ -107,6 +107,14 @@ export const legislationDocuments = p.pgTable(
     p
       .index("legislation_documents_indexed_idx")
       .on(t.indexedHash, t.contentHash),
+    // Pending set for the corpus indexer's missing scan (see the case-law
+    // twin for the reasoning).
+    p
+      .index("legislation_documents_corpus_pending_idx")
+      .on(t.id)
+      .where(
+        sql`${t.contentHash} is not null and ${t.indexedGeneration} is null`,
+      ),
     p.check(
       "legislation_documents_status_values",
       sql`${t.status} IN ('current','historical','repealed','draft')`,

--- a/apps/api/src/handlers/case-law/corpus-index.ts
+++ b/apps/api/src/handlers/case-law/corpus-index.ts
@@ -246,7 +246,12 @@ export const caseLawCorpusIndexAdapter = {
         )
         .limit(limit - fresh.length),
     );
-    return [...fresh, ...carried];
+    // A row read as never-indexed by the first arm can be marked by a
+    // concurrent build under another generation before the second arm
+    // runs, which would select it again; the ingest is append-only, so
+    // the same id must not be submitted twice.
+    const seen = new Set(fresh.map((row) => row.id));
+    return [...fresh, ...carried.filter((row) => !seen.has(row.id))];
   },
   selectStale: async (scopedDb, { generation, limit }) =>
     await scopedDb((tx) =>

--- a/apps/api/src/handlers/case-law/corpus-index.ts
+++ b/apps/api/src/handlers/case-law/corpus-index.ts
@@ -1,4 +1,4 @@
-import { and, eq, isNull, or, sql } from "drizzle-orm";
+import { and, eq, isNull, sql } from "drizzle-orm";
 
 import {
   caseLawDecisions,
@@ -202,8 +202,11 @@ export const caseLawCorpusIndexAdapter = {
   // created_at steers the planner onto the created_at index and
   // row-by-row heap filtering; the selective content-hash index is what
   // these scans need.
-  selectMissing: async (scopedDb, { generation, limit }) =>
-    await scopedDb((tx) =>
+  selectMissing: async (scopedDb, { generation, limit }) => {
+    // Never-indexed rows first: this arm is served by the partial pending
+    // index, so its cost tracks the remaining work instead of growing with
+    // every row already marked.
+    const fresh = await scopedDb((tx) =>
       tx
         .select(SELECT_COLUMNS)
         .from(caseLawDecisions)
@@ -215,14 +218,36 @@ export const caseLawCorpusIndexAdapter = {
           and(
             hasContent,
             redistributableCaseLawSource,
-            or(
-              isNull(caseLawDecisions.indexedGeneration),
-              sql`${caseLawDecisions.indexedGeneration} <> (${generation} || '_' || lower(${caseLawDecisions.country}))`,
-            ),
+            isNull(caseLawDecisions.indexedGeneration),
           ),
         )
         .limit(limit),
-    ),
+    );
+    if (fresh.length >= limit) {
+      return fresh;
+    }
+    // Rows marked under an older generation. Only a generation cutover makes
+    // this arm non-empty, so the unindexed scan it costs is rare and shrinks
+    // as rows re-mark into the current generation.
+    const carried = await scopedDb((tx) =>
+      tx
+        .select(SELECT_COLUMNS)
+        .from(caseLawDecisions)
+        .innerJoin(
+          caseLawSources,
+          eq(caseLawSources.id, caseLawDecisions.sourceId),
+        )
+        .where(
+          and(
+            hasContent,
+            redistributableCaseLawSource,
+            sql`${caseLawDecisions.indexedGeneration} <> (${generation} || '_' || lower(${caseLawDecisions.country}))`,
+          ),
+        )
+        .limit(limit - fresh.length),
+    );
+    return [...fresh, ...carried];
+  },
   selectStale: async (scopedDb, { generation, limit }) =>
     await scopedDb((tx) =>
       tx

--- a/apps/api/src/handlers/legislation/corpus-index.ts
+++ b/apps/api/src/handlers/legislation/corpus-index.ts
@@ -1,4 +1,4 @@
-import { and, eq, isNull, or, sql } from "drizzle-orm";
+import { and, eq, isNull, sql } from "drizzle-orm";
 
 import {
   legislationDocuments,
@@ -123,8 +123,11 @@ const indexer = createCorpusIndexer<"legislationDocument", IndexableRow>({
   // created_at steers the planner onto the created_at index and
   // row-by-row heap filtering; the selective content-hash index is what
   // these scans need.
-  selectMissing: async (scopedDb, { generation, limit }) =>
-    await scopedDb((tx) =>
+  selectMissing: async (scopedDb, { generation, limit }) => {
+    // Two arms for the same reason as the case-law twin: the never-indexed
+    // arm rides the partial pending index; the older-generation arm is only
+    // non-empty across a generation cutover.
+    const fresh = await scopedDb((tx) =>
       tx
         .select(SELECT_COLUMNS)
         .from(legislationDocuments)
@@ -136,14 +139,33 @@ const indexer = createCorpusIndexer<"legislationDocument", IndexableRow>({
           and(
             hasContent,
             redistributableLegislationSource,
-            or(
-              isNull(legislationDocuments.indexedGeneration),
-              sql`${legislationDocuments.indexedGeneration} <> (${generation} || '_' || lower(${legislationDocuments.country}))`,
-            ),
+            isNull(legislationDocuments.indexedGeneration),
           ),
         )
         .limit(limit),
-    ),
+    );
+    if (fresh.length >= limit) {
+      return fresh;
+    }
+    const carried = await scopedDb((tx) =>
+      tx
+        .select(SELECT_COLUMNS)
+        .from(legislationDocuments)
+        .innerJoin(
+          legislationSources,
+          eq(legislationSources.id, legislationDocuments.sourceId),
+        )
+        .where(
+          and(
+            hasContent,
+            redistributableLegislationSource,
+            sql`${legislationDocuments.indexedGeneration} <> (${generation} || '_' || lower(${legislationDocuments.country}))`,
+          ),
+        )
+        .limit(limit - fresh.length),
+    );
+    return [...fresh, ...carried];
+  },
   selectStale: async (scopedDb, { generation, limit }) =>
     await scopedDb((tx) =>
       tx

--- a/apps/api/src/handlers/legislation/corpus-index.ts
+++ b/apps/api/src/handlers/legislation/corpus-index.ts
@@ -164,7 +164,12 @@ const indexer = createCorpusIndexer<"legislationDocument", IndexableRow>({
         )
         .limit(limit - fresh.length),
     );
-    return [...fresh, ...carried];
+    // A row read as never-indexed by the first arm can be marked by a
+    // concurrent build under another generation before the second arm
+    // runs, which would select it again; the ingest is append-only, so
+    // the same id must not be submitted twice.
+    const seen = new Set(fresh.map((row) => row.id));
+    return [...fresh, ...carried.filter((row) => !seen.has(row.id))];
   },
   selectStale: async (scopedDb, { generation, limit }) =>
     await scopedDb((tx) =>


### PR DESCRIPTION
## Summary

The corpus indexer's missing scan selects rows whose `indexed_generation` is unset (or belongs to an older generation). Neither predicate is served by an index, so every selection pays a heap scan that skips past each row already marked; the cost therefore grows with progress, degrading both bulk builds and the daemon's steady-state loop as an index generation fills.

- New partial index per family (`… (id) WHERE content_hash IS NOT NULL AND indexed_generation IS NULL`): it covers exactly the never-indexed arm and stays proportional to the remaining work, shrinking toward empty as the build completes.
- `selectMissing` splits into two arms: the never-indexed arm rides the partial index; the older-generation arm (`<> current`) only becomes non-empty across a generation cutover, so its unindexed scan is rare and shrinks as rows re-mark.
- The migration builds the indexes with `CREATE INDEX CONCURRENTLY` outside the migrator transaction, same shape as `20260720140000_machine_api_keys_org_index` (drop-first so an INVALID leftover from a cancelled build cannot be skipped by a retry).

## Testing

- All corpus-index tests pass (21, including the batched-mark database test).
- `tsgo --noEmit` clean on `apps/api` and `apps/legal-atlas-runner`; squawk clean on the migration.
- Behavior of the selection is unchanged (same rows eligible; two queries instead of one `OR`), and pick order was already unspecified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Improved corpus indexing efficiency for case law and legislation using new partial “pending” indexes.
  - Updated missing-document selection to favour never-indexed rows, reducing unnecessary work.
- **Bug Fixes**
  - Improved prioritisation between never-processed and previously processed documents to avoid reprocessing.
  - Enhanced handling of concurrent index builds to minimise timeouts and incomplete indexing states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->