### PR TITLE
fix(api): classify a stream run error whose provider body arrives in the message

### DIFF
--- a/apps/api/src/handlers/chat/stream-chat.test.ts
+++ b/apps/api/src/handlers/chat/stream-chat.test.ts
@@ -685,6 +685,71 @@ describe("outgoing chat stream message ids", () => {
     ]);
   });
 
+  test("classifies a run error whose body arrives in the message", async () => {
+    const messageId = toSafeId<"chatMessage">(
+      "11111111-1111-4111-8111-111111111111",
+    );
+    const stream = processServerChatStream({
+      abortSignal: new AbortController().signal,
+      getResponseMessage: () => null,
+      mapMessageId: createChatMessageIdMapper(() => messageId),
+      onFinish: () => {
+        throw new Error("Expected run error not to finish");
+      },
+      processor: new StreamProcessor(),
+      source: streamChunks([
+        { type: EventType.RUN_STARTED, runId: "run-1", threadId: "thread-1" },
+        {
+          type: EventType.RUN_ERROR,
+          message: JSON.stringify({
+            error: {
+              code: 503,
+              message: "The model is currently overloaded.",
+              status: "UNAVAILABLE",
+            },
+          }),
+        },
+      ]),
+    });
+
+    expect(stripTimestamps(await collectChunks(stream))).toEqual([
+      { type: EventType.RUN_STARTED, runId: "run-1", threadId: "thread-1" },
+      {
+        type: EventType.RUN_ERROR,
+        message: "provider_unavailable",
+        code: "provider_unavailable",
+      },
+    ]);
+  });
+
+  test("leaves a plain-text run error unclassified", async () => {
+    const messageId = toSafeId<"chatMessage">(
+      "11111111-1111-4111-8111-111111111111",
+    );
+    const stream = processServerChatStream({
+      abortSignal: new AbortController().signal,
+      getResponseMessage: () => null,
+      mapMessageId: createChatMessageIdMapper(() => messageId),
+      onFinish: () => {
+        throw new Error("Expected run error not to finish");
+      },
+      processor: new StreamProcessor(),
+      source: streamChunks([
+        { type: EventType.RUN_STARTED, runId: "run-1", threadId: "thread-1" },
+        { type: EventType.RUN_ERROR, message: "something went wrong" },
+      ]),
+    });
+
+    expect(stripTimestamps(await collectChunks(stream))).toEqual([
+      { type: EventType.RUN_STARTED, runId: "run-1", threadId: "thread-1" },
+      {
+        type: EventType.RUN_ERROR,
+        message: "unknown",
+        code: "unknown",
+      },
+    ]);
+  });
+
   test("does not finish successfully after an in-band run error", async () => {
     const messageId = toSafeId<"chatMessage">(
       "11111111-1111-4111-8111-111111111111",

--- a/apps/api/src/handlers/chat/stream-chat.test.ts
+++ b/apps/api/src/handlers/chat/stream-chat.test.ts
@@ -722,6 +722,34 @@ describe("outgoing chat stream message ids", () => {
     ]);
   });
 
+  test("classifies a run error body behind leading whitespace", async () => {
+    const messageId = toSafeId<"chatMessage">(
+      "11111111-1111-4111-8111-111111111111",
+    );
+    const stream = processServerChatStream({
+      abortSignal: new AbortController().signal,
+      getResponseMessage: () => null,
+      mapMessageId: createChatMessageIdMapper(() => messageId),
+      onFinish: () => {
+        throw new Error("Expected run error not to finish");
+      },
+      processor: new StreamProcessor(),
+      source: streamChunks([
+        { type: EventType.RUN_STARTED, runId: "run-1", threadId: "thread-1" },
+        {
+          type: EventType.RUN_ERROR,
+          message: `\n  ${JSON.stringify({ error: { code: 429 } })}`,
+        },
+      ]),
+    });
+
+    expect(stripTimestamps(await collectChunks(stream)).at(-1)).toEqual({
+      type: EventType.RUN_ERROR,
+      message: "quota_exhausted",
+      code: "quota_exhausted",
+    });
+  });
+
   test("leaves a plain-text run error unclassified", async () => {
     const messageId = toSafeId<"chatMessage">(
       "11111111-1111-4111-8111-111111111111",

--- a/apps/api/src/handlers/chat/stream-chat.ts
+++ b/apps/api/src/handlers/chat/stream-chat.ts
@@ -923,8 +923,36 @@ const errorFromRunErrorChunk = (chunk: RunErrorChunk): Error => {
   return error;
 };
 
+// An adapter forwards the provider's structured error body as `rawEvent` only
+// when the SDK exception exposes one. An exception that carries the status as a
+// plain field and stringifies the response body into its message arrives with
+// neither `rawEvent` nor `code`, so the error rebuilt from the chunk holds no
+// status at all and every failure from that provider — quota, billing, retired
+// model and outage alike — falls to `unknown`. Recover the body from the
+// message when the message is one. It is read for classification only and
+// never logged: a provider message can echo request content.
+const isErrorBodyRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null;
+
+const providerErrorBody = (
+  message: string,
+): Record<string, unknown> | undefined => {
+  if (!message.startsWith("{")) {
+    return undefined;
+  }
+  const parsed = Result.try((): unknown => JSON.parse(message));
+  if (Result.isError(parsed)) {
+    return undefined;
+  }
+  return isErrorBodyRecord(parsed.value) ? parsed.value : undefined;
+};
+
 const classifyRunErrorChunk = (chunk: RunErrorChunk): AIErrorKind =>
-  classifyAIError(chunk.rawEvent ?? errorFromRunErrorChunk(chunk));
+  classifyAIError(
+    chunk.rawEvent ??
+      providerErrorBody(runErrorMessage(chunk)) ??
+      errorFromRunErrorChunk(chunk),
+  );
 
 // Classified kinds (quota, billing, retired model, provider outage) are
 // expected operational states; `unknown` means a failure shape this code

--- a/apps/api/src/handlers/chat/stream-chat.ts
+++ b/apps/api/src/handlers/chat/stream-chat.ts
@@ -927,8 +927,8 @@ const errorFromRunErrorChunk = (chunk: RunErrorChunk): Error => {
 // when the SDK exception exposes one. An exception that carries the status as a
 // plain field and stringifies the response body into its message arrives with
 // neither `rawEvent` nor `code`, so the error rebuilt from the chunk holds no
-// status at all and every failure from that provider — quota, billing, retired
-// model and outage alike — falls to `unknown`. Recover the body from the
+// status at all, and every failure from that provider (quota, billing, retired
+// model and outage alike) falls to `unknown`. Recover the body from the
 // message when the message is one. It is read for classification only and
 // never logged: a provider message can echo request content.
 const isErrorBodyRecord = (value: unknown): value is Record<string, unknown> =>
@@ -937,7 +937,9 @@ const isErrorBodyRecord = (value: unknown): value is Record<string, unknown> =>
 const providerErrorBody = (
   message: string,
 ): Record<string, unknown> | undefined => {
-  if (!message.startsWith("{")) {
+  // `JSON.parse` skips leading whitespace, so the guard must too; otherwise a
+  // body an adapter passed through verbatim would be dropped over a newline.
+  if (!message.trimStart().startsWith("{")) {
     return undefined;
   }
   const parsed = Result.try((): unknown => JSON.parse(message));

--- a/apps/api/src/lib/ai-error.test.ts
+++ b/apps/api/src/lib/ai-error.test.ts
@@ -83,6 +83,9 @@ describe("classifyAIError", () => {
     expect(classifyAIError(providerErrorBody(429, "RESOURCE_EXHAUSTED"))).toBe(
       "quota_exhausted",
     );
+    expect(classifyAIError(providerErrorBody(402, "PAYMENT_REQUIRED"))).toBe(
+      "provider_billing",
+    );
     expect(classifyAIError(providerErrorBody(404, "NOT_FOUND"))).toBe(
       "model_unavailable",
     );

--- a/apps/api/src/lib/ai-error.test.ts
+++ b/apps/api/src/lib/ai-error.test.ts
@@ -15,6 +15,15 @@ const tanStackProviderError = (status: number) =>
     message: `provider responded ${status}`,
   }) satisfies Record<string, unknown>;
 
+const providerErrorBody = (code: number, status: string) =>
+  ({
+    error: {
+      code,
+      message: `provider responded ${code}`,
+      status,
+    },
+  }) satisfies Record<string, unknown>;
+
 describe("classifyAIError", () => {
   test("maps chat loop stops to a stable stream error kind", () => {
     const error = new ChatLoopDetectedError({
@@ -65,5 +74,38 @@ describe("classifyAIError", () => {
     expect(classifyAIError(tanStackProviderError(503))).toBe(
       "provider_unavailable",
     );
+  });
+
+  test("reads the status from a nested provider error body", () => {
+    expect(classifyAIError(providerErrorBody(503, "UNAVAILABLE"))).toBe(
+      "provider_unavailable",
+    );
+    expect(classifyAIError(providerErrorBody(429, "RESOURCE_EXHAUSTED"))).toBe(
+      "quota_exhausted",
+    );
+    expect(classifyAIError(providerErrorBody(404, "NOT_FOUND"))).toBe(
+      "model_unavailable",
+    );
+  });
+
+  test("finds a nested provider error body through wrapped causes", () => {
+    const error = new Error("stream failed", {
+      cause: providerErrorBody(503, "UNAVAILABLE"),
+    });
+
+    expect(classifyAIError(error)).toBe("provider_unavailable");
+  });
+
+  test("ignores a nested code that is not an HTTP status", () => {
+    // OpenAI-shaped bodies put a symbolic code where Google puts the status,
+    // and gRPC-shaped ones put a small application code there.
+    expect(
+      classifyAIError({
+        error: { code: "insufficient_quota", message: "out of credits" },
+      }),
+    ).toBe("unknown");
+    expect(
+      classifyAIError({ error: { code: 14, message: "unavailable" } }),
+    ).toBe("unknown");
   });
 });

--- a/apps/api/src/lib/ai-error.ts
+++ b/apps/api/src/lib/ai-error.ts
@@ -51,7 +51,7 @@ const providerStatusCode = (error: unknown): number | null => {
   }
 
   // A provider response body nests the status one level down, as
-  // `{ error: { code, message, status } }` — `code` is the HTTP status and
+  // `{ error: { code, message, status } }`, where `code` is the HTTP status and
   // `status` its symbolic name. Only an integer inside the HTTP range counts,
   // so a body whose `code` is symbolic ("insufficient_quota") or an
   // application error number still falls through to the cause walk.

--- a/apps/api/src/lib/ai-error.ts
+++ b/apps/api/src/lib/ai-error.ts
@@ -23,8 +23,17 @@ export const AI_ERROR_KINDS = [
 
 export type AIErrorKind = (typeof AI_ERROR_KINDS)[number];
 
+const HTTP_STATUS_MIN = 100;
+const HTTP_STATUS_MAX = 599;
+
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   value !== null && typeof value === "object";
+
+const isHttpStatus = (value: unknown): value is number =>
+  typeof value === "number" &&
+  Number.isInteger(value) &&
+  value >= HTTP_STATUS_MIN &&
+  value <= HTTP_STATUS_MAX;
 
 const providerStatusCode = (error: unknown): number | null => {
   if (!isRecord(error)) {
@@ -39,6 +48,23 @@ const providerStatusCode = (error: unknown): number | null => {
   const status = error["status"];
   if (typeof status === "number" && Number.isInteger(status)) {
     return status;
+  }
+
+  // A provider response body nests the status one level down, as
+  // `{ error: { code, message, status } }` — `code` is the HTTP status and
+  // `status` its symbolic name. Only an integer inside the HTTP range counts,
+  // so a body whose `code` is symbolic ("insufficient_quota") or an
+  // application error number still falls through to the cause walk.
+  const body = error["error"];
+  if (isRecord(body)) {
+    const bodyStatus = body["status"];
+    if (isHttpStatus(bodyStatus)) {
+      return bodyStatus;
+    }
+    const bodyCode = body["code"];
+    if (isHttpStatus(bodyCode)) {
+      return bodyCode;
+    }
   }
 
   return null;


### PR DESCRIPTION
## Proposed change

`classifyAIError` (`apps/api/src/lib/ai-error.ts`) finds a provider's HTTP status on `statusCode`, on `status`, or by walking `cause`. The chat stream reaches it through `classifyRunErrorChunk`, which classifies `chunk.rawEvent` when present and otherwise an `Error` rebuilt from the chunk's `message` and `code`.

An adapter populates `rawEvent` only when the SDK exception exposes a structured body object. An exception that instead keeps the status on a plain field and stringifies the response body into its own message produces a `RUN_ERROR` chunk with no `rawEvent` and no `code`, so the rebuilt `Error` carries no status anywhere the classifier looks. Every failure from such a provider therefore classifies as `unknown`, including all four shapes the classifier explicitly names: `quota_exhausted`, `provider_billing`, `model_unavailable` and `provider_unavailable`. Two consequences:

- `normalizeRunErrorChunk` sends `unknown` to the client as the stream's error message and code, so the user gets the generic fallback copy instead of the actionable one (retry, check the provider account, update the configured model).
- `reportStreamFailure` logs at ERROR severity, which its own comment reserves for "a failure shape this code does not anticipate". An upstream outage is anticipated and is not a defect in this code.

The fix reads the status from the two places it can still be found:

- `providerErrorBody` in `stream-chat.ts` parses the chunk message as the provider's error envelope when it is one, and `classifyRunErrorChunk` classifies that before falling back to the rebuilt `Error`. The parsed body is used for classification and nothing else; it is never logged, because a provider message can echo request content, and the logged fingerprint is unchanged.
- `providerStatusCode` in `ai-error.ts` also reads a status nested one level down, under an `error` key, which is where a `{ error: { code, message, status } }` envelope puts it.

Only an integer inside the HTTP range counts as a status there, so a body whose nested `code` is symbolic (`insufficient_quota`) or an application error number keeps falling through to the cause walk as before. Classification only ever widens: an unparseable message, a non-object body, or an unrecognized status all leave the existing `unknown` result in place.

## Checklist

- [x] **BUILD ASSURANCE** | Code builds correctly and without any errors or warnings.
- [x] **TESTING** | Changes tested, including in different conditions (dark mode, language, narrow screen, etc).
- [ ] DARK MODE SUPPORT | User can use the webapp in dark mode. Make sure your changes are visible in both light and dark mode.
- [ ] ISSUE LINKED | Link an issue to this PR (not by mentioning it in the description, but by using the GitHub issue linking feature)
- [ ] SCREENSHOT INCLUDED | If relevant, please include a screenshot / video of the functionality added (allows for a quick check of minor ux changes)

Server-only change, so dark mode and screenshots do not apply.

Verified locally: `bun test src/lib/ai-error.test.ts src/handlers/chat/stream-chat.test.ts` (36 pass, 0 fail), `bun --filter @stll/api lint`, `tsc --noEmit` on `@stll/api`, and `oxfmt` on the touched files. New coverage: a nested envelope classified for 503/429/404 and through a wrapped `cause`; a symbolic and an out-of-range nested `code` both left `unknown`; a `RUN_ERROR` chunk whose message is an envelope normalized to `provider_unavailable`; a plain-text `RUN_ERROR` message still normalized to `unknown`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CmouKTrBNwzLj5DRKvrFCq)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of provider errors embedded in streamed responses.
  - More accurately identifies provider-unavailable failures using valid HTTP status information, including nested error details.
  - Prevents symbolic, invalid, or out-of-range error codes from being misclassified.
  - Retains appropriate unknown-error handling for plain-text and malformed error messages.

- **Tests**
  - Added coverage for direct, nested, JSON-embedded, and invalid provider error formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->