### PR TITLE
chore(github): repair issue template project ref and add issue chooser links

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -2,7 +2,7 @@ name: "\U0001F41B Bug Report"
 description: Submit a bug report
 title: "bug: "
 type: "bug"
-projects: ["stll-ai/1"]
+projects: ["stella/1"]
 
 body:
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 💬 Discord
+    url: https://discord.gg/8dZjmVFjTK
+    about: Questions, setup help, and development chat.
+  - name: 🔒 Security vulnerability
+    url: https://github.com/stella/stella/security/policy
+    about: Do not open a public issue. Report privately to security@stll.app.
+  - name: 📖 Contributing guide
+    url: https://github.com/stella/stella/blob/main/CONTRIBUTING.md
+    about: Local setup, conventions, and the pull request checklist.

--- a/.github/ISSUE_TEMPLATE/epic.yml
+++ b/.github/ISSUE_TEMPLATE/epic.yml
@@ -3,7 +3,7 @@ description: Epic
 title: "epic: "
 labels: ["⚡ epic"]
 type: "task"
-projects: ["stll-ai/1"]
+projects: ["stella/1"]
 
 body:
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -3,7 +3,7 @@ description: Submit a proposal/request for a feature
 title: "feat: "
 labels: ["needs approval"]
 type: "feature"
-projects: ["stll-ai/1"]
+projects: ["stella/1"]
 
 body:
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/other.yml
+++ b/.github/ISSUE_TEMPLATE/other.yml
@@ -1,7 +1,7 @@
 name: "Other Issue"
 description: Raise an issue that wouldn't be covered by the other templates.
 type: "task"
-projects: ["stll-ai/1"]
+projects: ["stella/1"]
 
 body:
   - type: textarea


### PR DESCRIPTION
All four issue templates carried `projects: ["stll-ai/1"]`. That owner returns 404, so every issue opened from a template silently failed to reach the board. The org-level templates in `stella/.github` already use `stella/1`; this brings the repo-local copies (which override them) back in line.

Adds `ISSUE_TEMPLATE/config.yml` so the chooser offers Discord for questions, the security policy for vulnerability reports, and CONTRIBUTING.md for setup, rather than sending all three down the issue tracker.

`blank_issues_enabled: false` because `other.yml` already covers the unstructured case.