### PR TITLE
feat(case-law): walk a source oldest-first until it is caught up

### DIFF
--- a/apps/api/drizzle/20260731150000_decision_sheet_number/migration.sql
+++ b/apps/api/drizzle/20260731150000_decision_sheet_number/migration.sql
@@ -1,0 +1,16 @@
+SET lock_timeout = '1s';--> statement-breakpoint
+SET statement_timeout = '5s';--> statement-breakpoint
+
+-- Sheet number within the court file (číslo listu), which some sources append
+-- to the docket as `11 C 153/2025-28`. It identifies where a document sits in
+-- the file, not which case it belongs to, and no citation names it, so keeping
+-- it on `case_number` fragments one case into a reference per sheet and
+-- matches nothing.
+--
+-- Values are not backfilled here: rewriting `case_number` on existing rows is
+-- more than one in-transaction UPDATE can finish within statement_timeout, and
+-- it is only safe once a row's identity no longer rests on the case number.
+-- src/scripts/normalize-case-numbers.ts does it in batches and skips any row
+-- whose `source_document_id` is still NULL.
+ALTER TABLE "case_law_decisions"
+  ADD COLUMN IF NOT EXISTS "sheet_number" varchar(32);--> statement-breakpoint

--- a/apps/api/src/db/schema/case-law.ts
+++ b/apps/api/src/db/schema/case-law.ts
@@ -115,6 +115,17 @@ export const caseLawDecisions = p.pgTable(
      */
     sourceDocumentId: p.varchar("source_document_id", { length: 256 }),
     /**
+     * Sheet number within the court file (číslo listu), where the source
+     * appends one to the docket: `11 C 153/2025-28` is sheet 28 of case
+     * `11 C 153/2025`.
+     *
+     * It is not part of the case reference and no one cites it, so it is kept
+     * out of `caseNumber`, which would otherwise fragment one case into a row
+     * per sheet and match no citation. Null wherever the source appends
+     * nothing.
+     */
+    sheetNumber: p.varchar("sheet_number", { length: 32 }),
+    /**
      * Bookkeeping for sources that ingest metadata first and fetch the
      * document later (see `ingestion/sk-document-backfill.ts`).
      * `documentFetchRequestedAt` is the first read that asked for the

--- a/apps/api/src/handlers/case-law/case-number.test.ts
+++ b/apps/api/src/handlers/case-law/case-number.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "bun:test";
+
+import { splitCaseReference } from "@/api/handlers/case-law/case-number";
+
+describe("splitCaseReference", () => {
+  test("takes the sheet number off a Czech docket", () => {
+    expect(splitCaseReference("11 C 153/2025-28")).toEqual({
+      caseNumber: "11 C 153/2025",
+      sheetNumber: "28",
+    });
+  });
+
+  test("leaves references that carry no sheet number", () => {
+    for (const reference of [
+      "0T/42/2019",
+      "II AKa 198/23",
+      "28 Cdo 5171/2008",
+      "C-123/20",
+      "ECLI:CZ:NS:2009:28.CDO.5171.2008.1",
+    ]) {
+      expect(splitCaseReference(reference)).toEqual({
+        caseNumber: reference,
+        sheetNumber: undefined,
+      });
+    }
+  });
+
+  /**
+   * The property that matters downstream: a citation names the docket, so
+   * every reference must reduce to the same docket whatever sheet it carries.
+   */
+  test("references differing only by sheet share one docket", () => {
+    const sheets = ["-1", "-28", "-145", ""];
+    const dockets = new Set(
+      sheets.map(
+        (sheet) => splitCaseReference(`11 C 153/2025${sheet}`).caseNumber,
+      ),
+    );
+
+    expect([...dockets]).toEqual(["11 C 153/2025"]);
+  });
+
+  test("is idempotent", () => {
+    const once = splitCaseReference("11 C 153/2025-28").caseNumber;
+
+    expect(splitCaseReference(once).caseNumber).toBe(once);
+  });
+});

