### PR TITLE
chore: speed up developer feedback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -959,17 +959,15 @@ jobs:
         if: steps.changed.outputs.run == 'true'
         run: bun --filter @stll/landing build
 
-  # Browser checks are split across isolated runners. The broad app suite uses
-  # a production build; one shard first runs a tiny Vite canary to retain the
-  # dependency re-optimization guard. Landing checks are gated independently;
-  # marketing screenshots run in the nightly test workflow.
-  e2e-shard:
+  # Browser checks use isolated parallel runners: broad production shards,
+  # a small Vite dependency canary, and the built landing-page suite.
+  # Marketing screenshots remain in the nightly test workflow.
+  e2e-production-shard:
     needs: [trust-check, ci-changes]
     if: >-
       (needs.trust-check.outputs.trusted == 'true'
        || github.event_name == 'workflow_dispatch')
-      && (needs.ci-changes.outputs.e2e_core_required == 'true'
-          || needs.ci-changes.outputs.e2e_landing_required == 'true')
+      && needs.ci-changes.outputs.e2e_core_required == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 25
     permissions:
@@ -985,39 +983,17 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Load E2E scopes
-        id: changed
-        env:
-          CORE_REQUIRED: ${{ needs.ci-changes.outputs.e2e_core_required }}
-          LANDING_REQUIRED: ${{ needs.ci-changes.outputs.e2e_landing_required }}
-          SHARD: ${{ matrix.shard }}
-        run: |
-          run=false
-          if [[ "$CORE_REQUIRED" == "true" \
-            || ("$SHARD" == "2" && "$LANDING_REQUIRED" == "true") ]]; then
-            run=true
-          fi
-          {
-            echo "app_stack=$CORE_REQUIRED"
-            echo "core=$CORE_REQUIRED"
-            echo "landing=$LANDING_REQUIRED"
-            echo "run=$run"
-          } >> "$GITHUB_OUTPUT"
-
       - name: Setup Bun
-        if: steps.changed.outputs.run == 'true'
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version-file: "package.json"
 
       - name: Install dependencies
-        if: steps.changed.outputs.run == 'true'
         run: bash scripts/bun-ci-retry.sh --ignore-scripts
         env:
           NPM_TOKEN: ""
 
       - name: Prepare environment
-        if: steps.changed.outputs.app_stack == 'true'
         run: |
           cd ./apps/api
           cp .env.example .env
@@ -1028,7 +1004,6 @@ jobs:
         id: dockerhub
         # Keep Docker Hub secrets scoped to this trusted inline check, not the
         # whole job environment where repository-controlled code can read them.
-        if: steps.changed.outputs.app_stack == 'true'
         env:
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -1043,14 +1018,13 @@ jobs:
         # Skipped automatically until DOCKERHUB_USERNAME / DOCKERHUB_TOKEN repo
         # secrets exist; authenticated pulls raise the rate limit well above the
         # shared-runner anonymous cap that flakes the gotenberg image pull.
-        if: steps.changed.outputs.app_stack == 'true' && steps.dockerhub.outputs.available == 'true'
+        if: steps.dockerhub.outputs.available == 'true'
         uses: docker/login-action@371161bbe7024a29a25c5e19bfcbc0804fe9ad2c # v4.5.2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Start docker stack
-        if: steps.changed.outputs.app_stack == 'true'
         # `--wait` only on long-running services; `minio-setup` is a one-shot
         # bucket-creator container that exits 0, which `--wait` treats as
         # "not running" and fails the whole command. Run it separately in
@@ -1075,11 +1049,10 @@ jobs:
 
       - name: Log out of Docker Hub
         # Remove credentials from the runner before executing app code and tests.
-        if: always() && steps.changed.outputs.app_stack == 'true' && steps.dockerhub.outputs.available == 'true'
+        if: always() && steps.dockerhub.outputs.available == 'true'
         run: docker logout
 
       - name: Run database migrations
-        if: steps.changed.outputs.app_stack == 'true'
         # `db:migrate` (not `db:push`) so role bootstrap migrations such as
         # `20260516000000_case_law_ingestion_role` actually execute. `db:push`
         # only diffs the declarative schema, which references `stella_ingestion`
@@ -1087,11 +1060,9 @@ jobs:
         run: bun --filter @stll/api db:migrate
 
       - name: Seed test user
-        if: steps.changed.outputs.app_stack == 'true'
         run: bun --filter @stll/api db:seed-test-user
 
       - name: Start API server
-        if: steps.changed.outputs.app_stack == 'true'
         # `--watch` is for local dev; CI runs the server flat. Logs land in
         # /tmp/api.log so the "Upload server logs" step can publish them on
         # failure for debugging.
@@ -1104,7 +1075,6 @@ jobs:
           echo $! > /tmp/api.pid
 
       - name: Wait for API
-        if: steps.changed.outputs.app_stack == 'true'
         run: |
           for i in {1..60}; do
             if curl --connect-timeout 2 --max-time 5 -sf http://localhost:3001/health > /dev/null 2>&1; then
@@ -1117,65 +1087,10 @@ jobs:
           tail -200 /tmp/api.log || true
           exit 1
 
