### PR TITLE
fix(ci): remove an expired quarantine exclude automatically

### DIFF
--- a/.github/workflows/quarantine-prune.yml
+++ b/.github/workflows/quarantine-prune.yml
@@ -30,10 +30,14 @@ jobs:
       contents: read
 
     steps:
+      # Pinned to the default branch: without a ref, a manual dispatch from a
+      # feature branch would prune that branch's bunfig.toml and force-push its
+      # commits into the removal PR along with it.
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+          ref: ${{ github.event.repository.default_branch }}
 
       - name: Setup Bun
         uses: stella/.github/actions/setup-bun-cached@859a61ee0a799ba1028281329555cadee15bfc4f

--- a/.github/workflows/quarantine-prune.yml
+++ b/.github/workflows/quarantine-prune.yml
@@ -1,0 +1,116 @@
+name: Quarantine Exclude Prune
+
+# A temporary `minimumReleaseAgeExcludes` entry stops being needed at a
+# wall-clock instant, and stops being safe at the same moment: it would let the
+# next version of that package publish straight past the release-age gate. So
+# the removal is proposed automatically rather than waiting to be noticed, and
+# the guard in ci.yml only tolerates an expired entry while this PR is open.
+
+on:
+  schedule:
+    - cron: "17 * * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: quarantine-prune
+  cancel-in-progress: false
+
+permissions: {}
+
+env:
+  PRUNE_BRANCH: chore/prune-quarantine-excludes
+
+jobs:
+  prune:
+    name: Propose removing expired excludes
+    if: github.repository == 'stella/stella'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Bun
+        uses: stella/.github/actions/setup-bun-cached@859a61ee0a799ba1028281329555cadee15bfc4f
+
+      # The script only reads bunfig.toml and bun.lock, so no install is needed.
+      - name: Prune expired excludes
+        id: prune
+        run: |
+          set -euo pipefail
+
+          bun scripts/check-stll-quarantine-excludes.ts --prune
+
+          if git diff --quiet -- bunfig.toml; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "Nothing expired." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+
+          # The pruned file must satisfy the guard, or the PR would land a
+          # bunfig.toml that fails CI for a different reason.
+          bun scripts/check-stll-quarantine-excludes.ts
+
+      - name: Mint app token
+        if: steps.prune.outputs.changed == 'true'
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.PROVENANCE_APP_ID }}
+          private-key: ${{ secrets.PROVENANCE_APP_PRIVATE_KEY }}
+          # Push the branch and open the PR, nothing else the app can reach.
+          permission-contents: write
+          permission-pull-requests: write
+
+      - name: Open or update the removal PR
+        if: steps.prune.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+        run: |
+          set -euo pipefail
+
+          bot_id="$(gh api "users/${APP_SLUG}[bot]" --jq '.id')"
+          git config user.name "${APP_SLUG}[bot]"
+          git config user.email "${bot_id}+${APP_SLUG}[bot]@users.noreply.github.com"
+
+          git checkout -b "$PRUNE_BRANCH"
+          git add bunfig.toml
+          git commit -m "chore(deps): remove expired quarantine excludes
+
+          The release-age gate admits these packages on its own now, and an
+          entry left behind would let their next version skip it."
+
+          # Force-with-lease is unsafe against a branch this job does not own,
+          # so the branch name is reserved for this job alone. Re-running
+          # replaces its own proposal with one computed from current main.
+          remote="https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git push --force "$remote" "HEAD:refs/heads/${PRUNE_BRANCH}"
+
+          if [[ -n "$(gh pr list --head "$PRUNE_BRANCH" --state open --json number --jq '.[0].number // ""')" ]]; then
+            echo "Updated the open removal PR." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          body_file="$RUNNER_TEMP/prune-pr-body.md"
+          # shellcheck disable=SC2016 # backticks are markdown, not substitution
+          printf '%s\n' \
+            'These temporary `minimumReleaseAgeExcludes` entries have passed their annotated expiry, so the release-age gate admits the packages without them.' \
+            '' \
+            'Leaving an expired entry in place is not neutral: it would let the next version of that package publish straight past the gate. Merging this restores that check.' \
+            '' \
+            'Opened automatically. The removal is what `bun scripts/check-stll-quarantine-excludes.ts --prune` produces.' \
+            > "$body_file"
+
+          gh pr create \
+            --base main \
+            --head "$PRUNE_BRANCH" \
+            --title "chore(deps): remove expired quarantine excludes" \
+            --body-file "$body_file" >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/check-stll-quarantine-excludes.test.ts
+++ b/scripts/check-stll-quarantine-excludes.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "bun:test";
 