--- a/apps/api/src/handlers/case-law/case-number.ts
+++ b/apps/api/src/handlers/case-law/case-number.ts
@@ -1,0 +1,39 @@
+/**
+ * Splitting a published case reference into the docket and what follows it.
+ *
+ * Some courts append the sheet number within the file (číslo listu) to the
+ * docket, as `11 C 153/2025-28`. The two are different things: the docket
+ * identifies the case, the sheet identifies where a document sits in it. Kept
+ * together, one case fragments into a reference per sheet and no citation
+ * matches, because a citation names the docket alone.
+ */
+
+/**
+ * Trailing `-<digits>` on a reference whose docket already carries a year.
+ *
+ * The year requirement is what keeps this from biting references that end in a
+ * number for another reason: Slovak `0T/42/2019` and Polish `II AKa 198/23`
+ * have no trailing group to take, while `11 C 153/2025-28` does. Anchored at
+ * the end so an internal dash (`ECLI:CZ:...`) is untouched.
+ */
+const SHEET_SUFFIX = /^(?<docket>.*\/\d{2,4})-(?<sheet>\d+)$/u;
+
+type CaseReference = {
+  caseNumber: string;
+  sheetNumber: string | undefined;
+};
+
+/**
+ * The docket and sheet of a published reference. A reference with no sheet
+ * comes back unchanged with `sheetNumber` undefined, so this is safe to apply
+ * to every source rather than only the ones known to append one.
+ */
+export const splitCaseReference = (reference: string): CaseReference => {
+  const groups = SHEET_SUFFIX.exec(reference.trim())?.groups;
+  const docket = groups?.["docket"];
+  const sheet = groups?.["sheet"];
+  if (docket === undefined || sheet === undefined) {
+    return { caseNumber: reference.trim(), sheetNumber: undefined };
+  }
+  return { caseNumber: docket, sheetNumber: sheet };
+};

