### PR TITLE
fix: harden AI provider canary checks

### DIFF
--- a/.github/workflows/ai-provider-canary.yml
+++ b/.github/workflows/ai-provider-canary.yml
@@ -37,9 +37,10 @@ jobs:
   provider-canary:
     name: ${{ matrix.provider }} capability contract
     runs-on: ubuntu-latest
-    # Weekly serial probe timeouts total at most 650 seconds; leave room for
-    # runner setup and install. Daily runs remain below the previous 10-minute budget.
-    timeout-minutes: 15
+    # A weekly run can spend 650 seconds on first attempts. One bounded retry
+    # per transient failure can double that budget; leave room for backoff,
+    # runner setup, and dependency installation.
+    timeout-minutes: 30
     permissions:
       contents: read
     strategy:

--- a/apps/api/scripts/ai-provider-canary.test.ts
+++ b/apps/api/scripts/ai-provider-canary.test.ts
@@ -366,6 +366,98 @@ describe("AI provider canary retry contract", () => {
     ).toEqual([false, false, false, false]);
   });
 
+  test("classifies bounded message-only provider error bodies", () => {
+    const signal = new AbortController().signal;
+    const cases = [
+      { body: { error: { code: 400 } }, retryable: false },
+      { body: { error: { code: 402 } }, retryable: false },
+      { body: { error: { code: 404 } }, retryable: false },
+      { body: { error: { code: 429 } }, retryable: true },
+      { body: { error: { code: 503 } }, retryable: true },
+      { body: { code: "billing_error" }, retryable: false },
+      { body: { code: "provider_error" }, retryable: true },
+    ];
+
+    const outcomes = cases.flatMap(({ body }) => {
+      const message = `\n ${JSON.stringify(body)}`;
+      return [
+        isRetryableCanaryError(
+          new CanaryProviderRunError({ message }, "before-tool-call"),
+          signal,
+        ),
+        isRetryableCanaryError({ message, status: 502 }, signal),
+      ];
+    });
+
+    expect(outcomes).toEqual(
+      cases.flatMap(({ retryable }) => [retryable, retryable]),
+    );
+  });
+
+  test("uses message bodies only when structured provider details are absent", () => {
+    const signal = new AbortController().signal;
+    const terminalMessage = JSON.stringify({ error: { code: 400 } });
+    const cases = [
+      new CanaryProviderRunError(
+        {
+          message: terminalMessage,
+          rawEvent: { code: "provider_error", status: 503 },
+        },
+        "before-tool-call",
+      ),
+      {
+        cause: { code: "provider_error", status: 503 },
+        message: terminalMessage,
+      },
+      new CanaryProviderRunError({ message: "{malformed" }, "before-tool-call"),
+      new CanaryProviderRunError(
+        { message: "plain provider failure" },
+        "before-tool-call",
+      ),
+    ];
+
+    expect(cases.map((error) => isRetryableCanaryError(error, signal))).toEqual(
+      [true, true, true, true],
+    );
+  });
+
+  test("does not parse provider error messages beyond the size bound", () => {
+    const signal = new AbortController().signal;
+    const terminalBody = JSON.stringify({ error: { code: 400 } });
+    const messages = [
+      JSON.stringify({
+        error: { code: 400 },
+        padding: "x".repeat(20_000),
+      }),
+      `${" ".repeat(20_000)}${terminalBody}`,
+    ];
+    const errors = messages.flatMap((message) => [
+      new CanaryProviderRunError({ message }, "before-tool-call"),
+      { message, status: 502 },
+    ]);
+
+    expect(
+      errors.map((error) => isRetryableCanaryError(error, signal)),
+    ).toEqual([true, true, true, true]);
+  });
+
+  test("honors explicit retryability before HTTP status fallback", () => {
+    const signal = new AbortController().signal;
+    const cases = [
+      { isRetryable: false, status: 429 },
+      { retryable: false, status: 503 },
+      { isRetryable: true, status: 400 },
+      new CanaryProviderRunError(
+        { retryable: false, status: 502 },
+        "before-tool-call",
+      ),
+    ];
+
+    expect(cases.map((error) => isRetryableCanaryError(error, signal))).toEqual(
+      [false, false, true, false],
+    );
+  });
+
   test("classifies only known status-less transport errors and SDK markers", () => {
     const signal = new AbortController().signal;
     const cases = [

--- a/apps/api/scripts/ai-provider-canary.test.ts
+++ b/apps/api/scripts/ai-provider-canary.test.ts
@@ -295,6 +295,30 @@ describe("AI provider canary retry contract", () => {
         signal,
       ),
     ).toBe(false);
+    expect(
+      isRetryableCanaryError(
+        new CanaryProviderRunError(
+          { error: { code: "unknown_permanent_error" } },
+          "before-tool-call",
+        ),
+        signal,
+      ),
+    ).toBe(false);
+  });
+
+  test("prefers a provider status nested beneath a generic transport wrapper", () => {
+    const signal = new AbortController().signal;
+    const error = new CanaryProviderRunError(
+      {
+        cause: { code: "authentication_error", status: 401 },
+        status: 502,
+      },
+      "before-tool-call",
+    );
+
+    expect(error.status).toBe(401);
+    expect(error.code).toBe("authentication_error");
+    expect(isRetryableCanaryError(error, signal)).toBe(false);
   });
 });
 
@@ -311,5 +335,38 @@ describe("AI provider weekly tool execution contract", () => {
         observedInputs: [input],
       }),
     ).not.toThrow();
+  });
+
+  test("rejects every invalid execution cardinality and argument shape", () => {
+    const input = {
+      details: { value: "stella-weekly" },
+      type: "nested",
+    };
+    const invalidExecutions = [
+      {
+        expectedMessage:
+          "Provider did not execute the weekly canary tool exactly once.",
+        observedInputs: [],
+      },
+      {
+        expectedMessage:
+          "Provider did not execute the weekly canary tool exactly once.",
+        observedInputs: [input, input],
+      },
+      {
+        expectedMessage:
+          "Provider returned unexpected weekly canary tool arguments.",
+        observedInputs: [{ details: { value: "unexpected" }, type: "nested" }],
+      },
+    ];
+
+    for (const { expectedMessage, observedInputs } of invalidExecutions) {
+      expect(() =>
+        requireWeeklyToolExecution({
+          expectedInputs: [input],
+          observedInputs,
+        }),
+      ).toThrow(expectedMessage);
+    }
   });
 });

