### PR TITLE
fix(landing): hide package releases from changelog

### DIFF
--- a/apps/landing/src/lib/changelog-release.test.ts
+++ b/apps/landing/src/lib/changelog-release.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "bun:test";
+
+import { getReleaseKind, isStellaReleaseTag } from "./changelog-release";
+
+describe("Stella changelog releases", () => {
+  test("accepts stable stella release tags", () => {
+    expect(isStellaReleaseTag("v0.6.1")).toBe(true);
+    expect(isStellaReleaseTag("v12.34.56")).toBe(true);
+  });
+
+  test("rejects package releases and prereleases", () => {
+    expect(isStellaReleaseTag("@stll/template-conditions@0.2.0")).toBe(false);
+    expect(isStellaReleaseTag("@stll/conditions@0.3.0")).toBe(false);
+    expect(isStellaReleaseTag("v0.7.0-rc.1")).toBe(false);
+  });
+
+  test("classifies stella versions", () => {
+    expect(getReleaseKind("v1.0.0")).toBe("major");
+    expect(getReleaseKind("v1.2.0")).toBe("minor");
+    expect(getReleaseKind("v1.2.3")).toBe("patch");
+  });
+});

--- a/apps/landing/src/lib/changelog-release.ts
+++ b/apps/landing/src/lib/changelog-release.ts
@@ -1,0 +1,16 @@
+export type ReleaseKind = "major" | "minor" | "patch";
+
+const STELLA_RELEASE_TAG_PATTERN = /^v\d+\.\d+\.\d+$/u;
+
+export const isStellaReleaseTag = (tagName: string) =>
+  STELLA_RELEASE_TAG_PATTERN.test(tagName);
+
+export const getReleaseKind = (tagName: string): ReleaseKind => {
+  const [, minor, patch] = tagName.replace(/^v/u, "").split(".").map(Number);
+
+  if (patch !== 0) {
+    return "patch";
+  }
+
+  return minor === 0 ? "major" : "minor";
+};

--- a/apps/landing/src/lib/changelog.ts
+++ b/apps/landing/src/lib/changelog.ts
@@ -1,6 +1,8 @@
 import { existsSync, readdirSync, readFileSync } from "node:fs";
 import path from "node:path";
 
