### PR TITLE
feat(case-law): separate precedent citations from procedural history

### DIFF
--- a/apps/api/drizzle/20260731090000_citation_kind/migration.sql
+++ b/apps/api/drizzle/20260731090000_citation_kind/migration.sql
@@ -33,6 +33,9 @@ SET lock_timeout = 0;
 --> statement-breakpoint
 
 -- Takes SHARE UPDATE EXCLUSIVE: concurrent reads and writes continue.
+-- Outside the transaction on purpose (see above), and safe to re-run:
+-- validating an already-valid constraint is a no-op.
+-- squawk-ignore prefer-robust-stmts
 ALTER TABLE "case_law_citations" VALIDATE CONSTRAINT "citations_kind_values";--> statement-breakpoint
 
 -- stella-migration-safety: reviewed destructive-change - drops only this

--- a/apps/api/drizzle/20260731090000_citation_kind/migration.sql
+++ b/apps/api/drizzle/20260731090000_citation_kind/migration.sql
@@ -1,0 +1,45 @@
+SET lock_timeout = '1s';--> statement-breakpoint
+SET statement_timeout = '5s';--> statement-breakpoint
+
+-- A decision cites two different things: authority it invokes, and the
+-- judgment it is reviewing (plus the first-instance file number) named in
+-- its recitals. Only the first belongs in the citation graph — counting
+-- the second would inflate the authority of whatever happened to be
+-- appealed.
+--
+-- Defaults to 'precedent' so existing rows keep their present meaning
+-- until the backfill classifies them; the ingest path sets it explicitly.
+ALTER TABLE "case_law_citations"
+  ADD COLUMN IF NOT EXISTS "kind" varchar(16) DEFAULT 'precedent' NOT NULL;--> statement-breakpoint
+
+-- squawk-ignore prefer-robust-stmts
+ALTER TABLE "case_law_citations"
+  ADD CONSTRAINT "citations_kind_values"
+  CHECK ("kind" IN ('precedent','procedural')) NOT VALID;--> statement-breakpoint
+
+-- Validated separately: NOT VALID avoids the full-table scan taking an
+-- ACCESS EXCLUSIVE lock, and VALIDATE takes only a SHARE UPDATE EXCLUSIVE.
+ALTER TABLE "case_law_citations" VALIDATE CONSTRAINT "citations_kind_values";--> statement-breakpoint
+
+-- squawk-ignore transaction-nesting
+COMMIT;
+--> statement-breakpoint
+SET statement_timeout = 0;
+--> statement-breakpoint
+SET lock_timeout = 0;
+--> statement-breakpoint
+
+-- stella-migration-safety: reviewed destructive-change - drops only this
+-- migration's own index by name before recreating it.
+DROP INDEX CONCURRENTLY IF EXISTS "case_law_citations_precedent_cited_idx";--> statement-breakpoint
+-- squawk-ignore prefer-robust-stmts
+CREATE INDEX CONCURRENTLY "case_law_citations_precedent_cited_idx"
+  ON "case_law_citations" ("cited_decision_id")
+  WHERE "kind" = 'precedent' AND "cited_decision_id" IS NOT NULL;--> statement-breakpoint
+
+SET statement_timeout = '5s';
+--> statement-breakpoint
+SET lock_timeout = '1s';
+--> statement-breakpoint
+-- squawk-ignore transaction-nesting, ban-uncommitted-transaction
+BEGIN;

--- a/apps/api/drizzle/20260731090000_citation_kind/migration.sql
+++ b/apps/api/drizzle/20260731090000_citation_kind/migration.sql
@@ -12,15 +12,18 @@ SET statement_timeout = '5s';--> statement-breakpoint
 ALTER TABLE "case_law_citations"
   ADD COLUMN IF NOT EXISTS "kind" varchar(16) DEFAULT 'precedent' NOT NULL;--> statement-breakpoint
 
+-- Added NOT VALID so it takes only a brief lock and does not scan the
+-- table here; the scan happens after the commit below.
 -- squawk-ignore prefer-robust-stmts
 ALTER TABLE "case_law_citations"
   ADD CONSTRAINT "citations_kind_values"
   CHECK ("kind" IN ('precedent','procedural')) NOT VALID;--> statement-breakpoint
 
--- Validated separately: NOT VALID avoids the full-table scan taking an
--- ACCESS EXCLUSIVE lock, and VALIDATE takes only a SHARE UPDATE EXCLUSIVE.
-ALTER TABLE "case_law_citations" VALIDATE CONSTRAINT "citations_kind_values";--> statement-breakpoint
-
+-- Drizzle wraps pending migrations in one transaction. Both statements
+-- below must run outside it: VALIDATE CONSTRAINT inside the same
+-- transaction as the ADD would hold the lock through the scan, which is
+-- exactly what NOT VALID exists to avoid, and CREATE INDEX CONCURRENTLY
+-- cannot run in a transaction at all.
 -- squawk-ignore transaction-nesting
 COMMIT;
 --> statement-breakpoint
@@ -29,8 +32,13 @@ SET statement_timeout = 0;
 SET lock_timeout = 0;
 --> statement-breakpoint
 
