### PR TITLE
fix(ci): watch the dispatched promote run instead of fire-and-forget

### DIFF
--- a/.github/actions/promote-dispatch/action.yml
+++ b/.github/actions/promote-dispatch/action.yml
@@ -1,0 +1,152 @@
+name: Dispatch and watch promote-release
+description: >
+  Dispatch stella-infra's promote-release.yml and block until the run it
+  created finishes. A dispatch that is accepted but later fails must fail the
+  caller: without the watch, the deploy job goes green on "the request was
+  accepted" and the failure only surfaces later as a post-deploy smoke that
+  cannot say what broke.
+
+inputs:
+  token:
+    description: App token with actions:write on the infra repository
+    required: true
+  infra-repo:
+    description: owner/name of the repository hosting the promote workflow
+    required: true
+  workflow-file:
+    description: >
+      Filename of the promote workflow in the infra repository. Overriding it
+      only works for a workflow whose `run-name:` matches the template this
+      action correlates on; see expected_title below.
+    required: false
+    default: promote-release.yml
+  release-ref:
+    description: Release tag (v1.2.3) or synthetic staging ref (main-<short-sha>)
+    required: true
+  target-environment:
+    description: Environment to promote into (staging or production)
+    required: true
+  run-migrations:
+    description: Run database migrations as part of the promotion
+    required: false
+    default: "true"
+  frontend:
+    description: Build and publish the frontend as part of the promotion
+    required: false
+    default: "true"
+  image-digest:
+    description: >
+      Image digest to deploy (sha256:...). Required for synthetic main-<sha>
+      refs, which have no GitHub Release manifest to resolve it from.
+    required: false
+    default: ""
+  git-sha:
+    description: >
+      Full 40-char commit SHA the synthetic ref points at. Only valid with
+      main-<sha> refs; for tagged releases the tag is the checkout target.
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - name: Dispatch and watch promote-release.yml
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.token }}
+        INFRA_REPO: ${{ inputs.infra-repo }}
+        WORKFLOW_FILE: ${{ inputs.workflow-file }}
+        RELEASE_REF: ${{ inputs.release-ref }}
+        TARGET_ENV: ${{ inputs.target-environment }}
+        RUN_MIGRATIONS: ${{ inputs.run-migrations }}
+        FRONTEND: ${{ inputs.frontend }}
+        IMAGE_DIGEST: ${{ inputs.image-digest }}
+        GIT_SHA: ${{ inputs.git-sha }}
+      run: |
+        set -euo pipefail
+
+        dispatched_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+        # Must match the `run-name:` template in
+        # stella-infra/.github/workflows/promote-release.yml. That template is
+        # load-bearing for correlation, not decoration: changing either side
+        # alone leaves the dispatch unmatched and this step failing.
+        expected_title="Promote ${RELEASE_REF} → ${TARGET_ENV}"
+
+        dispatch_args=(
+          -f "ref=main"
+          -f "inputs[release_ref]=${RELEASE_REF}"
+          -f "inputs[target_environment]=${TARGET_ENV}"
+          -f "inputs[run_migrations]=${RUN_MIGRATIONS}"
+          -f "inputs[frontend]=${FRONTEND}"
+        )
+        # Only sent when set: promote-release.yml rejects git_sha on tagged
+        # releases, where a populated value would silently swap the checked-out
+        # source for a different commit.
+        if [[ -n "$IMAGE_DIGEST" ]]; then
+          dispatch_args+=(-f "inputs[image_digest]=${IMAGE_DIGEST}")
+        fi
+        if [[ -n "$GIT_SHA" ]]; then
+          dispatch_args+=(-f "inputs[git_sha]=${GIT_SHA}")
+        fi
+
+        # Call the dispatches endpoint directly. `gh workflow run` first looks
+        # up the workflow by filename against the repo's default branch; with
+        # the narrowly-scoped App token (permission-actions: write only, no
+        # contents/metadata) those implicit lookups can fail silently and kill
+        # the step in well under a second with no output. Any failure here
+        # surfaces as a real HTTP error in the log.
+        echo "Dispatching ${WORKFLOW_FILE} on ${INFRA_REPO} (target=${TARGET_ENV}, release=${RELEASE_REF})..."
+        gh api --method POST \
+          "/repos/${INFRA_REPO}/actions/workflows/${WORKFLOW_FILE}/dispatches" \
+          "${dispatch_args[@]}"
+
+        # The dispatches endpoint returns 204 with no body, so the run id has
+        # to be recovered by listing. Match on exact display_title so
+        # concurrent dispatches cannot be confused and prefix-overlapping refs
+        # (v1.2.3 vs v1.2.3-rc.1, v1.2.3-rc.1 vs v1.2.3-rc.10) never collide.
+        echo "Dispatch accepted. Polling for the new run..."
+        run_id=""
+        for attempt in {1..30}; do
+          run_id="$(
+            gh api \
+              "/repos/${INFRA_REPO}/actions/workflows/${WORKFLOW_FILE}/runs?event=workflow_dispatch&per_page=10" \
+              --jq ".workflow_runs[] | select(.created_at >= \"${dispatched_at}\") | select(.display_title == \"${expected_title}\") | .id" \
+              | head -n 1
+          )"
+          if [[ -n "$run_id" ]]; then
+            echo "Found dispatched run: ${run_id} (attempt ${attempt}/30)"
+            break
+          fi
+          sleep 2
+        done
+
+        if [[ -z "$run_id" ]]; then
+          echo "::error::Dispatched a promote run but never observed it in the workflow's run list." >&2
+          exit 1
+        fi
+
+        echo "Watching run ${run_id}..."
+        if gh run watch "$run_id" --repo "$INFRA_REPO" --compact --exit-status; then
+          exit 0
+        fi
+
+        run_state="$(
+          gh api "/repos/${INFRA_REPO}/actions/runs/${run_id}" \
+            --jq '[.conclusion, .html_url] | @tsv'
+        )"
+        conclusion="$(cut -f1 <<<"$run_state")"
+        run_url="$(cut -f2 <<<"$run_state")"
+
+        # A cancelled promote stays fatal. When a newer push superseded this
+        # one, the caller is being torn down by its own concurrency group
+        # anyway, so nobody reads this result. When a human cancelled it, the
+        # deploy genuinely did not land, and passing here would hand the
+        # post-deploy smoke a commit that will never arrive: it would then
+        # block for its full readiness window and report the wrong thing.
+        if [[ "$conclusion" == "cancelled" ]]; then
+          echo "::error::Promote run was cancelled (superseded by a newer push, or cancelled manually): ${run_url}" >&2
+          exit 1
+        fi
+
+        echo "::error::Promote run finished with conclusion '${conclusion}': ${run_url}" >&2
+        exit 1

