### PR TITLE
perf: skip Gotenberg in PR E2E

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1056,7 +1056,7 @@ jobs:
       - name: Log in to Docker Hub
         # Skipped automatically until DOCKERHUB_USERNAME / DOCKERHUB_TOKEN repo
         # secrets exist; authenticated pulls raise the rate limit well above the
-        # shared-runner anonymous cap that flakes the gotenberg image pull.
+        # shared-runner anonymous cap that can flake infrastructure image pulls.
         if: steps.dockerhub.outputs.available == 'true'
         uses: docker/login-action@371161bbe7024a29a25c5e19bfcbc0804fe9ad2c # v4.5.2
         with:
@@ -1075,7 +1075,7 @@ jobs:
         # stack does not poison the retry.
         run: |
           for attempt in 1 2 3; do
-            if docker compose --profile dev up -d --wait postgres minio valkey gotenberg \
+            if docker compose --profile dev up -d --wait postgres minio valkey \
               && docker compose --profile dev run --rm --no-deps minio-setup; then
               exit 0
             fi
@@ -1269,7 +1269,7 @@ jobs:
       - name: Start docker stack
         run: |
           for attempt in 1 2 3; do
-            if docker compose --profile dev up -d --wait postgres minio valkey gotenberg \
+            if docker compose --profile dev up -d --wait postgres minio valkey \
               && docker compose --profile dev run --rm --no-deps minio-setup; then
               exit 0
             fi

--- a/scripts/detect-e2e-changes.test.ts
+++ b/scripts/detect-e2e-changes.test.ts
@@ -167,6 +167,17 @@ describe("detect-e2e-changes", () => {
     }
   });
 
+  test("starts only infrastructure exercised by pull request E2E", () => {
+    for (const jobId of ["e2e-production-shard", "e2e-vite-canary"]) {
+      const job = workflowJob(jobId);
+      expect(job).toContain("- name: Start docker stack");
+      expect(job).toContain(
+        "docker compose --profile dev up -d --wait postgres minio valkey",
+      );
+      expect(job).not.toContain("gotenberg");
+    }
+  });
+
   test("keeps full code quality for manual sweeps and scopes pull requests", () => {
     const codeQuality = workflowJob("code-quality");
     expect(codeQuality).toContain(

--- a/scripts/detect-e2e-changes.test.ts
+++ b/scripts/detect-e2e-changes.test.ts
@@ -171,9 +171,13 @@ describe("detect-e2e-changes", () => {
     for (const jobId of ["e2e-production-shard", "e2e-vite-canary"]) {
       const job = workflowJob(jobId);
       expect(job).toContain("- name: Start docker stack");
-      expect(job).toContain(
-        "docker compose --profile dev up -d --wait postgres minio valkey",
-      );
+      const composeStartLines = job
+        .split("\n")
+        .filter((line) => line.includes("docker compose --profile dev up"))
+        .map((line) => line.trim());
+      expect(composeStartLines).toEqual([
+        "if docker compose --profile dev up -d --wait postgres minio valkey \\",
+      ]);
       expect(job).not.toContain("gotenberg");
     }
   });


### PR DESCRIPTION
## Summary

- start only PostgreSQL, MinIO, and Valkey in pull request browser jobs
- avoid pulling and health-checking Gotenberg for native DOCX fixtures
- add a workflow invariant that keeps Gotenberg out of both core E2E jobs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automated end-to-end test startup by launching only the required development services.
  * Prevented unnecessary document-processing services from starting during production and Vite canary test runs.

* **Tests**
  * Added coverage to verify that test environments start the expected services and exclude unnecessary ones.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->