-      - name: Start web dev server
-        if: matrix.shard == 1 && steps.changed.outputs.core == 'true'
-        run: |
-          cd apps/web
-          nohup bun --bun vite --port 3000 > /tmp/web.log 2>&1 &
-          echo $! > /tmp/web.pid
-
-      - name: Wait for web dev server
-        if: matrix.shard == 1 && steps.changed.outputs.core == 'true'
-        run: |
-          for i in {1..60}; do
-            if curl --connect-timeout 2 --max-time 5 -sf http://localhost:3000 > /dev/null 2>&1; then
-              echo "Web up after ${i}s"
-              exit 0
-            fi
-            sleep 1
-          done
-          echo "::error::Web never came up"
-          tail -200 /tmp/web.log || true
-          exit 1
-
       - name: Install Playwright browsers
-        if: steps.changed.outputs.run == 'true'
         run: cd apps/web && bunx playwright install --with-deps chromium
 
-      - name: Run Vite dependency canary
-        if: matrix.shard == 1 && steps.changed.outputs.core == 'true'
-        env:
-          E2E_EXPECT_DEV_ROUTES: "true"
-        run: >-
-          bun --filter @stll/web test:e2e --
-          --project chromium --grep @dev-canary
-
-      # Flake guard: the tiny dev pass covers the lazy chat, Folio, and
-      # dev-autocomplete imports that can escape Vite's cold dependency scan.
-      - name: Guard against mid-test Vite re-optimize
-        if: >-
-          always()
-          && matrix.shard == 1
-          && steps.changed.outputs.core == 'true'
-        run: |
-          if grep -q "optimized dependencies changed. reloading" /tmp/web.log; then
-            echo "::error::Vite re-optimized dependencies mid-session and forced a reload. Add the lazy/runtime dependency named below to optimizeDeps.include in apps/web/vite.config.ts."
-            grep -nE "new dependencies optimized|optimized dependencies changed" /tmp/web.log || true
-            exit 1
-          fi
-          echo "No mid-session dep re-optimize detected."
-
-      - name: Stop web dev server
-        if: >-
-          always()
-          && matrix.shard == 1
-          && steps.changed.outputs.core == 'true'
-        run: |
-          kill "$(cat /tmp/web.pid)" || true
-          rm -f /tmp/web.pid
-
       - name: Build web for route checks
-        if: steps.changed.outputs.core == 'true'
         env:
           VITE_FEATURE_TIME_BILLING: "true"
           VITE_PLAYBOOKS_ENABLED: "true"
@@ -1183,14 +1098,12 @@ jobs:
         run: bun --filter @stll/web build
 
       - name: Start production web server
-        if: steps.changed.outputs.core == 'true'
         run: |
           cd apps/web
           NODE_ENV=production PORT=3000 nohup bun start-runtime.js > /tmp/web-production.log 2>&1 &
           echo $! > /tmp/web-production.pid
 
       - name: Wait for production web server
-        if: steps.changed.outputs.core == 'true'
         run: |
           for i in {1..60}; do
             if curl --connect-timeout 2 --max-time 5 -sf http://localhost:3000/health > /dev/null 2>&1; then
@@ -1204,7 +1117,6 @@ jobs:
           exit 1
 
       - name: Run Playwright shard
-        if: steps.changed.outputs.core == 'true'
         env:
           E2E_EXPECT_DEV_ROUTES: "false"
           PLAYWRIGHT_BLOB_OUTPUT_NAME: report-${{ matrix.shard }}.zip
@@ -1212,26 +1124,229 @@ jobs:
           bun --filter @stll/web test:e2e --
           --shard=${{ matrix.shard }}/2
 
