### PR TITLE
fix(api): collect a document's uploaded files

### DIFF
--- a/apps/api/src/handlers/entities/download-zip.ts
+++ b/apps/api/src/handlers/entities/download-zip.ts
@@ -1,4 +1,4 @@
-import { panic, Result } from "better-result";
+import { Result } from "better-result";
 import { makeZip } from "client-zip";
 import { and, eq, inArray, sql } from "drizzle-orm";
 
@@ -7,10 +7,14 @@ import { entities, entityVersions, fields } from "@/api/db/schema";
 import {
   buildArchivePaths,
   buildErrorManifest,
+  groupFileContentsByEntityId,
   mapOrderedConcurrent,
   uniquePath,
 } from "@/api/handlers/entities/zip-archive";
-import type { ArchiveNode } from "@/api/handlers/entities/zip-archive";
+import type {
+  ArchiveFileContent,
+  ArchiveNode,
+} from "@/api/handlers/entities/zip-archive";
 import { captureError } from "@/api/lib/analytics/capture";
 import { createSafeHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
@@ -145,10 +149,7 @@ const downloadZipHandler = async function* ({
   );
 
   // Uploaded-file content for the document descendants, in one query.
-  const fileContentsByEntityId = new Map<
-    string,
-    { fileId: string; fileName: string; mimeType: string }[]
-  >();
+  let fileContentsByEntityId = new Map<string, ArchiveFileContent[]>();
   if (descendants.length > 0) {
     const descendantIds = descendants.map((node) =>
       brandPersistedEntityId(node.id),
@@ -176,19 +177,21 @@ const downloadZipHandler = async function* ({
           .where(inArray(entityVersions.entityId, descendantIds)),
       ),
     );
-    for (const row of fieldRows) {
-      if (row.content.type === "file") {
-        const entityFileContents =
-          fileContentsByEntityId.get(String(row.entityId)) ??
-          panic("File contents missing for downloadable entity");
-        entityFileContents.push({
-          fileId: row.content.id,
-          fileName: row.content.fileName,
-          mimeType: row.content.mimeType,
-        });
-        fileContentsByEntityId.set(String(row.entityId), entityFileContents);
-      }
-    }
+    const uploadedFiles = fieldRows.flatMap((row) =>
+      row.content.type === "file"
+        ? [
+            {
+              entityId: String(row.entityId),
+              content: {
+                fileId: row.content.id,
+                fileName: row.content.fileName,
+                mimeType: row.content.mimeType,
+              },
+            },
+          ]
+        : [],
+    );
+    fileContentsByEntityId = groupFileContentsByEntityId(uploadedFiles);
   }
 
   // Rebuild the tree → archive paths, rooted at the folder's own name.

--- a/apps/api/src/handlers/entities/zip-archive.test.ts
+++ b/apps/api/src/handlers/entities/zip-archive.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "bun:test";
 import {
   buildArchivePaths,
   buildErrorManifest,
+  groupFileContentsByEntityId,
   mapOrderedConcurrent,
   uniquePath,
 } from "./zip-archive";
@@ -173,6 +174,34 @@ describe("buildArchivePaths", () => {
     const paths = buildArchivePaths({ rootId: "root", rootName: "R", nodes });
     expect(paths.get("a")?.startsWith("R")).toBe(true);
     expect(paths.get("b")?.startsWith("R")).toBe(true);
+  });
+});
+
+describe("groupFileContentsByEntityId", () => {
+  const file = (fileId: string) => ({
+    fileId,
+    fileName: `${fileId}.pdf`,
+    mimeType: "application/pdf",
+  });
+
+  test("keeps every file of an entity, in input order", () => {
+    const grouped = groupFileContentsByEntityId([
+      { entityId: "doc_1", content: file("a") },
+      { entityId: "doc_2", content: file("b") },
+      { entityId: "doc_1", content: file("c") },
+    ]);
+
+    expect(grouped.get("doc_1")?.map((c) => c.fileId)).toEqual(["a", "c"]);
+    expect(grouped.get("doc_2")?.map((c) => c.fileId)).toEqual(["b"]);
+  });
+
+  test("leaves entities without a file absent", () => {
+    expect(groupFileContentsByEntityId([]).size).toBe(0);
+    expect(
+      groupFileContentsByEntityId([
+        { entityId: "doc_1", content: file("a") },
+      ]).get("doc_2"),
+    ).toBeUndefined();
   });
 });
 

--- a/apps/api/src/handlers/entities/zip-archive.ts
+++ b/apps/api/src/handlers/entities/zip-archive.ts
@@ -194,9 +194,15 @@ export const groupFileContentsByEntityId = (
 ): Map<string, ArchiveFileContent[]> => {
   const contentsByEntityId = new Map<string, ArchiveFileContent[]>();
   for (const { entityId, content } of files) {
-    const contents = contentsByEntityId.get(entityId) ?? [];
+    const contents = contentsByEntityId.get(entityId);
+    // Absent means "no file seen for this document yet", the normal state
+    // on first encounter, so start the list rather than treating the miss
+    // as a violated invariant.
+    if (contents === undefined) {
+      contentsByEntityId.set(entityId, [content]);
+      continue;
+    }
     contents.push(content);
-    contentsByEntityId.set(entityId, contents);
   }
   return contentsByEntityId;
 };

--- a/apps/api/src/handlers/entities/zip-archive.ts
+++ b/apps/api/src/handlers/entities/zip-archive.ts
@@ -177,6 +177,30 @@ export const mapOrderedConcurrent = async function* <T, R>(
   }
 };
 
