### PR TITLE
chore: slim Vite dependency canary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1333,7 +1333,8 @@ jobs:
           PLAYWRIGHT_BLOB_OUTPUT_NAME: report-vite-canary.zip
         run: >-
           bun --filter @stll/web test:e2e --
-          --project chromium --grep @dev-canary
+          e2e/specs/vite-dependency-canary.spec.ts
+          --project chromium
 
       # These imports load only through cold lazy routes; a mid-test optimizer
       # restart would make the apparent canary result nondeterministic.

--- a/apps/web/e2e/helpers/document.ts
+++ b/apps/web/e2e/helpers/document.ts
@@ -1,0 +1,68 @@
+import type { APIRequestContext } from "@playwright/test";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+import { apiGet, apiUploadDocx } from "./api";
+import type { TestWorkspace } from "./workspace";
+
+const DOCX_MIME =
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
+const DOCX_PATH = path.resolve(import.meta.dirname, "../fixtures/simple.docx");
+
+type EntityFileField = {
+  id: string;
+  propertyId: string;
+  content: { type: string };
+};
+
+type EntityWithFields = {
+  fields?: EntityFileField[];
+};
+
+type CreateUploadedDocumentRouteOptions = {
+  fileName: string;
+  request: APIRequestContext;
+  workspace: TestWorkspace;
+};
+
+type UploadedDocumentRoute = {
+  entityId: string;
+  path: string;
+};
+
+export const createUploadedDocumentRoute = async ({
+  fileName,
+  request,
+  workspace,
+}: CreateUploadedDocumentRouteOptions): Promise<UploadedDocumentRoute> => {
+  const uploaded = await apiUploadDocx(
+    request,
+    workspace.id,
+    workspace.filePropertyId,
+    {
+      name: fileName,
+      mimeType: DOCX_MIME,
+      buffer: await readFile(DOCX_PATH),
+    },
+  );
+
+  const entity = await apiGet<EntityWithFields>(
+    request,
+    `/entities/${workspace.id}/entity/${uploaded.entityId}`,
+  );
+  const fileField = entity.fields?.find(
+    (field) =>
+      field.propertyId === workspace.filePropertyId &&
+      field.content.type === "file",
+  );
+  if (!fileField) {
+    throw new Error("Uploaded entity did not include the expected file field");
+  }
+
+  return {
+    entityId: uploaded.entityId,
+    path:
+      `/workspaces/${workspace.id}/${workspace.viewId}/document` +
+      `?entity=${uploaded.entityId}&field=${fileField.id}`,
+  };
+};

--- a/apps/web/e2e/helpers/document.ts
+++ b/apps/web/e2e/helpers/document.ts
@@ -1,4 +1,5 @@
 import type { APIRequestContext } from "@playwright/test";
