### PR TITLE
fix(case-law): hold the cursor when a new decision's raw upload fails

### DIFF
--- a/apps/api/src/handlers/case-law/ingestion/pipeline.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/pipeline.test.ts
@@ -1,5 +1,5 @@
 import { Result } from "better-result";
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, mock, test } from "bun:test";
 
 import type { Transaction } from "@/api/db/root";
 import type { ScopedDb } from "@/api/db/safe-db";
@@ -538,5 +538,57 @@ describe("processDecision — corpus storage off", () => {
       astS3Key: null,
       contentHash: null,
     });
+  });
+});
+
+describe("processDecision — source raw upload failure", () => {
+  test("reports a new decision's failed raw upload as retryable, not thrown", async () => {
+    // A thrown failure is caught by the decision loop, counted as skipped,
+    // and lets the page's cursor advance; a forward-only traversal then
+    // never returns to the decision and its raw source is lost. Only a
+    // retryable outcome reaches the page-level cursor hold.
+    await mock.module("@/api/lib/s3", () => ({
+      getS3: () => ({
+        write: () => {
+          throw new Error("an unexpected error has occurred");
+        },
+      }),
+    }));
+
+    const scopedDb: ScopedDb = async (callback) => {
+      const tx = {
+        query: {
+          caseLawDecisions: {
+            findFirst: async () => await Promise.resolve(undefined),
+          },
+        },
+      };
+
+      // SAFETY: the raw upload runs before any decision write, so the
+      // dedup lookup is the only chain this path reaches.
+      // eslint-disable-next-line typescript/no-unsafe-type-assertion
+      return await callback(tx as unknown as Transaction);
+    };
+
+    const outcome = await processDecision({
+      input: {
+        caseNumber: "X/2/2026",
+        court: "Test Court",
+        country: "SVK",
+        language: "sk",
+        fulltext: "Rozhodnutie o veci samej.",
+        metadata: {},
+        rawHash: "new-hash",
+        documentAst: EMPTY_AST,
+        sourceRaw: "<html></html>",
+      },
+      observationOrder: 1n,
+      sourceId: createSafeId<"caseLawSource">(),
+      scopedDb,
+      observedAt: new Date("2026-08-03T00:00:00.000Z"),
+    });
+
+    expect(outcome.status).toBe("retryable");
+    expect(outcome.inserted).toBe(false);
   });
 });

--- a/apps/api/src/handlers/case-law/ingestion/pipeline.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/pipeline.test.ts
@@ -588,7 +588,14 @@ describe("processDecision — source raw upload failure", () => {
       observedAt: new Date("2026-08-03T00:00:00.000Z"),
     });
 
-    expect(outcome.status).toBe("retryable");
+    if (outcome.status !== "retryable") {
+      throw new Error(`expected a retryable outcome, got ${outcome.status}`);
+    }
+
     expect(outcome.inserted).toBe(false);
+    // The reason selects the halt message and keeps this failure
+    // attributable apart from a corpus-write failure, so pin it: asserting
+    // only the status would pass on the corpus-write reason too.
+    expect(outcome.reason).toBe("source-raw-write");
   });
 });