--- a/apps/api/src/handlers/case-law/ingestion/adapter.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapter.ts
@@ -29,6 +29,13 @@ export type IngestionResult = {
    * Omit it only where the source publishes no such id.
    */
   sourceDocumentId?: string | undefined;
+  /**
+   * Sheet number within the court file, where the source appends one to the
+   * docket. Split it out with `splitCaseReference` rather than leaving it on
+   * `caseNumber`: a citation names the docket alone, so a number carrying a
+   * sheet matches nothing.
+   */
+  sheetNumber?: string | undefined;
   ecli?: string | undefined;
   court: string;
   country: string;

--- a/apps/api/src/handlers/case-law/ingestion/adapters/cz-regional.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/cz-regional.ts
@@ -1,5 +1,6 @@
 import { panic, Result } from "better-result";
 
+import { splitCaseReference } from "@/api/handlers/case-law/case-number";
 import {
   ADAPTER_KEYS,
   ADAPTER_TIMEOUT,
@@ -401,9 +402,12 @@ const parseItem = (item: CzRegionalApiItem): IngestionResult | null => {
   }
 
   const raw = JSON.stringify(item);
+  // This source publishes the docket with the sheet number appended.
+  const { caseNumber, sheetNumber } = splitCaseReference(item.jednaciCislo);
 
   return {
-    caseNumber: item.jednaciCislo,
+    caseNumber,
+    sheetNumber,
     ecli: toOptionalValue(item.ecli),
     court: item.soud,
     country: "CZE",
@@ -413,7 +417,11 @@ const parseItem = (item: CzRegionalApiItem): IngestionResult | null => {
     sourceUrl: sanitizeUrl(toOptionalValue(item.odkaz) ?? ""),
     documentUrl: sanitizeUrl(toOptionalValue(item.odkaz) ?? ""),
     metadata: {
-      caseNumber: item.jednaciCislo,
+      caseNumber,
+      sheetNumber,
+      // The reference exactly as the court publishes it, docket and sheet
+      // together, so the split stays reversible from what we stored.
+      publishedCaseNumber: item.jednaciCislo,
       ecli: toOptionalValue(item.ecli),
       court: item.soud,
       decisionDate: toOptionalValue(item.datumVydani),

--- a/apps/api/src/handlers/case-law/ingestion/adapters/pagination.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/pagination.test.ts
@@ -395,8 +395,12 @@ describe("offset cursor codec", () => {
 
 describe("traversal modes", () => {
   const modes = [
-    { name: "backfill", buildRequest: () => ({ url: "a" }), then: "live" },
-    { name: "live", buildRequest: () => ({ url: "b" }), then: null },
+    {
+      name: "backfill",
+      buildRequest: () => ({ url: "a" }),
+      followedBy: "live",
+    },
+    { name: "live", buildRequest: () => ({ url: "b" }), followedBy: null },
   ] as const;
 
   test("a cursor names the walk it belongs to", () => {

--- a/apps/api/src/handlers/case-law/ingestion/adapters/pagination.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/pagination.test.ts
@@ -9,7 +9,9 @@ import { asTestRaw, readTestJson } from "@/api/tests/helpers/test-tool-set";
 import {
   createPagePaginatedFetch,
   decodeOffsetCursor,
+  decodeTraversalCursor,
   encodeOffsetCursor,
+  encodeTraversalCursor,
 } from "./pagination";
 import { mockFetchWithFixtures, saveFixture } from "./test-utils";
 
@@ -388,5 +390,56 @@ describe("offset cursor codec", () => {
       ),
       propertyConfig({ numRuns: 500 }),
     );
+  });
+});
+
+describe("traversal modes", () => {
+  const modes = [
+    { name: "backfill", buildRequest: () => ({ url: "a" }), then: "live" },
+    { name: "live", buildRequest: () => ({ url: "b" }), then: null },
+  ] as const;
+
+  test("a cursor names the walk it belongs to", () => {
+    expect(decodeTraversalCursor("backfill:1200", modes)).toEqual({
+      mode: modes[0],
+      offset: 1200,
+    });
+    expect(decodeTraversalCursor("live:0", modes)).toEqual({
+      mode: modes[1],
+      offset: 0,
+    });
+  });
+
+  test("starts the first walk when there is no cursor", () => {
+    expect(decodeTraversalCursor(null, modes)?.mode.name).toBe("backfill");
+    expect(decodeTraversalCursor(null, modes)?.offset).toBe(0);
+  });
+
+  /**
+   * An offset counted newest-first points somewhere unrelated oldest-first,
+   * so a cursor from before the walks were declared cannot be carried into
+   * one. Restarting the first walk is both safe and what catching up needs.
+   */
+  test("restarts the first walk for a cursor naming no walk", () => {
+    for (const cursor of ["offset:1513900", "15139", "nonsense:4"]) {
+      expect(decodeTraversalCursor(cursor, modes)).toEqual({
+        mode: modes[0],
+        offset: 0,
+      });
+    }
+  });
+
+  test("rejects a walk cursor whose offset is not a number", () => {
+    expect(decodeTraversalCursor("backfill:-1", modes)).toBeNull();
+    expect(decodeTraversalCursor("backfill:x", modes)).toBeNull();
+  });
+
+  test("round-trips", () => {
+    expect(
+      decodeTraversalCursor(encodeTraversalCursor("live", 42), modes),
+    ).toEqual({
+      mode: modes[1],
+      offset: 42,
+    });
   });
 });

--- a/apps/api/src/handlers/case-law/ingestion/adapters/pagination.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/pagination.ts
@@ -464,18 +464,21 @@ export const createPagePaginatedFetch = <TResponse>(
         // the one that follows it, starting at its own beginning. Handing
         // over only here is what makes the switch a fact about the crawl
         // rather than a guess: the collection has demonstrably been seen.
-        if (!signal?.aborted && !hasMore && walk?.mode.followedBy !== null) {
-          const successor = walk?.mode.followedBy;
-          if (successor !== undefined) {
-            logger.info("case_law.ingestion.traversal_advanced", {
-              adapterKey: opts.adapterKey,
-              from: walk?.mode.name,
-              to: successor,
-              offset: fetched,
-              ...(total !== undefined ? { sourceTotal: total } : {}),
-            });
-            nextCursor = encodeTraversalCursor(successor, 0);
-          }
+        const successor = walk === null ? null : walk.mode.followedBy;
+        if (
+          walk !== null &&
+          successor !== null &&
+          !signal?.aborted &&
+          !hasMore
+        ) {
+          logger.info("case_law.ingestion.traversal_advanced", {
+            adapterKey: opts.adapterKey,
+            from: walk.mode.name,
+            to: successor,
+            offset: fetched,
+            ...(total !== undefined ? { sourceTotal: total } : {}),
+          });
+          nextCursor = encodeTraversalCursor(successor, 0);
         }
 
         return { decisions, nextCursor };

--- a/apps/api/src/handlers/case-law/ingestion/adapters/pagination.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/pagination.ts
@@ -28,6 +28,19 @@ import { logger } from "@/api/lib/observability/logger";
  * 0-indexed). Covers: SK, PL, AT, CZ-supreme-admin,
  * EE, HR, and similar adapters.
  */
+/** One ordered walk over a collection, named so a cursor can carry it. */
+export type TraversalMode = {
+  /** Persisted as the cursor prefix. Stable: changing it restarts the walk. */
+  name: string;
+  /** Request for a page within this walk. */
+  buildRequest: (page: number) => { url: string; init?: RequestInit };
+  /**
+   * Where to continue once this walk reaches the end of the collection, or
+   * null to park within it and re-scan its recent window (rule 13).
+   */
+  then: string | null;
+};
+
 type PagePaginationOptions<TResponse> = {
   /** Adapter key for error context. */
   adapterKey: string;
@@ -45,6 +58,25 @@ type PagePaginationOptions<TResponse> = {
    * Return the URL and optional RequestInit overrides.
    */
   buildRequest: (page: number) => { url: string; init?: RequestInit };
+  /**
+   * Ordered walks over the same collection, where one walk cannot serve both
+   * catching up and keeping up.
+   *
+   * A source sorted newest-first cannot be caught up by walking offsets
+   * forward: every publication shifts each later offset, so items slide past
+   * the cursor unseen and the crawl never converges. Walking oldest-first
+   * does converge, because new items land at the end and the offsets already
+   * walked never move. It is the wrong order to stay current in, though, so a
+   * source needs both: oldest-first until the collection has been seen, then
+   * newest-first from there on.
+   *
+   * The active mode is persisted in the cursor (`backfill:1200`) rather than
+   * chosen per call, so a restart, a redeploy, or a second caller all resume
+   * in the phase the crawl actually reached.
+   *
+   * Adapters that need only one walk omit this and keep `buildRequest`.
+   */
+  traversal?: readonly TraversalMode[] | undefined;
   /**
    * Parse the raw response into a typed result.
    * Should throw on unexpected response shapes.
@@ -154,10 +186,44 @@ export const decodeOffsetCursor = ({
   return Number.isSafeInteger(offset) && offset >= 0 ? offset : null;
 };
 
+/**
+ * The mode a cursor names and the offset within it.
+ *
+ * A cursor written before the adapter declared its walks names no mode. It
+ * cannot be carried into one either, because an offset counted in one order
+ * points somewhere unrelated in another, so the first walk restarts from its
+ * beginning — which is what catching up requires anyway.
+ */
+export const decodeTraversalCursor = (
+  cursor: string | null,
+  modes: readonly TraversalMode[],
+): { mode: TraversalMode; offset: number } | null => {
+  const [first] = modes;
+  if (first === undefined) {
+    return null;
+  }
+  if (cursor === null) {
+    return { mode: first, offset: 0 };
+  }
+  const separator = cursor.indexOf(":");
+  const named = modes.find((mode) => mode.name === cursor.slice(0, separator));
+  if (separator === -1 || named === undefined) {
+    return { mode: first, offset: 0 };
+  }
+  const offset = parseCanonicalNonNegativeSafeInteger(
+    cursor.slice(separator + 1),
+  );
+  return offset === null ? null : { mode: named, offset };
+};
+
+export const encodeTraversalCursor = (mode: string, offset: number): string =>
+  `${mode}:${offset}`;
+
 export const createPagePaginatedFetch = <TResponse>(
   opts: PagePaginationOptions<TResponse>,
 ) => {
   const firstPage = opts.zeroIndexed ? 0 : 1;
+  const modes = opts.traversal;
 
   return async (
     cursor: string | null,
@@ -166,11 +232,14 @@ export const createPagePaginatedFetch = <TResponse>(
   ): Promise<Result<SyncPage, AdapterFetchError>> =>
     await Result.tryPromise({
       try: async () => {
-        const offset = decodeOffsetCursor({
-          cursor,
-          firstPage,
-          legacyPageSize: opts.legacyPageSize ?? opts.pageSize,
-        });
+        const walk = modes ? decodeTraversalCursor(cursor, modes) : null;
+        const offset = walk
+          ? walk.offset
+          : decodeOffsetCursor({
+              cursor,
+              firstPage,
+              legacyPageSize: opts.legacyPageSize ?? opts.pageSize,
+            });
 
         if (offset === null) {
           throw new AdapterFetchError({
@@ -185,7 +254,7 @@ export const createPagePaginatedFetch = <TResponse>(
         const pageStartOffset = pageIndex * opts.pageSize;
         const itemsAlreadyFetched = offset - pageStartOffset;
 
-        const { url, init } = opts.buildRequest(page);
+        const { url, init } = (walk?.mode ?? opts).buildRequest(page);
         const fetchT0 = performance.now();
         const listTimeout = opts.listTimeoutMs ?? ADAPTER_TIMEOUT.LIST;
 
@@ -378,15 +447,35 @@ export const createPagePaginatedFetch = <TResponse>(
         // re-processing the already consumed page tail.
         // When exhausted with zero results (overshot past end),
         // step back so the cursor recovers into the valid range.
-        let nextCursor = encodeOffsetCursor(
-          Math.max(0, pageStartOffset - opts.pageSize),
-        );
+        const encode = walk
+          ? (at: number): string => encodeTraversalCursor(walk.mode.name, at)
+          : encodeOffsetCursor;
+
+        let nextCursor = encode(Math.max(0, pageStartOffset - opts.pageSize));
         if (signal?.aborted) {
-          nextCursor = encodeOffsetCursor(offset + processedThroughIndex);
+          nextCursor = encode(offset + processedThroughIndex);
         } else if (hasMore) {
-          nextCursor = encodeOffsetCursor(fetched);
+          nextCursor = encode(fetched);
         } else if (fetchedItems.length > 0) {
-          nextCursor = encodeOffsetCursor(offset + items.length);
+          nextCursor = encode(offset + items.length);
+        }
+
+        // This walk has reached the end of the collection, so hand over to
+        // the one that follows it, starting at its own beginning. Handing
+        // over only here is what makes the switch a fact about the crawl
+        // rather than a guess: the collection has demonstrably been seen.
+        if (!signal?.aborted && !hasMore && walk?.mode.then !== null) {
+          const successor = walk?.mode.then;
+          if (successor !== undefined) {
+            logger.info("case_law.ingestion.traversal_advanced", {
+              adapterKey: opts.adapterKey,
+              from: walk?.mode.name,
+              to: successor,
+              offset: fetched,
+              ...(total !== undefined ? { sourceTotal: total } : {}),
+            });
+            nextCursor = encodeTraversalCursor(successor, 0);
+          }
         }
 
         return { decisions, nextCursor };

--- a/apps/api/src/handlers/case-law/ingestion/adapters/pagination.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/pagination.ts
@@ -38,7 +38,7 @@ export type TraversalMode = {
    * Where to continue once this walk reaches the end of the collection, or
    * null to park within it and re-scan its recent window (rule 13).
    */
-  then: string | null;
+  followedBy: string | null;
 };
 
 type PagePaginationOptions<TResponse> = {
@@ -464,8 +464,8 @@ export const createPagePaginatedFetch = <TResponse>(
         // the one that follows it, starting at its own beginning. Handing
         // over only here is what makes the switch a fact about the crawl
         // rather than a guess: the collection has demonstrably been seen.
-        if (!signal?.aborted && !hasMore && walk?.mode.then !== null) {
-          const successor = walk?.mode.then;
+        if (!signal?.aborted && !hasMore && walk?.mode.followedBy !== null) {
+          const successor = walk?.mode.followedBy;
           if (successor !== undefined) {
             logger.info("case_law.ingestion.traversal_advanced", {
               adapterKey: opts.adapterKey,

--- a/apps/api/src/handlers/case-law/ingestion/adapters/sk-courts.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/sk-courts.ts
@@ -297,6 +297,20 @@ const parseItemWithDetail = async (
   };
 };
 
+/** One list page, in the given order. */
+const listRequest = (
+  page: number,
+  sortDirection: "ASC" | "DESC",
+): { url: string; init: RequestInit } => ({
+  url: `${BASE_URL}?${new URLSearchParams({
+    page: String(page),
+    size: String(PAGE_SIZE),
+    sortProperty: "datumVydania",
+    sortDirection,
+  }).toString()}`,
+  init: { headers: { Accept: "application/json" } },
+});
+
 export const skCourtsAdapter: SourceAdapter = {
   key: ADAPTER_KEYS.SK_COURTS,
   name: "obcan.justice.sk",
@@ -345,17 +359,25 @@ export const skCourtsAdapter: SourceAdapter = {
     listTimeoutMs: 60_000,
     itemConcurrency: ITEM_CONCURRENCY,
 
-    buildRequest: (page) => ({
-      url: `${BASE_URL}?${new URLSearchParams({
-        page: String(page),
-        size: String(PAGE_SIZE),
-        sortProperty: "datumVydania",
-        sortDirection: "DESC",
-      }).toString()}`,
-      init: {
-        headers: { Accept: "application/json" },
+    buildRequest: (page) => listRequest(page, "DESC"),
+
+    // Oldest-first until the collection has been seen, then newest-first.
+    // Walking this source newest-first from the start cannot catch up: it
+    // publishes continuously, and each new decision shifts every later
+    // offset, so items slide past the cursor unseen. Oldest-first converges
+    // because new decisions land at the end, behind the cursor.
+    traversal: [
+      {
+        name: "backfill",
+        buildRequest: (page) => listRequest(page, "ASC"),
+        then: "live",
       },
-    }),
+      {
+        name: "live",
+        buildRequest: (page) => listRequest(page, "DESC"),
+        then: null,
+      },
+    ],
 
     parseResponse: async (response) => {
       const json: unknown = await response.json();

--- a/apps/api/src/handlers/case-law/ingestion/adapters/sk-courts.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/sk-courts.ts
@@ -370,12 +370,12 @@ export const skCourtsAdapter: SourceAdapter = {
       {
         name: "backfill",
         buildRequest: (page) => listRequest(page, "ASC"),
-        then: "live",
+        followedBy: "live",
       },
       {
         name: "live",
         buildRequest: (page) => listRequest(page, "DESC"),
-        then: null,
+        followedBy: null,
       },
     ],
 

--- a/apps/api/src/handlers/case-law/ingestion/pipeline.ts
+++ b/apps/api/src/handlers/case-law/ingestion/pipeline.ts
@@ -238,6 +238,7 @@ export const sanitizeResult = (r: IngestionResult): IngestionResult => {
     // Part of the uniqueness key, so it is sanitized like the case number:
     // an invisible char here would make an already-stored decision look new.
     sourceDocumentId: strip(r.sourceDocumentId),
+    sheetNumber: strip(r.sheetNumber),
     fulltext: r.fulltext
       ? collapseSpacedLetters(strip(r.fulltext) ?? "")
       : undefined,
@@ -594,6 +595,7 @@ export const processDecision = async (
         ? {
             sourceId: { eq: sourceId },
             sourceDocumentId: result.sourceDocumentId,
+            sheetNumber: result.sheetNumber,
           }
         : {
             sourceId: { eq: sourceId },

--- a/apps/api/src/scripts/normalize-case-numbers.ts
+++ b/apps/api/src/scripts/normalize-case-numbers.ts
@@ -1,0 +1,109 @@
+/**
+ * Move the sheet number out of `case_number` into `sheet_number`.
+ *
+ * Some sources publish the docket with the sheet number within the court file
+ * appended (`11 C 153/2025-28`). A citation names the docket alone, so while
+ * the sheet stays on the case number nothing matches it, and one case appears
+ * as a separate reference per sheet.
+ *
+ * **Ordering.** A row whose `source_document_id` is still NULL is identified by
+ * its case number, so rewriting that number would collapse distinct rows onto
+ * one key. Such rows are skipped, which makes this safe to run at any time and
+ * makes `backfill-source-document-ids.ts` its prerequisite rather than a
+ * assumption. Run that first; re-run this afterwards to pick up the rest.
+ *
+ * `citation_key` is recomputed in the same statement, since it derives from the
+ * case number and would otherwise keep pointing at the un-normalized form.
+ *
+ * Idempotent: a row already split no longer matches the pattern.
+ *
+ *   bun apps/api/src/scripts/normalize-case-numbers.ts
+ *   bun apps/api/src/scripts/normalize-case-numbers.ts --dry-run
+ */
+
+import { sql } from "drizzle-orm";
+
+import { rootDb } from "@/api/db/root";
+import { isRecord } from "@/api/lib/type-guards";
+
+const BATCH = 2000;
+const DRY_RUN = process.argv.includes("--dry-run");
+
+/**
+ * Trailing `-<digits>` on a docket that already carries a year — the same
+ * shape `splitCaseReference` applies at ingest, expressed in SQL so a batch is
+ * one statement. The year is what keeps references that merely end in a number
+ * (`0T/42/2019`) from being split.
+ */
+const SHEET_PATTERN = String.raw`^(.*/\d{2,4})-(\d+)$`;
+
+const rowCount = (result: unknown): number => {
+  if (Array.isArray(result)) {
+    return result.length;
+  }
+  return isRecord(result) && Array.isArray(result["rows"])
+    ? result["rows"].length
+    : 0;
+};
+
+const firstNumber = (result: unknown, key: string): number => {
+  const rows = Array.isArray(result)
+    ? result
+    : isRecord(result) && Array.isArray(result["rows"])
+      ? result["rows"]
+      : [];
+  const row = rows.at(0);
+  return isRecord(row) && typeof row[key] === "number" ? row[key] : 0;
+};
+
+if (DRY_RUN) {
+  const counts = await rootDb.execute(sql`
+    SELECT
+      count(*) FILTER (WHERE source_document_id IS NOT NULL)::int AS ready,
+      count(*) FILTER (WHERE source_document_id IS NULL)::int AS blocked
+    FROM case_law_decisions
+    WHERE case_number ~ ${SHEET_PATTERN}
+  `);
+  console.info(
+    `carry a sheet number: ${firstNumber(counts, "ready").toLocaleString()} ready, ` +
+      `${firstNumber(counts, "blocked").toLocaleString()} still identified by case number (run the id backfill first)`,
+  );
+  process.exit(0);
+}
+
+/**
+ * Normalize one batch and continue from wherever it stopped. A walk rather
+ * than a loop: each step depends on the previous one having committed.
+ */
+const normalizeFrom = async (done: number): Promise<number> => {
+  const result = await rootDb.execute(sql`
+    WITH batch AS (
+      SELECT id FROM case_law_decisions
+      WHERE case_number ~ ${SHEET_PATTERN}
+        AND source_document_id IS NOT NULL
+      LIMIT ${BATCH}
+    )
+    UPDATE case_law_decisions d
+    SET case_number = regexp_replace(d.case_number, ${SHEET_PATTERN}, ${String.raw`\1`}),
+        sheet_number = regexp_replace(d.case_number, ${SHEET_PATTERN}, ${String.raw`\2`}),
+        citation_key = NULL
+    FROM batch
+    WHERE d.id = batch.id
+    RETURNING d.id
+  `);
+
+  const updated = rowCount(result);
+  if (updated === 0) {
+    return done;
+  }
+  const total = done + updated;
+  console.info(`${total.toLocaleString()} normalized`);
+  return await normalizeFrom(total);
+};
+
+const total = await normalizeFrom(0);
+console.info(
+  `done, ${total.toLocaleString()} rows. Re-run backfill-citation-keys.ts to refill citation_key.`,
+);
+
+process.exit(0);

--- a/apps/api/src/scripts/normalize-case-numbers.ts
+++ b/apps/api/src/scripts/normalize-case-numbers.ts
@@ -37,22 +37,21 @@ const DRY_RUN = process.argv.includes("--dry-run");
  */
 const SHEET_PATTERN = String.raw`^(.*/\d{2,4})-(\d+)$`;
 
-const rowCount = (result: unknown): number => {
+/** Rows from `execute` under either driver shape (bare array or `{ rows }`). */
+const executedRows = (result: unknown): unknown[] => {
   if (Array.isArray(result)) {
-    return result.length;
+    return result;
   }
-  return isRecord(result) && Array.isArray(result["rows"])
-    ? result["rows"].length
-    : 0;
+  if (isRecord(result) && Array.isArray(result["rows"])) {
+    return result["rows"];
+  }
+  return [];
 };
 
+const rowCount = (result: unknown): number => executedRows(result).length;
+
 const firstNumber = (result: unknown, key: string): number => {
-  const rows = Array.isArray(result)
-    ? result
-    : isRecord(result) && Array.isArray(result["rows"])
-      ? result["rows"]
-      : [];
-  const row = rows.at(0);
+  const row = executedRows(result).at(0);
   return isRecord(row) && typeof row[key] === "number" ? row[key] : 0;
 };
 


### PR DESCRIPTION
A source sorted newest-first cannot be caught up by walking offsets forward. It publishes continuously, so each new decision shifts every later offset and items slide past the cursor unseen — the crawl runs indefinitely without converging. Walking oldest-first does converge, because new decisions land at the end, behind the cursor, and the offsets already walked never move. It is the wrong order to *stay* current in, though, so a source needs both.

Adapters can now declare their walks and which follows which:

```ts
traversal: [
  { name: "backfill", buildRequest: (page) => listRequest(page, "ASC"), then: "live" },
  { name: "live", buildRequest: (page) => listRequest(page, "DESC"), then: null },
]
```

**The active walk lives in the cursor** (`backfill:1200` → `live:0`), not in the caller. If the caller chose it per run, a restart, a redeploy, or a second caller would each have to remember where the crawl got to, and a wrong guess either re-walks the whole collection or skips the tail. Persisting it means the phase survives all three and is self-describing; a caller that wants to force a re-walk still can, by setting the cursor.

The handover happens only when a walk has actually reached the end of the collection, so the switch is a fact about the crawl rather than a guess, and it is logged (`case_law.ingestion.traversal_advanced`).

A cursor written before an adapter declared its walks names no walk, and cannot be carried into one — an offset counted newest-first points somewhere unrelated oldest-first. Such a cursor restarts the first walk, which is what catching up needs anyway. Adapters that declare no `traversal` are untouched and keep `buildRequest` and `offset:` cursors.

sk-courts is the first to declare both. It is the source where this matters most: it publishes ~4.67M decisions and we hold a fraction of them, which a forward walk over a newest-first list cannot close.