### PR TITLE
fix(api): log classified AI generation failures at WARN

### DIFF
--- a/apps/api/src/lib/analytics/tanstack-ai.test.ts
+++ b/apps/api/src/lib/analytics/tanstack-ai.test.ts
@@ -1,8 +1,10 @@
 import type { ChatMiddlewareContext, TokenUsage } from "@tanstack/ai";
-import { describe, expect, test } from "bun:test";
+import { describe, expect, spyOn, test } from "bun:test";
 
 import type { OrgAIConfig } from "@/api/lib/ai-config";
+import type { AIErrorKind } from "@/api/lib/ai-error";
 import { toSafeId } from "@/api/lib/branded-types";
+import type * as TaggedErrors from "@/api/lib/errors/tagged-errors";
 import { createScopedDbMock } from "@/api/tests/scoped-db-mock";
 
 import { SERVER_ANALYTICS_EVENTS } from "./types";
@@ -393,4 +395,70 @@ describe("createTanStackAIAnalyticsCallbacks", () => {
       env.REQUIRE_PERSONAL_AI_KEY = originalRequirePersonalAIKey;
     }
   });
+
+  // Severity is part of this record's contract: only an unanticipated failure
+  // shape may log at ERROR. Driven over the whole `AIErrorKind` union, so a new
+  // kind cannot be added without deciding its severity.
+  const createErrorsByKind = (
+    ChatLoopDetectedError: typeof TaggedErrors.ChatLoopDetectedError,
+  ) =>
+    ({
+      quota_exhausted: { status: 429 },
+      provider_billing: { status: 402 },
+      model_unavailable: { status: 404 },
+      provider_unavailable: { status: 503 },
+      loop_detected: new ChatLoopDetectedError({ message: "repeated work" }),
+      unknown: new Error("boom"),
+    }) satisfies Record<AIErrorKind, unknown>;
+
+  const AI_ERROR_KINDS = [
+    "quota_exhausted",
+    "provider_billing",
+    "model_unavailable",
+    "provider_unavailable",
+    "loop_detected",
+    "unknown",
+  ] as const satisfies readonly AIErrorKind[];
+
+  for (const kind of AI_ERROR_KINDS) {
+    const severity = kind === "unknown" ? "ERROR" : "WARN";
+
+    test(`logs a ${kind} generation failure at ${severity}`, async () => {
+      const { createTanStackAIAnalyticsCallbacks } =
+        await loadTanStackAIAnalytics();
+      const { classifyAIError } = await import("@/api/lib/ai-error");
+      const { logger } = await import("@/api/lib/observability/logger");
+      const { ChatLoopDetectedError } =
+        await import("@/api/lib/errors/tagged-errors");
+      const error = createErrorsByKind(ChatLoopDetectedError)[kind];
+
+      expect(classifyAIError(error)).toBe(kind);
+
+      const errorSpy = spyOn(logger, "error");
+      const warnSpy = spyOn(logger, "warn");
+
+      try {
+        createTanStackAIAnalyticsCallbacks({
+          analytics: { capture: () => undefined, flush: async () => undefined },
+          feature: "chat.suggested_prompts",
+          traceId: `trace_${kind}`,
+        }).captureError(error);
+
+        const expected = severity === "ERROR" ? errorSpy : warnSpy;
+        const unexpected = severity === "ERROR" ? warnSpy : errorSpy;
+
+        expect(unexpected).not.toHaveBeenCalledWith(
+          "tanstack_ai.generation.failed",
+          expect.anything(),
+        );
+        expect(expected).toHaveBeenCalledWith(
+          "tanstack_ai.generation.failed",
+          expect.objectContaining({ "ai.error_kind": kind }),
+        );
+      } finally {
+        errorSpy.mockRestore();
+        warnSpy.mockRestore();
+      }
+    });
+  }
 });

--- a/apps/api/src/lib/analytics/tanstack-ai.ts
+++ b/apps/api/src/lib/analytics/tanstack-ai.ts
@@ -6,6 +6,7 @@ import type { ModelRole } from "@stll/ai-catalog";
 import type { SafeDb } from "@/api/db/safe-db";
 import type { UsageActionType, UsageServiceTier } from "@/api/db/schema";
 import type { OrgAIConfig } from "@/api/lib/ai-config";
