### PR TITLE
fix: emit structured API request logs

### DIFF
--- a/apps/api/src/lib/observability/logger.test.ts
+++ b/apps/api/src/lib/observability/logger.test.ts
@@ -3,9 +3,11 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { logger, sanitizeLogAttributes } from "@/api/lib/observability/logger";
 
 const originalStderrWrite = process.stderr.write;
+const originalStdoutWrite = process.stdout.write;
 
 afterEach(() => {
   process.stderr.write = originalStderrWrite;
+  process.stdout.write = originalStdoutWrite;
 });
 
 describe("logger attributes", () => {
@@ -67,5 +69,56 @@ describe("logger attributes", () => {
     expect(output).not.toContain("secret.pdf");
     expect(output).not.toContain("fileName");
     expect(output).not.toContain('"body"');
+  });
+
+  test("request sink emits only structured operational fields", () => {
+    const chunks: string[] = [];
+    process.stdout.write = (chunk: string | Uint8Array): boolean => {
+      chunks.push(typeof chunk === "string" ? chunk : chunk.toString());
+      return true;
+    };
+
+    logger.request({
+      durationMs: 42,
+      errorType: "TaggedError",
+      message: "request.completed",
+      method: "GET",
+      requestId: "safe-request-id",
+      route: "/test/:id",
+      severity: "INFO",
+      statusCode: 200,
+    });
+
+    const output = chunks.join("");
+    expect(JSON.parse(output)).toEqual({
+      severity: "INFO",
+      message: "request.completed",
+      "error.type": "TaggedError",
+      "http.method": "GET",
+      "http.route": "/test/:id",
+      "http.status_code": 200,
+      "request.duration_ms": 42,
+      "request.id": "safe-request-id",
+    });
+  });
+
+  test("request sink never falls back to a raw unmatched URL", () => {
+    const chunks: string[] = [];
+    process.stdout.write = (chunk: string | Uint8Array): boolean => {
+      chunks.push(typeof chunk === "string" ? chunk : chunk.toString());
+      return true;
+    };
+
+    logger.request({
+      durationMs: 1,
+      message: "request.failed",
+      method: "GET",
+      severity: "WARN",
+      statusCode: 404,
+    });
+
+    expect(JSON.parse(chunks.join(""))).toMatchObject({
+      "http.route": "unmatched",
+    });
   });
 });

