### PR TITLE
chore(ci): alert on scheduled workflow failures

### DIFF
--- a/.github/workflows/scheduled-run-alerts.yml
+++ b/.github/workflows/scheduled-run-alerts.yml
@@ -1,0 +1,48 @@
+name: Scheduled run alerts
+
+on:
+  workflow_run:
+    workflows:
+      - Nightly Full Test
+      - Nightly Full Typecheck
+      - AI provider canary
+    types: [completed]
+
+permissions: {}
+
+jobs:
+  notify:
+    if: github.event.workflow_run.conclusion == 'failure'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Send failure alert
+        env:
+          WEBHOOK_URL: ${{ secrets.SCHEDULED_ALERTS_WEBHOOK_URL }}
+          WEBHOOK_TOKEN: ${{ secrets.SCHEDULED_ALERTS_WEBHOOK_TOKEN }}
+          WEBHOOK_HEADERS: ${{ secrets.SCHEDULED_ALERTS_WEBHOOK_HEADERS }}
+          WORKFLOW_NAME: ${{ github.event.workflow_run.name }}
+          RUN_URL: ${{ github.event.workflow_run.html_url }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          RUN_EVENT: ${{ github.event.workflow_run.event }}
+        run: |
+          if [ -z "$WEBHOOK_URL" ] || [ -z "$WEBHOOK_TOKEN" ]; then
+            echo "::error::scheduled-run alert webhook secrets are not configured"
+            exit 1
+          fi
+          header_args=()
+          if [ -n "$WEBHOOK_HEADERS" ]; then
+            while IFS= read -r header; do
+              if [ -n "$header" ]; then
+                header_args+=(-H "$header")
+              fi
+            done <<< "$WEBHOOK_HEADERS"
+          fi
+          jq -n --arg text "Failed workflow: $WORKFLOW_NAME (event: $RUN_EVENT, branch: $HEAD_BRANCH, head sha: $HEAD_SHA). Run: $RUN_URL" '{text: $text}' |
+            curl --fail-with-body -sS -X POST \
+              -H "Authorization: Bearer $WEBHOOK_TOKEN" \
+              -H "content-type: application/json" \
+              "${header_args[@]}" \
+              --data-binary @- \
+              "$WEBHOOK_URL"


### PR DESCRIPTION
Nightly Full Test, Nightly Full Typecheck, and AI provider canary run unattended, so a red run only surfaces to whoever opens the Actions tab. This adds a `workflow_run` hook that posts the failed run's identity (workflow, run URL, branch, head SHA) to an alerting webhook.

Endpoint, credential, and any provider-specific headers come from repository secrets. Run metadata is passed through env vars so untrusted strings never reach shell interpolation, and the job fails loudly when the secrets are missing so dead alerting cannot look green. `permissions: {}`; fires only on `conclusion == 'failure'`.