-import { checkQuarantineExcludes } from "./check-stll-quarantine-excludes";
+import {
+  checkQuarantineExcludes,
+  pruneExpiredExcludes,
+} from "./check-stll-quarantine-excludes";
 
 const lockfile = `
 "packages": {
@@ -31,7 +34,9 @@ describe("quarantine exclude guard", () => {
     expect(result.activeTemporaryCount).toBe(1);
   });
 
-  test("rejects a temporary exclusion at its exact expiry", () => {
+  // An expiry is a wall-clock instant. Failing at it turned every open branch
+  // red at once for a change nobody made, so the instant only warns.
+  test("warns rather than fails at the exact expiry", () => {
     const result = checkQuarantineExcludes({
       bunfig: createBunfig(
         '"better-result", # quarantine-expires: 2026-08-06T21:35:30.036Z',
@@ -40,8 +45,38 @@ describe("quarantine exclude guard", () => {
       now: new Date("2026-08-06T21:35:30.036Z"),
     });
 
-    expect(result.errors).toContain(
-      'bunfig.toml temporary quarantine exclude "better-result" expired at 2026-08-06T21:35:30.036Z. Remove it: the configured release-age gate can admit the package now.',
+    expect(result.errors).toEqual([]);
+    expect(result.warnings.at(0)).toContain(
+      'temporary quarantine exclude "better-result" expired at',
+    );
+  });
+
+  // Nothing to say before it expires: the removal arrives on its own.
+  test("stays silent until the expiry", () => {
+    const result = checkQuarantineExcludes({
+      bunfig: createBunfig(
+        '"better-result", # quarantine-expires: 2026-08-06T21:35:30.036Z',
+      ),
+      lockfile,
+      now: new Date("2026-08-06T21:35:30.035Z"),
+    });
+
+    expect(result.errors).toEqual([]);
+    expect(result.warnings).toEqual([]);
+  });
+
+  test("fails once an expired exclusion is ignored past the notice window", () => {
+    const result = checkQuarantineExcludes({
+      bunfig: createBunfig(
+        '"better-result", # quarantine-expires: 2026-08-06T21:35:30.036Z',
+      ),
+      lockfile,
+      now: new Date("2026-08-07T21:35:30.036Z"),
+    });
+
+    expect(result.warnings).toEqual([]);
+    expect(result.errors.at(0)).toContain(
+      'temporary quarantine exclude "better-result" expired at 2026-08-06T21:35:30.036Z and is still here',
     );
   });
 
@@ -73,6 +108,51 @@ describe("quarantine exclude guard", () => {
 
     expect(result.firstPartyCount).toBe(2);
     expect(result.errors.at(0)).toContain('"@stll/shipped",');
+  });
+
+  test("prunes only the expired entries", () => {
+    const bunfig = `
+[install]
+minimumReleaseAge = 432_000
+minimumReleaseAgeExcludes = [
+  "@stll/native",
+  # Security patches for dependency-audit findings.
+  "brace-expansion", # quarantine-expires: 2026-08-04T10:00:32.762Z
+  "fast-uri", # quarantine-expires: 2026-08-05T09:16:56.212Z
+  "drizzle-kit",
+]
+`;
+    const result = pruneExpiredExcludes({
+      bunfig,
+      now: new Date("2026-08-04T10:37:00.000Z"),
+    });
+
+    expect(result.pruned).toEqual(["brace-expansion"]);
+    expect(result.bunfig).not.toContain("brace-expansion");
+    expect(result.bunfig).toContain('"fast-uri", # quarantine-expires:');
+    expect(result.bunfig).toContain('"@stll/native"');
+    expect(result.bunfig).toContain('"drizzle-kit"');
+    // The pruned file is what the guard should then accept.
+    expect(
+      checkQuarantineExcludes({
+        bunfig: result.bunfig,
+        lockfile,
+        now: new Date("2026-08-04T10:37:00.000Z"),
+      }).errors,
+    ).toEqual([]);
+  });
+
+  test("leaves a file with nothing expired untouched", () => {
+    const bunfig = createBunfig(
+      '"better-result", # quarantine-expires: 2026-08-06T21:35:30.036Z',
+    );
+    const result = pruneExpiredExcludes({
+      bunfig,
+      now: new Date("2026-08-04T00:00:00.000Z"),
+    });
+
+    expect(result.pruned).toEqual([]);
+    expect(result.bunfig).toBe(bunfig);
   });
 
   test("retains the first-party package coverage guard", () => {

--- a/scripts/check-stll-quarantine-excludes.test.ts
+++ b/scripts/check-stll-quarantine-excludes.test.ts
@@ -142,6 +142,41 @@ minimumReleaseAgeExcludes = [
     ).toEqual([]);
   });
 
+  // Matching by name would take the renewed entry with the expired one, which
+  // silently drops a package back out of the quarantine before its time.
+  test("keeps a renewed entry when an expired one shares its name", () => {
+    const bunfig = `
+[install]
+minimumReleaseAge = 432_000
+minimumReleaseAgeExcludes = [
+  "@stll/native",
+  "fast-uri", # quarantine-expires: 2026-08-05T09:16:56.212Z
+  "fast-uri", # quarantine-expires: 2026-09-01T09:16:56.212Z
+]
+`;
+    const result = pruneExpiredExcludes({
+      bunfig,
+      now: new Date("2026-08-06T00:00:00.000Z"),
+    });
+
+    expect(result.pruned).toEqual(["fast-uri"]);
+    expect(result.bunfig).toContain(
+      '"fast-uri", # quarantine-expires: 2026-09-01T09:16:56.212Z',
+    );
+    expect(result.bunfig).not.toContain("2026-08-05T09:16:56.212Z");
+  });
+
+  test("leaves a malformed annotation for the guard to report", () => {
+    const bunfig = createBunfig('"better-result", # quarantine-expires: nope');
+    const result = pruneExpiredExcludes({
+      bunfig,
+      now: new Date("2026-09-01T00:00:00.000Z"),
+    });
+
+    expect(result.pruned).toEqual([]);
+    expect(result.bunfig).toBe(bunfig);
+  });
+
   test("leaves a file with nothing expired untouched", () => {
     const bunfig = createBunfig(
       '"better-result", # quarantine-expires: 2026-08-06T21:35:30.036Z',

--- a/scripts/check-stll-quarantine-excludes.ts
+++ b/scripts/check-stll-quarantine-excludes.ts
@@ -4,8 +4,16 @@
  * 1. Every first-party `@stll/*` package the lockfile resolves from npm must
  *    be excluded.
  * 2. A temporary third-party exclusion annotated with
- *    `# quarantine-expires: <timestamp>` fails at that timestamp, when Bun's
- *    release-age gate can take over again.
+ *    `# quarantine-expires: <timestamp>` must be removed once Bun's release-age
+ *    gate can take over again.
+ *
+ * An expiry is a wall-clock instant, so failing at that instant turns every
+ * open branch red at once for a change nobody made. Removal is automatic
+ * instead: `quarantine-prune.yml` runs `--prune` hourly and opens the PR that
+ * deletes the entry. An expired entry is therefore only a warning while that
+ * PR waits to be merged, and fails once it has been ignored past the window.
+ * It has to fail eventually: a stale exclude is not inert, because the next
+ * version of that package published would skip the quarantine unnoticed.
  *
  * The 5-day quarantine is a supply-chain control for third-party code. First-
  * party packages publish continuously, so they are excluded by name. The
@@ -22,12 +30,13 @@
  * Run: `bun scripts/check-stll-quarantine-excludes.ts`
  */
 
