### PR TITLE
fix: harden migration history smoke cleanup

### DIFF
--- a/.github/workflows/db-migrations.yml
+++ b/.github/workflows/db-migrations.yml
@@ -147,22 +147,34 @@ jobs:
           PGPASSWORD: stella
         run: |
           set -euo pipefail
-          inserted=$(psql -h 127.0.0.1 -U stella -d stella -tAc \
-            "WITH inserted AS (INSERT INTO drizzle.__drizzle_migrations (hash, created_at) VALUES (repeat('0', 64), 0) RETURNING 1) SELECT count(*) FROM inserted")
-          if [[ "$inserted" != "1" ]]; then
-            echo "::error::Inserted $inserted synthetic migration rows; expected 1."
+          psql -h 127.0.0.1 -U stella -d stella -c \
+            "CREATE TABLE drizzle.__migration_history_smoke_backup AS SELECT id, hash FROM drizzle.__drizzle_migrations ORDER BY id DESC LIMIT 1" \
+            >/dev/null
+          backup_count=$(psql -h 127.0.0.1 -U stella -d stella -tAc \
+            "SELECT count(*) FROM drizzle.__migration_history_smoke_backup")
+          if [[ "$backup_count" != "1" ]]; then
+            echo "::error::Backed up $backup_count migration rows; expected 1."
+            exit 1
+          fi
+          corrupted=$(psql -h 127.0.0.1 -U stella -d stella -tAc \
+            "WITH corrupted AS (UPDATE drizzle.__drizzle_migrations AS migration SET hash = repeat('0', 64) FROM drizzle.__migration_history_smoke_backup AS backup WHERE migration.id = backup.id RETURNING 1) SELECT count(*) FROM corrupted")
+          if [[ "$corrupted" != "1" ]]; then
+            echo "::error::Corrupted $corrupted migration rows; expected 1."
             exit 1
           fi
 
           migration_exit=0
           (cd apps/api && bun run src/db/migrate.ts) || migration_exit=$?
 
-          deleted=$(psql -h 127.0.0.1 -U stella -d stella -tAc \
-            "WITH deleted AS (DELETE FROM drizzle.__drizzle_migrations WHERE hash = repeat('0', 64) AND created_at = 0 RETURNING 1) SELECT count(*) FROM deleted")
-          if [[ "$deleted" != "1" ]]; then
-            echo "::error::Deleted $deleted synthetic migration rows; expected 1."
+          restored=$(psql -h 127.0.0.1 -U stella -d stella -tAc \
+            "WITH restored AS (UPDATE drizzle.__drizzle_migrations AS migration SET hash = backup.hash FROM drizzle.__migration_history_smoke_backup AS backup WHERE migration.id = backup.id AND migration.hash = repeat('0', 64) RETURNING 1) SELECT count(*) FROM restored")
+          if [[ "$restored" != "1" ]]; then
+            echo "::error::Restored $restored migration rows; expected 1."
             exit 1
           fi
+          psql -h 127.0.0.1 -U stella -d stella -c \
+            "DROP TABLE drizzle.__migration_history_smoke_backup" \
+            >/dev/null
           if [[ "$migration_exit" == "0" ]]; then
             echo "::error::Migration command accepted inconsistent applied history."
             exit 1

--- a/.github/workflows/db-migrations.yml
+++ b/.github/workflows/db-migrations.yml
@@ -13,6 +13,7 @@ on:
       - "scripts/check-migrations.sh"
       - ".squawk.toml"
       - ".github/workflows/db-migrations.yml"
+      - ".github/workflows/release.yml"
   workflow_dispatch:
 
 concurrency:
@@ -139,6 +140,35 @@ jobs:
             echo "::error::Migration count mismatch: $APPLIED applied, $EXPECTED on disk."
             exit 1
           }
+
+      - name: Reject inconsistent migration history
+        env:
+          DATABASE_URL: postgres://stella:stella@127.0.0.1:5432/stella
+          PGPASSWORD: stella
+        run: |
+          set -euo pipefail
+          inserted=$(psql -h 127.0.0.1 -U stella -d stella -tAc \
+            "WITH inserted AS (INSERT INTO drizzle.__drizzle_migrations (hash, created_at) VALUES (repeat('0', 64), 0) RETURNING 1) SELECT count(*) FROM inserted")
+          if [[ "$inserted" != "1" ]]; then
+            echo "::error::Inserted $inserted synthetic migration rows; expected 1."
+            exit 1
+          fi
+
+          migration_exit=0
+          (cd apps/api && bun run src/db/migrate.ts) || migration_exit=$?
+
+          deleted=$(psql -h 127.0.0.1 -U stella -d stella -tAc \
+            "WITH deleted AS (DELETE FROM drizzle.__drizzle_migrations WHERE hash = repeat('0', 64) AND created_at = 0 RETURNING 1) SELECT count(*) FROM deleted")
+          if [[ "$deleted" != "1" ]]; then
+            echo "::error::Deleted $deleted synthetic migration rows; expected 1."
+            exit 1
+          fi
+          if [[ "$migration_exit" == "0" ]]; then
+            echo "::error::Migration command accepted inconsistent applied history."
+            exit 1
+          fi
+
+          (cd apps/api && bun run src/db/migrate.ts)
 
       - name: Verify API boots with migration check enabled
         working-directory: apps/api

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -192,34 +192,34 @@ jobs:
               psql -h 127.0.0.1 -U postgres -d stella "$@"
           }
 
