### PR TITLE
chore(ci): tighten deploy and publish workflow semantics

### DIFF
--- a/.github/workflows/deploy-landing.yml
+++ b/.github/workflows/deploy-landing.yml
@@ -28,6 +28,8 @@ jobs:
     runs-on: ubuntu-latest
     # Allows for the single retry below (a 3-minute wait plus a second deploy).
     timeout-minutes: 30
+    permissions:
+      contents: read
     steps:
       - name: Mint App token for the private workflows repo
         id: app-token

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -8,10 +8,14 @@ on:
     branches: [main]
   workflow_dispatch:
 
-# A newer push to main supersedes an in-flight staging deploy.
+# Queue rather than cancel: build-and-deploy dispatches a promotion to the
+# infra repo and then watches it to completion. A run cancelled mid-dispatch
+# would leave that promotion in flight with nothing watching it, racing
+# whatever the next run dispatches. A dispatched promotion must always be
+# watched, so a newer push waits for the current run instead of preempting it.
 concurrency:
   group: deploy-staging
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 env:
   REGISTRY: ghcr.io
@@ -73,7 +77,17 @@ jobs:
 
           echo "status=${status}" >> "$GITHUB_OUTPUT"
           if [[ "$status" == "$NOT_READY_STATUS" ]]; then
-            echo "::notice::Staging health gate did not pass; skipping this deployment."
+            if [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]; then
+              echo "::notice::Staging health gate did not pass; workflow_dispatch bypasses the gate and deploys anyway."
+            else
+              {
+                echo "### Staging health gate failed"
+                echo "The staging health probe did not return a ready status after ${MAX_ATTEMPTS} attempts."
+                echo "This deployment was skipped. Continuous deploy to staging is stalled until staging health recovers, or until this workflow is re-run with workflow_dispatch to bypass the gate."
+              } >> "$GITHUB_STEP_SUMMARY"
+              echo "::error::Staging health gate did not pass after ${MAX_ATTEMPTS} attempts; skipping this deployment and failing the run so continuous deploy does not stall silently."
+              exit 1
+            fi
           fi
 
   build-and-deploy:

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -52,13 +52,16 @@ on:
         type: string
 
 concurrency:
-  group: publish-npm-${{ github.event.workflow_run.id || github.ref }}
+  # One group across every trigger so publishes to the same registry
+  # serialize instead of racing each other.
+  group: publish-npm
   cancel-in-progress: false
 
 jobs:
   release-trigger:
     name: Resolve release trigger
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       actions: read # Download the completed release workflow's source receipt.
     outputs:
@@ -116,6 +119,7 @@ jobs:
     needs: release-trigger
     if: ${{ needs.release-trigger.outputs.eligible == 'true' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read # deliberately NO id-token: untrusted build scripts run here
     outputs:

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -5,8 +5,10 @@ on:
     branches: [main]
 
 concurrency:
+  # Queue instead of cancel: this workflow pushes commits to the release PR
+  # branch, so a cancelled mid-push run could leave that branch half-updated.
   group: release-pr-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 permissions: {}
 

--- a/.github/workflows/scheduled-run-alerts.yml
+++ b/.github/workflows/scheduled-run-alerts.yml
@@ -6,6 +6,9 @@ on:
       - Nightly Full Test
       - Nightly Full Typecheck
       - AI provider canary
+      # Not scheduled, but unattended: a failure here silently stalls
+      # continuous deploy to staging with nobody watching the run.
+      - Deploy main to staging
     types: [completed]
 
 permissions: {}

--- a/.github/workflows/tag-on-version-bump.yml
+++ b/.github/workflows/tag-on-version-bump.yml
@@ -30,6 +30,7 @@ jobs:
     # through the merge-to-main review path.
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Mint App token
         id: app-token
@@ -45,8 +46,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0 # full history: the marketing-recordings check diffs against each capture's recorded-at commit, which can be arbitrarily far back
-          token: ${{ steps.app-token.outputs.token }}
-          persist-credentials: true # zizmor: ignore[artipacked] release tag push requires persisted App token
+          persist-credentials: false
 
       - name: Read and validate VERSION
         id: version
@@ -111,8 +111,12 @@ jobs:
         if: env.skip != 'true'
         env:
           TAG: ${{ steps.version.outputs.tag }}
+          # Injected only for this step: the App token never touches disk via
+          # persisted git credentials, so earlier steps (setup-bun, repo
+          # scripts) run without it available.
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           git config user.name "stella-release-deployer[bot]"
           git config user.email "stella-release-deployer[bot]@users.noreply.github.com"
           git tag -a "$TAG" -m "$TAG"
-          git push origin "$TAG"
+          git push "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "$TAG"

--- a/scripts/check-api-deployment.test.ts
+++ b/scripts/check-api-deployment.test.ts
@@ -27,7 +27,10 @@ describe("API deployment health receipt", () => {
     expect(healthJob).toContain('status="$READY_STATUS"');
     expect(healthJob).toContain(`echo "status=\${status}" >> "$GITHUB_OUTPUT"`);
     expect(healthJob).toContain(
-      "Staging health gate did not pass; skipping this deployment.",
+      "workflow_dispatch bypasses the gate and deploys anyway.",
+    );
+    expect(healthJob).toContain(
+      "failing the run so continuous deploy does not stall silently",
     );
     expect(deployJob).toContain("needs: staging-health");
     expect(deployJob).toContain("github.event_name == 'workflow_dispatch'");


### PR DESCRIPTION
Maintenance pass over the deploy and publish workflows:

- **deploy-staging**: queue concurrent runs instead of cancelling, so a dispatched promotion is always watched to completion. When the staging health gate does not pass, fail the run with an error annotation and step summary instead of a silent green skip, and route it through `scheduled-run-alerts`; `workflow_dispatch` keeps bypassing the gate.
- **tag-on-version-bump**: check out with `persist-credentials: false` and inject the App token only in the final tag-push step; add a job timeout.
- **publish-npm**: serialize all publishes under a single concurrency group; add timeouts to `release-trigger` and `pack`.
- **release-pr**: queue instead of cancel in-progress runs, since the workflow pushes commits.
- **deploy-landing**: explicit per-job `permissions` block, matching the convention elsewhere.