### PR TITLE
feat(case-law): measure citation extraction against publisher cites at ingest

### DIFF
--- a/apps/api/src/handlers/case-law/ingestion/adapter.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapter.ts
@@ -46,6 +46,12 @@ export type IngestionResult = {
    * stored verbatim for future re-parsing without re-downloading.
    */
   sourceRaw?: string | undefined;
+  /**
+   * The publisher's own cited-decisions list, where the source supplies
+   * one (case numbers as published). Not stored on the row: it is the
+   * ground truth the pipeline measures citation extraction against.
+   */
+  publisherCitedCases?: readonly string[] | undefined;
   /** Binary raw source (e.g., PDF bytes) for S3 upload. */
   sourceRawBytes?: Uint8Array | undefined;
   /** MIME type of sourceRaw/sourceRawBytes for S3 storage. */

--- a/apps/api/src/handlers/case-law/ingestion/adapters/pl-courts.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/pl-courts.ts
@@ -602,6 +602,13 @@ const parseItemWithDetail = async (
   const rawPayload = JSON.stringify({ dumpItem, detail });
   const rawHash = hashContent(JSON.stringify(dumpItem));
 
+  const publisherCitedCases = normalizeOptionalArray(
+    item.referencedCourtCases,
+    dumpItem.referencedCourtCases,
+  )
+    ?.map((referenced) => referenced.caseNumber?.trim() ?? "")
+    .filter((caseNo) => caseNo.length > 0);
+
   return {
     caseNumber,
     ecli,
@@ -613,6 +620,7 @@ const parseItemWithDetail = async (
     fulltext,
     sourceUrl: publicSourceUrl(item.id ?? dumpItem.id),
     documentUrl,
+    publisherCitedCases,
     metadata: {
       caseNumber,
       court: courtName,

--- a/apps/api/src/handlers/case-law/ingestion/adapters/pl-courts.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/pl-courts.ts
@@ -606,7 +606,7 @@ const parseItemWithDetail = async (
     item.referencedCourtCases,
     dumpItem.referencedCourtCases,
   )
-    ?.map((referenced) => referenced.caseNumber?.trim() ?? "")
+    .map((referenced) => referenced.caseNumber?.trim() ?? "")
     .filter((caseNo) => caseNo.length > 0);
 
   return {

--- a/apps/api/src/handlers/case-law/ingestion/citation-extractor.ts
+++ b/apps/api/src/handlers/case-law/ingestion/citation-extractor.ts
@@ -112,6 +112,14 @@ const stripPrefix = (text: string): string => {
   return trimmed;
 };
 
+/**
+ * Canonical comparison key for a citation or case number: prefix
+ * stripped, typographic dashes normalized, case-folded. Two spellings
+ * of the same case number share one key.
+ */
+export const bareCitationKey = (text: string): string =>
+  normalizeDashes(stripPrefix(text.trim())).toLowerCase().trim();
+
 type DecisionIdentity = {
   caseNumber: string;
   ecli?: string | null;
@@ -133,10 +141,7 @@ export const isSelfCitation = (
   }
 
   // Compare bare case numbers (case-insensitive)
-  const bareCitation = normalizeDashes(stripPrefix(trimmed)).toLowerCase();
-  const bareSelf = normalizeDashes(decision.caseNumber).toLowerCase().trim();
-
-  return bareCitation === bareSelf;
+  return bareCitationKey(trimmed) === bareCitationKey(decision.caseNumber);
 };
 
 /**

--- a/apps/api/src/handlers/case-law/ingestion/citation-extractor.ts
+++ b/apps/api/src/handlers/case-law/ingestion/citation-extractor.ts
@@ -121,7 +121,10 @@ export const bareCitationKey = (text: string): string =>
   normalizeDashes(stripPrefix(text.trim()))
     .toLowerCase()
     .replaceAll(/\s+/gu, " ")
-    .replaceAll(/\s*\/\s*/gu, "/")
+    // After whitespace collapses, slash spacing is at most one space per
+    // side; plain string replaces keep the scan linear.
+    .replaceAll(" /", "/")
+    .replaceAll("/ ", "/")
     .trim();
 
 type DecisionIdentity = {

--- a/apps/api/src/handlers/case-law/ingestion/citation-extractor.ts
+++ b/apps/api/src/handlers/case-law/ingestion/citation-extractor.ts
@@ -118,7 +118,11 @@ const stripPrefix = (text: string): string => {
  * of the same case number share one key.
  */
 export const bareCitationKey = (text: string): string =>
-  normalizeDashes(stripPrefix(text.trim())).toLowerCase().trim();
+  normalizeDashes(stripPrefix(text.trim()))
+    .toLowerCase()
+    .replaceAll(/\s+/gu, " ")
+    .replaceAll(/\s*\/\s*/gu, "/")
+    .trim();
 
 type DecisionIdentity = {
   caseNumber: string;

--- a/apps/api/src/handlers/case-law/ingestion/citation-recall.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/citation-recall.test.ts
@@ -9,7 +9,7 @@ describe("publisherCitationGap", () => {
         extracted: ["sygn. akt II CSK 123/20", "C‑283/81"],
         publisherCited: ["II CSK 123/20", "C-283/81"],
       }),
-    ).toEqual([]);
+    ).toEqual({ publisherCitedCount: 2, missed: [] });
   });
 
   test("a publisher citation the extractor missed is reported verbatim", () => {
@@ -18,12 +18,21 @@ describe("publisherCitationGap", () => {
         extracted: ["sp. zn. 21 Cdo 1234/2020"],
         publisherCited: ["II CSK 999/20", "21 Cdo 1234/2020"],
       }),
-    ).toEqual(["II CSK 999/20"]);
+    ).toEqual({ publisherCitedCount: 2, missed: ["II CSK 999/20"] });
   });
 
   test("blank publisher entries are ignored", () => {
     expect(
       publisherCitationGap({ extracted: [], publisherCited: ["  ", ""] }),
-    ).toEqual([]);
+    ).toEqual({ publisherCitedCount: 0, missed: [] });
+  });
+
+  test("spelling variants of one publisher citation count once", () => {
+    expect(
+      publisherCitationGap({
+        extracted: [],
+        publisherCited: ["U 1/86", "U 1 /86"],
+      }),
+    ).toEqual({ publisherCitedCount: 1, missed: ["U 1/86"] });
   });
 });

