### PR TITLE
fix(landing): cs/de/sk metas

### DIFF
--- a/apps/landing/scripts/check-meta-budgets.ts
+++ b/apps/landing/scripts/check-meta-budgets.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bun
 import { products } from "../src/data/products/registry";
-import { localeCodes } from "../src/i18n/config";
+import { type Locale, localeCodes } from "../src/i18n/config";
 import { catalogs } from "../src/i18n/utils";
 
 // SERP length budgets for every indexable page's meta strings, in every locale.
@@ -32,6 +32,78 @@ const pagesFor = (locale: (typeof localeCodes)[number]): PageMeta[] => {
       description: catalog[slug].metaDescription,
     })),
   ];
+};
+
+/**
+ * Metas are written for searchers, not for the product catalog: each locale below
+ * targets researched demand phrasings and excludes the literal category label from
+ * meta strings, per the exception carved out in src/i18n/TRANSLATION.md ("Metas are
+ * the exception" under "The identity phrase"). That rule used to depend on whoever
+ * touched a catalog remembering it, which is how three locales drifted at once.
+ * Checked here instead.
+ */
+type TermPolicy = {
+  banned: readonly RegExp[];
+  homeRequiredAny: readonly RegExp[];
+};
+
+const termPolicies: Partial<Record<Locale, TermPolicy>> = {
+  cs: {
+    banned: [/pracovn\S*\s+prostor\S*/iu, /advokátn\S*\s+spis\S*/iu],
+    homeRequiredAny: [
+      /AI pro právníky/iu,
+      /právní rešerš/iu,
+      /reviz\S*\s+smluv/iu,
+    ],
+  },
+  sk: {
+    banned: [/pracovn\S*\s+priestor\S*/iu, /advokátsk\S*\s+spis\S*/iu],
+    homeRequiredAny: [/AI právny asistent/iu],
+  },
+  de: {
+    banned: [/arbeitsbereich/iu, /kanzleisoftware/iu, /schwärzung/iu],
+    homeRequiredAny: [
+      /KI für Anwälte/iu,
+      /aktenverwaltung/iu,
+      /vertragsanalyse/iu,
+    ],
+  },
+};
+
+const termPolicyViolations = (
+  locale: Locale,
+  pages: readonly PageMeta[],
+): string[] => {
+  const policy = termPolicies[locale];
+  if (!policy) {
+    return [];
+  }
+  const violations: string[] = [];
+  for (const meta of pages) {
+    for (const field of ["title", "description"] as const) {
+      for (const banned of policy.banned) {
+        const match = meta[field].match(banned);
+        if (match) {
+          violations.push(
+            `${meta.page} ${field} uses a term excluded from metas: "${match[0]}"`,
+          );
+        }
+      }
+    }
+  }
+  const home = pages.find(({ page }) => page === "/");
+  if (
+    home &&
+    policy.homeRequiredAny.length > 0 &&
+    !policy.homeRequiredAny.some((required) =>
+      required.test(`${home.title} ${home.description}`),
+    )
+  ) {
+    violations.push(
+      `${home.page} home metas carry none of the locale's meta demand terms`,
+    );
+  }
+  return violations;
 };
 
 const budgetViolations = ({ page, title, description }: PageMeta): string[] => {
@@ -78,6 +150,7 @@ for (const locale of localeCodes) {
   const violations = [
     ...pages.flatMap(budgetViolations),
     ...duplicateViolations(pages),
+    ...termPolicyViolations(locale, pages),
   ];
   for (const violation of violations) {
     failures.push(`${locale}: ${violation}`);

--- a/apps/landing/src/i18n/TRANSLATION.md
+++ b/apps/landing/src/i18n/TRANSLATION.md
@@ -200,9 +200,10 @@ et standalone "tööruum") because the app uses the Matter term where its UI
 says workspace. On the landing, "workspace" as _product positioning_ (the
 category the product belongs to) may translate literally; the
 grandfathered entries in `i18n-lint-baseline.json` exist for exactly that
-distinction: the cs and fr taglines, plus the three cs strings that carry the
+distinction: the cs and fr taglines, plus the two cs strings that carry the
 identity phrase next to the word "matters" (`hero.subtitle`,
-`meta.homeDescription`, `story.workspaceEyebrow`). Czech had been dodging the
+`story.workspaceEyebrow`; `meta.homeDescription` left the list when metas
+moved to demand terms — see below). Czech had been dodging the
 ban with a second rendering of workspace; one correct term plus an honest
 baseline entry beats two terms. Do not add baseline entries for any other
 reason. Each entry is keyed on the (source, target) pair, so editing either
@@ -240,6 +241,34 @@ uses the Estonian compound _õigustööruum_ and the French _plateforme
 juridique open source_ — the renderings those locales' `meta.homeDescription`
 already uses. Reach for an existing lint-safe wording before coining a new
 one; a third synonym costs more than the repetition it avoids.
+
+### Metas are the exception: demand terms
+
+Meta titles and descriptions are the one surface written for a searcher
+rather than a reader already on the page. Body copy keeps the identity
+phrase; in cs, sk, and de the metas instead lead with phrasings legal
+readers actually search for, and the literal category label stays out of
+meta strings entirely — in a results page it reads as a label, not an
+answer to anything anyone typed:
+
+| Locale | Meta demand terms                                | Excluded from metas                         |
+| ------ | ------------------------------------------------ | ------------------------------------------- |
+| cs     | AI pro právníky, právní rešerše, revize smluv    | právní pracovní prostor, advokátní spis     |
+| de     | KI für Anwälte, Aktenverwaltung, Vertragsanalyse | Arbeitsbereich, Kanzleisoftware, Schwärzung |
+| sk     | AI právny asistent                               | právny pracovný priestor, advokátsky spis   |
+
+de additionally excludes _Kanzleisoftware_ (the term promises
+practice-management features — beA, Fristen, RVG — the product does not
+have) and _Schwärzung_ (it claims irreversible removal, while the
+anonymization engine is reversible by design). cs and sk exclude the
+compound _advokátní/advokátsky spis_: it names the advocate's formal
+client file, which is narrower than the product's matter — the plain
+Matter term (`spis`) already says the right thing.
+
+`scripts/check-meta-budgets.ts` enforces both directions alongside the
+length budgets: an excluded term fails in any meta string of its locale,
+and the home title and description together must carry at least one of the
+locale's demand terms.
 
 ### Linking the phrase: the `<gh>…</gh>` markers
 

--- a/apps/landing/src/i18n/i18n-lint-baseline.json
+++ b/apps/landing/src/i18n/i18n-lint-baseline.json
@@ -18,12 +18,6 @@
         "source": "The <gh>open-source</gh> legal workspace: matters, documents, review, and an AI agent that answers with citations.",
         "target": "<gh>Open source</gh> právní pracovní prostor: spisy, dokumenty, revize a AI agent, který odpovídá s citacemi."
       }
