### PR TITLE
chore(case-law): exclude numeric administrative č. j. references from citation probe

### DIFF
--- a/apps/api/src/scripts/citation-probe.ts
+++ b/apps/api/src/scripts/citation-probe.ts
@@ -187,6 +187,13 @@ const BENIGN: readonly RegExp[] = [
   // from "sygn. akt II Ca (…)"), and self-references such as "sygn. j.w."
   // ("as above").
   /^(?:sp\.\s{0,3}zn\.|sen\.\s{0,3}zn\.|sygn\.(?:\s{1,3}akt)?|[čc]\.\s{0,3}j\.:?)[^\d]{0,45}$/iu,
+  // Administrative-authority "č. j." reference (tax office, land registry):
+  // three or more purely numeric segments joined by slashes, e.g. "č. j.
+  // 11055/01/332960/2959" (Finanční úřad), "č.j. 27662/97/332960/2959". A
+  // real court docket always carries a letter registry between the chamber
+  // digit and the docket number (CASE_NUMBER_BODY in the extractor); an
+  // all-numeric multi-segment reference is never a court citation.
+  /[čc]\.\s{0,3}j\.:?\s{0,3}\d{1,6}(?:\/\d{1,6}){2,4}(?!\p{L})/u,
 ];
 
 const isBenign = (candidate: string): boolean =>

--- a/apps/api/src/scripts/citation-probe.ts
+++ b/apps/api/src/scripts/citation-probe.ts
@@ -192,8 +192,12 @@ const BENIGN: readonly RegExp[] = [
   // 11055/01/332960/2959" (Finanční úřad), "č.j. 27662/97/332960/2959". A
   // real court docket always carries a letter registry between the chamber
   // digit and the docket number (CASE_NUMBER_BODY in the extractor); an
-  // all-numeric multi-segment reference is never a court citation.
-  /[čc]\.\s{0,3}j\.:?\s{0,3}\d{1,6}(?:\/\d{1,6}){2,4}(?!\p{L})/u,
+  // all-numeric multi-segment reference is never a court citation. The
+  // lookahead excludes a following letter, digit, or slash so a longer or
+  // mixed-format reference ("123/45/678/ABC", a 6-segment chain, or an
+  // oversized final segment beyond the 6-digit cap) is never silently
+  // truncated to a shorter benign-looking prefix.
+  /[čc]\.\s{0,3}j\.:?\s{0,3}\d{1,6}(?:\/\d{1,6}){2,4}(?![\p{L}\d/])/u,
 ];
 
 const isBenign = (candidate: string): boolean =>


### PR DESCRIPTION
## Proposed change

Czech administrative-review judgments frequently quote the underlying tax
office or land registry decision by its own file number, e.g. `č. j.
11055/01/332960/2959` (Finanční úřad) or `č.j. 2831/99/332960/2959`. This is
an all-numeric, multi-segment reference joined by slashes with no letter
registry — unlike a real court docket, which always carries a chamber
digit plus a letter registry (`21 Cdo 1234/2020`).

`citation-probe.ts`'s residual detector was flagging these administrative
references as uncovered citation candidates, since the existing `BENIGN`
list only excluded agency file numbers that carry a letter-hyphen prefix
(`MSP-725/2022`-style). This adds a targeted exclusion for the all-numeric
shape, scoped narrowly enough that it does not match any of the extractor's
existing court-citation patterns (verified against `5 As 123/2020`, the
`KSCB 26 INS 8270/2018` insolvency form, and the plain `sp. zn.` form).

No production extraction behavior changes: `citation-probe.ts` is a
sampling/reporting script, not part of the ingestion pipeline.

## Checklist

- [x] BUILD ASSURANCE | Code builds correctly and without any errors or warnings.
- [x] TESTING | `bun --smol test src/handlers/case-law/ingestion/citation-extractor.test.ts` passes unchanged (159/159); manually verified the new pattern against positive and negative fixtures.
- [ ] DARK MODE SUPPORT | N/A — script-only change, no UI.
- [ ] ISSUE LINKED | N/A
- [ ] SCREENSHOT INCLUDED | N/A — script-only change.


---
_Generated by [Claude Code](https://claude.ai/code/session_013CPSAqSzzULdTrTXeNBpqB)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced false-positive citation alerts by excluding recognised administrative references with multiple numeric segments.
  * Administrative `č. j.` references are now handled more accurately during citation checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->