### PR TITLE
fix(api): compare timestamp CAS tokens at full precision

### DIFF
--- a/apps/api/src/handlers/case-law/corpus-index-mark.db.test.ts
+++ b/apps/api/src/handlers/case-law/corpus-index-mark.db.test.ts
@@ -11,6 +11,7 @@ import { caseLawDecisions, caseLawSources } from "@/api/db/schema";
 import { caseLawCorpusIndexAdapter } from "@/api/handlers/case-law/corpus-index";
 import { createSafeId } from "@/api/lib/branded-types";
 import type { SafeId } from "@/api/lib/branded-types";
+import { timestampCasToken } from "@/api/lib/db/timestamp-cas";
 import {
   createSchemaPglite,
   installPgliteSchemaPrerequisites,
@@ -99,6 +100,13 @@ beforeAll(
         indexedGeneration: OLD_GENERATION,
       },
     ]);
+    // SQL now() carries microseconds, which a JS Date round-trip silently
+    // truncates: the CAS must match against the exact stored value, which
+    // is the whole point of the text token. Every row in this fixture gets
+    // a microsecond timestamp so a Date regression fails the test.
+    await db.execute(
+      sql`UPDATE ${caseLawDecisions} SET updated_at = now() + interval '123 microseconds'`,
+    );
   },
   { timeout: 30_000 },
 );
@@ -117,7 +125,7 @@ const loadRow = async (id: SafeId<"caseLawDecision">) => {
       contentHash: caseLawDecisions.contentHash,
       indexedHash: caseLawDecisions.indexedHash,
       indexedGeneration: caseLawDecisions.indexedGeneration,
-      updatedAt: caseLawDecisions.updatedAt,
+      updatedAtToken: timestampCasToken(caseLawDecisions.updatedAt),
     })
     .from(caseLawDecisions)
     .where(sql`${caseLawDecisions.id} = ${id}`);