-    },
-    "meta.homeDescription": {
-      "cs": {
-        "source": "Open-source legal workspace for documents, matters, contract review, and case-law research. Self-host or use our cloud. Usage-based AI, no vendor lock-in.",
-        "target": "Open source právní pracovní prostor pro advokáty: spisy, dokumenty, revize smluv i právní rešerše. Provozujte sami či v cloudu. AI podle využití."
-      }
     }
   }
 }

--- a/apps/landing/src/i18n/messages/cs.json
+++ b/apps/landing/src/i18n/messages/cs.json
@@ -83,8 +83,8 @@
     "toolsTitle": "Nástroje pro AI agenty."
   },
   "meta": {
-    "homeDescription": "Open source právní pracovní prostor pro advokáty: spisy, dokumenty, revize smluv i právní rešerše. Provozujte sami či v cloudu. AI podle využití.",
-    "homeTitle": "stella | open source právní pracovní prostor"
+    "homeDescription": "AI pro právníky v open source aplikaci: správa spisů a dokumentů, revize smluv i právní rešerše. Provozujte sami či v cloudu. AI podle využití.",
+    "homeTitle": "stella | AI pro právníky, právní rešerše a revize smluv"
   },
   "nav": {
     "aiFactSheet": "Přehled pro AI",
@@ -214,7 +214,7 @@
         }
       },
       "metaDescription": "Ptejte se svých spisů, dokumentů i rejstříků. AI agent jedná se schválením, opírá odpovědi o citace a rozšiřuje se o dovednosti i externí konektory.",
-      "metaTitle": "AI agent pro právníky a advokátní spisy | stella",
+      "metaTitle": "AI agent pro právníky a jejich spisy | stella",
       "quickAnswer": {
         "answer": "AI agent odpovídá na otázky nad vašimi spisy, soubory, obchodními rejstříky i připojenými nástroji. Než něco udělá, požádá o schválení, u toho, co čte, ukazuje náhled zdroje, a odpovědi opírá o citace. Rozšíříte ho o znovupoužitelné dovednosti a externí konektory kompatibilní s MCP.",
         "question": "Co AI agent umí?"
@@ -376,7 +376,7 @@
         }
       },
       "metaDescription": "Vyhledávejte, čtěte a pracujte s aplikací stella z příkazové řádky nebo z klienta kompatibilního s MCP. Obě rozhraní sdílejí schopnosti, oprávnění i data.",
