### PR TITLE
fix: drop unsupported value constraints from structured output schemas

### DIFF
--- a/apps/api/scripts/ai-provider-canary.ts
+++ b/apps/api/scripts/ai-provider-canary.ts
@@ -241,15 +241,15 @@ const CANARY_CACHING = {
 
 const structuredOutputSchema = v.strictObject({ ok: v.literal(true) });
 
-// Exercises the nested-array constraint shape that provider schema compilers
-// treat differently from a trivial object. The content is synthetic; this
-// canary exists to catch provider drift in the exact shared projection used by
-// production structured-output calls.
+// Exercises the nested shape and the value constraints (array bounds, string
+// lengths) that provider schema compilers treat differently from a trivial
+// object. The content is synthetic; this canary exists to catch provider drift
+// in the exact shared projection used by production structured-output calls.
 const nestedStructuredOutputSchema = v.strictObject({
   entries: v.pipe(
     v.array(
       v.strictObject({
-        heading: v.string(),
+        heading: v.pipe(v.string(), v.maxLength(120)),
         status: v.picklist(["accepted", "needs-work", "not-applicable"]),
         explanation: v.string(),
         primaryEvidence: v.pipe(

--- a/apps/api/src/dev/register-mock-ai.test.ts
+++ b/apps/api/src/dev/register-mock-ai.test.ts
@@ -28,9 +28,11 @@ const structuredOutputSchemaFor = (
 ): unknown => {
   const tanStackSchema = toTanStackValibotSchema(
     schema,
+    // The mock path's own purpose, not "structured-output": the synthesizer
+    // reads value constraints that real structured output drops.
     providerSafeJsonSchemaOptionsForTanStackProvider(
       provider,
-      "structured-output",
+      "mock-structured-output",
     ),
   );
   return convertSchemaToJsonSchema(tanStackSchema, {
@@ -99,10 +101,30 @@ const optionalFieldSchema = v.strictObject({
   note: v.optional(v.string()),
 });
 
+// Mirrors apps/api/src/lib/bbox/ai-generate-b-boxes.ts's `bboxOutputSchema`
+// shape: a required array that must be non-empty, plus a bounded number. The
+// synthesizer derives both from the projected schema, so it produces invalid
+// data the moment those constraints stop surviving the projection.
+const boundedCollectionSchema = v.strictObject({
+  boxes: v.pipe(
+    v.array(
+      v.strictObject({
+        // Narrower and wider than the synthesizer's own placeholder, so both
+        // the truncate and the pad path are covered.
+        code: v.pipe(v.string(), v.maxLength(2)),
+        label: v.pipe(v.string(), v.minLength(12)),
+        page: v.pipe(v.number(), v.integer(), v.minValue(1)),
+      }),
+    ),
+    v.minLength(1),
+  ),
+});
+
 const genericSynthesisBattery = [
   ["real templates/prefill schema", prefillOutputSchema],
   ["novel nested/array/enum/nullable schema", novelSchema],
   ["required-nullable ISO-date schema", nullableIsoDateSchema],
+  ["bounded non-empty collection schema", boundedCollectionSchema],
 ] as const;
 
 describe("mockStructuredData", () => {

--- a/apps/api/src/dev/register-mock-ai.test.ts
+++ b/apps/api/src/dev/register-mock-ai.test.ts
@@ -114,6 +114,11 @@ const boundedCollectionSchema = v.strictObject({
         code: v.pipe(v.string(), v.maxLength(2)),
         label: v.pipe(v.string(), v.minLength(12)),
         page: v.pipe(v.number(), v.integer(), v.minValue(1)),
+        // Fractional bounds on integer fields: satisfying the bound must not
+        // break the type. The upper one is negative so it is the binding
+        // constraint rather than the synthesizer's 0 default.
+        rank: v.pipe(v.number(), v.integer(), v.minValue(1.5)),
+        offset: v.pipe(v.number(), v.integer(), v.maxValue(-1.5)),
       }),
     ),
     v.minLength(1),

--- a/apps/api/src/dev/register-mock-ai.ts
+++ b/apps/api/src/dev/register-mock-ai.ts
@@ -491,15 +491,22 @@ const numberKeyword = (
 
 // The synthesized value has to satisfy the bounds the caller's own schema
 // enforces, not just the declared type: a `v.minValue(1)` field that comes
-// back as 0 fails the final `v.parse` exactly like a missing one would.
+// back as 0 fails the final `v.parse` exactly like a missing one would. A
+// fractional bound on an integer field has to be pulled inwards to a whole
+// number, or satisfying the bound would break the type instead.
 const synthesizeJsonSchemaNumber = (node: JsonSchemaNode): number => {
+  const isInteger = primaryType(node["type"]) === "integer";
+
   const minimum = numberKeyword(node, "minimum");
   if (minimum !== undefined) {
-    return minimum;
+    return isInteger ? Math.ceil(minimum) : minimum;
   }
 
   const maximum = numberKeyword(node, "maximum");
-  return maximum !== undefined && maximum < 0 ? maximum : 0;
+  if (maximum === undefined || maximum >= 0) {
+    return 0;
+  }
+  return isInteger ? Math.floor(maximum) : maximum;
 };
 
 const MOCK_STRING = "mock";

--- a/apps/api/src/dev/register-mock-ai.ts
+++ b/apps/api/src/dev/register-mock-ai.ts
@@ -440,10 +440,10 @@ const synthesizeJsonSchemaValue = (node: unknown): unknown => {
     case "array":
       return synthesizeJsonSchemaArray(node);
     case "string":
-      return "mock";
+      return synthesizeJsonSchemaString(node);
     case "number":
     case "integer":
-      return 0;
+      return synthesizeJsonSchemaNumber(node);
     case "boolean":
       return false;
     case "null":
@@ -481,6 +481,39 @@ const synthesizeJsonSchemaObject = (node: unknown): Record<string, unknown> => {
     result[key] = synthesizeJsonSchemaValue(propertySchema);
   }
   return result;
+};
+
+const numberKeyword = (
+  node: JsonSchemaNode,
+  key: string,
+): number | undefined =>
+  typeof node[key] === "number" ? node[key] : undefined;
+
+// The synthesized value has to satisfy the bounds the caller's own schema
+// enforces, not just the declared type: a `v.minValue(1)` field that comes
+// back as 0 fails the final `v.parse` exactly like a missing one would.
+const synthesizeJsonSchemaNumber = (node: JsonSchemaNode): number => {
+  const minimum = numberKeyword(node, "minimum");
+  if (minimum !== undefined) {
+    return minimum;
+  }
+
+  const maximum = numberKeyword(node, "maximum");
+  return maximum !== undefined && maximum < 0 ? maximum : 0;
+};
+
+const MOCK_STRING = "mock";
+
+const synthesizeJsonSchemaString = (node: JsonSchemaNode): string => {
+  const minLength = numberKeyword(node, "minLength") ?? 0;
+  const maxLength = numberKeyword(node, "maxLength");
+  if (maxLength !== undefined && maxLength < MOCK_STRING.length) {
+    return MOCK_STRING.slice(0, Math.max(maxLength, minLength));
+  }
+
+  return minLength <= MOCK_STRING.length
+    ? MOCK_STRING
+    : MOCK_STRING.padEnd(minLength, "-");
 };
 
 const synthesizeJsonSchemaArray = (node: JsonSchemaNode): unknown[] => {

--- a/apps/api/src/lib/provider-safe-json-schema.test.ts
+++ b/apps/api/src/lib/provider-safe-json-schema.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "bun:test";
 import fc from "fast-check";
 import * as v from "valibot";
 
+import { TANSTACK_AI_PROVIDERS } from "@stll/ai-catalog";
 import { propertyConfig } from "@stll/property-testing";
 
 import { toTanStackToolSchema } from "@/api/handlers/chat/tools/tanstack-tool-schema";
@@ -10,6 +11,7 @@ import {
   providerSafeJsonSchemaOptionsForTanStackProvider,
   projectToProviderSafeJsonSchema,
   PROVIDER_SAFE_JSON_SCHEMA_KEYWORDS,
+  VALUE_CONSTRAINT_JSON_SCHEMA_KEYWORDS,
 } from "@/api/lib/provider-safe-json-schema";
 import {
   projectSchemaInputJsonSchema,
@@ -129,23 +131,23 @@ describe("projectToProviderSafeJsonSchema", () => {
         "structured-output",
       ),
     ).toEqual({
-      arrayBoundStrategy: "omit",
       enumValueStrategy: "string-only",
       nullUnionStrategy: "openapi",
+      valueConstraintStrategy: "omit",
     });
     expect(
       providerSafeJsonSchemaOptionsForTanStackProvider("google", "tool"),
     ).toEqual({
-      arrayBoundStrategy: "preserve",
       enumValueStrategy: "string-only",
       nullUnionStrategy: "openapi",
+      valueConstraintStrategy: "preserve",
     });
     expect(
       providerSafeJsonSchemaOptionsForTanStackProvider("openrouter", "tool"),
     ).toEqual({
-      arrayBoundStrategy: "preserve",
       enumValueStrategy: "string-only",
       nullUnionStrategy: "json-schema",
+      valueConstraintStrategy: "preserve",
     });
     expect(
       providerSafeJsonSchemaOptionsForTanStackProvider(
@@ -153,13 +155,56 @@ describe("projectToProviderSafeJsonSchema", () => {
         "structured-output",
       ),
     ).toEqual({
-      arrayBoundStrategy: "preserve",
       enumValueStrategy: "json-schema",
       nullUnionStrategy: "json-schema",
+      valueConstraintStrategy: "omit",
     });
   });
 
-  test("keeps Gemini structured-output array bounds local", () => {
+  test("omits value constraints from every provider's structured output", () => {
+    for (const provider of TANSTACK_AI_PROVIDERS) {
+      expect(
+        providerSafeJsonSchemaOptionsForTanStackProvider(
+          provider,
+          "structured-output",
+        ).valueConstraintStrategy,
+      ).toBe("omit");
+      expect(
+        providerSafeJsonSchemaOptionsForTanStackProvider(provider, "tool")
+          .valueConstraintStrategy,
+      ).toBe("preserve");
+    }
+  });
+
+  test("drops every allowlisted value constraint under the omit strategy", () => {
+    const constrained = {
+      type: "object",
+      properties: Object.fromEntries(
+        VALUE_CONSTRAINT_JSON_SCHEMA_KEYWORDS.map((keyword, index) => [
+          `field${String(index)}`,
+          { type: "string", [keyword]: 4 },
+        ]),
+      ),
+    };
+
+    const { schema, droppedKeywords } = projectToProviderSafeJsonSchema(
+      constrained,
+      { valueConstraintStrategy: "omit" },
+    );
+
+    const projectedKeywords = collectKeywords(schema);
+    for (const [
+      index,
+      keyword,
+    ] of VALUE_CONSTRAINT_JSON_SCHEMA_KEYWORDS.entries()) {
+      expect(projectedKeywords.has(keyword)).toBe(false);
+      expect(droppedKeywords).toContain(
+        `properties.field${String(index)}.${keyword}`,
+      );
+    }
+  });
+
+  test("keeps structured-output array bounds local to the app", () => {
     const evidenceSchema = v.strictObject({
       source: v.string(),
       locator: v.string(),
@@ -180,20 +225,22 @@ describe("projectToProviderSafeJsonSchema", () => {
         v.maxLength(200),
       ),
     });
-    const providerSchema = convertSchemaToJsonSchema(
-      toTanStackValibotSchema(
-        sourceSchema,
-        providerSafeJsonSchemaOptionsForTanStackProvider(
-          "google",
-          "structured-output",
+    for (const provider of TANSTACK_AI_PROVIDERS) {
+      const providerSchema = convertSchemaToJsonSchema(
+        toTanStackValibotSchema(
+          sourceSchema,
+          providerSafeJsonSchemaOptionsForTanStackProvider(
+            provider,
+            "structured-output",
+          ),
         ),
-      ),
-    );
+      );
 
-    expect(providerSchema).toBeDefined();
-    const providerKeywords = collectProjectedSchemaKeywords(providerSchema);
-    expect(providerKeywords.has("minItems")).toBe(false);
-    expect(providerKeywords.has("maxItems")).toBe(false);
+      expect(providerSchema).toBeDefined();
+      const providerKeywords = collectProjectedSchemaKeywords(providerSchema);
+      expect(providerKeywords.has("minItems")).toBe(false);
+      expect(providerKeywords.has("maxItems")).toBe(false);
+    }
 
     expect(() => v.parse(sourceSchema, { entries: [] })).toThrow();
 

--- a/apps/api/src/lib/provider-safe-json-schema.ts
+++ b/apps/api/src/lib/provider-safe-json-schema.ts
@@ -88,7 +88,10 @@ export type ProviderSafeJsonSchemaProjection = {
 export type NullUnionStrategy = "json-schema" | "openapi";
 export type EnumValueStrategy = "json-schema" | "string-only";
 export type ValueConstraintStrategy = "preserve" | "omit";
-export type ProviderJsonSchemaPurpose = "structured-output" | "tool";
+export type ProviderJsonSchemaPurpose =
+  | "structured-output"
+  | "mock-structured-output"
+  | "tool";
 
 export type ProviderSafeJsonSchemaProjectionOptions = {
   enumValueStrategy?: EnumValueStrategy;
@@ -112,8 +115,14 @@ export const providerSafeJsonSchemaOptionsForTanStackProvider = (
   // request either: an OpenRouter model id resolves to an arbitrary upstream.
   // Constraints are validation, not shape, and the original Standard Schema
   // still validates the returned value locally, so structured output drops
-  // them for every provider. Tool schemas keep them: tool arguments are
-  // sampled without a schema compiler, and the bounds stay useful guidance.
+  // them for every provider.
+  //
+  // The other two purposes have no schema compiler to protect. Tool arguments
+  // are sampled directly, so their bounds stay useful guidance. The mock
+  // adapter goes further and *synthesizes* a response by walking these very
+  // keywords, so dropping them would hand it a schema it cannot satisfy: a
+  // required array would lose `minItems`, synthesize `[]`, and fail the
+  // caller's own `v.parse`.
   valueConstraintStrategy:
     purpose === "structured-output" ? "omit" : "preserve",
 });

--- a/apps/api/src/lib/provider-safe-json-schema.ts
+++ b/apps/api/src/lib/provider-safe-json-schema.ts
@@ -49,7 +49,25 @@ export const PROVIDER_SAFE_JSON_SCHEMA_KEYWORDS = [
   "example",
 ] as const;
 
+/**
+ * Allowlisted keywords that constrain a value rather than describe its shape.
+ * Dropped under `valueConstraintStrategy: "omit"`; the source Standard Schema
+ * still enforces them locally. The `satisfies` keeps this a subset of the
+ * allowlist, so a keyword can never be omitted here yet unreachable there.
+ */
+export const VALUE_CONSTRAINT_JSON_SCHEMA_KEYWORDS = [
+  "minimum",
+  "maximum",
+  "minItems",
+  "maxItems",
+  "minLength",
+  "maxLength",
+] as const satisfies readonly (typeof PROVIDER_SAFE_JSON_SCHEMA_KEYWORDS)[number][];
+
 const ALLOWED_KEYWORDS = new Set<string>(PROVIDER_SAFE_JSON_SCHEMA_KEYWORDS);
+const VALUE_CONSTRAINT_KEYWORDS = new Set<string>(
+  VALUE_CONSTRAINT_JSON_SCHEMA_KEYWORDS,
+);
 const ALLOWED_TYPE_VALUES = new Set([
   "array",
   "boolean",
@@ -69,34 +87,35 @@ export type ProviderSafeJsonSchemaProjection = {
 
 export type NullUnionStrategy = "json-schema" | "openapi";
 export type EnumValueStrategy = "json-schema" | "string-only";
-export type ArrayBoundStrategy = "preserve" | "omit";
+export type ValueConstraintStrategy = "preserve" | "omit";
 export type ProviderJsonSchemaPurpose = "structured-output" | "tool";
 
 export type ProviderSafeJsonSchemaProjectionOptions = {
-  arrayBoundStrategy?: ArrayBoundStrategy;
   enumValueStrategy?: EnumValueStrategy;
   nullUnionStrategy?: NullUnionStrategy;
+  valueConstraintStrategy?: ValueConstraintStrategy;
 };
 
 export const providerSafeJsonSchemaOptionsForTanStackProvider = (
   provider: string,
   purpose: ProviderJsonSchemaPurpose,
 ): ProviderSafeJsonSchemaProjectionOptions => ({
-  // Gemini counts array bounds against an undocumented structured-output
-  // schema complexity budget. A nested schema accepted without maxItems can
-  // be rejected with HTTP 400 as soon as the same bound is added. Bounds are
-  // validation constraints, not shape information, and the original Standard
-  // Schema still validates the returned value locally. Tool schemas use a
-  // separate profile because their bounds remain useful provider guidance.
-  arrayBoundStrategy:
-    provider === "google" && purpose === "structured-output"
-      ? "omit"
-      : "preserve",
   enumValueStrategy:
     provider === "google" || provider === "openrouter"
       ? "string-only"
       : "json-schema",
   nullUnionStrategy: provider === "google" ? "openapi" : "json-schema",
+  // Constrained-decoding compilers reject value constraints outright
+  // (Anthropic: HTTP 400 `For 'array' type, property 'maxItems' is not
+  // supported`) or count them against an undocumented schema complexity
+  // budget (Gemini). The set of rejecting providers is not knowable per
+  // request either: an OpenRouter model id resolves to an arbitrary upstream.
+  // Constraints are validation, not shape, and the original Standard Schema
+  // still validates the returned value locally, so structured output drops
+  // them for every provider. Tool schemas keep them: tool arguments are
+  // sampled without a schema compiler, and the bounds stay useful guidance.
+  valueConstraintStrategy:
+    purpose === "structured-output" ? "omit" : "preserve",
 });
 
 const isJsonObject = (value: unknown): value is JsonObject =>
@@ -132,9 +151,9 @@ const resolveLocalJsonPointer = (root: JsonObject, ref: string): unknown => {
 type ProjectionContext = {
   root: JsonObject;
   dropped: string[];
-  arrayBoundStrategy: ArrayBoundStrategy;
   enumValueStrategy: EnumValueStrategy;
   nullUnionStrategy: NullUnionStrategy;
+  valueConstraintStrategy: ValueConstraintStrategy;
 };
 
 type NormalizeSchemaDialectParams = {
@@ -866,8 +885,8 @@ const filterProviderSafeKeywords = ({
   const result: JsonObject = {};
   for (const [key, value] of Object.entries(node)) {
     if (
-      context.arrayBoundStrategy === "omit" &&
-      (key === "minItems" || key === "maxItems")
+      context.valueConstraintStrategy === "omit" &&
+      VALUE_CONSTRAINT_KEYWORDS.has(key)
     ) {
       context.dropped.push(joinPath(path, key));
       continue;
@@ -937,11 +956,11 @@ export const projectToProviderSafeJsonSchema = (
   const context: ProjectionContext = {
     root: schema,
     dropped: [],
-    arrayBoundStrategy: options.arrayBoundStrategy ?? "preserve",
     enumValueStrategy:
       options.enumValueStrategy ??
       (nullUnionStrategy === "openapi" ? "string-only" : "json-schema"),
     nullUnionStrategy,
+    valueConstraintStrategy: options.valueConstraintStrategy ?? "preserve",
   };
   const projected = projectNode({
     node: schema,

--- a/apps/api/src/lib/tanstack-ai-generate.ts
+++ b/apps/api/src/lib/tanstack-ai-generate.ts
@@ -11,7 +11,6 @@ import * as v from "valibot";
 
 import type { ModelRole } from "@stll/ai-catalog";
 
-import { isMockAI } from "@/api/consts";
 import type {
   AIRequestServiceTier,
   CachingDecision,
@@ -29,6 +28,7 @@ import { tanStackCacheControl } from "@/api/lib/tanstack-ai-caching";
 import {
   getTanStackTextModelById,
   getTanStackTextModelForRole,
+  isMockTextAdapterActive,
 } from "@/api/lib/tanstack-ai-models";
 import type {
   ResolvedTanStackTextModel,
@@ -342,7 +342,7 @@ const structuredOutputProjectionOptions = (
 ): ProviderSafeJsonSchemaProjectionOptions =>
   providerSafeJsonSchemaOptionsForTanStackProvider(
     provider,
-    isMockAI() ? "mock-structured-output" : "structured-output",
+    isMockTextAdapterActive() ? "mock-structured-output" : "structured-output",
   );
 
 export const generateTanStackObjectForRole = async <

--- a/apps/api/src/lib/tanstack-ai-generate.ts
+++ b/apps/api/src/lib/tanstack-ai-generate.ts
@@ -11,6 +11,7 @@ import * as v from "valibot";
 
 import type { ModelRole } from "@stll/ai-catalog";
 
+import { isMockAI } from "@/api/consts";
 import type {
   AIRequestServiceTier,
   CachingDecision,
@@ -20,7 +21,10 @@ import type { TanStackAIAnalyticsCallbacks } from "@/api/lib/analytics/tanstack-
 import type { SafeId } from "@/api/lib/branded-types";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import { logger } from "@/api/lib/observability/logger";
-import { providerSafeJsonSchemaOptionsForTanStackProvider } from "@/api/lib/provider-safe-json-schema";
+import {
+  providerSafeJsonSchemaOptionsForTanStackProvider,
+  type ProviderSafeJsonSchemaProjectionOptions,
+} from "@/api/lib/provider-safe-json-schema";
 import { tanStackCacheControl } from "@/api/lib/tanstack-ai-caching";
 import {
   getTanStackTextModelById,
@@ -333,6 +337,14 @@ const providerStatusCode = (error: Record<string, unknown>): number | null => {
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null;
 
+const structuredOutputProjectionOptions = (
+  provider: string,
+): ProviderSafeJsonSchemaProjectionOptions =>
+  providerSafeJsonSchemaOptionsForTanStackProvider(
+    provider,
+    isMockAI() ? "mock-structured-output" : "structured-output",
+  );
+
 export const generateTanStackObjectForRole = async <
   TSchema extends v.GenericSchema,
 >({
@@ -348,10 +360,7 @@ export const generateTanStackObjectForRole = async <
     : undefined;
   const tanStackOutputSchema = toTanStackValibotSchema(
     outputSchema,
-    providerSafeJsonSchemaOptionsForTanStackProvider(
-      model.provider,
-      "structured-output",
-    ),
+    structuredOutputProjectionOptions(model.provider),
   );
 
   const output = await withStandardServiceTierFallback({
@@ -439,10 +448,7 @@ const streamTanStackStructuredOutput = async function* <
   let rawJson = "";
   const tanStackOutputSchema = toTanStackValibotSchema(
     outputSchema,
-    providerSafeJsonSchemaOptionsForTanStackProvider(
-      model.provider,
-      "structured-output",
-    ),
+    structuredOutputProjectionOptions(model.provider),
   );
 
   const stream = iterateWithStandardServiceTierFallback({

--- a/apps/api/src/lib/tanstack-ai-models.ts
+++ b/apps/api/src/lib/tanstack-ai-models.ts
@@ -281,14 +281,22 @@ export const registerTanStackMockTextAdapterFactory = (
 };
 
 /**
- * Whether requests are actually served by the mock adapter. `USE_MOCK_AI` alone
- * is not enough: the factory is registered by a dev-only module, so a build
- * that never imports it falls through to a real provider with the flag still
- * set. Callers that shape a request differently for the mock must ask this, not
- * the env flag, or they will shape a real provider's request by mistake.
+ * The mock factory when it will actually serve requests, otherwise undefined.
+ * `USE_MOCK_AI` alone is not enough: the factory is registered by a dev-only
+ * module, so a build that never imports it falls through to a real provider
+ * with the flag still set.
+ */
+const activeMockTextAdapterFactory = ():
+  | TanStackTextAdapterFactory
+  | undefined => (env.USE_MOCK_AI ? mockTextAdapterFactory : undefined);
+
+/**
+ * Whether requests are actually served by the mock adapter. Callers that shape
+ * a request differently for the mock must ask this, not the env flag, or they
+ * will shape a real provider's request by mistake.
  */
 export const isMockTextAdapterActive = (): boolean =>
-  env.USE_MOCK_AI && mockTextAdapterFactory !== undefined;
+  activeMockTextAdapterFactory() !== undefined;
 
 const decodeModelOverride = (value: string): ModelOverride => {
   const [providerRaw, ...modelParts] = value.split("::");
@@ -556,8 +564,9 @@ const createTanStackTextAdapterFactory = ({
   apiKey,
   region,
 }: TanStackModelFactoryOptions): TanStackTextAdapterFactory => {
-  if (isMockTextAdapterActive()) {
-    return mockTextAdapterFactory;
+  const mockFactory = activeMockTextAdapterFactory();
+  if (mockFactory) {
+    return mockFactory;
   }
 
   const supportedProvider = resolveTanStackTextProvider({ provider, region });

--- a/apps/api/src/lib/tanstack-ai-models.ts
+++ b/apps/api/src/lib/tanstack-ai-models.ts
@@ -280,6 +280,16 @@ export const registerTanStackMockTextAdapterFactory = (
   mockTextAdapterFactory = factory;
 };
 
+/**
+ * Whether requests are actually served by the mock adapter. `USE_MOCK_AI` alone
+ * is not enough: the factory is registered by a dev-only module, so a build
+ * that never imports it falls through to a real provider with the flag still
+ * set. Callers that shape a request differently for the mock must ask this, not
+ * the env flag, or they will shape a real provider's request by mistake.
+ */
+export const isMockTextAdapterActive = (): boolean =>
+  env.USE_MOCK_AI && mockTextAdapterFactory !== undefined;
+
 const decodeModelOverride = (value: string): ModelOverride => {
   const [providerRaw, ...modelParts] = value.split("::");
   const modelId = modelParts.join("::");
@@ -546,7 +556,7 @@ const createTanStackTextAdapterFactory = ({
   apiKey,
   region,
 }: TanStackModelFactoryOptions): TanStackTextAdapterFactory => {
-  if (env.USE_MOCK_AI && mockTextAdapterFactory) {
+  if (isMockTextAdapterActive()) {
     return mockTextAdapterFactory;
   }
 
@@ -608,7 +618,7 @@ const hasInstanceProviderCredentials = (provider: AIProvider): boolean => {
   if (env.REQUIRE_PERSONAL_AI_KEY) {
     return false;
   }
-  if (env.USE_MOCK_AI && mockTextAdapterFactory) {
+  if (isMockTextAdapterActive()) {
     return true;
   }
 
@@ -642,7 +652,7 @@ const resolveProvider = (): AIProvider => {
   if (env.AI_PROVIDER) {
     return env.AI_PROVIDER;
   }
-  if (env.USE_MOCK_AI && mockTextAdapterFactory) {
+  if (isMockTextAdapterActive()) {
     return "google";
   }
 


### PR DESCRIPTION
Structured-output schema compilers reject value constraints. Anthropic returns
`400 output_config.format.schema: For 'array' type, property 'maxItems' is not
supported`; Gemini counts the same bounds against an undocumented schema
complexity budget. The shared projection only omitted array bounds for
`google`, so Anthropic and OpenRouter still received them — and an OpenRouter
model id resolves to an arbitrary upstream, so a per-provider allowlist cannot
be correct in principle.

Affected production schemas carry these keywords today: `handlers/search/ai.ts`
(string lengths, a numeric bound, and a citations array bound),
`lib/bbox/ai-generate-b-boxes.ts`, `lib/workflow/verdict-engine.ts`, and
`handlers/playbooks/derive-ask.ts`.

## Changes

- Replace `arrayBoundStrategy` with `valueConstraintStrategy`, covering every
  allowlisted constraint keyword: `minimum`, `maximum`, `minItems`, `maxItems`,
  `minLength`, `maxLength`. A `satisfies` clause keeps that list a subset of
  the provider-safe allowlist.
- Key the strategy on purpose rather than provider: structured output always
  omits, tool schemas always preserve. Constraints are validation, not shape,
  and the source Standard Schema still enforces them locally. Tool arguments
  are sampled without a schema compiler, so their bounds remain useful
  provider guidance.
- Widen the canary schema with a string length bound so the daily probe covers
  the whole keyword class against live providers, not just array bounds.

Tests assert the strategy invariant across every entry in
`TANSTACK_AI_PROVIDERS`, so a new provider cannot be added without inheriting
it, and that each allowlisted constraint keyword is actually dropped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved compatibility of structured outputs across supported AI providers by removing unsupported numeric, item-count and string-length constraints.
  * Tool schemas now retain these value constraints.
  * Mock structured-output responses now respect numeric and string boundaries.
  * Added a maximum 120-character limit for nested structured-output headings.

* **Bug Fixes**
  * Improved provider-safe schema handling across structured outputs, tools and mock responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->