### PR TITLE
fix(api): make bounding-box parity part of the output schema's shape

### DIFF
--- a/apps/api/src/lib/bbox/ai-generate-b-boxes.ts
+++ b/apps/api/src/lib/bbox/ai-generate-b-boxes.ts
@@ -1,43 +1,19 @@
 import type { DocumentPart } from "@tanstack/ai";
 import type { AnthropicDocumentMetadata } from "@tanstack/ai-anthropic";
-import { panic, Result } from "better-result";
-import * as v from "valibot";
+import { Result } from "better-result";
 
 import { resolveCaching, type OrgAIConfig } from "@/api/lib/ai-config";
 import { createTanStackAIAnalyticsCallbacks } from "@/api/lib/analytics/tanstack-ai";
 import {
-  BBOX_ARRAY_DESCRIPTION,
   BBOX_SYSTEM_PROMPT,
-  bboxItemSchema,
+  bboxOutputSchema,
   buildBBoxUserMessage,
+  type BBoxItem,
 } from "@/api/lib/bbox/ai-prompts";
 import type { SafeId } from "@/api/lib/branded-types";
 import { WorkflowIntegrationError } from "@/api/lib/errors/tagged-errors";
 import { markTanStackCacheBreakpoint } from "@/api/lib/tanstack-ai-caching";
 import { generateTanStackObjectForRole } from "@/api/lib/tanstack-ai-generate";
