### PR TITLE
fix: harden migration completion checks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -179,6 +179,40 @@ jobs:
             stella-api:smoke \
             bun /app/apps/api/src/db/migrate.js
 
+      - name: Reject inconsistent migration history
+        env:
+          DATABASE_URL: "postgres://postgres:postgres@127.0.0.1:5432/stella"
+          PGPASSWORD: postgres
+        run: |
+          set -euo pipefail
+          psql_smoke() {
+            docker run --rm --network host \
+              --env PGPASSWORD \
+              postgres:18 \
+              psql -h 127.0.0.1 -U postgres -d stella "$@"
+          }
+
+          original_hash=$(psql_smoke -tAc \
+            "SELECT hash FROM drizzle.__drizzle_migrations ORDER BY id DESC LIMIT 1")
+          restore_hash() {
+            psql_smoke -v ON_ERROR_STOP=1 -v original_hash="$original_hash" -c \
+              "UPDATE drizzle.__drizzle_migrations SET hash = :'original_hash' WHERE hash = repeat('0', 64)" \
+              >/dev/null
+          }
+          trap restore_hash EXIT
+
+          psql_smoke -v ON_ERROR_STOP=1 -c \
+            "UPDATE drizzle.__drizzle_migrations SET hash = repeat('0', 64) WHERE id = (SELECT max(id) FROM drizzle.__drizzle_migrations)" \
+            >/dev/null
+
+          if docker run --rm --network host \
+            --env DATABASE_URL \
+            stella-api:smoke \
+            bun /app/apps/api/src/db/migrate.js; then
+            echo "::error::Migration command accepted inconsistent applied history."
+            exit 1
+          fi
+
       - name: Run smoke container
         env:
           BETTER_AUTH_SECRET: "release-smoke-secret-at-least-32-chars"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -192,12 +192,20 @@ jobs:
               psql -h 127.0.0.1 -U postgres -d stella "$@"
           }
 
