### PR TITLE
fix(api): record each cause level's status in the failure log

### DIFF
--- a/apps/api/src/lib/api-handlers.test.ts
+++ b/apps/api/src/lib/api-handlers.test.ts
@@ -6,11 +6,12 @@ import { env } from "@/api/env";
 import type { OrgAIConfig } from "@/api/lib/ai-config";
 import {
   createSafeRootHandler,
+  errorCauseChainAttributes,
   resolveMeteringContext,
 } from "@/api/lib/api-handlers";
 import type { AuditRecorder } from "@/api/lib/audit-log";
 import { toSafeId } from "@/api/lib/branded-types";
-import { DatabaseError } from "@/api/lib/errors/tagged-errors";
+import { DatabaseError, HandlerError } from "@/api/lib/errors/tagged-errors";
 
 const noopAuditRecorder: AuditRecorder = async () => undefined;
 
@@ -254,5 +255,47 @@ describe("createSafeRootHandler permission gate", () => {
 
     expect(bodyRan).toBe(true);
     expect(result).toEqual({ ok: true });
+  });
+});
+
+describe("errorCauseChainAttributes", () => {
+  test("records the status of a typed cause behind a generic wrapper", () => {
+    const cause = new HandlerError({ status: 403, message: "byok missing" });
+    const wrapper = new HandlerError({
+      status: 500,
+      message: "Failed to suggest template fields",
+      cause,
+    });
+
+    expect(errorCauseChainAttributes(wrapper)).toEqual({
+      "error.cause.type": "HandlerError",
+      "error.cause.status_code": 403,
+    });
+  });
+
+  test("walks nested causes and omits the status of untyped levels", () => {
+    const root = new HandlerError({ status: 502, message: "upstream" });
+    const middle = new Error("adapter", { cause: root });
+    const wrapper = new HandlerError({
+      status: 500,
+      message: "generic",
+      cause: middle,
+    });
+
+    expect(errorCauseChainAttributes(wrapper)).toEqual({
+      "error.cause.type": "Error",
+      "error.cause2.type": "HandlerError",
+      "error.cause2.status_code": 502,
+    });
+  });
+
+  test("stops on a cause cycle", () => {
+    const first = new Error("first");
+    const second = new Error("second", { cause: first });
+    Object.defineProperty(first, "cause", { value: second });
+
+    expect(errorCauseChainAttributes(first)).toEqual({
+      "error.cause.type": "Error",
+    });
   });
 });

--- a/apps/api/src/lib/api-handlers.ts
+++ b/apps/api/src/lib/api-handlers.ts
@@ -961,6 +961,49 @@ const getErrorStatusCode = (error: Error): number | undefined => {
   return undefined;
 };
 
+/** How far up `.cause` the structural walk goes. */
+const MAX_CAUSE_DEPTH = 3;
+
+/**
+ * Structural attributes for an error's `.cause` chain, so nested
+ * wrappers do not hide the underlying failure.
+ *
+ * Each level records its type and, when it carries one, its status.
+ * The status is what makes the level useful: a `toXError(cause)`
+ * wrapper and its cause are usually both `HandlerError`, so type
+ * alone repeats one uninformative string while the wrapper's own
+ * generic 500 is the only status logged. The cause's 403
+ * (misconfiguration), 400 (unsupported input) or 502 (upstream run
+ * failure) is what names the failure. A status is a number, so this
+ * stays as non-PII as the rest of the sink.
+ */
+export const errorCauseChainAttributes = (
+  error: Error,
+): Record<string, string | number> => {
+  const attributes: Record<string, string | number> = {};
+  const seen = new WeakSet<object>([error]);
+  let cause = safeErrorCause(error);
+  let depth = 1;
+
+  while (
+    cause instanceof Error &&
+    depth <= MAX_CAUSE_DEPTH &&
+    !seen.has(cause)
+  ) {
+    seen.add(cause);
+    const prefix = depth === 1 ? "error.cause" : `error.cause${depth}`;
+    attributes[`${prefix}.type`] = errorTag(cause);
+    const causeStatusCode = getErrorStatusCode(cause);
+    if (causeStatusCode !== undefined) {
+      attributes[`${prefix}.status_code`] = causeStatusCode;
+    }
+    cause = safeErrorCause(cause);
+    depth++;
+  }
+
+  return attributes;
+};
+
 const logAndCaptureSafeError = ({
   request,
   route,
@@ -984,18 +1027,7 @@ const logAndCaptureSafeError = ({
     if (errorStatusCode !== undefined) {
       attributes["error.status_code"] = errorStatusCode;
     }
-    // Walk up to three levels of `.cause` so nested wrappers do not
-    // hide the underlying failure type.
-    const seen = new WeakSet<object>([error]);
-    let cause = safeErrorCause(error);
-    let depth = 1;
-    while (cause instanceof Error && depth <= 3 && !seen.has(cause)) {
-      seen.add(cause);
-      const prefix = depth === 1 ? "error.cause" : `error.cause${depth}`;
-      attributes[`${prefix}.type`] = errorTag(cause);
-      cause = safeErrorCause(cause);
-      depth++;
-    }
+    Object.assign(attributes, errorCauseChainAttributes(error));
   }
 
   // 5xx are the un-diagnosable class: the message and stack are


### PR DESCRIPTION
## Problem

`logAndCaptureSafeError` walks up to three levels of `.cause` "so nested wrappers do not hide the underlying failure type", but records only `error.cause*.type` per level. The status is taken from the top-level error alone.

That drops the one field that separates two levels of the same class. Every `toXError(cause)` helper in the codebase produces the same shape: a generic `HandlerError` wrapping a typed `HandlerError`. The resulting log line reads

```
"error.status_code": 500, "error.cause.type": "HandlerError"
```

for a 403 misconfiguration, a 400 unsupported input, and a 502 upstream run failure alike. `error.type` and `error.cause.type` are both the literal string `HandlerError`, and the only status recorded is the wrapper's generic 500, so the line names no failure at all. Since 5xx redact message and stack from every sink, nothing else recovers it.

## Change

Record each cause level's status next to its type, using the same `getErrorStatusCode` already applied to the top-level error, and extract the walk as `errorCauseChainAttributes` so it is testable on its own rather than only through a request.

A status is a number, so the sink stays exactly as non-PII as before: no message, cause, or stack is added. Levels that carry no status are unchanged, cycle and depth guards are preserved.

## Tests

`apps/api/src/lib/api-handlers.test.ts`: a typed cause behind a generic wrapper reports its status; a nested chain walks levels and omits the status of untyped ones; a cause cycle terminates.

## Verification

Run locally on the touched package:

- `bun test src/lib/api-handlers.test.ts` — 9 pass, 0 fail
- `bun --filter @stll/api typecheck` — exit 0
- `bun run lint` — 0 warnings, 0 errors
- `bun run format` — no changes to the touched files

---
_Generated by [Claude Code](https://claude.ai/code/session_01BG9mEpH24bYRW3jtaB7Rvy)_