### PR TITLE
fix: match suggested extraction prompts to source language

### DIFF
--- a/apps/api/src/handlers/properties/suggest-prompt-message.test.ts
+++ b/apps/api/src/handlers/properties/suggest-prompt-message.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  buildSuggestPromptUserMessage,
+  SUGGEST_PROMPT_SYSTEM_PROMPT,
+} from "./suggest-prompt-message";
+
+describe("suggest prompt language", () => {
+  test("uses the column name's language for a new prompt", () => {
+    const message = buildSuggestPromptUserMessage({
+      name: "Odpovědnost jednatele",
+      contentType: "text",
+      options: undefined,
+      currentPrompt: undefined,
+    });
+
+    expect(message).toContain(
+      "Output language: Match the column name's language.",
+    );
+  });
+
+  test("uses the current draft's language when refining a prompt", () => {
+    const message = buildSuggestPromptUserMessage({
+      name: "Executive liability",
+      contentType: "text",
+      options: undefined,
+      currentPrompt: "Popište rozsah odpovědnosti jednatele.",
+    });
+
+    expect(message).toContain(
+      "Output language: Match the current draft's language.",
+    );
+  });
+
+  test("prevents the English instructions from becoming the output default", () => {
+    expect(SUGGEST_PROMPT_SYSTEM_PROMPT).toContain(
+      "English merely because these instructions are in English.",
+    );
+  });
+});

--- a/apps/api/src/handlers/properties/suggest-prompt-message.ts
+++ b/apps/api/src/handlers/properties/suggest-prompt-message.ts
@@ -1,0 +1,48 @@
+export const SUGGEST_PROMPT_SYSTEM_PROMPT = `You write extraction prompts for a legal-document AI tool.
+Given a column name (and optionally the user's current prompt draft), produce
+ONE direct, imperative sentence telling the AI what to extract from the
+document. Rules:
+- Output the prompt only. No preamble, no quotes, no markdown.
+- Single sentence, plain text, ends with a period.
+- Write in the same language as the current draft when one is supplied;
+  otherwise, write in the same language as the column name. Do not default to
+  English merely because these instructions are in English.
+- If the user supplied a current draft, REFINE it: keep their intent and
+  vocabulary, fix grammar, tighten wording, and align with the result type.
+  Do not invent constraints they didn't ask for.
+- If no draft, write a fresh prompt grounded in the column name.
+- Match the result type:
+  - text → ask for the value as a short string.
+  - int → ask for a number.
+  - date → ask for a date in ISO 8601 (YYYY-MM-DD).
+  - single-select → ask the AI to choose exactly one of the listed options.
+  - multi-select → ask for all matching options from the list.
+- Reference the document implicitly when natural ("from the contract").
+- Stay under 280 characters.`;
+
+type BuildSuggestPromptUserMessageOptions = {
+  name: string;
+  contentType: string;
+  options: string[] | undefined;
+  currentPrompt: string | undefined;
+};
+
+export const buildSuggestPromptUserMessage = ({
+  name,
+  contentType,
+  options,
+  currentPrompt,
+}: BuildSuggestPromptUserMessageOptions): string => {
+  const lines = [`Column name: ${name}`, `Result type: ${contentType}`];
+  if (options && options.length > 0) {
+    lines.push(`Allowed options: ${options.join(", ")}`);
+  }
+  if (currentPrompt && currentPrompt.length > 0) {
+    lines.push(`Current draft (refine, don't replace): ${currentPrompt}`);
+    lines.push("Output language: Match the current draft's language.");
+  } else {
+    lines.push("Output language: Match the column name's language.");
+  }
+  lines.push("Write the extraction prompt:");
+  return lines.join("\n");
+};

--- a/apps/api/src/handlers/properties/suggest-prompt.ts
+++ b/apps/api/src/handlers/properties/suggest-prompt.ts
@@ -1,6 +1,10 @@
 import { Result } from "better-result";
 import { t } from "elysia";
 
