### PR TITLE
feat: improve search result previews

### DIFF
--- a/apps/api/drizzle/20260731120000_chat_search_display_metadata/migration.sql
+++ b/apps/api/drizzle/20260731120000_chat_search_display_metadata/migration.sql
@@ -1,9 +1,0 @@
--- stella-migration-safety: reviewed bulk-backfill - marks only derived chat search projections; the bounded scheduler repair is resumable and old/new writers remain schema-compatible
--- Mark every existing chat projection for the bounded scheduler repair.
--- During a rolling deploy, old application tasks continue writing their real
--- preview generation UUID; the new writer clears it after rebuilding. Search
--- reads exclude marked rows, so internal reference-only matches cannot surface
--- through while the repair converges.
-UPDATE chat_thread_search_documents
-SET preview_generation = '00000000-0000-0000-0000-000000000001'::uuid
-WHERE preview_generation IS NULL;

--- a/apps/api/drizzle/20260731120000_chat_search_display_metadata/migration.sql
+++ b/apps/api/drizzle/20260731120000_chat_search_display_metadata/migration.sql
@@ -1,0 +1,9 @@
+-- stella-migration-safety: reviewed bulk-backfill - marks only derived chat search projections; the bounded scheduler repair is resumable and old/new writers remain schema-compatible
+-- Mark every existing chat projection for the bounded scheduler repair.
+-- During a rolling deploy, old application tasks continue writing their real
+-- preview generation UUID; the new writer clears it after rebuilding. Search
+-- reads exclude marked rows, so internal reference-only matches cannot surface
+-- through while the repair converges.
+UPDATE chat_thread_search_documents
+SET preview_generation = '00000000-0000-0000-0000-000000000001'::uuid
+WHERE preview_generation IS NULL;

--- a/apps/api/src/handlers/search/search.test.ts
+++ b/apps/api/src/handlers/search/search.test.ts
@@ -115,6 +115,24 @@ describe("search handler workspace scoping", () => {
     });
   });
 
+  test("returns canonical positive locator candidates for native previews", async () => {
+    const result = await searchHandler({
+      accessibleWorkspaceIds,
+      body: {
+        ...emptySearchFilters(),
+        query: '"closing memo" OR liability NOT superseded',
+      },
+      organizationId,
+      userId,
+      search: searchMock,
+      scopedDb: unusedScopedDb,
+    });
+
+    expect(result).toMatchObject({
+      previewLocatorCandidates: ["closing memo", "liability"],
+    });
+  });
+
   test("rejects a blank query scoped only to a workspace", async () => {
     const result = await searchHandler({
       accessibleWorkspaceIds,

--- a/apps/api/src/handlers/search/search.ts
+++ b/apps/api/src/handlers/search/search.ts
@@ -9,6 +9,7 @@ import { tSafeId, tUserId } from "@/api/lib/custom-schema";
 import { LIMITS } from "@/api/lib/limits";
 import { searchGlobal } from "@/api/lib/search/index-global";
 import { parseGlobalSearchCursor } from "@/api/lib/search/pagination";
+import { getSearchPreviewLocatorCandidates } from "@/api/lib/search/query";
 import { GLOBAL_SEARCH_RESULT_TYPES } from "@/api/lib/search/types";
 
 const isoDateTime = t.String({ format: "date-time" });
@@ -166,7 +167,7 @@ export const searchHandler = async ({
 
   const types = body.types.length > 0 ? body.types : body.kinds;
 
-  return await search({
+  const result = await search({
     query: body.query,
     organizationId,
     userId,
@@ -180,4 +181,9 @@ export const searchHandler = async ({
     cursor: body.cursor,
     limit: body.limit ?? LIMITS.searchPageSizeDefault,
   });
+
+  return {
+    ...result,
+    previewLocatorCandidates: getSearchPreviewLocatorCandidates(body.query),
+  };
 };

--- a/apps/api/src/lib/limits.ts
+++ b/apps/api/src/lib/limits.ts
@@ -203,6 +203,10 @@ export const LIMITS = {
   searchQueryMaxLength: 500,
   searchPageSizeDefault: 20,
   searchPageSizeMax: 100,
+  /** Maximum visible text returned by any global-search preview response. */
+  searchPreviewResponseCharacterLimit: 16_000,
+  /** Messages surrounding the best match in a global-search chat preview. */
+  searchChatPreviewMessageLimit: 6,
   savedSearchesPerUser: 100,
   savedSearchesPageSizeDefault: 50,
   savedSearchesPageSizeMax: 100,

--- a/apps/api/src/lib/scheduler/jobs.ts
+++ b/apps/api/src/lib/scheduler/jobs.ts
@@ -8,6 +8,7 @@ import { RECONCILE_BUFFER_INTENTS_TASK } from "@/api/lib/scheduler/tasks/buffer-
 import { BACKFILL_SK_DOCUMENTS_TASK } from "@/api/lib/scheduler/tasks/case-law-sk-documents";
 import { EXPIRE_DESKTOP_EDIT_SESSIONS_TASK } from "@/api/lib/scheduler/tasks/desktop-edit-session-expiry";
 import { INFO_SOUD_SYNC_TRACKED_CASES_TASK } from "@/api/lib/scheduler/tasks/infosoud";
+import { REPAIR_CHAT_SEARCH_INDEX_TASK } from "@/api/lib/scheduler/tasks/search-chat-index";
 import { REPAIR_SEARCH_SEMANTIC_TIMESTAMPS_TASK } from "@/api/lib/scheduler/tasks/search-semantic-timestamps";
 
 type SchedulerJobDefinition = {
@@ -119,6 +120,16 @@ export const ensureDefaultSchedulerJobs = async (): Promise<void> => {
       everyMs: 60 * 1000,
     },
     task: RECONCILE_BUFFER_INTENTS_TASK,
+  });
+
+  await ensureSchedulerJob({
+    description: "Repair stale chat search projections",
+    id: "search.repairChatIndex.fiveMinute",
+    schedule: {
+      type: "interval",
+      everyMs: 5 * 60 * 1000,
+    },
+    task: REPAIR_CHAT_SEARCH_INDEX_TASK,
   });
 
   await ensureOneShotSchedulerJob({

--- a/apps/api/src/lib/scheduler/registry.ts
+++ b/apps/api/src/lib/scheduler/registry.ts
@@ -20,6 +20,10 @@ import {
   syncInfoSoudTrackedCases,
 } from "@/api/lib/scheduler/tasks/infosoud";
 import {
+  REPAIR_CHAT_SEARCH_INDEX_TASK,
+  repairChatSearchIndex,
+} from "@/api/lib/scheduler/tasks/search-chat-index";
+import {
   REPAIR_SEARCH_SEMANTIC_TIMESTAMPS_TASK,
   repairSearchSemanticTimestampsTask,
 } from "@/api/lib/scheduler/tasks/search-semantic-timestamps";
@@ -41,6 +45,7 @@ export const createSchedulerTaskRegistry = (): SchedulerTaskRegistry =>
     [FLOW_RUN_TASK, runScheduledFlow],
     [BACKFILL_SK_DOCUMENTS_TASK, backfillSkDocuments],
     [RECONCILE_BUFFER_INTENTS_TASK, reconcileBufferIntents],
+    [REPAIR_CHAT_SEARCH_INDEX_TASK, repairChatSearchIndex],
     [
       REPAIR_SEARCH_SEMANTIC_TIMESTAMPS_TASK,
       repairSearchSemanticTimestampsTask,

--- a/apps/api/src/lib/scheduler/tasks/search-chat-index.ts
+++ b/apps/api/src/lib/scheduler/tasks/search-chat-index.ts
@@ -1,0 +1,20 @@
+import type { SchedulerTask } from "@/api/lib/scheduler/types";
+import { backfillChatThreadSearchIndex } from "@/api/lib/search/index-chat";
+
+export const REPAIR_CHAT_SEARCH_INDEX_TASK = "search.repairChatIndex" as const;
+
+export const repairChatSearchIndex: SchedulerTask = async ({
+  logger,
+  signal,
+}) => {
+  // audit: skip — scheduler repairs derived search projections;
+  // scheduler_job_runs is the durable execution trail.
+  const indexed = await backfillChatThreadSearchIndex({ signal });
+
+  if (indexed === 0) {
+    logger.debug("chat_search.repair_clean");
+    return;
+  }
+
+  logger.info("chat_search.repair_complete", { indexed });
+};

--- a/apps/api/src/lib/search/chat-search-generation.ts
+++ b/apps/api/src/lib/search/chat-search-generation.ts
@@ -1,0 +1,7 @@
+/**
+ * Version marker for chat projections whose searchable source-document
+ * metadata follows the current display-only contract. UUIDv7 generations
+ * written by the previous indexer cannot equal this reserved UUID.
+ */
+export const CHAT_SEARCH_DISPLAY_METADATA_GENERATION =
+  "00000000-0000-0000-0000-000000000001" as const;

--- a/apps/api/src/lib/search/global-search-mappers.ts
+++ b/apps/api/src/lib/search/global-search-mappers.ts
@@ -52,6 +52,7 @@ export const mapEntityHit = (row: RawRow): ScoredEntityGlobalSearchHit => {
     updatedAt: toIso(row["updated_at"]),
     lastEditedByName: toNullableString(row["last_edited_by_name"]),
     lastEditedByImage: toNullableString(row["last_edited_by_image"]),
+    fileFieldId: toNullableString(row["file_field_id"]),
     mimeType: toNullableString(row["mime_type"]),
   };
 

--- a/apps/api/src/lib/search/global-search-mappers.ts
+++ b/apps/api/src/lib/search/global-search-mappers.ts
@@ -53,6 +53,7 @@ export const mapEntityHit = (row: RawRow): ScoredEntityGlobalSearchHit => {
     lastEditedByName: toNullableString(row["last_edited_by_name"]),
     lastEditedByImage: toNullableString(row["last_edited_by_image"]),
     fileFieldId: toNullableString(row["file_field_id"]),
+    filePropertyId: toNullableString(row["file_property_id"]),
     mimeType: toNullableString(row["mime_type"]),
   };
 

--- a/apps/api/src/lib/search/highlight.test.ts
+++ b/apps/api/src/lib/search/highlight.test.ts
@@ -8,14 +8,14 @@ import {
   SEARCH_PREVIEW_FRAGMENT_DELIMITER,
   SEARCH_PREVIEW_FRAGMENT_SEPARATOR,
   SEARCH_PREVIEW_HEADLINE_CONFIG,
-  truncateSearchPreviewAroundLexemes,
+  truncateSearchPreviewAroundCandidates,
 } from "./highlight";
 
 describe("search result highlighting", () => {
   test("centers a bounded preview around a normalized late match", () => {
     const source = `${"a".repeat(20_000)} odštěpení ${"b".repeat(20_000)}`;
-    const preview = truncateSearchPreviewAroundLexemes({
-      lexemes: ["odstepeni"],
+    const preview = truncateSearchPreviewAroundCandidates({
+      candidates: ["odstepeni"],
       maxLength: 16_000,
       source,
     });
@@ -27,8 +27,8 @@ describe("search result highlighting", () => {
 
   test("anchors locator prefixes at lexical boundaries", () => {
     const source = `educate ${"a".repeat(20_000)} catapult`;
-    const preview = truncateSearchPreviewAroundLexemes({
-      lexemes: ["cat"],
+    const preview = truncateSearchPreviewAroundCandidates({
+      candidates: ["cat"],
       maxLength: 16_000,
       source,
     });
@@ -39,8 +39,8 @@ describe("search result highlighting", () => {
 
   test("maps length-changing Arabic folds back to the source", () => {
     const source = `${"a".repeat(20_000)} مـحـمـد`;
-    const preview = truncateSearchPreviewAroundLexemes({
-      lexemes: ["محمد"],
+    const preview = truncateSearchPreviewAroundCandidates({
+      candidates: ["محمد"],
       maxLength: 16_000,
       source,
     });
@@ -50,14 +50,26 @@ describe("search result highlighting", () => {
 
   test("does not split surrogate pairs in a fallback preview", () => {
     const source = `${"a".repeat(15_999)}😀 trailing`;
-    const preview = truncateSearchPreviewAroundLexemes({
-      lexemes: ["absent"],
+    const preview = truncateSearchPreviewAroundCandidates({
+      candidates: ["absent"],
       maxLength: 16_000,
       source,
     });
 
     expect(preview).toBe("a".repeat(15_999));
     expect(preview).not.toContain("\u{d83d}");
+  });
+
+  test("centers on an intact phrase instead of an earlier standalone word", () => {
+    const source = `closing ${"a".repeat(20_000)} closing, memo`;
+    const preview = truncateSearchPreviewAroundCandidates({
+      candidates: ["closing memo"],
+      maxLength: 16_000,
+      source,
+    });
+
+    expect(preview).toContain("closing, memo");
+    expect(preview).not.toStartWith("closing ");
   });
 
   test("escapes HTML before inserting highlight tags", () => {

--- a/apps/api/src/lib/search/highlight.test.ts
+++ b/apps/api/src/lib/search/highlight.test.ts
@@ -25,6 +25,29 @@ describe("search result highlighting", () => {
     expect(preview).not.toBe("a".repeat(16_000));
   });
 
+  test("anchors locator prefixes at lexical boundaries", () => {
+    const source = `educate ${"a".repeat(20_000)} catapult`;
+    const preview = truncateSearchPreviewAroundLexemes({
+      lexemes: ["cat"],
+      maxLength: 16_000,
+      source,
+    });
+
+    expect(preview).toContain("catapult");
+    expect(preview).not.toContain("educate");
+  });
+
+  test("maps length-changing Arabic folds back to the source", () => {
+    const source = `${"a".repeat(20_000)} مـحـمـد`;
+    const preview = truncateSearchPreviewAroundLexemes({
+      lexemes: ["محمد"],
+      maxLength: 16_000,
+      source,
+    });
+
+    expect(preview).toContain("مـحـمـد");
+  });
+
   test("escapes HTML before inserting highlight tags", () => {
     const highlighted = escapeAndHighlight(
       `<script>alert("x")</script> ${HIGHLIGHT_START}Privileged & confidential${HIGHLIGHT_STOP}`,

--- a/apps/api/src/lib/search/highlight.test.ts
+++ b/apps/api/src/lib/search/highlight.test.ts
@@ -8,9 +8,23 @@ import {
   SEARCH_PREVIEW_FRAGMENT_DELIMITER,
   SEARCH_PREVIEW_FRAGMENT_SEPARATOR,
   SEARCH_PREVIEW_HEADLINE_CONFIG,
+  truncateSearchPreviewAroundLexemes,
 } from "./highlight";
 
 describe("search result highlighting", () => {
+  test("centers a bounded preview around a normalized late match", () => {
+    const source = `${"a".repeat(20_000)} odštěpení ${"b".repeat(20_000)}`;
+    const preview = truncateSearchPreviewAroundLexemes({
+      lexemes: ["odstepeni"],
+      maxLength: 16_000,
+      source,
+    });
+
+    expect(preview).toContain("odštěpení");
+    expect(preview.length).toBeLessThanOrEqual(16_000);
+    expect(preview).not.toBe("a".repeat(16_000));
+  });
+
   test("escapes HTML before inserting highlight tags", () => {
     const highlighted = escapeAndHighlight(
       `<script>alert("x")</script> ${HIGHLIGHT_START}Privileged & confidential${HIGHLIGHT_STOP}`,

--- a/apps/api/src/lib/search/highlight.test.ts
+++ b/apps/api/src/lib/search/highlight.test.ts
@@ -48,6 +48,18 @@ describe("search result highlighting", () => {
     expect(preview).toContain("مـحـمـد");
   });
 
+  test("does not split surrogate pairs in a fallback preview", () => {
+    const source = `${"a".repeat(15_999)}😀 trailing`;
+    const preview = truncateSearchPreviewAroundLexemes({
+      lexemes: ["absent"],
+      maxLength: 16_000,
+      source,
+    });
+
+    expect(preview).toBe("a".repeat(15_999));
+    expect(preview).not.toContain("\u{d83d}");
+  });
+
   test("escapes HTML before inserting highlight tags", () => {
     const highlighted = escapeAndHighlight(
       `<script>alert("x")</script> ${HIGHLIGHT_START}Privileged & confidential${HIGHLIGHT_STOP}`,

--- a/apps/api/src/lib/search/highlight.ts
+++ b/apps/api/src/lib/search/highlight.ts
@@ -1,4 +1,8 @@
-import { normalizeSearchText, stripDiacritics } from "@stll/text-normalize";
+import {
+  applyArabicFolds,
+  normalizeSearchText,
+  stripDiacritics,
+} from "@stll/text-normalize";
 
 // Non-HTML delimiters injected by ts_headline / pdb.snippet(). Keep these
 // high-entropy internal tokens distinct from user-typable source text: common
@@ -188,6 +192,77 @@ const sourceSpanAt = (
     start: mapping.sourceStart + offset,
     end: mapping.sourceStart + offset + 1,
   };
+};
+
+type TruncateSearchPreviewAroundLexemesOptions = {
+  lexemes: readonly string[];
+  maxLength: number;
+  source: string;
+};
+
+const isLowSurrogate = (value: number): boolean =>
+  value >= 0xdc_00 && value <= 0xdf_ff;
+
+const isHighSurrogate = (value: number): boolean =>
+  value >= 0xd8_00 && value <= 0xdb_ff;
+
+export const truncateSearchPreviewAroundLexemes = ({
+  lexemes,
+  maxLength,
+  source,
+}: TruncateSearchPreviewAroundLexemesOptions): string => {
+  const boundedLength = Math.max(0, Math.floor(maxLength));
+  if (boundedLength === 0) {
+    return "";
+  }
+  if (source.length <= boundedLength) {
+    return source;
+  }
+
+  const normalizedSource = normalizeSourceWithMappings(source, true);
+  const foldedSource = applyArabicFolds(normalizedSource.text);
+  let normalizedMatchStart = Number.POSITIVE_INFINITY;
+  let normalizedMatchLength = 0;
+  for (const lexeme of lexemes) {
+    const normalizedLexeme = applyArabicFolds(
+      normalizePreviewUnit(lexeme.trim(), true),
+    );
+    if (!normalizedLexeme) {
+      continue;
+    }
+    const start = foldedSource.indexOf(normalizedLexeme);
+    if (start !== -1 && start < normalizedMatchStart) {
+      normalizedMatchStart = start;
+      normalizedMatchLength = normalizedLexeme.length;
+    }
+  }
+
+  if (!Number.isFinite(normalizedMatchStart)) {
+    return source.slice(0, boundedLength);
+  }
+  const firstSpan = sourceSpanAt(normalizedSource, normalizedMatchStart);
+  const lastSpan = sourceSpanAt(
+    normalizedSource,
+    normalizedMatchStart + normalizedMatchLength - 1,
+  );
+  if (!firstSpan || !lastSpan) {
+    return source.slice(0, boundedLength);
+  }
+
+  const matchCenter = Math.floor((firstSpan.start + lastSpan.end) / 2);
+  let start = Math.max(
+    0,
+    Math.min(source.length - boundedLength, matchCenter - boundedLength / 2),
+  );
+  start = Math.floor(start);
+  if (isLowSurrogate(source.codePointAt(start))) {
+    start += 1;
+  }
+  let end = Math.min(source.length, start + boundedLength);
+  if (isHighSurrogate(source.codePointAt(end - 1))) {
+    end -= 1;
+  }
+  return source.slice(start, end);
 };
 
 type AlignmentAnchor = {

--- a/apps/api/src/lib/search/highlight.ts
+++ b/apps/api/src/lib/search/highlight.ts
@@ -1,5 +1,6 @@
 import {
   applyArabicFolds,
+  applyArabicFoldsWithOffsets,
   normalizeSearchText,
   stripDiacritics,
 } from "@stll/text-normalize";
@@ -206,6 +207,37 @@ const isLowSurrogate = (value: number): boolean =>
 const isHighSurrogate = (value: number): boolean =>
   value >= 0xd8_00 && value <= 0xdb_ff;
 
+const SEARCH_LEXEME_CHARACTER = /[\p{L}\p{N}]/u;
+
+const characterBefore = (text: string, index: number): string | null => {
+  if (index <= 0) {
+    return null;
+  }
+  const previousUnit = text.charCodeAt(index - 1);
+  const previousIndex = isLowSurrogate(previousUnit) ? index - 2 : index - 1;
+  const codePoint = text.codePointAt(previousIndex);
+  return codePoint === undefined ? null : String.fromCodePoint(codePoint);
+};
+
+const findLexemePrefix = (text: string, lexeme: string): number => {
+  let searchFrom = 0;
+  while (searchFrom <= text.length - lexeme.length) {
+    const start = text.indexOf(lexeme, searchFrom);
+    if (start === -1) {
+      return -1;
+    }
+    const previousCharacter = characterBefore(text, start);
+    if (
+      previousCharacter === null ||
+      !SEARCH_LEXEME_CHARACTER.test(previousCharacter)
+    ) {
+      return start;
+    }
+    searchFrom = start + lexeme.length;
+  }
+  return -1;
+};
+
 export const truncateSearchPreviewAroundLexemes = ({
   lexemes,
   maxLength,
@@ -220,9 +252,9 @@ export const truncateSearchPreviewAroundLexemes = ({
   }
 
   const normalizedSource = normalizeSourceWithMappings(source, true);
-  const foldedSource = applyArabicFolds(normalizedSource.text);
-  let normalizedMatchStart = Number.POSITIVE_INFINITY;
-  let normalizedMatchLength = 0;
+  const foldedSource = applyArabicFoldsWithOffsets(normalizedSource.text);
+  let foldedMatchStart = Number.POSITIVE_INFINITY;
+  let foldedMatchLength = 0;
   for (const lexeme of lexemes) {
     const normalizedLexeme = applyArabicFolds(
       normalizePreviewUnit(lexeme.trim(), true),
@@ -230,21 +262,29 @@ export const truncateSearchPreviewAroundLexemes = ({
     if (!normalizedLexeme) {
       continue;
     }
-    const start = foldedSource.indexOf(normalizedLexeme);
-    if (start !== -1 && start < normalizedMatchStart) {
-      normalizedMatchStart = start;
-      normalizedMatchLength = normalizedLexeme.length;
+    const start = findLexemePrefix(foldedSource.text, normalizedLexeme);
+    if (start !== -1 && start < foldedMatchStart) {
+      foldedMatchStart = start;
+      foldedMatchLength = normalizedLexeme.length;
     }
   }
 
-  if (!Number.isFinite(normalizedMatchStart)) {
+  if (!Number.isFinite(foldedMatchStart)) {
+    return source.slice(0, boundedLength);
+  }
+  const normalizedMatchStart = foldedSource.sourceIndex.at(foldedMatchStart);
+  const normalizedMatchEnd = foldedSource.sourceEndIndex.at(
+    foldedMatchStart + foldedMatchLength - 1,
+  );
+  if (
+    normalizedMatchStart === undefined ||
+    normalizedMatchEnd === undefined ||
+    normalizedMatchEnd <= normalizedMatchStart
+  ) {
     return source.slice(0, boundedLength);
   }
   const firstSpan = sourceSpanAt(normalizedSource, normalizedMatchStart);
-  const lastSpan = sourceSpanAt(
-    normalizedSource,
-    normalizedMatchStart + normalizedMatchLength - 1,
-  );
+  const lastSpan = sourceSpanAt(normalizedSource, normalizedMatchEnd - 1);
   if (!firstSpan || !lastSpan) {
     return source.slice(0, boundedLength);
   }
@@ -255,11 +295,11 @@ export const truncateSearchPreviewAroundLexemes = ({
     Math.min(source.length - boundedLength, matchCenter - boundedLength / 2),
   );
   start = Math.floor(start);
-  if (isLowSurrogate(source.codePointAt(start))) {
+  if (isLowSurrogate(source.charCodeAt(start))) {
     start += 1;
   }
   let end = Math.min(source.length, start + boundedLength);
-  if (isHighSurrogate(source.codePointAt(end - 1))) {
+  if (isHighSurrogate(source.charCodeAt(end - 1))) {
     end -= 1;
   }
   return source.slice(start, end);

--- a/apps/api/src/lib/search/highlight.ts
+++ b/apps/api/src/lib/search/highlight.ts
@@ -195,8 +195,8 @@ const sourceSpanAt = (
   };
 };
 
-type TruncateSearchPreviewAroundLexemesOptions = {
-  lexemes: readonly string[];
+type TruncateSearchPreviewAroundCandidatesOptions = {
+  candidates: readonly string[];
   maxLength: number;
   source: string;
 };
@@ -226,42 +226,62 @@ const sliceWithoutSplitSurrogate = (
   return source.slice(start, end);
 };
 
-const SEARCH_LEXEME_CHARACTER = /[\p{L}\p{N}]/u;
+const SEARCH_LEXEME = /[\p{L}\p{N}]+/gu;
 
-const characterBefore = (text: string, index: number): string | null => {
-  if (index <= 0) {
+type CandidatePrefixMatch = {
+  length: number;
+  start: number;
+};
+
+type SearchLexeme = {
+  start: number;
+  value: string;
+};
+
+const getSearchLexemes = (text: string): SearchLexeme[] =>
+  Array.from(text.matchAll(SEARCH_LEXEME), (match) => ({
+    start: match.index,
+    value: match[0],
+  }));
+
+const findCandidatePrefix = (
+  sourceLexemes: readonly SearchLexeme[],
+  candidate: string,
+): CandidatePrefixMatch | null => {
+  const candidateLexemes = Array.from(
+    candidate.matchAll(SEARCH_LEXEME),
+    (match) => match[0],
+  );
+  if (candidateLexemes.length === 0) {
     return null;
   }
-  const previousUnit = utf16CodeUnitAt(text, index - 1);
-  const previousIndex = isLowSurrogate(previousUnit) ? index - 2 : index - 1;
-  const codePoint = text.codePointAt(previousIndex);
-  return codePoint === undefined ? null : String.fromCodePoint(codePoint);
-};
-
-const findLexemePrefix = (text: string, lexeme: string): number => {
-  let searchFrom = 0;
-  while (searchFrom <= text.length - lexeme.length) {
-    const start = text.indexOf(lexeme, searchFrom);
-    if (start === -1) {
-      return -1;
+  const lastStartIndex = sourceLexemes.length - candidateLexemes.length;
+  for (let startIndex = 0; startIndex <= lastStartIndex; startIndex += 1) {
+    const matches = candidateLexemes.every((lexeme, offset) =>
+      sourceLexemes.at(startIndex + offset)?.value.startsWith(lexeme),
+    );
+    if (!matches) {
+      continue;
     }
-    const previousCharacter = characterBefore(text, start);
-    if (
-      previousCharacter === null ||
-      !SEARCH_LEXEME_CHARACTER.test(previousCharacter)
-    ) {
-      return start;
+    const first = sourceLexemes.at(startIndex);
+    const last = sourceLexemes.at(startIndex + candidateLexemes.length - 1);
+    const lastCandidate = candidateLexemes.at(-1);
+    if (!first || !last || !lastCandidate) {
+      return null;
     }
-    searchFrom = start + lexeme.length;
+    return {
+      length: last.start + lastCandidate.length - first.start,
+      start: first.start,
+    };
   }
-  return -1;
+  return null;
 };
 
-export const truncateSearchPreviewAroundLexemes = ({
-  lexemes,
+export const truncateSearchPreviewAroundCandidates = ({
+  candidates,
   maxLength,
   source,
-}: TruncateSearchPreviewAroundLexemesOptions): string => {
+}: TruncateSearchPreviewAroundCandidatesOptions): string => {
   const boundedLength = Math.max(0, Math.floor(maxLength));
   if (boundedLength === 0) {
     return "";
@@ -272,19 +292,20 @@ export const truncateSearchPreviewAroundLexemes = ({
 
   const normalizedSource = normalizeSourceWithMappings(source, true);
   const foldedSource = applyArabicFoldsWithOffsets(normalizedSource.text);
+  const sourceLexemes = getSearchLexemes(foldedSource.text);
   let foldedMatchStart = Number.POSITIVE_INFINITY;
   let foldedMatchLength = 0;
-  for (const lexeme of lexemes) {
-    const normalizedLexeme = applyArabicFolds(
-      normalizePreviewUnit(lexeme.trim(), true),
+  for (const candidate of candidates) {
+    const normalizedCandidate = applyArabicFolds(
+      normalizePreviewUnit(candidate.trim(), true),
     );
-    if (!normalizedLexeme) {
+    if (!normalizedCandidate) {
       continue;
     }
-    const start = findLexemePrefix(foldedSource.text, normalizedLexeme);
-    if (start !== -1 && start < foldedMatchStart) {
-      foldedMatchStart = start;
-      foldedMatchLength = normalizedLexeme.length;
+    const match = findCandidatePrefix(sourceLexemes, normalizedCandidate);
+    if (match && match.start < foldedMatchStart) {
+      foldedMatchStart = match.start;
+      foldedMatchLength = match.length;
     }
   }
 

--- a/apps/api/src/lib/search/highlight.ts
+++ b/apps/api/src/lib/search/highlight.ts
@@ -207,6 +207,22 @@ const isLowSurrogate = (value: number): boolean =>
 const isHighSurrogate = (value: number): boolean =>
   value >= 0xd8_00 && value <= 0xdb_ff;
 
+const sliceWithoutSplitSurrogate = (
+  source: string,
+  requestedStart: number,
+  maxLength: number,
+): string => {
+  let start = Math.max(0, Math.min(source.length, Math.floor(requestedStart)));
+  if (isLowSurrogate(source.charCodeAt(start))) {
+    start += 1;
+  }
+  let end = Math.min(source.length, start + maxLength);
+  if (isHighSurrogate(source.charCodeAt(end - 1))) {
+    end -= 1;
+  }
+  return source.slice(start, end);
+};
+
 const SEARCH_LEXEME_CHARACTER = /[\p{L}\p{N}]/u;
 
 const characterBefore = (text: string, index: number): string | null => {
@@ -270,7 +286,7 @@ export const truncateSearchPreviewAroundLexemes = ({
   }
 
   if (!Number.isFinite(foldedMatchStart)) {
-    return source.slice(0, boundedLength);
+    return sliceWithoutSplitSurrogate(source, 0, boundedLength);
   }
   const normalizedMatchStart = foldedSource.sourceIndex.at(foldedMatchStart);
   const normalizedMatchEnd = foldedSource.sourceEndIndex.at(
@@ -281,28 +297,20 @@ export const truncateSearchPreviewAroundLexemes = ({
     normalizedMatchEnd === undefined ||
     normalizedMatchEnd <= normalizedMatchStart
   ) {
-    return source.slice(0, boundedLength);
+    return sliceWithoutSplitSurrogate(source, 0, boundedLength);
   }
   const firstSpan = sourceSpanAt(normalizedSource, normalizedMatchStart);
   const lastSpan = sourceSpanAt(normalizedSource, normalizedMatchEnd - 1);
   if (!firstSpan || !lastSpan) {
-    return source.slice(0, boundedLength);
+    return sliceWithoutSplitSurrogate(source, 0, boundedLength);
   }
 
   const matchCenter = Math.floor((firstSpan.start + lastSpan.end) / 2);
-  let start = Math.max(
+  const start = Math.max(
     0,
     Math.min(source.length - boundedLength, matchCenter - boundedLength / 2),
   );
-  start = Math.floor(start);
-  if (isLowSurrogate(source.charCodeAt(start))) {
-    start += 1;
-  }
-  let end = Math.min(source.length, start + boundedLength);
-  if (isHighSurrogate(source.charCodeAt(end - 1))) {
-    end -= 1;
-  }
-  return source.slice(start, end);
+  return sliceWithoutSplitSurrogate(source, start, boundedLength);
 };
 
 type AlignmentAnchor = {

--- a/apps/api/src/lib/search/highlight.ts
+++ b/apps/api/src/lib/search/highlight.ts
@@ -207,17 +207,20 @@ const isLowSurrogate = (value: number): boolean =>
 const isHighSurrogate = (value: number): boolean =>
   value >= 0xd8_00 && value <= 0xdb_ff;
 
+const utf16CodeUnitAt = (source: string, index: number): number =>
+  source.at(index)?.codePointAt(0) ?? Number.NaN;
+
 const sliceWithoutSplitSurrogate = (
   source: string,
   requestedStart: number,
   maxLength: number,
 ): string => {
   let start = Math.max(0, Math.min(source.length, Math.floor(requestedStart)));
-  if (isLowSurrogate(source.charCodeAt(start))) {
+  if (isLowSurrogate(utf16CodeUnitAt(source, start))) {
     start += 1;
   }
   let end = Math.min(source.length, start + maxLength);
-  if (isHighSurrogate(source.charCodeAt(end - 1))) {
+  if (isHighSurrogate(utf16CodeUnitAt(source, end - 1))) {
     end -= 1;
   }
   return source.slice(start, end);
@@ -229,7 +232,7 @@ const characterBefore = (text: string, index: number): string | null => {
   if (index <= 0) {
     return null;
   }
-  const previousUnit = text.charCodeAt(index - 1);
+  const previousUnit = utf16CodeUnitAt(text, index - 1);
   const previousIndex = isLowSurrogate(previousUnit) ? index - 2 : index - 1;
   const codePoint = text.codePointAt(previousIndex);
   return codePoint === undefined ? null : String.fromCodePoint(codePoint);

--- a/apps/api/src/lib/search/index-chat.test.ts
+++ b/apps/api/src/lib/search/index-chat.test.ts
@@ -77,6 +77,28 @@ const findExecutedQuery = (needle: string): string | undefined => {
 };
 
 describe("chat search indexing", () => {
+  test("indexes only source-document metadata that previews can display", async () => {
+    const { extractMessageSearchText } = await import("./index-chat");
+
+    expect(
+      extractMessageSearchText({
+        version: 2,
+        data: [],
+        metadata: {
+          sourceDocuments: [
+            {
+              entityRef: "internal-entity-reference",
+              kind: "document",
+              matterRef: "internal-matter-reference",
+              mention: "@closing-memo",
+              title: "Closing memorandum",
+            },
+          ],
+        },
+      }),
+    ).toBe("Closing memorandum @closing-memo document");
+  });
+
   test("filters malformed version 2 source-document metadata", async () => {
     const { normalizeSearchableChatMessageContent } =
       await import("./index-chat");

--- a/apps/api/src/lib/search/index-chat.test.ts
+++ b/apps/api/src/lib/search/index-chat.test.ts
@@ -134,8 +134,8 @@ describe("chat search indexing", () => {
     );
     expect(
       findExecutedQuery("INSERT INTO chat_thread_search_preview_passages"),
-    ).toBeDefined();
-    expect(findExecutedQuery("SET preview_generation =")).toBeDefined();
+    ).toBeUndefined();
+    expect(findExecutedQuery("SET preview_generation =")).toBeUndefined();
   });
 
   test("does not let stale upserts overwrite newer message search documents", async () => {
@@ -199,5 +199,7 @@ describe("chat search indexing", () => {
     expect(compiled.sql).toContain("LEFT JOIN chat_thread_search_documents");
     expect(compiled.sql).toContain("LEFT JOIN chat_message_search_documents");
     expect(compiled.sql).toContain("md.message_id IS NULL");
+    expect(compiled.sql).not.toContain("preview_generation");
+    expect(compiled.sql).not.toContain("chat_thread_search_preview_passages");
   });
 });

--- a/apps/api/src/lib/search/index-chat.test.ts
+++ b/apps/api/src/lib/search/index-chat.test.ts
@@ -139,7 +139,9 @@ describe("chat search indexing", () => {
     expect(
       findExecutedQuery("INSERT INTO chat_thread_search_preview_passages"),
     ).toBeUndefined();
-    expect(findExecutedQuery("SET preview_generation =")).toBeUndefined();
+    const generationSql = findExecutedQuery("SET preview_generation =");
+    expect(generationSql).toContain("WHERE thread_id =");
+    expect(generationSql).toContain("AND updated_at =");
   });
 
   test("does not let stale upserts overwrite newer message search documents", async () => {
@@ -203,7 +205,7 @@ describe("chat search indexing", () => {
     expect(compiled.sql).toContain("LEFT JOIN chat_thread_search_documents");
     expect(compiled.sql).toContain("LEFT JOIN chat_message_search_documents");
     expect(compiled.sql).toContain("md.message_id IS NULL");
-    expect(compiled.sql).toContain("d.preview_generation IS NOT NULL");
+    expect(compiled.sql).toContain("d.preview_generation IS DISTINCT FROM");
     expect(compiled.sql).not.toContain("chat_thread_search_preview_passages");
   });
 });

--- a/apps/api/src/lib/search/index-chat.test.ts
+++ b/apps/api/src/lib/search/index-chat.test.ts
@@ -87,11 +87,14 @@ describe("chat search indexing", () => {
         metadata: {
           sourceDocuments: [
             {
+              entityId: "entity_1",
               entityRef: "internal-entity-reference",
               kind: "document",
               matterRef: "internal-matter-reference",
               mention: "@closing-memo",
+              mimeType: "application/pdf",
               title: "Closing memorandum",
+              workspaceId: "workspace_1",
             },
           ],
         },

--- a/apps/api/src/lib/search/index-chat.test.ts
+++ b/apps/api/src/lib/search/index-chat.test.ts
@@ -132,6 +132,7 @@ describe("chat search indexing", () => {
     expect(sqlText).toContain(
       "WHERE EXCLUDED.updated_at >= chat_thread_search_documents.updated_at",
     );
+    expect(sqlText).toContain("preview_generation = NULL");
     expect(
       findExecutedQuery("INSERT INTO chat_thread_search_preview_passages"),
     ).toBeUndefined();
@@ -199,7 +200,7 @@ describe("chat search indexing", () => {
     expect(compiled.sql).toContain("LEFT JOIN chat_thread_search_documents");
     expect(compiled.sql).toContain("LEFT JOIN chat_message_search_documents");
     expect(compiled.sql).toContain("md.message_id IS NULL");
-    expect(compiled.sql).not.toContain("preview_generation");
+    expect(compiled.sql).toContain("d.preview_generation IS NOT NULL");
     expect(compiled.sql).not.toContain("chat_thread_search_preview_passages");
   });
 });

--- a/apps/api/src/lib/search/index-chat.test.ts
+++ b/apps/api/src/lib/search/index-chat.test.ts
@@ -77,6 +77,28 @@ const findExecutedQuery = (needle: string): string | undefined => {
 };
 
 describe("chat search indexing", () => {
+  test("filters malformed version 2 source-document metadata", async () => {
+    const { normalizeSearchableChatMessageContent } =
+      await import("./index-chat");
+    const validSource = {
+      entityId: "entity-1",
+      kind: "document",
+      mimeType: "application/pdf",
+      title: "Agreement.pdf",
+      workspaceId: "workspace-1",
+    };
+
+    expect(
+      normalizeSearchableChatMessageContent({
+        version: 2,
+        data: [],
+        metadata: { sourceDocuments: [null, validSource] },
+      }),
+    ).toMatchObject({
+      metadata: { sourceDocuments: [validSource] },
+    });
+  });
+
   test("does not let stale upserts overwrite a newer search document", async () => {
     const { upsertChatThreadSearchDocument } = await import("./index-chat");
 

--- a/apps/api/src/lib/search/index-chat.ts
+++ b/apps/api/src/lib/search/index-chat.ts
@@ -13,10 +13,6 @@ import { captureError } from "@/api/lib/analytics/capture";
 import type { SafeId } from "@/api/lib/branded-types";
 import { LIMITS } from "@/api/lib/limits";
 import { logger } from "@/api/lib/observability/logger";
-import {
-  buildSearchPreviewPassages,
-  buildSearchPreviewPassageValueRows,
-} from "@/api/lib/search/preview-passages";
 
 const BACKFILL_BATCH_SIZE = 200;
 const ZERO_UUID = "00000000-0000-0000-0000-000000000000";
@@ -183,63 +179,31 @@ export const upsertChatThreadSearchDocument = async (
     threadId: thread.id,
     threadUpdatedAt: thread.updatedAt,
   });
-  const previewGeneration = Bun.randomUUIDv7();
-  const previewPassages = buildSearchPreviewPassages(
-    thread.title,
-    searchableText,
-  );
-
-  await rootDb.transaction(async (tx) => {
-    const indexed = await tx.execute<{ threadId: SafeId<"chatThread"> }>(sql`
-      INSERT INTO chat_thread_search_documents (
-        thread_id, title, searchable_text, updated_at, tsv
-      ) VALUES (
-        ${thread.id},
-        ${thread.title},
-        ${searchableText},
-        ${thread.updatedAt},
-        to_tsvector(
-          'simple',
-          unaccent(
-            arabic_normalize(
-              coalesce(${thread.title}, '') || ' ' ||
-              coalesce(${searchableText}, '')
-            )
+  await rootDb.execute(sql`
+    INSERT INTO chat_thread_search_documents (
+      thread_id, title, searchable_text, updated_at, tsv
+    ) VALUES (
+      ${thread.id},
+      ${thread.title},
+      ${searchableText},
+      ${thread.updatedAt},
+      to_tsvector(
+        'simple',
+        unaccent(
+          arabic_normalize(
+            coalesce(${thread.title}, '') || ' ' ||
+            coalesce(${searchableText}, '')
           )
         )
       )
-      ON CONFLICT (thread_id) DO UPDATE SET
-        title = EXCLUDED.title,
-        searchable_text = EXCLUDED.searchable_text,
-        updated_at = EXCLUDED.updated_at,
-        tsv = EXCLUDED.tsv
-      WHERE EXCLUDED.updated_at >= chat_thread_search_documents.updated_at
-      RETURNING thread_id AS "threadId"
-    `);
-    if (!indexed.at(0)) {
-      return;
-    }
-    await tx.execute(sql`
-      DELETE FROM chat_thread_search_preview_passages
-      WHERE thread_id = ${thread.id}
-    `);
-    await tx.execute(sql`
-      INSERT INTO chat_thread_search_preview_passages (
-        thread_id, generation, ordinal, content, tsv
-      ) VALUES ${buildSearchPreviewPassageValueRows({
-        generation: previewGeneration,
-        leadingValues: [sql`${thread.id}`],
-        passages: previewPassages,
-        regconfig: sql`'simple'`,
-        useUnaccent: true,
-      })}
-    `);
-    await tx.execute(sql`
-      UPDATE chat_thread_search_documents
-      SET preview_generation = ${previewGeneration}::uuid
-      WHERE thread_id = ${thread.id}
-    `);
-  });
+    )
+    ON CONFLICT (thread_id) DO UPDATE SET
+      title = EXCLUDED.title,
+      searchable_text = EXCLUDED.searchable_text,
+      updated_at = EXCLUDED.updated_at,
+      tsv = EXCLUDED.tsv
+    WHERE EXCLUDED.updated_at >= chat_thread_search_documents.updated_at
+  `);
 };
 
 /** Page through a thread's messages by `(created_at, id)`, write the
@@ -388,13 +352,6 @@ export const backfillChatThreadSearchIndex = async (): Promise<number> => {
       LEFT JOIN chat_thread_search_documents d ON d.thread_id = t.id
       WHERE (
           d.thread_id IS NULL
-          OR d.preview_generation IS NULL
-          OR NOT EXISTS (
-            SELECT 1
-            FROM chat_thread_search_preview_passages passage
-            WHERE passage.thread_id = d.thread_id
-              AND passage.generation = d.preview_generation
-          )
           OR EXISTS (
             SELECT 1
             FROM chat_messages m

--- a/apps/api/src/lib/search/index-chat.ts
+++ b/apps/api/src/lib/search/index-chat.ts
@@ -31,13 +31,73 @@ const isPersistedChatMessageContent = (
   (value["version"] === 1 || value["version"] === 2) &&
   Array.isArray(value["data"]);
 
+type SearchableChatSourceDocument = {
+  entityId?: string;
+  entityRef?: string;
+  kind: string;
+  matterRef?: string;
+  mention?: string;
+  mimeType?: string | null;
+  title: string;
+  workspaceId?: string | null;
+};
+
+const toSearchableChatSourceDocument = (
+  value: unknown,
+): SearchableChatSourceDocument | null => {
+  if (
+    !isRecord(value) ||
+    typeof value["kind"] !== "string" ||
+    typeof value["title"] !== "string"
+  ) {
+    return null;
+  }
+  return {
+    kind: value["kind"],
+    title: value["title"],
+    ...(typeof value["entityId"] === "string"
+      ? { entityId: value["entityId"] }
+      : {}),
+    ...(typeof value["entityRef"] === "string"
+      ? { entityRef: value["entityRef"] }
+      : {}),
+    ...(typeof value["matterRef"] === "string"
+      ? { matterRef: value["matterRef"] }
+      : {}),
+    ...(typeof value["mention"] === "string"
+      ? { mention: value["mention"] }
+      : {}),
+    ...(value["mimeType"] === null || typeof value["mimeType"] === "string"
+      ? { mimeType: value["mimeType"] }
+      : {}),
+    ...(value["workspaceId"] === null ||
+    typeof value["workspaceId"] === "string"
+      ? { workspaceId: value["workspaceId"] }
+      : {}),
+  };
+};
+
 export const normalizeSearchableChatMessageContent = (content: unknown) => {
   if (!isPersistedChatMessageContent(content)) {
     return null;
   }
   const normalized = normalizePersistedChatMessageContent(content);
+  const sourceDocuments: unknown = normalized.metadata.sourceDocuments;
+  const metadata =
+    sourceDocuments === undefined
+      ? normalized.metadata
+      : {
+          ...normalized.metadata,
+          sourceDocuments: Array.isArray(sourceDocuments)
+            ? sourceDocuments.flatMap((sourceDocument) => {
+                const searchable =
+                  toSearchableChatSourceDocument(sourceDocument);
+                return searchable ? [searchable] : [];
+              })
+            : [],
+        };
   return {
-    metadata: normalized.metadata,
+    metadata,
     parts: normalized.parts.filter(isChatPart),
   };
 };

--- a/apps/api/src/lib/search/index-chat.ts
+++ b/apps/api/src/lib/search/index-chat.ts
@@ -13,6 +13,7 @@ import { captureError } from "@/api/lib/analytics/capture";
 import type { SafeId } from "@/api/lib/branded-types";
 import { LIMITS } from "@/api/lib/limits";
 import { logger } from "@/api/lib/observability/logger";
+import { CHAT_SEARCH_DISPLAY_METADATA_GENERATION } from "@/api/lib/search/chat-search-generation";
 
 const BACKFILL_BATCH_SIZE = 200;
 const ZERO_UUID = "00000000-0000-0000-0000-000000000000";
@@ -206,6 +207,12 @@ export const upsertChatThreadSearchDocument = async (
       tsv = EXCLUDED.tsv
     WHERE EXCLUDED.updated_at >= chat_thread_search_documents.updated_at
   `);
+  await rootDb.execute(sql`
+    UPDATE chat_thread_search_documents
+    SET preview_generation = ${CHAT_SEARCH_DISPLAY_METADATA_GENERATION}::uuid
+    WHERE thread_id = ${thread.id}
+      AND updated_at = ${thread.updatedAt}
+  `);
 };
 
 /** Page through a thread's messages by `(created_at, id)`, write the
@@ -362,11 +369,11 @@ export const backfillChatThreadSearchIndex = async ({
       LEFT JOIN chat_thread_search_documents d ON d.thread_id = t.id
       WHERE (
           d.thread_id IS NULL
-          -- The previous writer always stored a preview generation. The live
-          -- preview no longer consumes those passages, so non-null doubles as
-          -- a rolling-deploy freshness marker: old tasks mark their writes
-          -- stale, while the current upsert clears the marker after rebuilding.
-          OR d.preview_generation IS NOT NULL
+          -- The previous writer stored UUIDv7 passage generations. The
+          -- reserved display-metadata generation therefore distinguishes the
+          -- current projection without rewriting existing rows in a migration.
+          OR d.preview_generation IS DISTINCT FROM
+            ${CHAT_SEARCH_DISPLAY_METADATA_GENERATION}::uuid
           OR EXISTS (
             SELECT 1
             FROM chat_messages m

--- a/apps/api/src/lib/search/index-chat.ts
+++ b/apps/api/src/lib/search/index-chat.ts
@@ -181,11 +181,12 @@ export const upsertChatThreadSearchDocument = async (
   });
   await rootDb.execute(sql`
     INSERT INTO chat_thread_search_documents (
-      thread_id, title, searchable_text, updated_at, tsv
+      thread_id, title, searchable_text, preview_generation, updated_at, tsv
     ) VALUES (
       ${thread.id},
       ${thread.title},
       ${searchableText},
+      NULL,
       ${thread.updatedAt},
       to_tsvector(
         'simple',
@@ -200,6 +201,7 @@ export const upsertChatThreadSearchDocument = async (
     ON CONFLICT (thread_id) DO UPDATE SET
       title = EXCLUDED.title,
       searchable_text = EXCLUDED.searchable_text,
+      preview_generation = NULL,
       updated_at = EXCLUDED.updated_at,
       tsv = EXCLUDED.tsv
     WHERE EXCLUDED.updated_at >= chat_thread_search_documents.updated_at
@@ -335,16 +337,24 @@ const upsertChatMessageSearchDocuments = async ({
   `);
 };
 
-/** One-time backfill: index every thread missing either a thread-level
- *  search document or per-message search documents. Idempotent and
- *  resumable. Keyset-paginates by thread id so a thread that cannot
- *  be indexed (e.g. deleted mid-run) advances the cursor instead of
+/** Periodic repair: index every thread with a missing or stale projection.
+ *  Idempotent and resumable. Keyset-paginates by thread id so a thread that
+ *  cannot be indexed (e.g. deleted mid-run) advances the cursor instead of
  *  looping. */
-export const backfillChatThreadSearchIndex = async (): Promise<number> => {
+type BackfillChatThreadSearchIndexOptions = {
+  signal?: AbortSignal;
+};
+
+export const backfillChatThreadSearchIndex = async ({
+  signal,
+}: BackfillChatThreadSearchIndexOptions = {}): Promise<number> => {
   let cursor = ZERO_UUID;
   let total = 0;
 
   for (;;) {
+    if (signal?.aborted) {
+      return total;
+    }
     // oxlint-disable-next-line no-await-in-loop, require-search-scope/require-search-scope -- system backfill repairs derived search documents across all threads; it does not return request data
     const batch = await rootDb.execute<{ id: SafeId<"chatThread"> }>(sql`
       SELECT t.id
@@ -352,6 +362,11 @@ export const backfillChatThreadSearchIndex = async (): Promise<number> => {
       LEFT JOIN chat_thread_search_documents d ON d.thread_id = t.id
       WHERE (
           d.thread_id IS NULL
+          -- The previous writer always stored a preview generation. The live
+          -- preview no longer consumes those passages, so non-null doubles as
+          -- a rolling-deploy freshness marker: old tasks mark their writes
+          -- stale, while the current upsert clears the marker after rebuilding.
+          OR d.preview_generation IS NOT NULL
           OR EXISTS (
             SELECT 1
             FROM chat_messages m
@@ -372,6 +387,9 @@ export const backfillChatThreadSearchIndex = async (): Promise<number> => {
     }
 
     for (const row of batch) {
+      if (signal?.aborted) {
+        return total;
+      }
       try {
         // oxlint-disable-next-line no-await-in-loop -- sequential by design: sequential per-thread backfill writes bound DB load
         await upsertChatThreadSearchDocument(row.id);

--- a/apps/api/src/lib/search/index-chat.ts
+++ b/apps/api/src/lib/search/index-chat.ts
@@ -1,7 +1,10 @@
 import { sql } from "drizzle-orm";
 
 import { rootDb } from "@/api/db/root";
-import { normalizePersistedChatMessageContent } from "@/api/handlers/chat/chat-message-parts";
+import {
+  isChatPart,
+  normalizePersistedChatMessageContent,
+} from "@/api/handlers/chat/chat-message-parts";
 import type {
   ChatMessageRole,
   PersistedChatMessageContent,
@@ -18,11 +21,35 @@ import {
 const BACKFILL_BATCH_SIZE = 200;
 const ZERO_UUID = "00000000-0000-0000-0000-000000000000";
 
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const isPersistedChatMessageContent = (
+  value: unknown,
+): value is PersistedChatMessageContent =>
+  isRecord(value) &&
+  (value["version"] === 1 || value["version"] === 2) &&
+  Array.isArray(value["data"]);
+
+export const normalizeSearchableChatMessageContent = (content: unknown) => {
+  if (!isPersistedChatMessageContent(content)) {
+    return null;
+  }
+  const normalized = normalizePersistedChatMessageContent(content);
+  return {
+    metadata: normalized.metadata,
+    parts: normalized.parts.filter(isChatPart),
+  };
+};
+
 const extractMessageSearchText = (
   content: PersistedChatMessageContent,
 ): string => {
   const parts: string[] = [];
-  const message = normalizePersistedChatMessageContent(content);
+  const message = normalizeSearchableChatMessageContent(content);
+  if (!message) {
+    return "";
+  }
   for (const part of message.parts) {
     if (part.type === "text") {
       const trimmed = part.content.trim();

--- a/apps/api/src/lib/search/index-chat.ts
+++ b/apps/api/src/lib/search/index-chat.ts
@@ -102,7 +102,7 @@ export const normalizeSearchableChatMessageContent = (content: unknown) => {
   };
 };
 
-const extractMessageSearchText = (
+export const extractMessageSearchText = (
   content: PersistedChatMessageContent,
 ): string => {
   const parts: string[] = [];
@@ -127,8 +127,6 @@ const extractMessageSearchText = (
     for (const value of [
       sourceDocumentData.title,
       sourceDocumentData.mention,
-      sourceDocumentData.entityRef,
-      sourceDocumentData.matterRef,
       sourceDocumentData.kind,
     ]) {
       if (typeof value !== "string") {

--- a/apps/api/src/lib/search/index-global.test.ts
+++ b/apps/api/src/lib/search/index-global.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, test } from "bun:test";
 import { PgDialect } from "drizzle-orm/pg-core";
 
 import { toSafeId } from "@/api/lib/branded-types";
+import { CHAT_SEARCH_DISPLAY_METADATA_GENERATION } from "@/api/lib/search/chat-search-generation";
 import { chatThreadScopeSql } from "@/api/lib/search/chat-thread-scope-sql";
 import { contactWorkspaceAccessSql } from "@/api/lib/search/contact-workspace-access-sql";
 import { encodeCursor } from "@/api/lib/search/cursor";
@@ -159,6 +160,7 @@ describe("global search SQL scope", () => {
       last_edited_by_name: "Clara Novak",
       last_edited_by_image: "https://example.test/clara.png",
       file_field_id: "field_1",
+      file_property_id: "property_1",
       mime_type: "application/pdf",
       headline: "Interim injunction memo",
       score: 0.9,
@@ -170,6 +172,7 @@ describe("global search SQL scope", () => {
       lastEditedByName: "Clara Novak",
       lastEditedByImage: "https://example.test/clara.png",
       fileFieldId: "field_1",
+      filePropertyId: "property_1",
     });
   });
 
@@ -244,7 +247,10 @@ describe("global search SQL scope", () => {
       3,
     );
     expect(sourceQueries.at(4)?.compiled.sql).toContain(
-      "cst.preview_generation IS NULL",
+      "cst.preview_generation =",
+    );
+    expect(sourceQueries.at(4)?.compiled.params).toContain(
+      CHAT_SEARCH_DISPLAY_METADATA_GENERATION,
     );
   });
 
@@ -383,6 +389,7 @@ describe("global search SQL scope", () => {
     for (const compiled of entityQueries) {
       expect(compiled.sql).toContain("FROM extracted_content ec");
       expect(compiled.sql).toContain("ec.source_field_id = f.id");
+      expect(compiled.sql).toContain("f.property_id");
       expect(compiled.sql).toContain("files.mime_type = ANY");
       expect(compiled.sql).toContain("array_agg(DISTINCT available.mime_type");
       expect(compiled.sql).toContain("files.is_extracted_source DESC");
@@ -392,5 +399,10 @@ describe("global search SQL scope", () => {
         "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
       );
     }
+    expect(
+      entityQueries.some((compiled) =>
+        compiled.sql.includes("file_field.property_id AS file_property_id"),
+      ),
+    ).toBeTrue();
   });
 });

--- a/apps/api/src/lib/search/index-global.test.ts
+++ b/apps/api/src/lib/search/index-global.test.ts
@@ -158,6 +158,7 @@ describe("global search SQL scope", () => {
       title: "Interim injunction memo.pdf",
       last_edited_by_name: "Clara Novak",
       last_edited_by_image: "https://example.test/clara.png",
+      file_field_id: "field_1",
       mime_type: "application/pdf",
       headline: "Interim injunction memo",
       score: 0.9,
@@ -168,6 +169,7 @@ describe("global search SQL scope", () => {
       type: "document",
       lastEditedByName: "Clara Novak",
       lastEditedByImage: "https://example.test/clara.png",
+      fileFieldId: "field_1",
     });
   });
 

--- a/apps/api/src/lib/search/index-global.test.ts
+++ b/apps/api/src/lib/search/index-global.test.ts
@@ -358,4 +358,34 @@ describe("global search SQL scope", () => {
       seen: 1,
     });
   });
+  test("selects the filtered file field and prefers the extracted-content source", async () => {
+    await searchGlobal({
+      query: "indemnity",
+      organizationId: toSafeId<"organization">("org_1"),
+      userId: toSafeId<"user">("user_1"),
+      accessibleWorkspaceIds: [],
+      selectedWorkspaceIds: [],
+      types: ["document"],
+      editedByUserIds: [],
+      mimeTypes: ["application/pdf"],
+      limit: 10,
+    });
+
+    const dialect = new PgDialect();
+    const entityQueries = rootDbExecuteMock.mock.calls
+      .map(([query]) => dialect.sqlToQuery(query))
+      .filter(({ sql: sqlText }) => sqlText.includes("file_field.field_id"));
+
+    expect(entityQueries.length).toBeGreaterThan(0);
+    for (const compiled of entityQueries) {
+      expect(compiled.sql).toContain("FROM extracted_content ec");
+      expect(compiled.sql).toContain("ec.source_field_id = f.id");
+      expect(compiled.sql).toContain("files.mime_type = ANY");
+      expect(compiled.sql).toContain("array_agg(DISTINCT available.mime_type");
+      expect(compiled.sql).toContain(
+        "ORDER BY files.is_extracted_source DESC, files.field_id ASC",
+      );
+      expect(compiled.params).toContain("application/pdf");
+    }
+  });
 });

--- a/apps/api/src/lib/search/index-global.test.ts
+++ b/apps/api/src/lib/search/index-global.test.ts
@@ -243,6 +243,9 @@ describe("global search SQL scope", () => {
     expect(matterQuery?.params.filter((param) => param === 0.15)).toHaveLength(
       3,
     );
+    expect(sourceQueries.at(4)?.compiled.sql).toContain(
+      "cst.preview_generation IS NULL",
+    );
   });
 
   test("continues legacy offset cursors during a rolling deployment", async () => {
@@ -358,7 +361,7 @@ describe("global search SQL scope", () => {
       seen: 1,
     });
   });
-  test("selects the filtered file field and prefers the extracted-content source", async () => {
+  test("selects the filtered file field and prefers previewable extracted sources", async () => {
     await searchGlobal({
       query: "indemnity",
       organizationId: toSafeId<"organization">("org_1"),
@@ -382,10 +385,12 @@ describe("global search SQL scope", () => {
       expect(compiled.sql).toContain("ec.source_field_id = f.id");
       expect(compiled.sql).toContain("files.mime_type = ANY");
       expect(compiled.sql).toContain("array_agg(DISTINCT available.mime_type");
-      expect(compiled.sql).toContain(
-        "ORDER BY files.is_extracted_source DESC, files.field_id ASC",
-      );
+      expect(compiled.sql).toContain("files.is_extracted_source DESC");
+      expect(compiled.sql).toContain("files.field_id ASC");
       expect(compiled.params).toContain("application/pdf");
+      expect(compiled.params).toContain(
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+      );
     }
   });
 });

--- a/apps/api/src/lib/search/index-global.ts
+++ b/apps/api/src/lib/search/index-global.ts
@@ -13,6 +13,7 @@ import { arrayOrEmpty } from "@/api/lib/array";
 import type { SafeId } from "@/api/lib/branded-types";
 import { redistributableSourceJoin } from "@/api/lib/case-law/search-sql";
 import { compareCodepoint } from "@/api/lib/collation";
+import { CHAT_SEARCH_DISPLAY_METADATA_GENERATION } from "@/api/lib/search/chat-search-generation";
 import { chatThreadScopeSql } from "@/api/lib/search/chat-thread-scope-sql";
 import {
   contactWorkspaceAccessSql,
@@ -198,6 +199,7 @@ const fileFieldJoin = (mimeTypes: readonly string[]) => {
     WITH files AS (
       SELECT
         f.id AS field_id,
+        f.property_id,
         field_content.content ->> 'mimeType' AS mime_type,
         EXISTS (
           SELECT 1
@@ -223,6 +225,7 @@ const fileFieldJoin = (mimeTypes: readonly string[]) => {
     )
     SELECT
       files.field_id,
+      files.property_id,
       files.mime_type,
       (
         SELECT array_agg(DISTINCT available.mime_type ORDER BY available.mime_type)
@@ -679,6 +682,7 @@ export const searchGlobal = async ({
         editor.name AS last_edited_by_name,
         editor.image AS last_edited_by_image,
         file_field.field_id AS file_field_id,
+        file_field.property_id AS file_property_id,
         file_field.mime_type,
         ${searchHeadline(sql`sd.title || ' ' || left(sd.searchable_text, 2000)`)},
         ${searchScore({ tsv: sql`sd.tsv`, updatedAt: sql`sd.updated_at` })},
@@ -833,7 +837,8 @@ export const searchGlobal = async ({
       LEFT JOIN workspaces w ON w.id = t.workspace_id
       WHERE TRUE
         AND ${chatScope}
-        AND cst.preview_generation IS NULL
+        AND cst.preview_generation =
+          ${CHAT_SEARCH_DISPLAY_METADATA_GENERATION}::uuid
         ${chatUpdatedFilter}
         ${chatTextSearchFilter}
         ${globalSearchCursorSql({
@@ -927,7 +932,8 @@ export const searchGlobal = async ({
         JOIN chat_threads t ON t.id = cst.thread_id
         WHERE TRUE
           AND ${chatScope}
-          AND cst.preview_generation IS NULL
+          AND cst.preview_generation =
+            ${CHAT_SEARCH_DISPLAY_METADATA_GENERATION}::uuid
           ${chatUpdatedFilter}
           ${chatTextSearchFilter}
       `),
@@ -1010,7 +1016,8 @@ export const searchGlobal = async ({
       JOIN chat_threads t ON t.id = cst.thread_id
       WHERE TRUE
         AND ${chatScope}
-        AND cst.preview_generation IS NULL
+        AND cst.preview_generation =
+          ${CHAT_SEARCH_DISPLAY_METADATA_GENERATION}::uuid
         ${chatUpdatedFilter}
         ${chatTextSearchFilter}
     `),

--- a/apps/api/src/lib/search/index-global.ts
+++ b/apps/api/src/lib/search/index-global.ts
@@ -188,10 +188,13 @@ const hasSelectedEntityType = (selected: ReadonlySet<GlobalSearchResultType>) =>
 const fileFieldJoin = sql`
   LEFT JOIN LATERAL (
     SELECT
+      (array_agg(files.field_id ORDER BY files.mime_type, files.field_id))[1] AS field_id,
       (array_agg(DISTINCT files.mime_type ORDER BY files.mime_type))[1] AS mime_type,
       array_agg(DISTINCT files.mime_type ORDER BY files.mime_type) AS mime_types
     FROM (
-      SELECT field_content.content ->> 'mimeType' AS mime_type
+      SELECT
+        f.id AS field_id,
+        field_content.content ->> 'mimeType' AS mime_type
       FROM fields f
       CROSS JOIN LATERAL (
         SELECT CASE jsonb_typeof(f.content)
@@ -644,6 +647,7 @@ export const searchGlobal = async ({
         sd.title,
         editor.name AS last_edited_by_name,
         editor.image AS last_edited_by_image,
+        file_field.field_id AS file_field_id,
         file_field.mime_type,
         ${searchHeadline(sql`sd.title || ' ' || left(sd.searchable_text, 2000)`)},
         ${searchScore({ tsv: sql`sd.tsv`, updatedAt: sql`sd.updated_at` })},

--- a/apps/api/src/lib/search/index-global.ts
+++ b/apps/api/src/lib/search/index-global.ts
@@ -46,6 +46,7 @@ import type {
   GlobalSearchResultType,
   MatterGlobalSearchHit,
 } from "@/api/lib/search/types";
+import { DOCX_MIME_TYPE, PDF_MIME_TYPE } from "@/api/mime-types";
 
 const REINDEX_BATCH_SIZE = 100;
 const WORKSPACE_REINDEX_CONCURRENCY = 4;
@@ -180,6 +181,7 @@ const NON_ENTITY_TYPES: ReadonlySet<GlobalSearchResultType> = new Set([
   "case-law",
   "chat",
 ]);
+const NATIVE_PREVIEW_MIME_TYPES = [PDF_MIME_TYPE, DOCX_MIME_TYPE] as const;
 
 const hasSelectedEntityType = (selected: ReadonlySet<GlobalSearchResultType>) =>
   selected.size === 0 ||
@@ -229,7 +231,10 @@ const fileFieldJoin = (mimeTypes: readonly string[]) => {
     FROM files
     WHERE TRUE
       ${mimeFilter}
-    ORDER BY files.is_extracted_source DESC, files.field_id ASC
+    ORDER BY
+      files.is_extracted_source DESC,
+      (files.mime_type = ANY(${typedPgArray(NATIVE_PREVIEW_MIME_TYPES, "text")})) DESC,
+      files.field_id ASC
     LIMIT 1
   ) file_field ON true
 `;
@@ -827,6 +832,7 @@ export const searchGlobal = async ({
       JOIN chat_threads t ON t.id = cst.thread_id
       LEFT JOIN workspaces w ON w.id = t.workspace_id
       WHERE TRUE
+        AND cst.preview_generation IS NULL
         ${chatUpdatedFilter}
         ${chatTextSearchFilter}
         AND ${chatScope}
@@ -920,6 +926,7 @@ export const searchGlobal = async ({
         FROM chat_thread_search_documents cst
         JOIN chat_threads t ON t.id = cst.thread_id
         WHERE TRUE
+          AND cst.preview_generation IS NULL
           ${chatUpdatedFilter}
           ${chatTextSearchFilter}
           AND ${chatScope}
@@ -1002,6 +1009,7 @@ export const searchGlobal = async ({
       FROM chat_thread_search_documents cst
       JOIN chat_threads t ON t.id = cst.thread_id
       WHERE TRUE
+        AND cst.preview_generation IS NULL
         ${chatUpdatedFilter}
         ${chatTextSearchFilter}
         AND ${chatScope}

--- a/apps/api/src/lib/search/index-global.ts
+++ b/apps/api/src/lib/search/index-global.ts
@@ -185,16 +185,27 @@ const hasSelectedEntityType = (selected: ReadonlySet<GlobalSearchResultType>) =>
   selected.size === 0 ||
   [...selected].some((type) => !NON_ENTITY_TYPES.has(type));
 
-const fileFieldJoin = sql`
+const fileFieldJoin = (mimeTypes: readonly string[]) => {
+  const mimeFilter =
+    mimeTypes.length > 0
+      ? sql`AND files.mime_type = ANY(${typedPgArray(mimeTypes, "text")})`
+      : sql``;
+
+  return sql`
   LEFT JOIN LATERAL (
-    SELECT
-      (array_agg(files.field_id ORDER BY files.mime_type, files.field_id))[1] AS field_id,
-      (array_agg(DISTINCT files.mime_type ORDER BY files.mime_type))[1] AS mime_type,
-      array_agg(DISTINCT files.mime_type ORDER BY files.mime_type) AS mime_types
-    FROM (
+    WITH files AS (
       SELECT
         f.id AS field_id,
-        field_content.content ->> 'mimeType' AS mime_type
+        field_content.content ->> 'mimeType' AS mime_type,
+        EXISTS (
+          SELECT 1
+          FROM extracted_content ec
+          WHERE ec.entity_id = sd.entity_id
+            AND ec.organization_id = sd.organization_id
+            AND ec.workspace_id = sd.workspace_id
+            AND ec.source_entity_version_id = e.current_version_id
+            AND ec.source_field_id = f.id
+        ) AS is_extracted_source
       FROM fields f
       CROSS JOIN LATERAL (
         SELECT CASE jsonb_typeof(f.content)
@@ -207,9 +218,22 @@ const fileFieldJoin = sql`
         AND f.entity_version_id = e.current_version_id
         AND field_content.content ->> 'type' = 'file'
         AND nullif(field_content.content ->> 'mimeType', '') IS NOT NULL
-    ) files
+    )
+    SELECT
+      files.field_id,
+      files.mime_type,
+      (
+        SELECT array_agg(DISTINCT available.mime_type ORDER BY available.mime_type)
+        FROM files available
+      ) AS mime_types
+    FROM files
+    WHERE TRUE
+      ${mimeFilter}
+    ORDER BY files.is_extracted_source DESC, files.field_id ASC
+    LIMIT 1
   ) file_field ON true
 `;
+};
 
 const caseLawBodyPreviewJoin = sql`
   LEFT JOIN LATERAL (
@@ -418,7 +442,7 @@ const buildSearchFilterFragments = ({
   );
   const entityMimeFilter = sqlWhen(
     hasMimeTypeFilter,
-    () => sql`AND file_field.mime_types && ${typedPgArray(mimeTypes, "text")}`,
+    () => sql`AND file_field.field_id IS NOT NULL`,
   );
   const updatedRangeFilter = (column: SQL): SQL => {
     const fragments: SQL[] = [];
@@ -623,6 +647,8 @@ export const searchGlobal = async ({
     accessibleWorkspaceIds,
     selectedWorkspaceIds: [],
   });
+  const selectedFileFieldJoin = fileFieldJoin(mimeTypes);
+  const allFileFieldJoin = fileFieldJoin([]);
   const matterWorkspaceFilter = workspaceSearchDocumentsAccessSql({
     accessibleWorkspaceIds,
     selectedWorkspaceIds,
@@ -658,7 +684,7 @@ export const searchGlobal = async ({
         ON e.id = sd.entity_id
         AND e.workspace_id = sd.workspace_id
       LEFT JOIN "user" editor ON editor.id = e.last_edited_by
-      ${fileFieldJoin}
+      ${selectedFileFieldJoin}
       WHERE sd.organization_id = ${organizationId}
         ${entityTypeFilter}
         ${entityEditorFilter}
@@ -841,7 +867,7 @@ export const searchGlobal = async ({
         LEFT JOIN entities e
           ON e.id = sd.entity_id
           AND e.workspace_id = sd.workspace_id
-        ${fileFieldJoin}
+        ${selectedFileFieldJoin}
         WHERE sd.organization_id = ${organizationId}
           ${entityTypeFilter}
           ${entityEditorFilter}
@@ -910,7 +936,7 @@ export const searchGlobal = async ({
       LEFT JOIN entities e
         ON e.id = sd.entity_id
         AND e.workspace_id = sd.workspace_id
-      ${fileFieldJoin}
+      ${selectedFileFieldJoin}
       WHERE sd.organization_id = ${organizationId}
         ${entityTypeFacetFilter}
         ${entityEditorFilter}
@@ -990,7 +1016,7 @@ export const searchGlobal = async ({
       LEFT JOIN entities e
         ON e.id = sd.entity_id
         AND e.workspace_id = sd.workspace_id
-      ${fileFieldJoin}
+      ${selectedFileFieldJoin}
       WHERE sd.organization_id = ${organizationId}
         ${entityTypeFilter}
         ${entityEditorFilter}
@@ -1042,7 +1068,7 @@ export const searchGlobal = async ({
         ON e.id = sd.entity_id
         AND e.workspace_id = sd.workspace_id
       JOIN "user" editor ON editor.id = e.last_edited_by
-      ${fileFieldJoin}
+      ${selectedFileFieldJoin}
       WHERE sd.organization_id = ${organizationId}
         ${entityTypeFilter}
         ${entityMimeFilter}
@@ -1065,7 +1091,7 @@ export const searchGlobal = async ({
       LEFT JOIN entities e
         ON e.id = sd.entity_id
         AND e.workspace_id = sd.workspace_id
-      ${fileFieldJoin}
+      ${allFileFieldJoin}
       CROSS JOIN LATERAL unnest(
         coalesce(file_field.mime_types, ARRAY[]::text[])
       ) AS mime_type(value)
@@ -1267,6 +1293,8 @@ export const searchGlobalFacet = async ({
     accessibleWorkspaceIds,
     selectedWorkspaceIds: [],
   });
+  const selectedFileFieldJoin = fileFieldJoin(mimeTypes);
+  const allFileFieldJoin = fileFieldJoin([]);
 
   if (facet === "editor") {
     if (!hasSelectedEntityType(selected)) {
@@ -1279,7 +1307,7 @@ export const searchGlobalFacet = async ({
         ON e.id = sd.entity_id
         AND e.workspace_id = sd.workspace_id
       JOIN "user" editor ON editor.id = e.last_edited_by
-      ${fileFieldJoin}
+      ${selectedFileFieldJoin}
       WHERE sd.organization_id = ${organizationId}
         ${entityTypeFilter}
         ${entityMimeFilter}
@@ -1304,7 +1332,7 @@ export const searchGlobalFacet = async ({
       LEFT JOIN entities e
         ON e.id = sd.entity_id
         AND e.workspace_id = sd.workspace_id
-      ${fileFieldJoin}
+      ${allFileFieldJoin}
       CROSS JOIN LATERAL unnest(
         coalesce(file_field.mime_types, ARRAY[]::text[])
       ) AS mime_type(value)
@@ -1338,7 +1366,7 @@ export const searchGlobalFacet = async ({
       LEFT JOIN entities e
         ON e.id = sd.entity_id
         AND e.workspace_id = sd.workspace_id
-      ${fileFieldJoin}
+      ${selectedFileFieldJoin}
       WHERE sd.organization_id = ${organizationId}
         ${entityTypeFilter}
         ${entityEditorFilter}

--- a/apps/api/src/lib/search/index-global.ts
+++ b/apps/api/src/lib/search/index-global.ts
@@ -832,10 +832,10 @@ export const searchGlobal = async ({
       JOIN chat_threads t ON t.id = cst.thread_id
       LEFT JOIN workspaces w ON w.id = t.workspace_id
       WHERE TRUE
+        AND ${chatScope}
         AND cst.preview_generation IS NULL
         ${chatUpdatedFilter}
         ${chatTextSearchFilter}
-        AND ${chatScope}
         ${globalSearchCursorSql({
           cursor: searchCursor,
           score: searchScoreValue({
@@ -926,10 +926,10 @@ export const searchGlobal = async ({
         FROM chat_thread_search_documents cst
         JOIN chat_threads t ON t.id = cst.thread_id
         WHERE TRUE
+          AND ${chatScope}
           AND cst.preview_generation IS NULL
           ${chatUpdatedFilter}
           ${chatTextSearchFilter}
-          AND ${chatScope}
       `),
     ),
   ] as const;
@@ -1009,10 +1009,10 @@ export const searchGlobal = async ({
       FROM chat_thread_search_documents cst
       JOIN chat_threads t ON t.id = cst.thread_id
       WHERE TRUE
+        AND ${chatScope}
         AND cst.preview_generation IS NULL
         ${chatUpdatedFilter}
         ${chatTextSearchFilter}
-        AND ${chatScope}
     `),
   );
 

--- a/apps/api/src/lib/search/preview-read.test.ts
+++ b/apps/api/src/lib/search/preview-read.test.ts
@@ -317,4 +317,79 @@ describe("search preview rendering contract", () => {
       ],
     });
   });
+
+  test("normalizes legacy source-document metadata for chat previews", async () => {
+    rootDbExecuteMock.mockResolvedValueOnce([
+      {
+        messages: [
+          {
+            id: "00000000-0000-4000-8000-000000000010",
+            isTarget: true,
+            role: "assistant",
+            content: {
+              version: 1,
+              data: [
+                { type: "text", text: "The answer cites:" },
+                {
+                  type: "data-stella-source-document",
+                  data: {
+                    title: "Closing memorandum",
+                    mention: "@closing-memo",
+                    kind: "document",
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    ]);
+
+    expect(await readSearchPreview({ ...previewQuery, type: "chat" })).toEqual({
+      type: "chat-messages",
+      messages: [
+        {
+          id: "00000000-0000-4000-8000-000000000010",
+          role: "assistant",
+          content:
+            "The answer cites:\n\nClosing memorandum\n\n@closing-memo\n\ndocument",
+        },
+      ],
+    });
+  });
+
+  test("returns a title preview when a chat thread has no matching messages", async () => {
+    rootDbExecuteMock.mockResolvedValueOnce([
+      {
+        hasMessageMatch: false,
+        messages: [],
+        title: "Closing memorandum review",
+      },
+    ]);
+
+    expect(await readSearchPreview({ ...previewQuery, type: "chat" })).toEqual({
+      type: "plain-text",
+      content: "Closing memorandum review",
+    });
+  });
+
+  test("skips malformed persisted chat parts", async () => {
+    rootDbExecuteMock.mockResolvedValueOnce([
+      {
+        messages: [
+          {
+            id: "00000000-0000-4000-8000-000000000010",
+            isTarget: true,
+            role: "assistant",
+            content: { version: 2, data: [null] },
+          },
+        ],
+      },
+    ]);
+
+    expect(await readSearchPreview({ ...previewQuery, type: "chat" })).toEqual({
+      type: "chat-messages",
+      messages: [],
+    });
+  });
 });

--- a/apps/api/src/lib/search/preview-read.test.ts
+++ b/apps/api/src/lib/search/preview-read.test.ts
@@ -91,6 +91,7 @@ describe("search preview rendering contract", () => {
         messages: [
           {
             id: "00000000-0000-4000-8000-000000000010",
+            isTarget: false,
             role: "user",
             content: {
               version: 1,
@@ -99,6 +100,7 @@ describe("search preview rendering contract", () => {
           },
           {
             id: "00000000-0000-4000-8000-000000000011",
+            isTarget: true,
             role: "assistant",
             content: {
               version: 2,
@@ -136,6 +138,7 @@ describe("search preview rendering contract", () => {
         messages: [
           {
             id: "00000000-0000-4000-8000-000000000010",
+            isTarget: false,
             role: "user",
             content: {
               version: 2,
@@ -144,6 +147,7 @@ describe("search preview rendering contract", () => {
           },
           {
             id: "00000000-0000-4000-8000-000000000011",
+            isTarget: true,
             role: "assistant",
             content: {
               version: 2,
@@ -158,7 +162,7 @@ describe("search preview rendering contract", () => {
 
     expect(preview).toMatchObject({
       type: "chat-messages",
-      messages: [{ content: "a".repeat(16_000) }],
+      messages: [{ content: "a".repeat(15_988) }, { content: "not returned" }],
     });
   });
 
@@ -175,5 +179,89 @@ describe("search preview rendering contract", () => {
     ]);
 
     expect(await readSearchPreview(previewQuery)).toBeNull();
+  });
+
+  test("retains the matching chat message when earlier context exhausts the cap", async () => {
+    rootDbExecuteMock.mockResolvedValueOnce([
+      {
+        messages: [
+          {
+            id: "00000000-0000-4000-8000-000000000010",
+            isTarget: false,
+            role: "user",
+            content: {
+              version: 2,
+              data: [{ type: "text", content: "a".repeat(16_000) }],
+            },
+          },
+          {
+            id: "00000000-0000-4000-8000-000000000011",
+            isTarget: true,
+            role: "assistant",
+            content: {
+              version: 2,
+              data: [{ type: "text", content: "matched message" }],
+            },
+          },
+        ],
+      },
+    ]);
+
+    expect(await readSearchPreview({ ...previewQuery, type: "chat" })).toEqual({
+      type: "chat-messages",
+      messages: [
+        {
+          id: "00000000-0000-4000-8000-000000000010",
+          role: "user",
+          content: "a".repeat(15_985),
+        },
+        {
+          id: "00000000-0000-4000-8000-000000000011",
+          role: "assistant",
+          content: "matched message",
+        },
+      ],
+    });
+  });
+
+  test("renders indexed source-document metadata in chat previews", async () => {
+    rootDbExecuteMock.mockResolvedValueOnce([
+      {
+        messages: [
+          {
+            id: "00000000-0000-4000-8000-000000000010",
+            isTarget: true,
+            role: "assistant",
+            content: {
+              version: 2,
+              data: [],
+              metadata: {
+                sourceDocuments: [
+                  {
+                    title: "Closing memorandum",
+                    mention: "@closing-memo",
+                    entityRef: "entity_1",
+                    matterRef: "matter_1",
+                    kind: "document",
+                  },
+                ],
+              },
+            },
+          },
+        ],
+      },
+    ]);
+
+    expect(await readSearchPreview({ ...previewQuery, type: "chat" })).toEqual({
+      type: "chat-messages",
+      messages: [
+        {
+          id: "00000000-0000-4000-8000-000000000010",
+          role: "assistant",
+          content:
+            "Closing memorandum\n\n@closing-memo\n\nentity_1\n\nmatter_1\n\ndocument",
+        },
+      ],
+    });
   });
 });

--- a/apps/api/src/lib/search/preview-read.test.ts
+++ b/apps/api/src/lib/search/preview-read.test.ts
@@ -85,6 +85,83 @@ describe("search preview rendering contract", () => {
     });
   });
 
+  test("returns bounded chat messages with their speaker roles and visible text", async () => {
+    rootDbExecuteMock.mockResolvedValueOnce([
+      {
+        messages: [
+          {
+            id: "00000000-0000-4000-8000-000000000010",
+            role: "user",
+            content: {
+              version: 2,
+              data: [{ type: "text", content: "Review this agreement" }],
+            },
+          },
+          {
+            id: "00000000-0000-4000-8000-000000000011",
+            role: "assistant",
+            content: {
+              version: 2,
+              data: [
+                { type: "text", content: "## Key issue" },
+                { type: "text", content: "The cap is uncapped." },
+              ],
+            },
+          },
+        ],
+      },
+    ]);
+
+    expect(await readSearchPreview({ ...previewQuery, type: "chat" })).toEqual({
+      type: "chat-messages",
+      messages: [
+        {
+          id: "00000000-0000-4000-8000-000000000010",
+          role: "user",
+          content: "Review this agreement",
+        },
+        {
+          id: "00000000-0000-4000-8000-000000000011",
+          role: "assistant",
+          content: "## Key issue\n\nThe cap is uncapped.",
+        },
+      ],
+    });
+  });
+
+  test("bounds the combined visible text in a chat preview", async () => {
+    const oversizedContent = "a".repeat(20_000);
+    rootDbExecuteMock.mockResolvedValueOnce([
+      {
+        messages: [
+          {
+            id: "00000000-0000-4000-8000-000000000010",
+            role: "user",
+            content: {
+              version: 2,
+              data: [{ type: "text", content: oversizedContent }],
+            },
+          },
+          {
+            id: "00000000-0000-4000-8000-000000000011",
+            role: "assistant",
+            content: {
+              version: 2,
+              data: [{ type: "text", content: "not returned" }],
+            },
+          },
+        ],
+      },
+    ]);
+
+    const preview = await readSearchPreview({ ...previewQuery, type: "chat" });
+
+    expect(preview).toMatchObject({
+      type: "chat-messages",
+      messages: [{ content: "a".repeat(16_000) }],
+    });
+  });
+
   test("rejects rows that mix plain and highlighted source fields", async () => {
     rootDbExecuteMock.mockResolvedValueOnce([
       {

--- a/apps/api/src/lib/search/preview-read.test.ts
+++ b/apps/api/src/lib/search/preview-read.test.ts
@@ -263,6 +263,43 @@ describe("search preview rendering contract", () => {
     }
   });
 
+  test("retains a late quoted phrase instead of an earlier standalone word", async () => {
+    rootDbExecuteMock.mockResolvedValueOnce([
+      {
+        messages: [
+          {
+            id: "00000000-0000-4000-8000-000000000010",
+            isTarget: true,
+            role: "assistant",
+            content: {
+              version: 2,
+              data: [
+                {
+                  type: "text",
+                  content: `closing ${"a".repeat(20_000)} closing, memo`,
+                },
+              ],
+            },
+          },
+        ],
+      },
+    ]);
+
+    const preview = await readSearchPreview({
+      ...previewQuery,
+      query: '"closing memo"',
+      type: "chat",
+    });
+
+    expect(preview).toMatchObject({
+      type: "chat-messages",
+      messages: [{ content: expect.stringContaining("closing, memo") }],
+    });
+    if (preview?.type === "chat-messages") {
+      expect(preview.messages.at(0)?.content).not.toStartWith("closing ");
+    }
+  });
+
   test("orders context around a first-position target without duplicates", async () => {
     rootDbExecuteMock.mockResolvedValueOnce([
       {

--- a/apps/api/src/lib/search/preview-read.test.ts
+++ b/apps/api/src/lib/search/preview-read.test.ts
@@ -93,8 +93,8 @@ describe("search preview rendering contract", () => {
             id: "00000000-0000-4000-8000-000000000010",
             role: "user",
             content: {
-              version: 2,
-              data: [{ type: "text", content: "Review this agreement" }],
+              version: 1,
+              data: [{ type: "text", text: "Review this agreement" }],
             },
           },
           {

--- a/apps/api/src/lib/search/preview-read.test.ts
+++ b/apps/api/src/lib/search/preview-read.test.ts
@@ -400,7 +400,7 @@ describe("search preview rendering contract", () => {
   test("returns a title preview when a chat thread has no matching messages", async () => {
     rootDbExecuteMock.mockResolvedValueOnce([
       {
-        hasMessageMatch: false,
+        isTitleOnlyMatch: true,
         messages: [],
         title: "Closing memorandum review",
       },
@@ -409,6 +409,51 @@ describe("search preview rendering contract", () => {
     expect(await readSearchPreview({ ...previewQuery, type: "chat" })).toEqual({
       type: "plain-text",
       content: "Closing memorandum review",
+    });
+  });
+
+  test("keeps the selected message window for cross-message matches", async () => {
+    rootDbExecuteMock.mockResolvedValueOnce([
+      {
+        isTitleOnlyMatch: false,
+        messages: [
+          {
+            id: "00000000-0000-4000-8000-000000000010",
+            isTarget: true,
+            role: "user",
+            content: {
+              version: 2,
+              data: [{ type: "text", content: "indemnity" }],
+            },
+          },
+          {
+            id: "00000000-0000-4000-8000-000000000011",
+            isTarget: false,
+            role: "assistant",
+            content: {
+              version: 2,
+              data: [{ type: "text", content: "liability" }],
+            },
+          },
+        ],
+        title: "Unrelated title",
+      },
+    ]);
+
+    expect(await readSearchPreview({ ...previewQuery, type: "chat" })).toEqual({
+      type: "chat-messages",
+      messages: [
+        {
+          id: "00000000-0000-4000-8000-000000000010",
+          role: "user",
+          content: "indemnity",
+        },
+        {
+          id: "00000000-0000-4000-8000-000000000011",
+          role: "assistant",
+          content: "liability",
+        },
+      ],
     });
   });
 

--- a/apps/api/src/lib/search/preview-read.test.ts
+++ b/apps/api/src/lib/search/preview-read.test.ts
@@ -224,6 +224,45 @@ describe("search preview rendering contract", () => {
     });
   });
 
+  test("retains a late match inside an oversized target message", async () => {
+    rootDbExecuteMock.mockResolvedValueOnce([
+      {
+        messages: [
+          {
+            id: "00000000-0000-4000-8000-000000000010",
+            isTarget: true,
+            role: "assistant",
+            content: {
+              version: 2,
+              data: [
+                {
+                  type: "text",
+                  content: `${"a".repeat(20_000)} résumé ${"b".repeat(1000)}`,
+                },
+              ],
+            },
+          },
+        ],
+      },
+    ]);
+
+    const preview = await readSearchPreview({
+      ...previewQuery,
+      query: "resume",
+      type: "chat",
+    });
+
+    expect(preview).toMatchObject({
+      type: "chat-messages",
+      messages: [{ content: expect.stringContaining("résumé") }],
+    });
+    if (preview?.type === "chat-messages") {
+      expect(preview.messages.at(0)?.content.length ?? 0).toBeLessThanOrEqual(
+        16_000,
+      );
+    }
+  });
+
   test("orders context around a first-position target without duplicates", async () => {
     rootDbExecuteMock.mockResolvedValueOnce([
       {

--- a/apps/api/src/lib/search/preview-read.test.ts
+++ b/apps/api/src/lib/search/preview-read.test.ts
@@ -224,6 +224,60 @@ describe("search preview rendering contract", () => {
     });
   });
 
+  test("orders context around a first-position target without duplicates", async () => {
+    rootDbExecuteMock.mockResolvedValueOnce([
+      {
+        messages: [
+          {
+            id: "00000000-0000-4000-8000-000000000010",
+            isTarget: true,
+            role: "user",
+            content: {
+              version: 2,
+              data: [{ type: "text", content: "target" }],
+            },
+          },
+          {
+            id: "00000000-0000-4000-8000-000000000011",
+            isTarget: false,
+            role: "assistant",
+            content: { version: 2, data: [{ type: "text", content: "reply" }] },
+          },
+          {
+            id: "00000000-0000-4000-8000-000000000012",
+            isTarget: false,
+            role: "user",
+            content: {
+              version: 2,
+              data: [{ type: "text", content: "follow-up" }],
+            },
+          },
+        ],
+      },
+    ]);
+
+    expect(await readSearchPreview({ ...previewQuery, type: "chat" })).toEqual({
+      type: "chat-messages",
+      messages: [
+        {
+          id: "00000000-0000-4000-8000-000000000010",
+          role: "user",
+          content: "target",
+        },
+        {
+          id: "00000000-0000-4000-8000-000000000011",
+          role: "assistant",
+          content: "reply",
+        },
+        {
+          id: "00000000-0000-4000-8000-000000000012",
+          role: "user",
+          content: "follow-up",
+        },
+      ],
+    });
+  });
+
   test("renders indexed source-document metadata in chat previews", async () => {
     rootDbExecuteMock.mockResolvedValueOnce([
       {
@@ -258,8 +312,7 @@ describe("search preview rendering contract", () => {
         {
           id: "00000000-0000-4000-8000-000000000010",
           role: "assistant",
-          content:
-            "Closing memorandum\n\n@closing-memo\n\nentity_1\n\nmatter_1\n\ndocument",
+          content: "Closing memorandum\n\n@closing-memo\n\ndocument",
         },
       ],
     });

--- a/apps/api/src/lib/search/preview.test.ts
+++ b/apps/api/src/lib/search/preview.test.ts
@@ -188,6 +188,7 @@ describe("search preview authorization scope", () => {
     const compiled = compilePreview("chat");
     expect(compiled.sql).toContain("FROM chat_thread_search_documents cst");
     expect(compiled.sql).toContain("FROM chat_message_search_documents");
+    expect(compiled.sql).toContain("cst.preview_generation IS NULL");
     expect(compiled.sql).toContain("JOIN chat_messages message");
     expect(compiled.sql).toContain("ts_rank_cd(matching.tsv");
     expect(compiled.sql).toContain('AS "isTitleOnlyMatch"');

--- a/apps/api/src/lib/search/preview.test.ts
+++ b/apps/api/src/lib/search/preview.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { PgDialect } from "drizzle-orm/pg-core";
 
 import { toSafeId } from "@/api/lib/branded-types";
+import { CHAT_SEARCH_DISPLAY_METADATA_GENERATION } from "@/api/lib/search/chat-search-generation";
 import { buildSearchPreviewQuery } from "@/api/lib/search/preview";
 import type { GlobalSearchResultType } from "@/api/lib/search/types";
 
@@ -188,7 +189,8 @@ describe("search preview authorization scope", () => {
     const compiled = compilePreview("chat");
     expect(compiled.sql).toContain("FROM chat_thread_search_documents cst");
     expect(compiled.sql).toContain("FROM chat_message_search_documents");
-    expect(compiled.sql).toContain("cst.preview_generation IS NULL");
+    expect(compiled.sql).toContain("cst.preview_generation =");
+    expect(compiled.params).toContain(CHAT_SEARCH_DISPLAY_METADATA_GENERATION);
     expect(compiled.sql).toContain("JOIN chat_messages message");
     expect(compiled.sql).toContain("ts_rank_cd(matching.tsv");
     expect(compiled.sql).toContain('AS "isTitleOnlyMatch"');

--- a/apps/api/src/lib/search/preview.test.ts
+++ b/apps/api/src/lib/search/preview.test.ts
@@ -200,6 +200,16 @@ describe("search preview authorization scope", () => {
     expect(compiled.params).toContain(organizationId);
   });
 
+  test("anchors advanced chat previews with positive locator terms", () => {
+    const compiled = compilePreview(
+      "chat",
+      "indemnity AND liability NOT superseded",
+    );
+
+    expect(compiled.params).toContain("(indemnity:*) | (liability:*)");
+    expect(compiled.params).not.toContain("(superseded:*)");
+  });
+
   test("chat filter-only preview returns a bounded recent message window", () => {
     const compiled = compilePreview("chat", "");
 

--- a/apps/api/src/lib/search/preview.test.ts
+++ b/apps/api/src/lib/search/preview.test.ts
@@ -190,6 +190,8 @@ describe("search preview authorization scope", () => {
     expect(compiled.sql).toContain("FROM chat_message_search_documents");
     expect(compiled.sql).toContain("JOIN chat_messages message");
     expect(compiled.sql).toContain("ts_rank_cd(matching.tsv");
+    expect(compiled.sql).toContain('AS "hasMessageMatch"');
+    expect(compiled.sql).toContain("cst.title");
     expect(compiled.sql).toContain("ORDER BY nearby.created_at");
     expect(compiled.sql).toContain("LIMIT");
     expect(compiled.sql).toContain("t.user_id =");

--- a/apps/api/src/lib/search/preview.test.ts
+++ b/apps/api/src/lib/search/preview.test.ts
@@ -190,7 +190,8 @@ describe("search preview authorization scope", () => {
     expect(compiled.sql).toContain("FROM chat_message_search_documents");
     expect(compiled.sql).toContain("JOIN chat_messages message");
     expect(compiled.sql).toContain("ts_rank_cd(matching.tsv");
-    expect(compiled.sql).toContain('AS "hasMessageMatch"');
+    expect(compiled.sql).toContain('AS "isTitleOnlyMatch"');
+    expect(compiled.sql).toContain("arabic_normalize(coalesce(cst.title, ''))");
     expect(compiled.sql).toContain("cst.title");
     expect(compiled.sql).toContain("ORDER BY nearby.created_at");
     expect(compiled.sql).toContain("LIMIT");

--- a/apps/api/src/lib/search/preview.test.ts
+++ b/apps/api/src/lib/search/preview.test.ts
@@ -69,7 +69,6 @@ describe("search preview authorization scope", () => {
       "matter",
       "contact",
       "case-law",
-      "chat",
       "document",
       "folder",
       "task",
@@ -120,7 +119,6 @@ describe("search preview authorization scope", () => {
     const projectionTypes = [
       "matter",
       "contact",
-      "chat",
     ] as const satisfies readonly GlobalSearchResultType[];
 
     for (const type of projectionTypes) {
@@ -189,12 +187,28 @@ describe("search preview authorization scope", () => {
   test("chat preview is private to its user, org, and workspace set", () => {
     const compiled = compilePreview("chat");
     expect(compiled.sql).toContain("FROM chat_thread_search_documents cst");
+    expect(compiled.sql).toContain("FROM chat_message_search_documents");
+    expect(compiled.sql).toContain("JOIN chat_messages message");
+    expect(compiled.sql).toContain("ts_rank_cd(matching.tsv");
+    expect(compiled.sql).toContain("ORDER BY nearby.created_at");
+    expect(compiled.sql).toContain("LIMIT");
     expect(compiled.sql).toContain("t.user_id =");
     expect(compiled.sql).toContain("t.organization_id =");
     expect(compiled.sql).toContain("t.workspace_id IS NULL");
     expect(compiled.sql).toContain("data_workspace_ids <@");
     expect(compiled.params).toContain(userId);
     expect(compiled.params).toContain(organizationId);
+  });
+
+  test("chat filter-only preview returns a bounded recent message window", () => {
+    const compiled = compilePreview("chat", "");
+
+    expect(compiled.sql).not.toContain("ts_rank_cd");
+    expect(compiled.sql).not.toContain("matching.tsv @@");
+    expect(compiled.sql).toContain("latest.created_at DESC");
+    expect(compiled.sql).toContain("JOIN chat_messages message");
+    expect(compiled.params).toContain(6);
+    expect(compiled.params).toContain(0);
   });
 
   test("case-law preview stays on the intentionally public corpus", () => {

--- a/apps/api/src/lib/search/preview.ts
+++ b/apps/api/src/lib/search/preview.ts
@@ -2,8 +2,14 @@ import { sql } from "drizzle-orm";
 import type { SQL } from "drizzle-orm";
 
 import { rootDb } from "@/api/db/root";
+import { normalizePersistedChatMessageContent } from "@/api/handlers/chat/chat-message-parts";
+import type {
+  ChatMessageRole,
+  PersistedChatMessageContent,
+} from "@/api/handlers/chat/types";
 import type { SafeId } from "@/api/lib/branded-types";
 import { redistributableSourceJoin } from "@/api/lib/case-law/search-sql";
+import { LIMITS } from "@/api/lib/limits";
 import { chatThreadScopeSql } from "@/api/lib/search/chat-thread-scope-sql";
 import {
   contactWorkspaceAccessSql,
@@ -37,6 +43,10 @@ type SearchPreviewQuery = {
 
 type SearchPreview =
   | {
+      messages: SearchPreviewChatMessage[];
+      type: "chat-messages";
+    }
+  | {
       content: string;
       type: "highlighted-html";
     }
@@ -45,11 +55,26 @@ type SearchPreview =
       type: "plain-text";
     };
 
+type SearchPreviewChatMessage = {
+  content: string;
+  id: string;
+  role: ChatMessageRole;
+};
+
+type SearchPreviewChatMessageRow = {
+  content: PersistedChatMessageContent;
+  id: SafeId<"chatMessage">;
+  role: ChatMessageRole;
+};
+
+type SearchPreviewChatRow = {
+  messages: SearchPreviewChatMessageRow[];
+};
+
 const SEARCH_PREVIEW_BODY_CHARACTER_LIMIT =
   SEARCH_PREVIEW_SOURCE_CHARACTER_LIMIT -
   SEARCH_PREVIEW_TITLE_CHARACTER_LIMIT -
   1;
-const SEARCH_PREVIEW_RESPONSE_CHARACTER_LIMIT = 16_000;
 const SEARCH_PREVIEW_NORMALIZED_SOURCE_CHARACTER_LIMIT = 100_000;
 
 type PreviewTextConfig = {
@@ -95,7 +120,7 @@ const previewHeadline = (options: PreviewHeadlineOptions) => sql`
             ${options.tsQuery},
             ${SEARCH_PREVIEW_HEADLINE_CONFIG}
           ),
-          ${SEARCH_PREVIEW_RESPONSE_CHARACTER_LIMIT}
+          ${LIMITS.searchPreviewResponseCharacterLimit}
         ),
         'sourceContent',
         preview_source.content,
@@ -119,7 +144,7 @@ const previewUnhighlighted = (title: SQL, body: SQL) => sql`
     left(${title}, ${SEARCH_PREVIEW_TITLE_CHARACTER_LIMIT})
       || ' ' ||
     left(${body}, ${SEARCH_PREVIEW_BODY_CHARACTER_LIMIT}),
-    ${SEARCH_PREVIEW_RESPONSE_CHARACTER_LIMIT}
+    ${LIMITS.searchPreviewResponseCharacterLimit}
   )
 `;
 
@@ -164,6 +189,100 @@ const previewContent = ({
 
 const previewTextFilter = (searchVector: SQL, tsQuery: SQL | null): SQL =>
   tsQuery ? sql`AND ${searchVector} @@ ${tsQuery}` : sql.empty();
+
+const chatPreviewTargetMessageId = (tsQuery: SQL | null): SQL => {
+  const latestMessageId = sql`
+    SELECT latest.message_id
+    FROM chat_message_search_documents latest
+    WHERE latest.thread_id = cst.thread_id
+    ORDER BY latest.created_at DESC, latest.message_id DESC
+    LIMIT 1
+  `;
+
+  if (!tsQuery) {
+    return latestMessageId;
+  }
+
+  return sql`
+    SELECT coalesce(
+      (
+        SELECT matching.message_id
+        FROM chat_message_search_documents matching
+        WHERE matching.thread_id = cst.thread_id
+          AND matching.tsv @@ ${tsQuery}
+        ORDER BY
+          ts_rank_cd(matching.tsv, ${tsQuery}) DESC,
+          matching.created_at DESC,
+          matching.message_id DESC
+        LIMIT 1
+      ),
+      (${latestMessageId})
+    )
+  `;
+};
+
+const chatPreviewMessages = (tsQuery: SQL | null): SQL => {
+  const precedingLimit = tsQuery
+    ? Math.ceil(LIMITS.searchChatPreviewMessageLimit / 2)
+    : LIMITS.searchChatPreviewMessageLimit;
+  const followingLimit = tsQuery
+    ? LIMITS.searchChatPreviewMessageLimit - precedingLimit
+    : 0;
+
+  return sql`
+    (
+      WITH target AS (
+        SELECT target_message.created_at, target_message.message_id
+        FROM chat_message_search_documents target_message
+        WHERE target_message.message_id = (${chatPreviewTargetMessageId(tsQuery)})
+      ),
+      preceding AS (
+        SELECT
+          candidate.message_id,
+          candidate.role,
+          candidate.created_at
+        FROM chat_message_search_documents candidate
+        CROSS JOIN target
+        WHERE candidate.thread_id = cst.thread_id
+          AND (candidate.created_at, candidate.message_id)
+            <= (target.created_at, target.message_id)
+        ORDER BY candidate.created_at DESC, candidate.message_id DESC
+        LIMIT ${precedingLimit}
+      ),
+      following AS (
+        SELECT
+          candidate.message_id,
+          candidate.role,
+          candidate.created_at
+        FROM chat_message_search_documents candidate
+        CROSS JOIN target
+        WHERE candidate.thread_id = cst.thread_id
+          AND (candidate.created_at, candidate.message_id)
+            > (target.created_at, target.message_id)
+        ORDER BY candidate.created_at, candidate.message_id
+        LIMIT ${followingLimit}
+      ),
+      nearby AS (
+        SELECT * FROM preceding
+        UNION ALL
+        SELECT * FROM following
+      )
+      SELECT coalesce(
+        json_agg(
+          json_build_object(
+            'id', nearby.message_id,
+            'role', nearby.role,
+            'content', message.content
+          )
+          ORDER BY nearby.created_at, nearby.message_id
+        ),
+        '[]'::json
+      )
+      FROM nearby
+      JOIN chat_messages message ON message.id = nearby.message_id
+    ) AS messages
+  `;
+};
 
 export const buildSearchPreviewQuery = ({
   query,
@@ -266,22 +385,9 @@ export const buildSearchPreviewQuery = ({
       `;
     case "chat":
       return sql`
-        SELECT ${previewContent({
-          body: sql`cst.searchable_text`,
-          headlineTsQuery: locatorTsQuery,
-          normalize: normalizeSearchPreviewText,
-          passageContent: sql`preview_passage.content`,
-          regconfig: sql`'simple'::regconfig`,
-          title: sql`cst.title`,
-          useUnaccent: sql`true`,
-        })}
+        SELECT ${chatPreviewMessages(tsQuery)}
         FROM chat_thread_search_documents cst
         JOIN chat_threads t ON t.id = cst.thread_id
-        ${previewPassageJoin({
-          generation: sql`cst.preview_generation`,
-          locatorTsQuery,
-          table: "chat",
-        })}
         WHERE cst.thread_id = ${resultId}
           ${previewTextFilter(sql`cst.tsv`, tsQuery)}
           AND ${chatThreadScopeSql({
@@ -363,6 +469,44 @@ const isSearchPreviewRow = (value: unknown): value is SearchPreviewRow =>
 export const readSearchPreview = async (
   input: SearchPreviewQuery,
 ): Promise<SearchPreview | null> => {
+  if (input.type === "chat") {
+    const rows = await rootDb.execute<SearchPreviewChatRow>(
+      buildSearchPreviewQuery(input),
+    );
+    const row = rows.at(0);
+    if (!row || !Array.isArray(row.messages)) {
+      return null;
+    }
+
+    const messages: SearchPreviewChatMessage[] = [];
+    let remainingCharacters = Number(
+      LIMITS.searchPreviewResponseCharacterLimit,
+    );
+    for (const rawMessage of row.messages) {
+      if (remainingCharacters <= 0) {
+        break;
+      }
+      const message = normalizePersistedChatMessageContent(rawMessage.content);
+      const textParts: string[] = [];
+      for (const part of message.parts) {
+        if (part.type === "text" && part.content.trim()) {
+          textParts.push(part.content);
+        }
+      }
+      if (textParts.length > 0) {
+        const content = textParts.join("\n\n").slice(0, remainingCharacters);
+        messages.push({
+          content,
+          id: rawMessage.id,
+          role: rawMessage.role,
+        });
+        remainingCharacters -= content.length;
+      }
+    }
+
+    return { type: "chat-messages", messages };
+  }
+
   const rows = await rootDb.execute(buildSearchPreviewQuery(input));
   const preview = rows.at(0)?.["preview"];
   if (!isSearchPreviewRow(preview)) {
@@ -374,7 +518,7 @@ export const readSearchPreview = async (
   }
   const content = restoreOriginalSearchPreview({
     headline: preview.content,
-    maxLength: SEARCH_PREVIEW_RESPONSE_CHARACTER_LIMIT,
+    maxLength: LIMITS.searchPreviewResponseCharacterLimit,
     normalizedSource: preview.normalizedSourceContent,
     source: preview.sourceContent,
     useUnaccent: preview.useUnaccent,

--- a/apps/api/src/lib/search/preview.ts
+++ b/apps/api/src/lib/search/preview.ts
@@ -59,6 +59,7 @@ type SearchPreviewChatMessage = {
 type SearchPreviewChatMessageRow = {
   content: unknown;
   id: SafeId<"chatMessage">;
+  isTarget: unknown;
   role: unknown;
 };
 
@@ -90,6 +91,22 @@ const extractChatPreviewTextParts = (content: unknown): string[] => {
       typeof part["content"] === "string" ? part["content"] : part["text"];
     if (typeof text === "string" && text.trim()) {
       textParts.push(text);
+    }
+  }
+
+  const metadata = content["metadata"];
+  if (!isRecord(metadata) || !Array.isArray(metadata["sourceDocuments"])) {
+    return textParts;
+  }
+  for (const sourceDocument of metadata["sourceDocuments"]) {
+    if (!isRecord(sourceDocument)) {
+      continue;
+    }
+    for (const key of ["title", "mention", "entityRef", "matterRef", "kind"]) {
+      const value = sourceDocument[key];
+      if (typeof value === "string" && value.trim()) {
+        textParts.push(value);
+      }
     }
   }
   return textParts;
@@ -296,13 +313,15 @@ const chatPreviewMessages = (tsQuery: SQL | null): SQL => {
           json_build_object(
             'id', nearby.message_id,
             'role', nearby.role,
-            'content', message.content
+            'content', message.content,
+            'isTarget', nearby.message_id = target.message_id
           )
           ORDER BY nearby.created_at, nearby.message_id
         ),
         '[]'::json
       )
       FROM nearby
+      CROSS JOIN target
       JOIN chat_messages message ON message.id = nearby.message_id
     ) AS messages
   `;
@@ -502,31 +521,69 @@ export const readSearchPreview = async (
       return null;
     }
 
-    const messages: SearchPreviewChatMessage[] = [];
-    let remainingCharacters = Math.max(
-      0,
-      LIMITS.searchPreviewResponseCharacterLimit,
-    );
-    for (const rawMessage of row.messages) {
-      if (remainingCharacters <= 0) {
-        break;
-      }
+    const candidates: Array<
+      SearchPreviewChatMessage & { isTarget: boolean; position: number }
+    > = [];
+    for (const [position, rawMessage] of row.messages.entries()) {
       if (!isSearchPreviewChatRole(rawMessage.role)) {
         continue;
       }
       const textParts = extractChatPreviewTextParts(rawMessage.content);
-      if (textParts.length > 0) {
-        const content = textParts.join("\n\n").slice(0, remainingCharacters);
-        messages.push({
-          content,
-          id: rawMessage.id,
-          role: rawMessage.role,
-        });
-        remainingCharacters -= content.length;
+      if (textParts.length === 0) {
+        continue;
       }
+      candidates.push({
+        content: textParts.join("\n\n"),
+        id: rawMessage.id,
+        isTarget: rawMessage.isTarget === true,
+        position,
+        role: rawMessage.role,
+      });
     }
 
-    return { type: "chat-messages", messages };
+    const targetIndex = candidates.findIndex(({ isTarget }) => isTarget);
+    const targetCandidate = candidates.at(targetIndex);
+    const orderedCandidates =
+      targetCandidate === undefined
+        ? candidates
+        : [
+            targetCandidate,
+            ...Array.from({ length: candidates.length - 1 }).flatMap(
+              (_, offset) => {
+                const distance = offset + 1;
+                return [
+                  candidates.at(targetIndex - distance),
+                  candidates.at(targetIndex + distance),
+                ].flatMap((candidate) => (candidate ? [candidate] : []));
+              },
+            ),
+          ];
+
+    const messages: Array<SearchPreviewChatMessage & { position: number }> = [];
+    let remainingCharacters = Math.max(
+      0,
+      LIMITS.searchPreviewResponseCharacterLimit,
+    );
+    for (const candidate of orderedCandidates) {
+      if (remainingCharacters <= 0) {
+        break;
+      }
+      const content = candidate.content.slice(0, remainingCharacters);
+      messages.push({
+        content,
+        id: candidate.id,
+        position: candidate.position,
+        role: candidate.role,
+      });
+      remainingCharacters -= content.length;
+    }
+
+    return {
+      type: "chat-messages",
+      messages: messages
+        .toSorted((first, second) => first.position - second.position)
+        .map(({ position: _, ...message }) => message),
+    };
   }
 
   const rows = await rootDb.execute(buildSearchPreviewQuery(input));

--- a/apps/api/src/lib/search/preview.ts
+++ b/apps/api/src/lib/search/preview.ts
@@ -15,7 +15,7 @@ import {
   escapeAndHighlight,
   restoreOriginalSearchPreview,
   SEARCH_PREVIEW_HEADLINE_CONFIG,
-  truncateSearchPreviewAroundLexemes,
+  truncateSearchPreviewAroundCandidates,
 } from "@/api/lib/search/highlight";
 import { normalizeSearchableChatMessageContent } from "@/api/lib/search/index-chat";
 import { previewPassageJoin } from "@/api/lib/search/preview-passage-sql";
@@ -26,7 +26,7 @@ import {
 import {
   buildSearchPreviewLocatorTsQuery,
   buildSearchTsQuery,
-  getSearchPreviewLocatorLexemes,
+  getSearchPreviewLocatorCandidates,
 } from "@/api/lib/search/query";
 import type { GlobalSearchResultType } from "@/api/lib/search/types";
 
@@ -598,7 +598,7 @@ export const readSearchPreview = async (
           ];
 
     const messages: (SearchPreviewChatMessage & { position: number })[] = [];
-    const locatorLexemes = getSearchPreviewLocatorLexemes(input.query);
+    const locatorCandidates = getSearchPreviewLocatorCandidates(input.query);
     let remainingCharacters = Math.max(
       0,
       LIMITS.searchPreviewResponseCharacterLimit,
@@ -608,8 +608,8 @@ export const readSearchPreview = async (
         break;
       }
       const content = candidate.isTarget
-        ? truncateSearchPreviewAroundLexemes({
-            lexemes: locatorLexemes,
+        ? truncateSearchPreviewAroundCandidates({
+            candidates: locatorCandidates,
             maxLength: remainingCharacters,
             source: candidate.content,
           })

--- a/apps/api/src/lib/search/preview.ts
+++ b/apps/api/src/lib/search/preview.ts
@@ -15,6 +15,7 @@ import {
   escapeAndHighlight,
   restoreOriginalSearchPreview,
   SEARCH_PREVIEW_HEADLINE_CONFIG,
+  truncateSearchPreviewAroundLexemes,
 } from "@/api/lib/search/highlight";
 import { normalizeSearchableChatMessageContent } from "@/api/lib/search/index-chat";
 import { previewPassageJoin } from "@/api/lib/search/preview-passage-sql";
@@ -25,6 +26,7 @@ import {
 import {
   buildSearchPreviewLocatorTsQuery,
   buildSearchTsQuery,
+  getSearchPreviewLocatorLexemes,
 } from "@/api/lib/search/query";
 import type { GlobalSearchResultType } from "@/api/lib/search/types";
 
@@ -587,6 +589,7 @@ export const readSearchPreview = async (
           ];
 
     const messages: (SearchPreviewChatMessage & { position: number })[] = [];
+    const locatorLexemes = getSearchPreviewLocatorLexemes(input.query);
     let remainingCharacters = Math.max(
       0,
       LIMITS.searchPreviewResponseCharacterLimit,
@@ -595,7 +598,13 @@ export const readSearchPreview = async (
       if (remainingCharacters <= 0) {
         break;
       }
-      const content = candidate.content.slice(0, remainingCharacters);
+      const content = candidate.isTarget
+        ? truncateSearchPreviewAroundLexemes({
+            lexemes: locatorLexemes,
+            maxLength: remainingCharacters,
+            source: candidate.content,
+          })
+        : candidate.content.slice(0, remainingCharacters);
       messages.push({
         content,
         id: candidate.id,

--- a/apps/api/src/lib/search/preview.ts
+++ b/apps/api/src/lib/search/preview.ts
@@ -5,6 +5,7 @@ import { rootDb } from "@/api/db/root";
 import type { SafeId } from "@/api/lib/branded-types";
 import { redistributableSourceJoin } from "@/api/lib/case-law/search-sql";
 import { LIMITS } from "@/api/lib/limits";
+import { CHAT_SEARCH_DISPLAY_METADATA_GENERATION } from "@/api/lib/search/chat-search-generation";
 import { chatThreadScopeSql } from "@/api/lib/search/chat-thread-scope-sql";
 import {
   contactWorkspaceAccessSql,
@@ -460,7 +461,8 @@ export const buildSearchPreviewQuery = ({
         FROM chat_thread_search_documents cst
         JOIN chat_threads t ON t.id = cst.thread_id
         WHERE cst.thread_id = ${resultId}
-          AND cst.preview_generation IS NULL
+          AND cst.preview_generation =
+            ${CHAT_SEARCH_DISPLAY_METADATA_GENERATION}::uuid
           ${previewTextFilter(sql`cst.tsv`, tsQuery)}
           AND ${chatThreadScopeSql({
             userId,

--- a/apps/api/src/lib/search/preview.ts
+++ b/apps/api/src/lib/search/preview.ts
@@ -67,7 +67,7 @@ type SearchPreviewChatMessageRow = {
 };
 
 type SearchPreviewChatRow = {
-  hasMessageMatch: unknown;
+  isTitleOnlyMatch: unknown;
   messages: SearchPreviewChatMessageRow[];
   title: unknown;
 };
@@ -266,17 +266,23 @@ const chatPreviewTargetMessageId = (tsQuery: SQL | null): SQL => {
   `;
 };
 
-const chatPreviewHasMatchingMessage = (tsQuery: SQL | null): SQL =>
+const chatPreviewTitleOnlyMatch = (tsQuery: SQL | null): SQL =>
   tsQuery
     ? sql`
-        EXISTS (
-          SELECT 1
-          FROM chat_message_search_documents matching
-          WHERE matching.thread_id = cst.thread_id
-            AND matching.tsv @@ ${tsQuery}
-        ) AS "hasMessageMatch"
+        (
+          to_tsvector(
+            'simple',
+            unaccent(arabic_normalize(coalesce(cst.title, '')))
+          ) @@ ${tsQuery}
+          AND NOT EXISTS (
+            SELECT 1
+            FROM chat_message_search_documents matching
+            WHERE matching.thread_id = cst.thread_id
+              AND matching.tsv @@ ${tsQuery}
+          )
+        ) AS "isTitleOnlyMatch"
       `
-    : sql`true AS "hasMessageMatch"`;
+    : sql`false AS "isTitleOnlyMatch"`;
 
 const chatPreviewMessages = (tsQuery: SQL | null): SQL => {
   const precedingLimit = tsQuery
@@ -446,7 +452,7 @@ export const buildSearchPreviewQuery = ({
       return sql`
         SELECT
           cst.title,
-          ${chatPreviewHasMatchingMessage(tsQuery)},
+          ${chatPreviewTitleOnlyMatch(tsQuery)},
           ${chatPreviewMessages(locatorTsQuery)}
         FROM chat_thread_search_documents cst
         JOIN chat_threads t ON t.id = cst.thread_id
@@ -540,7 +546,7 @@ export const readSearchPreview = async (
       return null;
     }
 
-    if (row.hasMessageMatch === false && typeof row.title === "string") {
+    if (row.isTitleOnlyMatch === true && typeof row.title === "string") {
       const title = row.title.trim();
       if (title) {
         return { type: "plain-text", content: title };

--- a/apps/api/src/lib/search/preview.ts
+++ b/apps/api/src/lib/search/preview.ts
@@ -2,11 +2,6 @@ import { sql } from "drizzle-orm";
 import type { SQL } from "drizzle-orm";
 
 import { rootDb } from "@/api/db/root";
-import { normalizePersistedChatMessageContent } from "@/api/handlers/chat/chat-message-parts";
-import type {
-  ChatMessageRole,
-  PersistedChatMessageContent,
-} from "@/api/handlers/chat/types";
 import type { SafeId } from "@/api/lib/branded-types";
 import { redistributableSourceJoin } from "@/api/lib/case-law/search-sql";
 import { LIMITS } from "@/api/lib/limits";
@@ -58,17 +53,46 @@ type SearchPreview =
 type SearchPreviewChatMessage = {
   content: string;
   id: string;
-  role: ChatMessageRole;
+  role: SearchPreviewChatRole;
 };
 
 type SearchPreviewChatMessageRow = {
-  content: PersistedChatMessageContent;
+  content: unknown;
   id: SafeId<"chatMessage">;
-  role: ChatMessageRole;
+  role: unknown;
 };
 
 type SearchPreviewChatRow = {
   messages: SearchPreviewChatMessageRow[];
+};
+
+type SearchPreviewChatRole = "assistant" | "system" | "user";
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null;
+
+const isSearchPreviewChatRole = (
+  value: unknown,
+): value is SearchPreviewChatRole =>
+  value === "assistant" || value === "system" || value === "user";
+
+const extractChatPreviewTextParts = (content: unknown): string[] => {
+  if (!isRecord(content) || !Array.isArray(content["data"])) {
+    return [];
+  }
+
+  const textParts: string[] = [];
+  for (const part of content["data"]) {
+    if (!isRecord(part) || part["type"] !== "text") {
+      continue;
+    }
+    const text =
+      typeof part["content"] === "string" ? part["content"] : part["text"];
+    if (typeof text === "string" && text.trim()) {
+      textParts.push(text);
+    }
+  }
+  return textParts;
 };
 
 const SEARCH_PREVIEW_BODY_CHARACTER_LIMIT =
@@ -479,20 +503,18 @@ export const readSearchPreview = async (
     }
 
     const messages: SearchPreviewChatMessage[] = [];
-    let remainingCharacters = Number(
+    let remainingCharacters = Math.max(
+      0,
       LIMITS.searchPreviewResponseCharacterLimit,
     );
     for (const rawMessage of row.messages) {
       if (remainingCharacters <= 0) {
         break;
       }
-      const message = normalizePersistedChatMessageContent(rawMessage.content);
-      const textParts: string[] = [];
-      for (const part of message.parts) {
-        if (part.type === "text" && part.content.trim()) {
-          textParts.push(part.content);
-        }
+      if (!isSearchPreviewChatRole(rawMessage.role)) {
+        continue;
       }
+      const textParts = extractChatPreviewTextParts(rawMessage.content);
       if (textParts.length > 0) {
         const content = textParts.join("\n\n").slice(0, remainingCharacters);
         messages.push({

--- a/apps/api/src/lib/search/preview.ts
+++ b/apps/api/src/lib/search/preview.ts
@@ -102,7 +102,7 @@ const extractChatPreviewTextParts = (content: unknown): string[] => {
     if (!isRecord(sourceDocument)) {
       continue;
     }
-    for (const key of ["title", "mention", "entityRef", "matterRef", "kind"]) {
+    for (const key of ["title", "mention", "kind"]) {
       const value = sourceDocument[key];
       if (typeof value === "string" && value.trim()) {
         textParts.push(value);
@@ -543,7 +543,8 @@ export const readSearchPreview = async (
     }
 
     const targetIndex = candidates.findIndex(({ isTarget }) => isTarget);
-    const targetCandidate = candidates.at(targetIndex);
+    const targetCandidate =
+      targetIndex === -1 ? undefined : candidates.at(targetIndex);
     const orderedCandidates =
       targetCandidate === undefined
         ? candidates
@@ -552,8 +553,9 @@ export const readSearchPreview = async (
             ...Array.from({ length: candidates.length - 1 }).flatMap(
               (_, offset) => {
                 const distance = offset + 1;
+                const beforeIndex = targetIndex - distance;
                 return [
-                  candidates.at(targetIndex - distance),
+                  beforeIndex < 0 ? undefined : candidates.at(beforeIndex),
                   candidates.at(targetIndex + distance),
                 ].flatMap((candidate) => (candidate ? [candidate] : []));
               },

--- a/apps/api/src/lib/search/preview.ts
+++ b/apps/api/src/lib/search/preview.ts
@@ -409,7 +409,7 @@ export const buildSearchPreviewQuery = ({
       `;
     case "chat":
       return sql`
-        SELECT ${chatPreviewMessages(tsQuery)}
+        SELECT ${chatPreviewMessages(locatorTsQuery)}
         FROM chat_thread_search_documents cst
         JOIN chat_threads t ON t.id = cst.thread_id
         WHERE cst.thread_id = ${resultId}

--- a/apps/api/src/lib/search/preview.ts
+++ b/apps/api/src/lib/search/preview.ts
@@ -16,6 +16,7 @@ import {
   restoreOriginalSearchPreview,
   SEARCH_PREVIEW_HEADLINE_CONFIG,
 } from "@/api/lib/search/highlight";
+import { normalizeSearchableChatMessageContent } from "@/api/lib/search/index-chat";
 import { previewPassageJoin } from "@/api/lib/search/preview-passage-sql";
 import {
   SEARCH_PREVIEW_SOURCE_CHARACTER_LIMIT,
@@ -64,7 +65,9 @@ type SearchPreviewChatMessageRow = {
 };
 
 type SearchPreviewChatRow = {
+  hasMessageMatch: unknown;
   messages: SearchPreviewChatMessageRow[];
+  title: unknown;
 };
 
 type SearchPreviewChatRole = "assistant" | "system" | "user";
@@ -78,27 +81,26 @@ const isSearchPreviewChatRole = (
   value === "assistant" || value === "system" || value === "user";
 
 const extractChatPreviewTextParts = (content: unknown): string[] => {
-  if (!isRecord(content) || !Array.isArray(content["data"])) {
+  const normalized = normalizeSearchableChatMessageContent(content);
+  if (!normalized) {
     return [];
   }
 
   const textParts: string[] = [];
-  for (const part of content["data"]) {
-    if (!isRecord(part) || part["type"] !== "text") {
+  for (const part of normalized.parts) {
+    if (part.type !== "text") {
       continue;
     }
-    const text =
-      typeof part["content"] === "string" ? part["content"] : part["text"];
-    if (typeof text === "string" && text.trim()) {
-      textParts.push(text);
+    if (part.content.trim()) {
+      textParts.push(part.content);
     }
   }
 
-  const metadata = content["metadata"];
-  if (!isRecord(metadata) || !Array.isArray(metadata["sourceDocuments"])) {
+  const sourceDocuments = normalized.metadata.sourceDocuments;
+  if (!sourceDocuments) {
     return textParts;
   }
-  for (const sourceDocument of metadata["sourceDocuments"]) {
+  for (const sourceDocument of sourceDocuments) {
     if (!isRecord(sourceDocument)) {
       continue;
     }
@@ -261,6 +263,18 @@ const chatPreviewTargetMessageId = (tsQuery: SQL | null): SQL => {
     )
   `;
 };
+
+const chatPreviewHasMatchingMessage = (tsQuery: SQL | null): SQL =>
+  tsQuery
+    ? sql`
+        EXISTS (
+          SELECT 1
+          FROM chat_message_search_documents matching
+          WHERE matching.thread_id = cst.thread_id
+            AND matching.tsv @@ ${tsQuery}
+        ) AS "hasMessageMatch"
+      `
+    : sql`true AS "hasMessageMatch"`;
 
 const chatPreviewMessages = (tsQuery: SQL | null): SQL => {
   const precedingLimit = tsQuery
@@ -428,7 +442,10 @@ export const buildSearchPreviewQuery = ({
       `;
     case "chat":
       return sql`
-        SELECT ${chatPreviewMessages(locatorTsQuery)}
+        SELECT
+          cst.title,
+          ${chatPreviewHasMatchingMessage(tsQuery)},
+          ${chatPreviewMessages(locatorTsQuery)}
         FROM chat_thread_search_documents cst
         JOIN chat_threads t ON t.id = cst.thread_id
         WHERE cst.thread_id = ${resultId}
@@ -519,6 +536,13 @@ export const readSearchPreview = async (
     const row = rows.at(0);
     if (!row || !Array.isArray(row.messages)) {
       return null;
+    }
+
+    if (row.hasMessageMatch === false && typeof row.title === "string") {
+      const title = row.title.trim();
+      if (title) {
+        return { type: "plain-text", content: title };
+      }
     }
 
     const candidates: (SearchPreviewChatMessage & {

--- a/apps/api/src/lib/search/preview.ts
+++ b/apps/api/src/lib/search/preview.ts
@@ -460,6 +460,7 @@ export const buildSearchPreviewQuery = ({
         FROM chat_thread_search_documents cst
         JOIN chat_threads t ON t.id = cst.thread_id
         WHERE cst.thread_id = ${resultId}
+          AND cst.preview_generation IS NULL
           ${previewTextFilter(sql`cst.tsv`, tsQuery)}
           AND ${chatThreadScopeSql({
             userId,

--- a/apps/api/src/lib/search/preview.ts
+++ b/apps/api/src/lib/search/preview.ts
@@ -106,8 +106,11 @@ const extractChatPreviewTextParts = (content: unknown): string[] => {
     if (!isRecord(sourceDocument)) {
       continue;
     }
-    for (const key of ["title", "mention", "kind"]) {
-      const value = sourceDocument[key];
+    for (const value of [
+      sourceDocument.title,
+      sourceDocument.mention,
+      sourceDocument.kind,
+    ]) {
       if (typeof value === "string" && value.trim()) {
         textParts.push(value);
       }

--- a/apps/api/src/lib/search/preview.ts
+++ b/apps/api/src/lib/search/preview.ts
@@ -521,9 +521,10 @@ export const readSearchPreview = async (
       return null;
     }
 
-    const candidates: Array<
-      SearchPreviewChatMessage & { isTarget: boolean; position: number }
-    > = [];
+    const candidates: (SearchPreviewChatMessage & {
+      isTarget: boolean;
+      position: number;
+    })[] = [];
     for (const [position, rawMessage] of row.messages.entries()) {
       if (!isSearchPreviewChatRole(rawMessage.role)) {
         continue;
@@ -559,7 +560,7 @@ export const readSearchPreview = async (
             ),
           ];
 
-    const messages: Array<SearchPreviewChatMessage & { position: number }> = [];
+    const messages: (SearchPreviewChatMessage & { position: number })[] = [];
     let remainingCharacters = Math.max(
       0,
       LIMITS.searchPreviewResponseCharacterLimit,

--- a/apps/api/src/lib/search/query.test.ts
+++ b/apps/api/src/lib/search/query.test.ts
@@ -7,6 +7,7 @@ import {
   buildSearchPreviewLocatorTsQuery,
   buildSearchTsQuery,
   fileNameSearchText,
+  getSearchPreviewLocatorLexemes,
   normalizeFileNameForSearch,
   normalizeFileNameVariantForSearch,
   removeSearchDiacritics,
@@ -17,6 +18,14 @@ import {
 } from "@/api/lib/search/query";
 
 describe("search query text", () => {
+  test("extracts only positive preview locator lexemes", () => {
+    expect(
+      getSearchPreviewLocatorLexemes(
+        '"closing memo" OR odštěpení NOT superseded',
+      ),
+    ).toEqual(["closing", "memo", "odstepeni"]);
+  });
+
   test("preview locator ORs positive terms and excludes negated terms", () => {
     const dialect = new PgDialect();
     const compiled = dialect.sqlToQuery(

--- a/apps/api/src/lib/search/query.test.ts
+++ b/apps/api/src/lib/search/query.test.ts
@@ -7,7 +7,7 @@ import {
   buildSearchPreviewLocatorTsQuery,
   buildSearchTsQuery,
   fileNameSearchText,
-  getSearchPreviewLocatorLexemes,
+  getSearchPreviewLocatorCandidates,
   normalizeFileNameForSearch,
   normalizeFileNameVariantForSearch,
   removeSearchDiacritics,
@@ -18,12 +18,12 @@ import {
 } from "@/api/lib/search/query";
 
 describe("search query text", () => {
-  test("extracts only positive preview locator lexemes", () => {
+  test("extracts positive preview locator candidates without losing phrases", () => {
     expect(
-      getSearchPreviewLocatorLexemes(
+      getSearchPreviewLocatorCandidates(
         '"closing memo" OR odštěpení NOT superseded',
       ),
-    ).toEqual(["closing", "memo", "odstepeni"]);
+    ).toEqual(["closing memo", "odstepeni"]);
   });
 
   test("preview locator ORs positive terms and excludes negated terms", () => {

--- a/apps/api/src/lib/search/query.ts
+++ b/apps/api/src/lib/search/query.ts
@@ -346,28 +346,42 @@ const toSearchLexemes = (
     })
     .slice(0, PREFIX_QUERY_TOKEN_LIMIT);
 
-const collectPositiveLocatorLexemes = (
+const collectPositiveLocatorCandidates = (
   ast: SearchAst,
-  lexemes: Set<string>,
+  candidates: Set<string>,
   negated = false,
 ): void => {
   switch (ast.type) {
     case "term":
       if (!negated) {
+        if (ast.phrase) {
+          const phraseLexemes: string[] = [];
+          for (const group of ast.lexemes) {
+            const lexeme = group.at(0);
+            if (lexeme) {
+              phraseLexemes.push(lexeme);
+            }
+          }
+          const phrase = phraseLexemes.join(" ");
+          if (phrase) {
+            candidates.add(phrase);
+          }
+          return;
+        }
         for (const group of ast.lexemes) {
           for (const lexeme of group) {
-            lexemes.add(lexeme);
+            candidates.add(lexeme);
           }
         }
       }
       return;
     case "not":
-      collectPositiveLocatorLexemes(ast.child, lexemes, !negated);
+      collectPositiveLocatorCandidates(ast.child, candidates, !negated);
       return;
     case "and":
     case "or":
-      collectPositiveLocatorLexemes(ast.left, lexemes, negated);
-      collectPositiveLocatorLexemes(ast.right, lexemes, negated);
+      collectPositiveLocatorCandidates(ast.left, candidates, negated);
+      collectPositiveLocatorCandidates(ast.right, candidates, negated);
       return;
     default: {
       const exhaustive: never = ast;
@@ -376,24 +390,24 @@ const collectPositiveLocatorLexemes = (
   }
 };
 
-export const getSearchPreviewLocatorLexemes = (query: string): string[] => {
-  const lexemes = new Set<string>();
+export const getSearchPreviewLocatorCandidates = (query: string): string[] => {
+  const candidates = new Set<string>();
   if (isAdvancedQuery(query.trim())) {
     const ast = parseAdvancedSearchAst(query);
     if (ast) {
-      collectPositiveLocatorLexemes(ast, lexemes);
+      collectPositiveLocatorCandidates(ast, candidates);
     }
-    return [...lexemes];
+    return [...candidates];
   }
 
   for (const variant of [query, normalizeFileNameVariantForSearch(query)]) {
     if (variant) {
       for (const lexeme of toSearchLexemes(variant)) {
-        lexemes.add(lexeme);
+        candidates.add(lexeme);
       }
     }
   }
-  return [...lexemes];
+  return [...candidates];
 };
 
 const toSearchLexemeGroups = (

--- a/apps/api/src/lib/search/query.ts
+++ b/apps/api/src/lib/search/query.ts
@@ -346,6 +346,56 @@ const toSearchLexemes = (
     })
     .slice(0, PREFIX_QUERY_TOKEN_LIMIT);
 
+const collectPositiveLocatorLexemes = (
+  ast: SearchAst,
+  lexemes: Set<string>,
+  negated = false,
+): void => {
+  switch (ast.type) {
+    case "term":
+      if (!negated) {
+        for (const group of ast.lexemes) {
+          for (const lexeme of group) {
+            lexemes.add(lexeme);
+          }
+        }
+      }
+      return;
+    case "not":
+      collectPositiveLocatorLexemes(ast.child, lexemes, !negated);
+      return;
+    case "and":
+    case "or":
+      collectPositiveLocatorLexemes(ast.left, lexemes, negated);
+      collectPositiveLocatorLexemes(ast.right, lexemes, negated);
+      return;
+    default: {
+      const exhaustive: never = ast;
+      return exhaustive;
+    }
+  }
+};
+
+export const getSearchPreviewLocatorLexemes = (query: string): string[] => {
+  const lexemes = new Set<string>();
+  if (isAdvancedQuery(query.trim())) {
+    const ast = parseAdvancedSearchAst(query);
+    if (ast) {
+      collectPositiveLocatorLexemes(ast, lexemes);
+    }
+    return [...lexemes];
+  }
+
+  for (const variant of [query, normalizeFileNameVariantForSearch(query)]) {
+    if (variant) {
+      for (const lexeme of toSearchLexemes(variant)) {
+        lexemes.add(lexeme);
+      }
+    }
+  }
+  return [...lexemes];
+};
+
 const toSearchLexemeGroups = (
   query: string,
   mode: ArabicFoldMode = "folded",

--- a/apps/api/src/lib/search/types.ts
+++ b/apps/api/src/lib/search/types.ts
@@ -189,6 +189,7 @@ export type EntityGlobalSearchHit = GlobalSearchHitBase & {
   workspaceName: string;
   lastEditedByName: string | null;
   lastEditedByImage: string | null;
+  fileFieldId: string | null;
   mimeType: string | null;
 };
 

--- a/apps/api/src/lib/search/types.ts
+++ b/apps/api/src/lib/search/types.ts
@@ -190,6 +190,7 @@ export type EntityGlobalSearchHit = GlobalSearchHitBase & {
   lastEditedByName: string | null;
   lastEditedByImage: string | null;
   fileFieldId: string | null;
+  filePropertyId: string | null;
   mimeType: string | null;
 };
 

--- a/apps/web/src/components/chat/rehype-search-matches.test.ts
+++ b/apps/web/src/components/chat/rehype-search-matches.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from "bun:test";
+import type { Root } from "hast";
+
+import { rehypeSearchMatches } from "@/components/chat/rehype-search-matches";
+
+describe("chat search highlighting", () => {
+  test("highlights every normalized prose match", () => {
+    const tree: Root = {
+      type: "root",
+      children: [
+        {
+          type: "element",
+          tagName: "p",
+          properties: {},
+          children: [{ type: "text", value: "Odštěpení a odstepeni" }],
+        },
+      ],
+    };
+
+    rehypeSearchMatches({ searchText: "odštepení" })(tree);
+
+    expect(tree.children).toEqual([
+      {
+        type: "element",
+        tagName: "p",
+        properties: {},
+        children: [
+          {
+            type: "element",
+            tagName: "mark",
+            properties: { "data-search-match": "true" },
+            children: [{ type: "text", value: "Odštěpení" }],
+          },
+          { type: "text", value: " a " },
+          {
+            type: "element",
+            tagName: "mark",
+            properties: { "data-search-match": "true" },
+            children: [{ type: "text", value: "odstepeni" }],
+          },
+        ],
+      },
+    ]);
+  });
+
+  test("does not inject marks into links or fenced code", () => {
+    const tree: Root = {
+      type: "root",
+      children: [
+        {
+          type: "element",
+          tagName: "a",
+          properties: {},
+          children: [{ type: "text", value: "needle" }],
+        },
+        {
+          type: "element",
+          tagName: "pre",
+          properties: {},
+          children: [{ type: "text", value: "needle" }],
+        },
+      ],
+    };
+
+    rehypeSearchMatches({ searchText: "needle" })(tree);
+
+    expect(tree.children).toEqual([
+      {
+        type: "element",
+        tagName: "a",
+        properties: {},
+        children: [{ type: "text", value: "needle" }],
+      },
+      {
+        type: "element",
+        tagName: "pre",
+        properties: {},
+        children: [{ type: "text", value: "needle" }],
+      },
+    ]);
+  });
+});

--- a/apps/web/src/components/chat/rehype-search-matches.test.ts
+++ b/apps/web/src/components/chat/rehype-search-matches.test.ts
@@ -43,6 +43,42 @@ describe("chat search highlighting", () => {
     ]);
   });
 
+  test("unions exact and normalized hits without duplicating exact spans", () => {
+    const tree: Root = {
+      type: "root",
+      children: [
+        {
+          type: "element",
+          tagName: "p",
+          properties: {},
+          children: [{ type: "text", value: "odstepeni odštěpení ODŠTĚPENÍ" }],
+        },
+      ],
+    };
+
+    rehypeSearchMatches({ searchText: "odštěpení" })(tree);
+
+    const paragraph = tree.children.at(0);
+    expect(paragraph).toMatchObject({
+      children: [
+        {
+          type: "element",
+          children: [{ value: "odstepeni" }],
+        },
+        { type: "text", value: " " },
+        {
+          type: "element",
+          children: [{ value: "odštěpení" }],
+        },
+        { type: "text", value: " " },
+        {
+          type: "element",
+          children: [{ value: "ODŠTĚPENÍ" }],
+        },
+      ],
+    });
+  });
+
   test("highlights visible text inside links and fenced code", () => {
     const tree: Root = {
       type: "root",

--- a/apps/web/src/components/chat/rehype-search-matches.test.ts
+++ b/apps/web/src/components/chat/rehype-search-matches.test.ts
@@ -89,6 +89,27 @@ describe("chat search highlighting", () => {
     });
   });
 
+  test("highlights context-sensitive case mappings", () => {
+    const tree: Root = {
+      type: "root",
+      children: [{ type: "text", value: "ΟΣ" }],
+    };
+
+    rehypeSearchMatches({
+      matchBudget: createMatchBudget(),
+      searchText: "ος",
+    })(tree);
+
+    expect(tree.children).toEqual([
+      {
+        type: "element",
+        tagName: "mark",
+        properties: { "data-search-match": "true" },
+        children: [{ type: "text", value: "ΟΣ" }],
+      },
+    ]);
+  });
+
   test("highlights visible text inside links and fenced code", () => {
     const tree: Root = {
       type: "root",

--- a/apps/web/src/components/chat/rehype-search-matches.test.ts
+++ b/apps/web/src/components/chat/rehype-search-matches.test.ts
@@ -43,7 +43,7 @@ describe("chat search highlighting", () => {
     ]);
   });
 
-  test("does not inject marks into links or fenced code", () => {
+  test("highlights visible text inside links and fenced code", () => {
     const tree: Root = {
       type: "root",
       children: [
@@ -69,13 +69,27 @@ describe("chat search highlighting", () => {
         type: "element",
         tagName: "a",
         properties: {},
-        children: [{ type: "text", value: "needle" }],
+        children: [
+          {
+            type: "element",
+            tagName: "mark",
+            properties: { "data-search-match": "true" },
+            children: [{ type: "text", value: "needle" }],
+          },
+        ],
       },
       {
         type: "element",
         tagName: "pre",
         properties: {},
-        children: [{ type: "text", value: "needle" }],
+        children: [
+          {
+            type: "element",
+            tagName: "mark",
+            properties: { "data-search-match": "true" },
+            children: [{ type: "text", value: "needle" }],
+          },
+        ],
       },
     ]);
   });

--- a/apps/web/src/components/chat/rehype-search-matches.test.ts
+++ b/apps/web/src/components/chat/rehype-search-matches.test.ts
@@ -1,11 +1,24 @@
 import { describe, expect, test } from "bun:test";
 import type { Root } from "hast";
 
-import { rehypeSearchMatches } from "@/components/chat/rehype-search-matches";
+import {
+  allocateSearchMatchBudgets,
+  rehypeSearchMatches,
+} from "@/components/chat/rehype-search-matches";
 
 const TEST_MAX_MATCHES = 200;
 
 describe("chat search highlighting", () => {
+  test("shares one immutable match budget across preview messages", () => {
+    expect(
+      allocateSearchMatchBudgets({
+        contents: ["hit ".repeat(150), "hit ".repeat(100), "hit ".repeat(10)],
+        maxMatches: 201,
+        searchText: "hit",
+      }),
+    ).toEqual([150, 51, 0]);
+  });
+
   test("highlights every normalized prose match", () => {
     const tree: Root = {
       type: "root",

--- a/apps/web/src/components/chat/rehype-search-matches.test.ts
+++ b/apps/web/src/components/chat/rehype-search-matches.test.ts
@@ -3,6 +3,10 @@ import type { Root } from "hast";
 
 import { rehypeSearchMatches } from "@/components/chat/rehype-search-matches";
 
+const TEST_MAX_MATCHES = 200;
+
+const createMatchBudget = (remaining = TEST_MAX_MATCHES) => ({ remaining });
+
 describe("chat search highlighting", () => {
   test("highlights every normalized prose match", () => {
     const tree: Root = {
@@ -17,7 +21,10 @@ describe("chat search highlighting", () => {
       ],
     };
 
-    rehypeSearchMatches({ searchText: "odštepení" })(tree);
+    rehypeSearchMatches({
+      matchBudget: createMatchBudget(),
+      searchText: "odštepení",
+    })(tree);
 
     expect(tree.children).toEqual([
       {
@@ -56,7 +63,10 @@ describe("chat search highlighting", () => {
       ],
     };
 
-    rehypeSearchMatches({ searchText: "odštěpení" })(tree);
+    rehypeSearchMatches({
+      matchBudget: createMatchBudget(),
+      searchText: "odštěpení",
+    })(tree);
 
     const paragraph = tree.children.at(0);
     expect(paragraph).toMatchObject({
@@ -98,7 +108,10 @@ describe("chat search highlighting", () => {
       ],
     };
 
-    rehypeSearchMatches({ searchText: "needle" })(tree);
+    rehypeSearchMatches({
+      matchBudget: createMatchBudget(),
+      searchText: "needle",
+    })(tree);
 
     expect(tree.children).toEqual([
       {
@@ -128,5 +141,58 @@ describe("chat search highlighting", () => {
         ],
       },
     ]);
+  });
+
+  test("stops constructing highlight nodes at the requested cap", () => {
+    const tree: Root = {
+      type: "root",
+      children: [
+        {
+          type: "element",
+          tagName: "p",
+          properties: {},
+          children: [{ type: "text", value: "hit ".repeat(300) }],
+        },
+      ],
+    };
+
+    rehypeSearchMatches({
+      matchBudget: createMatchBudget(3),
+      searchText: "hit",
+    })(tree);
+
+    const paragraph = tree.children.at(0);
+    expect(paragraph).toMatchObject({
+      children: [
+        { type: "element" },
+        { type: "text", value: " " },
+        { type: "element" },
+        { type: "text", value: " " },
+        { type: "element" },
+        { type: "text", value: expect.stringContaining("hit") },
+      ],
+    });
+  });
+
+  test("shares one match budget across separately rendered messages", () => {
+    const first: Root = {
+      type: "root",
+      children: [{ type: "text", value: "hit hit" }],
+    };
+    const second: Root = {
+      type: "root",
+      children: [{ type: "text", value: "hit hit" }],
+    };
+    const matchBudget = createMatchBudget(3);
+
+    rehypeSearchMatches({ matchBudget, searchText: "hit" })(first);
+    rehypeSearchMatches({ matchBudget, searchText: "hit" })(second);
+
+    const countMarks = (tree: Root) =>
+      tree.children.filter(
+        (child) => child.type === "element" && child.tagName === "mark",
+      ).length;
+    expect(countMarks(first) + countMarks(second)).toBe(3);
+    expect(matchBudget.remaining).toBe(0);
   });
 });

--- a/apps/web/src/components/chat/rehype-search-matches.test.ts
+++ b/apps/web/src/components/chat/rehype-search-matches.test.ts
@@ -5,8 +5,6 @@ import { rehypeSearchMatches } from "@/components/chat/rehype-search-matches";
 
 const TEST_MAX_MATCHES = 200;
 
-const createMatchBudget = (remaining = TEST_MAX_MATCHES) => ({ remaining });
-
 describe("chat search highlighting", () => {
   test("highlights every normalized prose match", () => {
     const tree: Root = {
@@ -22,7 +20,7 @@ describe("chat search highlighting", () => {
     };
 
     rehypeSearchMatches({
-      matchBudget: createMatchBudget(),
+      maxMatches: TEST_MAX_MATCHES,
       searchText: "odštepení",
     })(tree);
 
@@ -64,7 +62,7 @@ describe("chat search highlighting", () => {
     };
 
     rehypeSearchMatches({
-      matchBudget: createMatchBudget(),
+      maxMatches: TEST_MAX_MATCHES,
       searchText: "odštěpení",
     })(tree);
 
@@ -96,7 +94,7 @@ describe("chat search highlighting", () => {
     };
 
     rehypeSearchMatches({
-      matchBudget: createMatchBudget(),
+      maxMatches: TEST_MAX_MATCHES,
       searchText: "ος",
     })(tree);
 
@@ -130,7 +128,7 @@ describe("chat search highlighting", () => {
     };
 
     rehypeSearchMatches({
-      matchBudget: createMatchBudget(),
+      maxMatches: TEST_MAX_MATCHES,
       searchText: "needle",
     })(tree);
 
@@ -178,7 +176,7 @@ describe("chat search highlighting", () => {
     };
 
     rehypeSearchMatches({
-      matchBudget: createMatchBudget(3),
+      maxMatches: 3,
       searchText: "hit",
     })(tree);
 
@@ -195,25 +193,26 @@ describe("chat search highlighting", () => {
     });
   });
 
-  test("shares one match budget across separately rendered messages", () => {
-    const first: Root = {
+  test("resets the immutable cap when a transform is replayed", () => {
+    const createTree = (): Root => ({
       type: "root",
-      children: [{ type: "text", value: "hit hit" }],
-    };
-    const second: Root = {
-      type: "root",
-      children: [{ type: "text", value: "hit hit" }],
-    };
-    const matchBudget = createMatchBudget(3);
+      children: [{ type: "text", value: "hit hit hit hit" }],
+    });
+    const transform = rehypeSearchMatches({
+      maxMatches: 3,
+      searchText: "hit",
+    });
+    const first = createTree();
+    const replay = createTree();
 
-    rehypeSearchMatches({ matchBudget, searchText: "hit" })(first);
-    rehypeSearchMatches({ matchBudget, searchText: "hit" })(second);
+    transform(first);
+    transform(replay);
 
     const countMarks = (tree: Root) =>
       tree.children.filter(
         (child) => child.type === "element" && child.tagName === "mark",
       ).length;
-    expect(countMarks(first) + countMarks(second)).toBe(3);
-    expect(matchBudget.remaining).toBe(0);
+    expect(countMarks(first)).toBe(3);
+    expect(countMarks(replay)).toBe(3);
   });
 });

--- a/apps/web/src/components/chat/rehype-search-matches.ts
+++ b/apps/web/src/components/chat/rehype-search-matches.ts
@@ -13,15 +13,22 @@ const isText = (node: ElementContent | RootContent): node is Text =>
   node.type === "text";
 
 type SearchMatchPluginOptions = {
+  matchBudget: { remaining: number };
   searchText: SearchTextQuery;
 };
 
 export function rehypeSearchMatches(
   this: unknown,
-  { searchText }: SearchMatchPluginOptions,
+  { matchBudget, searchText }: SearchMatchPluginOptions,
 ) {
   const splitTextNode = (text: Text): ElementContent[] => {
-    const matches = findSearchTextMatches(text.value, searchText);
+    if (matchBudget.remaining <= 0) {
+      return [text];
+    }
+    const matches = findSearchTextMatches(text.value, searchText, {
+      maxMatches: matchBudget.remaining,
+    });
+    matchBudget.remaining -= matches.length;
     if (matches.length === 0) {
       return [text];
     }

--- a/apps/web/src/components/chat/rehype-search-matches.ts
+++ b/apps/web/src/components/chat/rehype-search-matches.ts
@@ -13,71 +13,72 @@ const isText = (node: ElementContent | RootContent): node is Text =>
   node.type === "text";
 
 type SearchMatchPluginOptions = {
-  matchBudget: { remaining: number };
+  maxMatches: number;
   searchText: SearchTextQuery;
 };
 
 export function rehypeSearchMatches(
   this: unknown,
-  { matchBudget, searchText }: SearchMatchPluginOptions,
+  { maxMatches, searchText }: SearchMatchPluginOptions,
 ) {
-  const splitTextNode = (text: Text): ElementContent[] => {
-    if (matchBudget.remaining <= 0) {
-      return [text];
-    }
-    const matches = findSearchTextMatches(text.value, searchText, {
-      maxMatches: matchBudget.remaining,
-    });
-    matchBudget.remaining -= matches.length;
-    if (matches.length === 0) {
-      return [text];
-    }
-
-    const result: ElementContent[] = [];
-    let offset = 0;
-    for (const match of matches) {
-      if (match.start > offset) {
-        result.push({
-          type: "text",
-          value: text.value.slice(offset, match.start),
-        });
-      }
-      result.push({
-        type: "element",
-        tagName: "mark",
-        properties: { "data-search-match": "true" },
-        children: [
-          { type: "text", value: text.value.slice(match.start, match.end) },
-        ],
-      });
-      offset = match.end;
-    }
-    if (offset < text.value.length) {
-      result.push({ type: "text", value: text.value.slice(offset) });
-    }
-    return result;
-  };
-
-  const walkElement = (parent: Element) => {
-    const next: ElementContent[] = [];
-    for (const child of parent.children) {
-      if (isText(child)) {
-        next.push(
-          ...(skipsSearchHighlight(parent.tagName)
-            ? [child]
-            : splitTextNode(child)),
-        );
-        continue;
-      }
-      if (isElement(child) && !skipsSearchHighlight(child.tagName)) {
-        walkElement(child);
-      }
-      next.push(child);
-    }
-    parent.children = next;
-  };
-
   return (tree: Root) => {
+    let remainingMatches = Math.max(0, Math.floor(maxMatches));
+    const splitTextNode = (text: Text): ElementContent[] => {
+      if (remainingMatches <= 0) {
+        return [text];
+      }
+      const matches = findSearchTextMatches(text.value, searchText, {
+        maxMatches: remainingMatches,
+      });
+      remainingMatches -= matches.length;
+      if (matches.length === 0) {
+        return [text];
+      }
+
+      const result: ElementContent[] = [];
+      let offset = 0;
+      for (const match of matches) {
+        if (match.start > offset) {
+          result.push({
+            type: "text",
+            value: text.value.slice(offset, match.start),
+          });
+        }
+        result.push({
+          type: "element",
+          tagName: "mark",
+          properties: { "data-search-match": "true" },
+          children: [
+            { type: "text", value: text.value.slice(match.start, match.end) },
+          ],
+        });
+        offset = match.end;
+      }
+      if (offset < text.value.length) {
+        result.push({ type: "text", value: text.value.slice(offset) });
+      }
+      return result;
+    };
+
+    const walkElement = (parent: Element) => {
+      const next: ElementContent[] = [];
+      for (const child of parent.children) {
+        if (isText(child)) {
+          next.push(
+            ...(skipsSearchHighlight(parent.tagName)
+              ? [child]
+              : splitTextNode(child)),
+          );
+          continue;
+        }
+        if (isElement(child) && !skipsSearchHighlight(child.tagName)) {
+          walkElement(child);
+        }
+        next.push(child);
+      }
+      parent.children = next;
+    };
+
     const next: RootContent[] = [];
     for (const child of tree.children) {
       if (isText(child)) {

--- a/apps/web/src/components/chat/rehype-search-matches.ts
+++ b/apps/web/src/components/chat/rehype-search-matches.ts
@@ -1,0 +1,92 @@
+import type { Element, ElementContent, Root, RootContent, Text } from "hast";
+
+import { findSearchTextMatches } from "@/lib/document-search";
+
+const SKIP_PARENT_TAGS: ReadonlySet<string> = new Set([
+  "a",
+  "button",
+  "pre",
+  "script",
+  "style",
+]);
+
+const isElement = (node: ElementContent | RootContent): node is Element =>
+  node.type === "element";
+
+const isText = (node: ElementContent | RootContent): node is Text =>
+  node.type === "text";
+
+type SearchMatchPluginOptions = {
+  searchText: string;
+};
+
+export function rehypeSearchMatches(
+  this: unknown,
+  { searchText }: SearchMatchPluginOptions,
+) {
+  const splitTextNode = (text: Text): ElementContent[] => {
+    const matches = findSearchTextMatches(text.value, searchText);
+    if (matches.length === 0) {
+      return [text];
+    }
+
+    const result: ElementContent[] = [];
+    let offset = 0;
+    for (const match of matches) {
+      if (match.start > offset) {
+        result.push({
+          type: "text",
+          value: text.value.slice(offset, match.start),
+        });
+      }
+      result.push({
+        type: "element",
+        tagName: "mark",
+        properties: { "data-search-match": "true" },
+        children: [
+          { type: "text", value: text.value.slice(match.start, match.end) },
+        ],
+      });
+      offset = match.end;
+    }
+    if (offset < text.value.length) {
+      result.push({ type: "text", value: text.value.slice(offset) });
+    }
+    return result;
+  };
+
+  const walkElement = (parent: Element) => {
+    const next: ElementContent[] = [];
+    for (const child of parent.children) {
+      if (isText(child)) {
+        next.push(
+          ...(SKIP_PARENT_TAGS.has(parent.tagName)
+            ? [child]
+            : splitTextNode(child)),
+        );
+        continue;
+      }
+      if (isElement(child) && !SKIP_PARENT_TAGS.has(child.tagName)) {
+        walkElement(child);
+      }
+      next.push(child);
+    }
+    parent.children = next;
+  };
+
+  return (tree: Root) => {
+    const next: RootContent[] = [];
+    for (const child of tree.children) {
+      if (isText(child)) {
+        next.push(...splitTextNode(child));
+        continue;
+      }
+      if (isElement(child) && !SKIP_PARENT_TAGS.has(child.tagName)) {
+        walkElement(child);
+      }
+      next.push(child);
+    }
+    tree.children = next;
+    return tree;
+  };
+}

--- a/apps/web/src/components/chat/rehype-search-matches.ts
+++ b/apps/web/src/components/chat/rehype-search-matches.ts
@@ -1,6 +1,7 @@
 import type { Element, ElementContent, Root, RootContent, Text } from "hast";
 
 import { findSearchTextMatches } from "@/lib/document-search";
+import type { SearchTextQuery } from "@/lib/search-text";
 
 const skipsSearchHighlight = (tagName: string): boolean =>
   tagName === "script" || tagName === "style";
@@ -12,7 +13,7 @@ const isText = (node: ElementContent | RootContent): node is Text =>
   node.type === "text";
 
 type SearchMatchPluginOptions = {
-  searchText: string;
+  searchText: SearchTextQuery;
 };
 
 export function rehypeSearchMatches(

--- a/apps/web/src/components/chat/rehype-search-matches.ts
+++ b/apps/web/src/components/chat/rehype-search-matches.ts
@@ -3,11 +3,7 @@ import type { Element, ElementContent, Root, RootContent, Text } from "hast";
 import { findSearchTextMatches } from "@/lib/document-search";
 
 const skipsSearchHighlight = (tagName: string): boolean =>
-  tagName === "a" ||
-  tagName === "button" ||
-  tagName === "pre" ||
-  tagName === "script" ||
-  tagName === "style";
+  tagName === "script" || tagName === "style";
 
 const isElement = (node: ElementContent | RootContent): node is Element =>
   node.type === "element";

--- a/apps/web/src/components/chat/rehype-search-matches.ts
+++ b/apps/web/src/components/chat/rehype-search-matches.ts
@@ -17,6 +17,30 @@ type SearchMatchPluginOptions = {
   searchText: SearchTextQuery;
 };
 
+type AllocateSearchMatchBudgetsOptions = {
+  contents: readonly string[];
+  maxMatches: number;
+  searchText: SearchTextQuery;
+};
+
+export const allocateSearchMatchBudgets = ({
+  contents,
+  maxMatches,
+  searchText,
+}: AllocateSearchMatchBudgetsOptions): number[] => {
+  let remainingMatches = Math.max(0, Math.floor(maxMatches));
+  return contents.map((content) => {
+    if (remainingMatches === 0) {
+      return 0;
+    }
+    const count = findSearchTextMatches(content, searchText, {
+      maxMatches: remainingMatches,
+    }).length;
+    remainingMatches -= count;
+    return count;
+  });
+};
+
 export function rehypeSearchMatches(
   this: unknown,
   { maxMatches, searchText }: SearchMatchPluginOptions,

--- a/apps/web/src/components/chat/rehype-search-matches.ts
+++ b/apps/web/src/components/chat/rehype-search-matches.ts
@@ -2,13 +2,12 @@ import type { Element, ElementContent, Root, RootContent, Text } from "hast";
 
 import { findSearchTextMatches } from "@/lib/document-search";
 
-const SKIP_PARENT_TAGS: ReadonlySet<string> = new Set([
-  "a",
-  "button",
-  "pre",
-  "script",
-  "style",
-]);
+const skipsSearchHighlight = (tagName: string): boolean =>
+  tagName === "a" ||
+  tagName === "button" ||
+  tagName === "pre" ||
+  tagName === "script" ||
+  tagName === "style";
 
 const isElement = (node: ElementContent | RootContent): node is Element =>
   node.type === "element";
@@ -60,13 +59,13 @@ export function rehypeSearchMatches(
     for (const child of parent.children) {
       if (isText(child)) {
         next.push(
-          ...(SKIP_PARENT_TAGS.has(parent.tagName)
+          ...(skipsSearchHighlight(parent.tagName)
             ? [child]
             : splitTextNode(child)),
         );
         continue;
       }
-      if (isElement(child) && !SKIP_PARENT_TAGS.has(child.tagName)) {
+      if (isElement(child) && !skipsSearchHighlight(child.tagName)) {
         walkElement(child);
       }
       next.push(child);
@@ -81,7 +80,7 @@ export function rehypeSearchMatches(
         next.push(...splitTextNode(child));
         continue;
       }
-      if (isElement(child) && !SKIP_PARENT_TAGS.has(child.tagName)) {
+      if (isElement(child) && !skipsSearchHighlight(child.tagName)) {
         walkElement(child);
       }
       next.push(child);

--- a/apps/web/src/components/saved-searches.logic.test.ts
+++ b/apps/web/src/components/saved-searches.logic.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "bun:test";
 import {
   canSaveSearch,
   savedSearchKeys,
+  shouldShowSavedSearchList,
   toSavedSearchCriteria,
   toSearchFilters,
 } from "./saved-searches.logic";
@@ -52,6 +53,26 @@ describe("saved search eligibility", () => {
         query: "",
       }),
     ).toBe(false);
+  });
+});
+
+describe("saved search list visibility", () => {
+  test("hides a successfully loaded empty list", () => {
+    expect(
+      shouldShowSavedSearchList({ itemCount: 0, status: "success" }),
+    ).toBeFalse();
+  });
+
+  test("keeps loading, error, and non-empty states visible", () => {
+    expect(
+      shouldShowSavedSearchList({ itemCount: 0, status: "pending" }),
+    ).toBeTrue();
+    expect(
+      shouldShowSavedSearchList({ itemCount: 0, status: "error" }),
+    ).toBeTrue();
+    expect(
+      shouldShowSavedSearchList({ itemCount: 1, status: "success" }),
+    ).toBeTrue();
   });
 });
 

--- a/apps/web/src/components/saved-searches.logic.ts
+++ b/apps/web/src/components/saved-searches.logic.ts
@@ -42,6 +42,16 @@ export const canSaveSearch = ({
     updatedTo: resolveUpdatedTo(filters.time),
   });
 
+type SavedSearchListState = {
+  itemCount: number;
+  status: "error" | "pending" | "success";
+};
+
+export const shouldShowSavedSearchList = ({
+  itemCount,
+  status,
+}: SavedSearchListState): boolean => status !== "success" || itemCount > 0;
+
 const toSavedSearchTime = (time: TimeFilter): SavedSearchTime => {
   if (time.mode === "preset") {
     return { type: "preset", preset: time.preset };

--- a/apps/web/src/components/saved-searches.tsx
+++ b/apps/web/src/components/saved-searches.tsx
@@ -34,6 +34,7 @@ import {
 import { Input } from "@stll/ui/components/input";
 import { stellaToast } from "@stll/ui/components/toast";
 import { contentDir } from "@stll/ui/hooks/use-content-dir";
+import type { OverlayLayer } from "@stll/ui/lib/overlay-layer";
 
 import {
   canSaveSearch,
@@ -70,6 +71,7 @@ type SavedSearchesProps = {
   isOpen: boolean;
   query: string;
   onApply: (criteria: SavedSearch["criteria"]) => void;
+  overlayLayer?: OverlayLayer;
   showList?: boolean;
   showTrigger?: boolean;
 };
@@ -79,6 +81,7 @@ export const SavedSearches = ({
   isOpen,
   query,
   onApply,
+  overlayLayer = "default",
   showList = true,
   showTrigger = true,
 }: SavedSearchesProps) => {
@@ -340,7 +343,7 @@ export const SavedSearches = ({
         }}
         open={dialog.type === "create" || dialog.type === "rename"}
       >
-        <DialogPopup>
+        <DialogPopup layer={overlayLayer}>
           <DialogHeader>
             <DialogTitle>
               {dialog.type === "rename"
@@ -400,7 +403,7 @@ export const SavedSearches = ({
         }}
         open={dialog.type === "delete"}
       >
-        <AlertDialogPopup>
+        <AlertDialogPopup layer={overlayLayer}>
           <AlertDialogHeader>
             <AlertDialogTitle>{t("search.deleteSearchTitle")}</AlertDialogTitle>
             <AlertDialogDescription>

--- a/apps/web/src/components/saved-searches.tsx
+++ b/apps/web/src/components/saved-searches.tsx
@@ -38,6 +38,7 @@ import { contentDir } from "@stll/ui/hooks/use-content-dir";
 import {
   canSaveSearch,
   savedSearchKeys,
+  shouldShowSavedSearchList,
   toSavedSearchCriteria,
 } from "@/components/saved-searches.logic";
 import type { SearchFilters } from "@/components/search-filters.logic";
@@ -187,6 +188,13 @@ export const SavedSearches = ({
   const savedSearches = savedSearchesQuery.data?.pages.flatMap(
     (page) => page.items,
   );
+  const hasSavedSearches = (savedSearches?.length ?? 0) > 0;
+  const shouldShowList =
+    showList &&
+    shouldShowSavedSearchList({
+      itemCount: hasSavedSearches ? (savedSearches?.length ?? 0) : 0,
+      status: savedSearchesQuery.status,
+    });
   const savedSearchesError = savedSearchesQuery.error;
   useExternalSyncEffect(() => {
     if (!showList || !savedSearchesError) {
@@ -241,7 +249,7 @@ export const SavedSearches = ({
         </Button>
       )}
 
-      {showList && (
+      {shouldShowList && (
         <section className="space-y-1">
           <h3 className="text-muted-foreground mb-2 text-xs font-medium">
             {t("search.savedSearches")}
@@ -305,11 +313,6 @@ export const SavedSearches = ({
               </Button>
             </div>
           ))}
-          {savedSearchesQuery.isSuccess && savedSearches?.length === 0 && (
-            <p className="text-muted-foreground px-2 py-2 text-sm">
-              {t("search.savedSearchesEmpty")}
-            </p>
-          )}
           {savedSearchesQuery.hasNextPage && (
             <Button
               className="h-11 w-full"

--- a/apps/web/src/components/search-chat-preview.tsx
+++ b/apps/web/src/components/search-chat-preview.tsx
@@ -43,6 +43,11 @@ export const SearchChatPreview = ({
   );
 
   useExternalSyncEffect(() => {
+    setActiveIndex(0);
+    lastScrolledMatchRef.current = null;
+  }, [searchText]);
+
+  useExternalSyncEffect(() => {
     const root = rootRef.current;
     if (!root) {
       return undefined;

--- a/apps/web/src/components/search-chat-preview.tsx
+++ b/apps/web/src/components/search-chat-preview.tsx
@@ -42,9 +42,14 @@ export const SearchChatPreview = ({
     useState<SearchMatchSummary>(EMPTY_MATCH_SUMMARY);
   const searchTextKey = searchTextQueryKey(searchText);
   const rehypePluginsByMessage = useMemo<PluggableList[]>(() => {
-    const matchBudget = { remaining: MAX_SEARCH_PREVIEW_MATCHES + 1 };
+    // The API bounds both message count and total preview characters. Keep the
+    // transform cap immutable per message so Strict Mode/concurrent replays
+    // cannot inherit a consumed budget; the DOM summary applies the global cap.
     return messages.map(() => [
-      [rehypeSearchMatches, { matchBudget, searchText }],
+      [
+        rehypeSearchMatches,
+        { maxMatches: MAX_SEARCH_PREVIEW_MATCHES + 1, searchText },
+      ],
     ]);
   }, [messages, searchText]);
 

--- a/apps/web/src/components/search-chat-preview.tsx
+++ b/apps/web/src/components/search-chat-preview.tsx
@@ -7,7 +7,10 @@ import {
   MessageContent,
   MessageResponse,
 } from "@/components/ai-elements/message";
-import { rehypeSearchMatches } from "@/components/chat/rehype-search-matches";
+import {
+  allocateSearchMatchBudgets,
+  rehypeSearchMatches,
+} from "@/components/chat/rehype-search-matches";
 import { SearchMatchControls } from "@/components/search-match-controls";
 import { useExternalSyncEffect } from "@/hooks/use-effect";
 import {
@@ -42,14 +45,16 @@ export const SearchChatPreview = ({
     useState<SearchMatchSummary>(EMPTY_MATCH_SUMMARY);
   const searchTextKey = searchTextQueryKey(searchText);
   const rehypePluginsByMessage = useMemo<PluggableList[]>(() => {
-    // The API bounds both message count and total preview characters. Keep the
-    // transform cap immutable per message so Strict Mode/concurrent replays
-    // cannot inherit a consumed budget; the DOM summary applies the global cap.
-    return messages.map(() => [
-      [
-        rehypeSearchMatches,
-        { maxMatches: MAX_SEARCH_PREVIEW_MATCHES + 1, searchText },
-      ],
+    // Allocate immutable per-message budgets from the same matcher before
+    // rendering. Their sum is globally bounded while each transform remains
+    // deterministic under Strict Mode and concurrent replays.
+    const budgets = allocateSearchMatchBudgets({
+      contents: messages.map(({ content }) => content),
+      maxMatches: MAX_SEARCH_PREVIEW_MATCHES + 1,
+      searchText,
+    });
+    return messages.map((_, index) => [
+      [rehypeSearchMatches, { maxMatches: budgets[index] ?? 0, searchText }],
     ]);
   }, [messages, searchText]);
 

--- a/apps/web/src/components/search-chat-preview.tsx
+++ b/apps/web/src/components/search-chat-preview.tsx
@@ -83,9 +83,9 @@ export const SearchChatPreview = ({
 
     for (const [index, match] of matches.entries()) {
       if (index === clampedIndex) {
-        match.dataset.active = "true";
+        match.dataset["active"] = "true";
       } else {
-        delete match.dataset.active;
+        delete match.dataset["active"];
       }
     }
     const activeMatch = matches.at(clampedIndex);

--- a/apps/web/src/components/search-chat-preview.tsx
+++ b/apps/web/src/components/search-chat-preview.tsx
@@ -16,11 +16,13 @@ import {
   MAX_SEARCH_PREVIEW_MATCHES,
   type SearchMatchSummary,
 } from "@/lib/search-match-navigation";
+import { searchTextQueryKey } from "@/lib/search-text";
+import type { SearchTextQuery } from "@/lib/search-text";
 import type { SearchPreviewChatMessage } from "@/lib/search.logic";
 
 type SearchChatPreviewProps = {
   messages: SearchPreviewChatMessage[];
-  searchText: string;
+  searchText: SearchTextQuery;
 };
 
 const EMPTY_MATCH_SUMMARY: SearchMatchSummary = {
@@ -37,6 +39,7 @@ export const SearchChatPreview = ({
   const [activeIndex, setActiveIndex] = useState(0);
   const [matchSummary, setMatchSummary] =
     useState<SearchMatchSummary>(EMPTY_MATCH_SUMMARY);
+  const searchTextKey = searchTextQueryKey(searchText);
   const rehypePlugins = useMemo<PluggableList>(
     () => [[rehypeSearchMatches, { searchText }]],
     [searchText],
@@ -45,7 +48,7 @@ export const SearchChatPreview = ({
   useExternalSyncEffect(() => {
     setActiveIndex(0);
     lastScrolledMatchRef.current = null;
-  }, [searchText]);
+  }, [searchTextKey]);
 
   useExternalSyncEffect(() => {
     const root = rootRef.current;

--- a/apps/web/src/components/search-chat-preview.tsx
+++ b/apps/web/src/components/search-chat-preview.tsx
@@ -37,6 +37,7 @@ export const SearchChatPreview = ({
   const rootRef = useRef<HTMLDivElement>(null);
   const lastScrolledMatchRef = useRef<Element | null>(null);
   const [activeIndex, setActiveIndex] = useState(0);
+  const [domRevision, setDomRevision] = useState(0);
   const [matchSummary, setMatchSummary] =
     useState<SearchMatchSummary>(EMPTY_MATCH_SUMMARY);
   const searchTextKey = searchTextQueryKey(searchText);
@@ -69,6 +70,7 @@ export const SearchChatPreview = ({
           ? current
           : next,
       );
+      setDomRevision((current) => current + 1);
     };
     syncMatchSummary();
     const observer = new MutationObserver(syncMatchSummary);
@@ -120,7 +122,7 @@ export const SearchChatPreview = ({
       }),
     });
     lastScrolledMatchRef.current = activeMatch;
-  }, [activeIndex, matchSummary.count]);
+  }, [activeIndex, domRevision, matchSummary.count]);
 
   const navigate = useCallback(
     (direction: "next" | "previous") => {

--- a/apps/web/src/components/search-chat-preview.tsx
+++ b/apps/web/src/components/search-chat-preview.tsx
@@ -163,15 +163,20 @@ export const SearchChatPreview = ({
           />
         </div>
       )}
-      {messages.map((message, index) => (
-        <Message from={message.role} key={message.id}>
-          <MessageContent>
-            <MessageResponse rehypePlugins={rehypePluginsByMessage[index]}>
-              {message.content}
-            </MessageResponse>
-          </MessageContent>
-        </Message>
-      ))}
+      {messages.map((message, index) => {
+        const rehypePlugins = rehypePluginsByMessage.at(index);
+        return (
+          <Message from={message.role} key={message.id}>
+            <MessageContent>
+              <MessageResponse
+                {...(rehypePlugins === undefined ? {} : { rehypePlugins })}
+              >
+                {message.content}
+              </MessageResponse>
+            </MessageContent>
+          </Message>
+        );
+      })}
     </div>
   );
 };

--- a/apps/web/src/components/search-chat-preview.tsx
+++ b/apps/web/src/components/search-chat-preview.tsx
@@ -40,10 +40,12 @@ export const SearchChatPreview = ({
   const [matchSummary, setMatchSummary] =
     useState<SearchMatchSummary>(EMPTY_MATCH_SUMMARY);
   const searchTextKey = searchTextQueryKey(searchText);
-  const rehypePlugins = useMemo<PluggableList>(
-    () => [[rehypeSearchMatches, { searchText }]],
-    [searchText],
-  );
+  const rehypePluginsByMessage = useMemo<PluggableList[]>(() => {
+    const matchBudget = { remaining: MAX_SEARCH_PREVIEW_MATCHES + 1 };
+    return messages.map(() => [
+      [rehypeSearchMatches, { matchBudget, searchText }],
+    ]);
+  }, [messages, searchText]);
 
   useExternalSyncEffect(() => {
     setActiveIndex(0);
@@ -72,7 +74,7 @@ export const SearchChatPreview = ({
     const observer = new MutationObserver(syncMatchSummary);
     observer.observe(root, { childList: true, subtree: true });
     return () => observer.disconnect();
-  }, [rehypePlugins]);
+  }, [rehypePluginsByMessage]);
 
   useExternalSyncEffect(() => {
     const root = rootRef.current;
@@ -149,10 +151,10 @@ export const SearchChatPreview = ({
           />
         </div>
       )}
-      {messages.map((message) => (
+      {messages.map((message, index) => (
         <Message from={message.role} key={message.id}>
           <MessageContent>
-            <MessageResponse rehypePlugins={rehypePlugins}>
+            <MessageResponse rehypePlugins={rehypePluginsByMessage[index]}>
               {message.content}
             </MessageResponse>
           </MessageContent>

--- a/apps/web/src/components/search-chat-preview.tsx
+++ b/apps/web/src/components/search-chat-preview.tsx
@@ -1,0 +1,155 @@
+import { useCallback, useMemo, useRef, useState } from "react";
+
+import type { PluggableList } from "unified";
+
+import {
+  Message,
+  MessageContent,
+  MessageResponse,
+} from "@/components/ai-elements/message";
+import { rehypeSearchMatches } from "@/components/chat/rehype-search-matches";
+import { SearchMatchControls } from "@/components/search-match-controls";
+import { useExternalSyncEffect } from "@/hooks/use-effect";
+import {
+  getAdjacentSearchMatchIndex,
+  getCenteredSearchMatchScrollTop,
+  MAX_SEARCH_PREVIEW_MATCHES,
+  type SearchMatchSummary,
+} from "@/lib/search-match-navigation";
+import type { SearchPreviewChatMessage } from "@/lib/search.logic";
+
+type SearchChatPreviewProps = {
+  messages: SearchPreviewChatMessage[];
+  searchText: string;
+};
+
+const EMPTY_MATCH_SUMMARY: SearchMatchSummary = {
+  count: 0,
+  truncated: false,
+};
+
+export const SearchChatPreview = ({
+  messages,
+  searchText,
+}: SearchChatPreviewProps) => {
+  const rootRef = useRef<HTMLDivElement>(null);
+  const lastScrolledMatchRef = useRef<Element | null>(null);
+  const [activeIndex, setActiveIndex] = useState(0);
+  const [matchSummary, setMatchSummary] =
+    useState<SearchMatchSummary>(EMPTY_MATCH_SUMMARY);
+  const rehypePlugins = useMemo<PluggableList>(
+    () => [[rehypeSearchMatches, { searchText }]],
+    [searchText],
+  );
+
+  useExternalSyncEffect(() => {
+    const root = rootRef.current;
+    if (!root) {
+      return undefined;
+    }
+
+    const syncMatchSummary = () => {
+      const total = root.querySelectorAll("[data-search-match]").length;
+      const next = {
+        count: Math.min(total, MAX_SEARCH_PREVIEW_MATCHES),
+        truncated: total > MAX_SEARCH_PREVIEW_MATCHES,
+      };
+      setMatchSummary((current) =>
+        current.count === next.count && current.truncated === next.truncated
+          ? current
+          : next,
+      );
+    };
+    syncMatchSummary();
+    const observer = new MutationObserver(syncMatchSummary);
+    observer.observe(root, { childList: true, subtree: true });
+    return () => observer.disconnect();
+  }, [rehypePlugins]);
+
+  useExternalSyncEffect(() => {
+    const root = rootRef.current;
+    if (!root) {
+      return;
+    }
+    const matches = [
+      ...root.querySelectorAll<HTMLElement>("[data-search-match]"),
+    ].slice(0, MAX_SEARCH_PREVIEW_MATCHES);
+    const clampedIndex =
+      matches.length === 0 ? 0 : Math.min(activeIndex, matches.length - 1);
+    if (clampedIndex !== activeIndex) {
+      setActiveIndex(clampedIndex);
+      return;
+    }
+
+    for (const [index, match] of matches.entries()) {
+      if (index === clampedIndex) {
+        match.dataset.active = "true";
+      } else {
+        delete match.dataset.active;
+      }
+    }
+    const activeMatch = matches.at(clampedIndex);
+    if (!activeMatch || lastScrolledMatchRef.current === activeMatch) {
+      return;
+    }
+    const scrollArea = activeMatch.closest<HTMLElement>(
+      '[data-slot="search-preview-scroll-area"]',
+    );
+    if (!scrollArea) {
+      return;
+    }
+    const containerRect = scrollArea.getBoundingClientRect();
+    const matchRect = activeMatch.getBoundingClientRect();
+    scrollArea.scrollTo({
+      top: getCenteredSearchMatchScrollTop({
+        containerHeight: containerRect.height,
+        containerTop: containerRect.top,
+        currentScrollTop: scrollArea.scrollTop,
+        matchHeight: matchRect.height,
+        matchTop: matchRect.top,
+      }),
+    });
+    lastScrolledMatchRef.current = activeMatch;
+  }, [activeIndex, matchSummary.count]);
+
+  const navigate = useCallback(
+    (direction: "next" | "previous") => {
+      setActiveIndex((current) =>
+        getAdjacentSearchMatchIndex({
+          activeIndex: current,
+          direction,
+          matchCount: matchSummary.count,
+        }),
+      );
+    },
+    [matchSummary.count],
+  );
+
+  return (
+    <div
+      ref={rootRef}
+      className="[&_[data-search-match]]:bg-highlight/45 [&_[data-search-match][data-active=true]]:bg-highlight/90 space-y-5 [&_[data-search-match]]:text-inherit"
+    >
+      {matchSummary.count > 0 && (
+        <div className="bg-background/90 sticky top-0 z-10 ms-auto flex w-fit rounded-md border p-0.5 shadow-sm backdrop-blur">
+          <SearchMatchControls
+            activeIndex={activeIndex}
+            matchCount={matchSummary.count}
+            onNext={() => navigate("next")}
+            onPrevious={() => navigate("previous")}
+            truncated={matchSummary.truncated}
+          />
+        </div>
+      )}
+      {messages.map((message) => (
+        <Message from={message.role} key={message.id}>
+          <MessageContent>
+            <MessageResponse rehypePlugins={rehypePlugins}>
+              {message.content}
+            </MessageResponse>
+          </MessageContent>
+        </Message>
+      ))}
+    </div>
+  );
+};

--- a/apps/web/src/components/search-dialog.logic.test.ts
+++ b/apps/web/src/components/search-dialog.logic.test.ts
@@ -84,6 +84,7 @@ describe("recent file previews", () => {
       getRecentFilePreviewHit({
         entityId: "entity-1",
         fileFieldId: "field-1",
+        filePropertyId: "property-1",
         mimeType: "application/pdf",
         openedAt: "2026-07-31T05:00:00.000Z",
         title: "Disclosure.pdf",
@@ -94,6 +95,7 @@ describe("recent file previews", () => {
     ).toEqual({
       entityId: "entity-1",
       fileFieldId: "field-1",
+      filePropertyId: "property-1",
       headline: null,
       id: "document:entity-1",
       lastEditedByImage: null,

--- a/apps/web/src/components/search-dialog.logic.test.ts
+++ b/apps/web/src/components/search-dialog.logic.test.ts
@@ -2,7 +2,11 @@ import { describe, expect, test } from "bun:test";
 
 import type { GlobalSearchHit } from "@stll/api/types";
 
-import { getChatHitRoute } from "./search-dialog.logic";
+import {
+  createDialogCloseActionQueue,
+  getChatHitRoute,
+  getRecentFilePreviewHit,
+} from "./search-dialog.logic";
 
 type ChatGlobalSearchHit = Extract<GlobalSearchHit, { type: "chat" }>;
 
@@ -39,6 +43,65 @@ describe("search chat result routing", () => {
     ).toEqual({
       to: "/chat/workspaces/$workspaceId/$threadId",
       params: { workspaceId: "workspace-1", threadId: "thread-workspace" },
+    });
+  });
+});
+
+describe("search dialog close actions", () => {
+  test("runs a queued route action once, only after close completes", () => {
+    const queue = createDialogCloseActionQueue();
+    let runCount = 0;
+
+    queue.schedule(() => {
+      runCount += 1;
+    });
+
+    expect(runCount).toBe(0);
+    queue.complete(false);
+    expect(runCount).toBe(1);
+    queue.complete(false);
+    expect(runCount).toBe(1);
+  });
+
+  test("discards a queued route action if the dialog reopens", () => {
+    const queue = createDialogCloseActionQueue();
+    let runCount = 0;
+
+    queue.schedule(() => {
+      runCount += 1;
+    });
+    queue.complete(true);
+    queue.complete(false);
+
+    expect(runCount).toBe(0);
+  });
+});
+
+describe("recent file previews", () => {
+  test("reuses stored file metadata as a native document search hit", () => {
+    expect(
+      getRecentFilePreviewHit({
+        entityId: "entity-1",
+        fileFieldId: "field-1",
+        mimeType: "application/pdf",
+        openedAt: "2026-07-31T05:00:00.000Z",
+        title: "Disclosure.pdf",
+        workspaceId: "workspace-1",
+        workspaceName: "Disclosure review",
+      }),
+    ).toEqual({
+      entityId: "entity-1",
+      fileFieldId: "field-1",
+      headline: null,
+      id: "document:entity-1",
+      lastEditedByImage: null,
+      lastEditedByName: null,
+      mimeType: "application/pdf",
+      title: "Disclosure.pdf",
+      type: "document",
+      updatedAt: "2026-07-31T05:00:00.000Z",
+      workspaceId: "workspace-1",
+      workspaceName: "Disclosure review",
     });
   });
 });

--- a/apps/web/src/components/search-dialog.logic.test.ts
+++ b/apps/web/src/components/search-dialog.logic.test.ts
@@ -5,6 +5,7 @@ import type { GlobalSearchHit } from "@stll/api/types";
 import {
   createDialogCloseActionQueue,
   getChatHitRoute,
+  getRecentFilePreviewDateVisibility,
   getRecentFilePreviewHit,
 } from "./search-dialog.logic";
 
@@ -86,6 +87,7 @@ describe("recent file previews", () => {
         mimeType: "application/pdf",
         openedAt: "2026-07-31T05:00:00.000Z",
         title: "Disclosure.pdf",
+        updatedAt: "2021-03-15T10:00:00.000Z",
         workspaceId: "workspace-1",
         workspaceName: "Disclosure review",
       }),
@@ -99,9 +101,34 @@ describe("recent file previews", () => {
       mimeType: "application/pdf",
       title: "Disclosure.pdf",
       type: "document",
-      updatedAt: "2026-07-31T05:00:00.000Z",
+      updatedAt: "2021-03-15T10:00:00.000Z",
       workspaceId: "workspace-1",
       workspaceName: "Disclosure review",
     });
+  });
+
+  test("omits dates for legacy recents that only store the open timestamp", () => {
+    expect(
+      getRecentFilePreviewDateVisibility({
+        entityId: "entity-1",
+        openedAt: "2026-07-31T05:00:00.000Z",
+        title: "Disclosure.pdf",
+        workspaceId: "workspace-1",
+        workspaceName: "Disclosure review",
+      }),
+    ).toBe("hide");
+  });
+
+  test("shows the persisted document update timestamp", () => {
+    expect(
+      getRecentFilePreviewDateVisibility({
+        entityId: "entity-1",
+        openedAt: "2026-07-31T05:00:00.000Z",
+        title: "Disclosure.pdf",
+        updatedAt: "2021-03-15T10:00:00.000Z",
+        workspaceId: "workspace-1",
+        workspaceName: "Disclosure review",
+      }),
+    ).toBe("show");
   });
 });

--- a/apps/web/src/components/search-dialog.logic.ts
+++ b/apps/web/src/components/search-dialog.logic.ts
@@ -1,8 +1,9 @@
-import type { EntityGlobalSearchHit, GlobalSearchHit } from "@stll/api/types";
+import type { GlobalSearchHit } from "@stll/api/types";
 
 import type { RecentFile } from "@/lib/search-recents";
 
 type ChatGlobalSearchHit = Extract<GlobalSearchHit, { type: "chat" }>;
+type DocumentGlobalSearchHit = Extract<GlobalSearchHit, { type: "document" }>;
 
 type DialogCloseActionState =
   | { status: "idle" }
@@ -54,7 +55,7 @@ export const getRecentFilePreviewHit = (
     updatedAt: file.openedAt,
     workspaceId: file.workspaceId,
     workspaceName: file.workspaceName,
-  }) satisfies EntityGlobalSearchHit;
+  }) satisfies DocumentGlobalSearchHit;
 
 export type ChatHitRoute =
   | {

--- a/apps/web/src/components/search-dialog.logic.ts
+++ b/apps/web/src/components/search-dialog.logic.ts
@@ -45,6 +45,7 @@ export const getRecentFilePreviewHit = (
   ({
     entityId: file.entityId,
     fileFieldId: resolvedFileFieldId ?? file.fileFieldId ?? null,
+    filePropertyId: file.filePropertyId ?? null,
     headline: null,
     id: `document:${file.entityId}`,
     lastEditedByImage: null,

--- a/apps/web/src/components/search-dialog.logic.ts
+++ b/apps/web/src/components/search-dialog.logic.ts
@@ -3,7 +3,7 @@ import type { GlobalSearchHit } from "@stll/api/types";
 import type { RecentFile } from "@/lib/search-recents";
 
 type ChatGlobalSearchHit = Extract<GlobalSearchHit, { type: "chat" }>;
-type DocumentGlobalSearchHit = Extract<GlobalSearchHit, { type: "document" }>;
+type EntityGlobalSearchHit = Extract<GlobalSearchHit, { entityId: string }>;
 
 type DialogCloseActionState =
   | { status: "idle" }
@@ -55,7 +55,7 @@ export const getRecentFilePreviewHit = (
     updatedAt: file.openedAt,
     workspaceId: file.workspaceId,
     workspaceName: file.workspaceName,
-  }) satisfies DocumentGlobalSearchHit;
+  }) satisfies EntityGlobalSearchHit;
 
 export type ChatHitRoute =
   | {

--- a/apps/web/src/components/search-dialog.logic.ts
+++ b/apps/web/src/components/search-dialog.logic.ts
@@ -52,10 +52,14 @@ export const getRecentFilePreviewHit = (
     mimeType: file.mimeType ?? null,
     title: file.title,
     type: "document",
-    updatedAt: file.openedAt,
+    updatedAt: file.updatedAt ?? file.openedAt,
     workspaceId: file.workspaceId,
     workspaceName: file.workspaceName,
   }) satisfies EntityGlobalSearchHit;
+
+export const getRecentFilePreviewDateVisibility = (
+  file: RecentFile,
+): "hide" | "show" => (file.updatedAt ? "show" : "hide");
 
 export type ChatHitRoute =
   | {

--- a/apps/web/src/components/search-dialog.logic.ts
+++ b/apps/web/src/components/search-dialog.logic.ts
@@ -1,6 +1,60 @@
-import type { GlobalSearchHit } from "@stll/api/types";
+import type { EntityGlobalSearchHit, GlobalSearchHit } from "@stll/api/types";
+
+import type { RecentFile } from "@/lib/search-recents";
 
 type ChatGlobalSearchHit = Extract<GlobalSearchHit, { type: "chat" }>;
+
+type DialogCloseActionState =
+  | { status: "idle" }
+  | { status: "pending"; run: () => void };
+
+export const createDialogCloseActionQueue = () => {
+  let state: DialogCloseActionState = { status: "idle" };
+
+  const cancel = () => {
+    state = { status: "idle" };
+  };
+
+  const complete = (open: boolean) => {
+    if (open) {
+      cancel();
+      return;
+    }
+
+    if (state.status === "idle") {
+      return;
+    }
+
+    const { run } = state;
+    state = { status: "idle" };
+    run();
+  };
+
+  const schedule = (run: () => void) => {
+    state = { status: "pending", run };
+  };
+
+  return { cancel, complete, schedule };
+};
+
+export const getRecentFilePreviewHit = (
+  file: RecentFile,
+  resolvedFileFieldId?: string | null,
+) =>
+  ({
+    entityId: file.entityId,
+    fileFieldId: resolvedFileFieldId ?? file.fileFieldId ?? null,
+    headline: null,
+    id: `document:${file.entityId}`,
+    lastEditedByImage: null,
+    lastEditedByName: null,
+    mimeType: file.mimeType ?? null,
+    title: file.title,
+    type: "document",
+    updatedAt: file.openedAt,
+    workspaceId: file.workspaceId,
+    workspaceName: file.workspaceName,
+  }) satisfies EntityGlobalSearchHit;
 
 export type ChatHitRoute =
   | {

--- a/apps/web/src/components/search-dialog.tsx
+++ b/apps/web/src/components/search-dialog.tsx
@@ -687,12 +687,12 @@ export const SearchDialog = ({
       },
       {
         onSuccess: (thread) => {
-          navigateAfterClose(() =>
-            navigate({
+          navigateAfterClose(async () => {
+            await navigate({
               to: "/chat/$threadId",
               params: { threadId: thread.threadId },
-            }),
-          );
+            });
+          });
         },
         onError: () => {
           stellaToast.add({
@@ -742,12 +742,12 @@ export const SearchDialog = ({
 
   const openRecentFile = (file: RecentFile) => {
     setRecentFiles(recordRecentFile(file, searchRecentsScope));
-    navigateAfterClose(() =>
-      navigate({
+    navigateAfterClose(async () => {
+      await navigate({
         to: "/workspaces/$workspaceId/entities/$entityId",
         params: { workspaceId: file.workspaceId, entityId: file.entityId },
-      }),
-    );
+      });
+    });
   };
 
   const toggleTypeFilter = (type: GlobalSearchResultType) => {
@@ -799,12 +799,12 @@ export const SearchDialog = ({
     }
 
     if (hit.type === "contact") {
-      navigateAfterClose(() =>
-        navigate({
+      navigateAfterClose(async () => {
+        await navigate({
           to: "/contacts/$contactId",
           params: { contactId: hit.contactId },
-        }),
-      );
+        });
+      });
       return;
     }
 
@@ -820,8 +820,8 @@ export const SearchDialog = ({
 
       const slug =
         "slug" in hit && typeof hit.slug === "string" ? hit.slug : null;
-      navigateAfterClose(() =>
-        navigate({
+      navigateAfterClose(async () => {
+        await navigate({
           to: "/law/$country/cases/$court/$slug",
           params: createCaseLawDecisionRouteParams({
             caseNumber: hit.caseNumber,
@@ -834,23 +834,25 @@ export const SearchDialog = ({
               q: getSearchHighlightText(hit.headline, ""),
             }),
           },
-        }),
-      );
+        });
+      });
       return;
     }
 
     if (hit.type === "matter") {
-      navigateAfterClose(() =>
-        navigate({
+      navigateAfterClose(async () => {
+        await navigate({
           to: "/workspaces/$workspaceId",
           params: { workspaceId: hit.workspaceId },
-        }),
-      );
+        });
+      });
       return;
     }
 
     if (hit.type === "chat") {
-      navigateAfterClose(() => navigate(getChatHitRoute(hit)));
+      navigateAfterClose(async () => {
+        await navigate(getChatHitRoute(hit));
+      });
       return;
     }
 
@@ -870,12 +872,12 @@ export const SearchDialog = ({
       );
     }
 
-    navigateAfterClose(() =>
-      navigate({
+    navigateAfterClose(async () => {
+      await navigate({
         to: "/workspaces/$workspaceId/entities/$entityId",
         params: { workspaceId: hit.workspaceId, entityId: hit.entityId },
-      }),
-    );
+      });
+    });
   };
 
   const openSearchResult = (hit: GlobalSearchHit): void => {

--- a/apps/web/src/components/search-dialog.tsx
+++ b/apps/web/src/components/search-dialog.tsx
@@ -63,6 +63,7 @@ import {
 import {
   createDialogCloseActionQueue,
   getChatHitRoute,
+  getRecentFilePreviewDateVisibility,
   getRecentFilePreviewHit,
 } from "@/components/search-dialog.logic";
 import {
@@ -869,6 +870,7 @@ export const SearchDialog = ({
             title: hit.title || hit.id,
             workspaceId: hit.workspaceId,
             workspaceName: hit.workspaceName,
+            updatedAt: hit.updatedAt,
           },
           searchRecentsScope,
         ),
@@ -1415,6 +1417,7 @@ export const SearchDialog = ({
 };
 
 type SearchPreviewPanelProps = {
+  dateVisibility?: "hide" | "show" | undefined;
   hit: GlobalSearchHit;
   organizationId: string;
   query: string;
@@ -1471,6 +1474,7 @@ const RecentFilePreviewPanel = ({
 
   return (
     <SearchPreviewPanel
+      dateVisibility={getRecentFilePreviewDateVisibility(file)}
       hit={hit}
       onOpen={onOpen}
       organizationId={organizationId}
@@ -1481,6 +1485,7 @@ const RecentFilePreviewPanel = ({
 };
 
 const SearchPreviewPanel = ({
+  dateVisibility = "show",
   hit,
   organizationId,
   query,
@@ -1499,6 +1504,7 @@ const SearchPreviewPanel = ({
         {t("common.preview")}
       </h2>
       <SearchPreviewContent
+        dateVisibility={dateVisibility}
         hit={hit}
         key={`${hit.type}:${hit.id}:${hit.updatedAt}:${normalizeSearchQuery(query)}`}
         onOpen={onOpen}
@@ -1511,6 +1517,7 @@ const SearchPreviewPanel = ({
 };
 
 type SearchPreviewContentProps = {
+  dateVisibility: "hide" | "show";
   hit: GlobalSearchHit;
   organizationId: string;
   query: string;
@@ -1519,6 +1526,7 @@ type SearchPreviewContentProps = {
 };
 
 const SearchPreviewContent = ({
+  dateVisibility,
   hit,
   organizationId,
   query,
@@ -1531,7 +1539,8 @@ const SearchPreviewContent = ({
     hit.type === "contact" || hit.type === "case-law"
       ? null
       : hit.workspaceName;
-  const previewDate = getSearchPreviewDate(hit);
+  const previewDate =
+    dateVisibility === "show" ? getSearchPreviewDate(hit) : null;
   const formattedPreviewDate = previewDate
     ? format.dateTime(new Date(previewDate.value), {
         month: "short",

--- a/apps/web/src/components/search-dialog.tsx
+++ b/apps/web/src/components/search-dialog.tsx
@@ -1,4 +1,12 @@
-import { useCallback, useId, useMemo, useRef, useState } from "react";
+import {
+  lazy,
+  Suspense,
+  useCallback,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 
 import type { UseMutationResult } from "@tanstack/react-query";
 import { useInfiniteQuery, useMutation, useQuery } from "@tanstack/react-query";
@@ -52,7 +60,11 @@ import {
   toSearchFilters,
   type SavedSearchCriteria,
 } from "@/components/saved-searches.logic";
-import { getChatHitRoute } from "@/components/search-dialog.logic";
+import {
+  createDialogCloseActionQueue,
+  getChatHitRoute,
+  getRecentFilePreviewHit,
+} from "@/components/search-dialog.logic";
 import {
   canShowSearchSummary,
   clearTime,
@@ -83,12 +95,14 @@ import { useAnalytics } from "@/lib/analytics/provider";
 import { api } from "@/lib/api";
 import { useAuthenticatedUser } from "@/lib/authenticated-user-context";
 import { createCaseLawDecisionRouteParams } from "@/lib/case-law-route";
+import { DOCX_MIME, PDF_MIME } from "@/lib/consts";
 import { detached } from "@/lib/detached";
 import { unwrapEden } from "@/lib/errors/api";
 import { toSafeId } from "@/lib/safe-id";
 import {
   searchFacetOptions,
   hasSearchQueryOrSelectiveFilter,
+  recentFilePreviewFieldOptions,
   searchInfiniteOptions,
   searchPreviewOptions,
   TIME_PRESETS,
@@ -110,14 +124,16 @@ import type {
   SearchRecentsScope,
 } from "@/lib/search-recents";
 import {
+  getNativeSearchDocumentPreviewTarget,
+  getSearchHighlightText,
   getSearchPreviewRenderContent,
   getSearchPreviewDate,
   getSearchPreviewTarget,
   normalizeSearchQuery,
   selectAuthorizedSearchPreviewData,
+  selectDisplayedSearchPreviewHit,
   selectSearchPreviewHit,
   shouldShowSearchPreview,
-  stripSearchMarkup,
 } from "@/lib/search.logic";
 import { DocumentIcon } from "@/routes/_protected.workspaces/$workspaceId/-components/document-icon";
 
@@ -145,6 +161,20 @@ const VIRTUAL_HIT_ESTIMATE_PX = 76;
 const VIRTUAL_HIT_OVERSCAN = 6;
 const SEARCH_PREVIEW_CONTENT_CLASS_NAME =
   "text-foreground/90 [&_mark]:bg-highlight [&_mark]:text-highlight-foreground text-sm leading-6 whitespace-pre-wrap [&_mark]:font-medium";
+const SEARCH_PREVIEW_COLUMN_CLASS_NAME =
+  "hidden min-h-0 w-[min(44%,32rem)] min-w-72 shrink-0 flex-col overflow-hidden border-s md:flex";
+
+const NativeDocumentPreview = lazy(async () => {
+  const { SearchDocumentPreview } =
+    await import("@/components/search-document-preview");
+  return { default: SearchDocumentPreview };
+});
+
+const ChatPreview = lazy(async () => {
+  const { SearchChatPreview } =
+    await import("@/components/search-chat-preview");
+  return { default: SearchChatPreview };
+});
 
 const KIND_ICONS = {
   contact: UserIcon,
@@ -223,15 +253,6 @@ const isAvailableSearchKind = (
   includePublicLaw: boolean,
 ): boolean => type !== "case-law" || includePublicLaw;
 
-const extractHighlightedText = (headline: string): string => {
-  const start = headline.indexOf("<mark>");
-  const end = headline.indexOf("</mark>", start);
-  if (start === -1 || end === -1 || end <= start) {
-    return stripSearchMarkup(headline);
-  }
-  return stripSearchMarkup(headline.slice(start + "<mark>".length, end));
-};
-
 const formatMimeTypeLabel = (mimeType: string): string => {
   if (mimeType === "application/pdf") {
     return "PDF";
@@ -308,6 +329,7 @@ export const SearchDialog = ({
   const user = useAuthenticatedUser();
   const isMobile = useIsMobile();
   const publicLawPreviewEnabled = usePublicLawPreviewEnabled();
+  const [closeActionQueue] = useState(createDialogCloseActionQueue);
   const searchRecentsScope = useMemo(
     (): SearchRecentsScope => ({
       organizationId: user.activeOrganizationId,
@@ -324,6 +346,9 @@ export const SearchDialog = ({
   const [previewEnabled, setPreviewEnabled] = useState(true);
   const [recentSearches, setRecentSearches] = useState<RecentSearch[]>([]);
   const [recentFiles, setRecentFiles] = useState<RecentFile[]>([]);
+  const [recentPreviewFile, setRecentPreviewFile] = useState<RecentFile | null>(
+    null,
+  );
   const [filters, setFilters] = useState<SearchFilters>(() =>
     initialSearchFilters(initialWorkspaceId),
   );
@@ -430,6 +455,12 @@ export const SearchDialog = ({
     isPlaceholderData,
   });
   const showPreview = shouldShowSearchPreview({ isMobile, previewEnabled });
+  const displayedPreviewHit = selectDisplayedSearchPreviewHit({
+    hit: previewHit,
+    showPreview,
+  });
+  const displayedRecentFile =
+    showPreview && !hasVisibleSearch ? recentPreviewFile : null;
 
   // Counts and facets are computed only on the first page (see backend);
   // ignore them entirely while the query is empty so a cleared input
@@ -585,6 +616,7 @@ export const SearchDialog = ({
     debouncedSetQuery.cancel();
     setQuery("");
     setDebouncedQuery("");
+    setRecentPreviewFile(null);
     summarizeSearchMutation.reset();
   };
 
@@ -615,6 +647,22 @@ export const SearchDialog = ({
     });
   };
 
+  const navigateAfterClose = (navigateToTarget: () => Promise<unknown>) => {
+    closeActionQueue.schedule(() => {
+      detached(
+        navigateToTarget().catch((error: unknown) => {
+          analytics.captureError(error);
+          stellaToast.add({
+            title: t("common.somethingWentWrong"),
+            type: "error",
+          });
+        }),
+        "SearchDialog.navigateAfterClose",
+      );
+    });
+    onOpenChange(false);
+  };
+
   const handleOpenSummaryChat = () => {
     const trimmedQuery = searchQuery.trim();
     const summaryData = summarizeSearchMutation.data;
@@ -639,13 +687,11 @@ export const SearchDialog = ({
       },
       {
         onSuccess: (thread) => {
-          onOpenChange(false);
-          detached(
+          navigateAfterClose(() =>
             navigate({
               to: "/chat/$threadId",
               params: { threadId: thread.threadId },
             }),
-            "onSuccess",
           );
         },
         onError: () => {
@@ -687,19 +733,21 @@ export const SearchDialog = ({
   };
 
   const applyRecentSearch = (recent: RecentSearch) => {
+    setRecentPreviewFile(null);
     setQuery(recent.query);
     setDebouncedQuery(recent.query);
     summarizeSearchMutation.reset();
     setRecentSearches(recordRecentSearch(recent.query, searchRecentsScope));
   };
 
-  const openRecentFile = async (file: RecentFile) => {
-    onOpenChange(false);
+  const openRecentFile = (file: RecentFile) => {
     setRecentFiles(recordRecentFile(file, searchRecentsScope));
-    await navigate({
-      to: "/workspaces/$workspaceId/entities/$entityId",
-      params: { workspaceId: file.workspaceId, entityId: file.entityId },
-    });
+    navigateAfterClose(() =>
+      navigate({
+        to: "/workspaces/$workspaceId/entities/$entityId",
+        params: { workspaceId: file.workspaceId, entityId: file.entityId },
+      }),
+    );
   };
 
   const toggleTypeFilter = (type: GlobalSearchResultType) => {
@@ -745,22 +793,24 @@ export const SearchDialog = ({
     }));
   };
 
-  const handleResultClick = async (hit: GlobalSearchHit) => {
+  const handleResultClick = (hit: GlobalSearchHit) => {
     if (query.trim()) {
       setRecentSearches(recordRecentSearch(query, searchRecentsScope));
     }
 
-    onOpenChange(false);
     if (hit.type === "contact") {
-      await navigate({
-        to: "/contacts/$contactId",
-        params: { contactId: hit.contactId },
-      });
+      navigateAfterClose(() =>
+        navigate({
+          to: "/contacts/$contactId",
+          params: { contactId: hit.contactId },
+        }),
+      );
       return;
     }
 
     if (hit.type === "case-law") {
       if (!isPublicLawPreviewEnabled()) {
+        onOpenChange(false);
         stellaToast.add({
           title: t("common.comingSoon"),
           type: "neutral",
@@ -770,33 +820,37 @@ export const SearchDialog = ({
 
       const slug =
         "slug" in hit && typeof hit.slug === "string" ? hit.slug : null;
-      await navigate({
-        to: "/law/$country/cases/$court/$slug",
-        params: createCaseLawDecisionRouteParams({
-          caseNumber: hit.caseNumber,
-          country: hit.country,
-          court: hit.court,
-          slug,
-        }),
-        search: {
-          ...(hit.headline && {
-            q: extractHighlightedText(hit.headline),
+      navigateAfterClose(() =>
+        navigate({
+          to: "/law/$country/cases/$court/$slug",
+          params: createCaseLawDecisionRouteParams({
+            caseNumber: hit.caseNumber,
+            country: hit.country,
+            court: hit.court,
+            slug,
           }),
-        },
-      });
+          search: {
+            ...(hit.headline && {
+              q: getSearchHighlightText(hit.headline, ""),
+            }),
+          },
+        }),
+      );
       return;
     }
 
     if (hit.type === "matter") {
-      await navigate({
-        to: "/workspaces/$workspaceId",
-        params: { workspaceId: hit.workspaceId },
-      });
+      navigateAfterClose(() =>
+        navigate({
+          to: "/workspaces/$workspaceId",
+          params: { workspaceId: hit.workspaceId },
+        }),
+      );
       return;
     }
 
     if (hit.type === "chat") {
-      await navigate(getChatHitRoute(hit));
+      navigateAfterClose(() => navigate(getChatHitRoute(hit)));
       return;
     }
 
@@ -805,6 +859,7 @@ export const SearchDialog = ({
         recordRecentFile(
           {
             entityId: hit.entityId,
+            fileFieldId: hit.fileFieldId,
             mimeType: hit.mimeType,
             title: hit.title || hit.id,
             workspaceId: hit.workspaceId,
@@ -815,17 +870,16 @@ export const SearchDialog = ({
       );
     }
 
-    await navigate({
-      to: "/workspaces/$workspaceId/entities/$entityId",
-      params: { workspaceId: hit.workspaceId, entityId: hit.entityId },
-    });
+    navigateAfterClose(() =>
+      navigate({
+        to: "/workspaces/$workspaceId/entities/$entityId",
+        params: { workspaceId: hit.workspaceId, entityId: hit.entityId },
+      }),
+    );
   };
 
   const openSearchResult = (hit: GlobalSearchHit): void => {
-    handleResultClick(hit).catch((error: unknown) => {
-      analytics.captureError(error);
-      stellaToast.add({ title: t("common.somethingWentWrong"), type: "error" });
-    });
+    handleResultClick(hit);
   };
 
   const hasResults = allHits.length > 0;
@@ -894,6 +948,7 @@ export const SearchDialog = ({
   const applySavedSearch = (criteria: SavedSearchCriteria) => {
     const savedFilters = toSearchFilters(criteria);
     debouncedSetQuery.cancel();
+    setRecentPreviewFile(null);
     setQuery(criteria.query);
     setDebouncedQuery(criteria.query);
     setFilters({
@@ -910,7 +965,13 @@ export const SearchDialog = ({
 
   return (
     <CommandDialog
+      onOpenChangeComplete={(nextOpen) => {
+        closeActionQueue.complete(nextOpen);
+      }}
       onOpenChange={(nextOpen, eventDetails) => {
+        if (nextOpen) {
+          closeActionQueue.cancel();
+        }
         if (
           !nextOpen &&
           eventDetails.reason === "escape-key" &&
@@ -925,18 +986,20 @@ export const SearchDialog = ({
       open={open}
     >
       <CommandDialogPopup
+        backdropClassName="z-[100]"
         className={cn(
-          "flex h-[calc(100dvh-32px)] w-[calc(100vw-16px)] max-w-none flex-col overflow-hidden sm:h-[min(720px,calc(100dvh-96px))]",
+          "flex h-[calc(100dvh-32px)] w-[calc(100vw-16px)] max-w-none flex-col overflow-clip sm:h-[min(720px,calc(100dvh-96px))]",
           showPreview
             ? "sm:w-[min(1120px,calc(100vw-32px))] xl:w-[min(1280px,calc(100vw-48px))]"
             : "sm:w-[min(960px,calc(100vw-32px))]",
         )}
         showCloseButton={false}
+        viewportClassName="z-[100]"
       >
         <Command
           itemToStringValue={(hit) => hit.title}
           items={commandHits}
-          keepHighlight={false}
+          keepHighlight
           mode="none"
           onItemHighlighted={(_, eventDetails) => {
             if (eventDetails.index < 0) {
@@ -963,6 +1026,7 @@ export const SearchDialog = ({
               return;
             }
             setQuery(value);
+            setRecentPreviewFile(null);
             debouncedSetQuery(value);
             summarizeSearchMutation.reset();
           }}
@@ -1041,7 +1105,7 @@ export const SearchDialog = ({
           </div>
 
           {/* Content area */}
-          <div className="flex min-h-0 flex-1">
+          <div className="flex min-h-0 flex-1 overflow-hidden">
             {/* Facets sidebar — always present so the layout stays stable. */}
             <div
               className={cn(
@@ -1162,7 +1226,9 @@ export const SearchDialog = ({
                   />
                   <SearchRecents
                     onFileClick={openRecentFile}
+                    onFilePreview={setRecentPreviewFile}
                     onSearchClick={applyRecentSearch}
+                    previewedFileId={displayedRecentFile?.entityId ?? null}
                     recentFiles={recentFiles}
                     recentSearches={recentSearches}
                   />
@@ -1312,13 +1378,28 @@ export const SearchDialog = ({
                 </div>
               )}
             </CommandList>
-            {showPreview && (
+            {showPreview && displayedPreviewHit && (
               <SearchPreviewPanel
-                hit={previewHit}
+                hit={displayedPreviewHit}
                 onOpen={openSearchResult}
                 organizationId={searchRecentsScope.organizationId}
                 query={searchQuery}
                 userId={searchRecentsScope.userId}
+              />
+            )}
+            {showPreview && !displayedPreviewHit && displayedRecentFile && (
+              <RecentFilePreviewPanel
+                file={displayedRecentFile}
+                organizationId={searchRecentsScope.organizationId}
+                onOpen={openSearchResult}
+                userId={searchRecentsScope.userId}
+              />
+            )}
+            {showPreview && !displayedPreviewHit && !displayedRecentFile && (
+              <div
+                aria-hidden="true"
+                className={SEARCH_PREVIEW_COLUMN_CLASS_NAME}
+                data-slot="search-preview-placeholder"
               />
             )}
           </div>
@@ -1329,11 +1410,69 @@ export const SearchDialog = ({
 };
 
 type SearchPreviewPanelProps = {
-  hit: GlobalSearchHit | null;
+  hit: GlobalSearchHit;
   organizationId: string;
   query: string;
   userId: string;
   onOpen: (hit: GlobalSearchHit) => void;
+};
+
+type RecentFilePreviewPanelProps = {
+  file: RecentFile;
+  onOpen: (hit: GlobalSearchHit) => void;
+  organizationId: string;
+  userId: string;
+};
+
+const RecentFilePreviewPanel = ({
+  file,
+  onOpen,
+  organizationId,
+  userId,
+}: RecentFilePreviewPanelProps) => {
+  const t = useTranslations();
+  const isNativeDocument =
+    file.mimeType === PDF_MIME || file.mimeType === DOCX_MIME;
+  const needsFieldResolution =
+    isNativeDocument &&
+    (file.fileFieldId === undefined || file.fileFieldId === null);
+  const fieldQuery = useQuery({
+    ...recentFilePreviewFieldOptions({
+      entityId: file.entityId,
+      mimeType: file.mimeType ?? null,
+      organizationId,
+      userId,
+      workspaceId: file.workspaceId,
+    }),
+    enabled: needsFieldResolution,
+  });
+  const resolvedFieldId = file.fileFieldId ?? fieldQuery.data ?? null;
+
+  if (needsFieldResolution && resolvedFieldId === null) {
+    return (
+      <aside className={SEARCH_PREVIEW_COLUMN_CLASS_NAME}>
+        {fieldQuery.isPending ? (
+          <NativeDocumentPreviewSkeleton />
+        ) : (
+          <div className="text-muted-foreground flex flex-1 items-center justify-center px-5 text-center text-sm">
+            {t("common.somethingWentWrong")}
+          </div>
+        )}
+      </aside>
+    );
+  }
+
+  const hit = getRecentFilePreviewHit(file, resolvedFieldId);
+
+  return (
+    <SearchPreviewPanel
+      hit={hit}
+      onOpen={onOpen}
+      organizationId={organizationId}
+      query=""
+      userId={userId}
+    />
+  );
 };
 
 const SearchPreviewPanel = ({
@@ -1349,30 +1488,19 @@ const SearchPreviewPanel = ({
   return (
     <aside
       aria-labelledby={headingId}
-      className="hidden w-[min(44%,32rem)] min-w-72 shrink-0 flex-col border-s md:flex"
+      className={SEARCH_PREVIEW_COLUMN_CLASS_NAME}
     >
       <h2 className="sr-only" id={headingId}>
         {t("common.preview")}
       </h2>
-      {hit ? (
-        <SearchPreviewContent
-          hit={hit}
-          key={`${hit.type}:${hit.id}:${hit.updatedAt}:${normalizeSearchQuery(query)}`}
-          onOpen={onOpen}
-          organizationId={organizationId}
-          query={query}
-          userId={userId}
-        />
-      ) : (
-        <>
-          <div className="shrink-0 border-b px-4 py-3 text-sm font-medium">
-            {t("common.preview")}
-          </div>
-          <div className="text-muted-foreground flex flex-1 items-center justify-center px-5 text-center text-sm">
-            {t("search.emptyState")}
-          </div>
-        </>
-      )}
+      <SearchPreviewContent
+        hit={hit}
+        key={`${hit.type}:${hit.id}:${hit.updatedAt}:${normalizeSearchQuery(query)}`}
+        onOpen={onOpen}
+        organizationId={organizationId}
+        query={query}
+        userId={userId}
+      />
     </aside>
   );
 };
@@ -1394,26 +1522,6 @@ const SearchPreviewContent = ({
 }: SearchPreviewContentProps) => {
   const t = useTranslations();
   const format = useFormatter();
-  const target = getSearchPreviewTarget(hit);
-  const { data, isError, isFetchedAfterMount, isFetching, refetch } = useQuery(
-    searchPreviewOptions({
-      organizationId,
-      query,
-      resultId: target.resultId,
-      type: target.type,
-      updatedAt: hit.updatedAt,
-      userId,
-    }),
-  );
-  const authorizedData = selectAuthorizedSearchPreviewData({
-    data,
-    isError,
-    isFetchedAfterMount,
-    isFetching,
-  });
-  const renderContent = authorizedData
-    ? getSearchPreviewRenderContent(authorizedData)
-    : null;
   const location =
     hit.type === "contact" || hit.type === "case-law"
       ? null
@@ -1464,55 +1572,143 @@ const SearchPreviewContent = ({
           </Button>
         </div>
       </div>
-      <div className="min-h-0 flex-1 overflow-y-auto px-5 py-5">
-        {!isError && authorizedData === undefined && (
-          <div className="space-y-3">
-            <Skeleton className="h-4 w-full" />
-            <Skeleton className="h-4 w-11/12" />
-            <Skeleton className="h-4 w-4/5" />
-            <Skeleton className="mt-6 h-4 w-full" />
-            <Skeleton className="h-4 w-3/4" />
-          </div>
-        )}
-        {isError && (
-          <div className="flex min-h-48 flex-col items-center justify-center gap-3">
-            <p className="text-muted-foreground text-sm">
-              {t("common.somethingWentWrong")}
-            </p>
-            <Button
-              disabled={isFetching}
-              onClick={() => {
-                detached(refetch(), "SearchPreviewContent");
-              }}
-              size="sm"
-              variant="outline"
-            >
-              {t("common.retry")}
-            </Button>
-          </div>
-        )}
-        {renderContent?.type === "plain-text" && (
-          <div
-            className={SEARCH_PREVIEW_CONTENT_CLASS_NAME}
-            dir={contentDir(renderContent.directionText)}
-          >
-            {renderContent.text}
-          </div>
-        )}
-        {renderContent?.type === "highlighted-html" && (
-          <div
-            className={SEARCH_PREVIEW_CONTENT_CLASS_NAME}
-            dir={contentDir(renderContent.directionText)}
-            dangerouslySetInnerHTML={{
-              // safe-html: preview content is server-escaped before the trusted <mark> tags are inserted
-              __html: renderContent.html,
-            }}
-          />
-        )}
-      </div>
+      <SearchPreviewBody
+        hit={hit}
+        organizationId={organizationId}
+        query={query}
+        userId={userId}
+      />
     </>
   );
 };
+
+type SearchPreviewBodyProps = Pick<
+  SearchPreviewContentProps,
+  "hit" | "organizationId" | "query" | "userId"
+>;
+
+const SearchPreviewBody = (props: SearchPreviewBodyProps) => {
+  const { hit } = props;
+  const nativePreviewTarget = getNativeSearchDocumentPreviewTarget(hit);
+  if (nativePreviewTarget) {
+    return (
+      <div className="min-h-0 flex-1 overflow-hidden">
+        <Suspense fallback={<NativeDocumentPreviewSkeleton />}>
+          <NativeDocumentPreview
+            fallback={<NativeDocumentPreviewSkeleton />}
+            searchText={getSearchHighlightText(hit.headline, props.query)}
+            target={nativePreviewTarget}
+          />
+        </Suspense>
+      </div>
+    );
+  }
+
+  return <SearchTextPreview {...props} />;
+};
+
+const NativeDocumentPreviewSkeleton = () => (
+  <div className="bg-muted/40 flex h-full justify-center overflow-hidden p-3">
+    <Skeleton className="h-[calc(100%+8rem)] w-full max-w-sm rounded-sm" />
+  </div>
+);
+
+const SearchTextPreview = ({
+  hit,
+  organizationId,
+  query,
+  userId,
+}: SearchPreviewBodyProps) => {
+  const t = useTranslations();
+  const target = getSearchPreviewTarget(hit);
+  const { data, isError, isFetchedAfterMount, isFetching, refetch } = useQuery(
+    searchPreviewOptions({
+      organizationId,
+      query,
+      resultId: target.resultId,
+      type: target.type,
+      updatedAt: hit.updatedAt,
+      userId,
+    }),
+  );
+  const authorizedData = selectAuthorizedSearchPreviewData({
+    data,
+    isError,
+    isFetchedAfterMount,
+    isFetching,
+  });
+  const renderContent = authorizedData
+    ? getSearchPreviewRenderContent(authorizedData)
+    : null;
+
+  return (
+    <div
+      className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-5 py-5"
+      data-slot="search-preview-scroll-area"
+    >
+      {!isError && authorizedData === undefined && (
+        <div className="space-y-3">
+          <Skeleton className="h-4 w-full" />
+          <Skeleton className="h-4 w-11/12" />
+          <Skeleton className="h-4 w-4/5" />
+          <Skeleton className="mt-6 h-4 w-full" />
+          <Skeleton className="h-4 w-3/4" />
+        </div>
+      )}
+      {isError && (
+        <div className="flex min-h-48 flex-col items-center justify-center gap-3">
+          <p className="text-muted-foreground text-sm">
+            {t("common.somethingWentWrong")}
+          </p>
+          <Button
+            disabled={isFetching}
+            onClick={() => {
+              detached(refetch(), "SearchTextPreview");
+            }}
+            size="sm"
+            variant="outline"
+          >
+            {t("common.retry")}
+          </Button>
+        </div>
+      )}
+      {renderContent?.type === "plain-text" && (
+        <div
+          className={SEARCH_PREVIEW_CONTENT_CLASS_NAME}
+          dir={contentDir(renderContent.directionText)}
+        >
+          {renderContent.text}
+        </div>
+      )}
+      {renderContent?.type === "chat-messages" && (
+        <Suspense fallback={<SearchTextPreviewSkeleton />}>
+          <ChatPreview
+            messages={renderContent.messages}
+            searchText={getSearchHighlightText(hit.headline, query)}
+          />
+        </Suspense>
+      )}
+      {renderContent?.type === "highlighted-html" && (
+        <div
+          className={SEARCH_PREVIEW_CONTENT_CLASS_NAME}
+          dir={contentDir(renderContent.directionText)}
+          dangerouslySetInnerHTML={{
+            // safe-html: preview content is server-escaped before the trusted <mark> tags are inserted
+            __html: renderContent.html,
+          }}
+        />
+      )}
+    </div>
+  );
+};
+
+const SearchTextPreviewSkeleton = () => (
+  <div className="space-y-3">
+    <Skeleton className="h-12 w-4/5" />
+    <Skeleton className="ms-auto h-16 w-3/4" />
+    <Skeleton className="h-20 w-11/12" />
+  </div>
+);
 
 type SearchSummaryItemProps = {
   summarizeMutation: UseMutationResult<
@@ -1676,7 +1872,9 @@ type SearchRecentsProps = {
   recentSearches: RecentSearch[];
   recentFiles: RecentFile[];
   onSearchClick: (recent: RecentSearch) => void;
-  onFileClick: (file: RecentFile) => Promise<void>;
+  onFileClick: (file: RecentFile) => void;
+  onFilePreview: (file: RecentFile) => void;
+  previewedFileId: string | null;
 };
 
 const SearchRecents = ({
@@ -1684,6 +1882,8 @@ const SearchRecents = ({
   recentFiles,
   onSearchClick,
   onFileClick,
+  onFilePreview,
+  previewedFileId,
 }: SearchRecentsProps) => {
   const t = useTranslations();
   const hasRecents = recentSearches.length > 0 || recentFiles.length > 0;
@@ -1731,11 +1931,16 @@ const SearchRecents = ({
             {recentFiles.map((file) => (
               <Button
                 className="h-auto! w-full justify-start gap-2 py-1 text-start text-sm"
+                data-previewing={previewedFileId === file.entityId}
                 key={file.entityId}
+                onFocus={() => onFilePreview(file)}
                 onClick={() => {
-                  detached(onFileClick(file), "SearchRecents");
+                  onFileClick(file);
                 }}
-                variant="ghost"
+                onPointerEnter={() => onFilePreview(file)}
+                variant={
+                  previewedFileId === file.entityId ? "secondary" : "ghost"
+                }
               >
                 {file.mimeType ? (
                   <DocumentIcon

--- a/apps/web/src/components/search-dialog.tsx
+++ b/apps/web/src/components/search-dialog.tsx
@@ -869,6 +869,7 @@ export const SearchDialog = ({
           {
             entityId: hit.entityId,
             fileFieldId: hit.fileFieldId,
+            filePropertyId: hit.filePropertyId,
             mimeType: hit.mimeType,
             title: hit.title || hit.id,
             workspaceId: hit.workspaceId,
@@ -1481,6 +1482,8 @@ const RecentFilePreviewPanel = ({
   const fieldQuery = useQuery({
     ...recentFilePreviewFieldOptions({
       entityId: file.entityId,
+      fileFieldId: file.fileFieldId,
+      filePropertyId: file.filePropertyId,
       mimeType: file.mimeType ?? null,
       organizationId,
       userId,

--- a/apps/web/src/components/search-dialog.tsx
+++ b/apps/web/src/components/search-dialog.tsx
@@ -1593,12 +1593,15 @@ const SearchPreviewBody = (props: SearchPreviewBodyProps) => {
   const { hit } = props;
   const nativePreviewTarget = getNativeSearchDocumentPreviewTarget(hit);
   if (nativePreviewTarget) {
+    const searchText = getSearchHighlightText(hit.headline, props.query);
     return (
       <div className="min-h-0 flex-1 overflow-hidden">
         <Suspense fallback={<NativeDocumentPreviewSkeleton />}>
           <NativeDocumentPreview
             fallback={<NativeDocumentPreviewSkeleton />}
-            searchText={getSearchHighlightText(hit.headline, props.query)}
+            key={`${hit.id}:${searchText}`}
+            noMatchFallback={<SearchTextPreview {...props} />}
+            searchText={searchText}
             target={nativePreviewTarget}
           />
         </Suspense>

--- a/apps/web/src/components/search-dialog.tsx
+++ b/apps/web/src/components/search-dialog.tsx
@@ -1432,18 +1432,44 @@ type RecentFilePreviewPanelProps = {
   userId: string;
 };
 
+type RecentFilePreviewUnavailableProps = {
+  reason: "missing" | "request-error";
+};
+
+const RecentFilePreviewUnavailable = ({
+  reason,
+}: RecentFilePreviewUnavailableProps) => {
+  const t = useTranslations();
+  let message: string;
+  switch (reason) {
+    case "missing":
+      message = t("search.previewUnavailable");
+      break;
+    case "request-error":
+      message = t("common.somethingWentWrong");
+      break;
+    default: {
+      const exhaustive: never = reason;
+      return exhaustive;
+    }
+  }
+  return (
+    <aside className={SEARCH_PREVIEW_COLUMN_CLASS_NAME}>
+      <div className="text-muted-foreground flex flex-1 items-center justify-center px-5 text-center text-sm">
+        {message}
+      </div>
+    </aside>
+  );
+};
+
 const RecentFilePreviewPanel = ({
   file,
   onOpen,
   organizationId,
   userId,
 }: RecentFilePreviewPanelProps) => {
-  const t = useTranslations();
   const isNativeDocument =
     file.mimeType === PDF_MIME || file.mimeType === DOCX_MIME;
-  const needsFieldResolution =
-    isNativeDocument &&
-    (file.fileFieldId === undefined || file.fileFieldId === null);
   const fieldQuery = useQuery({
     ...recentFilePreviewFieldOptions({
       entityId: file.entityId,
@@ -1452,23 +1478,25 @@ const RecentFilePreviewPanel = ({
       userId,
       workspaceId: file.workspaceId,
     }),
-    enabled: needsFieldResolution,
+    enabled: isNativeDocument,
   });
-  const resolvedFieldId = file.fileFieldId ?? fieldQuery.data ?? null;
-
-  if (needsFieldResolution && resolvedFieldId === null) {
+  if (isNativeDocument && fieldQuery.isPending) {
     return (
       <aside className={SEARCH_PREVIEW_COLUMN_CLASS_NAME}>
-        {fieldQuery.isPending ? (
-          <NativeDocumentPreviewSkeleton />
-        ) : (
-          <div className="text-muted-foreground flex flex-1 items-center justify-center px-5 text-center text-sm">
-            {t("common.somethingWentWrong")}
-          </div>
-        )}
+        <NativeDocumentPreviewSkeleton />
       </aside>
     );
   }
+  if (isNativeDocument && fieldQuery.isError) {
+    return <RecentFilePreviewUnavailable reason="request-error" />;
+  }
+  if (isNativeDocument && fieldQuery.data === null) {
+    return <RecentFilePreviewUnavailable reason="missing" />;
+  }
+
+  const resolvedFieldId = isNativeDocument
+    ? (fieldQuery.data ?? null)
+    : (file.fileFieldId ?? null);
 
   const hit = getRecentFilePreviewHit(file, resolvedFieldId);
 
@@ -1954,6 +1982,9 @@ const SearchRecents = ({
           <div className="flex flex-col gap-y-1">
             {recentFiles.map((file) => (
               <Button
+                aria-current={
+                  previewedFileId === file.entityId ? "true" : undefined
+                }
                 className="h-auto! w-full justify-start gap-2 py-1 text-start text-sm"
                 data-previewing={previewedFileId === file.entityId}
                 key={file.entityId}

--- a/apps/web/src/components/search-dialog.tsx
+++ b/apps/web/src/components/search-dialog.tsx
@@ -993,15 +993,14 @@ export const SearchDialog = ({
       open={open}
     >
       <CommandDialogPopup
-        backdropClassName="z-[100]"
         className={cn(
           "flex h-[calc(100dvh-32px)] w-[calc(100vw-16px)] max-w-none flex-col overflow-clip sm:h-[min(720px,calc(100dvh-96px))]",
           showPreview
             ? "sm:w-[min(1120px,calc(100vw-32px))] xl:w-[min(1280px,calc(100vw-48px))]"
             : "sm:w-[min(960px,calc(100vw-32px))]",
         )}
+        layer="search"
         showCloseButton={false}
-        viewportClassName="z-[100]"
       >
         <Command
           itemToStringValue={(hit) => hit.title}
@@ -1073,6 +1072,7 @@ export const SearchDialog = ({
               filters={filters}
               isOpen={open}
               onApply={applySavedSearch}
+              overlayLayer="search-child"
               query={query}
               showList={false}
             />
@@ -1228,6 +1228,7 @@ export const SearchDialog = ({
                     filters={filters}
                     isOpen={open}
                     onApply={applySavedSearch}
+                    overlayLayer="search-child"
                     query={query}
                     showTrigger={false}
                   />
@@ -1398,7 +1399,9 @@ export const SearchDialog = ({
               <RecentFilePreviewPanel
                 file={displayedRecentFile}
                 organizationId={searchRecentsScope.organizationId}
-                onOpen={openSearchResult}
+                onOpen={() => {
+                  openRecentFile(displayedRecentFile);
+                }}
                 userId={searchRecentsScope.userId}
               />
             )}
@@ -1427,7 +1430,7 @@ type SearchPreviewPanelProps = {
 
 type RecentFilePreviewPanelProps = {
   file: RecentFile;
-  onOpen: (hit: GlobalSearchHit) => void;
+  onOpen: () => void;
   organizationId: string;
   userId: string;
 };
@@ -1504,7 +1507,9 @@ const RecentFilePreviewPanel = ({
     <SearchPreviewPanel
       dateVisibility={getRecentFilePreviewDateVisibility(file)}
       hit={hit}
-      onOpen={onOpen}
+      onOpen={() => {
+        onOpen();
+      }}
       organizationId={organizationId}
       query=""
       userId={userId}
@@ -2142,6 +2147,7 @@ const TimeFacetGroup = ({
               {t("search.dateFrom")}
             </p>
             <DatePickerPopover
+              layer="search-child"
               locale={locale}
               onChange={handleFromChange}
               value={customFromValue}
@@ -2153,6 +2159,7 @@ const TimeFacetGroup = ({
               {t("search.dateTo")}
             </p>
             <DatePickerPopover
+              layer="search-child"
               locale={locale}
               onChange={handleToChange}
               value={customToValue}

--- a/apps/web/src/components/search-dialog.tsx
+++ b/apps/web/src/components/search-dialog.tsx
@@ -123,6 +123,7 @@ import type {
   RecentSearch,
   SearchRecentsScope,
 } from "@/lib/search-recents";
+import { searchTextQueryKey } from "@/lib/search-text";
 import {
   getFirstSearchHighlightText,
   getNativeSearchDocumentPreviewTarget,
@@ -1593,15 +1594,18 @@ type SearchPreviewBodyProps = Pick<
 
 const SearchPreviewBody = (props: SearchPreviewBodyProps) => {
   const { hit } = props;
+  const searchText = useMemo(
+    () => getSearchHighlightText(hit.headline, props.query),
+    [hit.headline, props.query],
+  );
   const nativePreviewTarget = getNativeSearchDocumentPreviewTarget(hit);
   if (nativePreviewTarget) {
-    const searchText = getSearchHighlightText(hit.headline, props.query);
     return (
       <div className="min-h-0 flex-1 overflow-hidden">
         <Suspense fallback={<NativeDocumentPreviewSkeleton />}>
           <NativeDocumentPreview
             fallback={<NativeDocumentPreviewSkeleton />}
-            key={`${hit.id}:${searchText}`}
+            key={`${hit.id}:${searchTextQueryKey(searchText)}`}
             noMatchFallback={<SearchTextPreview {...props} />}
             searchText={searchText}
             target={nativePreviewTarget}
@@ -1627,6 +1631,10 @@ const SearchTextPreview = ({
   userId,
 }: SearchPreviewBodyProps) => {
   const t = useTranslations();
+  const searchText = useMemo(
+    () => getSearchHighlightText(hit.headline, query),
+    [hit.headline, query],
+  );
   const target = getSearchPreviewTarget(hit);
   const { data, isError, isFetchedAfterMount, isFetching, refetch } = useQuery(
     searchPreviewOptions({
@@ -1691,7 +1699,7 @@ const SearchTextPreview = ({
         <Suspense fallback={<SearchTextPreviewSkeleton />}>
           <ChatPreview
             messages={renderContent.messages}
-            searchText={getSearchHighlightText(hit.headline, query)}
+            searchText={searchText}
           />
         </Suspense>
       )}

--- a/apps/web/src/components/search-dialog.tsx
+++ b/apps/web/src/components/search-dialog.tsx
@@ -124,6 +124,7 @@ import type {
   SearchRecentsScope,
 } from "@/lib/search-recents";
 import {
+  getFirstSearchHighlightText,
   getNativeSearchDocumentPreviewTarget,
   getSearchHighlightText,
   getSearchPreviewRenderContent,
@@ -503,6 +504,7 @@ export const SearchDialog = ({
   >(null);
   if (recentsSnapshotKey !== lastRecentsSnapshotKey) {
     setLastRecentsSnapshotKey(recentsSnapshotKey);
+    setRecentPreviewFile(null);
     if (recentsSnapshotKey) {
       setRecentSearches(readRecentSearches(searchRecentsScope));
       setRecentFiles(readRecentFiles(searchRecentsScope));
@@ -831,7 +833,7 @@ export const SearchDialog = ({
           }),
           search: {
             ...(hit.headline && {
-              q: getSearchHighlightText(hit.headline, ""),
+              q: getFirstSearchHighlightText(hit.headline, ""),
             }),
           },
         });

--- a/apps/web/src/components/search-dialog.tsx
+++ b/apps/web/src/components/search-dialog.tsx
@@ -451,6 +451,9 @@ export const SearchDialog = ({
     }
     return data.pages.flatMap((page) => page.hits);
   }, [data]);
+  const previewLocatorCandidates =
+    data?.pages.at(0)?.previewLocatorCandidates ??
+    EMPTY_SEARCH_PREVIEW_LOCATOR_CANDIDATES;
   const getHitVirtualKey = (index: number) => allHits.at(index)?.id ?? index;
   const previewHit = selectSearchPreviewHit({
     highlightedHitId,
@@ -1391,6 +1394,7 @@ export const SearchDialog = ({
                 hit={displayedPreviewHit}
                 onOpen={openSearchResult}
                 organizationId={searchRecentsScope.organizationId}
+                previewLocatorCandidates={previewLocatorCandidates}
                 query={searchQuery}
                 userId={searchRecentsScope.userId}
               />
@@ -1423,6 +1427,7 @@ type SearchPreviewPanelProps = {
   dateVisibility?: "hide" | "show" | undefined;
   hit: GlobalSearchHit;
   organizationId: string;
+  previewLocatorCandidates?: readonly string[] | undefined;
   query: string;
   userId: string;
   onOpen: (hit: GlobalSearchHit) => void;
@@ -1521,6 +1526,7 @@ const SearchPreviewPanel = ({
   dateVisibility = "show",
   hit,
   organizationId,
+  previewLocatorCandidates = EMPTY_SEARCH_PREVIEW_LOCATOR_CANDIDATES,
   query,
   userId,
   onOpen,
@@ -1542,6 +1548,7 @@ const SearchPreviewPanel = ({
         key={`${hit.type}:${hit.id}:${hit.updatedAt}:${normalizeSearchQuery(query)}`}
         onOpen={onOpen}
         organizationId={organizationId}
+        previewLocatorCandidates={previewLocatorCandidates}
         query={query}
         userId={userId}
       />
@@ -1553,6 +1560,7 @@ type SearchPreviewContentProps = {
   dateVisibility: "hide" | "show";
   hit: GlobalSearchHit;
   organizationId: string;
+  previewLocatorCandidates: readonly string[];
   query: string;
   userId: string;
   onOpen: (hit: GlobalSearchHit) => void;
@@ -1562,6 +1570,7 @@ const SearchPreviewContent = ({
   dateVisibility,
   hit,
   organizationId,
+  previewLocatorCandidates,
   query,
   userId,
   onOpen,
@@ -1622,6 +1631,7 @@ const SearchPreviewContent = ({
       <SearchPreviewBody
         hit={hit}
         organizationId={organizationId}
+        previewLocatorCandidates={previewLocatorCandidates}
         query={query}
         userId={userId}
       />
@@ -1631,14 +1641,19 @@ const SearchPreviewContent = ({
 
 type SearchPreviewBodyProps = Pick<
   SearchPreviewContentProps,
-  "hit" | "organizationId" | "query" | "userId"
+  "hit" | "organizationId" | "previewLocatorCandidates" | "query" | "userId"
 >;
 
 const SearchPreviewBody = (props: SearchPreviewBodyProps) => {
   const { hit } = props;
   const searchText = useMemo(
-    () => getSearchHighlightText(hit.headline, props.query),
-    [hit.headline, props.query],
+    () =>
+      getSearchHighlightText({
+        headline: hit.headline,
+        previewLocatorCandidates: props.previewLocatorCandidates,
+        query: props.query,
+      }),
+    [hit.headline, props.previewLocatorCandidates, props.query],
   );
   const nativePreviewTarget = getNativeSearchDocumentPreviewTarget(hit);
   if (nativePreviewTarget) {
@@ -1669,13 +1684,19 @@ const NativeDocumentPreviewSkeleton = () => (
 const SearchTextPreview = ({
   hit,
   organizationId,
+  previewLocatorCandidates,
   query,
   userId,
 }: SearchPreviewBodyProps) => {
   const t = useTranslations();
   const searchText = useMemo(
-    () => getSearchHighlightText(hit.headline, query),
-    [hit.headline, query],
+    () =>
+      getSearchHighlightText({
+        headline: hit.headline,
+        previewLocatorCandidates,
+        query,
+      }),
+    [hit.headline, previewLocatorCandidates, query],
   );
   const target = getSearchPreviewTarget(hit);
   const { data, isError, isFetchedAfterMount, isFetching, refetch } = useQuery(
@@ -1897,6 +1918,7 @@ const SummaryBody = ({
         <Tooltip
           content={`${citation.title}\n${citation.reason}`}
           key={`${citation.id}-${start}`}
+          layer="search-child"
           render={
             <button
               className="text-foreground hover:bg-muted mx-0.5 rounded px-1 font-medium"
@@ -2192,6 +2214,7 @@ type FacetBucket = { value: string; label?: string; count: number };
 
 const EMPTY_FACET_BUCKETS: readonly FacetBucket[] = [];
 const EMPTY_SEARCH_HITS: readonly GlobalSearchHit[] = [];
+const EMPTY_SEARCH_PREVIEW_LOCATOR_CANDIDATES: readonly string[] = [];
 
 type FacetBucketListProps = {
   buckets: FacetBucket[];

--- a/apps/web/src/components/search-document-preview.tsx
+++ b/apps/web/src/components/search-document-preview.tsx
@@ -8,6 +8,7 @@ import {
   getAdjacentSearchMatchIndex,
   type SearchMatchSummary,
 } from "@/lib/search-match-navigation";
+import type { SearchTextQuery } from "@/lib/search-text";
 import type {
   NativeSearchDocumentPreviewTarget,
   NativeSearchStatus,
@@ -21,7 +22,7 @@ import {
 type SearchDocumentPreviewProps = {
   fallback: ReactNode;
   noMatchFallback: ReactNode;
-  searchText: string;
+  searchText: SearchTextQuery;
   target: NativeSearchDocumentPreviewTarget;
 };
 

--- a/apps/web/src/components/search-document-preview.tsx
+++ b/apps/web/src/components/search-document-preview.tsx
@@ -1,0 +1,112 @@
+import { useCallback, useState } from "react";
+import type { ReactNode } from "react";
+
+import { MeasuredPdfProvider } from "@/components/inspector/measured-pdf-provider";
+import { usePdfTabZoom } from "@/components/inspector/use-pdf-tab-zoom";
+import { SearchMatchControls } from "@/components/search-match-controls";
+import {
+  getAdjacentSearchMatchIndex,
+  type SearchMatchSummary,
+} from "@/lib/search-match-navigation";
+import type { NativeSearchDocumentPreviewTarget } from "@/lib/search.logic";
+import {
+  PeekPdfControls,
+  PeekPdfViewer,
+} from "@/routes/_protected.workspaces/$workspaceId/-components/peek/peek-pdf-viewer";
+
+type SearchDocumentPreviewProps = {
+  fallback: ReactNode;
+  searchText: string;
+  target: NativeSearchDocumentPreviewTarget;
+};
+
+export const SearchDocumentPreview = ({
+  fallback,
+  searchText,
+  target,
+}: SearchDocumentPreviewProps) => {
+  const [activeSearchMatchIndex, setActiveSearchMatchIndex] = useState(0);
+  const [searchMatchSummary, setSearchMatchSummary] =
+    useState<SearchMatchSummary>({ count: 0, truncated: false });
+  const { handleResetZoom, handleZoom, pdfContentRef, scaleOffsets } =
+    usePdfTabZoom({
+      activeId: target.fieldId,
+      activeTabType: target.filePurpose === "display" ? "pdf" : "docx",
+    });
+  const scaleOffset = scaleOffsets.get(target.fieldId) ?? 0;
+  const handleSearchMatchSummaryChange = useCallback(
+    (summary: SearchMatchSummary) => {
+      setSearchMatchSummary(summary);
+      setActiveSearchMatchIndex((current) =>
+        summary.count === 0 ? 0 : Math.min(current, summary.count - 1),
+      );
+    },
+    [],
+  );
+  const navigateSearchMatches = useCallback(
+    (direction: "next" | "previous") => {
+      setActiveSearchMatchIndex((current) =>
+        getAdjacentSearchMatchIndex({
+          activeIndex: current,
+          direction,
+          matchCount: searchMatchSummary.count,
+        }),
+      );
+    },
+    [searchMatchSummary.count],
+  );
+  const viewer = (
+    <PeekPdfViewer
+      activeSearchMatchIndex={activeSearchMatchIndex}
+      activePropertyId=""
+      entityId={target.entityId}
+      fieldId={target.fieldId}
+      filePurpose={target.filePurpose}
+      interactionMode="preview-only"
+      mimeType={target.mimeType}
+      onSearchMatchSummaryChange={handleSearchMatchSummaryChange}
+      scaleOffset={scaleOffset}
+      searchText={searchText}
+      viewId="all"
+      workspaceId={target.workspaceId}
+    />
+  );
+
+  const content =
+    target.filePurpose === "native-display" ? (
+      viewer
+    ) : (
+      <MeasuredPdfProvider
+        active
+        fallback={{ suspense: fallback }}
+        fieldId={target.fieldId}
+        initialScaleOffset={scaleOffset}
+      >
+        {viewer}
+      </MeasuredPdfProvider>
+    );
+
+  return (
+    <div className="relative h-full min-h-0" ref={pdfContentRef}>
+      {content}
+      <div className="bg-background/80 supports-[backdrop-filter]:bg-background/65 absolute end-2 top-2 z-10 flex items-center gap-1 rounded-md border p-0.5 shadow-sm backdrop-blur">
+        {searchMatchSummary.count > 0 && (
+          <SearchMatchControls
+            activeIndex={activeSearchMatchIndex}
+            matchCount={searchMatchSummary.count}
+            onNext={() => navigateSearchMatches("next")}
+            onPrevious={() => navigateSearchMatches("previous")}
+            truncated={searchMatchSummary.truncated}
+          />
+        )}
+        <PeekPdfControls
+          canResetZoom={scaleOffset !== 0}
+          onResetZoom={() => handleResetZoom(target.fieldId)}
+          onZoomIn={() => handleZoom(target.fieldId, "in")}
+          onZoomOut={() => handleZoom(target.fieldId, "out")}
+          scaleOffset={scaleOffset}
+        />
+      </div>
+    </div>
+  );
+};

--- a/apps/web/src/components/search-document-preview.tsx
+++ b/apps/web/src/components/search-document-preview.tsx
@@ -131,6 +131,7 @@ export const SearchDocumentPreview = ({
             onZoomIn={() => handleZoom(target.fieldId, "in")}
             onZoomOut={() => handleZoom(target.fieldId, "out")}
             scaleOffset={scaleOffset}
+            tooltipLayer="search-child"
           />
         </div>
       )}

--- a/apps/web/src/components/search-document-preview.tsx
+++ b/apps/web/src/components/search-document-preview.tsx
@@ -8,7 +8,11 @@ import {
   getAdjacentSearchMatchIndex,
   type SearchMatchSummary,
 } from "@/lib/search-match-navigation";
-import type { NativeSearchDocumentPreviewTarget } from "@/lib/search.logic";
+import type {
+  NativeSearchDocumentPreviewTarget,
+  NativeSearchStatus,
+} from "@/lib/search.logic";
+import { shouldShowNativeSearchFallback } from "@/lib/search.logic";
 import {
   PeekPdfControls,
   PeekPdfViewer,
@@ -16,18 +20,22 @@ import {
 
 type SearchDocumentPreviewProps = {
   fallback: ReactNode;
+  noMatchFallback: ReactNode;
   searchText: string;
   target: NativeSearchDocumentPreviewTarget;
 };
 
 export const SearchDocumentPreview = ({
   fallback,
+  noMatchFallback,
   searchText,
   target,
 }: SearchDocumentPreviewProps) => {
   const [activeSearchMatchIndex, setActiveSearchMatchIndex] = useState(0);
   const [searchMatchSummary, setSearchMatchSummary] =
     useState<SearchMatchSummary>({ count: 0, truncated: false });
+  const [nativeSearchStatus, setNativeSearchStatus] =
+    useState<NativeSearchStatus>("pending");
   const { handleResetZoom, handleZoom, pdfContentRef, scaleOffsets } =
     usePdfTabZoom({
       activeId: target.fieldId,
@@ -37,6 +45,7 @@ export const SearchDocumentPreview = ({
   const handleSearchMatchSummaryChange = useCallback(
     (summary: SearchMatchSummary) => {
       setSearchMatchSummary(summary);
+      setNativeSearchStatus(summary.count > 0 ? "matched" : "unmatched");
       setActiveSearchMatchIndex((current) =>
         summary.count === 0 ? 0 : Math.min(current, summary.count - 1),
       );
@@ -55,6 +64,10 @@ export const SearchDocumentPreview = ({
     },
     [searchMatchSummary.count],
   );
+  const handlePreviewError = useCallback(() => {
+    setActiveSearchMatchIndex(0);
+    setSearchMatchSummary({ count: 0, truncated: false });
+  }, []);
   const viewer = (
     <PeekPdfViewer
       activeSearchMatchIndex={activeSearchMatchIndex}
@@ -64,6 +77,7 @@ export const SearchDocumentPreview = ({
       filePurpose={target.filePurpose}
       interactionMode="preview-only"
       mimeType={target.mimeType}
+      onError={handlePreviewError}
       onSearchMatchSummaryChange={handleSearchMatchSummaryChange}
       scaleOffset={scaleOffset}
       searchText={searchText}
@@ -85,28 +99,39 @@ export const SearchDocumentPreview = ({
         {viewer}
       </MeasuredPdfProvider>
     );
+  const showNoMatchFallback = shouldShowNativeSearchFallback({
+    searchText,
+    status: nativeSearchStatus,
+  });
 
   return (
     <div className="relative h-full min-h-0" ref={pdfContentRef}>
       {content}
-      <div className="bg-background/80 supports-[backdrop-filter]:bg-background/65 absolute end-2 top-2 z-10 flex items-center gap-1 rounded-md border p-0.5 shadow-sm backdrop-blur">
-        {searchMatchSummary.count > 0 && (
-          <SearchMatchControls
-            activeIndex={activeSearchMatchIndex}
-            matchCount={searchMatchSummary.count}
-            onNext={() => navigateSearchMatches("next")}
-            onPrevious={() => navigateSearchMatches("previous")}
-            truncated={searchMatchSummary.truncated}
+      {showNoMatchFallback && (
+        <div className="bg-background absolute inset-0 z-10 flex min-h-0 flex-col">
+          {noMatchFallback}
+        </div>
+      )}
+      {!showNoMatchFallback && (
+        <div className="bg-background/80 supports-[backdrop-filter]:bg-background/65 absolute end-2 top-2 z-10 flex items-center gap-1 rounded-md border p-0.5 shadow-sm backdrop-blur">
+          {searchMatchSummary.count > 0 && (
+            <SearchMatchControls
+              activeIndex={activeSearchMatchIndex}
+              matchCount={searchMatchSummary.count}
+              onNext={() => navigateSearchMatches("next")}
+              onPrevious={() => navigateSearchMatches("previous")}
+              truncated={searchMatchSummary.truncated}
+            />
+          )}
+          <PeekPdfControls
+            canResetZoom={scaleOffset !== 0}
+            onResetZoom={() => handleResetZoom(target.fieldId)}
+            onZoomIn={() => handleZoom(target.fieldId, "in")}
+            onZoomOut={() => handleZoom(target.fieldId, "out")}
+            scaleOffset={scaleOffset}
           />
-        )}
-        <PeekPdfControls
-          canResetZoom={scaleOffset !== 0}
-          onResetZoom={() => handleResetZoom(target.fieldId)}
-          onZoomIn={() => handleZoom(target.fieldId, "in")}
-          onZoomOut={() => handleZoom(target.fieldId, "out")}
-          scaleOffset={scaleOffset}
-        />
-      </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/apps/web/src/components/search-document-preview.tsx
+++ b/apps/web/src/components/search-document-preview.tsx
@@ -67,6 +67,7 @@ export const SearchDocumentPreview = ({
   const handlePreviewError = useCallback(() => {
     setActiveSearchMatchIndex(0);
     setSearchMatchSummary({ count: 0, truncated: false });
+    setNativeSearchStatus("unmatched");
   }, []);
   const viewer = (
     <PeekPdfViewer

--- a/apps/web/src/components/search-match-controls.tsx
+++ b/apps/web/src/components/search-match-controls.tsx
@@ -1,5 +1,5 @@
 import { ChevronDownIcon, ChevronUpIcon } from "lucide-react";
-import { useTranslations } from "use-intl";
+import { useFormatter, useTranslations } from "use-intl";
 
 import { Button } from "@stll/ui/components/button";
 
@@ -19,6 +19,7 @@ export const SearchMatchControls = ({
   truncated = false,
 }: SearchMatchControlsProps) => {
   const t = useTranslations();
+  const format = useFormatter();
   const hasMatches = matchCount > 0;
 
   return (
@@ -26,8 +27,8 @@ export const SearchMatchControls = ({
       <span className="text-muted-foreground min-w-12 text-center text-xs tabular-nums">
         {hasMatches
           ? t("folio.findReplace.matchCounter", {
-              current: String(activeIndex + 1),
-              total: `${String(matchCount)}${truncated ? "+" : ""}`,
+              current: format.number(activeIndex + 1),
+              total: `${format.number(matchCount)}${truncated ? "+" : ""}`,
             })
           : t("common.noResults")}
       </span>

--- a/apps/web/src/components/search-match-controls.tsx
+++ b/apps/web/src/components/search-match-controls.tsx
@@ -1,0 +1,56 @@
+import { ChevronDownIcon, ChevronUpIcon } from "lucide-react";
+import { useTranslations } from "use-intl";
+
+import { Button } from "@stll/ui/components/button";
+
+type SearchMatchControlsProps = {
+  activeIndex: number;
+  matchCount: number;
+  onNext: () => void;
+  onPrevious: () => void;
+  truncated?: boolean | undefined;
+};
+
+export const SearchMatchControls = ({
+  activeIndex,
+  matchCount,
+  onNext,
+  onPrevious,
+  truncated = false,
+}: SearchMatchControlsProps) => {
+  const t = useTranslations();
+  const hasMatches = matchCount > 0;
+
+  return (
+    <div className="flex items-center gap-0.5">
+      <span className="text-muted-foreground min-w-12 text-center text-xs tabular-nums">
+        {hasMatches
+          ? t("folio.findReplace.matchCounter", {
+              current: String(activeIndex + 1),
+              total: `${String(matchCount)}${truncated ? "+" : ""}`,
+            })
+          : t("common.noResults")}
+      </span>
+      <Button
+        aria-label={t("folio.findReplace.previous")}
+        disabled={!hasMatches}
+        onClick={onPrevious}
+        size="icon-xs"
+        title={t("folio.findReplace.previous")}
+        variant="ghost"
+      >
+        <ChevronUpIcon className="size-3.5" />
+      </Button>
+      <Button
+        aria-label={t("folio.findReplace.next")}
+        disabled={!hasMatches}
+        onClick={onNext}
+        size="icon-xs"
+        title={t("folio.findReplace.next")}
+        variant="ghost"
+      >
+        <ChevronDownIcon className="size-3.5" />
+      </Button>
+    </div>
+  );
+};

--- a/apps/web/src/components/tooltip.tsx
+++ b/apps/web/src/components/tooltip.tsx
@@ -16,7 +16,7 @@ type TooltipProps = {
   align?: TooltipPrimitive.Popup.State["align"];
   side?: "top" | "bottom" | "left" | "right";
   className?: string;
-  layer?: OverlayLayer;
+  layer?: OverlayLayer | undefined;
 };
 
 export default function Tooltip({
@@ -32,12 +32,12 @@ export default function Tooltip({
     <TooltipRoot>
       <TooltipTrigger render={render}>{children}</TooltipTrigger>
       <TooltipPopup
-        align={align}
+        {...(align === undefined ? {} : { align })}
         // text nowrap fixes tooltip for buttons in pdf viewer controls
         className={cn("max-w-70 text-nowrap", className)}
         hidden={content === undefined || content === null || content === ""}
-        layer={layer}
-        side={side}
+        {...(layer === undefined ? {} : { layer })}
+        {...(side === undefined ? {} : { side })}
       >
         {content}
       </TooltipPopup>

--- a/apps/web/src/components/tooltip.tsx
+++ b/apps/web/src/components/tooltip.tsx
@@ -7,6 +7,7 @@ import {
   Tooltip as TooltipRoot,
   TooltipTrigger,
 } from "@stll/ui/components/tooltip";
+import type { OverlayLayer } from "@stll/ui/lib/overlay-layer";
 import { cn } from "@stll/ui/lib/utils";
 
 type TooltipProps = {
@@ -15,6 +16,7 @@ type TooltipProps = {
   align?: TooltipPrimitive.Popup.State["align"];
   side?: "top" | "bottom" | "left" | "right";
   className?: string;
+  layer?: OverlayLayer;
 };
 
 export default function Tooltip({
@@ -24,6 +26,7 @@ export default function Tooltip({
   align,
   side,
   className,
+  layer,
 }: PropsWithChildren<TooltipProps>) {
   return (
     <TooltipRoot>
@@ -33,6 +36,7 @@ export default function Tooltip({
         // text nowrap fixes tooltip for buttons in pdf viewer controls
         className={cn("max-w-70 text-nowrap", className)}
         hidden={content === undefined || content === null || content === ""}
+        layer={layer}
         side={side}
       >
         {content}

--- a/apps/web/src/i18n/langs/ar.json
+++ b/apps/web/src/i18n/langs/ar.json
@@ -2367,6 +2367,7 @@
     "mimeType": "نوع الملف",
     "noResults": "لا نتائج لـ «{query}».",
     "placeholder": "البحث عبر جميع الملفات القانونية...",
+    "previewUnavailable": "المعاينة غير متوفرة",
     "recentSearches": "عمليات البحث الأخيرة",
     "recentlyOpenedFiles": "الملفات المفتوحة مؤخراً",
     "renameSearchTitle": "إعادة تسمية البحث المحفوظ",

--- a/apps/web/src/i18n/langs/cs.json
+++ b/apps/web/src/i18n/langs/cs.json
@@ -2367,6 +2367,7 @@
     "mimeType": "Typ souboru",
     "noResults": "Žádné výsledky pro „{query}“.",
     "placeholder": "Hledat ve všech spisech…",
+    "previewUnavailable": "Náhled není k dispozici",
     "recentSearches": "Nedávná hledání",
     "recentlyOpenedFiles": "Nedávno otevřené soubory",
     "renameSearchTitle": "Přejmenovat uložené hledání",

--- a/apps/web/src/i18n/langs/de.json
+++ b/apps/web/src/i18n/langs/de.json
@@ -2367,6 +2367,7 @@
     "mimeType": "Dateityp",
     "noResults": "Keine Ergebnisse für „{query}“ gefunden.",
     "placeholder": "Suchen …",
+    "previewUnavailable": "Keine Vorschau verfügbar",
     "recentSearches": "Letzte Suchen",
     "recentlyOpenedFiles": "Zuletzt geöffnete Dateien",
     "renameSearchTitle": "Gespeicherte Suche umbenennen",

--- a/apps/web/src/i18n/langs/en.json
+++ b/apps/web/src/i18n/langs/en.json
@@ -2367,6 +2367,7 @@
     "mimeType": "File type",
     "noResults": "No results found for \"{query}\".",
     "placeholder": "Search across all matters...",
+    "previewUnavailable": "Preview unavailable",
     "recentSearches": "Recent searches",
     "recentlyOpenedFiles": "Recently opened files",
     "renameSearchTitle": "Rename saved search",

--- a/apps/web/src/i18n/langs/es.json
+++ b/apps/web/src/i18n/langs/es.json
@@ -2367,6 +2367,7 @@
     "mimeType": "Tipo de archivo",
     "noResults": "Sin resultados para \"{query}\".",
     "placeholder": "Buscar en todos los asuntos...",
+    "previewUnavailable": "Vista previa no disponible",
     "recentSearches": "Búsquedas recientes",
     "recentlyOpenedFiles": "Archivos abiertos recientemente",
     "renameSearchTitle": "Cambiar nombre de la búsqueda guardada",

--- a/apps/web/src/i18n/langs/et.json
+++ b/apps/web/src/i18n/langs/et.json
@@ -2367,6 +2367,7 @@
     "mimeType": "Failitüüp",
     "noResults": "Päringule „{query}\" tulemusi ei leitud.",
     "placeholder": "Otsi kõigist asjadest...",
+    "previewUnavailable": "Eelvaade pole saadaval",
     "recentSearches": "Hiljutised otsingud",
     "recentlyOpenedFiles": "Hiljuti avatud failid",
     "renameSearchTitle": "Nimeta salvestatud otsing ümber",

--- a/apps/web/src/i18n/langs/fr.json
+++ b/apps/web/src/i18n/langs/fr.json
@@ -2367,6 +2367,7 @@
     "mimeType": "Type de fichier",
     "noResults": "Aucun résultat pour « {query} ».",
     "placeholder": "Rechercher dans tous les dossiers…",
+    "previewUnavailable": "Aperçu indisponible",
     "recentSearches": "Recherches récentes",
     "recentlyOpenedFiles": "Fichiers ouverts récemment",
     "renameSearchTitle": "Renommer la recherche enregistrée",

--- a/apps/web/src/i18n/langs/hu.json
+++ b/apps/web/src/i18n/langs/hu.json
@@ -2367,6 +2367,7 @@
     "mimeType": "Fájltípus",
     "noResults": "Nincs találat erre: „{query}”.",
     "placeholder": "Keresés az összes ügyben...",
+    "previewUnavailable": "Az előnézet nem érhető el",
     "recentSearches": "Legutóbbi keresések",
     "recentlyOpenedFiles": "Legutóbb megnyitott fájlok",
     "renameSearchTitle": "Mentett keresés átnevezése",

--- a/apps/web/src/i18n/langs/lt.json
+++ b/apps/web/src/i18n/langs/lt.json
@@ -2367,6 +2367,7 @@
     "mimeType": "Failo tipas",
     "noResults": "Nerasta rezultatų pagal \"{query}\".",
     "placeholder": "Ieškoti visose bylose...",
+    "previewUnavailable": "Peržiūra nepasiekiama",
     "recentSearches": "Naujausios paieškos",
     "recentlyOpenedFiles": "Neseniai atidaryti failai",
     "renameSearchTitle": "Pervadinti išsaugotą paiešką",

--- a/apps/web/src/i18n/langs/lv.json
+++ b/apps/web/src/i18n/langs/lv.json
@@ -2367,6 +2367,7 @@
     "mimeType": "Faila tips",
     "noResults": "Nav rezultātu meklēšanai \"{query}\".",
     "placeholder": "Meklēt visās lietās...",
+    "previewUnavailable": "Priekšskatījums nav pieejams",
     "recentSearches": "Nesenie meklējumi",
     "recentlyOpenedFiles": "Nesen atvērtie faili",
     "renameSearchTitle": "Pārdēvēt saglabāto meklējumu",

--- a/apps/web/src/i18n/langs/messages.gen.ts
+++ b/apps/web/src/i18n/langs/messages.gen.ts
@@ -2370,6 +2370,7 @@ type Messages = {
     "mimeType": "File type";
     "noResults": "No results found for \"{query}\".";
     "placeholder": "Search across all matters...";
+    "previewUnavailable": "Preview unavailable";
     "recentSearches": "Recent searches";
     "recentlyOpenedFiles": "Recently opened files";
     "renameSearchTitle": "Rename saved search";

--- a/apps/web/src/i18n/langs/pl.json
+++ b/apps/web/src/i18n/langs/pl.json
@@ -2367,6 +2367,7 @@
     "mimeType": "Typ pliku",
     "noResults": "Brak wyników dla „{query}”.",
     "placeholder": "Przeszukaj wszystkie sprawy...",
+    "previewUnavailable": "Podgląd niedostępny",
     "recentSearches": "Ostatnie wyszukiwania",
     "recentlyOpenedFiles": "Ostatnio otwarte pliki",
     "renameSearchTitle": "Zmień nazwę zapisanego wyszukiwania",

--- a/apps/web/src/i18n/langs/pt-BR.json
+++ b/apps/web/src/i18n/langs/pt-BR.json
@@ -2367,6 +2367,7 @@
     "mimeType": "Tipo de arquivo",
     "noResults": "Nenhum resultado encontrado para \"{query}\".",
     "placeholder": "Pesquisar em todos os casos...",
+    "previewUnavailable": "Prévia indisponível",
     "recentSearches": "Pesquisas recentes",
     "recentlyOpenedFiles": "Arquivos abertos recentemente",
     "renameSearchTitle": "Renomear pesquisa salva",

--- a/apps/web/src/i18n/langs/sk.json
+++ b/apps/web/src/i18n/langs/sk.json
@@ -2367,6 +2367,7 @@
     "mimeType": "Typ súboru",
     "noResults": "Nenašli sa žiadne výsledky pre „{query}“.",
     "placeholder": "Vyhľadávať vo všetkých spisoch...",
+    "previewUnavailable": "Náhľad nie je k dispozícii",
     "recentSearches": "Nedávne vyhľadávania",
     "recentlyOpenedFiles": "Nedávno otvorené súbory",
     "renameSearchTitle": "Premenovať uložené vyhľadávanie",

--- a/apps/web/src/lib/document-search.test.ts
+++ b/apps/web/src/lib/document-search.test.ts
@@ -68,6 +68,16 @@ describe("document search highlighting", () => {
     ]);
   });
 
+  test("unions exact and normalized matches without duplicating exact spans", () => {
+    expect(
+      findSearchTextMatches("odštěpení odstepeni ODŠTĚPENÍ", "odštěpení"),
+    ).toEqual([
+      { start: 0, end: 9 },
+      { start: 10, end: 19 },
+      { start: 20, end: 29 },
+    ]);
+  });
+
   test("bounds DOCX matches at one past the display cap", () => {
     const exactlyAtCap = createEmptyDocument({
       initialText: "hit ".repeat(200),
@@ -90,5 +100,45 @@ describe("document search highlighting", () => {
         searchText: "hit",
       }),
     ).toMatchObject({ matches: { length: 200 }, truncated: true });
+  });
+
+  test("keeps DOCX matches ordered when normalized and exact hits coexist", () => {
+    const document = createEmptyDocument({
+      initialText: "odštěpení odstepeni ODŠTĚPENÍ",
+    });
+
+    expect(findDocumentSearchMatches(document, "odštěpení")).toMatchObject([
+      { startOffset: 0, endOffset: 9 },
+      { startOffset: 10, endOffset: 19 },
+      { startOffset: 20, endOffset: 29 },
+    ]);
+    expect(
+      findDocumentSearchResult({
+        document,
+        maxMatches: 2,
+        searchText: "odštěpení",
+      }),
+    ).toMatchObject({
+      matches: [
+        { startOffset: 0, endOffset: 9 },
+        { startOffset: 10, endOffset: 19 },
+      ],
+      truncated: true,
+    });
+  });
+
+  test("applies the DOCX cap after globally ordering fallback-term matches", () => {
+    const document = createEmptyDocument({ initialText: "beta alpha alpha" });
+
+    expect(
+      findDocumentSearchResult({
+        document,
+        maxMatches: 1,
+        searchText: "alpha beta",
+      }),
+    ).toMatchObject({
+      matches: [{ startOffset: 0, endOffset: 4 }],
+      truncated: true,
+    });
   });
 });

--- a/apps/web/src/lib/document-search.test.ts
+++ b/apps/web/src/lib/document-search.test.ts
@@ -77,6 +77,18 @@ describe("document search highlighting", () => {
     expect(normalizeSearchText("ODŠTĚPENÍ")).toBe("odstepeni");
   });
 
+  test("uses canonical Arabic folds while preserving source offsets", () => {
+    expect(findNormalizedSearchTextMatches("مدرسة", "مدرسه")).toEqual([
+      { start: 0, end: 5 },
+    ]);
+    expect(findNormalizedSearchTextMatches("مـحـمـد", "محمد")).toEqual([
+      { start: 0, end: 7 },
+    ]);
+    expect(findNormalizedSearchTextMatches("٢٠٢٤", "2024")).toEqual([
+      { start: 0, end: 4 },
+    ]);
+  });
+
   test("finds every fallback term and maps unaccented DOCX queries", () => {
     const document = createEmptyDocument({
       initialText: "Plán odštěpení a následné assignment povinností",

--- a/apps/web/src/lib/document-search.test.ts
+++ b/apps/web/src/lib/document-search.test.ts
@@ -68,6 +68,17 @@ describe("document search highlighting", () => {
         terms: ["foo", "foobar"],
       }),
     ).toEqual([{ start: 0, end: 6 }]);
+
+    const document = createEmptyDocument({ initialText: "bar foobar" });
+    expect(
+      findDocumentSearchMatches(document, {
+        type: "separate-terms",
+        terms: ["bar", "foobar"],
+      }),
+    ).toMatchObject([
+      { startOffset: 0, endOffset: 3 },
+      { startOffset: 4, endOffset: 10 },
+    ]);
   });
 
   test("maps a diacritic-insensitive match back to original offsets", () => {

--- a/apps/web/src/lib/document-search.test.ts
+++ b/apps/web/src/lib/document-search.test.ts
@@ -77,6 +77,13 @@ describe("document search highlighting", () => {
     expect(normalizeSearchText("ODŠTĚPENÍ")).toBe("odstepeni");
   });
 
+  test("preserves contextual case folding while mapping source offsets", () => {
+    expect(normalizeSearchText("ΟΣ")).toBe("ος");
+    expect(findNormalizedSearchTextMatches("ΟΣ", "ος")).toEqual([
+      { start: 0, end: 2 },
+    ]);
+  });
+
   test("uses canonical Arabic folds while preserving source offsets", () => {
     expect(findNormalizedSearchTextMatches("مدرسة", "مدرسه")).toEqual([
       { start: 0, end: 5 },

--- a/apps/web/src/lib/document-search.test.ts
+++ b/apps/web/src/lib/document-search.test.ts
@@ -42,6 +42,25 @@ describe("document search highlighting", () => {
     ]);
   });
 
+  test("keeps independently marked server terms independent", () => {
+    const searchText = {
+      type: "separate-terms" as const,
+      terms: ["alpha", "beta"],
+    };
+
+    expect(findSearchTextMatches("alpha beta alpha", searchText)).toEqual([
+      { start: 0, end: 5 },
+      { start: 6, end: 10 },
+      { start: 11, end: 16 },
+    ]);
+    const document = createEmptyDocument({ initialText: "alpha beta alpha" });
+    expect(findDocumentSearchMatches(document, searchText)).toMatchObject([
+      { startOffset: 0, endOffset: 5 },
+      { startOffset: 6, endOffset: 10 },
+      { startOffset: 11, endOffset: 16 },
+    ]);
+  });
+
   test("maps a diacritic-insensitive match back to original offsets", () => {
     expect(
       findNormalizedSearchTextMatches("zápis odštepení", "odštěpení"),

--- a/apps/web/src/lib/document-search.test.ts
+++ b/apps/web/src/lib/document-search.test.ts
@@ -3,9 +3,11 @@ import { describe, expect, test } from "bun:test";
 import { createEmptyDocument } from "@stll/folio-core";
 
 import {
+  findDocumentSearchResult,
   findDocumentSearchMatches,
   findNormalizedSearchTextMatches,
   findSearchTextMatches,
+  getSearchTextCandidates,
   normalizeSearchText,
 } from "@/lib/document-search";
 
@@ -18,6 +20,16 @@ describe("document search highlighting", () => {
 
   test("does not create matches for an empty query", () => {
     expect(findSearchTextMatches("Meridian", "  ")).toEqual([]);
+  });
+
+  test("retains one-character Unicode terms", () => {
+    expect(getSearchTextCandidates("法")).toEqual(["法"]);
+    expect(findSearchTextMatches("準拠法", "法")).toEqual([
+      { start: 2, end: 3 },
+    ]);
+    expect(findNormalizedSearchTextMatches("Š", "s")).toEqual([
+      { start: 0, end: 1 },
+    ]);
   });
 
   test("falls back to web-search terms when an exact query is absent", () => {
@@ -54,5 +66,29 @@ describe("document search highlighting", () => {
       { startOffset: 5, endOffset: 14, text: "odštěpení" },
       { startOffset: 26, endOffset: 36, text: "assignment" },
     ]);
+  });
+
+  test("bounds DOCX matches at one past the display cap", () => {
+    const exactlyAtCap = createEmptyDocument({
+      initialText: "hit ".repeat(200),
+    });
+    const overCap = createEmptyDocument({
+      initialText: "hit ".repeat(201),
+    });
+
+    expect(
+      findDocumentSearchResult({
+        document: exactlyAtCap,
+        maxMatches: 200,
+        searchText: "hit",
+      }),
+    ).toMatchObject({ matches: { length: 200 }, truncated: false });
+    expect(
+      findDocumentSearchResult({
+        document: overCap,
+        maxMatches: 200,
+        searchText: "hit",
+      }),
+    ).toMatchObject({ matches: { length: 200 }, truncated: true });
   });
 });

--- a/apps/web/src/lib/document-search.test.ts
+++ b/apps/web/src/lib/document-search.test.ts
@@ -61,6 +61,15 @@ describe("document search highlighting", () => {
     ]);
   });
 
+  test("prefers the longest marked term when candidates overlap", () => {
+    expect(
+      findSearchTextMatches("foobar", {
+        type: "separate-terms",
+        terms: ["foo", "foobar"],
+      }),
+    ).toEqual([{ start: 0, end: 6 }]);
+  });
+
   test("maps a diacritic-insensitive match back to original offsets", () => {
     expect(
       findNormalizedSearchTextMatches("zápis odštepení", "odštěpení"),

--- a/apps/web/src/lib/document-search.test.ts
+++ b/apps/web/src/lib/document-search.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "bun:test";
+
+import { createEmptyDocument } from "@stll/folio-core";
+
+import {
+  findDocumentSearchMatches,
+  findNormalizedSearchTextMatches,
+  findSearchTextMatches,
+  normalizeSearchText,
+} from "@/lib/document-search";
+
+describe("document search highlighting", () => {
+  test("uses the native document find behavior across text runs", () => {
+    expect(
+      findSearchTextMatches("Meridian supply agreement", "SUPPLY"),
+    ).toEqual([{ start: 9, end: 15 }]);
+  });
+
+  test("does not create matches for an empty query", () => {
+    expect(findSearchTextMatches("Meridian", "  ")).toEqual([]);
+  });
+
+  test("falls back to web-search terms when an exact query is absent", () => {
+    expect(
+      findSearchTextMatches("Due Diligence Report", "Due_Diligence_Report"),
+    ).toEqual([
+      { start: 0, end: 3 },
+      { start: 4, end: 13 },
+      { start: 14, end: 20 },
+    ]);
+  });
+
+  test("maps a diacritic-insensitive match back to original offsets", () => {
+    expect(
+      findNormalizedSearchTextMatches("zápis odštepení", "odštěpení"),
+    ).toEqual([{ start: 6, end: 15 }]);
+    expect(normalizeSearchText("ODŠTĚPENÍ")).toBe("odstepeni");
+  });
+
+  test("finds every fallback term and maps unaccented DOCX queries", () => {
+    const document = createEmptyDocument({
+      initialText: "Plán odštěpení a následné assignment povinností",
+    });
+
+    expect(
+      findDocumentSearchMatches(document, "odstepeni assignment").map(
+        ({ startOffset, endOffset, text }) => ({
+          startOffset,
+          endOffset,
+          text,
+        }),
+      ),
+    ).toEqual([
+      { startOffset: 5, endOffset: 14, text: "odštěpení" },
+      { startOffset: 26, endOffset: 36, text: "assignment" },
+    ]);
+  });
+});

--- a/apps/web/src/lib/document-search.ts
+++ b/apps/web/src/lib/document-search.ts
@@ -1,0 +1,155 @@
+import type { Document } from "@stll/folio-core";
+import { getAllParagraphs } from "@stll/folio-core/docx/documentParser";
+import { getParagraphPlainText } from "@stll/folio-core/docx/serializer/paragraphSerializer";
+import {
+  createDefaultFindOptions,
+  findAllMatches,
+  findInDocument,
+  findInParagraph,
+} from "@stll/folio-core/utils/findReplace";
+import type { FindMatch } from "@stll/folio-core/utils/findReplace";
+
+import {
+  findNormalizedSearchTextMatches,
+  getSearchTextCandidates,
+} from "@/lib/search-text";
+import type { SearchTextMatch } from "@/lib/search-text";
+
+export {
+  findNormalizedSearchTextMatches,
+  getSearchTextCandidates,
+  normalizeSearchText,
+} from "@/lib/search-text";
+
+const documentSearchOptions = createDefaultFindOptions();
+
+const searchTextMatchKey = ({ end, start }: SearchTextMatch) =>
+  `${String(start)}:${String(end)}`;
+
+const sortSearchTextMatches = (
+  first: SearchTextMatch,
+  second: SearchTextMatch,
+) => first.start - second.start || first.end - second.end;
+
+const findTextCandidateMatches = (content: string, candidate: string) => {
+  const exactMatches = findAllMatches(
+    content,
+    candidate,
+    documentSearchOptions,
+  );
+  return exactMatches.length > 0
+    ? exactMatches
+    : findNormalizedSearchTextMatches(content, candidate);
+};
+
+export const findSearchTextMatches = (content: string, searchText: string) => {
+  const candidates = getSearchTextCandidates(searchText);
+  const phraseCandidate = candidates.at(0);
+  const phraseMatches = phraseCandidate
+    ? findTextCandidateMatches(content, phraseCandidate)
+    : [];
+  if (phraseMatches.length > 0 || candidates.length <= 1) {
+    return phraseMatches;
+  }
+
+  const matches = new Map<string, SearchTextMatch>();
+  for (const candidate of candidates.slice(1)) {
+    for (const match of findTextCandidateMatches(content, candidate)) {
+      matches.set(searchTextMatchKey(match), match);
+    }
+  }
+  return [...matches.values()].toSorted(sortSearchTextMatches);
+};
+
+const documentMatchKey = ({
+  endOffset,
+  paragraphIndex,
+  startOffset,
+}: FindMatch) =>
+  `${String(paragraphIndex)}:${String(startOffset)}:${String(endOffset)}`;
+
+const sortDocumentMatches = (first: FindMatch, second: FindMatch) =>
+  first.paragraphIndex - second.paragraphIndex ||
+  first.startOffset - second.startOffset ||
+  first.endOffset - second.endOffset;
+
+const findNormalizedDocumentCandidateMatches = (
+  document: Document,
+  candidate: string,
+): FindMatch[] => {
+  const matches: FindMatch[] = [];
+  const paragraphs = getAllParagraphs(document.package.document);
+
+  for (const [paragraphIndex, paragraph] of paragraphs.entries()) {
+    const paragraphText = getParagraphPlainText(paragraph);
+    for (const normalizedMatch of findNormalizedSearchTextMatches(
+      paragraphText,
+      candidate,
+    )) {
+      const originalText = paragraphText.slice(
+        normalizedMatch.start,
+        normalizedMatch.end,
+      );
+      const match = findInParagraph(
+        paragraph,
+        originalText,
+        documentSearchOptions,
+        paragraphIndex,
+      ).find(
+        (item) =>
+          item.startOffset === normalizedMatch.start &&
+          item.endOffset === normalizedMatch.end,
+      );
+      if (match) {
+        matches.push(match);
+      }
+    }
+  }
+
+  return matches;
+};
+
+const findDocumentCandidateMatches = (
+  document: Document,
+  candidate: string,
+) => {
+  const exactMatches = findInDocument(
+    document,
+    candidate,
+    documentSearchOptions,
+  );
+  return exactMatches.length > 0
+    ? exactMatches
+    : findNormalizedDocumentCandidateMatches(document, candidate);
+};
+
+export const findDocumentSearchMatches = (
+  document: Document | null,
+  searchText: string,
+) => {
+  if (!document) {
+    return [];
+  }
+
+  const candidates = getSearchTextCandidates(searchText);
+  const phraseCandidate = candidates.at(0);
+  const phraseMatches = phraseCandidate
+    ? findDocumentCandidateMatches(document, phraseCandidate)
+    : [];
+  if (phraseMatches.length > 0 || candidates.length <= 1) {
+    return phraseMatches;
+  }
+
+  const matches = new Map<string, FindMatch>();
+  for (const candidate of candidates.slice(1)) {
+    for (const match of findDocumentCandidateMatches(document, candidate)) {
+      matches.set(documentMatchKey(match), match);
+    }
+  }
+  return [...matches.values()].toSorted(sortDocumentMatches);
+};
+
+export const findFirstDocumentSearchMatch = (
+  document: Document | null,
+  searchText: string,
+) => findDocumentSearchMatches(document, searchText).at(0) ?? null;

--- a/apps/web/src/lib/document-search.ts
+++ b/apps/web/src/lib/document-search.ts
@@ -12,7 +12,7 @@ import {
   findNormalizedSearchTextMatches,
   getSearchTextCandidates,
 } from "@/lib/search-text";
-import type { SearchTextMatch } from "@/lib/search-text";
+import type { SearchTextMatch, SearchTextQuery } from "@/lib/search-text";
 
 export {
   findNormalizedSearchTextMatches,
@@ -45,8 +45,20 @@ const findTextCandidateMatches = (content: string, candidate: string) => {
   return [...matches.values()].toSorted(sortSearchTextMatches);
 };
 
-export const findSearchTextMatches = (content: string, searchText: string) => {
+export const findSearchTextMatches = (
+  content: string,
+  searchText: SearchTextQuery,
+) => {
   const candidates = getSearchTextCandidates(searchText);
+  if (typeof searchText !== "string") {
+    const matches = new Map<string, SearchTextMatch>();
+    for (const candidate of candidates) {
+      for (const match of findTextCandidateMatches(content, candidate)) {
+        matches.set(searchTextMatchKey(match), match);
+      }
+    }
+    return [...matches.values()].toSorted(sortSearchTextMatches);
+  }
   const phraseCandidate = candidates.at(0);
   const phraseMatches = phraseCandidate
     ? findTextCandidateMatches(content, phraseCandidate)
@@ -179,7 +191,7 @@ export type DocumentSearchResult = {
 
 type FindDocumentSearchResultOptions = {
   document: Document | null;
-  searchText: string;
+  searchText: SearchTextQuery;
   maxMatches: number;
 };
 
@@ -195,6 +207,17 @@ export const findDocumentSearchResult = ({
   const normalizedMaxMatches = Math.max(0, Math.floor(maxMatches));
   const collectionLimit = normalizedMaxMatches + 1;
   const candidates = getSearchTextCandidates(searchText);
+  if (typeof searchText !== "string") {
+    const matches = findDocumentCandidateMatches({
+      candidates,
+      document,
+      limit: collectionLimit,
+    });
+    return {
+      matches: matches.slice(0, normalizedMaxMatches),
+      truncated: matches.length > normalizedMaxMatches,
+    };
+  }
   const phraseCandidate = candidates.at(0);
   const phraseMatches = phraseCandidate
     ? findDocumentCandidateMatches({
@@ -224,7 +247,7 @@ export const findDocumentSearchResult = ({
 
 export const findDocumentSearchMatches = (
   document: Document | null,
-  searchText: string,
+  searchText: SearchTextQuery,
 ) =>
   findDocumentSearchResult({
     document,
@@ -234,7 +257,7 @@ export const findDocumentSearchMatches = (
 
 export const findFirstDocumentSearchMatch = (
   document: Document | null,
-  searchText: string,
+  searchText: SearchTextQuery,
 ) =>
   findDocumentSearchResult({ document, searchText, maxMatches: 1 }).matches.at(
     0,

--- a/apps/web/src/lib/document-search.ts
+++ b/apps/web/src/lib/document-search.ts
@@ -10,6 +10,7 @@ import type { FindMatch } from "@stll/folio-core/utils/findReplace";
 import {
   findNormalizedSearchTextMatches,
   getSearchTextCandidates,
+  selectNonOverlappingSearchMatches,
 } from "@/lib/search-text";
 import type { SearchTextMatch, SearchTextQuery } from "@/lib/search-text";
 
@@ -24,29 +25,15 @@ const documentSearchOptions = createDefaultFindOptions();
 const searchTextMatchKey = ({ end, start }: SearchTextMatch) =>
   `${String(start)}:${String(end)}`;
 
-const sortSearchTextMatches = (
-  first: SearchTextMatch,
-  second: SearchTextMatch,
-) => first.start - second.start || second.end - first.end;
-
 const selectNonOverlappingSearchTextMatches = (
   matches: Iterable<SearchTextMatch>,
   maxMatches: number,
-): SearchTextMatch[] => {
-  const selected: SearchTextMatch[] = [];
-  let previousEnd = -1;
-  for (const match of [...matches].toSorted(sortSearchTextMatches)) {
-    if (match.start < previousEnd) {
-      continue;
-    }
-    selected.push(match);
-    previousEnd = match.end;
-    if (selected.length >= maxMatches) {
-      break;
-    }
-  }
-  return selected;
-};
+) =>
+  selectNonOverlappingSearchMatches({
+    getRange: ({ end, start }) => ({ end, group: 0, start }),
+    matches,
+    maxMatches,
+  });
 
 type FindTextCandidateMatchesOptions = {
   candidate: string;
@@ -130,11 +117,6 @@ const documentMatchPositionKey = ({
 
 const documentMatchKey = (match: FindMatch) => documentMatchPositionKey(match);
 
-const sortDocumentMatches = (first: FindMatch, second: FindMatch) =>
-  first.paragraphIndex - second.paragraphIndex ||
-  first.startOffset - second.startOffset ||
-  first.endOffset - second.endOffset;
-
 type FindDocumentCandidateMatchesOptions = {
   candidates: readonly string[];
   document: Document;
@@ -205,9 +187,15 @@ const findDocumentCandidateMatches = ({
       for (const match of candidateMatches.values()) {
         paragraphMatches.set(documentMatchKey(match), match);
       }
-      const orderedParagraphMatches = [...paragraphMatches.values()]
-        .toSorted(sortDocumentMatches)
-        .slice(0, paragraphLimit);
+      const orderedParagraphMatches = selectNonOverlappingSearchMatches({
+        getRange: ({ endOffset, paragraphIndex: group, startOffset }) => ({
+          end: endOffset,
+          group,
+          start: startOffset,
+        }),
+        matches: paragraphMatches.values(),
+        maxMatches: paragraphLimit,
+      });
       paragraphMatches.clear();
       for (const match of orderedParagraphMatches) {
         paragraphMatches.set(documentMatchKey(match), match);

--- a/apps/web/src/lib/document-search.ts
+++ b/apps/web/src/lib/document-search.ts
@@ -3,7 +3,6 @@ import { getAllParagraphs } from "@stll/folio-core/docx/documentParser";
 import { getParagraphPlainText } from "@stll/folio-core/docx/serializer/paragraphSerializer";
 import {
   createDefaultFindOptions,
-  findAllMatches,
   findInParagraph,
 } from "@stll/folio-core/utils/findReplace";
 import type { FindMatch } from "@stll/folio-core/utils/findReplace";
@@ -28,40 +27,77 @@ const searchTextMatchKey = ({ end, start }: SearchTextMatch) =>
 const sortSearchTextMatches = (
   first: SearchTextMatch,
   second: SearchTextMatch,
-) => first.start - second.start || first.end - second.end;
+) => first.start - second.start || second.end - first.end;
 
-const findTextCandidateMatches = (content: string, candidate: string) => {
-  const matches = new Map<string, SearchTextMatch>();
-  for (const match of findAllMatches(
-    content,
-    candidate,
-    documentSearchOptions,
-  )) {
-    matches.set(searchTextMatchKey(match), match);
+const selectNonOverlappingSearchTextMatches = (
+  matches: Iterable<SearchTextMatch>,
+  maxMatches: number,
+): SearchTextMatch[] => {
+  const selected: SearchTextMatch[] = [];
+  let previousEnd = -1;
+  for (const match of [...matches].toSorted(sortSearchTextMatches)) {
+    if (match.start < previousEnd) {
+      continue;
+    }
+    selected.push(match);
+    previousEnd = match.end;
+    if (selected.length >= maxMatches) {
+      break;
+    }
   }
-  for (const match of findNormalizedSearchTextMatches(content, candidate)) {
-    matches.set(searchTextMatchKey(match), match);
-  }
-  return [...matches.values()].toSorted(sortSearchTextMatches);
+  return selected;
+};
+
+type FindTextCandidateMatchesOptions = {
+  candidate: string;
+  content: string;
+  maxMatches: number;
+};
+
+const findTextCandidateMatches = ({
+  candidate,
+  content,
+  maxMatches,
+}: FindTextCandidateMatchesOptions) =>
+  findNormalizedSearchTextMatches(content, candidate, { maxMatches });
+
+type FindSearchTextMatchesOptions = {
+  maxMatches?: number | undefined;
 };
 
 export const findSearchTextMatches = (
   content: string,
   searchText: SearchTextQuery,
+  options: FindSearchTextMatchesOptions = {},
 ) => {
+  const maxMatches = Math.max(
+    0,
+    Math.floor(options.maxMatches ?? Number.MAX_SAFE_INTEGER),
+  );
+  if (maxMatches === 0) {
+    return [];
+  }
   const candidates = getSearchTextCandidates(searchText);
   if (typeof searchText !== "string") {
     const matches = new Map<string, SearchTextMatch>();
     for (const candidate of candidates) {
-      for (const match of findTextCandidateMatches(content, candidate)) {
+      for (const match of findTextCandidateMatches({
+        candidate,
+        content,
+        maxMatches,
+      })) {
         matches.set(searchTextMatchKey(match), match);
       }
     }
-    return [...matches.values()].toSorted(sortSearchTextMatches);
+    return selectNonOverlappingSearchTextMatches(matches.values(), maxMatches);
   }
   const phraseCandidate = candidates.at(0);
   const phraseMatches = phraseCandidate
-    ? findTextCandidateMatches(content, phraseCandidate)
+    ? findTextCandidateMatches({
+        candidate: phraseCandidate,
+        content,
+        maxMatches,
+      })
     : [];
   if (phraseMatches.length > 0 || candidates.length <= 1) {
     return phraseMatches;
@@ -69,11 +105,15 @@ export const findSearchTextMatches = (
 
   const matches = new Map<string, SearchTextMatch>();
   for (const candidate of candidates.slice(1)) {
-    for (const match of findTextCandidateMatches(content, candidate)) {
+    for (const match of findTextCandidateMatches({
+      candidate,
+      content,
+      maxMatches,
+    })) {
       matches.set(searchTextMatchKey(match), match);
     }
   }
-  return [...matches.values()].toSorted(sortSearchTextMatches);
+  return selectNonOverlappingSearchTextMatches(matches.values(), maxMatches);
 };
 
 type DocumentMatchPosition = Pick<

--- a/apps/web/src/lib/document-search.ts
+++ b/apps/web/src/lib/document-search.ts
@@ -31,14 +31,18 @@ const sortSearchTextMatches = (
 ) => first.start - second.start || first.end - second.end;
 
 const findTextCandidateMatches = (content: string, candidate: string) => {
-  const exactMatches = findAllMatches(
+  const matches = new Map<string, SearchTextMatch>();
+  for (const match of findAllMatches(
     content,
     candidate,
     documentSearchOptions,
-  );
-  return exactMatches.length > 0
-    ? exactMatches
-    : findNormalizedSearchTextMatches(content, candidate);
+  )) {
+    matches.set(searchTextMatchKey(match), match);
+  }
+  for (const match of findNormalizedSearchTextMatches(content, candidate)) {
+    matches.set(searchTextMatchKey(match), match);
+  }
+  return [...matches.values()].toSorted(sortSearchTextMatches);
 };
 
 export const findSearchTextMatches = (content: string, searchText: string) => {
@@ -60,12 +64,19 @@ export const findSearchTextMatches = (content: string, searchText: string) => {
   return [...matches.values()].toSorted(sortSearchTextMatches);
 };
 
-const documentMatchKey = ({
+type DocumentMatchPosition = Pick<
+  FindMatch,
+  "endOffset" | "paragraphIndex" | "startOffset"
+>;
+
+const documentMatchPositionKey = ({
   endOffset,
   paragraphIndex,
   startOffset,
-}: FindMatch) =>
+}: DocumentMatchPosition) =>
   `${String(paragraphIndex)}:${String(startOffset)}:${String(endOffset)}`;
+
+const documentMatchKey = (match: FindMatch) => documentMatchPositionKey(match);
 
 const sortDocumentMatches = (first: FindMatch, second: FindMatch) =>
   first.paragraphIndex - second.paragraphIndex ||
@@ -73,13 +84,13 @@ const sortDocumentMatches = (first: FindMatch, second: FindMatch) =>
   first.endOffset - second.endOffset;
 
 type FindDocumentCandidateMatchesOptions = {
-  candidate: string;
+  candidates: readonly string[];
   document: Document;
   limit: number;
 };
 
 const findDocumentCandidateMatches = ({
-  candidate,
+  candidates,
   document,
   limit,
 }: FindDocumentCandidateMatchesOptions): FindMatch[] => {
@@ -87,48 +98,74 @@ const findDocumentCandidateMatches = ({
   const matches: FindMatch[] = [];
 
   for (const [paragraphIndex, paragraph] of paragraphs.entries()) {
-    for (const match of findInParagraph(
-      paragraph,
-      candidate,
-      documentSearchOptions,
-      paragraphIndex,
-    )) {
-      matches.push(match);
-      if (matches.length >= limit) {
-        return matches;
+    const paragraphLimit = limit - matches.length;
+    const paragraphMatches = new Map<string, FindMatch>();
+    const nativeMatchesByText = new Map<string, Map<string, FindMatch>>();
+    const getNativeMatches = (text: string) => {
+      const cachedMatches = nativeMatchesByText.get(text);
+      if (cachedMatches) {
+        return cachedMatches;
       }
-    }
-  }
-  if (matches.length > 0) {
-    return matches;
-  }
 
-  for (const [paragraphIndex, paragraph] of paragraphs.entries()) {
-    const paragraphText = getParagraphPlainText(paragraph);
-    for (const normalizedMatch of findNormalizedSearchTextMatches(
-      paragraphText,
-      candidate,
-    )) {
-      const originalText = paragraphText.slice(
-        normalizedMatch.start,
-        normalizedMatch.end,
-      );
-      const match = findInParagraph(
+      const nativeMatches = new Map<string, FindMatch>();
+      for (const match of findInParagraph(
         paragraph,
-        originalText,
+        text,
         documentSearchOptions,
         paragraphIndex,
-      ).find(
-        (item) =>
-          item.startOffset === normalizedMatch.start &&
-          item.endOffset === normalizedMatch.end,
-      );
-      if (match) {
-        matches.push(match);
-        if (matches.length >= limit) {
-          return matches;
+      )) {
+        nativeMatches.set(documentMatchKey(match), match);
+        if (nativeMatches.size >= paragraphLimit) {
+          break;
         }
       }
+      nativeMatchesByText.set(text, nativeMatches);
+      return nativeMatches;
+    };
+    const paragraphText = getParagraphPlainText(paragraph);
+    for (const candidate of candidates) {
+      const candidateMatches = new Map<string, FindMatch>();
+      for (const match of getNativeMatches(candidate).values()) {
+        candidateMatches.set(documentMatchKey(match), match);
+      }
+      const normalizedMatches = findNormalizedSearchTextMatches(
+        paragraphText,
+        candidate,
+        { maxMatches: paragraphLimit },
+      );
+      for (const normalizedMatch of normalizedMatches) {
+        const originalText = paragraphText.slice(
+          normalizedMatch.start,
+          normalizedMatch.end,
+        );
+        const match = getNativeMatches(originalText).get(
+          documentMatchPositionKey({
+            paragraphIndex,
+            startOffset: normalizedMatch.start,
+            endOffset: normalizedMatch.end,
+          }),
+        );
+        if (match) {
+          candidateMatches.set(documentMatchKey(match), match);
+        }
+      }
+
+      for (const match of candidateMatches.values()) {
+        paragraphMatches.set(documentMatchKey(match), match);
+      }
+      const orderedParagraphMatches = [...paragraphMatches.values()]
+        .toSorted(sortDocumentMatches)
+        .slice(0, paragraphLimit);
+      paragraphMatches.clear();
+      for (const match of orderedParagraphMatches) {
+        paragraphMatches.set(documentMatchKey(match), match);
+      }
+    }
+    for (const match of paragraphMatches.values()) {
+      matches.push(match);
+    }
+    if (matches.length >= limit) {
+      return matches;
     }
   }
 
@@ -161,7 +198,7 @@ export const findDocumentSearchResult = ({
   const phraseCandidate = candidates.at(0);
   const phraseMatches = phraseCandidate
     ? findDocumentCandidateMatches({
-        candidate: phraseCandidate,
+        candidates: [phraseCandidate],
         document,
         limit: collectionLimit,
       })
@@ -173,37 +210,15 @@ export const findDocumentSearchResult = ({
     };
   }
 
-  const matches = new Map<string, FindMatch>();
-  let truncated = false;
-  for (const candidate of candidates.slice(1)) {
-    const candidateMatches = findDocumentCandidateMatches({
-      candidate,
-      document,
-      limit: collectionLimit,
-    });
-    const candidateWasTruncated =
-      candidateMatches.length > normalizedMaxMatches;
-    for (const match of candidateMatches) {
-      matches.set(documentMatchKey(match), match);
-      if (matches.size > normalizedMaxMatches) {
-        truncated = true;
-        break;
-      }
-    }
-    if (truncated) {
-      break;
-    }
-    if (candidateWasTruncated) {
-      truncated = true;
-      break;
-    }
-  }
+  const matches = findDocumentCandidateMatches({
+    candidates: candidates.slice(1),
+    document,
+    limit: collectionLimit,
+  });
 
   return {
-    matches: [...matches.values()]
-      .toSorted(sortDocumentMatches)
-      .slice(0, normalizedMaxMatches),
-    truncated,
+    matches: matches.slice(0, normalizedMaxMatches),
+    truncated: matches.length > normalizedMaxMatches,
   };
 };
 

--- a/apps/web/src/lib/document-search.ts
+++ b/apps/web/src/lib/document-search.ts
@@ -4,7 +4,6 @@ import { getParagraphPlainText } from "@stll/folio-core/docx/serializer/paragrap
 import {
   createDefaultFindOptions,
   findAllMatches,
-  findInDocument,
   findInParagraph,
 } from "@stll/folio-core/utils/findReplace";
 import type { FindMatch } from "@stll/folio-core/utils/findReplace";
@@ -73,12 +72,36 @@ const sortDocumentMatches = (first: FindMatch, second: FindMatch) =>
   first.startOffset - second.startOffset ||
   first.endOffset - second.endOffset;
 
-const findNormalizedDocumentCandidateMatches = (
-  document: Document,
-  candidate: string,
-): FindMatch[] => {
-  const matches: FindMatch[] = [];
+type FindDocumentCandidateMatchesOptions = {
+  candidate: string;
+  document: Document;
+  limit: number;
+};
+
+const findDocumentCandidateMatches = ({
+  candidate,
+  document,
+  limit,
+}: FindDocumentCandidateMatchesOptions): FindMatch[] => {
   const paragraphs = getAllParagraphs(document.package.document);
+  const matches: FindMatch[] = [];
+
+  for (const [paragraphIndex, paragraph] of paragraphs.entries()) {
+    for (const match of findInParagraph(
+      paragraph,
+      candidate,
+      documentSearchOptions,
+      paragraphIndex,
+    )) {
+      matches.push(match);
+      if (matches.length >= limit) {
+        return matches;
+      }
+    }
+  }
+  if (matches.length > 0) {
+    return matches;
+  }
 
   for (const [paragraphIndex, paragraph] of paragraphs.entries()) {
     const paragraphText = getParagraphPlainText(paragraph);
@@ -102,6 +125,9 @@ const findNormalizedDocumentCandidateMatches = (
       );
       if (match) {
         matches.push(match);
+        if (matches.length >= limit) {
+          return matches;
+        }
       }
     }
   }
@@ -109,47 +135,92 @@ const findNormalizedDocumentCandidateMatches = (
   return matches;
 };
 
-const findDocumentCandidateMatches = (
-  document: Document,
-  candidate: string,
-) => {
-  const exactMatches = findInDocument(
-    document,
-    candidate,
-    documentSearchOptions,
-  );
-  return exactMatches.length > 0
-    ? exactMatches
-    : findNormalizedDocumentCandidateMatches(document, candidate);
+export type DocumentSearchResult = {
+  matches: FindMatch[];
+  truncated: boolean;
+};
+
+type FindDocumentSearchResultOptions = {
+  document: Document | null;
+  searchText: string;
+  maxMatches: number;
+};
+
+export const findDocumentSearchResult = ({
+  document,
+  searchText,
+  maxMatches,
+}: FindDocumentSearchResultOptions): DocumentSearchResult => {
+  if (!document) {
+    return { matches: [], truncated: false };
+  }
+
+  const normalizedMaxMatches = Math.max(0, Math.floor(maxMatches));
+  const collectionLimit = normalizedMaxMatches + 1;
+  const candidates = getSearchTextCandidates(searchText);
+  const phraseCandidate = candidates.at(0);
+  const phraseMatches = phraseCandidate
+    ? findDocumentCandidateMatches({
+        candidate: phraseCandidate,
+        document,
+        limit: collectionLimit,
+      })
+    : [];
+  if (phraseMatches.length > 0 || candidates.length <= 1) {
+    return {
+      matches: phraseMatches.slice(0, normalizedMaxMatches),
+      truncated: phraseMatches.length > normalizedMaxMatches,
+    };
+  }
+
+  const matches = new Map<string, FindMatch>();
+  let truncated = false;
+  for (const candidate of candidates.slice(1)) {
+    const candidateMatches = findDocumentCandidateMatches({
+      candidate,
+      document,
+      limit: collectionLimit,
+    });
+    const candidateWasTruncated =
+      candidateMatches.length > normalizedMaxMatches;
+    for (const match of candidateMatches) {
+      matches.set(documentMatchKey(match), match);
+      if (matches.size > normalizedMaxMatches) {
+        truncated = true;
+        break;
+      }
+    }
+    if (truncated) {
+      break;
+    }
+    if (candidateWasTruncated) {
+      truncated = true;
+      break;
+    }
+  }
+
+  return {
+    matches: [...matches.values()]
+      .toSorted(sortDocumentMatches)
+      .slice(0, normalizedMaxMatches),
+    truncated,
+  };
 };
 
 export const findDocumentSearchMatches = (
   document: Document | null,
   searchText: string,
-) => {
-  if (!document) {
-    return [];
-  }
-
-  const candidates = getSearchTextCandidates(searchText);
-  const phraseCandidate = candidates.at(0);
-  const phraseMatches = phraseCandidate
-    ? findDocumentCandidateMatches(document, phraseCandidate)
-    : [];
-  if (phraseMatches.length > 0 || candidates.length <= 1) {
-    return phraseMatches;
-  }
-
-  const matches = new Map<string, FindMatch>();
-  for (const candidate of candidates.slice(1)) {
-    for (const match of findDocumentCandidateMatches(document, candidate)) {
-      matches.set(documentMatchKey(match), match);
-    }
-  }
-  return [...matches.values()].toSorted(sortDocumentMatches);
-};
+) =>
+  findDocumentSearchResult({
+    document,
+    searchText,
+    maxMatches: Number.MAX_SAFE_INTEGER,
+  }).matches;
 
 export const findFirstDocumentSearchMatch = (
   document: Document | null,
   searchText: string,
-) => findDocumentSearchMatches(document, searchText).at(0) ?? null;
+) =>
+  findDocumentSearchResult({ document, searchText, maxMatches: 1 }).matches.at(
+    0,
+  ) ?? null;

--- a/apps/web/src/lib/pdf/pdf-context.tsx
+++ b/apps/web/src/lib/pdf/pdf-context.tsx
@@ -59,9 +59,10 @@ export type RenderPageResult = Result<RenderedPage, PDFViewerError>;
 
 type ScrollToTarget =
   | { kind: "justification"; id: string }
-  | { kind: "anonymizeEntity"; entityId: number };
+  | { kind: "anonymizeEntity"; entityId: number }
+  | { kind: "searchMatch"; matchIndex: number };
 
-type ScrollTo = {
+export type PDFScrollTo = {
   pageId: string;
   target?: ScrollToTarget | undefined;
 };
@@ -76,13 +77,13 @@ type PDFState = {
   fitToWidth: number | undefined;
   scaleOffset: number;
   containerWidth: number;
-  scrollTo: ScrollTo | null;
+  scrollTo: PDFScrollTo | null;
   activePages: string[];
   renderPromises: Map<string, Promise<RenderPageResult>>;
 };
 
 type PDFActions = {
-  setScrollTo: (scrollTo: ScrollTo | null) => void;
+  setScrollTo: (scrollTo: PDFScrollTo | null) => void;
   setScaleOffset: (offset: number) => void;
   setDocument: (document: PDFDocument) => void;
   updateVisiblePages: (visiblePageIds: string[]) => void;

--- a/apps/web/src/lib/pdf/pdf-page-scroll.logic.test.ts
+++ b/apps/web/src/lib/pdf/pdf-page-scroll.logic.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "bun:test";
+
+import { getPDFPageScrollTop } from "@/lib/pdf/pdf-page-scroll.logic";
+
+describe("getPDFPageScrollTop", () => {
+  it("aligns a page within its existing PDF viewport", () => {
+    expect(
+      getPDFPageScrollTop({
+        currentScrollTop: 240,
+        pageTop: 620,
+        viewportTop: 120,
+      }),
+    ).toBe(740);
+  });
+
+  it("preserves the viewport offset when the page is above it", () => {
+    expect(
+      getPDFPageScrollTop({
+        currentScrollTop: 900,
+        pageTop: 80,
+        viewportTop: 180,
+      }),
+    ).toBe(800);
+  });
+});

--- a/apps/web/src/lib/pdf/pdf-page-scroll.logic.test.ts
+++ b/apps/web/src/lib/pdf/pdf-page-scroll.logic.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "bun:test";
 
-import { getPDFPageScrollTop } from "@/lib/pdf/pdf-page-scroll.logic";
+import {
+  getPDFPageScrollTop,
+  isPDFSearchMatchScrollRequest,
+} from "@/lib/pdf/pdf-page-scroll.logic";
 
 describe("getPDFPageScrollTop", () => {
   it("aligns a page within its existing PDF viewport", () => {
@@ -21,5 +24,56 @@ describe("getPDFPageScrollTop", () => {
         viewportTop: 180,
       }),
     ).toBe(800);
+  });
+});
+
+describe("PDF search match scroll requests", () => {
+  it("matches only the requested result on the requested page", () => {
+    const scrollTo = {
+      pageId: "page-3",
+      target: { kind: "searchMatch", matchIndex: 7 },
+    } as const;
+
+    expect(
+      isPDFSearchMatchScrollRequest({
+        matchIndex: 7,
+        pageId: "page-3",
+        scrollTo,
+      }),
+    ).toBe(true);
+    expect(
+      isPDFSearchMatchScrollRequest({
+        matchIndex: 6,
+        pageId: "page-3",
+        scrollTo,
+      }),
+    ).toBe(false);
+    expect(
+      isPDFSearchMatchScrollRequest({
+        matchIndex: 7,
+        pageId: "page-2",
+        scrollTo,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not consume page alignment or other overlay requests", () => {
+    expect(
+      isPDFSearchMatchScrollRequest({
+        matchIndex: 0,
+        pageId: "page-1",
+        scrollTo: { pageId: "page-1" },
+      }),
+    ).toBe(false);
+    expect(
+      isPDFSearchMatchScrollRequest({
+        matchIndex: 0,
+        pageId: "page-1",
+        scrollTo: {
+          pageId: "page-1",
+          target: { kind: "justification", id: "justification-1" },
+        },
+      }),
+    ).toBe(false);
   });
 });

--- a/apps/web/src/lib/pdf/pdf-page-scroll.logic.ts
+++ b/apps/web/src/lib/pdf/pdf-page-scroll.logic.ts
@@ -1,3 +1,5 @@
+import type { PDFScrollTo } from "@/lib/pdf/pdf-context";
+
 type GetPDFPageScrollTopArgs = {
   currentScrollTop: number;
   pageTop: number;
@@ -9,3 +11,18 @@ export const getPDFPageScrollTop = ({
   pageTop,
   viewportTop,
 }: GetPDFPageScrollTopArgs) => currentScrollTop + pageTop - viewportTop;
+
+type IsPDFSearchMatchScrollRequestArgs = {
+  matchIndex: number;
+  pageId: string;
+  scrollTo: PDFScrollTo | null;
+};
+
+export const isPDFSearchMatchScrollRequest = ({
+  matchIndex,
+  pageId,
+  scrollTo,
+}: IsPDFSearchMatchScrollRequestArgs): boolean =>
+  scrollTo?.pageId === pageId &&
+  scrollTo.target?.kind === "searchMatch" &&
+  scrollTo.target.matchIndex === matchIndex;

--- a/apps/web/src/lib/pdf/pdf-page-scroll.logic.ts
+++ b/apps/web/src/lib/pdf/pdf-page-scroll.logic.ts
@@ -1,0 +1,11 @@
+type GetPDFPageScrollTopArgs = {
+  currentScrollTop: number;
+  pageTop: number;
+  viewportTop: number;
+};
+
+export const getPDFPageScrollTop = ({
+  currentScrollTop,
+  pageTop,
+  viewportTop,
+}: GetPDFPageScrollTopArgs) => currentScrollTop + pageTop - viewportTop;

--- a/apps/web/src/lib/pdf/pdf-page.tsx
+++ b/apps/web/src/lib/pdf/pdf-page.tsx
@@ -1,4 +1,4 @@
-import { Suspense, use, useDeferredValue } from "react";
+import { Suspense, use, useDeferredValue, useRef } from "react";
 import type { ReactNode } from "react";
 
 import { Result } from "better-result";
@@ -6,10 +6,23 @@ import { useShallow } from "zustand/react/shallow";
 
 import { Skeleton } from "@stll/ui/components/skeleton";
 
-import { PAGE_ID_ATTRIBUTE, TEXT_LAYER_ATTRIBUTE } from "@/lib/pdf/consts";
+import {
+  PAGE_ID_ATTRIBUTE,
+  SCROLL_AREA_VIEWPORT_SELECTOR,
+  TEXT_LAYER_ATTRIBUTE,
+} from "@/lib/pdf/consts";
 import { usePDFStore } from "@/lib/pdf/pdf-context";
 import type { RenderPageResult } from "@/lib/pdf/pdf-context";
 import { PDFErrorBoundary } from "@/lib/pdf/pdf-error-boundary";
+import { getPDFPageScrollTop } from "@/lib/pdf/pdf-page-scroll.logic";
+import type { PDFSearchBox } from "@/lib/pdf/pdf-search";
+import { toPDFSearchViewportBox } from "@/lib/pdf/pdf-search";
+import { getCenteredSearchMatchScrollTop } from "@/lib/search-match-navigation";
+
+export type PDFPageSearchMatch = {
+  boxes: readonly PDFSearchBox[];
+  matchIndex: number;
+};
 
 export type PDFPageFallback = {
   suspense?: ReactNode | undefined;
@@ -18,6 +31,8 @@ export type PDFPageFallback = {
 
 export type PDFPageProps = {
   pageId: string;
+  activeSearchMatchIndex?: number | undefined;
+  searchMatches?: readonly PDFPageSearchMatch[] | undefined;
   /** Render function instead of ReactNode so the
    *  reference stays stable across parent re-renders,
    *  letting PDFPage skip unnecessary renders. */
@@ -25,7 +40,15 @@ export type PDFPageProps = {
   fallback?: PDFPageFallback | undefined;
 };
 
-export const PDFPage = ({ pageId, renderOverlay, fallback }: PDFPageProps) => {
+const EMPTY_SEARCH_MATCHES: readonly PDFPageSearchMatch[] = [];
+
+export const PDFPage = ({
+  pageId,
+  activeSearchMatchIndex,
+  searchMatches = EMPTY_SEARCH_MATCHES,
+  renderOverlay,
+  fallback,
+}: PDFPageProps) => {
   const [page, scrollTo, setScrollTo, isActive, renderPromise] = usePDFStore(
     useShallow((s) => [
       s.pages.get(pageId),
@@ -50,7 +73,18 @@ export const PDFPage = ({ pageId, renderOverlay, fallback }: PDFPageProps) => {
         if (!el || !shouldScrollToPage) {
           return;
         }
-        el.scrollIntoView({ block: "start" });
+        const scrollViewport = el.closest<HTMLElement>(
+          SCROLL_AREA_VIEWPORT_SELECTOR,
+        );
+        if (scrollViewport) {
+          scrollViewport.scrollTo({
+            top: getPDFPageScrollTop({
+              currentScrollTop: scrollViewport.scrollTop,
+              pageTop: el.getBoundingClientRect().top,
+              viewportTop: scrollViewport.getBoundingClientRect().top,
+            }),
+          });
+        }
         if (scrollTo.target === undefined) {
           setScrollTo(null);
         }
@@ -69,6 +103,11 @@ export const PDFPage = ({ pageId, renderOverlay, fallback }: PDFPageProps) => {
           {isActive && deferredPromise && (
             <>
               <PDFPageContent pageId={pageId} renderPromise={deferredPromise} />
+              <PDFSearchHighlights
+                activeMatchIndex={activeSearchMatchIndex}
+                matches={searchMatches}
+                pageId={pageId}
+              />
               {renderOverlay?.(pageId)}
             </>
           )}
@@ -137,5 +176,89 @@ const PDFPageContent = ({ pageId, renderPromise }: PDFPageContentProps) => {
         className="[&_span::selection]:bg-foreground/25 [&_br]:absolute [&_br]:z-1 [&_br]:origin-top-left [&_br]:cursor-text [&_br]:whitespace-pre [&_br]:text-transparent [&_br::selection]:bg-transparent [&_span]:absolute [&_span]:z-1 [&_span]:origin-top-left [&_span]:cursor-text [&_span]:whitespace-pre [&_span]:text-transparent"
       />
     </>
+  );
+};
+
+type PDFSearchHighlightsProps = {
+  activeMatchIndex?: number | undefined;
+  matches: readonly PDFPageSearchMatch[];
+  pageId: string;
+};
+
+const PDFSearchHighlights = ({
+  activeMatchIndex,
+  matches,
+  pageId,
+}: PDFSearchHighlightsProps) => {
+  const viewport = usePDFStore((state) => state.pages.get(pageId)?.viewport);
+  const scrolledMatchRef = useRef<number | null>(null);
+
+  if (!viewport || matches.length === 0) {
+    return null;
+  }
+
+  return (
+    <div
+      aria-hidden={true}
+      className="pointer-events-none absolute inset-0 z-2"
+      data-search-highlight-layer={true}
+    >
+      {matches.flatMap((match) =>
+        match.boxes.map((box, boxIndex) => {
+          const viewportBox = toPDFSearchViewportBox(box, viewport);
+          if (
+            !viewportBox ||
+            viewportBox.width <= 0 ||
+            viewportBox.height <= 0
+          ) {
+            return null;
+          }
+          const isActive = match.matchIndex === activeMatchIndex;
+
+          return (
+            <div
+              ref={(element) => {
+                if (
+                  !element ||
+                  !isActive ||
+                  boxIndex !== 0 ||
+                  scrolledMatchRef.current === match.matchIndex
+                ) {
+                  return;
+                }
+                const scrollViewport = element.closest<HTMLElement>(
+                  SCROLL_AREA_VIEWPORT_SELECTOR,
+                );
+                if (!scrollViewport) {
+                  return;
+                }
+                const containerRect = scrollViewport.getBoundingClientRect();
+                const matchRect = element.getBoundingClientRect();
+                scrollViewport.scrollTo({
+                  top: getCenteredSearchMatchScrollTop({
+                    containerHeight: containerRect.height,
+                    containerTop: containerRect.top,
+                    currentScrollTop: scrollViewport.scrollTop,
+                    matchHeight: matchRect.height,
+                    matchTop: matchRect.top,
+                  }),
+                });
+                scrolledMatchRef.current = match.matchIndex;
+              }}
+              className={
+                isActive
+                  ? "search-document-highlight bg-highlight/90 ring-highlight-foreground/30 absolute rounded-xs ring-1"
+                  : "search-document-highlight bg-highlight/45 absolute rounded-xs"
+              }
+              data-active={isActive ? "true" : undefined}
+              data-search-highlight={true}
+              data-search-match-index={match.matchIndex}
+              key={`${match.matchIndex}:${box.x}:${box.y}:${box.width}:${box.height}`}
+              style={viewportBox}
+            />
+          );
+        }),
+      )}
+    </div>
   );
 };

--- a/apps/web/src/lib/pdf/pdf-page.tsx
+++ b/apps/web/src/lib/pdf/pdf-page.tsx
@@ -1,5 +1,5 @@
-import { Suspense, use, useDeferredValue, useRef } from "react";
-import type { ReactNode } from "react";
+import { Suspense, use, useCallback, useDeferredValue } from "react";
+import type { CSSProperties, ReactNode } from "react";
 
 import { Result } from "better-result";
 import { useShallow } from "zustand/react/shallow";
@@ -11,10 +11,13 @@ import {
   SCROLL_AREA_VIEWPORT_SELECTOR,
   TEXT_LAYER_ATTRIBUTE,
 } from "@/lib/pdf/consts";
-import { usePDFStore } from "@/lib/pdf/pdf-context";
-import type { RenderPageResult } from "@/lib/pdf/pdf-context";
+import { usePDFStore, usePDFStoreApi } from "@/lib/pdf/pdf-context";
+import type { PDFScrollTo, RenderPageResult } from "@/lib/pdf/pdf-context";
 import { PDFErrorBoundary } from "@/lib/pdf/pdf-error-boundary";
-import { getPDFPageScrollTop } from "@/lib/pdf/pdf-page-scroll.logic";
+import {
+  getPDFPageScrollTop,
+  isPDFSearchMatchScrollRequest,
+} from "@/lib/pdf/pdf-page-scroll.logic";
 import type { PDFSearchBox } from "@/lib/pdf/pdf-search";
 import { toPDFSearchViewportBox } from "@/lib/pdf/pdf-search";
 import { getCenteredSearchMatchScrollTop } from "@/lib/search-match-navigation";
@@ -191,7 +194,7 @@ const PDFSearchHighlights = ({
   pageId,
 }: PDFSearchHighlightsProps) => {
   const viewport = usePDFStore((state) => state.pages.get(pageId)?.viewport);
-  const scrolledMatchRef = useRef<number | null>(null);
+  const scrollTo = usePDFStore((state) => state.scrollTo);
 
   if (!viewport || matches.length === 0) {
     return null;
@@ -216,49 +219,100 @@ const PDFSearchHighlights = ({
           const isActive = match.matchIndex === activeMatchIndex;
 
           return (
-            <div
-              ref={(element) => {
-                if (
-                  !element ||
-                  !isActive ||
-                  boxIndex !== 0 ||
-                  scrolledMatchRef.current === match.matchIndex
-                ) {
-                  return;
-                }
-                const scrollViewport = element.closest<HTMLElement>(
-                  SCROLL_AREA_VIEWPORT_SELECTOR,
-                );
-                if (!scrollViewport) {
-                  return;
-                }
-                const containerRect = scrollViewport.getBoundingClientRect();
-                const matchRect = element.getBoundingClientRect();
-                scrollViewport.scrollTo({
-                  top: getCenteredSearchMatchScrollTop({
-                    containerHeight: containerRect.height,
-                    containerTop: containerRect.top,
-                    currentScrollTop: scrollViewport.scrollTop,
-                    matchHeight: matchRect.height,
-                    matchTop: matchRect.top,
-                  }),
-                });
-                scrolledMatchRef.current = match.matchIndex;
-              }}
-              className={
-                isActive
-                  ? "search-document-highlight bg-highlight/90 ring-highlight-foreground/30 absolute rounded-xs ring-1"
-                  : "search-document-highlight bg-highlight/45 absolute rounded-xs"
-              }
-              data-active={isActive ? "true" : undefined}
-              data-search-highlight={true}
-              data-search-match-index={match.matchIndex}
+            <PDFSearchHighlightBox
+              boxIndex={boxIndex}
+              isActive={isActive}
               key={`${match.matchIndex}:${box.x}:${box.y}:${box.width}:${box.height}`}
+              matchIndex={match.matchIndex}
+              pageId={pageId}
+              scrollTo={scrollTo}
               style={viewportBox}
             />
           );
         }),
       )}
     </div>
+  );
+};
+
+type PDFSearchHighlightBoxProps = {
+  boxIndex: number;
+  isActive: boolean;
+  matchIndex: number;
+  pageId: string;
+  scrollTo: PDFScrollTo | null;
+  style: CSSProperties;
+};
+
+const PDFSearchHighlightBox = ({
+  boxIndex,
+  isActive,
+  matchIndex,
+  pageId,
+  scrollTo,
+  style,
+}: PDFSearchHighlightBoxProps) => {
+  const store = usePDFStoreApi();
+  const shouldCenter =
+    boxIndex === 0 &&
+    isActive &&
+    isPDFSearchMatchScrollRequest({ matchIndex, pageId, scrollTo });
+  const highlightRef = useCallback(
+    (element: HTMLDivElement | null) => {
+      if (!element || !shouldCenter) {
+        return;
+      }
+
+      // The page ref first aligns the requested page. Centre the match in the
+      // following frame, using post-alignment geometry, and consume only the
+      // same request so a newer citation/anonymization jump cannot be cleared.
+      requestAnimationFrame(() => {
+        if (
+          !element.isConnected ||
+          element.dataset["active"] !== "true" ||
+          !isPDFSearchMatchScrollRequest({
+            matchIndex,
+            pageId,
+            scrollTo: store.getState().scrollTo,
+          })
+        ) {
+          return;
+        }
+        const scrollViewport = element.closest<HTMLElement>(
+          SCROLL_AREA_VIEWPORT_SELECTOR,
+        );
+        if (!scrollViewport) {
+          return;
+        }
+        const containerRect = scrollViewport.getBoundingClientRect();
+        const matchRect = element.getBoundingClientRect();
+        scrollViewport.scrollTo({
+          top: getCenteredSearchMatchScrollTop({
+            containerHeight: containerRect.height,
+            containerTop: containerRect.top,
+            currentScrollTop: scrollViewport.scrollTop,
+            matchHeight: matchRect.height,
+            matchTop: matchRect.top,
+          }),
+        });
+        store.getState().setScrollTo(null);
+      });
+    },
+    [matchIndex, pageId, shouldCenter, store],
+  );
+
+  return (
+    <div
+      ref={highlightRef}
+      className={
+        isActive
+          ? "search-document-highlight bg-highlight/90 ring-highlight-foreground/30 absolute rounded-xs ring-1"
+          : "search-document-highlight bg-highlight/45 absolute rounded-xs"
+      }
+      data-active={isActive ? "true" : undefined}
+      data-search-highlight={true}
+      data-search-match-index={matchIndex}
+      style={style}
+    />
   );
 };

--- a/apps/web/src/lib/pdf/pdf-renderer.ts
+++ b/apps/web/src/lib/pdf/pdf-renderer.ts
@@ -128,7 +128,11 @@ export const renderPage = async (
         signal.removeEventListener("abort", onAbort);
       }
 
-      return Result.ok({ canvas, textLayerDiv, viewport });
+      return Result.ok({
+        canvas,
+        textLayerDiv,
+        viewport,
+      });
     },
     catch: (err) =>
       isRenderingCancelledError(err, renderingCancelledException)

--- a/apps/web/src/lib/pdf/pdf-search-worker-client.ts
+++ b/apps/web/src/lib/pdf/pdf-search-worker-client.ts
@@ -17,14 +17,14 @@ type FindPDFSearchResultsInWorkerOptions = PDFSearchWorkerRequest & {
 
 const abortError = () => new DOMException("PDF search cancelled", "AbortError");
 
-export const findPDFSearchResultsInWorker = ({
+export const findPDFSearchResultsInWorker = async ({
   bytes,
   password,
   searchText,
   signal,
 }: FindPDFSearchResultsInWorkerOptions): Promise<PDFSearchResult | null> => {
   if (signal.aborted) {
-    return Promise.reject(abortError());
+    throw abortError();
   }
 
   const worker = new Worker(
@@ -67,11 +67,12 @@ export const findPDFSearchResultsInWorker = ({
       "error",
       (event) => {
         dispose();
+        const cause: unknown = event.error;
         reject(
           new PDFViewerError({
             code: "LOAD_FAILED",
             message: "PDF search worker failed",
-            cause: event.error,
+            cause,
           }),
         );
       },

--- a/apps/web/src/lib/pdf/pdf-search-worker-client.ts
+++ b/apps/web/src/lib/pdf/pdf-search-worker-client.ts
@@ -1,0 +1,89 @@
+import { PDFViewerError } from "@/lib/pdf/pdf-errors";
+import type { PDFSearchResult } from "@/lib/pdf/pdf-search";
+
+type PDFSearchWorkerRequest = {
+  bytes: ArrayBuffer;
+  password?: string | undefined;
+  searchText: string;
+};
+
+type PDFSearchWorkerResponse =
+  | { status: "error"; message: string }
+  | { status: "success"; result: PDFSearchResult | null };
+
+type FindPDFSearchResultsInWorkerOptions = PDFSearchWorkerRequest & {
+  signal: AbortSignal;
+};
+
+const abortError = () => new DOMException("PDF search cancelled", "AbortError");
+
+export const findPDFSearchResultsInWorker = ({
+  bytes,
+  password,
+  searchText,
+  signal,
+}: FindPDFSearchResultsInWorkerOptions): Promise<PDFSearchResult | null> => {
+  if (signal.aborted) {
+    return Promise.reject(abortError());
+  }
+
+  const worker = new Worker(
+    new URL("../../workers/pdf-search-worker.ts", import.meta.url),
+    { type: "module" },
+  );
+
+  return new Promise((resolve, reject) => {
+    let handleAbort: (() => void) | null = null;
+    const dispose = () => {
+      if (handleAbort) {
+        signal.removeEventListener("abort", handleAbort);
+      }
+      worker.terminate();
+    };
+    handleAbort = () => {
+      dispose();
+      reject(abortError());
+    };
+
+    signal.addEventListener("abort", handleAbort, { once: true });
+    worker.addEventListener(
+      "message",
+      (event: MessageEvent<PDFSearchWorkerResponse>) => {
+        dispose();
+        if (event.data.status === "success") {
+          resolve(event.data.result);
+          return;
+        }
+        reject(
+          new PDFViewerError({
+            code: "LOAD_FAILED",
+            message: event.data.message,
+          }),
+        );
+      },
+      { once: true },
+    );
+    worker.addEventListener(
+      "error",
+      (event) => {
+        dispose();
+        reject(
+          new PDFViewerError({
+            code: "LOAD_FAILED",
+            message: "PDF search worker failed",
+            cause: event.error,
+          }),
+        );
+      },
+      { once: true },
+    );
+
+    const request: PDFSearchWorkerRequest = {
+      bytes,
+      searchText,
+      ...(password !== undefined && { password }),
+    };
+    // eslint-disable-next-line unicorn/require-post-message-target-origin -- Worker.postMessage has no targetOrigin parameter
+    worker.postMessage(request, [bytes]);
+  });
+};

--- a/apps/web/src/lib/pdf/pdf-search-worker-client.ts
+++ b/apps/web/src/lib/pdf/pdf-search-worker-client.ts
@@ -83,7 +83,7 @@ export const findPDFSearchResultsInWorker = ({
       searchText,
       ...(password !== undefined && { password }),
     };
-    // eslint-disable-next-line unicorn/require-post-message-target-origin -- Worker.postMessage has no targetOrigin parameter
-    worker.postMessage(request, [bytes]);
+    const sendRequest = worker.postMessage.bind(worker);
+    sendRequest(request, [bytes]);
   });
 };

--- a/apps/web/src/lib/pdf/pdf-search-worker-client.ts
+++ b/apps/web/src/lib/pdf/pdf-search-worker-client.ts
@@ -32,59 +32,62 @@ export const findPDFSearchResultsInWorker = async ({
     { type: "module" },
   );
 
-  return new Promise((resolve, reject) => {
-    let handleAbort: (() => void) | null = null;
-    const dispose = () => {
-      if (handleAbort) {
-        signal.removeEventListener("abort", handleAbort);
-      }
-      worker.terminate();
-    };
-    handleAbort = () => {
-      dispose();
-      reject(abortError());
-    };
-
-    signal.addEventListener("abort", handleAbort, { once: true });
-    worker.addEventListener(
-      "message",
-      (event: MessageEvent<PDFSearchWorkerResponse>) => {
-        dispose();
-        if (event.data.status === "success") {
-          resolve(event.data.result);
-          return;
+  const result = await new Promise<PDFSearchResult | null>(
+    (resolve, reject) => {
+      let handleAbort: (() => void) | null = null;
+      const dispose = () => {
+        if (handleAbort) {
+          signal.removeEventListener("abort", handleAbort);
         }
-        reject(
-          new PDFViewerError({
-            code: "LOAD_FAILED",
-            message: event.data.message,
-          }),
-        );
-      },
-      { once: true },
-    );
-    worker.addEventListener(
-      "error",
-      (event) => {
+        worker.terminate();
+      };
+      handleAbort = () => {
         dispose();
-        const cause: unknown = event.error;
-        reject(
-          new PDFViewerError({
-            code: "LOAD_FAILED",
-            message: "PDF search worker failed",
-            cause,
-          }),
-        );
-      },
-      { once: true },
-    );
+        reject(abortError());
+      };
 
-    const request: PDFSearchWorkerRequest = {
-      bytes,
-      searchText,
-      ...(password !== undefined && { password }),
-    };
-    const sendRequest = worker.postMessage.bind(worker);
-    sendRequest(request, [bytes]);
-  });
+      signal.addEventListener("abort", handleAbort, { once: true });
+      worker.addEventListener(
+        "message",
+        (event: MessageEvent<PDFSearchWorkerResponse>) => {
+          dispose();
+          if (event.data.status === "success") {
+            resolve(event.data.result);
+            return;
+          }
+          reject(
+            new PDFViewerError({
+              code: "LOAD_FAILED",
+              message: event.data.message,
+            }),
+          );
+        },
+        { once: true },
+      );
+      worker.addEventListener(
+        "error",
+        (event) => {
+          dispose();
+          const cause: unknown = event.error;
+          reject(
+            new PDFViewerError({
+              code: "LOAD_FAILED",
+              message: "PDF search worker failed",
+              cause,
+            }),
+          );
+        },
+        { once: true },
+      );
+
+      const request: PDFSearchWorkerRequest = {
+        bytes,
+        searchText,
+        ...(password !== undefined && { password }),
+      };
+      const sendRequest = worker.postMessage.bind(worker);
+      sendRequest(request, [bytes]);
+    },
+  );
+  return result;
 };

--- a/apps/web/src/lib/pdf/pdf-search-worker-client.ts
+++ b/apps/web/src/lib/pdf/pdf-search-worker-client.ts
@@ -1,21 +1,24 @@
 import { PDFViewerError } from "@/lib/pdf/pdf-errors";
 import type { PDFSearchResult } from "@/lib/pdf/pdf-search";
+import {
+  isPDFSearchWorkerResponseForRequest,
+  type PDFSearchWorkerRequest,
+  type PDFSearchWorkerResponse,
+} from "@/lib/pdf/pdf-search-worker-protocol";
 
-type PDFSearchWorkerRequest = {
-  bytes: ArrayBuffer;
-  password?: string | undefined;
-  searchText: string;
-};
-
-type PDFSearchWorkerResponse =
-  | { status: "error"; message: string }
-  | { status: "success"; result: PDFSearchResult | null };
-
-type FindPDFSearchResultsInWorkerOptions = PDFSearchWorkerRequest & {
-  signal: AbortSignal;
-};
+type FindPDFSearchResultsInWorkerOptions = Omit<
+  PDFSearchWorkerRequest,
+  "requestId"
+> & { signal: AbortSignal };
 
 const abortError = () => new DOMException("PDF search cancelled", "AbortError");
+
+let nextPDFSearchRequestId = 0;
+
+const createPDFSearchRequestId = (): number => {
+  nextPDFSearchRequestId += 1;
+  return nextPDFSearchRequestId;
+};
 
 export const findPDFSearchResultsInWorker = async ({
   bytes,
@@ -31,6 +34,7 @@ export const findPDFSearchResultsInWorker = async ({
     new URL("../../workers/pdf-search-worker.ts", import.meta.url),
     { type: "module" },
   );
+  const requestId = createPDFSearchRequestId();
 
   const result = await new Promise<PDFSearchResult | null>(
     (resolve, reject) => {
@@ -50,6 +54,9 @@ export const findPDFSearchResultsInWorker = async ({
       worker.addEventListener(
         "message",
         (event: MessageEvent<PDFSearchWorkerResponse>) => {
+          if (!isPDFSearchWorkerResponseForRequest(event.data, requestId)) {
+            return;
+          }
           dispose();
           if (event.data.status === "success") {
             resolve(event.data.result);
@@ -62,7 +69,6 @@ export const findPDFSearchResultsInWorker = async ({
             }),
           );
         },
-        { once: true },
       );
       worker.addEventListener(
         "error",
@@ -82,6 +88,7 @@ export const findPDFSearchResultsInWorker = async ({
 
       const request: PDFSearchWorkerRequest = {
         bytes,
+        requestId,
         searchText,
         ...(password !== undefined && { password }),
       };

--- a/apps/web/src/lib/pdf/pdf-search-worker-protocol.test.ts
+++ b/apps/web/src/lib/pdf/pdf-search-worker-protocol.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from "bun:test";
+
+import { isPDFSearchWorkerResponseForRequest } from "@/lib/pdf/pdf-search-worker-protocol";
+import type { PDFSearchWorkerResponse } from "@/lib/pdf/pdf-search-worker-protocol";
+
+describe("PDF search worker protocol", () => {
+  test("correlates responses with exactly one request", () => {
+    const response = {
+      status: "success",
+      requestId: 7,
+      result: null,
+    } satisfies PDFSearchWorkerResponse;
+
+    expect(isPDFSearchWorkerResponseForRequest(response, 7)).toBeTrue();
+    expect(isPDFSearchWorkerResponseForRequest(response, 8)).toBeFalse();
+  });
+});

--- a/apps/web/src/lib/pdf/pdf-search-worker-protocol.ts
+++ b/apps/web/src/lib/pdf/pdf-search-worker-protocol.ts
@@ -1,10 +1,11 @@
 import type { PDFSearchResult } from "@/lib/pdf/pdf-search";
+import type { SearchTextQuery } from "@/lib/search-text";
 
 export type PDFSearchWorkerRequest = {
   bytes: ArrayBuffer;
   password?: string | undefined;
   requestId: number;
-  searchText: string;
+  searchText: SearchTextQuery;
 };
 
 export type PDFSearchWorkerResponse =

--- a/apps/web/src/lib/pdf/pdf-search-worker-protocol.ts
+++ b/apps/web/src/lib/pdf/pdf-search-worker-protocol.ts
@@ -1,0 +1,17 @@
+import type { PDFSearchResult } from "@/lib/pdf/pdf-search";
+
+export type PDFSearchWorkerRequest = {
+  bytes: ArrayBuffer;
+  password?: string | undefined;
+  requestId: number;
+  searchText: string;
+};
+
+export type PDFSearchWorkerResponse =
+  | { status: "error"; message: string; requestId: number }
+  | { status: "success"; requestId: number; result: PDFSearchResult | null };
+
+export const isPDFSearchWorkerResponseForRequest = (
+  response: PDFSearchWorkerResponse,
+  requestId: number,
+): boolean => response.requestId === requestId;

--- a/apps/web/src/lib/pdf/pdf-search.test.ts
+++ b/apps/web/src/lib/pdf/pdf-search.test.ts
@@ -7,6 +7,7 @@ import {
   mergePDFSearchBoxes,
   toPDFSearchViewportBox,
 } from "@/lib/pdf/pdf-search";
+import { MAX_SEARCH_PREVIEW_MATCHES } from "@/lib/search-match-navigation";
 
 const createSearchablePDF = async () => {
   const pdf = PDF.create();
@@ -62,7 +63,79 @@ describe("canonical PDF search", () => {
     expect(result?.matches.map((match) => match.pageIndex)).toEqual([0, 1, 1]);
   });
 
-  test("reports truncation only after observing the cap plus one", async () => {
+  test("searches PDF portfolio pages in viewer render order", async () => {
+    const createAttachment = async (
+      pages: readonly { text: string; y: number }[],
+    ) => {
+      const pdf = PDF.create();
+      for (const { text, y } of pages) {
+        const page = pdf.addPage({ size: "letter" });
+        page.drawText(text, { x: 50, y, size: 18 });
+      }
+      return await pdf.save();
+    };
+
+    const portfolio = PDF.create();
+    const containerPage = portfolio.addPage({ size: "letter" });
+    containerPage.drawText("needle in container", {
+      x: 50,
+      y: 700,
+      size: 18,
+    });
+    portfolio.addAttachment(
+      "z-second.pdf",
+      await createAttachment([{ text: "needle second", y: 500 }]),
+    );
+    portfolio.addAttachment(
+      "a-first.pdf",
+      await createAttachment([
+        { text: "needle first page", y: 700 },
+        { text: "needle next page", y: 600 },
+      ]),
+    );
+    portfolio.addAttachment("ignored.txt", new TextEncoder().encode("needle"));
+
+    const result = await findPDFSearchResults({
+      bytes: await portfolio.save(),
+      searchText: "needle",
+      signal: new AbortController().signal,
+    });
+
+    expect(result?.matches).toHaveLength(3);
+    expect(result?.matches.map((match) => match.pageIndex)).toEqual([0, 1, 2]);
+    expect(result?.matches.at(0)?.boxes.at(0)?.y).toBeGreaterThan(
+      result?.matches.at(1)?.boxes.at(0)?.y ?? Number.POSITIVE_INFINITY,
+    );
+    expect(result?.matches.at(1)?.boxes.at(0)?.y).toBeGreaterThan(
+      result?.matches.at(2)?.boxes.at(0)?.y ?? Number.POSITIVE_INFINITY,
+    );
+  });
+
+  test("searches root pages when attachments do not form a portfolio", async () => {
+    const attachment = PDF.create();
+    const attachmentPage = attachment.addPage({ size: "letter" });
+    attachmentPage.drawText("needle in attachment", {
+      x: 50,
+      y: 700,
+      size: 18,
+    });
+
+    const pdf = PDF.create();
+    const firstPage = pdf.addPage({ size: "letter" });
+    firstPage.drawText("needle in root", { x: 50, y: 700, size: 18 });
+    pdf.addPage({ size: "letter" });
+    pdf.addAttachment("attachment.pdf", await attachment.save());
+
+    const result = await findPDFSearchResults({
+      bytes: await pdf.save(),
+      searchText: "needle",
+      signal: new AbortController().signal,
+    });
+
+    expect(result?.matches.map((match) => match.pageIndex)).toEqual([0]);
+  });
+
+  test("bounds one page at the global cap plus one", async () => {
     const createPDFWithHits = async (count: number) => {
       const pdf = PDF.create();
       const page = pdf.addPage({ size: "letter" });
@@ -71,20 +144,39 @@ describe("canonical PDF search", () => {
     };
 
     const atCap = await findPDFSearchResults({
-      bytes: await createPDFWithHits(200),
+      bytes: await createPDFWithHits(MAX_SEARCH_PREVIEW_MATCHES),
       searchText: "hit",
       signal: new AbortController().signal,
     });
     const overCap = await findPDFSearchResults({
-      bytes: await createPDFWithHits(201),
+      bytes: await createPDFWithHits(MAX_SEARCH_PREVIEW_MATCHES + 1),
       searchText: "hit",
       signal: new AbortController().signal,
     });
 
-    expect(atCap?.matches).toHaveLength(200);
+    expect(atCap?.matches).toHaveLength(MAX_SEARCH_PREVIEW_MATCHES);
     expect(atCap?.truncated).toBe(false);
-    expect(overCap?.matches).toHaveLength(200);
+    expect(overCap?.matches).toHaveLength(MAX_SEARCH_PREVIEW_MATCHES);
     expect(overCap?.truncated).toBe(true);
+  });
+
+  test("bounds normalized-only matches at the global cap plus one", async () => {
+    const pdf = PDF.create();
+    const page = pdf.addPage({ size: "letter" });
+    page.drawText("odstepeni ".repeat(MAX_SEARCH_PREVIEW_MATCHES + 1), {
+      x: 20,
+      y: 700,
+      size: 8,
+    });
+
+    const result = await findPDFSearchResults({
+      bytes: await pdf.save(),
+      searchText: "odštěpení",
+      signal: new AbortController().signal,
+    });
+
+    expect(result?.matches).toHaveLength(MAX_SEARCH_PREVIEW_MATCHES);
+    expect(result?.truncated).toBe(true);
   });
 
   test("stops before loading LibPDF when the search is cancelled", async () => {

--- a/apps/web/src/lib/pdf/pdf-search.test.ts
+++ b/apps/web/src/lib/pdf/pdf-search.test.ts
@@ -62,19 +62,29 @@ describe("canonical PDF search", () => {
     expect(result?.matches.map((match) => match.pageIndex)).toEqual([0, 1, 1]);
   });
 
-  test("bounds preview work and reports additional matches", async () => {
-    const pdf = PDF.create();
-    const page = pdf.addPage({ size: "letter" });
-    page.drawText("hit ".repeat(201), { x: 20, y: 700, size: 8 });
+  test("reports truncation only after observing the cap plus one", async () => {
+    const createPDFWithHits = async (count: number) => {
+      const pdf = PDF.create();
+      const page = pdf.addPage({ size: "letter" });
+      page.drawText("hit ".repeat(count), { x: 20, y: 700, size: 8 });
+      return await pdf.save();
+    };
 
-    const result = await findPDFSearchResults({
-      bytes: await pdf.save(),
+    const atCap = await findPDFSearchResults({
+      bytes: await createPDFWithHits(200),
+      searchText: "hit",
+      signal: new AbortController().signal,
+    });
+    const overCap = await findPDFSearchResults({
+      bytes: await createPDFWithHits(201),
       searchText: "hit",
       signal: new AbortController().signal,
     });
 
-    expect(result?.matches).toHaveLength(200);
-    expect(result?.truncated).toBe(true);
+    expect(atCap?.matches).toHaveLength(200);
+    expect(atCap?.truncated).toBe(false);
+    expect(overCap?.matches).toHaveLength(200);
+    expect(overCap?.truncated).toBe(true);
   });
 
   test("stops before loading LibPDF when the search is cancelled", async () => {

--- a/apps/web/src/lib/pdf/pdf-search.test.ts
+++ b/apps/web/src/lib/pdf/pdf-search.test.ts
@@ -63,6 +63,19 @@ describe("canonical PDF search", () => {
     expect(result?.matches.map((match) => match.pageIndex)).toEqual([0, 1, 1]);
   });
 
+  test("finds every independently marked term even when one forms a phrase", async () => {
+    const result = await findPDFSearchResults({
+      bytes: await createSearchablePDF(),
+      searchText: {
+        type: "separate-terms",
+        terms: ["Due Diligence", "Introduction"],
+      },
+      signal: new AbortController().signal,
+    });
+
+    expect(result?.matches.map((match) => match.pageIndex)).toEqual([0, 1]);
+  });
+
   test("searches PDF portfolio pages in viewer render order", async () => {
     const createAttachment = async (
       pages: readonly { text: string; y: number }[],

--- a/apps/web/src/lib/pdf/pdf-search.test.ts
+++ b/apps/web/src/lib/pdf/pdf-search.test.ts
@@ -53,6 +53,29 @@ describe("canonical PDF search", () => {
     expect(result?.matches.at(0)?.boxes.length).toBeGreaterThan(0);
   });
 
+  test("preserves geometry offsets across length-changing case folds", async () => {
+    const pdf = PDF.create();
+    const font = pdf.embedFont(
+      await Bun.file(
+        new URL(
+          "../../../../landing/public/fonts/CabinetGrotesk-Regular.otf",
+          import.meta.url,
+        ),
+      ).bytes(),
+    );
+    const page = pdf.addPage({ size: "letter" });
+    page.drawText("İXYZ", { font, x: 50, y: 700, size: 18 });
+
+    const result = await findPDFSearchResults({
+      bytes: await pdf.save(),
+      searchText: "Y",
+      signal: new AbortController().signal,
+    });
+
+    expect(result?.matches).toHaveLength(1);
+    expect(result?.matches.at(0)?.textOffset).toBe(2);
+  });
+
   test("finds every query term when the exact phrase is absent", async () => {
     const result = await findPDFSearchResults({
       bytes: await createSearchablePDF(),

--- a/apps/web/src/lib/pdf/pdf-search.test.ts
+++ b/apps/web/src/lib/pdf/pdf-search.test.ts
@@ -63,6 +63,50 @@ describe("canonical PDF search", () => {
     expect(result?.matches.map((match) => match.pageIndex)).toEqual([0, 1, 1]);
   });
 
+  test("combines fallback terms in document order before applying the cap", async () => {
+    const pdf = PDF.create();
+    const page = pdf.addPage({ size: "letter" });
+    page.drawText(`rare ${"common ".repeat(MAX_SEARCH_PREVIEW_MATCHES + 1)}`, {
+      x: 20,
+      y: 700,
+      size: 8,
+    });
+
+    const result = await findPDFSearchResults({
+      bytes: await pdf.save(),
+      searchText: "common rare",
+      signal: new AbortController().signal,
+    });
+
+    expect(result?.matches).toHaveLength(MAX_SEARCH_PREVIEW_MATCHES);
+    expect(result?.truncated).toBe(true);
+    expect(result?.matches.at(0)?.boxes.at(0)?.x).toBeLessThan(
+      result?.matches.at(1)?.boxes.at(0)?.x ?? 0,
+    );
+  });
+
+  test("preserves extracted text order instead of imposing an x-axis order", async () => {
+    const pdf = PDF.create();
+    const page = pdf.addPage({ size: "letter" });
+    page.drawText("needle", { x: 400, y: 700, size: 12 });
+    page.drawText("needle", { x: 100, y: 700, size: 12 });
+
+    const result = await findPDFSearchResults({
+      bytes: await pdf.save(),
+      searchText: "needle",
+      signal: new AbortController().signal,
+    });
+
+    expect(result?.matches.map((match) => match.boxes.at(0)?.x)).toEqual([
+      100, 400,
+    ]);
+    const offsets = result?.matches.map((match) => match.textOffset) ?? [];
+    expect(offsets).toHaveLength(2);
+    expect(offsets.at(0) ?? Number.POSITIVE_INFINITY).toBeLessThan(
+      offsets.at(1) ?? Number.NEGATIVE_INFINITY,
+    );
+  });
+
   test("finds every independently marked term even when one forms a phrase", async () => {
     const result = await findPDFSearchResults({
       bytes: await createSearchablePDF(),

--- a/apps/web/src/lib/pdf/pdf-search.test.ts
+++ b/apps/web/src/lib/pdf/pdf-search.test.ts
@@ -1,4 +1,5 @@
 import { PDF } from "@libpdf/core";
+import { Result } from "better-result";
 import { describe, expect, test } from "bun:test";
 
 import {
@@ -80,13 +81,20 @@ describe("canonical PDF search", () => {
     const abortController = new AbortController();
     abortController.abort();
 
-    await expect(
-      findPDFSearchResults({
-        bytes: new Uint8Array(),
-        searchText: "term",
-        signal: abortController.signal,
-      }),
-    ).rejects.toMatchObject({ name: "AbortError" });
+    const result = await Result.tryPromise({
+      try: async () =>
+        await findPDFSearchResults({
+          bytes: new Uint8Array(),
+          searchText: "term",
+          signal: abortController.signal,
+        }),
+      catch: (cause) => cause,
+    });
+
+    expect(Result.isError(result)).toBe(true);
+    if (Result.isError(result)) {
+      expect(result.error).toMatchObject({ name: "AbortError" });
+    }
   });
 });
 

--- a/apps/web/src/lib/pdf/pdf-search.test.ts
+++ b/apps/web/src/lib/pdf/pdf-search.test.ts
@@ -319,6 +319,19 @@ describe("PDF search highlight geometry", () => {
     ]);
   });
 
+  test("merges nearby RTL boxes without bridging distant visual segments", () => {
+    expect(
+      mergePDFSearchBoxes([
+        { x: 100, y: 20, width: 5, height: 8 },
+        { x: 95, y: 20, width: 5, height: 8 },
+        { x: 20, y: 20, width: 5, height: 8 },
+      ]),
+    ).toEqual([
+      { x: 95, y: 20, width: 10, height: 8 },
+      { x: 20, y: 20, width: 5, height: 8 },
+    ]);
+  });
+
   test("maps bottom-left PDF coordinates through the active viewport", () => {
     expect(
       toPDFSearchViewportBox(

--- a/apps/web/src/lib/pdf/pdf-search.test.ts
+++ b/apps/web/src/lib/pdf/pdf-search.test.ts
@@ -1,0 +1,117 @@
+import { PDF } from "@libpdf/core";
+import { describe, expect, test } from "bun:test";
+
+import {
+  findPDFSearchResults,
+  mergePDFSearchBoxes,
+  toPDFSearchViewportBox,
+} from "@/lib/pdf/pdf-search";
+
+const createSearchablePDF = async () => {
+  const pdf = PDF.create();
+  const firstPage = pdf.addPage({ size: "letter" });
+  firstPage.drawText("Introduction", { x: 50, y: 700, size: 18 });
+  const secondPage = pdf.addPage({ size: "letter" });
+  secondPage.drawText("Due Diligence Report", { x: 72, y: 640, size: 18 });
+  secondPage.drawText("Another diligence review", {
+    x: 72,
+    y: 600,
+    size: 18,
+  });
+  return await pdf.save();
+};
+
+describe("canonical PDF search", () => {
+  test("finds case-insensitive text and returns LibPDF geometry", async () => {
+    const result = await findPDFSearchResults({
+      bytes: await createSearchablePDF(),
+      searchText: "DILIGENCE",
+      signal: new AbortController().signal,
+    });
+
+    expect(result?.matches).toHaveLength(2);
+    expect(result?.matches.map((match) => match.pageIndex)).toEqual([1, 1]);
+    expect(result?.matches.at(0)?.boxes.length).toBeGreaterThan(0);
+    expect(result?.matches.at(0)?.boxes.at(0)?.width).toBeGreaterThan(0);
+    expect(result?.matches.at(0)?.boxes.at(0)?.height).toBeGreaterThan(0);
+  });
+
+  test("normalizes OCR and embedded-text diacritic differences", async () => {
+    const pdf = PDF.create();
+    const page = pdf.addPage({ size: "letter" });
+    page.drawText("odštepení", { x: 50, y: 700, size: 18 });
+
+    const result = await findPDFSearchResults({
+      bytes: await pdf.save(),
+      searchText: "odštěpení",
+      signal: new AbortController().signal,
+    });
+
+    expect(result?.matches).toHaveLength(1);
+    expect(result?.matches.at(0)?.boxes.length).toBeGreaterThan(0);
+  });
+
+  test("finds every query term when the exact phrase is absent", async () => {
+    const result = await findPDFSearchResults({
+      bytes: await createSearchablePDF(),
+      searchText: "introduction diligence",
+      signal: new AbortController().signal,
+    });
+
+    expect(result?.matches.map((match) => match.pageIndex)).toEqual([0, 1, 1]);
+  });
+
+  test("bounds preview work and reports additional matches", async () => {
+    const pdf = PDF.create();
+    const page = pdf.addPage({ size: "letter" });
+    page.drawText("hit ".repeat(201), { x: 20, y: 700, size: 8 });
+
+    const result = await findPDFSearchResults({
+      bytes: await pdf.save(),
+      searchText: "hit",
+      signal: new AbortController().signal,
+    });
+
+    expect(result?.matches).toHaveLength(200);
+    expect(result?.truncated).toBe(true);
+  });
+
+  test("stops before loading LibPDF when the search is cancelled", async () => {
+    const abortController = new AbortController();
+    abortController.abort();
+
+    await expect(
+      findPDFSearchResults({
+        bytes: new Uint8Array(),
+        searchText: "term",
+        signal: abortController.signal,
+      }),
+    ).rejects.toMatchObject({ name: "AbortError" });
+  });
+});
+
+describe("PDF search highlight geometry", () => {
+  test("merges adjacent character boxes but preserves separate lines", () => {
+    expect(
+      mergePDFSearchBoxes([
+        { x: 10, y: 20, width: 4, height: 8 },
+        { x: 14, y: 20, width: 5, height: 8 },
+        { x: 10, y: 8, width: 6, height: 8 },
+      ]),
+    ).toEqual([
+      { x: 10, y: 20, width: 9, height: 8 },
+      { x: 10, y: 8, width: 6, height: 8 },
+    ]);
+  });
+
+  test("maps bottom-left PDF coordinates through the active viewport", () => {
+    expect(
+      toPDFSearchViewportBox(
+        { x: 10, y: 20, width: 30, height: 5 },
+        {
+          convertToViewportPoint: (x, y) => [x * 2, 1000 - y * 2],
+        },
+      ),
+    ).toEqual({ left: 20, top: 950, width: 60, height: 10 });
+  });
+});

--- a/apps/web/src/lib/pdf/pdf-search.test.ts
+++ b/apps/web/src/lib/pdf/pdf-search.test.ts
@@ -143,6 +143,31 @@ describe("canonical PDF search", () => {
     expect(result?.matches.map((match) => match.pageIndex)).toEqual([0, 1]);
   });
 
+  test("prefers the longest independently marked term when ranges overlap", async () => {
+    const pdf = PDF.create();
+    const page = pdf.addPage({ size: "letter" });
+    page.drawText("bar foobar", { x: 50, y: 700, size: 18 });
+
+    const result = await findPDFSearchResults({
+      bytes: await pdf.save(),
+      searchText: {
+        type: "separate-terms",
+        terms: ["bar", "foobar"],
+      },
+      signal: new AbortController().signal,
+    });
+
+    expect(
+      result?.matches.map(({ textEndOffset, textOffset }) => ({
+        textEndOffset,
+        textOffset,
+      })),
+    ).toEqual([
+      { textEndOffset: 3, textOffset: 0 },
+      { textEndOffset: 10, textOffset: 4 },
+    ]);
+  });
+
   test("searches PDF portfolio pages in viewer render order", async () => {
     const createAttachment = async (
       pages: readonly { text: string; y: number }[],

--- a/apps/web/src/lib/pdf/pdf-search.ts
+++ b/apps/web/src/lib/pdf/pdf-search.ts
@@ -263,29 +263,29 @@ export const toPDFSearchViewportBox = (
   box: PDFSearchBox,
   viewport: Pick<PageViewport, "convertToViewportPoint">,
 ): PDFSearchViewportBox | null => {
-  const start = viewport.convertToViewportPoint(box.x, box.y);
-  const end = viewport.convertToViewportPoint(
-    box.x + box.width,
-    box.y + box.height,
+  const parsePoint = (value: unknown) => {
+    if (!Array.isArray(value)) {
+      return null;
+    }
+    const x: unknown = value.at(0);
+    const y: unknown = value.at(1);
+    if (typeof x !== "number" || typeof y !== "number") {
+      return null;
+    }
+    return { x, y };
+  };
+  const start = parsePoint(viewport.convertToViewportPoint(box.x, box.y));
+  const end = parsePoint(
+    viewport.convertToViewportPoint(box.x + box.width, box.y + box.height),
   );
-  const startX = start.at(0);
-  const startY = start.at(1);
-  const endX = end.at(0);
-  const endY = end.at(1);
-
-  if (
-    typeof startX !== "number" ||
-    typeof startY !== "number" ||
-    typeof endX !== "number" ||
-    typeof endY !== "number"
-  ) {
+  if (!start || !end) {
     return null;
   }
 
   return {
-    left: Math.min(startX, endX),
-    top: Math.min(startY, endY),
-    width: Math.abs(endX - startX),
-    height: Math.abs(endY - startY),
+    left: Math.min(start.x, end.x),
+    top: Math.min(start.y, end.y),
+    width: Math.abs(end.x - start.x),
+    height: Math.abs(end.y - start.y),
   };
 };

--- a/apps/web/src/lib/pdf/pdf-search.ts
+++ b/apps/web/src/lib/pdf/pdf-search.ts
@@ -240,12 +240,12 @@ const getViewerSearchPages = async (
   const { PDF } = await import("@libpdf/core");
   const pages: ViewerSearchPage[] = [];
   const attachments = await Promise.all(
-    pdfAttachments.map((content) => {
+    pdfAttachments.map(async (content) => {
       signal.throwIfAborted();
       // Embedded portfolio PDFs are loaded without the container password,
       // just like the viewer's attachment loading path. Promise.all preserves
       // the name-tree order used by the viewer.
-      return PDF.load(content);
+      return await PDF.load(content);
     }),
   );
   signal.throwIfAborted();

--- a/apps/web/src/lib/pdf/pdf-search.ts
+++ b/apps/web/src/lib/pdf/pdf-search.ts
@@ -1,0 +1,291 @@
+import type { PDFPage } from "@libpdf/core";
+
+import type { PageViewport } from "@/lib/pdf/pdfjs-loader";
+import { MAX_SEARCH_PREVIEW_MATCHES } from "@/lib/search-match-navigation";
+import {
+  findNormalizedSearchTextMatches,
+  getSearchTextCandidates,
+} from "@/lib/search-text";
+
+export type PDFSearchBox = {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+};
+
+export type PDFSearchMatch = {
+  pageIndex: number;
+  boxes: PDFSearchBox[];
+};
+
+export type PDFSearchResult = {
+  matches: PDFSearchMatch[];
+  truncated: boolean;
+};
+
+export type PDFSearchViewportBox = {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+};
+
+type FindPDFSearchResultsOptions = {
+  bytes: Uint8Array;
+  password?: string | undefined;
+  searchText: string;
+  signal: AbortSignal;
+};
+
+const MIN_SAME_LINE_OVERLAP_RATIO = 0.5;
+const MAX_INLINE_GAP_HEIGHT_RATIO = 0.75;
+
+const getVerticalOverlap = (first: PDFSearchBox, second: PDFSearchBox) =>
+  Math.max(
+    0,
+    Math.min(first.y + first.height, second.y + second.height) -
+      Math.max(first.y, second.y),
+  );
+
+const canMergePDFSearchBoxes = (
+  current: PDFSearchBox,
+  next: PDFSearchBox,
+): boolean => {
+  const minimumHeight = Math.min(current.height, next.height);
+  const verticalOverlap = getVerticalOverlap(current, next);
+  const horizontalGap = next.x - (current.x + current.width);
+  const maximumInlineGap =
+    Math.max(current.height, next.height) * MAX_INLINE_GAP_HEIGHT_RATIO;
+
+  return (
+    minimumHeight > 0 &&
+    verticalOverlap / minimumHeight >= MIN_SAME_LINE_OVERLAP_RATIO &&
+    horizontalGap <= maximumInlineGap
+  );
+};
+
+export const mergePDFSearchBoxes = (
+  boxes: readonly PDFSearchBox[],
+): PDFSearchBox[] => {
+  const merged: PDFSearchBox[] = [];
+
+  for (const box of boxes) {
+    if (box.width <= 0 || box.height <= 0) {
+      continue;
+    }
+
+    const current = merged.at(-1);
+    if (!current || !canMergePDFSearchBoxes(current, box)) {
+      merged.push({ ...box });
+      continue;
+    }
+
+    const right = Math.max(current.x + current.width, box.x + box.width);
+    const top = Math.max(current.y + current.height, box.y + box.height);
+    current.x = Math.min(current.x, box.x);
+    current.y = Math.min(current.y, box.y);
+    current.width = right - current.x;
+    current.height = top - current.y;
+  }
+
+  return merged;
+};
+
+type PageText = ReturnType<PDFPage["extractText"]>;
+
+type PageSearchText = {
+  boxesByOffset: (PDFSearchBox | null)[];
+  text: string;
+};
+
+const buildPageSearchText = (pageText: PageText): PageSearchText => {
+  const boxesByOffset: (PDFSearchBox | null)[] = [];
+  const textParts: string[] = [];
+
+  for (const [lineIndex, line] of pageText.lines.entries()) {
+    if (lineIndex > 0) {
+      textParts.push("\n");
+      boxesByOffset.push(null);
+    }
+
+    for (const span of line.spans) {
+      for (const character of span.chars) {
+        textParts.push(character.char);
+        for (const _codeUnit of character.char.split("")) {
+          boxesByOffset.push(character.bbox);
+        }
+      }
+    }
+  }
+
+  return { boxesByOffset, text: textParts.join("") };
+};
+
+const getPDFSearchMatchKey = ({ boxes, pageIndex }: PDFSearchMatch): string =>
+  `${String(pageIndex)}:${boxes
+    .map(
+      (box) =>
+        `${String(box.x)}:${String(box.y)}:${String(box.width)}:${String(box.height)}`,
+    )
+    .join("|")}`;
+
+const comparePDFSearchMatches = (
+  first: PDFSearchMatch,
+  second: PDFSearchMatch,
+) => {
+  if (first.pageIndex !== second.pageIndex) {
+    return first.pageIndex - second.pageIndex;
+  }
+  const firstBox = first.boxes.at(0);
+  const secondBox = second.boxes.at(0);
+  if (!firstBox || !secondBox) {
+    return 0;
+  }
+  return secondBox.y - firstBox.y || firstBox.x - secondBox.x;
+};
+
+const findNormalizedPageMatches = (
+  page: PDFPage,
+  candidate: string,
+): PDFSearchMatch[] => {
+  const pageSearchText = buildPageSearchText(page.extractText());
+
+  return findNormalizedSearchTextMatches(pageSearchText.text, candidate)
+    .map((match) => {
+      const boxes = pageSearchText.boxesByOffset
+        .slice(match.start, match.end)
+        .filter((box): box is PDFSearchBox => box !== null);
+      return {
+        pageIndex: page.index,
+        boxes: mergePDFSearchBoxes(boxes),
+      };
+    })
+    .filter((match) => match.boxes.length > 0);
+};
+
+const findPageMatches = (
+  page: PDFPage,
+  candidate: string,
+): PDFSearchMatch[] => {
+  const exactMatches = page
+    .findText(candidate, { caseSensitive: false })
+    .map((match) => ({
+      pageIndex: page.index,
+      boxes: mergePDFSearchBoxes(
+        match.charBoxes.length > 0 ? match.charBoxes : [match.bbox],
+      ),
+    }));
+  const matches = new Map<string, PDFSearchMatch>();
+
+  for (const match of [
+    ...exactMatches,
+    ...findNormalizedPageMatches(page, candidate),
+  ]) {
+    if (match.boxes.length > 0) {
+      matches.set(getPDFSearchMatchKey(match), match);
+    }
+  }
+
+  return [...matches.values()].toSorted(comparePDFSearchMatches);
+};
+
+export const findPDFSearchResults = async ({
+  bytes,
+  password,
+  searchText,
+  signal,
+}: FindPDFSearchResultsOptions): Promise<PDFSearchResult | null> => {
+  signal.throwIfAborted();
+  const { PDF } = await import("@libpdf/core");
+  signal.throwIfAborted();
+  const pdf = await PDF.load(
+    bytes,
+    password ? { credentials: password } : undefined,
+  );
+  signal.throwIfAborted();
+
+  const pages = pdf.getPages();
+  const candidates = getSearchTextCandidates(searchText);
+
+  const findCandidateMatches = (candidate: string) => {
+    const matches: PDFSearchMatch[] = [];
+
+    for (const page of pages) {
+      signal.throwIfAborted();
+      matches.push(...findPageMatches(page, candidate));
+      if (matches.length >= MAX_SEARCH_PREVIEW_MATCHES) {
+        return {
+          matches: matches.slice(0, MAX_SEARCH_PREVIEW_MATCHES),
+          truncated: true,
+        };
+      }
+    }
+
+    return { matches, truncated: false };
+  };
+
+  const phraseCandidate = candidates.at(0);
+  const phraseResult = phraseCandidate
+    ? findCandidateMatches(phraseCandidate)
+    : { matches: [], truncated: false };
+  if (phraseResult.matches.length > 0 || candidates.length <= 1) {
+    return phraseResult.matches.length > 0 ? phraseResult : null;
+  }
+
+  const matches = new Map<string, PDFSearchMatch>();
+  for (const candidate of candidates.slice(1)) {
+    const candidateResult = findCandidateMatches(candidate);
+    for (const match of candidateResult.matches) {
+      matches.set(getPDFSearchMatchKey(match), match);
+      if (matches.size >= MAX_SEARCH_PREVIEW_MATCHES) {
+        return {
+          matches: [...matches.values()]
+            .toSorted(comparePDFSearchMatches)
+            .slice(0, MAX_SEARCH_PREVIEW_MATCHES),
+          truncated: true,
+        };
+      }
+    }
+  }
+
+  if (matches.size === 0) {
+    return null;
+  }
+
+  return {
+    matches: [...matches.values()].toSorted(comparePDFSearchMatches),
+    truncated: false,
+  };
+};
+
+export const toPDFSearchViewportBox = (
+  box: PDFSearchBox,
+  viewport: Pick<PageViewport, "convertToViewportPoint">,
+): PDFSearchViewportBox | null => {
+  const start = viewport.convertToViewportPoint(box.x, box.y);
+  const end = viewport.convertToViewportPoint(
+    box.x + box.width,
+    box.y + box.height,
+  );
+  const startX = start.at(0);
+  const startY = start.at(1);
+  const endX = end.at(0);
+  const endY = end.at(1);
+
+  if (
+    typeof startX !== "number" ||
+    typeof startY !== "number" ||
+    typeof endX !== "number" ||
+    typeof endY !== "number"
+  ) {
+    return null;
+  }
+
+  return {
+    left: Math.min(startX, endX),
+    top: Math.min(startY, endY),
+    width: Math.abs(endX - startX),
+    height: Math.abs(endY - startY),
+  };
+};

--- a/apps/web/src/lib/pdf/pdf-search.ts
+++ b/apps/web/src/lib/pdf/pdf-search.ts
@@ -5,6 +5,7 @@ import { MAX_SEARCH_PREVIEW_MATCHES } from "@/lib/search-match-navigation";
 import {
   findNormalizedSearchTextMatches,
   getSearchTextCandidates,
+  selectNonOverlappingSearchMatches,
 } from "@/lib/search-text";
 import type { SearchTextQuery } from "@/lib/search-text";
 
@@ -18,6 +19,7 @@ export type PDFSearchBox = {
 export type PDFSearchMatch = {
   pageIndex: number;
   boxes: PDFSearchBox[];
+  textEndOffset: number;
   textOffset: number;
 };
 
@@ -131,13 +133,18 @@ const buildPageSearchText = (pageText: PageText): PageSearchText => {
 
 const getPDFSearchMatchKey = ({
   pageIndex,
+  textEndOffset,
   textOffset,
-}: PDFSearchMatch): string => `${String(pageIndex)}:${String(textOffset)}`;
+}: PDFSearchMatch): string =>
+  `${String(pageIndex)}:${String(textOffset)}:${String(textEndOffset)}`;
 
 const comparePDFSearchMatches = (
   first: PDFSearchMatch,
   second: PDFSearchMatch,
-) => first.pageIndex - second.pageIndex || first.textOffset - second.textOffset;
+) =>
+  first.pageIndex - second.pageIndex ||
+  first.textOffset - second.textOffset ||
+  second.textEndOffset - first.textEndOffset;
 
 type ToPDFSearchMatchOptions = {
   end: number;
@@ -158,6 +165,7 @@ const toPDFSearchMatch = ({
   return {
     pageIndex,
     boxes: mergePDFSearchBoxes(boxes),
+    textEndOffset: end,
     textOffset: start,
   };
 };
@@ -297,12 +305,22 @@ export const findPDFSearchResults = async ({
   const toResult = (
     matches: ReadonlyMap<string, PDFSearchMatch>,
     truncated: boolean,
-  ): PDFSearchResult => ({
-    matches: [...matches.values()]
-      .toSorted(comparePDFSearchMatches)
-      .slice(0, MAX_SEARCH_PREVIEW_MATCHES),
-    truncated: truncated || matches.size > MAX_SEARCH_PREVIEW_MATCHES,
-  });
+  ): PDFSearchResult => {
+    const selectedMatches = selectNonOverlappingSearchMatches({
+      getRange: ({
+        pageIndex: group,
+        textEndOffset: end,
+        textOffset: start,
+      }) => ({ end, group, start }),
+      matches: matches.values(),
+      maxMatches: MAX_SEARCH_PREVIEW_MATCHES + 1,
+    }).toSorted(comparePDFSearchMatches);
+    return {
+      matches: selectedMatches.slice(0, MAX_SEARCH_PREVIEW_MATCHES),
+      truncated:
+        truncated || selectedMatches.length > MAX_SEARCH_PREVIEW_MATCHES,
+    };
+  };
 
   const collectCandidates = (searchCandidates: readonly string[]) => {
     const matches = new Map<string, PDFSearchMatch>();

--- a/apps/web/src/lib/pdf/pdf-search.ts
+++ b/apps/web/src/lib/pdf/pdf-search.ts
@@ -139,34 +139,6 @@ const comparePDFSearchMatches = (
   second: PDFSearchMatch,
 ) => first.pageIndex - second.pageIndex || first.textOffset - second.textOffset;
 
-type FindCaseInsensitiveSearchTextMatchesOptions = {
-  content: string;
-  maxMatches: number;
-  searchText: string;
-};
-
-const findCaseInsensitiveSearchTextMatches = ({
-  content,
-  maxMatches,
-  searchText,
-}: FindCaseInsensitiveSearchTextMatchesOptions) => {
-  const matches: { start: number; end: number }[] = [];
-  const normalizedContent = content.toLowerCase();
-  const normalizedSearchText = searchText.toLowerCase();
-  let searchFrom = 0;
-
-  while (matches.length < maxMatches) {
-    const start = normalizedContent.indexOf(normalizedSearchText, searchFrom);
-    if (start === -1) {
-      break;
-    }
-    matches.push({ start, end: start + normalizedSearchText.length });
-    searchFrom = start + 1;
-  }
-
-  return matches;
-};
-
 type ToPDFSearchMatchOptions = {
   end: number;
   pageIndex: number;
@@ -223,44 +195,13 @@ const findPageMatches = ({
   maxMatches,
   pageIndex,
   pageSearchText,
-}: FindPageMatchesOptions): PDFSearchMatch[] => {
-  const matches = new Map<string, PDFSearchMatch>();
-
-  const exactMatches = findCaseInsensitiveSearchTextMatches({
-    content: pageSearchText.text,
+}: FindPageMatchesOptions): PDFSearchMatch[] =>
+  findNormalizedPageMatches({
+    candidate,
     maxMatches,
-    searchText: candidate,
+    pageSearchText,
+    pageIndex,
   });
-  for (const { end, start } of exactMatches) {
-    const match = toPDFSearchMatch({
-      end,
-      pageIndex,
-      pageSearchText,
-      start,
-    });
-    if (match.boxes.length > 0) {
-      matches.set(getPDFSearchMatchKey(match), match);
-    }
-  }
-
-  if (matches.size < maxMatches) {
-    for (const match of findNormalizedPageMatches({
-      candidate,
-      maxMatches,
-      pageSearchText,
-      pageIndex,
-    })) {
-      if (match.boxes.length > 0) {
-        matches.set(getPDFSearchMatchKey(match), match);
-      }
-      if (matches.size >= maxMatches) {
-        break;
-      }
-    }
-  }
-
-  return [...matches.values()].toSorted(comparePDFSearchMatches);
-};
 
 const getViewerSearchPages = async (
   pdf: PDF,

--- a/apps/web/src/lib/pdf/pdf-search.ts
+++ b/apps/web/src/lib/pdf/pdf-search.ts
@@ -208,44 +208,47 @@ export const findPDFSearchResults = async ({
   const pages = pdf.getPages();
   const candidates = getSearchTextCandidates(searchText);
 
-  const findCandidateMatches = (candidate: string) => {
-    const matches: PDFSearchMatch[] = [];
-
+  const collectCandidateMatches = (
+    candidate: string,
+    matches: Map<string, PDFSearchMatch>,
+  ): boolean => {
     for (const page of pages) {
       signal.throwIfAborted();
-      matches.push(...findPageMatches(page, candidate));
-      if (matches.length >= MAX_SEARCH_PREVIEW_MATCHES) {
-        return {
-          matches: matches.slice(0, MAX_SEARCH_PREVIEW_MATCHES),
-          truncated: true,
-        };
+      for (const match of findPageMatches(page, candidate)) {
+        matches.set(getPDFSearchMatchKey(match), match);
+        if (matches.size > MAX_SEARCH_PREVIEW_MATCHES) {
+          return true;
+        }
       }
     }
-
-    return { matches, truncated: false };
+    return false;
   };
 
+  const toResult = (
+    matches: ReadonlyMap<string, PDFSearchMatch>,
+    truncated: boolean,
+  ): PDFSearchResult => ({
+    matches: [...matches.values()]
+      .toSorted(comparePDFSearchMatches)
+      .slice(0, MAX_SEARCH_PREVIEW_MATCHES),
+    truncated,
+  });
+
   const phraseCandidate = candidates.at(0);
-  const phraseResult = phraseCandidate
-    ? findCandidateMatches(phraseCandidate)
-    : { matches: [], truncated: false };
-  if (phraseResult.matches.length > 0 || candidates.length <= 1) {
-    return phraseResult.matches.length > 0 ? phraseResult : null;
+  const phraseMatches = new Map<string, PDFSearchMatch>();
+  const phraseTruncated = phraseCandidate
+    ? collectCandidateMatches(phraseCandidate, phraseMatches)
+    : false;
+  if (phraseMatches.size > 0 || candidates.length <= 1) {
+    return phraseMatches.size > 0
+      ? toResult(phraseMatches, phraseTruncated)
+      : null;
   }
 
   const matches = new Map<string, PDFSearchMatch>();
   for (const candidate of candidates.slice(1)) {
-    const candidateResult = findCandidateMatches(candidate);
-    for (const match of candidateResult.matches) {
-      matches.set(getPDFSearchMatchKey(match), match);
-      if (matches.size >= MAX_SEARCH_PREVIEW_MATCHES) {
-        return {
-          matches: [...matches.values()]
-            .toSorted(comparePDFSearchMatches)
-            .slice(0, MAX_SEARCH_PREVIEW_MATCHES),
-          truncated: true,
-        };
-      }
+    if (collectCandidateMatches(candidate, matches)) {
+      return toResult(matches, true);
     }
   }
 
@@ -253,10 +256,7 @@ export const findPDFSearchResults = async ({
     return null;
   }
 
-  return {
-    matches: [...matches.values()].toSorted(comparePDFSearchMatches),
-    truncated: false,
-  };
+  return toResult(matches, false);
 };
 
 export const toPDFSearchViewportBox = (

--- a/apps/web/src/lib/pdf/pdf-search.ts
+++ b/apps/web/src/lib/pdf/pdf-search.ts
@@ -1,4 +1,4 @@
-import type { PDFPage } from "@libpdf/core";
+import type { PDF, PDFPage } from "@libpdf/core";
 
 import type { PageViewport } from "@/lib/pdf/pdfjs-loader";
 import { MAX_SEARCH_PREVIEW_MATCHES } from "@/lib/search-match-navigation";
@@ -36,6 +36,11 @@ type FindPDFSearchResultsOptions = {
   password?: string | undefined;
   searchText: string;
   signal: AbortSignal;
+};
+
+type ViewerSearchPage = {
+  page: PDFPage;
+  pageIndex: number;
 };
 
 const MIN_SAME_LINE_OVERLAP_RATIO = 0.5;
@@ -145,49 +150,170 @@ const comparePDFSearchMatches = (
   return secondBox.y - firstBox.y || firstBox.x - secondBox.x;
 };
 
-const findNormalizedPageMatches = (
-  page: PDFPage,
-  candidate: string,
-): PDFSearchMatch[] => {
-  const pageSearchText = buildPageSearchText(page.extractText());
+type FindCaseInsensitiveSearchTextMatchesOptions = {
+  content: string;
+  maxMatches: number;
+  searchText: string;
+};
 
-  return findNormalizedSearchTextMatches(pageSearchText.text, candidate)
-    .map((match) => {
-      const boxes = pageSearchText.boxesByOffset
-        .slice(match.start, match.end)
-        .filter((box): box is PDFSearchBox => box !== null);
-      return {
-        pageIndex: page.index,
-        boxes: mergePDFSearchBoxes(boxes),
-      };
-    })
+const findCaseInsensitiveSearchTextMatches = ({
+  content,
+  maxMatches,
+  searchText,
+}: FindCaseInsensitiveSearchTextMatchesOptions) => {
+  const matches: { start: number; end: number }[] = [];
+  const normalizedContent = content.toLowerCase();
+  const normalizedSearchText = searchText.toLowerCase();
+  let searchFrom = 0;
+
+  while (matches.length < maxMatches) {
+    const start = normalizedContent.indexOf(normalizedSearchText, searchFrom);
+    if (start === -1) {
+      break;
+    }
+    matches.push({ start, end: start + normalizedSearchText.length });
+    searchFrom = start + 1;
+  }
+
+  return matches;
+};
+
+type ToPDFSearchMatchOptions = {
+  end: number;
+  pageIndex: number;
+  pageSearchText: PageSearchText;
+  start: number;
+};
+
+const toPDFSearchMatch = ({
+  end,
+  pageIndex,
+  pageSearchText,
+  start,
+}: ToPDFSearchMatchOptions): PDFSearchMatch => {
+  const boxes = pageSearchText.boxesByOffset
+    .slice(start, end)
+    .filter((box): box is PDFSearchBox => box !== null);
+  return {
+    pageIndex,
+    boxes: mergePDFSearchBoxes(boxes),
+  };
+};
+
+type FindNormalizedPageMatchesOptions = {
+  candidate: string;
+  maxMatches: number;
+  pageIndex: number;
+  pageSearchText: PageSearchText;
+};
+
+const findNormalizedPageMatches = ({
+  candidate,
+  maxMatches,
+  pageIndex,
+  pageSearchText,
+}: FindNormalizedPageMatchesOptions): PDFSearchMatch[] => {
+  return findNormalizedSearchTextMatches(pageSearchText.text, candidate, {
+    maxMatches,
+  })
+    .map(({ end, start }) =>
+      toPDFSearchMatch({ end, pageIndex, pageSearchText, start }),
+    )
     .filter((match) => match.boxes.length > 0);
 };
 
-const findPageMatches = (
-  page: PDFPage,
-  candidate: string,
-): PDFSearchMatch[] => {
-  const exactMatches = page
-    .findText(candidate, { caseSensitive: false })
-    .map((match) => ({
-      pageIndex: page.index,
-      boxes: mergePDFSearchBoxes(
-        match.charBoxes.length > 0 ? match.charBoxes : [match.bbox],
-      ),
-    }));
+type FindPageMatchesOptions = {
+  candidate: string;
+  maxMatches: number;
+  pageIndex: number;
+  pageSearchText: PageSearchText;
+};
+
+const findPageMatches = ({
+  candidate,
+  maxMatches,
+  pageIndex,
+  pageSearchText,
+}: FindPageMatchesOptions): PDFSearchMatch[] => {
   const matches = new Map<string, PDFSearchMatch>();
 
-  for (const match of [
-    ...exactMatches,
-    ...findNormalizedPageMatches(page, candidate),
-  ]) {
+  const exactMatches = findCaseInsensitiveSearchTextMatches({
+    content: pageSearchText.text,
+    maxMatches,
+    searchText: candidate,
+  });
+  for (const { end, start } of exactMatches) {
+    const match = toPDFSearchMatch({
+      end,
+      pageIndex,
+      pageSearchText,
+      start,
+    });
     if (match.boxes.length > 0) {
       matches.set(getPDFSearchMatchKey(match), match);
     }
   }
 
+  if (matches.size < maxMatches) {
+    for (const match of findNormalizedPageMatches({
+      candidate,
+      maxMatches,
+      pageSearchText,
+      pageIndex,
+    })) {
+      if (match.boxes.length > 0) {
+        matches.set(getPDFSearchMatchKey(match), match);
+      }
+      if (matches.size >= maxMatches) {
+        break;
+      }
+    }
+  }
+
   return [...matches.values()].toSorted(comparePDFSearchMatches);
+};
+
+const getViewerSearchPages = async (
+  pdf: PDF,
+  signal: AbortSignal,
+): Promise<ViewerSearchPage[]> => {
+  const rootPages = pdf.getPages();
+  const pdfAttachments: Uint8Array[] = [];
+
+  for (const [name, attachment] of pdf.getAttachments()) {
+    signal.throwIfAborted();
+    if (!attachment.filename.trim().toLowerCase().endsWith(".pdf")) {
+      continue;
+    }
+    const content = pdf.getAttachment(name);
+    if (content) {
+      pdfAttachments.push(content);
+    }
+  }
+
+  if (rootPages.length > 1 || pdfAttachments.length === 0) {
+    return rootPages.map((page, pageIndex) => ({ page, pageIndex }));
+  }
+
+  const { PDF } = await import("@libpdf/core");
+  const pages: ViewerSearchPage[] = [];
+  const attachments = await Promise.all(
+    pdfAttachments.map((content) => {
+      signal.throwIfAborted();
+      // Embedded portfolio PDFs are loaded without the container password,
+      // just like the viewer's attachment loading path. Promise.all preserves
+      // the name-tree order used by the viewer.
+      return PDF.load(content);
+    }),
+  );
+  signal.throwIfAborted();
+  for (const attachment of attachments) {
+    for (const page of attachment.getPages()) {
+      signal.throwIfAborted();
+      pages.push({ page, pageIndex: pages.length });
+    }
+  }
+  return pages;
 };
 
 export const findPDFSearchResults = async ({
@@ -205,16 +331,32 @@ export const findPDFSearchResults = async ({
   );
   signal.throwIfAborted();
 
-  const pages = pdf.getPages();
+  const pages = await getViewerSearchPages(pdf, signal);
+  signal.throwIfAborted();
   const candidates = getSearchTextCandidates(searchText);
+  const pageSearchTextCache = new WeakMap<PDFPage, PageSearchText>();
 
   const collectCandidateMatches = (
     candidate: string,
     matches: Map<string, PDFSearchMatch>,
   ): boolean => {
-    for (const page of pages) {
+    for (const { page, pageIndex } of pages) {
       signal.throwIfAborted();
-      for (const match of findPageMatches(page, candidate)) {
+      const remainingMatchLimit = MAX_SEARCH_PREVIEW_MATCHES + 1 - matches.size;
+      if (remainingMatchLimit <= 0) {
+        return true;
+      }
+      let pageSearchText = pageSearchTextCache.get(page);
+      if (!pageSearchText) {
+        pageSearchText = buildPageSearchText(page.extractText());
+        pageSearchTextCache.set(page, pageSearchText);
+      }
+      for (const match of findPageMatches({
+        candidate,
+        maxMatches: remainingMatchLimit,
+        pageSearchText,
+        pageIndex,
+      })) {
         matches.set(getPDFSearchMatchKey(match), match);
         if (matches.size > MAX_SEARCH_PREVIEW_MATCHES) {
           return true;

--- a/apps/web/src/lib/pdf/pdf-search.ts
+++ b/apps/web/src/lib/pdf/pdf-search.ts
@@ -18,6 +18,7 @@ export type PDFSearchBox = {
 export type PDFSearchMatch = {
   pageIndex: number;
   boxes: PDFSearchBox[];
+  textOffset: number;
 };
 
 export type PDFSearchResult = {
@@ -128,28 +129,15 @@ const buildPageSearchText = (pageText: PageText): PageSearchText => {
   return { boxesByOffset, text: textParts.join("") };
 };
 
-const getPDFSearchMatchKey = ({ boxes, pageIndex }: PDFSearchMatch): string =>
-  `${String(pageIndex)}:${boxes
-    .map(
-      (box) =>
-        `${String(box.x)}:${String(box.y)}:${String(box.width)}:${String(box.height)}`,
-    )
-    .join("|")}`;
+const getPDFSearchMatchKey = ({
+  pageIndex,
+  textOffset,
+}: PDFSearchMatch): string => `${String(pageIndex)}:${String(textOffset)}`;
 
 const comparePDFSearchMatches = (
   first: PDFSearchMatch,
   second: PDFSearchMatch,
-) => {
-  if (first.pageIndex !== second.pageIndex) {
-    return first.pageIndex - second.pageIndex;
-  }
-  const firstBox = first.boxes.at(0);
-  const secondBox = second.boxes.at(0);
-  if (!firstBox || !secondBox) {
-    return 0;
-  }
-  return secondBox.y - firstBox.y || firstBox.x - secondBox.x;
-};
+) => first.pageIndex - second.pageIndex || first.textOffset - second.textOffset;
 
 type FindCaseInsensitiveSearchTextMatchesOptions = {
   content: string;
@@ -198,6 +186,7 @@ const toPDFSearchMatch = ({
   return {
     pageIndex,
     boxes: mergePDFSearchBoxes(boxes),
+    textOffset: start,
   };
 };
 
@@ -336,15 +325,13 @@ export const findPDFSearchResults = async ({
   const candidates = getSearchTextCandidates(searchText);
   const pageSearchTextCache = new WeakMap<PDFPage, PageSearchText>();
 
-  const collectCandidateMatches = (
-    candidate: string,
-    matches: Map<string, PDFSearchMatch>,
-  ): boolean => {
+  const collectCandidateMatches = (candidate: string) => {
+    const matches = new Map<string, PDFSearchMatch>();
     for (const { page, pageIndex } of pages) {
       signal.throwIfAborted();
       const remainingMatchLimit = MAX_SEARCH_PREVIEW_MATCHES + 1 - matches.size;
       if (remainingMatchLimit <= 0) {
-        return true;
+        return { matches, truncated: true };
       }
       let pageSearchText = pageSearchTextCache.get(page);
       if (!pageSearchText) {
@@ -359,11 +346,11 @@ export const findPDFSearchResults = async ({
       })) {
         matches.set(getPDFSearchMatchKey(match), match);
         if (matches.size > MAX_SEARCH_PREVIEW_MATCHES) {
-          return true;
+          return { matches, truncated: true };
         }
       }
     }
-    return false;
+    return { matches, truncated: false };
   };
 
   const toResult = (
@@ -373,44 +360,44 @@ export const findPDFSearchResults = async ({
     matches: [...matches.values()]
       .toSorted(comparePDFSearchMatches)
       .slice(0, MAX_SEARCH_PREVIEW_MATCHES),
-    truncated,
+    truncated: truncated || matches.size > MAX_SEARCH_PREVIEW_MATCHES,
   });
 
-  if (typeof searchText !== "string") {
+  const collectCandidates = (searchCandidates: readonly string[]) => {
     const matches = new Map<string, PDFSearchMatch>();
     let truncated = false;
-    for (const candidate of candidates) {
-      truncated ||= collectCandidateMatches(candidate, matches);
-      if (truncated) {
-        break;
+    for (const candidate of searchCandidates) {
+      const candidateResult = collectCandidateMatches(candidate);
+      truncated ||= candidateResult.truncated;
+      for (const [key, match] of candidateResult.matches) {
+        matches.set(key, match);
       }
     }
-    return toResult(matches, truncated);
+    return { matches, truncated };
+  };
+
+  if (typeof searchText !== "string") {
+    const result = collectCandidates(candidates);
+    return toResult(result.matches, result.truncated);
   }
 
   const phraseCandidate = candidates.at(0);
-  const phraseMatches = new Map<string, PDFSearchMatch>();
-  const phraseTruncated = phraseCandidate
-    ? collectCandidateMatches(phraseCandidate, phraseMatches)
-    : false;
-  if (phraseMatches.size > 0 || candidates.length <= 1) {
-    return phraseMatches.size > 0
-      ? toResult(phraseMatches, phraseTruncated)
+  const phraseResult = phraseCandidate
+    ? collectCandidateMatches(phraseCandidate)
+    : { matches: new Map<string, PDFSearchMatch>(), truncated: false };
+  if (phraseResult.matches.size > 0 || candidates.length <= 1) {
+    return phraseResult.matches.size > 0
+      ? toResult(phraseResult.matches, phraseResult.truncated)
       : null;
   }
 
-  const matches = new Map<string, PDFSearchMatch>();
-  for (const candidate of candidates.slice(1)) {
-    if (collectCandidateMatches(candidate, matches)) {
-      return toResult(matches, true);
-    }
-  }
+  const result = collectCandidates(candidates.slice(1));
 
-  if (matches.size === 0) {
+  if (result.matches.size === 0) {
     return null;
   }
 
-  return toResult(matches, false);
+  return toResult(result.matches, result.truncated);
 };
 
 export const toPDFSearchViewportBox = (

--- a/apps/web/src/lib/pdf/pdf-search.ts
+++ b/apps/web/src/lib/pdf/pdf-search.ts
@@ -228,7 +228,7 @@ const getViewerSearchPages = async (
   const { PDF } = await import("@libpdf/core");
   const pages: ViewerSearchPage[] = [];
   const attachments = await Promise.all(
-    pdfAttachments.map((content) => {
+    pdfAttachments.map(async (content) => {
       signal.throwIfAborted();
       // Embedded portfolio PDFs are loaded without the container password,
       // just like the viewer's attachment loading path. Promise.all preserves

--- a/apps/web/src/lib/pdf/pdf-search.ts
+++ b/apps/web/src/lib/pdf/pdf-search.ts
@@ -240,7 +240,7 @@ const getViewerSearchPages = async (
   const { PDF } = await import("@libpdf/core");
   const pages: ViewerSearchPage[] = [];
   const attachments = await Promise.all(
-    pdfAttachments.map(async (content) => {
+    pdfAttachments.map((content) => {
       signal.throwIfAborted();
       // Embedded portfolio PDFs are loaded without the container password,
       // just like the viewer's attachment loading path. Promise.all preserves

--- a/apps/web/src/lib/pdf/pdf-search.ts
+++ b/apps/web/src/lib/pdf/pdf-search.ts
@@ -6,6 +6,7 @@ import {
   findNormalizedSearchTextMatches,
   getSearchTextCandidates,
 } from "@/lib/search-text";
+import type { SearchTextQuery } from "@/lib/search-text";
 
 export type PDFSearchBox = {
   x: number;
@@ -34,7 +35,7 @@ export type PDFSearchViewportBox = {
 type FindPDFSearchResultsOptions = {
   bytes: Uint8Array;
   password?: string | undefined;
-  searchText: string;
+  searchText: SearchTextQuery;
   signal: AbortSignal;
 };
 
@@ -212,15 +213,14 @@ const findNormalizedPageMatches = ({
   maxMatches,
   pageIndex,
   pageSearchText,
-}: FindNormalizedPageMatchesOptions): PDFSearchMatch[] => {
-  return findNormalizedSearchTextMatches(pageSearchText.text, candidate, {
+}: FindNormalizedPageMatchesOptions): PDFSearchMatch[] =>
+  findNormalizedSearchTextMatches(pageSearchText.text, candidate, {
     maxMatches,
   })
     .map(({ end, start }) =>
       toPDFSearchMatch({ end, pageIndex, pageSearchText, start }),
     )
     .filter((match) => match.boxes.length > 0);
-};
 
 type FindPageMatchesOptions = {
   candidate: string;
@@ -375,6 +375,18 @@ export const findPDFSearchResults = async ({
       .slice(0, MAX_SEARCH_PREVIEW_MATCHES),
     truncated,
   });
+
+  if (typeof searchText !== "string") {
+    const matches = new Map<string, PDFSearchMatch>();
+    let truncated = false;
+    for (const candidate of candidates) {
+      truncated ||= collectCandidateMatches(candidate, matches);
+      if (truncated) {
+        break;
+      }
+    }
+    return toResult(matches, truncated);
+  }
 
   const phraseCandidate = candidates.at(0);
   const phraseMatches = new Map<string, PDFSearchMatch>();

--- a/apps/web/src/lib/pdf/pdf-search.ts
+++ b/apps/web/src/lib/pdf/pdf-search.ts
@@ -63,7 +63,11 @@ const canMergePDFSearchBoxes = (
 ): boolean => {
   const minimumHeight = Math.min(current.height, next.height);
   const verticalOverlap = getVerticalOverlap(current, next);
-  const horizontalGap = next.x - (current.x + current.width);
+  const horizontalGap = Math.max(
+    0,
+    next.x - (current.x + current.width),
+    current.x - (next.x + next.width),
+  );
   const maximumInlineGap =
     Math.max(current.height, next.height) * MAX_INLINE_GAP_HEIGHT_RATIO;
 

--- a/apps/web/src/lib/pdf/pdf-viewport.tsx
+++ b/apps/web/src/lib/pdf/pdf-viewport.tsx
@@ -184,6 +184,8 @@ const PDFViewerContent = ({
     isSettled: searchPageQuery.isSuccess,
     result: searchPageQuery.data,
   });
+  const settledSearchMatchCount = settledSearchMatchSummary?.count;
+  const settledSearchMatchTruncated = settledSearchMatchSummary?.truncated;
   const viewportStyle: PDFViewportStyle = {
     "--pdf-page-filter": shouldInvert ? "invert(1) hue-rotate(180deg)" : "none",
     "--scale-factor": effectiveScale,
@@ -209,15 +211,21 @@ const PDFViewerContent = ({
   }, [activeSearchMatchIndex, searchPageId, setScrollTo]);
 
   useExternalSyncEffect(() => {
-    if (!settledSearchMatchSummary) {
+    if (
+      settledSearchMatchCount === undefined ||
+      settledSearchMatchTruncated === undefined
+    ) {
       return;
     }
 
-    onSearchMatchSummaryChange?.(settledSearchMatchSummary);
+    onSearchMatchSummaryChange?.({
+      count: settledSearchMatchCount,
+      truncated: settledSearchMatchTruncated,
+    });
   }, [
     onSearchMatchSummaryChange,
-    settledSearchMatchSummary?.count,
-    settledSearchMatchSummary?.truncated,
+    settledSearchMatchCount,
+    settledSearchMatchTruncated,
   ]);
 
   useTextSelection(containerRef);

--- a/apps/web/src/lib/pdf/pdf-viewport.tsx
+++ b/apps/web/src/lib/pdf/pdf-viewport.tsx
@@ -2,6 +2,7 @@ import { startTransition, useId, useMemo, useRef, useState } from "react";
 import type { CSSProperties, ReactNode } from "react";
 import { useFormStatus } from "react-dom";
 
+import { useQuery } from "@tanstack/react-query";
 import { Result } from "better-result";
 import { useTranslations } from "use-intl";
 import { useShallow } from "zustand/react/shallow";
@@ -13,6 +14,7 @@ import { ScrollArea } from "@stll/ui/components/scroll-area";
 
 import { useTheme } from "@/components/theme-provider";
 import { useExternalSyncEffect } from "@/hooks/use-effect";
+import { useAnalytics } from "@/lib/analytics/provider";
 import { usePageVisibility } from "@/lib/pdf/hooks/use-page-visibility";
 import { usePDFControlledScaleOffset } from "@/lib/pdf/hooks/use-pdf-controlled-scale-offset";
 import { usePDFDocument } from "@/lib/pdf/hooks/use-pdf-document";
@@ -24,6 +26,7 @@ import type { PDFDocument } from "@/lib/pdf/pdf-loader";
 import type { PDFPageProps } from "@/lib/pdf/pdf-page";
 import { approximateFraction } from "@/lib/pdf/pdfjs-utils";
 import { getDevicePixelRatio } from "@/lib/pdf/utils";
+import type { SearchMatchSummary } from "@/lib/search-match-navigation";
 import { composeRefs } from "@/lib/utils";
 
 export { usePDFStore } from "@/lib/pdf/pdf-context";
@@ -40,14 +43,21 @@ type PDFViewportProps = {
   invertColors?: boolean | undefined;
   className?: string | undefined;
   contentClassName?: string | undefined;
+  searchText?: string | undefined;
+  activeSearchMatchIndex?: number | undefined;
+  onSearchMatchSummaryChange?:
+    | ((summary: SearchMatchSummary) => void)
+    | undefined;
   renderPage: (props: PDFPageProps) => ReactNode;
 };
 
 type PDFViewerContentProps = Omit<
   PDFViewportProps,
-  "fallback" | "fileId" | "password" | "buffer"
+  "fileId" | "password" | "buffer"
 > & {
+  buffer: ArrayBuffer;
   document: PDFDocument;
+  password?: string | undefined;
 };
 
 type PDFViewportStyle = CSSProperties & {
@@ -82,7 +92,14 @@ export const PDFViewport = ({
   });
 
   if (Result.isOk(result)) {
-    return <PDFViewerContent {...contentProps} document={result.value} />;
+    return (
+      <PDFViewerContent
+        {...contentProps}
+        buffer={buffer}
+        document={result.value}
+        password={password}
+      />
+    );
   }
 
   if (
@@ -104,23 +121,64 @@ export const PDFViewport = ({
 };
 
 const PDFViewerContent = ({
+  buffer,
   document,
+  password,
   page,
   onPageChanged,
   scaleOffset = 0,
   invertColors,
   className,
   contentClassName,
+  searchText = "",
+  activeSearchMatchIndex = 0,
+  onSearchMatchSummaryChange,
   renderPage,
 }: PDFViewerContentProps) => {
   const { resolvedTheme } = useTheme();
+  const analytics = useAnalytics();
   const shouldInvert = invertColors ?? resolvedTheme === "dark";
-  const [attachmentLabels, scale, pages, setDocument] = usePDFStore(
-    useShallow((s) => [s.attachmentLabels, s.scale, s.pages, s.setDocument]),
-  );
+  const [attachmentLabels, scale, pages, setDocument, setScrollTo] =
+    usePDFStore(
+      useShallow((s) => [
+        s.attachmentLabels,
+        s.scale,
+        s.pages,
+        s.setDocument,
+        s.setScrollTo,
+      ]),
+    );
+  const normalizedSearchText = searchText.trim();
+  const searchPageQuery = useQuery({
+    enabled: normalizedSearchText.length > 0,
+    queryFn: async ({ signal }) => {
+      const { findPDFSearchResultsInWorker } =
+        await import("@/lib/pdf/pdf-search-worker-client");
+      signal.throwIfAborted();
+      return await findPDFSearchResultsInWorker({
+        bytes: buffer.slice(0),
+        password,
+        searchText: normalizedSearchText,
+        signal,
+      });
+    },
+    queryKey: [
+      "pdf-search-page",
+      document.document.fingerprints.at(0),
+      normalizedSearchText,
+      password === undefined ? "unprotected" : "password-protected",
+    ],
+    staleTime: Number.POSITIVE_INFINITY,
+  });
 
   const effectiveScale = scale + scaleOffset;
   const pageIds = useMemo(() => pages.keys().toArray(), [pages]);
+  const activeSearchMatch = searchPageQuery.data?.matches.at(
+    activeSearchMatchIndex,
+  );
+  const searchPageId = activeSearchMatch
+    ? pageIds.at(activeSearchMatch.pageIndex)
+    : undefined;
   const viewportStyle: PDFViewportStyle = {
     "--pdf-page-filter": shouldInvert ? "invert(1) hue-rotate(180deg)" : "none",
     "--scale-factor": effectiveScale,
@@ -135,6 +193,29 @@ const PDFViewerContent = ({
       setDocument(document);
     });
   }, [document, setDocument]);
+
+  useExternalSyncEffect(() => {
+    if (searchPageId) {
+      setScrollTo({ pageId: searchPageId });
+    }
+  }, [searchPageId, setScrollTo]);
+
+  useExternalSyncEffect(() => {
+    onSearchMatchSummaryChange?.({
+      count: searchPageQuery.data?.matches.length ?? 0,
+      truncated: searchPageQuery.data?.truncated ?? false,
+    });
+  }, [
+    onSearchMatchSummaryChange,
+    searchPageQuery.data?.matches.length,
+    searchPageQuery.data?.truncated,
+  ]);
+
+  useExternalSyncEffect(() => {
+    if (searchPageQuery.error) {
+      analytics.captureError(searchPageQuery.error);
+    }
+  }, [analytics, searchPageQuery.error]);
 
   useTextSelection(containerRef);
   const fitToWidthRef = usePDFFitToWidth({
@@ -181,13 +262,23 @@ const PDFViewerContent = ({
         className={contentClassName}
         style={viewportStyle}
       >
-        {pageIds.map((pageId) => {
+        {pageIds.map((pageId, pageIndex) => {
           const label = attachmentLabels.get(pageId);
+          const searchMatches = searchPageQuery.data?.matches.flatMap(
+            (match, matchIndex) =>
+              match.pageIndex === pageIndex
+                ? [{ boxes: match.boxes, matchIndex }]
+                : [],
+          );
 
           return (
             <div key={pageId}>
               {label && <PDFBanner label={label} />}
-              {renderPage({ pageId })}
+              {renderPage({
+                activeSearchMatchIndex,
+                pageId,
+                searchMatches,
+              })}
             </div>
           );
         })}

--- a/apps/web/src/lib/pdf/pdf-viewport.tsx
+++ b/apps/web/src/lib/pdf/pdf-viewport.tsx
@@ -29,6 +29,8 @@ import {
   getSettledSearchMatchSummary,
   type SearchMatchSummary,
 } from "@/lib/search-match-navigation";
+import { getSearchTextCandidates } from "@/lib/search-text";
+import type { SearchTextQuery } from "@/lib/search-text";
 import { composeRefs } from "@/lib/utils";
 
 export { usePDFStore } from "@/lib/pdf/pdf-context";
@@ -45,7 +47,7 @@ type PDFViewportProps = {
   invertColors?: boolean | undefined;
   className?: string | undefined;
   contentClassName?: string | undefined;
-  searchText?: string | undefined;
+  searchText?: SearchTextQuery | undefined;
   activeSearchMatchIndex?: number | undefined;
   onSearchMatchSummaryChange?:
     | ((summary: SearchMatchSummary) => void)
@@ -149,9 +151,9 @@ const PDFViewerContent = ({
         s.setScrollTo,
       ]),
     );
-  const normalizedSearchText = searchText.trim();
+  const hasSearchText = getSearchTextCandidates(searchText).length > 0;
   const searchPageQuery = useQuery({
-    enabled: normalizedSearchText.length > 0,
+    enabled: hasSearchText,
     queryFn: async ({ signal }) => {
       const { findPDFSearchResultsInWorker } =
         await import("@/lib/pdf/pdf-search-worker-client");
@@ -159,14 +161,14 @@ const PDFViewerContent = ({
       return await findPDFSearchResultsInWorker({
         bytes: buffer.slice(0),
         password,
-        searchText: normalizedSearchText,
+        searchText,
         signal,
       });
     },
     queryKey: [
       "pdf-search-page",
-      document.document.fingerprints.at(0),
-      normalizedSearchText,
+      document.document.fingerprints,
+      searchText,
       password === undefined ? "unprotected" : "password-protected",
     ],
     staleTime: Number.POSITIVE_INFINITY,

--- a/apps/web/src/lib/pdf/pdf-viewport.tsx
+++ b/apps/web/src/lib/pdf/pdf-viewport.tsx
@@ -14,7 +14,6 @@ import { ScrollArea } from "@stll/ui/components/scroll-area";
 
 import { useTheme } from "@/components/theme-provider";
 import { useExternalSyncEffect } from "@/hooks/use-effect";
-import { useAnalytics } from "@/lib/analytics/provider";
 import { usePageVisibility } from "@/lib/pdf/hooks/use-page-visibility";
 import { usePDFControlledScaleOffset } from "@/lib/pdf/hooks/use-pdf-controlled-scale-offset";
 import { usePDFDocument } from "@/lib/pdf/hooks/use-pdf-document";
@@ -26,7 +25,10 @@ import type { PDFDocument } from "@/lib/pdf/pdf-loader";
 import type { PDFPageProps } from "@/lib/pdf/pdf-page";
 import { approximateFraction } from "@/lib/pdf/pdfjs-utils";
 import { getDevicePixelRatio } from "@/lib/pdf/utils";
-import type { SearchMatchSummary } from "@/lib/search-match-navigation";
+import {
+  getSettledSearchMatchSummary,
+  type SearchMatchSummary,
+} from "@/lib/search-match-navigation";
 import { composeRefs } from "@/lib/utils";
 
 export { usePDFStore } from "@/lib/pdf/pdf-context";
@@ -136,7 +138,6 @@ const PDFViewerContent = ({
   renderPage,
 }: PDFViewerContentProps) => {
   const { resolvedTheme } = useTheme();
-  const analytics = useAnalytics();
   const shouldInvert = invertColors ?? resolvedTheme === "dark";
   const [attachmentLabels, scale, pages, setDocument, setScrollTo] =
     usePDFStore(
@@ -179,6 +180,10 @@ const PDFViewerContent = ({
   const searchPageId = activeSearchMatch
     ? pageIds.at(activeSearchMatch.pageIndex)
     : undefined;
+  const settledSearchMatchSummary = getSettledSearchMatchSummary({
+    isSettled: searchPageQuery.isSuccess,
+    result: searchPageQuery.data,
+  });
   const viewportStyle: PDFViewportStyle = {
     "--pdf-page-filter": shouldInvert ? "invert(1) hue-rotate(180deg)" : "none",
     "--scale-factor": effectiveScale,
@@ -196,26 +201,24 @@ const PDFViewerContent = ({
 
   useExternalSyncEffect(() => {
     if (searchPageId) {
-      setScrollTo({ pageId: searchPageId });
+      setScrollTo({
+        pageId: searchPageId,
+        target: { kind: "searchMatch", matchIndex: activeSearchMatchIndex },
+      });
     }
-  }, [searchPageId, setScrollTo]);
+  }, [activeSearchMatchIndex, searchPageId, setScrollTo]);
 
   useExternalSyncEffect(() => {
-    onSearchMatchSummaryChange?.({
-      count: searchPageQuery.data?.matches.length ?? 0,
-      truncated: searchPageQuery.data?.truncated ?? false,
-    });
+    if (!settledSearchMatchSummary) {
+      return;
+    }
+
+    onSearchMatchSummaryChange?.(settledSearchMatchSummary);
   }, [
     onSearchMatchSummaryChange,
-    searchPageQuery.data?.matches.length,
-    searchPageQuery.data?.truncated,
+    settledSearchMatchSummary?.count,
+    settledSearchMatchSummary?.truncated,
   ]);
-
-  useExternalSyncEffect(() => {
-    if (searchPageQuery.error) {
-      analytics.captureError(searchPageQuery.error);
-    }
-  }, [analytics, searchPageQuery.error]);
 
   useTextSelection(containerRef);
   const fitToWidthRef = usePDFFitToWidth({
@@ -240,6 +243,10 @@ const PDFViewerContent = ({
     () => composeRefs(containerRef, fitToWidthRef, pageVisibilityRef),
     [fitToWidthRef, pageVisibilityRef],
   );
+
+  if (searchPageQuery.error && !searchPageQuery.isFetching) {
+    throw searchPageQuery.error;
+  }
 
   return (
     // The surround background lives on the (non-scrolling) ScrollArea

--- a/apps/web/src/lib/search-match-navigation.test.ts
+++ b/apps/web/src/lib/search-match-navigation.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "bun:test";
 import {
   getAdjacentSearchMatchIndex,
   getCenteredSearchMatchScrollTop,
+  getSettledSearchMatchSummary,
 } from "@/lib/search-match-navigation";
 
 describe("search preview match navigation", () => {
@@ -43,5 +44,23 @@ describe("search preview match navigation", () => {
         matchTop: 500,
       }),
     ).toBe(410);
+  });
+
+  test("distinguishes a pending search from a settled search with no matches", () => {
+    expect(
+      getSettledSearchMatchSummary({ isSettled: false, result: undefined }),
+    ).toBeNull();
+    expect(
+      getSettledSearchMatchSummary({ isSettled: true, result: null }),
+    ).toEqual({ count: 0, truncated: false });
+  });
+
+  test("summarizes a settled bounded result", () => {
+    expect(
+      getSettledSearchMatchSummary({
+        isSettled: true,
+        result: { matches: [{}, {}], truncated: true },
+      }),
+    ).toEqual({ count: 2, truncated: true });
   });
 });

--- a/apps/web/src/lib/search-match-navigation.test.ts
+++ b/apps/web/src/lib/search-match-navigation.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  getAdjacentSearchMatchIndex,
+  getCenteredSearchMatchScrollTop,
+} from "@/lib/search-match-navigation";
+
+describe("search preview match navigation", () => {
+  test("wraps in both directions", () => {
+    expect(
+      getAdjacentSearchMatchIndex({
+        activeIndex: 2,
+        direction: "next",
+        matchCount: 3,
+      }),
+    ).toBe(0);
+    expect(
+      getAdjacentSearchMatchIndex({
+        activeIndex: 0,
+        direction: "previous",
+        matchCount: 3,
+      }),
+    ).toBe(2);
+  });
+
+  test("keeps an empty result at index zero", () => {
+    expect(
+      getAdjacentSearchMatchIndex({
+        activeIndex: 4,
+        direction: "next",
+        matchCount: 0,
+      }),
+    ).toBe(0);
+  });
+
+  test("centres a match within its own scroll viewport", () => {
+    expect(
+      getCenteredSearchMatchScrollTop({
+        containerHeight: 400,
+        containerTop: 100,
+        currentScrollTop: 200,
+        matchHeight: 20,
+        matchTop: 500,
+      }),
+    ).toBe(410);
+  });
+});

--- a/apps/web/src/lib/search-match-navigation.ts
+++ b/apps/web/src/lib/search-match-navigation.ts
@@ -5,6 +5,30 @@ export type SearchMatchSummary = {
   truncated: boolean;
 };
 
+type SearchMatchResult = {
+  matches: readonly unknown[];
+  truncated: boolean;
+};
+
+type GetSettledSearchMatchSummaryOptions = {
+  isSettled: boolean;
+  result: SearchMatchResult | null | undefined;
+};
+
+export const getSettledSearchMatchSummary = ({
+  isSettled,
+  result,
+}: GetSettledSearchMatchSummaryOptions): SearchMatchSummary | null => {
+  if (!isSettled) {
+    return null;
+  }
+
+  return {
+    count: result?.matches.length ?? 0,
+    truncated: result?.truncated ?? false,
+  };
+};
+
 type GetAdjacentSearchMatchIndexOptions = {
   activeIndex: number;
   direction: "next" | "previous";

--- a/apps/web/src/lib/search-match-navigation.ts
+++ b/apps/web/src/lib/search-match-navigation.ts
@@ -1,0 +1,48 @@
+export const MAX_SEARCH_PREVIEW_MATCHES = 200;
+
+export type SearchMatchSummary = {
+  count: number;
+  truncated: boolean;
+};
+
+type GetAdjacentSearchMatchIndexOptions = {
+  activeIndex: number;
+  direction: "next" | "previous";
+  matchCount: number;
+};
+
+export const getAdjacentSearchMatchIndex = ({
+  activeIndex,
+  direction,
+  matchCount,
+}: GetAdjacentSearchMatchIndexOptions): number => {
+  if (matchCount <= 0) {
+    return 0;
+  }
+
+  const delta = direction === "next" ? 1 : -1;
+  return (activeIndex + delta + matchCount) % matchCount;
+};
+
+type GetCenteredSearchMatchScrollTopOptions = {
+  containerHeight: number;
+  containerTop: number;
+  currentScrollTop: number;
+  matchHeight: number;
+  matchTop: number;
+};
+
+export const getCenteredSearchMatchScrollTop = ({
+  containerHeight,
+  containerTop,
+  currentScrollTop,
+  matchHeight,
+  matchTop,
+}: GetCenteredSearchMatchScrollTopOptions): number =>
+  Math.max(
+    0,
+    currentScrollTop +
+      matchTop -
+      containerTop -
+      (containerHeight - matchHeight) / 2,
+  );

--- a/apps/web/src/lib/search-recents.test.ts
+++ b/apps/web/src/lib/search-recents.test.ts
@@ -73,6 +73,7 @@ describe("search recents", () => {
       {
         entityId: "entity-1",
         fileFieldId: "field-draft",
+        filePropertyId: "property-file",
         mimeType:
           "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
         title: "Draft.docx",
@@ -87,6 +88,7 @@ describe("search recents", () => {
       {
         entityId: "entity-1",
         fileFieldId: "field-final",
+        filePropertyId: "property-file",
         mimeType: "application/pdf",
         title: "Final.docx",
         updatedAt: "2021-02-01T00:00:00.000Z",
@@ -101,6 +103,7 @@ describe("search recents", () => {
       readRecentFiles(scope, storage).map((item) => ({
         entityId: item.entityId,
         fileFieldId: item.fileFieldId,
+        filePropertyId: item.filePropertyId,
         mimeType: item.mimeType,
         title: item.title,
         updatedAt: item.updatedAt,
@@ -109,6 +112,7 @@ describe("search recents", () => {
       {
         entityId: "entity-1",
         fileFieldId: "field-final",
+        filePropertyId: "property-file",
         mimeType: "application/pdf",
         title: "Final.docx",
         updatedAt: "2021-02-01T00:00:00.000Z",

--- a/apps/web/src/lib/search-recents.test.ts
+++ b/apps/web/src/lib/search-recents.test.ts
@@ -72,6 +72,7 @@ describe("search recents", () => {
     recordRecentFile(
       {
         entityId: "entity-1",
+        fileFieldId: "field-draft",
         mimeType:
           "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
         title: "Draft.docx",
@@ -84,6 +85,7 @@ describe("search recents", () => {
     recordRecentFile(
       {
         entityId: "entity-1",
+        fileFieldId: "field-final",
         mimeType: "application/pdf",
         title: "Final.docx",
         workspaceId: "workspace-1",
@@ -96,12 +98,14 @@ describe("search recents", () => {
     expect(
       readRecentFiles(scope, storage).map((item) => ({
         entityId: item.entityId,
+        fileFieldId: item.fileFieldId,
         mimeType: item.mimeType,
         title: item.title,
       })),
     ).toEqual([
       {
         entityId: "entity-1",
+        fileFieldId: "field-final",
         mimeType: "application/pdf",
         title: "Final.docx",
       },

--- a/apps/web/src/lib/search-recents.test.ts
+++ b/apps/web/src/lib/search-recents.test.ts
@@ -76,6 +76,7 @@ describe("search recents", () => {
         mimeType:
           "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
         title: "Draft.docx",
+        updatedAt: "2021-01-01T00:00:00.000Z",
         workspaceId: "workspace-1",
         workspaceName: "Matter A",
       },
@@ -88,6 +89,7 @@ describe("search recents", () => {
         fileFieldId: "field-final",
         mimeType: "application/pdf",
         title: "Final.docx",
+        updatedAt: "2021-02-01T00:00:00.000Z",
         workspaceId: "workspace-1",
         workspaceName: "Matter A",
       },
@@ -101,6 +103,7 @@ describe("search recents", () => {
         fileFieldId: item.fileFieldId,
         mimeType: item.mimeType,
         title: item.title,
+        updatedAt: item.updatedAt,
       })),
     ).toEqual([
       {
@@ -108,6 +111,7 @@ describe("search recents", () => {
         fileFieldId: "field-final",
         mimeType: "application/pdf",
         title: "Final.docx",
+        updatedAt: "2021-02-01T00:00:00.000Z",
       },
     ]);
   });

--- a/apps/web/src/lib/search-recents.ts
+++ b/apps/web/src/lib/search-recents.ts
@@ -21,6 +21,7 @@ export type RecentSearch = {
 export type RecentFile = {
   entityId: string;
   fileFieldId?: string | null | undefined;
+  filePropertyId?: string | null | undefined;
   workspaceId: string;
   workspaceName: string;
   title: string;
@@ -51,6 +52,9 @@ const isRecentFile = (value: unknown): value is RecentFile =>
   (value["fileFieldId"] === undefined ||
     value["fileFieldId"] === null ||
     typeof value["fileFieldId"] === "string") &&
+  (value["filePropertyId"] === undefined ||
+    value["filePropertyId"] === null ||
+    typeof value["filePropertyId"] === "string") &&
   typeof value["workspaceId"] === "string" &&
   typeof value["workspaceName"] === "string" &&
   typeof value["title"] === "string" &&

--- a/apps/web/src/lib/search-recents.ts
+++ b/apps/web/src/lib/search-recents.ts
@@ -20,6 +20,7 @@ export type RecentSearch = {
 
 export type RecentFile = {
   entityId: string;
+  fileFieldId?: string | null | undefined;
   workspaceId: string;
   workspaceName: string;
   title: string;
@@ -46,6 +47,9 @@ const isRecentSearch = (value: unknown): value is RecentSearch =>
 const isRecentFile = (value: unknown): value is RecentFile =>
   isRecord(value) &&
   typeof value["entityId"] === "string" &&
+  (value["fileFieldId"] === undefined ||
+    value["fileFieldId"] === null ||
+    typeof value["fileFieldId"] === "string") &&
   typeof value["workspaceId"] === "string" &&
   typeof value["workspaceName"] === "string" &&
   typeof value["title"] === "string" &&

--- a/apps/web/src/lib/search-recents.ts
+++ b/apps/web/src/lib/search-recents.ts
@@ -26,6 +26,7 @@ export type RecentFile = {
   title: string;
   mimeType?: string | null | undefined;
   openedAt: string;
+  updatedAt?: string | undefined;
 };
 
 type RecentFileInput = Omit<RecentFile, "openedAt">;
@@ -56,7 +57,8 @@ const isRecentFile = (value: unknown): value is RecentFile =>
   (value["mimeType"] === undefined ||
     value["mimeType"] === null ||
     typeof value["mimeType"] === "string") &&
-  typeof value["openedAt"] === "string";
+  typeof value["openedAt"] === "string" &&
+  (value["updatedAt"] === undefined || typeof value["updatedAt"] === "string");
 
 // Top-level shape only: each item is validated individually below via
 // `isItem`, so one malformed entry drops just that entry rather than the

--- a/apps/web/src/lib/search-text.ts
+++ b/apps/web/src/lib/search-text.ts
@@ -6,6 +6,10 @@ export type SearchTextMatch = {
   end: number;
 };
 
+export type SearchTextQuery =
+  | string
+  | { type: "separate-terms"; terms: readonly string[] };
+
 type FindNormalizedSearchTextMatchesOptions = {
   maxMatches?: number;
 };
@@ -13,7 +17,24 @@ type FindNormalizedSearchTextMatchesOptions = {
 export const normalizeSearchText = (value: string): string =>
   value.normalize("NFKD").replace(COMBINING_MARKS, "").toLowerCase();
 
-export const getSearchTextCandidates = (searchText: string): string[] => {
+export const searchTextQueryKey = (query: SearchTextQuery): string =>
+  typeof query === "string"
+    ? `query:${JSON.stringify(query)}`
+    : `separate-terms:${JSON.stringify(query.terms)}`;
+
+export const getSearchTextCandidates = (
+  searchText: SearchTextQuery,
+): string[] => {
+  if (typeof searchText !== "string") {
+    return searchText.terms
+      .map((term) => term.trim())
+      .filter(
+        (term, index, terms) =>
+          (term.length > 1 || SINGLE_SEARCH_TERM.test(term)) &&
+          terms.indexOf(term) === index,
+      );
+  }
+
   const normalizedSearchText = searchText.trim();
   if (normalizedSearchText.length === 0) {
     return [];

--- a/apps/web/src/lib/search-text.ts
+++ b/apps/web/src/lib/search-text.ts
@@ -16,10 +16,62 @@ type FindNormalizedSearchTextMatchesOptions = {
   maxMatches?: number;
 };
 
+type NormalizedSearchTextWithOffsets = {
+  originalRanges: SearchTextMatch[];
+  text: string;
+};
+
+const normalizeSearchTextBeforeCase = (value: string): string =>
+  applyArabicFolds(value.normalize("NFKD").replace(COMBINING_MARKS, ""));
+
 export const normalizeSearchText = (value: string): string =>
-  applyArabicFolds(
-    value.normalize("NFKD").replace(COMBINING_MARKS, "").toLowerCase(),
-  );
+  normalizeSearchTextBeforeCase(value).toLowerCase();
+
+const normalizeSearchTextWithOffsets = (
+  content: string,
+): NormalizedSearchTextWithOffsets => {
+  const units: { range: SearchTextMatch; text: string }[] = [];
+  let originalOffset = 0;
+
+  for (const character of content) {
+    const start = originalOffset;
+    originalOffset += character.length;
+    units.push({
+      range: { start, end: originalOffset },
+      text: normalizeSearchTextBeforeCase(character),
+    });
+  }
+
+  const beforeCase = units.map(({ text }) => text).join("");
+  const contextualLowercase = beforeCase.toLowerCase();
+  if (contextualLowercase.length === beforeCase.length) {
+    const originalRanges: SearchTextMatch[] = [];
+    for (const unit of units) {
+      let codeUnit = 0;
+      while (codeUnit < unit.text.length) {
+        originalRanges.push(unit.range);
+        codeUnit += 1;
+      }
+    }
+    return {
+      text: contextualLowercase,
+      originalRanges,
+    };
+  }
+
+  const loweredParts: string[] = [];
+  const originalRanges: SearchTextMatch[] = [];
+  for (const unit of units) {
+    const lowered = unit.text.toLowerCase();
+    loweredParts.push(lowered);
+    let codeUnit = 0;
+    while (codeUnit < lowered.length) {
+      originalRanges.push(unit.range);
+      codeUnit += 1;
+    }
+  }
+  return { text: loweredParts.join(""), originalRanges };
+};
 
 export const searchTextQueryKey = (query: SearchTextQuery): string =>
   typeof query === "string"
@@ -69,21 +121,7 @@ export const findNormalizedSearchTextMatches = (
     return [];
   }
 
-  const normalizedContentParts: string[] = [];
-  const originalRanges: SearchTextMatch[] = [];
-  let originalOffset = 0;
-
-  for (const character of content) {
-    const start = originalOffset;
-    originalOffset += character.length;
-    const normalizedCharacter = normalizeSearchText(character);
-    normalizedContentParts.push(normalizedCharacter);
-    for (const _codeUnit of normalizedCharacter.split("")) {
-      originalRanges.push({ start, end: originalOffset });
-    }
-  }
-
-  const normalizedContent = normalizedContentParts.join("");
+  const normalizedContent = normalizeSearchTextWithOffsets(content);
   const normalizedQuery = normalizeSearchText(searchText.trim());
   if (normalizedQuery.length === 0) {
     return [];
@@ -91,8 +129,8 @@ export const findNormalizedSearchTextMatches = (
 
   const matches: SearchTextMatch[] = [];
   let searchFrom = 0;
-  while (searchFrom <= normalizedContent.length - normalizedQuery.length) {
-    const normalizedStart = normalizedContent.indexOf(
+  while (searchFrom <= normalizedContent.text.length - normalizedQuery.length) {
+    const normalizedStart = normalizedContent.text.indexOf(
       normalizedQuery,
       searchFrom,
     );
@@ -100,8 +138,8 @@ export const findNormalizedSearchTextMatches = (
       break;
     }
     const normalizedEnd = normalizedStart + normalizedQuery.length;
-    const firstRange = originalRanges.at(normalizedStart);
-    const lastRange = originalRanges.at(normalizedEnd - 1);
+    const firstRange = normalizedContent.originalRanges.at(normalizedStart);
+    const lastRange = normalizedContent.originalRanges.at(normalizedEnd - 1);
     if (firstRange && lastRange) {
       matches.push({ start: firstRange.start, end: lastRange.end });
       if (matches.length >= maxMatches) {

--- a/apps/web/src/lib/search-text.ts
+++ b/apps/web/src/lib/search-text.ts
@@ -1,4 +1,5 @@
 const COMBINING_MARKS = /\p{M}+/gu;
+const SINGLE_SEARCH_TERM = /^[\p{L}\p{N}]$/u;
 
 export type SearchTextMatch = {
   start: number;
@@ -21,7 +22,8 @@ export const getSearchTextCandidates = (searchText: string): string[] => {
   }
   return [normalizedSearchText, ...terms].filter(
     (candidate, index, candidates) =>
-      candidate.length > 1 && candidates.indexOf(candidate) === index,
+      (candidate.length > 1 || SINGLE_SEARCH_TERM.test(candidate)) &&
+      candidates.indexOf(candidate) === index,
   );
 };
 
@@ -45,7 +47,7 @@ export const findNormalizedSearchTextMatches = (
 
   const normalizedContent = normalizedContentParts.join("");
   const normalizedQuery = normalizeSearchText(searchText.trim());
-  if (normalizedQuery.length <= 1) {
+  if (normalizedQuery.length === 0) {
     return [];
   }
 

--- a/apps/web/src/lib/search-text.ts
+++ b/apps/web/src/lib/search-text.ts
@@ -15,7 +15,10 @@ export const getSearchTextCandidates = (searchText: string): string[] => {
   }
 
   const matchedTerms = normalizedSearchText.match(/[\p{L}\p{N}]+/gu);
-  const terms = matchedTerms ? matchedTerms : [];
+  const terms: string[] = [];
+  if (matchedTerms) {
+    terms.push(...matchedTerms);
+  }
   return [normalizedSearchText, ...terms].filter(
     (candidate, index, candidates) =>
       candidate.length > 1 && candidates.indexOf(candidate) === index,

--- a/apps/web/src/lib/search-text.ts
+++ b/apps/web/src/lib/search-text.ts
@@ -1,0 +1,68 @@
+const COMBINING_MARKS = /\p{M}+/gu;
+
+export type SearchTextMatch = {
+  start: number;
+  end: number;
+};
+
+export const normalizeSearchText = (value: string): string =>
+  value.normalize("NFKD").replace(COMBINING_MARKS, "").toLowerCase();
+
+export const getSearchTextCandidates = (searchText: string): string[] => {
+  const normalizedSearchText = searchText.trim();
+  if (normalizedSearchText.length === 0) {
+    return [];
+  }
+
+  const terms = normalizedSearchText.match(/[\p{L}\p{N}]+/gu) ?? [];
+  return [normalizedSearchText, ...terms].filter(
+    (candidate, index, candidates) =>
+      candidate.length > 1 && candidates.indexOf(candidate) === index,
+  );
+};
+
+export const findNormalizedSearchTextMatches = (
+  content: string,
+  searchText: string,
+): SearchTextMatch[] => {
+  const normalizedContentParts: string[] = [];
+  const originalRanges: SearchTextMatch[] = [];
+  let originalOffset = 0;
+
+  for (const character of content) {
+    const start = originalOffset;
+    originalOffset += character.length;
+    const normalizedCharacter = normalizeSearchText(character);
+    normalizedContentParts.push(normalizedCharacter);
+    for (const _codeUnit of normalizedCharacter.split("")) {
+      originalRanges.push({ start, end: originalOffset });
+    }
+  }
+
+  const normalizedContent = normalizedContentParts.join("");
+  const normalizedQuery = normalizeSearchText(searchText.trim());
+  if (normalizedQuery.length <= 1) {
+    return [];
+  }
+
+  const matches: SearchTextMatch[] = [];
+  let searchFrom = 0;
+  while (searchFrom <= normalizedContent.length - normalizedQuery.length) {
+    const normalizedStart = normalizedContent.indexOf(
+      normalizedQuery,
+      searchFrom,
+    );
+    if (normalizedStart === -1) {
+      break;
+    }
+    const normalizedEnd = normalizedStart + normalizedQuery.length;
+    const firstRange = originalRanges.at(normalizedStart);
+    const lastRange = originalRanges.at(normalizedEnd - 1);
+    if (firstRange && lastRange) {
+      matches.push({ start: firstRange.start, end: lastRange.end });
+    }
+    searchFrom = normalizedEnd;
+  }
+
+  return matches;
+};

--- a/apps/web/src/lib/search-text.ts
+++ b/apps/web/src/lib/search-text.ts
@@ -1,3 +1,5 @@
+import { applyArabicFolds } from "@stll/text-normalize";
+
 const COMBINING_MARKS = /\p{M}+/gu;
 const SINGLE_SEARCH_TERM = /^[\p{L}\p{N}]$/u;
 
@@ -15,7 +17,9 @@ type FindNormalizedSearchTextMatchesOptions = {
 };
 
 export const normalizeSearchText = (value: string): string =>
-  value.normalize("NFKD").replace(COMBINING_MARKS, "").toLowerCase();
+  applyArabicFolds(
+    value.normalize("NFKD").replace(COMBINING_MARKS, "").toLowerCase(),
+  );
 
 export const searchTextQueryKey = (query: SearchTextQuery): string =>
   typeof query === "string"

--- a/apps/web/src/lib/search-text.ts
+++ b/apps/web/src/lib/search-text.ts
@@ -14,7 +14,8 @@ export const getSearchTextCandidates = (searchText: string): string[] => {
     return [];
   }
 
-  const terms = normalizedSearchText.match(/[\p{L}\p{N}]+/gu) ?? [];
+  const matchedTerms = normalizedSearchText.match(/[\p{L}\p{N}]+/gu);
+  const terms = matchedTerms ? matchedTerms : [];
   return [normalizedSearchText, ...terms].filter(
     (candidate, index, candidates) =>
       candidate.length > 1 && candidates.indexOf(candidate) === index,

--- a/apps/web/src/lib/search-text.ts
+++ b/apps/web/src/lib/search-text.ts
@@ -8,6 +8,50 @@ export type SearchTextMatch = {
   end: number;
 };
 
+type SearchMatchRange = SearchTextMatch & { group: number };
+
+type SelectNonOverlappingSearchMatchesOptions<T> = {
+  getRange: (match: T) => SearchMatchRange;
+  matches: Iterable<T>;
+  maxMatches: number;
+};
+
+export const selectNonOverlappingSearchMatches = <T>({
+  getRange,
+  matches,
+  maxMatches,
+}: SelectNonOverlappingSearchMatchesOptions<T>): T[] => {
+  if (maxMatches <= 0) {
+    return [];
+  }
+  const selected: T[] = [];
+  let previousEnd = -1;
+  let previousGroup = -1;
+  const ordered = [...matches]
+    .map((match) => ({ match, range: getRange(match) }))
+    .toSorted(
+      (first, second) =>
+        first.range.group - second.range.group ||
+        first.range.start - second.range.start ||
+        second.range.end - first.range.end,
+    );
+  for (const { match, range } of ordered) {
+    if (range.group !== previousGroup) {
+      previousGroup = range.group;
+      previousEnd = -1;
+    }
+    if (range.start < previousEnd) {
+      continue;
+    }
+    selected.push(match);
+    previousEnd = range.end;
+    if (selected.length >= maxMatches) {
+      break;
+    }
+  }
+  return selected;
+};
+
 export type SearchTextQuery =
   | string
   | { type: "separate-terms"; terms: readonly string[] };

--- a/apps/web/src/lib/search-text.ts
+++ b/apps/web/src/lib/search-text.ts
@@ -6,6 +6,10 @@ export type SearchTextMatch = {
   end: number;
 };
 
+type FindNormalizedSearchTextMatchesOptions = {
+  maxMatches?: number;
+};
+
 export const normalizeSearchText = (value: string): string =>
   value.normalize("NFKD").replace(COMBINING_MARKS, "").toLowerCase();
 
@@ -30,7 +34,16 @@ export const getSearchTextCandidates = (searchText: string): string[] => {
 export const findNormalizedSearchTextMatches = (
   content: string,
   searchText: string,
+  options: FindNormalizedSearchTextMatchesOptions = {},
 ): SearchTextMatch[] => {
+  const maxMatches = Math.max(
+    0,
+    Math.floor(options.maxMatches ?? Number.MAX_SAFE_INTEGER),
+  );
+  if (maxMatches === 0) {
+    return [];
+  }
+
   const normalizedContentParts: string[] = [];
   const originalRanges: SearchTextMatch[] = [];
   let originalOffset = 0;
@@ -66,6 +79,9 @@ export const findNormalizedSearchTextMatches = (
     const lastRange = originalRanges.at(normalizedEnd - 1);
     if (firstRange && lastRange) {
       matches.push({ start: firstRange.start, end: lastRange.end });
+      if (matches.length >= maxMatches) {
+        break;
+      }
     }
     searchFrom = normalizedEnd;
   }

--- a/apps/web/src/lib/search.logic.ts
+++ b/apps/web/src/lib/search.logic.ts
@@ -1,11 +1,39 @@
 import type { GlobalSearchHit, GlobalSearchResultType } from "@stll/api/types";
 
+import { DOCX_MIME, PDF_MIME } from "@/lib/consts";
+
 export const normalizeSearchQuery = (query: string): string => query.trim();
 
 export const stripSearchMarkup = (value: string): string =>
   value.replaceAll("<mark>", " ").replaceAll("</mark>", " ").trim();
 
+export const getSearchHighlightText = (
+  headline: string | null,
+  query: string,
+): string => {
+  const normalizedQuery = normalizeSearchQuery(query);
+  if (normalizedQuery) {
+    return normalizedQuery;
+  }
+
+  if (!headline) {
+    return "";
+  }
+
+  const start = headline.indexOf("<mark>");
+  const end = headline.indexOf("</mark>", start);
+  if (start === -1 || end === -1 || end <= start) {
+    return stripSearchMarkup(headline);
+  }
+
+  return stripSearchMarkup(headline.slice(start + "<mark>".length, end));
+};
+
 type SearchPreviewContent =
+  | {
+      messages: SearchPreviewChatMessage[];
+      type: "chat-messages";
+    }
   | {
       content: string;
       type: "highlighted-html";
@@ -15,7 +43,17 @@ type SearchPreviewContent =
       type: "plain-text";
     };
 
+export type SearchPreviewChatMessage = {
+  content: string;
+  id: string;
+  role: "assistant" | "system" | "user";
+};
+
 type SearchPreviewRenderContent =
+  | {
+      messages: SearchPreviewChatMessage[];
+      type: "chat-messages";
+    }
   | {
       directionText: string;
       html: string;
@@ -31,6 +69,8 @@ export const getSearchPreviewRenderContent = (
   preview: SearchPreviewContent,
 ): SearchPreviewRenderContent => {
   switch (preview.type) {
+    case "chat-messages":
+      return { type: preview.type, messages: preview.messages };
     case "highlighted-html":
       return {
         type: preview.type,
@@ -59,6 +99,55 @@ export const shouldShowSearchPreview = ({
   isMobile,
   previewEnabled,
 }: SearchPreviewVisibilityArgs): boolean => previewEnabled && !isMobile;
+
+type DisplayedSearchPreviewHitArgs = {
+  hit: GlobalSearchHit | null;
+  showPreview: boolean;
+};
+
+export const selectDisplayedSearchPreviewHit = ({
+  hit,
+  showPreview,
+}: DisplayedSearchPreviewHitArgs): GlobalSearchHit | null =>
+  showPreview ? hit : null;
+
+export type NativeSearchDocumentPreviewTarget = {
+  entityId: string;
+  fieldId: string;
+  filePurpose: "display" | "native-display";
+  mimeType: typeof DOCX_MIME | typeof PDF_MIME;
+  workspaceId: string;
+};
+
+export const getNativeSearchDocumentPreviewTarget = (
+  hit: GlobalSearchHit,
+): NativeSearchDocumentPreviewTarget | null => {
+  if (hit.type !== "document" || hit.fileFieldId === null) {
+    return null;
+  }
+
+  if (hit.mimeType === PDF_MIME) {
+    return {
+      entityId: hit.entityId,
+      fieldId: hit.fileFieldId,
+      filePurpose: "display",
+      mimeType: hit.mimeType,
+      workspaceId: hit.workspaceId,
+    };
+  }
+
+  if (hit.mimeType === DOCX_MIME) {
+    return {
+      entityId: hit.entityId,
+      fieldId: hit.fileFieldId,
+      filePurpose: "native-display",
+      mimeType: hit.mimeType,
+      workspaceId: hit.workspaceId,
+    };
+  }
+
+  return null;
+};
 
 type AuthorizedSearchPreviewDataArgs<T> = {
   data: T | undefined;

--- a/apps/web/src/lib/search.logic.ts
+++ b/apps/web/src/lib/search.logic.ts
@@ -56,10 +56,17 @@ const getMarkedSearchTerms = (headline: string | null): string[] => {
   return terms;
 };
 
-export const getSearchHighlightText = (
-  headline: string | null,
-  query: string,
-): SearchTextQuery => {
+type GetSearchHighlightTextOptions = {
+  headline: string | null;
+  previewLocatorCandidates?: readonly string[] | undefined;
+  query: string;
+};
+
+export const getSearchHighlightText = ({
+  headline,
+  previewLocatorCandidates = [],
+  query,
+}: GetSearchHighlightTextOptions): SearchTextQuery => {
   const normalizedQuery = normalizeSearchQuery(query);
   const markedSearchTerms = getMarkedSearchTerms(headline);
   if (markedSearchTerms.length > 1) {
@@ -68,6 +75,14 @@ export const getSearchHighlightText = (
   const markedSearchText = markedSearchTerms.at(0);
   if (markedSearchText) {
     return markedSearchText;
+  }
+
+  if (previewLocatorCandidates.length > 1) {
+    return { type: "separate-terms", terms: [...previewLocatorCandidates] };
+  }
+  const previewLocatorCandidate = previewLocatorCandidates.at(0);
+  if (previewLocatorCandidate) {
+    return previewLocatorCandidate;
   }
 
   if (normalizedQuery) {

--- a/apps/web/src/lib/search.logic.ts
+++ b/apps/web/src/lib/search.logic.ts
@@ -7,26 +7,36 @@ export const normalizeSearchQuery = (query: string): string => query.trim();
 export const stripSearchMarkup = (value: string): string =>
   value.replaceAll("<mark>", " ").replaceAll("</mark>", " ").trim();
 
+const getMarkedSearchText = (headline: string | null): string => {
+  if (!headline) {
+    return "";
+  }
+
+  const terms: string[] = [];
+  for (const match of headline.matchAll(/<mark>(?<term>.*?)<\/mark>/gu)) {
+    const term = match.groups?.["term"]?.trim();
+    if (term && !terms.includes(term)) {
+      terms.push(term);
+    }
+  }
+  return terms.join(" ");
+};
+
 export const getSearchHighlightText = (
   headline: string | null,
   query: string,
 ): string => {
   const normalizedQuery = normalizeSearchQuery(query);
+  const markedSearchText = getMarkedSearchText(headline);
+  if (markedSearchText) {
+    return markedSearchText;
+  }
+
   if (normalizedQuery) {
     return normalizedQuery;
   }
 
-  if (!headline) {
-    return "";
-  }
-
-  const start = headline.indexOf("<mark>");
-  const end = headline.indexOf("</mark>", start);
-  if (start === -1 || end === -1 || end <= start) {
-    return stripSearchMarkup(headline);
-  }
-
-  return stripSearchMarkup(headline.slice(start + "<mark>".length, end));
+  return headline ? stripSearchMarkup(headline) : "";
 };
 
 type SearchPreviewContent =

--- a/apps/web/src/lib/search.logic.ts
+++ b/apps/web/src/lib/search.logic.ts
@@ -14,30 +14,24 @@ const SEARCH_HEADLINE_NAMED_ENTITIES: Readonly<Record<string, string>> = {
   lt: "<",
   quot: '"',
 };
-const SEARCH_HEADLINE_ENTITY = /&(?<entity>#x[\da-f]+|#\d+|[a-z]+);/giu;
+const MAX_UNICODE_CODE_POINT = 1_114_111;
+const SEARCH_HEADLINE_ENTITY = /&(?:#x[\da-f]+|#\d+|[a-z]+);/giu;
 
 const decodeSearchHeadlineEntities = (value: string): string =>
-  value.replace(SEARCH_HEADLINE_ENTITY, (encoded, _entity, ...args) => {
-    const groups = args.at(-1);
-    if (
-      typeof groups !== "object" ||
-      groups === null ||
-      !("entity" in groups)
-    ) {
-      return encoded;
-    }
-    const entity = groups["entity"];
-    if (typeof entity !== "string") {
-      return encoded;
-    }
+  value.replace(SEARCH_HEADLINE_ENTITY, (encoded) => {
+    const entity = encoded.slice(1, -1);
     const normalizedEntity = entity.toLowerCase();
     if (normalizedEntity.startsWith("#x")) {
       const codePoint = Number.parseInt(normalizedEntity.slice(2), 16);
-      return codePoint <= 0x10_ffff ? String.fromCodePoint(codePoint) : encoded;
+      return codePoint <= MAX_UNICODE_CODE_POINT
+        ? String.fromCodePoint(codePoint)
+        : encoded;
     }
     if (normalizedEntity.startsWith("#")) {
       const codePoint = Number.parseInt(normalizedEntity.slice(1), 10);
-      return codePoint <= 0x10_ffff ? String.fromCodePoint(codePoint) : encoded;
+      return codePoint <= MAX_UNICODE_CODE_POINT
+        ? String.fromCodePoint(codePoint)
+        : encoded;
     }
     return SEARCH_HEADLINE_NAMED_ENTITIES[normalizedEntity] ?? encoded;
   });

--- a/apps/web/src/lib/search.logic.ts
+++ b/apps/web/src/lib/search.logic.ts
@@ -36,9 +36,9 @@ const decodeSearchHeadlineEntities = (value: string): string =>
     return SEARCH_HEADLINE_NAMED_ENTITIES[normalizedEntity] ?? encoded;
   });
 
-const getMarkedSearchText = (headline: string | null): string => {
+const getMarkedSearchTerms = (headline: string | null): string[] => {
   if (!headline) {
-    return "";
+    return [];
   }
 
   const terms: string[] = [];
@@ -51,7 +51,7 @@ const getMarkedSearchText = (headline: string | null): string => {
       terms.push(term);
     }
   }
-  return terms.join(" ");
+  return terms;
 };
 
 export const getSearchHighlightText = (
@@ -59,7 +59,7 @@ export const getSearchHighlightText = (
   query: string,
 ): string => {
   const normalizedQuery = normalizeSearchQuery(query);
-  const markedSearchText = getMarkedSearchText(headline);
+  const markedSearchText = getMarkedSearchTerms(headline).join(" ");
   if (markedSearchText) {
     return markedSearchText;
   }
@@ -69,6 +69,14 @@ export const getSearchHighlightText = (
   }
 
   return headline ? stripSearchMarkup(headline) : "";
+};
+
+export const getFirstSearchHighlightText = (
+  headline: string | null,
+  query: string,
+): string => {
+  const markedSearchText = getMarkedSearchTerms(headline).at(0);
+  return markedSearchText ?? getSearchHighlightText(headline, query);
 };
 
 type SearchPreviewContent =

--- a/apps/web/src/lib/search.logic.ts
+++ b/apps/web/src/lib/search.logic.ts
@@ -7,6 +7,41 @@ export const normalizeSearchQuery = (query: string): string => query.trim();
 export const stripSearchMarkup = (value: string): string =>
   value.replaceAll("<mark>", " ").replaceAll("</mark>", " ").trim();
 
+const SEARCH_HEADLINE_NAMED_ENTITIES: Readonly<Record<string, string>> = {
+  amp: "&",
+  apos: "'",
+  gt: ">",
+  lt: "<",
+  quot: '"',
+};
+const SEARCH_HEADLINE_ENTITY = /&(?<entity>#x[\da-f]+|#\d+|[a-z]+);/giu;
+
+const decodeSearchHeadlineEntities = (value: string): string =>
+  value.replace(SEARCH_HEADLINE_ENTITY, (encoded, _entity, ...args) => {
+    const groups = args.at(-1);
+    if (
+      typeof groups !== "object" ||
+      groups === null ||
+      !("entity" in groups)
+    ) {
+      return encoded;
+    }
+    const entity = groups["entity"];
+    if (typeof entity !== "string") {
+      return encoded;
+    }
+    const normalizedEntity = entity.toLowerCase();
+    if (normalizedEntity.startsWith("#x")) {
+      const codePoint = Number.parseInt(normalizedEntity.slice(2), 16);
+      return codePoint <= 0x10_ffff ? String.fromCodePoint(codePoint) : encoded;
+    }
+    if (normalizedEntity.startsWith("#")) {
+      const codePoint = Number.parseInt(normalizedEntity.slice(1), 10);
+      return codePoint <= 0x10_ffff ? String.fromCodePoint(codePoint) : encoded;
+    }
+    return SEARCH_HEADLINE_NAMED_ENTITIES[normalizedEntity] ?? encoded;
+  });
+
 const getMarkedSearchText = (headline: string | null): string => {
   if (!headline) {
     return "";
@@ -14,7 +49,10 @@ const getMarkedSearchText = (headline: string | null): string => {
 
   const terms: string[] = [];
   for (const match of headline.matchAll(/<mark>(?<term>.*?)<\/mark>/gu)) {
-    const term = match.groups?.["term"]?.trim();
+    const encodedTerm = match.groups?.["term"]?.trim();
+    const term = encodedTerm
+      ? decodeSearchHeadlineEntities(encodedTerm).trim()
+      : undefined;
     if (term && !terms.includes(term)) {
       terms.push(term);
     }
@@ -128,6 +166,19 @@ export type NativeSearchDocumentPreviewTarget = {
   mimeType: typeof DOCX_MIME | typeof PDF_MIME;
   workspaceId: string;
 };
+
+export type NativeSearchStatus = "matched" | "pending" | "unmatched";
+
+type NativeSearchFallbackArgs = {
+  searchText: string;
+  status: NativeSearchStatus;
+};
+
+export const shouldShowNativeSearchFallback = ({
+  searchText,
+  status,
+}: NativeSearchFallbackArgs): boolean =>
+  searchText.trim().length > 0 && status === "unmatched";
 
 export const getNativeSearchDocumentPreviewTarget = (
   hit: GlobalSearchHit,

--- a/apps/web/src/lib/search.logic.ts
+++ b/apps/web/src/lib/search.logic.ts
@@ -1,6 +1,8 @@
 import type { GlobalSearchHit, GlobalSearchResultType } from "@stll/api/types";
 
 import { DOCX_MIME, PDF_MIME } from "@/lib/consts";
+import { getSearchTextCandidates } from "@/lib/search-text";
+import type { SearchTextQuery } from "@/lib/search-text";
 
 export const normalizeSearchQuery = (query: string): string => query.trim();
 
@@ -57,9 +59,13 @@ const getMarkedSearchTerms = (headline: string | null): string[] => {
 export const getSearchHighlightText = (
   headline: string | null,
   query: string,
-): string => {
+): SearchTextQuery => {
   const normalizedQuery = normalizeSearchQuery(query);
-  const markedSearchText = getMarkedSearchTerms(headline).join(" ");
+  const markedSearchTerms = getMarkedSearchTerms(headline);
+  if (markedSearchTerms.length > 1) {
+    return { type: "separate-terms", terms: markedSearchTerms };
+  }
+  const markedSearchText = markedSearchTerms.at(0);
   if (markedSearchText) {
     return markedSearchText;
   }
@@ -76,7 +82,12 @@ export const getFirstSearchHighlightText = (
   query: string,
 ): string => {
   const markedSearchText = getMarkedSearchTerms(headline).at(0);
-  return markedSearchText ?? getSearchHighlightText(headline, query);
+  if (markedSearchText) {
+    return markedSearchText;
+  }
+
+  const normalizedQuery = normalizeSearchQuery(query);
+  return normalizedQuery || (headline ? stripSearchMarkup(headline) : "");
 };
 
 type SearchPreviewContent =
@@ -172,7 +183,7 @@ export type NativeSearchDocumentPreviewTarget = {
 export type NativeSearchStatus = "matched" | "pending" | "unmatched";
 
 type NativeSearchFallbackArgs = {
-  searchText: string;
+  searchText: SearchTextQuery;
   status: NativeSearchStatus;
 };
 
@@ -180,7 +191,7 @@ export const shouldShowNativeSearchFallback = ({
   searchText,
   status,
 }: NativeSearchFallbackArgs): boolean =>
-  searchText.trim().length > 0 && status === "unmatched";
+  getSearchTextCandidates(searchText).length > 0 && status === "unmatched";
 
 export const getNativeSearchDocumentPreviewTarget = (
   hit: GlobalSearchHit,

--- a/apps/web/src/lib/search.test.ts
+++ b/apps/web/src/lib/search.test.ts
@@ -23,6 +23,7 @@ process.env["VITE_API_URL"] ??= "http://localhost:3001";
 const {
   hasSearchQueryOrSelectiveFilter,
   recentFilePreviewFieldOptions,
+  resolveRecentFilePreviewFieldId,
   searchInfiniteOptions,
   searchPreviewOptions,
 } = await import("@/lib/search");
@@ -194,6 +195,7 @@ describe("search preview targets", () => {
     lastEditedByName: null,
     lastEditedByImage: null,
     fileFieldId: null,
+    filePropertyId: null,
     mimeType: null,
   } as const satisfies GlobalSearchHit;
 
@@ -220,6 +222,8 @@ describe("search preview targets", () => {
   test("isolates legacy recent-file field resolution by owner", () => {
     const params = {
       entityId: "entity_1",
+      fileFieldId: "field_2",
+      filePropertyId: "property_2",
       mimeType: "application/pdf",
       organizationId: "org_1",
       userId: "user_1",
@@ -237,6 +241,62 @@ describe("search preview targets", () => {
 
     expect(organizationB.queryKey).not.toEqual(ownerA.queryKey);
     expect(userB.queryKey).not.toEqual(ownerA.queryKey);
+    expect(
+      recentFilePreviewFieldOptions({ ...params, fileFieldId: "field_1" })
+        .queryKey,
+    ).not.toEqual(ownerA.queryKey);
+    expect(
+      recentFilePreviewFieldOptions({
+        ...params,
+        filePropertyId: "property_1",
+      }).queryKey,
+    ).not.toEqual(ownerA.queryKey);
+  });
+
+  test("preserves recent attachment identity across current revisions", () => {
+    const fields = [
+      {
+        content: { mimeType: "application/pdf", type: "file" },
+        id: "field_1",
+        propertyId: "property_1",
+      },
+      {
+        content: { mimeType: "application/pdf", type: "file" },
+        id: "field_2",
+        propertyId: "property_2",
+      },
+    ];
+
+    expect(
+      resolveRecentFilePreviewFieldId({
+        fields,
+        fileFieldId: "field_2",
+        filePropertyId: "property_1",
+        mimeType: "application/pdf",
+      }),
+    ).toBe("field_2");
+    expect(
+      resolveRecentFilePreviewFieldId({
+        fields,
+        fileFieldId: "deleted_field",
+        filePropertyId: "deleted_property",
+        mimeType: "application/pdf",
+      }),
+    ).toBeNull();
+    expect(
+      resolveRecentFilePreviewFieldId({
+        fields,
+        fileFieldId: "field_from_old_revision",
+        filePropertyId: "property_2",
+        mimeType: "application/pdf",
+      }),
+    ).toBe("field_2");
+    expect(
+      resolveRecentFilePreviewFieldId({
+        fields,
+        mimeType: "application/pdf",
+      }),
+    ).toBe("field_1");
   });
 
   test("reauthorizes cached previews whenever they mount", () => {
@@ -333,6 +393,7 @@ describe("search preview targets", () => {
       getNativeSearchDocumentPreviewTarget({
         ...previewHit,
         fileFieldId: null,
+        filePropertyId: null,
         mimeType: "application/pdf",
       }),
     ).toBeNull();
@@ -505,6 +566,7 @@ describe("search preview targets", () => {
         lastEditedByName: null,
         lastEditedByImage: null,
         fileFieldId: null,
+        filePropertyId: null,
         mimeType: null,
       },
     ] as const satisfies readonly GlobalSearchHit[];

--- a/apps/web/src/lib/search.test.ts
+++ b/apps/web/src/lib/search.test.ts
@@ -116,35 +116,56 @@ describe("search query normalization", () => {
 
   test("uses server-located terms for native document highlighting", () => {
     expect(
-      getSearchHighlightText(
-        "The <mark>Closing</mark> memorandum",
-        "closing memo",
-      ),
-    ).toBe("Closing");
-    expect(getSearchHighlightText(null, "  closing memo ")).toBe(
-      "closing memo",
-    );
-    expect(
-      getSearchHighlightText("The <mark>Closing</mark> memorandum", ""),
+      getSearchHighlightText({
+        headline: "The <mark>Closing</mark> memorandum",
+        query: "closing memo",
+      }),
     ).toBe("Closing");
     expect(
-      getSearchHighlightText(
-        "The <mark>R&amp;D</mark> team&#x27;s <mark>&lt;draft&gt;</mark>",
-        "",
-      ),
+      getSearchHighlightText({ headline: null, query: "  closing memo " }),
+    ).toBe("closing memo");
+    expect(
+      getSearchHighlightText({
+        headline: "The <mark>Closing</mark> memorandum",
+        query: "",
+      }),
+    ).toBe("Closing");
+    expect(
+      getSearchHighlightText({
+        headline:
+          "The <mark>R&amp;D</mark> team&#x27;s <mark>&lt;draft&gt;</mark>",
+        query: "",
+      }),
     ).toEqual({ type: "separate-terms", terms: ["R&D", "<draft>"] });
   });
 
   test("excludes advanced-query operators and negated terms from previews", () => {
     expect(
-      getSearchHighlightText(
-        "<mark>indemnity</mark> and <mark>liability</mark>",
-        "indemnity AND liability NOT superseded",
-      ),
+      getSearchHighlightText({
+        headline: "<mark>indemnity</mark> and <mark>liability</mark>",
+        query: "indemnity AND liability NOT superseded",
+      }),
     ).toEqual({
       type: "separate-terms",
       terms: ["indemnity", "liability"],
     });
+    expect(
+      getSearchHighlightText({
+        headline: null,
+        previewLocatorCandidates: ["indemnity", "liability"],
+        query: "indemnity OR liability NOT superseded",
+      }),
+    ).toEqual({
+      type: "separate-terms",
+      terms: ["indemnity", "liability"],
+    });
+    expect(
+      getSearchHighlightText({
+        headline: null,
+        previewLocatorCandidates: ["closing memo"],
+        query: '"closing memo" NOT draft',
+      }),
+    ).toBe("closing memo");
   });
 
   test("uses one marked passage for case-law deep links", () => {

--- a/apps/web/src/lib/search.test.ts
+++ b/apps/web/src/lib/search.test.ts
@@ -12,6 +12,7 @@ import {
   selectAuthorizedSearchPreviewData,
   selectDisplayedSearchPreviewHit,
   selectSearchPreviewHit,
+  shouldShowNativeSearchFallback,
   shouldShowSearchPreview,
 } from "@/lib/search.logic";
 import type { SearchPreviewChatMessage } from "@/lib/search.logic";
@@ -125,6 +126,12 @@ describe("search query normalization", () => {
     expect(
       getSearchHighlightText("The <mark>Closing</mark> memorandum", ""),
     ).toBe("Closing");
+    expect(
+      getSearchHighlightText(
+        "The <mark>R&amp;D</mark> team&#x27;s <mark>&lt;draft&gt;</mark>",
+        "",
+      ),
+    ).toBe("R&D <draft>");
   });
 
   test("excludes advanced-query operators and negated terms from previews", () => {
@@ -233,6 +240,24 @@ describe("search preview targets", () => {
     expect(
       selectDisplayedSearchPreviewHit({ hit: previewHit, showPreview: true }),
     ).toBe(previewHit);
+  });
+
+  test("uses server text only after a native search settles without matches", () => {
+    expect(
+      shouldShowNativeSearchFallback({
+        searchText: "indemnity",
+        status: "unmatched",
+      }),
+    ).toBeTrue();
+    expect(
+      shouldShowNativeSearchFallback({
+        searchText: "indemnity",
+        status: "pending",
+      }),
+    ).toBeFalse();
+    expect(
+      shouldShowNativeSearchFallback({ searchText: "", status: "unmatched" }),
+    ).toBeFalse();
   });
 
   test("routes PDF and DOCX documents to the native inspector viewer", () => {

--- a/apps/web/src/lib/search.test.ts
+++ b/apps/web/src/lib/search.test.ts
@@ -111,19 +111,28 @@ describe("search query normalization", () => {
     expect(normalizeSearchQuery(" \t\n ")).toBe("");
   });
 
-  test("uses the full query for native document highlighting", () => {
+  test("uses server-located terms for native document highlighting", () => {
     expect(
       getSearchHighlightText(
         "The <mark>Closing</mark> memorandum",
         "closing memo",
       ),
-    ).toBe("closing memo");
+    ).toBe("Closing");
     expect(getSearchHighlightText(null, "  closing memo ")).toBe(
       "closing memo",
     );
     expect(
       getSearchHighlightText("The <mark>Closing</mark> memorandum", ""),
     ).toBe("Closing");
+  });
+
+  test("excludes advanced-query operators and negated terms from previews", () => {
+    expect(
+      getSearchHighlightText(
+        "<mark>indemnity</mark> and <mark>liability</mark>",
+        "indemnity AND liability NOT superseded",
+      ),
+    ).toBe("indemnity liability");
   });
 });
 

--- a/apps/web/src/lib/search.test.ts
+++ b/apps/web/src/lib/search.test.ts
@@ -132,7 +132,7 @@ describe("search query normalization", () => {
         "The <mark>R&amp;D</mark> team&#x27;s <mark>&lt;draft&gt;</mark>",
         "",
       ),
-    ).toBe("R&D <draft>");
+    ).toEqual({ type: "separate-terms", terms: ["R&D", "<draft>"] });
   });
 
   test("excludes advanced-query operators and negated terms from previews", () => {
@@ -141,7 +141,10 @@ describe("search query normalization", () => {
         "<mark>indemnity</mark> and <mark>liability</mark>",
         "indemnity AND liability NOT superseded",
       ),
-    ).toBe("indemnity liability");
+    ).toEqual({
+      type: "separate-terms",
+      terms: ["indemnity", "liability"],
+    });
   });
 
   test("uses one marked passage for case-law deep links", () => {

--- a/apps/web/src/lib/search.test.ts
+++ b/apps/web/src/lib/search.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "bun:test";
 import type { GlobalSearchHit } from "@stll/api/types";
 
 import {
+  getFirstSearchHighlightText,
   getNativeSearchDocumentPreviewTarget,
   getSearchHighlightText,
   getSearchPreviewRenderContent,
@@ -141,6 +142,18 @@ describe("search query normalization", () => {
         "indemnity AND liability NOT superseded",
       ),
     ).toBe("indemnity liability");
+  });
+
+  test("uses one marked passage for case-law deep links", () => {
+    expect(
+      getFirstSearchHighlightText(
+        "<mark>indemnity</mark> and <mark>liability</mark>",
+        "",
+      ),
+    ).toBe("indemnity");
+    expect(getFirstSearchHighlightText(null, "  closing memo ")).toBe(
+      "closing memo",
+    );
   });
 });
 

--- a/apps/web/src/lib/search.test.ts
+++ b/apps/web/src/lib/search.test.ts
@@ -14,6 +14,7 @@ import {
   selectSearchPreviewHit,
   shouldShowSearchPreview,
 } from "@/lib/search.logic";
+import type { SearchPreviewChatMessage } from "@/lib/search.logic";
 
 process.env["VITE_API_URL"] ??= "http://localhost:3001";
 
@@ -352,7 +353,7 @@ describe("search preview targets", () => {
     const messages = [
       { id: "message_1", role: "user", content: "Review this" },
       { id: "message_2", role: "assistant", content: "## Review" },
-    ] as const;
+    ] satisfies SearchPreviewChatMessage[];
 
     expect(
       getSearchPreviewRenderContent({

--- a/apps/web/src/lib/search.test.ts
+++ b/apps/web/src/lib/search.test.ts
@@ -3,11 +3,14 @@ import { describe, expect, test } from "bun:test";
 import type { GlobalSearchHit } from "@stll/api/types";
 
 import {
+  getNativeSearchDocumentPreviewTarget,
+  getSearchHighlightText,
   getSearchPreviewRenderContent,
   getSearchPreviewDate,
   getSearchPreviewTarget,
   normalizeSearchQuery,
   selectAuthorizedSearchPreviewData,
+  selectDisplayedSearchPreviewHit,
   selectSearchPreviewHit,
   shouldShowSearchPreview,
 } from "@/lib/search.logic";
@@ -16,6 +19,7 @@ process.env["VITE_API_URL"] ??= "http://localhost:3001";
 
 const {
   hasSearchQueryOrSelectiveFilter,
+  recentFilePreviewFieldOptions,
   searchInfiniteOptions,
   searchPreviewOptions,
 } = await import("@/lib/search");
@@ -106,6 +110,21 @@ describe("search query normalization", () => {
   test("turns whitespace-only input into an empty query", () => {
     expect(normalizeSearchQuery(" \t\n ")).toBe("");
   });
+
+  test("uses the full query for native document highlighting", () => {
+    expect(
+      getSearchHighlightText(
+        "The <mark>Closing</mark> memorandum",
+        "closing memo",
+      ),
+    ).toBe("closing memo");
+    expect(getSearchHighlightText(null, "  closing memo ")).toBe(
+      "closing memo",
+    );
+    expect(
+      getSearchHighlightText("The <mark>Closing</mark> memorandum", ""),
+    ).toBe("Closing");
+  });
 });
 
 describe("search preview targets", () => {
@@ -120,6 +139,7 @@ describe("search preview targets", () => {
     workspaceName: "Matter",
     lastEditedByName: null,
     lastEditedByImage: null,
+    fileFieldId: null,
     mimeType: null,
   } as const satisfies GlobalSearchHit;
 
@@ -138,6 +158,28 @@ describe("search preview targets", () => {
       organizationId: "org_2",
     });
     const userB = searchPreviewOptions({ ...params, userId: "user_2" });
+
+    expect(organizationB.queryKey).not.toEqual(ownerA.queryKey);
+    expect(userB.queryKey).not.toEqual(ownerA.queryKey);
+  });
+
+  test("isolates legacy recent-file field resolution by owner", () => {
+    const params = {
+      entityId: "entity_1",
+      mimeType: "application/pdf",
+      organizationId: "org_1",
+      userId: "user_1",
+      workspaceId: "workspace_1",
+    };
+    const ownerA = recentFilePreviewFieldOptions(params);
+    const organizationB = recentFilePreviewFieldOptions({
+      ...params,
+      organizationId: "org_2",
+    });
+    const userB = recentFilePreviewFieldOptions({
+      ...params,
+      userId: "user_2",
+    });
 
     expect(organizationB.queryKey).not.toEqual(ownerA.queryKey);
     expect(userB.queryKey).not.toEqual(ownerA.queryKey);
@@ -166,6 +208,69 @@ describe("search preview targets", () => {
     ]) {
       expect(shouldShowSearchPreview(testCase)).toBe(testCase.expected);
     }
+  });
+
+  test("does not reserve a preview pane without a current result", () => {
+    expect(
+      selectDisplayedSearchPreviewHit({ hit: null, showPreview: true }),
+    ).toBeNull();
+    expect(
+      selectDisplayedSearchPreviewHit({
+        hit: previewHit,
+        showPreview: false,
+      }),
+    ).toBeNull();
+    expect(
+      selectDisplayedSearchPreviewHit({ hit: previewHit, showPreview: true }),
+    ).toBe(previewHit);
+  });
+
+  test("routes PDF and DOCX documents to the native inspector viewer", () => {
+    expect(
+      getNativeSearchDocumentPreviewTarget({
+        ...previewHit,
+        fileFieldId: "field_pdf",
+        mimeType: "application/pdf",
+      }),
+    ).toEqual({
+      entityId: "entity_1",
+      fieldId: "field_pdf",
+      filePurpose: "display",
+      mimeType: "application/pdf",
+      workspaceId: "ws_1",
+    });
+    expect(
+      getNativeSearchDocumentPreviewTarget({
+        ...previewHit,
+        fileFieldId: "field_docx",
+        mimeType:
+          "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+      }),
+    ).toEqual({
+      entityId: "entity_1",
+      fieldId: "field_docx",
+      filePurpose: "native-display",
+      mimeType:
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+      workspaceId: "ws_1",
+    });
+  });
+
+  test("keeps unsupported and unresolved documents on the text path", () => {
+    expect(
+      getNativeSearchDocumentPreviewTarget({
+        ...previewHit,
+        fileFieldId: null,
+        mimeType: "application/pdf",
+      }),
+    ).toBeNull();
+    expect(
+      getNativeSearchDocumentPreviewTarget({
+        ...previewHit,
+        fileFieldId: "field_text",
+        mimeType: "text/plain",
+      }),
+    ).toBeNull();
   });
 
   test("retains authorized data during background refetches", () => {
@@ -232,6 +337,20 @@ describe("search preview targets", () => {
       directionText: "résumé",
       html: "<mark>résumé</mark>",
     });
+  });
+
+  test("preserves structured chat messages for native bubble rendering", () => {
+    const messages = [
+      { id: "message_1", role: "user", content: "Review this" },
+      { id: "message_2", role: "assistant", content: "## Review" },
+    ] as const;
+
+    expect(
+      getSearchPreviewRenderContent({
+        type: "chat-messages",
+        messages: [...messages],
+      }),
+    ).toEqual({ type: "chat-messages", messages });
   });
 
   test("withholds previews while hits belong to the previous query", () => {
@@ -313,6 +432,7 @@ describe("search preview targets", () => {
         workspaceName: "Matter",
         lastEditedByName: null,
         lastEditedByImage: null,
+        fileFieldId: null,
         mimeType: null,
       },
     ] as const satisfies readonly GlobalSearchHit[];

--- a/apps/web/src/lib/search.ts
+++ b/apps/web/src/lib/search.ts
@@ -87,6 +87,8 @@ type SearchOwner = Pick<SearchParams, "organizationId" | "userId">;
 
 type RecentFilePreviewFieldParams = SearchOwner & {
   entityId: string;
+  fileFieldId?: string | null | undefined;
+  filePropertyId?: string | null | undefined;
   mimeType: string | null;
   workspaceId: string;
 };
@@ -157,6 +159,8 @@ const searchKeys = {
       "recent-file-preview-field",
       {
         entityId: params.entityId,
+        fileFieldId: params.fileFieldId,
+        filePropertyId: params.filePropertyId,
         mimeType: params.mimeType,
         workspaceId: params.workspaceId,
       },
@@ -272,10 +276,55 @@ export const searchPreviewOptions = ({
     staleTime: 0,
   });
 
+type RecentFilePreviewCandidate = {
+  content: { mimeType?: string | null | undefined; type: string };
+  id: string;
+  propertyId: string;
+};
+
+type ResolveRecentFilePreviewFieldIdOptions = Pick<
+  RecentFilePreviewFieldParams,
+  "fileFieldId" | "filePropertyId" | "mimeType"
+> & {
+  fields: readonly RecentFilePreviewCandidate[];
+};
+
+export const resolveRecentFilePreviewFieldId = ({
+  fields,
+  fileFieldId,
+  filePropertyId,
+  mimeType,
+}: ResolveRecentFilePreviewFieldIdOptions): string | null => {
+  const matchesFile = ({ content }: RecentFilePreviewCandidate) =>
+    content.type === "file" &&
+    (mimeType === null || content.mimeType === mimeType);
+  const exactField = fileFieldId
+    ? fields.find(
+        (candidate) => candidate.id === fileFieldId && matchesFile(candidate),
+      )
+    : undefined;
+  if (exactField) {
+    return exactField.id;
+  }
+  const replacementField = filePropertyId
+    ? fields.find(
+        (candidate) =>
+          candidate.propertyId === filePropertyId && matchesFile(candidate),
+      )
+    : undefined;
+  if (replacementField) {
+    return replacementField.id;
+  }
+  if (fileFieldId || filePropertyId) {
+    return null;
+  }
+  return fields.find(matchesFile)?.id ?? null;
+};
+
 /**
- * Resolves legacy recent-file entries recorded before recents persisted their
- * file field id. The entity endpoint reauthorizes the workspace on every
- * cache miss; the owner-scoped key prevents reuse across org/user switches.
+ * Reauthorizes a recent file against the entity's current version. Exact field
+ * identity wins; a stable property id follows replacement revisions; the MIME
+ * fallback remains only for legacy recent entries without either identifier.
  */
 export const recentFilePreviewFieldOptions = (
   params: RecentFilePreviewFieldParams,
@@ -288,14 +337,12 @@ export const recentFilePreviewFieldOptions = (
         .entity({ entityId: toSafeId<"entity">(params.entityId) })
         .get({ fetch: { signal } });
       const entity = unwrapEden(response);
-      const field = entity.fields.find(
-        (candidate) =>
-          candidate.content.type === "file" &&
-          (params.mimeType === null ||
-            candidate.content.mimeType === params.mimeType),
-      );
-
-      return field?.id ?? null;
+      return resolveRecentFilePreviewFieldId({
+        fields: entity.fields,
+        fileFieldId: params.fileFieldId,
+        filePropertyId: params.filePropertyId,
+        mimeType: params.mimeType,
+      });
     },
   });
 

--- a/apps/web/src/lib/search.ts
+++ b/apps/web/src/lib/search.ts
@@ -85,6 +85,12 @@ type SearchFacetParams = {
 
 type SearchOwner = Pick<SearchParams, "organizationId" | "userId">;
 
+type RecentFilePreviewFieldParams = SearchOwner & {
+  entityId: string;
+  mimeType: string | null;
+  workspaceId: string;
+};
+
 export type SearchAISummaryParams = {
   query: string;
   locale: string;
@@ -143,6 +149,16 @@ const searchKeys = {
         resultId,
         type,
         updatedAt,
+      },
+    ] as const,
+  recentFilePreviewField: (params: RecentFilePreviewFieldParams) =>
+    [
+      ...searchKeys.owner(params),
+      "recent-file-preview-field",
+      {
+        entityId: params.entityId,
+        mimeType: params.mimeType,
+        workspaceId: params.workspaceId,
       },
     ] as const,
   facet: (params: SearchFacetParams) =>
@@ -254,6 +270,33 @@ export const searchPreviewOptions = ({
     },
     refetchOnMount: "always",
     staleTime: 0,
+  });
+
+/**
+ * Resolves legacy recent-file entries recorded before recents persisted their
+ * file field id. The entity endpoint reauthorizes the workspace on every
+ * cache miss; the owner-scoped key prevents reuse across org/user switches.
+ */
+export const recentFilePreviewFieldOptions = (
+  params: RecentFilePreviewFieldParams,
+) =>
+  queryOptions({
+    queryKey: searchKeys.recentFilePreviewField(params),
+    queryFn: async ({ signal }) => {
+      const response = await api
+        .entities({ workspaceId: toSafeId<"workspace">(params.workspaceId) })
+        .entity({ entityId: toSafeId<"entity">(params.entityId) })
+        .get({ fetch: { signal } });
+      const entity = unwrapEden(response);
+      const field = entity.fields.find(
+        (candidate) =>
+          candidate.content.type === "file" &&
+          (params.mimeType === null ||
+            candidate.content.mimeType === params.mimeType),
+      );
+
+      return field?.id ?? null;
+    },
   });
 
 export const searchFacetOptions = (params: SearchFacetParams) =>

--- a/apps/web/src/routes/_protected.chat/-components/chat-thread-page.tsx
+++ b/apps/web/src/routes/_protected.chat/-components/chat-thread-page.tsx
@@ -438,9 +438,9 @@ export const ChatThreadPage = ({
   // The floating composer block grows with the draft (multi-line text,
   // attachment chips, followup chips), so a static bottom offset cannot
   // keep the scroll-to-bottom button clear of it in every state. Publish
-  // the block's live height as a CSS variable on the page container; the
-  // button (inside <Conversation>) inherits it and floats just above the
-  // block at any composer height.
+  // the block's live height as a CSS variable on the page container. The
+  // transcript bottom padding and scroll button (inside <Conversation>) both
+  // inherit it, keeping the final content above the block at any height.
   const pageContainerRef = useRef<HTMLDivElement>(null);
   const composerBlockRef = useRef<HTMLDivElement>(null);
   useExternalSyncEffect(() => {
@@ -568,7 +568,7 @@ export const ChatThreadPage = ({
             ref={pageContainerRef}
           >
             <Conversation className="@container isolate min-h-0">
-              <ConversationContent className="mx-auto w-full max-w-5xl gap-3 px-4 pb-36">
+              <ConversationContent className="mx-auto w-full max-w-5xl gap-3 px-4 pb-[calc(var(--composer-block-h,7rem)+1.5rem)]">
                 {messages.length === 0 && !isGenerating && !error ? (
                   <div className="m-auto w-full max-w-md px-4">
                     <PromptSuggestions
@@ -645,8 +645,8 @@ export const ChatThreadPage = ({
                 showing through beneath the status row. The tray wrapper's
                 `p-2` keeps the composer breathing inside the veil.
                 `--composer-block-h` is measured from this block's live
-                height, so the scroll button's offset tracks the change
-                automatically. */}
+                height, so transcript clearance and the scroll button's
+                offset track the change automatically. */}
             <div
               className="absolute inset-x-0 bottom-0 z-20 mx-auto w-full max-w-5xl px-4"
               ref={composerBlockRef}

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/peek/peek-pdf-viewer.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/peek/peek-pdf-viewer.tsx
@@ -186,7 +186,9 @@ const PeekPdfViewerContent = ({
           onScrollTopChange={onDocxScrollTopChange}
           onSearchMatchSummaryChange={onSearchMatchSummaryChange}
           scaleOffset={scaleOffset}
-          searchText={searchText}
+          searchText={
+            interactionMode === "preview-only" ? searchText : undefined
+          }
           workspaceId={workspaceId}
         />
       </Suspense>
@@ -459,7 +461,7 @@ const PeekDocxViewer = ({
     | undefined;
   printActionsRef?: RefObject<Map<string, () => void>> | undefined;
   scaleOffset: number;
-  searchText: string;
+  searchText: string | undefined;
   workspaceId: string;
 }) => {
   const analytics = useAnalytics();
@@ -478,6 +480,10 @@ const PeekDocxViewer = ({
   useDocxBlockScroll({ editorRef, fieldId });
 
   const highlightSearchResult = useCallback(() => {
+    if (searchText === undefined) {
+      return true;
+    }
+
     const editor = editorRef.current;
     if (!editor) {
       return false;

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/peek/peek-pdf-viewer.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/peek/peek-pdf-viewer.tsx
@@ -20,6 +20,7 @@ import {
 } from "lucide-react";
 import { useTranslations } from "use-intl";
 
+import { resolveFindMatchRange } from "@stll/folio-core/prosemirror/findReplaceSelection";
 import type { DocxEditorRef } from "@stll/folio-react";
 import { Button } from "@stll/ui/components/button";
 import "@stll/folio-react/editor.css";
@@ -37,9 +38,12 @@ import { useExternalSyncEffect, useMountEffect } from "@/hooks/use-effect";
 import { useAnalytics } from "@/lib/analytics/provider";
 import { DOCX_MIME } from "@/lib/consts";
 import { detached } from "@/lib/detached";
+import { findDocumentSearchMatches } from "@/lib/document-search";
 import { usePDFStore } from "@/lib/pdf/pdf-context";
 import { PDFPage } from "@/lib/pdf/pdf-page";
 import { PDFViewport } from "@/lib/pdf/pdf-viewport";
+import type { SearchMatchSummary } from "@/lib/search-match-navigation";
+import { MAX_SEARCH_PREVIEW_MATCHES } from "@/lib/search-match-navigation";
 import { composeRefs } from "@/lib/utils";
 import { useDocxBlockScroll } from "@/routes/_protected.workspaces/$workspaceId/-components/docx/use-docx-block-scroll";
 import { fileOptions } from "@/routes/_protected.workspaces/$workspaceId/-components/files/queries";
@@ -55,6 +59,34 @@ const DocxEditor = lazy(async () => {
   return { default: m.DocxEditor };
 });
 
+const SEARCH_HIGHLIGHT_MAX_ANIMATION_FRAMES = 120;
+
+type ScheduleSearchHighlightFrameOptions = {
+  attempt: () => boolean;
+  onFrame: (frame: number | null) => void;
+  remainingFrames?: number | undefined;
+};
+
+const scheduleSearchHighlightFrame = ({
+  attempt,
+  onFrame,
+  remainingFrames = SEARCH_HIGHLIGHT_MAX_ANIMATION_FRAMES,
+}: ScheduleSearchHighlightFrameOptions): void => {
+  if (attempt() || remainingFrames <= 1) {
+    onFrame(null);
+    return;
+  }
+
+  const frame = requestAnimationFrame(() => {
+    scheduleSearchHighlightFrame({
+      attempt,
+      onFrame,
+      remainingFrames: remainingFrames - 1,
+    });
+  });
+  onFrame(frame);
+};
+
 type PeekPdfViewerProps = {
   workspaceId: string;
   viewId: string;
@@ -64,6 +96,12 @@ type PeekPdfViewerProps = {
   filePurpose?: "display" | "native-display" | undefined;
   scaleOffset: number;
   mimeType?: string | undefined;
+  interactionMode?: "preview-only" | "with-ai" | undefined;
+  searchText?: string | undefined;
+  activeSearchMatchIndex?: number | undefined;
+  onSearchMatchSummaryChange?:
+    | ((summary: SearchMatchSummary) => void)
+    | undefined;
   /** Called when navigating from peek to fullscreen PDF (e.g. inspector close). */
   onPeekNavigate?: (() => void) | undefined;
   docxPrintActionsRef?: RefObject<Map<string, () => void>> | undefined;
@@ -103,6 +141,10 @@ const PeekPdfViewerContent = ({
   filePurpose = "display",
   scaleOffset,
   mimeType,
+  interactionMode = "with-ai",
+  searchText = "",
+  activeSearchMatchIndex = 0,
+  onSearchMatchSummaryChange,
   onPeekNavigate,
   docxPrintActionsRef,
   onDocxScrollTopChange,
@@ -138,14 +180,38 @@ const PeekPdfViewerContent = ({
       <Suspense fallback={<PeekSuspenseFallback />}>
         <PeekDocxViewer
           buffer={file.buffer}
+          activeSearchMatchIndex={activeSearchMatchIndex}
           fieldId={fieldId}
           printActionsRef={docxPrintActionsRef}
           onScrollTopChange={onDocxScrollTopChange}
+          onSearchMatchSummaryChange={onSearchMatchSummaryChange}
           scaleOffset={scaleOffset}
+          searchText={searchText}
           workspaceId={workspaceId}
         />
       </Suspense>
     );
+  }
+
+  const viewport = (
+    <PDFViewport
+      buffer={file.buffer}
+      className="document-preview-surface h-full"
+      contentClassName="relative space-y-2 px-2 pt-2"
+      fileId={fieldId}
+      invertColors={isImageOrigin ? false : undefined}
+      scaleOffset={scaleOffset}
+      activeSearchMatchIndex={activeSearchMatchIndex}
+      onSearchMatchSummaryChange={onSearchMatchSummaryChange}
+      searchText={searchText}
+      renderPage={(props) => (
+        <PDFPage {...props} renderOverlay={renderPageOverlay} />
+      )}
+    />
+  );
+
+  if (interactionMode === "preview-only") {
+    return viewport;
   }
 
   return (
@@ -153,17 +219,7 @@ const PeekPdfViewerContent = ({
       activeFile={{ entityId, fileFieldId: fieldId, fileName: file.fileName }}
       workspaceId={workspaceId}
     >
-      <PDFViewport
-        buffer={file.buffer}
-        className="document-preview-surface h-full"
-        contentClassName="relative space-y-2 px-2 pt-2"
-        fileId={fieldId}
-        invertColors={isImageOrigin ? false : undefined}
-        scaleOffset={scaleOffset}
-        renderPage={(props) => (
-          <PDFPage {...props} renderOverlay={renderPageOverlay} />
-        )}
-      />
+      {viewport}
     </FileViewerWithAI>
   );
 };
@@ -384,23 +440,32 @@ export const PreparedPdfPrintButton = ({
 // ── DOCX peek viewer with zoom wiring ──────────────────
 
 const PeekDocxViewer = ({
+  activeSearchMatchIndex,
   buffer,
   fieldId,
   onScrollTopChange,
+  onSearchMatchSummaryChange,
   printActionsRef,
   scaleOffset,
+  searchText,
   workspaceId,
 }: {
+  activeSearchMatchIndex: number;
   buffer: ArrayBuffer;
   fieldId: string;
   onScrollTopChange?: ((scrollTop: number) => void) | undefined;
+  onSearchMatchSummaryChange?:
+    | ((summary: SearchMatchSummary) => void)
+    | undefined;
   printActionsRef?: RefObject<Map<string, () => void>> | undefined;
   scaleOffset: number;
+  searchText: string;
   workspaceId: string;
 }) => {
   const analytics = useAnalytics();
   const editorRef = useRef<DocxEditorRef>(null);
   const containerRef = useRef<HTMLDivElement>(null);
+  const searchHighlightFrameRef = useRef<number | null>(null);
   const { containerRef: fitZoomRef, fitZoom: targetZoom } = useDocxFitZoom({
     scaleOffset,
   });
@@ -411,6 +476,82 @@ const PeekDocxViewer = ({
     [fitZoomRef],
   );
   useDocxBlockScroll({ editorRef, fieldId });
+
+  const highlightSearchResult = useCallback(() => {
+    const editor = editorRef.current;
+    if (!editor) {
+      return false;
+    }
+
+    editor.ensureEditorView({ focus: false });
+    const pagedEditor = editor.getEditorRef();
+    const view = pagedEditor?.getView();
+    if (!view) {
+      return false;
+    }
+
+    const allMatches = findDocumentSearchMatches(
+      editor.getDocument(),
+      searchText,
+    );
+    const matches = allMatches.slice(0, MAX_SEARCH_PREVIEW_MATCHES);
+    onSearchMatchSummaryChange?.({
+      count: matches.length,
+      truncated: allMatches.length > matches.length,
+    });
+    const match = matches.at(activeSearchMatchIndex);
+    if (!match) {
+      pagedEditor.setPassageHighlight(null);
+      return true;
+    }
+
+    const range = resolveFindMatchRange(view.state.doc, match);
+    if (!range) {
+      pagedEditor.setPassageHighlight(null);
+      return true;
+    }
+
+    pagedEditor.setPassageHighlight(range);
+    pagedEditor.scrollToPosition(range.from);
+    return true;
+  }, [activeSearchMatchIndex, onSearchMatchSummaryChange, searchText]);
+
+  const scheduleSearchHighlight = useCallback(() => {
+    if (searchHighlightFrameRef.current !== null) {
+      cancelAnimationFrame(searchHighlightFrameRef.current);
+    }
+
+    scheduleSearchHighlightFrame({
+      attempt: highlightSearchResult,
+      onFrame: (frame) => {
+        searchHighlightFrameRef.current = frame;
+      },
+    });
+  }, [highlightSearchResult]);
+
+  useMountEffect(() => () => {
+    if (searchHighlightFrameRef.current !== null) {
+      cancelAnimationFrame(searchHighlightFrameRef.current);
+    }
+  });
+
+  useExternalSyncEffect(() => {
+    scheduleSearchHighlight();
+  }, [scheduleSearchHighlight]);
+
+  const handleDocumentReady = useCallback(() => {
+    scheduleSearchHighlight();
+  }, [scheduleSearchHighlight]);
+
+  const handleEditorViewReady = useCallback(
+    (view: unknown) => {
+      if (!view) {
+        return;
+      }
+      scheduleSearchHighlight();
+    },
+    [scheduleSearchHighlight],
+  );
 
   // Sync scaleOffset from inspector +/- buttons to Folio zoom
   useLayoutEffect(() => {
@@ -452,6 +593,8 @@ const PeekDocxViewer = ({
         documentBuffer={buffer}
         initialZoom={targetZoom}
         loadingIndicator={null}
+        onCompatibilityChange={handleDocumentReady}
+        onEditorViewReady={handleEditorViewReady}
         readOnly
         showToolbar={false}
         showZoomControl={false}

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/peek/peek-pdf-viewer.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/peek/peek-pdf-viewer.tsx
@@ -23,6 +23,7 @@ import { useTranslations } from "use-intl";
 import { resolveFindMatchRange } from "@stll/folio-core/prosemirror/findReplaceSelection";
 import type { DocxEditorRef } from "@stll/folio-react";
 import { Button } from "@stll/ui/components/button";
+import type { OverlayLayer } from "@stll/ui/lib/overlay-layer";
 import "@stll/folio-react/editor.css";
 
 import "./peek-docx.css";
@@ -273,12 +274,14 @@ export const PeekPdfControls = ({
   onZoomOut,
   onResetZoom,
   scaleOffset,
+  tooltipLayer,
 }: {
   canResetZoom: boolean;
   onZoomIn?: (() => void) | undefined;
   onZoomOut?: (() => void) | undefined;
   onResetZoom?: (() => void) | undefined;
   scaleOffset: number;
+  tooltipLayer?: OverlayLayer | undefined;
 }) => {
   const t = useTranslations();
 
@@ -286,6 +289,7 @@ export const PeekPdfControls = ({
     <>
       <Tooltip
         content={t("workspaces.pdf.zoomOut")}
+        layer={tooltipLayer}
         render={
           <Button
             disabled={!onZoomOut}
@@ -299,6 +303,7 @@ export const PeekPdfControls = ({
       />
       <Tooltip
         content={t("workspaces.pdf.zoomIn")}
+        layer={tooltipLayer}
         render={
           <Button
             disabled={!onZoomIn}
@@ -312,6 +317,7 @@ export const PeekPdfControls = ({
       />
       <Tooltip
         content={t("workspaces.pdf.resetZoom")}
+        layer={tooltipLayer}
         render={
           <Button
             disabled={!canResetZoom || !onResetZoom}

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/peek/peek-pdf-viewer.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/peek/peek-pdf-viewer.tsx
@@ -491,7 +491,10 @@ const PeekDocxViewer = ({
 
     editor.ensureEditorView({ focus: false });
     const pagedEditor = editor.getEditorRef();
-    const view = pagedEditor?.getView();
+    if (!pagedEditor) {
+      return false;
+    }
+    const view = pagedEditor.getView();
     if (!view) {
       return false;
     }
@@ -549,15 +552,9 @@ const PeekDocxViewer = ({
     scheduleSearchHighlight();
   }, [scheduleSearchHighlight]);
 
-  const handleEditorViewReady = useCallback(
-    (view: unknown) => {
-      if (!view) {
-        return;
-      }
-      scheduleSearchHighlight();
-    },
-    [scheduleSearchHighlight],
-  );
+  const handleEditorViewReady = useCallback(() => {
+    scheduleSearchHighlight();
+  }, [scheduleSearchHighlight]);
 
   // Sync scaleOffset from inspector +/- buttons to Folio zoom
   useLayoutEffect(() => {

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/peek/peek-pdf-viewer.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/peek/peek-pdf-viewer.tsx
@@ -45,6 +45,8 @@ import { PDFPage } from "@/lib/pdf/pdf-page";
 import { PDFViewport } from "@/lib/pdf/pdf-viewport";
 import type { SearchMatchSummary } from "@/lib/search-match-navigation";
 import { MAX_SEARCH_PREVIEW_MATCHES } from "@/lib/search-match-navigation";
+import { searchTextQueryKey } from "@/lib/search-text";
+import type { SearchTextQuery } from "@/lib/search-text";
 import { composeRefs } from "@/lib/utils";
 import { useDocxBlockScroll } from "@/routes/_protected.workspaces/$workspaceId/-components/docx/use-docx-block-scroll";
 import { fileOptions } from "@/routes/_protected.workspaces/$workspaceId/-components/files/queries";
@@ -71,7 +73,7 @@ type ScheduleSearchHighlightFrameOptions = {
 type DocxSearchResultCache = {
   document: ReturnType<DocxEditorRef["getDocument"]>;
   result: DocumentSearchResult;
-  searchText: string;
+  searchTextKey: string;
 };
 
 const scheduleSearchHighlightFrame = ({
@@ -104,7 +106,7 @@ type PeekPdfViewerProps = {
   scaleOffset: number;
   mimeType?: string | undefined;
   interactionMode?: "preview-only" | "with-ai" | undefined;
-  searchText?: string | undefined;
+  searchText?: SearchTextQuery | undefined;
   activeSearchMatchIndex?: number | undefined;
   onSearchMatchSummaryChange?:
     | ((summary: SearchMatchSummary) => void)
@@ -126,6 +128,8 @@ export const PeekPdfViewer = (props: PeekPdfViewerProps) => {
     searchText,
     workspaceId,
   } = props;
+  const searchTextKey =
+    searchText === undefined ? undefined : searchTextQueryKey(searchText);
 
   return (
     <QuerySuspenseBoundary
@@ -133,7 +137,7 @@ export const PeekPdfViewer = (props: PeekPdfViewerProps) => {
       errorFallback={errorFallback ?? defaultPeekViewerErrorFallback}
       suspenseFallback={<PeekSuspenseFallback />}
       onError={onError}
-      resetKeys={[workspaceId, fieldId, filePurpose, searchText]}
+      resetKeys={[workspaceId, fieldId, filePurpose, searchTextKey]}
     >
       <PeekPdfViewerContent {...props} filePurpose={filePurpose} />
     </QuerySuspenseBoundary>
@@ -469,7 +473,7 @@ const PeekDocxViewer = ({
     | undefined;
   printActionsRef?: RefObject<Map<string, () => void>> | undefined;
   scaleOffset: number;
-  searchText: string | undefined;
+  searchText: SearchTextQuery | undefined;
   workspaceId: string;
 }) => {
   const analytics = useAnalytics();
@@ -487,6 +491,8 @@ const PeekDocxViewer = ({
     [fitZoomRef],
   );
   useDocxBlockScroll({ editorRef, fieldId });
+  const searchTextKey =
+    searchText === undefined ? undefined : searchTextQueryKey(searchText);
 
   const highlightSearchResult = useCallback(() => {
     if (searchText === undefined) {
@@ -512,7 +518,7 @@ const PeekDocxViewer = ({
     const cachedSearchResult = searchResultCacheRef.current;
     const searchResult =
       cachedSearchResult?.document === document &&
-      cachedSearchResult.searchText === searchText
+      cachedSearchResult.searchTextKey === searchTextKey
         ? cachedSearchResult.result
         : findDocumentSearchResult({
             document,
@@ -522,7 +528,7 @@ const PeekDocxViewer = ({
     searchResultCacheRef.current = {
       document,
       result: searchResult,
-      searchText,
+      searchTextKey: searchTextKey ?? "",
     };
     onSearchMatchSummaryChange?.({
       count: searchResult.matches.length,
@@ -543,7 +549,12 @@ const PeekDocxViewer = ({
     pagedEditor.setPassageHighlight(range);
     pagedEditor.scrollToPosition(range.from);
     return true;
-  }, [activeSearchMatchIndex, onSearchMatchSummaryChange, searchText]);
+  }, [
+    activeSearchMatchIndex,
+    onSearchMatchSummaryChange,
+    searchText,
+    searchTextKey,
+  ]);
 
   const scheduleSearchHighlight = useCallback(() => {
     if (searchHighlightFrameRef.current !== null) {

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/peek/peek-pdf-viewer.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/peek/peek-pdf-viewer.tsx
@@ -183,7 +183,10 @@ const PeekPdfViewerContent = ({
     [activePropertyId, entityId, fieldId, onPeekNavigate, viewId, workspaceId],
   );
 
-  if (fileQuery.isError || !file) {
+  if (fileQuery.isError) {
+    throw fileQuery.error;
+  }
+  if (!file) {
     return null;
   }
 

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/peek/peek-pdf-viewer.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/peek/peek-pdf-viewer.tsx
@@ -38,7 +38,8 @@ import { useExternalSyncEffect, useMountEffect } from "@/hooks/use-effect";
 import { useAnalytics } from "@/lib/analytics/provider";
 import { DOCX_MIME } from "@/lib/consts";
 import { detached } from "@/lib/detached";
-import { findDocumentSearchMatches } from "@/lib/document-search";
+import { findDocumentSearchResult } from "@/lib/document-search";
+import type { DocumentSearchResult } from "@/lib/document-search";
 import { usePDFStore } from "@/lib/pdf/pdf-context";
 import { PDFPage } from "@/lib/pdf/pdf-page";
 import { PDFViewport } from "@/lib/pdf/pdf-viewport";
@@ -65,6 +66,12 @@ type ScheduleSearchHighlightFrameOptions = {
   attempt: () => boolean;
   onFrame: (frame: number | null) => void;
   remainingFrames?: number | undefined;
+};
+
+type DocxSearchResultCache = {
+  document: ReturnType<DocxEditorRef["getDocument"]>;
+  result: DocumentSearchResult;
+  searchText: string;
 };
 
 const scheduleSearchHighlightFrame = ({
@@ -116,6 +123,7 @@ export const PeekPdfViewer = (props: PeekPdfViewerProps) => {
     fieldId,
     filePurpose = "display",
     onError,
+    searchText,
     workspaceId,
   } = props;
 
@@ -125,7 +133,7 @@ export const PeekPdfViewer = (props: PeekPdfViewerProps) => {
       errorFallback={errorFallback ?? defaultPeekViewerErrorFallback}
       suspenseFallback={<PeekSuspenseFallback />}
       onError={onError}
-      resetKeys={[workspaceId, fieldId, filePurpose]}
+      resetKeys={[workspaceId, fieldId, filePurpose, searchText]}
     >
       <PeekPdfViewerContent {...props} filePurpose={filePurpose} />
     </QuerySuspenseBoundary>
@@ -468,6 +476,7 @@ const PeekDocxViewer = ({
   const editorRef = useRef<DocxEditorRef>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const searchHighlightFrameRef = useRef<number | null>(null);
+  const searchResultCacheRef = useRef<DocxSearchResultCache | null>(null);
   const { containerRef: fitZoomRef, fitZoom: targetZoom } = useDocxFitZoom({
     scaleOffset,
   });
@@ -499,16 +508,27 @@ const PeekDocxViewer = ({
       return false;
     }
 
-    const allMatches = findDocumentSearchMatches(
-      editor.getDocument(),
+    const document = editor.getDocument();
+    const cachedSearchResult = searchResultCacheRef.current;
+    const searchResult =
+      cachedSearchResult?.document === document &&
+      cachedSearchResult.searchText === searchText
+        ? cachedSearchResult.result
+        : findDocumentSearchResult({
+            document,
+            maxMatches: MAX_SEARCH_PREVIEW_MATCHES,
+            searchText,
+          });
+    searchResultCacheRef.current = {
+      document,
+      result: searchResult,
       searchText,
-    );
-    const matches = allMatches.slice(0, MAX_SEARCH_PREVIEW_MATCHES);
+    };
     onSearchMatchSummaryChange?.({
-      count: matches.length,
-      truncated: allMatches.length > matches.length,
+      count: searchResult.matches.length,
+      truncated: searchResult.truncated,
     });
-    const match = matches.at(activeSearchMatchIndex);
+    const match = searchResult.matches.at(activeSearchMatchIndex);
     if (!match) {
       pagedEditor.setPassageHighlight(null);
       return true;
@@ -549,10 +569,12 @@ const PeekDocxViewer = ({
   }, [scheduleSearchHighlight]);
 
   const handleDocumentReady = useCallback(() => {
+    searchResultCacheRef.current = null;
     scheduleSearchHighlight();
   }, [scheduleSearchHighlight]);
 
   const handleEditorViewReady = useCallback(() => {
+    searchResultCacheRef.current = null;
     scheduleSearchHighlight();
   }, [scheduleSearchHighlight]);
 

--- a/apps/web/src/workers/pdf-search-worker.ts
+++ b/apps/web/src/workers/pdf-search-worker.ts
@@ -25,6 +25,7 @@ if (!isDedicatedWorkerScope(globalThis)) {
 }
 
 const scope = globalThis;
+const sendResponse = scope.postMessage.bind(scope);
 
 const handle = async (
   request: PDFSearchWorkerRequest,
@@ -50,8 +51,7 @@ scope.addEventListener(
   (event: MessageEvent<PDFSearchWorkerRequest>) => {
     handle(event.data)
       .then((response) => {
-        // eslint-disable-next-line unicorn/require-post-message-target-origin -- Worker.postMessage has no targetOrigin parameter
-        scope.postMessage(response);
+        sendResponse(response);
         return undefined;
       })
       .catch(() => undefined);

--- a/apps/web/src/workers/pdf-search-worker.ts
+++ b/apps/web/src/workers/pdf-search-worker.ts
@@ -1,19 +1,10 @@
 /// <reference lib="webworker" />
 
 import { findPDFSearchResults } from "@/lib/pdf/pdf-search";
-
-type PDFSearchWorkerRequest = {
-  bytes: ArrayBuffer;
-  password?: string | undefined;
-  searchText: string;
-};
-
-type PDFSearchWorkerResponse =
-  | { status: "error"; message: string }
-  | {
-      status: "success";
-      result: Awaited<ReturnType<typeof findPDFSearchResults>>;
-    };
+import type {
+  PDFSearchWorkerRequest,
+  PDFSearchWorkerResponse,
+} from "@/lib/pdf/pdf-search-worker-protocol";
 
 const isDedicatedWorkerScope = (
   value: typeof globalThis,
@@ -26,21 +17,24 @@ if (!isDedicatedWorkerScope(globalThis)) {
 
 const scope = globalThis;
 const sendResponse = scope.postMessage.bind(scope);
+let activeController: AbortController | null = null;
 
 const handle = async (
   request: PDFSearchWorkerRequest,
+  signal: AbortSignal,
 ): Promise<PDFSearchWorkerResponse> => {
   try {
     const result = await findPDFSearchResults({
       bytes: new Uint8Array(request.bytes),
       password: request.password,
       searchText: request.searchText,
-      signal: new AbortController().signal,
+      signal,
     });
-    return { status: "success", result };
+    return { status: "success", requestId: request.requestId, result };
   } catch (error) {
     return {
       status: "error",
+      requestId: request.requestId,
       message: error instanceof Error ? error.message : String(error),
     };
   }
@@ -49,14 +43,25 @@ const handle = async (
 scope.addEventListener(
   "message",
   (event: MessageEvent<PDFSearchWorkerRequest>) => {
-    handle(event.data)
+    activeController?.abort();
+    const controller = new AbortController();
+    activeController = controller;
+
+    handle(event.data, controller.signal)
       .then((response) => {
+        if (controller.signal.aborted) {
+          return undefined;
+        }
         sendResponse(response);
         return undefined;
       })
       .catch((error: unknown) => {
+        if (controller.signal.aborted) {
+          return;
+        }
         sendResponse({
           status: "error",
+          requestId: event.data.requestId,
           message: error instanceof Error ? error.message : String(error),
         });
       });

--- a/apps/web/src/workers/pdf-search-worker.ts
+++ b/apps/web/src/workers/pdf-search-worker.ts
@@ -1,0 +1,59 @@
+/// <reference lib="webworker" />
+
+import { findPDFSearchResults } from "@/lib/pdf/pdf-search";
+
+type PDFSearchWorkerRequest = {
+  bytes: ArrayBuffer;
+  password?: string | undefined;
+  searchText: string;
+};
+
+type PDFSearchWorkerResponse =
+  | { status: "error"; message: string }
+  | {
+      status: "success";
+      result: Awaited<ReturnType<typeof findPDFSearchResults>>;
+    };
+
+const isDedicatedWorkerScope = (
+  value: typeof globalThis,
+): value is typeof globalThis & DedicatedWorkerGlobalScope =>
+  "importScripts" in value && "WorkerGlobalScope" in globalThis;
+
+if (!isDedicatedWorkerScope(globalThis)) {
+  throw new TypeError("PDF search must run in a dedicated worker");
+}
+
+const scope = globalThis;
+
+const handle = async (
+  request: PDFSearchWorkerRequest,
+): Promise<PDFSearchWorkerResponse> => {
+  try {
+    const result = await findPDFSearchResults({
+      bytes: new Uint8Array(request.bytes),
+      password: request.password,
+      searchText: request.searchText,
+      signal: new AbortController().signal,
+    });
+    return { status: "success", result };
+  } catch (error) {
+    return {
+      status: "error",
+      message: error instanceof Error ? error.message : String(error),
+    };
+  }
+};
+
+scope.addEventListener(
+  "message",
+  (event: MessageEvent<PDFSearchWorkerRequest>) => {
+    handle(event.data)
+      .then((response) => {
+        // eslint-disable-next-line unicorn/require-post-message-target-origin -- Worker.postMessage has no targetOrigin parameter
+        scope.postMessage(response);
+        return undefined;
+      })
+      .catch(() => undefined);
+  },
+);

--- a/apps/web/src/workers/pdf-search-worker.ts
+++ b/apps/web/src/workers/pdf-search-worker.ts
@@ -54,6 +54,11 @@ scope.addEventListener(
         sendResponse(response);
         return undefined;
       })
-      .catch(() => undefined);
+      .catch((error: unknown) => {
+        sendResponse({
+          status: "error",
+          message: error instanceof Error ? error.message : String(error),
+        });
+      });
   },
 );

--- a/packages/ui/src/components/alert-dialog.tsx
+++ b/packages/ui/src/components/alert-dialog.tsx
@@ -5,6 +5,10 @@ import type * as React from "react";
 import { AlertDialog as AlertDialogPrimitive } from "@base-ui/react/alert-dialog";
 
 import { renderTooltipTrigger } from "@stll/ui/components/tooltip-trigger-helper";
+import {
+  OVERLAY_LAYER_CLASS_NAMES,
+  type OverlayLayer,
+} from "@stll/ui/lib/overlay-layer";
 import { cn } from "@stll/ui/lib/utils";
 
 const AlertDialogCreateHandle = AlertDialogPrimitive.createHandle;
@@ -31,12 +35,14 @@ function AlertDialogTrigger({
 
 function AlertDialogBackdrop({
   className,
+  layer = "default",
   ...props
-}: AlertDialogPrimitive.Backdrop.Props) {
+}: AlertDialogPrimitive.Backdrop.Props & { layer?: OverlayLayer }) {
   return (
     <AlertDialogPrimitive.Backdrop
       className={cn(
-        "fixed inset-0 z-50 bg-black/32 backdrop-blur-sm transition-opacity duration-200 ease-out data-ending-style:opacity-0 data-starting-style:opacity-0",
+        "fixed inset-0 bg-black/32 backdrop-blur-sm transition-opacity duration-200 ease-out data-ending-style:opacity-0 data-starting-style:opacity-0",
+        OVERLAY_LAYER_CLASS_NAMES[layer],
         className,
       )}
       data-slot="alert-dialog-backdrop"
@@ -47,12 +53,14 @@ function AlertDialogBackdrop({
 
 function AlertDialogViewport({
   className,
+  layer = "default",
   ...props
-}: AlertDialogPrimitive.Viewport.Props) {
+}: AlertDialogPrimitive.Viewport.Props & { layer?: OverlayLayer }) {
   return (
     <AlertDialogPrimitive.Viewport
       className={cn(
-        "fixed inset-0 z-50 grid grid-rows-[1fr_auto_3fr] justify-items-center p-4",
+        "fixed inset-0 grid grid-rows-[1fr_auto_3fr] justify-items-center p-4",
+        OVERLAY_LAYER_CLASS_NAMES[layer],
         className,
       )}
       data-slot="alert-dialog-viewport"
@@ -64,18 +72,21 @@ function AlertDialogViewport({
 function AlertDialogPopup({
   className,
   bottomStickOnMobile = true,
+  layer = "default",
   ...props
 }: AlertDialogPrimitive.Popup.Props & {
   bottomStickOnMobile?: boolean;
+  layer?: OverlayLayer;
 }) {
   return (
     <AlertDialogPortal>
-      <AlertDialogBackdrop />
+      <AlertDialogBackdrop layer={layer} />
       <AlertDialogViewport
         className={cn(
           bottomStickOnMobile &&
             "max-sm:grid-rows-[1fr_auto] max-sm:p-0 max-sm:pt-12",
         )}
+        layer={layer}
       >
         <AlertDialogPrimitive.Popup
           className={cn(

--- a/packages/ui/src/components/date-picker-popover.tsx
+++ b/packages/ui/src/components/date-picker-popover.tsx
@@ -11,6 +11,7 @@ import {
   PopoverPopup,
   PopoverTrigger,
 } from "@stll/ui/components/popover";
+import type { OverlayLayer } from "@stll/ui/lib/overlay-layer";
 import { cn } from "@stll/ui/lib/utils";
 import { getLocaleWeekInfo, getWeekendDays } from "@stll/ui/lib/week";
 
@@ -212,6 +213,7 @@ type DatePickerPopoverProps = {
   minDate?: string;
   maxDate?: string;
   isDateDisabled?: (date: string) => boolean;
+  layer?: OverlayLayer;
 };
 
 function DatePickerPopover({
@@ -229,6 +231,7 @@ function DatePickerPopover({
   minDate,
   maxDate,
   isDateDisabled,
+  layer = "default",
 }: DatePickerPopoverProps) {
   const locale = localeProp ?? navigator.language;
   const value = normalizeDate(rawValue);
@@ -506,6 +509,7 @@ function DatePickerPopover({
       </PopoverTrigger>
       <PopoverPopup
         className="*:data-[slot=popover-viewport]:p-2!"
+        layer={layer}
         side="bottom"
         sideOffset={4}
       >

--- a/packages/ui/src/components/dialog.tsx
+++ b/packages/ui/src/components/dialog.tsx
@@ -8,6 +8,10 @@ import { XIcon } from "lucide-react";
 import { Button } from "@stll/ui/components/button";
 import { ScrollArea } from "@stll/ui/components/scroll-area";
 import { renderTooltipTrigger } from "@stll/ui/components/tooltip-trigger-helper";
+import {
+  OVERLAY_LAYER_CLASS_NAMES,
+  type OverlayLayer,
+} from "@stll/ui/lib/overlay-layer";
 import { cn } from "@stll/ui/lib/utils";
 
 const DialogCreateHandle = DialogPrimitive.createHandle;
@@ -38,12 +42,14 @@ function DialogClose({
 
 function DialogBackdrop({
   className,
+  layer = "default",
   ...props
-}: DialogPrimitive.Backdrop.Props) {
+}: DialogPrimitive.Backdrop.Props & { layer?: OverlayLayer }) {
   return (
     <DialogPrimitive.Backdrop
       className={cn(
-        "fixed inset-0 z-50 bg-black/32 backdrop-blur-sm transition-opacity duration-200 data-ending-style:opacity-0 data-starting-style:opacity-0",
+        "fixed inset-0 bg-black/32 backdrop-blur-sm transition-opacity duration-200 data-ending-style:opacity-0 data-starting-style:opacity-0",
+        OVERLAY_LAYER_CLASS_NAMES[layer],
         className,
       )}
       data-slot="dialog-backdrop"
@@ -54,12 +60,14 @@ function DialogBackdrop({
 
 function DialogViewport({
   className,
+  layer = "default",
   ...props
-}: DialogPrimitive.Viewport.Props) {
+}: DialogPrimitive.Viewport.Props & { layer?: OverlayLayer }) {
   return (
     <DialogPrimitive.Viewport
       className={cn(
-        "fixed inset-0 z-50 grid grid-rows-[1fr_auto_3fr] justify-items-center p-4",
+        "fixed inset-0 grid grid-rows-[1fr_auto_3fr] justify-items-center p-4",
+        OVERLAY_LAYER_CLASS_NAMES[layer],
         className,
       )}
       data-slot="dialog-viewport"
@@ -74,23 +82,26 @@ function DialogPopup({
   children,
   showCloseButton = true,
   bottomStickOnMobile = true,
+  layer = "default",
   viewportClassName,
   ...props
 }: DialogPrimitive.Popup.Props & {
   backdropClassName?: string;
   showCloseButton?: boolean;
   bottomStickOnMobile?: boolean;
+  layer?: OverlayLayer;
   viewportClassName?: string;
 }) {
   return (
     <DialogPortal>
-      <DialogBackdrop className={backdropClassName} />
+      <DialogBackdrop className={backdropClassName} layer={layer} />
       <DialogViewport
         className={cn(
           bottomStickOnMobile &&
             "max-sm:grid-rows-[1fr_auto] max-sm:p-0 max-sm:pt-12",
           viewportClassName,
         )}
+        layer={layer}
       >
         <DialogPrimitive.Popup
           className={cn(

--- a/packages/ui/src/components/dialog.tsx
+++ b/packages/ui/src/components/dialog.tsx
@@ -69,22 +69,27 @@ function DialogViewport({
 }
 
 function DialogPopup({
+  backdropClassName,
   className,
   children,
   showCloseButton = true,
   bottomStickOnMobile = true,
+  viewportClassName,
   ...props
 }: DialogPrimitive.Popup.Props & {
+  backdropClassName?: string;
   showCloseButton?: boolean;
   bottomStickOnMobile?: boolean;
+  viewportClassName?: string;
 }) {
   return (
     <DialogPortal>
-      <DialogBackdrop />
+      <DialogBackdrop className={backdropClassName} />
       <DialogViewport
         className={cn(
           bottomStickOnMobile &&
             "max-sm:grid-rows-[1fr_auto] max-sm:p-0 max-sm:pt-12",
+          viewportClassName,
         )}
       >
         <DialogPrimitive.Popup

--- a/packages/ui/src/components/popover.tsx
+++ b/packages/ui/src/components/popover.tsx
@@ -6,6 +6,10 @@ import type { ComponentProps } from "react";
 import { Popover as PopoverPrimitive } from "@base-ui/react/popover";
 
 import { renderTooltipTrigger } from "@stll/ui/components/tooltip-trigger-helper";
+import {
+  OVERLAY_LAYER_CLASS_NAMES,
+  type OverlayLayer,
+} from "@stll/ui/lib/overlay-layer";
 import { cn } from "@stll/ui/lib/utils";
 
 const PopoverCreateHandle = PopoverPrimitive.createHandle;
@@ -33,6 +37,7 @@ function PopoverPopup({
   alignOffset = 0,
   tooltipStyle = false,
   anchor,
+  layer = "default",
   ...props
 }: PopoverPrimitive.Popup.Props & {
   side?: PopoverPrimitive.Positioner.Props["side"];
@@ -40,6 +45,7 @@ function PopoverPopup({
   sideOffset?: PopoverPrimitive.Positioner.Props["sideOffset"];
   alignOffset?: PopoverPrimitive.Positioner.Props["alignOffset"];
   anchor?: PopoverPrimitive.Positioner.Props["anchor"];
+  layer?: OverlayLayer;
   tooltipStyle?: boolean;
 }) {
   return (
@@ -49,7 +55,8 @@ function PopoverPopup({
         alignOffset={alignOffset}
         anchor={anchor}
         className={cn(
-          "z-50 h-(--positioner-height) w-(--positioner-width) max-w-(--available-width) transition-[top,left,right,bottom,transform] data-instant:transition-none",
+          "h-(--positioner-height) w-(--positioner-width) max-w-(--available-width) transition-[top,left,right,bottom,transform] data-instant:transition-none",
+          OVERLAY_LAYER_CLASS_NAMES[layer],
           anchor && "transition-none",
         )}
         data-slot="popover-positioner"

--- a/packages/ui/src/components/tooltip.tsx
+++ b/packages/ui/src/components/tooltip.tsx
@@ -2,6 +2,10 @@
 
 import { Tooltip as TooltipPrimitive } from "@base-ui/react/tooltip";
 
+import {
+  OVERLAY_LAYER_CLASS_NAMES,
+  type OverlayLayer,
+} from "@stll/ui/lib/overlay-layer";
 import { cn } from "@stll/ui/lib/utils";
 
 const TooltipCreateHandle = TooltipPrimitive.createHandle;
@@ -19,18 +23,23 @@ function TooltipPopup({
   align = "center",
   sideOffset = 4,
   side = "top",
+  layer = "default",
   children,
   ...props
 }: TooltipPrimitive.Popup.Props & {
   align?: TooltipPrimitive.Positioner.Props["align"];
   side?: TooltipPrimitive.Positioner.Props["side"];
   sideOffset?: TooltipPrimitive.Positioner.Props["sideOffset"];
+  layer?: OverlayLayer;
 }) {
   return (
     <TooltipPrimitive.Portal>
       <TooltipPrimitive.Positioner
         align={align}
-        className="z-50 h-(--positioner-height) w-(--positioner-width) max-w-(--available-width) transition-[top,left,right,bottom,transform] data-instant:transition-none"
+        className={cn(
+          "h-(--positioner-height) w-(--positioner-width) max-w-(--available-width) transition-[top,left,right,bottom,transform] data-instant:transition-none",
+          OVERLAY_LAYER_CLASS_NAMES[layer],
+        )}
         data-slot="tooltip-positioner"
         side={side}
         sideOffset={sideOffset}

--- a/packages/ui/src/lib/overlay-layer.ts
+++ b/packages/ui/src/lib/overlay-layer.ts
@@ -1,0 +1,10 @@
+// Keep application chrome at or below 80, Search below the toast viewport at
+// 90, and Search-owned portals above both. Named layers keep portal stacking
+// coherent even though nested dialogs and popovers mount under document.body.
+export const OVERLAY_LAYER_CLASS_NAMES = {
+  default: "z-50",
+  search: "z-[85]",
+  "search-child": "z-[100]",
+} as const;
+
+export type OverlayLayer = keyof typeof OVERLAY_LAYER_CLASS_NAMES;

--- a/scripts/bundle-baseline.json
+++ b/scripts/bundle-baseline.json
@@ -1,12 +1,12 @@
 {
-  "entry": 1224,
+  "entry": 1226,
   "largest-route": 568513,
-  "routes": 5624229,
-  "total": 6467092,
+  "routes": 5910630,
+  "total": 6754913,
   "vendor-anonymize-data": 0,
   "vendor-editor": 122631,
   "vendor-graphs": 189783,
   "vendor-react": 56604,
-  "vendor-tanstack": 472621,
+  "vendor-tanstack": 474039,
   "wasm-vendor": 0
 }


### PR DESCRIPTION
## Summary

- render PDF and DOCX search results in the native inspector viewer with zoom and preview-local scrolling
- reuse chat message bubbles and add normalized, bounded match navigation across PDF, DOCX, and chat previews
- preserve Search layout and selection across empty, hover, keyboard, sidebar, and reopen states
- move canonical LibPDF search into a cancellable worker and bound chat preview responses
- keep the chat recap clear of the measured composer and suggested follow-ups

## Performance

The canonical `@libpdf/core` search worker adds about 243 KiB gzipped to aggregate lazy-route code. It is isolated from the entry and viewer chunks, starts only for PDF preview search, and is terminated when the preview changes. The bundle baseline records this intentional worker cost.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added rich search previews for documents, PDFs, DOCX files and chat messages.
  - Added search-term highlighting with next/previous match navigation and active-match scrolling.
  - Added recent-file preview support, including document metadata and field selection.
  - Improved chat previews with surrounding messages and extracted source details.

- **Bug Fixes**
  - Improved MIME-type filtering and document content selection.
  - Refined saved-search empty-state behaviour and dialog navigation.
  - Increased reliability for Unicode, diacritics and alternate query terms.
  - Improved handling of malformed chat content and preview length limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->