### PR TITLE
chore: reuse CI work across jobs

### DIFF
--- a/.github/actions/setup-playwright/action.yml
+++ b/.github/actions/setup-playwright/action.yml
@@ -1,0 +1,22 @@
+name: Setup Playwright Chromium
+description: Restore the pinned Playwright browser and install its system dependencies
+
+runs:
+  using: composite
+  steps:
+    - name: Resolve Playwright version
+      id: version
+      shell: bash
+      run: |
+        version=$(cd apps/web && bunx playwright --version)
+        echo "version=${version#Version }" >> "$GITHUB_OUTPUT"
+
+    - name: Restore Playwright browser
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      with:
+        path: ~/.cache/ms-playwright
+        key: playwright-${{ runner.os }}-${{ runner.arch }}-${{ steps.version.outputs.version }}
+
+    - name: Install Chromium and system dependencies
+      shell: bash
+      run: cd apps/web && bunx playwright install --with-deps chromium

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -586,8 +586,12 @@ jobs:
       - name: Test detect-desktop-release-changes script
         run: bash scripts/detect-desktop-release-changes.test.sh
 
-      - name: Test E2E change detector
+      - name: Test CI workflow invariants
         run: bun test scripts/detect-e2e-changes.test.ts
+
+      - name: Test affected code-check planner
+        if: needs.ci-changes.outputs.package_checks_required == 'true'
+        run: bun test scripts/code-check-affected.test.ts
 
       - name: Test bun ci retry script
         run: bash scripts/bun-ci-retry.test.sh
@@ -646,7 +650,15 @@ jobs:
           bun scripts/typecheck-coverage.ts
 
       - name: Code quality
