### PR TITLE
chore(github): require a description on the Other Issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/other.yml
+++ b/.github/ISSUE_TEMPLATE/other.yml
@@ -5,14 +5,20 @@ projects: ["stella/1"]
 
 body:
   - type: textarea
+    id: issue
+    validations:
+      required: true
     attributes:
-      label: "Issue"
+      label: Issue
       description: >
         Please describe the issue you'd like to raise as clearly as possible.
         Make sure to include any relevant links or references.
 
   - type: textarea
+    id: suggestion
+    validations:
+      required: false
     attributes:
-      label: "Suggestion:"
+      label: Suggestion
       description: >
         Please outline a suggestion to improve the issue here.


### PR DESCRIPTION
Neither field on `other.yml` was required, so the template could be submitted completely empty. That made it a blank issue with extra clicks, which is the only thing that made "Other Issue" and "Blank issue" look redundant in the chooser.

Requiring the description is what actually distinguishes it. Unlike a blank issue it also carries `type: task` and lands on project `stella/1`, so a catch-all issue arrives typed and on the board rather than needing manual triage.

Also adds field ids and explicit `validations`, matching `bug-report.yml`, `feature-request.yml`, and `epic.yml`, and drops a stray colon in the second label that rendered as "Suggestion::".

Worth noting for anyone reading the chooser: `blank_issues_enabled: false` does not hide the blank option from maintainers. GitHub shows it to Write, Maintain, and Admin with a "Maintainers only" badge, and there is [no way to turn that off](https://github.com/orgs/community/discussions/190197). Contributors with Read or Triage only ever see the templates, so the two never appear together for them.

Parsed with a YAML parser to confirm the structure:

```
valid YAML; type=task projects=["stella/1"]
  issue: required=true label="Issue"
  suggestion: required=false label="Suggestion"
```