+import {
+  buildSuggestPromptUserMessage,
+  SUGGEST_PROMPT_SYSTEM_PROMPT,
+} from "@/api/handlers/properties/suggest-prompt-message";
 import { resolveCaching } from "@/api/lib/ai-config";
 import {
   loadOrgAIConfig,
@@ -46,47 +50,6 @@ const config = {
 
 const SUGGEST_TIMEOUT_MS = 20_000;
 const MAX_PROMPT_LENGTH = 280;
-
-const SYSTEM_PROMPT = `You write extraction prompts for a legal-document AI tool.
-Given a column name (and optionally the user's current prompt draft), produce
-ONE direct, imperative sentence telling the AI what to extract from the
-document. Rules:
-- Output the prompt only. No preamble, no quotes, no markdown.
-- Single sentence, plain text, ends with a period.
-- If the user supplied a current draft, REFINE it: keep their intent and
-  vocabulary, fix grammar, tighten wording, and align with the result type.
-  Do not invent constraints they didn't ask for.
-- If no draft, write a fresh prompt grounded in the column name.
-- Match the result type:
-  - text → ask for the value as a short string.
-  - int → ask for a number.
-  - date → ask for a date in ISO 8601 (YYYY-MM-DD).
-  - single-select → ask the AI to choose exactly one of the listed options.
-  - multi-select → ask for all matching options from the list.
-- Reference the document implicitly when natural ("from the contract").
-- Stay under 280 characters.`;
-
-const buildUserMessage = ({
-  name,
-  contentType,
-  options,
-  currentPrompt,
-}: {
-  name: string;
-  contentType: string;
-  options: string[] | undefined;
-  currentPrompt: string | undefined;
-}): string => {
-  const lines = [`Column name: ${name}`, `Result type: ${contentType}`];
-  if (options && options.length > 0) {
-    lines.push(`Allowed options: ${options.join(", ")}`);
-  }
-  if (currentPrompt && currentPrompt.length > 0) {
-    lines.push(`Current draft (refine, don't replace): ${currentPrompt}`);
-  }
-  lines.push("Write the extraction prompt:");
-  return lines.join("\n");
-};
 
 const QUOTE_CHARS = new Set(['"', "'", "“", "”", "‘", "’"]);
 
@@ -151,7 +114,7 @@ const suggestPrompt = createSafeHandler(
       traceId: Bun.randomUUIDv7(),
     });
 
-    const userMessage = buildUserMessage({
+    const userMessage = buildSuggestPromptUserMessage({
       name: trimmedName,
       contentType: body.contentType,
       options: body.options?.map((o) => o.value),
@@ -171,7 +134,7 @@ const suggestPrompt = createSafeHandler(
             role: "fast",
             scopeKey: null,
           }),
-          system: SYSTEM_PROMPT,
+          system: SUGGEST_PROMPT_SYSTEM_PROMPT,
           messages: [{ role: "user", content: userMessage }],
           abortSignal: AbortSignal.any([
             request.signal,


### PR DESCRIPTION
## Proposed change

Suggested extraction prompts previously defaulted to English because the model received English instructions without an output-language rule, even when the column name was in another language.

- use the current draft language when refining an existing prompt
- otherwise use the column name language
- repeat the language requirement in both system and user messages
- cover Czech column names and current-draft precedence with focused tests

## Verification

- `bun test apps/api/src/handlers/properties/suggest-prompt-message.test.ts`
- `bun --filter @stll/api typecheck`
- pre-commit and pre-push validation hooks

## Checklist

- [x] BUILD ASSURANCE | **PASS** — API typecheck and repository pre-push checks passed.
- [x] TESTING | **PASS** — focused Czech and draft-precedence tests passed.
- [x] DARK MODE SUPPORT | **N/A** — backend prompt construction only.
- [x] ISSUE LINKED | **N/A** — no issue was supplied.
- [x] SCREENSHOT INCLUDED | **N/A** — no visual UI change.