-import { readFileSync } from "node:fs";
+import { readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 
 const REPO_ROOT = path.resolve(import.meta.dir, "..");
 const LOCKFILE = "bun.lock";
 const BUNFIG = "bunfig.toml";
+const SCRIPT_PATH = "scripts/check-stll-quarantine-excludes.ts";
 const EXPIRY_MARKER = "quarantine-expires:";
 const EXACT_UTC_TIMESTAMP = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/u;
 
@@ -138,11 +147,16 @@ const readRegistryStllPackages = (lockfile: string): Set<string> =>
     ),
   );
 
+const HOUR_MS = 60 * 60 * 1000;
+/** How long an expired entry is tolerated while its removal PR waits. */
+const NOTICE_WINDOW_MS = 24 * HOUR_MS;
+
 export type QuarantineExcludeCheckResult = {
   errors: string[];
   excludeCount: number;
   firstPartyCount: number;
   activeTemporaryCount: number;
+  warnings: string[];
 };
 
 export const checkQuarantineExcludes = ({
@@ -176,14 +190,27 @@ export const checkQuarantineExcludes = ({
   }
 
   const nowMs = now.getTime();
+  const warnings: string[] = [];
   for (const { expiresAt, name } of temporary.entries) {
-    if (nowMs < Date.parse(expiresAt)) {
+    const expiresAtMs = Date.parse(expiresAt);
+
+    if (nowMs >= expiresAtMs + NOTICE_WINDOW_MS) {
+      errors.push(
+        `${BUNFIG} temporary quarantine exclude "${name}" expired at ${expiresAt} ` +
+          `and is still here. Remove it (\`bun ${SCRIPT_PATH} --prune\`): the ` +
+          `release-age gate admits the package on its own now, and leaving the ` +
+          `entry lets the next version of it publish straight past the quarantine.`,
+      );
       continue;
     }
-    errors.push(
-      `${BUNFIG} temporary quarantine exclude "${name}" expired at ${expiresAt}. ` +
-        `Remove it: the configured release-age gate can admit the package now.`,
-    );
+
+    if (nowMs >= expiresAtMs) {
+      warnings.push(
+        `${BUNFIG} temporary quarantine exclude "${name}" expired at ${expiresAt}. ` +
+          `Its removal PR opens automatically; merge it, or run ` +
+          `\`bun ${SCRIPT_PATH} --prune\` to do it by hand.`,
+      );
+    }
   }
 
   return {
@@ -191,14 +218,93 @@ export const checkQuarantineExcludes = ({
     errors,
     excludeCount: excludes.size,
     firstPartyCount: firstPartyPackages.size,
+    warnings,
   };
 };
 
+export type PruneResult = {
+  bunfig: string;
+  pruned: string[];
+};
+
+/**
+ * Drops the entries whose expiry has passed. Only the entry line goes: the
+ * comments above the block explain why the remaining entries are there.
+ */
+export const pruneExpiredExcludes = ({
+  bunfig,
+  now = new Date(),
+}: {
+  bunfig: string;
+  now?: Date;
+}): PruneResult => {
+  const expired = new Set(
+    readTemporaryExcludes(bunfig)
+      .entries.filter(({ expiresAt }) => now.getTime() >= Date.parse(expiresAt))
+      .map(({ name }) => name),
+  );
+  if (expired.size === 0) {
+    return { bunfig, pruned: [] };
+  }
+
+  const blockStart = bunfig.indexOf("minimumReleaseAgeExcludes");
+  const blockEnd = bunfig.indexOf("]", blockStart);
+  const pruned: string[] = [];
+  const block = bunfig
+    .slice(blockStart, blockEnd)
+    .split("\n")
+    .filter((line) => {
+      if (!line.includes(EXPIRY_MARKER)) {
+        return true;
+      }
+      const name = [...expired].find((candidate) =>
+        line.includes(`"${candidate}"`),
+      );
+      if (name === undefined) {
+        return true;
+      }
+      pruned.push(name);
+      return false;
+    })
+    .join("\n");
+
+  return {
+    bunfig: bunfig.slice(0, blockStart) + block + bunfig.slice(blockEnd),
+    pruned,
+  };
+};
+
+const prune = () => {
+  const bunfigPath = path.join(REPO_ROOT, BUNFIG);
+  const { bunfig, pruned } = pruneExpiredExcludes({
+    bunfig: readFileSync(bunfigPath, "utf-8"),
+  });
+
+  if (pruned.length === 0) {
+    console.log(`${BUNFIG}: no expired quarantine excludes to remove.`);
+    return;
+  }
+
+  writeFileSync(bunfigPath, bunfig);
+  console.log(
+    `${BUNFIG}: removed ${pruned.length} expired quarantine exclude(s): ${pruned.join(", ")}.`,
+  );
+};
+
 const main = () => {
+  if (process.argv.includes("--prune")) {
+    prune();
+    return;
+  }
+
   const result = checkQuarantineExcludes({
     bunfig: readFileSync(path.join(REPO_ROOT, BUNFIG), "utf-8"),
     lockfile: readFileSync(path.join(REPO_ROOT, LOCKFILE), "utf-8"),
   });
+
+  if (result.warnings.length > 0) {
+    console.warn(`${result.warnings.join("\n")}\n`);
+  }
 
   if (result.errors.length > 0) {
     console.error(result.errors.join("\n\n"));

--- a/scripts/check-stll-quarantine-excludes.ts
+++ b/scripts/check-stll-quarantine-excludes.ts
@@ -72,6 +72,49 @@ type TemporaryExcludesResult = {
   errors: string[];
 };
 
+type ParsedTemporaryExclude =
+  | { error: string; kind: "error" }
+  | { expiresAt: string; kind: "entry"; name: string };
+
+/**
+ * One annotated line. Both the guard and the prune read it through here, so
+ * neither can disagree with the other about what a line means.
+ */
+const parseTemporaryExcludeLine = (line: string): ParsedTemporaryExclude => {
+  const commentStart = line.indexOf("#");
+  const declaration = line.slice(0, commentStart).trim();
+  const comment = line.slice(commentStart + 1).trim();
+  const quotedName = declaration.endsWith(",")
+    ? declaration.slice(0, -1).trim()
+    : declaration;
+  const isQuotedName =
+    quotedName.startsWith('"') &&
+    quotedName.endsWith('"') &&
+    !quotedName.slice(1, -1).includes('"');
+  if (!comment.startsWith(EXPIRY_MARKER) || !isQuotedName) {
+    return {
+      error: `${BUNFIG} has a malformed temporary quarantine annotation: ${line.trim()}`,
+      kind: "error",
+    };
+  }
+
+  const name = quotedName.slice(1, -1);
+  const expiresAt = comment.slice(EXPIRY_MARKER.length).trim();
+  const expiresAtMs = Date.parse(expiresAt);
+  if (
+    !EXACT_UTC_TIMESTAMP.test(expiresAt) ||
+    Number.isNaN(expiresAtMs) ||
+    new Date(expiresAtMs).toISOString() !== expiresAt
+  ) {
+    return {
+      error: `${BUNFIG} temporary quarantine exclude "${name}" has an invalid UTC expiry: ${expiresAt}`,
+      kind: "error",
+    };
+  }
+
+  return { expiresAt, kind: "entry", name };
+};
+
 const readTemporaryExcludes = (bunfig: string): TemporaryExcludesResult => {
   const entries: TemporaryExclude[] = [];
   const errors: string[] = [];
@@ -81,38 +124,13 @@ const readTemporaryExcludes = (bunfig: string): TemporaryExcludesResult => {
       continue;
     }
 
-    const commentStart = line.indexOf("#");
-    const declaration = line.slice(0, commentStart).trim();
-    const comment = line.slice(commentStart + 1).trim();
-    const quotedName = declaration.endsWith(",")
-      ? declaration.slice(0, -1).trim()
-      : declaration;
-    const isQuotedName =
-      quotedName.startsWith('"') &&
-      quotedName.endsWith('"') &&
-      !quotedName.slice(1, -1).includes('"');
-    if (!comment.startsWith(EXPIRY_MARKER) || !isQuotedName) {
-      errors.push(
-        `${BUNFIG} has a malformed temporary quarantine annotation: ${line.trim()}`,
-      );
+    const parsed = parseTemporaryExcludeLine(line);
+    if (parsed.kind === "error") {
+      errors.push(parsed.error);
       continue;
     }
 
-    const name = quotedName.slice(1, -1);
-    const expiresAt = comment.slice(EXPIRY_MARKER.length).trim();
-    const expiresAtMs = Date.parse(expiresAt);
-    if (
-      !EXACT_UTC_TIMESTAMP.test(expiresAt) ||
-      Number.isNaN(expiresAtMs) ||
-      new Date(expiresAtMs).toISOString() !== expiresAt
-    ) {
-      errors.push(
-        `${BUNFIG} temporary quarantine exclude "${name}" has an invalid UTC expiry: ${expiresAt}`,
-      );
-      continue;
-    }
-
-    entries.push({ expiresAt, name });
+    entries.push({ expiresAt: parsed.expiresAt, name: parsed.name });
   }
 
   return { entries, errors };
@@ -238,18 +256,16 @@ export const pruneExpiredExcludes = ({
   bunfig: string;
   now?: Date;
 }): PruneResult => {
-  const expired = new Set(
-    readTemporaryExcludes(bunfig)
-      .entries.filter(({ expiresAt }) => now.getTime() >= Date.parse(expiresAt))
-      .map(({ name }) => name),
-  );
-  if (expired.size === 0) {
+  const blockStart = bunfig.indexOf("minimumReleaseAgeExcludes");
+  if (blockStart === -1) {
     return { bunfig, pruned: [] };
   }
-
-  const blockStart = bunfig.indexOf("minimumReleaseAgeExcludes");
   const blockEnd = bunfig.indexOf("]", blockStart);
   const pruned: string[] = [];
+
+  // Each line is judged by its own annotation. Matching by name instead would
+  // delete every entry sharing that name, including one whose expiry was
+  // renewed and has not passed.
   const block = bunfig
     .slice(blockStart, blockEnd)
     .split("\n")
@@ -257,16 +273,22 @@ export const pruneExpiredExcludes = ({
       if (!line.includes(EXPIRY_MARKER)) {
         return true;
       }
-      const name = [...expired].find((candidate) =>
-        line.includes(`"${candidate}"`),
-      );
-      if (name === undefined) {
+      const parsed = parseTemporaryExcludeLine(line);
+      // A malformed annotation is the guard's to report, not this to delete.
+      if (parsed.kind !== "entry") {
         return true;
       }
-      pruned.push(name);
+      if (now.getTime() < Date.parse(parsed.expiresAt)) {
+        return true;
+      }
+      pruned.push(parsed.name);
       return false;
     })
     .join("\n");
+
+  if (pruned.length === 0) {
+    return { bunfig, pruned: [] };
+  }
 
   return {
     bunfig: bunfig.slice(0, blockStart) + block + bunfig.slice(blockEnd),


### PR DESCRIPTION
A temporary `minimumReleaseAgeExcludes` entry expires at a wall-clock instant,
and the guard failed at exactly that instant. Every open branch went red at
once for a change nobody made, and the fix was a hand edit nobody knew was due.
That happened today, and two more entries expire this week.

Removal is now proposed on its own. `quarantine-prune.yml` runs hourly, deletes
the entries whose expiry has passed via the new `--prune`, checks the result
still satisfies the guard, and opens a single PR with the removal. A run with
nothing expired does nothing.

The guard is silent until an entry expires, warns for a day while that PR waits
to be merged, and fails after that. It has to fail eventually: an expired entry
is not inert, because it would let the next version of that package publish
straight past the release-age gate.

Notes for review:

- The prune job reserves the branch `chore/prune-quarantine-excludes` and
  force-pushes it, so re-running replaces its own proposal rather than stacking
  branches. Nothing else may use that name.
- It removes the entry line only. A comment covering the last remaining entry
  is left behind for a human to tidy.
- The PR is opened with the provenance app's token, scoped to `contents: write`
  and `pull-requests: write`, because Actions cannot open PRs with the default
  token in this repository.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic detection and removal of expired quarantine exclusions.
  * Added scheduled and manual workflows that prepare pull requests when expired exclusions are found.
  * Added a 24-hour warning period before expired exclusions become errors.

* **Bug Fixes**
  * Improved validation messages and handling for expired, active, and unannotated exclusions.

* **Tests**
  * Expanded coverage for expiry warnings, pruning behaviour, and configuration validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->