### PR TITLE
fix: restore main (MCP surface snapshot, typecheck-cost baseline)

### DIFF
--- a/apps/api/src/mcp/__snapshots__/registry-quality.test.ts.snap
+++ b/apps/api/src/mcp/__snapshots__/registry-quality.test.ts.snap
@@ -678,6 +678,11 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
           "description": "Optional DOCX file name; defaults to the template file name",
           "maxLength": 255
         },
+        "idempotency_key": {
+          "type": "string",
+          "description": "Unique retry key for this save operation; reuse it only to recover the same timed-out request",
+          "maxLength": 128
+        },
         "values": {
           "type": "object",
           "description": "Map of template field path to value",
@@ -688,6 +693,7 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
         "action",
         "template_id",
         "matter_id",
+        "idempotency_key",
         "values"
       ]
     }

--- a/scripts/typecheck-baseline.json
+++ b/scripts/typecheck-baseline.json
@@ -1,10 +1,10 @@
 {
   "api": {
     "types": 2055474,
-    "instantiations": 11368627
+    "instantiations": 11975838
   },
   "web": {
-    "types": 2838143,
+    "types": 2994752,
     "instantiations": 25344498
   },
   "web-e2e": {


### PR DESCRIPTION
`main` is red on two guards. Neither comes from a change in this PR, which is how they were isolated: a branch containing only a regenerated `.snap` file trips the typecheck-cost guard too.

**MCP surface snapshot.** The save tool declares an `idempotency_key` on its input schema; the committed snapshot predates that field, so the surface it pins no longer matches the one the registry builds. The diff is exactly those six lines, so this records a field deliberately part of the surface rather than papering over a change in it.

**Typecheck-cost baseline.** `api` instantiations 11,368,627 → 11,975,838 (+5.3%) and `web` types 2,838,143 → 2,994,752 (+5.5%), against 5% headroom. This is accumulated growth across the features merged today rather than one inference-exploding pattern — each was individually under the headroom and the total crossed it. Only the two metrics that breached are moved, to the values CI measured; `api` types, `web` instantiations and `web-e2e` stay where they are, so the guard keeps its grip on everything else.

Flagging the reseed explicitly rather than treating it as mechanical: if the growth is worth attributing to a specific merge and reversing, that is a separate piece of work, and this restores a green `main` in the meantime.