@@ -161,7 +169,7 @@ test(
     expect(freshAfter.indexedHash).toBe("hash-fresh");
     // Bookkeeping must not read as a content change: the trim scan and the
     // ingest refresh both compare-and-set on updated_at.
-    expect(freshAfter.updatedAt).toEqual(fresh.updatedAt);
+    expect(freshAfter.updatedAtToken).toBe(fresh.updatedAtToken);
     const movedAfter = await loadRow(movedId);
     expect(movedAfter.indexedGeneration).toBeNull();
 

--- a/apps/api/src/handlers/case-law/corpus-index.test.ts
+++ b/apps/api/src/handlers/case-law/corpus-index.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "bun:test";
 import { loadDocsForBatch } from "@/api/handlers/case-law/corpus-index";
 import { toSafeId } from "@/api/lib/branded-types";
 import { corpusDocumentDeleteQuery } from "@/api/lib/corpus-index/core";
+import type { TimestampCasToken } from "@/api/lib/db/timestamp-cas";
 import { TimeoutError } from "@/api/lib/errors/tagged-errors";
 import { corpusIndexId } from "@/api/lib/legal-search/index-naming";
 
@@ -30,7 +31,10 @@ const makeRow = ({ id, contentHash, textS3Key }: MakeRowOptions) => ({
   contentHash,
   indexedHash: null,
   indexedGeneration: null,
-  updatedAt: new Date("2024-01-01T00:00:00Z"),
+  // SAFETY: tests fabricate the branded token the adapters normally
+  // select as `updated_at::text`.
+  // eslint-disable-next-line typescript/no-unsafe-type-assertion
+  updatedAtToken: "2024-01-01 00:00:00" as TimestampCasToken,
 });
 
 describe("loadDocsForBatch read-failure isolation", () => {

--- a/apps/api/src/handlers/case-law/corpus-index.ts
+++ b/apps/api/src/handlers/case-law/corpus-index.ts
@@ -25,6 +25,10 @@ import {
   createCorpusIndexer,
   resolveMarkedRowIds,
 } from "@/api/lib/corpus-index/core";
+import {
+  timestampCasToken,
+  type TimestampCasToken,
+} from "@/api/lib/db/timestamp-cas";
 
 /**
  * corpus index search-projection maintenance for the `case_law` family.
@@ -59,7 +63,7 @@ type IndexableRow = {
   contentHash: string | null;
   indexedHash: string | null;
   indexedGeneration: string | null;
-  updatedAt: Date;
+  updatedAtToken: TimestampCasToken;
 };
 
 // Deliberately excludes `fulltext`: it is only the fallback for rows without
@@ -83,7 +87,7 @@ const SELECT_COLUMNS = {
   contentHash: caseLawDecisions.contentHash,
   indexedHash: caseLawDecisions.indexedHash,
   indexedGeneration: caseLawDecisions.indexedGeneration,
-  updatedAt: caseLawDecisions.updatedAt,
+  updatedAtToken: timestampCasToken(caseLawDecisions.updatedAt),
 };
 
 // A row is indexable once its canonical payload is in object storage.
@@ -297,7 +301,7 @@ export const caseLawCorpusIndexAdapter = {
     const tuples = sql.join(
       rows.map(
         (row) =>
-          sql`(${row.id}::uuid, ${row.contentHash}::text, ${row.indexedHash}::text, ${row.indexedGeneration}::text, ${row.updatedAt.toISOString()}::timestamp)`,
+          sql`(${row.id}::uuid, ${row.contentHash}::text, ${row.indexedHash}::text, ${row.indexedGeneration}::text, ${row.updatedAtToken}::timestamp)`,
       ),
       sql`, `,
     );

--- a/apps/api/src/handlers/legislation/corpus-index.test.ts
+++ b/apps/api/src/handlers/legislation/corpus-index.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 
 import { loadDocsForBatch } from "@/api/handlers/legislation/corpus-index";
 import { toSafeId } from "@/api/lib/branded-types";
+import type { TimestampCasToken } from "@/api/lib/db/timestamp-cas";
 import { TimeoutError } from "@/api/lib/errors/tagged-errors";
 import { corpusIndexId } from "@/api/lib/legal-search/index-naming";
 
@@ -30,7 +31,10 @@ const makeRow = ({ id, contentHash, textS3Key }: MakeRowOptions) => ({
   contentHash,
   indexedHash: null,
   indexedGeneration: null,
-  updatedAt: new Date("2024-01-01T00:00:00Z"),
+  // SAFETY: tests fabricate the branded token the adapters normally
+  // select as `updated_at::text`.
+  // eslint-disable-next-line typescript/no-unsafe-type-assertion
+  updatedAtToken: "2024-01-01 00:00:00" as TimestampCasToken,
 });
 
 describe("legislation loadDocsForBatch read-failure isolation", () => {

--- a/apps/api/src/handlers/legislation/corpus-index.ts
+++ b/apps/api/src/handlers/legislation/corpus-index.ts
@@ -13,6 +13,10 @@ import {
   createCorpusIndexer,
   resolveMarkedRowIds,
 } from "@/api/lib/corpus-index/core";
+import {
+  timestampCasToken,
+  type TimestampCasToken,
+} from "@/api/lib/db/timestamp-cas";
 
 /**
  * corpus index projection for the `legislation` family. Domain adapter over the
@@ -47,7 +51,7 @@ type IndexableRow = {
   contentHash: string | null;
   indexedHash: string | null;
   indexedGeneration: string | null;
-  updatedAt: Date;
+  updatedAtToken: TimestampCasToken;
 };
 
 // Deliberately excludes `fulltext` (see the case-law indexer): the fallback
@@ -71,7 +75,7 @@ const SELECT_COLUMNS = {
   contentHash: legislationDocuments.contentHash,
   indexedHash: legislationDocuments.indexedHash,
   indexedGeneration: legislationDocuments.indexedGeneration,
-  updatedAt: legislationDocuments.updatedAt,
+  updatedAtToken: timestampCasToken(legislationDocuments.updatedAt),
 };
 
 const hasContent = sql`${legislationDocuments.contentHash} IS NOT NULL`;
@@ -212,7 +216,7 @@ const indexer = createCorpusIndexer<"legislationDocument", IndexableRow>({
     const tuples = sql.join(
       rows.map(
         (row) =>
-          sql`(${row.id}::uuid, ${row.contentHash}::text, ${row.indexedHash}::text, ${row.indexedGeneration}::text, ${row.updatedAt.toISOString()}::timestamp)`,
+          sql`(${row.id}::uuid, ${row.contentHash}::text, ${row.indexedHash}::text, ${row.indexedGeneration}::text, ${row.updatedAtToken}::timestamp)`,
       ),
       sql`, `,
     );

--- a/apps/api/src/lib/corpus-index/core.test.ts
+++ b/apps/api/src/lib/corpus-index/core.test.ts
@@ -8,6 +8,7 @@ import {
   settleBoth,
   splitIngestRequests,
 } from "@/api/lib/corpus-index/core";
+import type { TimestampCasToken } from "@/api/lib/db/timestamp-cas";
 import { corpusIndexId } from "@/api/lib/legal-search/index-naming";
 
 /**
@@ -188,7 +189,10 @@ describe("failed index jobs always reach the audit trail", () => {
     contentHash: `hash-${id}`,
     indexedHash: null,
     indexedGeneration: null,
-    updatedAt: new Date("2026-01-01T00:00:00Z"),
+    // SAFETY: tests fabricate the branded token the adapters normally
+    // select as `updated_at::text`.
+    // eslint-disable-next-line typescript/no-unsafe-type-assertion
+    updatedAtToken: "2026-01-01 00:00:00" as TimestampCasToken,
   });
 
   beforeEach(() => {

--- a/apps/api/src/lib/corpus-index/core.ts
+++ b/apps/api/src/lib/corpus-index/core.ts
@@ -5,6 +5,7 @@ import type { Transaction } from "@/api/db/root";
 import type { ScopedDb } from "@/api/db/safe-db";
 import { captureError } from "@/api/lib/analytics/capture";
 import type { SafeId, SafeIdType } from "@/api/lib/branded-types";
+import type { TimestampCasToken } from "@/api/lib/db/timestamp-cas";
 import type { CorpusFamily } from "@/api/lib/legal-search/corpus-family";
 import {
   getCorpusIndexClient,
@@ -117,7 +118,12 @@ export type CorpusIndexRow<TBrand extends SafeIdType> = {
   contentHash: string | null;
   indexedHash: string | null;
   indexedGeneration: string | null;
-  updatedAt: Date;
+  /**
+   * Exact-precision CAS token for `updated_at` (see `lib/db/timestamp-cas`).
+   * Never a `Date`: the millisecond round-trip made every microsecond-
+   * precision row unmatchable.
+   */
+  updatedAtToken: TimestampCasToken;
 };
 
 /**

--- a/apps/api/src/lib/db/timestamp-cas.ts
+++ b/apps/api/src/lib/db/timestamp-cas.ts
@@ -1,0 +1,27 @@
+import { sql } from "drizzle-orm";
+import type { AnyColumn, SQL } from "drizzle-orm";
+
+/**
+ * Compare-and-set token for a `timestamp` column.
+ *
+ * Postgres stores microseconds while a JS `Date` carries milliseconds, so
+ * reading a timestamp into a `Date` and comparing it back silently narrows
+ * the value: a row whose timestamp came from SQL `now()` can never match,
+ * and the guarded write no-ops without an error. The token is the column's
+ * exact text form; treat it as opaque and only feed it back through
+ * {@link timestampMatchesCasToken} (or an equivalent `::timestamp` cast in
+ * hand-built statements).
+ */
+export type TimestampCasToken = string & {
+  readonly __timestampCasToken: "TimestampCasToken";
+};
+
+/** Select expression producing the column's exact-precision CAS token. */
+export const timestampCasToken = (column: AnyColumn): SQL<TimestampCasToken> =>
+  sql<TimestampCasToken>`${column}::text`;
+
+/** WHERE fragment comparing the column against a previously selected token. */
+export const timestampMatchesCasToken = (
+  column: AnyColumn,
+  token: TimestampCasToken,
+): SQL => sql`${column} IS NOT DISTINCT FROM ${token}::timestamp`;

--- a/apps/api/src/scripts/backfill-corpus-storage.ts
+++ b/apps/api/src/scripts/backfill-corpus-storage.ts
@@ -46,6 +46,11 @@ import type { EmptyAst } from "@/api/handlers/case-law/ingestion/adapter";
 import type { DecisionSection } from "@/api/handlers/case-law/types";
 import { captureError } from "@/api/lib/analytics/capture";
 import type { SafeId } from "@/api/lib/branded-types";
+import {
+  timestampCasToken,
+  type TimestampCasToken,
+  timestampMatchesCasToken,
+} from "@/api/lib/db/timestamp-cas";
 import { refreshCorpusS3, refreshS3 } from "@/api/lib/s3";
 
 const BATCH_SIZE = 50;
@@ -60,7 +65,7 @@ type BackfillRow = {
   sections: DecisionSection[] | null;
   documentAst: DocumentAst | EmptyAst | null;
   contentHash: string | null;
-  updatedAt: Date;
+  updatedAtToken: TimestampCasToken;
 };
 
 /** Never written to object storage. */
@@ -123,7 +128,10 @@ const backfillRow = async (row: BackfillRow): Promise<void> => {
           and(
             eq(caseLawDecisions.id, row.id),
             sql`${caseLawDecisions.contentHash} IS NOT DISTINCT FROM ${row.contentHash}`,
-            sql`${caseLawDecisions.updatedAt} IS NOT DISTINCT FROM ${row.updatedAt}`,
+            timestampMatchesCasToken(
+              caseLawDecisions.updatedAt,
+              row.updatedAtToken,
+            ),
           ),
         ),
     );
@@ -151,7 +159,7 @@ while (true) {
         sections: caseLawDecisions.sections,
         documentAst: caseLawDecisions.documentAst,
         contentHash: caseLawDecisions.contentHash,
-        updatedAt: caseLawDecisions.updatedAt,
+        updatedAtToken: timestampCasToken(caseLawDecisions.updatedAt),
       })
       .from(caseLawDecisions)
       .where(where)