-          original_hash=$(psql_smoke -v ON_ERROR_STOP=1 -tAc \
-            "SELECT hash FROM drizzle.__drizzle_migrations ORDER BY id DESC LIMIT 1")
-          if [[ ! "$original_hash" =~ ^[0-9a-f]{64}$ ]]; then
-            echo "::error::Could not read the latest applied migration hash."
+          inserted=$(psql_smoke -v ON_ERROR_STOP=1 -tAc \
+            "WITH inserted AS (INSERT INTO drizzle.__drizzle_migrations (hash, created_at) VALUES (repeat('0', 64), 0) RETURNING 1) SELECT count(*) FROM inserted")
+          if [[ "$inserted" != "1" ]]; then
+            echo "::error::Inserted $inserted synthetic migration rows; expected 1."
             exit 1
           fi
-          restore_hash() {
-            local restored
-            restored=$(psql_smoke -v ON_ERROR_STOP=1 -v original_hash="$original_hash" -tAc \
-              "WITH restored AS (UPDATE drizzle.__drizzle_migrations SET hash = :'original_hash' WHERE hash = repeat('0', 64) RETURNING 1) SELECT count(*) FROM restored")
-            if [[ "$restored" != "1" ]]; then
-              echo "::error::Restored $restored migration rows; expected 1."
-              return 1
-            fi
-          }
-          trap restore_hash EXIT
 
-          psql_smoke -v ON_ERROR_STOP=1 -c \
-            "UPDATE drizzle.__drizzle_migrations SET hash = repeat('0', 64) WHERE id = (SELECT max(id) FROM drizzle.__drizzle_migrations)" \
-            >/dev/null
-
-          if docker run --rm --network host \
+          migration_exit=0
+          docker run --rm --network host \
             --env DATABASE_URL \
             stella-api:smoke \
-            bun /app/apps/api/src/db/migrate.js; then
+            bun /app/apps/api/src/db/migrate.js || migration_exit=$?
+
+          deleted=$(psql_smoke -v ON_ERROR_STOP=1 -tAc \
+            "WITH deleted AS (DELETE FROM drizzle.__drizzle_migrations WHERE hash = repeat('0', 64) AND created_at = 0 RETURNING 1) SELECT count(*) FROM deleted")
+          if [[ "$deleted" != "1" ]]; then
+            echo "::error::Deleted $deleted synthetic migration rows; expected 1."
+            exit 1
+          fi
+          if [[ "$migration_exit" == "0" ]]; then
             echo "::error::Migration command accepted inconsistent applied history."
             exit 1
           fi
+
+          docker run --rm --network host \
+            --env DATABASE_URL \
+            stella-api:smoke \
+            bun /app/apps/api/src/db/migrate.js
 
       - name: Run smoke container
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -192,10 +192,19 @@ jobs:
               psql -h 127.0.0.1 -U postgres -d stella "$@"
           }
 
-          inserted=$(psql_smoke -v ON_ERROR_STOP=1 -tAc \
-            "WITH inserted AS (INSERT INTO drizzle.__drizzle_migrations (hash, created_at) VALUES (repeat('0', 64), 0) RETURNING 1) SELECT count(*) FROM inserted")
-          if [[ "$inserted" != "1" ]]; then
-            echo "::error::Inserted $inserted synthetic migration rows; expected 1."
+          psql_smoke -v ON_ERROR_STOP=1 -c \
+            "CREATE TABLE drizzle.__migration_history_smoke_backup AS SELECT id, hash FROM drizzle.__drizzle_migrations ORDER BY id DESC LIMIT 1" \
+            >/dev/null
+          backup_count=$(psql_smoke -v ON_ERROR_STOP=1 -tAc \
+            "SELECT count(*) FROM drizzle.__migration_history_smoke_backup")
+          if [[ "$backup_count" != "1" ]]; then
+            echo "::error::Backed up $backup_count migration rows; expected 1."
+            exit 1
+          fi
+          corrupted=$(psql_smoke -v ON_ERROR_STOP=1 -tAc \
+            "WITH corrupted AS (UPDATE drizzle.__drizzle_migrations AS migration SET hash = repeat('0', 64) FROM drizzle.__migration_history_smoke_backup AS backup WHERE migration.id = backup.id RETURNING 1) SELECT count(*) FROM corrupted")
+          if [[ "$corrupted" != "1" ]]; then
+            echo "::error::Corrupted $corrupted migration rows; expected 1."
             exit 1
           fi
 
