### PR TITLE
fix(web): decouple file overlay from route matches

### DIFF
--- a/apps/web/e2e/specs/upload-docx.spec.ts
+++ b/apps/web/e2e/specs/upload-docx.spec.ts
@@ -73,7 +73,7 @@ test.describe("DOCX upload + inspector", () => {
     workspace = null;
   });
 
-  test("uploaded DOCX renders in the document view", async ({
+  test("uploaded DOCX opens from the matter with its AI overlay", async ({
     browserErrors,
     page,
     request,
@@ -97,20 +97,6 @@ test.describe("DOCX upload + inspector", () => {
     );
     expect(uploaded.entityId).toBeTruthy();
 
-    // The document view requires both entity + field URL params (see
-    // apps/web/src/routes/_protected.workspaces/$workspaceId/$viewId.document.tsx:198).
-    // Read the entity to find the file field id.
-    const entity = await readEntity(
-      request,
-      testWorkspace.id,
-      uploaded.entityId,
-    );
-    const fileField = findFileFieldForProperty(
-      entity,
-      testWorkspace.filePropertyId,
-    );
-    expect(fileField, "uploaded file field present on entity").toBeTruthy();
-
     const { cookies } = await request.storageState();
     await page.context().addCookies(cookies);
 
@@ -125,23 +111,33 @@ test.describe("DOCX upload + inspector", () => {
       )
       .toBe(200);
 
-    // Do not wait for the full load event here; the assertions below prove
-    // the route and viewer finished the work that matters for this test.
-    await page.goto(
-      `/workspaces/${testWorkspace.id}/${testWorkspace.viewId}/document?entity=${uploaded.entityId}&field=${fileField!.id}`,
-      { waitUntil: "domcontentloaded" },
-    );
+    // Exercise the user path that originally exposed the route-context race:
+    // enter the matter first, then mount the cold lazy file-chat overlay by
+    // opening the file from the table. A direct document URL does not cover
+    // this client-side transition.
+    await page.goto(`/workspaces/${testWorkspace.id}/${testWorkspace.viewId}`, {
+      waitUntil: "domcontentloaded",
+    });
 
-    // The route stays mounted (didn't redirect to /auth or the workspace
-    // index). toHaveURL retries until it matches the timeout, so we don't
-    // have to fight networkidle on a page that keeps long-poll/SSE sockets
-    // open.
-    await expect(page).toHaveURL(
-      new RegExp(
-        `/workspaces/${testWorkspace.id}/${testWorkspace.viewId}/document(\\?|$)`,
-        "u",
-      ),
-    );
+    // New matters land on their Overview view. Move through the visible Table
+    // tab before opening the uploaded file so this remains a client-side user
+    // transition instead of falling back to a direct document URL.
+    const tableTab = page.getByRole("tab", { exact: true, name: "Table" });
+    await expect(tableTab).toBeVisible({ timeout: 30_000 });
+    await tableTab.click();
+
+    const fileButton = page.getByRole("button", {
+      exact: true,
+      name: "stella-e2e.docx",
+    });
+    await expect(fileButton).toBeVisible({ timeout: 30_000 });
+    await fileButton.click();
+
+    // Prove the optional overlay itself mounted; asserting only document text
+    // would pass if its local error boundary had silently removed the overlay.
+    await expect(
+      page.getByRole("toolbar", { name: "AI message composer" }),
+    ).toBeVisible({ timeout: 45_000 });
 
     // Positive proof the viewer actually rendered: the fixture's first
     // paragraph appears in the painted layout. This catches render crashes

--- a/apps/web/src/components/ai-suggestions/file-chat-overlay.tsx
+++ b/apps/web/src/components/ai-suggestions/file-chat-overlay.tsx
@@ -21,7 +21,6 @@ import {
   useQueryClient,
   useSuspenseQuery,
 } from "@tanstack/react-query";
-import { getRouteApi } from "@tanstack/react-router";
 import { Result } from "better-result";
 import { LoaderCircleIcon } from "lucide-react";
 import { useTranslations } from "use-intl";
@@ -105,6 +104,7 @@ import { getTranslator } from "@/i18n/i18n-store";
 import { getAnalytics } from "@/lib/analytics/provider";
 import { ChatAnonymizationLayer } from "@/lib/anonymize/use-chat-anonymization-layer";
 import { api } from "@/lib/api";
+import { useAuthenticatedUser } from "@/lib/authenticated-user-context";
 import {
   getChatSendMode,
   useChatAnonymized,
@@ -865,8 +865,6 @@ type FileChatOverlayProps = {
   onNewThread: () => void;
 };
 
-const protectedRouteApi = getRouteApi("/_protected");
-
 const fallback = (
   <div
     aria-hidden="true"
@@ -954,9 +952,7 @@ const ResolvedFileChatOverlay = ({
   requestDocxEditMode,
   workspaceId,
 }: ResolvedFileChatOverlayProps) => {
-  const activeOrganizationId = protectedRouteApi.useRouteContext({
-    select: (ctx) => ctx.user.activeOrganizationId,
-  });
+  const activeOrganizationId = useAuthenticatedUser().activeOrganizationId;
   const { data: chatThreadId } = useSuspenseQuery(
     fileChatThreadOptions({
       activeOrganizationId,
@@ -1006,9 +1002,7 @@ const FileChatOverlayInner = ({
   onNewThread,
 }: FileChatOverlayInnerProps) => {
   const t = useTranslations();
-  const activeOrganizationId = protectedRouteApi.useRouteContext({
-    select: (ctx) => ctx.user.activeOrganizationId,
-  });
+  const activeOrganizationId = useAuthenticatedUser().activeOrganizationId;
   const userContext = useChatUserContext();
   const getUserContext = useLatestCallback(() => userContext);
   const threadRef = useMemo<ChatThreadRef>(

--- a/apps/web/src/components/ai-suggestions/file-viewer-with-ai.impl.tsx
+++ b/apps/web/src/components/ai-suggestions/file-viewer-with-ai.impl.tsx
@@ -14,7 +14,7 @@
  */
 
 import type { ReactNode, RefObject } from "react";
-import { startTransition, useState } from "react";
+import { startTransition } from "react";
 
 import type { DocxEditorRef } from "@stll/folio-react";
 
@@ -91,11 +91,13 @@ export type FileViewerWithAIProps = {
 type FileChatOverlayHostProps = Omit<
   FileViewerWithAIProps,
   "children" | "className"
->;
+> & {
+  onChatThreadIdChange: (threadId: ChatThreadId) => void;
+};
 
 export const FileChatOverlayHost = ({
   workspaceId,
-  chatThreadId: initialChatThreadId,
+  chatThreadId,
   activeFile,
   activeExternal,
   docxEditable,
@@ -103,11 +105,9 @@ export const FileChatOverlayHost = ({
   docxEditorRef,
   docxComments,
   onDocxCommentsChange,
+  onChatThreadIdChange,
   requestDocxEditMode,
 }: FileChatOverlayHostProps) => {
-  const [currentChatThreadId, setCurrentChatThreadId] =
-    useState(initialChatThreadId);
-
   const handleNewThread = () => {
     // The previous thread's queued/accepted/rejected suggestions
     // belong to that thread's history. Carrying them into a fresh
@@ -122,7 +122,7 @@ export const FileChatOverlayHost = ({
     // instead of unmounting back to the Suspense spinner. The fresh
     // thread snaps in atomically once its (empty) state is ready.
     startTransition(() => {
-      setCurrentChatThreadId(createChatThreadId());
+      onChatThreadIdChange(createChatThreadId());
     });
   };
 
@@ -130,7 +130,7 @@ export const FileChatOverlayHost = ({
     <FileChatOverlay
       activeExternal={activeExternal}
       activeFile={activeFile}
-      chatThreadId={currentChatThreadId}
+      chatThreadId={chatThreadId}
       docxComments={docxComments}
       docxEditable={docxEditable}
       docxEditSafety={docxEditSafety}

--- a/apps/web/src/components/ai-suggestions/file-viewer-with-ai.tsx
+++ b/apps/web/src/components/ai-suggestions/file-viewer-with-ai.tsx
@@ -1,6 +1,12 @@
-import { lazy, Suspense, useCallback } from "react";
+import { lazy, useCallback, useState } from "react";
 
+import { useTranslations } from "use-intl";
+
+import { Button } from "@stll/ui/components/button";
 import { cn } from "@stll/ui/lib/utils";
+
+import { QuerySuspenseBoundary } from "@/components/query-suspense-boundary";
+import type { ChatThreadId } from "@/lib/chat-thread-ref";
 
 import type { FileViewerWithAIProps } from "./file-viewer-with-ai.impl";
 
@@ -11,10 +17,11 @@ import type { FileViewerWithAIProps } from "./file-viewer-with-ai.impl";
 // (~490 KB gz) from being preloaded on the homepage. The wrapper just
 // keeps the file viewer mounted while the AI overlay chunk is in flight,
 // so the visible viewer never pauses or remounts for AI bytes.
-const LazyFileChatOverlayHost = lazy(async () => {
-  const m = await import("./file-viewer-with-ai.impl");
-  return { default: m.FileChatOverlayHost };
-});
+const createLazyFileChatOverlayHost = () =>
+  lazy(async () => {
+    const m = await import("./file-viewer-with-ai.impl");
+    return { default: m.FileChatOverlayHost };
+  });
 
 export const FileViewerWithAI = ({
   workspaceId,
@@ -37,6 +44,17 @@ export const FileViewerWithAI = ({
     activeFile?.fileFieldId ?? "",
     activeExternal?.url ?? "",
   ].join(":");
+  const [LazyFileChatOverlayHost, setLazyFileChatOverlayHost] = useState(
+    createLazyFileChatOverlayHost,
+  );
+  const [overlayThread, setOverlayThread] = useState<{
+    overlayKey: string;
+    threadId: ChatThreadId | undefined;
+  }>(() => ({ overlayKey, threadId: chatThreadId }));
+  const activeChatThreadId =
+    overlayThread.overlayKey === overlayKey
+      ? overlayThread.threadId
+      : chatThreadId;
 
   return (
     <div
@@ -44,22 +62,57 @@ export const FileViewerWithAI = ({
       data-file-viewer-ai="true"
     >
       {children}
-      <Suspense fallback={null}>
+      <QuerySuspenseBoundary
+        area="file-chat-overlay"
+        errorFallback={({ reset }) => (
+          <FileChatOverlayErrorFallback
+            onRetry={() => {
+              // React.lazy caches a rejected thenable. Recreate the lazy type
+              // before resetting the boundary so a transient chunk failure
+              // gets a genuinely fresh import attempt.
+              setLazyFileChatOverlayHost(() => createLazyFileChatOverlayHost());
+              reset();
+            }}
+          />
+        )}
+        resetKeys={[overlayKey]}
+        suspenseFallback={null}
+      >
         <LazyFileChatOverlayHost
           activeExternal={activeExternal}
           activeFile={activeFile}
-          chatThreadId={chatThreadId}
+          chatThreadId={activeChatThreadId}
           docxComments={docxComments}
           docxEditable={docxEditable}
           docxEditSafety={docxEditSafety}
           docxEditorRef={docxEditorRef}
           key={overlayKey}
+          onChatThreadIdChange={(threadId) => {
+            setOverlayThread({ overlayKey, threadId });
+          }}
           onDocxCommentsChange={onDocxCommentsChange}
           requestDocxEditMode={requestDocxEditMode}
           workspaceId={workspaceId}
         />
-      </Suspense>
+      </QuerySuspenseBoundary>
       {docxEditorRef !== undefined && <DocxHorizontalScrollbar />}
+    </div>
+  );
+};
+
+const FileChatOverlayErrorFallback = ({ onRetry }: { onRetry: () => void }) => {
+  const t = useTranslations();
+
+  return (
+    <div className="pointer-events-none absolute inset-x-0 bottom-4 z-10 flex justify-center px-4">
+      <div className="bg-background/95 pointer-events-auto flex items-center gap-3 rounded-md border px-3 py-2 shadow-sm">
+        <span className="text-muted-foreground text-sm">
+          {t("common.somethingWentWrong")}
+        </span>
+        <Button onClick={onRetry} size="sm" variant="outline">
+          {t("common.tryAgain")}
+        </Button>
+      </div>
     </div>
   );
 };

--- a/apps/web/src/components/ai-suggestions/review-panel.impl.tsx
+++ b/apps/web/src/components/ai-suggestions/review-panel.impl.tsx
@@ -9,7 +9,6 @@ import { useRef, useState } from "react";
 import type { CSSProperties, RefObject } from "react";
 
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { useRouteContext } from "@tanstack/react-router";
 import { panic } from "better-result";
 import {
   ArrowRightIcon,
@@ -65,6 +64,7 @@ import {
 import { useExternalSyncEffect } from "@/hooks/use-effect";
 import { useFormatter, useLocale } from "@/i18n/formatting-context";
 import { authClient } from "@/lib/auth";
+import { useAuthenticatedUser } from "@/lib/authenticated-user-context";
 import { compareByLocale } from "@/lib/collation";
 import { detached } from "@/lib/detached";
 import { toAuthClientError } from "@/lib/errors/auth";
@@ -191,14 +191,7 @@ export const ReviewPanelImpl = ({
   // (preferredName / wordEditShortcut). The popover next to
   // "Tracked changes" exposes them read-only with a deep link to
   // account settings — single source of truth, no in-panel state.
-  const user = useRouteContext({
-    from: "/_protected",
-    select: (ctx) => ({
-      name: ctx.user.name ?? null,
-      preferredName: ctx.user.preferredName ?? null,
-      wordEditShortcut: ctx.user.wordEditShortcut ?? null,
-    }),
-  });
+  const user = useAuthenticatedUser();
   const wordAuthor = getWordEditAuthorName(user);
   const wordShortcut =
     getWordEditShortcut(user) || computeInitialsFrom(wordAuthor);

--- a/apps/web/src/components/ai-suggestions/use-review-actions.ts
+++ b/apps/web/src/components/ai-suggestions/use-review-actions.ts
@@ -10,7 +10,6 @@
 
 import type { RefObject } from "react";
 
-import { useRouteContext } from "@tanstack/react-router";
 import { useTranslations } from "use-intl";
 
 import type { DocxEditorRef, FolioAIEditApplyMode } from "@stll/folio-react";
@@ -33,6 +32,7 @@ import type {
 import { getWordEditAuthorName } from "@/features/chat/hooks/use-chat-user-context";
 import { useLatestCallback } from "@/hooks/use-latest-callback";
 import { getAnalytics } from "@/lib/analytics/provider";
+import { useAuthenticatedUser } from "@/lib/authenticated-user-context";
 import { detached } from "@/lib/detached";
 
 const DOCUMENT_OPERATION_CONTRACT_VERSION = 1 as const;
@@ -115,15 +115,8 @@ export const useReviewActions = ({
   // Author the tracked-change marks as the user (their preferred name
   // from account settings): they are accepting the AI's suggestion AS
   // THEMSELVES, not as "AI".
-  const wordAuthor = useRouteContext({
-    from: "/_protected",
-    select: (ctx) =>
-      getWordEditAuthorName({
-        name: ctx.user.name ?? null,
-        preferredName: ctx.user.preferredName ?? null,
-        wordEditShortcut: ctx.user.wordEditShortcut ?? null,
-      }),
-  });
+  const user = useAuthenticatedUser();
+  const wordAuthor = getWordEditAuthorName(user);
 
   const setApplyMode = useLatestCallback((mode: FolioAIEditApplyMode) => {
     setApplyModeAction(entityId, mode);

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -1038,6 +1038,57 @@ export default defineConfig({
       },
     },
     {
+      // AI suggestion surfaces are shared lazy components. They can render
+      // while the router is activating a match, so user data must come from
+      // AuthenticatedUserProvider rather than a route-match store.
+      files: ["apps/web/src/components/ai-suggestions/**/*.{ts,tsx}"],
+      rules: {
+        "no-restricted-imports": [
+          "error",
+          {
+            paths: [
+              {
+                name: "zod",
+                message: "Use 'valibot' instead of 'zod'.",
+              },
+              {
+                name: "@tanstack/react-router",
+                importNames: ["getRouteApi", "useRouteContext"],
+                message:
+                  "Shared AI suggestion components must read authenticated user data from '@/lib/authenticated-user-context', not an active route match.",
+              },
+            ],
+            patterns: [
+              {
+                group: ["@/api/*", "@/api/**/*"],
+                message: "Use '@stll/api/types' instead of '@/api/'.",
+              },
+              {
+                group: ["@stll/api", "@stll/api/**", "!@stll/api/types"],
+                message:
+                  "apps/web may only import the public '@stll/api/types' surface.",
+              },
+              {
+                group: [
+                  "@stll/desktop",
+                  "@stll/desktop/**",
+                  "@stll/landing",
+                  "@stll/landing/**",
+                ],
+                message:
+                  "apps/web must not import other app workspaces directly.",
+              },
+              {
+                group: ["@stll/ui/components/date-picker-popover"],
+                message:
+                  "Use '@/components/date-picker-popover' so locale labels are injected.",
+              },
+            ],
+          },
+        ],
+      },
+    },
+    {
       files: [
         "apps/web/src/routes/law/**/*.{ts,tsx}",
         "apps/web/src/features/case-law/**/*.{ts,tsx}",


### PR DESCRIPTION
## Summary

- read authenticated user and organization data from `AuthenticatedUserProvider` in shared AI suggestion surfaces instead of requiring an active `/_protected` route match
- contain lazy file-chat overlay failures so the underlying document viewer stays mounted
- forbid route-context access in shared AI suggestion modules and cover the cold matter-to-DOCX interaction in Playwright

## Root cause

The lazy file-chat overlay resumed through a shared component that called `useRouteContext` for `/_protected`. TanStack Router throws when that route match store is unavailable, and the error previously propagated to the matter route boundary.

## Validation

- pre-commit formatting, lint, and secret checks
- repository-wide format check
- 28 focused AI suggestion unit tests
- targeted type-aware lint and web/e2e type checking

The Playwright regression requires the local application stack and seeded browser state, so CI is its first browser execution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * DOCX files can now be opened directly from the workspace after upload.
  * The AI message composer is available when viewing an uploaded DOCX.

* **Bug Fixes**
  * Improved AI suggestions and document review behaviour by consistently using the signed-in user’s details.
  * Improved reliability when loading the AI overlay during document transitions.

* **Tests**
  * Expanded end-to-end coverage for the DOCX upload, opening, inspection and AI composer workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->