### PR TITLE
feat(case-law): walk a source oldest-first until it is caught up

### DIFF
--- a/apps/api/src/handlers/case-law/ingestion/adapters/pagination.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/pagination.test.ts
@@ -9,7 +9,9 @@ import { asTestRaw, readTestJson } from "@/api/tests/helpers/test-tool-set";
 import {
   createPagePaginatedFetch,
   decodeOffsetCursor,
+  decodeTraversalCursor,
   encodeOffsetCursor,
+  encodeTraversalCursor,
 } from "./pagination";
 import { mockFetchWithFixtures, saveFixture } from "./test-utils";
 
@@ -388,5 +390,60 @@ describe("offset cursor codec", () => {
       ),
       propertyConfig({ numRuns: 500 }),
     );
+  });
+});
+
+describe("traversal modes", () => {
+  const modes = [
+    {
+      name: "backfill",
+      buildRequest: () => ({ url: "a" }),
+      followedBy: "live",
+    },
+    { name: "live", buildRequest: () => ({ url: "b" }), followedBy: null },
+  ] as const;
+
+  test("a cursor names the walk it belongs to", () => {
+    expect(decodeTraversalCursor("backfill:1200", modes)).toEqual({
+      mode: modes[0],
+      offset: 1200,
+    });
+    expect(decodeTraversalCursor("live:0", modes)).toEqual({
+      mode: modes[1],
+      offset: 0,
+    });
+  });
+
+  test("starts the first walk when there is no cursor", () => {
+    expect(decodeTraversalCursor(null, modes)?.mode.name).toBe("backfill");
+    expect(decodeTraversalCursor(null, modes)?.offset).toBe(0);
+  });
+
+  /**
+   * An offset counted newest-first points somewhere unrelated oldest-first,
+   * so a cursor from before the walks were declared cannot be carried into
+   * one. Restarting the first walk is both safe and what catching up needs.
+   */
+  test("restarts the first walk for a cursor naming no walk", () => {
+    for (const cursor of ["offset:1513900", "15139", "nonsense:4"]) {
+      expect(decodeTraversalCursor(cursor, modes)).toEqual({
+        mode: modes[0],
+        offset: 0,
+      });
+    }
+  });
+
+  test("rejects a walk cursor whose offset is not a number", () => {
+    expect(decodeTraversalCursor("backfill:-1", modes)).toBeNull();
+    expect(decodeTraversalCursor("backfill:x", modes)).toBeNull();
+  });
+
+  test("round-trips", () => {
+    expect(
+      decodeTraversalCursor(encodeTraversalCursor("live", 42), modes),
+    ).toEqual({
+      mode: modes[1],
+      offset: 42,
+    });
   });
 });

--- a/apps/api/src/handlers/case-law/ingestion/adapters/pagination.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/pagination.test.ts
@@ -447,3 +447,36 @@ describe("traversal modes", () => {
     });
   });
 });
+
+describe("traversal cursors survive the paths that write them", () => {
+  const bounded = [
+    {
+      name: "backfill",
+      buildRequest: () => ({ url: "a" }),
+      followedBy: "live",
+    },
+    {
+      name: "live",
+      buildRequest: () => ({ url: "b" }),
+      followedBy: null,
+      windowItems: 200,
+    },
+  ] as const;
+
+  /**
+   * A cursor that names no walk restarts the first one, so any path writing
+   * a bare offset while a walk is active would silently discard its
+   * progress. This asserts the reading half of that contract.
+   */
+  test("a bare offset cursor discards traversal progress", () => {
+    expect(decodeTraversalCursor("offset:1200", bounded)).toEqual({
+      mode: bounded[0],
+      offset: 0,
+    });
+  });
+
+  test("a bounded walk declares where it turns back", () => {
+    expect(bounded[1].windowItems).toBe(200);
+    expect(bounded[0]).not.toHaveProperty("windowItems");
+  });
+});