+      - name: Upload Playwright blob report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: playwright-blob-${{ matrix.shard }}
+          path: apps/web/test-results/blob-report/
+          retention-days: 7
+
+      - name: Upload server logs
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: server-logs-production-${{ matrix.shard }}
+          path: |
+            /tmp/api.log
+            /tmp/web-production.log
+          retention-days: 7
+
+  e2e-vite-canary:
+    needs: [trust-check, ci-changes]
+    if: >-
+      (needs.trust-check.outputs.trusted == 'true'
+       || github.event_name == 'workflow_dispatch')
+      && needs.ci-changes.outputs.e2e_core_required == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version-file: "package.json"
+
+      - name: Install dependencies
+        run: bash scripts/bun-ci-retry.sh --ignore-scripts
+        env:
+          NPM_TOKEN: ""
+
+      - name: Prepare environment
+        run: |
+          cd ./apps/api
+          cp .env.example .env
+          cd ../web
+          cp .env.example .env
+
+      - name: Check Docker Hub credentials
+        id: dockerhub
+        # Secrets stay scoped to the check and login action; application code
+        # runs only after the runner has logged out again.
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+        run: |
+          if [[ -n "$DOCKERHUB_USERNAME" && -n "$DOCKERHUB_TOKEN" ]]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "available=false" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to Docker Hub
+        if: steps.dockerhub.outputs.available == 'true'
+        uses: docker/login-action@371161bbe7024a29a25c5e19bfcbc0804fe9ad2c # v4.5.2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Start docker stack
+        run: |
+          for attempt in 1 2 3; do
+            if docker compose --profile dev up -d --wait postgres minio valkey gotenberg \
+              && docker compose --profile dev run --rm --no-deps minio-setup; then
+              exit 0
+            fi
+            echo "::warning::docker stack start failed (attempt ${attempt}/3); tearing down and retrying"
+            docker compose --profile dev down --volumes --remove-orphans || true
+            sleep "$((attempt * 20))"
+          done
+          echo "::error::docker stack failed to start after 3 attempts"
+          exit 1
+
+      - name: Log out of Docker Hub
+        if: always() && steps.dockerhub.outputs.available == 'true'
+        run: docker logout
+
+      - name: Run database migrations
+        run: bun --filter @stll/api db:migrate
+
+      - name: Seed test user
+        run: bun --filter @stll/api db:seed-test-user
+
+      - name: Start API server
+        run: |
+          cd apps/api
+          NODE_ENV=development E2E_DISABLE_AUTH_RATE_LIMIT=true nohup bun --port 3001 --preload ./src/dev/register-mock-ai.ts src/server.ts > /tmp/api.log 2>&1 &
+          echo $! > /tmp/api.pid
+
+      - name: Wait for API
+        run: |
+          for i in {1..60}; do
+            if curl --connect-timeout 2 --max-time 5 -sf http://localhost:3001/health > /dev/null 2>&1; then
+              echo "API up after ${i}s"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "::error::API never came up"
+          tail -200 /tmp/api.log || true
+          exit 1
+
+      - name: Start web dev server
+        run: |
+          cd apps/web
+          nohup bun --bun vite --port 3000 > /tmp/web.log 2>&1 &
+          echo $! > /tmp/web.pid
+
+      - name: Wait for web dev server
+        run: |
+          for i in {1..60}; do
+            if curl --connect-timeout 2 --max-time 5 -sf http://localhost:3000 > /dev/null 2>&1; then
+              echo "Web up after ${i}s"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "::error::Web never came up"
+          tail -200 /tmp/web.log || true
+          exit 1
+
+      - name: Install Playwright browsers
+        run: cd apps/web && bunx playwright install --with-deps chromium
+
+      - name: Run Vite dependency canary
+        env:
+          E2E_EXPECT_DEV_ROUTES: "true"
+          PLAYWRIGHT_BLOB_OUTPUT_NAME: report-vite-canary.zip
+        run: >-
+          bun --filter @stll/web test:e2e --
+          --project chromium --grep @dev-canary
+
+      # These imports load only through cold lazy routes; a mid-test optimizer
+      # restart would make the apparent canary result nondeterministic.
+      - name: Guard against mid-test Vite re-optimize
+        if: always()
+        run: |
+          if grep -q "optimized dependencies changed. reloading" /tmp/web.log; then
+            echo "::error::Vite re-optimized dependencies mid-session and forced a reload. Add the lazy/runtime dependency named below to optimizeDeps.include in apps/web/vite.config.ts."
+            grep -nE "new dependencies optimized|optimized dependencies changed" /tmp/web.log || true
+            exit 1
+          fi
+          echo "No mid-session dep re-optimize detected."
+
+      - name: Stop web dev server
+        if: always()
+        run: |
+          if [[ -f /tmp/web.pid ]]; then
+            kill "$(cat /tmp/web.pid)" || true
+            rm -f /tmp/web.pid
+          fi
+
+      - name: Upload Playwright blob report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: playwright-blob-vite-canary
+          path: apps/web/test-results/blob-report/
+          retention-days: 7
+
+      - name: Upload server logs
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: server-logs-vite-canary
+          path: |
+            /tmp/api.log
+            /tmp/web.log
+          retention-days: 7
+
+  e2e-landing:
+    needs: [trust-check, ci-changes]
+    if: >-
+      (needs.trust-check.outputs.trusted == 'true'
+       || github.event_name == 'workflow_dispatch')
+      && needs.ci-changes.outputs.e2e_landing_required == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version-file: "package.json"
+
+      - name: Install dependencies
+        run: bash scripts/bun-ci-retry.sh --ignore-scripts
+        env:
+          NPM_TOKEN: ""
+
       - name: Build landing
-        if: matrix.shard == 2 && steps.changed.outputs.landing == 'true'
-        # The landing specs must run against the built bundle, not `astro dev`.
-        # The live anonymization demo's failure mode is a dictionary import
-        # that only a bundler can get wrong: unbundled dev serves the same
-        # specifier straight off disk and passes either way.
+        # Built preview retains the COOP/COEP and bundler behavior used by the
+        # WASM anonymization island; Astro dev cannot prove this path.
         run: bun --filter @stll/landing build
 
       - name: Start landing preview server
-        if: matrix.shard == 2 && steps.changed.outputs.landing == 'true'
-        # `astro preview` serves dist/ with astro.config.mjs's COOP/COEP
-        # headers, which the demo's wasm runtime needs (SharedArrayBuffer is
-        # only exposed to a cross-origin-isolated page).
         run: |
           cd apps/landing
           nohup bun --bun astro preview --port 4321 > /tmp/landing.log 2>&1 &
           echo $! > /tmp/landing.pid
 
       - name: Wait for landing
-        if: matrix.shard == 2 && steps.changed.outputs.landing == 'true'
         run: |
           for i in {1..60}; do
             if curl --connect-timeout 2 --max-time 5 -sf http://localhost:4321 > /dev/null 2>&1; then