--- a/apps/api/src/scripts/backfill-corpus-storage.ts
+++ b/apps/api/src/scripts/backfill-corpus-storage.ts
@@ -98,6 +98,7 @@ console.log(
 
 let lastId: SafeId<"caseLawDecision"> | null = null;
 let written = 0;
+let skipped = 0;
 let failed = 0;
 
 const backfillRow = async (row: BackfillRow): Promise<void> => {
@@ -109,7 +110,7 @@ const backfillRow = async (row: BackfillRow): Promise<void> => {
       sections: row.sections,
       ast: row.documentAst,
     });
-    await ingestionDb((tx) =>
+    const recorded = await ingestionDb((tx) =>
       tx
         .update(caseLawDecisions)
         .set({
@@ -133,9 +134,16 @@ const backfillRow = async (row: BackfillRow): Promise<void> => {
               row.updatedAtToken,
             ),
           ),
-        ),
+        )
+        .returning({ id: caseLawDecisions.id }),
     );
-    written += 1;
+    // A refused CAS is not success: the row changed under the scan and
+    // still points at its own payload, so nothing was recorded.
+    if (recorded.length > 0) {
+      written += 1;
+    } else {
+      skipped += 1;
+    }
   } catch (error) {
     failed += 1;
     captureError(error, { decisionId: row.id, step: "backfillCorpusStorage" });
@@ -177,10 +185,12 @@ while (true) {
   }
 
   lastId = rows.at(-1)?.id ?? lastId;
-  console.log(`  written=${written} failed=${failed}`);
+  console.log(`  written=${written} skipped=${skipped} failed=${failed}`);
 }
 
