### PR TITLE
fix(api): drop unsupported streamed chat parts instead of panicking

### DIFF
--- a/apps/api/src/handlers/chat/__fixtures__/non-persistable-chat-parts.ts
+++ b/apps/api/src/handlers/chat/__fixtures__/non-persistable-chat-parts.ts
@@ -1,0 +1,20 @@
+import type { UIMessage } from "@tanstack/ai";
+
+/** Every `MessagePart` variant excluded from `PersistableChatPart`. Shared so a
+ *  new non-persistable type is added in one place, not per test file. */
+export const nonPersistableChatParts = [
+  {
+    type: "audio",
+    source: { type: "url", value: "https://example.test/a.mp3" },
+  },
+  {
+    type: "video",
+    source: { type: "url", value: "https://example.test/v.mp4" },
+  },
+  {
+    type: "ui-resource",
+    resource: { uri: "ui://widget", mimeType: "text/html" },
+    toolCallId: "call-1",
+    toolName: "widget",
+  },
+] as const satisfies UIMessage["parts"];

--- a/apps/api/src/handlers/chat/__fixtures__/non-persistable-chat-parts.ts
+++ b/apps/api/src/handlers/chat/__fixtures__/non-persistable-chat-parts.ts
@@ -1,5 +1,6 @@
-/** Every `MessagePart` variant excluded from `PersistableChatPart`. Shared so a
- *  new non-persistable type is added in one place, not per test file. */
+/** Every `MessagePart` variant explicitly dropped by the persistence policy.
+ * Shared so a future TanStack union change cannot update one stream-path test
+ * in isolation. */
 export const nonPersistableChatParts = [
   {
     type: "audio",

--- a/apps/api/src/handlers/chat/__fixtures__/non-persistable-chat-parts.ts
+++ b/apps/api/src/handlers/chat/__fixtures__/non-persistable-chat-parts.ts
@@ -1,5 +1,3 @@
-import type { UIMessage } from "@tanstack/ai";
-
 /** Every `MessagePart` variant excluded from `PersistableChatPart`. Shared so a
  *  new non-persistable type is added in one place, not per test file. */
 export const nonPersistableChatParts = [
@@ -17,4 +15,4 @@ export const nonPersistableChatParts = [
     toolCallId: "call-1",
     toolName: "widget",
   },
-] as const satisfies UIMessage["parts"];
+] as const;

--- a/apps/api/src/handlers/chat/chat-message-parts.test.ts
+++ b/apps/api/src/handlers/chat/chat-message-parts.test.ts
@@ -2,10 +2,11 @@ import { describe, expect, test } from "bun:test";
 
 import {
   chatMessageFromPersisted,
+  classifyChatPartForPersistence,
   isChatAttachmentPart,
   isChatPart,
+  toChatMessageContent,
 } from "@/api/handlers/chat/chat-message-parts";
-import type { ChatMessageContent } from "@/api/handlers/chat/types";
 import { toSafeId } from "@/api/lib/branded-types";
 
 describe("persisted chat message parts", () => {
@@ -13,13 +14,13 @@ describe("persisted chat message parts", () => {
     const message = chatMessageFromPersisted({
       id: toSafeId<"chatMessage">("019eb9fa-c91f-7000-9b9c-9365977dda78"),
       role: "assistant",
-      content: {
+      content: toChatMessageContent({
         version: 2,
         data: [{ type: "text", content: "Summary" }],
         metadata: {
           serverProvenance: { type: "search-summary", version: 1 },
         },
-      } satisfies ChatMessageContent,
+      }),
     });
 
     expect(message.metadata).toEqual({
@@ -31,7 +32,7 @@ describe("persisted chat message parts", () => {
     const message = chatMessageFromPersisted({
       id: toSafeId<"chatMessage">("019eb9fa-c91f-7000-9b9c-9365977dda79"),
       role: "assistant",
-      content: {
+      content: toChatMessageContent({
         version: 2,
         data: [{ type: "text", content: "Ahoj" }],
         metadata: {
@@ -42,7 +43,7 @@ describe("persisted chat message parts", () => {
             totalTokens: 30,
           },
         },
-      } satisfies ChatMessageContent,
+      }),
     });
 
     expect(message.metadata).toEqual({
@@ -70,5 +71,11 @@ describe("chat attachment parts", () => {
 
     expect(isChatPart({ type: "audio", source })).toBe(false);
     expect(isChatPart({ type: "video", source })).toBe(false);
+  });
+
+  test("fails loudly for malformed parts whose type must be persisted", () => {
+    expect(() =>
+      classifyChatPartForPersistence({ type: "tool-call", state: "new-state" }),
+    ).toThrow("Cannot persist malformed chat part type: tool-call");
   });
 });

--- a/apps/api/src/handlers/chat/chat-message-parts.ts
+++ b/apps/api/src/handlers/chat/chat-message-parts.ts
@@ -1,21 +1,25 @@
 import type { ContentPartSource } from "@tanstack/ai";
+import { panic } from "better-result";
 
 import { normalizeLegacyRawToolInputs } from "@/api/handlers/chat/legacy-tool-compat";
 import type {
   ChatAttachmentMetadata,
   ChatAttachmentPart,
   ChatMessage,
+  ChatMessageContentCandidate,
   ChatMessageContent,
   ChatMessageMetadata,
   ChatMessageRole,
   ChatPart,
   ChatTanStackPart,
-  PersistableChatPart,
+  PersistableChatPartType,
+  PersistableChatMessageCandidate,
   PersistableChatMessage,
   PersistedChatMessageContent,
 } from "@/api/handlers/chat/types";
 import { arrayOrEmpty } from "@/api/lib/array";
 import type { SafeId } from "@/api/lib/branded-types";
+import { provePersistedChatMessageContent } from "@/api/lib/chat/persisted-message-content";
 import { isUserFileUrl, parseUserFileId } from "@/api/lib/user-files/types";
 
 const IMAGE_MIME_PREFIX = "image/";
@@ -227,23 +231,24 @@ export const chatMessageFromPersisted = ({
   role,
 }: PersistedChatMessageRow): PersistableChatMessage => {
   const normalized = normalizePersistedChatMessageContent(content);
-  return {
+  return toPersistableChatMessage({
     id,
     role,
     parts: normalized.parts,
     ...(isChatMessageMetadataEmpty(normalized.metadata)
       ? {}
       : { metadata: normalized.metadata }),
-  };
+  });
 };
 
 export const chatMessageContentFromMessage = (
-  message: ChatMessage,
-): ChatMessageContent => ({
-  version: 2,
-  data: message.parts,
-  ...(message.metadata === undefined ? {} : { metadata: message.metadata }),
-});
+  message: PersistableChatMessage,
+): ChatMessageContent =>
+  toChatMessageContent({
+    version: 2,
+    data: message.parts,
+    ...(message.metadata === undefined ? {} : { metadata: message.metadata }),
+  });
 
 export const toProviderVisibleMessage = (
   message: ChatMessage,
@@ -290,10 +295,25 @@ const isContentPartWithSource = (
 
 type ChatPartValidator = (part: Record<string, unknown>) => boolean;
 
-// This record is deliberately exhaustive over Stella's persistable subset of
-// TanStack MessagePart. A future SDK variant becomes persistable by
-// default, then fails typecheck here until its persistence policy and validator
-// are defined. Unsupported modalities stay explicit in the excluded union.
+type ChatPartPersistence = "drop" | "persist";
+
+// Every TanStack part must receive an explicit persistence policy. A future SDK
+// variant fails typecheck here until it is deliberately persisted or dropped.
+const CHAT_PART_PERSISTENCE = {
+  audio: "drop",
+  document: "persist",
+  image: "persist",
+  "structured-output": "persist",
+  text: "persist",
+  thinking: "persist",
+  "tool-call": "persist",
+  "tool-result": "persist",
+  "ui-resource": "drop",
+  video: "drop",
+} as const satisfies Record<ChatTanStackPart["type"], ChatPartPersistence>;
+
+// Validators are independently exhaustive over the persistable subset, so a
+// part cannot enter the persistence boundary without structural validation.
 const CHAT_PART_VALIDATORS = {
   document: isContentPartWithSource,
   image: isContentPartWithSource,
@@ -310,20 +330,71 @@ const CHAT_PART_VALIDATORS = {
     isTanStackToolResultContent(part["content"]) &&
     isTanStackToolResultState(part["state"]) &&
     (!("error" in part) || typeof part["error"] === "string"),
-} satisfies Record<PersistableChatPart["type"], ChatPartValidator>;
+} satisfies Record<PersistableChatPartType, ChatPartValidator>;
+
+const isChatPartPersistenceType = (
+  type: string,
+): type is keyof typeof CHAT_PART_PERSISTENCE =>
+  Object.hasOwn(CHAT_PART_PERSISTENCE, type);
 
 const isChatPartType = (
   type: string,
 ): type is keyof typeof CHAT_PART_VALIDATORS =>
   Object.hasOwn(CHAT_PART_VALIDATORS, type);
 
-export const isChatPart = (part: unknown): part is PersistableChatPart => {
+export const isChatPart = (part: unknown): part is ChatPart => {
   if (!isRecord(part) || typeof part["type"] !== "string") {
     return false;
   }
   const type = part["type"];
+  if (
+    !isChatPartPersistenceType(type) ||
+    CHAT_PART_PERSISTENCE[type] === "drop"
+  ) {
+    return false;
+  }
   return isChatPartType(type) && CHAT_PART_VALIDATORS[type](part);
 };
+
+type ChatPartPersistenceDecision =
+  | { type: "drop"; partType: string }
+  | { type: "persist"; part: ChatPart };
+
+export const classifyChatPartForPersistence = (
+  part: unknown,
+): ChatPartPersistenceDecision => {
+  if (!isRecord(part) || typeof part["type"] !== "string") {
+    panic("Cannot classify a malformed chat part for persistence");
+  }
+  const type = part["type"];
+  if (!isChatPartPersistenceType(type)) {
+    panic(`Cannot classify unknown chat part type: ${type}`);
+  }
+  if (CHAT_PART_PERSISTENCE[type] === "drop") {
+    return { type: "drop", partType: type };
+  }
+  if (!isChatPart(part)) {
+    panic(`Cannot persist malformed chat part type: ${type}`);
+  }
+  return { type: "persist", part };
+};
+
+const isPersistableChatMessage = (
+  message: PersistableChatMessageCandidate,
+): message is PersistableChatMessage => message.parts.every(isChatPart);
+
+export const toPersistableChatMessage = (
+  message: PersistableChatMessageCandidate,
+): PersistableChatMessage => {
+  if (!isPersistableChatMessage(message)) {
+    panic("Cannot mark a chat message with unsupported parts as persistable");
+  }
+  return message;
+};
+
+export const toChatMessageContent = (
+  content: ChatMessageContentCandidate,
+): ChatMessageContent => provePersistedChatMessageContent(content, isChatPart);
 
 const isLegacyAnonRestorationsPart = (
   part: unknown,

--- a/apps/api/src/handlers/chat/chat-message-parts.ts
+++ b/apps/api/src/handlers/chat/chat-message-parts.ts
@@ -19,7 +19,6 @@ import type {
 } from "@/api/handlers/chat/types";
 import { arrayOrEmpty } from "@/api/lib/array";
 import type { SafeId } from "@/api/lib/branded-types";
-import { provePersistedChatMessageContent } from "@/api/lib/chat/persisted-message-content";
 import { isUserFileUrl, parseUserFileId } from "@/api/lib/user-files/types";
 
 const IMAGE_MIME_PREFIX = "image/";
@@ -392,9 +391,18 @@ export const toPersistableChatMessage = (
   return message;
 };
 
+const isChatMessageContent = (
+  content: ChatMessageContentCandidate,
+): content is ChatMessageContent => content.data.every(isChatPart);
+
 export const toChatMessageContent = (
   content: ChatMessageContentCandidate,
-): ChatMessageContent => provePersistedChatMessageContent(content, isChatPart);
+): ChatMessageContent => {
+  if (!isChatMessageContent(content)) {
+    panic("Cannot persist chat message content with unsupported parts");
+  }
+  return content;
+};
 
 const isLegacyAnonRestorationsPart = (
   part: unknown,

--- a/apps/api/src/handlers/chat/chat-message-parts.ts
+++ b/apps/api/src/handlers/chat/chat-message-parts.ts
@@ -276,43 +276,6 @@ export const getUserFileIdFromAttachmentPart = (
   return parseUserFileId(url);
 };
 
-export const isChatPart = (part: unknown): part is ChatPart => {
-  if (!isRecord(part) || typeof part["type"] !== "string") {
-    return false;
-  }
-
-  switch (part["type"]) {
-    case "text":
-      return typeof part["content"] === "string";
-    case "image":
-    case "document":
-      return isContentPartWithSource(part);
-    case "audio":
-    case "video":
-      return false;
-    case "tool-call":
-      return (
-        typeof part["id"] === "string" &&
-        typeof part["name"] === "string" &&
-        typeof part["arguments"] === "string" &&
-        isTanStackToolCallState(part["state"])
-      );
-    case "tool-result":
-      return (
-        typeof part["toolCallId"] === "string" &&
-        isTanStackToolResultContent(part["content"]) &&
-        isTanStackToolResultState(part["state"]) &&
-        (!("error" in part) || typeof part["error"] === "string")
-      );
-    case "thinking":
-      return typeof part["content"] === "string";
-    case "structured-output":
-      return "data" in part;
-    default:
-      return false;
-  }
-};
-
 const isContentPartWithSource = (
   part: Record<string, unknown>,
 ): part is Record<string, unknown> & {
@@ -323,6 +286,43 @@ const isContentPartWithSource = (
   typeof part["source"]["value"] === "string" &&
   (!("mimeType" in part["source"]) ||
     typeof part["source"]["mimeType"] === "string");
+
+type ChatPartValidator = (part: Record<string, unknown>) => boolean;
+
+// This record is deliberately exhaustive over Stella's persistable subset of
+// TanStack MessagePart. A future SDK variant becomes part of ChatPart by
+// default, then fails typecheck here until its persistence policy and validator
+// are defined. Unsupported modalities stay explicit in ChatPart's excluded union.
+const CHAT_PART_VALIDATORS = {
+  document: isContentPartWithSource,
+  image: isContentPartWithSource,
+  "structured-output": (part) => "data" in part,
+  text: (part) => typeof part["content"] === "string",
+  thinking: (part) => typeof part["content"] === "string",
+  "tool-call": (part) =>
+    typeof part["id"] === "string" &&
+    typeof part["name"] === "string" &&
+    typeof part["arguments"] === "string" &&
+    isTanStackToolCallState(part["state"]),
+  "tool-result": (part) =>
+    typeof part["toolCallId"] === "string" &&
+    isTanStackToolResultContent(part["content"]) &&
+    isTanStackToolResultState(part["state"]) &&
+    (!("error" in part) || typeof part["error"] === "string"),
+} satisfies Record<ChatPart["type"], ChatPartValidator>;
+
+const isChatPartType = (
+  type: string,
+): type is keyof typeof CHAT_PART_VALIDATORS =>
+  Object.hasOwn(CHAT_PART_VALIDATORS, type);
+
+export const isChatPart = (part: unknown): part is ChatPart => {
+  if (!isRecord(part) || typeof part["type"] !== "string") {
+    return false;
+  }
+  const type = part["type"];
+  return isChatPartType(type) && CHAT_PART_VALIDATORS[type](part);
+};
 
 const isLegacyAnonRestorationsPart = (
   part: unknown,

--- a/apps/api/src/handlers/chat/chat-message-parts.ts
+++ b/apps/api/src/handlers/chat/chat-message-parts.ts
@@ -10,6 +10,7 @@ import type {
   ChatMessageRole,
   ChatPart,
   ChatTanStackPart,
+  PersistableChatPart,
   PersistableChatMessage,
   PersistedChatMessageContent,
 } from "@/api/handlers/chat/types";
@@ -290,9 +291,9 @@ const isContentPartWithSource = (
 type ChatPartValidator = (part: Record<string, unknown>) => boolean;
 
 // This record is deliberately exhaustive over Stella's persistable subset of
-// TanStack MessagePart. A future SDK variant becomes part of ChatPart by
+// TanStack MessagePart. A future SDK variant becomes persistable by
 // default, then fails typecheck here until its persistence policy and validator
-// are defined. Unsupported modalities stay explicit in ChatPart's excluded union.
+// are defined. Unsupported modalities stay explicit in the excluded union.
 const CHAT_PART_VALIDATORS = {
   document: isContentPartWithSource,
   image: isContentPartWithSource,
@@ -309,14 +310,14 @@ const CHAT_PART_VALIDATORS = {
     isTanStackToolResultContent(part["content"]) &&
     isTanStackToolResultState(part["state"]) &&
     (!("error" in part) || typeof part["error"] === "string"),
-} satisfies Record<ChatPart["type"], ChatPartValidator>;
+} satisfies Record<PersistableChatPart["type"], ChatPartValidator>;
 
 const isChatPartType = (
   type: string,
 ): type is keyof typeof CHAT_PART_VALIDATORS =>
   Object.hasOwn(CHAT_PART_VALIDATORS, type);
 
-export const isChatPart = (part: unknown): part is ChatPart => {
+export const isChatPart = (part: unknown): part is PersistableChatPart => {
   if (!isRecord(part) || typeof part["type"] !== "string") {
     return false;
   }

--- a/apps/api/src/handlers/chat/chat-schema.ts
+++ b/apps/api/src/handlers/chat/chat-schema.ts
@@ -19,6 +19,7 @@ import {
 import {
   isChatPart,
   isChatTextPart,
+  toPersistableChatMessage,
 } from "@/api/handlers/chat/chat-message-parts";
 import { CHAT_TOOL_SCOPE } from "@/api/handlers/chat/tools/tool-scope";
 import type {
@@ -276,14 +277,14 @@ export const validateMessage = async ({
       return Result.err(metadataResult.error);
     }
 
-    const validatedMessage: PersistableChatMessage = {
+    const validatedMessage = toPersistableChatMessage({
       id: message.id,
       role: message.role,
       parts: partsResult.value,
       ...(metadataResult.value === undefined
         ? {}
         : { metadata: metadataResult.value }),
-    };
+    });
     const toolValidationResult = validateToolCallParts({
       message: validatedMessage,
       tools,
@@ -877,7 +878,7 @@ export const parseMessage = ({
     };
   }
 
-  const normalizedParts: ChatMessage["parts"] = [];
+  const normalizedParts: ChatPart[] = [];
   const mentions: ChatMention[] = [];
 
   for (const part of message.parts) {

--- a/apps/api/src/handlers/chat/message-page.test.ts
+++ b/apps/api/src/handlers/chat/message-page.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, test } from "bun:test";
 
+import { toChatMessageContent } from "@/api/handlers/chat/chat-message-parts";
 import {
   clientMessageFromPageRow,
   decodeMessagePageCursor,
   encodeMessagePageCursor,
 } from "@/api/handlers/chat/message-page";
-import type { ChatMessageContent } from "@/api/handlers/chat/types";
 import { brandPersistedChatMessageId } from "@/api/lib/safe-id-boundaries";
 
 const MESSAGE_ID = brandPersistedChatMessageId(
@@ -50,7 +50,7 @@ describe("clientMessageFromPageRow", () => {
       {
         id: MESSAGE_ID,
         role: "assistant",
-        content: {
+        content: toChatMessageContent({
           version: 2,
           data: [{ type: "text", content: "Done" }],
           metadata: {
@@ -72,7 +72,7 @@ describe("clientMessageFromPageRow", () => {
               totalTokens: 5,
             },
           },
-        } satisfies ChatMessageContent,
+        }),
       },
       new Map(),
     );

--- a/apps/api/src/handlers/chat/persist-message.test.ts
+++ b/apps/api/src/handlers/chat/persist-message.test.ts
@@ -3,10 +3,14 @@ import { describe, expect, test } from "bun:test";
 import { toSafeId } from "@/api/lib/branded-types";
 
 import {
+  toChatMessageContent,
+  toPersistableChatMessage,
+} from "./chat-message-parts";
+import {
   planAssistantFinishPersistence,
   planMessagePersistence,
 } from "./persist-message";
-import type { ChatMessageContent, PersistableChatMessage } from "./types";
+import type { PersistableChatMessage } from "./types";
 
 const workspaceId = toSafeId<"workspace">(
   "0dc54d0c-10d7-501d-897e-e801dbd0998c",
@@ -19,11 +23,11 @@ const chatMessageId = (id: string) => toSafeId<"chatMessage">(id);
 const stored = (message: PersistableChatMessage) => ({
   id: message.id,
   role: message.role,
-  content: {
+  content: toChatMessageContent({
     version: 2,
     data: message.parts,
     metadata: message.metadata,
-  } satisfies ChatMessageContent,
+  }),
 });
 
 const createDocumentInput = {
@@ -31,7 +35,7 @@ const createDocumentInput = {
   source: "@title Draft agreement",
 };
 
-const createDocumentApprovalRespondedMessage = {
+const createDocumentApprovalRespondedMessage = toPersistableChatMessage({
   id: chatMessageId("019aef0c-4df0-7d25-b5ad-cfa5a548fb2b"),
   role: "assistant",
   parts: [
@@ -44,9 +48,9 @@ const createDocumentApprovalRespondedMessage = {
       input: createDocumentInput,
     },
   ],
-} satisfies PersistableChatMessage;
+});
 
-const createDocumentFinishedMessage = {
+const createDocumentFinishedMessage = toPersistableChatMessage({
   ...createDocumentApprovalRespondedMessage,
   parts: [
     {
@@ -75,9 +79,9 @@ const createDocumentFinishedMessage = {
         `${workspaceId}:${entityId}).`,
     },
   ],
-} satisfies PersistableChatMessage;
+});
 
-const updateFieldsApprovalRespondedMessage = {
+const updateFieldsApprovalRespondedMessage = toPersistableChatMessage({
   id: chatMessageId("019aef0c-4df0-7d25-b5ad-cfa5a548fb2c"),
   role: "assistant",
   parts: [
@@ -105,9 +109,9 @@ const updateFieldsApprovalRespondedMessage = {
       },
     },
   ],
-} satisfies PersistableChatMessage;
+});
 
-const updateFieldsFinishedMessage = {
+const updateFieldsFinishedMessage = toPersistableChatMessage({
   ...updateFieldsApprovalRespondedMessage,
   parts: [
     {
@@ -144,7 +148,7 @@ const updateFieldsFinishedMessage = {
       content: "Updated Status to Reviewed.",
     },
   ],
-} satisfies PersistableChatMessage;
+});
 
 describe("chat approval persistence", () => {
   test("updates an approved create-document assistant message with the final output and text", () => {
@@ -186,11 +190,11 @@ describe("chat approval persistence", () => {
   });
 
   test("inserts a new final assistant message after an ordinary user turn", () => {
-    const userMessage = {
+    const userMessage = toPersistableChatMessage({
       id: chatMessageId("019aef0c-4df0-7d25-b5ad-cfa5a548fb2d"),
       role: "user",
       parts: [{ type: "text", content: "Create a document" }],
-    } satisfies PersistableChatMessage;
+    });
 
     const incomingPlan = planMessagePersistence({
       message: userMessage,
@@ -210,11 +214,11 @@ describe("chat approval persistence", () => {
   });
 
   test("does not overwrite user messages from the finish callback", () => {
-    const userMessage = {
+    const userMessage = toPersistableChatMessage({
       id: chatMessageId("019aef0c-4df0-7d25-b5ad-cfa5a548fb2e"),
       role: "user",
       parts: [{ type: "text", content: "Approved" }],
-    } satisfies PersistableChatMessage;
+    });
 
     const finishPlan = planAssistantFinishPersistence({
       existingIds: new Set([userMessage.id]),
@@ -237,17 +241,17 @@ describe("chat approval persistence", () => {
 });
 
 describe("chat finish persistence on client disconnect", () => {
-  const userMessage = {
+  const userMessage = toPersistableChatMessage({
     id: chatMessageId("019aef0c-4df0-7d25-b5ad-cfa5a548fb30"),
     role: "user",
     parts: [{ type: "text", content: "Draft a mutual NDA" }],
-  } satisfies PersistableChatMessage;
+  });
 
-  const completedAssistantMessage = {
+  const completedAssistantMessage = toPersistableChatMessage({
     id: chatMessageId("019aef0c-4df0-7d25-b5ad-cfa5a548fb31"),
     role: "assistant",
     parts: [{ type: "text", content: "Here is the completed draft." }],
-  } satisfies PersistableChatMessage;
+  });
 
   // A dropped client connection does not abort the metered provider call, so
   // the generation still reaches `onFinish` as completed. The completed (and
@@ -314,11 +318,11 @@ describe("chat finish persistence on client disconnect", () => {
 });
 
 describe("chat user-message persistence", () => {
-  const userMessage = {
+  const userMessage = toPersistableChatMessage({
     id: chatMessageId("019aef0c-4df0-7d25-b5ad-cfa5a548fb2f"),
     role: "user",
     parts: [{ type: "text", content: "Summarize this matter" }],
-  } satisfies PersistableChatMessage;
+  });
 
   test("does not append a re-sent message already present in the loaded window", () => {
     const result = planMessagePersistence({

--- a/apps/api/src/handlers/chat/send-message.ts
+++ b/apps/api/src/handlers/chat/send-message.ts
@@ -9,7 +9,10 @@ import type { SafeDb, SafeDbError } from "@/api/db/safe-db";
 import { chatMessages, chatThreads } from "@/api/db/schema";
 import type { FieldContent } from "@/api/db/schema-validators";
 import { env } from "@/api/env";
-import { chatMessageContentFromMessage } from "@/api/handlers/chat/chat-message-parts";
+import {
+  chatMessageContentFromMessage,
+  isChatPart,
+} from "@/api/handlers/chat/chat-message-parts";
 import {
   appendAnonymizedModeHintToChatSafePrompt,
   buildChatPromptCacheKey,
@@ -1980,7 +1983,7 @@ const resolveAssistantMessageRefs = ({
     part: ChatMessage["parts"][number],
   ): ChatMessage["parts"][number] => {
     const resolved = refRegistry.resolveAssistantValueRefs(part);
-    if (!isChatMessagePart(resolved)) {
+    if (!isChatPart(resolved)) {
       panic("Resolving assistant refs changed the message part shape");
     }
     return resolved;

--- a/apps/api/src/handlers/chat/stream-chat.property.test.ts
+++ b/apps/api/src/handlers/chat/stream-chat.property.test.ts
@@ -1,34 +1,17 @@
-import type { UIMessage } from "@tanstack/ai";
 import { describe, expect, test } from "bun:test";
 import fc from "fast-check";
 
 import { propertyConfig } from "@stll/property-testing";
 
+import { nonPersistableChatParts } from "./__fixtures__/non-persistable-chat-parts";
 import { toChatMessage } from "./stream-chat";
-
-const unsupportedParts = [
-  {
-    type: "audio",
-    source: { type: "url", value: "https://example.test/a.mp3" },
-  },
-  {
-    type: "video",
-    source: { type: "url", value: "https://example.test/v.mp4" },
-  },
-  {
-    type: "ui-resource",
-    resource: { uri: "ui://widget", mimeType: "text/html" },
-    toolCallId: "call-1",
-    toolName: "widget",
-  },
-] as const satisfies UIMessage["parts"];
 
 const textPart = fc.record({
   content: fc.string(),
   type: fc.constant("text"),
 });
 const streamedParts = fc.array(
-  fc.oneof(textPart, fc.constantFrom(...unsupportedParts)),
+  fc.oneof(textPart, fc.constantFrom(...nonPersistableChatParts)),
   { maxLength: 20 },
 );
 

--- a/apps/api/src/handlers/chat/stream-chat.property.test.ts
+++ b/apps/api/src/handlers/chat/stream-chat.property.test.ts
@@ -1,0 +1,55 @@
+import type { UIMessage } from "@tanstack/ai";
+import { describe, expect, test } from "bun:test";
+import fc from "fast-check";
+
+import { propertyConfig } from "@stll/property-testing";
+
+import { toChatMessage } from "./stream-chat";
+
+const unsupportedParts = [
+  {
+    type: "audio",
+    source: { type: "url", value: "https://example.test/a.mp3" },
+  },
+  {
+    type: "video",
+    source: { type: "url", value: "https://example.test/v.mp4" },
+  },
+  {
+    type: "ui-resource",
+    resource: { uri: "ui://widget", mimeType: "text/html" },
+    toolCallId: "call-1",
+    toolName: "widget",
+  },
+] as const satisfies UIMessage["parts"];
+
+const textPart = fc.record({
+  content: fc.string(),
+  type: fc.constant("text"),
+});
+const streamedParts = fc.array(
+  fc.oneof(textPart, fc.constantFrom(...unsupportedParts)),
+  { maxLength: 20 },
+);
+
+describe("streamed chat message conversion invariants", () => {
+  test("returns a message exactly when at least one persistable part remains", () => {
+    fc.assert(
+      fc.property(streamedParts, (parts) => {
+        const expectedParts = parts.filter((part) => part.type === "text");
+        const message = toChatMessage({
+          id: "assistant-message",
+          role: "assistant",
+          parts,
+        });
+
+        if (expectedParts.length === 0) {
+          expect(message).toBeNull();
+          return;
+        }
+        expect(message?.parts).toEqual(expectedParts);
+      }),
+      propertyConfig(),
+    );
+  });
+});

--- a/apps/api/src/handlers/chat/stream-chat.test.ts
+++ b/apps/api/src/handlers/chat/stream-chat.test.ts
@@ -1,5 +1,10 @@
 import { EventType, StreamProcessor } from "@tanstack/ai";
-import type { ModelMessage, StreamChunk, ToolCallPart } from "@tanstack/ai";
+import type {
+  ModelMessage,
+  StreamChunk,
+  ToolCallPart,
+  UIMessage,
+} from "@tanstack/ai";
 import { Result } from "better-result";
 import { describe, expect, test } from "bun:test";
 
@@ -34,6 +39,7 @@ import {
   processServerChatStream,
   recordChatAttemptFinish,
   remapOutgoingMessageIds,
+  toChatMessage,
   transformOutgoingStream,
 } from "./stream-chat";
 
@@ -1004,6 +1010,46 @@ describe("chat message usage metadata", () => {
       totalTokens: 32,
     });
   });
+});
+
+describe("streamed chat message conversion", () => {
+  // Every `MessagePart` variant `isChatPart` rejects. Each is a part the SDK
+  // may legally stream, so none may cost the message the model finished.
+  const unsupportedParts: UIMessage["parts"] = [
+    {
+      type: "audio",
+      source: { type: "url", value: "https://example.test/a.mp3" },
+    },
+    {
+      type: "video",
+      source: { type: "url", value: "https://example.test/v.mp4" },
+    },
+    {
+      type: "ui-resource",
+      resource: { uri: "ui://widget", mimeType: "text/html" },
+      toolCallId: "call-1",
+      toolName: "widget",
+    },
+  ];
+
+  for (const unsupported of unsupportedParts) {
+    test(`keeps the surrounding parts when a ${unsupported.type} part arrives`, () => {
+      const message = toChatMessage({
+        id: "assistant-message",
+        role: "assistant",
+        parts: [
+          { content: "Dobrý den", type: "text" },
+          unsupported,
+          { content: "Na shledanou", type: "text" },
+        ],
+      });
+
+      expect(message.parts).toEqual([
+        { content: "Dobrý den", type: "text" },
+        { content: "Na shledanou", type: "text" },
+      ]);
+    });
+  }
 });
 
 describe("chat attempt terminal classification", () => {

--- a/apps/api/src/handlers/chat/stream-chat.test.ts
+++ b/apps/api/src/handlers/chat/stream-chat.test.ts
@@ -1,10 +1,5 @@
 import { EventType, StreamProcessor } from "@tanstack/ai";
-import type {
-  ModelMessage,
-  StreamChunk,
-  ToolCallPart,
-  UIMessage,
-} from "@tanstack/ai";
+import type { ModelMessage, StreamChunk, ToolCallPart } from "@tanstack/ai";
 import { Result } from "better-result";
 import { describe, expect, test } from "bun:test";
 
@@ -28,6 +23,7 @@ import { toUserFileUrl } from "@/api/lib/user-files/types";
 import { PDF_MIME_TYPE } from "@/api/mime-types";
 import { createScopedDbMock } from "@/api/tests/scoped-db-mock";
 
+import { nonPersistableChatParts } from "./__fixtures__/non-persistable-chat-parts";
 import {
   chatMessageUsageFromTokenUsage,
   collectInitialRestorationPlaceholders,
@@ -1013,26 +1009,9 @@ describe("chat message usage metadata", () => {
 });
 
 describe("streamed chat message conversion", () => {
-  // Every `MessagePart` variant `isChatPart` rejects. Each is a part the SDK
-  // may legally stream, so none may cost the message the model finished.
-  const unsupportedParts: UIMessage["parts"] = [
-    {
-      type: "audio",
-      source: { type: "url", value: "https://example.test/a.mp3" },
-    },
-    {
-      type: "video",
-      source: { type: "url", value: "https://example.test/v.mp4" },
-    },
-    {
-      type: "ui-resource",
-      resource: { uri: "ui://widget", mimeType: "text/html" },
-      toolCallId: "call-1",
-      toolName: "widget",
-    },
-  ];
-
-  for (const unsupported of unsupportedParts) {
+  // Each is a part the SDK may legally stream, so none may cost the message
+  // the model finished.
+  for (const unsupported of nonPersistableChatParts) {
     test(`keeps the surrounding parts when a ${unsupported.type} part arrives`, () => {
       const message = toChatMessage({
         id: "assistant-message",
@@ -1085,6 +1064,54 @@ describe("streamed chat message conversion", () => {
         ]),
       }),
     );
+
+    expect(finishCount).toBe(0);
+  });
+
+  // The teardown `finally` reaches the same guard by a different route, so a
+  // dropped connection must not persist the blank turn either.
+  test("does not finish a part-less turn when the client disconnects", async () => {
+    const messageId = toSafeId<"chatMessage">(
+      "11111111-1111-4111-8111-111111111111",
+    );
+    let finishCount = 0;
+    const responseMessage: ChatMessage = {
+      id: messageId,
+      parts: [],
+      role: "assistant",
+    };
+    const processor = new StreamProcessor({ events: {} });
+
+    const stream = processServerChatStream({
+      abortSignal: new AbortController().signal,
+      getResponseMessage: () => responseMessage,
+      mapMessageId: createChatMessageIdMapper(() => messageId),
+      onFinish: () => {
+        finishCount += 1;
+      },
+      processor,
+      source: streamChunks([
+        { type: EventType.RUN_STARTED, runId: "run-1", threadId: "thread-1" },
+        {
+          type: EventType.TEXT_MESSAGE_START,
+          messageId: "provider-message",
+          role: "assistant",
+        },
+        {
+          type: EventType.TEXT_MESSAGE_CONTENT,
+          delta: "Dobrý den",
+          messageId: "provider-message",
+        },
+      ]),
+    });
+
+    // Breaking the `for await` `.return()`s the generator, running the teardown
+    // `finally` that calls `finalizeInterruptedResponseMessage`.
+    for await (const chunk of stream) {
+      if (chunk.type === EventType.TEXT_MESSAGE_CONTENT) {
+        break;
+      }
+    }
 
     expect(finishCount).toBe(0);
   });

--- a/apps/api/src/handlers/chat/stream-chat.test.ts
+++ b/apps/api/src/handlers/chat/stream-chat.test.ts
@@ -1050,6 +1050,44 @@ describe("streamed chat message conversion", () => {
       ]);
     });
   }
+
+  test("does not finish a turn whose parts were all unsupported", async () => {
+    const messageId = toSafeId<"chatMessage">(
+      "11111111-1111-4111-8111-111111111111",
+    );
+    let finishCount = 0;
+    // Every part was dropped, so the turn has nothing to persist. Finishing it
+    // would insert a blank assistant message into the history.
+    const responseMessage: ChatMessage = {
+      id: messageId,
+      parts: [],
+      role: "assistant",
+    };
+    const processor = new StreamProcessor({ events: {} });
+
+    await collectChunks(
+      processServerChatStream({
+        abortSignal: new AbortController().signal,
+        getResponseMessage: () => responseMessage,
+        mapMessageId: createChatMessageIdMapper(() => messageId),
+        onFinish: () => {
+          finishCount += 1;
+        },
+        processor,
+        source: streamChunks([
+          { type: EventType.RUN_STARTED, runId: "run-1", threadId: "thread-1" },
+          {
+            type: EventType.RUN_FINISHED,
+            finishReason: "stop",
+            runId: "run-1",
+            threadId: "thread-1",
+          },
+        ]),
+      }),
+    );
+
+    expect(finishCount).toBe(0);
+  });
 });
 
 describe("chat attempt terminal classification", () => {

--- a/apps/api/src/handlers/chat/stream-chat.test.ts
+++ b/apps/api/src/handlers/chat/stream-chat.test.ts
@@ -7,7 +7,10 @@ import { CHAT_SEND_MODE } from "@stll/anonymize-chat";
 import { createPipelineContext } from "@stll/anonymize-wasm";
 
 import type { ScopedDb } from "@/api/db/safe-db";
-import { createChatAttachmentPart } from "@/api/handlers/chat/chat-message-parts";
+import {
+  createChatAttachmentPart,
+  toPersistableChatMessage,
+} from "@/api/handlers/chat/chat-message-parts";
 import type { ChatThirdPartyBoundary } from "@/api/handlers/chat/third-party-boundary";
 import type {
   ChatAnonRestoration,
@@ -203,23 +206,25 @@ describe("outgoing chat stream message ids", () => {
           ],
         },
       }),
-    ).toEqual({
-      id: messageId,
-      role: "assistant",
-      parts: [
-        {
-          content: "Checking source law.",
-          type: "thinking",
-        },
-        {
-          arguments: "{}",
-          id: "tool-1",
-          name: "ask-user",
-          state: "input-complete",
-          type: "tool-call",
-        },
-      ],
-    });
+    ).toEqual(
+      toPersistableChatMessage({
+        id: messageId,
+        role: "assistant",
+        parts: [
+          {
+            content: "Checking source law.",
+            type: "thinking",
+          },
+          {
+            arguments: "{}",
+            id: "tool-1",
+            name: "ask-user",
+            state: "input-complete",
+            type: "tool-call",
+          },
+        ],
+      }),
+    );
   });
 
   test("seeds tanstack message state before reasoning-only chunks", async () => {

--- a/apps/api/src/handlers/chat/stream-chat.test.ts
+++ b/apps/api/src/handlers/chat/stream-chat.test.ts
@@ -1044,7 +1044,7 @@ describe("streamed chat message conversion", () => {
         ],
       });
 
-      expect(message.parts).toEqual([
+      expect(message?.parts).toEqual([
         { content: "Dobrý den", type: "text" },
         { content: "Na shledanou", type: "text" },
       ]);

--- a/apps/api/src/handlers/chat/stream-chat.ts
+++ b/apps/api/src/handlers/chat/stream-chat.ts
@@ -1095,7 +1095,11 @@ const finishResponseMessage = async ({
   usage,
 }: FinishResponseMessageProps): Promise<boolean> => {
   const responseMessage = getResponseMessage();
-  if (!responseMessage) {
+  // A part-less message is not a turn. `planAssistantFinishPersistence` inserts
+  // whatever a `completed` finish hands it, so letting one through would put a
+  // blank assistant turn in the history that hydration then renders as an empty
+  // reply. Both callers funnel through here, so no path can persist one.
+  if (!responseMessage || responseMessage.parts.length === 0) {
     return false;
   }
 

--- a/apps/api/src/handlers/chat/stream-chat.ts
+++ b/apps/api/src/handlers/chat/stream-chat.ts
@@ -278,10 +278,14 @@ export const streamChat = async ({
     initialMessages: preparedMessages.value,
     events: {
       onStreamEnd: (message) => {
-        responseMessage = attachRestorationMetadata({
-          message: toChatMessage(message),
-          restorationPairs,
-        });
+        const convertedMessage = toChatMessage(message);
+        responseMessage =
+          convertedMessage === null
+            ? null
+            : attachRestorationMetadata({
+                message: convertedMessage,
+                restorationPairs,
+              });
       },
     },
   });
@@ -1960,23 +1964,27 @@ export const chatMessageUsageFromTokenUsage = (
   };
 };
 
-export const toChatMessage = (message: UIMessage): ChatMessage => ({
-  id: message.id,
-  role: message.role,
-  parts: toChatParts(message.parts),
-});
+export const toChatMessage = (message: UIMessage): ChatMessage | null => {
+  const parts = toChatParts(message.parts);
+  if (parts.length === 0) {
+    return null;
+  }
+  return {
+    id: message.id,
+    role: message.role,
+    parts,
+  };
+};
 
 // Which parts a message carries is decided by the model and the SDK, not by
-// this code: `isChatPart` rejects `audio` and `video`, and its `default` rejects
-// `ui-resource` and any part type a later SDK version adds, all of which
-// `MessagePart` permits. An unrecognized part is therefore ordinary external
-// input rather than the broken internal invariant `panic` is for.
+// this code. Stella's persistable subset excludes TanStack's `audio`, `video`,
+// and `ui-resource` parts. A rejected part is therefore ordinary external input
+// rather than the broken internal invariant `panic` is for.
 //
 // Skipping one also keeps the rest of a finished turn, which throwing does not.
-// This runs in the processor's `onStreamEnd`, inside `processServerChatStream`'s
-// `try`, where a throw sets `streamFailed`; that suppresses the `finally`
-// persist, so a single unsupported part would discard an assistant message the
-// model had already completed and the client had already been streamed.
+// When nothing persistable remains, `toChatMessage` returns null rather than an
+// empty message; its nullable return type forces every caller to handle that
+// outcome before a blank assistant turn can reach persistence.
 const toChatParts = (
   parts: readonly UIMessage["parts"][number][],
 ): ChatPart[] => {

--- a/apps/api/src/handlers/chat/stream-chat.ts
+++ b/apps/api/src/handlers/chat/stream-chat.ts
@@ -27,11 +27,12 @@ import type { ChatSendMode } from "@stll/anonymize-chat";
 import type { SafeDb, SafeDbError } from "@/api/db/safe-db";
 import { modelAcceptsDocumentAttachment } from "@/api/handlers/chat/attachment-modality";
 import {
+  classifyChatPartForPersistence,
   getChatAttachmentMimeType,
   getUserFileIdFromAttachmentPart,
-  isChatPart,
   isChatAttachmentPart,
   isChatDocumentPart,
+  toPersistableChatMessage,
 } from "@/api/handlers/chat/chat-message-parts";
 import type {
   ChatSafePrompt,
@@ -60,7 +61,7 @@ import type {
   ChatAnonRestoration,
   ChatMessage,
   ChatMessageUsage,
-  PersistableChatPart,
+  ChatPart,
   PersistableChatMessage,
 } from "@/api/handlers/chat/types";
 import { hydrateFilePart } from "@/api/handlers/chat/upload-files";
@@ -1175,7 +1176,7 @@ export const normalizeFinalAssistantMessageId = ({
   message: ChatMessage;
 }): PersistableChatMessage => {
   const id = mapMessageId(message.id);
-  return { ...message, id };
+  return toPersistableChatMessage({ ...message, id });
 };
 
 type RemapOutgoingMessageIdsProps = {
@@ -1987,17 +1988,18 @@ export const toChatMessage = (message: UIMessage): ChatMessage | null => {
 // outcome before a blank assistant turn can reach persistence.
 const toChatParts = (
   parts: readonly UIMessage["parts"][number][],
-): PersistableChatPart[] => {
-  const chatParts: PersistableChatPart[] = [];
+): ChatPart[] => {
+  const chatParts: ChatPart[] = [];
   for (const part of parts) {
-    if (isChatPart(part)) {
-      chatParts.push(part);
+    const decision = classifyChatPartForPersistence(part);
+    if (decision.type === "persist") {
+      chatParts.push(decision.part);
       continue;
     }
     // Telemetry only: the discriminator alone. A part's content can carry
     // document text, so it is never logged.
     logger.warn("Dropped an unsupported part from a streamed chat message", {
-      "chat.part_type": part.type,
+      "chat.part_type": decision.partType,
     });
   }
   return chatParts;

--- a/apps/api/src/handlers/chat/stream-chat.ts
+++ b/apps/api/src/handlers/chat/stream-chat.ts
@@ -60,7 +60,7 @@ import type {
   ChatAnonRestoration,
   ChatMessage,
   ChatMessageUsage,
-  ChatPart,
+  PersistableChatPart,
   PersistableChatMessage,
 } from "@/api/handlers/chat/types";
 import { hydrateFilePart } from "@/api/handlers/chat/upload-files";
@@ -1987,8 +1987,8 @@ export const toChatMessage = (message: UIMessage): ChatMessage | null => {
 // outcome before a blank assistant turn can reach persistence.
 const toChatParts = (
   parts: readonly UIMessage["parts"][number][],
-): ChatPart[] => {
-  const chatParts: ChatPart[] = [];
+): PersistableChatPart[] => {
+  const chatParts: PersistableChatPart[] = [];
   for (const part of parts) {
     if (isChatPart(part)) {
       chatParts.push(part);

--- a/apps/api/src/handlers/chat/stream-chat.ts
+++ b/apps/api/src/handlers/chat/stream-chat.ts
@@ -1956,21 +1956,37 @@ export const chatMessageUsageFromTokenUsage = (
   };
 };
 
-const toChatMessage = (message: UIMessage): ChatMessage => ({
+export const toChatMessage = (message: UIMessage): ChatMessage => ({
   id: message.id,
   role: message.role,
   parts: toChatParts(message.parts),
 });
 
+// Which parts a message carries is decided by the model and the SDK, not by
+// this code: `isChatPart` rejects `audio` and `video`, and its `default` rejects
+// `ui-resource` and any part type a later SDK version adds, all of which
+// `MessagePart` permits. An unrecognized part is therefore ordinary external
+// input rather than the broken internal invariant `panic` is for.
+//
+// Skipping one also keeps the rest of a finished turn, which throwing does not.
+// This runs in the processor's `onStreamEnd`, inside `processServerChatStream`'s
+// `try`, where a throw sets `streamFailed`; that suppresses the `finally`
+// persist, so a single unsupported part would discard an assistant message the
+// model had already completed and the client had already been streamed.
 const toChatParts = (
   parts: readonly UIMessage["parts"][number][],
 ): ChatPart[] => {
   const chatParts: ChatPart[] = [];
   for (const part of parts) {
-    if (!isChatPart(part)) {
-      panic("TanStack stream emitted an unsupported chat part");
+    if (isChatPart(part)) {
+      chatParts.push(part);
+      continue;
     }
-    chatParts.push(part);
+    // Telemetry only: the discriminator alone. A part's content can carry
+    // document text, so it is never logged.
+    logger.warn("Dropped an unsupported part from a streamed chat message", {
+      "chat.part_type": part.type,
+    });
   }
   return chatParts;
 };

--- a/apps/api/src/handlers/chat/types.ts
+++ b/apps/api/src/handlers/chat/types.ts
@@ -108,14 +108,23 @@ export type ChatMessage = UIMessage<ChatClientTools> & {
   metadata?: ChatMessageMetadata | undefined;
 };
 
-export type PersistableChatMessageCandidate = ChatMessage & {
+export type PersistableChatMessageCandidate = {
+  createdAt?: ChatMessage["createdAt"];
   id: SafeId<"chatMessage">;
+  metadata?: ChatMessageMetadata | undefined;
+  parts: ChatMessage["parts"];
+  role: ChatMessage["role"];
 };
 
 /** Opaque proof assigned only after every part passes the persistence policy. */
 declare const persistableChatMessageProof: unique symbol;
-export type PersistableChatMessage = PersistableChatMessageCandidate & {
+export type PersistableChatMessage = {
+  createdAt?: ChatMessage["createdAt"];
+  id: SafeId<"chatMessage">;
+  metadata?: ChatMessageMetadata | undefined;
+  parts: ChatMessage["parts"];
   readonly [persistableChatMessageProof]: true;
+  role: ChatMessage["role"];
 };
 
 export type ChatMessageRole = UIMessage["role"];

--- a/apps/api/src/handlers/chat/types.ts
+++ b/apps/api/src/handlers/chat/types.ts
@@ -58,7 +58,11 @@ export type ChatAttachmentPart =
   | DocumentPart<ChatAttachmentMetadata>;
 
 export type ChatTanStackPart = MessagePart<ChatClientTools>;
-export type ChatPart = ChatTanStackPart;
+type NonPersistableChatPartType = "audio" | "video" | "ui-resource";
+export type ChatPart = Exclude<
+  ChatTanStackPart,
+  { type: NonPersistableChatPartType }
+>;
 
 export type ChatMessageUsage = Pick<
   TokenUsage,
@@ -95,8 +99,9 @@ export type ChatMessageMetadata = {
   usage?: ChatMessageUsage | undefined;
 };
 
-export type ChatMessage = UIMessage<ChatClientTools> & {
+export type ChatMessage = Omit<UIMessage<ChatClientTools>, "parts"> & {
   metadata?: ChatMessageMetadata | undefined;
+  parts: ChatPart[];
 };
 
 export type PersistableChatMessage = ChatMessage & {

--- a/apps/api/src/handlers/chat/types.ts
+++ b/apps/api/src/handlers/chat/types.ts
@@ -109,7 +109,7 @@ export type ChatMessage = UIMessage<ChatClientTools> & {
 };
 
 export type PersistableChatMessageCandidate = {
-  createdAt?: ChatMessage["createdAt"];
+  createdAt?: NonNullable<ChatMessage["createdAt"]>;
   id: SafeId<"chatMessage">;
   metadata?: ChatMessageMetadata | undefined;
   parts: ChatMessage["parts"];
@@ -119,7 +119,7 @@ export type PersistableChatMessageCandidate = {
 /** Opaque proof assigned only after every part passes the persistence policy. */
 declare const persistableChatMessageProof: unique symbol;
 export type PersistableChatMessage = {
-  createdAt?: ChatMessage["createdAt"];
+  createdAt?: NonNullable<ChatMessage["createdAt"]>;
   id: SafeId<"chatMessage">;
   metadata?: ChatMessageMetadata | undefined;
   parts: ChatMessage["parts"];

--- a/apps/api/src/handlers/chat/types.ts
+++ b/apps/api/src/handlers/chat/types.ts
@@ -59,7 +59,8 @@ export type ChatAttachmentPart =
 
 export type ChatTanStackPart = MessagePart<ChatClientTools>;
 type NonPersistableChatPartType = "audio" | "video" | "ui-resource";
-export type ChatPart = Exclude<
+export type ChatPart = ChatTanStackPart;
+export type PersistableChatPart = Exclude<
   ChatTanStackPart,
   { type: NonPersistableChatPartType }
 >;
@@ -99,9 +100,8 @@ export type ChatMessageMetadata = {
   usage?: ChatMessageUsage | undefined;
 };
 
-export type ChatMessage = Omit<UIMessage<ChatClientTools>, "parts"> & {
+export type ChatMessage = UIMessage<ChatClientTools> & {
   metadata?: ChatMessageMetadata | undefined;
-  parts: ChatPart[];
 };
 
 export type PersistableChatMessage = ChatMessage & {

--- a/apps/api/src/handlers/chat/types.ts
+++ b/apps/api/src/handlers/chat/types.ts
@@ -12,6 +12,7 @@ import type {
   ChatClientToolsFor,
   ChatUIToolsFor,
 } from "@/api/lib/chat/chat-tool-types";
+import type { persistedChatMessageContentProof } from "@/api/lib/chat/persisted-message-content";
 import type { ChatMentionsData } from "@/api/lib/chat/references";
 import type { UserFileUrl } from "@/api/lib/user-files/types";
 
@@ -58,12 +59,15 @@ export type ChatAttachmentPart =
   | DocumentPart<ChatAttachmentMetadata>;
 
 export type ChatTanStackPart = MessagePart<ChatClientTools>;
-type NonPersistableChatPartType = "audio" | "video" | "ui-resource";
 export type ChatPart = ChatTanStackPart;
-export type PersistableChatPart = Exclude<
-  ChatTanStackPart,
-  { type: NonPersistableChatPartType }
->;
+export type PersistableChatPartType =
+  | "document"
+  | "image"
+  | "structured-output"
+  | "text"
+  | "thinking"
+  | "tool-call"
+  | "tool-result";
 
 export type ChatMessageUsage = Pick<
   TokenUsage,
@@ -104,8 +108,14 @@ export type ChatMessage = UIMessage<ChatClientTools> & {
   metadata?: ChatMessageMetadata | undefined;
 };
 
-export type PersistableChatMessage = ChatMessage & {
+export type PersistableChatMessageCandidate = ChatMessage & {
   id: SafeId<"chatMessage">;
+};
+
+/** Opaque proof assigned only after every part passes the persistence policy. */
+declare const persistableChatMessageProof: unique symbol;
+export type PersistableChatMessage = PersistableChatMessageCandidate & {
+  readonly [persistableChatMessageProof]: true;
 };
 
 export type ChatMessageRole = UIMessage["role"];
@@ -136,9 +146,16 @@ export type LegacyChatMessageContent = {
   data: unknown[];
 };
 
+export type ChatMessageContentCandidate = {
+  data: ChatMessage["parts"];
+  metadata?: ChatMessageMetadata | undefined;
+  version: 2;
+};
+
 export type ChatMessageContent = {
   data: ChatMessage["parts"];
   metadata?: ChatMessageMetadata | undefined;
+  readonly [persistedChatMessageContentProof]: true;
   version: 2;
 };
 

--- a/apps/api/src/handlers/chat/upload-files.test.ts
+++ b/apps/api/src/handlers/chat/upload-files.test.ts
@@ -11,8 +11,10 @@ import {
   TEXT_MARKDOWN_MIME_TYPE,
   TEXT_PLAIN_MIME_TYPE,
 } from "@/api/handlers/chat/attachment-validation";
-import { createChatAttachmentPart } from "@/api/handlers/chat/chat-message-parts";
-import type { PersistableChatMessage } from "@/api/handlers/chat/types";
+import {
+  createChatAttachmentPart,
+  toPersistableChatMessage,
+} from "@/api/handlers/chat/chat-message-parts";
 import { toSafeId } from "@/api/lib/branded-types";
 import { toDataUrl } from "@/api/lib/data-url";
 import { DatabaseError } from "@/api/lib/errors/tagged-errors";
@@ -234,7 +236,7 @@ describe("chat attachment hydration", () => {
     const safeDb: SafeDb = async (callback) =>
       // oxlint-disable-next-line node/callback-return -- arrow body already returns the callback result
       await Result.tryPromise(async () => await callback(testTx));
-    const message: PersistableChatMessage = {
+    const message = toPersistableChatMessage({
       id: toSafeId<"chatMessage">("11111111-1111-4111-8111-111111111111"),
       role: "user",
       parts: [
@@ -252,7 +254,7 @@ describe("chat attachment hydration", () => {
           url: "not-a-data-url",
         }),
       ],
-    };
+    });
 
     const recordAuditEvent = mock(async () => undefined);
     const result = await uploadMessageFiles({

--- a/apps/api/src/handlers/search/ai.ts
+++ b/apps/api/src/handlers/search/ai.ts
@@ -27,6 +27,7 @@ import type { AuditRecorder } from "@/api/lib/audit-log";
 import { AUDIT_ACTION, AUDIT_RESOURCE_TYPE } from "@/api/lib/audit-log";
 import type { SafeId } from "@/api/lib/branded-types";
 import { createSafeId } from "@/api/lib/branded-types";
+import { proveTextOnlyPersistedChatMessageContent } from "@/api/lib/chat/persisted-message-content";
 import { tSafeId, tUserId } from "@/api/lib/custom-schema";
 import { LIMITS } from "@/api/lib/limits";
 import {
@@ -54,6 +55,10 @@ const SEARCH_CONTEXT_CHARS_PER_RESULT = 3000;
 const SEARCH_CONTEXT_TOTAL_CHARS = 14_000;
 const SEARCH_REFINE_MAX_ATTEMPTS = 3;
 const SEARCH_SUMMARY_CITATION_LIMIT = 5;
+const SEARCH_SUMMARY_PROVENANCE = {
+  type: "search-summary",
+  version: 1,
+} as const;
 const CITABLE_SEARCH_RESULT_TYPES = [
   "matter",
   "contact",
@@ -672,14 +677,14 @@ export const createSearchSummaryChatThread = async ({
         workspaceId: null,
         userId,
         role: "assistant",
-        content: {
+        content: proveTextOnlyPersistedChatMessageContent({
           version: 2,
           data: [{ type: "text", content: assistantText }],
           metadata: {
-            serverProvenance: { type: "search-summary", version: 1 },
+            serverProvenance: SEARCH_SUMMARY_PROVENANCE,
             sourceDocuments: citedContexts.flatMap(toChatSourceDocuments),
           },
-        },
+        }),
         createdAt: new Date(now.getTime() + 1),
       },
     ]);

--- a/apps/api/src/lib/chat/persisted-message-content.ts
+++ b/apps/api/src/lib/chat/persisted-message-content.ts
@@ -1,0 +1,54 @@
+import { panic } from "better-result";
+
+export type PersistedChatMessageContentCandidate<TPart, TMetadata> = {
+  data: TPart[];
+  metadata?: TMetadata | undefined;
+  version: 2;
+};
+
+export declare const persistedChatMessageContentProof: unique symbol;
+export type PersistedChatMessageContentProof = {
+  readonly [persistedChatMessageContentProof]: true;
+};
+export type ProvenPersistedChatMessageContent<TContent> = TContent &
+  PersistedChatMessageContentProof;
+
+const hasOnlyProvenParts = <TPart, TMetadata>(
+  content: PersistedChatMessageContentCandidate<TPart, TMetadata>,
+  isPersistablePart: (part: TPart) => boolean,
+): content is ProvenPersistedChatMessageContent<
+  PersistedChatMessageContentCandidate<TPart, TMetadata>
+> => content.data.every(isPersistablePart);
+
+export const provePersistedChatMessageContent = <TPart, TMetadata>(
+  content: PersistedChatMessageContentCandidate<TPart, TMetadata>,
+  isPersistablePart: (part: TPart) => boolean,
+): ProvenPersistedChatMessageContent<
+  PersistedChatMessageContentCandidate<TPart, TMetadata>
+> => {
+  if (!hasOnlyProvenParts(content, isPersistablePart)) {
+    panic("Cannot persist chat message content with unsupported parts");
+  }
+  return content;
+};
+
+type PersistedTextChatPart = { content: string; type: "text" };
+
+const isPersistedTextChatPart = (
+  part: unknown,
+): part is PersistedTextChatPart =>
+  typeof part === "object" &&
+  part !== null &&
+  "type" in part &&
+  part.type === "text" &&
+  "content" in part &&
+  typeof part.content === "string";
+
+export const proveTextOnlyPersistedChatMessageContent = <TMetadata>(
+  content: PersistedChatMessageContentCandidate<
+    PersistedTextChatPart,
+    TMetadata
+  >,
+): ProvenPersistedChatMessageContent<
+  PersistedChatMessageContentCandidate<PersistedTextChatPart, TMetadata>
+> => provePersistedChatMessageContent(content, isPersistedTextChatPart);

--- a/apps/api/src/lib/chat/persisted-message-content.ts
+++ b/apps/api/src/lib/chat/persisted-message-content.ts
@@ -1,16 +1,16 @@
 import { panic } from "better-result";
 
-export type PersistedChatMessageContentCandidate<TPart, TMetadata> = {
+type PersistedChatMessageContentCandidate<TPart, TMetadata> = {
   data: TPart[];
   metadata?: TMetadata | undefined;
   version: 2;
 };
 
 export declare const persistedChatMessageContentProof: unique symbol;
-export type PersistedChatMessageContentProof = {
+type PersistedChatMessageContentProof = {
   readonly [persistedChatMessageContentProof]: true;
 };
-export type ProvenPersistedChatMessageContent<TContent> = TContent &
+type ProvenPersistedChatMessageContent<TContent> = TContent &
   PersistedChatMessageContentProof;
 
 const hasOnlyProvenParts = <TPart, TMetadata>(
@@ -20,7 +20,7 @@ const hasOnlyProvenParts = <TPart, TMetadata>(
   PersistedChatMessageContentCandidate<TPart, TMetadata>
 > => content.data.every(isPersistablePart);
 
-export const provePersistedChatMessageContent = <TPart, TMetadata>(
+const provePersistedChatMessageContent = <TPart, TMetadata>(
   content: PersistedChatMessageContentCandidate<TPart, TMetadata>,
   isPersistablePart: (part: TPart) => boolean,
 ): ProvenPersistedChatMessageContent<


### PR DESCRIPTION
## Problem

TanStack MessagePart currently includes audio, video, and ui-resource. Stella treated every rejected part as an impossible invariant inside the stream finalizer, so one valid SDK part could turn a completed response into a generic run error and suppress assistant-message persistence.

## Structural fix

- Define an exhaustive persistence policy over every TanStack chat-part discriminator. A future SDK variant now fails typecheck until it is explicitly classified as persist or drop.
- Validate every persist-classified shape independently. Malformed persistable parts and unknown runtime discriminators still fail loudly; only the three explicitly unsupported variants are dropped.
- Filter unsupported parts on both normal completion and client-disconnect finalization, logging only the discriminator.
- Refuse to create or persist an empty assistant message when filtering removes every part.
- Require opaque, constructor-issued proof types for persistable messages and version-2 database envelopes. Alternate producers cannot write an unchecked ordinary message through the typed persistence boundary.
- Keep the proof objects as direct shapes so the TanStack tool union does not recursively expand through branded intersections.

## Verification

- Property test: for arbitrary mixtures of supported text and unsupported variants, conversion preserves exactly the supported subsequence in order.
- Regression coverage for audio, video, ui-resource, all-filtered output, malformed persistable parts, natural completion, client disconnect, and persistence-boundary construction.
- Focused chat/search suite: 62 passing tests on the last behavior-changing revision.
- Required CI is the source of truth for full lint, typecheck, type-cost, tests, E2E, CodeQL, and dependency review.