-        run: bun run code-check
+        env:
+          BASE_REF: ${{ github.base_ref || 'main' }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+            bun run code-check
+            exit 0
+          fi
+          bun run code-check:affected -- --base "origin/$BASE_REF"
 
       - name: Result consumption
         env:
@@ -720,7 +732,7 @@ jobs:
   # that could plausibly affect the web output so this class of
   # failure is caught pre-merge.
   web-build:
-    needs: trust-check
+    needs: [trust-check, ci-changes]
     if: >-
       needs.trust-check.outputs.trusted == 'true'
       || github.event_name == 'workflow_dispatch'
@@ -740,9 +752,10 @@ jobs:
         id: changed
         env:
           BASE_REF: ${{ github.base_ref || 'main' }}
+          CORE_REQUIRED: ${{ needs.ci-changes.outputs.e2e_core_required }}
           EVENT_NAME: ${{ github.event_name }}
         run: |
-          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+          if [[ "$EVENT_NAME" == "workflow_dispatch" || "$CORE_REQUIRED" == "true" ]]; then
             echo "run=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -786,7 +799,24 @@ jobs:
 
       - name: Build web
         if: steps.changed.outputs.run == 'true'
+        env:
+          # The same artifact serves the feature-complete production E2E suite.
+          # These flags preserve the committed bundle baseline.
+          VITE_FEATURE_TIME_BILLING: "true"
+          VITE_PLAYBOOKS_ENABLED: "true"
+          VITE_WORKFLOWS_ENABLED: "true"
         run: bun --filter @stll/web build
+
+      - name: Upload production E2E web build
+        if: >-
+          steps.changed.outputs.run == 'true'
+          && needs.ci-changes.outputs.e2e_core_required == 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: e2e-web-build
+          path: apps/web/dist/
+          if-no-files-found: error
+          retention-days: 1
 
       - name: Bundle size guard
         if: steps.changed.outputs.run == 'true'
@@ -975,6 +1005,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 25
     permissions:
+      actions: read
       contents: read
     strategy:
       fail-fast: false
@@ -1092,14 +1123,43 @@ jobs:
           exit 1
 
       - name: Install Playwright browsers
-        run: cd apps/web && bunx playwright install --with-deps chromium
+        uses: ./.github/actions/setup-playwright
 
-      - name: Build web for route checks
+      - name: Wait for production web build
         env:
-          VITE_FEATURE_TIME_BILLING: "true"
-          VITE_PLAYBOOKS_ENABLED: "true"
-          VITE_WORKFLOWS_ENABLED: "true"
-        run: bun --filter @stll/web build
+          ARTIFACT_NAME: e2e-web-build
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          for attempt in {1..90}; do
+            count=$(gh api --method GET \
+              "repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID/artifacts" \
+              -f name="$ARTIFACT_NAME" \
+              --jq '[.artifacts[] | select(.expired == false)] | length')
+            if [[ "$count" -gt 0 ]]; then
+              echo "Production web build ready after $((attempt * 2))s"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "::error::Production web build artifact was not published"
+          exit 1
+
+      - name: Download production web build
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v8.0.0
+        with:
+          name: e2e-web-build
+          path: apps/web/dist
+
+      - name: Validate production web build
+        run: |
+          for side in client server; do
+            manifest="apps/web/dist/$side/version.json"
+            commit=$(jq -r '.commit' "$manifest")
+            if [[ "$commit" != "$GITHUB_SHA" ]]; then
+              echo "::error::$side build is for $commit, expected $GITHUB_SHA"
+              exit 1
+            fi
+          done
 
       - name: Start production web server
         run: |
@@ -1264,7 +1324,7 @@ jobs:
           exit 1
 
       - name: Install Playwright browsers
-        run: cd apps/web && bunx playwright install --with-deps chromium
+        uses: ./.github/actions/setup-playwright
 
       - name: Run Vite dependency canary
         env:
@@ -1364,7 +1424,7 @@ jobs:
           exit 1
 
       - name: Install Playwright browsers
-        run: cd apps/web && bunx playwright install --with-deps chromium
+        uses: ./.github/actions/setup-playwright
 
       - name: Check landing islands
         run: E2E_LANDING_URL=http://localhost:4321 bun --filter @stll/web test:e2e:landing

--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -231,7 +231,7 @@ jobs:
           exit 1
 
       - name: Install Playwright browsers
-        run: cd apps/web && bunx playwright install --with-deps chromium
+        uses: ./.github/actions/setup-playwright
 
       - name: Seed deterministic marketing content
         run: bun --filter @stll/api db:seed-dev

--- a/scripts/code-check-affected.test.ts
+++ b/scripts/code-check-affected.test.ts
@@ -55,6 +55,7 @@ describe("affected code-check planning", () => {
     "package.json",
     "bun.lock",
     "bunfig.toml",
+    "scripts/code-check-affected.ts",
     "scripts/lint-oxlint-fixtures.sh",
     "turbo.json",
     "oxlint.config.ts",

--- a/scripts/code-check-affected.ts
+++ b/scripts/code-check-affected.ts
@@ -22,6 +22,7 @@ const FULL_CHECK_FILES = new Set([
   "bunfig.toml",
   "oxlint.config.ts",
   "package.json",
+  "scripts/code-check-affected.ts",
   "scripts/lint-oxlint-fixtures.sh",
   "turbo.json",
   "tsconfig.json",

--- a/scripts/detect-e2e-changes.sh
+++ b/scripts/detect-e2e-changes.sh
@@ -11,7 +11,7 @@ fi
 
 for file in "$@"; do
   case "$file" in
-    .github/workflows/ci.yml|scripts/detect-e2e-changes.sh|bun.lock|package.json|patches/*)
+    .github/actions/setup-playwright/*|.github/workflows/ci.yml|scripts/detect-e2e-changes.sh|bun.lock|package.json|patches/*)
       echo true
       exit 0
       ;;

--- a/scripts/detect-e2e-changes.test.ts
+++ b/scripts/detect-e2e-changes.test.ts
@@ -3,8 +3,20 @@ import { readFileSync } from "node:fs";
 import path from "node:path";
 
 const script = path.join(import.meta.dirname, "detect-e2e-changes.sh");
+const githubExpression = (value: string) => ["$", "{{ ", value, " }}"].join("");
 const workflow = readFileSync(
   path.join(import.meta.dirname, "../.github/workflows/ci.yml"),
+  "utf-8",
+);
+const nightlyWorkflow = readFileSync(
+  path.join(import.meta.dirname, "../.github/workflows/nightly-test.yml"),
+  "utf-8",
+);
+const playwrightSetup = readFileSync(
+  path.join(
+    import.meta.dirname,
+    "../.github/actions/setup-playwright/action.yml",
+  ),
   "utf-8",
 );
 
@@ -69,9 +81,13 @@ describe("detect-e2e-changes", () => {
   });
 
   test("runs both PR scopes when their orchestration changes", () => {
-    const files = [".github/workflows/ci.yml"];
-    expect(detects("core", files)).toBe("true");
-    expect(detects("landing", files)).toBe("true");
+    for (const file of [
+      ".github/workflows/ci.yml",
+      ".github/actions/setup-playwright/action.yml",
+    ]) {
+      expect(detects("core", [file])).toBe("true");
+      expect(detects("landing", [file])).toBe("true");
+    }
   });
 
   test("keeps production, Vite canary, and landing work parallel", () => {
@@ -95,5 +111,57 @@ describe("detect-e2e-changes", () => {
     ]) {
       expect(aggregate).toContain(requiredJob);
     }
+  });
+
+  test("keeps full code quality for manual sweeps and scopes pull requests", () => {
+    const codeQuality = workflowJob("code-quality");
+    expect(codeQuality).toContain(
+      `EVENT_NAME: ${githubExpression("github.event_name")}`,
+    );
+    expect(codeQuality).toContain(
+      'if [[ "$EVENT_NAME" == "workflow_dispatch" ]]',
+    );
+    expect(codeQuality).toContain("bun run code-check\n");
+    expect(codeQuality).toContain(
+      'bun run code-check:affected -- --base "origin/$BASE_REF"',
+    );
+  });
+
+  test("builds the production web artifact once per workflow run", () => {
+    const webBuild = workflowJob("web-build");
+    expect(webBuild).toContain("needs: [trust-check, ci-changes]");
+    expect(webBuild).toContain("Upload production E2E web build");
+    expect(webBuild).toContain("VITE_FEATURE_TIME_BILLING");
+
+    const production = workflowJob("e2e-production-shard");
+    expect(production).not.toContain("Build web for route checks");
+    expect(production).toContain("Wait for production web build");
+    expect(production).toContain("Download production web build");
+    expect(production).toContain("Validate production web build");
+    expect(production.indexOf("Install Playwright browsers")).toBeLessThan(
+      production.indexOf("Wait for production web build"),
+    );
+  });
+
+  test("shares a version-keyed Playwright browser cache across browser jobs", () => {
+    expect(
+      workflow.match(/uses: \.\/\.github\/actions\/setup-playwright/gu),
+    ).toHaveLength(3);
+    expect(nightlyWorkflow).toContain(
+      "uses: ./.github/actions/setup-playwright",
+    );
+    expect(playwrightSetup).toContain("bunx playwright --version");
+    expect(playwrightSetup).toContain("~/.cache/ms-playwright");
+    expect(playwrightSetup).toContain(
+      [
+        "playwright",
+        githubExpression("runner.os"),
+        githubExpression("runner.arch"),
+        githubExpression("steps.version.outputs.version"),
+      ].join("-"),
+    );
+    expect(playwrightSetup).toContain(
+      "actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae",
+    );
   });
 });


### PR DESCRIPTION
Summary

- scope pull-request code quality to affected workspaces while preserving full manual and conservative fallback checks\n- build the feature-complete production web app once and share the commit-verified artifact across E2E shards\n- cache the Playwright Chromium binary by runner and Playwright version, with nightly main warming\n- encode the CI orchestration invariants in regression tests\n\n## Measured result\n\nTwo complete runs are green. Against the pre-change baseline, production E2E shard 1 fell from 3m52s to 2m54s (58s, 25% faster); shard 2 fell from 4m10s to 3m11s (59s, 24% faster).\n\nThe shared web build took 60s plus 5s to upload. It completed while the shards provisioned Docker and Chromium, so artifact waiting cost 2–7s, download cost 3–4s, and validation was immediate. This replaces the previous 52–63s build inside each shard.\n\nThe first cold-cache run reached 3m09s / 3m23s. The second run reached 2m54s / 3m11s, but Playwright setup itself remained 19–28s versus 22–27s cold because system dependency installation dominates. The version-keyed cache still avoids repeat Chromium downloads; shared build reuse produces the main gain.\n\nCode quality was green in 2m43s, with its main step taking 2m03s. This PR intentionally changes the affected-check planner, so its structural fallback forces a full repository check; ordinary package-scoped pull requests exercise the affected path.\n\n## Validation\n\n- 29 focused CI planner and workflow invariant tests\n- actionlint for CI and nightly workflows\n- scripts TypeScript check\n- full pre-push code-check, format, and i18n gates\n- dependency security audit\n- feature-complete production web build\n- bundle baseline check\n- two complete GitHub CI runs, including E2E, CodeQL, dependency review, CLA, and PR lint gates