--- a/apps/api/src/handlers/case-law/ingestion/citation-recall.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/citation-recall.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test";
+
+import { publisherCitationGap } from "@/api/handlers/case-law/ingestion/citation-recall";
+
+describe("publisherCitationGap", () => {
+  test("prefix and dash spellings of the same number are not gaps", () => {
+    expect(
+      publisherCitationGap({
+        extracted: ["sygn. akt II CSK 123/20", "C‑283/81"],
+        publisherCited: ["II CSK 123/20", "C-283/81"],
+      }),
+    ).toEqual([]);
+  });
+
+  test("a publisher citation the extractor missed is reported verbatim", () => {
+    expect(
+      publisherCitationGap({
+        extracted: ["sp. zn. 21 Cdo 1234/2020"],
+        publisherCited: ["II CSK 999/20", "21 Cdo 1234/2020"],
+      }),
+    ).toEqual(["II CSK 999/20"]);
+  });
+
+  test("blank publisher entries are ignored", () => {
+    expect(
+      publisherCitationGap({ extracted: [], publisherCited: ["  ", ""] }),
+    ).toEqual([]);
+  });
+});

--- a/apps/api/src/handlers/case-law/ingestion/citation-recall.ts
+++ b/apps/api/src/handlers/case-law/ingestion/citation-recall.ts
@@ -1,0 +1,24 @@
+import { bareCitationKey } from "@/api/handlers/case-law/ingestion/citation-extractor";
+
+/**
+ * Which of the publisher's own cited-decision list the extractor missed.
+ *
+ * Courts that publish structured "cites" metadata are the only ground truth
+ * the extractor can be measured against without measuring it against itself:
+ * a non-empty gap at ingest time means a citation shape the patterns do not
+ * cover, and is escalated as a structured event for the citation-quality
+ * routine to turn into a new pattern or a delegated classification.
+ */
+export const publisherCitationGap = ({
+  extracted,
+  publisherCited,
+}: {
+  extracted: readonly string[];
+  publisherCited: readonly string[];
+}): string[] => {
+  const have = new Set(extracted.map(bareCitationKey));
+  return publisherCited.filter((cited) => {
+    const trimmed = cited.trim();
+    return trimmed.length > 0 && !have.has(bareCitationKey(trimmed));
+  });
+};

