### PR TITLE
feat(api): unify document version persistence

### DIFF
--- a/apps/api/drizzle/20260731080000_pending_upload_buffer_intent_recovery_index/migration.sql
+++ b/apps/api/drizzle/20260731080000_pending_upload_buffer_intent_recovery_index/migration.sql
@@ -21,7 +21,7 @@ DROP INDEX CONCURRENTLY IF EXISTS "pending_uploads_buffer_intent_recovery_idx";
 -- squawk-ignore prefer-robust-stmts
 CREATE INDEX CONCURRENTLY "pending_uploads_buffer_intent_recovery_idx"
   ON "pending_uploads" ("claimed_at", "id")
-  WHERE "status" = 'scanning'
+  WHERE "status" IN ('scanning', 'failed')
     AND "purpose" IN ('entity_create', 'entity_version')
     AND ("purpose_data"->>'reservedFileId') IS NOT NULL;
 --> statement-breakpoint

--- a/apps/api/drizzle/20260731080000_pending_upload_buffer_intent_recovery_index/migration.sql
+++ b/apps/api/drizzle/20260731080000_pending_upload_buffer_intent_recovery_index/migration.sql
@@ -1,0 +1,33 @@
+SET lock_timeout = '1s';--> statement-breakpoint
+SET statement_timeout = '5s';--> statement-breakpoint
+
+-- Drizzle wraps pending migrations in one transaction, while PostgreSQL
+-- requires CREATE INDEX CONCURRENTLY to run outside a transaction block.
+-- Split the migrator transaction, lift the timeouts for the concurrent build,
+-- then restore and reopen a transaction for Drizzle's migration row.
+-- squawk-ignore transaction-nesting
+COMMIT;
+--> statement-breakpoint
+SET statement_timeout = 0;
+--> statement-breakpoint
+SET lock_timeout = 0;
+--> statement-breakpoint
+
+-- stella-migration-safety: reviewed destructive-change - drops only this
+-- migration's own index by name before recreating it. A cancelled concurrent
+-- build leaves an INVALID index behind, which IF NOT EXISTS would preserve.
+DROP INDEX CONCURRENTLY IF EXISTS "pending_uploads_buffer_intent_recovery_idx";
+--> statement-breakpoint
+-- squawk-ignore prefer-robust-stmts
+CREATE INDEX CONCURRENTLY "pending_uploads_buffer_intent_recovery_idx"
+  ON "pending_uploads" ("claimed_at", "id")
+  WHERE "status" = 'scanning'
+    AND "purpose" IN ('entity_create', 'entity_version')
+    AND ("purpose_data"->>'reservedFileId') IS NOT NULL;
+--> statement-breakpoint
+SET statement_timeout = '5s';
+--> statement-breakpoint
+SET lock_timeout = '1s';
+--> statement-breakpoint
+-- squawk-ignore transaction-nesting, ban-uncommitted-transaction
+BEGIN;

--- a/apps/api/drizzle/20260731103000_buffer_object_cleanup_intents/migration.sql
+++ b/apps/api/drizzle/20260731103000_buffer_object_cleanup_intents/migration.sql
@@ -1,0 +1,68 @@
+SET LOCAL lock_timeout = '1s';--> statement-breakpoint
+SET LOCAL statement_timeout = '5s';--> statement-breakpoint
+
+CREATE TABLE "buffer_object_cleanup_intents" (
+  "id" uuid PRIMARY KEY NOT NULL,
+  "organization_id" varchar(128) NOT NULL,
+  "workspace_id" uuid NOT NULL,
+  "object_key" text NOT NULL,
+  "attempt_count" integer DEFAULT 0 NOT NULL,
+  "next_attempt_at" timestamptz DEFAULT now() NOT NULL,
+  "created_at" timestamptz DEFAULT now() NOT NULL,
+  CONSTRAINT "buffer_object_cleanup_attempt_count_nonnegative_check"
+    CHECK ("attempt_count" >= 0)
+);
+--> statement-breakpoint
+CREATE INDEX "buffer_object_cleanup_schedule_idx"
+  ON "buffer_object_cleanup_intents" ("next_attempt_at", "id");
+--> statement-breakpoint
+-- Tombstones contain storage keys and are root-worker-readable only. Scoped
+-- lifecycle deletion may insert one for its active tenant; the original scoped
+-- writer may delete it after its PUT settles and exact-key cleanup succeeds.
+ALTER TABLE "buffer_object_cleanup_intents" ENABLE ROW LEVEL SECURITY;
+--> statement-breakpoint
+REVOKE ALL PRIVILEGES ON TABLE "buffer_object_cleanup_intents" FROM stella;
+--> statement-breakpoint
+GRANT INSERT, DELETE ON TABLE "buffer_object_cleanup_intents" TO stella;
+--> statement-breakpoint
+CREATE POLICY "buffer_object_cleanup_insert"
+  ON "buffer_object_cleanup_intents"
+  AS PERMISSIVE FOR INSERT TO stella
+  WITH CHECK ((CASE
+    WHEN workspace_id = ANY(
+      COALESCE(
+        NULLIF(
+          (SELECT pg_catalog.current_setting('app.workspace_ids', true)),
+          ''
+        )::uuid[],
+        ARRAY[]::uuid[]
+      )
+    ) THEN true
+    ELSE workspace_id IN (
+      SELECT aw.authorized_workspace_id
+      FROM public.stella_authorized_workspaces aw
+    )
+  END) AND organization_id = (SELECT current_setting(
+    'app.organization_id', true
+  )));
+--> statement-breakpoint
+CREATE POLICY "buffer_object_cleanup_delete"
+  ON "buffer_object_cleanup_intents"
+  AS PERMISSIVE FOR DELETE TO stella
+  USING ((CASE
+    WHEN workspace_id = ANY(
+      COALESCE(
+        NULLIF(
+          (SELECT pg_catalog.current_setting('app.workspace_ids', true)),
+          ''
+        )::uuid[],
+        ARRAY[]::uuid[]
+      )
+    ) THEN true
+    ELSE workspace_id IN (
+      SELECT aw.authorized_workspace_id
+      FROM public.stella_authorized_workspaces aw
+    )
+  END) AND organization_id = (SELECT current_setting(
+    'app.organization_id', true
+  )));

--- a/apps/api/drizzle/20260731103000_buffer_object_cleanup_intents/migration.sql
+++ b/apps/api/drizzle/20260731103000_buffer_object_cleanup_intents/migration.sql
@@ -25,6 +25,10 @@ REVOKE ALL PRIVILEGES ON TABLE "buffer_object_cleanup_intents" FROM stella;
 --> statement-breakpoint
 GRANT INSERT, DELETE ON TABLE "buffer_object_cleanup_intents" TO stella;
 --> statement-breakpoint
+-- The writer's DELETE predicate references only the opaque intent id. Grant
+-- column-level read rather than exposing retained tenant storage keys.
+GRANT SELECT ("id") ON TABLE "buffer_object_cleanup_intents" TO stella;
+--> statement-breakpoint
 CREATE POLICY "buffer_object_cleanup_insert"
   ON "buffer_object_cleanup_intents"
   AS PERMISSIVE FOR INSERT TO stella

--- a/apps/api/src/db/schema/entities.test.ts
+++ b/apps/api/src/db/schema/entities.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { getTableConfig, PgDialect } from "drizzle-orm/pg-core";
 
-import { pendingUploads } from "@/api/db/schema";
+import { bufferObjectCleanupIntents, pendingUploads } from "@/api/db/schema";
 
 describe("pending upload recovery indexes", () => {
   test("the global stale-buffer sweep starts from claimed_at", () => {
@@ -24,5 +24,21 @@ describe("pending upload recovery indexes", () => {
     expect(new PgDialect().sqlToQuery(recoveryPredicate).sql).toContain(
       "IN ('scanning', 'failed')",
     );
+  });
+});
+
+describe("buffer object cleanup tombstones", () => {
+  test("survive owner deletion and have a bounded scheduler index", () => {
+    const config = getTableConfig(bufferObjectCleanupIntents);
+
+    expect(config.foreignKeys).toHaveLength(0);
+    const scheduleIndex = config.indexes.find(
+      (index) => index.config.name === "buffer_object_cleanup_schedule_idx",
+    );
+    expect(
+      scheduleIndex?.config.columns.map((column) =>
+        "name" in column ? column.name : undefined,
+      ),
+    ).toEqual(["next_attempt_at", "id"]);
   });
 });

--- a/apps/api/src/db/schema/entities.test.ts
+++ b/apps/api/src/db/schema/entities.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { getTableConfig } from "drizzle-orm/pg-core";
+import { getTableConfig, PgDialect } from "drizzle-orm/pg-core";
 
 import { pendingUploads } from "@/api/db/schema";
 
@@ -16,6 +16,13 @@ describe("pending upload recovery indexes", () => {
         "name" in column ? column.name : undefined,
       ),
     ).toEqual(["claimed_at", "id"]);
-    expect(recoveryIndex?.config.where).toBeDefined();
+    const recoveryPredicate = recoveryIndex?.config.where;
+    expect(recoveryPredicate).toBeDefined();
+    if (!recoveryPredicate) {
+      return;
+    }
+    expect(new PgDialect().sqlToQuery(recoveryPredicate).sql).toContain(
+      "IN ('scanning', 'failed')",
+    );
   });
 });

--- a/apps/api/src/db/schema/entities.test.ts
+++ b/apps/api/src/db/schema/entities.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from "bun:test";
+import { getTableConfig } from "drizzle-orm/pg-core";
+
+import { pendingUploads } from "@/api/db/schema";
+
+describe("pending upload recovery indexes", () => {
+  test("the global stale-buffer sweep starts from claimed_at", () => {
+    const recoveryIndex = getTableConfig(pendingUploads).indexes.find(
+      (index) =>
+        index.config.name === "pending_uploads_buffer_intent_recovery_idx",
+    );
+
+    expect(recoveryIndex).toBeDefined();
+    expect(
+      recoveryIndex?.config.columns.map((column) =>
+        "name" in column ? column.name : undefined,
+      ),
+    ).toEqual(["claimed_at", "id"]);
+    expect(recoveryIndex?.config.where).toBeDefined();
+  });
+});

--- a/apps/api/src/db/schema/entities.ts
+++ b/apps/api/src/db/schema/entities.ts
@@ -702,6 +702,11 @@ export const PENDING_UPLOAD_STATUSES = [
   "failed",
 ] as const;
 
+export const PENDING_UPLOAD_RECOVERABLE_STATUSES = [
+  "scanning",
+  "failed",
+] as const satisfies readonly (typeof PENDING_UPLOAD_STATUSES)[number][];
+
 /**
  * Each upload purpose drives a different finalize transaction (entity
  * vs. version vs. skill...). The discriminator lives in its own column
@@ -817,7 +822,7 @@ export const pendingUploads = p.pgTable(
       .index("pending_uploads_buffer_intent_recovery_idx")
       .on(table.claimedAt, table.id)
       .where(
-        sql`${table.status} = 'scanning'
+        sql`${table.status} IN ('scanning', 'failed')
           AND ${table.purpose} IN ('entity_create', 'entity_version')
           AND ${table.purposeData}->>'reservedFileId' IS NOT NULL`,
       ),

--- a/apps/api/src/db/schema/entities.ts
+++ b/apps/api/src/db/schema/entities.ts
@@ -719,10 +719,22 @@ export type PendingUploadPurposeData =
   | {
       type: "entity_create";
       propertyId: SafeId<"property">;
+      /**
+       * Final object id reserved by trusted server-side writers. Persisting it
+       * before S3 publication lets the bounded reconciler derive and remove a
+       * final-key object left behind by a hard process death.
+       */
+      reservedFileId?: string;
     }
   | {
       type: "entity_version";
       entityId: SafeId<"entity">;
+      /**
+       * Final object id reserved by trusted server-side writers. Persisting it
+       * before S3 publication lets the bounded reconciler derive and remove a
+       * final-key object left behind by a hard process death.
+       */
+      reservedFileId?: string;
     }
   | {
       type: "agent_skill";
@@ -801,6 +813,14 @@ export const pendingUploads = p.pgTable(
     p
       .index("pending_uploads_org_created_idx")
       .on(table.organizationId, table.createdAt),
+    p
+      .index("pending_uploads_buffer_intent_recovery_idx")
+      .on(table.claimedAt, table.id)
+      .where(
+        sql`${table.status} = 'scanning'
+          AND ${table.purpose} IN ('entity_create', 'entity_version')
+          AND ${table.purposeData}->>'reservedFileId' IS NOT NULL`,
+      ),
     ...wsPolicies(),
   ],
 );

--- a/apps/api/src/db/schema/entities.ts
+++ b/apps/api/src/db/schema/entities.ts
@@ -830,6 +830,47 @@ export const pendingUploads = p.pgTable(
   ],
 );
 