--- a/apps/api/src/lib/observability/logger.test.ts
+++ b/apps/api/src/lib/observability/logger.test.ts
@@ -80,6 +80,12 @@ describe("logger attributes", () => {
 
     logger.request({
       durationMs: 42,
+      errorFingerprint: {
+        errorClass: "TaggedError",
+        errorCode: "DATABASE_UNAVAILABLE",
+        errorFrame: "src/server.ts:10:2",
+        pgCode: "08006",
+      },
       errorType: "TaggedError",
       message: "request.completed",
       method: "GET",
@@ -94,6 +100,10 @@ describe("logger attributes", () => {
       severity: "INFO",
       message: "request.completed",
       "error.type": "TaggedError",
+      "error.class": "TaggedError",
+      "error.code": "DATABASE_UNAVAILABLE",
+      "error.frame": "src/server.ts:10:2",
+      "error.cause.pg_code": "08006",
       "http.method": "GET",
       "http.route": "/test/:id",
       "http.status_code": 200,

--- a/apps/api/src/lib/observability/logger.ts
+++ b/apps/api/src/lib/observability/logger.ts
@@ -20,6 +20,18 @@ type LoggerAttributeValue = boolean | number | string;
 
 export type LoggerAttributes = Record<string, LoggerAttributeValue>;
 
+type RequestLogOptions = {
+  durationMs: number;
+  elysiaCode?: string | undefined;
+  errorType?: string | undefined;
+  message: "request.completed" | "request.failed";
+  method: string;
+  requestId?: string | undefined;
+  route?: string | undefined;
+  severity: "ERROR" | "INFO" | "WARN";
+  statusCode: number;
+};
+
 export const sanitizeLogAttributes = (
   attributes: LoggerAttributes | undefined,
 ): LoggerAttributes | undefined => {
@@ -90,6 +102,44 @@ const emit = ({
   }
 };
 
+const REQUEST_SEVERITY = {
+  ERROR: SeverityNumber.ERROR,
+  INFO: SeverityNumber.INFO,
+  WARN: SeverityNumber.WARN,
+} as const;
+
+const emitRequest = ({
+  durationMs,
+  elysiaCode,
+  errorType,
+  message,
+  method,
+  requestId,
+  route,
+  severity,
+  statusCode,
+}: RequestLogOptions): void => {
+  const safeAttributes: LoggerAttributes = {
+    "http.method": method,
+    "http.route": route ?? "unmatched",
+    "http.status_code": statusCode,
+    "request.duration_ms": durationMs,
+    ...(elysiaCode === undefined ? {} : { "http.elysia_code": elysiaCode }),
+    ...(errorType === undefined ? {} : { "error.type": errorType }),
+    ...(requestId === undefined ? {} : { "request.id": requestId }),
+  };
+
+  otelLogger.emit({
+    attributes: safeAttributes,
+    body: message,
+    severityNumber: REQUEST_SEVERITY[severity],
+    severityText: severity,
+  });
+  process.stdout.write(
+    `${JSON.stringify({ severity, message, ...safeAttributes })}\n`,
+  );
+};
+
 export const logger = {
   debug: (message: string, attributes?: LoggerAttributes) =>
     emit({
@@ -119,4 +169,5 @@ export const logger = {
       severityNumber: SeverityNumber.ERROR,
       severityText: "ERROR",
     }),
+  request: (options: RequestLogOptions) => emitRequest(options),
 };

--- a/apps/api/src/lib/observability/logger.ts
+++ b/apps/api/src/lib/observability/logger.ts
@@ -20,8 +20,23 @@ type LoggerAttributeValue = boolean | number | string;
 
 export type LoggerAttributes = Record<string, LoggerAttributeValue>;
 
+export type RequestErrorFingerprint = {
+  errorCauseFrame?: string | undefined;
+  errorClass?: string | undefined;
+  errorCode?: string | undefined;
+  errorFrame?: string | undefined;
+  pgCode?: string | undefined;
+  pgColumn?: string | undefined;
+  pgConstraint?: string | undefined;
+  pgRoutine?: string | undefined;
+  pgSchema?: string | undefined;
+  pgSeverity?: string | undefined;
+  pgTable?: string | undefined;
+};
+
 type RequestLogOptions = {
   durationMs: number;
+  errorFingerprint?: RequestErrorFingerprint | undefined;
   elysiaCode?: string | undefined;
   errorType?: string | undefined;
   message: "request.completed" | "request.failed";
@@ -111,6 +126,7 @@ const REQUEST_SEVERITY = {
 const emitRequest = ({
   durationMs,
   elysiaCode,
+  errorFingerprint,
   errorType,
   message,
   method,
@@ -126,6 +142,39 @@ const emitRequest = ({
     "request.duration_ms": durationMs,
     ...(elysiaCode === undefined ? {} : { "http.elysia_code": elysiaCode }),
     ...(errorType === undefined ? {} : { "error.type": errorType }),
+    ...(errorFingerprint?.errorCauseFrame === undefined
+      ? {}
+      : { "error.cause.frame": errorFingerprint.errorCauseFrame }),
+    ...(errorFingerprint?.errorClass === undefined
+      ? {}
+      : { "error.class": errorFingerprint.errorClass }),
+    ...(errorFingerprint?.errorCode === undefined
+      ? {}
+      : { "error.code": errorFingerprint.errorCode }),
+    ...(errorFingerprint?.errorFrame === undefined
+      ? {}
+      : { "error.frame": errorFingerprint.errorFrame }),
+    ...(errorFingerprint?.pgCode === undefined
+      ? {}
+      : { "error.cause.pg_code": errorFingerprint.pgCode }),
+    ...(errorFingerprint?.pgColumn === undefined
+      ? {}
+      : { "error.cause.pg_column": errorFingerprint.pgColumn }),
+    ...(errorFingerprint?.pgConstraint === undefined
+      ? {}
+      : { "error.cause.pg_constraint": errorFingerprint.pgConstraint }),
+    ...(errorFingerprint?.pgRoutine === undefined
+      ? {}
+      : { "error.cause.pg_routine": errorFingerprint.pgRoutine }),
+    ...(errorFingerprint?.pgSchema === undefined
+      ? {}
+      : { "error.cause.pg_schema": errorFingerprint.pgSchema }),
+    ...(errorFingerprint?.pgSeverity === undefined
+      ? {}
+      : { "error.cause.pg_severity": errorFingerprint.pgSeverity }),
+    ...(errorFingerprint?.pgTable === undefined
+      ? {}
+      : { "error.cause.pg_table": errorFingerprint.pgTable }),
     ...(requestId === undefined ? {} : { "request.id": requestId }),
   };
 

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -97,12 +97,15 @@ import { detached } from "@/api/lib/detached";
 import { DEV_INSPECTOR_ORIGINS, frontendOrigins } from "@/api/lib/dev-origins";
 import { initEntityDeletionCleanupWorker } from "@/api/lib/entity-deletion-cleanup-queue";
 import { httpError } from "@/api/lib/errors/http-error";
-import { errorTag } from "@/api/lib/errors/utils";
+import { errorFingerprint, errorTag } from "@/api/lib/errors/utils";
 import { initFileDerivativeWorker } from "@/api/lib/file-derivative-queue";
 import { initFlowRunWorker } from "@/api/lib/flows/flow-run-worker";
 import { API_RATE_LIMITS } from "@/api/lib/limits";
 import { FORMATTING_LOCALE_HEADER } from "@/api/lib/locale";
-import { logger } from "@/api/lib/observability/logger";
+import {
+  logger,
+  type RequestErrorFingerprint,
+} from "@/api/lib/observability/logger";
 import {
   getRequestContext,
   getRequestId,
@@ -175,6 +178,25 @@ const shouldLogRequest = (path: string): boolean => path !== HEALTH_PATH;
 
 const getRouteName = (route: string | undefined): string =>
   route ?? "unmatched";
+
+const buildRequestErrorFingerprint = (
+  error: unknown,
+): RequestErrorFingerprint => {
+  const fingerprint = errorFingerprint(error);
+  return {
+    errorCauseFrame: fingerprint["error.cause.frame"],
+    errorClass: fingerprint["error.class"],
+    errorCode: fingerprint["error.code"],
+    errorFrame: fingerprint["error.frame"],
+    pgCode: fingerprint["error.cause.pg_code"],
+    pgColumn: fingerprint["error.cause.pg_column"],
+    pgConstraint: fingerprint["error.cause.pg_constraint"],
+    pgRoutine: fingerprint["error.cause.pg_routine"],
+    pgSchema: fingerprint["error.cause.pg_schema"],
+    pgSeverity: fingerprint["error.cause.pg_severity"],
+    pgTable: fingerprint["error.cause.pg_table"],
+  };
+};
 
 const buildRequestLogDetails = ({
   durationMs,
@@ -305,6 +327,7 @@ const api = new Elysia()
       if (statusCode >= 500) {
         logger.request({
           ...details,
+          errorFingerprint: buildRequestErrorFingerprint(error),
           message: "request.failed",
           severity: "ERROR",
         });

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -97,11 +97,7 @@ import { detached } from "@/api/lib/detached";
 import { DEV_INSPECTOR_ORIGINS, frontendOrigins } from "@/api/lib/dev-origins";
 import { initEntityDeletionCleanupWorker } from "@/api/lib/entity-deletion-cleanup-queue";
 import { httpError } from "@/api/lib/errors/http-error";
-import {
-  errorFingerprint,
-  errorTag,
-  unredactedErrorFields,
-} from "@/api/lib/errors/utils";
+import { errorTag } from "@/api/lib/errors/utils";
 import { initFileDerivativeWorker } from "@/api/lib/file-derivative-queue";
 import { initFlowRunWorker } from "@/api/lib/flows/flow-run-worker";
 import { API_RATE_LIMITS } from "@/api/lib/limits";
@@ -177,18 +173,12 @@ const setDbQueryCountHeader = (set: Context["set"]) => {
 
 const shouldLogRequest = (path: string): boolean => path !== HEALTH_PATH;
 
-const getRouteName = ({
-  path,
-  route,
-}: {
-  path: string;
-  route: string | undefined;
-}): string => route ?? path;
+const getRouteName = (route: string | undefined): string =>
+  route ?? "unmatched";
 
-const buildRequestLogAttributes = ({
+const buildRequestLogDetails = ({
   durationMs,
   errorType,
-  path,
   request,
   route,
   statusCode,
@@ -197,45 +187,32 @@ const buildRequestLogAttributes = ({
 }: {
   durationMs: number;
   errorType?: string;
-  path: string;
   request: Request;
   route?: string;
   statusCode: number;
   reqCtx?: ReturnType<typeof getRequestContext>;
   elysiaCode?: string;
 }) => {
-  const attributes: Record<string, string | number | boolean> = {
-    "http.method": request.method,
-    "http.route": getRouteName({ path, route }),
-    "http.status_code": statusCode,
-    "request.duration_ms": Math.round(durationMs),
+  const details = {
+    durationMs: Math.round(durationMs),
+    method: request.method,
+    route,
+    statusCode,
   };
 
   if (elysiaCode) {
-    attributes["http.elysia_code"] = elysiaCode;
+    Object.assign(details, { elysiaCode });
   }
 
   if (errorType) {
-    attributes["error.type"] = errorType;
+    Object.assign(details, { errorType });
   }
 
   if (reqCtx?.requestId) {
-    attributes["request.id"] = reqCtx.requestId;
+    Object.assign(details, { requestId: reqCtx.requestId });
   }
 
-  if (reqCtx?.posthogDistinctId) {
-    attributes["posthogDistinctId"] = reqCtx.posthogDistinctId;
-  }
-
-  if (reqCtx?.sessionId) {
-    attributes["sessionId"] = reqCtx.sessionId;
-  }
-
-  if (reqCtx?.organizationId) {
-    attributes["enduser.organization_id"] = reqCtx.organizationId;
-  }
-
-  return attributes;
+  return details;
 };
 
 const api = new Elysia()
@@ -315,10 +292,9 @@ const api = new Elysia()
     const statusCode = STATUS_BY_ELYSIA_CODE[code] ?? 500;
 
     if (shouldLogRequest(path)) {
-      const attributes = buildRequestLogAttributes({
+      const details = buildRequestLogDetails({
         durationMs: reqCtx ? performance.now() - reqCtx.startTime : 0,
         errorType: errorTag(error),
-        path,
         request,
         route,
         statusCode,
@@ -327,20 +303,24 @@ const api = new Elysia()
       });
 
       if (statusCode >= 500) {
-        Object.assign(attributes, errorFingerprint(error));
-        if (env.isDev && env.DEBUG_UNREDACTED_ERRORS) {
-          Object.assign(attributes, unredactedErrorFields(error));
-        }
-        logger.error("request.failed", attributes);
+        logger.request({
+          ...details,
+          message: "request.failed",
+          severity: "ERROR",
+        });
       } else {
-        logger.warn("request.failed", attributes);
+        logger.request({
+          ...details,
+          message: "request.failed",
+          severity: "WARN",
+        });
       }
     }
 
     captureRequestError(error, {
       request,
       context: {
-        route: getRouteName({ path, route }),
+        route: getRouteName(route),
         method: request.method,
         elysiaCode: String(code),
       },
@@ -370,9 +350,8 @@ const api = new Elysia()
 
     if (shouldLogRequest(path) && reqCtx) {
       const statusCode = typeof set.status === "number" ? set.status : 200;
-      const attributes = buildRequestLogAttributes({
+      const details = buildRequestLogDetails({
         durationMs: performance.now() - reqCtx.startTime,
-        path,
         request,
         route,
         statusCode,
@@ -380,11 +359,23 @@ const api = new Elysia()
       });
 
       if (statusCode >= 500) {
-        logger.error("request.completed", attributes);
+        logger.request({
+          ...details,
+          message: "request.completed",
+          severity: "ERROR",
+        });
       } else if (statusCode >= 400) {
-        logger.warn("request.completed", attributes);
+        logger.request({
+          ...details,
+          message: "request.completed",
+          severity: "WARN",
+        });
       } else {
-        logger.info("request.completed", attributes);
+        logger.request({
+          ...details,
+          message: "request.completed",
+          severity: "INFO",
+        });
       }
     }
 
@@ -393,7 +384,7 @@ const api = new Elysia()
       await analytics.flush().catch((error: unknown) => {
         logger.error("analytics.flush.failed", {
           "error.type": errorTag(error),
-          "http.route": getRouteName({ path, route }),
+          "http.route": getRouteName(route),
         });
       });
     }


### PR DESCRIPTION
## Summary

- emit request completion and failure events through a dedicated structured sink
- constrain request attributes to an explicit operational allowlist
- represent unmatched routes with a constant sentinel instead of a request URL

## Testing

- logger attribute and redaction tests
- repository pre-commit checks
- GitHub CI pending