### PR TITLE
feat(api): demo-account sign-in OTP override and host-verification endpoint

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -148,6 +148,20 @@ USE_MOCK_AI="true"
 # Generate with: openssl rand -base64 32
 # SELFHOST_BOOTSTRAP_TOKEN=""
 
+# --- Demo account -----------------------------------------------------------
+# Optional. Fixed sign-in OTP for one designated demo account, for external
+# evaluations that need working credentials without inbox access. Inert unless
+# both are set; only the sign-in OTP type for this exact address is overridden,
+# and the usual attempt limit and expiry still apply.
+# DEMO_ACCOUNT_EMAIL="demo@example.com"
+# DEMO_ACCOUNT_OTP="000000"
+
+# --- Host verification ------------------------------------------------------
+# Optional. Plain-text token served at /.well-known/openai-apps-challenge so an
+# external verifier can confirm control of this API's host. Unset, the endpoint
+# returns 404.
+# OPENAI_APPS_CHALLENGE_TOKEN=""
+
 # --- Operator observability -------------------------------------------------
 # Optional. Bearer token for GET /operator/registrations, which lets an
 # instance operator list recent account registrations (id, email, name,

--- a/apps/api/src/env.ts
+++ b/apps/api/src/env.ts
@@ -211,6 +211,27 @@ const envApi = createEnv({
     SELFHOST_BOOTSTRAP_TOKEN: v.optional(v.pipe(v.string(), v.minLength(32))),
 
     /**
+     * Fixed sign-in OTP for one designated demo account, for external
+     * evaluations that need working credentials without inbox access. Inert
+     * unless both are set. The override applies only to the `sign-in` OTP
+     * type for the exact configured address; the code still goes through the
+     * normal OTP store, so the attempt limit and expiry keep applying, and
+     * email delivery is skipped for this account (the code is shared
+     * out-of-band).
+     */
+    DEMO_ACCOUNT_EMAIL: v.optional(
+      v.pipe(v.string(), v.trim(), v.toLowerCase(), v.email()),
+    ),
+    DEMO_ACCOUNT_OTP: v.optional(v.pipe(v.string(), v.digits(), v.length(6))),
+
+    /**
+     * Plain-text token served at `/.well-known/openai-apps-challenge` so an
+     * external verifier can confirm control of this API's host. Unset (the
+     * default), the endpoint returns 404.
+     */
+    OPENAI_APPS_CHALLENGE_TOKEN: v.optional(v.pipe(v.string(), v.minLength(1))),
+
+    /**
      * Comma-separated CIDRs of proxies the API may trust to set the
      * `x-forwarded-for` header.
      * Typical value covers Cloudflare's published IP ranges and any

--- a/apps/api/src/handlers/well-known/routes.ts
+++ b/apps/api/src/handlers/well-known/routes.ts
@@ -1,0 +1,26 @@
+/**
+ * Public well-known endpoints served from the API host. OAuth metadata
+ * well-knowns are mounted by the auth stack; this file carries the remaining
+ * static ones.
+ *
+ * `/.well-known/openai-apps-challenge` serves a plain-text host-control token
+ * when `OPENAI_APPS_CHALLENGE_TOKEN` is configured and 404s otherwise, so
+ * instances that never set the token expose nothing.
+ */
+
+import Elysia, { status } from "elysia";
+
+import { env } from "@/api/env";
+
+export const wellKnownRoute = new Elysia().get(
+  "/.well-known/openai-apps-challenge",
+  () => {
+    const token = env.OPENAI_APPS_CHALLENGE_TOKEN;
+    if (!token) {
+      return status(404);
+    }
+    return new Response(token, {
+      headers: { "content-type": "text/plain; charset=utf-8" },
+    });
+  },
+);

--- a/apps/api/src/lib/auth.ts
+++ b/apps/api/src/lib/auth.ts
@@ -42,6 +42,7 @@ import { toSafeId } from "@/api/lib/branded-types";
 import type { SafeId } from "@/api/lib/branded-types";
 import { verifyConfirmationOtp } from "@/api/lib/confirmation-otp";
 import { isUuid, tUuid } from "@/api/lib/custom-schema";
+import { getDemoAccountOtpOverride } from "@/api/lib/demo-account-otp";
 import { detached } from "@/api/lib/detached";
 import { detectedCountryFromRequestContext } from "@/api/lib/detected-country";
 import { DEV_INSPECTOR_ORIGINS, frontendOrigins } from "@/api/lib/dev-origins";
@@ -900,6 +901,11 @@ const createAuth = () => {
         otpLength: 6,
         expiresIn: 5 * 60,
         allowedAttempts: 3,
+        // Returning undefined falls back to the plugin's random generator
+        // (`opts.generateOTP(...) || defaultOTPGenerator`), so every account
+        // except the configured demo account keeps random codes.
+        generateOTP: ({ email, type }) =>
+          getDemoAccountOtpOverride({ email, type }),
         async sendVerificationOTP({ email, otp, type }, ctx) {
           await runEmailOtpRequestOnResponseSchedule({
             responseDelayMs: getEmailOtpMinimumResponseDuration({
@@ -930,6 +936,13 @@ const createAuth = () => {
                 // eslint-disable-next-line no-console -- dev-only OTP echo for local testing (env.isDev gated; value printed verbatim by design)
                 console.log(`[DEV] OTP for ${email}: ${otp} (type: ${type})`);
                 stashDevOtp(email, otp);
+                return;
+              }
+
+              if (getDemoAccountOtpOverride({ email, type }) !== undefined) {
+                // The demo account's fixed code is shared out-of-band;
+                // nothing to deliver. The shared response schedule above
+                // keeps the timing indistinguishable from a real send.
                 return;
               }
 

--- a/apps/api/src/lib/demo-account-otp.test.ts
+++ b/apps/api/src/lib/demo-account-otp.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "bun:test";
+
+import { resolveDemoAccountOtp } from "@/api/lib/demo-account-otp";
+
+const CONFIGURED = {
+  demoEmail: "demo@example.com",
+  demoOtp: "123456",
+};
+
+describe("resolveDemoAccountOtp", () => {
+  it("returns the fixed code only for the configured address on sign-in", () => {
+    expect(
+      resolveDemoAccountOtp({
+        email: "demo@example.com",
+        type: "sign-in",
+        ...CONFIGURED,
+      }),
+    ).toBe("123456");
+  });
+
+  it("normalizes case and whitespace before matching", () => {
+    expect(
+      resolveDemoAccountOtp({
+        email: "  Demo@Example.COM ",
+        type: "sign-in",
+        ...CONFIGURED,
+      }),
+    ).toBe("123456");
+  });
+
+  it("never overrides non-sign-in OTP types", () => {
+    for (const type of [
+      "email-verification",
+      "forget-password",
+      "change-email",
+    ] as const) {
+      expect(
+        resolveDemoAccountOtp({
+          email: "demo@example.com",
+          type,
+          ...CONFIGURED,
+        }),
+      ).toBeUndefined();
+    }
+  });
+
+  it("ignores other addresses and half-configured env", () => {
+    expect(
+      resolveDemoAccountOtp({
+        email: "other@example.com",
+        type: "sign-in",
+        ...CONFIGURED,
+      }),
+    ).toBeUndefined();
+    expect(
+      resolveDemoAccountOtp({
+        email: "demo@example.com",
+        type: "sign-in",
+        demoEmail: "demo@example.com",
+        demoOtp: undefined,
+      }),
+    ).toBeUndefined();
+    expect(
+      resolveDemoAccountOtp({
+        email: "demo@example.com",
+        type: "sign-in",
+        demoEmail: undefined,
+        demoOtp: "123456",
+      }),
+    ).toBeUndefined();
+  });
+});

--- a/apps/api/src/lib/demo-account-otp.ts
+++ b/apps/api/src/lib/demo-account-otp.ts
@@ -1,0 +1,47 @@
+import { env } from "@/api/env";
+
+type DemoAccountOtpArgs = {
+  email: string;
+  type: "sign-in" | "email-verification" | "forget-password" | "change-email";
+};
+
+type ResolveDemoAccountOtpOptions = DemoAccountOtpArgs & {
+  demoEmail: string | undefined;
+  demoOtp: string | undefined;
+};
+
+/**
+ * Fixed-OTP override for the single designated demo account
+ * (`DEMO_ACCOUNT_EMAIL` + `DEMO_ACCOUNT_OTP`), for external evaluations that
+ * need working credentials without inbox access. Deliberately narrow: both
+ * variables must be set, only the exact configured address matches, and only
+ * the `sign-in` type is overridden, so password-reset and change-email flows
+ * can never ride on the fixed code. The returned code is stored and verified
+ * like any generated OTP, so the attempt limit and expiry keep applying.
+ */
+export const resolveDemoAccountOtp = ({
+  email,
+  type,
+  demoEmail,
+  demoOtp,
+}: ResolveDemoAccountOtpOptions): string | undefined => {
+  if (type !== "sign-in" || !demoEmail || !demoOtp) {
+    return undefined;
+  }
+  if (email.trim().toLowerCase() !== demoEmail) {
+    return undefined;
+  }
+  return demoOtp;
+};
+
+/** Env-wired form of {@link resolveDemoAccountOtp}. */
+export const getDemoAccountOtpOverride = ({
+  email,
+  type,
+}: DemoAccountOtpArgs): string | undefined =>
+  resolveDemoAccountOtp({
+    email,
+    type,
+    demoEmail: env.DEMO_ACCOUNT_EMAIL,
+    demoOtp: env.DEMO_ACCOUNT_OTP,
+  });

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -82,6 +82,7 @@ import { userFilesRoute } from "@/api/handlers/user-files/routes";
 import { verifyAuthRoute, verifyRoute } from "@/api/handlers/verify/routes";
 import { viewTemplatesRoute } from "@/api/handlers/view-templates/routes";
 import { viewsRoute } from "@/api/handlers/views/routes";
+import { wellKnownRoute } from "@/api/handlers/well-known/routes";
 import { workspaceEventsRoute } from "@/api/handlers/workspaces/events";
 import { workspacesRoute } from "@/api/handlers/workspaces/routes";
 import { initAccountDeletionCleanupWorker } from "@/api/lib/account-deletion-cleanup-queue";
@@ -467,6 +468,7 @@ const api = new Elysia()
       .use(agentAuthConfirmRoute),
   )
   .use(healthRoute)
+  .use(wellKnownRoute)
   .use(verifyRoute)
   .use(hostedUsageWebhookRoute)
   .use(mcpRoute)

--- a/apps/api/src/tests/security/cross-tenant-coverage.test.ts
+++ b/apps/api/src/tests/security/cross-tenant-coverage.test.ts
@@ -111,6 +111,8 @@ const CROSS_TENANT_WAIVERS: Record<string, WaiverReason> = {
   smoke: WAIVER_REASON.noTenantReadSurface,
   uploads: WAIVER_REASON.noTenantReadSurface,
   verify: WAIVER_REASON.noTenantReadSurface,
+  // Static plain-text host-verification token from env; no database access.
+  "well-known": WAIVER_REASON.noTenantReadSurface,
 };
 
 const handlerDomains = readdirSync(handlersDir, { withFileTypes: true })

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -1903,6 +1903,7 @@ export default defineConfig({
         "apps/api/src/handlers/hosted-usage-webhook/routes.ts",
         "apps/api/src/handlers/smoke/routes.ts",
         "apps/api/src/handlers/verify/routes.ts",
+        "apps/api/src/handlers/well-known/routes.ts",
         "apps/api/src/handlers/workspaces/events.ts",
       ],
       rules: {


### PR DESCRIPTION
Adds two env-gated capabilities, both inert unless configured:

- `DEMO_ACCOUNT_EMAIL` + `DEMO_ACCOUNT_OTP`: fixed sign-in OTP for exactly one address, for external evaluations that need working credentials without inbox access. Wired via the better-auth `emailOTP` plugin's `generateOTP` hook; returning `undefined` for every other address falls back to the plugin's random generator. Only the `sign-in` OTP type is overridden (password-reset and change-email flows always use random codes), the fixed code goes through the normal OTP store so the attempt limit and expiry keep applying, and email delivery is skipped for the configured address since the code is shared out-of-band.
- `OPENAI_APPS_CHALLENGE_TOKEN`: served as `text/plain` at `/.well-known/openai-apps-challenge` for host-control verification; the endpoint returns 404 when the variable is unset.

The new public route file follows the existing protocol-route pattern (`require-safe-route-handlers` exception list). Unit tests cover the OTP resolver's gating (type, address normalization, half-configured env).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for signing in to a configured demo account using a fixed six-digit one-time password.
  - Demo-account sign-in codes are not sent by email when the fixed code is enabled.
  - Added a public verification endpoint for OpenAI Apps host validation.

- **Configuration**
  - Added optional settings for the demo account, fixed sign-in code, and host-verification challenge token.
  - The verification endpoint returns a not-found response when no challenge token is configured.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->