### PR TITLE
fix(web): restore ratchet and bundle guards to green

### DIFF
--- a/apps/web/src/features/chat/hooks/use-chat-session.ts
+++ b/apps/web/src/features/chat/hooks/use-chat-session.ts
@@ -1057,11 +1057,12 @@ export const useChatSession = ({
       // the persisted inspector view is read-only, so unresolved proposals
       // would vanish. Keep the draft review session alive until the user
       // resolves it.
-      const hasPendingDraftReview = (
-        useReviewStore.getState().sessions[
-          createDocumentDraftReviewId(toolCallId)
-        ] ?? []
-      ).some((item) => item.status === "pending" || item.status === "applying");
+      const hasPendingDraftReview =
+        useReviewStore
+          .getState()
+          .sessions[createDocumentDraftReviewId(toolCallId)]?.some(
+            (item) => item.status === "pending" || item.status === "applying",
+          ) === true;
       if (hasPendingDraftReview) {
         stellaToast.add({
           title: t("chat.createDocument.savePendingReview"),

--- a/scripts/bundle-baseline.json
+++ b/scripts/bundle-baseline.json
@@ -1,12 +1,12 @@
 {
-  "entry": 1226,
+  "entry": 1223,
   "largest-route": 568513,
-  "routes": 5910630,
-  "total": 6754913,
+  "routes": 6091839,
+  "total": 6940555,
   "vendor-anonymize-data": 0,
-  "vendor-editor": 122631,
+  "vendor-editor": 120430,
   "vendor-graphs": 189783,
-  "vendor-react": 56604,
-  "vendor-tanstack": 474039,
+  "vendor-react": 56621,
+  "vendor-tanstack": 480659,
   "wasm-vendor": 0
 }


### PR DESCRIPTION
## Summary

followup to #1580 

- **Ratchet** (`nullish-array-fallback` 4 → 5): the pending-draft-review guard in `use-chat-session.ts` used an `?? []` array fallback. Rewritten to narrow the possibly-absent session explicitly; `bun scripts/ratchet.ts --check` is green again.
- **Bundle baseline reseed** (`routes` 5772 → 5949 KiB, +3.1% over the 3% headroom): the growth is the draft document editor surface #1580 shipped (chat-side draft compiler, inspector editor, review staging), a deliberate feature addition rather than an accidental dependency leak. Reseeded via `bun scripts/bundle-baseline.ts --write-baseline` after a clean build; `--check` passes on the new baseline.