### PR TITLE
chore(ci): call the shared label-sync workflow

### DIFF
--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -1,0 +1,28 @@
+name: Label Sync
+
+# Applies stella/.github/labels.yml to this repository. Manual only: labels
+# should not drift under a push, and a run that writes is a decision.
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: What the run is allowed to do
+        type: choice
+        default: plan
+        options:
+          - plan
+          - apply
+          - apply-with-prune
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  label-sync:
+    # Reusable workflow only consumes the auto-provided GITHUB_TOKEN.
+    # Do not switch to `secrets: inherit` — that widens the blast radius
+    # if the reusable ever starts touching named secrets.
+    uses: stella/.github/.github/workflows/label-sync.yml@63738e702fb3c86003b2f24c5006a151aeafe253
+    with:
+      mode: ${{ inputs.mode }}


### PR DESCRIPTION
Opts this repository into `stella/.github/labels.yml`, added in stella/.github#66.

Manual dispatch only. Labels should not drift under a push, and a run that writes is a decision rather than a side effect. The `mode` input defaults to `plan`, so a run with no arguments reports drift and writes nothing.

The reusable workflow uses this repo's own `GITHUB_TOKEN` with `issues: write`. It holds no stored credential and cannot reach another repository. Pinned to a commit SHA, and no `secrets: inherit`, matching the `pr-lint` caller.

Expected `plan` output on merge, from a local dry run:

```
=== stella/stella
  + create  💬 chat
  + create  📝 word plugin
  ~ update  🧮 table (description "Tabular review" -> "Table view feature")
  ~ update  enhancement (description "" -> "New feature or improvement")
  ~ update  bug (color #747e01 -> #d73a4a, description "" -> "Something is not working")
  ~ update  docs (color #3b222f -> #0075ca, description "" -> "Documentation only")
  ~ update  chore (description "" -> "Maintenance work with no user-facing change")
  ~ update  perf (description "" -> "Performance work")

create=2 update=6 prune=0 keep=0 mode=plan
```

The color corrections on `bug` and `docs` undo what `ytanikin/PRConventionalCommits` picked arbitrarily when it auto-created labels that the manifest had never declared.