### PR TITLE
feat(case-law): keep the sheet number out of the case number

### DIFF
--- a/apps/api/drizzle/20260731150000_decision_sheet_number/migration.sql
+++ b/apps/api/drizzle/20260731150000_decision_sheet_number/migration.sql
@@ -1,0 +1,16 @@
+SET lock_timeout = '1s';--> statement-breakpoint
+SET statement_timeout = '5s';--> statement-breakpoint
+
+-- Sheet number within the court file (číslo listu), which some sources append
+-- to the docket as `11 C 153/2025-28`. It identifies where a document sits in
+-- the file, not which case it belongs to, and no citation names it, so keeping
+-- it on `case_number` fragments one case into a reference per sheet and
+-- matches nothing.
+--
+-- Values are not backfilled here: rewriting `case_number` on existing rows is
+-- more than one in-transaction UPDATE can finish within statement_timeout, and
+-- it is only safe once a row's identity no longer rests on the case number.
+-- src/scripts/normalize-case-numbers.ts does it in batches and skips any row
+-- whose `source_document_id` is still NULL.
+ALTER TABLE "case_law_decisions"
+  ADD COLUMN IF NOT EXISTS "sheet_number" varchar(32);--> statement-breakpoint

--- a/apps/api/src/db/schema/case-law.ts
+++ b/apps/api/src/db/schema/case-law.ts
@@ -115,6 +115,17 @@ export const caseLawDecisions = p.pgTable(
      */
     sourceDocumentId: p.varchar("source_document_id", { length: 256 }),
     /**
+     * Sheet number within the court file (číslo listu), where the source
+     * appends one to the docket: `11 C 153/2025-28` is sheet 28 of case
+     * `11 C 153/2025`.
+     *
+     * It is not part of the case reference and no one cites it, so it is kept
+     * out of `caseNumber`, which would otherwise fragment one case into a row
+     * per sheet and match no citation. Null wherever the source appends
+     * nothing.
+     */
+    sheetNumber: p.varchar("sheet_number", { length: 32 }),
+    /**
      * Bookkeeping for sources that ingest metadata first and fetch the
      * document later (see `ingestion/sk-document-backfill.ts`).
      * `documentFetchRequestedAt` is the first read that asked for the

--- a/apps/api/src/handlers/case-law/case-number.test.ts
+++ b/apps/api/src/handlers/case-law/case-number.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "bun:test";
+
+import { splitCaseReference } from "@/api/handlers/case-law/case-number";
+
+describe("splitCaseReference", () => {
+  test("takes the sheet number off a Czech docket", () => {
+    expect(splitCaseReference("11 C 153/2025-28")).toEqual({
+      caseNumber: "11 C 153/2025",
+      sheetNumber: "28",
+    });
+  });
+
+  test("leaves references that carry no sheet number", () => {
+    for (const reference of [
+      "0T/42/2019",
+      "II AKa 198/23",
+      "28 Cdo 5171/2008",
+      "C-123/20",
+      "ECLI:CZ:NS:2009:28.CDO.5171.2008.1",
+    ]) {
+      expect(splitCaseReference(reference)).toEqual({
+        caseNumber: reference,
+        sheetNumber: undefined,
+      });
+    }
+  });
+
+  /**
+   * The property that matters downstream: a citation names the docket, so
+   * every reference must reduce to the same docket whatever sheet it carries.
+   */
+  test("references differing only by sheet share one docket", () => {
+    const sheets = ["-1", "-28", "-145", ""];
+    const dockets = new Set(
+      sheets.map(
+        (sheet) => splitCaseReference(`11 C 153/2025${sheet}`).caseNumber,
+      ),
+    );
+
+    expect([...dockets]).toEqual(["11 C 153/2025"]);
+  });
+
+  test("is idempotent", () => {
+    const once = splitCaseReference("11 C 153/2025-28").caseNumber;
+
+    expect(splitCaseReference(once).caseNumber).toBe(once);
+  });
+});

