### PR TITLE
fix: keep landing anonymization demo CSP-compatible

### DIFF
--- a/apps/landing/astro.config.mjs
+++ b/apps/landing/astro.config.mjs
@@ -6,6 +6,16 @@ import { defineConfig } from "astro/config";
 import stllAnonymizeWasm from "@stll/anonymize-wasm/vite";
 import { UI_LOCALES } from "@stll/locales";
 
+// Keep this aligned with the production CDN response-headers policy.
+// `wasm-unsafe-eval` permits WebAssembly compilation without enabling
+// JavaScript eval; COOP/COEP expose SharedArrayBuffer to the threaded runtime.
+const LANDING_SECURITY_HEADERS = {
+  "Content-Security-Policy":
+    "default-src 'self'; script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; media-src 'self' https://github.com https://*.githubusercontent.com https://objects.githubusercontent.com https://*.s3.amazonaws.com; connect-src 'self' https://api.github.com; frame-ancestors 'none'",
+  "Cross-Origin-Opener-Policy": "same-origin",
+  "Cross-Origin-Embedder-Policy": "credentialless",
+};
+
 // Derived from @stll/locales so routing + sitemap locales equal the app's UI
 // locales (mirrors src/i18n/config.ts). Default locale (en) sits at root; the
 // rest under a lowercased path prefix (/es/, /pt-br/, /ar/, /de/, ...).
@@ -26,10 +36,7 @@ export default defineConfig({
   // the deployed site's actual host/CDN must send the same pair in
   // production or the demo will fail there even though it works locally.
   server: {
-    headers: {
-      "Cross-Origin-Opener-Policy": "same-origin",
-      "Cross-Origin-Embedder-Policy": "credentialless",
-    },
+    headers: LANDING_SECURITY_HEADERS,
   },
   i18n: {
     defaultLocale: "en",
@@ -68,10 +75,7 @@ export default defineConfig({
     // not reliably reach every dev response. `astro preview` and production
     // still rely on the top-level/host headers documented above.
     server: {
-      headers: {
-        "Cross-Origin-Opener-Policy": "same-origin",
-        "Cross-Origin-Embedder-Policy": "credentialless",
-      },
+      headers: LANDING_SECURITY_HEADERS,
     },
     // Emits @stll/anonymize-wasm's binding + glue as build assets and
     // rewrites its runtime asset URLs so `astro build` (Vite/Rollup) can

--- a/apps/landing/src/components/react/AnonymizeLiveDemo.tsx
+++ b/apps/landing/src/components/react/AnonymizeLiveDemo.tsx
@@ -170,7 +170,7 @@ const buildSegments = (
 type EngineState =
   | { status: "warming" }
   | { status: "ready"; pairs: readonly HighlightPair[] }
-  | { status: "error"; message: string };
+  | { status: "error" };
 
 /**
  * Which detection the backdrop renders. `precomputed` only ever applies to the
@@ -217,17 +217,11 @@ export const AnonymizeLiveDemo = () => {
         }
         return;
       })
-      .catch((error: unknown) => {
+      .catch(() => {
         if (requestId !== latestRequestRef.current) {
           return;
         }
-        setEngine({
-          status: "error",
-          message:
-            error instanceof Error
-              ? error.message
-              : "The anonymisation engine hit an error.",
-        });
+        setEngine({ status: "error" });
       });
   };
 
@@ -381,7 +375,7 @@ const describeEngineStatus = (
         : "Reading your text…";
     }
     case "error": {
-      return engine.message;
+      return "Something went wrong.";
     }
     case "ready": {
       if (highlights.pairs.length === 0) {

--- a/apps/web/e2e/marketing/landing-anonymize-demo.spec.ts
+++ b/apps/web/e2e/marketing/landing-anonymize-demo.spec.ts
@@ -113,6 +113,21 @@ test("live anonymization demo highlights a city as an address", async ({
     .toMatchObject({ highlighted: [CITY], legend: [ADDRESS_LEGEND] });
 });
 
+test("live anonymization demo does not expose runtime errors", async ({
+  page,
+}) => {
+  await page.route(/\.wasm(?:\?|$)/u, async (route) => {
+    await route.abort("failed");
+  });
+  await page.goto(DEMO_URL, { waitUntil: "domcontentloaded" });
+
+  await expect(page.locator(DEMO_SELECTORS.textarea)).toBeVisible();
+  await expect(page.locator(DEMO_SELECTORS.status)).toHaveText(
+    "Something went wrong.",
+    { timeout: 30_000 },
+  );
+});
+
 // The engine is hundreds of kilobytes of wasm plus name and city
 // dictionaries, so the demo would otherwise open on a loading line and show a
 // visitor nothing until all of it lands. The island renders the untouched

--- a/apps/web/src/features/chat/hooks/use-chat-session-created-document.logic.ts
+++ b/apps/web/src/features/chat/hooks/use-chat-session-created-document.logic.ts
@@ -10,6 +10,8 @@ export const invalidateCreatedDocumentQueries = async ({
   queryClient,
 }: InvalidateCreatedDocumentQueriesOptions): Promise<void> => {
   await Promise.all(
-    queryKeys.map((queryKey) => queryClient.invalidateQueries({ queryKey })),
+    queryKeys.map(async (queryKey) => {
+      await queryClient.invalidateQueries({ queryKey });
+    }),
   );
 };


### PR DESCRIPTION
Allow the landing demo's WebAssembly worker through the narrow CSP source token, apply equivalent headers during local preview, and keep runtime details out of the visitor-facing fallback. The browser regression covers both successful detection and the generic failure state.