### PR TITLE
feat(case-law): key decisions on the publisher's document id

### DIFF
--- a/apps/api/drizzle/20260731130000_decision_source_document_id/migration.sql
+++ b/apps/api/drizzle/20260731130000_decision_source_document_id/migration.sql
@@ -1,0 +1,51 @@
+SET lock_timeout = '1s';--> statement-breakpoint
+SET statement_timeout = '5s';--> statement-breakpoint
+
+-- What identifies a decision is the id its publisher gives it. A case
+-- number cannot: courts number dockets per court, so a source covering
+-- many courts issues the same number many times over, and keying on it
+-- makes two unrelated decisions the same row.
+--
+-- Identity becomes two halves that together cover every row exactly once:
+-- the publisher's id where the source states one, the case number where it
+-- does not (sound for a source holding a single court).
+--
+-- Values are not backfilled here. The table holds millions of rows, which
+-- is more than one in-transaction UPDATE can finish within
+-- statement_timeout; src/scripts/backfill-source-document-ids.ts fills them
+-- in batches. Until a row is filled it stays NULL and keeps the case-number
+-- key, so the pair of partial indexes is valid at every point in between.
+ALTER TABLE "case_law_decisions"
+  ADD COLUMN IF NOT EXISTS "source_document_id" varchar(256);--> statement-breakpoint
+
+-- Both indexes are built CONCURRENTLY so neither write-locks a table this
+-- size. Drizzle wraps pending migrations in one transaction and CREATE
+-- INDEX CONCURRENTLY cannot run inside one, so COMMIT here and reopen with
+-- BEGIN for the migration bookkeeping row (same split as
+-- 20260603120000_case_law_public_slugs).
+--
+-- An interrupted CONCURRENTLY build leaves an INVALID index under the same
+-- name, and a `CREATE ... IF NOT EXISTS` retry would skip it and record the
+-- migration as applied with uniqueness silently unenforced. Drop first
+-- (no-op on a clean run), then build without IF NOT EXISTS.
+--
+-- Order matters: the replacement for the old key is built before the old
+-- one is dropped, so uniqueness is enforced continuously rather than
+-- leaving a window in which duplicates could land.
+COMMIT;
+--> statement-breakpoint
+DROP INDEX CONCURRENTLY IF EXISTS "case_law_decisions_source_document_idx";
+--> statement-breakpoint
+CREATE UNIQUE INDEX CONCURRENTLY "case_law_decisions_source_document_idx"
+  ON "case_law_decisions" ("source_id","source_document_id")
+  WHERE "source_document_id" IS NOT NULL;
+--> statement-breakpoint
+DROP INDEX CONCURRENTLY IF EXISTS "case_law_decisions_source_case_lang_null_idx";
+--> statement-breakpoint
+CREATE UNIQUE INDEX CONCURRENTLY "case_law_decisions_source_case_lang_null_idx"
+  ON "case_law_decisions" ("source_id","case_number","language")
+  WHERE "source_document_id" IS NULL;
+--> statement-breakpoint
+DROP INDEX CONCURRENTLY IF EXISTS "case_law_decisions_source_case_lang_idx";
+--> statement-breakpoint
+BEGIN;

--- a/apps/api/drizzle/20260731130000_decision_source_document_id/migration.sql
+++ b/apps/api/drizzle/20260731130000_decision_source_document_id/migration.sql
@@ -1,3 +1,11 @@
+-- stella-migration-safety: reviewed destructive-change - drops indexes only, no
+-- table or column data. Two of the three drops are the idempotency guard the
+-- CONCURRENTLY pattern requires (an interrupted build leaves an INVALID index
+-- that a later CREATE IF NOT EXISTS would skip), so they are no-ops on a clean
+-- run. The third drops the old case-number unique index only after its partial
+-- replacement has been built, so uniqueness is enforced throughout. Rollback is
+-- to recreate that index CONCURRENTLY over the same columns without the
+-- predicate; no data is lost either way.
 SET lock_timeout = '1s';--> statement-breakpoint
 SET statement_timeout = '5s';--> statement-breakpoint
 

--- a/apps/api/drizzle/20260731130000_decision_source_document_id/migration.sql
+++ b/apps/api/drizzle/20260731130000_decision_source_document_id/migration.sql
@@ -40,6 +40,7 @@ ALTER TABLE "case_law_decisions"
 -- Order matters: the replacement for the old key is built before the old
 -- one is dropped, so uniqueness is enforced continuously rather than
 -- leaving a window in which duplicates could land.
