### PR TITLE
chore: add unit tests for array normalizers, matter-color helpers, and iterateJustificationCitations

### DIFF
--- a/apps/web/src/lib/arrays.test.ts
+++ b/apps/web/src/lib/arrays.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  normalizeOptionalArray,
+  optionalArray,
+  optionalReadonlyArray,
+} from "./arrays";
+
+describe("normalizeOptionalArray", () => {
+  test("returns the array unchanged when populated", () => {
+    expect(normalizeOptionalArray([1, 2, 3])).toEqual([1, 2, 3]);
+  });
+
+  test("returns [] for an empty array", () => {
+    expect(normalizeOptionalArray([])).toEqual([]);
+  });
+
+  test("returns [] for undefined", () => {
+    expect(normalizeOptionalArray(undefined)).toEqual([]);
+  });
+});
+
+describe("optionalArray", () => {
+  test("returns the array unchanged when populated", () => {
+    expect(optionalArray(["a", "b"])).toEqual(["a", "b"]);
+  });
+
+  test("returns [] for an empty array", () => {
+    expect(optionalArray([])).toEqual([]);
+  });
+
+  test("returns [] for null", () => {
+    expect(optionalArray(null)).toEqual([]);
+  });
+
+  test("returns [] for undefined", () => {
+    expect(optionalArray(undefined)).toEqual([]);
+  });
+});
+
+describe("optionalReadonlyArray", () => {
+  test("returns the array unchanged when populated", () => {
+    expect(optionalReadonlyArray([10, 20])).toEqual([10, 20]);
+  });
+
+  test("returns [] for an empty readonly array", () => {
+    expect(optionalReadonlyArray([])).toEqual([]);
+  });
+
+  test("returns [] for null", () => {
+    expect(optionalReadonlyArray(null)).toEqual([]);
+  });
+
+  test("returns [] for undefined", () => {
+    expect(optionalReadonlyArray(undefined)).toEqual([]);
+  });
+});

--- a/apps/web/src/lib/citations.test.ts
+++ b/apps/web/src/lib/citations.test.ts
@@ -73,3 +73,106 @@ describe("iterateJustificationCitations — docx-folio status threading", () => 
     expect("blockId" in citation).toBe(false);
   });
 });
