### PR TITLE
fix(corpus): bound per-document indexing cost

### DIFF
--- a/apps/api/src/handlers/case-law/corpus-storage.ts
+++ b/apps/api/src/handlers/case-law/corpus-storage.ts
@@ -6,7 +6,10 @@ import { EMPTY_AST } from "@/api/handlers/case-law/ingestion/adapter";
 import type { EmptyAst } from "@/api/handlers/case-law/ingestion/adapter";
 import type { DecisionSection } from "@/api/handlers/case-law/types";
 import { captureError } from "@/api/lib/analytics/capture";
-import { zstdCompress, zstdDecompressToString } from "@/api/lib/compression";
+import {
+  zstdCompressAsync,
+  zstdDecompressToStringBounded,
+} from "@/api/lib/compression";
 import { CorpusPayloadUnavailableError } from "@/api/lib/errors/tagged-errors";
 import { LIMITS } from "@/api/lib/limits";
 import { getCorpusS3 } from "@/api/lib/s3";
@@ -23,6 +26,8 @@ import { withTimeout } from "@/api/lib/with-timeout";
 const CONTENT_TYPE = "application/zstd";
 
 const CORPUS_IO_TIMEOUT_MS = LIMITS.corpusObjectIoTimeoutMs;
+
+const PAYLOAD_MAX_BYTES = LIMITS.corpusPayloadMaxDecompressedBytes;
 
 /**
  * The single bounded boundary for every corpus object read/write/delete.
@@ -156,7 +161,7 @@ export const writeCorpusDocument = async ({
     boundedCorpusIo(
       "corpus-write-text",
       async () =>
-        await s3.write(keys.textKey, zstdCompress(text ?? ""), {
+        await s3.write(keys.textKey, await zstdCompressAsync(text ?? ""), {
           type: CONTENT_TYPE,
         }),
     ),
@@ -165,16 +170,18 @@ export const writeCorpusDocument = async ({
       async () =>
         await s3.write(
           keys.sectionsKey,
-          zstdCompress(JSON.stringify(sections ?? null)),
+          await zstdCompressAsync(JSON.stringify(sections ?? null)),
           { type: CONTENT_TYPE },
         ),
     ),
     boundedCorpusIo(
       "corpus-write-ast",
       async () =>
-        await s3.write(keys.astKey, zstdCompress(JSON.stringify(ast ?? null)), {
-          type: CONTENT_TYPE,
-        }),
+        await s3.write(
+          keys.astKey,
+          await zstdCompressAsync(JSON.stringify(ast ?? null)),
+          { type: CONTENT_TYPE },
+        ),
     ),
   ]);
 
@@ -200,7 +207,7 @@ export const readCorpusText = async (
     read ?? (async () => await getCorpusS3().file(key).bytes()),
     timeoutMs,
   );
-  return zstdDecompressToString(bytes);
+  return await zstdDecompressToStringBounded(bytes, PAYLOAD_MAX_BYTES);
 };
 
 export const readCorpusSections = async (
@@ -212,7 +219,7 @@ export const readCorpusSections = async (
   );
   // eslint-disable-next-line typescript/no-unsafe-assignment -- decompressed corpus JSON written by this module
   const parsed: DecisionSection[] | null = JSON.parse(
-    zstdDecompressToString(bytes),
+    await zstdDecompressToStringBounded(bytes, PAYLOAD_MAX_BYTES),
   );
   return parsed;
 };
@@ -226,7 +233,7 @@ export const readCorpusAst = async (
   );
   // eslint-disable-next-line typescript/no-unsafe-assignment -- decompressed corpus JSON written by this module
   const parsed: DocumentAst | EmptyAst | null = JSON.parse(
-    zstdDecompressToString(bytes),
+    await zstdDecompressToStringBounded(bytes, PAYLOAD_MAX_BYTES),
   );
   return parsed;
 };

--- a/apps/api/src/lib/compression.test.ts
+++ b/apps/api/src/lib/compression.test.ts
@@ -8,7 +8,7 @@ import {
 
 describe("bounded corpus compression", () => {
   test("async round-trip preserves the payload", async () => {
-    const text = `rozsudek — §  čl. 5 ${  "long body ".repeat(1000)}`;
+    const text = `rozsudek — §  čl. 5 ${"long body ".repeat(1000)}`;
     const compressed = await zstdCompressAsync(text);
     expect(await zstdDecompressToStringBounded(compressed, 1024 * 1024)).toBe(
       text,

--- a/apps/api/src/lib/compression.test.ts
+++ b/apps/api/src/lib/compression.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  zstdCompress,
+  zstdCompressAsync,
+  zstdDecompressToStringBounded,
+} from "@/api/lib/compression";
+
+describe("bounded corpus compression", () => {
+  test("async round-trip preserves the payload", async () => {
+    const text = `rozsudek — §  čl. 5 ${  "long body ".repeat(1000)}`;
+    const compressed = await zstdCompressAsync(text);
+    expect(await zstdDecompressToStringBounded(compressed, 1024 * 1024)).toBe(
+      text,
+    );
+  });
+
+  test("sync-compressed objects decompress through the bounded path", async () => {
+    // Existing corpus objects were written with the sync variant; the read
+    // path must keep accepting them byte-for-byte.
+    const compressed = zstdCompress("legacy object");
+    expect(await zstdDecompressToStringBounded(compressed, 1024)).toBe(
+      "legacy object",
+    );
+  });
+
+  test("a payload past the decompressed ceiling throws instead of returning", async () => {
+    // Highly compressible input: a small object that inflates well past the
+    // ceiling — the shape of a corrupt or hostile corpus object.
+    const compressed = await zstdCompressAsync("a".repeat(1_000_000));
+    await expect(
+      zstdDecompressToStringBounded(compressed, 65_536),
+    ).rejects.toThrow(/ceiling/u);
+  });
+});

--- a/apps/api/src/lib/compression.test.ts
+++ b/apps/api/src/lib/compression.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  PayloadBudgetError,
   zstdCompress,
   zstdCompressAsync,
   zstdDecompressToStringBounded,
@@ -28,8 +29,10 @@ describe("bounded corpus compression", () => {
     // Highly compressible input: a small object that inflates well past the
     // ceiling — the shape of a corrupt or hostile corpus object.
     const compressed = await zstdCompressAsync("a".repeat(1_000_000));
-    expect(zstdDecompressToStringBounded(compressed, 65_536)).rejects.toThrow(
-      /ceiling/u,
-    );
+    const outcome = await zstdDecompressToStringBounded(
+      compressed,
+      65_536,
+    ).catch((error: unknown) => error);
+    expect(outcome).toBeInstanceOf(PayloadBudgetError);
   });
 });

--- a/apps/api/src/lib/compression.test.ts
+++ b/apps/api/src/lib/compression.test.ts
@@ -28,8 +28,8 @@ describe("bounded corpus compression", () => {
     // Highly compressible input: a small object that inflates well past the
     // ceiling — the shape of a corrupt or hostile corpus object.
     const compressed = await zstdCompressAsync("a".repeat(1_000_000));
-    await expect(
-      zstdDecompressToStringBounded(compressed, 65_536),
-    ).rejects.toThrow(/ceiling/u);
+    expect(zstdDecompressToStringBounded(compressed, 65_536)).rejects.toThrow(
+      /ceiling/u,
+    );
   });
 });

--- a/apps/api/src/lib/compression.ts
+++ b/apps/api/src/lib/compression.ts
@@ -1,7 +1,20 @@
+import { TaggedError } from "better-result";
+
 /**
  * Zstandard compression for corpus payloads in object storage.
  * Bun-native (this is a Bun runtime; no JS fallback).
+ *
+ * The corpus read/write paths use the async variants: they run on Bun's
+ * thread pool, so a pathological payload costs wall-clock but never blocks
+ * the event loop — the ingestion daemon's heartbeats, watchdog, and sibling
+ * loops keep running. The sync variants remain for one-shot scripts where
+ * event-loop latency is irrelevant.
  */