+import { panic } from "better-result";
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 
@@ -56,7 +57,7 @@ export const createUploadedDocumentRoute = async ({
       field.content.type === "file",
   );
   if (!fileField) {
-    throw new Error("Uploaded entity did not include the expected file field");
+    panic("Uploaded entity did not include the expected file field");
   }
 
   return {

--- a/apps/web/e2e/helpers/workspace.ts
+++ b/apps/web/e2e/helpers/workspace.ts
@@ -1,4 +1,5 @@
 import type { APIRequestContext } from "@playwright/test";
+import { Result, panic } from "better-result";
 import { randomUUID } from "node:crypto";
 
 import { apiDelete, apiGet, apiPut } from "./api";
@@ -18,6 +19,13 @@ type WorkspaceReadProperty = {
 
 type ViewListItem = { id: string };
 
+type TestWorkspaceOperations = {
+  create: (workspace: { id: string; name: string }) => Promise<void>;
+  delete: (workspaceId: string) => Promise<void>;
+  properties: (workspaceId: string) => Promise<WorkspaceReadProperty[]>;
+  views: (workspaceId: string) => Promise<ViewListItem[]>;
+};
+
 const isFileProperty = (
   p: WorkspaceReadProperty,
 ): p is FileProperty & WorkspaceReadProperty => p.content.type === "file";
@@ -25,43 +33,84 @@ const isFileProperty = (
 export const createTestWorkspace = async (
   request: APIRequestContext,
   label = "e2e",
+): Promise<TestWorkspace> =>
+  await createTestWorkspaceWithOperations(
+    {
+      create: async ({ id, name }) => {
+        await apiPut(
+          request,
+          "/workspaces",
+          {
+            id,
+            name,
+            filePropertyName: "Documents",
+          },
+          { invalidates: true },
+        );
+      },
+      delete: async (workspaceId) => {
+        await deleteTestWorkspace(request, workspaceId);
+      },
+      properties: async (workspaceId) =>
+        await apiGet<WorkspaceReadProperty[]>(
+          request,
+          `/properties/${workspaceId}`,
+        ),
+      views: async (workspaceId) =>
+        await apiGet<ViewListItem[]>(request, `/views/${workspaceId}`),
+    },
+    label,
+  );
+
+export const createTestWorkspaceWithOperations = async (
+  operations: TestWorkspaceOperations,
+  label = "e2e",
 ): Promise<TestWorkspace> => {
   const workspaceId = randomUUID();
 
-  await apiPut(
-    request,
-    "/workspaces",
-    {
-      id: workspaceId,
-      name: `${label}-${workspaceId.slice(0, 8)}`,
-      filePropertyName: "Documents",
-    },
-    { invalidates: true },
-  );
+  await operations.create({
+    id: workspaceId,
+    name: `${label}-${workspaceId.slice(0, 8)}`,
+  });
 
-  // Find the file property and the first view, both auto-created on workspace creation.
-  const properties = await apiGet<WorkspaceReadProperty[]>(
-    request,
-    `/properties/${workspaceId}`,
-  );
-  const fileProperty = properties.find(isFileProperty);
-  if (!fileProperty) {
-    throw new Error(
-      `workspace ${workspaceId} has no file property: ${JSON.stringify(properties)}`,
+  const initialized = await Result.tryPromise(async () => {
+    // Find the file property and first view, both auto-created with the workspace.
+    const properties = await operations.properties(workspaceId);
+    const fileProperty = properties.find(isFileProperty);
+    if (!fileProperty) {
+      panic(
+        `workspace ${workspaceId} has no file property: ${JSON.stringify(properties)}`,
+      );
+    }
+
+    const views = await operations.views(workspaceId);
+    const firstView = views.at(0);
+    if (!firstView) {
+      panic(`workspace ${workspaceId} has no views`);
+    }
+
+    return {
+      id: workspaceId,
+      filePropertyId: fileProperty.id,
+      viewId: firstView.id,
+    };
+  });
+
+  if (Result.isOk(initialized)) {
+    return initialized.value;
+  }
+
+  const cleanup = await Result.tryPromise(async () => {
+    await operations.delete(workspaceId);
+  });
+  if (Result.isError(cleanup)) {
+    throw new AggregateError(
+      [initialized.error.cause, cleanup.error.cause],
+      `workspace ${workspaceId} setup and rollback both failed`,
     );
   }
 
-  const views = await apiGet<ViewListItem[]>(request, `/views/${workspaceId}`);
-  const firstView = views.at(0);
-  if (!firstView) {
-    throw new Error(`workspace ${workspaceId} has no views`);
-  }
-
-  return {
-    id: workspaceId,
-    filePropertyId: fileProperty.id,
-    viewId: firstView.id,
-  };
+  throw initialized.error.cause;
 };
 
 export const deleteTestWorkspace = async (

--- a/apps/web/e2e/specs/chat.spec.ts
+++ b/apps/web/e2e/specs/chat.spec.ts
@@ -4,87 +4,81 @@ import { expect, test } from "../helpers/test";
 // usage_entitlements row — the dark-launch default every production org
 // starts in. We deliberately do not create an entitlement here: regressions
 // that only surface in that default state must fail this spec.
-test(
-  "chat composer sends a message and renders the assistant reply",
-  {
-    tag: "@dev-canary",
-  },
-  async ({ page }) => {
-    // A route is ready when its UI is ready, not when every cold Vite resource
-    // has fired the browser load event. Commit the document, then synchronize on
-    // the composer below.
-    await page.goto("/chat", { waitUntil: "commit" });
+test("chat composer sends a message and renders the assistant reply", async ({
+  page,
+}) => {
+  // A route is ready when its UI is ready, not when every cold Vite resource
+  // has fired the browser load event. Commit the document, then synchronize on
+  // the composer below.
+  await page.goto("/chat", { waitUntil: "commit" });
 
-    // Route error boundary heading (apps/web/src/components/route-components.tsx,
-    // title routeError.title). Checked after every step below; declared
-    // once so the assertions read the same way each time.
-    const errorBoundary = page.getByRole("heading", {
-      name: "This page couldn’t be opened",
-    });
-    await expect(errorBoundary).toHaveCount(0);
+  // Route error boundary heading (apps/web/src/components/route-components.tsx,
+  // title routeError.title). Checked after every step below; declared
+  // once so the assertions read the same way each time.
+  const errorBoundary = page.getByRole("heading", {
+    name: "This page couldn’t be opened",
+  });
+  await expect(errorBoundary).toHaveCount(0);
 
-    // The composer's contenteditable carries an explicit role and
-    // aria-label (chat-editor-provider editorProps); the name filter
-    // keeps the locator unique even when other textbox-role editors
-    // (e.g. folio) are mounted.
-    const composer = page.getByRole("textbox", {
-      name: /type your question/iu,
-    });
-    // First locator after navigation: a cold Vite dev server compiles the
-    // chat route chunk on demand, which can exceed the default 10s expect
-    // timeout on a fresh CI runner (see playwright.config.ts).
-    await expect(composer).toBeVisible({ timeout: 30_000 });
+  // The composer's contenteditable carries an explicit role and
+  // aria-label (chat-editor-provider editorProps); the name filter
+  // keeps the locator unique even when other textbox-role editors
+  // (e.g. folio) are mounted.
+  const composer = page.getByRole("textbox", {
+    name: /type your question/iu,
+  });
+  // First locator after navigation: a cold Vite dev server compiles the
+  // chat route chunk on demand, which can exceed the default 10s expect
+  // timeout on a fresh CI runner (see playwright.config.ts).
+  await expect(composer).toBeVisible({ timeout: 30_000 });
 
-    const messageText = "Hello from the stella e2e chat spec";
-    await composer.click();
-    await composer.pressSequentially(messageText);
+  const messageText = "Hello from the stella e2e chat spec";
+  await composer.click();
+  await composer.pressSequentially(messageText);
 
-    await page.getByRole("button", { name: "Send message" }).click();
+  await page.getByRole("button", { name: "Send message" }).click();
 
-    // Sending from /chat fires the request and navigates to the new
-    // thread (apps/web/src/routes/_protected.chat/index.tsx:389); the
-    // thread id is a client-generated uuidv7.
-    // The thread-creation request + client nav can exceed the default 10s expect
-    // timeout on a cold CI runner — the same headroom the waits below use.
-    await expect(page).toHaveURL(
-      /\/chat\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/u,
-      { timeout: 30_000 },
-    );
+  // Sending from /chat fires the request and navigates to the new
+  // thread (apps/web/src/routes/_protected.chat/index.tsx:389); the
+  // thread id is a client-generated uuidv7.
+  // The thread-creation request + client nav can exceed the default 10s expect
+  // timeout on a cold CI runner — the same headroom the waits below use.
+  await expect(page).toHaveURL(
+    /\/chat\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/u,
+    { timeout: 30_000 },
+  );
 
-    const transcript = page.getByRole("log");
-    // First assertion on the thread route: its lazy chunk cold-compiles
-    // on a fresh dev server, so allow the same headroom as the composer.
-    await expect(transcript.getByText(messageText)).toBeVisible({
-      timeout: 30_000,
-    });
+  const transcript = page.getByRole("log");
+  // First assertion on the thread route: its lazy chunk cold-compiles
+  // on a fresh dev server, so allow the same headroom as the composer.
+  await expect(transcript.getByText(messageText)).toBeVisible({
+    timeout: 30_000,
+  });
 
-    // A "Copy" action renders only under an assistant message that has
-    // non-empty text (AssistantMessageActions in
-    // apps/web/src/components/chat/chat-thread-messages.tsx) — neither the
-    // thinking indicator nor the error bubble has one — so its presence
-    // proves an actual reply painted, independent of what the registered
-    // mock model streams. Generous timeout: cold Vite chunks + the
-    // streamed response both land inside this wait.
-    await expect(transcript.getByRole("button", { name: "Copy" })).toBeVisible({
-      timeout: 30_000,
-    });
+  // A "Copy" action renders only under an assistant message that has
+  // non-empty text (AssistantMessageActions in
+  // apps/web/src/components/chat/chat-thread-messages.tsx) — neither the
+  // thinking indicator nor the error bubble has one — so its presence
+  // proves an actual reply painted, independent of what the registered
+  // mock model streams. Generous timeout: cold Vite chunks + the
+  // streamed response both land inside this wait.
+  await expect(transcript.getByRole("button", { name: "Copy" })).toBeVisible({
+    timeout: 30_000,
+  });
 
-    // "Retry" appears on the latest assistant message only once the
-    // stream finished, so waiting for it pins the turn as complete before
-    // the negative assertions below — otherwise an error chunk arriving
-    // after partial text could slip past them.
-    await expect(transcript.getByRole("button", { name: "Retry" })).toBeVisible(
-      {
-        timeout: 30_000,
-      },
-    );
+  // "Retry" appears on the latest assistant message only once the
+  // stream finished, so waiting for it pins the turn as complete before
+  // the negative assertions below — otherwise an error chunk arriving
+  // after partial text could slip past them.
+  await expect(transcript.getByRole("button", { name: "Retry" })).toBeVisible({
+    timeout: 30_000,
+  });
 
-    // Every ChatErrorMessage variant renders a "Resend" button
-    // (apps/web/src/components/chat/chat-thread-messages.tsx:329-340);
-    // zero of them means the turn ended without a stream error.
-    await expect(
-      transcript.getByRole("button", { name: "Resend" }),
-    ).toHaveCount(0);
-    await expect(errorBoundary).toHaveCount(0);
-  },
-);
+  // Every ChatErrorMessage variant renders a "Resend" button
+  // (apps/web/src/components/chat/chat-thread-messages.tsx:329-340);
+  // zero of them means the turn ended without a stream error.
+  await expect(transcript.getByRole("button", { name: "Resend" })).toHaveCount(
+    0,
+  );
+  await expect(errorBoundary).toHaveCount(0);
+});

--- a/apps/web/e2e/specs/dev-autocomplete.spec.ts
+++ b/apps/web/e2e/specs/dev-autocomplete.spec.ts
@@ -4,24 +4,20 @@ import { expect, test } from "../helpers/test";
 // this same spec proves the dev route cannot leak into the built app.
 const EXPECTS_DEV_ROUTES = process.env["E2E_EXPECT_DEV_ROUTES"] !== "false";
 
-test(
-  "autocomplete playground matches the web runtime mode",
-  {
-    tag: "@dev-canary",
-  },
-  async ({ page }) => {
-    await page.goto("/dev/autocomplete", { waitUntil: "commit" });
+test("autocomplete playground matches the web runtime mode", async ({
+  page,
+}) => {
+  await page.goto("/dev/autocomplete", { waitUntil: "commit" });
 
-    if (!EXPECTS_DEV_ROUTES) {
-      await expect(page).toHaveURL((url) => url.pathname === "/");
-      return;
-    }
+  if (!EXPECTS_DEV_ROUTES) {
+    await expect(page).toHaveURL((url) => url.pathname === "/");
+    return;
+  }
 
-    await expect(page).toHaveURL(/\/dev\/autocomplete$/u);
-    await expect(
-      page.getByRole("heading", {
-        name: "stella autocomplete — dev playground",
-      }),
-    ).toBeVisible({ timeout: 30_000 });
-  },
-);
+  await expect(page).toHaveURL(/\/dev\/autocomplete$/u);
+  await expect(
+    page.getByRole("heading", {
+      name: "stella autocomplete — dev playground",
+    }),
+  ).toBeVisible({ timeout: 30_000 });
+});

--- a/apps/web/e2e/specs/route-smoke.spec.ts
+++ b/apps/web/e2e/specs/route-smoke.spec.ts
@@ -13,7 +13,8 @@ import {
   partitionRoundRobin,
   resolveE2eExecutionProfile,
 } from "../execution-profile";
-import { apiDelete, apiGet, apiPut, apiUploadDocx } from "../helpers/api";
+import { apiDelete, apiPut } from "../helpers/api";
+import { createUploadedDocumentRoute } from "../helpers/document";
 import {
   type RouteNetworkMetrics,
   assertNetworkBaseline,
@@ -42,9 +43,6 @@ const DEFAULT_SETTLE_MS = 1000;
 const REPO_ROOT = path.resolve(import.meta.dirname, "../../../..");
 const STORAGE_STATE = path.resolve(REPO_ROOT, ".playwright/storage-state.json");
 
-const DOCX_MIME =
-  "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
-const DOCX_PATH = path.resolve(import.meta.dirname, "../fixtures/simple.docx");
 const ROUTE_TREE_PATH = path.resolve(
   import.meta.dirname,
   "../../src/routeTree.gen.ts",
@@ -263,7 +261,11 @@ const declareRouteSmokeGroup = ({
       createdWorkspace = workspace;
       const contactId = await createContact(apiRequest);
       createdContactId = contactId;
-      const documentRoute = await createDocumentRoute(apiRequest, workspace);
+      const documentRoute = await createUploadedDocumentRoute({
+        fileName: "route-smoke.docx",
+        request: apiRequest,
+        workspace,
+      });
       world = { workspace, contactId, documentRoute };
     });
 
@@ -379,47 +381,6 @@ const createContact = async (request: APIRequestContext): Promise<string> => {
   });
 
   return contactId;
-};
-
-const createDocumentRoute = async (
-  request: APIRequestContext,
-  workspace: TestWorkspace,
-): Promise<{ entityId: string; path: string }> => {
-  const docxBuffer = await readFile(DOCX_PATH);
-  const uploaded = await apiUploadDocx(
-    request,
-    workspace.id,
-    workspace.filePropertyId,
-    {
-      name: "route-smoke.docx",
-      mimeType: DOCX_MIME,
-      buffer: docxBuffer,
-    },
-  );
-
-  const entity = await apiGet<{
-    fields?: {
-      id: string;
-      propertyId: string;
-      content: { type: string };
-    }[];
-  }>(request, `/entities/${workspace.id}/entity/${uploaded.entityId}`);
-
-  const fileField = entity.fields?.find(
-    (field) =>
-      field.propertyId === workspace.filePropertyId &&
-      field.content.type === "file",
-  );
-  if (!fileField) {
-    throw new Error("Uploaded entity did not include the expected file field");
-  }
-
-  return {
-    entityId: uploaded.entityId,
-    path:
-      `/workspaces/${workspace.id}/${workspace.viewId}/document` +
-      `?entity=${uploaded.entityId}&field=${fileField.id}`,
-  };
 };
 
 const smokeRoute = async ({

--- a/apps/web/e2e/specs/upload-docx.spec.ts
+++ b/apps/web/e2e/specs/upload-docx.spec.ts
@@ -73,109 +73,104 @@ test.describe("DOCX upload + inspector", () => {
     workspace = null;
   });
 
-  test(
-    "uploaded DOCX opens from the matter with its AI overlay",
-    {
-      tag: "@dev-canary",
-    },
-    async ({ browserErrors, page, request }) => {
-      const testWorkspace = workspace;
-      if (testWorkspace === null) {
-        throw new Error("Test workspace was not created");
-      }
+  test("uploaded DOCX opens from the matter with its AI overlay", async ({
+    browserErrors,
+    page,
+    request,
+  }) => {
+    const testWorkspace = workspace;
+    if (testWorkspace === null) {
+      throw new Error("Test workspace was not created");
+    }
 
-      const docxBuffer = await readFile(DOCX_PATH);
+    const docxBuffer = await readFile(DOCX_PATH);
 
-      const uploaded = await apiUploadDocx(
-        request,
-        testWorkspace.id,
-        testWorkspace.filePropertyId,
-        {
-          name: "stella-e2e.docx",
-          mimeType: DOCX_MIME,
-          buffer: docxBuffer,
-        },
-      );
-      expect(uploaded.entityId).toBeTruthy();
-
-      const { cookies } = await request.storageState();
-      await page.context().addCookies(cookies);
-
-      await expect
-        .poll(
-          async () =>
-            await apiStatus(page.request, `/workspaces/${testWorkspace.id}`),
-          {
-            message: "browser context can read the created workspace",
-            timeout: 10_000,
-          },
-        )
-        .toBe(200);
-
-      // Exercise the user path that originally exposed the route-context race:
-      // enter the matter first, then mount the cold lazy file-chat overlay by
-      // opening the file from the table. A direct document URL does not cover
-      // this client-side transition.
-      await page.goto(
-        `/workspaces/${testWorkspace.id}/${testWorkspace.viewId}`,
-        {
-          waitUntil: "domcontentloaded",
-        },
-      );
-
-      // New matters land on their Overview view. Move through the visible Table
-      // tab before opening the uploaded file so this remains a client-side user
-      // transition instead of falling back to a direct document URL.
-      const tableTab = page.getByRole("tab", { exact: true, name: "Table" });
-      await expect(tableTab).toBeVisible({ timeout: 30_000 });
-      await tableTab.click();
-
-      const fileButton = page.getByRole("button", {
-        exact: true,
+    const uploaded = await apiUploadDocx(
+      request,
+      testWorkspace.id,
+      testWorkspace.filePropertyId,
+      {
         name: "stella-e2e.docx",
-      });
-      await expect(fileButton).toBeVisible({ timeout: 30_000 });
-      await fileButton.click();
+        mimeType: DOCX_MIME,
+        buffer: docxBuffer,
+      },
+    );
+    expect(uploaded.entityId).toBeTruthy();
 
-      // Prove the optional overlay itself mounted; asserting only document text
-      // would pass if its local error boundary had silently removed the overlay.
-      await expect(
-        page.getByRole("toolbar", { name: "AI message composer" }),
-      ).toBeVisible({ timeout: 45_000 });
+    const { cookies } = await request.storageState();
+    await page.context().addCookies(cookies);
 
-      // Positive proof the viewer actually rendered: the fixture's first
-      // paragraph appears in the painted layout. This catches render crashes
-      // (an error boundary fallback wouldn't contain this string) without an
-      // arbitrary sleep. Generous timeout because in CI the Folio chunk
-      // compiles + loads cold AND the DOCX file is fetched from the API +
-      // parsed.
-      //
-      // Scope to `.layout-run-text` (emitted by the layout painter in
-      // packages/folio/src/core/layout-painter/renderParagraph.ts) rather
-      // than getByText so the assertion targets the *visible* painted span
-      // only. The hidden ProseMirror at left:-9999px also contains the same
-      // text inside a <p> under aria-label="Document content" — a bare
-      // getByText hits both elements and trips Playwright strict mode.
-      const docxText = page.locator(".layout-run-text", {
-        hasText: "Stella E2E test document.",
-      });
-      try {
-        await expect(docxText).toBeVisible({ timeout: 45_000 });
-      } catch (error) {
-        // Surface any errors collected so far — they're usually the real cause
-        // of the viewer never mounting (network failure, render crash caught
-        // by an error boundary, etc.).
-        const errors = browserErrors.entries();
-        if (errors.length > 0) {
-          throw new Error(
-            `viewer text never appeared; collected errors:\n${errors.join("\n\n")}`,
-            { cause: error },
-          );
-        }
-        throw error;
+    await expect
+      .poll(
+        async () =>
+          await apiStatus(page.request, `/workspaces/${testWorkspace.id}`),
+        {
+          message: "browser context can read the created workspace",
+          timeout: 10_000,
+        },
+      )
+      .toBe(200);
+
+    // Exercise the user path that originally exposed the route-context race:
+    // enter the matter first, then mount the cold lazy file-chat overlay by
+    // opening the file from the table. A direct document URL does not cover
+    // this client-side transition.
+    await page.goto(`/workspaces/${testWorkspace.id}/${testWorkspace.viewId}`, {
+      waitUntil: "domcontentloaded",
+    });
+
+    // New matters land on their Overview view. Move through the visible Table
+    // tab before opening the uploaded file so this remains a client-side user
+    // transition instead of falling back to a direct document URL.
+    const tableTab = page.getByRole("tab", { exact: true, name: "Table" });
+    await expect(tableTab).toBeVisible({ timeout: 30_000 });
+    await tableTab.click();
+
+    const fileButton = page.getByRole("button", {
+      exact: true,
+      name: "stella-e2e.docx",
+    });
+    await expect(fileButton).toBeVisible({ timeout: 30_000 });
+    await fileButton.click();
+
+    // Prove the optional overlay itself mounted; asserting only document text
+    // would pass if its local error boundary had silently removed the overlay.
+    await expect(
+      page.getByRole("toolbar", { name: "AI message composer" }),
+    ).toBeVisible({ timeout: 45_000 });
+
+    // Positive proof the viewer actually rendered: the fixture's first
+    // paragraph appears in the painted layout. This catches render crashes
+    // (an error boundary fallback wouldn't contain this string) without an
+    // arbitrary sleep. Generous timeout because in CI the Folio chunk
+    // compiles + loads cold AND the DOCX file is fetched from the API +
+    // parsed.
+    //
+    // Scope to `.layout-run-text` (emitted by the layout painter in
+    // packages/folio/src/core/layout-painter/renderParagraph.ts) rather
+    // than getByText so the assertion targets the *visible* painted span
+    // only. The hidden ProseMirror at left:-9999px also contains the same
+    // text inside a <p> under aria-label="Document content" — a bare
+    // getByText hits both elements and trips Playwright strict mode.
+    const docxText = page.locator(".layout-run-text", {
+      hasText: "Stella E2E test document.",
+    });
+    try {
+      await expect(docxText).toBeVisible({ timeout: 45_000 });
+    } catch (error) {
+      // Surface any errors collected so far — they're usually the real cause
+      // of the viewer never mounting (network failure, render crash caught
+      // by an error boundary, etc.).
+      const errors = browserErrors.entries();
+      if (errors.length > 0) {
+        throw new Error(
+          `viewer text never appeared; collected errors:\n${errors.join("\n\n")}`,
+          { cause: error },
+        );
       }
-    },
-  );
+      throw error;
+    }
+  });
 
   test("browser edit save creates a persisted DOCX version with the typed text", async ({
     page,

--- a/apps/web/e2e/specs/vite-dependency-canary.spec.ts
+++ b/apps/web/e2e/specs/vite-dependency-canary.spec.ts
@@ -1,0 +1,78 @@
+import { randomUUID } from "node:crypto";
+
+import { createUploadedDocumentRoute } from "../helpers/document";
+import { expect, test } from "../helpers/test";
+import {
+  type TestWorkspace,
+  createTestWorkspace,
+  deleteTestWorkspace,
+} from "../helpers/workspace";
+
+const EXPECTS_DEV_ROUTES = process.env["E2E_EXPECT_DEV_ROUTES"] !== "false";
+
+test.describe("Vite dependency optimizer canary", () => {
+  let workspace: TestWorkspace | null = null;
+
+  test.skip(
+    !EXPECTS_DEV_ROUTES,
+    "This optimizer canary applies only to the Vite development server",
+  );
+
+  test.beforeEach(async ({ request }) => {
+    workspace = await createTestWorkspace(request, "vite-canary");
+  });
+
+  test.afterEach(async ({ request }) => {
+    if (workspace === null) {
+      return;
+    }
+
+    await deleteTestWorkspace(request, workspace.id);
+    workspace = null;
+  });
+
+  test("cold lazy dependency graphs settle without restarting Vite", async ({
+    page,
+    request,
+  }) => {
+    const testWorkspace = workspace;
+    if (testWorkspace === null) {
+      throw new Error("Test workspace was not created");
+    }
+
+    const documentRoute = await createUploadedDocumentRoute({
+      fileName: "vite-canary.docx",
+      request,
+      workspace: testWorkspace,
+    });
+
+    await page.goto("/chat", { waitUntil: "commit" });
+    await expect(
+      page.getByRole("textbox", { name: /type your question/iu }),
+    ).toBeVisible({ timeout: 30_000 });
+
+    // The thread route is a separate lazy chunk. A missing record is valid for
+    // this dependency check; the route deliberately supports an empty thread.
+    await page.goto(`/chat/${randomUUID()}`, { waitUntil: "commit" });
+    await expect(page.getByRole("log")).toBeVisible({ timeout: 30_000 });
+
+    // A direct document route mounts the Folio editor and file-chat overlay
+    // without repeating the production suite's table-navigation journey.
+    await page.goto(documentRoute.path, { waitUntil: "commit" });
+    await expect(
+      page.getByRole("toolbar", { name: "AI message composer" }),
+    ).toBeVisible({ timeout: 45_000 });
+    await expect(
+      page.locator(".layout-run-text", {
+        hasText: "Stella E2E test document.",
+      }),
+    ).toBeVisible({ timeout: 45_000 });
+
+    await page.goto("/dev/autocomplete", { waitUntil: "commit" });
+    await expect(
+      page.getByRole("heading", {
+        name: "stella autocomplete — dev playground",
+      }),
+    ).toBeVisible({ timeout: 30_000 });
+  });
+});

--- a/apps/web/e2e/specs/vite-dependency-canary.spec.ts
+++ b/apps/web/e2e/specs/vite-dependency-canary.spec.ts
@@ -1,3 +1,4 @@
+import type { Page } from "@playwright/test";
 import { randomUUID } from "node:crypto";
 
 import { createUploadedDocumentRoute } from "../helpers/document";
@@ -32,6 +33,8 @@ test.describe("Vite dependency optimizer canary", () => {
   });
 
   test("cold lazy dependency graphs settle without restarting Vite", async ({
+    browserErrors,
+    context,
     page,
     request,
   }) => {
@@ -46,33 +49,67 @@ test.describe("Vite dependency optimizer canary", () => {
       workspace: testWorkspace,
     });
 
-    await page.goto("/chat", { waitUntil: "commit" });
-    await expect(
-      page.getByRole("textbox", { name: /type your question/iu }),
-    ).toBeVisible({ timeout: 30_000 });
+    const [threadPage, documentPage, autocompletePage] = await Promise.all([
+      context.newPage(),
+      context.newPage(),
+      context.newPage(),
+    ]);
+    const extraPages = [threadPage, documentPage, autocompletePage];
+    const detachErrorCollectors = extraPages.map((extraPage) =>
+      browserErrors.trackPage(extraPage),
+    );
 
-    // The thread route is a separate lazy chunk. A missing record is valid for
-    // this dependency check; the route deliberately supports an empty thread.
-    await page.goto(`/chat/${randomUUID()}`, { waitUntil: "commit" });
-    await expect(page.getByRole("log")).toBeVisible({ timeout: 30_000 });
-
-    // A direct document route mounts the Folio editor and file-chat overlay
-    // without repeating the production suite's table-navigation journey.
-    await page.goto(documentRoute.path, { waitUntil: "commit" });
-    await expect(
-      page.getByRole("toolbar", { name: "AI message composer" }),
-    ).toBeVisible({ timeout: 45_000 });
-    await expect(
-      page.locator(".layout-run-text", {
-        hasText: "Stella E2E test document.",
-      }),
-    ).toBeVisible({ timeout: 45_000 });
-
-    await page.goto("/dev/autocomplete", { waitUntil: "commit" });
-    await expect(
-      page.getByRole("heading", {
-        name: "stella autocomplete — dev playground",
-      }),
-    ).toBeVisible({ timeout: 30_000 });
+    try {
+      // These graphs are independent. Requesting them concurrently lets Vite
+      // compile shared modules once without serializing four cold route waits.
+      await Promise.all([
+        mountChatIndex(page),
+        mountChatThread(threadPage),
+        mountDocumentRoute(documentPage, documentRoute.path),
+        mountAutocomplete(autocompletePage),
+      ]);
+    } finally {
+      await Promise.all(extraPages.map(async (extraPage) => extraPage.close()));
+      for (const detach of detachErrorCollectors) {
+        detach();
+      }
+    }
   });
 });
+
+const mountChatIndex = async (page: Page): Promise<void> => {
+  await page.goto("/chat", { waitUntil: "commit" });
+  await expect(
+    page.getByRole("textbox", { name: /type your question/iu }),
+  ).toBeVisible({ timeout: 45_000 });
+};
+
+const mountChatThread = async (page: Page): Promise<void> => {
+  // The thread route is a separate lazy chunk. A missing record is valid for
+  // this dependency check; the route deliberately supports an empty thread.
+  await page.goto(`/chat/${randomUUID()}`, { waitUntil: "commit" });
+  await expect(page.getByRole("log")).toBeVisible({ timeout: 45_000 });
+};
+
+const mountDocumentRoute = async (page: Page, route: string): Promise<void> => {
+  // A direct document route mounts the Folio editor and file-chat overlay
+  // without repeating the production suite's table-navigation journey.
+  await page.goto(route, { waitUntil: "commit" });
+  await expect(
+    page.getByRole("toolbar", { name: "AI message composer" }),
+  ).toBeVisible({ timeout: 45_000 });
+  await expect(
+    page.locator(".layout-run-text", {
+      hasText: "Stella E2E test document.",
+    }),
+  ).toBeVisible({ timeout: 45_000 });
+};
+
+const mountAutocomplete = async (page: Page): Promise<void> => {
+  await page.goto("/dev/autocomplete", { waitUntil: "commit" });
+  await expect(
+    page.getByRole("heading", {
+      name: "stella autocomplete — dev playground",
+    }),
+  ).toBeVisible({ timeout: 45_000 });
+};

--- a/apps/web/e2e/specs/vite-dependency-canary.spec.ts
+++ b/apps/web/e2e/specs/vite-dependency-canary.spec.ts
@@ -14,6 +14,8 @@ const EXPECTS_DEV_ROUTES = process.env["E2E_EXPECT_DEV_ROUTES"] !== "false";
 test.describe("Vite dependency optimizer canary", () => {
   let workspace: TestWorkspace | null = null;
 
+  test.setTimeout(90_000);
+
   test.skip(
     !EXPECTS_DEV_ROUTES,
     "This optimizer canary applies only to the Vite development server",
@@ -60,11 +62,10 @@ test.describe("Vite dependency optimizer canary", () => {
     );
 
     try {
-      // These graphs are independent. Requesting them concurrently lets Vite
-      // compile shared modules once without serializing four cold route waits.
+      // Bound cold compilation to two graphs at once. Four-way contention can
+      // starve a route on CI; these pairs still overlap shared module work.
+      await Promise.all([mountChatIndex(page), mountChatThread(threadPage)]);
       await Promise.all([
-        mountChatIndex(page),
-        mountChatThread(threadPage),
         mountDocumentRoute(documentPage, documentRoute.path),
         mountAutocomplete(autocompletePage),
       ]);
@@ -81,14 +82,14 @@ const mountChatIndex = async (page: Page): Promise<void> => {
   await page.goto("/chat", { waitUntil: "commit" });
   await expect(
     page.getByRole("textbox", { name: /type your question/iu }),
-  ).toBeVisible({ timeout: 45_000 });
+  ).toBeVisible({ timeout: 60_000 });
 };
 
 const mountChatThread = async (page: Page): Promise<void> => {
   // The thread route is a separate lazy chunk. A missing record is valid for
   // this dependency check; the route deliberately supports an empty thread.
   await page.goto(`/chat/${randomUUID()}`, { waitUntil: "commit" });
-  await expect(page.getByRole("log")).toBeVisible({ timeout: 45_000 });
+  await expect(page.getByRole("log")).toBeVisible({ timeout: 60_000 });
 };
 
 const mountDocumentRoute = async (page: Page, route: string): Promise<void> => {
@@ -97,12 +98,12 @@ const mountDocumentRoute = async (page: Page, route: string): Promise<void> => {
   await page.goto(route, { waitUntil: "commit" });
   await expect(
     page.getByRole("toolbar", { name: "AI message composer" }),
-  ).toBeVisible({ timeout: 45_000 });
+  ).toBeVisible({ timeout: 60_000 });
   await expect(
     page.locator(".layout-run-text", {
       hasText: "Stella E2E test document.",
     }),
-  ).toBeVisible({ timeout: 45_000 });
+  ).toBeVisible({ timeout: 60_000 });
 };
 
 const mountAutocomplete = async (page: Page): Promise<void> => {
@@ -111,5 +112,5 @@ const mountAutocomplete = async (page: Page): Promise<void> => {
     page.getByRole("heading", {
       name: "stella autocomplete — dev playground",
     }),
-  ).toBeVisible({ timeout: 45_000 });
+  ).toBeVisible({ timeout: 60_000 });
 };

--- a/apps/web/e2e/unit/workspace.test.ts
+++ b/apps/web/e2e/unit/workspace.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "bun:test";
+
+import { createTestWorkspaceWithOperations } from "../helpers/workspace";
+
+const fileProperty = [{ id: "file-property", content: { type: "file" } }];
+const firstView = [{ id: "first-view" }];
+
+describe("test workspace setup", () => {
+  test("rolls back every failure after workspace creation", async () => {
+    const failureStages = [
+      {
+        name: "property request",
+        properties: async () => await Promise.reject(new Error("properties")),
+        views: async () => firstView,
+      },
+      {
+        name: "missing file property",
+        properties: async () => [],
+        views: async () => firstView,
+      },
+      {
+        name: "view request",
+        properties: async () => fileProperty,
+        views: async () => await Promise.reject(new Error("views")),
+      },
+      {
+        name: "missing view",
+        properties: async () => fileProperty,
+        views: async () => [],
+      },
+    ];
+
+    await Promise.all(
+      failureStages.map(async (failure) => {
+        let createdId: string | null = null;
+        let deletedId: string | null = null;
+        const result = createTestWorkspaceWithOperations(
+          {
+            create: async ({ id }) => {
+              createdId = id;
+            },
+            delete: async (workspaceId) => {
+              deletedId = workspaceId;
+            },
+            properties: failure.properties,
+            views: failure.views,
+          },
+          failure.name,
+        );
+
+        const rejection = await result.then(
+          () => null,
+          (error: unknown) => error,
+        );
+        expect(rejection).toBeInstanceOf(Error);
+        expect(deletedId).toBe(createdId);
+      }),
+    );
+  });
+});

--- a/scripts/detect-e2e-changes.test.ts
+++ b/scripts/detect-e2e-changes.test.ts
@@ -33,6 +33,28 @@ const workflowJob = (jobId: string): string => {
     : workflow.slice(bodyStart, bodyStart + nextJob);
 };
 
+const workflowStepRun = (job: string, stepName: string): string => {
+  const marker = `\n      - name: ${stepName}\n`;
+  const start = job.indexOf(marker);
+  if (start === -1) {
+    throw new Error(`CI job is missing step ${stepName}`);
+  }
+  const bodyStart = start + marker.length;
+  const nextStep = job.slice(bodyStart).search(/\n {6}- name:/u);
+  const step =
+    nextStep === -1
+      ? job.slice(bodyStart)
+      : job.slice(bodyStart, bodyStart + nextStep);
+  const runMarker = "\n        run: ";
+  const runStart = step.indexOf(runMarker);
+  if (runStart === -1) {
+    throw new Error(`CI step ${stepName} is missing its run command`);
+  }
+  const run = step.slice(runStart + runMarker.length);
+  const runEnd = run.search(/\n(?= {0,8}\S)/u);
+  return (runEnd === -1 ? run : run.slice(0, runEnd)).trimEnd();
+};
+
 const detects = (scope: "core" | "landing", files: string[]) =>
   Bun.spawnSync(["bash", script, scope, ...files], {
     stdout: "pipe",
@@ -102,8 +124,16 @@ describe("detect-e2e-changes", () => {
     expect(canary).not.toContain("E2E_EXECUTION_PROFILE");
     expect(canary).not.toContain("Build web for route checks");
     expect(canary).not.toContain("Run Playwright shard");
-    expect(canary).toContain("e2e/specs/vite-dependency-canary.spec.ts");
-    expect(canary).not.toContain("--grep @dev-canary");
+    const canaryRun = workflowStepRun(canary, "Run Vite dependency canary");
+    expect(canaryRun).toBe(
+      [
+        ">-",
+        "          bun --filter @stll/web test:e2e --",
+        "          e2e/specs/vite-dependency-canary.spec.ts",
+        "          --project chromium",
+      ].join("\n"),
+    );
+    expect(canaryRun).not.toMatch(/--grep(?:=|\s)+["']?@dev-canary/u);
 
     const landing = workflowJob("e2e-landing");
     expect(landing).not.toContain("Start docker stack");

--- a/scripts/detect-e2e-changes.test.ts
+++ b/scripts/detect-e2e-changes.test.ts
@@ -102,6 +102,8 @@ describe("detect-e2e-changes", () => {
     expect(canary).not.toContain("E2E_EXECUTION_PROFILE");
     expect(canary).not.toContain("Build web for route checks");
     expect(canary).not.toContain("Run Playwright shard");
+    expect(canary).toContain("e2e/specs/vite-dependency-canary.spec.ts");
+    expect(canary).not.toContain("--grep @dev-canary");
 
     const landing = workflowJob("e2e-landing");
     expect(landing).not.toContain("Start docker stack");


### PR DESCRIPTION
Replace the Vite canary's full chat, upload, and autocomplete journeys with one focused optimizer-sensitive route walk. Full product behavior remains covered by production E2E; the canary mounts the chat, thread, Folio/document, and dev-autocomplete lazy graphs directly.

The workflow selects the dedicated spec by filename, with a workflow invariant preventing tag-based scope creep. The shared document-route fixture also removes duplicate setup from route smoke. Workspace initialization now rolls back every post-creation failure, backed by an invariant test over all setup failure stages.

Clean CI measured the canary Playwright step at 79 seconds versus 82 seconds on main: a 3-second (3.7%) reduction. The full job was 156 seconds versus 157 seconds, so the durable benefit is isolation and reduced product-journey coupling rather than a material critical-path saving. Production-build profiling found no repeatable devtools-transform saving, so this PR does not change build behavior.
