### PR TITLE
feat(sk-courts): report the source's own decision total

### DIFF
--- a/apps/api/src/handlers/case-law/ingestion/adapters/sk-courts.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/sk-courts.ts
@@ -311,6 +311,31 @@ export const skCourtsAdapter: SourceAdapter = {
   // 30 min cycle fits ~70 pages = ~7000 decisions per cursor persist.
   maxCycleMs: 30 * 60 * 1000,
 
+  /**
+   * The list endpoint reports `numFound` for the whole collection, so one
+   * minimal request measures the source. Without it this corpus — the
+   * largest we hold — has no completeness signal at all.
+   */
+  async getTotalCount(signal) {
+    const response = await fetchWithTimeout(
+      `${BASE_URL}?${new URLSearchParams({ page: "0", size: "1" }).toString()}`,
+      {
+        signal,
+        headers: { Accept: "application/json" },
+        timeoutMs: ADAPTER_TIMEOUT.REQUEST,
+      },
+    );
+    if (!response.ok) {
+      return null;
+    }
+    const json: unknown = await response.json();
+    if (!isRecord(json)) {
+      return null;
+    }
+    const total = json["numFound"];
+    return typeof total === "number" && total > 0 ? total : null;
+  },
+
   fetchPage: createPagePaginatedFetch<SkApiResponse>({
     adapterKey: ADAPTER_KEYS.SK_COURTS,
     pageSize: PAGE_SIZE,


### PR DESCRIPTION
`getTotalCount` was unimplemented for sk-courts, so the largest corpus we hold had no completeness signal (rule 15 in the ingestion guide). The list endpoint already returns a collection-wide result count; one minimal request reads it.

What the measurement shows:

| | |
|---|---|
| decisions the source publishes | 4,672,780 |
| decisions we hold | 807,847 |
| coverage | 17.3% |

Per-court, from the source's own facets: Okresný súd 4,081,262 · Krajský 422,612 · Mestský 112,861 · Najvyšší súd SR 35,216 · Správny 13,345 · Špecializovaný 2,151.

This PR adds only the measurement. Closing the gap is a traversal change: the adapter walks a numeric offset over a list sorted newest-first, which cannot converge while the list grows. That is a separate, larger change.