+
+/** A corpus payload exceeded the decompressed-size ceiling. */
+export class PayloadBudgetError extends TaggedError("PayloadBudgetError")<{
+  message: string;
+}>() {}
 
 export const zstdCompress = (data: string | Uint8Array): Uint8Array => {
   const bytes = typeof data === "string" ? Buffer.from(data, "utf-8") : data;
@@ -10,3 +23,30 @@ export const zstdCompress = (data: string | Uint8Array): Uint8Array => {
 
 export const zstdDecompressToString = (data: Uint8Array): string =>
   Buffer.from(Bun.zstdDecompressSync(data)).toString("utf-8");
+
+export const zstdCompressAsync = async (
+  data: string | Uint8Array,
+): Promise<Uint8Array> => {
+  const bytes = typeof data === "string" ? Buffer.from(data, "utf-8") : data;
+  return await Bun.zstdCompress(bytes);
+};
+
+/**
+ * Decompress off-thread and enforce a decompressed-size ceiling, so a
+ * corrupt or hostile object cannot hand a multi-gigabyte string to the
+ * JSON parser or chunker downstream. The ceiling is checked after
+ * decompression: zstd's frame header size hint is optional, so the byte
+ * count is only trustworthy once the frame is actually decoded.
+ */
+export const zstdDecompressToStringBounded = async (
+  data: Uint8Array,
+  maxBytes: number,
+): Promise<string> => {
+  const out = await Bun.zstdDecompress(data);
+  if (out.byteLength > maxBytes) {
+    throw new PayloadBudgetError({
+      message: `Decompressed payload is ${out.byteLength} bytes; ceiling is ${maxBytes}`,
+    });
+  }
+  return Buffer.from(out).toString("utf-8");
+};

--- a/apps/api/src/lib/compression.ts
+++ b/apps/api/src/lib/compression.ts
@@ -1,4 +1,6 @@
 import { TaggedError } from "better-result";
+import { promisify } from "node:util";
+import { zstdDecompress } from "node:zlib";
 
 /**
  * Zstandard compression for corpus payloads in object storage.
@@ -31,22 +33,36 @@ export const zstdCompressAsync = async (
   return await Bun.zstdCompress(bytes);
 };
 
+const zstdDecompressBounded = promisify(zstdDecompress);
+
 /**
  * Decompress off-thread and enforce a decompressed-size ceiling, so a
  * corrupt or hostile object cannot hand a multi-gigabyte string to the
- * JSON parser or chunker downstream. The ceiling is checked after
- * decompression: zstd's frame header size hint is optional, so the byte
- * count is only trustworthy once the frame is actually decoded.
+ * JSON parser or chunker downstream. `node:zlib`'s `maxOutputLength`
+ * enforces the ceiling during decoding — the oversized output is never
+ * materialized, so a decompression bomb cannot exhaust the heap before
+ * a post-hoc check would run.
  */
 export const zstdDecompressToStringBounded = async (
   data: Uint8Array,
   maxBytes: number,
 ): Promise<string> => {
-  const out = await Bun.zstdDecompress(data);
-  if (out.byteLength > maxBytes) {
-    throw new PayloadBudgetError({
-      message: `Decompressed payload is ${out.byteLength} bytes; ceiling is ${maxBytes}`,
+  try {
+    const out = await zstdDecompressBounded(data, {
+      maxOutputLength: maxBytes,
     });
+    return out.toString("utf-8");
+  } catch (error) {
+    if (
+      error instanceof RangeError ||
+      (error instanceof Error &&
+        "code" in error &&
+        error.code === "ERR_BUFFER_TOO_LARGE")
+    ) {
+      throw new PayloadBudgetError({
+        message: `Decompressed payload exceeds the ${maxBytes}-byte ceiling`,
+      });
+    }
+    throw error;
   }
-  return Buffer.from(out).toString("utf-8");
 };

--- a/apps/api/src/lib/corpus-index/chunking.test.ts
+++ b/apps/api/src/lib/corpus-index/chunking.test.ts
@@ -467,16 +467,42 @@ describe("structural budget", () => {
     // Persisted junk can carry any numeric level; ever-ascending levels grow
     // the ancestry stack without bound, which is what made path
     // materialization quadratic. The clamp keeps the deepest entries.
-    const ascending = Array.from({ length: 100 }, (_, index) => {
-      const base = heading(index, 1, `H${index}`);
-      // SAFETY: constructs the malformed persisted shape under test — a
-      // numeric heading level outside the parser's 1|2|3 union.
-      return { ...base, level: index + 1 } as Block;
-    });
-    const chunks = chunkDocument({
-      ast: astOf([...ascending, paragraph(100, "body under deep headings")]),
-      fallbackText: "",
-    });
+    // Parsed through the production guard rather than cast, so the test
+    // proves the real path: `isDocumentAst` validates the envelope only, and
+    // any numeric level reaches the chunker.
+    const ast = parseDocumentAst(
+      JSON.stringify({
+        version: 1,
+        source: { system: "t", documentId: "d", webUrl: "", printUrl: "" },
+        metadata: {
+          caseNumber: null,
+          ecli: null,
+          court: null,
+          decisionDate: null,
+          decisionType: null,
+          keywords: [],
+          statutes: [],
+        },
+        blocks: [
+          ...Array.from({ length: 100 }, (_, index) => ({
+            id: `h${index}`,
+            anchorId: `h${index}-anchor`,
+            type: "heading",
+            level: index + 1,
+            inlines: [],
+            plainText: `H${index}`,
+          })),
+          {
+            id: "p100",
+            anchorId: "p100-anchor",
+            type: "paragraph",
+            inlines: [],
+            plainText: "body under deep headings",
+          },
+        ],
+      }),
+    );
+    const chunks = chunkDocument({ ast, fallbackText: "" });
     const last = chunks.at(-1);
     expect(last?.headingPath.length).toBe(64);
     expect(last?.headingPath.at(-1)).toBe("H99");

--- a/apps/api/src/lib/corpus-index/chunking.test.ts
+++ b/apps/api/src/lib/corpus-index/chunking.test.ts
@@ -447,3 +447,39 @@ describe("chunkDocument fallbacks", () => {
     ]);
   });
 });
+
+describe("structural budget", () => {
+  test("a block count past the ceiling throws instead of walking", () => {
+    const block = paragraph(0, "body text");
+    const blocks = Array.from({ length: 400_001 }, () => block);
+    expect(() =>
+      chunkDocument({ ast: astOf(blocks), fallbackText: "" }),
+    ).toThrow(/ceiling/u);
+  });
+
+  test("fallback text past the ceiling throws instead of splitting", () => {
+    expect(() =>
+      chunkDocument({ ast: null, fallbackText: "x".repeat(30_000_001) }),
+    ).toThrow(/ceiling/u);
+  });
+
+  test("heading ancestry is clamped to the deepest entries", () => {
+    // Persisted junk can carry any numeric level; ever-ascending levels grow
+    // the ancestry stack without bound, which is what made path
+    // materialization quadratic. The clamp keeps the deepest entries.
+    const ascending = Array.from({ length: 100 }, (_, index) => {
+      const base = heading(index, 1, `H${index}`);
+      // SAFETY: constructs the malformed persisted shape under test — a
+      // numeric heading level outside the parser's 1|2|3 union.
+      return { ...base, level: index + 1 } as Block;
+    });
+    const chunks = chunkDocument({
+      ast: astOf([...ascending, paragraph(100, "body under deep headings")]),
+      fallbackText: "",
+    });
+    const last = chunks.at(-1);
+    expect(last?.headingPath.length).toBe(64);
+    expect(last?.headingPath.at(-1)).toBe("H99");
+    expect(last?.headingPath.at(0)).toBe("H36");
+  });
+});

--- a/apps/api/src/lib/corpus-index/chunking.test.ts
+++ b/apps/api/src/lib/corpus-index/chunking.test.ts
@@ -509,3 +509,12 @@ describe("structural budget", () => {
     expect(last?.headingPath.at(0)).toBe("H36");
   });
 });
+
+describe("AST character budget", () => {
+  test("one oversized block throws instead of chunking", () => {
+    const blocks = [paragraph(0, "x".repeat(30_000_001))];
+    expect(() =>
+      chunkDocument({ ast: astOf(blocks), fallbackText: "" }),
+    ).toThrow(/ceiling/u);
+  });
+});

--- a/apps/api/src/lib/corpus-index/chunking.ts
+++ b/apps/api/src/lib/corpus-index/chunking.ts
@@ -1,3 +1,5 @@
+import { TaggedError } from "better-result";
+
 import type { Block, DocumentAst } from "@stll/legal-ast/document-ast";
 
 /**
@@ -67,6 +69,41 @@ const CHUNK_MIN_CHARS = 250 * CHARS_PER_TOKEN;
 
 /** Block separator. Also what the fallback splits paragraphs on. */
 const BLOCK_SEPARATOR = "\n\n";
+
+/**
+ * Structural ceilings for one document's chunking work.
+ *
+ * The chunker runs synchronously on the ingestion daemon's event loop, so
+ * its cost per document must be bounded up front: one pathological document
+ * that chunks for minutes starves every sibling loop, trips the daemon's
+ * own starvation watchdog, and turns into a restart loop because the same
+ * row is re-picked on every start. A document past either ceiling throws
+ * `ChunkBudgetError` instead, which the indexer's per-row isolation records
+ * as a failed index job — the poison document is named in the audit trail
+ * and skipped, and its batch-mates still commit.
+ *
+ * The ceilings are far above any legitimate decision or statute: the
+ * longest real judgments run to a few hundred thousand characters and a
+ * few thousand blocks.
+ */
+const MAX_CHUNK_INPUT_CHARS = 30_000_000;
+const MAX_CHUNK_BLOCKS = 400_000;
+
+/**
+ * Heading ancestry deeper than this is a malformed AST (real documents
+ * nest a handful of levels). The stack is clamped rather than thrown on:
+ * ancestry is a search label, so dropping the shallowest entries degrades
+ * a path nobody could read anyway, while a throw would fail a document
+ * whose text is perfectly indexable. The clamp also bounds the per-block
+ * cost of materializing the path, which is what makes an ever-growing
+ * stack quadratic.
+ */
+const MAX_HEADING_DEPTH = 64;
+
+/** A document exceeded the chunker's structural ceilings. */
+export class ChunkBudgetError extends TaggedError("ChunkBudgetError")<{
+  message: string;
+}>() {}
 
 const PARAGRAPH_BREAK = /\n[ \t]*\n/u;
 
@@ -194,6 +231,9 @@ const createHeadingStack = () => {
       stack.pop();
     }
     stack.push({ level, text });
+    if (stack.length > MAX_HEADING_DEPTH) {
+      stack.splice(0, stack.length - MAX_HEADING_DEPTH);
+    }
   };
 
   const path = (): string[] => stack.map((entry) => entry.text);
