### PR TITLE
fix: recover failed lazy route modules

### DIFF
--- a/apps/web/src/components/route-components.logic.test.ts
+++ b/apps/web/src/components/route-components.logic.test.ts
@@ -6,8 +6,60 @@ import { CriticalQueryTimeoutError } from "@/lib/react-query";
 import {
   buildErrorReportMailto,
   isNetworkError,
+  recoverRouteError,
+  resolveRouteErrorRecovery,
   resolveRouteErrorSupport,
 } from "./route-components.logic";
+
+describe("route error recovery", () => {
+  test("reloads for every browser dynamic-import failure shape", () => {
+    const messages = [
+      "Failed to fetch dynamically imported module: https://example.test/chunk.js",
+      "error loading dynamically imported module: https://example.test/chunk.js",
+      "Importing a module script failed.",
+    ];
+
+    for (const message of messages) {
+      expect(resolveRouteErrorRecovery(new TypeError(message))).toEqual({
+        type: "reload-page",
+      });
+    }
+  });
+
+  test("hard reloads instead of retrying a cached rejected import", () => {
+    const actions: string[] = [];
+
+    recoverRouteError({
+      error: new TypeError(
+        "Failed to fetch dynamically imported module: https://example.test/chunk.js",
+      ),
+      reloadPage: () => {
+        actions.push("reload");
+      },
+      retryRoute: () => {
+        actions.push("retry");
+      },
+    });
+
+    expect(actions).toEqual(["reload"]);
+  });
+
+  test("keeps ordinary route errors on the in-app retry path", () => {
+    const actions: string[] = [];
+
+    recoverRouteError({
+      error: new TypeError("Cannot read properties of null"),
+      reloadPage: () => {
+        actions.push("reload");
+      },
+      retryRoute: () => {
+        actions.push("retry");
+      },
+    });
+
+    expect(actions).toEqual(["retry"]);
+  });
+});
 
 describe("route network error classification", () => {
   test("recognises query timeouts and browser network errors", () => {

--- a/apps/web/src/components/route-components.logic.ts
+++ b/apps/web/src/components/route-components.logic.ts
@@ -13,6 +13,67 @@ const NETWORK_ERROR_MESSAGES = Object.freeze([
   "Load failed",
 ]);
 
+// Keep this aligned with TanStack Router's cross-browser dynamic-import
+// classifier. A rejected lazy import is cached inside lazyRouteComponent, so
+// resetting the route boundary can only throw the same error again; recovery
+// requires a new page module graph.
+const DYNAMIC_IMPORT_ERROR_PREFIXES = Object.freeze([
+  "Failed to fetch dynamically imported module",
+  "error loading dynamically imported module",
+  "Importing a module script failed",
+]);
+
+export type RouteErrorRecovery =
+  | { type: "reload-page" }
+  | { type: "retry-route" };
+
+const getErrorMessage = (error: unknown): string | undefined => {
+  if (typeof error !== "object" || error === null || !("message" in error)) {
+    return undefined;
+  }
+  const { message } = error;
+  return typeof message === "string" ? message : undefined;
+};
+
+export const resolveRouteErrorRecovery = (
+  error: unknown,
+): RouteErrorRecovery => {
+  const message = getErrorMessage(error);
+  if (
+    message !== undefined &&
+    DYNAMIC_IMPORT_ERROR_PREFIXES.some((prefix) => message.startsWith(prefix))
+  ) {
+    return { type: "reload-page" };
+  }
+  return { type: "retry-route" };
+};
+
+type RecoverRouteErrorOptions = {
+  error: unknown;
+  reloadPage: () => void;
+  retryRoute: () => void;
+};
+
+export const recoverRouteError = ({
+  error,
+  reloadPage,
+  retryRoute,
+}: RecoverRouteErrorOptions): void => {
+  const recovery = resolveRouteErrorRecovery(error);
+  switch (recovery.type) {
+    case "reload-page":
+      reloadPage();
+      return;
+    case "retry-route":
+      retryRoute();
+      return;
+    default: {
+      const exhaustive: never = recovery;
+      return exhaustive;
+    }
+  }
+};
+
 export type RouteErrorSupport =
   | { type: "report"; recipient: string }
   | { type: "administrator" }

--- a/apps/web/src/components/route-components.tsx
+++ b/apps/web/src/components/route-components.tsx
@@ -6,7 +6,6 @@ import type { ErrorComponentProps } from "@tanstack/react-router";
 import {
   CircleAlertIcon,
   CopyIcon,
-  FolderOpenIcon,
   MailIcon,
   RefreshCcwIcon,
 } from "lucide-react";
@@ -16,9 +15,11 @@ import { Button } from "@stll/ui/components/button";
 import { stellaToast } from "@stll/ui/components/toast";
 import { cn } from "@stll/ui/lib/utils";
 
+import { MattersNavIcon } from "@/components/matter-icon";
 import {
   buildErrorReportMailto,
   isNetworkError,
+  recoverRouteError,
   resolveRouteErrorSupport,
 } from "@/components/route-components.logic";
 import { StellaMark } from "@/components/stella-mark";
@@ -271,6 +272,14 @@ const UnexpectedRouteError = ({
         })
       : null;
 
+  const handleRecovery = () => {
+    recoverRouteError({
+      error,
+      reloadPage: () => window.location.reload(),
+      retryRoute: retry,
+    });
+  };
+
   return (
     <div
       className={cn(
@@ -302,11 +311,11 @@ const UnexpectedRouteError = ({
         </div>
 
         <div className="flex flex-wrap gap-2">
-          <Button loading={isPending} onClick={retry}>
+          <Button loading={isPending} onClick={handleRecovery}>
             <RefreshCcwIcon /> {t("common.tryAgain")}
           </Button>
           <Button render={<Link from="/" to="/workspaces" />} variant="outline">
-            <FolderOpenIcon /> {t("routeError.backToMatters")}
+            <MattersNavIcon /> {t("routeError.backToMatters")}
           </Button>
           {reportHref ? (
             <Button


### PR DESCRIPTION
## Summary

- reload the page when a lazy route module import fails instead of retrying its cached rejection
- make route recovery modes exhaustive and cover browser-specific import failure shapes
- reuse the canonical matters icon in the shared recovery screen