--- a/.github/actions/promote-dispatch/action.yml
+++ b/.github/actions/promote-dispatch/action.yml
@@ -106,13 +106,22 @@ runs:
         # (v1.2.3 vs v1.2.3-rc.1, v1.2.3-rc.1 vs v1.2.3-rc.10) never collide.
         echo "Dispatch accepted. Polling for the new run..."
         run_id=""
+        lookup_failures=0
         for attempt in {1..30}; do
-          run_id="$(
+          # `if !` keeps a failed lookup from tripping `set -e`. Empty output
+          # means the run has not appeared yet; a non-zero exit means the API
+          # call itself failed (rate limit, 5xx, network blip). Both are worth
+          # retrying, but only the second is worth reporting.
+          if ! run_id="$(
             gh api \
               "/repos/${INFRA_REPO}/actions/workflows/${WORKFLOW_FILE}/runs?event=workflow_dispatch&per_page=10" \
               --jq ".workflow_runs[] | select(.created_at >= \"${dispatched_at}\") | select(.display_title == \"${expected_title}\") | .id" \
               | head -n 1
-          )"
+          )"; then
+            lookup_failures=$((lookup_failures + 1))
+            echo "Run lookup failed (attempt ${attempt}/30); retrying..."
+            run_id=""
+          fi
           if [[ -n "$run_id" ]]; then
             echo "Found dispatched run: ${run_id} (attempt ${attempt}/30)"
             break
