### PR TITLE
feat(chat): add composer response modes and prompt improvement

### DIFF
--- a/apps/api/src/handlers/chat/get-model-options.ts
+++ b/apps/api/src/handlers/chat/get-model-options.ts
@@ -3,6 +3,7 @@ import { Result } from "better-result";
 import { createSafeRootHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
 import {
+  getChatModeModelValue,
   getConfiguredChatModelOptions,
   getDefaultChatModelValue,
 } from "@/api/lib/chat-model-selection";
@@ -25,6 +26,18 @@ const getModelOptions = createSafeRootHandler(
         orgAIConfig,
         organizationId: session.activeOrganizationId,
       }),
+      modeValues: {
+        deepThinking: getChatModeModelValue({
+          orgAIConfig,
+          organizationId: session.activeOrganizationId,
+          role: "reasoning",
+        }),
+        fast: getChatModeModelValue({
+          orgAIConfig,
+          organizationId: session.activeOrganizationId,
+          role: "fast",
+        }),
+      },
     });
   },
 );

--- a/apps/api/src/handlers/chat/improve-prompt.ts
+++ b/apps/api/src/handlers/chat/improve-prompt.ts
@@ -1,0 +1,117 @@
+import { Result } from "better-result";
+import { t } from "elysia";
+
+import { resolveCaching } from "@/api/lib/ai-config";
+import { aiHandlerError } from "@/api/lib/ai-error";
+import { createTanStackAIAnalyticsCallbacks } from "@/api/lib/analytics/tanstack-ai";
+import { createSafeRootHandler } from "@/api/lib/api-handlers";
+import type { HandlerConfig } from "@/api/lib/api-handlers";
+import { HandlerError } from "@/api/lib/errors/tagged-errors";
+import { generateTanStackTextForRole } from "@/api/lib/tanstack-ai-generate";
+
+const IMPROVE_PROMPT_SYSTEM = `You improve prompts for a legal-workspace AI assistant.
+Rewrite the user's draft so it is clearer, more specific, and easier to act on while preserving the user's intent, facts, language, and level of formality.
+
+Rules:
+- Return only the improved prompt. No preamble, commentary, quotation marks, or markdown fences.
+- Write in the same language as the draft.
+- Keep all names, dates, citations, defined terms, constraints, and requested output formats intact.
+- Do not invent facts, legal authorities, assumptions, or requirements.
+- Prefer direct instructions and make the desired outcome explicit.
+- Keep a short draft concise. Use paragraphs or bullets only when they materially improve a longer request.`;
+
+const config = {
+  permissions: { chat: ["create"] },
+  mcp: { type: "internal", reason: "assistant_chat" },
+  body: t.Object({
+    prompt: t.String({ minLength: 1, maxLength: 12_000 }),
+  }),
+  requiresUsage: { actionType: "chat", modelRole: "fast" },
+} satisfies HandlerConfig;
+
+const IMPROVE_PROMPT_TIMEOUT_MS = 20_000;
+const IMPROVE_PROMPT_MAX_OUTPUT_TOKENS = 4096;
+
+const improvePrompt = createSafeRootHandler(
+  config,
+  // eslint-disable-next-line require-yield -- no database operation to unwrap
+  async function* ({
+    body,
+    orgAIConfig,
+    promptCachingEnabled,
+    request,
+    safeDb,
+    session,
+    user,
+  }) {
+    const prompt = body.prompt.trim();
+    if (prompt.length === 0) {
+      return Result.err(
+        new HandlerError({ status: 400, message: "Prompt is required" }),
+      );
+    }
+
+    const aiAnalytics = createTanStackAIAnalyticsCallbacks({
+      usageMetering: {
+        actionType: "chat",
+        organizationId: session.activeOrganizationId,
+        safeDb,
+        serviceTier: "standard",
+        userId: user.id,
+        workspaceId: null,
+      },
+      feature: "chat.improve_prompt",
+      modelRole: "fast",
+      orgAIConfig,
+      properties: { organization_id: session.activeOrganizationId },
+      traceId: Bun.randomUUIDv7(),
+    });
+
+    const generated = await Result.tryPromise({
+      try: async () =>
+        await generateTanStackTextForRole({
+          abortSignal: AbortSignal.any([
+            request.signal,
+            AbortSignal.timeout(IMPROVE_PROMPT_TIMEOUT_MS),
+          ]),
+          analytics: aiAnalytics,
+          caching: resolveCaching({
+            promptCachingEnabled,
+            role: "fast",
+            scopeKey: null,
+          }),
+          messages: [{ role: "user", content: prompt }],
+          maxOutputTokens: IMPROVE_PROMPT_MAX_OUTPUT_TOKENS,
+          organizationId: session.activeOrganizationId,
+          orgAIConfig,
+          role: "fast",
+          serviceTier: "standard",
+          system: IMPROVE_PROMPT_SYSTEM,
+        }),
+      catch: (error) => {
+        aiAnalytics.captureError(error);
+        return error;
+      },
+    });
+
+    if (Result.isError(generated)) {
+      return Result.err(
+        aiHandlerError(generated.error, {
+          status: 502,
+          message: "Improve prompt failed",
+        }),
+      );
+    }
+
+    const improvedPrompt = generated.value.trim();
+    if (improvedPrompt.length === 0) {
+      return Result.err(
+        new HandlerError({ status: 502, message: "Empty improved prompt" }),
+      );
+    }
+
+    return Result.ok({ prompt: improvedPrompt });
+  },
+);
+
+export default improvePrompt;

--- a/apps/api/src/handlers/chat/improve-prompt.ts
+++ b/apps/api/src/handlers/chat/improve-prompt.ts
@@ -1,6 +1,8 @@
 import { Result } from "better-result";
 import { t } from "elysia";
 
+import { CHAT_SEND_MODE } from "@stll/anonymize-chat";
+
 import { resolveCaching } from "@/api/lib/ai-config";
 import { aiHandlerError } from "@/api/lib/ai-error";
 import { createTanStackAIAnalyticsCallbacks } from "@/api/lib/analytics/tanstack-ai";
@@ -25,6 +27,10 @@ const config = {
   mcp: { type: "internal", reason: "assistant_chat" },
   body: t.Object({
     prompt: t.String({ minLength: 1, maxLength: 12_000 }),
+    sendMode: t.Union([
+      t.Literal(CHAT_SEND_MODE.anonymized),
+      t.Literal(CHAT_SEND_MODE.rawOverride),
+    ]),
   }),
   requiresUsage: { actionType: "chat", modelRole: "fast" },
 } satisfies HandlerConfig;
