### PR TITLE
feat(mcp): require display titles on tool annotations

### DIFF
--- a/.changeset/mcp-tool-titles.md
+++ b/.changeset/mcp-tool-titles.md
@@ -1,0 +1,5 @@
+---
+"@stll/cli": minor
+---
+
+Accept and project the `title` tool annotation from fetched registries (string, capped at 64 characters); the committed registry snapshot now carries display titles for every tool.

--- a/apps/api/scripts/export-capability-catalog.ts
+++ b/apps/api/scripts/export-capability-catalog.ts
@@ -1382,20 +1382,22 @@ const computeCliCommandPaths = async (
       name: string;
       description: string;
       inputSchema: Record<string, unknown>;
-      annotations?: { readOnlyHint?: boolean; destructiveHint?: boolean };
+      annotations: {
+        title: string;
+        readOnlyHint?: boolean;
+        destructiveHint?: boolean;
+      };
     } = {
       name: tool.name,
       description: tool.description,
       inputSchema: tool.inputSchema,
+      annotations: { title: tool.annotations.title },
     };
-    if (tool.annotations?.readOnlyHint !== undefined) {
-      listing.annotations = { readOnlyHint: tool.annotations.readOnlyHint };
+    if (tool.annotations.readOnlyHint !== undefined) {
+      listing.annotations.readOnlyHint = tool.annotations.readOnlyHint;
     }
-    if (tool.annotations?.destructiveHint !== undefined) {
-      listing.annotations = {
-        ...listing.annotations,
-        destructiveHint: tool.annotations.destructiveHint,
-      };
+    if (tool.annotations.destructiveHint !== undefined) {
+      listing.annotations.destructiveHint = tool.annotations.destructiveHint;
     }
     return listing;
   });

--- a/apps/api/src/mcp/__snapshots__/registry-quality.test.ts.snap
+++ b/apps/api/src/mcp/__snapshots__/registry-quality.test.ts.snap
@@ -8,6 +8,7 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "access": "read",
     "description": "Search knowledge across accessible matters using the OpenAI-compatible search tool shape. Returns results with id, title, and url for follow-up fetch calls.",
     "annotations": {
+      "title": "Search",
       "readOnlyHint": true,
       "openWorldHint": false
     },
@@ -36,6 +37,7 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "access": "read",
     "description": "Fetch a knowledge document by id using the OpenAI-compatible fetch tool shape. Use ids returned by the search tool. Long documents are returned in windows; pass the returned nextCursor back as cursor to read more.",
     "annotations": {
+      "title": "Fetch",
       "readOnlyHint": true,
       "openWorldHint": false
     },
@@ -63,6 +65,7 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "access": "read",
     "description": "List the matters you can access, or get one matter's overview. Omit matter_id to list accessible matters (filter with status, page with cursor); list first when the user does not name a matter or you need matter IDs for follow-up tools. Pass matter_id to return that matter's overview instead: counts, recent entities, linked contacts, and members.",
     "annotations": {
+      "title": "List matters",
       "readOnlyHint": true,
       "openWorldHint": false
     },
@@ -101,6 +104,7 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "access": "read",
     "description": "Search across all accessible matters. Use this when the user explicitly asks to search outside a single matter or you do not yet know the right matter.",
     "annotations": {
+      "title": "Search across matters",
       "readOnlyHint": true,
       "openWorldHint": false
     },
@@ -136,6 +140,7 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "feature": "FEATURE_PUBLIC_LAW",
     "description": "Search the shared case-law corpus. Supports free-text search plus optional filters such as court, country, language, date range, and decision type.",
     "annotations": {
+      "title": "Search case law",
       "readOnlyHint": true,
       "openWorldHint": false
     },
@@ -205,6 +210,7 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "access": "read",
     "description": "Read a document's content, found anywhere in your accessible matters. DOCX files are converted to Markdown with structure preserved (headings, tables, lists); other formats return their extracted plain text. Use after search_across_matters. Long documents are returned in windows; pass the returned nextCursor back as cursor to read more.",
     "annotations": {
+      "title": "Read content across matters",
       "readOnlyHint": true,
       "openWorldHint": false
     },
@@ -233,6 +239,7 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "feature": "FEATURE_PUBLIC_LAW",
     "description": "Read a single case-law decision by its decision ID. Returns metadata, plain text, citation links, and source URLs. Long decision text and large citation lists are returned in windows; pass the returned nextCursor back as cursor to read more.",
     "annotations": {
+      "title": "Read case-law decision",
       "readOnlyHint": true,
       "openWorldHint": false
     },
@@ -260,6 +267,7 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "access": "read",
     "description": "Read a contact by ID. Use this after matter overview or entity metadata surfaces a contact the user wants to inspect more closely.",
     "annotations": {
+      "title": "Read contact",
       "readOnlyHint": true,
       "openWorldHint": false
     },
@@ -282,6 +290,7 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "access": "write",
     "description": "Set the practice jurisdictions for the user's stella organization. Call this when the org's practice jurisdictions are empty (e.g., the user signed up via an OAuth client and skipped onboarding). Pass an array of {countryCode, isPrimary}; exactly one entry should be primary.",
     "annotations": {
+      "title": "Set practice jurisdictions",
       "idempotentHint": false,
       "openWorldHint": false
     },
@@ -575,6 +584,7 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "access": "read",
     "description": "List the document templates in this organization (NDAs, powers of attorney, leases), or describe one template's fillable fields. Omit template_id to list templates: each template's id, name, field count, tags, and usage guidance (whenToUse / whenNotToUse); prefer a template whose whenToUse matches the request and skip any whose whenNotToUse applies. Pass template_id to return that template's full field configuration (path, label, inputType, required, hint, options, optionsFrom, aiPrompt / aiAdapt, date format, composite parts, registry-lookup formats) plus its named conditions and formula fields; feed the same shape to save_template to update it. \`required\` controls form validation; omitted optional scalar placeholders render blank.",
     "annotations": {
+      "title": "List templates",
       "readOnlyHint": true,
       "openWorldHint": false
     },
@@ -599,6 +609,7 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "access": "write",
     "description": "Fill a template and return text plus the DOCX as base64. First call list_templates with template_id for field paths, then pass values as a path-to-value map (for example, {\\"tenant.name\\":\\"ACME\\"}). Registry, composite, formula, and AI fields resolve automatically. Unknown keys fail unless allow_unused_values is true; unfilled placeholders fail unless completion_mode is allow_partial. Successful output includes completionStatus.",
     "annotations": {
+      "title": "Fill template",
       "idempotentHint": false,
       "openWorldHint": true
     },
@@ -643,6 +654,7 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "access": "write",
     "description": "Fill a registered template and persist the generated DOCX directly in a matter, without requiring the client to upload bytes. Use action='create_document' to create a new document (optionally inside parent_id), or action='create_version' with entity_id to append a version to an existing document. Call list_templates first to learn the field paths. Returns the entity and version identifiers plus any unmatched placeholders or unused values.",
     "annotations": {
+      "title": "Save filled template",
       "idempotentHint": false,
       "openWorldHint": true
     },
@@ -704,6 +716,7 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "access": "write",
     "description": "Create a document template from a DOCX, or configure an existing template's fields. To create, pass docx_base64 (base64-encoded .docx / Office Open XML bytes, max ~10 MB decoded) and a name; the {{field}} markers in the file become the template's fillable fields, and you can pass fields to configure them in the same call. To configure an existing template, pass template_id with fields and no docx_base64; only the manifest changes, the document's {{markers}} stay untouched. Each fields entry's path must match a {{marker}} in the template. Read the marker grammar from the template-markers reference resource when unsure. Returns the template id and field count when creating, or the updated field list when configuring.",
     "annotations": {
+      "title": "Save template",
       "idempotentHint": false,
       "openWorldHint": false
     },
@@ -870,6 +883,7 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "access": "read",
     "description": "List the documents and folders in a matter. Use 'flat' mode to enumerate every document and folder in the matter, or 'children' mode to walk the folder tree one level at a time (pass parent_id to list a folder's direct children, or omit it for the matter root). Returns each entity's id, name, kind (document or folder), and parentId. Read a document's metadata, fields, or versions with read_document.",
     "annotations": {
+      "title": "List documents",
       "readOnlyHint": true,
       "openWorldHint": false
     },
@@ -915,6 +929,7 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "access": "read",
     "description": "Read a document's metadata and field values by entity ID. By default returns the current version's name, kind, and field/property values. Pass version_id to inspect a specific version instead. Pass version_id and compare_with_version_id to get a plain-text line diff between two versions. Pass include_versions to also return the version history. To read the document's extracted text content, use read_content_across_matters.",
     "annotations": {
+      "title": "Read document",
       "readOnlyHint": true,
       "openWorldHint": false
     },
@@ -954,6 +969,7 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "access": "write",
     "description": "Create a document or folder, or update an existing one. Omit entity_id to create: pass matter_id and name, optionally a parent_id folder and kind ('document' by default, or 'folder'). Creating makes an empty named entity; uploading file content is a separate step. Pass entity_id to update: set name to rename; parent_id to move it into a folder or move_to_root to move it to the matter root; version_id with label and/or description to annotate a version. An update needs at least one change. Returns the entity ID.",
     "annotations": {
+      "title": "Save document",
       "idempotentHint": false,
       "openWorldHint": false
     },
