### PR TITLE
chore(web): copy only runtime files into the web image

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -118,7 +118,11 @@ ENV HOST=0.0.0.0
 ENV PORT=3002
 RUN groupadd --system --gid 1001 stella && \
     useradd --system --uid 1001 --gid stella --no-create-home stella
-COPY --chown=stella:stella --from=pruner /app/out/full/ .
+# The runtime needs only the workspace manifests (node_modules linkage), the
+# server entry, and the built output. Workspace sources stay in the build
+# stages; `scripts/check-web-docker-platform.test.ts` enforces this boundary.
+COPY --chown=stella:stella --from=pruner /app/out/json/ .
+COPY --chown=stella:stella --from=builder /app/apps/web/start-runtime.js ./apps/web/start-runtime.js
 COPY --chown=stella:stella --from=builder /app/apps/web/dist ./apps/web/dist
 WORKDIR /app/apps/web
 USER stella

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -37,14 +37,16 @@ RUN turbo prune @stll/web --docker
 
 FROM build-base AS deps
 COPY --from=install-inputs /json/ .
-RUN bun install --filter @stll/web --frozen-lockfile --ignore-scripts --network-concurrency=8
+RUN --mount=type=cache,target=/root/.bun/install/cache \
+    bun install --filter @stll/web --frozen-lockfile --ignore-scripts --network-concurrency=8
 
 # Runtime install: the SSR server bundle (dist/server/server.js) externalises
 # its imports, so they must resolve from `dependencies` alone with
 # devDependencies stripped. The web-build CI job boot-smokes this same install.
 FROM runtime-base AS deps-prod
 COPY --from=install-inputs /json/ .
-RUN bun install --filter @stll/web --production --frozen-lockfile --ignore-scripts --network-concurrency=8
+RUN --mount=type=cache,target=/root/.bun/install/cache \
+    bun install --filter @stll/web --production --frozen-lockfile --ignore-scripts --network-concurrency=8
 
 FROM deps AS builder
 ARG STELLA_VERSION=dev

--- a/scripts/check-web-docker-platform.test.ts
+++ b/scripts/check-web-docker-platform.test.ts
@@ -59,9 +59,20 @@ describe("web container platform boundary", () => {
     });
     expect(crossPlatformCopies).toEqual([
       "deps-prod: COPY --from=install-inputs /json/ .",
-      "runner: COPY --chown=stella:stella --from=pruner /app/out/full/ .",
+      "runner: COPY --chown=stella:stella --from=pruner /app/out/json/ .",
+      "runner: COPY --chown=stella:stella --from=builder /app/apps/web/start-runtime.js ./apps/web/start-runtime.js",
       "runner: COPY --chown=stella:stella --from=builder /app/apps/web/dist ./apps/web/dist",
     ]);
+  });
+
+  test("keeps workspace source out of the runtime image", () => {
+    const runner = stagesByName.get("runner");
+    // The pruned source tree (out/full) belongs to the build stages only; the
+    // runtime needs just workspace manifests, the server entry, and dist/.
+    expect(runner?.body).not.toContain("out/full");
+    expect(runner?.body).toContain(
+      "COPY --chown=stella:stella --from=pruner /app/out/json/ .",
+    );
   });
 
   test("uses the same pinned multi-architecture base for build and runtime", () => {


### PR DESCRIPTION
The web runner stage copied the whole pruned workspace tree (`out/full`), which put backend and workspace source inside the public-facing web container. The runtime surface is only: workspace manifests (for node_modules linkage), `start-runtime.js`, and `dist/` — verified by reading the entrypoint (imports only Bun builtins and `dist/server/server.js`, serves from `dist/client/`).

- Runner now copies exactly those three; the platform stage split and `deps-prod` stage are untouched.
- `check-web-docker-platform.test.ts` gains a structural assertion that the runner never copies `out/full`, so the boundary is enforced, not conventional.
- BuildKit cache mounts on both `bun install` steps.

Verified with local builds of both images: container boots, `/health` and SSR `/` return 200, and an exec inspection confirms zero `src` directories remain under `apps/` or `packages/`.