+/**
+ * Durable tombstones for server-generated object writes interrupted by a
+ * workspace or account deletion. They intentionally have no foreign keys:
+ * recovery must survive both workspace cascades and user cleanup until the
+ * original writer confirms that it can no longer publish the reserved key.
+ */
+export const bufferObjectCleanupIntents = p.pgTable(
+  "buffer_object_cleanup_intents",
+  {
+    id: pUuid<"pendingUpload">().primaryKey(),
+    organizationId: safeOrganizationId("organization_id").notNull(),
+    workspaceId: safeWorkspaceId("workspace_id").notNull(),
+    objectKey: p.text("object_key").notNull(),
+    attemptCount: p.integer("attempt_count").notNull().default(0),
+    nextAttemptAt: timestamptz("next_attempt_at").notNull().defaultNow(),
+    createdAt: timestamptz("created_at").notNull().defaultNow(),
+  },
+  (table) => [
+    p
+      .index("buffer_object_cleanup_schedule_idx")
+      .on(table.nextAttemptAt, table.id),
+    p.check(
+      "buffer_object_cleanup_attempt_count_nonnegative_check",
+      sql`${table.attemptCount} >= 0`,
+    ),
+    // Lifecycle deletion may transfer the intent through its scoped
+    // transaction. The original scoped writer may remove it only after its
+    // PUT settles and exact-key cleanup succeeds; retry reads stay root-only.
+    p.pgPolicy("buffer_object_cleanup_insert", {
+      for: "insert",
+      to: stella,
+      withCheck: sql`${workspaceCheck} AND ${organizationCheck}`,
+    }),
+    p.pgPolicy("buffer_object_cleanup_delete", {
+      for: "delete",
+      to: stella,
+      using: sql`${workspaceCheck} AND ${organizationCheck}`,
+    }),
+  ],
+);
+
 export const fields = p.pgTable(
   "fields",
   {

--- a/apps/api/src/handlers/chat/send-message-side-effects.test.ts
+++ b/apps/api/src/handlers/chat/send-message-side-effects.test.ts
@@ -10,8 +10,11 @@ import { toSafeId } from "@/api/lib/branded-types";
 import { createScopedDbMock } from "@/api/tests/scoped-db-mock";
 
 const s3Delete = mock(async () => undefined);
+const realS3 = await import("@/api/lib/s3");
 
 void mock.module("@/api/lib/s3", () => ({
+  ...realS3,
+  deleteS3ObjectWithSignal: s3Delete,
   getS3: () => ({ delete: s3Delete }),
 }));
 
@@ -147,7 +150,10 @@ describe("send-message side-effect rollback", () => {
     });
 
     expect(Result.isOk(result)).toBe(true);
-    expect(s3Delete).toHaveBeenCalledWith(uploadedFile.s3Key);
+    expect(s3Delete).toHaveBeenCalledWith(
+      uploadedFile.s3Key,
+      expect.any(AbortSignal),
+    );
     expect(deleteRows).toHaveBeenCalledTimes(1);
     expect(deleteRowsWhere).toHaveBeenCalledTimes(1);
     expect(recordAuditEvent).toHaveBeenCalledWith(expect.anything(), [

--- a/apps/api/src/handlers/chat/tools/create-workspace-document-tools.test.ts
+++ b/apps/api/src/handlers/chat/tools/create-workspace-document-tools.test.ts
@@ -21,10 +21,12 @@ const enqueueImageThumbnailOrMarkFailedMock = mock(async () => {});
 const enqueuePdfDerivativeOrMarkFailedMock = mock(async () => {});
 
 void mock.module("@/api/lib/s3", () => ({
+  deleteS3ObjectWithSignal: s3DeleteMock,
   getS3: () => ({
     write: s3WriteMock,
     delete: s3DeleteMock,
   }),
+  putS3ObjectWithSignal: s3WriteMock,
 }));
 
 void mock.module("@/api/lib/search/process-extraction", () => ({
@@ -154,7 +156,7 @@ describe("createCreateWorkspaceDocumentTools", () => {
       select: () => ({
         from: () => ({
           where: () => ({
-            limit: () => ({ for: async () => [] }),
+            limit: () => ({ for: async () => [{ status: "active" }] }),
           }),
         }),
       }),

--- a/apps/api/src/handlers/chat/tools/create-workspace-document-tools.test.ts
+++ b/apps/api/src/handlers/chat/tools/create-workspace-document-tools.test.ts
@@ -7,6 +7,7 @@ import {
   entities,
   entityVersions,
   fields,
+  pendingUploads,
 } from "@/api/db/schema";
 import { createChatRefRegistry } from "@/api/handlers/chat/tools/execute/ref-registry";
 import { toSafeId } from "@/api/lib/branded-types";
@@ -150,14 +151,24 @@ describe("createCreateWorkspaceDocumentTools", () => {
         },
       },
       $count: async () => 0,
+      select: () => ({
+        from: () => ({
+          where: () => ({
+            limit: () => ({ for: async () => [] }),
+          }),
+        }),
+      }),
       insert: (table: unknown) => ({
-        values: (values: { name?: string }) => {
+        values: (values: { id?: string; name?: string }) => {
           if (table === documentCounters) {
             return {
               onConflictDoUpdate: () => ({
                 returning: async () => [{ lastValue: 1 }],
               }),
             };
+          }
+          if (table === pendingUploads) {
+            return { returning: async () => [{ id: values.id }] };
           }
           if (table === entities) {
             insertedFileName = values.name;
@@ -172,7 +183,14 @@ describe("createCreateWorkspaceDocumentTools", () => {
           return undefined;
         },
       }),
-      update: () => ({ set: () => ({ where: async () => {} }) }),
+      update: (table: unknown) => ({
+        set: () => ({
+          where: () =>
+            table === pendingUploads
+              ? { returning: async () => [{ id: "intent_1" }] }
+              : undefined,
+        }),
+      }),
     };
     return { tx, getInsertedFileName: () => insertedFileName };
   };

--- a/apps/api/src/handlers/chat/tools/create-workspace-document-tools.ts
+++ b/apps/api/src/handlers/chat/tools/create-workspace-document-tools.ts
@@ -76,11 +76,17 @@ type CreateWorkspaceDocumentToolsProps = {
 
 const toChatToolError = (
   error:
+    | { _tag: "DocumentTooLargeError" }
     | { _tag: "EntityLimitError" }
     | { _tag: "InvalidParentError" }
     | { _tag: "MissingFilePropertyError" },
 ): ChatToolError => {
   switch (error._tag) {
+    case "DocumentTooLargeError":
+      return new ChatToolError({
+        message:
+          "The generated document exceeds stella's document size limit, so it could not be created.",
+      });
     case "EntityLimitError":
       return new ChatToolError({
         message:

--- a/apps/api/src/handlers/entities/create-blank-document-service.ts
+++ b/apps/api/src/handlers/entities/create-blank-document-service.ts
@@ -55,11 +55,17 @@ export const createBlankDocument = async ({
 
 const toHandlerError = (
   error:
+    | { _tag: "DocumentTooLargeError" }
     | { _tag: "EntityLimitError" }
     | { _tag: "InvalidParentError"; message: string }
     | { _tag: "MissingFilePropertyError" },
 ): HandlerError => {
   switch (error._tag) {
+    case "DocumentTooLargeError":
+      return new HandlerError({
+        status: 413,
+        message: "The generated document exceeds the document size limit.",
+      });
     case "EntityLimitError":
       return new HandlerError({
         status: 409,

--- a/apps/api/src/handlers/entities/create-from-buffer.test.ts
+++ b/apps/api/src/handlers/entities/create-from-buffer.test.ts
@@ -27,9 +27,9 @@ const broadcastMock = mock();
 let intentStatuses: string[] = [];
 
 void mock.module("@/api/lib/s3", () => ({
+  deleteS3ObjectWithSignal: s3DeleteMock,
   getS3: () => ({
     write: s3WriteMock,
-    delete: s3DeleteMock,
   }),
 }));
 

--- a/apps/api/src/handlers/entities/create-from-buffer.test.ts
+++ b/apps/api/src/handlers/entities/create-from-buffer.test.ts
@@ -24,15 +24,6 @@ const enqueuePdfDerivativeMock = mock(async () => {});
 const enqueuePdfDerivativeOrMarkFailedMock = mock(async () => {});
 const broadcastMock = mock();
 let intentStatuses: string[] = [];
-let staleIntentRows: {
-  declaredMime: string;
-  id: ReturnType<typeof toSafeId<"pendingUpload">>;
-  purposeData: {
-    type: "entity_create";
-    propertyId: typeof propertyId;
-    reservedFileId: string;
-  };
-}[] = [];
 
 void mock.module("@/api/lib/s3", () => ({
   getS3: () => ({
@@ -80,22 +71,7 @@ const withIntentPersistence = (base: IntentPersistenceBase) => {
   const baseUpdate = base.update;
   return {
     ...base,
-    select: (selection: unknown) => {
-      if (
-        typeof selection === "object" &&
-        selection !== null &&
-        "purposeData" in selection
-      ) {
-        return {
-          from: () => ({
-            where: () => ({
-              limit: () => ({ for: async () => staleIntentRows }),
-            }),
-          }),
-        };
-      }
-      return baseSelect?.(selection);
-    },
+    select: (selection: unknown) => baseSelect?.(selection),
     insert: (table: unknown) => {
       if (table === pendingUploads) {
         return {
@@ -138,7 +114,6 @@ describe("createEntityFromBuffer", () => {
     processExtractionMock.mockClear();
     broadcastMock.mockClear();
     intentStatuses = [];
-    staleIntentRows = [];
   });
 
   test("rejects oversized documents before database or object-storage work", async () => {
@@ -318,7 +293,7 @@ describe("createEntityFromBuffer", () => {
         }),
       );
     }
-    expect(getCallCount()).toBe(5);
+    expect(getCallCount()).toBe(4);
     expect(locks).toEqual(["update"]);
     expect(s3WriteMock).toHaveBeenCalledTimes(1);
     expect(s3DeleteMock).toHaveBeenCalledTimes(1);
@@ -483,7 +458,7 @@ describe("createEntityFromBuffer", () => {
       async <T>(run: (transaction: Transaction) => Promise<T>) => {
         callCount += 1;
         const value = await run(asTestRaw<Transaction>(tx));
-        if (callCount === 4) {
+        if (callCount === 3) {
           throw commitError;
         }
         return value;

--- a/apps/api/src/handlers/entities/create-from-buffer.test.ts
+++ b/apps/api/src/handlers/entities/create-from-buffer.test.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 import type { Transaction } from "@/api/db/root";
 import type { ScopedDb } from "@/api/db/safe-db";
 import {
+  bufferObjectCleanupIntents,
   documentCounters,
   entities,
   entityVersions,
@@ -60,6 +61,7 @@ const parentId = toSafeId<"entity">("00000000-0000-0000-0000-000000000005");
 
 type IntentPersistenceBase = {
   [key: string]: unknown;
+  delete?: (table: unknown) => unknown;
   insert?: (table: unknown) => unknown;
   select?: (selection: unknown) => unknown;
   update?: (table: unknown) => unknown;
@@ -67,11 +69,18 @@ type IntentPersistenceBase = {
 
 const withIntentPersistence = (base: IntentPersistenceBase) => {
   const baseSelect = base.select;
+  const baseDelete = base.delete;
   const baseInsert = base.insert;
   const baseUpdate = base.update;
   return {
     ...base,
     select: (selection: unknown) => baseSelect?.(selection),
+    delete: (table: unknown) => {
+      if (table === bufferObjectCleanupIntents) {
+        return { where: async () => undefined };
+      }
+      return baseDelete?.(table);
+    },
     insert: (table: unknown) => {
       if (table === pendingUploads) {
         return {

--- a/apps/api/src/handlers/entities/create-from-buffer.test.ts
+++ b/apps/api/src/handlers/entities/create-from-buffer.test.ts
@@ -29,9 +29,7 @@ let intentStatuses: string[] = [];
 
 void mock.module("@/api/lib/s3", () => ({
   deleteS3ObjectWithSignal: s3DeleteMock,
-  getS3: () => ({
-    write: s3WriteMock,
-  }),
+  putS3ObjectWithSignal: s3WriteMock,
 }));
 
 void mock.module("@/api/lib/search/process-extraction", () => ({

--- a/apps/api/src/handlers/entities/create-from-buffer.test.ts
+++ b/apps/api/src/handlers/entities/create-from-buffer.test.ts
@@ -1,13 +1,18 @@
 import { Result } from "better-result";
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
+import type { Transaction } from "@/api/db/root";
+import type { ScopedDb } from "@/api/db/safe-db";
 import {
   documentCounters,
   entities,
   entityVersions,
   fields,
+  pendingUploads,
 } from "@/api/db/schema";
 import { toSafeId } from "@/api/lib/branded-types";
+import { FILE_SIZE_LIMIT_BYTES } from "@/api/lib/limits";
+import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
 import { createScopedDbMock } from "@/api/tests/scoped-db-mock";
 
 const s3WriteMock = mock(async () => {});
@@ -17,6 +22,17 @@ const enqueueImageThumbnailMock = mock(async () => {});
 const enqueueImageThumbnailOrMarkFailedMock = mock(async () => {});
 const enqueuePdfDerivativeMock = mock(async () => {});
 const enqueuePdfDerivativeOrMarkFailedMock = mock(async () => {});
+const broadcastMock = mock();
+let intentStatuses: string[] = [];
+let staleIntentRows: {
+  declaredMime: string;
+  id: ReturnType<typeof toSafeId<"pendingUpload">>;
+  purposeData: {
+    type: "entity_create";
+    propertyId: typeof propertyId;
+    reservedFileId: string;
+  };
+}[] = [];
 
 void mock.module("@/api/lib/s3", () => ({
   getS3: () => ({
@@ -37,6 +53,8 @@ void mock.module("@/api/lib/file-derivative-queue", () => ({
   initFileDerivativeWorker: mock(() => undefined),
 }));
 
+void mock.module("@/api/lib/sse", () => ({ broadcast: broadcastMock }));
+
 const { createEntityFromBuffer } = await import("./create-from-buffer");
 
 const organizationId = toSafeId<"organization">(
@@ -49,10 +67,107 @@ const userId = toSafeId<"user">("00000000-0000-0000-0000-000000000003");
 const propertyId = toSafeId<"property">("00000000-0000-0000-0000-000000000004");
 const parentId = toSafeId<"entity">("00000000-0000-0000-0000-000000000005");
 
+type IntentPersistenceBase = {
+  [key: string]: unknown;
+  insert?: (table: unknown) => unknown;
+  select?: (selection: unknown) => unknown;
+  update?: (table: unknown) => unknown;
+};
+
+const withIntentPersistence = (base: IntentPersistenceBase) => {
+  const baseSelect = base.select;
+  const baseInsert = base.insert;
+  const baseUpdate = base.update;
+  return {
+    ...base,
+    select: (selection: unknown) => {
+      if (
+        typeof selection === "object" &&
+        selection !== null &&
+        "purposeData" in selection
+      ) {
+        return {
+          from: () => ({
+            where: () => ({
+              limit: () => ({ for: async () => staleIntentRows }),
+            }),
+          }),
+        };
+      }
+      return baseSelect?.(selection);
+    },
+    insert: (table: unknown) => {
+      if (table === pendingUploads) {
+        return {
+          values: (values: { id: string; status?: string }) => {
+            if (values.status) {
+              intentStatuses.push(values.status);
+            }
+            return { returning: async () => [{ id: values.id }] };
+          },
+        };
+      }
+      return baseInsert?.(table);
+    },
+    update: (table: unknown) => {
+      if (table === pendingUploads) {
+        return {
+          set: (values: { status?: string }) => {
+            if (values.status) {
+              intentStatuses.push(values.status);
+            }
+            return {
+              where: () => ({
+                returning: async () => [{ id: "intent_1" }],
+              }),
+            };
+          },
+        };
+      }
+      return baseUpdate?.(table);
+    },
+  };
+};
+
 describe("createEntityFromBuffer", () => {
   beforeEach(() => {
-    s3WriteMock.mockClear();
-    s3DeleteMock.mockClear();
+    s3WriteMock.mockReset();
+    s3WriteMock.mockResolvedValue(undefined);
+    s3DeleteMock.mockReset();
+    s3DeleteMock.mockResolvedValue(undefined);
+    processExtractionMock.mockClear();
+    broadcastMock.mockClear();
+    intentStatuses = [];
+    staleIntentRows = [];
+  });
+
+  test("rejects oversized documents before database or object-storage work", async () => {
+    const { getCallCount, scopedDb } = createScopedDbMock({});
+
+    const result = await createEntityFromBuffer({
+      scopedDb,
+      organizationId,
+      workspaceId,
+      userId,
+      recordAuditEvent: async () => undefined,
+      buffer: new Uint8Array(FILE_SIZE_LIMIT_BYTES.document + 1),
+      fileName: "Oversized Agreement.docx",
+      mimeType:
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    });
+
+    expect(Result.isError(result)).toBe(true);
+    if (Result.isError(result)) {
+      expect(result.error).toEqual(
+        expect.objectContaining({
+          _tag: "DocumentTooLargeError",
+          message: `Document exceeds the ${FILE_SIZE_LIMIT_BYTES.document}-byte size limit`,
+        }),
+      );
+    }
+    expect(getCallCount()).toBe(0);
+    expect(s3WriteMock).not.toHaveBeenCalled();
+    expect(s3DeleteMock).not.toHaveBeenCalled();
   });
 
   test("writes an entity create audit log with the DB insert", async () => {
@@ -107,7 +222,7 @@ describe("createEntityFromBuffer", () => {
         }),
       }),
     };
-    const { scopedDb } = createScopedDbMock(tx);
+    const { scopedDb } = createScopedDbMock(withIntentPersistence(tx));
 
     const recordedAuditEvents: unknown[] = [];
     const result = await createEntityFromBuffer({
@@ -149,6 +264,10 @@ describe("createEntityFromBuffer", () => {
     expect(insertedEntity).toEqual(
       expect.objectContaining({ parentId, workspaceId }),
     );
+    expect(broadcastMock).toHaveBeenCalledWith(workspaceId, {
+      type: "invalidate-query",
+      data: ["entities", workspaceId],
+    });
   });
 
   test("locks and rechecks the parent in the insert transaction", async () => {
@@ -172,7 +291,9 @@ describe("createEntityFromBuffer", () => {
         },
       }),
     };
-    const { getCallCount, scopedDb } = createScopedDbMock(tx);
+    const { getCallCount, scopedDb } = createScopedDbMock(
+      withIntentPersistence(tx),
+    );
     const recordAuditEvent = mock(async () => {});
 
     const result = await createEntityFromBuffer({
@@ -197,11 +318,203 @@ describe("createEntityFromBuffer", () => {
         }),
       );
     }
-    expect(getCallCount()).toBe(2);
+    expect(getCallCount()).toBe(5);
     expect(locks).toEqual(["update"]);
     expect(s3WriteMock).toHaveBeenCalledTimes(1);
     expect(s3DeleteMock).toHaveBeenCalledTimes(1);
     expect(recordAuditEvent).not.toHaveBeenCalled();
+  });
+
+  test("cleans up uploaded bytes when the in-transaction callback fails", async () => {
+    const tx = {
+      query: {
+        properties: {
+          findMany: async () => [
+            { id: propertyId, content: { type: "file" as const } },
+          ],
+        },
+        workspaces: {
+          findFirst: async () => ({ reference: null }),
+        },
+      },
+      $count: async () => 0,
+      select: createParentSelect({ parentKind: "folder" }),
+      insert: (table: unknown) => ({
+        values: () =>
+          table === documentCounters
+            ? {
+                onConflictDoUpdate: () => ({
+                  returning: async () => [{ lastValue: 1 }],
+                }),
+              }
+            : undefined,
+      }),
+      update: () => ({
+        set: () => ({ where: async () => {} }),
+      }),
+    };
+    const { scopedDb } = createScopedDbMock(withIntentPersistence(tx));
+
+    const attempted = await Result.tryPromise({
+      try: async () =>
+        await createEntityFromBuffer({
+          scopedDb,
+          organizationId,
+          workspaceId,
+          userId,
+          recordAuditEvent: async () => undefined,
+          buffer: new TextEncoder().encode("docx bytes"),
+          fileName: "Generated Agreement.docx",
+          mimeType:
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+          parentId,
+          afterCreate: async () => {
+            throw new Error("audit failed");
+          },
+        }),
+      catch: (cause) => cause,
+    });
+
+    expect(Result.isError(attempted)).toBe(true);
+    if (Result.isError(attempted) && attempted.error instanceof Error) {
+      expect(attempted.error.message).toBe("audit failed");
+    }
+    expect(s3DeleteMock).toHaveBeenCalledTimes(1);
+    expect(processExtractionMock).not.toHaveBeenCalled();
+    expect(broadcastMock).not.toHaveBeenCalled();
+  });
+
+  test("keeps a failed-cleanup intent available for bounded reconciliation", async () => {
+    const tx = {
+      query: {
+        properties: {
+          findMany: async () => [
+            { id: propertyId, content: { type: "file" as const } },
+          ],
+        },
+        workspaces: {
+          findFirst: async () => ({ reference: null }),
+        },
+      },
+      $count: async () => 0,
+      select: createParentSelect({ parentKind: "folder" }),
+      insert: (table: unknown) => ({
+        values: () =>
+          table === documentCounters
+            ? {
+                onConflictDoUpdate: () => ({
+                  returning: async () => [{ lastValue: 1 }],
+                }),
+              }
+            : undefined,
+      }),
+      update: () => ({
+        set: () => ({ where: async () => {} }),
+      }),
+    };
+    const { scopedDb } = createScopedDbMock(withIntentPersistence(tx));
+    s3DeleteMock.mockRejectedValue(new Error("object deletion timed out"));
+
+    const attempted = await Result.tryPromise({
+      try: async () =>
+        await createEntityFromBuffer({
+          scopedDb,
+          organizationId,
+          workspaceId,
+          userId,
+          recordAuditEvent: async () => undefined,
+          buffer: new TextEncoder().encode("docx bytes"),
+          fileName: "Generated Agreement.docx",
+          mimeType:
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+          parentId,
+          afterCreate: async () => {
+            throw new Error("audit failed");
+          },
+        }),
+      catch: (cause) => cause,
+    });
+
+    expect(Result.isError(attempted)).toBe(true);
+    if (Result.isError(attempted) && attempted.error instanceof Error) {
+      expect(attempted.error.message).toBe("audit failed");
+    }
+    expect(s3DeleteMock).toHaveBeenCalledTimes(1);
+    expect(intentStatuses).toEqual(["scanning"]);
+    expect(processExtractionMock).not.toHaveBeenCalled();
+  });
+
+  test("preserves bytes when the entity commit acknowledgement is ambiguous", async () => {
+    let nextDocumentSequence = 0;
+    const tx = withIntentPersistence({
+      execute: async () => undefined,
+      query: {
+        properties: {
+          findMany: async () => [
+            { id: propertyId, content: { type: "file" as const } },
+          ],
+        },
+        workspaces: {
+          findFirst: async () => ({ reference: null }),
+        },
+      },
+      $count: async () => 0,
+      select: createParentSelect({ parentKind: "folder" }),
+      insert: (table: unknown) => ({
+        values: () =>
+          table === documentCounters
+            ? {
+                onConflictDoUpdate: () => ({
+                  returning: async () => {
+                    nextDocumentSequence += 1;
+                    return [{ lastValue: nextDocumentSequence }];
+                  },
+                }),
+              }
+            : undefined,
+      }),
+      update: () => ({
+        set: () => ({ where: async () => {} }),
+      }),
+    });
+    const commitError = new Error("connection lost after commit");
+    let callCount = 0;
+    const scopedDb = asTestRaw<ScopedDb>(
+      async <T>(run: (transaction: Transaction) => Promise<T>) => {
+        callCount += 1;
+        const value = await run(asTestRaw<Transaction>(tx));
+        if (callCount === 4) {
+          throw commitError;
+        }
+        return value;
+      },
+    );
+
+    const attempted = await Result.tryPromise({
+      try: async () =>
+        await createEntityFromBuffer({
+          scopedDb,
+          organizationId,
+          workspaceId,
+          userId,
+          recordAuditEvent: async () => undefined,
+          buffer: new TextEncoder().encode("docx bytes"),
+          fileName: "Generated Agreement.docx",
+          mimeType:
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+          parentId,
+        }),
+      catch: (cause) => cause,
+    });
+
+    expect(Result.isError(attempted)).toBe(true);
+    if (Result.isError(attempted)) {
+      expect(attempted.error).toBe(commitError);
+    }
+    expect(intentStatuses).toEqual(["scanning", "finalized"]);
+    expect(s3DeleteMock).not.toHaveBeenCalled();
+    expect(processExtractionMock).not.toHaveBeenCalled();
+    expect(broadcastMock).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/api/src/handlers/entities/create-from-buffer.test.ts
+++ b/apps/api/src/handlers/entities/create-from-buffer.test.ts
@@ -10,6 +10,7 @@ import {
   entityVersions,
   fields,
   pendingUploads,
+  workspaces,
 } from "@/api/db/schema";
 import { toSafeId } from "@/api/lib/branded-types";
 import { FILE_SIZE_LIMIT_BYTES } from "@/api/lib/limits";
@@ -303,7 +304,7 @@ describe("createEntityFromBuffer", () => {
       );
     }
     expect(getCallCount()).toBe(4);
-    expect(locks).toEqual(["update"]);
+    expect(locks).toEqual(["share", "update"]);
     expect(s3WriteMock).toHaveBeenCalledTimes(1);
     expect(s3DeleteMock).toHaveBeenCalledTimes(1);
     expect(recordAuditEvent).not.toHaveBeenCalled();
@@ -505,16 +506,24 @@ describe("createEntityFromBuffer", () => {
 type CreateParentSelectOptions = {
   parentKind: "document" | "folder" | null;
   onLock?: (strength: unknown) => void;
+  workspaceStatus?: "active" | "deleting";
 };
 
 const createParentSelect =
-  ({ parentKind, onLock }: CreateParentSelectOptions) =>
+  ({
+    parentKind,
+    onLock,
+    workspaceStatus = "active",
+  }: CreateParentSelectOptions) =>
   (_selection: unknown) => ({
-    from: (_table: unknown) => ({
+    from: (table: unknown) => ({
       where: () => ({
         limit: () => ({
           for: async (strength: unknown) => {
             onLock?.(strength);
+            if (table === workspaces) {
+              return [{ status: workspaceStatus }];
+            }
             if (parentKind !== null) {
               return [{ id: parentId, kind: parentKind }];
             }

--- a/apps/api/src/handlers/entities/create-from-buffer.ts
+++ b/apps/api/src/handlers/entities/create-from-buffer.ts
@@ -89,6 +89,7 @@ class InvalidParentError extends TaggedError("InvalidParentError")<{
 
 type CreateEntityFromBufferValue = {
   entityId: SafeId<"entity">;
+  entityVersionId: SafeId<"entityVersion">;
   fieldId: SafeId<"field">;
   fileName: string;
 };
@@ -344,7 +345,12 @@ export const createEntityFromBuffer = async ({
           },
         });
 
-        await afterCreate?.(tx, { entityId, fieldId, fileName });
+        await afterCreate?.(tx, {
+          entityId,
+          entityVersionId,
+          fieldId,
+          fileName,
+        });
 
         const finalizedResult: Extract<
           PendingUploadFinalizedResult,
@@ -432,5 +438,5 @@ export const createEntityFromBuffer = async ({
     data: ["entities", workspaceId],
   });
 
-  return Result.ok({ entityId, fieldId, fileName });
+  return Result.ok({ entityId, entityVersionId, fieldId, fileName });
 };

--- a/apps/api/src/handlers/entities/create-from-buffer.ts
+++ b/apps/api/src/handlers/entities/create-from-buffer.ts
@@ -27,6 +27,7 @@ import type { AuditRecorder } from "@/api/lib/audit-log";
 import { createSafeId } from "@/api/lib/branded-types";
 import type { SafeId } from "@/api/lib/branded-types";
 import {
+  BUFFER_INTENT_DELETE_TIMEOUT_MS,
   BUFFER_INTENT_HEARTBEAT_MS,
   BUFFER_INTENT_TTL_MS,
 } from "@/api/lib/buffer-intent-reconciliation";
@@ -37,10 +38,11 @@ import {
   enqueuePdfDerivativeOrMarkFailed,
 } from "@/api/lib/file-derivative-queue";
 import { FILE_SIZE_LIMIT_BYTES, LIMITS } from "@/api/lib/limits";
-import { getS3 } from "@/api/lib/s3";
+import { deleteS3ObjectWithSignal, getS3 } from "@/api/lib/s3";
 import { sanitizeFilenamePreservingExtension } from "@/api/lib/sanitize-filename";
 import { processExtraction } from "@/api/lib/search/process-extraction";
 import { broadcast } from "@/api/lib/sse";
+import { withTimeout } from "@/api/lib/with-timeout";
 
 type BufferEntityCreateIntent = {
   claimRequestId: string;
@@ -341,7 +343,14 @@ export const createEntityFromBuffer = async ({
   try {
     const cleanupObject = async (): Promise<boolean> => {
       const cleanup = await Result.tryPromise({
-        try: async () => await getS3().delete(s3Key),
+        try: async () =>
+          await withTimeout(
+            async (signal) => await deleteS3ObjectWithSignal(s3Key, signal),
+            {
+              label: "buffer-entity-writer-cleanup.delete",
+              timeoutMs: BUFFER_INTENT_DELETE_TIMEOUT_MS,
+            },
+          ),
         catch: (cause) => cause,
       });
       if (Result.isError(cleanup)) {

--- a/apps/api/src/handlers/entities/create-from-buffer.ts
+++ b/apps/api/src/handlers/entities/create-from-buffer.ts
@@ -4,6 +4,7 @@ import { and, eq, inArray } from "drizzle-orm";
 import type { Transaction } from "@/api/db/root";
 import type { SafeDb, ScopedDb } from "@/api/db/safe-db";
 import {
+  bufferObjectCleanupIntents,
   entities,
   entityVersions,
   fields,
@@ -140,6 +141,9 @@ const abandonEntityCreateIntent = async ({
           inArray(pendingUploads.status, PENDING_UPLOAD_RECOVERABLE_STATUSES),
         ),
       );
+    await tx
+      .delete(bufferObjectCleanupIntents)
+      .where(eq(bufferObjectCleanupIntents.id, intent.id));
   });
   if (Result.isError(abandoned)) {
     captureError(abandoned.error, {

--- a/apps/api/src/handlers/entities/create-from-buffer.ts
+++ b/apps/api/src/handlers/entities/create-from-buffer.ts
@@ -1,5 +1,5 @@
 import { Result, TaggedError, panic } from "better-result";
-import { and, eq } from "drizzle-orm";
+import { and, eq, inArray } from "drizzle-orm";
 
 import type { Transaction } from "@/api/db/root";
 import type { SafeDb, ScopedDb } from "@/api/db/safe-db";
@@ -8,6 +8,7 @@ import {
   entityVersions,
   fields,
   pendingUploads,
+  PENDING_UPLOAD_RECOVERABLE_STATUSES,
   workspaces,
 } from "@/api/db/schema";
 import type { PendingUploadFinalizedResult } from "@/api/db/schema";
@@ -123,6 +124,9 @@ const abandonEntityCreateIntent = async ({
 }): Promise<void> => {
   const abandoned = await safeDb(async (tx) => {
     // audit: skip — failed intent bookkeeping; no durable entity was created.
+    // The writer reaches this only after its PUT settled and deletion of its
+    // exact reserved key succeeded. It may therefore close a recoverable row
+    // even when the reconciler replaced its expired lease in the meantime.
     await tx
       .update(pendingUploads)
       .set({
@@ -133,8 +137,7 @@ const abandonEntityCreateIntent = async ({
       .where(
         and(
           eq(pendingUploads.id, intent.id),
-          eq(pendingUploads.status, "scanning"),
-          eq(pendingUploads.claimedByRequestId, intent.claimRequestId),
+          inArray(pendingUploads.status, PENDING_UPLOAD_RECOVERABLE_STATUSES),
         ),
       );
   });

--- a/apps/api/src/handlers/entities/create-from-buffer.ts
+++ b/apps/api/src/handlers/entities/create-from-buffer.ts
@@ -1,8 +1,16 @@
-import { Result, TaggedError } from "better-result";
-import { eq } from "drizzle-orm";
+import { Result, TaggedError, panic } from "better-result";
+import { and, eq } from "drizzle-orm";
 
-import type { ScopedDb } from "@/api/db/safe-db";
-import { entities, entityVersions, fields, workspaces } from "@/api/db/schema";
+import type { Transaction } from "@/api/db/root";
+import type { SafeDb, ScopedDb } from "@/api/db/safe-db";
+import {
+  entities,
+  entityVersions,
+  fields,
+  pendingUploads,
+  workspaces,
+} from "@/api/db/schema";
+import type { PendingUploadFinalizedResult } from "@/api/db/schema";
 import { validateParentIdForInsert } from "@/api/handlers/entities/validate-parent-id";
 import {
   allocateFileObject,
@@ -16,16 +24,181 @@ import { AUDIT_ACTION, AUDIT_RESOURCE_TYPE } from "@/api/lib/audit-log";
 import type { AuditRecorder } from "@/api/lib/audit-log";
 import { createSafeId } from "@/api/lib/branded-types";
 import type { SafeId } from "@/api/lib/branded-types";
+import {
+  BUFFER_INTENT_HEARTBEAT_MS,
+  BUFFER_INTENT_TTL_MS,
+  reconcileStaleBufferIntents,
+} from "@/api/lib/buffer-intent-reconciliation";
 import { allocateEntityStamp } from "@/api/lib/document-counter";
 import { lockWorkspacesForEntityCap } from "@/api/lib/entity-cap-lock";
 import {
   enqueueImageThumbnailOrMarkFailed,
   enqueuePdfDerivativeOrMarkFailed,
 } from "@/api/lib/file-derivative-queue";
-import { LIMITS } from "@/api/lib/limits";
+import { FILE_SIZE_LIMIT_BYTES, LIMITS } from "@/api/lib/limits";
 import { getS3 } from "@/api/lib/s3";
 import { sanitizeFilenamePreservingExtension } from "@/api/lib/sanitize-filename";
 import { processExtraction } from "@/api/lib/search/process-extraction";
+import { broadcast } from "@/api/lib/sse";
+
+type BufferEntityCreateIntent = {
+  claimRequestId: string;
+  id: SafeId<"pendingUpload">;
+};
+
+const toSafeDb =
+  (scopedDb: ScopedDb): SafeDb =>
+  async <T>(run: (tx: Transaction) => Promise<T>) =>
+    await Result.tryPromise(async () => await scopedDb(run));
+
+const reserveEntityCreateIntent = async ({
+  safeDb,
+  organizationId,
+  workspaceId,
+  userId,
+  propertyId,
+  fileId,
+  fileName,
+  mimeType,
+  sizeBytes,
+  sha256Hex,
+}: {
+  safeDb: SafeDb;
+  organizationId: SafeId<"organization">;
+  workspaceId: SafeId<"workspace">;
+  userId: SafeId<"user">;
+  propertyId: SafeId<"property">;
+  fileId: string;
+  fileName: string;
+  mimeType: string;
+  sizeBytes: number;
+  sha256Hex: string;
+}): Promise<BufferEntityCreateIntent> => {
+  const id = createSafeId<"pendingUpload">();
+  const claimRequestId = Bun.randomUUIDv7().slice(0, 64);
+  const now = new Date();
+  const reserved = await safeDb(async (tx) => {
+    // audit: skip — crash-recovery intent; entity creation is audited later.
+    const rows = await tx
+      .insert(pendingUploads)
+      .values({
+        id,
+        organizationId,
+        workspaceId,
+        userId,
+        purpose: "entity_create",
+        purposeData: {
+          type: "entity_create",
+          propertyId,
+          reservedFileId: fileId,
+        },
+        declaredName: fileName,
+        declaredMime: mimeType,
+        declaredSize: sizeBytes,
+        declaredSha256: sha256Hex,
+        status: "scanning",
+        claimedAt: now,
+        claimedByRequestId: claimRequestId,
+        expiresAt: new Date(now.getTime() + BUFFER_INTENT_TTL_MS),
+        createdAt: now,
+      })
+      .returning({ id: pendingUploads.id });
+    return (
+      rows.at(0)?.id ?? panic("Entity buffer intent insert returned no row")
+    );
+  });
+  if (Result.isError(reserved)) {
+    throw reserved.error;
+  }
+  return { id: reserved.value, claimRequestId };
+};
+
+const abandonEntityCreateIntent = async ({
+  safeDb,
+  intent,
+  reason,
+}: {
+  safeDb: SafeDb;
+  intent: BufferEntityCreateIntent;
+  reason: string;
+}): Promise<void> => {
+  const abandoned = await safeDb(async (tx) => {
+    // audit: skip — failed intent bookkeeping; no durable entity was created.
+    await tx
+      .update(pendingUploads)
+      .set({
+        finalizedAt: new Date(),
+        rejectReason: reason,
+        status: "rejected",
+      })
+      .where(
+        and(
+          eq(pendingUploads.id, intent.id),
+          eq(pendingUploads.status, "scanning"),
+          eq(pendingUploads.claimedByRequestId, intent.claimRequestId),
+        ),
+      );
+  });
+  if (Result.isError(abandoned)) {
+    captureError(abandoned.error, {
+      pendingUploadId: intent.id,
+      stage: "buffer-entity-intent-abandon",
+    });
+  }
+};
+
+const startEntityCreateIntentHeartbeat = ({
+  safeDb,
+  intent,
+}: {
+  safeDb: SafeDb;
+  intent: BufferEntityCreateIntent;
+}): (() => Promise<void>) => {
+  let heartbeatPromise: Promise<void> | null = null;
+  let stopped = false;
+  const heartbeat = async (): Promise<void> => {
+    try {
+      const renewed = await safeDb(async (tx) => {
+        // audit: skip — live crash-recovery lease bookkeeping only.
+        await tx
+          .update(pendingUploads)
+          .set({ claimedAt: new Date() })
+          .where(
+            and(
+              eq(pendingUploads.id, intent.id),
+              eq(pendingUploads.status, "scanning"),
+              eq(pendingUploads.claimedByRequestId, intent.claimRequestId),
+            ),
+          );
+      });
+      if (Result.isError(renewed)) {
+        captureError(renewed.error, {
+          pendingUploadId: intent.id,
+          stage: "buffer-entity-intent-heartbeat",
+        });
+      }
+    } catch (error) {
+      captureError(error, {
+        pendingUploadId: intent.id,
+        stage: "buffer-entity-intent-heartbeat-unhandled",
+      });
+    } finally {
+      heartbeatPromise = null;
+    }
+  };
+  const triggerHeartbeat = (): void => {
+    if (heartbeatPromise === null && !stopped) {
+      heartbeatPromise = heartbeat();
+    }
+  };
+  const timer = setInterval(triggerHeartbeat, BUFFER_INTENT_HEARTBEAT_MS);
+  timer.unref();
+  return async () => {
+    stopped = true;
+    clearInterval(timer);
+    await heartbeatPromise;
+  };
+};
 
 type CreateEntityFromBufferInput = {
   scopedDb: ScopedDb;
@@ -38,9 +211,16 @@ type CreateEntityFromBufferInput = {
   mimeType: string;
   parentId?: SafeId<"entity"> | null | undefined;
   scanWarnings?: string[] | undefined;
+  afterCreate?:
+    | ((tx: Transaction, result: CreateEntityFromBufferValue) => Promise<void>)
+    | undefined;
 };
 
 class EntityLimitError extends TaggedError("EntityLimitError")<{
+  message: string;
+}>() {}
+
+class DocumentTooLargeError extends TaggedError("DocumentTooLargeError")<{
   message: string;
 }>() {}
 
@@ -52,13 +232,18 @@ class InvalidParentError extends TaggedError("InvalidParentError")<{
   message: string;
 }>() {}
 
+type CreateEntityFromBufferValue = {
+  entityId: SafeId<"entity">;
+  fieldId: SafeId<"field">;
+  fileName: string;
+};
+
 export type CreateEntityFromBufferResult = Result<
-  {
-    entityId: SafeId<"entity">;
-    fieldId: SafeId<"field">;
-    fileName: string;
-  },
-  EntityLimitError | InvalidParentError | MissingFilePropertyError
+  CreateEntityFromBufferValue,
+  | DocumentTooLargeError
+  | EntityLimitError
+  | InvalidParentError
+  | MissingFilePropertyError
 >;
 
 /**
@@ -79,7 +264,17 @@ export const createEntityFromBuffer = async ({
   mimeType,
   parentId,
   scanWarnings,
+  afterCreate,
 }: CreateEntityFromBufferInput): Promise<CreateEntityFromBufferResult> => {
+  const bytes = buffer instanceof Uint8Array ? buffer : new Uint8Array(buffer);
+  if (bytes.byteLength > FILE_SIZE_LIMIT_BYTES.document) {
+    return Result.err(
+      new DocumentTooLargeError({
+        message: `Document exceeds the ${FILE_SIZE_LIMIT_BYTES.document}-byte size limit`,
+      }),
+    );
+  }
+
   const fileName = sanitizeFilenamePreservingExtension(rawFileName);
   const fileId = allocateFileObject();
   const s3Key = createFileKey({
@@ -89,7 +284,6 @@ export const createEntityFromBuffer = async ({
     mimeType,
   });
 
-  const bytes = buffer instanceof Uint8Array ? buffer : new Uint8Array(buffer);
   const sha256Hex = new Bun.CryptoHasher("sha256").update(bytes).digest("hex");
 
   // Check for file property before uploading to avoid
@@ -111,132 +305,234 @@ export const createEntityFromBuffer = async ({
     );
   }
 
-  // Track S3 keys for cleanup before any uploads.
-  const s3Keys = [s3Key];
-
   const entityId = createSafeId<"entity">();
   const entityVersionId = createSafeId<"entityVersion">();
   const fieldId = createSafeId<"field">();
+  const safeDb = toSafeDb(scopedDb);
+
+  // Reconcile older crash leftovers before publishing another final object,
+  // then durably reserve this exact file id. A hard death after the S3 write
+  // can therefore be distinguished from a committed entity and cleaned later.
+  await reconcileStaleBufferIntents({
+    safeDb,
+    organizationId,
+    workspaceId,
+    purpose: "entity_create",
+  });
+  const intent = await reserveEntityCreateIntent({
+    safeDb,
+    organizationId,
+    workspaceId,
+    userId,
+    propertyId: fileProperty.id,
+    fileId,
+    fileName,
+    mimeType,
+    sizeBytes: bytes.byteLength,
+    sha256Hex,
+  });
+
+  const stopIntentHeartbeat = startEntityCreateIntentHeartbeat({
+    safeDb,
+    intent,
+  });
 
   try {
-    await getS3().write(s3Key, bytes);
+    const cleanupObject = async (): Promise<boolean> => {
+      const cleanup = await Result.tryPromise({
+        try: async () => await getS3().delete(s3Key),
+        catch: (cause) => cause,
+      });
+      if (Result.isError(cleanup)) {
+        captureError(cleanup.error, { entityId, objectKey: s3Key });
+        return false;
+      }
+      return true;
+    };
 
-    await scopedDb(async (tx) => {
-      // See `lockWorkspacesForEntityCap` for the canonical lock
-      // order every entity-creating path follows (issue #1139).
-      await lockWorkspacesForEntityCap(tx, [workspaceId]);
-
-      // The authoritative limit check must stay in the same
-      // transaction as the insert, behind the lock above, to avoid
-      // TOCTOU races.
-      const entityCount = await tx.$count(
-        entities,
-        eq(entities.workspaceId, workspaceId),
-      );
-      if (entityCount >= LIMITS.entitiesCount) {
-        throw new EntityLimitError({
-          message: "Entities limit reached",
+    try {
+      await getS3().write(s3Key, bytes);
+    } catch (error) {
+      // A transport failure is ambiguous: S3 may have accepted the object.
+      // Keep the intent recoverable unless deletion is confirmed.
+      if (await cleanupObject()) {
+        await abandonEntityCreateIntent({
+          safeDb,
+          intent,
+          reason: "Server-generated entity object write failed",
         });
       }
-
-      // The earlier parent lookup is only a fail-fast preflight. Recheck and
-      // lock the row here so it cannot disappear between validation and insert.
-      if (parentId) {
-        const parentError = await validateParentIdForInsert({
-          tx,
-          parentId,
-          workspaceId,
-        });
-        if (parentError) {
-          throw new InvalidParentError({ message: parentError });
-        }
-      }
-
-      const entityStamp = await allocateEntityStamp(tx, workspaceId);
-
-      await tx.insert(entities).values({
-        id: entityId,
-        workspaceId,
-        name: fileName,
-        parentId: parentId ?? null,
-        createdBy: userId,
-        docSequence: entityStamp.docSequence,
-      });
-
-      await tx.insert(entityVersions).values({
-        id: entityVersionId,
-        workspaceId,
-        entityId,
-        versionNumber: 1,
-        stamp: entityStamp.stamp,
-        verificationCode: entityStamp.verificationCode,
-      });
-
-      await tx
-        .update(entities)
-        .set({ currentVersionId: entityVersionId })
-        .where(eq(entities.id, entityId));
-
-      await tx.insert(fields).values({
-        id: fieldId,
-        workspaceId,
-        propertyId: fileProperty.id,
-        entityVersionId,
-        content: fileContentWithMintedObject({
-          type: "file",
-          version: 1,
-          id: fileId,
-          fileName,
-          mimeType,
-          sizeBytes: bytes.byteLength,
-          encrypted: false,
-          sha256Hex,
-          pdfFileId: null,
-          pdfDerivative: pdfDerivativeStateForFile({
-            encrypted: false,
-            mimeType,
-          }),
-          thumbnailFileId: null,
-          thumbnailDerivative: thumbnailDerivativeStateForFile({
-            encrypted: false,
-            mimeType,
-          }),
-          ...(scanWarnings !== undefined && { scanWarnings }),
-        }),
-      });
-
-      await tx
-        .update(workspaces)
-        .set({ lastActivityAt: new Date() })
-        .where(eq(workspaces.id, workspaceId));
-
-      await recordAuditEvent(tx, {
-        action: AUDIT_ACTION.CREATE,
-        resourceType: AUDIT_RESOURCE_TYPE.ENTITY,
-        resourceId: entityId,
-        changes: {
-          created: {
-            old: null,
-            new: {
-              kind: "document",
-              fileName,
-              mimeType,
-              sizeBytes: bytes.byteLength,
-              propertyId: fileProperty.id,
-              parentId: parentId ?? null,
-            },
-          },
-        },
-      });
-    });
-  } catch (error) {
-    await Promise.all(s3Keys.map(async (k) => await getS3().delete(k)));
-
-    if (EntityLimitError.is(error) || InvalidParentError.is(error)) {
-      return Result.err(error);
+      throw error;
     }
 
-    throw error;
+    // `scopedDb` cannot distinguish a callback rollback from a lost COMMIT
+    // acknowledgement. The intent finalization is atomic with the entity rows;
+    // this flag prevents deleting bytes that an ambiguously committed entity
+    // may already reference. A real rollback leaves a stale scanning intent for
+    // the bounded reconciler.
+    const transactionState = { durableReferencePrepared: false };
+    try {
+      await scopedDb(async (tx) => {
+        // See `lockWorkspacesForEntityCap` for the canonical lock
+        // order every entity-creating path follows (issue #1139).
+        await lockWorkspacesForEntityCap(tx, [workspaceId]);
+
+        // The authoritative limit check must stay in the same
+        // transaction as the insert, behind the lock above, to avoid
+        // TOCTOU races.
+        const entityCount = await tx.$count(
+          entities,
+          eq(entities.workspaceId, workspaceId),
+        );
+        if (entityCount >= LIMITS.entitiesCount) {
+          throw new EntityLimitError({
+            message: "Entities limit reached",
+          });
+        }
+
+        // The earlier parent lookup is only a fail-fast preflight. Recheck and
+        // lock the row here so it cannot disappear between validation and insert.
+        if (parentId) {
+          const parentError = await validateParentIdForInsert({
+            tx,
+            parentId,
+            workspaceId,
+          });
+          if (parentError) {
+            throw new InvalidParentError({ message: parentError });
+          }
+        }
+
+        const entityStamp = await allocateEntityStamp(tx, workspaceId);
+
+        await tx.insert(entities).values({
+          id: entityId,
+          workspaceId,
+          name: fileName,
+          parentId: parentId ?? null,
+          createdBy: userId,
+          docSequence: entityStamp.docSequence,
+        });
+
+        await tx.insert(entityVersions).values({
+          id: entityVersionId,
+          workspaceId,
+          entityId,
+          versionNumber: 1,
+          stamp: entityStamp.stamp,
+          verificationCode: entityStamp.verificationCode,
+        });
+
+        await tx
+          .update(entities)
+          .set({ currentVersionId: entityVersionId })
+          .where(eq(entities.id, entityId));
+
+        await tx.insert(fields).values({
+          id: fieldId,
+          workspaceId,
+          propertyId: fileProperty.id,
+          entityVersionId,
+          content: fileContentWithMintedObject({
+            type: "file",
+            version: 1,
+            id: fileId,
+            fileName,
+            mimeType,
+            sizeBytes: bytes.byteLength,
+            encrypted: false,
+            sha256Hex,
+            pdfFileId: null,
+            pdfDerivative: pdfDerivativeStateForFile({
+              encrypted: false,
+              mimeType,
+            }),
+            thumbnailFileId: null,
+            thumbnailDerivative: thumbnailDerivativeStateForFile({
+              encrypted: false,
+              mimeType,
+            }),
+            ...(scanWarnings !== undefined && { scanWarnings }),
+          }),
+        });
+
+        await tx
+          .update(workspaces)
+          .set({ lastActivityAt: new Date() })
+          .where(eq(workspaces.id, workspaceId));
+
+        await recordAuditEvent(tx, {
+          action: AUDIT_ACTION.CREATE,
+          resourceType: AUDIT_RESOURCE_TYPE.ENTITY,
+          resourceId: entityId,
+          changes: {
+            created: {
+              old: null,
+              new: {
+                kind: "document",
+                fileName,
+                mimeType,
+                sizeBytes: bytes.byteLength,
+                propertyId: fileProperty.id,
+                parentId: parentId ?? null,
+              },
+            },
+          },
+        });
+
+        await afterCreate?.(tx, { entityId, fieldId, fileName });
+
+        const finalizedResult: Extract<
+          PendingUploadFinalizedResult,
+          { type: "entity_create" }
+        > = {
+          type: "entity_create",
+          entityId,
+          fileId,
+          fileName,
+          renamed: false,
+        };
+        // audit: skip — intent bookkeeping is atomic with the audited entity.
+        const finalizedRows = await tx
+          .update(pendingUploads)
+          .set({
+            status: "finalized",
+            finalizedResult,
+            finalizedAt: new Date(),
+          })
+          .where(
+            and(
+              eq(pendingUploads.id, intent.id),
+              eq(pendingUploads.status, "scanning"),
+              eq(pendingUploads.claimedByRequestId, intent.claimRequestId),
+            ),
+          )
+          .returning({ id: pendingUploads.id });
+        if (!finalizedRows.at(0)) {
+          panic("Entity buffer intent finalize returned no row");
+        }
+        transactionState.durableReferencePrepared = true;
+      });
+    } catch (error) {
+      if (
+        !transactionState.durableReferencePrepared &&
+        (await cleanupObject())
+      ) {
+        await abandonEntityCreateIntent({
+          safeDb,
+          intent,
+          reason: "Server-generated entity transaction failed",
+        });
+      }
+
+      if (EntityLimitError.is(error) || InvalidParentError.is(error)) {
+        return Result.err(error);
+      }
+
+      throw error;
+    }
+  } finally {
+    await stopIntentHeartbeat();
   }
 
   // LOOP-GUARD INVARIANT: this is the server-side entity-creation path (flow
@@ -265,6 +561,11 @@ export const createEntityFromBuffer = async ({
     userId,
     workspaceId,
   }).catch(captureError);
+
+  broadcast(workspaceId, {
+    type: "invalidate-query",
+    data: ["entities", workspaceId],
+  });
 
   return Result.ok({ entityId, fieldId, fileName });
 };

--- a/apps/api/src/handlers/entities/create-from-buffer.ts
+++ b/apps/api/src/handlers/entities/create-from-buffer.ts
@@ -27,7 +27,6 @@ import type { SafeId } from "@/api/lib/branded-types";
 import {
   BUFFER_INTENT_HEARTBEAT_MS,
   BUFFER_INTENT_TTL_MS,
-  reconcileStaleBufferIntents,
 } from "@/api/lib/buffer-intent-reconciliation";
 import { allocateEntityStamp } from "@/api/lib/document-counter";
 import { lockWorkspacesForEntityCap } from "@/api/lib/entity-cap-lock";
@@ -310,15 +309,10 @@ export const createEntityFromBuffer = async ({
   const fieldId = createSafeId<"field">();
   const safeDb = toSafeDb(scopedDb);
 
-  // Reconcile older crash leftovers before publishing another final object,
-  // then durably reserve this exact file id. A hard death after the S3 write
-  // can therefore be distinguished from a committed entity and cleaned later.
-  await reconcileStaleBufferIntents({
-    safeDb,
-    organizationId,
-    workspaceId,
-    purpose: "entity_create",
-  });
+  // Durably reserve this exact file id before publishing. A hard death after
+  // the S3 write can therefore be distinguished from a committed entity and
+  // cleaned by the bounded scheduler without adding a repair query to every
+  // request.
   const intent = await reserveEntityCreateIntent({
     safeDb,
     organizationId,

--- a/apps/api/src/handlers/entities/create-from-buffer.ts
+++ b/apps/api/src/handlers/entities/create-from-buffer.ts
@@ -30,6 +30,7 @@ import {
   BUFFER_INTENT_DELETE_TIMEOUT_MS,
   BUFFER_INTENT_HEARTBEAT_MS,
   BUFFER_INTENT_TTL_MS,
+  lockActiveWorkspaceForBufferIntent,
 } from "@/api/lib/buffer-intent-reconciliation";
 import { allocateEntityStamp } from "@/api/lib/document-counter";
 import { lockWorkspacesForEntityCap } from "@/api/lib/entity-cap-lock";
@@ -81,6 +82,7 @@ const reserveEntityCreateIntent = async ({
   const claimRequestId = Bun.randomUUIDv7().slice(0, 64);
   const now = new Date();
   const reserved = await safeDb(async (tx) => {
+    await lockActiveWorkspaceForBufferIntent(tx, workspaceId);
     // audit: skip — crash-recovery intent; entity creation is audited later.
     const rows = await tx
       .insert(pendingUploads)

--- a/apps/api/src/handlers/entities/create-from-buffer.ts
+++ b/apps/api/src/handlers/entities/create-from-buffer.ts
@@ -1,15 +1,13 @@
 import { Result, TaggedError, panic } from "better-result";
-import { and, eq, inArray } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 
 import type { Transaction } from "@/api/db/root";
 import type { SafeDb, ScopedDb } from "@/api/db/safe-db";
 import {
-  bufferObjectCleanupIntents,
   entities,
   entityVersions,
   fields,
   pendingUploads,
-  PENDING_UPLOAD_RECOVERABLE_STATUSES,
   workspaces,
 } from "@/api/db/schema";
 import type { PendingUploadFinalizedResult } from "@/api/db/schema";
@@ -28,10 +26,10 @@ import { createSafeId } from "@/api/lib/branded-types";
 import type { SafeId } from "@/api/lib/branded-types";
 import {
   BUFFER_INTENT_DELETE_TIMEOUT_MS,
-  BUFFER_INTENT_HEARTBEAT_MS,
-  BUFFER_INTENT_TTL_MS,
   BUFFER_INTENT_WRITE_TIMEOUT_MS,
-  lockActiveWorkspaceForBufferIntent,
+  abandonBufferIntent,
+  reserveBufferIntent,
+  startBufferIntentHeartbeat,
 } from "@/api/lib/buffer-intent-reconciliation";
 import { allocateEntityStamp } from "@/api/lib/document-counter";
 import { lockWorkspacesForEntityCap } from "@/api/lib/entity-cap-lock";
@@ -46,169 +44,15 @@ import { processExtraction } from "@/api/lib/search/process-extraction";
 import { broadcast } from "@/api/lib/sse";
 import { withTimeout } from "@/api/lib/with-timeout";
 
-type BufferEntityCreateIntent = {
-  claimRequestId: string;
-  id: SafeId<"pendingUpload">;
-};
-
 const toSafeDb =
   (scopedDb: ScopedDb): SafeDb =>
   async <T>(run: (tx: Transaction) => Promise<T>) =>
     await Result.tryPromise(async () => await scopedDb(run));
 
-const reserveEntityCreateIntent = async ({
-  safeDb,
-  organizationId,
-  workspaceId,
-  userId,
-  propertyId,
-  fileId,
-  fileName,
-  mimeType,
-  sizeBytes,
-  sha256Hex,
-}: {
-  safeDb: SafeDb;
-  organizationId: SafeId<"organization">;
-  workspaceId: SafeId<"workspace">;
-  userId: SafeId<"user">;
-  propertyId: SafeId<"property">;
-  fileId: string;
-  fileName: string;
-  mimeType: string;
-  sizeBytes: number;
-  sha256Hex: string;
-}): Promise<BufferEntityCreateIntent> => {
-  const id = createSafeId<"pendingUpload">();
-  const claimRequestId = Bun.randomUUIDv7().slice(0, 64);
-  const now = new Date();
-  const reserved = await safeDb(async (tx) => {
-    await lockActiveWorkspaceForBufferIntent(tx, workspaceId);
-    // audit: skip — crash-recovery intent; entity creation is audited later.
-    const rows = await tx
-      .insert(pendingUploads)
-      .values({
-        id,
-        organizationId,
-        workspaceId,
-        userId,
-        purpose: "entity_create",
-        purposeData: {
-          type: "entity_create",
-          propertyId,
-          reservedFileId: fileId,
-        },
-        declaredName: fileName,
-        declaredMime: mimeType,
-        declaredSize: sizeBytes,
-        declaredSha256: sha256Hex,
-        status: "scanning",
-        claimedAt: now,
-        claimedByRequestId: claimRequestId,
-        expiresAt: new Date(now.getTime() + BUFFER_INTENT_TTL_MS),
-        createdAt: now,
-      })
-      .returning({ id: pendingUploads.id });
-    return (
-      rows.at(0)?.id ?? panic("Entity buffer intent insert returned no row")
-    );
-  });
-  if (Result.isError(reserved)) {
-    throw reserved.error;
-  }
-  return { id: reserved.value, claimRequestId };
-};
-
-const abandonEntityCreateIntent = async ({
-  safeDb,
-  intent,
-  reason,
-}: {
-  safeDb: SafeDb;
-  intent: BufferEntityCreateIntent;
-  reason: string;
-}): Promise<void> => {
-  const abandoned = await safeDb(async (tx) => {
-    // audit: skip — failed intent bookkeeping; no durable entity was created.
-    // The writer reaches this only after its PUT settled and deletion of its
-    // exact reserved key succeeded. It may therefore close a recoverable row
-    // even when the reconciler replaced its expired lease in the meantime.
-    await tx
-      .update(pendingUploads)
-      .set({
-        finalizedAt: new Date(),
-        rejectReason: reason,
-        status: "rejected",
-      })
-      .where(
-        and(
-          eq(pendingUploads.id, intent.id),
-          inArray(pendingUploads.status, PENDING_UPLOAD_RECOVERABLE_STATUSES),
-        ),
-      );
-    await tx
-      .delete(bufferObjectCleanupIntents)
-      .where(eq(bufferObjectCleanupIntents.id, intent.id));
-  });
-  if (Result.isError(abandoned)) {
-    captureError(abandoned.error, {
-      pendingUploadId: intent.id,
-      stage: "buffer-entity-intent-abandon",
-    });
-  }
-};
-
-const startEntityCreateIntentHeartbeat = ({
-  safeDb,
-  intent,
-}: {
-  safeDb: SafeDb;
-  intent: BufferEntityCreateIntent;
-}): (() => Promise<void>) => {
-  let heartbeatPromise: Promise<void> | null = null;
-  let stopped = false;
-  const heartbeat = async (): Promise<void> => {
-    try {
-      const renewed = await safeDb(async (tx) => {
-        // audit: skip — live crash-recovery lease bookkeeping only.
-        await tx
-          .update(pendingUploads)
-          .set({ claimedAt: new Date() })
-          .where(
-            and(
-              eq(pendingUploads.id, intent.id),
-              eq(pendingUploads.status, "scanning"),
-              eq(pendingUploads.claimedByRequestId, intent.claimRequestId),
-            ),
-          );
-      });
-      if (Result.isError(renewed)) {
-        captureError(renewed.error, {
-          pendingUploadId: intent.id,
-          stage: "buffer-entity-intent-heartbeat",
-        });
-      }
-    } catch (error) {
-      captureError(error, {
-        pendingUploadId: intent.id,
-        stage: "buffer-entity-intent-heartbeat-unhandled",
-      });
-    } finally {
-      heartbeatPromise = null;
-    }
-  };
-  const triggerHeartbeat = (): void => {
-    if (heartbeatPromise === null && !stopped) {
-      heartbeatPromise = heartbeat();
-    }
-  };
-  const timer = setInterval(triggerHeartbeat, BUFFER_INTENT_HEARTBEAT_MS);
-  timer.unref();
-  return async () => {
-    stopped = true;
-    clearInterval(timer);
-    await heartbeatPromise;
-  };
+const ENTITY_BUFFER_INTENT_TELEMETRY = {
+  abandon: "buffer-entity-intent-abandon",
+  heartbeat: "buffer-entity-intent-heartbeat",
+  heartbeatUnhandled: "buffer-entity-intent-heartbeat-unhandled",
 };
 
 type CreateEntityFromBufferInput = {
@@ -325,22 +169,27 @@ export const createEntityFromBuffer = async ({
   // the S3 write can therefore be distinguished from a committed entity and
   // cleaned by the bounded scheduler without adding a repair query to every
   // request.
-  const intent = await reserveEntityCreateIntent({
+  const intent = await reserveBufferIntent({
     safeDb,
     organizationId,
     workspaceId,
     userId,
-    propertyId: fileProperty.id,
-    fileId,
+    purpose: "entity_create",
+    purposeData: {
+      type: "entity_create",
+      propertyId: fileProperty.id,
+      reservedFileId: fileId,
+    },
     fileName,
     mimeType,
     sizeBytes: bytes.byteLength,
     sha256Hex,
   });
 
-  const stopIntentHeartbeat = startEntityCreateIntentHeartbeat({
+  const stopIntentHeartbeat = startBufferIntentHeartbeat({
     safeDb,
     intent,
+    telemetry: ENTITY_BUFFER_INTENT_TELEMETRY,
   });
 
   try {
@@ -365,7 +214,8 @@ export const createEntityFromBuffer = async ({
 
     try {
       await withTimeout(
-        async (signal) => await putS3ObjectWithSignal(s3Key, bytes, signal),
+        async (signal) =>
+          await putS3ObjectWithSignal(s3Key, bytes, mimeType, signal),
         {
           label: "buffer-entity-writer-put",
           timeoutMs: BUFFER_INTENT_WRITE_TIMEOUT_MS,
@@ -532,10 +382,11 @@ export const createEntityFromBuffer = async ({
         !transactionState.durableReferencePrepared &&
         (await cleanupObject())
       ) {
-        await abandonEntityCreateIntent({
+        await abandonBufferIntent({
           safeDb,
           intent,
           reason: "Server-generated entity transaction failed",
+          telemetry: ENTITY_BUFFER_INTENT_TELEMETRY,
         });
       }
 

--- a/apps/api/src/handlers/entities/create-from-buffer.ts
+++ b/apps/api/src/handlers/entities/create-from-buffer.ts
@@ -30,6 +30,7 @@ import {
   BUFFER_INTENT_DELETE_TIMEOUT_MS,
   BUFFER_INTENT_HEARTBEAT_MS,
   BUFFER_INTENT_TTL_MS,
+  BUFFER_INTENT_WRITE_TIMEOUT_MS,
   lockActiveWorkspaceForBufferIntent,
 } from "@/api/lib/buffer-intent-reconciliation";
 import { allocateEntityStamp } from "@/api/lib/document-counter";
@@ -39,7 +40,7 @@ import {
   enqueuePdfDerivativeOrMarkFailed,
 } from "@/api/lib/file-derivative-queue";
 import { FILE_SIZE_LIMIT_BYTES, LIMITS } from "@/api/lib/limits";
-import { deleteS3ObjectWithSignal, getS3 } from "@/api/lib/s3";
+import { deleteS3ObjectWithSignal, putS3ObjectWithSignal } from "@/api/lib/s3";
 import { sanitizeFilenamePreservingExtension } from "@/api/lib/sanitize-filename";
 import { processExtraction } from "@/api/lib/search/process-extraction";
 import { broadcast } from "@/api/lib/sse";
@@ -363,7 +364,13 @@ export const createEntityFromBuffer = async ({
     };
 
     try {
-      await getS3().write(s3Key, bytes);
+      await withTimeout(
+        async (signal) => await putS3ObjectWithSignal(s3Key, bytes, signal),
+        {
+          label: "buffer-entity-writer-put",
+          timeoutMs: BUFFER_INTENT_WRITE_TIMEOUT_MS,
+        },
+      );
     } catch (error) {
       // A transport failure is ambiguous: S3 may have accepted the object.
       // Keep the intent recoverable unless deletion is confirmed.

--- a/apps/api/src/handlers/entities/create-from-buffer.ts
+++ b/apps/api/src/handlers/entities/create-from-buffer.ts
@@ -372,15 +372,10 @@ export const createEntityFromBuffer = async ({
         },
       );
     } catch (error) {
-      // A transport failure is ambiguous: S3 may have accepted the object.
-      // Keep the intent recoverable unless deletion is confirmed.
-      if (await cleanupObject()) {
-        await abandonEntityCreateIntent({
-          safeDb,
-          intent,
-          reason: "Server-generated entity object write failed",
-        });
-      }
+      // A transport failure is ambiguous: S3 may publish after this immediate
+      // delete completes. Keep the intent recoverable so later sweeps remove
+      // any late publication; the heartbeat stops in finally below.
+      await cleanupObject();
       throw error;
     }
 

--- a/apps/api/src/handlers/entities/create-from-legal-source.ts
+++ b/apps/api/src/handlers/entities/create-from-legal-source.ts
@@ -100,11 +100,19 @@ export default createSafeHandler(
 
 const toHandlerError = (
   error:
+    | { _tag: "DocumentTooLargeError" }
     | { _tag: "EntityLimitError" }
     | { _tag: "InvalidParentError" }
     | { _tag: "MissingFilePropertyError" },
 ): HandlerError => {
   switch (error._tag) {
+    case "DocumentTooLargeError":
+      return new HandlerError({
+        code: "legal_source_document_too_large",
+        status: 413,
+        message:
+          "The generated document exceeds the document size limit, so it could not be created.",
+      });
     case "EntityLimitError":
       return new HandlerError({
         code: "legal_source_entity_limit_reached",

--- a/apps/api/src/handlers/entities/create-version-from-buffer.test.ts
+++ b/apps/api/src/handlers/entities/create-version-from-buffer.test.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import type { Transaction } from "@/api/db/root";
 import type { SafeDb } from "@/api/db/safe-db";
-import { bufferObjectCleanupIntents } from "@/api/db/schema";
+import { bufferObjectCleanupIntents, workspaces } from "@/api/db/schema";
 import type { AuditRecorder } from "@/api/lib/audit-log";
 import { toSafeId } from "@/api/lib/branded-types";
 import { FILE_SIZE_LIMIT_BYTES } from "@/api/lib/limits";
@@ -74,6 +74,16 @@ const createTestTransaction = (): Transaction =>
           returning: async () => [{ id: values.id }],
         };
       },
+    }),
+    select: () => ({
+      from: (table: unknown) => ({
+        where: () => ({
+          limit: () => ({
+            for: async () =>
+              table === workspaces ? [{ status: "active" }] : [],
+          }),
+        }),
+      }),
     }),
     update: () => ({
       set: (values: { status?: string }) => {

--- a/apps/api/src/handlers/entities/create-version-from-buffer.test.ts
+++ b/apps/api/src/handlers/entities/create-version-from-buffer.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import type { Transaction } from "@/api/db/root";
 import type { SafeDb } from "@/api/db/safe-db";
+import { bufferObjectCleanupIntents } from "@/api/db/schema";
 import type { AuditRecorder } from "@/api/lib/audit-log";
 import { toSafeId } from "@/api/lib/branded-types";
 import { FILE_SIZE_LIMIT_BYTES } from "@/api/lib/limits";
@@ -56,6 +57,12 @@ const { createEntityVersionFromBuffer } =
 
 const createTestTransaction = (): Transaction =>
   asTestRaw<Transaction>({
+    delete: (table: unknown) => {
+      if (table === bufferObjectCleanupIntents) {
+        return { where: async () => undefined };
+      }
+      throw new Error("Unexpected delete table");
+    },
     insert: () => ({
       values: (values: { id: string; status?: string }) => {
         persistenceEvents.push("intent-reserved");

--- a/apps/api/src/handlers/entities/create-version-from-buffer.test.ts
+++ b/apps/api/src/handlers/entities/create-version-from-buffer.test.ts
@@ -229,6 +229,7 @@ describe("createEntityVersionFromBuffer", () => {
     expect(s3WriteMock).toHaveBeenCalledWith(
       "org_1/ws_1/file_1.docx",
       expect.any(Uint8Array),
+      "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
       expect.any(AbortSignal),
     );
     expect(persistenceEvents).toEqual(["intent-reserved", "s3-written"]);

--- a/apps/api/src/handlers/entities/create-version-from-buffer.test.ts
+++ b/apps/api/src/handlers/entities/create-version-from-buffer.test.ts
@@ -30,7 +30,8 @@ void mock.module("@/api/handlers/files/utils", () => ({
   createFileKey: () => "org_1/ws_1/file_1.docx",
 }));
 void mock.module("@/api/lib/s3", () => ({
-  getS3: () => ({ write: s3WriteMock, delete: s3DeleteMock }),
+  deleteS3ObjectWithSignal: s3DeleteMock,
+  getS3: () => ({ write: s3WriteMock }),
 }));
 void mock.module("@/api/lib/search/process-extraction", () => ({
   processExtraction: processExtractionMock,
@@ -170,7 +171,10 @@ describe("createEntityVersionFromBuffer", () => {
     if (Result.isError(attempted)) {
       expect(attempted.error).toBe(writeError);
     }
-    expect(s3DeleteMock).toHaveBeenCalledWith("org_1/ws_1/file_1.docx");
+    expect(s3DeleteMock).toHaveBeenCalledWith(
+      "org_1/ws_1/file_1.docx",
+      expect.any(AbortSignal),
+    );
     expect(writeFileVersionMock).not.toHaveBeenCalled();
     expect(intentStatuses).toEqual(["scanning", "rejected"]);
   });
@@ -189,7 +193,10 @@ describe("createEntityVersionFromBuffer", () => {
     if (Result.isError(attempted)) {
       expect(attempted.error).toBe(writeError);
     }
-    expect(s3DeleteMock).toHaveBeenCalledWith("org_1/ws_1/file_1.docx");
+    expect(s3DeleteMock).toHaveBeenCalledWith(
+      "org_1/ws_1/file_1.docx",
+      expect.any(AbortSignal),
+    );
     expect(intentStatuses).toEqual(["scanning"]);
   });
 
@@ -237,7 +244,10 @@ describe("createEntityVersionFromBuffer", () => {
     if (Result.isError(result)) {
       expect(result.error.code).toBe("entity-read-only");
     }
-    expect(s3DeleteMock).toHaveBeenCalledWith("org_1/ws_1/file_1.docx");
+    expect(s3DeleteMock).toHaveBeenCalledWith(
+      "org_1/ws_1/file_1.docx",
+      expect.any(AbortSignal),
+    );
     expect(processExtractionMock).not.toHaveBeenCalled();
   });
 
@@ -255,7 +265,10 @@ describe("createEntityVersionFromBuffer", () => {
         expect(attempted.error.message).toBe("db unavailable");
       }
     }
-    expect(s3DeleteMock).toHaveBeenCalledWith("org_1/ws_1/file_1.docx");
+    expect(s3DeleteMock).toHaveBeenCalledWith(
+      "org_1/ws_1/file_1.docx",
+      expect.any(AbortSignal),
+    );
   });
 
   test("preserves the object when the commit acknowledgement is ambiguous", async () => {
@@ -323,7 +336,10 @@ describe("createEntityVersionFromBuffer", () => {
     if (Result.isError(attempted) && attempted.error instanceof Error) {
       expect(attempted.error.message).toBe("audit failed");
     }
-    expect(s3DeleteMock).toHaveBeenCalledWith("org_1/ws_1/file_1.docx");
+    expect(s3DeleteMock).toHaveBeenCalledWith(
+      "org_1/ws_1/file_1.docx",
+      expect.any(AbortSignal),
+    );
     expect(processExtractionMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/handlers/entities/create-version-from-buffer.test.ts
+++ b/apps/api/src/handlers/entities/create-version-from-buffer.test.ts
@@ -31,7 +31,7 @@ void mock.module("@/api/handlers/files/utils", () => ({
 }));
 void mock.module("@/api/lib/s3", () => ({
   deleteS3ObjectWithSignal: s3DeleteMock,
-  getS3: () => ({ write: s3WriteMock }),
+  putS3ObjectWithSignal: s3WriteMock,
 }));
 void mock.module("@/api/lib/search/process-extraction", () => ({
   processExtraction: processExtractionMock,
@@ -226,6 +226,11 @@ describe("createEntityVersionFromBuffer", () => {
 
     expect(Result.isOk(result)).toBe(true);
     expect(s3WriteMock).toHaveBeenCalledTimes(1);
+    expect(s3WriteMock).toHaveBeenCalledWith(
+      "org_1/ws_1/file_1.docx",
+      expect.any(Uint8Array),
+      expect.any(AbortSignal),
+    );
     expect(persistenceEvents).toEqual(["intent-reserved", "s3-written"]);
     expect(writeFileVersionMock).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/apps/api/src/handlers/entities/create-version-from-buffer.test.ts
+++ b/apps/api/src/handlers/entities/create-version-from-buffer.test.ts
@@ -168,7 +168,7 @@ describe("createEntityVersionFromBuffer", () => {
     expect(s3DeleteMock).not.toHaveBeenCalled();
   });
 
-  test("best-effort deletes an object after an ambiguous initial write failure", async () => {
+  test("keeps recovery after deleting an ambiguous initial write", async () => {
     const writeError = new Error("object storage timed out");
     s3WriteMock.mockRejectedValue(writeError);
 
@@ -186,7 +186,7 @@ describe("createEntityVersionFromBuffer", () => {
       expect.any(AbortSignal),
     );
     expect(writeFileVersionMock).not.toHaveBeenCalled();
-    expect(intentStatuses).toEqual(["scanning", "rejected"]);
+    expect(intentStatuses).toEqual(["scanning"]);
   });
 
   test("keeps the durable intent recoverable when ambiguous-write cleanup fails", async () => {

--- a/apps/api/src/handlers/entities/create-version-from-buffer.test.ts
+++ b/apps/api/src/handlers/entities/create-version-from-buffer.test.ts
@@ -16,15 +16,6 @@ const pdfDerivativeMock = mock();
 const thumbnailDerivativeMock = mock();
 const diffStatsMock = mock();
 const broadcastMock = mock();
-let staleIntentRows: {
-  declaredMime: string;
-  id: ReturnType<typeof toSafeId<"pendingUpload">>;
-  purposeData: {
-    type: "entity_version";
-    entityId: ReturnType<typeof toSafeId<"entity">>;
-    reservedFileId: string;
-  };
-}[] = [];
 let persistenceEvents: string[] = [];
 let intentStatuses: string[] = [];
 
@@ -65,15 +56,6 @@ const { createEntityVersionFromBuffer } =
 
 const createTestTransaction = (): Transaction =>
   asTestRaw<Transaction>({
-    select: () => ({
-      from: () => ({
-        where: () => ({
-          limit: () => ({
-            for: async () => staleIntentRows,
-          }),
-        }),
-      }),
-    }),
     insert: () => ({
       values: (values: { id: string; status?: string }) => {
         persistenceEvents.push("intent-reserved");
@@ -144,7 +126,6 @@ describe("createEntityVersionFromBuffer", () => {
     pdfDerivativeMock.mockResolvedValue(undefined);
     thumbnailDerivativeMock.mockResolvedValue(undefined);
     diffStatsMock.mockResolvedValue(undefined);
-    staleIntentRows = [];
     persistenceEvents = [];
     intentStatuses = [];
   });
@@ -240,40 +221,6 @@ describe("createEntityVersionFromBuffer", () => {
     });
   });
 
-  test("reconciles a stale durable intent before publishing new bytes", async () => {
-    staleIntentRows = [
-      {
-        declaredMime:
-          "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-        id: toSafeId<"pendingUpload">("019c0000-0000-7000-8000-000000000001"),
-        purposeData: {
-          type: "entity_version",
-          entityId: toSafeId<"entity">("entity_old"),
-          reservedFileId: "019c0000-0000-7000-8000-000000000002",
-        },
-      },
-    ];
-    writeFileVersionMock.mockImplementation(async (input) => {
-      const result = {
-        status: "ok" as const,
-        entityVersionId: input.entityVersionId,
-        fieldId: input.fieldId,
-        versionNumber: 2,
-      };
-      await input.afterWrite(result);
-      return result;
-    });
-
-    const result = await createEntityVersionFromBuffer(baseInput);
-
-    expect(Result.isOk(result)).toBe(true);
-    expect(s3DeleteMock).toHaveBeenCalledTimes(1);
-    expect(s3DeleteMock).toHaveBeenCalledWith(
-      "org_1/ws_1/019c0000-0000-7000-8000-000000000002.docx",
-    );
-    expect(persistenceEvents).toEqual(["intent-reserved", "s3-written"]);
-  });
-
   test("deletes the object when the target rejects under the lock", async () => {
     writeFileVersionMock.mockResolvedValue({ status: "entity-read-only" });
 
@@ -321,7 +268,7 @@ describe("createEntityVersionFromBuffer", () => {
       async <T>(run: (tx: Transaction) => Promise<T>) => {
         safeDbCall += 1;
         const value = await run(createTestTransaction());
-        return safeDbCall === 3 ? Result.err(commitError) : Result.ok(value);
+        return safeDbCall === 2 ? Result.err(commitError) : Result.ok(value);
       },
     );
 

--- a/apps/api/src/handlers/entities/create-version-from-buffer.test.ts
+++ b/apps/api/src/handlers/entities/create-version-from-buffer.test.ts
@@ -1,0 +1,375 @@
+import { Result } from "better-result";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { Transaction } from "@/api/db/root";
+import type { SafeDb } from "@/api/db/safe-db";
+import type { AuditRecorder } from "@/api/lib/audit-log";
+import { toSafeId } from "@/api/lib/branded-types";
+import { FILE_SIZE_LIMIT_BYTES } from "@/api/lib/limits";
+import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
+
+const writeFileVersionMock = mock();
+const s3WriteMock = mock();
+const s3DeleteMock = mock();
+const processExtractionMock = mock();
+const pdfDerivativeMock = mock();
+const thumbnailDerivativeMock = mock();
+const diffStatsMock = mock();
+const broadcastMock = mock();
+let staleIntentRows: {
+  declaredMime: string;
+  id: ReturnType<typeof toSafeId<"pendingUpload">>;
+  purposeData: {
+    type: "entity_version";
+    entityId: ReturnType<typeof toSafeId<"entity">>;
+    reservedFileId: string;
+  };
+}[] = [];
+let persistenceEvents: string[] = [];
+let intentStatuses: string[] = [];
+
+void mock.module("@/api/handlers/entities/write-file-version", () => ({
+  writeFileVersion: writeFileVersionMock,
+}));
+void mock.module("@/api/handlers/files/file-object-ids", () => ({
+  allocateFileObject: () => "file_1",
+}));
+void mock.module("@/api/handlers/files/utils", () => ({
+  createFileKey: () => "org_1/ws_1/file_1.docx",
+}));
+void mock.module("@/api/lib/s3", () => ({
+  getS3: () => ({ write: s3WriteMock, delete: s3DeleteMock }),
+}));
+void mock.module("@/api/lib/search/process-extraction", () => ({
+  processExtraction: processExtractionMock,
+}));
+void mock.module("@/api/lib/file-derivative-queue", () => ({
+  enqueuePdfDerivativeOrMarkFailed: pdfDerivativeMock,
+  enqueueImageThumbnailOrMarkFailed: thumbnailDerivativeMock,
+}));
+void mock.module("@/api/handlers/entities/compute-version-diff", () => ({
+  computeVersionDiffStats: diffStatsMock,
+}));
+void mock.module("@/api/lib/root-scoped-db", () => ({
+  createRootScopedDb: () => mock(),
+}));
+void mock.module("@/api/lib/sse", () => ({ broadcast: broadcastMock }));
+void mock.module("@/api/lib/analytics/capture", () => ({
+  captureError: mock(),
+  captureRequestError: mock(),
+  getAnalytics: () => ({ capture: mock(), flush: mock() }),
+}));
+
+const { createEntityVersionFromBuffer } =
+  await import("@/api/handlers/entities/create-version-from-buffer");
+
+const createTestTransaction = (): Transaction =>
+  asTestRaw<Transaction>({
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          limit: () => ({
+            for: async () => staleIntentRows,
+          }),
+        }),
+      }),
+    }),
+    insert: () => ({
+      values: (values: { id: string; status?: string }) => {
+        persistenceEvents.push("intent-reserved");
+        if (values.status) {
+          intentStatuses.push(values.status);
+        }
+        return {
+          returning: async () => [{ id: values.id }],
+        };
+      },
+    }),
+    update: () => ({
+      set: (values: { status?: string }) => {
+        if (values.status) {
+          intentStatuses.push(values.status);
+        }
+        return {
+          where: () => ({
+            returning: async () => [{ id: "intent_1" }],
+          }),
+        };
+      },
+    }),
+  });
+
+const safeDb = asTestRaw<SafeDb>(
+  async <T>(run: (tx: Transaction) => Promise<T>) =>
+    await Result.tryPromise({
+      try: async () => await run(createTestTransaction()),
+      catch: (cause) => cause,
+    }),
+);
+const recordAuditEvent = asTestRaw<AuditRecorder>(async () => undefined);
+const baseInput = {
+  safeDb,
+  organizationId: toSafeId<"organization">("org_1"),
+  workspaceId: toSafeId<"workspace">("ws_1"),
+  entityId: toSafeId<"entity">("entity_1"),
+  userId: toSafeId<"user">("user_1"),
+  recordAuditEvent,
+  buffer: Buffer.from("filled docx"),
+  fileName: "filled.docx",
+  mimeType:
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+  source: null,
+};
+
+describe("createEntityVersionFromBuffer", () => {
+  beforeEach(() => {
+    for (const fn of [
+      writeFileVersionMock,
+      s3WriteMock,
+      s3DeleteMock,
+      processExtractionMock,
+      pdfDerivativeMock,
+      thumbnailDerivativeMock,
+      diffStatsMock,
+      broadcastMock,
+    ]) {
+      fn.mockReset();
+    }
+    s3WriteMock.mockResolvedValue(undefined);
+    s3WriteMock.mockImplementation(async () => {
+      persistenceEvents.push("s3-written");
+    });
+    s3DeleteMock.mockResolvedValue(undefined);
+    processExtractionMock.mockResolvedValue(undefined);
+    pdfDerivativeMock.mockResolvedValue(undefined);
+    thumbnailDerivativeMock.mockResolvedValue(undefined);
+    diffStatsMock.mockResolvedValue(undefined);
+    staleIntentRows = [];
+    persistenceEvents = [];
+    intentStatuses = [];
+  });
+
+  test("rejects oversized documents before object storage or the transaction", async () => {
+    const result = await createEntityVersionFromBuffer({
+      ...baseInput,
+      buffer: new Uint8Array(FILE_SIZE_LIMIT_BYTES.document + 1),
+    });
+
+    expect(Result.isError(result)).toBe(true);
+    if (Result.isError(result)) {
+      expect(result.error).toEqual(
+        expect.objectContaining({
+          code: "document-too-large",
+          message: `Document exceeds the ${FILE_SIZE_LIMIT_BYTES.document}-byte size limit`,
+        }),
+      );
+    }
+    expect(s3WriteMock).not.toHaveBeenCalled();
+    expect(writeFileVersionMock).not.toHaveBeenCalled();
+    expect(s3DeleteMock).not.toHaveBeenCalled();
+  });
+
+  test("best-effort deletes an object after an ambiguous initial write failure", async () => {
+    const writeError = new Error("object storage timed out");
+    s3WriteMock.mockRejectedValue(writeError);
+
+    const attempted = await Result.tryPromise({
+      try: async () => await createEntityVersionFromBuffer(baseInput),
+      catch: (cause) => cause,
+    });
+
+    expect(Result.isError(attempted)).toBe(true);
+    if (Result.isError(attempted)) {
+      expect(attempted.error).toBe(writeError);
+    }
+    expect(s3DeleteMock).toHaveBeenCalledWith("org_1/ws_1/file_1.docx");
+    expect(writeFileVersionMock).not.toHaveBeenCalled();
+    expect(intentStatuses).toEqual(["scanning", "rejected"]);
+  });
+
+  test("keeps the durable intent recoverable when ambiguous-write cleanup fails", async () => {
+    const writeError = new Error("object storage timed out");
+    s3WriteMock.mockRejectedValue(writeError);
+    s3DeleteMock.mockRejectedValue(new Error("object deletion timed out"));
+
+    const attempted = await Result.tryPromise({
+      try: async () => await createEntityVersionFromBuffer(baseInput),
+      catch: (cause) => cause,
+    });
+
+    expect(Result.isError(attempted)).toBe(true);
+    if (Result.isError(attempted)) {
+      expect(attempted.error).toBe(writeError);
+    }
+    expect(s3DeleteMock).toHaveBeenCalledWith("org_1/ws_1/file_1.docx");
+    expect(intentStatuses).toEqual(["scanning"]);
+  });
+
+  test("stores bytes and delegates the canonical locked transaction", async () => {
+    writeFileVersionMock.mockImplementation(async (input) => {
+      const result = {
+        status: "ok" as const,
+        entityVersionId: input.entityVersionId,
+        fieldId: input.fieldId,
+        versionNumber: 2,
+      };
+      await input.afterWrite(result);
+      return result;
+    });
+
+    const result = await createEntityVersionFromBuffer(baseInput);
+
+    expect(Result.isOk(result)).toBe(true);
+    expect(s3WriteMock).toHaveBeenCalledTimes(1);
+    expect(persistenceEvents).toEqual(["intent-reserved", "s3-written"]);
+    expect(writeFileVersionMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspaceId: "ws_1",
+        entityId: "entity_1",
+        fileId: "file_1",
+        fileName: "filled.docx",
+        sizeBytes: Buffer.byteLength("filled docx"),
+        source: null,
+      }),
+    );
+    expect(s3DeleteMock).not.toHaveBeenCalled();
+    expect(processExtractionMock).toHaveBeenCalledWith("entity_1");
+    expect(broadcastMock).toHaveBeenCalledWith("ws_1", {
+      type: "invalidate-query",
+      data: ["entities", "ws_1"],
+    });
+  });
+
+  test("reconciles a stale durable intent before publishing new bytes", async () => {
+    staleIntentRows = [
+      {
+        declaredMime:
+          "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        id: toSafeId<"pendingUpload">("019c0000-0000-7000-8000-000000000001"),
+        purposeData: {
+          type: "entity_version",
+          entityId: toSafeId<"entity">("entity_old"),
+          reservedFileId: "019c0000-0000-7000-8000-000000000002",
+        },
+      },
+    ];
+    writeFileVersionMock.mockImplementation(async (input) => {
+      const result = {
+        status: "ok" as const,
+        entityVersionId: input.entityVersionId,
+        fieldId: input.fieldId,
+        versionNumber: 2,
+      };
+      await input.afterWrite(result);
+      return result;
+    });
+
+    const result = await createEntityVersionFromBuffer(baseInput);
+
+    expect(Result.isOk(result)).toBe(true);
+    expect(s3DeleteMock).toHaveBeenCalledTimes(1);
+    expect(s3DeleteMock).toHaveBeenCalledWith(
+      "org_1/ws_1/019c0000-0000-7000-8000-000000000002.docx",
+    );
+    expect(persistenceEvents).toEqual(["intent-reserved", "s3-written"]);
+  });
+
+  test("deletes the object when the target rejects under the lock", async () => {
+    writeFileVersionMock.mockResolvedValue({ status: "entity-read-only" });
+
+    const result = await createEntityVersionFromBuffer(baseInput);
+
+    expect(Result.isError(result)).toBe(true);
+    if (Result.isError(result)) {
+      expect(result.error.code).toBe("entity-read-only");
+    }
+    expect(s3DeleteMock).toHaveBeenCalledWith("org_1/ws_1/file_1.docx");
+    expect(processExtractionMock).not.toHaveBeenCalled();
+  });
+
+  test("deletes the object when the transaction callback fails before commit", async () => {
+    writeFileVersionMock.mockRejectedValue(new Error("db unavailable"));
+
+    const attempted = await Result.tryPromise({
+      try: async () => await createEntityVersionFromBuffer(baseInput),
+      catch: (cause) => cause,
+    });
+    expect(Result.isError(attempted)).toBe(true);
+    if (Result.isError(attempted)) {
+      expect(attempted.error).toBeInstanceOf(Error);
+      if (attempted.error instanceof Error) {
+        expect(attempted.error.message).toBe("db unavailable");
+      }
+    }
+    expect(s3DeleteMock).toHaveBeenCalledWith("org_1/ws_1/file_1.docx");
+  });
+
+  test("preserves the object when the commit acknowledgement is ambiguous", async () => {
+    writeFileVersionMock.mockImplementation(async (input) => {
+      const result = {
+        status: "ok" as const,
+        entityVersionId: input.entityVersionId,
+        fieldId: input.fieldId,
+        versionNumber: 2,
+      };
+      await input.afterWrite(result);
+      return result;
+    });
+    const commitError = new Error("connection lost after commit");
+    let safeDbCall = 0;
+    const ambiguousSafeDb = asTestRaw<SafeDb>(
+      async <T>(run: (tx: Transaction) => Promise<T>) => {
+        safeDbCall += 1;
+        const value = await run(createTestTransaction());
+        return safeDbCall === 3 ? Result.err(commitError) : Result.ok(value);
+      },
+    );
+
+    const attempted = await Result.tryPromise({
+      try: async () =>
+        await createEntityVersionFromBuffer({
+          ...baseInput,
+          safeDb: ambiguousSafeDb,
+        }),
+      catch: (cause) => cause,
+    });
+
+    expect(Result.isError(attempted)).toBe(true);
+    if (Result.isError(attempted)) {
+      expect(attempted.error).toBe(commitError);
+    }
+    expect(s3DeleteMock).not.toHaveBeenCalled();
+    expect(processExtractionMock).not.toHaveBeenCalled();
+  });
+
+  test("rolls back persistence when the in-transaction callback fails", async () => {
+    writeFileVersionMock.mockImplementation(async (input) => {
+      const result = {
+        status: "ok" as const,
+        entityVersionId: input.entityVersionId,
+        fieldId: input.fieldId,
+        versionNumber: 2,
+      };
+      await input.afterWrite(result);
+      return result;
+    });
+
+    const attempted = await Result.tryPromise({
+      try: async () =>
+        await createEntityVersionFromBuffer({
+          ...baseInput,
+          afterWrite: async () => {
+            throw new Error("audit failed");
+          },
+        }),
+      catch: (cause) => cause,
+    });
+
+    expect(Result.isError(attempted)).toBe(true);
+    if (Result.isError(attempted) && attempted.error instanceof Error) {
+      expect(attempted.error.message).toBe("audit failed");
+    }
+    expect(s3DeleteMock).toHaveBeenCalledWith("org_1/ws_1/file_1.docx");
+    expect(processExtractionMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/handlers/entities/create-version-from-buffer.ts
+++ b/apps/api/src/handlers/entities/create-version-from-buffer.ts
@@ -1,13 +1,9 @@
 import { Result, TaggedError, panic } from "better-result";
-import { and, eq, inArray } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 
 import type { Transaction } from "@/api/db/root";
 import type { SafeDb } from "@/api/db/safe-db";
-import {
-  bufferObjectCleanupIntents,
-  pendingUploads,
-  PENDING_UPLOAD_RECOVERABLE_STATUSES,
-} from "@/api/db/schema";
+import { pendingUploads } from "@/api/db/schema";
 import { computeVersionDiffStats } from "@/api/handlers/entities/compute-version-diff";
 import { writeFileVersion } from "@/api/handlers/entities/write-file-version";
 import type { WriteFileVersionResult } from "@/api/handlers/entities/write-file-version";
@@ -19,10 +15,10 @@ import { createSafeId } from "@/api/lib/branded-types";
 import type { SafeId } from "@/api/lib/branded-types";
 import {
   BUFFER_INTENT_DELETE_TIMEOUT_MS,
-  BUFFER_INTENT_HEARTBEAT_MS,
-  BUFFER_INTENT_TTL_MS,
   BUFFER_INTENT_WRITE_TIMEOUT_MS,
-  lockActiveWorkspaceForBufferIntent,
+  abandonBufferIntent,
+  reserveBufferIntent,
+  startBufferIntentHeartbeat,
 } from "@/api/lib/buffer-intent-reconciliation";
 import type { DocumentSource } from "@/api/lib/document-source";
 import {
@@ -91,165 +87,10 @@ const ENTITY_VERSION_TARGET_MESSAGES = {
 const messageForStatus = (status: EntityVersionTargetErrorCode): string =>
   ENTITY_VERSION_TARGET_MESSAGES[status];
 
-type BufferVersionIntent = {
-  claimRequestId: string;
-  id: SafeId<"pendingUpload">;
-};
-
-const reserveBufferVersionIntent = async ({
-  safeDb,
-  organizationId,
-  workspaceId,
-  entityId,
-  userId,
-  fileId,
-  fileName,
-  mimeType,
-  sizeBytes,
-  sha256Hex,
-}: Pick<
-  CreateEntityVersionFromBufferInput,
-  "safeDb" | "organizationId" | "workspaceId" | "entityId" | "userId"
-> & {
-  fileId: string;
-  fileName: string;
-  mimeType: string;
-  sizeBytes: number;
-  sha256Hex: string;
-}): Promise<BufferVersionIntent> => {
-  const id = createSafeId<"pendingUpload">();
-  const claimRequestId = Bun.randomUUIDv7().slice(0, 64);
-  const now = new Date();
-  const reserved = await safeDb(async (tx) => {
-    await lockActiveWorkspaceForBufferIntent(tx, workspaceId);
-    // audit: skip — crash-recovery intent; the version transaction records the
-    // durable entity and version events.
-    const rows = await tx
-      .insert(pendingUploads)
-      .values({
-        id,
-        organizationId,
-        workspaceId,
-        userId,
-        purpose: "entity_version",
-        purposeData: {
-          type: "entity_version",
-          entityId,
-          reservedFileId: fileId,
-        },
-        declaredName: fileName,
-        declaredMime: mimeType,
-        declaredSize: sizeBytes,
-        declaredSha256: sha256Hex,
-        status: "scanning",
-        claimedAt: now,
-        claimedByRequestId: claimRequestId,
-        expiresAt: new Date(now.getTime() + BUFFER_INTENT_TTL_MS),
-        createdAt: now,
-      })
-      .returning({ id: pendingUploads.id });
-    return (
-      rows.at(0)?.id ?? panic("Buffer version intent insert returned no row")
-    );
-  });
-  if (Result.isError(reserved)) {
-    throw reserved.error;
-  }
-  return { id: reserved.value, claimRequestId };
-};
-
-const abandonBufferVersionIntent = async ({
-  safeDb,
-  intent,
-  reason,
-}: {
-  safeDb: SafeDb;
-  intent: BufferVersionIntent;
-  reason: string;
-}): Promise<void> => {
-  const abandoned = await safeDb(async (tx) => {
-    // audit: skip — failed intent bookkeeping; no durable version was created.
-    // The writer reaches this only after its PUT settled and deletion of its
-    // exact reserved key succeeded. It may therefore close a recoverable row
-    // even when the reconciler replaced its expired lease in the meantime.
-    await tx
-      .update(pendingUploads)
-      .set({
-        finalizedAt: new Date(),
-        rejectReason: reason,
-        status: "rejected",
-      })
-      .where(
-        and(
-          eq(pendingUploads.id, intent.id),
-          inArray(pendingUploads.status, PENDING_UPLOAD_RECOVERABLE_STATUSES),
-        ),
-      );
-    await tx
-      .delete(bufferObjectCleanupIntents)
-      .where(eq(bufferObjectCleanupIntents.id, intent.id));
-  });
-  if (Result.isError(abandoned)) {
-    captureError(abandoned.error, {
-      pendingUploadId: intent.id,
-      stage: "buffer-version-intent-abandon",
-    });
-  }
-};
-
-const startBufferVersionIntentHeartbeat = ({
-  safeDb,
-  intent,
-}: {
-  safeDb: SafeDb;
-  intent: BufferVersionIntent;
-}): (() => Promise<void>) => {
-  let heartbeatPromise: Promise<void> | null = null;
-  let stopped = false;
-  const heartbeat = async (): Promise<void> => {
-    try {
-      const renewed = await safeDb(async (tx) => {
-        // audit: skip — live crash-recovery lease bookkeeping only.
-        await tx
-          .update(pendingUploads)
-          .set({ claimedAt: new Date() })
-          .where(
-            and(
-              eq(pendingUploads.id, intent.id),
-              eq(pendingUploads.status, "scanning"),
-              eq(pendingUploads.claimedByRequestId, intent.claimRequestId),
-            ),
-          );
-      });
-      if (Result.isError(renewed)) {
-        captureError(renewed.error, {
-          pendingUploadId: intent.id,
-          stage: "buffer-version-intent-heartbeat",
-        });
-      }
-    } catch (error) {
-      captureError(error, {
-        pendingUploadId: intent.id,
-        stage: "buffer-version-intent-heartbeat-unhandled",
-      });
-    } finally {
-      heartbeatPromise = null;
-    }
-  };
-  const triggerHeartbeat = (): void => {
-    if (heartbeatPromise !== null || stopped) {
-      return;
-    }
-    heartbeatPromise = heartbeat();
-  };
-  const timer = setInterval(triggerHeartbeat, BUFFER_INTENT_HEARTBEAT_MS);
-  timer.unref();
-
-  return async () => {
-    stopped = true;
-    clearInterval(timer);
-    await heartbeatPromise;
-  };
+const VERSION_BUFFER_INTENT_TELEMETRY = {
+  abandon: "buffer-version-intent-abandon",
+  heartbeat: "buffer-version-intent-heartbeat",
+  heartbeatUnhandled: "buffer-version-intent-heartbeat-unhandled",
 };
 
 /** Persist trusted server-generated bytes as a new version of an entity. */
@@ -293,22 +134,27 @@ export const createEntityVersionFromBuffer = async ({
   // the S3 write can therefore be distinguished from a committed version and
   // cleaned by the bounded scheduler without adding a repair query to every
   // request.
-  const intent = await reserveBufferVersionIntent({
+  const intent = await reserveBufferIntent({
     safeDb,
     organizationId,
     workspaceId,
-    entityId,
     userId,
-    fileId,
+    purpose: "entity_version",
+    purposeData: {
+      type: "entity_version",
+      entityId,
+      reservedFileId: fileId,
+    },
     fileName,
     mimeType,
     sizeBytes: bytes.byteLength,
     sha256Hex,
   });
 
-  const stopIntentHeartbeat = startBufferVersionIntentHeartbeat({
+  const stopIntentHeartbeat = startBufferIntentHeartbeat({
     safeDb,
     intent,
+    telemetry: VERSION_BUFFER_INTENT_TELEMETRY,
   });
   let written: Extract<WriteFileVersionResult, { status: "ok" }>;
   try {
@@ -333,7 +179,8 @@ export const createEntityVersionFromBuffer = async ({
 
     try {
       await withTimeout(
-        async (signal) => await putS3ObjectWithSignal(objectKey, bytes, signal),
+        async (signal) =>
+          await putS3ObjectWithSignal(objectKey, bytes, mimeType, signal),
         {
           label: "buffer-version-writer-put",
           timeoutMs: BUFFER_INTENT_WRITE_TIMEOUT_MS,
@@ -413,10 +260,11 @@ export const createEntityVersionFromBuffer = async ({
         !transactionState.durableReferencePrepared &&
         (await cleanupObject())
       ) {
-        await abandonBufferVersionIntent({
+        await abandonBufferIntent({
           safeDb,
           intent,
           reason: "Server-generated version transaction failed",
+          telemetry: VERSION_BUFFER_INTENT_TELEMETRY,
         });
       }
       throw writeResult.error;
@@ -425,10 +273,11 @@ export const createEntityVersionFromBuffer = async ({
 
     if (writeOutcome.status !== "ok") {
       if (await cleanupObject()) {
-        await abandonBufferVersionIntent({
+        await abandonBufferIntent({
           safeDb,
           intent,
           reason: `Server-generated version rejected: ${writeOutcome.status}`,
+          telemetry: VERSION_BUFFER_INTENT_TELEMETRY,
         });
       }
       return Result.err(

--- a/apps/api/src/handlers/entities/create-version-from-buffer.ts
+++ b/apps/api/src/handlers/entities/create-version-from-buffer.ts
@@ -341,16 +341,10 @@ export const createEntityVersionFromBuffer = async ({
       );
     } catch (error) {
       // A timeout or connection failure can be ambiguous: object storage may
-      // have accepted the complete object even though the client saw an error.
-      // Terminalize the intent only after confirmed deletion; otherwise its
-      // live lease remains recoverable by the bounded reconciler.
-      if (await cleanupObject()) {
-        await abandonBufferVersionIntent({
-          safeDb,
-          intent,
-          reason: "Server-generated version object write failed",
-        });
-      }
+      // publish after the immediate delete completes. Keep the intent
+      // recoverable so later sweeps remove any late publication; the
+      // heartbeat stops in finally below.
+      await cleanupObject();
       throw error;
     }
 

--- a/apps/api/src/handlers/entities/create-version-from-buffer.ts
+++ b/apps/api/src/handlers/entities/create-version-from-buffer.ts
@@ -16,7 +16,6 @@ import type { SafeId } from "@/api/lib/branded-types";
 import {
   BUFFER_INTENT_HEARTBEAT_MS,
   BUFFER_INTENT_TTL_MS,
-  reconcileStaleBufferIntents,
 } from "@/api/lib/buffer-intent-reconciliation";
 import type { DocumentSource } from "@/api/lib/document-source";
 import {
@@ -276,16 +275,10 @@ export const createEntityVersionFromBuffer = async ({
     mimeType,
   });
 
-  // Reconcile older crash leftovers before publishing another final object,
-  // then durably reserve this exact file id. A hard death after the S3 write
-  // can therefore be distinguished from a committed version and cleaned by a
-  // later bounded reconciliation pass.
-  await reconcileStaleBufferIntents({
-    safeDb,
-    organizationId,
-    workspaceId,
-    purpose: "entity_version",
-  });
+  // Durably reserve this exact file id before publishing. A hard death after
+  // the S3 write can therefore be distinguished from a committed version and
+  // cleaned by the bounded scheduler without adding a repair query to every
+  // request.
   const intent = await reserveBufferVersionIntent({
     safeDb,
     organizationId,

--- a/apps/api/src/handlers/entities/create-version-from-buffer.ts
+++ b/apps/api/src/handlers/entities/create-version-from-buffer.ts
@@ -1,0 +1,482 @@
+import { Result, TaggedError, panic } from "better-result";
+import { and, eq } from "drizzle-orm";
+
+import type { Transaction } from "@/api/db/root";
+import type { SafeDb } from "@/api/db/safe-db";
+import { pendingUploads } from "@/api/db/schema";
+import { computeVersionDiffStats } from "@/api/handlers/entities/compute-version-diff";
+import { writeFileVersion } from "@/api/handlers/entities/write-file-version";
+import type { WriteFileVersionResult } from "@/api/handlers/entities/write-file-version";
+import { allocateFileObject } from "@/api/handlers/files/file-object-ids";
+import { createFileKey } from "@/api/handlers/files/utils";
+import { captureError } from "@/api/lib/analytics/capture";
+import type { AuditRecorder } from "@/api/lib/audit-log";
+import { createSafeId } from "@/api/lib/branded-types";
+import type { SafeId } from "@/api/lib/branded-types";
+import {
+  BUFFER_INTENT_HEARTBEAT_MS,
+  BUFFER_INTENT_TTL_MS,
+  reconcileStaleBufferIntents,
+} from "@/api/lib/buffer-intent-reconciliation";
+import type { DocumentSource } from "@/api/lib/document-source";
+import {
+  enqueueImageThumbnailOrMarkFailed,
+  enqueuePdfDerivativeOrMarkFailed,
+} from "@/api/lib/file-derivative-queue";
+import { FILE_SIZE_LIMIT_BYTES } from "@/api/lib/limits";
+import { createRootScopedDb } from "@/api/lib/root-scoped-db";
+import { getS3 } from "@/api/lib/s3";
+import { sanitizeFilenamePreservingExtension } from "@/api/lib/sanitize-filename";
+import { processExtraction } from "@/api/lib/search/process-extraction";
+import { broadcast } from "@/api/lib/sse";
+
+class EntityVersionTargetError extends TaggedError("EntityVersionTargetError")<{
+  code:
+    | "current-version-not-found"
+    | "document-too-large"
+    | "entity-not-found"
+    | "entity-read-only"
+    | "missing-file-field";
+  message: string;
+}>() {}
+
+type EntityVersionTargetErrorCode = EntityVersionTargetError["code"];
+
+type CreateEntityVersionFromBufferInput = {
+  safeDb: SafeDb;
+  organizationId: SafeId<"organization">;
+  workspaceId: SafeId<"workspace">;
+  entityId: SafeId<"entity">;
+  userId: SafeId<"user">;
+  recordAuditEvent: AuditRecorder;
+  buffer: Uint8Array | ArrayBuffer;
+  fileName: string;
+  mimeType: string;
+  source: DocumentSource | null;
+  scanWarnings?: string[] | undefined;
+  afterWrite?:
+    | ((
+        tx: Transaction,
+        result: Extract<WriteFileVersionResult, { status: "ok" }>,
+      ) => Promise<void>)
+    | undefined;
+};
+
+export type CreateEntityVersionFromBufferResult = Result<
+  {
+    entityId: SafeId<"entity">;
+    entityVersionId: SafeId<"entityVersion">;
+    fieldId: SafeId<"field">;
+    fileName: string;
+    versionNumber: number;
+  },
+  EntityVersionTargetError
+>;
+
+const ENTITY_VERSION_TARGET_MESSAGES = {
+  "entity-not-found": "Entity not found",
+  "entity-read-only": "Entity is read-only",
+  "current-version-not-found": "Current version not found",
+  "document-too-large": `Document exceeds the ${FILE_SIZE_LIMIT_BYTES.document}-byte size limit`,
+  "missing-file-field": "Entity has no file field",
+} satisfies Record<EntityVersionTargetErrorCode, string>;
+
+const messageForStatus = (status: EntityVersionTargetErrorCode): string =>
+  ENTITY_VERSION_TARGET_MESSAGES[status];
+
+type BufferVersionIntent = {
+  claimRequestId: string;
+  id: SafeId<"pendingUpload">;
+};
+
+const reserveBufferVersionIntent = async ({
+  safeDb,
+  organizationId,
+  workspaceId,
+  entityId,
+  userId,
+  fileId,
+  fileName,
+  mimeType,
+  sizeBytes,
+  sha256Hex,
+}: Pick<
+  CreateEntityVersionFromBufferInput,
+  "safeDb" | "organizationId" | "workspaceId" | "entityId" | "userId"
+> & {
+  fileId: string;
+  fileName: string;
+  mimeType: string;
+  sizeBytes: number;
+  sha256Hex: string;
+}): Promise<BufferVersionIntent> => {
+  const id = createSafeId<"pendingUpload">();
+  const claimRequestId = Bun.randomUUIDv7().slice(0, 64);
+  const now = new Date();
+  const reserved = await safeDb(async (tx) => {
+    // audit: skip — crash-recovery intent; the version transaction records the
+    // durable entity and version events.
+    const rows = await tx
+      .insert(pendingUploads)
+      .values({
+        id,
+        organizationId,
+        workspaceId,
+        userId,
+        purpose: "entity_version",
+        purposeData: {
+          type: "entity_version",
+          entityId,
+          reservedFileId: fileId,
+        },
+        declaredName: fileName,
+        declaredMime: mimeType,
+        declaredSize: sizeBytes,
+        declaredSha256: sha256Hex,
+        status: "scanning",
+        claimedAt: now,
+        claimedByRequestId: claimRequestId,
+        expiresAt: new Date(now.getTime() + BUFFER_INTENT_TTL_MS),
+        createdAt: now,
+      })
+      .returning({ id: pendingUploads.id });
+    return (
+      rows.at(0)?.id ?? panic("Buffer version intent insert returned no row")
+    );
+  });
+  if (Result.isError(reserved)) {
+    throw reserved.error;
+  }
+  return { id: reserved.value, claimRequestId };
+};
+
+const abandonBufferVersionIntent = async ({
+  safeDb,
+  intent,
+  reason,
+}: {
+  safeDb: SafeDb;
+  intent: BufferVersionIntent;
+  reason: string;
+}): Promise<void> => {
+  const abandoned = await safeDb(async (tx) => {
+    // audit: skip — failed intent bookkeeping; no durable version was created.
+    await tx
+      .update(pendingUploads)
+      .set({
+        finalizedAt: new Date(),
+        rejectReason: reason,
+        status: "rejected",
+      })
+      .where(
+        and(
+          eq(pendingUploads.id, intent.id),
+          eq(pendingUploads.status, "scanning"),
+          eq(pendingUploads.claimedByRequestId, intent.claimRequestId),
+        ),
+      );
+  });
+  if (Result.isError(abandoned)) {
+    captureError(abandoned.error, {
+      pendingUploadId: intent.id,
+      stage: "buffer-version-intent-abandon",
+    });
+  }
+};
+
+const startBufferVersionIntentHeartbeat = ({
+  safeDb,
+  intent,
+}: {
+  safeDb: SafeDb;
+  intent: BufferVersionIntent;
+}): (() => Promise<void>) => {
+  let heartbeatPromise: Promise<void> | null = null;
+  let stopped = false;
+  const heartbeat = async (): Promise<void> => {
+    try {
+      const renewed = await safeDb(async (tx) => {
+        // audit: skip — live crash-recovery lease bookkeeping only.
+        await tx
+          .update(pendingUploads)
+          .set({ claimedAt: new Date() })
+          .where(
+            and(
+              eq(pendingUploads.id, intent.id),
+              eq(pendingUploads.status, "scanning"),
+              eq(pendingUploads.claimedByRequestId, intent.claimRequestId),
+            ),
+          );
+      });
+      if (Result.isError(renewed)) {
+        captureError(renewed.error, {
+          pendingUploadId: intent.id,
+          stage: "buffer-version-intent-heartbeat",
+        });
+      }
+    } catch (error) {
+      captureError(error, {
+        pendingUploadId: intent.id,
+        stage: "buffer-version-intent-heartbeat-unhandled",
+      });
+    } finally {
+      heartbeatPromise = null;
+    }
+  };
+  const triggerHeartbeat = (): void => {
+    if (heartbeatPromise !== null || stopped) {
+      return;
+    }
+    heartbeatPromise = heartbeat();
+  };
+  const timer = setInterval(triggerHeartbeat, BUFFER_INTENT_HEARTBEAT_MS);
+  timer.unref();
+
+  return async () => {
+    stopped = true;
+    clearInterval(timer);
+    await heartbeatPromise;
+  };
+};
+
+/** Persist trusted server-generated bytes as a new version of an entity. */
+export const createEntityVersionFromBuffer = async ({
+  safeDb,
+  organizationId,
+  workspaceId,
+  entityId,
+  userId,
+  recordAuditEvent,
+  buffer,
+  fileName: rawFileName,
+  mimeType,
+  source,
+  scanWarnings,
+  afterWrite,
+}: CreateEntityVersionFromBufferInput): Promise<CreateEntityVersionFromBufferResult> => {
+  const bytes = buffer instanceof Uint8Array ? buffer : new Uint8Array(buffer);
+  if (bytes.byteLength > FILE_SIZE_LIMIT_BYTES.document) {
+    return Result.err(
+      new EntityVersionTargetError({
+        code: "document-too-large",
+        message: messageForStatus("document-too-large"),
+      }),
+    );
+  }
+
+  const fileName = sanitizeFilenamePreservingExtension(rawFileName);
+  const fileId = allocateFileObject();
+  const entityVersionId = createSafeId<"entityVersion">();
+  const fieldId = createSafeId<"field">();
+  const sha256Hex = new Bun.CryptoHasher("sha256").update(bytes).digest("hex");
+  const objectKey = createFileKey({
+    organizationId,
+    workspaceId,
+    fileId,
+    mimeType,
+  });
+
+  // Reconcile older crash leftovers before publishing another final object,
+  // then durably reserve this exact file id. A hard death after the S3 write
+  // can therefore be distinguished from a committed version and cleaned by a
+  // later bounded reconciliation pass.
+  await reconcileStaleBufferIntents({
+    safeDb,
+    organizationId,
+    workspaceId,
+    purpose: "entity_version",
+  });
+  const intent = await reserveBufferVersionIntent({
+    safeDb,
+    organizationId,
+    workspaceId,
+    entityId,
+    userId,
+    fileId,
+    fileName,
+    mimeType,
+    sizeBytes: bytes.byteLength,
+    sha256Hex,
+  });
+
+  const stopIntentHeartbeat = startBufferVersionIntentHeartbeat({
+    safeDb,
+    intent,
+  });
+  let written: Extract<WriteFileVersionResult, { status: "ok" }>;
+  try {
+    const cleanupObject = async (): Promise<boolean> => {
+      const cleanup = await Result.tryPromise({
+        try: async () => await getS3().delete(objectKey),
+        catch: (cause) => cause,
+      });
+      if (Result.isError(cleanup)) {
+        captureError(cleanup.error, { entityId, objectKey });
+        return false;
+      }
+      return true;
+    };
+
+    try {
+      await getS3().write(objectKey, bytes);
+    } catch (error) {
+      // A timeout or connection failure can be ambiguous: object storage may
+      // have accepted the complete object even though the client saw an error.
+      // Terminalize the intent only after confirmed deletion; otherwise its
+      // live lease remains recoverable by the bounded reconciler.
+      if (await cleanupObject()) {
+        await abandonBufferVersionIntent({
+          safeDb,
+          intent,
+          reason: "Server-generated version object write failed",
+        });
+      }
+      throw error;
+    }
+
+    // `safeDb` cannot distinguish a callback failure (which necessarily rolls
+    // back) from a lost COMMIT acknowledgement (which may already be durable).
+    // The intent is finalized atomically with the version. Track whether that
+    // durable reference was prepared so ambiguous acknowledgements preserve the
+    // object; a rolled-back intent remains recoverable by the bounded janitor.
+    const transactionState = { durableReferencePrepared: false };
+    const writeResult = await safeDb(async (tx) => {
+      const versionWriteResult = await writeFileVersion({
+        tx,
+        workspaceId,
+        entityId,
+        userId,
+        recordAuditEvent,
+        entityVersionId,
+        fieldId,
+        fileId,
+        fileName,
+        mimeType,
+        sizeBytes: bytes.byteLength,
+        sha256Hex,
+        source,
+        scanWarnings,
+        afterWrite: async (result) => {
+          const finalizedResult = {
+            type: "entity_version" as const,
+            entityId,
+            entityVersionId,
+            versionNumber: result.versionNumber,
+            fileId,
+            fileName,
+          };
+          // audit: skip — intent bookkeeping is atomic with the audited entity
+          // and version mutations performed by writeFileVersion.
+          const rows = await tx
+            .update(pendingUploads)
+            .set({
+              status: "finalized",
+              finalizedResult,
+              finalizedAt: new Date(),
+            })
+            .where(
+              and(
+                eq(pendingUploads.id, intent.id),
+                eq(pendingUploads.status, "scanning"),
+                eq(pendingUploads.claimedByRequestId, intent.claimRequestId),
+              ),
+            )
+            .returning({ id: pendingUploads.id });
+          if (!rows.at(0)) {
+            panic("Buffer version intent finalize returned no row");
+          }
+          if (afterWrite !== undefined) {
+            await afterWrite(tx, result);
+          }
+        },
+      });
+      transactionState.durableReferencePrepared =
+        versionWriteResult.status === "ok";
+      return versionWriteResult;
+    });
+    if (Result.isError(writeResult)) {
+      if (
+        !transactionState.durableReferencePrepared &&
+        (await cleanupObject())
+      ) {
+        await abandonBufferVersionIntent({
+          safeDb,
+          intent,
+          reason: "Server-generated version transaction failed",
+        });
+      }
+      throw writeResult.error;
+    }
+    const writeOutcome = writeResult.value;
+
+    if (writeOutcome.status !== "ok") {
+      if (await cleanupObject()) {
+        await abandonBufferVersionIntent({
+          safeDb,
+          intent,
+          reason: `Server-generated version rejected: ${writeOutcome.status}`,
+        });
+      }
+      return Result.err(
+        new EntityVersionTargetError({
+          code: writeOutcome.status,
+          message: messageForStatus(writeOutcome.status),
+        }),
+      );
+    }
+    written = writeOutcome;
+  } finally {
+    await stopIntentHeartbeat();
+  }
+
+  processExtraction(entityId).catch((error: unknown) => {
+    captureError(error, { entityId });
+  });
+  enqueuePdfDerivativeOrMarkFailed({
+    encrypted: false,
+    entityId,
+    fieldId,
+    mimeType,
+    organizationId,
+    userId,
+    workspaceId,
+  }).catch((error: unknown) => {
+    captureError(error, { entityId, fieldId, mimeType });
+  });
+  enqueueImageThumbnailOrMarkFailed({
+    encrypted: false,
+    entityId,
+    fieldId,
+    mimeType,
+    organizationId,
+    userId,
+    workspaceId,
+  }).catch((error: unknown) => {
+    captureError(error, { entityId, fieldId, mimeType });
+  });
+  computeVersionDiffStats({
+    versionId: entityVersionId,
+    entityId,
+    scopedDb: createRootScopedDb({
+      organizationId,
+      userId,
+      workspaceIds: [workspaceId],
+    }),
+    workspaceId,
+    organizationId,
+  }).catch((error: unknown) => {
+    captureError(error, { versionId: entityVersionId });
+  });
+  broadcast(workspaceId, {
+    type: "invalidate-query",
+    data: ["entities", workspaceId],
+  });
+
+  return Result.ok({
+    entityId,
+    entityVersionId,
+    fieldId,
+    fileName,
+    versionNumber: written.versionNumber,
+  });
+};

--- a/apps/api/src/handlers/entities/create-version-from-buffer.ts
+++ b/apps/api/src/handlers/entities/create-version-from-buffer.ts
@@ -1,9 +1,12 @@
 import { Result, TaggedError, panic } from "better-result";
-import { and, eq } from "drizzle-orm";
+import { and, eq, inArray } from "drizzle-orm";
 
 import type { Transaction } from "@/api/db/root";
 import type { SafeDb } from "@/api/db/safe-db";
-import { pendingUploads } from "@/api/db/schema";
+import {
+  pendingUploads,
+  PENDING_UPLOAD_RECOVERABLE_STATUSES,
+} from "@/api/db/schema";
 import { computeVersionDiffStats } from "@/api/handlers/entities/compute-version-diff";
 import { writeFileVersion } from "@/api/handlers/entities/write-file-version";
 import type { WriteFileVersionResult } from "@/api/handlers/entities/write-file-version";
@@ -160,6 +163,9 @@ const abandonBufferVersionIntent = async ({
 }): Promise<void> => {
   const abandoned = await safeDb(async (tx) => {
     // audit: skip — failed intent bookkeeping; no durable version was created.
+    // The writer reaches this only after its PUT settled and deletion of its
+    // exact reserved key succeeded. It may therefore close a recoverable row
+    // even when the reconciler replaced its expired lease in the meantime.
     await tx
       .update(pendingUploads)
       .set({
@@ -170,8 +176,7 @@ const abandonBufferVersionIntent = async ({
       .where(
         and(
           eq(pendingUploads.id, intent.id),
-          eq(pendingUploads.status, "scanning"),
-          eq(pendingUploads.claimedByRequestId, intent.claimRequestId),
+          inArray(pendingUploads.status, PENDING_UPLOAD_RECOVERABLE_STATUSES),
         ),
       );
   });

--- a/apps/api/src/handlers/entities/create-version-from-buffer.ts
+++ b/apps/api/src/handlers/entities/create-version-from-buffer.ts
@@ -21,6 +21,7 @@ import {
   BUFFER_INTENT_DELETE_TIMEOUT_MS,
   BUFFER_INTENT_HEARTBEAT_MS,
   BUFFER_INTENT_TTL_MS,
+  BUFFER_INTENT_WRITE_TIMEOUT_MS,
   lockActiveWorkspaceForBufferIntent,
 } from "@/api/lib/buffer-intent-reconciliation";
 import type { DocumentSource } from "@/api/lib/document-source";
@@ -30,7 +31,7 @@ import {
 } from "@/api/lib/file-derivative-queue";
 import { FILE_SIZE_LIMIT_BYTES } from "@/api/lib/limits";
 import { createRootScopedDb } from "@/api/lib/root-scoped-db";
-import { deleteS3ObjectWithSignal, getS3 } from "@/api/lib/s3";
+import { deleteS3ObjectWithSignal, putS3ObjectWithSignal } from "@/api/lib/s3";
 import { sanitizeFilenamePreservingExtension } from "@/api/lib/sanitize-filename";
 import { processExtraction } from "@/api/lib/search/process-extraction";
 import { broadcast } from "@/api/lib/sse";
@@ -331,7 +332,13 @@ export const createEntityVersionFromBuffer = async ({
     };
 
     try {
-      await getS3().write(objectKey, bytes);
+      await withTimeout(
+        async (signal) => await putS3ObjectWithSignal(objectKey, bytes, signal),
+        {
+          label: "buffer-version-writer-put",
+          timeoutMs: BUFFER_INTENT_WRITE_TIMEOUT_MS,
+        },
+      );
     } catch (error) {
       // A timeout or connection failure can be ambiguous: object storage may
       // have accepted the complete object even though the client saw an error.

--- a/apps/api/src/handlers/entities/create-version-from-buffer.ts
+++ b/apps/api/src/handlers/entities/create-version-from-buffer.ts
@@ -4,6 +4,7 @@ import { and, eq, inArray } from "drizzle-orm";
 import type { Transaction } from "@/api/db/root";
 import type { SafeDb } from "@/api/db/safe-db";
 import {
+  bufferObjectCleanupIntents,
   pendingUploads,
   PENDING_UPLOAD_RECOVERABLE_STATUSES,
 } from "@/api/db/schema";
@@ -179,6 +180,9 @@ const abandonBufferVersionIntent = async ({
           inArray(pendingUploads.status, PENDING_UPLOAD_RECOVERABLE_STATUSES),
         ),
       );
+    await tx
+      .delete(bufferObjectCleanupIntents)
+      .where(eq(bufferObjectCleanupIntents.id, intent.id));
   });
   if (Result.isError(abandoned)) {
     captureError(abandoned.error, {

--- a/apps/api/src/handlers/entities/create-version-from-buffer.ts
+++ b/apps/api/src/handlers/entities/create-version-from-buffer.ts
@@ -18,6 +18,7 @@ import type { AuditRecorder } from "@/api/lib/audit-log";
 import { createSafeId } from "@/api/lib/branded-types";
 import type { SafeId } from "@/api/lib/branded-types";
 import {
+  BUFFER_INTENT_DELETE_TIMEOUT_MS,
   BUFFER_INTENT_HEARTBEAT_MS,
   BUFFER_INTENT_TTL_MS,
 } from "@/api/lib/buffer-intent-reconciliation";
@@ -28,10 +29,11 @@ import {
 } from "@/api/lib/file-derivative-queue";
 import { FILE_SIZE_LIMIT_BYTES } from "@/api/lib/limits";
 import { createRootScopedDb } from "@/api/lib/root-scoped-db";
-import { getS3 } from "@/api/lib/s3";
+import { deleteS3ObjectWithSignal, getS3 } from "@/api/lib/s3";
 import { sanitizeFilenamePreservingExtension } from "@/api/lib/sanitize-filename";
 import { processExtraction } from "@/api/lib/search/process-extraction";
 import { broadcast } from "@/api/lib/sse";
+import { withTimeout } from "@/api/lib/with-timeout";
 
 class EntityVersionTargetError extends TaggedError("EntityVersionTargetError")<{
   code:
@@ -309,7 +311,14 @@ export const createEntityVersionFromBuffer = async ({
   try {
     const cleanupObject = async (): Promise<boolean> => {
       const cleanup = await Result.tryPromise({
-        try: async () => await getS3().delete(objectKey),
+        try: async () =>
+          await withTimeout(
+            async (signal) => await deleteS3ObjectWithSignal(objectKey, signal),
+            {
+              label: "buffer-version-writer-cleanup.delete",
+              timeoutMs: BUFFER_INTENT_DELETE_TIMEOUT_MS,
+            },
+          ),
         catch: (cause) => cause,
       });
       if (Result.isError(cleanup)) {

--- a/apps/api/src/handlers/entities/create-version-from-buffer.ts
+++ b/apps/api/src/handlers/entities/create-version-from-buffer.ts
@@ -21,6 +21,7 @@ import {
   BUFFER_INTENT_DELETE_TIMEOUT_MS,
   BUFFER_INTENT_HEARTBEAT_MS,
   BUFFER_INTENT_TTL_MS,
+  lockActiveWorkspaceForBufferIntent,
 } from "@/api/lib/buffer-intent-reconciliation";
 import type { DocumentSource } from "@/api/lib/document-source";
 import {
@@ -119,6 +120,7 @@ const reserveBufferVersionIntent = async ({
   const claimRequestId = Bun.randomUUIDv7().slice(0, 64);
   const now = new Date();
   const reserved = await safeDb(async (tx) => {
+    await lockActiveWorkspaceForBufferIntent(tx, workspaceId);
     // audit: skip — crash-recovery intent; the version transaction records the
     // durable entity and version events.
     const rows = await tx

--- a/apps/api/src/handlers/entities/delete-version.test.ts
+++ b/apps/api/src/handlers/entities/delete-version.test.ts
@@ -253,25 +253,6 @@ describe("delete-version chain-of-custody guard", () => {
             "Version-number allocator (nextEntityVersionNumber): MAX(versionNumber) deliberately spans tombstones so a new version never reuses a withdrawn number; reads versionNumber only, no content.",
         },
       ],
-      "handlers/entities/upload-version.ts": [
-        {
-          anchor: "currentVersion.fields.find",
-          reason:
-            "New-version upload: reads the current version's fields to carry them forward. currentVersionId is invariant-live (tombstoning promotes it off a withdrawn row).",
-        },
-        {
-          anchor: "freshCurrentVersion.fields.find",
-          reason:
-            "Same carry-forward read, re-taken under the entity-cap lock; currentVersionId is invariant-live.",
-        },
-      ],
-      "handlers/uploads/entity-version.ts": [
-        {
-          anchor: "freshCurrentVersionId",
-          reason:
-            "Presigned-upload finalize: reads the locked current version's fields to carry forward into a new version; currentVersionId is invariant-live.",
-        },
-      ],
       "handlers/entities/finalize-desktop-edit-session.ts": [
         {
           anchor: "editSession.baseVersionId",

--- a/apps/api/src/handlers/entities/translate.test.ts
+++ b/apps/api/src/handlers/entities/translate.test.ts
@@ -51,6 +51,7 @@ void mock.module("@/api/lib/content-encryption", () => ({
 }));
 
 void mock.module("@/api/lib/s3", () => ({
+  deleteS3ObjectWithSignal: s3DeleteMock,
   getS3: () => ({
     file: () => ({
       arrayBuffer: async () => new Uint8Array([80, 75, 3, 4]).buffer,
@@ -58,6 +59,7 @@ void mock.module("@/api/lib/s3", () => ({
     write: s3WriteMock,
     delete: s3DeleteMock,
   }),
+  putS3ObjectWithSignal: s3WriteMock,
 }));
 
 void mock.module("@/api/lib/file-scan/scan", () => ({

--- a/apps/api/src/handlers/entities/upload-version.ts
+++ b/apps/api/src/handlers/entities/upload-version.ts
@@ -1,43 +1,13 @@
 import { Result } from "better-result";
-import { and, eq } from "drizzle-orm";
 
-import {
-  cellMetadata,
-  entities,
-  entityVersions,
-  fields,
-  workspaces,
-} from "@/api/db/schema";
-import { computeVersionDiffStats } from "@/api/handlers/entities/compute-version-diff";
+import { createEntityVersionFromBuffer } from "@/api/handlers/entities/create-version-from-buffer";
 import { uploadVersionBodySchema } from "@/api/handlers/entities/upload-version-schema";
-import {
-  buildVersionStamp,
-  cloneFieldsForRevision,
-  nextEntityVersionNumber,
-} from "@/api/handlers/entities/version-utils";
-import {
-  allocateFileObject,
-  fileContentWithMintedObject,
-} from "@/api/handlers/files/file-object-ids";
-import { pdfDerivativeStateForFile } from "@/api/handlers/files/gotenberg";
-import { thumbnailDerivativeStateForFile } from "@/api/handlers/files/image-derivative";
-import { createFileKey } from "@/api/handlers/files/utils";
-import { captureError } from "@/api/lib/analytics/capture";
 import { createSafeHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
-import { AUDIT_ACTION, AUDIT_RESOURCE_TYPE } from "@/api/lib/audit-log";
-import { createSafeId } from "@/api/lib/branded-types";
+import { UPLOAD_DOCUMENT_SOURCE } from "@/api/lib/document-source";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
-import {
-  enqueueImageThumbnailOrMarkFailed,
-  enqueuePdfDerivativeOrMarkFailed,
-} from "@/api/lib/file-derivative-queue";
 import { getScanWarnings, scanFile } from "@/api/lib/file-scan/scan";
-import { createRootScopedDb } from "@/api/lib/root-scoped-db";
-import { getS3 } from "@/api/lib/s3";
 import { sanitizeFilename } from "@/api/lib/sanitize-filename";
-import { processExtraction } from "@/api/lib/search/process-extraction";
-import { broadcast } from "@/api/lib/sse";
 
 const config = {
   permissions: { entity: ["update"] },
@@ -45,19 +15,14 @@ const config = {
   body: uploadVersionBodySchema,
 } satisfies HandlerConfig;
 
-type UploadVersionWriteResult =
-  | {
-      status: "ok";
-      versionNumber: number;
-    }
-  | {
-      status:
-        | "current-version-not-found"
-        | "entity-not-found"
-        | "entity-read-only"
-        | "missing-file-field";
-    };
-
+/**
+ * Legacy multipart transport for creating an entity version. The canonical
+ * persistence transaction lives in createEntityVersionFromBuffer, which is
+ * also used by server-generated template fills; the presigned transport joins
+ * the same writeFileVersion transaction after promoting its staged object.
+ *
+ * @yields Safe database and handler errors to createSafeHandler.
+ */
 export default createSafeHandler(
   config,
   async function* ({
@@ -73,7 +38,8 @@ export default createSafeHandler(
     const { entityId, file } = body;
     const sanitizedName = sanitizeFilename(file.name);
 
-    // Verify entity exists and get current version info
+    // Reject an invalid target before spending scan/storage work. The shared
+    // transaction repeats these checks under FOR UPDATE to close the race.
     const entity = yield* Result.await(
       safeDb((tx) =>
         tx.query.entities.findFirst({
@@ -81,17 +47,11 @@ export default createSafeHandler(
             id: { eq: entityId },
             workspaceId: { eq: workspaceId },
           },
-          columns: {
-            currentVersionId: true,
-            docSequence: true,
-            id: true,
-            readOnly: true,
-          },
+          columns: { currentVersionId: true, readOnly: true },
         }),
       ),
     );
-
-    if (!entity || !entity.currentVersionId) {
+    if (!entity?.currentVersionId) {
       return Result.err(
         new HandlerError({ status: 404, message: "Entity not found" }),
       );
@@ -102,54 +62,17 @@ export default createSafeHandler(
       );
     }
 
-    const currentVersionId = entity.currentVersionId;
-
-    // Get current version number and fields
-    const currentVersion = yield* Result.await(
-      safeDb((tx) =>
-        tx.query.entityVersions.findFirst({
-          where: { id: { eq: currentVersionId } },
-          columns: { versionNumber: true },
-          with: {
-            fields: { columns: { content: true, propertyId: true } },
-          },
-        }),
-      ),
-    );
-
-    if (!currentVersion) {
-      return Result.err(
-        new HandlerError({ status: 404, message: "Current version not found" }),
-      );
-    }
-
-    // Find the file property from existing fields
-    const fileField = currentVersion.fields.find(
-      (f) => f.content.type === "file",
-    );
-    if (!fileField) {
-      return Result.err(
-        new HandlerError({
-          status: 400,
-          message: "Entity has no file field",
-        }),
-      );
-    }
-
-    // Scan the uploaded file
     const fileBuffer = await file.arrayBuffer();
     const scanResult = await scanFile({
       buffer: new Uint8Array(fileBuffer),
       declaredMimeType: file.type,
       fileName: sanitizedName,
     });
-
     if (Result.isError(scanResult)) {
       return Result.err(
         new HandlerError({ status: 422, message: "File scan failed" }),
       );
     }
-
     if (scanResult.value.verdict === "reject") {
       const reasons = scanResult.value.findings.flatMap((finding) =>
         finding.severity === "reject" ? [finding.message] : [],
@@ -162,324 +85,46 @@ export default createSafeHandler(
       );
     }
 
-    const scanWarnings = getScanWarnings(scanResult.value) ?? undefined;
-
-    // Upload the source file first; PDF derivatives are generated
-    // asynchronously by the file-derivative queue.
-    const fileId = allocateFileObject();
-    const sha256Hex = new Bun.CryptoHasher("sha256")
-      .update(new Uint8Array(fileBuffer))
-      .digest("hex");
-    const sourceKey = createFileKey({
-      organizationId,
-      workspaceId,
-      fileId,
-      mimeType: file.type,
-    });
-
-    await getS3().write(sourceKey, new Uint8Array(fileBuffer));
-
-    // Get workspace reference for stamp
-    const workspace = yield* Result.await(
-      safeDb((tx) =>
-        tx.query.workspaces.findFirst({
-          where: { id: { eq: workspaceId } },
-          columns: { reference: true },
-        }),
-      ),
-    );
-
-    const nextVersionId = createSafeId<"entityVersion">();
-    const fileFieldId = createSafeId<"field">();
-
-    // Create new version in DB
-    const writeResult = yield* Result.await(
-      safeDb(async (tx): Promise<UploadVersionWriteResult> => {
-        const entityRows = await tx
-          .select({
-            currentVersionId: entities.currentVersionId,
-            docSequence: entities.docSequence,
-            readOnly: entities.readOnly,
-          })
-          .from(entities)
-          .where(
-            and(
-              eq(entities.id, entityId),
-              eq(entities.workspaceId, workspaceId),
-            ),
-          )
-          .limit(1)
-          .for("update");
-        const lockedEntity = entityRows.at(0);
-
-        if (!lockedEntity?.currentVersionId) {
-          return { status: "entity-not-found" };
-        }
-        if (lockedEntity.readOnly) {
-          return { status: "entity-read-only" };
-        }
-
-        const freshCurrentVersionId = lockedEntity.currentVersionId;
-        const freshCurrentVersion = await tx.query.entityVersions.findFirst({
-          where: { id: { eq: freshCurrentVersionId } },
-          columns: { versionNumber: true },
-          with: {
-            fields: { columns: { content: true, propertyId: true } },
-          },
-        });
-
-        if (!freshCurrentVersion) {
-          return { status: "current-version-not-found" };
-        }
-
-        const freshFileField = freshCurrentVersion.fields.find(
-          (f) => f.content.type === "file",
-        );
-        if (!freshFileField) {
-          return { status: "missing-file-field" };
-        }
-
-        // MAX over all versions (incl. tombstoned) under the entity lock, not
-        // currentVersion + 1, which would reuse a tombstoned latest version's
-        // number after currentVersionId promoted backward. See
-        // nextEntityVersionNumber.
-        const nextVersionNumber = await nextEntityVersionNumber(tx, {
-          entityId,
-          workspaceId,
-        });
-        const nextVersionStamp = buildVersionStamp({
-          docSequence: lockedEntity.docSequence,
-          versionNumber: nextVersionNumber,
-          workspaceReference: workspace?.reference ?? null,
-        });
-
-        await tx.insert(entityVersions).values({
-          createdBy: userId,
-          entityId,
-          id: nextVersionId,
-          stamp: nextVersionStamp.stamp,
-          verificationCode: nextVersionStamp.verificationCode,
-          versionNumber: nextVersionNumber,
-          workspaceId,
-        });
-
-        await tx.insert(fields).values(
-          cloneFieldsForRevision({
-            currentFields: freshCurrentVersion.fields,
-            entityVersionId: nextVersionId,
-            propertyId: freshFileField.propertyId,
-            replacementFieldId: fileFieldId,
-            replacementContent: fileContentWithMintedObject({
-              encrypted: false,
-              fileName: sanitizedName,
-              id: fileId,
-              mimeType: file.type,
-              pdfFileId: null,
-              sha256Hex,
-              sizeBytes: file.size,
-              type: "file",
-              version: 1,
-              pdfDerivative: pdfDerivativeStateForFile({
-                encrypted: false,
-                mimeType: file.type,
-              }),
-              thumbnailFileId: null,
-              thumbnailDerivative: thumbnailDerivativeStateForFile({
-                encrypted: false,
-                mimeType: file.type,
-              }),
-              ...(scanWarnings !== undefined && { scanWarnings }),
-            }),
+    const created = yield* Result.await(
+      Result.tryPromise({
+        try: async () =>
+          await createEntityVersionFromBuffer({
+            safeDb,
+            organizationId,
             workspaceId,
+            entityId,
+            userId,
+            recordAuditEvent,
+            buffer: fileBuffer,
+            fileName: sanitizedName,
+            mimeType: file.type,
+            source: UPLOAD_DOCUMENT_SOURCE,
+            scanWarnings: getScanWarnings(scanResult.value) ?? undefined,
           }),
-        );
-
-        const currentCellMetadataRows = await tx
-          .select({
-            createdAt: cellMetadata.createdAt,
-            createdBy: cellMetadata.createdBy,
-            metadata: cellMetadata.metadata,
-            propertyId: cellMetadata.propertyId,
-            updatedAt: cellMetadata.updatedAt,
-            updatedBy: cellMetadata.updatedBy,
-          })
-          .from(cellMetadata)
-          .where(
-            and(
-              eq(cellMetadata.workspaceId, workspaceId),
-              eq(cellMetadata.entityVersionId, freshCurrentVersionId),
-            ),
-          )
-          .for("update");
-
-        const cellMetadataRowsToCopy = currentCellMetadataRows.filter(
-          (row) => row.propertyId !== freshFileField.propertyId,
-        );
-
-        if (cellMetadataRowsToCopy.length > 0) {
-          await tx.insert(cellMetadata).values(
-            cellMetadataRowsToCopy.map((row) => ({
-              workspaceId,
-              entityVersionId: nextVersionId,
-              propertyId: row.propertyId,
-              metadata: row.metadata,
-              createdBy: row.createdBy,
-              updatedBy: row.updatedBy,
-              createdAt: row.createdAt,
-              updatedAt: row.updatedAt,
-            })),
-          );
-        }
-
-        await tx
-          .update(entities)
-          .set({
-            currentVersionId: nextVersionId,
-            lastEditedBy: userId,
-            updatedAt: new Date(),
-          })
-          .where(
-            and(
-              eq(entities.id, entityId),
-              eq(entities.workspaceId, workspaceId),
-            ),
-          );
-
-        await tx
-          .update(workspaces)
-          .set({ lastActivityAt: new Date() })
-          .where(eq(workspaces.id, workspaceId));
-
-        await recordAuditEvent(tx, [
-          {
-            action: AUDIT_ACTION.CREATE,
-            resourceType: AUDIT_RESOURCE_TYPE.ENTITY_VERSION,
-            resourceId: nextVersionId,
-            changes: {
-              created: {
-                old: null,
-                new: {
-                  entityId,
-                  versionNumber: nextVersionNumber,
-                  fileName: sanitizedName,
-                  mimeType: file.type,
-                  sizeBytes: file.size,
-                  sha256Hex,
-                },
-              },
-            },
-            metadata: {
-              fileName: sanitizedName,
-              mimeType: file.type,
-              sizeBytes: file.size,
-              sha256Hex,
-            },
-          },
-          {
-            action: AUDIT_ACTION.UPDATE,
-            resourceType: AUDIT_RESOURCE_TYPE.ENTITY,
-            resourceId: entityId,
-            changes: {
-              currentVersionId: {
-                old: freshCurrentVersionId,
-                new: nextVersionId,
-              },
-            },
-          },
-        ]);
-
-        return { status: "ok", versionNumber: nextVersionNumber };
+        catch: (cause) =>
+          new HandlerError({
+            status: 500,
+            message: "Failed to store entity version",
+            cause,
+          }),
       }),
     );
-
-    if (writeResult.status !== "ok") {
-      switch (writeResult.status) {
-        case "entity-not-found":
-          return Result.err(
-            new HandlerError({ status: 404, message: "Entity not found" }),
-          );
-        case "entity-read-only":
-          return Result.err(
-            new HandlerError({ status: 409, message: "Entity is read-only" }),
-          );
-        case "current-version-not-found":
-          return Result.err(
-            new HandlerError({
-              status: 404,
-              message: "Current version not found",
-            }),
-          );
-        case "missing-file-field":
-          return Result.err(
-            new HandlerError({
-              status: 400,
-              message: "Entity has no file field",
-            }),
-          );
+    if (Result.isError(created)) {
+      let status: 400 | 404 | 409 = 404;
+      if (created.error.code === "entity-read-only") {
+        status = 409;
+      } else if (created.error.code === "missing-file-field") {
+        status = 400;
       }
+      return Result.err(
+        new HandlerError({ status, message: created.error.message }),
+      );
     }
-    const nextVersionNumber = writeResult.versionNumber;
-
-    // Fire-and-forget: extraction + diff stats
-    processExtraction(entityId).catch((error: unknown) => {
-      captureError(error, { entityId });
-    });
-
-    enqueuePdfDerivativeOrMarkFailed({
-      encrypted: false,
-      entityId,
-      fieldId: fileFieldId,
-      mimeType: file.type,
-      organizationId,
-      userId,
-      workspaceId,
-    }).catch((error: unknown) => {
-      captureError(error, {
-        entityId,
-        fieldId: fileFieldId,
-        mimeType: file.type,
-      });
-    });
-
-    enqueueImageThumbnailOrMarkFailed({
-      encrypted: false,
-      entityId,
-      fieldId: fileFieldId,
-      mimeType: file.type,
-      organizationId,
-      userId,
-      workspaceId,
-    }).catch((error: unknown) => {
-      captureError(error, {
-        entityId,
-        fieldId: fileFieldId,
-        mimeType: file.type,
-      });
-    });
-
-    computeVersionDiffStats({
-      versionId: nextVersionId,
-      entityId,
-      scopedDb: createRootScopedDb({
-        organizationId,
-        userId,
-        workspaceIds: [workspaceId],
-      }),
-      workspaceId,
-      organizationId,
-    }).catch((error: unknown) => {
-      captureError(error, { versionId: nextVersionId });
-    });
-
-    broadcast(workspaceId, {
-      type: "invalidate-query",
-      data: ["entities", workspaceId],
-    });
 
     return Result.ok({
-      fieldId: fileFieldId,
-      versionId: nextVersionId,
-      versionNumber: nextVersionNumber,
+      fieldId: created.value.fieldId,
+      versionId: created.value.entityVersionId,
+      versionNumber: created.value.versionNumber,
     });
   },
 );

--- a/apps/api/src/handlers/entities/upload-version.ts
+++ b/apps/api/src/handlers/entities/upload-version.ts
@@ -110,11 +110,29 @@ export default createSafeHandler(
       }),
     );
     if (Result.isError(created)) {
-      let status: 400 | 404 | 409 = 404;
-      if (created.error.code === "entity-read-only") {
-        status = 409;
-      } else if (created.error.code === "missing-file-field") {
-        status = 400;
+      let status: 400 | 404 | 409 | 413;
+      switch (created.error.code) {
+        case "current-version-not-found":
+        case "entity-not-found": {
+          status = 404;
+          break;
+        }
+        case "document-too-large": {
+          status = 413;
+          break;
+        }
+        case "entity-read-only": {
+          status = 409;
+          break;
+        }
+        case "missing-file-field": {
+          status = 400;
+          break;
+        }
+        default: {
+          const exhaustive: never = created.error.code;
+          return exhaustive;
+        }
       }
       return Result.err(
         new HandlerError({ status, message: created.error.message }),

--- a/apps/api/src/handlers/entities/write-file-version-parity.test.ts
+++ b/apps/api/src/handlers/entities/write-file-version-parity.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "bun:test";
+
+const readApiSource = async (relativePath: string): Promise<string> =>
+  await Bun.file(new URL(`../../${relativePath}`, import.meta.url)).text();
+
+describe("entity-version persistence parity", () => {
+  test("every byte transport delegates to the shared version transaction", async () => {
+    const [multipart, presigned, templates, templatePersistence] =
+      await Promise.all([
+        readApiSource("handlers/entities/upload-version.ts"),
+        readApiSource("handlers/uploads/entity-version.ts"),
+        readApiSource("mcp/template-tools.ts"),
+        readApiSource("mcp/template-persistence.ts"),
+      ]);
+
+    expect(multipart).toContain("createEntityVersionFromBuffer");
+    expect(presigned).toContain("writeFileVersion");
+    expect(templates).toContain("persistFilledTemplateVersion");
+    expect(templatePersistence).toContain("createEntityVersionFromBuffer");
+    expect(multipart).toContain("source: UPLOAD_DOCUMENT_SOURCE");
+    expect(presigned).toContain("source: UPLOAD_DOCUMENT_SOURCE");
+    expect(templates).toContain("source: null");
+
+    for (const transport of [
+      multipart,
+      presigned,
+      templates,
+      templatePersistence,
+    ]) {
+      expect(transport).not.toContain("cloneFieldsForRevision");
+      expect(transport).not.toContain("nextEntityVersionNumber");
+    }
+  });
+
+  test("the shared transaction retains the versioning and audit invariants", async () => {
+    const core = await readApiSource("handlers/entities/write-file-version.ts");
+
+    expect(core).toContain('.for("update")');
+    expect(core).toContain("nextEntityVersionNumber");
+    expect(core).toContain("cloneFieldsForRevision");
+    expect(core).toContain("cellMetadata");
+    expect(core).toContain("ENTITY_VERSION");
+    expect(core).toContain("AUDIT_RESOURCE_TYPE.ENTITY");
+    expect(core).toContain("entity-read-only");
+    expect(core).toContain("source,");
+    expect(core).toContain("deletedAt: { isNull: true }");
+  });
+});

--- a/apps/api/src/handlers/entities/write-file-version-parity.test.ts
+++ b/apps/api/src/handlers/entities/write-file-version-parity.test.ts
@@ -5,28 +5,17 @@ const readApiSource = async (relativePath: string): Promise<string> =>
 
 describe("entity-version persistence parity", () => {
   test("every byte transport delegates to the shared version transaction", async () => {
-    const [multipart, presigned, templates, templatePersistence] =
-      await Promise.all([
-        readApiSource("handlers/entities/upload-version.ts"),
-        readApiSource("handlers/uploads/entity-version.ts"),
-        readApiSource("mcp/template-tools.ts"),
-        readApiSource("mcp/template-persistence.ts"),
-      ]);
+    const [multipart, presigned] = await Promise.all([
+      readApiSource("handlers/entities/upload-version.ts"),
+      readApiSource("handlers/uploads/entity-version.ts"),
+    ]);
 
     expect(multipart).toContain("createEntityVersionFromBuffer");
     expect(presigned).toContain("writeFileVersion");
-    expect(templates).toContain("persistFilledTemplateVersion");
-    expect(templatePersistence).toContain("createEntityVersionFromBuffer");
     expect(multipart).toContain("source: UPLOAD_DOCUMENT_SOURCE");
     expect(presigned).toContain("source: UPLOAD_DOCUMENT_SOURCE");
-    expect(templates).toContain("source: null");
 
-    for (const transport of [
-      multipart,
-      presigned,
-      templates,
-      templatePersistence,
-    ]) {
+    for (const transport of [multipart, presigned]) {
       expect(transport).not.toContain("cloneFieldsForRevision");
       expect(transport).not.toContain("nextEntityVersionNumber");
     }

--- a/apps/api/src/handlers/entities/write-file-version.ts
+++ b/apps/api/src/handlers/entities/write-file-version.ts
@@ -1,0 +1,271 @@
+import { and, eq } from "drizzle-orm";
+
+import type { Transaction } from "@/api/db/root";
+import {
+  cellMetadata,
+  entities,
+  entityVersions,
+  fields,
+  workspaces,
+} from "@/api/db/schema";
+import {
+  buildVersionStamp,
+  cloneFieldsForRevision,
+  nextEntityVersionNumber,
+} from "@/api/handlers/entities/version-utils";
+import { fileContentWithMintedObject } from "@/api/handlers/files/file-object-ids";
+import type { MintedFileId } from "@/api/handlers/files/file-object-ids";
+import { pdfDerivativeStateForFile } from "@/api/handlers/files/gotenberg";
+import { thumbnailDerivativeStateForFile } from "@/api/handlers/files/image-derivative";
+import { AUDIT_ACTION, AUDIT_RESOURCE_TYPE } from "@/api/lib/audit-log";
+import type { AuditRecorder } from "@/api/lib/audit-log";
+import type { SafeId } from "@/api/lib/branded-types";
+import type { DocumentSource } from "@/api/lib/document-source";
+
+export type WriteFileVersionResult =
+  | {
+      status: "ok";
+      entityVersionId: SafeId<"entityVersion">;
+      fieldId: SafeId<"field">;
+      versionNumber: number;
+    }
+  | {
+      status:
+        | "current-version-not-found"
+        | "entity-not-found"
+        | "entity-read-only"
+        | "missing-file-field";
+    };
+
+type WriteFileVersionInput = {
+  tx: Transaction;
+  workspaceId: SafeId<"workspace">;
+  entityId: SafeId<"entity">;
+  userId: SafeId<"user">;
+  recordAuditEvent: AuditRecorder;
+  entityVersionId: SafeId<"entityVersion">;
+  fieldId: SafeId<"field">;
+  fileId: MintedFileId;
+  fileName: string;
+  mimeType: string;
+  sizeBytes: number;
+  sha256Hex: string;
+  source: DocumentSource | null;
+  scanWarnings?: string[] | undefined;
+  afterWrite?:
+    | ((
+        result: Extract<WriteFileVersionResult, { status: "ok" }>,
+      ) => Promise<void>)
+    | undefined;
+};
+
+/**
+ * Canonical transaction for replacing an entity's file with a new version.
+ *
+ * Every transport (multipart, presigned upload, and compound template fill)
+ * delegates here, so row locking, version numbering, field/cell cloning, and
+ * audit events cannot drift between CLI, MCP, and HTTP entry points. Callers
+ * own object-storage placement and post-commit derivative/extraction work.
+ */
+export const writeFileVersion = async ({
+  tx,
+  workspaceId,
+  entityId,
+  userId,
+  recordAuditEvent,
+  entityVersionId,
+  fieldId,
+  fileId,
+  fileName,
+  mimeType,
+  sizeBytes,
+  sha256Hex,
+  source,
+  scanWarnings,
+  afterWrite,
+}: WriteFileVersionInput): Promise<WriteFileVersionResult> => {
+  const entityRows = await tx
+    .select({
+      currentVersionId: entities.currentVersionId,
+      docSequence: entities.docSequence,
+      readOnly: entities.readOnly,
+    })
+    .from(entities)
+    .where(
+      and(eq(entities.id, entityId), eq(entities.workspaceId, workspaceId)),
+    )
+    .limit(1)
+    .for("update");
+  const lockedEntity = entityRows.at(0);
+
+  if (!lockedEntity?.currentVersionId) {
+    return { status: "entity-not-found" };
+  }
+  if (lockedEntity.readOnly) {
+    return { status: "entity-read-only" };
+  }
+
+  const currentVersionId = lockedEntity.currentVersionId;
+  const currentVersion = await tx.query.entityVersions.findFirst({
+    where: { id: { eq: currentVersionId }, deletedAt: { isNull: true } },
+    columns: { versionNumber: true },
+    with: {
+      fields: { columns: { content: true, propertyId: true } },
+    },
+  });
+  if (!currentVersion) {
+    return { status: "current-version-not-found" };
+  }
+
+  const fileField = currentVersion.fields.find(
+    (candidate) => candidate.content.type === "file",
+  );
+  if (!fileField) {
+    return { status: "missing-file-field" };
+  }
+
+  const workspace = await tx.query.workspaces.findFirst({
+    where: { id: { eq: workspaceId } },
+    columns: { reference: true },
+  });
+  const versionNumber = await nextEntityVersionNumber(tx, {
+    entityId,
+    workspaceId,
+  });
+  const stamp = buildVersionStamp({
+    docSequence: lockedEntity.docSequence,
+    versionNumber,
+    workspaceReference: workspace?.reference ?? null,
+  });
+
+  await tx.insert(entityVersions).values({
+    createdBy: userId,
+    entityId,
+    id: entityVersionId,
+    stamp: stamp.stamp,
+    verificationCode: stamp.verificationCode,
+    versionNumber,
+    workspaceId,
+    source,
+  });
+
+  await tx.insert(fields).values(
+    cloneFieldsForRevision({
+      currentFields: currentVersion.fields,
+      entityVersionId,
+      propertyId: fileField.propertyId,
+      replacementFieldId: fieldId,
+      replacementContent: fileContentWithMintedObject({
+        encrypted: false,
+        fileName,
+        id: fileId,
+        mimeType,
+        pdfFileId: null,
+        sha256Hex,
+        sizeBytes,
+        type: "file",
+        version: 1,
+        pdfDerivative: pdfDerivativeStateForFile({
+          encrypted: false,
+          mimeType,
+        }),
+        thumbnailFileId: null,
+        thumbnailDerivative: thumbnailDerivativeStateForFile({
+          encrypted: false,
+          mimeType,
+        }),
+        ...(scanWarnings !== undefined && { scanWarnings }),
+      }),
+      workspaceId,
+    }),
+  );
+
+  const currentCellMetadataRows = await tx
+    .select({
+      createdAt: cellMetadata.createdAt,
+      createdBy: cellMetadata.createdBy,
+      metadata: cellMetadata.metadata,
+      propertyId: cellMetadata.propertyId,
+      updatedAt: cellMetadata.updatedAt,
+      updatedBy: cellMetadata.updatedBy,
+    })
+    .from(cellMetadata)
+    .where(
+      and(
+        eq(cellMetadata.workspaceId, workspaceId),
+        eq(cellMetadata.entityVersionId, currentVersionId),
+      ),
+    )
+    .for("update");
+  const metadataToCopy = currentCellMetadataRows.filter(
+    (row) => row.propertyId !== fileField.propertyId,
+  );
+  if (metadataToCopy.length > 0) {
+    await tx.insert(cellMetadata).values(
+      metadataToCopy.map((row) => ({
+        workspaceId,
+        entityVersionId,
+        propertyId: row.propertyId,
+        metadata: row.metadata,
+        createdBy: row.createdBy,
+        updatedBy: row.updatedBy,
+        createdAt: row.createdAt,
+        updatedAt: row.updatedAt,
+      })),
+    );
+  }
+
+  await tx
+    .update(entities)
+    .set({
+      currentVersionId: entityVersionId,
+      lastEditedBy: userId,
+      updatedAt: new Date(),
+    })
+    .where(
+      and(eq(entities.id, entityId), eq(entities.workspaceId, workspaceId)),
+    );
+  await tx
+    .update(workspaces)
+    .set({ lastActivityAt: new Date() })
+    .where(eq(workspaces.id, workspaceId));
+
+  await recordAuditEvent(tx, [
+    {
+      action: AUDIT_ACTION.CREATE,
+      resourceType: AUDIT_RESOURCE_TYPE.ENTITY_VERSION,
+      resourceId: entityVersionId,
+      changes: {
+        created: {
+          old: null,
+          new: {
+            entityId,
+            versionNumber,
+            fileName,
+            mimeType,
+            sizeBytes,
+            sha256Hex,
+          },
+        },
+      },
+      metadata: { fileName, mimeType, sizeBytes, sha256Hex },
+    },
+    {
+      action: AUDIT_ACTION.UPDATE,
+      resourceType: AUDIT_RESOURCE_TYPE.ENTITY,
+      resourceId: entityId,
+      changes: {
+        currentVersionId: { old: currentVersionId, new: entityVersionId },
+      },
+    },
+  ]);
+
+  const result = {
+    status: "ok",
+    entityVersionId,
+    fieldId,
+    versionNumber,
+  } as const;
+  await afterWrite?.(result);
+  return result;
+};

--- a/apps/api/src/handlers/files/utils.ts
+++ b/apps/api/src/handlers/files/utils.ts
@@ -6,7 +6,8 @@ import {
   createUserFileKey,
   getFileExtension,
 } from "@/api/lib/file-key";
-import { getS3 } from "@/api/lib/s3";
+import { deleteS3ObjectWithSignal } from "@/api/lib/s3";
+import { withTimeout } from "@/api/lib/with-timeout";
 
 export { createFileKey, createUserFileKey, getFileExtension };
 
@@ -66,6 +67,7 @@ export const resolveUploadMime = ({
  * overwhelming the endpoint with concurrent HTTP requests.
  */
 const S3_DELETE_CONCURRENCY = 50;
+const S3_DELETE_TIMEOUT_MS = 30 * 1000;
 
 type DeleteS3ObjectsProps = {
   fileRows: { fileId: string; mimeType: string }[];
@@ -108,7 +110,18 @@ export const deleteS3Keys = async (
     // oxlint-disable-next-line no-await-in-loop -- chunks run sequentially for bounded S3 concurrency and early return on the first failed chunk
     const result = await Result.tryPromise(
       async () =>
-        await Promise.all(chunk.map(async (key) => await getS3().delete(key))),
+        await Promise.all(
+          chunk.map(
+            async (key) =>
+              await withTimeout(
+                async (signal) => await deleteS3ObjectWithSignal(key, signal),
+                {
+                  label: "s3-object-delete",
+                  timeoutMs: S3_DELETE_TIMEOUT_MS,
+                },
+              ),
+          ),
+        ),
     );
 
     if (Result.isError(result)) {

--- a/apps/api/src/handlers/templates/fill-to-workspace.ts
+++ b/apps/api/src/handlers/templates/fill-to-workspace.ts
@@ -1,13 +1,11 @@
 import { Result } from "better-result";
-import { eq } from "drizzle-orm";
 import { t } from "elysia";
 
-import { entities, templateFills } from "@/api/db/schema";
+import { templateFills } from "@/api/db/schema";
 import { clauseBodySchema } from "@/api/handlers/clauses/shared-schemas";
 import { createEntityFromBuffer } from "@/api/handlers/entities/create-from-buffer";
 import { containsNull } from "@/api/handlers/templates/fill";
 import { fillStoredTemplateDocx } from "@/api/handlers/templates/template-fill-service";
-import { captureError } from "@/api/lib/analytics/capture";
 import { createTanStackAIAnalyticsCallbacks } from "@/api/lib/analytics/tanstack-ai";
 import {
   assertUsageAvailableForHandler,
@@ -243,6 +241,7 @@ const fillTemplateToWorkspace = createSafeHandler(
             buffer: filled.buffer,
             fileName,
             mimeType: DOCX_MIME_TYPE,
+            parentId,
           }),
         catch: (cause) =>
           new HandlerError({
@@ -260,27 +259,6 @@ const fillTemplateToWorkspace = createSafeHandler(
     }
 
     const entityId = created.value.entityId;
-
-    if (parentId !== null) {
-      // Re-parent after creation (the shared creator always lands at root).
-      // The parent was validated above; if it vanished in between, the FK
-      // rejects and the document simply stays at the workspace root.
-      const reparented = await Result.tryPromise({
-        try: async () =>
-          await scopedDb(async (tx) => {
-            // audit: skip — placement detail of an entity creation that was
-            // already audited (createEntityFromBuffer records the CREATE).
-            await tx
-              .update(entities)
-              .set({ parentId })
-              .where(eq(entities.id, entityId));
-          }),
-        catch: (cause) => cause,
-      });
-      if (Result.isError(reparented)) {
-        captureError(reparented.error, { entityId, parentId });
-      }
-    }
 
     const fillStatus =
       filled.unmatchedPlaceholders.length > 0 ? "partial" : "success";

--- a/apps/api/src/handlers/uploads/entity-version.ts
+++ b/apps/api/src/handlers/uploads/entity-version.ts
@@ -16,6 +16,7 @@ import { captureError } from "@/api/lib/analytics/capture";
 import type { AuditRecorder } from "@/api/lib/audit-log";
 import { createSafeId } from "@/api/lib/branded-types";
 import type { SafeId } from "@/api/lib/branded-types";
+import { BUFFER_INTENT_DELETE_TIMEOUT_MS } from "@/api/lib/buffer-intent-reconciliation";
 import { UPLOAD_DOCUMENT_SOURCE } from "@/api/lib/document-source";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import {
@@ -23,10 +24,11 @@ import {
   enqueuePdfDerivativeOrMarkFailed,
 } from "@/api/lib/file-derivative-queue";
 import { createRootScopedDb } from "@/api/lib/root-scoped-db";
-import { getS3 } from "@/api/lib/s3";
+import { deleteS3ObjectWithSignal } from "@/api/lib/s3";
 import { sanitizeFilename } from "@/api/lib/sanitize-filename";
 import { processExtraction } from "@/api/lib/search/process-extraction";
 import { broadcast } from "@/api/lib/sse";
+import { withTimeout } from "@/api/lib/with-timeout";
 
 import { finalizeErr, finalizeOk } from "./lib";
 import type { UploadFinalizeError } from "./lib";
@@ -133,71 +135,97 @@ export const finalizeEntityVersion = async function* ({
   }
 
   const cleanupFinalObject = async (stage: string) => {
-    await getS3()
-      .delete(finalKey)
-      .catch((error: unknown) =>
-        captureError(error, { entityId, fieldId, stage }),
-      );
+    await withTimeout(
+      async (signal) => await deleteS3ObjectWithSignal(finalKey, signal),
+      {
+        label: "entity-version-final-cleanup.delete",
+        timeoutMs: BUFFER_INTENT_DELETE_TIMEOUT_MS,
+      },
+    ).catch((error: unknown) =>
+      captureError(error, { entityId, fieldId, stage }),
+    );
   };
 
   let finalized:
     | Extract<PendingUploadFinalizedResult, { type: "entity_version" }>
     | undefined;
-  const writeResultResult = await safeDb(
-    async (tx) =>
-      await writeFileVersion({
-        tx,
-        workspaceId,
-        entityId,
-        userId,
-        recordAuditEvent,
-        entityVersionId,
-        fieldId,
-        fileId,
-        fileName,
-        mimeType: declaredMime,
-        sizeBytes: declaredSize,
-        sha256Hex: declaredSha256Hex,
-        source: UPLOAD_DOCUMENT_SOURCE,
-        scanWarnings,
-        afterWrite: async ({ versionNumber }) => {
-          finalized = {
-            type: "entity_version",
-            entityId,
-            entityVersionId,
-            versionNumber,
-            fileId,
-            fileName,
-          };
-          // audit: skip — FSM bookkeeping; entity/version events are recorded
-          // by writeFileVersion in this same transaction.
-          const rows = await tx
-            .update(pendingUploads)
-            .set({
-              status: "finalized",
-              finalizedResult: finalized,
-              finalizedAt: new Date(),
-            })
-            .where(
-              and(
-                eq(pendingUploads.id, uploadId),
-                eq(pendingUploads.userId, userId),
-                eq(pendingUploads.workspaceId, workspaceId),
-                eq(pendingUploads.status, "scanning"),
-                eq(pendingUploads.claimedByRequestId, claimRequestId),
-              ),
-            )
-            .returning({ id: pendingUploads.id });
-          if (!rows.at(0)) {
-            panic("Pending upload finalize marker update returned no rows");
-          }
-        },
-      }),
-  );
+  const writeResultResult = await safeDb(async (tx) => {
+    const claimRows = await tx
+      .select({ id: pendingUploads.id })
+      .from(pendingUploads)
+      .where(
+        and(
+          eq(pendingUploads.id, uploadId),
+          eq(pendingUploads.userId, userId),
+          eq(pendingUploads.workspaceId, workspaceId),
+          eq(pendingUploads.status, "scanning"),
+          eq(pendingUploads.claimedByRequestId, claimRequestId),
+        ),
+      )
+      .limit(1)
+      .for("update");
+    if (!claimRows.at(0)) {
+      return { status: "upload-claim-lost" as const };
+    }
+
+    return await writeFileVersion({
+      tx,
+      workspaceId,
+      entityId,
+      userId,
+      recordAuditEvent,
+      entityVersionId,
+      fieldId,
+      fileId,
+      fileName,
+      mimeType: declaredMime,
+      sizeBytes: declaredSize,
+      sha256Hex: declaredSha256Hex,
+      source: UPLOAD_DOCUMENT_SOURCE,
+      scanWarnings,
+      afterWrite: async ({ versionNumber }) => {
+        finalized = {
+          type: "entity_version",
+          entityId,
+          entityVersionId,
+          versionNumber,
+          fileId,
+          fileName,
+        };
+        // audit: skip — FSM bookkeeping; entity/version events are recorded
+        // by writeFileVersion in this same transaction.
+        await tx
+          .update(pendingUploads)
+          .set({
+            status: "finalized",
+            finalizedResult: finalized,
+            finalizedAt: new Date(),
+          })
+          .where(
+            and(
+              eq(pendingUploads.id, uploadId),
+              eq(pendingUploads.userId, userId),
+              eq(pendingUploads.workspaceId, workspaceId),
+              eq(pendingUploads.status, "scanning"),
+              eq(pendingUploads.claimedByRequestId, claimRequestId),
+            ),
+          );
+      },
+    });
+  });
   if (Result.isError(writeResultResult)) {
     await cleanupFinalObject("final-cleanup-after-db-error");
   }
   const writeResult = yield* writeResultResult;
+
+  if (writeResult.status === "upload-claim-lost") {
+    await cleanupFinalObject("final-cleanup-after-claim-loss");
+    return finalizeErr({
+      status: 409,
+      message: "Upload finalization claim was lost",
+      rejectReason: "claim-lost",
+    });
+  }
 
   if (writeResult.status !== "ok") {
     await cleanupFinalObject("final-cleanup-after-business-error");

--- a/apps/api/src/handlers/uploads/entity-version.ts
+++ b/apps/api/src/handlers/uploads/entity-version.ts
@@ -1,14 +1,4 @@
-/**
- * `entity_version` purpose: a presigned-upload flow that creates a
- * new `entityVersions` row + `fields` clone for an existing entity,
- * mirroring the legacy multipart endpoint at
- * `apps/api/src/handlers/entities/upload-version.ts`.
- *
- * Reuses `cloneFieldsForRevision`, `buildVersionStamp`, and the
- * cell-metadata carry-over from the legacy handler exactly so the
- * resulting row is byte-for-byte identical to what the multipart
- * path would have produced.
- */
+/** Presigned-upload transport for creating a new entity file version. */
 import { Result, panic } from "better-result";
 import { and, eq } from "drizzle-orm";
 
@@ -17,29 +7,12 @@ import type {
   PendingUploadFinalizedResult,
   PendingUploadPurposeData,
 } from "@/api/db/schema";
-import {
-  cellMetadata,
-  entities,
-  entityVersions,
-  fields,
-  pendingUploads,
-  workspaces,
-} from "@/api/db/schema";
+import { pendingUploads } from "@/api/db/schema";
 import { computeVersionDiffStats } from "@/api/handlers/entities/compute-version-diff";
-import {
-  buildVersionStamp,
-  cloneFieldsForRevision,
-  nextEntityVersionNumber,
-} from "@/api/handlers/entities/version-utils";
-import {
-  allocateFileObject,
-  fileContentWithMintedObject,
-} from "@/api/handlers/files/file-object-ids";
-import { pdfDerivativeStateForFile } from "@/api/handlers/files/gotenberg";
-import { thumbnailDerivativeStateForFile } from "@/api/handlers/files/image-derivative";
+import { writeFileVersion } from "@/api/handlers/entities/write-file-version";
+import { allocateFileObject } from "@/api/handlers/files/file-object-ids";
 import { createFileKey } from "@/api/handlers/files/utils";
 import { captureError } from "@/api/lib/analytics/capture";
-import { AUDIT_ACTION, AUDIT_RESOURCE_TYPE } from "@/api/lib/audit-log";
 import type { AuditRecorder } from "@/api/lib/audit-log";
 import { createSafeId } from "@/api/lib/branded-types";
 import type { SafeId } from "@/api/lib/branded-types";
@@ -65,11 +38,9 @@ export type ValidateEntityVersionProps = {
 };
 
 /**
- * Up-front gating: entity exists, isn't read-only, has a file
- * field. Lets the API refuse to mint a presigned URL the user
- * couldn't redeem anyway.
+ * Refuse to mint a presigned URL for an invalid or read-only target.
  *
- * @yields safeDb errors out to the parent safe-handler.
+ * @yields Safe database errors to the parent safe handler.
  */
 export const validateEntityVersion = async function* ({
   safeDb,
@@ -83,14 +54,11 @@ export const validateEntityVersion = async function* ({
           id: { eq: entityId },
           workspaceId: { eq: workspaceId },
         },
-        columns: {
-          currentVersionId: true,
-          readOnly: true,
-        },
+        columns: { currentVersionId: true, readOnly: true },
       }),
     ),
   );
-  if (!entity || !entity.currentVersionId) {
+  if (!entity?.currentVersionId) {
     return Result.err(
       new HandlerError({ status: 404, message: "Entity not found" }),
     );
@@ -100,7 +68,6 @@ export const validateEntityVersion = async function* ({
       new HandlerError({ status: 409, message: "Entity is read-only" }),
     );
   }
-
   return Result.ok(undefined);
 };
 
@@ -125,13 +92,11 @@ export type FinalizeEntityVersionProps = {
 };
 
 /**
- * Domain transaction for `entity_version`. Allocates a new
- * `entityVersions` row + cloned fields with the uploaded file
- * swapped into the file field, carries cell metadata across,
- * records the two audit events the legacy handler emits, kicks
- * off async extraction + diff-stat computation + SSE broadcast.
+ * Promote the staged object, then join the canonical version transaction. The
+ * pending-upload FSM transition is supplied as writeFileVersion's afterWrite
+ * hook so it commits atomically with the entity/version audit rows.
  *
- * @yields safeDb errors out to the parent safe-handler.
+ * @yields Safe database errors to the parent finalize handler.
  */
 export const finalizeEntityVersion = async function* ({
   safeDb,
@@ -150,12 +115,11 @@ export const finalizeEntityVersion = async function* ({
   claimRequestId,
   promoteTmpObject,
 }: FinalizeEntityVersionProps) {
-  const sanitizedName = sanitizeFilename(declaredName);
+  const fileName = sanitizeFilename(declaredName);
   const { entityId } = purposeData;
-
   const fileId = allocateFileObject();
-  const nextVersionId = createSafeId<"entityVersion">();
-  const fileFieldId = createSafeId<"field">();
+  const entityVersionId = createSafeId<"entityVersion">();
+  const fieldId = createSafeId<"field">();
   const finalKey = createFileKey({
     organizationId,
     workspaceId,
@@ -163,350 +127,138 @@ export const finalizeEntityVersion = async function* ({
     mimeType: declaredMime,
   });
 
-  const promoteResult = await promoteTmpObject(finalKey);
-  if (Result.isError(promoteResult)) {
-    return promoteResult;
+  const promoted = await promoteTmpObject(finalKey);
+  if (Result.isError(promoted)) {
+    return promoted;
   }
-
-  type WriteResult =
-    | {
-        status: "ok";
-        finalized: Extract<
-          PendingUploadFinalizedResult,
-          { type: "entity_version" }
-        >;
-      }
-    | {
-        status:
-          | "entity-not-found"
-          | "entity-read-only"
-          | "current-version-not-found"
-          | "missing-file-field";
-      };
 
   const cleanupFinalObject = async (stage: string) => {
     await getS3()
       .delete(finalKey)
-      .catch((deleteError: unknown) =>
-        captureError(deleteError, {
-          entityId,
-          fieldId: fileFieldId,
-          stage,
-        }),
+      .catch((error: unknown) =>
+        captureError(error, { entityId, fieldId, stage }),
       );
   };
 
-  const writeResultResult = await safeDb(async (tx): Promise<WriteResult> => {
-    // Lock the entity row for the duration of the transaction so
-    // a concurrent version upload can't observe a stale
-    // currentVersionId.
-    const entityRows = await tx
-      .select({
-        currentVersionId: entities.currentVersionId,
-        docSequence: entities.docSequence,
-        readOnly: entities.readOnly,
-      })
-      .from(entities)
-      .where(
-        and(eq(entities.id, entityId), eq(entities.workspaceId, workspaceId)),
-      )
-      .limit(1)
-      .for("update");
-    const lockedEntity = entityRows.at(0);
-
-    if (!lockedEntity?.currentVersionId) {
-      return { status: "entity-not-found" };
-    }
-    if (lockedEntity.readOnly) {
-      return { status: "entity-read-only" };
-    }
-
-    const freshCurrentVersionId = lockedEntity.currentVersionId;
-    const freshCurrentVersion = await tx.query.entityVersions.findFirst({
-      where: { id: { eq: freshCurrentVersionId } },
-      columns: { versionNumber: true },
-      with: {
-        fields: { columns: { content: true, propertyId: true } },
-      },
-    });
-    if (!freshCurrentVersion) {
-      return { status: "current-version-not-found" };
-    }
-
-    const freshFileField = freshCurrentVersion.fields.find(
-      (field) => field.content.type === "file",
-    );
-    if (!freshFileField) {
-      return { status: "missing-file-field" };
-    }
-
-    const workspace = await tx.query.workspaces.findFirst({
-      where: { id: { eq: workspaceId } },
-      columns: { reference: true },
-    });
-
-    // MAX over all versions (incl. tombstoned) under the entity lock, not
-    // currentVersion + 1, which would reuse a tombstoned latest version's number
-    // after currentVersionId promoted backward. See nextEntityVersionNumber.
-    const nextVersionNumber = await nextEntityVersionNumber(tx, {
-      entityId,
-      workspaceId,
-    });
-    const nextVersionStamp = buildVersionStamp({
-      docSequence: lockedEntity.docSequence,
-      versionNumber: nextVersionNumber,
-      workspaceReference: workspace?.reference ?? null,
-    });
-
-    await tx.insert(entityVersions).values({
-      createdBy: userId,
-      entityId,
-      id: nextVersionId,
-      source: UPLOAD_DOCUMENT_SOURCE,
-      stamp: nextVersionStamp.stamp,
-      verificationCode: nextVersionStamp.verificationCode,
-      versionNumber: nextVersionNumber,
-      workspaceId,
-    });
-
-    await tx.insert(fields).values(
-      cloneFieldsForRevision({
-        currentFields: freshCurrentVersion.fields,
-        entityVersionId: nextVersionId,
-        propertyId: freshFileField.propertyId,
-        replacementFieldId: fileFieldId,
-        replacementContent: fileContentWithMintedObject({
-          encrypted: false,
-          fileName: sanitizedName,
-          id: fileId,
-          mimeType: declaredMime,
-          pdfFileId: null,
-          sha256Hex: declaredSha256Hex,
-          sizeBytes: declaredSize,
-          type: "file",
-          version: 1,
-          pdfDerivative: pdfDerivativeStateForFile({
-            encrypted: false,
-            mimeType: declaredMime,
-          }),
-          thumbnailFileId: null,
-          thumbnailDerivative: thumbnailDerivativeStateForFile({
-            encrypted: false,
-            mimeType: declaredMime,
-          }),
-          ...(scanWarnings !== undefined && { scanWarnings }),
-        }),
+  let finalized:
+    | Extract<PendingUploadFinalizedResult, { type: "entity_version" }>
+    | undefined;
+  const writeResultResult = await safeDb(
+    async (tx) =>
+      await writeFileVersion({
+        tx,
         workspaceId,
+        entityId,
+        userId,
+        recordAuditEvent,
+        entityVersionId,
+        fieldId,
+        fileId,
+        fileName,
+        mimeType: declaredMime,
+        sizeBytes: declaredSize,
+        sha256Hex: declaredSha256Hex,
+        source: UPLOAD_DOCUMENT_SOURCE,
+        scanWarnings,
+        afterWrite: async ({ versionNumber }) => {
+          finalized = {
+            type: "entity_version",
+            entityId,
+            entityVersionId,
+            versionNumber,
+            fileId,
+            fileName,
+          };
+          // audit: skip — FSM bookkeeping; entity/version events are recorded
+          // by writeFileVersion in this same transaction.
+          const rows = await tx
+            .update(pendingUploads)
+            .set({
+              status: "finalized",
+              finalizedResult: finalized,
+              finalizedAt: new Date(),
+            })
+            .where(
+              and(
+                eq(pendingUploads.id, uploadId),
+                eq(pendingUploads.userId, userId),
+                eq(pendingUploads.workspaceId, workspaceId),
+                eq(pendingUploads.status, "scanning"),
+                eq(pendingUploads.claimedByRequestId, claimRequestId),
+              ),
+            )
+            .returning({ id: pendingUploads.id });
+          if (!rows.at(0)) {
+            panic("Pending upload finalize marker update returned no rows");
+          }
+        },
       }),
-    );
-
-    // Carry over cell metadata from every property except the
-    // file field (whose metadata starts fresh per version).
-    const currentCellMetadataRows = await tx
-      .select({
-        createdAt: cellMetadata.createdAt,
-        createdBy: cellMetadata.createdBy,
-        metadata: cellMetadata.metadata,
-        propertyId: cellMetadata.propertyId,
-        updatedAt: cellMetadata.updatedAt,
-        updatedBy: cellMetadata.updatedBy,
-      })
-      .from(cellMetadata)
-      .where(
-        and(
-          eq(cellMetadata.workspaceId, workspaceId),
-          eq(cellMetadata.entityVersionId, freshCurrentVersionId),
-        ),
-      )
-      .for("update");
-
-    const cellMetadataRowsToCopy = currentCellMetadataRows.filter(
-      (row) => row.propertyId !== freshFileField.propertyId,
-    );
-
-    if (cellMetadataRowsToCopy.length > 0) {
-      await tx.insert(cellMetadata).values(
-        cellMetadataRowsToCopy.map((row) => ({
-          workspaceId,
-          entityVersionId: nextVersionId,
-          propertyId: row.propertyId,
-          metadata: row.metadata,
-          createdBy: row.createdBy,
-          updatedBy: row.updatedBy,
-          createdAt: row.createdAt,
-          updatedAt: row.updatedAt,
-        })),
-      );
-    }
-
-    await tx
-      .update(entities)
-      .set({
-        currentVersionId: nextVersionId,
-        lastEditedBy: userId,
-        updatedAt: new Date(),
-      })
-      .where(
-        and(eq(entities.id, entityId), eq(entities.workspaceId, workspaceId)),
-      );
-
-    await tx
-      .update(workspaces)
-      .set({ lastActivityAt: new Date() })
-      .where(eq(workspaces.id, workspaceId));
-
-    await recordAuditEvent(tx, [
-      {
-        action: AUDIT_ACTION.CREATE,
-        resourceType: AUDIT_RESOURCE_TYPE.ENTITY_VERSION,
-        resourceId: nextVersionId,
-        changes: {
-          created: {
-            old: null,
-            new: {
-              entityId,
-              versionNumber: nextVersionNumber,
-              fileName: sanitizedName,
-              mimeType: declaredMime,
-              sizeBytes: declaredSize,
-              sha256Hex: declaredSha256Hex,
-            },
-          },
-        },
-        metadata: {
-          fileName: sanitizedName,
-          mimeType: declaredMime,
-          sizeBytes: declaredSize,
-          sha256Hex: declaredSha256Hex,
-        },
-      },
-      {
-        action: AUDIT_ACTION.UPDATE,
-        resourceType: AUDIT_RESOURCE_TYPE.ENTITY,
-        resourceId: entityId,
-        changes: {
-          currentVersionId: {
-            old: freshCurrentVersionId,
-            new: nextVersionId,
-          },
-        },
-      },
-    ]);
-
-    const finalized: Extract<
-      PendingUploadFinalizedResult,
-      { type: "entity_version" }
-    > = {
-      type: "entity_version",
-      entityId,
-      entityVersionId: nextVersionId,
-      versionNumber: nextVersionNumber,
-      fileId,
-      fileName: sanitizedName,
-    };
-
-    // audit: skip — final FSM transition on pending_uploads;
-    // the entity/version audit rows landed above in this same transaction.
-    const finalizedRows = await tx
-      .update(pendingUploads)
-      .set({
-        status: "finalized",
-        finalizedResult: finalized,
-        finalizedAt: new Date(),
-      })
-      .where(
-        and(
-          eq(pendingUploads.id, uploadId),
-          eq(pendingUploads.userId, userId),
-          eq(pendingUploads.workspaceId, workspaceId),
-          eq(pendingUploads.status, "scanning"),
-          eq(pendingUploads.claimedByRequestId, claimRequestId),
-        ),
-      )
-      .returning({ id: pendingUploads.id });
-    if (!finalizedRows.at(0)) {
-      panic("Pending upload finalize marker update returned no rows");
-    }
-
-    return { status: "ok", finalized };
-  });
+  );
   if (Result.isError(writeResultResult)) {
     await cleanupFinalObject("final-cleanup-after-db-error");
   }
   const writeResult = yield* writeResultResult;
 
   if (writeResult.status !== "ok") {
-    const status = writeResult.status;
+    await cleanupFinalObject("final-cleanup-after-business-error");
     if (
-      status === "entity-not-found" ||
-      status === "current-version-not-found"
+      writeResult.status === "entity-not-found" ||
+      writeResult.status === "current-version-not-found"
     ) {
-      await cleanupFinalObject("final-cleanup-after-business-error");
       return finalizeErr({
         status: 404,
         message:
-          status === "entity-not-found"
+          writeResult.status === "entity-not-found"
             ? "Entity not found"
             : "Current version not found",
-        rejectReason: status,
+        rejectReason: writeResult.status,
       });
     }
-    if (status === "entity-read-only") {
-      await cleanupFinalObject("final-cleanup-after-business-error");
+    if (writeResult.status === "entity-read-only") {
       return finalizeErr({
         status: 409,
         message: "Entity is read-only",
-        rejectReason: "entity-read-only",
+        rejectReason: writeResult.status,
       });
     }
-    await cleanupFinalObject("final-cleanup-after-business-error");
     return finalizeErr({
       status: 400,
       message: "Entity has no file field",
-      rejectReason: "missing-file-field",
+      rejectReason: writeResult.status,
     });
   }
 
-  const finalized = writeResult.finalized;
+  const finalizedResult =
+    finalized ??
+    panic("Entity version write completed without finalize result");
   const afterPromote = () => {
-    // Async kickoffs mirror the legacy handler. They run only after
-    // both promotion and the DB transaction have succeeded, so
-    // consumers never read a final key before it exists.
     processExtraction(entityId).catch((error: unknown) => {
       captureError(error, { entityId });
     });
     enqueuePdfDerivativeOrMarkFailed({
       encrypted: false,
       entityId,
-      fieldId: fileFieldId,
+      fieldId,
       mimeType: declaredMime,
       organizationId,
       userId,
       workspaceId,
     }).catch((error: unknown) => {
-      captureError(error, {
-        entityId,
-        fieldId: fileFieldId,
-        mimeType: declaredMime,
-      });
+      captureError(error, { entityId, fieldId, mimeType: declaredMime });
     });
     enqueueImageThumbnailOrMarkFailed({
       encrypted: false,
       entityId,
-      fieldId: fileFieldId,
+      fieldId,
       mimeType: declaredMime,
       organizationId,
       userId,
       workspaceId,
     }).catch((error: unknown) => {
-      captureError(error, {
-        entityId,
-        fieldId: fileFieldId,
-        mimeType: declaredMime,
-      });
+      captureError(error, { entityId, fieldId, mimeType: declaredMime });
     });
     computeVersionDiffStats({
-      versionId: nextVersionId,
+      versionId: entityVersionId,
       entityId,
       scopedDb: createRootScopedDb({
         organizationId,
@@ -516,7 +268,7 @@ export const finalizeEntityVersion = async function* ({
       workspaceId,
       organizationId,
     }).catch((error: unknown) => {
-      captureError(error, { versionId: nextVersionId });
+      captureError(error, { versionId: entityVersionId });
     });
     broadcast(workspaceId, {
       type: "invalidate-query",
@@ -524,5 +276,5 @@ export const finalizeEntityVersion = async function* ({
     });
   };
 
-  return finalizeOk({ finalizedResult: finalized, finalKey, afterPromote });
+  return finalizeOk({ finalizedResult, finalKey, afterPromote });
 };

--- a/apps/api/src/handlers/workspaces/delete.ts
+++ b/apps/api/src/handlers/workspaces/delete.ts
@@ -44,12 +44,22 @@ const changeWorkspaceStatus = async (
     // lock immediately before it claims a run, so a delete either seals first
     // or observes the in-flight run and leaves the workspace active.
     const workspaceRows = await tx
-      .select({ id: workspaces.id })
+      .select({ id: workspaces.id, status: workspaces.status })
       .from(workspaces)
       .where(eq(workspaces.id, workspaceId))
       .limit(1)
       .for("update");
-    if (newStatus === "deleting" && workspaceRows.at(0)) {
+    const workspace = workspaceRows.at(0);
+    if (!workspace) {
+      return false;
+    }
+    // Only one request may own the deletion seal. A concurrent request must
+    // not proceed to its own snapshot or later reactivate this workspace when
+    // its cleanup fails.
+    if (newStatus === "deleting" && workspace.status === "deleting") {
+      return false;
+    }
+    if (newStatus === "deleting") {
       const runningOcrRuns = await tx
         .select({ id: documentProcessingRuns.id })
         .from(documentProcessingRuns)
@@ -135,7 +145,8 @@ export const deleteWorkspaceHandler = async function* ({
     return Result.err(
       new HandlerError({
         status: 409,
-        message: "Wait for document processing to finish before deleting",
+        message:
+          "Wait for document processing or another deletion attempt to finish",
       }),
     );
   }

--- a/apps/api/src/handlers/workspaces/delete.ts
+++ b/apps/api/src/handlers/workspaces/delete.ts
@@ -153,9 +153,9 @@ export const deleteWorkspaceHandler = async function* ({
     await tx
       .update(pendingUploads)
       .set({
-        // Keep failed rows retryable if a later S3/DB step fails and the
-        // workspace is reactivated; upload finalization only reclaims failed
-        // rows whose claim is stale.
+        // Invalidate the writer's claim while keeping the row eligible for
+        // bounded repair if object cleanup fails and the workspace is
+        // reactivated. The writer's finalize CAS requires its original claim.
         claimedAt: new Date(0),
         claimedByRequestId: null,
         rejectReason: "Workspace deletion cancelled the upload",

--- a/apps/api/src/handlers/workspaces/delete.ts
+++ b/apps/api/src/handlers/workspaces/delete.ts
@@ -1,5 +1,5 @@
 import { Result } from "better-result";
-import { and, eq, inArray } from "drizzle-orm";
+import { and, eq, inArray, ne } from "drizzle-orm";
 
 import { member } from "@/api/db/auth-schema";
 import type { SafeDb, ScopedDb } from "@/api/db/safe-db";
@@ -9,6 +9,7 @@ import {
   entities,
   entityVersions,
   fields,
+  pendingUploads,
   properties,
   propertyDependencies,
   userFiles,
@@ -27,6 +28,7 @@ import { AUDIT_ACTION, AUDIT_RESOURCE_TYPE } from "@/api/lib/audit-log";
 import type { AuditRecorder } from "@/api/lib/audit-log";
 import type { SafeId } from "@/api/lib/branded-types";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
+import { pendingUploadS3KeysForDeletion } from "@/api/lib/pending-upload-keys";
 import { brandPersistedUserId } from "@/api/lib/safe-id-boundaries";
 import { PDF_MIME_TYPE } from "@/api/mime-types";
 
@@ -140,6 +142,32 @@ export const deleteWorkspaceHandler = async function* ({
   // Workspace is sealed by status: "deleting", so no
   // concurrent uploads can insert new files.
   const fileQueryResult = await safeDb(async (tx) => {
+    // Cancel every non-finalized upload before enumerating its keys. A live
+    // server buffer writer can no longer commit after this compare-and-set;
+    // if it publishes concurrently, its failed persistence path deletes the
+    // reserved final object too. This closes the publish-vs-workspace-cascade
+    // race instead of merely snapshotting recovery intents before deleting
+    // their rows.
+    // audit: skip — internal upload-lease cancellation within the audited
+    // workspace delete; the user-visible DELETE event is recorded below.
+    await tx
+      .update(pendingUploads)
+      .set({
+        // Keep failed rows retryable if a later S3/DB step fails and the
+        // workspace is reactivated; upload finalization only reclaims failed
+        // rows whose claim is stale.
+        claimedAt: new Date(0),
+        claimedByRequestId: null,
+        rejectReason: "Workspace deletion cancelled the upload",
+        status: "failed",
+      })
+      .where(
+        and(
+          eq(pendingUploads.workspaceId, workspaceId),
+          ne(pendingUploads.status, "finalized"),
+        ),
+      );
+
     const workspaceEntityVersionIds = tx
       .select({ id: entityVersions.id })
       .from(entityVersions)
@@ -165,7 +193,28 @@ export const deleteWorkspaceHandler = async function* ({
       .innerJoin(chatThreads, eq(userFiles.threadId, chatThreads.id))
       .where(eq(chatThreads.workspaceId, workspaceId));
 
-    return await Promise.all([fileRefsPromise, chatFileRefsPromise]);
+    const pendingUploadRowsPromise = tx
+      .select({
+        declaredMime: pendingUploads.declaredMime,
+        id: pendingUploads.id,
+        organizationId: pendingUploads.organizationId,
+        purpose: pendingUploads.purpose,
+        purposeData: pendingUploads.purposeData,
+        workspaceId: pendingUploads.workspaceId,
+      })
+      .from(pendingUploads)
+      .where(
+        and(
+          eq(pendingUploads.workspaceId, workspaceId),
+          ne(pendingUploads.status, "finalized"),
+        ),
+      );
+
+    return await Promise.all([
+      fileRefsPromise,
+      chatFileRefsPromise,
+      pendingUploadRowsPromise,
+    ]);
   });
 
   if (Result.isError(fileQueryResult)) {
@@ -179,7 +228,7 @@ export const deleteWorkspaceHandler = async function* ({
     );
   }
 
-  const [fileRefs, chatFileRefs] = fileQueryResult.value;
+  const [fileRefs, chatFileRefs, pendingUploadRows] = fileQueryResult.value;
 
   // Delete S3 objects outside any transaction.
   // On retry, already-deleted S3 objects are no-ops.
@@ -214,6 +263,16 @@ export const deleteWorkspaceHandler = async function* ({
         ),
       ).then((result) =>
         Result.unwrap(result, "Workspace chat file cleanup failed"),
+      ),
+    );
+  }
+
+  if (pendingUploadRows.length > 0) {
+    s3Deletes.push(
+      deleteS3Keys(
+        pendingUploadRows.flatMap(pendingUploadS3KeysForDeletion),
+      ).then((result) =>
+        Result.unwrap(result, "Workspace pending upload cleanup failed"),
       ),
     );
   }

--- a/apps/api/src/handlers/workspaces/delete.ts
+++ b/apps/api/src/handlers/workspaces/delete.ts
@@ -27,6 +27,7 @@ import type { HandlerConfig } from "@/api/lib/api-handlers";
 import { AUDIT_ACTION, AUDIT_RESOURCE_TYPE } from "@/api/lib/audit-log";
 import type { AuditRecorder } from "@/api/lib/audit-log";
 import type { SafeId } from "@/api/lib/branded-types";
+import { preserveBufferObjectCleanupIntents } from "@/api/lib/buffer-intent-reconciliation";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import { pendingUploadS3KeysForDeletion } from "@/api/lib/pending-upload-keys";
 import { brandPersistedUserId } from "@/api/lib/safe-id-boundaries";
@@ -210,11 +211,13 @@ export const deleteWorkspaceHandler = async function* ({
         ),
       );
 
-    return await Promise.all([
+    const result = await Promise.all([
       fileRefsPromise,
       chatFileRefsPromise,
       pendingUploadRowsPromise,
     ]);
+    await preserveBufferObjectCleanupIntents(tx, result[2]);
+    return result;
   });
 
   if (Result.isError(fileQueryResult)) {

--- a/apps/api/src/handlers/workspaces/delete.ts
+++ b/apps/api/src/handlers/workspaces/delete.ts
@@ -1,5 +1,5 @@
 import { Result } from "better-result";
-import { and, eq, inArray, ne } from "drizzle-orm";
+import { and, eq, inArray } from "drizzle-orm";
 
 import { member } from "@/api/db/auth-schema";
 import type { SafeDb, ScopedDb } from "@/api/db/safe-db";
@@ -10,6 +10,7 @@ import {
   entityVersions,
   fields,
   pendingUploads,
+  PENDING_UPLOAD_RECOVERABLE_STATUSES,
   properties,
   propertyDependencies,
   userFiles,
@@ -165,7 +166,7 @@ export const deleteWorkspaceHandler = async function* ({
       .where(
         and(
           eq(pendingUploads.workspaceId, workspaceId),
-          ne(pendingUploads.status, "finalized"),
+          inArray(pendingUploads.status, PENDING_UPLOAD_RECOVERABLE_STATUSES),
         ),
       );
 
@@ -207,7 +208,7 @@ export const deleteWorkspaceHandler = async function* ({
       .where(
         and(
           eq(pendingUploads.workspaceId, workspaceId),
-          ne(pendingUploads.status, "finalized"),
+          inArray(pendingUploads.status, PENDING_UPLOAD_RECOVERABLE_STATUSES),
         ),
       );
 

--- a/apps/api/src/handlers/workspaces/delete.ts
+++ b/apps/api/src/handlers/workspaces/delete.ts
@@ -1,5 +1,5 @@
 import { Result } from "better-result";
-import { and, eq, inArray } from "drizzle-orm";
+import { and, eq, inArray, ne } from "drizzle-orm";
 
 import { member } from "@/api/db/auth-schema";
 import type { SafeDb, ScopedDb } from "@/api/db/safe-db";
@@ -202,13 +202,14 @@ export const deleteWorkspaceHandler = async function* ({
         organizationId: pendingUploads.organizationId,
         purpose: pendingUploads.purpose,
         purposeData: pendingUploads.purposeData,
+        status: pendingUploads.status,
         workspaceId: pendingUploads.workspaceId,
       })
       .from(pendingUploads)
       .where(
         and(
           eq(pendingUploads.workspaceId, workspaceId),
-          inArray(pendingUploads.status, PENDING_UPLOAD_RECOVERABLE_STATUSES),
+          ne(pendingUploads.status, "finalized"),
         ),
       );
 
@@ -217,7 +218,12 @@ export const deleteWorkspaceHandler = async function* ({
       chatFileRefsPromise,
       pendingUploadRowsPromise,
     ]);
-    await preserveBufferObjectCleanupIntents(tx, result[2]);
+    await preserveBufferObjectCleanupIntents(
+      tx,
+      result[2].filter(
+        ({ status }) => status === "scanning" || status === "failed",
+      ),
+    );
     return result;
   });
 

--- a/apps/api/src/lib/account-deletion-steps.test.ts
+++ b/apps/api/src/lib/account-deletion-steps.test.ts
@@ -51,6 +51,8 @@ describe("pendingUploadS3KeysForDeletion", () => {
   test("locks active intents before queuing their object keys", async () => {
     const lockStrengths: string[] = [];
     const deletedUserIds: unknown[] = [];
+    const insertedCleanupValues: unknown[] = [];
+    const updateValues: unknown[] = [];
     const tx = asTestRaw<Transaction>({
       select: () => ({
         from: () => ({
@@ -78,6 +80,19 @@ describe("pendingUploadS3KeysForDeletion", () => {
           }),
         }),
       }),
+      insert: () => ({
+        values: (values: unknown[]) => ({
+          onConflictDoNothing: async () => {
+            insertedCleanupValues.push(...values);
+          },
+        }),
+      }),
+      update: () => ({
+        set: (values: unknown) => {
+          updateValues.push(values);
+          return { where: async () => undefined };
+        },
+      }),
       delete: () => ({
         where: async (condition: unknown) => {
           deletedUserIds.push(condition);
@@ -94,6 +109,20 @@ describe("pendingUploadS3KeysForDeletion", () => {
 
     expect(lockStrengths).toEqual(["update"]);
     expect(deletedUserIds).toHaveLength(1);
+    expect(updateValues).toEqual([
+      expect.objectContaining({
+        claimedByRequestId: null,
+        status: "failed",
+      }),
+    ]);
+    expect(insertedCleanupValues).toEqual([
+      expect.objectContaining({
+        id,
+        organizationId,
+        workspaceId,
+        objectKey: `${organizationId}/${workspaceId}/0198fa3d-fc8d-7000-8000-000000000005.docx`,
+      }),
+    ]);
     expect(s3KeysToDelete).toContain(
       `${organizationId}/${workspaceId}/0198fa3d-fc8d-7000-8000-000000000005.docx`,
     );

--- a/apps/api/src/lib/account-deletion-steps.test.ts
+++ b/apps/api/src/lib/account-deletion-steps.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "bun:test";
+
+import { toSafeId } from "@/api/lib/branded-types";
+import { pendingUploadS3KeysForDeletion } from "@/api/lib/pending-upload-keys";
+
+describe("pendingUploadS3KeysForDeletion", () => {
+  const organizationId = toSafeId<"organization">(
+    "0198fa3d-fc8d-7000-8000-000000000001",
+  );
+  const workspaceId = toSafeId<"workspace">(
+    "0198fa3d-fc8d-7000-8000-000000000002",
+  );
+  const id = toSafeId<"pendingUpload">("0198fa3d-fc8d-7000-8000-000000000003");
+
+  test("includes the reserved final object for an abandoned buffer intent", () => {
+    expect(
+      pendingUploadS3KeysForDeletion({
+        declaredMime:
+          "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        id,
+        organizationId,
+        purpose: "entity_version",
+        purposeData: {
+          type: "entity_version",
+          entityId: toSafeId<"entity">("0198fa3d-fc8d-7000-8000-000000000004"),
+          reservedFileId: "0198fa3d-fc8d-7000-8000-000000000005",
+        },
+        workspaceId,
+      }),
+    ).toContain(
+      `${organizationId}/${workspaceId}/0198fa3d-fc8d-7000-8000-000000000005.docx`,
+    );
+  });
+
+  test("does not invent a final key for ordinary presigned uploads", () => {
+    expect(
+      pendingUploadS3KeysForDeletion({
+        declaredMime: "application/zip",
+        id,
+        organizationId,
+        purpose: "agent_skill",
+        purposeData: { type: "agent_skill", scope: "private" },
+        workspaceId,
+      }),
+    ).not.toContainEqual(expect.stringContaining(".zip"));
+  });
+});

--- a/apps/api/src/lib/account-deletion-steps.test.ts
+++ b/apps/api/src/lib/account-deletion-steps.test.ts
@@ -14,6 +14,9 @@ describe("pendingUploadS3KeysForDeletion", () => {
     "0198fa3d-fc8d-7000-8000-000000000002",
   );
   const id = toSafeId<"pendingUpload">("0198fa3d-fc8d-7000-8000-000000000003");
+  const normalUploadId = toSafeId<"pendingUpload">(
+    "0198fa3d-fc8d-7000-8000-000000000006",
+  );
 
   test("includes the reserved final object for an abandoned buffer intent", () => {
     expect(
@@ -73,6 +76,16 @@ describe("pendingUploadS3KeysForDeletion", () => {
                     ),
                     reservedFileId: "0198fa3d-fc8d-7000-8000-000000000005",
                   },
+                  status: "scanning",
+                  workspaceId,
+                },
+                {
+                  declaredMime: "application/zip",
+                  id: normalUploadId,
+                  organizationId,
+                  purpose: "agent_skill",
+                  purposeData: { type: "agent_skill", scope: "private" },
+                  status: "pending",
                   workspaceId,
                 },
               ];
@@ -125,6 +138,18 @@ describe("pendingUploadS3KeysForDeletion", () => {
     ]);
     expect(s3KeysToDelete).toContain(
       `${organizationId}/${workspaceId}/0198fa3d-fc8d-7000-8000-000000000005.docx`,
+    );
+    expect(s3KeysToDelete).toEqual(
+      expect.arrayContaining(
+        pendingUploadS3KeysForDeletion({
+          declaredMime: "application/zip",
+          id: normalUploadId,
+          organizationId,
+          purpose: "agent_skill",
+          purposeData: { type: "agent_skill", scope: "private" },
+          workspaceId,
+        }),
+      ),
     );
   });
 });

--- a/apps/api/src/lib/account-deletion-steps.test.ts
+++ b/apps/api/src/lib/account-deletion-steps.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, test } from "bun:test";
 
+import type { Transaction } from "@/api/db/root";
+import { deletePendingUploads } from "@/api/lib/account-deletion-steps";
 import { toSafeId } from "@/api/lib/branded-types";
 import { pendingUploadS3KeysForDeletion } from "@/api/lib/pending-upload-keys";
+import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
 
 describe("pendingUploadS3KeysForDeletion", () => {
   const organizationId = toSafeId<"organization">(
@@ -43,5 +46,56 @@ describe("pendingUploadS3KeysForDeletion", () => {
         workspaceId,
       }),
     ).not.toContainEqual(expect.stringContaining(".zip"));
+  });
+
+  test("locks active intents before queuing their object keys", async () => {
+    const lockStrengths: string[] = [];
+    const deletedUserIds: unknown[] = [];
+    const tx = asTestRaw<Transaction>({
+      select: () => ({
+        from: () => ({
+          where: () => ({
+            for: async (strength: string) => {
+              lockStrengths.push(strength);
+              return [
+                {
+                  declaredMime:
+                    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+                  id,
+                  organizationId,
+                  purpose: "entity_version",
+                  purposeData: {
+                    type: "entity_version",
+                    entityId: toSafeId<"entity">(
+                      "0198fa3d-fc8d-7000-8000-000000000004",
+                    ),
+                    reservedFileId: "0198fa3d-fc8d-7000-8000-000000000005",
+                  },
+                  workspaceId,
+                },
+              ];
+            },
+          }),
+        }),
+      }),
+      delete: () => ({
+        where: async (condition: unknown) => {
+          deletedUserIds.push(condition);
+        },
+      }),
+    });
+    const s3KeysToDelete: string[] = [];
+
+    await deletePendingUploads({
+      tx,
+      currentUserId: "user-1",
+      s3KeysToDelete,
+    });
+
+    expect(lockStrengths).toEqual(["update"]);
+    expect(deletedUserIds).toHaveLength(1);
+    expect(s3KeysToDelete).toContain(
+      `${organizationId}/${workspaceId}/0198fa3d-fc8d-7000-8000-000000000005.docx`,
+    );
   });
 });

--- a/apps/api/src/lib/account-deletion-steps.ts
+++ b/apps/api/src/lib/account-deletion-steps.ts
@@ -689,7 +689,8 @@ export const deletePendingUploads = async ({
         eq(pendingUploads.userId, currentUserId),
         ne(pendingUploads.status, "finalized"),
       ),
-    );
+    )
+    .for("update");
   s3KeysToDelete.push(
     ...stagedUploadRows.flatMap(pendingUploadS3KeysForDeletion),
   );

--- a/apps/api/src/lib/account-deletion-steps.ts
+++ b/apps/api/src/lib/account-deletion-steps.ts
@@ -55,6 +55,7 @@ import {
 import { arrayOrEmpty } from "@/api/lib/array";
 import { AUDIT_ACTION, AUDIT_RESOURCE_TYPE } from "@/api/lib/audit-log";
 import type { SafeId } from "@/api/lib/branded-types";
+import { preserveBufferObjectCleanupIntents } from "@/api/lib/buffer-intent-reconciliation";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import { FOLIO_COLLAB_YJS_UPDATE_MIME_TYPE } from "@/api/lib/folio-collab-sessions";
 import { LIMITS } from "@/api/lib/limits";
@@ -694,6 +695,28 @@ export const deletePendingUploads = async ({
   s3KeysToDelete.push(
     ...stagedUploadRows.flatMap(pendingUploadS3KeysForDeletion),
   );
+
+  if (stagedUploadRows.length > 0) {
+    const ids = stagedUploadRows.map(({ id }) => id);
+    // Invalidate every live writer before transferring recovery ownership.
+    // A later finalize CAS must fail and route through the writer's exact-key
+    // cleanup, which removes the independent tombstone only after PUT settles.
+    await tx
+      .update(pendingUploads)
+      .set({
+        claimedAt: new Date(0),
+        claimedByRequestId: null,
+        rejectReason: "Account deletion cancelled the upload",
+        status: "failed",
+      })
+      .where(
+        and(
+          inArray(pendingUploads.id, ids),
+          ne(pendingUploads.status, "finalized"),
+        ),
+      );
+    await preserveBufferObjectCleanupIntents(tx, stagedUploadRows);
+  }
 
   await tx
     .delete(pendingUploads)

--- a/apps/api/src/lib/account-deletion-steps.ts
+++ b/apps/api/src/lib/account-deletion-steps.ts
@@ -39,6 +39,7 @@ import {
   mcpOAuthState,
   mcpUserConnections,
   pendingUploads,
+  PENDING_UPLOAD_RECOVERABLE_STATUSES,
   rateEntries,
   taskAssignees,
   userFiles,
@@ -688,7 +689,7 @@ export const deletePendingUploads = async ({
     .where(
       and(
         eq(pendingUploads.userId, currentUserId),
-        ne(pendingUploads.status, "finalized"),
+        inArray(pendingUploads.status, PENDING_UPLOAD_RECOVERABLE_STATUSES),
       ),
     )
     .for("update");
@@ -712,7 +713,7 @@ export const deletePendingUploads = async ({
       .where(
         and(
           inArray(pendingUploads.id, ids),
-          ne(pendingUploads.status, "finalized"),
+          inArray(pendingUploads.status, PENDING_UPLOAD_RECOVERABLE_STATUSES),
         ),
       );
     await preserveBufferObjectCleanupIntents(tx, stagedUploadRows);

--- a/apps/api/src/lib/account-deletion-steps.ts
+++ b/apps/api/src/lib/account-deletion-steps.ts
@@ -47,7 +47,6 @@ import {
   workspaces,
 } from "@/api/db/schema";
 import { createFileKey, createUserFileKey } from "@/api/handlers/files/utils";
-import { tmpUploadKeys } from "@/api/handlers/uploads/lib";
 import {
   ACTIVE_TASK_REASSIGNMENT_STATUSES,
   buildAccountDeletionTaskReassignmentTargets,
@@ -59,6 +58,7 @@ import type { SafeId } from "@/api/lib/branded-types";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import { FOLIO_COLLAB_YJS_UPDATE_MIME_TYPE } from "@/api/lib/folio-collab-sessions";
 import { LIMITS } from "@/api/lib/limits";
+import { pendingUploadS3KeysForDeletion } from "@/api/lib/pending-upload-keys";
 import {
   brandPersistedOrganizationId,
   brandPersistedUserId,
@@ -676,8 +676,11 @@ export const deletePendingUploads = async ({
 }: DeletePendingUploadsParams): Promise<void> => {
   const stagedUploadRows = await tx
     .select({
+      declaredMime: pendingUploads.declaredMime,
       id: pendingUploads.id,
       organizationId: pendingUploads.organizationId,
+      purpose: pendingUploads.purpose,
+      purposeData: pendingUploads.purposeData,
       workspaceId: pendingUploads.workspaceId,
     })
     .from(pendingUploads)
@@ -688,13 +691,7 @@ export const deletePendingUploads = async ({
       ),
     );
   s3KeysToDelete.push(
-    ...stagedUploadRows.flatMap((row) =>
-      tmpUploadKeys({
-        organizationId: row.organizationId,
-        uploadId: row.id,
-        workspaceId: row.workspaceId,
-      }),
-    ),
+    ...stagedUploadRows.flatMap(pendingUploadS3KeysForDeletion),
   );
 
   await tx

--- a/apps/api/src/lib/account-deletion-steps.ts
+++ b/apps/api/src/lib/account-deletion-steps.ts
@@ -683,13 +683,14 @@ export const deletePendingUploads = async ({
       organizationId: pendingUploads.organizationId,
       purpose: pendingUploads.purpose,
       purposeData: pendingUploads.purposeData,
+      status: pendingUploads.status,
       workspaceId: pendingUploads.workspaceId,
     })
     .from(pendingUploads)
     .where(
       and(
         eq(pendingUploads.userId, currentUserId),
-        inArray(pendingUploads.status, PENDING_UPLOAD_RECOVERABLE_STATUSES),
+        ne(pendingUploads.status, "finalized"),
       ),
     )
     .for("update");
@@ -697,8 +698,11 @@ export const deletePendingUploads = async ({
     ...stagedUploadRows.flatMap(pendingUploadS3KeysForDeletion),
   );
 
-  if (stagedUploadRows.length > 0) {
-    const ids = stagedUploadRows.map(({ id }) => id);
+  const recoverableRows = stagedUploadRows.filter(
+    ({ status }) => status === "scanning" || status === "failed",
+  );
+  if (recoverableRows.length > 0) {
+    const ids = recoverableRows.map(({ id }) => id);
     // Invalidate every live writer before transferring recovery ownership.
     // A later finalize CAS must fail and route through the writer's exact-key
     // cleanup, which removes the independent tombstone only after PUT settles.
@@ -716,7 +720,7 @@ export const deletePendingUploads = async ({
           inArray(pendingUploads.status, PENDING_UPLOAD_RECOVERABLE_STATUSES),
         ),
       );
-    await preserveBufferObjectCleanupIntents(tx, stagedUploadRows);
+    await preserveBufferObjectCleanupIntents(tx, recoverableRows);
   }
 
   await tx

--- a/apps/api/src/lib/buffer-intent-reconciliation.test.ts
+++ b/apps/api/src/lib/buffer-intent-reconciliation.test.ts
@@ -11,6 +11,7 @@ const s3DeleteMock = mock(
 );
 
 const {
+  lockActiveWorkspaceForBufferIntent,
   reconcileBufferObjectCleanupIntents,
   reconcileStaleBufferIntentsGlobally,
 } = await import("@/api/lib/buffer-intent-reconciliation");
@@ -77,6 +78,53 @@ const createReconciliationSafeDb = (updates: UpdateValues[]): SafeDb => {
 beforeEach(() => {
   s3DeleteMock.mockReset();
   s3DeleteMock.mockResolvedValue(undefined);
+});
+
+test("share-locks an active workspace before reserving a writer intent", async () => {
+  const locks: unknown[] = [];
+  const tx = asTestRaw<Transaction>({
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          limit: () => ({
+            for: async (strength: unknown) => {
+              locks.push(strength);
+              return [{ status: "active" }];
+            },
+          }),
+        }),
+      }),
+    }),
+  });
+
+  await lockActiveWorkspaceForBufferIntent(tx, workspaceId);
+
+  expect(locks).toEqual(["share"]);
+});
+
+test("rejects a writer reservation after workspace deletion seals", async () => {
+  const tx = asTestRaw<Transaction>({
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          limit: () => ({ for: async () => [{ status: "deleting" }] }),
+        }),
+      }),
+    }),
+  });
+
+  const rejection: unknown = await lockActiveWorkspaceForBufferIntent(
+    tx,
+    workspaceId,
+  ).then(
+    () => null,
+    (error: unknown) => error,
+  );
+
+  expect(rejection).toMatchObject({
+    _tag: "BufferIntentWorkspaceUnavailableError",
+    message: "Workspace is not active",
+  });
 });
 
 test("keeps a reclaimed writer intent recoverable after deleting its object", async () => {

--- a/apps/api/src/lib/buffer-intent-reconciliation.test.ts
+++ b/apps/api/src/lib/buffer-intent-reconciliation.test.ts
@@ -6,14 +6,14 @@ import type { SafeDb } from "@/api/db/safe-db";
 import { toSafeId } from "@/api/lib/branded-types";
 import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
 
-const s3DeleteMock = mock(async () => undefined);
+const s3DeleteMock = mock(
+  async (_key: string, _signal: AbortSignal) => undefined,
+);
 
-void mock.module("@/api/lib/s3", () => ({
-  getS3: () => ({ delete: s3DeleteMock }),
-}));
-
-const { reconcileStaleBufferIntentsGlobally } =
-  await import("@/api/lib/buffer-intent-reconciliation");
+const {
+  reconcileBufferObjectCleanupIntents,
+  reconcileStaleBufferIntentsGlobally,
+} = await import("@/api/lib/buffer-intent-reconciliation");
 
 const pendingUploadId = toSafeId<"pendingUpload">(
   "00000000-0000-0000-0000-000000000001",
@@ -85,6 +85,7 @@ test("keeps a reclaimed writer intent recoverable after deleting its object", as
   const claimed = await reconcileStaleBufferIntentsGlobally({
     safeDb: createReconciliationSafeDb(updates),
     limit: 1,
+    deleteObject: s3DeleteMock,
   });
 
   expect(claimed).toBe(1);
@@ -98,16 +99,80 @@ test("keeps a reclaimed writer intent recoverable after deleting its object", as
   expect(updates.at(-1)).not.toHaveProperty("finalizedAt");
 });
 
+test("keeps a lifecycle tombstone while backing off repeated deletion", async () => {
+  const updates: unknown[] = [];
+  const tx = asTestRaw<Transaction>({
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          orderBy: () => ({
+            limit: () => ({
+              for: async () => [
+                {
+                  attemptCount: 0,
+                  id: pendingUploadId,
+                  objectKey: `${organizationId}/${workspaceId}/reserved.docx`,
+                },
+              ],
+            }),
+          }),
+        }),
+      }),
+    }),
+    update: () => ({
+      set: (values: unknown) => {
+        updates.push(values);
+        return { where: async () => undefined };
+      },
+    }),
+  });
+  const safeDb = asTestRaw<SafeDb>(
+    async <T>(run: (transaction: Transaction) => Promise<T>) =>
+      await Result.tryPromise({
+        try: async () => await run(tx),
+        catch: (cause) => cause,
+      }),
+  );
+
+  const claimed = await reconcileBufferObjectCleanupIntents({
+    safeDb,
+    limit: 1,
+    deleteObject: s3DeleteMock,
+  });
+
+  expect(claimed).toBe(1);
+  expect(s3DeleteMock).toHaveBeenCalledWith(
+    `${organizationId}/${workspaceId}/reserved.docx`,
+    expect.any(AbortSignal),
+  );
+  expect(updates).toHaveLength(1);
+  expect(updates.at(0)).toEqual(
+    expect.objectContaining({
+      attemptCount: expect.anything(),
+      nextAttemptAt: expect.anything(),
+    }),
+  );
+});
+
 test("stops an in-flight object cleanup when the scheduler aborts", async () => {
   const updates: UpdateValues[] = [];
   let deletionStarted: (() => void) | undefined;
   const started = new Promise<void>((resolve) => {
     deletionStarted = resolve;
   });
-  s3DeleteMock.mockImplementation(async () => {
+  s3DeleteMock.mockImplementation(async (_key, signal: AbortSignal) => {
     deletionStarted?.();
-    return await new Promise<never>(() => {
-      // Intentionally pending: only the scheduler abort may settle the batch.
+    return await new Promise<never>((_resolve, reject) => {
+      signal.addEventListener(
+        "abort",
+        () =>
+          reject(
+            signal.reason instanceof Error
+              ? signal.reason
+              : new DOMException("Aborted", "AbortError"),
+          ),
+        { once: true },
+      );
     });
   });
   const controller = new AbortController();
@@ -115,6 +180,7 @@ test("stops an in-flight object cleanup when the scheduler aborts", async () => 
     safeDb: createReconciliationSafeDb(updates),
     limit: 1,
     signal: controller.signal,
+    deleteObject: s3DeleteMock,
   });
 
   await started;
@@ -132,4 +198,5 @@ test("stops an in-flight object cleanup when the scheduler aborts", async () => 
   expect(updates.at(0)).toEqual(
     expect.objectContaining({ status: "scanning" }),
   );
+  expect(s3DeleteMock.mock.calls.at(0)?.at(1)).toMatchObject({ aborted: true });
 });

--- a/apps/api/src/lib/buffer-intent-reconciliation.test.ts
+++ b/apps/api/src/lib/buffer-intent-reconciliation.test.ts
@@ -1,0 +1,135 @@
+import { Result } from "better-result";
+import { beforeEach, expect, mock, test } from "bun:test";
+
+import type { Transaction } from "@/api/db/root";
+import type { SafeDb } from "@/api/db/safe-db";
+import { toSafeId } from "@/api/lib/branded-types";
+import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
+
+const s3DeleteMock = mock(async () => undefined);
+
+void mock.module("@/api/lib/s3", () => ({
+  getS3: () => ({ delete: s3DeleteMock }),
+}));
+
+const { reconcileStaleBufferIntentsGlobally } =
+  await import("@/api/lib/buffer-intent-reconciliation");
+
+const pendingUploadId = toSafeId<"pendingUpload">(
+  "00000000-0000-0000-0000-000000000001",
+);
+const organizationId = toSafeId<"organization">(
+  "00000000-0000-0000-0000-000000000002",
+);
+const workspaceId = toSafeId<"workspace">(
+  "00000000-0000-0000-0000-000000000003",
+);
+
+type UpdateValues = {
+  claimedAt?: Date | undefined;
+  finalizedAt?: Date | undefined;
+  status?: string | undefined;
+};
+
+const createReconciliationSafeDb = (updates: UpdateValues[]): SafeDb => {
+  const row = {
+    declaredMime:
+      "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    id: pendingUploadId,
+    organizationId,
+    purpose: "entity_create",
+    purposeData: {
+      type: "entity_create" as const,
+      propertyId: toSafeId<"property">("00000000-0000-0000-0000-000000000004"),
+      reservedFileId: "00000000-0000-0000-0000-000000000005",
+    },
+    workspaceId,
+  };
+  const tx = asTestRaw<Transaction>({
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          orderBy: () => ({
+            limit: () => ({
+              for: async () => [row],
+            }),
+          }),
+        }),
+      }),
+    }),
+    update: () => ({
+      set: (values: UpdateValues) => {
+        updates.push(values);
+        return { where: async () => undefined };
+      },
+    }),
+  });
+
+  return asTestRaw<SafeDb>(
+    async <T>(run: (transaction: Transaction) => Promise<T>) =>
+      await Result.tryPromise({
+        try: async () => await run(tx),
+        catch: (cause) => cause,
+      }),
+  );
+};
+
+beforeEach(() => {
+  s3DeleteMock.mockReset();
+  s3DeleteMock.mockResolvedValue(undefined);
+});
+
+test("keeps a reclaimed writer intent recoverable after deleting its object", async () => {
+  const updates: UpdateValues[] = [];
+
+  const claimed = await reconcileStaleBufferIntentsGlobally({
+    safeDb: createReconciliationSafeDb(updates),
+    limit: 1,
+  });
+
+  expect(claimed).toBe(1);
+  expect(s3DeleteMock).toHaveBeenCalledTimes(1);
+  expect(updates.at(-1)).toEqual(
+    expect.objectContaining({
+      claimedAt: expect.any(Date),
+      status: "failed",
+    }),
+  );
+  expect(updates.at(-1)).not.toHaveProperty("finalizedAt");
+});
+
+test("stops an in-flight object cleanup when the scheduler aborts", async () => {
+  const updates: UpdateValues[] = [];
+  let deletionStarted: (() => void) | undefined;
+  const started = new Promise<void>((resolve) => {
+    deletionStarted = resolve;
+  });
+  s3DeleteMock.mockImplementation(async () => {
+    deletionStarted?.();
+    return await new Promise<never>(() => {
+      // Intentionally pending: only the scheduler abort may settle the batch.
+    });
+  });
+  const controller = new AbortController();
+  const reconciliation = reconcileStaleBufferIntentsGlobally({
+    safeDb: createReconciliationSafeDb(updates),
+    limit: 1,
+    signal: controller.signal,
+  });
+
+  await started;
+  controller.abort();
+
+  const rejection: unknown = await reconciliation.then(
+    () => null,
+    (error: unknown) => error,
+  );
+  expect(rejection).toMatchObject({
+    message: "The operation was aborted.",
+    name: "AbortError",
+  });
+  expect(updates).toHaveLength(1);
+  expect(updates.at(0)).toEqual(
+    expect.objectContaining({ status: "scanning" }),
+  );
+});

--- a/apps/api/src/lib/buffer-intent-reconciliation.ts
+++ b/apps/api/src/lib/buffer-intent-reconciliation.ts
@@ -11,11 +11,13 @@ import { captureError } from "@/api/lib/analytics/capture";
 import type { SafeId } from "@/api/lib/branded-types";
 import { createFileKey } from "@/api/lib/file-key";
 import { getS3 } from "@/api/lib/s3";
+import { withTimeout } from "@/api/lib/with-timeout";
 
 export const BUFFER_INTENT_TTL_MS = 5 * 60 * 1000;
 export const BUFFER_INTENT_STALE_MS = 60 * 1000;
 export const BUFFER_INTENT_HEARTBEAT_MS = 15 * 1000;
 const BUFFER_INTENT_RECONCILE_LIMIT = 25;
+const BUFFER_INTENT_DELETE_TIMEOUT_MS = 30 * 1000;
 
 export type BufferIntentPurpose = "entity_create" | "entity_version";
 
@@ -53,11 +55,14 @@ const reconcileStaleBufferIntentBatch = async ({
   safeDb,
   scope,
   limit,
+  signal,
 }: {
   safeDb: SafeDb;
   scope?: BufferIntentScope | undefined;
   limit: number;
+  signal?: AbortSignal | undefined;
 }): Promise<number> => {
+  signal?.throwIfAborted();
   const reconcileClaimId = Bun.randomUUIDv7().slice(0, 64);
   const timeoutSeconds = Math.floor(BUFFER_INTENT_STALE_MS / 1000);
   const ownershipPredicate =
@@ -129,10 +134,18 @@ const reconcileStaleBufferIntentBatch = async ({
         mimeType: row.declaredMime,
       });
       const cleanup = await Result.tryPromise({
-        try: async () => await getS3().delete(objectKey),
+        try: async () =>
+          await withTimeout(async () => await getS3().delete(objectKey), {
+            label: "buffer-intent-reconciliation.delete",
+            signal,
+            timeoutMs: BUFFER_INTENT_DELETE_TIMEOUT_MS,
+          }),
         catch: (cause) => cause,
       });
       if (Result.isError(cleanup)) {
+        if (signal?.aborted) {
+          return null;
+        }
         captureError(cleanup.error, {
           objectKey,
           pendingUploadId: row.id,
@@ -143,6 +156,7 @@ const reconcileStaleBufferIntentBatch = async ({
       return row.id;
     }),
   );
+  signal?.throwIfAborted();
   const cleanedIds = cleanupResults.filter(
     (id): id is SafeId<"pendingUpload"> => id !== null,
   );
@@ -150,18 +164,22 @@ const reconcileStaleBufferIntentBatch = async ({
     return claimedResult.value.length;
   }
 
-  const finalizedCleanup = await safeDb(async (tx) => {
-    // audit: skip — terminal crash-recovery bookkeeping after object cleanup.
+  const retainedCleanup = await safeDb(async (tx) => {
+    // audit: skip — durable crash-recovery retry bookkeeping; no entity changes.
+    // A reclaimed writer may still publish after this delete. Keep the row
+    // recoverable so later sweeps delete any late object publication. A writer
+    // that eventually settles can terminalize the row after its own confirmed
+    // cleanup.
     await tx
       .update(pendingUploads)
       .set({
-        finalizedAt: new Date(),
+        claimedAt: new Date(),
         rejectReason: sql<string>`CASE
           WHEN ${pendingUploads.purpose} = 'entity_create'
             THEN ${rejectionReason("entity_create")}
           ELSE ${rejectionReason("entity_version")}
         END`,
-        status: "rejected",
+        status: "failed",
       })
       .where(
         and(
@@ -171,10 +189,10 @@ const reconcileStaleBufferIntentBatch = async ({
         ),
       );
   });
-  if (Result.isError(finalizedCleanup)) {
-    captureError(finalizedCleanup.error, {
+  if (Result.isError(retainedCleanup)) {
+    captureError(retainedCleanup.error, {
       pendingUploadIds: cleanedIds.join(","),
-      stage: "buffer-intent-reconcile-finalize",
+      stage: "buffer-intent-reconcile-retain",
     });
   }
   return claimedResult.value.length;
@@ -213,7 +231,10 @@ export const reconcileStaleBufferIntents = async ({
 export const reconcileStaleBufferIntentsGlobally = async ({
   safeDb,
   limit,
+  signal,
 }: {
   safeDb: SafeDb;
   limit: number;
-}): Promise<number> => await reconcileStaleBufferIntentBatch({ safeDb, limit });
+  signal?: AbortSignal | undefined;
+}): Promise<number> =>
+  await reconcileStaleBufferIntentBatch({ safeDb, limit, signal });

--- a/apps/api/src/lib/buffer-intent-reconciliation.ts
+++ b/apps/api/src/lib/buffer-intent-reconciliation.ts
@@ -21,6 +21,7 @@ export const BUFFER_INTENT_STALE_MS = 60 * 1000;
 export const BUFFER_INTENT_HEARTBEAT_MS = 15 * 1000;
 const BUFFER_INTENT_RECONCILE_LIMIT = 25;
 export const BUFFER_INTENT_DELETE_TIMEOUT_MS = 30 * 1000;
+export const BUFFER_INTENT_WRITE_TIMEOUT_MS = 2 * 60 * 1000;
 const BUFFER_CLEANUP_RETRY_MAX_EXPONENT = 14;
 
 export type BufferIntentPurpose = "entity_create" | "entity_version";

--- a/apps/api/src/lib/buffer-intent-reconciliation.ts
+++ b/apps/api/src/lib/buffer-intent-reconciliation.ts
@@ -19,7 +19,7 @@ export const BUFFER_INTENT_TTL_MS = 5 * 60 * 1000;
 export const BUFFER_INTENT_STALE_MS = 60 * 1000;
 export const BUFFER_INTENT_HEARTBEAT_MS = 15 * 1000;
 const BUFFER_INTENT_RECONCILE_LIMIT = 25;
-const BUFFER_INTENT_DELETE_TIMEOUT_MS = 30 * 1000;
+export const BUFFER_INTENT_DELETE_TIMEOUT_MS = 30 * 1000;
 const BUFFER_CLEANUP_RETRY_MAX_EXPONENT = 14;
 
 export type BufferIntentPurpose = "entity_create" | "entity_version";

--- a/apps/api/src/lib/buffer-intent-reconciliation.ts
+++ b/apps/api/src/lib/buffer-intent-reconciliation.ts
@@ -1,4 +1,4 @@
-import { Result, TaggedError } from "better-result";
+import { Result, TaggedError, panic } from "better-result";
 import { and, asc, eq, inArray, lte, sql } from "drizzle-orm";
 
 import type { Transaction } from "@/api/db/root";
@@ -11,6 +11,7 @@ import {
 } from "@/api/db/schema";
 import type { PendingUploadPurposeData } from "@/api/db/schema";
 import { captureError } from "@/api/lib/analytics/capture";
+import { createSafeId } from "@/api/lib/branded-types";
 import type { SafeId } from "@/api/lib/branded-types";
 import { createFileKey } from "@/api/lib/file-key";
 import { deleteS3ObjectWithSignal } from "@/api/lib/s3";
@@ -25,6 +26,41 @@ export const BUFFER_INTENT_WRITE_TIMEOUT_MS = 2 * 60 * 1000;
 const BUFFER_CLEANUP_RETRY_MAX_EXPONENT = 14;
 
 export type BufferIntentPurpose = "entity_create" | "entity_version";
+
+export type BufferIntent = {
+  claimRequestId: string;
+  id: SafeId<"pendingUpload">;
+};
+
+type BufferIntentPurposeData =
+  | {
+      purpose: "entity_create";
+      purposeData: Extract<PendingUploadPurposeData, { type: "entity_create" }>;
+    }
+  | {
+      purpose: "entity_version";
+      purposeData: Extract<
+        PendingUploadPurposeData,
+        { type: "entity_version" }
+      >;
+    };
+
+type ReserveBufferIntentOptions = BufferIntentPurposeData & {
+  safeDb: SafeDb;
+  organizationId: SafeId<"organization">;
+  workspaceId: SafeId<"workspace">;
+  userId: SafeId<"user">;
+  fileName: string;
+  mimeType: string;
+  sizeBytes: number;
+  sha256Hex: string;
+};
+
+type BufferIntentTelemetryStages = {
+  abandon: string;
+  heartbeat: string;
+  heartbeatUnhandled: string;
+};
 
 type BufferIntentScope = {
   organizationId: SafeId<"organization">;
@@ -71,6 +107,153 @@ export const lockActiveWorkspaceForBufferIntent = async (
       message: "Workspace is not active",
     });
   }
+};
+
+/** Reserve the final object key before a trusted server-side writer publishes. */
+export const reserveBufferIntent = async ({
+  safeDb,
+  organizationId,
+  workspaceId,
+  userId,
+  purpose,
+  purposeData,
+  fileName,
+  mimeType,
+  sizeBytes,
+  sha256Hex,
+}: ReserveBufferIntentOptions): Promise<BufferIntent> => {
+  const id = createSafeId<"pendingUpload">();
+  const claimRequestId = Bun.randomUUIDv7().slice(0, 64);
+  const now = new Date();
+  const reserved = await safeDb(async (tx) => {
+    await lockActiveWorkspaceForBufferIntent(tx, workspaceId);
+    // audit: skip — crash-recovery intent; the durable entity mutation is
+    // audited in the transaction that finalizes this row.
+    const rows = await tx
+      .insert(pendingUploads)
+      .values({
+        id,
+        organizationId,
+        workspaceId,
+        userId,
+        purpose,
+        purposeData,
+        declaredName: fileName,
+        declaredMime: mimeType,
+        declaredSize: sizeBytes,
+        declaredSha256: sha256Hex,
+        status: "scanning",
+        claimedAt: now,
+        claimedByRequestId: claimRequestId,
+        expiresAt: new Date(now.getTime() + BUFFER_INTENT_TTL_MS),
+        createdAt: now,
+      })
+      .returning({ id: pendingUploads.id });
+    return rows.at(0)?.id ?? panic("Buffer intent insert returned no row");
+  });
+  if (Result.isError(reserved)) {
+    throw reserved.error;
+  }
+  return { id: reserved.value, claimRequestId };
+};
+
+/** Close a recoverable intent only after its exact object key was deleted. */
+export const abandonBufferIntent = async ({
+  safeDb,
+  intent,
+  reason,
+  telemetry,
+}: {
+  safeDb: SafeDb;
+  intent: BufferIntent;
+  reason: string;
+  telemetry: BufferIntentTelemetryStages;
+}): Promise<void> => {
+  const abandoned = await safeDb(async (tx) => {
+    // audit: skip — failed intent bookkeeping; no durable entity mutation.
+    // The writer reaches this only after its PUT settled and deletion of its
+    // exact reserved key succeeded, even if a reconciler replaced its lease.
+    await tx
+      .update(pendingUploads)
+      .set({
+        finalizedAt: new Date(),
+        rejectReason: reason,
+        status: "rejected",
+      })
+      .where(
+        and(
+          eq(pendingUploads.id, intent.id),
+          inArray(pendingUploads.status, PENDING_UPLOAD_RECOVERABLE_STATUSES),
+        ),
+      );
+    await tx
+      .delete(bufferObjectCleanupIntents)
+      .where(eq(bufferObjectCleanupIntents.id, intent.id));
+  });
+  if (Result.isError(abandoned)) {
+    captureError(abandoned.error, {
+      pendingUploadId: intent.id,
+      stage: telemetry.abandon,
+    });
+  }
+};
+
+/** Renew one writer's recovery lease until its storage/DB work settles. */
+export const startBufferIntentHeartbeat = ({
+  safeDb,
+  intent,
+  telemetry,
+}: {
+  safeDb: SafeDb;
+  intent: BufferIntent;
+  telemetry: BufferIntentTelemetryStages;
+}): (() => Promise<void>) => {
+  let heartbeatPromise: Promise<void> | null = null;
+  let stopped = false;
+  const heartbeat = async (): Promise<void> => {
+    try {
+      const renewed = await safeDb(async (tx) => {
+        // audit: skip — live crash-recovery lease bookkeeping only.
+        await tx
+          .update(pendingUploads)
+          .set({ claimedAt: new Date() })
+          .where(
+            and(
+              eq(pendingUploads.id, intent.id),
+              eq(pendingUploads.status, "scanning"),
+              eq(pendingUploads.claimedByRequestId, intent.claimRequestId),
+            ),
+          );
+      });
+      if (Result.isError(renewed)) {
+        captureError(renewed.error, {
+          pendingUploadId: intent.id,
+          stage: telemetry.heartbeat,
+        });
+      }
+    } catch (error) {
+      captureError(error, {
+        pendingUploadId: intent.id,
+        stage: telemetry.heartbeatUnhandled,
+      });
+    } finally {
+      heartbeatPromise = null;
+    }
+  };
+  const triggerHeartbeat = (): void => {
+    if (heartbeatPromise !== null || stopped) {
+      return;
+    }
+    heartbeatPromise = heartbeat();
+  };
+  const timer = setInterval(triggerHeartbeat, BUFFER_INTENT_HEARTBEAT_MS);
+  timer.unref();
+
+  return async () => {
+    stopped = true;
+    clearInterval(timer);
+    await heartbeatPromise;
+  };
 };
 
 export const isRecoverableBufferIntent = (
@@ -342,7 +525,7 @@ export const reconcileBufferObjectCleanupIntents = async ({
         nextAttemptAt: sql`NOW() + LEAST(
           POWER(2, LEAST(
             ${bufferObjectCleanupIntents.attemptCount},
-            ${BUFFER_CLEANUP_RETRY_MAX_EXPONENT}
+            ${BUFFER_CLEANUP_RETRY_MAX_EXPONENT}::integer
           )) * interval '1 minute',
           interval '24 hours'
         )`,

--- a/apps/api/src/lib/buffer-intent-reconciliation.ts
+++ b/apps/api/src/lib/buffer-intent-reconciliation.ts
@@ -1,0 +1,213 @@
+import { Result } from "better-result";
+import { and, asc, eq, inArray, sql } from "drizzle-orm";
+
+import type { SafeDb } from "@/api/db/safe-db";
+import { pendingUploads } from "@/api/db/schema";
+import type { PendingUploadPurposeData } from "@/api/db/schema";
+import { captureError } from "@/api/lib/analytics/capture";
+import type { SafeId } from "@/api/lib/branded-types";
+import { createFileKey } from "@/api/lib/file-key";
+import { getS3 } from "@/api/lib/s3";
+
+export const BUFFER_INTENT_TTL_MS = 5 * 60 * 1000;
+export const BUFFER_INTENT_STALE_MS = 60 * 1000;
+export const BUFFER_INTENT_HEARTBEAT_MS = 15 * 1000;
+const BUFFER_INTENT_RECONCILE_LIMIT = 25;
+
+export type BufferIntentPurpose = "entity_create" | "entity_version";
+
+type BufferIntentScope = {
+  organizationId: SafeId<"organization">;
+  purpose: BufferIntentPurpose;
+  workspaceId: SafeId<"workspace">;
+};
+
+type RecoverableBufferIntent = PendingUploadPurposeData & {
+  reservedFileId: string;
+  type: BufferIntentPurpose;
+};
+
+export const isRecoverableBufferIntent = (
+  value: PendingUploadPurposeData,
+  purpose: BufferIntentPurpose,
+): value is RecoverableBufferIntent =>
+  value.type === purpose &&
+  "reservedFileId" in value &&
+  typeof value.reservedFileId === "string" &&
+  value.reservedFileId.length > 0;
+
+const rejectionReason = (purpose: BufferIntentPurpose): string =>
+  purpose === "entity_create"
+    ? "Reconciled abandoned server-generated entity bytes"
+    : "Reconciled abandoned server-generated version bytes";
+
+export const isBufferIntentPurpose = (
+  purpose: string,
+): purpose is BufferIntentPurpose =>
+  purpose === "entity_create" || purpose === "entity_version";
+
+const reconcileStaleBufferIntentBatch = async ({
+  safeDb,
+  scope,
+  limit,
+}: {
+  safeDb: SafeDb;
+  scope?: BufferIntentScope | undefined;
+  limit: number;
+}): Promise<number> => {
+  const reconcileClaimId = Bun.randomUUIDv7().slice(0, 64);
+  const timeoutSeconds = Math.floor(BUFFER_INTENT_STALE_MS / 1000);
+  const ownershipPredicate =
+    scope === undefined
+      ? sql`${pendingUploads.purpose} IN ('entity_create', 'entity_version')`
+      : sql`${pendingUploads.organizationId} = ${scope.organizationId}
+          AND ${pendingUploads.workspaceId} = ${scope.workspaceId}
+          AND ${pendingUploads.purpose} = ${scope.purpose}`;
+  const claimedResult = await safeDb(async (tx) => {
+    const staleRows = await tx
+      .select({
+        declaredMime: pendingUploads.declaredMime,
+        id: pendingUploads.id,
+        organizationId: pendingUploads.organizationId,
+        purpose: pendingUploads.purpose,
+        purposeData: pendingUploads.purposeData,
+        workspaceId: pendingUploads.workspaceId,
+      })
+      .from(pendingUploads)
+      .where(
+        sql`${ownershipPredicate}
+          AND ${pendingUploads.purposeData}->>'reservedFileId' IS NOT NULL
+          AND ${pendingUploads.status} = 'scanning'
+          AND ${pendingUploads.claimedAt} < NOW() - ${timeoutSeconds} * interval '1 second'`,
+      )
+      .orderBy(asc(pendingUploads.claimedAt), asc(pendingUploads.id))
+      .limit(limit)
+      .for("update", { skipLocked: true });
+
+    if (staleRows.length === 0) {
+      return [];
+    }
+
+    const ids = staleRows.map((row) => row.id);
+    // audit: skip — crash-recovery claim bookkeeping; no entity changes.
+    await tx
+      .update(pendingUploads)
+      .set({
+        claimedAt: new Date(),
+        claimedByRequestId: reconcileClaimId,
+      })
+      .where(
+        and(
+          inArray(pendingUploads.id, ids),
+          eq(pendingUploads.status, "scanning"),
+        ),
+      );
+    return staleRows;
+  });
+  if (Result.isError(claimedResult)) {
+    throw claimedResult.error;
+  }
+
+  const cleanupResults = await Promise.all(
+    claimedResult.value.map(async (row) => {
+      if (
+        !isBufferIntentPurpose(row.purpose) ||
+        !isRecoverableBufferIntent(row.purposeData, row.purpose)
+      ) {
+        return null;
+      }
+      const objectKey = createFileKey({
+        organizationId: row.organizationId,
+        workspaceId: row.workspaceId,
+        fileId: row.purposeData.reservedFileId,
+        mimeType: row.declaredMime,
+      });
+      const cleanup = await Result.tryPromise({
+        try: async () => await getS3().delete(objectKey),
+        catch: (cause) => cause,
+      });
+      if (Result.isError(cleanup)) {
+        captureError(cleanup.error, {
+          objectKey,
+          pendingUploadId: row.id,
+          stage: `buffer-${row.purpose}-intent-reconcile`,
+        });
+        return null;
+      }
+      return row.id;
+    }),
+  );
+  const cleanedIds = cleanupResults.filter(
+    (id): id is SafeId<"pendingUpload"> => id !== null,
+  );
+  if (cleanedIds.length === 0) {
+    return claimedResult.value.length;
+  }
+
+  const finalizedCleanup = await safeDb(async (tx) => {
+    // audit: skip — terminal crash-recovery bookkeeping after object cleanup.
+    await tx
+      .update(pendingUploads)
+      .set({
+        finalizedAt: new Date(),
+        rejectReason: sql<string>`CASE
+          WHEN ${pendingUploads.purpose} = 'entity_create'
+            THEN ${rejectionReason("entity_create")}
+          ELSE ${rejectionReason("entity_version")}
+        END`,
+        status: "rejected",
+      })
+      .where(
+        and(
+          inArray(pendingUploads.id, cleanedIds),
+          eq(pendingUploads.status, "scanning"),
+          eq(pendingUploads.claimedByRequestId, reconcileClaimId),
+        ),
+      );
+  });
+  if (Result.isError(finalizedCleanup)) {
+    captureError(finalizedCleanup.error, {
+      pendingUploadIds: cleanedIds.join(","),
+      stage: "buffer-intent-reconcile-finalize",
+    });
+  }
+  return claimedResult.value.length;
+};
+
+/**
+ * Claim and remove one bounded workspace batch of final-key objects whose
+ * durable intent proves that no entity/version transaction committed. The
+ * intent is finalized atomically with the reference, so a committed object
+ * can never satisfy this stale-scanning predicate.
+ */
+export const reconcileStaleBufferIntents = async ({
+  safeDb,
+  organizationId,
+  workspaceId,
+  purpose,
+}: {
+  safeDb: SafeDb;
+  organizationId: SafeId<"organization">;
+  workspaceId: SafeId<"workspace">;
+  purpose: BufferIntentPurpose;
+}): Promise<void> => {
+  await reconcileStaleBufferIntentBatch({
+    safeDb,
+    scope: { organizationId, workspaceId, purpose },
+    limit: BUFFER_INTENT_RECONCILE_LIMIT,
+  });
+};
+
+/**
+ * Fair global scheduler entrypoint. It claims the oldest stale rows directly,
+ * rather than rediscovering a fixed prefix of tenant scopes. Every attempted
+ * cleanup advances `claimedAt`, so a persistently failing object rotates behind
+ * older untouched rows and cannot starve the rest of the table.
+ */
+export const reconcileStaleBufferIntentsGlobally = async ({
+  safeDb,
+  limit,
+}: {
+  safeDb: SafeDb;
+  limit: number;
+}): Promise<number> => await reconcileStaleBufferIntentBatch({ safeDb, limit });

--- a/apps/api/src/lib/buffer-intent-reconciliation.ts
+++ b/apps/api/src/lib/buffer-intent-reconciliation.ts
@@ -1,8 +1,10 @@
 import { Result } from "better-result";
-import { and, asc, eq, inArray, sql } from "drizzle-orm";
+import { and, asc, eq, inArray, lte, sql } from "drizzle-orm";
 
+import type { Transaction } from "@/api/db/root";
 import type { SafeDb } from "@/api/db/safe-db";
 import {
+  bufferObjectCleanupIntents,
   pendingUploads,
   PENDING_UPLOAD_RECOVERABLE_STATUSES,
 } from "@/api/db/schema";
@@ -10,7 +12,7 @@ import type { PendingUploadPurposeData } from "@/api/db/schema";
 import { captureError } from "@/api/lib/analytics/capture";
 import type { SafeId } from "@/api/lib/branded-types";
 import { createFileKey } from "@/api/lib/file-key";
-import { getS3 } from "@/api/lib/s3";
+import { deleteS3ObjectWithSignal } from "@/api/lib/s3";
 import { withTimeout } from "@/api/lib/with-timeout";
 
 export const BUFFER_INTENT_TTL_MS = 5 * 60 * 1000;
@@ -18,6 +20,7 @@ export const BUFFER_INTENT_STALE_MS = 60 * 1000;
 export const BUFFER_INTENT_HEARTBEAT_MS = 15 * 1000;
 const BUFFER_INTENT_RECONCILE_LIMIT = 25;
 const BUFFER_INTENT_DELETE_TIMEOUT_MS = 30 * 1000;
+const BUFFER_CLEANUP_RETRY_MAX_EXPONENT = 14;
 
 export type BufferIntentPurpose = "entity_create" | "entity_version";
 
@@ -31,6 +34,16 @@ type RecoverableBufferIntent = PendingUploadPurposeData & {
   reservedFileId: string;
   type: BufferIntentPurpose;
 };
+
+type BufferIntentDeletionRow = Pick<
+  typeof pendingUploads.$inferSelect,
+  | "declaredMime"
+  | "id"
+  | "organizationId"
+  | "purpose"
+  | "purposeData"
+  | "workspaceId"
+>;
 
 export const isRecoverableBufferIntent = (
   value: PendingUploadPurposeData,
@@ -51,16 +64,68 @@ export const isBufferIntentPurpose = (
 ): purpose is BufferIntentPurpose =>
   purpose === "entity_create" || purpose === "entity_version";
 
+export const bufferIntentObjectKey = (
+  row: BufferIntentDeletionRow,
+): string | null => {
+  if (
+    !isBufferIntentPurpose(row.purpose) ||
+    !isRecoverableBufferIntent(row.purposeData, row.purpose)
+  ) {
+    return null;
+  }
+  return createFileKey({
+    organizationId: row.organizationId,
+    workspaceId: row.workspaceId,
+    fileId: row.purposeData.reservedFileId,
+    mimeType: row.declaredMime,
+  });
+};
+
+/**
+ * Transfer final-key cleanup ownership before lifecycle cascades remove the
+ * pending-upload row. The tombstone has no user/workspace foreign keys, so a
+ * dead writer can never erase the last durable recovery record.
+ */
+export const preserveBufferObjectCleanupIntents = async (
+  tx: Transaction,
+  rows: BufferIntentDeletionRow[],
+): Promise<void> => {
+  const values = rows.flatMap((row) => {
+    const objectKey = bufferIntentObjectKey(row);
+    if (objectKey === null) {
+      return [];
+    }
+    return [
+      {
+        id: row.id,
+        organizationId: row.organizationId,
+        workspaceId: row.workspaceId,
+        objectKey,
+      },
+    ];
+  });
+  if (values.length === 0) {
+    return;
+  }
+  // audit: skip — storage recovery ownership transfer only.
+  await tx
+    .insert(bufferObjectCleanupIntents)
+    .values(values)
+    .onConflictDoNothing();
+};
+
 const reconcileStaleBufferIntentBatch = async ({
   safeDb,
   scope,
   limit,
   signal,
+  deleteObject = deleteS3ObjectWithSignal,
 }: {
   safeDb: SafeDb;
   scope?: BufferIntentScope | undefined;
   limit: number;
   signal?: AbortSignal | undefined;
+  deleteObject?: typeof deleteS3ObjectWithSignal;
 }): Promise<number> => {
   signal?.throwIfAborted();
   const reconcileClaimId = Bun.randomUUIDv7().slice(0, 64);
@@ -135,11 +200,15 @@ const reconcileStaleBufferIntentBatch = async ({
       });
       const cleanup = await Result.tryPromise({
         try: async () =>
-          await withTimeout(async () => await getS3().delete(objectKey), {
-            label: "buffer-intent-reconciliation.delete",
-            signal,
-            timeoutMs: BUFFER_INTENT_DELETE_TIMEOUT_MS,
-          }),
+          await withTimeout(
+            async (operationSignal) =>
+              await deleteObject(objectKey, operationSignal),
+            {
+              label: "buffer-intent-reconciliation.delete",
+              signal,
+              timeoutMs: BUFFER_INTENT_DELETE_TIMEOUT_MS,
+            },
+          ),
         catch: (cause) => cause,
       });
       if (Result.isError(cleanup)) {
@@ -199,6 +268,92 @@ const reconcileStaleBufferIntentBatch = async ({
 };
 
 /**
+ * Retry lifecycle-transferred keys indefinitely with exponential backoff.
+ * Only the original writer may remove a tombstone after its PUT has settled
+ * and deletion of the exact key succeeds.
+ */
+export const reconcileBufferObjectCleanupIntents = async ({
+  safeDb,
+  limit,
+  signal,
+  deleteObject = deleteS3ObjectWithSignal,
+}: {
+  safeDb: SafeDb;
+  limit: number;
+  signal?: AbortSignal | undefined;
+  deleteObject?: typeof deleteS3ObjectWithSignal;
+}): Promise<number> => {
+  if (limit === 0) {
+    return 0;
+  }
+  signal?.throwIfAborted();
+  const claimedResult = await safeDb(async (tx) => {
+    const rows = await tx
+      .select({
+        attemptCount: bufferObjectCleanupIntents.attemptCount,
+        id: bufferObjectCleanupIntents.id,
+        objectKey: bufferObjectCleanupIntents.objectKey,
+      })
+      .from(bufferObjectCleanupIntents)
+      .where(lte(bufferObjectCleanupIntents.nextAttemptAt, new Date()))
+      .orderBy(
+        asc(bufferObjectCleanupIntents.nextAttemptAt),
+        asc(bufferObjectCleanupIntents.id),
+      )
+      .limit(limit)
+      .for("update", { skipLocked: true });
+    if (rows.length === 0) {
+      return [];
+    }
+    const ids = rows.map(({ id }) => id);
+    // audit: skip — bounded durable cleanup retry bookkeeping only.
+    await tx
+      .update(bufferObjectCleanupIntents)
+      .set({
+        attemptCount: sql`${bufferObjectCleanupIntents.attemptCount} + 1`,
+        nextAttemptAt: sql`NOW() + LEAST(
+          POWER(2, LEAST(
+            ${bufferObjectCleanupIntents.attemptCount},
+            ${BUFFER_CLEANUP_RETRY_MAX_EXPONENT}
+          )) * interval '1 minute',
+          interval '24 hours'
+        )`,
+      })
+      .where(inArray(bufferObjectCleanupIntents.id, ids));
+    return rows;
+  });
+  if (Result.isError(claimedResult)) {
+    throw claimedResult.error;
+  }
+
+  await Promise.all(
+    claimedResult.value.map(async (row) => {
+      const cleanup = await Result.tryPromise({
+        try: async () =>
+          await withTimeout(
+            async (operationSignal) =>
+              await deleteObject(row.objectKey, operationSignal),
+            {
+              label: "buffer-object-cleanup.delete",
+              signal,
+              timeoutMs: BUFFER_INTENT_DELETE_TIMEOUT_MS,
+            },
+          ),
+        catch: (cause) => cause,
+      });
+      if (Result.isError(cleanup) && !signal?.aborted) {
+        captureError(cleanup.error, {
+          pendingUploadId: row.id,
+          stage: "buffer-object-cleanup-reconcile",
+        });
+      }
+    }),
+  );
+  signal?.throwIfAborted();
+  return claimedResult.value.length;
+};
+
+/**
  * Claim and remove one bounded workspace batch of final-key objects whose
  * durable intent proves that no entity/version transaction committed. The
  * intent is finalized atomically with the reference, so a committed object
@@ -232,9 +387,28 @@ export const reconcileStaleBufferIntentsGlobally = async ({
   safeDb,
   limit,
   signal,
+  deleteObject = deleteS3ObjectWithSignal,
 }: {
   safeDb: SafeDb;
   limit: number;
   signal?: AbortSignal | undefined;
-}): Promise<number> =>
-  await reconcileStaleBufferIntentBatch({ safeDb, limit, signal });
+  deleteObject?: typeof deleteS3ObjectWithSignal;
+}): Promise<number> => {
+  const pendingLimit = Math.ceil(limit / 2);
+  const transferredLimit = Math.floor(limit / 2);
+  const [pendingCount, transferredCount] = await Promise.all([
+    reconcileStaleBufferIntentBatch({
+      safeDb,
+      limit: pendingLimit,
+      signal,
+      deleteObject,
+    }),
+    reconcileBufferObjectCleanupIntents({
+      safeDb,
+      limit: transferredLimit,
+      signal,
+      deleteObject,
+    }),
+  ]);
+  return pendingCount + transferredCount;
+};

--- a/apps/api/src/lib/buffer-intent-reconciliation.ts
+++ b/apps/api/src/lib/buffer-intent-reconciliation.ts
@@ -1,4 +1,4 @@
-import { Result } from "better-result";
+import { Result, TaggedError } from "better-result";
 import { and, asc, eq, inArray, lte, sql } from "drizzle-orm";
 
 import type { Transaction } from "@/api/db/root";
@@ -7,6 +7,7 @@ import {
   bufferObjectCleanupIntents,
   pendingUploads,
   PENDING_UPLOAD_RECOVERABLE_STATUSES,
+  workspaces,
 } from "@/api/db/schema";
 import type { PendingUploadPurposeData } from "@/api/db/schema";
 import { captureError } from "@/api/lib/analytics/capture";
@@ -44,6 +45,32 @@ type BufferIntentDeletionRow = Pick<
   | "purposeData"
   | "workspaceId"
 >;
+
+class BufferIntentWorkspaceUnavailableError extends TaggedError(
+  "BufferIntentWorkspaceUnavailableError",
+)<{ message: string }>() {}
+
+/**
+ * Share-lock the workspace while reserving an intent. Workspace deletion
+ * takes an update lock before sealing, so either the reservation commits in
+ * time for its cleanup snapshot or it observes the seal and cannot publish.
+ */
+export const lockActiveWorkspaceForBufferIntent = async (
+  tx: Transaction,
+  workspaceId: SafeId<"workspace">,
+): Promise<void> => {
+  const rows = await tx
+    .select({ status: workspaces.status })
+    .from(workspaces)
+    .where(eq(workspaces.id, workspaceId))
+    .limit(1)
+    .for("share");
+  if (rows.at(0)?.status !== "active") {
+    throw new BufferIntentWorkspaceUnavailableError({
+      message: "Workspace is not active",
+    });
+  }
+};
 
 export const isRecoverableBufferIntent = (
   value: PendingUploadPurposeData,

--- a/apps/api/src/lib/buffer-intent-reconciliation.ts
+++ b/apps/api/src/lib/buffer-intent-reconciliation.ts
@@ -2,7 +2,10 @@ import { Result } from "better-result";
 import { and, asc, eq, inArray, sql } from "drizzle-orm";
 
 import type { SafeDb } from "@/api/db/safe-db";
-import { pendingUploads } from "@/api/db/schema";
+import {
+  pendingUploads,
+  PENDING_UPLOAD_RECOVERABLE_STATUSES,
+} from "@/api/db/schema";
 import type { PendingUploadPurposeData } from "@/api/db/schema";
 import { captureError } from "@/api/lib/analytics/capture";
 import type { SafeId } from "@/api/lib/branded-types";
@@ -75,10 +78,12 @@ const reconcileStaleBufferIntentBatch = async ({
       })
       .from(pendingUploads)
       .where(
-        sql`${ownershipPredicate}
-          AND ${pendingUploads.purposeData}->>'reservedFileId' IS NOT NULL
-          AND ${pendingUploads.status} = 'scanning'
-          AND ${pendingUploads.claimedAt} < NOW() - ${timeoutSeconds} * interval '1 second'`,
+        and(
+          ownershipPredicate,
+          sql`${pendingUploads.purposeData}->>'reservedFileId' IS NOT NULL`,
+          inArray(pendingUploads.status, PENDING_UPLOAD_RECOVERABLE_STATUSES),
+          sql`${pendingUploads.claimedAt} < NOW() - ${timeoutSeconds} * interval '1 second'`,
+        ),
       )
       .orderBy(asc(pendingUploads.claimedAt), asc(pendingUploads.id))
       .limit(limit)
@@ -95,11 +100,12 @@ const reconcileStaleBufferIntentBatch = async ({
       .set({
         claimedAt: new Date(),
         claimedByRequestId: reconcileClaimId,
+        status: "scanning",
       })
       .where(
         and(
           inArray(pendingUploads.id, ids),
-          eq(pendingUploads.status, "scanning"),
+          inArray(pendingUploads.status, PENDING_UPLOAD_RECOVERABLE_STATUSES),
         ),
       );
     return staleRows;

--- a/apps/api/src/lib/flows/flow-run-worker.integration.test.ts
+++ b/apps/api/src/lib/flows/flow-run-worker.integration.test.ts
@@ -100,7 +100,9 @@ void mock.module("@/api/lib/tanstack-ai-generate", () => ({
 const s3WriteMock = mock(async () => {});
 const s3DeleteMock = mock(async () => {});
 void mock.module("@/api/lib/s3", () => ({
+  deleteS3ObjectWithSignal: s3DeleteMock,
   getS3: () => ({ write: s3WriteMock, delete: s3DeleteMock }),
+  putS3ObjectWithSignal: s3WriteMock,
 }));
 
 void mock.module("@/api/lib/search/process-extraction", () => ({

--- a/apps/api/src/lib/pending-upload-keys.ts
+++ b/apps/api/src/lib/pending-upload-keys.ts
@@ -1,0 +1,41 @@
+import type { pendingUploads } from "@/api/db/schema";
+import { createFileKey } from "@/api/handlers/files/utils";
+import { tmpUploadKeys } from "@/api/handlers/uploads/lib";
+import {
+  isBufferIntentPurpose,
+  isRecoverableBufferIntent,
+} from "@/api/lib/buffer-intent-reconciliation";
+
+type PendingUploadDeletionRow = Pick<
+  typeof pendingUploads.$inferSelect,
+  | "declaredMime"
+  | "id"
+  | "organizationId"
+  | "purpose"
+  | "purposeData"
+  | "workspaceId"
+>;
+
+export const pendingUploadS3KeysForDeletion = (
+  row: PendingUploadDeletionRow,
+): string[] => {
+  const keys = tmpUploadKeys({
+    organizationId: row.organizationId,
+    uploadId: row.id,
+    workspaceId: row.workspaceId,
+  });
+  if (
+    isBufferIntentPurpose(row.purpose) &&
+    isRecoverableBufferIntent(row.purposeData, row.purpose)
+  ) {
+    keys.push(
+      createFileKey({
+        fileId: row.purposeData.reservedFileId,
+        mimeType: row.declaredMime,
+        organizationId: row.organizationId,
+        workspaceId: row.workspaceId,
+      }),
+    );
+  }
+  return keys;
+};

--- a/apps/api/src/lib/pending-upload-keys.ts
+++ b/apps/api/src/lib/pending-upload-keys.ts
@@ -1,10 +1,6 @@
 import type { pendingUploads } from "@/api/db/schema";
-import { createFileKey } from "@/api/handlers/files/utils";
 import { tmpUploadKeys } from "@/api/handlers/uploads/lib";
-import {
-  isBufferIntentPurpose,
-  isRecoverableBufferIntent,
-} from "@/api/lib/buffer-intent-reconciliation";
+import { bufferIntentObjectKey } from "@/api/lib/buffer-intent-reconciliation";
 
 type PendingUploadDeletionRow = Pick<
   typeof pendingUploads.$inferSelect,
@@ -24,18 +20,9 @@ export const pendingUploadS3KeysForDeletion = (
     uploadId: row.id,
     workspaceId: row.workspaceId,
   });
-  if (
-    isBufferIntentPurpose(row.purpose) &&
-    isRecoverableBufferIntent(row.purposeData, row.purpose)
-  ) {
-    keys.push(
-      createFileKey({
-        fileId: row.purposeData.reservedFileId,
-        mimeType: row.declaredMime,
-        organizationId: row.organizationId,
-        workspaceId: row.workspaceId,
-      }),
-    );
+  const objectKey = bufferIntentObjectKey(row);
+  if (objectKey !== null) {
+    keys.push(objectKey);
   }
   return keys;
 };

--- a/apps/api/src/lib/s3.ts
+++ b/apps/api/src/lib/s3.ts
@@ -1,3 +1,7 @@
+import {
+  DeleteObjectCommand,
+  S3Client as AwsS3Client,
+} from "@aws-sdk/client-s3";
 import { S3Client } from "bun";
 
 import { envBase } from "@/api/env-base";
@@ -216,6 +220,33 @@ const buildS3Client = (
       : {}),
   });
 
+const isPathStyleRequired = (endpoint: string): boolean => {
+  try {
+    const host = new URL(endpoint).hostname.toLowerCase();
+    return !(host.includes("s3") && host.endsWith(".amazonaws.com"));
+  } catch {
+    return true;
+  }
+};
+
+const buildAbortableS3Client = (
+  creds?: OptionalS3Credentials | null,
+): AwsS3Client =>
+  new AwsS3Client({
+    region: envBase.S3_REGION,
+    endpoint: envBase.S3_ENDPOINT,
+    forcePathStyle: isPathStyleRequired(envBase.S3_ENDPOINT),
+    ...(creds
+      ? {
+          credentials: {
+            accessKeyId: creds.accessKeyId,
+            secretAccessKey: creds.secretAccessKey,
+            ...(creds.sessionToken ? { sessionToken: creds.sessionToken } : {}),
+          },
+        }
+      : {}),
+  });
+
 /** The legal-corpus bucket; falls back to the default bucket in dev. */
 const corpusBucket = (): string =>
   envBase.LEGAL_CORPUS_S3_BUCKET ?? envBase.S3_BUCKET;
@@ -333,7 +364,9 @@ export const resolveS3Credentials = async ({
  * processes to prevent STS credential expiry.
  */
 export const refreshS3 = async (): Promise<void> => {
-  _client = buildS3Client(envBase.S3_BUCKET, await resolveS3Credentials());
+  const credentials = await resolveS3Credentials();
+  _client = buildS3Client(envBase.S3_BUCKET, credentials);
+  _abortableClient = buildAbortableS3Client(credentials);
   _clientCreatedAt = Date.now();
 };
 
@@ -345,6 +378,7 @@ const CREDENTIAL_MAX_AGE_MS = 50 * 60 * 1000;
 // periodically — replaces the client with credentials resolved via
 // the configured provider.
 let _client: S3Client | null = null;
+let _abortableClient: AwsS3Client | null = null;
 let _clientCreatedAt = 0;
 
 /**
@@ -355,6 +389,18 @@ let _clientCreatedAt = 0;
 export const getS3 = (): S3Client => {
   _client ??= buildS3Client(envBase.S3_BUCKET, staticCredentialsFromEnv());
   return _client;
+};
+
+/** Delete one object while allowing the caller to cancel the HTTP request. */
+export const deleteS3ObjectWithSignal = async (
+  key: string,
+  signal: AbortSignal,
+): Promise<void> => {
+  _abortableClient ??= buildAbortableS3Client(staticCredentialsFromEnv());
+  await _abortableClient.send(
+    new DeleteObjectCommand({ Bucket: envBase.S3_BUCKET, Key: key }),
+    { abortSignal: signal },
+  );
 };
 
 /** True when credentials are older than 50 minutes (or not yet built). */

--- a/apps/api/src/lib/s3.ts
+++ b/apps/api/src/lib/s3.ts
@@ -1,5 +1,6 @@
 import {
   DeleteObjectCommand,
+  PutObjectCommand,
   S3Client as AwsS3Client,
 } from "@aws-sdk/client-s3";
 import { S3Client } from "bun";
@@ -399,6 +400,23 @@ export const deleteS3ObjectWithSignal = async (
   _abortableClient ??= buildAbortableS3Client(staticCredentialsFromEnv());
   await _abortableClient.send(
     new DeleteObjectCommand({ Bucket: envBase.S3_BUCKET, Key: key }),
+    { abortSignal: signal },
+  );
+};
+
+/** Publish one object while allowing the caller to cancel the HTTP request. */
+export const putS3ObjectWithSignal = async (
+  key: string,
+  bytes: Uint8Array,
+  signal: AbortSignal,
+): Promise<void> => {
+  _abortableClient ??= buildAbortableS3Client(staticCredentialsFromEnv());
+  await _abortableClient.send(
+    new PutObjectCommand({
+      Body: bytes,
+      Bucket: envBase.S3_BUCKET,
+      Key: key,
+    }),
     { abortSignal: signal },
   );
 };

--- a/apps/api/src/lib/s3.ts
+++ b/apps/api/src/lib/s3.ts
@@ -408,6 +408,7 @@ export const deleteS3ObjectWithSignal = async (
 export const putS3ObjectWithSignal = async (
   key: string,
   bytes: Uint8Array,
+  mimeType: string,
   signal: AbortSignal,
 ): Promise<void> => {
   _abortableClient ??= buildAbortableS3Client(staticCredentialsFromEnv());
@@ -415,6 +416,7 @@ export const putS3ObjectWithSignal = async (
     new PutObjectCommand({
       Body: bytes,
       Bucket: envBase.S3_BUCKET,
+      ContentType: mimeType,
       Key: key,
     }),
     { abortSignal: signal },

--- a/apps/api/src/lib/scheduler/jobs.ts
+++ b/apps/api/src/lib/scheduler/jobs.ts
@@ -4,6 +4,7 @@ import { rootDb } from "@/api/db/root";
 import type { SchedulerPayload, SchedulerSchedule } from "@/api/db/schema";
 import { schedulerJobs } from "@/api/db/schema";
 import { computeNextRunAt } from "@/api/lib/scheduler/schedule";
+import { RECONCILE_BUFFER_INTENTS_TASK } from "@/api/lib/scheduler/tasks/buffer-intent-reconciliation";
 import { BACKFILL_SK_DOCUMENTS_TASK } from "@/api/lib/scheduler/tasks/case-law-sk-documents";
 import { EXPIRE_DESKTOP_EDIT_SESSIONS_TASK } from "@/api/lib/scheduler/tasks/desktop-edit-session-expiry";
 import { INFO_SOUD_SYNC_TRACKED_CASES_TASK } from "@/api/lib/scheduler/tasks/infosoud";
@@ -109,6 +110,17 @@ const sameSchedule = (
 };
 
 export const ensureDefaultSchedulerJobs = async (): Promise<void> => {
+  await ensureSchedulerJob({
+    description:
+      "Reconcile abandoned server-generated entity and version objects",
+    id: "entityBuffers.reconcileIntents.minutely",
+    schedule: {
+      type: "interval",
+      everyMs: 60 * 1000,
+    },
+    task: RECONCILE_BUFFER_INTENTS_TASK,
+  });
+
   await ensureOneShotSchedulerJob({
     description:
       "Repair entity search timestamps and persisted preview passages",

--- a/apps/api/src/lib/scheduler/registry.ts
+++ b/apps/api/src/lib/scheduler/registry.ts
@@ -1,5 +1,9 @@
 import { createBullMqDispatchTask } from "@/api/lib/scheduler/bullmq";
 import {
+  RECONCILE_BUFFER_INTENTS_TASK,
+  reconcileBufferIntents,
+} from "@/api/lib/scheduler/tasks/buffer-intent-reconciliation";
+import {
   BACKFILL_SK_DOCUMENTS_TASK,
   backfillSkDocuments,
 } from "@/api/lib/scheduler/tasks/case-law-sk-documents";
@@ -36,6 +40,7 @@ export const createSchedulerTaskRegistry = (): SchedulerTaskRegistry =>
     [EXPIRE_DESKTOP_EDIT_SESSIONS_TASK, expireDesktopEditSessions],
     [FLOW_RUN_TASK, runScheduledFlow],
     [BACKFILL_SK_DOCUMENTS_TASK, backfillSkDocuments],
+    [RECONCILE_BUFFER_INTENTS_TASK, reconcileBufferIntents],
     [
       REPAIR_SEARCH_SEMANTIC_TIMESTAMPS_TASK,
       repairSearchSemanticTimestampsTask,

--- a/apps/api/src/lib/scheduler/tasks/buffer-intent-reconciliation.test.ts
+++ b/apps/api/src/lib/scheduler/tasks/buffer-intent-reconciliation.test.ts
@@ -25,17 +25,19 @@ beforeEach(() => {
 test("independently schedules one bounded fair global recovery batch", async () => {
   reconcileStaleBufferIntentsGloballyMock.mockResolvedValue(2);
   const info = mock();
+  const signal = new AbortController().signal;
 
   await reconcileBufferIntents(
     asTestRaw<SchedulerTaskContext>({
       logger: { info },
-      signal: new AbortController().signal,
+      signal,
     }),
   );
 
   expect(reconcileStaleBufferIntentsGloballyMock).toHaveBeenCalledWith({
     safeDb: expect.any(Function),
     limit: 50,
+    signal,
   });
   expect(info).toHaveBeenCalledWith("scheduler.buffer_intents_reconciled", {
     "bufferIntents.claimed": 2,

--- a/apps/api/src/lib/scheduler/tasks/buffer-intent-reconciliation.test.ts
+++ b/apps/api/src/lib/scheduler/tasks/buffer-intent-reconciliation.test.ts
@@ -1,0 +1,43 @@
+import { beforeEach, expect, mock, test } from "bun:test";
+
+import type { SchedulerTaskContext } from "@/api/lib/scheduler/types";
+import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
+
+const transactionMock = mock();
+const reconcileStaleBufferIntentsGloballyMock = mock(async () => 0);
+
+void mock.module("@/api/db/root", () => ({
+  rootDb: { transaction: transactionMock },
+}));
+void mock.module("@/api/lib/buffer-intent-reconciliation", () => ({
+  reconcileStaleBufferIntentsGlobally: reconcileStaleBufferIntentsGloballyMock,
+}));
+
+const { reconcileBufferIntents } =
+  await import("@/api/lib/scheduler/tasks/buffer-intent-reconciliation");
+
+beforeEach(() => {
+  transactionMock.mockReset();
+  reconcileStaleBufferIntentsGloballyMock.mockReset();
+  reconcileStaleBufferIntentsGloballyMock.mockResolvedValue(0);
+});
+
+test("independently schedules one bounded fair global recovery batch", async () => {
+  reconcileStaleBufferIntentsGloballyMock.mockResolvedValue(2);
+  const info = mock();
+
+  await reconcileBufferIntents(
+    asTestRaw<SchedulerTaskContext>({
+      logger: { info },
+      signal: new AbortController().signal,
+    }),
+  );
+
+  expect(reconcileStaleBufferIntentsGloballyMock).toHaveBeenCalledWith({
+    safeDb: expect.any(Function),
+    limit: 50,
+  });
+  expect(info).toHaveBeenCalledWith("scheduler.buffer_intents_reconciled", {
+    "bufferIntents.claimed": 2,
+  });
+});

--- a/apps/api/src/lib/scheduler/tasks/buffer-intent-reconciliation.ts
+++ b/apps/api/src/lib/scheduler/tasks/buffer-intent-reconciliation.ts
@@ -1,0 +1,37 @@
+import { Result, panic } from "better-result";
+
+import { rootDb } from "@/api/db/root";
+import type { SafeDb } from "@/api/db/safe-db";
+import { reconcileStaleBufferIntentsGlobally } from "@/api/lib/buffer-intent-reconciliation";
+import type { SchedulerTask } from "@/api/lib/scheduler/types";
+
+export const RECONCILE_BUFFER_INTENTS_TASK =
+  "entityBuffers.reconcileIntents" as const;
+
+const RECONCILE_INTENT_LIMIT = 50;
+
+const rootSafeDb: SafeDb = async (run) =>
+  await Result.tryPromise(async () => await rootDb.transaction(run));
+
+/**
+ * Independently drain abandoned server-generated file intents. Request-path
+ * reconciliation remains a fast recovery path, while this scheduled sweep
+ * guarantees that a workspace never needs another write to reclaim orphaned
+ * final-key S3 objects after a hard process death.
+ */
+export const reconcileBufferIntents: SchedulerTask = async ({
+  logger,
+  signal,
+}) => {
+  if (signal.aborted) {
+    panic("SchedulerAborted");
+  }
+  const claimedIntents = await reconcileStaleBufferIntentsGlobally({
+    safeDb: rootSafeDb,
+    limit: RECONCILE_INTENT_LIMIT,
+  });
+
+  logger.info("scheduler.buffer_intents_reconciled", {
+    "bufferIntents.claimed": claimedIntents,
+  });
+};

--- a/apps/api/src/lib/scheduler/tasks/buffer-intent-reconciliation.ts
+++ b/apps/api/src/lib/scheduler/tasks/buffer-intent-reconciliation.ts
@@ -28,6 +28,7 @@ export const reconcileBufferIntents: SchedulerTask = async ({
   const claimedIntents = await reconcileStaleBufferIntentsGlobally({
     safeDb: rootSafeDb,
     limit: RECONCILE_INTENT_LIMIT,
+    signal,
   });
 
   logger.info("scheduler.buffer_intents_reconciled", {

--- a/apps/api/src/lib/scheduler/tasks/buffer-intent-reconciliation.ts
+++ b/apps/api/src/lib/scheduler/tasks/buffer-intent-reconciliation.ts
@@ -14,10 +14,9 @@ const rootSafeDb: SafeDb = async (run) =>
   await Result.tryPromise(async () => await rootDb.transaction(run));
 
 /**
- * Independently drain abandoned server-generated file intents. Request-path
- * reconciliation remains a fast recovery path, while this scheduled sweep
- * guarantees that a workspace never needs another write to reclaim orphaned
- * final-key S3 objects after a hard process death.
+ * Independently drain abandoned server-generated file intents. This scheduled
+ * sweep guarantees that a workspace never needs another write to reclaim
+ * orphaned final-key S3 objects after a hard process death.
  */
 export const reconcileBufferIntents: SchedulerTask = async ({
   logger,

--- a/apps/api/src/lib/with-timeout.test.ts
+++ b/apps/api/src/lib/with-timeout.test.ts
@@ -80,4 +80,60 @@ describe("withTimeout", () => {
       process.off("unhandledRejection", onUnhandled);
     }
   });
+
+  test("stops waiting when its abort signal fires", async () => {
+    const controller = new AbortController();
+    let operationStarted: (() => void) | undefined;
+    const started = new Promise<void>((resolve) => {
+      operationStarted = resolve;
+    });
+    const pending = withTimeout(
+      async () => {
+        operationStarted?.();
+        return await new Promise<never>(() => {
+          // Intentionally pending: only the abort signal may settle the wrapper.
+        });
+      },
+      {
+        label: "aborted-operation",
+        signal: controller.signal,
+        timeoutMs: 60_000,
+      },
+    );
+
+    await started;
+    controller.abort();
+
+    const rejection: unknown = await pending.then(
+      () => null,
+      (error: unknown) => error,
+    );
+    expect(rejection).toMatchObject({
+      message: "The operation was aborted.",
+      name: "AbortError",
+    });
+  });
+
+  test("does not start an operation for an already-aborted signal", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    let started = false;
+
+    const rejection: unknown = await withTimeout(
+      async () => {
+        started = true;
+      },
+      {
+        label: "pre-aborted-operation",
+        signal: controller.signal,
+        timeoutMs: 60_000,
+      },
+    ).then(
+      () => null,
+      (error: unknown) => error,
+    );
+
+    expect(started).toBe(false);
+    expect(rejection).toMatchObject({ name: "AbortError" });
+  });
 });

--- a/apps/api/src/lib/with-timeout.test.ts
+++ b/apps/api/src/lib/with-timeout.test.ts
@@ -114,6 +114,73 @@ describe("withTimeout", () => {
     });
   });
 
+  test("passes deadline cancellation to the underlying operation", async () => {
+    let operationSignal: AbortSignal | undefined;
+
+    const rejection: unknown = await withTimeout(
+      async (signal) => {
+        operationSignal = signal;
+        return await new Promise<never>((_resolve, reject) => {
+          signal.addEventListener(
+            "abort",
+            () =>
+              reject(
+                signal.reason instanceof Error
+                  ? signal.reason
+                  : new DOMException("Aborted", "AbortError"),
+              ),
+            { once: true },
+          );
+        });
+      },
+      { label: "abortable-timeout", timeoutMs: 5 },
+    ).then(
+      () => null,
+      (error: unknown) => error,
+    );
+
+    expect(rejection).toBeInstanceOf(TimeoutError);
+    expect(operationSignal?.aborted).toBe(true);
+    expect(operationSignal?.reason).toBe(rejection);
+  });
+
+  test("passes caller cancellation to the underlying operation", async () => {
+    const controller = new AbortController();
+    let operationSignal: AbortSignal | undefined;
+    const pending = withTimeout(
+      async (signal) => {
+        operationSignal = signal;
+        return await new Promise<never>((_resolve, reject) => {
+          signal.addEventListener(
+            "abort",
+            () =>
+              reject(
+                signal.reason instanceof Error
+                  ? signal.reason
+                  : new DOMException("Aborted", "AbortError"),
+              ),
+            { once: true },
+          );
+        });
+      },
+      {
+        label: "abortable-operation",
+        signal: controller.signal,
+        timeoutMs: 60_000,
+      },
+    );
+
+    await Promise.resolve();
+    controller.abort();
+    const rejection: unknown = await pending.then(
+      () => null,
+      (error: unknown) => error,
+    );
+
+    expect(rejection).toMatchObject({ name: "AbortError" });
+    expect(operationSignal?.aborted).toBe(true);
+  });
+
   test("does not start an operation for an already-aborted signal", async () => {
     const controller = new AbortController();
     controller.abort();

--- a/apps/api/src/lib/with-timeout.ts
+++ b/apps/api/src/lib/with-timeout.ts
@@ -14,33 +14,32 @@ type WithTimeoutOptions = {
  * The motivating case is a DB read on a pooled connection that the
  * server reaped silently (no RST): Bun's SQL client never settles the
  * query promise, so the await hangs indefinitely. There is no portable
- * way to cancel the underlying query, so the operation is abandoned,
- * not aborted — callers must be safe to retry, because the work may
- * still complete server-side.
+ * way to cancel every underlying API, so callers must still be safe to retry.
+ * Operations that support cancellation should consume the provided signal;
+ * other work may still complete server-side after the wrapper rejects.
  */
 export const withTimeout = async <T>(
-  operation: () => Promise<T>,
+  operation: (signal: AbortSignal) => Promise<T>,
   { label, signal, timeoutMs }: WithTimeoutOptions,
 ): Promise<T> => {
   signal?.throwIfAborted();
-  if (timeoutMs === 0 && signal === undefined) {
-    return await operation();
-  }
-
-  const op = operation();
+  const operationController = new AbortController();
+  const op = Promise.resolve().then(
+    async () => await operation(operationController.signal),
+  );
   let timer: ReturnType<typeof setTimeout> | undefined;
   const deadlines: Promise<never>[] = [];
   if (timeoutMs > 0) {
     deadlines.push(
       new Promise<never>((_resolve, reject) => {
         timer = setTimeout(() => {
-          reject(
-            new TimeoutError({
-              message: `${label} exceeded ${timeoutMs}ms`,
-              label,
-              timeoutMs,
-            }),
-          );
+          const error = new TimeoutError({
+            message: `${label} exceeded ${timeoutMs}ms`,
+            label,
+            timeoutMs,
+          });
+          operationController.abort(error);
+          reject(error);
         }, timeoutMs);
       }),
     );
@@ -50,12 +49,14 @@ export const withTimeout = async <T>(
   if (signal !== undefined) {
     deadlines.push(
       new Promise<never>((_resolve, reject) => {
-        abort = () =>
-          reject(
+        abort = () => {
+          const reason =
             signal.reason instanceof Error
               ? signal.reason
-              : new DOMException("The operation was aborted.", "AbortError"),
-          );
+              : new DOMException("The operation was aborted.", "AbortError");
+          operationController.abort(reason);
+          reject(reason);
+        };
         signal.addEventListener("abort", abort, { once: true });
         if (signal.aborted) {
           abort();
@@ -71,8 +72,9 @@ export const withTimeout = async <T>(
     if (signal !== undefined && abort !== undefined) {
       signal.removeEventListener("abort", abort);
     }
-    // If a deadline won the race, `op` is still pending; swallow its eventual
-    // settlement so a late rejection is not reported as unhandled.
+    // Cancellation is cooperative: operations that use the provided signal
+    // stop their underlying work. Keep swallowing late settlement for APIs
+    // that cannot cancel so their rejection is never reported as unhandled.
     op.catch(() => undefined);
   }
 };

--- a/apps/api/src/lib/with-timeout.ts
+++ b/apps/api/src/lib/with-timeout.ts
@@ -2,12 +2,13 @@ import { TimeoutError } from "@/api/lib/errors/tagged-errors";
 
 type WithTimeoutOptions = {
   label: string;
+  signal?: AbortSignal | undefined;
   timeoutMs: number;
 };
 
 /**
- * Races an async operation against a wall-clock deadline. If the
- * deadline passes first, rejects with a TimeoutError instead of
+ * Races an async operation against a wall-clock deadline and optional abort
+ * signal. If the deadline passes first, rejects with a TimeoutError instead of
  * waiting forever.
  *
  * The motivating case is a DB read on a pooled connection that the
@@ -19,33 +20,59 @@ type WithTimeoutOptions = {
  */
 export const withTimeout = async <T>(
   operation: () => Promise<T>,
-  { label, timeoutMs }: WithTimeoutOptions,
+  { label, signal, timeoutMs }: WithTimeoutOptions,
 ): Promise<T> => {
-  if (timeoutMs === 0) {
+  signal?.throwIfAborted();
+  if (timeoutMs === 0 && signal === undefined) {
     return await operation();
   }
 
   const op = operation();
   let timer: ReturnType<typeof setTimeout> | undefined;
-  const timeout = new Promise<never>((_resolve, reject) => {
-    timer = setTimeout(() => {
-      reject(
-        new TimeoutError({
-          message: `${label} exceeded ${timeoutMs}ms`,
-          label,
-          timeoutMs,
-        }),
-      );
-    }, timeoutMs);
-  });
+  const deadlines: Promise<never>[] = [];
+  if (timeoutMs > 0) {
+    deadlines.push(
+      new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(() => {
+          reject(
+            new TimeoutError({
+              message: `${label} exceeded ${timeoutMs}ms`,
+              label,
+              timeoutMs,
+            }),
+          );
+        }, timeoutMs);
+      }),
+    );
+  }
+
+  let abort: (() => void) | undefined;
+  if (signal !== undefined) {
+    deadlines.push(
+      new Promise<never>((_resolve, reject) => {
+        abort = () =>
+          reject(
+            signal.reason instanceof Error
+              ? signal.reason
+              : new DOMException("The operation was aborted.", "AbortError"),
+          );
+        signal.addEventListener("abort", abort, { once: true });
+        if (signal.aborted) {
+          abort();
+        }
+      }),
+    );
+  }
 
   try {
-    return await Promise.race([op, timeout]);
+    return await Promise.race([op, ...deadlines]);
   } finally {
     clearTimeout(timer);
-    // If the timeout won the race, `op` is still pending; swallow its
-    // eventual settlement so a late rejection is not reported as an
-    // unhandled rejection.
+    if (signal !== undefined && abort !== undefined) {
+      signal.removeEventListener("abort", abort);
+    }
+    // If a deadline won the race, `op` is still pending; swallow its eventual
+    // settlement so a late rejection is not reported as unhandled.
     op.catch(() => undefined);
   }
 };

--- a/apps/api/src/tests/security/rls-coverage.test.ts
+++ b/apps/api/src/tests/security/rls-coverage.test.ts
@@ -91,6 +91,7 @@ describe("policy coverage", () => {
   ]);
   const APPEND_ONLY = new Set(["audit_logs"]);
   const INSERT_ONLY = new Set(["entity_deletion_cleanup_requests"]);
+  const INSERT_DELETE_ONLY = new Set(["buffer_object_cleanup_intents"]);
   const GLOBAL_CASE_LAW_TABLES = [
     "case_law_citations",
     "case_law_court_weights",
@@ -202,6 +203,8 @@ describe("policy coverage", () => {
       expect(cmds).toContain("a"); // INSERT
       if (INSERT_ONLY.has(table)) {
         expect(cmds).toEqual(new Set(["a"]));
+      } else if (INSERT_DELETE_ONLY.has(table)) {
+        expect(cmds).toEqual(new Set(["a", "d"]));
       } else {
         expect(cmds).toContain("r"); // SELECT
         if (!APPEND_ONLY.has(table)) {

--- a/apps/api/src/tests/security/rls-table-grants.test.ts
+++ b/apps/api/src/tests/security/rls-table-grants.test.ts
@@ -55,9 +55,11 @@ const POST_BOOTSTRAP_SELECT_ONLY_TABLES = new Set([
   "case_law_coverage_slices",
 ]);
 
-// Internal outbox tables that scoped requests may append to, while privileged
-// workers remain the only readers and state-transition writers.
-const POST_BOOTSTRAP_INSERT_ONLY_TABLES = new Set([
+// Internal handoff tables whose scoped role needs INSERT but not table-wide
+// SELECT. Privileged workers own reads; a table may additionally grant a
+// narrowly scoped transition such as deleting an exact cleanup tombstone.
+const POST_BOOTSTRAP_SCOPED_HANDOFF_TABLES = new Set([
+  "buffer_object_cleanup_intents",
   "entity_deletion_cleanup_requests",
 ]);
 
@@ -132,7 +134,7 @@ const grantsRequiredPrivileges = ({
   if (POST_BOOTSTRAP_SELECT_ONLY_TABLES.has(table)) {
     return privileges.has("select");
   }
-  if (POST_BOOTSTRAP_INSERT_ONLY_TABLES.has(table)) {
+  if (POST_BOOTSTRAP_SCOPED_HANDOFF_TABLES.has(table)) {
     return privileges.has("insert");
   }
   return grantsTableDml;


### PR DESCRIPTION
Unifies server-generated document and document-version writes behind shared persistence paths.

- Reserves durable upload intents before object publication.
- Preserves bytes across ambiguous commits and repairs abandoned objects with a bounded scheduler.
- Centralizes locking, version numbering, field cloning, and audit behavior.
- Hardens workspace and account deletion against active persistence races.

This is the base of the stacked template-persistence PR: #1501.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added reliable document and file-version creation with upload recovery and cleanup.
  * Added automatic reconciliation and retrying of abandoned uploads.
  * Added document size-limit validation with clear error responses.
  * Added workspace updates after successful document creation.
* **Bug Fixes**
  * Improved cleanup of temporary files after failed or interrupted uploads.
  * Standardised file-version writing across upload methods.
  * Added cancellation and timeout handling for storage operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->