+-- squawk-ignore transaction-nesting -- deliberate: CREATE INDEX CONCURRENTLY cannot run inside the migrator's transaction, so it is closed here and reopened below
 COMMIT;
 --> statement-breakpoint
 DROP INDEX CONCURRENTLY IF EXISTS "case_law_decisions_source_document_idx";
@@ -59,4 +60,5 @@ CREATE UNIQUE INDEX CONCURRENTLY "case_law_decisions_source_case_lang_null_idx"
 DROP INDEX CONCURRENTLY IF EXISTS "case_law_decisions_source_case_lang_idx";
 --> statement-breakpoint
 -- squawk-ignore ban-uncommitted-transaction -- reopens the migrator transaction the COMMIT above closed; Drizzle commits it after writing its bookkeeping row
+-- squawk-ignore transaction-nesting -- same split; the transaction this reopens is the migrator's own
 BEGIN;

--- a/apps/api/drizzle/20260731130000_decision_source_document_id/migration.sql
+++ b/apps/api/drizzle/20260731130000_decision_source_document_id/migration.sql
@@ -59,6 +59,5 @@ CREATE UNIQUE INDEX CONCURRENTLY "case_law_decisions_source_case_lang_null_idx"
 --> statement-breakpoint
 DROP INDEX CONCURRENTLY IF EXISTS "case_law_decisions_source_case_lang_idx";
 --> statement-breakpoint
--- squawk-ignore ban-uncommitted-transaction -- reopens the migrator transaction the COMMIT above closed; Drizzle commits it after writing its bookkeeping row
--- squawk-ignore transaction-nesting -- same split; the transaction this reopens is the migrator's own
+-- squawk-ignore ban-uncommitted-transaction, transaction-nesting -- reopens the migrator's own transaction, closed above so the concurrent builds could run outside it; Drizzle commits it after writing its bookkeeping row
 BEGIN;

--- a/apps/api/drizzle/20260731130000_decision_source_document_id/migration.sql
+++ b/apps/api/drizzle/20260731130000_decision_source_document_id/migration.sql
@@ -44,16 +44,19 @@ COMMIT;
 --> statement-breakpoint
 DROP INDEX CONCURRENTLY IF EXISTS "case_law_decisions_source_document_idx";
 --> statement-breakpoint
+-- squawk-ignore prefer-robust-stmts -- IF NOT EXISTS would skip an INVALID index left by an interrupted CONCURRENTLY build; the preceding DROP is what makes a retry robust
 CREATE UNIQUE INDEX CONCURRENTLY "case_law_decisions_source_document_idx"
   ON "case_law_decisions" ("source_id","source_document_id")
   WHERE "source_document_id" IS NOT NULL;
 --> statement-breakpoint
 DROP INDEX CONCURRENTLY IF EXISTS "case_law_decisions_source_case_lang_null_idx";
 --> statement-breakpoint
+-- squawk-ignore prefer-robust-stmts -- see the note on the index above
 CREATE UNIQUE INDEX CONCURRENTLY "case_law_decisions_source_case_lang_null_idx"
   ON "case_law_decisions" ("source_id","case_number","language")
   WHERE "source_document_id" IS NULL;
 --> statement-breakpoint
 DROP INDEX CONCURRENTLY IF EXISTS "case_law_decisions_source_case_lang_idx";
 --> statement-breakpoint
+-- squawk-ignore ban-uncommitted-transaction -- reopens the migrator transaction the COMMIT above closed; Drizzle commits it after writing its bookkeeping row
 BEGIN;