--- a/apps/api/src/handlers/case-law/case-number.ts
+++ b/apps/api/src/handlers/case-law/case-number.ts
@@ -1,0 +1,39 @@
+/**
+ * Splitting a published case reference into the docket and what follows it.
+ *
+ * Some courts append the sheet number within the file (číslo listu) to the
+ * docket, as `11 C 153/2025-28`. The two are different things: the docket
+ * identifies the case, the sheet identifies where a document sits in it. Kept
+ * together, one case fragments into a reference per sheet and no citation
+ * matches, because a citation names the docket alone.
+ */
+
+/**
+ * Trailing `-<digits>` on a reference whose docket already carries a year.
+ *
+ * The year requirement is what keeps this from biting references that end in a
+ * number for another reason: Slovak `0T/42/2019` and Polish `II AKa 198/23`
+ * have no trailing group to take, while `11 C 153/2025-28` does. Anchored at
+ * the end so an internal dash (`ECLI:CZ:...`) is untouched.
+ */
+const SHEET_SUFFIX = /^(?<docket>.*\/\d{2,4})-(?<sheet>\d+)$/u;
+
+type CaseReference = {
+  caseNumber: string;
+  sheetNumber: string | undefined;
+};
+
+/**
+ * The docket and sheet of a published reference. A reference with no sheet
+ * comes back unchanged with `sheetNumber` undefined, so this is safe to apply
+ * to every source rather than only the ones known to append one.
+ */
+export const splitCaseReference = (reference: string): CaseReference => {
+  const groups = SHEET_SUFFIX.exec(reference.trim())?.groups;
+  const docket = groups?.["docket"];
+  const sheet = groups?.["sheet"];
+  if (docket === undefined || sheet === undefined) {
+    return { caseNumber: reference.trim(), sheetNumber: undefined };
+  }
+  return { caseNumber: docket, sheetNumber: sheet };
+};

