### PR TITLE
chore: speed up production browser checks

### DIFF
--- a/.github/actions/setup-playwright/action.yml
+++ b/.github/actions/setup-playwright/action.yml
@@ -1,22 +1,76 @@
 name: Setup Playwright Chromium
-description: Restore the pinned Playwright browser and install its system dependencies
+description: Restore the pinned browser and verify its host dependencies
+
+inputs:
+  dependency-mode:
+    description: Use full for deterministic screenshot fonts; otherwise verify launch compatibility
+    required: false
+    default: launch-verified
 
 runs:
   using: composite
   steps:
+    - name: Validate dependency mode
+      shell: bash
+      env:
+        DEPENDENCY_MODE: ${{ inputs.dependency-mode }}
+      run: |
+        case "$DEPENDENCY_MODE" in
+          full|launch-verified) ;;
+          *)
+            echo "::error::Unknown Playwright dependency mode: $DEPENDENCY_MODE"
+            exit 1
+            ;;
+        esac
+
     - name: Resolve Playwright version
       id: version
       shell: bash
       run: |
-        version=$(cd apps/web && bunx playwright --version)
-        echo "version=${version#Version }" >> "$GITHUB_OUTPUT"
+        version=$(cd apps/web && bun -e 'import metadata from "@playwright/test/package.json"; process.stdout.write(metadata.version)')
+        echo "version=$version" >> "$GITHUB_OUTPUT"
 
     - name: Restore Playwright browser
+      id: browser-cache
       uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: ~/.cache/ms-playwright
         key: playwright-${{ runner.os }}-${{ runner.arch }}-${{ steps.version.outputs.version }}
 
-    - name: Install Chromium and system dependencies
+    - name: Install Chromium on cache miss
+      if: steps.browser-cache.outputs.cache-hit != 'true'
       shell: bash
       run: cd apps/web && bunx playwright install --with-deps chromium
+
+    - name: Install deterministic screenshot dependencies
+      if: steps.browser-cache.outputs.cache-hit == 'true' && inputs.dependency-mode == 'full'
+      shell: bash
+      run: cd apps/web && bunx playwright install-deps chromium
+
+    - name: Verify Chromium host dependencies
+      shell: bash
+      env:
+        DEPENDENCY_MODE: ${{ inputs.dependency-mode }}
+        PLAYWRIGHT_CACHE_HIT: ${{ steps.browser-cache.outputs.cache-hit }}
+      run: |
+        cd apps/web
+        verify_chromium() {
+          bun -e '
+            import { chromium } from "@playwright/test";
+            const browser = await chromium.launch();
+            await browser.close();
+          '
+        }
+
+        if verify_chromium; then
+          exit 0
+        fi
+
+        if [[ "$PLAYWRIGHT_CACHE_HIT" != "true" || "$DEPENDENCY_MODE" == "full" ]]; then
+          echo "::error::Chromium failed to launch after installing its declared dependencies"
+          exit 1
+        fi
+
+        echo "::warning::Cached Chromium needs additional host dependencies; installing them now"
+        bunx playwright install-deps chromium
+        verify_chromium

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1194,7 +1194,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: playwright-blob-${{ matrix.shard }}
-          path: apps/web/test-results/blob-report/
+          path: apps/web/e2e/test-results/blob-report/
           retention-days: 7
 
       - name: Upload server logs
@@ -1360,7 +1360,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: playwright-blob-vite-canary
-          path: apps/web/test-results/blob-report/
+          path: apps/web/e2e/test-results/blob-report/
           retention-days: 7
 
       - name: Upload server logs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1182,6 +1182,7 @@ jobs:
 
       - name: Run Playwright shard
         env:
+          E2E_EXECUTION_PROFILE: ci-production-parallel
           E2E_EXPECT_DEV_ROUTES: "false"
           PLAYWRIGHT_BLOB_OUTPUT_NAME: report-${{ matrix.shard }}.zip
         run: >-

--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -232,6 +232,8 @@ jobs:
 
       - name: Install Playwright browsers
         uses: ./.github/actions/setup-playwright
+        with:
+          dependency-mode: full
 
       - name: Seed deterministic marketing content
         run: bun --filter @stll/api db:seed-dev

