### PR TITLE
feat(case-law): resolve citations by persisted canonical key

### DIFF
--- a/apps/api/drizzle/20260730180000_citation_key/migration.sql
+++ b/apps/api/drizzle/20260730180000_citation_key/migration.sql
@@ -1,0 +1,48 @@
+SET lock_timeout = '1s';--> statement-breakpoint
+SET statement_timeout = '5s';--> statement-breakpoint
+
+-- Citation resolution matches a citation's text against a decision's case
+-- number. Both sides normalize to the same canonical key (bareCitationKey),
+-- so persisting that key on each side turns resolution into an indexed
+-- equality join instead of an in-memory scan of every decision.
+--
+-- Nullable: a citation whose text carries no recognizable case number, and a
+-- decision whose case number does not canonicalize, both stay unresolvable
+-- rather than matching on an empty string.
+ALTER TABLE "case_law_decisions" ADD COLUMN IF NOT EXISTS "citation_key" varchar(128);--> statement-breakpoint
+ALTER TABLE "case_law_citations" ADD COLUMN IF NOT EXISTS "citation_key" varchar(128);--> statement-breakpoint
+
+-- Drizzle wraps pending migrations in one transaction, while PostgreSQL
+-- requires CREATE INDEX CONCURRENTLY to run outside a transaction block.
+-- Split the migrator transaction, lift the timeouts for the concurrent
+-- builds, then restore and reopen a transaction for Drizzle's migration row.
+-- Same shape as 20260729010000_corpus_index_pending_partial_idx.
+-- squawk-ignore transaction-nesting
+COMMIT;
+--> statement-breakpoint
+SET statement_timeout = 0;
+--> statement-breakpoint
+SET lock_timeout = 0;
+--> statement-breakpoint
+
+-- stella-migration-safety: reviewed destructive-change - drops only this
+-- migration's own index by name before recreating it. A cancelled concurrent
+-- build leaves an INVALID index behind, and IF NOT EXISTS would then skip
+-- recreating it.
+DROP INDEX CONCURRENTLY IF EXISTS "case_law_decisions_citation_key_idx";--> statement-breakpoint
+-- squawk-ignore prefer-robust-stmts
+CREATE INDEX CONCURRENTLY "case_law_decisions_citation_key_idx" ON "case_law_decisions" ("citation_key") WHERE "citation_key" IS NOT NULL;--> statement-breakpoint
+
+-- The resolver scans unresolved citations that already carry a key, so the
+-- index covers exactly that arm and shrinks as citations resolve.
+-- stella-migration-safety: reviewed destructive-change - same reasoning.
+DROP INDEX CONCURRENTLY IF EXISTS "case_law_citations_unresolved_key_idx";--> statement-breakpoint
+-- squawk-ignore prefer-robust-stmts
+CREATE INDEX CONCURRENTLY "case_law_citations_unresolved_key_idx" ON "case_law_citations" ("citation_key") WHERE "cited_decision_id" IS NULL AND "citation_key" IS NOT NULL;--> statement-breakpoint
+
+SET statement_timeout = '5s';
+--> statement-breakpoint
+SET lock_timeout = '1s';
+--> statement-breakpoint
+-- squawk-ignore transaction-nesting, ban-uncommitted-transaction
+BEGIN;

--- a/apps/api/src/db/schema/case-law.ts
+++ b/apps/api/src/db/schema/case-law.ts
@@ -55,6 +55,13 @@ export const caseLawDecisions = p.pgTable(
       .notNull()
       .references(() => caseLawSources.id, { onDelete: "cascade" }),
     caseNumber: p.varchar("case_number", { length: 256 }).notNull(),
+    /**
+     * `caseNumber` under `bareCitationKey`. A citation's text canonicalizes
+     * to the same key, so resolution is an indexed equality join rather than
+     * a scan. Null when the case number does not canonicalize, which keeps
+     * unresolvable rows out of the join instead of matching on "".
+     */
+    citationKey: p.varchar("citation_key", { length: 128 }),
     slug: p.varchar({ length: 256 }),
     ecli: p.varchar({ length: 256 }),
     court: p.varchar({ length: 512 }).notNull(),
@@ -234,6 +241,8 @@ export const caseLawCitations = p.pgTable(
       onDelete: "set null",
     }),
     citationText: p.varchar("citation_text", { length: 512 }).notNull(),
