### PR TITLE
chore: combine lint and typecheck analysis

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -116,6 +116,7 @@ updates:
       oxc:
         patterns:
           - "oxlint"
+          - "oxlint-tsgolint"
           - "oxfmt"
       ai:
         patterns:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,7 +202,7 @@ jobs:
       needs.trust-check.outputs.trusted == 'true'
       || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
-    # 25m, matching lint/typecheck-baseline: this job's own "Test" step
+    # 25m, matching code-quality/typecheck-baseline: this job's own "Test" step
     # duration scales with however many packages `turbo --affected` marks
     # (any PR touching multiple large packages' test suites at once runs
     # them with --concurrency=2 on a standard runner, not in isolation).
@@ -576,7 +576,7 @@ jobs:
         if: github.event_name == 'pull_request'
         run: bash scripts/check-bridge-version.sh
 
-  lint:
+  code-quality:
     needs: [trust-check, ci-changes]
     if: >-
       needs.ci-changes.outputs.package_checks_required == 'true'
@@ -599,66 +599,6 @@ jobs:
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version-file: "package.json"
-
-      - name: Turbo remote cache
-        uses: rharkor/caching-for-turbo@2238fae6eb9a9936f92356f54cb3660200d105e7 # v2.5.1
-
-      - name: Install dependencies
-        run: bash scripts/bun-ci-retry.sh --ignore-scripts
-        env:
-          # .npmrc references NPM_TOKEN, but PR installs must not expose
-          # the real npm token to dependency lifecycle scripts.
-          NPM_TOKEN: ""
-
-      - name: Compute affected flag
-        id: affected
-        env:
-          BASE_REF: ${{ github.base_ref || 'main' }}
-          EVENT_NAME: ${{ github.event_name }}
-        run: |
-          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
-            echo "flag=" >> "$GITHUB_OUTPUT"
-          else
-            echo "flag=--affected" >> "$GITHUB_OUTPUT"
-            echo "TURBO_SCM_BASE=origin/$BASE_REF" >> "$GITHUB_ENV"
-          fi
-
-      - name: Lint
-        env:
-          AFFECTED_FLAG: ${{ steps.affected.outputs.flag }}
-        run: |
-          args=()
-          [[ -z "$AFFECTED_FLAG" ]] || args+=("$AFFECTED_FLAG")
-          # Type-aware API and web linting together can exhaust the hosted
-          # runner. Serialize packages so lint failures remain deterministic.
-          bun run lint -- "${args[@]}" --concurrency=1
-
-  typecheck:
-    needs: [trust-check, ci-changes]
-    if: >-
-      needs.ci-changes.outputs.package_checks_required == 'true'
-      && (needs.trust-check.outputs.trusted == 'true'
-          || github.event_name == 'workflow_dispatch')
-    runs-on: ubuntu-latest
-    timeout-minutes: 25
-    permissions:
-      contents: read
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-          submodules: true
-
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
-        with:
-          bun-version-file: "package.json"
-
-      - name: Turbo remote cache
-        uses: rharkor/caching-for-turbo@2238fae6eb9a9936f92356f54cb3660200d105e7 # v2.5.1
 
       - name: Install dependencies
         run: bash scripts/bun-ci-retry.sh --ignore-scripts
@@ -682,36 +622,18 @@ jobs:
           bun scripts/typecheck-coverage.ts --self-test
           bun scripts/typecheck-coverage.ts
 
-      - name: Compute affected flag
-        id: affected
+      - name: Code quality
+        run: bun run code-check
+
+      - name: Result consumption
         env:
           BASE_REF: ${{ github.base_ref || 'main' }}
           EVENT_NAME: ${{ github.event_name }}
         run: |
           if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
-            echo "flag=" >> "$GITHUB_OUTPUT"
-          else
-            echo "flag=--affected" >> "$GITHUB_OUTPUT"
-            echo "TURBO_SCM_BASE=origin/$BASE_REF" >> "$GITHUB_ENV"
-          fi
-
-      - name: Typecheck
-        env:
-          AFFECTED_FLAG: ${{ steps.affected.outputs.flag }}
-        run: |
-          args=()
-          [[ -z "$AFFECTED_FLAG" ]] || args+=("$AFFECTED_FLAG")
-          bun run typecheck -- "${args[@]}"
-          bun run typecheck:repo
-
-      - name: Result consumption
-        env:
-          AFFECTED_FLAG: ${{ steps.affected.outputs.flag }}
-        run: |
-          if [[ -z "$AFFECTED_FLAG" ]]; then
             bun run check:result-consumption -- --all
           else
-            bun run check:result-consumption -- --base "$TURBO_SCM_BASE"
+            bun run check:result-consumption -- --base "origin/$BASE_REF"
           fi
 
   # Typecheck-cost baseline guard. What silently rots is the compiler's
@@ -769,7 +691,7 @@ jobs:
           bun scripts/typecheck-baseline.ts --check
 
   # Vite web build. Same rationale as landing-build below: the
-  # required lint, typecheck, and test checks don't exercise the
+  # required code-quality and test checks don't exercise the
   # bundler, so worker bundling / wasm-loader / plugin issues
   # surface only at deploy time. Run `vite build` on every PR
   # that could plausibly affect the web output so this class of
@@ -952,8 +874,8 @@ jobs:
         if: steps.changed.outputs.run == 'true'
         run: bun --filter @stll/mobile build
 
-  # Astro landing build. The required checks run lint, typecheck,
-  # and test, but no `astro build`, so plugin/runtime
+  # Astro landing build. The required checks run code quality and tests,
+  # but no `astro build`, so plugin/runtime
   # incompatibilities surface only at deploy time. Catch those
   # here on every PR that could plausibly affect the landing
   # output.
@@ -1022,7 +944,7 @@ jobs:
   # (Postgres, MinIO, Valkey, Gotenberg) plus the API and web
   # dev server, then runs the E2E specs under
   # apps/web/e2e/. Catches integration regressions that
-  # lint/typecheck/unit tests miss (auth, routing, upload flow,
+  # code-quality/unit tests miss (auth, routing, upload flow,
   # document rendering). Finishes with the landing suite against a
   # built `astro preview`, which is the only place bundler-only
   # island regressions are visible.
@@ -1666,8 +1588,7 @@ jobs:
         trust-check,
         changeset,
         ci-checks,
-        lint,
-        typecheck,
+        code-quality,
         typecheck-baseline,
         web-build,
         mobile-build,
@@ -1693,13 +1614,12 @@ jobs:
           E2E_RESULT: ${{ needs.e2e.result }}
           EVENT: ${{ github.event_name }}
           LANDING_RESULT: ${{ needs.landing-build.result }}