@@ -1018,6 +1034,7 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "access": "write",
     "description": "Delete a document and all its versions, or delete a single version when version_id is provided (the current version is promoted to the next latest; the only remaining version cannot be deleted). This is irreversible.",
     "annotations": {
+      "title": "Delete document",
       "destructiveHint": true,
       "idempotentHint": true,
       "openWorldHint": false
@@ -1049,6 +1066,7 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "access": "read",
     "description": "List the property (column) definitions of a matter. Returns each property's id, name, value type (text, single-select, multi-select, date, or int), and status. Use the returned property id with set_field_value to set a document's value for that property.",
     "annotations": {
+      "title": "List properties",
       "readOnlyHint": true,
       "openWorldHint": false
     },
@@ -1082,6 +1100,7 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "access": "write",
     "description": "Set a document's value for a property (a cell in the matter's table). Pass the document entity_id, the property_id (from list_properties), and a content object whose 'type' matches the property's value type: text (value: string), single-select (value: string or null), multi-select (value: array of strings), date (value: ISO YYYY-MM-DD or null), or int (value: integer, optional currency: 3-letter ISO code). An empty value clears the cell.",
     "annotations": {
+      "title": "Set field value",
       "idempotentHint": false,
       "openWorldHint": false
     },
@@ -1139,6 +1158,7 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "access": "write",
     "description": "Create, update, archive, or unarchive a matter. Omit matter_id to create a new matter (name required; pass client_id to attach a client contact). Pass matter_id to update an existing matter: set name, reference, or billing_reference, and/or set status to 'archived' or 'active' to archive or unarchive it. Returns the matter ID.",
     "annotations": {
+      "title": "Save matter",
       "idempotentHint": false,
       "openWorldHint": false
     },
@@ -1188,6 +1208,7 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "access": "write",
     "description": "Permanently delete a matter and all its documents, tasks, fields, and chat history. This is irreversible.",
     "annotations": {
+      "title": "Delete matter",
       "destructiveHint": true,
       "idempotentHint": true,
       "openWorldHint": false
@@ -1215,6 +1236,7 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "access": "read",
     "description": "List or search the organization's internal contact directory. Returns internal contact IDs accepted by read_contact, save_contact, and link_matter_contact. Use q to search display names and type to filter people or organizations.",
     "annotations": {
+      "title": "List contacts",
       "readOnlyHint": true,
       "openWorldHint": false
     },
@@ -1254,6 +1276,7 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "access": "write",
     "description": "Create or update a contact (a person or organization in the address book, shared across the whole organization). Omit contact_id to create (type and display_name required); pass contact_id to update. String fields other than display_name accept null to clear them.",
     "annotations": {
+      "title": "Save contact",
       "idempotentHint": false,
       "openWorldHint": false
     },
@@ -1317,6 +1340,7 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "access": "write",
     "description": "Permanently delete a contact from the organization address book. Rejected while the contact is still the client of any matter. This is irreversible.",
     "annotations": {
+      "title": "Delete contact",
       "destructiveHint": true,
       "idempotentHint": true,
       "openWorldHint": false
@@ -1344,6 +1368,7 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "access": "read",
     "description": "Look up a company in a public business register (ARES, Brreg, Companies House, EDGAR, GCIS, KRS, ORSR, PRH, recherche-entreprises, or VIES). Pass a canonical identifier (company/registration number, VAT number) for an exact match, or a company name to search where the register supports it. Returns registered names, addresses, and registry-specific details. Result IDs belong to the external registry, not stella's contact directory; create a contact with save_contact before using read_contact.",
     "annotations": {
+      "title": "Look up business registry",
       "readOnlyHint": true,
       "openWorldHint": true
     },
@@ -1385,6 +1410,7 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "access": "read",
     "description": "List tasks in a matter, or read one task in detail. Pass task_id to get a single task's fields, assignees, and linked entities. Otherwise pass matter_id to list the matter's tasks, optionally filtered by a due-date range (date_from/date_to, ISO YYYY-MM-DD) and status. Returns each task's id, name, status, priority, and due date.",
     "annotations": {
+      "title": "List tasks",
       "readOnlyHint": true,
       "openWorldHint": false
     },
@@ -1434,6 +1460,7 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "access": "write",
     "description": "Create or update a task, and manage its assignees and entity links. Omit task_id to create a task (matter_id and name required). Pass task_id to update: set name, status, priority, or due_date (ISO YYYY-MM-DD, null to clear); add or remove one assignee (add_assignee_user_id / remove_assignee_user_id); link the task to another entity (link_entity_id) or remove a link (unlink_link_id). Returns the task ID.",
     "annotations": {
+      "title": "Save task",
       "idempotentHint": false,
       "openWorldHint": false
     },
@@ -1496,6 +1523,7 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "access": "write",
     "description": "Link a contact to a matter in a party role (opposing party/counsel, co-counsel, witness, expert witness, third party, judge, mediator, or other), or remove such a link. Pass contact_id with role to link. To unlink, pass workspace_contact_id (precise, from list_matters) or contact_id alone; contact_id alone is rejected when the contact holds several roles on the matter.",
     "annotations": {
+      "title": "Link contact to matter",
       "idempotentHint": false,
       "openWorldHint": false
     },
@@ -1541,6 +1569,7 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "access": "read",
     "description": "List the clause library for this organization, or read one clause in detail. Pass clause_id to get a clause's body, description, usage notes, variants, and version history; add version_id to read one version's body. Otherwise list clauses (newest first), optionally filtered by category_id or a text query, and set include_categories to also return the category tree. Returns each clause's id, title, category, language, and current version.",
     "annotations": {
+      "title": "List clauses",
       "readOnlyHint": true,
       "openWorldHint": false
     },
@@ -1587,6 +1616,7 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "access": "write",
     "description": "Create or update a clause in the organization's clause library. Omit clause_id to create (title and body required); pass clause_id to update. body is an ordered array of paragraphs, each with text and optional formatting. category_id, language, description, usage_notes, and metadata accept null to clear them on update. Set snapshot_version true on an update to also append a version snapshot of the body. Returns the clause id.",
     "annotations": {
+      "title": "Save clause",
       "idempotentHint": false,
       "openWorldHint": false
     },
@@ -1734,6 +1764,7 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "access": "write",
     "description": "Permanently delete a clause and all its variants and versions from the organization's clause library. This is irreversible.",
     "annotations": {
+      "title": "Delete clause",
       "destructiveHint": true,
       "idempotentHint": true,
       "openWorldHint": false
@@ -1761,6 +1792,7 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "access": "read",
     "description": "List the review playbooks in this organization, or read one in detail. Pass playbook_id to get a playbook's positions (the issues it reviews, their questions, tiered rules, and ideal language), scope, and description. Otherwise list playbooks (newest first). Returns each playbook's id, name, and description.",
     "annotations": {
+      "title": "List playbooks",
       "readOnlyHint": true,
       "openWorldHint": false
     },
@@ -1791,6 +1823,7 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "access": "write",
     "description": "Run a review playbook over a matter's documents. Materializes the playbook's extraction and verdict columns onto the matter's table and starts the AI review; findings populate asynchronously. Pass matter_id and playbook_id. Returns the number of columns queued for review.",
     "annotations": {
+      "title": "Run playbook",
       "idempotentHint": false,
       "openWorldHint": false
     },
@@ -1819,6 +1852,7 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "feature": "FEATURE_TIME_BILLING",
     "description": "List time entries in a matter, or read one entry in detail. Pass time_entry_id to get a single entry. Otherwise pass matter_id to list the matter's entries, optionally filtered by entity_id (the item the time was logged against), user_id, a date-worked range (date_from/date_to, ISO YYYY-MM-DD), and status. Returns each entry's id, entity, user, date, minutes, rate (minor currency units), currency, narrative, and status.",
     "annotations": {
+      "title": "List time entries",
       "readOnlyHint": true,
       "openWorldHint": false
     },
@@ -1882,6 +1916,7 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "feature": "FEATURE_TIME_BILLING",
     "description": "Create or update a time entry. Omit time_entry_id to create (matter_id, entity_id, date_worked, timezone_id, duration_minutes, rate_at_entry, currency, and narrative all required). Pass time_entry_id to update: set date_worked, duration_minutes, narrative, invoice_narrative, billable, no_charge, entity_id (move the entry), task_code, activity_code, rate_at_entry, currency, and/or status (draft or approved). Rates and amounts are integer minor currency units (e.g. cents); durations are whole minutes. Returns the time entry ID.",
     "annotations": {
+      "title": "Save time entry",
       "idempotentHint": false,
       "openWorldHint": false
     },
@@ -1980,6 +2015,7 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "feature": "FEATURE_TIME_BILLING",
     "description": "Delete a time entry. A draft entry is permanently deleted; an approved entry is written off instead (kept for the audit trail, excluded from billing). A billed entry cannot be deleted until its invoice is reverted. Returns whether the entry was hard-deleted.",
     "annotations": {
+      "title": "Delete time entry",
       "destructiveHint": true,
       "idempotentHint": true,
       "openWorldHint": false
@@ -2008,6 +2044,7 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "feature": "FEATURE_TIME_BILLING",
     "description": "Resolve the effective hourly rate for a user on a given date in a matter, using the matter's default rate table (user-specific rate first, then the table default). Returns the hourly rate in integer minor currency units (e.g. cents) and the currency, or nulls when no rate applies.",
     "annotations": {
+      "title": "Resolve billing rate",
       "readOnlyHint": true,
       "openWorldHint": false
     },
@@ -2042,6 +2079,7 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "feature": "FEATURE_TIME_BILLING",
     "description": "List invoices in a matter, or read one invoice in detail. Pass invoice_id to get a single invoice with its line items (time entries and expenses). Otherwise pass matter_id to list the matter's invoices. Returns each invoice's id, number, reference, status, dates, currency, and total (integer minor currency units).",
     "annotations": {
+      "title": "List invoices",
       "readOnlyHint": true,
       "openWorldHint": false
     },
@@ -2077,6 +2115,7 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "feature": "FEATURE_USAGE",
     "description": "Read the organization's current usage entitlement: plan, seats, billing period, and how many usage units (AI credits) remain this period. Returns { entitlement: null } when the organization has no active plan. Requires organization-settings management access.",
     "annotations": {
+      "title": "Get usage",
       "readOnlyHint": true,
       "openWorldHint": false
     },
@@ -2092,6 +2131,7 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "feature": "FEATURE_PUBLIC_LAW",
     "description": "Search and read Spanish consolidated legislation from the BOE. In search mode, pass query (free text) and/or filters (title, department_code, legal_range_code, matter_code, date_from/date_to as YYYYMMDD); at least one filter is required. In read mode, pass law_id (e.g. BOE-A-1889-4763) to return the law with its block structure; add full_text to include the consolidated text, block_id to return one text block, or relation_type to list related laws instead. Returns public statutory data.",
     "annotations": {
+      "title": "Search legislation",
       "readOnlyHint": true,
       "openWorldHint": true
     },
@@ -2177,6 +2217,7 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "access": "read",
     "description": "Read the organization's audit trail (compliance view). Returns audit entries newest first, each with its action, resource type and id, actor user id, workspace, timestamp, and change detail. Filter by workspace_id, action, resource_type (with optional resource_id), user_id, and a created-at range (from/to, ISO date-time). Paginate with limit and cursor. Requires organization audit-log access.",
     "annotations": {
+      "title": "List audit log",
       "readOnlyHint": true,
       "openWorldHint": false
     },
@@ -2233,6 +2274,7 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "access": "write",
     "description": "Manage organization members and non-secret settings. Member actions require matter_id and user_id. update_org_settings controls matter numbering, prompt caching, and document processing. Manage provider secrets in the dashboard.",
     "annotations": {
+      "title": "Manage organization",
       "idempotentHint": false,
       "openWorldHint": false
     },
@@ -2295,6 +2337,7 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "access": "write",
     "description": "File a bug, feature request, or docs issue with the stella maintainers. Requires explicit human approval; the tool never publishes anything on its own. It returns a prefilled new-issue URL and a gh command the human opens and submits under their own GitHub account. All content is sanitized server-side (emails, ids, secrets, URLs, IPs are redacted). Never include tenant data, client or matter names, ids, or secrets; describe the problem, reproduction steps, and expected vs actual result.",
     "annotations": {
+      "title": "Send feedback",
       "idempotentHint": false,
       "openWorldHint": true
     },
@@ -2342,6 +2385,7 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "access": "read",
     "description": "List the automatable capabilities beyond the curated tools: every safe backend operation (CRUD, exports, processing triggers) reachable through invoke_capability. Paginated; filter by domain (the id prefix, e.g. \\"time-entries\\") or access (read/write). Each item gives the capability id, a one-line summary, and every OAuth scope it needs. Use describe_capability for the full input schema.",
     "annotations": {
+      "title": "List capabilities",
       "openWorldHint": false
     },
     "inputSchema": {
@@ -2380,6 +2424,7 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "access": "read",
     "description": "Describe one capability in full: its live input JSON Schema (body/params/query), required OAuth scopes, member permissions, whether it is destructive, its handler kind (workspace/root), and its disposition. Call this before invoke_capability to learn exactly what input to pass.",
     "annotations": {
+      "title": "Describe capability",
       "openWorldHint": false
     },
     "inputSchema": {
@@ -2402,6 +2447,7 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "access": "write",
     "description": "Invoke one capability by id (from list_capabilities/describe_capability). Pass its input under { body, params, query }; workspace-scoped capabilities take the target workspace as input.params.workspaceId. Real authority is enforced per capability: the session must hold the capability's scope and your member role its permissions. Set validateOnly: true to check input without running it; destructive capabilities require confirm: true after human approval.",
     "annotations": {
+      "title": "Invoke capability",
       "idempotentHint": false,
       "openWorldHint": true
     },
@@ -2460,6 +2506,7 @@ exports[`MCP registry quality (anonymized surface) tool surface snapshot (name, 
     "access": "read",
     "description": "Search anonymized knowledge across accessible matters using the OpenAI-compatible search tool shape. Returns anonymized titles with ids and urls for follow-up fetch calls.",
     "annotations": {
+      "title": "Search",
       "readOnlyHint": true,
       "openWorldHint": false
     },
@@ -2488,6 +2535,7 @@ exports[`MCP registry quality (anonymized surface) tool surface snapshot (name, 
     "access": "read",
     "description": "Fetch anonymized document text by id using the OpenAI-compatible fetch tool shape. Use ids returned by the anonymized search tool. Long documents are returned in windows; pass the returned nextCursor back as cursor to read more.",
     "annotations": {
+      "title": "Fetch",
       "readOnlyHint": true,
       "openWorldHint": false
     },
@@ -2515,6 +2563,7 @@ exports[`MCP registry quality (anonymized surface) tool surface snapshot (name, 
     "access": "read",
     "description": "List the matters you can access, or get one matter's overview. Omit matter_id to list accessible matters (filter with status, page with cursor); list first when the user does not name a matter or you need matter IDs for follow-up tools. Pass matter_id to return that matter's overview instead: counts, recent entities, linked contacts, and members.",
     "annotations": {
+      "title": "List matters",
       "readOnlyHint": true,
       "openWorldHint": false
     },
@@ -2553,6 +2602,7 @@ exports[`MCP registry quality (anonymized surface) tool surface snapshot (name, 
     "access": "read",
     "description": "Search across all accessible matters. Use this when the user explicitly asks to search outside a single matter or you do not yet know the right matter.",
     "annotations": {
+      "title": "Search across matters",
       "readOnlyHint": true,
       "openWorldHint": false
     },
@@ -2588,6 +2638,7 @@ exports[`MCP registry quality (anonymized surface) tool surface snapshot (name, 
     "feature": "FEATURE_PUBLIC_LAW",
     "description": "Search the shared case-law corpus. Supports free-text search plus optional filters such as court, country, language, date range, and decision type.",
     "annotations": {
+      "title": "Search case law",
       "readOnlyHint": true,
       "openWorldHint": false
     },
@@ -2657,6 +2708,7 @@ exports[`MCP registry quality (anonymized surface) tool surface snapshot (name, 
     "access": "read",
     "description": "Read a document's content, found anywhere in your accessible matters. DOCX files are converted to Markdown with structure preserved (headings, tables, lists); other formats return their extracted plain text. Use after search_across_matters. Long documents are returned in windows; pass the returned nextCursor back as cursor to read more.",
     "annotations": {
+      "title": "Read content across matters",
       "readOnlyHint": true,
       "openWorldHint": false
     },
@@ -2685,6 +2737,7 @@ exports[`MCP registry quality (anonymized surface) tool surface snapshot (name, 
     "feature": "FEATURE_PUBLIC_LAW",
     "description": "Read a single case-law decision by its decision ID. Returns metadata, plain text, citation links, and source URLs. Long decision text and large citation lists are returned in windows; pass the returned nextCursor back as cursor to read more.",
     "annotations": {
+      "title": "Read case-law decision",
       "readOnlyHint": true,
       "openWorldHint": false
     },
@@ -2712,6 +2765,7 @@ exports[`MCP registry quality (anonymized surface) tool surface snapshot (name, 
     "access": "read",
     "description": "Read a contact by ID. Use this after matter overview or entity metadata surfaces a contact the user wants to inspect more closely.",
     "annotations": {
+      "title": "Read contact",
       "readOnlyHint": true,
       "openWorldHint": false
     },
@@ -2734,6 +2788,7 @@ exports[`MCP registry quality (anonymized surface) tool surface snapshot (name, 
     "access": "read",
     "description": "List the document templates in this organization (NDAs, powers of attorney, leases), or describe one template's fillable fields. Omit template_id to list templates: each template's id, name, field count, tags, and usage guidance (whenToUse / whenNotToUse); prefer a template whose whenToUse matches the request and skip any whose whenNotToUse applies. Pass template_id to return that template's full field configuration (path, label, inputType, required, hint, options, optionsFrom, aiPrompt / aiAdapt, date format, composite parts, registry-lookup formats) plus its named conditions and formula fields; feed the same shape to save_template to update it. \`required\` controls form validation; omitted optional scalar placeholders render blank.",
     "annotations": {
+      "title": "List templates",
       "readOnlyHint": true,
       "openWorldHint": false
     },
@@ -2758,6 +2813,7 @@ exports[`MCP registry quality (anonymized surface) tool surface snapshot (name, 
     "access": "read",
     "description": "List the documents and folders in a matter. Use 'flat' mode to enumerate every document and folder in the matter, or 'children' mode to walk the folder tree one level at a time (pass parent_id to list a folder's direct children, or omit it for the matter root). Returns each entity's id, name, kind (document or folder), and parentId. Read a document's metadata, fields, or versions with read_document.",
     "annotations": {
+      "title": "List documents",
       "readOnlyHint": true,
       "openWorldHint": false
     },
@@ -2803,6 +2859,7 @@ exports[`MCP registry quality (anonymized surface) tool surface snapshot (name, 
     "access": "read",
     "description": "Read a document's metadata and field values by entity ID. By default returns the current version's name, kind, and field/property values. Pass version_id to inspect a specific version instead. Pass version_id and compare_with_version_id to get a plain-text line diff between two versions. Pass include_versions to also return the version history. To read the document's extracted text content, use read_content_across_matters.",
     "annotations": {
+      "title": "Read document",
       "readOnlyHint": true,
       "openWorldHint": false
     },
@@ -2842,6 +2899,7 @@ exports[`MCP registry quality (anonymized surface) tool surface snapshot (name, 
     "access": "read",
     "description": "List the property (column) definitions of a matter. Returns each property's id, name, value type (text, single-select, multi-select, date, or int), and status. Use the returned property id with set_field_value to set a document's value for that property.",
     "annotations": {
+      "title": "List properties",
       "readOnlyHint": true,
       "openWorldHint": false
     },
@@ -2875,6 +2933,7 @@ exports[`MCP registry quality (anonymized surface) tool surface snapshot (name, 
     "access": "read",
     "description": "Look up a company in a public business register (ARES, Brreg, Companies House, EDGAR, GCIS, KRS, ORSR, PRH, recherche-entreprises, or VIES). Pass a canonical identifier (company/registration number, VAT number) for an exact match, or a company name to search where the register supports it. Returns registered names, addresses, and registry-specific details. Result IDs belong to the external registry, not stella's contact directory; create a contact with save_contact before using read_contact.",
     "annotations": {
+      "title": "Look up business registry",
       "readOnlyHint": true,
       "openWorldHint": true
     },
@@ -2916,6 +2975,7 @@ exports[`MCP registry quality (anonymized surface) tool surface snapshot (name, 
     "access": "read",
     "description": "List tasks in a matter, or read one task in detail. Pass task_id to get a single task's fields, assignees, and linked entities. Otherwise pass matter_id to list the matter's tasks, optionally filtered by a due-date range (date_from/date_to, ISO YYYY-MM-DD) and status. Returns each task's id, name, status, priority, and due date.",
     "annotations": {
+      "title": "List tasks",
       "readOnlyHint": true,
       "openWorldHint": false
     },
@@ -2965,6 +3025,7 @@ exports[`MCP registry quality (anonymized surface) tool surface snapshot (name, 
     "access": "read",
     "description": "List the clause library for this organization, or read one clause in detail. Pass clause_id to get a clause's body, description, usage notes, variants, and version history; add version_id to read one version's body. Otherwise list clauses (newest first), optionally filtered by category_id or a text query, and set include_categories to also return the category tree. Returns each clause's id, title, category, language, and current version.",
     "annotations": {
+      "title": "List clauses",
       "readOnlyHint": true,
       "openWorldHint": false
     },
@@ -3011,6 +3072,7 @@ exports[`MCP registry quality (anonymized surface) tool surface snapshot (name, 
     "access": "read",
     "description": "List the review playbooks in this organization, or read one in detail. Pass playbook_id to get a playbook's positions (the issues it reviews, their questions, tiered rules, and ideal language), scope, and description. Otherwise list playbooks (newest first). Returns each playbook's id, name, and description.",
     "annotations": {
+      "title": "List playbooks",
       "readOnlyHint": true,
       "openWorldHint": false
     },
@@ -3042,6 +3104,7 @@ exports[`MCP registry quality (anonymized surface) tool surface snapshot (name, 
     "feature": "FEATURE_TIME_BILLING",
     "description": "List time entries in a matter, or read one entry in detail. Pass time_entry_id to get a single entry. Otherwise pass matter_id to list the matter's entries, optionally filtered by entity_id (the item the time was logged against), user_id, a date-worked range (date_from/date_to, ISO YYYY-MM-DD), and status. Returns each entry's id, entity, user, date, minutes, rate (minor currency units), currency, narrative, and status.",
     "annotations": {
+      "title": "List time entries",
       "readOnlyHint": true,
       "openWorldHint": false
     },
@@ -3105,6 +3168,7 @@ exports[`MCP registry quality (anonymized surface) tool surface snapshot (name, 
     "feature": "FEATURE_TIME_BILLING",
     "description": "Resolve the effective hourly rate for a user on a given date in a matter, using the matter's default rate table (user-specific rate first, then the table default). Returns the hourly rate in integer minor currency units (e.g. cents) and the currency, or nulls when no rate applies.",
     "annotations": {
+      "title": "Resolve billing rate",
       "readOnlyHint": true,
       "openWorldHint": false
     },
@@ -3139,6 +3203,7 @@ exports[`MCP registry quality (anonymized surface) tool surface snapshot (name, 
     "feature": "FEATURE_TIME_BILLING",
     "description": "List invoices in a matter, or read one invoice in detail. Pass invoice_id to get a single invoice with its line items (time entries and expenses). Otherwise pass matter_id to list the matter's invoices. Returns each invoice's id, number, reference, status, dates, currency, and total (integer minor currency units).",
     "annotations": {
+      "title": "List invoices",
       "readOnlyHint": true,
       "openWorldHint": false
     },
@@ -3174,6 +3239,7 @@ exports[`MCP registry quality (anonymized surface) tool surface snapshot (name, 
     "feature": "FEATURE_USAGE",
     "description": "Read the organization's current usage entitlement: plan, seats, billing period, and how many usage units (AI credits) remain this period. Returns { entitlement: null } when the organization has no active plan. Requires organization-settings management access.",
     "annotations": {
+      "title": "Get usage",
       "readOnlyHint": true,
       "openWorldHint": false
     },
@@ -3189,6 +3255,7 @@ exports[`MCP registry quality (anonymized surface) tool surface snapshot (name, 
     "feature": "FEATURE_PUBLIC_LAW",
     "description": "Search and read Spanish consolidated legislation from the BOE. In search mode, pass query (free text) and/or filters (title, department_code, legal_range_code, matter_code, date_from/date_to as YYYYMMDD); at least one filter is required. In read mode, pass law_id (e.g. BOE-A-1889-4763) to return the law with its block structure; add full_text to include the consolidated text, block_id to return one text block, or relation_type to list related laws instead. Returns public statutory data.",
     "annotations": {
+      "title": "Search legislation",
       "readOnlyHint": true,
       "openWorldHint": true
     },

--- a/apps/api/src/mcp/billing-tools.ts
+++ b/apps/api/src/mcp/billing-tools.ts
@@ -290,7 +290,11 @@ const INVOICE_DETAIL_TEXT_FIELD_PATHS = deriveTextFieldPaths(
 
 export const BILLING_TOOL_DEFINITIONS = [
   {
-    annotations: { readOnlyHint: true, openWorldHint: false },
+    annotations: {
+      title: "List time entries",
+      readOnlyHint: true,
+      openWorldHint: false,
+    },
     description:
       "List time entries in a matter, or read one entry in detail. Pass " +
       "time_entry_id to get a single entry. Otherwise pass matter_id to list " +
@@ -422,7 +426,11 @@ export const BILLING_TOOL_DEFINITIONS = [
         ),
       },
     },
-    annotations: { idempotentHint: false, openWorldHint: false },
+    annotations: {
+      title: "Save time entry",
+      idempotentHint: false,
+      openWorldHint: false,
+    },
     access: "write",
     anonymized: { exposure: "excluded", reason: "write" },
     feature: "FEATURE_TIME_BILLING",
@@ -431,6 +439,7 @@ export const BILLING_TOOL_DEFINITIONS = [
   },
   {
     annotations: {
+      title: "Delete time entry",
       destructiveHint: true,
       idempotentHint: true,
       openWorldHint: false,
@@ -455,7 +464,11 @@ export const BILLING_TOOL_DEFINITIONS = [
     scope: "stella:billing_write",
   },
   {
-    annotations: { readOnlyHint: true, openWorldHint: false },
+    annotations: {
+      title: "Resolve billing rate",
+      readOnlyHint: true,
+      openWorldHint: false,
+    },
     description:
       "Resolve the effective hourly rate for a user on a given date in a " +
       "matter, using the matter's default rate table (user-specific rate " +
@@ -480,7 +493,11 @@ export const BILLING_TOOL_DEFINITIONS = [
     scope: "stella:read",
   },
   {
-    annotations: { readOnlyHint: true, openWorldHint: false },
+    annotations: {
+      title: "List invoices",
+      readOnlyHint: true,
+      openWorldHint: false,
+    },
     description:
       "List invoices in a matter, or read one invoice in detail. Pass " +
       "invoice_id to get a single invoice with its line items (time entries " +
@@ -518,7 +535,11 @@ export const BILLING_TOOL_DEFINITIONS = [
     scope: "stella:read",
   },
   {
-    annotations: { readOnlyHint: true, openWorldHint: false },
+    annotations: {
+      title: "Get usage",
+      readOnlyHint: true,
+      openWorldHint: false,
+    },
     description:
       "Read the organization's current usage entitlement: plan, seats, billing " +
       "period, and how many usage units (AI credits) remain this period. " +

--- a/apps/api/src/mcp/capability-tools.ts
+++ b/apps/api/src/mcp/capability-tools.ts
@@ -1260,7 +1260,7 @@ export const mapHandlerResult = ({
 
 const CAPABILITY_TOOL_DEFINITIONS = [
   {
-    annotations: { openWorldHint: false },
+    annotations: { title: "List capabilities", openWorldHint: false },
     name: "list_capabilities",
     access: "read",
     anonymized: { exposure: "excluded", reason: "dynamic_tenant_payload" },
@@ -1291,7 +1291,7 @@ const CAPABILITY_TOOL_DEFINITIONS = [
     },
   },
   {
-    annotations: { openWorldHint: false },
+    annotations: { title: "Describe capability", openWorldHint: false },
     name: "describe_capability",
     access: "read",
     anonymized: { exposure: "excluded", reason: "dynamic_tenant_payload" },
@@ -1320,7 +1320,11 @@ const CAPABILITY_TOOL_DEFINITIONS = [
     // lookup and template-tools.ts's fill_template declare open-world for;
     // the hint is static per tool, so it must cover that reachable case even
     // though most capabilities never leave the closed Stella domain.
-    annotations: { idempotentHint: false, openWorldHint: true },
+    annotations: {
+      title: "Invoke capability",
+      idempotentHint: false,
+      openWorldHint: true,
+    },
     name: "invoke_capability",
     access: "write",
     anonymized: { exposure: "excluded", reason: "write" },

--- a/apps/api/src/mcp/compat-tools.ts
+++ b/apps/api/src/mcp/compat-tools.ts
@@ -230,7 +230,7 @@ const getCompatFetchPayload = ({
 
 export const COMPAT_TOOL_DEFINITIONS = [
   {
-    annotations: { readOnlyHint: true, openWorldHint: false },
+    annotations: { title: "Search", readOnlyHint: true, openWorldHint: false },
     access: "read",
     anonymized: {
       exposure: "anonymize",
@@ -259,7 +259,7 @@ export const COMPAT_TOOL_DEFINITIONS = [
     scope: "stella:search",
   },
   {
-    annotations: { readOnlyHint: true, openWorldHint: false },
+    annotations: { title: "Fetch", readOnlyHint: true, openWorldHint: false },
     access: "read",
     anonymized: {
       exposure: "anonymize",

--- a/apps/api/src/mcp/document-tools.ts
+++ b/apps/api/src/mcp/document-tools.ts
@@ -443,7 +443,11 @@ const READ_DOCUMENT_TEXT_FIELD_PATHS = [
 
 export const DOCUMENT_TOOL_DEFINITIONS = [
   {
-    annotations: { readOnlyHint: true, openWorldHint: false },
+    annotations: {
+      title: "List documents",
+      readOnlyHint: true,
+      openWorldHint: false,
+    },
     description:
       "List the documents and folders in a matter. Use 'flat' mode to " +
       "enumerate every document and folder in the matter, or 'children' mode " +
@@ -488,7 +492,11 @@ export const DOCUMENT_TOOL_DEFINITIONS = [
     scope: "stella:read",
   },
   {
-    annotations: { readOnlyHint: true, openWorldHint: false },
+    annotations: {
+      title: "Read document",
+      readOnlyHint: true,
+      openWorldHint: false,
+    },
     description:
       "Read a document's metadata and field values by entity ID. By default " +
       "returns the current version's name, kind, and field/property values. " +
@@ -572,7 +580,11 @@ export const DOCUMENT_TOOL_DEFINITIONS = [
         ),
       },
     },
-    annotations: { idempotentHint: false, openWorldHint: false },
+    annotations: {
+      title: "Save document",
+      idempotentHint: false,
+      openWorldHint: false,
+    },
     access: "write",
     anonymized: { exposure: "excluded", reason: "write" },
     name: "save_document",
@@ -580,6 +592,7 @@ export const DOCUMENT_TOOL_DEFINITIONS = [
   },
   {
     annotations: {
+      title: "Delete document",
       destructiveHint: true,
       idempotentHint: true,
       openWorldHint: false,
@@ -606,7 +619,11 @@ export const DOCUMENT_TOOL_DEFINITIONS = [
     scope: "stella:documents_write",
   },
   {
-    annotations: { readOnlyHint: true, openWorldHint: false },
+    annotations: {
+      title: "List properties",
+      readOnlyHint: true,
+      openWorldHint: false,
+    },
     description:
       "List the property (column) definitions of a matter. Returns each " +
       "property's id, name, value type (text, single-select, multi-select, " +
@@ -677,7 +694,11 @@ export const DOCUMENT_TOOL_DEFINITIONS = [
     // reindexes the cell and records a fresh audit event + updatedAt bump on
     // every call, so a repeat with identical args has an observable additional
     // effect (a duplicate audit entry) in this compliance context.
-    annotations: { idempotentHint: false, openWorldHint: false },
+    annotations: {
+      title: "Set field value",
+      idempotentHint: false,
+      openWorldHint: false,
+    },
     access: "write",
     anonymized: { exposure: "excluded", reason: "write" },
     name: "set_field_value",

--- a/apps/api/src/mcp/feedback-tools.ts
+++ b/apps/api/src/mcp/feedback-tools.ts
@@ -67,7 +67,11 @@ export const FEEDBACK_TOOL_DEFINITIONS = [
       },
       required: ["kind", "title", "body"],
     },
-    annotations: { idempotentHint: false, openWorldHint: true },
+    annotations: {
+      title: "Send feedback",
+      idempotentHint: false,
+      openWorldHint: true,
+    },
     access: "write",
     anonymized: { exposure: "excluded", reason: "write" },
     name: "send_feedback",

--- a/apps/api/src/mcp/gateway/list-tools.ts
+++ b/apps/api/src/mcp/gateway/list-tools.ts
@@ -169,7 +169,7 @@ export const listGatewayMcpToolDefinitions = async ({
       definitions.push({
         access: "read",
         annotations: {
-          title: toDynamicToolTitle(skill.name),
+          title: toDynamicToolTitle(skill.name) || skill.exposedName,
           readOnlyHint: true,
         },
         anonymized: DYNAMIC_GATEWAY_ANONYMIZED,
@@ -245,7 +245,7 @@ export const getGatewayMcpToolDefinition = async ({
   return {
     access: "read",
     annotations: {
-      title: toDynamicToolTitle(skill.name),
+      title: toDynamicToolTitle(skill.name) || skill.exposedName,
       readOnlyHint: true,
     },
     anonymized: DYNAMIC_GATEWAY_ANONYMIZED,

--- a/apps/api/src/mcp/gateway/list-tools.ts
+++ b/apps/api/src/mcp/gateway/list-tools.ts
@@ -146,9 +146,10 @@ export const listGatewayMcpToolDefinitions = async ({
       definitions.push({
         access: externalMcpToolAccess(readOnlyHint),
         annotations: {
-          title: toDynamicToolTitle(
-            `${tool.connectorDisplayName}: ${tool.cachedTool.rawName}`,
-          ),
+          title: externalToolTitle({
+            connectorDisplayName: tool.connectorDisplayName,
+            rawName: tool.cachedTool.rawName,
+          }),
           ...(readOnlyHint === undefined ? {} : { readOnlyHint }),
         },
         anonymized: DYNAMIC_GATEWAY_ANONYMIZED,
@@ -213,9 +214,10 @@ export const getGatewayMcpToolDefinition = async ({
     return {
       access: externalMcpToolAccess(externalTool.cachedTool.readOnlyHint),
       annotations: {
-        title: toDynamicToolTitle(
-          `${externalTool.connectorDisplayName}: ${externalTool.cachedTool.rawName}`,
-        ),
+        title: externalToolTitle({
+          connectorDisplayName: externalTool.connectorDisplayName,
+          rawName: externalTool.cachedTool.rawName,
+        }),
         ...(externalTool.cachedTool.readOnlyHint === undefined
           ? {}
           : { readOnlyHint: externalTool.cachedTool.readOnlyHint }),
@@ -275,11 +277,54 @@ export const toMcpTools = (
 // fetched-registry validation.
 const DYNAMIC_TOOL_TITLE_MAX_CHARS = 64;
 
-const toDynamicToolTitle = (raw: string): string => {
+// The budget counts UTF-16 units (that is what the trust boundary measures),
+// but the cut advances by code point so a boundary can never emit a lone
+// surrogate.
+const clampTitle = (raw: string, maxUnits: number): string => {
   const trimmed = raw.trim();
-  return trimmed.length <= DYNAMIC_TOOL_TITLE_MAX_CHARS
-    ? trimmed
-    : trimmed.slice(0, DYNAMIC_TOOL_TITLE_MAX_CHARS);
+  if (trimmed.length <= maxUnits) {
+    return trimmed;
+  }
+  let clamped = "";
+  for (const point of trimmed) {
+    if (clamped.length + point.length > maxUnits) {
+      break;
+    }
+    clamped += point;
+  }
+  return clamped.trimEnd();
+};
+
+const toDynamicToolTitle = (raw: string): string =>
+  clampTitle(raw, DYNAMIC_TOOL_TITLE_MAX_CHARS);
+
+// `<connector display name>: <upstream tool name>`, preferring the tool name:
+// connector display names can be far longer than the cap, and truncating the
+// combined string from the right would leave every tool of such a connector
+// with the same title. The distinguishing suffix keeps its budget first; the
+// display-name prefix gets whatever remains.
+const EXTERNAL_TITLE_SEPARATOR = ": ";
+
+const externalToolTitle = ({
+  connectorDisplayName,
+  rawName,
+}: {
+  connectorDisplayName: string;
+  rawName: string;
+}): string => {
+  const name = toDynamicToolTitle(rawName);
+  const displayBudget =
+    DYNAMIC_TOOL_TITLE_MAX_CHARS -
+    name.length -
+    EXTERNAL_TITLE_SEPARATOR.length;
+  if (displayBudget <= 0) {
+    return name;
+  }
+  const display = clampTitle(connectorDisplayName, displayBudget);
+  if (display.length === 0) {
+    return name;
+  }
+  return `${display}${EXTERNAL_TITLE_SEPARATOR}${name}`;
 };
 
 const externalToolDescription = ({

--- a/apps/api/src/mcp/gateway/list-tools.ts
+++ b/apps/api/src/mcp/gateway/list-tools.ts
@@ -145,9 +145,12 @@ export const listGatewayMcpToolDefinitions = async ({
       const { readOnlyHint } = tool.cachedTool;
       definitions.push({
         access: externalMcpToolAccess(readOnlyHint),
-        ...(readOnlyHint === undefined
-          ? {}
-          : { annotations: { readOnlyHint } }),
+        annotations: {
+          title: toDynamicToolTitle(
+            `${tool.connectorDisplayName}: ${tool.cachedTool.rawName}`,
+          ),
+          ...(readOnlyHint === undefined ? {} : { readOnlyHint }),
+        },
         anonymized: DYNAMIC_GATEWAY_ANONYMIZED,
         description: externalToolDescription({
           connectorDisplayName: tool.connectorDisplayName,
@@ -164,7 +167,10 @@ export const listGatewayMcpToolDefinitions = async ({
     for (const skill of await loadVisibleSkillTools({ context })) {
       definitions.push({
         access: "read",
-        annotations: { readOnlyHint: true },
+        annotations: {
+          title: toDynamicToolTitle(skill.name),
+          readOnlyHint: true,
+        },
         anonymized: DYNAMIC_GATEWAY_ANONYMIZED,
         description: skill.description,
         inputSchema: {
@@ -206,13 +212,14 @@ export const getGatewayMcpToolDefinition = async ({
 
     return {
       access: externalMcpToolAccess(externalTool.cachedTool.readOnlyHint),
-      ...(externalTool.cachedTool.readOnlyHint === undefined
-        ? {}
-        : {
-            annotations: {
-              readOnlyHint: externalTool.cachedTool.readOnlyHint,
-            },
-          }),
+      annotations: {
+        title: toDynamicToolTitle(
+          `${externalTool.connectorDisplayName}: ${externalTool.cachedTool.rawName}`,
+        ),
+        ...(externalTool.cachedTool.readOnlyHint === undefined
+          ? {}
+          : { readOnlyHint: externalTool.cachedTool.readOnlyHint }),
+      },
       anonymized: DYNAMIC_GATEWAY_ANONYMIZED,
       description: externalToolDescription({
         connectorDisplayName: externalTool.connectorDisplayName,
@@ -235,7 +242,10 @@ export const getGatewayMcpToolDefinition = async ({
 
   return {
     access: "read",
-    annotations: { readOnlyHint: true },
+    annotations: {
+      title: toDynamicToolTitle(skill.name),
+      readOnlyHint: true,
+    },
     anonymized: DYNAMIC_GATEWAY_ANONYMIZED,
     description: skill.description,
     inputSchema: {
@@ -251,11 +261,26 @@ export const getGatewayMcpToolDefinition = async ({
 export const toMcpTools = (
   definitions: readonly McpToolDefinition[],
 ): McpTool[] =>
-  definitions.map(({ annotations, description, inputSchema, name }) =>
-    annotations === undefined
-      ? { description, inputSchema, name }
-      : { annotations, description, inputSchema, name },
-  );
+  definitions.map(({ annotations, description, inputSchema, name }) => ({
+    annotations,
+    description,
+    inputSchema,
+    name,
+  }));
+
+// Display title for a dynamically-gated tool. External connectors and skills
+// carry human names already; clamp to the CLI trust boundary's 64-char wire
+// cap (MAX_TOOL_TITLE_CHARS in packages/cli/src/registry-trust.ts) so a long
+// connector or skill name cannot make the served listing fail a client's
+// fetched-registry validation.
+const DYNAMIC_TOOL_TITLE_MAX_CHARS = 64;
+
+const toDynamicToolTitle = (raw: string): string => {
+  const trimmed = raw.trim();
+  return trimmed.length <= DYNAMIC_TOOL_TITLE_MAX_CHARS
+    ? trimmed
+    : trimmed.slice(0, DYNAMIC_TOOL_TITLE_MAX_CHARS);
+};
 
 const externalToolDescription = ({
   connectorDisplayName,

--- a/apps/api/src/mcp/knowledge-tools.ts
+++ b/apps/api/src/mcp/knowledge-tools.ts
@@ -607,7 +607,11 @@ const playbookDetailTextFieldSpecs = (
 
 export const KNOWLEDGE_TOOL_DEFINITIONS = [
   {
-    annotations: { readOnlyHint: true, openWorldHint: false },
+    annotations: {
+      title: "List clauses",
+      readOnlyHint: true,
+      openWorldHint: false,
+    },
     description:
       "List the clause library for this organization, or read one clause in " +
       "detail. Pass clause_id to get a clause's body, description, usage notes, " +
@@ -695,7 +699,11 @@ export const KNOWLEDGE_TOOL_DEFINITIONS = [
         },
       },
     },
-    annotations: { idempotentHint: false, openWorldHint: false },
+    annotations: {
+      title: "Save clause",
+      idempotentHint: false,
+      openWorldHint: false,
+    },
     access: "write",
     anonymized: { exposure: "excluded", reason: "write" },
     name: "save_clause",
@@ -703,6 +711,7 @@ export const KNOWLEDGE_TOOL_DEFINITIONS = [
   },
   {
     annotations: {
+      title: "Delete clause",
       destructiveHint: true,
       idempotentHint: true,
       openWorldHint: false,
@@ -724,7 +733,11 @@ export const KNOWLEDGE_TOOL_DEFINITIONS = [
     scope: "stella:knowledge_write",
   },
   {
-    annotations: { readOnlyHint: true, openWorldHint: false },
+    annotations: {
+      title: "List playbooks",
+      readOnlyHint: true,
+      openWorldHint: false,
+    },
     description:
       "List the review playbooks in this organization, or read one in detail. " +
       "Pass playbook_id to get a playbook's positions (the issues it reviews, " +
@@ -773,7 +786,11 @@ export const KNOWLEDGE_TOOL_DEFINITIONS = [
       },
       required: ["matter_id", "playbook_id"],
     },
-    annotations: { idempotentHint: false, openWorldHint: false },
+    annotations: {
+      title: "Run playbook",
+      idempotentHint: false,
+      openWorldHint: false,
+    },
     access: "write",
     anonymized: { exposure: "excluded", reason: "write" },
     name: "run_playbook",

--- a/apps/api/src/mcp/matter-tools.ts
+++ b/apps/api/src/mcp/matter-tools.ts
@@ -244,7 +244,11 @@ export const MATTER_TOOL_DEFINITIONS = [
         ),
       },
     },
-    annotations: { idempotentHint: false, openWorldHint: false },
+    annotations: {
+      title: "Save matter",
+      idempotentHint: false,
+      openWorldHint: false,
+    },
     access: "write",
     anonymized: { exposure: "excluded", reason: "write" },
     name: "save_matter",
@@ -252,6 +256,7 @@ export const MATTER_TOOL_DEFINITIONS = [
   },
   {
     annotations: {
+      title: "Delete matter",
       destructiveHint: true,
       idempotentHint: true,
       openWorldHint: false,
@@ -273,7 +278,11 @@ export const MATTER_TOOL_DEFINITIONS = [
     scope: "stella:matters_write",
   },
   {
-    annotations: { readOnlyHint: true, openWorldHint: false },
+    annotations: {
+      title: "List contacts",
+      readOnlyHint: true,
+      openWorldHint: false,
+    },
     description:
       "List or search the organization's internal contact directory. Returns " +
       "internal contact IDs accepted by read_contact, save_contact, and " +
@@ -328,7 +337,11 @@ export const MATTER_TOOL_DEFINITIONS = [
         notes: nullableStringProp("Free-text notes; pass null to clear"),
       },
     },
-    annotations: { idempotentHint: false, openWorldHint: false },
+    annotations: {
+      title: "Save contact",
+      idempotentHint: false,
+      openWorldHint: false,
+    },
     access: "write",
     anonymized: { exposure: "excluded", reason: "write" },
     name: "save_contact",
@@ -336,6 +349,7 @@ export const MATTER_TOOL_DEFINITIONS = [
   },
   {
     annotations: {
+      title: "Delete contact",
       destructiveHint: true,
       idempotentHint: true,
       openWorldHint: false,
@@ -358,7 +372,11 @@ export const MATTER_TOOL_DEFINITIONS = [
     scope: "stella:matters_write",
   },
   {
-    annotations: { readOnlyHint: true, openWorldHint: true },
+    annotations: {
+      title: "Look up business registry",
+      readOnlyHint: true,
+      openWorldHint: true,
+    },
     description:
       "Look up a company in a public business register (ARES, Brreg, " +
       "Companies House, EDGAR, GCIS, KRS, ORSR, PRH, recherche-entreprises, " +
@@ -388,7 +406,11 @@ export const MATTER_TOOL_DEFINITIONS = [
     scope: "stella:read",
   },
   {
-    annotations: { readOnlyHint: true, openWorldHint: false },
+    annotations: {
+      title: "List tasks",
+      readOnlyHint: true,
+      openWorldHint: false,
+    },
     description:
       "List tasks in a matter, or read one task in detail. Pass task_id to " +
       "get a single task's fields, assignees, and linked entities. Otherwise " +
@@ -469,7 +491,11 @@ export const MATTER_TOOL_DEFINITIONS = [
         unlink_link_id: stringProp("Entity-link ID to remove"),
       },
     },
-    annotations: { idempotentHint: false, openWorldHint: false },
+    annotations: {
+      title: "Save task",
+      idempotentHint: false,
+      openWorldHint: false,
+    },
     access: "write",
     anonymized: { exposure: "excluded", reason: "write" },
     name: "save_task",
@@ -501,7 +527,11 @@ export const MATTER_TOOL_DEFINITIONS = [
       },
       required: ["matter_id"],
     },
-    annotations: { idempotentHint: false, openWorldHint: false },
+    annotations: {
+      title: "Link contact to matter",
+      idempotentHint: false,
+      openWorldHint: false,
+    },
     access: "write",
     anonymized: { exposure: "excluded", reason: "write" },
     name: "link_matter_contact",

--- a/apps/api/src/mcp/registry-quality.test.ts
+++ b/apps/api/src/mcp/registry-quality.test.ts
@@ -73,13 +73,15 @@ const TOOL_DESCRIPTION_CHAR_CEILING = 810;
 // verb_noun style: lowercase words joined by single underscores.
 const TOOL_NAME_PATTERN = /^[a-z]+(?:_[a-z]+)*$/u;
 
-// Display titles: sentence case, no trailing period, short enough for a
-// client's tool list or consent prompt. The 40-char product cap sits under
-// the CLI trust boundary's 64-char wire cap (MAX_TOOL_TITLE_CHARS in
-// packages/cli/src/registry-trust.ts), so every title the registry can emit
-// is also one a fetched listing would accept.
+// Display titles: start with an uppercase letter, end without a period or
+// whitespace, and contain at least one lowercase letter (sentence case, not
+// shouting; the lowercase check lives in the test since a regex cannot say
+// "not fully uppercase" readably). Internal punctuation is allowed. The
+// 40-char product cap sits under the CLI trust boundary's 64-unit wire cap
+// (MAX_TOOL_TITLE_CHARS in packages/cli/src/registry-trust.ts), so every
+// title the registry can emit is also one a fetched listing would accept.
 const TOOL_TITLE_MAX_CHARS = 40;
-const TOOL_TITLE_PATTERN = /^[A-Z][^.]*[^.\s]$/u;
+const TOOL_TITLE_PATTERN = /^[A-Z].*[^.\s]$/u;
 
 describe.each([...SURFACES])(
   "MCP registry quality ($mode surface)",
@@ -124,6 +126,10 @@ describe.each([...SURFACES])(
         expect(title, `Tool ${tool.name} title "${title}"`).toMatch(
           TOOL_TITLE_PATTERN,
         );
+        expect(
+          title,
+          `Tool ${tool.name} title "${title}" is fully uppercase`,
+        ).not.toBe(title.toUpperCase());
         expect(
           title.length,
           `Tool ${tool.name} title is ${title.length} chars`,

--- a/apps/api/src/mcp/registry-quality.test.ts
+++ b/apps/api/src/mcp/registry-quality.test.ts
@@ -73,6 +73,14 @@ const TOOL_DESCRIPTION_CHAR_CEILING = 810;
 // verb_noun style: lowercase words joined by single underscores.
 const TOOL_NAME_PATTERN = /^[a-z]+(?:_[a-z]+)*$/u;
 
+// Display titles: sentence case, no trailing period, short enough for a
+// client's tool list or consent prompt. The 40-char product cap sits under
+// the CLI trust boundary's 64-char wire cap (MAX_TOOL_TITLE_CHARS in
+// packages/cli/src/registry-trust.ts), so every title the registry can emit
+// is also one a fetched listing would accept.
+const TOOL_TITLE_MAX_CHARS = 40;
+const TOOL_TITLE_PATTERN = /^[A-Z][^.]*[^.\s]$/u;
+
 describe.each([...SURFACES])(
   "MCP registry quality ($mode surface)",
   ({ mode, definitions }) => {
@@ -106,6 +114,26 @@ describe.each([...SURFACES])(
     test("tool names follow verb_noun naming", () => {
       for (const tool of definitions) {
         expect(tool.name).toMatch(TOOL_NAME_PATTERN);
+      }
+    });
+
+    test("tool titles are unique, sentence-case display names", () => {
+      const seen = new Map<string, string>();
+      for (const tool of definitions) {
+        const title = tool.annotations.title;
+        expect(title, `Tool ${tool.name} title "${title}"`).toMatch(
+          TOOL_TITLE_PATTERN,
+        );
+        expect(
+          title.length,
+          `Tool ${tool.name} title is ${title.length} chars`,
+        ).toBeLessThanOrEqual(TOOL_TITLE_MAX_CHARS);
+        const holder = seen.get(title);
+        expect(
+          holder,
+          `Tools ${holder} and ${tool.name} share the title "${title}"`,
+        ).toBeUndefined();
+        seen.set(title, tool.name);
       }
     });
 
@@ -281,10 +309,13 @@ describe("MCP registry annotation coherence", () => {
         source,
         `Anonymized tool ${tool.name} has no default-surface counterpart`,
       ).toBeDefined();
+      if (!source) {
+        continue;
+      }
       expect(
         tool.annotations,
         `Anonymized tool ${tool.name} annotations diverge from the default surface`,
-      ).toEqual(source?.annotations);
+      ).toEqual(source.annotations);
     }
   });
 });

--- a/apps/api/src/mcp/registry-quality.test.ts
+++ b/apps/api/src/mcp/registry-quality.test.ts
@@ -193,7 +193,7 @@ describe("MCP registry access coherence", () => {
     for (const tool of defaultTools) {
       if (tool.access === "write") {
         expect(
-          tool.annotations?.readOnlyHint,
+          tool.annotations.readOnlyHint,
           `Tool ${tool.name} is access: "write" but carries readOnlyHint`,
         ).not.toBe(true);
       }
@@ -202,7 +202,7 @@ describe("MCP registry access coherence", () => {
 
   test('destructiveHint tools are always access: "write"', () => {
     for (const tool of defaultTools) {
-      if (tool.annotations?.destructiveHint) {
+      if (tool.annotations.destructiveHint) {
         expect(
           tool.access,
           `Tool ${tool.name} carries destructiveHint but is not access: "write"`,
@@ -257,7 +257,7 @@ describe("MCP registry annotation coherence", () => {
   test("every tool declares openWorldHint explicitly (boolean)", () => {
     for (const tool of defaultTools) {
       expect(
-        typeof tool.annotations?.openWorldHint,
+        typeof tool.annotations.openWorldHint,
         `Tool ${tool.name} must declare annotations.openWorldHint explicitly`,
       ).toBe("boolean");
     }
@@ -269,7 +269,7 @@ describe("MCP registry annotation coherence", () => {
         continue;
       }
       expect(
-        typeof tool.annotations?.idempotentHint,
+        typeof tool.annotations.idempotentHint,
         `Tool ${tool.name} is access: "write" but does not declare annotations.idempotentHint`,
       ).toBe("boolean");
     }
@@ -281,7 +281,7 @@ describe("MCP registry annotation coherence", () => {
         continue;
       }
       expect(
-        tool.annotations?.idempotentHint,
+        tool.annotations.idempotentHint,
         `Tool ${tool.name} is access: "read"; idempotentHint is meaningless and must be omitted`,
       ).toBeUndefined();
     }
@@ -293,7 +293,7 @@ describe("MCP registry annotation coherence", () => {
         continue;
       }
       expect(
-        tool.annotations?.idempotentHint,
+        tool.annotations.idempotentHint,
         `Tool ${tool.name} is a delete_* tool and must be idempotentHint true`,
       ).toBe(true);
     }
@@ -424,7 +424,7 @@ describe("destructive write-tool naming convention", () => {
 
   test("every destructiveHint write tool is named delete_*", () => {
     const offenders = writeTools
-      .filter((tool) => tool.annotations?.destructiveHint === true)
+      .filter((tool) => tool.annotations.destructiveHint === true)
       .filter((tool) => !tool.name.startsWith("delete_"))
       .map((tool) => tool.name);
     expect(offenders).toEqual([]);
@@ -433,7 +433,7 @@ describe("destructive write-tool naming convention", () => {
   test("every delete_* write tool carries destructiveHint", () => {
     const offenders = writeTools
       .filter((tool) => tool.name.startsWith("delete_"))
-      .filter((tool) => tool.annotations?.destructiveHint !== true)
+      .filter((tool) => tool.annotations.destructiveHint !== true)
       .map((tool) => tool.name);
     expect(offenders).toEqual([]);
   });

--- a/apps/api/src/mcp/research-admin-tools.test.ts
+++ b/apps/api/src/mcp/research-admin-tools.test.ts
@@ -273,7 +273,7 @@ describe("manage_organization remove_member confirm gate", () => {
     // The remove_member gate is action-level inside the handler instead. (It
     // does carry the behavioural idempotent/open-world hints like every write
     // tool; only destructiveHint drives the central gate.)
-    expect(def?.annotations?.destructiveHint).not.toBe(true);
+    expect(def?.annotations.destructiveHint).not.toBe(true);
   });
 
   test("remove_member without confirm is refused with confirmation_required", async () => {

--- a/apps/api/src/mcp/research-admin-tools.ts
+++ b/apps/api/src/mcp/research-admin-tools.ts
@@ -76,7 +76,11 @@ const MANAGE_ORG_ACTIONS = [
 
 export const RESEARCH_ADMIN_TOOL_DEFINITIONS = [
   {
-    annotations: { readOnlyHint: true, openWorldHint: true },
+    annotations: {
+      title: "Search legislation",
+      readOnlyHint: true,
+      openWorldHint: true,
+    },
     description:
       "Search and read Spanish consolidated legislation from the BOE. In " +
       "search mode, pass query (free text) and/or filters (title, " +
@@ -149,7 +153,11 @@ export const RESEARCH_ADMIN_TOOL_DEFINITIONS = [
     scope: "stella:read",
   },
   {
-    annotations: { readOnlyHint: true, openWorldHint: false },
+    annotations: {
+      title: "List audit log",
+      readOnlyHint: true,
+      openWorldHint: false,
+    },
     description:
       "Read the organization's audit trail (compliance view). Returns audit " +
       "entries newest first, each with its action, resource type and id, actor " +
@@ -236,7 +244,11 @@ export const RESEARCH_ADMIN_TOOL_DEFINITIONS = [
       },
       required: ["action"],
     },
-    annotations: { idempotentHint: false, openWorldHint: false },
+    annotations: {
+      title: "Manage organization",
+      idempotentHint: false,
+      openWorldHint: false,
+    },
     access: "write",
     anonymized: { exposure: "excluded", reason: "write" },
     name: "manage_organization",

--- a/apps/api/src/mcp/stella-tools.ts
+++ b/apps/api/src/mcp/stella-tools.ts
@@ -447,7 +447,11 @@ const buildContactTextFieldSpecs = (
 
 export const STELLA_TOOL_DEFINITIONS = [
   {
-    annotations: { readOnlyHint: true, openWorldHint: false },
+    annotations: {
+      title: "List matters",
+      readOnlyHint: true,
+      openWorldHint: false,
+    },
     description:
       "List the matters you can access, or get one matter's overview. Omit " +
       "matter_id to list accessible matters (filter with status, page with " +
@@ -486,7 +490,11 @@ export const STELLA_TOOL_DEFINITIONS = [
     scope: "stella:read",
   },
   {
-    annotations: { readOnlyHint: true, openWorldHint: false },
+    annotations: {
+      title: "Search across matters",
+      readOnlyHint: true,
+      openWorldHint: false,
+    },
     description:
       "Search across all accessible matters. Use this when the user explicitly " +
       "asks to search outside a single matter or you do not yet know the right matter.",
@@ -516,7 +524,11 @@ export const STELLA_TOOL_DEFINITIONS = [
     scope: "stella:search",
   },
   {
-    annotations: { readOnlyHint: true, openWorldHint: false },
+    annotations: {
+      title: "Search case law",
+      readOnlyHint: true,
+      openWorldHint: false,
+    },
     description:
       "Search the shared case-law corpus. Supports free-text search plus " +
       "optional filters such as court, country, language, date range, and " +
@@ -562,7 +574,11 @@ export const STELLA_TOOL_DEFINITIONS = [
     scope: "stella:search",
   },
   {
-    annotations: { readOnlyHint: true, openWorldHint: false },
+    annotations: {
+      title: "Read content across matters",
+      readOnlyHint: true,
+      openWorldHint: false,
+    },
     description:
       "Read a document's content, found anywhere in your accessible matters. " +
       "DOCX files are converted to Markdown with structure preserved " +
@@ -591,7 +607,11 @@ export const STELLA_TOOL_DEFINITIONS = [
     scope: "stella:read",
   },
   {
-    annotations: { readOnlyHint: true, openWorldHint: false },
+    annotations: {
+      title: "Read case-law decision",
+      readOnlyHint: true,
+      openWorldHint: false,
+    },
     description:
       "Read a single case-law decision by its decision ID. Returns metadata, " +
       "plain text, citation links, and source URLs. Long decision text and " +
@@ -617,7 +637,11 @@ export const STELLA_TOOL_DEFINITIONS = [
     scope: "stella:read",
   },
   {
-    annotations: { readOnlyHint: true, openWorldHint: false },
+    annotations: {
+      title: "Read contact",
+      readOnlyHint: true,
+      openWorldHint: false,
+    },
     description:
       "Read a contact by ID. Use this after matter overview or entity metadata " +
       "surfaces a contact the user wants to inspect more closely.",
@@ -679,7 +703,11 @@ export const STELLA_TOOL_DEFINITIONS = [
     // updatedAt on every call even when the jurisdictions are unchanged, so a
     // repeat with identical args has an observable additional effect (a
     // duplicate audit entry) in this compliance context.
-    annotations: { idempotentHint: false, openWorldHint: false },
+    annotations: {
+      title: "Set practice jurisdictions",
+      idempotentHint: false,
+      openWorldHint: false,
+    },
     access: "write",
     anonymized: { exposure: "excluded", reason: "write" },
     name: "set_practice_jurisdictions",

--- a/apps/api/src/mcp/template-tools.ts
+++ b/apps/api/src/mcp/template-tools.ts
@@ -397,7 +397,11 @@ const buildTemplateDetailTextFieldSpecs = (
 
 export const TEMPLATE_TOOL_DEFINITIONS = [
   {
-    annotations: { readOnlyHint: true, openWorldHint: false },
+    annotations: {
+      title: "List templates",
+      readOnlyHint: true,
+      openWorldHint: false,
+    },
     description:
       "List the document templates in this organization (NDAs, powers of " +
       "attorney, leases), or describe one template's fillable fields. Omit " +
@@ -474,7 +478,11 @@ export const TEMPLATE_TOOL_DEFINITIONS = [
     // external interaction matter-tools.ts's company lookup declares open-
     // world for; the hint is static per tool, so it must cover that case even
     // though most fills touch no lookup field.
-    annotations: { idempotentHint: false, openWorldHint: true },
+    annotations: {
+      title: "Fill template",
+      idempotentHint: false,
+      openWorldHint: true,
+    },
     access: "write",
     anonymized: { exposure: "excluded", reason: "write" },
     name: "fill_template",
@@ -526,7 +534,11 @@ export const TEMPLATE_TOOL_DEFINITIONS = [
         "values",
       ],
     },
-    annotations: { idempotentHint: false, openWorldHint: true },
+    annotations: {
+      title: "Save filled template",
+      idempotentHint: false,
+      openWorldHint: true,
+    },
     access: "write",
     additionalScopes: ["stella:templates"],
     anonymized: { exposure: "excluded", reason: "write" },
@@ -561,7 +573,11 @@ export const TEMPLATE_TOOL_DEFINITIONS = [
         fields: fieldsOverlayProp,
       },
     },
-    annotations: { idempotentHint: false, openWorldHint: false },
+    annotations: {
+      title: "Save template",
+      idempotentHint: false,
+      openWorldHint: false,
+    },
     access: "write",
     anonymized: { exposure: "excluded", reason: "write" },
     name: "save_template",

--- a/apps/api/src/mcp/tool-types.ts
+++ b/apps/api/src/mcp/tool-types.ts
@@ -98,7 +98,15 @@ export type McpToolDefinition = {
    * be advertised or called with only one half of their consent contract.
    */
   additionalScopes?: readonly ToolScope[];
-  annotations?: McpTool["annotations"];
+  /**
+   * MCP client-hint annotations. Required, and `title` is required within it
+   * (no default), so a new tool cannot land without a human-readable display
+   * name; clients render `title` in tool listings and consent prompts where
+   * the `verb_noun` wire name would read poorly. The behavioural hints stay
+   * optional; the registry-quality suite enforces their coherence and the
+   * title style.
+   */
+  annotations: NonNullable<McpTool["annotations"]> & { title: string };
   anonymized: McpAnonymizedPolicy;
   description: string;
   /**

--- a/apps/api/src/mcp/tools.ts
+++ b/apps/api/src/mcp/tools.ts
@@ -133,7 +133,7 @@ export const handleMcpToolCall = async ({
   // approved the action. Runs before dispatch so the mutation never starts
   // without the confirmation.
   if (
-    staticTool.annotations?.destructiveHint === true &&
+    staticTool.annotations.destructiveHint === true &&
     args["confirm"] !== true
   ) {
     return structuredErrorResult({
@@ -154,7 +154,7 @@ export const handleMcpToolCall = async ({
 
   try {
     const executionContext =
-      staticTool.annotations?.destructiveHint === true
+      staticTool.annotations.destructiveHint === true
         ? bindApprovedMcpAuditContext(context)
         : context;
     // Handlers never see the mode: they return either a finished result or an

--- a/packages/cli/src/generated/registry-snapshot.json
+++ b/packages/cli/src/generated/registry-snapshot.json
@@ -24,6 +24,7 @@
       "required": ["query"]
     },
     "annotations": {
+      "title": "Search",
       "readOnlyHint": true,
       "openWorldHint": false
     }
@@ -52,6 +53,7 @@
       "required": ["id"]
     },
     "annotations": {
+      "title": "Fetch",
       "readOnlyHint": true,
       "openWorldHint": false
     }
@@ -91,6 +93,7 @@
       }
     },
     "annotations": {
+      "title": "List matters",
       "readOnlyHint": true,
       "openWorldHint": false
     }
@@ -126,6 +129,7 @@
       "required": ["query"]
     },
     "annotations": {
+      "title": "Search across matters",
       "readOnlyHint": true,
       "openWorldHint": false
     }
@@ -196,6 +200,7 @@
       "required": ["query"]
     },
     "annotations": {
+      "title": "Search case law",
       "readOnlyHint": true,
       "openWorldHint": false
     }
@@ -224,6 +229,7 @@
       "required": ["entity_id"]
     },
     "annotations": {
+      "title": "Read content across matters",
       "readOnlyHint": true,
       "openWorldHint": false
     }
@@ -252,6 +258,7 @@
       "required": ["decision_id"]
     },
     "annotations": {
+      "title": "Read case-law decision",
       "readOnlyHint": true,
       "openWorldHint": false
     }
@@ -274,6 +281,7 @@
       "required": ["contact_id"]
     },
     "annotations": {
+      "title": "Read contact",
       "readOnlyHint": true,
       "openWorldHint": false
     }
@@ -564,6 +572,7 @@
       "required": ["jurisdictions"]
     },
     "annotations": {
+      "title": "Set practice jurisdictions",
       "idempotentHint": false,
       "openWorldHint": false
     }
@@ -593,6 +602,7 @@
       }
     },
     "annotations": {
+      "title": "List templates",
       "readOnlyHint": true,
       "openWorldHint": false
     }
@@ -630,6 +640,7 @@
       "required": ["template_id", "values"]
     },
     "annotations": {
+      "title": "Fill template",
       "idempotentHint": false,
       "openWorldHint": true
     }
@@ -733,6 +744,7 @@
       ]
     },
     "annotations": {
+      "title": "Save filled template",
       "idempotentHint": false,
       "openWorldHint": true
     }
@@ -879,6 +891,7 @@
       }
     },
     "annotations": {
+      "title": "Save template",
       "idempotentHint": false,
       "openWorldHint": false
     }
@@ -922,6 +935,7 @@
       "required": ["matter_id"]
     },
     "annotations": {
+      "title": "List documents",
       "readOnlyHint": true,
       "openWorldHint": false
     }
@@ -961,6 +975,7 @@
       "required": ["entity_id"]
     },
     "annotations": {
+      "title": "Read document",
       "readOnlyHint": true,
       "openWorldHint": false
     }
@@ -1018,6 +1033,7 @@
       }
     },
     "annotations": {
+      "title": "Save document",
       "idempotentHint": false,
       "openWorldHint": false
     }
@@ -1048,6 +1064,7 @@
       "required": ["entity_id"]
     },
     "annotations": {
+      "title": "Delete document",
       "destructiveHint": true,
       "idempotentHint": true,
       "openWorldHint": false
@@ -1083,6 +1100,7 @@
       "required": ["matter_id"]
     },
     "annotations": {
+      "title": "List properties",
       "readOnlyHint": true,
       "openWorldHint": false
     }
@@ -1129,6 +1147,7 @@
       "required": ["entity_id", "property_id", "content"]
     },
     "annotations": {
+      "title": "Set field value",
       "idempotentHint": false,
       "openWorldHint": false
     }
@@ -1174,6 +1193,7 @@
       }
     },
     "annotations": {
+      "title": "Save matter",
       "idempotentHint": false,
       "openWorldHint": false
     }
@@ -1200,6 +1220,7 @@
       "required": ["matter_id"]
     },
     "annotations": {
+      "title": "Delete matter",
       "destructiveHint": true,
       "idempotentHint": true,
       "openWorldHint": false
@@ -1240,6 +1261,7 @@
       "additionalProperties": false
     },
     "annotations": {
+      "title": "List contacts",
       "readOnlyHint": true,
       "openWorldHint": false
     }
@@ -1290,6 +1312,7 @@
       }
     },
     "annotations": {
+      "title": "Save contact",
       "idempotentHint": false,
       "openWorldHint": false
     }
@@ -1316,6 +1339,7 @@
       "required": ["contact_id"]
     },
     "annotations": {
+      "title": "Delete contact",
       "destructiveHint": true,
       "idempotentHint": true,
       "openWorldHint": false
@@ -1357,6 +1381,7 @@
       "required": ["registry", "query"]
     },
     "annotations": {
+      "title": "Look up business registry",
       "readOnlyHint": true,
       "openWorldHint": true
     }
@@ -1410,6 +1435,7 @@
       }
     },
     "annotations": {
+      "title": "List tasks",
       "readOnlyHint": true,
       "openWorldHint": false
     }
@@ -1471,6 +1497,7 @@
       }
     },
     "annotations": {
+      "title": "Save task",
       "idempotentHint": false,
       "openWorldHint": false
     }
@@ -1516,6 +1543,7 @@
       "required": ["matter_id"]
     },
     "annotations": {
+      "title": "Link contact to matter",
       "idempotentHint": false,
       "openWorldHint": false
     }
@@ -1566,6 +1594,7 @@
       }
     },
     "annotations": {
+      "title": "List clauses",
       "readOnlyHint": true,
       "openWorldHint": false
     }
@@ -1686,6 +1715,7 @@
       }
     },
     "annotations": {
+      "title": "Save clause",
       "idempotentHint": false,
       "openWorldHint": false
     }
@@ -1712,6 +1742,7 @@
       "required": ["clause_id"]
     },
     "annotations": {
+      "title": "Delete clause",
       "destructiveHint": true,
       "idempotentHint": true,
       "openWorldHint": false
@@ -1747,6 +1778,7 @@
       }
     },
     "annotations": {
+      "title": "List playbooks",
       "readOnlyHint": true,
       "openWorldHint": false
     }
@@ -1773,6 +1805,7 @@
       "required": ["matter_id", "playbook_id"]
     },
     "annotations": {
+      "title": "Run playbook",
       "idempotentHint": false,
       "openWorldHint": false
     }
@@ -1834,6 +1867,7 @@
       }
     },
     "annotations": {
+      "title": "List time entries",
       "readOnlyHint": true,
       "openWorldHint": false
     }
@@ -1921,6 +1955,7 @@
       }
     },
     "annotations": {
+      "title": "Save time entry",
       "idempotentHint": false,
       "openWorldHint": false
     }
@@ -1947,6 +1982,7 @@
       "required": ["time_entry_id"]
     },
     "annotations": {
+      "title": "Delete time entry",
       "destructiveHint": true,
       "idempotentHint": true,
       "openWorldHint": false
@@ -1979,6 +2015,7 @@
       "required": ["matter_id", "user_id", "date"]
     },
     "annotations": {
+      "title": "Resolve billing rate",
       "readOnlyHint": true,
       "openWorldHint": false
     }
@@ -2017,6 +2054,7 @@
       }
     },
     "annotations": {
+      "title": "List invoices",
       "readOnlyHint": true,
       "openWorldHint": false
     }
@@ -2033,6 +2071,7 @@
       "properties": {}
     },
     "annotations": {
+      "title": "Get usage",
       "readOnlyHint": true,
       "openWorldHint": false
     }
@@ -2115,6 +2154,7 @@
       }
     },
     "annotations": {
+      "title": "Search legislation",
       "readOnlyHint": true,
       "openWorldHint": true
     }
@@ -2174,6 +2214,7 @@
       }
     },
     "annotations": {
+      "title": "List audit log",
       "readOnlyHint": true,
       "openWorldHint": false
     }
@@ -2254,6 +2295,7 @@
       "required": ["action"]
     },
     "annotations": {
+      "title": "Manage organization",
       "idempotentHint": false,
       "openWorldHint": false
     }
@@ -2292,6 +2334,7 @@
       "required": ["kind", "title", "body"]
     },
     "annotations": {
+      "title": "Send feedback",
       "idempotentHint": false,
       "openWorldHint": true
     }
@@ -2330,6 +2373,7 @@
       "additionalProperties": false
     },
     "annotations": {
+      "title": "List capabilities",
       "openWorldHint": false
     }
   },
@@ -2352,6 +2396,7 @@
       "additionalProperties": false
     },
     "annotations": {
+      "title": "Describe capability",
       "openWorldHint": false
     }
   },
@@ -2405,6 +2450,7 @@
       "additionalProperties": false
     },
     "annotations": {
+      "title": "Invoke capability",
       "idempotentHint": false,
       "openWorldHint": true
     }

--- a/packages/cli/src/registry-trust.test.ts
+++ b/packages/cli/src/registry-trust.test.ts
@@ -5,6 +5,7 @@ import {
   MAX_LISTING_BYTES,
   MAX_PROPS,
   MAX_SCHEMA_DEPTH,
+  MAX_TOOL_TITLE_CHARS,
   MAX_TOOLS,
   validateFetchedToolsList,
 } from "./registry-trust.js";
@@ -99,6 +100,26 @@ describe("validateFetchedToolsList: rule 2 (meta-schema)", () => {
   test("a non-boolean annotation hint is rejected", () => {
     const tool = validTool({ annotations: { readOnlyHint: "yes" } });
     expect(validateFetchedToolsList(body([tool])).ok).toBe(false);
+  });
+
+  test("a string title annotation is accepted and projected", () => {
+    const tool = validTool({
+      annotations: { title: "List matters", readOnlyHint: true },
+    });
+    const result = validateFetchedToolsList(body([tool]));
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.listings[0]?.annotations?.title).toBe("List matters");
+    }
+  });
+
+  test("a non-string or over-cap title annotation is rejected", () => {
+    const nonString = validTool({ annotations: { title: true } });
+    expect(validateFetchedToolsList(body([nonString])).ok).toBe(false);
+    const overCap = validTool({
+      annotations: { title: "x".repeat(MAX_TOOL_TITLE_CHARS + 1) },
+    });
+    expect(validateFetchedToolsList(body([overCap])).ok).toBe(false);
   });
 
   test("invalid schema regex patterns are rejected at the trust boundary", () => {

--- a/packages/cli/src/registry-trust.ts
+++ b/packages/cli/src/registry-trust.ts
@@ -38,7 +38,13 @@ export const MAX_PROPS = 100;
 /** Tool names must match this (spec S5.5 rule 2). */
 export const TOOL_NAME_PATTERN: RegExp = /^[a-z][a-z0-9_]{0,63}$/u;
 
-/** Longest display title a fetched listing may carry (spec S5.5 rule 2). */
+/**
+ * Longest display title a fetched listing may carry, in UTF-16 code units
+ * (spec S5.5 rule 2). Deliberately the same unit `String.length` measures and
+ * the server clamps by, and the stricter of the two possible readings: a
+ * bound in code points would accept up to twice as many units for
+ * astral-heavy strings.
+ */
 export const MAX_TOOL_TITLE_CHARS = 64;
 
 /** The only annotation keys a fetched listing may carry (spec S5.5 rule 2). */

--- a/packages/cli/src/registry-trust.ts
+++ b/packages/cli/src/registry-trust.ts
@@ -38,8 +38,12 @@ export const MAX_PROPS = 100;
 /** Tool names must match this (spec S5.5 rule 2). */
 export const TOOL_NAME_PATTERN: RegExp = /^[a-z][a-z0-9_]{0,63}$/u;
 
-/** The only annotation hints a fetched listing may carry (spec S5.5 rule 2). */
+/** Longest display title a fetched listing may carry (spec S5.5 rule 2). */
+export const MAX_TOOL_TITLE_CHARS = 64;
+
+/** The only annotation keys a fetched listing may carry (spec S5.5 rule 2). */
 const ALLOWED_ANNOTATION_KEYS: ReadonlySet<string> = new Set([
+  "title",
   "readOnlyHint",
   "destructiveHint",
   "idempotentHint",
@@ -268,7 +272,7 @@ const walkSchema = (schema: unknown, depth: number): string | undefined => {
   return undefined;
 };
 
-/** Validate the `annotations` field to the two known boolean hints (rule 2). */
+/** Validate the `annotations` field to the known keys (rule 2). */
 const annotationsViolation = (annotations: unknown): string | undefined => {
   if (annotations === undefined) {
     return undefined;
@@ -279,6 +283,15 @@ const annotationsViolation = (annotations: unknown): string | undefined => {
   for (const [key, value] of Object.entries(annotations)) {
     if (!ALLOWED_ANNOTATION_KEYS.has(key)) {
       return `annotations has an unknown key '${key}'`;
+    }
+    if (key === "title") {
+      if (typeof value !== "string") {
+        return "annotations.title must be a string";
+      }
+      if (value.length > MAX_TOOL_TITLE_CHARS) {
+        return `annotations.title longer than ${MAX_TOOL_TITLE_CHARS}`;
+      }
+      continue;
     }
     if (typeof value !== "boolean") {
       return `annotations.${key} must be a boolean`;
@@ -299,11 +312,15 @@ const projectListing = (
     return { name, description, inputSchema };
   }
   const annotations: {
+    title?: string;
     readOnlyHint?: boolean;
     destructiveHint?: boolean;
     idempotentHint?: boolean;
     openWorldHint?: boolean;
   } = {};
+  if (typeof rawAnnotations["title"] === "string") {
+    annotations.title = rawAnnotations["title"];
+  }
   if (typeof rawAnnotations["readOnlyHint"] === "boolean") {
     annotations.readOnlyHint = rawAnnotations["readOnlyHint"];
   }

--- a/packages/cli/src/route-types.ts
+++ b/packages/cli/src/route-types.ts
@@ -29,6 +29,7 @@ export type RegistryToolListing = {
   description: string;
   inputSchema: JsonSchema;
   annotations?: {
+    title?: string;
     readOnlyHint?: boolean;
     destructiveHint?: boolean;
     idempotentHint?: boolean;


### PR DESCRIPTION
Adds a human-readable `annotations.title` to every MCP tool and makes it structurally required.

- `McpToolDefinition.annotations` is now required, with a required `title`, so a tool cannot land without a display name; clients render titles in tool listings and consent prompts where the `verb_noun` wire name reads poorly.
- Registry-quality invariants enforce title style: sentence case, no trailing period, 40-char cap, unique per surface. Surface snapshots regenerated.
- Dynamically gated tools title themselves too: external connector tools as `<connector display name>: <upstream tool name>`, skill tools by the skill's name, both clamped to the 64-char wire cap.
- CLI parity: the fetched-registry trust boundary accepts `title` as a string annotation with the same 64-char cap (previously any unknown annotation key made a fetched listing fail closed, so already-deployed CLIs degrade to their baked route tree during rollout rather than breaking), the route-map listing type and capability-catalog exporter carry the title through, and the committed `registry-snapshot.json` is regenerated from the registry.
- New trust-boundary tests: title accepted and projected; non-string or over-cap titles rejected.

`tools/list` payload grows ~1.5k chars and stays well under the existing character ceilings; no budget changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clear, human-readable titles to available tools across billing, documents, templates, research, and other areas.
  * Tool titles now appear in CLI listings and registry snapshots, with support for fetched and external tools.
  * Preserved tool behaviour indicators, including read-only, destructive, and idempotency details.

* **Validation**
  * Added checks for unique, sentence-case titles with length limits and valid metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->