### PR TITLE
perf: replace global search offset pagination

### DIFF
--- a/apps/api/src/handlers/search/search.test.ts
+++ b/apps/api/src/handlers/search/search.test.ts
@@ -138,6 +138,27 @@ describe("search handler workspace scoping", () => {
     expect(searchMock).not.toHaveBeenCalled();
   });
 
+  test("rejects an incompatible cursor instead of restarting pagination", async () => {
+    const result = await searchHandler({
+      accessibleWorkspaceIds,
+      body: {
+        ...emptySearchFilters(),
+        cursor: "not-a-search-cursor",
+        query: "closing memo",
+      },
+      organizationId,
+      userId,
+      search: searchMock,
+      scopedDb: unusedScopedDb,
+    });
+
+    expect(result).toMatchObject({
+      code: 400,
+      response: { message: "Invalid cursor" },
+    });
+    expect(searchMock).not.toHaveBeenCalled();
+  });
+
   test("runs a blank query when an entity-kind filter is selected", async () => {
     await searchHandler({
       accessibleWorkspaceIds,

--- a/apps/api/src/handlers/search/search.ts
+++ b/apps/api/src/handlers/search/search.ts
@@ -8,6 +8,7 @@ import type { SafeId } from "@/api/lib/branded-types";
 import { tSafeId, tUserId } from "@/api/lib/custom-schema";
 import { LIMITS } from "@/api/lib/limits";
 import { searchGlobal } from "@/api/lib/search/index-global";
+import { parseGlobalSearchCursor } from "@/api/lib/search/pagination";
 import { GLOBAL_SEARCH_RESULT_TYPES } from "@/api/lib/search/types";
 
 const isoDateTime = t.String({ format: "date-time" });
@@ -147,6 +148,10 @@ export const searchHandler = async ({
     return status(400, {
       message: "Provide a search query or at least one filter",
     });
+  }
+
+  if (parseGlobalSearchCursor(body.cursor).type === "invalid") {
+    return status(400, { message: "Invalid cursor" });
   }
 
   const resolved = await resolveSelectedWorkspaceIds({

--- a/apps/api/src/lib/search/cursor.test.ts
+++ b/apps/api/src/lib/search/cursor.test.ts
@@ -28,11 +28,8 @@ describe("search cursor encoding", () => {
 });
 
 describe("search cursor encoding — properties", () => {
-  // The decoder splits on ":" and takes only the first two parts, so ids containing ":"
-  // cannot round-trip. -0 is excluded because String(-0) === "0" loses the sign.
-  const arbId = fc
-    .string({ minLength: 1, maxLength: 32 })
-    .filter((s) => !s.includes(":"));
+  // -0 is excluded because String(-0) === "0" loses the sign.
+  const arbId = fc.string({ minLength: 1, maxLength: 32 });
   const arbScore = fc
     .double({ noNaN: true, noDefaultInfinity: true })
     .filter((n) => !Object.is(n, -0));

--- a/apps/api/src/lib/search/cursor.test.ts
+++ b/apps/api/src/lib/search/cursor.test.ts
@@ -28,8 +28,8 @@ describe("search cursor encoding", () => {
 });
 
 describe("search cursor encoding — properties", () => {
-  // -0 is excluded because String(-0) === "0" loses the sign.
   const arbId = fc.string({ minLength: 1, maxLength: 32 });
+  // -0 is excluded because String(-0) === "0" loses the sign.
   const arbScore = fc
     .double({ noNaN: true, noDefaultInfinity: true })
     .filter((n) => !Object.is(n, -0));

--- a/apps/api/src/lib/search/cursor.ts
+++ b/apps/api/src/lib/search/cursor.ts
@@ -7,7 +7,13 @@ export const decodeCursor = (
   cursor: string,
 ): { score: number; id: string } | null => {
   const decoded = Buffer.from(cursor, "base64").toString();
-  const [scoreStr, id] = decoded.split(":");
+  const separatorIndex = decoded.indexOf(":");
+  if (separatorIndex < 0) {
+    return null;
+  }
+
+  const scoreStr = decoded.slice(0, separatorIndex);
+  const id = decoded.slice(separatorIndex + 1);
   const score = Number(scoreStr);
   if (!Number.isFinite(score) || !id) {
     return null;

--- a/apps/api/src/lib/search/cursor.ts
+++ b/apps/api/src/lib/search/cursor.ts
@@ -8,7 +8,7 @@ export const decodeCursor = (
 ): { score: number; id: string } | null => {
   const decoded = Buffer.from(cursor, "base64").toString();
   const separatorIndex = decoded.indexOf(":");
-  if (separatorIndex < 0) {
+  if (separatorIndex === -1) {
     return null;
   }
 

--- a/apps/api/src/lib/search/index-global.test.ts
+++ b/apps/api/src/lib/search/index-global.test.ts
@@ -4,9 +4,12 @@ import { PgDialect } from "drizzle-orm/pg-core";
 import { toSafeId } from "@/api/lib/branded-types";
 import { chatThreadScopeSql } from "@/api/lib/search/chat-thread-scope-sql";
 import { contactWorkspaceAccessSql } from "@/api/lib/search/contact-workspace-access-sql";
-import { encodeCursor } from "@/api/lib/search/cursor";
 import { mapEntityHit } from "@/api/lib/search/global-search-mappers";
 import { searchGlobal } from "@/api/lib/search/index-global";
+import {
+  decodeGlobalSearchCursor,
+  encodeGlobalSearchCursor,
+} from "@/api/lib/search/pagination";
 import {
   clearRootDbMocks,
   rootDbExecuteMock,
@@ -169,44 +172,72 @@ describe("global search SQL scope", () => {
 
   test("applies the score/id cursor and bounded lookahead to every source", async () => {
     const sourceCases = [
-      { type: "document", idSql: "'entity:' || sd.entity_id::text" },
-      { type: "matter", idSql: "'matter:' || wsd.workspace_id::text" },
-      { type: "contact", idSql: "'contact:' || csd.contact_id::text" },
       {
-        type: "case-law",
+        tableSql: "FROM search_documents sd",
+        idSql: "'entity:' || sd.entity_id::text",
+      },
+      {
+        tableSql: "FROM workspace_search_documents wsd",
+        idSql: "'matter:' || wsd.workspace_id::text",
+      },
+      {
+        tableSql: "FROM contact_search_documents csd",
+        idSql: "'contact:' || csd.contact_id::text",
+      },
+      {
+        tableSql: "FROM case_law_search_documents clsd",
         idSql: "'case-law:' || clsd.decision_id::text",
       },
-      { type: "chat", idSql: "'chat:' || cst.thread_id::text" },
+      {
+        tableSql: "FROM chat_thread_search_documents cst",
+        idSql: "'chat:' || cst.thread_id::text",
+      },
     ] as const;
     const dialect = new PgDialect();
 
-    for (const source of sourceCases) {
-      clearRootDbMocks();
-      await searchGlobal({
-        query: "contract",
-        organizationId: toSafeId<"organization">("org_1"),
-        userId: toSafeId<"user">("user_1"),
-        accessibleWorkspaceIds: [toSafeId<"workspace">("ws_1")],
-        selectedWorkspaceIds: [],
-        types: [source.type],
-        editedByUserIds: [],
-        mimeTypes: [],
-        updatedTo: "2026-07-29T08:00:00.000Z",
-        cursor: encodeCursor(0.75, "entity:boundary"),
-        limit: 3,
-      });
+    await searchGlobal({
+      query: "contract",
+      organizationId: toSafeId<"organization">("org_1"),
+      userId: toSafeId<"user">("user_1"),
+      accessibleWorkspaceIds: [toSafeId<"workspace">("ws_1")],
+      selectedWorkspaceIds: [],
+      types: [],
+      editedByUserIds: [],
+      mimeTypes: [],
+      updatedTo: "2026-07-29T08:00:00.000Z",
+      cursor: encodeGlobalSearchCursor({
+        score: 0.75,
+        id: "entity:boundary",
+        seen: 3,
+      }),
+      limit: 3,
+    });
 
-      expect(rootDbExecuteMock).toHaveBeenCalledTimes(1);
-      const query = rootDbExecuteMock.mock.calls.at(0)?.at(0);
-      if (query === undefined) {
-        throw new Error(`Missing ${source.type} search query`);
+    expect(rootDbExecuteMock).toHaveBeenCalledTimes(5);
+    const compiledQueries = rootDbExecuteMock.mock.calls.map(([query]) =>
+      dialect.sqlToQuery(query),
+    );
+    const sourceQueries = sourceCases.map((source) => {
+      const compiled = compiledQueries.find(({ sql }) =>
+        sql.includes(source.tableSql),
+      );
+      if (compiled === undefined) {
+        throw new Error(`Missing query for ${source.tableSql}`);
       }
-      const compiled = dialect.sqlToQuery(query);
+      return { source, compiled };
+    });
+
+    for (const { source, compiled } of sourceQueries) {
       expect(compiled.sql).toContain(source.idSql);
       expect(compiled.sql).toContain('COLLATE "C" <');
       expect(compiled.params).toContain(0.75);
       expect(compiled.params.at(-1)).toBe(4);
     }
+
+    const matterQuery = sourceQueries.at(1)?.compiled;
+    expect(matterQuery?.params.filter((param) => param === 0.15)).toHaveLength(
+      3,
+    );
   });
 
   test("uses updated time as the keyset value for empty-query search", async () => {
@@ -222,7 +253,11 @@ describe("global search SQL scope", () => {
       types: ["document"],
       editedByUserIds: [],
       mimeTypes: [],
-      cursor: encodeCursor(cursorValue, "entity:boundary"),
+      cursor: encodeGlobalSearchCursor({
+        score: cursorValue,
+        id: "entity:boundary",
+        seen: 3,
+      }),
       limit: 3,
     });
 
@@ -238,5 +273,60 @@ describe("global search SQL scope", () => {
     expect(compiled.sql).not.toContain("sd.tsv @@");
     expect(compiled.params).toContain(cursorValue);
     expect(compiled.params.at(-1)).toBe(4);
+  });
+
+  test("preserves the SQL timestamp score in filter-only cursors", async () => {
+    const dialect = new PgDialect();
+    const preciseScore = Date.parse("2026-07-29T08:00:00.999Z") + 0.5;
+    rootDbExecuteMock.mockImplementation(async (query) => {
+      const compiled = dialect.sqlToQuery(query);
+      if (
+        compiled.sql.includes("FROM search_documents sd") &&
+        compiled.sql.includes("JOIN workspaces w")
+      ) {
+        return [
+          {
+            id: "entity_1",
+            workspace_id: "ws_1",
+            workspace_name: "Matter",
+            type: "document",
+            title: "First",
+            headline: null,
+            score: preciseScore,
+            updated_at: new Date("2026-07-29T08:00:00.999Z"),
+          },
+          {
+            id: "entity_2",
+            workspace_id: "ws_1",
+            workspace_name: "Matter",
+            type: "document",
+            title: "Second",
+            headline: null,
+            score: preciseScore - 0.4,
+            updated_at: new Date("2026-07-29T08:00:00.999Z"),
+          },
+        ];
+      }
+      return [];
+    });
+
+    const result = await searchGlobal({
+      query: "",
+      organizationId: toSafeId<"organization">("org_1"),
+      userId: toSafeId<"user">("user_1"),
+      accessibleWorkspaceIds: [toSafeId<"workspace">("ws_1")],
+      selectedWorkspaceIds: [],
+      types: ["document"],
+      editedByUserIds: [],
+      mimeTypes: [],
+      limit: 1,
+    });
+
+    expect(result.hits.map(({ id }) => id)).toEqual(["entity:entity_1"]);
+    expect(decodeGlobalSearchCursor(result.nextCursor ?? undefined)).toEqual({
+      score: preciseScore,
+      id: "entity:entity_1",
+      seen: 1,
+    });
   });
 });

--- a/apps/api/src/lib/search/index-global.test.ts
+++ b/apps/api/src/lib/search/index-global.test.ts
@@ -4,6 +4,7 @@ import { PgDialect } from "drizzle-orm/pg-core";
 import { toSafeId } from "@/api/lib/branded-types";
 import { chatThreadScopeSql } from "@/api/lib/search/chat-thread-scope-sql";
 import { contactWorkspaceAccessSql } from "@/api/lib/search/contact-workspace-access-sql";
+import { encodeCursor } from "@/api/lib/search/cursor";
 import { mapEntityHit } from "@/api/lib/search/global-search-mappers";
 import { searchGlobal } from "@/api/lib/search/index-global";
 import {
@@ -235,9 +236,35 @@ describe("global search SQL scope", () => {
     }
 
     const matterQuery = sourceQueries.at(1)?.compiled;
+    // One boost parameter is in the selected score; each cursor OR branch
+    // repeats that same score expression for the keyset boundary.
     expect(matterQuery?.params.filter((param) => param === 0.15)).toHaveLength(
       3,
     );
+  });
+
+  test("continues legacy offset cursors during a rolling deployment", async () => {
+    const dialect = new PgDialect();
+
+    await searchGlobal({
+      query: "contract",
+      organizationId: toSafeId<"organization">("org_1"),
+      userId: toSafeId<"user">("user_1"),
+      accessibleWorkspaceIds: [toSafeId<"workspace">("ws_1")],
+      selectedWorkspaceIds: [],
+      types: [],
+      editedByUserIds: [],
+      mimeTypes: [],
+      cursor: encodeCursor(25, "global"),
+      limit: 3,
+    });
+
+    expect(rootDbExecuteMock).toHaveBeenCalledTimes(5);
+    for (const [query] of rootDbExecuteMock.mock.calls) {
+      const compiled = dialect.sqlToQuery(query);
+      expect(compiled.sql).not.toContain('COLLATE "C" <');
+      expect(compiled.params.at(-1)).toBe(29);
+    }
   });
 
   test("uses updated time as the keyset value for empty-query search", async () => {

--- a/apps/api/src/lib/search/index-global.test.ts
+++ b/apps/api/src/lib/search/index-global.test.ts
@@ -4,6 +4,7 @@ import { PgDialect } from "drizzle-orm/pg-core";
 import { toSafeId } from "@/api/lib/branded-types";
 import { chatThreadScopeSql } from "@/api/lib/search/chat-thread-scope-sql";
 import { contactWorkspaceAccessSql } from "@/api/lib/search/contact-workspace-access-sql";
+import { encodeCursor } from "@/api/lib/search/cursor";
 import { mapEntityHit } from "@/api/lib/search/global-search-mappers";
 import { searchGlobal } from "@/api/lib/search/index-global";
 import {
@@ -164,5 +165,78 @@ describe("global search SQL scope", () => {
       lastEditedByName: "Clara Novak",
       lastEditedByImage: "https://example.test/clara.png",
     });
+  });
+
+  test("applies the score/id cursor and bounded lookahead to every source", async () => {
+    const sourceCases = [
+      { type: "document", idSql: "'entity:' || sd.entity_id::text" },
+      { type: "matter", idSql: "'matter:' || wsd.workspace_id::text" },
+      { type: "contact", idSql: "'contact:' || csd.contact_id::text" },
+      {
+        type: "case-law",
+        idSql: "'case-law:' || clsd.decision_id::text",
+      },
+      { type: "chat", idSql: "'chat:' || cst.thread_id::text" },
+    ] as const;
+    const dialect = new PgDialect();
+
+    for (const source of sourceCases) {
+      clearRootDbMocks();
+      await searchGlobal({
+        query: "contract",
+        organizationId: toSafeId<"organization">("org_1"),
+        userId: toSafeId<"user">("user_1"),
+        accessibleWorkspaceIds: [toSafeId<"workspace">("ws_1")],
+        selectedWorkspaceIds: [],
+        types: [source.type],
+        editedByUserIds: [],
+        mimeTypes: [],
+        updatedTo: "2026-07-29T08:00:00.000Z",
+        cursor: encodeCursor(0.75, "entity:boundary"),
+        limit: 3,
+      });
+
+      expect(rootDbExecuteMock).toHaveBeenCalledTimes(1);
+      const query = rootDbExecuteMock.mock.calls.at(0)?.at(0);
+      if (query === undefined) {
+        throw new Error(`Missing ${source.type} search query`);
+      }
+      const compiled = dialect.sqlToQuery(query);
+      expect(compiled.sql).toContain(source.idSql);
+      expect(compiled.sql).toContain('COLLATE "C" <');
+      expect(compiled.params).toContain(0.75);
+      expect(compiled.params.at(-1)).toBe(4);
+    }
+  });
+
+  test("uses updated time as the keyset value for empty-query search", async () => {
+    const cursorValue = Date.parse("2026-07-29T08:00:00.000Z");
+    const dialect = new PgDialect();
+
+    await searchGlobal({
+      query: "",
+      organizationId: toSafeId<"organization">("org_1"),
+      userId: toSafeId<"user">("user_1"),
+      accessibleWorkspaceIds: [toSafeId<"workspace">("ws_1")],
+      selectedWorkspaceIds: [],
+      types: ["document"],
+      editedByUserIds: [],
+      mimeTypes: [],
+      cursor: encodeCursor(cursorValue, "entity:boundary"),
+      limit: 3,
+    });
+
+    expect(rootDbExecuteMock).toHaveBeenCalledTimes(1);
+    const query = rootDbExecuteMock.mock.calls.at(0)?.at(0);
+    if (query === undefined) {
+      throw new Error("Missing empty-query document search query");
+    }
+    const compiled = dialect.sqlToQuery(query);
+    expect(compiled.sql).toContain(
+      "extract(epoch from sd.updated_at)::float8 * 1000",
+    );
+    expect(compiled.sql).not.toContain("sd.tsv @@");
+    expect(compiled.params).toContain(cursorValue);
+    expect(compiled.params.at(-1)).toBe(4);
   });
 });

--- a/apps/api/src/lib/search/index-global.ts
+++ b/apps/api/src/lib/search/index-global.ts
@@ -18,15 +18,16 @@ import {
   searchDocumentsAccessSql,
   workspaceSearchDocumentsAccessSql,
 } from "@/api/lib/search/contact-workspace-access-sql";
-import { decodeCursor } from "@/api/lib/search/cursor";
 import { mapEntityHit } from "@/api/lib/search/global-search-mappers";
 import {
   escapeAndHighlight,
   TS_HEADLINE_CONFIG,
 } from "@/api/lib/search/highlight";
 import {
-  GLOBAL_SEARCH_MAX_OFFSET,
-  resolveGlobalSearchNextCursor,
+  compareScoredSearchHits,
+  decodeGlobalSearchCursor,
+  globalSearchCursorSql,
+  paginateScoredSearchHits,
 } from "@/api/lib/search/pagination";
 import {
   buildSearchPreviewPassages,
@@ -47,6 +48,7 @@ import type {
 const REINDEX_BATCH_SIZE = 100;
 const WORKSPACE_REINDEX_CONCURRENCY = 4;
 const GLOBAL_SEARCH_FACET_LIMIT = 20;
+const GLOBAL_SEARCH_COUNT_LIMIT = 1000;
 
 type RawRow = Record<string, unknown>;
 type CountRow = { total?: unknown };
@@ -239,7 +241,7 @@ const mapMatterHit = (row: RawRow): ScoredGlobalSearchHit => {
     color: toNullableString(row["color"]),
   };
 
-  return { hit, score: Number(row["score"]) + 0.15 };
+  return { hit, score: Number(row["score"]) };
 };
 
 const mapContactHit = (row: RawRow): ScoredGlobalSearchHit => {
@@ -366,18 +368,6 @@ const toMimeTypeFacetMap = (
   return map;
 };
 
-const globalSearchOffset = (cursor: string | undefined): number => {
-  const parsedCursor = cursor ? decodeCursor(cursor) : null;
-  if (parsedCursor?.id !== "global") {
-    return 0;
-  }
-
-  return Math.max(
-    0,
-    Math.min(GLOBAL_SEARCH_MAX_OFFSET, Math.floor(parsedCursor.score)),
-  );
-};
-
 type FilterFragmentInput = {
   query: string;
   types: readonly GlobalSearchResultType[];
@@ -473,6 +463,16 @@ const buildSearchFilterFragments = ({
     hasSearchQuery
       ? sql`ts_rank(${tsv}, ${tsQuery})::float8 AS score`
       : sql`0::float8 AS score`;
+  const searchCursorValue = ({
+    tsv,
+    updatedAt,
+  }: {
+    tsv: SQL;
+    updatedAt: SQL;
+  }): SQL =>
+    hasSearchQuery
+      ? sql`ts_rank(${tsv}, ${tsQuery})::float8`
+      : sql`extract(epoch from ${updatedAt})::float8 * 1000`;
   const searchOrderBy = ({
     id,
     updatedAt,
@@ -512,6 +512,7 @@ const buildSearchFilterFragments = ({
     chatTextSearchFilter,
     searchHeadline,
     searchScore,
+    searchCursorValue,
     searchOrderBy,
     hasSearchQuery,
     entityTypeFilter,
@@ -533,12 +534,12 @@ export const searchGlobal = async ({
   cursor,
   limit,
 }: GlobalSearchQuery): Promise<GlobalSearchResult> => {
-  const offset = globalSearchOffset(cursor);
-  const fetchLimit = offset + limit;
+  const searchCursor = decodeGlobalSearchCursor(cursor);
+  const fetchLimit = limit + 1;
   // Counts and facets are computed only on the first page. Subsequent
   // pages reuse the values the client already has, saving ~7 of the
   // 15 SQL round-trips per request.
-  const isFirstPage = offset === 0;
+  const isFirstPage = searchCursor === null;
   const {
     selected,
     restrictToEntities,
@@ -556,6 +557,7 @@ export const searchGlobal = async ({
     chatTextSearchFilter,
     searchHeadline,
     searchScore,
+    searchCursorValue,
     searchOrderBy,
     hasSearchQuery,
     entityTypeFilter,
@@ -618,6 +620,14 @@ export const searchGlobal = async ({
         ${entityUpdatedFilter}
         ${entityTextSearchFilter}
         ${entityWorkspaceFilter}
+        ${globalSearchCursorSql({
+          cursor: searchCursor,
+          score: searchCursorValue({
+            tsv: sql`sd.tsv`,
+            updatedAt: sql`sd.updated_at`,
+          }),
+          id: sql`'entity:' || sd.entity_id::text`,
+        })}
       ORDER BY ${searchOrderBy({ id: sql`sd.entity_id`, updatedAt: sql`sd.updated_at` })}
       LIMIT ${fetchLimit}
     `),
@@ -640,6 +650,14 @@ export const searchGlobal = async ({
         ${matterUpdatedFilter}
         ${matterTextSearchFilter}
         ${matterWorkspaceFilter}
+        ${globalSearchCursorSql({
+          cursor: searchCursor,
+          score: searchCursorValue({
+            tsv: sql`wsd.tsv`,
+            updatedAt: sql`wsd.updated_at`,
+          }),
+          id: sql`'matter:' || wsd.workspace_id::text`,
+        })}
       ORDER BY ${searchOrderBy({ id: sql`wsd.workspace_id`, updatedAt: sql`wsd.updated_at` })}
       LIMIT ${fetchLimit}
     `),
@@ -663,6 +681,14 @@ export const searchGlobal = async ({
         ${contactUpdatedFilter}
         ${contactTextSearchFilter}
         ${contactWorkspaceFilter}
+        ${globalSearchCursorSql({
+          cursor: searchCursor,
+          score: searchCursorValue({
+            tsv: sql`csd.tsv`,
+            updatedAt: sql`csd.updated_at`,
+          }),
+          id: sql`'contact:' || csd.contact_id::text`,
+        })}
       ORDER BY ${searchOrderBy({ id: sql`csd.contact_id`, updatedAt: sql`csd.updated_at` })}
       LIMIT ${fetchLimit}
     `),
@@ -688,6 +714,14 @@ export const searchGlobal = async ({
       WHERE TRUE
         ${caseLawTextSearchFilter}
         ${caseLawUpdatedFilter}
+        ${globalSearchCursorSql({
+          cursor: searchCursor,
+          score: searchCursorValue({
+            tsv: sql`clsd.tsv`,
+            updatedAt: sql`d.updated_at`,
+          }),
+          id: sql`'case-law:' || clsd.decision_id::text`,
+        })}
       ORDER BY ${searchOrderBy({ id: sql`clsd.decision_id`, updatedAt: sql`d.updated_at` })}
       LIMIT ${fetchLimit}
     `),
@@ -719,6 +753,14 @@ export const searchGlobal = async ({
         ${chatUpdatedFilter}
         ${chatTextSearchFilter}
         AND ${chatScope}
+        ${globalSearchCursorSql({
+          cursor: searchCursor,
+          score: searchCursorValue({
+            tsv: sql`cst.tsv`,
+            updatedAt: sql`t.updated_at`,
+          }),
+          id: sql`'chat:' || cst.thread_id::text`,
+        })}
       ORDER BY ${searchOrderBy({ id: sql`t.id`, updatedAt: sql`t.updated_at` })}
       LIMIT ${fetchLimit}
     `),
@@ -736,7 +778,7 @@ export const searchGlobal = async ({
       WHERE TRUE
         ${caseLawTextSearchFilter}
         ${caseLawUpdatedFilter}
-      LIMIT ${GLOBAL_SEARCH_MAX_OFFSET}
+      LIMIT ${GLOBAL_SEARCH_COUNT_LIMIT}
     ) bounded_case_law
   `;
 
@@ -1033,12 +1075,16 @@ export const searchGlobal = async ({
     // hit.id tiebreak for deterministic ranking, not display text
   ].sort((a, b) =>
     hasSearchQuery
-      ? b.score - a.score || compareCodepoint(b.hit.id, a.hit.id)
+      ? compareScoredSearchHits(a, b)
       : compareCodepoint(b.hit.updatedAt, a.hit.updatedAt) ||
         compareCodepoint(b.hit.id, a.hit.id),
   );
 
-  const hits = scoredHits.slice(offset, offset + limit).map(({ hit }) => hit);
+  const paginationHits = scoredHits.map(({ hit, score }) => ({
+    hit,
+    score: hasSearchQuery ? score : new Date(hit.updatedAt).getTime(),
+  }));
+  const page = paginateScoredSearchHits(paginationHits, limit);
   const totalEntities = totalFrom(entityCount);
   const totalMatters = totalFrom(matterCount);
   const totalContacts = totalFrom(contactCount);
@@ -1081,7 +1127,7 @@ export const searchGlobal = async ({
   const mimeTypeFacetMap = toMimeTypeFacetMap(mimeTypeFacetRows);
 
   return {
-    hits,
+    hits: page.items,
     facets: {
       type: facetBuckets(typeFacetMap),
       workspace: facetBuckets(workspaceFacetMap),
@@ -1089,15 +1135,7 @@ export const searchGlobal = async ({
       mimeType: facetBuckets(mimeTypeFacetMap),
     },
     totalCount,
-    nextCursor: resolveGlobalSearchNextCursor({
-      limit,
-      offset,
-      // Counts are skipped on paginated requests; signal with `null`
-      // so the cursor decision falls back to the hit count instead of
-      // misreading a zeroed total as "no more results".
-      totalCount: isFirstPage ? totalCount : null,
-      hitsLength: hits.length,
-    }),
+    nextCursor: page.nextCursor,
   };
 };
 

--- a/apps/api/src/lib/search/index-global.ts
+++ b/apps/api/src/lib/search/index-global.ts
@@ -26,6 +26,7 @@ import {
 import {
   compareScoredSearchHits,
   decodeGlobalSearchCursor,
+  GLOBAL_SEARCH_RESULT_LIMIT,
   globalSearchCursorSql,
   paginateScoredSearchHits,
 } from "@/api/lib/search/pagination";
@@ -48,7 +49,7 @@ import type {
 const REINDEX_BATCH_SIZE = 100;
 const WORKSPACE_REINDEX_CONCURRENCY = 4;
 const GLOBAL_SEARCH_FACET_LIMIT = 20;
-const GLOBAL_SEARCH_COUNT_LIMIT = 1000;
+const MATTER_RELEVANCE_BOOST = 0.15;
 
 type RawRow = Record<string, unknown>;
 type CountRow = { total?: unknown };
@@ -459,20 +460,28 @@ const buildSearchFilterFragments = ({
           ${TS_HEADLINE_CONFIG}
         ) AS headline`
       : sql`NULL::text AS headline`;
-  const searchScore = (tsv: SQL): SQL =>
-    hasSearchQuery
-      ? sql`ts_rank(${tsv}, ${tsQuery})::float8 AS score`
-      : sql`0::float8 AS score`;
-  const searchCursorValue = ({
+  const searchScoreValue = ({
     tsv,
     updatedAt,
+    relevanceBoost,
   }: {
     tsv: SQL;
     updatedAt: SQL;
-  }): SQL =>
-    hasSearchQuery
-      ? sql`ts_rank(${tsv}, ${tsQuery})::float8`
-      : sql`extract(epoch from ${updatedAt})::float8 * 1000`;
+    relevanceBoost?: number | undefined;
+  }): SQL => {
+    if (!hasSearchQuery) {
+      return sql`extract(epoch from ${updatedAt})::float8 * 1000`;
+    }
+    if (relevanceBoost === undefined) {
+      return sql`ts_rank(${tsv}, ${tsQuery})::float8`;
+    }
+    return sql`ts_rank(${tsv}, ${tsQuery})::float8 + ${relevanceBoost}::float8`;
+  };
+  const searchScore = (options: {
+    tsv: SQL;
+    updatedAt: SQL;
+    relevanceBoost?: number | undefined;
+  }): SQL => sql`${searchScoreValue(options)} AS score`;
   const searchOrderBy = ({
     id,
     updatedAt,
@@ -512,7 +521,7 @@ const buildSearchFilterFragments = ({
     chatTextSearchFilter,
     searchHeadline,
     searchScore,
-    searchCursorValue,
+    searchScoreValue,
     searchOrderBy,
     hasSearchQuery,
     entityTypeFilter,
@@ -535,7 +544,9 @@ export const searchGlobal = async ({
   limit,
 }: GlobalSearchQuery): Promise<GlobalSearchResult> => {
   const searchCursor = decodeGlobalSearchCursor(cursor);
-  const fetchLimit = limit + 1;
+  const seen = searchCursor?.seen ?? 0;
+  const pageLimit = Math.min(limit, GLOBAL_SEARCH_RESULT_LIMIT - seen);
+  const fetchLimit = pageLimit + 1;
   // Counts and facets are computed only on the first page. Subsequent
   // pages reuse the values the client already has, saving ~7 of the
   // 15 SQL round-trips per request.
@@ -557,7 +568,7 @@ export const searchGlobal = async ({
     chatTextSearchFilter,
     searchHeadline,
     searchScore,
-    searchCursorValue,
+    searchScoreValue,
     searchOrderBy,
     hasSearchQuery,
     entityTypeFilter,
@@ -604,7 +615,7 @@ export const searchGlobal = async ({
         editor.image AS last_edited_by_image,
         file_field.mime_type,
         ${searchHeadline(sql`sd.title || ' ' || left(sd.searchable_text, 2000)`)},
-        ${searchScore(sql`sd.tsv`)},
+        ${searchScore({ tsv: sql`sd.tsv`, updatedAt: sql`sd.updated_at` })},
         sd.updated_at
       FROM search_documents sd
       JOIN workspaces w ON w.id = sd.workspace_id
@@ -622,7 +633,7 @@ export const searchGlobal = async ({
         ${entityWorkspaceFilter}
         ${globalSearchCursorSql({
           cursor: searchCursor,
-          score: searchCursorValue({
+          score: searchScoreValue({
             tsv: sql`sd.tsv`,
             updatedAt: sql`sd.updated_at`,
           }),
@@ -642,7 +653,11 @@ export const searchGlobal = async ({
         wsd.title,
         w.color,
         ${searchHeadline(sql`wsd.title || ' ' || left(wsd.searchable_text, 2000)`)},
-        ${searchScore(sql`wsd.tsv`)},
+        ${searchScore({
+          tsv: sql`wsd.tsv`,
+          updatedAt: sql`wsd.updated_at`,
+          relevanceBoost: MATTER_RELEVANCE_BOOST,
+        })},
         wsd.updated_at
       FROM workspace_search_documents wsd
       JOIN workspaces w ON w.id = wsd.workspace_id
@@ -652,9 +667,10 @@ export const searchGlobal = async ({
         ${matterWorkspaceFilter}
         ${globalSearchCursorSql({
           cursor: searchCursor,
-          score: searchCursorValue({
+          score: searchScoreValue({
             tsv: sql`wsd.tsv`,
             updatedAt: sql`wsd.updated_at`,
+            relevanceBoost: MATTER_RELEVANCE_BOOST,
           }),
           id: sql`'matter:' || wsd.workspace_id::text`,
         })}
@@ -674,7 +690,7 @@ export const searchGlobal = async ({
         csd.contact_type,
         csd.title,
         ${searchHeadline(sql`csd.title || ' ' || left(csd.searchable_text, 2000)`)},
-        ${searchScore(sql`csd.tsv`)},
+        ${searchScore({ tsv: sql`csd.tsv`, updatedAt: sql`csd.updated_at` })},
         csd.updated_at
       FROM contact_search_documents csd
       WHERE csd.organization_id = ${organizationId}
@@ -683,7 +699,7 @@ export const searchGlobal = async ({
         ${contactWorkspaceFilter}
         ${globalSearchCursorSql({
           cursor: searchCursor,
-          score: searchCursorValue({
+          score: searchScoreValue({
             tsv: sql`csd.tsv`,
             updatedAt: sql`csd.updated_at`,
           }),
@@ -705,7 +721,7 @@ export const searchGlobal = async ({
         d.country,
         d.decision_date,
         ${searchHeadline(sql`coalesce(nullif(body_preview.text, ''), d.fulltext, clsd.searchable_text)`)},
-        ${searchScore(sql`clsd.tsv`)},
+        ${searchScore({ tsv: sql`clsd.tsv`, updatedAt: sql`d.updated_at` })},
         d.updated_at
       FROM case_law_search_documents clsd
       JOIN case_law_decisions d ON d.id = clsd.decision_id
@@ -716,7 +732,7 @@ export const searchGlobal = async ({
         ${caseLawUpdatedFilter}
         ${globalSearchCursorSql({
           cursor: searchCursor,
-          score: searchCursorValue({
+          score: searchScoreValue({
             tsv: sql`clsd.tsv`,
             updatedAt: sql`d.updated_at`,
           }),
@@ -744,7 +760,7 @@ export const searchGlobal = async ({
         w.name AS workspace_name,
         cst.title,
         ${searchHeadline(sql`cst.title || ' ' || left(cst.searchable_text, 2000)`)},
-        ${searchScore(sql`cst.tsv`)},
+        ${searchScore({ tsv: sql`cst.tsv`, updatedAt: sql`t.updated_at` })},
         t.updated_at
       FROM chat_thread_search_documents cst
       JOIN chat_threads t ON t.id = cst.thread_id
@@ -755,7 +771,7 @@ export const searchGlobal = async ({
         AND ${chatScope}
         ${globalSearchCursorSql({
           cursor: searchCursor,
-          score: searchCursorValue({
+          score: searchScoreValue({
             tsv: sql`cst.tsv`,
             updatedAt: sql`t.updated_at`,
           }),
@@ -778,7 +794,7 @@ export const searchGlobal = async ({
       WHERE TRUE
         ${caseLawTextSearchFilter}
         ${caseLawUpdatedFilter}
-      LIMIT ${GLOBAL_SEARCH_COUNT_LIMIT}
+      LIMIT ${GLOBAL_SEARCH_RESULT_LIMIT}
     ) bounded_case_law
   `;
 
@@ -1073,18 +1089,9 @@ export const searchGlobal = async ({
     ...caseLawRows.map(mapCaseLawHit),
     ...chatRows.map(mapChatHit),
     // hit.id tiebreak for deterministic ranking, not display text
-  ].sort((a, b) =>
-    hasSearchQuery
-      ? compareScoredSearchHits(a, b)
-      : compareCodepoint(b.hit.updatedAt, a.hit.updatedAt) ||
-        compareCodepoint(b.hit.id, a.hit.id),
-  );
+  ].sort(compareScoredSearchHits);
 
-  const paginationHits = scoredHits.map(({ hit, score }) => ({
-    hit,
-    score: hasSearchQuery ? score : new Date(hit.updatedAt).getTime(),
-  }));
-  const page = paginateScoredSearchHits(paginationHits, limit);
+  const page = paginateScoredSearchHits({ scoredHits, limit, seen });
   const totalEntities = totalFrom(entityCount);
   const totalMatters = totalFrom(matterCount);
   const totalContacts = totalFrom(contactCount);

--- a/apps/api/src/lib/search/index-global.ts
+++ b/apps/api/src/lib/search/index-global.ts
@@ -1,3 +1,4 @@
+import { panic } from "better-result";
 import { and, asc, eq, gt, or, sql } from "drizzle-orm";
 import type { SQL } from "drizzle-orm";
 
@@ -25,10 +26,10 @@ import {
 } from "@/api/lib/search/highlight";
 import {
   compareScoredSearchHits,
-  decodeGlobalSearchCursor,
   GLOBAL_SEARCH_RESULT_LIMIT,
   globalSearchCursorSql,
   paginateScoredSearchHits,
+  parseGlobalSearchCursor,
 } from "@/api/lib/search/pagination";
 import {
   buildSearchPreviewPassages,
@@ -543,14 +544,44 @@ export const searchGlobal = async ({
   cursor,
   limit,
 }: GlobalSearchQuery): Promise<GlobalSearchResult> => {
-  const searchCursor = decodeGlobalSearchCursor(cursor);
-  const seen = searchCursor?.seen ?? 0;
+  const parsedCursor = parseGlobalSearchCursor(cursor);
+  const pagination = (() => {
+    switch (parsedCursor.type) {
+      case "initial":
+        return {
+          isFirstPage: true,
+          legacyOffset: null,
+          searchCursor: null,
+          seen: 0,
+        };
+      case "keyset":
+        return {
+          isFirstPage: false,
+          legacyOffset: null,
+          searchCursor: parsedCursor.cursor,
+          seen: parsedCursor.cursor.seen,
+        };
+      case "legacy":
+        return {
+          isFirstPage: false,
+          legacyOffset: parsedCursor.offset,
+          searchCursor: null,
+          seen: parsedCursor.offset,
+        };
+      case "invalid":
+        return panic("searchGlobal received an invalid cursor");
+      default: {
+        const exhaustive: never = parsedCursor;
+        return exhaustive;
+      }
+    }
+  })();
+  const { isFirstPage, legacyOffset, searchCursor, seen } = pagination;
   const pageLimit = Math.min(limit, GLOBAL_SEARCH_RESULT_LIMIT - seen);
-  const fetchLimit = pageLimit + 1;
+  const fetchLimit = (legacyOffset ?? 0) + pageLimit + 1;
   // Counts and facets are computed only on the first page. Subsequent
   // pages reuse the values the client already has, saving ~7 of the
   // 15 SQL round-trips per request.
-  const isFirstPage = searchCursor === null;
   const {
     selected,
     restrictToEntities,
@@ -1091,7 +1122,12 @@ export const searchGlobal = async ({
     // hit.id tiebreak for deterministic ranking, not display text
   ].sort(compareScoredSearchHits);
 
-  const page = paginateScoredSearchHits({ scoredHits, limit, seen });
+  const page = paginateScoredSearchHits({
+    scoredHits:
+      legacyOffset === null ? scoredHits : scoredHits.slice(legacyOffset),
+    limit: pageLimit,
+    seen,
+  });
   const totalEntities = totalFrom(entityCount);
   const totalMatters = totalFrom(matterCount);
   const totalContacts = totalFrom(contactCount);

--- a/apps/api/src/lib/search/pagination.test.ts
+++ b/apps/api/src/lib/search/pagination.test.ts
@@ -1,143 +1,141 @@
 import { describe, expect, test } from "bun:test";
+import { sql } from "drizzle-orm";
+import { PgDialect } from "drizzle-orm/pg-core";
 import fc from "fast-check";
 
 import { propertyConfig } from "@stll/property-testing";
 
-import { decodeCursor, encodeCursor } from "@/api/lib/search/cursor";
+import { encodeCursor } from "@/api/lib/search/cursor";
 import {
-  GLOBAL_SEARCH_MAX_OFFSET,
-  resolveGlobalSearchNextCursor,
+  compareScoredSearchHits,
+  decodeGlobalSearchCursor,
+  globalSearchCursorSql,
+  isAfterGlobalSearchCursor,
+  paginateScoredSearchHits,
 } from "@/api/lib/search/pagination";
 
-describe("global search pagination", () => {
-  test("returns the next cursor while the next page is below the max offset", () => {
-    expect(
-      resolveGlobalSearchNextCursor({
-        limit: 25,
-        offset: 50,
-        totalCount: 100,
-        hitsLength: 25,
-      }),
-    ).toBe(encodeCursor(75, "global"));
-  });
+type TestHit = {
+  id: string;
+};
 
-  test("does not return a cursor at or beyond the max offset", () => {
-    expect(
-      resolveGlobalSearchNextCursor({
-        limit: 25,
-        offset: GLOBAL_SEARCH_MAX_OFFSET - 25,
-        totalCount: GLOBAL_SEARCH_MAX_OFFSET + 100,
-        hitsLength: 25,
-      }),
-    ).toBeNull();
-  });
+const pageThrough = (
+  source: readonly { hit: TestHit; score: number }[],
+  limit: number,
+): TestHit[] => {
+  const sorted = source.toSorted(compareScoredSearchHits);
+  const prefixes = ["entity:", "matter:", "contact:", "case-law:", "chat:"];
+  const collected: TestHit[] = [];
+  let cursor: { score: number; id: string } | null = null;
 
-  test("stops paginating when the page is short", () => {
-    expect(
-      resolveGlobalSearchNextCursor({
-        limit: 25,
-        offset: 50,
-        totalCount: 100,
-        hitsLength: 10,
-      }),
-    ).toBeNull();
-  });
+  for (;;) {
+    const candidates = prefixes
+      .flatMap((prefix) =>
+        sorted
+          .filter(
+            ({ hit, score }) =>
+              hit.id.startsWith(prefix) &&
+              (cursor === null ||
+                isAfterGlobalSearchCursor({ id: hit.id, score }, cursor)),
+          )
+          .slice(0, limit + 1),
+      )
+      .sort(compareScoredSearchHits);
+    const page = paginateScoredSearchHits(candidates, limit);
+    collected.push(...page.items);
+    if (page.nextCursor === null) {
+      return collected;
+    }
+    cursor = decodeGlobalSearchCursor(page.nextCursor);
+    if (cursor === null) {
+      throw new Error("pagination produced an invalid cursor");
+    }
+  }
+};
 
-  test("falls back to hits length when totalCount is unknown (paginated request)", () => {
-    expect(
-      resolveGlobalSearchNextCursor({
-        limit: 25,
-        offset: 50,
-        totalCount: null,
-        hitsLength: 25,
-      }),
-    ).toBe(encodeCursor(75, "global"));
-
-    expect(
-      resolveGlobalSearchNextCursor({
-        limit: 25,
-        offset: 50,
-        totalCount: null,
-        hitsLength: 5,
-      }),
-    ).toBeNull();
-  });
-
-  test("refuses to advance past a known total", () => {
-    expect(
-      resolveGlobalSearchNextCursor({
-        limit: 25,
-        offset: 50,
-        totalCount: 75,
-        hitsLength: 25,
-      }),
-    ).toBeNull();
-  });
-});
-
-describe("global search pagination — properties", () => {
-  const arbLimit = fc.integer({ min: 1, max: 100 });
-  const arbOffset = fc.integer({
-    min: 0,
-    max: GLOBAL_SEARCH_MAX_OFFSET + 200,
-  });
-  const arbHitsLength = fc.integer({ min: 0, max: 100 });
-  const arbTotalCount = fc.option(fc.integer({ min: 0, max: 5000 }), {
-    nil: null,
-  });
-
-  test("returns null iff any pruning rule fires; otherwise encodes nextOffset", () => {
-    fc.assert(
-      fc.property(
-        arbLimit,
-        arbOffset,
-        arbHitsLength,
-        arbTotalCount,
-        (limit, offset, hitsLength, totalCount) => {
-          const result = resolveGlobalSearchNextCursor({
-            limit,
-            offset,
-            totalCount,
-            hitsLength,
-          });
-          const nextOffset = offset + limit;
-          const shouldStop =
-            nextOffset >= GLOBAL_SEARCH_MAX_OFFSET ||
-            hitsLength < limit ||
-            (totalCount !== null && totalCount <= nextOffset);
-
-          if (shouldStop) {
-            expect(result).toBeNull();
-          } else {
-            expect(result).toBe(encodeCursor(nextOffset, "global"));
-          }
-        },
-      ),
-      propertyConfig(),
+describe("global search keyset pagination", () => {
+  test("encodes the last returned score and globally unique id", () => {
+    const page = paginateScoredSearchHits(
+      [
+        { hit: { id: "matter:3" }, score: 0.9 },
+        { hit: { id: "entity:2" }, score: 0.8 },
+        { hit: { id: "contact:1" }, score: 0.7 },
+      ],
+      2,
     );
+
+    expect(page).toEqual({
+      items: [{ id: "matter:3" }, { id: "entity:2" }],
+      nextCursor: encodeCursor(0.8, "entity:2"),
+    });
   });
 
-  test("non-null cursor decodes to (nextOffset, 'global')", () => {
+  test("stops when the merged candidates contain no lookahead row", () => {
+    expect(
+      paginateScoredSearchHits(
+        [
+          { hit: { id: "matter:2" }, score: 0.9 },
+          { hit: { id: "entity:1" }, score: 0.8 },
+        ],
+        2,
+      ).nextCursor,
+    ).toBeNull();
+  });
+
+  test("compiles a descending score/id boundary with C collation", () => {
+    const dialect = new PgDialect();
+    const compiled = dialect.sqlToQuery(
+      globalSearchCursorSql({
+        cursor: { score: 0.75, id: "case-law:decision_1" },
+        score: sql`ts_rank(document, query)::float8`,
+        id: sql`'case-law:' || decision_id::text`,
+      }),
+    );
+
+    expect(compiled.sql).toContain("ts_rank(document, query)::float8 <");
+    expect(compiled.sql).toContain('COLLATE "C" <');
+    expect(compiled.params).toEqual([0.75, 0.75, "case-law:decision_1"]);
+  });
+
+  test("rejects cursors that do not identify a global search hit", () => {
+    expect(decodeGlobalSearchCursor(encodeCursor(0.5, "global"))).toBeNull();
+    expect(decodeGlobalSearchCursor(encodeCursor(0.5, "unknown:1"))).toBeNull();
+  });
+
+  test("repeated pages preserve the complete deterministic order", () => {
+    const arbitraryHit = fc.record({
+      id: fc
+        .tuple(
+          fc.constantFrom(
+            "entity:",
+            "matter:",
+            "contact:",
+            "case-law:",
+            "chat:",
+          ),
+          fc.uuid(),
+        )
+        .map(([prefix, id]) => `${prefix}${id}`),
+      score: fc.integer({ min: 0, max: 8 }),
+    });
+
     fc.assert(
       fc.property(
-        arbLimit,
-        arbOffset,
-        arbHitsLength,
-        arbTotalCount,
-        (limit, offset, hitsLength, totalCount) => {
-          const result = resolveGlobalSearchNextCursor({
-            limit,
-            offset,
-            totalCount,
-            hitsLength,
-          });
-          if (result === null) {
-            return;
-          }
-          expect(decodeCursor(result)).toEqual({
-            score: offset + limit,
-            id: "global",
-          });
+        fc.uniqueArray(arbitraryHit, {
+          minLength: 0,
+          maxLength: 200,
+          selector: ({ id }) => id,
+        }),
+        fc.integer({ min: 1, max: 40 }),
+        (rows, limit) => {
+          const source = rows.map(({ id, score }) => ({
+            hit: { id },
+            score,
+          }));
+          const expected = source
+            .toSorted(compareScoredSearchHits)
+            .map(({ hit }) => hit);
+
+          expect(pageThrough(source, limit)).toEqual(expected);
         },
       ),
       propertyConfig(),

--- a/apps/api/src/lib/search/pagination.test.ts
+++ b/apps/api/src/lib/search/pagination.test.ts
@@ -5,15 +5,17 @@ import fc from "fast-check";
 
 import { propertyConfig } from "@stll/property-testing";
 
-import { encodeCursor } from "@/api/lib/search/cursor";
+import { decodeCursor, encodeCursor } from "@/api/lib/search/cursor";
 import {
   compareScoredSearchHits,
   decodeGlobalSearchCursor,
   encodeGlobalSearchCursor,
+  GLOBAL_SEARCH_HIT_ID_PREFIXES,
   GLOBAL_SEARCH_RESULT_LIMIT,
   globalSearchCursorSql,
   isAfterGlobalSearchCursor,
   paginateScoredSearchHits,
+  parseGlobalSearchCursor,
 } from "@/api/lib/search/pagination";
 
 type TestHit = {
@@ -54,14 +56,13 @@ const pageThrough = (
   limit: number,
 ): TestHit[] => {
   const sorted = source.toSorted(compareScoredSearchHits);
-  const prefixes = ["entity:", "matter:", "contact:", "case-law:", "chat:"];
   const collected: TestHit[] = [];
   let cursor: ReturnType<typeof decodeGlobalSearchCursor> = null;
 
   for (;;) {
     const candidates = candidatesAfterCursor({
       sorted,
-      prefixes,
+      prefixes: GLOBAL_SEARCH_HIT_ID_PREFIXES,
       cursor,
       limit,
     });
@@ -101,6 +102,56 @@ describe("global search keyset pagination", () => {
         seen: 2,
       }),
     });
+  });
+
+  test("keeps new cursors consumable by legacy replicas", () => {
+    const cursor = encodeGlobalSearchCursor({
+      score: 0.8,
+      id: "entity:2",
+      seen: 25,
+    });
+
+    expect(decodeCursor(cursor)).toEqual({ score: 25, id: "global" });
+    expect(parseGlobalSearchCursor(cursor)).toEqual({
+      type: "keyset",
+      cursor: { score: 0.8, id: "entity:2", seen: 25 },
+    });
+  });
+
+  test("recognizes cursors issued by legacy replicas", () => {
+    expect(parseGlobalSearchCursor(encodeCursor(25, "global"))).toEqual({
+      type: "legacy",
+      offset: 25,
+    });
+    expect(parseGlobalSearchCursor(encodeCursor(100, "global"))).toEqual({
+      type: "legacy",
+      offset: 100,
+    });
+  });
+
+  test("dual cursors preserve both formats for every supported position", () => {
+    fc.assert(
+      fc.property(
+        fc.integer({ min: 1, max: GLOBAL_SEARCH_RESULT_LIMIT - 1 }),
+        fc.integer({ min: -8, max: 8 }),
+        fc.constantFrom(...GLOBAL_SEARCH_HIT_ID_PREFIXES),
+        fc.uuid(),
+        (seen, score, prefix, id) => {
+          const keysetCursor = { score, id: `${prefix}${id}`, seen };
+          const encoded = encodeGlobalSearchCursor(keysetCursor);
+
+          expect(decodeCursor(encoded)).toEqual({ score: seen, id: "global" });
+          expect(parseGlobalSearchCursor(encoded)).toEqual({
+            type: "keyset",
+            cursor: keysetCursor,
+          });
+          expect(parseGlobalSearchCursor(encodeCursor(seen, "global"))).toEqual(
+            { type: "legacy", offset: seen },
+          );
+        },
+      ),
+      propertyConfig(),
+    );
   });
 
   test("stops when the merged candidates contain no lookahead row", () => {
@@ -153,21 +204,18 @@ describe("global search keyset pagination", () => {
         encodeCursor(0.5, `${GLOBAL_SEARCH_RESULT_LIMIT}:entity:1`),
       ),
     ).toBeNull();
+    expect(
+      decodeGlobalSearchCursor(encodeCursor(0.5, "0:entity:1")),
+    ).toBeNull();
+    expect(
+      decodeGlobalSearchCursor(encodeCursor(0.5, "-1:entity:1")),
+    ).toBeNull();
   });
 
   test("repeated pages preserve the complete deterministic order", () => {
     const arbitraryHit = fc.record({
       id: fc
-        .tuple(
-          fc.constantFrom(
-            "entity:",
-            "matter:",
-            "contact:",
-            "case-law:",
-            "chat:",
-          ),
-          fc.uuid(),
-        )
+        .tuple(fc.constantFrom(...GLOBAL_SEARCH_HIT_ID_PREFIXES), fc.uuid())
         .map(([prefix, id]) => `${prefix}${id}`),
       score: fc.integer({ min: 0, max: 8 }),
     });

--- a/apps/api/src/lib/search/pagination.test.ts
+++ b/apps/api/src/lib/search/pagination.test.ts
@@ -9,6 +9,8 @@ import { encodeCursor } from "@/api/lib/search/cursor";
 import {
   compareScoredSearchHits,
   decodeGlobalSearchCursor,
+  encodeGlobalSearchCursor,
+  GLOBAL_SEARCH_RESULT_LIMIT,
   globalSearchCursorSql,
   isAfterGlobalSearchCursor,
   paginateScoredSearchHits,
@@ -18,6 +20,35 @@ type TestHit = {
   id: string;
 };
 
+type TestScoredHit = {
+  hit: TestHit;
+  score: number;
+};
+
+const candidatesAfterCursor = ({
+  sorted,
+  prefixes,
+  cursor,
+  limit,
+}: {
+  sorted: readonly TestScoredHit[];
+  prefixes: readonly string[];
+  cursor: ReturnType<typeof decodeGlobalSearchCursor>;
+  limit: number;
+}) =>
+  prefixes
+    .flatMap((prefix) =>
+      sorted
+        .filter(
+          ({ hit, score }) =>
+            hit.id.startsWith(prefix) &&
+            (cursor === null ||
+              isAfterGlobalSearchCursor({ id: hit.id, score }, cursor)),
+        )
+        .slice(0, limit + 1),
+    )
+    .sort(compareScoredSearchHits);
+
 const pageThrough = (
   source: readonly { hit: TestHit; score: number }[],
   limit: number,
@@ -25,22 +56,20 @@ const pageThrough = (
   const sorted = source.toSorted(compareScoredSearchHits);
   const prefixes = ["entity:", "matter:", "contact:", "case-law:", "chat:"];
   const collected: TestHit[] = [];
-  let cursor: { score: number; id: string } | null = null;
+  let cursor: ReturnType<typeof decodeGlobalSearchCursor> = null;
 
   for (;;) {
-    const candidates = prefixes
-      .flatMap((prefix) =>
-        sorted
-          .filter(
-            ({ hit, score }) =>
-              hit.id.startsWith(prefix) &&
-              (cursor === null ||
-                isAfterGlobalSearchCursor({ id: hit.id, score }, cursor)),
-          )
-          .slice(0, limit + 1),
-      )
-      .sort(compareScoredSearchHits);
-    const page = paginateScoredSearchHits(candidates, limit);
+    const candidates = candidatesAfterCursor({
+      sorted,
+      prefixes,
+      cursor,
+      limit,
+    });
+    const page = paginateScoredSearchHits({
+      scoredHits: candidates,
+      limit,
+      seen: cursor?.seen ?? 0,
+    });
     collected.push(...page.items);
     if (page.nextCursor === null) {
       return collected;
@@ -54,38 +83,58 @@ const pageThrough = (
 
 describe("global search keyset pagination", () => {
   test("encodes the last returned score and globally unique id", () => {
-    const page = paginateScoredSearchHits(
-      [
+    const page = paginateScoredSearchHits({
+      scoredHits: [
         { hit: { id: "matter:3" }, score: 0.9 },
         { hit: { id: "entity:2" }, score: 0.8 },
         { hit: { id: "contact:1" }, score: 0.7 },
       ],
-      2,
-    );
+      limit: 2,
+      seen: 0,
+    });
 
     expect(page).toEqual({
       items: [{ id: "matter:3" }, { id: "entity:2" }],
-      nextCursor: encodeCursor(0.8, "entity:2"),
+      nextCursor: encodeGlobalSearchCursor({
+        score: 0.8,
+        id: "entity:2",
+        seen: 2,
+      }),
     });
   });
 
   test("stops when the merged candidates contain no lookahead row", () => {
     expect(
-      paginateScoredSearchHits(
-        [
+      paginateScoredSearchHits({
+        scoredHits: [
           { hit: { id: "matter:2" }, score: 0.9 },
           { hit: { id: "entity:1" }, score: 0.8 },
         ],
-        2,
-      ).nextCursor,
+        limit: 2,
+        seen: 0,
+      }).nextCursor,
     ).toBeNull();
+  });
+
+  test("stops at the established global result horizon", () => {
+    const page = paginateScoredSearchHits({
+      scoredHits: Array.from({ length: 11 }, (_, index) => ({
+        hit: { id: `entity:${index}` },
+        score: 11 - index,
+      })),
+      limit: 25,
+      seen: GLOBAL_SEARCH_RESULT_LIMIT - 10,
+    });
+
+    expect(page.items).toHaveLength(10);
+    expect(page.nextCursor).toBeNull();
   });
 
   test("compiles a descending score/id boundary with C collation", () => {
     const dialect = new PgDialect();
     const compiled = dialect.sqlToQuery(
       globalSearchCursorSql({
-        cursor: { score: 0.75, id: "case-law:decision_1" },
+        cursor: { score: 0.75, id: "case-law:decision_1", seen: 10 },
         score: sql`ts_rank(document, query)::float8`,
         id: sql`'case-law:' || decision_id::text`,
       }),
@@ -99,6 +148,11 @@ describe("global search keyset pagination", () => {
   test("rejects cursors that do not identify a global search hit", () => {
     expect(decodeGlobalSearchCursor(encodeCursor(0.5, "global"))).toBeNull();
     expect(decodeGlobalSearchCursor(encodeCursor(0.5, "unknown:1"))).toBeNull();
+    expect(
+      decodeGlobalSearchCursor(
+        encodeCursor(0.5, `${GLOBAL_SEARCH_RESULT_LIMIT}:entity:1`),
+      ),
+    ).toBeNull();
   });
 
   test("repeated pages preserve the complete deterministic order", () => {

--- a/apps/api/src/lib/search/pagination.ts
+++ b/apps/api/src/lib/search/pagination.ts
@@ -12,13 +12,22 @@ export type GlobalSearchCursor = {
 
 export const GLOBAL_SEARCH_RESULT_LIMIT = 1000;
 
-const GLOBAL_SEARCH_HIT_ID_PREFIXES = [
+const LEGACY_GLOBAL_SEARCH_CURSOR_ID = "global";
+const DUAL_CURSOR_SEPARATOR = "==";
+
+export const GLOBAL_SEARCH_HIT_ID_PREFIXES = [
   "entity:",
   "matter:",
   "contact:",
   "case-law:",
   "chat:",
 ] as const;
+
+export type ParsedGlobalSearchCursor =
+  | { type: "initial" }
+  | { type: "keyset"; cursor: GlobalSearchCursor }
+  | { type: "legacy"; offset: number }
+  | { type: "invalid" };
 
 type ScoredSearchHit<T extends { id: string }> = {
   hit: T;
@@ -37,19 +46,18 @@ export const isAfterGlobalSearchCursor = (
   hit.score < cursor.score ||
   (hit.score === cursor.score && compareCodepoint(hit.id, cursor.id) < 0);
 
-export const decodeGlobalSearchCursor = (
-  cursor: string | undefined,
+const decodeGlobalSearchKeysetPayload = (
+  cursor: string,
 ): GlobalSearchCursor | null => {
-  if (cursor === undefined) {
+  const decoded = decodeCursor(cursor);
+  if (decoded === null) {
     return null;
   }
 
-  const decoded = decodeCursor(cursor);
-  const separatorIndex = decoded?.id.indexOf(":") ?? -1;
-  const seen = Number(decoded?.id.slice(0, separatorIndex));
-  const id = decoded?.id.slice(separatorIndex + 1) ?? "";
+  const separatorIndex = decoded.id.indexOf(":");
+  const seen = Number(decoded.id.slice(0, separatorIndex));
+  const id = decoded.id.slice(separatorIndex + 1);
   if (
-    decoded === null ||
     separatorIndex === -1 ||
     !Number.isInteger(seen) ||
     seen <= 0 ||
@@ -64,11 +72,79 @@ export const decodeGlobalSearchCursor = (
   return { score: decoded.score, id, seen };
 };
 
+const decodeLegacyGlobalSearchOffset = (cursor: string): number | null => {
+  const decoded = decodeCursor(cursor);
+  if (
+    decoded?.id !== LEGACY_GLOBAL_SEARCH_CURSOR_ID ||
+    !Number.isInteger(decoded.score) ||
+    decoded.score < 0 ||
+    decoded.score >= GLOBAL_SEARCH_RESULT_LIMIT
+  ) {
+    return null;
+  }
+
+  return decoded.score;
+};
+
+export const parseGlobalSearchCursor = (
+  cursor: string | undefined,
+): ParsedGlobalSearchCursor => {
+  if (cursor === undefined) {
+    return { type: "initial" };
+  }
+
+  const dualSeparatorIndex = cursor.indexOf(DUAL_CURSOR_SEPARATOR);
+  if (
+    dualSeparatorIndex !== -1 &&
+    dualSeparatorIndex + DUAL_CURSOR_SEPARATOR.length < cursor.length
+  ) {
+    const legacyPayload = cursor.slice(0, dualSeparatorIndex);
+    const keysetPayload = cursor.slice(
+      dualSeparatorIndex + DUAL_CURSOR_SEPARATOR.length,
+    );
+    const offset = decodeLegacyGlobalSearchOffset(legacyPayload);
+    const keysetCursor = decodeGlobalSearchKeysetPayload(keysetPayload);
+    if (
+      offset === null ||
+      keysetCursor === null ||
+      offset !== keysetCursor.seen
+    ) {
+      return { type: "invalid" };
+    }
+    return { type: "keyset", cursor: keysetCursor };
+  }
+
+  const keysetCursor = decodeGlobalSearchKeysetPayload(cursor);
+  if (keysetCursor !== null) {
+    return { type: "keyset", cursor: keysetCursor };
+  }
+
+  const offset = decodeLegacyGlobalSearchOffset(cursor);
+  return offset === null ? { type: "invalid" } : { type: "legacy", offset };
+};
+
+export const decodeGlobalSearchCursor = (
+  cursor: string | undefined,
+): GlobalSearchCursor | null => {
+  const parsed = parseGlobalSearchCursor(cursor);
+  return parsed.type === "keyset" ? parsed.cursor : null;
+};
+
 export const encodeGlobalSearchCursor = ({
   score,
   id,
   seen,
-}: GlobalSearchCursor): string => encodeCursor(score, `${seen}:${id}`);
+}: GlobalSearchCursor): string => {
+  // The prefix remains a valid offset cursor for replicas running the previous
+  // release. New replicas use the suffix for keyset pagination, so requests can
+  // move safely between old and new replicas during a rolling deployment.
+  const legacyPayload = encodeCursor(
+    seen,
+    LEGACY_GLOBAL_SEARCH_CURSOR_ID,
+  ).replace(/=+$/, "");
+  const keysetPayload = encodeCursor(score, `${seen}:${id}`);
+  return `${legacyPayload}${DUAL_CURSOR_SEPARATOR}${keysetPayload}`;
+};
 
 export const globalSearchCursorSql = ({
   cursor,

--- a/apps/api/src/lib/search/pagination.ts
+++ b/apps/api/src/lib/search/pagination.ts
@@ -138,10 +138,15 @@ export const encodeGlobalSearchCursor = ({
   // The prefix remains a valid offset cursor for replicas running the previous
   // release. New replicas use the suffix for keyset pagination, so requests can
   // move safely between old and new replicas during a rolling deployment.
-  const legacyPayload = encodeCursor(
+  const encodedLegacyCursor = encodeCursor(
     seen,
     LEGACY_GLOBAL_SEARCH_CURSOR_ID,
-  ).replace(/=+$/, "");
+  );
+  const paddingIndex = encodedLegacyCursor.indexOf("=");
+  const legacyPayload =
+    paddingIndex === -1
+      ? encodedLegacyCursor
+      : encodedLegacyCursor.slice(0, paddingIndex);
   const keysetPayload = encodeCursor(score, `${seen}:${id}`);
   return `${legacyPayload}${DUAL_CURSOR_SEPARATOR}${keysetPayload}`;
 };

--- a/apps/api/src/lib/search/pagination.ts
+++ b/apps/api/src/lib/search/pagination.ts
@@ -7,7 +7,10 @@ import { decodeCursor, encodeCursor } from "@/api/lib/search/cursor";
 export type GlobalSearchCursor = {
   score: number;
   id: string;
+  seen: number;
 };
+
+export const GLOBAL_SEARCH_RESULT_LIMIT = 1000;
 
 const GLOBAL_SEARCH_HIT_ID_PREFIXES = [
   "entity:",
@@ -42,18 +45,30 @@ export const decodeGlobalSearchCursor = (
   }
 
   const decoded = decodeCursor(cursor);
+  const separatorIndex = decoded?.id.indexOf(":") ?? -1;
+  const seen = Number(decoded?.id.slice(0, separatorIndex));
+  const id = decoded?.id.slice(separatorIndex + 1) ?? "";
   if (
     decoded === null ||
+    separatorIndex === -1 ||
+    !Number.isInteger(seen) ||
+    seen <= 0 ||
+    seen >= GLOBAL_SEARCH_RESULT_LIMIT ||
     !GLOBAL_SEARCH_HIT_ID_PREFIXES.some(
-      (prefix) =>
-        decoded.id.startsWith(prefix) && decoded.id.length > prefix.length,
+      (prefix) => id.startsWith(prefix) && id.length > prefix.length,
     )
   ) {
     return null;
   }
 
-  return decoded;
+  return { score: decoded.score, id, seen };
 };
+
+export const encodeGlobalSearchCursor = ({
+  score,
+  id,
+  seen,
+}: GlobalSearchCursor): string => encodeCursor(score, `${seen}:${id}`);
 
 export const globalSearchCursorSql = ({
   cursor,
@@ -79,15 +94,36 @@ export const globalSearchCursorSql = ({
   `;
 };
 
-export const paginateScoredSearchHits = <T extends { id: string }>(
-  scoredHits: readonly ScoredSearchHit<T>[],
-  limit: number,
-): { items: T[]; nextCursor: string | null } => {
-  const page = scoredHits.slice(0, limit);
+type PaginateScoredSearchHitsOptions<T extends { id: string }> = {
+  scoredHits: readonly ScoredSearchHit<T>[];
+  limit: number;
+  seen: number;
+};
+
+export const paginateScoredSearchHits = <T extends { id: string }>({
+  scoredHits,
+  limit,
+  seen,
+}: PaginateScoredSearchHitsOptions<T>): {
+  items: T[];
+  nextCursor: string | null;
+} => {
+  const pageLimit = Math.max(
+    0,
+    Math.min(limit, GLOBAL_SEARCH_RESULT_LIMIT - seen),
+  );
+  const page = scoredHits.slice(0, pageLimit);
   const last = page.at(-1);
+  const nextSeen = seen + page.length;
   const nextCursor =
-    scoredHits.length > limit && last !== undefined
-      ? encodeCursor(last.score, last.hit.id)
+    scoredHits.length > pageLimit &&
+    last !== undefined &&
+    nextSeen < GLOBAL_SEARCH_RESULT_LIMIT
+      ? encodeGlobalSearchCursor({
+          score: last.score,
+          id: last.hit.id,
+          seen: nextSeen,
+        })
       : null;
 
   return {

--- a/apps/api/src/lib/search/pagination.ts
+++ b/apps/api/src/lib/search/pagination.ts
@@ -1,33 +1,97 @@
-import { encodeCursor } from "@/api/lib/search/cursor";
+import { sql } from "drizzle-orm";
+import type { SQL } from "drizzle-orm";
 
-export const GLOBAL_SEARCH_MAX_OFFSET = 1000;
+import { compareCodepoint } from "@/api/lib/collation";
+import { decodeCursor, encodeCursor } from "@/api/lib/search/cursor";
 
-export const resolveGlobalSearchNextCursor = ({
-  limit,
-  offset,
-  totalCount,
-  hitsLength,
+export type GlobalSearchCursor = {
+  score: number;
+  id: string;
+};
+
+const GLOBAL_SEARCH_HIT_ID_PREFIXES = [
+  "entity:",
+  "matter:",
+  "contact:",
+  "case-law:",
+  "chat:",
+] as const;
+
+type ScoredSearchHit<T extends { id: string }> = {
+  hit: T;
+  score: number;
+};
+
+export const compareScoredSearchHits = <T extends { id: string }>(
+  a: ScoredSearchHit<T>,
+  b: ScoredSearchHit<T>,
+): number => b.score - a.score || compareCodepoint(b.hit.id, a.hit.id);
+
+export const isAfterGlobalSearchCursor = (
+  hit: { id: string; score: number },
+  cursor: GlobalSearchCursor,
+): boolean =>
+  hit.score < cursor.score ||
+  (hit.score === cursor.score && compareCodepoint(hit.id, cursor.id) < 0);
+
+export const decodeGlobalSearchCursor = (
+  cursor: string | undefined,
+): GlobalSearchCursor | null => {
+  if (cursor === undefined) {
+    return null;
+  }
+
+  const decoded = decodeCursor(cursor);
+  if (
+    decoded === null ||
+    !GLOBAL_SEARCH_HIT_ID_PREFIXES.some(
+      (prefix) =>
+        decoded.id.startsWith(prefix) && decoded.id.length > prefix.length,
+    )
+  ) {
+    return null;
+  }
+
+  return decoded;
+};
+
+export const globalSearchCursorSql = ({
+  cursor,
+  score,
+  id,
 }: {
-  limit: number;
-  offset: number;
-  /**
-   * Real total when known (first page); pass `null` when count was
-   * skipped (paginated request) so the decision falls back to hit count.
-   */
-  totalCount: number | null;
-  hitsLength: number;
-}): string | null => {
-  const nextOffset = offset + limit;
-  if (nextOffset >= GLOBAL_SEARCH_MAX_OFFSET) {
-    return null;
+  cursor: GlobalSearchCursor | null;
+  score: SQL;
+  id: SQL;
+}): SQL => {
+  if (cursor === null) {
+    return sql``;
   }
-  // A short page means no more rows beyond this one.
-  if (hitsLength < limit) {
-    return null;
-  }
-  // When we know the total, refuse to advance past it.
-  if (totalCount !== null && totalCount <= nextOffset) {
-    return null;
-  }
-  return encodeCursor(nextOffset, "global");
+
+  return sql`
+    AND (
+      ${score} < ${cursor.score}
+      OR (
+        ${score} = ${cursor.score}
+        AND (${id}) COLLATE "C" < ${cursor.id}::text COLLATE "C"
+      )
+    )
+  `;
+};
+
+export const paginateScoredSearchHits = <T extends { id: string }>(
+  scoredHits: readonly ScoredSearchHit<T>[],
+  limit: number,
+): { items: T[]; nextCursor: string | null } => {
+  const page = scoredHits.slice(0, limit);
+  const last = page.at(-1);
+  const nextCursor =
+    scoredHits.length > limit && last !== undefined
+      ? encodeCursor(last.score, last.hit.id)
+      : null;
+
+  return {
+    items: page.map(({ hit }) => hit),
+    nextCursor,
+  };
 };


### PR DESCRIPTION
## Proposed change

Replace global search offset pagination with deterministic score-and-ID keyset cursors.

- Apply a cursor boundary and bounded lookahead to each search source before merging results.
- Preserve recent-first ordering for empty queries and the existing lazy preview flow.
- Skip count and facet queries after the first page.
- Preserve IDs containing colons when decoding cursors.

## Checklist

- [ ] **BUILD ASSURANCE: CI PENDING** | Required build, lint, and typecheck checks will run in CI.
- [x] **TESTING** | 17 focused cursor, pagination, SQL-scope, and property tests pass with 363 assertions.
- [x] **DARK MODE SUPPORT: NOT APPLICABLE** | Backend-only change.
- [ ] **ISSUE LINKED: NOT APPLICABLE** | No issue is linked.
- [ ] **SCREENSHOT INCLUDED: NOT APPLICABLE** | No visual change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved global search pagination for more consistent ordering and smoother navigation between result pages.
  * Added support for relevance- and recency-based result ordering, including matter relevance boosts.
  * Added safeguards to limit the maximum number of global search results returned.

* **Bug Fixes**
  * Fixed cursor handling for identifiers containing colons.
  * Improved validation and precision when continuing searches from pagination cursors.
  * Invalid search cursors now return a clear 400 error instead of starting an invalid search.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->