### PR TITLE
feat(case-law): backfill citation keys and drive resolution

### DIFF
--- a/apps/api/src/scripts/backfill-citation-keys.ts
+++ b/apps/api/src/scripts/backfill-citation-keys.ts
@@ -36,82 +36,96 @@ const keyOf = (text: string): string | null => bareCitationKey(text) || null;
  * revisited forever — null means "not yet computed", so leaving it null on
  * an uncanonicalizable row would make the scan never terminate.
  */
-const backfillKeys = async (
+/**
+ * Fill one table's keys. `sourceColumn` is where the key derives from, and
+ * rows whose text does not canonicalize get an empty key rather than being
+ * revisited forever — null means "not yet computed", so leaving it null on
+ * an uncanonicalizable row would make the scan never terminate.
+ *
+ * Expressed as a walk rather than a loop: each step depends on the
+ * previous step's last id, so there is nothing to parallelise, and the
+ * depth is bounded by rows/BATCH.
+ */
+const backfillFrom = async (
   table: "case_law_decisions" | "case_law_citations",
   sourceColumn: "case_number" | "citation_text",
-): Promise<void> => {
-  let after: string | null = null;
-  let seen = 0;
-  let keyed = 0;
+  after: string | null,
+  seen: number,
+  keyed: number,
+): Promise<{ seen: number; keyed: number }> => {
+  const result: unknown = await rootDb.execute(
+    sql`SELECT id, ${sql.raw(sourceColumn)} AS text
+          FROM ${sql.raw(table)}
+         WHERE citation_key IS NULL
+           ${after === null ? sql`` : sql`AND id > ${after}`}
+         ORDER BY id
+         LIMIT ${BATCH}`,
+  );
+  const rows = (Array.isArray(result) ? result : []).flatMap((row) =>
+    isRecord(row) &&
+    typeof row["id"] === "string" &&
+    typeof row["text"] === "string"
+      ? [{ id: row["id"], text: row["text"] }]
+      : [],
+  );
 
-  while (true) {
-    // oxlint-disable-next-line no-await-in-loop -- keyset walk: each batch starts where the previous ended
-    const result: unknown = await rootDb.execute(
-      sql`SELECT id, ${sql.raw(sourceColumn)} AS text
-            FROM ${sql.raw(table)}
-           WHERE citation_key IS NULL
-             ${after === null ? sql`` : sql`AND id > ${after}`}
-           ORDER BY id
-           LIMIT ${BATCH}`,
-    );
-    const rows = (Array.isArray(result) ? result : []).flatMap((row) =>
-      isRecord(row) &&
-      typeof row["id"] === "string" &&
-      typeof row["text"] === "string"
-        ? [{ id: row["id"], text: row["text"] }]
-        : [],
-    );
-
-    if (rows.length === 0) {
-      break;
-    }
-
-    const values = rows.map((row) => {
-      const key = keyOf(row.text) ?? "";
-      return sql`(${row.id}::uuid, ${key}::varchar)`;
-    });
-
-    // oxlint-disable-next-line no-await-in-loop -- one bounded batch write per iteration
-    await rootDb.execute(
-      sql`UPDATE ${sql.raw(table)} AS t
-             SET citation_key = v.key
-            FROM (VALUES ${sql.join(values, sql`, `)}) AS v(id, key)
-           WHERE t.id = v.id`,
-    );
-
-    seen += rows.length;
-    keyed += rows.filter((row) => keyOf(row.text) !== null).length;
-    after = rows.at(-1)?.id ?? after;
-    console.log(`  ${table}: ${seen} scanned, ${keyed} keyed`);
+  if (rows.length === 0) {
+    return { seen, keyed };
   }
+
+  const values = rows.map(
+    (row) => sql`(${row.id}::uuid, ${keyOf(row.text) ?? ""}::varchar)`,
+  );
+  await rootDb.execute(
+    sql`UPDATE ${sql.raw(table)} AS t
+           SET citation_key = v.key
+          FROM (VALUES ${sql.join(values, sql`, `)}) AS v(id, key)
+         WHERE t.id = v.id`,
+  );
+
+  const nextSeen = seen + rows.length;
+  const nextKeyed =
+    keyed + rows.filter((row) => keyOf(row.text) !== null).length;
+  console.log(`  ${table}: ${nextSeen} scanned, ${nextKeyed} keyed`);
+  return await backfillFrom(
+    table,
+    sourceColumn,
+    rows.at(-1)?.id ?? after,
+    nextSeen,
+    nextKeyed,
+  );
+};
+
+/** Walk resolution to completion; same shape, same reason. */
+const resolveFrom = async (
+  after: string | null,
+  scanned: number,
+  resolved: number,
+): Promise<{ scanned: number; resolved: number }> => {
+  const batch = await resolveCitationBatch(ingestionDb, {
+    limit: BATCH,
+    afterId: after,
+  });
+  if (batch.scanned === 0) {
+    return { scanned, resolved };
+  }
+  const next = {
+    scanned: scanned + batch.scanned,
+    resolved: resolved + batch.resolved,
+  };
+  console.log(`  scanned ${next.scanned}, resolved ${next.resolved}`);
+  return await resolveFrom(batch.lastId, next.scanned, next.resolved);
 };
 
 if (!RESOLVE_ONLY) {
   console.log("=== Backfilling citation keys ===");
-  await backfillKeys("case_law_decisions", "case_number");
-  await backfillKeys("case_law_citations", "citation_text");
+  await backfillFrom("case_law_decisions", "case_number", null, 0, 0);
+  await backfillFrom("case_law_citations", "citation_text", null, 0, 0);
 }
 
 if (!KEYS_ONLY) {
   console.log("=== Resolving citations ===");
-  let after: string | null = null;
-  let scanned = 0;
-  let resolved = 0;
-
-  while (true) {
-    // oxlint-disable-next-line no-await-in-loop -- keyset walk: each batch's cursor comes from the previous one
-    const batch = await resolveCitationBatch(ingestionDb, {
-      limit: BATCH,
-      afterId: after,
-    });
-    if (batch.scanned === 0) {
-      break;
-    }
-    scanned += batch.scanned;
-    resolved += batch.resolved;
-    after = batch.lastId;
-    console.log(`  scanned ${scanned}, resolved ${resolved}`);
-  }
+  const { scanned, resolved } = await resolveFrom(null, 0, 0);
   console.log(`Done. Scanned ${scanned}, resolved ${resolved}.`);
 }
 

--- a/apps/api/src/scripts/backfill-citation-keys.ts
+++ b/apps/api/src/scripts/backfill-citation-keys.ts
@@ -1,0 +1,118 @@
+/**
+ * Populate `citation_key` on decisions and citations, then resolve.
+ *
+ * Both sides canonicalize through `bareCitationKey`, so once the column is
+ * filled, resolution is an indexed equality join (see
+ * `handlers/case-law/citation-resolution.ts`). Rows written after the
+ * column landed already carry it; this fills everything older.
+ *
+ * Keyset-paginated by id and idempotent: it can stop anywhere and resume,
+ * and re-running only touches rows still missing a key.
+ *
+ *   bun apps/api/src/scripts/backfill-citation-keys.ts
+ *   bun apps/api/src/scripts/backfill-citation-keys.ts --keys-only
+ *   bun apps/api/src/scripts/backfill-citation-keys.ts --resolve-only
+ */
+
+import { sql } from "drizzle-orm";
+
+import { rlsDb, rootDb } from "@/api/db/root";
+import { createIngestionDb } from "@/api/db/scoped";
+import { resolveCitationBatch } from "@/api/handlers/case-law/citation-resolution";
+import { bareCitationKey } from "@/api/handlers/case-law/ingestion/citation-extractor";
+import { isRecord } from "@/api/lib/type-guards";
+
+const BATCH = 5000;
+const KEYS_ONLY = process.argv.includes("--keys-only");
+const RESOLVE_ONLY = process.argv.includes("--resolve-only");
+
+const ingestionDb = createIngestionDb(rlsDb);
+
+const keyOf = (text: string): string | null => bareCitationKey(text) || null;
+
+/**
+ * Fill one table's keys. `source` is the column the key derives from, and
+ * rows whose text does not canonicalize get an empty key rather than being
+ * revisited forever — null means "not yet computed", so leaving it null on
+ * an uncanonicalizable row would make the scan never terminate.
+ */
+const backfillKeys = async (
+  table: "case_law_decisions" | "case_law_citations",
+  sourceColumn: "case_number" | "citation_text",
+): Promise<void> => {
+  let after: string | null = null;
+  let seen = 0;
+  let keyed = 0;
+
+  while (true) {
+    // oxlint-disable-next-line no-await-in-loop -- keyset walk: each batch starts where the previous ended
+    const result: unknown = await rootDb.execute(
+      sql`SELECT id, ${sql.raw(sourceColumn)} AS text
+            FROM ${sql.raw(table)}
+           WHERE citation_key IS NULL
+             ${after === null ? sql`` : sql`AND id > ${after}`}
+           ORDER BY id
+           LIMIT ${BATCH}`,
+    );
+    const rows = (Array.isArray(result) ? result : []).flatMap((row) =>
+      isRecord(row) &&
+      typeof row["id"] === "string" &&
+      typeof row["text"] === "string"
+        ? [{ id: row["id"], text: row["text"] }]
+        : [],
+    );
+
+    if (rows.length === 0) {
+      break;
+    }
+
+    const values = rows.map((row) => {
+      const key = keyOf(row.text) ?? "";
+      return sql`(${row.id}::uuid, ${key}::varchar)`;
+    });
+
+    // oxlint-disable-next-line no-await-in-loop -- one bounded batch write per iteration
+    await rootDb.execute(
+      sql`UPDATE ${sql.raw(table)} AS t
+             SET citation_key = v.key
+            FROM (VALUES ${sql.join(values, sql`, `)}) AS v(id, key)
+           WHERE t.id = v.id`,
+    );
+
+    seen += rows.length;
+    keyed += rows.filter((row) => keyOf(row.text) !== null).length;
+    after = rows.at(-1)?.id ?? after;
+    console.log(`  ${table}: ${seen} scanned, ${keyed} keyed`);
+  }
+};
+
+if (!RESOLVE_ONLY) {
+  console.log("=== Backfilling citation keys ===");
+  await backfillKeys("case_law_decisions", "case_number");
+  await backfillKeys("case_law_citations", "citation_text");
+}
+
+if (!KEYS_ONLY) {
+  console.log("=== Resolving citations ===");
+  let after: string | null = null;
+  let scanned = 0;
+  let resolved = 0;
+
+  while (true) {
+    // oxlint-disable-next-line no-await-in-loop -- keyset walk: each batch's cursor comes from the previous one
+    const batch = await resolveCitationBatch(ingestionDb, {
+      limit: BATCH,
+      afterId: after,
+    });
+    if (batch.scanned === 0) {
+      break;
+    }
+    scanned += batch.scanned;
+    resolved += batch.resolved;
+    after = batch.lastId;
+    console.log(`  scanned ${scanned}, resolved ${resolved}`);
+  }
+  console.log(`Done. Scanned ${scanned}, resolved ${resolved}.`);
+}
+
+process.exit(0);


### PR DESCRIPTION
#1484 added `citation_key` and the set-based resolver, but only rows written since then carry a key — so resolution currently matches nothing across the existing 3.4M citations and 2.1M decisions.

This fills both sides from `bareCitationKey` (the same canonicalizer the extractor already uses, verified symmetric across Czech `sp. zn.`/`č. j.`, Polish `sygn. akt`, Slovak and ÚS forms), then walks `resolveCitationBatch` to completion.

Two properties that matter for a job this size:

- **Resumable.** Keyset-paginated by id, so it can stop anywhere and continue; re-running only touches rows still missing a key.
- **Terminating.** Text that does not canonicalize is keyed to the empty string rather than left null. Null means "not yet computed", so leaving it null on an uncanonicalizable row would make the scan revisit it forever.

Flags allow the phases to run separately (`--keys-only`, `--resolve-only`) so the key fill can be verified before anything writes to the citation graph.

Measured on a corrected 50k production sample, resolution should link about **52%** of citations — roughly 1.8M edges. The remainder is dominated by procedural references to unpublished lower-court judgments, which the `precedent | procedural` discriminator will classify rather than chase.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added a resumable maintenance process for standardising citation keys across existing records.
  - Supports processing all records or running targeted stages independently.
  - Handles records that cannot be standardised without interrupting the overall process.
  - Processes data in manageable batches and reports progress and completion totals for improved operational visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->