### PR TITLE
fix: improve landing page on iOS

### DIFF
--- a/apps/landing/src/components/HomePage.astro
+++ b/apps/landing/src/components/HomePage.astro
@@ -117,13 +117,21 @@ const subtitle = requireLinkedSegment("hero.subtitle", t("hero.subtitle"));
                   </span>
                 )
               }
-              <span class="min-w-0 truncate" lang="en" dir="ltr">
-                {
-                  latestRelease
-                    ? (latestRelease.heading ?? latestRelease.displayName)
-                    : t("nav.changelog")
-                }
-              </span>
+              <overflow-marquee
+                class="hero-news-marquee min-w-0 flex-1 overflow-hidden"
+              >
+                <span
+                  class="hero-news-marquee-content block w-max whitespace-nowrap"
+                  lang="en"
+                  dir="ltr"
+                >
+                  {
+                    latestRelease
+                      ? (latestRelease.heading ?? latestRelease.displayName)
+                      : t("nav.changelog")
+                  }
+                </span>
+              </overflow-marquee>
               <span
                 aria-hidden="true"
                 class="shrink-0 transition-transform rtl:-scale-x-100 ltr:group-hover:translate-x-0.5 rtl:group-hover:-translate-x-0.5"
@@ -182,7 +190,7 @@ const subtitle = requireLinkedSegment("hero.subtitle", t("hero.subtitle"));
 
       {/* ——— Opening product story ——— */}
       <section class="relative overflow-clip" id="opening-product-story">
-        <div class="relative aspect-[4/5] w-full sm:aspect-[2.03]">
+        <div class="relative aspect-[5/4] w-full sm:aspect-[2.03]">
           <CliMcpPreview
             client:load
             revealSideWindowsOnScroll
@@ -343,6 +351,23 @@ const subtitle = requireLinkedSegment("hero.subtitle", t("hero.subtitle"));
       animation: hero-beta-pulse 4s var(--ease-out-quint) infinite;
     }
 
+    .hero-news-marquee[data-overflowing="true"]
+      .hero-news-marquee-content {
+      animation: hero-news-marquee var(--marquee-duration) ease-in-out infinite
+        alternate;
+    }
+
+    @keyframes hero-news-marquee {
+      0%,
+      18% {
+        transform: translate3d(0, 0, 0);
+      }
+      82%,
+      100% {
+        transform: translate3d(calc(-1 * var(--marquee-distance)), 0, 0);
+      }
+    }
+
     @keyframes hero-beta-pulse {
       0%, 100% {
         box-shadow: 0 0 0 0 color-mix(in srgb, var(--success) 22%, transparent);
@@ -381,6 +406,50 @@ const subtitle = requireLinkedSegment("hero.subtitle", t("hero.subtitle"));
         padding-block-start: 1.5rem;
       }
     }
+
+    @media (prefers-reduced-motion: reduce) {
+      .hero-news-marquee-content {
+        animation: none !important;
+      }
+    }
   </style>
+
+  <script>
+    class OverflowMarquee extends HTMLElement {
+      #resizeObserver = new ResizeObserver(() => this.#update());
+
+      connectedCallback() {
+        const content = this.firstElementChild;
+        this.#resizeObserver.observe(this);
+        if (content instanceof HTMLElement) {
+          this.#resizeObserver.observe(content);
+        }
+        this.#update();
+      }
+
+      disconnectedCallback() {
+        this.#resizeObserver.disconnect();
+      }
+
+      #update() {
+        const content = this.firstElementChild;
+        if (!(content instanceof HTMLElement)) {
+          return;
+        }
+
+        const distance = Math.max(0, content.scrollWidth - this.clientWidth);
+        this.dataset.overflowing = distance > 0 ? "true" : "false";
+        this.style.setProperty("--marquee-distance", `${distance}px`);
+        this.style.setProperty(
+          "--marquee-duration",
+          `${Math.max(7, distance / 18).toFixed(1)}s`,
+        );
+      }
+    }
+
+    if (!customElements.get("overflow-marquee")) {
+      customElements.define("overflow-marquee", OverflowMarquee);
+    }
+  </script>
 
 </Base>

