### PR TITLE
fix: gate staging deploy on health

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -81,7 +81,8 @@ jobs:
     needs: staging-health
     if: >-
       github.ref == 'refs/heads/main' &&
-      needs.staging-health.outputs.status == 'ready'
+      (github.event_name == 'workflow_dispatch' ||
+      needs.staging-health.outputs.status == 'ready')
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 90
     permissions:

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -18,9 +18,70 @@ env:
   IMAGE_NAME: ${{ github.repository_owner }}/stella-api
 
 jobs:
+  # Tie promotion and its dependent smoke job to the current health of the
+  # staging environment.
+  staging-health:
+    name: Check staging health
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 2
+    permissions: {}
+    outputs:
+      status: ${{ steps.probe.outputs.status }}
+
+    steps:
+      - name: Probe staging health
+        id: probe
+        env:
+          STAGING_HEALTH_URL: https://api-staging.stll.app/health
+        run: |
+          set -euo pipefail
+
+          readonly READY_STATUS="ready"
+          readonly NOT_READY_STATUS="not_ready"
+          readonly MAX_ATTEMPTS=3
+          readonly RETRY_SECONDS=5
+
+          response_file="$RUNNER_TEMP/staging-health.json"
+          status="$NOT_READY_STATUS"
+          for ((attempt = 1; attempt <= MAX_ATTEMPTS; attempt += 1)); do
+            http_status="000"
+            if ! http_status="$(
+              curl \
+                --connect-timeout 5 \
+                --max-time 10 \
+                --output "$response_file" \
+                --silent \
+                --show-error \
+                --write-out '%{http_code}' \
+                "$STAGING_HEALTH_URL"
+            )"; then
+              http_status="000"
+            fi
+
+            if [[ "$http_status" == "200" ]] &&
+              jq -e '.status == "ok"' "$response_file" >/dev/null 2>&1; then
+              status="$READY_STATUS"
+              break
+            fi
+
+            echo "Staging health probe ${attempt}/${MAX_ATTEMPTS} returned HTTP ${http_status}."
+            if (( attempt < MAX_ATTEMPTS )); then
+              sleep "$RETRY_SECONDS"
+            fi
+          done
+
+          echo "status=${status}" >> "$GITHUB_OUTPUT"
+          if [[ "$status" == "$NOT_READY_STATUS" ]]; then
+            echo "::notice::Staging health gate did not pass; skipping this deployment."
+          fi
+
   build-and-deploy:
     name: Build + deploy staging
-    if: github.ref == 'refs/heads/main'
+    needs: staging-health
+    if: >-
+      github.ref == 'refs/heads/main' &&
+      needs.staging-health.outputs.status == 'ready'
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 90
     permissions:

--- a/scripts/check-api-deployment.test.ts
+++ b/scripts/check-api-deployment.test.ts
@@ -30,6 +30,7 @@ describe("API deployment health receipt", () => {
       "Staging health gate did not pass; skipping this deployment.",
     );
     expect(deployJob).toContain("needs: staging-health");
+    expect(deployJob).toContain("github.event_name == 'workflow_dispatch'");
     expect(deployJob).toContain(
       "needs.staging-health.outputs.status == 'ready'",
     );

--- a/scripts/check-api-deployment.test.ts
+++ b/scripts/check-api-deployment.test.ts
@@ -4,6 +4,37 @@ import { getApiHealthUrl, parseHealthCommit } from "./api-health";
 import { advanceDeploymentStability } from "./check-api-deployment";
 
 describe("API deployment health receipt", () => {
+  test("ties staging promotion to the current health gate", async () => {
+    const workflow = await Bun.file(
+      new URL("../.github/workflows/deploy-staging.yml", import.meta.url),
+    ).text();
+    const healthJobStart = workflow.indexOf("\n  staging-health:\n");
+    const deployJobStart = workflow.indexOf("\n  build-and-deploy:\n");
+    const verifyJobStart = workflow.indexOf("\n  verify-staging:\n");
+    const healthJob = workflow.slice(healthJobStart, deployJobStart);
+    const deployJob = workflow.slice(deployJobStart, verifyJobStart);
+
+    expect(healthJobStart).toBeGreaterThanOrEqual(0);
+    expect(deployJobStart).toBeGreaterThan(healthJobStart);
+    expect(verifyJobStart).toBeGreaterThan(deployJobStart);
+    expect(healthJob).toContain("permissions: {}");
+    expect(healthJob).toContain(
+      "STAGING_HEALTH_URL: https://api-staging.stll.app/health",
+    );
+    expect(healthJob).toContain('readonly NOT_READY_STATUS="not_ready"');
+    expect(healthJob).toContain('readonly READY_STATUS="ready"');
+    expect(healthJob).toContain('status="$NOT_READY_STATUS"');
+    expect(healthJob).toContain('status="$READY_STATUS"');
+    expect(healthJob).toContain(`echo "status=\${status}" >> "$GITHUB_OUTPUT"`);
+    expect(healthJob).toContain(
+      "Staging health gate did not pass; skipping this deployment.",
+    );
+    expect(deployJob).toContain("needs: staging-health");
+    expect(deployJob).toContain(
+      "needs.staging-health.outputs.status == 'ready'",
+    );
+  });
+
   test("release promotion preserves the full online-migration window", async () => {
     const [releaseWorkflow, stagingWorkflow, promoteAction] = await Promise.all(
       [
@@ -49,31 +80,31 @@ describe("API deployment health receipt", () => {
     expect(manifestJobStart).toBeGreaterThan(webBuildJobStart);
     expect(promoteJob).toContain("timeout-minutes: 360");
     expect(webBuildJob).toContain("timeout-minutes: 55");
-    expect(webBuildJob).toContain('-f "inputs[release_sha]=${RELEASE_SHA}"');
-    expect(webBuildJob).toContain('-f "inputs[request_id]=${REQUEST_ID}"');
+    expect(webBuildJob).toContain(`-f "inputs[release_sha]=\${RELEASE_SHA}"`);
+    expect(webBuildJob).toContain(`-f "inputs[request_id]=\${REQUEST_ID}"`);
     expect(webBuildJob).toContain(".releaseSha == $release_sha");
     expect(webBuildJob).toContain("stella-web.intoto.jsonl");
     expect(webBuildJob).toContain(
       "actions/attest@508db95dd578ae2727ebd6217d5ba78e4fbda05d",
     );
     expect(webBuildJob).toContain(
-      'candidate_tag="candidate-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"',
+      `candidate_tag="candidate-\${GITHUB_RUN_ID}-\${GITHUB_RUN_ATTEMPT}"`,
     );
     expect(webBuildJob).toContain(".targetEnvironment == $target_environment");
-    expect(webBuildJob).not.toContain('tags+=("${IMAGE}:latest")');
+    expect(webBuildJob).not.toContain(`tags+=("\${IMAGE}:latest")`);
     expect(manifestJob).toContain(
       "bash .workflow-source/scripts/create-release-manifest.sh",
     );
     expect(manifestJob).toContain("Publish immutable release image tags");
     expect(manifestJob).toContain(
-      "Immutable image tag ${image}:${tag} points to a different digest.",
+      `Immutable image tag \${image}:\${tag} points to a different digest.`,
     );
     expect(manifestJob).toContain('"STELLA_COMMIT_SHA=" + $commit');
     expect(manifestJob.indexOf("Publish GitHub release manifest")).toBeLessThan(
       manifestJob.indexOf("Advance stable image tags"),
     );
     expect(releaseWorkflow).toContain(
-      "group: release-${{ github.event_name == 'workflow_dispatch' && inputs.release_ref || github.ref_name }}",
+      `group: release-\${{ github.event_name == 'workflow_dispatch' && inputs.release_ref || github.ref_name }}`,
     );
     expect(releaseWorkflow).toContain(
       "needs: [resolve, build-arm64, build-amd64, prepare-web-image, smoke]",
@@ -87,18 +118,18 @@ describe("API deployment health receipt", () => {
     );
     expect(promoteAction).toContain('"/installation/token"');
     expect(promoteAction).toContain("retaining the current token and retrying");
-    expect(promoteAction).toContain('echo "::add-mask::${jwt}" >&2');
+    expect(promoteAction).toContain(`echo "::add-mask::\${jwt}" >&2`);
     expect(promoteAction).toContain(`printf '%s\\n' "$APP_PRIVATE_KEY"`);
     expect(
       promoteAction.match(/Authorization: Bearer \$\{jwt\}/gu),
     ).toHaveLength(2);
     expect(promoteAction).not.toContain("gh run watch");
     expect(promoteAction).toContain(
-      'run_url="https://github.com/${INFRA_REPO}/actions/runs/${run_id}"',
+      `run_url="https://github.com/\${INFRA_REPO}/actions/runs/\${run_id}"`,
     );
-    expect(promoteAction).not.toContain("Check https://github.com/${run_url}");
+    expect(promoteAction).not.toContain(`Check https://github.com/\${run_url}`);
     expect(promoteAction).toContain(
-      '-f "inputs[web_image_digest]=${WEB_IMAGE_DIGEST}"',
+      `-f "inputs[web_image_digest]=\${WEB_IMAGE_DIGEST}"`,
     );
     expect(promoteAction).toContain(
       "Tagged frontend promotions require a prebuilt web image digest.",


### PR DESCRIPTION
Gate continuous staging promotion on the existing health endpoint. When the health gate does not pass, promotion and dependent verification skip cleanly; normal build and promotion failures remain blocking once the gate passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved staging deployment reliability by verifying service health before promotion.
  * Deployments now proceed only when staging is available and reports a healthy status.
  * Added limited health-check retries and clearer notifications when staging is unavailable.

* **Tests**
  * Added coverage to verify staging health validation and deployment sequencing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->