### PR TITLE
fix: require fresh release recordings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -339,6 +339,17 @@ jobs:
           BASE_REF: ${{ github.base_ref || 'main' }}
         run: bash scripts/check-release-changelog.sh --base "origin/$BASE_REF"
 
+      - name: Release marketing freshness guard
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_REF: ${{ github.base_ref || 'main' }}
+        run: |
+          if git diff --quiet "origin/$BASE_REF"...HEAD -- VERSION; then
+            echo "VERSION unchanged; fresh release recordings not required."
+            exit 0
+          fi
+          bun run marketing:stale --strict
+
       - name: Format
         if: needs.ci-changes.outputs.package_checks_required == 'true'
         # Call turbo directly: the `format:check` script already


### PR DESCRIPTION
## Summary

- run the strict marketing freshness check when a pull request changes VERSION
- keep ordinary pull requests outside the release-recording gate

## Testing

- repository pre-commit checks
- GitHub CI pending