-console.log(`Done. Wrote ${written} decisions, ${failed} failed.`);
+console.log(
+  `Done. Wrote ${written} decisions, skipped ${skipped}, ${failed} failed.`,
+);
 
 // Non-zero on partial failure: the cutover checklist treats this run as
 // green only when every decision has its corpus objects.

--- a/apps/api/src/scripts/corpus-column-trim.ts
+++ b/apps/api/src/scripts/corpus-column-trim.ts
@@ -37,6 +37,11 @@ import { payloadCarriesDocument } from "@/api/handlers/case-law/stored-payload";
 import type { DecisionSection } from "@/api/handlers/case-law/types";
 import { captureError } from "@/api/lib/analytics/capture";
 import type { SafeId } from "@/api/lib/branded-types";
+import {
+  timestampCasToken,
+  type TimestampCasToken,
+  timestampMatchesCasToken,
+} from "@/api/lib/db/timestamp-cas";
 import { LIMITS } from "@/api/lib/limits";
 import { getCorpusS3, refreshCorpusS3, refreshS3 } from "@/api/lib/s3";
 import { withTimeout } from "@/api/lib/with-timeout";
@@ -61,7 +66,7 @@ type TrimRow = {
   fulltext: string | null;
   sections: DecisionSection[] | null;
   documentAst: DocumentAst | EmptyAst | null;
-  updatedAt: Date;
+  updatedAtToken: TimestampCasToken;
 };
 
 const parsed = parseColumnTrimArgs(Bun.argv.slice(2));
