### PR TITLE
chore(test): cover justification citation iteration

### DIFF
--- a/apps/web/src/lib/citations.test.ts
+++ b/apps/web/src/lib/citations.test.ts
@@ -72,4 +72,99 @@ describe("iterateJustificationCitations — docx-folio status threading", () => 
     // is non-navigable by construction.
     expect("blockId" in citation).toBe(false);
   });
+
+  test("yields every citation from a pdf-bates block", () => {
+    const content: JustificationContent = {
+      version: 1,
+      blocks: [
+        {
+          kind: "pdf-bates",
+          fileFieldId: "field-pdf",
+          statements: [
+            {
+              text: "first claim",
+              citations: [{ bates: "ABC0001", pageNumber: 2 }],
+            },
+            {
+              text: "second claim",
+              citations: [{ bates: "ABC0002", pageNumber: 7 }],
+            },
+          ],
+        },
+      ],
+    };
+
+    expect([...iterateJustificationCitations(content)]).toEqual([
+      {
+        kind: "pdf-bates",
+        fileFieldId: "field-pdf",
+        bates: "ABC0001",
+        pageNumber: 2,
+      },
+      {
+        kind: "pdf-bates",
+        fileFieldId: "field-pdf",
+        bates: "ABC0002",
+        pageNumber: 7,
+      },
+    ]);
+  });
+
+  test("skips playbook-verdict blocks", () => {
+    const content: JustificationContent = {
+      version: 1,
+      blocks: [
+        {
+          kind: "playbook-verdict",
+          rationale: "The clause meets the requirement.",
+        },
+      ],
+    };
+
+    expect([...iterateJustificationCitations(content)]).toEqual([]);
+  });
+
+  test("preserves citation order across mixed block kinds", () => {
+    const content: JustificationContent = {
+      version: 1,
+      blocks: [
+        {
+          kind: "pdf-bates",
+          fileFieldId: "field-pdf",
+          statements: [{ text: "claim", citations: [{ bates: "ABC0001", pageNumber: 1 }] }],
+        },
+        {
+          kind: "playbook-verdict",
+          rationale: "No document citation.",
+        },
+        {
+          kind: "docx-folio",
+          fileFieldId: "field-docx",
+          statements: [
+            {
+              text: "claim",
+              citations: [
+                { citationStatus: "verified", blockId: "BBBB0001", text: "quoted text" },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    expect([...iterateJustificationCitations(content)]).toEqual([
+      { kind: "pdf-bates", fileFieldId: "field-pdf", bates: "ABC0001", pageNumber: 1 },
+      {
+        kind: "docx-folio",
+        citationStatus: "verified",
+        fileFieldId: "field-docx",
+        blockId: "BBBB0001",
+        text: "quoted text",
+      },
+    ]);
+  });
+
+  test("yields no citations for empty content", () => {
+    expect([...iterateJustificationCitations({ version: 1, blocks: [] })]).toEqual([]);
+  });
 });


### PR DESCRIPTION
Fixes #1635

Add coverage for PDF Bates citations, verdict blocks, mixed block ordering, and empty justification content.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for extracting citations from PDF content.
  * Verified citation order is preserved when different content types are combined.
  * Confirmed non-PDF content is skipped and empty content produces no citations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->