### PR TITLE
chore: speed up browser checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1142,12 +1142,14 @@ jobs:
 
       - name: Run Vite dependency canary
         if: matrix.shard == 1 && steps.changed.outputs.core == 'true'
+        env:
+          E2E_EXPECT_DEV_ROUTES: "true"
         run: >-
           bun --filter @stll/web test:e2e --
           --project chromium --grep @dev-canary
 
-      # Flake guard: the tiny dev pass covers the lazy chat and Folio imports
-      # that have historically escaped Vite's cold dependency scan.
+      # Flake guard: the tiny dev pass covers the lazy chat, Folio, and
+      # dev-autocomplete imports that can escape Vite's cold dependency scan.
       - name: Guard against mid-test Vite re-optimize
         if: >-
           always()
@@ -1202,6 +1204,7 @@ jobs:
       - name: Run Playwright shard
         if: steps.changed.outputs.core == 'true'
         env:
+          E2E_EXPECT_DEV_ROUTES: "false"
           PLAYWRIGHT_BLOB_OUTPUT_NAME: report-${{ matrix.shard }}.zip
         run: >-
           bun --filter @stll/web test:e2e --

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1054,14 +1054,16 @@ jobs:
         # `--wait` only on long-running services; `minio-setup` is a one-shot
         # bucket-creator container that exits 0, which `--wait` treats as
         # "not running" and fails the whole command. Run it separately in
-        # the foreground so we still block on its success. The whole bring-up
-        # is retried: image pulls and `--wait` health checks occasionally fail
-        # transiently on CI runners. Tear the stack down between attempts so a
-        # half-started stack does not poison the retry.
+        # the foreground so we still block on its success. `compose run`
+        # propagates the one-shot command's exit code without stopping the
+        # already-running MinIO dependency. The whole bring-up is retried:
+        # image pulls and `--wait` health checks occasionally fail transiently
+        # on CI runners. Tear the stack down between attempts so a half-started
+        # stack does not poison the retry.
         run: |
           for attempt in 1 2 3; do
             if docker compose --profile dev up -d --wait postgres minio valkey gotenberg \
-              && docker compose --profile dev up minio-setup; then
+              && docker compose --profile dev run --rm --no-deps minio-setup; then
               exit 0
             fi
             echo "::warning::docker stack start failed (attempt ${attempt}/3); tearing down and retrying"
@@ -1328,9 +1330,15 @@ jobs:
         env:
           SHARD_RESULT: ${{ needs.e2e-shard.result }}
         run: |
-          if [[ "$SHARD_RESULT" == "success" || "$SHARD_RESULT" == "skipped" ]]; then
-            exit 0
-          fi
+          case "$SHARD_RESULT" in
+            success|skipped)
+              exit 0
+              ;;
+            cancelled)
+              echo "Browser checks were cancelled; a newer run is authoritative."
+              exit 0
+              ;;
+          esac
           echo "::error::Browser checks ended with $SHARD_RESULT"
           exit 1
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,7 +144,6 @@ jobs:
       desktop_rust_checks_required: ${{ steps.changed-files.outputs.desktop_rust_checks_required }}
       e2e_core_required: ${{ steps.changed-files.outputs.e2e_core_required }}
       e2e_landing_required: ${{ steps.changed-files.outputs.e2e_landing_required }}
-      e2e_marketing_required: ${{ steps.changed-files.outputs.e2e_marketing_required }}
       package_checks_required: ${{ steps.changed-files.outputs.package_checks_required }}
 
     steps:
@@ -165,7 +164,6 @@ jobs:
               echo "desktop_rust_checks_required=true"
               echo "e2e_core_required=true"
               echo "e2e_landing_required=true"
-              echo "e2e_marketing_required=true"
               echo "package_checks_required=true"
             } >> "$GITHUB_OUTPUT"
             exit 0
@@ -179,7 +177,6 @@ jobs:
               echo "desktop_rust_checks_required=false"
               echo "e2e_core_required=false"
               echo "e2e_landing_required=false"
-              echo "e2e_marketing_required=false"
               echo "package_checks_required=true"
             } >> "$GITHUB_OUTPUT"
             exit 0
@@ -188,7 +185,6 @@ jobs:
           desktop_rust_checks_required=$(bash scripts/detect-tauri-rust-changes.sh "${changed_files[@]}")
           e2e_core_required=$(bash scripts/detect-e2e-changes.sh core "${changed_files[@]}")
           e2e_landing_required=$(bash scripts/detect-e2e-changes.sh landing "${changed_files[@]}")
-          e2e_marketing_required=$(bash scripts/detect-e2e-changes.sh marketing "${changed_files[@]}")
           package_checks_required=false
           for file in "${changed_files[@]}"; do
             case "$file" in
@@ -209,7 +205,6 @@ jobs:
             echo "desktop_rust_checks_required=$desktop_rust_checks_required"
             echo "e2e_core_required=$e2e_core_required"
             echo "e2e_landing_required=$e2e_landing_required"
-            echo "e2e_marketing_required=$e2e_marketing_required"
             echo "package_checks_required=$package_checks_required"
           } >> "$GITHUB_OUTPUT"
 
@@ -966,15 +961,14 @@ jobs:
 
   # Browser checks are split across isolated runners. The broad app suite uses
   # a production build; one shard first runs a tiny Vite canary to retain the
-  # dependency re-optimization guard. Marketing and landing checks are gated
-  # independently by their declared inputs.
+  # dependency re-optimization guard. Landing checks are gated independently;
+  # marketing screenshots run in the nightly test workflow.
   e2e-shard:
     needs: [trust-check, ci-changes]
     if: >-
       (needs.trust-check.outputs.trusted == 'true'
        || github.event_name == 'workflow_dispatch')
       && (needs.ci-changes.outputs.e2e_core_required == 'true'
-          || needs.ci-changes.outputs.e2e_marketing_required == 'true'
           || needs.ci-changes.outputs.e2e_landing_required == 'true')
     runs-on: ubuntu-latest
     timeout-minutes: 25
@@ -996,25 +990,17 @@ jobs:
         env:
           CORE_REQUIRED: ${{ needs.ci-changes.outputs.e2e_core_required }}
           LANDING_REQUIRED: ${{ needs.ci-changes.outputs.e2e_landing_required }}
-          MARKETING_REQUIRED: ${{ needs.ci-changes.outputs.e2e_marketing_required }}
           SHARD: ${{ matrix.shard }}
         run: |
           run=false
           if [[ "$CORE_REQUIRED" == "true" \
-            || ("$SHARD" == "1" && "$MARKETING_REQUIRED" == "true") \
             || ("$SHARD" == "2" && "$LANDING_REQUIRED" == "true") ]]; then
             run=true
           fi
-          app_stack=false
-          if [[ "$CORE_REQUIRED" == "true" \
-            || ("$SHARD" == "1" && "$MARKETING_REQUIRED" == "true") ]]; then
-            app_stack=true
-          fi
           {
-            echo "app_stack=$app_stack"
+            echo "app_stack=$CORE_REQUIRED"
             echo "core=$CORE_REQUIRED"
             echo "landing=$LANDING_REQUIRED"
-            echo "marketing=$MARKETING_REQUIRED"
             echo "run=$run"
           } >> "$GITHUB_OUTPUT"
 
@@ -1130,20 +1116,14 @@ jobs:
           exit 1
 
       - name: Start web dev server
-        if: >-
-          matrix.shard == 1
-          && (steps.changed.outputs.core == 'true'
-              || steps.changed.outputs.marketing == 'true')
+        if: matrix.shard == 1 && steps.changed.outputs.core == 'true'
         run: |
           cd apps/web
           nohup bun --bun vite --port 3000 > /tmp/web.log 2>&1 &
           echo $! > /tmp/web.pid
 
       - name: Wait for web dev server
-        if: >-
-          matrix.shard == 1
-          && (steps.changed.outputs.core == 'true'
-              || steps.changed.outputs.marketing == 'true')
+        if: matrix.shard == 1 && steps.changed.outputs.core == 'true'
         run: |
           for i in {1..60}; do
             if curl --connect-timeout 2 --max-time 5 -sf http://localhost:3000 > /dev/null 2>&1; then
@@ -1166,22 +1146,13 @@ jobs:
           bun --filter @stll/web test:e2e --
           --project chromium --grep @dev-canary
 
-      - name: Seed deterministic marketing content
-        if: matrix.shard == 1 && steps.changed.outputs.marketing == 'true'
-        run: bun --filter @stll/api db:seed-dev
-
-      - name: Check landing product screenshots
-        if: matrix.shard == 1 && steps.changed.outputs.marketing == 'true'
-        run: bun --filter @stll/web test:e2e:marketing
-
       # Flake guard: the tiny dev pass covers the lazy chat and Folio imports
       # that have historically escaped Vite's cold dependency scan.
       - name: Guard against mid-test Vite re-optimize
         if: >-
           always()
           && matrix.shard == 1
-          && (steps.changed.outputs.core == 'true'
-              || steps.changed.outputs.marketing == 'true')
+          && steps.changed.outputs.core == 'true'
         run: |
           if grep -q "optimized dependencies changed. reloading" /tmp/web.log; then
             echo "::error::Vite re-optimized dependencies mid-session and forced a reload. Add the lazy/runtime dependency named below to optimizeDeps.include in apps/web/vite.config.ts."
@@ -1194,8 +1165,7 @@ jobs:
         if: >-
           always()
           && matrix.shard == 1
-          && (steps.changed.outputs.core == 'true'
-              || steps.changed.outputs.marketing == 'true')
+          && steps.changed.outputs.core == 'true'
         run: |
           kill "$(cat /tmp/web.pid)" || true
           rm -f /tmp/web.pid

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,6 +142,9 @@ jobs:
       contents: read
     outputs:
       desktop_rust_checks_required: ${{ steps.changed-files.outputs.desktop_rust_checks_required }}
+      e2e_core_required: ${{ steps.changed-files.outputs.e2e_core_required }}
+      e2e_landing_required: ${{ steps.changed-files.outputs.e2e_landing_required }}
+      e2e_marketing_required: ${{ steps.changed-files.outputs.e2e_marketing_required }}
       package_checks_required: ${{ steps.changed-files.outputs.package_checks_required }}
 
     steps:
@@ -158,8 +161,13 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
         run: |
           if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