+/** An uploaded file held by a document descendant. */
+export type ArchiveFileContent = {
+  fileId: string;
+  fileName: string;
+  mimeType: string;
+};
+
+/**
+ * Group uploaded files by the id of the document that holds them. A
+ * document can carry several file fields, so each id maps to a list;
+ * documents without one are absent rather than mapped to an empty list.
+ */
+export const groupFileContentsByEntityId = (
+  files: readonly { entityId: string; content: ArchiveFileContent }[],
+): Map<string, ArchiveFileContent[]> => {
+  const contentsByEntityId = new Map<string, ArchiveFileContent[]>();
+  for (const { entityId, content } of files) {
+    const contents = contentsByEntityId.get(entityId) ?? [];
+    contents.push(content);
+    contentsByEntityId.set(entityId, contents);
+  }
+  return contentsByEntityId;
+};
+
 /** Body of the in-archive notice listing files that could not be fetched. */
 export const buildErrorManifest = (failedPaths: readonly string[]): string =>
   [


### PR DESCRIPTION
## Proposed change

`download-zip.ts` groups uploaded files by document id with a get-or-create idiom whose default branch is `panic()`:

```ts
const entityFileContents =
  fileContentsByEntityId.get(String(row.entityId)) ??
  panic("File contents missing for downloadable entity");
entityFileContents.push({ /* ... */ });
fileContentsByEntityId.set(String(row.entityId), entityFileContents);
```

The map is created empty and nothing else writes to it, so the lookup misses on every document's *first* file field: the handler panics before it can ever reach a second one. The `.set()` immediately after the `.push()` is the tell that this was meant to be `?? []`.

Effect: a folder subtree containing any uploaded file fails outright. Subtrees with no file-typed field still stream fine, because the branch never runs, which is why the archive-path and streaming helpers around it look healthy.

The API guidelines reserve `panic()` for structural invariants of the data model, and that is a fair reading of *"file contents missing for a downloadable entity"* in isolation. But this is an accumulator, not a lookup: an absent key means "no file seen for this document yet", which is the normal state on first encounter. Seeding each document's list empty is the correct default; a document that genuinely has no file simply stays absent from the map, which is what the downstream `.get(node.id)` already expects.

The grouping moves to `zip-archive.ts` beside the other pure archive helpers. That is where it belongs by the module's own contract ("pure helpers ... `download-zip.ts` wires these to the database, S3, and `client-zip`"), and it is also what makes the defect testable at all: reaching the accumulator through the handler requires the recursive CTE and the field join, so no unit test could previously observe it.

Verified with `bun run lint`, `bun --filter @stll/api typecheck`, and the `zip-archive` suite. The added tests fail against the previous grouping and pass against this one.

## Checklist

- [x] **BUILD ASSURANCE** | Code builds correctly and without any errors or warnings.
- [x] **TESTING** | Changes tested, including in different conditions (dark mode, language, narrow screen, etc).
- [ ] DARK MODE SUPPORT | Not applicable: API-only change, no UI surface.
- [ ] ISSUE LINKED | No existing issue.
- [ ] SCREENSHOT INCLUDED | Not applicable: no user-visible UI change.

---
_Generated by [Claude Code](https://claude.ai/code/session_017RBpH1YnPqdEiwrazGbQJi)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ZIP archive generation by reliably grouping uploaded files with their corresponding entities.
  * Preserved file order within generated archives.
  * Prevented empty entity entries from being included when no files are available.

* **Tests**
  * Added coverage for file grouping, ordering, and entities without files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->