### PR TITLE
feat(case-law): record crawl coverage per slice

### DIFF
--- a/apps/api/drizzle/20260730210000_coverage_slices/migration.sql
+++ b/apps/api/drizzle/20260730210000_coverage_slices/migration.sql
@@ -1,0 +1,37 @@
+SET lock_timeout = '1s';--> statement-breakpoint
+SET statement_timeout = '5s';--> statement-breakpoint
+
+-- Per-slice crawl coverage: the count a court reports for a slice against
+-- what the crawl stored. A partial crawl is otherwise indistinguishable
+-- from a quiet day, and a forward-only cursor never revisits, so the loss
+-- is silent and permanent. A row per slice makes the shortfall queryable.
+CREATE TABLE IF NOT EXISTS "case_law_coverage_slices" (
+  "id" uuid PRIMARY KEY NOT NULL,
+  "source_id" uuid NOT NULL,
+  "slice" varchar(64) NOT NULL,
+  "reported" integer NOT NULL,
+  "collected" integer NOT NULL,
+  "checked_at" timestamptz DEFAULT now() NOT NULL
+);--> statement-breakpoint
+
+-- squawk-ignore prefer-robust-stmts
+ALTER TABLE "case_law_coverage_slices"
+  ADD CONSTRAINT "case_law_coverage_slices_source_id_case_law_sources_id_fk"
+  FOREIGN KEY ("source_id") REFERENCES "public"."case_law_sources"("id")
+  ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+
+CREATE UNIQUE INDEX IF NOT EXISTS "case_law_coverage_slices_source_slice_idx"
+  ON "case_law_coverage_slices" ("source_id","slice");--> statement-breakpoint
+
+-- The reconciliation pass reads only short slices, so the index covers
+-- that arm and shrinks as gaps close.
+CREATE INDEX IF NOT EXISTS "case_law_coverage_slices_short_idx"
+  ON "case_law_coverage_slices" ("source_id","slice")
+  WHERE "collected" < "reported";--> statement-breakpoint
+
+ALTER TABLE "case_law_coverage_slices" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+
+-- Same access shape as every other case-law table: readable by the app
+-- role, writable only by ingestion.
+CREATE POLICY "case_law_global_access" ON "case_law_coverage_slices" AS PERMISSIVE FOR SELECT TO "stella" USING (true);--> statement-breakpoint
+CREATE POLICY "case_law_ingestion_access" ON "case_law_coverage_slices" AS PERMISSIVE FOR ALL TO "stella_ingestion" USING (true) WITH CHECK (true);

--- a/apps/api/drizzle/20260730210000_coverage_slices/migration.sql
+++ b/apps/api/drizzle/20260730210000_coverage_slices/migration.sql
@@ -34,4 +34,9 @@ ALTER TABLE "case_law_coverage_slices" ENABLE ROW LEVEL SECURITY;--> statement-b
 -- Same access shape as every other case-law table: readable by the app
 -- role, writable only by ingestion.
 CREATE POLICY "case_law_global_access" ON "case_law_coverage_slices" AS PERMISSIVE FOR SELECT TO "stella" USING (true);--> statement-breakpoint
-CREATE POLICY "case_law_ingestion_access" ON "case_law_coverage_slices" AS PERMISSIVE FOR ALL TO "stella_ingestion" USING (true) WITH CHECK (true);
+CREATE POLICY "case_law_ingestion_access" ON "case_law_coverage_slices" AS PERMISSIVE FOR ALL TO "stella_ingestion" USING (true) WITH CHECK (true);--> statement-breakpoint
+
+-- The app role reads the ledger (coverage reporting); only ingestion
+-- writes it. RLS restricts rows, grants restrict verbs — both are needed.
+GRANT SELECT ON TABLE "case_law_coverage_slices" TO stella;--> statement-breakpoint
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE "case_law_coverage_slices" TO stella_ingestion;

--- a/apps/api/src/db/schema/case-law.ts
+++ b/apps/api/src/db/schema/case-law.ts
@@ -232,6 +232,44 @@ export const caseLawDecisions = p.pgTable(
   ],
 );
 
