### PR TITLE
fix: remove repaired redactions from search

### DIFF
--- a/apps/api/drizzle/20260801130000_case_law_redaction_projection_fence/migration.sql
+++ b/apps/api/drizzle/20260801130000_case_law_redaction_projection_fence/migration.sql
@@ -13,7 +13,7 @@ BEGIN
   FROM "case_law_decisions"
   WHERE "id" = NEW."decision_id"
     AND "redacted_at" IS NULL
-  FOR KEY SHARE;
+  FOR SHARE;
 
   IF NOT FOUND THEN
     RAISE EXCEPTION 'cannot write a search projection for a redacted case-law decision'

--- a/apps/api/drizzle/20260801130000_case_law_redaction_projection_fence/migration.sql
+++ b/apps/api/drizzle/20260801130000_case_law_redaction_projection_fence/migration.sql
@@ -1,0 +1,32 @@
+SET lock_timeout = '1s';--> statement-breakpoint
+SET statement_timeout = '5s';--> statement-breakpoint
+
+-- Every projection writer shares a row lock with redaction. A writer that
+-- started from a stale read therefore either finishes before redaction deletes
+-- its projection, or observes the committed tombstone and is rejected.
+CREATE OR REPLACE FUNCTION fence_redacted_case_law_search_projection()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $function$
+BEGIN
+  PERFORM 1
+  FROM "case_law_decisions"
+  WHERE "id" = NEW."decision_id"
+    AND "redacted_at" IS NULL
+  FOR KEY SHARE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'cannot write a search projection for a redacted case-law decision'
+      USING ERRCODE = 'check_violation';
+  END IF;
+  RETURN NEW;
+END
+$function$;--> statement-breakpoint
+
+-- stella-migration-safety: reviewed destructive-change - replaces only this migration's projection fence; table data is unchanged.
+DROP TRIGGER IF EXISTS case_law_search_documents_redaction_fence
+  ON "case_law_search_documents";--> statement-breakpoint
+CREATE TRIGGER case_law_search_documents_redaction_fence
+BEFORE INSERT OR UPDATE ON "case_law_search_documents"
+FOR EACH ROW
+EXECUTE FUNCTION fence_redacted_case_law_search_projection();