+-- Takes SHARE UPDATE EXCLUSIVE: concurrent reads and writes continue.
+ALTER TABLE "case_law_citations" VALIDATE CONSTRAINT "citations_kind_values";--> statement-breakpoint
+
 -- stella-migration-safety: reviewed destructive-change - drops only this
--- migration's own index by name before recreating it.
+-- migration's own index by name before recreating it. A cancelled
+-- concurrent build leaves an INVALID index behind, and IF NOT EXISTS
+-- would then skip recreating it.
 DROP INDEX CONCURRENTLY IF EXISTS "case_law_citations_precedent_cited_idx";--> statement-breakpoint
 -- squawk-ignore prefer-robust-stmts
 CREATE INDEX CONCURRENTLY "case_law_citations_precedent_cited_idx"

--- a/apps/api/src/db/schema/case-law.ts
+++ b/apps/api/src/db/schema/case-law.ts
@@ -285,6 +285,16 @@ export const caseLawCitations = p.pgTable(
     citationText: p.varchar("citation_text", { length: 512 }).notNull(),
     /** `citationText` under `bareCitationKey`; joins to a decision's own key. */
     citationKey: p.varchar("citation_key", { length: 128 }),
+    /**
+     * Whether this citation invokes authority or names the case's own
+     * procedural history. Only `precedent` belongs in the citation graph:
+     * the judgment under review is not an endorsement of it.
+     */
+    kind: p
+      .varchar({ length: 16 })
+      .$type<"precedent" | "procedural">()
+      .default("precedent")
+      .notNull(),
     sectionIndex: p.integer("section_index"),
     polarity: p.varchar("polarity", { length: 16 }),
     polarityRuleId: safeUuid<"caseLawPolarityRule">(
@@ -314,6 +324,15 @@ export const caseLawCitations = p.pgTable(
       "citations_polarity_values",
       sql`${t.polarity} IN ('positive','supportive','neutral','negative','unknown')`,
     ),
+    p.check(
+      "citations_kind_values",
+      sql`${t.kind} IN ('precedent','procedural')`,
+    ),
+    // Authority reads precedent only, so the index covers that arm.
+    p
+      .index("case_law_citations_precedent_cited_idx")
+      .on(t.citedDecisionId)
+      .where(sql`${t.kind} = 'precedent' AND ${t.citedDecisionId} IS NOT NULL`),
     ...globalCaseLawPolicies(),
   ],
 );

