### PR TITLE
feat(case-law): benchmark every source against its own published total

### DIFF
--- a/apps/api/src/handlers/case-law/ingestion/adapters/at-courts.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/at-courts.ts
@@ -435,7 +435,8 @@ export const atCourtsAdapter: SourceAdapter = {
         return null;
       }
       const raw = json.OgdSearchResult?.OgdDocumentResults?.Hits?.["#text"];
-      const parsed = raw === undefined ? Number.NaN : Number.parseInt(raw, 10);
+      const parsed =
+        typeof raw === "string" ? Number.parseInt(raw, 10) : Number.NaN;
       return Number.isNaN(parsed) || parsed <= 0 ? null : parsed;
     } catch {
       return null;

--- a/apps/api/src/handlers/case-law/ingestion/adapters/at-courts.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/at-courts.ts
@@ -407,6 +407,41 @@ export const atCourtsAdapter: SourceAdapter = {
   minRequestIntervalMs: 1000,
   pageTimeoutMs: 220_000,
 
+  /**
+   * The search envelope carries the total hit count on every page, so the
+   * source's own total is one minimal request with the same query the crawl
+   * uses — the benchmark then measures exactly the universe the crawl sees.
+   */
+  async getTotalCount(signal) {
+    try {
+      const response = await fetchWithTimeout(
+        `${API_URL}?${new URLSearchParams({
+          Seitennummer: "1",
+          Seitengroesse: String(PAGE_SIZE),
+          Sortierung: "Aenderungsdatum",
+          Aufsteigend: "false",
+        }).toString()}`,
+        {
+          signal,
+          headers: { Accept: "application/json" },
+          timeoutMs: ADAPTER_TIMEOUT.REQUEST,
+        },
+      );
+      if (!response.ok) {
+        return null;
+      }
+      const json: unknown = await response.json();
+      if (!isRisApiResponse(json)) {
+        return null;
+      }
+      const raw = json.OgdSearchResult?.OgdDocumentResults?.Hits?.["#text"];
+      const parsed = raw === undefined ? Number.NaN : Number.parseInt(raw, 10);
+      return Number.isNaN(parsed) || parsed <= 0 ? null : parsed;
+    } catch {
+      return null;
+    }
+  },
+
   fetchPage: createPagePaginatedFetch<RisApiResponse>({
     adapterKey: ADAPTER_KEYS.AT_COURTS,
     pageSize: PAGE_SIZE,

--- a/apps/api/src/handlers/case-law/ingestion/adapters/cz-nss.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/cz-nss.ts
@@ -849,7 +849,7 @@ export const czNssAdapter: SourceAdapter = {
       );
       formData.set(
         "vyhledavaciSekce[1].vyhledavaciPodminka[0].vyhledavaciPodminkaHodnota[0].HodnotaDatumACasDo",
-        "31.12.2030",
+        `31.12.${new Date().getFullYear() + 1}`,
       );
 
       const response = await fetchWithTimeout(`${BASE_URL}/Home/Index`, {

--- a/apps/api/src/handlers/case-law/ingestion/adapters/cz-nss.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/cz-nss.ts
@@ -824,16 +824,33 @@ export const czNssAdapter: SourceAdapter = {
   pageTimeoutMs: 120_000,
   maxSyncPages: 20,
 
+  /**
+   * The portal aggregates several courts, and its search filters cannot be
+   * scoped to one of them without executing the site's own scripts — so the
+   * count, like the crawl, covers the portal's whole collection rather than
+   * this court alone. The benchmark still matches what the crawl sees.
+   */
   async getTotalCount(signal) {
     try {
       const session = await getSession(signal);
 
-      // Submit empty search (no date filters = all results)
+      // A search with no criterion silently no-ops (the page re-renders
+      // unsubmitted), so an all-inclusive decision-date range supplies the
+      // one criterion without excluding anything. Counting the full range
+      // is slow on the source's side; the longer timeout is deliberate.
       const formData = new URLSearchParams();
       for (const [name, value] of session.formFields) {
         formData.set(name, value);
       }
       formData.set("__RequestVerificationToken", session.token);
+      formData.set(
+        "vyhledavaciSekce[1].vyhledavaciPodminka[0].vyhledavaciPodminkaHodnota[0].HodnotaDatumACasOd",
+        "01.01.1990",
+      );
+      formData.set(
+        "vyhledavaciSekce[1].vyhledavaciPodminka[0].vyhledavaciPodminkaHodnota[0].HodnotaDatumACasDo",
+        "31.12.2030",
+      );
 
       const response = await fetchWithTimeout(`${BASE_URL}/Home/Index`, {
         method: "POST",
@@ -846,7 +863,7 @@ export const czNssAdapter: SourceAdapter = {
         },
         body: formData.toString(),
         redirect: "follow",
-        timeoutMs: ADAPTER_TIMEOUT.REQUEST,
+        timeoutMs: 90_000,
       });
 
       if (!response.ok) {

--- a/apps/api/src/handlers/case-law/ingestion/adapters/cz-regional.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/cz-regional.ts
@@ -654,11 +654,55 @@ export const czRegionalAdapter: SourceAdapter = {
   // tight for large pages with slow upstream responses.
   pageTimeoutMs: 100_000,
 
-  async getTotalCount(_signal) {
-    // The rozhodnuti.justice.cz API is date-based with no
-    // single total count endpoint. There is no efficient way
-    // to get the total without crawling all dates.
-    return await Promise.resolve(null);
+  /**
+   * The year endpoint (`/opendata/{year}`) returns exact per-month
+   * publication counts, so the source's total is the sum over the years it
+   * has published — from October 2020, when the open-data feed began. A
+   * failed year returns null rather than a partial sum, because an
+   * undercount would read as a coverage gap that does not exist.
+   */
+  async getTotalCount(signal) {
+    try {
+      const FIRST_PUBLICATION_YEAR = 2020;
+      const currentYear = new Date().getFullYear();
+      const years = Array.from(
+        { length: currentYear - FIRST_PUBLICATION_YEAR + 1 },
+        (_, i) => FIRST_PUBLICATION_YEAR + i,
+      );
+      const perYear = await Promise.all(
+        years.map(async (year) => {
+          const response = await fetchWithTimeout(
+            `${BASE_URL}/opendata/${year}`,
+            { signal, timeoutMs: ADAPTER_TIMEOUT.REQUEST },
+          );
+          if (!response.ok) {
+            return null;
+          }
+          const json: unknown = await response.json();
+          if (!Array.isArray(json)) {
+            return null;
+          }
+          let sum = 0;
+          for (const month of json) {
+            if (!isRecord(month) || typeof month["pocet"] !== "number") {
+              return null;
+            }
+            sum += month["pocet"];
+          }
+          return sum;
+        }),
+      );
+      let total = 0;
+      for (const sum of perYear) {
+        if (sum === null) {
+          return null;
+        }
+        total += sum;
+      }
+      return total > 0 ? total : null;
+    } catch {
+      return null;
+    }
   },
 
   async fetchPage(cursor, _config, signal) {

--- a/apps/api/src/handlers/case-law/ingestion/adapters/cz-us.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/cz-us.ts
@@ -402,7 +402,7 @@ export const czUsAdapter: SourceAdapter = {
         ctl00$MainContent$usneseni: "on",
         ctl00$MainContent$stanoviska_plena: "on",
         ctl00$MainContent$decidedFrom: "1.1.1900",
-        ctl00$MainContent$decidedTo: "31.12.2030",
+        ["ctl00$MainContent$decidedTo"]: `31.12.${new Date().getFullYear() + 1}`,
         ctl00$MainContent$but_search: "Vyhledat",
       });
       const submit = await fetchWithTimeout(searchUrl, {

--- a/apps/api/src/handlers/case-law/ingestion/adapters/cz-us.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/cz-us.ts
@@ -360,11 +360,85 @@ export const czUsAdapter: SourceAdapter = {
   pageTimeoutMs: 120_000,
   maxSyncPages: 20,
 
-  // NALUS requires a POST with ASP.NET ViewState to return search results.
-  // A GET to the search page returns the form but no count; full historical
-  // ÚS ingestion should add a POST-based total count.
-  async getTotalCount(_signal) {
-    return await Promise.resolve(null);
+  /**
+   * NALUS reports its total only on a search result page, and a search
+   * demands a session: the form's ViewState fields and cookies from a GET,
+   * a POST carrying them plus at least one criterion (an all-inclusive date
+   * range excludes nothing), then the redirected results page, which states
+   * "z celkem N".
+   */
+  async getTotalCount(signal) {
+    try {
+      const searchUrl = "https://nalus.usoud.cz/Search/Search.aspx";
+      const first = await fetchWithTimeout(searchUrl, {
+        signal,
+        timeoutMs: ADAPTER_TIMEOUT.REQUEST,
+      });
+      if (!first.ok) {
+        return null;
+      }
+      const cookies = first.headers
+        .getSetCookie()
+        .map((cookie) => cookie.split(";")[0])
+        .join("; ");
+      const html = await first.text();
+      const hidden = (name: string): string | null => {
+        const match = new RegExp(`id="${name}" value="([^"]*)"`, "u").exec(
+          html,
+        );
+        return match?.[1] ?? null;
+      };
+      const viewState = hidden("__VIEWSTATE");
+      const generator = hidden("__VIEWSTATEGENERATOR");
+      const validation = hidden("__EVENTVALIDATION");
+      if (viewState === null || validation === null) {
+        return null;
+      }
+      const form = new URLSearchParams({
+        __VIEWSTATE: viewState,
+        ...(generator === null ? {} : { __VIEWSTATEGENERATOR: generator }),
+        __EVENTVALIDATION: validation,
+        ctl00$MainContent$nalezy: "on",
+        ctl00$MainContent$usneseni: "on",
+        ctl00$MainContent$stanoviska_plena: "on",
+        ctl00$MainContent$decidedFrom: "1.1.1900",
+        ctl00$MainContent$decidedTo: "31.12.2030",
+        ctl00$MainContent$but_search: "Vyhledat",
+      });
+      const submit = await fetchWithTimeout(searchUrl, {
+        method: "POST",
+        signal,
+        redirect: "manual",
+        timeoutMs: ADAPTER_TIMEOUT.REQUEST,
+        headers: {
+          "Content-Type": "application/x-www-form-urlencoded",
+          Cookie: cookies,
+        },
+        body: form.toString(),
+      });
+      if (submit.status !== 302 && !submit.ok) {
+        return null;
+      }
+      const results = await fetchWithTimeout(
+        "https://nalus.usoud.cz/Search/Results.aspx",
+        {
+          signal,
+          timeoutMs: ADAPTER_TIMEOUT.REQUEST,
+          headers: { Cookie: cookies },
+        },
+      );
+      if (!results.ok) {
+        return null;
+      }
+      const total = /z celkem (?<n>\d+)/u.exec(await results.text())?.groups?.[
+        "n"
+      ];
+      const parsed =
+        total === undefined ? Number.NaN : Number.parseInt(total, 10);
+      return Number.isNaN(parsed) || parsed <= 0 ? null : parsed;
+    } catch {
+      return null;
+    }
   },
 
   async fetchPage(cursor, _config, signal) {

--- a/apps/api/src/handlers/case-law/ingestion/adapters/cz-us.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/cz-us.ts
@@ -402,7 +402,7 @@ export const czUsAdapter: SourceAdapter = {
         ctl00$MainContent$usneseni: "on",
         ctl00$MainContent$stanoviska_plena: "on",
         ctl00$MainContent$decidedFrom: "1.1.1900",
-        ["ctl00$MainContent$decidedTo"]: `31.12.${new Date().getFullYear() + 1}`,
+        ctl00$MainContent$decidedTo: `31.12.${new Date().getFullYear() + 1}`,
         ctl00$MainContent$but_search: "Vyhledat",
       });
       const submit = await fetchWithTimeout(searchUrl, {

--- a/apps/api/src/handlers/case-law/ingestion/adapters/eu-ecj.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/eu-ecj.ts
@@ -632,6 +632,70 @@ export const euEcjAdapter: SourceAdapter = {
   minRequestIntervalMs: 1000,
   pageTimeoutMs: ECJ_PAGE_TIMEOUT,
 
+  /**
+   * Counts (work, language) pairs under the same type and manifestation
+   * filters the page query uses, so the total is the exact universe this
+   * crawl can ever ingest — not Cellar's whole case-law class, which
+   * includes works with no XHTML manifestation that a crawl would never
+   * store.
+   */
+  async getTotalCount(signal) {
+    try {
+      const query = `
+PREFIX cdm: <http://publications.europa.eu/ontology/cdm#>
+SELECT (COUNT(*) AS ?n)
+WHERE {
+  SELECT DISTINCT ?doc ?language
+  WHERE {
+    ?doc cdm:case-law_ecli ?ecli .
+    ?doc a ?type .
+    ?expression cdm:expression_belongs_to_work ?doc .
+    ?expression cdm:expression_uses_language ?language .
+    ?manifestation cdm:manifestation_manifests_expression ?expression .
+    ?manifestation cdm:manifestation_type ?manifestationType .
+    FILTER(?type IN (
+      cdm:judgement,
+      cdm:order,
+      cdm:order_cjeu,
+      cdm:opinion_advocate_general,
+      cdm:opinion_advocate-general
+    ))
+    FILTER(STR(?manifestationType) = "xhtml")
+  }
+}`.trim();
+      const response = await fetchWithTimeout(SPARQL_URL, {
+        method: "POST",
+        signal,
+        timeoutMs: 60_000,
+        headers: {
+          Accept: "application/sparql-results+json",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "User-Agent": INGESTION_USER_AGENT,
+        },
+        body: new URLSearchParams({ query }).toString(),
+      });
+      if (!response.ok) {
+        return null;
+      }
+      const json: unknown = await response.json();
+      if (!isRecord(json)) {
+        return null;
+      }
+      const results = json["results"];
+      if (!isRecord(results) || !Array.isArray(results["bindings"])) {
+        return null;
+      }
+      const binding: unknown = results["bindings"].at(0);
+      if (!isRecord(binding) || !isRecord(binding["n"])) {
+        return null;
+      }
+      const parsed = Number.parseInt(String(binding["n"]["value"]), 10);
+      return Number.isNaN(parsed) || parsed <= 0 ? null : parsed;
+    } catch {
+      return null;
+    }
+  },
+
   async fetchPage(cursor, _config, signal) {
     return await Result.tryPromise({
       try: async () => {

--- a/apps/api/src/handlers/case-law/ingestion/adapters/sk-us.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/sk-us.ts
@@ -421,6 +421,13 @@ export const skUsAdapter: SourceAdapter = {
   pageTimeoutMs: 120_000,
   maxSyncPages: 10,
 
+  /**
+   * Known blind spot: the court's decision search runs on a portal widget
+   * whose search endpoint answers scripted requests with an empty 204 even
+   * when replayed with browser-identical headers and session state, so the
+   * total it shows in a browser cannot be read from here. Coverage for this
+   * source is benchmarked only by what the crawl itself reports.
+   */
   async getTotalCount(_signal) {
     return await Promise.resolve(null);
   },

--- a/apps/api/src/scripts/adapter-health.ts
+++ b/apps/api/src/scripts/adapter-health.ts
@@ -146,7 +146,11 @@ const COVERAGE_THRESHOLD_PCT = 80;
 const STUCK_PREFIX = "Stuck:" as const;
 
 /** Timeout for each remote total fetch (ms). */
-const SOURCE_TOTAL_TIMEOUT = 10_000;
+// The slowest total is the NSS full-range count, which the source itself
+// takes tens of seconds to produce; the budget must exceed the adapter's
+// own request timeout or the probe aborts first and reports a false blind
+// spot.
+const SOURCE_TOTAL_TIMEOUT = 120_000;
 
 // ── Helpers ─────────────────────────────────────────────
 


### PR DESCRIPTION
Every adapter now either reports the source's own total for the daily coverage benchmark, or documents exactly why it cannot. Verified live against each source:

| adapter | total | how |
|---|---|---|
| cz-regional | **595,310** (exact) | `/api/opendata/{year}` returns exact per-month counts; summed 2020→current. The old stub's comment claimed no such endpoint exists — it does. |
| cz-us | **103,821** | NALUS reports totals only on a search result page; the session flow (ViewState fields + cookies, one all-inclusive date criterion, redirected results page) reads "z celkem N". |
| eu-ecj | **557,177** | SPARQL count of distinct (work, language) pairs under the same type and XHTML-manifestation filters the page query uses — the exact universe the crawl can ingest, not Cellar's broader case-law class. |
| at-courts | **138,445** | The search envelope carries `Hits` on every page; one minimal request with the crawl's own query. |
| cz-nss | fixed | Its empty-search POST silently no-ops on the source's side; an all-inclusive date range supplies the one criterion the form requires. The portal aggregates several courts and cannot be scoped without executing its scripts, so the count covers the portal's collection — which is also what the crawl walks. |
| cz-ns | unchanged | Already correct: the view count (164,227) matches the view the crawl pages through. |
| sk-us | blind spot documented | The portal widget's search endpoint answers scripted requests with an empty 204 even under browser-identical replay; the doc comment records it instead of dead code. |

Coverage this reveals immediately: cz-regional 92.7%, cz-ns 95.3%, cz-us **69.3%** (~32k gap at the constitutional court), eu-ecj **2.6%** of ingestable work-language pairs (the planned historical re-crawl).