@@ -241,6 +281,11 @@ const isChunkableBlock = (block: unknown): boolean => {
 };
 
 const chunkBlocks = (blocks: readonly Block[]): CorpusChunk[] => {
+  if (blocks.length > MAX_CHUNK_BLOCKS) {
+    throw new ChunkBudgetError({
+      message: `Document has ${blocks.length} blocks; ceiling is ${MAX_CHUNK_BLOCKS}`,
+    });
+  }
   const accumulator = createChunkAccumulator();
   const headings = createHeadingStack();
 
@@ -271,6 +316,11 @@ const chunkBlocks = (blocks: readonly Block[]): CorpusChunk[] => {
  * rather than pointing somewhere approximate.
  */
 const chunkPlainText = (text: string): CorpusChunk[] => {
+  if (text.length > MAX_CHUNK_INPUT_CHARS) {
+    throw new ChunkBudgetError({
+      message: `Fallback text is ${text.length} chars; ceiling is ${MAX_CHUNK_INPUT_CHARS}`,
+    });
+  }
   const accumulator = createChunkAccumulator();
   for (const paragraph of text.split(PARAGRAPH_BREAK)) {
     if (isBlank(paragraph)) {
@@ -309,6 +359,13 @@ export const chunkDocument = ({
   ast,
   fallbackText,
 }: ChunkDocumentInput): CorpusChunk[] => {
+  // The ceiling applies before the conformance scan: `every` is linear too,
+  // so a many-million-block junk array must be rejected before any walk.
+  if (ast !== null && ast.blocks.length > MAX_CHUNK_BLOCKS) {
+    throw new ChunkBudgetError({
+      message: `Document has ${ast.blocks.length} blocks; ceiling is ${MAX_CHUNK_BLOCKS}`,
+    });
+  }
   // A single non-conforming block condemns the whole AST rather than being
   // skipped: the canonical text is complete, so degrading to it keeps every
   // word, while dropping bad blocks would silently lose whatever they held.

--- a/apps/api/src/lib/corpus-index/chunking.ts
+++ b/apps/api/src/lib/corpus-index/chunking.ts
@@ -289,7 +289,17 @@ const chunkBlocks = (blocks: readonly Block[]): CorpusChunk[] => {
   const accumulator = createChunkAccumulator();
   const headings = createHeadingStack();
 
+  // The block-count ceiling alone does not bound the walk: one block can
+  // carry an arbitrarily long `plainText`, so total characters are budgeted
+  // like the plain-text path's input.
+  let totalChars = 0;
   for (const block of blocks) {
+    totalChars += block.plainText.length;
+    if (totalChars > MAX_CHUNK_INPUT_CHARS) {
+      throw new ChunkBudgetError({
+        message: `Document text exceeds the ${MAX_CHUNK_INPUT_CHARS}-char ceiling`,
+      });
+    }
     if (isBlank(block.plainText)) {
       continue;
     }

--- a/apps/api/src/lib/limits.ts
+++ b/apps/api/src/lib/limits.ts
@@ -269,6 +269,11 @@ export const LIMITS = {
    *  a slow-but-live transfer. Bounds every corpus S3 call so a wedged
    *  transfer can never freeze a daemon loop. */
   corpusObjectIoTimeoutMs: 60_000,
+  /** Max decompressed bytes for one corpus object. Real payloads are a few
+   *  MB; anything past this ceiling is a corrupt or hostile object, and
+   *  rejecting it here keeps a giant string away from JSON.parse and the
+   *  chunker, whose cost scales with input size on the daemon's thread. */
+  corpusPayloadMaxDecompressedBytes: 128 * 1024 * 1024,
   infoSoudEventsMax: 200,
   infoSoudHearingsMax: 50,
   infoSoudRelatedCasesMax: 50,


### PR DESCRIPTION
The corpus indexer isolates per-row failures into failed index jobs, but that isolation only catches code that throws. A document whose synchronous cost is unbounded (a corrupt many-block AST, a giant decompressed payload, malformed heading levels making path materialization quadratic) never throws — it blocks the daemon's event loop until the starvation watchdog restarts the process, and the same row is re-picked on the next start.

This bounds every unbounded step so such a document becomes a catchable, audited failure:

- **Async zstd with a decompressed-size ceiling**: corpus reads/writes use Bun's thread-pool zstd variants, and decompression rejects payloads past `corpusPayloadMaxDecompressedBytes` before the string reaches `JSON.parse` or the chunker. Existing sync-written objects decompress byte-for-byte through the bounded path (covered by test).
- **Chunker structural ceilings**: block-count and fallback-text-size caps, checked before any linear walk (including the `every` conformance scan), plus a heading-ancestry depth clamp.
- Ceiling violations throw tagged errors that the indexer's per-row isolation records as failed index jobs carrying the row id, so a pathological document names itself in the audit trail and its batch-mates still commit.

Follow-up (not here): failed rows are retried each cycle; the retries are now cheap and visible, but an attempt-capped quarantine would stop them occupying batch slots.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added safer handling for compressed corpus content, including asynchronous processing and size limits.
  * Added protections against excessively large documents and fallback text during indexing.
  * Limited heading ancestry depth to keep generated passages manageable.

* **Bug Fixes**
  * Prevented oversized or potentially harmful payloads from consuming excessive memory or processing resources.
  * Added compatibility for previously compressed corpus content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->