+import { classifyAIError } from "@/api/lib/ai-error";
 import { captureError as captureTelemetryError } from "@/api/lib/analytics/capture";
 import type { SafeId } from "@/api/lib/branded-types";
 import { errorTag } from "@/api/lib/errors/utils";
@@ -298,8 +299,15 @@ export const createTanStackAIAnalyticsCallbacks = ({
     hasCapturedGenerationError = true;
     const resolvedModelInfo = resolveAnalyticsModelInfo();
 
-    logger.error("tanstack_ai.generation.failed", {
+    // Classified kinds (quota, billing, retired model, provider outage) are
+    // expected operational states of an upstream account, not faults in this
+    // service, so they log at WARN; `unknown` is a failure shape this code
+    // does not anticipate and is the only kind logged at ERROR. Same split as
+    // `reportStreamFailure` in the chat stream handler.
+    const kind = classifyAIError(error);
+    const attributes = {
       "error.type": errorTag(error),
+      "ai.error_kind": kind,
       "ai.feature": config.feature,
       ...(resolvedModelInfo
         ? {
@@ -307,7 +315,12 @@ export const createTanStackAIAnalyticsCallbacks = ({
             "ai.model": resolvedModelInfo.modelId,
           }
         : {}),
-    });
+    };
+    if (kind === "unknown") {
+      logger.error("tanstack_ai.generation.failed", attributes);
+    } else {
+      logger.warn("tanstack_ai.generation.failed", attributes);
+    }
     captureTelemetryError(error, {
       feature: config.feature,
       organization_id: config.usageMetering?.organizationId ?? "",


### PR DESCRIPTION
## Proposed change

`captureGenerationError` in `apps/api/src/lib/analytics/tanstack-ai.ts` logged
every generation failure at ERROR, including the provider conditions
`classifyAIError` already recognises: an exhausted upstream quota
(`quota_exhausted`), a billing problem on the provider account
(`provider_billing`), a model the provider no longer serves
(`model_unavailable`), and a provider outage (`provider_unavailable`). Those
describe the state of an upstream account, not a fault in this service, and
ERROR is the severity `logger` mirrors to stderr as a JSON record.

The chat stream handler already draws this line: `reportStreamFailure` in
`handlers/chat/stream-chat.ts` classifies first and logs only `unknown` at
ERROR, with a comment stating the rule ("Classified kinds ... are expected
operational states; `unknown` means a failure shape this code does not
anticipate"). The shared analytics callback did not follow it, so the two paths
disagreed on the severity of the same provider condition.

This applies the same split and records the resolved kind as `ai.error_kind`.
That field is what makes the record actionable: everything reaching this path
through `aiHandlerError` arrives wrapped, so `error.type` is `HandlerError` for
a quota problem, a retired model, and an unanticipated bug alike.

Behaviour otherwise unchanged: the PostHog capture and the deduplication flag
are untouched, so a classified failure is still reported, just not as an
unanticipated one.

### Tests

`tanstack-ai.test.ts` now drives the severity split over the whole
`AIErrorKind` union rather than one example, with the fixture map typed
`satisfies Record<AIErrorKind, unknown>` so a new kind fails typecheck until
its severity is decided. Each case also asserts the classifier agrees with the
kind under test, so a fixture cannot silently drift to `unknown` and pass
vacuously.

Verified the tests fail against the previous behaviour: reverting the severity
split alone fails 5 of the 6 cases.

## Checklist

- [x] **BUILD ASSURANCE** | Code builds correctly and without any errors or warnings.
- [x] **TESTING** | Changes tested, including in different conditions (dark mode, language, narrow screen, etc).
- [ ] DARK MODE SUPPORT | **Not applicable** — no user-facing surface changes.
- [ ] ISSUE LINKED | **No linked issue**.
- [ ] SCREENSHOT INCLUDED | **Not applicable** — server-side logging only.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NjXA61zCGium8Zj1RsM4ZW)_