### PR TITLE
fix: recognize soft-hyphen CJEU case number separator

### DIFF
--- a/apps/api/src/handlers/case-law/ingestion/citation-extractor.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/citation-extractor.test.ts
@@ -100,6 +100,20 @@ describe("extractCitations", () => {
     expect(texts).toContain("T-13/99");
   });
 
+  test("extracts a CJEU case number whose hyphen is a soft hyphen (U+00AD)", () => {
+    // Verbatim from a Slovak Constitutional Court decision citing CJEU
+    // Banif Plus Bank v. Csaba Cipani. A PDF-to-text conversion left a
+    // soft hyphen (invisible when rendered) standing in for the ordinary
+    // separator between "C" and the docket number.
+    const text =
+      "vo veci Banif Plus Bank Zrt proti Csaba Cipani a spol. sp. zn. " +
+      "C­472/11 z 21. februára 2013";
+    const texts = extractCitations([{ index: 0, text }]).map(
+      (c) => c.citationText,
+    );
+    expect(texts).toContain("C­472/11");
+  });
+
   test("extracts CJEU case numbers with OCR-noisy hyphen spacing, hyphen still present", () => {
     // Verbatim from a Czech decision citing CJEU C-679/18 three different
     // ways within the same paragraph. A no-hyphen spelling ("C679/18") is

--- a/apps/api/src/handlers/case-law/ingestion/citation-extractor.ts
+++ b/apps/api/src/handlers/case-law/ingestion/citation-extractor.ts
@@ -235,14 +235,16 @@ const CITATION_PATTERNS: RegExp[] = [
   // CJEU: "C-283/81", "T-13/99", "F-100/09" (Court of Justice, General
   // Court, Civil Service Tribunal), including the non-breaking hyphen the
   // publications office uses ("C‑283/81"), the en/em dash normalizeDashes
-  // already canonicalizes for the dedup key ("C–128/22"), and OCR/typo
-  // spacing around the separator seen in prod text for the same case
-  // ("C- 679/18", "C -679/18"), bounded to a few characters so a stray
-  // long whitespace run does not leak into the stored citation text. The
-  // separator itself is never dropped: a bare "C679/18" would collide
-  // with the Czech civil "C" registry ("21 C 1234/2020"), so it is
-  // intentionally out of scope (see the module-level exclusion list).
-  /\b(?<caseNumber>[CTF]\s{0,3}[-‑–—]\s{0,3}\d{1,4}\/\d{2})(?!\d)/gu,
+  // already canonicalizes for the dedup key ("C–128/22"), the soft hyphen
+  // (U+00AD) a PDF-to-text conversion leaves behind at a line-wrap
+  // boundary ("C­472/11", invisible when rendered), and OCR/typo spacing
+  // around the separator seen in prod text for the same case ("C- 679/18",
+  // "C -679/18"), bounded to a few characters so a stray long whitespace
+  // run does not leak into the stored citation text. The separator itself
+  // is never dropped: a bare "C679/18" would collide with the Czech civil
+  // "C" registry ("21 C 1234/2020"), so it is intentionally out of scope
+  // (see the module-level exclusion list).
+  /\b(?<caseNumber>[CTF]\s{0,3}[-‑–—­]\s{0,3}\d{1,4}\/\d{2})(?!\d)/gu,
 
   // ECLI: "ECLI:CZ:NS:2020:21.CDO.1234.2020.1"
   /ECLI:[A-Z]{2}:[A-Z]{1,8}:\d{4}:[\w.]+/gu,
@@ -269,9 +271,10 @@ const CITATION_PATTERNS: RegExp[] = [
   // bare tail of an already-prefixed number ("T‑381/15" must not also
   // yield a phantom "381/15"), including every separator spelling the
   // CJEU C/T/F pattern above tolerates: spaced ("C- 679/18" must not also
-  // yield a phantom "679/18") and en/em dash ("C–128/22" must not also
-  // yield a phantom "128/22").
-  /(?<![CTF]\s{0,4}[-‑–—]\s{0,4})\b(?<caseNumber>\d{1,4}\/\d{2})(?!\d)(?=[\s,]*(?:(?:and|e)\s+\d{1,4}\/\d{2}(?!\d)[\s,]*)?EU:[CTF]:\d{4}:\d+)/gu,
+  // yield a phantom "679/18"), en/em dash ("C–128/22" must not also yield
+  // a phantom "128/22"), and soft hyphen ("C­128/22" must not also yield a
+  // phantom "128/22").
+  /(?<![CTF]\s{0,4}[-‑–—­]\s{0,4})\b(?<caseNumber>\d{1,4}\/\d{2})(?!\d)(?=[\s,]*(?:(?:and|e)\s+\d{1,4}\/\d{2}(?!\d)[\s,]*)?EU:[CTF]:\d{4}:\d+)/gu,
 
   // Czech collection: "č. 123/2020 Sb. rozh. tr." (Nejvyšší soud, civil or
   // criminal) or "č. 2018/2010 Sb. NSS" (Nejvyšší správní soud, a


### PR DESCRIPTION
## Proposed change

Some corpus documents' PDF-to-text conversion leaves a soft hyphen (U+00AD,
invisible when rendered) standing in for the ordinary hyphen between a CJEU
chamber letter (`C`/`T`/`F`) and its docket number, e.g. `C472/11`. The
citation extractor's hyphen character class for the CJEU pattern didn't
include U+00AD, so these citations were silently dropped instead of
extracted — confirmed against a real corpus document where 9 CJEU citations
in one decision used this separator and were all missed.

Adds U+00AD to the CJEU hyphen character class (both the main pattern and
its mirrored negative lookbehind, which must stay in sync per the existing
comment), plus a fixture test with verbatim corpus prose.

## Checklist

- [x] BUILD ASSURANCE | Code builds correctly and without any errors or warnings.
- [x] TESTING | Added a fixture test with verbatim corpus prose; full `citation-extractor.test.ts` suite passes (160/160).
- [ ] DARK MODE SUPPORT | N/A, no UI change.
- [ ] ISSUE LINKED | N/A.
- [ ] SCREENSHOT INCLUDED | N/A, no UI change.


---
_Generated by [Claude Code](https://claude.ai/code/session_015uso1EzPR6gG3ex9iYn9hm)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recognition of CJEU case citations containing soft hyphens.
  * Preserved the original citation text when soft hyphens are present.
  * Prevented incorrect matches in certain pre-1989 CJEU citations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->