### PR TITLE
feat: make route errors recoverable

### DIFF
--- a/apps/web/e2e/specs/chat-composer-during-stream.spec.ts
+++ b/apps/web/e2e/specs/chat-composer-during-stream.spec.ts
@@ -20,11 +20,11 @@ test("composer draft survives typing while a response is streaming", async ({
   // the composer below.
   await page.goto("/chat", { waitUntil: "commit" });
 
-  // Route error boundary heading (apps/web/src/components/route-components.tsx:253,
-  // title common.somethingWentWrong). Checked after every step below; declared
+  // Route error boundary heading (apps/web/src/components/route-components.tsx,
+  // title routeError.title). Checked after every step below; declared
   // once so the assertions read the same way each time.
   const errorBoundary = page.getByRole("heading", {
-    name: "Something went wrong",
+    name: "This page couldn’t be opened",
   });
   await expect(errorBoundary).toHaveCount(0);
 

--- a/apps/web/e2e/specs/chat.spec.ts
+++ b/apps/web/e2e/specs/chat.spec.ts
@@ -12,11 +12,11 @@ test("chat composer sends a message and renders the assistant reply", async ({
   // the composer below.
   await page.goto("/chat", { waitUntil: "commit" });
 
-  // Route error boundary heading (apps/web/src/components/route-components.tsx:253,
-  // title common.somethingWentWrong). Checked after every step below; declared
+  // Route error boundary heading (apps/web/src/components/route-components.tsx,
+  // title routeError.title). Checked after every step below; declared
   // once so the assertions read the same way each time.
   const errorBoundary = page.getByRole("heading", {
-    name: "Something went wrong",
+    name: "This page couldn’t be opened",
   });
   await expect(errorBoundary).toHaveCount(0);
 

--- a/apps/web/e2e/specs/route-smoke.spec.ts
+++ b/apps/web/e2e/specs/route-smoke.spec.ts
@@ -600,7 +600,7 @@ const comparableHref = (url: URL, assertSearch: boolean) =>
 
 const assertNoRouteBoundary = async (page: Page, routeTemplate: string) => {
   await expect(
-    page.getByRole("heading", { name: "Something went wrong" }),
+    page.getByRole("heading", { name: "This page couldn’t be opened" }),
     `route error boundary rendered on ${routeTemplate}`,
   ).toHaveCount(0);
 };

--- a/apps/web/e2e/staging/staging-smoke.spec.ts
+++ b/apps/web/e2e/staging/staging-smoke.spec.ts
@@ -35,7 +35,7 @@ test("chat thread page renders for an entitlement-less owner", async ({
 
   // The route error boundary replaces the thread UI wholesale; its
   // title is the canonical signature of a client-side render crash.
-  await expect(page.getByText("Something went wrong")).toBeHidden();
+  await expect(page.getByText("This page couldn’t be opened")).toBeHidden();
 
   // The smoke org has no AI provider credentials, so RequireAIKey
   // legitimately gates the thread with the connect-provider card

--- a/apps/web/src/components/inspector/inspector-broadcast.ts
+++ b/apps/web/src/components/inspector/inspector-broadcast.ts
@@ -339,6 +339,7 @@ const createInspectorBroadcastSession = (
       });
     } catch (error) {
       getAnalytics().captureError(error, {
+        type: "detached",
         operation: "inspector-tabs.broadcast",
       });
     }

--- a/apps/web/src/components/route-components.logic.test.ts
+++ b/apps/web/src/components/route-components.logic.test.ts
@@ -3,7 +3,11 @@ import { describe, expect, test } from "bun:test";
 import { APIError } from "@/lib/errors/api";
 import { CriticalQueryTimeoutError } from "@/lib/react-query";
 
-import { isNetworkError } from "./route-components.logic";
+import {
+  buildErrorReportMailto,
+  isNetworkError,
+  resolveRouteErrorSupport,
+} from "./route-components.logic";
 
 describe("route network error classification", () => {
   test("recognises query timeouts and browser network errors", () => {
@@ -43,5 +47,47 @@ describe("route network error classification", () => {
     expect(
       isNetworkError(new TypeError("Cannot read properties of null")),
     ).toBe(false);
+  });
+});
+
+describe("route error support", () => {
+  test("uses a deployment-configured feedback recipient", () => {
+    expect(
+      resolveRouteErrorSupport({
+        deployment: "selfHosted",
+        feedbackRecipient: "ops@example.test",
+      }),
+    ).toEqual({ type: "report", recipient: "ops@example.test" });
+  });
+
+  test("directs self-hosted users to their administrator when email is unset", () => {
+    expect(
+      resolveRouteErrorSupport({
+        deployment: "selfHosted",
+        feedbackRecipient: undefined,
+      }),
+    ).toEqual({ type: "administrator" });
+  });
+
+  test("does not invent a support destination for unconfigured hosted deployments", () => {
+    expect(
+      resolveRouteErrorSupport({
+        deployment: "hosted",
+        feedbackRecipient: undefined,
+      }),
+    ).toEqual({ type: "none" });
+  });
+
+  test("builds a report containing only caller-provided support copy", () => {
+    const href = buildErrorReportMailto({
+      body: "Error reference: ERR-DEAD-BEEF-1234",
+      recipient: "ops@example.test",
+      subject: "stella error ERR-DEAD-BEEF-1234",
+    });
+
+    expect(decodeURIComponent(href)).toBe(
+      "mailto:ops@example.test?subject=stella error ERR-DEAD-BEEF-1234&body=Error reference: ERR-DEAD-BEEF-1234",
+    );
+    expect(href).not.toContain("workspaces");
   });
 });

--- a/apps/web/src/components/route-components.logic.ts
+++ b/apps/web/src/components/route-components.logic.ts
@@ -13,6 +13,44 @@ const NETWORK_ERROR_MESSAGES = Object.freeze([
   "Load failed",
 ]);
 
+export type RouteErrorSupport =
+  | { type: "report"; recipient: string }
+  | { type: "administrator" }
+  | { type: "none" };
+
+type ResolveRouteErrorSupportOptions = {
+  deployment: "hosted" | "selfHosted";
+  feedbackRecipient: string | undefined;
+};
+
+export const resolveRouteErrorSupport = ({
+  deployment,
+  feedbackRecipient,
+}: ResolveRouteErrorSupportOptions): RouteErrorSupport => {
+  if (feedbackRecipient) {
+    return { type: "report", recipient: feedbackRecipient };
+  }
+
+  if (deployment === "selfHosted") {
+    return { type: "administrator" };
+  }
+
+  return { type: "none" };
+};
+
+type BuildErrorReportMailtoOptions = {
+  body: string;
+  recipient: string;
+  subject: string;
+};
+
+export const buildErrorReportMailto = ({
+  body,
+  recipient,
+  subject,
+}: BuildErrorReportMailtoOptions): string =>
+  `mailto:${recipient}?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`;
+
 export const isNetworkError = (error: unknown): boolean => {
   if (CriticalQueryTimeoutError.is(error)) {
     return true;

--- a/apps/web/src/components/route-components.tsx
+++ b/apps/web/src/components/route-components.tsx
@@ -1,20 +1,34 @@
 import { useState, useTransition } from "react";
 
 import { CancelledError, useQueryClient } from "@tanstack/react-query";
-import { Navigate } from "@tanstack/react-router";
+import { Link, Navigate } from "@tanstack/react-router";
 import type { ErrorComponentProps } from "@tanstack/react-router";
-import { RefreshCcwIcon } from "lucide-react";
+import {
+  CircleAlertIcon,
+  CopyIcon,
+  FolderOpenIcon,
+  MailIcon,
+  RefreshCcwIcon,
+} from "lucide-react";
 import { useTranslations } from "use-intl";
 
 import { Button } from "@stll/ui/components/button";
+import { stellaToast } from "@stll/ui/components/toast";
 import { cn } from "@stll/ui/lib/utils";
 
-import { isNetworkError } from "@/components/route-components.logic";
+import {
+  buildErrorReportMailto,
+  isNetworkError,
+  resolveRouteErrorSupport,
+} from "@/components/route-components.logic";
 import { StellaMark } from "@/components/stella-mark";
+import { env } from "@/env";
 import { useExternalSyncEffect, useMountEffect } from "@/hooks/use-effect";
 import { useLatestCallback } from "@/hooks/use-latest-callback";
 import { useSignOut } from "@/hooks/use-sign-out";
+import { createErrorReference } from "@/lib/analytics/error-reference";
 import { useAnalytics } from "@/lib/analytics/provider";
+import { detached } from "@/lib/detached";
 import { isMemberError, isUnauthorizedError } from "@/lib/errors/auth";
 
 type DefaultErrorComponentProps = ErrorComponentProps & {
@@ -121,16 +135,10 @@ export const DefaultErrorComponent = ({
     retry: retryErroredQueries,
   });
 
-  // Capture errors that aren't auth/cancel/network noise once,
-  // plus network errors once retries are exhausted. Keeping the
-  // two cases in one effect avoids the prior staggered chain.
+  // Capture exhausted network failures. Unexpected errors are captured by
+  // their recovery panel so the visible support reference can be attached.
   useExternalSyncEffect(() => {
-    if (showUnauthorizedError || isCancelledError) {
-      return;
-    }
-
-    if (!networkError) {
-      analytics.captureError(error);
+    if (showUnauthorizedError || isCancelledError || !networkError) {
       return;
     }
 
@@ -188,17 +196,155 @@ export const DefaultErrorComponent = ({
   }
 
   return (
-    <StatusMessage
-      actionButton={
-        <Button disabled={isPending} onClick={retryErroredQueries}>
-          <RefreshCcwIcon /> {t("common.tryAgain")}
-        </Button>
-      }
+    <UnexpectedRouteError
       className={className}
-      description={t("common.unexpectedError")}
-      status="error"
-      title={t("common.somethingWentWrong")}
+      error={error}
+      isPending={isPending}
+      retry={retryErroredQueries}
     />
+  );
+};
+
+type UnexpectedRouteErrorProps = {
+  className?: string | undefined;
+  error: unknown;
+  isPending: boolean;
+  retry: () => void;
+};
+
+const focusHeading = (heading: HTMLHeadingElement | null) => {
+  heading?.focus();
+};
+
+const UnexpectedRouteError = ({
+  className,
+  error,
+  isPending,
+  retry,
+}: UnexpectedRouteErrorProps) => {
+  const analytics = useAnalytics();
+  const t = useTranslations();
+  const [errorReference] = useState(createErrorReference);
+  const support = resolveRouteErrorSupport({
+    deployment: env.VITE_SELFHOST ? "selfHosted" : "hosted",
+    feedbackRecipient: env.VITE_FEEDBACK_EMAIL_TO,
+  });
+  let description: string;
+  switch (support.type) {
+    case "report":
+      description = t("routeError.descriptionReport");
+      break;
+    case "administrator":
+      description = t("routeError.descriptionAdministrator");
+      break;
+    case "none":
+      description = t("routeError.descriptionNone");
+      break;
+    default: {
+      const exhaustive: never = support;
+      description = exhaustive;
+    }
+  }
+
+  useExternalSyncEffect(() => {
+    analytics.captureError(error, {
+      type: "recovery",
+      reference: errorReference,
+    });
+  }, [analytics, error, errorReference]);
+
+  const handleCopyReference = async () => {
+    try {
+      await navigator.clipboard.writeText(errorReference);
+      stellaToast.add({ title: t("common.copied"), type: "success" });
+    } catch {
+      stellaToast.add({ title: t("errors.actionFailed"), type: "error" });
+    }
+  };
+
+  const reportHref =
+    support.type === "report"
+      ? buildErrorReportMailto({
+          recipient: support.recipient,
+          subject: t("routeError.reportSubject", { reference: errorReference }),
+          body: t("routeError.reportBody", { reference: errorReference }),
+        })
+      : null;
+
+  return (
+    <div
+      className={cn(
+        "flex h-full w-full items-center overflow-auto px-6 py-10 sm:px-10",
+        className,
+      )}
+    >
+      <section
+        aria-labelledby="route-error-title"
+        className="mx-auto flex w-full max-w-xl flex-col gap-6"
+        role="alert"
+      >
+        <div className="bg-muted text-muted-foreground flex size-10 items-center justify-center rounded-xl">
+          <CircleAlertIcon aria-hidden="true" className="size-5" />
+        </div>
+
+        <div className="flex flex-col gap-2">
+          <h1
+            className="text-foreground text-xl font-semibold text-balance outline-none"
+            id="route-error-title"
+            ref={focusHeading}
+            tabIndex={-1}
+          >
+            {t("routeError.title")}
+          </h1>
+          <p className="text-muted-foreground max-w-lg text-sm leading-6 text-pretty">
+            {description}
+          </p>
+        </div>
+
+        <div className="flex flex-wrap gap-2">
+          <Button loading={isPending} onClick={retry}>
+            <RefreshCcwIcon /> {t("common.tryAgain")}
+          </Button>
+          <Button render={<Link to="/workspaces" />} variant="outline">
+            <FolderOpenIcon /> {t("routeError.backToMatters")}
+          </Button>
+          {reportHref ? (
+            <Button
+              render={
+                <a
+                  aria-label={t("routeError.reportProblem")}
+                  href={reportHref}
+                />
+              }
+              variant="ghost"
+            >
+              <MailIcon /> {t("routeError.reportProblem")}
+            </Button>
+          ) : null}
+        </div>
+
+        <div className="border-border bg-muted/40 flex items-center justify-between gap-3 rounded-xl border p-3">
+          <div className="flex min-w-0 flex-col gap-0.5">
+            <span className="text-muted-foreground text-xs">
+              {t("routeError.reference")}
+            </span>
+            <bdi className="text-foreground truncate font-mono text-sm">
+              {errorReference}
+            </bdi>
+          </div>
+          <Button
+            aria-label={t("routeError.copyReference")}
+            onClick={() => {
+              detached(handleCopyReference(), "route-error.copy-reference");
+            }}
+            size="icon"
+            variant="ghost"
+          >
+            <CopyIcon />
+          </Button>
+        </div>
+      </section>
+    </div>
   );
 };
 
@@ -230,7 +376,7 @@ export const StatusMessage = ({
 }: StatusMessageProps) => (
   <div
     className={cn(
-      "mx-auto flex h-full w-screen max-w-md flex-col items-center justify-center gap-y-6 p-6 text-center",
+      "mx-auto flex h-full w-full max-w-md flex-col items-center justify-center gap-y-6 p-6 text-center",
       className,
     )}
   >

--- a/apps/web/src/components/route-components.tsx
+++ b/apps/web/src/components/route-components.tsx
@@ -305,7 +305,7 @@ const UnexpectedRouteError = ({
           <Button loading={isPending} onClick={retry}>
             <RefreshCcwIcon /> {t("common.tryAgain")}
           </Button>
-          <Button render={<Link to="/workspaces" />} variant="outline">
+          <Button render={<Link from="/" to="/workspaces" />} variant="outline">
             <FolderOpenIcon /> {t("routeError.backToMatters")}
           </Button>
           {reportHref ? (

--- a/apps/web/src/i18n/langs/ar.json
+++ b/apps/web/src/i18n/langs/ar.json
@@ -2344,6 +2344,18 @@
     "settingsDescription": "عدّل اسم مؤسستك والمعرّف",
     "switchOrganization": "تبديل المؤسسة"
   },
+  "routeError": {
+    "backToMatters": "العودة إلى الملفات القانونية",
+    "copyReference": "نسخ مرجع الخطأ",
+    "descriptionAdministrator": "حاول مرة أخرى. إذا استمرت المشكلة، فارجع إلى ملفاتك القانونية أو تواصل مع مسؤولك باستخدام المرجع أدناه.",
+    "descriptionNone": "حاول مرة أخرى. إذا استمرت المشكلة، فارجع إلى ملفاتك القانونية.",
+    "descriptionReport": "حاول مرة أخرى. إذا استمرت المشكلة، فارجع إلى ملفاتك القانونية أو أبلغ عنها باستخدام المرجع أدناه.",
+    "reference": "مرجع الخطأ",
+    "reportBody": "مرجع الخطأ: {reference}\n\nماذا حدث؟\n",
+    "reportProblem": "الإبلاغ عن مشكلة",
+    "reportSubject": "خطأ في stella: {reference}",
+    "title": "تعذر فتح هذه الصفحة"
+  },
   "search": {
     "aiRefine": "تحسين الاستعلام باستخدام AI",
     "continueInChat": "المتابعة في المحادثة",

--- a/apps/web/src/i18n/langs/cs.json
+++ b/apps/web/src/i18n/langs/cs.json
@@ -2344,6 +2344,18 @@
     "settingsDescription": "Upravte název a slug organizace",
     "switchOrganization": "Přepnout organizaci"
   },
+  "routeError": {
+    "backToMatters": "Zpět na spisy",
+    "copyReference": "Kopírovat referenci chyby",
+    "descriptionAdministrator": "Zkuste to znovu. Pokud problém přetrvává, vraťte se ke svým spisům nebo kontaktujte správce s referencí níže.",
+    "descriptionNone": "Zkuste to znovu. Pokud problém přetrvává, vraťte se ke svým spisům.",
+    "descriptionReport": "Zkuste to znovu. Pokud problém přetrvává, vraťte se ke svým spisům nebo jej nahlaste s referencí níže.",
+    "reference": "Reference chyby",
+    "reportBody": "Reference chyby: {reference}\n\nCo se stalo?\n",
+    "reportProblem": "Nahlásit problém",
+    "reportSubject": "Chyba stella {reference}",
+    "title": "Tuto stránku se nepodařilo otevřít"
+  },
   "search": {
     "aiRefine": "Vylepšit dotaz pomocí AI",
     "continueInChat": "Pokračovat v chatu",

--- a/apps/web/src/i18n/langs/de.json
+++ b/apps/web/src/i18n/langs/de.json
@@ -2344,6 +2344,18 @@
     "settingsDescription": "Name und Slug der Organisation bearbeiten",
     "switchOrganization": "Organisation wechseln"
   },
+  "routeError": {
+    "backToMatters": "Zu den Akten zurückkehren",
+    "copyReference": "Fehlerreferenz kopieren",
+    "descriptionAdministrator": "Versuchen Sie es erneut. Wenn das Problem weiterhin besteht, kehren Sie zu Ihren Akten zurück oder wenden Sie sich mit der unten stehenden Referenz an Ihre Administration.",
+    "descriptionNone": "Versuchen Sie es erneut. Wenn das Problem weiterhin besteht, kehren Sie zu Ihren Akten zurück.",
+    "descriptionReport": "Versuchen Sie es erneut. Wenn das Problem weiterhin besteht, kehren Sie zu Ihren Akten zurück oder melden Sie es mit der unten stehenden Referenz.",
+    "reference": "Fehlerreferenz",
+    "reportBody": "Fehlerreferenz: {reference}\n\nWas ist passiert?\n",
+    "reportProblem": "Problem melden",
+    "reportSubject": "stella-Fehler {reference}",
+    "title": "Diese Seite konnte nicht geöffnet werden"
+  },
   "search": {
     "aiRefine": "Suchanfrage mit KI verbessern",
     "continueInChat": "Im Chat fortsetzen",

--- a/apps/web/src/i18n/langs/en.json
+++ b/apps/web/src/i18n/langs/en.json
@@ -2344,6 +2344,18 @@
     "settingsDescription": "Edit your organization name and slug",
     "switchOrganization": "Switch organization"
   },
+  "routeError": {
+    "backToMatters": "Return to matters",
+    "copyReference": "Copy error reference",
+    "descriptionAdministrator": "Try again. If the problem continues, return to your matters or contact your administrator with the reference below.",
+    "descriptionNone": "Try again. If the problem continues, return to your matters.",
+    "descriptionReport": "Try again. If the problem continues, return to your matters or report it with the reference below.",
+    "reference": "Error reference",
+    "reportBody": "Error reference: {reference}\n\nWhat happened?\n",
+    "reportProblem": "Report problem",
+    "reportSubject": "stella error {reference}",
+    "title": "This page couldn’t be opened"
+  },
   "search": {
     "aiRefine": "Improve query with AI",
     "continueInChat": "Continue in chat",

--- a/apps/web/src/i18n/langs/es.json
+++ b/apps/web/src/i18n/langs/es.json
@@ -2344,6 +2344,18 @@
     "settingsDescription": "Edite el nombre y el slug de su organización",
     "switchOrganization": "Cambiar de organización"
   },
+  "routeError": {
+    "backToMatters": "Volver a los asuntos",
+    "copyReference": "Copiar referencia del error",
+    "descriptionAdministrator": "Inténtalo de nuevo. Si el problema continúa, vuelve a tus asuntos o contacta con tu administrador usando la referencia de abajo.",
+    "descriptionNone": "Inténtalo de nuevo. Si el problema continúa, vuelve a tus asuntos.",
+    "descriptionReport": "Inténtalo de nuevo. Si el problema continúa, vuelve a tus asuntos o repórtalo con la referencia de abajo.",
+    "reference": "Referencia del error",
+    "reportBody": "Referencia del error: {reference}\n\n¿Qué ocurrió?\n",
+    "reportProblem": "Reportar problema",
+    "reportSubject": "Error de stella {reference}",
+    "title": "No se pudo abrir esta página"
+  },
   "search": {
     "aiRefine": "Mejorar consulta con IA",
     "continueInChat": "Continuar en el chat",

--- a/apps/web/src/i18n/langs/et.json
+++ b/apps/web/src/i18n/langs/et.json
@@ -2344,6 +2344,18 @@
     "settingsDescription": "Muutke oma organisatsiooni nime ja slugi",
     "switchOrganization": "Vaheta organisatsiooni"
   },
+  "routeError": {
+    "backToMatters": "Naase toimikute juurde",
+    "copyReference": "Kopeeri vea viide",
+    "descriptionAdministrator": "Proovi uuesti. Kui probleem püsib, naase oma toimikute juurde või võta alloleva viitega ühendust administraatoriga.",
+    "descriptionNone": "Proovi uuesti. Kui probleem püsib, naase oma toimikute juurde.",
+    "descriptionReport": "Proovi uuesti. Kui probleem püsib, naase oma toimikute juurde või teata sellest alloleva viitega.",
+    "reference": "Vea viide",
+    "reportBody": "Vea viide: {reference}\n\nMis juhtus?\n",
+    "reportProblem": "Teata probleemist",
+    "reportSubject": "stella tõrge {reference}",
+    "title": "Seda lehte ei saanud avada"
+  },
   "search": {
     "aiRefine": "Täpsusta päringut AI-ga",
     "continueInChat": "Jätka vestluses",

--- a/apps/web/src/i18n/langs/fr.json
+++ b/apps/web/src/i18n/langs/fr.json
@@ -2344,6 +2344,18 @@
     "settingsDescription": "Modifier le nom et le slug de votre organisation",
     "switchOrganization": "Changer d'organisation"
   },
+  "routeError": {
+    "backToMatters": "Retourner aux dossiers",
+    "copyReference": "Copier la référence de l’erreur",
+    "descriptionAdministrator": "Réessayez. Si le problème persiste, retournez à vos dossiers ou contactez votre administrateur avec la référence ci-dessous.",
+    "descriptionNone": "Réessayez. Si le problème persiste, retournez à vos dossiers.",
+    "descriptionReport": "Réessayez. Si le problème persiste, retournez à vos dossiers ou signalez-le avec la référence ci-dessous.",
+    "reference": "Référence de l’erreur",
+    "reportBody": "Référence de l’erreur : {reference}\n\nQue s’est-il passé ?\n",
+    "reportProblem": "Signaler un problème",
+    "reportSubject": "Erreur stella {reference}",
+    "title": "Cette page n’a pas pu être ouverte"
+  },
   "search": {
     "aiRefine": "Améliorer la requête avec l’IA",
     "continueInChat": "Continuer dans le chat",

--- a/apps/web/src/i18n/langs/hu.json
+++ b/apps/web/src/i18n/langs/hu.json
@@ -2344,6 +2344,18 @@
     "settingsDescription": "Szervezet nevének és slugjának szerkesztése",
     "switchOrganization": "Szervezet váltása"
   },
+  "routeError": {
+    "backToMatters": "Vissza az ügyekhez",
+    "copyReference": "Hibahivatkozás másolása",
+    "descriptionAdministrator": "Próbálja újra. Ha a probléma továbbra is fennáll, térjen vissza az ügyeihez, vagy forduljon rendszergazdájához az alábbi hivatkozással.",
+    "descriptionNone": "Próbálja újra. Ha a probléma továbbra is fennáll, térjen vissza az ügyeihez.",
+    "descriptionReport": "Próbálja újra. Ha a probléma továbbra is fennáll, térjen vissza az ügyeihez, vagy jelentse a problémát az alábbi hivatkozással.",
+    "reference": "Hibahivatkozás",
+    "reportBody": "Hibahivatkozás: {reference}\n\nMi történt?\n",
+    "reportProblem": "Probléma jelentése",
+    "reportSubject": "stella hiba: {reference}",
+    "title": "Ezt az oldalt nem sikerült megnyitni"
+  },
   "search": {
     "aiRefine": "Keresés javítása AI-val",
     "continueInChat": "Folytatás chatben",

--- a/apps/web/src/i18n/langs/lt.json
+++ b/apps/web/src/i18n/langs/lt.json
@@ -2344,6 +2344,18 @@
     "settingsDescription": "Redaguokite organizacijos pavadinimą ir slug",
     "switchOrganization": "Pakeisti organizaciją"
   },
+  "routeError": {
+    "backToMatters": "Grįžti į bylas",
+    "copyReference": "Kopijuoti klaidos nuorodą",
+    "descriptionAdministrator": "Bandykite dar kartą. Jei problema išlieka, grįžkite į savo bylas arba susisiekite su administratoriumi naudodami toliau pateiktą nuorodą.",
+    "descriptionNone": "Bandykite dar kartą. Jei problema išlieka, grįžkite į savo bylas.",
+    "descriptionReport": "Bandykite dar kartą. Jei problema išlieka, grįžkite į savo bylas arba praneškite apie ją naudodami toliau pateiktą nuorodą.",
+    "reference": "Klaidos nuoroda",
+    "reportBody": "Klaidos nuoroda: {reference}\n\nKas nutiko?\n",
+    "reportProblem": "Pranešti apie problemą",
+    "reportSubject": "stella klaida: {reference}",
+    "title": "Nepavyko atidaryti šio puslapio"
+  },
   "search": {
     "aiRefine": "Patobulinti užklausą su DI",
     "continueInChat": "Tęsti pokalbyje",

--- a/apps/web/src/i18n/langs/lv.json
+++ b/apps/web/src/i18n/langs/lv.json
@@ -2344,6 +2344,18 @@
     "settingsDescription": "Rediģēt organizācijas nosaukumu un slug",
     "switchOrganization": "Mainīt organizāciju"
   },
+  "routeError": {
+    "backToMatters": "Atgriezties pie lietām",
+    "copyReference": "Kopēt kļūdas atsauci",
+    "descriptionAdministrator": "Mēģiniet vēlreiz. Ja problēma turpinās, atgriezieties pie savām lietām vai sazinieties ar administratoru, izmantojot tālāk norādīto atsauci.",
+    "descriptionNone": "Mēģiniet vēlreiz. Ja problēma turpinās, atgriezieties pie savām lietām.",
+    "descriptionReport": "Mēģiniet vēlreiz. Ja problēma turpinās, atgriezieties pie savām lietām vai ziņojiet par to, izmantojot tālāk norādīto atsauci.",
+    "reference": "Kļūdas atsauce",
+    "reportBody": "Kļūdas atsauce: {reference}\n\nKas notika?\n",
+    "reportProblem": "Ziņot par problēmu",
+    "reportSubject": "stella kļūda: {reference}",
+    "title": "Šo lapu neizdevās atvērt"
+  },
   "search": {
     "aiRefine": "Uzlabot vaicājumu ar AI",
     "continueInChat": "Turpināt tērzēšanā",

--- a/apps/web/src/i18n/langs/messages.gen.ts
+++ b/apps/web/src/i18n/langs/messages.gen.ts
@@ -2347,6 +2347,18 @@ type Messages = {
     "settingsDescription": "Edit your organization name and slug";
     "switchOrganization": "Switch organization";
   };
+  "routeError": {
+    "backToMatters": "Return to matters";
+    "copyReference": "Copy error reference";
+    "descriptionAdministrator": "Try again. If the problem continues, return to your matters or contact your administrator with the reference below.";
+    "descriptionNone": "Try again. If the problem continues, return to your matters.";
+    "descriptionReport": "Try again. If the problem continues, return to your matters or report it with the reference below.";
+    "reference": "Error reference";
+    "reportBody": "Error reference: {reference}\n\nWhat happened?\n";
+    "reportProblem": "Report problem";
+    "reportSubject": "stella error {reference}";
+    "title": "This page couldn’t be opened";
+  };
   "search": {
     "aiRefine": "Improve query with AI";
     "continueInChat": "Continue in chat";

--- a/apps/web/src/i18n/langs/pl.json
+++ b/apps/web/src/i18n/langs/pl.json
@@ -2344,6 +2344,18 @@
     "settingsDescription": "Edytuj nazwę i slug organizacji",
     "switchOrganization": "Przełącz organizację"
   },
+  "routeError": {
+    "backToMatters": "Wróć do spraw",
+    "copyReference": "Kopiuj identyfikator błędu",
+    "descriptionAdministrator": "Spróbuj ponownie. Jeśli problem będzie się powtarzał, wróć do swoich spraw lub skontaktuj się z administratorem, podając poniższy identyfikator.",
+    "descriptionNone": "Spróbuj ponownie. Jeśli problem będzie się powtarzał, wróć do swoich spraw.",
+    "descriptionReport": "Spróbuj ponownie. Jeśli problem będzie się powtarzał, wróć do swoich spraw lub zgłoś go, podając poniższy identyfikator.",
+    "reference": "Identyfikator błędu",
+    "reportBody": "Identyfikator błędu: {reference}\n\nCo się stało?\n",
+    "reportProblem": "Zgłoś problem",
+    "reportSubject": "Błąd stella: {reference}",
+    "title": "Nie udało się otworzyć tej strony"
+  },
   "search": {
     "aiRefine": "Ulepsz zapytanie z AI",
     "continueInChat": "Kontynuuj na czacie",

--- a/apps/web/src/i18n/langs/pt-BR.json
+++ b/apps/web/src/i18n/langs/pt-BR.json
@@ -2344,6 +2344,18 @@
     "settingsDescription": "Edite o nome e o slug da sua organização",
     "switchOrganization": "Mudar de organização"
   },
+  "routeError": {
+    "backToMatters": "Voltar aos casos",
+    "copyReference": "Copiar referência do erro",
+    "descriptionAdministrator": "Tente novamente. Se o problema continuar, volte aos seus casos ou entre em contato com o administrador usando a referência abaixo.",
+    "descriptionNone": "Tente novamente. Se o problema continuar, volte aos seus casos.",
+    "descriptionReport": "Tente novamente. Se o problema continuar, volte aos seus casos ou relate-o usando a referência abaixo.",
+    "reference": "Referência do erro",
+    "reportBody": "Referência do erro: {reference}\n\nO que aconteceu?\n",
+    "reportProblem": "Relatar problema",
+    "reportSubject": "Erro do stella: {reference}",
+    "title": "Não foi possível abrir esta página"
+  },
   "search": {
     "aiRefine": "Melhore a consulta com IA",
     "continueInChat": "Continuar no bate-papo",

--- a/apps/web/src/i18n/langs/sk.json
+++ b/apps/web/src/i18n/langs/sk.json
@@ -2344,6 +2344,18 @@
     "settingsDescription": "Upravte názov a slug organizácie",
     "switchOrganization": "Prepnúť organizáciu"
   },
+  "routeError": {
+    "backToMatters": "Späť na spisy",
+    "copyReference": "Kopírovať referenciu chyby",
+    "descriptionAdministrator": "Skúste to znova. Ak problém pretrváva, vráťte sa k svojim spisom alebo kontaktujte správcu s nižšie uvedenou referenciou.",
+    "descriptionNone": "Skúste to znova. Ak problém pretrváva, vráťte sa k svojim spisom.",
+    "descriptionReport": "Skúste to znova. Ak problém pretrváva, vráťte sa k svojim spisom alebo ho nahláste s nižšie uvedenou referenciou.",
+    "reference": "Referencia chyby",
+    "reportBody": "Referencia chyby: {reference}\n\nČo sa stalo?\n",
+    "reportProblem": "Nahlásiť problém",
+    "reportSubject": "Chyba stella {reference}",
+    "title": "Túto stránku sa nepodarilo otvoriť"
+  },
   "search": {
     "aiRefine": "Vylepšiť dotaz pomocou AI",
     "continueInChat": "Pokračovať v chate",

--- a/apps/web/src/lib/analytics/error-reference.test.ts
+++ b/apps/web/src/lib/analytics/error-reference.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  createErrorReference,
+  formatErrorReference,
+  isErrorReference,
+} from "@/lib/analytics/error-reference";
+
+describe("error support references", () => {
+  test("formats only opaque random bytes", () => {
+    expect(
+      formatErrorReference(
+        Uint8Array.from([0xde, 0xad, 0xbe, 0xef, 0x12, 0x34]),
+      ),
+    ).toBe("ERR-DEAD-BEEF-1234");
+  });
+
+  test("rejects invalid reference shapes", () => {
+    expect(isErrorReference("ERR-DEAD-BEEF-1234")).toBe(true);
+    expect(isErrorReference("ERR-DEAD-BEEF")).toBe(false);
+    expect(isErrorReference("/workspaces/private-matter")).toBe(false);
+  });
+
+  test("generates references in the public format", () => {
+    expect(isErrorReference(createErrorReference())).toBe(true);
+  });
+});

--- a/apps/web/src/lib/analytics/error-reference.ts
+++ b/apps/web/src/lib/analytics/error-reference.ts
@@ -1,0 +1,30 @@
+import { panic } from "better-result";
+
+const ERROR_REFERENCE_BYTES = 6;
+const ERROR_REFERENCE_PATTERN = /^ERR-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}$/u;
+
+export type ErrorReference = `ERR-${string}-${string}-${string}`;
+
+export const formatErrorReference = (bytes: Uint8Array): ErrorReference => {
+  if (bytes.length !== ERROR_REFERENCE_BYTES) {
+    return panic(`Expected ${ERROR_REFERENCE_BYTES} reference bytes`);
+  }
+
+  const hexadecimal = Array.from(bytes, (byte) =>
+    byte.toString(16).padStart(2, "0").toUpperCase(),
+  ).join("");
+  return `ERR-${hexadecimal.slice(0, 4)}-${hexadecimal.slice(4, 8)}-${hexadecimal.slice(8, 12)}`;
+};
+
+/**
+ * Create an opaque support reference without accepting error, route, workspace,
+ * or user data. The API shape makes sensitive-data inclusion impossible.
+ */
+export const createErrorReference = (): ErrorReference => {
+  const bytes = new Uint8Array(ERROR_REFERENCE_BYTES);
+  globalThis.crypto.getRandomValues(bytes);
+  return formatErrorReference(bytes);
+};
+
+export const isErrorReference = (value: unknown): value is ErrorReference =>
+  typeof value === "string" && ERROR_REFERENCE_PATTERN.test(value);

--- a/apps/web/src/lib/analytics/noop.ts
+++ b/apps/web/src/lib/analytics/noop.ts
@@ -1,16 +1,35 @@
 import { CancelledError } from "@tanstack/react-query";
 
-import type { Analytics } from "@/lib/analytics/types";
+import type { Analytics, ErrorCaptureContext } from "@/lib/analytics/types";
 import { logDevError } from "@/lib/errors/utils";
 
 const noop = () => undefined;
+
+const devErrorContext = (
+  context: ErrorCaptureContext | undefined,
+): Record<string, string> | undefined => {
+  if (!context) {
+    return undefined;
+  }
+
+  switch (context.type) {
+    case "detached":
+      return { detached: context.operation };
+    case "recovery":
+      return { error_reference: context.reference };
+    default: {
+      const exhaustive: never = context;
+      return exhaustive;
+    }
+  }
+};
 
 export const noopAnalytics: Analytics = {
   captureError: (error, context) => {
     if (error instanceof CancelledError) {
       return;
     }
-    logDevError(error, context);
+    logDevError(error, devErrorContext(context));
   },
   capturePageViewed: noop,
   identifyUser: noop,

--- a/apps/web/src/lib/analytics/posthog.test.ts
+++ b/apps/web/src/lib/analytics/posthog.test.ts
@@ -32,7 +32,9 @@ let distinctId = "anonymous";
 let identified = false;
 
 const captureMock = mock((_event: string, _properties?: unknown) => undefined);
-const captureExceptionMock = mock((_error: unknown) => undefined);
+const captureExceptionMock = mock(
+  (_error: unknown, _properties?: Record<string, unknown>) => undefined,
+);
 const identifyMock = mock(
   (id: string, _properties?: Record<string, unknown>) => {
     distinctId = id;
@@ -225,6 +227,21 @@ describe("PostHog browser analytics adapter", () => {
     expect(captured.stack).toBeUndefined();
   });
 
+  test("captureError correlates a recovery reference without error details", () => {
+    const { analytics } = createPostHogAnalytics(
+      "phc_test",
+      "https://posthog.test",
+    );
+    analytics.captureError(new TypeError("Privileged document name"), {
+      type: "recovery",
+      reference: "ERR-DEAD-BEEF-1234",
+    });
+
+    expect(captureExceptionMock.mock.calls.at(-1)?.[1]).toEqual({
+      error_reference: "ERR-DEAD-BEEF-1234",
+    });
+  });
+
   test("before_send strips exception messages and stack frames", () => {
     createPostHogAnalytics("phc_test", "https://posthog.test");
     const sanitized = initOptions?.before_send({
@@ -245,6 +262,42 @@ describe("PostHog browser analytics adapter", () => {
       event: WEB_ANALYTICS_EVENTS.exception,
       properties: {
         $distinct_id: "user_123",
+        $exception_list: [{ type: "TypeError", value: "" }],
+        $exception_type: "TypeError",
+      },
+    });
+  });
+
+  test("before_send keeps only valid opaque recovery references", () => {
+    createPostHogAnalytics("phc_test", "https://posthog.test");
+    const sanitized = initOptions?.before_send({
+      event: WEB_ANALYTICS_EVENTS.exception,
+      properties: {
+        error_reference: "ERR-DEAD-BEEF-1234",
+        route: "/workspaces/private-matter",
+        $exception_list: [{ type: "TypeError", value: "Private matter" }],
+      },
+    });
+
+    expect(sanitized).toEqual({
+      event: WEB_ANALYTICS_EVENTS.exception,
+      properties: {
+        error_reference: "ERR-DEAD-BEEF-1234",
+        $exception_list: [{ type: "TypeError", value: "" }],
+        $exception_type: "TypeError",
+      },
+    });
+
+    const rejected = initOptions?.before_send({
+      event: WEB_ANALYTICS_EVENTS.exception,
+      properties: {
+        error_reference: "/workspaces/private-matter",
+        $exception_list: [{ type: "TypeError", value: "Private matter" }],
+      },
+    });
+    expect(rejected).toEqual({
+      event: WEB_ANALYTICS_EVENTS.exception,
+      properties: {
         $exception_list: [{ type: "TypeError", value: "" }],
         $exception_type: "TypeError",
       },

--- a/apps/web/src/lib/analytics/posthog.ts
+++ b/apps/web/src/lib/analytics/posthog.ts
@@ -3,8 +3,13 @@ import { posthog } from "posthog-js";
 import type { CaptureResult } from "posthog-js";
 
 import { env } from "@/env";
+import { isErrorReference } from "@/lib/analytics/error-reference";
 import { WEB_ANALYTICS_EVENTS } from "@/lib/analytics/types";
-import type { Analytics, WebAnalyticsEvent } from "@/lib/analytics/types";
+import type {
+  Analytics,
+  ErrorCaptureContext,
+  WebAnalyticsEvent,
+} from "@/lib/analytics/types";
 import { logDevError } from "@/lib/errors/utils";
 
 const isWebAnalyticsEvent = (event: string): event is WebAnalyticsEvent =>
@@ -85,6 +90,7 @@ const sanitizeExceptionEvent = (event: CaptureResult): CaptureResult => {
   const distinctId = properties["$distinct_id"];
   const appCommit = properties["app_commit"];
   const appVersion = properties["app_version"];
+  const errorReference = properties["error_reference"];
   const exceptionList = properties["$exception_list"];
   const firstException: unknown = Array.isArray(exceptionList)
     ? exceptionList.at(0)
@@ -100,8 +106,40 @@ const sanitizeExceptionEvent = (event: CaptureResult): CaptureResult => {
       ...(typeof distinctId === "string" ? { $distinct_id: distinctId } : {}),
       ...(typeof appCommit === "string" ? { app_commit: appCommit } : {}),
       ...(typeof appVersion === "string" ? { app_version: appVersion } : {}),
+      ...(isErrorReference(errorReference)
+        ? { error_reference: errorReference }
+        : {}),
     },
   };
+};
+
+const errorContextProperties = (
+  context: ErrorCaptureContext | undefined,
+): Record<string, string> | undefined => {
+  if (context?.type !== "recovery") {
+    return undefined;
+  }
+
+  return { error_reference: context.reference };
+};
+
+const devErrorContext = (
+  context: ErrorCaptureContext | undefined,
+): Record<string, string> | undefined => {
+  if (!context) {
+    return undefined;
+  }
+
+  switch (context.type) {
+    case "detached":
+      return { detached: context.operation };
+    case "recovery":
+      return { error_reference: context.reference };
+    default: {
+      const exhaustive: never = context;
+      return exhaustive;
+    }
+  }
 };
 
 /**
@@ -183,8 +221,11 @@ export const createPostHogAnalytics = (
       ) {
         return;
       }
-      logDevError(error, context);
-      posthog.captureException(toRedactedTelemetryError(error));
+      logDevError(error, devErrorContext(context));
+      posthog.captureException(
+        toRedactedTelemetryError(error),
+        errorContextProperties(context),
+      );
     },
     capturePageViewed: ({ path }) => {
       posthog.capture(WEB_ANALYTICS_EVENTS.pageViewed, {

--- a/apps/web/src/lib/analytics/types.ts
+++ b/apps/web/src/lib/analytics/types.ts
@@ -1,3 +1,5 @@
+import type { ErrorReference } from "@/lib/analytics/error-reference";
+
 export const WEB_ANALYTICS_EVENTS = {
   exception: "$exception",
   identify: "$identify",
@@ -8,11 +10,15 @@ export type WebAnalyticsEvent =
   (typeof WEB_ANALYTICS_EVENTS)[keyof typeof WEB_ANALYTICS_EVENTS];
 
 export type Analytics = {
-  captureError: (error: unknown, context?: Record<string, string>) => void;
+  captureError: (error: unknown, context?: ErrorCaptureContext) => void;
   capturePageViewed: (properties: PageViewedProperties) => void;
   identifyUser: (user: AnalyticsUserIdentity) => void;
   reset: (options?: AnalyticsResetOptions) => void;
 };
+
+export type ErrorCaptureContext =
+  | { type: "detached"; operation: string }
+  | { type: "recovery"; reference: ErrorReference };
 
 export type AnalyticsResetOptions = {
   onlyIfIdentified?: boolean;

--- a/apps/web/src/lib/detached.ts
+++ b/apps/web/src/lib/detached.ts
@@ -20,6 +20,9 @@ export const detached = (
   context: string,
 ): void => {
   Promise.resolve(operation).catch((error: unknown) => {
-    getAnalytics().captureError(error, { detached: context });
+    getAnalytics().captureError(error, {
+      type: "detached",
+      operation: context,
+    });
   });
 };


### PR DESCRIPTION
## Summary

- replace the generic route failure state with retry, matters navigation, and configured reporting
- attach a privacy-safe support reference to redacted error telemetry
- localize the recovery experience across all supported languages and preserve RTL behavior