--- a/apps/api/scripts/ai-provider-canary.test.ts
+++ b/apps/api/scripts/ai-provider-canary.test.ts
@@ -255,6 +255,26 @@ describe("AI provider canary retry contract", () => {
     expect(calls).toBe(2);
   });
 
+  test("retries a known status-less transport failure before succeeding", async () => {
+    let calls = 0;
+    const result = await runCanaryProbe({
+      retryDelayMs: 0,
+      run: async () => {
+        calls += 1;
+        if (calls === 1) {
+          throw new TypeError("fetch failed", {
+            cause: { code: "ECONNRESET" },
+          });
+        }
+      },
+      timeoutMs: 1000,
+      wait: async () => {},
+    });
+
+    expect(result).toEqual({ attempts: 2, status: "passed" });
+    expect(calls).toBe(2);
+  });
+
   test("does not retry deterministic contract failures", async () => {
     let calls = 0;
     const error = new TypeError(
@@ -319,6 +339,25 @@ describe("AI provider canary retry contract", () => {
     expect(error.status).toBe(401);
     expect(error.code).toBe("authentication_error");
     expect(isRetryableCanaryError(error, signal)).toBe(false);
+  });
+
+  test("classifies only known status-less transport errors and SDK markers", () => {
+    const signal = new AbortController().signal;
+    const cases = [
+      { error: { cause: { code: "ECONNRESET" } }, retryable: true },
+      { error: { code: "ETIMEDOUT" }, retryable: true },
+      { error: { retryable: true }, retryable: true },
+      { error: { $retryable: {} }, retryable: true },
+      {
+        error: { cause: { code: "ECONNRESET" }, isRetryable: false },
+        retryable: false,
+      },
+      { error: { code: "EACCES" }, retryable: false },
+    ];
+
+    expect(
+      cases.map(({ error }) => isRetryableCanaryError(error, signal)),
+    ).toEqual(cases.map(({ retryable }) => retryable));
   });
 });
 

--- a/apps/api/scripts/ai-provider-canary.test.ts
+++ b/apps/api/scripts/ai-provider-canary.test.ts
@@ -13,8 +13,11 @@ import {
   CanaryProviderRunError,
   createPdfCanaryMessages,
   errorSummary,
+  isRetryableCanaryError,
   PDF_CANARY_TOKEN,
   pdfCanarySelection,
+  requireWeeklyToolExecution,
+  runCanaryProbe,
   toolRoundTripInputSchema,
   toolRoundTripInputSchemaForProvider,
   toolRoundTripPromptForProvider,
@@ -175,5 +178,138 @@ describe("AI provider canary error summaries", () => {
     );
 
     expect(errorSummary(error, signal)).toBe("provider HTTP 429");
+  });
+});
+
+class ProviderStatusError extends Error {
+  readonly status: number;
+
+  constructor(status: number) {
+    super(`Synthetic provider HTTP ${status}`);
+    this.name = "ProviderStatusError";
+    this.status = status;
+  }
+}
+
+describe("AI provider canary retry contract", () => {
+  test("retries exactly once for every retryable HTTP status class", async () => {
+    const statuses = [
+      { retryable: false, status: 400 },
+      { retryable: false, status: 401 },
+      { retryable: false, status: 403 },
+      { retryable: false, status: 422 },
+      { retryable: true, status: 429 },
+      { retryable: true, status: 500 },
+      { retryable: true, status: 502 },
+      { retryable: true, status: 503 },
+    ];
+
+    const outcomes = await Promise.all(
+      statuses.map(async ({ retryable, status }) => {
+        let calls = 0;
+        const result = await runCanaryProbe({
+          retryDelayMs: 0,
+          run: async () => {
+            calls += 1;
+            throw new ProviderStatusError(status);
+          },
+          timeoutMs: 1000,
+          wait: async () => {},
+        });
+        return { calls, result, retryable, status };
+      }),
+    );
+
+    expect(
+      outcomes.map(({ calls, result, retryable, status }) => ({
+        attempts: result.attempts,
+        calls,
+        retryable,
+        status,
+      })),
+    ).toEqual(
+      statuses.map(({ retryable, status }) => ({
+        attempts: retryable ? 2 : 1,
+        calls: retryable ? 2 : 1,
+        retryable,
+        status,
+      })),
+    );
+  });
+
+  test("retries an opaque provider stream failure before succeeding", async () => {
+    let calls = 0;
+    const result = await runCanaryProbe({
+      retryDelayMs: 0,
+      run: async () => {
+        calls += 1;
+        if (calls === 1) {
+          throw new CanaryProviderRunError({}, "before-tool-call");
+        }
+      },
+      timeoutMs: 1000,
+      wait: async () => {},
+    });
+
+    expect(result).toEqual({ attempts: 2, status: "passed" });
+    expect(calls).toBe(2);
+  });
+
+  test("does not retry deterministic contract failures", async () => {
+    let calls = 0;
+    const error = new TypeError(
+      "Provider returned unexpected weekly canary tool arguments.",
+    );
+    const result = await runCanaryProbe({
+      retryDelayMs: 0,
+      run: async () => {
+        calls += 1;
+        throw error;
+      },
+      timeoutMs: 1000,
+      wait: async () => {},
+    });
+
+    expect(result).toMatchObject({ attempts: 1, error, status: "failed" });
+    expect(calls).toBe(1);
+  });
+
+  test("classifies only bounded provider codes as retryable", () => {
+    const signal = new AbortController().signal;
+
+    expect(
+      isRetryableCanaryError(
+        new CanaryProviderRunError(
+          { error: { code: "provider_error" } },
+          "before-tool-call",
+        ),
+        signal,
+      ),
+    ).toBe(true);
+    expect(
+      isRetryableCanaryError(
+        new CanaryProviderRunError(
+          { error: { code: "invalid_request_error" } },
+          "before-tool-call",
+        ),
+        signal,
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("AI provider weekly tool execution contract", () => {
+  test("accepts valid execution without inspecting assistant wording", () => {
+    const input = {
+      details: { value: "stella-weekly" },
+      type: "nested",
+    };
+
+    expect(() =>
+      requireWeeklyToolExecution({
+        expectedInputs: [input],
+        observedInputs: [input],
+      }),
+    ).not.toThrow();
   });
 });

--- a/apps/api/scripts/ai-provider-canary.test.ts
+++ b/apps/api/scripts/ai-provider-canary.test.ts
@@ -341,6 +341,31 @@ describe("AI provider canary retry contract", () => {
     expect(isRetryableCanaryError(error, signal)).toBe(false);
   });
 
+  test("prefers terminal provider codes over a generic wrapper status", () => {
+    const signal = new AbortController().signal;
+    const errors = [
+      { code: "invalid_request_error", status: 502 },
+      { error: { code: "authentication_error" }, status: 502 },
+      {
+        cause: { code: "ECONNRESET" },
+        code: "invalid_request_error",
+        status: 502,
+      },
+      new CanaryProviderRunError(
+        {
+          cause: { code: "provider_error" },
+          code: "permission_error",
+          status: 502,
+        },
+        "before-tool-call",
+      ),
+    ];
+
+    expect(
+      errors.map((error) => isRetryableCanaryError(error, signal)),
+    ).toEqual([false, false, false, false]);
+  });
+
   test("classifies only known status-less transport errors and SDK markers", () => {
     const signal = new AbortController().signal;
     const cases = [

--- a/apps/api/scripts/ai-provider-canary.ts
+++ b/apps/api/scripts/ai-provider-canary.ts
@@ -275,12 +275,39 @@ const isRetryableProviderCode = (code: string | null): boolean =>
   code !== null &&
   (RETRYABLE_PROVIDER_CODES.has(code) || RETRYABLE_TRANSPORT_CODES.has(code));
 
+const isTerminalProviderCode = (code: string | null): boolean =>
+  code !== null &&
+  SAFE_PROVIDER_CODES.has(code) &&
+  !RETRYABLE_PROVIDER_CODES.has(code);
+
+const terminalProviderCode = (error: unknown, depth = 0): string | null => {
+  if (!isRecord(error)) {
+    return null;
+  }
+
+  const code = error["code"];
+  if (typeof code === "string" && isTerminalProviderCode(code)) {
+    return code;
+  }
+
+  if (depth < 3) {
+    for (const key of PROVIDER_ERROR_NESTED_KEYS) {
+      const nestedCode = terminalProviderCode(error[key], depth + 1);
+      if (nestedCode !== null) {
+        return nestedCode;
+      }
+    }
+  }
+  return null;
+};
+
 export class CanaryProviderRunError extends TypeError {
   readonly code: string | null;
   readonly retryCode: string | null;
   readonly retryable: boolean | null;
   readonly stage: CanaryRunStage;
   readonly status: number | null;
+  readonly terminalCode: string | null;
 
   constructor(event: unknown, stage: CanaryRunStage) {
     super("Provider stream failed.");
@@ -290,6 +317,7 @@ export class CanaryProviderRunError extends TypeError {
     this.code = safeProviderCode(this.retryCode);
     this.stage = stage;
     this.status = providerStatus(event);
+    this.terminalCode = terminalProviderCode(event);
   }
 }
 
@@ -302,6 +330,9 @@ export const isRetryableCanaryError = (
   }
 
   if (error instanceof CanaryProviderRunError) {
+    if (error.terminalCode !== null) {
+      return false;
+    }
     if (error.status !== null) {
       return isRetryableProviderStatus(error.status);
     }
@@ -311,6 +342,10 @@ export const isRetryableCanaryError = (
     return error.retryCode === null || isRetryableProviderCode(error.retryCode);
   }
 
+  const code = rawProviderCode(error);
+  if (terminalProviderCode(error) !== null) {
+    return false;
+  }
   const status = providerStatus(error);
   if (status !== null) {
     return isRetryableProviderStatus(status);
@@ -319,7 +354,7 @@ export const isRetryableCanaryError = (
   if (retryable !== null) {
     return retryable;
   }
-  return isRetryableProviderCode(rawProviderCode(error));
+  return isRetryableProviderCode(code);
 };
 
 type CanaryProbeResult =

--- a/apps/api/scripts/ai-provider-canary.ts
+++ b/apps/api/scripts/ai-provider-canary.ts
@@ -1,5 +1,6 @@
 import { chat, EventType, maxIterations, toolDefinition } from "@tanstack/ai";
 import type { ModelMessage, Tool } from "@tanstack/ai";
+import { panic } from "better-result";
 import { isDeepStrictEqual } from "node:util";
 import * as v from "valibot";
 
@@ -37,10 +38,7 @@ import type {
   CanaryProvider,
   WeeklyCanaryRotation,
 } from "./ai-provider-canary-config";
-import {
-  createWeeklyToolShapeDefinition,
-  WEEKLY_TOOL_RESULT,
-} from "./ai-provider-canary-weekly";
+import { createWeeklyToolShapeDefinition } from "./ai-provider-canary-weekly";
 
 const CAPABILITY_ROLE = "fast" satisfies ModelRole;
 const TOOL_CALL_ROLE = "chat" satisfies ModelRole;
@@ -48,6 +46,8 @@ const MAX_OUTPUT_TOKENS = 64;
 const CAPABILITY_PROBE_TIMEOUT_MS = 20_000;
 const MODEL_ROLE_PROBE_TIMEOUT_MS = 30_000;
 const TOOL_ROUND_TRIP_PROBE_TIMEOUT_MS = 45_000;
+const CANARY_PROBE_MAX_ATTEMPTS = 2;
+const CANARY_PROBE_RETRY_DELAY_MS = 5000;
 const MILLISECONDS_PER_WEEK = 7 * 24 * 60 * 60 * 1000;
 const SYNTHETIC_PROMPT = "Reply with exactly OK.";
 export const PDF_CANARY_TOKEN = "STELLA_PDF_CANARY_OK";
@@ -81,10 +81,8 @@ const SAFE_CANARY_ERROR_MESSAGES = new Set([
   "Provider adapter preserved a synthetic null tool argument.",
   "Provider generated an unexpected optional tool argument.",
   "Provider returned unexpected canary tool arguments.",
-  "Provider did not return the canary tool result.",
   "Provider did not execute the weekly canary tool exactly once.",
   "Provider returned unexpected weekly canary tool arguments.",
-  "Provider did not return the weekly canary tool result.",
   "Provider did not read the attached PDF.",
   "Provider returned no text.",
 ]);
@@ -160,6 +158,20 @@ const SAFE_PROVIDER_CODES = new Set([
   "timeout_error",
 ]);
 
+const RETRYABLE_PROVIDER_CODES = new Set([
+  "aborted",
+  "api_error",
+  "error",
+  "incomplete",
+  "overloaded_error",
+  "provider_error",
+  "rate_limit_error",
+  "rate_limit_exceeded",
+  "server_error",
+  "timeout",
+  "timeout_error",
+]);
+
 type CanaryRunStage =
   | "before-tool-call"
   | "after-tool-call"
@@ -214,6 +226,9 @@ const providerStatus = (error: unknown, depth = 0): number | null => {
   return null;
 };
 
+const isRetryableProviderStatus = (status: number): boolean =>
+  status === 429 || status >= 500;
+
 export class CanaryProviderRunError extends TypeError {
   readonly code: string | null;
   readonly stage: CanaryRunStage;
@@ -227,6 +242,68 @@ export class CanaryProviderRunError extends TypeError {
     this.status = providerStatus(event);
   }
 }
+
+export const isRetryableCanaryError = (
+  error: unknown,
+  signal: AbortSignal,
+): boolean => {
+  if (signal.aborted) {
+    return true;
+  }
+
+  if (error instanceof CanaryProviderRunError) {
+    if (error.status !== null) {
+      return isRetryableProviderStatus(error.status);
+    }
+    return error.code === null || RETRYABLE_PROVIDER_CODES.has(error.code);
+  }
+
+  const status = providerStatus(error);
+  return status !== null && isRetryableProviderStatus(status);
+};
+
+type CanaryProbeResult =
+  | { attempts: number; status: "passed" }
+  | {
+      attempts: number;
+      error: unknown;
+      signal: AbortSignal;
+      status: "failed";
+    };
+
+type RunCanaryProbeOptions = {
+  retryDelayMs?: number;
+  run: (signal: AbortSignal) => Promise<void>;
+  timeoutMs: number;
+  wait?: (delayMs: number) => Promise<void>;
+};
+
+export const runCanaryProbe = async ({
+  retryDelayMs = CANARY_PROBE_RETRY_DELAY_MS,
+  run: runAttempt,
+  timeoutMs,
+  wait = Bun.sleep,
+}: RunCanaryProbeOptions): Promise<CanaryProbeResult> => {
+  for (let attempt = 1; attempt <= CANARY_PROBE_MAX_ATTEMPTS; attempt += 1) {
+    const signal = AbortSignal.timeout(timeoutMs);
+    try {
+      // oxlint-disable-next-line no-await-in-loop -- retries must wait for the preceding provider attempt to fail.
+      await runAttempt(signal);
+      return { attempts: attempt, status: "passed" };
+    } catch (error) {
+      if (
+        attempt === CANARY_PROBE_MAX_ATTEMPTS ||
+        !isRetryableCanaryError(error, signal)
+      ) {
+        return { attempts: attempt, error, signal, status: "failed" };
+      }
+      // oxlint-disable-next-line no-await-in-loop -- bounded backoff separates sequential provider attempts.
+      await wait(retryDelayMs);
+    }
+  }
+
+  return panic("Canary retry loop exhausted without a result.");
+};
 
 const NO_CACHING = {
   enabled: false,
@@ -432,7 +509,7 @@ const capabilityProbes = [
     name: "strict-tool-schema",
     timeoutMs: CAPABILITY_PROBE_TIMEOUT_MS,
     run: async (context, signal) => {
-      await runToolProbe({
+      const output = await runToolProbe({
         context,
         maxOutputTokens: MAX_OUTPUT_TOKENS,
         prompt: TOOL_SCHEMA_PROMPT,
@@ -440,6 +517,7 @@ const capabilityProbes = [
         signal,
         tool: strictTool,
       });
+      requireNonEmptyText(output);
     },
   },
   {
@@ -447,7 +525,7 @@ const capabilityProbes = [
     name: "open-map-tool-schema",
     timeoutMs: CAPABILITY_PROBE_TIMEOUT_MS,
     run: async (context, signal) => {
-      await runToolProbe({
+      const output = await runToolProbe({
         context,
         maxOutputTokens: MAX_OUTPUT_TOKENS,
         prompt: TOOL_SCHEMA_PROMPT,
@@ -455,6 +533,7 @@ const capabilityProbes = [
         signal,
         tool: openMapTool,
       });
+      requireNonEmptyText(output);
     },
   },
   {
@@ -639,7 +718,7 @@ const runToolCallRoundTripProbe = async ({
     return { confirmation: TOOL_ROUND_TRIP_RESULT };
   });
 
-  const output = await runToolProbe({
+  await runToolProbe({
     context,
     maxOutputTokens: modelRoleMaxOutputTokens(TOOL_CALL_ROLE),
     prompt: toolRoundTripPromptForProvider(context.provider),
@@ -671,9 +750,6 @@ const runToolCallRoundTripProbe = async ({
       "Provider generated an unexpected optional tool argument.",
     );
   }
-  if (output.trim() !== TOOL_ROUND_TRIP_RESULT) {
-    throw new TypeError("Provider did not return the canary tool result.");
-  }
 };
 
 type RunWeeklyToolShapeProbeOptions = {
@@ -681,25 +757,15 @@ type RunWeeklyToolShapeProbeOptions = {
   signal: AbortSignal;
 };
 
-const runWeeklyToolShapeProbe = async ({
-  context,
-  signal,
-}: RunWeeklyToolShapeProbeOptions): Promise<void> => {
-  const observedInputs: unknown[] = [];
-  const { expectedInputs, prompt, tool } = createWeeklyToolShapeDefinition(
-    context.rotation.toolShape,
-    context.provider,
-    observedInputs,
-  );
-  const output = await runToolProbe({
-    context: { config: context.rotatedConfig, provider: context.provider },
-    maxOutputTokens: modelRoleMaxOutputTokens(TOOL_CALL_ROLE),
-    prompt,
-    role: TOOL_CALL_ROLE,
-    signal,
-    tool,
-  });
+type RequireWeeklyToolExecutionOptions = {
+  expectedInputs: readonly unknown[];
+  observedInputs: readonly unknown[];
+};
 
+export const requireWeeklyToolExecution = ({
+  expectedInputs,
+  observedInputs,
+}: RequireWeeklyToolExecutionOptions): void => {
   if (observedInputs.length !== 1) {
     throw new TypeError(
       "Provider did not execute the weekly canary tool exactly once.",
@@ -715,11 +781,28 @@ const runWeeklyToolShapeProbe = async ({
       "Provider returned unexpected weekly canary tool arguments.",
     );
   }
-  if (output.trim() !== WEEKLY_TOOL_RESULT) {
-    throw new TypeError(
-      "Provider did not return the weekly canary tool result.",
-    );
-  }
+};
+
+const runWeeklyToolShapeProbe = async ({
+  context,
+  signal,
+}: RunWeeklyToolShapeProbeOptions): Promise<void> => {
+  const observedInputs: unknown[] = [];
+  const { expectedInputs, prompt, tool } = createWeeklyToolShapeDefinition(
+    context.rotation.toolShape,
+    context.provider,
+    observedInputs,
+  );
+  await runToolProbe({
+    context: { config: context.rotatedConfig, provider: context.provider },
+    maxOutputTokens: modelRoleMaxOutputTokens(TOOL_CALL_ROLE),
+    prompt,
+    role: TOOL_CALL_ROLE,
+    signal,
+    tool,
+  });
+
+  requireWeeklyToolExecution({ expectedInputs, observedInputs });
 };
 
 type RunToolProbeOptions = {
@@ -784,7 +867,6 @@ const runToolProbe = async ({
       throw new CanaryProviderRunError(chunk, stage);
     }
   }
-  requireNonEmptyText(output);
   return output;
 };
 
@@ -948,6 +1030,9 @@ const probeLabel = (context: CanaryContext, probe: Probe): string => {
   return `${prefix}-${probe.role}:${modelId ?? "unsupported"}`;
 };
 
+const attemptSummary = (attempts: number): string =>
+  attempts === 1 ? "" : ` after ${attempts} attempts`;
+
 const run = async (): Promise<void> => {
   const args = parseCanaryRunArgs(Bun.argv.slice(2));
   const { provider } = args;
@@ -1017,17 +1102,23 @@ const runProbes = async (
     return await runProbes(context, index + 1, failures);
   }
 
-  const signal = AbortSignal.timeout(probe.timeoutMs);
-  try {
-    await probe.run(context, signal);
-    console.log(`[ai-canary] ${context.provider}/${label}: passed`);
-    return await runProbes(context, index + 1, failures);
-  } catch (error) {
-    console.error(
-      `[ai-canary] ${context.provider}/${label}: failed (${errorSummary(error, signal)})`,
+  const result = await runCanaryProbe({
+    run: async (signal) => {
+      await probe.run(context, signal);
+    },
+    timeoutMs: probe.timeoutMs,
+  });
+  if (result.status === "passed") {
+    console.log(
+      `[ai-canary] ${context.provider}/${label}: passed${attemptSummary(result.attempts)}`,
     );
-    return await runProbes(context, index + 1, failures + 1);
+    return await runProbes(context, index + 1, failures);
   }
+
+  console.error(
+    `[ai-canary] ${context.provider}/${label}: failed${attemptSummary(result.attempts)} (${errorSummary(result.error, result.signal)})`,
+  );
+  return await runProbes(context, index + 1, failures + 1);
 };
 
 const runWeeklyCanaryProbes = async (
@@ -1038,48 +1129,66 @@ const runWeeklyCanaryProbes = async (
 
   for (const role of context.rotation.modelRoles) {
     const label = `weekly-role-${role}:${context.rotation.modelId}`;
-    const signal = AbortSignal.timeout(MODEL_ROLE_PROBE_TIMEOUT_MS);
-    try {
-      // oxlint-disable-next-line no-await-in-loop -- role probes must stay sequential so the failure count and console output stay ordered.
-      await runWeeklyModelRoleProbe({ context, role, signal });
-      console.log(`[ai-canary] ${context.provider}/${label}: passed`);
-    } catch (error) {
+    // oxlint-disable-next-line no-await-in-loop -- role probes must stay sequential so provider rate limits and output remain deterministic.
+    const result = await runCanaryProbe({
+      run: async (signal) => {
+        await runWeeklyModelRoleProbe({ context, role, signal });
+      },
+      timeoutMs: MODEL_ROLE_PROBE_TIMEOUT_MS,
+    });
+    if (result.status === "passed") {
+      console.log(
+        `[ai-canary] ${context.provider}/${label}: passed${attemptSummary(result.attempts)}`,
+      );
+    } else {
       console.error(
-        `[ai-canary] ${context.provider}/${label}: failed (${errorSummary(error, signal)})`,
+        `[ai-canary] ${context.provider}/${label}: failed${attemptSummary(result.attempts)} (${errorSummary(result.error, result.signal)})`,
       );
       totalFailures += 1;
     }
 
     const structuredLabel = `weekly-structured-role-${role}:${context.rotation.modelId}`;
-    const structuredSignal = AbortSignal.timeout(MODEL_ROLE_PROBE_TIMEOUT_MS);
-    try {
-      // oxlint-disable-next-line no-await-in-loop -- provider probes must stay sequential so rate limits and output remain deterministic.
-      await runWeeklyStructuredOutputModelRoleProbe({
-        context,
-        role,
-        signal: structuredSignal,
-      });
-      console.log(`[ai-canary] ${context.provider}/${structuredLabel}: passed`);
-    } catch (error) {
+    // oxlint-disable-next-line no-await-in-loop -- structured probes share the same provider quota and must remain sequential.
+    const structuredResult = await runCanaryProbe({
+      run: async (signal) => {
+        await runWeeklyStructuredOutputModelRoleProbe({
+          context,
+          role,
+          signal,
+        });
+      },
+      timeoutMs: MODEL_ROLE_PROBE_TIMEOUT_MS,
+    });
+    if (structuredResult.status === "passed") {
+      console.log(
+        `[ai-canary] ${context.provider}/${structuredLabel}: passed${attemptSummary(structuredResult.attempts)}`,
+      );
+    } else {
       console.error(
-        `[ai-canary] ${context.provider}/${structuredLabel}: failed (${errorSummary(error, structuredSignal)})`,
+        `[ai-canary] ${context.provider}/${structuredLabel}: failed${attemptSummary(structuredResult.attempts)} (${errorSummary(structuredResult.error, structuredResult.signal)})`,
       );
       totalFailures += 1;
     }
   }
 
   const label = `weekly-tool-${context.rotation.toolShape}:${context.rotation.modelId}`;
-  const signal = AbortSignal.timeout(TOOL_ROUND_TRIP_PROBE_TIMEOUT_MS);
-  try {
-    await runWeeklyToolShapeProbe({ context, signal });
-    console.log(`[ai-canary] ${context.provider}/${label}: passed`);
-    return totalFailures;
-  } catch (error) {
-    console.error(
-      `[ai-canary] ${context.provider}/${label}: failed (${errorSummary(error, signal)})`,
+  const result = await runCanaryProbe({
+    run: async (signal) => {
+      await runWeeklyToolShapeProbe({ context, signal });
+    },
+    timeoutMs: TOOL_ROUND_TRIP_PROBE_TIMEOUT_MS,
+  });
+  if (result.status === "passed") {
+    console.log(
+      `[ai-canary] ${context.provider}/${label}: passed${attemptSummary(result.attempts)}`,
     );
-    return totalFailures + 1;
+    return totalFailures;
   }
+
+  console.error(
+    `[ai-canary] ${context.provider}/${label}: failed${attemptSummary(result.attempts)} (${errorSummary(result.error, result.signal)})`,
+  );
+  return totalFailures + 1;
 };
 
 if (import.meta.main) {

--- a/apps/api/scripts/ai-provider-canary.ts
+++ b/apps/api/scripts/ai-provider-canary.ts
@@ -1,6 +1,6 @@
 import { chat, EventType, maxIterations, toolDefinition } from "@tanstack/ai";
 import type { ModelMessage, Tool } from "@tanstack/ai";
-import { panic } from "better-result";
+import { panic, Result } from "better-result";
 import { isDeepStrictEqual } from "node:util";
 import * as v from "valibot";
 
@@ -48,6 +48,7 @@ const MODEL_ROLE_PROBE_TIMEOUT_MS = 30_000;
 const TOOL_ROUND_TRIP_PROBE_TIMEOUT_MS = 45_000;
 const CANARY_PROBE_MAX_ATTEMPTS = 2;
 const CANARY_PROBE_RETRY_DELAY_MS = 5000;
+const PROVIDER_ERROR_MESSAGE_MAX_LENGTH = 16_384;
 const MILLISECONDS_PER_WEEK = 7 * 24 * 60 * 60 * 1000;
 const SYNTHETIC_PROMPT = "Reply with exactly OK.";
 export const PDF_CANARY_TOKEN = "STELLA_PDF_CANARY_OK";
@@ -189,6 +190,32 @@ type CanaryRunStage =
 
 const PROVIDER_ERROR_NESTED_KEYS = ["rawEvent", "error", "cause"] as const;
 
+const providerErrorBodyFromMessage = (
+  error: Record<string, unknown>,
+): Record<string, unknown> | null => {
+  if (PROVIDER_ERROR_NESTED_KEYS.some((key) => error[key] !== undefined)) {
+    return null;
+  }
+
+  const message = error["message"];
+  if (typeof message !== "string") {
+    return null;
+  }
+  if (message.length > PROVIDER_ERROR_MESSAGE_MAX_LENGTH) {
+    return null;
+  }
+  const body = message.trimStart();
+  if (!body.startsWith("{")) {
+    return null;
+  }
+
+  const parsed = Result.try((): unknown => JSON.parse(body));
+  if (Result.isError(parsed) || !isRecord(parsed.value)) {
+    return null;
+  }
+  return parsed.value;
+};
+
 const explicitRetryability = (error: unknown, depth = 0): boolean | null => {
   if (!isRecord(error)) {
     return null;
@@ -215,6 +242,13 @@ const explicitRetryability = (error: unknown, depth = 0): boolean | null => {
         return nestedRetryability;
       }
     }
+    const messageRetryability = explicitRetryability(
+      providerErrorBodyFromMessage(error),
+      depth + 1,
+    );
+    if (messageRetryability !== null) {
+      return messageRetryability;
+    }
   }
   return null;
 };
@@ -230,6 +264,13 @@ const rawProviderCode = (error: unknown, depth = 0): string | null => {
       if (nestedCode !== null) {
         return nestedCode;
       }
+    }
+    const messageCode = rawProviderCode(
+      providerErrorBodyFromMessage(error),
+      depth + 1,
+    );
+    if (messageCode !== null) {
+      return messageCode;
     }
   }
 
@@ -251,6 +292,13 @@ const providerStatus = (error: unknown, depth = 0): number | null => {
       if (nestedStatus !== null) {
         return nestedStatus;
       }
+    }
+    const messageStatus = providerStatus(
+      providerErrorBodyFromMessage(error),
+      depth + 1,
+    );
+    if (messageStatus !== null) {
+      return messageStatus;
     }
   }
 
@@ -297,6 +345,13 @@ const terminalProviderCode = (error: unknown, depth = 0): string | null => {
         return nestedCode;
       }
     }
+    const messageCode = terminalProviderCode(
+      providerErrorBodyFromMessage(error),
+      depth + 1,
+    );
+    if (messageCode !== null) {
+      return messageCode;
+    }
   }
   return null;
 };
@@ -333,11 +388,11 @@ export const isRetryableCanaryError = (
     if (error.terminalCode !== null) {
       return false;
     }
-    if (error.status !== null) {
-      return isRetryableProviderStatus(error.status);
-    }
     if (error.retryable !== null) {
       return error.retryable;
+    }
+    if (error.status !== null) {
+      return isRetryableProviderStatus(error.status);
     }
     return error.retryCode === null || isRetryableProviderCode(error.retryCode);
   }
@@ -346,13 +401,13 @@ export const isRetryableCanaryError = (
   if (terminalProviderCode(error) !== null) {
     return false;
   }
-  const status = providerStatus(error);
-  if (status !== null) {
-    return isRetryableProviderStatus(status);
-  }
   const retryable = explicitRetryability(error);
   if (retryable !== null) {
     return retryable;
+  }
+  const status = providerStatus(error);
+  if (status !== null) {
+    return isRetryableProviderStatus(status);
   }
   return isRetryableProviderCode(code);
 };

--- a/apps/api/scripts/ai-provider-canary.ts
+++ b/apps/api/scripts/ai-provider-canary.ts
@@ -177,31 +177,43 @@ type CanaryRunStage =
   | "after-tool-call"
   | "after-tool-result";
 
-const providerCode = (error: unknown, depth = 0): string | null => {
+const PROVIDER_ERROR_NESTED_KEYS = ["rawEvent", "error", "cause"] as const;
+
+const rawProviderCode = (error: unknown, depth = 0): string | null => {
   if (!isRecord(error)) {
     return null;
   }
-  const code = error["code"];
-  if (typeof code === "string" && SAFE_PROVIDER_CODES.has(code)) {
-    return code;
-  }
 
-  if (depth >= 3) {
-    return null;
-  }
-  for (const key of ["rawEvent", "error", "cause"] as const) {
-    const nestedCode = providerCode(error[key], depth + 1);
-    if (nestedCode !== null) {
-      return nestedCode;
+  if (depth < 3) {
+    for (const key of PROVIDER_ERROR_NESTED_KEYS) {
+      const nestedCode = rawProviderCode(error[key], depth + 1);
+      if (nestedCode !== null) {
+        return nestedCode;
+      }
     }
   }
-  return null;
+
+  const code = error["code"];
+  return typeof code === "string" ? code : null;
 };
+
+const safeProviderCode = (code: string | null): string | null =>
+  code !== null && SAFE_PROVIDER_CODES.has(code) ? code : null;
 
 const providerStatus = (error: unknown, depth = 0): number | null => {
   if (!isRecord(error)) {
     return null;
   }
+
+  if (depth < 3) {
+    for (const key of PROVIDER_ERROR_NESTED_KEYS) {
+      const nestedStatus = providerStatus(error[key], depth + 1);
+      if (nestedStatus !== null) {
+        return nestedStatus;
+      }
+    }
+  }
+
   for (const key of ["status", "statusCode", "code"] as const) {
     const value = error[key];
     if (
@@ -213,16 +225,6 @@ const providerStatus = (error: unknown, depth = 0): number | null => {
       return value;
     }
   }
-
-  if (depth >= 3) {
-    return null;
-  }
-  for (const key of ["rawEvent", "error", "cause"] as const) {
-    const nestedStatus = providerStatus(error[key], depth + 1);
-    if (nestedStatus !== null) {
-      return nestedStatus;
-    }
-  }
   return null;
 };
 
@@ -231,13 +233,15 @@ const isRetryableProviderStatus = (status: number): boolean =>
 
 export class CanaryProviderRunError extends TypeError {
   readonly code: string | null;
+  readonly retryCode: string | null;
   readonly stage: CanaryRunStage;
   readonly status: number | null;
 
   constructor(event: unknown, stage: CanaryRunStage) {
     super("Provider stream failed.");
     this.name = "CanaryProviderRunError";
-    this.code = providerCode(event);
+    this.retryCode = rawProviderCode(event);
+    this.code = safeProviderCode(this.retryCode);
     this.stage = stage;
     this.status = providerStatus(event);
   }
@@ -255,7 +259,9 @@ export const isRetryableCanaryError = (
     if (error.status !== null) {
       return isRetryableProviderStatus(error.status);
     }
-    return error.code === null || RETRYABLE_PROVIDER_CODES.has(error.code);
+    return (
+      error.retryCode === null || RETRYABLE_PROVIDER_CODES.has(error.retryCode)
+    );
   }
 
   const status = providerStatus(error);
@@ -1033,6 +1039,30 @@ const probeLabel = (context: CanaryContext, probe: Probe): string => {
 const attemptSummary = (attempts: number): string =>
   attempts === 1 ? "" : ` after ${attempts} attempts`;
 
+type RecordProbeResultOptions = {
+  label: string;
+  provider: CanaryProvider;
+  result: CanaryProbeResult;
+};
+
+const recordProbeResult = ({
+  label,
+  provider,
+  result,
+}: RecordProbeResultOptions): number => {
+  if (result.status === "passed") {
+    console.log(
+      `[ai-canary] ${provider}/${label}: passed${attemptSummary(result.attempts)}`,
+    );
+    return 0;
+  }
+
+  console.error(
+    `[ai-canary] ${provider}/${label}: failed${attemptSummary(result.attempts)} (${errorSummary(result.error, result.signal)})`,
+  );
+  return 1;
+};
+
 const run = async (): Promise<void> => {
   const args = parseCanaryRunArgs(Bun.argv.slice(2));
   const { provider } = args;
@@ -1108,17 +1138,12 @@ const runProbes = async (
     },
     timeoutMs: probe.timeoutMs,
   });
-  if (result.status === "passed") {
-    console.log(
-      `[ai-canary] ${context.provider}/${label}: passed${attemptSummary(result.attempts)}`,
-    );
-    return await runProbes(context, index + 1, failures);
-  }
-
-  console.error(
-    `[ai-canary] ${context.provider}/${label}: failed${attemptSummary(result.attempts)} (${errorSummary(result.error, result.signal)})`,
-  );
-  return await runProbes(context, index + 1, failures + 1);
+  const failureDelta = recordProbeResult({
+    label,
+    provider: context.provider,
+    result,
+  });
+  return await runProbes(context, index + 1, failures + failureDelta);
 };
 
 const runWeeklyCanaryProbes = async (
@@ -1136,16 +1161,11 @@ const runWeeklyCanaryProbes = async (
       },
       timeoutMs: MODEL_ROLE_PROBE_TIMEOUT_MS,
     });
-    if (result.status === "passed") {
-      console.log(
-        `[ai-canary] ${context.provider}/${label}: passed${attemptSummary(result.attempts)}`,
-      );
-    } else {
-      console.error(
-        `[ai-canary] ${context.provider}/${label}: failed${attemptSummary(result.attempts)} (${errorSummary(result.error, result.signal)})`,
-      );
-      totalFailures += 1;
-    }
+    totalFailures += recordProbeResult({
+      label,
+      provider: context.provider,
+      result,
+    });
 
     const structuredLabel = `weekly-structured-role-${role}:${context.rotation.modelId}`;
     // oxlint-disable-next-line no-await-in-loop -- structured probes share the same provider quota and must remain sequential.
@@ -1159,16 +1179,11 @@ const runWeeklyCanaryProbes = async (
       },
       timeoutMs: MODEL_ROLE_PROBE_TIMEOUT_MS,
     });
-    if (structuredResult.status === "passed") {
-      console.log(
-        `[ai-canary] ${context.provider}/${structuredLabel}: passed${attemptSummary(structuredResult.attempts)}`,
-      );
-    } else {
-      console.error(
-        `[ai-canary] ${context.provider}/${structuredLabel}: failed${attemptSummary(structuredResult.attempts)} (${errorSummary(structuredResult.error, structuredResult.signal)})`,
-      );
-      totalFailures += 1;
-    }
+    totalFailures += recordProbeResult({
+      label: structuredLabel,
+      provider: context.provider,
+      result: structuredResult,
+    });
   }
 
   const label = `weekly-tool-${context.rotation.toolShape}:${context.rotation.modelId}`;
@@ -1178,17 +1193,10 @@ const runWeeklyCanaryProbes = async (
     },
     timeoutMs: TOOL_ROUND_TRIP_PROBE_TIMEOUT_MS,
   });
-  if (result.status === "passed") {
-    console.log(
-      `[ai-canary] ${context.provider}/${label}: passed${attemptSummary(result.attempts)}`,
-    );
-    return totalFailures;
-  }
-
-  console.error(
-    `[ai-canary] ${context.provider}/${label}: failed${attemptSummary(result.attempts)} (${errorSummary(result.error, result.signal)})`,
+  return (
+    totalFailures +
+    recordProbeResult({ label, provider: context.provider, result })
   );
-  return totalFailures + 1;
 };
 
 if (import.meta.main) {

--- a/apps/api/scripts/ai-provider-canary.ts
+++ b/apps/api/scripts/ai-provider-canary.ts
@@ -172,12 +172,52 @@ const RETRYABLE_PROVIDER_CODES = new Set([
   "timeout_error",
 ]);
 
+const RETRYABLE_TRANSPORT_CODES = new Set([
+  "EAI_AGAIN",
+  "ECONNABORTED",
+  "ECONNRESET",
+  "ETIMEDOUT",
+  "UND_ERR_CONNECT_TIMEOUT",
+  "UND_ERR_HEADERS_TIMEOUT",
+  "UND_ERR_SOCKET",
+]);
+
 type CanaryRunStage =
   | "before-tool-call"
   | "after-tool-call"
   | "after-tool-result";
 
 const PROVIDER_ERROR_NESTED_KEYS = ["rawEvent", "error", "cause"] as const;
+
+const explicitRetryability = (error: unknown, depth = 0): boolean | null => {
+  if (!isRecord(error)) {
+    return null;
+  }
+
+  for (const key of ["retryable", "isRetryable"] as const) {
+    const value = error[key];
+    if (typeof value === "boolean") {
+      return value;
+    }
+  }
+  const smithyRetryable = error["$retryable"];
+  if (typeof smithyRetryable === "boolean") {
+    return smithyRetryable;
+  }
+  if (isRecord(smithyRetryable)) {
+    return true;
+  }
+
+  if (depth < 3) {
+    for (const key of PROVIDER_ERROR_NESTED_KEYS) {
+      const nestedRetryability = explicitRetryability(error[key], depth + 1);
+      if (nestedRetryability !== null) {
+        return nestedRetryability;
+      }
+    }
+  }
+  return null;
+};
 
 const rawProviderCode = (error: unknown, depth = 0): string | null => {
   if (!isRecord(error)) {
@@ -231,9 +271,14 @@ const providerStatus = (error: unknown, depth = 0): number | null => {
 const isRetryableProviderStatus = (status: number): boolean =>
   status === 429 || status >= 500;
 
+const isRetryableProviderCode = (code: string | null): boolean =>
+  code !== null &&
+  (RETRYABLE_PROVIDER_CODES.has(code) || RETRYABLE_TRANSPORT_CODES.has(code));
+
 export class CanaryProviderRunError extends TypeError {
   readonly code: string | null;
   readonly retryCode: string | null;
+  readonly retryable: boolean | null;
   readonly stage: CanaryRunStage;
   readonly status: number | null;
 
@@ -241,6 +286,7 @@ export class CanaryProviderRunError extends TypeError {
     super("Provider stream failed.");
     this.name = "CanaryProviderRunError";
     this.retryCode = rawProviderCode(event);
+    this.retryable = explicitRetryability(event);
     this.code = safeProviderCode(this.retryCode);
     this.stage = stage;
     this.status = providerStatus(event);
@@ -259,13 +305,21 @@ export const isRetryableCanaryError = (
     if (error.status !== null) {
       return isRetryableProviderStatus(error.status);
     }
-    return (
-      error.retryCode === null || RETRYABLE_PROVIDER_CODES.has(error.retryCode)
-    );
+    if (error.retryable !== null) {
+      return error.retryable;
+    }
+    return error.retryCode === null || isRetryableProviderCode(error.retryCode);
   }
 
   const status = providerStatus(error);
-  return status !== null && isRetryableProviderStatus(status);
+  if (status !== null) {
+    return isRetryableProviderStatus(status);
+  }
+  const retryable = explicitRetryability(error);
+  if (retryable !== null) {
+    return retryable;
+  }
+  return isRetryableProviderCode(rawProviderCode(error));
 };
 
 type CanaryProbeResult =

--- a/scripts/env-tool.test.ts
+++ b/scripts/env-tool.test.ts
@@ -25,6 +25,8 @@ import {
   validateDoctorEnvironment,
 } from "./env-tool";
 
+const BUN_ENV_REJECTION_TEST_TIMEOUT_MS = 15_000;
+
 describe("generated environment examples", () => {
   test("contain every documented schema entry exactly once", () => {
     const examples = {
@@ -131,13 +133,17 @@ describe("environment file parsing", () => {
     });
   });
 
-  test("fails closed when Bun rejects nested fallbacks", () => {
-    expect(() =>
-      parseEnvText(`DB_PORT=\${MISSING_PORT:-\${PGPORT:-5432}}`, {
-        PGPORT: "6432",
-      }),
-    ).toThrow("Bun failed to load environment layers.");
-  });
+  test(
+    "fails closed when Bun rejects nested fallbacks",
+    () => {
+      expect(() =>
+        parseEnvText(`DB_PORT=\${MISSING_PORT:-\${PGPORT:-5432}}`, {
+          PGPORT: "6432",
+        }),
+      ).toThrow("Bun failed to load environment layers.");
+    },
+    BUN_ENV_REJECTION_TEST_TIMEOUT_MS,
+  );
 
   test("matches Bun consecutive-dollar expansion", () => {
     const dollars = String.fromCodePoint(36);

--- a/scripts/env-tool.ts
+++ b/scripts/env-tool.ts
@@ -152,7 +152,7 @@ export const renderCollabEnvExample = () =>
 
 const BUN_ENV_READER =
   'const names=JSON.parse(process.argv[1]??"[]");process.stdout.write(JSON.stringify(Object.fromEntries(names.map(name=>[name,process.env[name]??""]))));';
-const BUN_ENV_LOAD_TIMEOUT_MS = 1000;
+const BUN_ENV_LOAD_TIMEOUT_MS = 10_000;
 
 const definedEnvironment = (environment: NodeJS.ProcessEnv) => {
   const defined: Record<string, string> = {};


### PR DESCRIPTION
## Summary

- retry transient provider failures once with a fresh timeout
- validate successful tool execution and arguments without requiring exact assistant wording
- expand the workflow timeout for bounded retries and make environment loading resilient under CI saturation
- cover retry classification and tool execution with invariant tests

## Rationale

The scheduled canary failed immediately on transient provider 429 and 5xx responses, while its tool probes also treated presentation text as part of the execution contract. The environment helper used a one-second child-process timeout that could expire on a saturated runner.

## Validation

- bun run verify
- bun run security:audit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved AI provider health checks by retrying temporary network, rate-limit and server errors.
  - Canary results now retain failure details and show the number of attempts made.
  - Tool validation now accepts successful executions without requiring text output.
  - Reduced false failures for valid weekly tool checks.

- **Reliability**
  - Extended the monitoring window for slower weekly checks.
  - Increased the environment configuration loading timeout to better support slower setups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->