-          LINT_RESULT: ${{ needs.lint.result }}
+          CODE_QUALITY_RESULT: ${{ needs.code-quality.result }}
           MOBILE_RESULT: ${{ needs.mobile-build.result }}
           OCR_IMAGE_RESULT: ${{ needs.ocr-image.result }}
           TRUSTED: ${{ needs.trust-check.outputs.trusted }}
           TRUST_RESULT: ${{ needs.trust-check.result }}
           TYPECHECK_BASELINE_RESULT: ${{ needs.typecheck-baseline.result }}
-          TYPECHECK_RESULT: ${{ needs.typecheck.result }}
           WEB_RESULT: ${{ needs.web-build.result }}
           WINDOWS_SCRIPTS_RESULT: ${{ needs.windows-scripts.result }}
         run: |
@@ -1713,8 +1633,7 @@ jobs:
 
           if [[ "$EVENT" == "workflow_dispatch" ]]; then
             if [[ "$CI_RESULT" == "failure" || "$CI_RESULT" == "cancelled" \
-                  || "$LINT_RESULT" == "failure" || "$LINT_RESULT" == "cancelled" \
-                  || "$TYPECHECK_RESULT" == "failure" || "$TYPECHECK_RESULT" == "cancelled" \
+                  || "$CODE_QUALITY_RESULT" == "failure" || "$CODE_QUALITY_RESULT" == "cancelled" \
                   || "$TYPECHECK_BASELINE_RESULT" == "failure" || "$TYPECHECK_BASELINE_RESULT" == "cancelled" \
                   || "$WEB_RESULT" == "failure" || "$WEB_RESULT" == "cancelled" \
                   || "$MOBILE_RESULT" == "failure" || "$MOBILE_RESULT" == "cancelled" \
@@ -1739,12 +1658,12 @@ jobs:
 
           # "cancelled" means cancel-in-progress replaced this
           # run with a newer one; the newer run is authoritative.
-          if [[ "$CI_RESULT" == "cancelled" || "$LINT_RESULT" == "cancelled" || "$TYPECHECK_RESULT" == "cancelled" || "$TYPECHECK_BASELINE_RESULT" == "cancelled" || "$WEB_RESULT" == "cancelled" || "$MOBILE_RESULT" == "cancelled" || "$LANDING_RESULT" == "cancelled" || "$E2E_RESULT" == "cancelled" || "$API_IMAGE_DEPS_RESULT" == "cancelled" || "$OCR_IMAGE_RESULT" == "cancelled" || "$WINDOWS_SCRIPTS_RESULT" == "cancelled" || "$CI_CHANGES_RESULT" == "cancelled" || "$CHANGESET_RESULT" == "cancelled" || "$DESKTOP_CLIPPY_RESULT" == "cancelled" ]]; then
+          if [[ "$CI_RESULT" == "cancelled" || "$CODE_QUALITY_RESULT" == "cancelled" || "$TYPECHECK_BASELINE_RESULT" == "cancelled" || "$WEB_RESULT" == "cancelled" || "$MOBILE_RESULT" == "cancelled" || "$LANDING_RESULT" == "cancelled" || "$E2E_RESULT" == "cancelled" || "$API_IMAGE_DEPS_RESULT" == "cancelled" || "$OCR_IMAGE_RESULT" == "cancelled" || "$WINDOWS_SCRIPTS_RESULT" == "cancelled" || "$CI_CHANGES_RESULT" == "cancelled" || "$CHANGESET_RESULT" == "cancelled" || "$DESKTOP_CLIPPY_RESULT" == "cancelled" ]]; then
             echo "CI run was superseded by a newer run (cancel-in-progress). Passing."
             exit 0
           fi
 
-          if [[ "$CI_RESULT" == "failure" || "$LINT_RESULT" == "failure" || "$TYPECHECK_RESULT" == "failure" || "$TYPECHECK_BASELINE_RESULT" == "failure" || "$WEB_RESULT" == "failure" || "$MOBILE_RESULT" == "failure" || "$LANDING_RESULT" == "failure" || "$E2E_RESULT" == "failure" || "$API_IMAGE_DEPS_RESULT" == "failure" || "$OCR_IMAGE_RESULT" == "failure" || "$WINDOWS_SCRIPTS_RESULT" == "failure" || "$CI_CHANGES_RESULT" == "failure" || "$CHANGESET_RESULT" == "failure" || "$DESKTOP_CLIPPY_RESULT" == "failure" ]]; then
+          if [[ "$CI_RESULT" == "failure" || "$CODE_QUALITY_RESULT" == "failure" || "$TYPECHECK_BASELINE_RESULT" == "failure" || "$WEB_RESULT" == "failure" || "$MOBILE_RESULT" == "failure" || "$LANDING_RESULT" == "failure" || "$E2E_RESULT" == "failure" || "$API_IMAGE_DEPS_RESULT" == "failure" || "$OCR_IMAGE_RESULT" == "failure" || "$WINDOWS_SCRIPTS_RESULT" == "failure" || "$CI_CHANGES_RESULT" == "failure" || "$CHANGESET_RESULT" == "failure" || "$DESKTOP_CLIPPY_RESULT" == "failure" ]]; then
             echo "::error::CI checks failed."
             exit 1
           fi

--- a/.github/workflows/nightly-typecheck.yml
+++ b/.github/workflows/nightly-typecheck.yml
@@ -32,6 +32,6 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Full typecheck (no --affected, no turbo cache)
-        run: bun run typecheck
+        run: bun run typecheck && bun run typecheck:repo
         env:
           TURBO_FORCE: "true"

--- a/apps/api/contracts/tsconfig.json
+++ b/apps/api/contracts/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../tsconfig.contracts.json"
+}

--- a/apps/api/scripts/export-mcp-tool-registry.ts
+++ b/apps/api/scripts/export-mcp-tool-registry.ts
@@ -33,9 +33,7 @@ for (const tool of DEFAULT_MCP_TOOL_DEFINITIONS) {
     name: tool.name,
     description: tool.description,
     inputSchema: tool.inputSchema,
-    ...(tool.annotations === undefined
-      ? {}
-      : { annotations: tool.annotations }),
+    annotations: tool.annotations,
   });
 }
 

--- a/apps/api/scripts/tsconfig.json
+++ b/apps/api/scripts/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../tsconfig.scripts.json"
+}

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -26,5 +26,5 @@
     "jsx": "react-jsx",
     "types": ["bun"]
   },
-  "include": ["src", "../../types"]
+  "include": ["src", "drizzle.config.ts", "../../types"]
 }