--- a/apps/landing/src/components/HomePage.astro
+++ b/apps/landing/src/components/HomePage.astro
@@ -119,6 +119,7 @@ const subtitle = requireLinkedSegment("hero.subtitle", t("hero.subtitle"));
               }
               <overflow-marquee
                 class="hero-news-marquee min-w-0 flex-1 overflow-hidden"
+                dir="ltr"
               >
                 <span
                   class="hero-news-marquee-content block w-max whitespace-nowrap"
@@ -355,6 +356,11 @@ const subtitle = requireLinkedSegment("hero.subtitle", t("hero.subtitle"));
       .hero-news-marquee-content {
       animation: hero-news-marquee var(--marquee-duration) ease-in-out infinite
         alternate;
+    }
+
+    .group:hover .hero-news-marquee-content,
+    .group:focus-visible .hero-news-marquee-content {
+      animation-play-state: paused;
     }
 
     @keyframes hero-news-marquee {

--- a/apps/landing/src/components/LandingFooter.astro
+++ b/apps/landing/src/components/LandingFooter.astro
@@ -170,6 +170,12 @@ const legalLinks = [
     inset-inline: 0;
   }
 
+  @media (max-width: 639px) {
+    .footer-link::before {
+      inset-block: 0;
+    }
+  }
+
   .footer-link:hover,
   .footer-link:focus-visible {
     color: var(--foreground);

--- a/apps/landing/src/components/LandingFooter.astro
+++ b/apps/landing/src/components/LandingFooter.astro
@@ -51,8 +51,8 @@ const legalLinks = [
     class="footer-art footer-art-dark pointer-events-none absolute"
     aria-hidden="true"
   ></div>
-  <div class="relative z-10 mx-auto max-w-300 px-6 pb-6 pt-16 sm:pb-8 sm:pt-20">
-    <div class="grid gap-14 lg:grid-cols-12 lg:gap-8">
+  <div class="relative z-10 mx-auto max-w-300 px-6 pb-5 pt-12 sm:pb-8 sm:pt-20">
+    <div class="grid gap-10 sm:gap-14 lg:grid-cols-12 lg:gap-8">
       <div class="lg:col-span-4">
         <span class="inline-flex">
           <img
@@ -67,15 +67,15 @@ const legalLinks = [
 
       </div>
 
-      <nav class="grid grid-cols-2 gap-x-6 gap-y-10 sm:grid-cols-3 lg:col-span-8" aria-label={t("footer.navLabel")}>
+      <nav class="grid grid-cols-3 gap-x-4 sm:gap-x-6 lg:col-span-8" aria-label={t("footer.navLabel")}>
         {columns.map((column) => (
           <section>
             <h2 class="footer-heading text-sm font-semibold" style="color: var(--foreground)">{column.heading}</h2>
-            <ul class="footer-link-list mt-5 space-y-3">
+            <ul class="footer-link-list mt-3 sm:mt-5 sm:space-y-3">
               {column.links.map((link) => (
                 <li>
                   <a
-                    class="footer-link group inline-grid min-h-6 grid-cols-[1fr_auto] items-baseline gap-2 text-sm"
+                    class="footer-link group inline-grid min-h-11 grid-cols-[1fr_auto] items-center gap-1 text-xs sm:min-h-6 sm:items-baseline sm:gap-2 sm:text-sm"
                     href={link.href}
                     target={isExternal(link.href) ? "_blank" : undefined}
                     rel={isExternal(link.href) ? "noopener noreferrer" : undefined}
@@ -91,7 +91,7 @@ const legalLinks = [
       </nav>
     </div>
 
-    <div class="mt-16 flex flex-col gap-4 border-t pt-4 text-sm sm:flex-row sm:items-center sm:justify-between" style="border-color: var(--border)">
+    <div class="mt-10 flex flex-col gap-4 border-t pt-4 text-sm sm:mt-16 sm:flex-row sm:items-center sm:justify-between" style="border-color: var(--border)">
       <nav class="flex gap-6" aria-label={t("footer.legal")}>
         {legalLinks.map((link) => (
           <a class="footer-link group inline-grid grid-cols-[1fr_auto] items-baseline gap-2" href={link.href}>

--- a/apps/landing/src/components/LandingFooter.astro
+++ b/apps/landing/src/components/LandingFooter.astro
@@ -80,7 +80,7 @@ const legalLinks = [
                     target={isExternal(link.href) ? "_blank" : undefined}
                     rel={isExternal(link.href) ? "noopener noreferrer" : undefined}
                   >
-                    <span>{link.label}</span>
+                    <span class="footer-link-label">{link.label}</span>
                     <span class="footer-arrow" aria-hidden="true">{arrow}</span>
                   </a>
                 </li>
@@ -176,10 +176,21 @@ const legalLinks = [
   }
 
   .footer-arrow {
-    display: inline-block;
+    display: none;
     opacity: 0;
     transform: translateX(-0.35rem);
     transition: opacity 180ms ease, transform 180ms ease;
+  }
+
+  .footer-link-label {
+    min-width: 0;
+    overflow-wrap: anywhere;
+  }
+
+  @media (min-width: 640px) {
+    .footer-arrow {
+      display: inline-block;
+    }
   }
 
   [dir="rtl"] .footer-arrow {

--- a/apps/landing/src/components/react/previews/CliMcpPreview.tsx
+++ b/apps/landing/src/components/react/previews/CliMcpPreview.tsx
@@ -1047,7 +1047,7 @@ const DiscoverTag = ({
   <a
     onPointerEnter={onPointerEnter}
     onPointerLeave={onPointerLeave}
-    className="absolute z-[70] inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-semibold whitespace-nowrap no-underline shadow-md"
+    className="cli-discover-tag absolute z-[70] inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-semibold whitespace-nowrap no-underline shadow-md"
     dir="auto"
     href={href}
     style={{
@@ -1471,6 +1471,28 @@ const CLI_STYLES = `
       inset: auto auto 2.5% 5%;
       width: 90%;
       height: 33%;
+    }
+    /* The homepage hero follows the single-focus mobile composition: keep
+       the main animated stella window and drop every companion. Other embeds
+       retain their purpose-built mobile layouts. */
+    .cli-story-with-scroll-reveal .cli-window {
+      display: none;
+    }
+    .cli-story-with-scroll-reveal .cli-selected {
+      outline: none;
+    }
+    .cli-story-with-scroll-reveal .cli-discover-tag {
+      display: none;
+    }
+    .cli-story-with-scroll-reveal .cli-main-window {
+      --cli-main-width: 94cqw;
+      inset-block: 50% auto;
+      inset-inline: 50% auto;
+      width: var(--cli-main-width);
+      height: calc(var(--cli-main-width) / 1.674 + var(--mac-titlebar-height));
+      animation: none;
+      transform: none;
+      translate: -50% -50%;
     }
     .cli-idle-prompt { display: none; }
   }

--- a/apps/landing/src/layouts/Base.astro
+++ b/apps/landing/src/layouts/Base.astro
@@ -496,10 +496,14 @@ const structuredData = {
     </script>
 
     <script>
-      import { initializePageGradients } from "../lib/animated-gradient";
+      import {
+        cleanupPageGradients,
+        initializePageGradients,
+      } from "../lib/animated-gradient";
       import { initializeThemeImages } from "../lib/theme-images";
 
       document.addEventListener("astro:page-load", initializePageGradients);
+      document.addEventListener("astro:before-swap", cleanupPageGradients);
       document.addEventListener("astro:page-load", initializeThemeImages);
     </script>
   </body>

--- a/apps/landing/src/lib/animated-gradient.test.ts
+++ b/apps/landing/src/lib/animated-gradient.test.ts
@@ -104,12 +104,17 @@ test("iOS gradients animate one original SVG surface", () => {
     configurable: true,
     value: class {
       disconnect = visibilityDisconnect;
+      private readonly callback: (
+        entries: { isIntersecting: boolean; target: Element }[],
+      ) => void;
 
       constructor(
-        private readonly callback: (
+        callback: (
           entries: { isIntersecting: boolean; target: Element }[],
         ) => void,
-      ) {}
+      ) {
+        this.callback = callback;
+      }
 
       observe(target: Element) {
         this.callback([{ isIntersecting: true, target }]);

--- a/apps/landing/src/lib/animated-gradient.test.ts
+++ b/apps/landing/src/lib/animated-gradient.test.ts
@@ -14,9 +14,27 @@ const originalNavigator = Object.getOwnPropertyDescriptor(
   "navigator",
 );
 const originalWindow = Object.getOwnPropertyDescriptor(globalThis, "window");
+const originalGetComputedStyle = Object.getOwnPropertyDescriptor(
+  globalThis,
+  "getComputedStyle",
+);
+const originalIntersectionObserver = Object.getOwnPropertyDescriptor(
+  globalThis,
+  "IntersectionObserver",
+);
+const originalMutationObserver = Object.getOwnPropertyDescriptor(
+  globalThis,
+  "MutationObserver",
+);
 
 const restoreGlobal = (
-  property: "document" | "navigator" | "window",
+  property:
+    | "document"
+    | "getComputedStyle"
+    | "IntersectionObserver"
+    | "MutationObserver"
+    | "navigator"
+    | "window",
   descriptor: PropertyDescriptor | undefined,
 ) => {
   if (descriptor === undefined) {
@@ -32,14 +50,21 @@ afterEach(() => {
   restoreGlobal("document", originalDocument);
   restoreGlobal("navigator", originalNavigator);
   restoreGlobal("window", originalWindow);
+  restoreGlobal("getComputedStyle", originalGetComputedStyle);
+  restoreGlobal("IntersectionObserver", originalIntersectionObserver);
+  restoreGlobal("MutationObserver", originalMutationObserver);
 });
 
 test("iOS gradients animate one original SVG surface", () => {
   const cancel = mock(() => undefined);
+  const pause = mock(() => undefined);
+  const play = mock(() => undefined);
   const animate = mock((keyframes: unknown, options: unknown) => ({
     cancel,
     keyframes,
     options,
+    pause,
+    play,
   }));
   const image = {
     alt: "",
@@ -49,14 +74,60 @@ test("iOS gradients animate one original SVG surface", () => {
     style: {},
   };
   const renderedChildren: unknown[] = [];
+  const root = {};
+  let syncTransition = () => undefined;
+  const removeEventListener = mock(() => undefined);
   const container = {
+    addEventListener: (event: string, listener: () => void) => {
+      if (event === "transitionend") {
+        syncTransition = listener;
+      }
+    },
     dataset: { animatedGradient: "" },
     id: "gradient-light",
     isConnected: true,
+    removeEventListener,
     replaceChildren: (...children: unknown[]) => {
       renderedChildren.push(...children);
     },
   };
+  const visibilityDisconnect = mock(() => undefined);
+  const themeDisconnect = mock(() => undefined);
+  let opacity = "0";
+  let syncTheme = () => undefined;
+
+  Object.defineProperty(globalThis, "getComputedStyle", {
+    configurable: true,
+    value: () => ({ opacity }),
+  });
+  Object.defineProperty(globalThis, "IntersectionObserver", {
+    configurable: true,
+    value: class {
+      disconnect = visibilityDisconnect;
+
+      constructor(
+        private readonly callback: (
+          entries: { isIntersecting: boolean; target: Element }[],
+        ) => void,
+      ) {}
+
+      observe(target: Element) {
+        this.callback([{ isIntersecting: true, target }]);
+      }
+    },
+  });
+  Object.defineProperty(globalThis, "MutationObserver", {
+    configurable: true,
+    value: class {
+      disconnect = themeDisconnect;
+
+      constructor(callback: () => void) {
+        syncTheme = callback;
+      }
+
+      observe() {}
+    },
+  });
 
   Object.defineProperty(globalThis, "navigator", {
     configurable: true,
@@ -76,6 +147,7 @@ test("iOS gradients animate one original SVG surface", () => {
     configurable: true,
     value: {
       createElement: () => image,
+      documentElement: root,
       querySelector: (selector: string) =>
         selector === "#gradient-light" ? container : null,
     },
@@ -86,6 +158,16 @@ test("iOS gradients animate one original SVG surface", () => {
   expect(renderedChildren).toEqual([image]);
   expect(image.src).toBe("/images/gradients/hero-light.svg");
   expect(animate).toHaveBeenCalledTimes(1);
+  expect(pause).toHaveBeenCalledTimes(2);
+  expect(play).toHaveBeenCalledTimes(0);
+
+  opacity = "1";
+  syncTheme();
+  expect(play).toHaveBeenCalledTimes(1);
+
+  opacity = "0";
+  syncTransition();
+  expect(pause).toHaveBeenCalledTimes(3);
   expect(animate.mock.calls.at(0)?.at(0)).toEqual({
     opacity: ["0.96", "1", "0.93", "1", "0.96"],
     transform: [
@@ -99,4 +181,7 @@ test("iOS gradients animate one original SVG surface", () => {
 
   cleanupPageGradients();
   expect(cancel).toHaveBeenCalledTimes(1);
+  expect(removeEventListener).toHaveBeenCalledTimes(1);
+  expect(visibilityDisconnect).toHaveBeenCalledTimes(1);
+  expect(themeDisconnect).toHaveBeenCalledTimes(1);
 });

--- a/apps/landing/src/lib/animated-gradient.test.ts
+++ b/apps/landing/src/lib/animated-gradient.test.ts
@@ -1,6 +1,9 @@
 import { afterEach, expect, mock, test } from "bun:test";
 
-import { initializePageGradients } from "./animated-gradient";
+import {
+  cleanupPageGradients,
+  initializePageGradients,
+} from "./animated-gradient";
 
 const originalDocument = Object.getOwnPropertyDescriptor(
   globalThis,
@@ -25,13 +28,16 @@ const restoreGlobal = (
 };
 
 afterEach(() => {
+  cleanupPageGradients();
   restoreGlobal("document", originalDocument);
   restoreGlobal("navigator", originalNavigator);
   restoreGlobal("window", originalWindow);
 });
 
 test("iOS gradients animate one original SVG surface", () => {
+  const cancel = mock(() => undefined);
   const animate = mock((keyframes: unknown, options: unknown) => ({
+    cancel,
     keyframes,
     options,
   }));
@@ -90,4 +96,7 @@ test("iOS gradients animate one original SVG surface", () => {
       "translate3d(-2%, -3%, 0) scale3d(1.11, 1.05, 1) rotate(-0.6deg)",
     ],
   });
+
+  cleanupPageGradients();
+  expect(cancel).toHaveBeenCalledTimes(1);
 });

--- a/apps/landing/src/lib/animated-gradient.test.ts
+++ b/apps/landing/src/lib/animated-gradient.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, expect, mock, test } from "bun:test";
+
+import { initializePageGradients } from "./animated-gradient";
+
+const originalDocument = Object.getOwnPropertyDescriptor(
+  globalThis,
+  "document",
+);
+const originalNavigator = Object.getOwnPropertyDescriptor(
+  globalThis,
+  "navigator",
+);
+const originalWindow = Object.getOwnPropertyDescriptor(globalThis, "window");
+
+const restoreGlobal = (
+  property: "document" | "navigator" | "window",
+  descriptor: PropertyDescriptor | undefined,
+) => {
+  if (descriptor === undefined) {
+    Reflect.deleteProperty(globalThis, property);
+    return;
+  }
+
+  Object.defineProperty(globalThis, property, descriptor);
+};
+
+afterEach(() => {
+  restoreGlobal("document", originalDocument);
+  restoreGlobal("navigator", originalNavigator);
+  restoreGlobal("window", originalWindow);
+});
+
+test("iOS gradients animate one original SVG surface", () => {
+  const animate = mock((keyframes: unknown, options: unknown) => ({
+    keyframes,
+    options,
+  }));
+  const image = {
+    alt: "",
+    animate,
+    setAttribute: mock(() => undefined),
+    src: "",
+    style: {},
+  };
+  const renderedChildren: unknown[] = [];
+  const container = {
+    dataset: { animatedGradient: "" },
+    id: "gradient-light",
+    isConnected: true,
+    replaceChildren: (...children: unknown[]) => {
+      renderedChildren.push(...children);
+    },
+  };
+
+  Object.defineProperty(globalThis, "navigator", {
+    configurable: true,
+    value: {
+      maxTouchPoints: 5,
+      platform: "iPhone",
+      userAgent: "iPhone",
+    },
+  });
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: {
+      matchMedia: () => ({ matches: false }),
+    },
+  });
+  Object.defineProperty(globalThis, "document", {
+    configurable: true,
+    value: {
+      createElement: () => image,
+      querySelector: (selector: string) =>
+        selector === "#gradient-light" ? container : null,
+    },
+  });
+
+  initializePageGradients();
+
+  expect(renderedChildren).toEqual([image]);
+  expect(image.src).toBe("/images/gradients/hero-light.svg");
+  expect(animate).toHaveBeenCalledTimes(1);
+  expect(animate.mock.calls.at(0)?.at(0)).toEqual({
+    opacity: ["0.96", "1", "0.93", "1", "0.96"],
+    transform: [
+      "translate3d(-2%, -3%, 0) scale3d(1.11, 1.05, 1) rotate(-0.6deg)",
+      "translate3d(2%, 1%, 0) scale3d(1.04, 1.12, 1) rotate(0.4deg)",
+      "translate3d(-1%, 3%, 0) scale3d(1.13, 1.06, 1) rotate(-0.2deg)",
+      "translate3d(3%, -2%, 0) scale3d(1.06, 1.13, 1) rotate(0.5deg)",
+      "translate3d(-2%, -3%, 0) scale3d(1.11, 1.05, 1) rotate(-0.6deg)",
+    ],
+  });
+});

--- a/apps/landing/src/lib/animated-gradient.test.ts
+++ b/apps/landing/src/lib/animated-gradient.test.ts
@@ -75,7 +75,7 @@ test("iOS gradients animate one original SVG surface", () => {
   };
   const renderedChildren: unknown[] = [];
   const root = {};
-  let syncTransition = () => undefined;
+  let syncTransition: () => void = () => undefined;
   const removeEventListener = mock(() => undefined);
   const container = {
     addEventListener: (event: string, listener: () => void) => {
@@ -94,7 +94,7 @@ test("iOS gradients animate one original SVG surface", () => {
   const visibilityDisconnect = mock(() => undefined);
   const themeDisconnect = mock(() => undefined);
   let opacity = "0";
-  let syncTheme = () => undefined;
+  let syncTheme: () => void = () => undefined;
 
   Object.defineProperty(globalThis, "getComputedStyle", {
     configurable: true,

--- a/apps/landing/src/lib/animated-gradient.ts
+++ b/apps/landing/src/lib/animated-gradient.ts
@@ -16,6 +16,14 @@ const IOS_GRADIENT_TRANSFORMS = [
 ];
 const IOS_GRADIENT_OPACITIES = ["0.96", "1", "0.93", "1", "0.96"];
 const IOS_GRADIENT_DURATION_MS = 20_000;
+const activeIOSGradientAnimations = new Set<Animation>();
+
+export const cleanupPageGradients = () => {
+  for (const animation of activeIOSGradientAnimations) {
+    animation.cancel();
+  }
+  activeIOSGradientAnimations.clear();
+};
 
 export const initializePageGradients = () => {
   for (const [containerId, svgUrl, speed] of GRADIENT_LAYERS) {
@@ -189,7 +197,7 @@ const initializeIOSGradient = (
     return;
   }
 
-  image.animate(
+  const animation = image.animate(
     {
       opacity: IOS_GRADIENT_OPACITIES,
       transform: IOS_GRADIENT_TRANSFORMS,
@@ -200,4 +208,5 @@ const initializeIOSGradient = (
       iterations: Number.POSITIVE_INFINITY,
     },
   );
+  activeIOSGradientAnimations.add(animation);
 };

--- a/apps/landing/src/lib/animated-gradient.ts
+++ b/apps/landing/src/lib/animated-gradient.ts
@@ -16,13 +16,33 @@ const IOS_GRADIENT_TRANSFORMS = [
 ];
 const IOS_GRADIENT_OPACITIES = ["0.96", "1", "0.93", "1", "0.96"];
 const IOS_GRADIENT_DURATION_MS = 20_000;
-const activeIOSGradientAnimations = new Set<Animation>();
+
+type IOSGradientAnimationState = {
+  animation: Animation;
+  isIntersecting: boolean;
+  syncOnTransitionEnd: () => void;
+};
+
+const activeIOSGradientAnimations = new Map<
+  Element,
+  IOSGradientAnimationState
+>();
+let iosGradientVisibilityObserver: IntersectionObserver | undefined;
+let iosGradientThemeObserver: MutationObserver | undefined;
 
 export const cleanupPageGradients = () => {
-  for (const animation of activeIOSGradientAnimations) {
+  for (const [
+    container,
+    { animation, syncOnTransitionEnd },
+  ] of activeIOSGradientAnimations) {
     animation.cancel();
+    container.removeEventListener("transitionend", syncOnTransitionEnd);
   }
   activeIOSGradientAnimations.clear();
+  iosGradientVisibilityObserver?.disconnect();
+  iosGradientVisibilityObserver = undefined;
+  iosGradientThemeObserver?.disconnect();
+  iosGradientThemeObserver = undefined;
 };
 
 export const initializePageGradients = () => {
@@ -208,5 +228,57 @@ const initializeIOSGradient = (
       iterations: Number.POSITIVE_INFINITY,
     },
   );
-  activeIOSGradientAnimations.add(animation);
+  const syncOnTransitionEnd = () => {
+    const currentState = activeIOSGradientAnimations.get(container);
+    if (currentState !== undefined) {
+      syncIOSGradientAnimation(container, currentState);
+    }
+  };
+  const state = { animation, isIntersecting: false, syncOnTransitionEnd };
+  activeIOSGradientAnimations.set(container, state);
+  container.addEventListener("transitionend", syncOnTransitionEnd);
+  ensureIOSGradientObservers();
+  syncIOSGradientAnimation(container, state);
+  iosGradientVisibilityObserver?.observe(container);
+};
+
+const ensureIOSGradientObservers = () => {
+  iosGradientVisibilityObserver ??= new IntersectionObserver((entries) => {
+    for (const entry of entries) {
+      const state = activeIOSGradientAnimations.get(entry.target);
+      if (state === undefined) {
+        continue;
+      }
+
+      state.isIntersecting = entry.isIntersecting;
+      syncIOSGradientAnimation(entry.target, state);
+    }
+  });
+
+  iosGradientThemeObserver ??= new MutationObserver(() => {
+    for (const [container, state] of activeIOSGradientAnimations) {
+      syncIOSGradientAnimation(container, state);
+    }
+  });
+  iosGradientThemeObserver.observe(document.documentElement, {
+    attributes: true,
+    attributeFilter: ["class"],
+  });
+};
+
+const syncIOSGradientAnimation = (
+  container: Element,
+  state: IOSGradientAnimationState,
+) => {
+  const shouldPlay =
+    container.isConnected &&
+    state.isIntersecting &&
+    getComputedStyle(container).opacity !== "0";
+
+  if (shouldPlay) {
+    state.animation.play();
+    return;
+  }
+
+  state.animation.pause();
 };

--- a/apps/landing/src/lib/animated-gradient.ts
+++ b/apps/landing/src/lib/animated-gradient.ts
@@ -5,6 +5,18 @@ const GRADIENT_LAYERS = [
   ["footer-gradient-dark", "/images/gradients/hero-dark.svg", 1.6],
 ] as const;
 
+const IOS_GRADIENT_START_TRANSFORM =
+  "translate3d(-2%, -3%, 0) scale3d(1.11, 1.05, 1) rotate(-0.6deg)";
+const IOS_GRADIENT_TRANSFORMS = [
+  IOS_GRADIENT_START_TRANSFORM,
+  "translate3d(2%, 1%, 0) scale3d(1.04, 1.12, 1) rotate(0.4deg)",
+  "translate3d(-1%, 3%, 0) scale3d(1.13, 1.06, 1) rotate(-0.2deg)",
+  "translate3d(3%, -2%, 0) scale3d(1.06, 1.13, 1) rotate(0.5deg)",
+  IOS_GRADIENT_START_TRANSFORM,
+];
+const IOS_GRADIENT_OPACITIES = ["0.96", "1", "0.93", "1", "0.96"];
+const IOS_GRADIENT_DURATION_MS = 20_000;
+
 export const initializePageGradients = () => {
   for (const [containerId, svgUrl, speed] of GRADIENT_LAYERS) {
     const container = document.querySelector<HTMLElement>(`#${containerId}`);
@@ -22,6 +34,11 @@ const initializeGradient = async (
   svgUrl: string,
   speed: number,
 ) => {
+  if (isIOSWebKit()) {
+    initializeIOSGradient(container, svgUrl, speed);
+    return;
+  }
+
   const response = await fetch(svgUrl, {
     signal: AbortSignal.timeout(10_000),
   });
@@ -139,4 +156,48 @@ const initializeGradient = async (
   };
 
   requestAnimationFrame(animate);
+};
+
+const isIOSWebKit = () => {
+  const isIOSDevice = /iP(?:ad|hone|od)/u.test(navigator.userAgent);
+  const isIPadDesktopMode =
+    navigator.platform === "MacIntel" && navigator.maxTouchPoints > 1;
+
+  return isIOSDevice || isIPadDesktopMode;
+};
+
+const initializeIOSGradient = (
+  container: HTMLElement,
+  svgUrl: string,
+  speed: number,
+) => {
+  const image = document.createElement("img");
+  image.src = svgUrl;
+  image.alt = "";
+  image.setAttribute("aria-hidden", "true");
+  image.style.display = "block";
+  image.style.width = "100%";
+  image.style.height = "100%";
+  image.style.objectFit = "fill";
+  image.style.transform = IOS_GRADIENT_START_TRANSFORM;
+  image.style.transformOrigin = "center";
+  image.style.willChange = "transform";
+
+  container.replaceChildren(image);
+
+  if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
+    return;
+  }
+
+  image.animate(
+    {
+      opacity: IOS_GRADIENT_OPACITIES,
+      transform: IOS_GRADIENT_TRANSFORMS,
+    },
+    {
+      duration: IOS_GRADIENT_DURATION_MS / speed,
+      easing: "ease-in-out",
+      iterations: Number.POSITIVE_INFINITY,
+    },
+  );
 };


### PR DESCRIPTION
## Summary

- render landing gradients as one animated SVG surface on iOS WebKit
- simplify the mobile hero to one centered, aspect-preserving product window
- compact the mobile footer and marquee overflowing release text
- cover the iOS gradient rendering invariant with a regression test