@@ -1244,33 +1359,41 @@ jobs:
           tail -200 /tmp/landing.log || true
           exit 1
 
+      - name: Install Playwright browsers
+        run: cd apps/web && bunx playwright install --with-deps chromium
+
       - name: Check landing islands
-        if: matrix.shard == 2 && steps.changed.outputs.landing == 'true'
         run: E2E_LANDING_URL=http://localhost:4321 bun --filter @stll/web test:e2e:landing
 
-      - name: Upload Playwright blob report
-        if: always() && steps.changed.outputs.core == 'true'
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: playwright-blob-${{ matrix.shard }}
-          path: apps/web/test-results/blob-report/
-          retention-days: 7
+      - name: Stop landing preview server
+        if: always()
+        run: |
+          if [[ -f /tmp/landing.pid ]]; then
+            kill "$(cat /tmp/landing.pid)" || true
+            rm -f /tmp/landing.pid
+          fi
 
-      - name: Upload server logs
-        if: failure() && steps.changed.outputs.run == 'true'
+      - name: Upload failure diagnostics
+        if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: server-logs-${{ matrix.shard }}
+          name: landing-e2e-diagnostics
           path: |
-            /tmp/api.log
-            /tmp/web.log
-            /tmp/web-production.log
             /tmp/landing.log
+            apps/web/test-results/
+          if-no-files-found: ignore
           retention-days: 7
 
   e2e:
     if: always()
-    needs: [trust-check, ci-changes, e2e-shard]
+    needs:
+      [
+        trust-check,
+        ci-changes,
+        e2e-production-shard,
+        e2e-vite-canary,
+        e2e-landing,
+      ]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
@@ -1278,7 +1401,8 @@ jobs:
     steps:
       - name: Checkout
         if: >-
-          needs.e2e-shard.result == 'failure'
+          (needs.e2e-production-shard.result == 'failure'
+           || needs.e2e-vite-canary.result == 'failure')
           && needs.ci-changes.outputs.e2e_core_required == 'true'
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -1286,7 +1410,8 @@ jobs:
 
       - name: Setup Bun
         if: >-
-          needs.e2e-shard.result == 'failure'
+          (needs.e2e-production-shard.result == 'failure'
+           || needs.e2e-vite-canary.result == 'failure')
           && needs.ci-changes.outputs.e2e_core_required == 'true'
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
@@ -1294,7 +1419,8 @@ jobs:
 
       - name: Install dependencies
         if: >-
-          needs.e2e-shard.result == 'failure'
+          (needs.e2e-production-shard.result == 'failure'
+           || needs.e2e-vite-canary.result == 'failure')
           && needs.ci-changes.outputs.e2e_core_required == 'true'
         run: bash scripts/bun-ci-retry.sh --ignore-scripts
         env:
@@ -1302,7 +1428,8 @@ jobs:
 
       - name: Download Playwright blob reports
         if: >-
-          needs.e2e-shard.result == 'failure'
+          (needs.e2e-production-shard.result == 'failure'
+           || needs.e2e-vite-canary.result == 'failure')
           && needs.ci-changes.outputs.e2e_core_required == 'true'
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v8.0.0
         with:
@@ -1312,13 +1439,15 @@ jobs:
 
       - name: Merge Playwright reports
         if: >-
-          needs.e2e-shard.result == 'failure'
+          (needs.e2e-production-shard.result == 'failure'
+           || needs.e2e-vite-canary.result == 'failure')
           && needs.ci-changes.outputs.e2e_core_required == 'true'
         run: cd apps/web && bunx playwright merge-reports --reporter html all-blob-reports
 
       - name: Upload merged Playwright report
         if: >-
-          needs.e2e-shard.result == 'failure'
+          (needs.e2e-production-shard.result == 'failure'
+           || needs.e2e-vite-canary.result == 'failure')
           && needs.ci-changes.outputs.e2e_core_required == 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -1328,19 +1457,27 @@ jobs:
 
       - name: Evaluate browser checks
         env:
-          SHARD_RESULT: ${{ needs.e2e-shard.result }}
+          LANDING_RESULT: ${{ needs.e2e-landing.result }}
+          PRODUCTION_RESULT: ${{ needs.e2e-production-shard.result }}
+          VITE_CANARY_RESULT: ${{ needs.e2e-vite-canary.result }}
         run: |
-          case "$SHARD_RESULT" in
-            success|skipped)
-              exit 0
-              ;;
-            cancelled)
-              echo "Browser checks were cancelled; a newer run is authoritative."
-              exit 0
-              ;;
-          esac
-          echo "::error::Browser checks ended with $SHARD_RESULT"
-          exit 1
+          cancelled=false
+          for result in "$PRODUCTION_RESULT" "$VITE_CANARY_RESULT" "$LANDING_RESULT"; do
+            case "$result" in
+              success|skipped)
+                ;;
+              cancelled)
+                cancelled=true
+                ;;
+              *)
+                echo "::error::Browser checks ended with $result"
+                exit 1
+                ;;
+            esac
+          done
+          if [[ "$cancelled" == "true" ]]; then
+            echo "Browser checks were cancelled; a newer run is authoritative."
+          fi
 
   # Image dependency guard. The API and legal-atlas-runner Dockerfiles use
   # Turbo only for pruned source overlays; dependency installs come from the

