### PR TITLE
fix: keep inspector controls within bounds

### DIFF
--- a/apps/web/src/components/ai-suggestions/accept-all-button.tsx
+++ b/apps/web/src/components/ai-suggestions/accept-all-button.tsx
@@ -12,7 +12,7 @@
 import { useState } from "react";
 import type { ComponentProps, ReactNode } from "react";
 
-import { CheckIcon } from "lucide-react";
+import { CheckCheckIcon } from "lucide-react";
 import { useTranslations } from "use-intl";
 
 import {
@@ -119,13 +119,15 @@ export const AcceptAllButton = ({
   return (
     <>
       <Button
+        aria-label={t("docxReview.acceptAll")}
         className={className}
         disabled={pendingItems.length === 0 || isAccepting}
         onClick={handleClick}
         size={buttonSize}
+        tooltip={t("docxReview.acceptAll")}
         variant={buttonVariant}
       >
-        <CheckIcon className="me-1 size-3.5" />
+        <CheckCheckIcon className="me-1 size-3.5" />
         {children}
       </Button>
       <AlertDialog onOpenChange={setConfirmOpen} open={confirmOpen}>
@@ -166,7 +168,7 @@ export const AcceptAllButton = ({
               size="sm"
               variant="default"
             >
-              <CheckIcon className="me-1 size-3.5" />
+              <CheckCheckIcon className="me-1 size-3.5" />
               {t("docxReview.acceptAll")}
             </Button>
           </AlertDialogFooter>

--- a/apps/web/src/components/ai-suggestions/file-viewer-with-ai.tsx
+++ b/apps/web/src/components/ai-suggestions/file-viewer-with-ai.tsx
@@ -40,7 +40,7 @@ export const FileViewerWithAI = ({
 
   return (
     <div
-      className={cn("relative h-full w-full", className)}
+      className={cn("@container/file-viewer relative h-full w-full", className)}
       data-file-viewer-ai="true"
     >
       {children}

--- a/apps/web/src/components/ai-suggestions/review-bar.tsx
+++ b/apps/web/src/components/ai-suggestions/review-bar.tsx
@@ -235,7 +235,7 @@ export const ReviewBar = ({
       aria-label={t("docxReview.barLabel")}
       data-docx-review-bar=""
       className={cn(
-        "bg-popover/90 text-popover-foreground border-border pointer-events-auto absolute start-1/2 bottom-28 z-50 flex -translate-x-1/2 items-center gap-1 rounded-full border py-1 ps-2 pe-1.5",
+        "bg-popover/90 text-popover-foreground border-border pointer-events-auto absolute start-1/2 bottom-28 z-50 flex w-max max-w-[calc(100%-2rem)] -translate-x-1/2 flex-wrap items-center justify-center gap-1 rounded-full border py-1 ps-2 pe-1.5",
         "[backdrop-filter:blur(18px)_saturate(160%)] [-webkit-backdrop-filter:blur(18px)_saturate(160%)]",
         "shadow-[0_1px_2px_rgb(0_0_0/0.06),0_12px_32px_rgb(0_0_0/0.14)]",
         "animate-in fade-in-0 slide-in-from-bottom-1",
@@ -278,8 +278,10 @@ export const ReviewBar = ({
         tooltip={`${t("common.accept")} · ${SHORTCUT_HINTS.accept}`}
         variant="default"
       >
-        <CheckIcon className="me-1 size-3.5" />
-        {t("common.accept")}
+        <CheckIcon className="me-1 size-3.5 @max-[80rem]/file-viewer:me-0" />
+        <span className="@max-[80rem]/file-viewer:hidden">
+          {t("common.accept")}
+        </span>
       </Button>
       <Button
         className="h-7 px-2.5 text-xs"
@@ -288,8 +290,10 @@ export const ReviewBar = ({
         tooltip={`${t("docxReview.reject")} · ${SHORTCUT_HINTS.reject}`}
         variant="outline"
       >
-        <XIcon className="me-1 size-3.5" />
-        {t("docxReview.reject")}
+        <XIcon className="me-1 size-3.5 @max-[80rem]/file-viewer:me-0" />
+        <span className="@max-[80rem]/file-viewer:hidden">
+          {t("docxReview.reject")}
+        </span>
       </Button>
       <AcceptAllButton
         className="h-7 px-2.5 text-xs"
@@ -298,7 +302,9 @@ export const ReviewBar = ({
         size="sm"
         variant="ghost"
       >
-        {t("docxReview.acceptAll")}
+        <span className="@max-[80rem]/file-viewer:hidden">
+          {t("docxReview.acceptAll")}
+        </span>
       </AcceptAllButton>
       <span aria-hidden="true" className="bg-border mx-0.5 h-5 w-px" />
       <Select
@@ -311,7 +317,7 @@ export const ReviewBar = ({
       >
         <SelectTrigger
           aria-label={t("docxReview.applyAs")}
-          className="hover:bg-muted h-7 w-auto min-w-0 justify-between gap-1 rounded-full border-0 bg-transparent px-2 text-xs font-medium"
+          className="hover:bg-muted h-7 w-auto max-w-64 min-w-0 justify-between gap-1 rounded-full border-0 bg-transparent px-2 text-xs font-medium @max-[36rem]/file-viewer:max-w-36"
         >
           <SelectValue />
         </SelectTrigger>

--- a/apps/web/src/components/chat/composer-plus-menu.tsx
+++ b/apps/web/src/components/chat/composer-plus-menu.tsx
@@ -366,7 +366,7 @@ const ComposerModelsSubmenu = ({
         <CpuIcon />
         {t("chat.composerMenu.models")}
       </MenuSubTrigger>
-      <MenuSubPopup className="w-64">
+      <MenuSubPopup className="w-[min(32rem,calc(100vw-2rem))] max-w-(--available-width)">
         <ComposerSubmenuSearch
           onChange={setSearch}
           // Reuses the AI-config role-model picker's placeholder (same
@@ -381,10 +381,9 @@ const ComposerModelsSubmenu = ({
           <MenuRadioGroup value={selectedModel ?? ""}>
             {rows.map((row) => (
               <MenuRadioItem
-                // `minmax(0,1fr)` lets the label cell shrink so `truncate`
-                // applies; the default `1fr` track sizes to the longest model
-                // id and forces horizontal overflow (same fix as the matters
-                // picker's TRUNCATING_ITEM_CLASS).
+                // `minmax(0,1fr)` lets the label cell shrink and wrap; the
+                // default `1fr` track sizes to the longest model id and forces
+                // horizontal overflow.
                 className="grid-cols-[1rem_minmax(0,1fr)]"
                 key={row.value || "default"}
                 onClick={() => {
@@ -392,10 +391,12 @@ const ComposerModelsSubmenu = ({
                 }}
                 value={row.value}
               >
-                {/* `block`: the radio item's own children wrapper is inline,
-                    and `truncate`'s overflow clipping is inert on inline
-                    elements. */}
-                <span className="block truncate">{row.label}</span>
+                {/* Model identifiers are decision-critical and often share a
+                    long provider prefix. Keep the complete value visible;
+                    wrap only when the viewport cannot fit the wider popup. */}
+                <span className="block [overflow-wrap:anywhere] whitespace-normal">
+                  {row.label}
+                </span>
               </MenuRadioItem>
             ))}
           </MenuRadioGroup>

--- a/apps/web/src/i18n/langs/cs.json
+++ b/apps/web/src/i18n/langs/cs.json
@@ -414,7 +414,7 @@
       "noSkills": "Nejsou k dispozici žádné dovednosti",
       "open": "Otevřít nabídku příloh a nástrojů",
       "openMcpSettings": "Otevřít nastavení MCP",
-      "openSkills": "Otevřít dovednosti",
+      "openSkills": "Otevřít nastavení dovedností",
       "referenceMatter": "Odkázat na tento spis",
       "searchFiles": "Hledat soubory",
       "searchMatters": "Hledat spisy",


### PR DESCRIPTION
## Proposed change

- keep the floating DOCX review toolbar within its Inspector pane and compact localized action labels at narrower container widths
- widen the model submenu and wrap full provider-qualified model identifiers instead of truncating them
- change the Czech Skills destination label to “Otevřít nastavení dovedností”

## Validation

- pre-commit formatting, lint, i18n sync, and secret checks
- pre-push affected-workspace formatting, i18n checks, and web typecheck
- production client and SSR build

## Checklist

- [x] **BUILD ASSURANCE** | Code builds correctly and without errors.
- [x] **TESTING** | Responsive styles compile and the affected web workspace typechecks.
- [x] **DARK MODE SUPPORT** | Changes retain semantic design tokens and do not alter colors.
- [ ] **ISSUE LINKED** | No issue supplied.
- [ ] **SCREENSHOT INCLUDED** | Reproduction screenshots were supplied outside the repository.

CC on behalf of jan-kubica