### PR TITLE
feat(web): show file-type icons in the table export menu

### DIFF
--- a/apps/web/src/components/document-icon.logic.test.ts
+++ b/apps/web/src/components/document-icon.logic.test.ts
@@ -31,7 +31,16 @@ describe("document icon MIME classification", () => {
       getDocumentIconKind(
         "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
       ),
+    ).toBe("excel");
+  });
+
+  // The Excel mark is brand-specific: a spreadsheet that is not an Excel
+  // workbook must not carry it.
+  test("keeps non-Excel spreadsheets off the Excel mark", () => {
+    expect(
+      getDocumentIconKind("application/vnd.oasis.opendocument.spreadsheet"),
     ).toBe("spreadsheet");
+    expect(getDocumentIconKind("application/vnd.ms-excel")).toBe("excel");
   });
 
   test("classifies markdown by MIME or extension", () => {

--- a/apps/web/src/components/document-icon.logic.test.ts
+++ b/apps/web/src/components/document-icon.logic.test.ts
@@ -34,12 +34,17 @@ describe("document icon MIME classification", () => {
     ).toBe("excel");
   });
 
-  // The Excel mark is brand-specific: a spreadsheet that is not an Excel
-  // workbook must not carry it.
-  test("keeps non-Excel spreadsheets off the Excel mark", () => {
+  // Each mark names one format. A format must never borrow another's mark,
+  // so every member of the old catch-all "word"/"spreadsheet" groups is pinned.
+  test("gives RTF, ODT, and ODS their own marks", () => {
+    expect(getDocumentIconKind("application/rtf")).toBe("rtf");
+    expect(getDocumentIconKind("application/vnd.oasis.opendocument.text")).toBe(
+      "openDocumentText",
+    );
     expect(
       getDocumentIconKind("application/vnd.oasis.opendocument.spreadsheet"),
-    ).toBe("spreadsheet");
+    ).toBe("openDocumentSheet");
+    expect(getDocumentIconKind("application/msword")).toBe("word");
     expect(getDocumentIconKind("application/vnd.ms-excel")).toBe("excel");
   });
 

--- a/apps/web/src/components/document-icon.logic.test.ts
+++ b/apps/web/src/components/document-icon.logic.test.ts
@@ -23,6 +23,17 @@ describe("document icon MIME classification", () => {
     expect(getDocumentIconKind("text/plain")).toBe("text");
   });
 
+  // text/csv also matches the generic text/ prefix, so it must be classified
+  // before the text fallback to keep its own icon.
+  test("separates CSV from spreadsheet workbooks and plain text", () => {
+    expect(getDocumentIconKind("text/csv")).toBe("csv");
+    expect(
+      getDocumentIconKind(
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+      ),
+    ).toBe("spreadsheet");
+  });
+
   test("classifies markdown by MIME or extension", () => {
     expect(getDocumentIconKind("text/markdown")).toBe("markdown");
     expect(getDocumentIconKind("application/octet-stream", "notes.md")).toBe(

--- a/apps/web/src/components/document-icon.logic.ts
+++ b/apps/web/src/components/document-icon.logic.ts
@@ -8,9 +8,14 @@ const wordMimeTypes = Object.freeze({
   "application/vnd.oasis.opendocument.text": true,
 });
 
-const spreadsheetMimeTypes = Object.freeze({
+// Only the Excel formats get the Excel mark. ODS is a spreadsheet but not an
+// Excel workbook, so it keeps the unbranded spreadsheet glyph.
+const excelMimeTypes = Object.freeze({
   "application/vnd.ms-excel": true,
   "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": true,
+});
+
+const spreadsheetMimeTypes = Object.freeze({
   "application/vnd.oasis.opendocument.spreadsheet": true,
 });
 
@@ -31,6 +36,7 @@ const emailMimeTypes = Object.freeze({ [EML_MIME]: true, [MSG_MIME]: true });
 export type DocumentIconKind =
   | "pdf"
   | "word"
+  | "excel"
   | "spreadsheet"
   | "csv"
   | "image"
@@ -49,6 +55,10 @@ export const getDocumentIconKind = (
 
   if (Object.hasOwn(wordMimeTypes, mimeType)) {
     return "word";
+  }
+
+  if (Object.hasOwn(excelMimeTypes, mimeType)) {
+    return "excel";
   }
 
   if (Object.hasOwn(spreadsheetMimeTypes, mimeType)) {

--- a/apps/web/src/components/document-icon.logic.ts
+++ b/apps/web/src/components/document-icon.logic.ts
@@ -4,18 +4,25 @@ import { EML_MIME, MSG_MIME, isEmailFile, isMarkdownFile } from "@/lib/consts";
 const wordMimeTypes = Object.freeze({
   "application/msword": true,
   "application/vnd.openxmlformats-officedocument.wordprocessingml.document": true,
+});
+
+const rtfMimeTypes = Object.freeze({
   "application/rtf": true,
+  "text/rtf": true,
+});
+
+const openDocumentTextMimeTypes = Object.freeze({
   "application/vnd.oasis.opendocument.text": true,
 });
 
-// Only the Excel formats get the Excel mark. ODS is a spreadsheet but not an
-// Excel workbook, so it keeps the unbranded spreadsheet glyph.
+// Each format carries its own mark: the Excel and Word marks are reserved for
+// the formats they name, and RTF/ODT/ODS get theirs.
 const excelMimeTypes = Object.freeze({
   "application/vnd.ms-excel": true,
   "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": true,
 });
 
-const spreadsheetMimeTypes = Object.freeze({
+const openDocumentSheetMimeTypes = Object.freeze({
   "application/vnd.oasis.opendocument.spreadsheet": true,
 });
 
@@ -36,8 +43,10 @@ const emailMimeTypes = Object.freeze({ [EML_MIME]: true, [MSG_MIME]: true });
 export type DocumentIconKind =
   | "pdf"
   | "word"
+  | "rtf"
+  | "openDocumentText"
   | "excel"
-  | "spreadsheet"
+  | "openDocumentSheet"
   | "csv"
   | "image"
   | "email"
@@ -57,12 +66,20 @@ export const getDocumentIconKind = (
     return "word";
   }
 
+  if (Object.hasOwn(rtfMimeTypes, mimeType)) {
+    return "rtf";
+  }
+
+  if (Object.hasOwn(openDocumentTextMimeTypes, mimeType)) {
+    return "openDocumentText";
+  }
+
   if (Object.hasOwn(excelMimeTypes, mimeType)) {
     return "excel";
   }
 
-  if (Object.hasOwn(spreadsheetMimeTypes, mimeType)) {
-    return "spreadsheet";
+  if (Object.hasOwn(openDocumentSheetMimeTypes, mimeType)) {
+    return "openDocumentSheet";
   }
 
   if (Object.hasOwn(csvMimeTypes, mimeType)) {

--- a/apps/web/src/components/document-icon.logic.ts
+++ b/apps/web/src/components/document-icon.logic.ts
@@ -12,7 +12,11 @@ const spreadsheetMimeTypes = Object.freeze({
   "application/vnd.ms-excel": true,
   "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": true,
   "application/vnd.oasis.opendocument.spreadsheet": true,
+});
+
+const csvMimeTypes = Object.freeze({
   "text/csv": true,
+  "application/csv": true,
 });
 
 const imageMimeTypes = Object.freeze({
@@ -28,6 +32,7 @@ export type DocumentIconKind =
   | "pdf"
   | "word"
   | "spreadsheet"
+  | "csv"
   | "image"
   | "email"
   | "markdown"
@@ -48,6 +53,10 @@ export const getDocumentIconKind = (
 
   if (Object.hasOwn(spreadsheetMimeTypes, mimeType)) {
     return "spreadsheet";
+  }
+
+  if (Object.hasOwn(csvMimeTypes, mimeType)) {
+    return "csv";
   }
 
   if (Object.hasOwn(imageMimeTypes, mimeType)) {

--- a/apps/web/src/components/document-icon.tsx
+++ b/apps/web/src/components/document-icon.tsx
@@ -1,12 +1,7 @@
 import type { SVGProps } from "react";
+import { useId } from "react";
 
-import {
-  File,
-  FileImage,
-  FileSpreadsheet,
-  FileText,
-  MailIcon,
-} from "lucide-react";
+import { File, FileImage, FileText, MailIcon } from "lucide-react";
 
 import { getDocumentIconKind } from "@/components/document-icon.logic";
 import { MarkdownIcon } from "@/components/markdown-icon";
@@ -106,6 +101,324 @@ export const CsvIcon = (props: SVGProps<SVGSVGElement>) => (
   </svg>
 );
 
+export const RtfIcon = (props: SVGProps<SVGSVGElement>) => (
+  <svg
+    aria-hidden="true"
+    fill="none"
+    viewBox="0 0 48 48"
+    xmlns="http://www.w3.org/2000/svg"
+    {...props}
+  >
+    <path
+      fill="#FFF"
+      d="M9.5 44h29c.275 0 .5-.225.5-.5V14h-8.5c-.827 0-1.5-.673-1.5-1.5V4H9.5c-.275 0-.5.225-.5.5v39c0 .275.225.5.5.5z"
+    />
+    <path fill="#FFF" d="M38.293 13L30 4.707V12.5c0 .275.225.5.5.5h7.793z" />
+    <path
+      opacity=".64"
+      fill="#605E5C"
+      d="M39.56 12.854l-9.414-9.415A1.51 1.51 0 0029.086 3H9.5C8.673 3 8 3.673 8 4.5v39c0 .827.673 1.5 1.5 1.5h29c.827 0 1.5-.673 1.5-1.5V13.914c0-.4-.156-.777-.44-1.06zM30 4.707L38.293 13H30.5a.501.501 0 01-.5-.5V4.707zM38.5 44h-29a.501.501 0 01-.5-.5v-39c0-.275.225-.5.5-.5H29v8.5c0 .827.673 1.5 1.5 1.5H39v29.5c0 .275-.225.5-.5.5z"
+    />
+    <path
+      fill="#69AFE5"
+      d="M35.5 21h-14a.5.5 0 010-1h14a.5.5 0 010 1zm0 3h-14a.5.5 0 010-1h14a.5.5 0 010 1z"
+    />
+    <path fill="#0078D7" d="M35.5 27h-23a.5.5 0 010-1h23a.5.5 0 010 1z" />
+    <path
+      fill="#C8C6C4"
+      d="M22.5 30h-10a.5.5 0 010-1h10a.5.5 0 010 1zm0 3h-10a.5.5 0 010-1h10a.5.5 0 010 1zm0 3h-10a.5.5 0 010-1h10a.5.5 0 010 1z"
+    />
+    <path
+      fill="#69AFE5"
+      d="M35 36h-9a1 1 0 01-1-1v-5a1 1 0 011-1h9a1 1 0 011 1v5a1 1 0 01-1 1z"
+    />
+    <path
+      fill="#0078D7"
+      d="M20 24h-1.751l-.696-1.817h-3.187L13.708 24H12l3.105-8h1.703L20 24zm-2.964-3.165l-1.099-2.969-1.076 2.969h2.175z"
+    />
+  </svg>
+);
+
+// ODT and ODS ship generic gradient ids, so every instance namespaces them
+// with useId: two of these marks on one page would otherwise resolve each
+// other's gradients.
+export const OdtIcon = (props: SVGProps<SVGSVGElement>) => {
+  const uid = useId();
+
+  return (
+    <svg
+      aria-hidden="true"
+      fill="none"
+      viewBox="0 0 48 48"
+      xmlns="http://www.w3.org/2000/svg"
+      {...props}
+    >
+      <g>
+        <polygon fill="#FFFFFF" points="43,44 13,44 13,4 34,4 43,13" />
+        <path
+          fill="#949494"
+          d="M34.0005,3H12v42h32V13L34.0005,3z M34,4.5l8.5,8.5H34V4.5z M43,44H13V4h20v10h10V44z"
+        />
+      </g>
+      <rect x="24" y="35" fill="#C8C8C8" width="16" height="1" />
+      <rect x="24" y="32" fill="#C8C8C8" width="16" height="1" />
+      <rect x="24" y="38" fill="#C8C8C8" width="16" height="1" />
+      <polygon fill="#2B579A" points="4,17 24,14 24,40 4,37" />
+      <g>
+        <path
+          fill="#FFFFFF"
+          d="M21,22l-2.6241,10h-2.4787l-1.6479-6.4156c-0.0878-0.3347-0.1409-0.7088-0.1592-1.1227h-0.0277
+      c-0.0415,0.4558-0.1016,0.8298-0.18,1.1227L12.1929,32H9.6103L7,22h2.4441l1.3986,6.6597
+      c0.0598,0.2837,0.1039,0.665,0.1316,1.1437h0.0415c0.0183-0.3579,0.0853-0.7484,0.2008-1.1715L13.0168,22h2.3956l1.6271,6.7155
+      c0.0598,0.2466,0.113,0.6045,0.1592,1.0739h0.0277c0.0183-0.3671,0.0668-0.7392,0.1454-1.1158L18.7428,22H21z"
+        />
+      </g>
+      <g>
+        <path
+          fill="#ACBBE3"
+          d="M33.0381,18c1.0137,0,1.6631,0.5059,2.0293,0.9307c0.6475,0.7505,0.9502,1.8481,0.9063,3.0693h2.0161
+      c0.0923-3.3911-1.9761-6-4.9517-6s-5.8179,2.6089-6.7314,6h2.0923C29.2051,19.7324,31.1221,18,33.0381,18z"
+        />
+        <path
+          fill="#ACBBE3"
+          d="M30.9619,28c-1.0137,0-1.6631-0.5059-2.0293-0.9307c-0.6475-0.7505-0.9502-1.8481-0.9063-3.0693h-2.0161
+      c-0.0923,3.3911,1.9761,6,4.9517,6s5.8179-2.6089,6.7314-6h-2.0923C34.7949,26.2676,32.8779,28,30.9619,28z"
+        />
+      </g>
+      <linearGradient
+        id={`${uid}-1`}
+        gradientUnits="userSpaceOnUse"
+        x1="8.5867"
+        y1="5.8641"
+        x2="42.4893"
+        y2="46.2676"
+      >
+        <stop offset="0" stopColor="#FFFFFF" stopOpacity={0} />
+        <stop offset="0.2264" stopColor="#FCFCFC" stopOpacity={0.0226} />
+        <stop offset="0.3626" stopColor="#F4F4F4" stopOpacity={0.0363} />
+        <stop offset="0.475" stopColor="#E6E6E6" stopOpacity={0.0475} />
+        <stop offset="0.5744" stopColor="#D1D1D1" stopOpacity={0.0574} />
+        <stop offset="0.6652" stopColor="#B7B7B7" stopOpacity={0.0665} />
+        <stop offset="0.7498" stopColor="#979797" stopOpacity={0.075} />
+        <stop offset="0.8297" stopColor="#707070" stopOpacity={0.083} />
+        <stop offset="0.9057" stopColor="#444444" stopOpacity={0.0906} />
+        <stop offset="0.9761" stopColor="#121212" stopOpacity={0.0976} />
+        <stop offset="1" stopColor="#000000" stopOpacity={0.1} />
+      </linearGradient>
+      <path fill={`url(#${uid}-1)`} d="M44,13L34,3H12v42h32V13z" />
+      <linearGradient
+        id={`${uid}-2`}
+        gradientUnits="userSpaceOnUse"
+        x1="38"
+        y1="16.9063"
+        x2="38"
+        y2="14.0875"
+      >
+        <stop offset="0" stopColor="#828282" stopOpacity={0} />
+        <stop offset="0.2812" stopColor="#7F7F7F" stopOpacity={0.0281} />
+        <stop offset="0.4503" stopColor="#777777" stopOpacity={0.045} />
+        <stop offset="0.5899" stopColor="#696969" stopOpacity={0.059} />
+        <stop offset="0.7133" stopColor="#545454" stopOpacity={0.0713} />
+        <stop offset="0.8259" stopColor="#3A3A3A" stopOpacity={0.0826} />
+        <stop offset="0.9294" stopColor="#1A1A1A" stopOpacity={0.0929} />
+        <stop offset="1" stopColor="#000000" stopOpacity={0.1} />
+      </linearGradient>
+      <rect x="33" y="14" fill={`url(#${uid}-2)`} width="10" height="3" />
+      <linearGradient
+        id={`${uid}-3`}
+        gradientUnits="userSpaceOnUse"
+        x1="31.27"
+        y1="12.23"
+        x2="37.2361"
+        y2="6.2639"
+      >
+        <stop offset="0" stopColor="#FFFFFF" stopOpacity={0} />
+        <stop offset="0.8537" stopColor="#FFFFFF" stopOpacity={0.2134} />
+        <stop offset="1" stopColor="#FFFFFF" stopOpacity={0.25} />
+      </linearGradient>
+      <polygon
+        fill={`url(#${uid}-3)`}
+        points="12,3 12,4 33,4 33,14 43,14 43,28 44,28 44,13 34,3"
+      />
+      <linearGradient
+        id={`${uid}-4`}
+        gradientUnits="userSpaceOnUse"
+        x1="14"
+        y1="39.1875"
+        x2="14"
+        y2="14.7584"
+      >
+        <stop offset="0" stopColor="#FFFFFF" stopOpacity={0} />
+        <stop offset="0.8587" stopColor="#FFFFFF" stopOpacity={0.1546} />
+        <stop offset="1" stopColor="#FFFFFF" stopOpacity={0.18} />
+      </linearGradient>
+      <polygon fill={`url(#${uid}-4)`} points="24,14 4,17 4,37 24,40" />
+      <linearGradient
+        id={`${uid}-5`}
+        gradientUnits="userSpaceOnUse"
+        x1="17.7538"
+        y1="42.9183"
+        x2="18.1773"
+        y2="38.93"
+      >
+        <stop offset="0" stopColor="#828282" stopOpacity={0} />
+        <stop offset="0.1699" stopColor="#7E7E7E" stopOpacity={0.0341} />
+        <stop offset="0.346" stopColor="#717171" stopOpacity={0.0694} />
+        <stop offset="0.5248" stopColor="#5D5D5D" stopOpacity={0.1053} />
+        <stop offset="0.7057" stopColor="#404040" stopOpacity={0.1415} />
+        <stop offset="0.8863" stopColor="#1B1B1B" stopOpacity={0.1778} />
+        <stop offset="0.9972" stopColor="#000000" stopOpacity={0.2} />
+      </linearGradient>
+      <polygon fill={`url(#${uid}-5)`} points="24,43 12,43 12,38.2 24,40" />
+      <linearGradient
+        id={`${uid}-6`}
+        gradientUnits="userSpaceOnUse"
+        x1="14"
+        y1="39.1875"
+        x2="14"
+        y2="14.7584"
+      >
+        <stop offset="0" stopColor="#FFFFFF" stopOpacity={0} />
+        <stop offset="0.8587" stopColor="#FFFFFF" stopOpacity={0.1546} />
+        <stop offset="1" stopColor="#FFFFFF" stopOpacity={0.18} />
+      </linearGradient>
+      <polygon fill={`url(#${uid}-6)`} points="24,14 4,17 4,37 24,40" />
+    </svg>
+  );
+};
+
+export const OdsIcon = (props: SVGProps<SVGSVGElement>) => {
+  const uid = useId();
+
+  return (
+    <svg
+      aria-hidden="true"
+      fill="none"
+      viewBox="0 0 48 48"
+      xmlns="http://www.w3.org/2000/svg"
+      {...props}
+    >
+      <g>
+        <polygon fill="#FFFFFF" points="43,44 13,44 13,4 34,4 43,13" />
+        <path
+          fill="#949494"
+          d="M34.0005,3H12v42h32V13L34.0005,3z M34,4.5l8.5,8.5H34V4.5z M43,44H13V4h20v10h10V44z"
+        />
+      </g>
+      <rect x="24" y="35" fill="#C8C8C8" width="16" height="1" />
+      <rect x="24" y="32" fill="#C8C8C8" width="16" height="1" />
+      <rect x="24" y="38" fill="#C8C8C8" width="16" height="1" />
+      <polygon fill="#217346" points="4,17 24,14 24,40 4,37" />
+      <g>
+        <path
+          fill="#FFFFFF"
+          d="M19,33h-2.8819l-1.8585-3.9079c-0.0703-0.1449-0.143-0.4127-0.2182-0.8033h-0.0301
+      c-0.0353,0.1841-0.118,0.4631-0.2483,0.8368L11.8969,33H9l3.4387-6l-3.1452-6h2.9571l1.5425,3.5983
+      c0.1204,0.2845,0.2281,0.6221,0.3236,1.0126h0.0301c0.0602-0.2343,0.1731-0.5829,0.3386-1.046L16.2009,21h2.7088l-3.2355,5.9498
+      L19,33z"
+        />
+      </g>
+      <g>
+        <path
+          fill="#8BBF8A"
+          d="M33.0381,18c1.0137,0,1.6631,0.5059,2.0293,0.9307c0.6475,0.7505,0.9502,1.8481,0.9063,3.0693h2.0161
+      c0.0923-3.3911-1.9761-6-4.9517-6s-5.8179,2.6089-6.7314,6h2.0923C29.2051,19.7324,31.1221,18,33.0381,18z"
+        />
+        <path
+          fill="#8BBF8A"
+          d="M30.9619,28c-1.0137,0-1.6631-0.5059-2.0293-0.9307c-0.6475-0.7505-0.9502-1.8481-0.9063-3.0693h-2.0161
+      c-0.0923,3.3911,1.9761,6,4.9517,6s5.8179-2.6089,6.7314-6h-2.0923C34.7949,26.2676,32.8779,28,30.9619,28z"
+        />
+      </g>
+      <linearGradient
+        id={`${uid}-1`}
+        gradientUnits="userSpaceOnUse"
+        x1="8.5867"
+        y1="5.8641"
+        x2="42.4893"
+        y2="46.2676"
+      >
+        <stop offset="0" stopColor="#FFFFFF" stopOpacity={0} />
+        <stop offset="0.2264" stopColor="#FCFCFC" stopOpacity={0.0226} />
+        <stop offset="0.3626" stopColor="#F4F4F4" stopOpacity={0.0363} />
+        <stop offset="0.475" stopColor="#E6E6E6" stopOpacity={0.0475} />
+        <stop offset="0.5744" stopColor="#D1D1D1" stopOpacity={0.0574} />
+        <stop offset="0.6652" stopColor="#B7B7B7" stopOpacity={0.0665} />
+        <stop offset="0.7498" stopColor="#979797" stopOpacity={0.075} />
+        <stop offset="0.8297" stopColor="#707070" stopOpacity={0.083} />
+        <stop offset="0.9057" stopColor="#444444" stopOpacity={0.0906} />
+        <stop offset="0.9761" stopColor="#121212" stopOpacity={0.0976} />
+        <stop offset="1" stopColor="#000000" stopOpacity={0.1} />
+      </linearGradient>
+      <path fill={`url(#${uid}-1)`} d="M44,13L34,3H12v42h32V13z" />
+      <linearGradient
+        id={`${uid}-2`}
+        gradientUnits="userSpaceOnUse"
+        x1="38"
+        y1="16.9063"
+        x2="38"
+        y2="14.0875"
+      >
+        <stop offset="0" stopColor="#828282" stopOpacity={0} />
+        <stop offset="0.2812" stopColor="#7F7F7F" stopOpacity={0.0281} />
+        <stop offset="0.4503" stopColor="#777777" stopOpacity={0.045} />
+        <stop offset="0.5899" stopColor="#696969" stopOpacity={0.059} />
+        <stop offset="0.7133" stopColor="#545454" stopOpacity={0.0713} />
+        <stop offset="0.8259" stopColor="#3A3A3A" stopOpacity={0.0826} />
+        <stop offset="0.9294" stopColor="#1A1A1A" stopOpacity={0.0929} />
+        <stop offset="1" stopColor="#000000" stopOpacity={0.1} />
+      </linearGradient>
+      <rect x="33" y="14" fill={`url(#${uid}-2)`} width="10" height="3" />
+      <linearGradient
+        id={`${uid}-3`}
+        gradientUnits="userSpaceOnUse"
+        x1="31.27"
+        y1="12.23"
+        x2="37.2361"
+        y2="6.2639"
+      >
+        <stop offset="0" stopColor="#FFFFFF" stopOpacity={0} />
+        <stop offset="0.8537" stopColor="#FFFFFF" stopOpacity={0.2134} />
+        <stop offset="1" stopColor="#FFFFFF" stopOpacity={0.25} />
+      </linearGradient>
+      <polygon
+        fill={`url(#${uid}-3)`}
+        points="12,3 12,4 33,4 33,14 43,14 43,28 44,28 44,13 34,3"
+      />
+      <linearGradient
+        id={`${uid}-4`}
+        gradientUnits="userSpaceOnUse"
+        x1="17.7538"
+        y1="42.9183"
+        x2="18.1773"
+        y2="38.93"
+      >
+        <stop offset="0" stopColor="#828282" stopOpacity={0} />
+        <stop offset="0.1699" stopColor="#7E7E7E" stopOpacity={0.0341} />
+        <stop offset="0.346" stopColor="#717171" stopOpacity={0.0694} />
+        <stop offset="0.5248" stopColor="#5D5D5D" stopOpacity={0.1053} />
+        <stop offset="0.7057" stopColor="#404040" stopOpacity={0.1415} />
+        <stop offset="0.8863" stopColor="#1B1B1B" stopOpacity={0.1778} />
+        <stop offset="0.9972" stopColor="#000000" stopOpacity={0.2} />
+      </linearGradient>
+      <polygon fill={`url(#${uid}-4)`} points="24,43 12,43 12,38.2 24,40" />
+      <linearGradient
+        id={`${uid}-5`}
+        gradientUnits="userSpaceOnUse"
+        x1="14"
+        y1="39.1875"
+        x2="14"
+        y2="14.7584"
+      >
+        <stop offset="0" stopColor="#FFFFFF" stopOpacity={0} />
+        <stop offset="0.8587" stopColor="#FFFFFF" stopOpacity={0.1546} />
+        <stop offset="1" stopColor="#FFFFFF" stopOpacity={0.18} />
+      </linearGradient>
+      <polygon fill={`url(#${uid}-5)`} points="24,14 4,17 4,37 24,40" />
+    </svg>
+  );
+};
+
 type PdfIconProps = {
   className?: string | undefined;
 };
@@ -172,12 +485,20 @@ export function DocumentIcon({
     return <DocxIcon className={className} />;
   }
 
+  if (iconKind === "rtf") {
+    return <RtfIcon className={className} />;
+  }
+
+  if (iconKind === "openDocumentText") {
+    return <OdtIcon className={className} />;
+  }
+
   if (iconKind === "excel") {
     return <XlsxIcon className={className} />;
   }
 
-  if (iconKind === "spreadsheet") {
-    return <FileSpreadsheet className={className} />;
+  if (iconKind === "openDocumentSheet") {
+    return <OdsIcon className={className} />;
   }
 
   if (iconKind === "csv") {

--- a/apps/web/src/components/document-icon.tsx
+++ b/apps/web/src/components/document-icon.tsx
@@ -1,37 +1,14 @@
-import {
-  File,
-  FileImage,
-  FileSpreadsheet,
-  FileText,
-  MailIcon,
-} from "lucide-react";
+import type { SVGProps } from "react";
+
+import { File, FileImage, FileText, MailIcon } from "lucide-react";
 
 import { getDocumentIconKind } from "@/components/document-icon.logic";
 import { MarkdownIcon } from "@/components/markdown-icon";
 
-type DocxIconProps = {
-  className?: string | undefined;
-  style?: React.CSSProperties | undefined;
-  width?: number | string;
-  height?: number | string;
-};
-
-export const DocxIcon = ({
-  className,
-  style,
-  width,
-  height,
-}: DocxIconProps) => (
-  <svg
-    aria-hidden="true"
-    className={className}
-    fill="none"
-    height={height}
-    style={style}
-    viewBox="0 0 48 48"
-    width={width}
-    xmlns="http://www.w3.org/2000/svg"
-  >
+// Page body shared by all three: white sheet, folded top-right corner, grey
+// outline, in a 48×48 viewBox.
+const OfficePage = () => (
+  <>
     <path
       d="M13.5 44h29c.275 0 .5-.225.5-.5V14h-8.5c-.827 0-1.5-.673-1.5-1.5V4H13.5c-.275 0-.5.225-.5.5v39c0 .275.225.5.5.5z"
       fill="#fff"
@@ -44,6 +21,18 @@ export const DocxIcon = ({
       fillRule="evenodd"
       opacity=".64"
     />
+  </>
+);
+
+export const DocxIcon = (props: SVGProps<SVGSVGElement>) => (
+  <svg
+    aria-hidden="true"
+    fill="none"
+    viewBox="0 0 48 48"
+    xmlns="http://www.w3.org/2000/svg"
+    {...props}
+  >
+    <OfficePage />
     <path d="M39.5 30H28v1h11.5a.5.5 0 0 0 0-1z" fill="#103F91" />
     <path d="M39.5 27H28v1h11.5a.5.5 0 0 0 0-1z" fill="#185ABD" />
     <path d="M39.5 24H28v1h11.5a.5.5 0 0 0 0-1z" fill="#2B7CD3" />
@@ -56,6 +45,58 @@ export const DocxIcon = ({
       d="M11.829 29.322c.033.262.055.49.065.684h.038c.045-.446.117-.89.214-1.328L13.921 21h2.295l1.836 7.564c.092.373.168.848.23 1.426h.03c.026-.399.09-.859.191-1.38l1.47-7.61h2.088l-2.57 11H17.05l-1.752-7.287c-.051-.21-.109-.484-.172-.822a10.585 10.585 0 0 1-.119-.736h-.03c-.02.18-.06.446-.119.798-.059.354-.106.613-.141.783L13.072 32h-2.479L8 21h2.127l1.598 7.694c.036.159.07.369.104.628z"
       fill="#F9F7F7"
     />
+  </svg>
+);
+
+// Green lettered badge, shared by the XLSX and CSV marks.
+const SpreadsheetBadge = () => (
+  <>
+    <path
+      d="M6 37h18a2 2 0 002-2V17a2 2 0 00-2-2H6a2 2 0 00-2 2v18a2 2 0 002 2z"
+      fill="#107C41"
+    />
+    <path
+      d="M9.518 32l3.851-6.017L9.841 20h2.839l1.926 3.825c.177.362.298.633.365.811h.025c.127-.29.26-.572.398-.845L17.454 20h2.605l-3.62 5.95L20.15 32h-2.772l-2.225-4.2a3.522 3.522 0 01-.265-.561h-.033a2.605 2.605 0 01-.257.543L12.307 32h-2.79z"
+      fill="#F9F7F7"
+    />
+  </>
+);
+
+export const XlsxIcon = (props: SVGProps<SVGSVGElement>) => (
+  <svg
+    aria-hidden="true"
+    fill="none"
+    viewBox="0 0 48 48"
+    xmlns="http://www.w3.org/2000/svg"
+    {...props}
+  >
+    <OfficePage />
+    <path d="M39 31h-3a1 1 0 110-2h3a1 1 0 110 2z" fill="#134A2C" />
+    <path d="M32 31h-3a1 1 0 110-2h3a1 1 0 110 2z" fill="#185C37" />
+    <path d="M39 27h-3a1 1 0 110-2h3a1 1 0 110 2z" fill="#21A366" />
+    <path d="M32 27h-3a1 1 0 110-2h3a1 1 0 110 2z" fill="#107C41" />
+    <path d="M39 23h-3a1 1 0 110-2h3a1 1 0 110 2z" fill="#33C481" />
+    <path d="M32 23h-3a1 1 0 110-2h3a1 1 0 110 2z" fill="#21A366" />
+    <SpreadsheetBadge />
+  </svg>
+);
+
+// The CSV mark pairs the spreadsheet badge with an "a," glyph: same workbook
+// family, marked as delimited text.
+export const CsvIcon = (props: SVGProps<SVGSVGElement>) => (
+  <svg
+    aria-hidden="true"
+    fill="none"
+    viewBox="0 0 48 48"
+    xmlns="http://www.w3.org/2000/svg"
+    {...props}
+  >
+    <OfficePage />
+    <path
+      d="M36 31.03h-1.58v-1.54h-.038c-.687 1.187-1.699 1.781-3.034 1.781-.95 0-1.711-.258-2.282-.775-.572-.517-.858-1.212-.858-2.085 0-1.837 1.085-2.909 3.255-3.217l2.957-.414c0-1.67-.678-2.504-2.032-2.504-1.188 0-2.26.401-3.217 1.203v-1.618c.289-.218.784-.428 1.483-.63.7-.202 1.323-.304 1.869-.304 2.317 0 3.477 1.23 3.477 3.69v6.413zm-1.58-4.989l-2.388.337c-.816.116-1.387.31-1.715.583-.327.273-.49.715-.49 1.324 0 .495.175.891.528 1.19.354.299.806.448 1.359.448.783 0 1.43-.276 1.94-.829.51-.552.767-1.242.767-2.07v-.983zm5.58 3.23L38.468 34h-1.126l1.126-4.729H40z"
+      fill="#33C481"
+    />
+    <SpreadsheetBadge />
   </svg>
 );
 
@@ -126,7 +167,11 @@ export function DocumentIcon({
   }
 
   if (iconKind === "spreadsheet") {
-    return <FileSpreadsheet className={className} />;
+    return <XlsxIcon className={className} />;
+  }
+
+  if (iconKind === "csv") {
+    return <CsvIcon className={className} />;
   }
 
   if (iconKind === "image") {

--- a/apps/web/src/components/document-icon.tsx
+++ b/apps/web/src/components/document-icon.tsx
@@ -1,6 +1,12 @@
 import type { SVGProps } from "react";
 
-import { File, FileImage, FileText, MailIcon } from "lucide-react";
+import {
+  File,
+  FileImage,
+  FileSpreadsheet,
+  FileText,
+  MailIcon,
+} from "lucide-react";
 
 import { getDocumentIconKind } from "@/components/document-icon.logic";
 import { MarkdownIcon } from "@/components/markdown-icon";
@@ -166,8 +172,12 @@ export function DocumentIcon({
     return <DocxIcon className={className} />;
   }
 
-  if (iconKind === "spreadsheet") {
+  if (iconKind === "excel") {
     return <XlsxIcon className={className} />;
+  }
+
+  if (iconKind === "spreadsheet") {
+    return <FileSpreadsheet className={className} />;
   }
 
   if (iconKind === "csv") {

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-toolbar.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-toolbar.tsx
@@ -1,5 +1,5 @@
 import type { ComponentType } from "react";
-import { useState } from "react";
+import { Fragment, useState } from "react";
 
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { getRouteApi } from "@tanstack/react-router";
@@ -11,6 +11,7 @@ import {
   DownloadIcon,
   EyeIcon,
   HashIcon,
+  Loader2Icon,
   PlayIcon,
   Rows3Icon,
   SparklesIcon,
@@ -41,6 +42,7 @@ import {
 } from "@stll/ui/components/select";
 import { stellaToast } from "@stll/ui/components/toast";
 
+import { CsvIcon, DocxIcon, XlsxIcon } from "@/components/document-icon";
 import { FolderExpandToggle } from "@/components/file-tree/folder-expand-toggle";
 import {
   getInternalPropertyId,
@@ -347,6 +349,51 @@ const TableContentModeControl = ({ viewId }: TableContentModeControlProps) => {
 
 type TableExportFormat = "csv" | "xlsx" | "docx";
 
+// One row per downloadable format, in menu order. `separatorBefore` splits the
+// spreadsheet formats from the document formats.
+const TABLE_EXPORT_FORMATS = [
+  {
+    format: "csv",
+    icon: CsvIcon,
+    labelKey: "workspaces.views.exportCsv",
+    separatorBefore: false,
+  },
+  {
+    format: "xlsx",
+    icon: XlsxIcon,
+    labelKey: "workspaces.views.exportXlsx",
+    separatorBefore: false,
+  },
+  {
+    format: "docx",
+    icon: DocxIcon,
+    labelKey: "workspaces.views.exportDocxPlain",
+    separatorBefore: true,
+  },
+] as const satisfies readonly {
+  format: TableExportFormat;
+  icon: ComponentType<{ className?: string }>;
+  labelKey: TranslationKey;
+  separatorBefore: boolean;
+}[];
+
+type ExportFormatIconProps = {
+  Icon: ComponentType<{ className?: string }>;
+  pending: boolean;
+};
+
+// The file-type icons carry their own colours, so `opacity-100` opts them out
+// of the menu's default icon dimming.
+const ExportFormatIcon = ({ Icon, pending }: ExportFormatIconProps) => {
+  if (pending) {
+    return (
+      <Loader2Icon className="text-muted-foreground size-4.5 animate-spin sm:size-4" />
+    );
+  }
+
+  return <Icon className="size-4.5 opacity-100 sm:size-4" />;
+};
+
 type TableExportMenuProps = {
   view: Pick<WorkspaceView, "id" | "name">;
   workspaceId: string;
@@ -420,33 +467,26 @@ const TableExportMenu = ({ view, workspaceId }: TableExportMenuProps) => {
         >
           <DownloadIcon className="size-3.5" />
         </MenuTrigger>
-        <MenuPopup>
-          <MenuItem
-            disabled={exportingFormat !== null}
-            onClick={() => {
-              detached(handleExport("csv"), "TableExportMenu");
-            }}
-          >
-            {t("workspaces.views.exportCsv")}
-          </MenuItem>
-          <MenuItem
-            disabled={exportingFormat !== null}
-            onClick={() => {
-              detached(handleExport("xlsx"), "TableExportMenu");
-            }}
-          >
-            {t("workspaces.views.exportXlsx")}
-          </MenuItem>
-          <MenuSeparator />
-          <MenuItem
-            disabled={exportingFormat !== null}
-            onClick={() => {
-              detached(handleExport("docx"), "TableExportMenu");
-            }}
-          >
-            {t("workspaces.views.exportDocxPlain")}
-          </MenuItem>
+        <MenuPopup className="min-w-56">
+          {TABLE_EXPORT_FORMATS.map((option) => (
+            <Fragment key={option.format}>
+              {option.separatorBefore ? <MenuSeparator /> : null}
+              <MenuItem
+                disabled={exportingFormat !== null}
+                onClick={() => {
+                  detached(handleExport(option.format), "TableExportMenu");
+                }}
+              >
+                <ExportFormatIcon
+                  Icon={option.icon}
+                  pending={exportingFormat === option.format}
+                />
+                {t(option.labelKey)}
+              </MenuItem>
+            </Fragment>
+          ))}
           <MenuItem onClick={() => setReportOpen(true)}>
+            <ExportFormatIcon Icon={DocxIcon} pending={false} />
             {t("workspaces.views.exportDocxTemplate")}
           </MenuItem>
         </MenuPopup>

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-toolbar.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-toolbar.tsx
@@ -383,11 +383,19 @@ type ExportFormatIconProps = {
 };
 
 // The file-type icons carry their own colours, so `opacity-100` opts them out
-// of the menu's default icon dimming.
+// of the menu's default icon dimming. The spinner is the only signal that an
+// export is running, so it is labelled rather than left aria-hidden.
 const ExportFormatIcon = ({ Icon, pending }: ExportFormatIconProps) => {
+  const t = useTranslations();
+
   if (pending) {
     return (
-      <Loader2Icon className="text-muted-foreground size-4.5 animate-spin sm:size-4" />
+      <Loader2Icon
+        aria-hidden={false}
+        aria-label={t("common.loading")}
+        className="text-muted-foreground size-4.5 animate-spin sm:size-4"
+        role="img"
+      />
     );
   }
 
@@ -457,6 +465,7 @@ const TableExportMenu = ({ view, workspaceId }: TableExportMenuProps) => {
         <MenuTrigger
           render={
             <Button
+              aria-busy={exportingFormat !== null}
               aria-label={t("workspaces.views.exportTable")}
               disabled={exportingFormat !== null}
               size="icon-xs"

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-toolbar.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-toolbar.tsx
@@ -465,13 +465,18 @@ const TableExportMenu = ({ view, workspaceId }: TableExportMenuProps) => {
             />
           }
         >
-          <DownloadIcon className="size-3.5" />
+          {exportingFormat === null ? (
+            <DownloadIcon className="size-3.5" />
+          ) : (
+            <Loader2Icon className="size-3.5 animate-spin" />
+          )}
         </MenuTrigger>
         <MenuPopup className="min-w-56">
           {TABLE_EXPORT_FORMATS.map((option) => (
             <Fragment key={option.format}>
               {option.separatorBefore ? <MenuSeparator /> : null}
               <MenuItem
+                closeOnClick={false}
                 disabled={exportingFormat !== null}
                 onClick={() => {
                   detached(handleExport(option.format), "TableExportMenu");


### PR DESCRIPTION
The table export menu listed four formats as bare text, so CSV, XLSX, and the two DOCX entries were only distinguishable by reading them. Each row now carries its file-type mark, and the mark swaps to a spinner while that format is downloading.

## Changes

- `XlsxIcon` and `CsvIcon` alongside the existing `DocxIcon`, sharing the page body (`OfficePage`) and the spreadsheet badge (`SpreadsheetBadge`). `DocxIcon` and friends now take `SVGProps<SVGSVGElement>` instead of a hand-rolled prop type; existing call sites pass `className`/`width`/`height` unchanged.
- `DocumentIcon` renders the new marks too. Spreadsheets previously fell back to a generic outline glyph, so this also affects file lists and the catalogue, not just the export menu.
- `csv` is split out of `spreadsheetMimeTypes` into its own icon kind. `text/csv` also matches the generic `text/` prefix, so classification order decides which icon it gets; a test pins it.
- The four hand-written menu items become a `TABLE_EXPORT_FORMATS` table (format, icon, label key, separator).

## Verification

`bun run lint` (type-aware, whole of `apps/web`), `tsc --noEmit`, and `document-icon.logic.test.ts` are green.

CC on behalf of jan-kubica

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dedicated document icons for CSV, Excel, RTF, OpenDocument Text, and OpenDocument Spreadsheet files.
  * Updated table export options for CSV, XLSX, and DOCX with clearer icons, translated labels, separators, and individual loading indicators.
* **Improvements**
  * Export controls now show activity while an export is running and prevent additional selections until it completes.
  * Improved visual distinction between spreadsheet and text-based document formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->