--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -47,6 +47,75 @@ jobs:
         env:
           TURBO_FORCE: "true"
 
+  # The production client build is the remaining browser-CI setup hotspot.
+  # Profile it nightly rather than taxing every PR; retain TanStack Start's
+  # import-protection boundary and collect evidence for upgrades or upstream
+  # performance fixes.
+  web-build-profile:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version-file: "package.json"
+
+      - name: Install dependencies
+        run: bash scripts/bun-ci-retry.sh --ignore-scripts
+        env:
+          NPM_TOKEN: ""
+
+      - name: Prepare environment
+        run: cp apps/web/.env.example apps/web/.env
+
+      - name: Profile production web build
+        env:
+          TSR_IMPORT_PROTECTION_PERF: "1"
+          TSR_IMPORT_PROTECTION_PERF_FILE: ${{ github.workspace }}/web-build-profile/import-protection.json
+        run: |
+          set -o pipefail
+          profile_dir=web-build-profile
+          mkdir -p "$profile_dir"
+          started_at=$SECONDS
+          set +e
+          bun --filter @stll/web build 2>&1 | tee "$profile_dir/vite.log"
+          build_status=${PIPESTATUS[0]}
+          set -e
+          build_seconds=$((SECONDS - started_at))
+          {
+            echo "## Nightly web build profile"
+            echo
+            echo "| Metric | Value |"
+            echo "| --- | ---: |"
+            echo "| Build wall time | ${build_seconds}s |"
+            if [[ -f "$profile_dir/import-protection.json" ]]; then
+              jq -r '
+                "| Import-protection resolve calls | \(.counters["resolveId.calls"] // 0) |",
+                "| Import-protection transforms | \(.counters["transform.calls"] // 0) |",
+                "| Internal resolver calls | \(.counters["thisResolve.calls"] // 0) |",
+                "| Slowest internal resolve | \(.timings.thisResolve.maxMs // 0)ms |"
+              ' "$profile_dir/import-protection.json"
+            fi
+          } | tee "$profile_dir/summary.md" >> "$GITHUB_STEP_SUMMARY"
+          exit "$build_status"
+
+      - name: Upload build profile
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: nightly-web-build-profile
+          path: web-build-profile/
+          if-no-files-found: error
+          retention-days: 30
+
   # Marketing captures are intentionally nightly, not part of the PR critical
   # path. They exercise seeded product scenes against the complete default-
   # branch runtime, so dependency changes need no fragile per-file allowlist.

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -32,9 +32,9 @@ pre-push:
   parallel: false
   commands:
     code-check:
-      # One Oxc type-aware pass covers every workspace, while the root native
-      # projects remain checked explicitly by the combined command.
-      run: bun run code-check
+      # One Oxc type-aware pass covers changed workspaces plus reverse
+      # dependants. Global compiler/lint inputs fall back to the full repo.
+      run: bun run code-check:affected -- --base origin/main
     format:
       run: bun run format --concurrency=2 -- --check
     i18n:

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "typecheck": "turbo run typecheck",
     "typecheck:repo": "bun packages/scripts/src/tsc-native.ts --noEmit -p tsconfig.scripts.json && bun packages/scripts/src/tsc-native.ts --noEmit -p tsconfig.tooling.json && bun packages/scripts/src/tsc-native.ts --noEmit -p tsconfig.oxlint-plugins.json",
     "code-check": "bash scripts/lint-oxlint-fixtures.sh && bun --cwd apps/landing typecheck && bun apps/landing/scripts/check-logical-properties.ts && bun --bun oxlint -c oxlint.config.ts --report-unused-disable-directives-severity=error --deny-warnings --type-aware --type-check apps packages && bun run typecheck:repo",
+    "code-check:affected": "bun scripts/code-check-affected.ts",
     "secrets:check:staged": "bash scripts/check-staged-secrets.sh",
     "security:audit": "bun scripts/dependency-audit.ts --check",
     "security:audit:report": "bun scripts/dependency-audit.ts",

--- a/scripts/code-check-affected.test.ts
+++ b/scripts/code-check-affected.test.ts
@@ -55,12 +55,14 @@ describe("affected code-check planning", () => {
     "package.json",
     "bun.lock",
     "bunfig.toml",
+    "scripts/lint-oxlint-fixtures.sh",
     "turbo.json",
     "oxlint.config.ts",
     "tsconfig.json",
     ".oxlint-plugins/no-raw-use-effect.ts",
     "packages/typescript-config/base.json",
     "patches/vite.patch",
+    "types/react-css-properties.d.ts",
   ])("falls back to the full repository for global input %s", (changedPath) => {
     expect(plan([changedPath], [])).toEqual({ type: "full", changedPath });
   });