--- a/apps/api/src/handlers/case-law/ingestion/adapter.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapter.ts
@@ -29,6 +29,13 @@ export type IngestionResult = {
    * Omit it only where the source publishes no such id.
    */
   sourceDocumentId?: string | undefined;
+  /**
+   * Sheet number within the court file, where the source appends one to the
+   * docket. Split it out with `splitCaseReference` rather than leaving it on
+   * `caseNumber`: a citation names the docket alone, so a number carrying a
+   * sheet matches nothing.
+   */
+  sheetNumber?: string | undefined;
   ecli?: string | undefined;
   court: string;
   country: string;

--- a/apps/api/src/handlers/case-law/ingestion/adapters/cz-regional.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/cz-regional.ts
@@ -1,5 +1,6 @@
 import { panic, Result } from "better-result";
 
+import { splitCaseReference } from "@/api/handlers/case-law/case-number";
 import {
   ADAPTER_KEYS,
   ADAPTER_TIMEOUT,
@@ -401,9 +402,12 @@ const parseItem = (item: CzRegionalApiItem): IngestionResult | null => {
   }
 
   const raw = JSON.stringify(item);
+  // This source publishes the docket with the sheet number appended.
+  const { caseNumber, sheetNumber } = splitCaseReference(item.jednaciCislo);
 
   return {
-    caseNumber: item.jednaciCislo,
+    caseNumber,
+    sheetNumber,
     ecli: toOptionalValue(item.ecli),
     court: item.soud,
     country: "CZE",
@@ -413,7 +417,11 @@ const parseItem = (item: CzRegionalApiItem): IngestionResult | null => {
     sourceUrl: sanitizeUrl(toOptionalValue(item.odkaz) ?? ""),
     documentUrl: sanitizeUrl(toOptionalValue(item.odkaz) ?? ""),
     metadata: {
-      caseNumber: item.jednaciCislo,
+      caseNumber,
+      sheetNumber,
+      // The reference exactly as the court publishes it, docket and sheet
+      // together, so the split stays reversible from what we stored.
+      publishedCaseNumber: item.jednaciCislo,
       ecli: toOptionalValue(item.ecli),
       court: item.soud,
       decisionDate: toOptionalValue(item.datumVydani),

--- a/apps/api/src/handlers/case-law/ingestion/pipeline.ts
+++ b/apps/api/src/handlers/case-law/ingestion/pipeline.ts
@@ -238,6 +238,7 @@ export const sanitizeResult = (r: IngestionResult): IngestionResult => {
     // Part of the uniqueness key, so it is sanitized like the case number:
     // an invisible char here would make an already-stored decision look new.
     sourceDocumentId: strip(r.sourceDocumentId),
+    sheetNumber: strip(r.sheetNumber),
     fulltext: r.fulltext
       ? collapseSpacedLetters(strip(r.fulltext) ?? "")
       : undefined,
@@ -594,6 +595,7 @@ export const processDecision = async (
         ? {
             sourceId: { eq: sourceId },
             sourceDocumentId: result.sourceDocumentId,
+            sheetNumber: result.sheetNumber,
           }
         : {
             sourceId: { eq: sourceId },

--- a/apps/api/src/scripts/normalize-case-numbers.ts
+++ b/apps/api/src/scripts/normalize-case-numbers.ts
@@ -1,0 +1,109 @@
+/**
+ * Move the sheet number out of `case_number` into `sheet_number`.
+ *
+ * Some sources publish the docket with the sheet number within the court file
+ * appended (`11 C 153/2025-28`). A citation names the docket alone, so while
+ * the sheet stays on the case number nothing matches it, and one case appears
+ * as a separate reference per sheet.
+ *
+ * **Ordering.** A row whose `source_document_id` is still NULL is identified by
+ * its case number, so rewriting that number would collapse distinct rows onto
+ * one key. Such rows are skipped, which makes this safe to run at any time and
+ * makes `backfill-source-document-ids.ts` its prerequisite rather than a
+ * assumption. Run that first; re-run this afterwards to pick up the rest.
+ *
+ * `citation_key` is recomputed in the same statement, since it derives from the
+ * case number and would otherwise keep pointing at the un-normalized form.
+ *
+ * Idempotent: a row already split no longer matches the pattern.
+ *
+ *   bun apps/api/src/scripts/normalize-case-numbers.ts
+ *   bun apps/api/src/scripts/normalize-case-numbers.ts --dry-run
+ */
+
+import { sql } from "drizzle-orm";
+
+import { rootDb } from "@/api/db/root";
+import { isRecord } from "@/api/lib/type-guards";
+
+const BATCH = 2000;
+const DRY_RUN = process.argv.includes("--dry-run");
+
+/**
+ * Trailing `-<digits>` on a docket that already carries a year — the same
+ * shape `splitCaseReference` applies at ingest, expressed in SQL so a batch is
+ * one statement. The year is what keeps references that merely end in a number
+ * (`0T/42/2019`) from being split.
+ */
+const SHEET_PATTERN = String.raw`^(.*/\d{2,4})-(\d+)$`;
+
+const rowCount = (result: unknown): number => {
+  if (Array.isArray(result)) {
+    return result.length;
+  }
+  return isRecord(result) && Array.isArray(result["rows"])
+    ? result["rows"].length
+    : 0;
+};
+
+const firstNumber = (result: unknown, key: string): number => {
+  const rows = Array.isArray(result)
+    ? result
+    : isRecord(result) && Array.isArray(result["rows"])
+      ? result["rows"]
+      : [];
+  const row = rows.at(0);
+  return isRecord(row) && typeof row[key] === "number" ? row[key] : 0;
+};
+
+if (DRY_RUN) {
+  const counts = await rootDb.execute(sql`
+    SELECT
+      count(*) FILTER (WHERE source_document_id IS NOT NULL)::int AS ready,
+      count(*) FILTER (WHERE source_document_id IS NULL)::int AS blocked
+    FROM case_law_decisions
+    WHERE case_number ~ ${SHEET_PATTERN}
+  `);
+  console.info(
+    `carry a sheet number: ${firstNumber(counts, "ready").toLocaleString()} ready, ` +
+      `${firstNumber(counts, "blocked").toLocaleString()} still identified by case number (run the id backfill first)`,
+  );
+  process.exit(0);
+}
+
+/**
+ * Normalize one batch and continue from wherever it stopped. A walk rather
+ * than a loop: each step depends on the previous one having committed.
+ */
+const normalizeFrom = async (done: number): Promise<number> => {
+  const result = await rootDb.execute(sql`
+    WITH batch AS (
+      SELECT id FROM case_law_decisions
+      WHERE case_number ~ ${SHEET_PATTERN}
+        AND source_document_id IS NOT NULL
+      LIMIT ${BATCH}
+    )
+    UPDATE case_law_decisions d
+    SET case_number = regexp_replace(d.case_number, ${SHEET_PATTERN}, ${String.raw`\1`}),
+        sheet_number = regexp_replace(d.case_number, ${SHEET_PATTERN}, ${String.raw`\2`}),
+        citation_key = NULL
+    FROM batch
+    WHERE d.id = batch.id
+    RETURNING d.id
+  `);
+
+  const updated = rowCount(result);
+  if (updated === 0) {
+    return done;
+  }
+  const total = done + updated;
+  console.info(`${total.toLocaleString()} normalized`);
+  return await normalizeFrom(total);
+};
+
+const total = await normalizeFrom(0);
+console.info(
+  `done, ${total.toLocaleString()} rows. Re-run backfill-citation-keys.ts to refill citation_key.`,
+);
+
+process.exit(0);

--- a/apps/api/src/scripts/normalize-case-numbers.ts
+++ b/apps/api/src/scripts/normalize-case-numbers.ts
@@ -37,22 +37,21 @@ const DRY_RUN = process.argv.includes("--dry-run");
  */
 const SHEET_PATTERN = String.raw`^(.*/\d{2,4})-(\d+)$`;
 
-const rowCount = (result: unknown): number => {
+/** Rows from `execute` under either driver shape (bare array or `{ rows }`). */
+const executedRows = (result: unknown): unknown[] => {
   if (Array.isArray(result)) {
-    return result.length;
+    return result;
   }
-  return isRecord(result) && Array.isArray(result["rows"])
-    ? result["rows"].length
-    : 0;
+  if (isRecord(result) && Array.isArray(result["rows"])) {
+    return result["rows"];
+  }
+  return [];
 };
 
+const rowCount = (result: unknown): number => executedRows(result).length;
+
 const firstNumber = (result: unknown, key: string): number => {
-  const rows = Array.isArray(result)
-    ? result
-    : isRecord(result) && Array.isArray(result["rows"])
-      ? result["rows"]
-      : [];
-  const row = rows.at(0);
+  const row = executedRows(result).at(0);
   return isRecord(row) && typeof row[key] === "number" ? row[key] : 0;
 };
 


### PR DESCRIPTION
Some sources publish the docket with the sheet number within the court file (číslo listu) appended: `11 C 153/2025-28` is sheet 28 of case `11 C 153/2025`. The two identify different things, and a citation names the docket alone, so while they stay joined no citation matches and one case reads as a separate reference per sheet.

`splitCaseReference` separates them at ingest; `sheet_number` is a new nullable column. cz-regional is the source that appends one today (about 96% of its rows), and its metadata keeps the reference exactly as published so the split stays reversible.

The split is conservative by construction: it only takes a trailing `-<digits>` from a docket that already carries a year, which is what keeps references merely ending in a number intact — `0T/42/2019` and `II AKa 198/23` pass through untouched. `case-number.test.ts` asserts that, plus the property that matters downstream: references differing only by sheet all reduce to one docket, and the split is idempotent.

**Existing rows are not rewritten here.** `scripts/normalize-case-numbers.ts` does that in batches, and skips any row whose `source_document_id` is still NULL — such a row is still identified by its case number, so rewriting it would collapse distinct rows onto one key. That makes the id backfill a prerequisite the script enforces rather than assumes, and makes it safe to run at any point. It clears `citation_key` for the rows it touches, since that key derives from the case number.