--- a/apps/desktop/tests/rpc.golden.test.ts
+++ b/apps/desktop/tests/rpc.golden.test.ts
@@ -12,7 +12,7 @@ import {
   type OpenDocxResponse,
   type SessionSnapshot,
   type TrustedSelfHostConnection,
-} from "./rpc";
+} from "../src/shared/rpc";
 
 // Golden-fixture contract for the desktop bridge RPC surface.
 //
@@ -38,7 +38,7 @@ import {
 // same files via serde, so a change on either side that is not mirrored
 // in the fixtures fails one of the two suites.
 
-const FIXTURE_DIR = path.join(import.meta.dir, "../../fixtures/rpc");
+const FIXTURE_DIR = path.join(import.meta.dir, "../fixtures/rpc");
 
 const readFixture = (name: string): unknown =>
   JSON.parse(readFileSync(path.join(FIXTURE_DIR, name), "utf-8"));

--- a/apps/desktop/tests/tsconfig.json
+++ b/apps/desktop/tests/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../tsconfig.test.json"
+}

--- a/apps/desktop/tsconfig.test.json
+++ b/apps/desktop/tsconfig.test.json
@@ -4,6 +4,6 @@
     "types": ["bun"],
     "tsBuildInfoFile": "./.cache/tsbuildinfo.test.json"
   },
-  "include": ["src/**/*.test.ts", "src/**/*.test.tsx"],
+  "include": ["tests/**/*.test.ts", "tests/**/*.test.tsx"],
   "exclude": ["dist", "node_modules", "src-tauri"]
 }

--- a/apps/web/scripts/tsconfig.json
+++ b/apps/web/scripts/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../../tsconfig.tooling.json"
+}

--- a/apps/web/src/types/start-runtime.d.ts
+++ b/apps/web/src/types/start-runtime.d.ts
@@ -1,0 +1,4 @@
+declare module "*dist/server/server.js" {
+  const handler: unknown;
+  export default handler;
+}

--- a/apps/web/start-runtime.js
+++ b/apps/web/start-runtime.js
@@ -1,3 +1,5 @@
+import { env, file, serve } from "bun";
+
 import handler from "./dist/server/server.js";
 
 const DEFAULT_PORT = 3002;
@@ -9,8 +11,8 @@ const CROSS_ORIGIN_ISOLATION_HEADERS = {
   "Cross-Origin-Embedder-Policy": "credentialless",
 };
 
-const port = Number.parseInt(Bun.env.PORT ?? String(DEFAULT_PORT), 10);
-const hostname = Bun.env.HOST ?? DEFAULT_HOST;
+const port = Number.parseInt(env["PORT"] ?? String(DEFAULT_PORT), 10);
+const hostname = env["HOST"] ?? DEFAULT_HOST;
 
 /** @typedef {{ fetch(request: Request): Response | Promise<Response> }} StartHandler */
 
@@ -103,14 +105,14 @@ const serveClientAsset = async (request) => {
     return null;
   }
 