@@ -226,7 +231,10 @@ const trimRow = async (row: TrimRow): Promise<void> => {
           and(
             eq(caseLawDecisions.id, row.id),
             sql`${caseLawDecisions.contentHash} IS NOT DISTINCT FROM ${row.contentHash}`,
-            sql`${caseLawDecisions.updatedAt} IS NOT DISTINCT FROM ${row.updatedAt}`,
+            timestampMatchesCasToken(
+              caseLawDecisions.updatedAt,
+              row.updatedAtToken,
+            ),
           ),
         )
         .returning({ id: caseLawDecisions.id });
@@ -278,7 +286,7 @@ while (true) {
         fulltext: caseLawDecisions.fulltext,
         sections: caseLawDecisions.sections,
         documentAst: caseLawDecisions.documentAst,
-        updatedAt: caseLawDecisions.updatedAt,
+        updatedAtToken: timestampCasToken(caseLawDecisions.updatedAt),
       })
       .from(caseLawDecisions)
       .where(idFilter ? and(candidateFilter, idFilter) : candidateFilter)

--- a/apps/legal-atlas-runner/src/runners/case-law-corpus-storage-backfill.ts
+++ b/apps/legal-atlas-runner/src/runners/case-law-corpus-storage-backfill.ts
@@ -1,4 +1,4 @@
-import { and, asc, eq, gt, isNull, sql } from "drizzle-orm";
+import { and, asc, eq, gt, isNull } from "drizzle-orm";
 import type { SQL } from "drizzle-orm";
 
 import type { DocumentAst } from "@stll/legal-ast/document-ast";
@@ -11,6 +11,11 @@ import type { DecisionSection } from "@/api/handlers/case-law/types";
 import { backfillLegislationCorpusIndex } from "@/api/handlers/legislation/corpus-index";
 import { captureError } from "@/api/lib/analytics/capture";
 import type { SafeId } from "@/api/lib/branded-types";
