### PR TITLE
fix: polish matter activity uploads

### DIFF
--- a/apps/api/src/handlers/invoices/transition.integration.test.ts
+++ b/apps/api/src/handlers/invoices/transition.integration.test.ts
@@ -205,7 +205,7 @@ const createContext = ({
     getAccessibleWorkspaces: async () => [{ id: ids.wsA1, status: "active" }],
     getWorkspaceAccess: async () => ({ id: ids.wsA1, status: "active" }),
     body: { action },
-    createAuditRecorder: () => async () => undefined,
+    createAuditRecorder: () => recordAuditEvent,
     memberRole: { role: "owner" },
     orgAIConfig: null,
     params: { workspaceId: ids.wsA1, invoiceId },

--- a/apps/api/src/handlers/workspaces/read-overview-activity.logic.ts
+++ b/apps/api/src/handlers/workspaces/read-overview-activity.logic.ts
@@ -126,13 +126,13 @@ export const resolveActivityRunId = ({
 }: ResolveActivityRunIdOptions): string | null =>
   runId ?? (resourceType === AUDIT_RESOURCE_TYPE.FLOW_RUN ? resourceId : null);
 
-type ResolveActivityActionOptions = {
-  action: AuditAction;
+type ResolveActivityActionOptions<TAction extends AuditAction> = {
+  action: TAction;
   relationshipChange: "add" | "remove" | null;
 };
 
-export const resolveActivityAction = ({
+export const resolveActivityAction = <TAction extends AuditAction>({
   action,
   relationshipChange,
-}: ResolveActivityActionOptions): AuditAction | "add" | "remove" =>
+}: ResolveActivityActionOptions<TAction>): TAction | "add" | "remove" =>
   relationshipChange ?? action;

--- a/apps/api/src/handlers/workspaces/read-overview-activity.ts
+++ b/apps/api/src/handlers/workspaces/read-overview-activity.ts
@@ -695,6 +695,7 @@ const readOverviewActivity = createSafeHandler(
         actor.id,
         {
           deletedAt: actor.deletedAt?.toISOString() ?? null,
+          id: actor.id,
           image: actor.image,
           name: actor.name || actor.email,
           type: "user" as const,
@@ -733,6 +734,7 @@ const readOverviewActivity = createSafeHandler(
           row.performerType === "user"
             ? (actorMap.get(performerId) ?? {
                 deletedAt: null,
+                id: performerId,
                 image: null,
                 name: null,
                 type: "user" as const,

--- a/apps/api/src/lib/api-handlers.test.ts
+++ b/apps/api/src/lib/api-handlers.test.ts
@@ -5,6 +5,7 @@ import type { SafeDb, SafeDbError } from "@/api/db/safe-db";
 import { env } from "@/api/env";
 import type { OrgAIConfig } from "@/api/lib/ai-config";
 import {
+  createSafeHandler,
   createSafeRootHandler,
   errorCauseChainAttributes,
   resolveMeteringContext,
@@ -12,8 +13,71 @@ import {
 import type { AuditRecorder } from "@/api/lib/audit-log";
 import { toSafeId } from "@/api/lib/branded-types";
 import { DatabaseError, HandlerError } from "@/api/lib/errors/tagged-errors";
+import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
 
 const noopAuditRecorder: AuditRecorder = async () => undefined;
+
+describe("createSafeHandler workspace audit binding", () => {
+  test("rebinds audit recording to the validated workspace", async () => {
+    const workspaceId = toSafeId<"workspace">(
+      "019e7000-0000-7000-8000-000000000003",
+    );
+    const reboundRecorder: AuditRecorder = async () => undefined;
+    let recorderSeenByHandler: AuditRecorder | undefined;
+    let recorderWorkspaceId: string | null | undefined;
+    const endpoint = createSafeHandler(
+      {
+        permissions: { workspace: ["read"] },
+        mcp: { type: "internal", reason: "health_infra" },
+      },
+      async function* ({ recordAuditEvent }) {
+        recorderSeenByHandler = recordAuditEvent;
+        return Result.ok({ ok: true });
+      },
+    );
+    const safeDb: SafeDb = async <T>() =>
+      Result.err<T, SafeDbError>(
+        new DatabaseError({ message: "db should not be read" }),
+      );
+    const context = {
+      request: new Request("https://example.test/workspace-audit"),
+      route: "/workspace-audit",
+      workspaceId,
+      user: {
+        id: toSafeId<"user">("019e7000-0000-7000-8000-000000000001"),
+      },
+      session: {
+        activeOrganizationId: toSafeId<"organization">(
+          "019e7000-0000-7000-8000-000000000002",
+        ),
+      },
+      memberRole: { role: "owner" },
+      safeDb,
+      scopedDb: async () => {
+        throw new DatabaseError({ message: "scopedDb should not be called" });
+      },
+      getActiveWorkspaceIds: async () => [],
+      getAccessibleWorkspaces: async () => [],
+      getWorkspaceAccess: async () => null,
+      pinServerValidatedWorkspaceId: () => false,
+      orgAIConfig: null,
+      promptCachingEnabled: false,
+      recordAuditEvent: noopAuditRecorder,
+      createAuditRecorder: (options?: {
+        workspaceId?: typeof workspaceId | null;
+      }) => {
+        recorderWorkspaceId = options?.workspaceId;
+        return reboundRecorder;
+      },
+    };
+
+    const result = await endpoint.handler(asTestRaw(context));
+
+    expect(result).toEqual({ ok: true });
+    expect(recorderWorkspaceId).toBe(workspaceId);
+    expect(recorderSeenByHandler).toBe(reboundRecorder);
+  });
+});
 
 describe("createSafeRootHandler usage preflight", () => {
   test("uses effective provider tier for preflight cost", () => {

--- a/apps/api/src/lib/api-handlers.ts
+++ b/apps/api/src/lib/api-handlers.ts
@@ -856,7 +856,25 @@ export const createSafeHandler = <
   config: TConfig,
   handler: SafeHandlerFn<WorkspaceHandlerContext<TConfig>, TResult>,
 ): SafeHandlerDefinition<TConfig, WorkspaceHandlerContext<TConfig>, TResult> =>
-  createSafeScopedHandler(config, handler);
+  createSafeScopedHandler(config, (ctx) => {
+    // Elysia may expand validateAuth again after validateWorkspaceAccess when a
+    // route also declares permissions. That later resolve carries the root
+    // recorder and can overwrite the recorder bound by the workspace macro.
+    // Rebind here, where the context type proves workspaceId was validated, so
+    // workspace mutations cannot emit organization-only audit rows regardless
+    // of macro composition order.
+    // Direct unit tests below the Elysia boundary may intentionally use a
+    // minimal raw context. Real WorkspaceHandlerContext values always carry
+    // this factory; keep those fixture-only omissions from changing handler
+    // behavior while still rebinding every framework-produced request.
+    const recorderFactory: unknown = Reflect.get(ctx, "createAuditRecorder");
+    if (typeof recorderFactory === "function") {
+      ctx.recordAuditEvent = ctx.createAuditRecorder({
+        workspaceId: ctx.workspaceId,
+      });
+    }
+    return handler(ctx);
+  });
 
 export const createSafeSessionHandler = <
   TConfig extends SessionHandlerConfig,

--- a/apps/web/e2e/network-baseline.json
+++ b/apps/web/e2e/network-baseline.json
@@ -1694,7 +1694,7 @@
       "GET /v1/workspaces/:id/activity": 1024,
       "GET /v1/workspaces/:id/members": 1024,
       "GET /v1/workspaces/:id/overview": 1024,
-      "GET /v1/workspaces/:id/overview/activity": 1024,
+      "GET /v1/workspaces/:id/overview/activity": 2048,
       "GET /v1/workspaces/:id/workflow": 1024,
       "GET /v1/workspaces/navigation": 20480
     }
@@ -1784,7 +1784,7 @@
       "GET /v1/workspaces/:id/activity": 1024,
       "GET /v1/workspaces/:id/members": 1024,
       "GET /v1/workspaces/:id/overview": 1024,
-      "GET /v1/workspaces/:id/overview/activity": 1024,
+      "GET /v1/workspaces/:id/overview/activity": 2048,
       "GET /v1/workspaces/:id/workflow": 1024,
       "GET /v1/workspaces/navigation": 20480
     }
@@ -2242,7 +2242,7 @@
       "GET /v1/workspaces/:id/activity": 1024,
       "GET /v1/workspaces/:id/members": 1024,
       "GET /v1/workspaces/:id/overview": 1024,
-      "GET /v1/workspaces/:id/overview/activity": 1024,
+      "GET /v1/workspaces/:id/overview/activity": 2048,
       "GET /v1/workspaces/:id/workflow": 1024,
       "GET /v1/workspaces/navigation": 20480
     }

--- a/apps/web/src/hooks/external-file-drop.logic.test.ts
+++ b/apps/web/src/hooks/external-file-drop.logic.test.ts
@@ -11,14 +11,17 @@ class TestFileEntry {
   readonly isFile = true;
   readonly name: string;
   private readonly fileValue: File;
+  private readonly onRead: (() => void) | undefined;
 
-  constructor(name: string, fileValue?: File) {
+  constructor(name: string, fileValue?: File, onRead?: () => void) {
     this.name = name;
     this.fileValue =
       fileValue ?? new File(["test"], name, { type: "text/plain" });
+    this.onRead = onRead;
   }
 
   file(successCallback: (file: File) => void) {
+    this.onRead?.();
     successCallback(this.fileValue);
   }
 }
@@ -105,5 +108,35 @@ describe("external folder drops", () => {
 
     expect(tree.directoryPaths).toEqual([]);
     expect(tree.files).toEqual([{ file, pathSegments: ["loose.eml"] }]);
+  });
+
+  test("snapshots every dropped item before asynchronous entry reads", async () => {
+    let dragDataReadable = true;
+    const files = [
+      new File(["one"], "one.pdf"),
+      new File(["two"], "two.pdf"),
+      new File(["three"], "three.pdf"),
+    ];
+    const entries = files.map(
+      (file, index) =>
+        new TestFileEntry(
+          file.name,
+          file,
+          index === 0
+            ? () => {
+                dragDataReadable = false;
+              }
+            : undefined,
+        ),
+    );
+    const items = entries.map((entry) => ({
+      kind: "file",
+      getAsFile: () => null,
+      webkitGetAsEntry: () => (dragDataReadable ? entry : null),
+    }));
+
+    const tree = await collectDroppedFileTree({ items });
+
+    expect(tree.files.map(({ file }) => file)).toEqual(files);
   });
 });

--- a/apps/web/src/hooks/external-file-drop.logic.ts
+++ b/apps/web/src/hooks/external-file-drop.logic.ts
@@ -42,6 +42,11 @@ type FileSystemDirectoryEntryLike = {
   createReader: () => FileSystemDirectoryReaderLike;
 };
 
+type DroppedItemSnapshot =
+  | { entry: FileSystemDirectoryEntryLike; type: "directory" }
+  | { entry: FileSystemFileEntryLike; type: "file_entry" }
+  | { file: File; type: "file" };
+
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null;
 
@@ -152,6 +157,33 @@ const collectDirectory = async ({
   }
 };
 
+const snapshotDroppedItems = (
+  items: DroppedDataTransferItem[],
+): DroppedItemSnapshot[] => {
+  const snapshots: DroppedItemSnapshot[] = [];
+  for (const item of items) {
+    if (item.kind !== "file") {
+      continue;
+    }
+
+    const entry = item.webkitGetAsEntry?.();
+    if (isDirectoryEntry(entry)) {
+      snapshots.push({ entry, type: "directory" });
+      continue;
+    }
+    if (isFileEntry(entry)) {
+      snapshots.push({ entry, type: "file_entry" });
+      continue;
+    }
+
+    const file = item.getAsFile();
+    if (file) {
+      snapshots.push({ file, type: "file" });
+    }
+  }
+  return snapshots;
+};
+
 export const collectDroppedFileTree = async ({
   items,
 }: DroppedDataTransferSource): Promise<DroppedFileTree> => {
@@ -160,35 +192,36 @@ export const collectDroppedFileTree = async ({
     directoryPaths: [],
   };
 
-  for (const item of items) {
-    if (item.kind !== "file") {
-      continue;
-    }
-
-    const entry = item.webkitGetAsEntry?.();
-    if (isDirectoryEntry(entry)) {
-      // oxlint-disable-next-line no-await-in-loop -- ordered traversal: dropped items append to a shared tree in deterministic order
-      await collectDirectory({
-        entry,
-        path: pathWithSegment([], entry.name),
-        tree,
-      });
-      continue;
-    }
-
-    if (isFileEntry(entry)) {
-      // oxlint-disable-next-line no-await-in-loop -- ordered traversal: dropped files append to a shared tree in deterministic order
-      const file = await readFileEntry(entry);
-      tree.files.push({
-        file,
-        pathSegments: [file.name || entry.name],
-      });
-      continue;
-    }
-
-    const file = item.getAsFile();
-    if (file) {
-      tree.files.push({ file, pathSegments: [file.name] });
+  const snapshots = snapshotDroppedItems(items);
+  for (const snapshot of snapshots) {
+    switch (snapshot.type) {
+      case "directory":
+        // oxlint-disable-next-line no-await-in-loop -- ordered traversal: dropped items append to a shared tree in deterministic order
+        await collectDirectory({
+          entry: snapshot.entry,
+          path: pathWithSegment([], snapshot.entry.name),
+          tree,
+        });
+        break;
+      case "file_entry": {
+        // oxlint-disable-next-line no-await-in-loop -- ordered traversal: dropped files append to a shared tree in deterministic order
+        const file = await readFileEntry(snapshot.entry);
+        tree.files.push({
+          file,
+          pathSegments: [file.name || snapshot.entry.name],
+        });
+        break;
+      }
+      case "file":
+        tree.files.push({
+          file: snapshot.file,
+          pathSegments: [snapshot.file.name],
+        });
+        break;
+      default: {
+        const exhaustive: never = snapshot;
+        return exhaustive;
+      }
     }
   }
 

--- a/apps/web/src/i18n/langs/ar.json
+++ b/apps/web/src/i18n/langs/ar.json
@@ -3392,14 +3392,14 @@
     "overview": {
       "activity": {
         "actions": {
-          "added": "أضاف <actor>المستخدم</actor> <target>العنصر</target>",
-          "cancelled": "ألغى <actor>المستخدم</actor> <target>العنصر</target>",
-          "created": "أنشأ <actor>المستخدم</actor> <target>العنصر</target>",
-          "deleted": "حذف <actor>المستخدم</actor> <target>العنصر</target>",
-          "executed": "شغّل <actor>المستخدم</actor> <target>العنصر</target>",
-          "removed": "أزال <actor>المستخدم</actor> <target>العنصر</target>",
-          "reviewed": "راجع <actor>المستخدم</actor> <target>العنصر</target>",
-          "updated": "حدّث <actor>المستخدم</actor> <target>العنصر</target>"
+          "added": "تمت الإضافة",
+          "cancelled": "تم الإلغاء",
+          "created": "تم الإنشاء",
+          "deleted": "تم الحذف",
+          "executed": "تم التشغيل",
+          "removed": "تمت الإزالة",
+          "reviewed": "تمت المراجعة",
+          "updated": "تم التحديث"
         },
         "approvals": {
           "approved": "تم منح الموافقة",
@@ -3465,9 +3465,9 @@
         "targets": {
           "automation": "الأتمتة",
           "court": "سجل المحكمة",
-          "document": "مستند محذوف",
+          "document": "مستند",
           "matter": "الملف القانوني",
-          "task": "عنصر جدول أعمال محذوف",
+          "task": "عنصر جدول أعمال",
           "team": "فريق الملف القانوني"
         },
         "title": "النشاط",

--- a/apps/web/src/i18n/langs/cs.json
+++ b/apps/web/src/i18n/langs/cs.json
@@ -3392,14 +3392,14 @@
     "overview": {
       "activity": {
         "actions": {
-          "added": "<actor>Uživatel</actor> přidal(a) <target>položku</target>",
-          "cancelled": "<actor>Uživatel</actor> zrušil(a) <target>položku</target>",
-          "created": "<actor>Uživatel</actor> vytvořil(a) <target>položku</target>",
-          "deleted": "<actor>Uživatel</actor> odstranil(a) <target>položku</target>",
-          "executed": "<actor>Uživatel</actor> spustil(a) <target>položku</target>",
-          "removed": "<actor>Uživatel</actor> odebral(a) <target>položku</target>",
-          "reviewed": "<actor>Uživatel</actor> zkontroloval(a) <target>položku</target>",
-          "updated": "<actor>Uživatel</actor> upravil(a) <target>položku</target>"
+          "added": "Přidáno",
+          "cancelled": "Bylo zrušeno",
+          "created": "Vytvořeno",
+          "deleted": "Bylo odstraněno",
+          "executed": "Spuštěno",
+          "removed": "Odebráno",
+          "reviewed": "Zkontrolováno",
+          "updated": "Bylo upraveno"
         },
         "approvals": {
           "approved": "Schválení uděleno",
@@ -3463,11 +3463,11 @@
           "mcp": "Připojený nástroj"
         },
         "targets": {
-          "automation": "automatizaci",
+          "automation": "automatizace",
           "court": "soudní záznam",
-          "document": "odstraněný dokument",
+          "document": "dokument",
           "matter": "věc",
-          "task": "odstraněnou položku agendy",
+          "task": "položka agendy",
           "team": "tým věci"
         },
         "title": "Aktivita",

--- a/apps/web/src/i18n/langs/de.json
+++ b/apps/web/src/i18n/langs/de.json
@@ -3392,14 +3392,14 @@
     "overview": {
       "activity": {
         "actions": {
-          "added": "<actor>Person</actor> hat <target>Element</target> hinzugefügt",
-          "cancelled": "<actor>Person</actor> hat <target>Element</target> abgebrochen",
-          "created": "<actor>Person</actor> hat <target>Element</target> erstellt",
-          "deleted": "<actor>Person</actor> hat <target>Element</target> gelöscht",
-          "executed": "<actor>Person</actor> hat <target>Element</target> ausgeführt",
-          "removed": "<actor>Person</actor> hat <target>Element</target> entfernt",
-          "reviewed": "<actor>Person</actor> hat <target>Element</target> geprüft",
-          "updated": "<actor>Person</actor> hat <target>Element</target> aktualisiert"
+          "added": "Hinzugefügt",
+          "cancelled": "Wurde abgebrochen",
+          "created": "Erstellt",
+          "deleted": "Wurde gelöscht",
+          "executed": "Ausgeführt",
+          "removed": "Entfernt",
+          "reviewed": "Geprüft",
+          "updated": "Wurde aktualisiert"
         },
         "approvals": {
           "approved": "Genehmigung erteilt",
@@ -3465,9 +3465,9 @@
         "targets": {
           "automation": "Automatisierung",
           "court": "Gerichtseintrag",
-          "document": "gelöschtes Dokument",
+          "document": "Dokument",
           "matter": "Akte",
-          "task": "gelöschter Agendaeintrag",
+          "task": "Agendaeintrag",
           "team": "Aktenteam"
         },
         "title": "Aktivität",

--- a/apps/web/src/i18n/langs/en.json
+++ b/apps/web/src/i18n/langs/en.json
@@ -3392,14 +3392,14 @@
     "overview": {
       "activity": {
         "actions": {
-          "added": "<actor>Actor</actor> added <target>target</target>",
-          "cancelled": "<actor>Actor</actor> cancelled <target>target</target>",
-          "created": "<actor>Actor</actor> created <target>target</target>",
-          "deleted": "<actor>Actor</actor> deleted <target>target</target>",
-          "executed": "<actor>Actor</actor> ran <target>target</target>",
-          "removed": "<actor>Actor</actor> removed <target>target</target>",
-          "reviewed": "<actor>Actor</actor> reviewed <target>target</target>",
-          "updated": "<actor>Actor</actor> updated <target>target</target>"
+          "added": "Added",
+          "cancelled": "Was cancelled",
+          "created": "Created",
+          "deleted": "Was deleted",
+          "executed": "Ran",
+          "removed": "Removed",
+          "reviewed": "Reviewed",
+          "updated": "Was updated"
         },
         "approvals": {
           "approved": "Approval granted",
@@ -3465,9 +3465,9 @@
         "targets": {
           "automation": "automation",
           "court": "court record",
-          "document": "deleted document",
+          "document": "document",
           "matter": "matter",
-          "task": "deleted agenda item",
+          "task": "agenda item",
           "team": "matter team"
         },
         "title": "Matter activity",

--- a/apps/web/src/i18n/langs/es.json
+++ b/apps/web/src/i18n/langs/es.json
@@ -3392,14 +3392,14 @@
     "overview": {
       "activity": {
         "actions": {
-          "added": "<actor>Persona</actor> añadió <target>elemento</target>",
-          "cancelled": "<actor>Persona</actor> canceló <target>elemento</target>",
-          "created": "<actor>Persona</actor> creó <target>elemento</target>",
-          "deleted": "<actor>Persona</actor> eliminó <target>elemento</target>",
-          "executed": "<actor>Persona</actor> ejecutó <target>elemento</target>",
-          "removed": "<actor>Persona</actor> retiró <target>elemento</target>",
-          "reviewed": "<actor>Persona</actor> revisó <target>elemento</target>",
-          "updated": "<actor>Persona</actor> actualizó <target>elemento</target>"
+          "added": "Añadido",
+          "cancelled": "Se canceló",
+          "created": "Creado",
+          "deleted": "Se eliminó",
+          "executed": "Ejecutado",
+          "removed": "Retirado",
+          "reviewed": "Revisado",
+          "updated": "Se actualizó"
         },
         "approvals": {
           "approved": "Aprobación concedida",
@@ -3465,9 +3465,9 @@
         "targets": {
           "automation": "automatización",
           "court": "registro judicial",
-          "document": "documento eliminado",
+          "document": "documento",
           "matter": "asunto",
-          "task": "elemento de agenda eliminado",
+          "task": "elemento de agenda",
           "team": "equipo del asunto"
         },
         "title": "Actividad",

--- a/apps/web/src/i18n/langs/et.json
+++ b/apps/web/src/i18n/langs/et.json
@@ -3392,14 +3392,14 @@
     "overview": {
       "activity": {
         "actions": {
-          "added": "<actor>Kasutaja</actor> lisas <target>üksuse</target>",
-          "cancelled": "<actor>Kasutaja</actor> tühistas <target>üksuse</target>",
-          "created": "<actor>Kasutaja</actor> lõi <target>üksuse</target>",
-          "deleted": "<actor>Kasutaja</actor> kustutas <target>üksuse</target>",
-          "executed": "<actor>Kasutaja</actor> käivitas <target>üksuse</target>",
-          "removed": "<actor>Kasutaja</actor> eemaldas <target>üksuse</target>",
-          "reviewed": "<actor>Kasutaja</actor> vaatas üle <target>üksuse</target>",
-          "updated": "<actor>Kasutaja</actor> uuendas <target>üksust</target>"
+          "added": "Lisatud",
+          "cancelled": "Tühistati",
+          "created": "Loodud",
+          "deleted": "Kustutati",
+          "executed": "Käivitatud",
+          "removed": "Eemaldatud",
+          "reviewed": "Üle vaadatud",
+          "updated": "Uuendati"
         },
         "approvals": {
           "approved": "Kinnitus antud",
@@ -3463,12 +3463,12 @@
           "mcp": "Ühendatud tööriist"
         },
         "targets": {
-          "automation": "automatiseerimise",
+          "automation": "automatiseerimine",
           "court": "kohtukirje",
-          "document": "kustutatud dokumendi",
-          "matter": "toimiku",
-          "task": "kustutatud päevakorrapunkti",
-          "team": "toimiku meeskonna"
+          "document": "dokument",
+          "matter": "toimik",
+          "task": "päevakorrapunkt",
+          "team": "toimiku meeskond"
         },
         "title": "Tegevus",
         "views": {

--- a/apps/web/src/i18n/langs/fr.json
+++ b/apps/web/src/i18n/langs/fr.json
@@ -3392,14 +3392,14 @@
     "overview": {
       "activity": {
         "actions": {
-          "added": "<actor>Personne</actor> a ajouté <target>élément</target>",
-          "cancelled": "<actor>Personne</actor> a annulé <target>élément</target>",
-          "created": "<actor>Personne</actor> a créé <target>élément</target>",
-          "deleted": "<actor>Personne</actor> a supprimé <target>élément</target>",
-          "executed": "<actor>Personne</actor> a exécuté <target>élément</target>",
-          "removed": "<actor>Personne</actor> a retiré <target>élément</target>",
-          "reviewed": "<actor>Personne</actor> a vérifié <target>élément</target>",
-          "updated": "<actor>Personne</actor> a mis à jour <target>élément</target>"
+          "added": "Ajouté",
+          "cancelled": "A été annulé",
+          "created": "Créé",
+          "deleted": "A été supprimé",
+          "executed": "Exécuté",
+          "removed": "Retiré",
+          "reviewed": "Vérifié",
+          "updated": "A été mis à jour"
         },
         "approvals": {
           "approved": "Approbation accordée",
@@ -3465,9 +3465,9 @@
         "targets": {
           "automation": "automatisation",
           "court": "dossier judiciaire",
-          "document": "document supprimé",
+          "document": "fichier",
           "matter": "dossier",
-          "task": "élément d’agenda supprimé",
+          "task": "élément d’agenda",
           "team": "équipe du dossier"
         },
         "title": "Activité",

--- a/apps/web/src/i18n/langs/hu.json
+++ b/apps/web/src/i18n/langs/hu.json
@@ -3392,14 +3392,14 @@
     "overview": {
       "activity": {
         "actions": {
-          "added": "<actor>Felhasználó</actor> hozzáadta: <target>elem</target>",
-          "cancelled": "<actor>Felhasználó</actor> megszakította: <target>elem</target>",
-          "created": "<actor>Felhasználó</actor> létrehozta: <target>elem</target>",
-          "deleted": "<actor>Felhasználó</actor> törölte: <target>elem</target>",
-          "executed": "<actor>Felhasználó</actor> futtatta: <target>elem</target>",
-          "removed": "<actor>Felhasználó</actor> eltávolította: <target>elem</target>",
-          "reviewed": "<actor>Felhasználó</actor> ellenőrizte: <target>elem</target>",
-          "updated": "<actor>Felhasználó</actor> frissítette: <target>elem</target>"
+          "added": "Hozzáadva",
+          "cancelled": "Megszakítva",
+          "created": "Létrehozva",
+          "deleted": "Törölve",
+          "executed": "Futtatva",
+          "removed": "Eltávolítva",
+          "reviewed": "Ellenőrizve",
+          "updated": "Frissítve"
         },
         "approvals": {
           "approved": "Jóváhagyás megadva",
@@ -3465,9 +3465,9 @@
         "targets": {
           "automation": "automatizálás",
           "court": "bírósági bejegyzés",
-          "document": "törölt dokumentum",
+          "document": "dokumentum",
           "matter": "ügy",
-          "task": "törölt napirendi elem",
+          "task": "napirendi elem",
           "team": "ügycsapat"
         },
         "title": "Tevékenység",

--- a/apps/web/src/i18n/langs/lt.json
+++ b/apps/web/src/i18n/langs/lt.json
@@ -3392,14 +3392,14 @@
     "overview": {
       "activity": {
         "actions": {
-          "added": "<actor>Naudotojas</actor> pridėjo <target>elementą</target>",
-          "cancelled": "<actor>Naudotojas</actor> atšaukė <target>elementą</target>",
-          "created": "<actor>Naudotojas</actor> sukūrė <target>elementą</target>",
-          "deleted": "<actor>Naudotojas</actor> ištrynė <target>elementą</target>",
-          "executed": "<actor>Naudotojas</actor> paleido <target>elementą</target>",
-          "removed": "<actor>Naudotojas</actor> pašalino <target>elementą</target>",
-          "reviewed": "<actor>Naudotojas</actor> peržiūrėjo <target>elementą</target>",
-          "updated": "<actor>Naudotojas</actor> atnaujino <target>elementą</target>"
+          "added": "Pridėta",
+          "cancelled": "Atšaukta",
+          "created": "Sukurta",
+          "deleted": "Ištrinta",
+          "executed": "Paleista",
+          "removed": "Pašalinta",
+          "reviewed": "Peržiūrėta",
+          "updated": "Atnaujinta"
         },
         "approvals": {
           "approved": "Patvirtinimas suteiktas",
@@ -3463,12 +3463,12 @@
           "mcp": "Prijungtas įrankis"
         },
         "targets": {
-          "automation": "automatizavimą",
-          "court": "teismo įrašą",
-          "document": "ištrintą dokumentą",
-          "matter": "bylą",
-          "task": "ištrintą darbotvarkės elementą",
-          "team": "bylos komandą"
+          "automation": "automatizavimas",
+          "court": "teismo įrašas",
+          "document": "dokumentas",
+          "matter": "byla",
+          "task": "darbotvarkės elementas",
+          "team": "bylos komanda"
         },
         "title": "Veikla",
         "views": {

--- a/apps/web/src/i18n/langs/lv.json
+++ b/apps/web/src/i18n/langs/lv.json
@@ -3392,14 +3392,14 @@
     "overview": {
       "activity": {
         "actions": {
-          "added": "<actor>Lietotājs</actor> pievienoja <target>vienumu</target>",
-          "cancelled": "<actor>Lietotājs</actor> atcēla <target>vienumu</target>",
-          "created": "<actor>Lietotājs</actor> izveidoja <target>vienumu</target>",
-          "deleted": "<actor>Lietotājs</actor> dzēsa <target>vienumu</target>",
-          "executed": "<actor>Lietotājs</actor> palaida <target>vienumu</target>",
-          "removed": "<actor>Lietotājs</actor> noņēma <target>vienumu</target>",
-          "reviewed": "<actor>Lietotājs</actor> pārskatīja <target>vienumu</target>",
-          "updated": "<actor>Lietotājs</actor> atjaunināja <target>vienumu</target>"
+          "added": "Pievienots",
+          "cancelled": "Tika atcelts",
+          "created": "Izveidots",
+          "deleted": "Tika dzēsts",
+          "executed": "Palaists",
+          "removed": "Noņemts",
+          "reviewed": "Pārskatīts",
+          "updated": "Tika atjaunināts"
         },
         "approvals": {
           "approved": "Apstiprinājums piešķirts",
@@ -3463,12 +3463,12 @@
           "mcp": "Pievienots rīks"
         },
         "targets": {
-          "automation": "automatizāciju",
-          "court": "tiesas ierakstu",
-          "document": "dzēstu dokumentu",
-          "matter": "lietu",
-          "task": "dzēstu darba kārtības vienumu",
-          "team": "lietas komandu"
+          "automation": "automatizācija",
+          "court": "tiesas ieraksts",
+          "document": "dokuments",
+          "matter": "lieta",
+          "task": "darba kārtības vienums",
+          "team": "lietas komanda"
         },
         "title": "Darbības",
         "views": {

--- a/apps/web/src/i18n/langs/messages.gen.ts
+++ b/apps/web/src/i18n/langs/messages.gen.ts
@@ -3395,14 +3395,14 @@ type Messages = {
     "overview": {
       "activity": {
         "actions": {
-          "added": "<actor>Actor</actor> added <target>target</target>";
-          "cancelled": "<actor>Actor</actor> cancelled <target>target</target>";
-          "created": "<actor>Actor</actor> created <target>target</target>";
-          "deleted": "<actor>Actor</actor> deleted <target>target</target>";
-          "executed": "<actor>Actor</actor> ran <target>target</target>";
-          "removed": "<actor>Actor</actor> removed <target>target</target>";
-          "reviewed": "<actor>Actor</actor> reviewed <target>target</target>";
-          "updated": "<actor>Actor</actor> updated <target>target</target>";
+          "added": "Added";
+          "cancelled": "Was cancelled";
+          "created": "Created";
+          "deleted": "Was deleted";
+          "executed": "Ran";
+          "removed": "Removed";
+          "reviewed": "Reviewed";
+          "updated": "Was updated";
         };
         "approvals": {
           "approved": "Approval granted";
@@ -3468,9 +3468,9 @@ type Messages = {
         "targets": {
           "automation": "automation";
           "court": "court record";
-          "document": "deleted document";
+          "document": "document";
           "matter": "matter";
-          "task": "deleted agenda item";
+          "task": "agenda item";
           "team": "matter team";
         };
         "title": "Matter activity";

--- a/apps/web/src/i18n/langs/pl.json
+++ b/apps/web/src/i18n/langs/pl.json
@@ -3392,14 +3392,14 @@
     "overview": {
       "activity": {
         "actions": {
-          "added": "<actor>Osoba</actor> dodała <target>element</target>",
-          "cancelled": "<actor>Osoba</actor> anulowała <target>element</target>",
-          "created": "<actor>Osoba</actor> utworzyła <target>element</target>",
-          "deleted": "<actor>Osoba</actor> usunęła <target>element</target>",
-          "executed": "<actor>Osoba</actor> uruchomiła <target>element</target>",
-          "removed": "<actor>Osoba</actor> odłączyła <target>element</target>",
-          "reviewed": "<actor>Osoba</actor> sprawdziła <target>element</target>",
-          "updated": "<actor>Osoba</actor> zaktualizowała <target>element</target>"
+          "added": "Dodano",
+          "cancelled": "Anulowano",
+          "created": "Utworzono",
+          "deleted": "Usunięto",
+          "executed": "Uruchomiono",
+          "removed": "Odłączono",
+          "reviewed": "Sprawdzono",
+          "updated": "Zaktualizowano"
         },
         "approvals": {
           "approved": "Zatwierdzenie udzielone",
@@ -3463,11 +3463,11 @@
           "mcp": "Połączone narzędzie"
         },
         "targets": {
-          "automation": "automatyzację",
+          "automation": "automatyzacja",
           "court": "wpis sądowy",
-          "document": "usunięty dokument",
-          "matter": "sprawę",
-          "task": "usunięty element agendy",
+          "document": "dokument",
+          "matter": "sprawa",
+          "task": "element agendy",
           "team": "zespół sprawy"
         },
         "title": "Aktywność",

--- a/apps/web/src/i18n/langs/pt-BR.json
+++ b/apps/web/src/i18n/langs/pt-BR.json
@@ -3392,14 +3392,14 @@
     "overview": {
       "activity": {
         "actions": {
-          "added": "<actor>Pessoa</actor> adicionou <target>item</target>",
-          "cancelled": "<actor>Pessoa</actor> cancelou <target>item</target>",
-          "created": "<actor>Pessoa</actor> criou <target>item</target>",
-          "deleted": "<actor>Pessoa</actor> excluiu <target>item</target>",
-          "executed": "<actor>Pessoa</actor> executou <target>item</target>",
-          "removed": "<actor>Pessoa</actor> removeu <target>item</target>",
-          "reviewed": "<actor>Pessoa</actor> revisou <target>item</target>",
-          "updated": "<actor>Pessoa</actor> atualizou <target>item</target>"
+          "added": "Adicionado",
+          "cancelled": "Foi cancelado",
+          "created": "Criado",
+          "deleted": "Foi excluído",
+          "executed": "Executado",
+          "removed": "Removido",
+          "reviewed": "Revisado",
+          "updated": "Foi atualizado"
         },
         "approvals": {
           "approved": "Aprovação concedida",
@@ -3465,9 +3465,9 @@
         "targets": {
           "automation": "automação",
           "court": "registro judicial",
-          "document": "documento excluído",
+          "document": "documento",
           "matter": "caso",
-          "task": "item de agenda excluído",
+          "task": "item de agenda",
           "team": "equipe do caso"
         },
         "title": "Atividade",

--- a/apps/web/src/i18n/langs/sk.json
+++ b/apps/web/src/i18n/langs/sk.json
@@ -3392,14 +3392,14 @@
     "overview": {
       "activity": {
         "actions": {
-          "added": "<actor>Používateľ</actor> pridal <target>položku</target>",
-          "cancelled": "<actor>Používateľ</actor> zrušil <target>položku</target>",
-          "created": "<actor>Používateľ</actor> vytvoril <target>položku</target>",
-          "deleted": "<actor>Používateľ</actor> odstránil <target>položku</target>",
-          "executed": "<actor>Používateľ</actor> spustil <target>položku</target>",
-          "removed": "<actor>Používateľ</actor> odobral <target>položku</target>",
-          "reviewed": "<actor>Používateľ</actor> skontroloval <target>položku</target>",
-          "updated": "<actor>Používateľ</actor> upravil <target>položku</target>"
+          "added": "Pridané",
+          "cancelled": "Bolo zrušené",
+          "created": "Vytvorené",
+          "deleted": "Bolo odstránené",
+          "executed": "Spustené",
+          "removed": "Odobrané",
+          "reviewed": "Skontrolované",
+          "updated": "Bolo upravené"
         },
         "approvals": {
           "approved": "Schválenie udelené",
@@ -3463,11 +3463,11 @@
           "mcp": "Pripojený nástroj"
         },
         "targets": {
-          "automation": "automatizáciu",
+          "automation": "automatizácia",
           "court": "súdny záznam",
-          "document": "odstránený dokument",
+          "document": "dokument",
           "matter": "spis",
-          "task": "odstránenú položku agendy",
+          "task": "položka agendy",
           "team": "tím spisu"
         },
         "title": "Aktivita",

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/activity/activity-panel.logic.test.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/activity/activity-panel.logic.test.ts
@@ -7,7 +7,11 @@ import {
   activityDayKey,
   expandActivityGroupsForList,
   groupActivityItems,
+  resolveSelectedActivityGroup,
 } from "./activity-panel.logic";
+
+const LOCAL_NOON = new Date(2026, 6, 30, 12).getTime();
+const LOCAL_MIDNIGHT = new Date(2026, 6, 31).getTime();
 
 type ItemOptions = {
   action?: MatterActivityItem["action"];
@@ -102,19 +106,19 @@ describe("groupActivityItems", () => {
     const groups = groupActivityItems([
       item("1", {
         action: "create",
-        activityAt: "2026-07-30T12:01:00.000Z",
+        activityAt: new Date(LOCAL_NOON + 60_000).toISOString(),
         performer,
         runId: null,
       }),
       item("2", {
         action: "create",
-        activityAt: "2026-07-30T12:00:01.000Z",
+        activityAt: new Date(LOCAL_NOON + 1000).toISOString(),
         performer,
         runId: null,
       }),
       item("3", {
         action: "create",
-        activityAt: "2026-07-30T11:59:59.999Z",
+        activityAt: new Date(LOCAL_NOON - 1).toISOString(),
         performer,
         runId: null,
       }),
@@ -123,7 +127,7 @@ describe("groupActivityItems", () => {
     expect(groups.map(({ items }) => items.length)).toEqual([2, 1]);
   });
 
-  test("keeps uploads in one batch when the minute crosses midnight", () => {
+  test("splits upload batches at local midnight", () => {
     const performer = {
       deletedAt: null,
       id: "user-1",
@@ -134,20 +138,36 @@ describe("groupActivityItems", () => {
     const groups = groupActivityItems([
       item("1", {
         action: "create",
-        activityAt: "2026-07-31T00:00:20.000Z",
+        activityAt: new Date(LOCAL_MIDNIGHT + 20_000).toISOString(),
         performer,
         runId: null,
       }),
       item("2", {
         action: "create",
-        activityAt: "2026-07-30T23:59:40.000Z",
+        activityAt: new Date(LOCAL_MIDNIGHT - 20_000).toISOString(),
         performer,
         runId: null,
       }),
     ]);
 
-    expect(groups).toHaveLength(1);
-    expect(groups[0]?.items).toHaveLength(2);
+    expect(groups).toHaveLength(2);
+    expect(groups.map(({ items }) => items.length)).toEqual([1, 1]);
+  });
+
+  test("splits automation runs at local midnight", () => {
+    const groups = groupActivityItems([
+      item("1", {
+        activityAt: new Date(LOCAL_MIDNIGHT + 20_000).toISOString(),
+        runId: "run-a",
+      }),
+      item("2", {
+        activityAt: new Date(LOCAL_MIDNIGHT - 20_000).toISOString(),
+        runId: "run-a",
+      }),
+    ]);
+
+    expect(groups).toHaveLength(2);
+    expect(groups.map(({ items }) => items.length)).toEqual([1, 1]);
   });
 
   test("keeps same-named users in separate upload batches", () => {
@@ -181,7 +201,19 @@ describe("groupActivityItems", () => {
 
     expect(
       expandActivityGroupsForList(groups).map(({ items }) => items[0].id),
-    ).toEqual(["1", "2"]);
+    ).toEqual([toSafeId<"auditLog">("1"), toSafeId<"auditLog">("2")]);
+  });
+
+  test("resolves an individual event inside an automation run", () => {
+    const groups = groupActivityItems([
+      item("1", { runId: "run-a" }),
+      item("2", { runId: "run-a" }),
+    ]);
+
+    const selectedGroup = resolveSelectedActivityGroup(groups, "item:2");
+
+    expect(selectedGroup?.type).toBe("single");
+    expect(selectedGroup?.items[0].id).toBe(toSafeId<"auditLog">("2"));
   });
 
   test("uses local calendar days instead of UTC slices", () => {

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/activity/activity-panel.logic.test.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/activity/activity-panel.logic.test.ts
@@ -3,15 +3,30 @@ import { describe, expect, test } from "bun:test";
 import { toSafeId } from "@/lib/safe-id";
 import type { MatterActivityItem } from "@/routes/_protected.workspaces/-queries";
 
-import { activityDayKey, groupActivityRuns } from "./activity-panel.logic";
+import { activityDayKey, groupActivityItems } from "./activity-panel.logic";
 
-const item = (id: string, runId: string | null): MatterActivityItem => ({
-  action: "update",
-  activityAt: "2026-07-30T12:00:00.000Z",
+type ItemOptions = {
+  action?: MatterActivityItem["action"];
+  activityAt?: string;
+  performer?: MatterActivityItem["performer"];
+  runId: string | null;
+};
+
+const item = (
+  id: string,
+  {
+    action = "update",
+    activityAt = "2026-07-30T12:00:00.000Z",
+    performer = { name: "Review agent", type: "agent" },
+    runId,
+  }: ItemOptions,
+): MatterActivityItem => ({
+  action,
+  activityAt,
   approval: { status: "not_required", user: null },
   category: "documents",
   id: toSafeId<"auditLog">(id),
-  performer: { name: "Review agent", type: "agent" },
+  performer,
   runId,
   target: {
     deleted: false,
@@ -32,19 +47,100 @@ const item = (id: string, runId: string | null): MatterActivityItem => ({
   },
 });
 
-describe("groupActivityRuns", () => {
+describe("groupActivityItems", () => {
   test("groups only consecutive events from the same AI run", () => {
-    const groups = groupActivityRuns([
-      item("1", "run-a"),
-      item("2", "run-a"),
-      item("3", null),
-      item("4", "run-a"),
+    const groups = groupActivityItems([
+      item("1", { runId: "run-a" }),
+      item("2", { runId: "run-a" }),
+      item("3", { runId: null }),
+      item("4", { runId: "run-a" }),
     ]);
 
     expect(
       groups.map((group) => group.items.map(({ id }) => String(id))),
     ).toEqual([["1", "2"], ["3"], ["4"]]);
     expect(new Set(groups.map(({ id }) => id)).size).toBe(groups.length);
+  });
+
+  test("groups fifty document uploads by one person within one minute", () => {
+    const anchor = new Date("2026-07-30T12:00:00.000Z").getTime();
+    const performer = {
+      deletedAt: null,
+      image: null,
+      name: "Matter Administrator",
+      type: "user",
+    } satisfies MatterActivityItem["performer"];
+    const uploads = Array.from({ length: 50 }, (_, index) =>
+      item(String(index), {
+        action: "create",
+        activityAt: new Date(anchor - index * 1000).toISOString(),
+        performer,
+        runId: null,
+      }),
+    );
+
+    const groups = groupActivityItems(uploads);
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0]?.type).toBe("document_batch");
+    expect(groups[0]?.items).toHaveLength(50);
+  });
+
+  test("starts a new document batch outside the first item's minute", () => {
+    const performer = {
+      deletedAt: null,
+      image: null,
+      name: "Matter Administrator",
+      type: "user",
+    } satisfies MatterActivityItem["performer"];
+    const groups = groupActivityItems([
+      item("1", {
+        action: "create",
+        activityAt: "2026-07-30T12:01:00.000Z",
+        performer,
+        runId: null,
+      }),
+      item("2", {
+        action: "create",
+        activityAt: "2026-07-30T12:00:01.000Z",
+        performer,
+        runId: null,
+      }),
+      item("3", {
+        action: "create",
+        activityAt: "2026-07-30T11:59:59.999Z",
+        performer,
+        runId: null,
+      }),
+    ]);
+
+    expect(groups.map(({ items }) => items.length)).toEqual([2, 1]);
+  });
+
+  test("keeps uploads in one batch when the minute crosses midnight", () => {
+    const performer = {
+      deletedAt: null,
+      image: null,
+      name: "Matter Administrator",
+      type: "user",
+    } satisfies MatterActivityItem["performer"];
+    const groups = groupActivityItems([
+      item("1", {
+        action: "create",
+        activityAt: "2026-07-31T00:00:20.000Z",
+        performer,
+        runId: null,
+      }),
+      item("2", {
+        action: "create",
+        activityAt: "2026-07-30T23:59:40.000Z",
+        performer,
+        runId: null,
+      }),
+    ]);
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0]?.items).toHaveLength(2);
   });
 
   test("uses local calendar days instead of UTC slices", () => {

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/activity/activity-panel.logic.test.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/activity/activity-panel.logic.test.ts
@@ -3,7 +3,11 @@ import { describe, expect, test } from "bun:test";
 import { toSafeId } from "@/lib/safe-id";
 import type { MatterActivityItem } from "@/routes/_protected.workspaces/-queries";
 
-import { activityDayKey, groupActivityItems } from "./activity-panel.logic";
+import {
+  activityDayKey,
+  expandActivityGroupsForList,
+  groupActivityItems,
+} from "./activity-panel.logic";
 
 type ItemOptions = {
   action?: MatterActivityItem["action"];
@@ -66,6 +70,7 @@ describe("groupActivityItems", () => {
     const anchor = new Date("2026-07-30T12:00:00.000Z").getTime();
     const performer = {
       deletedAt: null,
+      id: "user-1",
       image: null,
       name: "Matter Administrator",
       type: "user",
@@ -89,6 +94,7 @@ describe("groupActivityItems", () => {
   test("starts a new document batch outside the first item's minute", () => {
     const performer = {
       deletedAt: null,
+      id: "user-1",
       image: null,
       name: "Matter Administrator",
       type: "user",
@@ -120,6 +126,7 @@ describe("groupActivityItems", () => {
   test("keeps uploads in one batch when the minute crosses midnight", () => {
     const performer = {
       deletedAt: null,
+      id: "user-1",
       image: null,
       name: "Matter Administrator",
       type: "user",
@@ -141,6 +148,40 @@ describe("groupActivityItems", () => {
 
     expect(groups).toHaveLength(1);
     expect(groups[0]?.items).toHaveLength(2);
+  });
+
+  test("keeps same-named users in separate upload batches", () => {
+    const performer = {
+      deletedAt: null,
+      image: null,
+      name: "Matter Administrator",
+      type: "user",
+    } as const;
+    const groups = groupActivityItems([
+      item("1", {
+        action: "create",
+        performer: { ...performer, id: "user-1" },
+        runId: null,
+      }),
+      item("2", {
+        action: "create",
+        performer: { ...performer, id: "user-2" },
+        runId: null,
+      }),
+    ]);
+
+    expect(groups).toHaveLength(2);
+  });
+
+  test("expands every automation event for list mode", () => {
+    const groups = groupActivityItems([
+      item("1", { runId: "run-a" }),
+      item("2", { runId: "run-a" }),
+    ]);
+
+    expect(
+      expandActivityGroupsForList(groups).map(({ items }) => items[0].id),
+    ).toEqual(["1", "2"]);
   });
 
   test("uses local calendar days instead of UTC slices", () => {

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/activity/activity-panel.logic.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/activity/activity-panel.logic.ts
@@ -32,11 +32,7 @@ const hasSamePerformer = (
   if (left.performer.type !== "user" || right.performer.type !== "user") {
     return false;
   }
-  return (
-    left.performer.name === right.performer.name &&
-    left.performer.image === right.performer.image &&
-    left.performer.deletedAt === right.performer.deletedAt
-  );
+  return left.performer.id !== null && left.performer.id === right.performer.id;
 };
 
 const isWithinDocumentBatchWindow = (
@@ -104,3 +100,16 @@ export const activityDayKey = (activityAt: string): string => {
     ? activityAt
     : `${date.getFullYear()}-${date.getMonth()}-${date.getDate()}`;
 };
+
+export const expandActivityGroupsForList = (
+  groups: ActivityGroup[],
+): ActivityGroup[] =>
+  groups.flatMap((group) =>
+    group.type === "automation_run"
+      ? group.items.map((item) => ({
+          id: `item:${item.id}`,
+          items: [item],
+          type: "single" as const,
+        }))
+      : [group],
+  );

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/activity/activity-panel.logic.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/activity/activity-panel.logic.ts
@@ -1,28 +1,98 @@
 import type { MatterActivityItem } from "@/routes/_protected.workspaces/-queries";
 
-export type ActivityRun = {
-  id: string;
-  items: MatterActivityItem[];
-  runId: string | null;
+const DOCUMENT_BATCH_WINDOW_MS = 60_000;
+
+export type ActivityGroup =
+  | {
+      id: string;
+      items: [MatterActivityItem, ...MatterActivityItem[]];
+      type: "automation_run";
+    }
+  | {
+      id: string;
+      items: [MatterActivityItem, ...MatterActivityItem[]];
+      type: "document_batch";
+    }
+  | {
+      id: string;
+      items: [MatterActivityItem];
+      type: "single";
+    };
+
+const isBatchableDocumentCreate = (item: MatterActivityItem) =>
+  item.runId === null &&
+  item.action === "create" &&
+  item.target.kind === "document" &&
+  item.performer.type === "user";
+
+const hasSamePerformer = (
+  left: MatterActivityItem,
+  right: MatterActivityItem,
+) => {
+  if (left.performer.type !== "user" || right.performer.type !== "user") {
+    return false;
+  }
+  return (
+    left.performer.name === right.performer.name &&
+    left.performer.image === right.performer.image &&
+    left.performer.deletedAt === right.performer.deletedAt
+  );
 };
 
-export const groupActivityRuns = (
+const isWithinDocumentBatchWindow = (
+  anchor: MatterActivityItem,
+  candidate: MatterActivityItem,
+) => {
+  const anchorTime = new Date(anchor.activityAt).getTime();
+  const candidateTime = new Date(candidate.activityAt).getTime();
+  return (
+    Number.isFinite(anchorTime) &&
+    Number.isFinite(candidateTime) &&
+    Math.abs(anchorTime - candidateTime) <= DOCUMENT_BATCH_WINDOW_MS
+  );
+};
+
+export const groupActivityItems = (
   items: MatterActivityItem[],
-): ActivityRun[] => {
-  const groups: ActivityRun[] = [];
+): ActivityGroup[] => {
+  const groups: ActivityGroup[] = [];
 
   for (const item of items) {
-    const runKey = item.runId ? `run:${item.runId}` : null;
     const previous = groups.at(-1);
-    if (item.runId && previous?.runId === item.runId) {
+    if (
+      item.runId &&
+      previous?.type === "automation_run" &&
+      previous.items[0].runId === item.runId
+    ) {
       previous.items.push(item);
       continue;
     }
-    groups.push({
-      id: runKey ? `${runKey}:${item.id}` : `item:${item.id}`,
-      items: [item],
-      runId: item.runId,
-    });
+    if (
+      isBatchableDocumentCreate(item) &&
+      previous?.type === "document_batch" &&
+      hasSamePerformer(previous.items[0], item) &&
+      isWithinDocumentBatchWindow(previous.items[0], item)
+    ) {
+      previous.items.push(item);
+      continue;
+    }
+    if (item.runId) {
+      groups.push({
+        id: `run:${item.runId}:${item.id}`,
+        items: [item],
+        type: "automation_run",
+      });
+      continue;
+    }
+    if (isBatchableDocumentCreate(item)) {
+      groups.push({
+        id: `document-batch:${item.id}`,
+        items: [item],
+        type: "document_batch",
+      });
+      continue;
+    }
+    groups.push({ id: `item:${item.id}`, items: [item], type: "single" });
   }
 
   return groups;

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/activity/activity-panel.logic.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/activity/activity-panel.logic.ts
@@ -2,6 +2,13 @@ import type { MatterActivityItem } from "@/routes/_protected.workspaces/-queries
 
 const DOCUMENT_BATCH_WINDOW_MS = 60_000;
 
+export const activityDayKey = (activityAt: string): string => {
+  const date = new Date(activityAt);
+  return Number.isNaN(date.getTime())
+    ? activityAt
+    : `${date.getFullYear()}-${date.getMonth()}-${date.getDate()}`;
+};
+
 export type ActivityGroup =
   | {
       id: string;
@@ -32,7 +39,7 @@ const hasSamePerformer = (
   if (left.performer.type !== "user" || right.performer.type !== "user") {
     return false;
   }
-  return left.performer.id !== null && left.performer.id === right.performer.id;
+  return left.performer.id === right.performer.id;
 };
 
 const isWithinDocumentBatchWindow = (
@@ -48,6 +55,11 @@ const isWithinDocumentBatchWindow = (
   );
 };
 
+const hasSameActivityDay = (
+  left: MatterActivityItem,
+  right: MatterActivityItem,
+) => activityDayKey(left.activityAt) === activityDayKey(right.activityAt);
+
 export const groupActivityItems = (
   items: MatterActivityItem[],
 ): ActivityGroup[] => {
@@ -58,7 +70,8 @@ export const groupActivityItems = (
     if (
       item.runId &&
       previous?.type === "automation_run" &&
-      previous.items[0].runId === item.runId
+      previous.items[0].runId === item.runId &&
+      hasSameActivityDay(previous.items[0], item)
     ) {
       previous.items.push(item);
       continue;
@@ -67,6 +80,7 @@ export const groupActivityItems = (
       isBatchableDocumentCreate(item) &&
       previous?.type === "document_batch" &&
       hasSamePerformer(previous.items[0], item) &&
+      hasSameActivityDay(previous.items[0], item) &&
       isWithinDocumentBatchWindow(previous.items[0], item)
     ) {
       previous.items.push(item);
@@ -94,13 +108,6 @@ export const groupActivityItems = (
   return groups;
 };
 
-export const activityDayKey = (activityAt: string): string => {
-  const date = new Date(activityAt);
-  return Number.isNaN(date.getTime())
-    ? activityAt
-    : `${date.getFullYear()}-${date.getMonth()}-${date.getDate()}`;
-};
-
 export const expandActivityGroupsForList = (
   groups: ActivityGroup[],
 ): ActivityGroup[] =>
@@ -113,3 +120,32 @@ export const expandActivityGroupsForList = (
         }))
       : [group],
   );
+
+export const toSingleActivityGroup = (
+  item: MatterActivityItem,
+): ActivityGroup => ({
+  id: `item:${item.id}`,
+  items: [item],
+  type: "single",
+});
+
+export const resolveSelectedActivityGroup = (
+  groups: ActivityGroup[],
+  selectedGroupId: string | null,
+): ActivityGroup | null => {
+  if (!selectedGroupId) {
+    return null;
+  }
+  for (const group of groups) {
+    if (group.id === selectedGroupId) {
+      return group;
+    }
+    const selectedItem = group.items.find(
+      ({ id }) => `item:${id}` === selectedGroupId,
+    );
+    if (selectedItem) {
+      return toSingleActivityGroup(selectedItem);
+    }
+  }
+  return null;
+};

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/activity/activity-panel.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/activity/activity-panel.tsx
@@ -1,4 +1,4 @@
-import { Suspense, useDeferredValue, useMemo, useState } from "react";
+import { Suspense, useCallback, useDeferredValue, useState } from "react";
 import type { ReactElement, ReactNode } from "react";
 
 import { useSuspenseInfiniteQuery } from "@tanstack/react-query";
@@ -38,14 +38,17 @@ import {
 } from "@stll/ui/components/sheet";
 import { stellaToast } from "@stll/ui/components/toast";
 
+import { MatterIcon } from "@/components/matter-icon";
 import { PersonMentionLabel } from "@/components/person-mention-label";
 import Tooltip from "@/components/tooltip";
+import { useLatestCallback } from "@/hooks/use-latest-callback";
 import { useFormatter } from "@/i18n/formatting-context";
 import type { getTranslator } from "@/i18n/i18n-store";
 import { useAuthenticatedUser } from "@/lib/authenticated-user-context";
 import { detached } from "@/lib/detached";
 import { userErrorFromThrown } from "@/lib/errors/user-safe";
 import { isFileDisplayable } from "@/lib/types";
+import { DocumentIcon } from "@/routes/_protected.workspaces/$workspaceId/-components/document-icon";
 import { useInspectorStore } from "@/routes/_protected.workspaces/$workspaceId/-components/inspector/inspector-store";
 import type {
   MatterActivityCategory,
@@ -53,15 +56,33 @@ import type {
 } from "@/routes/_protected.workspaces/-queries";
 import { overviewActivityOptions } from "@/routes/_protected.workspaces/-queries";
 
-import { activityDayKey, groupActivityRuns } from "./activity-panel.logic";
+import type { ActivityGroup } from "./activity-panel.logic";
+import { activityDayKey, groupActivityItems } from "./activity-panel.logic";
 
 type ActivityPanelProps = { workspaceId: string };
-type ActivityDay = [MatterActivityItem, ...MatterActivityItem[]];
+type ActivityDay = [ActivityGroup, ...ActivityGroup[]];
 type ActivityViewMode = "timeline" | "list";
 type ActivityTranslator = ReturnType<typeof getTranslator>;
 
+const groupActivityDays = (groups: ActivityGroup[]): ActivityDay[] => {
+  const result = new Map<string, ActivityDay>();
+  for (const group of groups) {
+    const key = activityDayKey(group.items[0].activityAt);
+    const dayGroups = result.get(key);
+    if (dayGroups) {
+      dayGroups.push(group);
+      continue;
+    }
+    result.set(key, [group]);
+  }
+  return [...result.values()];
+};
+
 const FIRST_STRONG_ISOLATE = String.fromCodePoint(8296);
 const POP_DIRECTIONAL_ISOLATE = String.fromCodePoint(8297);
+const EMPTY_ACTIVITY_SENTENCE_PART = (
+  <span aria-hidden="true" className="hidden" />
+);
 const isolateBidi = (value: string): string =>
   `${FIRST_STRONG_ISOLATE}${value}${POP_DIRECTIONAL_ISOLATE}`;
 
@@ -104,7 +125,7 @@ const categoryLabel = (
 export const ActivityPanel = ({ workspaceId }: ActivityPanelProps) => {
   const t = useTranslations();
   const [category, setCategory] = useState<MatterActivityCategory>("all");
-  const [selectedItem, setSelectedItem] = useState<MatterActivityItem | null>(
+  const [selectedGroup, setSelectedGroup] = useState<ActivityGroup | null>(
     null,
   );
   const [viewMode, setViewMode] = useState<ActivityViewMode>("timeline");
@@ -155,7 +176,7 @@ export const ActivityPanel = ({ workspaceId }: ActivityPanelProps) => {
                   <MenuRadioItem
                     key={value}
                     onClick={() => {
-                      setSelectedItem(null);
+                      setSelectedGroup(null);
                       setCategory(value);
                     }}
                     value={value}
@@ -180,17 +201,17 @@ export const ActivityPanel = ({ workspaceId }: ActivityPanelProps) => {
         <Suspense fallback={<ActivityTimelineSkeleton />}>
           <ActivityTimeline
             category={deferredCategory}
-            onSelectItem={setSelectedItem}
+            onSelectGroup={setSelectedGroup}
             viewMode={viewMode}
             workspaceId={workspaceId}
           />
         </Suspense>
       </div>
       <ActivityDetailsSheet
-        item={selectedItem}
+        group={selectedGroup}
         onOpenChange={(open) => {
           if (!open) {
-            setSelectedItem(null);
+            setSelectedGroup(null);
           }
         }}
         workspaceId={workspaceId}
@@ -201,12 +222,12 @@ export const ActivityPanel = ({ workspaceId }: ActivityPanelProps) => {
 
 const ActivityTimeline = ({
   category,
-  onSelectItem,
+  onSelectGroup,
   viewMode,
   workspaceId,
 }: {
   category: MatterActivityCategory;
-  onSelectItem: (item: MatterActivityItem) => void;
+  onSelectGroup: (group: ActivityGroup) => void;
   viewMode: ActivityViewMode;
   workspaceId: string;
 }) => {
@@ -216,19 +237,34 @@ const ActivityTimeline = ({
     overviewActivityOptions({ activeOrganizationId, category, workspaceId }),
   );
   const items = query.data.pages.flatMap((page) => page.items);
-  const days = useMemo(() => {
-    const result = new Map<string, ActivityDay>();
-    for (const item of items) {
-      const key = activityDayKey(item.activityAt);
-      const dayItems = result.get(key);
-      if (dayItems) {
-        dayItems.push(item);
-      } else {
-        result.set(key, [item]);
-      }
-    }
-    return [...result.values()];
-  }, [items]);
+  const groups = groupActivityItems(items);
+  const days = groupActivityDays(groups);
+  const loadEarlier = () => {
+    const request = query
+      .fetchNextPage()
+      .then((result) => {
+        if (result.isError) {
+          stellaToast.add({
+            description: userErrorFromThrown(
+              result.error,
+              t("common.unexpectedError"),
+            ),
+            title: t("errors.actionFailed"),
+            type: "error",
+          });
+        }
+        return result;
+      })
+      .catch((error: unknown) => {
+        stellaToast.add({
+          description: userErrorFromThrown(error, t("common.unexpectedError")),
+          title: t("errors.actionFailed"),
+          type: "error",
+        });
+        throw error;
+      });
+    detached(request, "ActivityPanel.fetchNextPage");
+  };
 
   let activityContent: ReactNode;
   if (days.length === 0) {
@@ -239,83 +275,136 @@ const ActivityTimeline = ({
     );
   } else if (viewMode === "list") {
     activityContent = (
-      <ActivityList items={items} onSelectItem={onSelectItem} />
+      <>
+        <ActivityList groups={groups} onSelectGroup={onSelectGroup} />
+        {query.hasNextPage && (
+          <ActivityLoadSentinel
+            isFetching={query.isFetchingNextPage}
+            onLoadEarlier={loadEarlier}
+          />
+        )}
+      </>
     );
   } else {
     activityContent = (
       <>
-        <HorizontalTimeline days={days} onSelectItem={onSelectItem} />
+        <HorizontalTimeline
+          days={days}
+          hasNextPage={query.hasNextPage}
+          isFetchingNextPage={query.isFetchingNextPage}
+          onLoadEarlier={loadEarlier}
+          onSelectGroup={onSelectGroup}
+        />
         <div className="md:hidden">
-          {days.map((dayItems) => (
-            <div key={activityDayKey(dayItems[0].activityAt)}>
-              <TimelineDateMarker activityAt={dayItems[0].activityAt} />
-              {groupActivityRuns(dayItems).map((run) => (
+          {days.map((dayGroups) => (
+            <div key={activityDayKey(dayGroups[0].items[0].activityAt)}>
+              <TimelineDateMarker
+                activityAt={dayGroups[0].items[0].activityAt}
+              />
+              {dayGroups.map((group) => (
                 <ActivityRunRow
-                  items={run.items}
-                  key={run.id}
-                  onSelectItem={onSelectItem}
+                  group={group}
+                  key={group.id}
+                  onSelectGroup={onSelectGroup}
                 />
               ))}
             </div>
           ))}
+          {query.hasNextPage && (
+            <ActivityLoadSentinel
+              isFetching={query.isFetchingNextPage}
+              onLoadEarlier={loadEarlier}
+            />
+          )}
         </div>
       </>
     );
   }
 
   return (
-    <>
-      <div className="bg-background ring-foreground/5 overflow-hidden rounded-xl shadow-sm ring-1">
-        {activityContent}
-      </div>
+    <div className="bg-background ring-foreground/5 overflow-hidden rounded-xl shadow-sm ring-1">
+      {activityContent}
+    </div>
+  );
+};
 
-      {query.hasNextPage && (
-        <div className="mt-2 flex justify-center">
-          <Button
-            disabled={query.isFetchingNextPage}
-            onClick={() => {
-              const request = query
-                .fetchNextPage()
-                .then((result) => {
-                  if (result.isError) {
-                    stellaToast.add({
-                      description: userErrorFromThrown(
-                        result.error,
-                        t("common.unexpectedError"),
-                      ),
-                      title: t("errors.actionFailed"),
-                      type: "error",
-                    });
-                  }
-                  return result;
-                })
-                .catch((error: unknown) => {
-                  stellaToast.add({
-                    description: userErrorFromThrown(
-                      error,
-                      t("common.unexpectedError"),
-                    ),
-                    title: t("errors.actionFailed"),
-                    type: "error",
-                  });
-                  throw error;
-                });
-              detached(request, "ActivityPanel.fetchNextPage");
-            }}
-            size="sm"
-            variant="ghost"
-          >
-            {query.isFetchingNextPage
-              ? t("workspaces.overview.activity.loading")
-              : t("workspaces.overview.activity.loadEarlier")}
-          </Button>
-        </div>
-      )}
-    </>
+type ActivityLoadSentinelProps = {
+  horizontal?: boolean;
+  isFetching: boolean;
+  onLoadEarlier: () => void;
+};
+
+type ObserveActivityIntersectionOptions = {
+  node: HTMLSpanElement;
+  onIntersect: () => void;
+  root: Element | null;
+};
+
+const observeActivityIntersection = ({
+  node,
+  onIntersect,
+  root,
+}: ObserveActivityIntersectionOptions) => {
+  const observer = new IntersectionObserver(
+    (entries) => {
+      if (!entries.at(0)?.isIntersecting) {
+        return;
+      }
+      observer.disconnect();
+      onIntersect();
+    },
+    { root },
+  );
+  observer.observe(node);
+  return () => observer.disconnect();
+};
+
+const ActivityLoadSentinel = ({
+  horizontal = false,
+  isFetching,
+  onLoadEarlier,
+}: ActivityLoadSentinelProps) => {
+  const loadEarlier = useLatestCallback(onLoadEarlier);
+  const sentinelRef = useCallback(
+    (node: HTMLSpanElement | null) => {
+      if (!node || isFetching) {
+        return undefined;
+      }
+      const root = horizontal ? node.closest("[data-activity-scroll]") : null;
+      if (horizontal && !root) {
+        return undefined;
+      }
+      return observeActivityIntersection({
+        node,
+        onIntersect: loadEarlier,
+        root,
+      });
+    },
+    [horizontal, isFetching, loadEarlier],
+  );
+
+  return (
+    <span
+      aria-hidden="true"
+      className={horizontal ? "h-px w-px shrink-0" : "block h-px w-px"}
+      ref={sentinelRef}
+    />
   );
 };
 
 const ACTIVITY_SKELETON_WIDTHS = ["w-24", "w-32", "w-28", "w-36"] as const;
+
+const revealCurrentActivity = (node: HTMLSpanElement | null) => {
+  const scrollArea = node?.closest<HTMLElement>("[data-activity-scroll]");
+  if (!scrollArea) {
+    return;
+  }
+  const behavior = scrollArea.dataset["activityPositioned"]
+    ? "smooth"
+    : "instant";
+  scrollArea.dataset["activityPositioned"] = "true";
+  node.scrollIntoView({ behavior, block: "nearest", inline: "end" });
+};
 
 const ActivityTimelineSkeleton = () => (
   <div
@@ -372,73 +461,94 @@ const ActivityTimelineSkeleton = () => (
 
 const HorizontalTimeline = ({
   days,
-  onSelectItem,
+  hasNextPage,
+  isFetchingNextPage,
+  onLoadEarlier,
+  onSelectGroup,
 }: {
   days: ActivityDay[];
-  onSelectItem: (item: MatterActivityItem) => void;
+  hasNextPage: boolean;
+  isFetchingNextPage: boolean;
+  onLoadEarlier: () => void;
+  onSelectGroup: (group: ActivityGroup) => void;
 }) => (
-  <div className="hidden overflow-x-auto overscroll-x-contain md:block">
-    <div className="flex min-w-max snap-x snap-proximity px-5 pt-4 pb-5">
-      {days.flatMap((dayItems) =>
-        groupActivityRuns(dayItems).map((run, index) => (
+  <div
+    className="hidden overflow-x-auto overscroll-x-contain md:block"
+    data-activity-scroll=""
+  >
+    <div className="flex min-w-max snap-x snap-proximity flex-row-reverse px-5 pt-4 pb-5">
+      <HorizontalTodayMarker />
+      <span
+        aria-hidden="true"
+        className="size-px shrink-0"
+        key={days[0][0].id}
+        ref={revealCurrentActivity}
+      />
+      {days.flatMap((dayGroups) =>
+        dayGroups.map((group, index) => (
           <HorizontalActivityMilestone
-            dateAt={index === 0 ? dayItems[0].activityAt : undefined}
-            items={run.items}
-            key={run.id}
-            onSelectItem={onSelectItem}
+            dateAt={
+              index === dayGroups.length - 1
+                ? group.items[0].activityAt
+                : undefined
+            }
+            group={group}
+            key={group.id}
+            onSelectGroup={onSelectGroup}
           />
         )),
+      )}
+      {hasNextPage && (
+        <ActivityLoadSentinel
+          horizontal
+          isFetching={isFetchingNextPage}
+          onLoadEarlier={onLoadEarlier}
+        />
       )}
     </div>
   </div>
 );
 
+const HorizontalTodayMarker = () => {
+  const t = useTranslations();
+  return (
+    <div className="w-20 shrink-0 snap-end">
+      <div className="h-5" />
+      <div className="text-destructive mt-1 h-4 text-end text-[11px] font-medium">
+        {t("common.today")}
+      </div>
+      <div aria-hidden="true" className="relative mt-2 h-3">
+        <span className="bg-border absolute start-0 end-0 top-1/2 h-px" />
+        <span className="bg-destructive absolute end-0 top-0 h-3 w-px" />
+      </div>
+    </div>
+  );
+};
+
 const HorizontalActivityMilestone = ({
   dateAt,
-  items,
-  onSelectItem,
+  group,
+  onSelectGroup,
 }: {
   dateAt: string | undefined;
-  items: MatterActivityItem[];
-  onSelectItem: (item: MatterActivityItem) => void;
+  group: ActivityGroup;
+  onSelectGroup: (group: ActivityGroup) => void;
 }) => {
   const t = useTranslations();
+  const { items } = group;
   const first = items[0];
-  if (!first) {
-    return null;
-  }
 
-  if (first.runId === null) {
+  if (group.type !== "automation_run") {
     const detail = triggerDetail(first, t);
-    const target = (
-      <BidiText as="span" className="font-medium">
-        {targetName(first, t)}
-      </BidiText>
-    );
-    const content = (
-      <span className="min-w-0">
-        <span className="flex min-h-5 items-center text-[13px] leading-5 font-medium">
-          <Performer item={first} />
-        </span>
-        {detail && (
-          <span className="text-muted-foreground mt-0.5 block text-[11px] leading-4">
-            {detail}
-          </span>
-        )}
-        <span className="mt-2 block text-[13px] leading-5">
-          {actionSentence(first, <Performer item={first} />, target, t)}
-        </span>
-      </span>
-    );
 
     return (
       <HorizontalMilestoneFrame activityAt={first.activityAt} dateAt={dateAt}>
         <button
           className="hover:bg-muted/40 -ms-2 flex min-h-11 w-[calc(100%+0.5rem)] items-start rounded-md px-2 py-1 text-start transition-colors"
-          onClick={() => onSelectItem(first)}
+          onClick={() => onSelectGroup(group)}
           type="button"
         >
-          {content}
+          <ActivityTriplet detail={detail} group={group} size="compact" />
         </button>
       </HorizontalMilestoneFrame>
     );
@@ -474,7 +584,7 @@ const HorizontalActivityMilestone = ({
           <HorizontalRunActivityItem
             item={item}
             key={item.id}
-            onSelectItem={onSelectItem}
+            onSelectGroup={onSelectGroup}
           />
         ))}
       </div>
@@ -494,7 +604,7 @@ const HorizontalMilestoneFrame = ({
   const format = useFormatter();
   const date = new Date(activityAt);
   return (
-    <article className="w-64 shrink-0 snap-start">
+    <article className="animate-in fade-in-0 slide-in-from-right-1 rtl:slide-in-from-left-1 w-64 shrink-0 snap-start duration-300 motion-reduce:animate-none">
       <div className="text-muted-foreground h-5 pe-8 text-[13px] font-medium tabular-nums">
         {dateAt
           ? format.dateTime(new Date(dateAt), { dateStyle: "long" })
@@ -503,7 +613,7 @@ const HorizontalMilestoneFrame = ({
       <Tooltip
         content={format.dateTime(date, {
           dateStyle: "full",
-          timeStyle: "medium",
+          timeStyle: "long",
         })}
         render={
           <time
@@ -525,43 +635,32 @@ const HorizontalMilestoneFrame = ({
 
 const HorizontalRunActivityItem = ({
   item,
-  onSelectItem,
+  onSelectGroup,
 }: {
   item: MatterActivityItem;
-  onSelectItem: (item: MatterActivityItem) => void;
-}) => {
-  const t = useTranslations();
-  const target = (
-    <BidiText as="span" className="font-medium">
-      {targetName(item, t)}
-    </BidiText>
-  );
-  const sentence = actionSentence(item, <Performer item={item} />, target, t);
-  return (
-    <button
-      className="hover:bg-muted/40 -ms-2 flex min-h-11 w-[calc(100%+0.5rem)] items-center rounded-md px-2 text-start transition-colors"
-      onClick={() => onSelectItem(item)}
-      type="button"
-    >
-      <span className="text-[13px] leading-5">{sentence}</span>
-    </button>
-  );
-};
+  onSelectGroup: (group: ActivityGroup) => void;
+}) => (
+  <button
+    className="hover:bg-muted/40 -ms-2 flex min-h-11 w-[calc(100%+0.5rem)] items-center rounded-md px-2 text-start transition-colors"
+    onClick={() => onSelectGroup(toSingleActivityGroup(item))}
+    type="button"
+  >
+    <ActivityTriplet group={toSingleActivityGroup(item)} size="compact" />
+  </button>
+);
 
 const ActivityRunRow = ({
-  items,
-  onSelectItem,
+  group,
+  onSelectGroup,
 }: {
-  items: MatterActivityItem[];
-  onSelectItem: (item: MatterActivityItem) => void;
+  group: ActivityGroup;
+  onSelectGroup: (group: ActivityGroup) => void;
 }) => {
   const t = useTranslations();
+  const { items } = group;
   const first = items[0];
-  if (!first) {
-    return null;
-  }
-  if (first.runId === null) {
-    return <ActivityItemRow item={first} onSelectItem={onSelectItem} />;
+  if (group.type !== "automation_run") {
+    return <ActivityItemRow group={group} onSelectGroup={onSelectGroup} />;
   }
 
   const detail = triggerDetail(first, t);
@@ -593,7 +692,7 @@ const ActivityRunRow = ({
             <RunActivityItem
               item={item}
               key={item.id}
-              onSelectItem={onSelectItem}
+              onSelectGroup={onSelectGroup}
             />
           ))}
         </div>
@@ -643,7 +742,7 @@ const TimelineEntry = ({
       <Tooltip
         content={format.dateTime(date, {
           dateStyle: "full",
-          timeStyle: "medium",
+          timeStyle: "long",
         })}
         render={
           <time
@@ -670,28 +769,19 @@ const TimelineEntry = ({
 
 const RunActivityItem = ({
   item,
-  onSelectItem,
+  onSelectGroup,
 }: {
   item: MatterActivityItem;
-  onSelectItem: (item: MatterActivityItem) => void;
-}) => {
-  const t = useTranslations();
-  const target = (
-    <BidiText as="span" className="font-medium">
-      {targetName(item, t)}
-    </BidiText>
-  );
-  const sentence = actionSentence(item, <Performer item={item} />, target, t);
-  return (
-    <button
-      className="hover:bg-muted/40 -ms-2 flex min-h-11 w-[calc(100%+0.5rem)] items-center rounded-md px-2 text-start transition-colors"
-      onClick={() => onSelectItem(item)}
-      type="button"
-    >
-      <span className="text-sm leading-5">{sentence}</span>
-    </button>
-  );
-};
+  onSelectGroup: (group: ActivityGroup) => void;
+}) => (
+  <button
+    className="hover:bg-muted/40 -ms-2 flex min-h-11 w-[calc(100%+0.5rem)] items-center rounded-md px-2 text-start transition-colors"
+    onClick={() => onSelectGroup(toSingleActivityGroup(item))}
+    type="button"
+  >
+    <ActivityTriplet group={toSingleActivityGroup(item)} size="default" />
+  </button>
+);
 
 const RunCount = ({ count }: { count: number }) => {
   const t = useTranslations();
@@ -699,59 +789,42 @@ const RunCount = ({ count }: { count: number }) => {
 };
 
 const ActivityItemRow = ({
-  item,
-  onSelectItem,
+  group,
+  onSelectGroup,
 }: {
-  item: MatterActivityItem;
-  onSelectItem: (item: MatterActivityItem) => void;
+  group: ActivityGroup;
+  onSelectGroup: (group: ActivityGroup) => void;
 }) => {
+  const item = group.items[0];
   const t = useTranslations();
-  const actor = <Performer item={item} />;
-  const target = (
-    <BidiText as="span" className="font-medium">
-      {targetName(item, t)}
-    </BidiText>
-  );
-  const sentence = actionSentence(item, actor, target, t);
   const detail = triggerDetail(item, t);
-  const icon = targetIcon(item.target.kind);
-
-  const content = (
-    <span className="min-w-0 text-sm">
-      <span className="block leading-5">{sentence}</span>
-      {detail && (
-        <span className="text-muted-foreground mt-0.5 block text-xs">
-          {detail}
-        </span>
-      )}
-    </span>
-  );
+  const icon = activityGroupTargetIcon(group);
 
   return (
     <TimelineEntry activityAt={item.activityAt} marker={icon}>
       <button
         className="hover:bg-muted/40 flex min-h-11 w-full items-center rounded-md py-2 ps-3 pe-4 text-start transition-colors"
-        onClick={() => onSelectItem(item)}
+        onClick={() => onSelectGroup(group)}
         type="button"
       >
-        {content}
+        <ActivityTriplet detail={detail} group={group} size="default" />
       </button>
     </TimelineEntry>
   );
 };
 
 const ActivityList = ({
-  items,
-  onSelectItem,
+  groups,
+  onSelectGroup,
 }: {
-  items: MatterActivityItem[];
-  onSelectItem: (item: MatterActivityItem) => void;
+  groups: ActivityGroup[];
+  onSelectGroup: (group: ActivityGroup) => void;
 }) => {
   const format = useFormatter();
   const t = useTranslations();
   return (
     <div className="overflow-x-auto" role="list">
-      <div className="min-w-full md:w-max md:min-w-[57rem]">
+      <div className="w-full min-w-[57rem]">
         <div
           aria-hidden="true"
           className="text-muted-foreground hidden border-b px-4 py-2 text-[11px] font-medium md:grid md:grid-cols-[10rem_12rem_minmax(16rem,1fr)_14rem] md:gap-4"
@@ -761,22 +834,18 @@ const ActivityList = ({
           <span>{t("workspaces.overview.activity.list.event")}</span>
           <span>{t("workspaces.overview.activity.list.provenance")}</span>
         </div>
-        {items.map((item) => {
-          const target = (
-            <BidiText as="span" className="font-medium">
-              {targetName(item, t)}
-            </BidiText>
-          );
+        {groups.map((group) => {
+          const item = group.items[0];
           const provenance = triggerDetail(item, t);
           return (
             <div
               className="border-b last:border-b-0"
-              key={item.id}
+              key={group.id}
               role="listitem"
             >
               <button
                 className="hover:bg-muted/40 focus-visible:bg-muted/40 grid min-h-14 w-full gap-1 px-4 py-2.5 text-start transition-colors md:grid-cols-[10rem_12rem_minmax(16rem,1fr)_14rem] md:items-center md:gap-4"
-                onClick={() => onSelectItem(item)}
+                onClick={() => onSelectGroup(group)}
                 type="button"
               >
                 <time
@@ -792,7 +861,15 @@ const ActivityList = ({
                   <Performer item={item} />
                 </span>
                 <span className="min-w-0 text-sm leading-5">
-                  {actionSentence(item, <Performer item={item} />, target, t)}
+                  <span className="block">{activityAction(item, t)}</span>
+                  <span className="mt-1 grid grid-cols-[1.25rem_minmax(0,1fr)] items-start gap-x-1.5 font-medium">
+                    <span className="flex size-5 items-center justify-center">
+                      {activityGroupTargetIcon(group)}
+                    </span>
+                    <BidiText as="span">
+                      {activityGroupTargetName(group, t)}
+                    </BidiText>
+                  </span>
                 </span>
                 <span className="text-muted-foreground min-w-0 text-xs leading-4">
                   {provenance ??
@@ -810,26 +887,24 @@ const ActivityList = ({
 };
 
 const ActivityDetailsSheet = ({
-  item,
+  group,
   onOpenChange,
   workspaceId,
 }: {
-  item: MatterActivityItem | null;
+  group: ActivityGroup | null;
   onOpenChange: (open: boolean) => void;
   workspaceId: string;
 }) => {
   const format = useFormatter();
   const t = useTranslations();
-  if (!item) {
+  if (!group) {
     return null;
   }
 
-  const target = (
-    <BidiText as="span" className="font-medium">
-      {targetName(item, t)}
-    </BidiText>
-  );
-  const openTarget = getOpenTarget(item, workspaceId);
+  const item = group.items[0];
+  const provenance = triggerDetail(item, t);
+  const openTarget =
+    group.items.length === 1 ? getOpenTarget(item, workspaceId) : undefined;
   const rows = [
     {
       label: t("workspaces.overview.activity.details.dateTime"),
@@ -842,30 +917,69 @@ const ActivityDetailsSheet = ({
         </time>
       ),
     },
-    {
-      label: t("workspaces.overview.activity.details.actor"),
-      value: <Performer item={item} />,
-    },
-    {
-      label: t("workspaces.overview.activity.details.target"),
-      value: target,
-    },
-    {
-      label: t("common.category"),
-      value: categoryLabel(item.category, t),
-    },
-    {
-      label: t("workspaces.overview.activity.details.trigger"),
-      value: triggerName(item, t),
-    },
-    {
-      label: t("workspaces.overview.activity.details.channel"),
-      value: sourceName(item.trigger.source, t),
-    },
-    {
-      label: t("workspaces.overview.activity.details.approval"),
-      value: approvalName(item.approval.status, t),
-    },
+    ...(group.type === "document_batch" && group.items.length > 1
+      ? [
+          {
+            label: t("workspaces.overview.activity.filters.documents"),
+            value: (
+              <div className="space-y-1">
+                {group.items.map((batchItem) => {
+                  const batchOpenTarget = getOpenTarget(batchItem, workspaceId);
+                  const content = (
+                    <>
+                      <span className="flex size-5 shrink-0 items-center justify-center">
+                        {activityTargetIcon(batchItem)}
+                      </span>
+                      <BidiText as="span" className="min-w-0 break-words">
+                        {targetName(batchItem, t)}
+                      </BidiText>
+                    </>
+                  );
+                  if (!batchOpenTarget) {
+                    return (
+                      <div
+                        className="grid grid-cols-[1.25rem_minmax(0,1fr)] gap-x-1.5 py-1"
+                        key={batchItem.id}
+                      >
+                        {content}
+                      </div>
+                    );
+                  }
+                  return (
+                    <button
+                      className="hover:bg-muted -ms-2 grid min-h-11 w-[calc(100%+0.5rem)] grid-cols-[1.25rem_minmax(0,1fr)] items-center gap-x-1.5 rounded-md px-2 py-1 text-start transition-colors"
+                      key={batchItem.id}
+                      onClick={() => {
+                        onOpenChange(false);
+                        batchOpenTarget();
+                      }}
+                      type="button"
+                    >
+                      {content}
+                    </button>
+                  );
+                })}
+              </div>
+            ),
+          },
+        ]
+      : []),
+    ...(provenance
+      ? [
+          {
+            label: t("workspaces.overview.activity.details.trigger"),
+            value: provenance,
+          },
+        ]
+      : []),
+    ...(item.approval.status !== "not_required"
+      ? [
+          {
+            label: t("workspaces.overview.activity.details.approval"),
+            value: approvalName(item.approval.status, t),
+          },
+        ]
+      : []),
     ...(item.approval.user
       ? [
           {
@@ -874,18 +988,6 @@ const ActivityDetailsSheet = ({
           },
         ]
       : []),
-    ...(item.runId
-      ? [
-          {
-            label: t("workspaces.overview.activity.details.runId"),
-            value: <BidiText as="span">{item.runId}</BidiText>,
-          },
-        ]
-      : []),
-    {
-      label: t("workspaces.overview.activity.details.eventId"),
-      value: <BidiText as="span">{item.id}</BidiText>,
-    },
   ];
 
   return (
@@ -895,8 +997,8 @@ const ActivityDetailsSheet = ({
           <SheetTitle>
             {t("workspaces.overview.activity.details.title")}
           </SheetTitle>
-          <SheetDescription className="pe-8">
-            {actionSentence(item, <Performer item={item} />, target, t)}
+          <SheetDescription className="text-foreground pe-8">
+            <ActivityTriplet group={group} size="default" />
           </SheetDescription>
         </SheetHeader>
         <SheetPanel>
@@ -948,23 +1050,6 @@ const sourceName = (
   }
 };
 
-const triggerName = (item: MatterActivityItem, t: ActivityTranslator) => {
-  const detail = triggerDetail(item, t);
-  if (detail) {
-    return detail;
-  }
-  switch (item.trigger.type) {
-    case "direct":
-      return t("workspaces.overview.activity.details.direct");
-    case "webhook":
-      return t("workspaces.overview.activity.details.webhook");
-    case "system":
-      return t("workspaces.overview.activity.details.system");
-    default:
-      return t("workspaces.overview.activity.details.notAvailable");
-  }
-};
-
 const approvalName = (
   status: MatterActivityItem["approval"]["status"],
   t: ActivityTranslator,
@@ -1005,25 +1090,82 @@ const Performer = ({ item }: { item: MatterActivityItem }) => {
     );
   }
   return (
-    <BidiText as="span" className="inline-flex items-center gap-1 font-medium">
-      {item.performer.type === "agent" ? (
-        <BotIcon className="size-3.5" />
-      ) : (
-        <WorkflowIcon className="size-3.5" />
-      )}
+    <BidiText
+      as="span"
+      className="inline-flex items-center gap-1.5 font-medium"
+    >
+      <span className="flex size-5 items-center justify-center">
+        {item.performer.type === "agent" ? (
+          <BotIcon className="size-3.5" />
+        ) : (
+          <WorkflowIcon className="size-3.5" />
+        )}
+      </span>
       {item.performer.name ??
         t("workspaces.overview.activity.automatedService")}
     </BidiText>
   );
 };
 
-const actionSentence = (
+type ActivityTripletProps = {
+  detail?: ReactNode;
+  group: ActivityGroup;
+  size: "compact" | "default";
+};
+
+const toSingleActivityGroup = (item: MatterActivityItem): ActivityGroup => ({
+  id: `item:${item.id}`,
+  items: [item],
+  type: "single",
+});
+
+const ActivityTriplet = ({ detail, group, size }: ActivityTripletProps) => {
+  const t = useTranslations();
+  const item = group.items[0];
+  const compact = size === "compact";
+  return (
+    <span
+      className={
+        compact ? "min-w-0 text-[13px] leading-5" : "min-w-0 text-sm leading-5"
+      }
+    >
+      <span className="block min-h-5 font-medium">
+        <Performer item={item} />
+      </span>
+      <span className="mt-1 grid grid-cols-[1.25rem_minmax(0,1fr)] gap-x-1.5">
+        <span aria-hidden="true" />
+        <span>{activityAction(item, t)}</span>
+      </span>
+      <span className="mt-1 grid grid-cols-[1.25rem_minmax(0,1fr)] items-start gap-x-1.5 font-medium">
+        <span className="flex size-5 items-center justify-center">
+          {activityGroupTargetIcon(group)}
+        </span>
+        <BidiText as="span">{activityGroupTargetName(group, t)}</BidiText>
+      </span>
+      {detail && (
+        <span
+          className={
+            compact
+              ? "text-muted-foreground mt-0.5 grid grid-cols-[1.25rem_minmax(0,1fr)] gap-x-1.5 text-[11px] leading-4"
+              : "text-muted-foreground mt-0.5 grid grid-cols-[1.25rem_minmax(0,1fr)] gap-x-1.5 text-xs leading-4"
+          }
+        >
+          <span aria-hidden="true" />
+          <span>{detail}</span>
+        </span>
+      )}
+    </span>
+  );
+};
+
+const activityAction = (
   item: MatterActivityItem,
-  actor: ReactElement | null,
-  target: ReactElement,
   t: ActivityTranslator,
 ): ReactElement => {
-  const values = { actor: () => actor, target: () => target };
+  const values = {
+    actor: () => EMPTY_ACTIVITY_SENTENCE_PART,
+    target: () => EMPTY_ACTIVITY_SENTENCE_PART,
+  };
   switch (item.action) {
     case "add":
       return (
@@ -1058,7 +1200,7 @@ const actionSentence = (
         <>{t.rich("workspaces.overview.activity.actions.cancelled", values)}</>
       );
     default:
-      return target;
+      return item.action satisfies never;
   }
 };
 
@@ -1120,14 +1262,16 @@ const triggerDetail = (item: MatterActivityItem, t: ActivityTranslator) => {
   }
 };
 
-const targetIcon = (kind: MatterActivityItem["target"]["kind"]) => {
-  switch (kind) {
+const targetIcon = (item: MatterActivityItem) => {
+  switch (item.target.kind) {
     case "document":
       return <FileTextIcon className="text-muted-foreground size-3.5" />;
     case "task":
       return <SquareCheckIcon className="text-muted-foreground size-3.5" />;
     case "matter":
-      return <ScaleIcon className="text-muted-foreground size-3.5" />;
+      return (
+        <MatterIcon className="text-muted-foreground size-3.5" variant="none" />
+      );
     case "team":
       return <UsersIcon className="text-muted-foreground size-3.5" />;
     case "court":
@@ -1135,10 +1279,54 @@ const targetIcon = (kind: MatterActivityItem["target"]["kind"]) => {
     case "automation":
       return <WorkflowIcon className="text-muted-foreground size-3.5" />;
     default: {
-      const exhaustive: never = kind;
+      const exhaustive: never = item.target.kind;
       return exhaustive;
     }
   }
+};
+
+const activityTargetIcon = (item: MatterActivityItem) => {
+  if (item.target.kind === "document" && item.target.mimeType) {
+    return (
+      <DocumentIcon
+        className="size-3.5"
+        fileName={item.target.name}
+        mimeType={item.target.mimeType}
+      />
+    );
+  }
+  return targetIcon(item);
+};
+
+const activityGroupTargetIcon = (group: ActivityGroup) => {
+  if (group.type === "document_batch" && group.items.length > 1) {
+    return (
+      <span
+        aria-hidden="true"
+        className="flex w-5 items-center [&>*+*]:-ms-2.5"
+      >
+        {group.items.slice(0, 3).map((item) => (
+          <span
+            className="bg-background flex size-3.5 shrink-0 items-center justify-center rounded-[2px]"
+            key={item.id}
+          >
+            {activityTargetIcon(item)}
+          </span>
+        ))}
+      </span>
+    );
+  }
+  return activityTargetIcon(group.items[0]);
+};
+
+const activityGroupTargetName = (
+  group: ActivityGroup,
+  t: ActivityTranslator,
+) => {
+  if (group.type === "document_batch" && group.items.length > 1) {
+    return t("workspaces.documentsCount", { count: group.items.length });
+  }
+  return targetName(group.items[0], t);
 };
 
 const getOpenTarget = (item: MatterActivityItem, workspaceId: string) => {

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/activity/activity-panel.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/activity/activity-panel.tsx
@@ -57,7 +57,11 @@ import type {
 import { overviewActivityOptions } from "@/routes/_protected.workspaces/-queries";
 
 import type { ActivityGroup } from "./activity-panel.logic";
-import { activityDayKey, groupActivityItems } from "./activity-panel.logic";
+import {
+  activityDayKey,
+  expandActivityGroupsForList,
+  groupActivityItems,
+} from "./activity-panel.logic";
 
 type ActivityPanelProps = { workspaceId: string };
 type ActivityDay = [ActivityGroup, ...ActivityGroup[]];
@@ -822,6 +826,7 @@ const ActivityList = ({
 }) => {
   const format = useFormatter();
   const t = useTranslations();
+  const listGroups = expandActivityGroupsForList(groups);
   return (
     <div className="overflow-x-auto" role="list">
       <div className="w-full min-w-[57rem]">
@@ -834,7 +839,7 @@ const ActivityList = ({
           <span>{t("workspaces.overview.activity.list.event")}</span>
           <span>{t("workspaces.overview.activity.list.provenance")}</span>
         </div>
-        {groups.map((group) => {
+        {listGroups.map((group) => {
           const item = group.items[0];
           const provenance = triggerDetail(item, t);
           return (

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/activity/activity-panel.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/activity/activity-panel.tsx
@@ -61,6 +61,8 @@ import {
   activityDayKey,
   expandActivityGroupsForList,
   groupActivityItems,
+  resolveSelectedActivityGroup,
+  toSingleActivityGroup,
 } from "./activity-panel.logic";
 
 type ActivityPanelProps = { workspaceId: string };
@@ -84,9 +86,6 @@ const groupActivityDays = (groups: ActivityGroup[]): ActivityDay[] => {
 
 const FIRST_STRONG_ISOLATE = String.fromCodePoint(8296);
 const POP_DIRECTIONAL_ISOLATE = String.fromCodePoint(8297);
-const EMPTY_ACTIVITY_SENTENCE_PART = (
-  <span aria-hidden="true" className="hidden" />
-);
 const isolateBidi = (value: string): string =>
   `${FIRST_STRONG_ISOLATE}${value}${POP_DIRECTIONAL_ISOLATE}`;
 
@@ -129,9 +128,7 @@ const categoryLabel = (
 export const ActivityPanel = ({ workspaceId }: ActivityPanelProps) => {
   const t = useTranslations();
   const [category, setCategory] = useState<MatterActivityCategory>("all");
-  const [selectedGroup, setSelectedGroup] = useState<ActivityGroup | null>(
-    null,
-  );
+  const [selectedGroupId, setSelectedGroupId] = useState<string | null>(null);
   const [viewMode, setViewMode] = useState<ActivityViewMode>("timeline");
   const deferredCategory = useDeferredValue(category);
   const isFilterPending = category !== deferredCategory;
@@ -180,7 +177,7 @@ export const ActivityPanel = ({ workspaceId }: ActivityPanelProps) => {
                   <MenuRadioItem
                     key={value}
                     onClick={() => {
-                      setSelectedGroup(null);
+                      setSelectedGroupId(null);
                       setCategory(value);
                     }}
                     value={value}
@@ -205,33 +202,27 @@ export const ActivityPanel = ({ workspaceId }: ActivityPanelProps) => {
         <Suspense fallback={<ActivityTimelineSkeleton />}>
           <ActivityTimeline
             category={deferredCategory}
-            onSelectGroup={setSelectedGroup}
+            onSelectedGroupChange={setSelectedGroupId}
+            selectedGroupId={selectedGroupId}
             viewMode={viewMode}
             workspaceId={workspaceId}
           />
         </Suspense>
       </div>
-      <ActivityDetailsSheet
-        group={selectedGroup}
-        onOpenChange={(open) => {
-          if (!open) {
-            setSelectedGroup(null);
-          }
-        }}
-        workspaceId={workspaceId}
-      />
     </section>
   );
 };
 
 const ActivityTimeline = ({
   category,
-  onSelectGroup,
+  onSelectedGroupChange,
+  selectedGroupId,
   viewMode,
   workspaceId,
 }: {
   category: MatterActivityCategory;
-  onSelectGroup: (group: ActivityGroup) => void;
+  onSelectedGroupChange: (groupId: string | null) => void;
+  selectedGroupId: string | null;
   viewMode: ActivityViewMode;
   workspaceId: string;
 }) => {
@@ -243,6 +234,10 @@ const ActivityTimeline = ({
   const items = query.data.pages.flatMap((page) => page.items);
   const groups = groupActivityItems(items);
   const days = groupActivityDays(groups);
+  const selectedGroup = resolveSelectedActivityGroup(groups, selectedGroupId);
+  const onSelectGroup = (group: ActivityGroup) => {
+    onSelectedGroupChange(group.id);
+  };
   const loadEarlier = () => {
     const request = query
       .fetchNextPage()
@@ -283,6 +278,7 @@ const ActivityTimeline = ({
         <ActivityList groups={groups} onSelectGroup={onSelectGroup} />
         {query.hasNextPage && (
           <ActivityLoadSentinel
+            hasError={query.isFetchNextPageError}
             isFetching={query.isFetchingNextPage}
             onLoadEarlier={loadEarlier}
           />
@@ -295,6 +291,7 @@ const ActivityTimeline = ({
         <HorizontalTimeline
           days={days}
           hasNextPage={query.hasNextPage}
+          hasNextPageError={query.isFetchNextPageError}
           isFetchingNextPage={query.isFetchingNextPage}
           onLoadEarlier={loadEarlier}
           onSelectGroup={onSelectGroup}
@@ -316,6 +313,7 @@ const ActivityTimeline = ({
           ))}
           {query.hasNextPage && (
             <ActivityLoadSentinel
+              hasError={query.isFetchNextPageError}
               isFetching={query.isFetchingNextPage}
               onLoadEarlier={loadEarlier}
             />
@@ -326,13 +324,25 @@ const ActivityTimeline = ({
   }
 
   return (
-    <div className="bg-background ring-foreground/5 overflow-hidden rounded-xl shadow-sm ring-1">
-      {activityContent}
-    </div>
+    <>
+      <div className="bg-background ring-foreground/5 overflow-hidden rounded-xl shadow-sm ring-1">
+        {activityContent}
+      </div>
+      <ActivityDetailsSheet
+        group={selectedGroup}
+        onOpenChange={(open) => {
+          if (!open) {
+            onSelectedGroupChange(null);
+          }
+        }}
+        workspaceId={workspaceId}
+      />
+    </>
   );
 };
 
 type ActivityLoadSentinelProps = {
+  hasError: boolean;
   horizontal?: boolean;
   isFetching: boolean;
   onLoadEarlier: () => void;
@@ -364,14 +374,16 @@ const observeActivityIntersection = ({
 };
 
 const ActivityLoadSentinel = ({
+  hasError,
   horizontal = false,
   isFetching,
   onLoadEarlier,
 }: ActivityLoadSentinelProps) => {
+  const t = useTranslations();
   const loadEarlier = useLatestCallback(onLoadEarlier);
   const sentinelRef = useCallback(
     (node: HTMLSpanElement | null) => {
-      if (!node || isFetching) {
+      if (!node || hasError || isFetching) {
         return undefined;
       }
       const root = horizontal ? node.closest("[data-activity-scroll]") : null;
@@ -384,8 +396,26 @@ const ActivityLoadSentinel = ({
         root,
       });
     },
-    [horizontal, isFetching, loadEarlier],
+    [hasError, horizontal, isFetching, loadEarlier],
   );
+
+  if (hasError) {
+    return (
+      <Button
+        className={
+          horizontal ? "mx-4 min-h-11 shrink-0 self-end" : "m-2 min-h-11"
+        }
+        disabled={isFetching}
+        onClick={loadEarlier}
+        size="sm"
+        variant="ghost"
+      >
+        {isFetching
+          ? t("workspaces.overview.activity.loading")
+          : t("common.tryAgain")}
+      </Button>
+    );
+  }
 
   return (
     <span
@@ -399,13 +429,20 @@ const ActivityLoadSentinel = ({
 const ACTIVITY_SKELETON_WIDTHS = ["w-24", "w-32", "w-28", "w-36"] as const;
 
 const revealCurrentActivity = (node: HTMLSpanElement | null) => {
-  const scrollArea = node?.closest<HTMLElement>("[data-activity-scroll]");
+  if (!node) {
+    return;
+  }
+  const scrollArea = node.closest<HTMLElement>("[data-activity-scroll]");
   if (!scrollArea) {
     return;
   }
-  const behavior = scrollArea.dataset["activityPositioned"]
-    ? "smooth"
-    : "instant";
+  const prefersReducedMotion = globalThis.matchMedia(
+    "(prefers-reduced-motion: reduce)",
+  ).matches;
+  const behavior =
+    scrollArea.dataset["activityPositioned"] && !prefersReducedMotion
+      ? "smooth"
+      : "instant";
   scrollArea.dataset["activityPositioned"] = "true";
   node.scrollIntoView({ behavior, block: "nearest", inline: "end" });
 };
@@ -465,12 +502,14 @@ const ActivityTimelineSkeleton = () => (
 
 const HorizontalTimeline = ({
   days,
+  hasNextPageError,
   hasNextPage,
   isFetchingNextPage,
   onLoadEarlier,
   onSelectGroup,
 }: {
   days: ActivityDay[];
+  hasNextPageError: boolean;
   hasNextPage: boolean;
   isFetchingNextPage: boolean;
   onLoadEarlier: () => void;
@@ -485,7 +524,7 @@ const HorizontalTimeline = ({
       <span
         aria-hidden="true"
         className="size-px shrink-0"
-        key={days[0][0].id}
+        key={days.at(0)?.at(0)?.id}
         ref={revealCurrentActivity}
       />
       {days.flatMap((dayGroups) =>
@@ -504,6 +543,7 @@ const HorizontalTimeline = ({
       )}
       {hasNextPage && (
         <ActivityLoadSentinel
+          hasError={hasNextPageError}
           horizontal
           isFetching={isFetchingNextPage}
           onLoadEarlier={onLoadEarlier}
@@ -578,11 +618,9 @@ const HorizontalActivityMilestone = ({
           <RunCount count={items.length} />
         </span>
       </div>
-      {detail && (
-        <p className="text-muted-foreground mt-0.5 text-[11px] leading-4">
-          {detail}
-        </p>
-      )}
+      <p className="text-muted-foreground mt-0.5 text-[11px] leading-4">
+        {detail}
+      </p>
       <div className="mt-3 space-y-1">
         {items.map((item) => (
           <HorizontalRunActivityItem
@@ -688,9 +726,7 @@ const ActivityRunRow = ({
             <RunCount count={items.length} />
           </span>
         </div>
-        {detail && (
-          <p className="text-muted-foreground mt-0.5 text-xs">{detail}</p>
-        )}
+        <p className="text-muted-foreground mt-0.5 text-xs">{detail}</p>
         <div className="mt-2.5 space-y-0.5 ps-3">
           {items.map((item) => (
             <RunActivityItem
@@ -829,7 +865,7 @@ const ActivityList = ({
   const listGroups = expandActivityGroupsForList(groups);
   return (
     <div className="overflow-x-auto" role="list">
-      <div className="w-full min-w-[57rem]">
+      <div className="w-full md:min-w-[57rem]">
         <div
           aria-hidden="true"
           className="text-muted-foreground hidden border-b px-4 py-2 text-[11px] font-medium md:grid md:grid-cols-[10rem_12rem_minmax(16rem,1fr)_14rem] md:gap-4"
@@ -877,10 +913,7 @@ const ActivityList = ({
                   </span>
                 </span>
                 <span className="text-muted-foreground min-w-0 text-xs leading-4">
-                  {provenance ??
-                    (item.trigger.source
-                      ? sourceName(item.trigger.source, t)
-                      : "—")}
+                  {provenance}
                 </span>
               </button>
             </div>
@@ -935,9 +968,24 @@ const ActivityDetailsSheet = ({
                       <span className="flex size-5 shrink-0 items-center justify-center">
                         {activityTargetIcon(batchItem)}
                       </span>
-                      <BidiText as="span" className="min-w-0 break-words">
-                        {targetName(batchItem, t)}
-                      </BidiText>
+                      <span className="min-w-0">
+                        <BidiText as="span" className="block break-words">
+                          {targetName(batchItem, t)}
+                        </BidiText>
+                        <span className="text-muted-foreground mt-0.5 block text-xs leading-4 tabular-nums">
+                          <time dateTime={batchItem.activityAt}>
+                            {format.dateTime(new Date(batchItem.activityAt), {
+                              dateStyle: "medium",
+                              timeStyle: "short",
+                            })}
+                          </time>
+                          <span aria-hidden="true"> · </span>
+                          {t("workspaces.overview.activity.details.eventId")}:{" "}
+                          <BidiText as="span" className="break-all">
+                            {batchItem.id}
+                          </BidiText>
+                        </span>
+                      </span>
                     </>
                   );
                   if (!batchOpenTarget) {
@@ -969,14 +1017,10 @@ const ActivityDetailsSheet = ({
           },
         ]
       : []),
-    ...(provenance
-      ? [
-          {
-            label: t("workspaces.overview.activity.details.trigger"),
-            value: provenance,
-          },
-        ]
-      : []),
+    {
+      label: t("workspaces.overview.activity.details.trigger"),
+      value: provenance,
+    },
     ...(item.approval.status !== "not_required"
       ? [
           {
@@ -993,6 +1037,18 @@ const ActivityDetailsSheet = ({
           },
         ]
       : []),
+    ...(item.runId
+      ? [
+          {
+            label: t("workspaces.overview.activity.details.runId"),
+            value: <BidiText as="span">{item.runId}</BidiText>,
+          },
+        ]
+      : []),
+    {
+      label: t("workspaces.overview.activity.details.eventId"),
+      value: <BidiText as="span">{item.id}</BidiText>,
+    },
   ];
 
   return (
@@ -1118,12 +1174,6 @@ type ActivityTripletProps = {
   size: "compact" | "default";
 };
 
-const toSingleActivityGroup = (item: MatterActivityItem): ActivityGroup => ({
-  id: `item:${item.id}`,
-  items: [item],
-  type: "single",
-});
-
 const ActivityTriplet = ({ detail, group, size }: ActivityTripletProps) => {
   const t = useTranslations();
   const item = group.items[0];
@@ -1147,7 +1197,7 @@ const ActivityTriplet = ({ detail, group, size }: ActivityTripletProps) => {
         </span>
         <BidiText as="span">{activityGroupTargetName(group, t)}</BidiText>
       </span>
-      {detail && (
+      {detail !== null && detail !== undefined && (
         <span
           className={
             compact
@@ -1166,44 +1216,24 @@ const ActivityTriplet = ({ detail, group, size }: ActivityTripletProps) => {
 const activityAction = (
   item: MatterActivityItem,
   t: ActivityTranslator,
-): ReactElement => {
-  const values = {
-    actor: () => EMPTY_ACTIVITY_SENTENCE_PART,
-    target: () => EMPTY_ACTIVITY_SENTENCE_PART,
-  };
+): string => {
   switch (item.action) {
     case "add":
-      return (
-        <>{t.rich("workspaces.overview.activity.actions.added", values)}</>
-      );
+      return t("workspaces.overview.activity.actions.added");
     case "create":
-      return (
-        <>{t.rich("workspaces.overview.activity.actions.created", values)}</>
-      );
+      return t("workspaces.overview.activity.actions.created");
     case "update":
-      return (
-        <>{t.rich("workspaces.overview.activity.actions.updated", values)}</>
-      );
+      return t("workspaces.overview.activity.actions.updated");
     case "delete":
-      return (
-        <>{t.rich("workspaces.overview.activity.actions.deleted", values)}</>
-      );
+      return t("workspaces.overview.activity.actions.deleted");
     case "remove":
-      return (
-        <>{t.rich("workspaces.overview.activity.actions.removed", values)}</>
-      );
+      return t("workspaces.overview.activity.actions.removed");
     case "execute":
-      return (
-        <>{t.rich("workspaces.overview.activity.actions.executed", values)}</>
-      );
+      return t("workspaces.overview.activity.actions.executed");
     case "review":
-      return (
-        <>{t.rich("workspaces.overview.activity.actions.reviewed", values)}</>
-      );
+      return t("workspaces.overview.activity.actions.reviewed");
     case "cancel":
-      return (
-        <>{t.rich("workspaces.overview.activity.actions.cancelled", values)}</>
-      );
+      return t("workspaces.overview.activity.actions.cancelled");
     default:
       return item.action satisfies never;
   }
@@ -1231,6 +1261,21 @@ const targetName = (item: MatterActivityItem, t: ActivityTranslator) => {
       return exhaustive;
     }
   }
+};
+
+const triggerLabelWithSource = (
+  label: string,
+  source: MatterActivityItem["trigger"]["source"],
+  t: ActivityTranslator,
+) => {
+  if (!source) {
+    return label;
+  }
+  return (
+    <>
+      {label} · {sourceName(source, t)}
+    </>
+  );
 };
 
 const triggerDetail = (item: MatterActivityItem, t: ActivityTranslator) => {
@@ -1262,8 +1307,28 @@ const triggerDetail = (item: MatterActivityItem, t: ActivityTranslator) => {
       return user
         ? t("workspaces.overview.activity.provenance.delegatedBy", { user })
         : t("workspaces.overview.activity.provenance.delegated");
-    default:
-      return null;
+    case "direct":
+      return triggerLabelWithSource(
+        t("workspaces.overview.activity.details.direct"),
+        item.trigger.source,
+        t,
+      );
+    case "webhook":
+      return triggerLabelWithSource(
+        t("workspaces.overview.activity.details.webhook"),
+        item.trigger.source,
+        t,
+      );
+    case "system":
+      return triggerLabelWithSource(
+        t("workspaces.overview.activity.details.system"),
+        item.trigger.source,
+        t,
+      );
+    default: {
+      const exhaustive: never = item.trigger.type;
+      return exhaustive;
+    }
   }
 };
 

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-hooks/create-file-upload-payload.logic.test.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-hooks/create-file-upload-payload.logic.test.ts
@@ -7,6 +7,7 @@ import { workspacesKeys } from "@/routes/_protected.workspaces/-queries";
 import {
   buildEntityCreateInvalidationPayload,
   buildEntityCreatePresignPayload,
+  entityCreateLocalInvalidationKeys,
 } from "./create-file-upload-payload.logic";
 
 const baseInput = {
@@ -50,15 +51,20 @@ describe("entity-create upload payload", () => {
     expect(payload.size).toBe(0);
   });
 
-  test("invalidates matter activity when an upload is finalized", () => {
+  test("broadcasts one non-overlapping invalidation per finalized file", () => {
     const workspaceId = "workspace_upload";
 
     expect(buildEntityCreateInvalidationPayload(workspaceId)).toEqual({
       queryKey: entitiesKeys.all(workspaceId),
-      queryKeys: [
-        workspacesKeys.overview(workspaceId),
-        workspacesKeys.overviewActivityAll(workspaceId),
-      ],
     });
+  });
+
+  test("invalidates overview and activity once after the upload operation", () => {
+    const workspaceId = "workspace_upload";
+
+    expect(entityCreateLocalInvalidationKeys(workspaceId)).toEqual([
+      entitiesKeys.all(workspaceId),
+      workspacesKeys.overview(workspaceId),
+    ]);
   });
 });

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-hooks/create-file-upload-payload.logic.test.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-hooks/create-file-upload-payload.logic.test.ts
@@ -1,8 +1,13 @@
 import { describe, expect, test } from "bun:test";
 
 import { toSafeId } from "@/lib/safe-id";
+import { entitiesKeys } from "@/routes/_protected.workspaces/$workspaceId/-queries/entities";
+import { workspacesKeys } from "@/routes/_protected.workspaces/-queries";
 
-import { buildEntityCreatePresignPayload } from "./create-file-upload-payload.logic";
+import {
+  buildEntityCreateInvalidationPayload,
+  buildEntityCreatePresignPayload,
+} from "./create-file-upload-payload.logic";
 
 const baseInput = {
   propertyId: "property_upload",
@@ -43,5 +48,17 @@ describe("entity-create upload payload", () => {
     });
 
     expect(payload.size).toBe(0);
+  });
+
+  test("invalidates matter activity when an upload is finalized", () => {
+    const workspaceId = "workspace_upload";
+
+    expect(buildEntityCreateInvalidationPayload(workspaceId)).toEqual({
+      queryKey: entitiesKeys.all(workspaceId),
+      queryKeys: [
+        workspacesKeys.overview(workspaceId),
+        workspacesKeys.overviewActivityAll(workspaceId),
+      ],
+    });
   });
 });

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-hooks/create-file-upload-payload.logic.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-hooks/create-file-upload-payload.logic.ts
@@ -1,4 +1,6 @@
 import { toSafeId } from "@/lib/safe-id";
+import { entitiesKeys } from "@/routes/_protected.workspaces/$workspaceId/-queries/entities";
+import { workspacesKeys } from "@/routes/_protected.workspaces/-queries";
 
 export type EntityCreatePresignPayloadInput = {
   propertyId: string;
@@ -24,4 +26,12 @@ export const buildEntityCreatePresignPayload = ({
   mimeType,
   size,
   sha256Hex,
+});
+
+export const buildEntityCreateInvalidationPayload = (workspaceId: string) => ({
+  queryKey: entitiesKeys.all(workspaceId),
+  queryKeys: [
+    workspacesKeys.overview(workspaceId),
+    workspacesKeys.overviewActivityAll(workspaceId),
+  ],
 });

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-hooks/create-file-upload-payload.logic.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-hooks/create-file-upload-payload.logic.ts
@@ -30,8 +30,10 @@ export const buildEntityCreatePresignPayload = ({
 
 export const buildEntityCreateInvalidationPayload = (workspaceId: string) => ({
   queryKey: entitiesKeys.all(workspaceId),
-  queryKeys: [
-    workspacesKeys.overview(workspaceId),
-    workspacesKeys.overviewActivityAll(workspaceId),
-  ],
 });
+
+export const entityCreateLocalInvalidationKeys = (workspaceId: string) => [
+  entitiesKeys.all(workspaceId),
+  // This prefix also invalidates every overview activity category.
+  workspacesKeys.overview(workspaceId),
+];

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-hooks/use-create-file-entities.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-hooks/use-create-file-entities.ts
@@ -22,14 +22,16 @@ import {
   buildDroppedFolderUploadPlan,
   type DroppedFolderUploadPlan,
 } from "@/routes/_protected.workspaces/$workspaceId/-hooks/create-file-tree-upload.logic";
-import { buildEntityCreatePresignPayload } from "@/routes/_protected.workspaces/$workspaceId/-hooks/create-file-upload-payload.logic";
+import {
+  buildEntityCreateInvalidationPayload,
+  buildEntityCreatePresignPayload,
+} from "@/routes/_protected.workspaces/$workspaceId/-hooks/create-file-upload-payload.logic";
 import { useStartWorkflow } from "@/routes/_protected.workspaces/$workspaceId/-hooks/use-start-workflow";
 import { entitiesKeys } from "@/routes/_protected.workspaces/$workspaceId/-queries/entities";
 import {
   propertiesKeys,
   propertiesOptions,
 } from "@/routes/_protected.workspaces/$workspaceId/-queries/properties";
-import { workspacesKeys } from "@/routes/_protected.workspaces/-queries";
 
 const MAX_DISPLAYED_FAILURES = 5;
 // Matches the versions-sidebar PUT-to-S3 upload budget (same flow, uploaded
@@ -354,7 +356,7 @@ const uploadPreparedFileEntity = async ({
 
   // 4. Finalize.
   const finalize = await wsClient({ uploadId }).finalize.post(
-    { queryKey: entitiesKeys.all(workspaceId) },
+    buildEntityCreateInvalidationPayload(workspaceId),
     { fetch: { signal } },
   );
   if (finalize.error) {
@@ -745,16 +747,14 @@ export const useCreateFileEntities = (workspaceId: string) => {
       analytics.captureError(error);
     },
     onSettled: () => {
+      const { queryKey, queryKeys } =
+        buildEntityCreateInvalidationPayload(workspaceId);
       detached(
-        queryClient.invalidateQueries({
-          queryKey: entitiesKeys.all(workspaceId),
-        }),
-        "onSettled",
-      );
-      detached(
-        queryClient.invalidateQueries({
-          queryKey: workspacesKeys.overview(workspaceId),
-        }),
+        Promise.all(
+          [queryKey, ...queryKeys].map((key) =>
+            queryClient.invalidateQueries({ queryKey: key }),
+          ),
+        ),
         "onSettled",
       );
     },

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-hooks/use-create-file-entities.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-hooks/use-create-file-entities.ts
@@ -750,8 +750,9 @@ export const useCreateFileEntities = (workspaceId: string) => {
     onSettled: () => {
       detached(
         Promise.all(
-          entityCreateLocalInvalidationKeys(workspaceId).map((key) =>
-            queryClient.invalidateQueries({ queryKey: key }),
+          entityCreateLocalInvalidationKeys(workspaceId).map(
+            async (key) =>
+              await queryClient.invalidateQueries({ queryKey: key }),
           ),
         ),
         "onSettled",

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-hooks/use-create-file-entities.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-hooks/use-create-file-entities.ts
@@ -25,6 +25,7 @@ import {
 import {
   buildEntityCreateInvalidationPayload,
   buildEntityCreatePresignPayload,
+  entityCreateLocalInvalidationKeys,
 } from "@/routes/_protected.workspaces/$workspaceId/-hooks/create-file-upload-payload.logic";
 import { useStartWorkflow } from "@/routes/_protected.workspaces/$workspaceId/-hooks/use-start-workflow";
 import { entitiesKeys } from "@/routes/_protected.workspaces/$workspaceId/-queries/entities";
@@ -747,11 +748,9 @@ export const useCreateFileEntities = (workspaceId: string) => {
       analytics.captureError(error);
     },
     onSettled: () => {
-      const { queryKey, queryKeys } =
-        buildEntityCreateInvalidationPayload(workspaceId);
       detached(
         Promise.all(
-          [queryKey, ...queryKeys].map((key) =>
+          entityCreateLocalInvalidationKeys(workspaceId).map((key) =>
             queryClient.invalidateQueries({ queryKey: key }),
           ),
         ),

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/route.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/route.tsx
@@ -9,6 +9,7 @@ import {
   redirect,
   useMatch,
 } from "@tanstack/react-router";
+import { useDebouncedCallback } from "use-debounce";
 
 import { stellaToast } from "@stll/ui/components/toast";
 
@@ -42,6 +43,7 @@ const EXTRACTION_PREVIEW_EVENT_TYPE = "workflow-extraction-preview";
 const INVALIDATE_QUERY_EVENT_TYPE = "invalidate-query";
 const EXTRACTION_PREVIEW_CLIENT_TTL_MS = 5 * 60 * 1000;
 const ACTIVITY_INVALIDATION_DEBOUNCE_MS = 1000;
+const ACTIVITY_INVALIDATION_MAX_WAIT_MS = 5000;
 
 type ExtractionPreviewEventData = {
   entityId: string;
@@ -185,8 +187,17 @@ function RouteComponent() {
   const [previewClearTimers] = useState(
     () => new Map<string, ReturnType<typeof setTimeout>>(),
   );
-  const [activityInvalidationTimers] = useState(
-    () => new Map<string, ReturnType<typeof setTimeout>>(),
+  const invalidateActivity = useDebouncedCallback(
+    (workspaceIdToInvalidate: string) => {
+      detached(
+        queryClient.invalidateQueries({
+          queryKey: workspacesKeys.overviewActivityAll(workspaceIdToInvalidate),
+        }),
+        "handleWorkspaceActivityInvalidation",
+      );
+    },
+    ACTIVITY_INVALIDATION_DEBOUNCE_MS,
+    { maxWait: ACTIVITY_INVALIDATION_MAX_WAIT_MS },
   );
 
   const handleWorkspaceSSEEvent = ({
@@ -197,20 +208,7 @@ function RouteComponent() {
     data: unknown;
   }) => {
     if (type === INVALIDATE_QUERY_EVENT_TYPE) {
-      const previousTimer = activityInvalidationTimers.get(workspaceId);
-      if (previousTimer !== undefined) {
-        clearTimeout(previousTimer);
-      }
-      const nextTimer = setTimeout(() => {
-        activityInvalidationTimers.delete(workspaceId);
-        detached(
-          queryClient.invalidateQueries({
-            queryKey: workspacesKeys.overviewActivityAll(workspaceId),
-          }),
-          "handleWorkspaceActivityInvalidation",
-        );
-      }, ACTIVITY_INVALIDATION_DEBOUNCE_MS);
-      activityInvalidationTimers.set(workspaceId, nextTimer);
+      invalidateActivity(workspaceId);
     }
 
     const workspaceStore = useWorkspaceStore.getState();
@@ -309,7 +307,7 @@ function RouteComponent() {
   return (
     <WorkflowStartConfirmationPromptProvider>
       <WorkspaceLifecycleCleanup
-        activityInvalidationTimers={activityInvalidationTimers}
+        flushActivityInvalidation={invalidateActivity.flush}
         key={workspaceId}
         previewClearTimers={previewClearTimers}
       />
@@ -322,17 +320,14 @@ function RouteComponent() {
 }
 
 const WorkspaceLifecycleCleanup = ({
-  activityInvalidationTimers,
+  flushActivityInvalidation,
   previewClearTimers,
 }: {
-  activityInvalidationTimers: Map<string, ReturnType<typeof setTimeout>>;
+  flushActivityInvalidation: () => void;
   previewClearTimers: Map<string, ReturnType<typeof setTimeout>>;
 }) => {
   useMountEffect(() => () => {
-    for (const timer of activityInvalidationTimers.values()) {
-      clearTimeout(timer);
-    }
-    activityInvalidationTimers.clear();
+    flushActivityInvalidation();
     for (const timer of previewClearTimers.values()) {
       clearTimeout(timer);
     }

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/route.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/route.tsx
@@ -41,6 +41,7 @@ import { workspacesKeys } from "@/routes/_protected.workspaces/-queries.logic";
 const EXTRACTION_PREVIEW_EVENT_TYPE = "workflow-extraction-preview";
 const INVALIDATE_QUERY_EVENT_TYPE = "invalidate-query";
 const EXTRACTION_PREVIEW_CLIENT_TTL_MS = 5 * 60 * 1000;
+const ACTIVITY_INVALIDATION_DEBOUNCE_MS = 1000;
 
 type ExtractionPreviewEventData = {
   entityId: string;
@@ -184,6 +185,9 @@ function RouteComponent() {
   const [previewClearTimers] = useState(
     () => new Map<string, ReturnType<typeof setTimeout>>(),
   );
+  const [activityInvalidationTimers] = useState(
+    () => new Map<string, ReturnType<typeof setTimeout>>(),
+  );
 
   const handleWorkspaceSSEEvent = ({
     type,
@@ -193,12 +197,20 @@ function RouteComponent() {
     data: unknown;
   }) => {
     if (type === INVALIDATE_QUERY_EVENT_TYPE) {
-      detached(
-        queryClient.invalidateQueries({
-          queryKey: workspacesKeys.overviewActivityAll(workspaceId),
-        }),
-        "handleWorkspaceActivityInvalidation",
-      );
+      const previousTimer = activityInvalidationTimers.get(workspaceId);
+      if (previousTimer !== undefined) {
+        clearTimeout(previousTimer);
+      }
+      const nextTimer = setTimeout(() => {
+        activityInvalidationTimers.delete(workspaceId);
+        detached(
+          queryClient.invalidateQueries({
+            queryKey: workspacesKeys.overviewActivityAll(workspaceId),
+          }),
+          "handleWorkspaceActivityInvalidation",
+        );
+      }, ACTIVITY_INVALIDATION_DEBOUNCE_MS);
+      activityInvalidationTimers.set(workspaceId, nextTimer);
     }
 
     const workspaceStore = useWorkspaceStore.getState();
@@ -297,6 +309,7 @@ function RouteComponent() {
   return (
     <WorkflowStartConfirmationPromptProvider>
       <WorkspaceLifecycleCleanup
+        activityInvalidationTimers={activityInvalidationTimers}
         key={workspaceId}
         previewClearTimers={previewClearTimers}
       />
@@ -309,11 +322,17 @@ function RouteComponent() {
 }
 
 const WorkspaceLifecycleCleanup = ({
+  activityInvalidationTimers,
   previewClearTimers,
 }: {
+  activityInvalidationTimers: Map<string, ReturnType<typeof setTimeout>>;
   previewClearTimers: Map<string, ReturnType<typeof setTimeout>>;
 }) => {
   useMountEffect(() => () => {
+    for (const timer of activityInvalidationTimers.values()) {
+      clearTimeout(timer);
+    }
+    activityInvalidationTimers.clear();
     for (const timer of previewClearTimers.values()) {
       clearTimeout(timer);
     }


### PR DESCRIPTION
## Proposed change

Polish the matter activity experience and upload integration:

- Render each activity as an aligned actor/action/object triplet, with MIME-aware document icons and the neutral matter icon.
- Group direct document uploads by the same actor within one minute; list every uploaded document in the detail sheet.
- Keep history on the left and current activity on the right, add the Today marker and full timestamp tooltip, auto-position new activity, and lazy-load older history at the scroll boundary.
- Preserve every item from multi-file drag-and-drop, refresh activity after upload finalization, and bind workspace audit recording at the validated handler boundary.

The network response-size budget increases from 1 KiB to 2 KiB for the seeded activity request on three matter routes. This is intentional: workspace-bound audit records are now included in the activity page instead of being omitted as organization-only rows.

## Checklist

- [ ] BUILD ASSURANCE | Code builds correctly and without any errors or warnings.
- [x] TESTING | Changes tested, including batching boundaries, multi-file drops, activity invalidation, and workspace audit binding.
- [x] DARK MODE SUPPORT | New UI uses semantic theme colors.
- [ ] ISSUE LINKED | Link an issue to this PR using GitHub's linking feature.
- [ ] SCREENSHOT INCLUDED | Add a screenshot or video if needed during review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Workspace activity is now grouped into document batches, automation runs and individual events.
  - Groups can be expanded for detailed list views, with improved timeline navigation and grouped selection.
  - Earlier activity loads automatically as you scroll, with retry and error handling.
  - Trigger details now show the event source.

- **Bug Fixes**
  - Improved external file and folder uploads to capture all dropped items reliably.
  - Activity updates refresh more efficiently and consistently.
  - Activity labels are now simpler and standardised across supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->