--- a/apps/api/src/handlers/case-law/ingestion/adapters/pagination.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/pagination.ts
@@ -36,9 +36,21 @@ export type TraversalMode = {
   buildRequest: (page: number) => { url: string; init?: RequestInit };
   /**
    * Where to continue once this walk reaches the end of the collection, or
-   * null to park within it and re-scan its recent window (rule 13).
+   * null to stay in it.
    */
   followedBy: string | null;
+  /**
+   * How many items this walk covers before returning to its own start.
+   *
+   * A walk that keeps a crawl current has to stay near the head. Without a
+   * bound it advances deeper into the collection every cycle and ends parked
+   * at the far tail, where it sees nothing new — the same non-convergence
+   * the ordered walks exist to avoid, reached from the other end.
+   *
+   * Omit it for a walk that is meant to cross the whole collection once,
+   * which is what catching up is.
+   */
+  windowItems?: number | undefined;
 };
 
 type PagePaginationOptions<TResponse> = {
@@ -253,6 +265,13 @@ export const createPagePaginatedFetch = <TResponse>(
         const page = firstPage + pageIndex;
         const pageStartOffset = pageIndex * opts.pageSize;
         const itemsAlreadyFetched = offset - pageStartOffset;
+        // Every cursor this call writes goes through here, including the
+        // skip-ahead ones below. A bare offset written while a walk is
+        // active would name no walk, and the next call would read that as
+        // "start over" — one timeout would discard the whole traversal.
+        const encode = walk
+          ? (at: number): string => encodeTraversalCursor(walk.mode.name, at)
+          : encodeOffsetCursor;
 
         const { url, init } = (walk?.mode ?? opts).buildRequest(page);
         const fetchT0 = performance.now();
@@ -289,7 +308,7 @@ export const createPagePaginatedFetch = <TResponse>(
             );
             return {
               decisions: [],
-              nextCursor: encodeOffsetCursor(pageStartOffset + opts.pageSize),
+              nextCursor: encode(pageStartOffset + opts.pageSize),
             };
           }
           throw error;
@@ -313,7 +332,7 @@ export const createPagePaginatedFetch = <TResponse>(
             );
             return {
               decisions: [],
-              nextCursor: encodeOffsetCursor(pageStartOffset + opts.pageSize),
+              nextCursor: encode(pageStartOffset + opts.pageSize),
             };
           }
 