-  const file = Bun.file(assetUrl);
-  if (!(await file.exists())) {
+  const assetFile = file(assetUrl);
+  if (!(await assetFile.exists())) {
     return null;
   }
 
   const headers = new Headers();
-  if (file.type) {
-    headers.set("content-type", file.type);
+  if (assetFile.type) {
+    headers.set("content-type", assetFile.type);
   }
   headers.set(
     "cache-control",
@@ -119,10 +121,12 @@ const serveClientAsset = async (request) => {
       : "public, max-age=300",
   );
 
-  return new Response(request.method === "HEAD" ? null : file, { headers });
+  return new Response(request.method === "HEAD" ? null : assetFile, {
+    headers,
+  });
 };
 
-Bun.serve({
+serve({
   hostname,
   port,
   async fetch(request) {

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -30,6 +30,12 @@
     }
   },
 
-  "include": ["src", "vite.config.ts", "vite.config.test.ts", "../../types"],
+  "include": [
+    "src",
+    "start-runtime.js",
+    "vite.config.ts",
+    "vite.config.test.ts",
+    "../../types"
+  ],
   "exclude": ["node_modules"]
 }

--- a/docs/policies/change-management.md
+++ b/docs/policies/change-management.md
@@ -52,16 +52,15 @@ The `ci.yml` workflow runs on every PR and produces a single
 `ci-result` status check that gates merging. The pipeline
 includes:
 
-| Check              | Tool                      | Purpose                                |
-| ------------------ | ------------------------- | -------------------------------------- |
-| Dependency install | `bun ci`                  | Verify lockfile integrity              |
-| i18n sync          | `bun run i18n:check`      | Ensure translation keys are consistent |
-| Lint               | oxlint (ultracite preset) | Code quality and security rules        |
-| Custom lint rules  | oxlint JS plugins         | Semantic tokens, RTL, ownership IDs    |
-| Format             | oxfmt                     | Consistent code formatting             |
-| Type check         | TypeScript native preview | Type safety                            |
-| Tests              | Bun test runner           | Functional correctness                 |
-| Policy evidence    | Repository guard          | Policy-to-implementation drift         |
+| Check              | Tool                 | Purpose                                |
+| ------------------ | -------------------- | -------------------------------------- |
+| Dependency install | `bun ci`             | Verify lockfile integrity              |
+| i18n sync          | `bun run i18n:check` | Ensure translation keys are consistent |
+| Code quality       | oxlint + tsgolint    | Lint rules and TypeScript diagnostics  |
+| Custom lint rules  | oxlint JS plugins    | Semantic tokens, RTL, ownership IDs    |
+| Format             | oxfmt                | Consistent code formatting             |
+| Tests              | Bun test runner      | Functional correctness                 |
+| Policy evidence    | Repository guard     | Policy-to-implementation drift         |
 
 All checks must pass. The `ci-result` aggregation job
 (`if: always()`) ensures the gate is never accidentally

--- a/docs/policies/evidence.json
+++ b/docs/policies/evidence.json
@@ -82,17 +82,16 @@
             "name: CI Checks",
             "name: Policy evidence",
             "name: Format",
-            "name: Typecheck",
+            "name: Code quality",
             "name: Test"
           ]
         },
         {
           "path": "scripts/verify.sh",
           "contains": [
-            "run_step \"Lint\"",
             "run_step \"Policy evidence\"",
             "run_step \"Format\"",
-            "run_step \"Typecheck\"",
+            "run_step \"Code quality\"",
             "run_step \"Test\""
           ]
         }

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -31,19 +31,10 @@ pre-commit:
 pre-push:
   parallel: false
   commands:
-    typecheck:
-      # Root scripts and tooling configs are outside Turbo's package graph;
-      # check them explicitly so pre-push matches the CI typecheck boundary.
-      # Scoped to packages changed vs. origin/main plus their dependents
-      # (turbo `...[ref]` filter). tsgo itself still runs project-wide
-      # within each selected package, but unaffected packages are skipped
-      # entirely instead of being walked for cache decisions.
-      run: bun run typecheck:repo && bun run typecheck "--filter=...[origin/main]" --concurrency=2
-    # Lint runs in CI on every push (~10-15 min full-monorepo). Keeping
-    # it on pre-push too added another ~15-18 min of waiting that
-    # duplicated the CI signal, so the local hook drops it. The
-    # pre-commit hook still lints staged files inline for fast feedback
-    # on the most common class of mistakes.
+    code-check:
+      # One Oxc type-aware pass covers every workspace, while the root native
+      # projects remain checked explicitly by the combined command.
+      run: bun run code-check
     format:
       run: bun run format --concurrency=2 -- --check
     i18n:

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "typegen": "turbo run typegen",
     "typecheck": "turbo run typecheck",
     "typecheck:repo": "bun packages/scripts/src/tsc-native.ts --noEmit -p tsconfig.scripts.json && bun packages/scripts/src/tsc-native.ts --noEmit -p tsconfig.tooling.json && bun packages/scripts/src/tsc-native.ts --noEmit -p tsconfig.oxlint-plugins.json",
+    "code-check": "bash scripts/lint-oxlint-fixtures.sh && bun --cwd apps/landing typecheck && bun apps/landing/scripts/check-logical-properties.ts && bun --bun oxlint -c oxlint.config.ts --report-unused-disable-directives-severity=error --deny-warnings --type-aware --type-check --ignore-pattern apps/web/start-runtime.js apps packages && bun --bun oxlint -c oxlint.config.ts --deny-warnings apps/web/start-runtime.js && bun run typecheck:repo",
     "secrets:check:staged": "bash scripts/check-staged-secrets.sh",
     "security:audit": "bun scripts/dependency-audit.ts --check",
     "security:audit:report": "bun scripts/dependency-audit.ts",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "typegen": "turbo run typegen",
     "typecheck": "turbo run typecheck",
     "typecheck:repo": "bun packages/scripts/src/tsc-native.ts --noEmit -p tsconfig.scripts.json && bun packages/scripts/src/tsc-native.ts --noEmit -p tsconfig.tooling.json && bun packages/scripts/src/tsc-native.ts --noEmit -p tsconfig.oxlint-plugins.json",
-    "code-check": "bash scripts/lint-oxlint-fixtures.sh && bun --cwd apps/landing typecheck && bun apps/landing/scripts/check-logical-properties.ts && bun --bun oxlint -c oxlint.config.ts --report-unused-disable-directives-severity=error --deny-warnings --type-aware --type-check --ignore-pattern apps/web/start-runtime.js apps packages && bun --bun oxlint -c oxlint.config.ts --deny-warnings apps/web/start-runtime.js && bun run typecheck:repo",
+    "code-check": "bash scripts/lint-oxlint-fixtures.sh && bun --cwd apps/landing typecheck && bun apps/landing/scripts/check-logical-properties.ts && bun --bun oxlint -c oxlint.config.ts --report-unused-disable-directives-severity=error --deny-warnings --type-aware --type-check apps packages && bun run typecheck:repo",
     "secrets:check:staged": "bash scripts/check-staged-secrets.sh",
     "security:audit": "bun scripts/dependency-audit.ts --check",
     "security:audit:report": "bun scripts/dependency-audit.ts",

--- a/packages/catalogue/scripts/tsconfig.json
+++ b/packages/catalogue/scripts/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../../tsconfig.tooling.json"
+}

--- a/packages/skills/scripts/tsconfig.json
+++ b/packages/skills/scripts/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../../tsconfig.tooling.json"
+}

