### PR TITLE
fix: keep dev OTP prefill idempotent

### DIFF
--- a/apps/api/src/handlers/agent-auth/id-jag.test.ts
+++ b/apps/api/src/handlers/agent-auth/id-jag.test.ts
@@ -33,7 +33,7 @@ import {
 } from "@/api/handlers/agent-auth/routes";
 import { getAuth } from "@/api/lib/auth";
 import { getAuthIssuerUrl } from "@/api/lib/auth-paths";
-import { popDevOtp } from "@/api/lib/dev-otp-store";
+import { readDevOtp } from "@/api/lib/dev-otp-store";
 import { getMcpResourceUrl } from "@/api/mcp/constants";
 import {
   initAgentAuthTestDb,
@@ -214,7 +214,7 @@ const decodeJwt = (jwt: string): Json => {
 const createHumanSession = async (email: string) => {
   const auth = getAuth();
   await auth.api.sendVerificationOTP({ body: { email, type: "sign-in" } });
-  const otp = popDevOtp(email);
+  const otp = readDevOtp(email);
   if (!otp) {
     throw new Error("dev OTP not stashed; is env.isDev true under test?");
   }

--- a/apps/api/src/handlers/agent-auth/identity.test.ts
+++ b/apps/api/src/handlers/agent-auth/identity.test.ts
@@ -17,7 +17,7 @@ import {
   agentAuthRoute,
 } from "@/api/handlers/agent-auth/routes";
 import { getAuth } from "@/api/lib/auth";
-import { popDevOtp } from "@/api/lib/dev-otp-store";
+import { readDevOtp } from "@/api/lib/dev-otp-store";
 import {
   getMcpResourceUrl,
   MCP_ANONYMIZED_RESOURCE_SCOPES,
@@ -100,7 +100,7 @@ const createHumanSession = async () => {
   const auth = getAuth();
   const email = `agent-test-${Bun.randomUUIDv7()}@stella.dev`;
   await auth.api.sendVerificationOTP({ body: { email, type: "sign-in" } });
-  const otp = popDevOtp(email);
+  const otp = readDevOtp(email);
   if (!otp) {
     throw new Error("dev OTP not stashed; is env.isDev true under test?");
   }

--- a/apps/api/src/handlers/dev/routes.ts
+++ b/apps/api/src/handlers/dev/routes.ts
@@ -13,7 +13,7 @@ import {
 } from "@/api/db/schema";
 import { env } from "@/api/env";
 import { authMacro } from "@/api/lib/auth";
-import { popDevOtp } from "@/api/lib/dev-otp-store";
+import { readDevOtp } from "@/api/lib/dev-otp-store";
 import { rebuildSupplementalSearchIndex } from "@/api/lib/search/index-global";
 import { getSearchProvider } from "@/api/lib/search/provider";
 
@@ -148,7 +148,7 @@ export const devPublicRoute = new Elysia({ prefix: "/dev-public" })
   .get(
     "/last-otp",
     ({ query }) => {
-      const otp = popDevOtp(query.email);
+      const otp = readDevOtp(query.email);
       if (!otp) {
         return new Response("No OTP", { status: 404 });
       }

--- a/apps/api/src/lib/dev-otp-store.test.ts
+++ b/apps/api/src/lib/dev-otp-store.test.ts
@@ -1,14 +1,57 @@
-import { describe, expect, test } from "bun:test";
+import {
+  afterEach,
+  describe,
+  expect,
+  jest,
+  setSystemTime,
+  test,
+} from "bun:test";
 
 import { readDevOtp, stashDevOtp } from "@/api/lib/dev-otp-store";
 
+const OTP_TTL_MS = 5 * 60_000;
+const TEST_START_MS = Date.UTC(2026, 0, 1);
+
+afterEach(() => {
+  jest.useRealTimers();
+  setSystemTime();
+});
+
 describe("dev OTP store", () => {
   test("repeated reads return the latest unexpired OTP", () => {
+    jest.useFakeTimers();
     const email = "repeated-loader@example.test";
 
     stashDevOtp(email, "123456");
 
     expect(readDevOtp(email)).toBe("123456");
     expect(readDevOtp(email)).toBe("123456");
+  });
+
+  test("expires an OTP at the exact TTL boundary", () => {
+    jest.useFakeTimers();
+    setSystemTime(TEST_START_MS);
+    const email = "ttl-boundary@example.test";
+
+    stashDevOtp(email, "234567");
+    setSystemTime(TEST_START_MS + OTP_TTL_MS);
+
+    expect(readDevOtp(email)).toBeNull();
+  });
+
+  test("a stale eviction timer cannot delete a replacement OTP", () => {
+    jest.useFakeTimers();
+    setSystemTime(TEST_START_MS);
+    const email = "replacement@example.test";
+
+    stashDevOtp(email, "345678");
+    jest.advanceTimersByTime(OTP_TTL_MS / 2);
+    stashDevOtp(email, "456789");
+    jest.advanceTimersByTime(OTP_TTL_MS / 2);
+
+    expect(readDevOtp(email)).toBe("456789");
+
+    jest.advanceTimersByTime(OTP_TTL_MS / 2);
+    expect(readDevOtp(email)).toBeNull();
   });
 });

--- a/apps/api/src/lib/dev-otp-store.test.ts
+++ b/apps/api/src/lib/dev-otp-store.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, test } from "bun:test";
+
+import { readDevOtp, stashDevOtp } from "@/api/lib/dev-otp-store";
+
+describe("dev OTP store", () => {
+  test("repeated reads return the latest unexpired OTP", () => {
+    const email = "repeated-loader@example.test";
+
+    stashDevOtp(email, "123456");
+
+    expect(readDevOtp(email)).toBe("123456");
+    expect(readDevOtp(email)).toBe("123456");
+  });
+});

--- a/apps/api/src/lib/dev-otp-store.ts
+++ b/apps/api/src/lib/dev-otp-store.ts
@@ -4,7 +4,15 @@ const store = new Map<string, Entry>();
 const TTL_MS = 5 * 60_000;
 
 export const stashDevOtp = (email: string, otp: string): void => {
-  store.set(email, { otp, ts: Date.now() });
+  const entry = { otp, ts: Date.now() };
+  store.set(email, entry);
+
+  const expiryTimer = setTimeout(() => {
+    if (store.get(email) === entry) {
+      store.delete(email);
+    }
+  }, TTL_MS);
+  expiryTimer.unref();
 };
 
 export const readDevOtp = (email: string): string | null => {
@@ -12,7 +20,7 @@ export const readDevOtp = (email: string): string | null => {
   if (!entry) {
     return null;
   }
-  if (Date.now() - entry.ts > TTL_MS) {
+  if (Date.now() - entry.ts >= TTL_MS) {
     store.delete(email);
     return null;
   }

--- a/apps/api/src/lib/dev-otp-store.ts
+++ b/apps/api/src/lib/dev-otp-store.ts
@@ -7,13 +7,13 @@ export const stashDevOtp = (email: string, otp: string): void => {
   store.set(email, { otp, ts: Date.now() });
 };
 
-export const popDevOtp = (email: string): string | null => {
+export const readDevOtp = (email: string): string | null => {
   const entry = store.get(email);
   if (!entry) {
     return null;
   }
-  store.delete(email);
   if (Date.now() - entry.ts > TTL_MS) {
+    store.delete(email);
     return null;
   }
   return entry.otp;

--- a/apps/web/src/lib/dev-otp.ts
+++ b/apps/web/src/lib/dev-otp.ts
@@ -7,7 +7,7 @@ import { fetchWithTimeout } from "@/lib/fetch";
 const devOtpSchema = v.object({ otp: v.string() });
 
 /**
- * Reads (and consumes) the email-OTP the dev API mirrors for an address so the
+ * Reads the email-OTP the dev API mirrors for an address so the
  * sign-in flow can prefill the code instead of making you copy it by hand. The
  * mirror endpoint only exists in dev, so this resolves to `null` in production
  * (and the fetch is tree-shaken out) and whenever no mirrored code is waiting.


### PR DESCRIPTION
Makes the development OTP mirror idempotent for its existing TTL so repeated route-loader reads return the same code. Renames the store API to match its read semantics and adds a regression invariant for repeated reads.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Development one-time passwords can now be retrieved repeatedly while still valid, improving sign-in and testing flows.
  - Expired development one-time passwords are automatically removed and reported as unavailable.

- **Tests**
  - Added coverage confirming repeated reads, expiry handling, replacement codes and stale timer protection.

- **Documentation**
  - Updated development one-time password guidance to reflect the non-consuming retrieval behaviour.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->