--- a/apps/api/src/lib/legal-search/case-law-corpus-upload-intents.test.ts
+++ b/apps/api/src/lib/legal-search/case-law-corpus-upload-intents.test.ts
@@ -144,11 +144,11 @@ describe("case-law corpus upload intents", () => {
     expect(redactionIndexMigration).toContain(
       'CREATE INDEX CONCURRENTLY "case_law_index_jobs_redaction_decision_idx"',
     );
-    expect(redactionProjectionFenceMigration).toContain("FOR KEY SHARE");
+    expect(redactionProjectionFenceMigration).toContain("FOR SHARE");
     expect(redactionProjectionFenceMigration).toContain(
       "cannot write a search projection for a redacted case-law decision",
     );
-    expect(searchIndexSource).toContain('.for("key share")');
+    expect(searchIndexSource).toContain('.for("share")');
     expect(schedulerJobsSource).toContain(
       'id: "caseLaw.backfillRedactionTombstones.v2"',
     );

--- a/apps/api/src/lib/legal-search/case-law-corpus-upload-intents.test.ts
+++ b/apps/api/src/lib/legal-search/case-law-corpus-upload-intents.test.ts
@@ -29,6 +29,21 @@ const redactionIndexMigration = readFileSync(
   ),
   "utf-8",
 );
+const redactionProjectionFenceMigration = readFileSync(
+  new URL(
+    "../../../drizzle/20260801130000_case_law_redaction_projection_fence/migration.sql",
+    import.meta.url,
+  ),
+  "utf-8",
+);
+const searchIndexSource = readFileSync(
+  new URL("case-law-search-index.ts", import.meta.url),
+  "utf-8",
+);
+const schedulerJobsSource = readFileSync(
+  new URL("../scheduler/jobs.ts", import.meta.url),
+  "utf-8",
+);
 const redactionBackfillTask = readFileSync(
   new URL(
     "../scheduler/tasks/case-law-redaction-tombstone-backfill.ts",
@@ -129,6 +144,14 @@ describe("case-law corpus upload intents", () => {
     expect(redactionIndexMigration).toContain(
       'CREATE INDEX CONCURRENTLY "case_law_index_jobs_redaction_decision_idx"',
     );
+    expect(redactionProjectionFenceMigration).toContain("FOR KEY SHARE");
+    expect(redactionProjectionFenceMigration).toContain(
+      "cannot write a search projection for a redacted case-law decision",
+    );
+    expect(searchIndexSource).toContain('.for("key share")');
+    expect(schedulerJobsSource).toContain(
+      'id: "caseLaw.backfillRedactionTombstones.v2"',
+    );
     expect(redactionBackfillTask).toContain(".limit(BACKFILL_LIMIT)");
     expect(redactionBackfillTask).not.toContain(
       "isNull(caseLawDecisions.fulltext)",
@@ -138,6 +161,9 @@ describe("case-law corpus upload intents", () => {
     );
     expect(redactionBackfillTask).toContain("fulltext: null");
     expect(redactionBackfillTask).toContain("textS3Key: null");
+    expect(redactionBackfillTask).toContain(
+      "caseLawSearchDocuments.decisionId, decisionIds",
+    );
     const tombstoneUpdate = redactionBackfillTask.indexOf(
       ".update(caseLawDecisions)",
     );

--- a/apps/api/src/lib/legal-search/case-law-corpus-upload-intents.test.ts
+++ b/apps/api/src/lib/legal-search/case-law-corpus-upload-intents.test.ts
@@ -141,6 +141,9 @@ describe("case-law corpus upload intents", () => {
     const tombstoneUpdate = redactionBackfillTask.indexOf(
       ".update(caseLawDecisions)",
     );
+    const searchProjectionDelete = redactionBackfillTask.indexOf(
+      ".delete(caseLawSearchDocuments)",
+    );
     const cleanupOwnership = redactionBackfillTask.indexOf(
       ".insert(caseLawCorpusUploadIntents)",
     );
@@ -148,8 +151,11 @@ describe("case-law corpus upload intents", () => {
       ".set({ payload: { cursor: lastDecisionId } })",
     );
     expect(tombstoneUpdate).toBeGreaterThan(-1);
+    expect(searchProjectionDelete).toBeGreaterThan(-1);
     expect(cleanupOwnership).toBeGreaterThan(-1);
+    expect(searchProjectionDelete).toBeGreaterThan(cleanupOwnership);
     expect(tombstoneUpdate).toBeGreaterThan(cleanupOwnership);
+    expect(tombstoneUpdate).toBeGreaterThan(searchProjectionDelete);
     expect(checkpoint).toBeGreaterThan(tombstoneUpdate);
   });
 

--- a/apps/api/src/lib/legal-search/case-law-search-index.ts
+++ b/apps/api/src/lib/legal-search/case-law-search-index.ts
@@ -103,6 +103,24 @@ export const indexDecision = async (
     // CPU-intensive. The helper scopes the higher timeout to
     // this transaction only; user-facing queries keep the default.
     await setCorpusBackfillStatementTimeout(tx);
+    const writableDecision = await tx
+      .select({ id: caseLawDecisions.id })
+      .from(caseLawDecisions)
+      .where(
+        and(
+          eq(caseLawDecisions.id, decision.id),
+          isNull(caseLawDecisions.redactedAt),
+        ),
+      )
+      .for("key share")
+      .limit(1);
+    if (!writableDecision.at(0)) {
+      // audit: skip — search index maintenance; rebuilds derived state
+      await tx
+        .delete(caseLawSearchDocuments)
+        .where(eq(caseLawSearchDocuments.decisionId, decision.id));
+      return;
+    }
     await tx.execute(sql`
     INSERT INTO case_law_search_documents (
       decision_id, title, searchable_text,

--- a/apps/api/src/lib/legal-search/case-law-search-index.ts
+++ b/apps/api/src/lib/legal-search/case-law-search-index.ts
@@ -112,7 +112,7 @@ export const indexDecision = async (
           isNull(caseLawDecisions.redactedAt),
         ),
       )
-      .for("key share")
+      .for("share")
       .limit(1);
     if (!writableDecision.at(0)) {
       // audit: skip — search index maintenance; rebuilds derived state

--- a/apps/api/src/lib/scheduler/jobs.ts
+++ b/apps/api/src/lib/scheduler/jobs.ts
@@ -135,8 +135,9 @@ export const ensureDefaultSchedulerJobs = async (): Promise<void> => {
   });
 
   await ensureOneShotSchedulerJob({
-    description: "Backfill durable case-law redaction tombstones",
-    id: "caseLaw.backfillRedactionTombstones.v1",
+    description:
+      "Backfill durable case-law redaction tombstones and search cleanup",
+    id: "caseLaw.backfillRedactionTombstones.v2",
     schedule: {
       type: "interval",
       everyMs: 60 * 1000,

--- a/apps/api/src/lib/scheduler/tasks/case-law-redaction-tombstone-backfill.db.test.ts
+++ b/apps/api/src/lib/scheduler/tasks/case-law-redaction-tombstone-backfill.db.test.ts
@@ -50,7 +50,7 @@ if (!databaseUrl || !runPostgresTests) {
         where: { id: { eq: schedulerJobId } },
       });
       if (!job) {
-        return panic("expected scheduler job");
+        panic("expected scheduler job");
       }
       await backfillCaseLawRedactionTombstones({
         job,
@@ -78,7 +78,7 @@ if (!databaseUrl || !runPostgresTests) {
         })
         .returning({ id: caseLawSources.id });
       if (!source) {
-        return panic("expected source row");
+        panic("expected source row");
       }
       sourceId = source.id;
 
@@ -94,7 +94,7 @@ if (!databaseUrl || !runPostgresTests) {
         })
         .returning({ id: caseLawDecisions.id });
       if (!decision) {
-        return panic("expected decision row");
+        panic("expected decision row");
       }
 
       await db.insert(caseLawSearchDocuments).values({

--- a/apps/api/src/lib/scheduler/tasks/case-law-redaction-tombstone-backfill.db.test.ts
+++ b/apps/api/src/lib/scheduler/tasks/case-law-redaction-tombstone-backfill.db.test.ts
@@ -4,6 +4,7 @@
  * job; skipped elsewhere.
  */
 
+import { panic } from "better-result";
 import { afterAll, describe, expect, test } from "bun:test";
 import { eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/bun-sql";
@@ -49,7 +50,7 @@ if (!databaseUrl || !runPostgresTests) {
         where: { id: { eq: schedulerJobId } },
       });
       if (!job) {
-        throw new Error("expected scheduler job");
+        return panic("expected scheduler job");
       }
       await backfillCaseLawRedactionTombstones({
         job,
@@ -77,7 +78,7 @@ if (!databaseUrl || !runPostgresTests) {
         })
         .returning({ id: caseLawSources.id });
       if (!source) {
-        throw new Error("expected source row");
+        return panic("expected source row");
       }
       sourceId = source.id;
 
@@ -93,7 +94,7 @@ if (!databaseUrl || !runPostgresTests) {
         })
         .returning({ id: caseLawDecisions.id });
       if (!decision) {
-        throw new Error("expected decision row");
+        return panic("expected decision row");
       }
 
       await db.insert(caseLawSearchDocuments).values({

--- a/apps/api/src/lib/scheduler/tasks/case-law-redaction-tombstone-backfill.db.test.ts
+++ b/apps/api/src/lib/scheduler/tasks/case-law-redaction-tombstone-backfill.db.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Historical redaction repair must erase every readable projection in the
+ * same transaction as the canonical tombstone. Runs in the nightly Postgres
+ * job; skipped elsewhere.
+ */
+
+import { afterAll, describe, expect, test } from "bun:test";
+import { eq } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/bun-sql";
+
+import { authRelationsPart } from "@/api/db/auth-schema";
+import {
+  caseLawDecisions,
+  caseLawIndexJobs,
+  caseLawSearchDocuments,
+  caseLawSources,
+  relations,
+  schedulerJobs,
+} from "@/api/db/schema";
+import { createSafeId } from "@/api/lib/branded-types";
+import { logger } from "@/api/lib/observability/logger";
+
+import {
+  BACKFILL_CASE_LAW_REDACTION_TOMBSTONES_TASK,
+  backfillCaseLawRedactionTombstones,
+} from "./case-law-redaction-tombstone-backfill";
+
+const databaseUrl = process.env["DATABASE_URL"];
+const runPostgresTests = process.env["STELLA_RUN_POSTGRES_TESTS"] === "true";
+
+if (!databaseUrl || !runPostgresTests) {
+  describe.skip("case-law redaction tombstone backfill", () => {
+    test("requires STELLA_RUN_POSTGRES_TESTS=true and DATABASE_URL", () => {
+      expect(runPostgresTests && Boolean(databaseUrl)).toBe(false);
+    });
+  });
+} else {
+  describe("case-law redaction tombstone backfill", () => {
+    const db = drizzle(databaseUrl, {
+      relations: { ...relations, ...authRelationsPart },
+    });
+    const suffix = Bun.randomUUIDv7();
+    const schedulerJobId = `test.case-law-redaction-backfill.${suffix}`;
+    const leaseToken = `test-lease-${suffix}`;
+    let sourceId = createSafeId<"caseLawSource">();
+
+    const runTask = async () => {
+      const job = await db.query.schedulerJobs.findFirst({
+        where: { id: { eq: schedulerJobId } },
+      });
+      if (!job) {
+        throw new Error("expected scheduler job");
+      }
+      await backfillCaseLawRedactionTombstones({
+        job,
+        payload: job.payload,
+        runId: createSafeId<"schedulerJobRun">(),
+        signal: new AbortController().signal,
+        logger,
+      });
+    };
+
+    afterAll(async () => {
+      await db
+        .delete(schedulerJobs)
+        .where(eq(schedulerJobs.id, schedulerJobId));
+      await db.delete(caseLawSources).where(eq(caseLawSources.id, sourceId));
+    });
+
+    test("atomically removes stale search projections and reaches a fixed point", async () => {
+      const [source] = await db
+        .insert(caseLawSources)
+        .values({
+          adapterKey: `redaction-backfill-${suffix}`,
+          enabled: false,
+          name: "Redaction backfill test",
+        })
+        .returning({ id: caseLawSources.id });
+      if (!source) {
+        throw new Error("expected source row");
+      }
+      sourceId = source.id;
+
+      const [decision] = await db
+        .insert(caseLawDecisions)
+        .values({
+          caseNumber: `redaction-backfill-${suffix}`,
+          country: "CZE",
+          court: "Test court",
+          fulltext: "text that must no longer be searchable",
+          language: "cs",
+          sourceId,
+        })
+        .returning({ id: caseLawDecisions.id });
+      if (!decision) {
+        throw new Error("expected decision row");
+      }
+
+      await db.insert(caseLawSearchDocuments).values({
+        decisionId: decision.id,
+        searchableText: "stale searchable text",
+        title: "Stale title",
+      });
+      await db.insert(caseLawIndexJobs).values({
+        decisionId: decision.id,
+        generation: "case_law_v1",
+        operation: "redact",
+        status: "succeeded",
+      });
+      await db.insert(schedulerJobs).values({
+        description: "redaction repair test",
+        id: schedulerJobId,
+        lockedBy: leaseToken,
+        nextRunAt: new Date("2026-08-01T00:00:00.000Z"),
+        schedule: { type: "interval", everyMs: 60_000 },
+        task: BACKFILL_CASE_LAW_REDACTION_TOMBSTONES_TASK,
+      });
+
+      await runTask();
+
+      expect(
+        await db.query.caseLawDecisions.findFirst({
+          where: { id: { eq: decision.id } },
+          columns: { fulltext: true, redactedAt: true },
+        }),
+      ).toMatchObject({ fulltext: null, redactedAt: expect.any(Date) });
+      expect(
+        await db
+          .select({ id: caseLawSearchDocuments.decisionId })
+          .from(caseLawSearchDocuments)
+          .where(eq(caseLawSearchDocuments.decisionId, decision.id)),
+      ).toHaveLength(0);
+
+      await runTask();
+
+      expect(
+        await db.query.schedulerJobs.findFirst({
+          where: { id: { eq: schedulerJobId } },
+          columns: { enabled: true },
+        }),
+      ).toEqual({ enabled: false });
+    });
+  });
+}

--- a/apps/api/src/lib/scheduler/tasks/case-law-redaction-tombstone-backfill.db.test.ts
+++ b/apps/api/src/lib/scheduler/tasks/case-law-redaction-tombstone-backfill.db.test.ts
@@ -68,7 +68,7 @@ if (!databaseUrl || !runPostgresTests) {
       await db.delete(caseLawSources).where(eq(caseLawSources.id, sourceId));
     });
 
-    test("atomically removes stale search projections and reaches a fixed point", async () => {
+    test("replays v1 rows, fences projection restoration, and reaches a fixed point", async () => {
       const [source] = await db
         .insert(caseLawSources)
         .values({
@@ -108,6 +108,10 @@ if (!databaseUrl || !runPostgresTests) {
         operation: "redact",
         status: "succeeded",
       });
+      await db
+        .update(caseLawDecisions)
+        .set({ fulltext: null })
+        .where(eq(caseLawDecisions.id, decision.id));
       await db.insert(schedulerJobs).values({
         description: "redaction repair test",
         id: schedulerJobId,
@@ -125,6 +129,25 @@ if (!databaseUrl || !runPostgresTests) {
           columns: { fulltext: true, redactedAt: true },
         }),
       ).toMatchObject({ fulltext: null, redactedAt: expect.any(Date) });
+      expect(
+        await db
+          .select({ id: caseLawSearchDocuments.decisionId })
+          .from(caseLawSearchDocuments)
+          .where(eq(caseLawSearchDocuments.decisionId, decision.id)),
+      ).toHaveLength(0);
+
+      const rejectedProjection = await db
+        .insert(caseLawSearchDocuments)
+        .values({
+          decisionId: decision.id,
+          searchableText: "attempted restored text",
+          title: "Attempted restored title",
+        })
+        .then(
+          () => null,
+          (error: unknown) => error,
+        );
+      expect(rejectedProjection).toBeInstanceOf(Error);
       expect(
         await db
           .select({ id: caseLawSearchDocuments.decisionId })

--- a/apps/api/src/lib/scheduler/tasks/case-law-redaction-tombstone-backfill.db.test.ts
+++ b/apps/api/src/lib/scheduler/tasks/case-law-redaction-tombstone-backfill.db.test.ts
@@ -155,6 +155,68 @@ if (!databaseUrl || !runPostgresTests) {
           .where(eq(caseLawSearchDocuments.decisionId, decision.id)),
       ).toHaveLength(0);
 
+      const [raceDecision] = await db
+        .insert(caseLawDecisions)
+        .values({
+          caseNumber: `redaction-race-${suffix}`,
+          country: "CZE",
+          court: "Test court",
+          fulltext: "text from a stale projection writer",
+          language: "cs",
+          sourceId,
+        })
+        .returning({ id: caseLawDecisions.id });
+      if (!raceDecision) {
+        panic("expected race decision row");
+      }
+
+      let markRedactionReady: (() => void) | undefined;
+      let releaseRedaction: (() => void) | undefined;
+      const redactionReady = new Promise<void>((resolve) => {
+        markRedactionReady = resolve;
+      });
+      const heldRedaction = db.transaction(async (tx) => {
+        await tx
+          .update(caseLawDecisions)
+          .set({ redactedAt: new Date() })
+          .where(eq(caseLawDecisions.id, raceDecision.id));
+        markRedactionReady?.();
+        await new Promise<void>((resolve) => {
+          releaseRedaction = resolve;
+        });
+      });
+      await redactionReady;
+
+      const staleWriter = db
+        .insert(caseLawSearchDocuments)
+        .values({
+          decisionId: raceDecision.id,
+          searchableText: "attempted concurrent restoration",
+          title: "Attempted concurrent restoration",
+        })
+        .then(
+          () => "written" as const,
+          () => "rejected" as const,
+        );
+      try {
+        expect(
+          await Promise.race([
+            staleWriter,
+            Bun.sleep(100).then(() => "blocked" as const),
+          ]),
+        ).toBe("blocked");
+      } finally {
+        releaseRedaction?.();
+        await heldRedaction;
+      }
+      expect(await staleWriter).toBe("rejected");
+      expect(
+        await db
+          .select({ id: caseLawSearchDocuments.decisionId })
+          .from(caseLawSearchDocuments)
+          .where(eq(caseLawSearchDocuments.decisionId, raceDecision.id)),
+      ).toHaveLength(0);
+
       await runTask();
 
       expect(

--- a/apps/api/src/lib/scheduler/tasks/case-law-redaction-tombstone-backfill.db.test.ts
+++ b/apps/api/src/lib/scheduler/tasks/case-law-redaction-tombstone-backfill.db.test.ts
@@ -178,7 +178,7 @@ if (!databaseUrl || !runPostgresTests) {
       const heldRedaction = db.transaction(async (tx) => {
         await tx
           .update(caseLawDecisions)
-          .set({ redactedAt: new Date() })
+          .set({ fulltext: null, redactedAt: new Date() })
           .where(eq(caseLawDecisions.id, raceDecision.id));
         markRedactionReady?.();
         await new Promise<void>((resolve) => {

--- a/apps/api/src/lib/scheduler/tasks/case-law-redaction-tombstone-backfill.ts
+++ b/apps/api/src/lib/scheduler/tasks/case-law-redaction-tombstone-backfill.ts
@@ -143,14 +143,15 @@ export const backfillCaseLawRedactionTombstones: SchedulerTask = async ({
     }
 
     // The audit is authoritative even if pre-fence ingestion restored a
-    // historical payload. Own every object key durably, then scrub the row in
-    // the same transaction so no restored content remains publicly readable.
+    // historical payload. Own every object key durably, remove projections
+    // for the full audit page (including rows repaired by v1), then scrub the
+    // row in the same transaction so no restored content remains readable.
     // audit: skip — bounded compatibility repair derived from append-only
     // redaction audit rows.
-    if (repairIds.length > 0) {
+    if (decisionIds.length > 0) {
       await tx
         .delete(caseLawSearchDocuments)
-        .where(inArray(caseLawSearchDocuments.decisionId, repairIds));
+        .where(inArray(caseLawSearchDocuments.decisionId, decisionIds));
     }
     const repaired =
       repairIds.length === 0

--- a/apps/api/src/lib/scheduler/tasks/case-law-redaction-tombstone-backfill.ts
+++ b/apps/api/src/lib/scheduler/tasks/case-law-redaction-tombstone-backfill.ts
@@ -8,6 +8,7 @@ import {
   caseLawCorpusUploadIntents,
   caseLawDecisions,
   caseLawIndexJobs,
+  caseLawSearchDocuments,
   schedulerJobs,
 } from "@/api/db/schema";
 import { isUuid } from "@/api/lib/custom-schema";
@@ -146,6 +147,11 @@ export const backfillCaseLawRedactionTombstones: SchedulerTask = async ({
     // the same transaction so no restored content remains publicly readable.
     // audit: skip — bounded compatibility repair derived from append-only
     // redaction audit rows.
+    if (repairIds.length > 0) {
+      await tx
+        .delete(caseLawSearchDocuments)
+        .where(inArray(caseLawSearchDocuments.decisionId, repairIds));
+    }
     const repaired =
       repairIds.length === 0
         ? []


### PR DESCRIPTION
## Proposed change

Remove PostgreSQL search projections in the same transaction as historical case-law redaction repair. Add a Postgres regression for projection cleanup and fixed-point replay, plus a source-level ordering invariant.

## Checklist

- [ ] BUILD ASSURANCE | Deferred to required CI checks.
- [x] TESTING | Focused invariant and Postgres regression tests pass.
- [x] DARK MODE SUPPORT | Not applicable; no UI changes.
- [ ] ISSUE LINKED | No linked issue.
- [x] SCREENSHOT INCLUDED | Not applicable; no UI changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Redacted case-law records now have their search results removed during backfill.
  * Cleanup is completed before records are tombstoned, preventing outdated content from remaining searchable.
  * Search results can no longer be restored for redacted case-law records.

* **Tests**
  * Added coverage for redaction cleanup, operation ordering, repeat runs, concurrent updates and scheduler-job handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->