### PR TITLE
chore(ci): bump the label-sync pin for the manifest overlay

### DIFF
--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -23,6 +23,6 @@ jobs:
     # Reusable workflow only consumes the auto-provided GITHUB_TOKEN.
     # Do not switch to `secrets: inherit` — that widens the blast radius
     # if the reusable ever starts touching named secrets.
-    uses: stella/.github/.github/workflows/label-sync.yml@63738e702fb3c86003b2f24c5006a151aeafe253
+    uses: stella/.github/.github/workflows/label-sync.yml@76d4e3ab6e89ea897c177b026e6ef91c5c46ecc2
     with:
       mode: ${{ inputs.mode }}


### PR DESCRIPTION
stella/.github#69 splits the label manifest into an org baseline plus per-repo overlays, and widens the reusable workflow's sparse checkout to include `labels/`.

The caller pins the reusable workflow to a SHA, so without this bump `labels/stella.yml` is never checked out and the sync silently falls back to baseline only. Nothing would break loudly; the five app-specific labels would just stop being managed.

Expected `plan` after merge is `create=0 update=0 prune=0`, since the baseline plus overlay reproduces the current live state exactly. I will run it to confirm.