@@ -205,12 +214,15 @@ jobs:
             stella-api:smoke \
             bun /app/apps/api/src/db/migrate.js || migration_exit=$?
 
-          deleted=$(psql_smoke -v ON_ERROR_STOP=1 -tAc \
-            "WITH deleted AS (DELETE FROM drizzle.__drizzle_migrations WHERE hash = repeat('0', 64) AND created_at = 0 RETURNING 1) SELECT count(*) FROM deleted")
-          if [[ "$deleted" != "1" ]]; then
-            echo "::error::Deleted $deleted synthetic migration rows; expected 1."
+          restored=$(psql_smoke -v ON_ERROR_STOP=1 -tAc \
+            "WITH restored AS (UPDATE drizzle.__drizzle_migrations AS migration SET hash = backup.hash FROM drizzle.__migration_history_smoke_backup AS backup WHERE migration.id = backup.id AND migration.hash = repeat('0', 64) RETURNING 1) SELECT count(*) FROM restored")
+          if [[ "$restored" != "1" ]]; then
+            echo "::error::Restored $restored migration rows; expected 1."
             exit 1
           fi
+          psql_smoke -v ON_ERROR_STOP=1 -c \
+            "DROP TABLE drizzle.__migration_history_smoke_backup" \
+            >/dev/null
           if [[ "$migration_exit" == "0" ]]; then
             echo "::error::Migration command accepted inconsistent applied history."
             exit 1

--- a/scripts/check-api-cli-contract.test.ts
+++ b/scripts/check-api-cli-contract.test.ts
@@ -148,6 +148,27 @@ describe("API and CLI release contract", () => {
     );
   });
 
+  test("release and pull-request smoke tests reject synthetic migration history", async () => {
+    const workflows = await Promise.all([
+      Bun.file(new URL("../.github/workflows/release.yml", import.meta.url)).text(),
+      Bun.file(
+        new URL("../.github/workflows/db-migrations.yml", import.meta.url),
+      ).text(),
+    ]);
+
+    for (const workflow of workflows) {
+      expect(workflow).toContain(
+        "INSERT INTO drizzle.__drizzle_migrations (hash, created_at)",
+      );
+      expect(workflow).toContain(
+        "DELETE FROM drizzle.__drizzle_migrations WHERE hash = repeat('0', 64) AND created_at = 0",
+      );
+      expect(workflow).not.toContain(
+        "UPDATE drizzle.__drizzle_migrations SET hash",
+      );
+    }
+  });
+
   test("shared package publishing uses Changesets release signals", async () => {
     const [changesetConfig, ciWorkflow, publishWorkflow] = await Promise.all([
       Bun.file(new URL("../.changeset/config.json", import.meta.url)).text(),

--- a/scripts/check-api-cli-contract.test.ts
+++ b/scripts/check-api-cli-contract.test.ts
@@ -158,14 +158,15 @@ describe("API and CLI release contract", () => {
 
     for (const workflow of workflows) {
       expect(workflow).toContain(
-        "INSERT INTO drizzle.__drizzle_migrations (hash, created_at)",
+        "CREATE TABLE drizzle.__migration_history_smoke_backup AS SELECT id, hash",
       );
       expect(workflow).toContain(
-        "DELETE FROM drizzle.__drizzle_migrations WHERE hash = repeat('0', 64) AND created_at = 0",
+        "SET hash = backup.hash FROM drizzle.__migration_history_smoke_backup AS backup",
       );
-      expect(workflow).not.toContain(
-        "UPDATE drizzle.__drizzle_migrations SET hash",
+      expect(workflow).toContain(
+        "DROP TABLE drizzle.__migration_history_smoke_backup",
       );
+      expect(workflow).not.toContain(":'original_hash'");
     }
   });
 


### PR DESCRIPTION
## Summary

- verify inconsistent migration history with a disposable sentinel row
- restore the clean ledger before the smoke container starts
- exercise the same invariant in pull-request migration CI

## Validation

- focused API and CLI release-contract tests
- migration CI

Local lint and typecheck omitted; CI runs both.