+import {
+  timestampCasToken,
+  type TimestampCasToken,
+  timestampMatchesCasToken,
+} from "@/api/lib/db/timestamp-cas";
 import { corpusGeneration } from "@/api/lib/legal-search/corpus-family";
 import {
   isCorpusS3Stale,
@@ -30,7 +35,7 @@ type BackfillRow = {
   fulltext: string | null;
   sections: DecisionSection[] | null;
   documentAst: DocumentAst | EmptyAst | null;
-  updatedAt: Date;
+  updatedAtToken: TimestampCasToken;
 };
 
 type LegislationBackfillRow = {
@@ -39,7 +44,7 @@ type LegislationBackfillRow = {
   fulltext: string | null;
   sections: DecisionSection[] | null;
   documentAst: DocumentAst | EmptyAst | null;
-  updatedAt: Date;
+  updatedAtToken: TimestampCasToken;
 };
 
 type BackfillOptions = {
@@ -163,7 +168,9 @@ const parseArgs = (argv: readonly string[]): ParseResult => {
   return { ok: true, options };
 };
 
-const backfillRow = async (row: BackfillRow): Promise<boolean> => {
+const backfillRow = async (
+  row: BackfillRow,
+): Promise<"written" | "skipped" | "failed"> => {
   try {
     const result = await writeCorpusDocument({
       documentId: row.id,
@@ -173,7 +180,7 @@ const backfillRow = async (row: BackfillRow): Promise<boolean> => {
       ast: row.documentAst,
     });
 
-    await ingestionDb((tx) =>
+    const recorded = await ingestionDb((tx) =>
       tx
         .update(caseLawDecisions)
         .set({
@@ -190,24 +197,30 @@ const backfillRow = async (row: BackfillRow): Promise<boolean> => {
           and(
             eq(caseLawDecisions.id, row.id),
             isNull(caseLawDecisions.textS3Key),
-            sql`${caseLawDecisions.updatedAt} IS NOT DISTINCT FROM ${row.updatedAt}`,
+            timestampMatchesCasToken(
+              caseLawDecisions.updatedAt,
+              row.updatedAtToken,
+            ),
           ),
-        ),
+        )
+        .returning({ id: caseLawDecisions.id }),
     );
 
-    return true;
+    // A refused CAS is not success: the objects exist but the row still
+    // points nowhere, and only the recording makes the work durable.
+    return recorded.length > 0 ? "written" : "skipped";
   } catch (error) {
     captureError(error, {
       decisionId: row.id,
       step: "caseLawCorpusStorageBackfill",
     });
-    return false;
+    return "failed";
   }
 };
 
 const backfillLegislationRow = async (
   row: LegislationBackfillRow,
-): Promise<boolean> => {
+): Promise<"written" | "skipped" | "failed"> => {
   try {
     const result = await writeCorpusDocument({
       documentId: row.id,
@@ -217,7 +230,7 @@ const backfillLegislationRow = async (
       ast: row.documentAst,
     });
 
-    await ingestionDb((tx) =>
+    const recorded = await ingestionDb((tx) =>
       tx
         .update(legislationDocuments)
         .set({
@@ -234,23 +247,28 @@ const backfillLegislationRow = async (
           and(
             eq(legislationDocuments.id, row.id),
             isNull(legislationDocuments.textS3Key),
-            sql`${legislationDocuments.updatedAt} IS NOT DISTINCT FROM ${row.updatedAt}`,
+            timestampMatchesCasToken(
+              legislationDocuments.updatedAt,
+              row.updatedAtToken,
+            ),
           ),
-        ),
+        )
+        .returning({ id: legislationDocuments.id }),
     );
 
-    return true;
+    return recorded.length > 0 ? "written" : "skipped";
   } catch (error) {
     captureError(error, {
       documentId: row.id,
       step: "legislationCorpusStorageBackfill",
     });
-    return false;
+    return "failed";
   }
 };
 
 type BackfillResult = {
   written: number;
+  skipped: number;
   failed: number;
 };
 
@@ -281,10 +299,11 @@ const backfillCaseLaw = async (
 ): Promise<BackfillResult> => {
   let lastId: SafeId<"caseLawDecision"> | null = null;
   let written = 0;
+  let skipped = 0;
   let failed = 0;
 
   while (true) {
-    const batchSize = nextBatchSize(limit, written + failed);
+    const batchSize = nextBatchSize(limit, written + skipped + failed);
     if (batchSize === 0) {
       break;
     }
@@ -306,7 +325,7 @@ const backfillCaseLaw = async (
           fulltext: caseLawDecisions.fulltext,
           sections: caseLawDecisions.sections,
           documentAst: caseLawDecisions.documentAst,
-          updatedAt: caseLawDecisions.updatedAt,
+          updatedAtToken: timestampCasToken(caseLawDecisions.updatedAt),
         })
         .from(caseLawDecisions)
         .where(where)
@@ -324,8 +343,10 @@ const backfillCaseLaw = async (
         rows.slice(i, i + CONCURRENCY).map(backfillRow),
       );
       for (const outcome of outcomes) {
-        if (outcome) {
+        if (outcome === "written") {
           written += 1;
+        } else if (outcome === "skipped") {
+          skipped += 1;
         } else {
           failed += 1;
         }
@@ -333,10 +354,12 @@ const backfillCaseLaw = async (
     }
 
     lastId = rows.at(-1)?.id ?? lastId;
-    logInfo(`  case-law written=${written} failed=${failed}`);
+    logInfo(
+      `  case-law written=${written} skipped=${skipped} failed=${failed}`,
+    );
   }
 
-  return { written, failed };
+  return { written, skipped, failed };
 };
 
 const backfillLegislation = async (
@@ -344,10 +367,11 @@ const backfillLegislation = async (
 ): Promise<BackfillResult> => {
   let lastId: SafeId<"legislationDocument"> | null = null;
   let written = 0;
+  let skipped = 0;
   let failed = 0;
 
   while (true) {
-    const batchSize = nextBatchSize(limit, written + failed);
+    const batchSize = nextBatchSize(limit, written + skipped + failed);
     if (batchSize === 0) {
       break;
     }
@@ -369,7 +393,7 @@ const backfillLegislation = async (
           fulltext: legislationDocuments.fulltext,
           sections: legislationDocuments.sections,
           documentAst: legislationDocuments.documentAst,
-          updatedAt: legislationDocuments.updatedAt,
+          updatedAtToken: timestampCasToken(legislationDocuments.updatedAt),
         })
         .from(legislationDocuments)
         .where(where)
@@ -387,8 +411,10 @@ const backfillLegislation = async (
         rows.slice(i, i + CONCURRENCY).map(backfillLegislationRow),
       );
       for (const outcome of outcomes) {
-        if (outcome) {
+        if (outcome === "written") {
           written += 1;
+        } else if (outcome === "skipped") {
+          skipped += 1;
         } else {
           failed += 1;
         }
@@ -396,10 +422,12 @@ const backfillLegislation = async (
     }
 
     lastId = rows.at(-1)?.id ?? lastId;
-    logInfo(`  legislation written=${written} failed=${failed}`);
+    logInfo(
+      `  legislation written=${written} skipped=${skipped} failed=${failed}`,
+    );
   }
 
-  return { written, failed };
+  return { written, skipped, failed };
 };
 
 type IndexBackfillResult = {
@@ -508,7 +536,7 @@ export const runLegalCorpusStorageBackfill = async (
   );
 
   logInfo(
-    `Done. Case-law wrote ${caseLaw.written}, ${caseLaw.failed} failed. Legislation wrote ${legislation.written}, ${legislation.failed} failed.`,
+    `Done. Case-law wrote ${caseLaw.written}, skipped ${caseLaw.skipped}, ${caseLaw.failed} failed. Legislation wrote ${legislation.written}, skipped ${legislation.skipped}, ${legislation.failed} failed.`,
   );
   return caseLaw.failed === 0 && legislation.failed === 0 ? 0 : 1;
 };
@@ -572,7 +600,7 @@ export const runCaseLawCorpusStorageBackfill = async (
   const caseLaw = await backfillCaseLaw(parsed.options.caseLawLimit);
 
   logInfo(
-    `Done. Wrote ${caseLaw.written} decisions, ${caseLaw.failed} failed.`,
+    `Done. Wrote ${caseLaw.written} decisions, skipped ${caseLaw.skipped}, ${caseLaw.failed} failed.`,
   );
   return caseLaw.failed === 0 ? 0 : 1;
 };


### PR DESCRIPTION
## Summary

Every `updated_at` compare-and-set in the corpus family read the timestamp into a JS `Date` and compared it back. Postgres stores microseconds and a `Date` carries milliseconds, so the round-trip silently narrows the value: a row whose timestamp came from SQL `now()` can never match, and the guarded write no-ops without an error — the worst kind of failure, because the caller counts it as success.

- New `TimestampCasToken` (branded string) in `lib/db/timestamp-cas.ts`: the token is the column's exact `::text` form, selected via `timestampCasToken(column)` and compared via `timestampMatchesCasToken(column, token)`. The brand keeps a `Date` from re-entering any CAS path through the type system.
- Converted sites: the corpus storage backfills (runner and script variants, both families), the batched index mark (`markIndexedBatch` tuples), and the column-trim script.
- The storage backfill also stops counting a refused CAS as written: outcomes are now `written | skipped | failed` with `RETURNING`-based confirmation, and the progress/terminal logs report all three.

## Testing

- The database-backed mark test now forces microsecond-precision `updated_at` on every fixture row (SQL `now()`), so the suite fails if a `Date` round-trip reappears; all 21 corpus-index tests pass.
- `tsgo --noEmit` clean on `apps/api` and `apps/legal-atlas-runner`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved protection against overwriting newer case-law and legislation updates during indexing, backfills, and corpus maintenance.
  * Timestamp compare-and-set logic now retains full database precision (including microseconds), improving reliability for closely timed changes.
  * Concurrently refused updates are now treated as **skipped** rather than **successful** writes.

* **Improvements**
  * Backfill and corpus maintenance reporting now distinguishes **written**, **skipped**, and **failed** records for clearer operational visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->