### PR TITLE
fix: refine iOS landing visuals and locale selection

### DIFF
--- a/apps/landing/src/components/LanguageSwitcher.astro
+++ b/apps/landing/src/components/LanguageSwitcher.astro
@@ -8,9 +8,9 @@ import {
 } from "../i18n/config";
 import { getTranslations, localizePath } from "../i18n/utils";
 
-// Only the homepage is translated today. Keep the switcher available in the
-// shared header, but always send visitors to a real localized route instead of
-// inventing paths such as /de/security that the static build does not emit.
+// Not every page rendered with the shared header has localized routes. Send
+// language choices to the localized homepage instead of inventing paths such
+// as /de/security that the static build does not emit.
 const rawLocale = Astro.currentLocale ?? defaultLocale;
 const current: Locale = isLocale(rawLocale) ? rawLocale : defaultLocale;
 const t = getTranslations(current);

--- a/apps/landing/src/components/LanguageSwitcher.astro
+++ b/apps/landing/src/components/LanguageSwitcher.astro
@@ -57,6 +57,7 @@ const options = localeCodes.map((code) => ({
         <a
           href={option.href}
           hreflang={option.hreflang}
+          data-landing-locale-choice={option.code}
           class={`lang-item ${option.active ? "is-active" : ""}`}
         >
           {option.label}

--- a/apps/landing/src/components/ProductMediaFrame.astro
+++ b/apps/landing/src/components/ProductMediaFrame.astro
@@ -41,6 +41,8 @@ const rawLocale = Astro.currentLocale ?? defaultLocale;
 const locale = isLocale(rawLocale) ? rawLocale : defaultLocale;
 const sceneWindowLabels = resolveSceneWindowLabels(getTranslations(locale));
 const aspect = media.aspect ?? "16 / 9";
+const mobileAspect =
+  media.type === "story" ? media.mobileAspect ?? aspect : aspect;
 
 // A video slot upgrades from skeleton to <video> the moment its file lands in
 // public/. The build's cwd is the Astro project dir (apps/landing), so resolve
@@ -51,7 +53,10 @@ const posterReady = media.type === "video" && media.poster !== undefined && vide
 const storyThumbnail = media.type === "story" ? productStoryThumbnails[media.sceneId] : undefined;
 ---
 
-<div class="product-media relative" style={`aspect-ratio: ${aspect}`}>
+<div
+  class="product-media relative"
+  style={`--product-media-aspect: ${aspect}; --product-media-mobile-aspect: ${mobileAspect}`}
+>
   {
     media.type === "preview" && (
       <div class="absolute inset-0">
@@ -204,7 +209,14 @@ const storyThumbnail = media.type === "story" ? productStoryThumbnails[media.sce
      on the plain <img>/<video> element) instead of relying on a shared ring
      here. */
   .product-media {
+    aspect-ratio: var(--product-media-aspect);
     overflow: visible;
+  }
+
+  @media (max-width: 639px) {
+    .product-media {
+      aspect-ratio: var(--product-media-mobile-aspect);
+    }
   }
 
   /* Portrait document window: full frame height, width derived from the

--- a/apps/landing/src/components/ProductMediaFrame.astro
+++ b/apps/landing/src/components/ProductMediaFrame.astro
@@ -9,7 +9,7 @@ import MacWindow from "./MacWindow.astro";
 import MediaSkeleton from "./MediaSkeleton.astro";
 import ThemeImage from "./ThemeImage.astro";
 import { AnonymizeLiveDemo } from "./react/AnonymizeLiveDemo";
-import { EditorLiveDemo } from "./react/EditorLiveDemo";
+import { EditorLiveDemoShell } from "./react/EditorLiveDemoShell";
 import { ProductPreview } from "./react/previews/ProductPreview";
 import { CliMcpPreview } from "./react/previews/CliMcpPreview";
 import { RecordedStellaScene } from "./react/product-story/RecordedStellaScene";
@@ -173,11 +173,30 @@ const storyThumbnail = media.type === "story" ? productStoryThumbnails[media.sce
 
   {
     media.type === "live-editor" && !thumbnail && (
-      <div class="absolute inset-0">
-        <MacWindow class="h-full" label={media.alt}>
-          <EditorLiveDemo client:only="react" />
-        </MacWindow>
-      </div>
+      <>
+        {/* The real folio toolbar is scaled below a usable touch size in the
+            mobile hero. Show its theme-aware capture there so the preview is
+            clearly illustrative; larger viewports retain the live editor. */}
+        <div class="absolute inset-0 sm:hidden" data-editor-preview="static">
+          <MacWindow class="h-full" label={media.alt}>
+            <ThemeImage
+              lightSrc="/media/products/editor.png"
+              darkSrc="/media/products/editor-dark.png"
+              alt={media.alt}
+              class="h-full w-full object-contain object-top"
+              loading="eager"
+            />
+          </MacWindow>
+        </div>
+        <div
+          class="absolute inset-0 hidden sm:block"
+          data-editor-preview="interactive"
+        >
+          <MacWindow class="h-full" label={media.alt}>
+            <EditorLiveDemoShell client:only="react" />
+          </MacWindow>
+        </div>
+      </>
     )
   }
 

--- a/apps/landing/src/components/ProductMediaFrame.astro
+++ b/apps/landing/src/components/ProductMediaFrame.astro
@@ -39,7 +39,9 @@ const { media, compact = false, deferThemeImage = false, thumbnail = false } = A
 // catalog keys.
 const rawLocale = Astro.currentLocale ?? defaultLocale;
 const locale = isLocale(rawLocale) ? rawLocale : defaultLocale;
-const sceneWindowLabels = resolveSceneWindowLabels(getTranslations(locale));
+const t = getTranslations(locale);
+const sceneWindowLabels = resolveSceneWindowLabels(t);
+const staticEditorLabel = `${t("nav.products.editor.eyebrow")} · ${t("products.ui.preview")}`;
 const aspect = media.aspect ?? "16 / 9";
 const mobileAspect =
   media.type === "story" ? media.mobileAspect ?? aspect : aspect;
@@ -178,13 +180,13 @@ const storyThumbnail = media.type === "story" ? productStoryThumbnails[media.sce
             mobile hero. Show its theme-aware capture there so the preview is
             clearly illustrative; larger viewports retain the live editor. */}
         <div class="absolute inset-0 sm:hidden" data-editor-preview="static">
-          <MacWindow class="h-full" label={media.alt}>
+          <MacWindow class="h-full" label={staticEditorLabel}>
             <ThemeImage
               lightSrc="/media/products/editor.png"
               darkSrc="/media/products/editor-dark.png"
-              alt={media.alt}
+              alt=""
               class="h-full w-full object-contain object-top"
-              loading="eager"
+              media="(max-width: 639px)"
             />
           </MacWindow>
         </div>

--- a/apps/landing/src/components/ProductMediaFrame.test.ts
+++ b/apps/landing/src/components/ProductMediaFrame.test.ts
@@ -1,0 +1,15 @@
+import { expect, test } from "bun:test";
+
+const componentPath = new URL("ProductMediaFrame.astro", import.meta.url);
+
+test("editor media is static on mobile and interactive on larger viewports", async () => {
+  const component = await Bun.file(componentPath).text();
+
+  expect(component).toContain(
+    'class="absolute inset-0 sm:hidden" data-editor-preview="static"',
+  );
+  expect(component).toContain(
+    'class="absolute inset-0 hidden sm:block"\n          data-editor-preview="interactive"',
+  );
+  expect(component).toContain('<EditorLiveDemoShell client:only="react" />');
+});

--- a/apps/landing/src/components/ProductMediaFrame.test.ts
+++ b/apps/landing/src/components/ProductMediaFrame.test.ts
@@ -12,4 +12,6 @@ test("editor media is static on mobile and interactive on larger viewports", asy
     'class="absolute inset-0 hidden sm:block"\n          data-editor-preview="interactive"',
   );
   expect(component).toContain('<EditorLiveDemoShell client:only="react" />');
+  expect(component).toContain('media="(max-width: 639px)"');
+  expect(component).toContain("label={staticEditorLabel}");
 });