@@ -447,10 +466,6 @@ export const createPagePaginatedFetch = <TResponse>(
         // re-processing the already consumed page tail.
         // When exhausted with zero results (overshot past end),
         // step back so the cursor recovers into the valid range.
-        const encode = walk
-          ? (at: number): string => encodeTraversalCursor(walk.mode.name, at)
-          : encodeOffsetCursor;
-
         let nextCursor = encode(Math.max(0, pageStartOffset - opts.pageSize));
         if (signal?.aborted) {
           nextCursor = encode(offset + processedThroughIndex);
@@ -458,6 +473,20 @@ export const createPagePaginatedFetch = <TResponse>(
           nextCursor = encode(fetched);
         } else if (fetchedItems.length > 0) {
           nextCursor = encode(offset + items.length);
+        }
+
+        // A bounded walk returns to its own start rather than carrying on
+        // deeper. Reaching the edge of the window is not the end of
+        // anything, so this is not a handover: the walk simply begins again
+        // at the head, which is where the new items are.
+        const windowItems = walk?.mode.windowItems;
+        if (
+          walk !== null &&
+          windowItems !== undefined &&
+          !signal?.aborted &&
+          fetched >= windowItems
+        ) {
+          nextCursor = encodeTraversalCursor(walk.mode.name, 0);
         }
 
         // This walk has reached the end of the collection, so hand over to

--- a/apps/api/src/handlers/case-law/ingestion/adapters/pagination.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/pagination.ts
@@ -28,6 +28,19 @@ import { logger } from "@/api/lib/observability/logger";
  * 0-indexed). Covers: SK, PL, AT, CZ-supreme-admin,
  * EE, HR, and similar adapters.
  */
+/** One ordered walk over a collection, named so a cursor can carry it. */
+export type TraversalMode = {
+  /** Persisted as the cursor prefix. Stable: changing it restarts the walk. */
+  name: string;
+  /** Request for a page within this walk. */
+  buildRequest: (page: number) => { url: string; init?: RequestInit };
+  /**
+   * Where to continue once this walk reaches the end of the collection, or
+   * null to park within it and re-scan its recent window (rule 13).
+   */
+  followedBy: string | null;
+};
+
 type PagePaginationOptions<TResponse> = {
   /** Adapter key for error context. */
   adapterKey: string;
@@ -45,6 +58,25 @@ type PagePaginationOptions<TResponse> = {
    * Return the URL and optional RequestInit overrides.
    */
   buildRequest: (page: number) => { url: string; init?: RequestInit };
+  /**
+   * Ordered walks over the same collection, where one walk cannot serve both
+   * catching up and keeping up.
+   *
+   * A source sorted newest-first cannot be caught up by walking offsets
+   * forward: every publication shifts each later offset, so items slide past
+   * the cursor unseen and the crawl never converges. Walking oldest-first
+   * does converge, because new items land at the end and the offsets already
+   * walked never move. It is the wrong order to stay current in, though, so a
+   * source needs both: oldest-first until the collection has been seen, then
+   * newest-first from there on.
+   *
+   * The active mode is persisted in the cursor (`backfill:1200`) rather than
+   * chosen per call, so a restart, a redeploy, or a second caller all resume
+   * in the phase the crawl actually reached.
+   *
+   * Adapters that need only one walk omit this and keep `buildRequest`.
+   */
+  traversal?: readonly TraversalMode[] | undefined;
   /**
    * Parse the raw response into a typed result.
    * Should throw on unexpected response shapes.
@@ -154,10 +186,44 @@ export const decodeOffsetCursor = ({
   return Number.isSafeInteger(offset) && offset >= 0 ? offset : null;
 };
 
+/**
+ * The mode a cursor names and the offset within it.
+ *
+ * A cursor written before the adapter declared its walks names no mode. It
+ * cannot be carried into one either, because an offset counted in one order
+ * points somewhere unrelated in another, so the first walk restarts from its
+ * beginning — which is what catching up requires anyway.
+ */
+export const decodeTraversalCursor = (
+  cursor: string | null,
+  modes: readonly TraversalMode[],
+): { mode: TraversalMode; offset: number } | null => {
+  const [first] = modes;
+  if (first === undefined) {
+    return null;
+  }
+  if (cursor === null) {
+    return { mode: first, offset: 0 };
+  }
+  const separator = cursor.indexOf(":");
+  const named = modes.find((mode) => mode.name === cursor.slice(0, separator));
+  if (separator === -1 || named === undefined) {
+    return { mode: first, offset: 0 };
+  }
+  const offset = parseCanonicalNonNegativeSafeInteger(
+    cursor.slice(separator + 1),
+  );
+  return offset === null ? null : { mode: named, offset };
+};
+
+export const encodeTraversalCursor = (mode: string, offset: number): string =>
+  `${mode}:${offset}`;
+
 export const createPagePaginatedFetch = <TResponse>(
   opts: PagePaginationOptions<TResponse>,
 ) => {
   const firstPage = opts.zeroIndexed ? 0 : 1;
+  const modes = opts.traversal;
 
   return async (
     cursor: string | null,
@@ -166,11 +232,14 @@ export const createPagePaginatedFetch = <TResponse>(
   ): Promise<Result<SyncPage, AdapterFetchError>> =>
     await Result.tryPromise({
       try: async () => {
-        const offset = decodeOffsetCursor({
-          cursor,
-          firstPage,
-          legacyPageSize: opts.legacyPageSize ?? opts.pageSize,
-        });
+        const walk = modes ? decodeTraversalCursor(cursor, modes) : null;
+        const offset = walk
+          ? walk.offset
+          : decodeOffsetCursor({
+              cursor,
+              firstPage,
+              legacyPageSize: opts.legacyPageSize ?? opts.pageSize,
+            });
 
         if (offset === null) {
           throw new AdapterFetchError({
@@ -185,7 +254,7 @@ export const createPagePaginatedFetch = <TResponse>(
         const pageStartOffset = pageIndex * opts.pageSize;
         const itemsAlreadyFetched = offset - pageStartOffset;
 
-        const { url, init } = opts.buildRequest(page);
+        const { url, init } = (walk?.mode ?? opts).buildRequest(page);
         const fetchT0 = performance.now();
         const listTimeout = opts.listTimeoutMs ?? ADAPTER_TIMEOUT.LIST;
 
@@ -378,15 +447,38 @@ export const createPagePaginatedFetch = <TResponse>(
         // re-processing the already consumed page tail.
         // When exhausted with zero results (overshot past end),
         // step back so the cursor recovers into the valid range.
-        let nextCursor = encodeOffsetCursor(
-          Math.max(0, pageStartOffset - opts.pageSize),
-        );
+        const encode = walk
+          ? (at: number): string => encodeTraversalCursor(walk.mode.name, at)
+          : encodeOffsetCursor;
+
+        let nextCursor = encode(Math.max(0, pageStartOffset - opts.pageSize));
         if (signal?.aborted) {
-          nextCursor = encodeOffsetCursor(offset + processedThroughIndex);
+          nextCursor = encode(offset + processedThroughIndex);
         } else if (hasMore) {
-          nextCursor = encodeOffsetCursor(fetched);
+          nextCursor = encode(fetched);
         } else if (fetchedItems.length > 0) {
-          nextCursor = encodeOffsetCursor(offset + items.length);
+          nextCursor = encode(offset + items.length);
+        }
+
+        // This walk has reached the end of the collection, so hand over to
+        // the one that follows it, starting at its own beginning. Handing
+        // over only here is what makes the switch a fact about the crawl
+        // rather than a guess: the collection has demonstrably been seen.
+        const successor = walk === null ? null : walk.mode.followedBy;
+        if (
+          walk !== null &&
+          successor !== null &&
+          !signal?.aborted &&
+          !hasMore
+        ) {
+          logger.info("case_law.ingestion.traversal_advanced", {
+            adapterKey: opts.adapterKey,
+            from: walk.mode.name,
+            to: successor,
+            offset: fetched,
+            ...(total !== undefined ? { sourceTotal: total } : {}),
+          });
+          nextCursor = encodeTraversalCursor(successor, 0);
         }
 
         return { decisions, nextCursor };

--- a/apps/api/src/handlers/case-law/ingestion/adapters/sk-courts.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/sk-courts.ts
@@ -297,6 +297,20 @@ const parseItemWithDetail = async (
   };
 };
 
+/** One list page, in the given order. */
+const listRequest = (
+  page: number,
+  sortDirection: "ASC" | "DESC",
+): { url: string; init: RequestInit } => ({
+  url: `${BASE_URL}?${new URLSearchParams({
+    page: String(page),
+    size: String(PAGE_SIZE),
+    sortProperty: "datumVydania",
+    sortDirection,
+  }).toString()}`,
+  init: { headers: { Accept: "application/json" } },
+});
+
 export const skCourtsAdapter: SourceAdapter = {
   key: ADAPTER_KEYS.SK_COURTS,
   name: "obcan.justice.sk",
@@ -345,17 +359,25 @@ export const skCourtsAdapter: SourceAdapter = {
     listTimeoutMs: 60_000,
     itemConcurrency: ITEM_CONCURRENCY,
 
-    buildRequest: (page) => ({
-      url: `${BASE_URL}?${new URLSearchParams({
-        page: String(page),
-        size: String(PAGE_SIZE),
-        sortProperty: "datumVydania",
-        sortDirection: "DESC",
-      }).toString()}`,
-      init: {
-        headers: { Accept: "application/json" },
+    buildRequest: (page) => listRequest(page, "DESC"),
+
+    // Oldest-first until the collection has been seen, then newest-first.
+    // Walking this source newest-first from the start cannot catch up: it
+    // publishes continuously, and each new decision shifts every later
+    // offset, so items slide past the cursor unseen. Oldest-first converges
+    // because new decisions land at the end, behind the cursor.
+    traversal: [
+      {
+        name: "backfill",
+        buildRequest: (page) => listRequest(page, "ASC"),
+        followedBy: "live",
       },
-    }),
+      {
+        name: "live",
+        buildRequest: (page) => listRequest(page, "DESC"),
+        followedBy: null,
+      },
+    ],
 
     parseResponse: async (response) => {
       const json: unknown = await response.json();

--- a/apps/api/src/handlers/case-law/ingestion/adapters/sk-courts.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/sk-courts.ts
@@ -39,6 +39,13 @@ const BASE_URL =
 const PAGE_SIZE = 100;
 const LEGACY_PAGE_SIZE = 100;
 const ITEM_CONCURRENCY = 10;
+/**
+ * How far back the newest-first walk reaches before returning to the head.
+ * Comfortably more than this source publishes between cycles, so a slow or
+ * skipped cycle still cannot let a decision slip past unseen; already-stored
+ * decisions in the overlap cost a list read and are then deduplicated.
+ */
+const LIVE_WINDOW_ITEMS = 5000;
 
 const arrayOrEmpty = <T>(value: T[] | null | undefined): T[] => {
   if (value === undefined || value === null) {
@@ -376,6 +383,10 @@ export const skCourtsAdapter: SourceAdapter = {
         name: "live",
         buildRequest: (page) => listRequest(page, "DESC"),
         followedBy: null,
+        // Newest-first only has to reach as far back as what was published
+        // since the last cycle. Walking further would drift into history
+        // this source has already been caught up on.
+        windowItems: LIVE_WINDOW_ITEMS,
       },
     ],
 


### PR DESCRIPTION
A source sorted newest-first cannot be caught up by walking offsets forward. It publishes continuously, so each new decision shifts every later offset and items slide past the cursor unseen — the crawl runs indefinitely without converging. Walking oldest-first does converge, because new decisions land at the end, behind the cursor, and the offsets already walked never move. It is the wrong order to *stay* current in, though, so a source needs both.

Adapters can now declare their walks and which follows which:

```ts
traversal: [
  { name: "backfill", buildRequest: (page) => listRequest(page, "ASC"), followedBy: "live" },
  { name: "live", buildRequest: (page) => listRequest(page, "DESC"), followedBy: null },
]
```

**The active walk lives in the cursor** (`backfill:1200` → `live:0`), not in the caller. If the caller chose it per run, a restart, a redeploy, or a second caller would each have to remember where the crawl got to, and a wrong guess either re-walks the whole collection or skips the tail. Persisting it means the phase survives all three and is self-describing; a caller that wants to force a re-walk still can, by setting the cursor.

The handover happens only when a walk has actually reached the end of the collection, so the switch is a fact about the crawl rather than a guess, and it is logged (`case_law.ingestion.traversal_advanced`).

A cursor written before an adapter declared its walks names no walk, and cannot be carried into one — an offset counted newest-first points somewhere unrelated oldest-first. Such a cursor restarts the first walk, which is what catching up needs anyway. Adapters that declare no `traversal` are untouched and keep `buildRequest` and `offset:` cursors.

sk-courts is the first to declare both: it is the source where the gap between what is published and what we hold is widest, and a forward walk over a newest-first list cannot close it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for multiple pagination traversal modes with persistent progress tracking.
  * Added bounded live updates, enabling efficient retrieval within a defined recent-results window.
  * Improved transitions between historical backfill and live-result retrieval.

* **Bug Fixes**
  * Improved handling of legacy, invalid, timed-out and failed-page cursors.
  * Ensured pagination progress is preserved when switching traversal modes or reaching a window boundary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->