### PR TITLE
chore: automate maintenance release preparation

### DIFF
--- a/.github/actions/promote-dispatch/action.yml
+++ b/.github/actions/promote-dispatch/action.yml
@@ -91,11 +91,11 @@ runs:
           )"
           unsigned="${header}.${payload}"
           signature="$(
-            openssl dgst -sha256 -sign <(printf '%s' "$APP_PRIVATE_KEY") \
+            openssl dgst -sha256 -sign <(printf '%s\n' "$APP_PRIVATE_KEY") \
               <(printf '%s' "$unsigned") | base64url
           )"
           jwt="${unsigned}.${signature}"
-          echo "::add-mask::${jwt}"
+          echo "::add-mask::${jwt}" >&2
 
           installation_id="$(
             GH_TOKEN="$jwt" gh api -H "Authorization: Bearer ${jwt}" \
@@ -224,7 +224,7 @@ runs:
           exit 1
         fi
 
-        run_url="${INFRA_REPO}/actions/runs/${run_id}"
+        run_url="https://github.com/${INFRA_REPO}/actions/runs/${run_id}"
         consecutive_read_failures=0
         echo "Watching run ${run_id}..."
         while true; do
@@ -240,7 +240,7 @@ runs:
           )"; then
             consecutive_read_failures=$((consecutive_read_failures + 1))
             if (( consecutive_read_failures >= 3 )); then
-              echo "::error::Lost track of promote run ${run_id} after ${consecutive_read_failures} consecutive API failures. Check https://github.com/${run_url}" >&2
+              echo "::error::Lost track of promote run ${run_id} after ${consecutive_read_failures} consecutive API failures. Check ${run_url}" >&2
               exit 1
             fi
             echo "Run status lookup failed (${consecutive_read_failures}/3); retrying..."

--- a/.github/actions/promote-dispatch/action.yml
+++ b/.github/actions/promote-dispatch/action.yml
@@ -7,8 +7,11 @@ description: >
   cannot say what broke.
 
 inputs:
-  token:
-    description: App token with actions:write on the infra repository
+  app-client-id:
+    description: Client ID for the GitHub App installed on the target repository
+    required: true
+  app-private-key:
+    description: Private key for minting short-lived installation tokens
     required: true
   infra-repo:
     description: owner/name of the repository hosting the promote workflow
@@ -53,7 +56,8 @@ runs:
     - name: Dispatch and watch promote-release.yml
       shell: bash
       env:
-        GH_TOKEN: ${{ inputs.token }}
+        APP_CLIENT_ID: ${{ inputs.app-client-id }}
+        APP_PRIVATE_KEY: ${{ inputs.app-private-key }}
         INFRA_REPO: ${{ inputs.infra-repo }}
         WORKFLOW_FILE: ${{ inputs.workflow-file }}
         RELEASE_REF: ${{ inputs.release-ref }}
@@ -64,6 +68,88 @@ runs:
         GIT_SHA: ${{ inputs.git-sha }}
       run: |
         set -euo pipefail
+
+        readonly TOKEN_REFRESH_SECONDS=2700
+        readonly TOKEN_REFRESH_ATTEMPTS=20
+        readonly TOKEN_REFRESH_RETRY_SECONDS=15
+        readonly WATCH_POLL_SECONDS=10
+
+        base64url() {
+          openssl base64 -A | tr '/+' '_-' | tr -d '='
+        }
+
+        mint_app_token() {
+          local now issued_at expires_at header payload unsigned signature jwt
+          local installation_id repository_name request_body
+          now="$(date +%s)"
+          issued_at="$((now - 60))"
+          expires_at="$((now + 600))"
+          header="$(printf '%s' '{"typ":"JWT","alg":"RS256"}' | base64url)"
+          payload="$(
+            printf '{"iat":%s,"exp":%s,"iss":"%s"}' \
+              "$issued_at" "$expires_at" "$APP_CLIENT_ID" | base64url
+          )"
+          unsigned="${header}.${payload}"
+          signature="$(
+            openssl dgst -sha256 -sign <(printf '%s' "$APP_PRIVATE_KEY") \
+              <(printf '%s' "$unsigned") | base64url
+          )"
+          jwt="${unsigned}.${signature}"
+          echo "::add-mask::${jwt}"
+
+          installation_id="$(
+            GH_TOKEN="$jwt" gh api -H "Authorization: Bearer ${jwt}" \
+              "/repos/${INFRA_REPO}/installation" --jq '.id'
+          )"
+          repository_name="${INFRA_REPO#*/}"
+          request_body="$(
+            jq -cn --arg repository "$repository_name" \
+              '{repositories: [$repository], permissions: {actions: "write"}}'
+          )"
+          GH_TOKEN="$jwt" gh api -H "Authorization: Bearer ${jwt}" \
+            --method POST \
+            "/app/installations/${installation_id}/access_tokens" \
+            --input - --jq '.token' <<<"$request_body"
+        }
+
+        refresh_app_token() {
+          local attempt token=""
+          for ((attempt = 1; attempt <= TOKEN_REFRESH_ATTEMPTS; attempt += 1)); do
+            if token="$(mint_app_token)" && [[ -n "$token" ]]; then
+              break
+            fi
+            token=""
+            echo "Token mint failed (${attempt}/${TOKEN_REFRESH_ATTEMPTS}); retaining the current token and retrying..." >&2
+            sleep "$TOKEN_REFRESH_RETRY_SECONDS"
+          done
+          if [[ -z "$token" ]]; then
+            echo "::error::Could not renew the GitHub App token after ${TOKEN_REFRESH_ATTEMPTS} attempts." >&2
+            exit 1
+          fi
+          if [[ -n "${current_app_token:-}" ]]; then
+            GH_TOKEN="$current_app_token" gh api --method DELETE \
+              "/installation/token" >/dev/null 2>&1 || true
+          fi
+          echo "::add-mask::${token}"
+          current_app_token="$token"
+          export GH_TOKEN="$token"
+          token_refreshed_at="$(date +%s)"
+        }
+
+        revoke_app_token() {
+          if [[ -n "${current_app_token:-}" ]]; then
+            GH_TOKEN="$current_app_token" gh api --method DELETE \
+              "/installation/token" >/dev/null 2>&1 || true
+          fi
+        }
+
+        if [[ ! "$INFRA_REPO" =~ ^[^/]+/[^/]+$ ]]; then
+          echo "::error::infra-repo must be an owner/name pair." >&2
+          exit 1
+        fi
+        current_app_token=""
+        trap revoke_app_token EXIT
+        refresh_app_token
 
         dispatched_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
         # Must match the `run-name:` template in
@@ -138,31 +224,42 @@ runs:
           exit 1
         fi
 
