### PR TITLE
fix(ci): defer the staging deploy when staging is unreachable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -651,6 +651,7 @@ jobs:
       - name: Test release policy scripts
         run: |
           bun test scripts/check-api-deployment.test.ts
+          bun test scripts/check-staging-deploy-decision.test.ts
           bash scripts/create-release-manifest.test.sh
 
       - name: Test maintenance release preparation

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -2,10 +2,19 @@ name: Deploy main to staging
 
 # Continuous deploy of every push to main into staging. The tagged
 # release workflow remains the production path.
+#
+# Staging can be unreachable for reasons that say nothing about the commit, so
+# an unreachable environment defers the deploy instead of failing it, and the
+# schedule below resumes the deploy once staging answers again. What still
+# fails is a commit that cannot reach staging for MAX_DEFERRAL_HOURS: that is
+# a stalled delivery rather than a passing interruption.
 
 on:
   push:
     branches: [main]
+  schedule:
+    # Resume deferred deploys once staging is reachable again.
+    - cron: "*/30 * * * *"
   workflow_dispatch:
 
 # Queue rather than cancel: build-and-deploy dispatches a promotion to the
@@ -28,10 +37,12 @@ jobs:
     name: Check staging health
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-24.04
-    timeout-minutes: 2
-    permissions: {}
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      deployments: read
     outputs:
-      status: ${{ steps.probe.outputs.status }}
+      deploy: ${{ steps.decide.outputs.deploy }}
 
     steps:
       - name: Probe staging health
@@ -48,6 +59,7 @@ jobs:
 
           response_file="$RUNNER_TEMP/staging-health.json"
           status="$NOT_READY_STATUS"
+          served_commit=""
           for ((attempt = 1; attempt <= MAX_ATTEMPTS; attempt += 1)); do
             http_status="000"
             if ! http_status="$(
@@ -66,6 +78,7 @@ jobs:
             if [[ "$http_status" == "200" ]] &&
               jq -e '.status == "ok"' "$response_file" >/dev/null 2>&1; then
               status="$READY_STATUS"
+              served_commit="$(jq -r '.commit // ""' "$response_file")"
               break
             fi
 
@@ -76,27 +89,104 @@ jobs:
           done
 
           echo "status=${status}" >> "$GITHUB_OUTPUT"
-          if [[ "$status" == "$NOT_READY_STATUS" ]]; then
-            if [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]; then
-              echo "::notice::Staging health gate did not pass; workflow_dispatch bypasses the gate and deploys anyway."
-            else
+          echo "served_commit=${served_commit}" >> "$GITHUB_OUTPUT"
+
+      # Absent staging defers; a commit that stays undeliverable fails.
+      - name: Decide deploy, defer, or escalate
+        id: decide
+        env:
+          DEPLOY_ENVIRONMENT: staging
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SERVED_COMMIT: ${{ steps.probe.outputs.served_commit }}
+          STATUS: ${{ steps.probe.outputs.status }}
+        run: |
+          set -euo pipefail
+
+          # A passing interruption resolves well inside this budget; anything
+          # longer is a stalled delivery worth waking someone.
+          readonly MAX_DEFERRAL_HOURS=12
+
+          if [[ "$STATUS" == "ready" ]]; then
+            # A push or dispatch always deploys what it carries. The schedule
+            # only resumes a deploy it can prove is missing, so an unreadable
+            # commit stamp leaves staging alone instead of redeploying it on
+            # every tick.
+            if [[ "$GITHUB_EVENT_NAME" == "schedule" ]]; then
+              if [[ ! "$SERVED_COMMIT" =~ ^[0-9a-f]{40}$ ]]; then
+                echo "deploy=false" >> "$GITHUB_OUTPUT"
+                echo "Staging reported no resolvable commit, so there is nothing to resume." >> "$GITHUB_STEP_SUMMARY"
+                exit 0
+              fi
+              if [[ "$SERVED_COMMIT" == "$GITHUB_SHA" ]]; then
+                echo "deploy=false" >> "$GITHUB_OUTPUT"
+                echo "Staging already serves \`${GITHUB_SHA}\`; nothing to resume." >> "$GITHUB_STEP_SUMMARY"
+                exit 0
+              fi
+            fi
+            echo "deploy=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]; then
+            echo "deploy=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::Staging is not answering; workflow_dispatch bypasses the gate and deploys anyway."
+            exit 0
+          fi
+
+          echo "deploy=false" >> "$GITHUB_OUTPUT"
+
+          # Only the schedule escalates. A push has just started waiting, and
+          # the schedule revisits it well before the budget runs out, so the
+          # decision is made in one place against a measured wait.
+          if [[ "$GITHUB_EVENT_NAME" == "schedule" ]]; then
+            # The last commit recorded as deployed. Empty before this workflow
+            # has recorded one, which reads as "still pending" and so can only
+            # escalate, never suppress.
+            deployed_sha="$(
+              gh api \
+                "repos/${GITHUB_REPOSITORY}/deployments?environment=${DEPLOY_ENVIRONMENT}&per_page=1" \
+                --jq '.[0].sha // ""'
+            )"
+
+            if [[ "$deployed_sha" == "$GITHUB_SHA" ]]; then
               {
-                echo "### Staging health gate failed"
-                echo "The staging health probe did not return a ready status after ${MAX_ATTEMPTS} attempts."
-                echo "This deployment was skipped. Continuous deploy to staging is stalled until staging health recovers, or until this workflow is re-run with workflow_dispatch to bypass the gate."
+                echo "### Staging is not answering"
+                echo "Nothing is waiting: staging already has \`${GITHUB_SHA}\`, so this run stays green."
               } >> "$GITHUB_STEP_SUMMARY"
