### PR TITLE
fix: keep search affordances visible and link copy toast

### DIFF
--- a/apps/web/src/components/inspector/external-reference-panel.tsx
+++ b/apps/web/src/components/inspector/external-reference-panel.tsx
@@ -823,7 +823,6 @@ export const ExternalReferencePanel = ({
           </div>
           {findOpen && (
             <div className="flex h-10 shrink-0 items-center gap-1 border-b px-2">
-              <SearchIcon className="text-muted-foreground size-3.5 shrink-0" />
               <Input
                 aria-label={t("folio.findReplace.findText")}
                 className="h-7 flex-1 rounded-md"

--- a/apps/web/src/components/matter-target-picker.tsx
+++ b/apps/web/src/components/matter-target-picker.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 
 import { useQuery } from "@tanstack/react-query";
-import { ChevronRightIcon, FolderIcon, SearchIcon } from "lucide-react";
+import { ChevronRightIcon, FolderIcon } from "lucide-react";
 import { useTranslations } from "use-intl";
 
 import { BidiText } from "@stll/ui/components/bidi-text";
@@ -71,19 +71,12 @@ export const MatterTargetPicker = ({
     <div className="space-y-4">
       <div className="space-y-2">
         <Label>{t("workspaces.copyToMatter.targetMatter")}</Label>
-        <div className="relative">
-          <SearchIcon
-            aria-hidden="true"
-            className="text-muted-foreground pointer-events-none absolute start-2.5 top-1/2 size-3.5 -translate-y-1/2"
-          />
-          <Input
-            className="ps-8"
-            onChange={(e) => setSearch(e.target.value)}
-            placeholder={t("inspector.matterPicker.searchPlaceholder")}
-            type="search"
-            value={search}
-          />
-        </div>
+        <Input
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder={t("inspector.matterPicker.searchPlaceholder")}
+          type="search"
+          value={search}
+        />
         <ScrollArea className="border-border h-48 rounded-md border">
           <div className="p-1">
             {(() => {

--- a/apps/web/src/i18n/langs/ar.json
+++ b/apps/web/src/i18n/langs/ar.json
@@ -3106,6 +3106,7 @@
       "copyOption": "نسخ (مع الاحتفاظ بالأصل)",
       "description": "نسخ «{name}» أو نقله إلى ملف آخر",
       "descriptionCount": "نسخ {count, plural, zero {لا عناصر} one {عنصر واحد} two {عنصرين} few {# عناصر} many {# عنصرًا} other {# عنصر}} أو نقلها إلى ملف آخر",
+      "goToMatter": "الانتقال إلى الملف",
       "menuItem": "نسخ/نقل إلى ملف",
       "moveButton": "نقل",
       "moveOption": "نقل (حذف الأصل)",

--- a/apps/web/src/i18n/langs/cs.json
+++ b/apps/web/src/i18n/langs/cs.json
@@ -3106,6 +3106,7 @@
       "copyOption": "Kopírovat (ponechat originál)",
       "description": "Zkopírovat nebo přesunout \"{name}\" do jiného spisu",
       "descriptionCount": "Zkopírovat nebo přesunout {count, plural, one {# položku} few {# položky} other {# položek}} do jiného spisu",
+      "goToMatter": "Přejít do spisu",
       "menuItem": "Kopírovat/Přesunout do spisu",
       "moveButton": "Přesunout",
       "moveOption": "Přesunout (smazat originál)",

--- a/apps/web/src/i18n/langs/de.json
+++ b/apps/web/src/i18n/langs/de.json
@@ -3106,6 +3106,7 @@
       "copyOption": "Kopieren (Original behalten)",
       "description": "\"{name}\" in eine andere Akte kopieren oder verschieben",
       "descriptionCount": "{count, plural, one {# Element} other {# Elemente}} in eine andere Akte kopieren oder verschieben",
+      "goToMatter": "Zur Akte",
       "menuItem": "In Akte kopieren/verschieben",
       "moveButton": "Verschieben",
       "moveOption": "Verschieben (Original löschen)",

--- a/apps/web/src/i18n/langs/en.json
+++ b/apps/web/src/i18n/langs/en.json
@@ -3106,6 +3106,7 @@
       "copyOption": "Copy (keep original)",
       "description": "Copy or move \"{name}\" to another Matter",
       "descriptionCount": "Copy or move {count, plural, one {# item} other {# items}} to another Matter",
+      "goToMatter": "Go to matter",
       "menuItem": "Copy/Move to Matter",
       "moveButton": "Move",
       "moveOption": "Move (delete original)",

--- a/apps/web/src/i18n/langs/es.json
+++ b/apps/web/src/i18n/langs/es.json
@@ -3106,6 +3106,7 @@
       "copyOption": "Copiar (mantener original)",
       "description": "Copiar o mover \"{name}\" a otro asunto",
       "descriptionCount": "Copiar o mover {count, plural, one {# elemento} other {# elementos}} a otro asunto",
+      "goToMatter": "Ir al asunto",
       "menuItem": "Copiar/Mover a asunto",
       "moveButton": "Mover",
       "moveOption": "Mover (eliminar original)",

--- a/apps/web/src/i18n/langs/et.json
+++ b/apps/web/src/i18n/langs/et.json
@@ -3106,6 +3106,7 @@
       "copyOption": "Kopeeri (säilita originaal)",
       "description": "Kopeeri või teisalda \"{name}\" teise toimikusse",
       "descriptionCount": "Kopeeri või teisalda {count, plural, one {# üksus} other {# üksust}} teise toimikusse",
+      "goToMatter": "Mine toimikusse",
       "menuItem": "Kopeeri/Teisalda toimikusse",
       "moveButton": "Teisalda",
       "moveOption": "Teisalda (kustuta originaal)",

--- a/apps/web/src/i18n/langs/fr.json
+++ b/apps/web/src/i18n/langs/fr.json
@@ -3106,6 +3106,7 @@
       "copyOption": "Copier (conserver l'original)",
       "description": "Copier ou déplacer \"{name}\" vers un autre dossier",
       "descriptionCount": "Copier ou déplacer {count, plural, one {# élément} other {# éléments}} vers un autre dossier",
+      "goToMatter": "Accéder au dossier",
       "menuItem": "Copier/Déplacer vers un dossier",
       "moveButton": "Déplacer",
       "moveOption": "Déplacer (supprimer l'original)",

--- a/apps/web/src/i18n/langs/hu.json
+++ b/apps/web/src/i18n/langs/hu.json
@@ -3106,6 +3106,7 @@
       "copyOption": "Másolás (eredeti megtartása)",
       "description": "\"{name}\" másolása vagy áthelyezése másik ügyiratba",
       "descriptionCount": "{count, plural, one {# elem} other {# elem}} másolása vagy áthelyezése másik ügyiratba",
+      "goToMatter": "Ugrás az ügyirathoz",
       "menuItem": "Másolás/Áthelyezés ügyiratba",
       "moveButton": "Áthelyezés",
       "moveOption": "Áthelyezés (eredeti törlése)",

--- a/apps/web/src/i18n/langs/lt.json
+++ b/apps/web/src/i18n/langs/lt.json
@@ -3106,6 +3106,7 @@
       "copyOption": "Kopijuoti (palikti originalą)",
       "description": "Kopijuoti arba perkelti \"{name}\" į kitą bylą",
       "descriptionCount": "Kopijuoti arba perkelti {count, plural, one {# elementą} few {# elementus} other {# elementų}} į kitą bylą",
+      "goToMatter": "Eiti į bylą",
       "menuItem": "Kopijuoti/Perkelti į bylą",
       "moveButton": "Perkelti",
       "moveOption": "Perkelti (ištrinti originalą)",

--- a/apps/web/src/i18n/langs/lv.json
+++ b/apps/web/src/i18n/langs/lv.json
@@ -3106,6 +3106,7 @@
       "copyOption": "Kopēt (saglabāt oriģinālu)",
       "description": "Kopēt vai pārvietot \"{name}\" uz citu lietu",
       "descriptionCount": "Kopēt vai pārvietot {count, plural, zero {# vienību} one {# vienību} other {# vienības}} uz citu lietu",
+      "goToMatter": "Doties uz lietu",
       "menuItem": "Kopēt/Pārvietot uz lietu",
       "moveButton": "Pārvietot",
       "moveOption": "Pārvietot (dzēst oriģinālu)",

--- a/apps/web/src/i18n/langs/messages.gen.ts
+++ b/apps/web/src/i18n/langs/messages.gen.ts
@@ -3109,6 +3109,7 @@ type Messages = {
       "copyOption": "Copy (keep original)";
       "description": "Copy or move \"{name}\" to another Matter";
       "descriptionCount": "Copy or move {count, plural, one {# item} other {# items}} to another Matter";
+      "goToMatter": "Go to matter";
       "menuItem": "Copy/Move to Matter";
       "moveButton": "Move";
       "moveOption": "Move (delete original)";

--- a/apps/web/src/i18n/langs/pl.json
+++ b/apps/web/src/i18n/langs/pl.json
@@ -3106,6 +3106,7 @@
       "copyOption": "Kopiuj (zachowaj oryginał)",
       "description": "Skopiuj lub przenieś \"{name}\" do innej sprawy",
       "descriptionCount": "Skopiuj lub przenieś {count, plural, one {# element} few {# elementy} many {# elementów} other {# elementów}} do innej sprawy",
+      "goToMatter": "Przejdź do sprawy",
       "menuItem": "Kopiuj/Przenieś do sprawy",
       "moveButton": "Przenieś",
       "moveOption": "Przenieś (usuń oryginał)",

--- a/apps/web/src/i18n/langs/pt-BR.json
+++ b/apps/web/src/i18n/langs/pt-BR.json
@@ -3106,6 +3106,7 @@
       "copyOption": "Copiar (manter original)",
       "description": "Copiar ou mover \"{name}\" para outro caso",
       "descriptionCount": "Copiar ou mover {count, plural, one {# item} other {# itens}} para outro caso",
+      "goToMatter": "Ir para o caso",
       "menuItem": "Copiar/Mover para caso",
       "moveButton": "Mover",
       "moveOption": "Mover (excluir original)",

--- a/apps/web/src/i18n/langs/sk.json
+++ b/apps/web/src/i18n/langs/sk.json
@@ -3106,6 +3106,7 @@
       "copyOption": "Kopírovať (ponechať originál)",
       "description": "Skopírovať alebo presunúť \"{name}\" do iného spisu",
       "descriptionCount": "Skopírovať alebo presunúť {count, plural, one {# položku} few {# položky} other {# položiek}} do iného spisu",
+      "goToMatter": "Prejsť do spisu",
       "menuItem": "Kopírovať/Presunúť do spisu",
       "moveButton": "Presunúť",
       "moveOption": "Presunúť (vymazať originál)",

--- a/apps/web/src/routes/_protected.knowledge/-components/catalogue/catalogue-browser.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/catalogue/catalogue-browser.tsx
@@ -302,9 +302,6 @@ export const CatalogueBrowser = ({
       <ResponsiveActionToolbar>
         <ResponsiveActionToolbarItem slot="primary">
           <InputGroup className="min-h-11 sm:min-h-0">
-            <InputGroupAddon>
-              <SearchIcon className="text-muted-foreground" />
-            </InputGroupAddon>
             <InputGroupInput
               className="max-sm:h-11 max-sm:leading-11"
               onChange={(e) => setQuery(e.target.value)}

--- a/apps/web/src/routes/_protected.knowledge/-components/clause-list.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/clause-list.tsx
@@ -3,7 +3,6 @@ import { useState } from "react";
 import {
   DownloadIcon,
   PlusIcon,
-  SearchIcon,
   TextQuoteIcon,
   UploadIcon,
 } from "lucide-react";
@@ -11,11 +10,7 @@ import { useDebouncedCallback } from "use-debounce";
 import { useTranslations } from "use-intl";
 
 import { Button } from "@stll/ui/components/button";
-import {
-  InputGroup,
-  InputGroupAddon,
-  InputGroupInput,
-} from "@stll/ui/components/input-group";
+import { InputGroup, InputGroupInput } from "@stll/ui/components/input-group";
 import { stellaToast } from "@stll/ui/components/toast";
 
 import {
@@ -162,9 +157,6 @@ export const ClauseList = ({
                   type="search"
                   value={searchInput}
                 />
-                <InputGroupAddon>
-                  <SearchIcon />
-                </InputGroupAddon>
               </InputGroup>
             </ResponsiveActionToolbarItem>
             <ResponsiveActionToolbarItem

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/copy-to-matter-dialog.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/copy-to-matter-dialog.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 
 import { useQueryClient } from "@tanstack/react-query";
+import { useNavigate } from "@tanstack/react-router";
 import { Result } from "better-result";
 import { useTranslations } from "use-intl";
 
@@ -52,6 +53,7 @@ export const CopyToMatterDialog = ({
 }: CopyToMatterDialogProps) => {
   const t = useTranslations();
   const queryClient = useQueryClient();
+  const navigate = useNavigate();
   const [mode, setMode] = useState<MoveMode>("copy");
   const [target, setTarget] = useState<MatterTarget | null>(
     initialTargetWorkspaceId
@@ -146,14 +148,33 @@ export const CopyToMatterDialog = ({
       mode === "copy"
         ? t("workspaces.copyToMatter.copied")
         : t("workspaces.copyToMatter.moved");
+    const goToMatterAction = {
+      label: t("workspaces.copyToMatter.goToMatter"),
+      onClick: () => {
+        detached(
+          navigate({
+            to: "/workspaces/$workspaceId",
+            params: { workspaceId: targetWorkspaceId },
+          }),
+          "goToMatter",
+        );
+      },
+    };
     if (failedCount > 0) {
       stellaToast.add({
         title: successTitle,
         description: t("errors.actionFailed"),
         type: "warning",
+        action: goToMatterAction,
+        timeout: 10_000,
       });
     } else {
-      stellaToast.add({ title: successTitle, type: "success" });
+      stellaToast.add({
+        title: successTitle,
+        type: "success",
+        action: goToMatterAction,
+        timeout: 10_000,
+      });
     }
 
     onOpenChange(false);

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/new-document-from-template-dialog.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/new-document-from-template-dialog.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 
 import { useInfiniteQuery, useQueryClient } from "@tanstack/react-query";
 import { getRouteApi, useNavigate } from "@tanstack/react-router";
-import { ArrowLeftIcon, LayoutTemplateIcon, SearchIcon } from "lucide-react";
+import { ArrowLeftIcon, LayoutTemplateIcon } from "lucide-react";
 import { useTranslations } from "use-intl";
 
 import { Button } from "@stll/ui/components/button";
@@ -167,20 +167,13 @@ const TemplatePickList = ({
 
   return (
     <div className="flex min-h-0 flex-col gap-2 p-4">
-      <div className="relative">
-        <SearchIcon
-          aria-hidden="true"
-          className="text-muted-foreground pointer-events-none absolute start-2.5 top-1/2 size-3.5 -translate-y-1/2"
-        />
-        <Input
-          autoFocus
-          className="ps-8"
-          onChange={(e) => setSearch(e.target.value)}
-          placeholder={t("templates.searchTemplates")}
-          type="search"
-          value={search}
-        />
-      </div>
+      <Input
+        autoFocus
+        onChange={(e) => setSearch(e.target.value)}
+        placeholder={t("templates.searchTemplates")}
+        type="search"
+        value={search}
+      />
       <ul className="min-h-0 flex-1 divide-y overflow-y-auto rounded-lg border">
         {visibleTemplates.length === 0 && (
           <li className="text-muted-foreground p-3 text-sm">

--- a/packages/ui/src/components/input.test.tsx
+++ b/packages/ui/src/components/input.test.tsx
@@ -1,0 +1,16 @@
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { describe, expect, test } from "bun:test";
+
+import { Input } from "./input";
+
+describe("Input", () => {
+  test("search inputs always render their search affordance", () => {
+    const markup = renderToStaticMarkup(<Input type="search" />);
+
+    expect(markup).toContain('data-slot="input-search-icon"');
+    expect(markup.indexOf('data-slot="input-search-icon"')).toBeLessThan(
+      markup.indexOf('data-slot="input"'),
+    );
+  });
+});

--- a/packages/ui/src/components/input.test.tsx
+++ b/packages/ui/src/components/input.test.tsx
@@ -13,4 +13,12 @@ describe("Input", () => {
       markup.indexOf('data-slot="input"'),
     );
   });
+
+  test("search affordances follow the resolved content direction", () => {
+    const markup = renderToStaticMarkup(
+      <Input type="search" value="legal matter" />,
+    );
+
+    expect(markup).toContain('data-slot="input-control" dir="auto"');
+  });
 });

--- a/packages/ui/src/components/input.tsx
+++ b/packages/ui/src/components/input.tsx
@@ -3,6 +3,7 @@
 import type * as React from "react";
 
 import { Input as InputPrimitive } from "@base-ui/react/input";
+import { SearchIcon } from "lucide-react";
 
 import {
   isStructuredInputType,
@@ -48,7 +49,7 @@ function Input({
       "h-7.5 px-[calc(--spacing(2.5)-1px)] leading-7.5 sm:h-6.5 sm:leading-6.5",
     size === "lg" && "h-9.5 leading-9.5 sm:h-8.5 sm:leading-8.5",
     props.type === "search" &&
-      "[&::-webkit-search-cancel-button]:appearance-none [&::-webkit-search-decoration]:appearance-none [&::-webkit-search-results-button]:appearance-none [&::-webkit-search-results-decoration]:appearance-none",
+      "ps-8 [&::-webkit-search-cancel-button]:appearance-none [&::-webkit-search-decoration]:appearance-none [&::-webkit-search-results-button]:appearance-none [&::-webkit-search-results-decoration]:appearance-none",
     props.type === "file" &&
       "text-muted-foreground file:text-foreground file:me-3 file:bg-transparent file:text-sm file:font-medium",
   );
@@ -65,6 +66,13 @@ function Input({
       data-size={size}
       data-slot="input-control"
     >
+      {props.type === "search" && (
+        <SearchIcon
+          aria-hidden="true"
+          className="text-muted-foreground pointer-events-none absolute start-2.5 top-1/2 z-1 size-3.5 -translate-y-1/2"
+          data-slot="input-search-icon"
+        />
+      )}
       {nativeInput ? (
         <input
           className={inputClassName}

--- a/packages/ui/src/components/input.tsx
+++ b/packages/ui/src/components/input.tsx
@@ -65,6 +65,7 @@ function Input({
       }
       data-size={size}
       data-slot="input-control"
+      dir={contentDir.dir}
     >
       {props.type === "search" && (
         <SearchIcon


### PR DESCRIPTION
## Summary

- render the search icon inside the shared Input whenever `type="search"`, so opaque control wrappers cannot cover it
- remove now-redundant call-site search icons and add a render invariant test
- add a localized “Go to matter” action to successful and partially successful copy/move toasts

## Test plan

- `bun --cwd packages/ui test src/components/input.test.tsx`
- `bun --cwd packages/ui typecheck`
- `bun --cwd apps/web typecheck`
- `bun --cwd apps/web i18n:check`
- focused type-aware oxlint and formatting checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Go to matter” action after copying or moving items, including translated labels across supported languages.
  * Search fields now provide a consistent built-in search icon and improved text-direction handling.

* **Bug Fixes**
  * Improved navigation from copy/move notifications, including partial-success scenarios.
  * Simplified search controls across matter, catalogue, clause, and template pickers for a cleaner interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->