-        echo "Watching run ${run_id}..."
-        if gh run watch "$run_id" --repo "$INFRA_REPO" --compact --exit-status; then
-          exit 0
-        fi
-
-        # The watch failed, so this job fails either way. Read the run back
-        # only to say why. A lookup that itself fails must not mask that with
-        # `set -e` killing the step silently.
         run_url="${INFRA_REPO}/actions/runs/${run_id}"
-        if ! run_state="$(
-          gh api "/repos/${INFRA_REPO}/actions/runs/${run_id}" \
-            --jq '[.conclusion, .html_url] | @tsv'
-        )"; then
-          echo "::error::Promote run ${run_id} did not complete successfully, and reading its final state failed. Check https://github.com/${run_url}" >&2
-          exit 1
-        fi
-        conclusion="$(cut -f1 <<<"$run_state")"
-        run_url="$(cut -f2 <<<"$run_state")"
+        consecutive_read_failures=0
+        echo "Watching run ${run_id}..."
+        while true; do
+          now="$(date +%s)"
+          if (( now - token_refreshed_at >= TOKEN_REFRESH_SECONDS )); then
+            echo "Refreshing promotion watcher credentials..."
+            refresh_app_token
+          fi
 
-        # `gh run watch` can exit non-zero without the run having concluded,
-        # for example when the watch itself lost the API. Reporting an empty
-        # conclusion as a verdict would be misleading.
-        if [[ -z "$conclusion" || "$conclusion" == "null" ]]; then
-          echo "::error::Lost track of promote run ${run_id} before it concluded: ${run_url}" >&2
-          exit 1
+          if ! run_state="$(
+            gh api "/repos/${INFRA_REPO}/actions/runs/${run_id}" \
+              --jq '[.status, .conclusion, .html_url] | @tsv'
+          )"; then
+            consecutive_read_failures=$((consecutive_read_failures + 1))
+            if (( consecutive_read_failures >= 3 )); then
+              echo "::error::Lost track of promote run ${run_id} after ${consecutive_read_failures} consecutive API failures. Check https://github.com/${run_url}" >&2
+              exit 1
+            fi
+            echo "Run status lookup failed (${consecutive_read_failures}/3); retrying..."
+            sleep "$WATCH_POLL_SECONDS"
+            continue
+          fi
+          consecutive_read_failures=0
+          status="$(cut -f1 <<<"$run_state")"
+          conclusion="$(cut -f2 <<<"$run_state")"
+          run_url="$(cut -f3 <<<"$run_state")"
+          if [[ "$status" == "completed" ]]; then
+            break
+          fi
+          sleep "$WATCH_POLL_SECONDS"
+        done
+
+        if [[ "$conclusion" == "success" ]]; then
+          echo "Promote run completed successfully: ${run_url}"
+          exit 0
         fi
 
         # A cancelled promote stays fatal. When a newer push superseded this

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -562,6 +562,10 @@ jobs:
           bun test
           scripts/check-api-deployment.test.ts
 
+      - name: Test maintenance release preparation
+        if: needs.ci-changes.outputs.package_checks_required == 'true'
+        run: bun test scripts/prepare-maintenance-release.property.test.ts
+
       # The api test runner only globs `src/**`, so this seed-side regression
       # guard (it imports `createMockDocx` and the Export Review citation
       # seeds) needs an explicit invocation to run in CI, like the scripts

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -86,16 +86,6 @@ jobs:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           subject-digest: ${{ steps.build.outputs.digest }}
 