-              echo "::error::Staging health gate did not pass after ${MAX_ATTEMPTS} attempts; skipping this deployment and failing the run so continuous deploy does not stall silently."
+              exit 0
+            fi
+
+            committed_at="$(
+              gh api "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}" \
+                --jq '.commit.committer.date'
+            )"
+            waited_seconds=$(( $(date -u +%s) - $(date -u -d "$committed_at" +%s) ))
+
+            if (( waited_seconds > MAX_DEFERRAL_HOURS * 3600 )); then
+              waited_hours=$(( waited_seconds / 3600 ))
+              {
+                echo "### Staging deploy stalled"
+                echo "\`${GITHUB_SHA}\` has been undeployable for ${waited_hours}h because staging has not answered its health probe."
+                echo "That is past the ${MAX_DEFERRAL_HOURS}h budget, so staging needs a look."
+              } >> "$GITHUB_STEP_SUMMARY"
+              echo "::error::Staging has not accepted ${GITHUB_SHA} for ${waited_hours}h (budget ${MAX_DEFERRAL_HOURS}h); the environment needs attention."
               exit 1
             fi
           fi
+
+          {
+            echo "### Staging deploy deferred"
+            echo "Staging is not answering its health probe, so \`${GITHUB_SHA}\` was not deployed."
+            echo "The scheduled run resumes it automatically once staging is reachable; this run stays green because the commit itself is fine."
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "::notice::Staging is not answering; deploy of ${GITHUB_SHA} deferred until it does."
 
   build-and-deploy:
     name: Build + deploy staging
     needs: staging-health
     if: >-
       github.ref == 'refs/heads/main' &&
-      (github.event_name == 'workflow_dispatch' ||
-      needs.staging-health.outputs.status == 'ready')
+      needs.staging-health.outputs.deploy == 'true'
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 90
     permissions:
@@ -105,6 +195,7 @@ jobs:
       id-token: write
       attestations: write
       artifact-metadata: write
+      deployments: write
 
     steps:
       - name: Resolve synthetic ref
@@ -187,6 +278,36 @@ jobs:
           target-environment: staging
           image-digest: ${{ steps.build.outputs.digest }}
           git-sha: ${{ github.sha }}
+
+      # The commit staging is running, recorded where it outlives this run:
+      # the health gate reads it to tell a deploy that is waiting from one
+      # that is stuck.
+      - name: Record staging deployment
+        env:
+          DEPLOY_ENVIRONMENT: staging
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          deployment_id="$(
+            jq -n \
+              --arg ref "$GITHUB_SHA" \
+              --arg environment "$DEPLOY_ENVIRONMENT" \
+              '{
+                ref: $ref,
+                environment: $environment,
+                auto_merge: false,
+                required_contexts: [],
+                production_environment: false,
+                description: "Continuous deploy of main to staging"
+              }' |
+              gh api "repos/${GITHUB_REPOSITORY}/deployments" \
+                --method POST --input - --jq '.id'
+          )"
+
+          jq -n '{state: "success", environment_url: "https://staging.stll.app"}' |
+            gh api "repos/${GITHUB_REPOSITORY}/deployments/${deployment_id}/statuses" \
+              --method POST --input - >/dev/null
 
   # Post-deploy verification: authenticate via the secret-guarded
   # /smoke/session endpoint and click through the deployed app so a

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -156,11 +156,13 @@ jobs:
               exit 0
             fi
 
