### PR TITLE
fix(api): filter no-digit case-number residuals in citation probe

### DIFF
--- a/apps/api/src/scripts/citation-probe.ts
+++ b/apps/api/src/scripts/citation-probe.ts
@@ -179,6 +179,14 @@ const BENIGN: readonly RegExp[] = [
   // Polish procurement-tribunal rulings (KIO/UZP): quasi-judicial, not a
   // court source the corpus ingests, so never a resolvable citation.
   /\bKIO ?\/? ?UZP\b/u,
+  // A case-number prefix ("sp. zn.", "sen. zn.", "sygn.[ akt]", "č. j.")
+  // with no digit anywhere in the captured tail is never a real citation:
+  // every actual docket carries a number. Covers Polish anonymization
+  // placeholders, where the detector's own trailing-paren exclusion
+  // truncates the candidate right before the redaction ("sygn. akt II Ca"
+  // from "sygn. akt II Ca (…)"), and self-references such as "sygn. j.w."
+  // ("as above").
+  /^(?:sp\.\s{0,3}zn\.|sen\.\s{0,3}zn\.|sygn\.(?:\s{1,3}akt)?|[čc]\.\s{0,3}j\.:?)[^\d]{0,45}$/iu,
 ];
 
 const isBenign = (candidate: string): boolean =>


### PR DESCRIPTION
## Proposed change

`citation-probe.ts` samples decisions and flags text that looks like a case-number citation but wasn't extracted, for human review. Its broad detectors truncate the captured candidate right before any parenthesis, so a citation whose docket was replaced with an anonymization placeholder (`sygn. akt II Ca (…)`) is captured as `sygn. akt II Ca` — the placeholder that actually explains it is outside the match. The same is true for self-references like `sygn. j.w.` ("as above"), which never carry a docket at all.

Both cases share one structural signal: a `sp. zn.` / `sen. zn.` / `sygn.[ akt]` / `č. j.` prefix with no digit anywhere in the captured tail is never a real citation, since every real docket carries a number. Added a `BENIGN` regex for that shape.

## Checklist

- [x] BUILD ASSURANCE | Code builds correctly and without any errors or warnings.
- [x] TESTING | Verified the new pattern against the residual strings that motivated it (anonymization placeholders, `sygn. j.w.`) and against the real citation shapes it must not swallow.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UQijoVpoPidmHPJBMRjv6C)_