### PR TITLE
fix(web): put the role badge on the organization name row

### DIFF
--- a/apps/web/src/components/sidebar-user-menu.tsx
+++ b/apps/web/src/components/sidebar-user-menu.tsx
@@ -328,12 +328,12 @@ function OrganizationMenuSection({
     return (
       <>
         <MenuGroup>
-          <MenuGroupLabel className="pb-1 text-sm">
+          <MenuGroupLabel className="flex min-w-0 items-center gap-1.5 text-sm">
             <BidiText as="span" className="min-w-0 truncate">
               {activeOrganization.name}
             </BidiText>
+            <OrganizationRoleBadge role={role} />
           </MenuGroupLabel>
-          <OrganizationRoleBadge role={role} />
         </MenuGroup>
         <MenuSeparator />
       </>
@@ -348,6 +348,7 @@ function OrganizationMenuSection({
           <BidiText as="span" className="min-w-0 truncate">
             {activeOrganization.name}
           </BidiText>
+          <OrganizationRoleBadge role={role} />
         </MenuSubTrigger>
         <MenuSubPopup>
           <MenuGroup>
@@ -375,11 +376,6 @@ function OrganizationMenuSection({
           </MenuGroup>
         </MenuSubPopup>
       </MenuSub>
-      {role && (
-        <MenuGroup>
-          <OrganizationRoleBadge role={role} />
-        </MenuGroup>
-      )}
       <MenuSeparator />
     </>
   );
@@ -394,10 +390,8 @@ function OrganizationRoleBadge({ role }: { role: Role | undefined }) {
   }
 
   return (
-    <div className="px-2 pb-1.5">
-      <span className="bg-muted text-muted-foreground inline-flex items-center rounded-md px-1.5 py-0.5 text-[0.6875rem] font-medium select-none">
-        {t(`organization.roles.${role}`)}
-      </span>
-    </div>
+    <span className="bg-muted text-muted-foreground inline-flex shrink-0 items-center rounded-md px-1.5 py-0.5 text-[0.6875rem] font-medium select-none">
+      {t(`organization.roles.${role}`)}
+    </span>
   );
 }


### PR DESCRIPTION
## Proposed change

The account menu gave the role badge its own row under the organization name, which read as a separate menu entry. It now sits inline after the name.

- Single-organization users: the badge moves into `MenuGroupLabel` next to the name.
- Multi-organization users: the badge moves into the switcher `MenuSubTrigger`, after the name and before the chevron; the standalone badge group is gone.
- `OrganizationRoleBadge` drops its block wrapper and becomes an inline `shrink-0` span, so a long organization name truncates and the badge stays intact.

No new strings. Colours are unchanged semantic tokens (`bg-muted` / `text-muted-foreground`), so light and dark are unaffected.

## Checklist

- [x] BUILD ASSURANCE | Code builds correctly and without any errors or warnings.
- [ ] TESTING | Changes tested, including in different conditions (dark mode, language, narrow screen, etc). — lint and typecheck are green; not yet checked in a running app.
- [x] DARK MODE SUPPORT | User can use the webapp in dark mode. Make sure your changes are visible in both light and dark mode.
- [ ] ISSUE LINKED | Link an issue to this PR (not by mentioning it in the description, but by using the GitHub issue linking feature)
- [ ] SCREENSHOT INCLUDED | If relevant, please include a screenshot / video of the functionality added (allows for a quick check of minor ux changes)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Organisation role badges now appear inline beside the active organisation name.
  * Updated badge sizing and spacing improve visual consistency.
  * Removed the separate role display previously shown below the organisation switcher.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->