### PR TITLE
fix: add auditable marketing recording verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -529,6 +529,10 @@ jobs:
         if: needs.ci-changes.outputs.package_checks_required == 'true'
         run: bun test packages/property-testing/src/convention.test.ts
 
+      - name: Test marketing recording verification guard
+        if: needs.ci-changes.outputs.package_checks_required == 'true'
+        run: bun test scripts/check-marketing-recordings.test.ts
+
       # Self-test the bridge-version guard so a regression in the
       # script itself is caught immediately, not on the next desktop
       # bridge change. Always runs (no `if:` gate) — it's seconds

--- a/apps/landing/public/media/products/README.md
+++ b/apps/landing/public/media/products/README.md
@@ -136,6 +136,13 @@ rendering changes that arrive through dependency upgrades (notably
 `@stll/folio-react` for the editor scene) are not tracked, so judge those
 manually when bumping.
 
+For scenes with a deterministic ready-state screenshot, source changes alone
+do not make the recording stale when that committed screenshot is unchanged.
+The marketing screenshot suite renders the current app in CI and compares it
+with that reference, so this covers broad refactors without weakening the
+visual check. Recorder choreography changes always invalidate the recording;
+multi-step scenes without a representative screenshot remain source-triggered.
+
 ## Reshooting on release
 
 `bun run marketing:reshoot` re-records only the captures `marketing:stale`
@@ -168,3 +175,20 @@ commands, including a ready-to-run `jq` snippet for the second commit.
 pushing a release tag, so a stale recording fails the tag push instead of
 shipping a landing page that has quietly drifted from the product. Clear it
 with `bun run marketing:reshoot` before bumping `VERSION`.
+
+### Manual verification escape hatch
+
+When existing media has been visually reviewed against the current app and
+does not need new footage, commit an explicit manual verification instead of
+rewriting `recordedAtCommit`:
+
+```sh
+bun run marketing:verify-current -- \
+  --confirm-current-recordings-reviewed \
+  --reason "Existing recordings visually reviewed for this release"
+```
+
+Use `--capture workspace,review` to limit the attestation. The command updates
+only selected stale manifest entries and binds the review to a hash of their
+exact watched source tree. Any later relevant code change invalidates it. A
+new recording replaces the entry and clears its manual verification.

--- a/apps/landing/public/media/products/README.md
+++ b/apps/landing/public/media/products/README.md
@@ -183,5 +183,6 @@ bun run marketing:verify-current -- \
 
 Use `--capture workspace,review` to limit the attestation. The command updates
 only selected stale manifest entries and binds the review to a hash of their
-exact watched source tree. Any later relevant code change invalidates it. A
-new recording replaces the entry and clears its manual verification.
+exact watched source tree, MP4, and poster. Any later relevant code or media
+change invalidates it. A new recording replaces the entry and clears its
+manual verification.

--- a/apps/landing/public/media/products/README.md
+++ b/apps/landing/public/media/products/README.md
@@ -136,13 +136,6 @@ rendering changes that arrive through dependency upgrades (notably
 `@stll/folio-react` for the editor scene) are not tracked, so judge those
 manually when bumping.
 
-For scenes with a deterministic ready-state screenshot, source changes alone
-do not make the recording stale when that committed screenshot is unchanged.
-The marketing screenshot suite renders the current app in CI and compares it
-with that reference, so this covers broad refactors without weakening the
-visual check. Recorder choreography changes always invalidate the recording;
-multi-step scenes without a representative screenshot remain source-triggered.
-
 ## Reshooting on release
 
 `bun run marketing:reshoot` re-records only the captures `marketing:stale`

--- a/apps/web/e2e/marketing/captures.ts
+++ b/apps/web/e2e/marketing/captures.ts
@@ -64,6 +64,7 @@ export type CaptureDefinition = {
   captureId: string;
   dpr: number;
   sceneId: StoryCaptureId;
+  visualReference?: string;
   viewport: CaptureViewport;
   watchedPaths: readonly string[];
 };
@@ -141,6 +142,20 @@ const SCENE_WATCHED_PATHS: Record<StoryCaptureId, readonly string[]> = {
   ],
 };
 
+// Stable ready-state screenshots are checked against the current app in CI.
+// When one stays pixel-equivalent, source-only refactors in that scene do not
+// need to invalidate its existing recording. Scenes whose essential behavior
+// is a multi-step interaction keep source-path invalidation until they gain a
+// representative reference capture.
+const VISUAL_REFERENCES: Partial<Record<StoryCaptureId, string>> = {
+  agent: "agent",
+  editor: "editor",
+  "editor-doc": "editor",
+  review: "tabular-review",
+  templates: "templates",
+  workspace: "workspace",
+};
+
 // Scenes consumed at both the wide (scene-only embeds) and hero (companion
 // composition main window) viewports. "templates" is wide-only below: it
 // plays only in scene-only embeds (templates product page).
@@ -154,6 +169,7 @@ const toDefinition = (
   captureId,
   dpr: CAPTURE_DPR,
   sceneId,
+  visualReference: VISUAL_REFERENCES[sceneId],
   viewport,
   watchedPaths: [...COMMON_WATCHED_PATHS, ...SCENE_WATCHED_PATHS[sceneId]],
 });

--- a/apps/web/e2e/marketing/captures.ts
+++ b/apps/web/e2e/marketing/captures.ts
@@ -64,7 +64,7 @@ export type CaptureDefinition = {
   captureId: string;
   dpr: number;
   sceneId: StoryCaptureId;
-  visualReference?: string;
+  visualReference: string | undefined;
   viewport: CaptureViewport;
   watchedPaths: readonly string[];
 };

--- a/apps/web/e2e/marketing/captures.ts
+++ b/apps/web/e2e/marketing/captures.ts
@@ -64,7 +64,6 @@ export type CaptureDefinition = {
   captureId: string;
   dpr: number;
   sceneId: StoryCaptureId;
-  visualReference: string | undefined;
   viewport: CaptureViewport;
   watchedPaths: readonly string[];
 };
@@ -142,20 +141,6 @@ const SCENE_WATCHED_PATHS: Record<StoryCaptureId, readonly string[]> = {
   ],
 };
 
-// Stable ready-state screenshots are checked against the current app in CI.
-// When one stays pixel-equivalent, source-only refactors in that scene do not
-// need to invalidate its existing recording. Scenes whose essential behavior
-// is a multi-step interaction keep source-path invalidation until they gain a
-// representative reference capture.
-const VISUAL_REFERENCES: Partial<Record<StoryCaptureId, string>> = {
-  agent: "agent",
-  editor: "editor",
-  "editor-doc": "editor",
-  review: "tabular-review",
-  templates: "templates",
-  workspace: "workspace",
-};
-
 // Scenes consumed at both the wide (scene-only embeds) and hero (companion
 // composition main window) viewports. "templates" is wide-only below: it
 // plays only in scene-only embeds (templates product page).