--- a/scripts/typecheck-coverage.ts
+++ b/scripts/typecheck-coverage.ts
@@ -287,14 +287,13 @@ const assertProxyTargets = (proxies: readonly OxcProjectProxy[]): void => {
 const hasDiscoverableAncestorConfig = (
   file: string,
   discoverableConfigFiles: Map<string, Set<string>>,
+  configExists: (config: string) => boolean,
 ): boolean => {
   let directory = path.posix.dirname(file);
   while (directory !== ".") {
-    const configFiles = discoverableConfigFiles.get(
-      `${directory}/${CONVENTIONAL_TSCONFIG}`,
-    );
-    if (configFiles) {
-      return configFiles.has(file);
+    const config = `${directory}/${CONVENTIONAL_TSCONFIG}`;
+    if (configExists(config)) {
+      return discoverableConfigFiles.get(config)?.has(file) ?? false;
     }
     directory = path.posix.dirname(directory);
   }
@@ -305,6 +304,7 @@ const findSourcesWithoutDiscoverableConfig = (
   repositoryFiles: Set<string>,
   covered: Set<string>,
   discoverableConfigFiles: Map<string, Set<string>>,
+  configExists: (config: string) => boolean,
 ): string[] =>
   [...repositoryFiles]
     .filter((file) =>
@@ -312,7 +312,12 @@ const findSourcesWithoutDiscoverableConfig = (
     )
     .filter((file) => covered.has(file))
     .filter(
-      (file) => !hasDiscoverableAncestorConfig(file, discoverableConfigFiles),
+      (file) =>
+        !hasDiscoverableAncestorConfig(
+          file,
+          discoverableConfigFiles,
+          configExists,
+        ),
     )
     .sort();
 
@@ -540,6 +545,7 @@ const selfTest = (): void => {
       "packages/missing/src/uncovered.ts",
     ]),
     discoverableConfigs,
+    (config) => discoverableConfigs.has(config),
   );
   assert(
     sourcesWithoutConfig.join(",") ===
@@ -556,10 +562,30 @@ const selfTest = (): void => {
         new Set(["apps/desktop/tests/rpc.golden.test.ts"]),
       ],
     ]),
+    (config) => config === "apps/desktop/tests/tsconfig.json",
   );
   assert(
     testProxySources.length === 0,
     "must accept a dedicated Oxc proxy for a co-located test project",
+  );
+
+  const sourceMaskedByUnregisteredConfig = findSourcesWithoutDiscoverableConfig(
+    new Set(["apps/example/scripts/unregistered.ts"]),
+    new Set(["apps/example/scripts/unregistered.ts"]),
+    new Map([
+      [
+        "apps/example/tsconfig.json",
+        new Set(["apps/example/scripts/unregistered.ts"]),
+      ],
+    ]),
+    (config) =>
+      config === "apps/example/scripts/tsconfig.json" ||
+      config === "apps/example/tsconfig.json",
+  );
+  assert(
+    sourceMaskedByUnregisteredConfig.join(",") ===
+      "apps/example/scripts/unregistered.ts",
+    "must reject a nearer physical tsconfig that is absent from CI project discovery",
   );
 
   const oxcFilesWithoutProject = findOxcFilesWithoutProject(
@@ -609,6 +635,7 @@ const main = (): void => {
     oxcFiles,
     covered,
     discoverableConfigs,
+    (config) => existsSync(path.join(REPO_ROOT, config)),
   );
   const oxcFilesWithoutProject = findOxcFilesWithoutProject(oxcFiles, covered);
   if (oxcFilesWithoutProject.length > 0) {

--- a/scripts/typecheck-coverage.ts
+++ b/scripts/typecheck-coverage.ts
@@ -25,10 +25,8 @@ const WORKSPACE_PARENTS = ["apps", "packages"] as const;
 const EXEMPT_PREFIXES = [".oxlint-plugins/__fixtures__/"] as const;
 const CONVENTIONAL_TSCONFIG = "tsconfig.json";
 const ROOT_TSCONFIG = "tsconfig.json";
-// start-runtime imports a generated dist file that does not exist before the web
-// build. apps/web/public contains intentionally untyped static browser assets;
-// both are outside the combined Oxc target.
-const OXC_DISCOVERY_EXEMPT_FILES = new Set(["apps/web/start-runtime.js"]);
+// apps/web/public contains intentionally untyped static browser assets outside
+// the combined Oxc target.
 const OXC_DISCOVERY_EXEMPT_PREFIXES = ["apps/web/public/"] as const;
 const PROJECT_ARGUMENT =
   /(?:^|\s)(?:-p|--project)(?:\s+|=)(["']?)([^\s"';&]+)\1/gu;
@@ -101,7 +99,6 @@ const isOxcSourceFile = (file: string): boolean =>
   /\.(?:tsx?|jsx?)$/u.test(file);
 
 const isOxcDiscoveryExempt = (file: string): boolean =>
-  OXC_DISCOVERY_EXEMPT_FILES.has(file) ||
   OXC_DISCOVERY_EXEMPT_PREFIXES.some((prefix) => file.startsWith(prefix));
 
 const isConventionalProject = (project: string): boolean =>
@@ -593,7 +590,6 @@ const selfTest = (): void => {
       "apps/web/covered.js",
       "apps/web/missing.jsx",
       "apps/web/public/dark-mode-init.js",
-      "apps/web/start-runtime.js",
     ]),
     new Set(["apps/web/covered.js"]),
   );

--- a/scripts/typecheck-coverage.ts
+++ b/scripts/typecheck-coverage.ts
@@ -23,8 +23,56 @@ const REPO_ROOT = path.resolve(import.meta.dir, "..");
 const TSC_NATIVE = "packages/scripts/src/tsc-native.ts";
 const WORKSPACE_PARENTS = ["apps", "packages"] as const;
 const EXEMPT_PREFIXES = [".oxlint-plugins/__fixtures__/"] as const;
+const CONVENTIONAL_TSCONFIG = "tsconfig.json";
+const ROOT_TSCONFIG = "tsconfig.json";
+// start-runtime imports a generated dist file that does not exist before the web
+// build. apps/web/public contains intentionally untyped static browser assets;
+// both are outside the combined Oxc target.
+const OXC_DISCOVERY_EXEMPT_FILES = new Set(["apps/web/start-runtime.js"]);
+const OXC_DISCOVERY_EXEMPT_PREFIXES = ["apps/web/public/"] as const;
 const PROJECT_ARGUMENT =
   /(?:^|\s)(?:-p|--project)(?:\s+|=)(["']?)([^\s"';&]+)\1/gu;
+
+type OxcProjectProxy = {
+  config: string;
+  target: string;
+};
+
+// Oxc discovers only tsconfig.json files while walking up from a source file.
+// Keep every proxy beside the source subtree that its nonstandard native project
+// covers. Root-only projects have no source subtree suitable for a proxy.
+const OXC_PROJECT_PROXIES = [
+  {
+    config: "apps/api/contracts/tsconfig.json",
+    target: "apps/api/tsconfig.contracts.json",
+  },
+  {
+    config: "apps/api/scripts/tsconfig.json",
+    target: "apps/api/tsconfig.scripts.json",
+  },
+  {
+    config: "apps/desktop/tests/tsconfig.json",
+    target: "apps/desktop/tsconfig.test.json",
+  },
+  {
+    config: "apps/web/scripts/tsconfig.json",
+    target: "tsconfig.tooling.json",
+  },
+  {
+    config: "packages/catalogue/scripts/tsconfig.json",
+    target: "tsconfig.tooling.json",
+  },
+  {
+    config: "packages/skills/scripts/tsconfig.json",
+    target: "tsconfig.tooling.json",
+  },
+] as const satisfies readonly OxcProjectProxy[];
+
+const OXC_NATIVE_ONLY_PROJECTS = [
+  "tsconfig.scripts.json",
+  "tsconfig.tooling.json",
+  "tsconfig.oxlint-plugins.json",
+] as const;
 
 type Options = {
   selfTest: boolean;
@@ -48,6 +96,16 @@ const normalizeRepoPath = (file: string): string =>
   file.split(path.sep).join("/");
 
 const isTypeScriptFile = (file: string): boolean => /\.tsx?$/u.test(file);
+
+const isOxcSourceFile = (file: string): boolean =>
+  /\.(?:tsx?|jsx?)$/u.test(file);
+
+const isOxcDiscoveryExempt = (file: string): boolean =>
+  OXC_DISCOVERY_EXEMPT_FILES.has(file) ||
+  OXC_DISCOVERY_EXEMPT_PREFIXES.some((prefix) => file.startsWith(prefix));
+
+const isConventionalProject = (project: string): boolean =>
+  path.posix.basename(project) === CONVENTIONAL_TSCONFIG;
 
 const isExempt = (file: string): boolean =>
   EXEMPT_PREFIXES.some((prefix) => file.startsWith(prefix));
@@ -135,10 +193,176 @@ const typecheckProjects = (): string[] => {
   return [...projects].sort();
 };
 
-const coveredFiles = (projects: string[]): Set<string> => {
-  const covered = new Set<string>();
+const projectAccountingErrors = (
+  projects: string[],
+  proxies: readonly OxcProjectProxy[],
+  nativeOnlyProjects: readonly string[],
+): string[] => {
+  const nonstandardProjects = new Set(
+    projects.filter((project) => !isConventionalProject(project)),
+  );
+  const accountedProjects = new Set(nativeOnlyProjects);
+  const errors: string[] = [];
+
+  for (const { config, target } of proxies) {
+    if (!isConventionalProject(config)) {
+      errors.push(`Oxc proxy ${config} is not named ${CONVENTIONAL_TSCONFIG}`);
+    }
+    accountedProjects.add(target);
+    if (!nonstandardProjects.has(target)) {
+      errors.push(
+        `Oxc proxy ${config} targets ${target}, which is not a nonstandard CI typecheck project`,
+      );
+    }
+  }
+
+  for (const project of nativeOnlyProjects) {
+    if (!nonstandardProjects.has(project)) {
+      errors.push(
+        `Oxc native-only project ${project} is not a nonstandard CI typecheck project`,
+      );
+    }
+  }
+
+  for (const project of nonstandardProjects) {
+    if (!accountedProjects.has(project)) {
+      errors.push(
+        `nonstandard CI typecheck project ${project} has no Oxc proxy or native-only entry`,
+      );
+    }
+  }
+
+  return errors;
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  value !== null && typeof value === "object" && !Array.isArray(value);
+
+const readJsonObject = (file: string): Record<string, unknown> => {
+  const parsed = Bun.JSONC.parse(readFileSync(file, "utf-8"));
+  if (!isRecord(parsed)) {
+    panic(
+      `${normalizeRepoPath(path.relative(REPO_ROOT, file))} must contain an object`,
+    );
+  }
+  return parsed;
+};
+
+const assertRootConfigIsEmpty = (): void => {
+  const rootConfig = readJsonObject(path.join(REPO_ROOT, ROOT_TSCONFIG));
+  const files = rootConfig["files"];
+  assert(
+    Array.isArray(files) && files.length === 0,
+    `${ROOT_TSCONFIG} must set "files": [] so Oxc does not typecheck arbitrary root sources`,
+  );
+};
+
+const assertProxyTargets = (proxies: readonly OxcProjectProxy[]): void => {
+  for (const { config, target } of proxies) {
+    const proxyPath = path.join(REPO_ROOT, config);
+    assert(existsSync(proxyPath), `Oxc proxy config is missing: ${config}`);
+
+    const extendsPath = readJsonObject(proxyPath)["extends"];
+    assert(
+      typeof extendsPath === "string",
+      `Oxc proxy ${config} must directly extend ${target}`,
+    );
+    if (typeof extendsPath !== "string") {
+      continue;
+    }
+
+    const resolvedTarget = normalizeRepoPath(
+      path.relative(
+        REPO_ROOT,
+        path.resolve(path.dirname(proxyPath), extendsPath),
+      ),
+    );
+    assert(
+      resolvedTarget === target,
+      `Oxc proxy ${config} must extend ${target}, found ${extendsPath}`,
+    );
+  }
+};
+
+const hasDiscoverableAncestorConfig = (
+  file: string,
+  discoverableConfigFiles: Map<string, Set<string>>,
+): boolean => {
+  let directory = path.posix.dirname(file);
+  while (directory !== ".") {
+    const configFiles = discoverableConfigFiles.get(
+      `${directory}/${CONVENTIONAL_TSCONFIG}`,
+    );
+    if (configFiles) {
+      return configFiles.has(file);
+    }
+    directory = path.posix.dirname(directory);
+  }
+  return false;
+};
+
+const findSourcesWithoutDiscoverableConfig = (
+  repositoryFiles: Set<string>,
+  covered: Set<string>,
+  discoverableConfigFiles: Map<string, Set<string>>,
+): string[] =>
+  [...repositoryFiles]
+    .filter((file) =>
+      WORKSPACE_PARENTS.some((parent) => file.startsWith(`${parent}/`)),
+    )
+    .filter((file) => covered.has(file))
+    .filter(
+      (file) => !hasDiscoverableAncestorConfig(file, discoverableConfigFiles),
+    )
+    .sort();
+
+const assertOxcProjectDiscovery = (projects: string[]): void => {
+  const errors = projectAccountingErrors(
+    projects,
+    OXC_PROJECT_PROXIES,
+    OXC_NATIVE_ONLY_PROJECTS,
+  );
+  assert(
+    errors.length === 0,
+    `Oxc project-discovery parity failed:\n${errors.join("\n")}`,
+  );
+  assertRootConfigIsEmpty();
+  assertProxyTargets(OXC_PROJECT_PROXIES);
+};
+
+const discoverableConfigFiles = (
+  projects: string[],
+  filesByProject: Map<string, Set<string>>,
+): Map<string, Set<string>> => {
+  const configFiles = new Map<string, Set<string>>();
+
+  const addConfig = (config: string, project: string): void => {
+    const projectFiles = filesByProject.get(project);
+    if (!projectFiles) {
+      panic(`Missing file list for CI typecheck project ${project}`);
+    }
+    configFiles.set(config, projectFiles);
+  };
 
   for (const project of projects) {
+    if (isConventionalProject(project)) {
+      addConfig(project, project);
+    }
+  }
+  for (const { config, target } of OXC_PROJECT_PROXIES) {
+    addConfig(config, target);
+  }
+
+  return configFiles;
+};
+
+const coveredFilesByProject = (
+  projects: string[],
+): Map<string, Set<string>> => {
+  const filesByProject = new Map<string, Set<string>>();
+
+  for (const project of projects) {
+    const projectFiles = new Set<string>();
     const output = run([
       process.execPath,
       TSC_NATIVE,
@@ -151,7 +375,22 @@ const coveredFiles = (projects: string[]): Set<string> => {
       if (relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative)) {
         continue;
       }
-      covered.add(normalizeRepoPath(relative));
+      projectFiles.add(normalizeRepoPath(relative));
+    }
+    filesByProject.set(project, projectFiles);
+  }
+
+  return filesByProject;
+};
+
+const coveredFiles = (
+  filesByProject: Map<string, Set<string>>,
+): Set<string> => {
+  const covered = new Set<string>();
+
+  for (const projectFiles of filesByProject.values()) {
+    for (const file of projectFiles) {
+      covered.add(file);
     }
   }
 
@@ -171,7 +410,29 @@ const repositoryTypeScriptFiles = (): Set<string> =>
         "*.ts",
         "*.tsx",
       ]),
-    ).filter(isTypeScriptFile),
+    )
+      .filter((file) => existsSync(path.join(REPO_ROOT, file)))
+      .filter(isTypeScriptFile),
+  );
+
+const repositoryOxcFiles = (): Set<string> =>
+  new Set(
+    lines(
+      run([
+        "git",
+        "ls-files",
+        "--cached",
+        "--others",
+        "--exclude-standard",
+        "--",
+        "*.ts",
+        "*.tsx",
+        "*.js",
+        "*.jsx",
+      ]),
+    )
+      .filter((file) => existsSync(path.join(REPO_ROOT, file)))
+      .filter(isOxcSourceFile),
   );
 
 const findUncovered = (
@@ -180,6 +441,18 @@ const findUncovered = (
 ): string[] =>
   [...repositoryFiles]
     .filter((file) => !isExempt(file))
+    .filter((file) => !covered.has(file))
+    .sort();
+
+const findOxcFilesWithoutProject = (
+  repositoryFiles: Set<string>,
+  covered: Set<string>,
+): string[] =>
+  [...repositoryFiles]
+    .filter((file) =>
+      WORKSPACE_PARENTS.some((parent) => file.startsWith(`${parent}/`)),
+    )
+    .filter((file) => !isOxcDiscoveryExempt(file))
     .filter((file) => !covered.has(file))
     .sort();
 
@@ -194,6 +467,14 @@ const selfTest = (): void => {
   assert(isTypeScriptFile("src/env.d.ts"), "must recognize declaration files");
   assert(isTypeScriptFile("src/view.tsx"), "must recognize .tsx files");
   assert(!isTypeScriptFile("src/view.js"), "must ignore non-TypeScript files");
+  assert(
+    isOxcSourceFile("apps/web/file.js"),
+    "must recognize .js files for Oxc",
+  );
+  assert(
+    isOxcSourceFile("apps/web/view.jsx"),
+    "must recognize .jsx files for Oxc",
+  );
 
   const parsed = supplementalProjects(
     "tsc --noEmit -p tsconfig.test.json && tsc --project=e2e/tsconfig.json",
@@ -201,6 +482,98 @@ const selfTest = (): void => {
   assert(
     parsed.join(",") === "tsconfig.test.json,e2e/tsconfig.json",
     "must discover supplemental typecheck projects",
+  );
+
+  const unaccountedProjectErrors = projectAccountingErrors(
+    ["apps/example/tsconfig.json", "apps/example/tsconfig.extra.json"],
+    [],
+    [],
+  );
+  assert(
+    unaccountedProjectErrors.some((error) =>
+      error.includes("tsconfig.extra.json"),
+    ),
+    "must reject a nonstandard CI project without an Oxc proxy or native-only entry",
+  );
+
+  const staleProxyErrors = projectAccountingErrors(
+    ["apps/example/tsconfig.json"],
+    [
+      {
+        config: "apps/example/scripts/tsconfig.json",
+        target: "apps/example/tsconfig.extra.json",
+      },
+    ],
+    [],
+  );
+  assert(
+    staleProxyErrors.some((error) => error.includes("not a nonstandard CI")),
+    "must reject an Oxc proxy whose target is no longer a CI project",
+  );
+
+  const discoverableConfigs = new Map([
+    [
+      "apps/example/tsconfig.json",
+      new Set([
+        "apps/example/src/covered.ts",
+        "apps/example/scripts/mismatched.ts",
+      ]),
+    ],
+    [
+      "apps/example/scripts/tsconfig.json",
+      new Set(["apps/example/scripts/tool.ts"]),
+    ],
+  ]);
+  const sourcesWithoutConfig = findSourcesWithoutDiscoverableConfig(
+    new Set([
+      "apps/example/src/covered.ts",
+      "apps/example/scripts/tool.ts",
+      "apps/example/scripts/mismatched.ts",
+      "apps/example/excluded.ts",
+      "packages/missing/src/uncovered.ts",
+    ]),
+    new Set([
+      "apps/example/src/covered.ts",
+      "apps/example/scripts/tool.ts",
+      "apps/example/scripts/mismatched.ts",
+      "apps/example/excluded.ts",
+      "packages/missing/src/uncovered.ts",
+    ]),
+    discoverableConfigs,
+  );
+  assert(
+    sourcesWithoutConfig.join(",") ===
+      "apps/example/excluded.ts,apps/example/scripts/mismatched.ts,packages/missing/src/uncovered.ts",
+    "must use Oxc's nearest config instead of accepting a higher config that covers the source",
+  );
+
+  const testProxySources = findSourcesWithoutDiscoverableConfig(
+    new Set(["apps/desktop/tests/rpc.golden.test.ts"]),
+    new Set(["apps/desktop/tests/rpc.golden.test.ts"]),
+    new Map([
+      [
+        "apps/desktop/tests/tsconfig.json",
+        new Set(["apps/desktop/tests/rpc.golden.test.ts"]),
+      ],
+    ]),
+  );
+  assert(
+    testProxySources.length === 0,
+    "must accept a dedicated Oxc proxy for a co-located test project",
+  );
+
+  const oxcFilesWithoutProject = findOxcFilesWithoutProject(
+    new Set([
+      "apps/web/covered.js",
+      "apps/web/missing.jsx",
+      "apps/web/public/dark-mode-init.js",
+      "apps/web/start-runtime.js",
+    ]),
+    new Set(["apps/web/covered.js"]),
+  );
+  assert(
+    oxcFilesWithoutProject.join(",") === "apps/web/missing.jsx",
+    "must reject uncovered JS/JSX while exempting only intentional Oxc exclusions",
   );
 
   const repository = new Set([
@@ -226,8 +599,42 @@ const main = (): void => {
   }
 
   const projects = typecheckProjects();
+  assertOxcProjectDiscovery(projects);
   const repositoryFiles = repositoryTypeScriptFiles();
-  const covered = coveredFiles(projects);
+  const oxcFiles = repositoryOxcFiles();
+  const filesByProject = coveredFilesByProject(projects);
+  const covered = coveredFiles(filesByProject);
+  const discoverableConfigs = discoverableConfigFiles(projects, filesByProject);
+  const sourcesWithoutConfig = findSourcesWithoutDiscoverableConfig(
+    oxcFiles,
+    covered,
+    discoverableConfigs,
+  );
+  const oxcFilesWithoutProject = findOxcFilesWithoutProject(oxcFiles, covered);
+  if (oxcFilesWithoutProject.length > 0) {
+    console.error(
+      "typecheck-coverage: Oxc workspace JS/JSX/TS/TSX files belong to no CI typecheck project:\n",
+    );
+    for (const file of oxcFilesWithoutProject) {
+      console.error(`  - ${file}`);
+    }
+    console.error(
+      "\nAdd each file to a CI typecheck project, or add a narrowly documented Oxc discovery exception.",
+    );
+    process.exit(1);
+  }
+  if (sourcesWithoutConfig.length > 0) {
+    console.error(
+      "typecheck-coverage: Covered workspace JS/JSX/TS/TSX files have no discoverable Oxc config:\n",
+    );
+    for (const file of sourcesWithoutConfig) {
+      console.error(`  - ${file}`);
+    }
+    console.error(
+      "\nAdd a conventional tsconfig.json ancestor that belongs to CI, or an explicit proxy for its nonstandard CI project.",
+    );
+    process.exit(1);
+  }
   const uncovered = findUncovered(repositoryFiles, covered);
 
   if (uncovered.length > 0) {

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -71,14 +71,6 @@ run_step() {
   fi
 }
 
-run_lint() {
-  if [[ -n "$affected_flag" ]]; then
-    bun run lint -- "$affected_flag"
-  else
-    bun run lint
-  fi
-}
-
 run_format() {
   # Call turbo directly: the package `format` scripts take `--check`
   # after `--`, so the affected flag must land before it.
@@ -97,21 +89,11 @@ run_rust_format() {
   cargo fmt --manifest-path apps/desktop/src-tauri/Cargo.toml -- --check
 }
 
-run_typecheck() {
-  # tsc processes are memory-hungry; serialize typecheck tasks so
-  # parallel instances cannot exhaust memory on contributor machines.
-  # CI runs lint and typecheck as separate jobs; results match.
-  # The typecheck-cost baseline guard (scripts/typecheck-baseline.ts) is
-  # deliberately NOT run here: like the bundle baseline, it re-runs full
-  # per-project typechecks and is too slow for the local loop. It runs in
-  # its own CI job (typecheck-baseline); its failures point at type-cost growth, not
-  # type errors, so a green verify still matches a green typecheck.
-  if [[ -n "$affected_flag" ]]; then
-    bun run typecheck -- --concurrency=1 "$affected_flag" || return 1
-  else
-    bun run typecheck -- --concurrency=1 || return 1
-  fi
-  bun run typecheck:repo
+run_code_check() {
+  # Oxc performs the repository-wide type-aware lint and type diagnostics in
+  # one pass. The typecheck-cost baseline guard remains CI-only because it
+  # intentionally re-runs every native project to measure compiler workload.
+  bun run code-check
 }
 
 run_typecheck_coverage() {
@@ -205,11 +187,10 @@ run_step "Marketing content evidence" bun run marketing:check
 run_step "Railway template shape" bun run check:railway-template
 run_step "i18n" bun run i18n:check
 run_step "Release changelog guard" bash scripts/check-release-changelog.sh --base "$base_ref"
-run_step "Lint" run_lint
 run_step "Format" run_format
 run_step "Rust format" run_rust_format
 run_step "Typecheck coverage" run_typecheck_coverage
-run_step "Typecheck" run_typecheck
+run_step "Code quality" run_code_check
 if [[ -n "$affected_flag" ]]; then
   run_step "Result consumption" bun run check:result-consumption -- --base "$base_ref"
 else

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,3 +1,4 @@
 {
-  "extends": "@stll/typescript-config/base.json"
+  "extends": "@stll/typescript-config/base.json",
+  "files": []
 }

--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://turborepo.com/schema.json",
-  "globalDependencies": ["oxlint.config.ts", ".oxfmtrc.json"],
   // Turbo runs tasks in strict env mode, which strips undeclared variables from
   // the task environment. propertyConfig reads these at run time: the nightly
   // factor that scales property numRuns, and CI to enable fast-check verbose
@@ -33,14 +32,25 @@
       "outputs": []
     },
     "lint": {
-      "dependsOn": ["transit"]
+      "dependsOn": ["transit"],
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "$TURBO_ROOT$/oxlint.config.ts",
+        "$TURBO_ROOT$/.oxlint-plugins/**"
+      ]
     },
     "lint:fix": {
       "dependsOn": ["transit"],
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "$TURBO_ROOT$/oxlint.config.ts",
+        "$TURBO_ROOT$/.oxlint-plugins/**"
+      ],
       "cache": false
     },
     "format": {
-      "dependsOn": ["transit"]
+      "dependsOn": ["transit"],
+      "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/.oxfmtrc.json"]
     },
     "i18n:check": {
       "dependsOn": ["transit"],


### PR DESCRIPTION
## Proposed change

Run Oxlint type-aware linting and TypeScript diagnostics through one shared tsgolint semantic program. Consolidate the CI lint and typecheck jobs into one code-quality job, while preserving Astro checks, fixture checks, native root-project checks, the Turbo-backed lint interface, and nightly native project typechecking.

Add a coverage guard for all 45 TypeScript project boundaries. Conventional proxy tsconfig files make nonstandard projects discoverable; the desktop RPC golden test now lives in a dedicated test project. The guard stops at any physical nearer tsconfig and fails when that config is not registered, preventing Oxlint from silently using unintended compiler options.

Local warm-worktree measurements on the same checkout:

| Check | Wall time |
| --- | ---: |
| Separate lint | 75.365 s |
| Separate typecheck | 97.267 s |
| Separate total | 172.632 s |
| Combined code-check | 60.880 s |

The combined local path is 64.7% faster than the separate total (2.84x throughput), and 37.4% faster than the previous typecheck path alone. A subsequent pre-push run completed code-check in 58.10 s.

First GitHub Actions comparison:

| CI job | Wall time |
| --- | ---: |
| Previous lint | 1m55s |
| Previous typecheck | 3m12s |
| Combined code-quality | 2m55s |

The combined job is 8.9% faster on the CI critical path and reduces lint-plus-typecheck runner time from 5m07s to 2m55s, about 43%.

No type-aware rules move to nightly: profiling did not show a useful wall-time improvement from disabling the most expensive individual rules. Formatting remains a separate oxfmt check.

## Validation

- `bun run verify`: all stages passed; the final bridge-version guard was rerun after removing a comment-only Rust diff and passed
- `bun run code-check`: passed after review feedback
- Typecheck coverage: 3,777 source files across 45 projects
- Coverage guard self-test: includes unregistered nearer-config masking
- Desktop RPC golden tests: 31 passed
- Security audit: no findings

## Checklist

- [x] **BUILD ASSURANCE** | Code builds correctly and without any errors or warnings.
- [x] **TESTING** | Changes tested.
- [x] **DARK MODE SUPPORT: NOT APPLICABLE** | No user-facing UI changes.
- [x] **ISSUE LINKED: NOT APPLICABLE** | No tracking issue.
- [x] **SCREENSHOT INCLUDED: NOT APPLICABLE** | Tooling-only change.