### PR TITLE
chore: remove direct Zod dependencies

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -104,8 +104,7 @@
     "quickjs-emscripten": "^0.32.0",
     "quickjs-emscripten-core": "^0.32.0",
     "slimdom": "^4.3.5",
-    "valibot": "catalog:",
-    "zod": "catalog:"
+    "valibot": "catalog:"
   },
   "devDependencies": {
     "@electric-sql/pglite": "^0.5.4",

--- a/apps/api/scripts/run-tests.ts
+++ b/apps/api/scripts/run-tests.ts
@@ -27,7 +27,7 @@ const MODULE_MOCK_TEST_BATCH_SIZE = 4;
 // db via context, and module-level singletons are lazy per the side-effect
 // conventions). The path fallback catches integration suites that reach the
 // db through their own local setup.
-const DB_TEST_BATCH_SIZE = 4;
+const DB_TEST_BATCH_SIZE = 3;
 const DB_TEST_MARKERS = [
   "tests/security/rls-helpers",
   "tests/security/rls-fixture",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -122,7 +122,6 @@
     "vite": "catalog:",
     "y-prosemirror": "^1.3.7",
     "yjs": "^13.6.31",
-    "zod": "catalog:",
     "zustand": "^5.0.14"
   },
   "devDependencies": {

--- a/bun.lock
+++ b/bun.lock
@@ -107,7 +107,6 @@
         "quickjs-emscripten-core": "^0.32.0",
         "slimdom": "^4.3.5",
         "valibot": "catalog:",
-        "zod": "catalog:",
       },
       "devDependencies": {
         "@electric-sql/pglite": "^0.5.4",
@@ -340,7 +339,6 @@
         "vite": "catalog:",
         "y-prosemirror": "^1.3.7",
         "yjs": "^13.6.31",
-        "zod": "catalog:",
         "zustand": "^5.0.14",
       },
       "devDependencies": {
@@ -769,7 +767,6 @@
     "use-intl": "4.13.4",
     "valibot": "1.4.2",
     "vite": "8.1.5",
-    "zod": "4.4.3",
   },
   "catalogs": {
     "react19": {

--- a/package.json
+++ b/package.json
@@ -146,8 +146,7 @@
     "ultracite": "7.9.4",
     "use-intl": "4.13.4",
     "valibot": "1.4.2",
-    "vite": "8.1.5",
-    "zod": "4.4.3"
+    "vite": "8.1.5"
   },
   "catalogs": {
     "react19": {


### PR DESCRIPTION
## Summary

- remove direct Zod declarations from the API, web app, and root dependency catalog
- keep Valibot as the application validation dependency while dependency-owned Zod versions remain transitive
- reduce database-test batches from four files to three after the existing four-file batch reproducibly exceeded the fixed peak-RSS budget; the budget itself is unchanged

## Verification

- `bun install`
- `bun run verify` (all pre-test checks passed; the initial test run exposed the database-batch RSS failure)
- `bun --filter @stll/api test` (passed after splitting database batches)
- pre-commit format, lint, and secret checks

CC on behalf of jan-kubica

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the unused Zod dependency across the application packages.
  * Reduced database test batch size to improve test execution reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->