### PR TITLE
fix: recover i18n bootstrap from invalid storage

### DIFF
--- a/apps/web/e2e/specs/i18n-bootstrap.spec.ts
+++ b/apps/web/e2e/specs/i18n-bootstrap.spec.ts
@@ -1,0 +1,26 @@
+import { expect, test } from "@playwright/test";
+
+import { getStorageKey } from "../../src/consts";
+
+test.use({ storageState: { cookies: [], origins: [] } });
+
+test("malformed persisted i18n state cannot block app bootstrap", async ({
+  page,
+}) => {
+  const storageKey = getStorageKey("i18n");
+  await page.addInitScript(
+    ({ storageKey: key }) => {
+      localStorage.setItem(key, "{");
+    },
+    { storageKey },
+  );
+
+  await page.goto("/", { waitUntil: "commit" });
+
+  await expect(page).toHaveURL(/\/auth\/?$/u, { timeout: 30_000 });
+  await expect
+    .poll(async () =>
+      page.evaluate((key) => localStorage.getItem(key), storageKey),
+    )
+    .not.toBe("{");
+});

--- a/apps/web/src/i18n/i18n-store.ts
+++ b/apps/web/src/i18n/i18n-store.ts
@@ -550,12 +550,11 @@ const waitForHydration = async (): Promise<void> => {
     return;
   }
 
-  await new Promise<void>((resolve) => {
-    const unsubscribe = useI18nStore.persist.onFinishHydration(() => {
-      unsubscribe();
-      resolve();
-    });
-  });
+  // onFinishHydration only fires after successful persistence reads. Await an
+  // explicit attempt so malformed browser storage settles instead of blocking
+  // React hydration forever; the following loadMessages call persists a valid
+  // default state.
+  await useI18nStore.persist.rehydrate();
 };
 
 export const initializeI18n = async (): Promise<void> => {


### PR DESCRIPTION
Ensures i18n initialization settles when persisted browser state cannot be read, allowing the application to continue bootstrapping normally.

Adds a focused browser regression covering malformed persisted state and its replacement with a valid value. Validated with the regression and the existing i18n store tests.