--- a/scripts/code-check-affected.test.ts
+++ b/scripts/code-check-affected.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from "bun:test";
+
+import { affectedCommands, planCheck } from "./code-check-affected";
+
+const WORKSPACES = new Set([
+  "apps/api",
+  "apps/landing",
+  "apps/web",
+  "packages/errors",
+  "packages/ui",
+]);
+
+const plan = (changedPaths: string[], affectedWorkspacePaths: string[]) =>
+  planCheck({
+    changedPaths,
+    affectedWorkspacePaths,
+    workspacePaths: WORKSPACES,
+  });
+
+describe("affected code-check planning", () => {
+  test("checks complete changed workspaces and reverse dependants", () => {
+    expect(
+      plan(
+        ["packages/ui/src/button.tsx"],
+        ["packages/ui", "apps/web", "apps/landing"],
+      ),
+    ).toEqual({
+      type: "affected",
+      targets: ["apps/landing", "apps/web", "packages/ui"],
+      checkLanding: true,
+    });
+  });
+
+  test("does not run workspace analysis for documentation-only changes", () => {
+    expect(plan(["README.md"], [])).toEqual({
+      type: "affected",
+      targets: [],
+      checkLanding: false,
+    });
+  });
+
+  test("keeps lint and TypeScript diagnostics in one affected Oxc pass", () => {
+    const commands = affectedCommands({
+      type: "affected",
+      targets: ["apps/web", "packages/ui"],
+      checkLanding: false,
+    });
+    const oxc = commands.find((command) => command.includes("oxlint"));
+    expect(oxc).toContain("--type-aware");
+    expect(oxc).toContain("--type-check");
+    expect(oxc?.slice(-2)).toEqual(["apps/web", "packages/ui"]);
+  });
+
+  test.each([
+    "package.json",
+    "bun.lock",
+    "bunfig.toml",
+    "turbo.json",
+    "oxlint.config.ts",
+    "tsconfig.json",
+    ".oxlint-plugins/no-raw-use-effect.ts",
+    "packages/typescript-config/base.json",
+    "patches/vite.patch",
+  ])("falls back to the full repository for global input %s", (changedPath) => {
+    expect(plan([changedPath], [])).toEqual({ type: "full", changedPath });
+  });
+
+  test("falls back when Turbo omits the directly changed workspace", () => {
+    expect(plan(["apps/api/src/server.ts"], ["apps/web"])).toEqual({
+      type: "full",
+      changedPath: "apps/api/src/server.ts",
+    });
+  });
+
+  test("falls back for an unknown workspace directory", () => {
+    expect(plan(["apps/unknown/src/main.ts"], [])).toEqual({
+      type: "full",
+      changedPath: "apps/unknown/src/main.ts",
+    });
+  });
+
+  test("falls back when Turbo returns a non-workspace target", () => {
+    expect(plan(["README.md"], ["tools/unknown"])).toEqual({
+      type: "full",
+      changedPath: "invalid Turbo workspace output",
+    });
+  });
+});

