### PR TITLE
chore(api): ship only compiled outputs in the runtime image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -310,6 +310,30 @@ jobs:
           docker logs stella-api-smoke || true
           exit 1
 
+      - name: Boot-smoke bundled entrypoints
+        # The runner stage ships compiled outputs and their runtime asset
+        # trees without a workspace node_modules. The server and migrate
+        # entrypoints are exercised above; this loads each remaining bundle
+        # far enough to prove its module graph resolves inside the runtime
+        # image. Stopping at environment validation is expected; a module
+        # resolution error fails.
+        run: |
+          set -euo pipefail
+          for entrypoint in /app/scheduler.js /app/document-processing-worker.js /app/backfill.js; do
+            output=$(docker run --rm stella-api:smoke timeout 20 bun "$entrypoint" 2>&1 || true)
+            if grep -qiE "cannot (find|resolve) (module|package)" <<<"$output"; then
+              echo "::error::${entrypoint} failed module resolution in the runtime image."
+              printf '%s\n' "$output"
+              exit 1
+            fi
+            if ! grep -q "Invalid environment variables" <<<"$output"; then
+              echo "::error::${entrypoint} did not reach environment validation."
+              printf '%s\n' "$output"
+              exit 1
+            fi
+          done
+          docker run --rm stella-api:smoke bun /app/legal-atlas.js list
+
   build-arm64:
     name: Build API image (linux/arm64)
     runs-on: ubuntu-24.04-arm

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -19,14 +19,16 @@ RUN mkdir -p /json && \
 # Prune the monorepo for the API
 FROM base AS pruner
 # Keep in sync with the turbo version in the root package.json.
-RUN bun install -g turbo@2.10.7
+RUN --mount=type=cache,target=/root/.bun/install/cache \
+    bun install -g turbo@2.10.7
 COPY . .
 RUN turbo prune @stll/api @stll/legal-atlas-runner --docker
 
 # Install dependencies using only package manifests (cached layer)
 FROM base AS deps
 COPY --from=install-inputs /json/ .
-RUN bun install --filter @stll/api --filter @stll/legal-atlas-runner --frozen-lockfile --ignore-scripts --network-concurrency=8
+RUN --mount=type=cache,target=/root/.bun/install/cache \
+    bun install --filter @stll/api --filter @stll/legal-atlas-runner --frozen-lockfile --ignore-scripts --network-concurrency=8
 
 # Copy source code and compile the API to a Bun binary.
 #
@@ -88,8 +90,12 @@ RUN mkdir -p /app/runtime-workers && \
       apps/api/src/lib/search/extraction-worker.ts
 RUN bun --filter @stll/legal-atlas-runner build
 
-# Run the compiled API as non-root.
-FROM deps AS runner
+# Run the compiled API as non-root. Built from the bare base image: every
+# entrypoint is either the compiled binary or a self-contained
+# `bun build --target bun` bundle, so the runtime image ships only those
+# outputs plus the asset trees they read at runtime; the workspace install
+# (node_modules, manifest tree) stays in the build stages.
+FROM base AS runner
 # Stamp the running container with the release version so the API can
 # return it from /health and tag PostHog events with build metadata.
 # Defaults to "dev" for local `docker build` outside the release flow.


### PR DESCRIPTION
The API runner stage previously built on the full workspace install, so the runtime image carried node_modules (including dev tooling) and the manifest tree alongside the compiled binary. Every entrypoint is either the compiled server binary or a self-contained `bun build --target bun` bundle, so none of that is needed at runtime.

- Runner stage now starts from the bare base image and ships only the compiled outputs, the drizzle folder, and the runtime asset trees (workers, yara, anonymize-wasm, quickjs WASM). Image size drops from 1.07GB to 420MB.
- Release preflight gains a boot-smoke that loads each bundled entrypoint inside the runtime image and asserts it reaches environment validation rather than failing module resolution; `legal-atlas.js list` runs end-to-end.
- `bun install` steps use a BuildKit cache mount.

Verified locally against both images: all six entrypoints reproduce identical fail-fast behavior (env validation / usage output), with no module resolution errors; infra task definitions only invoke entrypoints the image still ships.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release validation by checking that key background processing services start correctly and reach environment validation.
  * Added safeguards to detect missing modules or packages during smoke testing.
  * Streamlined production images to reduce unnecessary build content and improve deployment efficiency.
  * Improved build performance through better reuse of cached build data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->