--- a/apps/landing/src/components/ThemeImage.astro
+++ b/apps/landing/src/components/ThemeImage.astro
@@ -8,6 +8,7 @@ type Props = {
   loading?: "eager" | "lazy";
   decoding?: "async" | "auto" | "sync";
   defer?: "manual" | "visible";
+  media?: string;
 };
 
 const {
@@ -19,6 +20,7 @@ const {
   loading = "lazy",
   decoding = "async",
   defer,
+  media,
 } = Astro.props;
 
 const transparentPixel =
@@ -32,14 +34,19 @@ const transparentPixel =
 //
 // `manual` defers keep the placeholder: those are the nav mega-menu
 // thumbnails inside a closed <details>, where a real source would fetch every
-// product preview on every page load.
-const initialSrc = defer === "manual" ? transparentPixel : lightSrc;
+// product preview on every page load. A `media` constraint also keeps the
+// placeholder until theme-images.ts observes a matching viewport, so a
+// responsive-only capture does not download on the opposite breakpoint.
+const initialSrc =
+  defer === "manual" || media !== undefined ? transparentPixel : lightSrc;
+const deferredMode = media === undefined ? defer : "media";
 ---
 
 <img
   src={initialSrc}
   data-theme-image
-  data-theme-image-deferred={defer}
+  data-theme-image-deferred={deferredMode}
+  data-theme-image-media={media}
   data-theme-light-src={lightSrc}
   data-theme-dark-src={darkSrc}
   alt={alt}

--- a/apps/landing/src/components/react/EditorLiveDemo.tsx
+++ b/apps/landing/src/components/react/EditorLiveDemo.tsx
@@ -25,12 +25,13 @@ const FOLIO_MESSAGES = getFolioMessages("en");
  * and is fully editable — including folio's own formatting toolbar and
  * track-changes toggle — with no server round-trip.
  *
- * Mounted with Astro's `client:only="react"` (see ProductMediaFrame.astro),
- * not `client:visible`: folio's `DocxEditor` renders a real ProseMirror surface
- * and has no server snapshot, so `astro build`'s SSR of a `client:visible`
- * island crashes (its `useEditorMode` calls `useSyncExternalStore` without the
- * `getServerSnapshot` argument SSR requires). `client:only` skips server
- * rendering, which is also simply correct for a ProseMirror-backed editor.
+ * Loaded through EditorLiveDemoShell, which ProductMediaFrame mounts with
+ * Astro's `client:only="react"`, not `client:visible`: folio's `DocxEditor`
+ * renders a real ProseMirror surface and has no server snapshot, so
+ * `astro build`'s SSR of a `client:visible` island crashes (its `useEditorMode`
+ * calls `useSyncExternalStore` without the `getServerSnapshot` argument SSR
+ * requires). `client:only` skips server rendering, which is also simply
+ * correct for a ProseMirror-backed editor.
  *
  * `DocxEditor` ships its own dependency-light default chrome (buttons, menus,
  * dialogs, keyed off the same `--doc-*` CSS variables the app's semantic tokens

--- a/apps/landing/src/components/react/EditorLiveDemoShell.tsx
+++ b/apps/landing/src/components/react/EditorLiveDemoShell.tsx
@@ -1,0 +1,41 @@
+import { lazy, Suspense, useSyncExternalStore } from "react";
+
+const DESKTOP_EDITOR_QUERY = "(min-width: 640px)";
+
+const LazyEditorLiveDemo = lazy(async () => {
+  const { EditorLiveDemo } = await import("./EditorLiveDemo");
+  return { default: EditorLiveDemo };
+});
+
+const subscribeToDesktopViewport = (onStoreChange: () => void) => {
+  const query = window.matchMedia(DESKTOP_EDITOR_QUERY);
+  query.addEventListener("change", onStoreChange);
+  return () => {
+    query.removeEventListener("change", onStoreChange);
+  };
+};
+
+const isDesktopViewport = () => window.matchMedia(DESKTOP_EDITOR_QUERY).matches;
+
+/**
+ * Keeps folio's editor bundle and sample DOCX out of mobile sessions. The
+ * containing Astro component supplies a static mobile capture, while this
+ * shell loads the interactive editor only after the desktop query matches.
+ */
+export const EditorLiveDemoShell = () => {
+  const desktop = useSyncExternalStore(
+    subscribeToDesktopViewport,
+    isDesktopViewport,
+    () => false,
+  );
+
+  if (!desktop) {
+    return null;
+  }
+
+  return (
+    <Suspense fallback={null}>
+      <LazyEditorLiveDemo />
+    </Suspense>
+  );
+};

--- a/apps/landing/src/components/react/previews/CliMcpPreview.tsx
+++ b/apps/landing/src/components/react/previews/CliMcpPreview.tsx
@@ -1472,6 +1472,15 @@ const CLI_STYLES = `
       width: 90%;
       height: 33%;
     }
+    /* Two-window product scenes stack vertically on mobile. Give the
+       terminal enough room for its titlebar, command, results, and status
+       while keeping the app window as the larger surface. */
+    .cli-story-two-window .cli-main-window {
+      height: 55%;
+    }
+    .cli-story-two-window .cli-window {
+      height: 39%;
+    }
     /* The homepage hero follows the single-focus mobile composition: keep
        the main animated stella window and drop every companion. Other embeds
        retain their purpose-built mobile layouts. */

--- a/apps/landing/src/data/products/cli-mcp.ts
+++ b/apps/landing/src/data/products/cli-mcp.ts
@@ -18,6 +18,9 @@ export const cliMcp: Product = {
     // homepage opening story keeps the full four-window scene.
     sideWindows: false,
     aspect: "2.03",
+    // Mobile stacks the app and terminal, so the desktop-wide ratio would
+    // leave less height than the terminal chrome alone requires.
+    mobileAspect: "1 / 1",
   },
   // Frame rhythm down the page: bloom, wash, bloom.
   heroFrameVariant: "bloom",

--- a/apps/landing/src/data/products/types.ts
+++ b/apps/landing/src/data/products/types.ts
@@ -51,10 +51,11 @@ export type ProductMedia =
       aspect?: string;
     }
   | {
-      /** Live, in-browser run of the real folio DOCX editor (EditorLiveDemo):
-       *  a sample contract opens pre-parsed (no server round-trip) and is
-       *  fully editable, including folio's own formatting toolbar and
-       *  track-changes toggle. Mounted with `client:only` (not
+      /** In-browser presentation of the real folio DOCX editor: mobile uses
+       *  a non-interactive, theme-aware capture because the scaled controls
+       *  are too small for touch; larger viewports mount EditorLiveDemo, where
+       *  a sample contract is fully editable, including folio's formatting
+       *  toolbar and track-changes toggle. Mounted with `client:only` (not
        *  `client:visible`, unlike `live-anonymize`): folio's `DocxEditor`
        *  has no SSR guard and crashes under Astro's server render for a
        *  `document`-seeded editor; see ProductMediaFrame and

--- a/apps/landing/src/data/products/types.ts
+++ b/apps/landing/src/data/products/types.ts
@@ -24,6 +24,8 @@ export type ProductMedia =
        *  as a centred portrait window instead of the wide app scene. */
       variant?: "portrait";
       aspect?: string;
+      /** Optional mobile ratio for scenes whose windows recompose vertically. */
+      mobileAspect?: string;
     }
   | { type: "placeholder"; note: string; aspect?: string }
   | {

--- a/apps/landing/src/i18n/messages/ar.json
+++ b/apps/landing/src/i18n/messages/ar.json
@@ -793,7 +793,8 @@
       "capabilities": "الإمكانات",
       "exploreMore": "استكشف المزيد",
       "faq": "الأسئلة الشائعة",
-      "inShort": "باختصار"
+      "inShort": "باختصار",
+      "preview": "معاينة"
     },
     "workspace": {
       "adjacent": {

--- a/apps/landing/src/i18n/messages/cs.json
+++ b/apps/landing/src/i18n/messages/cs.json
@@ -793,7 +793,8 @@
       "capabilities": "Co to umí",
       "exploreMore": "Prozkoumejte dál",
       "faq": "Časté dotazy",
-      "inShort": "Ve zkratce"
+      "inShort": "Ve zkratce",
+      "preview": "Náhled"
     },
     "workspace": {
       "adjacent": {

--- a/apps/landing/src/i18n/messages/de.json
+++ b/apps/landing/src/i18n/messages/de.json
@@ -793,7 +793,8 @@
       "capabilities": "Was es kann",
       "exploreMore": "Mehr entdecken",
       "faq": "Häufige Fragen",
-      "inShort": "Kurz gefasst"
+      "inShort": "Kurz gefasst",
+      "preview": "Vorschau"
     },
     "workspace": {
       "adjacent": {

--- a/apps/landing/src/i18n/messages/en.json
+++ b/apps/landing/src/i18n/messages/en.json
@@ -793,7 +793,8 @@
       "capabilities": "Capabilities",
       "exploreMore": "Explore more",
       "faq": "FAQ",
-      "inShort": "In short"
+      "inShort": "In short",
+      "preview": "Preview"
     },
     "workspace": {
       "adjacent": {

--- a/apps/landing/src/i18n/messages/es.json
+++ b/apps/landing/src/i18n/messages/es.json
@@ -793,7 +793,8 @@
       "capabilities": "Funcionalidades",
       "exploreMore": "Sigue explorando",
       "faq": "Preguntas frecuentes",
-      "inShort": "En resumen"
+      "inShort": "En resumen",
+      "preview": "Vista previa"
     },
     "workspace": {
       "adjacent": {

--- a/apps/landing/src/i18n/messages/et.json
+++ b/apps/landing/src/i18n/messages/et.json
@@ -793,7 +793,8 @@
       "capabilities": "Võimalused",
       "exploreMore": "Avasta veel",
       "faq": "KKK",
-      "inShort": "Lühidalt"
+      "inShort": "Lühidalt",
+      "preview": "Eelvaade"
     },
     "workspace": {
       "adjacent": {

--- a/apps/landing/src/i18n/messages/fr.json
+++ b/apps/landing/src/i18n/messages/fr.json
@@ -793,7 +793,8 @@
       "capabilities": "Fonctionnalités",
       "exploreMore": "Pour aller plus loin",
       "faq": "Questions fréquentes",
-      "inShort": "En bref"
+      "inShort": "En bref",
+      "preview": "Aperçu"
     },
     "workspace": {
       "adjacent": {

--- a/apps/landing/src/i18n/messages/hu.json
+++ b/apps/landing/src/i18n/messages/hu.json
@@ -793,7 +793,8 @@
       "capabilities": "Képességek",
       "exploreMore": "Fedezzen fel többet",
       "faq": "GYIK",
-      "inShort": "Röviden"
+      "inShort": "Röviden",
+      "preview": "Előnézet"
     },
     "workspace": {
       "adjacent": {

--- a/apps/landing/src/i18n/messages/lt.json
+++ b/apps/landing/src/i18n/messages/lt.json
@@ -793,7 +793,8 @@
       "capabilities": "Galimybės",
       "exploreMore": "Sužinokite daugiau",
       "faq": "Dažni klausimai",
-      "inShort": "Trumpai"
+      "inShort": "Trumpai",
+      "preview": "Peržiūra"
     },
     "workspace": {
       "adjacent": {

--- a/apps/landing/src/i18n/messages/lv.json
+++ b/apps/landing/src/i18n/messages/lv.json
@@ -793,7 +793,8 @@
       "capabilities": "Iespējas",
       "exploreMore": "Uzziniet vairāk",
       "faq": "Biežāk uzdotie jautājumi",
-      "inShort": "Īsumā"
+      "inShort": "Īsumā",
+      "preview": "Priekšskatījums"
     },
     "workspace": {
       "adjacent": {

--- a/apps/landing/src/i18n/messages/messages.gen.ts
+++ b/apps/landing/src/i18n/messages/messages.gen.ts
@@ -797,6 +797,7 @@ type Messages = {
       "exploreMore": "Explore more";
       "faq": "FAQ";
       "inShort": "In short";
+      "preview": "Preview";
     };
     "workspace": {
       "adjacent": {

--- a/apps/landing/src/i18n/messages/pl.json
+++ b/apps/landing/src/i18n/messages/pl.json
@@ -793,7 +793,8 @@
       "capabilities": "Co potrafi",
       "exploreMore": "Poznaj więcej",
       "faq": "Najczęstsze pytania",
-      "inShort": "W skrócie"
+      "inShort": "W skrócie",
+      "preview": "Podgląd"
     },
     "workspace": {
       "adjacent": {

--- a/apps/landing/src/i18n/messages/pt-BR.json
+++ b/apps/landing/src/i18n/messages/pt-BR.json
@@ -793,7 +793,8 @@
       "capabilities": "Funcionalidades",
       "exploreMore": "Explore mais",
       "faq": "Perguntas frequentes",
-      "inShort": "Em resumo"
+      "inShort": "Em resumo",
+      "preview": "Prévia"
     },
     "workspace": {
       "adjacent": {

--- a/apps/landing/src/i18n/messages/sk.json
+++ b/apps/landing/src/i18n/messages/sk.json
@@ -793,7 +793,8 @@
       "capabilities": "Čo to dokáže",
       "exploreMore": "Preskúmajte ďalej",
       "faq": "Časté otázky",
-      "inShort": "V skratke"
+      "inShort": "V skratke",
+      "preview": "Náhľad"
     },
     "workspace": {
       "adjacent": {

--- a/apps/landing/src/layouts/Base.astro
+++ b/apps/landing/src/layouts/Base.astro
@@ -175,10 +175,20 @@ const structuredData = {
   stll.app — stella landing page
 */}
 <!doctype html>
-<html lang={localeConfig.hreflang} dir={localeConfig.dir} class="scroll-smooth">
+<html
+  lang={localeConfig.hreflang}
+  dir={localeConfig.dir}
+  class="scroll-smooth"
+  data-landing-current-locale={locale}
+>
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <script>
+      import { initializeLandingLocale } from "../lib/landing-locale";
+
+      initializeLandingLocale();
+    </script>
     <meta name="description" content={description} />
     <meta name="robots" content={robotsContent} />
     <title>{title}</title>

--- a/apps/landing/src/layouts/Base.astro
+++ b/apps/landing/src/layouts/Base.astro
@@ -187,7 +187,7 @@ const structuredData = {
     <script>
       import { initializeLandingLocale } from "../lib/landing-locale";
 
-      initializeLandingLocale();
+      document.addEventListener("astro:page-load", initializeLandingLocale);
     </script>
     <meta name="description" content={description} />
     <meta name="robots" content={robotsContent} />

--- a/apps/landing/src/lib/animated-gradient.test.ts
+++ b/apps/landing/src/lib/animated-gradient.test.ts
@@ -162,6 +162,7 @@ test("iOS gradients animate one original SVG surface", () => {
 
   expect(renderedChildren).toEqual([image]);
   expect(image.src).toBe("/images/gradients/hero-light.svg");
+  expect(image.style).toMatchObject({ opacity: "0.38" });
   expect(animate).toHaveBeenCalledTimes(1);
   expect(pause).toHaveBeenCalledTimes(2);
   expect(play).toHaveBeenCalledTimes(0);
@@ -174,7 +175,7 @@ test("iOS gradients animate one original SVG surface", () => {
   syncTransition();
   expect(pause).toHaveBeenCalledTimes(3);
   expect(animate.mock.calls.at(0)?.at(0)).toEqual({
-    opacity: ["0.96", "1", "0.93", "1", "0.96"],
+    opacity: ["0.365", "0.38", "0.353", "0.38", "0.365"],
     transform: [
       "translate3d(-2%, -3%, 0) scale3d(1.11, 1.05, 1) rotate(-0.6deg)",
       "translate3d(2%, 1%, 0) scale3d(1.04, 1.12, 1) rotate(0.4deg)",

--- a/apps/landing/src/lib/animated-gradient.ts
+++ b/apps/landing/src/lib/animated-gradient.ts
@@ -1,8 +1,28 @@
 const GRADIENT_LAYERS = [
-  ["gradient-light", "/images/gradients/hero-light.svg", 1],
-  ["gradient-dark", "/images/gradients/hero-dark.svg", 1],
-  ["footer-gradient-light", "/images/gradients/hero-light.svg", 1.6],
-  ["footer-gradient-dark", "/images/gradients/hero-dark.svg", 1.6],
+  {
+    containerId: "gradient-light",
+    iosIntensity: 0.38,
+    speed: 1,
+    svgUrl: "/images/gradients/hero-light.svg",
+  },
+  {
+    containerId: "gradient-dark",
+    iosIntensity: 0.3,
+    speed: 1,
+    svgUrl: "/images/gradients/hero-dark.svg",
+  },
+  {
+    containerId: "footer-gradient-light",
+    iosIntensity: 1,
+    speed: 1.6,
+    svgUrl: "/images/gradients/hero-light.svg",
+  },
+  {
+    containerId: "footer-gradient-dark",
+    iosIntensity: 1,
+    speed: 1.6,
+    svgUrl: "/images/gradients/hero-dark.svg",
+  },
 ] as const;
 
 const IOS_GRADIENT_START_TRANSFORM =
@@ -14,8 +34,13 @@ const IOS_GRADIENT_TRANSFORMS = [
   "translate3d(3%, -2%, 0) scale3d(1.06, 1.13, 1) rotate(0.5deg)",
   IOS_GRADIENT_START_TRANSFORM,
 ];
-const IOS_GRADIENT_OPACITIES = ["0.96", "1", "0.93", "1", "0.96"];
+const IOS_GRADIENT_OPACITIES = [0.96, 1, 0.93, 1, 0.96] as const;
 const IOS_GRADIENT_DURATION_MS = 20_000;
+
+const scaledIOSGradientOpacities = (intensity: number) =>
+  IOS_GRADIENT_OPACITIES.map((opacity) =>
+    String(Number((opacity * intensity).toFixed(3))),
+  );
 
 type IOSGradientAnimationState = {
   animation: Animation;
@@ -46,14 +71,14 @@ export const cleanupPageGradients = () => {
 };
 
 export const initializePageGradients = () => {
-  for (const [containerId, svgUrl, speed] of GRADIENT_LAYERS) {
+  for (const { containerId, iosIntensity, speed, svgUrl } of GRADIENT_LAYERS) {
     const container = document.querySelector<HTMLElement>(`#${containerId}`);
     if (!container || container.dataset.animatedGradient === "initialized") {
       continue;
     }
 
     container.dataset.animatedGradient = "initialized";
-    void initializeGradient(container, svgUrl, speed);
+    void initializeGradient(container, svgUrl, speed, iosIntensity);
   }
 };
 