--- a/scripts/code-check-affected.ts
+++ b/scripts/code-check-affected.ts
@@ -1,0 +1,281 @@
+#!/usr/bin/env bun
+
+// Fast local code-quality gate.
+//
+// CI keeps the full repository-wide `code-check`. Pre-push uses this wrapper
+// to ask Turbo for changed workspaces plus reverse dependants, then runs one
+// shared Oxlint/tsgolint program over those complete workspace roots. Global
+// compiler, dependency-graph, and lint inputs conservatively fall back to the
+// full check.
+
+import { panic } from "better-result";
+import { existsSync, readdirSync } from "node:fs";
+import path from "node:path";
+
+const REPO_ROOT = path.resolve(import.meta.dirname, "..");
+const DEFAULT_BASE = "origin/main";
+const WORKSPACE_PARENTS = ["apps", "packages"] as const;
+
+const FULL_CHECK_FILES = new Set([
+  ".npmrc",
+  "bun.lock",
+  "bunfig.toml",
+  "oxlint.config.ts",
+  "package.json",
+  "turbo.json",
+  "tsconfig.json",
+  "tsconfig.oxlint-plugins.json",
+  "tsconfig.scripts.json",
+  "tsconfig.tooling.json",
+]);
+
+const FULL_CHECK_PREFIXES = [
+  ".oxlint-plugins/",
+  "packages/typescript-config/",
+  "patches/",
+] as const;
+
+type CheckPlan =
+  | { type: "full"; changedPath: string }
+  | { type: "affected"; targets: string[]; checkLanding: boolean };
+
+type PlanCheckOptions = {
+  changedPaths: readonly string[];
+  affectedWorkspacePaths: readonly string[];
+  workspacePaths: ReadonlySet<string>;
+};
+
+const workspaceForPath = (file: string): string | null => {
+  const segments = file.split("/");
+  const parent = segments.at(0);
+  const name = segments.at(1);
+  if (
+    parent === undefined ||
+    name === undefined ||
+    !WORKSPACE_PARENTS.some((workspaceParent) => workspaceParent === parent)
+  ) {
+    return null;
+  }
+  return `${parent}/${name}`;
+};
+
+const requiresFullCheck = (file: string): boolean =>
+  FULL_CHECK_FILES.has(file) ||
+  FULL_CHECK_PREFIXES.some((prefix) => file.startsWith(prefix));
+
+export const planCheck = ({
+  changedPaths,
+  affectedWorkspacePaths,
+  workspacePaths,
+}: PlanCheckOptions): CheckPlan => {
+  for (const changedPath of changedPaths) {
+    if (requiresFullCheck(changedPath)) {
+      return { type: "full", changedPath };
+    }
+  }
+
+  const targets = [...new Set(affectedWorkspacePaths)].sort();
+  if (targets.some((target) => !workspacePaths.has(target))) {
+    return { type: "full", changedPath: "invalid Turbo workspace output" };
+  }
+
+  const targetSet = new Set(targets);
+  for (const changedPath of changedPaths) {
+    const owner = workspaceForPath(changedPath);
+    if (owner === null) {
+      continue;
+    }
+    if (!workspacePaths.has(owner) || !targetSet.has(owner)) {
+      return { type: "full", changedPath };
+    }
+  }
+
+  return {
+    type: "affected",
+    targets,
+    checkLanding: targetSet.has("apps/landing"),
+  };
+};
+
+type Options = {
+  base: string;
+  dryRun: boolean;
+};
+
+const parseArgs = (args: readonly string[]): Options => {
+  let base = DEFAULT_BASE;
+  let dryRun = false;
+
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index];
+    if (argument === "--dry-run") {
+      dryRun = true;
+      continue;
+    }
+    if (argument === "--base") {
+      const value = args.at(index + 1);
+      if (value === undefined) {
+        panic("--base requires a git ref");
+      }
+      base = value;
+      index += 1;
+      continue;
+    }
+    panic(`Unknown argument: ${argument}`);
+  }
+
+  return { base, dryRun };
+};
+
+const run = (
+  command: readonly string[],
+  options: { capture?: boolean; env?: Record<string, string | undefined> } = {},
+): string => {
+  const capture = options.capture ?? false;
+  const result = Bun.spawnSync([...command], {
+    cwd: REPO_ROOT,
+    ...(options.env === undefined ? {} : { env: options.env }),
+    stdout: capture ? "pipe" : "inherit",
+    stderr: capture ? "pipe" : "inherit",
+  });
+  const stdout = result.stdout?.toString() ?? "";
+  const stderr = result.stderr?.toString() ?? "";
+  if (result.exitCode !== 0) {
+    const output = capture ? `\n${stderr}${stdout}` : "";
+    panic(`Command failed (${result.exitCode}): ${command.join(" ")}${output}`);
+  }
+  return stdout;
+};
+
+const workspacePaths = (): Set<string> => {
+  const workspaces = new Set<string>();
+  for (const parent of WORKSPACE_PARENTS) {
+    for (const entry of readdirSync(path.join(REPO_ROOT, parent), {
+      withFileTypes: true,
+    })) {
+      if (!entry.isDirectory()) {
+        continue;
+      }
+      const workspace = `${parent}/${entry.name}`;
+      if (existsSync(path.join(REPO_ROOT, workspace, "package.json"))) {
+        workspaces.add(workspace);
+      }
+    }
+  }
+  return workspaces;
+};
+
+const changedPaths = (base: string): { mergeBase: string; paths: string[] } => {
+  const mergeBase = run(["git", "merge-base", base, "HEAD"], {
+    capture: true,
+  }).trim();
+  if (mergeBase === "") {
+    panic(`Could not find merge base for ${base}`);
+  }
+  const output = run(["git", "diff", "--name-only", "-z", mergeBase, "HEAD"], {
+    capture: true,
+  });
+  return {
+    mergeBase,
+    paths: output.split("\0").filter(Boolean),
+  };
+};
+
+type TurboOutput = {
+  packages?: {
+    items?: { path?: unknown }[];
+  };
+};
+
+const affectedWorkspacePaths = (mergeBase: string): string[] => {
+  const output = run(
+    ["bun", "--bun", "turbo", "ls", "--affected", "--output=json"],
+    {
+      capture: true,
+      env: {
+        ...process.env,
+        TURBO_SCM_BASE: mergeBase,
+        TURBO_SCM_HEAD: "HEAD",
+      },
+    },
+  );
+  const jsonStart = output.indexOf("{");
+  if (jsonStart === -1) {
+    panic("Turbo affected output did not contain JSON");
+  }
+  const parsed: TurboOutput = JSON.parse(output.slice(jsonStart));
+  const items = parsed.packages?.items;
+  if (!Array.isArray(items)) {
+    panic("Turbo affected output did not contain package items");
+  }
+  return items.map(({ path: workspacePath }) => {
+    if (typeof workspacePath !== "string") {
+      panic("Turbo affected output contained a package without a path");
+    }
+    return workspacePath;
+  });
+};
+
+export const affectedCommands = (
+  plan: Extract<CheckPlan, { type: "affected" }>,
+) => {
+  const commands: string[][] = [];
+  if (plan.checkLanding) {
+    commands.push(["bun", "--cwd", "apps/landing", "typecheck"]);
+    commands.push(["bun", "apps/landing/scripts/check-logical-properties.ts"]);
+  }
+  if (plan.targets.length > 0) {
+    commands.push([
+      "bun",
+      "--bun",
+      "oxlint",
+      "-c",
+      "oxlint.config.ts",
+      "--report-unused-disable-directives-severity=error",
+      "--deny-warnings",
+      "--type-aware",
+      "--type-check",
+      ...plan.targets,
+    ]);
+  }
+  commands.push(["bun", "run", "typecheck:repo"]);
+  return commands;
+};
+
+const main = () => {
+  const options = parseArgs(process.argv.slice(2));
+  const changed = changedPaths(options.base);
+  const plan = planCheck({
+    changedPaths: changed.paths,
+    affectedWorkspacePaths: affectedWorkspacePaths(changed.mergeBase),
+    workspacePaths: workspacePaths(),
+  });
+
+  if (plan.type === "full") {
+    process.stdout.write(
+      `code-check: full repository (${plan.changedPath} requires fallback)\n`,
+    );
+    if (!options.dryRun) {
+      run(["bun", "run", "code-check"]);
+    }
+    return;
+  }
+
+  const targetLabel =
+    plan.targets.length === 0 ? "root projects only" : plan.targets.join(", ");
+  process.stdout.write(`code-check: affected ${targetLabel}\n`);
+  const commands = affectedCommands(plan);
+  if (options.dryRun) {
+    for (const command of commands) {
+      process.stdout.write(`  ${command.join(" ")}\n`);
+    }
+    return;
+  }
+  for (const command of commands) {
+    run(command);
+  }
+};
+
+if (import.meta.main) {
+  main();
+}