-
-const bboxOutputSchema = v.strictObject({
-  boxes: v.pipe(
-    v.array(bboxItemSchema),
-    v.minLength(1),
-    v.description(BBOX_ARRAY_DESCRIPTION),
-  ),
-});
-
-// `bboxItemSchema` already validated `v.length(4)`; this only narrows
-// the static type from `number[]` to the 4-tuple without a cast.
-const toBBoxTuple = (item: number[]): [number, number, number, number] => {
-  const [yMin, xMin, yMax, xMax] = item;
-  if (
-    yMin === undefined ||
-    xMin === undefined ||
-    yMax === undefined ||
-    xMax === undefined
-  ) {
-    panic("BBox element passed length validation but has missing values");
-  }
-  return [yMin, xMin, yMax, xMax];
-};
 
 type GenerateBBoxDataProps = {
   pdfData: Uint8Array;
@@ -66,7 +42,7 @@ export const generateBBoxData = async ({
   orgAIConfig,
   promptCachingEnabled,
 }: GenerateBBoxDataProps): Promise<
-  Result<[number, number, number, number][], WorkflowIntegrationError>
+  Result<BBoxItem[], WorkflowIntegrationError>
 > => {
   const caching = resolveCaching({
     promptCachingEnabled,
@@ -148,5 +124,5 @@ export const generateBBoxData = async ({
     aiAnalytics.captureError(error);
     return Result.err(error);
   }
-  return Result.ok(generated.value.map(toBBoxTuple));
+  return Result.ok(generated.value);
 };

--- a/apps/api/src/lib/bbox/ai-prompts.test.ts
+++ b/apps/api/src/lib/bbox/ai-prompts.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "bun:test";
+
+import { bboxOutputSchema } from "@/api/lib/bbox/ai-prompts";
+import { providerSafeJsonSchemaOptionsForTanStackProvider } from "@/api/lib/provider-safe-json-schema";
+import type { ValueConstraintStrategy } from "@/api/lib/provider-safe-json-schema";
+import { toTanStackValibotSchema } from "@/api/lib/tanstack-ai-schema";
+
+// The provider only ever compiles the `structured-output` projection,
+// which omits value constraints; anything the schema expresses with
+// one is enforced nowhere but the local parse of a finished response.
+const projectBBoxSchema = (valueConstraintStrategy: ValueConstraintStrategy) =>
+  toTanStackValibotSchema(bboxOutputSchema, {
+    ...providerSafeJsonSchemaOptionsForTanStackProvider(
+      "openrouter",
+      "structured-output",
+    ),
+    valueConstraintStrategy,
+  })["~standard"].jsonSchema.output({ target: "draft-2020-12" });
+
+describe("bboxOutputSchema", () => {
+  test("states its contract in keywords the projection keeps", () => {
+    expect(projectBBoxSchema("omit")).toEqual(projectBBoxSchema("preserve"));
+  });
+
+  test("compiles to a fully required coordinate object", () => {
+    expect(projectBBoxSchema("omit")).toEqual({
+      type: "object",
+      properties: {
+        boxes: {
+          type: "array",
+          items: {
+            type: "object",
+            properties: {
+              yMin: { type: "number" },
+              xMin: { type: "number" },
+              yMax: { type: "number" },
+              xMax: { type: "number" },
+            },
+            required: ["yMin", "xMin", "yMax", "xMax"],
+            additionalProperties: false,
+            description:
+              "Bounding box normalized to a 0-1000 scale, with yMin/xMin " +
+              "the top-left corner and yMax/xMax the bottom-right",
+          },
+          description: "Array of bounding boxes",
+        },
+      },
+      required: ["boxes"],
+      additionalProperties: false,
+    });
+  });
+});

--- a/apps/api/src/lib/bbox/ai-prompts.ts
+++ b/apps/api/src/lib/bbox/ai-prompts.ts
@@ -12,14 +12,9 @@ export const BBOX_SYSTEM_PROMPT =
 const context = {
   bBoxItem: {
     description:
-      "Bounding box in format [ymin, xmin, ymax, xmax] " +
-      "normalized to 0-1000 scale",
-    examples: [[120, 200, 350, 800]] satisfies [
-      number,
-      number,
-      number,
-      number,
-    ][],
+      "Bounding box normalized to a 0-1000 scale, with yMin/xMin the " +
+      "top-left corner and yMax/xMax the bottom-right",
+    examples: [{ yMin: 120, xMin: 200, yMax: 350, xMax: 800 }],
   },
   bBoxArray: {
     description: "Array of bounding boxes",
@@ -30,20 +25,39 @@ const context = {
 
 // Element schema for the top-level `boxes` array. The object root
 // keeps provider strict-response modes away from top-level array
-// schemas. Emptiness is checked at the array schema/caller boundary.
+// schemas. Emptiness is checked at the caller boundary.
 //
-// A length-4 array, not `v.tuple`: tuples convert to the array form
-// of `items`, which OpenAI strict mode rejects; `v.length(4)`
-// converts to `minItems`/`maxItems`, which it accepts. The caller
-// narrows validated elements back to the 4-tuple.
-export const bboxItemSchema = v.pipe(
-  v.array(v.number()),
-  v.length(4),
+// Four named coordinates rather than a length-4 array: array arity is
+// expressible only as `minItems`/`maxItems`, which the
+// structured-output projection drops with every other value
+// constraint, leaving nothing in the compiled schema to oblige four
+// numbers; a shorter or longer array then fails here only once the
+// response is complete. `properties` and `required` are shape, so
+// they survive the projection and the coordinate count is part of
+// what the provider decodes.
+const bboxItemSchema = v.pipe(
+  v.strictObject({
+    yMin: v.number(),
+    xMin: v.number(),
+    yMax: v.number(),
+    xMax: v.number(),
+  }),
   v.description(context.bBoxItem.description),
   v.examples(context.bBoxItem.examples),
 );
 
-export const BBOX_ARRAY_DESCRIPTION = context.bBoxArray.description;
+// No lower bound on `boxes`: the projection drops value constraints,
+// so `v.minLength(1)` would reach the model as nothing at all and
+// could only reject an empty response afterwards, preempting the
+// caller's own emptiness check.
+export const bboxOutputSchema = v.strictObject({
+  boxes: v.pipe(
+    v.array(bboxItemSchema),
+    v.description(context.bBoxArray.description),
+  ),
+});
+
+export type BBoxItem = v.InferOutput<typeof bboxItemSchema>;
 
 // --------------- User message templates ---------------
 

--- a/apps/api/src/lib/bbox/generate-b-boxes-mock.ts
+++ b/apps/api/src/lib/bbox/generate-b-boxes-mock.ts
@@ -19,7 +19,7 @@ export const generateBBoxesMock = async ({
   }
 
   return Result.ok(
-    parseGeminiBBoxes([[100, 100, 300, 900]], {
+    parseGeminiBBoxes([{ yMin: 100, xMin: 100, yMax: 300, xMax: 900 }], {
       pageNumber,
       width: page.width,
       height: page.height,

--- a/apps/api/src/lib/bbox/generate-b-boxes-shared.ts
+++ b/apps/api/src/lib/bbox/generate-b-boxes-shared.ts
@@ -9,6 +9,7 @@ import type {
 } from "@/api/db/schema";
 import type { FieldContent } from "@/api/db/schema-validators";
 import type { OrgAIConfig } from "@/api/lib/ai-config";
+import type { BBoxItem } from "@/api/lib/bbox/ai-prompts";
 import type { SafeId } from "@/api/lib/branded-types";
 import type { WorkflowIntegrationError } from "@/api/lib/errors/tagged-errors";
 import { createFileKey } from "@/api/lib/files/utils";
@@ -110,8 +111,6 @@ export const extractJustificationContent = (
 
 const GEMINI_B_BOX_SCALE = 1000;
 
-type GeminiBBox = [number, number, number, number];
-
 type Page = {
   pageNumber: number;
   width: number;
@@ -119,14 +118,14 @@ type Page = {
 };
 
 export const parseGeminiBBoxes = (
-  bBoxes: GeminiBBox[],
+  bBoxes: BBoxItem[],
   { pageNumber, width, height }: Page,
 ): BoundingBox[] => {
   const boundingBoxHashes = new Set<string>();
   const boundingBoxes: BoundingBox[] = [];
 
   for (const bBox of bBoxes) {
-    const hash = `${pageNumber}-${bBox.join("-")}`;
+    const hash = `${pageNumber}-${bBox.yMin}-${bBox.xMin}-${bBox.yMax}-${bBox.xMax}`;
 
     // gemini sometimes returns duplicate bounding boxes
     if (boundingBoxHashes.has(hash)) {
@@ -137,10 +136,10 @@ export const parseGeminiBBoxes = (
 
     boundingBoxes.push({
       pageNumber,
-      yMin: Math.round((bBox[0] / GEMINI_B_BOX_SCALE) * height),
-      xMin: Math.round((bBox[1] / GEMINI_B_BOX_SCALE) * width),
-      yMax: Math.round((bBox[2] / GEMINI_B_BOX_SCALE) * height),
-      xMax: Math.round((bBox[3] / GEMINI_B_BOX_SCALE) * width),
+      yMin: Math.round((bBox.yMin / GEMINI_B_BOX_SCALE) * height),
+      xMin: Math.round((bBox.xMin / GEMINI_B_BOX_SCALE) * width),
+      yMax: Math.round((bBox.yMax / GEMINI_B_BOX_SCALE) * height),
+      xMax: Math.round((bBox.xMax / GEMINI_B_BOX_SCALE) * width),
     });
   }
 


### PR DESCRIPTION
## Proposed change

`bboxItemSchema` described a bounding box as a four-element number array, with the
arity expressed by `v.length(4)`, which compiles to `minItems`/`maxItems`.

Structured output projects every schema with `valueConstraintStrategy: "omit"`
(`providerSafeJsonSchemaOptionsForTanStackProvider`), which strips exactly those
keywords along with `minLength`/`maxLength`/`minimum`/`maximum`. The schema the
provider compiles for this feature is therefore:

```json
{ "boxes": { "type": "array", "items": { "type": "array", "items": { "type": "number" } } } }
```

Nothing in it obliges four numbers, and nothing rules out an empty `boxes`. Both
requirements survive only in the `v.parse` at the end of
`generateTanStackObjectForRole`, i.e. after the response is complete: a model that
returns three coordinates, or no boxes, fails validation there, and
`generateBoundingBoxes` turns that into `aiHandlerError(..., { status: 502 })` for
the whole request. The comment justifying `v.length(4)` over `v.tuple` predates the
projection change and no longer holds: neither form reaches the provider.

The fix models a box as an object with four required number properties.
`properties` and `required` are shape, not value constraints, so the projection
keeps them and the coordinate count becomes part of what the provider decodes.
`v.minLength(1)` goes for the same reason, and dropping it also un-shadows the
caller's own emptiness check in `generateBBoxData`, which currently cannot run and
reports the outcome with its own message.

Falling out of the shape change: `toBBoxTuple` and its `panic` disappear, since
there is no longer an array to narrow back to a tuple.

The new test pins the invariant rather than the instance: projecting the schema with
value constraints preserved and omitted must give the same result, so any future
constraint that only the local parse would enforce fails the test. The second case
pins the compiled shape the provider receives.

Verified locally: `bun test src/lib/bbox/ai-prompts.test.ts` (2 pass), `tsc --noEmit`
and `oxlint --type-aware` clean on `@stll/api`, `bun run format` clean.

## Checklist

- [x] **BUILD ASSURANCE** | Code builds correctly and without any errors or warnings.
- [x] **TESTING** | Changes tested, including in different conditions (dark mode, language, narrow screen, etc).
- [ ] DARK MODE SUPPORT | User can use the webapp in dark mode. Make sure your changes are visible in both light and dark mode.
- [ ] ISSUE LINKED | Link an issue to this PR (not by mentioning it in the description, but by using the GitHub issue linking feature)
- [ ] SCREENSHOT INCLUDED | If relevant, please include a screenshot / video of the functionality added (allows for a quick check of minor ux changes)

Backend-only change: no UI surface, so dark mode and screenshots do not apply.

---
_Generated by [Claude Code](https://claude.ai/code/session_01M3i3gRSTXxrEV6WNtQPaMM)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bounding-box data now uses clearly named coordinate fields for improved readability and consistency.
  * AI-generated bounding boxes are validated against a stricter output format.

* **Bug Fixes**
  * Improved coordinate scaling and duplicate detection when processing bounding boxes.

* **Tests**
  * Added coverage to verify bounding-box schema structure and validation behaviour.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->