### PR TITLE
feat(case-law): random-sample citation probe script

### DIFF
--- a/apps/api/src/handlers/case-law/ingestion/citation-extractor.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/citation-extractor.test.ts
@@ -65,6 +65,13 @@ describe("extractCitations", () => {
     expect(texts).toContain("Pl. ÚS 12/94");
   });
 
+  test("extracts Slovak Constitutional Court citations without the senate dot", () => {
+    const text = "nález sp. zn. III ÚS 154/2011 z 13. 4. 2011";
+    const citations = extractCitations([{ index: 0, text }]);
+    expect(citations).toHaveLength(1);
+    expect(citations[0]?.citationText).toBe("III ÚS 154/2011");
+  });
+
   test("treats hyphen variants of a CJEU number as one citation and as self", () => {
     const text = "věc C‑128/22 a rozsudek C-128/22";
     const citations = extractCitations([{ index: 0, text }]);

--- a/apps/api/src/handlers/case-law/ingestion/citation-extractor.ts
+++ b/apps/api/src/handlers/case-law/ingestion/citation-extractor.ts
@@ -40,11 +40,12 @@ const CITATION_PATTERNS: RegExp[] = [
   // ("MSP-725/2022") out.
   /sp\.\s*zn\.\s*(?<caseNumber>\p{L}{1,4}\s+\d{1,6}\/\d{2,4})(?!\d)/gu,
 
-  // Czech Constitutional Court: "IV. ÚS 23/05", "Pl. ÚS 12/94" — the
-  // senate is a Roman numeral (or Pl. for the plenum), so the digit-led
-  // pattern above never matches these. The bare form also covers the
-  // "sp. zn. IV. ÚS 23/05" spelling.
-  /\b(?<caseNumber>(?:[IVX]{1,4}|Pl)\.\s*ÚS\s+\d{1,5}\/\d{2,4})(?!\d)/gu,
+  // Constitutional Courts: "IV. ÚS 23/05", "Pl. ÚS 12/94" (Czech, with a
+  // dot after the senate numeral) and "III ÚS 154/2011" (Slovak, without
+  // one). The senate is a Roman numeral (or Pl. for the plenum), so the
+  // digit-led pattern above never matches these; the bare form also
+  // covers the "sp. zn. IV. ÚS 23/05" spelling.
+  /\b(?<caseNumber>(?:[IVX]{1,4}|Pl)\.?\s*ÚS\s+\d{1,5}\/\d{2,4})(?!\d)/gu,
 
   // CJEU: "C-283/81", "T-13/99", "F-100/09" (Court of Justice, General
   // Court, Civil Service Tribunal), including the non-breaking hyphen

--- a/apps/api/src/scripts/citation-probe.ts
+++ b/apps/api/src/scripts/citation-probe.ts
@@ -177,11 +177,22 @@ const sampleKeys = async (jurisdiction: string, want: number) => {
     if (keys.size >= want) {
       break;
     }
-    const textKey = listed.contents?.find((entry) =>
+    const textEntries = (listed.contents ?? []).filter((entry) =>
       entry.key.endsWith("/text.zst"),
-    )?.key;
-    if (textKey) {
-      keys.add(textKey);
+    );
+    // A backfilled document can leave an orphaned older content-addressed
+    // payload beside the live one; the most recent write is the version
+    // the database points at.
+    const docOf = (key: string): string => key.split("/").at(3) ?? key;
+    const first = textEntries.at(0);
+    if (first) {
+      const sameDoc = textEntries.filter(
+        (entry) => docOf(entry.key) === docOf(first.key),
+      );
+      const newest = sameDoc.reduce((a, b) =>
+        (a.lastModified ?? "") > (b.lastModified ?? "") ? a : b,
+      );
+      keys.add(newest.key);
     }
   }
   return [...keys];
@@ -212,12 +223,26 @@ const probeKey = async (
     };
   }
   const extracted = extractCitations([{ index: 0, text }]);
-  const covered = (candidate: string): boolean =>
-    extracted.some(
-      (c) =>
-        candidate.includes(c.citationText) ||
-        c.citationText.includes(candidate),
+  // Both sides normalize (prefix stripped, whitespace collapsed) before
+  // the containment check: the extractor dedups sp. zn. and č. j.
+  // spellings of one case number to a single entry, and the surviving
+  // prefix must not decide coverage.
+  const stripCitePrefix = (value: string): string =>
+    value
+      .replace(
+        /^(?:sp\.\s{0,3}zn\.:?|sen\.\s{0,3}zn\.:?|sygn\.(?:\s{1,3}akt)?|[čc]\.\s{0,3}j\.:?)\s{0,3}/iu,
+        "",
+      )
+      .replaceAll(/\s+/gu, " ")
+      .toLowerCase()
+      .trim();
+  const extractedKeys = extracted.map((c) => stripCitePrefix(c.citationText));
+  const covered = (candidate: string): boolean => {
+    const key = stripCitePrefix(candidate);
+    return extractedKeys.some(
+      (have) => key.includes(have) || have.includes(key),
     );
+  };
   const residuals = new Set<string>();
   for (const detector of DETECTORS) {
     detector.lastIndex = 0;
@@ -241,10 +266,19 @@ const probeKey = async (
   };
 };
 
-const want = Math.max(1, Math.floor(sampleTarget / JURISDICTIONS.length));
+// Distribute the requested total across jurisdictions, remainder to the
+// front, so --sample means what it says.
+const perJurisdiction = JURISDICTIONS.map((_, i) => {
+  const base = Math.floor(sampleTarget / JURISDICTIONS.length);
+  return base + (i < sampleTarget % JURISDICTIONS.length ? 1 : 0);
+});
 const docs = (
   await Promise.all(
-    JURISDICTIONS.map(async (jurisdiction) => {
+    JURISDICTIONS.map(async (jurisdiction, i) => {
+      const want = perJurisdiction[i] ?? 0;
+      if (want === 0) {
+        return [];
+      }
       const keys = await sampleKeys(jurisdiction, want);
       return await Promise.all(
         keys.map(async (key) => await probeKey(jurisdiction, key)),

--- a/apps/api/src/scripts/citation-probe.ts
+++ b/apps/api/src/scripts/citation-probe.ts
@@ -1,0 +1,165 @@
+/**
+ * Random-sample citation probe: how much citation-shaped text does the
+ * extractor miss in real decisions?
+ *
+ * Samples decisions straight from the corpus bucket (uniform over document
+ * ids via random-UUID `startAfter` listing, no database needed), runs the
+ * production extractor, then a set of deliberately broad citation-ish
+ * detectors, and reports only the residuals no benign filter explains. The
+ * output is intentionally compact: a scheduled reviewer reads residual
+ * lines, not decisions.
+ *
+ *   AWS_REGION=eu-central-1 bun src/scripts/citation-probe.ts \
+ *     --bucket <legal-corpus-bucket> [--sample 18]
+ */
+import { extractCitations } from "@/api/handlers/case-law/ingestion/citation-extractor";
+import { zstdDecompressToString } from "@/api/lib/compression";
+
+const JURISDICTIONS = ["CZE", "SVK", "POL"] as const;
+const KEY_PREFIX = "legal-corpus/documents/jurisdiction=";
+
+const args = Bun.argv.slice(2);
+const argValue = (name: string): string | undefined => {
+  const idx = args.indexOf(name);
+  return idx >= 0 ? args[idx + 1] : undefined;
+};
+
+const bucket = argValue("--bucket");
+if (!bucket) {
+  console.error("citation-probe: --bucket is required");
+  process.exit(2);
+}
+const sampleTarget = Number(argValue("--sample") ?? "18");
+if (!Number.isInteger(sampleTarget) || sampleTarget <= 0) {
+  console.error("citation-probe: --sample must be a positive integer");
+  process.exit(2);
+}
+
+// Explicit credential plumbing: the client's environment inference does
+// not cover session credentials (SSO, task roles), which carry a token.
+const credentialEnv = {
+  ...(Bun.env["AWS_ACCESS_KEY_ID"]
+    ? { accessKeyId: Bun.env["AWS_ACCESS_KEY_ID"] }
+    : {}),
+  ...(Bun.env["AWS_SECRET_ACCESS_KEY"]
+    ? { secretAccessKey: Bun.env["AWS_SECRET_ACCESS_KEY"] }
+    : {}),
+  ...(Bun.env["AWS_SESSION_TOKEN"]
+    ? { sessionToken: Bun.env["AWS_SESSION_TOKEN"] }
+    : {}),
+};
+
+const region = Bun.env["AWS_REGION"] ?? "eu-central-1";
+
+const s3 = new Bun.S3Client({
+  bucket,
+  region,
+  // Without an explicit endpoint the client signs against the wrong host
+  // and session credentials are rejected.
+  endpoint: `https://s3.${region}.amazonaws.com`,
+  ...credentialEnv,
+});
+
+// Broad candidate detectors. Noisy on purpose; benign filters and the
+// covered-check prune them, and whatever survives is worth human review.
+const DETECTORS: readonly RegExp[] = [
+  /(?:sp\.\s*zn\.|sen\.\s*zn\.|sygn\.\s*(?:akt\s+)?|[čc]\.\s*j\.:?)\s*[^\s,;()][^,;()\n]{2,38}/gu,
+  /\b(?:[IVX]{1,4}|Pl)\.?\s*ÚS[^,;()\n]{0,18}/gu,
+  /\bECLI:[^\s,;)]+/gu,
+  /\b[CTF][-‑–]\s?\d{1,4}\/\d{2,4}/gu,
+];
+
+// Residual classes that are not court decisions and never will be:
+// administrative-authority file numbers (letter blocks joined by dashes),
+// anonymization placeholders, and statute/collection references.
+const BENIGN: readonly RegExp[] = [
+  /[A-ZÁČĎÉĚÍŇÓŘŠŤÚŮÝŽ]{2,}[-–][\w/–-]*\d/u,
+  /X{2,}/u,
+  /\d+\/\d+\s+Sb\b/u,
+  /\bZb\.\s*z\b/u,
+  // Polish procurement-tribunal rulings (KIO/UZP): quasi-judicial, not a
+  // court source the corpus ingests, so never a resolvable citation.
+  /\bKIO\s*\/?\s*UZP\b/u,
+];
+
+const isBenign = (candidate: string): boolean =>
+  BENIGN.some((re) => re.test(candidate));
+
+const sampleKeys = async (jurisdiction: string, want: number) => {
+  const keys: string[] = [];
+  const prefix = `${KEY_PREFIX}${jurisdiction}/`;
+  let guard = 0;
+  while (keys.length < want && guard < want * 4) {
+    guard += 1;
+    // A random v4 UUID as the listing cursor is a uniform draw over the
+    // id space; v7 would be time-prefixed and collapse every draw onto
+    // the most recent documents.
+    const listed = await s3.list({
+      prefix,
+      startAfter: `${prefix}${crypto.randomUUID()}`,
+      maxKeys: 8,
+    });
+    const textKey = listed.contents?.find((entry) =>
+      entry.key.endsWith("/text.zst"),
+    )?.key;
+    if (textKey && !keys.includes(textKey)) {
+      keys.push(textKey);
+    }
+  }
+  return keys;
+};
+
+let totalDocs = 0;
+let totalExtracted = 0;
+let totalResiduals = 0;
+let emptyDocs = 0;
+
+for (const jurisdiction of JURISDICTIONS) {
+  const want = Math.max(1, Math.floor(sampleTarget / JURISDICTIONS.length));
+  // oxlint-disable-next-line no-await-in-loop -- sequential per-jurisdiction sampling keeps S3 pressure trivial
+  const keys = await sampleKeys(jurisdiction, want);
+  for (const key of keys) {
+    // oxlint-disable-next-line no-await-in-loop -- one object at a time; the probe favors simplicity over speed
+    const body = await s3.file(key).bytes();
+    const text = zstdDecompressToString(body);
+    if (text.trim().length === 0) {
+      emptyDocs += 1;
+      continue;
+    }
+    const extracted = extractCitations([{ index: 0, text }]);
+    const covered = (candidate: string): boolean =>
+      extracted.some(
+        (c) =>
+          candidate.includes(c.citationText) ||
+          c.citationText.includes(candidate),
+      );
+    const residuals = new Set<string>();
+    for (const detector of DETECTORS) {
+      detector.lastIndex = 0;
+      for (
+        let match = detector.exec(text);
+        match !== null;
+        match = detector.exec(text)
+      ) {
+        const candidate = match[0].replaceAll(/\s+/gu, " ").trim();
+        if (!covered(candidate) && !isBenign(candidate)) {
+          residuals.add(candidate);
+        }
+      }
+    }
+    totalDocs += 1;
+    totalExtracted += extracted.length;
+    totalResiduals += residuals.size;
+    const documentId = key.slice(KEY_PREFIX.length).split("/").at(1) ?? key;
+    if (residuals.size > 0) {
+      console.log(`RESIDUAL ${jurisdiction} ${documentId}`);
+      for (const residual of [...residuals].slice(0, 6)) {
+        console.log(`  ${residual}`);
+      }
+    }
+  }
+}
+
+console.log(
+  `SUMMARY docs=${totalDocs} empty=${emptyDocs} extracted=${totalExtracted} residual-candidates=${totalResiduals}`,
+);

--- a/apps/api/src/scripts/citation-probe.ts
+++ b/apps/api/src/scripts/citation-probe.ts
@@ -177,7 +177,11 @@ const sampleKeys = async (jurisdiction: string, want: number) => {
     if (keys.size >= want) {
       break;
     }
-    const textEntries = (listed.contents ?? []).filter((entry) =>
+    const contents = listed.contents;
+    if (!contents) {
+      continue;
+    }
+    const textEntries = contents.filter((entry) =>
       entry.key.endsWith("/text.zst"),
     );
     // A backfilled document can leave an orphaned older content-addressed
@@ -189,9 +193,12 @@ const sampleKeys = async (jurisdiction: string, want: number) => {
       const sameDoc = textEntries.filter(
         (entry) => docOf(entry.key) === docOf(first.key),
       );
-      const newest = sameDoc.reduce((a, b) =>
-        (a.lastModified ?? "") > (b.lastModified ?? "") ? a : b,
-      );
+      let newest = first;
+      for (const entry of sameDoc) {
+        if ((entry.lastModified ?? "") > (newest.lastModified ?? "")) {
+          newest = entry;
+        }
+      }
       keys.add(newest.key);
     }
   }
@@ -238,9 +245,9 @@ const probeKey = async (
       .trim();
   const extractedKeys = extracted.map((c) => stripCitePrefix(c.citationText));
   const covered = (candidate: string): boolean => {
-    const key = stripCitePrefix(candidate);
+    const candidateKey = stripCitePrefix(candidate);
     return extractedKeys.some(
-      (have) => key.includes(have) || have.includes(key),
+      (have) => candidateKey.includes(have) || have.includes(candidateKey),
     );
   };
   const residuals = new Set<string>();

--- a/apps/api/src/scripts/citation-probe.ts
+++ b/apps/api/src/scripts/citation-probe.ts
@@ -14,6 +14,7 @@
  */
 import { extractCitations } from "@/api/handlers/case-law/ingestion/citation-extractor";
 import { zstdDecompressToString } from "@/api/lib/compression";
+import { isRecord } from "@/api/lib/type-guards";
 
 const JURISDICTIONS = ["CZE", "SVK", "POL"] as const;
 const KEY_PREFIX = "legal-corpus/documents/jurisdiction=";
@@ -21,7 +22,7 @@ const KEY_PREFIX = "legal-corpus/documents/jurisdiction=";
 const args = Bun.argv.slice(2);
 const argValue = (name: string): string | undefined => {
   const idx = args.indexOf(name);
-  return idx >= 0 ? args[idx + 1] : undefined;
+  return idx !== -1 ? args[idx + 1] : undefined;
 };
 
 const bucket = argValue("--bucket");
@@ -35,19 +36,73 @@ if (!Number.isInteger(sampleTarget) || sampleTarget <= 0) {
   process.exit(2);
 }
 
-// Explicit credential plumbing: the client's environment inference does
-// not cover session credentials (SSO, task roles), which carry a token.
-const credentialEnv = {
-  ...(Bun.env["AWS_ACCESS_KEY_ID"]
-    ? { accessKeyId: Bun.env["AWS_ACCESS_KEY_ID"] }
-    : {}),
-  ...(Bun.env["AWS_SECRET_ACCESS_KEY"]
-    ? { secretAccessKey: Bun.env["AWS_SECRET_ACCESS_KEY"] }
-    : {}),
-  ...(Bun.env["AWS_SESSION_TOKEN"]
-    ? { sessionToken: Bun.env["AWS_SESSION_TOKEN"] }
-    : {}),
+/** Race an S3 operation against a deadline so a stall cannot hang the probe. */
+const withDeadline = async <T>(work: Promise<T>, label: string): Promise<T> => {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const deadline = new Promise<never>((_resolve, reject) => {
+    timer = setTimeout(
+      () => reject(new Error(`${label}: timed out after 30s`)),
+      30_000,
+    );
+  });
+  try {
+    return await Promise.race([work, deadline]);
+  } finally {
+    clearTimeout(timer);
+  }
 };
+
+type ResolvedCredentials = {
+  accessKeyId: string;
+  secretAccessKey: string;
+  sessionToken?: string;
+};
+
+/**
+ * Environment keys first (SSO exports, CI); otherwise the ECS container
+ * credential endpoint, which is how a task role exposes its keys.
+ */
+const resolveCredentials = async (): Promise<ResolvedCredentials | null> => {
+  const accessKeyId = Bun.env["AWS_ACCESS_KEY_ID"];
+  const secretAccessKey = Bun.env["AWS_SECRET_ACCESS_KEY"];
+  if (accessKeyId && secretAccessKey) {
+    const sessionToken = Bun.env["AWS_SESSION_TOKEN"];
+    return {
+      accessKeyId,
+      secretAccessKey,
+      ...(sessionToken ? { sessionToken } : {}),
+    };
+  }
+  const relativeUri = Bun.env["AWS_CONTAINER_CREDENTIALS_RELATIVE_URI"];
+  if (!relativeUri) {
+    return null;
+  }
+  const response = await fetch(`http://169.254.170.2${relativeUri}`, {
+    signal: AbortSignal.timeout(5000),
+  });
+  const body: unknown = await response.json();
+  if (
+    !isRecord(body) ||
+    typeof body["AccessKeyId"] !== "string" ||
+    typeof body["SecretAccessKey"] !== "string"
+  ) {
+    return null;
+  }
+  const token = body["Token"];
+  return {
+    accessKeyId: body["AccessKeyId"],
+    secretAccessKey: body["SecretAccessKey"],
+    ...(typeof token === "string" ? { sessionToken: token } : {}),
+  };
+};
+
+const credentials = await resolveCredentials();
+if (!credentials) {
+  console.error(
+    "citation-probe: no AWS credentials (env keys or container endpoint)",
+  );
+  process.exit(2);
+}
 
 const region = Bun.env["AWS_REGION"] ?? "eu-central-1";
 
@@ -57,109 +112,165 @@ const s3 = new Bun.S3Client({
   // Without an explicit endpoint the client signs against the wrong host
   // and session credentials are rejected.
   endpoint: `https://s3.${region}.amazonaws.com`,
-  ...credentialEnv,
+  ...credentials,
 });
 
 // Broad candidate detectors. Noisy on purpose; benign filters and the
 // covered-check prune them, and whatever survives is worth human review.
+// Every quantifier is bounded so the scan stays linear (the repo ratchets
+// super-linear regexes).
 const DETECTORS: readonly RegExp[] = [
-  /(?:sp\.\s*zn\.|sen\.\s*zn\.|sygn\.\s*(?:akt\s+)?|[čc]\.\s*j\.:?)\s*[^\s,;()][^,;()\n]{2,38}/gu,
-  /\b(?:[IVX]{1,4}|Pl)\.?\s*ÚS[^,;()\n]{0,18}/gu,
-  /\bECLI:[^\s,;)]+/gu,
-  /\b[CTF][-‑–]\s?\d{1,4}\/\d{2,4}/gu,
+  /(?:sp\.\s{0,3}zn\.|sen\.\s{0,3}zn\.|sygn\.(?:\s{1,3}akt)?|[čc]\.\s{0,3}j\.:?)\s{0,3}[^,;()\n]{3,38}/gu,
+  /\b(?:[IVX]{1,4}|Pl)\.?\s{0,3}ÚS[^,;()\n]{0,18}/gu,
+  /\bECLI:[^\s,;)]{1,60}/gu,
+  /\b[CTF][-‑–]\s{0,1}\d{1,4}\/\d{2,4}/gu,
 ];
 
 // Residual classes that are not court decisions and never will be:
 // administrative-authority file numbers (letter blocks joined by dashes),
 // anonymization placeholders, and statute/collection references.
 const BENIGN: readonly RegExp[] = [
-  /[A-ZÁČĎÉĚÍŇÓŘŠŤÚŮÝŽ]{2,}[-–][\w/–-]*\d/u,
+  /[A-ZÁČĎÉĚÍŇÓŘŠŤÚŮÝŽ]{2,8}[-–][\w/–-]{0,30}\d/u,
   /X{2,}/u,
-  /\d+\/\d+\s+Sb\b/u,
+  /\b\d{1,5}\/\d{2,4}\s{1,3}Sb\b/u,
   /\bZb\.\s*z\b/u,
   // Polish procurement-tribunal rulings (KIO/UZP): quasi-judicial, not a
   // court source the corpus ingests, so never a resolvable citation.
-  /\bKIO\s*\/?\s*UZP\b/u,
+  /\bKIO ?\/? ?UZP\b/u,
 ];
 
 const isBenign = (candidate: string): boolean =>
   BENIGN.some((re) => re.test(candidate));
 
+/** Uniform random UUID-shaped hex string (not crypto.randomUUID: the id
+ * layout is irrelevant here, only its lexicographic position). */
+const randomHexUuid = (): string => {
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  const hex = [...bytes].map((b) => b.toString(16).padStart(2, "0")).join("");
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+};
+
 const sampleKeys = async (jurisdiction: string, want: number) => {
-  const keys: string[] = [];
   const prefix = `${KEY_PREFIX}${jurisdiction}/`;
-  let guard = 0;
-  while (keys.length < want && guard < want * 4) {
-    guard += 1;
-    // A random v4 UUID as the listing cursor is a uniform draw over the
-    // id space; v7 would be time-prefixed and collapse every draw onto
-    // the most recent documents.
-    const listed = await s3.list({
-      prefix,
-      startAfter: `${prefix}${crypto.randomUUID()}`,
-      maxKeys: 8,
-    });
+  // The id space is mixed: database-defaulted rows carry uniform v4 ids
+  // while application-minted rows carry time-prefixed v7 ids that cluster
+  // lexicographically under `01…`. Half the cursors draw fully at random
+  // (v4 region), half are pinned into the v7 era prefix; within each
+  // region, sampling is proportional to key gaps, which for the
+  // time-ordered v7 cluster approximates time-uniform. Over-draw and
+  // deduplicate, since independent draws can land on the same document.
+  const cursors = Array.from({ length: want * 3 }, (_, i) =>
+    i % 2 === 0 ? randomHexUuid() : `019${randomHexUuid().slice(3)}`,
+  );
+  const listings = await Promise.all(
+    cursors.map(
+      async (cursor) =>
+        await withDeadline(
+          s3.list({ prefix, startAfter: `${prefix}${cursor}`, maxKeys: 8 }),
+          "s3.list",
+        ),
+    ),
+  );
+  const keys = new Set<string>();
+  for (const listed of listings) {
+    if (keys.size >= want) {
+      break;
+    }
     const textKey = listed.contents?.find((entry) =>
       entry.key.endsWith("/text.zst"),
     )?.key;
-    if (textKey && !keys.includes(textKey)) {
-      keys.push(textKey);
+    if (textKey) {
+      keys.add(textKey);
     }
   }
-  return keys;
+  return [...keys];
 };
 
-let totalDocs = 0;
+type ProbedDoc = {
+  jurisdiction: string;
+  documentId: string;
+  empty: boolean;
+  extractedCount: number;
+  residuals: string[];
+};
+
+const probeKey = async (
+  jurisdiction: string,
+  key: string,
+): Promise<ProbedDoc> => {
+  const body = await withDeadline(s3.file(key).bytes(), "s3.get");
+  const text = zstdDecompressToString(body);
+  const documentId = key.slice(KEY_PREFIX.length).split("/").at(1) ?? key;
+  if (text.trim().length === 0) {
+    return {
+      jurisdiction,
+      documentId,
+      empty: true,
+      extractedCount: 0,
+      residuals: [],
+    };
+  }
+  const extracted = extractCitations([{ index: 0, text }]);
+  const covered = (candidate: string): boolean =>
+    extracted.some(
+      (c) =>
+        candidate.includes(c.citationText) ||
+        c.citationText.includes(candidate),
+    );
+  const residuals = new Set<string>();
+  for (const detector of DETECTORS) {
+    detector.lastIndex = 0;
+    for (
+      let match = detector.exec(text);
+      match !== null;
+      match = detector.exec(text)
+    ) {
+      const candidate = match[0].replaceAll(/\s+/gu, " ").trim();
+      if (!covered(candidate) && !isBenign(candidate)) {
+        residuals.add(candidate);
+      }
+    }
+  }
+  return {
+    jurisdiction,
+    documentId,
+    empty: false,
+    extractedCount: extracted.length,
+    residuals: [...residuals],
+  };
+};
+
+const want = Math.max(1, Math.floor(sampleTarget / JURISDICTIONS.length));
+const docs = (
+  await Promise.all(
+    JURISDICTIONS.map(async (jurisdiction) => {
+      const keys = await sampleKeys(jurisdiction, want);
+      return await Promise.all(
+        keys.map(async (key) => await probeKey(jurisdiction, key)),
+      );
+    }),
+  )
+).flat();
+
 let totalExtracted = 0;
 let totalResiduals = 0;
 let emptyDocs = 0;
-
-for (const jurisdiction of JURISDICTIONS) {
-  const want = Math.max(1, Math.floor(sampleTarget / JURISDICTIONS.length));
-  // oxlint-disable-next-line no-await-in-loop -- sequential per-jurisdiction sampling keeps S3 pressure trivial
-  const keys = await sampleKeys(jurisdiction, want);
-  for (const key of keys) {
-    // oxlint-disable-next-line no-await-in-loop -- one object at a time; the probe favors simplicity over speed
-    const body = await s3.file(key).bytes();
-    const text = zstdDecompressToString(body);
-    if (text.trim().length === 0) {
-      emptyDocs += 1;
-      continue;
-    }
-    const extracted = extractCitations([{ index: 0, text }]);
-    const covered = (candidate: string): boolean =>
-      extracted.some(
-        (c) =>
-          candidate.includes(c.citationText) ||
-          c.citationText.includes(candidate),
-      );
-    const residuals = new Set<string>();
-    for (const detector of DETECTORS) {
-      detector.lastIndex = 0;
-      for (
-        let match = detector.exec(text);
-        match !== null;
-        match = detector.exec(text)
-      ) {
-        const candidate = match[0].replaceAll(/\s+/gu, " ").trim();
-        if (!covered(candidate) && !isBenign(candidate)) {
-          residuals.add(candidate);
-        }
-      }
-    }
-    totalDocs += 1;
-    totalExtracted += extracted.length;
-    totalResiduals += residuals.size;
-    const documentId = key.slice(KEY_PREFIX.length).split("/").at(1) ?? key;
-    if (residuals.size > 0) {
-      console.log(`RESIDUAL ${jurisdiction} ${documentId}`);
-      for (const residual of [...residuals].slice(0, 6)) {
-        console.log(`  ${residual}`);
-      }
+for (const doc of docs) {
+  if (doc.empty) {
+    emptyDocs += 1;
+    continue;
+  }
+  totalExtracted += doc.extractedCount;
+  totalResiduals += doc.residuals.length;
+  if (doc.residuals.length > 0) {
+    console.log(`RESIDUAL ${doc.jurisdiction} ${doc.documentId}`);
+    for (const residual of doc.residuals.slice(0, 6)) {
+      console.log(`  ${residual}`);
     }
   }
 }
 
 console.log(
-  `SUMMARY docs=${totalDocs} empty=${emptyDocs} extracted=${totalExtracted} residual-candidates=${totalResiduals}`,
+  `SUMMARY docs=${docs.length - emptyDocs} empty=${emptyDocs} extracted=${totalExtracted} residual-candidates=${totalResiduals}`,
 );

--- a/apps/api/src/scripts/citation-probe.ts
+++ b/apps/api/src/scripts/citation-probe.ts
@@ -212,11 +212,19 @@ const sampleKeys = async (jurisdiction: string, want: number) => {
     if (keys.size >= want) {
       break;
     }
-    const contents = listed.contents;
-    if (!contents) {
+    const landed = listed.contents?.at(0)?.key;
+    if (!landed) {
       continue;
     }
-    const textEntries = contents.filter((entry) =>
+    const docPrefix = landed.split("/").slice(0, 4).join("/") + "/";
+    // Enumerate the landed document's own prefix: three objects per
+    // content version means a short window can miss the newest text
+    // object entirely.
+    const docListing = await withDeadline(
+      s3.list({ prefix: docPrefix, maxKeys: 64 }),
+      "s3.list-doc",
+    );
+    const textEntries = (docListing.contents ?? []).filter((entry) =>
       entry.key.endsWith("/text.zst"),
     );
     // A backfilled document can leave an orphaned content-addressed
@@ -226,14 +234,10 @@ const sampleKeys = async (jurisdiction: string, want: number) => {
     // database, which this probe deliberately avoids — and a superseded
     // payload is still real court prose, which is all pattern-mining
     // needs.
-    const docOf = (key: string): string => key.split("/").at(3) ?? key;
     const first = textEntries.at(0);
     if (first) {
-      const sameDoc = textEntries.filter(
-        (entry) => docOf(entry.key) === docOf(first.key),
-      );
       let newest = first;
-      for (const entry of sameDoc) {
+      for (const entry of textEntries) {
         if ((entry.lastModified ?? "") > (newest.lastModified ?? "")) {
           newest = entry;
         }
@@ -355,9 +359,12 @@ console.log(
   `SUMMARY docs=${docs.length - emptyDocs} empty=${emptyDocs} extracted=${totalExtracted} residual-candidates=${totalResiduals}`,
 );
 
-// A run that could not read anything is a failure, not a clean zero: the
-// scheduled reviewer must see a non-zero exit instead of an empty SUMMARY.
-if (s3Attempts > 0 && s3Failures >= s3Attempts) {
-  console.error("citation-probe: every S3 operation failed; unusable run");
+// A run that probed nothing is a failure, not a clean zero: the scheduled
+// reviewer must see a non-zero exit instead of an empty SUMMARY — whether
+// every operation failed or the listings succeeded and every get did not.
+if (docs.length === 0) {
+  console.error(
+    `citation-probe: no documents probed (${s3Failures}/${s3Attempts} S3 operations failed); unusable run`,
+  );
   process.exit(1);
 }

--- a/apps/api/src/scripts/citation-probe.ts
+++ b/apps/api/src/scripts/citation-probe.ts
@@ -31,10 +31,37 @@ if (!bucket) {
   process.exit(2);
 }
 const sampleTarget = Number(argValue("--sample") ?? "18");
-if (!Number.isInteger(sampleTarget) || sampleTarget <= 0) {
-  console.error("citation-probe: --sample must be a positive integer");
+if (!Number.isInteger(sampleTarget) || sampleTarget <= 0 || sampleTarget > 60) {
+  console.error("citation-probe: --sample must be an integer between 1 and 60");
   process.exit(2);
 }
+
+/** Run thunks with bounded concurrency, tolerating individual failures. */
+const settleInBatches = async <T>(
+  thunks: readonly (() => Promise<T>)[],
+): Promise<T[]> => {
+  const results: T[] = [];
+  let failures = 0;
+  for (let i = 0; i < thunks.length; i += 8) {
+    // oxlint-disable-next-line no-await-in-loop -- bounded batches: each 8-wide slice settles before the next to cap S3 pressure
+    const settled = await Promise.allSettled(
+      thunks.slice(i, i + 8).map((thunk) => thunk()),
+    );
+    for (const outcome of settled) {
+      if (outcome.status === "fulfilled") {
+        results.push(outcome.value);
+      } else {
+        failures += 1;
+      }
+    }
+  }
+  if (failures > 0) {
+    console.error(
+      `citation-probe: ${failures} S3 operations failed; continuing`,
+    );
+  }
+  return results;
+};
 
 /** Race an S3 operation against a deadline so a stall cannot hang the probe. */
 const withDeadline = async <T>(work: Promise<T>, label: string): Promise<T> => {
@@ -80,6 +107,9 @@ const resolveCredentials = async (): Promise<ResolvedCredentials | null> => {
   const response = await fetch(`http://169.254.170.2${relativeUri}`, {
     signal: AbortSignal.timeout(5000),
   });
+  if (!response.ok) {
+    return null;
+  }
   const body: unknown = await response.json();
   if (
     !isRecord(body) ||
@@ -163,9 +193,9 @@ const sampleKeys = async (jurisdiction: string, want: number) => {
   const cursors = Array.from({ length: want * 3 }, (_, i) =>
     i % 2 === 0 ? randomHexUuid() : `019${randomHexUuid().slice(3)}`,
   );
-  const listings = await Promise.all(
+  const listings = await settleInBatches(
     cursors.map(
-      async (cursor) =>
+      (cursor) => async () =>
         await withDeadline(
           s3.list({ prefix, startAfter: `${prefix}${cursor}`, maxKeys: 8 }),
           "s3.list",
@@ -184,9 +214,13 @@ const sampleKeys = async (jurisdiction: string, want: number) => {
     const textEntries = contents.filter((entry) =>
       entry.key.endsWith("/text.zst"),
     );
-    // A backfilled document can leave an orphaned older content-addressed
-    // payload beside the live one; the most recent write is the version
-    // the database points at.
+    // A backfilled document can leave an orphaned content-addressed
+    // payload beside the live one. Newest-write is a heuristic, not a
+    // guarantee (a compare-and-set-rejected write can be newer than the
+    // live payload); resolving the truly live key would need the
+    // database, which this probe deliberately avoids — and a superseded
+    // payload is still real court prose, which is all pattern-mining
+    // needs.
     const docOf = (key: string): string => key.split("/").at(3) ?? key;
     const first = textEntries.at(0);
     if (first) {
@@ -287,8 +321,8 @@ const docs = (
         return [];
       }
       const keys = await sampleKeys(jurisdiction, want);
-      return await Promise.all(
-        keys.map(async (key) => await probeKey(jurisdiction, key)),
+      return await settleInBatches(
+        keys.map((key) => async () => await probeKey(jurisdiction, key)),
       );
     }),
   )

--- a/apps/api/src/scripts/citation-probe.ts
+++ b/apps/api/src/scripts/citation-probe.ts
@@ -202,29 +202,41 @@ const sampleKeys = async (jurisdiction: string, want: number) => {
     cursors.map(
       (cursor) => async () =>
         await withDeadline(
-          s3.list({ prefix, startAfter: `${prefix}${cursor}`, maxKeys: 8 }),
+          s3.list({ prefix, startAfter: `${prefix}${cursor}`, maxKeys: 2 }),
           "s3.list",
         ),
     ),
   );
-  const keys = new Set<string>();
+  const docPrefixes = new Set<string>();
   for (const listed of listings) {
-    if (keys.size >= want) {
+    if (docPrefixes.size >= want) {
       break;
     }
     const landed = listed.contents?.at(0)?.key;
-    if (!landed) {
+    if (landed) {
+      docPrefixes.add(`${landed.split("/").slice(0, 4).join("/")}/`);
+    }
+  }
+  // Enumerate each landed document's own prefix: three objects per
+  // content version means a short window can miss the newest text
+  // object entirely. Settled batches, so one failed enumeration costs
+  // one document.
+  const docListings = await settleInBatches(
+    [...docPrefixes].map(
+      (docPrefix) => async () =>
+        await withDeadline(
+          s3.list({ prefix: docPrefix, maxKeys: 64 }),
+          "s3.list-doc",
+        ),
+    ),
+  );
+  const keys = new Set<string>();
+  for (const docListing of docListings) {
+    const contents = docListing.contents;
+    if (!contents) {
       continue;
     }
-    const docPrefix = landed.split("/").slice(0, 4).join("/") + "/";
-    // Enumerate the landed document's own prefix: three objects per
-    // content version means a short window can miss the newest text
-    // object entirely.
-    const docListing = await withDeadline(
-      s3.list({ prefix: docPrefix, maxKeys: 64 }),
-      "s3.list-doc",
-    );
-    const textEntries = (docListing.contents ?? []).filter((entry) =>
+    const textEntries = contents.filter((entry) =>
       entry.key.endsWith("/text.zst"),
     );
     // A backfilled document can leave an orphaned content-addressed

--- a/apps/api/src/scripts/citation-probe.ts
+++ b/apps/api/src/scripts/citation-probe.ts
@@ -313,7 +313,16 @@ const probeKey = async (
       match !== null;
       match = detector.exec(text)
     ) {
-      const candidate = match[0].replaceAll(/\s+/gu, " ").trim();
+      let candidate = match[0].replaceAll(/\s+/gu, " ").trim();
+      // A greedy tail can swallow a second prefixed reference into one
+      // candidate, hiding it behind the first one's coverage; cut the
+      // candidate at any embedded prefix so each reference stands alone.
+      const embedded = candidate
+        .slice(4)
+        .search(/(?:sp\.\s?zn\.|sen\.\s?zn\.|sygn\.|[čc]\.\s?j\.)/iu);
+      if (embedded !== -1) {
+        candidate = candidate.slice(0, embedded + 4).trim();
+      }
       if (!covered(candidate) && !isBenign(candidate)) {
         residuals.add(candidate);
       }
@@ -374,9 +383,9 @@ console.log(
 // A run that probed nothing is a failure, not a clean zero: the scheduled
 // reviewer must see a non-zero exit instead of an empty SUMMARY — whether
 // every operation failed or the listings succeeded and every get did not.
-if (docs.length === 0) {
+if (docs.length === 0 || docs.every((doc) => doc.empty)) {
   console.error(
-    `citation-probe: no documents probed (${s3Failures}/${s3Attempts} S3 operations failed); unusable run`,
+    `citation-probe: no usable documents probed (${docs.length} sampled, ${s3Failures}/${s3Attempts} S3 operations failed); unusable run`,
   );
   process.exit(1);
 }

--- a/apps/api/src/scripts/citation-probe.ts
+++ b/apps/api/src/scripts/citation-probe.ts
@@ -36,6 +36,9 @@ if (!Number.isInteger(sampleTarget) || sampleTarget <= 0 || sampleTarget > 60) {
   process.exit(2);
 }
 
+let s3Attempts = 0;
+let s3Failures = 0;
+
 /** Run thunks with bounded concurrency, tolerating individual failures. */
 const settleInBatches = async <T>(
   thunks: readonly (() => Promise<T>)[],
@@ -45,7 +48,7 @@ const settleInBatches = async <T>(
   for (let i = 0; i < thunks.length; i += 8) {
     // oxlint-disable-next-line no-await-in-loop -- bounded batches: each 8-wide slice settles before the next to cap S3 pressure
     const settled = await Promise.allSettled(
-      thunks.slice(i, i + 8).map((thunk) => thunk()),
+      thunks.slice(i, i + 8).map(async (thunk) => await thunk()),
     );
     for (const outcome of settled) {
       if (outcome.status === "fulfilled") {
@@ -60,6 +63,8 @@ const settleInBatches = async <T>(
       `citation-probe: ${failures} S3 operations failed; continuing`,
     );
   }
+  s3Attempts += thunks.length;
+  s3Failures += failures;
   return results;
 };
 
@@ -349,3 +354,10 @@ for (const doc of docs) {
 console.log(
   `SUMMARY docs=${docs.length - emptyDocs} empty=${emptyDocs} extracted=${totalExtracted} residual-candidates=${totalResiduals}`,
 );
+
+// A run that could not read anything is a failure, not a clean zero: the
+// scheduled reviewer must see a non-zero exit instead of an empty SUMMARY.
+if (s3Attempts > 0 && s3Failures >= s3Attempts) {
+  console.error("citation-probe: every S3 operation failed; unusable run");
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary

A compact self-audit for citation extraction, designed to be run by a scheduled reviewer:

- `src/scripts/citation-probe.ts` samples decisions uniformly from the corpus bucket (random v4-UUID listing cursors — v7 would collapse draws onto recent documents), runs the production extractor, then deliberately broad citation-shape detectors, prunes residuals the extractor covered or a benign filter explains (agency file numbers, anonymization placeholders, statute references, out-of-corpus tribunals), and prints only the unexplained residuals plus a one-line summary. A 20-decision sample reads in a few hundred tokens.
- Validated live: the first run surfaced a real gap — Slovak Constitutional Court citations omit the dot after the senate numeral (`III ÚS 154/2011`) — so the extractor's Constitutional Court pattern now accepts both spellings, with a fixture test.

## Testing

- 27 extractor tests pass (new Slovak ÚS case included).
- Probe exercised against the production bucket: 11 documents, 29 extracted citations, residuals correctly reduced to genuinely reviewable lines.
- `tsgo --noEmit` clean on `apps/api`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved case-law citation recognition for Czech and Slovak Constitutional Court references.
  * Citations are now detected whether or not a dot appears after the Roman numeral or plenary prefix.
  * This ensures formats such as `III ÚS 154/2011` and `III. ÚS 154/2011` are handled consistently.

* **Tests**
  * Added coverage for citation formats without the customary dot.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->