--- a/apps/api/src/db/schema/case-law.ts
+++ b/apps/api/src/db/schema/case-law.ts
@@ -101,6 +101,20 @@ export const caseLawDecisions = p.pgTable(
     sourceUrl: p.varchar("source_url", { length: 2048 }),
     documentUrl: p.varchar("document_url", { length: 2048 }),
     /**
+     * The publisher's own identifier for this document, as the source states
+     * it. This is what identifies a decision.
+     *
+     * A case number cannot: courts number their dockets per court, so one
+     * source covering many courts issues the same number many times over
+     * (`0T/42/2019` exists at most Slovak district courts). Keying on it
+     * makes two unrelated decisions the same row. The publisher's id is
+     * unique across the whole source by construction.
+     *
+     * Null only for sources that expose no such id; those keep the older
+     * case-number key, which is sound for a source holding one court.
+     */
+    sourceDocumentId: p.varchar("source_document_id", { length: 256 }),
+    /**
      * Bookkeeping for sources that ingest metadata first and fetch the
      * document later (see `ingestion/sk-document-backfill.ts`).
      * `documentFetchRequestedAt` is the first read that asked for the
@@ -165,9 +179,18 @@ export const caseLawDecisions = p.pgTable(
       .$onUpdate(() => new Date()),
   },
   (t) => [
+    // Identity, in two halves that together cover every row exactly once.
+    // Where the publisher states an id, that is the key. Where it does not,
+    // the case number still serves, because such a source holds one court
+    // and its numbering is unique within it.
     p
-      .uniqueIndex("case_law_decisions_source_case_lang_idx")
-      .on(t.sourceId, t.caseNumber, t.language),
+      .uniqueIndex("case_law_decisions_source_document_idx")
+      .on(t.sourceId, t.sourceDocumentId)
+      .where(isNotNull(t.sourceDocumentId)),
+    p
+      .uniqueIndex("case_law_decisions_source_case_lang_null_idx")
+      .on(t.sourceId, t.caseNumber, t.language)
+      .where(isNull(t.sourceDocumentId)),
     p
       .uniqueIndex("case_law_decisions_slug_uidx")
       .on(t.slug)

--- a/apps/api/src/handlers/case-law/CLAUDE.md
+++ b/apps/api/src/handlers/case-law/CLAUDE.md
@@ -309,6 +309,27 @@ a reconciliation pass that reads the coverage ledger (rule 15)
 and re-crawls the slices that are short. Do not rely on "it will
 come around again", because it will not.
 
+### 17. Identity is the publisher's id, never the case number
+
+Courts number their dockets per court, so a source covering many
+courts issues the same number over and over: `0T/42/2019` exists at
+most Slovak district courts, `II AKa 198/23` at several Polish
+appellate courts. A key built from the case number makes two
+unrelated decisions the same row, and the second one stored silently
+replaces the first.
+
+So set `sourceDocumentId` on every `IngestionResult` whose source
+states an id, even where the number looks unique today. It is usually
+there: a `guid` in the list item, or the last segment of the detail
+URL. Uniqueness is enforced on `(source_id, source_document_id)`;
+sources with no such id fall back to the case number, which is sound
+only because they hold a single court.
+
+Watch for a number that embeds something other than the case: a
+trailing sheet number (`-28`, číslo listu) belongs in its own optional
+field, not in the docket, or one case fragments into a row per sheet
+and no citation ever matches it.
+
 ## DocumentAst Conventions
 
 ```typescript

--- a/apps/api/src/handlers/case-law/ingestion/adapter.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapter.ts
@@ -20,6 +20,15 @@ export const EMPTY_AST: EmptyAst = {};
 /** Result of parsing a single court decision from a source. */
 export type IngestionResult = {
   caseNumber: string;
+  /**
+   * The publisher's own identifier for this document. Supply it whenever the
+   * source has one: it is what makes a decision identifiable. A case number
+   * does not, because courts number dockets per court and one source often
+   * covers many, so the same number recurs across unrelated decisions.
+   *
+   * Omit it only where the source publishes no such id.
+   */
+  sourceDocumentId?: string | undefined;
   ecli?: string | undefined;
   court: string;
   country: string;

--- a/apps/api/src/handlers/case-law/ingestion/adapters/cz-regional.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/cz-regional.ts
@@ -392,8 +392,7 @@ const documentIdFromLink = (link: string | undefined): string | undefined => {
   if (link === undefined) {
     return undefined;
   }
-  const segment = link.split("?").at(0)?.split("/").filter(Boolean).at(-1);
-  return segment === undefined || segment.length === 0 ? undefined : segment;
+  return /\/(?<id>[^/?#]+)\/*(?:[?#]|$)/u.exec(link)?.groups?.["id"];
 };
 
 const parseItem = (item: CzRegionalApiItem): IngestionResult | null => {

--- a/apps/api/src/handlers/case-law/ingestion/adapters/cz-regional.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/cz-regional.ts
@@ -382,6 +382,20 @@ const fetchFinaldoc = async (
   }
 };
 
+/**
+ * The publisher's document id, which this source states only as the last
+ * segment of the item's link (`/api/finaldoc/<id>`). Returns undefined for a
+ * link that carries no segment, so identity falls back to the case number
+ * rather than keying every such row on the same empty string.
+ */
+const documentIdFromLink = (link: string | undefined): string | undefined => {
+  if (link === undefined) {
+    return undefined;
+  }
+  const segment = link.split("?").at(0)?.split("/").filter(Boolean).at(-1);
+  return segment === undefined || segment.length === 0 ? undefined : segment;
+};
+
 const parseItem = (item: CzRegionalApiItem): IngestionResult | null => {
   if (!item.jednaciCislo || !item.soud) {
     return null;
@@ -396,6 +410,7 @@ const parseItem = (item: CzRegionalApiItem): IngestionResult | null => {
     country: "CZE",
     language: "cs",
     decisionDate: toOptionalValue(item.datumVydani),
+    sourceDocumentId: documentIdFromLink(toOptionalValue(item.odkaz)),
     sourceUrl: sanitizeUrl(toOptionalValue(item.odkaz) ?? ""),
     documentUrl: sanitizeUrl(toOptionalValue(item.odkaz) ?? ""),
     metadata: {

--- a/apps/api/src/handlers/case-law/ingestion/adapters/pl-courts.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/pl-courts.ts
@@ -618,6 +618,7 @@ const parseItemWithDetail = async (
     decisionDate,
     decisionType,
     fulltext,
+    sourceDocumentId: String(item.id ?? dumpItem.id),
     sourceUrl: publicSourceUrl(item.id ?? dumpItem.id),
     documentUrl,
     publisherCitedCases,

--- a/apps/api/src/handlers/case-law/ingestion/adapters/sk-courts.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/sk-courts.ts
@@ -265,6 +265,7 @@ const parseItemWithDetail = async (
     language: "sk",
     decisionDate,
     decisionType,
+    sourceDocumentId: toOptionalValue(item.guid),
     sourceUrl: item.guid
       ? sanitizeUrl(sourceUrlForDecision(item.guid, detail?.dokument?.url))
       : undefined,

--- a/apps/api/src/handlers/case-law/ingestion/pipeline-identity.db.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/pipeline-identity.db.test.ts
@@ -9,6 +9,7 @@ import { EMPTY_AST } from "@/api/handlers/case-law/ingestion/adapter";
 import type { IngestionResult } from "@/api/handlers/case-law/ingestion/adapter";
 import { processDecision } from "@/api/handlers/case-law/ingestion/pipeline";
 import type { SafeId } from "@/api/lib/branded-types";
+import { isRecord } from "@/api/lib/type-guards";
 
 const databaseUrl = process.env["DATABASE_URL"];
 const runPostgresTests = process.env["STELLA_RUN_POSTGRES_TESTS"] === "true";
@@ -59,7 +60,7 @@ if (!databaseUrl || !runPostgresTests) {
         ORDER BY court
       `);
       const list = Array.isArray(rows) ? rows : [];
-      return list.map((row) => String((row as { court: unknown }).court));
+      return list.map((row) => (isRecord(row) ? String(row["court"]) : ""));
     };
 
     beforeAll(async () => {

--- a/apps/api/src/handlers/case-law/ingestion/pipeline-identity.db.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/pipeline-identity.db.test.ts
@@ -1,0 +1,111 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { eq, sql } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/bun-sql";
+
+import { authRelationsPart } from "@/api/db/auth-schema";
+import type { ScopedDb } from "@/api/db/safe-db";
+import { caseLawSources, relations } from "@/api/db/schema";
+import { EMPTY_AST } from "@/api/handlers/case-law/ingestion/adapter";
+import type { IngestionResult } from "@/api/handlers/case-law/ingestion/adapter";
+import { processDecision } from "@/api/handlers/case-law/ingestion/pipeline";
+import type { SafeId } from "@/api/lib/branded-types";
+
+const databaseUrl = process.env["DATABASE_URL"];
+const runPostgresTests = process.env["STELLA_RUN_POSTGRES_TESTS"] === "true";
+
+/**
+ * Courts number their dockets per court, so one source covering many courts
+ * issues the same number repeatedly. These decisions are unrelated and must
+ * both survive; identity comes from the publisher's id, not the number.
+ */
+const decisionAt = (
+  court: string,
+  sourceDocumentId: string | undefined,
+): IngestionResult => ({
+  caseNumber: "0T/42/2019",
+  sourceDocumentId,
+  court,
+  country: "SVK",
+  language: "sk",
+  decisionDate: "2019-05-14",
+  decisionType: "rozsudok",
+  fulltext: `Rozsudok ${court}`,
+  metadata: { court },
+  rawHash: `hash-${court}`,
+  documentAst: EMPTY_AST,
+});
+
+if (!databaseUrl || !runPostgresTests) {
+  describe.skip("case-law decision identity", () => {
+    test("requires STELLA_RUN_POSTGRES_TESTS=true and DATABASE_URL", () => {
+      expect(runPostgresTests && Boolean(databaseUrl)).toBe(false);
+    });
+  });
+} else {
+  describe("case-law decision identity", () => {
+    const adapterKey = `identity-${Bun.randomUUIDv7()}`;
+    const db = drizzle(databaseUrl, {
+      relations: { ...relations, ...authRelationsPart },
+    });
+    const scopedDb: ScopedDb = async (callback) =>
+      // oxlint-disable-next-line node/callback-return -- arrow body already returns the callback result
+      await db.transaction(async (tx) => await callback(tx));
+    let sourceId: SafeId<"caseLawSource">;
+
+    const storedCourts = async (): Promise<string[]> => {
+      const rows = await db.execute(sql<{ court: string }>`
+        SELECT court FROM case_law_decisions
+        WHERE source_id = ${sourceId}
+        ORDER BY court
+      `);
+      const list = Array.isArray(rows) ? rows : [];
+      return list.map((row) => String((row as { court: unknown }).court));
+    };
+
+    beforeAll(async () => {
+      const [source] = await db
+        .insert(caseLawSources)
+        .values({ adapterKey, name: "Identity source", enabled: false })
+        .returning({ id: caseLawSources.id });
+      if (!source) {
+        throw new Error("expected source row");
+      }
+      sourceId = source.id;
+    });
+
+    afterAll(async () => {
+      if (sourceId) {
+        await db.delete(caseLawSources).where(eq(caseLawSources.id, sourceId));
+      }
+    });
+
+    test("keeps decisions that share a docket across courts", async () => {
+      await processDecision(
+        decisionAt("Okresný súd Prievidza", "g1"),
+        sourceId,
+        scopedDb,
+      );
+      await processDecision(
+        decisionAt("Okresný súd Trenčín", "g2"),
+        sourceId,
+        scopedDb,
+      );
+
+      expect(await storedCourts()).toEqual([
+        "Okresný súd Prievidza",
+        "Okresný súd Trenčín",
+      ]);
+    });
+
+    test("treats the same publisher id as the same decision on replay", async () => {
+      const before = await storedCourts();
+      await processDecision(
+        decisionAt("Okresný súd Prievidza", "g1"),
+        sourceId,
+        scopedDb,
+      );
+
+      expect(await storedCourts()).toEqual(before);
+    });
+  });
+}

--- a/apps/api/src/handlers/case-law/ingestion/pipeline.ts
+++ b/apps/api/src/handlers/case-law/ingestion/pipeline.ts
@@ -235,6 +235,9 @@ export const sanitizeResult = (r: IngestionResult): IngestionResult => {
   return {
     ...r,
     caseNumber: r.caseNumber.replace(DANGEROUS_CHARS, ""),
+    // Part of the uniqueness key, so it is sanitized like the case number:
+    // an invisible char here would make an already-stored decision look new.
+    sourceDocumentId: strip(r.sourceDocumentId),
     fulltext: r.fulltext
       ? collapseSpacedLetters(strip(r.fulltext) ?? "")
       : undefined,
@@ -581,13 +584,22 @@ export const processDecision = async (
 ): Promise<ProcessResult> => {
   const result = sanitizeResult(input);
 
+  // Match on the publisher's id where the adapter supplies one, and only
+  // fall back to the case number where it does not. The two are the halves
+  // of the uniqueness key, so the lookup has to split the same way the
+  // index does or it would find a row the insert cannot replace.
   const existing = await scopedDb((tx) =>
     tx.query.caseLawDecisions.findFirst({
-      where: {
-        sourceId: { eq: sourceId },
-        caseNumber: result.caseNumber,
-        language: result.language,
-      },
+      where: result.sourceDocumentId
+        ? {
+            sourceId: { eq: sourceId },
+            sourceDocumentId: result.sourceDocumentId,
+          }
+        : {
+            sourceId: { eq: sourceId },
+            caseNumber: result.caseNumber,
+            language: result.language,
+          },
       columns: {
         id: true,
         metadata: true,
@@ -937,6 +949,7 @@ export const processDecision = async (
           id: decisionId,
           sourceId,
           caseNumber: result.caseNumber,
+          sourceDocumentId: result.sourceDocumentId,
           citationKey: citationKeyOf(result.caseNumber),
           slug,
           ecli: result.ecli,

--- a/apps/api/src/scripts/backfill-source-document-ids.ts
+++ b/apps/api/src/scripts/backfill-source-document-ids.ts
@@ -1,0 +1,115 @@
+/**
+ * Populate `source_document_id` on decisions from data already stored.
+ *
+ * Identity keys on the publisher's own document id (see the column's note in
+ * `db/schema/case-law.ts`). Rows written after the column landed carry it;
+ * this fills everything older, with no re-crawl, because every source that
+ * states an id also records it in `source_url` or in `metadata`.
+ *
+ * Derivation per source:
+ *   sk-courts    metadata->>'guid'
+ *   cz-regional  last path segment of source_url  (/api/finaldoc/<id>)
+ *   pl-courts    last path segment of source_url  (/judgments/<id>)
+ *
+ * A source not listed here publishes no such id; its rows keep the
+ * case-number key and are deliberately left NULL.
+ *
+ * Keyset-paginated by id and idempotent: it can stop anywhere and resume,
+ * and re-running only touches rows that still lack an id.
+ *
+ *   bun apps/api/src/scripts/backfill-source-document-ids.ts
+ *   bun apps/api/src/scripts/backfill-source-document-ids.ts --adapter sk-courts
+ */
+
+import { sql } from "drizzle-orm";
+
+import { rootDb } from "@/api/db/root";
+import { isRecord } from "@/api/lib/type-guards";
+
+const BATCH = 2000;
+
+const adapterArgIndex = process.argv.indexOf("--adapter");
+const ADAPTER_FILTER =
+  adapterArgIndex === -1 ? null : (process.argv[adapterArgIndex + 1] ?? null);
+
+/**
+ * How each source states its document id, as SQL over columns we already
+ * hold. Kept as expressions rather than fetched-and-parsed in TypeScript so
+ * a batch is one statement: at corpus scale the round-trips dominate.
+ */
+const ID_EXPRESSION_BY_ADAPTER: Record<string, string> = {
+  "sk-courts": `metadata->>'guid'`,
+  "cz-regional": `regexp_replace(source_url, '^.*/([^/?]+)/?(\\?.*)?$', '\\1')`,
+  "pl-courts": `regexp_replace(source_url, '^.*/([^/?]+)/?(\\?.*)?$', '\\1')`,
+};
+
+const rowCount = (result: unknown): number => {
+  if (Array.isArray(result)) {
+    return result.length;
+  }
+  return isRecord(result) && Array.isArray(result["rows"])
+    ? result["rows"].length
+    : 0;
+};
+
+/**
+ * Fill one source's ids, one batch at a time.
+ *
+ * Expressed as a walk rather than a loop because each step depends on where
+ * the previous one stopped. The `IS NOT NULL` guard on the derived value
+ * keeps a row whose url or metadata carries nothing from being rewritten as
+ * an empty string, which would key every such row together — exactly the
+ * collapse this column exists to prevent.
+ */
+const fillFrom = async (
+  adapterKey: string,
+  expression: string,
+  filled: number,
+): Promise<number> => {
+  const result = await rootDb.execute(sql`
+    WITH batch AS (
+      SELECT d.id
+      FROM case_law_decisions d
+      JOIN case_law_sources s ON s.id = d.source_id
+      WHERE s.adapter_key = ${adapterKey}
+        AND d.source_document_id IS NULL
+      LIMIT ${BATCH}
+    )
+    UPDATE case_law_decisions d
+    SET source_document_id = ${sql.raw(expression)}
+    FROM batch
+    WHERE d.id = batch.id
+      AND ${sql.raw(expression)} IS NOT NULL
+      AND ${sql.raw(expression)} <> ''
+    RETURNING d.id
+  `);
+
+  const updated = rowCount(result);
+  if (updated === 0) {
+    return filled;
+  }
+  const total = filled + updated;
+  console.info(`${adapterKey}: ${total.toLocaleString()} filled`);
+  return await fillFrom(adapterKey, expression, total);
+};
+
+const adapters = Object.entries(ID_EXPRESSION_BY_ADAPTER).filter(
+  ([adapterKey]) => ADAPTER_FILTER === null || adapterKey === ADAPTER_FILTER,
+);
+
+if (adapters.length === 0) {
+  console.error(
+    `No id derivation known for "${ADAPTER_FILTER}". Known: ${Object.keys(ID_EXPRESSION_BY_ADAPTER).join(", ")}`,
+  );
+  process.exit(1);
+}
+
+for (const [adapterKey, expression] of adapters) {
+  // Sequential by design: each source is a full table walk, and running
+  // them together would multiply the write load on one table.
+  // oxlint-disable-next-line no-await-in-loop -- one corpus-wide walk at a time
+  const filled = await fillFrom(adapterKey, expression, 0);
+  console.info(`${adapterKey}: done, ${filled.toLocaleString()} rows`);
+}
+
+process.exit(0);

--- a/apps/api/src/scripts/backfill-source-document-ids.ts
+++ b/apps/api/src/scripts/backfill-source-document-ids.ts
@@ -104,12 +104,25 @@ if (adapters.length === 0) {
   process.exit(1);
 }
 
-for (const [adapterKey, expression] of adapters) {
-  // Sequential by design: each source is a full table walk, and running
-  // them together would multiply the write load on one table.
-  // oxlint-disable-next-line no-await-in-loop -- one corpus-wide walk at a time
+/**
+ * Walk the sources one at a time. Sequential by design: each is a full table
+ * pass, and running them together would multiply the write load on one table.
+ * Expressed as a walk rather than a loop so the sequencing is the shape of the
+ * code rather than an awaited step inside an iteration.
+ */
+const fillEach = async (
+  remaining: readonly (readonly [string, string])[],
+): Promise<void> => {
+  const [next, ...rest] = remaining;
+  if (next === undefined) {
+    return;
+  }
+  const [adapterKey, expression] = next;
   const filled = await fillFrom(adapterKey, expression, 0);
   console.info(`${adapterKey}: done, ${filled.toLocaleString()} rows`);
-}
+  await fillEach(rest);
+};
+
+await fillEach(adapters);
 
 process.exit(0);


### PR DESCRIPTION
Decision identity was `(source_id, case_number, language)`. Courts number dockets per court, so a source covering many courts issues the same number repeatedly — `0T/42/2019` exists at most Slovak district courts, `II AKa 198/23` at several Polish appellate courts. Under that key two unrelated decisions are the same row.

Identity now keys on the id the publisher itself assigns, in two halves that together cover every row exactly once:

- `(source_id, source_document_id)` where the source states an id
- `(source_id, case_number, language)` where it does not, which stays sound because such a source holds a single court

Both are partial unique indexes on complementary predicates, so every row is covered by exactly one and neither can drift.

**Where the id comes from.** No re-crawl: every affected source already records it. sk-courts has it as `guid` in the list item; cz-regional and pl-courts as the last segment of the document URL. `scripts/backfill-source-document-ids.ts` fills existing rows in batches, keyset-paginated and idempotent.

**Migration ordering.** The column lands NULL, so at that moment the case-number index still covers every row and semantics are unchanged. The replacement index is built before the old one is dropped, so uniqueness is enforced continuously rather than leaving a window. Both builds are `CONCURRENTLY` (the table holds millions of rows), following the split in `20260603120000_case_law_public_slugs`. Rows move between the two indexes as the backfill fills them.

**Guard.** `pipeline-identity.db.test.ts` asserts two decisions sharing a docket across courts both persist, and that replaying one publisher id does not add a row.

Follow-up, deliberately not in this PR: the trailing sheet number (`-28`, číslo listu) belongs in its own optional field rather than the docket. It has to move only after this lands — while the case number is still load-bearing for identity, normalizing it would collapse distinct keys.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Case-law records can now use publisher-provided document identifiers for more reliable matching and deduplication.
  * Supported court sources now capture document IDs during ingestion.
  * Legacy case-law records can be updated with recovered source document identifiers.

* **Bug Fixes**
  * Decisions sharing docket numbers across different courts are now retained separately.
  * Reprocessing the same publisher document no longer creates duplicate decisions.

* **Tests**
  * Added integration coverage for case-law identity and duplicate prevention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->