### PR TITLE
fix(templates): keep typed statuses on suggest-fields failures

### DIFF
--- a/apps/api/src/handlers/templates/suggest-fields.ts
+++ b/apps/api/src/handlers/templates/suggest-fields.ts
@@ -1,11 +1,13 @@
 import { Result } from "better-result";
 import { t } from "elysia";
 
-import { suggestTemplateFields } from "@/api/handlers/templates/suggest-template-fields";
+import {
+  suggestTemplateFields,
+  toSuggestFieldsError,
+} from "@/api/handlers/templates/suggest-template-fields";
 import { createTanStackAIAnalyticsCallbacks } from "@/api/lib/analytics/tanstack-ai";
 import { createSafeRootHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
-import { HandlerError } from "@/api/lib/errors/tagged-errors";
 
 const suggestFieldsBodySchema = t.Object({
   // The text the editor chose to send: the whole document or just the current
@@ -70,11 +72,7 @@ const suggestFields = createSafeRootHandler(
           }),
         catch: (cause) => {
           aiAnalytics.captureError(cause);
-          return new HandlerError({
-            status: 500,
-            message: "Failed to suggest template fields",
-            cause,
-          });
+          return toSuggestFieldsError(cause);
         },
       }),
     );

--- a/apps/api/src/handlers/templates/suggest-template-fields.test.ts
+++ b/apps/api/src/handlers/templates/suggest-template-fields.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, test } from "bun:test";
 import * as v from "valibot";
 
-import { fieldSuggestionsSchema } from "./suggest-template-fields";
+import { HandlerError } from "@/api/lib/errors/tagged-errors";
+
+import {
+  fieldSuggestionsSchema,
+  toSuggestFieldsError,
+} from "./suggest-template-fields";
 
 describe("fieldSuggestionsSchema", () => {
   test("accepts well-formed suggestions (plain, typed, and AI-fillable)", () => {
@@ -53,5 +58,21 @@ describe("fieldSuggestionsSchema", () => {
         suggestions: [{ literalText: "x" }],
       }).success,
     ).toBe(false);
+  });
+});
+
+describe("toSuggestFieldsError", () => {
+  test("a typed HandlerError passes through with its status and message", () => {
+    const typed = new HandlerError({
+      status: 403,
+      message: "AI is not available for this role",
+    });
+    expect(toSuggestFieldsError(typed)).toBe(typed);
+  });
+
+  test("an untyped failure becomes a 500", () => {
+    const mapped = toSuggestFieldsError(new Error("socket hang up"));
+    expect(mapped.status).toBe(500);
+    expect(mapped.message).toBe("Failed to suggest template fields");
   });
 });

--- a/apps/api/src/handlers/templates/suggest-template-fields.ts
+++ b/apps/api/src/handlers/templates/suggest-template-fields.ts
@@ -166,9 +166,14 @@ export const suggestTemplateFieldsOrEmpty = async (
   }
 };
 
+// `instanceof` on the generic class narrows to `HandlerError<any>`; the
+// predicate restores the default parameter.
+const isHandlerError = (error: unknown): error is HandlerError =>
+  error instanceof HandlerError;
+
 /** A typed failure keeps its status and message; everything else is a 500. */
 export const toSuggestFieldsError = (cause: unknown): HandlerError => {
-  if (cause instanceof HandlerError) {
+  if (isHandlerError(cause)) {
     return cause;
   }
   return new HandlerError({

--- a/apps/api/src/handlers/templates/suggest-template-fields.ts
+++ b/apps/api/src/handlers/templates/suggest-template-fields.ts
@@ -23,6 +23,7 @@ import { resolveCaching, type OrgAIConfig } from "@/api/lib/ai-config";
 import type { createTanStackAIAnalyticsCallbacks } from "@/api/lib/analytics/tanstack-ai";
 import type { SafeId } from "@/api/lib/branded-types";
 import type { FieldSuggestion } from "@/api/lib/docx/apply-field-suggestions";
+import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import { generateTanStackObjectForRole } from "@/api/lib/tanstack-ai-generate";
 
 const SUGGEST_TIMEOUT_MS = 45_000;
@@ -163,4 +164,16 @@ export const suggestTemplateFieldsOrEmpty = async (
     args.aiAnalytics.captureError(error);
     return [];
   }
+};
+
+/** A typed failure keeps its status and message; everything else is a 500. */
+export const toSuggestFieldsError = (cause: unknown): HandlerError => {
+  if (cause instanceof HandlerError) {
+    return cause;
+  }
+  return new HandlerError({
+    status: 500,
+    message: "Failed to suggest template fields",
+    cause,
+  });
 };


### PR DESCRIPTION
`POST /v1/templates/suggest-fields` wrapped every rejection from the model call into a fresh 500. Typed conditions the model-resolution layer already classified were discarded — notably the 403 "configure an AI key for this role" raised on BYOK-only deployments, which reached the editor as a generic server error (observed in production as repeated 500s from a single session, enough to page the ALB 5xx alarm).

The rejection now routes through `toSuggestFieldsError`: `HandlerError` passes through with its status and message; anything untyped stays a 500. Regression tests pin both directions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when suggesting template fields.
  * Preserved existing error details where available.
  * Standardised unexpected failures with a clear error message and server-error status.

* **Tests**
  * Added coverage for both recognised and unexpected error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->