+/**
+ * Per-slice crawl coverage: what a court said a slice contains against what
+ * the crawl stored for it.
+ *
+ * Without this, a partial crawl is indistinguishable from a quiet day, and
+ * the loss is silent and permanent — a forward-only cursor never revisits.
+ * A row per slice makes the shortfall queryable, so re-crawls target the
+ * slices that are actually short instead of re-running whole years.
+ */
+export const caseLawCoverageSlices = p.pgTable(
+  "case_law_coverage_slices",
+  {
+    id: pUuid<"caseLawCoverageSlice">().primaryKey(),
+    sourceId: safeUuid<"caseLawSource">("source_id")
+      .notNull()
+      .references(() => caseLawSources.id, { onDelete: "cascade" }),
+    /** The crawl slice, e.g. an ISO day for date-cursor adapters. */
+    slice: p.varchar({ length: 64 }).notNull(),
+    /** The source's own count for this slice. */
+    reported: p.integer().notNull(),
+    /** What the crawl produced for it. */
+    collected: p.integer().notNull(),
+    checkedAt: timestamptz("checked_at").defaultNow().notNull(),
+  },
+  (t) => [
+    p
+      .uniqueIndex("case_law_coverage_slices_source_slice_idx")
+      .on(t.sourceId, t.slice),
+    // The reconciliation pass reads only the short slices, so the index
+    // covers that arm and shrinks as gaps close.
+    p
+      .index("case_law_coverage_slices_short_idx")
+      .on(t.sourceId, t.slice)
+      .where(sql`${t.collected} < ${t.reported}`),
+    ...globalCaseLawPolicies(),
+  ],
+);
+
 export const caseLawCitations = p.pgTable(
   "case_law_citations",
   {

--- a/apps/api/src/handlers/case-law/CLAUDE.md
+++ b/apps/api/src/handlers/case-law/CLAUDE.md
@@ -268,6 +268,47 @@ from scratch, causing an infinite re-scan loop where every
 previously ingested decision is re-fetched, hash-checked,
 and skipped, consuming the page budget with zero progress.
 
+### 14. A missing continuation token is a failure, not an ending
+
+Pagination ends when the source says there is nothing more, never
+because the next-page token is absent. Treating a **full** page
+with no token as "slice complete" silently drops the remainder,
+and a forward-only cursor never returns to it, so the loss is
+permanent and invisible.
+
+The signature is recognisable: stored counts per slice top out at
+a multiple of the page size, with slices piling up on that ceiling.
+
+Fail loudly instead. Throwing holds the cursor and retries the
+slice; a bad crawl that stops is recoverable, a bad crawl that
+skips is not.
+
+### 15. Report coverage against the source's own count
+
+Where a source states how many records a query matched (a result
+count on a search page, a `totalElements` in an API envelope),
+carry it back on the page that completes the slice as
+`SliceCoverage` — `{ slice, reported, collected }`. The pipeline
+persists it, so a shortfall becomes a queryable row rather than
+an inference.
+
+Without it, an incomplete crawl and a genuinely quiet slice are
+indistinguishable, and neither the operator nor a repair pass has
+anything to act on. An adapter whose source publishes no count
+omits the field; that is a known blind spot, not a silent one.
+
+### 16. A forward-only cursor cannot repair history
+
+An adapter that walks dates or ids in one direction and parks at
+the present will never revisit what it passed. Any hole — from a
+failed fetch, a truncated page, or a range crawled before a
+parser fix — stays a hole forever.
+
+So the repair path has to exist separately from the live cursor:
+a reconciliation pass that reads the coverage ledger (rule 15)
+and re-crawls the slices that are short. Do not rely on "it will
+come around again", because it will not.
+
 ## DocumentAst Conventions
 
 ```typescript
@@ -309,6 +350,12 @@ When adding a new country adapter:
 7. **Add adapter key** to `consts.ts` `ADAPTER_KEYS`
 8. **Test with real data** — seed 3+ decisions, verify metadata
    completeness, check AST content retention
+9. **Prove the pagination terminates for the right reason** — force
+   a slice larger than one page and confirm the adapter follows it
+   to the end rather than stopping at a page boundary (rules 14-16)
+10. **Wire the coverage count** — if the source reports a total for
+    a query, return `SliceCoverage`; if it does not, say so in the
+    adapter's doc comment so the blind spot is recorded
 
 ## File Map
 

--- a/apps/api/src/handlers/case-law/ingestion/adapter.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapter.ts
@@ -58,10 +58,34 @@ export type IngestionResult = {
   sourceRawContentType?: string | undefined;
 };
 
+/**
+ * What a source says it holds for the slice just crawled, against what the
+ * crawl actually produced.
+ *
+ * Coverage is otherwise unknowable: a crawl that silently stops early looks
+ * exactly like a slice with fewer decisions in it. Reporting the source's
+ * own count next to the collected count turns that into a number the
+ * reconciliation pass can act on. Adapters whose source publishes no count
+ * omit it, and their slices are simply not tracked.
+ */
+export type SliceCoverage = {
+  /**
+   * The crawl slice these counts describe — a calendar day for date-cursor
+   * adapters. Stable across re-crawls, since it keys the ledger row.
+   */
+  slice: string;
+  /** How many records the source says the slice contains. */
+  reported: number;
+  /** How many this crawl produced for it. */
+  collected: number;
+};
+
 /** A page of ingestion results with an optional cursor. */
 export type SyncPage = {
   decisions: IngestionResult[];
   nextCursor: string | null;
+  /** Present on the page that completes a slice; see `SliceCoverage`. */
+  coverage?: SliceCoverage | undefined;
 };
 
 /**

--- a/apps/api/src/handlers/case-law/ingestion/adapters/cz-nss.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/cz-nss.ts
@@ -10,6 +10,7 @@ import { EMPTY_AST } from "@/api/handlers/case-law/ingestion/adapter";
 import type {
   EmptyAst,
   IngestionResult,
+  SliceCoverage,
   SourceAdapter,
 } from "@/api/handlers/case-law/ingestion/adapter";
 import {
@@ -965,26 +966,19 @@ export const czNssAdapter: SourceAdapter = {
           };
         }
 
-        // Day-completeness signal: the court states how many records its
-        // own search matched, so a partial crawl is measurable instead of
-        // inferred. Emitted on the last page of a day, where the running
-        // total is known.
-        if (page === 0 || rows.length < RESULTS_PER_PAGE) {
-          const reported = reportedResultCount(searchResult.html);
-          if (reported !== null) {
-            const collected = page * RESULTS_PER_PAGE + rows.length;
-            logger[collected < reported ? "warn" : "info"](
-              "case_law.ingestion.day_coverage",
-              {
-                adapterKey: ADAPTER_KEYS.CZ_NSS,
-                day: date,
+        // Day-completeness: the court states how many records its own
+        // search matched, so a partial crawl is measurable rather than
+        // inferred. Reported on the page that finishes the day, where the
+        // running total is known (see CLAUDE.md rule 15).
+        const reported = reportedResultCount(searchResult.html);
+        const dayCoverage: SliceCoverage | undefined =
+          reported === null
+            ? undefined
+            : {
+                slice: date,
                 reported,
-                collected,
-                missing: Math.max(0, reported - collected),
-              },
-            );
-          }
-        }
+                collected: page * RESULTS_PER_PAGE + rows.length,
+              };
 
         // A full page with no continuation token is not the end of the day
         // — it is a day whose remainder is unreachable. Advancing here
@@ -1004,6 +998,7 @@ export const czNssAdapter: SourceAdapter = {
         return {
           decisions,
           nextCursor: next <= today ? `${next}:0` : `${today}:0`,
+          ...(dayCoverage === undefined ? {} : { coverage: dayCoverage }),
         };
       },
       catch: adapterCatch(ADAPTER_KEYS.CZ_NSS, cursor),

--- a/apps/api/src/handlers/case-law/ingestion/coverage-ledger.ts
+++ b/apps/api/src/handlers/case-law/ingestion/coverage-ledger.ts
@@ -1,0 +1,52 @@
+/**
+ * Crawl-coverage ledger.
+ *
+ * A crawl that stops early is indistinguishable from a slice that simply
+ * held fewer decisions, and a forward-only cursor never revisits, so the
+ * shortfall is invisible and permanent. Recording the source's own count
+ * for a slice next to what the crawl produced turns that into a row the
+ * reconciliation pass can select on.
+ *
+ * The write is an upsert keyed on (source, slice): re-crawling a slice
+ * replaces its counts rather than accumulating, so the ledger always
+ * describes the latest attempt.
+ */
+
+import { sql } from "drizzle-orm";
+
+import type { ScopedDb } from "@/api/db/safe-db";
+import { caseLawCoverageSlices } from "@/api/db/schema";
+import type { SliceCoverage } from "@/api/handlers/case-law/ingestion/adapter";
+import { createSafeId } from "@/api/lib/branded-types";
+import type { SafeId } from "@/api/lib/branded-types";
+
+export type RecordSliceCoverageInput = {
+  sourceId: SafeId<"caseLawSource">;
+  coverage: SliceCoverage;
+};
+
+export const recordSliceCoverage = async (
+  scopedDb: ScopedDb,
+  { sourceId, coverage }: RecordSliceCoverageInput,
+): Promise<void> => {
+  await scopedDb(async (tx) => {
+    // audit: skip — crawl bookkeeping, not a user action
+    await tx
+      .insert(caseLawCoverageSlices)
+      .values({
+        id: createSafeId<"caseLawCoverageSlice">(),
+        sourceId,
+        slice: coverage.slice,
+        reported: coverage.reported,
+        collected: coverage.collected,
+      })
+      .onConflictDoUpdate({
+        target: [caseLawCoverageSlices.sourceId, caseLawCoverageSlices.slice],
+        set: {
+          reported: coverage.reported,
+          collected: coverage.collected,
+          checkedAt: sql`now()`,
+        },
+      });
+  });
+};

--- a/apps/api/src/handlers/case-law/ingestion/pipeline.ts
+++ b/apps/api/src/handlers/case-law/ingestion/pipeline.ts
@@ -41,6 +41,7 @@ import {
   isSelfCitation,
 } from "@/api/handlers/case-law/ingestion/citation-extractor";
 import { publisherCitationGap } from "@/api/handlers/case-law/ingestion/citation-recall";
+import { recordSliceCoverage } from "@/api/handlers/case-law/ingestion/coverage-ledger";
 import { storedDecisionSignal } from "@/api/handlers/case-law/ingestion/parsers/validate-ast";
 import { shouldSkipRefresh } from "@/api/handlers/case-law/ingestion/refresh-policy";
 import {
@@ -1239,6 +1240,17 @@ export const runIngestionPipeline = async ({
         // changes again.
         haltReason = `${pageS3Failures} corpus write failure(s); cursor held for retry`;
       }
+      // Record what the source said this slice holds against what the
+      // crawl produced. Written before the cursor advances, so a slice is
+      // never passed without leaving a row behind to reconcile against.
+      if (page.coverage) {
+        // oxlint-disable-next-line no-await-in-loop -- the row must land before this page's cursor advances, so it cannot be deferred past the loop
+        await recordSliceCoverage(scopedDb, {
+          sourceId: source.id,
+          coverage: page.coverage,
+        });
+      }
+
       logger.info("case_law.ingestion.pipeline_page_done", {
         adapterKey: adapter.key,
         cursor: cursor ?? "",

--- a/apps/api/src/lib/branded-types.ts
+++ b/apps/api/src/lib/branded-types.ts
@@ -11,6 +11,7 @@ export type SafeIdType =
   | "auditLog"
   | "billingCode"
   | "caseLawCitation"
+  | "caseLawCoverageSlice"
   | "caseLawCourtWeight"
   | "caseLawDecision"
   | "caseLawIndexJob"

--- a/apps/api/src/tests/security/rls-table-grants.test.ts
+++ b/apps/api/src/tests/security/rls-table-grants.test.ts
@@ -50,6 +50,9 @@ const POST_BOOTSTRAP_SELECT_ONLY_TABLES = new Set([
   "legislation_documents",
   "legislation_search_documents",
   "legislation_index_jobs",
+  // Crawl bookkeeping: the app role reads coverage for reporting, only
+  // ingestion writes it.
+  "case_law_coverage_slices",
 ]);
 
 // Post-bootstrap control-plane auth tables that deny `stella` entirely


### PR DESCRIPTION
Coverage was previously inferred: an incomplete crawl and a genuinely quiet slice produce the same row count, and a forward-only cursor never revisits, so a shortfall is invisible and permanent.

**Adapters report, the pipeline persists.** `SyncPage` gains an optional `SliceCoverage` — `{ slice, reported, collected }` — returned on the page that finishes a slice. `case_law_coverage_slices` stores it, upserted on (source, slice) so a re-crawl replaces its counts rather than accumulating, and written **before the cursor advances** so no slice is passed without leaving a row to reconcile against. A partial index covers only `collected < reported`, so the reconciliation arm stays proportional to the gaps rather than the corpus.

Wired for `cz-nss`, whose search page states its own result count — the same patterns `getTotalCount` already used, hoisted into `reportedResultCount` in #1486. Adapters whose source publishes no count omit the field and are simply untracked, which is a recorded blind spot rather than a silent one.

This is the measurement half of the work; the reconciliation pass that re-crawls short slices reads this table and lands separately.

**Docs (separate commit):** rules 14–16 in the case-law guide, covering what a new source integration has to get right beyond parsing — a missing continuation token is a failure rather than an ending, coverage is reported against the source's own count, and a forward-only cursor needs a repair path because it cannot revisit what it passed. Plus two checklist items for new adapters.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added slice-level coverage tracking for case-law crawls, including reported and collected record counts.
  * Added reconciliation data storage to help identify incomplete crawl slices.
  * Case-law ingestion now records coverage information when provided by supported sources.

* **Documentation**
  * Added guidance for pagination validation, coverage reporting and recovery of missed history.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->