### PR TITLE
fix: harden provider structured output schemas

### DIFF
--- a/.github/workflows/ai-provider-canary.yml
+++ b/.github/workflows/ai-provider-canary.yml
@@ -37,7 +37,7 @@ jobs:
   provider-canary:
     name: ${{ matrix.provider }} capability contract
     runs-on: ubuntu-latest
-    # Weekly serial probe timeouts total at most 410 seconds; leave room for
+    # Weekly serial probe timeouts total at most 650 seconds; leave room for
     # runner setup and install. Daily runs remain below the previous 10-minute budget.
     timeout-minutes: 15
     permissions:

--- a/apps/api/scripts/ai-provider-canary-config.test.ts
+++ b/apps/api/scripts/ai-provider-canary-config.test.ts
@@ -26,6 +26,18 @@ describe("AI provider canary role budgets", () => {
 });
 
 describe("AI provider canary coverage", () => {
+  test("keeps the scheduled workflow matrix aligned with the provider catalog", async () => {
+    const workflow = await Bun.file(
+      new URL(
+        "../../../.github/workflows/ai-provider-canary.yml",
+        import.meta.url,
+      ),
+    ).text();
+    const scheduledMatrix = JSON.stringify(CANARY_PROVIDERS);
+
+    expect(workflow).toContain(`|| '${scheduledMatrix}'`);
+  });
+
   test("requires every supported provider for an all-provider run", () => {
     const configuredProviders = CANARY_PROVIDERS.filter(
       (provider) => provider !== "bedrock",

--- a/apps/api/scripts/ai-provider-canary-weekly.test.ts
+++ b/apps/api/scripts/ai-provider-canary-weekly.test.ts
@@ -30,7 +30,7 @@ describe("AI provider weekly tool shapes", () => {
 
         const projected = projectSchemaInputJsonSchema(
           tool.inputSchema,
-          providerSafeJsonSchemaOptionsForTanStackProvider(provider),
+          providerSafeJsonSchemaOptionsForTanStackProvider(provider, "tool"),
         );
         const jsonSchema = convertSchemaToJsonSchema(projected);
 

--- a/apps/api/scripts/ai-provider-canary.ts
+++ b/apps/api/scripts/ai-provider-canary.ts
@@ -241,6 +241,32 @@ const CANARY_CACHING = {
 
 const structuredOutputSchema = v.strictObject({ ok: v.literal(true) });
 
+// Exercises the nested-array constraint shape that provider schema compilers
+// treat differently from a trivial object. The content is synthetic; this
+// canary exists to catch provider drift in the exact shared projection used by
+// production structured-output calls.
+const nestedStructuredOutputSchema = v.strictObject({
+  entries: v.pipe(
+    v.array(
+      v.strictObject({
+        heading: v.string(),
+        status: v.picklist(["accepted", "needs-work", "not-applicable"]),
+        explanation: v.string(),
+        primaryEvidence: v.pipe(
+          v.array(v.strictObject({ source: v.string(), locator: v.string() })),
+          v.maxLength(8),
+        ),
+        secondaryEvidence: v.pipe(
+          v.array(v.strictObject({ source: v.string(), locator: v.string() })),
+          v.maxLength(8),
+        ),
+        suggestedRevision: v.nullable(v.string()),
+      }),
+    ),
+    v.maxLength(200),
+  ),
+});
+
 const strictTool = toolDefinition({
   name: "canary_closed_tool",
   description: "Synthetic no-op tool with a closed input schema.",
@@ -325,7 +351,12 @@ type ModelRoleProbe = ProbeBase & {
   role: ModelRole;
 };
 
-type Probe = CapabilityProbe | ModelRoleProbe;
+type StructuredOutputModelRoleProbe = ProbeBase & {
+  type: "structured-output-role";
+  role: ModelRole;
+};
+
+type Probe = CapabilityProbe | ModelRoleProbe | StructuredOutputModelRoleProbe;
 
 type CanaryContext = {
   config: OrgAIConfig;
@@ -363,6 +394,18 @@ const modelRoleProbes = MODEL_ROLES.map(
         await runModelRoleProbe({ context, role, signal });
       },
     }) satisfies ModelRoleProbe,
+);
+
+const structuredOutputModelRoleProbes = MODEL_ROLES.map(
+  (role) =>
+    ({
+      type: "structured-output-role",
+      role,
+      timeoutMs: MODEL_ROLE_PROBE_TIMEOUT_MS,
+      run: async (context, signal) => {
+        await runStructuredOutputModelRoleProbe({ context, role, signal });
+      },
+    }) satisfies StructuredOutputModelRoleProbe,
 );
 
 const capabilityProbes = [
@@ -445,6 +488,7 @@ const capabilityProbes = [
 
 const probes = [
   ...modelRoleProbes,
+  ...structuredOutputModelRoleProbes,
   ...capabilityProbes,
 ] satisfies readonly Probe[];
 
@@ -503,6 +547,24 @@ const runModelRoleProbe = async ({
   requireExpectedRoleOutput(output, role);
 };
 
+const runStructuredOutputModelRoleProbe = async ({
+  context: { config },
+  role,
+  signal,
+}: RunModelRoleProbeOptions): Promise<void> => {
+  await generateTanStackObjectForRole({
+    abortSignal: signal,
+    caching: NO_CACHING,
+    maxOutputTokens: modelRoleMaxOutputTokens(role),
+    organizationId: null,
+    orgAIConfig: config,
+    outputSchema: nestedStructuredOutputSchema,
+    prompt: "Return an object with an empty entries array.",
+    role,
+    serviceTier: "standard",
+  });
+};
+
 type RunWeeklyModelRoleProbeOptions = {
   context: WeeklyCanaryContext;
   role: ModelRole;
@@ -536,6 +598,24 @@ const runWeeklyModelRoleProbe = async ({
     serviceTier: "standard",
   });
   requireExpectedRoleOutput(output, role);
+};
+
+const runWeeklyStructuredOutputModelRoleProbe = async ({
+  context: { rotatedConfig },
+  role,
+  signal,
+}: RunWeeklyModelRoleProbeOptions): Promise<void> => {
+  await generateTanStackObjectForRole({
+    abortSignal: signal,
+    caching: NO_CACHING,
+    maxOutputTokens: modelRoleMaxOutputTokens(role),
+    organizationId: null,
+    orgAIConfig: rotatedConfig,
+    outputSchema: nestedStructuredOutputSchema,
+    prompt: "Return an object with an empty entries array.",
+    role,
+    serviceTier: "standard",
+  });
 };
 
 type RunToolCallRoundTripProbeOptions = {
@@ -666,7 +746,7 @@ const runToolProbe = async ({
   });
   const inputSchema = projectSchemaInputJsonSchema(
     tool.inputSchema,
-    providerSafeJsonSchemaOptionsForTanStackProvider(provider),
+    providerSafeJsonSchemaOptionsForTanStackProvider(provider, "tool"),
   );
   const projectedTool = {
     ...tool,
@@ -860,10 +940,12 @@ const probeLabel = (context: CanaryContext, probe: Probe): string => {
   }
 
   const modelId =
-    probe.role === "pdf"
+    probe.type === "model-role" && probe.role === "pdf"
       ? pdfCanarySelection(context.provider)?.modelId
       : DEFAULT_MODELS[context.provider][probe.role];
-  return `role-${probe.role}:${modelId ?? "unsupported"}`;
+  const prefix =
+    probe.type === "structured-output-role" ? "structured-role" : "role";
+  return `${prefix}-${probe.role}:${modelId ?? "unsupported"}`;
 };
 
 const run = async (): Promise<void> => {
@@ -921,8 +1003,8 @@ const runProbes = async (
 
   const label = probeLabel(context, probe);
   if (
-    probe.type === "model-role" &&
-    (probe.role === "pdf"
+    probe.type !== "capability" &&
+    (probe.type === "model-role" && probe.role === "pdf"
       ? pdfCanarySelection(context.provider) === null
       : !isBYOKProviderRoleSupported({
           provider: context.provider,
@@ -964,6 +1046,23 @@ const runWeeklyCanaryProbes = async (
     } catch (error) {
       console.error(
         `[ai-canary] ${context.provider}/${label}: failed (${errorSummary(error, signal)})`,
+      );
+      totalFailures += 1;
+    }
+
+    const structuredLabel = `weekly-structured-role-${role}:${context.rotation.modelId}`;
+    const structuredSignal = AbortSignal.timeout(MODEL_ROLE_PROBE_TIMEOUT_MS);
+    try {
+      // oxlint-disable-next-line no-await-in-loop -- provider probes must stay sequential so rate limits and output remain deterministic.
+      await runWeeklyStructuredOutputModelRoleProbe({
+        context,
+        role,
+        signal: structuredSignal,
+      });
+      console.log(`[ai-canary] ${context.provider}/${structuredLabel}: passed`);
+    } catch (error) {
+      console.error(
+        `[ai-canary] ${context.provider}/${structuredLabel}: failed (${errorSummary(error, structuredSignal)})`,
       );
       totalFailures += 1;
     }

--- a/apps/api/src/dev/register-mock-ai.test.ts
+++ b/apps/api/src/dev/register-mock-ai.test.ts
@@ -28,7 +28,10 @@ const structuredOutputSchemaFor = (
 ): unknown => {
   const tanStackSchema = toTanStackValibotSchema(
     schema,
-    providerSafeJsonSchemaOptionsForTanStackProvider(provider),
+    providerSafeJsonSchemaOptionsForTanStackProvider(
+      provider,
+      "structured-output",
+    ),
   );
   return convertSchemaToJsonSchema(tanStackSchema, {
     forStructuredOutput: true,

--- a/apps/api/src/handlers/chat/stream-chat.ts
+++ b/apps/api/src/handlers/chat/stream-chat.ts
@@ -416,8 +416,10 @@ const projectServerToolsForProvider = ({
   provider: string;
   serverTools: readonly ServerTool[];
 }): ServerTool[] => {
-  const projectionOptions =
-    providerSafeJsonSchemaOptionsForTanStackProvider(provider);
+  const projectionOptions = providerSafeJsonSchemaOptionsForTanStackProvider(
+    provider,
+    "tool",
+  );
   const projectedTools: ServerTool[] = [];
   for (const tool of serverTools) {
     const projectedTool = { ...tool };

--- a/apps/api/src/handlers/chat/tools/tool-schema.test.ts
+++ b/apps/api/src/handlers/chat/tools/tool-schema.test.ts
@@ -1166,7 +1166,7 @@ describe("chat tool schemas", () => {
           nullableNote: v.nullable(v.string()),
         }),
       ),
-      providerSafeJsonSchemaOptionsForTanStackProvider("mistral"),
+      providerSafeJsonSchemaOptionsForTanStackProvider("mistral", "tool"),
     );
     const inputSchema = convertSchemaToJsonSchema(projectedInputSchema);
     if (!inputSchema?.properties) {

--- a/apps/api/src/lib/chat/provider-tool-projection.ts
+++ b/apps/api/src/lib/chat/provider-tool-projection.ts
@@ -9,8 +9,10 @@ export const projectChatToolSchemasForProvider = ({
   modelTools: ReturnType<typeof chatToolMapToArray>;
   provider: string;
 }): ReturnType<typeof chatToolMapToArray> => {
-  const projectionOptions =
-    providerSafeJsonSchemaOptionsForTanStackProvider(provider);
+  const projectionOptions = providerSafeJsonSchemaOptionsForTanStackProvider(
+    provider,
+    "tool",
+  );
   const projectedTools: ReturnType<typeof chatToolMapToArray> = [];
   for (const tool of modelTools) {
     const projectedTool = { ...tool };

--- a/apps/api/src/lib/provider-safe-json-schema.test.ts
+++ b/apps/api/src/lib/provider-safe-json-schema.test.ts
@@ -11,7 +11,10 @@ import {
   projectToProviderSafeJsonSchema,
   PROVIDER_SAFE_JSON_SCHEMA_KEYWORDS,
 } from "@/api/lib/provider-safe-json-schema";
-import { projectSchemaInputJsonSchema } from "@/api/lib/tanstack-ai-schema";
+import {
+  projectSchemaInputJsonSchema,
+  toTanStackValibotSchema,
+} from "@/api/lib/tanstack-ai-schema";
 
 const PROVIDER_SAFE_KEYWORDS = new Set<string>(
   PROVIDER_SAFE_JSON_SCHEMA_KEYWORDS,
@@ -120,20 +123,91 @@ const schemaWithComposition = fc.oneof(
 
 describe("projectToProviderSafeJsonSchema", () => {
   test("selects explicit schema dialects for provider adapters", () => {
-    expect(providerSafeJsonSchemaOptionsForTanStackProvider("google")).toEqual({
+    expect(
+      providerSafeJsonSchemaOptionsForTanStackProvider(
+        "google",
+        "structured-output",
+      ),
+    ).toEqual({
+      arrayBoundStrategy: "omit",
       enumValueStrategy: "string-only",
       nullUnionStrategy: "openapi",
     });
     expect(
-      providerSafeJsonSchemaOptionsForTanStackProvider("openrouter"),
+      providerSafeJsonSchemaOptionsForTanStackProvider("google", "tool"),
     ).toEqual({
+      arrayBoundStrategy: "preserve",
+      enumValueStrategy: "string-only",
+      nullUnionStrategy: "openapi",
+    });
+    expect(
+      providerSafeJsonSchemaOptionsForTanStackProvider("openrouter", "tool"),
+    ).toEqual({
+      arrayBoundStrategy: "preserve",
       enumValueStrategy: "string-only",
       nullUnionStrategy: "json-schema",
     });
-    expect(providerSafeJsonSchemaOptionsForTanStackProvider("openai")).toEqual({
+    expect(
+      providerSafeJsonSchemaOptionsForTanStackProvider(
+        "openai",
+        "structured-output",
+      ),
+    ).toEqual({
+      arrayBoundStrategy: "preserve",
       enumValueStrategy: "json-schema",
       nullUnionStrategy: "json-schema",
     });
+  });
+
+  test("keeps Gemini structured-output array bounds local", () => {
+    const evidenceSchema = v.strictObject({
+      source: v.string(),
+      locator: v.string(),
+    });
+    const sourceSchema = v.strictObject({
+      entries: v.pipe(
+        v.array(
+          v.strictObject({
+            heading: v.string(),
+            status: v.picklist(["accepted", "needs-work", "not-applicable"]),
+            explanation: v.string(),
+            primaryEvidence: v.pipe(v.array(evidenceSchema), v.maxLength(8)),
+            secondaryEvidence: v.pipe(v.array(evidenceSchema), v.maxLength(8)),
+            suggestedRevision: v.nullable(v.string()),
+          }),
+        ),
+        v.minLength(1),
+        v.maxLength(200),
+      ),
+    });
+    const providerSchema = convertSchemaToJsonSchema(
+      toTanStackValibotSchema(
+        sourceSchema,
+        providerSafeJsonSchemaOptionsForTanStackProvider(
+          "google",
+          "structured-output",
+        ),
+      ),
+    );
+
+    expect(providerSchema).toBeDefined();
+    const providerKeywords = collectProjectedSchemaKeywords(providerSchema);
+    expect(providerKeywords.has("minItems")).toBe(false);
+    expect(providerKeywords.has("maxItems")).toBe(false);
+
+    expect(() => v.parse(sourceSchema, { entries: [] })).toThrow();
+
+    const tooManyEntries = {
+      entries: Array.from({ length: 201 }, (_, index) => ({
+        heading: `Section ${String(index + 1)}`,
+        status: "accepted",
+        explanation: "Synthetic review note.",
+        primaryEvidence: [],
+        secondaryEvidence: [],
+        suggestedRevision: null,
+      })),
+    };
+    expect(() => v.parse(sourceSchema, tooManyEntries)).toThrow();
   });
 
   test("drops propertyNames from the fill_template repro while keeping additionalProperties", () => {

--- a/apps/api/src/lib/provider-safe-json-schema.ts
+++ b/apps/api/src/lib/provider-safe-json-schema.ts
@@ -69,15 +69,29 @@ export type ProviderSafeJsonSchemaProjection = {
 
 export type NullUnionStrategy = "json-schema" | "openapi";
 export type EnumValueStrategy = "json-schema" | "string-only";
+export type ArrayBoundStrategy = "preserve" | "omit";
+export type ProviderJsonSchemaPurpose = "structured-output" | "tool";
 
 export type ProviderSafeJsonSchemaProjectionOptions = {
+  arrayBoundStrategy?: ArrayBoundStrategy;
   enumValueStrategy?: EnumValueStrategy;
   nullUnionStrategy?: NullUnionStrategy;
 };
 
 export const providerSafeJsonSchemaOptionsForTanStackProvider = (
   provider: string,
+  purpose: ProviderJsonSchemaPurpose,
 ): ProviderSafeJsonSchemaProjectionOptions => ({
+  // Gemini counts array bounds against an undocumented structured-output
+  // schema complexity budget. A nested schema accepted without maxItems can
+  // be rejected with HTTP 400 as soon as the same bound is added. Bounds are
+  // validation constraints, not shape information, and the original Standard
+  // Schema still validates the returned value locally. Tool schemas use a
+  // separate profile because their bounds remain useful provider guidance.
+  arrayBoundStrategy:
+    provider === "google" && purpose === "structured-output"
+      ? "omit"
+      : "preserve",
   enumValueStrategy:
     provider === "google" || provider === "openrouter"
       ? "string-only"
@@ -118,6 +132,7 @@ const resolveLocalJsonPointer = (root: JsonObject, ref: string): unknown => {
 type ProjectionContext = {
   root: JsonObject;
   dropped: string[];
+  arrayBoundStrategy: ArrayBoundStrategy;
   enumValueStrategy: EnumValueStrategy;
   nullUnionStrategy: NullUnionStrategy;
 };
@@ -850,6 +865,13 @@ const filterProviderSafeKeywords = ({
 }): JsonObject => {
   const result: JsonObject = {};
   for (const [key, value] of Object.entries(node)) {
+    if (
+      context.arrayBoundStrategy === "omit" &&
+      (key === "minItems" || key === "maxItems")
+    ) {
+      context.dropped.push(joinPath(path, key));
+      continue;
+    }
     if (!ALLOWED_KEYWORDS.has(key)) {
       context.dropped.push(joinPath(path, key));
       continue;
@@ -915,6 +937,7 @@ export const projectToProviderSafeJsonSchema = (
   const context: ProjectionContext = {
     root: schema,
     dropped: [],
+    arrayBoundStrategy: options.arrayBoundStrategy ?? "preserve",
     enumValueStrategy:
       options.enumValueStrategy ??
       (nullUnionStrategy === "openapi" ? "string-only" : "json-schema"),

--- a/apps/api/src/lib/tanstack-ai-generate.ts
+++ b/apps/api/src/lib/tanstack-ai-generate.ts
@@ -348,7 +348,10 @@ export const generateTanStackObjectForRole = async <
     : undefined;
   const tanStackOutputSchema = toTanStackValibotSchema(
     outputSchema,
-    providerSafeJsonSchemaOptionsForTanStackProvider(model.provider),
+    providerSafeJsonSchemaOptionsForTanStackProvider(
+      model.provider,
+      "structured-output",
+    ),
   );
 
   const output = await withStandardServiceTierFallback({
@@ -436,7 +439,10 @@ const streamTanStackStructuredOutput = async function* <
   let rawJson = "";
   const tanStackOutputSchema = toTanStackValibotSchema(
     outputSchema,
-    providerSafeJsonSchemaOptionsForTanStackProvider(model.provider),
+    providerSafeJsonSchemaOptionsForTanStackProvider(
+      model.provider,
+      "structured-output",
+    ),
   );
 
   const stream = iterateWithStandardServiceTierFallback({


### PR DESCRIPTION
## Summary

- distinguish tool schemas from structured-output schemas at the type boundary
- retain array-bound guarantees in local validation while projecting provider-safe Google structured-output schemas
- exercise nested structured output across every supported provider and default model role each night
- rotate curated non-default models weekly and fail CI when the scheduled matrix drifts from the exhaustive provider catalog

Validated with bun run verify, the security audit, and the live Google daily capability canary.