--- a/apps/web/e2e/execution-profile.ts
+++ b/apps/web/e2e/execution-profile.ts
@@ -1,0 +1,44 @@
+import { panic } from "better-result";
+
+export const E2E_EXECUTION_PROFILE = {
+  standard: "standard",
+  ciProductionParallel: "ci-production-parallel",
+} as const;
+
+const EXECUTION_PROFILES = {
+  [E2E_EXECUTION_PROFILE.standard]: {
+    routeSmokeGroupCount: 2,
+    workerCount: 1,
+  },
+  [E2E_EXECUTION_PROFILE.ciProductionParallel]: {
+    routeSmokeGroupCount: 4,
+    workerCount: 2,
+  },
+} as const;
+
+export const resolveE2eExecutionProfile = (name: string | undefined) => {
+  const resolvedName = name ?? E2E_EXECUTION_PROFILE.standard;
+  switch (resolvedName) {
+    case E2E_EXECUTION_PROFILE.standard:
+      return EXECUTION_PROFILES[E2E_EXECUTION_PROFILE.standard];
+    case E2E_EXECUTION_PROFILE.ciProductionParallel:
+      return EXECUTION_PROFILES[E2E_EXECUTION_PROFILE.ciProductionParallel];
+    default:
+      return panic(`Unknown E2E execution profile: ${resolvedName}`);
+  }
+};
+
+export const partitionRoundRobin = <T>(
+  items: readonly T[],
+  groupCount: number,
+): T[][] => {
+  if (!Number.isSafeInteger(groupCount) || groupCount < 1) {
+    panic("E2E group count must be a positive safe integer");
+  }
+
+  return Array.from({ length: groupCount }, (_unused, groupIndex) =>
+    items.filter(
+      (_unusedItem, itemIndex) => itemIndex % groupCount === groupIndex,
+    ),
+  );
+};

--- a/apps/web/e2e/helpers/network.ts
+++ b/apps/web/e2e/helpers/network.ts
@@ -462,6 +462,11 @@ const pushNewRequestProblems = ({
   );
 };
 
