### PR TITLE
fix(release): warn on stale marketing recordings instead of blocking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -355,7 +355,7 @@ jobs:
           BASE_REF: ${{ github.base_ref || 'main' }}
         run: bash scripts/check-release-changelog.sh --base "origin/$BASE_REF"
 
-      - name: Release marketing freshness guard
+      - name: Release marketing freshness warning
         if: github.event_name == 'pull_request'
         env:
           BASE_REF: ${{ github.base_ref || 'main' }}
@@ -364,7 +364,9 @@ jobs:
             echo "VERSION unchanged; fresh release recordings not required."
             exit 0
           fi
-          bun run marketing:stale --strict
+          if ! bun run marketing:stale --strict; then
+            echo "::warning::Stale marketing recordings for this release (see step log). Re-record with \`bun run marketing:reshoot\`."
+          fi
 
       - name: Format
         if: needs.ci-plan.outputs.package_checks_required == 'true'

--- a/.github/workflows/tag-on-version-bump.yml
+++ b/.github/workflows/tag-on-version-bump.yml
@@ -95,14 +95,17 @@ jobs:
             echo "skip=true" >> "$GITHUB_ENV"
           fi
 
-      - name: Require fresh marketing recordings
+      - name: Warn on stale marketing recordings
         if: env.skip != 'true'
         # Reads the committed captures.ts matrix and recordings-manifest.json
-        # only (no node_modules), so no install step is needed. `--strict`
-        # fails the tag push instead of just reporting; run
-        # `bun run marketing:reshoot` (re-records only the stale captures)
-        # before bumping VERSION to clear this.
-        run: bun run marketing:stale --strict
+        # only (no node_modules), so no install step is needed. Marketing
+        # freshness is content debt, not a release defect: staleness surfaces
+        # as a workflow warning instead of blocking the tag. Clear it with
+        # `bun run marketing:reshoot` (re-records only the stale captures).
+        run: |
+          if ! bun run marketing:stale --strict; then
+            echo "::warning::Stale marketing recordings (see step log). Re-record with \`bun run marketing:reshoot\`."
+          fi
 
       - name: Push tag
         if: env.skip != 'true'


### PR DESCRIPTION
The tag-on-VERSION-bump workflow ran `marketing:stale --strict`, so stale marketing recordings blocked the release tag outright. The strict PR-side guard in ci.yml cannot reliably prevent this: it checks the PR head against main at CI time, and any later merge that touches a watched source tree re-stales the recordings before the post-merge tag check runs, failing the release with no pre-merge signal (v0.6.20 hit exactly this: 28/28 recordings reported stale at tag time).

Marketing freshness is content debt, not a release defect. Both gates now run the same check but surface staleness as a `::warning::` annotation instead of failing: the release PR shows it early, the tag push proceeds regardless. `bun run marketing:reshoot` remains the way to clear the warning.