-      "metaTitle": "MCP server a CLI pro váš právní pracovní prostor | stella",
+      "metaTitle": "MCP server a CLI pro advokátní kancelář | stella",
       "quickAnswer": {
         "answer": "Dvě rozhraní ke stejným schopnostem aplikace stella. CLI zrcadlí registr nástrojů MCP jako příkazy, zatímco MCP server umožňuje kompatibilním AI agentům a nástrojům pracovat se spisy, dokumenty, vzory i veřejnými právními daty pod stejnou kontrolou přístupu.",
         "question": "Co je CLI a MCP server aplikace stella?"
@@ -855,8 +855,8 @@
           "question": "Dosáhnou na pracovní prostor i jiné nástroje?"
         }
       },
-      "metaDescription": "Spisy, dokumenty, úpravy Word .docx, revize i rešerše na jednom místě. Elektronický advokátní spis, ve kterém práce zůstává v kontextu od podkladů po odpověď.",
-      "metaTitle": "Elektronický advokátní spis a správa dokumentů | stella",
+      "metaDescription": "Spisy, dokumenty, úpravy Word .docx, revize i rešerše na jednom místě. Elektronický spis, ve kterém práce zůstává v kontextu od podkladů po odpověď.",
+      "metaTitle": "Elektronický spis a správa dokumentů | stella",
       "quickAnswer": {
         "answer": "Webová aplikace, která drží spisy, dokumenty, úpravy Word .docx, revize, rešerše i chat na jednom místě. Vše, co do spisu přidáte, u něj zůstane, takže kontext najdete i po návratu. Doprovodná desktopová aplikace slouží jako lokální most, když dokument potřebuje Microsoft Word.",
         "question": "Co je pracovní prostor v aplikaci stella?"

--- a/apps/landing/src/i18n/messages/de.json
+++ b/apps/landing/src/i18n/messages/de.json
@@ -83,8 +83,8 @@
     "toolsTitle": "Werkzeuge für KI-Agenten."
   },
   "meta": {
-    "homeDescription": "Juristischer Open-Source-Arbeitsbereich für Kanzleien: Akten, Dokumente, Vertragsanalyse und Recherche. Selbst hosten oder in der Cloud. Nutzungsbasierte KI.",
-    "homeTitle": "stella | juristischer Open-Source-Arbeitsbereich"
+    "homeDescription": "KI für Anwälte: Akten, Dokumente, Vertragsanalyse und juristische Recherche in einer Open-Source-Plattform. Selbst hosten oder Cloud. Nutzungsbasierte KI.",
+    "homeTitle": "stella | KI für Anwälte, Aktenverwaltung, Vertragsanalyse"
   },
   "nav": {
     "aiFactSheet": "KI-Faktenblatt",
@@ -855,7 +855,7 @@
           "question": "Können andere Werkzeuge auf den Arbeitsbereich zugreifen?"
         }
       },
-      "metaDescription": "Akten, Dokumente, Word-.docx-Bearbeitung, Prüfung, Recherche und Chat in einem juristischen Arbeitsbereich, von den Unterlagen bis zur Antwort.",
+      "metaDescription": "Akten, Dokumente, Word-.docx-Bearbeitung, Prüfung, Recherche und Chat in einer digitalen Aktenverwaltung, von den Unterlagen bis zur Antwort.",
       "metaTitle": "Digitale Aktenverwaltung für Kanzleien | stella",
       "quickAnswer": {
         "answer": "Eine Web-App, die Akten, Dokumente, Word-.docx-Bearbeitung, Prüfung, Recherche und Chat an einem Ort hält. Alles, was in eine Akte kommt, bleibt bei ihr, sodass der Kontext da ist, wenn Sie zurückkehren. Eine begleitende Desktop-App dient als lokale Brücke, wenn ein Dokument Microsoft Word braucht.",

--- a/apps/landing/src/i18n/messages/sk.json
+++ b/apps/landing/src/i18n/messages/sk.json
@@ -83,8 +83,8 @@
     "toolsTitle": "Nástroje pre AI agentov."
   },
   "meta": {
-    "homeDescription": "Open source právny pracovný priestor pre advokátov: spisy, dokumenty, kontrola zmlúv aj právne rešerše. Prevádzkujte sami alebo v cloude. AI podľa využitia.",
-    "homeTitle": "stella | open source právny pracovný priestor"
+    "homeDescription": "AI právny asistent pre advokátov: spisy, dokumenty, kontrola zmlúv aj právne rešerše v jednej aplikácii. Prevádzkujte sami alebo v cloude. AI podľa využitia.",
+    "homeTitle": "stella | AI právny asistent pre advokátske kancelárie"
   },
   "nav": {
     "aiFactSheet": "Prehľad pre AI",
@@ -376,7 +376,7 @@
         }
       },
       "metaDescription": "Vyhľadávajte, čítajte a pracujte s aplikáciou stella z príkazového riadka alebo z klienta kompatibilného s MCP. Obe rozhrania zdieľajú oprávnenia aj dáta.",
