### PR TITLE
feat(workspaces): flag the bulk-actions menu on first row selection

### DIFF
--- a/apps/web/src/components/inspector/document-ai-source-bar.tsx
+++ b/apps/web/src/components/inspector/document-ai-source-bar.tsx
@@ -389,7 +389,7 @@ export const DocumentAiSourceBar = ({
           the overlay and re-runs the keyframe. */}
       <div
         aria-hidden
-        className="bg-primary/12 animate-source-bar-flash pointer-events-none absolute inset-0 opacity-0"
+        className="bg-primary/12 animate-attention-flash pointer-events-none absolute inset-0 opacity-0"
         key={justificationId}
       />
       <div

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-toolbar.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-toolbar.tsx
@@ -288,8 +288,18 @@ const SelectionActions = ({
   }
 
   return (
-    <div className="ms-auto flex items-center gap-1.5">
-      <span className="text-muted-foreground text-xs">
+    <div className="relative ms-auto flex items-center gap-1.5">
+      {/* The bulk actions behind the "…" menu stay invisible until a
+          row is selected, so nothing signals that selecting rows
+          unlocked them. This group only mounts once something is
+          selected, which makes mount the 0 → 1 transition: a double
+          tint blink then points at the count and the menu exactly
+          once per selection, without any timer state. */}
+      <div
+        aria-hidden
+        className="bg-primary/12 animate-attention-flash-twice pointer-events-none absolute -inset-x-1.5 -inset-y-1 rounded-md opacity-0 motion-reduce:animate-none"
+      />
+      <span className="text-muted-foreground relative text-xs">
         {t("workspaces.views.fieldsSelected", {
           count: selectedEntities.length,
         })}
@@ -299,7 +309,7 @@ const SelectionActions = ({
         selectedEntities={
           selectedEntities.length > 1 ? selectedEntities : undefined
         }
-        triggerClassName=""
+        triggerClassName="relative"
         workspaceId={workspaceId}
       />
     </div>

--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -59,7 +59,11 @@
   --color-card: var(--card);
   --animate-skeleton: skeleton 2s -1s infinite linear;
   --animate-caret-blink: caret-blink 1.25s ease-out infinite;
-  --animate-source-bar-flash: source-bar-flash 700ms ease-out;
+  /* One-shot tint pulse for a surface that just became relevant.
+     The `-twice` variant blinks the same curve twice, for an
+     affordance the user has to notice, not merely acknowledge. */
+  --animate-attention-flash: attention-flash 700ms ease-out;
+  --animate-attention-flash-twice: attention-flash 700ms ease-out 2;
   @keyframes skeleton {
     to {
       background-position: -200% 0;
@@ -81,7 +85,7 @@
       opacity: 0;
     }
   }
-  @keyframes source-bar-flash {
+  @keyframes attention-flash {
     0% {
       opacity: 0;
     }


### PR DESCRIPTION
Selecting rows in a table view reveals a selection count and a "…" menu that holds the bulk actions (delete, copy/move to matter, download). Nothing draws the eye to that menu when a selection starts, so the actions are easy to miss.

The `SelectionActions` group only renders once something is selected, so its mount *is* the 0 → 1 transition. A short tint overlay blinks twice on mount over both the count and the menu trigger: no timer state, and no repeat as the selection grows or shrinks above zero. `motion-reduce:animate-none` opts out under reduced motion.

The existing `source-bar-flash` keyframe is generalized to `attention-flash`, with an `attention-flash-twice` token for the repeated variant; the inspector source bar now uses the renamed utility.