### PR TITLE
fix(templates): pass through only 4xx suggest-fields failures

### DIFF
--- a/apps/api/src/handlers/templates/suggest-template-fields.test.ts
+++ b/apps/api/src/handlers/templates/suggest-template-fields.test.ts
@@ -76,3 +76,15 @@ describe("toSuggestFieldsError", () => {
     expect(mapped.message).toBe("Failed to suggest template fields");
   });
 });
+
+describe("toSuggestFieldsError provider-run errors", () => {
+  test("a 5xx HandlerError is remapped to the generic 500", () => {
+    const providerRun = new HandlerError({
+      status: 502,
+      message: "provider text that could echo request content",
+    });
+    const mapped = toSuggestFieldsError(providerRun);
+    expect(mapped.status).toBe(500);
+    expect(mapped.message).toBe("Failed to suggest template fields");
+  });
+});

--- a/apps/api/src/handlers/templates/suggest-template-fields.ts
+++ b/apps/api/src/handlers/templates/suggest-template-fields.ts
@@ -171,9 +171,14 @@ export const suggestTemplateFieldsOrEmpty = async (
 const isHandlerError = (error: unknown): error is HandlerError =>
   error instanceof HandlerError;
 
-/** A typed failure keeps its status and message; everything else is a 500. */
+/**
+ * A typed 4xx keeps its status and message (curated client conditions such
+ * as the BYOK 403). Anything else — including provider-run 502s, whose
+ * message is provider-controlled and can echo request content — becomes the
+ * generic 500.
+ */
 export const toSuggestFieldsError = (cause: unknown): HandlerError => {
-  if (isHandlerError(cause)) {
+  if (isHandlerError(cause) && cause.status < 500) {
     return cause;
   }
   return new HandlerError({


### PR DESCRIPTION
Follow-up to #1465, from review: `tanStackRunError` builds 502 `HandlerError`s directly from provider-controlled `chunk.message`/`chunk.code`, so the unconditional pass-through could expose provider text that echoes request content. The classifier now keeps typed **4xx** conditions (the curated BYOK 403 and friends) and remaps every 5xx or untyped failure to the generic 500. Regression test pins the 502 remap.