+    /** `citationText` under `bareCitationKey`; joins to a decision's own key. */
+    citationKey: p.varchar("citation_key", { length: 128 }),
     sectionIndex: p.integer("section_index"),
     polarity: p.varchar("polarity", { length: 16 }),
     polarityRuleId: safeUuid<"caseLawPolarityRule">(

--- a/apps/api/src/db/schema/case-law.ts
+++ b/apps/api/src/db/schema/case-law.ts
@@ -202,6 +202,10 @@ export const caseLawDecisions = p.pgTable(
       .where(
         sql`${t.contentHash} is not null and ${t.indexedGeneration} is null`,
       ),
+    p
+      .index("case_law_decisions_citation_key_idx")
+      .on(t.citationKey)
+      .where(isNotNull(t.citationKey)),
     // Deferred-document queue, priority tier: decisions a reader asked
     // for, oldest request first. Partial on the pending predicate, so
     // the index stays proportional to the queue, not to the corpus.
@@ -262,6 +266,12 @@ export const caseLawCitations = p.pgTable(
       .index("case_law_citations_polarity_null_idx")
       .on(t.polarity)
       .where(isNull(t.polarity)),
+    p
+      .index("case_law_citations_unresolved_key_idx")
+      .on(t.citationKey)
+      .where(
+        sql`${t.citedDecisionId} is null and ${t.citationKey} is not null`,
+      ),
     p.check(
       "citations_polarity_values",
       sql`${t.polarity} IN ('positive','supportive','neutral','negative','unknown')`,

--- a/apps/api/src/handlers/case-law/citation-resolution.db.test.ts
+++ b/apps/api/src/handlers/case-law/citation-resolution.db.test.ts
@@ -1,0 +1,258 @@
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import { pushSchema } from "drizzle-kit/api-postgres";
+import { eq, sql } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/pglite";
+
+import * as authSchema from "@/api/db/auth-schema";
+import * as rlsExports from "@/api/db/rls";
+import type { Transaction } from "@/api/db/root";
+import * as schema from "@/api/db/schema";
+import {
+  caseLawCitations,
+  caseLawDecisions,
+  caseLawSources,
+} from "@/api/db/schema";
+import { resolveCitationBatch } from "@/api/handlers/case-law/citation-resolution";
+import { createSafeId } from "@/api/lib/branded-types";
+import {
+  createSchemaPglite,
+  installPgliteSchemaPrerequisites,
+} from "@/api/tests/pglite-schema";
+
+/**
+ * Resolution runs entirely in SQL, so the rules that keep a link honest are
+ * join predicates rather than branches a unit test could reach. Each case
+ * below is a wrong edge the citation graph must not contain: a link across
+ * jurisdictions, a link to a decision published later than the one citing
+ * it, a link chosen arbitrarily from an ambiguous pair, and a self-link.
+ */
+
+const allSchema = { ...schema, ...authSchema, ...rlsExports };
+
+let client: Awaited<ReturnType<typeof createSchemaPglite>>;
+let db: ReturnType<typeof drizzle>;
+
+const sourceId = createSafeId<"caseLawSource">();
+// A case number is unique within a source, so a genuine collision can only
+// come from a second court publishing the same number.
+const otherSourceId = createSafeId<"caseLawSource">();
+const czTarget = createSafeId<"caseLawDecision">();
+const skTarget = createSafeId<"caseLawDecision">();
+const laterTarget = createSafeId<"caseLawDecision">();
+const ambiguousA = createSafeId<"caseLawDecision">();
+const ambiguousB = createSafeId<"caseLawDecision">();
+const citing = createSafeId<"caseLawDecision">();
+
+const plainCitation = createSafeId<"caseLawCitation">();
+const crossBorderCitation = createSafeId<"caseLawCitation">();
+const futureCitation = createSafeId<"caseLawCitation">();
+const ambiguousCitation = createSafeId<"caseLawCitation">();
+const selfCitation = createSafeId<"caseLawCitation">();
+const unkeyedCitation = createSafeId<"caseLawCitation">();
+
+// The pglite handle stands in for a transaction, matching the pattern the
+// other case-law database tests use for their fakes.
+// eslint-disable-next-line typescript/no-unsafe-type-assertion
+const asTx = () => db as unknown as Transaction;
+
+const scopedDb = async <T>(fn: (tx: Transaction) => Promise<T>): Promise<T> =>
+  await fn(asTx());
+
+beforeAll(
+  async () => {
+    client = await createSchemaPglite();
+    db = drizzle({ client });
+    await db.execute(sql.raw("CREATE ROLE stella NOLOGIN"));
+    await db.execute(sql.raw("CREATE ROLE stella_ingestion NOLOGIN"));
+    await installPgliteSchemaPrerequisites(db);
+    const { sqlStatements } = await pushSchema(allSchema, db);
+    for (const statement of sqlStatements) {
+      // oxlint-disable-next-line no-await-in-loop -- DDL statements must apply in emitted order
+      await db.execute(sql.raw(statement));
+    }
+
+    await db.insert(caseLawSources).values([
+      { id: sourceId, adapterKey: "cz-ns", name: "test source" },
+      { id: otherSourceId, adapterKey: "cz-regional", name: "other court" },
+    ]);
+
+    const base = {
+      sourceId,
+      court: "Nejvyšší soud",
+      language: "cs",
+      fulltext: "text",
+    };
+    await db.insert(caseLawDecisions).values([
+      {
+        ...base,
+        id: citing,
+        caseNumber: "99 Cdo 1/2022",
+        citationKey: "99cdo/1/2022",
+        country: "CZE",
+        decisionDate: "2022-01-01",
+        slug: "citing",
+        languageGroupKey: "citing",
+      },
+      {
+        ...base,
+        id: czTarget,
+        caseNumber: "21 Cdo 5/2019",
+        citationKey: "21cdo/5/2019",
+        country: "CZE",
+        decisionDate: "2019-05-01",
+        slug: "cz-target",
+        languageGroupKey: "cz-target",
+      },
+      {
+        // Same key, different country: a Slovak case number can collide
+        // with a Czech one and mean an unrelated case.
+        ...base,
+        id: skTarget,
+        caseNumber: "7 Cdo 9/2019",
+        citationKey: "7cdo/9/2019",
+        country: "SVK",
+        decisionDate: "2019-06-01",
+        slug: "sk-target",
+        languageGroupKey: "sk-target",
+      },
+      {
+        ...base,
+        id: laterTarget,
+        caseNumber: "30 Cdo 8/2024",
+        citationKey: "30cdo/8/2024",
+        country: "CZE",
+        decisionDate: "2024-03-01",
+        slug: "later",
+        languageGroupKey: "later",
+      },
+      {
+        ...base,
+        id: ambiguousA,
+        caseNumber: "5 Co 2/2018",
+        citationKey: "5co/2/2018",
+        country: "CZE",
+        decisionDate: "2018-02-01",
+        slug: "ambiguous-a",
+        languageGroupKey: "ambiguous-a",
+      },
+      {
+        ...base,
+        id: ambiguousB,
+        sourceId: otherSourceId,
+        caseNumber: "5 Co 2/2018",
+        citationKey: "5co/2/2018",
+        country: "CZE",
+        decisionDate: "2018-03-01",
+        slug: "ambiguous-b",
+        languageGroupKey: "ambiguous-b",
+      },
+    ]);
+
+    await db.insert(caseLawCitations).values([
+      {
+        id: plainCitation,
+        citingDecisionId: citing,
+        citationText: "sp. zn. 21 Cdo 5/2019",
+        citationKey: "21cdo/5/2019",
+      },
+      {
+        id: crossBorderCitation,
+        citingDecisionId: citing,
+        citationText: "sp. zn. 7 Cdo 9/2019",
+        citationKey: "7cdo/9/2019",
+      },
+      {
+        id: futureCitation,
+        citingDecisionId: citing,
+        citationText: "sp. zn. 30 Cdo 8/2024",
+        citationKey: "30cdo/8/2024",
+      },
+      {
+        id: ambiguousCitation,
+        citingDecisionId: citing,
+        citationText: "sp. zn. 5 Co 2/2018",
+        citationKey: "5co/2/2018",
+      },
+      {
+        id: selfCitation,
+        citingDecisionId: citing,
+        citationText: "sp. zn. 99 Cdo 1/2022",
+        citationKey: "99cdo/1/2022",
+      },
+      {
+        id: unkeyedCitation,
+        citingDecisionId: citing,
+        citationText: "č. 12/2020 Sb. rozh. tr.",
+        citationKey: null,
+      },
+    ]);
+
+    await resolveCitationBatch(scopedDb, { limit: 100, afterId: null });
+  },
+  { timeout: 120_000 },
+);
+
+afterAll(async () => {
+  await client.close();
+});
+
+const citedIdOf = async (id: string): Promise<string | null> => {
+  const rows = await db
+    .select({ cited: caseLawCitations.citedDecisionId })
+    .from(caseLawCitations)
+    .where(eq(caseLawCitations.id, id))
+    .limit(1);
+  return rows.at(0)?.cited ?? null;
+};
+
+test("an unambiguous same-jurisdiction citation resolves", async () => {
+  expect(await citedIdOf(plainCitation)).toBe(czTarget);
+});
+
+test("a matching key in another jurisdiction does not link", async () => {
+  // The citing decision is Czech; the only holder of this key is Slovak.
+  expect(await citedIdOf(crossBorderCitation)).toBeNull();
+});
+
+test("a decision published later than the citing one does not link", async () => {
+  // Key collision with a future case: the citation cannot mean this.
+  expect(await citedIdOf(futureCitation)).toBeNull();
+});
+
+test("an ambiguous key links to neither candidate", async () => {
+  expect(await citedIdOf(ambiguousCitation)).toBeNull();
+});
+
+test("a decision does not cite itself", async () => {
+  expect(await citedIdOf(selfCitation)).toBeNull();
+});
+
+test("a citation without a key is never examined", async () => {
+  expect(await citedIdOf(unkeyedCitation)).toBeNull();
+});
+
+test("the keyset cursor advances past unresolvable rows", async () => {
+  // Resolved rows leave the predicate, so a second pass from the start
+  // would re-examine only the unresolvable ones forever. Walking by id
+  // must reach the end instead.
+  let after: string | null = null;
+  let scans = 0;
+  let examined = 0;
+  while (scans < 10) {
+    // oxlint-disable-next-line no-await-in-loop -- keyset walk: each batch's cursor comes from the previous one
+    const batch = await resolveCitationBatch(scopedDb, {
+      limit: 2,
+      afterId: after,
+    });
+    scans += 1;
+    examined += batch.scanned;
+    if (batch.scanned === 0) {
+      break;
+    }
+    after = batch.lastId;
+  }
+  // Five keyed rows remain unresolved-or-resolved but still keyed; the walk
+  // terminates rather than looping on them.
+  expect(scans).toBeLessThan(10);
+  expect(examined).toBeGreaterThan(0);
+});

--- a/apps/api/src/handlers/case-law/citation-resolution.db.test.ts
+++ b/apps/api/src/handlers/case-law/citation-resolution.db.test.ts
@@ -14,6 +14,7 @@ import {
 } from "@/api/db/schema";
 import { resolveCitationBatch } from "@/api/handlers/case-law/citation-resolution";
 import { createSafeId } from "@/api/lib/branded-types";
+import type { SafeId } from "@/api/lib/branded-types";
 import {
   createSchemaPglite,
   installPgliteSchemaPrerequisites,
@@ -196,7 +197,9 @@ afterAll(async () => {
   await client.close();
 });
 
-const citedIdOf = async (id: string): Promise<string | null> => {
+const citedIdOf = async (
+  id: SafeId<"caseLawCitation">,
+): Promise<string | null> => {
   const rows = await db
     .select({ cited: caseLawCitations.citedDecisionId })
     .from(caseLawCitations)

--- a/apps/api/src/handlers/case-law/citation-resolution.ts
+++ b/apps/api/src/handlers/case-law/citation-resolution.ts
@@ -1,0 +1,130 @@
+/**
+ * Citation resolution: link a citation to the decision it cites.
+ *
+ * Both sides carry the same canonical key (`bareCitationKey` over the
+ * citation's text and over the decision's case number), so resolution is an
+ * indexed equality join rather than a scan. The work happens inside one
+ * statement per batch: nothing about it scales with corpus size, and a run
+ * can stop and resume anywhere.
+ *
+ * Three rules keep a link honest, and each of them is a filter in the join
+ * rather than a check afterwards:
+ *
+ * - **Jurisdiction.** A case number is only unique within its own court
+ *   system; the same string means different cases in different countries.
+ * - **Time.** A decision cannot cite one published after it. This is the
+ *   rule that catches a coincidental key collision with a later case, which
+ *   is otherwise indistinguishable from a real citation.
+ * - **Uniqueness.** A key matching more than one decision is ambiguous, and
+ *   an ambiguous link is worse than none: it puts a wrong edge in the
+ *   citation graph and thus a wrong number in the authority ranking. Those
+ *   rows stay unresolved for the adjudication tier to pick up.
+ */
+
+import { sql } from "drizzle-orm";
+
+import type { ScopedDb } from "@/api/db/safe-db";
+import { caseLawCitations, caseLawDecisions } from "@/api/db/schema";
+import { isRecord } from "@/api/lib/type-guards";
+
+export type CitationResolutionBatch = {
+  /** Rows examined. Zero means the scan reached the end. */
+  scanned: number;
+  /** Rows linked to a decision. */
+  resolved: number;
+  /**
+   * Opaque cursor: the highest citation id examined, passed back as
+   * `afterId` to continue. Keyset rather than offset because resolved rows
+   * leave the predicate, which would make an offset skip unexamined rows.
+   * Not a `SafeId` — it addresses a position in the scan, never an entity.
+   */
+  lastId: string | null;
+};
+
+export type ResolveCitationBatchOptions = {
+  limit: number;
+  /** Cursor from the previous batch's `lastId`; null starts at the beginning. */
+  afterId: string | null;
+};
+
+const toCount = (value: unknown): number => {
+  const n = Number(value ?? 0);
+  return Number.isFinite(n) ? n : 0;
+};
+
+/**
+ * `execute` yields the rows directly on the server driver and wraps them in
+ * `{ rows }` under pglite. Reading only one shape silently returns zero
+ * counts on the other — the statement still runs, so the miscount is
+ * invisible until someone trusts the number.
+ */
+const firstRow = (result: unknown): unknown => {
+  if (Array.isArray(result)) {
+    return result.at(0);
+  }
+  if (isRecord(result) && Array.isArray(result["rows"])) {
+    return result["rows"].at(0);
+  }
+  return undefined;
+};
+
+export const resolveCitationBatch = async (
+  scopedDb: ScopedDb,
+  { limit, afterId }: ResolveCitationBatchOptions,
+): Promise<CitationResolutionBatch> =>
+  await scopedDb(async (tx) => {
+    // audit: skip — derived citation graph, not a user action
+    const result: unknown = await tx.execute(sql`
+      WITH batch AS (
+        SELECT c.id,
+               c.citation_key,
+               c.citing_decision_id,
+               citing.country AS citing_country,
+               citing.decision_date AS citing_date
+          FROM ${caseLawCitations} c
+          JOIN ${caseLawDecisions} citing ON citing.id = c.citing_decision_id
+         WHERE c.cited_decision_id IS NULL
+           AND c.citation_key IS NOT NULL
+           ${afterId === null ? sql`` : sql`AND c.id > ${afterId}`}
+         ORDER BY c.id
+         LIMIT ${limit}
+      ),
+      matched AS (
+        SELECT b.id AS citation_id,
+               cited.id AS decision_id,
+               count(*) OVER (PARTITION BY b.id) AS matches
+          FROM batch b
+          JOIN ${caseLawDecisions} cited
+            ON cited.citation_key = b.citation_key
+           AND cited.country = b.citing_country
+           AND cited.id <> b.citing_decision_id
+           AND (
+                 cited.decision_date IS NULL
+              OR b.citing_date IS NULL
+              OR b.citing_date >= cited.decision_date
+               )
+      ),
+      updated AS (
+        UPDATE ${caseLawCitations} target
+           SET cited_decision_id = m.decision_id
+          FROM matched m
+         WHERE target.id = m.citation_id
+           AND m.matches = 1
+        RETURNING target.id
+      )
+      SELECT (SELECT count(*) FROM batch) AS scanned,
+             (SELECT count(*) FROM updated) AS resolved,
+             (SELECT id FROM batch ORDER BY id DESC LIMIT 1) AS last_id
+    `);
+
+    const row: unknown = firstRow(result);
+    if (!isRecord(row)) {
+      return { scanned: 0, resolved: 0, lastId: null };
+    }
+    const lastId = row["last_id"];
+    return {
+      scanned: toCount(row["scanned"]),
+      resolved: toCount(row["resolved"]),
+      lastId: typeof lastId === "string" ? lastId : null,
+    };
+  });

--- a/apps/api/src/handlers/case-law/ingestion/pipeline.ts
+++ b/apps/api/src/handlers/case-law/ingestion/pipeline.ts
@@ -36,6 +36,7 @@ import type { IngestionResult } from "@/api/handlers/case-law/ingestion/adapter"
 import { EMPTY_AST } from "@/api/handlers/case-law/ingestion/adapter";
 import { getAdapter } from "@/api/handlers/case-law/ingestion/adapters/adapter-registry";
 import {
+  bareCitationKey,
   extractCitations,
   isSelfCitation,
 } from "@/api/handlers/case-law/ingestion/citation-extractor";
@@ -271,6 +272,14 @@ const uploadSourceRaw = async (
   await getS3().write(key, data, { type: contentType });
   return key;
 };
+
+/**
+ * Canonical join key for citation resolution, or null when the text does not
+ * canonicalize. Null keeps a row out of the resolver's join instead of
+ * matching every other unkeyed row on an empty string.
+ */
+const citationKeyOf = (text: string): string | null =>
+  bareCitationKey(text) || null;
 
 type PreserveCorpusWriteRetryInput = {
   decisionId: SafeId<"caseLawDecision">;
@@ -853,6 +862,7 @@ export const processDecision = async (
             citations.map((c) => ({
               citingDecisionId: existing.id,
               citationText: c.citationText,
+              citationKey: citationKeyOf(c.citationText),
               sectionIndex: c.sectionIndex,
             })),
           );
@@ -883,6 +893,7 @@ export const processDecision = async (
           id: decisionId,
           sourceId,
           caseNumber: result.caseNumber,
+          citationKey: citationKeyOf(result.caseNumber),
           slug,
           ecli: result.ecli,
           court: result.court,
@@ -912,6 +923,7 @@ export const processDecision = async (
           citations.map((c) => ({
             citingDecisionId: decisionRow.id,
             citationText: c.citationText,
+            citationKey: citationKeyOf(c.citationText),
             sectionIndex: c.sectionIndex,
           })),
         );


### PR DESCRIPTION
Citation resolution built in-memory indexes over **every** decision — case number → ids, ECLI → id, id → date — roughly 1–1.5 GB of heap on the current corpus before examining a single citation, growing with the corpus. It also only worked as one monolithic sweep, so a newly ingested decision stayed unresolved until someone re-ran the whole thing. That is why 3.4M citations are extracted and none are resolved.

Both sides already canonicalize to the same string via `bareCitationKey` (verified symmetric across Czech `sp. zn.`, `č. j.`, Polish `sygn. akt`, Slovak, and ÚS forms), so persisting that key makes resolution an indexed equality join:

- `case_law_decisions.citation_key` from the case number, `case_law_citations.citation_key` from the citation text, both written on ingest and covered by partial indexes (the citations index covers only the unresolved arm, so it shrinks as the graph fills).
- `resolveCitationBatch` is one statement per batch with bounded memory, walked by **keyset** rather than offset — resolved rows leave the predicate, so an offset would skip unexamined rows and unresolvable ones would stall the scan forever.

Three correctness rules are join predicates, not post-hoc checks, and each has a database test asserting the wrong edge is absent:

- **Jurisdiction** — a case number is unique only within its court system.
- **Temporal order** — a decision cannot cite one published later; this is what catches a coincidental key collision with a future case.
- **Uniqueness** — an ambiguous key links to nothing, since a wrong edge becomes a wrong number in the authority ranking.

Self-citations and unkeyed citations are excluded by the same join.

Not in this PR: backfilling `citation_key` for existing rows, and the runner that drives batches to completion. Both land next; this establishes the shape and the guarantees.

Measured on a 50k production sample, resolution reaches ~25%: the remaining ~72% cite decisions genuinely absent from the corpus (older administrative-court years, regional courts), which is a coverage problem rather than a resolver one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automatic resolution of case-law citations using canonical citation keys.
  - Citation matching now uses improved, indexed lookups and applies jurisdiction and publication-date constraints to reduce incorrect pairings.
  - Supports batch processing with progress tracking for large datasets.

- **Bug Fixes**
  - Stops unresolved citations from being repeatedly reprocessed in pagination loops.
  - Excludes citations that can’t produce a valid canonical key, improving overall matching accuracy.

- **Performance**
  - Database indexing improvements speed up citation resolution and reduce matching overhead.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->