--- a/apps/api/src/db/schema/case-law.ts
+++ b/apps/api/src/db/schema/case-law.ts
@@ -291,8 +291,7 @@ export const caseLawCitations = p.pgTable(
      * the judgment under review is not an endorsement of it.
      */
     kind: p
-      .varchar({ length: 16 })
-      .$type<"precedent" | "procedural">()
+      .varchar({ length: 16, enum: ["precedent", "procedural"] })
       .default("precedent")
       .notNull(),
     sectionIndex: p.integer("section_index"),

--- a/apps/api/src/db/schema/case-law.ts
+++ b/apps/api/src/db/schema/case-law.ts
@@ -289,11 +289,14 @@ export const caseLawCitations = p.pgTable(
      * Whether this citation invokes authority or names the case's own
      * procedural history. Only `precedent` belongs in the citation graph:
      * the judgment under review is not an endorsement of it.
+     *
+     * Deliberately a plain string rather than a column-level union: the
+     * union re-instantiates this table's type everywhere it is referenced,
+     * including through the API surface into the web type graph, which
+     * costs more than it buys. `citations_kind_values` keeps the database
+     * honest and `CitationKind` types the write path.
      */
-    kind: p
-      .varchar({ length: 16, enum: ["precedent", "procedural"] })
-      .default("precedent")
-      .notNull(),
+    kind: p.varchar({ length: 16 }).default("precedent").notNull(),
     sectionIndex: p.integer("section_index"),
     polarity: p.varchar("polarity", { length: 16 }),
     polarityRuleId: safeUuid<"caseLawPolarityRule">(

--- a/apps/api/src/handlers/case-law/citation-authority.ts
+++ b/apps/api/src/handlers/case-law/citation-authority.ts
@@ -73,7 +73,7 @@ export const hasResolvedCitations = async (
   tx: CitationAuthorityTx,
 ): Promise<boolean> => {
   const result = await tx.execute(
-    sql`SELECT 1 AS one FROM case_law_citations WHERE cited_decision_id IS NOT NULL LIMIT 1`,
+    sql`SELECT 1 AS one FROM case_law_citations WHERE cited_decision_id IS NOT NULL AND kind = 'precedent' LIMIT 1`,
   );
   return executedRows(result).length > 0;
 };
@@ -169,6 +169,10 @@ export const recomputeCitationAuthorityForAll = async (
           ON citing_src.id = citing_d.source_id
          AND ${sql.raw(redistributableCaseLawSourceSqlFor("citing_src"))}
       ) ON c.cited_decision_id = d2.id
+         -- Procedural references name the judgment under review, not an
+         -- authority being invoked; counting them would rank a decision
+         -- by how often it was appealed.
+         AND c.kind = 'precedent'
       GROUP BY d2.id
     ) agg
     WHERE agg.decision_id = d.id

--- a/apps/api/src/handlers/case-law/citation-kind.test.ts
+++ b/apps/api/src/handlers/case-law/citation-kind.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  CITATION_KIND,
+  classifyCitation,
+} from "@/api/handlers/case-law/citation-kind";
+
+/**
+ * The contexts below are the shapes real decisions use, because the
+ * distinction is not a property of the citation string — the same case
+ * number reads as authority in one sentence and as the case's own history
+ * in another. Each case states which signal is expected to decide it.
+ */
+
+describe("context decides when it speaks", () => {
+  test("an appeal recital is procedural even for a supreme-court registry", () => {
+    expect(
+      classifyCitation({
+        citationText: "č. j. 8 Co 39/2018",
+        context:
+          "o dovolání žalovaného proti rozsudku Krajského soudu v Ostravě ze dne 20. dubna 2018, č. j. 8 Co 39/2018-72, takto:",
+      }),
+    ).toBe(CITATION_KIND.PROCEDURAL);
+  });
+
+  test("a compare-cue marks precedent even for a lower-court registry", () => {
+    // A regional judgment reported in the official collection is cited as
+    // authority; the registry alone would have called this procedural.
+    expect(
+      classifyCitation({
+        citationText: "sp. zn. 15 Ca 609/2000",
+        context:
+          "K tomu srov. rozsudek KS Ústí nad Labem ze dne 7. 2. 2003, sp. zn. 15 Ca 609/2000, publikovaný pod č. 551/2005 Sb. NSS.",
+      }),
+    ).toBe(CITATION_KIND.PRECEDENT);
+  });
+
+  test("a settled-case-law cue marks precedent", () => {
+    expect(
+      classifyCitation({
+        citationText: "sp. zn. 29 Cdo 1983/2013",
+        context:
+          "srov. shodně např. usnesení Nejvyššího soudu ze dne 29. 8. 2013, sp. zn. 29 Cdo 1983/2013",
+      }),
+    ).toBe(CITATION_KIND.PRECEDENT);
+  });
+
+  test("first-instance file references are procedural", () => {
+    expect(
+      classifyCitation({
+        citationText: "sp. zn. 19 C 332/2011",
+        context:
+          "vedené u Obvodního soudu pro Prahu 2 pod sp. zn. 19 C 332/2011, o dovolání žalované proti rozsudku Městského soudu v Praze",
+      }),
+    ).toBe(CITATION_KIND.PROCEDURAL);
+  });
+});
+
+describe("the registry decides when context does not", () => {
+  test("a published-court registry falls back to precedent", () => {
+    expect(
+      classifyCitation({
+        citationText: "sp. zn. 21 Cdo 1234/2020",
+        context: null,
+      }),
+    ).toBe(CITATION_KIND.PRECEDENT);
+  });
+
+  test("a first-instance registry falls back to procedural", () => {
+    expect(
+      classifyCitation({ citationText: "27 Co 221/2019", context: null }),
+    ).toBe(CITATION_KIND.PROCEDURAL);
+  });
+
+  test("a constitutional-court citation is precedent", () => {
+    expect(
+      classifyCitation({ citationText: "II. ÚS 251/04", context: null }),
+    ).toBe(CITATION_KIND.PRECEDENT);
+  });
+
+  test("a Polish supreme-court registry is precedent", () => {
+    expect(
+      classifyCitation({
+        citationText: "sygn. akt II CSK 123/20",
+        context: null,
+      }),
+    ).toBe(CITATION_KIND.PRECEDENT);
+  });
+
+  test("context carrying both cues falls back to the registry", () => {
+    // "srov." and an appeal recital in one window: the string alone cannot
+    // arbitrate, so publication status decides rather than cue order.
+    expect(
+      classifyCitation({
+        citationText: "sp. zn. 30 Cdo 1417/2016",
+        context:
+          "proti rozsudku odvolacího soudu, srov. rozsudek Nejvyššího soudu sp. zn. 30 Cdo 1417/2016",
+      }),
+    ).toBe(CITATION_KIND.PRECEDENT);
+  });
+});

--- a/apps/api/src/handlers/case-law/citation-kind.test.ts
+++ b/apps/api/src/handlers/case-law/citation-kind.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "bun:test";
 import {
   CITATION_KIND,
   classifyCitation,
+  proceduralKeysFromMetadata,
 } from "@/api/handlers/case-law/citation-kind";
 
 /**
@@ -97,5 +98,65 @@ describe("the registry decides when context does not", () => {
           "proti rozsudku odvolacího soudu, srov. rozsudek Nejvyššího soudu sp. zn. 30 Cdo 1417/2016",
       }),
     ).toBe(CITATION_KIND.PRECEDENT);
+  });
+});
+
+describe("the publisher outranks every heuristic", () => {
+  const keys = new Set(["iiaca 123/19"]);
+
+  test("a case the publisher lists as procedural history is procedural", () => {
+    // Cues and registry both argue for precedent; the court's own
+    // statement that this judgment is below it in the same case wins.
+    expect(
+      classifyCitation({
+        citationText: "sygn. akt II ACa 123/19",
+        citationKey: "iiaca 123/19",
+        proceduralKeys: keys,
+        context: "srov. wyrok Sądu Apelacyjnego, sygn. akt II ACa 123/19",
+      }),
+    ).toBe(CITATION_KIND.PROCEDURAL);
+  });
+
+  test("a case absent from that list still falls through to the cues", () => {
+    expect(
+      classifyCitation({
+        citationText: "sygn. akt II CSK 999/20",
+        citationKey: "iicsk 999/20",
+        proceduralKeys: keys,
+        context: "srov. wyrok Sądu Najwyższego, sygn. akt II CSK 999/20",
+      }),
+    ).toBe(CITATION_KIND.PRECEDENT);
+  });
+});
+
+describe("proceduralKeysFromMetadata", () => {
+  const identity = (caseNumber: string) => caseNumber.toLowerCase();
+
+  test("reads the publisher's lower-court judgments", () => {
+    expect([
+      ...proceduralKeysFromMetadata(
+        { lowerCourtJudgments: [{ caseNumber: "II ACa 123/19" }] },
+        identity,
+      ),
+    ]).toEqual(["ii aca 123/19"]);
+  });
+
+  test("ignores the publisher's list of cited authorities", () => {
+    // referencedCourtCases is the opposite claim: authorities the decision
+    // cites, not judgments it passed through.
+    expect(
+      proceduralKeysFromMetadata(
+        { referencedCourtCases: [{ caseNumber: "II CSK 1/20" }] },
+        identity,
+      ).size,
+    ).toBe(0);
+  });
+
+  test("tolerates absent or malformed metadata", () => {
+    expect(proceduralKeysFromMetadata(null, identity).size).toBe(0);
+    expect(
+      proceduralKeysFromMetadata({ lowerCourtJudgments: "nope" }, identity)
+        .size,
+    ).toBe(0);
   });
 });

--- a/apps/api/src/handlers/case-law/citation-kind.ts
+++ b/apps/api/src/handlers/case-law/citation-kind.ts
@@ -15,6 +15,8 @@
  * to be appealed, which is the opposite of what authority means.
  */
 
+import { isRecord } from "@/api/lib/type-guards";
+
 /** Closed set; persisted, so a CHECK constraint mirrors it in the schema. */
 export const CITATION_KIND = {
   PRECEDENT: "precedent",
@@ -107,22 +109,51 @@ const registryOf = (citationText: string): string | null => {
   return raw === undefined ? null : raw.toLowerCase();
 };
 
+/**
+ * Case numbers the publisher itself names as this decision's procedural
+ * history — SAOS `lowerCourtJudgments`, for instance. Canonical keys, so
+ * they compare against a citation's own key regardless of how either side
+ * spells the number.
+ *
+ * This is the only evidence that is not inference: the court is stating
+ * which judgments the case passed through. Where it exists it settles the
+ * question, and the cues below never get consulted.
+ */
+export type ProceduralKeys = ReadonlySet<string>;
+
 export type ClassifyCitationInput = {
   /** The citation as it appears, prefix and all. */
   citationText: string;
   /** Text around the citation; null when it could not be located. */
   context: string | null;
+  /** The citation under `bareCitationKey`, for comparing against publisher keys. */
+  citationKey?: string | null | undefined;
+  /** Publisher-declared procedural history; see `ProceduralKeys`. */
+  proceduralKeys?: ProceduralKeys | undefined;
 };
 
 /**
- * Context decides when it speaks unambiguously, because the same registry
- * can appear in either role. Where context is silent or says both, the
- * registry's publication status is the fallback.
+ * Evidence in descending order of authority: what the publisher declares,
+ * then what the surrounding sentence says, then whether the cited court
+ * publishes at all. Each step only runs because the one above it was
+ * silent.
  */
 export const classifyCitation = ({
   citationText,
   context,
+  citationKey,
+  proceduralKeys,
 }: ClassifyCitationInput): CitationKind => {
+  // The publisher's own account of the case's history outranks anything
+  // read out of the prose: it is a statement, not a reading of one.
+  if (
+    citationKey !== null &&
+    citationKey !== undefined &&
+    proceduralKeys?.has(citationKey) === true
+  ) {
+    return CITATION_KIND.PROCEDURAL;
+  }
+
   if (context !== null) {
     const procedural = PROCEDURAL_CUE.test(context);
     const precedent = PRECEDENT_CUE.test(context);
@@ -136,4 +167,52 @@ export const classifyCitation = ({
     return CITATION_KIND.PRECEDENT;
   }
   return CITATION_KIND.PROCEDURAL;
+};
+
+/**
+ * Case numbers a publisher names as the decision's own procedural history.
+ *
+ * Only fields that mean exactly that are read. `referencedCourtCases` is
+ * deliberately excluded: it is the publisher's list of authorities the
+ * decision cites, which is the opposite claim.
+ */
+const PROCEDURAL_METADATA_FIELDS = ["lowerCourtJudgments"] as const;
+
+/** Publishers list these either as bare strings or as `{ caseNumber }`. */
+const caseNumberOf = (entry: unknown): string | null => {
+  if (typeof entry === "string") {
+    return entry;
+  }
+  if (!isRecord(entry)) {
+    return null;
+  }
+  const caseNumber = entry["caseNumber"];
+  return typeof caseNumber === "string" ? caseNumber : null;
+};
+
+export const proceduralKeysFromMetadata = (
+  metadata: Record<string, unknown> | null | undefined,
+  toKey: (caseNumber: string) => string,
+): ProceduralKeys => {
+  const keys = new Set<string>();
+  if (!metadata) {
+    return keys;
+  }
+  for (const field of PROCEDURAL_METADATA_FIELDS) {
+    const value = metadata[field];
+    if (!Array.isArray(value)) {
+      continue;
+    }
+    for (const entry of value) {
+      const caseNumber = caseNumberOf(entry);
+      if (caseNumber === null) {
+        continue;
+      }
+      const key = toKey(caseNumber);
+      if (key.length > 0) {
+        keys.add(key);
+      }
+    }
+  }
+  return keys;
 };

--- a/apps/api/src/handlers/case-law/citation-kind.ts
+++ b/apps/api/src/handlers/case-law/citation-kind.ts
@@ -25,6 +25,12 @@ export const CITATION_KIND = {
 
 export type CitationKind = (typeof CITATION_KIND)[keyof typeof CITATION_KIND];
 
+/** The same values as a list, for the column's `enum` and the CHECK. */
+export const CITATION_KINDS = [
+  CITATION_KIND.PRECEDENT,
+  CITATION_KIND.PROCEDURAL,
+] as const;
+
 /**
  * Registries of courts whose decisions are published as standalone
  * documents and therefore citable as authority. Everything else is
@@ -132,18 +138,38 @@ export type ClassifyCitationInput = {
   proceduralKeys?: ProceduralKeys | undefined;
 };
 
+/** Which tier of evidence decided a classification. */
+export const CITATION_KIND_EVIDENCE = {
+  /** The publisher named this judgment as the case's own history. */
+  PUBLISHER: "publisher",
+  /** The surrounding sentence carried exactly one of the two cue sets. */
+  CONTEXT: "context",
+  /** Neither spoke; the cited court's publication status decided. */
+  REGISTRY: "registry",
+} as const;
+
+export type CitationKindEvidence =
+  (typeof CITATION_KIND_EVIDENCE)[keyof typeof CITATION_KIND_EVIDENCE];
+
+export type CitationKindVerdict = {
+  kind: CitationKind;
+  evidence: CitationKindEvidence;
+};
+
 /**
+ * Classification with the reason attached.
+ *
  * Evidence in descending order of authority: what the publisher declares,
  * then what the surrounding sentence says, then whether the cited court
  * publishes at all. Each step only runs because the one above it was
  * silent.
  */
-export const classifyCitation = ({
+export const classifyCitationVerdict = ({
   citationText,
   context,
   citationKey,
   proceduralKeys,
-}: ClassifyCitationInput): CitationKind => {
+}: ClassifyCitationInput): CitationKindVerdict => {
   // The publisher's own account of the case's history outranks anything
   // read out of the prose: it is a statement, not a reading of one.
   if (
@@ -151,23 +177,54 @@ export const classifyCitation = ({
     citationKey !== undefined &&
     proceduralKeys?.has(citationKey) === true
   ) {
-    return CITATION_KIND.PROCEDURAL;
+    return {
+      kind: CITATION_KIND.PROCEDURAL,
+      evidence: CITATION_KIND_EVIDENCE.PUBLISHER,
+    };
   }
 
   if (context !== null) {
     const procedural = PROCEDURAL_CUE.test(context);
     const precedent = PRECEDENT_CUE.test(context);
     if (procedural !== precedent) {
-      return procedural ? CITATION_KIND.PROCEDURAL : CITATION_KIND.PRECEDENT;
+      return {
+        kind: procedural ? CITATION_KIND.PROCEDURAL : CITATION_KIND.PRECEDENT,
+        evidence: CITATION_KIND_EVIDENCE.CONTEXT,
+      };
     }
   }
 
   const registry = registryOf(withoutPrefix(citationText));
-  if (registry !== null && AUTHORITY_REGISTRIES.has(registry)) {
-    return CITATION_KIND.PRECEDENT;
-  }
-  return CITATION_KIND.PROCEDURAL;
+  return {
+    kind:
+      registry !== null && AUTHORITY_REGISTRIES.has(registry)
+        ? CITATION_KIND.PRECEDENT
+        : CITATION_KIND.PROCEDURAL,
+    evidence: CITATION_KIND_EVIDENCE.REGISTRY,
+  };
 };
+
+export const classifyCitation = (input: ClassifyCitationInput): CitationKind =>
+  classifyCitationVerdict(input).kind;
+
+/**
+ * How the heuristics would have classified this citation with the
+ * publisher's account withheld.
+ *
+ * Where a publisher states a case's procedural history, that statement is
+ * a free label for the tiers below it — and the only way to know whether
+ * the cue lists work on sources that publish no such list. The comparison
+ * is one-sided: a publisher naming a judgment proves it *is* procedural,
+ * but its silence proves nothing, so this measures how much of the known
+ * procedural set the heuristics recover, never how much they over-call.
+ */
+export const classifyWithoutPublisher = (
+  input: ClassifyCitationInput,
+): CitationKindVerdict =>
+  classifyCitationVerdict({
+    citationText: input.citationText,
+    context: input.context,
+  });
 
 /**
  * Case numbers a publisher names as the decision's own procedural history.

--- a/apps/api/src/handlers/case-law/citation-kind.ts
+++ b/apps/api/src/handlers/case-law/citation-kind.ts
@@ -1,0 +1,139 @@
+/**
+ * What a citation is doing: invoking authority, or naming the case's own
+ * procedural history.
+ *
+ * A decision under review cites two very different things. It invokes
+ * precedent — "srov. rozsudek Nejvyššího soudu ..." — and it names the
+ * judgment it is reviewing, together with the first-instance file number,
+ * in its recitals. Both are extracted as citations, but only the first is
+ * an endorsement of authority.
+ *
+ * Conflating them costs twice over. Procedural references never resolve,
+ * because first- and second-instance judgments are largely unpublished, so
+ * counting them makes a working citator look broken. And if they reached
+ * the citation graph they would inflate the authority of whatever happened
+ * to be appealed, which is the opposite of what authority means.
+ */
+
+/** Closed set; persisted, so a CHECK constraint mirrors it in the schema. */
+export const CITATION_KIND = {
+  PRECEDENT: "precedent",
+  PROCEDURAL: "procedural",
+} as const;
+
+export type CitationKind = (typeof CITATION_KIND)[keyof typeof CITATION_KIND];
+
+/**
+ * Registries of courts whose decisions are published as standalone
+ * documents and therefore citable as authority. Everything else is
+ * first- or second-instance, where a reference is almost always the
+ * case's own history.
+ *
+ * The registry is a prior, not a verdict: a published lower-court
+ * decision can be cited as authority (a regional judgment reported in
+ * Sb. NSS), so context wins where it speaks.
+ */
+const AUTHORITY_REGISTRIES = new Set([
+  // Czech Supreme Court
+  "cdo",
+  "tdo",
+  "odo",
+  "nd",
+  // Czech Supreme Administrative Court
+  "as",
+  "afs",
+  "azs",
+  "ads",
+  "ars",
+  "aps",
+  "ao",
+  "konf",
+  // Constitutional courts
+  "ús",
+  "us",
+  // Polish Supreme Court
+  "csk",
+  "ck",
+  "czp",
+  "uzp",
+  "kzp",
+  "cskp",
+  // Slovak Supreme Court
+  "sžo",
+  "sž",
+  "obdo",
+  "cdo",
+]);
+
+/**
+ * Phrases that mark the recitals: the appeal, the judgment under review,
+ * the court below. Deliberately morphological stems rather than whole
+ * words — Czech and Slovak inflect heavily, and matching stems keeps one
+ * list working across cases.
+ */
+const PROCEDURAL_CUE =
+  /napaden|proti\s+(?:rozsudk|usnesen)|odvol[áa]n|dovol[áa]n[íi]\s+(?:žalovan|žalobc)|soud[ue]?\s+prvn[íi]ho\s+stupn|prvostupňov|potvrdil|zrušil\s+a\s+vr[áa]til|vedl[ei]?\s+u\s+|pobočka\s+v/iu;
+
+/**
+ * Phrases that mark an authority being invoked. `srov.` (compare) and
+ * `viz` (see) are the strongest: they exist only to point at precedent.
+ */
+const PRECEDENT_CUE =
+  /srov\.|srovnej|viz\s|judikat|ust[áa]len|pr[áa]vn[íi]\s+n[áa]zor|dovodil|vyslovil|konstatoval|st[áa]l[áa]\s+praxe|ve\s+sv[ée]m\s+rozhodnut/iu;
+
+/**
+ * Drop the citation prefix so the registry token is first. Spelled out
+ * per language rather than matched generically: `sygn. akt` carries one
+ * dot and `sp. zn.` two, and a pattern loose enough for both also eats
+ * the registry it is meant to expose.
+ */
+const withoutPrefix = (text: string): string =>
+  text
+    .replace(/^\s*sp\.\s*zn\.:?\s*/iu, "")
+    .replace(/^\s*[čc]\.\s*j\.:?\s*/iu, "")
+    .replace(/^\s*sygn\.\s*(?:akt\s+)?/iu, "")
+    .trim();
+
+/** The registry token of a case number: `21 Cdo 1234/2020` -> `cdo`. */
+const registryOf = (citationText: string): string | null => {
+  const roman = /^\s*[IVX]+\.?\s*(?<reg>[A-Za-zÁ-Žá-ž]{1,5})/u.exec(
+    citationText,
+  );
+  const arabic = /^\s*\d{1,3}\s*(?<reg>[A-Za-zÁ-Žá-ž]{1,6})/u.exec(
+    citationText,
+  );
+  const us = /ÚS|US/u.exec(citationText);
+  const raw = roman?.groups?.["reg"] ?? arabic?.groups?.["reg"] ?? us?.[0];
+  return raw === undefined ? null : raw.toLowerCase();
+};
+
+export type ClassifyCitationInput = {
+  /** The citation as it appears, prefix and all. */
+  citationText: string;
+  /** Text around the citation; null when it could not be located. */
+  context: string | null;
+};
+
+/**
+ * Context decides when it speaks unambiguously, because the same registry
+ * can appear in either role. Where context is silent or says both, the
+ * registry's publication status is the fallback.
+ */
+export const classifyCitation = ({
+  citationText,
+  context,
+}: ClassifyCitationInput): CitationKind => {
+  if (context !== null) {
+    const procedural = PROCEDURAL_CUE.test(context);
+    const precedent = PRECEDENT_CUE.test(context);
+    if (procedural !== precedent) {
+      return procedural ? CITATION_KIND.PROCEDURAL : CITATION_KIND.PRECEDENT;
+    }
+  }
+
+  const registry = registryOf(withoutPrefix(citationText));
+  if (registry !== null && AUTHORITY_REGISTRIES.has(registry)) {
+    return CITATION_KIND.PRECEDENT;
+  }
+  return CITATION_KIND.PROCEDURAL;
+};

--- a/apps/api/src/handlers/case-law/ingestion/pipeline.ts
+++ b/apps/api/src/handlers/case-law/ingestion/pipeline.ts
@@ -11,7 +11,11 @@ import {
   type caseLawSources,
 } from "@/api/db/schema";
 import { corpusStorageMode } from "@/api/env-base";
-import { classifyCitation } from "@/api/handlers/case-law/citation-kind";
+import {
+  classifyCitation,
+  proceduralKeysFromMetadata,
+} from "@/api/handlers/case-law/citation-kind";
+import type { ProceduralKeys } from "@/api/handlers/case-law/citation-kind";
 import {
   ADAPTER_TIMEOUT,
   MAX_SYNC_PAGES,
@@ -294,20 +298,26 @@ const citationRow = (
   citingDecisionId: SafeId<"caseLawDecision">,
   citation: { citationText: string; sectionIndex: number | null },
   sections: { index: number; text: string }[],
-) => ({
-  citingDecisionId,
-  citationText: citation.citationText,
-  citationKey: citationKeyOf(citation.citationText),
-  kind: classifyCitation({
+  proceduralKeys: ProceduralKeys,
+) => {
+  const citationKey = citationKeyOf(citation.citationText);
+  return {
+    citingDecisionId,
     citationText: citation.citationText,
-    context: extractContext(
-      sections,
-      citation.citationText,
-      citation.sectionIndex,
-    ),
-  }),
-  sectionIndex: citation.sectionIndex,
-});
+    citationKey,
+    kind: classifyCitation({
+      citationText: citation.citationText,
+      citationKey,
+      proceduralKeys,
+      context: extractContext(
+        sections,
+        citation.citationText,
+        citation.sectionIndex,
+      ),
+    }),
+    sectionIndex: citation.sectionIndex,
+  };
+};
 
 type PreserveCorpusWriteRetryInput = {
   decisionId: SafeId<"caseLawDecision">;
@@ -700,6 +710,13 @@ export const processDecision = async (
     }
   }
 
+  // The publisher's own statement of the case's procedural history, where
+  // it supplies one; classification consults it before any heuristic.
+  const proceduralKeys = proceduralKeysFromMetadata(
+    result.metadata,
+    (caseNumber) => bareCitationKey(caseNumber),
+  );
+
   const citations = extractCitations(
     sections.map((s) => ({ index: s.index, text: s.text })),
   ).filter(
@@ -889,7 +906,9 @@ export const processDecision = async (
           await tx
             .insert(caseLawCitations)
             .values(
-              citations.map((c) => citationRow(existing.id, c, sections)),
+              citations.map((c) =>
+                citationRow(existing.id, c, sections, proceduralKeys),
+              ),
             );
         }
 
@@ -947,7 +966,9 @@ export const processDecision = async (
         await tx
           .insert(caseLawCitations)
           .values(
-            citations.map((c) => citationRow(decisionRow.id, c, sections)),
+            citations.map((c) =>
+              citationRow(decisionRow.id, c, sections, proceduralKeys),
+            ),
           );
       }
     });

--- a/apps/api/src/handlers/case-law/ingestion/pipeline.ts
+++ b/apps/api/src/handlers/case-law/ingestion/pipeline.ts
@@ -11,6 +11,7 @@ import {
   type caseLawSources,
 } from "@/api/db/schema";
 import { corpusStorageMode } from "@/api/env-base";
+import { classifyCitation } from "@/api/handlers/case-law/citation-kind";
 import {
   ADAPTER_TIMEOUT,
   MAX_SYNC_PAGES,
@@ -50,6 +51,7 @@ import {
   stripDangerousChars,
 } from "@/api/handlers/case-law/ingestion/sanitize";
 import { segmentDecision } from "@/api/handlers/case-law/ingestion/segmenter";
+import { extractContext } from "@/api/handlers/case-law/polarity/context";
 import { pgPayloadCarriesDocument } from "@/api/handlers/case-law/stored-payload";
 import type { DecisionSection } from "@/api/handlers/case-law/types";
 import { captureError } from "@/api/lib/analytics/capture";
@@ -281,6 +283,31 @@ const uploadSourceRaw = async (
  */
 const citationKeyOf = (text: string): string | null =>
   bareCitationKey(text) || null;
+
+/**
+ * Row values for one extracted citation, including what the citation is
+ * doing: invoking authority, or naming the case's own procedural history.
+ * Classified here rather than in the extractor because the decision needs
+ * the surrounding text, which the pipeline already holds.
+ */
+const citationRow = (
+  citingDecisionId: SafeId<"caseLawDecision">,
+  citation: { citationText: string; sectionIndex: number | null },
+  sections: { index: number; text: string }[],
+) => ({
+  citingDecisionId,
+  citationText: citation.citationText,
+  citationKey: citationKeyOf(citation.citationText),
+  kind: classifyCitation({
+    citationText: citation.citationText,
+    context: extractContext(
+      sections,
+      citation.citationText,
+      citation.sectionIndex,
+    ),
+  }),
+  sectionIndex: citation.sectionIndex,
+});
 
 type PreserveCorpusWriteRetryInput = {
   decisionId: SafeId<"caseLawDecision">;
@@ -859,14 +886,11 @@ export const processDecision = async (
           .where(eq(caseLawCitations.citingDecisionId, existing.id));
 
         if (citations.length > 0) {
-          await tx.insert(caseLawCitations).values(
-            citations.map((c) => ({
-              citingDecisionId: existing.id,
-              citationText: c.citationText,
-              citationKey: citationKeyOf(c.citationText),
-              sectionIndex: c.sectionIndex,
-            })),
-          );
+          await tx
+            .insert(caseLawCitations)
+            .values(
+              citations.map((c) => citationRow(existing.id, c, sections)),
+            );
         }
 
         return;
@@ -920,14 +944,11 @@ export const processDecision = async (
       }
 
       if (citations.length > 0) {
-        await tx.insert(caseLawCitations).values(
-          citations.map((c) => ({
-            citingDecisionId: decisionRow.id,
-            citationText: c.citationText,
-            citationKey: citationKeyOf(c.citationText),
-            sectionIndex: c.sectionIndex,
-          })),
-        );
+        await tx
+          .insert(caseLawCitations)
+          .values(
+            citations.map((c) => citationRow(decisionRow.id, c, sections)),
+          );
       }
     });
   };


### PR DESCRIPTION
A decision under review cites two very different things:

- **Precedent** it invokes — *"srov. rozsudek Nejvyššího soudu ze dne …"*
- **Procedural history** — the judgment being appealed and the first-instance file number, named in the recitals: *"o dovolání žalovaného proti rozsudku Krajského soudu v Ostravě, č. j. 8 Co 39/2018-72"*

Both were stored as citations and both fed `citation_authority`, so a decision accrued authority from having been **appealed**, which inverts what authority means. The second class also never resolves — first- and second-instance judgments are largely unpublished, confirmed against thirdparty databases — so counting them made a working citator look broken.

**Classification** happens at ingest, where the surrounding text is already in hand. Context decides when it speaks unambiguously (`srov.`/`viz`/`ustálená judikatura` against `napadeným`/`proti rozsudku`/`soud prvního stupně`); where context is silent or says both, the fallback is whether the cited registry belongs to a court publishing standalone decisions. The registry is a prior rather than a verdict, so a regional judgment reported in Sb. NSS still classifies as precedent when the text cites it that way — covered by a test.

**Validated on 351 production contexts**, not just fixtures:

| registry | precedent | procedural |
|---|---|---|
| `cdo` Supreme (civil) | 67 | 3 |
| `tdo` Supreme (criminal) | 65 | 5 |
| `afs` Supreme Admin | 65 | 5 |
| `co` regional appellate | 3 | 67 |
| `c` district | 0 | 70 |

That matches a hand-classified sample of the same corpus.

Authority now aggregates precedent only, with a partial index covering that arm. Existing rows default to `precedent` so present behaviour is unchanged until a backfill classifies them; the CHECK is added `NOT VALID` then validated separately to avoid an ACCESS EXCLUSIVE lock on 3.4M rows.

---

**Update — publisher metadata now outranks the heuristics.**

Courts state which judgments a case passed through, and we were already storing it: SAOS supplies `lowerCourtJudgments`, captured in `IngestionResult.metadata` by the pl-courts adapter. That is the court's own account of the case's history rather than an inference from prose, so classification now consults it first and only falls through to context cues and the registry prior when it is absent.

`referencedCourtCases` is deliberately **not** read: it is the publisher's list of authorities the decision cites, which is the opposite claim.

This follows the same rule as the parser guidance — prefer the publisher's structure over its wording.

**Correction:** an earlier revision of this description claimed the Czech Supreme Court parser's `related-proceedings` table was the equivalent signal. It is not. That table is keyed off `ústavní stížnost` and holds the *constitutional complaint filed against* the decision — later in time, not earlier. It is subsequent history, not procedural history, and using it here would misclassify. It is valuable, but for a different feature.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Citations are now classified as either precedent or procedural references.
  - Classification uses decision context, court registry information and publisher metadata.
  - Procedural references can be identified from lower-court judgment details.

- **Bug Fixes**
  - Procedural references are excluded from precedent citation counts, authority scores and resolution checks.
  - Existing citation records are assigned a default precedent classification.

- **Tests**
  - Added coverage for citation classification, metadata handling and malformed or missing information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->