@@ -61,9 +86,10 @@ const initializeGradient = async (
   container: HTMLElement,
   svgUrl: string,
   speed: number,
+  iosIntensity: number,
 ) => {
   if (isIOSWebKit()) {
-    initializeIOSGradient(container, svgUrl, speed);
+    initializeIOSGradient(container, svgUrl, speed, iosIntensity);
     return;
   }
 
@@ -198,6 +224,7 @@ const initializeIOSGradient = (
   container: HTMLElement,
   svgUrl: string,
   speed: number,
+  intensity: number,
 ) => {
   const image = document.createElement("img");
   image.src = svgUrl;
@@ -207,6 +234,7 @@ const initializeIOSGradient = (
   image.style.width = "100%";
   image.style.height = "100%";
   image.style.objectFit = "fill";
+  image.style.opacity = String(intensity);
   image.style.transform = IOS_GRADIENT_START_TRANSFORM;
   image.style.transformOrigin = "center";
   image.style.willChange = "transform";
@@ -219,7 +247,7 @@ const initializeIOSGradient = (
 
   const animation = image.animate(
     {
-      opacity: IOS_GRADIENT_OPACITIES,
+      opacity: scaledIOSGradientOpacities(intensity),
       transform: IOS_GRADIENT_TRANSFORMS,
     },
     {

--- a/apps/landing/src/lib/landing-locale.test.ts
+++ b/apps/landing/src/lib/landing-locale.test.ts
@@ -1,0 +1,75 @@
+import { expect, test } from "bun:test";
+
+import { resolveLandingLocaleRedirect } from "./landing-locale";
+
+const localizedRoutes = [
+  { locale: "en", path: "/product/agent" },
+  { locale: "cs", path: "/cs/product/agent" },
+  { locale: "pt-BR", path: "/pt-br/product/agent" },
+] as const;
+
+test("redirects a fresh Czech browser to the Czech localized route", () => {
+  expect(
+    resolveLandingLocaleRedirect({
+      browserLanguages: ["cs-CZ", "en-US"],
+      currentLocale: "en",
+      hash: "#demo",
+      localizedRoutes,
+      savedLocale: null,
+      search: "?source=homepage",
+    }),
+  ).toBe("/cs/product/agent?source=homepage#demo");
+});
+
+test("an explicit English choice wins over the browser language", () => {
+  expect(
+    resolveLandingLocaleRedirect({
+      browserLanguages: ["cs-CZ", "en-US"],
+      currentLocale: "en",
+      hash: "",
+      localizedRoutes,
+      savedLocale: "en",
+      search: "",
+    }),
+  ).toBeUndefined();
+});
+
+test("does not redirect source-only or already localized routes", () => {
+  const route = {
+    browserLanguages: ["cs-CZ"],
+    hash: "",
+    savedLocale: null,
+    search: "",
+  } as const;
+
+  expect(
+    resolveLandingLocaleRedirect({
+      ...route,
+      currentLocale: "en",
+      localizedRoutes: [],
+    }),
+  ).toBeUndefined();
+  expect(
+    resolveLandingLocaleRedirect({
+      ...route,
+      currentLocale: "cs",
+      localizedRoutes,
+    }),
+  ).toBeUndefined();
+});
+
+test("matches regional browser tags to a supported language", () => {
+  expect(
+    resolveLandingLocaleRedirect({
+      browserLanguages: ["pt-PT"],
+      currentLocale: "en",
+      hash: "",
+      localizedRoutes: [
+        { locale: "en", path: "/" },
+        { locale: "pt-BR", path: "/pt-br/" },
+      ],
+      savedLocale: null,
+      search: "",
+    }),
+  ).toBe("/pt-br/");
+});

--- a/apps/landing/src/lib/landing-locale.test.ts
+++ b/apps/landing/src/lib/landing-locale.test.ts
@@ -2,6 +2,8 @@ import { expect, test } from "bun:test";
 
 import { resolveLandingLocaleRedirect } from "./landing-locale";
 
+const baseLayoutPath = new URL("../layouts/Base.astro", import.meta.url);
+
 const localizedRoutes = [
   { locale: "en", path: "/product/agent" },
   { locale: "cs", path: "/cs/product/agent" },
@@ -72,4 +74,12 @@ test("matches regional browser tags to a supported language", () => {
       search: "",
     }),
   ).toBe("/pt-br/");
+});
+
+test("locale selection reruns after client-routed page loads", async () => {
+  const baseLayout = await Bun.file(baseLayoutPath).text();
+
+  expect(baseLayout).toContain(
+    'document.addEventListener("astro:page-load", initializeLandingLocale);',
+  );
 });

--- a/apps/landing/src/lib/landing-locale.ts
+++ b/apps/landing/src/lib/landing-locale.ts
@@ -67,10 +67,7 @@ export const resolveLandingLocaleRedirect = ({
   );
   const preferredRoute =
     savedRoute ?? matchBrowserRoute(browserLanguages, localizedRoutes);
-  if (
-    preferredRoute === undefined ||
-    preferredRoute.locale === currentLocale
-  ) {
+  if (preferredRoute === undefined || preferredRoute.locale === currentLocale) {
     return undefined;
   }
 
@@ -118,9 +115,7 @@ export const initializeLandingLocale = () => {
   }
 
   const browserLanguages =
-    navigator.languages.length > 0
-      ? navigator.languages
-      : [navigator.language];
+    navigator.languages.length > 0 ? navigator.languages : [navigator.language];
   const destination = resolveLandingLocaleRedirect({
     browserLanguages,
     currentLocale,

--- a/apps/landing/src/lib/landing-locale.ts
+++ b/apps/landing/src/lib/landing-locale.ts
@@ -1,0 +1,135 @@
+const LANDING_LOCALE_PREFERENCE_KEY = "stella:landing-locale";
+const DEFAULT_LANDING_LOCALE = "en";
+
+type LocalizedLandingRoute = {
+  locale: string;
+  path: string;
+};
+
+const matchBrowserRoute = (
+  browserLanguages: readonly string[],
+  localizedRoutes: readonly LocalizedLandingRoute[],
+): LocalizedLandingRoute | undefined => {
+  const normalizedRoutes = localizedRoutes.map((route) => ({
+    route,
+    tag: route.locale.toLowerCase(),
+  }));
+
+  for (const language of browserLanguages) {
+    const normalizedLanguage = language.trim().toLowerCase();
+    const exact = normalizedRoutes.find(
+      ({ tag }) => tag === normalizedLanguage,
+    );
+    if (exact !== undefined) {
+      return exact.route;
+    }
+
+    const primaryLanguage = normalizedLanguage.split("-").at(0);
+    const regionalMatch = normalizedRoutes.find(
+      ({ tag }) => tag.split("-").at(0) === primaryLanguage,
+    );
+    if (regionalMatch !== undefined) {
+      return regionalMatch.route;
+    }
+  }
+
+  return localizedRoutes.find(
+    ({ locale }) => locale === DEFAULT_LANDING_LOCALE,
+  );
+};
+
+type LandingLocaleRedirectOptions = {
+  browserLanguages: readonly string[];
+  currentLocale: string;
+  hash: string;
+  localizedRoutes: readonly LocalizedLandingRoute[];
+  savedLocale: string | null;
+  search: string;
+};
+
+export const resolveLandingLocaleRedirect = ({
+  browserLanguages,
+  currentLocale,
+  hash,
+  localizedRoutes,
+  savedLocale,
+  search,
+}: LandingLocaleRedirectOptions): string | undefined => {
+  if (
+    localizedRoutes.length === 0 ||
+    currentLocale !== DEFAULT_LANDING_LOCALE
+  ) {
+    return undefined;
+  }
+
+  const savedRoute = localizedRoutes.find(
+    ({ locale }) => locale === savedLocale,
+  );
+  const preferredRoute =
+    savedRoute ?? matchBrowserRoute(browserLanguages, localizedRoutes);
+  if (
+    preferredRoute === undefined ||
+    preferredRoute.locale === currentLocale
+  ) {
+    return undefined;
+  }
+
+  return `${preferredRoute.path}${search}${hash}`;
+};
+
+let isPreferenceListenerRegistered = false;
+
+const persistLandingLocaleChoice = (event: MouseEvent) => {
+  if (!(event.target instanceof Element)) {
+    return;
+  }
+
+  const link = event.target.closest<HTMLElement>(
+    "[data-landing-locale-choice]",
+  );
+  const locale = link?.dataset.landingLocaleChoice;
+  if (locale !== undefined) {
+    window.localStorage.setItem(LANDING_LOCALE_PREFERENCE_KEY, locale);
+  }
+};
+
+const getLocalizedRoutes = (): LocalizedLandingRoute[] =>
+  [
+    ...document.querySelectorAll<HTMLLinkElement>(
+      'link[rel="alternate"][hreflang]',
+    ),
+  ].flatMap((link) => {
+    const locale = link.hreflang;
+    if (locale === "" || locale === "x-default") {
+      return [];
+    }
+    return [{ locale, path: new URL(link.href).pathname }];
+  });
+
+export const initializeLandingLocale = () => {
+  if (!isPreferenceListenerRegistered) {
+    document.addEventListener("click", persistLandingLocaleChoice);
+    isPreferenceListenerRegistered = true;
+  }
+
+  const currentLocale = document.documentElement.dataset.landingCurrentLocale;
+  if (currentLocale === undefined) {
+    return;
+  }
+
+  const browserLanguages =
+    navigator.languages.length > 0
+      ? navigator.languages
+      : [navigator.language];
+  const destination = resolveLandingLocaleRedirect({
+    browserLanguages,
+    currentLocale,
+    hash: window.location.hash,
+    localizedRoutes: getLocalizedRoutes(),
+    savedLocale: window.localStorage.getItem(LANDING_LOCALE_PREFERENCE_KEY),
+    search: window.location.search,
+  });
+  if (destination !== undefined) {
+    window.location.replace(destination);
+  }
+};

--- a/apps/landing/src/lib/theme-images.ts
+++ b/apps/landing/src/lib/theme-images.ts
@@ -3,6 +3,7 @@ const LOAD_THEME_IMAGES_EVENT = "stella:load-theme-images";
 
 let themeObserver: MutationObserver | undefined;
 let visibilityObserver: IntersectionObserver | undefined;
+let mediaQueryCleanups: (() => void)[] = [];
 let loadEventBound = false;
 
 export const initializeThemeImages = () => {
@@ -31,6 +32,31 @@ export const initializeThemeImages = () => {
     if (!Object.hasOwn(image.dataset, "themeImageLoaded")) {
       visibilityObserver.observe(image);
     }
+  }
+
+  for (const cleanup of mediaQueryCleanups) {
+    cleanup();
+  }
+  mediaQueryCleanups = [];
+  for (const image of document.querySelectorAll<HTMLImageElement>(
+    `${THEME_IMAGE_SELECTOR}[data-theme-image-media]`,
+  )) {
+    const media = image.dataset.themeImageMedia;
+    if (media === undefined) {
+      continue;
+    }
+
+    const query = window.matchMedia(media);
+    const loadWhenMatched = () => {
+      if (query.matches) {
+        loadThemeImage(image);
+      }
+    };
+    query.addEventListener("change", loadWhenMatched);
+    mediaQueryCleanups.push(() => {
+      query.removeEventListener("change", loadWhenMatched);
+    });
+    loadWhenMatched();
   }
 
   themeObserver?.disconnect();


### PR DESCRIPTION
## Summary

- match the iOS hero gradient intensity to the footer while retaining composited animation
- give the CLI product hero a readable stacked mobile composition
- select translated landing routes from browser language preferences and remember explicit choices
- cover mobile gradient and locale resolution regressions