-            echo "desktop_rust_checks_required=true" >> "$GITHUB_OUTPUT"
-            echo "package_checks_required=true" >> "$GITHUB_OUTPUT"
+            {
+              echo "desktop_rust_checks_required=true"
+              echo "e2e_core_required=true"
+              echo "e2e_landing_required=true"
+              echo "e2e_marketing_required=true"
+              echo "package_checks_required=true"
+            } >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -167,12 +175,20 @@ jobs:
           mapfile -t changed_files < <(git diff --name-only "$base_ref"...HEAD)
 
           if (( ${#changed_files[@]} == 0 )); then
-            echo "desktop_rust_checks_required=false" >> "$GITHUB_OUTPUT"
-            echo "package_checks_required=true" >> "$GITHUB_OUTPUT"
+            {
+              echo "desktop_rust_checks_required=false"
+              echo "e2e_core_required=false"
+              echo "e2e_landing_required=false"
+              echo "e2e_marketing_required=false"
+              echo "package_checks_required=true"
+            } >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
           desktop_rust_checks_required=$(bash scripts/detect-tauri-rust-changes.sh "${changed_files[@]}")
+          e2e_core_required=$(bash scripts/detect-e2e-changes.sh core "${changed_files[@]}")
+          e2e_landing_required=$(bash scripts/detect-e2e-changes.sh landing "${changed_files[@]}")
+          e2e_marketing_required=$(bash scripts/detect-e2e-changes.sh marketing "${changed_files[@]}")
           package_checks_required=false
           for file in "${changed_files[@]}"; do
             case "$file" in
@@ -189,8 +205,13 @@ jobs:
 
           printf 'Changed files:\n'
           printf ' - %s\n' "${changed_files[@]}"
-          echo "desktop_rust_checks_required=$desktop_rust_checks_required" >> "$GITHUB_OUTPUT"
-          echo "package_checks_required=$package_checks_required" >> "$GITHUB_OUTPUT"
+          {
+            echo "desktop_rust_checks_required=$desktop_rust_checks_required"
+            echo "e2e_core_required=$e2e_core_required"
+            echo "e2e_landing_required=$e2e_landing_required"
+            echo "e2e_marketing_required=$e2e_marketing_required"
+            echo "package_checks_required=$package_checks_required"
+          } >> "$GITHUB_OUTPUT"
 
           if [[ "$package_checks_required" != "true" ]]; then
             echo "::notice::Only workflow/provenance files changed; skipping package CI checks."
@@ -566,6 +587,9 @@ jobs:
       - name: Test detect-desktop-release-changes script
         run: bash scripts/detect-desktop-release-changes.test.sh
 
+      - name: Test E2E change detector
+        run: bun test scripts/detect-e2e-changes.test.ts
+
       - name: Test bun ci retry script
         run: bash scripts/bun-ci-retry.test.sh
 
@@ -940,23 +964,26 @@ jobs:
         if: steps.changed.outputs.run == 'true'
         run: bun --filter @stll/landing build
 
-  # Playwright end-to-end suite. Boots the full local stack
-  # (Postgres, MinIO, Valkey, Gotenberg) plus the API and web
-  # dev server, then runs the E2E specs under
-  # apps/web/e2e/. Catches integration regressions that
-  # code-quality/unit tests miss (auth, routing, upload flow,
-  # document rendering). Finishes with the landing suite against a
-  # built `astro preview`, which is the only place bundler-only
-  # island regressions are visible.
-  e2e:
-    needs: trust-check
+  # Browser checks are split across isolated runners. The broad app suite uses
+  # a production build; one shard first runs a tiny Vite canary to retain the
+  # dependency re-optimization guard. Marketing and landing checks are gated
+  # independently by their declared inputs.
+  e2e-shard:
+    needs: [trust-check, ci-changes]
     if: >-
-      needs.trust-check.outputs.trusted == 'true'
-      || github.event_name == 'workflow_dispatch'
+      (needs.trust-check.outputs.trusted == 'true'
+       || github.event_name == 'workflow_dispatch')
+      && (needs.ci-changes.outputs.e2e_core_required == 'true'
+          || needs.ci-changes.outputs.e2e_marketing_required == 'true'
+          || needs.ci-changes.outputs.e2e_landing_required == 'true')
     runs-on: ubuntu-latest
     timeout-minutes: 25
     permissions:
       contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2]
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -964,31 +991,32 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Check whether E2E-affecting paths changed
+      - name: Load E2E scopes
         id: changed
         env:
-          BASE_REF: ${{ github.base_ref || 'main' }}
-          EVENT_NAME: ${{ github.event_name }}
+          CORE_REQUIRED: ${{ needs.ci-changes.outputs.e2e_core_required }}
+          LANDING_REQUIRED: ${{ needs.ci-changes.outputs.e2e_landing_required }}
+          MARKETING_REQUIRED: ${{ needs.ci-changes.outputs.e2e_marketing_required }}
+          SHARD: ${{ matrix.shard }}
         run: |
-          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
-            echo "run=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          base_ref="origin/$BASE_REF"
-          mapfile -t changed_files < <(git diff --name-only "$base_ref"...HEAD)
           run=false
-          for file in "${changed_files[@]}"; do
-            case "$file" in
-              apps/web/*|apps/api/*|apps/landing/*|packages/*|patches/*|docker-compose.yml|bun.lock|package.json|.github/workflows/ci.yml)
-                run=true
-                break
-                ;;
-            esac
-          done
-          echo "run=$run" >> "$GITHUB_OUTPUT"
-          if [[ "$run" != "true" ]]; then
-            echo "::notice::No E2E-affecting paths changed; skipping E2E."
+          if [[ "$CORE_REQUIRED" == "true" \
+            || ("$SHARD" == "1" && "$MARKETING_REQUIRED" == "true") \
+            || ("$SHARD" == "2" && "$LANDING_REQUIRED" == "true") ]]; then
+            run=true
           fi
+          app_stack=false
+          if [[ "$CORE_REQUIRED" == "true" \
+            || ("$SHARD" == "1" && "$MARKETING_REQUIRED" == "true") ]]; then
+            app_stack=true
+          fi
+          {
+            echo "app_stack=$app_stack"
+            echo "core=$CORE_REQUIRED"
+            echo "landing=$LANDING_REQUIRED"
+            echo "marketing=$MARKETING_REQUIRED"
+            echo "run=$run"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Setup Bun
         if: steps.changed.outputs.run == 'true'
@@ -1003,7 +1031,7 @@ jobs:
           NPM_TOKEN: ""
 
       - name: Prepare environment
-        if: steps.changed.outputs.run == 'true'
+        if: steps.changed.outputs.app_stack == 'true'
         run: |
           cd ./apps/api
           cp .env.example .env
@@ -1014,7 +1042,7 @@ jobs:
         id: dockerhub
         # Keep Docker Hub secrets scoped to this trusted inline check, not the
         # whole job environment where repository-controlled code can read them.
-        if: steps.changed.outputs.run == 'true'
+        if: steps.changed.outputs.app_stack == 'true'
         env:
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -1029,14 +1057,14 @@ jobs:
         # Skipped automatically until DOCKERHUB_USERNAME / DOCKERHUB_TOKEN repo
         # secrets exist; authenticated pulls raise the rate limit well above the
         # shared-runner anonymous cap that flakes the gotenberg image pull.
-        if: steps.changed.outputs.run == 'true' && steps.dockerhub.outputs.available == 'true'
+        if: steps.changed.outputs.app_stack == 'true' && steps.dockerhub.outputs.available == 'true'
         uses: docker/login-action@371161bbe7024a29a25c5e19bfcbc0804fe9ad2c # v4.5.2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Start docker stack
-        if: steps.changed.outputs.run == 'true'
+        if: steps.changed.outputs.app_stack == 'true'
         # `--wait` only on long-running services; `minio-setup` is a one-shot
         # bucket-creator container that exits 0, which `--wait` treats as
         # "not running" and fails the whole command. Run it separately in
@@ -1059,11 +1087,11 @@ jobs:
 
       - name: Log out of Docker Hub
         # Remove credentials from the runner before executing app code and tests.
-        if: always() && steps.changed.outputs.run == 'true' && steps.dockerhub.outputs.available == 'true'
+        if: always() && steps.changed.outputs.app_stack == 'true' && steps.dockerhub.outputs.available == 'true'
         run: docker logout
 
       - name: Run database migrations
-        if: steps.changed.outputs.run == 'true'
+        if: steps.changed.outputs.app_stack == 'true'
         # `db:migrate` (not `db:push`) so role bootstrap migrations such as
         # `20260516000000_case_law_ingestion_role` actually execute. `db:push`
         # only diffs the declarative schema, which references `stella_ingestion`
@@ -1071,11 +1099,11 @@ jobs:
         run: bun --filter @stll/api db:migrate
 
       - name: Seed test user
-        if: steps.changed.outputs.run == 'true'
+        if: steps.changed.outputs.app_stack == 'true'
         run: bun --filter @stll/api db:seed-test-user
 
       - name: Start API server
-        if: steps.changed.outputs.run == 'true'
+        if: steps.changed.outputs.app_stack == 'true'
         # `--watch` is for local dev; CI runs the server flat. Logs land in
         # /tmp/api.log so the "Upload server logs" step can publish them on
         # failure for debugging.
@@ -1088,7 +1116,7 @@ jobs:
           echo $! > /tmp/api.pid
 
       - name: Wait for API
-        if: steps.changed.outputs.run == 'true'
+        if: steps.changed.outputs.app_stack == 'true'
         run: |
           for i in {1..60}; do
             if curl --connect-timeout 2 --max-time 5 -sf http://localhost:3001/health > /dev/null 2>&1; then
@@ -1102,14 +1130,20 @@ jobs:
           exit 1
 
       - name: Start web dev server
-        if: steps.changed.outputs.run == 'true'
+        if: >-
+          matrix.shard == 1
+          && (steps.changed.outputs.core == 'true'
+              || steps.changed.outputs.marketing == 'true')
         run: |
           cd apps/web
           nohup bun --bun vite --port 3000 > /tmp/web.log 2>&1 &
           echo $! > /tmp/web.pid
 
-      - name: Wait for web
-        if: steps.changed.outputs.run == 'true'
+      - name: Wait for web dev server
+        if: >-
+          matrix.shard == 1
+          && (steps.changed.outputs.core == 'true'
+              || steps.changed.outputs.marketing == 'true')
         run: |
           for i in {1..60}; do
             if curl --connect-timeout 2 --max-time 5 -sf http://localhost:3000 > /dev/null 2>&1; then
@@ -1126,20 +1160,85 @@ jobs:
         if: steps.changed.outputs.run == 'true'
         run: cd apps/web && bunx playwright install --with-deps chromium
 
-      - name: Run Playwright tests
-        if: steps.changed.outputs.run == 'true'
-        run: bun --filter @stll/web test:e2e
+      - name: Run Vite dependency canary
+        if: matrix.shard == 1 && steps.changed.outputs.core == 'true'
+        run: >-
+          bun --filter @stll/web test:e2e --
+          --project chromium --grep @dev-canary
 
       - name: Seed deterministic marketing content
-        if: steps.changed.outputs.run == 'true'
+        if: matrix.shard == 1 && steps.changed.outputs.marketing == 'true'
         run: bun --filter @stll/api db:seed-dev
 
       - name: Check landing product screenshots
-        if: steps.changed.outputs.run == 'true'
+        if: matrix.shard == 1 && steps.changed.outputs.marketing == 'true'
         run: bun --filter @stll/web test:e2e:marketing
 
+      # Flake guard: the tiny dev pass covers the lazy chat and Folio imports
+      # that have historically escaped Vite's cold dependency scan.
+      - name: Guard against mid-test Vite re-optimize
+        if: >-
+          always()
+          && matrix.shard == 1
+          && (steps.changed.outputs.core == 'true'
+              || steps.changed.outputs.marketing == 'true')
+        run: |
+          if grep -q "optimized dependencies changed. reloading" /tmp/web.log; then
+            echo "::error::Vite re-optimized dependencies mid-session and forced a reload. Add the lazy/runtime dependency named below to optimizeDeps.include in apps/web/vite.config.ts."
+            grep -nE "new dependencies optimized|optimized dependencies changed" /tmp/web.log || true
+            exit 1
+          fi
+          echo "No mid-session dep re-optimize detected."
+
+      - name: Stop web dev server
+        if: >-
+          always()
+          && matrix.shard == 1
+          && (steps.changed.outputs.core == 'true'
+              || steps.changed.outputs.marketing == 'true')
+        run: |
+          kill "$(cat /tmp/web.pid)" || true
+          rm -f /tmp/web.pid
+
+      - name: Build web for route checks
+        if: steps.changed.outputs.core == 'true'
+        env:
+          VITE_FEATURE_TIME_BILLING: "true"
+          VITE_PLAYBOOKS_ENABLED: "true"
+          VITE_WORKFLOWS_ENABLED: "true"
+        run: bun --filter @stll/web build
+
+      - name: Start production web server
+        if: steps.changed.outputs.core == 'true'
+        run: |
+          cd apps/web
+          NODE_ENV=production PORT=3000 nohup bun start-runtime.js > /tmp/web-production.log 2>&1 &
+          echo $! > /tmp/web-production.pid
+
+      - name: Wait for production web server
+        if: steps.changed.outputs.core == 'true'
+        run: |
+          for i in {1..60}; do
+            if curl --connect-timeout 2 --max-time 5 -sf http://localhost:3000/health > /dev/null 2>&1; then
+              echo "Production web up after ${i}s"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "::error::Production web never came up"
+          tail -200 /tmp/web-production.log || true
+          exit 1
+
+      - name: Run Playwright shard
+        if: steps.changed.outputs.core == 'true'
+        env:
+          PLAYWRIGHT_BLOB_OUTPUT_NAME: report-${{ matrix.shard }}.zip
+        run: >-
+          bun --filter @stll/web test:e2e --
+          --shard=${{ matrix.shard }}/2
+
       - name: Build landing
-        if: steps.changed.outputs.run == 'true'
+        if: matrix.shard == 2 && steps.changed.outputs.landing == 'true'
         # The landing specs must run against the built bundle, not `astro dev`.
         # The live anonymization demo's failure mode is a dictionary import
         # that only a bundler can get wrong: unbundled dev serves the same
@@ -1147,7 +1246,7 @@ jobs:
         run: bun --filter @stll/landing build
 
       - name: Start landing preview server
-        if: steps.changed.outputs.run == 'true'
+        if: matrix.shard == 2 && steps.changed.outputs.landing == 'true'
         # `astro preview` serves dist/ with astro.config.mjs's COOP/COEP
         # headers, which the demo's wasm runtime needs (SharedArrayBuffer is
         # only exposed to a cross-origin-isolated page).
@@ -1157,7 +1256,7 @@ jobs:
           echo $! > /tmp/landing.pid
 
       - name: Wait for landing
-        if: steps.changed.outputs.run == 'true'
+        if: matrix.shard == 2 && steps.changed.outputs.landing == 'true'
         run: |
           for i in {1..60}; do
             if curl --connect-timeout 2 --max-time 5 -sf http://localhost:4321 > /dev/null 2>&1; then
@@ -1171,43 +1270,96 @@ jobs:
           exit 1
 
       - name: Check landing islands
-        if: steps.changed.outputs.run == 'true'
+        if: matrix.shard == 2 && steps.changed.outputs.landing == 'true'
         run: E2E_LANDING_URL=http://localhost:4321 bun --filter @stll/web test:e2e:landing
 
-      # Flake guard: the dev server's dependency optimizer must finish during
-      # the cold pass. A second pass mid-session prints "optimized dependencies
-      # changed. reloading" and forces a full-page reload that can tear the page
-      # down mid-test (see optimizeDeps.include in apps/web/vite.config.ts).
-      # Fail loudly — even on a lucky pass — so a newly added lazy/runtime dep
-      # that escapes the cold scan is fixed at its source instead of flaking.
-      - name: Guard against mid-test Vite re-optimize
-        if: always() && steps.changed.outputs.run == 'true'
-        run: |
-          if grep -q "optimized dependencies changed. reloading" /tmp/web.log; then
-            echo "::error::Vite re-optimized dependencies mid-session and forced a reload. A dependency reachable only via a lazy/runtime import is missing from optimizeDeps.include in apps/web/vite.config.ts — add the dep(s) named below."
-            grep -nE "new dependencies optimized|optimized dependencies changed" /tmp/web.log || true
-            exit 1
-          fi
-          echo "No mid-session dep re-optimize detected."
-
-      - name: Upload Playwright report
-        if: failure() && steps.changed.outputs.run == 'true'
+      - name: Upload Playwright blob report
+        if: always() && steps.changed.outputs.core == 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: playwright-report
-          path: apps/web/playwright-report/
+          name: playwright-blob-${{ matrix.shard }}
+          path: apps/web/test-results/blob-report/
           retention-days: 7
 
       - name: Upload server logs
         if: failure() && steps.changed.outputs.run == 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: server-logs
+          name: server-logs-${{ matrix.shard }}
           path: |
             /tmp/api.log
             /tmp/web.log
+            /tmp/web-production.log
             /tmp/landing.log
           retention-days: 7
+
+  e2e:
+    if: always()
+    needs: [trust-check, ci-changes, e2e-shard]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        if: >-
+          needs.e2e-shard.result == 'failure'
+          && needs.ci-changes.outputs.e2e_core_required == 'true'
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Bun
+        if: >-
+          needs.e2e-shard.result == 'failure'
+          && needs.ci-changes.outputs.e2e_core_required == 'true'
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version-file: "package.json"
+
+      - name: Install dependencies
+        if: >-
+          needs.e2e-shard.result == 'failure'
+          && needs.ci-changes.outputs.e2e_core_required == 'true'
+        run: bash scripts/bun-ci-retry.sh --ignore-scripts
+        env:
+          NPM_TOKEN: ""
+
+      - name: Download Playwright blob reports
+        if: >-
+          needs.e2e-shard.result == 'failure'
+          && needs.ci-changes.outputs.e2e_core_required == 'true'
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v8.0.0
+        with:
+          pattern: playwright-blob-*
+          path: apps/web/all-blob-reports
+          merge-multiple: true
+
+      - name: Merge Playwright reports
+        if: >-
+          needs.e2e-shard.result == 'failure'
+          && needs.ci-changes.outputs.e2e_core_required == 'true'
+        run: cd apps/web && bunx playwright merge-reports --reporter html all-blob-reports
+
+      - name: Upload merged Playwright report
+        if: >-
+          needs.e2e-shard.result == 'failure'
+          && needs.ci-changes.outputs.e2e_core_required == 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: playwright-report
+          path: apps/web/playwright-report/
+          retention-days: 7
+
+      - name: Evaluate browser checks
+        env:
+          SHARD_RESULT: ${{ needs.e2e-shard.result }}
+        run: |
+          if [[ "$SHARD_RESULT" == "success" || "$SHARD_RESULT" == "skipped" ]]; then
+            exit 0
+          fi
+          echo "::error::Browser checks ended with $SHARD_RESULT"
+          exit 1
 
   # Image dependency guard. The API and legal-atlas-runner Dockerfiles use
   # Turbo only for pruned source overlays; dependency installs come from the

--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -103,7 +103,7 @@ jobs:
         run: |
           for attempt in 1 2 3; do
             if docker compose --profile dev up -d --wait postgres minio valkey gotenberg \
-              && docker compose --profile dev up minio-setup; then
+              && docker compose --profile dev run --rm --no-deps minio-setup; then
               exit 0
             fi
             echo "::warning::docker stack start failed (attempt ${attempt}/3); tearing down and retrying"

--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -47,6 +47,157 @@ jobs:
         env:
           TURBO_FORCE: "true"
 
+  # Marketing captures are intentionally nightly, not part of the PR critical
+  # path. They exercise seeded product scenes against the complete default-
+  # branch runtime, so dependency changes need no fragile per-file allowlist.
+  marketing-screenshots:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          submodules: true
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version-file: "package.json"
+
+      - name: Install dependencies
+        run: bash scripts/bun-ci-retry.sh --ignore-scripts
+        env:
+          NPM_TOKEN: ""
+
+      - name: Prepare environment
+        run: |
+          cd ./apps/api
+          cp .env.example .env
+          cd ../web
+          cp .env.example .env
+
+      - name: Check Docker Hub credentials
+        id: dockerhub
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+        run: |
+          if [[ -n "$DOCKERHUB_USERNAME" && -n "$DOCKERHUB_TOKEN" ]]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "available=false" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to Docker Hub
+        if: steps.dockerhub.outputs.available == 'true'
+        uses: docker/login-action@371161bbe7024a29a25c5e19bfcbc0804fe9ad2c # v4.5.2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Start docker stack
+        run: |
+          for attempt in 1 2 3; do
+            if docker compose --profile dev up -d --wait postgres minio valkey gotenberg \
+              && docker compose --profile dev up minio-setup; then
+              exit 0
+            fi
+            echo "::warning::docker stack start failed (attempt ${attempt}/3); tearing down and retrying"
+            docker compose --profile dev down --volumes --remove-orphans || true
+            sleep "$((attempt * 20))"
+          done
+          echo "::error::docker stack failed to start after 3 attempts"
+          exit 1
+
+      - name: Log out of Docker Hub
+        if: always() && steps.dockerhub.outputs.available == 'true'
+        run: docker logout
+
+      - name: Run database migrations
+        run: bun --filter @stll/api db:migrate
+
+      - name: Seed test user
+        run: bun --filter @stll/api db:seed-test-user
+
+      - name: Start API server
+        run: |
+          cd apps/api
+          NODE_ENV=development E2E_DISABLE_AUTH_RATE_LIMIT=true nohup bun --port 3001 --preload ./src/dev/register-mock-ai.ts src/server.ts > /tmp/api.log 2>&1 &
+          echo $! > /tmp/api.pid
+
+      - name: Wait for API
+        run: |
+          for i in {1..60}; do
+            if curl --connect-timeout 2 --max-time 5 -sf http://localhost:3001/health > /dev/null 2>&1; then
+              echo "API up after ${i}s"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "::error::API never came up"
+          tail -200 /tmp/api.log || true
+          exit 1
+
+      - name: Start web dev server
+        run: |
+          cd apps/web
+          nohup bun --bun vite --port 3000 > /tmp/web.log 2>&1 &
+          echo $! > /tmp/web.pid
+
+      - name: Wait for web dev server
+        run: |
+          for i in {1..60}; do
+            if curl --connect-timeout 2 --max-time 5 -sf http://localhost:3000 > /dev/null 2>&1; then
+              echo "Web up after ${i}s"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "::error::Web never came up"
+          tail -200 /tmp/web.log || true
+          exit 1
+
+      - name: Install Playwright browsers
+        run: cd apps/web && bunx playwright install --with-deps chromium
+
+      - name: Seed deterministic marketing content
+        run: bun --filter @stll/api db:seed-dev
+
+      - name: Check marketing screenshots
+        run: bun --filter @stll/web test:e2e:marketing
+
+      - name: Guard against mid-test Vite re-optimize
+        if: always()
+        run: |
+          if grep -q "optimized dependencies changed. reloading" /tmp/web.log; then
+            echo "::error::Vite re-optimized dependencies mid-session and forced a reload. Add the lazy/runtime dependency named below to optimizeDeps.include in apps/web/vite.config.ts."
+            grep -nE "new dependencies optimized|optimized dependencies changed" /tmp/web.log || true
+            exit 1
+          fi
+          echo "No mid-session dep re-optimize detected."
+
+      - name: Stop web dev server
+        if: always()
+        run: |
+          kill "$(cat /tmp/web.pid)" || true
+          rm -f /tmp/web.pid
+
+      - name: Upload failure diagnostics
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: nightly-marketing-screenshot-diagnostics
+          path: |
+            /tmp/api.log
+            /tmp/web.log
+            apps/web/test-results/
+          if-no-files-found: ignore
+          retention-days: 7
+
   # Postgres-backed API suites that gate on STELLA_RUN_POSTGRES_TESTS=true and a
   # real DATABASE_URL. The plain `bun run test` above skips them (they no-op in
   # the skip branch), so they only ever execute here against a service Postgres

--- a/apps/web/e2e/helpers/network.ts
+++ b/apps/web/e2e/helpers/network.ts
@@ -57,9 +57,54 @@ export type NetworkCapture = {
 
 export type NetworkCollector = {
   trackPage: (page: Page) => () => void;
+  // Waits until tracked API activity has been quiet for the requested window.
+  // Long-lived SSE streams do not block this: only their request/response
+  // events count as activity, not the open connection itself.
+  waitForQuiet: (options: NetworkQuietOptions) => Promise<"idle" | "timeout">;
   // Async: waits for in-flight response-body reads so response sizes are
   // populated before the caller summarizes the capture.
   capture: () => Promise<NetworkCapture>;
+};
+
+export type NetworkQuietOptions = {
+  idleMs: number;
+  timeoutMs: number;
+};
+
+type WaitForQuietPeriodOptions = NetworkQuietOptions & {
+  getLastActivityAt: () => number;
+  now?: () => number;
+  sleep?: (durationMs: number) => Promise<void>;
+};
+
+// Kept independent of Playwright so the timing state machine can be exercised
+// deterministically with a fake clock. The timeout is a cap, matching the old
+// settle window; reaching it allows capture instead of hanging on polling.
+export const waitForQuietPeriod = async ({
+  getLastActivityAt,
+  idleMs,
+  timeoutMs,
+  now = Date.now,
+  sleep = async (durationMs) =>
+    new Promise((resolve) => {
+      setTimeout(resolve, durationMs);
+    }),
+}: WaitForQuietPeriodOptions): Promise<"idle" | "timeout"> => {
+  const startedAt = now();
+  const timeoutAt = startedAt + timeoutMs;
+
+  while (true) {
+    const current = now();
+    const idleAt = Math.max(startedAt, getLastActivityAt()) + idleMs;
+    if (current >= idleAt) {
+      return "idle";
+    }
+    if (current >= timeoutAt) {
+      return "timeout";
+    }
+    // eslint-disable-next-line no-await-in-loop -- each wait observes activity that may have arrived during the preceding wait; parallel sleeps cannot model a quiet period
+    await sleep(Math.min(idleAt, timeoutAt) - current);
+  }
 };
 
 type NetworkCollectorOptions = {
@@ -112,14 +157,20 @@ const readResponseBytes = async (
 };
 
 export const createNetworkCollector = (
-  options: NetworkCollectorOptions = {},
+  collectorOptions: NetworkCollectorOptions = {},
 ): NetworkCollector => {
-  const apiOrigin = options.apiOrigin ?? new URL(DEFAULT_API_URL).origin;
+  const apiOrigin =
+    collectorOptions.apiOrigin ?? new URL(DEFAULT_API_URL).origin;
   const records: NetworkRecord[] = [];
   const byRequest = new Map<Request, NetworkRecord>();
   // Body reads are async (Playwright must finish downloading the response),
   // so capture() awaits these before reading responseBytes off the records.
   const pendingBodyReads: Promise<void>[] = [];
+  let lastActivityAt = Date.now();
+
+  const markActivity = () => {
+    lastActivityAt = Date.now();
+  };
 
   return {
     trackPage: (page) => {
@@ -139,12 +190,14 @@ export const createNetworkCollector = (
         };
         records.push(record);
         byRequest.set(request, record);
+        markActivity();
       };
 
       const onSettled = (request: Request) => {
         const record = byRequest.get(request);
         if (record) {
           record.end = Date.now();
+          markActivity();
         }
       };
 
@@ -153,6 +206,7 @@ export const createNetworkCollector = (
         if (!record) {
           return;
         }
+        markActivity();
         const header = response.headers()[DB_QUERIES_HEADER];
         if (header !== undefined) {
           record.dbQueries = Number(header);
@@ -178,6 +232,12 @@ export const createNetworkCollector = (
         page.off("requestfailed", onSettled);
       };
     },
+
+    waitForQuiet: async (quietOptions) =>
+      waitForQuietPeriod({
+        ...quietOptions,
+        getLastActivityAt: () => lastActivityAt,
+      }),
 
     capture: async () => {
       await Promise.all(pendingBodyReads);
@@ -360,6 +420,10 @@ export const summarizeCapture = (
 export type NetworkBaselineDiff = {
   problems: string[];
   notices: string[];
+};
+
+type DiffNetworkBaselineOptions = {
+  requireAllRoutes?: boolean;
 };
 
 const pushNewRequestProblems = ({
@@ -600,6 +664,7 @@ const requestCountBudget = (
 export const diffNetworkBaseline = (
   baseline: NetworkBaseline | null,
   results: Map<string, RouteNetworkMetrics>,
+  { requireAllRoutes = true }: DiffNetworkBaselineOptions = {},
 ): NetworkBaselineDiff => {
   const problems: string[] = [];
   const notices: string[] = [];
@@ -636,13 +701,15 @@ export const diffNetworkBaseline = (
     pushImprovementNotices({ route, entry, metrics, notices });
   }
 
-  for (const route of Object.keys(baseline)) {
-    if (!results.has(route)) {
-      problems.push(
-        `Stale network baseline entry (route not visited this run): ${route}\n` +
-          `  The smoke route set is deterministic, so a baseline route that never\n` +
-          `  ran means the route was renamed or removed — prune it: ${WRITE_HINT}.`,
-      );
+  if (requireAllRoutes) {
+    for (const route of Object.keys(baseline)) {
+      if (!results.has(route)) {
+        problems.push(
+          `Stale network baseline entry (route not visited this run): ${route}\n` +
+            `  The smoke route set is deterministic, so a baseline route that never\n` +
+            `  ran means the route was renamed or removed — prune it: ${WRITE_HINT}.`,
+        );
+      }
     }
   }
 
@@ -767,6 +834,7 @@ const writeNetworkBaseline = (baseline: NetworkBaseline) => {
 
 export const assertNetworkBaseline = (
   results: Map<string, RouteNetworkMetrics>,
+  options: DiffNetworkBaselineOptions = {},
 ) => {
   const mode = process.env["E2E_NETWORK_BASELINE"];
 
@@ -790,6 +858,7 @@ export const assertNetworkBaseline = (
   const { problems, notices } = diffNetworkBaseline(
     readNetworkBaseline(),
     results,
+    options,
   );
 
   for (const notice of notices) {
@@ -802,4 +871,12 @@ export const assertNetworkBaseline = (
       ? "network baseline"
       : `Network baseline check failed:\n\n${problems.join("\n\n")}`,
   ).toEqual([]);
+};
+
+export const assertNetworkBaselineCoverage = (expectedRoutes: string[]) => {
+  const baseline = readNetworkBaseline();
+  expect(
+    baseline === null ? [] : Object.keys(baseline).sort(),
+    `network baseline route keys in ${BASELINE_RELATIVE}`,
+  ).toEqual(expectedRoutes.toSorted());
 };

--- a/apps/web/e2e/helpers/network.ts
+++ b/apps/web/e2e/helpers/network.ts
@@ -68,6 +68,7 @@ export type NetworkCollector = {
 
 export type NetworkQuietOptions = {
   idleMs: number;
+  minimumObservationMs: number;
   timeoutMs: number;
 };
 
@@ -83,6 +84,7 @@ type WaitForQuietPeriodOptions = NetworkQuietOptions & {
 export const waitForQuietPeriod = async ({
   getLastActivityAt,
   idleMs,
+  minimumObservationMs,
   timeoutMs,
   now = Date.now,
   sleep = async (durationMs) =>
@@ -95,7 +97,10 @@ export const waitForQuietPeriod = async ({
 
   while (true) {
     const current = now();
-    const idleAt = Math.max(startedAt, getLastActivityAt()) + idleMs;
+    const idleAt = Math.max(
+      startedAt + minimumObservationMs,
+      Math.max(startedAt, getLastActivityAt()) + idleMs,
+    );
     if (current >= idleAt) {
       return "idle";
     }

--- a/apps/web/e2e/network-baseline.json
+++ b/apps/web/e2e/network-baseline.json
@@ -392,7 +392,9 @@
       "GET /api/auth/organization/list",
       "GET /health",
       "GET /v1/chat/threads",
+      "GET /v1/chat/threads/:id/messages",
       "GET /v1/organization-settings/ai-availability",
+      "GET /v1/skills",
       "GET /v1/workspaces/navigation"
     ],
     "requestCounts": {
@@ -401,7 +403,9 @@
       "GET /api/auth/organization/list": 1,
       "GET /health": 1,
       "GET /v1/chat/threads": 1,
+      "GET /v1/chat/threads/:id/messages": 1,
       "GET /v1/organization-settings/ai-availability": 1,
+      "GET /v1/skills": 1,
       "GET /v1/workspaces/navigation": 1
     },
     "dbQueries": {
@@ -410,7 +414,9 @@
       "GET /api/auth/organization/list": 6,
       "GET /health": 1,
       "GET /v1/chat/threads": 6,
+      "GET /v1/chat/threads/:id/messages": 7,
       "GET /v1/organization-settings/ai-availability": 4,
+      "GET /v1/skills": 6,
       "GET /v1/workspaces/navigation": 6
     },
     "responseSizes": {
@@ -419,7 +425,9 @@
       "GET /api/auth/organization/list": 1024,
       "GET /health": 1024,
       "GET /v1/chat/threads": 4096,
+      "GET /v1/chat/threads/:id/messages": 1024,
       "GET /v1/organization-settings/ai-availability": 1024,
+      "GET /v1/skills": 4096,
       "GET /v1/workspaces/navigation": 20480
     }
   },
@@ -936,6 +944,7 @@
     "depth": 3,
     "requests": [
       "GET /api/auth/get-session",
+      "GET /api/auth/list-sessions",
       "GET /api/auth/organization/get-active-member-role",
       "GET /api/auth/organization/list",
       "GET /health",
@@ -945,6 +954,7 @@
     ],
     "requestCounts": {
       "GET /api/auth/get-session": 1,
+      "GET /api/auth/list-sessions": 1,
       "GET /api/auth/organization/get-active-member-role": 1,
       "GET /api/auth/organization/list": 1,
       "GET /health": 1,
@@ -954,6 +964,7 @@
     },
     "dbQueries": {
       "GET /api/auth/get-session": 2,
+      "GET /api/auth/list-sessions": 3,
       "GET /api/auth/organization/get-active-member-role": 4,
       "GET /api/auth/organization/list": 6,
       "GET /health": 1,
@@ -963,6 +974,7 @@
     },
     "responseSizes": {
       "GET /api/auth/get-session": 1024,
+      "GET /api/auth/list-sessions": 3072,
       "GET /api/auth/organization/get-active-member-role": 1024,
       "GET /api/auth/organization/list": 1024,
       "GET /health": 1024,

--- a/apps/web/e2e/playwright.config.ts
+++ b/apps/web/e2e/playwright.config.ts
@@ -11,18 +11,20 @@ const IS_CI = process.env["CI"] !== undefined;
 
 export default defineConfig({
   testDir: "./specs",
-  // Each spec creates and tears down its own workspace, so parallelism
-  // is safe. Capped at 4 locally to keep Postgres/MinIO contention
-  // modest; serial in CI because two specs cold-compiling heavy route
-  // chunks (folio, chat) on a 2-core runner starve each other past
-  // their expect timeouts.
+  // Each spec creates and tears down its own workspace, so parallelism is
+  // safe. CI parallelizes across isolated two-way shards; each runner keeps a
+  // single worker so Postgres, MinIO, and Chromium do not contend for 2 cores.
   fullyParallel: true,
   workers: IS_CI ? 1 : 4,
   // CI failures are almost always real (server logs, traces tell the story).
   // Retries hide flakes; fix them in code instead.
   retries: 0,
   reporter: IS_CI
-    ? [["github"], ["html", { open: "never" }], ["list"]]
+    ? [
+        ["blob", { outputDir: "test-results/blob-report" }],
+        ["github"],
+        ["list"],
+      ]
     : [["list"], ["html", { open: "never" }]],
   // Cold Vite + folio editor compile on a fresh CI runner can use 25-30s
   // before the first locator runs, leaving no headroom for in-spec

--- a/apps/web/e2e/specs/chat.spec.ts
+++ b/apps/web/e2e/specs/chat.spec.ts
@@ -4,79 +4,87 @@ import { expect, test } from "../helpers/test";
 // usage_entitlements row — the dark-launch default every production org
 // starts in. We deliberately do not create an entitlement here: regressions
 // that only surface in that default state must fail this spec.
-test("chat composer sends a message and renders the assistant reply", async ({
-  page,
-}) => {
-  // A route is ready when its UI is ready, not when every cold Vite resource
-  // has fired the browser load event. Commit the document, then synchronize on
-  // the composer below.
-  await page.goto("/chat", { waitUntil: "commit" });
+test(
+  "chat composer sends a message and renders the assistant reply",
+  {
+    tag: "@dev-canary",
+  },
+  async ({ page }) => {
+    // A route is ready when its UI is ready, not when every cold Vite resource
+    // has fired the browser load event. Commit the document, then synchronize on
+    // the composer below.
+    await page.goto("/chat", { waitUntil: "commit" });
 
-  // Route error boundary heading (apps/web/src/components/route-components.tsx,
-  // title routeError.title). Checked after every step below; declared
-  // once so the assertions read the same way each time.
-  const errorBoundary = page.getByRole("heading", {
-    name: "This page couldn’t be opened",
-  });
-  await expect(errorBoundary).toHaveCount(0);
+    // Route error boundary heading (apps/web/src/components/route-components.tsx,
+    // title routeError.title). Checked after every step below; declared
+    // once so the assertions read the same way each time.
+    const errorBoundary = page.getByRole("heading", {
+      name: "This page couldn’t be opened",
+    });
+    await expect(errorBoundary).toHaveCount(0);
 
-  // The composer's contenteditable carries an explicit role and
-  // aria-label (chat-editor-provider editorProps); the name filter
-  // keeps the locator unique even when other textbox-role editors
-  // (e.g. folio) are mounted.
-  const composer = page.getByRole("textbox", { name: /type your question/iu });
-  // First locator after navigation: a cold Vite dev server compiles the
-  // chat route chunk on demand, which can exceed the default 10s expect
-  // timeout on a fresh CI runner (see playwright.config.ts).
-  await expect(composer).toBeVisible({ timeout: 30_000 });
+    // The composer's contenteditable carries an explicit role and
+    // aria-label (chat-editor-provider editorProps); the name filter
+    // keeps the locator unique even when other textbox-role editors
+    // (e.g. folio) are mounted.
+    const composer = page.getByRole("textbox", {
+      name: /type your question/iu,
+    });
+    // First locator after navigation: a cold Vite dev server compiles the
+    // chat route chunk on demand, which can exceed the default 10s expect
+    // timeout on a fresh CI runner (see playwright.config.ts).
+    await expect(composer).toBeVisible({ timeout: 30_000 });
 
-  const messageText = "Hello from the stella e2e chat spec";
-  await composer.click();
-  await composer.pressSequentially(messageText);
+    const messageText = "Hello from the stella e2e chat spec";
+    await composer.click();
+    await composer.pressSequentially(messageText);
 
-  await page.getByRole("button", { name: "Send message" }).click();
+    await page.getByRole("button", { name: "Send message" }).click();
 
-  // Sending from /chat fires the request and navigates to the new
-  // thread (apps/web/src/routes/_protected.chat/index.tsx:389); the
-  // thread id is a client-generated uuidv7.
-  // The thread-creation request + client nav can exceed the default 10s expect
-  // timeout on a cold CI runner — the same headroom the waits below use.
-  await expect(page).toHaveURL(
-    /\/chat\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/u,
-    { timeout: 30_000 },
-  );
+    // Sending from /chat fires the request and navigates to the new
+    // thread (apps/web/src/routes/_protected.chat/index.tsx:389); the
+    // thread id is a client-generated uuidv7.
+    // The thread-creation request + client nav can exceed the default 10s expect
+    // timeout on a cold CI runner — the same headroom the waits below use.
+    await expect(page).toHaveURL(
+      /\/chat\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/u,
+      { timeout: 30_000 },
+    );
 
-  const transcript = page.getByRole("log");
-  // First assertion on the thread route: its lazy chunk cold-compiles
-  // on a fresh dev server, so allow the same headroom as the composer.
-  await expect(transcript.getByText(messageText)).toBeVisible({
-    timeout: 30_000,
-  });
+    const transcript = page.getByRole("log");
+    // First assertion on the thread route: its lazy chunk cold-compiles
+    // on a fresh dev server, so allow the same headroom as the composer.
+    await expect(transcript.getByText(messageText)).toBeVisible({
+      timeout: 30_000,
+    });
 
-  // A "Copy" action renders only under an assistant message that has
-  // non-empty text (AssistantMessageActions in
-  // apps/web/src/components/chat/chat-thread-messages.tsx) — neither the
-  // thinking indicator nor the error bubble has one — so its presence
-  // proves an actual reply painted, independent of what the registered
-  // mock model streams. Generous timeout: cold Vite chunks + the
-  // streamed response both land inside this wait.
-  await expect(transcript.getByRole("button", { name: "Copy" })).toBeVisible({
-    timeout: 30_000,
-  });
+    // A "Copy" action renders only under an assistant message that has
+    // non-empty text (AssistantMessageActions in
+    // apps/web/src/components/chat/chat-thread-messages.tsx) — neither the
+    // thinking indicator nor the error bubble has one — so its presence
+    // proves an actual reply painted, independent of what the registered
+    // mock model streams. Generous timeout: cold Vite chunks + the
+    // streamed response both land inside this wait.
+    await expect(transcript.getByRole("button", { name: "Copy" })).toBeVisible({
+      timeout: 30_000,
+    });
 
-  // "Retry" appears on the latest assistant message only once the
-  // stream finished, so waiting for it pins the turn as complete before
-  // the negative assertions below — otherwise an error chunk arriving
-  // after partial text could slip past them.
-  await expect(transcript.getByRole("button", { name: "Retry" })).toBeVisible({
-    timeout: 30_000,
-  });
+    // "Retry" appears on the latest assistant message only once the
+    // stream finished, so waiting for it pins the turn as complete before
+    // the negative assertions below — otherwise an error chunk arriving
+    // after partial text could slip past them.
+    await expect(transcript.getByRole("button", { name: "Retry" })).toBeVisible(
+      {
+        timeout: 30_000,
+      },
+    );
 
-  // Every ChatErrorMessage variant renders a "Resend" button
-  // (apps/web/src/components/chat/chat-thread-messages.tsx:329-340);
-  // zero of them means the turn ended without a stream error.
-  await expect(transcript.getByRole("button", { name: "Resend" })).toHaveCount(
-    0,
-  );
-  await expect(errorBoundary).toHaveCount(0);
-});
+    // Every ChatErrorMessage variant renders a "Resend" button
+    // (apps/web/src/components/chat/chat-thread-messages.tsx:329-340);
+    // zero of them means the turn ended without a stream error.
+    await expect(
+      transcript.getByRole("button", { name: "Resend" }),
+    ).toHaveCount(0);
+    await expect(errorBoundary).toHaveCount(0);
+  },
+);

--- a/apps/web/e2e/specs/dev-autocomplete.spec.ts
+++ b/apps/web/e2e/specs/dev-autocomplete.spec.ts
@@ -1,0 +1,27 @@
+import { expect, test } from "../helpers/test";
+
+// Local E2E runs normally target Vite. Production CI opts out explicitly so
+// this same spec proves the dev route cannot leak into the built app.
+const EXPECTS_DEV_ROUTES = process.env["E2E_EXPECT_DEV_ROUTES"] !== "false";
+
+test(
+  "autocomplete playground matches the web runtime mode",
+  {
+    tag: "@dev-canary",
+  },
+  async ({ page }) => {
+    await page.goto("/dev/autocomplete", { waitUntil: "commit" });
+
+    if (!EXPECTS_DEV_ROUTES) {
+      await expect(page).toHaveURL((url) => url.pathname === "/");
+      return;
+    }
+
+    await expect(page).toHaveURL(/\/dev\/autocomplete$/u);
+    await expect(
+      page.getByRole("heading", {
+        name: "stella autocomplete — dev playground",
+      }),
+    ).toBeVisible({ timeout: 30_000 });
+  },
+);

--- a/apps/web/e2e/specs/route-smoke.spec.ts
+++ b/apps/web/e2e/specs/route-smoke.spec.ts
@@ -24,10 +24,9 @@ import {
   deleteTestWorkspace,
 } from "../helpers/workspace";
 
-// A route is ready when tracked API activity stays quiet for this window.
-// This still captures delayed warmups while avoiding a fixed one-second tax
-// after routes that became idle immediately. Per-route settleMs remains the
-// maximum wait for unusually heavy document surfaces.
+// Every route retains the former one-second observation floor so delayed
+// warmups remain visible. After that floor, tracked API activity may finish
+// the longer document-route windows early once it stays quiet.
 const NETWORK_QUIET_MS = 500;
 const DEFAULT_SETTLE_MS = 1000;
 
@@ -479,6 +478,7 @@ const smokeRouteTarget = async ({
     await renderSmokeRoute({ page, route });
     await network.waitForQuiet({
       idleMs: NETWORK_QUIET_MS,
+      minimumObservationMs: DEFAULT_SETTLE_MS,
       timeoutMs: route.settleMs ?? DEFAULT_SETTLE_MS,
     });
     await assertNoRouteBoundary(page, route.template);

--- a/apps/web/e2e/specs/route-smoke.spec.ts
+++ b/apps/web/e2e/specs/route-smoke.spec.ts
@@ -13,23 +13,22 @@ import { apiDelete, apiGet, apiPut, apiUploadDocx } from "../helpers/api";
 import {
   type RouteNetworkMetrics,
   assertNetworkBaseline,
+  assertNetworkBaselineCoverage,
   createNetworkCollector,
   summarizeCapture,
 } from "../helpers/network";
-import {
-  type BrowserErrorCollector,
-  createBrowserErrorCollector,
-} from "../helpers/test";
+import { createBrowserErrorCollector } from "../helpers/test";
 import {
   type TestWorkspace,
   createTestWorkspace,
   deleteTestWorkspace,
 } from "../helpers/workspace";
 
-// Long enough that idle warmup requests (tool connectors, skills, usage
-// entitlement on chat routes) land inside the window deterministically; the
-// network baseline records them as part of the route's manifest instead of
-// racing them.
+// A route is ready when tracked API activity stays quiet for this window.
+// This still captures delayed warmups while avoiding a fixed one-second tax
+// after routes that became idle immediately. Per-route settleMs remains the
+// maximum wait for unusually heavy document surfaces.
+const NETWORK_QUIET_MS = 500;
 const DEFAULT_SETTLE_MS = 1000;
 
 // Repo-root .playwright/storage-state.json — mirrors apps/web/e2e/playwright.config.ts
@@ -237,103 +236,139 @@ const INTENTIONALLY_NOT_SMOKED = new Set([
   "/workspaces/$workspaceId/reports/$exportId",
 ]);
 
-// One serial group so the expensive workspace/contact/document setup runs once
-// and is shared across every route case. Each route is its own `test()` with
-// the config's per-test timeout: a single slow route (cold compile) or a
-// dev-server sub-resource stall now fails and is attributed to that one route
-// instead of consuming a single 300s budget shared by all ~45 routes.
-test.describe
-  .serial("authenticated routes render without browser errors", () => {
-  let apiRequest: APIRequestContext;
-  let context: BrowserContext;
-  let world: SmokeWorld | null = null;
-  // Recorded the moment each fixture is created (not only after the whole
-  // setup succeeds), so a failure mid-setup still tears down what exists.
-  let createdWorkspace: SmokeWorld["workspace"] | null = null;
-  let createdContactId: string | null = null;
-  const networkResults = new Map<string, RouteNetworkMetrics>();
+const declareRouteSmokeGroup = ({
+  defs,
+  name,
+  requireAllRoutes,
+}: {
+  defs: readonly SmokeRouteDef[];
+  name: string;
+  requireAllRoutes: boolean;
+}) => {
+  // Serial within one fixture-owning group; separate groups are independent
+  // Playwright scheduling units and can run on different workers or CI shards.
+  test.describe.serial(name, () => {
+    let apiRequest: APIRequestContext;
+    let context: BrowserContext;
+    let world: SmokeWorld | null = null;
+    // Recorded the moment each fixture is created (not only after the whole
+    // setup succeeds), so a failure mid-setup still tears down what exists.
+    let createdWorkspace: SmokeWorld["workspace"] | null = null;
+    let createdContactId: string | null = null;
+    const networkResults = new Map<string, RouteNetworkMetrics>();
 
-  test.beforeAll(async ({ browser }) => {
-    apiRequest = await apiRequestFactory.newContext({
-      storageState: STORAGE_STATE,
-    });
-    context = await browser.newContext({ storageState: STORAGE_STATE });
-
-    const workspace = await createTestWorkspace(apiRequest, "route-smoke");
-    createdWorkspace = workspace;
-    const contactId = await createContact(apiRequest);
-    createdContactId = contactId;
-    const documentRoute = await createDocumentRoute(apiRequest, workspace);
-    world = { workspace, contactId, documentRoute };
-  });
-
-  test.afterAll(async () => {
-    // Best-effort but total: attempt every teardown step even if one throws,
-    // so a single failure cannot strand the other fixture or leak the browser
-    // context / request context. Runs on the beforeAll-owned request context
-    // (not a per-test fixture), so it cannot race a timing-out test body into
-    // the "context closed" masking error.
-    const failures: unknown[] = [];
-    if (createdContactId !== null) {
-      try {
-        await apiDelete(apiRequest, `/contacts/${createdContactId}`);
-      } catch (error) {
-        failures.push(error);
-      }
-    }
-    if (createdWorkspace !== null) {
-      try {
-        await deleteTestWorkspace(apiRequest, createdWorkspace.id);
-      } catch (error) {
-        failures.push(error);
-      }
-    }
-    try {
-      await context.close();
-    } catch (error) {
-      failures.push(error);
-    }
-    try {
-      await apiRequest.dispose();
-    } catch (error) {
-      failures.push(error);
-    }
-    if (failures.length > 0) {
-      throw new AggregateError(
-        failures,
-        "route-smoke teardown failed to release one or more fixtures",
-      );
-    }
-  });
-
-  test("route coverage matches the authenticated route tree", async () => {
-    await expectAuthenticatedRouteCoverage(SMOKE_ROUTE_DEFS);
-  });
-
-  // Declared via a helper (not a closure literal inside the loop) so each
-  // parametrized `test()` is a plain call in the loop body. The shared
-  // context/world/results it closes over are group-scoped and assigned once in
-  // beforeAll.
-  const declareRouteTest = (def: SmokeRouteDef) => {
-    test(def.template, async () => {
-      if (world === null) {
-        throw new Error("route-smoke world was not initialized in beforeAll");
-      }
-      await smokeRoute({
-        context,
-        results: networkResults,
-        route: resolveRoute(def, world),
+    test.beforeAll(async ({ browser }) => {
+      apiRequest = await apiRequestFactory.newContext({
+        storageState: STORAGE_STATE,
       });
-    });
-  };
-  for (const def of SMOKE_ROUTE_DEFS) {
-    declareRouteTest(def);
-  }
+      context = await browser.newContext({ storageState: STORAGE_STATE });
 
-  test("network manifest matches the committed baseline", () => {
-    assertNetworkBaseline(networkResults);
+      const workspace = await createTestWorkspace(apiRequest, "route-smoke");
+      createdWorkspace = workspace;
+      const contactId = await createContact(apiRequest);
+      createdContactId = contactId;
+      const documentRoute = await createDocumentRoute(apiRequest, workspace);
+      world = { workspace, contactId, documentRoute };
+    });
+
+    test.afterAll(async () => {
+      // Best-effort but total: attempt every teardown step even if one throws,
+      // so a single failure cannot strand the other fixture or leak the browser
+      // context / request context. Runs on the beforeAll-owned request context
+      // (not a per-test fixture), so it cannot race a timing-out test body into
+      // the "context closed" masking error.
+      const failures: unknown[] = [];
+      if (createdContactId !== null) {
+        try {
+          await apiDelete(apiRequest, `/contacts/${createdContactId}`);
+        } catch (error) {
+          failures.push(error);
+        }
+      }
+      if (createdWorkspace !== null) {
+        try {
+          await deleteTestWorkspace(apiRequest, createdWorkspace.id);
+        } catch (error) {
+          failures.push(error);
+        }
+      }
+      try {
+        await context.close();
+      } catch (error) {
+        failures.push(error);
+      }
+      try {
+        await apiRequest.dispose();
+      } catch (error) {
+        failures.push(error);
+      }
+      if (failures.length > 0) {
+        throw new AggregateError(
+          failures,
+          "route-smoke teardown failed to release one or more fixtures",
+        );
+      }
+    });
+
+    // Declared via a helper (not a closure literal inside the loop) so each
+    // parametrized `test()` is a plain call in the loop body. The shared
+    // context/world/results it closes over are group-scoped and assigned once in
+    // beforeAll.
+    const declareRouteTest = (def: SmokeRouteDef) => {
+      test(def.template, async () => {
+        if (world === null) {
+          throw new Error("route-smoke world was not initialized in beforeAll");
+        }
+        await smokeRoute({
+          context,
+          results: networkResults,
+          route: resolveRoute(def, world),
+        });
+      });
+    };
+    for (const def of defs) {
+      declareRouteTest(def);
+    }
+
+    test("network manifest matches the committed baseline", () => {
+      assertNetworkBaseline(networkResults, { requireAllRoutes });
+    });
   });
+};
+
+test("route coverage matches the authenticated route tree", async () => {
+  await expectAuthenticatedRouteCoverage(SMOKE_ROUTE_DEFS);
+  assertNetworkBaselineCoverage(
+    SMOKE_ROUTE_DEFS.map((def) =>
+      def.expectation?.kind === "redirectsTo"
+        ? `${def.template} target`
+        : def.template,
+    ),
+  );
 });
+
+const baselineMode = process.env["E2E_NETWORK_BASELINE"];
+if (baselineMode === "write" || baselineMode === "rewrite") {
+  // Baseline writes need one complete result set and one writer. Normal checks
+  // use two groups below because each independently compares its observed
+  // routes against the same committed per-route budgets.
+  declareRouteSmokeGroup({
+    defs: SMOKE_ROUTE_DEFS,
+    name: "authenticated routes render without browser errors",
+    requireAllRoutes: true,
+  });
+} else {
+  const groups = [0, 1].map((groupIndex) =>
+    SMOKE_ROUTE_DEFS.filter((_, index) => index % 2 === groupIndex),
+  );
+  for (const [groupIndex, defs] of groups.entries()) {
+    declareRouteSmokeGroup({
+      defs,
+      name: `authenticated routes render without browser errors ${groupIndex + 1}/${groups.length}`,
+      requireAllRoutes: false,
+    });
+  }
+}
 
 const createContact = async (request: APIRequestContext): Promise<string> => {
   const contactId = randomUUID();
@@ -441,11 +476,17 @@ const smokeRouteTarget = async ({
   const detachNetwork = network.trackPage(page);
 
   try {
-    await renderSmokeRoute({ browserErrors, page, route });
-    // Captured right after the settle + assertions in renderSmokeRoute (its
-    // last step is browserErrors.assertEmpty), so the manifest reflects the
-    // fully-rendered route. Stored under the template it received; redirect
-    // targets already arrive as "<template> target".
+    await renderSmokeRoute({ page, route });
+    await network.waitForQuiet({
+      idleMs: NETWORK_QUIET_MS,
+      timeoutMs: route.settleMs ?? DEFAULT_SETTLE_MS,
+    });
+    await assertNoRouteBoundary(page, route.template);
+    assertFinalDestination(page, route);
+    browserErrors.assertEmpty(`unexpected browser errors on ${route.template}`);
+    // Captured after the route shell and tracked API work are ready, so the
+    // manifest reflects the fully-rendered route. Stored under the template
+    // it received; redirect targets arrive as "<template> target".
     results.set(route.template, summarizeCapture(await network.capture()));
   } finally {
     detachNetwork();
@@ -477,11 +518,9 @@ const assertRedirectRoute = async ({
 };
 
 const renderSmokeRoute = async ({
-  browserErrors,
   page,
   route,
 }: {
-  browserErrors: Pick<BrowserErrorCollector, "assertEmpty">;
   page: Page;
   route: SmokeRoute;
 }) => {
@@ -494,12 +533,6 @@ const renderSmokeRoute = async ({
   await expect(page.locator("main").first(), route.template).toBeVisible({
     timeout: 30_000,
   });
-
-  await page.waitForTimeout(route.settleMs ?? DEFAULT_SETTLE_MS);
-
-  await assertNoRouteBoundary(page, route.template);
-  assertFinalDestination(page, route);
-  browserErrors.assertEmpty(`unexpected browser errors on ${route.template}`);
 };
 
 // `goto` waits for DOMContentLoaded, which a render-blocking `<head>`

--- a/apps/web/e2e/specs/upload-docx.spec.ts
+++ b/apps/web/e2e/specs/upload-docx.spec.ts
@@ -73,104 +73,109 @@ test.describe("DOCX upload + inspector", () => {
     workspace = null;
   });
 
-  test("uploaded DOCX opens from the matter with its AI overlay", async ({
-    browserErrors,
-    page,
-    request,
-  }) => {
-    const testWorkspace = workspace;
-    if (testWorkspace === null) {
-      throw new Error("Test workspace was not created");
-    }
-
-    const docxBuffer = await readFile(DOCX_PATH);
-
-    const uploaded = await apiUploadDocx(
-      request,
-      testWorkspace.id,
-      testWorkspace.filePropertyId,
-      {
-        name: "stella-e2e.docx",
-        mimeType: DOCX_MIME,
-        buffer: docxBuffer,
-      },
-    );
-    expect(uploaded.entityId).toBeTruthy();
-
-    const { cookies } = await request.storageState();
-    await page.context().addCookies(cookies);
-
-    await expect
-      .poll(
-        async () =>
-          await apiStatus(page.request, `/workspaces/${testWorkspace.id}`),
-        {
-          message: "browser context can read the created workspace",
-          timeout: 10_000,
-        },
-      )
-      .toBe(200);
-
-    // Exercise the user path that originally exposed the route-context race:
-    // enter the matter first, then mount the cold lazy file-chat overlay by
-    // opening the file from the table. A direct document URL does not cover
-    // this client-side transition.
-    await page.goto(`/workspaces/${testWorkspace.id}/${testWorkspace.viewId}`, {
-      waitUntil: "domcontentloaded",
-    });
-
-    // New matters land on their Overview view. Move through the visible Table
-    // tab before opening the uploaded file so this remains a client-side user
-    // transition instead of falling back to a direct document URL.
-    const tableTab = page.getByRole("tab", { exact: true, name: "Table" });
-    await expect(tableTab).toBeVisible({ timeout: 30_000 });
-    await tableTab.click();
-
-    const fileButton = page.getByRole("button", {
-      exact: true,
-      name: "stella-e2e.docx",
-    });
-    await expect(fileButton).toBeVisible({ timeout: 30_000 });
-    await fileButton.click();
-
-    // Prove the optional overlay itself mounted; asserting only document text
-    // would pass if its local error boundary had silently removed the overlay.
-    await expect(
-      page.getByRole("toolbar", { name: "AI message composer" }),
-    ).toBeVisible({ timeout: 45_000 });
-
-    // Positive proof the viewer actually rendered: the fixture's first
-    // paragraph appears in the painted layout. This catches render crashes
-    // (an error boundary fallback wouldn't contain this string) without an
-    // arbitrary sleep. Generous timeout because in CI the Folio chunk
-    // compiles + loads cold AND the DOCX file is fetched from the API +
-    // parsed.
-    //
-    // Scope to `.layout-run-text` (emitted by the layout painter in
-    // packages/folio/src/core/layout-painter/renderParagraph.ts) rather
-    // than getByText so the assertion targets the *visible* painted span
-    // only. The hidden ProseMirror at left:-9999px also contains the same
-    // text inside a <p> under aria-label="Document content" — a bare
-    // getByText hits both elements and trips Playwright strict mode.
-    const docxText = page.locator(".layout-run-text", {
-      hasText: "Stella E2E test document.",
-    });
-    try {
-      await expect(docxText).toBeVisible({ timeout: 45_000 });
-    } catch (error) {
-      // Surface any errors collected so far — they're usually the real cause
-      // of the viewer never mounting (network failure, render crash caught
-      // by an error boundary, etc.).
-      const errors = browserErrors.entries();
-      if (errors.length > 0) {
-        throw new Error(
-          `viewer text never appeared; collected errors:\n${errors.join("\n\n")}`,
-          { cause: error },
-        );
+  test(
+    "uploaded DOCX opens from the matter with its AI overlay",
+    {
+      tag: "@dev-canary",
+    },
+    async ({ browserErrors, page, request }) => {
+      const testWorkspace = workspace;
+      if (testWorkspace === null) {
+        throw new Error("Test workspace was not created");
       }
-      throw error;
-    }
-  });
+
+      const docxBuffer = await readFile(DOCX_PATH);
+
+      const uploaded = await apiUploadDocx(
+        request,
+        testWorkspace.id,
+        testWorkspace.filePropertyId,
+        {
+          name: "stella-e2e.docx",
+          mimeType: DOCX_MIME,
+          buffer: docxBuffer,
+        },
+      );
+      expect(uploaded.entityId).toBeTruthy();
+
+      const { cookies } = await request.storageState();
+      await page.context().addCookies(cookies);
+
+      await expect
+        .poll(
+          async () =>
+            await apiStatus(page.request, `/workspaces/${testWorkspace.id}`),
+          {
+            message: "browser context can read the created workspace",
+            timeout: 10_000,
+          },
+        )
+        .toBe(200);
+
+      // Exercise the user path that originally exposed the route-context race:
+      // enter the matter first, then mount the cold lazy file-chat overlay by
+      // opening the file from the table. A direct document URL does not cover
+      // this client-side transition.
+      await page.goto(
+        `/workspaces/${testWorkspace.id}/${testWorkspace.viewId}`,
+        {
+          waitUntil: "domcontentloaded",
+        },
+      );
+
+      // New matters land on their Overview view. Move through the visible Table
+      // tab before opening the uploaded file so this remains a client-side user
+      // transition instead of falling back to a direct document URL.
+      const tableTab = page.getByRole("tab", { exact: true, name: "Table" });
+      await expect(tableTab).toBeVisible({ timeout: 30_000 });
+      await tableTab.click();
+
+      const fileButton = page.getByRole("button", {
+        exact: true,
+        name: "stella-e2e.docx",
+      });
+      await expect(fileButton).toBeVisible({ timeout: 30_000 });
+      await fileButton.click();
+
+      // Prove the optional overlay itself mounted; asserting only document text
+      // would pass if its local error boundary had silently removed the overlay.
+      await expect(
+        page.getByRole("toolbar", { name: "AI message composer" }),
+      ).toBeVisible({ timeout: 45_000 });
+
+      // Positive proof the viewer actually rendered: the fixture's first
+      // paragraph appears in the painted layout. This catches render crashes
+      // (an error boundary fallback wouldn't contain this string) without an
+      // arbitrary sleep. Generous timeout because in CI the Folio chunk
+      // compiles + loads cold AND the DOCX file is fetched from the API +
+      // parsed.
+      //
+      // Scope to `.layout-run-text` (emitted by the layout painter in
+      // packages/folio/src/core/layout-painter/renderParagraph.ts) rather
+      // than getByText so the assertion targets the *visible* painted span
+      // only. The hidden ProseMirror at left:-9999px also contains the same
+      // text inside a <p> under aria-label="Document content" — a bare
+      // getByText hits both elements and trips Playwright strict mode.
+      const docxText = page.locator(".layout-run-text", {
+        hasText: "Stella E2E test document.",
+      });
+      try {
+        await expect(docxText).toBeVisible({ timeout: 45_000 });
+      } catch (error) {
+        // Surface any errors collected so far — they're usually the real cause
+        // of the viewer never mounting (network failure, render crash caught
+        // by an error boundary, etc.).
+        const errors = browserErrors.entries();
+        if (errors.length > 0) {
+          throw new Error(
+            `viewer text never appeared; collected errors:\n${errors.join("\n\n")}`,
+            { cause: error },
+          );
+        }
+        throw error;
+      }
+    },
+  );
 
   test("browser edit save creates a persisted DOCX version with the typed text", async ({
     page,

--- a/apps/web/e2e/tsconfig.json
+++ b/apps/web/e2e/tsconfig.json
@@ -5,5 +5,5 @@
     "tsBuildInfoFile": "./.cache/tsbuildinfo.json"
   },
   "include": ["**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "unit"]
 }

--- a/apps/web/e2e/unit/network-metrics.test.ts
+++ b/apps/web/e2e/unit/network-metrics.test.ts
@@ -1,6 +1,6 @@
 // Pure-logic tests for the network baseline metrics. These never open a page,
 // so they launch no browser and need no dev server or storageState.
-import { expect, test } from "@playwright/test";
+import { describe, expect, test } from "bun:test";
 
 import {
   type NetworkBaseline,
@@ -9,13 +9,14 @@ import {
   mergeNetworkBaseline,
   normalizeApiPath,
   responseSizeAllowance,
+  waitForQuietPeriod,
   waterfallDepth,
 } from "../helpers/network";
 
 const UUID = "11111111-2222-4333-8444-555555555555";
 const UUID_UPPER = "AAAAAAAA-BBBB-4CCC-8DDD-EEEEEEEEEEEE";
 
-test.describe("normalizeApiPath", () => {
+describe("normalizeApiPath", () => {
   test("leaves a plain path untouched", () => {
     expect(normalizeApiPath("/v1/contacts")).toBe("/v1/contacts");
   });
@@ -35,7 +36,7 @@ test.describe("normalizeApiPath", () => {
   });
 });
 
-test.describe("waterfallDepth", () => {
+describe("waterfallDepth", () => {
   test("empty input is 0", () => {
     expect(waterfallDepth([])).toBe(0);
   });
@@ -94,6 +95,62 @@ test.describe("waterfallDepth", () => {
   });
 });
 
+describe("waitForQuietPeriod", () => {
+  test("returns after one idle window when no activity arrives", async () => {
+    let current = 100;
+    const result = await waitForQuietPeriod({
+      getLastActivityAt: () => 0,
+      idleMs: 500,
+      timeoutMs: 1000,
+      now: () => current,
+      sleep: async (durationMs) => {
+        current += durationMs;
+      },
+    });
+
+    expect(result).toBe("idle");
+    expect(current).toBe(600);
+  });
+
+  test("restarts the idle window when new activity arrives", async () => {
+    let current = 0;
+    let lastActivityAt = 0;
+    const result = await waitForQuietPeriod({
+      getLastActivityAt: () => lastActivityAt,
+      idleMs: 500,
+      timeoutMs: 2000,
+      now: () => current,
+      sleep: async (durationMs) => {
+        current += durationMs;
+        if (current === 500) {
+          lastActivityAt = 400;
+        }
+      },
+    });
+
+    expect(result).toBe("idle");
+    expect(current).toBe(900);
+  });
+
+  test("caps a route that never becomes quiet", async () => {
+    let current = 0;
+    let lastActivityAt = 0;
+    const result = await waitForQuietPeriod({
+      getLastActivityAt: () => lastActivityAt,
+      idleMs: 500,
+      timeoutMs: 1000,
+      now: () => current,
+      sleep: async (durationMs) => {
+        current += durationMs;
+        lastActivityAt = current;
+      },
+    });
+
+    expect(result).toBe("timeout");
+    expect(current).toBe(1000);
+  });
+});
+
 const metrics = (
   requests: string[],
   depth: number,
@@ -114,7 +171,7 @@ const metrics = (
   missingResponseSizeCounts,
 });
 
-test.describe("diffNetworkBaseline", () => {
+describe("diffNetworkBaseline", () => {
   const baseline: NetworkBaseline = {
     "/contacts": { depth: 2, requests: ["GET /v1/contacts"] },
   };
@@ -215,6 +272,13 @@ test.describe("diffNetworkBaseline", () => {
   test("a stale baseline entry is a problem", () => {
     const { problems } = diffNetworkBaseline(baseline, new Map());
     expect(problems.some((p) => p.includes("Stale"))).toBe(true);
+  });
+
+  test("a shard checks only the routes it observed", () => {
+    const { problems } = diffNetworkBaseline(baseline, new Map(), {
+      requireAllRoutes: false,
+    });
+    expect(problems).toEqual([]);
   });
 
   test("a missing request is a notice, not a problem", () => {
@@ -438,7 +502,7 @@ test.describe("diffNetworkBaseline", () => {
   });
 });
 
-test.describe("mergeNetworkBaseline", () => {
+describe("mergeNetworkBaseline", () => {
   test("no existing baseline yields a snapshot", () => {
     const merged = mergeNetworkBaseline(
       null,

--- a/apps/web/e2e/unit/network-metrics.test.ts
+++ b/apps/web/e2e/unit/network-metrics.test.ts
@@ -96,11 +96,12 @@ describe("waterfallDepth", () => {
 });
 
 describe("waitForQuietPeriod", () => {
-  test("returns after one idle window when no activity arrives", async () => {
+  test("observes the minimum window before returning idle", async () => {
     let current = 100;
     const result = await waitForQuietPeriod({
       getLastActivityAt: () => 0,
       idleMs: 500,
+      minimumObservationMs: 1000,
       timeoutMs: 1000,
       now: () => current,
       sleep: async (durationMs) => {
@@ -109,7 +110,7 @@ describe("waitForQuietPeriod", () => {
     });
 
     expect(result).toBe("idle");
-    expect(current).toBe(600);
+    expect(current).toBe(1100);
   });
 
   test("restarts the idle window when new activity arrives", async () => {
@@ -118,18 +119,19 @@ describe("waitForQuietPeriod", () => {
     const result = await waitForQuietPeriod({
       getLastActivityAt: () => lastActivityAt,
       idleMs: 500,
+      minimumObservationMs: 1000,
       timeoutMs: 2000,
       now: () => current,
       sleep: async (durationMs) => {
         current += durationMs;
-        if (current === 500) {
-          lastActivityAt = 400;
+        if (current === 1000) {
+          lastActivityAt = 800;
         }
       },
     });
 
     expect(result).toBe("idle");
-    expect(current).toBe(900);
+    expect(current).toBe(1300);
   });
 
   test("caps a route that never becomes quiet", async () => {
@@ -138,6 +140,7 @@ describe("waitForQuietPeriod", () => {
     const result = await waitForQuietPeriod({
       getLastActivityAt: () => lastActivityAt,
       idleMs: 500,
+      minimumObservationMs: 1000,
       timeoutMs: 1000,
       now: () => current,
       sleep: async (durationMs) => {

--- a/apps/web/e2e/unit/tsconfig.json
+++ b/apps/web/e2e/unit/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../../../packages/typescript-config/base.json",
+  "compilerOptions": {
+    "types": ["bun", "node"],
+    "tsBuildInfoFile": "./.cache/tsbuildinfo.json"
+  },
+  "include": ["**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -17,7 +17,7 @@
     "format": "oxfmt -c ../../.oxfmtrc.json .",
     "i18n:check": "bun ../../packages/scripts/src/i18n-typegen.ts src/i18n/langs --check && bun ../../packages/scripts/src/i18n-check.ts src/i18n/langs && bun ../../packages/scripts/src/glossary-gen.ts src/i18n --check && bun ../../packages/scripts/src/i18n-lint.ts src/i18n/langs",
     "i18n:sync": "bun ../../packages/scripts/src/i18n-check.ts src/i18n/langs --sync && bun ../../packages/scripts/src/i18n-typegen.ts src/i18n/langs && bun ../../packages/scripts/src/glossary-gen.ts src/i18n",
-    "test": "bun test --path-ignore-patterns='e2e/**'",
+    "test": "bun test --path-ignore-patterns='e2e/**' && bun test e2e/unit",
     "test:e2e": "playwright test --config e2e/playwright.config.ts",
     "test:e2e:marketing": "playwright test --config e2e/playwright.marketing.config.ts --project app",
     "test:e2e:marketing:update": "playwright test --config e2e/playwright.marketing.config.ts --project app --update-snapshots",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,7 +11,7 @@
     "clean": "git clean -xdf .cache .turbo node_modules",
     "typegen": "bun ../../packages/scripts/src/i18n-typegen.ts src/i18n/langs",
     "glossary": "bun ../../packages/scripts/src/glossary-gen.ts src/i18n",
-    "typecheck": "bun ../../packages/scripts/src/tsc-native.ts --noEmit && bun ../../packages/scripts/src/tsc-native.ts --noEmit -p e2e/tsconfig.json",
+    "typecheck": "bun ../../packages/scripts/src/tsc-native.ts --noEmit && bun ../../packages/scripts/src/tsc-native.ts --noEmit -p e2e/tsconfig.json && bun ../../packages/scripts/src/tsc-native.ts --noEmit -p e2e/unit/tsconfig.json",
     "lint": "cd ../.. && bun --bun oxlint -c oxlint.config.ts --report-unused-disable-directives-severity=error --deny-warnings --type-aware apps/web",
     "lint:fix": "cd ../.. && bun --bun oxlint -c oxlint.config.ts --type-aware --fix apps/web",
     "format": "oxfmt -c ../../.oxfmtrc.json .",

--- a/scripts/detect-e2e-changes.sh
+++ b/scripts/detect-e2e-changes.sh
@@ -24,7 +24,7 @@ for file in "$@"; do
       echo true
       exit 0
       ;;
-    landing:apps/landing/*|landing:apps/web/e2e/marketing/landing-*.spec.ts|landing:apps/web/e2e/playwright.marketing.config.ts|landing:packages/ui/*|landing:packages/anonymize-*|landing:packages/locales/*)
+    landing:apps/landing/*|landing:apps/web/package.json|landing:apps/web/e2e/marketing/landing-*.spec.ts|landing:apps/web/e2e/playwright.marketing.config.ts|landing:packages/ui/*|landing:packages/anonymize-*|landing:packages/locales/*)
       echo true
       exit 0
       ;;

--- a/scripts/detect-e2e-changes.sh
+++ b/scripts/detect-e2e-changes.sh
@@ -22,6 +22,8 @@ for file in "$@"; do
       ;;
     marketing:apps/api/src/*.test.*|marketing:apps/api/src/*.spec.*|marketing:apps/web/src/*.test.*|marketing:apps/web/src/*.spec.*|marketing:packages/*.test.*|marketing:packages/*.spec.*)
       ;;
+    marketing:apps/web/e2e/marketing/landing-*.spec.ts)
+      ;;
     core:apps/api/*|core:apps/web/*|core:packages/*|core:docker-compose.yml)
       echo true
       exit 0
@@ -30,7 +32,7 @@ for file in "$@"; do
       echo true
       exit 0
       ;;
-    landing:apps/landing/*|landing:packages/ui/*|landing:packages/anonymize-*|landing:packages/locales/*)
+    landing:apps/landing/*|landing:apps/web/e2e/marketing/landing-*.spec.ts|landing:apps/web/e2e/playwright.marketing.config.ts|landing:packages/ui/*|landing:packages/anonymize-*|landing:packages/locales/*)
       echo true
       exit 0
       ;;

--- a/scripts/detect-e2e-changes.sh
+++ b/scripts/detect-e2e-changes.sh
@@ -20,11 +20,13 @@ for file in "$@"; do
   case "$scope:$file" in
     core:apps/web/e2e/marketing/*|core:apps/web/e2e/playwright.marketing.config.ts)
       ;;
+    marketing:apps/api/src/*.test.*|marketing:apps/api/src/*.spec.*|marketing:apps/web/src/*.test.*|marketing:apps/web/src/*.spec.*|marketing:packages/*.test.*|marketing:packages/*.spec.*)
+      ;;
     core:apps/api/*|core:apps/web/*|core:packages/*|core:docker-compose.yml)
       echo true
       exit 0
       ;;
-    marketing:apps/web/e2e/marketing/*|marketing:apps/web/e2e/playwright.marketing.config.ts|marketing:apps/api/scripts/seed-dev.ts|marketing:apps/api/scripts/seed-templates.ts|marketing:apps/api/scripts/seed-test-user.ts|marketing:apps/web/src/components/*|marketing:apps/web/src/features/case-law/*|marketing:apps/web/src/features/chat/*|marketing:apps/web/src/i18n/*|marketing:apps/web/src/lib/knowledge/*|marketing:apps/web/src/routes/_protected.chat*|marketing:apps/web/src/routes/_protected.knowledge*|marketing:apps/web/src/routes/_protected.workspaces*|marketing:apps/web/src/routes/law*|marketing:apps/web/src/routes/__root.tsx|marketing:apps/web/src/fonts.css|marketing:apps/web/public/dark-mode-init.js|marketing:packages/docx-utils/*|marketing:packages/locales/*|marketing:packages/ui/*|marketing:apps/landing/public/media/products/*.png)
+    marketing:apps/web/e2e/marketing/*|marketing:apps/web/e2e/playwright.marketing.config.ts|marketing:apps/api/src/*|marketing:apps/api/scripts/seed-dev.ts|marketing:apps/api/scripts/seed-templates.ts|marketing:apps/api/scripts/seed-test-user.ts|marketing:apps/api/.env.example|marketing:apps/api/package.json|marketing:apps/web/src/*|marketing:apps/web/public/*|marketing:apps/web/.env.example|marketing:apps/web/index.html|marketing:apps/web/package.json|marketing:apps/web/vite.config.*|marketing:packages/*|marketing:apps/landing/public/media/products/*.png)
       echo true
       exit 0
       ;;

--- a/scripts/detect-e2e-changes.sh
+++ b/scripts/detect-e2e-changes.sh
@@ -4,8 +4,8 @@ set -euo pipefail
 scope=${1:-}
 shift || true
 
-if [[ "$scope" != "core" && "$scope" != "marketing" && "$scope" != "landing" ]]; then
-  echo "usage: $0 <core|marketing|landing> [changed-file ...]" >&2
+if [[ "$scope" != "core" && "$scope" != "landing" ]]; then
+  echo "usage: $0 <core|landing> [changed-file ...]" >&2
   exit 2
 fi
 
@@ -20,15 +20,7 @@ for file in "$@"; do
   case "$scope:$file" in
     core:apps/web/e2e/marketing/*|core:apps/web/e2e/playwright.marketing.config.ts)
       ;;
-    marketing:apps/api/scripts/*.test.*|marketing:apps/api/scripts/*.spec.*|marketing:apps/api/src/*.test.*|marketing:apps/api/src/*.spec.*|marketing:apps/web/src/*.test.*|marketing:apps/web/src/*.spec.*|marketing:packages/*.test.*|marketing:packages/*.spec.*)
-      ;;
-    marketing:apps/web/e2e/marketing/landing-*.spec.ts)
-      ;;
     core:apps/api/*|core:apps/web/*|core:packages/*|core:docker-compose.yml)
-      echo true
-      exit 0
-      ;;
-    marketing:apps/web/e2e/marketing/*|marketing:apps/web/e2e/playwright.marketing.config.ts|marketing:apps/api/src/*|marketing:apps/api/scripts/*|marketing:apps/api/.env.example|marketing:apps/api/package.json|marketing:apps/web/src/*|marketing:apps/web/public/*|marketing:apps/web/.env.example|marketing:apps/web/index.html|marketing:apps/web/package.json|marketing:apps/web/vite.config.*|marketing:packages/*|marketing:apps/landing/public/media/products/*.png)
       echo true
       exit 0
       ;;

--- a/scripts/detect-e2e-changes.sh
+++ b/scripts/detect-e2e-changes.sh
@@ -20,7 +20,7 @@ for file in "$@"; do
   case "$scope:$file" in
     core:apps/web/e2e/marketing/*|core:apps/web/e2e/playwright.marketing.config.ts)
       ;;
-    marketing:apps/api/src/*.test.*|marketing:apps/api/src/*.spec.*|marketing:apps/web/src/*.test.*|marketing:apps/web/src/*.spec.*|marketing:packages/*.test.*|marketing:packages/*.spec.*)
+    marketing:apps/api/scripts/*.test.*|marketing:apps/api/scripts/*.spec.*|marketing:apps/api/src/*.test.*|marketing:apps/api/src/*.spec.*|marketing:apps/web/src/*.test.*|marketing:apps/web/src/*.spec.*|marketing:packages/*.test.*|marketing:packages/*.spec.*)
       ;;
     marketing:apps/web/e2e/marketing/landing-*.spec.ts)
       ;;
@@ -28,7 +28,7 @@ for file in "$@"; do
       echo true
       exit 0
       ;;
-    marketing:apps/web/e2e/marketing/*|marketing:apps/web/e2e/playwright.marketing.config.ts|marketing:apps/api/src/*|marketing:apps/api/scripts/seed-dev.ts|marketing:apps/api/scripts/seed-templates.ts|marketing:apps/api/scripts/seed-test-user.ts|marketing:apps/api/.env.example|marketing:apps/api/package.json|marketing:apps/web/src/*|marketing:apps/web/public/*|marketing:apps/web/.env.example|marketing:apps/web/index.html|marketing:apps/web/package.json|marketing:apps/web/vite.config.*|marketing:packages/*|marketing:apps/landing/public/media/products/*.png)
+    marketing:apps/web/e2e/marketing/*|marketing:apps/web/e2e/playwright.marketing.config.ts|marketing:apps/api/src/*|marketing:apps/api/scripts/*|marketing:apps/api/.env.example|marketing:apps/api/package.json|marketing:apps/web/src/*|marketing:apps/web/public/*|marketing:apps/web/.env.example|marketing:apps/web/index.html|marketing:apps/web/package.json|marketing:apps/web/vite.config.*|marketing:packages/*|marketing:apps/landing/public/media/products/*.png)
       echo true
       exit 0
       ;;

--- a/scripts/detect-e2e-changes.sh
+++ b/scripts/detect-e2e-changes.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+scope=${1:-}
+shift || true
+
+if [[ "$scope" != "core" && "$scope" != "marketing" && "$scope" != "landing" ]]; then
+  echo "usage: $0 <core|marketing|landing> [changed-file ...]" >&2
+  exit 2
+fi
+
+for file in "$@"; do
+  case "$file" in
+    .github/workflows/ci.yml|scripts/detect-e2e-changes.sh|bun.lock|package.json|patches/*)
+      echo true
+      exit 0
+      ;;
+  esac
+
+  case "$scope:$file" in
+    core:apps/web/e2e/marketing/*|core:apps/web/e2e/playwright.marketing.config.ts)
+      ;;
+    core:apps/api/*|core:apps/web/*|core:packages/*|core:docker-compose.yml)
+      echo true
+      exit 0
+      ;;
+    marketing:apps/web/e2e/marketing/*|marketing:apps/web/e2e/playwright.marketing.config.ts|marketing:apps/api/scripts/seed-dev.ts|marketing:apps/api/scripts/seed-templates.ts|marketing:apps/api/scripts/seed-test-user.ts|marketing:apps/web/src/components/*|marketing:apps/web/src/features/case-law/*|marketing:apps/web/src/features/chat/*|marketing:apps/web/src/i18n/*|marketing:apps/web/src/lib/knowledge/*|marketing:apps/web/src/routes/_protected.chat*|marketing:apps/web/src/routes/_protected.knowledge*|marketing:apps/web/src/routes/_protected.workspaces*|marketing:apps/web/src/routes/law*|marketing:apps/web/src/routes/__root.tsx|marketing:apps/web/src/fonts.css|marketing:apps/web/public/dark-mode-init.js|marketing:packages/docx-utils/*|marketing:packages/locales/*|marketing:packages/ui/*|marketing:apps/landing/public/media/products/*.png)
+      echo true
+      exit 0
+      ;;
+    landing:apps/landing/*|landing:packages/ui/*|landing:packages/anonymize-*|landing:packages/locales/*)
+      echo true
+      exit 0
+      ;;
+  esac
+done
+
+echo false

--- a/scripts/detect-e2e-changes.test.ts
+++ b/scripts/detect-e2e-changes.test.ts
@@ -27,6 +27,9 @@ describe("detect-e2e-changes", () => {
   test("covers the complete screenshot runtime dependency surface", () => {
     for (const file of [
       "apps/api/src/handlers/case-law/decisions/get.ts",
+      "apps/api/scripts/seed-case-law.ts",
+      "apps/api/scripts/seed-utils.ts",
+      "apps/api/scripts/__fixtures__/case-law/cz-us.json",
       "apps/web/src/app-providers.tsx",
       "packages/workspace-ui/src/workspace.tsx",
     ]) {
@@ -38,6 +41,8 @@ describe("detect-e2e-changes", () => {
 
   test("test-only product files do not trigger marketing screenshots", () => {
     for (const file of [
+      "apps/api/scripts/seed-dev.test.ts",
+      "apps/api/scripts/__fixtures__/case-law/eu-ecj.test.ts",
       "apps/api/src/handlers/tasks/get.test.ts",
       "apps/web/src/features/tasks/task-list.spec.tsx",
     ]) {

--- a/scripts/detect-e2e-changes.test.ts
+++ b/scripts/detect-e2e-changes.test.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 
 const script = path.join(import.meta.dirname, "detect-e2e-changes.sh");
 
-const detects = (scope: "core" | "landing" | "marketing", files: string[]) =>
+const detects = (scope: "core" | "landing", files: string[]) =>
   Bun.spawnSync(["bash", script, scope, ...files], {
     stdout: "pipe",
   })
@@ -13,49 +13,18 @@ const detects = (scope: "core" | "landing" | "marketing", files: string[]) =>
 describe("detect-e2e-changes", () => {
   test("skips documentation-only changes", () => {
     expect(detects("core", ["README.md"])).toBe("false");
-    expect(detects("marketing", ["README.md"])).toBe("false");
     expect(detects("landing", ["README.md"])).toBe("false");
   });
 
-  test("runs product-code changes through core and marketing", () => {
+  test("runs product-code changes through core", () => {
     const files = ["apps/api/src/handlers/tasks/get.ts"];
     expect(detects("core", files)).toBe("true");
-    expect(detects("marketing", files)).toBe("true");
     expect(detects("landing", files)).toBe("false");
   });
 
-  test("covers the complete screenshot runtime dependency surface", () => {
-    for (const file of [
-      "apps/api/src/handlers/case-law/decisions/get.ts",
-      "apps/api/scripts/seed-case-law.ts",
-      "apps/api/scripts/seed-utils.ts",
-      "apps/api/scripts/__fixtures__/case-law/cz-us.json",
-      "apps/web/src/app-providers.tsx",
-      "packages/workspace-ui/src/workspace.tsx",
-    ]) {
-      expect(detects("core", [file])).toBe("true");
-      expect(detects("marketing", [file])).toBe("true");
-      expect(detects("landing", [file])).toBe("false");
-    }
-  });
-
-  test("test-only product files do not trigger marketing screenshots", () => {
-    for (const file of [
-      "apps/api/scripts/seed-dev.test.ts",
-      "apps/api/scripts/__fixtures__/case-law/eu-ecj.test.ts",
-      "apps/api/src/handlers/tasks/get.test.ts",
-      "apps/web/src/features/tasks/task-list.spec.tsx",
-    ]) {
-      expect(detects("core", [file])).toBe("true");
-      expect(detects("marketing", [file])).toBe("false");
-      expect(detects("landing", [file])).toBe("false");
-    }
-  });
-
-  test("a marketing-test-only change skips the broad app suite", () => {
+  test("a marketing-test-only change waits for the nightly suite", () => {
     const files = ["apps/web/e2e/marketing/product-screenshots.spec.ts"];
     expect(detects("core", files)).toBe("false");
-    expect(detects("marketing", files)).toBe("true");
     expect(detects("landing", files)).toBe("false");
   });
 
@@ -65,22 +34,19 @@ describe("detect-e2e-changes", () => {
       "apps/web/e2e/marketing/landing-navigation.spec.ts",
     ]) {
       expect(detects("core", [file])).toBe("false");
-      expect(detects("marketing", [file])).toBe("false");
       expect(detects("landing", [file])).toBe("true");
     }
   });
 
-  test("the shared marketing config exercises both projects", () => {
+  test("the shared marketing config exercises the landing project", () => {
     const files = ["apps/web/e2e/playwright.marketing.config.ts"];
     expect(detects("core", files)).toBe("false");
-    expect(detects("marketing", files)).toBe("true");
     expect(detects("landing", files)).toBe("true");
   });
 
-  test("runs every scope when its orchestration changes", () => {
+  test("runs both PR scopes when their orchestration changes", () => {
     const files = [".github/workflows/ci.yml"];
     expect(detects("core", files)).toBe("true");
-    expect(detects("marketing", files)).toBe("true");
     expect(detects("landing", files)).toBe("true");
   });
 });

--- a/scripts/detect-e2e-changes.test.ts
+++ b/scripts/detect-e2e-changes.test.ts
@@ -55,9 +55,20 @@ describe("detect-e2e-changes", () => {
   });
 
   test("keeps a landing-only change out of app E2E", () => {
-    const files = ["apps/landing/src/pages/index.astro"];
+    for (const file of [
+      "apps/landing/src/pages/index.astro",
+      "apps/web/e2e/marketing/landing-navigation.spec.ts",
+    ]) {
+      expect(detects("core", [file])).toBe("false");
+      expect(detects("marketing", [file])).toBe("false");
+      expect(detects("landing", [file])).toBe("true");
+    }
+  });
+
+  test("the shared marketing config exercises both projects", () => {
+    const files = ["apps/web/e2e/playwright.marketing.config.ts"];
     expect(detects("core", files)).toBe("false");
-    expect(detects("marketing", files)).toBe("false");
+    expect(detects("marketing", files)).toBe("true");
     expect(detects("landing", files)).toBe("true");
   });
 

--- a/scripts/detect-e2e-changes.test.ts
+++ b/scripts/detect-e2e-changes.test.ts
@@ -44,6 +44,12 @@ describe("detect-e2e-changes", () => {
     expect(detects("landing", files)).toBe("true");
   });
 
+  test("the web package manifest exercises its core and landing commands", () => {
+    const files = ["apps/web/package.json"];
+    expect(detects("core", files)).toBe("true");
+    expect(detects("landing", files)).toBe("true");
+  });
+
   test("runs both PR scopes when their orchestration changes", () => {
     const files = [".github/workflows/ci.yml"];
     expect(detects("core", files)).toBe("true");

--- a/scripts/detect-e2e-changes.test.ts
+++ b/scripts/detect-e2e-changes.test.ts
@@ -17,21 +17,32 @@ describe("detect-e2e-changes", () => {
     expect(detects("landing", ["README.md"])).toBe("false");
   });
 
-  test("keeps an ordinary API change out of marketing and landing", () => {
+  test("runs product-code changes through core and marketing", () => {
     const files = ["apps/api/src/handlers/tasks/get.ts"];
     expect(detects("core", files)).toBe("true");
-    expect(detects("marketing", files)).toBe("false");
+    expect(detects("marketing", files)).toBe("true");
     expect(detects("landing", files)).toBe("false");
   });
 
-  test("runs marketing only for declared screenshot inputs", () => {
+  test("covers the complete screenshot runtime dependency surface", () => {
     for (const file of [
-      "apps/web/src/routes/_protected.chat/index.tsx",
-      "apps/web/src/features/case-law/components/case-viewer.tsx",
-      "apps/web/src/i18n/langs/fr.json",
+      "apps/api/src/handlers/case-law/decisions/get.ts",
+      "apps/web/src/app-providers.tsx",
+      "packages/workspace-ui/src/workspace.tsx",
     ]) {
       expect(detects("core", [file])).toBe("true");
       expect(detects("marketing", [file])).toBe("true");
+      expect(detects("landing", [file])).toBe("false");
+    }
+  });
+
+  test("test-only product files do not trigger marketing screenshots", () => {
+    for (const file of [
+      "apps/api/src/handlers/tasks/get.test.ts",
+      "apps/web/src/features/tasks/task-list.spec.tsx",
+    ]) {
+      expect(detects("core", [file])).toBe("true");
+      expect(detects("marketing", [file])).toBe("false");
       expect(detects("landing", [file])).toBe("false");
     }
   });

--- a/scripts/detect-e2e-changes.test.ts
+++ b/scripts/detect-e2e-changes.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "bun:test";
+import path from "node:path";
+
+const script = path.join(import.meta.dirname, "detect-e2e-changes.sh");
+
+const detects = (scope: "core" | "landing" | "marketing", files: string[]) =>
+  Bun.spawnSync(["bash", script, scope, ...files], {
+    stdout: "pipe",
+  })
+    .stdout.toString()
+    .trim();
+
+describe("detect-e2e-changes", () => {
+  test("skips documentation-only changes", () => {
+    expect(detects("core", ["README.md"])).toBe("false");
+    expect(detects("marketing", ["README.md"])).toBe("false");
+    expect(detects("landing", ["README.md"])).toBe("false");
+  });
+
+  test("keeps an ordinary API change out of marketing and landing", () => {
+    const files = ["apps/api/src/handlers/tasks/get.ts"];
+    expect(detects("core", files)).toBe("true");
+    expect(detects("marketing", files)).toBe("false");
+    expect(detects("landing", files)).toBe("false");
+  });
+
+  test("runs marketing only for declared screenshot inputs", () => {
+    for (const file of [
+      "apps/web/src/routes/_protected.chat/index.tsx",
+      "apps/web/src/features/case-law/components/case-viewer.tsx",
+      "apps/web/src/i18n/langs/fr.json",
+    ]) {
+      expect(detects("core", [file])).toBe("true");
+      expect(detects("marketing", [file])).toBe("true");
+      expect(detects("landing", [file])).toBe("false");
+    }
+  });
+
+  test("a marketing-test-only change skips the broad app suite", () => {
+    const files = ["apps/web/e2e/marketing/product-screenshots.spec.ts"];
+    expect(detects("core", files)).toBe("false");
+    expect(detects("marketing", files)).toBe("true");
+    expect(detects("landing", files)).toBe("false");
+  });
+
+  test("keeps a landing-only change out of app E2E", () => {
+    const files = ["apps/landing/src/pages/index.astro"];
+    expect(detects("core", files)).toBe("false");
+    expect(detects("marketing", files)).toBe("false");
+    expect(detects("landing", files)).toBe("true");
+  });
+
+  test("runs every scope when its orchestration changes", () => {
+    const files = [".github/workflows/ci.yml"];
+    expect(detects("core", files)).toBe("true");
+    expect(detects("marketing", files)).toBe("true");
+    expect(detects("landing", files)).toBe("true");
+  });
+});


### PR DESCRIPTION
## Summary

- run the broad app browser suite against a production build and split it across two isolated shards
- retain Vite dependency coverage with a three-test development canary
- move seeded marketing screenshot checks from the PR critical path to the nightly full-test workflow
- gate landing checks independently
- replace fixed route delays with bounded network quiescence while preserving the one-second observation floor
- move pure network metrics to Bun tests and merge Playwright blob reports only when a shard fails
- migrate two route budgets from the former Vite runtime to the production runtime: the added requests are existing app behavior with existing query and response-size budgets

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved end-to-end test reliability by waiting for network activity to settle before validating pages.
  - Added checks to ensure expected application routes are covered by smoke tests.
  - Expanded performance baselines for chat, skills, and account session requests.

- **Testing**
  - Core and landing-page checks now run independently and in parallel where applicable.
  - Added nightly marketing screenshot coverage and improved failure diagnostics.
  - Enhanced test reporting, result aggregation, and validation of changed areas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->