--- a/apps/api/src/handlers/case-law/ingestion/pipeline.ts
+++ b/apps/api/src/handlers/case-law/ingestion/pipeline.ts
@@ -145,6 +145,7 @@ const PROCESS_DECISION_STATUS = {
 const PROCESS_DECISION_RETRY_REASON = {
   CONTENTION: "contention",
   CORPUS_WRITE: "corpus-write",
+  SOURCE_RAW_WRITE: "source-raw-write",
 } as const;
 
 type ProcessResult =
@@ -682,13 +683,29 @@ const processDecisionAttempt = async ({
       sourceRawContentType = rawContentType;
     } catch (error) {
       if (!existing) {
-        // New decision: re-throw so the pipeline skips this decision
-        // and retries next cycle. Inserting with sourceRawS3Key: null
-        // would set sourceHash, causing the dedup check to skip it
-        // permanently — the raw source would be lost forever.
-        // Skip captureError here; the outer catch in
-        // runIngestionPipeline will capture it once.
-        throw error;
+        // New decision: hold the page's cursor and retry the slice.
+        // Inserting with sourceRawS3Key: null would set sourceHash,
+        // causing the dedup check to skip it permanently — the raw
+        // source would be lost forever.
+        //
+        // Reported as retryable rather than thrown: the decision loop
+        // catches a throw, counts it as skipped, and lets the cursor
+        // advance, so a forward-only traversal passes the decision and
+        // never returns to it. Only a retryable outcome reaches the
+        // page-level hold.
+        logger.error("case_law.ingestion.source_raw_write_failed", {
+          sourceId,
+          caseNumber: result.caseNumber,
+          "error.type": errorTag(error),
+          "error.detail": corpusWriteErrorDetail(error),
+        });
+        captureError(error, { sourceId, step: "uploadSourceRaw" });
+
+        return {
+          status: PROCESS_DECISION_STATUS.RETRYABLE,
+          inserted: false,
+          reason: PROCESS_DECISION_RETRY_REASON.SOURCE_RAW_WRITE,
+        };
       }
 
       captureError(error, { sourceId, step: "uploadSourceRaw" });
@@ -1524,14 +1541,23 @@ export const runIngestionPipeline = async ({
               }
               break;
             case PROCESS_DECISION_STATUS.RETRYABLE:
-              if (
-                outcome.reason === PROCESS_DECISION_RETRY_REASON.CORPUS_WRITE
-              ) {
-                s3UploadFailures++;
-                haltReason = "1 corpus write failure(s); cursor held for retry";
-              } else {
-                haltReason =
-                  "Concurrent decision reconciliation; cursor held for retry";
+              switch (outcome.reason) {
+                case PROCESS_DECISION_RETRY_REASON.CORPUS_WRITE:
+                  s3UploadFailures++;
+                  haltReason =
+                    "1 corpus write failure(s); cursor held for retry";
+                  break;
+                case PROCESS_DECISION_RETRY_REASON.SOURCE_RAW_WRITE:
+                  s3UploadFailures++;
+                  haltReason =
+                    "1 source raw write failure(s); cursor held for retry";
+                  break;
+                case PROCESS_DECISION_RETRY_REASON.CONTENTION:
+                  haltReason =
+                    "Concurrent decision reconciliation; cursor held for retry";
+                  break;
+                default:
+                  return outcome.reason satisfies never;
               }
               retryableDecision = true;
               break;


### PR DESCRIPTION
## Proposed change

`processDecisionAttempt` re-throws when `uploadSourceRaw` fails for a decision
that has no existing row. The comment states the intent: skip this decision and
retry it next cycle, because inserting with `sourceRawS3Key: null` would set
`sourceHash` and make the dedup check skip it permanently.

The retry never happens. The decision loop in `runIngestionPipeline` catches the
throw, counts it in `skipped`, and continues; only `s3UploadFailures` (which the
sibling corpus-write failure increments) produces the page-level
`cursor held for retry` halt. So the page's cursor advances past the decision,
and for an adapter whose traversal walks one way — `sk-courts` walks its archive
oldest-first before switching to newest-first — nothing ever returns to it.
`case_law_ingestion_failures` is written for status reporting; no loop replays
it. The result is a permanent, invisible gap, which is exactly what rules 14 and
16 in this module's guide warn about: a bad crawl that stops is recoverable, a
bad crawl that skips is not.

Report the failure as a retryable outcome instead of throwing. It then reaches
the same page-level hold the corpus-write path already uses, which holds the
cursor and retries the slice. The two S3-write failure classes now behave
identically, which is the point: they fail for the same reasons.

Also read the retry reason with an exhaustive `switch` plus a `never` check.
The previous `if`/`else` sent every non-corpus-write reason down the contention
branch, so a new reason would silently inherit the wrong halt message and skip
the `s3UploadFailures` increment.

Note on the trade-off: holding the cursor means a decision whose raw upload
fails deterministically will retry rather than be passed over. That is the
behaviour the corpus-write path already has, and it fails loudly (the adapter's
existing no-progress accounting surfaces a stuck slice) rather than silently
dropping records.

`case_law.ingestion.source_raw_write_failed` is added so the failure is
attributable; it reuses `corpusWriteErrorDetail`, which unwraps the cause the
way the sibling path does.

## Checklist

- [x] **BUILD ASSURANCE** | `tsc --noEmit -p apps/api` clean; `oxlint --type-aware --deny-warnings` clean on the touched directory; `oxfmt` clean.
- [x] **TESTING** | `apps/api/src/handlers/case-law/ingestion/pipeline.test.ts` passes (12/12), including a new case asserting that a new decision's failed raw upload is reported as retryable rather than thrown — the property that keeps the cursor held.
- [ ] DARK MODE SUPPORT | Not applicable: no UI surface in this change.
- [ ] ISSUE LINKED | No existing issue.
- [ ] SCREENSHOT INCLUDED | Not applicable: ingestion pipeline control flow.

---
_Generated by [Claude Code](https://claude.ai/code/session_0159WYe9AgRJCqLF4ABf6ouw)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved case-law ingestion when raw source uploads fail.
  * Failed uploads are now marked for retry instead of causing decisions to be skipped.
  * Processing now retains its place and reports the failure clearly, allowing ingestion to resume safely.
* **Tests**
  * Added coverage to verify that raw-source upload failures produce a retryable result without creating an incomplete decision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->