### PR TITLE
fix(api): widen CLI support band to 0.4.0

### DIFF
--- a/apps/api/src/mcp/constants.ts
+++ b/apps/api/src/mcp/constants.ts
@@ -79,7 +79,7 @@ export const STELLA_MCP_API_CONTRACT_VERSION = 1;
 const CLI_SUPPORT_BAND = declareCliSupportBand({
   minimum: "0.3.0",
   latest: "0.3.0",
-  maximum: "0.3.1",
+  maximum: "0.4.0",
 });
 
 export const STELLA_CLI_MINIMUM_VERSION = CLI_SUPPORT_BAND.minimum;


### PR DESCRIPTION
## Why

The Changesets release PR #1544 bumps `@stll/cli` to **0.4.0**, but the API still advertises a maximum supported CLI of **0.3.1**:

```ts
// apps/api/src/mcp/constants.ts
const CLI_SUPPORT_BAND = declareCliSupportBand({
  minimum: "0.3.0",
  latest: "0.3.0",
  maximum: "0.3.1",
});
```

So `scripts/check-api-cli-contract.test.ts` fails on #1544 — `semver.satisfies("0.4.0", ">=0.3.0 <=0.3.1")` is false — and blocks the release:

```
(fail) API and CLI release contract > the current CLI package cannot exceed server support
```

This is the guardrail working as intended: *"Deploy support for a CLI version before publishing it."* The API just never got the release that widens the band.

## What

Bump `maximum` to `0.4.0`.

`latest` stays at `0.3.0` — that is still the newest version actually published to npm (verified: `npm view @stll/cli versions` ends at 0.3.0), and it drives the CLI update nudge, so it should only move once 0.4.0 is published. `minimum 0.3.0 <= latest 0.3.0 <= maximum 0.4.0` satisfies the band invariant.

No changeset: `@stll/api` is in the Changesets `ignore` list and `apps/api/**` is not a `release-path` in the changeset-policy job.

## Verification

Ran locally off `main` with this change:

- `scripts/check-api-cli-contract.test.ts` — 8 pass, 0 fail
- Same, with `packages/cli/package.json` temporarily set to `0.4.0` to simulate #1544 — 8 pass, 0 fail
- `apps/api/src/mcp/metadata.test.ts`, `cli-mirror-drift.test.ts`, `handlers/mcp/routes.test.ts` — 16 pass, 0 fail

## Order of operations

Merge and **deploy the API** before #1544 is merged/published, otherwise the production canary will reject the packed 0.4.0 CLI. Once this is on `main`, the release bot regenerates #1544 and its CI should go green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Extended CLI compatibility to support versions up to 0.4.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->