### PR TITLE
docs: remove stale third-party notice for folio

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -8,39 +8,3 @@ Licensed under the Apache License, Version 2.0 (the "License"); you may
 not use this product except in compliance with the License. You may
 obtain a copy of the License in the LICENSE file at the root of this
 repository or at http://www.apache.org/licenses/LICENSE-2.0.
-
---------------------------------------------------------------------------
-
-Third-party notices
-
-This product contains code originally from the Eigenpal docx-editor
-project (https://github.com/eigenpal/docx-editor), used under the MIT
-License. The original work is reproduced in packages/folio under the
-terms of its original license. Modifications and additions made by
-stella labs, s.r.o. are licensed under Apache License 2.0.
-
-The original Eigenpal MIT License notice:
-
-    MIT License
-
-    Copyright (c) 2025 Eigenpal
-
-    Permission is hereby granted, free of charge, to any person
-    obtaining a copy of this software and associated documentation
-    files (the "Software"), to deal in the Software without
-    restriction, including without limitation the rights to use, copy,
-    modify, merge, publish, distribute, sublicense, and/or sell copies
-    of the Software, and to permit persons to whom the Software is
-    furnished to do so, subject to the following conditions:
-
-    The above copyright notice and this permission notice shall be
-    included in all copies or substantial portions of the Software.
-
-    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
-    HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
-    WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-    DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
`NOTICE` attributed the Eigenpal docx-editor code to `packages/folio`. That directory left this repository in #959, when folio moved to its own repository and was reintroduced as the published `@stll/folio-core` and `@stll/folio-react`. The pointer has been dangling since.

Verified before removing:

- No Eigenpal-derived source remains in this repository. `packages/docx-utils` shares commit lineage with the original folio work, but no files were renamed out of `packages/folio` into it.
- Attribution travels with the code: the folio repository carries its own `NOTICE.md` reproducing the MIT license.
- The published artifact carries it too. The `@stll/folio-core@0.15.13` tarball ships both `LICENSE` and `NOTICE.md`, so the MIT notice reaches consumers through the dependency rather than through this file.

The stella copyright and Apache-2.0 header are unchanged. `docs/changelog/v0.3.1.md` still mentions Eigenpal and is left alone, since it records what that release contained.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the third-party attribution and embedded MIT licence notice from the project’s legal notices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->