-      - name: Mint deployment token
-        id: deployment-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        with:
-          client-id: ${{ vars.STELLA_RELEASE_APP_CLIENT_ID }}
-          private-key: ${{ secrets.STELLA_RELEASE_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-          repositories: ${{ vars.STAGING_DEPLOY_REPOSITORY }}
-          permission-actions: write
-
       - name: Check staging deployment target is configured
         env:
           DEPLOY_REPOSITORY: ${{ github.repository_owner }}/${{ vars.STAGING_DEPLOY_REPOSITORY }}
@@ -113,7 +103,8 @@ jobs:
       - name: Deploy to staging
         uses: ./.github/actions/promote-dispatch
         with:
-          token: ${{ steps.deployment-token.outputs.token }}
+          app-client-id: ${{ vars.STELLA_RELEASE_APP_CLIENT_ID }}
+          app-private-key: ${{ secrets.STELLA_RELEASE_APP_PRIVATE_KEY }}
           infra-repo: ${{ github.repository_owner }}/${{ vars.STAGING_DEPLOY_REPOSITORY }}
           workflow-file: ${{ vars.STAGING_DEPLOY_WORKFLOW }}
           release-ref: ${{ steps.ref.outputs.release_ref }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -597,20 +597,11 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Mint App token for the infra repo
-        id: app-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        with:
-          client-id: ${{ vars.STELLA_RELEASE_APP_CLIENT_ID }}
-          private-key: ${{ secrets.STELLA_RELEASE_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-          repositories: stella-infra
-          permission-actions: write
-
       - name: Promote to production
         uses: ./.github/actions/promote-dispatch
         with:
-          token: ${{ steps.app-token.outputs.token }}
+          app-client-id: ${{ vars.STELLA_RELEASE_APP_CLIENT_ID }}
+          app-private-key: ${{ secrets.STELLA_RELEASE_APP_PRIVATE_KEY }}
           infra-repo: ${{ github.repository_owner }}/stella-infra
           release-ref: ${{ needs.resolve.outputs.release_ref }}
           target-environment: production
@@ -656,20 +647,11 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Mint App token for the infra repo
-        id: app-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        with:
-          client-id: ${{ vars.STELLA_RELEASE_APP_CLIENT_ID }}
-          private-key: ${{ secrets.STELLA_RELEASE_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-          repositories: stella-infra
-          permission-actions: write
-
       - name: Promote to staging
         uses: ./.github/actions/promote-dispatch
         with:
-          token: ${{ steps.app-token.outputs.token }}
+          app-client-id: ${{ vars.STELLA_RELEASE_APP_CLIENT_ID }}
+          app-private-key: ${{ secrets.STELLA_RELEASE_APP_PRIVATE_KEY }}
           infra-repo: ${{ github.repository_owner }}/stella-infra
           release-ref: ${{ needs.resolve.outputs.release_ref }}
           target-environment: staging

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -578,9 +578,10 @@ jobs:
     # carrying a prerelease label (vX.Y.Z-anything) publishes the
     # artifact and is handled by `promote-staging` below.
     runs-on: ubuntu-latest
-    # Infra promotion can consume most of the old 30-minute budget; retain
-    # headroom for the exact-commit verification that gates CLI publication.
-    timeout-minutes: 40
+    # The infra workflow waits for online migrations to reach their real
+    # terminal state. Match GitHub's full hosted-job window so this caller
+    # cannot time out first and lose observation of an active promotion.
+    timeout-minutes: 360
     needs: [resolve, manifest, smoke]
     if: ${{ !contains(needs.resolve.outputs.release_ref, '-') }}
     permissions:

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "marketing:stale": "bun scripts/check-marketing-recordings.ts",
     "marketing:verify-current": "bun scripts/verify-marketing-recordings.ts",
     "marketing:reshoot": "bun scripts/marketing-reshoot.ts",
+    "release:maintenance": "bun scripts/prepare-maintenance-release.ts",
     "sync-ai": "bash .ai/shared/scripts/sync-ai-skills.sh .",
     "sync-ai:check": "bash .ai/shared/scripts/sync-ai-skills.sh --check .",
     "link-codex": "bash scripts/link-codex-skills.sh",

--- a/scripts/check-api-cli-contract.test.ts
+++ b/scripts/check-api-cli-contract.test.ts
@@ -148,25 +148,11 @@ describe("API and CLI release contract", () => {
     );
   });
 
-  test("release promotion preserves the full online-migration window", async () => {
-    const releaseWorkflow = await Bun.file(
-      new URL("../.github/workflows/release.yml", import.meta.url),
-    ).text();
-    const promoteJobStart = releaseWorkflow.indexOf("\n  promote:\n");
-    const stagingJobStart = releaseWorkflow.indexOf(
-      "\n  promote-staging:\n",
-      promoteJobStart,
-    );
-    const promoteJob = releaseWorkflow.slice(promoteJobStart, stagingJobStart);
-
-    expect(promoteJobStart).toBeGreaterThanOrEqual(0);
-    expect(stagingJobStart).toBeGreaterThan(promoteJobStart);
-    expect(promoteJob).toContain("timeout-minutes: 360");
-  });
-
   test("release and pull-request smoke tests reject synthetic migration history", async () => {
     const workflows = await Promise.all([
-      Bun.file(new URL("../.github/workflows/release.yml", import.meta.url)).text(),
+      Bun.file(
+        new URL("../.github/workflows/release.yml", import.meta.url),
+      ).text(),
       Bun.file(
         new URL("../.github/workflows/db-migrations.yml", import.meta.url),
       ).text(),

--- a/scripts/check-api-cli-contract.test.ts
+++ b/scripts/check-api-cli-contract.test.ts
@@ -148,6 +148,22 @@ describe("API and CLI release contract", () => {
     );
   });
 
+  test("release promotion preserves the full online-migration window", async () => {
+    const releaseWorkflow = await Bun.file(
+      new URL("../.github/workflows/release.yml", import.meta.url),
+    ).text();
+    const promoteJobStart = releaseWorkflow.indexOf("\n  promote:\n");
+    const stagingJobStart = releaseWorkflow.indexOf(
+      "\n  promote-staging:\n",
+      promoteJobStart,
+    );
+    const promoteJob = releaseWorkflow.slice(promoteJobStart, stagingJobStart);
+
+    expect(promoteJobStart).toBeGreaterThanOrEqual(0);
+    expect(stagingJobStart).toBeGreaterThan(promoteJobStart);
+    expect(promoteJob).toContain("timeout-minutes: 360");
+  });
+
   test("release and pull-request smoke tests reject synthetic migration history", async () => {
     const workflows = await Promise.all([
       Bun.file(new URL("../.github/workflows/release.yml", import.meta.url)).text(),

--- a/scripts/check-api-deployment.test.ts
+++ b/scripts/check-api-deployment.test.ts
@@ -4,6 +4,51 @@ import { getApiHealthUrl, parseHealthCommit } from "./api-health";
 import { advanceDeploymentStability } from "./check-api-deployment";
 
 describe("API deployment health receipt", () => {
+  test("release promotion preserves the full online-migration window", async () => {
+    const [releaseWorkflow, stagingWorkflow, promoteAction] = await Promise.all(
+      [
+        Bun.file(
+          new URL("../.github/workflows/release.yml", import.meta.url),
+        ).text(),
+        Bun.file(
+          new URL("../.github/workflows/deploy-staging.yml", import.meta.url),
+        ).text(),
+        Bun.file(
+          new URL(
+            "../.github/actions/promote-dispatch/action.yml",
+            import.meta.url,
+          ),
+        ).text(),
+      ],
+    );
+    const promoteJobStart = releaseWorkflow.indexOf("\n  promote:\n");
+    const stagingJobStart = releaseWorkflow.indexOf(
+      "\n  promote-staging:\n",
+      promoteJobStart,
+    );
+    const promoteJob = releaseWorkflow.slice(promoteJobStart, stagingJobStart);
+
+    expect(promoteJobStart).toBeGreaterThanOrEqual(0);
+    expect(stagingJobStart).toBeGreaterThan(promoteJobStart);
+    expect(promoteJob).toContain("timeout-minutes: 360");
+    expect(promoteAction).toContain("readonly TOKEN_REFRESH_SECONDS=2700");
+    expect(promoteAction).toContain("readonly TOKEN_REFRESH_ATTEMPTS=20");
+    expect(promoteAction).toContain("refresh_app_token");
+    expect(promoteAction).toContain(
+      "now - token_refreshed_at >= TOKEN_REFRESH_SECONDS",
+    );
+    expect(promoteAction).toContain('"/installation/token"');
+    expect(promoteAction).toContain("retaining the current token and retrying");
+    expect(
+      promoteAction.match(/Authorization: Bearer \$\{jwt\}/gu),
+    ).toHaveLength(2);
+    expect(promoteAction).not.toContain("gh run watch");
+    expect(releaseWorkflow).not.toContain("steps.app-token.outputs.token");
+    expect(stagingWorkflow).not.toContain(
+      "steps.deployment-token.outputs.token",
+    );
+  });
+
   test("preserves a configured API path prefix", () => {
     expect(getApiHealthUrl("https://example.com/api").toString()).toBe(
       "https://example.com/api/health",

--- a/scripts/check-api-deployment.test.ts
+++ b/scripts/check-api-deployment.test.ts
@@ -39,10 +39,16 @@ describe("API deployment health receipt", () => {
     );
     expect(promoteAction).toContain('"/installation/token"');
     expect(promoteAction).toContain("retaining the current token and retrying");
+    expect(promoteAction).toContain('echo "::add-mask::${jwt}" >&2');
+    expect(promoteAction).toContain(`printf '%s\\n' "$APP_PRIVATE_KEY"`);
     expect(
       promoteAction.match(/Authorization: Bearer \$\{jwt\}/gu),
     ).toHaveLength(2);
     expect(promoteAction).not.toContain("gh run watch");
+    expect(promoteAction).toContain(
+      'run_url="https://github.com/${INFRA_REPO}/actions/runs/${run_id}"',
+    );
+    expect(promoteAction).not.toContain("Check https://github.com/${run_url}");
     expect(releaseWorkflow).not.toContain("steps.app-token.outputs.token");
     expect(stagingWorkflow).not.toContain(
       "steps.deployment-token.outputs.token",

--- a/scripts/prepare-maintenance-release.property.test.ts
+++ b/scripts/prepare-maintenance-release.property.test.ts
@@ -14,6 +14,7 @@ import nodePath from "node:path";
 import { propertyConfig } from "@stll/property-testing";
 
 import {
+  MaintenanceReleaseError,
   nextPatchVersion,
   parseMaintenanceReleaseOptions,
   parseStableVersion,
@@ -106,7 +107,7 @@ describe("maintenance release preparation", () => {
     expect(
       readFileSync(nodePath.join(root, "docs/changelog/v1.2.4.md"), "utf-8"),
     ).toBe(
-      "# Maintenance release\n\nStella includes reliability and maintenance improvements.\n",
+      "# Maintenance release\n\nstella includes reliability and maintenance improvements.\n",
     );
     const releaseDates: unknown = JSON.parse(
       readFileSync(
@@ -214,18 +215,31 @@ describe("maintenance release preparation", () => {
     );
     writeFileSync(releaseDatesPath, "{}\n");
 
-    expect(() =>
+    const originalFailure = new Error("persistent write failure");
+    let caught: unknown;
+    try {
       prepareMaintenanceReleaseFiles({
         publishedAt: "2026-02-03T04:05:06Z",
         rootDir: root,
         writeFile: (path, contents) => {
           if (path === releaseDatesPath) {
-            throw new Error("persistent write failure");
+            throw originalFailure;
           }
           writeFileSync(path, contents);
         },
-      }),
-    ).toThrow("1 rollback operation(s) did not complete");
+      });
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(MaintenanceReleaseError);
+    if (!(caught instanceof MaintenanceReleaseError)) {
+      throw new Error("Expected maintenance release failure");
+    }
+    expect(caught.message).toContain("persistent write failure");
+    expect(caught.message).toContain(
+      "1 rollback operation(s) did not complete",
+    );
+    expect(caught.cause).toBe(originalFailure);
 
     expect(existsSync(nextChangelogPath)).toBe(false);
     expect(

--- a/scripts/prepare-maintenance-release.property.test.ts
+++ b/scripts/prepare-maintenance-release.property.test.ts
@@ -1,0 +1,153 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import fc from "fast-check";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import nodePath from "node:path";
+
+import { propertyConfig } from "@stll/property-testing";
+
+import {
+  nextPatchVersion,
+  parseMaintenanceReleaseOptions,
+  parseStableVersion,
+  prepareMaintenanceReleaseFiles,
+} from "./prepare-maintenance-release";
+
+const roots: string[] = [];
+
+afterEach(() => {
+  for (const root of roots.splice(0)) {
+    rmSync(root, { force: true, recursive: true });
+  }
+});
+
+describe("maintenance release preparation", () => {
+  test("increments every safe stable patch version without changing its series", () => {
+    fc.assert(
+      fc.property(
+        fc.nat({ max: 1_000_000 }),
+        fc.nat({ max: 1_000_000 }),
+        fc.nat({ max: 1_000_000 }),
+        (major, minor, patch) => {
+          const next = nextPatchVersion(
+            parseStableVersion(`${major}.${minor}.${patch}`),
+          );
+          expect(next).toEqual({
+            major,
+            minor,
+            patch: patch + 1,
+            value: `${major}.${minor}.${patch + 1}`,
+          });
+        },
+      ),
+      propertyConfig({ numRuns: 200 }),
+    );
+  });
+
+  test("makes recording attestation an explicit reviewed state", () => {
+    expect(parseMaintenanceReleaseOptions([])).toEqual({
+      recordingReviewReason: null,
+    });
+    expect(() =>
+      parseMaintenanceReleaseOptions([
+        "--reason",
+        "Current recordings remain representative.",
+      ]),
+    ).toThrow("requires --confirm-current-recordings-reviewed");
+    expect(
+      parseMaintenanceReleaseOptions([
+        "--confirm-current-recordings-reviewed",
+        "--reason",
+        "Current recordings remain representative.",
+      ]),
+    ).toEqual({
+      recordingReviewReason: "Current recordings remain representative.",
+    });
+  });
+
+  test("writes the complete release file set", () => {
+    const root = mkdtempSync(nodePath.join(tmpdir(), "stella-release-"));
+    roots.push(root);
+    mkdirSync(nodePath.join(root, "docs/changelog"), { recursive: true });
+    mkdirSync(nodePath.join(root, "apps/landing/src/data"), {
+      recursive: true,
+    });
+    writeFileSync(nodePath.join(root, "VERSION"), "1.2.3\n");
+    writeFileSync(
+      nodePath.join(root, "docs/changelog/v1.2.3.md"),
+      "# Previous release\n",
+    );
+    writeFileSync(
+      nodePath.join(root, "apps/landing/src/data/changelog-release-dates.json"),
+      `${JSON.stringify({ _note: "fixture", "v1.2.2": "2026-01-01T00:00:00Z" }, null, 2)}\n`,
+    );
+
+    expect(
+      prepareMaintenanceReleaseFiles({
+        publishedAt: "2026-02-03T04:05:06Z",
+        rootDir: root,
+      }),
+    ).toEqual({
+      changelogPath: "docs/changelog/v1.2.4.md",
+      previousTag: "v1.2.3",
+      version: "1.2.4",
+    });
+    expect(readFileSync(nodePath.join(root, "VERSION"), "utf-8")).toBe(
+      "1.2.4\n",
+    );
+    expect(
+      readFileSync(nodePath.join(root, "docs/changelog/v1.2.4.md"), "utf-8"),
+    ).toBe(
+      "# Maintenance release\n\nStella includes reliability and maintenance improvements.\n",
+    );
+    const releaseDates: unknown = JSON.parse(
+      readFileSync(
+        nodePath.join(
+          root,
+          "apps/landing/src/data/changelog-release-dates.json",
+        ),
+        "utf-8",
+      ),
+    );
+    expect(releaseDates).toEqual({
+      _note: "fixture",
+      "v1.2.2": "2026-01-01T00:00:00Z",
+      "v1.2.3": "2026-02-03T04:05:06Z",
+    });
+  });
+
+  test("refuses to overwrite an already prepared release", () => {
+    const root = mkdtempSync(nodePath.join(tmpdir(), "stella-release-"));
+    roots.push(root);
+    mkdirSync(nodePath.join(root, "docs/changelog"), { recursive: true });
+    mkdirSync(nodePath.join(root, "apps/landing/src/data"), {
+      recursive: true,
+    });
+    writeFileSync(nodePath.join(root, "VERSION"), "1.2.3\n");
+    writeFileSync(
+      nodePath.join(root, "docs/changelog/v1.2.3.md"),
+      "# Previous release\n",
+    );
+    writeFileSync(
+      nodePath.join(root, "docs/changelog/v1.2.4.md"),
+      "# Existing release\n",
+    );
+    writeFileSync(
+      nodePath.join(root, "apps/landing/src/data/changelog-release-dates.json"),
+      "{}\n",
+    );
+
+    expect(() =>
+      prepareMaintenanceReleaseFiles({
+        publishedAt: "2026-02-03T04:05:06Z",
+        rootDir: root,
+      }),
+    ).toThrow("already exists");
+  });
+});

--- a/scripts/prepare-maintenance-release.property.test.ts
+++ b/scripts/prepare-maintenance-release.property.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import fc from "fast-check";
 import {
+  existsSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
@@ -17,6 +18,7 @@ import {
   parseMaintenanceReleaseOptions,
   parseStableVersion,
   prepareMaintenanceReleaseFiles,
+  withFileRollback,
 } from "./prepare-maintenance-release";
 
 const roots: string[] = [];
@@ -149,5 +151,114 @@ describe("maintenance release preparation", () => {
         rootDir: root,
       }),
     ).toThrow("already exists");
+  });
+
+  test("restores every release file when preparation fails", () => {
+    const root = mkdtempSync(nodePath.join(tmpdir(), "stella-release-"));
+    roots.push(root);
+    mkdirSync(nodePath.join(root, "docs/changelog"), { recursive: true });
+    mkdirSync(nodePath.join(root, "apps/landing/src/data"), {
+      recursive: true,
+    });
+    const versionPath = nodePath.join(root, "VERSION");
+    const releaseDatesPath = nodePath.join(
+      root,
+      "apps/landing/src/data/changelog-release-dates.json",
+    );
+    const nextChangelogPath = nodePath.join(root, "docs/changelog/v1.2.4.md");
+    writeFileSync(versionPath, "1.2.3\n");
+    writeFileSync(
+      nodePath.join(root, "docs/changelog/v1.2.3.md"),
+      "# Previous release\n",
+    );
+    writeFileSync(releaseDatesPath, '{"v1.2.2":"2026-01-01T00:00:00Z"}\n');
+
+    let failed = false;
+    expect(() =>
+      prepareMaintenanceReleaseFiles({
+        publishedAt: "2026-02-03T04:05:06Z",
+        rootDir: root,
+        writeFile: (path, contents) => {
+          if (path === releaseDatesPath && !failed) {
+            failed = true;
+            throw new Error("simulated write failure");
+          }
+          writeFileSync(path, contents);
+        },
+      }),
+    ).toThrow("simulated write failure");
+
+    expect(readFileSync(versionPath, "utf-8")).toBe("1.2.3\n");
+    expect(readFileSync(releaseDatesPath, "utf-8")).toBe(
+      '{"v1.2.2":"2026-01-01T00:00:00Z"}\n',
+    );
+    expect(existsSync(nextChangelogPath)).toBe(false);
+  });
+
+  test("continues rollback after a persistent restore failure", () => {
+    const root = mkdtempSync(nodePath.join(tmpdir(), "stella-release-"));
+    roots.push(root);
+    mkdirSync(nodePath.join(root, "docs/changelog"), { recursive: true });
+    mkdirSync(nodePath.join(root, "apps/landing/src/data"), {
+      recursive: true,
+    });
+    const releaseDatesPath = nodePath.join(
+      root,
+      "apps/landing/src/data/changelog-release-dates.json",
+    );
+    const nextChangelogPath = nodePath.join(root, "docs/changelog/v1.2.4.md");
+    writeFileSync(nodePath.join(root, "VERSION"), "1.2.3\n");
+    writeFileSync(
+      nodePath.join(root, "docs/changelog/v1.2.3.md"),
+      "# Previous release\n",
+    );
+    writeFileSync(releaseDatesPath, "{}\n");
+
+    expect(() =>
+      prepareMaintenanceReleaseFiles({
+        publishedAt: "2026-02-03T04:05:06Z",
+        rootDir: root,
+        writeFile: (path, contents) => {
+          if (path === releaseDatesPath) {
+            throw new Error("persistent write failure");
+          }
+          writeFileSync(path, contents);
+        },
+      }),
+    ).toThrow("1 rollback operation(s) did not complete");
+
+    expect(existsSync(nextChangelogPath)).toBe(false);
+    expect(
+      prepareMaintenanceReleaseFiles({
+        publishedAt: "2026-02-03T04:05:06Z",
+        rootDir: root,
+      }),
+    ).toMatchObject({ version: "1.2.4" });
+  });
+
+  test("restores attestation and release files as one transaction", () => {
+    const root = mkdtempSync(nodePath.join(tmpdir(), "stella-release-"));
+    roots.push(root);
+    const manifestPath = nodePath.join(root, "recordings-manifest.json");
+    const versionPath = nodePath.join(root, "VERSION");
+    const changelogPath = nodePath.join(root, "v1.2.4.md");
+    writeFileSync(manifestPath, '{"entries":[]}\n');
+    writeFileSync(versionPath, "1.2.3\n");
+
+    expect(() =>
+      withFileRollback({
+        operation: () => {
+          writeFileSync(manifestPath, '{"entries":[{"reviewed":true}]}\n');
+          writeFileSync(versionPath, "1.2.4\n");
+          writeFileSync(changelogPath, "# Maintenance release\n");
+          throw new Error("simulated post-attestation failure");
+        },
+        paths: [manifestPath, versionPath, changelogPath],
+      }),
+    ).toThrow("simulated post-attestation failure");
+
+    expect(readFileSync(manifestPath, "utf-8")).toBe('{"entries":[]}\n');
+    expect(readFileSync(versionPath, "utf-8")).toBe("1.2.3\n");
+    expect(existsSync(changelogPath)).toBe(false);
   });
 });

--- a/scripts/prepare-maintenance-release.ts
+++ b/scripts/prepare-maintenance-release.ts
@@ -19,7 +19,7 @@ const CONFIRMATION_FLAG = "--confirm-current-recordings-reviewed";
 const REASON_FLAG = "--reason";
 const STABLE_VERSION_PATTERN = /^(\d+)\.(\d+)\.(\d+)$/u;
 const MAINTENANCE_CHANGELOG =
-  "# Maintenance release\n\nStella includes reliability and maintenance improvements.\n";
+  "# Maintenance release\n\nstella includes reliability and maintenance improvements.\n";
 
 type StableVersion = {
   major: number;
@@ -46,8 +46,8 @@ type FileSnapshot = {
 };
 
 export class MaintenanceReleaseError extends Error {
-  constructor(message: string) {
-    super(message);
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
     this.name = "MaintenanceReleaseError";
   }
 }
@@ -203,8 +203,11 @@ export const withFileRollback = <T>({
       }
     }
     if (rollbackErrors.length > 0) {
+      const originalMessage =
+        error instanceof Error ? error.message : String(error);
       throw new MaintenanceReleaseError(
-        `Release preparation failed and ${String(rollbackErrors.length)} rollback operation(s) did not complete: ${rollbackErrors.map(String).join("; ")}`,
+        `Release preparation failed (${originalMessage}) and ${String(rollbackErrors.length)} rollback operation(s) did not complete: ${rollbackErrors.map(String).join("; ")}`,
+        { cause: error },
       );
     }
     throw error;

--- a/scripts/prepare-maintenance-release.ts
+++ b/scripts/prepare-maintenance-release.ts
@@ -1,0 +1,327 @@
+#!/usr/bin/env bun
+
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import nodePath from "node:path";
+
+import { computeVerdicts } from "./check-marketing-recordings";
+
+const ROOT_DIR = nodePath.resolve(import.meta.dirname, "..");
+const RELEASE_DATES_PATH = "apps/landing/src/data/changelog-release-dates.json";
+const CONFIRMATION_FLAG = "--confirm-current-recordings-reviewed";
+const REASON_FLAG = "--reason";
+const STABLE_VERSION_PATTERN = /^(\d+)\.(\d+)\.(\d+)$/u;
+const MAINTENANCE_CHANGELOG =
+  "# Maintenance release\n\nStella includes reliability and maintenance improvements.\n";
+
+type StableVersion = {
+  major: number;
+  minor: number;
+  patch: number;
+  value: string;
+};
+
+type MaintenanceReleaseOptions = {
+  recordingReviewReason: string | null;
+};
+
+type PreparedMaintenanceRelease = {
+  changelogPath: string;
+  previousTag: string;
+  version: string;
+};
+
+export class MaintenanceReleaseError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "MaintenanceReleaseError";
+  }
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null;
+
+const checkedVersionPart = (value: string | undefined): number => {
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed)) {
+    throw new MaintenanceReleaseError(`Invalid stable version part: ${value}`);
+  }
+  return parsed;
+};
+
+export const parseStableVersion = (value: string): StableVersion => {
+  const match = STABLE_VERSION_PATTERN.exec(value);
+  if (!match) {
+    throw new MaintenanceReleaseError(
+      `VERSION must be a stable semantic version; got '${value}'`,
+    );
+  }
+  return {
+    major: checkedVersionPart(match.at(1)),
+    minor: checkedVersionPart(match.at(2)),
+    patch: checkedVersionPart(match.at(3)),
+    value,
+  };
+};
+
+export const nextPatchVersion = (current: StableVersion): StableVersion => {
+  const patch = current.patch + 1;
+  if (!Number.isSafeInteger(patch)) {
+    throw new MaintenanceReleaseError(
+      `Patch version cannot be incremented safely: ${current.value}`,
+    );
+  }
+  return {
+    major: current.major,
+    minor: current.minor,
+    patch,
+    value: `${String(current.major)}.${String(current.minor)}.${String(patch)}`,
+  };
+};
+
+export const parseMaintenanceReleaseOptions = (
+  args: readonly string[],
+): MaintenanceReleaseOptions => {
+  let confirmed = false;
+  let reason: string | undefined;
+  const seen = new Set<string>();
+
+  for (let index = 0; index < args.length; index += 1) {
+    const flag = args.at(index);
+    if (flag !== CONFIRMATION_FLAG && flag !== REASON_FLAG) {
+      throw new MaintenanceReleaseError(`Unknown argument: ${String(flag)}`);
+    }
+    if (seen.has(flag)) {
+      throw new MaintenanceReleaseError(`${flag} may be passed only once`);
+    }
+    seen.add(flag);
+
+    if (flag === CONFIRMATION_FLAG) {
+      confirmed = true;
+      continue;
+    }
+    const value = args.at(index + 1);
+    if (!value || value.startsWith("--")) {
+      throw new MaintenanceReleaseError(`${REASON_FLAG} requires a value`);
+    }
+    reason = value;
+    index += 1;
+  }
+
+  if (!confirmed && reason === undefined) {
+    return { recordingReviewReason: null };
+  }
+  if (!confirmed) {
+    throw new MaintenanceReleaseError(
+      `${REASON_FLAG} requires ${CONFIRMATION_FLAG}`,
+    );
+  }
+  if (
+    !reason ||
+    reason.trim() !== reason ||
+    reason.length < 12 ||
+    reason.length > 240
+  ) {
+    throw new MaintenanceReleaseError(
+      `${REASON_FLAG} must be a trimmed reason between 12 and 240 characters`,
+    );
+  }
+  return { recordingReviewReason: reason };
+};
+
+const readReleaseDates = (rootDir: string): Record<string, string> => {
+  const parsed: unknown = JSON.parse(
+    readFileSync(nodePath.join(rootDir, RELEASE_DATES_PATH), "utf-8"),
+  );
+  if (
+    !isRecord(parsed) ||
+    Object.values(parsed).some((value) => typeof value !== "string")
+  ) {
+    throw new MaintenanceReleaseError(
+      `${RELEASE_DATES_PATH} must be an object of string values`,
+    );
+  }
+  const releaseDates: Record<string, string> = {};
+  for (const [key, value] of Object.entries(parsed)) {
+    if (typeof value === "string") {
+      releaseDates[key] = value;
+    }
+  }
+  return releaseDates;
+};
+
+export const prepareMaintenanceReleaseFiles = ({
+  publishedAt,
+  rootDir,
+}: {
+  publishedAt: string;
+  rootDir: string;
+}): PreparedMaintenanceRelease => {
+  if (Number.isNaN(Date.parse(publishedAt))) {
+    throw new MaintenanceReleaseError(
+      `Previous release has an invalid publication timestamp: ${publishedAt}`,
+    );
+  }
+
+  const versionPath = nodePath.join(rootDir, "VERSION");
+  const current = parseStableVersion(readFileSync(versionPath, "utf-8").trim());
+  const next = nextPatchVersion(current);
+  const previousTag = `v${current.value}`;
+  if (
+    !existsSync(nodePath.join(rootDir, "docs/changelog", `${previousTag}.md`))
+  ) {
+    throw new MaintenanceReleaseError(
+      `Previous release changelog is missing: docs/changelog/${previousTag}.md`,
+    );
+  }
+
+  const changelogPath = `docs/changelog/v${next.value}.md`;
+  const absoluteChangelogPath = nodePath.join(rootDir, changelogPath);
+  if (existsSync(absoluteChangelogPath)) {
+    throw new MaintenanceReleaseError(
+      `Next release changelog already exists: ${changelogPath}`,
+    );
+  }
+
+  const releaseDates = readReleaseDates(rootDir);
+  releaseDates[previousTag] = publishedAt;
+  writeFileSync(
+    nodePath.join(rootDir, RELEASE_DATES_PATH),
+    `${JSON.stringify(releaseDates, null, 2)}\n`,
+  );
+  writeFileSync(versionPath, `${next.value}\n`);
+  writeFileSync(absoluteChangelogPath, MAINTENANCE_CHANGELOG);
+  return { changelogPath, previousTag, version: next.value };
+};
+
+const run = (command: readonly string[]) => {
+  const result = Bun.spawnSync([...command], {
+    cwd: ROOT_DIR,
+    stderr: "inherit",
+    stdout: "inherit",
+  });
+  if (!result.success) {
+    throw new MaintenanceReleaseError(
+      `${command.join(" ")} exited with code ${String(result.exitCode)}`,
+    );
+  }
+};
+
+const assertCleanWorktree = () => {
+  const result = Bun.spawnSync(
+    ["git", "status", "--porcelain=v1", "--untracked-files=all"],
+    { cwd: ROOT_DIR, stderr: "pipe", stdout: "pipe" },
+  );
+  if (!result.success || result.stdout.length > 0) {
+    throw new MaintenanceReleaseError(
+      "Commit or stash worktree changes before preparing a release",
+    );
+  }
+};
+
+const fetchPublishedAt = async (tag: string): Promise<string> => {
+  const headers: Record<string, string> = {
+    Accept: "application/vnd.github+json",
+    "User-Agent": "stella-maintenance-release",
+    "X-GitHub-Api-Version": "2022-11-28",
+  };
+  const token = process.env["GH_TOKEN"] ?? process.env["GITHUB_TOKEN"];
+  if (token) {
+    headers["Authorization"] = `Bearer ${token}`;
+  }
+  const response = await fetch(
+    `https://api.github.com/repos/stella/stella/releases/tags/${encodeURIComponent(tag)}`,
+    { headers },
+  );
+  if (!response.ok) {
+    throw new MaintenanceReleaseError(
+      `Could not read ${tag} from GitHub Releases (HTTP ${String(response.status)})`,
+    );
+  }
+  const payload: unknown = await response.json();
+  if (
+    !isRecord(payload) ||
+    typeof payload["published_at"] !== "string" ||
+    Number.isNaN(Date.parse(payload["published_at"]))
+  ) {
+    throw new MaintenanceReleaseError(
+      `GitHub release ${tag} has no valid published_at timestamp`,
+    );
+  }
+  return payload["published_at"];
+};
+
+const staleCaptureIds = (): string[] => [
+  ...new Set(
+    computeVerdicts()
+      .filter(({ status }) => status === "STALE")
+      .map(({ captureId }) => captureId),
+  ),
+];
+
+const ensureFreshRecordings = (reviewReason: string | null) => {
+  const stale = staleCaptureIds();
+  if (stale.length === 0) {
+    return;
+  }
+  if (reviewReason === null) {
+    throw new MaintenanceReleaseError(
+      [
+        `Marketing recordings require review: ${stale.join(", ")}`,
+        "Re-record with `bun run marketing:reshoot`, or visually review and rerun:",
+        `bun run release:maintenance -- ${CONFIRMATION_FLAG} ${REASON_FLAG} "<review reason>"`,
+      ].join("\n"),
+    );
+  }
+  run([
+    "bun",
+    "scripts/verify-marketing-recordings.ts",
+    CONFIRMATION_FLAG,
+    REASON_FLAG,
+    reviewReason,
+  ]);
+  const unresolved = staleCaptureIds();
+  if (unresolved.length > 0) {
+    throw new MaintenanceReleaseError(
+      `Recordings remain stale after verification: ${unresolved.join(", ")}`,
+    );
+  }
+};
+
+const main = async () => {
+  const options = parseMaintenanceReleaseOptions(process.argv.slice(2));
+  assertCleanWorktree();
+  const current = parseStableVersion(
+    readFileSync(nodePath.join(ROOT_DIR, "VERSION"), "utf-8").trim(),
+  );
+  const publishedAt = await fetchPublishedAt(`v${current.value}`);
+  ensureFreshRecordings(options.recordingReviewReason);
+  const prepared = prepareMaintenanceReleaseFiles({
+    publishedAt,
+    rootDir: ROOT_DIR,
+  });
+  run([
+    "bash",
+    "scripts/check-release-changelog.sh",
+    "--version",
+    prepared.version,
+  ]);
+  run(["bun", "run", "marketing:stale", "--strict"]);
+  process.stdout.write(
+    [
+      `maintenance-release: prepared ${prepared.version}`,
+      `  VERSION`,
+      `  ${prepared.changelogPath}`,
+      `  ${RELEASE_DATES_PATH} (${prepared.previousTag})`,
+      "Review the diff, commit it, and open the release PR.",
+      "",
+    ].join("\n"),
+  );
+};
+
+if (import.meta.main) {
+  await main().catch((error: unknown) => {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`maintenance-release: ${message}`);
+    process.exit(1);
+  });
+}

--- a/scripts/prepare-maintenance-release.ts
+++ b/scripts/prepare-maintenance-release.ts
@@ -1,8 +1,16 @@
 #!/usr/bin/env bun
 
-import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { randomUUID } from "node:crypto";
+import {
+  existsSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import nodePath from "node:path";
 
+import { RECORDINGS_MANIFEST_PATH } from "../apps/web/e2e/marketing/captures";
 import { computeVerdicts } from "./check-marketing-recordings";
 
 const ROOT_DIR = nodePath.resolve(import.meta.dirname, "..");
@@ -28,6 +36,13 @@ type PreparedMaintenanceRelease = {
   changelogPath: string;
   previousTag: string;
   version: string;
+};
+
+type ReleaseFileWriter = (path: string, contents: string) => void;
+
+type FileSnapshot = {
+  contents: string | null;
+  path: string;
 };
 
 export class MaintenanceReleaseError extends Error {
@@ -149,12 +164,61 @@ const readReleaseDates = (rootDir: string): Record<string, string> => {
   return releaseDates;
 };
 
+const atomicWriteFile: ReleaseFileWriter = (path, contents) => {
+  const temporaryPath = `${path}.${String(process.pid)}.${randomUUID()}.tmp`;
+  try {
+    writeFileSync(temporaryPath, contents, { flag: "wx" });
+    renameSync(temporaryPath, path);
+  } finally {
+    rmSync(temporaryPath, { force: true });
+  }
+};
+
+export const withFileRollback = <T>({
+  operation,
+  paths,
+  writeFile = atomicWriteFile,
+}: {
+  operation: () => T;
+  paths: readonly string[];
+  writeFile?: ReleaseFileWriter;
+}): T => {
+  const snapshots: FileSnapshot[] = paths.map((path) => ({
+    contents: existsSync(path) ? readFileSync(path, "utf-8") : null,
+    path,
+  }));
+  try {
+    return operation();
+  } catch (error) {
+    const rollbackErrors: unknown[] = [];
+    for (const { contents, path } of snapshots) {
+      try {
+        if (contents === null) {
+          rmSync(path, { force: true });
+        } else {
+          writeFile(path, contents);
+        }
+      } catch (rollbackError) {
+        rollbackErrors.push(rollbackError);
+      }
+    }
+    if (rollbackErrors.length > 0) {
+      throw new MaintenanceReleaseError(
+        `Release preparation failed and ${String(rollbackErrors.length)} rollback operation(s) did not complete: ${rollbackErrors.map(String).join("; ")}`,
+      );
+    }
+    throw error;
+  }
+};
+
 export const prepareMaintenanceReleaseFiles = ({
   publishedAt,
   rootDir,
+  writeFile = atomicWriteFile,
 }: {
   publishedAt: string;
   rootDir: string;
+  writeFile?: ReleaseFileWriter;
 }): PreparedMaintenanceRelease => {
   if (Number.isNaN(Date.parse(publishedAt))) {
     throw new MaintenanceReleaseError(
@@ -182,15 +246,21 @@ export const prepareMaintenanceReleaseFiles = ({
     );
   }
 
+  const releaseDatesPath = nodePath.join(rootDir, RELEASE_DATES_PATH);
   const releaseDates = readReleaseDates(rootDir);
   releaseDates[previousTag] = publishedAt;
-  writeFileSync(
-    nodePath.join(rootDir, RELEASE_DATES_PATH),
-    `${JSON.stringify(releaseDates, null, 2)}\n`,
-  );
-  writeFileSync(versionPath, `${next.value}\n`);
-  writeFileSync(absoluteChangelogPath, MAINTENANCE_CHANGELOG);
-  return { changelogPath, previousTag, version: next.value };
+  return withFileRollback({
+    operation: () => {
+      // VERSION is the commit marker: every dependent file is durable before
+      // it advances. Atomic sibling renames prevent truncated files.
+      writeFile(absoluteChangelogPath, MAINTENANCE_CHANGELOG);
+      writeFile(releaseDatesPath, `${JSON.stringify(releaseDates, null, 2)}\n`);
+      writeFile(versionPath, `${next.value}\n`);
+      return { changelogPath, previousTag, version: next.value };
+    },
+    paths: [versionPath, releaseDatesPath, absoluteChangelogPath],
+    writeFile,
+  });
 };
 
 const run = (command: readonly string[]) => {
@@ -294,18 +364,30 @@ const main = async () => {
     readFileSync(nodePath.join(ROOT_DIR, "VERSION"), "utf-8").trim(),
   );
   const publishedAt = await fetchPublishedAt(`v${current.value}`);
-  ensureFreshRecordings(options.recordingReviewReason);
-  const prepared = prepareMaintenanceReleaseFiles({
-    publishedAt,
-    rootDir: ROOT_DIR,
+  const next = nextPatchVersion(current);
+  const prepared = withFileRollback({
+    operation: () => {
+      ensureFreshRecordings(options.recordingReviewReason);
+      const release = prepareMaintenanceReleaseFiles({
+        publishedAt,
+        rootDir: ROOT_DIR,
+      });
+      run([
+        "bash",
+        "scripts/check-release-changelog.sh",
+        "--version",
+        release.version,
+      ]);
+      run(["bun", "run", "marketing:stale", "--strict"]);
+      return release;
+    },
+    paths: [
+      nodePath.join(ROOT_DIR, RECORDINGS_MANIFEST_PATH),
+      nodePath.join(ROOT_DIR, "VERSION"),
+      nodePath.join(ROOT_DIR, RELEASE_DATES_PATH),
+      nodePath.join(ROOT_DIR, `docs/changelog/v${next.value}.md`),
+    ],
   });
-  run([
-    "bash",
-    "scripts/check-release-changelog.sh",
-    "--version",
-    prepared.version,
-  ]);
-  run(["bun", "run", "marketing:stale", "--strict"]);
   process.stdout.write(
     [
       `maintenance-release: prepared ${prepared.version}`,

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -215,6 +215,8 @@ run_step "API release contract self-test" bun test \
   --preload ./apps/api/src/tests/setup-env.ts \
   scripts/check-api-cli-contract.test.ts \
   scripts/check-api-deployment.test.ts
+run_step "Maintenance release preparation self-test" bun test \
+  scripts/prepare-maintenance-release.property.test.ts
 run_step "Desktop-release-changes self-test" bash scripts/detect-desktop-release-changes.test.sh
 run_step "Bridge-version guard" bash scripts/check-bridge-version.sh
 


### PR DESCRIPTION
## Summary

- add a release:maintenance command that derives the next stable patch version and changelog
- synchronize the prior GitHub release publication timestamp before preparing release files
- require fresh recordings or an explicit reviewed-current attestation, then run the release guards
- preserve the full hosted-job window while production promotion observes online migrations
- cover patch arithmetic, release-file preparation, and promotion timeout invariants with tests

## Validation

- bun test scripts/prepare-maintenance-release.property.test.ts
- bun test packages/property-testing/src/convention.test.ts
- bun test --preload ./apps/api/src/tests/setup-env.ts scripts/check-api-cli-contract.test.ts
- local lint and typecheck omitted; CI provides the authoritative results

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a maintenance release preparation workflow that validates release details, updates version and release files, and safely rolls back incomplete changes.
  - Added a `release:maintenance` command for preparing patch releases.
  - Improved release promotion reliability with refreshed credentials, retry handling, and longer monitoring periods.

- **Bug Fixes**
  - Promotion monitoring now reports success only after completed successful runs and handles transient status failures more reliably.

- **Tests**
  - Added comprehensive maintenance release and deployment workflow coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->