+
+describe("iterateJustificationCitations — pdf-bates block", () => {
+  test("yields one citation per bates reference", () => {
+    const content: JustificationContent = {
+      version: 1,
+      blocks: [
+        {
+          kind: "pdf-bates",
+          fileFieldId: "pdf-field-1",
+          statements: [
+            {
+              text: "Clause 4.1 applies.",
+              citations: [
+                { bates: "ACME-0001", pageNumber: 1 },
+                { bates: "ACME-0002", pageNumber: 2 },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    const citations = [...iterateJustificationCitations(content)];
+    expect(citations).toEqual([
+      {
+        kind: "pdf-bates",
+        fileFieldId: "pdf-field-1",
+        bates: "ACME-0001",
+        pageNumber: 1,
+      },
+      {
+        kind: "pdf-bates",
+        fileFieldId: "pdf-field-1",
+        bates: "ACME-0002",
+        pageNumber: 2,
+      },
+    ]);
+  });
+});
+
+describe("iterateJustificationCitations — mixed blocks", () => {
+  test("yields citations from all document blocks and skips playbook-verdict", () => {
+    const content: JustificationContent = {
+      version: 1,
+      blocks: [
+        {
+          kind: "pdf-bates",
+          fileFieldId: "pdf-field-1",
+          statements: [
+            { text: "first", citations: [{ bates: "REF-001", pageNumber: 5 }] },
+          ],
+        },
+        {
+          // playbook-verdict carries no document citations — should be skipped
+          kind: "playbook-verdict",
+          rationale: "Meets tier 2",
+        },
+        {
+          kind: "docx-folio",
+          fileFieldId: "docx-field-1",
+          statements: [
+            {
+              text: "second",
+              citations: [
+                {
+                  citationStatus: "verified",
+                  blockId: "BLK-42",
+                  text: "second",
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    const citations = [...iterateJustificationCitations(content)];
+    expect(citations).toHaveLength(2);
+    expect(citations[0]).toMatchObject({ kind: "pdf-bates", bates: "REF-001" });
+    expect(citations[1]).toMatchObject({
+      kind: "docx-folio",
+      blockId: "BLK-42",
+    });
+  });
+});
+
+describe("iterateJustificationCitations — empty input", () => {
+  test("yields nothing for an empty blocks array", () => {
+    const content: JustificationContent = { version: 1, blocks: [] };
+    expect([...iterateJustificationCitations(content)]).toEqual([]);
+  });
+
+  test("yields nothing for blocks with no statements", () => {
+    const content: JustificationContent = {
+      version: 1,
+      blocks: [
+        { kind: "pdf-bates", fileFieldId: "f", statements: [] },
+        { kind: "docx-folio", fileFieldId: "f", statements: [] },
+      ],
+    };
+    expect([...iterateJustificationCitations(content)]).toEqual([]);
+  });
+});

--- a/apps/web/src/lib/matter-colors.test.ts
+++ b/apps/web/src/lib/matter-colors.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  getMatterColor,
+  getMatterPickerColor,
+  getMatterSwatch,
+  MATTER_SWATCHES,
+  resolveMatterColor,
+  toStoredMatterColor,
+} from "./matter-colors";
+
+describe("getMatterSwatch", () => {
+  test("always returns the same swatch for the same id (deterministic hash)", () => {
+    const id = "matter-abc-123";
+    expect(getMatterSwatch(id)).toBe(getMatterSwatch(id));
+  });
+
+  test("returned swatch is within MATTER_SWATCHES", () => {
+    for (const id of ["alpha", "beta", "gamma", "delta", "epsilon"]) {
+      expect(MATTER_SWATCHES).toContain(getMatterSwatch(id));
+    }
+  });
+
+  test("different ids spread across multiple swatches", () => {
+    const seen = new Set(
+      ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j"].map(getMatterSwatch),
+    );
+    expect(seen.size).toBeGreaterThan(1);
+  });
+});
+
+describe("getMatterColor", () => {
+  test("wraps the swatch in a CSS var() expression", () => {
+    const id = "some-matter";
+    expect(getMatterColor(id)).toBe(`var(${getMatterSwatch(id)})`);
+  });
+});
+
+describe("getMatterPickerColor", () => {
+  test("returns the swatch name (without --option- prefix) when color is null", () => {
+    const swatch = getMatterSwatch("picker-id");
+    const expected = swatch.slice("--option-".length);
+    expect(getMatterPickerColor("picker-id", null)).toBe(expected);
+  });
+
+  test("strips # from a hex color", () => {
+    expect(getMatterPickerColor("any-id", "#A1B2C3")).toBe("A1B2C3");
+  });
+
+  test("strips --option- prefix from a CSS-var token", () => {
+    expect(getMatterPickerColor("any-id", "--option-violet")).toBe("violet");
+  });
+});
+
+describe("toStoredMatterColor", () => {
+  test("normalises a hex color to uppercase with # prefix", () => {
+    expect(toStoredMatterColor("a1b2c3")).toBe("#A1B2C3");
+    expect(toStoredMatterColor("#a1b2c3")).toBe("#A1B2C3");
+  });
+
+  test("returns --option-* tokens unchanged", () => {
+    expect(toStoredMatterColor("--option-emerald")).toBe("--option-emerald");
+  });
+
+  test("prepends --option- to bare color names", () => {
+    expect(toStoredMatterColor("cyan")).toBe("--option-cyan");
+  });
+});
+
+describe("resolveMatterColor — round-trip with toStoredMatterColor", () => {
+  test("hex input round-trips through storage and resolution", () => {
+    const stored = toStoredMatterColor("FF5733");
+    expect(resolveMatterColor("id", stored)).toBe("#FF5733");
+  });
+
+  test("CSS-var token resolves to var() form", () => {
+    expect(resolveMatterColor("id", "--option-teal")).toBe(
+      "var(--option-teal)",
+    );
+  });
+
+  test("bare color name resolves to var(--option-*)", () => {
+    expect(resolveMatterColor("id", "orange")).toBe("var(--option-orange)");
+  });
+
+  test("falls back to id-hash color when color is null", () => {
+    const id = "fallback-id";
+    expect(resolveMatterColor(id, null)).toBe(getMatterColor(id));
+  });
+});


### PR DESCRIPTION
## Proposed change

Three utility modules in `apps/web/src/lib/` had no test coverage. Added focused test files, verified green with `bun test` locally.

- **`arrays.test.ts`** (`#1632`) — covers `normalizeOptionalArray`, `optionalArray`, and `optionalReadonlyArray` with populated, empty, `null`, and `undefined` inputs
- **`matter-colors.test.ts`** (`#1634`) — tests deterministic hashing in `getMatterSwatch`, `var(…)` wrapping in `getMatterColor`, prefix-stripping in `getMatterPickerColor`, hex normalisation in `toStoredMatterColor`, and a full round-trip through `resolveMatterColor` for hex, CSS-var token, and the null/id-hash fallback
- **`citations.test.ts`** (`#1635`) — extends the existing docx-folio tests with the missing block-kind branches: `pdf-bates` (yields one citation per bates ref), mixed blocks skipping `playbook-verdict`, and empty inputs yielding nothing

Closes #1632, closes #1634, closes #1635

## Checklist

- [x] BUILD ASSURANCE | Code builds correctly and without any errors or warnings.
- [x] TESTING | Changes tested, including in different conditions (dark mode, language, narrow screen, etc).
- [x] DARK MODE SUPPORT | User can use the webapp in dark mode. Make sure your changes are visible in both light and dark mode.
- [x] ISSUE LINKED | Link an issue to this PR (not by mentioning it in the description, but by using the GitHub issue linking feature)
- [ ] SCREENSHOT INCLUDED | If relevant, please include a screenshot / video of the functionality added (allows for a quick check of minor ux changes)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for array utilities, citation processing, and colour utilities.
  * Added checks for empty, absent, mixed, and populated inputs, including citation ordering, document handling, colour fallbacks, and normalisation behaviour.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->