--- a/apps/api/src/handlers/case-law/ingestion/citation-recall.ts
+++ b/apps/api/src/handlers/case-law/ingestion/citation-recall.ts
@@ -15,10 +15,24 @@ export const publisherCitationGap = ({
 }: {
   extracted: readonly string[];
   publisherCited: readonly string[];
-}): string[] => {
+}): { publisherCitedCount: number; missed: string[] } => {
   const have = new Set(extracted.map(bareCitationKey));
-  return publisherCited.filter((cited) => {
+  // Publisher lists repeat the same decision under spelling variants
+  // ("U 1/86" vs "U 1 /86"); the canonical key deduplicates them so the
+  // denominator counts decisions, not spellings.
+  const canonical = new Map<string, string>();
+  for (const cited of publisherCited) {
     const trimmed = cited.trim();
-    return trimmed.length > 0 && !have.has(bareCitationKey(trimmed));
-  });
+    if (trimmed.length === 0) {
+      continue;
+    }
+    const key = bareCitationKey(trimmed);
+    if (!canonical.has(key)) {
+      canonical.set(key, trimmed);
+    }
+  }
+  const missed = [...canonical.entries()]
+    .filter(([key]) => !have.has(key))
+    .map(([, spelling]) => spelling);
+  return { publisherCitedCount: canonical.size, missed };
 };