+// Browser scheduling can split one logical launch burst across the threshold.
+// Keep that bounded +1 allowance; unlike the former response-order metric, the
+// launch-only calculation cannot accumulate arbitrary depth from slow replies.
+const DEPTH_JITTER_ALLOWANCE = 1;
+
 const pushWaterfallDepthProblems = ({
   route,
   entry,
@@ -473,11 +478,11 @@ const pushWaterfallDepthProblems = ({
   metrics: RouteNetworkMetrics;
   problems: string[];
 }) => {
-  if (metrics.depth <= entry.depth) {
+  if (metrics.depth <= entry.depth + DEPTH_JITTER_ALLOWANCE) {
     return;
   }
   problems.push(
-    `Request waterfall got deeper on ${route}: ${entry.depth} -> ${metrics.depth}\n` +
+    `Request waterfall got deeper on ${route}: ${entry.depth} -> ${metrics.depth} (already tolerating +${DEPTH_JITTER_ALLOWANCE} for launch-scheduling jitter)\n` +
       `  Each extra level is one more sequential network round the user waits\n` +
       `  through before the page can finish. Usually the fix is to start the\n` +
       `  query in the route loader (ensureRouteQueryData / prefetchRouteQuery in\n` +

--- a/apps/web/e2e/helpers/network.ts
+++ b/apps/web/e2e/helpers/network.ts
@@ -295,39 +295,44 @@ export const requestKey = ({
   pathname: string;
 }): string => `${method} ${normalizeApiPath(pathname)}`;
 
-// A dependency edge exists only when the next request starts PROMPTLY after
-// the previous response: real render-fetch waterfalls dispatch the next call
-// within milliseconds of the response that unblocked them. Without this cap,
-// an independent idle prefetch firing a second later would coincidentally
-// "chain" after whatever happened to finish before it, making the depth vary
-// with machine load instead of app structure.
-const CHAIN_GAP_MS = 500;
+// Requests launched within one browser scheduling burst belong to the same
+// round. Completion timestamps are deliberately excluded: timing alone cannot
+// prove that one response caused the next request, and a loaded runner can
+// serialize independent responses into an arbitrarily deep false waterfall.
+const REQUEST_BURST_MS = 50;
 
-// Longest chain r1..rn where each next request starts after the previous one
-// ended, within CHAIN_GAP_MS: the number of causally sequential request
-// rounds, i.e. how many times the browser had to wait for a response before
-// it could fire the next call. Sorted by start with an O(n^2) longest-chain
-// DP; n is a handful of requests per route.
+// A request launched after this quiet gap starts a new observation sequence,
+// not another route-load round. This excludes idle prefetches from the route's
+// longest contiguous burst sequence.
+const REQUEST_SEQUENCE_GAP_MS = 500;
+
+// Longest sequence of request-launch bursts. This is a stable lower bound on
+// user-visible request rounds: backend latency and response ordering cannot
+// change it, while a newly deferred request still creates another round.
 export const waterfallDepth = (
   intervals: { start: number; end: number }[],
 ): number => {
-  const sorted = intervals
-    .map((interval) => ({ ...interval, depth: 1 }))
-    .sort((a, b) => a.start - b.start);
+  const starts = intervals.map(({ start }) => start).sort((a, b) => a - b);
+  const firstStart = starts.at(0);
+  if (firstStart === undefined) {
+    return 0;
+  }
 
-  let best = 0;
-  for (const [index, current] of sorted.entries()) {
-    for (let prevIndex = 0; prevIndex < index; prevIndex++) {
-      const prev = sorted[prevIndex];
-      if (
-        prev !== undefined &&
-        current.start >= prev.end &&
-        current.start - prev.end <= CHAIN_GAP_MS
-      ) {
-        current.depth = Math.max(current.depth, prev.depth + 1);
-      }
+  let best = 1;
+  let currentDepth = 1;
+  let burstStartedAt = firstStart;
+  let previousStart = firstStart;
+
+  for (const start of starts.slice(1)) {
+    if (start - previousStart > REQUEST_SEQUENCE_GAP_MS) {
+      currentDepth = 1;
+      burstStartedAt = start;
+    } else if (start - burstStartedAt > REQUEST_BURST_MS) {
+      currentDepth += 1;
+      burstStartedAt = start;
     }
-    best = Math.max(best, current.depth);
+    previousStart = start;
+    best = Math.max(best, currentDepth);
   }
   return best;
 };
@@ -457,13 +462,6 @@ const pushNewRequestProblems = ({
   );
 };
 
-// Under load, independent PARALLEL requests can serialize just enough to land
-// inside CHAIN_GAP_MS and bump the measured depth by one with no change to
-// the request manifest (a quiet CI runner rarely reproduces this; a busy dev
-// machine does). Mirrors dbQueryAllowance's role: tolerate one level of
-// measurement jitter before treating a depth increase as a real regression.
-const DEPTH_JITTER_ALLOWANCE = 1;
-
 const pushWaterfallDepthProblems = ({
   route,
   entry,
@@ -475,11 +473,11 @@ const pushWaterfallDepthProblems = ({
   metrics: RouteNetworkMetrics;
   problems: string[];
 }) => {
-  if (metrics.depth <= entry.depth + DEPTH_JITTER_ALLOWANCE) {
+  if (metrics.depth <= entry.depth) {
     return;
   }
   problems.push(
-    `Request waterfall got deeper on ${route}: ${entry.depth} -> ${metrics.depth} (already tolerating +${DEPTH_JITTER_ALLOWANCE} for parallel-request jitter)\n` +
+    `Request waterfall got deeper on ${route}: ${entry.depth} -> ${metrics.depth}\n` +
       `  Each extra level is one more sequential network round the user waits\n` +
       `  through before the page can finish. Usually the fix is to start the\n` +
       `  query in the route loader (ensureRouteQueryData / prefetchRouteQuery in\n` +

--- a/apps/web/e2e/helpers/network.ts
+++ b/apps/web/e2e/helpers/network.ts
@@ -295,43 +295,42 @@ export const requestKey = ({
   pathname: string;
 }): string => `${method} ${normalizeApiPath(pathname)}`;
 
-// Requests launched within one browser scheduling burst belong to the same
-// round. Completion timestamps are deliberately excluded: timing alone cannot
-// prove that one response caused the next request, and a loaded runner can
-// serialize independent responses into an arbitrarily deep false waterfall.
-const REQUEST_BURST_MS = 50;
-
 // A request launched after this quiet gap starts a new observation sequence,
 // not another route-load round. This excludes idle prefetches from the route's
-// longest contiguous burst sequence.
+// longest contiguous request sequence.
 const REQUEST_SEQUENCE_GAP_MS = 500;
 
-// Longest sequence of request-launch bursts. This is a stable lower bound on
-// user-visible request rounds: backend latency and response ordering cannot
-// change it, while a newly deferred request still creates another round.
+// Longest sequence of non-overlapping request waves. A new round starts only
+// after every request in the current wave has completed. This deliberately
+// computes a lower bound: a request that depends on a fast response can be
+// hidden by an unrelated slow response, but runner load cannot serialize
+// independent completions into a false waterfall. Lengthening any response can
+// only merge rounds, never deepen them.
 export const waterfallDepth = (
   intervals: { start: number; end: number }[],
 ): number => {
-  const starts = intervals.map(({ start }) => start).sort((a, b) => a - b);
-  const firstStart = starts.at(0);
-  if (firstStart === undefined) {
+  const sorted = intervals.toSorted((a, b) => a.start - b.start);
+  const first = sorted.at(0);
+  if (first === undefined) {
     return 0;
   }
 
   let best = 1;
   let currentDepth = 1;
-  let burstStartedAt = firstStart;
-  let previousStart = firstStart;
+  let waveEndsAt = first.end;
 
-  for (const start of starts.slice(1)) {
-    if (start - previousStart > REQUEST_SEQUENCE_GAP_MS) {
-      currentDepth = 1;
-      burstStartedAt = start;
-    } else if (start - burstStartedAt > REQUEST_BURST_MS) {
-      currentDepth += 1;
-      burstStartedAt = start;
+  for (const interval of sorted.slice(1)) {
+    if (interval.start < waveEndsAt) {
+      waveEndsAt = Math.max(waveEndsAt, interval.end);
+      continue;
     }
-    previousStart = start;
+
+    if (interval.start - waveEndsAt > REQUEST_SEQUENCE_GAP_MS) {
+      currentDepth = 1;
+    } else {
+      currentDepth += 1;
+    }
+    waveEndsAt = interval.end;
     best = Math.max(best, currentDepth);
   }
   return best;
@@ -462,9 +461,9 @@ const pushNewRequestProblems = ({
   );
 };
 
-// Browser scheduling can split one logical launch burst across the threshold.
-// Keep that bounded +1 allowance; unlike the former response-order metric, the
-// launch-only calculation cannot accumulate arbitrary depth from slow replies.
+// Browser scheduling can still split one logical wave at its boundary. Keep a
+// bounded +1 allowance; the wave calculation itself is monotonic under slower
+// responses, so load cannot accumulate arbitrary false depth.
 const DEPTH_JITTER_ALLOWANCE = 1;
 
 const pushWaterfallDepthProblems = ({
@@ -482,7 +481,7 @@ const pushWaterfallDepthProblems = ({
     return;
   }
   problems.push(
-    `Request waterfall got deeper on ${route}: ${entry.depth} -> ${metrics.depth} (already tolerating +${DEPTH_JITTER_ALLOWANCE} for launch-scheduling jitter)\n` +
+    `Request waterfall got deeper on ${route}: ${entry.depth} -> ${metrics.depth} (already tolerating +${DEPTH_JITTER_ALLOWANCE} for wave-boundary jitter)\n` +
       `  Each extra level is one more sequential network round the user waits\n` +
       `  through before the page can finish. Usually the fix is to start the\n` +
       `  query in the route loader (ensureRouteQueryData / prefetchRouteQuery in\n` +

--- a/apps/web/e2e/playwright.config.ts
+++ b/apps/web/e2e/playwright.config.ts
@@ -1,6 +1,8 @@
 import { defineConfig, devices } from "@playwright/test";
 import path from "node:path";
 
+import { resolveE2eExecutionProfile } from "./execution-profile";
+
 // Mirrors apps/api/scripts/seed-test-user.ts:349 — repo-root .playwright/
 const REPO_ROOT = path.resolve(import.meta.dirname, "../../..");
 const STORAGE_STATE = path.resolve(REPO_ROOT, ".playwright/storage-state.json");
@@ -8,14 +10,16 @@ const STORAGE_STATE = path.resolve(REPO_ROOT, ".playwright/storage-state.json");
 const WEB_BASE_URL = process.env["E2E_WEB_URL"] ?? "http://localhost:3000";
 const API_BASE_URL = process.env["E2E_API_URL"] ?? "http://localhost:3001";
 const IS_CI = process.env["CI"] !== undefined;
+const executionProfile = resolveE2eExecutionProfile(
+  process.env["E2E_EXECUTION_PROFILE"],
+);
 
 export default defineConfig({
   testDir: "./specs",
-  // Each spec creates and tears down its own workspace, so parallelism is
-  // safe. CI parallelizes across isolated two-way shards; each runner keeps a
-  // single worker so Postgres, MinIO, and Chromium do not contend for 2 cores.
+  // The production CI profile pairs two workers with four isolated route-smoke
+  // groups. Other CI checks stay single-worker; local runs retain four workers.
   fullyParallel: true,
-  workers: IS_CI ? 1 : 4,
+  workers: IS_CI ? executionProfile.workerCount : 4,
   // CI failures are almost always real (server logs, traces tell the story).
   // Retries hide flakes; fix them in code instead.
   retries: 0,

--- a/apps/web/e2e/specs/route-smoke.spec.ts
+++ b/apps/web/e2e/specs/route-smoke.spec.ts
@@ -9,6 +9,10 @@ import { randomUUID } from "node:crypto";
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 
+import {
+  partitionRoundRobin,
+  resolveE2eExecutionProfile,
+} from "../execution-profile";
 import { apiDelete, apiGet, apiPut, apiUploadDocx } from "../helpers/api";
 import {
   type RouteNetworkMetrics,
@@ -342,17 +346,18 @@ test("route coverage matches the authenticated route tree", async () => {
 const baselineMode = process.env["E2E_NETWORK_BASELINE"];
 if (baselineMode === "write" || baselineMode === "rewrite") {
   // Baseline writes need one complete result set and one writer. Normal checks
-  // use two groups below because each independently compares its observed
-  // routes against the same committed per-route budgets.
+  // use isolated groups because each independently compares its observed routes
+  // against the same committed per-route budgets.
   declareRouteSmokeGroup({
     defs: SMOKE_ROUTE_DEFS,
     name: "authenticated routes render without browser errors",
     requireAllRoutes: true,
   });
 } else {
-  const groups = [0, 1].map((groupIndex) =>
-    SMOKE_ROUTE_DEFS.filter((_, index) => index % 2 === groupIndex),
+  const { routeSmokeGroupCount } = resolveE2eExecutionProfile(
+    process.env["E2E_EXECUTION_PROFILE"],
   );
+  const groups = partitionRoundRobin(SMOKE_ROUTE_DEFS, routeSmokeGroupCount);
   for (const [groupIndex, defs] of groups.entries()) {
     declareRouteSmokeGroup({
       defs,

--- a/apps/web/e2e/unit/execution-profile.test.ts
+++ b/apps/web/e2e/unit/execution-profile.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  E2E_EXECUTION_PROFILE,
+  partitionRoundRobin,
+  resolveE2eExecutionProfile,
+} from "../execution-profile";
+
+describe("E2E execution profiles", () => {
+  test("keeps the standard checks single-worker", () => {
+    expect(resolveE2eExecutionProfile(undefined)).toEqual({
+      routeSmokeGroupCount: 2,
+      workerCount: 1,
+    });
+  });
+
+  test("pairs two production workers with four independent route groups", () => {
+    expect(
+      resolveE2eExecutionProfile(E2E_EXECUTION_PROFILE.ciProductionParallel),
+    ).toEqual({
+      routeSmokeGroupCount: 4,
+      workerCount: 2,
+    });
+  });
+
+  test("rejects unknown profiles at the environment boundary", () => {
+    expect(() => resolveE2eExecutionProfile("typo")).toThrow(
+      "Unknown E2E execution profile: typo",
+    );
+  });
+});
+
+describe("round-robin route groups", () => {
+  test("preserve every item exactly once with balanced group sizes", () => {
+    for (let itemCount = 0; itemCount <= 64; itemCount += 1) {
+      const items = Array.from({ length: itemCount }, (_, index) => index);
+      for (let groupCount = 1; groupCount <= 8; groupCount += 1) {
+        const groups = partitionRoundRobin(items, groupCount);
+        const sizes = groups.map((group) => group.length);
+
+        expect(groups).toHaveLength(groupCount);
+        expect(groups.flat().toSorted((left, right) => left - right)).toEqual(
+          items,
+        );
+        expect(Math.max(...sizes) - Math.min(...sizes)).toBeLessThanOrEqual(1);
+      }
+    }
+  });
+
+  test("rejects invalid group counts", () => {
+    for (const groupCount of [0, -1, 1.5, Number.POSITIVE_INFINITY]) {
+      expect(() => partitionRoundRobin([], groupCount)).toThrow(
+        "E2E group count must be a positive safe integer",
+      );
+    }
+  });
+});

--- a/apps/web/e2e/unit/network-metrics.test.ts
+++ b/apps/web/e2e/unit/network-metrics.test.ts
@@ -51,30 +51,29 @@ describe("waterfallDepth", () => {
     ).toBe(1);
   });
 
-  test("a strict chain is n rounds", () => {
+  test("distinct launch bursts are separate rounds", () => {
     expect(
       waterfallDepth([
-        { start: 0, end: 10 },
-        { start: 10, end: 20 },
-        { start: 20, end: 30 },
+        { start: 0, end: 75 },
+        { start: 75, end: 150 },
+        { start: 150, end: 225 },
       ]),
     ).toBe(3);
   });
 
-  test("mixed overlap counts only the sequential rounds", () => {
-    // Two parallel at the start, then one that waits for both.
+  test("mixed launch bursts count only distinct rounds", () => {
     expect(
       waterfallDepth([
-        { start: 0, end: 10 },
-        { start: 0, end: 12 },
-        { start: 12, end: 20 },
+        { start: 0, end: 100 },
+        { start: 2, end: 12 },
+        { start: 75, end: 100 },
       ]),
     ).toBe(2);
   });
 
   test("an independent late request does not chain", () => {
-    // Gap between the first response and the late request exceeds the causal
-    // window, so this is an idle prefetch, not a waterfall round.
+    // A quiet gap between launches makes this an idle prefetch, not another
+    // route-load round.
     expect(
       waterfallDepth([
         { start: 0, end: 10 },
@@ -83,15 +82,29 @@ describe("waterfallDepth", () => {
     ).toBe(1);
   });
 
-  test("a pending tail (end = now) extends the chain by one", () => {
-    const now = 1000;
-    expect(
-      waterfallDepth([
-        { start: 0, end: 10 },
-        { start: 10, end: 20 },
-        { start: 20, end: now },
-      ]),
-    ).toBe(3);
+  test("response-timing property cannot change launch rounds", () => {
+    const starts = [0, 2, 4, 75, 77, 150];
+    for (let seed = 1; seed <= 256; seed++) {
+      let state = seed;
+      const intervals = starts.map((start) => {
+        state = (state * 48_271) % 2_147_483_647;
+        return { start, end: start + (state % 1000) };
+      });
+      expect(waterfallDepth(intervals)).toBe(3);
+    }
+  });
+
+  test("interval order cannot change launch rounds", () => {
+    const intervals = [
+      { start: 0, end: 500 },
+      { start: 2, end: 10 },
+      { start: 75, end: 80 },
+      { start: 77, end: 90 },
+      { start: 150, end: 155 },
+    ];
+
+    expect(waterfallDepth(intervals)).toBe(3);
+    expect(waterfallDepth(intervals.toReversed())).toBe(3);
   });
 });
 
@@ -219,25 +232,12 @@ describe("diffNetworkBaseline", () => {
     expect(problems.some((p) => p.includes("GET /v1/contacts/:id"))).toBe(true);
   });
 
-  test("a waterfall within the jitter allowance passes", () => {
-    // baseline depth 2 + DEPTH_JITTER_ALLOWANCE (1) = 3: parallel-request
-    // serialization jitter under load, not a real regression.
+  test("a deeper waterfall is a problem", () => {
     const { problems } = diffNetworkBaseline(
       baseline,
       new Map([["/contacts", metrics(["GET /v1/contacts"], 3)]]),
     );
-    expect(problems).toEqual([]);
-  });
-
-  test("a waterfall beyond the jitter allowance is a problem", () => {
-    const { problems } = diffNetworkBaseline(
-      baseline,
-      new Map([["/contacts", metrics(["GET /v1/contacts"], 4)]]),
-    );
-    expect(problems.some((p) => p.includes("2 -> 4"))).toBe(true);
-    expect(problems.some((p) => p.includes("already tolerating +1"))).toBe(
-      true,
-    );
+    expect(problems.some((p) => p.includes("2 -> 3"))).toBe(true);
   });
 
   test("a repeated API request is a problem", () => {

--- a/apps/web/e2e/unit/network-metrics.test.ts
+++ b/apps/web/e2e/unit/network-metrics.test.ts
@@ -263,9 +263,7 @@ describe("diffNetworkBaseline", () => {
       new Map([["/contacts", metrics(["GET /v1/contacts"], 4)]]),
     );
     expect(problems.some((p) => p.includes("2 -> 4"))).toBe(true);
-    expect(
-      problems.some((p) => p.includes("wave-boundary jitter")),
-    ).toBe(true);
+    expect(problems.some((p) => p.includes("wave-boundary jitter"))).toBe(true);
   });
 
   test("a repeated API request is a problem", () => {

--- a/apps/web/e2e/unit/network-metrics.test.ts
+++ b/apps/web/e2e/unit/network-metrics.test.ts
@@ -51,24 +51,35 @@ describe("waterfallDepth", () => {
     ).toBe(1);
   });
 
-  test("distinct launch bursts are separate rounds", () => {
+  test("distinct non-overlapping waves are separate rounds", () => {
     expect(
       waterfallDepth([
-        { start: 0, end: 75 },
-        { start: 75, end: 150 },
-        { start: 150, end: 225 },
+        { start: 0, end: 10 },
+        { start: 10, end: 20 },
+        { start: 20, end: 30 },
       ]),
     ).toBe(3);
   });
 
-  test("mixed launch bursts count only distinct rounds", () => {
+  test("mixed overlap counts only distinct waves", () => {
     expect(
       waterfallDepth([
         { start: 0, end: 100 },
         { start: 2, end: 12 },
-        { start: 75, end: 100 },
+        { start: 100, end: 120 },
       ]),
     ).toBe(2);
+  });
+
+  test("a long parallel request prevents false chains through fast replies", () => {
+    expect(
+      waterfallDepth([
+        { start: 0, end: 500 },
+        { start: 2, end: 10 },
+        { start: 10, end: 20 },
+        { start: 20, end: 30 },
+      ]),
+    ).toBe(1);
   });
 
   test("an independent late request does not chain", () => {
@@ -82,25 +93,31 @@ describe("waterfallDepth", () => {
     ).toBe(1);
   });
 
-  test("response-timing property cannot change launch rounds", () => {
-    const starts = [0, 2, 4, 75, 77, 150];
+  test("slower-response property cannot deepen a waterfall", () => {
+    const starts = [0, 2, 75, 77, 150, 225];
     for (let seed = 1; seed <= 256; seed++) {
       let state = seed;
       const intervals = starts.map((start) => {
         state = (state * 48_271) % 2_147_483_647;
-        return { start, end: start + (state % 1000) };
+        return { start, end: start + 1 + (state % 100) };
       });
-      expect(waterfallDepth(intervals)).toBe(3);
+      const slowerIntervals = intervals.map(({ start, end }) => {
+        state = (state * 48_271) % 2_147_483_647;
+        return { start, end: end + (state % 1000) };
+      });
+      expect(waterfallDepth(slowerIntervals)).toBeLessThanOrEqual(
+        waterfallDepth(intervals),
+      );
     }
   });
 
   test("interval order cannot change launch rounds", () => {
     const intervals = [
-      { start: 0, end: 500 },
-      { start: 2, end: 10 },
-      { start: 75, end: 80 },
-      { start: 77, end: 90 },
-      { start: 150, end: 155 },
+      { start: 0, end: 10 },
+      { start: 2, end: 12 },
+      { start: 12, end: 20 },
+      { start: 15, end: 25 },
+      { start: 25, end: 35 },
     ];
 
     expect(waterfallDepth(intervals)).toBe(3);
@@ -232,7 +249,7 @@ describe("diffNetworkBaseline", () => {
     expect(problems.some((p) => p.includes("GET /v1/contacts/:id"))).toBe(true);
   });
 
-  test("a waterfall within the launch-jitter allowance passes", () => {
+  test("a waterfall within the wave-boundary allowance passes", () => {
     const { problems } = diffNetworkBaseline(
       baseline,
       new Map([["/contacts", metrics(["GET /v1/contacts"], 3)]]),
@@ -240,14 +257,14 @@ describe("diffNetworkBaseline", () => {
     expect(problems).toEqual([]);
   });
 
-  test("a waterfall beyond the launch-jitter allowance is a problem", () => {
+  test("a waterfall beyond the wave-boundary allowance is a problem", () => {
     const { problems } = diffNetworkBaseline(
       baseline,
       new Map([["/contacts", metrics(["GET /v1/contacts"], 4)]]),
     );
     expect(problems.some((p) => p.includes("2 -> 4"))).toBe(true);
     expect(
-      problems.some((p) => p.includes("launch-scheduling jitter")),
+      problems.some((p) => p.includes("wave-boundary jitter")),
     ).toBe(true);
   });
 

--- a/apps/web/e2e/unit/network-metrics.test.ts
+++ b/apps/web/e2e/unit/network-metrics.test.ts
@@ -232,12 +232,23 @@ describe("diffNetworkBaseline", () => {
     expect(problems.some((p) => p.includes("GET /v1/contacts/:id"))).toBe(true);
   });
 
-  test("a deeper waterfall is a problem", () => {
+  test("a waterfall within the launch-jitter allowance passes", () => {
     const { problems } = diffNetworkBaseline(
       baseline,
       new Map([["/contacts", metrics(["GET /v1/contacts"], 3)]]),
     );
-    expect(problems.some((p) => p.includes("2 -> 3"))).toBe(true);
+    expect(problems).toEqual([]);
+  });
+
+  test("a waterfall beyond the launch-jitter allowance is a problem", () => {
+    const { problems } = diffNetworkBaseline(
+      baseline,
+      new Map([["/contacts", metrics(["GET /v1/contacts"], 4)]]),
+    );
+    expect(problems.some((p) => p.includes("2 -> 4"))).toBe(true);
+    expect(
+      problems.some((p) => p.includes("launch-scheduling jitter")),
+    ).toBe(true);
   });
 
   test("a repeated API request is a problem", () => {

--- a/scripts/detect-e2e-changes.test.ts
+++ b/scripts/detect-e2e-changes.test.ts
@@ -92,10 +92,14 @@ describe("detect-e2e-changes", () => {
 
   test("keeps production, Vite canary, and landing work parallel", () => {
     const production = workflowJob("e2e-production-shard");
+    expect(production).toContain(
+      "E2E_EXECUTION_PROFILE: ci-production-parallel",
+    );
     expect(production).not.toContain("Run Vite dependency canary");
     expect(production).not.toContain("Check landing islands");
 
     const canary = workflowJob("e2e-vite-canary");
+    expect(canary).not.toContain("E2E_EXECUTION_PROFILE");
     expect(canary).not.toContain("Build web for route checks");
     expect(canary).not.toContain("Run Playwright shard");
 

--- a/scripts/detect-e2e-changes.test.ts
+++ b/scripts/detect-e2e-changes.test.ts
@@ -188,4 +188,11 @@ describe("detect-e2e-changes", () => {
     expect(playwrightSetup).toContain("if verify_chromium; then");
     expect(playwrightSetup).toContain("bunx playwright install-deps chromium");
   });
+
+  test("uploads blob reports from the configured Playwright output directory", () => {
+    expect(
+      workflow.match(/path: apps\/web\/e2e\/test-results\/blob-report\//gu),
+    ).toHaveLength(2);
+    expect(workflow).not.toContain("path: apps/web/test-results/blob-report/");
+  });
 });

--- a/scripts/detect-e2e-changes.test.ts
+++ b/scripts/detect-e2e-changes.test.ts
@@ -147,14 +147,21 @@ describe("detect-e2e-changes", () => {
     );
   });
 
-  test("shares a version-keyed Playwright browser cache across browser jobs", () => {
+  test("shares and launch-verifies a version-keyed browser cache", () => {
     expect(
       workflow.match(/uses: \.\/\.github\/actions\/setup-playwright/gu),
     ).toHaveLength(3);
     expect(nightlyWorkflow).toContain(
-      "uses: ./.github/actions/setup-playwright",
+      [
+        "uses: ./.github/actions/setup-playwright",
+        "        with:",
+        "          dependency-mode: full",
+      ].join("\n"),
     );
-    expect(playwrightSetup).toContain("bunx playwright --version");
+    expect(playwrightSetup).toContain(
+      'import metadata from "@playwright/test/package.json"',
+    );
+    expect(playwrightSetup).not.toContain("bunx playwright --version");
     expect(playwrightSetup).toContain("~/.cache/ms-playwright");
     expect(playwrightSetup).toContain(
       [
@@ -167,5 +174,18 @@ describe("detect-e2e-changes", () => {
     expect(playwrightSetup).toContain(
       "actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae",
     );
+    expect(playwrightSetup).toContain("id: browser-cache");
+    expect(playwrightSetup).toContain("full|launch-verified");
+    expect(playwrightSetup).toContain(
+      "if: steps.browser-cache.outputs.cache-hit != 'true'",
+    );
+    expect(playwrightSetup).toContain(
+      "if: steps.browser-cache.outputs.cache-hit == 'true' && inputs.dependency-mode == 'full'",
+    );
+    expect(playwrightSetup).toContain(
+      `PLAYWRIGHT_CACHE_HIT: ${githubExpression("steps.browser-cache.outputs.cache-hit")}`,
+    );
+    expect(playwrightSetup).toContain("if verify_chromium; then");
+    expect(playwrightSetup).toContain("bunx playwright install-deps chromium");
   });
 });


### PR DESCRIPTION
## Summary

- run production route smoke with two Playwright workers across four isolated, balanced groups
- skip redundant Playwright OS-dependency installation on warm cache hits while launch-verifying Chromium; retain the full dependency/font setup for nightly screenshots
- upload Playwright blob reports from the configured output directory so failures retain traces
- measure network waterfalls as complete request waves, with a property test proving slower responses cannot manufacture deeper waterfalls

## Measurements

Warm baseline from #1556:
- Playwright shards: 76s / 90s
- production E2E jobs: 2m54 / 3m11

Final green CI, trial 1:
- Playwright browser setup: 5s / 4s
- Playwright shards: 55s / 59s
- production E2E jobs: 2m21 / 2m24

Final green CI after rebasing onto main, trial 2:
- Playwright browser setup: 6s / 4s
- Playwright shards: 56s / 66s
- production E2E jobs: 2m32 / 2m41

Across both final green trials, browser setup falls from a prior warm average of 21s to 4.75s: 16.25s saved per browser job (77%). Compared with #1556, Playwright execution averages 29% lower and production-job duration averages 18% lower. The critical path falls by 30–47s (3m11 to 2m24–2m41, 16–25%).

## Validation

- complete green CI on the final commit, including both production shards, aggregate report, format, lint/type-aware code quality, typecheck baseline, CodeQL, and dependency review
- property invariant over 256 response schedules: increasing response latency cannot deepen the measured request waterfall
- Playwright report artifacts verified for both production shards and the Vite canary
- security audit: no new high or critical findings
