### PR TITLE
chore(e2e): raise skills seed query budget to its multi-page cost

### DIFF
--- a/apps/web/e2e/network-baseline.json
+++ b/apps/web/e2e/network-baseline.json
@@ -553,7 +553,7 @@
       "GET /v1/organization-settings": 6,
       "GET /v1/organization-settings/ai-availability": 4,
       "GET /v1/workspaces/navigation": 6,
-      "POST /v1/skills/seed": 6
+      "POST /v1/skills/seed": 9
     },
     "responseSizes": {
       "GET /api/auth/get-session": 1024,
@@ -647,7 +647,7 @@
       "GET /v1/organization-settings": 6,
       "GET /v1/organization-settings/ai-availability": 4,
       "GET /v1/workspaces/navigation": 6,
-      "POST /v1/skills/seed": 6
+      "POST /v1/skills/seed": 9
     },
     "responseSizes": {
       "GET /api/auth/get-session": 1024,
@@ -698,7 +698,7 @@
       "GET /v1/organization-settings": 6,
       "GET /v1/organization-settings/ai-availability": 4,
       "GET /v1/workspaces/navigation": 6,
-      "POST /v1/skills/seed": 6
+      "POST /v1/skills/seed": 9
     },
     "responseSizes": {
       "GET /api/auth/get-session": 1024,
@@ -839,7 +839,7 @@
       "GET /v1/organization-settings": 6,
       "GET /v1/organization-settings/ai-availability": 4,
       "GET /v1/workspaces/navigation": 6,
-      "POST /v1/skills/seed": 6
+      "POST /v1/skills/seed": 9
     },
     "responseSizes": {
       "GET /api/auth/get-session": 1024,
@@ -1332,7 +1332,7 @@
       "GET /v1/organization-settings": 6,
       "GET /v1/organization-settings/ai-availability": 4,
       "GET /v1/workspaces/navigation": 6,
-      "POST /v1/skills/seed": 6
+      "POST /v1/skills/seed": 9
     },
     "responseSizes": {
       "GET /api/auth/get-session": 1024,


### PR DESCRIPTION
Baseline adjustment, justified rather than mechanical: #1626 changed bounding-box generation to treat a page with no boxes as an empty result instead of failing the request, so `POST /v1/skills/seed` now processes every cited page and persists boxes from all of them. The three additional queries per request are that legitimately added work, not an N+1 (the route-smoke guard reports 6 → 9 on the affected routes). This bumps only that endpoint's per-request DB query budget, on all five routes that invoke it; every other budget stays as committed.