+import { getReleaseKind } from "./changelog-release";
+
 export type ChangelogRelease = {
   description: string;
   displayName: string;
@@ -11,18 +13,6 @@ export type ChangelogRelease = {
 
 const CHANGELOG_DIR = resolveRepoPath("docs", "changelog");
 const STABLE_CHANGELOG_FILE_PATTERN = /^v\d+\.\d+\.\d+\.md$/u;
-
-export type ReleaseKind = "major" | "minor" | "patch";
-
-export const getReleaseKind = (tagName: string): ReleaseKind => {
-  const [, minor, patch] = tagName.replace(/^v/u, "").split(".").map(Number);
-
-  if (patch !== 0) {
-    return "patch";
-  }
-
-  return minor === 0 ? "major" : "minor";
-};
 
 export const releaseAnchorId = (tagName: string) =>
   tagName

--- a/apps/landing/src/pages/changelog.astro
+++ b/apps/landing/src/pages/changelog.astro
@@ -294,6 +294,10 @@ const previewReleaseSlugs = getChangelogReleases().map((release) => release.slug
   </style>
 
   <script>
+    import {
+      getReleaseKind,
+      isStellaReleaseTag,
+    } from "../lib/changelog-release";
     import { parseChangelogMarkdown } from "../lib/changelog-markdown";
 
     type GitHubRelease = {
@@ -305,8 +309,6 @@ const previewReleaseSlugs = getChangelogReleases().map((release) => release.slug
       published_at: string | null;
       tag_name: string;
     };
-
-    type ReleaseKind = "major" | "minor" | "patch";
 
     const RELEASES_PER_PAGE = 12;
     const GITHUB_RELEASES_PER_PAGE = 100;
@@ -355,21 +357,6 @@ const previewReleaseSlugs = getChangelogReleases().map((release) => release.slug
         .replace(/[^a-z0-9-]/gu, "-")
         .replace(/-+/gu, "-")
         .replace(/^-|-$/gu, "");
-
-    const getReleaseKind = (tagName: string): ReleaseKind => {
-      const version = tagName.match(/^v?(\d+)\.(\d+)\.(\d+)$/iu);
-      if (!version) {
-        return "minor";
-      }
-
-      const minor = Number(version[2]);
-      const patch = Number(version[3]);
-      if (patch !== 0) {
-        return "patch";
-      }
-
-      return minor === 0 ? "major" : "minor";
-    };
 
     const normalizeMarkdownText = (text: string) =>
       text
@@ -756,14 +743,14 @@ const previewReleaseSlugs = getChangelogReleases().map((release) => release.slug
     const buildReleasesUrl = (githubPage: number) =>
       `${releasesEndpoint}&page=${githubPage}`;
 
-    const fetchStableReleasePage = async () => {
-      const stableReleaseOffset = (currentPage - 1) * RELEASES_PER_PAGE;
-      const stableReleaseLimit = stableReleaseOffset + RELEASES_PER_PAGE + 1;
-      const stableReleases: GitHubRelease[] = [];
+    const fetchStellaReleasePage = async () => {
+      const stellaReleaseOffset = (currentPage - 1) * RELEASES_PER_PAGE;
+      const stellaReleaseLimit = stellaReleaseOffset + RELEASES_PER_PAGE + 1;
+      const stellaReleases: GitHubRelease[] = [];
       let githubPage = 1;
       let hasMoreGithubPages = true;
 
-      while (hasMoreGithubPages && stableReleases.length < stableReleaseLimit) {
+      while (hasMoreGithubPages && stellaReleases.length < stellaReleaseLimit) {
         // eslint-disable-next-line no-await-in-loop -- GitHub pagination is sequential: the next page number and stop condition depend on this page's rel="next" link header, so pages cannot be fetched in parallel
         const response = await fetch(buildReleasesUrl(githubPage), {
           headers: { Accept: "application/vnd.github+json" },
@@ -772,8 +759,13 @@ const previewReleaseSlugs = getChangelogReleases().map((release) => release.slug
 
         // eslint-disable-next-line no-await-in-loop -- parse this page's body before deciding whether to fetch the next one
         const releases = (await response.json()) as GitHubRelease[];
-        stableReleases.push(
-          ...releases.filter((release) => !release.draft && !release.prerelease),
+        stellaReleases.push(
+          ...releases.filter(
+            (release) =>
+              !release.draft &&
+              !release.prerelease &&
+              isStellaReleaseTag(release.tag_name),
+          ),
         );
         hasMoreGithubPages = responseHasNextPage(response);
         githubPage += 1;
@@ -781,10 +773,10 @@ const previewReleaseSlugs = getChangelogReleases().map((release) => release.slug
 
       return {
         hasNextPage:
-          stableReleases.length > stableReleaseOffset + RELEASES_PER_PAGE,
-        releases: stableReleases.slice(
-          stableReleaseOffset,
-          stableReleaseOffset + RELEASES_PER_PAGE,
+          stellaReleases.length > stellaReleaseOffset + RELEASES_PER_PAGE,
+        releases: stellaReleases.slice(
+          stellaReleaseOffset,
+          stellaReleaseOffset + RELEASES_PER_PAGE,
         ),
       };
     };
@@ -845,7 +837,7 @@ const previewReleaseSlugs = getChangelogReleases().map((release) => release.slug
       try {
         releasesContainer.replaceChildren(renderLoading());
 
-        const releasePage = await fetchStableReleasePage();
+        const releasePage = await fetchStellaReleasePage();
         if (!releasePage) {
           hasNextPage = false;
           renderPagination();


### PR DESCRIPTION
## Summary

- filter the public changelog feed to stable stella `vX.Y.Z` release tags
- exclude package releases such as `@stll/template-conditions@0.2.0` before changelog pagination
- share and test the release-tag and release-kind logic used by static and live changelog rendering

## Validation

- `bun run lint` in `apps/landing`
- `bun run typecheck` in `apps/landing`
- `bun run build` in `apps/landing`
- `bun test src/lib/changelog-release.test.ts src/lib/changelog-markdown.test.ts` in `apps/landing`
- pre-commit and pre-push hooks

CC on behalf of jan-kubica