-            committed_at="$(
+            # jq resolves the timestamp so the arithmetic does not depend on
+            # GNU date's -d.
+            committed_epoch="$(
               gh api "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}" \
-                --jq '.commit.committer.date'
+                --jq '.commit.committer.date | fromdateiso8601'
             )"
-            waited_seconds=$(( $(date -u +%s) - $(date -u -d "$committed_at" +%s) ))
+            waited_seconds=$(( $(date -u +%s) - committed_epoch ))
 
             if (( waited_seconds > MAX_DEFERRAL_HOURS * 3600 )); then
               waited_hours=$(( waited_seconds / 3600 ))

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -156,22 +156,40 @@ jobs:
               exit 0
             fi
 
-            # jq resolves the timestamp so the arithmetic does not depend on
-            # GNU date's -d.
-            committed_epoch="$(
-              gh api "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}" \
-                --jq '.commit.committer.date | fromdateiso8601'
-            )"
-            waited_seconds=$(( $(date -u +%s) - committed_epoch ))
+            # How long delivery has been blocked, which is the age of the
+            # oldest commit staging has not taken yet. Measuring the tip
+            # instead would restart the clock on every push made during one
+            # continuous outage, so the alarm would never fire. jq resolves
+            # the timestamp so the arithmetic does not depend on GNU date's -d.
+            pending_since_epoch=""
+            if [[ -n "$deployed_sha" ]]; then
+              pending_since_epoch="$(
+                gh api \
+                  "repos/${GITHUB_REPOSITORY}/compare/${deployed_sha}...${GITHUB_SHA}" \
+                  --jq '[.commits[].commit.committer.date | fromdateiso8601] | first // empty' \
+                  2>/dev/null || true
+              )"
+            fi
+
+            # Before the first recorded deployment, and if the recorded commit
+            # has since left the history, the tip is all there is to measure.
+            if [[ -z "$pending_since_epoch" ]]; then
+              pending_since_epoch="$(
+                gh api "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}" \
+                  --jq '.commit.committer.date | fromdateiso8601'
+              )"
+            fi
+
+            waited_seconds=$(( $(date -u +%s) - pending_since_epoch ))
 
             if (( waited_seconds > MAX_DEFERRAL_HOURS * 3600 )); then
               waited_hours=$(( waited_seconds / 3600 ))
               {
                 echo "### Staging deploy stalled"
-                echo "\`${GITHUB_SHA}\` has been undeployable for ${waited_hours}h because staging has not answered its health probe."
+                echo "Staging has not answered its health probe, and has taken no commit for ${waited_hours}h. The tip waiting on it is \`${GITHUB_SHA}\`."
                 echo "That is past the ${MAX_DEFERRAL_HOURS}h budget, so staging needs a look."
               } >> "$GITHUB_STEP_SUMMARY"
-              echo "::error::Staging has not accepted ${GITHUB_SHA} for ${waited_hours}h (budget ${MAX_DEFERRAL_HOURS}h); the environment needs attention."
+              echo "::error::Staging has taken no commit for ${waited_hours}h (budget ${MAX_DEFERRAL_HOURS}h); the environment needs attention."
               exit 1
             fi
           fi