@@ -43,6 +49,15 @@ const improvePrompt = createSafeRootHandler(
     session,
     user,
   }) {
+    if (body.sendMode === CHAT_SEND_MODE.anonymized) {
+      return Result.err(
+        new HandlerError({
+          status: 403,
+          message: "Prompt improvement is unavailable in anonymized mode",
+        }),
+      );
+    }
+
     const prompt = body.prompt.trim();
     if (prompt.length === 0) {
       return Result.err(

--- a/apps/api/src/handlers/chat/improve-prompt.ts
+++ b/apps/api/src/handlers/chat/improve-prompt.ts
@@ -34,7 +34,6 @@ const IMPROVE_PROMPT_MAX_OUTPUT_TOKENS = 4096;
 
 const improvePrompt = createSafeRootHandler(
   config,
-  // eslint-disable-next-line require-yield -- no database operation to unwrap
   async function* ({
     body,
     orgAIConfig,
@@ -67,43 +66,37 @@ const improvePrompt = createSafeRootHandler(
       traceId: Bun.randomUUIDv7(),
     });
 
-    const generated = await Result.tryPromise({
-      try: async () =>
-        await generateTanStackTextForRole({
-          abortSignal: AbortSignal.any([
-            request.signal,
-            AbortSignal.timeout(IMPROVE_PROMPT_TIMEOUT_MS),
-          ]),
-          analytics: aiAnalytics,
-          caching: resolveCaching({
-            promptCachingEnabled,
+    const improvedPrompt = (yield* Result.await(
+      Result.tryPromise({
+        try: async () =>
+          await generateTanStackTextForRole({
+            abortSignal: AbortSignal.any([
+              request.signal,
+              AbortSignal.timeout(IMPROVE_PROMPT_TIMEOUT_MS),
+            ]),
+            analytics: aiAnalytics,
+            caching: resolveCaching({
+              promptCachingEnabled,
+              role: "fast",
+              scopeKey: null,
+            }),
+            messages: [{ role: "user", content: prompt }],
+            maxOutputTokens: IMPROVE_PROMPT_MAX_OUTPUT_TOKENS,
+            organizationId: session.activeOrganizationId,
+            orgAIConfig,
             role: "fast",
-            scopeKey: null,
+            serviceTier: "standard",
+            system: IMPROVE_PROMPT_SYSTEM,
           }),
-          messages: [{ role: "user", content: prompt }],
-          maxOutputTokens: IMPROVE_PROMPT_MAX_OUTPUT_TOKENS,
-          organizationId: session.activeOrganizationId,
-          orgAIConfig,
-          role: "fast",
-          serviceTier: "standard",
-          system: IMPROVE_PROMPT_SYSTEM,
-        }),
-      catch: (error) => {
-        aiAnalytics.captureError(error);
-        return error;
-      },
-    });
-
-    if (Result.isError(generated)) {
-      return Result.err(
-        aiHandlerError(generated.error, {
-          status: 502,
-          message: "Improve prompt failed",
-        }),
-      );
-    }
-
-    const improvedPrompt = generated.value.trim();
+        catch: (error) => {
+          aiAnalytics.captureError(error);
+          return aiHandlerError(error, {
+            status: 502,
+            message: "Improve prompt failed",
+          });
+        },
+      }),
+    )).trim();
     if (improvedPrompt.length === 0) {
       return Result.err(
         new HandlerError({ status: 502, message: "Empty improved prompt" }),

--- a/apps/api/src/handlers/chat/routes.ts
+++ b/apps/api/src/handlers/chat/routes.ts
@@ -9,6 +9,7 @@ import getSuggestedPrompts from "@/api/handlers/chat/get-suggested-prompts";
 import getThreadRecap from "@/api/handlers/chat/get-thread-recap";
 import getThreadTitle from "@/api/handlers/chat/get-thread-title";
 import getThreads from "@/api/handlers/chat/get-threads";
+import improvePrompt from "@/api/handlers/chat/improve-prompt";
 import renameThread from "@/api/handlers/chat/rename-thread";
 import resolveFileThread from "@/api/handlers/chat/resolve-file-thread";
 import resolveTemplateThread from "@/api/handlers/chat/resolve-template-thread";
@@ -54,6 +55,11 @@ export const chatRoute = new Elysia({ prefix: "/chat" })
   })
   .get("/model-options", getModelOptions.handler, {
     permissions: getModelOptions.config.permissions,
+  })
+  .post("/improve-prompt", improvePrompt.handler, {
+    body: improvePrompt.config.body,
+    permissions: improvePrompt.config.permissions,
+    requiresUsage: improvePrompt.config.requiresUsage,
   })
   .delete("/threads/:threadId", deleteThread.handler, {
     params: deleteThread.config.params,

--- a/apps/api/src/lib/chat-model-selection.test.ts
+++ b/apps/api/src/lib/chat-model-selection.test.ts
@@ -22,6 +22,7 @@ env.OPENAI_API_KEY = "test-openai-instance-key";
 const {
   decodeChatModelSelection,
   encodeChatModelSelection,
+  getChatModeModelValue,
   getConfiguredChatModelOptions,
   getDefaultChatModelValue,
   isChatModelSelectionAvailable,
@@ -189,6 +190,46 @@ describe("getDefaultChatModelValue", () => {
       getDefaultChatModelValue({
         orgAIConfig: orgConfigForProviders([]),
         organizationId: null,
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("getChatModeModelValue", () => {
+  test("resolves configured fast and reasoning role models", () => {
+    const orgAIConfig = orgConfigForProviders(["anthropic"]);
+    orgAIConfig.overrideModels.fast = {
+      provider: "anthropic",
+      modelId: "claude-haiku-4-5-20251001",
+    };
+    orgAIConfig.overrideModels.reasoning = {
+      provider: "anthropic",
+      modelId: "claude-opus-4-7",
+    };
+
+    expect(
+      getChatModeModelValue({
+        orgAIConfig,
+        organizationId: null,
+        role: "fast",
+      }),
+    ).toBe("anthropic::claude-haiku-4-5-20251001");
+    expect(
+      getChatModeModelValue({
+        orgAIConfig,
+        organizationId: null,
+        role: "reasoning",
+      }),
+    ).toBe("anthropic::claude-opus-4-7");
+  });
+
+  test("omits a mode whose configured model is outside the chat catalog", () => {
+    const orgAIConfig = orgConfigForProviders(["anthropic"]);
+    expect(
+      getChatModeModelValue({
+        orgAIConfig,
+        organizationId: null,
+        role: "fast",
       }),
     ).toBeNull();
   });

--- a/apps/api/src/lib/chat-model-selection.ts
+++ b/apps/api/src/lib/chat-model-selection.ts
@@ -117,6 +117,31 @@ const configuredChatProviders = (
   return isBYOKProviderValue(activeProvider) ? [activeProvider] : [];
 };
 
+const hasResolvableModelForRole = ({
+  orgAIConfig,
+  role,
+}: {
+  orgAIConfig: OrgAIConfig | null;
+  role: ModelRole;
+}): boolean => {
+  if (!orgAIConfig) {
+    return hasTanStackInstanceProvider();
+  }
+
+  const selection = orgAIConfig.overrideModels[role];
+  return (
+    isBYOKProviderValue(selection.provider) &&
+    orgAIConfig.providers.some(
+      (providerConfig) => providerConfig.provider === selection.provider,
+    ) &&
+    isAllowedBYOKModelForRole({
+      provider: selection.provider,
+      modelId: selection.modelId,
+      role,
+    })
+  );
+};
+
 /**
  * Chat-role model options across every provider currently configured for
  * the org (or the single instance provider when no org BYOK config
@@ -129,8 +154,8 @@ export const getConfiguredChatModelOptions = (
 
 /**
  * The encoded selection a send would use absent a thread override, or
- * `null` when the chat role has no configured provider at all (BYOK
- * unset and no instance provider). Never throws.
+ * `null` when the chat role has no usable configured provider or model.
+ * Unexpected resolver failures propagate to the handler boundary.
  */
 export const getDefaultChatModelValue = ({
   orgAIConfig,
@@ -139,20 +164,17 @@ export const getDefaultChatModelValue = ({
   orgAIConfig: OrgAIConfig | null;
   organizationId: SafeId<"organization"> | null;
 }): string | null => {
-  try {
-    const info = getTanStackTextModelInfoForRole(CHAT_MODEL_ROLE, orgAIConfig, {
-      organizationId,
-    });
-    return encodeChatModelSelection({
-      provider: info.provider,
-      modelId: info.modelId,
-    });
-  } catch {
-    // Boundary: `getTanStackTextModelInfoForRole` throws when the chat
-    // role has no configured provider. Best-effort — same fallback
-    // pattern as `resolveChatCompactionBudget`.
+  if (!hasResolvableModelForRole({ orgAIConfig, role: CHAT_MODEL_ROLE })) {
     return null;
   }
+
+  const info = getTanStackTextModelInfoForRole(CHAT_MODEL_ROLE, orgAIConfig, {
+    organizationId,
+  });
+  return encodeChatModelSelection({
+    provider: info.provider,
+    modelId: info.modelId,
+  });
 };
 
 /**
@@ -169,21 +191,21 @@ export const getChatModeModelValue = ({
   organizationId: SafeId<"organization"> | null;
   role: Extract<ModelRole, "fast" | "reasoning">;
 }): string | null => {
-  try {
-    const info = getTanStackTextModelInfoForRole(role, orgAIConfig, {
-      organizationId,
-    });
-    if (!isBYOKProviderValue(info.provider)) {
-      return null;
-    }
-    const selection = { provider: info.provider, modelId: info.modelId };
-    if (!isChatModelSelectionAvailable({ ...selection, orgAIConfig })) {
-      return null;
-    }
-    return encodeChatModelSelection(selection);
-  } catch {
+  if (!hasResolvableModelForRole({ orgAIConfig, role })) {
     return null;
   }
+
+  const info = getTanStackTextModelInfoForRole(role, orgAIConfig, {
+    organizationId,
+  });
+  if (!isBYOKProviderValue(info.provider)) {
+    return null;
+  }
+  const selection = { provider: info.provider, modelId: info.modelId };
+  if (!isChatModelSelectionAvailable({ ...selection, orgAIConfig })) {
+    return null;
+  }
+  return encodeChatModelSelection(selection);
 };
 
 /**

--- a/apps/api/src/lib/chat-model-selection.ts
+++ b/apps/api/src/lib/chat-model-selection.ts
@@ -156,6 +156,37 @@ export const getDefaultChatModelValue = ({
 };
 
 /**
+ * The concrete configured model behind a friendly composer mode. These are
+ * still persisted as ordinary provider/model overrides, so old clients and
+ * the existing "all models" picker remain fully interoperable.
+ */
+export const getChatModeModelValue = ({
+  orgAIConfig,
+  organizationId,
+  role,
+}: {
+  orgAIConfig: OrgAIConfig | null;
+  organizationId: SafeId<"organization"> | null;
+  role: Extract<ModelRole, "fast" | "reasoning">;
+}): string | null => {
+  try {
+    const info = getTanStackTextModelInfoForRole(role, orgAIConfig, {
+      organizationId,
+    });
+    if (!isBYOKProviderValue(info.provider)) {
+      return null;
+    }
+    const selection = { provider: info.provider, modelId: info.modelId };
+    if (!isChatModelSelectionAvailable({ ...selection, orgAIConfig })) {
+      return null;
+    }
+    return encodeChatModelSelection(selection);
+  } catch {
+    return null;
+  }
+};
+
+/**
  * Resolves the effective chat model override for a turn: the dev
  * override (local-only, already validated by
  * `validateTanStackDevModelOverride`) always wins; otherwise a valid

--- a/apps/api/src/lib/search/index-entity.test.ts
+++ b/apps/api/src/lib/search/index-entity.test.ts
@@ -168,6 +168,11 @@ test("rejects an out-of-order projection against the authoritative entity", asyn
 
   const compiled = new PgDialect().sqlToQuery(query);
   expect(compiled.sql).toContain("FROM entities e");
+  expect(compiled.sql).toContain(
+    "INNER JOIN workspaces w ON w.id = e.workspace_id",
+  );
+  expect(compiled.sql).toContain("w.organization_id =");
+  expect(compiled.sql).not.toContain("e.organization_id");
   expect(compiled.sql).toContain("e.current_version_id =");
   expect(compiled.sql).toMatch(
     /COALESCE\(e\.updated_at, e\.created_at\)\s+IS NOT DISTINCT FROM/u,

--- a/apps/api/src/lib/search/index-entity.ts
+++ b/apps/api/src/lib/search/index-entity.ts
@@ -300,8 +300,9 @@ export const upsertSearchDocument = async (
           ))
         )
       FROM entities e
+      INNER JOIN workspaces w ON w.id = e.workspace_id
       WHERE e.id = ${doc.entityId}
-        AND e.organization_id = ${doc.organizationId}
+        AND w.organization_id = ${doc.organizationId}
         AND e.workspace_id = ${doc.workspaceId}
         AND e.current_version_id = ${doc.sourceVersionId}
         AND COALESCE(e.updated_at, e.created_at)

--- a/apps/web/src/components/ai-suggestions/file-chat-overlay.tsx
+++ b/apps/web/src/components/ai-suggestions/file-chat-overlay.tsx
@@ -2129,6 +2129,12 @@ const FileChatOverlayInner = ({
           dock={
             <ChatComposerDock
               data={data}
+              models={{
+                activeOrganizationId,
+                threadRef,
+                selectedModel: data.model,
+                selectModel: modelSelection.selectModel,
+              }}
               onNewThread={hasMessages ? startNewThread : null}
               leadingContext={
                 // The matter control is a real picker on every surface, so

--- a/apps/web/src/components/chat-input-surface.tsx
+++ b/apps/web/src/components/chat-input-surface.tsx
@@ -14,6 +14,8 @@ import type {
 } from "@/components/chat-editor-provider";
 import { ChatComposerActionButton } from "@/components/chat/chat-composer-action-button";
 import { ChatDraftAttachmentChips } from "@/components/chat/chat-draft-attachment-chips";
+import { ChatModelModeSelector } from "@/components/chat/chat-model-mode-selector";
+import { ChatPromptImproveButton } from "@/components/chat/chat-prompt-improve-button";
 import {
   ComposerPlusMenu,
   type ComposerContextMenuProps,
@@ -269,33 +271,42 @@ export const ChatInputSurface = ({
           )}
         </div>
         <div className="flex items-center justify-end gap-0.5 px-1.5 pb-1.5">
-          <ComposerPlusMenu
-            context={
-              context
-                ? {
-                    activeOrganizationId: context.activeOrganizationId,
-                    editor,
-                    threadRef: context.threadRef,
-                  }
-                : undefined
-            }
-            disabled={inputDisabled}
-            mcp={
-              mcpOrganizationId
-                ? { activeOrganizationId: mcpOrganizationId }
-                : undefined
-            }
-            models={models}
-            onOpenFilePicker={openFilePicker}
-            onProgrammaticMenuClose={focus}
-            ref={plusMenuRef}
-            skills={
-              skillsOrganizationId
-                ? { activeOrganizationId: skillsOrganizationId, editor }
-                : undefined
-            }
-            triggerClassName="me-auto"
-          />
+          <div className="me-auto flex min-w-0 items-center gap-0.5">
+            <ComposerPlusMenu
+              context={
+                context
+                  ? {
+                      activeOrganizationId: context.activeOrganizationId,
+                      editor,
+                      threadRef: context.threadRef,
+                    }
+                  : undefined
+              }
+              disabled={inputDisabled}
+              mcp={
+                mcpOrganizationId
+                  ? { activeOrganizationId: mcpOrganizationId }
+                  : undefined
+              }
+              models={models}
+              onOpenFilePicker={openFilePicker}
+              onProgrammaticMenuClose={focus}
+              ref={plusMenuRef}
+              skills={
+                skillsOrganizationId
+                  ? { activeOrganizationId: skillsOrganizationId, editor }
+                  : undefined
+              }
+            />
+            {models && (
+              <ChatModelModeSelector disabled={inputDisabled} models={models} />
+            )}
+            <ChatPromptImproveButton
+              anonymized={anonymized}
+              controller={controller}
+              disabled={inputDisabled || isBlank}
+            />
+          </div>
           <input
             accept={fileInputAccept}
             className="hidden"

--- a/apps/web/src/components/chat-input-surface.tsx
+++ b/apps/web/src/components/chat-input-surface.tsx
@@ -307,11 +307,13 @@ export const ChatInputSurface = ({
             ref={fileInputRef}
             type="file"
           />
-          <ChatPromptImproveButton
-            anonymized={anonymized}
-            controller={controller}
-            disabled={inputDisabled || isBlank}
-          />
+          <span className="me-0.5 inline-flex">
+            <ChatPromptImproveButton
+              anonymized={anonymized}
+              controller={controller}
+              disabled={inputDisabled || isBlank}
+            />
+          </span>
           {/* The single primary affordance morphs in place: the button
               itself resolves send vs. stop from the state it is fed, so
               this surface cannot render a second, parallel control. */}

--- a/apps/web/src/components/chat-input-surface.tsx
+++ b/apps/web/src/components/chat-input-surface.tsx
@@ -14,7 +14,6 @@ import type {
 } from "@/components/chat-editor-provider";
 import { ChatComposerActionButton } from "@/components/chat/chat-composer-action-button";
 import { ChatDraftAttachmentChips } from "@/components/chat/chat-draft-attachment-chips";
-import { ChatModelModeSelector } from "@/components/chat/chat-model-mode-selector";
 import { ChatPromptImproveButton } from "@/components/chat/chat-prompt-improve-button";
 import {
   ComposerPlusMenu,
@@ -313,9 +312,6 @@ export const ChatInputSurface = ({
             controller={controller}
             disabled={inputDisabled || isBlank}
           />
-          {models && (
-            <ChatModelModeSelector disabled={inputDisabled} models={models} />
-          )}
           {/* The single primary affordance morphs in place: the button
               itself resolves send vs. stop from the state it is fed, so
               this surface cannot render a second, parallel control. */}

--- a/apps/web/src/components/chat-input-surface.tsx
+++ b/apps/web/src/components/chat-input-surface.tsx
@@ -298,14 +298,6 @@ export const ChatInputSurface = ({
                   : undefined
               }
             />
-            {models && (
-              <ChatModelModeSelector disabled={inputDisabled} models={models} />
-            )}
-            <ChatPromptImproveButton
-              anonymized={anonymized}
-              controller={controller}
-              disabled={inputDisabled || isBlank}
-            />
           </div>
           <input
             accept={fileInputAccept}
@@ -316,6 +308,14 @@ export const ChatInputSurface = ({
             ref={fileInputRef}
             type="file"
           />
+          <ChatPromptImproveButton
+            anonymized={anonymized}
+            controller={controller}
+            disabled={inputDisabled || isBlank}
+          />
+          {models && (
+            <ChatModelModeSelector disabled={inputDisabled} models={models} />
+          )}
           {/* The single primary affordance morphs in place: the button
               itself resolves send vs. stop from the state it is fed, so
               this surface cannot render a second, parallel control. */}

--- a/apps/web/src/components/chat/chat-composer-dock.tsx
+++ b/apps/web/src/components/chat/chat-composer-dock.tsx
@@ -8,6 +8,8 @@ import { Button } from "@stll/ui/components/button";
 import type { ChatComposerDockData } from "@/components/chat/chat-composer-dock-controls";
 import { resolveChatComposerDockControls } from "@/components/chat/chat-composer-dock-controls";
 import { ChatContextMeter } from "@/components/chat/chat-context-meter";
+import { ChatModelModeSelector } from "@/components/chat/chat-model-mode-selector";
+import type { ComposerModelsMenuProps } from "@/components/chat/composer-plus-menu";
 import { ComposerStatusRow } from "@/components/chat/composer-status-row";
 import Tooltip from "@/components/tooltip";
 import { ChatAnonymizedToggle } from "@/features/chat/components/chat-anonymized-toggle";
@@ -46,6 +48,8 @@ type ChatComposerDockProps = {
    * controls so callers never reopen a free-form status row.
    */
   endExtras?: ReactNode | undefined;
+  /** Model picker rendered beside the context percentage. */
+  models?: ComposerModelsMenuProps | undefined;
   /** Row positioning override, forwarded to `ComposerStatusRow`. */
   className?: string | undefined;
 };
@@ -53,7 +57,7 @@ type ChatComposerDockProps = {
 // The one organism that assembles a chat surface's status row. It
 // derives the standard controls from the thread session itself and
 // renders them through `ComposerStatusRow` in the canonical order
-// (context -> globe -> shield -> extras -> new chat -> meter), so every
+// (context -> globe -> shield -> extras -> new chat -> model -> meter), so every
 // surface gets the full set by construction and cannot omit one.
 //
 // Anonymize source: the shield reads and writes the shared per-thread
@@ -67,6 +71,7 @@ export const ChatComposerDock = ({
   onNewThread,
   leadingContext,
   endExtras,
+  models,
   className,
 }: ChatComposerDockProps) => {
   const t = useTranslations();
@@ -95,6 +100,7 @@ export const ChatComposerDock = ({
               }
             />
           )}
+          {models && <ChatModelModeSelector models={models} />}
           {/* The meter renders on every surface: it shows an empty 0% ring
               for a brand-new thread (context null) and fills in once an
               estimate lands. */}

--- a/apps/web/src/components/chat/chat-model-mode-selector.tsx
+++ b/apps/web/src/components/chat/chat-model-mode-selector.tsx
@@ -12,6 +12,7 @@ import {
 import type { LucideIcon } from "lucide-react";
 import { useTranslations } from "use-intl";
 
+import { Button } from "@stll/ui/components/button";
 import {
   Menu,
   MenuItem,
@@ -95,20 +96,6 @@ export const ChatModelModeSelector = ({
   if (selectedMode) {
     triggerLabel = t(MODE_LABEL_KEY[selectedMode]);
   }
-  const pinnedOption = resolveFavoriteOption({
-    favorite,
-    modeOptions: options,
-    modelOptions: data?.options,
-  });
-  let pinnedLabel: string | null = null;
-  if (pinnedOption?.type === "model") {
-    pinnedLabel = pinnedOption.label;
-  }
-  if (pinnedOption?.type === "mode") {
-    pinnedLabel = t(MODE_LABEL_KEY[pinnedOption.mode]);
-  }
-  const PinnedIcon = pinnedOption?.Icon;
-
   const toggleFavorite = (nextFavorite: ChatModelFavorite) => {
     setFavorite(
       models.activeOrganizationId,
@@ -126,26 +113,20 @@ export const ChatModelModeSelector = ({
   return (
     <Menu onOpenChange={setOpen} open={open}>
       <MenuTrigger
-        aria-label={t("chat.modelMode.select")}
-        className="text-foreground/80 hover:text-foreground hover:bg-accent relative inline-flex size-7 shrink-0 items-center justify-center rounded-md transition-colors before:absolute before:-inset-2"
-        disabled={disabled}
-        tooltip={triggerLabel}
+        render={
+          <Button
+            aria-label={t("chat.modelMode.select")}
+            className="text-muted-foreground hover:text-foreground"
+            disabled={disabled}
+            size="icon-xs"
+            tooltip={triggerLabel}
+            variant="ghost"
+          />
+        }
       >
-        <TriggerIcon aria-hidden="true" className="size-4" />
+        <TriggerIcon aria-hidden="true" className="size-3.5" />
       </MenuTrigger>
       <MenuPopup align="start" className="w-72" side="top" sideOffset={6}>
-        {pinnedOption && pinnedLabel && PinnedIcon && (
-          <>
-            <p className="text-muted-foreground px-2 py-1.5 text-xs font-medium">
-              {t("navigation.pinned")}
-            </p>
-            <MenuItem onClick={() => selectValue(pinnedOption.value)}>
-              <PinnedIcon />
-              <span className="min-w-0 truncate">{pinnedLabel}</span>
-            </MenuItem>
-            <MenuSeparator />
-          </>
-        )}
         <MenuRadioGroup value={models.selectedModel ?? ""}>
           {options.map((option) => {
             const Icon = MODE_ICON[option.mode];
@@ -308,46 +289,6 @@ const resolveSelectedMode = ({
     return CHAT_MODEL_MODE.standard;
   }
   return options.find((option) => option.value === selectedModel)?.mode ?? null;
-};
-
-type FavoriteOption =
-  | { type: "mode"; Icon: LucideIcon; mode: ChatModelMode; value: string }
-  | { type: "model"; Icon: LucideIcon; label: string; value: string };
-
-const resolveFavoriteOption = ({
-  favorite,
-  modeOptions,
-  modelOptions,
-}: {
-  favorite: ChatModelFavorite | undefined;
-  modeOptions: ModelModeOption[];
-  modelOptions: ModelOption[] | undefined;
-}): FavoriteOption | null => {
-  if (!favorite) {
-    return null;
-  }
-  if (favorite.type === "mode") {
-    const option = modeOptions.find(({ mode }) => mode === favorite.mode);
-    if (!option) {
-      return null;
-    }
-    return {
-      type: "mode",
-      Icon: MODE_ICON[favorite.mode],
-      mode: favorite.mode,
-      value: option.value,
-    };
-  }
-  const option = modelOptions?.find(({ value }) => value === favorite.value);
-  if (!option) {
-    return null;
-  }
-  return {
-    type: "model",
-    Icon: CpuIcon,
-    label: formatModelLabel(option),
-    value: option.value,
-  };
 };
 
 const isSameFavorite = (

--- a/apps/web/src/components/chat/chat-model-mode-selector.tsx
+++ b/apps/web/src/components/chat/chat-model-mode-selector.tsx
@@ -14,6 +14,7 @@ import { useTranslations } from "use-intl";
 
 import {
   Menu,
+  MenuGroup,
   MenuGroupLabel,
   MenuItem,
   MenuPopup,
@@ -137,11 +138,13 @@ export const ChatModelModeSelector = ({
       <MenuPopup align="start" className="w-72" side="top" sideOffset={6}>
         {pinnedOption && pinnedLabel && PinnedIcon && (
           <>
-            <MenuGroupLabel>{t("navigation.pinned")}</MenuGroupLabel>
-            <MenuItem onClick={() => selectValue(pinnedOption.value)}>
-              <PinnedIcon />
-              <span className="min-w-0 truncate">{pinnedLabel}</span>
-            </MenuItem>
+            <MenuGroup>
+              <MenuGroupLabel>{t("navigation.pinned")}</MenuGroupLabel>
+              <MenuItem onClick={() => selectValue(pinnedOption.value)}>
+                <PinnedIcon />
+                <span className="min-w-0 truncate">{pinnedLabel}</span>
+              </MenuItem>
+            </MenuGroup>
             <MenuSeparator />
           </>
         )}

--- a/apps/web/src/components/chat/chat-model-mode-selector.tsx
+++ b/apps/web/src/components/chat/chat-model-mode-selector.tsx
@@ -3,32 +3,39 @@ import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import {
   BrainCircuitIcon,
-  ChevronDownIcon,
+  CpuIcon,
   GaugeIcon,
   MessageCircleIcon,
+  PinIcon,
+  PinOffIcon,
 } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import { useTranslations } from "use-intl";
 
 import {
   Menu,
+  MenuGroupLabel,
+  MenuItem,
   MenuPopup,
   MenuRadioGroup,
   MenuRadioItem,
+  MenuSeparator,
+  MenuSub,
+  MenuSubPopup,
+  MenuSubTrigger,
   MenuTrigger,
 } from "@stll/ui/components/menu";
 
+import { PROVIDER_LABELS } from "@/components/ai-config-role-models.logic";
 import type { ComposerModelsMenuProps } from "@/components/chat/composer-plus-menu";
 import { modelOptionsOptions } from "@/features/chat/queries";
 import type { TranslationKey } from "@/i18n/types";
-
-const CHAT_MODEL_MODE = {
-  standard: "standard",
-  deepThinking: "deepThinking",
-  fast: "fast",
-} as const;
-
-type ChatModelMode = (typeof CHAT_MODEL_MODE)[keyof typeof CHAT_MODEL_MODE];
+import {
+  CHAT_MODEL_MODE,
+  type ChatModelFavorite,
+  type ChatModelMode,
+  useChatModelFavoriteStore,
+} from "@/lib/chat-model-favorite-store";
 
 const MODE_LABEL_KEY = {
   [CHAT_MODEL_MODE.standard]: "chat.modelMode.standard",
@@ -54,10 +61,9 @@ type ChatModelModeSelectorProps = {
 };
 
 /**
- * Friendly, always-visible counterpart to the technical model list in (+).
- * Each mode resolves to the organization's configured role model; provider
- * names stay out of the primary chat UX while power users retain the full
- * picker one level away.
+ * Compact access to friendly modes and exact models. Modes resolve to the
+ * organization's configured role model; pinned modes therefore follow later
+ * configuration changes, while pinned exact models retain their identity.
  */
 export const ChatModelModeSelector = ({
   disabled,
@@ -67,66 +73,194 @@ export const ChatModelModeSelector = ({
   const [open, setOpen] = useState(false);
   const { data } = useQuery({
     ...modelOptionsOptions(models.activeOrganizationId),
-    enabled: open,
+    enabled: open || models.selectedModel !== null,
   });
+  const favorite = useChatModelFavoriteStore(
+    (state) => state.favoritesByOrganization[models.activeOrganizationId],
+  );
+  const setFavorite = useChatModelFavoriteStore((state) => state.setFavorite);
 
   const options = resolveModeOptions(data?.modeValues);
   const selectedMode = resolveSelectedMode({
     options,
     selectedModel: models.selectedModel,
   });
-  const TriggerIcon = selectedMode
-    ? MODE_ICON[selectedMode]
-    : MessageCircleIcon;
+  const selectedExactModel = data?.options.find(
+    (option) => option.value === models.selectedModel,
+  );
+  const TriggerIcon = selectedMode ? MODE_ICON[selectedMode] : CpuIcon;
   const triggerLabel = selectedMode
     ? t(MODE_LABEL_KEY[selectedMode])
-    : t("organization.matterNumber.presets.custom");
+    : selectedExactModel
+      ? formatModelLabel(selectedExactModel)
+      : (models.selectedModel ?? t("chat.modelMode.exactModels"));
+  const pinnedOption = resolveFavoriteOption({
+    favorite,
+    modeOptions: options,
+    modelOptions: data?.options,
+  });
+  const pinnedLabel = pinnedOption
+    ? pinnedOption.type === "mode"
+      ? t(MODE_LABEL_KEY[pinnedOption.mode])
+      : pinnedOption.label
+    : null;
+  const PinnedIcon = pinnedOption?.Icon;
+
+  const toggleFavorite = (nextFavorite: ChatModelFavorite) => {
+    setFavorite(
+      models.activeOrganizationId,
+      isSameFavorite(favorite, nextFavorite) ? null : nextFavorite,
+    );
+  };
+
+  const selectValue = (value: string) => {
+    const nextModel = value || null;
+    if (nextModel !== models.selectedModel) {
+      models.selectModel(nextModel);
+    }
+  };
 
   return (
     <Menu onOpenChange={setOpen} open={open}>
       <MenuTrigger
         aria-label={t("chat.modelMode.select")}
-        className="text-muted-foreground hover:text-foreground hover:bg-accent inline-flex max-w-40 items-center gap-1 rounded-md px-1.5 py-1 text-[11px] transition-colors"
+        className="text-muted-foreground hover:text-foreground hover:bg-accent relative inline-flex size-7 shrink-0 items-center justify-center rounded-md transition-colors before:absolute before:-inset-2"
         disabled={disabled}
-        title={triggerLabel}
+        tooltip={triggerLabel}
       >
-        <TriggerIcon aria-hidden="true" className="size-3 shrink-0" />
-        <span className="truncate">{triggerLabel}</span>
-        <ChevronDownIcon
-          aria-hidden="true"
-          className="size-3 shrink-0 opacity-70"
-        />
+        <TriggerIcon aria-hidden="true" className="size-3.5" />
       </MenuTrigger>
       <MenuPopup align="start" className="w-72" side="top" sideOffset={6}>
+        {pinnedOption && pinnedLabel && PinnedIcon && (
+          <>
+            <MenuGroupLabel>{t("navigation.pinned")}</MenuGroupLabel>
+            <MenuItem onClick={() => selectValue(pinnedOption.value)}>
+              <PinnedIcon />
+              <span className="min-w-0 truncate">{pinnedLabel}</span>
+            </MenuItem>
+            <MenuSeparator />
+          </>
+        )}
         <MenuRadioGroup value={models.selectedModel ?? ""}>
           {options.map((option) => {
             const Icon = MODE_ICON[option.mode];
+            const label = t(MODE_LABEL_KEY[option.mode]);
+            const optionFavorite = {
+              type: "mode",
+              mode: option.mode,
+            } as const satisfies ChatModelFavorite;
+            const pinned = isSameFavorite(favorite, optionFavorite);
             return (
-              <MenuRadioItem
+              <div
+                className="grid grid-cols-[minmax(0,1fr)_auto]"
                 key={option.mode}
-                onClick={() => {
-                  const nextModel = option.value || null;
-                  if (nextModel !== models.selectedModel) {
-                    models.selectModel(nextModel);
-                  }
-                }}
-                value={option.value}
               >
-                <span className="flex min-w-0 items-start gap-2 py-0.5">
-                  <Icon className="mt-0.5 size-3.5 shrink-0" />
-                  <span className="flex min-w-0 flex-col">
-                    <span>{t(MODE_LABEL_KEY[option.mode])}</span>
-                    <span className="text-muted-foreground text-[11px] text-wrap">
-                      {t(MODE_DESCRIPTION_KEY[option.mode])}
+                <MenuRadioItem
+                  className="pe-2"
+                  onClick={() => selectValue(option.value)}
+                  value={option.value}
+                >
+                  <span className="flex min-w-0 items-start gap-2 py-0.5">
+                    <Icon className="mt-0.5 size-3.5 shrink-0" />
+                    <span className="flex min-w-0 flex-col">
+                      <span>{label}</span>
+                      <span className="text-muted-foreground text-[11px] text-wrap">
+                        {t(MODE_DESCRIPTION_KEY[option.mode])}
+                      </span>
                     </span>
                   </span>
-                </span>
-              </MenuRadioItem>
+                </MenuRadioItem>
+                <FavoriteMenuItem
+                  label={label}
+                  onClick={() => toggleFavorite(optionFavorite)}
+                  pinned={pinned}
+                />
+              </div>
             );
           })}
         </MenuRadioGroup>
+        <MenuSeparator />
+        <MenuSub>
+          <MenuSubTrigger>
+            <CpuIcon />
+            {t("chat.modelMode.exactModels")}
+          </MenuSubTrigger>
+          <MenuSubPopup className="w-[min(32rem,calc(100vw-2rem))] max-w-(--available-width)">
+            {data ? (
+              <MenuRadioGroup value={models.selectedModel ?? ""}>
+                {data.options.map((option) => {
+                  const label = formatModelLabel(option);
+                  const optionFavorite = {
+                    type: "model",
+                    value: option.value,
+                  } as const satisfies ChatModelFavorite;
+                  const pinned = isSameFavorite(favorite, optionFavorite);
+                  return (
+                    <div
+                      className="grid grid-cols-[minmax(0,1fr)_auto]"
+                      key={option.value}
+                    >
+                      <MenuRadioItem
+                        className="grid-cols-[1rem_minmax(0,1fr)] pe-2"
+                        onClick={() => selectValue(option.value)}
+                        value={option.value}
+                      >
+                        <span className="block [overflow-wrap:anywhere] whitespace-normal">
+                          <bdi>{label}</bdi>
+                        </span>
+                      </MenuRadioItem>
+                      <FavoriteMenuItem
+                        label={label}
+                        onClick={() => toggleFavorite(optionFavorite)}
+                        pinned={pinned}
+                      />
+                    </div>
+                  );
+                })}
+              </MenuRadioGroup>
+            ) : (
+              <MenuItem disabled>{t("common.loading")}</MenuItem>
+            )}
+          </MenuSubPopup>
+        </MenuSub>
       </MenuPopup>
     </Menu>
+  );
+};
+
+const PROVIDER_LABEL_FALLBACKS: Readonly<Partial<Record<string, string>>> =
+  PROVIDER_LABELS;
+
+type ModelOption = {
+  modelId: string;
+  provider: string;
+  value: string;
+};
+
+const formatModelLabel = (option: ModelOption): string =>
+  `${PROVIDER_LABEL_FALLBACKS[option.provider] ?? option.provider} · ${option.modelId}`;
+
+const FavoriteMenuItem = ({
+  label,
+  onClick,
+  pinned,
+}: {
+  label: string;
+  onClick: () => void;
+  pinned: boolean;
+}) => {
+  const t = useTranslations();
+  const action = t(pinned ? "common.unpin" : "common.pin");
+  const Icon = pinned ? PinOffIcon : PinIcon;
+  return (
+    <MenuItem
+      aria-label={`${action}: ${label}`}
+      className="justify-center px-2"
+      onClick={onClick}
+      title={`${action}: ${label}`}
+    >
+      <Icon />
+    </MenuItem>
   );
 };
 
@@ -169,4 +303,62 @@ const resolveSelectedMode = ({
     return CHAT_MODEL_MODE.standard;
   }
   return options.find((option) => option.value === selectedModel)?.mode ?? null;
+};
+
+type FavoriteOption =
+  | { type: "mode"; Icon: LucideIcon; mode: ChatModelMode; value: string }
+  | { type: "model"; Icon: LucideIcon; label: string; value: string };
+
+const resolveFavoriteOption = ({
+  favorite,
+  modeOptions,
+  modelOptions,
+}: {
+  favorite: ChatModelFavorite | undefined;
+  modeOptions: ModelModeOption[];
+  modelOptions: ModelOption[] | undefined;
+}): FavoriteOption | null => {
+  if (!favorite) {
+    return null;
+  }
+  if (favorite.type === "mode") {
+    const option = modeOptions.find(({ mode }) => mode === favorite.mode);
+    if (!option) {
+      return null;
+    }
+    return {
+      type: "mode",
+      Icon: MODE_ICON[favorite.mode],
+      mode: favorite.mode,
+      value: option.value,
+    };
+  }
+  const option = modelOptions?.find(({ value }) => value === favorite.value);
+  if (!option) {
+    return null;
+  }
+  return {
+    type: "model",
+    Icon: CpuIcon,
+    label: formatModelLabel(option),
+    value: option.value,
+  };
+};
+
+const isSameFavorite = (
+  current: ChatModelFavorite | undefined,
+  candidate: ChatModelFavorite,
+): boolean => {
+  if (!current || current.type !== candidate.type) {
+    return false;
+  }
+  switch (candidate.type) {
+    case "mode":
+      return current.type === "mode" && current.mode === candidate.mode;
+    case "model":
+      return current.type === "model" && current.value === candidate.value;
+    default:
+      candidate satisfies never;
+      return false;
+  }
 };

--- a/apps/web/src/components/chat/chat-model-mode-selector.tsx
+++ b/apps/web/src/components/chat/chat-model-mode-selector.tsx
@@ -1,0 +1,172 @@
+import { useState } from "react";
+
+import { useQuery } from "@tanstack/react-query";
+import {
+  BrainCircuitIcon,
+  ChevronDownIcon,
+  GaugeIcon,
+  MessageCircleIcon,
+} from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+import { useTranslations } from "use-intl";
+
+import {
+  Menu,
+  MenuPopup,
+  MenuRadioGroup,
+  MenuRadioItem,
+  MenuTrigger,
+} from "@stll/ui/components/menu";
+
+import type { ComposerModelsMenuProps } from "@/components/chat/composer-plus-menu";
+import { modelOptionsOptions } from "@/features/chat/queries";
+import type { TranslationKey } from "@/i18n/types";
+
+const CHAT_MODEL_MODE = {
+  standard: "standard",
+  deepThinking: "deepThinking",
+  fast: "fast",
+} as const;
+
+type ChatModelMode = (typeof CHAT_MODEL_MODE)[keyof typeof CHAT_MODEL_MODE];
+
+const MODE_LABEL_KEY = {
+  [CHAT_MODEL_MODE.standard]: "chat.modelMode.standard",
+  [CHAT_MODEL_MODE.deepThinking]: "chat.modelMode.deepThinking",
+  [CHAT_MODEL_MODE.fast]: "organization.aiConfig.roles.fast",
+} as const satisfies Record<ChatModelMode, TranslationKey>;
+
+const MODE_DESCRIPTION_KEY = {
+  [CHAT_MODEL_MODE.standard]: "chat.modelMode.standardDescription",
+  [CHAT_MODEL_MODE.deepThinking]: "chat.modelMode.deepThinkingDescription",
+  [CHAT_MODEL_MODE.fast]: "chat.modelMode.fastDescription",
+} as const satisfies Record<ChatModelMode, TranslationKey>;
+
+const MODE_ICON = {
+  [CHAT_MODEL_MODE.standard]: MessageCircleIcon,
+  [CHAT_MODEL_MODE.deepThinking]: BrainCircuitIcon,
+  [CHAT_MODEL_MODE.fast]: GaugeIcon,
+} as const satisfies Record<ChatModelMode, LucideIcon>;
+
+type ChatModelModeSelectorProps = {
+  disabled: boolean;
+  models: ComposerModelsMenuProps;
+};
+
+/**
+ * Friendly, always-visible counterpart to the technical model list in (+).
+ * Each mode resolves to the organization's configured role model; provider
+ * names stay out of the primary chat UX while power users retain the full
+ * picker one level away.
+ */
+export const ChatModelModeSelector = ({
+  disabled,
+  models,
+}: ChatModelModeSelectorProps) => {
+  const t = useTranslations();
+  const [open, setOpen] = useState(false);
+  const { data } = useQuery({
+    ...modelOptionsOptions(models.activeOrganizationId),
+    enabled: open,
+  });
+
+  const options = resolveModeOptions(data?.modeValues);
+  const selectedMode = resolveSelectedMode({
+    options,
+    selectedModel: models.selectedModel,
+  });
+  const TriggerIcon = selectedMode
+    ? MODE_ICON[selectedMode]
+    : MessageCircleIcon;
+  const triggerLabel = selectedMode
+    ? t(MODE_LABEL_KEY[selectedMode])
+    : t("organization.matterNumber.presets.custom");
+
+  return (
+    <Menu onOpenChange={setOpen} open={open}>
+      <MenuTrigger
+        aria-label={t("chat.modelMode.select")}
+        className="text-muted-foreground hover:text-foreground hover:bg-accent inline-flex max-w-40 items-center gap-1 rounded-md px-1.5 py-1 text-[11px] transition-colors"
+        disabled={disabled}
+        title={triggerLabel}
+      >
+        <TriggerIcon aria-hidden="true" className="size-3 shrink-0" />
+        <span className="truncate">{triggerLabel}</span>
+        <ChevronDownIcon
+          aria-hidden="true"
+          className="size-3 shrink-0 opacity-70"
+        />
+      </MenuTrigger>
+      <MenuPopup align="start" className="w-72" side="top" sideOffset={6}>
+        <MenuRadioGroup value={models.selectedModel ?? ""}>
+          {options.map((option) => {
+            const Icon = MODE_ICON[option.mode];
+            return (
+              <MenuRadioItem
+                key={option.mode}
+                onClick={() => {
+                  const nextModel = option.value || null;
+                  if (nextModel !== models.selectedModel) {
+                    models.selectModel(nextModel);
+                  }
+                }}
+                value={option.value}
+              >
+                <span className="flex min-w-0 items-start gap-2 py-0.5">
+                  <Icon className="mt-0.5 size-3.5 shrink-0" />
+                  <span className="flex min-w-0 flex-col">
+                    <span>{t(MODE_LABEL_KEY[option.mode])}</span>
+                    <span className="text-muted-foreground text-[11px] text-wrap">
+                      {t(MODE_DESCRIPTION_KEY[option.mode])}
+                    </span>
+                  </span>
+                </span>
+              </MenuRadioItem>
+            );
+          })}
+        </MenuRadioGroup>
+      </MenuPopup>
+    </Menu>
+  );
+};
+
+type ModeValues = {
+  deepThinking: string | null;
+  fast: string | null;
+};
+
+type ModelModeOption = {
+  mode: ChatModelMode;
+  value: string;
+};
+
+const resolveModeOptions = (
+  modeValues: ModeValues | undefined,
+): ModelModeOption[] => {
+  const options: ModelModeOption[] = [
+    { mode: CHAT_MODEL_MODE.standard, value: "" },
+  ];
+  if (modeValues?.deepThinking) {
+    options.push({
+      mode: CHAT_MODEL_MODE.deepThinking,
+      value: modeValues.deepThinking,
+    });
+  }
+  if (modeValues?.fast && modeValues.fast !== modeValues.deepThinking) {
+    options.push({ mode: CHAT_MODEL_MODE.fast, value: modeValues.fast });
+  }
+  return options;
+};
+
+const resolveSelectedMode = ({
+  options,
+  selectedModel,
+}: {
+  options: ModelModeOption[];
+  selectedModel: string | null;
+}): ChatModelMode | null => {
+  if (selectedModel === null) {
+    return CHAT_MODEL_MODE.standard;
+  }
+  return options.find((option) => option.value === selectedModel)?.mode ?? null;
+};

--- a/apps/web/src/components/chat/chat-model-mode-selector.tsx
+++ b/apps/web/src/components/chat/chat-model-mode-selector.tsx
@@ -146,7 +146,11 @@ export const ChatModelModeSelector = ({
         render={
           <Button
             aria-label={t("chat.modelMode.select")}
-            className="text-muted-foreground hover:text-foreground"
+            className={
+              selectedChoice.type === "model"
+                ? "bg-accent text-accent-foreground hover:text-accent-foreground"
+                : "text-muted-foreground hover:text-foreground"
+            }
             disabled={disabled}
             onFocus={() => setDetailsRequested(true)}
             onMouseEnter={() => setDetailsRequested(true)}

--- a/apps/web/src/components/chat/chat-model-mode-selector.tsx
+++ b/apps/web/src/components/chat/chat-model-mode-selector.tsx
@@ -71,9 +71,10 @@ export const ChatModelModeSelector = ({
 }: ChatModelModeSelectorProps) => {
   const t = useTranslations();
   const [open, setOpen] = useState(false);
+  const [detailsRequested, setDetailsRequested] = useState(false);
   const { data } = useQuery({
     ...modelOptionsOptions(models.activeOrganizationId),
-    enabled: open || models.selectedModel !== null,
+    enabled: open || detailsRequested || models.selectedModel !== null,
   });
   const favorite = useChatModelFavoriteStore(
     (state) => state.favoritesByOrganization[models.activeOrganizationId],
@@ -85,17 +86,19 @@ export const ChatModelModeSelector = ({
     options,
     selectedModel: models.selectedModel,
   });
-  const selectedExactModel = data?.options.find(
-    (option) => option.value === models.selectedModel,
+  const effectiveModelValue =
+    selectedMode === CHAT_MODEL_MODE.standard
+      ? data?.defaultValue
+      : models.selectedModel;
+  const effectiveModel = data?.options.find(
+    (option) => option.value === effectiveModelValue,
   );
   const TriggerIcon = selectedMode ? MODE_ICON[selectedMode] : CpuIcon;
-  let triggerLabel = models.selectedModel ?? t("chat.modelMode.exactModels");
-  if (selectedExactModel) {
-    triggerLabel = formatModelLabel(selectedExactModel);
-  }
-  if (selectedMode) {
-    triggerLabel = t(MODE_LABEL_KEY[selectedMode]);
-  }
+  const triggerLabel = effectiveModel
+    ? formatModelLabel(effectiveModel)
+    : selectedMode
+      ? t(MODE_LABEL_KEY[selectedMode])
+      : (models.selectedModel ?? t("chat.modelMode.exactModels"));
   const toggleFavorite = (nextFavorite: ChatModelFavorite) => {
     setFavorite(
       models.activeOrganizationId,
@@ -118,11 +121,13 @@ export const ChatModelModeSelector = ({
             aria-label={t("chat.modelMode.select")}
             className="text-muted-foreground hover:text-foreground"
             disabled={disabled}
+            onFocus={() => setDetailsRequested(true)}
+            onMouseEnter={() => setDetailsRequested(true)}
             size="icon-xs"
-            tooltip={triggerLabel}
             variant="ghost"
           />
         }
+        tooltip={triggerLabel}
       >
         <TriggerIcon aria-hidden="true" className="size-3.5" />
       </MenuTrigger>
@@ -138,11 +143,11 @@ export const ChatModelModeSelector = ({
             const pinned = isSameFavorite(favorite, optionFavorite);
             return (
               <div
-                className="grid grid-cols-[minmax(0,1fr)_auto]"
+                className="hover:bg-accent has-[[data-highlighted]]:bg-accent has-[[data-highlighted]]:text-accent-foreground grid grid-cols-[minmax(0,1fr)_auto] rounded-sm"
                 key={option.mode}
               >
                 <MenuRadioItem
-                  className="pe-2"
+                  className="data-highlighted:bg-transparent pe-2"
                   onClick={() => selectValue(option.value)}
                   value={option.value}
                 >
@@ -183,11 +188,11 @@ export const ChatModelModeSelector = ({
                   const pinned = isSameFavorite(favorite, optionFavorite);
                   return (
                     <div
-                      className="grid grid-cols-[minmax(0,1fr)_auto]"
+                      className="hover:bg-accent has-[[data-highlighted]]:bg-accent has-[[data-highlighted]]:text-accent-foreground grid grid-cols-[minmax(0,1fr)_auto] rounded-sm"
                       key={option.value}
                     >
                       <MenuRadioItem
-                        className="grid-cols-[1rem_minmax(0,1fr)] pe-2"
+                        className="data-highlighted:bg-transparent grid-cols-[1rem_minmax(0,1fr)] pe-2"
                         onClick={() => selectValue(option.value)}
                         value={option.value}
                       >
@@ -241,7 +246,7 @@ const FavoriteMenuItem = ({
   return (
     <MenuItem
       aria-label={`${action}: ${label}`}
-      className="justify-center px-2"
+      className="data-highlighted:bg-transparent justify-center px-2"
       onClick={onClick}
       title={`${action}: ${label}`}
     >

--- a/apps/web/src/components/chat/chat-model-mode-selector.tsx
+++ b/apps/web/src/components/chat/chat-model-mode-selector.tsx
@@ -127,11 +127,11 @@ export const ChatModelModeSelector = ({
     <Menu onOpenChange={setOpen} open={open}>
       <MenuTrigger
         aria-label={t("chat.modelMode.select")}
-        className="text-muted-foreground hover:text-foreground hover:bg-accent relative inline-flex size-7 shrink-0 items-center justify-center rounded-md transition-colors before:absolute before:-inset-2"
+        className="text-foreground/80 hover:text-foreground hover:bg-accent relative inline-flex size-7 shrink-0 items-center justify-center rounded-md transition-colors before:absolute before:-inset-2"
         disabled={disabled}
         tooltip={triggerLabel}
       >
-        <TriggerIcon aria-hidden="true" className="size-3.5" />
+        <TriggerIcon aria-hidden="true" className="size-4" />
       </MenuTrigger>
       <MenuPopup align="start" className="w-72" side="top" sideOffset={6}>
         {pinnedOption && pinnedLabel && PinnedIcon && (

--- a/apps/web/src/components/chat/chat-model-mode-selector.tsx
+++ b/apps/web/src/components/chat/chat-model-mode-selector.tsx
@@ -2,12 +2,12 @@ import { useRef, useState } from "react";
 
 import { useQuery } from "@tanstack/react-query";
 import {
+  BlendIcon,
   BrainCircuitIcon,
   CpuIcon,
   GaugeIcon,
   PinIcon,
   PinOffIcon,
-  ScaleIcon,
 } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import { useTranslations } from "use-intl";
@@ -51,7 +51,7 @@ const MODE_DESCRIPTION_KEY = {
 } as const satisfies Record<ChatModelMode, TranslationKey>;
 
 const MODE_ICON = {
-  [CHAT_MODEL_MODE.standard]: ScaleIcon,
+  [CHAT_MODEL_MODE.standard]: BlendIcon,
   [CHAT_MODEL_MODE.deepThinking]: BrainCircuitIcon,
   [CHAT_MODEL_MODE.fast]: GaugeIcon,
 } as const satisfies Record<ChatModelMode, LucideIcon>;

--- a/apps/web/src/components/chat/chat-model-mode-selector.tsx
+++ b/apps/web/src/components/chat/chat-model-mode-selector.tsx
@@ -14,8 +14,6 @@ import { useTranslations } from "use-intl";
 
 import {
   Menu,
-  MenuGroup,
-  MenuGroupLabel,
   MenuItem,
   MenuPopup,
   MenuRadioGroup,
@@ -138,13 +136,13 @@ export const ChatModelModeSelector = ({
       <MenuPopup align="start" className="w-72" side="top" sideOffset={6}>
         {pinnedOption && pinnedLabel && PinnedIcon && (
           <>
-            <MenuGroup>
-              <MenuGroupLabel>{t("navigation.pinned")}</MenuGroupLabel>
-              <MenuItem onClick={() => selectValue(pinnedOption.value)}>
-                <PinnedIcon />
-                <span className="min-w-0 truncate">{pinnedLabel}</span>
-              </MenuItem>
-            </MenuGroup>
+            <p className="text-muted-foreground px-2 py-1.5 text-xs font-medium">
+              {t("navigation.pinned")}
+            </p>
+            <MenuItem onClick={() => selectValue(pinnedOption.value)}>
+              <PinnedIcon />
+              <span className="min-w-0 truncate">{pinnedLabel}</span>
+            </MenuItem>
             <MenuSeparator />
           </>
         )}

--- a/apps/web/src/components/chat/chat-model-mode-selector.tsx
+++ b/apps/web/src/components/chat/chat-model-mode-selector.tsx
@@ -60,6 +60,11 @@ type ChatModelModeSelectorProps = {
   models: ComposerModelsMenuProps;
 };
 
+type ChatModelSelectionIntent = {
+  choice: ChatModelFavorite;
+  threadId: string;
+};
+
 /**
  * Compact access to friendly modes and exact models. Modes resolve to the
  * organization's configured role model; pinned modes therefore follow later
@@ -72,6 +77,8 @@ export const ChatModelModeSelector = ({
   const t = useTranslations();
   const [open, setOpen] = useState(false);
   const [detailsRequested, setDetailsRequested] = useState(false);
+  const [selectionIntent, setSelectionIntent] =
+    useState<ChatModelSelectionIntent | null>(null);
   const { data } = useQuery({
     ...modelOptionsOptions(models.activeOrganizationId),
     enabled: open || detailsRequested || models.selectedModel !== null,
@@ -82,14 +89,27 @@ export const ChatModelModeSelector = ({
   const setFavorite = useChatModelFavoriteStore((state) => state.setFavorite);
 
   const options = resolveModeOptions(data?.modeValues);
-  const selectedMode = resolveSelectedMode({
+  const intendedChoice =
+    selectionIntent?.threadId === models.threadRef.threadId
+      ? selectionIntent.choice
+      : null;
+  const selectedChoice =
+    intendedChoice ??
+    resolveSelectedChoice({
+      favorite,
+      options,
+      selectedModel: models.selectedModel,
+    });
+  const selectedMode =
+    selectedChoice.type === "mode" ? selectedChoice.mode : null;
+  const selectedValue = resolveChoiceModelValue({
+    choice: selectedChoice,
     options,
-    selectedModel: models.selectedModel,
   });
   const effectiveModelValue =
     selectedMode === CHAT_MODEL_MODE.standard
       ? data?.defaultValue
-      : models.selectedModel;
+      : selectedValue;
   const effectiveModel = data?.options.find(
     (option) => option.value === effectiveModelValue,
   );
@@ -99,18 +119,25 @@ export const ChatModelModeSelector = ({
     : selectedMode
       ? t(MODE_LABEL_KEY[selectedMode])
       : (models.selectedModel ?? t("chat.modelMode.exactModels"));
-  const toggleFavorite = (nextFavorite: ChatModelFavorite) => {
-    setFavorite(
-      models.activeOrganizationId,
-      isSameFavorite(favorite, nextFavorite) ? null : nextFavorite,
-    );
-  };
 
-  const selectValue = (value: string) => {
-    const nextModel = value === "" ? null : value;
+  const selectChoice = (choice: ChatModelFavorite) => {
+    const nextModel = resolveChoiceModelValue({ choice, options });
+    if (nextModel === undefined) {
+      return;
+    }
+    setSelectionIntent({ choice, threadId: models.threadRef.threadId });
     if (nextModel !== models.selectedModel) {
       models.selectModel(nextModel);
     }
+  };
+
+  const toggleFavorite = (nextFavorite: ChatModelFavorite) => {
+    if (isSameFavorite(favorite, nextFavorite)) {
+      setFavorite(models.activeOrganizationId, null);
+      return;
+    }
+    setFavorite(models.activeOrganizationId, nextFavorite);
+    selectChoice(nextFavorite);
   };
 
   return (
@@ -132,7 +159,7 @@ export const ChatModelModeSelector = ({
         <TriggerIcon aria-hidden="true" className="size-3.5" />
       </MenuTrigger>
       <MenuPopup align="start" className="w-72" side="top" sideOffset={6}>
-        <MenuRadioGroup value={models.selectedModel ?? ""}>
+        <MenuRadioGroup value={selectionKey(selectedChoice)}>
           {options.map((option) => {
             const Icon = MODE_ICON[option.mode];
             const label = t(MODE_LABEL_KEY[option.mode]);
@@ -148,8 +175,8 @@ export const ChatModelModeSelector = ({
               >
                 <MenuRadioItem
                   className="data-highlighted:bg-transparent pe-2"
-                  onClick={() => selectValue(option.value)}
-                  value={option.value}
+                  onClick={() => selectChoice(optionFavorite)}
+                  value={selectionKey(optionFavorite)}
                 >
                   <span className="flex min-w-0 items-start gap-2 py-0.5">
                     <Icon className="mt-0.5 size-3.5 shrink-0" />
@@ -178,7 +205,7 @@ export const ChatModelModeSelector = ({
           </MenuSubTrigger>
           <MenuSubPopup className="w-[min(32rem,calc(100vw-2rem))] max-w-(--available-width)">
             {data ? (
-              <MenuRadioGroup value={models.selectedModel ?? ""}>
+              <MenuRadioGroup value={selectionKey(selectedChoice)}>
                 {data.options.map((option) => {
                   const label = formatModelLabel(option);
                   const optionFavorite = {
@@ -193,8 +220,8 @@ export const ChatModelModeSelector = ({
                     >
                       <MenuRadioItem
                         className="data-highlighted:bg-transparent grid-cols-[1rem_minmax(0,1fr)] pe-2"
-                        onClick={() => selectValue(option.value)}
-                        value={option.value}
+                        onClick={() => selectChoice(optionFavorite)}
+                        value={selectionKey(optionFavorite)}
                       >
                         <span className="block [overflow-wrap:anywhere] whitespace-normal">
                           <bdi>{label}</bdi>
@@ -247,6 +274,7 @@ const FavoriteMenuItem = ({
     <MenuItem
       aria-label={`${action}: ${label}`}
       className="data-highlighted:bg-transparent justify-center px-2"
+      closeOnClick={false}
       onClick={onClick}
       title={`${action}: ${label}`}
     >
@@ -277,24 +305,57 @@ const resolveModeOptions = (
       value: modeValues.deepThinking,
     });
   }
-  if (modeValues?.fast && modeValues.fast !== modeValues.deepThinking) {
+  if (modeValues?.fast) {
     options.push({ mode: CHAT_MODEL_MODE.fast, value: modeValues.fast });
   }
   return options;
 };
 
-const resolveSelectedMode = ({
+const resolveChoiceModelValue = ({
+  choice,
+  options,
+}: {
+  choice: ChatModelFavorite;
+  options: ModelModeOption[];
+}): string | null | undefined => {
+  if (choice.type === "model") {
+    return choice.value;
+  }
+  const option = options.find(({ mode }) => mode === choice.mode);
+  if (!option) {
+    return undefined;
+  }
+  return option.value === "" ? null : option.value;
+};
+
+const resolveSelectedChoice = ({
+  favorite,
   options,
   selectedModel,
 }: {
+  favorite: ChatModelFavorite | undefined;
   options: ModelModeOption[];
   selectedModel: string | null;
-}): ChatModelMode | null => {
-  if (selectedModel === null) {
-    return CHAT_MODEL_MODE.standard;
+}): ChatModelFavorite => {
+  if (
+    favorite &&
+    resolveChoiceModelValue({ choice: favorite, options }) === selectedModel
+  ) {
+    return favorite;
   }
-  return options.find((option) => option.value === selectedModel)?.mode ?? null;
+  if (selectedModel === null) {
+    return { type: "mode", mode: CHAT_MODEL_MODE.standard };
+  }
+  const mode = options.find(({ value }) => value === selectedModel)?.mode;
+  return mode
+    ? { type: "mode", mode }
+    : { type: "model", value: selectedModel };
 };
+
+const selectionKey = (selection: ChatModelFavorite): string =>
+  selection.type === "mode"
+    ? `mode:${selection.mode}`
+    : `model:${selection.value}`;
 
 const isSameFavorite = (
   current: ChatModelFavorite | undefined,

--- a/apps/web/src/components/chat/chat-model-mode-selector.tsx
+++ b/apps/web/src/components/chat/chat-model-mode-selector.tsx
@@ -55,7 +55,7 @@ const MODE_ICON = {
 } as const satisfies Record<ChatModelMode, LucideIcon>;
 
 type ChatModelModeSelectorProps = {
-  disabled: boolean;
+  disabled?: boolean;
   models: ComposerModelsMenuProps;
 };
 
@@ -65,7 +65,7 @@ type ChatModelModeSelectorProps = {
  * configuration changes, while pinned exact models retain their identity.
  */
 export const ChatModelModeSelector = ({
-  disabled,
+  disabled = false,
   models,
 }: ChatModelModeSelectorProps) => {
   const t = useTranslations();

--- a/apps/web/src/components/chat/chat-model-mode-selector.tsx
+++ b/apps/web/src/components/chat/chat-model-mode-selector.tsx
@@ -209,11 +209,12 @@ export const ChatModelModeSelector = ({
             const pinned = isSameFavorite(favorite, optionFavorite);
             return (
               <div
-                className="hover:bg-accent has-[[data-highlighted]]:bg-accent has-[[data-highlighted]]:text-accent-foreground grid grid-cols-[minmax(0,1fr)_auto] rounded-sm"
+                className="hover:bg-accent has-[[data-checked]]:bg-accent has-[[data-highlighted]]:bg-accent has-[[data-highlighted]]:text-accent-foreground grid grid-cols-[minmax(0,1fr)_auto] rounded-sm"
                 key={option.mode}
               >
                 <MenuRadioItem
                   className="data-highlighted:bg-transparent pe-2"
+                  indicator="none"
                   onClick={() => selectChoice(optionFavorite)}
                   value={selectionKey(optionFavorite)}
                 >

--- a/apps/web/src/components/chat/chat-model-mode-selector.tsx
+++ b/apps/web/src/components/chat/chat-model-mode-selector.tsx
@@ -89,21 +89,25 @@ export const ChatModelModeSelector = ({
     (option) => option.value === models.selectedModel,
   );
   const TriggerIcon = selectedMode ? MODE_ICON[selectedMode] : CpuIcon;
-  const triggerLabel = selectedMode
-    ? t(MODE_LABEL_KEY[selectedMode])
-    : selectedExactModel
-      ? formatModelLabel(selectedExactModel)
-      : (models.selectedModel ?? t("chat.modelMode.exactModels"));
+  let triggerLabel = models.selectedModel ?? t("chat.modelMode.exactModels");
+  if (selectedExactModel) {
+    triggerLabel = formatModelLabel(selectedExactModel);
+  }
+  if (selectedMode) {
+    triggerLabel = t(MODE_LABEL_KEY[selectedMode]);
+  }
   const pinnedOption = resolveFavoriteOption({
     favorite,
     modeOptions: options,
     modelOptions: data?.options,
   });
-  const pinnedLabel = pinnedOption
-    ? pinnedOption.type === "mode"
-      ? t(MODE_LABEL_KEY[pinnedOption.mode])
-      : pinnedOption.label
-    : null;
+  let pinnedLabel: string | null = null;
+  if (pinnedOption?.type === "model") {
+    pinnedLabel = pinnedOption.label;
+  }
+  if (pinnedOption?.type === "mode") {
+    pinnedLabel = t(MODE_LABEL_KEY[pinnedOption.mode]);
+  }
   const PinnedIcon = pinnedOption?.Icon;
 
   const toggleFavorite = (nextFavorite: ChatModelFavorite) => {
@@ -114,7 +118,7 @@ export const ChatModelModeSelector = ({
   };
 
   const selectValue = (value: string) => {
-    const nextModel = value || null;
+    const nextModel = value === "" ? null : value;
     if (nextModel !== models.selectedModel) {
       models.selectModel(nextModel);
     }

--- a/apps/web/src/components/chat/chat-model-mode-selector.tsx
+++ b/apps/web/src/components/chat/chat-model-mode-selector.tsx
@@ -213,7 +213,7 @@ export const ChatModelModeSelector = ({
                 key={option.mode}
               >
                 <MenuRadioItem
-                  className="data-highlighted:bg-transparent pe-2"
+                  className="pe-2 data-highlighted:bg-transparent"
                   indicator="none"
                   onClick={() => selectChoice(optionFavorite)}
                   value={selectionKey(optionFavorite)}
@@ -259,7 +259,7 @@ export const ChatModelModeSelector = ({
                       key={option.value}
                     >
                       <MenuRadioItem
-                        className="data-highlighted:bg-transparent grid-cols-[1rem_minmax(0,1fr)] pe-2"
+                        className="grid-cols-[1rem_minmax(0,1fr)] pe-2 data-highlighted:bg-transparent"
                         onClick={() => selectChoice(optionFavorite)}
                         value={selectionKey(optionFavorite)}
                       >
@@ -313,7 +313,7 @@ const FavoriteMenuItem = ({
   return (
     <MenuItem
       aria-label={`${action}: ${label}`}
-      className="data-highlighted:bg-transparent justify-center px-2"
+      className="justify-center px-2 data-highlighted:bg-transparent"
       closeOnClick={false}
       onClick={onClick}
       title={`${action}: ${label}`}

--- a/apps/web/src/components/chat/chat-model-mode-selector.tsx
+++ b/apps/web/src/components/chat/chat-model-mode-selector.tsx
@@ -1,13 +1,13 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 
 import { useQuery } from "@tanstack/react-query";
 import {
   BrainCircuitIcon,
   CpuIcon,
   GaugeIcon,
-  MessageCircleIcon,
   PinIcon,
   PinOffIcon,
+  ScaleIcon,
 } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import { useTranslations } from "use-intl";
@@ -29,6 +29,7 @@ import {
 import { PROVIDER_LABELS } from "@/components/ai-config-role-models.logic";
 import type { ComposerModelsMenuProps } from "@/components/chat/composer-plus-menu";
 import { modelOptionsOptions } from "@/features/chat/queries";
+import { useExternalSyncEffect } from "@/hooks/use-effect";
 import type { TranslationKey } from "@/i18n/types";
 import {
   CHAT_MODEL_MODE,
@@ -50,7 +51,7 @@ const MODE_DESCRIPTION_KEY = {
 } as const satisfies Record<ChatModelMode, TranslationKey>;
 
 const MODE_ICON = {
-  [CHAT_MODEL_MODE.standard]: MessageCircleIcon,
+  [CHAT_MODEL_MODE.standard]: ScaleIcon,
   [CHAT_MODEL_MODE.deepThinking]: BrainCircuitIcon,
   [CHAT_MODEL_MODE.fast]: GaugeIcon,
 } as const satisfies Record<ChatModelMode, LucideIcon>;
@@ -67,7 +68,8 @@ type ChatModelSelectionIntent = {
 
 /**
  * Compact access to friendly modes and exact models. Modes resolve to the
- * organization's configured role model; pinned modes therefore follow later
+ * organization's configured role model. A pinned choice becomes the default
+ * for a thread without an explicit selection; pinned modes follow later
  * configuration changes, while pinned exact models retain their identity.
  */
 export const ChatModelModeSelector = ({
@@ -79,22 +81,39 @@ export const ChatModelModeSelector = ({
   const [detailsRequested, setDetailsRequested] = useState(false);
   const [selectionIntent, setSelectionIntent] =
     useState<ChatModelSelectionIntent | null>(null);
-  const { data } = useQuery({
-    ...modelOptionsOptions(models.activeOrganizationId),
-    enabled: open || detailsRequested || models.selectedModel !== null,
-  });
+  const autoAppliedFavoriteRef = useRef<string | null>(null);
   const favorite = useChatModelFavoriteStore(
     (state) => state.favoritesByOrganization[models.activeOrganizationId],
   );
   const setFavorite = useChatModelFavoriteStore((state) => state.setFavorite);
+  const { data } = useQuery({
+    ...modelOptionsOptions(models.activeOrganizationId),
+    enabled:
+      open ||
+      detailsRequested ||
+      models.selectedModel !== null ||
+      favorite !== undefined,
+  });
 
   const options = resolveModeOptions(data?.modeValues);
   const intendedChoice =
     selectionIntent?.threadId === models.threadRef.threadId
       ? selectionIntent.choice
       : null;
+  const favoriteValue = resolveAvailableFavoriteValue({
+    favorite,
+    modeOptions: options,
+    modelOptions: data?.options,
+  });
+  const favoriteAsDefault =
+    intendedChoice === null &&
+    models.selectedModel === null &&
+    favoriteValue !== undefined
+      ? favorite
+      : null;
   const selectedChoice =
     intendedChoice ??
+    favoriteAsDefault ??
     resolveSelectedChoice({
       favorite,
       options,
@@ -119,6 +138,22 @@ export const ChatModelModeSelector = ({
     : selectedMode
       ? t(MODE_LABEL_KEY[selectedMode])
       : (models.selectedModel ?? t("chat.modelMode.exactModels"));
+
+  const autoApplyKey = favoriteAsDefault
+    ? `${models.threadRef.threadId}:${selectionKey(favoriteAsDefault)}`
+    : null;
+  useExternalSyncEffect(() => {
+    if (
+      autoApplyKey === null ||
+      favoriteValue === null ||
+      favoriteValue === undefined ||
+      autoAppliedFavoriteRef.current === autoApplyKey
+    ) {
+      return;
+    }
+    autoAppliedFavoriteRef.current = autoApplyKey;
+    models.selectModel(favoriteValue);
+  }, [autoApplyKey, favoriteValue, models.selectModel]);
 
   const selectChoice = (choice: ChatModelFavorite) => {
     const nextModel = resolveChoiceModelValue({ choice, options });
@@ -330,6 +365,26 @@ const resolveChoiceModelValue = ({
     return undefined;
   }
   return option.value === "" ? null : option.value;
+};
+
+const resolveAvailableFavoriteValue = ({
+  favorite,
+  modeOptions,
+  modelOptions,
+}: {
+  favorite: ChatModelFavorite | undefined;
+  modeOptions: ModelModeOption[];
+  modelOptions: ModelOption[] | undefined;
+}): string | null | undefined => {
+  if (!favorite) {
+    return undefined;
+  }
+  if (favorite.type === "mode") {
+    return resolveChoiceModelValue({ choice: favorite, options: modeOptions });
+  }
+  return modelOptions?.some(({ value }) => value === favorite.value)
+    ? favorite.value
+    : undefined;
 };
 
 const resolveSelectedChoice = ({

--- a/apps/web/src/components/chat/chat-model-mode-selector.tsx
+++ b/apps/web/src/components/chat/chat-model-mode-selector.tsx
@@ -77,27 +77,29 @@ export const ChatModelModeSelector = ({
   models,
 }: ChatModelModeSelectorProps) => {
   const t = useTranslations();
+  const { activeOrganizationId, selectedModel, selectModel, threadRef } =
+    models;
   const [open, setOpen] = useState(false);
   const [detailsRequested, setDetailsRequested] = useState(false);
   const [selectionIntent, setSelectionIntent] =
     useState<ChatModelSelectionIntent | null>(null);
   const autoAppliedFavoriteRef = useRef<string | null>(null);
   const favorite = useChatModelFavoriteStore(
-    (state) => state.favoritesByOrganization[models.activeOrganizationId],
+    (state) => state.favoritesByOrganization[activeOrganizationId],
   );
   const setFavorite = useChatModelFavoriteStore((state) => state.setFavorite);
   const { data } = useQuery({
-    ...modelOptionsOptions(models.activeOrganizationId),
+    ...modelOptionsOptions(activeOrganizationId),
     enabled:
       open ||
       detailsRequested ||
-      models.selectedModel !== null ||
+      selectedModel !== null ||
       favorite !== undefined,
   });
 
   const options = resolveModeOptions(data?.modeValues);
   const intendedChoice =
-    selectionIntent?.threadId === models.threadRef.threadId
+    selectionIntent?.threadId === threadRef.threadId
       ? selectionIntent.choice
       : null;
   const favoriteValue = resolveAvailableFavoriteValue({
@@ -107,7 +109,7 @@ export const ChatModelModeSelector = ({
   });
   const favoriteAsDefault =
     intendedChoice === null &&
-    models.selectedModel === null &&
+    selectedModel === null &&
     favoriteValue !== undefined
       ? favorite
       : null;
@@ -117,7 +119,7 @@ export const ChatModelModeSelector = ({
     resolveSelectedChoice({
       favorite,
       options,
-      selectedModel: models.selectedModel,
+      selectedModel,
     });
   const selectedMode =
     selectedChoice.type === "mode" ? selectedChoice.mode : null;
@@ -133,14 +135,16 @@ export const ChatModelModeSelector = ({
     (option) => option.value === effectiveModelValue,
   );
   const TriggerIcon = selectedMode ? MODE_ICON[selectedMode] : CpuIcon;
-  const triggerLabel = effectiveModel
-    ? formatModelLabel(effectiveModel)
-    : selectedMode
-      ? t(MODE_LABEL_KEY[selectedMode])
-      : (models.selectedModel ?? t("chat.modelMode.exactModels"));
+  let triggerLabel = selectedModel ?? t("chat.modelMode.exactModels");
+  if (selectedMode) {
+    triggerLabel = t(MODE_LABEL_KEY[selectedMode]);
+  }
+  if (effectiveModel) {
+    triggerLabel = formatModelLabel(effectiveModel);
+  }
 
   const autoApplyKey = favoriteAsDefault
-    ? `${models.threadRef.threadId}:${selectionKey(favoriteAsDefault)}`
+    ? `${threadRef.threadId}:${selectionKey(favoriteAsDefault)}`
     : null;
   useExternalSyncEffect(() => {
     if (
@@ -152,26 +156,26 @@ export const ChatModelModeSelector = ({
       return;
     }
     autoAppliedFavoriteRef.current = autoApplyKey;
-    models.selectModel(favoriteValue);
-  }, [autoApplyKey, favoriteValue, models.selectModel]);
+    selectModel(favoriteValue);
+  }, [autoApplyKey, favoriteValue, selectModel]);
 
   const selectChoice = (choice: ChatModelFavorite) => {
     const nextModel = resolveChoiceModelValue({ choice, options });
     if (nextModel === undefined) {
       return;
     }
-    setSelectionIntent({ choice, threadId: models.threadRef.threadId });
-    if (nextModel !== models.selectedModel) {
-      models.selectModel(nextModel);
+    setSelectionIntent({ choice, threadId: threadRef.threadId });
+    if (nextModel !== selectedModel) {
+      selectModel(nextModel);
     }
   };
 
   const toggleFavorite = (nextFavorite: ChatModelFavorite) => {
     if (isSameFavorite(favorite, nextFavorite)) {
-      setFavorite(models.activeOrganizationId, null);
+      setFavorite(activeOrganizationId, null);
       return;
     }
-    setFavorite(models.activeOrganizationId, nextFavorite);
+    setFavorite(activeOrganizationId, nextFavorite);
     selectChoice(nextFavorite);
   };
 

--- a/apps/web/src/components/chat/chat-prompt-improve-button.tsx
+++ b/apps/web/src/components/chat/chat-prompt-improve-button.tsx
@@ -4,6 +4,7 @@ import { Result } from "better-result";
 import { Loader2Icon, WandSparklesIcon } from "lucide-react";
 import { useTranslations } from "use-intl";
 
+import { CHAT_SEND_MODE } from "@stll/anonymize-chat";
 import { Button } from "@stll/ui/components/button";
 import { stellaToast } from "@stll/ui/components/toast";
 
@@ -45,7 +46,13 @@ export const ChatPromptImproveButton = ({
 
     setIsPending(true);
     const result = await Result.tryPromise(
-      async () => await api.chat["improve-prompt"].post({ prompt }),
+      async () =>
+        await api.chat["improve-prompt"].post({
+          prompt,
+          sendMode: anonymized
+            ? CHAT_SEND_MODE.anonymized
+            : CHAT_SEND_MODE.rawOverride,
+        }),
     );
     setIsPending(false);
 

--- a/apps/web/src/components/chat/chat-prompt-improve-button.tsx
+++ b/apps/web/src/components/chat/chat-prompt-improve-button.tsx
@@ -99,7 +99,7 @@ export const ChatPromptImproveButton = ({
       render={
         <Button
           aria-label={label}
-          className="text-muted-foreground hover:text-foreground"
+          className="text-muted-foreground hover:text-foreground relative before:absolute before:-inset-2"
           disabled={anonymized || disabled || isPending}
           onClick={() => {
             detached(improvePrompt(), "ChatPromptImproveButton");

--- a/apps/web/src/components/chat/chat-prompt-improve-button.tsx
+++ b/apps/web/src/components/chat/chat-prompt-improve-button.tsx
@@ -1,0 +1,151 @@
+import { useState } from "react";
+
+import { Result } from "better-result";
+import { Loader2Icon, WandSparklesIcon } from "lucide-react";
+import { useTranslations } from "use-intl";
+
+import { Button } from "@stll/ui/components/button";
+import { stellaToast } from "@stll/ui/components/toast";
+
+import type { ChatEditorController } from "@/components/chat-editor-provider";
+import Tooltip from "@/components/tooltip";
+import { getAnalytics } from "@/lib/analytics/provider";
+import { api } from "@/lib/api";
+import { detached } from "@/lib/detached";
+import { toAPIError } from "@/lib/errors/api";
+
+type ChatPromptImproveButtonProps = {
+  anonymized: boolean;
+  controller: ChatEditorController;
+  disabled: boolean;
+};
+
+export const ChatPromptImproveButton = ({
+  anonymized,
+  controller,
+  disabled,
+}: ChatPromptImproveButtonProps) => {
+  const t = useTranslations();
+  const [isPending, setIsPending] = useState(false);
+
+  const improvePrompt = async () => {
+    const { editor } = controller;
+    if (!editor || editor.isDestroyed || !isPlainTextDraft(editor)) {
+      stellaToast.add({
+        title: t("chat.improvePromptPlainTextOnly"),
+        type: "warning",
+      });
+      return;
+    }
+
+    const prompt = editor.getText().trim();
+    if (!prompt) {
+      return;
+    }
+
+    setIsPending(true);
+    const result = await Result.tryPromise(
+      async () => await api.chat["improve-prompt"].post({ prompt }),
+    );
+    setIsPending(false);
+
+    if (Result.isError(result)) {
+      getAnalytics().captureError(result.error);
+      stellaToast.add({
+        title: t("common.somethingWentWrong"),
+        type: "error",
+      });
+      return;
+    }
+    if (result.value.error) {
+      getAnalytics().captureError(toAPIError(result.value.error));
+      stellaToast.add({
+        title: t("common.somethingWentWrong"),
+        type: "error",
+      });
+      return;
+    }
+
+    if (!isCurrentDraftUnchanged({ controller, editor, prompt })) {
+      stellaToast.add({
+        title: t("chat.improvePromptDraftChanged"),
+        type: "info",
+      });
+      return;
+    }
+
+    controller.setContent(result.value.data.prompt);
+    controller.focus();
+  };
+
+  let label = t("chat.improvePrompt");
+  if (anonymized) {
+    label = t("chat.improvePromptUnavailableAnonymized");
+  }
+  if (isPending) {
+    label = t("chat.improvingPrompt");
+  }
+
+  return (
+    <Tooltip
+      content={label}
+      render={
+        <Button
+          aria-label={label}
+          className="text-muted-foreground hover:text-foreground"
+          disabled={anonymized || disabled || isPending}
+          onClick={() => {
+            detached(improvePrompt(), "ChatPromptImproveButton");
+          }}
+          size="icon-xs"
+          type="button"
+          variant="ghost"
+        >
+          {isPending ? (
+            <Loader2Icon aria-hidden="true" className="size-3.5 animate-spin" />
+          ) : (
+            <WandSparklesIcon aria-hidden="true" className="size-3.5" />
+          )}
+        </Button>
+      }
+    />
+  );
+};
+
+const PLAIN_TEXT_NODE_NAMES = new Set([
+  "doc",
+  "hardBreak",
+  "paragraph",
+  "text",
+]);
+
+const isPlainTextDraft = (
+  editor: NonNullable<ChatEditorController["editor"]>,
+): boolean => {
+  let isPlainText = true;
+  editor.state.doc.descendants((node) => {
+    if (!PLAIN_TEXT_NODE_NAMES.has(node.type.name)) {
+      isPlainText = false;
+      return false;
+    }
+    return isPlainText;
+  });
+  return isPlainText;
+};
+
+const isCurrentDraftUnchanged = ({
+  controller,
+  editor,
+  prompt,
+}: {
+  controller: ChatEditorController;
+  editor: NonNullable<ChatEditorController["editor"]>;
+  prompt: string;
+}): boolean => {
+  const currentEditor = controller.editor;
+  return (
+    currentEditor === editor &&
+    !currentEditor.isDestroyed &&
+    currentEditor.getText().trim() === prompt
+  );
+};

--- a/apps/web/src/components/chat/chat-prompt-improve-button.tsx
+++ b/apps/web/src/components/chat/chat-prompt-improve-button.tsx
@@ -112,19 +112,19 @@ export const ChatPromptImproveButton = ({
   );
 };
 
-const PLAIN_TEXT_NODE_NAMES = new Set([
+const PLAIN_TEXT_NODE_NAMES = [
   "doc",
   "hardBreak",
   "paragraph",
   "text",
-]);
+] as const;
 
 const isPlainTextDraft = (
   editor: NonNullable<ChatEditorController["editor"]>,
 ): boolean => {
   let isPlainText = true;
   editor.state.doc.descendants((node) => {
-    if (!PLAIN_TEXT_NODE_NAMES.has(node.type.name)) {
+    if (!PLAIN_TEXT_NODE_NAMES.some((name) => name === node.type.name)) {
       isPlainText = false;
       return false;
     }

--- a/apps/web/src/components/chat/tool-call-card.tsx
+++ b/apps/web/src/components/chat/tool-call-card.tsx
@@ -626,7 +626,7 @@ export const ToolCallCard = ({
           </div>
         )}
       {hasError && errorMessage && (
-        <p className="text-destructive max-w-xl px-2 py-1 text-[11px] leading-relaxed whitespace-pre-wrap">
+        <p className="text-destructive max-w-xl py-1 text-[11px] leading-relaxed whitespace-pre-wrap">
           {errorMessage}
         </p>
       )}

--- a/apps/web/src/i18n/langs/ar.json
+++ b/apps/web/src/i18n/langs/ar.json
@@ -474,6 +474,11 @@
     "greeting": "ما الذي تودّ العمل عليه؟",
     "greetingSubtitle": "ابدأ بملف قانوني أو مستند أو سؤال مباشر.",
     "hideThread": "إخفاء المحادثة",
+    "improvePrompt": "تحسين الطلب",
+    "improvePromptDraftChanged": "تغيّرت المسودة، لذلك لم يُطبّق التحسين.",
+    "improvePromptPlainTextOnly": "تحسين الطلب متاح للنص العادي فقط.",
+    "improvePromptUnavailableAnonymized": "تحسين الطلب غير متاح في وضع إخفاء الهوية.",
+    "improvingPrompt": "جارٍ تحسين الطلب…",
     "inDocument": "في المستند",
     "jumpToMessage": "الانتقال إلى هذه الرسالة",
     "landing": {
@@ -494,6 +499,14 @@
         "entities": "في هذا الملف القانوني"
       },
       "loadError": "تعذّر تحميل الكيانات"
+    },
+    "modelMode": {
+      "deepThinking": "تفكير عميق",
+      "deepThinkingDescription": "استدلال وتحليل معقدان",
+      "fastDescription": "أسئلة يومية سريعة",
+      "select": "اختيار وضع الإجابة",
+      "standard": "قياسي",
+      "standardDescription": "الأفضل لمعظم المهام"
     },
     "modelSelector": {
       "defaultLabel": "الافتراضي (دور المحادثة)",

--- a/apps/web/src/i18n/langs/ar.json
+++ b/apps/web/src/i18n/langs/ar.json
@@ -503,6 +503,7 @@
     "modelMode": {
       "deepThinking": "تفكير عميق",
       "deepThinkingDescription": "استدلال وتحليل معقدان",
+      "exactModels": "نموذج محدد",
       "fastDescription": "أسئلة يومية سريعة",
       "select": "اختيار وضع الإجابة",
       "standard": "قياسي",

--- a/apps/web/src/i18n/langs/cs.json
+++ b/apps/web/src/i18n/langs/cs.json
@@ -503,6 +503,7 @@
     "modelMode": {
       "deepThinking": "Hloubkové myšlení",
       "deepThinkingDescription": "Složitá argumentace a analýza",
+      "exactModels": "Konkrétní model",
       "fastDescription": "Rychlé každodenní dotazy",
       "select": "Vybrat režim odpovědi",
       "standard": "Standardní",

--- a/apps/web/src/i18n/langs/cs.json
+++ b/apps/web/src/i18n/langs/cs.json
@@ -474,6 +474,11 @@
     "greeting": "Na čem chcete pracovat?",
     "greetingSubtitle": "Začněte spisem, dokumentem nebo obyčejnou otázkou.",
     "hideThread": "Skrýt konverzaci",
+    "improvePrompt": "Vylepšit zadání",
+    "improvePromptDraftChanged": "Zadání se změnilo, takže vylepšení nebylo použito.",
+    "improvePromptPlainTextOnly": "Vylepšení zadání je dostupné pouze pro prostý text.",
+    "improvePromptUnavailableAnonymized": "Vylepšení zadání není dostupné v anonymizovaném režimu.",
+    "improvingPrompt": "Vylepšuji zadání…",
     "inDocument": "V dokumentu",
     "jumpToMessage": "Přejít na tuto zprávu",
     "landing": {
@@ -494,6 +499,14 @@
         "entities": "V tomto spisu"
       },
       "loadError": "Nepodařilo se načíst entity"
+    },
+    "modelMode": {
+      "deepThinking": "Hloubkové myšlení",
+      "deepThinkingDescription": "Složitá argumentace a analýza",
+      "fastDescription": "Rychlé každodenní dotazy",
+      "select": "Vybrat režim odpovědi",
+      "standard": "Standardní",
+      "standardDescription": "Nejlepší pro většinu úkolů"
     },
     "modelSelector": {
       "defaultLabel": "Výchozí (role chatu)",

--- a/apps/web/src/i18n/langs/de.json
+++ b/apps/web/src/i18n/langs/de.json
@@ -474,6 +474,11 @@
     "greeting": "Woran möchten Sie arbeiten?",
     "greetingSubtitle": "Beginnen Sie mit einer Akte, einem Dokument oder einer einfachen Frage.",
     "hideThread": "Konversation ausblenden",
+    "improvePrompt": "Prompt verbessern",
+    "improvePromptDraftChanged": "Der Entwurf wurde geändert, daher wurde die Verbesserung nicht übernommen.",
+    "improvePromptPlainTextOnly": "Prompts können nur als Klartext verbessert werden.",
+    "improvePromptUnavailableAnonymized": "Im anonymisierten Modus können Prompts nicht verbessert werden.",
+    "improvingPrompt": "Prompt wird verbessert…",
     "inDocument": "Im Dokument",
     "jumpToMessage": "Zu dieser Nachricht springen",
     "landing": {
@@ -494,6 +499,14 @@
         "entities": "In dieser Akte"
       },
       "loadError": "Entitäten konnten nicht geladen werden"
+    },
+    "modelMode": {
+      "deepThinking": "Tiefes Denken",
+      "deepThinkingDescription": "Komplexe Argumentation und Analyse",
+      "fastDescription": "Schnelle, alltägliche Fragen",
+      "select": "Antwortmodus auswählen",
+      "standard": "Normal",
+      "standardDescription": "Am besten für die meisten Aufgaben"
     },
     "modelSelector": {
       "defaultLabel": "Standard (Chat-Rolle)",

--- a/apps/web/src/i18n/langs/de.json
+++ b/apps/web/src/i18n/langs/de.json
@@ -503,6 +503,7 @@
     "modelMode": {
       "deepThinking": "Tiefes Denken",
       "deepThinkingDescription": "Komplexe Argumentation und Analyse",
+      "exactModels": "Konkretes Modell",
       "fastDescription": "Schnelle, alltägliche Fragen",
       "select": "Antwortmodus auswählen",
       "standard": "Normal",

--- a/apps/web/src/i18n/langs/en.json
+++ b/apps/web/src/i18n/langs/en.json
@@ -474,6 +474,11 @@
     "greeting": "What would you like to work on?",
     "greetingSubtitle": "Start with a matter, document, or plain question.",
     "hideThread": "Hide conversation",
+    "improvePrompt": "Improve prompt",
+    "improvePromptDraftChanged": "Draft changed, so the improvement wasn't applied.",
+    "improvePromptPlainTextOnly": "Prompt improvement is available for plain text only.",
+    "improvePromptUnavailableAnonymized": "Prompt improvement is unavailable in anonymized mode.",
+    "improvingPrompt": "Improving prompt…",
     "inDocument": "In document",
     "jumpToMessage": "Jump to this message",
     "landing": {
@@ -494,6 +499,14 @@
         "entities": "In this matter"
       },
       "loadError": "Failed to load entities"
+    },
+    "modelMode": {
+      "deepThinking": "Deep Thinking",
+      "deepThinkingDescription": "Complex reasoning and analysis",
+      "fastDescription": "Quick, everyday questions",
+      "select": "Select response mode",
+      "standard": "Standard",
+      "standardDescription": "Best for most tasks"
     },
     "modelSelector": {
       "defaultLabel": "Default (chat role)",

--- a/apps/web/src/i18n/langs/en.json
+++ b/apps/web/src/i18n/langs/en.json
@@ -503,6 +503,7 @@
     "modelMode": {
       "deepThinking": "Deep Thinking",
       "deepThinkingDescription": "Complex reasoning and analysis",
+      "exactModels": "Exact model",
       "fastDescription": "Quick, everyday questions",
       "select": "Select response mode",
       "standard": "Standard",

--- a/apps/web/src/i18n/langs/es.json
+++ b/apps/web/src/i18n/langs/es.json
@@ -503,6 +503,7 @@
     "modelMode": {
       "deepThinking": "Razonamiento profundo",
       "deepThinkingDescription": "Razonamiento y análisis complejos",
+      "exactModels": "Modelo específico",
       "fastDescription": "Consultas rápidas y cotidianas",
       "select": "Seleccionar modo de respuesta",
       "standard": "Estándar",

--- a/apps/web/src/i18n/langs/es.json
+++ b/apps/web/src/i18n/langs/es.json
@@ -474,6 +474,11 @@
     "greeting": "¿En qué le gustaría trabajar?",
     "greetingSubtitle": "Empiece con un asunto, un documento o una pregunta sencilla.",
     "hideThread": "Ocultar conversación",
+    "improvePrompt": "Mejorar prompt",
+    "improvePromptDraftChanged": "El borrador cambió, por lo que no se aplicó la mejora.",
+    "improvePromptPlainTextOnly": "La mejora de prompts solo está disponible para texto sin formato.",
+    "improvePromptUnavailableAnonymized": "La mejora de prompts no está disponible en modo anonimizado.",
+    "improvingPrompt": "Mejorando prompt…",
     "inDocument": "En el documento",
     "jumpToMessage": "Ir a este mensaje",
     "landing": {
@@ -494,6 +499,14 @@
         "entities": "En este asunto"
       },
       "loadError": "Error al cargar entidades"
+    },
+    "modelMode": {
+      "deepThinking": "Razonamiento profundo",
+      "deepThinkingDescription": "Razonamiento y análisis complejos",
+      "fastDescription": "Consultas rápidas y cotidianas",
+      "select": "Seleccionar modo de respuesta",
+      "standard": "Estándar",
+      "standardDescription": "Ideal para la mayoría de las tareas"
     },
     "modelSelector": {
       "defaultLabel": "Predeterminado (rol de chat)",

--- a/apps/web/src/i18n/langs/et.json
+++ b/apps/web/src/i18n/langs/et.json
@@ -474,6 +474,11 @@
     "greeting": "Millega soovite tegeleda?",
     "greetingSubtitle": "Alustage toimikust, dokumendist või lihtsast küsimusest.",
     "hideThread": "Peida vestlus",
+    "improvePrompt": "Täiusta viipa",
+    "improvePromptDraftChanged": "Mustand muutus, seega täiustust ei rakendatud.",
+    "improvePromptPlainTextOnly": "Viipa saab täiustada ainult lihttekstina.",
+    "improvePromptUnavailableAnonymized": "Anonüümitud režiimis ei saa viipa täiustada.",
+    "improvingPrompt": "Viiba täiustamine…",
     "inDocument": "Dokumendis",
     "jumpToMessage": "Liigu selle sõnumi juurde",
     "landing": {
@@ -494,6 +499,14 @@
         "entities": "Selles toimikus"
       },
       "loadError": "Üksuste laadimine ebaõnnestus"
+    },
+    "modelMode": {
+      "deepThinking": "Süvamõtlemine",
+      "deepThinkingDescription": "Keerukas arutlus ja analüüs",
+      "fastDescription": "Kiired igapäevased küsimused",
+      "select": "Vali vastamisrežiim",
+      "standard": "Standardne",
+      "standardDescription": "Parim enamiku ülesannete jaoks"
     },
     "modelSelector": {
       "defaultLabel": "Vaikimisi (vestluse roll)",

--- a/apps/web/src/i18n/langs/et.json
+++ b/apps/web/src/i18n/langs/et.json
@@ -503,6 +503,7 @@
     "modelMode": {
       "deepThinking": "Süvamõtlemine",
       "deepThinkingDescription": "Keerukas arutlus ja analüüs",
+      "exactModels": "Konkreetne mudel",
       "fastDescription": "Kiired igapäevased küsimused",
       "select": "Vali vastamisrežiim",
       "standard": "Standardne",

--- a/apps/web/src/i18n/langs/fr.json
+++ b/apps/web/src/i18n/langs/fr.json
@@ -503,6 +503,7 @@
     "modelMode": {
       "deepThinking": "Réflexion approfondie",
       "deepThinkingDescription": "Raisonnement et analyse complexes",
+      "exactModels": "Modèle précis",
       "fastDescription": "Questions rapides du quotidien",
       "select": "Sélectionner le mode de réponse",
       "standard": "Par défaut",

--- a/apps/web/src/i18n/langs/fr.json
+++ b/apps/web/src/i18n/langs/fr.json
@@ -474,6 +474,11 @@
     "greeting": "Sur quoi souhaitez-vous travailler ?",
     "greetingSubtitle": "Commencez par un dossier, un document ou une question simple.",
     "hideThread": "Masquer la conversation",
+    "improvePrompt": "Améliorer le prompt",
+    "improvePromptDraftChanged": "Le brouillon a changé, l'amélioration n'a donc pas été appliquée.",
+    "improvePromptPlainTextOnly": "L'amélioration du prompt est disponible uniquement pour le texte brut.",
+    "improvePromptUnavailableAnonymized": "L'amélioration du prompt n'est pas disponible en mode anonymisé.",
+    "improvingPrompt": "Amélioration du prompt…",
     "inDocument": "Dans le document",
     "jumpToMessage": "Aller à ce message",
     "landing": {
@@ -494,6 +499,14 @@
         "entities": "Dans ce dossier"
       },
       "loadError": "Échec du chargement des entités"
+    },
+    "modelMode": {
+      "deepThinking": "Réflexion approfondie",
+      "deepThinkingDescription": "Raisonnement et analyse complexes",
+      "fastDescription": "Questions rapides du quotidien",
+      "select": "Sélectionner le mode de réponse",
+      "standard": "Par défaut",
+      "standardDescription": "Idéal pour la plupart des tâches"
     },
     "modelSelector": {
       "defaultLabel": "Par défaut (rôle de chat)",

--- a/apps/web/src/i18n/langs/hu.json
+++ b/apps/web/src/i18n/langs/hu.json
@@ -474,6 +474,11 @@
     "greeting": "Min szeretne dolgozni?",
     "greetingSubtitle": "Kezdje egy üggyel, dokumentummal vagy egyszerű kérdéssel.",
     "hideThread": "Beszélgetés elrejtése",
+    "improvePrompt": "Prompt javítása",
+    "improvePromptDraftChanged": "A piszkozat megváltozott, ezért a javítás nem lett alkalmazva.",
+    "improvePromptPlainTextOnly": "A prompt javítása csak egyszerű szövegnél érhető el.",
+    "improvePromptUnavailableAnonymized": "A prompt javítása anonimizált módban nem érhető el.",
+    "improvingPrompt": "Prompt javítása…",
     "inDocument": "A dokumentumban",
     "jumpToMessage": "Ugrás ehhez az üzenethez",
     "landing": {
@@ -494,6 +499,14 @@
         "entities": "Ebben az ügyben"
       },
       "loadError": "Az entitások betöltése sikertelen"
+    },
+    "modelMode": {
+      "deepThinking": "Mély gondolkodás",
+      "deepThinkingDescription": "Összetett érvelés és elemzés",
+      "fastDescription": "Gyors, mindennapi kérdések",
+      "select": "Válaszmód kiválasztása",
+      "standard": "Általános",
+      "standardDescription": "A legtöbb feladathoz ideális"
     },
     "modelSelector": {
       "defaultLabel": "Alapértelmezett (csevegési szerepkör)",

--- a/apps/web/src/i18n/langs/hu.json
+++ b/apps/web/src/i18n/langs/hu.json
@@ -503,6 +503,7 @@
     "modelMode": {
       "deepThinking": "Mély gondolkodás",
       "deepThinkingDescription": "Összetett érvelés és elemzés",
+      "exactModels": "Konkrét modell",
       "fastDescription": "Gyors, mindennapi kérdések",
       "select": "Válaszmód kiválasztása",
       "standard": "Általános",

--- a/apps/web/src/i18n/langs/lt.json
+++ b/apps/web/src/i18n/langs/lt.json
@@ -474,6 +474,11 @@
     "greeting": "Prie ko norėtumėte dirbti?",
     "greetingSubtitle": "Pradėkite nuo bylos, dokumento arba paprasto klausimo.",
     "hideThread": "Slėpti pokalbį",
+    "improvePrompt": "Patobulinti užklausą",
+    "improvePromptDraftChanged": "Juodraštis pasikeitė, todėl patobulinimas nebuvo pritaikytas.",
+    "improvePromptPlainTextOnly": "Užklausą galima tobulinti tik kaip paprastą tekstą.",
+    "improvePromptUnavailableAnonymized": "Anonimizuotu režimu užklausos tobulinti negalima.",
+    "improvingPrompt": "Užklausa tobulinama…",
     "inDocument": "Dokumente",
     "jumpToMessage": "Pereiti prie šios žinutės",
     "landing": {
@@ -494,6 +499,14 @@
         "entities": "Šioje byloje"
       },
       "loadError": "Nepavyko įkelti objektų"
+    },
+    "modelMode": {
+      "deepThinking": "Gilus mąstymas",
+      "deepThinkingDescription": "Sudėtingas samprotavimas ir analizė",
+      "fastDescription": "Greiti kasdieniai klausimai",
+      "select": "Pasirinkti atsakymo režimą",
+      "standard": "Standartinis",
+      "standardDescription": "Tinka daugumai užduočių"
     },
     "modelSelector": {
       "defaultLabel": "Numatytasis (pokalbio vaidmuo)",

--- a/apps/web/src/i18n/langs/lt.json
+++ b/apps/web/src/i18n/langs/lt.json
@@ -503,6 +503,7 @@
     "modelMode": {
       "deepThinking": "Gilus mąstymas",
       "deepThinkingDescription": "Sudėtingas samprotavimas ir analizė",
+      "exactModels": "Konkretus modelis",
       "fastDescription": "Greiti kasdieniai klausimai",
       "select": "Pasirinkti atsakymo režimą",
       "standard": "Standartinis",

--- a/apps/web/src/i18n/langs/lv.json
+++ b/apps/web/src/i18n/langs/lv.json
@@ -474,6 +474,11 @@
     "greeting": "Pie kā vēlaties strādāt?",
     "greetingSubtitle": "Sāciet ar lietu, dokumentu vai vienkāršu jautājumu.",
     "hideThread": "Paslēpt sarunu",
+    "improvePrompt": "Uzlabot uzvedni",
+    "improvePromptDraftChanged": "Melnraksts mainījās, tāpēc uzlabojums netika lietots.",
+    "improvePromptPlainTextOnly": "Uzvedni var uzlabot tikai vienkārša teksta formā.",
+    "improvePromptUnavailableAnonymized": "Anonimizētajā režīmā uzvedni nevar uzlabot.",
+    "improvingPrompt": "Uzvedne tiek uzlabota…",
     "inDocument": "Dokumentā",
     "jumpToMessage": "Pāriet uz šo ziņu",
     "landing": {
@@ -494,6 +499,14 @@
         "entities": "Šajā lietā"
       },
       "loadError": "Neizdevās ielādēt entītijas"
+    },
+    "modelMode": {
+      "deepThinking": "Padziļināta domāšana",
+      "deepThinkingDescription": "Sarežģīta argumentācija un analīze",
+      "fastDescription": "Ātri ikdienas jautājumi",
+      "select": "Atlasīt atbildes režīmu",
+      "standard": "Standarta",
+      "standardDescription": "Vislabāk piemērots vairumam uzdevumu"
     },
     "modelSelector": {
       "defaultLabel": "Noklusējuma (tērzēšanas loma)",

--- a/apps/web/src/i18n/langs/lv.json
+++ b/apps/web/src/i18n/langs/lv.json
@@ -503,6 +503,7 @@
     "modelMode": {
       "deepThinking": "Padziļināta domāšana",
       "deepThinkingDescription": "Sarežģīta argumentācija un analīze",
+      "exactModels": "Konkrēts modelis",
       "fastDescription": "Ātri ikdienas jautājumi",
       "select": "Atlasīt atbildes režīmu",
       "standard": "Standarta",

--- a/apps/web/src/i18n/langs/messages.gen.ts
+++ b/apps/web/src/i18n/langs/messages.gen.ts
@@ -506,6 +506,7 @@ type Messages = {
     "modelMode": {
       "deepThinking": "Deep Thinking";
       "deepThinkingDescription": "Complex reasoning and analysis";
+      "exactModels": "Exact model";
       "fastDescription": "Quick, everyday questions";
       "select": "Select response mode";
       "standard": "Standard";

--- a/apps/web/src/i18n/langs/messages.gen.ts
+++ b/apps/web/src/i18n/langs/messages.gen.ts
@@ -477,6 +477,11 @@ type Messages = {
     "greeting": "What would you like to work on?";
     "greetingSubtitle": "Start with a matter, document, or plain question.";
     "hideThread": "Hide conversation";
+    "improvePrompt": "Improve prompt";
+    "improvePromptDraftChanged": "Draft changed, so the improvement wasn't applied.";
+    "improvePromptPlainTextOnly": "Prompt improvement is available for plain text only.";
+    "improvePromptUnavailableAnonymized": "Prompt improvement is unavailable in anonymized mode.";
+    "improvingPrompt": "Improving prompt…";
     "inDocument": "In document";
     "jumpToMessage": "Jump to this message";
     "landing": {
@@ -497,6 +502,14 @@ type Messages = {
         "entities": "In this matter";
       };
       "loadError": "Failed to load entities";
+    };
+    "modelMode": {
+      "deepThinking": "Deep Thinking";
+      "deepThinkingDescription": "Complex reasoning and analysis";
+      "fastDescription": "Quick, everyday questions";
+      "select": "Select response mode";
+      "standard": "Standard";
+      "standardDescription": "Best for most tasks";
     };
     "modelSelector": {
       "defaultLabel": "Default (chat role)";

--- a/apps/web/src/i18n/langs/pl.json
+++ b/apps/web/src/i18n/langs/pl.json
@@ -503,6 +503,7 @@
     "modelMode": {
       "deepThinking": "Głębokie myślenie",
       "deepThinkingDescription": "Złożone rozumowanie i analiza",
+      "exactModels": "Konkretny model",
       "fastDescription": "Szybkie, codzienne pytania",
       "select": "Wybierz tryb odpowiedzi",
       "standard": "Standardowy",

--- a/apps/web/src/i18n/langs/pl.json
+++ b/apps/web/src/i18n/langs/pl.json
@@ -474,6 +474,11 @@
     "greeting": "Nad czym chcesz pracować?",
     "greetingSubtitle": "Zacznij od sprawy, dokumentu albo prostego pytania.",
     "hideThread": "Ukryj konwersację",
+    "improvePrompt": "Ulepsz prompt",
+    "improvePromptDraftChanged": "Wersja robocza się zmieniła, więc ulepszenie nie zostało zastosowane.",
+    "improvePromptPlainTextOnly": "Ulepszanie promptu jest dostępne tylko dla zwykłego tekstu.",
+    "improvePromptUnavailableAnonymized": "Ulepszanie promptu jest niedostępne w trybie anonimizacji.",
+    "improvingPrompt": "Ulepszanie promptu…",
     "inDocument": "W dokumencie",
     "jumpToMessage": "Przejdź do tej wiadomości",
     "landing": {
@@ -494,6 +499,14 @@
         "entities": "W tej sprawie"
       },
       "loadError": "Nie udało się załadować elementów"
+    },
+    "modelMode": {
+      "deepThinking": "Głębokie myślenie",
+      "deepThinkingDescription": "Złożone rozumowanie i analiza",
+      "fastDescription": "Szybkie, codzienne pytania",
+      "select": "Wybierz tryb odpowiedzi",
+      "standard": "Standardowy",
+      "standardDescription": "Najlepszy do większości zadań"
     },
     "modelSelector": {
       "defaultLabel": "Domyślny (rola czatu)",

--- a/apps/web/src/i18n/langs/pt-BR.json
+++ b/apps/web/src/i18n/langs/pt-BR.json
@@ -503,6 +503,7 @@
     "modelMode": {
       "deepThinking": "Raciocínio profundo",
       "deepThinkingDescription": "Raciocínio e análise complexos",
+      "exactModels": "Modelo específico",
       "fastDescription": "Perguntas rápidas do dia a dia",
       "select": "Selecionar modo de resposta",
       "standard": "Padrão",

--- a/apps/web/src/i18n/langs/pt-BR.json
+++ b/apps/web/src/i18n/langs/pt-BR.json
@@ -474,6 +474,11 @@
     "greeting": "No que você gostaria de trabalhar?",
     "greetingSubtitle": "Comece com um caso, documento ou pergunta simples.",
     "hideThread": "Ocultar conversa",
+    "improvePrompt": "Melhorar prompt",
+    "improvePromptDraftChanged": "O rascunho mudou, então a melhoria não foi aplicada.",
+    "improvePromptPlainTextOnly": "A melhoria de prompts está disponível apenas para texto simples.",
+    "improvePromptUnavailableAnonymized": "A melhoria de prompts não está disponível no modo anonimizado.",
+    "improvingPrompt": "Melhorando prompt…",
     "inDocument": "No documento",
     "jumpToMessage": "Ir para esta mensagem",
     "landing": {
@@ -494,6 +499,14 @@
         "entities": "Neste caso"
       },
       "loadError": "Falha ao carregar entidades"
+    },
+    "modelMode": {
+      "deepThinking": "Raciocínio profundo",
+      "deepThinkingDescription": "Raciocínio e análise complexos",
+      "fastDescription": "Perguntas rápidas do dia a dia",
+      "select": "Selecionar modo de resposta",
+      "standard": "Padrão",
+      "standardDescription": "Ideal para a maioria das tarefas"
     },
     "modelSelector": {
       "defaultLabel": "Padrão (função de chat)",

--- a/apps/web/src/i18n/langs/sk.json
+++ b/apps/web/src/i18n/langs/sk.json
@@ -474,6 +474,11 @@
     "greeting": "Na čom chcete pracovať?",
     "greetingSubtitle": "Začnite spisom, dokumentom alebo obyčajnou otázkou.",
     "hideThread": "Skryť konverzáciu",
+    "improvePrompt": "Vylepšiť zadanie",
+    "improvePromptDraftChanged": "Zadanie sa zmenilo, preto vylepšenie nebolo použité.",
+    "improvePromptPlainTextOnly": "Vylepšenie zadania je dostupné iba pre obyčajný text.",
+    "improvePromptUnavailableAnonymized": "Vylepšenie zadania nie je dostupné v anonymizovanom režime.",
+    "improvingPrompt": "Vylepšujem zadanie…",
     "inDocument": "V dokumente",
     "jumpToMessage": "Prejsť na túto správu",
     "landing": {
@@ -494,6 +499,14 @@
         "entities": "V tomto spise"
       },
       "loadError": "Nepodarilo sa načítať entity"
+    },
+    "modelMode": {
+      "deepThinking": "Hĺbkové myslenie",
+      "deepThinkingDescription": "Zložité uvažovanie a analýza",
+      "fastDescription": "Rýchle každodenné otázky",
+      "select": "Vybrať režim odpovede",
+      "standard": "Štandardný",
+      "standardDescription": "Najlepší pre väčšinu úloh"
     },
     "modelSelector": {
       "defaultLabel": "Predvolené (rola chatu)",

--- a/apps/web/src/i18n/langs/sk.json
+++ b/apps/web/src/i18n/langs/sk.json
@@ -503,6 +503,7 @@
     "modelMode": {
       "deepThinking": "Hĺbkové myslenie",
       "deepThinkingDescription": "Zložité uvažovanie a analýza",
+      "exactModels": "Konkrétny model",
       "fastDescription": "Rýchle každodenné otázky",
       "select": "Vybrať režim odpovede",
       "standard": "Štandardný",

--- a/apps/web/src/lib/chat-model-favorite-store.ts
+++ b/apps/web/src/lib/chat-model-favorite-store.ts
@@ -31,10 +31,15 @@ export const useChatModelFavoriteStore = create<ChatModelFavoriteStore>()(
           const nextFavorites = { ...favoritesByOrganization };
           if (favorite) {
             nextFavorites[organizationId] = favorite;
-          } else {
-            delete nextFavorites[organizationId];
+            return { favoritesByOrganization: nextFavorites };
           }
-          return { favoritesByOrganization: nextFavorites };
+          return {
+            favoritesByOrganization: Object.fromEntries(
+              Object.entries(nextFavorites).filter(
+                ([id]) => id !== organizationId,
+              ),
+            ),
+          };
         });
       },
     }),
@@ -54,15 +59,15 @@ export const useChatModelFavoriteStore = create<ChatModelFavoriteStore>()(
 const isChatModelMode = (value: unknown): value is ChatModelMode =>
   Object.values(CHAT_MODEL_MODE).some((mode) => mode === value);
 
+const isUnknownRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null;
+
 const readPersistedFavorites = (
   persisted: unknown,
 ): Record<string, ChatModelFavorite> => {
   if (
-    typeof persisted !== "object" ||
-    persisted === null ||
-    !("favoritesByOrganization" in persisted) ||
-    typeof persisted.favoritesByOrganization !== "object" ||
-    persisted.favoritesByOrganization === null
+    !isUnknownRecord(persisted) ||
+    !isUnknownRecord(persisted.favoritesByOrganization)
   ) {
     return {};
   }
@@ -71,7 +76,7 @@ const readPersistedFavorites = (
   for (const [organizationId, favorite] of Object.entries(
     persisted.favoritesByOrganization,
   )) {
-    if (typeof favorite !== "object" || favorite === null) {
+    if (!isUnknownRecord(favorite)) {
       continue;
     }
     if (

--- a/apps/web/src/lib/chat-model-favorite-store.ts
+++ b/apps/web/src/lib/chat-model-favorite-store.ts
@@ -1,0 +1,97 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+export const CHAT_MODEL_MODE = {
+  standard: "standard",
+  deepThinking: "deepThinking",
+  fast: "fast",
+} as const;
+
+export type ChatModelMode =
+  (typeof CHAT_MODEL_MODE)[keyof typeof CHAT_MODEL_MODE];
+
+export type ChatModelFavorite =
+  | { type: "mode"; mode: ChatModelMode }
+  | { type: "model"; value: string };
+
+type ChatModelFavoriteStore = {
+  favoritesByOrganization: Record<string, ChatModelFavorite>;
+  setFavorite: (
+    organizationId: string,
+    favorite: ChatModelFavorite | null,
+  ) => void;
+};
+
+export const useChatModelFavoriteStore = create<ChatModelFavoriteStore>()(
+  persist(
+    (set) => ({
+      favoritesByOrganization: {},
+      setFavorite: (organizationId, favorite) => {
+        set(({ favoritesByOrganization }) => {
+          const nextFavorites = { ...favoritesByOrganization };
+          if (favorite) {
+            nextFavorites[organizationId] = favorite;
+          } else {
+            delete nextFavorites[organizationId];
+          }
+          return { favoritesByOrganization: nextFavorites };
+        });
+      },
+    }),
+    {
+      name: "stella.chat.modelFavorite",
+      version: 1,
+      partialize: ({ favoritesByOrganization }) => ({
+        favoritesByOrganization,
+      }),
+      migrate: (persisted) => ({
+        favoritesByOrganization: readPersistedFavorites(persisted),
+      }),
+    },
+  ),
+);
+
+const isChatModelMode = (value: unknown): value is ChatModelMode =>
+  Object.values(CHAT_MODEL_MODE).some((mode) => mode === value);
+
+const readPersistedFavorites = (
+  persisted: unknown,
+): Record<string, ChatModelFavorite> => {
+  if (
+    typeof persisted !== "object" ||
+    persisted === null ||
+    !("favoritesByOrganization" in persisted) ||
+    typeof persisted.favoritesByOrganization !== "object" ||
+    persisted.favoritesByOrganization === null
+  ) {
+    return {};
+  }
+
+  const favorites: Record<string, ChatModelFavorite> = {};
+  for (const [organizationId, favorite] of Object.entries(
+    persisted.favoritesByOrganization,
+  )) {
+    if (typeof favorite !== "object" || favorite === null) {
+      continue;
+    }
+    if (
+      "type" in favorite &&
+      favorite.type === "mode" &&
+      "mode" in favorite &&
+      isChatModelMode(favorite.mode)
+    ) {
+      favorites[organizationId] = { type: "mode", mode: favorite.mode };
+      continue;
+    }
+    if (
+      "type" in favorite &&
+      favorite.type === "model" &&
+      "value" in favorite &&
+      typeof favorite.value === "string" &&
+      favorite.value.length > 0
+    ) {
+      favorites[organizationId] = { type: "model", value: favorite.value };
+    }
+  }
+  return favorites;
+};

--- a/apps/web/src/lib/chat-model-favorite-store.ts
+++ b/apps/web/src/lib/chat-model-favorite-store.ts
@@ -67,35 +67,41 @@ const readPersistedFavorites = (
 ): Record<string, ChatModelFavorite> => {
   if (
     !isUnknownRecord(persisted) ||
-    !isUnknownRecord(persisted.favoritesByOrganization)
+    !isUnknownRecord(persisted["favoritesByOrganization"])
   ) {
     return {};
   }
 
   const favorites: Record<string, ChatModelFavorite> = {};
   for (const [organizationId, favorite] of Object.entries(
-    persisted.favoritesByOrganization,
+    persisted["favoritesByOrganization"],
   )) {
     if (!isUnknownRecord(favorite)) {
       continue;
     }
     if (
       "type" in favorite &&
-      favorite.type === "mode" &&
+      favorite["type"] === "mode" &&
       "mode" in favorite &&
-      isChatModelMode(favorite.mode)
+      isChatModelMode(favorite["mode"])
     ) {
-      favorites[organizationId] = { type: "mode", mode: favorite.mode };
+      favorites[organizationId] = {
+        type: "mode",
+        mode: favorite["mode"],
+      };
       continue;
     }
     if (
       "type" in favorite &&
-      favorite.type === "model" &&
+      favorite["type"] === "model" &&
       "value" in favorite &&
-      typeof favorite.value === "string" &&
-      favorite.value.length > 0
+      typeof favorite["value"] === "string" &&
+      favorite["value"].length > 0
     ) {
-      favorites[organizationId] = { type: "model", value: favorite.value };
+      favorites[organizationId] = {
+        type: "model",
+        value: favorite["value"],
+      };
     }
   }
   return favorites;

--- a/apps/web/src/routes/_protected.chat/-components/chat-thread-page.tsx
+++ b/apps/web/src/routes/_protected.chat/-components/chat-thread-page.tsx
@@ -695,6 +695,12 @@ export const ChatThreadPage = ({
                   dock={
                     <ChatComposerDock
                       data={data}
+                      models={{
+                        activeOrganizationId,
+                        threadRef,
+                        selectedModel: data.model,
+                        selectModel: modelSelection.selectModel,
+                      }}
                       leadingContext={
                         <ChatMatterPicker
                           matterIds={selectedContextMatterIds}

--- a/apps/web/src/routes/_protected.chat/index.tsx
+++ b/apps/web/src/routes/_protected.chat/index.tsx
@@ -497,6 +497,12 @@ function ChatIndex() {
                     // (~system prompt + tools) rather than 0% until send.
                     context: chatDraftMeta?.context ?? null,
                   }}
+                  models={{
+                    activeOrganizationId,
+                    threadRef,
+                    selectedModel: chatDraftMeta?.model ?? null,
+                    selectModel: modelSelection.selectModel,
+                  }}
                   leadingContext={
                     <ChatMatterPicker
                       matterIds={contextMatterIds}

--- a/docs/capability-coverage.md
+++ b/docs/capability-coverage.md
@@ -457,7 +457,7 @@ mechanics, and similar), not gaps in coverage.
 | Reason                 | Count |
 | ---------------------- | ----- |
 | account_lifecycle      | 4     |
-| assistant_chat         | 7     |
+| assistant_chat         | 8     |
 | auth_plumbing          | 7     |
 | chat_thread_ui         | 1     |
 | compound_consent       | 1     |
@@ -475,4 +475,4 @@ mechanics, and similar), not gaps in coverage.
 | upload_mechanics       | 4     |
 | url_preview            | 2     |
 
-Total: 99
+Total: 100

--- a/packages/ui/src/components/menu.tsx
+++ b/packages/ui/src/components/menu.tsx
@@ -162,34 +162,46 @@ function MenuRadioGroup(props: MenuPrimitive.RadioGroup.Props) {
 function MenuRadioItem({
   className,
   children,
+  indicator = "check",
   ...props
-}: MenuPrimitive.RadioItem.Props) {
+}: MenuPrimitive.RadioItem.Props & {
+  indicator?: "check" | "none";
+}) {
   return (
     <MenuPrimitive.RadioItem
       className={cn(
-        "text-foreground data-highlighted:bg-accent data-highlighted:text-accent-foreground grid min-h-8 cursor-pointer grid-cols-[1rem_1fr] items-center gap-2 rounded-sm py-1 ps-2 pe-4 text-base outline-none in-data-[side=none]:min-w-[calc(var(--anchor-width)+1.25rem)] data-disabled:pointer-events-none data-disabled:opacity-64 sm:min-h-7 sm:text-sm [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4.5 sm:[&_svg:not([class*='size-'])]:size-4",
+        "text-foreground data-highlighted:bg-accent data-highlighted:text-accent-foreground min-h-8 cursor-pointer items-center gap-2 rounded-sm py-1 text-base outline-none in-data-[side=none]:min-w-[calc(var(--anchor-width)+1.25rem)] data-disabled:pointer-events-none data-disabled:opacity-64 sm:min-h-7 sm:text-sm [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4.5 sm:[&_svg:not([class*='size-'])]:size-4",
+        indicator === "check"
+          ? "grid grid-cols-[1rem_1fr] ps-2 pe-4"
+          : "flex px-2",
         className,
       )}
       data-slot="menu-radio-item"
       {...props}
     >
-      <MenuPrimitive.RadioItemIndicator className="col-start-1">
-        <svg
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          strokeWidth="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <title>Selected</title>
-          <path d="M5.252 12.7 10.2 18.63 18.748 5.37" />
-        </svg>
-      </MenuPrimitive.RadioItemIndicator>
-      <span className="col-start-2">{children}</span>
+      {indicator === "check" ? (
+        <>
+          <MenuPrimitive.RadioItemIndicator className="col-start-1">
+            <svg
+              fill="none"
+              height="24"
+              stroke="currentColor"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth="2"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <title>Selected</title>
+              <path d="M5.252 12.7 10.2 18.63 18.748 5.37" />
+            </svg>
+          </MenuPrimitive.RadioItemIndicator>
+          <span className="col-start-2">{children}</span>
+        </>
+      ) : (
+        children
+      )}
     </MenuPrimitive.RadioItem>
   );
 }


### PR DESCRIPTION
## Proposed change

- Add a compact response-mode selector with Standard, Deep Thinking, and Fast choices backed by the organization’s configured model roles.
- Keep provider and model identifiers in the existing advanced picker while presenting task-oriented choices in the composer.
- Add a prompt-improvement action using the fast model role, with bounded output and same-language instructions.
- Protect drafts by refusing structured mention or skill content, avoiding overwrite after concurrent edits, and disabling improvement in anonymized mode.
- Localize the new controls across all supported languages.

## Validation

- API typecheck passed.
- Type-aware lint passed for the changed API and web slice.
- Formatting and i18n validation passed.
- 30 focused model-selection and route-auth tests passed.

## Checklist

- [ ] BUILD ASSURANCE | Code builds correctly and without any errors or warnings.
- [x] TESTING | Changes tested, including model resolution, route authorization, formatting, lint, and localization.
- [ ] DARK MODE SUPPORT | User can use the webapp in dark mode.
- [ ] ISSUE LINKED | Link an issue to this PR using the GitHub issue linking feature.
- [ ] SCREENSHOT INCLUDED | If relevant, include a screenshot or video of the functionality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an “Improve prompt” action for plain-text-only chat drafts.
  * Introduced a chat response mode selector (standard, deep thinking, fast) plus “exact model” selection.
  * Chat model options now expose mode-specific selections, and the UI supports pinning favourites.
* **Bug Fixes**
  * Prevented improved text from overwriting drafts changed while improving.
  * Added guards for unsupported, empty, or anonymised prompt requests.
* **Tests**
  * Added coverage for role-aware model resolution and fallbacks.
* **Translations**
  * Added localised UI labels, descriptions, and progress/availability messaging across supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->