-          original_hash=$(psql_smoke -tAc \
+          original_hash=$(psql_smoke -v ON_ERROR_STOP=1 -tAc \
             "SELECT hash FROM drizzle.__drizzle_migrations ORDER BY id DESC LIMIT 1")
+          if [[ ! "$original_hash" =~ ^[0-9a-f]{64}$ ]]; then
+            echo "::error::Could not read the latest applied migration hash."
+            exit 1
+          fi
           restore_hash() {
-            psql_smoke -v ON_ERROR_STOP=1 -v original_hash="$original_hash" -c \
-              "UPDATE drizzle.__drizzle_migrations SET hash = :'original_hash' WHERE hash = repeat('0', 64)" \
-              >/dev/null
+            local restored
+            restored=$(psql_smoke -v ON_ERROR_STOP=1 -v original_hash="$original_hash" -tAc \
+              "WITH restored AS (UPDATE drizzle.__drizzle_migrations SET hash = :'original_hash' WHERE hash = repeat('0', 64) RETURNING 1) SELECT count(*) FROM restored")
+            if [[ "$restored" != "1" ]]; then
+              echo "::error::Restored $restored migration rows; expected 1."
+              return 1
+            fi
           }
           trap restore_hash EXIT
 

--- a/apps/api/drizzle/20260603120000_case_law_public_slugs/migration.sql
+++ b/apps/api/drizzle/20260603120000_case_law_public_slugs/migration.sql
@@ -19,6 +19,8 @@
 -- migration record as applied, so `slug` would silently not be unique. Drop
 -- any leftover index first (no-op on a clean run) and build without
 -- IF NOT EXISTS so a retry always rebuilds a valid index.
+SET statement_timeout = 0;
+--> statement-breakpoint
 COMMIT;
 --> statement-breakpoint
 DROP INDEX CONCURRENTLY IF EXISTS "case_law_decisions_slug_uidx";
@@ -28,3 +30,5 @@ CREATE UNIQUE INDEX CONCURRENTLY "case_law_decisions_slug_uidx"
   WHERE "slug" IS NOT NULL;
 --> statement-breakpoint
 BEGIN;
+--> statement-breakpoint
+SET statement_timeout = DEFAULT;

--- a/apps/api/drizzle/20260603120000_case_law_public_slugs/migration.sql
+++ b/apps/api/drizzle/20260603120000_case_law_public_slugs/migration.sql
@@ -13,19 +13,15 @@
 -- partial predicate keeps the index valid while legacy rows still carry a
 -- NULL slug.
 --
--- A CONCURRENTLY build that is interrupted (timeout, cancel, dropped
--- connection) leaves an INVALID index behind under the same name. A plain
--- `CREATE ... IF NOT EXISTS` retry would skip that invalid index and let the
--- migration record as applied, so `slug` would silently not be unique. Drop
--- any leftover index first (no-op on a clean run) and build without
--- IF NOT EXISTS so a retry always rebuilds a valid index.
+-- The migration runner validates this index after the ledger update and
+-- concurrently repairs an interrupted INVALID build. IF NOT EXISTS preserves
+-- an already-valid uniqueness boundary when a prior run reached the index but
+-- stopped before recording the migration.
 SET statement_timeout = 0;
 --> statement-breakpoint
 COMMIT;
 --> statement-breakpoint
-DROP INDEX CONCURRENTLY IF EXISTS "case_law_decisions_slug_uidx";
---> statement-breakpoint
-CREATE UNIQUE INDEX CONCURRENTLY "case_law_decisions_slug_uidx"
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS "case_law_decisions_slug_uidx"
   ON "case_law_decisions" ("slug")
   WHERE "slug" IS NOT NULL;
 --> statement-breakpoint

--- a/apps/api/drizzle/20260605143000_workflow_pending_fields_index/migration.sql
+++ b/apps/api/drizzle/20260605143000_workflow_pending_fields_index/migration.sql
@@ -6,11 +6,8 @@ SET statement_timeout = 0;
 --> statement-breakpoint
 COMMIT;
 --> statement-breakpoint
--- stella-migration-safety: reviewed destructive-change - retry cleanup drops only this migration's index before rebuilding it, so an interrupted INVALID index cannot be mistaken for completion.
-DROP INDEX CONCURRENTLY IF EXISTS "fields_pending_workspace_idx";
---> statement-breakpoint
--- squawk-ignore prefer-robust-stmts -- preceding DROP removes invalid retry artifacts; IF NOT EXISTS could accept one.
-CREATE INDEX CONCURRENTLY "fields_pending_workspace_idx" ON "fields" ("workspace_id") WHERE "content"->>'type' = 'pending';
+-- The runner validates this index and concurrently repairs an INVALID build.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "fields_pending_workspace_idx" ON "fields" ("workspace_id") WHERE "content"->>'type' = 'pending';
 --> statement-breakpoint
 BEGIN;
 --> statement-breakpoint

--- a/apps/api/drizzle/20260605143000_workflow_pending_fields_index/migration.sql
+++ b/apps/api/drizzle/20260605143000_workflow_pending_fields_index/migration.sql
@@ -6,7 +6,10 @@ SET statement_timeout = 0;
 --> statement-breakpoint
 COMMIT;
 --> statement-breakpoint
-CREATE INDEX CONCURRENTLY IF NOT EXISTS "fields_pending_workspace_idx" ON "fields" ("workspace_id") WHERE "content"->>'type' = 'pending';
+-- stella-migration-safety: reviewed destructive-change - retry cleanup drops only this migration's index before rebuilding it, so an interrupted INVALID index cannot be mistaken for completion.
+DROP INDEX CONCURRENTLY IF EXISTS "fields_pending_workspace_idx";
+--> statement-breakpoint
+CREATE INDEX CONCURRENTLY "fields_pending_workspace_idx" ON "fields" ("workspace_id") WHERE "content"->>'type' = 'pending';
 --> statement-breakpoint
 BEGIN;
 --> statement-breakpoint

--- a/apps/api/drizzle/20260605143000_workflow_pending_fields_index/migration.sql
+++ b/apps/api/drizzle/20260605143000_workflow_pending_fields_index/migration.sql
@@ -9,6 +9,7 @@ COMMIT;
 -- stella-migration-safety: reviewed destructive-change - retry cleanup drops only this migration's index before rebuilding it, so an interrupted INVALID index cannot be mistaken for completion.
 DROP INDEX CONCURRENTLY IF EXISTS "fields_pending_workspace_idx";
 --> statement-breakpoint
+-- squawk-ignore prefer-robust-stmts -- preceding DROP removes invalid retry artifacts; IF NOT EXISTS could accept one.
 CREATE INDEX CONCURRENTLY "fields_pending_workspace_idx" ON "fields" ("workspace_id") WHERE "content"->>'type' = 'pending';
 --> statement-breakpoint
 BEGIN;

--- a/apps/api/drizzle/20260605143000_workflow_pending_fields_index/migration.sql
+++ b/apps/api/drizzle/20260605143000_workflow_pending_fields_index/migration.sql
@@ -2,8 +2,12 @@
 -- requires CREATE INDEX CONCURRENTLY to run outside a transaction block.
 -- Split the migrator transaction, build the large-table index without
 -- write-blocking locks, then reopen a transaction for Drizzle's migration row.
+SET statement_timeout = 0;
+--> statement-breakpoint
 COMMIT;
 --> statement-breakpoint
 CREATE INDEX CONCURRENTLY IF NOT EXISTS "fields_pending_workspace_idx" ON "fields" ("workspace_id") WHERE "content"->>'type' = 'pending';
 --> statement-breakpoint
 BEGIN;
+--> statement-breakpoint
+SET statement_timeout = DEFAULT;

--- a/apps/api/drizzle/20260629123000_arabic_normalize_function/migration.sql
+++ b/apps/api/drizzle/20260629123000_arabic_normalize_function/migration.sql
@@ -46,22 +46,22 @@ COMMIT;
 --> statement-breakpoint
 DROP INDEX CONCURRENTLY IF EXISTS "contacts_display_name_arabic_norm_trgm_idx";
 --> statement-breakpoint
-CREATE INDEX CONCURRENTLY IF NOT EXISTS "contacts_display_name_arabic_norm_trgm_idx"
+CREATE INDEX CONCURRENTLY "contacts_display_name_arabic_norm_trgm_idx"
   ON "contacts" USING gin (arabic_normalize("display_name") gin_trgm_ops);
 --> statement-breakpoint
 DROP INDEX CONCURRENTLY IF EXISTS "contacts_first_name_arabic_norm_trgm_idx";
 --> statement-breakpoint
-CREATE INDEX CONCURRENTLY IF NOT EXISTS "contacts_first_name_arabic_norm_trgm_idx"
+CREATE INDEX CONCURRENTLY "contacts_first_name_arabic_norm_trgm_idx"
   ON "contacts" USING gin (arabic_normalize("first_name") gin_trgm_ops);
 --> statement-breakpoint
 DROP INDEX CONCURRENTLY IF EXISTS "contacts_last_name_arabic_norm_trgm_idx";
 --> statement-breakpoint
-CREATE INDEX CONCURRENTLY IF NOT EXISTS "contacts_last_name_arabic_norm_trgm_idx"
+CREATE INDEX CONCURRENTLY "contacts_last_name_arabic_norm_trgm_idx"
   ON "contacts" USING gin (arabic_normalize("last_name") gin_trgm_ops);
 --> statement-breakpoint
 DROP INDEX CONCURRENTLY IF EXISTS "contacts_organization_name_arabic_norm_trgm_idx";
 --> statement-breakpoint
-CREATE INDEX CONCURRENTLY IF NOT EXISTS "contacts_organization_name_arabic_norm_trgm_idx"
+CREATE INDEX CONCURRENTLY "contacts_organization_name_arabic_norm_trgm_idx"
   ON "contacts" USING gin (arabic_normalize("organization_name") gin_trgm_ops);
 --> statement-breakpoint
 -- squawk-ignore transaction-nesting, ban-uncommitted-transaction

--- a/apps/api/drizzle/20260629123000_arabic_normalize_function/migration.sql
+++ b/apps/api/drizzle/20260629123000_arabic_normalize_function/migration.sql
@@ -1,6 +1,5 @@
 SET lock_timeout = '1s';--> statement-breakpoint
 SET statement_timeout = '5s';--> statement-breakpoint
--- stella-migration-safety: reviewed destructive-change - retry cleanup only drops the Arabic normalization indexes introduced by this same migration, immediately before rebuilding them concurrently; rollback is to drop these additive indexes and function.
 CREATE EXTENSION IF NOT EXISTS pg_trgm;--> statement-breakpoint
 -- Search match-key fold for Arabic. Must stay byte-for-byte equal to
 -- @stll/text-normalize's normalizeSearchText (golden vectors pin both).
@@ -44,28 +43,17 @@ SET statement_timeout = 0;
 -- squawk-ignore transaction-nesting
 COMMIT;
 --> statement-breakpoint
-DROP INDEX CONCURRENTLY IF EXISTS "contacts_display_name_arabic_norm_trgm_idx";
---> statement-breakpoint
--- squawk-ignore prefer-robust-stmts -- preceding DROP removes invalid retry artifacts; IF NOT EXISTS could accept one.
-CREATE INDEX CONCURRENTLY "contacts_display_name_arabic_norm_trgm_idx"
+-- The runner validates these indexes and concurrently repairs INVALID builds.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "contacts_display_name_arabic_norm_trgm_idx"
   ON "contacts" USING gin (arabic_normalize("display_name") gin_trgm_ops);
 --> statement-breakpoint
-DROP INDEX CONCURRENTLY IF EXISTS "contacts_first_name_arabic_norm_trgm_idx";
---> statement-breakpoint
--- squawk-ignore prefer-robust-stmts -- preceding DROP removes invalid retry artifacts; IF NOT EXISTS could accept one.
-CREATE INDEX CONCURRENTLY "contacts_first_name_arabic_norm_trgm_idx"
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "contacts_first_name_arabic_norm_trgm_idx"
   ON "contacts" USING gin (arabic_normalize("first_name") gin_trgm_ops);
 --> statement-breakpoint
-DROP INDEX CONCURRENTLY IF EXISTS "contacts_last_name_arabic_norm_trgm_idx";
---> statement-breakpoint
--- squawk-ignore prefer-robust-stmts -- preceding DROP removes invalid retry artifacts; IF NOT EXISTS could accept one.
-CREATE INDEX CONCURRENTLY "contacts_last_name_arabic_norm_trgm_idx"
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "contacts_last_name_arabic_norm_trgm_idx"
   ON "contacts" USING gin (arabic_normalize("last_name") gin_trgm_ops);
 --> statement-breakpoint
-DROP INDEX CONCURRENTLY IF EXISTS "contacts_organization_name_arabic_norm_trgm_idx";
---> statement-breakpoint
--- squawk-ignore prefer-robust-stmts -- preceding DROP removes invalid retry artifacts; IF NOT EXISTS could accept one.
-CREATE INDEX CONCURRENTLY "contacts_organization_name_arabic_norm_trgm_idx"
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "contacts_organization_name_arabic_norm_trgm_idx"
   ON "contacts" USING gin (arabic_normalize("organization_name") gin_trgm_ops);
 --> statement-breakpoint
 -- squawk-ignore transaction-nesting, ban-uncommitted-transaction

--- a/apps/api/drizzle/20260629123000_arabic_normalize_function/migration.sql
+++ b/apps/api/drizzle/20260629123000_arabic_normalize_function/migration.sql
@@ -46,21 +46,25 @@ COMMIT;
 --> statement-breakpoint
 DROP INDEX CONCURRENTLY IF EXISTS "contacts_display_name_arabic_norm_trgm_idx";
 --> statement-breakpoint
+-- squawk-ignore prefer-robust-stmts -- preceding DROP removes invalid retry artifacts; IF NOT EXISTS could accept one.
 CREATE INDEX CONCURRENTLY "contacts_display_name_arabic_norm_trgm_idx"
   ON "contacts" USING gin (arabic_normalize("display_name") gin_trgm_ops);
 --> statement-breakpoint
 DROP INDEX CONCURRENTLY IF EXISTS "contacts_first_name_arabic_norm_trgm_idx";
 --> statement-breakpoint
+-- squawk-ignore prefer-robust-stmts -- preceding DROP removes invalid retry artifacts; IF NOT EXISTS could accept one.
 CREATE INDEX CONCURRENTLY "contacts_first_name_arabic_norm_trgm_idx"
   ON "contacts" USING gin (arabic_normalize("first_name") gin_trgm_ops);
 --> statement-breakpoint
 DROP INDEX CONCURRENTLY IF EXISTS "contacts_last_name_arabic_norm_trgm_idx";
 --> statement-breakpoint
+-- squawk-ignore prefer-robust-stmts -- preceding DROP removes invalid retry artifacts; IF NOT EXISTS could accept one.
 CREATE INDEX CONCURRENTLY "contacts_last_name_arabic_norm_trgm_idx"
   ON "contacts" USING gin (arabic_normalize("last_name") gin_trgm_ops);
 --> statement-breakpoint
 DROP INDEX CONCURRENTLY IF EXISTS "contacts_organization_name_arabic_norm_trgm_idx";
 --> statement-breakpoint
+-- squawk-ignore prefer-robust-stmts -- preceding DROP removes invalid retry artifacts; IF NOT EXISTS could accept one.
 CREATE INDEX CONCURRENTLY "contacts_organization_name_arabic_norm_trgm_idx"
   ON "contacts" USING gin (arabic_normalize("organization_name") gin_trgm_ops);
 --> statement-breakpoint

--- a/apps/api/drizzle/20260701160000_property_playbook_definition_id/migration.sql
+++ b/apps/api/drizzle/20260701160000_property_playbook_definition_id/migration.sql
@@ -6,11 +6,8 @@ SET statement_timeout = 0;--> statement-breakpoint
 -- squawk-ignore transaction-nesting
 COMMIT;
 --> statement-breakpoint
--- stella-migration-safety: reviewed destructive-change - retry cleanup drops only this migration's index before rebuilding it, so an interrupted INVALID index cannot be mistaken for completion.
-DROP INDEX CONCURRENTLY IF EXISTS "properties_workspace_playbook_definition_idx";
---> statement-breakpoint
--- squawk-ignore prefer-robust-stmts -- preceding DROP removes invalid retry artifacts; IF NOT EXISTS could accept one.
-CREATE INDEX CONCURRENTLY "properties_workspace_playbook_definition_idx" ON "properties" USING btree ("workspace_id","playbook_definition_id");
+-- The runner validates this index and concurrently repairs an INVALID build.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "properties_workspace_playbook_definition_idx" ON "properties" USING btree ("workspace_id","playbook_definition_id");
 --> statement-breakpoint
 -- squawk-ignore transaction-nesting, ban-uncommitted-transaction
 BEGIN;

--- a/apps/api/drizzle/20260701160000_property_playbook_definition_id/migration.sql
+++ b/apps/api/drizzle/20260701160000_property_playbook_definition_id/migration.sql
@@ -6,7 +6,10 @@ SET statement_timeout = 0;--> statement-breakpoint
 -- squawk-ignore transaction-nesting
 COMMIT;
 --> statement-breakpoint
-CREATE INDEX CONCURRENTLY IF NOT EXISTS "properties_workspace_playbook_definition_idx" ON "properties" USING btree ("workspace_id","playbook_definition_id");
+-- stella-migration-safety: reviewed destructive-change - retry cleanup drops only this migration's index before rebuilding it, so an interrupted INVALID index cannot be mistaken for completion.
+DROP INDEX CONCURRENTLY IF EXISTS "properties_workspace_playbook_definition_idx";
+--> statement-breakpoint
+CREATE INDEX CONCURRENTLY "properties_workspace_playbook_definition_idx" ON "properties" USING btree ("workspace_id","playbook_definition_id");
 --> statement-breakpoint
 -- squawk-ignore transaction-nesting, ban-uncommitted-transaction
 BEGIN;

--- a/apps/api/drizzle/20260701160000_property_playbook_definition_id/migration.sql
+++ b/apps/api/drizzle/20260701160000_property_playbook_definition_id/migration.sql
@@ -2,6 +2,7 @@ SET lock_timeout = '1s';--> statement-breakpoint
 SET statement_timeout = '5s';--> statement-breakpoint
 ALTER TABLE "properties" ADD COLUMN "playbook_definition_id" uuid;--> statement-breakpoint
 ALTER TABLE "properties" ADD CONSTRAINT "properties_playbook_definition_id_playbook_definitions_id_fk" FOREIGN KEY ("playbook_definition_id") REFERENCES "playbook_definitions"("id") ON DELETE CASCADE ON UPDATE NO ACTION NOT VALID;--> statement-breakpoint
+SET statement_timeout = 0;--> statement-breakpoint
 -- squawk-ignore transaction-nesting
 COMMIT;
 --> statement-breakpoint
@@ -9,3 +10,5 @@ CREATE INDEX CONCURRENTLY IF NOT EXISTS "properties_workspace_playbook_definitio
 --> statement-breakpoint
 -- squawk-ignore transaction-nesting, ban-uncommitted-transaction
 BEGIN;
+--> statement-breakpoint
+SET statement_timeout = '5s';

--- a/apps/api/drizzle/20260701160000_property_playbook_definition_id/migration.sql
+++ b/apps/api/drizzle/20260701160000_property_playbook_definition_id/migration.sql
@@ -9,6 +9,7 @@ COMMIT;
 -- stella-migration-safety: reviewed destructive-change - retry cleanup drops only this migration's index before rebuilding it, so an interrupted INVALID index cannot be mistaken for completion.
 DROP INDEX CONCURRENTLY IF EXISTS "properties_workspace_playbook_definition_idx";
 --> statement-breakpoint
+-- squawk-ignore prefer-robust-stmts -- preceding DROP removes invalid retry artifacts; IF NOT EXISTS could accept one.
 CREATE INDEX CONCURRENTLY "properties_workspace_playbook_definition_idx" ON "properties" USING btree ("workspace_id","playbook_definition_id");
 --> statement-breakpoint
 -- squawk-ignore transaction-nesting, ban-uncommitted-transaction

--- a/apps/api/drizzle/20260703233000_account_credential_singleton/migration.sql
+++ b/apps/api/drizzle/20260703233000_account_credential_singleton/migration.sql
@@ -4,7 +4,10 @@ SET statement_timeout = 0;--> statement-breakpoint
 -- squawk-ignore transaction-nesting
 COMMIT;
 --> statement-breakpoint
-CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS "account_credential_singleton_uidx" ON "account" ("provider_id") WHERE provider_id = 'credential';
+-- stella-migration-safety: reviewed destructive-change - retry cleanup drops only this migration's index before rebuilding it, so an interrupted INVALID index cannot be mistaken for completion.
+DROP INDEX CONCURRENTLY IF EXISTS "account_credential_singleton_uidx";
+--> statement-breakpoint
+CREATE UNIQUE INDEX CONCURRENTLY "account_credential_singleton_uidx" ON "account" ("provider_id") WHERE provider_id = 'credential';
 --> statement-breakpoint
 -- squawk-ignore transaction-nesting, ban-uncommitted-transaction
 BEGIN;

--- a/apps/api/drizzle/20260703233000_account_credential_singleton/migration.sql
+++ b/apps/api/drizzle/20260703233000_account_credential_singleton/migration.sql
@@ -1,5 +1,6 @@
 SET lock_timeout = '1s';--> statement-breakpoint
 SET statement_timeout = '5s';--> statement-breakpoint
+SET statement_timeout = 0;--> statement-breakpoint
 -- squawk-ignore transaction-nesting
 COMMIT;
 --> statement-breakpoint
@@ -7,3 +8,5 @@ CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS "account_credential_singleton_uid
 --> statement-breakpoint
 -- squawk-ignore transaction-nesting, ban-uncommitted-transaction
 BEGIN;
+--> statement-breakpoint
+SET statement_timeout = '5s';

--- a/apps/api/drizzle/20260703233000_account_credential_singleton/migration.sql
+++ b/apps/api/drizzle/20260703233000_account_credential_singleton/migration.sql
@@ -4,11 +4,9 @@ SET statement_timeout = 0;--> statement-breakpoint
 -- squawk-ignore transaction-nesting
 COMMIT;
 --> statement-breakpoint
--- stella-migration-safety: reviewed destructive-change - retry cleanup drops only this migration's index before rebuilding it, so an interrupted INVALID index cannot be mistaken for completion.
-DROP INDEX CONCURRENTLY IF EXISTS "account_credential_singleton_uidx";
---> statement-breakpoint
--- squawk-ignore prefer-robust-stmts -- preceding DROP removes invalid retry artifacts; IF NOT EXISTS could accept one.
-CREATE UNIQUE INDEX CONCURRENTLY "account_credential_singleton_uidx" ON "account" ("provider_id") WHERE provider_id = 'credential';
+-- The migration runner preserves a valid index and concurrently repairs an
+-- interrupted INVALID build before reporting completion.
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS "account_credential_singleton_uidx" ON "account" ("provider_id") WHERE provider_id = 'credential';
 --> statement-breakpoint
 -- squawk-ignore transaction-nesting, ban-uncommitted-transaction
 BEGIN;

--- a/apps/api/drizzle/20260703233000_account_credential_singleton/migration.sql
+++ b/apps/api/drizzle/20260703233000_account_credential_singleton/migration.sql
@@ -7,6 +7,7 @@ COMMIT;
 -- stella-migration-safety: reviewed destructive-change - retry cleanup drops only this migration's index before rebuilding it, so an interrupted INVALID index cannot be mistaken for completion.
 DROP INDEX CONCURRENTLY IF EXISTS "account_credential_singleton_uidx";
 --> statement-breakpoint
+-- squawk-ignore prefer-robust-stmts -- preceding DROP removes invalid retry artifacts; IF NOT EXISTS could accept one.
 CREATE UNIQUE INDEX CONCURRENTLY "account_credential_singleton_uidx" ON "account" ("provider_id") WHERE provider_id = 'credential';
 --> statement-breakpoint
 -- squawk-ignore transaction-nesting, ban-uncommitted-transaction

--- a/apps/api/drizzle/20260707120000_property_role/migration.sql
+++ b/apps/api/drizzle/20260707120000_property_role/migration.sql
@@ -8,16 +8,10 @@ SET statement_timeout = 0;
 --> statement-breakpoint
 SET lock_timeout = 0;
 --> statement-breakpoint
--- stella-migration-safety: reviewed destructive-change - this drops only this
--- migration's partial index by name before recreating it below; retries must not
--- record the migration without the unique classifier invariant in place.
--- A cancelled concurrent index build can leave an INVALID index with this name.
--- Drop any leftover index first, then recreate without IF NOT EXISTS so retries
--- cannot record the migration without enforcing the invariant.
-DROP INDEX CONCURRENTLY IF EXISTS "properties_ws_document_type_classifier_unq";
---> statement-breakpoint
--- squawk-ignore prefer-robust-stmts
-CREATE UNIQUE INDEX CONCURRENTLY "properties_ws_document_type_classifier_unq" ON "properties" USING btree ("workspace_id") WHERE "role" = 'document-type-classifier';
+-- The migration runner validates this index after the ledger update and
+-- concurrently repairs an interrupted INVALID build. IF NOT EXISTS preserves
+-- an already-valid uniqueness boundary across retries.
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS "properties_ws_document_type_classifier_unq" ON "properties" USING btree ("workspace_id") WHERE "role" = 'document-type-classifier';
 --> statement-breakpoint
 SET lock_timeout = '1s';
 --> statement-breakpoint

--- a/apps/api/drizzle/20260707120000_property_role/migration.sql
+++ b/apps/api/drizzle/20260707120000_property_role/migration.sql
@@ -21,5 +21,7 @@ CREATE UNIQUE INDEX CONCURRENTLY "properties_ws_document_type_classifier_unq" ON
 --> statement-breakpoint
 SET lock_timeout = '1s';
 --> statement-breakpoint
+SET statement_timeout = '5s';
+--> statement-breakpoint
 -- squawk-ignore transaction-nesting, ban-uncommitted-transaction
 BEGIN;

--- a/apps/api/drizzle/20260717110000_usage_event_idempotency/migration.sql
+++ b/apps/api/drizzle/20260717110000_usage_event_idempotency/migration.sql
@@ -1,5 +1,3 @@
--- stella-migration-safety: reviewed destructive-change - retry cleanup only removes the same-name index before rebuilding it; no ledger rows or columns are removed
-
 SET lock_timeout = '1s';--> statement-breakpoint
 SET statement_timeout = '5s';--> statement-breakpoint
 ALTER TABLE "usage_events" ADD COLUMN IF NOT EXISTS "idempotency_key" text;
@@ -16,10 +14,10 @@ SET statement_timeout = 0;
 --> statement-breakpoint
 SET lock_timeout = 0;
 --> statement-breakpoint
-DROP INDEX CONCURRENTLY IF EXISTS "usage_events_org_idempotency_key_uidx";
---> statement-breakpoint
--- squawk-ignore prefer-robust-stmts
-CREATE UNIQUE INDEX CONCURRENTLY "usage_events_org_idempotency_key_uidx"
+-- The migration runner validates this index after the ledger update and
+-- concurrently repairs an interrupted INVALID build. IF NOT EXISTS preserves
+-- an already-valid uniqueness boundary across retries.
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS "usage_events_org_idempotency_key_uidx"
   ON "usage_events" ("organization_id", "idempotency_key")
   WHERE "idempotency_key" IS NOT NULL;
 --> statement-breakpoint

--- a/apps/api/drizzle/20260717170000_report_export_notifications/migration.sql
+++ b/apps/api/drizzle/20260717170000_report_export_notifications/migration.sql
@@ -2,6 +2,7 @@ SET lock_timeout = '1s';--> statement-breakpoint
 SET statement_timeout = '5s';--> statement-breakpoint
 ALTER TABLE "report_exports" ADD COLUMN IF NOT EXISTS "notification_status" text DEFAULT 'suppressed' NOT NULL;--> statement-breakpoint
 ALTER TABLE "report_exports" ADD COLUMN IF NOT EXISTS "notification_lang" varchar(10) DEFAULT 'en' NOT NULL;--> statement-breakpoint
+-- squawk-ignore prefer-timestamp-tz -- the later timestamptz_everywhere migration upgrades this historical intermediate type
 ALTER TABLE "report_exports" ADD COLUMN IF NOT EXISTS "notification_attempted_at" timestamp;--> statement-breakpoint
 -- squawk-ignore transaction-nesting
 COMMIT;

--- a/apps/api/drizzle/20260717170000_report_export_notifications/migration.sql
+++ b/apps/api/drizzle/20260717170000_report_export_notifications/migration.sql
@@ -9,11 +9,8 @@ COMMIT;
 --> statement-breakpoint
 SET statement_timeout = '0';
 --> statement-breakpoint
--- stella-migration-safety: reviewed destructive-change - retry cleanup drops only this migration's partial reconciliation index before rebuilding it; no table data is removed, and this prevents a cancelled concurrent build from leaving an invalid index that IF NOT EXISTS would silently accept.
-DROP INDEX CONCURRENTLY IF EXISTS "report_exports_pending_notification_idx";
---> statement-breakpoint
--- squawk-ignore prefer-robust-stmts
-CREATE INDEX CONCURRENTLY "report_exports_pending_notification_idx" ON "report_exports" USING btree ("created_at","id") WHERE "notification_status" = 'pending' AND "status" IN ('completed', 'failed');
+-- The runner validates this index and concurrently repairs an INVALID build.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "report_exports_pending_notification_idx" ON "report_exports" USING btree ("created_at","id") WHERE "notification_status" = 'pending' AND "status" IN ('completed', 'failed');
 --> statement-breakpoint
 -- squawk-ignore transaction-nesting, ban-uncommitted-transaction
 BEGIN;

--- a/apps/api/drizzle/20260717170000_report_export_notifications/migration.sql
+++ b/apps/api/drizzle/20260717170000_report_export_notifications/migration.sql
@@ -16,3 +16,5 @@ CREATE INDEX CONCURRENTLY "report_exports_pending_notification_idx" ON "report_e
 --> statement-breakpoint
 -- squawk-ignore transaction-nesting, ban-uncommitted-transaction
 BEGIN;
+--> statement-breakpoint
+SET statement_timeout = '5s';

--- a/apps/api/drizzle/20260719172000_user_created_at_index/migration.sql
+++ b/apps/api/drizzle/20260719172000_user_created_at_index/migration.sql
@@ -5,11 +5,8 @@ SET statement_timeout = '0';
 -- squawk-ignore transaction-nesting
 COMMIT;
 --> statement-breakpoint
--- stella-migration-safety: reviewed destructive-change - retry cleanup drops only this migration's index if a cancelled concurrent build left an invalid index behind; no table data is removed.
-DROP INDEX CONCURRENTLY IF EXISTS "user_createdAt_idx";
---> statement-breakpoint
--- squawk-ignore prefer-robust-stmts
-CREATE INDEX CONCURRENTLY "user_createdAt_idx" ON "user" USING btree ("created_at","id");
+-- The runner validates this index and concurrently repairs an INVALID build.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "user_createdAt_idx" ON "user" USING btree ("created_at","id");
 --> statement-breakpoint
 -- squawk-ignore transaction-nesting, ban-uncommitted-transaction
 BEGIN;

--- a/apps/api/drizzle/20260719172000_user_created_at_index/migration.sql
+++ b/apps/api/drizzle/20260719172000_user_created_at_index/migration.sql
@@ -13,3 +13,5 @@ CREATE INDEX CONCURRENTLY "user_createdAt_idx" ON "user" USING btree ("created_a
 --> statement-breakpoint
 -- squawk-ignore transaction-nesting, ban-uncommitted-transaction
 BEGIN;
+--> statement-breakpoint
+SET statement_timeout = DEFAULT;

--- a/apps/api/drizzle/20260720140000_machine_api_keys_org_index/migration.sql
+++ b/apps/api/drizzle/20260720140000_machine_api_keys_org_index/migration.sql
@@ -54,5 +54,7 @@ CREATE INDEX CONCURRENTLY "apikey_org_keyset_idx" ON "apikey" (((metadata::jsonb
 --> statement-breakpoint
 SET lock_timeout = '1s';
 --> statement-breakpoint
+SET statement_timeout = '5s';
+--> statement-breakpoint
 -- squawk-ignore transaction-nesting, ban-uncommitted-transaction
 BEGIN;

--- a/apps/api/drizzle/20260720140000_machine_api_keys_org_index/migration.sql
+++ b/apps/api/drizzle/20260720140000_machine_api_keys_org_index/migration.sql
@@ -31,26 +31,12 @@ SET statement_timeout = 0;
 SET lock_timeout = 0;
 --> statement-breakpoint
 
--- stella-migration-safety: reviewed destructive-change - drops only this
--- migration's own indexes by name before recreating them below. A cancelled
--- concurrent build leaves an INVALID index behind, and `IF NOT EXISTS` would
--- then skip recreating it — leaving the tenant filter running against an index
--- Postgres will not use. Dropping first and creating without `IF NOT EXISTS`
--- means a retry cannot record the migration while that boundary is unindexed.
-DROP INDEX CONCURRENTLY IF EXISTS "apikey_metadata_organization_id_idx";
---> statement-breakpoint
--- squawk-ignore prefer-robust-stmts
-CREATE INDEX CONCURRENTLY "apikey_metadata_organization_id_idx" ON "apikey" (((metadata::jsonb ->> 'organizationId'))) WHERE metadata IS NOT NULL;
+-- The runner validates these indexes and concurrently repairs INVALID builds.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "apikey_metadata_organization_id_idx" ON "apikey" (((metadata::jsonb ->> 'organizationId'))) WHERE metadata IS NOT NULL;
 --> statement-breakpoint
 
--- stella-migration-safety: reviewed destructive-change - same reasoning as the
--- index above; this one additionally carries the keyset ordering the
--- organization-scoped list paginates on.
-DROP INDEX CONCURRENTLY IF EXISTS "apikey_org_keyset_idx";
---> statement-breakpoint
 -- Keyset pagination for the organization-scoped list orders by (created_at, id).
--- squawk-ignore prefer-robust-stmts
-CREATE INDEX CONCURRENTLY "apikey_org_keyset_idx" ON "apikey" (((metadata::jsonb ->> 'organizationId')), "created_at" DESC, "id" DESC) WHERE metadata IS NOT NULL;
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "apikey_org_keyset_idx" ON "apikey" (((metadata::jsonb ->> 'organizationId')), "created_at" DESC, "id" DESC) WHERE metadata IS NOT NULL;
 --> statement-breakpoint
 SET lock_timeout = '1s';
 --> statement-breakpoint

--- a/apps/api/drizzle/20260731130000_decision_source_document_id/migration.sql
+++ b/apps/api/drizzle/20260731130000_decision_source_document_id/migration.sql
@@ -1,11 +1,3 @@
--- stella-migration-safety: reviewed destructive-change - drops indexes only, no
--- table or column data. Two of the three drops are the idempotency guard the
--- CONCURRENTLY pattern requires (an interrupted build leaves an INVALID index
--- that a later CREATE IF NOT EXISTS would skip), so they are no-ops on a clean
--- run. The third drops the old case-number unique index only after its partial
--- replacement has been built, so uniqueness is enforced throughout. Rollback is
--- to recreate that index CONCURRENTLY over the same columns without the
--- predicate; no data is lost either way.
 SET lock_timeout = '1s';--> statement-breakpoint
 SET statement_timeout = '5s';--> statement-breakpoint
 
@@ -36,9 +28,9 @@ ALTER TABLE "case_law_decisions"
 -- update and concurrently repairs interrupted INVALID builds. IF NOT EXISTS
 -- preserves an already-valid uniqueness boundary across retries.
 --
--- Order matters: the replacement for the old key is built before the old
--- one is dropped, so uniqueness is enforced continuously rather than
--- leaving a window in which duplicates could land.
+-- The online migration runner retires the old key only after catalog checks
+-- prove that both replacements are valid and ready. This keeps uniqueness
+-- enforced across interrupted and retried builds.
 SET statement_timeout = 0;
 --> statement-breakpoint
 -- squawk-ignore transaction-nesting -- deliberate: CREATE INDEX CONCURRENTLY cannot run inside the migrator's transaction, so it is closed here and reopened below
@@ -51,8 +43,6 @@ CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS "case_law_decisions_source_docume
 CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS "case_law_decisions_source_case_lang_null_idx"
   ON "case_law_decisions" ("source_id","case_number","language")
   WHERE "source_document_id" IS NULL;
---> statement-breakpoint
-DROP INDEX CONCURRENTLY IF EXISTS "case_law_decisions_source_case_lang_idx";
 --> statement-breakpoint
 -- squawk-ignore ban-uncommitted-transaction, transaction-nesting -- reopens the migrator's own transaction, closed above so the concurrent builds could run outside it; Drizzle commits it after writing its bookkeeping row
 BEGIN;

--- a/apps/api/drizzle/20260731130000_decision_source_document_id/migration.sql
+++ b/apps/api/drizzle/20260731130000_decision_source_document_id/migration.sql
@@ -32,10 +32,9 @@ ALTER TABLE "case_law_decisions"
 -- BEGIN for the migration bookkeeping row (same split as
 -- 20260603120000_case_law_public_slugs).
 --
--- An interrupted CONCURRENTLY build leaves an INVALID index under the same
--- name, and a `CREATE ... IF NOT EXISTS` retry would skip it and record the
--- migration as applied with uniqueness silently unenforced. Drop first
--- (no-op on a clean run), then build without IF NOT EXISTS.
+-- The migration runner validates both replacement indexes after the ledger
+-- update and concurrently repairs interrupted INVALID builds. IF NOT EXISTS
+-- preserves an already-valid uniqueness boundary across retries.
 --
 -- Order matters: the replacement for the old key is built before the old
 -- one is dropped, so uniqueness is enforced continuously rather than
@@ -45,17 +44,11 @@ SET statement_timeout = 0;
 -- squawk-ignore transaction-nesting -- deliberate: CREATE INDEX CONCURRENTLY cannot run inside the migrator's transaction, so it is closed here and reopened below
 COMMIT;
 --> statement-breakpoint
-DROP INDEX CONCURRENTLY IF EXISTS "case_law_decisions_source_document_idx";
---> statement-breakpoint
--- squawk-ignore prefer-robust-stmts -- IF NOT EXISTS would skip an INVALID index left by an interrupted CONCURRENTLY build; the preceding DROP is what makes a retry robust
-CREATE UNIQUE INDEX CONCURRENTLY "case_law_decisions_source_document_idx"
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS "case_law_decisions_source_document_idx"
   ON "case_law_decisions" ("source_id","source_document_id")
   WHERE "source_document_id" IS NOT NULL;
 --> statement-breakpoint
-DROP INDEX CONCURRENTLY IF EXISTS "case_law_decisions_source_case_lang_null_idx";
---> statement-breakpoint
--- squawk-ignore prefer-robust-stmts -- see the note on the index above
-CREATE UNIQUE INDEX CONCURRENTLY "case_law_decisions_source_case_lang_null_idx"
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS "case_law_decisions_source_case_lang_null_idx"
   ON "case_law_decisions" ("source_id","case_number","language")
   WHERE "source_document_id" IS NULL;
 --> statement-breakpoint

--- a/apps/api/drizzle/20260731130000_decision_source_document_id/migration.sql
+++ b/apps/api/drizzle/20260731130000_decision_source_document_id/migration.sql
@@ -40,6 +40,8 @@ ALTER TABLE "case_law_decisions"
 -- Order matters: the replacement for the old key is built before the old
 -- one is dropped, so uniqueness is enforced continuously rather than
 -- leaving a window in which duplicates could land.
+SET statement_timeout = 0;
+--> statement-breakpoint
 -- squawk-ignore transaction-nesting -- deliberate: CREATE INDEX CONCURRENTLY cannot run inside the migrator's transaction, so it is closed here and reopened below
 COMMIT;
 --> statement-breakpoint
@@ -61,3 +63,5 @@ DROP INDEX CONCURRENTLY IF EXISTS "case_law_decisions_source_case_lang_idx";
 --> statement-breakpoint
 -- squawk-ignore ban-uncommitted-transaction, transaction-nesting -- reopens the migrator's own transaction, closed above so the concurrent builds could run outside it; Drizzle commits it after writing its bookkeeping row
 BEGIN;
+--> statement-breakpoint
+SET statement_timeout = '5s';

--- a/apps/api/src/db/migrate.ts
+++ b/apps/api/src/db/migrate.ts
@@ -77,6 +77,17 @@ try {
   await client.unsafe(bootstrapRoleSql);
   const database = drizzle({ client });
   await migrate(database, { migrationsFolder });
+  await assertMigrationHistory({
+    context: "migrate",
+    migrationsDir: migrationsFolder,
+    queryAppliedHashes: async () => {
+      const rows = await database.execute<AppliedMigrationRow>(
+        sql`SELECT hash FROM drizzle.__drizzle_migrations`,
+      );
+      return new Set(rows.map(({ hash }) => hash));
+    },
+    remedy: "Migration completion requires every bundled migration hash.",
+  });
   await runOnlineMigrations({
     reserve: async () => {
       const connection = await client.reserve();
@@ -89,17 +100,6 @@ try {
         release: () => connection.release(),
       };
     },
-  });
-  await assertMigrationHistory({
-    context: "migrate",
-    migrationsDir: migrationsFolder,
-    queryAppliedHashes: async () => {
-      const rows = await database.execute<AppliedMigrationRow>(
-        sql`SELECT hash FROM drizzle.__drizzle_migrations`,
-      );
-      return new Set(rows.map(({ hash }) => hash));
-    },
-    remedy: "Migration completion requires every bundled migration hash.",
   });
   // eslint-disable-next-line no-console -- migrate CLI entrypoint; stdout is its interface (no app logger in this minimal-env task)
   console.info("[migrate] migrations applied");

--- a/apps/api/src/db/migrate.ts
+++ b/apps/api/src/db/migrate.ts
@@ -1,5 +1,6 @@
 import { panic } from "better-result";
 import { SQL } from "bun";
+import { sql } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/bun-sql";
 import { migrate } from "drizzle-orm/bun-sql/migrator";
 import nodePath from "node:path";
@@ -7,6 +8,7 @@ import nodePath from "node:path";
 // Relative imports (not the `@/api` alias): this script ships as a loose
 // file in the runtime image, which has no tsconfig to resolve paths.
 import { resolveDatabaseUrl } from "../db-url";
+import { assertMigrationHistory } from "../lib/db/migration-history";
 import { runOnlineMigrations } from "./online-migrations";
 
 // Migrations run through Bun's SQL client — the same driver the API uses
@@ -69,10 +71,12 @@ $$;
 // lands on the same migrations folder either way. Keep the bundle's COPY
 // destination two directories above its drizzle/ copy to preserve this.
 const migrationsFolder = nodePath.resolve(import.meta.dir, "../../drizzle");
+type AppliedMigrationRow = { hash: string };
 
 try {
   await client.unsafe(bootstrapRoleSql);
-  await migrate(drizzle({ client }), { migrationsFolder });
+  const database = drizzle({ client });
+  await migrate(database, { migrationsFolder });
   await runOnlineMigrations({
     reserve: async () => {
       const connection = await client.reserve();
@@ -85,6 +89,17 @@ try {
         release: () => connection.release(),
       };
     },
+  });
+  await assertMigrationHistory({
+    context: "migrate",
+    migrationsDir: migrationsFolder,
+    queryAppliedHashes: async () => {
+      const rows = await database.execute<AppliedMigrationRow>(
+        sql`SELECT hash FROM drizzle.__drizzle_migrations`,
+      );
+      return new Set(rows.map(({ hash }) => hash));
+    },
+    remedy: "Migration completion requires every bundled migration hash.",
   });
   // eslint-disable-next-line no-console -- migrate CLI entrypoint; stdout is its interface (no app logger in this minimal-env task)
   console.info("[migrate] migrations applied");

--- a/apps/api/src/db/migration-concurrent-index.test.ts
+++ b/apps/api/src/db/migration-concurrent-index.test.ts
@@ -3,7 +3,7 @@ import nodePath from "node:path";
 
 const MIGRATIONS_DIR = nodePath.resolve(import.meta.dir, "../../drizzle");
 const SAFETY_TOKEN =
-  /\bSET\s+(?:LOCAL\s+)?statement_timeout\s*=\s*(?:'[^']*'|[^\s;]+)|\bCREATE\s+(?:UNIQUE\s+)?INDEX\s+CONCURRENTLY\b/giu;
+  /\bSET\s+(?:LOCAL\s+)?statement_timeout\s*=\s*(?:'[^']*'|[^\s;]+)|\b(?:CREATE\s+(?:UNIQUE\s+)?|DROP\s+)INDEX\s+CONCURRENTLY\b/giu;
 const UNBOUNDED_TIMEOUT = /^SET\s+statement_timeout\s*=\s*(?:'0'|0)$/iu;
 
 const collectUnsafeConcurrentIndexes = async (): Promise<string[]> => {
@@ -30,7 +30,9 @@ const collectUnsafeConcurrentIndexes = async (): Promise<string[]> => {
         continue;
       }
       if (!hasUnboundedTimeout) {
-        violations.push(`${relativePath}: concurrent index has a timeout`);
+        violations.push(
+          `${relativePath}: concurrent index operation has a timeout`,
+        );
       }
       sawConcurrentIndex = true;
     }
@@ -44,7 +46,7 @@ const collectUnsafeConcurrentIndexes = async (): Promise<string[]> => {
 };
 
 describe("concurrent index migration safety", () => {
-  test("disables statement timeout before every concurrent index build", async () => {
+  test("disables statement timeout around every concurrent index operation", async () => {
     expect(await collectUnsafeConcurrentIndexes()).toEqual([]);
   });
 });

--- a/apps/api/src/db/migration-concurrent-index.test.ts
+++ b/apps/api/src/db/migration-concurrent-index.test.ts
@@ -40,17 +40,19 @@ const collectUnsafeConcurrentIndexes = async (): Promise<string[]> => {
     }
 
     const droppedIndexes = new Set(
-      [...sqlWithoutLineComments.matchAll(CONCURRENT_DROP)].flatMap((match) =>
-        match.at(1) ? [match[1]] : [],
-      ),
+      [...sqlWithoutLineComments.matchAll(CONCURRENT_DROP)].flatMap((match) => {
+        const name = match.at(1);
+        return name ? [name] : [];
+      }),
     );
     const concurrentUniqueCreates = [
       ...sqlWithoutLineComments.matchAll(CONCURRENT_UNIQUE_CREATE),
     ];
     const createdUniqueIndexes = new Set(
-      concurrentUniqueCreates.flatMap(({ groups }) =>
-        groups?.["name"] ? [groups["name"]] : [],
-      ),
+      concurrentUniqueCreates.flatMap(({ groups }) => {
+        const name = groups?.["name"];
+        return name ? [name] : [];
+      }),
     );
     if (
       concurrentUniqueCreates.some(({ groups }) => groups?.["idempotent"]) &&

--- a/apps/api/src/db/migration-concurrent-index.test.ts
+++ b/apps/api/src/db/migration-concurrent-index.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "bun:test";
+import nodePath from "node:path";
+
+const MIGRATIONS_DIR = nodePath.resolve(import.meta.dir, "../../drizzle");
+const SAFETY_TOKEN =
+  /\bSET\s+(?:LOCAL\s+)?statement_timeout\s*=\s*(?:'[^']*'|[^\s;]+)|\bCREATE\s+(?:UNIQUE\s+)?INDEX\s+CONCURRENTLY\b/giu;
+const UNBOUNDED_TIMEOUT = /^SET\s+statement_timeout\s*=\s*(?:'0'|0)$/iu;
+
+const collectUnsafeConcurrentIndexes = async (): Promise<string[]> => {
+  const violations: string[] = [];
+  const migrationFiles = new Bun.Glob("20*/migration.sql");
+
+  for await (const relativePath of migrationFiles.scan({
+    cwd: MIGRATIONS_DIR,
+  })) {
+    const source = await Bun.file(
+      nodePath.join(MIGRATIONS_DIR, relativePath),
+    ).text();
+    const sqlWithoutLineComments = source
+      .split("\n")
+      .filter((line) => !line.trimStart().startsWith("--"))
+      .join("\n");
+    let hasUnboundedTimeout = false;
+    let sawConcurrentIndex = false;
+
+    for (const match of sqlWithoutLineComments.matchAll(SAFETY_TOKEN)) {
+      const token = match[0].replaceAll(/\s+/gu, " ").trim();
+      if (/^SET\s/iu.test(token)) {
+        hasUnboundedTimeout = UNBOUNDED_TIMEOUT.test(token);
+        continue;
+      }
+      if (!hasUnboundedTimeout) {
+        violations.push(`${relativePath}: concurrent index has a timeout`);
+      }
+      sawConcurrentIndex = true;
+    }
+
+    if (sawConcurrentIndex && hasUnboundedTimeout) {
+      violations.push(`${relativePath}: statement timeout is not restored`);
+    }
+  }
+
+  return violations.sort();
+};
+
+describe("concurrent index migration safety", () => {
+  test("disables statement timeout before every concurrent index build", async () => {
+    expect(await collectUnsafeConcurrentIndexes()).toEqual([]);
+  });
+});

--- a/apps/api/src/db/migration-concurrent-index.test.ts
+++ b/apps/api/src/db/migration-concurrent-index.test.ts
@@ -5,6 +5,8 @@ const MIGRATIONS_DIR = nodePath.resolve(import.meta.dir, "../../drizzle");
 const SAFETY_TOKEN =
   /\bSET\s+(?:LOCAL\s+)?statement_timeout\s*=\s*(?:'[^']*'|[^\s;]+)|\b(?:CREATE\s+(?:UNIQUE\s+)?|DROP\s+)INDEX\s+CONCURRENTLY\b/giu;
 const UNBOUNDED_TIMEOUT = /^SET\s+statement_timeout\s*=\s*(?:'0'|0)$/iu;
+const UNSAFE_IDEMPOTENCE =
+  /\bCREATE\s+(?:UNIQUE\s+)?INDEX\s+CONCURRENTLY\s+IF\s+NOT\s+EXISTS\b/iu;
 
 const collectUnsafeConcurrentIndexes = async (): Promise<string[]> => {
   const violations: string[] = [];
@@ -20,6 +22,11 @@ const collectUnsafeConcurrentIndexes = async (): Promise<string[]> => {
       .split("\n")
       .filter((line) => !line.trimStart().startsWith("--"))
       .join("\n");
+    if (UNSAFE_IDEMPOTENCE.test(sqlWithoutLineComments)) {
+      violations.push(
+        `${relativePath}: concurrent index uses IF NOT EXISTS`,
+      );
+    }
     let hasUnboundedTimeout = false;
     let sawConcurrentIndex = false;
 

--- a/apps/api/src/db/migration-concurrent-index.test.ts
+++ b/apps/api/src/db/migration-concurrent-index.test.ts
@@ -44,9 +44,23 @@ const collectUnsafeConcurrentIndexes = async (): Promise<string[]> => {
         match.at(1) ? [match[1]] : [],
       ),
     );
-    for (const { groups } of sqlWithoutLineComments.matchAll(
-      CONCURRENT_UNIQUE_CREATE,
-    )) {
+    const concurrentUniqueCreates = [
+      ...sqlWithoutLineComments.matchAll(CONCURRENT_UNIQUE_CREATE),
+    ];
+    const createdUniqueIndexes = new Set(
+      concurrentUniqueCreates.flatMap(({ groups }) =>
+        groups?.["name"] ? [groups["name"]] : [],
+      ),
+    );
+    if (
+      concurrentUniqueCreates.some(({ groups }) => groups?.["idempotent"]) &&
+      [...droppedIndexes].some((name) => !createdUniqueIndexes.has(name))
+    ) {
+      violations.push(
+        `${relativePath}: unique replacement drop must follow online validity postconditions`,
+      );
+    }
+    for (const { groups } of concurrentUniqueCreates) {
       const name = groups?.["name"];
       if (!name) {
         continue;

--- a/apps/api/src/db/migration-concurrent-index.test.ts
+++ b/apps/api/src/db/migration-concurrent-index.test.ts
@@ -23,9 +23,7 @@ const collectUnsafeConcurrentIndexes = async (): Promise<string[]> => {
       .filter((line) => !line.trimStart().startsWith("--"))
       .join("\n");
     if (UNSAFE_IDEMPOTENCE.test(sqlWithoutLineComments)) {
-      violations.push(
-        `${relativePath}: concurrent index uses IF NOT EXISTS`,
-      );
+      violations.push(`${relativePath}: concurrent index uses IF NOT EXISTS`);
     }
     let hasUnboundedTimeout = false;
     let sawConcurrentIndex = false;

--- a/apps/api/src/db/migration-concurrent-index.test.ts
+++ b/apps/api/src/db/migration-concurrent-index.test.ts
@@ -47,11 +47,11 @@ const collectUnsafeConcurrentIndexes = async (): Promise<string[]> => {
     for (const { groups } of sqlWithoutLineComments.matchAll(
       CONCURRENT_UNIQUE_CREATE,
     )) {
-      const name = groups?.name;
+      const name = groups?.["name"];
       if (!name) {
         continue;
       }
-      if (!groups.idempotent) {
+      if (!groups["idempotent"]) {
         violations.push(
           `${relativePath}: unique index ${name} is not retry-idempotent`,
         );

--- a/apps/api/src/db/migration-concurrent-index.test.ts
+++ b/apps/api/src/db/migration-concurrent-index.test.ts
@@ -1,12 +1,18 @@
 import { describe, expect, test } from "bun:test";
 import nodePath from "node:path";
 
+import { ONLINE_VALIDATED_INDEX_NAMES } from "./online-migrations";
+
 const MIGRATIONS_DIR = nodePath.resolve(import.meta.dir, "../../drizzle");
 const SAFETY_TOKEN =
   /\bSET\s+(?:LOCAL\s+)?statement_timeout\s*=\s*(?:'[^']*'|[^\s;]+)|\b(?:CREATE\s+(?:UNIQUE\s+)?|DROP\s+)INDEX\s+CONCURRENTLY\b/giu;
 const UNBOUNDED_TIMEOUT = /^SET\s+statement_timeout\s*=\s*(?:'0'|0)$/iu;
-const UNSAFE_IDEMPOTENCE =
-  /\bCREATE\s+(?:UNIQUE\s+)?INDEX\s+CONCURRENTLY\s+IF\s+NOT\s+EXISTS\b/iu;
+const CONCURRENT_IF_NOT_EXISTS =
+  /\bCREATE\s+(?:UNIQUE\s+)?INDEX\s+CONCURRENTLY\s+IF\s+NOT\s+EXISTS\s+"([^"]+)"/giu;
+const CONCURRENT_UNIQUE_CREATE =
+  /\bCREATE\s+UNIQUE\s+INDEX\s+CONCURRENTLY(?<idempotent>\s+IF\s+NOT\s+EXISTS)?\s+"(?<name>[^"]+)"/giu;
+const CONCURRENT_DROP =
+  /\bDROP\s+INDEX\s+CONCURRENTLY\s+IF\s+EXISTS\s+"([^"]+)"/giu;
 
 const collectUnsafeConcurrentIndexes = async (): Promise<string[]> => {
   const violations: string[] = [];
@@ -22,8 +28,39 @@ const collectUnsafeConcurrentIndexes = async (): Promise<string[]> => {
       .split("\n")
       .filter((line) => !line.trimStart().startsWith("--"))
       .join("\n");
-    if (UNSAFE_IDEMPOTENCE.test(sqlWithoutLineComments)) {
-      violations.push(`${relativePath}: concurrent index uses IF NOT EXISTS`);
+    for (const match of sqlWithoutLineComments.matchAll(
+      CONCURRENT_IF_NOT_EXISTS,
+    )) {
+      const name = match.at(1);
+      if (!name || !ONLINE_VALIDATED_INDEX_NAMES.has(name)) {
+        violations.push(
+          `${relativePath}: ${name ?? "unknown index"} uses IF NOT EXISTS without an online validity postcondition`,
+        );
+      }
+    }
+
+    const droppedIndexes = new Set(
+      [...sqlWithoutLineComments.matchAll(CONCURRENT_DROP)].flatMap((match) =>
+        match.at(1) ? [match[1]] : [],
+      ),
+    );
+    for (const { groups } of sqlWithoutLineComments.matchAll(
+      CONCURRENT_UNIQUE_CREATE,
+    )) {
+      const name = groups?.name;
+      if (!name) {
+        continue;
+      }
+      if (!groups.idempotent) {
+        violations.push(
+          `${relativePath}: unique index ${name} is not retry-idempotent`,
+        );
+      }
+      if (droppedIndexes.has(name)) {
+        violations.push(
+          `${relativePath}: retry can remove valid unique index ${name}`,
+        );
+      }
     }
     let hasUnboundedTimeout = false;
     let sawConcurrentIndex = false;
@@ -51,7 +88,7 @@ const collectUnsafeConcurrentIndexes = async (): Promise<string[]> => {
 };
 
 describe("concurrent index migration safety", () => {
-  test("disables statement timeout around every concurrent index operation", async () => {
+  test("enforces bounded-lock, unbounded-build, and validity-aware retries", async () => {
     expect(await collectUnsafeConcurrentIndexes()).toEqual([]);
   });
 });

--- a/apps/api/src/db/online-migrations.test.ts
+++ b/apps/api/src/db/online-migrations.test.ts
@@ -3,54 +3,70 @@ import { describe, expect, test } from "bun:test";
 import { runOnlineMigrations } from "./online-migrations";
 
 const CREATE_INDEX_FRAGMENT = "CREATE INDEX CONCURRENTLY";
-const DROP_INDEX_FRAGMENT = "DROP INDEX CONCURRENTLY";
+const REINDEX_FRAGMENT = "REINDEX INDEX CONCURRENTLY";
+const REPORT_EXPORT_INDEX = "report_exports_workspace_requester_created_idx";
+const CREDENTIAL_INDEX = "account_credential_singleton_uidx";
 
 describe("online migrations", () => {
   test("accepts an already valid index without rebuilding it", async () => {
-    const harness = createHarness([true, true]);
+    const harness = createHarness();
 
     await runOnlineMigrations(harness.pool);
 
-    expect(indexOfStatement(harness.statements, DROP_INDEX_FRAGMENT)).toBe(-1);
     expect(indexOfStatement(harness.statements, CREATE_INDEX_FRAGMENT)).toBe(
       -1,
     );
+    expect(indexOfStatement(harness.statements, REINDEX_FRAGMENT)).toBe(-1);
     expect(harness.released()).toBe(true);
   });
 
   test("creates a missing index online and verifies completion", async () => {
-    const harness = createHarness([undefined, true]);
+    const harness = createHarness({
+      [REPORT_EXPORT_INDEX]: [undefined, true],
+    });
 
     await runOnlineMigrations(harness.pool);
 
-    expect(indexOfStatement(harness.statements, DROP_INDEX_FRAGMENT)).toBe(-1);
     expect(
       indexOfStatement(harness.statements, CREATE_INDEX_FRAGMENT),
     ).toBeGreaterThan(-1);
     expect(harness.released()).toBe(true);
   });
 
-  test("repairs an interrupted invalid build before verifying completion", async () => {
-    const harness = createHarness([false, true]);
+  test("concurrently repairs an interrupted invalid build", async () => {
+    const harness = createHarness({
+      [CREDENTIAL_INDEX]: [false, true],
+    });
 
     await runOnlineMigrations(harness.pool);
 
-    const dropIndex = indexOfStatement(harness.statements, DROP_INDEX_FRAGMENT);
-    const createIndex = indexOfStatement(
-      harness.statements,
-      CREATE_INDEX_FRAGMENT,
+    expect(
+      indexOfStatement(
+        harness.statements,
+        `${REINDEX_FRAGMENT} public."${CREDENTIAL_INDEX}"`,
+      ),
+    ).toBeGreaterThan(-1);
+    expect(harness.released()).toBe(true);
+  });
+
+  test("rejects a missing index required by a rewritten migration", async () => {
+    const harness = createHarness({
+      [CREDENTIAL_INDEX]: [undefined],
+    });
+
+    await expect(runOnlineMigrations(harness.pool)).rejects.toThrow(
+      `Required migration index ${CREDENTIAL_INDEX} is missing`,
     );
-    expect(dropIndex).toBeGreaterThan(-1);
-    expect(createIndex).toBeGreaterThan(dropIndex);
     expect(harness.released()).toBe(true);
   });
 });
 
 type IndexValidity = boolean | undefined;
+type IndexStates = Readonly<Record<string, IndexValidity[]>>;
 
-const createHarness = (indexStates: IndexValidity[]) => {
+const createHarness = (indexStates: IndexStates = {}) => {
   const statements: string[] = [];
-  let indexState = 0;
+  const indexOffsets = new Map<string, number>();
   let released = false;
 
   return {
@@ -59,10 +75,16 @@ const createHarness = (indexStates: IndexValidity[]) => {
         execute: async (query: string) => {
           statements.push(query);
         },
-        query: async (query: string) => {
+        query: async (query: string, params: readonly unknown[] = []) => {
           statements.push(query);
-          const isValid = indexStates.at(indexState);
-          indexState += 1;
+          const indexName = params.at(1);
+          if (typeof indexName !== "string") {
+            throw new TypeError("Expected index name query parameter");
+          }
+          const offset = indexOffsets.get(indexName) ?? 0;
+          const states = indexStates[indexName];
+          const isValid = states ? states.at(offset) : true;
+          indexOffsets.set(indexName, offset + 1);
           return isValid === undefined ? [] : [{ isValid }];
         },
         release: () => {

--- a/apps/api/src/db/online-migrations.test.ts
+++ b/apps/api/src/db/online-migrations.test.ts
@@ -11,6 +11,9 @@ const DROP_INDEX_FRAGMENT = "DROP INDEX CONCURRENTLY";
 const REINDEX_FRAGMENT = "REINDEX INDEX CONCURRENTLY";
 const REPORT_EXPORT_INDEX = "report_exports_workspace_requester_created_idx";
 const CREDENTIAL_INDEX = "account_credential_singleton_uidx";
+const SOURCE_DOCUMENT_INDEX = "case_law_decisions_source_document_idx";
+const SOURCE_CASE_INDEX = "case_law_decisions_source_case_lang_null_idx";
+const LEGACY_SOURCE_CASE_INDEX = "case_law_decisions_source_case_lang_idx";
 
 describe("online migrations", () => {
   test("accepts an already valid index without rebuilding it", async () => {
@@ -119,6 +122,36 @@ describe("online migrations", () => {
     expect(indexOfStatement(harness.statements, REINDEX_FRAGMENT)).toBe(-1);
   });
 
+  test("retires a legacy index only after both replacements validate", async () => {
+    const harness = createHarness();
+
+    await runOnlineMigrations(harness.pool);
+
+    const dropOffset = indexOfStatement(
+      harness.statements,
+      `DROP INDEX CONCURRENTLY IF EXISTS public."${LEGACY_SOURCE_CASE_INDEX}"`,
+    );
+    expect(dropOffset).toBeGreaterThan(
+      indexOfStatement(harness.statements, SOURCE_DOCUMENT_INDEX),
+    );
+    expect(dropOffset).toBeGreaterThan(
+      indexOfStatement(harness.statements, SOURCE_CASE_INDEX),
+    );
+  });
+
+  test("preserves a legacy index when a replacement is not ready", async () => {
+    const harness = createHarness({
+      indexStates: { [SOURCE_CASE_INDEX]: [false, false] },
+    });
+
+    await expect(runOnlineMigrations(harness.pool)).rejects.toMatchObject({
+      message: `Required migration index ${SOURCE_CASE_INDEX} is not ready`,
+    });
+    expect(indexOfStatement(harness.statements, LEGACY_SOURCE_CASE_INDEX)).toBe(
+      -1,
+    );
+  });
+
   test("rejects a missing index required by a rewritten migration", async () => {
     const harness = createHarness({
       indexStates: { [CREDENTIAL_INDEX]: [undefined] },
@@ -183,7 +216,7 @@ const createHarness = ({
           }
         },
         query: async (query: string, params: readonly unknown[] = []) => {
-          statements.push(query);
+          statements.push(`${query}\n-- params ${JSON.stringify(params)}`);
           if (query.includes("starts_with")) {
             const newPrefix = params.at(2);
             const oldPrefix = params.at(3);
@@ -212,7 +245,10 @@ const createHarness = ({
           }
           const offset = indexOffsets.get(indexName) ?? 0;
           const states = indexStates[indexName];
-          const state = states ? states.at(offset) : true;
+          let state: IndexState = true;
+          if (states) {
+            state = offset < states.length ? states.at(offset) : states.at(-1);
+          }
           indexOffsets.set(indexName, offset + 1);
           if (state === undefined) {
             return [];

--- a/apps/api/src/db/online-migrations.test.ts
+++ b/apps/api/src/db/online-migrations.test.ts
@@ -54,9 +54,13 @@ describe("online migrations", () => {
       [CREDENTIAL_INDEX]: [undefined],
     });
 
-    await expect(runOnlineMigrations(harness.pool)).rejects.toThrow(
-      `Required migration index ${CREDENTIAL_INDEX} is missing`,
+    const rejection: unknown = await runOnlineMigrations(harness.pool).then(
+      () => null,
+      (error: unknown) => error,
     );
+    expect(rejection).toMatchObject({
+      message: `Required migration index ${CREDENTIAL_INDEX} is missing`,
+    });
     expect(harness.released()).toBe(true);
   });
 });

--- a/apps/api/src/db/online-migrations.test.ts
+++ b/apps/api/src/db/online-migrations.test.ts
@@ -144,7 +144,11 @@ describe("online migrations", () => {
       indexStates: { [SOURCE_CASE_INDEX]: [false, false] },
     });
 
-    await expect(runOnlineMigrations(harness.pool)).rejects.toMatchObject({
+    const rejection: unknown = await runOnlineMigrations(harness.pool).then(
+      () => null,
+      (error: unknown) => error,
+    );
+    expect(rejection).toMatchObject({
       message: `Required migration index ${SOURCE_CASE_INDEX} is not ready`,
     });
     expect(indexOfStatement(harness.statements, LEGACY_SOURCE_CASE_INDEX)).toBe(

--- a/apps/api/src/db/online-migrations.test.ts
+++ b/apps/api/src/db/online-migrations.test.ts
@@ -1,8 +1,13 @@
 import { describe, expect, test } from "bun:test";
 
-import { runOnlineMigrations } from "./online-migrations";
+import {
+  assertOnlineMigrationsApplied,
+  ONLINE_MIGRATION_INDEXES,
+  runOnlineMigrations,
+} from "./online-migrations";
 
 const CREATE_INDEX_FRAGMENT = "CREATE INDEX CONCURRENTLY";
+const DROP_INDEX_FRAGMENT = "DROP INDEX CONCURRENTLY";
 const REINDEX_FRAGMENT = "REINDEX INDEX CONCURRENTLY";
 const REPORT_EXPORT_INDEX = "report_exports_workspace_requester_created_idx";
 const CREDENTIAL_INDEX = "account_credential_singleton_uidx";
@@ -22,7 +27,7 @@ describe("online migrations", () => {
 
   test("creates a missing index online and verifies completion", async () => {
     const harness = createHarness({
-      [REPORT_EXPORT_INDEX]: [undefined, true],
+      indexStates: { [REPORT_EXPORT_INDEX]: [undefined, true] },
     });
 
     await runOnlineMigrations(harness.pool);
@@ -35,7 +40,7 @@ describe("online migrations", () => {
 
   test("concurrently repairs an interrupted invalid build", async () => {
     const harness = createHarness({
-      [CREDENTIAL_INDEX]: [false, true],
+      indexStates: { [CREDENTIAL_INDEX]: [false, true] },
     });
 
     await runOnlineMigrations(harness.pool);
@@ -49,9 +54,74 @@ describe("online migrations", () => {
     expect(harness.released()).toBe(true);
   });
 
+  test("drops an interrupted reindex artifact before retrying", async () => {
+    const artifactName = `${CREDENTIAL_INDEX}_ccnew`;
+    const harness = createHarness({
+      artifacts: {
+        [CREDENTIAL_INDEX]: [{ isValid: false, name: artifactName }],
+      },
+      indexStates: { [CREDENTIAL_INDEX]: [false, true] },
+    });
+
+    await runOnlineMigrations(harness.pool);
+
+    expect(
+      indexOfStatement(
+        harness.statements,
+        `${DROP_INDEX_FRAGMENT} public."${artifactName}"`,
+      ),
+    ).toBeGreaterThan(-1);
+    expect(
+      indexOfStatement(
+        harness.statements,
+        `${REINDEX_FRAGMENT} public."${CREDENTIAL_INDEX}"`,
+      ),
+    ).toBeGreaterThan(-1);
+  });
+
+  test("rejects a valid same-named index with the wrong definition", async () => {
+    const harness = createHarness({
+      indexStates: {
+        [CREDENTIAL_INDEX]: [
+          {
+            definitionBody: "ON public.account USING btree (id)",
+            isValid: true,
+          },
+        ],
+      },
+    });
+
+    const rejection: unknown = await runOnlineMigrations(harness.pool).then(
+      () => null,
+      (error: unknown) => error,
+    );
+
+    expect(rejection).toMatchObject({
+      message: `Required migration index ${CREDENTIAL_INDEX} has an unexpected definition`,
+    });
+  });
+
+  test("startup validation rejects an invalid required index", async () => {
+    const harness = createHarness({
+      indexStates: { [CREDENTIAL_INDEX]: [false] },
+    });
+
+    const rejection: unknown = await assertOnlineMigrationsApplied(
+      harness.pool,
+    ).then(
+      () => null,
+      (error: unknown) => error,
+    );
+
+    expect(rejection).toMatchObject({
+      message: `Required migration index ${CREDENTIAL_INDEX} is not ready`,
+    });
+    expect(indexOfStatement(harness.statements, REINDEX_FRAGMENT)).toBe(-1);
+  });
+
   test("rejects a missing index required by a rewritten migration", async () => {
     const harness = createHarness({
-      [CREDENTIAL_INDEX]: [undefined],
+      indexStates: { [CREDENTIAL_INDEX]: [undefined] },
     });
 
     const rejection: unknown = await runOnlineMigrations(harness.pool).then(
@@ -65,12 +135,33 @@ describe("online migrations", () => {
   });
 });
 
-type IndexValidity = boolean | undefined;
-type IndexStates = Readonly<Record<string, IndexValidity[]>>;
+type IndexState =
+  | boolean
+  | undefined
+  | { definitionBody: string; isValid: boolean };
+type IndexStates = Readonly<Record<string, IndexState[]>>;
+type Artifact = { isValid: boolean; name: string };
+type Artifacts = Readonly<Record<string, Artifact[]>>;
 
-const createHarness = (indexStates: IndexStates = {}) => {
+type HarnessOptions = {
+  artifacts?: Artifacts;
+  indexStates?: IndexStates;
+};
+
+const POSTGRES_IDENTIFIER_MAX_LENGTH = 63;
+
+const artifactPrefix = (name: string, suffix: "_ccnew" | "_ccold") =>
+  `${name.slice(0, POSTGRES_IDENTIFIER_MAX_LENGTH - suffix.length)}${suffix}`;
+
+const createHarness = ({
+  artifacts = {},
+  indexStates = {},
+}: HarnessOptions = {}) => {
   const statements: string[] = [];
   const indexOffsets = new Map<string, number>();
+  const remainingArtifacts = new Map(
+    Object.entries(artifacts).map(([name, values]) => [name, [...values]]),
+  );
   let released = false;
 
   return {
@@ -78,18 +169,60 @@ const createHarness = (indexStates: IndexStates = {}) => {
       reserve: async () => ({
         execute: async (query: string) => {
           statements.push(query);
+          if (!query.includes(DROP_INDEX_FRAGMENT)) {
+            return;
+          }
+          for (const [name, values] of remainingArtifacts) {
+            remainingArtifacts.set(
+              name,
+              values.filter(
+                ({ name: artifactName }) =>
+                  !query.includes(`"${artifactName}"`),
+              ),
+            );
+          }
         },
         query: async (query: string, params: readonly unknown[] = []) => {
           statements.push(query);
+          if (query.includes("starts_with")) {
+            const newPrefix = params.at(2);
+            const oldPrefix = params.at(3);
+            const index = ONLINE_MIGRATION_INDEXES.find(
+              ({ name }) =>
+                artifactPrefix(name, "_ccnew") === newPrefix &&
+                artifactPrefix(name, "_ccold") === oldPrefix,
+            );
+            if (!index) {
+              throw new TypeError("Expected managed index artifact prefixes");
+            }
+            return (remainingArtifacts.get(index.name) ?? []).map(
+              ({ isValid, name }) => indexRow(index, isValid, name),
+            );
+          }
+
           const indexName = params.at(1);
           if (typeof indexName !== "string") {
             throw new TypeError("Expected index name query parameter");
           }
+          const index = ONLINE_MIGRATION_INDEXES.find(
+            ({ name }) => name === indexName,
+          );
+          if (!index) {
+            throw new TypeError("Expected managed index name");
+          }
           const offset = indexOffsets.get(indexName) ?? 0;
           const states = indexStates[indexName];
-          const isValid = states ? states.at(offset) : true;
+          const state = states ? states.at(offset) : true;
           indexOffsets.set(indexName, offset + 1);
-          return isValid === undefined ? [] : [{ isValid }];
+          if (state === undefined) {
+            return [];
+          }
+          if (typeof state === "boolean") {
+            return [indexRow(index, state)];
+          }
+          return [
+            indexRow(index, state.isValid, index.name, state.definitionBody),
+          ];
         },
         release: () => {
           released = true;
@@ -100,6 +233,19 @@ const createHarness = (indexStates: IndexStates = {}) => {
     statements,
   };
 };
+
+const indexRow = (
+  index: (typeof ONLINE_MIGRATION_INDEXES)[number],
+  isValid: boolean,
+  name = index.name,
+  body = index.definitionBody,
+) => ({
+  definition: `CREATE ${index.isUnique ? "UNIQUE " : ""}INDEX ${name} ${body}`,
+  isReady: isValid,
+  isUnique: index.isUnique,
+  isValid,
+  name,
+});
 
 const indexOfStatement = (statements: string[], fragment: string): number =>
   statements.findIndex((statement) => statement.includes(fragment));

--- a/apps/api/src/db/online-migrations.ts
+++ b/apps/api/src/db/online-migrations.ts
@@ -10,7 +10,12 @@ const ONLINE_MIGRATIONS_LOCK_SQL =
 const ONLINE_MIGRATIONS_UNLOCK_SQL =
   "SELECT pg_advisory_unlock(hashtext('stella-online-migrations'))";
 const READ_INDEX_STATE_SQL = `
-  SELECT index_state.indisvalid AS "isValid"
+  SELECT
+    index_state.indisready AS "isReady",
+    index_state.indisunique AS "isUnique",
+    index_state.indisvalid AS "isValid",
+    pg_get_indexdef(index_relation.oid) AS "definition",
+    index_relation.relname AS "name"
   FROM pg_catalog.pg_class index_relation
   JOIN pg_catalog.pg_namespace index_namespace
     ON index_namespace.oid = index_relation.relnamespace
@@ -22,15 +27,39 @@ const READ_INDEX_STATE_SQL = `
     AND index_relation.relname = $2
     AND table_relation.relname = $3
 `;
+const READ_REINDEX_ARTIFACTS_SQL = `
+  SELECT
+    index_state.indisready AS "isReady",
+    index_state.indisunique AS "isUnique",
+    index_state.indisvalid AS "isValid",
+    pg_get_indexdef(index_relation.oid) AS "definition",
+    index_relation.relname AS "name"
+  FROM pg_catalog.pg_class index_relation
+  JOIN pg_catalog.pg_namespace index_namespace
+    ON index_namespace.oid = index_relation.relnamespace
+  JOIN pg_catalog.pg_index index_state
+    ON index_state.indexrelid = index_relation.oid
+  JOIN pg_catalog.pg_class table_relation
+    ON table_relation.oid = index_state.indrelid
+  WHERE index_namespace.nspname = $1
+    AND table_relation.relname = $2
+    AND (
+      starts_with(index_relation.relname, $3)
+      OR starts_with(index_relation.relname, $4)
+    )
+`;
 
 type OnlineIndex = RequiredMigrationIndex & {
   createSql?: string;
 };
 
-const ONLINE_INDEXES: readonly OnlineIndex[] = [
+export const ONLINE_MIGRATION_INDEXES: readonly OnlineIndex[] = [
   {
     createSql:
       'CREATE INDEX CONCURRENTLY "report_exports_workspace_requester_created_idx" ON public."report_exports" USING btree ("workspace_id", "requested_by", "created_at", "id")',
+    definitionBody:
+      "ON public.report_exports USING btree (workspace_id, requested_by, created_at, id)",
+    isUnique: false,
     name: "report_exports_workspace_requester_created_idx",
     tableName: "report_exports",
   },
@@ -38,7 +67,7 @@ const ONLINE_INDEXES: readonly OnlineIndex[] = [
 ];
 
 export const ONLINE_VALIDATED_INDEX_NAMES: ReadonlySet<string> = new Set(
-  ONLINE_INDEXES.map(({ name }) => name),
+  ONLINE_MIGRATION_INDEXES.map(({ name }) => name),
 );
 
 type OnlineMigrationConnection = {
@@ -50,17 +79,34 @@ type OnlineMigrationConnection = {
   release: () => void;
 };
 
-type OnlineMigrationPool = {
+export type OnlineMigrationPool = {
   reserve: () => Promise<OnlineMigrationConnection>;
 };
 
-type OnlineIndexState =
-  | { type: "invalid" }
-  | { type: "missing" }
-  | { type: "valid" };
+type PresentIndexState = {
+  definition: string;
+  isReady: boolean;
+  isUnique: boolean;
+  isValid: boolean;
+  name: string;
+  type: "present";
+};
+
+type OnlineIndexState = { type: "missing" } | PresentIndexState;
+
+type OnlineMigrationOperation = "repair" | "validate";
 
 export const runOnlineMigrations = async (
   pool: OnlineMigrationPool,
+): Promise<void> => await processOnlineMigrations(pool, "repair");
+
+export const assertOnlineMigrationsApplied = async (
+  pool: OnlineMigrationPool,
+): Promise<void> => await processOnlineMigrations(pool, "validate");
+
+const processOnlineMigrations = async (
+  pool: OnlineMigrationPool,
+  operation: OnlineMigrationOperation,
 ): Promise<void> => {
   const connection = await pool.reserve();
   let lockAcquired = false;
@@ -68,12 +114,20 @@ export const runOnlineMigrations = async (
   try {
     await connection.execute(ONLINE_MIGRATIONS_LOCK_SQL);
     lockAcquired = true;
-    await connection.execute("SET lock_timeout = '1s'");
-    await connection.execute("SET statement_timeout = '0'");
 
-    for (const index of ONLINE_INDEXES) {
-      // oxlint-disable-next-line no-await-in-loop -- PostgreSQL permits only one concurrent index build per table; preserve deterministic order.
-      await ensureIndexValid(connection, index);
+    if (operation === "repair") {
+      await connection.execute("SET lock_timeout = '1s'");
+      await connection.execute("SET statement_timeout = '0'");
+    }
+
+    for (const index of ONLINE_MIGRATION_INDEXES) {
+      if (operation === "repair") {
+        // oxlint-disable-next-line no-await-in-loop -- PostgreSQL permits only one concurrent index build per table; preserve deterministic order.
+        await ensureIndexValid(connection, index);
+      } else {
+        // oxlint-disable-next-line no-await-in-loop -- Startup must validate the complete catalog before serving.
+        await assertIndexReady(connection, index);
+      }
     }
   } finally {
     try {
@@ -86,6 +140,34 @@ export const runOnlineMigrations = async (
   }
 };
 
+const parsePresentIndexState = (row: unknown): PresentIndexState => {
+  if (
+    typeof row !== "object" ||
+    row === null ||
+    !("definition" in row) ||
+    typeof row.definition !== "string" ||
+    !("isReady" in row) ||
+    typeof row.isReady !== "boolean" ||
+    !("isUnique" in row) ||
+    typeof row.isUnique !== "boolean" ||
+    !("isValid" in row) ||
+    typeof row.isValid !== "boolean" ||
+    !("name" in row) ||
+    typeof row.name !== "string"
+  ) {
+    panic("Online migration index state has an invalid shape");
+  }
+
+  return {
+    definition: row.definition,
+    isReady: row.isReady,
+    isUnique: row.isUnique,
+    isValid: row.isValid,
+    name: row.name,
+    type: "present",
+  };
+};
+
 const readIndexState = async (
   connection: OnlineMigrationConnection,
   { name, tableName }: RequiredMigrationIndex,
@@ -93,30 +175,105 @@ const readIndexState = async (
   const row = (
     await connection.query(READ_INDEX_STATE_SQL, ["public", name, tableName])
   ).at(0);
-  if (row === undefined) {
-    return { type: "missing" };
+  return row === undefined ? { type: "missing" } : parsePresentIndexState(row);
+};
+
+const POSTGRES_IDENTIFIER_MAX_LENGTH = 63;
+
+const reindexArtifactPrefix = (name: string, suffix: "_ccnew" | "_ccold") =>
+  `${name.slice(0, POSTGRES_IDENTIFIER_MAX_LENGTH - suffix.length)}${suffix}`;
+
+const readReindexArtifacts = async (
+  connection: OnlineMigrationConnection,
+  { name, tableName }: RequiredMigrationIndex,
+): Promise<PresentIndexState[]> =>
+  (
+    await connection.query(READ_REINDEX_ARTIFACTS_SQL, [
+      "public",
+      tableName,
+      reindexArtifactPrefix(name, "_ccnew"),
+      reindexArtifactPrefix(name, "_ccold"),
+    ])
+  ).map(parsePresentIndexState);
+
+const definitionBody = (definition: string): string => {
+  const bodyStart = definition.indexOf(" ON ");
+  if (bodyStart === -1) {
+    panic("Online migration index definition has an invalid shape");
   }
+  return definition.slice(bodyStart + 1);
+};
+
+const assertIndexDefinition = (
+  index: RequiredMigrationIndex,
+  state: PresentIndexState,
+): void => {
   if (
-    typeof row !== "object" ||
-    row === null ||
-    !("isValid" in row) ||
-    typeof row.isValid !== "boolean"
+    state.isUnique !== index.isUnique ||
+    definitionBody(state.definition) !== index.definitionBody
   ) {
-    panic("Online report export history index state has an invalid shape");
+    panic(
+      `Required migration index ${index.name} has an unexpected definition`,
+    );
   }
-  return row.isValid ? { type: "valid" } : { type: "invalid" };
+};
+
+const assertNoReindexArtifacts = async (
+  connection: OnlineMigrationConnection,
+  index: RequiredMigrationIndex,
+): Promise<void> => {
+  const artifacts = await readReindexArtifacts(connection, index);
+  if (artifacts.length > 0) {
+    panic(`Required migration index ${index.name} has reindex artifacts`);
+  }
+};
+
+const cleanupFailedReindexArtifacts = async (
+  connection: OnlineMigrationConnection,
+  index: RequiredMigrationIndex,
+): Promise<void> => {
+  const artifacts = await readReindexArtifacts(connection, index);
+  for (const artifact of artifacts) {
+    assertIndexDefinition(index, artifact);
+    if (artifact.isValid) {
+      panic(
+        `Required migration index ${index.name} has a valid reindex artifact`,
+      );
+    }
+    // oxlint-disable-next-line no-await-in-loop -- Each concurrent drop must finish before the next repair step.
+    await connection.execute(
+      `DROP INDEX CONCURRENTLY public.${quoteIdentifier(artifact.name)}`,
+    );
+  }
+};
+
+const assertIndexReady = async (
+  connection: OnlineMigrationConnection,
+  index: RequiredMigrationIndex,
+): Promise<void> => {
+  const state = await readIndexState(connection, index);
+  if (state.type === "missing") {
+    panic(`Required migration index ${index.name} is missing`);
+  }
+  assertIndexDefinition(index, state);
+  if (!state.isValid || !state.isReady) {
+    panic(`Required migration index ${index.name} is not ready`);
+  }
+  await assertNoReindexArtifacts(connection, index);
 };
 
 const ensureIndexValid = async (
   connection: OnlineMigrationConnection,
   index: OnlineIndex,
 ): Promise<void> => {
+  await cleanupFailedReindexArtifacts(connection, index);
   const initialState = await readIndexState(connection, index);
-  if (initialState.type === "valid") {
-    return;
-  }
+  if (initialState.type === "present") {
+    assertIndexDefinition(index, initialState);
+    if (initialState.isValid && initialState.isReady) {
+      return;
+    }
 
-  if (initialState.type === "invalid") {
     await connection.execute(
       `REINDEX INDEX CONCURRENTLY public.${quoteIdentifier(index.name)}`,
     );
@@ -126,10 +283,7 @@ const ensureIndexValid = async (
     panic(`Required migration index ${index.name} is missing`);
   }
 
-  const completedState = await readIndexState(connection, index);
-  if (completedState.type !== "valid") {
-    panic(`Required migration index ${index.name} is not valid after repair`);
-  }
+  await assertIndexReady(connection, index);
 };
 
 const POSTGRES_IDENTIFIER = /^[A-Za-z_][A-Za-z0-9_]*$/u;

--- a/apps/api/src/db/online-migrations.ts
+++ b/apps/api/src/db/online-migrations.ts
@@ -120,15 +120,7 @@ const processOnlineMigrations = async (
       await connection.execute("SET statement_timeout = '0'");
     }
 
-    for (const index of ONLINE_MIGRATION_INDEXES) {
-      if (operation === "repair") {
-        // oxlint-disable-next-line no-await-in-loop -- PostgreSQL permits only one concurrent index build per table; preserve deterministic order.
-        await ensureIndexValid(connection, index);
-      } else {
-        // oxlint-disable-next-line no-await-in-loop -- Startup must validate the complete catalog before serving.
-        await assertIndexReady(connection, index);
-      }
-    }
+    await processOnlineIndexAt(connection, operation);
   } finally {
     try {
       if (lockAcquired) {
@@ -138,6 +130,24 @@ const processOnlineMigrations = async (
       connection.release();
     }
   }
+};
+
+const processOnlineIndexAt = async (
+  connection: OnlineMigrationConnection,
+  operation: OnlineMigrationOperation,
+  offset = 0,
+): Promise<void> => {
+  const index = ONLINE_MIGRATION_INDEXES.at(offset);
+  if (!index) {
+    return;
+  }
+
+  if (operation === "repair") {
+    await ensureIndexValid(connection, index);
+  } else {
+    await assertIndexReady(connection, index);
+  }
+  await processOnlineIndexAt(connection, operation, offset + 1);
 };
 
 const parsePresentIndexState = (row: unknown): PresentIndexState => {
@@ -233,18 +243,30 @@ const cleanupFailedReindexArtifacts = async (
   index: RequiredMigrationIndex,
 ): Promise<void> => {
   const artifacts = await readReindexArtifacts(connection, index);
-  for (const artifact of artifacts) {
-    assertIndexDefinition(index, artifact);
-    if (artifact.isValid) {
-      panic(
-        `Required migration index ${index.name} has a valid reindex artifact`,
-      );
-    }
-    // oxlint-disable-next-line no-await-in-loop -- Each concurrent drop must finish before the next repair step.
-    await connection.execute(
-      `DROP INDEX CONCURRENTLY public.${quoteIdentifier(artifact.name)}`,
+  await cleanupReindexArtifactAt(connection, index, artifacts);
+};
+
+const cleanupReindexArtifactAt = async (
+  connection: OnlineMigrationConnection,
+  index: RequiredMigrationIndex,
+  artifacts: readonly PresentIndexState[],
+  offset = 0,
+): Promise<void> => {
+  const artifact = artifacts.at(offset);
+  if (!artifact) {
+    return;
+  }
+
+  assertIndexDefinition(index, artifact);
+  if (artifact.isValid) {
+    panic(
+      `Required migration index ${index.name} has a valid reindex artifact`,
     );
   }
+  await connection.execute(
+    `DROP INDEX CONCURRENTLY public.${quoteIdentifier(artifact.name)}`,
+  );
+  await cleanupReindexArtifactAt(connection, index, artifacts, offset + 1);
 };
 
 const assertIndexReady = async (

--- a/apps/api/src/db/online-migrations.ts
+++ b/apps/api/src/db/online-migrations.ts
@@ -70,6 +70,21 @@ export const ONLINE_VALIDATED_INDEX_NAMES: ReadonlySet<string> = new Set(
   ONLINE_MIGRATION_INDEXES.map(({ name }) => name),
 );
 
+type OnlineIndexReplacement = {
+  legacyName: string;
+  replacementNames: readonly string[];
+};
+
+const ONLINE_INDEX_REPLACEMENTS: readonly OnlineIndexReplacement[] = [
+  {
+    legacyName: "case_law_decisions_source_case_lang_idx",
+    replacementNames: [
+      "case_law_decisions_source_document_idx",
+      "case_law_decisions_source_case_lang_null_idx",
+    ],
+  },
+];
+
 type OnlineMigrationConnection = {
   execute: (query: string, params?: readonly unknown[]) => Promise<void>;
   query: (
@@ -121,6 +136,9 @@ const processOnlineMigrations = async (
     }
 
     await processOnlineIndexAt(connection, operation);
+    if (operation === "repair") {
+      await retireReplacedIndexAt(connection);
+    }
   } finally {
     try {
       if (lockAcquired) {
@@ -148,6 +166,44 @@ const processOnlineIndexAt = async (
     await assertIndexReady(connection, index);
   }
   await processOnlineIndexAt(connection, operation, offset + 1);
+};
+
+const retireReplacedIndexAt = async (
+  connection: OnlineMigrationConnection,
+  offset = 0,
+): Promise<void> => {
+  const replacement = ONLINE_INDEX_REPLACEMENTS.at(offset);
+  if (!replacement) {
+    return;
+  }
+
+  await assertReplacementIndexAt(connection, replacement);
+  await connection.execute(
+    `DROP INDEX CONCURRENTLY IF EXISTS public.${quoteIdentifier(replacement.legacyName)}`,
+  );
+  await retireReplacedIndexAt(connection, offset + 1);
+};
+
+const assertReplacementIndexAt = async (
+  connection: OnlineMigrationConnection,
+  replacement: OnlineIndexReplacement,
+  offset = 0,
+): Promise<void> => {
+  const replacementName = replacement.replacementNames.at(offset);
+  if (!replacementName) {
+    return;
+  }
+  const index = ONLINE_MIGRATION_INDEXES.find(
+    ({ name }) => name === replacementName,
+  );
+  if (!index) {
+    panic(
+      `Replacement index ${replacementName} is not registered for online validation`,
+    );
+  }
+
+  await assertIndexReady(connection, index);
+  await assertReplacementIndexAt(connection, replacement, offset + 1);
 };
 
 const parsePresentIndexState = (row: unknown): PresentIndexState => {

--- a/apps/api/src/db/online-migrations.ts
+++ b/apps/api/src/db/online-migrations.ts
@@ -1,5 +1,10 @@
 import { panic } from "better-result";
 
+import {
+  REWRITTEN_MIGRATION_INDEXES,
+  type RequiredMigrationIndex,
+} from "../lib/db/migration-history";
+
 const ONLINE_MIGRATIONS_LOCK_SQL =
   "SELECT pg_advisory_lock(hashtext('stella-online-migrations'))";
 const ONLINE_MIGRATIONS_UNLOCK_SQL =
@@ -13,14 +18,28 @@ const READ_INDEX_STATE_SQL = `
     ON index_state.indexrelid = index_relation.oid
   JOIN pg_catalog.pg_class table_relation
     ON table_relation.oid = index_state.indrelid
-  WHERE index_namespace.nspname = 'public'
-    AND index_relation.relname = 'report_exports_workspace_requester_created_idx'
-    AND table_relation.relname = 'report_exports'
+  WHERE index_namespace.nspname = $1
+    AND index_relation.relname = $2
+    AND table_relation.relname = $3
 `;
-const DROP_INVALID_INDEX_SQL =
-  'DROP INDEX CONCURRENTLY IF EXISTS public."report_exports_workspace_requester_created_idx"';
-const CREATE_INDEX_SQL =
-  'CREATE INDEX CONCURRENTLY "report_exports_workspace_requester_created_idx" ON public."report_exports" USING btree ("workspace_id", "requested_by", "created_at", "id")';
+
+type OnlineIndex = RequiredMigrationIndex & {
+  createSql?: string;
+};
+
+const ONLINE_INDEXES: readonly OnlineIndex[] = [
+  {
+    createSql:
+      'CREATE INDEX CONCURRENTLY "report_exports_workspace_requester_created_idx" ON public."report_exports" USING btree ("workspace_id", "requested_by", "created_at", "id")',
+    name: "report_exports_workspace_requester_created_idx",
+    tableName: "report_exports",
+  },
+  ...REWRITTEN_MIGRATION_INDEXES,
+];
+
+export const ONLINE_VALIDATED_INDEX_NAMES: ReadonlySet<string> = new Set(
+  ONLINE_INDEXES.map(({ name }) => name),
+);
 
 type OnlineMigrationConnection = {
   execute: (query: string, params?: readonly unknown[]) => Promise<void>;
@@ -52,17 +71,8 @@ export const runOnlineMigrations = async (
     await connection.execute("SET lock_timeout = '1s'");
     await connection.execute("SET statement_timeout = '0'");
 
-    const initialState = await readIndexState(connection);
-    if (initialState.type === "invalid") {
-      await connection.execute(DROP_INVALID_INDEX_SQL);
-    }
-    if (initialState.type !== "valid") {
-      await connection.execute(CREATE_INDEX_SQL);
-    }
-
-    const completedState = await readIndexState(connection);
-    if (completedState.type !== "valid") {
-      panic("Online report export history index is not valid after creation");
+    for (const index of ONLINE_INDEXES) {
+      await ensureIndexValid(connection, index);
     }
   } finally {
     try {
@@ -77,8 +87,11 @@ export const runOnlineMigrations = async (
 
 const readIndexState = async (
   connection: OnlineMigrationConnection,
+  { name, tableName }: RequiredMigrationIndex,
 ): Promise<OnlineIndexState> => {
-  const row = (await connection.query(READ_INDEX_STATE_SQL)).at(0);
+  const row = (
+    await connection.query(READ_INDEX_STATE_SQL, ["public", name, tableName])
+  ).at(0);
   if (row === undefined) {
     return { type: "missing" };
   }
@@ -91,4 +104,38 @@ const readIndexState = async (
     panic("Online report export history index state has an invalid shape");
   }
   return row.isValid ? { type: "valid" } : { type: "invalid" };
+};
+
+const ensureIndexValid = async (
+  connection: OnlineMigrationConnection,
+  index: OnlineIndex,
+): Promise<void> => {
+  const initialState = await readIndexState(connection, index);
+  if (initialState.type === "valid") {
+    return;
+  }
+
+  if (initialState.type === "invalid") {
+    await connection.execute(
+      `REINDEX INDEX CONCURRENTLY public.${quoteIdentifier(index.name)}`,
+    );
+  } else if (index.createSql) {
+    await connection.execute(index.createSql);
+  } else {
+    panic(`Required migration index ${index.name} is missing`);
+  }
+
+  const completedState = await readIndexState(connection, index);
+  if (completedState.type !== "valid") {
+    panic(`Required migration index ${index.name} is not valid after repair`);
+  }
+};
+
+const POSTGRES_IDENTIFIER = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+const quoteIdentifier = (identifier: string): string => {
+  if (!POSTGRES_IDENTIFIER.test(identifier)) {
+    panic(`Invalid internal PostgreSQL identifier: ${identifier}`);
+  }
+  return `"${identifier}"`;
 };

--- a/apps/api/src/db/online-migrations.ts
+++ b/apps/api/src/db/online-migrations.ts
@@ -72,6 +72,7 @@ export const runOnlineMigrations = async (
     await connection.execute("SET statement_timeout = '0'");
 
     for (const index of ONLINE_INDEXES) {
+      // oxlint-disable-next-line no-await-in-loop -- PostgreSQL permits only one concurrent index build per table; preserve deterministic order.
       await ensureIndexValid(connection, index);
     }
   } finally {
@@ -131,7 +132,7 @@ const ensureIndexValid = async (
   }
 };
 
-const POSTGRES_IDENTIFIER = /^[A-Za-z_][A-Za-z0-9_]*$/;
+const POSTGRES_IDENTIFIER = /^[A-Za-z_][A-Za-z0-9_]*$/u;
 
 const quoteIdentifier = (identifier: string): string => {
   if (!POSTGRES_IDENTIFIER.test(identifier)) {

--- a/apps/api/src/lib/db/arabic-normalize.test.ts
+++ b/apps/api/src/lib/db/arabic-normalize.test.ts
@@ -82,28 +82,6 @@ describe("arabic_normalize SQL function", () => {
       expect(result.rows.at(0)?.out).toBe(normalizeSearchText(input));
     }
   });
-
-  test("keeps concurrent index creation retry-safe", () => {
-    const migrationSql = readFileSync(
-      INITIAL_ARABIC_NORMALIZE_MIGRATION_PATH,
-      "utf-8",
-    );
-    const indexNames = [
-      "contacts_display_name_arabic_norm_trgm_idx",
-      "contacts_first_name_arabic_norm_trgm_idx",
-      "contacts_last_name_arabic_norm_trgm_idx",
-      "contacts_organization_name_arabic_norm_trgm_idx",
-    ];
-
-    for (const indexName of indexNames) {
-      expect(migrationSql).toContain(
-        `DROP INDEX CONCURRENTLY IF EXISTS "${indexName}"`,
-      );
-      expect(migrationSql).toContain(
-        `CREATE INDEX CONCURRENTLY IF NOT EXISTS "${indexName}"`,
-      );
-    }
-  });
 });
 
 const isPortableFunctionStatement = (statement: string): boolean => {

--- a/apps/api/src/lib/db/assert-migrations-applied.ts
+++ b/apps/api/src/lib/db/assert-migrations-applied.ts
@@ -5,6 +5,8 @@ import { rootDb } from "@/api/db/root";
 import { assertMigrationHistory } from "@/api/lib/db/migration-history";
 import { logger } from "@/api/lib/observability/logger";
 
+import { assertOnlineMigrationsApplied } from "../../db/online-migrations";
+
 const MIGRATIONS_DIR = nodePath.resolve(process.cwd(), "drizzle");
 const ESCAPE_HATCH_ENV = "SKIP_MIGRATION_CHECK";
 
@@ -36,5 +38,18 @@ export const assertMigrationsApplied = async (): Promise<void> => {
     remedy:
       `Run \`bun run db:migrate\` against this database, or set ${ESCAPE_HATCH_ENV}=true ` +
       "to bypass the check (emergency only).",
+  });
+  await assertOnlineMigrationsApplied({
+    reserve: async () => {
+      const connection = await rootDb.$client.reserve();
+      return {
+        execute: async (query, params = []) => {
+          await connection.unsafe(query, [...params]);
+        },
+        query: async (query, params = []) =>
+          await connection.unsafe(query, [...params]),
+        release: () => connection.release(),
+      };
+    },
   });
 };

--- a/apps/api/src/lib/db/assert-migrations-applied.ts
+++ b/apps/api/src/lib/db/assert-migrations-applied.ts
@@ -1,49 +1,14 @@
-import { panic } from "better-result";
 import { sql } from "drizzle-orm";
-import { existsSync, readdirSync } from "node:fs";
 import nodePath from "node:path";
 
 import { rootDb } from "@/api/db/root";
+import { assertMigrationHistory } from "@/api/lib/db/migration-history";
 import { logger } from "@/api/lib/observability/logger";
 
 const MIGRATIONS_DIR = nodePath.resolve(process.cwd(), "drizzle");
 const ESCAPE_HATCH_ENV = "SKIP_MIGRATION_CHECK";
 
-// Migrations intentionally rewritten after they shipped in a release. A
-// database that applied the earlier version recorded its hash, and the
-// migrator never re-runs an already-applied folder, so the rewritten hash is
-// never stored. Accept the prior hash as satisfying the check for these.
-const REWRITTEN_MIGRATION_PRIOR_HASHES: Record<string, string> = {
-  // 0.5.0 backfilled slugs inside the migration and built the unique index
-  // non-concurrently. The in-transaction backfill exceeded statement_timeout
-  // on large corpora, so 0.5.1 rewrote it to build the index CONCURRENTLY and
-  // moved the slug backfill into src/scripts/backfill-case-law-slugs.ts.
-  "20260603120000_case_law_public_slugs":
-    "4757efe9484615eff7bcba9c34687be4aa9b28e07a71137a3638a3072d8a6d3d",
-};
-
-type LocalMigration = { name: string; hash: string };
 type AppliedMigrationRow = { hash: string };
-
-const hashMigrationFile = async (path: string): Promise<string> =>
-  new Bun.CryptoHasher("sha256")
-    .update(await Bun.file(path).bytes())
-    .digest("hex");
-
-const listLocalMigrations = async (): Promise<LocalMigration[]> =>
-  await Promise.all(
-    readdirSync(MIGRATIONS_DIR)
-      .filter((name) =>
-        existsSync(nodePath.join(MIGRATIONS_DIR, name, "migration.sql")),
-      )
-      .sort()
-      .map(async (name) => ({
-        name,
-        hash: await hashMigrationFile(
-          nodePath.join(MIGRATIONS_DIR, name, "migration.sql"),
-        ),
-      })),
-  );
 
 const queryAppliedHashes = async (): Promise<Set<string>> => {
   // Compare on `hash` (always populated) rather than `name` (NULL
@@ -64,32 +29,12 @@ export const assertMigrationsApplied = async (): Promise<void> => {
     return;
   }
 
-  const local = await listLocalMigrations();
-  if (local.length === 0) {
-    panic(
-      `[startup] No migration files at ${MIGRATIONS_DIR}; refusing to start. ` +
-        "The runtime image must include apps/api/drizzle/.",
-    );
-  }
-
-  const appliedHashes = await queryAppliedHashes();
-  const isApplied = (m: LocalMigration): boolean => {
-    if (appliedHashes.has(m.hash)) {
-      return true;
-    }
-    const priorHash = REWRITTEN_MIGRATION_PRIOR_HASHES[m.name];
-    return priorHash !== undefined && appliedHashes.has(priorHash);
-  };
-  const missing = local.filter((m) => !isApplied(m));
-
-  if (missing.length > 0) {
-    const missingNames = missing.map((m) => m.name).join(", ");
-    panic(
-      `[startup] Schema drift: ${missing.length} migration(s) in code are not applied to the database. ` +
-        `Code has ${local.length}; DB has ${appliedHashes.size}. ` +
-        `Missing or modified after apply: ${missingNames}. ` +
-        `Run \`bun run db:migrate\` against this database, or set ${ESCAPE_HATCH_ENV}=true ` +
-        "to bypass the check (emergency only).",
-    );
-  }
+  await assertMigrationHistory({
+    context: "startup",
+    migrationsDir: MIGRATIONS_DIR,
+    queryAppliedHashes,
+    remedy:
+      `Run \`bun run db:migrate\` against this database, or set ${ESCAPE_HATCH_ENV}=true ` +
+      "to bypass the check (emergency only).",
+  });
 };

--- a/apps/api/src/lib/db/migration-history.property.test.ts
+++ b/apps/api/src/lib/db/migration-history.property.test.ts
@@ -74,22 +74,22 @@ describe("migration history invariant", () => {
       ],
       [
         "20260605143000_workflow_pending_fields_index",
-        "e01fb3a73766f84e0ee0ea062f64d38cd56f777f71f9b74c5fb1fd42b282312e",
+        "798fdbc4b5e88b6e6aae86815d2aab3b4d4e1c05207f86dd17dce4e2c1ca71fe",
         "0088003d298f869017cf4047a74692a9ddefa4bc246aa6c25ca950ebeb29f918",
       ],
       [
         "20260629123000_arabic_normalize_function",
-        "6e7b6481011f0eea42b5ca645e959ec95e91d9f1a8f7eb920e071dc9cba654b9",
+        "5c18323c0211930aee1eb476720d3a6f00b808156f1c72b758ff0458f92a685d",
         "36ccbd00b7e98f6489d4a493ff61eba96eec145b38ef684045ae408fe88521ce",
       ],
       [
         "20260701160000_property_playbook_definition_id",
-        "424a1d2b0ae33d434efdea8f82fcbfd08bdf19f5f5c500857f3028fd7d6b76b2",
+        "428aea6ac33b60c3e401a9c83b1eae0a5b87a9fbadaecd5ab48b38bb31ec64ca",
         "423af8ce20ec27fa4895b37e3caf64f3470e1ebaa92da58cee04ea5c3dc9085e",
       ],
       [
         "20260703233000_account_credential_singleton",
-        "c2d26af1dc97f687ab3a1a0a41538fe2eac7dbf60824d2d74187104be957ade6",
+        "1e3a3cd7ef1373e6a6c48ded10bd53dc32169066a79fb3a808552d52849fb9ff",
         "ffd1598dc3a56f44095b549438313351e4bfb467b0fdb83c1def5a6d55f74583",
       ],
       [

--- a/apps/api/src/lib/db/migration-history.property.test.ts
+++ b/apps/api/src/lib/db/migration-history.property.test.ts
@@ -9,6 +9,7 @@ import {
   findUnappliedMigrations,
 } from "./migration-history";
 
+const MIGRATIONS_DIR = nodePath.resolve(import.meta.dir, "../../../drizzle");
 const hexadecimalCharacter = fc.constantFrom(..."0123456789abcdef".split(""));
 const migrationHash = fc.string({
   unit: hexadecimalCharacter,
@@ -60,16 +61,16 @@ describe("migration history invariant", () => {
     );
   });
 
-  test("accepts every supported predecessor hash", () => {
+  test("accepts every supported predecessor only for its exact current file", async () => {
     const supportedHistories = [
       [
         "20260603120000_case_law_public_slugs",
-        "c1ba2ed2049dd11aeab770ae4681e6b47d924bdbbc2ea480d3d0035199e4ab28",
+        "6b7745706b35e0bba31829f9c5262794c7ed4f33455679f28fd998c37eb1718c",
         "4757efe9484615eff7bcba9c34687be4aa9b28e07a71137a3638a3072d8a6d3d",
       ],
       [
         "20260603120000_case_law_public_slugs",
-        "c1ba2ed2049dd11aeab770ae4681e6b47d924bdbbc2ea480d3d0035199e4ab28",
+        "6b7745706b35e0bba31829f9c5262794c7ed4f33455679f28fd998c37eb1718c",
         "0d7608766b5bbec1031a31e8a004fc093124596b0cbf4446bd4269ffc834a90b",
       ],
       [
@@ -89,13 +90,18 @@ describe("migration history invariant", () => {
       ],
       [
         "20260703233000_account_credential_singleton",
-        "1e3a3cd7ef1373e6a6c48ded10bd53dc32169066a79fb3a808552d52849fb9ff",
+        "9de5d6af3b0acd569ebffa1452e7e441939a1afafb9c6bc59bd461e87e1586bc",
         "ffd1598dc3a56f44095b549438313351e4bfb467b0fdb83c1def5a6d55f74583",
       ],
       [
         "20260707120000_property_role",
-        "8d47e05862c978c9c7176c2e406e00eb5fc3e73e5f80edda28e7a37320856d93",
+        "a3e5b0faa0bf5fc1249848c25707c589d00a5ef1a969efcd6fa313f483030c54",
         "033466ccb60b0baa4ad4bbd6b8b0f4e116531b4061353ca0b7069178aebfde02",
+      ],
+      [
+        "20260717110000_usage_event_idempotency",
+        "c769f5c5257528acb310673a276549138a2e44006eeed8dc10beb4153a54cddb",
+        "dd0acd610eb979875428ca7778d97cce4baf33b4332479434f66e68c729b2433",
       ],
       [
         "20260717170000_report_export_notifications",
@@ -114,12 +120,20 @@ describe("migration history invariant", () => {
       ],
       [
         "20260731130000_decision_source_document_id",
-        "85bdb5023fe1126f39e04aad8e7fd3969e2fce28b7d69096cad1a668b8dc45fc",
+        "15d92f17395b90ef96815823e22b7928cdeaa5ee39021428b7268ffcf0fe4b84",
         "f0dc5e37d764febdad8eba0bc36506c048d22f182f5e0423fd48ad6a26d29a48",
       ],
     ] as const;
 
     for (const [name, currentHash, priorHash] of supportedHistories) {
+      const actualHash = new Bun.CryptoHasher("sha256")
+        .update(
+          await Bun.file(
+            nodePath.join(MIGRATIONS_DIR, name, "migration.sql"),
+          ).bytes(),
+        )
+        .digest("hex");
+      expect(currentHash).toBe(actualHash);
       expect(
         findUnappliedMigrations({
           appliedHashes: new Set([priorHash]),

--- a/apps/api/src/lib/db/migration-history.property.test.ts
+++ b/apps/api/src/lib/db/migration-history.property.test.ts
@@ -74,17 +74,22 @@ describe("migration history invariant", () => {
       ],
       [
         "20260605143000_workflow_pending_fields_index",
-        "6b0a292d42e172b87ce3bbbf7bfdc108acc2f2f9f0427a32b643b763cb75b447",
+        "e01fb3a73766f84e0ee0ea062f64d38cd56f777f71f9b74c5fb1fd42b282312e",
         "0088003d298f869017cf4047a74692a9ddefa4bc246aa6c25ca950ebeb29f918",
       ],
       [
+        "20260629123000_arabic_normalize_function",
+        "6e7b6481011f0eea42b5ca645e959ec95e91d9f1a8f7eb920e071dc9cba654b9",
+        "36ccbd00b7e98f6489d4a493ff61eba96eec145b38ef684045ae408fe88521ce",
+      ],
+      [
         "20260701160000_property_playbook_definition_id",
-        "3877a28437845ea1714a41bf2b8c22206ce6f8af363f40a9361b04f38c486c04",
+        "424a1d2b0ae33d434efdea8f82fcbfd08bdf19f5f5c500857f3028fd7d6b76b2",
         "423af8ce20ec27fa4895b37e3caf64f3470e1ebaa92da58cee04ea5c3dc9085e",
       ],
       [
         "20260703233000_account_credential_singleton",
-        "988b8729f253ee11187aeb8e80ef915c98c7f384e6bffb78ce6201a66b72bfb6",
+        "c2d26af1dc97f687ab3a1a0a41538fe2eac7dbf60824d2d74187104be957ade6",
         "ffd1598dc3a56f44095b549438313351e4bfb467b0fdb83c1def5a6d55f74583",
       ],
       [

--- a/apps/api/src/lib/db/migration-history.property.test.ts
+++ b/apps/api/src/lib/db/migration-history.property.test.ts
@@ -125,28 +125,30 @@ describe("migration history invariant", () => {
       ],
     ] as const;
 
-    for (const [name, currentHash, priorHash] of supportedHistories) {
-      const actualHash = new Bun.CryptoHasher("sha256")
-        .update(
-          await Bun.file(
-            nodePath.join(MIGRATIONS_DIR, name, "migration.sql"),
-          ).bytes(),
-        )
-        .digest("hex");
-      expect(actualHash).toBe(currentHash);
-      expect(
-        findUnappliedMigrations({
-          appliedHashes: new Set([priorHash]),
-          localMigrations: [{ hash: currentHash, name }],
-        }),
-      ).toEqual([]);
-      expect(
-        findUnappliedMigrations({
-          appliedHashes: new Set([priorHash]),
-          localMigrations: [{ hash: `modified-${currentHash}`, name }],
-        }),
-      ).toEqual([{ hash: `modified-${currentHash}`, name }]);
-    }
+    await Promise.all(
+      supportedHistories.map(async ([name, currentHash, priorHash]) => {
+        const actualHash = new Bun.CryptoHasher("sha256")
+          .update(
+            await Bun.file(
+              nodePath.join(MIGRATIONS_DIR, name, "migration.sql"),
+            ).bytes(),
+          )
+          .digest("hex");
+        expect(actualHash).toBe(currentHash);
+        expect(
+          findUnappliedMigrations({
+            appliedHashes: new Set([priorHash]),
+            localMigrations: [{ hash: currentHash, name }],
+          }),
+        ).toEqual([]);
+        expect(
+          findUnappliedMigrations({
+            appliedHashes: new Set([priorHash]),
+            localMigrations: [{ hash: `modified-${currentHash}`, name }],
+          }),
+        ).toEqual([{ hash: `modified-${currentHash}`, name }]);
+      }),
+    );
   });
 
   test("reports the intended error when the migrations directory is absent", async () => {

--- a/apps/api/src/lib/db/migration-history.property.test.ts
+++ b/apps/api/src/lib/db/migration-history.property.test.ts
@@ -7,6 +7,7 @@ import { propertyConfig } from "@stll/property-testing";
 import {
   assertMigrationHistory,
   findUnappliedMigrations,
+  REWRITTEN_MIGRATION_HISTORIES,
 } from "./migration-history";
 
 const MIGRATIONS_DIR = nodePath.resolve(import.meta.dir, "../../../drizzle");
@@ -62,68 +63,12 @@ describe("migration history invariant", () => {
   });
 
   test("accepts every supported predecessor only for its exact current file", async () => {
-    const supportedHistories = [
-      [
-        "20260603120000_case_law_public_slugs",
-        "6b7745706b35e0bba31829f9c5262794c7ed4f33455679f28fd998c37eb1718c",
-        "4757efe9484615eff7bcba9c34687be4aa9b28e07a71137a3638a3072d8a6d3d",
-      ],
-      [
-        "20260603120000_case_law_public_slugs",
-        "6b7745706b35e0bba31829f9c5262794c7ed4f33455679f28fd998c37eb1718c",
-        "0d7608766b5bbec1031a31e8a004fc093124596b0cbf4446bd4269ffc834a90b",
-      ],
-      [
-        "20260605143000_workflow_pending_fields_index",
-        "00e0820a64f6d5888c79ab9fcd611b599e6622bbc1dc8f4ad668c894af1a41d0",
-        "0088003d298f869017cf4047a74692a9ddefa4bc246aa6c25ca950ebeb29f918",
-      ],
-      [
-        "20260629123000_arabic_normalize_function",
-        "2efd4a25545a7a4aea7957fccae54994b4037d1963d6c4f479797500f6b79bf4",
-        "36ccbd00b7e98f6489d4a493ff61eba96eec145b38ef684045ae408fe88521ce",
-      ],
-      [
-        "20260701160000_property_playbook_definition_id",
-        "f5e8604a73353044e3164bc67cb1e6c13936e61639a4190f809df5cc60b44f15",
-        "423af8ce20ec27fa4895b37e3caf64f3470e1ebaa92da58cee04ea5c3dc9085e",
-      ],
-      [
-        "20260703233000_account_credential_singleton",
-        "9de5d6af3b0acd569ebffa1452e7e441939a1afafb9c6bc59bd461e87e1586bc",
-        "ffd1598dc3a56f44095b549438313351e4bfb467b0fdb83c1def5a6d55f74583",
-      ],
-      [
-        "20260707120000_property_role",
-        "a3e5b0faa0bf5fc1249848c25707c589d00a5ef1a969efcd6fa313f483030c54",
-        "033466ccb60b0baa4ad4bbd6b8b0f4e116531b4061353ca0b7069178aebfde02",
-      ],
-      [
-        "20260717110000_usage_event_idempotency",
-        "c769f5c5257528acb310673a276549138a2e44006eeed8dc10beb4153a54cddb",
-        "dd0acd610eb979875428ca7778d97cce4baf33b4332479434f66e68c729b2433",
-      ],
-      [
-        "20260717170000_report_export_notifications",
-        "8aa876b20155b73a71d3d610210412f0a532dca61ee56f89446540e6eee3809e",
-        "11856277db1674f04ecf66d39df8f81242f4347af15d60cf2270ee1e3910a317",
-      ],
-      [
-        "20260719172000_user_created_at_index",
-        "60e691372d1eaff6bab6009ed2bc88fff625836b50253203e065c125accdf164",
-        "d75842b57e1ba5f734b2dea9926c76da9fca178d41fafe8005f144cdc4960eee",
-      ],
-      [
-        "20260720140000_machine_api_keys_org_index",
-        "cc793baee2e7e5c0637cc0f0edbc8cff44706119e7fdd88629d17246857b308f",
-        "c9c7b5d968fe2efa54ef017592d43bb640688ebd6f56b957aca27b45b1412468",
-      ],
-      [
-        "20260731130000_decision_source_document_id",
-        "15d92f17395b90ef96815823e22b7928cdeaa5ee39021428b7268ffcf0fe4b84",
-        "f0dc5e37d764febdad8eba0bc36506c048d22f182f5e0423fd48ad6a26d29a48",
-      ],
-    ] as const;
+    const supportedHistories = Object.entries(
+      REWRITTEN_MIGRATION_HISTORIES,
+    ).flatMap(([name, { currentHash, priorHashes }]) =>
+      priorHashes.map((priorHash) => [name, currentHash, priorHash] as const),
+    );
+    expect(supportedHistories.length).toBeGreaterThan(0);
 
     await Promise.all(
       supportedHistories.map(async ([name, currentHash, priorHash]) => {

--- a/apps/api/src/lib/db/migration-history.property.test.ts
+++ b/apps/api/src/lib/db/migration-history.property.test.ts
@@ -1,9 +1,13 @@
 import { describe, expect, test } from "bun:test";
 import fc from "fast-check";
+import nodePath from "node:path";
 
 import { propertyConfig } from "@stll/property-testing";
 
-import { findUnappliedMigrations } from "./migration-history";
+import {
+  assertMigrationHistory,
+  findUnappliedMigrations,
+} from "./migration-history";
 
 const hexadecimalCharacter = fc.constantFrom(..."0123456789abcdef".split(""));
 const migrationHash = fc.string({
@@ -60,53 +64,80 @@ describe("migration history invariant", () => {
     const supportedHistories = [
       [
         "20260603120000_case_law_public_slugs",
+        "c1ba2ed2049dd11aeab770ae4681e6b47d924bdbbc2ea480d3d0035199e4ab28",
         "4757efe9484615eff7bcba9c34687be4aa9b28e07a71137a3638a3072d8a6d3d",
       ],
       [
         "20260603120000_case_law_public_slugs",
+        "c1ba2ed2049dd11aeab770ae4681e6b47d924bdbbc2ea480d3d0035199e4ab28",
         "0d7608766b5bbec1031a31e8a004fc093124596b0cbf4446bd4269ffc834a90b",
       ],
       [
         "20260605143000_workflow_pending_fields_index",
+        "6b0a292d42e172b87ce3bbbf7bfdc108acc2f2f9f0427a32b643b763cb75b447",
         "0088003d298f869017cf4047a74692a9ddefa4bc246aa6c25ca950ebeb29f918",
       ],
       [
         "20260701160000_property_playbook_definition_id",
+        "3877a28437845ea1714a41bf2b8c22206ce6f8af363f40a9361b04f38c486c04",
         "423af8ce20ec27fa4895b37e3caf64f3470e1ebaa92da58cee04ea5c3dc9085e",
       ],
       [
         "20260703233000_account_credential_singleton",
+        "988b8729f253ee11187aeb8e80ef915c98c7f384e6bffb78ce6201a66b72bfb6",
         "ffd1598dc3a56f44095b549438313351e4bfb467b0fdb83c1def5a6d55f74583",
       ],
       [
         "20260707120000_property_role",
+        "8d47e05862c978c9c7176c2e406e00eb5fc3e73e5f80edda28e7a37320856d93",
         "033466ccb60b0baa4ad4bbd6b8b0f4e116531b4061353ca0b7069178aebfde02",
       ],
       [
         "20260717170000_report_export_notifications",
+        "094bed35cbea00fc194dc2c2351c9034c55e67b6a6fb808b82cf008345566c3a",
         "11856277db1674f04ecf66d39df8f81242f4347af15d60cf2270ee1e3910a317",
       ],
       [
         "20260719172000_user_created_at_index",
+        "cd765faf1da8f1da04146b4ca2736bd739a936f3b3b183b8b2448609a4b18447",
         "d75842b57e1ba5f734b2dea9926c76da9fca178d41fafe8005f144cdc4960eee",
       ],
       [
         "20260720140000_machine_api_keys_org_index",
+        "f8714547100e32110a4cd266fb7836c76d6668c23c6223fe718bb5beb36469d3",
         "c9c7b5d968fe2efa54ef017592d43bb640688ebd6f56b957aca27b45b1412468",
       ],
       [
         "20260731130000_decision_source_document_id",
+        "85bdb5023fe1126f39e04aad8e7fd3969e2fce28b7d69096cad1a668b8dc45fc",
         "f0dc5e37d764febdad8eba0bc36506c048d22f182f5e0423fd48ad6a26d29a48",
       ],
     ] as const;
 
-    for (const [name, priorHash] of supportedHistories) {
+    for (const [name, currentHash, priorHash] of supportedHistories) {
       expect(
         findUnappliedMigrations({
           appliedHashes: new Set([priorHash]),
-          localMigrations: [{ hash: "current-hash", name }],
+          localMigrations: [{ hash: currentHash, name }],
         }),
       ).toEqual([]);
+      expect(
+        findUnappliedMigrations({
+          appliedHashes: new Set([priorHash]),
+          localMigrations: [{ hash: `modified-${currentHash}`, name }],
+        }),
+      ).toEqual([{ hash: `modified-${currentHash}`, name }]);
     }
+  });
+
+  test("reports the intended error when the migrations directory is absent", async () => {
+    await expect(
+      assertMigrationHistory({
+        context: "migrate",
+        migrationsDir: nodePath.join(import.meta.dir, "missing-migrations"),
+        queryAppliedHashes: async () => new Set(),
+        remedy: "No remedy.",
+      }),
+    ).rejects.toThrow("No migration files");
   });
 });

--- a/apps/api/src/lib/db/migration-history.property.test.ts
+++ b/apps/api/src/lib/db/migration-history.property.test.ts
@@ -75,17 +75,17 @@ describe("migration history invariant", () => {
       ],
       [
         "20260605143000_workflow_pending_fields_index",
-        "798fdbc4b5e88b6e6aae86815d2aab3b4d4e1c05207f86dd17dce4e2c1ca71fe",
+        "00e0820a64f6d5888c79ab9fcd611b599e6622bbc1dc8f4ad668c894af1a41d0",
         "0088003d298f869017cf4047a74692a9ddefa4bc246aa6c25ca950ebeb29f918",
       ],
       [
         "20260629123000_arabic_normalize_function",
-        "5c18323c0211930aee1eb476720d3a6f00b808156f1c72b758ff0458f92a685d",
+        "2efd4a25545a7a4aea7957fccae54994b4037d1963d6c4f479797500f6b79bf4",
         "36ccbd00b7e98f6489d4a493ff61eba96eec145b38ef684045ae408fe88521ce",
       ],
       [
         "20260701160000_property_playbook_definition_id",
-        "428aea6ac33b60c3e401a9c83b1eae0a5b87a9fbadaecd5ab48b38bb31ec64ca",
+        "f5e8604a73353044e3164bc67cb1e6c13936e61639a4190f809df5cc60b44f15",
         "423af8ce20ec27fa4895b37e3caf64f3470e1ebaa92da58cee04ea5c3dc9085e",
       ],
       [
@@ -105,17 +105,17 @@ describe("migration history invariant", () => {
       ],
       [
         "20260717170000_report_export_notifications",
-        "094bed35cbea00fc194dc2c2351c9034c55e67b6a6fb808b82cf008345566c3a",
+        "8aa876b20155b73a71d3d610210412f0a532dca61ee56f89446540e6eee3809e",
         "11856277db1674f04ecf66d39df8f81242f4347af15d60cf2270ee1e3910a317",
       ],
       [
         "20260719172000_user_created_at_index",
-        "cd765faf1da8f1da04146b4ca2736bd739a936f3b3b183b8b2448609a4b18447",
+        "60e691372d1eaff6bab6009ed2bc88fff625836b50253203e065c125accdf164",
         "d75842b57e1ba5f734b2dea9926c76da9fca178d41fafe8005f144cdc4960eee",
       ],
       [
         "20260720140000_machine_api_keys_org_index",
-        "f8714547100e32110a4cd266fb7836c76d6668c23c6223fe718bb5beb36469d3",
+        "cc793baee2e7e5c0637cc0f0edbc8cff44706119e7fdd88629d17246857b308f",
         "c9c7b5d968fe2efa54ef017592d43bb640688ebd6f56b957aca27b45b1412468",
       ],
       [

--- a/apps/api/src/lib/db/migration-history.property.test.ts
+++ b/apps/api/src/lib/db/migration-history.property.test.ts
@@ -131,13 +131,19 @@ describe("migration history invariant", () => {
   });
 
   test("reports the intended error when the migrations directory is absent", async () => {
-    await expect(
-      assertMigrationHistory({
-        context: "migrate",
-        migrationsDir: nodePath.join(import.meta.dir, "missing-migrations"),
-        queryAppliedHashes: async () => new Set(),
-        remedy: "No remedy.",
-      }),
-    ).rejects.toThrow("No migration files");
+    const rejection: unknown = await assertMigrationHistory({
+      context: "migrate",
+      migrationsDir: nodePath.join(import.meta.dir, "missing-migrations"),
+      queryAppliedHashes: async () => new Set(),
+      remedy: "No remedy.",
+    }).then(
+      () => null,
+      (error: unknown) => error,
+    );
+
+    expect(rejection).toBeInstanceOf(Error);
+    expect(rejection).toMatchObject({
+      message: expect.stringContaining("No migration files"),
+    });
   });
 });

--- a/apps/api/src/lib/db/migration-history.property.test.ts
+++ b/apps/api/src/lib/db/migration-history.property.test.ts
@@ -133,7 +133,7 @@ describe("migration history invariant", () => {
           ).bytes(),
         )
         .digest("hex");
-      expect(currentHash).toBe(actualHash);
+      expect(actualHash).toBe(currentHash);
       expect(
         findUnappliedMigrations({
           appliedHashes: new Set([priorHash]),

--- a/apps/api/src/lib/db/migration-history.property.test.ts
+++ b/apps/api/src/lib/db/migration-history.property.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, test } from "bun:test";
+import fc from "fast-check";
+
+import { propertyConfig } from "@stll/property-testing";
+
+import { findUnappliedMigrations } from "./migration-history";
+
+const hexadecimalCharacter = fc.constantFrom(..."0123456789abcdef".split(""));
+const migrationHash = fc.string({
+  unit: hexadecimalCharacter,
+  minLength: 64,
+  maxLength: 64,
+});
+const localMigrations = fc.uniqueArray(
+  fc.record({
+    hash: migrationHash,
+    name: fc.uuid(),
+  }),
+  { minLength: 1, selector: ({ hash }) => hash },
+);
+
+const migrationHistory = localMigrations.chain((local) =>
+  fc
+    .tuple(
+      fc.array(fc.boolean(), {
+        minLength: local.length,
+        maxLength: local.length,
+      }),
+      fc.array(fc.uuid(), { maxLength: 10 }),
+    )
+    .map(([isApplied, unrelatedHashes]) => ({
+      appliedHashes: new Set([
+        ...local.filter((_, index) => isApplied[index]).map(({ hash }) => hash),
+        ...unrelatedHashes.map((hash) => `unrelated-${hash}`),
+      ]),
+      expectedUnapplied: local.filter((_, index) => !isApplied[index]),
+      local,
+    })),
+);
+
+describe("migration history invariant", () => {
+  test("reports exactly the bundled hashes absent from any applied history", () => {
+    fc.assert(
+      fc.property(
+        migrationHistory,
+        ({ appliedHashes, expectedUnapplied, local }) => {
+          expect(
+            findUnappliedMigrations({
+              appliedHashes,
+              localMigrations: local,
+            }),
+          ).toEqual(expectedUnapplied);
+        },
+      ),
+      propertyConfig(),
+    );
+  });
+
+  test("accepts every supported predecessor hash", () => {
+    const supportedHistories = [
+      [
+        "20260603120000_case_law_public_slugs",
+        "4757efe9484615eff7bcba9c34687be4aa9b28e07a71137a3638a3072d8a6d3d",
+      ],
+      [
+        "20260603120000_case_law_public_slugs",
+        "0d7608766b5bbec1031a31e8a004fc093124596b0cbf4446bd4269ffc834a90b",
+      ],
+      [
+        "20260605143000_workflow_pending_fields_index",
+        "0088003d298f869017cf4047a74692a9ddefa4bc246aa6c25ca950ebeb29f918",
+      ],
+      [
+        "20260701160000_property_playbook_definition_id",
+        "423af8ce20ec27fa4895b37e3caf64f3470e1ebaa92da58cee04ea5c3dc9085e",
+      ],
+      [
+        "20260703233000_account_credential_singleton",
+        "ffd1598dc3a56f44095b549438313351e4bfb467b0fdb83c1def5a6d55f74583",
+      ],
+      [
+        "20260707120000_property_role",
+        "033466ccb60b0baa4ad4bbd6b8b0f4e116531b4061353ca0b7069178aebfde02",
+      ],
+      [
+        "20260717170000_report_export_notifications",
+        "11856277db1674f04ecf66d39df8f81242f4347af15d60cf2270ee1e3910a317",
+      ],
+      [
+        "20260719172000_user_created_at_index",
+        "d75842b57e1ba5f734b2dea9926c76da9fca178d41fafe8005f144cdc4960eee",
+      ],
+      [
+        "20260720140000_machine_api_keys_org_index",
+        "c9c7b5d968fe2efa54ef017592d43bb640688ebd6f56b957aca27b45b1412468",
+      ],
+      [
+        "20260731130000_decision_source_document_id",
+        "f0dc5e37d764febdad8eba0bc36506c048d22f182f5e0423fd48ad6a26d29a48",
+      ],
+    ] as const;
+
+    for (const [name, priorHash] of supportedHistories) {
+      expect(
+        findUnappliedMigrations({
+          appliedHashes: new Set([priorHash]),
+          localMigrations: [{ hash: "current-hash", name }],
+        }),
+      ).toEqual([]);
+    }
+  });
+});

--- a/apps/api/src/lib/db/migration-history.ts
+++ b/apps/api/src/lib/db/migration-history.ts
@@ -19,7 +19,7 @@ export type RequiredMigrationIndex = {
   tableName: string;
 };
 
-export const REWRITTEN_MIGRATION_HISTORIES = {
+const rewrittenMigrationHistories = {
   // 0.5.0 backfilled slugs inside the migration and built the unique index
   // non-concurrently. The in-transaction backfill exceeded statement_timeout
   // on large corpora, so 0.5.1 rewrote it to build the index CONCURRENTLY and
@@ -238,9 +238,9 @@ export const REWRITTEN_MIGRATION_HISTORIES = {
   },
 } as const satisfies Readonly<Record<string, RewrittenMigrationHistory>>;
 
-const rewrittenMigrationHistoryByName: Readonly<
+export const REWRITTEN_MIGRATION_HISTORIES: Readonly<
   Record<string, RewrittenMigrationHistory>
-> = REWRITTEN_MIGRATION_HISTORIES;
+> = rewrittenMigrationHistories;
 
 export const REWRITTEN_MIGRATION_INDEXES: readonly RequiredMigrationIndex[] =
   Object.values(REWRITTEN_MIGRATION_HISTORIES).flatMap(
@@ -262,7 +262,7 @@ export const findUnappliedMigrations = ({
     if (appliedHashes.has(hash)) {
       return false;
     }
-    const supportedHistory = rewrittenMigrationHistoryByName[name];
+    const supportedHistory = REWRITTEN_MIGRATION_HISTORIES[name];
     if (supportedHistory?.currentHash !== hash) {
       return true;
     }

--- a/apps/api/src/lib/db/migration-history.ts
+++ b/apps/api/src/lib/db/migration-history.ts
@@ -40,7 +40,7 @@ const REWRITTEN_MIGRATION_HISTORIES: Readonly<
   },
   "20260605143000_workflow_pending_fields_index": {
     currentHash:
-      "798fdbc4b5e88b6e6aae86815d2aab3b4d4e1c05207f86dd17dce4e2c1ca71fe",
+      "00e0820a64f6d5888c79ab9fcd611b599e6622bbc1dc8f4ad668c894af1a41d0",
     priorHashes: [
       "0088003d298f869017cf4047a74692a9ddefa4bc246aa6c25ca950ebeb29f918",
     ],
@@ -50,7 +50,7 @@ const REWRITTEN_MIGRATION_HISTORIES: Readonly<
   },
   "20260629123000_arabic_normalize_function": {
     currentHash:
-      "5c18323c0211930aee1eb476720d3a6f00b808156f1c72b758ff0458f92a685d",
+      "2efd4a25545a7a4aea7957fccae54994b4037d1963d6c4f479797500f6b79bf4",
     priorHashes: [
       "36ccbd00b7e98f6489d4a493ff61eba96eec145b38ef684045ae408fe88521ce",
     ],
@@ -75,7 +75,7 @@ const REWRITTEN_MIGRATION_HISTORIES: Readonly<
   },
   "20260701160000_property_playbook_definition_id": {
     currentHash:
-      "428aea6ac33b60c3e401a9c83b1eae0a5b87a9fbadaecd5ab48b38bb31ec64ca",
+      "f5e8604a73353044e3164bc67cb1e6c13936e61639a4190f809df5cc60b44f15",
     priorHashes: [
       "423af8ce20ec27fa4895b37e3caf64f3470e1ebaa92da58cee04ea5c3dc9085e",
     ],
@@ -124,7 +124,7 @@ const REWRITTEN_MIGRATION_HISTORIES: Readonly<
   },
   "20260717170000_report_export_notifications": {
     currentHash:
-      "094bed35cbea00fc194dc2c2351c9034c55e67b6a6fb808b82cf008345566c3a",
+      "8aa876b20155b73a71d3d610210412f0a532dca61ee56f89446540e6eee3809e",
     priorHashes: [
       "11856277db1674f04ecf66d39df8f81242f4347af15d60cf2270ee1e3910a317",
     ],
@@ -137,7 +137,7 @@ const REWRITTEN_MIGRATION_HISTORIES: Readonly<
   },
   "20260719172000_user_created_at_index": {
     currentHash:
-      "cd765faf1da8f1da04146b4ca2736bd739a936f3b3b183b8b2448609a4b18447",
+      "60e691372d1eaff6bab6009ed2bc88fff625836b50253203e065c125accdf164",
     priorHashes: [
       "d75842b57e1ba5f734b2dea9926c76da9fca178d41fafe8005f144cdc4960eee",
     ],
@@ -145,7 +145,7 @@ const REWRITTEN_MIGRATION_HISTORIES: Readonly<
   },
   "20260720140000_machine_api_keys_org_index": {
     currentHash:
-      "f8714547100e32110a4cd266fb7836c76d6668c23c6223fe718bb5beb36469d3",
+      "cc793baee2e7e5c0637cc0f0edbc8cff44706119e7fdd88629d17246857b308f",
     priorHashes: [
       "c9c7b5d968fe2efa54ef017592d43bb640688ebd6f56b957aca27b45b1412468",
     ],

--- a/apps/api/src/lib/db/migration-history.ts
+++ b/apps/api/src/lib/db/migration-history.ts
@@ -1,0 +1,124 @@
+import { panic } from "better-result";
+import { existsSync, readdirSync } from "node:fs";
+import nodePath from "node:path";
+
+// Migrations intentionally rewritten after they shipped in a release. A
+// database that applied the earlier version recorded its hash, and the
+// migrator never re-runs an already-applied folder, so the rewritten hash is
+// never stored. Accept the prior hash as satisfying the check for these.
+const REWRITTEN_MIGRATION_PRIOR_HASHES: Record<string, readonly string[]> = {
+  // 0.5.0 backfilled slugs inside the migration and built the unique index
+  // non-concurrently. The in-transaction backfill exceeded statement_timeout
+  // on large corpora, so 0.5.1 rewrote it to build the index CONCURRENTLY and
+  // moved the slug backfill into src/scripts/backfill-case-law-slugs.ts.
+  "20260603120000_case_law_public_slugs": [
+    "4757efe9484615eff7bcba9c34687be4aa9b28e07a71137a3638a3072d8a6d3d",
+    "0d7608766b5bbec1031a31e8a004fc093124596b0cbf4446bd4269ffc834a90b",
+  ],
+  "20260605143000_workflow_pending_fields_index": [
+    "0088003d298f869017cf4047a74692a9ddefa4bc246aa6c25ca950ebeb29f918",
+  ],
+  "20260701160000_property_playbook_definition_id": [
+    "423af8ce20ec27fa4895b37e3caf64f3470e1ebaa92da58cee04ea5c3dc9085e",
+  ],
+  "20260703233000_account_credential_singleton": [
+    "ffd1598dc3a56f44095b549438313351e4bfb467b0fdb83c1def5a6d55f74583",
+  ],
+  "20260707120000_property_role": [
+    "033466ccb60b0baa4ad4bbd6b8b0f4e116531b4061353ca0b7069178aebfde02",
+  ],
+  "20260717170000_report_export_notifications": [
+    "11856277db1674f04ecf66d39df8f81242f4347af15d60cf2270ee1e3910a317",
+  ],
+  "20260719172000_user_created_at_index": [
+    "d75842b57e1ba5f734b2dea9926c76da9fca178d41fafe8005f144cdc4960eee",
+  ],
+  "20260720140000_machine_api_keys_org_index": [
+    "c9c7b5d968fe2efa54ef017592d43bb640688ebd6f56b957aca27b45b1412468",
+  ],
+  "20260731130000_decision_source_document_id": [
+    "f0dc5e37d764febdad8eba0bc36506c048d22f182f5e0423fd48ad6a26d29a48",
+  ],
+};
+
+export type LocalMigration = { name: string; hash: string };
+
+type FindUnappliedMigrationsOptions = {
+  appliedHashes: ReadonlySet<string>;
+  localMigrations: LocalMigration[];
+};
+
+export const findUnappliedMigrations = ({
+  appliedHashes,
+  localMigrations,
+}: FindUnappliedMigrationsOptions): LocalMigration[] =>
+  localMigrations.filter(({ hash, name }) => {
+    if (appliedHashes.has(hash)) {
+      return false;
+    }
+    const priorHashes = REWRITTEN_MIGRATION_PRIOR_HASHES[name];
+    return (
+      priorHashes === undefined ||
+      !priorHashes.some((priorHash) => appliedHashes.has(priorHash))
+    );
+  });
+
+const hashMigrationFile = async (path: string): Promise<string> =>
+  new Bun.CryptoHasher("sha256")
+    .update(await Bun.file(path).bytes())
+    .digest("hex");
+
+const listLocalMigrations = async (
+  migrationsDir: string,
+): Promise<LocalMigration[]> =>
+  await Promise.all(
+    readdirSync(migrationsDir)
+      .filter((name) =>
+        existsSync(nodePath.join(migrationsDir, name, "migration.sql")),
+      )
+      .sort()
+      .map(async (name) => ({
+        name,
+        hash: await hashMigrationFile(
+          nodePath.join(migrationsDir, name, "migration.sql"),
+        ),
+      })),
+  );
+
+type AssertMigrationHistoryOptions = {
+  context: "migrate" | "startup";
+  migrationsDir: string;
+  queryAppliedHashes: () => Promise<ReadonlySet<string>>;
+  remedy: string;
+};
+
+export const assertMigrationHistory = async ({
+  context,
+  migrationsDir,
+  queryAppliedHashes,
+  remedy,
+}: AssertMigrationHistoryOptions): Promise<void> => {
+  const localMigrations = await listLocalMigrations(migrationsDir);
+  if (localMigrations.length === 0) {
+    panic(
+      `[${context}] No migration files at ${migrationsDir}; refusing to continue. ` +
+        "The runtime image must include apps/api/drizzle/.",
+    );
+  }
+
+  const appliedHashes = await queryAppliedHashes();
+  const unapplied = findUnappliedMigrations({
+    appliedHashes,
+    localMigrations,
+  });
+  if (unapplied.length === 0) {
+    return;
+  }
+
+  const unappliedNames = unapplied.map(({ name }) => name).join(", ");
+  panic(
+    `[${context}] Schema drift: ${unapplied.length} migration(s) in code are not applied to the database. ` +
+      `Code has ${localMigrations.length}; DB has ${appliedHashes.size}. ` +
+      `Missing or modified after apply: ${unappliedNames}. ${remedy}`,
+  );
+};

--- a/apps/api/src/lib/db/migration-history.ts
+++ b/apps/api/src/lib/db/migration-history.ts
@@ -28,28 +28,28 @@ const REWRITTEN_MIGRATION_HISTORIES: Readonly<
   },
   "20260605143000_workflow_pending_fields_index": {
     currentHash:
-      "e01fb3a73766f84e0ee0ea062f64d38cd56f777f71f9b74c5fb1fd42b282312e",
+      "798fdbc4b5e88b6e6aae86815d2aab3b4d4e1c05207f86dd17dce4e2c1ca71fe",
     priorHashes: [
       "0088003d298f869017cf4047a74692a9ddefa4bc246aa6c25ca950ebeb29f918",
     ],
   },
   "20260629123000_arabic_normalize_function": {
     currentHash:
-      "6e7b6481011f0eea42b5ca645e959ec95e91d9f1a8f7eb920e071dc9cba654b9",
+      "5c18323c0211930aee1eb476720d3a6f00b808156f1c72b758ff0458f92a685d",
     priorHashes: [
       "36ccbd00b7e98f6489d4a493ff61eba96eec145b38ef684045ae408fe88521ce",
     ],
   },
   "20260701160000_property_playbook_definition_id": {
     currentHash:
-      "424a1d2b0ae33d434efdea8f82fcbfd08bdf19f5f5c500857f3028fd7d6b76b2",
+      "428aea6ac33b60c3e401a9c83b1eae0a5b87a9fbadaecd5ab48b38bb31ec64ca",
     priorHashes: [
       "423af8ce20ec27fa4895b37e3caf64f3470e1ebaa92da58cee04ea5c3dc9085e",
     ],
   },
   "20260703233000_account_credential_singleton": {
     currentHash:
-      "c2d26af1dc97f687ab3a1a0a41538fe2eac7dbf60824d2d74187104be957ade6",
+      "1e3a3cd7ef1373e6a6c48ded10bd53dc32169066a79fb3a808552d52849fb9ff",
     priorHashes: [
       "ffd1598dc3a56f44095b549438313351e4bfb467b0fdb83c1def5a6d55f74583",
     ],

--- a/apps/api/src/lib/db/migration-history.ts
+++ b/apps/api/src/lib/db/migration-history.ts
@@ -13,6 +13,8 @@ type RewrittenMigrationHistory = {
 };
 
 export type RequiredMigrationIndex = {
+  definitionBody: string;
+  isUnique: boolean;
   name: string;
   tableName: string;
 };
@@ -33,6 +35,9 @@ const REWRITTEN_MIGRATION_HISTORIES: Readonly<
     ],
     requiredIndexes: [
       {
+        definitionBody:
+          "ON public.case_law_decisions USING btree (slug) WHERE (slug IS NOT NULL)",
+        isUnique: true,
         name: "case_law_decisions_slug_uidx",
         tableName: "case_law_decisions",
       },
@@ -45,7 +50,13 @@ const REWRITTEN_MIGRATION_HISTORIES: Readonly<
       "0088003d298f869017cf4047a74692a9ddefa4bc246aa6c25ca950ebeb29f918",
     ],
     requiredIndexes: [
-      { name: "fields_pending_workspace_idx", tableName: "fields" },
+      {
+        definitionBody:
+          "ON public.fields USING btree (workspace_id) WHERE ((content ->> 'type'::text) = 'pending'::text)",
+        isUnique: false,
+        name: "fields_pending_workspace_idx",
+        tableName: "fields",
+      },
     ],
   },
   "20260629123000_arabic_normalize_function": {
@@ -56,18 +67,30 @@ const REWRITTEN_MIGRATION_HISTORIES: Readonly<
     ],
     requiredIndexes: [
       {
+        definitionBody:
+          "ON public.contacts USING gin (arabic_normalize((display_name)::text) gin_trgm_ops)",
+        isUnique: false,
         name: "contacts_display_name_arabic_norm_trgm_idx",
         tableName: "contacts",
       },
       {
+        definitionBody:
+          "ON public.contacts USING gin (arabic_normalize((first_name)::text) gin_trgm_ops)",
+        isUnique: false,
         name: "contacts_first_name_arabic_norm_trgm_idx",
         tableName: "contacts",
       },
       {
+        definitionBody:
+          "ON public.contacts USING gin (arabic_normalize((last_name)::text) gin_trgm_ops)",
+        isUnique: false,
         name: "contacts_last_name_arabic_norm_trgm_idx",
         tableName: "contacts",
       },
       {
+        definitionBody:
+          "ON public.contacts USING gin (arabic_normalize((organization_name)::text) gin_trgm_ops)",
+        isUnique: false,
         name: "contacts_organization_name_arabic_norm_trgm_idx",
         tableName: "contacts",
       },
@@ -81,6 +104,9 @@ const REWRITTEN_MIGRATION_HISTORIES: Readonly<
     ],
     requiredIndexes: [
       {
+        definitionBody:
+          "ON public.properties USING btree (workspace_id, playbook_definition_id)",
+        isUnique: false,
         name: "properties_workspace_playbook_definition_idx",
         tableName: "properties",
       },
@@ -93,7 +119,13 @@ const REWRITTEN_MIGRATION_HISTORIES: Readonly<
       "ffd1598dc3a56f44095b549438313351e4bfb467b0fdb83c1def5a6d55f74583",
     ],
     requiredIndexes: [
-      { name: "account_credential_singleton_uidx", tableName: "account" },
+      {
+        definitionBody:
+          "ON public.account USING btree (provider_id) WHERE (provider_id = 'credential'::text)",
+        isUnique: true,
+        name: "account_credential_singleton_uidx",
+        tableName: "account",
+      },
     ],
   },
   "20260707120000_property_role": {
@@ -104,6 +136,9 @@ const REWRITTEN_MIGRATION_HISTORIES: Readonly<
     ],
     requiredIndexes: [
       {
+        definitionBody:
+          "ON public.properties USING btree (workspace_id) WHERE (role = 'document-type-classifier'::text)",
+        isUnique: true,
         name: "properties_ws_document_type_classifier_unq",
         tableName: "properties",
       },
@@ -117,6 +152,9 @@ const REWRITTEN_MIGRATION_HISTORIES: Readonly<
     ],
     requiredIndexes: [
       {
+        definitionBody:
+          "ON public.usage_events USING btree (organization_id, idempotency_key) WHERE (idempotency_key IS NOT NULL)",
+        isUnique: true,
         name: "usage_events_org_idempotency_key_uidx",
         tableName: "usage_events",
       },
@@ -130,6 +168,9 @@ const REWRITTEN_MIGRATION_HISTORIES: Readonly<
     ],
     requiredIndexes: [
       {
+        definitionBody:
+          "ON public.report_exports USING btree (created_at, id) WHERE ((notification_status = 'pending'::text) AND (status = ANY (ARRAY['completed'::text, 'failed'::text])))",
+        isUnique: false,
         name: "report_exports_pending_notification_idx",
         tableName: "report_exports",
       },
@@ -141,7 +182,14 @@ const REWRITTEN_MIGRATION_HISTORIES: Readonly<
     priorHashes: [
       "d75842b57e1ba5f734b2dea9926c76da9fca178d41fafe8005f144cdc4960eee",
     ],
-    requiredIndexes: [{ name: "user_createdAt_idx", tableName: "user" }],
+    requiredIndexes: [
+      {
+        definitionBody: 'ON public."user" USING btree (created_at, id)',
+        isUnique: false,
+        name: "user_createdAt_idx",
+        tableName: "user",
+      },
+    ],
   },
   "20260720140000_machine_api_keys_org_index": {
     currentHash:
@@ -150,8 +198,20 @@ const REWRITTEN_MIGRATION_HISTORIES: Readonly<
       "c9c7b5d968fe2efa54ef017592d43bb640688ebd6f56b957aca27b45b1412468",
     ],
     requiredIndexes: [
-      { name: "apikey_metadata_organization_id_idx", tableName: "apikey" },
-      { name: "apikey_org_keyset_idx", tableName: "apikey" },
+      {
+        definitionBody:
+          "ON public.apikey USING btree ((((metadata)::jsonb ->> 'organizationId'::text))) WHERE (metadata IS NOT NULL)",
+        isUnique: false,
+        name: "apikey_metadata_organization_id_idx",
+        tableName: "apikey",
+      },
+      {
+        definitionBody:
+          "ON public.apikey USING btree ((((metadata)::jsonb ->> 'organizationId'::text)), created_at DESC, id DESC) WHERE (metadata IS NOT NULL)",
+        isUnique: false,
+        name: "apikey_org_keyset_idx",
+        tableName: "apikey",
+      },
     ],
   },
   "20260731130000_decision_source_document_id": {
@@ -162,10 +222,16 @@ const REWRITTEN_MIGRATION_HISTORIES: Readonly<
     ],
     requiredIndexes: [
       {
+        definitionBody:
+          "ON public.case_law_decisions USING btree (source_id, source_document_id) WHERE (source_document_id IS NOT NULL)",
+        isUnique: true,
         name: "case_law_decisions_source_document_idx",
         tableName: "case_law_decisions",
       },
       {
+        definitionBody:
+          "ON public.case_law_decisions USING btree (source_id, case_number, language) WHERE (source_document_id IS NULL)",
+        isUnique: true,
         name: "case_law_decisions_source_case_lang_null_idx",
         tableName: "case_law_decisions",
       },

--- a/apps/api/src/lib/db/migration-history.ts
+++ b/apps/api/src/lib/db/migration-history.ts
@@ -6,39 +6,82 @@ import nodePath from "node:path";
 // database that applied the earlier version recorded its hash, and the
 // migrator never re-runs an already-applied folder, so the rewritten hash is
 // never stored. Accept the prior hash as satisfying the check for these.
-const REWRITTEN_MIGRATION_PRIOR_HASHES: Record<string, readonly string[]> = {
+type RewrittenMigrationHistory = {
+  currentHash: string;
+  priorHashes: readonly string[];
+};
+
+const REWRITTEN_MIGRATION_HISTORIES: Readonly<
+  Record<string, RewrittenMigrationHistory>
+> = {
   // 0.5.0 backfilled slugs inside the migration and built the unique index
   // non-concurrently. The in-transaction backfill exceeded statement_timeout
   // on large corpora, so 0.5.1 rewrote it to build the index CONCURRENTLY and
   // moved the slug backfill into src/scripts/backfill-case-law-slugs.ts.
-  "20260603120000_case_law_public_slugs": [
-    "4757efe9484615eff7bcba9c34687be4aa9b28e07a71137a3638a3072d8a6d3d",
-    "0d7608766b5bbec1031a31e8a004fc093124596b0cbf4446bd4269ffc834a90b",
-  ],
-  "20260605143000_workflow_pending_fields_index": [
-    "0088003d298f869017cf4047a74692a9ddefa4bc246aa6c25ca950ebeb29f918",
-  ],
-  "20260701160000_property_playbook_definition_id": [
-    "423af8ce20ec27fa4895b37e3caf64f3470e1ebaa92da58cee04ea5c3dc9085e",
-  ],
-  "20260703233000_account_credential_singleton": [
-    "ffd1598dc3a56f44095b549438313351e4bfb467b0fdb83c1def5a6d55f74583",
-  ],
-  "20260707120000_property_role": [
-    "033466ccb60b0baa4ad4bbd6b8b0f4e116531b4061353ca0b7069178aebfde02",
-  ],
-  "20260717170000_report_export_notifications": [
-    "11856277db1674f04ecf66d39df8f81242f4347af15d60cf2270ee1e3910a317",
-  ],
-  "20260719172000_user_created_at_index": [
-    "d75842b57e1ba5f734b2dea9926c76da9fca178d41fafe8005f144cdc4960eee",
-  ],
-  "20260720140000_machine_api_keys_org_index": [
-    "c9c7b5d968fe2efa54ef017592d43bb640688ebd6f56b957aca27b45b1412468",
-  ],
-  "20260731130000_decision_source_document_id": [
-    "f0dc5e37d764febdad8eba0bc36506c048d22f182f5e0423fd48ad6a26d29a48",
-  ],
+  "20260603120000_case_law_public_slugs": {
+    currentHash:
+      "c1ba2ed2049dd11aeab770ae4681e6b47d924bdbbc2ea480d3d0035199e4ab28",
+    priorHashes: [
+      "4757efe9484615eff7bcba9c34687be4aa9b28e07a71137a3638a3072d8a6d3d",
+      "0d7608766b5bbec1031a31e8a004fc093124596b0cbf4446bd4269ffc834a90b",
+    ],
+  },
+  "20260605143000_workflow_pending_fields_index": {
+    currentHash:
+      "6b0a292d42e172b87ce3bbbf7bfdc108acc2f2f9f0427a32b643b763cb75b447",
+    priorHashes: [
+      "0088003d298f869017cf4047a74692a9ddefa4bc246aa6c25ca950ebeb29f918",
+    ],
+  },
+  "20260701160000_property_playbook_definition_id": {
+    currentHash:
+      "3877a28437845ea1714a41bf2b8c22206ce6f8af363f40a9361b04f38c486c04",
+    priorHashes: [
+      "423af8ce20ec27fa4895b37e3caf64f3470e1ebaa92da58cee04ea5c3dc9085e",
+    ],
+  },
+  "20260703233000_account_credential_singleton": {
+    currentHash:
+      "988b8729f253ee11187aeb8e80ef915c98c7f384e6bffb78ce6201a66b72bfb6",
+    priorHashes: [
+      "ffd1598dc3a56f44095b549438313351e4bfb467b0fdb83c1def5a6d55f74583",
+    ],
+  },
+  "20260707120000_property_role": {
+    currentHash:
+      "8d47e05862c978c9c7176c2e406e00eb5fc3e73e5f80edda28e7a37320856d93",
+    priorHashes: [
+      "033466ccb60b0baa4ad4bbd6b8b0f4e116531b4061353ca0b7069178aebfde02",
+    ],
+  },
+  "20260717170000_report_export_notifications": {
+    currentHash:
+      "094bed35cbea00fc194dc2c2351c9034c55e67b6a6fb808b82cf008345566c3a",
+    priorHashes: [
+      "11856277db1674f04ecf66d39df8f81242f4347af15d60cf2270ee1e3910a317",
+    ],
+  },
+  "20260719172000_user_created_at_index": {
+    currentHash:
+      "cd765faf1da8f1da04146b4ca2736bd739a936f3b3b183b8b2448609a4b18447",
+    priorHashes: [
+      "d75842b57e1ba5f734b2dea9926c76da9fca178d41fafe8005f144cdc4960eee",
+    ],
+  },
+  "20260720140000_machine_api_keys_org_index": {
+    currentHash:
+      "f8714547100e32110a4cd266fb7836c76d6668c23c6223fe718bb5beb36469d3",
+    priorHashes: [
+      "c9c7b5d968fe2efa54ef017592d43bb640688ebd6f56b957aca27b45b1412468",
+    ],
+  },
+  "20260731130000_decision_source_document_id": {
+    currentHash:
+      "85bdb5023fe1126f39e04aad8e7fd3969e2fce28b7d69096cad1a668b8dc45fc",
+    priorHashes: [
+      "f0dc5e37d764febdad8eba0bc36506c048d22f182f5e0423fd48ad6a26d29a48",
+    ],
+  },
 };
 
 export type LocalMigration = { name: string; hash: string };
@@ -56,10 +99,12 @@ export const findUnappliedMigrations = ({
     if (appliedHashes.has(hash)) {
       return false;
     }
-    const priorHashes = REWRITTEN_MIGRATION_PRIOR_HASHES[name];
-    return (
-      priorHashes === undefined ||
-      !priorHashes.some((priorHash) => appliedHashes.has(priorHash))
+    const supportedHistory = REWRITTEN_MIGRATION_HISTORIES[name];
+    if (supportedHistory?.currentHash !== hash) {
+      return true;
+    }
+    return !supportedHistory.priorHashes.some((priorHash) =>
+      appliedHashes.has(priorHash),
     );
   });
 
@@ -70,8 +115,11 @@ const hashMigrationFile = async (path: string): Promise<string> =>
 
 const listLocalMigrations = async (
   migrationsDir: string,
-): Promise<LocalMigration[]> =>
-  await Promise.all(
+): Promise<LocalMigration[]> => {
+  if (!existsSync(migrationsDir)) {
+    return [];
+  }
+  return await Promise.all(
     readdirSync(migrationsDir)
       .filter((name) =>
         existsSync(nodePath.join(migrationsDir, name, "migration.sql")),
@@ -84,6 +132,7 @@ const listLocalMigrations = async (
         ),
       })),
   );
+};
 
 type AssertMigrationHistoryOptions = {
   context: "migrate" | "startup";

--- a/apps/api/src/lib/db/migration-history.ts
+++ b/apps/api/src/lib/db/migration-history.ts
@@ -28,21 +28,28 @@ const REWRITTEN_MIGRATION_HISTORIES: Readonly<
   },
   "20260605143000_workflow_pending_fields_index": {
     currentHash:
-      "6b0a292d42e172b87ce3bbbf7bfdc108acc2f2f9f0427a32b643b763cb75b447",
+      "e01fb3a73766f84e0ee0ea062f64d38cd56f777f71f9b74c5fb1fd42b282312e",
     priorHashes: [
       "0088003d298f869017cf4047a74692a9ddefa4bc246aa6c25ca950ebeb29f918",
     ],
   },
+  "20260629123000_arabic_normalize_function": {
+    currentHash:
+      "6e7b6481011f0eea42b5ca645e959ec95e91d9f1a8f7eb920e071dc9cba654b9",
+    priorHashes: [
+      "36ccbd00b7e98f6489d4a493ff61eba96eec145b38ef684045ae408fe88521ce",
+    ],
+  },
   "20260701160000_property_playbook_definition_id": {
     currentHash:
-      "3877a28437845ea1714a41bf2b8c22206ce6f8af363f40a9361b04f38c486c04",
+      "424a1d2b0ae33d434efdea8f82fcbfd08bdf19f5f5c500857f3028fd7d6b76b2",
     priorHashes: [
       "423af8ce20ec27fa4895b37e3caf64f3470e1ebaa92da58cee04ea5c3dc9085e",
     ],
   },
   "20260703233000_account_credential_singleton": {
     currentHash:
-      "988b8729f253ee11187aeb8e80ef915c98c7f384e6bffb78ce6201a66b72bfb6",
+      "c2d26af1dc97f687ab3a1a0a41538fe2eac7dbf60824d2d74187104be957ade6",
     priorHashes: [
       "ffd1598dc3a56f44095b549438313351e4bfb467b0fdb83c1def5a6d55f74583",
     ],

--- a/apps/api/src/lib/db/migration-history.ts
+++ b/apps/api/src/lib/db/migration-history.ts
@@ -19,9 +19,7 @@ export type RequiredMigrationIndex = {
   tableName: string;
 };
 
-const REWRITTEN_MIGRATION_HISTORIES: Readonly<
-  Record<string, RewrittenMigrationHistory>
-> = {
+export const REWRITTEN_MIGRATION_HISTORIES = {
   // 0.5.0 backfilled slugs inside the migration and built the unique index
   // non-concurrently. The in-transaction backfill exceeded statement_timeout
   // on large corpora, so 0.5.1 rewrote it to build the index CONCURRENTLY and
@@ -216,9 +214,10 @@ const REWRITTEN_MIGRATION_HISTORIES: Readonly<
   },
   "20260731130000_decision_source_document_id": {
     currentHash:
-      "15d92f17395b90ef96815823e22b7928cdeaa5ee39021428b7268ffcf0fe4b84",
+      "479cd1cd88870fb947ea7da61411f76d96a18f07bf7cc308465ce8d62dc8c40e",
     priorHashes: [
       "f0dc5e37d764febdad8eba0bc36506c048d22f182f5e0423fd48ad6a26d29a48",
+      "15d92f17395b90ef96815823e22b7928cdeaa5ee39021428b7268ffcf0fe4b84",
     ],
     requiredIndexes: [
       {
@@ -237,7 +236,11 @@ const REWRITTEN_MIGRATION_HISTORIES: Readonly<
       },
     ],
   },
-};
+} as const satisfies Readonly<Record<string, RewrittenMigrationHistory>>;
+
+const rewrittenMigrationHistoryByName: Readonly<
+  Record<string, RewrittenMigrationHistory>
+> = REWRITTEN_MIGRATION_HISTORIES;
 
 export const REWRITTEN_MIGRATION_INDEXES: readonly RequiredMigrationIndex[] =
   Object.values(REWRITTEN_MIGRATION_HISTORIES).flatMap(
@@ -259,7 +262,7 @@ export const findUnappliedMigrations = ({
     if (appliedHashes.has(hash)) {
       return false;
     }
-    const supportedHistory = REWRITTEN_MIGRATION_HISTORIES[name];
+    const supportedHistory = rewrittenMigrationHistoryByName[name];
     if (supportedHistory?.currentHash !== hash) {
       return true;
     }

--- a/apps/api/src/lib/db/migration-history.ts
+++ b/apps/api/src/lib/db/migration-history.ts
@@ -9,6 +9,12 @@ import nodePath from "node:path";
 type RewrittenMigrationHistory = {
   currentHash: string;
   priorHashes: readonly string[];
+  requiredIndexes: readonly RequiredMigrationIndex[];
+};
+
+export type RequiredMigrationIndex = {
+  name: string;
+  tableName: string;
 };
 
 const REWRITTEN_MIGRATION_HISTORIES: Readonly<
@@ -20,10 +26,16 @@ const REWRITTEN_MIGRATION_HISTORIES: Readonly<
   // moved the slug backfill into src/scripts/backfill-case-law-slugs.ts.
   "20260603120000_case_law_public_slugs": {
     currentHash:
-      "c1ba2ed2049dd11aeab770ae4681e6b47d924bdbbc2ea480d3d0035199e4ab28",
+      "6b7745706b35e0bba31829f9c5262794c7ed4f33455679f28fd998c37eb1718c",
     priorHashes: [
       "4757efe9484615eff7bcba9c34687be4aa9b28e07a71137a3638a3072d8a6d3d",
       "0d7608766b5bbec1031a31e8a004fc093124596b0cbf4446bd4269ffc834a90b",
+    ],
+    requiredIndexes: [
+      {
+        name: "case_law_decisions_slug_uidx",
+        tableName: "case_law_decisions",
+      },
     ],
   },
   "20260605143000_workflow_pending_fields_index": {
@@ -32,12 +44,33 @@ const REWRITTEN_MIGRATION_HISTORIES: Readonly<
     priorHashes: [
       "0088003d298f869017cf4047a74692a9ddefa4bc246aa6c25ca950ebeb29f918",
     ],
+    requiredIndexes: [
+      { name: "fields_pending_workspace_idx", tableName: "fields" },
+    ],
   },
   "20260629123000_arabic_normalize_function": {
     currentHash:
       "5c18323c0211930aee1eb476720d3a6f00b808156f1c72b758ff0458f92a685d",
     priorHashes: [
       "36ccbd00b7e98f6489d4a493ff61eba96eec145b38ef684045ae408fe88521ce",
+    ],
+    requiredIndexes: [
+      {
+        name: "contacts_display_name_arabic_norm_trgm_idx",
+        tableName: "contacts",
+      },
+      {
+        name: "contacts_first_name_arabic_norm_trgm_idx",
+        tableName: "contacts",
+      },
+      {
+        name: "contacts_last_name_arabic_norm_trgm_idx",
+        tableName: "contacts",
+      },
+      {
+        name: "contacts_organization_name_arabic_norm_trgm_idx",
+        tableName: "contacts",
+      },
     ],
   },
   "20260701160000_property_playbook_definition_id": {
@@ -46,19 +79,47 @@ const REWRITTEN_MIGRATION_HISTORIES: Readonly<
     priorHashes: [
       "423af8ce20ec27fa4895b37e3caf64f3470e1ebaa92da58cee04ea5c3dc9085e",
     ],
+    requiredIndexes: [
+      {
+        name: "properties_workspace_playbook_definition_idx",
+        tableName: "properties",
+      },
+    ],
   },
   "20260703233000_account_credential_singleton": {
     currentHash:
-      "1e3a3cd7ef1373e6a6c48ded10bd53dc32169066a79fb3a808552d52849fb9ff",
+      "9de5d6af3b0acd569ebffa1452e7e441939a1afafb9c6bc59bd461e87e1586bc",
     priorHashes: [
       "ffd1598dc3a56f44095b549438313351e4bfb467b0fdb83c1def5a6d55f74583",
+    ],
+    requiredIndexes: [
+      { name: "account_credential_singleton_uidx", tableName: "account" },
     ],
   },
   "20260707120000_property_role": {
     currentHash:
-      "8d47e05862c978c9c7176c2e406e00eb5fc3e73e5f80edda28e7a37320856d93",
+      "a3e5b0faa0bf5fc1249848c25707c589d00a5ef1a969efcd6fa313f483030c54",
     priorHashes: [
       "033466ccb60b0baa4ad4bbd6b8b0f4e116531b4061353ca0b7069178aebfde02",
+    ],
+    requiredIndexes: [
+      {
+        name: "properties_ws_document_type_classifier_unq",
+        tableName: "properties",
+      },
+    ],
+  },
+  "20260717110000_usage_event_idempotency": {
+    currentHash:
+      "c769f5c5257528acb310673a276549138a2e44006eeed8dc10beb4153a54cddb",
+    priorHashes: [
+      "dd0acd610eb979875428ca7778d97cce4baf33b4332479434f66e68c729b2433",
+    ],
+    requiredIndexes: [
+      {
+        name: "usage_events_org_idempotency_key_uidx",
+        tableName: "usage_events",
+      },
     ],
   },
   "20260717170000_report_export_notifications": {
@@ -67,6 +128,12 @@ const REWRITTEN_MIGRATION_HISTORIES: Readonly<
     priorHashes: [
       "11856277db1674f04ecf66d39df8f81242f4347af15d60cf2270ee1e3910a317",
     ],
+    requiredIndexes: [
+      {
+        name: "report_exports_pending_notification_idx",
+        tableName: "report_exports",
+      },
+    ],
   },
   "20260719172000_user_created_at_index": {
     currentHash:
@@ -74,6 +141,7 @@ const REWRITTEN_MIGRATION_HISTORIES: Readonly<
     priorHashes: [
       "d75842b57e1ba5f734b2dea9926c76da9fca178d41fafe8005f144cdc4960eee",
     ],
+    requiredIndexes: [{ name: "user_createdAt_idx", tableName: "user" }],
   },
   "20260720140000_machine_api_keys_org_index": {
     currentHash:
@@ -81,15 +149,34 @@ const REWRITTEN_MIGRATION_HISTORIES: Readonly<
     priorHashes: [
       "c9c7b5d968fe2efa54ef017592d43bb640688ebd6f56b957aca27b45b1412468",
     ],
+    requiredIndexes: [
+      { name: "apikey_metadata_organization_id_idx", tableName: "apikey" },
+      { name: "apikey_org_keyset_idx", tableName: "apikey" },
+    ],
   },
   "20260731130000_decision_source_document_id": {
     currentHash:
-      "85bdb5023fe1126f39e04aad8e7fd3969e2fce28b7d69096cad1a668b8dc45fc",
+      "15d92f17395b90ef96815823e22b7928cdeaa5ee39021428b7268ffcf0fe4b84",
     priorHashes: [
       "f0dc5e37d764febdad8eba0bc36506c048d22f182f5e0423fd48ad6a26d29a48",
     ],
+    requiredIndexes: [
+      {
+        name: "case_law_decisions_source_document_idx",
+        tableName: "case_law_decisions",
+      },
+      {
+        name: "case_law_decisions_source_case_lang_null_idx",
+        tableName: "case_law_decisions",
+      },
+    ],
   },
 };
+
+export const REWRITTEN_MIGRATION_INDEXES: readonly RequiredMigrationIndex[] =
+  Object.values(REWRITTEN_MIGRATION_HISTORIES).flatMap(
+    ({ requiredIndexes }) => requiredIndexes,
+  );
 
 export type LocalMigration = { name: string; hash: string };
 


### PR DESCRIPTION
## Summary

- share the applied-migration invariant between the migration command and API startup
- make concurrent-index timeout transitions explicit and preserve supported migration histories
- exercise inconsistent history through the shipped release image

## Testing

- focused migration invariant tests
- full lint, typecheck, migration, and image checks run in CI

CC on behalf of jan-kubica

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database migration reliability by safely managing execution timeouts during index creation.
  * Prevented application startup when migrations are missing, altered or inconsistent with recorded migration history.
  * Improved handling of compatible migration updates released after deployment.

* **Tests**
  * Added automated checks to detect unsafe migration timeout configurations.
  * Expanded migration-history validation and release smoke-test coverage, including detection of inconsistent migration records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->