@@ -169,7 +154,6 @@ const toDefinition = (
   captureId,
   dpr: CAPTURE_DPR,
   sceneId,
-  visualReference: VISUAL_REFERENCES[sceneId],
   viewport,
   watchedPaths: [...COMMON_WATCHED_PATHS, ...SCENE_WATCHED_PATHS[sceneId]],
 });

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "policies:check": "bun test scripts/check-policy-evidence.test.ts && bun scripts/check-policy-evidence.ts",
     "marketing:check": "bun scripts/check-marketing-content.ts",
     "marketing:stale": "bun scripts/check-marketing-recordings.ts",
+    "marketing:verify-current": "bun scripts/verify-marketing-recordings.ts",
     "marketing:reshoot": "bun scripts/marketing-reshoot.ts",
     "sync-ai": "bash .ai/shared/scripts/sync-ai-skills.sh .",
     "sync-ai:check": "bash .ai/shared/scripts/sync-ai-skills.sh --check .",

--- a/scripts/check-marketing-recordings.test.ts
+++ b/scripts/check-marketing-recordings.test.ts
@@ -57,6 +57,18 @@ describe("marketing recording freshness", () => {
         watchedPaths: definition.watchedPaths,
       }),
     ).toBe(false);
+    expect(
+      manualVerificationMatches({
+        captureId: "missing-artifact-fixture",
+        theme: "light",
+        verification: {
+          artifactsHash: "0".repeat(64),
+          reason: "Reviewed for a maintenance release",
+          watchedPathsHash,
+        },
+        watchedPaths: definition.watchedPaths,
+      }),
+    ).toBe(false);
   });
 
   test("accepts a matching explicit verification as the freshness basis", () => {

--- a/scripts/check-marketing-recordings.test.ts
+++ b/scripts/check-marketing-recordings.test.ts
@@ -109,6 +109,33 @@ describe("marketing recording freshness", () => {
     expect(verdict.reasons.at(0)).toStartWith("viewport drifted");
   });
 
+  test("does not fall back to the recording stamp after media drift", () => {
+    const recordedAtCommit = execFileSync("git", ["rev-parse", "HEAD"], {
+      encoding: "utf-8",
+    }).trim();
+    const verdict = judgeEntry({
+      captureId: definition.captureId,
+      dpr: definition.dpr,
+      manualVerification: {
+        artifactsHash: "0".repeat(64),
+        reason: "Reviewed for a maintenance release",
+        watchedPathsHash: watchedPathsHashAtHead(definition.watchedPaths),
+      },
+      recordedAtCommit,
+      theme: "light",
+      viewport: definition.viewport,
+      watchedPaths: definition.watchedPaths,
+    });
+
+    expect(verdict).toMatchObject({
+      basis: null,
+      reasons: [
+        "manual verification does not match the watched source tree or recording artifacts",
+      ],
+      status: "STALE",
+    });
+  });
+
   test("requires deliberate confirmation and a review reason", () => {
     expect(() => parseVerificationOptions([])).toThrow(
       "--confirm-current-recordings-reviewed",

--- a/scripts/check-marketing-recordings.test.ts
+++ b/scripts/check-marketing-recordings.test.ts
@@ -1,0 +1,85 @@
+import { panic } from "better-result";
+import { describe, expect, test } from "bun:test";
+import { execFileSync } from "node:child_process";
+
+import { captureDefinitions } from "../apps/web/e2e/marketing/captures";
+import {
+  judgeEntry,
+  manualVerificationMatches,
+  uncoveredChangedPaths,
+  watchedPathsHashAtHead,
+} from "./check-marketing-recordings";
+import { parseVerificationOptions } from "./verify-marketing-recordings";
+
+const definition =
+  captureDefinitions.at(0) ?? panic("expected a marketing capture definition");
+
+describe("marketing recording freshness", () => {
+  test("binds manual verification to the exact watched source tree", () => {
+    const watchedPathsHash = watchedPathsHashAtHead(definition.watchedPaths);
+
+    expect(
+      manualVerificationMatches(
+        { reason: "Reviewed for a maintenance release", watchedPathsHash },
+        [...definition.watchedPaths].reverse(),
+      ),
+    ).toBe(true);
+    expect(
+      manualVerificationMatches(
+        {
+          reason: "Reviewed for a maintenance release",
+          watchedPathsHash: "0".repeat(64),
+        },
+        definition.watchedPaths,
+      ),
+    ).toBe(false);
+  });
+
+  test("accepts a matching explicit verification as the freshness basis", () => {
+    const recordedAtCommit = execFileSync("git", ["rev-parse", "HEAD"], {
+      encoding: "utf-8",
+    }).trim();
+    const verdict = judgeEntry({
+      captureId: definition.captureId,
+      dpr: definition.dpr,
+      manualVerification: {
+        reason: "Reviewed for a maintenance release",
+        watchedPathsHash: watchedPathsHashAtHead(definition.watchedPaths),
+      },
+      recordedAtCommit,
+      theme: "light",
+      viewport: definition.viewport,
+      watchedPaths: definition.watchedPaths,
+    });
+
+    expect(verdict).toMatchObject({
+      basis: "manual-verification",
+      reasons: [],
+      status: "FRESH",
+    });
+  });
+
+  test("uses a current visual reference only for source changes it covers", () => {
+    const recorderPath = "apps/web/e2e/marketing/record-product-story.ts";
+    const sourcePath = "apps/web/src/components/breadcrumbs/index.tsx";
+
+    expect(uncoveredChangedPaths([sourcePath], true)).toEqual([]);
+    expect(uncoveredChangedPaths([sourcePath], false)).toEqual([sourcePath]);
+    expect(uncoveredChangedPaths([sourcePath, recorderPath], true)).toEqual([
+      recorderPath,
+    ]);
+  });
+
+  test("requires deliberate confirmation and a review reason", () => {
+    expect(() => parseVerificationOptions([])).toThrow(
+      "--confirm-current-recordings-reviewed",
+    );
+    expect(() =>
+      parseVerificationOptions([
+        "--confirm-current-recordings-reviewed",
+        "--reason",
+        "Reviewed for a maintenance release",
+      ]),
+    ).not.toThrow();
+  });
+});

--- a/scripts/check-marketing-recordings.test.ts
+++ b/scripts/check-marketing-recordings.test.ts
@@ -103,7 +103,16 @@ describe("marketing recording freshness", () => {
         "Reviewed for a maintenance release",
         "--capture",
       ]),
-    ).toThrow("--capture must name at least one capture");
+    ).toThrow("--capture requires a value");
+    expect(() =>
+      parseVerificationOptions([
+        "--confirm-current-recordings-reviewed",
+        "--reason",
+        "Reviewed for a maintenance release",
+        "--captur",
+        "workspace",
+      ]),
+    ).toThrow("Unknown argument: --captur");
   });
 
   test("never claims to attest a recording missing from the manifest", () => {

--- a/scripts/check-marketing-recordings.test.ts
+++ b/scripts/check-marketing-recordings.test.ts
@@ -6,6 +6,7 @@ import { captureDefinitions } from "../apps/web/e2e/marketing/captures";
 import {
   judgeEntry,
   manualVerificationMatches,
+  recordingArtifactsHash,
   watchedPathsHashAtHead,
 } from "./check-marketing-recordings";
 import {
@@ -17,23 +18,44 @@ const definition =
   captureDefinitions.at(0) ?? panic("expected a marketing capture definition");
 
 describe("marketing recording freshness", () => {
-  test("binds manual verification to the exact watched source tree", () => {
+  test("binds manual verification to the exact reviewed source and media", () => {
     const watchedPathsHash = watchedPathsHashAtHead(definition.watchedPaths);
 
     expect(
-      manualVerificationMatches(
-        { reason: "Reviewed for a maintenance release", watchedPathsHash },
-        [...definition.watchedPaths].reverse(),
-      ),
+      manualVerificationMatches({
+        captureId: definition.captureId,
+        theme: "light",
+        verification: {
+          artifactsHash: recordingArtifactsHash(definition.captureId, "light"),
+          reason: "Reviewed for a maintenance release",
+          watchedPathsHash,
+        },
+        watchedPaths: [...definition.watchedPaths].reverse(),
+      }),
     ).toBe(true);
     expect(
-      manualVerificationMatches(
-        {
+      manualVerificationMatches({
+        captureId: definition.captureId,
+        theme: "light",
+        verification: {
+          artifactsHash: recordingArtifactsHash(definition.captureId, "light"),
           reason: "Reviewed for a maintenance release",
           watchedPathsHash: "0".repeat(64),
         },
-        definition.watchedPaths,
-      ),
+        watchedPaths: definition.watchedPaths,
+      }),
+    ).toBe(false);
+    expect(
+      manualVerificationMatches({
+        captureId: definition.captureId,
+        theme: "light",
+        verification: {
+          artifactsHash: "0".repeat(64),
+          reason: "Reviewed for a maintenance release",
+          watchedPathsHash,
+        },
+        watchedPaths: definition.watchedPaths,
+      }),
     ).toBe(false);
   });
 
@@ -45,6 +67,7 @@ describe("marketing recording freshness", () => {
       captureId: definition.captureId,
       dpr: definition.dpr,
       manualVerification: {
+        artifactsHash: recordingArtifactsHash(definition.captureId, "light"),
         reason: "Reviewed for a maintenance release",
         watchedPathsHash: watchedPathsHashAtHead(definition.watchedPaths),
       },
@@ -69,6 +92,7 @@ describe("marketing recording freshness", () => {
       captureId: definition.captureId,
       dpr: definition.dpr,
       manualVerification: {
+        artifactsHash: recordingArtifactsHash(definition.captureId, "light"),
         reason: "Reviewed for a maintenance release",
         watchedPathsHash: watchedPathsHashAtHead(definition.watchedPaths),
       },

--- a/scripts/check-marketing-recordings.test.ts
+++ b/scripts/check-marketing-recordings.test.ts
@@ -6,10 +6,12 @@ import { captureDefinitions } from "../apps/web/e2e/marketing/captures";
 import {
   judgeEntry,
   manualVerificationMatches,
-  uncoveredChangedPaths,
   watchedPathsHashAtHead,
 } from "./check-marketing-recordings";
-import { parseVerificationOptions } from "./verify-marketing-recordings";
+import {
+  parseVerificationOptions,
+  partitionAttestableKeys,
+} from "./verify-marketing-recordings";
 
 const definition =
   captureDefinitions.at(0) ?? panic("expected a marketing capture definition");
@@ -59,17 +61,6 @@ describe("marketing recording freshness", () => {
     });
   });
 
-  test("uses a current visual reference only for source changes it covers", () => {
-    const recorderPath = "apps/web/e2e/marketing/record-product-story.ts";
-    const sourcePath = "apps/web/src/components/breadcrumbs/index.tsx";
-
-    expect(uncoveredChangedPaths([sourcePath], true)).toEqual([]);
-    expect(uncoveredChangedPaths([sourcePath], false)).toEqual([sourcePath]);
-    expect(uncoveredChangedPaths([sourcePath, recorderPath], true)).toEqual([
-      recorderPath,
-    ]);
-  });
-
   test("requires deliberate confirmation and a review reason", () => {
     expect(() => parseVerificationOptions([])).toThrow(
       "--confirm-current-recordings-reviewed",
@@ -81,5 +72,15 @@ describe("marketing recording freshness", () => {
         "Reviewed for a maintenance release",
       ]),
     ).not.toThrow();
+  });
+
+  test("never claims to attest a recording missing from the manifest", () => {
+    const partition = partitionAttestableKeys(
+      new Set(["workspace:light", "missing:dark"]),
+      new Set(["workspace:light"]),
+    );
+
+    expect([...partition.attestableKeys]).toEqual(["workspace:light"]);
+    expect(partition.neverRecorded).toEqual(["missing:dark"]);
   });
 });

--- a/scripts/check-marketing-recordings.test.ts
+++ b/scripts/check-marketing-recordings.test.ts
@@ -61,6 +61,30 @@ describe("marketing recording freshness", () => {
     });
   });
 
+  test("does not let source verification hide capture-contract drift", () => {
+    const recordedAtCommit = execFileSync("git", ["rev-parse", "HEAD"], {
+      encoding: "utf-8",
+    }).trim();
+    const verdict = judgeEntry({
+      captureId: definition.captureId,
+      dpr: definition.dpr,
+      manualVerification: {
+        reason: "Reviewed for a maintenance release",
+        watchedPathsHash: watchedPathsHashAtHead(definition.watchedPaths),
+      },
+      recordedAtCommit,
+      theme: "light",
+      viewport: {
+        height: definition.viewport.height + 1,
+        width: definition.viewport.width,
+      },
+      watchedPaths: definition.watchedPaths,
+    });
+
+    expect(verdict.status).toBe("STALE");
+    expect(verdict.reasons.at(0)).toStartWith("viewport drifted");
+  });
+
   test("requires deliberate confirmation and a review reason", () => {
     expect(() => parseVerificationOptions([])).toThrow(
       "--confirm-current-recordings-reviewed",
@@ -72,6 +96,14 @@ describe("marketing recording freshness", () => {
         "Reviewed for a maintenance release",
       ]),
     ).not.toThrow();
+    expect(() =>
+      parseVerificationOptions([
+        "--confirm-current-recordings-reviewed",
+        "--reason",
+        "Reviewed for a maintenance release",
+        "--capture",
+      ]),
+    ).toThrow("--capture must name at least one capture");
   });
 
   test("never claims to attest a recording missing from the manifest", () => {

--- a/scripts/check-marketing-recordings.ts
+++ b/scripts/check-marketing-recordings.ts
@@ -161,9 +161,18 @@ export const manualVerificationMatches = ({
   if (!verification) {
     return false;
   }
+  let artifactsHash: string;
+  try {
+    artifactsHash = recordingArtifactsHash(captureId, theme);
+  } catch (error) {
+    if (isRecord(error) && error["code"] === "ENOENT") {
+      return false;
+    }
+    throw error;
+  }
   return (
     verification.watchedPathsHash === watchedPathsHashAtHead(watchedPaths) &&
-    verification.artifactsHash === recordingArtifactsHash(captureId, theme)
+    verification.artifactsHash === artifactsHash
   );
 };
 

--- a/scripts/check-marketing-recordings.ts
+++ b/scripts/check-marketing-recordings.ts
@@ -36,7 +36,7 @@ export type RecordingManifestEntryWithVerification = RecordingManifestEntry & {
 };
 
 export type Verdict = {
-  basis: "manual-verification" | "recording" | "visual-reference" | null;
+  basis: "manual-verification" | "recording" | null;
   captureId: string;
   theme: CaptureTheme;
   status: "FRESH" | "STALE";
@@ -160,44 +160,6 @@ const changedWatchedPaths = (
   return output === "" ? [] : output.split("\n");
 };
 
-const DIRECT_INVALIDATION_PATHS = new Set([
-  "apps/web/e2e/marketing/record-product-story.ts",
-]);
-
-export const uncoveredChangedPaths = (
-  changedPaths: readonly string[],
-  visualReferenceIsCurrent: boolean,
-): string[] =>
-  changedPaths.filter(
-    (path) => DIRECT_INVALIDATION_PATHS.has(path) || !visualReferenceIsCurrent,
-  );
-
-const visualReferencePath = (visualReference: string, theme: CaptureTheme) =>
-  `apps/landing/public/media/products/${visualReference}${
-    theme === "dark" ? "-dark" : ""
-  }.png`;
-
-const gitBlob = (commit: string, path: string): string | null => {
-  try {
-    return git(["rev-parse", `${commit}:${path}`]);
-  } catch {
-    return null;
-  }
-};
-
-const visualReferenceUnchanged = (
-  recordedAtCommit: string,
-  visualReference: string | undefined,
-  theme: CaptureTheme,
-): boolean => {
-  if (!visualReference) {
-    return false;
-  }
-  const path = visualReferencePath(visualReference, theme);
-  const recordedBlob = gitBlob(recordedAtCommit, path);
-  return recordedBlob !== null && recordedBlob === gitBlob("HEAD", path);
-};
-
 export const rerecordCommand = (
   captureIds: readonly string[],
   theme?: CaptureTheme,
@@ -254,21 +216,7 @@ export const judgeEntry = (
     } else if (changedPaths.length === 0) {
       basis = "recording";
     } else {
-      const visualReferenceIsCurrent =
-        definition !== undefined &&
-        visualReferenceUnchanged(
-          entry.recordedAtCommit,
-          definition.visualReference,
-          entry.theme,
-        );
-      const uncoveredChanges = uncoveredChangedPaths(
-        changedPaths,
-        visualReferenceIsCurrent,
-      );
-      reasons.push(...uncoveredChanges.map((path) => `changed: ${path}`));
-      if (uncoveredChanges.length === 0) {
-        basis = "visual-reference";
-      }
+      reasons.push(...changedPaths.map((path) => `changed: ${path}`));
       if (entry.manualVerification && reasons.length > 0) {
         reasons.unshift(
           "manual verification does not match the watched source tree",
@@ -327,11 +275,7 @@ const main = () => {
     const label = `${verdict.captureId} (${verdict.theme})`;
     if (verdict.status === "FRESH") {
       const suffix =
-        verdict.basis === "manual-verification"
-          ? " (manual verification)"
-          : verdict.basis === "visual-reference"
-            ? " (visual reference unchanged)"
-            : "";
+        verdict.basis === "manual-verification" ? " (manual verification)" : "";
       process.stdout.write(`FRESH ${label}${suffix}\n`);
       continue;
     }

--- a/scripts/check-marketing-recordings.ts
+++ b/scripts/check-marketing-recordings.ts
@@ -27,6 +27,7 @@ const ROOT_DIR = nodePath.resolve(import.meta.dirname, "..");
 const STRICT = process.argv.includes("--strict");
 
 export type ManualRecordingVerification = {
+  artifactsHash: string;
   reason: string;
   watchedPathsHash: string;
 };
@@ -64,6 +65,8 @@ const isManualVerification = (
   value["reason"].trim() === value["reason"] &&
   value["reason"].length >= 12 &&
   value["reason"].length <= 240 &&
+  typeof value["artifactsHash"] === "string" &&
+  SHA_256_PATTERN.test(value["artifactsHash"]) &&
   typeof value["watchedPathsHash"] === "string" &&
   SHA_256_PATTERN.test(value["watchedPathsHash"]);
 
@@ -123,14 +126,45 @@ export const watchedPathsHashAtHead = (
     .digest("hex");
 };
 
-export const manualVerificationMatches = (
-  verification: ManualRecordingVerification | undefined,
-  watchedPaths: readonly string[],
-): boolean => {
+const recordingArtifactPaths = (captureId: string, theme: CaptureTheme) => {
+  const base = `apps/landing/public/media/products/story-${captureId}${
+    theme === "dark" ? "-dark" : ""
+  }`;
+  return [`${base}.mp4`, `${base}-poster.jpg`] as const;
+};
+
+export const recordingArtifactsHash = (
+  captureId: string,
+  theme: CaptureTheme,
+): string => {
+  const hasher = new Bun.CryptoHasher("sha256");
+  for (const path of recordingArtifactPaths(captureId, theme)) {
+    hasher.update(`${path}\0`);
+    hasher.update(readFileSync(nodePath.join(ROOT_DIR, path)));
+  }
+  return hasher.digest("hex");
+};
+
+type ManualVerificationMatchOptions = {
+  captureId: string;
+  theme: CaptureTheme;
+  verification: ManualRecordingVerification | undefined;
+  watchedPaths: readonly string[];
+};
+
+export const manualVerificationMatches = ({
+  captureId,
+  theme,
+  verification,
+  watchedPaths,
+}: ManualVerificationMatchOptions): boolean => {
   if (!verification) {
     return false;
   }
-  return verification.watchedPathsHash === watchedPathsHashAtHead(watchedPaths);
+  return (
+    verification.watchedPathsHash === watchedPathsHashAtHead(watchedPaths) &&
+    verification.artifactsHash === recordingArtifactsHash(captureId, theme)
+  );
 };
 
 const isKnownCommit = (commit: string): boolean => {
@@ -211,7 +245,14 @@ export const judgeEntry = (
       entry.recordedAtCommit,
       watchedPaths,
     );
-    if (manualVerificationMatches(entry.manualVerification, watchedPaths)) {
+    if (
+      manualVerificationMatches({
+        captureId: entry.captureId,
+        theme: entry.theme,
+        verification: entry.manualVerification,
+        watchedPaths,
+      })
+    ) {
       basis = "manual-verification";
     } else if (changedPaths.length === 0) {
       basis = "recording";

--- a/scripts/check-marketing-recordings.ts
+++ b/scripts/check-marketing-recordings.ts
@@ -26,7 +26,17 @@ import type {
 const ROOT_DIR = nodePath.resolve(import.meta.dirname, "..");
 const STRICT = process.argv.includes("--strict");
 
+export type ManualRecordingVerification = {
+  reason: string;
+  watchedPathsHash: string;
+};
+
+export type RecordingManifestEntryWithVerification = RecordingManifestEntry & {
+  manualVerification?: ManualRecordingVerification;
+};
+
 export type Verdict = {
+  basis: "manual-verification" | "recording" | "visual-reference" | null;
   captureId: string;
   theme: CaptureTheme;
   status: "FRESH" | "STALE";
@@ -44,7 +54,22 @@ const isViewport = (value: unknown): value is CaptureViewport =>
 const isTheme = (value: unknown): value is CaptureTheme =>
   CAPTURE_THEMES.some((theme) => theme === value);
 
-const isManifestEntry = (value: unknown): value is RecordingManifestEntry =>
+const SHA_256_PATTERN = /^[0-9a-f]{64}$/u;
+
+const isManualVerification = (
+  value: unknown,
+): value is ManualRecordingVerification =>
+  isRecord(value) &&
+  typeof value["reason"] === "string" &&
+  value["reason"].trim() === value["reason"] &&
+  value["reason"].length >= 12 &&
+  value["reason"].length <= 240 &&
+  typeof value["watchedPathsHash"] === "string" &&
+  SHA_256_PATTERN.test(value["watchedPathsHash"]);
+
+const isManifestEntry = (
+  value: unknown,
+): value is RecordingManifestEntryWithVerification =>
   isRecord(value) &&
   typeof value["captureId"] === "string" &&
   isTheme(value["theme"]) &&
@@ -52,31 +77,61 @@ const isManifestEntry = (value: unknown): value is RecordingManifestEntry =>
   typeof value["dpr"] === "number" &&
   typeof value["recordedAtCommit"] === "string" &&
   Array.isArray(value["watchedPaths"]) &&
-  value["watchedPaths"].every((path) => typeof path === "string");
+  value["watchedPaths"].every((path) => typeof path === "string") &&
+  (value["manualVerification"] === undefined ||
+    isManualVerification(value["manualVerification"]));
 
-const readManifestEntries = (): RecordingManifestEntry[] => {
-  const manifestPath = nodePath.join(ROOT_DIR, RECORDINGS_MANIFEST_PATH);
-  if (!existsSync(manifestPath)) {
-    return [];
-  }
-  const parsed: unknown = JSON.parse(readFileSync(manifestPath, "utf-8"));
-  if (!isRecord(parsed) || !Array.isArray(parsed["entries"])) {
-    throw new TypeError(
-      `${RECORDINGS_MANIFEST_PATH} must contain an entries array`,
-    );
-  }
-  return parsed["entries"].map((entry, index) => {
-    if (!isManifestEntry(entry)) {
+export const readManifestEntries =
+  (): RecordingManifestEntryWithVerification[] => {
+    const manifestPath = nodePath.join(ROOT_DIR, RECORDINGS_MANIFEST_PATH);
+    if (!existsSync(manifestPath)) {
+      return [];
+    }
+    const parsed: unknown = JSON.parse(readFileSync(manifestPath, "utf-8"));
+    if (!isRecord(parsed) || !Array.isArray(parsed["entries"])) {
       throw new TypeError(
-        `${RECORDINGS_MANIFEST_PATH} entry ${index} is malformed`,
+        `${RECORDINGS_MANIFEST_PATH} must contain an entries array`,
       );
     }
-    return entry;
-  });
-};
+    return parsed["entries"].map((entry, index) => {
+      if (!isManifestEntry(entry)) {
+        throw new TypeError(
+          `${RECORDINGS_MANIFEST_PATH} entry ${index} is malformed`,
+        );
+      }
+      return entry;
+    });
+  };
 
 const git = (args: readonly string[]): string =>
   execFileSync("git", [...args], { cwd: ROOT_DIR, encoding: "utf-8" }).trim();
+
+export const watchedPathsHashAtHead = (
+  watchedPaths: readonly string[],
+): string => {
+  const normalizedPaths = [...new Set(watchedPaths)].sort();
+  const tree = git([
+    "ls-tree",
+    "-r",
+    "--full-tree",
+    "HEAD",
+    "--",
+    ...normalizedPaths,
+  ]);
+  return new Bun.CryptoHasher("sha256")
+    .update(`${JSON.stringify(normalizedPaths)}\n${tree}\n`)
+    .digest("hex");
+};
+
+export const manualVerificationMatches = (
+  verification: ManualRecordingVerification | undefined,
+  watchedPaths: readonly string[],
+): boolean => {
+  if (!verification) {
+    return false;
+  }
+  return verification.watchedPathsHash === watchedPathsHashAtHead(watchedPaths);
+};
 
 const isKnownCommit = (commit: string): boolean => {
   try {
@@ -105,6 +160,44 @@ const changedWatchedPaths = (
   return output === "" ? [] : output.split("\n");
 };
 
+const DIRECT_INVALIDATION_PATHS = new Set([
+  "apps/web/e2e/marketing/record-product-story.ts",
+]);
+
+export const uncoveredChangedPaths = (
+  changedPaths: readonly string[],
+  visualReferenceIsCurrent: boolean,
+): string[] =>
+  changedPaths.filter(
+    (path) => DIRECT_INVALIDATION_PATHS.has(path) || !visualReferenceIsCurrent,
+  );
+
+const visualReferencePath = (visualReference: string, theme: CaptureTheme) =>
+  `apps/landing/public/media/products/${visualReference}${
+    theme === "dark" ? "-dark" : ""
+  }.png`;
+
+const gitBlob = (commit: string, path: string): string | null => {
+  try {
+    return git(["rev-parse", `${commit}:${path}`]);
+  } catch {
+    return null;
+  }
+};
+
+const visualReferenceUnchanged = (
+  recordedAtCommit: string,
+  visualReference: string | undefined,
+  theme: CaptureTheme,
+): boolean => {
+  if (!visualReference) {
+    return false;
+  }
+  const path = visualReferencePath(visualReference, theme);
+  const recordedBlob = gitBlob(recordedAtCommit, path);
+  return recordedBlob !== null && recordedBlob === gitBlob("HEAD", path);
+};
+
 export const rerecordCommand = (
   captureIds: readonly string[],
   theme?: CaptureTheme,
@@ -116,8 +209,11 @@ export const rerecordCommand = (
     "bun run capture:product-story",
   ].join(" ");
 
-const judgeEntry = (entry: RecordingManifestEntry): Verdict => {
+export const judgeEntry = (
+  entry: RecordingManifestEntryWithVerification,
+): Verdict => {
   const reasons: string[] = [];
+  let basis: Verdict["basis"] = null;
   const definition = captureDefinitions.find(
     ({ captureId }) => captureId === entry.captureId,
   );
@@ -149,14 +245,40 @@ const judgeEntry = (entry: RecordingManifestEntry): Verdict => {
     // a watched path added to captures.ts after a recording must invalidate
     // that recording too, which a stored snapshot could never do.
     const watchedPaths = definition?.watchedPaths ?? entry.watchedPaths;
-    reasons.push(
-      ...changedWatchedPaths(entry.recordedAtCommit, watchedPaths).map(
-        (path) => `changed: ${path}`,
-      ),
+    const changedPaths = changedWatchedPaths(
+      entry.recordedAtCommit,
+      watchedPaths,
     );
+    if (manualVerificationMatches(entry.manualVerification, watchedPaths)) {
+      basis = "manual-verification";
+    } else if (changedPaths.length === 0) {
+      basis = "recording";
+    } else {
+      const visualReferenceIsCurrent =
+        definition !== undefined &&
+        visualReferenceUnchanged(
+          entry.recordedAtCommit,
+          definition.visualReference,
+          entry.theme,
+        );
+      const uncoveredChanges = uncoveredChangedPaths(
+        changedPaths,
+        visualReferenceIsCurrent,
+      );
+      reasons.push(...uncoveredChanges.map((path) => `changed: ${path}`));
+      if (uncoveredChanges.length === 0) {
+        basis = "visual-reference";
+      }
+      if (entry.manualVerification && reasons.length > 0) {
+        reasons.unshift(
+          "manual verification does not match the watched source tree",
+        );
+      }
+    }
   }
 
   return {
+    basis: reasons.length === 0 ? basis : null,
     captureId: entry.captureId,
     theme: entry.theme,
     status: reasons.length === 0 ? "FRESH" : "STALE",
@@ -182,6 +304,7 @@ export const computeVerdicts = (): Verdict[] => {
         continue;
       }
       verdicts.push({
+        basis: null,
         captureId: definition.captureId,
         theme,
         status: "STALE",
@@ -203,7 +326,13 @@ const main = () => {
   for (const verdict of verdicts) {
     const label = `${verdict.captureId} (${verdict.theme})`;
     if (verdict.status === "FRESH") {
-      process.stdout.write(`FRESH ${label}\n`);
+      const suffix =
+        verdict.basis === "manual-verification"
+          ? " (manual verification)"
+          : verdict.basis === "visual-reference"
+            ? " (visual reference unchanged)"
+            : "";
+      process.stdout.write(`FRESH ${label}${suffix}\n`);
       continue;
     }
     process.stdout.write(`STALE ${label}\n`);

--- a/scripts/check-marketing-recordings.ts
+++ b/scripts/check-marketing-recordings.ts
@@ -254,15 +254,14 @@ export const judgeEntry = (
       })
     ) {
       basis = "manual-verification";
+    } else if (entry.manualVerification) {
+      reasons.push(
+        "manual verification does not match the watched source tree or recording artifacts",
+      );
     } else if (changedPaths.length === 0) {
       basis = "recording";
     } else {
       reasons.push(...changedPaths.map((path) => `changed: ${path}`));
-      if (entry.manualVerification && reasons.length > 0) {
-        reasons.unshift(
-          "manual verification does not match the watched source tree",
-        );
-      }
     }
   }
 

--- a/scripts/verify-marketing-recordings.ts
+++ b/scripts/verify-marketing-recordings.ts
@@ -15,6 +15,7 @@ import {
 } from "../apps/web/e2e/marketing/captures";
 import {
   computeVerdicts,
+  judgeEntry,
   readManifestEntries,
   watchedPathsHashAtHead,
 } from "./check-marketing-recordings";
@@ -43,7 +44,8 @@ class MarketingVerificationError extends Error {
 
 const optionValue = (args: readonly string[], flag: string) => {
   const index = args.indexOf(flag);
-  return index === -1 ? undefined : args.at(index + 1);
+  const value = index === -1 ? undefined : args.at(index + 1);
+  return value?.startsWith("--") ? undefined : value;
 };
 
 export const parseVerificationOptions = (
@@ -66,10 +68,15 @@ export const parseVerificationOptions = (
     );
   }
   const captureValue = optionValue(args, CAPTURE_FLAG);
+  if (args.includes(CAPTURE_FLAG) && !captureValue) {
+    throw new MarketingVerificationError(
+      `${CAPTURE_FLAG} must name at least one capture`,
+    );
+  }
   const captureIds = captureValue
     ? new Set(captureValue.split(",").filter(Boolean))
     : null;
-  if (captureValue !== undefined && captureIds?.size === 0) {
+  if (captureIds?.size === 0) {
     throw new MarketingVerificationError(
       `${CAPTURE_FLAG} must name at least one capture`,
     );
@@ -148,8 +155,8 @@ const main = () => {
     manifestKeys,
   );
   if (neverRecorded.length > 0) {
-    process.stdout.write(
-      `marketing-verification: skipped never-recorded ${neverRecorded.join(", ")}\n`,
+    throw new MarketingVerificationError(
+      `Cannot verify never-recorded capture(s): ${neverRecorded.join(", ")}`,
     );
   }
   if (staleKeys.size === 0) {
@@ -190,6 +197,20 @@ const main = () => {
       },
     };
   });
+  const unresolved = entries
+    .filter((entry) => staleKeys.has(`${entry.captureId}:${entry.theme}`))
+    .map(judgeEntry)
+    .filter(({ status }) => status === "STALE");
+  if (unresolved.length > 0) {
+    throw new MarketingVerificationError(
+      `Verification cannot clear: ${unresolved
+        .map(
+          ({ captureId, reasons, theme }) =>
+            `${captureId}:${theme} (${reasons.join("; ")})`,
+        )
+        .join(", ")}`,
+    );
+  }
 
   writeFileSync(
     nodePath.join(ROOT_DIR, RECORDINGS_MANIFEST_PATH),

--- a/scripts/verify-marketing-recordings.ts
+++ b/scripts/verify-marketing-recordings.ts
@@ -42,21 +42,52 @@ class MarketingVerificationError extends Error {
   }
 }
 
-const optionValue = (args: readonly string[], flag: string) => {
-  const index = args.indexOf(flag);
-  const value = index === -1 ? undefined : args.at(index + 1);
-  return value?.startsWith("--") ? undefined : value;
-};
-
 export const parseVerificationOptions = (
   args: readonly string[],
 ): VerificationOptions => {
-  if (!args.includes(CONFIRMATION_FLAG)) {
+  let confirmed = false;
+  let reason: string | undefined;
+  let captureValue: string | undefined;
+  const seenFlags = new Set<string>();
+
+  for (let index = 0; index < args.length; index += 1) {
+    const flag = args.at(index);
+    if (!flag) {
+      throw new MarketingVerificationError("Unknown empty argument");
+    }
+    if (
+      flag !== CONFIRMATION_FLAG &&
+      flag !== REASON_FLAG &&
+      flag !== CAPTURE_FLAG
+    ) {
+      throw new MarketingVerificationError(`Unknown argument: ${flag}`);
+    }
+    if (seenFlags.has(flag)) {
+      throw new MarketingVerificationError(`${flag} may be passed only once`);
+    }
+    seenFlags.add(flag);
+
+    if (flag === CONFIRMATION_FLAG) {
+      confirmed = true;
+      continue;
+    }
+    const value = args.at(index + 1);
+    if (!value || value.startsWith("--")) {
+      throw new MarketingVerificationError(`${flag} requires a value`);
+    }
+    index += 1;
+    if (flag === REASON_FLAG) {
+      reason = value;
+    } else {
+      captureValue = value;
+    }
+  }
+
+  if (!confirmed) {
     throw new MarketingVerificationError(
       `Pass ${CONFIRMATION_FLAG} after visually reviewing every selected recording`,
     );
   }
-  const reason = optionValue(args, REASON_FLAG);
   if (
     !reason ||
     reason.trim() !== reason ||
@@ -65,12 +96,6 @@ export const parseVerificationOptions = (
   ) {
     throw new MarketingVerificationError(
       `${REASON_FLAG} must be a trimmed reason between 12 and 240 characters`,
-    );
-  }
-  const captureValue = optionValue(args, CAPTURE_FLAG);
-  if (args.includes(CAPTURE_FLAG) && !captureValue) {
-    throw new MarketingVerificationError(
-      `${CAPTURE_FLAG} must name at least one capture`,
     );
   }
   const captureIds = captureValue

--- a/scripts/verify-marketing-recordings.ts
+++ b/scripts/verify-marketing-recordings.ts
@@ -17,6 +17,7 @@ import {
   computeVerdicts,
   judgeEntry,
   readManifestEntries,
+  recordingArtifactsHash,
   watchedPathsHashAtHead,
 } from "./check-marketing-recordings";
 
@@ -217,6 +218,7 @@ const main = () => {
     return {
       ...entry,
       manualVerification: {
+        artifactsHash: recordingArtifactsHash(entry.captureId, entry.theme),
         reason: options.reason,
         watchedPathsHash: watchedPathsHashAtHead(definition.watchedPaths),
       },

--- a/scripts/verify-marketing-recordings.ts
+++ b/scripts/verify-marketing-recordings.ts
@@ -29,6 +29,11 @@ type VerificationOptions = {
   reason: string;
 };
 
+type AttestableKeyPartition = {
+  attestableKeys: ReadonlySet<string>;
+  neverRecorded: readonly string[];
+};
+
 class MarketingVerificationError extends Error {
   constructor(message: string) {
     super(message);
@@ -83,19 +88,41 @@ export const parseVerificationOptions = (
   return { captureIds, reason };
 };
 
+export const partitionAttestableKeys = (
+  selectedKeys: ReadonlySet<string>,
+  manifestKeys: ReadonlySet<string>,
+): AttestableKeyPartition => ({
+  attestableKeys: new Set(
+    [...selectedKeys].filter((key) => manifestKeys.has(key)),
+  ),
+  neverRecorded: [...selectedKeys].filter((key) => !manifestKeys.has(key)),
+});
+
 const assertWatchedPathsClean = (watchedPaths: readonly string[]) => {
-  const result = Bun.spawnSync([
-    "git",
-    "status",
-    "--porcelain=v1",
-    "--untracked-files=all",
-    "--",
-    ...watchedPaths,
-  ], {
-    cwd: ROOT_DIR,
-    stdout: "pipe",
-  });
-  if (!result.success || result.stdout.length > 0) {
+  const result = Bun.spawnSync(
+    [
+      "git",
+      "status",
+      "--porcelain=v1",
+      "--untracked-files=all",
+      "--",
+      ...watchedPaths,
+    ],
+    {
+      cwd: ROOT_DIR,
+      stderr: "pipe",
+      stdout: "pipe",
+    },
+  );
+  if (!result.success) {
+    const detail = new TextDecoder().decode(result.stderr).trim();
+    throw new MarketingVerificationError(
+      detail === ""
+        ? `git status failed with exit code ${String(result.exitCode)}`
+        : `git status failed: ${detail}`,
+    );
+  }
+  if (result.stdout.length > 0) {
     throw new MarketingVerificationError(
       "Commit watched-path changes before creating a manual verification",
     );
@@ -104,7 +131,11 @@ const assertWatchedPathsClean = (watchedPaths: readonly string[]) => {
 
 const main = () => {
   const options = parseVerificationOptions(process.argv.slice(2));
-  const staleKeys = new Set(
+  const manifestEntries = readManifestEntries();
+  const manifestKeys = new Set(
+    manifestEntries.map((entry) => `${entry.captureId}:${entry.theme}`),
+  );
+  const selectedStaleKeys = new Set(
     computeVerdicts()
       .filter(
         ({ captureId, status }) =>
@@ -112,6 +143,15 @@ const main = () => {
       )
       .map(({ captureId, theme }) => `${captureId}:${theme}`),
   );
+  const { attestableKeys: staleKeys, neverRecorded } = partitionAttestableKeys(
+    selectedStaleKeys,
+    manifestKeys,
+  );
+  if (neverRecorded.length > 0) {
+    process.stdout.write(
+      `marketing-verification: skipped never-recorded ${neverRecorded.join(", ")}\n`,
+    );
+  }
   if (staleKeys.size === 0) {
     process.stdout.write(
       "marketing-verification: no selected stale recordings\n",
@@ -132,7 +172,7 @@ const main = () => {
   ];
   assertWatchedPathsClean(watchedPaths);
 
-  const entries = readManifestEntries().map((entry) => {
+  const entries = manifestEntries.map((entry) => {
     if (!staleKeys.has(`${entry.captureId}:${entry.theme}`)) {
       return entry;
     }

--- a/scripts/verify-marketing-recordings.ts
+++ b/scripts/verify-marketing-recordings.ts
@@ -1,0 +1,175 @@
+#!/usr/bin/env bun
+
+// Explicit release escape hatch for recordings that were visually reviewed
+// against the current product but do not need to be re-recorded. The
+// attestation binds that review to the exact watched source tree, so the next
+// relevant code change makes it stale automatically.
+
+import { execFileSync } from "node:child_process";
+import { writeFileSync } from "node:fs";
+import nodePath from "node:path";
+
+import {
+  captureDefinitions,
+  RECORDINGS_MANIFEST_PATH,
+} from "../apps/web/e2e/marketing/captures";
+import {
+  computeVerdicts,
+  readManifestEntries,
+  watchedPathsHashAtHead,
+} from "./check-marketing-recordings";
+
+const ROOT_DIR = nodePath.resolve(import.meta.dirname, "..");
+const CONFIRMATION_FLAG = "--confirm-current-recordings-reviewed";
+const REASON_FLAG = "--reason";
+const CAPTURE_FLAG = "--capture";
+
+type VerificationOptions = {
+  captureIds: ReadonlySet<string> | null;
+  reason: string;
+};
+
+class MarketingVerificationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "MarketingVerificationError";
+  }
+}
+
+const optionValue = (args: readonly string[], flag: string) => {
+  const index = args.indexOf(flag);
+  return index === -1 ? undefined : args.at(index + 1);
+};
+
+export const parseVerificationOptions = (
+  args: readonly string[],
+): VerificationOptions => {
+  if (!args.includes(CONFIRMATION_FLAG)) {
+    throw new MarketingVerificationError(
+      `Pass ${CONFIRMATION_FLAG} after visually reviewing every selected recording`,
+    );
+  }
+  const reason = optionValue(args, REASON_FLAG);
+  if (
+    !reason ||
+    reason.trim() !== reason ||
+    reason.length < 12 ||
+    reason.length > 240
+  ) {
+    throw new MarketingVerificationError(
+      `${REASON_FLAG} must be a trimmed reason between 12 and 240 characters`,
+    );
+  }
+  const captureValue = optionValue(args, CAPTURE_FLAG);
+  const captureIds = captureValue
+    ? new Set(captureValue.split(",").filter(Boolean))
+    : null;
+  if (captureValue !== undefined && captureIds?.size === 0) {
+    throw new MarketingVerificationError(
+      `${CAPTURE_FLAG} must name at least one capture`,
+    );
+  }
+  const knownCaptureIds = new Set(
+    captureDefinitions.map(({ captureId }) => captureId),
+  );
+  const unknownCaptureIds = [...(captureIds ?? [])].filter(
+    (captureId) => !knownCaptureIds.has(captureId),
+  );
+  if (unknownCaptureIds.length > 0) {
+    throw new MarketingVerificationError(
+      `Unknown capture id(s): ${unknownCaptureIds.join(", ")}`,
+    );
+  }
+  return { captureIds, reason };
+};
+
+const assertWatchedPathsClean = (watchedPaths: readonly string[]) => {
+  const result = Bun.spawnSync([
+    "git",
+    "status",
+    "--porcelain=v1",
+    "--untracked-files=all",
+    "--",
+    ...watchedPaths,
+  ], {
+    cwd: ROOT_DIR,
+    stdout: "pipe",
+  });
+  if (!result.success || result.stdout.length > 0) {
+    throw new MarketingVerificationError(
+      "Commit watched-path changes before creating a manual verification",
+    );
+  }
+};
+
+const main = () => {
+  const options = parseVerificationOptions(process.argv.slice(2));
+  const staleKeys = new Set(
+    computeVerdicts()
+      .filter(
+        ({ captureId, status }) =>
+          status === "STALE" && (options.captureIds?.has(captureId) ?? true),
+      )
+      .map(({ captureId, theme }) => `${captureId}:${theme}`),
+  );
+  if (staleKeys.size === 0) {
+    process.stdout.write(
+      "marketing-verification: no selected stale recordings\n",
+    );
+    return;
+  }
+
+  const definitionsById = new Map(
+    captureDefinitions.map((definition) => [definition.captureId, definition]),
+  );
+  const watchedPaths = [
+    ...new Set(
+      [...staleKeys].flatMap((key) => {
+        const captureId = key.slice(0, key.lastIndexOf(":"));
+        return definitionsById.get(captureId)?.watchedPaths ?? [];
+      }),
+    ),
+  ];
+  assertWatchedPathsClean(watchedPaths);
+
+  const entries = readManifestEntries().map((entry) => {
+    if (!staleKeys.has(`${entry.captureId}:${entry.theme}`)) {
+      return entry;
+    }
+    const definition = definitionsById.get(entry.captureId);
+    if (!definition) {
+      throw new MarketingVerificationError(
+        `Missing capture definition for ${entry.captureId}`,
+      );
+    }
+    return {
+      ...entry,
+      manualVerification: {
+        reason: options.reason,
+        watchedPathsHash: watchedPathsHashAtHead(definition.watchedPaths),
+      },
+    };
+  });
+
+  writeFileSync(
+    nodePath.join(ROOT_DIR, RECORDINGS_MANIFEST_PATH),
+    `${JSON.stringify({ entries }, null, 2)}\n`,
+  );
+  const head = execFileSync("git", ["rev-parse", "--short", "HEAD"], {
+    cwd: ROOT_DIR,
+    encoding: "utf-8",
+  }).trim();
+  process.stdout.write(
+    `marketing-verification: attested ${String(staleKeys.size)} recording(s) against ${head}\n`,
+  );
+};
+
+if (import.meta.main) {
+  try {
+    main();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`marketing-verification: ${message}`);
+    process.exit(1);
+  }
+}

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -184,6 +184,8 @@ run_step "Workspace hygiene" bun run lint:ws
 run_step "Lockfile workspace-version guard" bun scripts/check-lockfile-workspace-versions.ts
 run_step "Policy evidence" bun run policies:check
 run_step "Marketing content evidence" bun run marketing:check
+run_step "Marketing recording verification self-test" bun test \
+  scripts/check-marketing-recordings.test.ts
 run_step "Railway template shape" bun run check:railway-template
 run_step "i18n" bun run i18n:check
 run_step "Release changelog guard" bash scripts/check-release-changelog.sh --base "$base_ref"


### PR DESCRIPTION
## Summary

- add an explicit source-tree-bound verification command for reviewed recordings
- keep watched source changes stale until a recording is re-shot or deliberately attested
- prevent verification from covering never-recorded captures or dirty source trees

## Validation

- `bun test scripts/check-marketing-recordings.test.ts`
- `bun run marketing:check`
- `bun run marketing:stale`
- `bun run security:audit`

Local lint and typecheck omitted; CI runs both.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a command to manually verify visually reviewed marketing recordings with a reason and optional capture selection.
  * Verification now records the current media and source state, identifying recordings that become outdated after relevant changes.

* **Bug Fixes**
  * Improved detection of stale recordings, including viewport changes and missing recording manifests.

* **Tests**
  * Added automated coverage for verification validation, freshness checks, and stale recording detection.
  * Integrated marketing recording checks into CI and verification workflows.

* **Documentation**
  * Documented the marketing recording verification process and available options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->