--- a/scripts/check-api-deployment.test.ts
+++ b/scripts/check-api-deployment.test.ts
@@ -18,10 +18,15 @@ describe("API deployment health receipt", () => {
     expect(deployJobStart).toBeGreaterThan(healthJobStart);
     expect(verifyJobStart).toBeGreaterThan(deployJobStart);
     // The gate only reads: it decides whether to promote, never promotes.
-    const healthPermissions = healthJob.slice(
-      healthJob.indexOf("permissions:"),
-      healthJob.indexOf("outputs:"),
-    );
+    // Both delimiters are asserted so a missing block cannot slice to "" and
+    // satisfy the write check by being empty.
+    const permissionsStart = healthJob.indexOf("permissions:");
+    const outputsStart = healthJob.indexOf("outputs:");
+    expect(permissionsStart).toBeGreaterThanOrEqual(0);
+    expect(outputsStart).toBeGreaterThan(permissionsStart);
+    const healthPermissions = healthJob.slice(permissionsStart, outputsStart);
+    expect(healthPermissions).toContain("contents: read");
+    expect(healthPermissions).toContain("deployments: read");
     expect(healthPermissions).not.toContain("write");
     expect(healthJob).toContain(
       "STAGING_HEALTH_URL: https://api-staging.stll.app/health",

--- a/scripts/check-api-deployment.test.ts
+++ b/scripts/check-api-deployment.test.ts
@@ -17,7 +17,12 @@ describe("API deployment health receipt", () => {
     expect(healthJobStart).toBeGreaterThanOrEqual(0);
     expect(deployJobStart).toBeGreaterThan(healthJobStart);
     expect(verifyJobStart).toBeGreaterThan(deployJobStart);
-    expect(healthJob).toContain("permissions: {}");
+    // The gate only reads: it decides whether to promote, never promotes.
+    const healthPermissions = healthJob.slice(
+      healthJob.indexOf("permissions:"),
+      healthJob.indexOf("outputs:"),
+    );
+    expect(healthPermissions).not.toContain("write");
     expect(healthJob).toContain(
       "STAGING_HEALTH_URL: https://api-staging.stll.app/health",
     );
@@ -29,13 +34,12 @@ describe("API deployment health receipt", () => {
     expect(healthJob).toContain(
       "workflow_dispatch bypasses the gate and deploys anyway.",
     );
-    expect(healthJob).toContain(
-      "failing the run so continuous deploy does not stall silently",
-    );
+    // An unreachable environment defers; only a wait past the budget fails.
+    expect(healthJob).toContain("readonly MAX_DEFERRAL_HOURS=");
+    expect(healthJob).toContain("the environment needs attention.");
     expect(deployJob).toContain("needs: staging-health");
-    expect(deployJob).toContain("github.event_name == 'workflow_dispatch'");
     expect(deployJob).toContain(
-      "needs.staging-health.outputs.status == 'ready'",
+      "needs.staging-health.outputs.deploy == 'true'",
     );
   });
 

--- a/scripts/check-staging-deploy-decision.test.ts
+++ b/scripts/check-staging-deploy-decision.test.ts
@@ -42,6 +42,9 @@ type DecisionCase = {
   committedHoursAgo?: number;
   deployedSha?: string;
   event: "push" | "schedule" | "workflow_dispatch";
+  // Age of the oldest commit staging has not taken. Defaults to the tip's own
+  // age; set it independently to model an outage that outlives its commits.
+  pendingSinceHoursAgo?: number;
   servedCommit?: string;
   status: "not_ready" | "ready";
 };
@@ -55,6 +58,7 @@ const runDecision = async ({
   committedHoursAgo = 1,
   deployedSha = OTHER_SHA,
   event,
+  pendingSinceHoursAgo,
   servedCommit = "",
   status,
 }: DecisionCase): Promise<Decision> => {
@@ -62,8 +66,10 @@ const runDecision = async ({
   const summaryPath = join(workspace, `summary-${Bun.randomUUIDv7()}.md`);
   await Promise.all([Bun.write(outputPath, ""), Bun.write(summaryPath, "")]);
 
-  const committedEpoch =
-    Math.floor(Date.now() / 1000) - committedHoursAgo * HOUR_SECONDS;
+  const nowSeconds = Math.floor(Date.now() / 1000);
+  const committedEpoch = nowSeconds - committedHoursAgo * HOUR_SECONDS;
+  const pendingSinceEpoch =
+    nowSeconds - (pendingSinceHoursAgo ?? committedHoursAgo) * HOUR_SECONDS;
 
   const result = Bun.spawnSync(["bash", scriptPath], {
     env: {
@@ -80,6 +86,7 @@ const runDecision = async ({
       STATUS: status,
       STUB_COMMITTED_EPOCH: String(committedEpoch),
       STUB_DEPLOYED_SHA: deployedSha,
+      STUB_PENDING_SINCE_EPOCH: String(pendingSinceEpoch),
     },
   });
 
@@ -101,8 +108,9 @@ beforeAll(async () => {
   expect(script).toContain("readonly MAX_DEFERRAL_HOURS=");
   await Bun.write(scriptPath, script);
 
-  // Stands in for the two reads the script makes: the last recorded staging
-  // deployment, and the commit's timestamp.
+  // Stands in for the reads the script makes: the last recorded staging
+  // deployment, the oldest commit staging has not taken, and the tip's own
+  // timestamp.
   const stub = join(workspace, "gh");
   await Bun.write(
     stub,
@@ -110,6 +118,7 @@ beforeAll(async () => {
 for arg in "$@"; do
   case "$arg" in
     *"/deployments?environment="*) echo "\${STUB_DEPLOYED_SHA}"; exit 0 ;;
+    *"/compare/"*) echo "\${STUB_PENDING_SINCE_EPOCH}"; exit 0 ;;
     *"/commits/"*) echo "\${STUB_COMMITTED_EPOCH}"; exit 0 ;;
   esac
 done
@@ -197,6 +206,30 @@ describe("staging deploy decision", () => {
         status: "not_ready",
       }),
     ).toEqual({ deploy: "deploy=false", exitCode: 1 });
+  });
+
+  // Measuring the tip would restart the clock on every push made during one
+  // outage, so the alarm would never fire during the longest outages.
+  test("keeps the clock running when a push lands mid-outage", async () => {
+    expect(
+      await runDecision({
+        committedHoursAgo: 1,
+        event: "schedule",
+        pendingSinceHoursAgo: 20,
+        status: "not_ready",
+      }),
+    ).toEqual({ deploy: "deploy=false", exitCode: 1 });
+  });
+
+  test("does not escalate when only the tip is old but delivery is current", async () => {
+    expect(
+      await runDecision({
+        committedHoursAgo: 240,
+        event: "schedule",
+        pendingSinceHoursAgo: 2,
+        status: "not_ready",
+      }),
+    ).toEqual({ deploy: "deploy=false", exitCode: 0 });
   });
 
   test("escalates when no deployment has ever been recorded", async () => {

--- a/scripts/check-staging-deploy-decision.test.ts
+++ b/scripts/check-staging-deploy-decision.test.ts
@@ -1,0 +1,223 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { chmod, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// The staging gate decides, per run, whether to deploy, defer, or escalate.
+// Reading that decision out of the workflow text only proves the words are
+// there, so this runs the real script against a stubbed API instead: the
+// outcome of a push during an outage is exactly what regresses unnoticed.
+
+const WORKFLOW_URL = new URL(
+  "../.github/workflows/deploy-staging.yml",
+  import.meta.url,
+);
+const TIP_SHA = "a".repeat(40);
+const OTHER_SHA = "b".repeat(40);
+const HOUR_SECONDS = 3600;
+
+const extractDecideScript = (workflow: string) => {
+  const stepStart = workflow.indexOf(
+    "      - name: Decide deploy, defer, or escalate\n",
+  );
+  const jobEnd = workflow.indexOf("\n  build-and-deploy:\n", stepStart);
+  const runStart = workflow.indexOf("run: |\n", stepStart);
+  if (stepStart < 0 || jobEnd < 0 || runStart < 0) {
+    throw new Error("deploy-staging.yml no longer exposes the decide step");
+  }
+
+  const body = workflow.slice(runStart + "run: |\n".length, jobEnd);
+  const indents = body
+    .split("\n")
+    .filter((line) => line.trim().length > 0)
+    .map((line) => line.length - line.trimStart().length);
+  const dedent = Math.min(...indents);
+  return body
+    .split("\n")
+    .map((line) => line.slice(dedent))
+    .join("\n");
+};
+
+type DecisionCase = {
+  committedHoursAgo?: number;
+  deployedSha?: string;
+  event: "push" | "schedule" | "workflow_dispatch";
+  servedCommit?: string;
+  status: "not_ready" | "ready";
+};
+
+type Decision = { deploy: string; exitCode: number };
+
+let workspace = "";
+let scriptPath = "";
+
+const runDecision = async ({
+  committedHoursAgo = 1,
+  deployedSha = OTHER_SHA,
+  event,
+  servedCommit = "",
+  status,
+}: DecisionCase): Promise<Decision> => {
+  const outputPath = join(workspace, `output-${Bun.randomUUIDv7()}.txt`);
+  const summaryPath = join(workspace, `summary-${Bun.randomUUIDv7()}.md`);
+  await Promise.all([Bun.write(outputPath, ""), Bun.write(summaryPath, "")]);
+
+  const committedEpoch =
+    Math.floor(Date.now() / 1000) - committedHoursAgo * HOUR_SECONDS;
+
+  const result = Bun.spawnSync(["bash", scriptPath], {
+    env: {
+      ...process.env,
+      DEPLOY_ENVIRONMENT: "staging",
+      GH_TOKEN: "stub",
+      GITHUB_EVENT_NAME: event,
+      GITHUB_OUTPUT: outputPath,
+      GITHUB_REPOSITORY: "stella/stella",
+      GITHUB_SHA: TIP_SHA,
+      GITHUB_STEP_SUMMARY: summaryPath,
+      PATH: `${workspace}:${process.env["PATH"] ?? ""}`,
+      SERVED_COMMIT: servedCommit,
+      STATUS: status,
+      STUB_COMMITTED_EPOCH: String(committedEpoch),
+      STUB_DEPLOYED_SHA: deployedSha,
+    },
+  });
+
+  const output = await Bun.file(outputPath).text();
+  const deploy = output
+    .split("\n")
+    .filter((line) => line.startsWith("deploy="))
+    .at(-1);
+
+  return { deploy: deploy ?? "", exitCode: result.exitCode };
+};
+
+beforeAll(async () => {
+  workspace = await mkdtemp(join(tmpdir(), "staging-deploy-decision-"));
+  scriptPath = join(workspace, "decide.sh");
+
+  const script = extractDecideScript(await Bun.file(WORKFLOW_URL).text());
+  expect(script).toContain("set -euo pipefail");
+  expect(script).toContain("readonly MAX_DEFERRAL_HOURS=");
+  await Bun.write(scriptPath, script);
+
+  // Stands in for the two reads the script makes: the last recorded staging
+  // deployment, and the commit's timestamp.
+  const stub = join(workspace, "gh");
+  await Bun.write(
+    stub,
+    `#!/usr/bin/env bash
+for arg in "$@"; do
+  case "$arg" in
+    *"/deployments?environment="*) echo "\${STUB_DEPLOYED_SHA}"; exit 0 ;;
+    *"/commits/"*) echo "\${STUB_COMMITTED_EPOCH}"; exit 0 ;;
+  esac
+done
+exit 0
+`,
+  );
+  await chmod(stub, 0o755);
+});
+
+afterAll(async () => {
+  await rm(workspace, { force: true, recursive: true });
+});
+
+describe("staging deploy decision", () => {
+  test("deploys what a push or dispatch carries once staging answers", async () => {
+    expect(await runDecision({ event: "push", status: "ready" })).toEqual({
+      deploy: "deploy=true",
+      exitCode: 0,
+    });
+  });
+
+  test("resumes a deferred deploy when staging serves an older commit", async () => {
+    expect(
+      await runDecision({
+        event: "schedule",
+        servedCommit: OTHER_SHA,
+        status: "ready",
+      }),
+    ).toEqual({ deploy: "deploy=true", exitCode: 0 });
+  });
+
+  test("leaves staging alone when it already serves the tip", async () => {
+    expect(
+      await runDecision({
+        event: "schedule",
+        servedCommit: TIP_SHA,
+        status: "ready",
+      }),
+    ).toEqual({ deploy: "deploy=false", exitCode: 0 });
+  });
+
+  // An unreadable stamp once meant "staging is behind" forever, which
+  // redeployed staging on every scheduled tick.
+  test.each(["", "dev", TIP_SHA.toUpperCase(), `${TIP_SHA}extra`])(
+    "does not resume on the unresolvable commit stamp %p",
+    async (servedCommit) => {
+      expect(
+        await runDecision({ event: "schedule", servedCommit, status: "ready" }),
+      ).toEqual({ deploy: "deploy=false", exitCode: 0 });
+    },
+  );
+
+  test("deploys anyway when a dispatch bypasses the gate", async () => {
+    expect(
+      await runDecision({ event: "workflow_dispatch", status: "not_ready" }),
+    ).toEqual({ deploy: "deploy=true", exitCode: 0 });
+  });
+
+  test("defers instead of failing while staging is unreachable", async () => {
+    expect(
+      await runDecision({
+        committedHoursAgo: 11,
+        event: "schedule",
+        status: "not_ready",
+      }),
+    ).toEqual({ deploy: "deploy=false", exitCode: 0 });
+  });
+
+  test("stays green when nothing is waiting on the environment", async () => {
+    expect(
+      await runDecision({
+        committedHoursAgo: 240,
+        deployedSha: TIP_SHA,
+        event: "schedule",
+        status: "not_ready",
+      }),
+    ).toEqual({ deploy: "deploy=false", exitCode: 0 });
+  });
+
+  test("fails once a commit has waited past the deferral budget", async () => {
+    expect(
+      await runDecision({
+        committedHoursAgo: 20,
+        event: "schedule",
+        status: "not_ready",
+      }),
+    ).toEqual({ deploy: "deploy=false", exitCode: 1 });
+  });
+
+  test("escalates when no deployment has ever been recorded", async () => {
+    expect(
+      await runDecision({
+        committedHoursAgo: 20,
+        deployedSha: "",
+        event: "schedule",
+        status: "not_ready",
+      }),
+    ).toEqual({ deploy: "deploy=false", exitCode: 1 });
+  });
+
+  // A push has just started waiting, whatever its committer date says.
+  test("never escalates on a push", async () => {
+    expect(
+      await runDecision({
+        committedHoursAgo: 240,
+        event: "push",
+        status: "not_ready",
+      }),
+    ).toEqual({ deploy: "deploy=false", exitCode: 0 });
+  });
+});


### PR DESCRIPTION
The staging health gate failed the run whenever staging did not answer its
health probe. That reported a healthy commit as a broken one, and made the
outcome depend on when a push landed rather than on what it contained.

The probe now feeds a decision step with three outcomes:

- **Deploy** when staging answers. A push or dispatch always deploys what it
  carries.
- **Defer** when it does not. The run stays green, records why in the job
  summary, and skips the deploy.
- **Escalate** when a commit has been undeployable for more than 12h. That is
  a stalled delivery rather than a passing interruption, so it still fails and
  keeps the signal the previous hard failure was protecting.

A deferred deploy no longer needs another push to land: a `*/30` schedule
retries it and promotes the waiting commit once staging answers. The scheduled
run resumes a deploy only when it can prove one is missing, so it leaves
staging alone when the reported commit already matches or cannot be read.

To tell "waiting on the environment" apart from "stuck", each promote records a
GitHub deployment for the staging environment. The gate reads the last recorded
commit, so an outage with nothing pending stays green instead of failing a
delivery that is not blocked.

Only the schedule escalates, against a measured wait, so a push cannot report a
deferral that has just started as a stall.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Staging deployments now run automatically every 30 minutes, alongside push-triggered and manually started deployments.
  * Deployments check staging health and the currently served commit before proceeding.
  * Push deployments are deferred when staging is unreachable, while manual deployments can bypass the health gate.
  * Scheduled deployments resume when appropriate and escalate unresolved deployments after 12 hours.
  * Successful staging deployments are now recorded for improved release visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->