@@ -121,7 +130,11 @@ runs:
         done
 
         if [[ -z "$run_id" ]]; then
-          echo "::error::Dispatched a promote run but never observed it in the workflow's run list." >&2
+          if [[ "$lookup_failures" -gt 0 ]]; then
+            echo "::error::Dispatched a promote run but could not look it up (${lookup_failures}/30 lookups failed). The promote may still be running: check ${INFRA_REPO}." >&2
+          else
+            echo "::error::Dispatched a promote run but never observed it in the workflow's run list." >&2
+          fi
           exit 1
         fi
 
@@ -130,12 +143,27 @@ runs:
           exit 0
         fi
 
-        run_state="$(
+        # The watch failed, so this job fails either way. Read the run back
+        # only to say why. A lookup that itself fails must not mask that with
+        # `set -e` killing the step silently.
+        run_url="${INFRA_REPO}/actions/runs/${run_id}"
+        if ! run_state="$(
           gh api "/repos/${INFRA_REPO}/actions/runs/${run_id}" \
             --jq '[.conclusion, .html_url] | @tsv'
-        )"
+        )"; then
+          echo "::error::Promote run ${run_id} did not complete successfully, and reading its final state failed. Check https://github.com/${run_url}" >&2
+          exit 1
+        fi
         conclusion="$(cut -f1 <<<"$run_state")"
         run_url="$(cut -f2 <<<"$run_state")"
+
+        # `gh run watch` can exit non-zero without the run having concluded,
+        # for example when the watch itself lost the API. Reporting an empty
+        # conclusion as a verdict would be misleading.
+        if [[ -z "$conclusion" || "$conclusion" == "null" ]]; then
+          echo "::error::Lost track of promote run ${run_id} before it concluded: ${run_url}" >&2
+          exit 1
+        fi
 
         # A cancelled promote stays fatal. When a newer push superseded this
         # one, the caller is being torn down by its own concurrency group

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -96,29 +96,30 @@ jobs:
           repositories: ${{ vars.STAGING_DEPLOY_REPOSITORY }}
           permission-actions: write
 
-      - name: Request staging deployment
+      - name: Check staging deployment target is configured
         env:
-          GH_TOKEN: ${{ steps.deployment-token.outputs.token }}
           DEPLOY_REPOSITORY: ${{ github.repository_owner }}/${{ vars.STAGING_DEPLOY_REPOSITORY }}
           DEPLOY_WORKFLOW: ${{ vars.STAGING_DEPLOY_WORKFLOW }}
-          RELEASE_REF: ${{ steps.ref.outputs.release_ref }}
-          GIT_SHA: ${{ github.sha }}
-          IMAGE_DIGEST: ${{ steps.build.outputs.digest }}
         run: |
           if [[ -z "${DEPLOY_REPOSITORY#*/}" || -z "$DEPLOY_WORKFLOW" ]]; then
             echo "::error::Staging deployment target is not configured." >&2
             exit 1
           fi
 
-          gh api --method POST \
-            "/repos/${DEPLOY_REPOSITORY}/actions/workflows/${DEPLOY_WORKFLOW}/dispatches" \
-            -f "ref=main" \
-            -f "inputs[release_ref]=${RELEASE_REF}" \
-            -f "inputs[target_environment]=staging" \
-            -f "inputs[image_digest]=${IMAGE_DIGEST}" \
-            -f "inputs[git_sha]=${GIT_SHA}" \
-            -f "inputs[run_migrations]=true" \
-            -f "inputs[frontend]=true"
+      # Watches the dispatched run to completion: a promote that fails after
+      # the dispatch is accepted must fail this job, so verify-staging is
+      # skipped by `needs` instead of blocking on a commit that will never
+      # be served.
+      - name: Deploy to staging
+        uses: ./.github/actions/promote-dispatch
+        with:
+          token: ${{ steps.deployment-token.outputs.token }}
+          infra-repo: ${{ github.repository_owner }}/${{ vars.STAGING_DEPLOY_REPOSITORY }}
+          workflow-file: ${{ vars.STAGING_DEPLOY_WORKFLOW }}
+          release-ref: ${{ steps.ref.outputs.release_ref }}
+          target-environment: staging
+          image-digest: ${{ steps.build.outputs.digest }}
+          git-sha: ${{ github.sha }}
 
   # Post-deploy verification: authenticate via the secret-guarded
   # /smoke/session endpoint and click through the deployed app so a

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -532,6 +532,14 @@ jobs:
     permissions:
       contents: read
     steps:
+      # Checked out before the promote because the dispatch runs from a local
+      # composite action, and again supplies the verification script below.
+      - name: Checkout release source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.resolve.outputs.release_sha }}
+          persist-credentials: false
+
       - name: Mint App token for the infra repo
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
@@ -542,73 +550,13 @@ jobs:
           repositories: stella-infra
           permission-actions: write
 
-      - name: Dispatch and watch promote-release.yml
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          RELEASE_REF: ${{ needs.resolve.outputs.release_ref }}
-          TARGET_ENV: production
-          INFRA_REPO: ${{ github.repository_owner }}/stella-infra
-        run: |
-          set -euo pipefail
-          dispatched_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-          # Must match the `run-name:` template in
-          # stella-infra/.github/workflows/promote-release.yml
-          expected_title="Promote ${RELEASE_REF} → ${TARGET_ENV}"
-
-          # Use the dispatches REST endpoint directly. `gh workflow
-          # run` first looks up the workflow by filename and the
-          # repo's default branch; with the narrowly-scoped App
-          # token (permission-actions: write only, no contents/
-          # metadata) those implicit lookups can fail silently and
-          # kill the step in well under a second with no output.
-          # Calling /dispatches directly uses exactly the
-          # actions:write we have and any failure surfaces as a
-          # real HTTP error in the log.
-          echo "Dispatching promote-release.yml on ${INFRA_REPO} (target=${TARGET_ENV}, release=${RELEASE_REF})..."
-          gh api --method POST \
-            "/repos/${INFRA_REPO}/actions/workflows/promote-release.yml/dispatches" \
-            -f "ref=main" \
-            -f "inputs[release_ref]=${RELEASE_REF}" \
-            -f "inputs[target_environment]=${TARGET_ENV}" \
-            -f "inputs[run_migrations]=true" \
-            -f "inputs[frontend]=true"
-
-          echo "Dispatch accepted. Polling for the new run..."
-          run_id=""
-          for attempt in {1..30}; do
-            # Match by exact display_title so concurrent dispatches
-            # cannot be confused, and prefix-overlapping refs
-            # (v1.2.3 vs v1.2.3-rc.1, v1.2.3-rc.1 vs v1.2.3-rc.10)
-            # never collide.
-            run_id="$(
-              gh api \
-                "/repos/${INFRA_REPO}/actions/workflows/promote-release.yml/runs?event=workflow_dispatch&per_page=10" \
-                --jq ".workflow_runs[] | select(.created_at >= \"${dispatched_at}\") | select(.display_title == \"${expected_title}\") | .id" \
-                | head -n 1
-            )"
-            if [[ -n "$run_id" ]]; then
-              echo "Found dispatched run: ${run_id} (attempt ${attempt}/30)"
-              break
-            fi
-            sleep 2
-          done
-
-          if [[ -z "$run_id" ]]; then
-            echo "::error::Dispatched a promote run but never observed it in the workflow's run list." >&2
-            exit 1
-          fi
-
-          echo "Watching run ${run_id}..."
-          gh run watch "$run_id" \
-            --repo "$INFRA_REPO" \
-            --compact \
-            --exit-status
-
-      - name: Checkout release verification script
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Promote to production
+        uses: ./.github/actions/promote-dispatch
         with:
-          ref: ${{ needs.resolve.outputs.release_sha }}
-          persist-credentials: false
+          token: ${{ steps.app-token.outputs.token }}
+          infra-repo: ${{ github.repository_owner }}/stella-infra
+          release-ref: ${{ needs.resolve.outputs.release_ref }}
+          target-environment: production
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
@@ -634,6 +582,14 @@ jobs:
     permissions:
       contents: read
     steps:
+      # The dispatch runs from a local composite action, so the workspace has
+      # to hold this release's source before it can be resolved.
+      - name: Checkout release source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.resolve.outputs.release_sha }}
+          persist-credentials: false
+
       - name: Mint App token for the infra repo
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
@@ -644,53 +600,10 @@ jobs:
           repositories: stella-infra
           permission-actions: write
 
-      - name: Dispatch and watch promote-release.yml (staging)
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          RELEASE_REF: ${{ needs.resolve.outputs.release_ref }}
-          TARGET_ENV: staging
-          INFRA_REPO: ${{ github.repository_owner }}/stella-infra
-        run: |
-          set -euo pipefail
-          dispatched_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-          # Must match the `run-name:` template in
-          # stella-infra/.github/workflows/promote-release.yml
-          expected_title="Promote ${RELEASE_REF} → ${TARGET_ENV}"
-
-          # See the production variant above for why we call the
-          # dispatches endpoint directly instead of `gh workflow run`.
-          echo "Dispatching promote-release.yml on ${INFRA_REPO} (target=${TARGET_ENV}, release=${RELEASE_REF})..."
-          gh api --method POST \
-            "/repos/${INFRA_REPO}/actions/workflows/promote-release.yml/dispatches" \
-            -f "ref=main" \
-            -f "inputs[release_ref]=${RELEASE_REF}" \
-            -f "inputs[target_environment]=${TARGET_ENV}" \
-            -f "inputs[run_migrations]=true" \
-            -f "inputs[frontend]=true"
-
-          echo "Dispatch accepted. Polling for the new run..."
-          run_id=""
-          for attempt in {1..30}; do
-            run_id="$(
-              gh api \
-                "/repos/${INFRA_REPO}/actions/workflows/promote-release.yml/runs?event=workflow_dispatch&per_page=10" \
-                --jq ".workflow_runs[] | select(.created_at >= \"${dispatched_at}\") | select(.display_title == \"${expected_title}\") | .id" \
-                | head -n 1
-            )"
-            if [[ -n "$run_id" ]]; then
-              echo "Found dispatched run: ${run_id} (attempt ${attempt}/30)"
-              break
-            fi
-            sleep 2
-          done
-
-          if [[ -z "$run_id" ]]; then
-            echo "::error::Dispatched a promote run but never observed it in the workflow's run list." >&2
-            exit 1
-          fi
-
-          echo "Watching run ${run_id}..."
-          gh run watch "$run_id" \
-            --repo "$INFRA_REPO" \
-            --compact \
-            --exit-status
+      - name: Promote to staging
+        uses: ./.github/actions/promote-dispatch
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          infra-repo: ${{ github.repository_owner }}/stella-infra
+          release-ref: ${{ needs.resolve.outputs.release_ref }}
+          target-environment: staging

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -532,12 +532,14 @@ jobs:
     permissions:
       contents: read
     steps:
-      # Checked out before the promote because the dispatch runs from a local
-      # composite action, and again supplies the verification script below.
-      - name: Checkout release source
+      # The dispatch runs from a local composite action, so the workspace has
+      # to hold the workflow's own revision rather than the release's. This
+      # job can be dispatched manually against any existing tag, including one
+      # cut before the action existed: checking out that release first would
+      # leave `uses: ./...` unresolvable and fail before dispatching.
+      - name: Checkout workflow source
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ needs.resolve.outputs.release_sha }}
           persist-credentials: false
 
       - name: Mint App token for the infra repo
@@ -557,6 +559,14 @@ jobs:
           infra-repo: ${{ github.repository_owner }}/stella-infra
           release-ref: ${{ needs.resolve.outputs.release_ref }}
           target-environment: production
+
+      # Swap the workspace to the release being promoted: the verification
+      # script must come from that revision, not from the workflow's.
+      - name: Checkout release verification script
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.resolve.outputs.release_sha }}
+          persist-credentials: false
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
@@ -582,12 +592,13 @@ jobs:
     permissions:
       contents: read
     steps:
-      # The dispatch runs from a local composite action, so the workspace has
-      # to hold this release's source before it can be resolved.
-      - name: Checkout release source
+      # The workflow's own revision, not the release's: this job can be
+      # dispatched manually against a tag cut before the composite action
+      # existed, and only the workflow revision is guaranteed to contain it.
+      # Nothing here reads the release source, so it is never checked out.
+      - name: Checkout workflow source
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ needs.resolve.outputs.release_sha }}
           persist-credentials: false
 
       - name: Mint App token for the infra repo


### PR DESCRIPTION
## Problem

`deploy-staging.yml` dispatched `promote-release.yml` and treated the accepted `202` as success:

```yaml
gh api --method POST ".../promote-release.yml/dispatches" -f ...
# job ends here, green
```

The dispatch being accepted says nothing about whether the deployment succeeded. When the promote failed after that point, `build-and-deploy` still went green, so `verify-staging` ran and blocked for its full 20-minute readiness window before failing with:

```
Staging did not stably serve <sha> within 1200s.
Last sample: api: ready (commit <new>); web: waiting (stale commit <old>)
```

That names the symptom, not the deploy that failed, and costs 20 CI minutes to say it.

`release.yml` already got this right for tagged releases: it dispatches, correlates the run it created, and watches it with `--exit-status`. That logic exists twice in the file, copy-pasted. `deploy-staging.yml` was the one call site that never got it.

## Change

Extract the dispatch-and-watch logic into `.github/actions/promote-dispatch` and use it from all three call sites.

The defect is not "deploy-staging forgot to watch"; it is that each call site independently decides whether to. A shared action makes watching what a call site gets by default, so a fourth one cannot quietly reintroduce this. Net `-130/+44` across the two workflows.

Behavior:

- Polls for the run it created, matching the infra workflow's `run-name` template on exact `display_title`, so concurrent dispatches and prefix-overlapping refs (`v1.2.3` vs `v1.2.3-rc.1`) cannot be confused.
- Watches to completion; on failure reports the conclusion and the run URL.
- `image_digest` and `git_sha` are sent only when set. The promote workflow rejects `git_sha` on tagged releases, where a populated value would silently swap the checked-out source for a different commit. The staging and production call sites keep exactly the argument sets they sent before.
- `workflow-file` stays configurable, so `vars.STAGING_DEPLOY_WORKFLOW` keeps working rather than being silently hardcoded.

A cancelled promote stays fatal. When a newer push superseded it, the caller is being cancelled by its own concurrency group anyway; when a human cancelled it, passing would hand the smoke a commit that never arrives and recreate the blind 20-minute wait.

Both `release.yml` jobs now check out the release source before dispatching, which a local composite action requires. The production job already checked out that same ref for its verification script, so that step just moves up; the staging job gains one.

## Verification

`actionlint` clean on both workflows; `shellcheck -S warning` clean on the action's script; all three files parse. The script was exercised against a stubbed `gh`:

| Case | Result |
| --- | --- |
| Watch succeeds | exit 0 |
| Watch fails, conclusion `cancelled` | exit 1, message distinguishes superseded from manual cancel |
| Watch fails, conclusion `failure` | exit 1, reports conclusion + run URL |
| Run never appears in the list | exit 1, `never observed it in the workflow's run list` |
| Digest and SHA set / unset | staging sends both, production sends neither |

## Follow-up

`READINESS_TIMEOUT_MS` in `apps/web/e2e/staging/global-setup.ts` can drop from 1200s to roughly 300s once this is in: the gate then only covers ECS and CDN rollover, not "did a deploy happen at all". Left for a separate PR so this one can be judged on the watch behavior alone.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a reusable deployment action that starts staging or production promotions and monitors them through to completion.
  - Deployment options now support release references, target environments, migration and frontend toggles, image digests, and Git revisions.

- **Bug Fixes**
  - Deployments now fail clearly when required targets are unavailable or when the promotion workflow cannot be located or completes unsuccessfully.
  - Staging deployments validate their configuration before attempting promotion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->