### PR TITLE
fix(api): send OpenRouter PDFs as file data

### DIFF
--- a/apps/api/scripts/ai-provider-canary.test.ts
+++ b/apps/api/scripts/ai-provider-canary.test.ts
@@ -5,11 +5,35 @@ import { toTanStackToolSchema } from "@/api/handlers/chat/tools/tanstack-tool-sc
 
 import {
   CanaryProviderRunError,
+  createPdfCanaryMessages,
   errorSummary,
+  PDF_CANARY_TOKEN,
   toolRoundTripInputSchema,
   toolRoundTripInputSchemaForProvider,
   toolRoundTripPromptForProvider,
 } from "./ai-provider-canary";
+
+describe("AI provider PDF canary contract", () => {
+  test("sends a real inline PDF rather than a text-only pdf-role probe", () => {
+    const message = createPdfCanaryMessages().at(0);
+    expect(message?.role).toBe("user");
+    if (!message || typeof message.content === "string") {
+      throw new Error("Expected multimodal PDF canary message");
+    }
+
+    const text = message.content.find((part) => part.type === "text");
+    expect(text?.content).not.toContain(PDF_CANARY_TOKEN);
+    const document = message.content.find((part) => part.type === "document");
+    expect(document?.source.type).toBe("data");
+    if (!document || document.source.type !== "data") {
+      throw new Error("Expected inline PDF canary data");
+    }
+
+    const bytes = Buffer.from(document.source.value, "base64");
+    expect(bytes.subarray(0, 8).toString()).toBe("%PDF-1.4");
+    expect(bytes.toString()).toContain(PDF_CANARY_TOKEN);
+  });
+});
 
 describe("AI provider canary tool contract", () => {
   test("keeps the omission marker outside the application schema", () => {

--- a/apps/api/scripts/ai-provider-canary.test.ts
+++ b/apps/api/scripts/ai-provider-canary.test.ts
@@ -19,7 +19,7 @@ describe("AI provider PDF canary contract", () => {
     expect(message?.role).toBe("user");
     const content = message?.content;
     if (!Array.isArray(content)) {
-      throw new Error("Expected multimodal PDF canary message");
+      throw new TypeError("Expected multimodal PDF canary message");
     }
 
     const text = content.find((part) => part.type === "text");

--- a/apps/api/scripts/ai-provider-canary.test.ts
+++ b/apps/api/scripts/ai-provider-canary.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, test } from "bun:test";
 import * as v from "valibot";
 
+import {
+  CHAT_PDF_ATTACHMENT_MODEL_OPTIONS,
+  DEFAULT_MODELS,
+  isBYOKProviderRoleSupported,
+} from "@stll/ai-catalog";
+
 import { toTanStackToolSchema } from "@/api/handlers/chat/tools/tanstack-tool-schema";
 
 import {
@@ -8,10 +14,12 @@ import {
   createPdfCanaryMessages,
   errorSummary,
   PDF_CANARY_TOKEN,
+  pdfCanarySelection,
   toolRoundTripInputSchema,
   toolRoundTripInputSchemaForProvider,
   toolRoundTripPromptForProvider,
 } from "./ai-provider-canary";
+import { CANARY_PROVIDERS } from "./ai-provider-canary-config";
 
 describe("AI provider PDF canary contract", () => {
   test("sends a real inline PDF rather than a text-only pdf-role probe", () => {
@@ -33,6 +41,32 @@ describe("AI provider PDF canary contract", () => {
     const bytes = Buffer.from(document.source.value, "base64");
     expect(bytes.subarray(0, 8).toString()).toBe("%PDF-1.4");
     expect(bytes.toString()).toContain(PDF_CANARY_TOKEN);
+  });
+
+  test("covers every provider with an available PDF attachment path", () => {
+    for (const provider of CANARY_PROVIDERS) {
+      const selection = pdfCanarySelection(provider);
+      if (isBYOKProviderRoleSupported({ provider, role: "pdf" })) {
+        expect(selection).toEqual({
+          modelId: DEFAULT_MODELS[provider].pdf,
+          role: "pdf",
+        });
+        continue;
+      }
+
+      const chatAttachmentModel =
+        CHAT_PDF_ATTACHMENT_MODEL_OPTIONS[provider].at(0);
+      expect(selection).toEqual(
+        chatAttachmentModel === undefined
+          ? null
+          : { modelId: chatAttachmentModel, role: "chat" },
+      );
+    }
+
+    expect(pdfCanarySelection("mistral")).toEqual({
+      modelId: "mistral-medium-latest",
+      role: "chat",
+    });
   });
 });
 

--- a/apps/api/scripts/ai-provider-canary.test.ts
+++ b/apps/api/scripts/ai-provider-canary.test.ts
@@ -17,13 +17,14 @@ describe("AI provider PDF canary contract", () => {
   test("sends a real inline PDF rather than a text-only pdf-role probe", () => {
     const message = createPdfCanaryMessages().at(0);
     expect(message?.role).toBe("user");
-    if (!message || typeof message.content === "string") {
+    const content = message?.content;
+    if (!Array.isArray(content)) {
       throw new Error("Expected multimodal PDF canary message");
     }
 
-    const text = message.content.find((part) => part.type === "text");
+    const text = content.find((part) => part.type === "text");
     expect(text?.content).not.toContain(PDF_CANARY_TOKEN);
-    const document = message.content.find((part) => part.type === "document");
+    const document = content.find((part) => part.type === "document");
     expect(document?.source.type).toBe("data");
     if (!document || document.source.type !== "data") {
       throw new Error("Expected inline PDF canary data");

--- a/apps/api/scripts/ai-provider-canary.ts
+++ b/apps/api/scripts/ai-provider-canary.ts
@@ -4,6 +4,7 @@ import { isDeepStrictEqual } from "node:util";
 import * as v from "valibot";
 
 import {
+  CHAT_PDF_ATTACHMENT_MODEL_OPTIONS,
   DEFAULT_MODELS,
   isBYOKModelRoleSupported,
   isBYOKProviderRoleSupported,
@@ -331,6 +332,22 @@ type CanaryContext = {
   provider: CanaryProvider;
 };
 
+type PdfCanarySelection = {
+  modelId: string;
+  role: "chat" | "pdf";
+};
+
+export const pdfCanarySelection = (
+  provider: CanaryProvider,
+): PdfCanarySelection | null => {
+  if (isBYOKProviderRoleSupported({ provider, role: "pdf" })) {
+    return { modelId: DEFAULT_MODELS[provider].pdf, role: "pdf" };
+  }
+
+  const modelId = CHAT_PDF_ATTACHMENT_MODEL_OPTIONS[provider].at(0);
+  return modelId === undefined ? null : { modelId, role: "chat" };
+};
+
 type WeeklyCanaryContext = CanaryContext & {
   rotatedConfig: OrgAIConfig;
   rotation: WeeklyCanaryRotation;
@@ -442,14 +459,34 @@ const runModelRoleProbe = async ({
   role,
   signal,
 }: RunModelRoleProbeOptions): Promise<void> => {
+  const selection =
+    role === "pdf"
+      ? pdfCanarySelection(provider)
+      : { modelId: DEFAULT_MODELS[provider][role], role };
+  if (selection === null) {
+    throw new TypeError("Canary resolved an unexpected provider model.");
+  }
+  const probeConfig =
+    selection.role === role
+      ? config
+      : {
+          ...config,
+          overrideModels: {
+            ...config.overrideModels,
+            [selection.role]: {
+              modelId: selection.modelId,
+              provider,
+            },
+          },
+        };
   const model = resolveTanStackTextModel({
     organizationId: null,
-    orgAIConfig: config,
-    role,
+    orgAIConfig: probeConfig,
+    role: selection.role,
   });
   if (
     model.provider !== provider ||
-    model.modelId !== DEFAULT_MODELS[provider][role]
+    model.modelId !== selection.modelId
   ) {
     throw new TypeError("Canary resolved an unexpected provider model.");
   }
@@ -462,8 +499,8 @@ const runModelRoleProbe = async ({
       ? { messages: createPdfCanaryMessages() }
       : { prompt: SYNTHETIC_PROMPT }),
     organizationId: null,
-    orgAIConfig: config,
-    role,
+    orgAIConfig: probeConfig,
+    role: selection.role,
     serviceTier: "standard",
   });
   requireExpectedRoleOutput(output, role);
@@ -825,7 +862,11 @@ const probeLabel = (context: CanaryContext, probe: Probe): string => {
     return probe.name;
   }
 
-  return `role-${probe.role}:${DEFAULT_MODELS[context.provider][probe.role]}`;
+  const modelId =
+    probe.role === "pdf"
+      ? pdfCanarySelection(context.provider)?.modelId
+      : DEFAULT_MODELS[context.provider][probe.role];
+  return `role-${probe.role}:${modelId ?? "unsupported"}`;
 };
 
 const run = async (): Promise<void> => {
@@ -884,10 +925,12 @@ const runProbes = async (
   const label = probeLabel(context, probe);
   if (
     probe.type === "model-role" &&
-    !isBYOKProviderRoleSupported({
-      provider: context.provider,
-      role: probe.role,
-    })
+    (probe.role === "pdf"
+      ? pdfCanarySelection(context.provider) === null
+      : !isBYOKProviderRoleSupported({
+          provider: context.provider,
+          role: probe.role,
+        }))
   ) {
     console.log(
       `[ai-canary] ${context.provider}/${label}: skipped (unsupported role)`,

--- a/apps/api/scripts/ai-provider-canary.ts
+++ b/apps/api/scripts/ai-provider-canary.ts
@@ -484,10 +484,7 @@ const runModelRoleProbe = async ({
     orgAIConfig: probeConfig,
     role: selection.role,
   });
-  if (
-    model.provider !== provider ||
-    model.modelId !== selection.modelId
-  ) {
+  if (model.provider !== provider || model.modelId !== selection.modelId) {
     throw new TypeError("Canary resolved an unexpected provider model.");
   }
 

--- a/apps/api/scripts/ai-provider-canary.ts
+++ b/apps/api/scripts/ai-provider-canary.ts
@@ -1,5 +1,5 @@
 import { chat, EventType, maxIterations, toolDefinition } from "@tanstack/ai";
-import type { Tool } from "@tanstack/ai";
+import type { ModelMessage, Tool } from "@tanstack/ai";
 import { isDeepStrictEqual } from "node:util";
 import * as v from "valibot";
 
@@ -22,6 +22,7 @@ import {
   resolveTanStackTextModel,
 } from "@/api/lib/tanstack-ai-generate";
 import { projectSchemaInputJsonSchema } from "@/api/lib/tanstack-ai-schema";
+import { PDF_MIME_TYPE } from "@/api/mime-types";
 
 import {
   CANARY_TIERS,
@@ -48,6 +49,10 @@ const MODEL_ROLE_PROBE_TIMEOUT_MS = 30_000;
 const TOOL_ROUND_TRIP_PROBE_TIMEOUT_MS = 45_000;
 const MILLISECONDS_PER_WEEK = 7 * 24 * 60 * 60 * 1000;
 const SYNTHETIC_PROMPT = "Reply with exactly OK.";
+export const PDF_CANARY_TOKEN = "STELLA_PDF_CANARY_OK";
+const PDF_CANARY_FILENAME = "stella-provider-canary.pdf";
+const PDF_CANARY_PROMPT =
+  "Read the attached PDF and reply with exactly the uppercase identifier printed on its page.";
 const TOOL_SCHEMA_PROMPT = "Do not call any tool. Reply with exactly OK.";
 const TOOL_ROUND_TRIP_NAME = "canary_round_trip";
 const TOOL_ROUND_TRIP_VALUE = "stella-canary";
@@ -79,8 +84,54 @@ const SAFE_CANARY_ERROR_MESSAGES = new Set([
   "Provider did not execute the weekly canary tool exactly once.",
   "Provider returned unexpected weekly canary tool arguments.",
   "Provider did not return the weekly canary tool result.",
+  "Provider did not read the attached PDF.",
   "Provider returned no text.",
 ]);
+
+const createSyntheticPdf = (): Uint8Array => {
+  const stream = `BT /F1 18 Tf 72 720 Td (${PDF_CANARY_TOKEN}) Tj ET`;
+  const objects = [
+    "<< /Type /Catalog /Pages 2 0 R >>",
+    "<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+    "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>",
+    "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>",
+    `<< /Length ${Buffer.byteLength(stream)} >>\nstream\n${stream}\nendstream`,
+  ];
+  let pdf = "%PDF-1.4\n";
+  const offsets: number[] = [];
+  for (const [index, object] of objects.entries()) {
+    offsets.push(Buffer.byteLength(pdf));
+    pdf += `${index + 1} 0 obj\n${object}\nendobj\n`;
+  }
+  const xrefOffset = Buffer.byteLength(pdf);
+  const entries = offsets
+    .map((offset) => `${offset.toString().padStart(10, "0")} 00000 n \n`)
+    .join("");
+  pdf +=
+    `xref\n0 ${objects.length + 1}\n` +
+    `0000000000 65535 f \n${entries}` +
+    `trailer\n<< /Size ${objects.length + 1} /Root 1 0 R >>\n` +
+    `startxref\n${xrefOffset}\n%%EOF\n`;
+  return new TextEncoder().encode(pdf);
+};
+
+export const createPdfCanaryMessages = (): ModelMessage[] => [
+  {
+    role: "user",
+    content: [
+      { type: "text", content: PDF_CANARY_PROMPT },
+      {
+        type: "document",
+        source: {
+          type: "data",
+          value: Buffer.from(createSyntheticPdf()).toString("base64"),
+          mimeType: PDF_MIME_TYPE,
+        },
+        metadata: { filename: PDF_CANARY_FILENAME },
+      },
+    ],
+  },
+];
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null;
@@ -407,13 +458,15 @@ const runModelRoleProbe = async ({
     abortSignal: signal,
     caching: NO_CACHING,
     maxOutputTokens: modelRoleMaxOutputTokens(role),
+    ...(role === "pdf"
+      ? { messages: createPdfCanaryMessages() }
+      : { prompt: SYNTHETIC_PROMPT }),
     organizationId: null,
     orgAIConfig: config,
-    prompt: SYNTHETIC_PROMPT,
     role,
     serviceTier: "standard",
   });
-  requireNonEmptyText(output);
+  requireExpectedRoleOutput(output, role);
 };
 
 type RunWeeklyModelRoleProbeOptions = {
@@ -440,13 +493,15 @@ const runWeeklyModelRoleProbe = async ({
     abortSignal: signal,
     caching: NO_CACHING,
     maxOutputTokens: modelRoleMaxOutputTokens(role),
+    ...(role === "pdf"
+      ? { messages: createPdfCanaryMessages() }
+      : { prompt: SYNTHETIC_PROMPT }),
     organizationId: null,
     orgAIConfig: rotatedConfig,
-    prompt: SYNTHETIC_PROMPT,
     role,
     serviceTier: "standard",
   });
-  requireNonEmptyText(output);
+  requireExpectedRoleOutput(output, role);
 };
 
 type RunToolCallRoundTripProbeOptions = {
@@ -622,6 +677,13 @@ const runToolProbe = async ({
 const requireNonEmptyText = (output: string): void => {
   if (output.trim().length === 0) {
     throw new TypeError("Provider returned no text.");
+  }
+};
+
+const requireExpectedRoleOutput = (output: string, role: ModelRole): void => {
+  requireNonEmptyText(output);
+  if (role === "pdf" && output.trim() !== PDF_CANARY_TOKEN) {
+    throw new TypeError("Provider did not read the attached PDF.");
   }
 };
 

--- a/apps/api/src/handlers/chat/upload-files.test.ts
+++ b/apps/api/src/handlers/chat/upload-files.test.ts
@@ -20,6 +20,7 @@ import { DOCX_MIME_TYPE, PDF_MIME_TYPE } from "@/api/mime-types";
 import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
 
 const fileBytes = new TextEncoder().encode("Jan Novak,Acme");
+const IMAGE_PNG_MIME_TYPE = "image/png";
 const arrayBufferMock = mock(async () =>
   fileBytes.buffer.slice(
     fileBytes.byteOffset,
@@ -144,6 +145,32 @@ describe("chat attachment hydration", () => {
           mimeType: PDF_MIME_TYPE,
         },
         type: "document",
+      },
+    });
+  });
+
+  test("keeps raw image attachments URL-backed for provider adapters", async () => {
+    const result = await hydrateFilePart({
+      fileName: "scan.png",
+      mimeType: IMAGE_PNG_MIME_TYPE,
+      sendMode: CHAT_SEND_MODE.rawOverride,
+      s3Key: "user/file",
+    });
+
+    expect(Result.isOk(result)).toBe(true);
+    if (Result.isError(result)) {
+      throw result.error;
+    }
+    expect(result.value).toMatchObject({
+      type: "rawOverride",
+      part: {
+        metadata: { filename: "scan.png" },
+        source: {
+          type: "url",
+          value: toDataUrl(fileBytes, IMAGE_PNG_MIME_TYPE),
+          mimeType: IMAGE_PNG_MIME_TYPE,
+        },
+        type: "image",
       },
     });
   });

--- a/apps/api/src/handlers/chat/upload-files.test.ts
+++ b/apps/api/src/handlers/chat/upload-files.test.ts
@@ -138,7 +138,11 @@ describe("chat attachment hydration", () => {
       type: "rawOverride",
       part: {
         metadata: { filename: "scan.pdf" },
-        source: { mimeType: PDF_MIME_TYPE },
+        source: {
+          type: "data",
+          value: Buffer.from(fileBytes).toString("base64"),
+          mimeType: PDF_MIME_TYPE,
+        },
         type: "document",
       },
     });

--- a/apps/api/src/handlers/chat/upload-files.ts
+++ b/apps/api/src/handlers/chat/upload-files.ts
@@ -38,7 +38,11 @@ import { AUDIT_ACTION, AUDIT_RESOURCE_TYPE } from "@/api/lib/audit-log";
 import type { AuditRecorder } from "@/api/lib/audit-log";
 import { createSafeId } from "@/api/lib/branded-types";
 import type { SafeId } from "@/api/lib/branded-types";
-import { isDataUrlSizeLimitError, parseDataUrl } from "@/api/lib/data-url";
+import {
+  isDataUrlSizeLimitError,
+  parseDataUrl,
+  toDataUrl,
+} from "@/api/lib/data-url";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import { getScanWarnings, scanFile } from "@/api/lib/file-scan/scan";
 import { FILE_SIZE_LIMITS, LIMITS } from "@/api/lib/limits";
@@ -288,16 +292,27 @@ export const createRawChatFilePart = ({
   mimeType: string;
 }): ChatAttachmentPart => {
   const metadata = { filename: fileName };
-  const source = {
-    type: "data" as const,
-    value: Buffer.from(bytes).toString("base64"),
-    mimeType,
-  };
 
   if (mimeType.startsWith("image/")) {
-    return { type: "image", source, metadata };
+    return {
+      type: "image",
+      source: {
+        type: "url",
+        value: toDataUrl(bytes, mimeType),
+        mimeType,
+      },
+      metadata,
+    };
   }
-  return { type: "document", source, metadata };
+  return {
+    type: "document",
+    source: {
+      type: "data",
+      value: Buffer.from(bytes).toString("base64"),
+      mimeType,
+    },
+    metadata,
+  };
 };
 
 /**

--- a/apps/api/src/handlers/chat/upload-files.ts
+++ b/apps/api/src/handlers/chat/upload-files.ts
@@ -38,11 +38,7 @@ import { AUDIT_ACTION, AUDIT_RESOURCE_TYPE } from "@/api/lib/audit-log";
 import type { AuditRecorder } from "@/api/lib/audit-log";
 import { createSafeId } from "@/api/lib/branded-types";
 import type { SafeId } from "@/api/lib/branded-types";
-import {
-  isDataUrlSizeLimitError,
-  parseDataUrl,
-  toDataUrl,
-} from "@/api/lib/data-url";
+import { isDataUrlSizeLimitError, parseDataUrl } from "@/api/lib/data-url";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import { getScanWarnings, scanFile } from "@/api/lib/file-scan/scan";
 import { FILE_SIZE_LIMITS, LIMITS } from "@/api/lib/limits";
@@ -290,12 +286,19 @@ export const createRawChatFilePart = ({
   bytes: Uint8Array;
   fileName: string;
   mimeType: string;
-}): ChatAttachmentPart =>
-  createChatAttachmentPart({
-    filename: fileName,
+}): ChatAttachmentPart => {
+  const metadata = { filename: fileName };
+  const source = {
+    type: "data" as const,
+    value: Buffer.from(bytes).toString("base64"),
     mimeType,
-    url: toDataUrl(bytes, mimeType),
-  });
+  };
+
+  if (mimeType.startsWith("image/")) {
+    return { type: "image", source, metadata };
+  }
+  return { type: "document", source, metadata };
+};
 
 /**
  * Wraps extracted attachment text with a filename header so the model has the

--- a/apps/api/src/lib/ai-caching-invariants.test.ts
+++ b/apps/api/src/lib/ai-caching-invariants.test.ts
@@ -38,6 +38,9 @@ describe("TanStack AI is the only live app provider SDK boundary", () => {
     const glob = new Glob("**/*.ts");
     const allowed = new Set([
       "lib/tanstack-ai-models.ts",
+      // Stella's document-transport override subclasses the stable OpenRouter
+      // adapter; model construction remains centralized in tanstack-ai-models.
+      "lib/stella-openrouter-text-adapter.ts",
       // These contract tests deliberately construct real adapters with intercepted
       // clients; they are not imported by app code.
       "handlers/chat/tools/provider-null-normalization.property.test.ts",

--- a/apps/api/src/lib/stella-openrouter-text-adapter.test.ts
+++ b/apps/api/src/lib/stella-openrouter-text-adapter.test.ts
@@ -1,0 +1,132 @@
+import { chat } from "@tanstack/ai";
+import type { ContentPart } from "@tanstack/ai";
+import { describe, expect, test } from "bun:test";
+
+import { StellaOpenRouterTextAdapter } from "@/api/lib/stella-openrouter-text-adapter";
+
+class InspectableOpenRouterAdapter extends StellaOpenRouterTextAdapter {
+  convertForRequest(part: ContentPart) {
+    return this.convertContentPart(part);
+  }
+}
+
+const adapter = new InspectableOpenRouterAdapter(
+  { apiKey: "test-openrouter-key" },
+  "google/gemini-2.5-flash",
+);
+
+describe("OpenRouter document transport", () => {
+  test("serializes inline PDF bytes as file_data instead of a URL or text", () => {
+    const base64 = Buffer.from("%PDF-1.4\nsynthetic").toString("base64");
+
+    expect(
+      adapter.convertForRequest({
+        type: "document",
+        source: {
+          type: "data",
+          value: base64,
+          mimeType: "application/pdf",
+        },
+        metadata: { filename: "contract.pdf" },
+      }),
+    ).toEqual({
+      type: "file",
+      file: {
+        fileData: `data:application/pdf;base64,${base64}`,
+        filename: "contract.pdf",
+      },
+    });
+  });
+
+  test("serializes a remote PDF as a file reference, never document prompt text", () => {
+    expect(
+      adapter.convertForRequest({
+        type: "document",
+        source: {
+          type: "url",
+          value: "https://example.com/contract.pdf",
+          mimeType: "application/pdf",
+        },
+      }),
+    ).toEqual({
+      type: "file",
+      file: { fileData: "https://example.com/contract.pdf" },
+    });
+  });
+
+  test("emits the official snake_case file_data shape on the HTTP wire", async () => {
+    const originalFetch = globalThis.fetch;
+    let requestBody: unknown;
+    const fetchStub = async (
+      input: Parameters<typeof globalThis.fetch>[0],
+      init?: RequestInit,
+    ): Promise<Response> => {
+      const request =
+        input instanceof Request ? input : new Request(input.toString(), init);
+      requestBody = await request.clone().json();
+      return new Response(
+        JSON.stringify({
+          error: { code: "invalid_request", message: "synthetic stop" },
+        }),
+        {
+          status: 400,
+          headers: { "content-type": "application/json" },
+        },
+      );
+    };
+    globalThis.fetch = Object.assign(fetchStub, {
+      preconnect: originalFetch.preconnect,
+    });
+
+    try {
+      const base64 = Buffer.from("%PDF-1.4\nwire").toString("base64");
+      const wireAdapter = new StellaOpenRouterTextAdapter(
+        { apiKey: "test-openrouter-key" },
+        "google/gemini-2.5-flash",
+      );
+      for await (const _chunk of chat({
+        adapter: wireAdapter,
+        messages: [
+          {
+            role: "user",
+            content: [
+              { type: "text", content: "Read the attached PDF." },
+              {
+                type: "document",
+                source: {
+                  type: "data",
+                  value: base64,
+                  mimeType: "application/pdf",
+                },
+                metadata: { filename: "contract.pdf" },
+              },
+            ],
+          },
+        ],
+        stream: true,
+      })) {
+        // The synthetic HTTP 400 ends the stream after request serialization.
+      }
+
+      expect(requestBody).toMatchObject({
+        messages: [
+          {
+            role: "user",
+            content: [
+              { type: "text", text: "Read the attached PDF." },
+              {
+                type: "file",
+                file: {
+                  file_data: `data:application/pdf;base64,${base64}`,
+                  filename: "contract.pdf",
+                },
+              },
+            ],
+          },
+        ],
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});

--- a/apps/api/src/lib/stella-openrouter-text-adapter.ts
+++ b/apps/api/src/lib/stella-openrouter-text-adapter.ts
@@ -1,0 +1,62 @@
+import type { ContentPart } from "@tanstack/ai";
+import { OpenRouterTextAdapter } from "@tanstack/ai-openrouter";
+import type {
+  createOpenRouterText,
+  OpenRouterConfig,
+} from "@tanstack/ai-openrouter";
+
+type OpenRouterModel = Parameters<typeof createOpenRouterText>[0];
+
+const DATA_URL_PREFIX = "data:";
+
+const documentFilename = (part: ContentPart): string | undefined => {
+  if (
+    part.type !== "document" ||
+    typeof part.metadata !== "object" ||
+    part.metadata === null ||
+    !("filename" in part.metadata) ||
+    typeof part.metadata.filename !== "string"
+  ) {
+    return undefined;
+  }
+  return part.metadata.filename;
+};
+
+/**
+ * Stable OpenRouter Chat Completions adapter with document serialization.
+ *
+ * The upstream adapter intentionally rejects inline documents even though the
+ * OpenRouter SDK and Chat Completions API support the `file`/`file_data` wire
+ * shape. Keep this override narrow so every other modality and stream behavior
+ * remains on the stable upstream adapter.
+ */
+export class StellaOpenRouterTextAdapter extends OpenRouterTextAdapter<OpenRouterModel> {
+  protected override convertContentPart(part: ContentPart) {
+    if (part.type !== "document") {
+      return super.convertContentPart(part);
+    }
+
+    const mimeType = part.source.mimeType || "application/octet-stream";
+    const fileData =
+      part.source.type === "data" &&
+      !part.source.value.startsWith(DATA_URL_PREFIX)
+        ? `data:${mimeType};base64,${part.source.value}`
+        : part.source.value;
+    const filename = documentFilename(part);
+
+    return {
+      type: "file" as const,
+      file: {
+        fileData,
+        ...(filename === undefined ? {} : { filename }),
+      },
+    };
+  }
+}
+
+export const createStellaOpenRouterText = (
+  model: OpenRouterModel,
+  apiKey: string,
+  config?: Omit<OpenRouterConfig, "apiKey">,
+): StellaOpenRouterTextAdapter =>
+  new StellaOpenRouterTextAdapter({ apiKey, ...config }, model);

--- a/apps/api/src/lib/tanstack-ai-models.test.ts
+++ b/apps/api/src/lib/tanstack-ai-models.test.ts
@@ -14,6 +14,7 @@ import { env } from "@/api/env";
 import type { OrgAIConfig } from "@/api/lib/ai-config";
 import { toSafeId } from "@/api/lib/branded-types";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
+import { StellaOpenRouterTextAdapter } from "@/api/lib/stella-openrouter-text-adapter";
 import type { TanStackModelOptions } from "@/api/lib/tanstack-ai-models";
 
 process.env["EMAIL_PROVIDER"] ??= "smtp";
@@ -416,6 +417,7 @@ describe("TanStack text model resolution", () => {
     });
     expect(model.adapter.name).toBe("openrouter");
     expect(model.adapter.model).toBe("google/gemini-3.5-flash");
+    expect(model.adapter).toBeInstanceOf(StellaOpenRouterTextAdapter);
   });
 
   test("resolves Mistral BYOK selections through the TanStack adapter", () => {

--- a/apps/api/src/lib/tanstack-ai-models.ts
+++ b/apps/api/src/lib/tanstack-ai-models.ts
@@ -12,10 +12,7 @@ import { createMistralText } from "@tanstack/ai-mistral";
 import type { MistralTextProviderOptions } from "@tanstack/ai-mistral";
 import { createOpenaiChat } from "@tanstack/ai-openai";
 import type { OpenAITextProviderOptions } from "@tanstack/ai-openai";
-import {
-  createOpenRouterText,
-  type OpenRouterTextModelOptions,
-} from "@tanstack/ai-openrouter";
+import type { OpenRouterTextModelOptions } from "@tanstack/ai-openrouter";
 import { Result, panic } from "better-result";
 import * as v from "valibot";
 
@@ -49,6 +46,7 @@ import {
 } from "@/api/lib/ai-config";
 import type { SafeId } from "@/api/lib/branded-types";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
+import { createStellaOpenRouterText } from "@/api/lib/stella-openrouter-text-adapter";
 
 const AI_PROVIDER_VALUES = new Set<string>(AI_PROVIDERS);
 const ANTHROPIC_LEGACY_THINKING_BUDGET_TOKENS = 10_000;
@@ -461,7 +459,7 @@ const createExtendedOpenRouterAdapter = (
   modelId: string,
   apiKey: string,
 ): AnyTextAdapter => {
-  const openrouter = extendAdapter(createOpenRouterText, [
+  const openrouter = extendAdapter(createStellaOpenRouterText, [
     createModel(modelId, {
       input: ["text", "image", "document"] as const,
       features: ["structured_outputs"] as const,


### PR DESCRIPTION
## Summary

- serialize inline document inputs as OpenRouter file content parts
- keep other modalities on the stable Chat Completions adapter
- exercise real PDF attachment transport in scheduled provider canaries