### PR TITLE
fix(api): align disconnect-persistence test with chat turn writes

### DIFF
--- a/apps/api/src/handlers/chat/send-message-regeneration.integration.test.ts
+++ b/apps/api/src/handlers/chat/send-message-regeneration.integration.test.ts
@@ -51,7 +51,9 @@ void mock.module("@/api/handlers/chat/tools/external-mcp-tools", () => ({
   },
 }));
 
+const loadOrgKeysModule = await import("@/api/lib/web-search/load-org-keys");
 void mock.module("@/api/lib/web-search/load-org-keys", () => ({
+  ...loadOrgKeysModule,
   loadWebSearchProvidersForOrg: async () => ({
     urlFetcher: null,
     webSearchProvider: null,

--- a/apps/api/src/handlers/chat/send-message.test.ts
+++ b/apps/api/src/handlers/chat/send-message.test.ts
@@ -24,7 +24,9 @@ const loadWebSearchProvidersForOrgMock = mock(async () => {
     webSearchProvider: null,
   };
 });
+const loadOrgKeysModule = await import("@/api/lib/web-search/load-org-keys");
 void mock.module("@/api/lib/web-search/load-org-keys", () => ({
+  ...loadOrgKeysModule,
   loadWebSearchProvidersForOrg: loadWebSearchProvidersForOrgMock,
 }));
 
@@ -950,8 +952,11 @@ describe("send message disconnect handling", () => {
       code: 400,
       response: { message: "Client disconnected before stream started" },
     });
-    expect(insertValues).toHaveBeenCalledTimes(2);
-    expect(updateWhere).toHaveBeenCalledTimes(1);
+    // Turn acceptance, the user message, and the terminal interrupted
+    // assistant message each persist their own row; the user-message
+    // persist and the interrupt persist each touch the thread row once.
+    expect(insertValues).toHaveBeenCalledTimes(3);
+    expect(updateWhere).toHaveBeenCalledTimes(2);
     expect(upsertChatThreadSearchDocumentMock).toHaveBeenCalledWith(threadId);
     expect(loadExternalMcpToolsForUserMock).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
The scheduled full-test run fails on `send message disconnect handling > stops before connector discovery when the client disconnects during persistence` (https://github.com/stella/stella/actions/runs/30880521649). The disconnect-during-persistence path persists three rows (turn acceptance, user message, terminal interrupted assistant message) and touches the thread row on both persists; the test still expected the pre-#1580 counts. First commit updates the expectations to match the implemented behaviour; the guarded properties (400 response, no connector discovery after disconnect) are unchanged.

Second commit fixes a latent under-mock in the same tests: both chat send tests replaced the whole `load-org-keys` module with a single export, so any later import of its other exports in the same shared test process failed to resolve (`resolveWebSearchProvidersFromOrgSettingsRow` in `list-catalogue.test.ts`, depending on batch composition). The mocks now spread the real module and override only `loadWebSearchProvidersForOrg`.

Full `@stll/api` suite is green locally with both changes.