### PR TITLE
fix(web): paint the matter glyph in the activity feed with its own colour

### DIFF
--- a/apps/api/src/handlers/workspaces/read-overview-activity.ts
+++ b/apps/api/src/handlers/workspaces/read-overview-activity.ts
@@ -393,6 +393,9 @@ const config = {
 } satisfies HandlerConfig;
 
 type ActivityTarget = {
+  // Matter colour, so a `matter` target renders its own glyph colour
+  // instead of a mono one. Null for every other kind.
+  color: string | null;
   deleted: boolean;
   encrypted: boolean | null;
   entityId: string | null;
@@ -648,7 +651,7 @@ const readOverviewActivity = createSafeHandler(
             id: { eq: workspaceId },
             organizationId: { eq: session.activeOrganizationId },
           },
-          columns: { name: true },
+          columns: { color: true, name: true },
         });
 
         const actorIds = [
@@ -770,6 +773,7 @@ const readOverviewActivity = createSafeHandler(
             entityIdSnapshot: row.entityIdSnapshot,
             entityNameSnapshot: row.entityNameSnapshot,
             fieldVersionMap,
+            matterColor: result.workspace?.color ?? null,
             matterName: result.workspace?.name ?? null,
             resourceId: row.resourceId,
             resourceType: row.resourceType,
@@ -812,6 +816,7 @@ type EntityFile = {
 const toEntityTarget = (entity: EntityRow): EntityTarget => {
   const file = entity.kind === "task" ? null : entity.file;
   return {
+    color: null,
     deleted: false,
     encrypted: file?.encrypted ?? null,
     entityId: entity.id,
@@ -831,6 +836,7 @@ type TargetForRowOptions = {
   entityIdSnapshot: string | null;
   entityNameSnapshot: string | null;
   fieldVersionMap: Map<string, string>;
+  matterColor: string | null;
   matterName: string | null;
   resourceId: string;
   resourceType: string;
@@ -844,6 +850,7 @@ const targetForRow = ({
   entityIdSnapshot,
   entityNameSnapshot,
   fieldVersionMap,
+  matterColor,
   matterName,
   resourceId,
   resourceType,
@@ -895,19 +902,44 @@ const targetForRow = ({
   }
   if (resourceType === AUDIT_RESOURCE_TYPE.WORKSPACE) {
     return category === "team"
-      ? genericTarget("team", resourceId, teamTargetName)
-      : genericTarget("matter", resourceId, matterName);
+      ? genericTarget({
+          color: null,
+          id: resourceId,
+          kind: "team",
+          name: teamTargetName,
+        })
+      : genericTarget({
+          color: matterColor,
+          id: resourceId,
+          kind: "matter",
+          name: matterName,
+        });
   }
   if (
     resourceType === AUDIT_RESOURCE_TYPE.WORKSPACE_MEMBER ||
     resourceType === AUDIT_RESOURCE_TYPE.WORKSPACE_CONTACT
   ) {
-    return genericTarget("team", resourceId, teamTargetName);
+    return genericTarget({
+      color: null,
+      id: resourceId,
+      kind: "team",
+      name: teamTargetName,
+    });
   }
   if (resourceType === AUDIT_RESOURCE_TYPE.CASE_LAW_MATTER_LINK) {
-    return genericTarget("court", resourceId, null);
+    return genericTarget({
+      color: null,
+      id: resourceId,
+      kind: "court",
+      name: null,
+    });
   }
-  return genericTarget("automation", resourceId, null);
+  return genericTarget({
+    color: null,
+    id: resourceId,
+    kind: "automation",
+    name: null,
+  });
 };
 
 type DeletedEntityTargetOptions = {
@@ -921,6 +953,7 @@ const deletedEntityTarget = ({
   id,
   name = null,
 }: DeletedEntityTargetOptions): EntityTarget => ({
+  color: null,
   deleted: true,
   encrypted: null,
   entityId: null,
@@ -939,11 +972,20 @@ const documentTarget = (id: string): EntityTarget => ({
   encrypted: null,
 });
 
-const genericTarget = (
-  kind: Exclude<ActivityTarget["kind"], "document" | "task">,
-  id: string,
-  name: string | null,
-): ActivityTarget => ({
+type GenericTargetOptions = {
+  color: string | null;
+  id: string;
+  kind: Exclude<ActivityTarget["kind"], "document" | "task">;
+  name: string | null;
+};
+
+const genericTarget = ({
+  color,
+  id,
+  kind,
+  name,
+}: GenericTargetOptions): ActivityTarget => ({
+  color,
   deleted: false,
   encrypted: null,
   entityId: null,

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/activity/activity-panel.logic.test.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/activity/activity-panel.logic.test.ts
@@ -37,6 +37,7 @@ const item = (
   performer,
   runId,
   target: {
+    color: null,
     deleted: false,
     encrypted: false,
     entityId: "entity-1",

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/activity/activity-panel.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/activity/activity-panel.tsx
@@ -1333,7 +1333,10 @@ const targetIcon = (item: MatterActivityItem) => {
       return <SquareCheckIcon className="text-muted-foreground size-3.5" />;
     case "matter":
       return (
-        <MatterIcon className="text-muted-foreground size-3.5" variant="none" />
+        <MatterIcon
+          className="size-3.5"
+          matter={{ color: item.target.color, id: item.target.id }}
+        />
       );
     case "team":
       return <UsersIcon className="text-muted-foreground size-3.5" />;


### PR DESCRIPTION
## Problem

In the matter overview activity feed, a `matter` target rendered `MatterIcon variant="none"`: the mono affordance intended for pickers, empty states, and the matters nav entry. Everywhere else a specific matter carries its colour, so the same matter read grey in the activity row and coloured in the sidebar, breadcrumb, and mention chips.

`MatterIcon` documents the invariant it is meant to hold: a specific matter is unrepresentable without its colour. The activity feed was the one call site that broke it. The remaining `variant="none"` use (`chat-matter-picker`, no matter selected) is correct.

## Change

The colour was not available on the client, so it is carried on the activity target rather than guessed:

- `read-overview-activity` already loads the workspace row for the target name, so `color` joins the existing `columns` selection: no extra query, network baseline untouched.
- `ActivityTarget` gains `color: string | null`, kind-specific like the existing `mimeType` / `pdfFileId`, and null for every non-matter kind.
- `genericTarget` moves to an options object now that it takes four arguments; `id` and `name` were both loosely typed strings that were easy to transpose.
- `targetIcon` renders `<MatterIcon matter={{ color, id }} />`. `resolveMatterColor` falls back to the id-hash swatch when no colour is stored, and the target id is the workspace id, so the fallback matches what the sidebar computes for the same matter.

## Verification

`typecheck`, `lint`, and `format` are clean. The web activity logic tests pass (9/9; the fixture gained the new field). The API tests were not run locally (no `apps/api/.env` in this checkout: `read-overview-activity.logic.test.ts` fails at import with "Invalid environment variables" both with and without this change); CI covers them. The change was not exercised in a running app.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Workspace activity entries now display matter icons using the associated matter colour.
  - Activity targets consistently provide colour information, with unsupported target types shown without a colour.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->