### PR TITLE
fix(web): keep the pin/unpin label in sync with pinning state

### DIFF
--- a/apps/web/src/components/workspaces/properties/pin-property.tsx
+++ b/apps/web/src/components/workspaces/properties/pin-property.tsx
@@ -1,3 +1,5 @@
+import { useSelector } from "@tanstack/react-store";
+import type { ColumnPinningState } from "@tanstack/react-table";
 import { PinIcon, PinOffIcon } from "lucide-react";
 import { useTranslations } from "use-intl";
 
@@ -9,14 +11,25 @@ type PinPropertyProps = {
   column: TableColumn;
 };
 
+const isColumnPinned = (pinning: ColumnPinningState, columnId: string) =>
+  pinning.start.includes(columnId) || pinning.end.includes(columnId);
+
 export const PinProperty = ({ column }: PinPropertyProps) => {
   const t = useTranslations();
+  // Subscribe to the pinning slice instead of calling `column.getIsPinned()`.
+  // Column objects are memoized on `options.columns`, so their identity does
+  // not change when pinning does; React Compiler caches a plain getter read
+  // against that identity, leaving the label at whatever it was when this
+  // popover first mounted. The store subscription also re-renders the button
+  // when an ancestor reuses its own memoized output.
+  const isPinned = useSelector(column.table.store, (state) =>
+    isColumnPinned(state.columnPinning, column.id),
+  );
 
   if (!column.getCanPin()) {
     return null;
   }
 
-  const isPinned = column.getIsPinned() !== false;
   const togglePinned = () => {
     column.pin(isPinned ? false : "start");
   };


### PR DESCRIPTION
## Problem

Pinning or unpinning a table column from the column menu left the button label
stale: after pinning, the menu still read "Pin" until the popover was closed and
reopened.

## Cause

`PinProperty` read `column.getIsPinned()` during render. Column objects are
memoized on `table.options.columns` (`coreColumnsFeature`), so pinning does not
change a column's identity, and React Compiler caches the getter result against
that identity:

```js
if ($[0] !== column) {
  t1 = column.getIsPinned();   // never recomputed: `column` is stable
  ...
}
```

The value therefore stayed at whatever it was when the popover mounted.
Reopening the menu remounted the component, which is why it looked correct
afterwards. Header groups do depend on the pinning atom, so the column itself
moved immediately; only the label lagged.

## Fix

Read the state through a store subscription (`useSelector` on
`column.table.store`) rather than a getter on a stable object. Hook results are
not compiler-cached, and the subscription re-renders the button even when an
ancestor reuses its memoized output, so both call sites (`property-popover`,
`metadata-popover`) are covered.

## Notes

The same pattern (state-derived output computed from a getter on a stable
`column` / `row` / `header`) can bite elsewhere under React Compiler; this PR
only fixes the reported instance.

## Verification

- `bun --filter @stll/web typecheck`
- oxlint / oxfmt clean on the changed file
- Compiled the component with `babel-plugin-react-compiler` before and after to
  confirm the cached read is gone

CC on behalf of jan-kubica

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved column pinning indicators so they accurately reflect whether a column is pinned to the start or end of a table.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->