--- a/scripts/code-check-affected.ts
+++ b/scripts/code-check-affected.ts
@@ -22,6 +22,7 @@ const FULL_CHECK_FILES = new Set([
   "bunfig.toml",
   "oxlint.config.ts",
   "package.json",
+  "scripts/lint-oxlint-fixtures.sh",
   "turbo.json",
   "tsconfig.json",
   "tsconfig.oxlint-plugins.json",
@@ -33,6 +34,7 @@ const FULL_CHECK_PREFIXES = [
   ".oxlint-plugins/",
   "packages/typescript-config/",
   "patches/",
+  "types/",
 ] as const;
 
 type CheckPlan =

--- a/scripts/detect-e2e-changes.test.ts
+++ b/scripts/detect-e2e-changes.test.ts
@@ -1,7 +1,25 @@
 import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
 import path from "node:path";
 
 const script = path.join(import.meta.dirname, "detect-e2e-changes.sh");
+const workflow = readFileSync(
+  path.join(import.meta.dirname, "../.github/workflows/ci.yml"),
+  "utf-8",
+);
+
+const workflowJob = (jobId: string): string => {
+  const marker = `\n  ${jobId}:\n`;
+  const start = workflow.indexOf(marker);
+  if (start === -1) {
+    throw new Error(`CI workflow is missing ${jobId}`);
+  }
+  const bodyStart = start + marker.length;
+  const nextJob = workflow.slice(bodyStart).search(/\n {2}[a-z][\w-]*:\n/u);
+  return nextJob === -1
+    ? workflow.slice(bodyStart)
+    : workflow.slice(bodyStart, bodyStart + nextJob);
+};
 
 const detects = (scope: "core" | "landing", files: string[]) =>
   Bun.spawnSync(["bash", script, scope, ...files], {
@@ -54,5 +72,28 @@ describe("detect-e2e-changes", () => {
     const files = [".github/workflows/ci.yml"];
     expect(detects("core", files)).toBe("true");
     expect(detects("landing", files)).toBe("true");
+  });
+
+  test("keeps production, Vite canary, and landing work parallel", () => {
+    const production = workflowJob("e2e-production-shard");
+    expect(production).not.toContain("Run Vite dependency canary");
+    expect(production).not.toContain("Check landing islands");
+
+    const canary = workflowJob("e2e-vite-canary");
+    expect(canary).not.toContain("Build web for route checks");
+    expect(canary).not.toContain("Run Playwright shard");
+
+    const landing = workflowJob("e2e-landing");
+    expect(landing).not.toContain("Start docker stack");
+    expect(landing).not.toContain("Start API server");
+
+    const aggregate = workflowJob("e2e");
+    for (const requiredJob of [
+      "e2e-production-shard",
+      "e2e-vite-canary",
+      "e2e-landing",
+    ]) {
+      expect(aggregate).toContain(requiredJob);
+    }
   });
 });


### PR DESCRIPTION
## Summary

- check only changed workspaces and reverse dependants in the local pre-push Oxc gate, with conservative full-repository fallbacks for global inputs or incomplete Turbo output
- run production Playwright shards, the Vite dependency canary, and landing browser coverage as independent parallel CI jobs
- profile the remaining production web-build hotspot nightly while retaining TanStack Start import protection

## Measurements

| Scenario | Wall time |
| --- | ---: |
| Previous full local code check | 139.62s |
| Web-only affected check | 19.58s |
| Root-only check | 0.77s |

The web-only path is 86% faster. Root tooling changes, including this PR, deliberately retain the full check.

Local profiling found TanStack Start import protection consumes most of the final Vite phase. This PR records its resolver and transform counters nightly instead of weakening that correctness boundary without a measured safe replacement.

## Validation

- bun run lint
- bun run format
- bun run typecheck
- bun run test
- bun test scripts/code-check-affected.test.ts scripts/detect-e2e-changes.test.ts
- actionlint .github/workflows/ci.yml .github/workflows/nightly-test.yml
- bun run security:audit
- bun run verify --all: all repository checks passed; the initially absent .ai/shared checkout prerequisite was initialized and bun run sync-ai:check then passed
- pre-push hooks