--- a/apps/api/src/handlers/case-law/ingestion/pipeline.ts
+++ b/apps/api/src/handlers/case-law/ingestion/pipeline.ts
@@ -235,6 +235,12 @@ export const sanitizeResult = (r: IngestionResult): IngestionResult => {
     sourceUrl: strip(r.sourceUrl),
     documentUrl: strip(r.documentUrl),
     metadata: sanitizeMetadata(r.metadata),
+    // Publisher-supplied case numbers are compared against citations
+    // extracted from the sanitized text; an unsanitized zero-width char
+    // here would break that key equality.
+    publisherCitedCases: r.publisherCitedCases?.map((cited) =>
+      stripDangerousChars(cited),
+    ),
     // Adapter-supplied sections come from court HTML like every other
     // field and must go through the same strip. The fallback path was
     // safe only incidentally: `segmentDecision` runs on the already

--- a/apps/api/src/handlers/case-law/ingestion/pipeline.ts
+++ b/apps/api/src/handlers/case-law/ingestion/pipeline.ts
@@ -673,13 +673,16 @@ export const processDecision = async (
   // commits (a replayed decision must not re-count) — and emitted for
   // zero-gap decisions too, or aggregated events could not produce a
   // recall denominator.
-  // Skipped on a document-preserving refresh: the stored document and its
-  // citations are retained, so measuring the empty incoming payload would
-  // report every publisher citation as missed. Emitted here rather than
-  // after the write because an ambiguous timeout can commit the row yet
-  // throw, and the replay dedup-skips before re-measuring; the source
-  // hash is the identity a consumer deduplicates retries on.
+  // Measured only when the incoming payload carries a document: an empty
+  // payload has nothing for extraction to find, so every publisher
+  // citation would read as missed — on document-preserving refreshes and
+  // equally when a concurrent backfill wins the row between the read and
+  // the transaction. Emitted here rather than after the write because an
+  // ambiguous timeout can commit the row yet throw, and the replay
+  // dedup-skips before re-measuring; the source hash is the identity a
+  // consumer deduplicates retries on.
   if (
+    incomingCarriesDocument &&
     !preserveStoredDocument &&
     result.publisherCitedCases &&
     result.publisherCitedCases.length > 0

--- a/apps/api/src/handlers/case-law/ingestion/pipeline.ts
+++ b/apps/api/src/handlers/case-law/ingestion/pipeline.ts
@@ -39,6 +39,7 @@ import {
   extractCitations,
   isSelfCitation,
 } from "@/api/handlers/case-law/ingestion/citation-extractor";
+import { publisherCitationGap } from "@/api/handlers/case-law/ingestion/citation-recall";
 import { storedDecisionSignal } from "@/api/handlers/case-law/ingestion/parsers/validate-ast";
 import { shouldSkipRefresh } from "@/api/handlers/case-law/ingestion/refresh-policy";
 import {
@@ -665,6 +666,27 @@ export const processDecision = async (
         ecli: result.ecli ?? null,
       }),
   );
+
+  // Where the publisher supplies its own cited-decisions list, it is the
+  // one ground truth extraction can be measured against without measuring
+  // it against itself: a gap here is a citation shape the patterns do not
+  // cover, escalated for the citation-quality routine to pick up.
+  if (result.publisherCitedCases && result.publisherCitedCases.length > 0) {
+    const missedPublisherCitations = publisherCitationGap({
+      extracted: citations.map((c) => c.citationText),
+      publisherCited: result.publisherCitedCases,
+    });
+    if (missedPublisherCitations.length > 0) {
+      logger.warn("case_law.ingestion.citation_recall_gap", {
+        caseNumber: result.caseNumber,
+        language: result.language,
+        url: result.sourceUrl ?? "",
+        publisherCitedCount: result.publisherCitedCases.length,
+        missedCount: missedPublisherCitations.length,
+        missed: missedPublisherCitations.slice(0, 10).join("; "),
+      });
+    }
+  }
 
   const languageGroupKey = result.ecli || `${sourceId}:${result.caseNumber}`;
 

--- a/apps/api/src/handlers/case-law/ingestion/pipeline.ts
+++ b/apps/api/src/handlers/case-law/ingestion/pipeline.ts
@@ -669,24 +669,20 @@ export const processDecision = async (
 
   // Where the publisher supplies its own cited-decisions list, it is the
   // one ground truth extraction can be measured against without measuring
-  // it against itself: a gap here is a citation shape the patterns do not
-  // cover, escalated for the citation-quality routine to pick up.
-  if (result.publisherCitedCases && result.publisherCitedCases.length > 0) {
-    const missedPublisherCitations = publisherCitationGap({
-      extracted: citations.map((c) => c.citationText),
-      publisherCited: result.publisherCitedCases,
-    });
-    if (missedPublisherCitations.length > 0) {
-      logger.warn("case_law.ingestion.citation_recall_gap", {
-        caseNumber: result.caseNumber,
-        language: result.language,
-        url: result.sourceUrl ?? "",
-        publisherCitedCount: result.publisherCitedCases.length,
-        missedCount: missedPublisherCitations.length,
-        missed: missedPublisherCitations.slice(0, 10).join("; "),
-      });
-    }
-  }
+  // it against itself. Computed here, emitted only after the row write
+  // commits (a replayed decision must not re-count) — and emitted for
+  // zero-gap decisions too, or aggregated events could not produce a
+  // recall denominator.
+  const publisherRecall =
+    result.publisherCitedCases && result.publisherCitedCases.length > 0
+      ? {
+          publisherCitedCount: result.publisherCitedCases.length,
+          missed: publisherCitationGap({
+            extracted: citations.map((c) => c.citationText),
+            publisherCited: result.publisherCitedCases,
+          }),
+        }
+      : null;
 
   const languageGroupKey = result.ecli || `${sourceId}:${result.caseNumber}`;
 
@@ -916,6 +912,19 @@ export const processDecision = async (
       await discardOrphanedCorpusObjects(corpusPlan.written, decisionId);
     }
     throw rowWrite.error;
+  }
+
+  if (publisherRecall) {
+    const level = publisherRecall.missed.length > 0 ? "warn" : "info";
+    logger[level]("case_law.ingestion.citation_recall", {
+      caseNumber: result.caseNumber,
+      language: result.language,
+      url: result.sourceUrl ?? "",
+      sourceHash: result.rawHash,
+      publisherCitedCount: publisherRecall.publisherCitedCount,
+      missedCount: publisherRecall.missed.length,
+      missed: publisherRecall.missed.slice(0, 10).join("; "),
+    });
   }
 
   // Mirror text/sections/AST to object storage, then record the keys +

--- a/apps/api/src/handlers/case-law/ingestion/pipeline.ts
+++ b/apps/api/src/handlers/case-law/ingestion/pipeline.ts
@@ -673,16 +673,32 @@ export const processDecision = async (
   // commits (a replayed decision must not re-count) — and emitted for
   // zero-gap decisions too, or aggregated events could not produce a
   // recall denominator.
-  const publisherRecall =
-    result.publisherCitedCases && result.publisherCitedCases.length > 0
-      ? {
-          publisherCitedCount: result.publisherCitedCases.length,
-          missed: publisherCitationGap({
-            extracted: citations.map((c) => c.citationText),
-            publisherCited: result.publisherCitedCases,
-          }),
-        }
-      : null;
+  // Skipped on a document-preserving refresh: the stored document and its
+  // citations are retained, so measuring the empty incoming payload would
+  // report every publisher citation as missed. Emitted here rather than
+  // after the write because an ambiguous timeout can commit the row yet
+  // throw, and the replay dedup-skips before re-measuring; the source
+  // hash is the identity a consumer deduplicates retries on.
+  if (
+    !preserveStoredDocument &&
+    result.publisherCitedCases &&
+    result.publisherCitedCases.length > 0
+  ) {
+    const recall = publisherCitationGap({
+      extracted: citations.map((c) => c.citationText),
+      publisherCited: result.publisherCitedCases,
+    });
+    const level = recall.missed.length > 0 ? "warn" : "info";
+    logger[level]("case_law.ingestion.citation_recall", {
+      caseNumber: result.caseNumber,
+      language: result.language,
+      url: result.sourceUrl ?? "",
+      sourceHash: result.rawHash,
+      publisherCitedCount: recall.publisherCitedCount,
+      missedCount: recall.missed.length,
+      missed: recall.missed.slice(0, 10).join("; "),
+    });
+  }
 
   const languageGroupKey = result.ecli || `${sourceId}:${result.caseNumber}`;
 
@@ -912,19 +928,6 @@ export const processDecision = async (
       await discardOrphanedCorpusObjects(corpusPlan.written, decisionId);
     }
     throw rowWrite.error;
-  }
-
-  if (publisherRecall) {
-    const level = publisherRecall.missed.length > 0 ? "warn" : "info";
-    logger[level]("case_law.ingestion.citation_recall", {
-      caseNumber: result.caseNumber,
-      language: result.language,
-      url: result.sourceUrl ?? "",
-      sourceHash: result.rawHash,
-      publisherCitedCount: publisherRecall.publisherCitedCount,
-      missedCount: publisherRecall.missed.length,
-      missed: publisherRecall.missed.slice(0, 10).join("; "),
-    });
   }
 
   // Mirror text/sections/AST to object storage, then record the keys +


### PR DESCRIPTION
## Summary

Courts that publish structured cited-decision metadata are the only ground truth citation extraction can be measured against without measuring it against itself. This wires that check into the pipeline:

- `IngestionResult.publisherCitedCases` (optional): the publisher's own cited-decision list, as published; pl-courts populates it from SAOS `referencedCourtCases`.
- After extraction, the pipeline computes the gap (`publisherCitationGap`, a pure function) and emits `case_law.ingestion.citation_recall_gap` — a WARN-level structured event carrying the missed citations (bounded), the counts, and the standard case identifiers — so a scheduled sweep can aggregate per-source recall and turn concrete missed shapes into new extractor patterns.
- Both sides key through the extractor's canonical bare-number form (`bareCitationKey`, now exported and reused by the self-citation check), so prefix variants and typographic-dash spellings of the same case number are not false gaps.

## Testing

- New unit tests for the gap function (prefix/dash equivalence, verbatim miss reporting, blank-entry handling); extractor and pipeline suites pass (29 + 11).
- `tsgo --noEmit` clean on `apps/api`.