-      "metaTitle": "MCP server a CLI pre váš právny pracovný priestor | stella",
+      "metaTitle": "MCP server a CLI pre vašu advokátsku kanceláriu | stella",
       "quickAnswer": {
         "answer": "Dve rozhrania k rovnakým schopnostiam aplikácie stella. CLI zrkadlí register nástrojov MCP ako príkazy, zatiaľ čo MCP server umožňuje kompatibilným AI agentom a nástrojom pracovať so spismi, dokumentmi, vzormi aj verejnými právnymi dátami pod rovnakou kontrolou prístupu.",
         "question": "Čo je CLI a MCP server aplikácie stella?"
@@ -855,8 +855,8 @@
           "question": "Dosiahnu na pracovný priestor aj iné nástroje?"
         }
       },
-      "metaDescription": "Spisy, dokumenty, úpravy Word .docx, revízia, rešerše aj chat v jednom právnom pracovnom priestore. Práca zostáva v kontexte od podkladov až po odpoveď.",
-      "metaTitle": "Správa advokátskych spisov na jednom mieste | stella",
+      "metaDescription": "Spisy, dokumenty, úpravy Word .docx, revízia aj rešerše na jednom mieste. Elektronický spis, v ktorom práca zostáva v kontexte od podkladov po odpoveď.",
+      "metaTitle": "Správa spisov a dokumentov na jednom mieste | stella",
       "quickAnswer": {
         "answer": "Webová aplikácia, ktorá drží spisy, dokumenty, úpravy Word .docx, revíziu, rešerše aj chat na jednom mieste. Všetko, čo do spisu pridáte, pri ňom zostane, takže kontext nájdete aj po návrate. Sprievodná desktopová aplikácia slúži ako lokálny most, keď dokument potrebuje Microsoft Word.",
         "question": "Čo je pracovný priestor v aplikácii stella?"


### PR DESCRIPTION
The cs, de, and sk meta titles and descriptions led with the literal category label ("právní pracovní prostor", "Arbeitsbereich", "právny pracovný priestor"). A meta string is written for a searcher, and the category label is a label, not a phrasing anyone types; the demand phrasings each locale's legal readers actually use are now documented in `TRANSLATION.md` ("Metas are the exception" under "The identity phrase"). de additionally excludes `Kanzleisoftware` (promises beA/Fristen/RVG features the product lacks) and `Schwärzung` (claims irreversible removal; the engine is reversible by design); cs/sk exclude the compound `advokátní/advokátsky spis` (names the advocate's formal client file, narrower than the product's matter — the plain Matter term `spis` already says the right thing).

Changes:
- Rewrite the affected cs/de/sk metas to the demand terms within the existing length budgets: home title/description in all three, cs+sk `cli-mcp.metaTitle`, cs+sk `workspace` metas, cs `agent.metaTitle`, de `workspace.metaDescription`.
- Extend `scripts/check-meta-budgets.ts` with a per-locale term policy: an excluded term fails in any meta string of its locale (inflected forms covered), and the home title+description must carry at least one demand term. The wording rule previously lived only in editors' memory, which is how three locales drifted at once — same class as the length budgets the script already guards.
- Prune the `i18n-lint-baseline.json` entry that grandfathered the old cs `meta.homeDescription`; the rewritten string no longer needs the exception.

Verified: `bun scripts/check-meta-budgets.ts` (13 locales × 9 pages ok, and fails correctly on injected drift in both directions), `bun run i18n:check` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Czech, German, and Slovak page metadata to better highlight AI legal assistance, legal research, contract analysis, and case management.
  * Added locale-specific metadata quality rules for approved and restricted terms.

* **Documentation**
  * Updated translation guidance and metadata requirements for supported locales.

* **Bug Fixes**
  * Refined translated titles and descriptions across homepage, workspace, AI agent, and CLI/MCP pages for clearer positioning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->