### PR TITLE
fix(api): allow the ingestion role to take the corpus checkpoint lock

### DIFF
--- a/apps/api/drizzle/20260802093000_case_law_ingestion_source_lock_grant/migration.sql
+++ b/apps/api/drizzle/20260802093000_case_law_ingestion_source_lock_grant/migration.sql
@@ -1,0 +1,12 @@
+SET lock_timeout = '1s';--> statement-breakpoint
+SET statement_timeout = '5s';--> statement-breakpoint
+
+-- The corpus generation checkpoint takes `LOCK TABLE case_law_decisions,
+-- case_law_sources IN SHARE MODE` to hold out writers while it captures the
+-- snapshot clock. PostgreSQL admits that lock mode only for a role holding
+-- table-level UPDATE, DELETE, TRUNCATE, or MAINTAIN; a column-scoped UPDATE
+-- does not satisfy the check, and case_law_sources is granted column-scoped
+-- UPDATE only, so the role cannot take the lock it needs.
+-- MAINTAIN is the narrowest privilege that admits the lock: it confers no
+-- whole-row write, so the column scope on this table is preserved.
+GRANT MAINTAIN ON TABLE "case_law_sources" TO stella_ingestion;--> statement-breakpoint

--- a/apps/api/src/handlers/case-law/corpus-index-query-guard.test.ts
+++ b/apps/api/src/handlers/case-law/corpus-index-query-guard.test.ts
@@ -1,4 +1,6 @@
 import { expect, test } from "bun:test";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import nodePath from "node:path";
 
 import {
   CASE_LAW_CORPUS_INDEX_BACKFILL_STATUSES,
@@ -29,6 +31,71 @@ const ingestionSourceLeaseMigration = new URL(
   "../../../drizzle/20260801120000_case_law_source_ingestion_lease/migration.sql",
   import.meta.url,
 );
+const DRIZZLE_DIR = nodePath.resolve(import.meta.dir, "../../../drizzle");
+const SHARE_LOCK_PATTERN = /LOCK TABLE (?<tables>[^`]*?) IN SHARE MODE/u;
+const DRIZZLE_TABLE_REFERENCE_PATTERN = /\$\{(?<identifier>\w+)\}/gu;
+const PG_TABLE_DECLARATION_PATTERN =
+  /export const (?<identifier>\w+) = (?:p\.)?pgTable\(\s*"(?<table>\w+)"/gu;
+const TABLE_GRANT_PATTERN =
+  /^GRANT (?<privileges>.+?) ON TABLE (?<tables>.+?) TO (?<roles>.+)$/iu;
+// PostgreSQL admits SHARE MODE only for a role holding one of these at table
+// level; a column-scoped grant does not satisfy the check.
+const LOCK_CONFERRING_PRIVILEGES = [
+  "UPDATE",
+  "DELETE",
+  "TRUNCATE",
+  "MAINTAIN",
+] as const;
+
+const migrationStatements = (): string[] =>
+  readdirSync(DRIZZLE_DIR, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => nodePath.join(DRIZZLE_DIR, entry.name, "migration.sql"))
+    .filter((file) => existsSync(file))
+    .flatMap((file) =>
+      readFileSync(file, "utf-8")
+        .split(/\r?\n/u)
+        .map((line) => {
+          const commentStart = line.indexOf("--");
+          return commentStart === -1 ? line : line.slice(0, commentStart);
+        })
+        .join("\n")
+        .split(";")
+        .map((statement) => statement.replace(/\s+/gu, " ").trim())
+        .filter((statement) => statement.length > 0),
+    );
+
+const identifierList = (list: string): string[] =>
+  list.split(",").map((entry) => entry.trim().replaceAll('"', ""));
+
+const grantsIngestionLockPrivilege = (
+  statement: string,
+  table: string,
+): boolean => {
+  const grant = TABLE_GRANT_PATTERN.exec(statement);
+  if (!grant?.groups) {
+    return false;
+  }
+
+  const { privileges, roles, tables } = grant.groups;
+  if (
+    privileges === undefined ||
+    roles === undefined ||
+    tables === undefined ||
+    // A parenthesised column list marks the grant column-scoped.
+    privileges.includes("(") ||
+    !identifierList(roles).includes("stella_ingestion") ||
+    !identifierList(tables).includes(table)
+  ) {
+    return false;
+  }
+
+  const granted = identifierList(privileges.toUpperCase());
+  return LOCK_CONFERRING_PRIVILEGES.some((privilege) =>
+    granted.includes(privilege),
+  );
+};
+
 const GENERATION_STATE_TABLES = [
   "case_law_corpus_index_backfills",
   "case_law_corpus_index_source_reconciliations",
@@ -319,6 +386,39 @@ test("ordered source progress remains inside the ingestion role boundary", async
   );
   expect(leaseSource).toContain('ON TABLE "case_law_sources"');
   expect(leaseSource).toContain("TO stella_ingestion");
+});
+
+test("the ingestion role can take every lock the corpus checkpoint holds", async () => {
+  const [source, schemaSource] = await Promise.all([
+    Bun.file(caseLawCorpusIndexSource).text(),
+    Bun.file(caseLawSchemaSource).text(),
+  ]);
+
+  const sqlTableByIdentifier = new Map(
+    [...schemaSource.matchAll(PG_TABLE_DECLARATION_PATTERN)].map((match) => [
+      match.groups?.["identifier"],
+      match.groups?.["table"],
+    ]),
+  );
+  const lockTargets = SHARE_LOCK_PATTERN.exec(source)?.groups?.["tables"] ?? "";
+  const lockedTables = [
+    ...lockTargets.matchAll(DRIZZLE_TABLE_REFERENCE_PATTERN),
+  ].map((match) => sqlTableByIdentifier.get(match.groups?.["identifier"]));
+
+  // Non-vacuity: the lock must still be found and resolvable to table names.
+  expect(lockedTables).toContain("case_law_decisions");
+  expect(lockedTables).toContain("case_law_sources");
+
+  const statements = migrationStatements();
+  for (const table of lockedTables) {
+    expect(table).toBeDefined();
+    expect({
+      table,
+      lockable: statements.some((statement) =>
+        grantsIngestionLockPrivilege(statement, table ?? ""),
+      ),
+    }).toEqual({ table, lockable: true });
+  }
 });
 
 test("every case-law corpus search boundary uses generation projection state", async () => {

--- a/apps/api/src/handlers/case-law/corpus-index-query-guard.test.ts
+++ b/apps/api/src/handlers/case-law/corpus-index-query-guard.test.ts
@@ -36,8 +36,11 @@ const SHARE_LOCK_PATTERN = /LOCK TABLE (?<tables>[^`]*?) IN SHARE MODE/u;
 const DRIZZLE_TABLE_REFERENCE_PATTERN = /\$\{(?<identifier>\w+)\}/gu;
 const PG_TABLE_DECLARATION_PATTERN =
   /export const (?<identifier>\w+) = (?:p\.)?pgTable\(\s*"(?<table>\w+)"/gu;
-const TABLE_GRANT_PATTERN =
-  /^GRANT (?<privileges>.+?) ON TABLE (?<tables>.+?) TO (?<roles>.+)$/iu;
+const TABLE_PRIVILEGE_PATTERN =
+  /^(?<action>GRANT|REVOKE) (?<privileges>.+?) ON TABLE (?<tables>.+?) (?:TO|FROM) (?<roles>.+)$/iu;
+// Dropping a table takes its grants with it, so a recreated table starts bare.
+const DROP_TABLE_PATTERN =
+  /^DROP TABLE (?:IF EXISTS )?(?<tables>.+?)(?: CASCADE| RESTRICT)?$/iu;
 // PostgreSQL admits SHARE MODE only for a role holding one of these at table
 // level; a column-scoped grant does not satisfy the check.
 const LOCK_CONFERRING_PRIVILEGES = [
@@ -47,10 +50,14 @@ const LOCK_CONFERRING_PRIVILEGES = [
   "MAINTAIN",
 ] as const;
 
+// Timestamp-prefixed directory names, so lexical order is apply order. The
+// replay below depends on it.
 const migrationStatements = (): string[] =>
   readdirSync(DRIZZLE_DIR, { withFileTypes: true })
     .filter((entry) => entry.isDirectory())
-    .map((entry) => nodePath.join(DRIZZLE_DIR, entry.name, "migration.sql"))
+    .map((entry) => entry.name)
+    .sort()
+    .map((name) => nodePath.join(DRIZZLE_DIR, name, "migration.sql"))
     .filter((file) => existsSync(file))
     .flatMap((file) =>
       readFileSync(file, "utf-8")
@@ -68,32 +75,54 @@ const migrationStatements = (): string[] =>
 const identifierList = (list: string): string[] =>
   list.split(",").map((entry) => entry.trim().replaceAll('"', ""));
 
-const grantsIngestionLockPrivilege = (
-  statement: string,
-  table: string,
-): boolean => {
-  const grant = TABLE_GRANT_PATTERN.exec(statement);
-  if (!grant?.groups) {
-    return false;
+const lockPrivilegesNamed = (privileges: string): string[] => {
+  const upper = privileges.toUpperCase();
+  if (upper === "ALL" || upper === "ALL PRIVILEGES") {
+    return [...LOCK_CONFERRING_PRIVILEGES];
   }
 
-  const { privileges, roles, tables } = grant.groups;
-  if (
-    privileges === undefined ||
-    roles === undefined ||
-    tables === undefined ||
-    // A parenthesised column list marks the grant column-scoped.
-    privileges.includes("(") ||
-    !identifierList(roles).includes("stella_ingestion") ||
-    !identifierList(tables).includes(table)
-  ) {
-    return false;
-  }
-
-  const granted = identifierList(privileges.toUpperCase());
-  return LOCK_CONFERRING_PRIVILEGES.some((privilege) =>
-    granted.includes(privilege),
+  const named = identifierList(upper);
+  return LOCK_CONFERRING_PRIVILEGES.filter((privilege) =>
+    named.includes(privilege),
   );
+};
+
+// Replay every table-level GRANT/REVOKE touching the role in apply order: an
+// earlier grant that a later migration revokes must not count as held.
+const ingestionLockPrivileges = (table: string): string[] => {
+  const held = new Set<string>();
+  for (const statement of migrationStatements()) {
+    const dropped = DROP_TABLE_PATTERN.exec(statement)?.groups?.["tables"];
+    if (dropped !== undefined && identifierList(dropped).includes(table)) {
+      held.clear();
+      continue;
+    }
+
+    const { action, privileges, roles, tables } =
+      TABLE_PRIVILEGE_PATTERN.exec(statement)?.groups ?? {};
+    if (
+      action === undefined ||
+      privileges === undefined ||
+      roles === undefined ||
+      tables === undefined ||
+      // A parenthesised column list marks the change column-scoped.
+      privileges.includes("(") ||
+      !identifierList(roles).includes("stella_ingestion") ||
+      !identifierList(tables).includes(table)
+    ) {
+      continue;
+    }
+
+    for (const privilege of lockPrivilegesNamed(privileges)) {
+      if (action.toUpperCase() === "GRANT") {
+        held.add(privilege);
+        continue;
+      }
+      held.delete(privilege);
+    }
+  }
+
+  return [...held];
 };
 
 const GENERATION_STATE_TABLES = [
@@ -409,14 +438,11 @@ test("the ingestion role can take every lock the corpus checkpoint holds", async
   expect(lockedTables).toContain("case_law_decisions");
   expect(lockedTables).toContain("case_law_sources");
 
-  const statements = migrationStatements();
   for (const table of lockedTables) {
     expect(table).toBeDefined();
     expect({
       table,
-      lockable: statements.some((statement) =>
-        grantsIngestionLockPrivilege(statement, table ?? ""),
-      ),
+      lockable: ingestionLockPrivileges(table ?? "").length > 0,
     }).toEqual({ table, lockable: true });
   }
 });


### PR DESCRIPTION
## Proposed change

The corpus generation checkpoint fences concurrent writers before it captures its snapshot clock:

```ts
// apps/api/src/handlers/case-law/corpus-index.ts
await tx.execute(
  sql`LOCK TABLE ${caseLawDecisions}, ${caseLawSources} IN SHARE MODE`,
);
```

That statement runs as `stella_ingestion`. PostgreSQL admits `SHARE MODE` only for a role holding table-level `UPDATE`, `DELETE`, `TRUNCATE`, or `MAINTAIN` on **every** table named in the lock, and the role's grants across the two tables are asymmetric:

| table | grants to `stella_ingestion` | lock admitted |
| --- | --- | --- |
| `case_law_decisions` | table-level `INSERT, UPDATE, DELETE` (`20260516000000`) | yes |
| `case_law_sources` | `SELECT`, plus column-scoped `UPDATE` on the cursor, progress and lease columns (`20260516000000`, `20260731210000`, `20260801120000`) | no |

A column-scoped `UPDATE` satisfies `has_column_privilege` but not the table-level check `LOCK TABLE` performs. The checkpoint is therefore refused on the second table in its own lock list, with `permission denied for table case_law_sources`, before it can insert the checkpoint row. The lock has named `case_law_sources` since #1518 introduced the checkpoint; the column scoping predates it.

### Fix

`GRANT MAINTAIN ON TABLE "case_law_sources" TO stella_ingestion`. `MAINTAIN` is the narrowest privilege that admits the lock and confers no whole-row write, so the deliberate column scoping on this table is preserved.

Checked against PostgreSQL 18 with the role's grant shape reproduced:

- column-scoped grants only: `LOCK TABLE ... IN SHARE MODE` is refused with `permission denied for table case_law_sources`
- with `MAINTAIN` added: the lock is taken, a whole-row `UPDATE case_law_sources` is still denied, and the column-scoped updates still succeed

### Regression guard

Rather than pinning this one table, `corpus-index-query-guard.test.ts` now enforces the invariant: it resolves every table named in the checkpoint's `SHARE` lock back through the schema's `pgTable` declarations, then asserts each one has a lock-conferring **table-level** grant to `stella_ingestion` somewhere in the migration set, ignoring column-scoped grants. Adding a table to the lock list without the matching grant fails the suite; removing this migration reproduces the failure on `case_law_sources`.

## Checklist

- [x] **BUILD ASSURANCE** | Code builds correctly and without any errors or warnings.
- [x] **TESTING** | Changes tested, including in different conditions (dark mode, language, narrow screen, etc).
- [ ] DARK MODE SUPPORT | Not applicable: no user-facing surface.
- [ ] ISSUE LINKED | No tracking issue.
- [ ] SCREENSHOT INCLUDED | Not applicable: no user-facing surface.


---
_Generated by [Claude Code](https://claude.ai/code/session_01V5G7HRQwjjMjGH1987iej5)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of case law ingestion by ensuring the required database access is available for source maintenance.
  - Added safeguards to verify that corpus indexing can access all required tables.

- **Tests**
  - Expanded automated checks to validate database permissions and table access during corpus indexing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->