### PR TITLE
fix(ci): stop a workspace neighbour hiding a first-party package

### DIFF
--- a/scripts/check-stll-quarantine-excludes.test.ts
+++ b/scripts/check-stll-quarantine-excludes.test.ts
@@ -56,6 +56,25 @@ describe("quarantine exclude guard", () => {
     );
   });
 
+  // A fixed-width lookahead read past the entry, so a workspace member on the
+  // next line marked its registry-resolved neighbour as a workspace member
+  // too, and the coverage check silently stopped requiring it.
+  test("counts a registry package followed by a workspace member", () => {
+    const result = checkQuarantineExcludes({
+      bunfig: createBunfig('"better-result",'),
+      lockfile: `
+"packages": {
+  "@stll/native": ["@stll/native@1.0.0", "", {}, "sha512-test"],
+  "@stll/shipped": ["@stll/shipped@1.0.0", "", { "dependencies": { "valibot": "1.4.1" } }, "sha512-test"],
+  "@stll/local": ["@stll/local@workspace:packages/local"],
+}
+`,
+    });
+
+    expect(result.firstPartyCount).toBe(2);
+    expect(result.errors.at(0)).toContain('"@stll/shipped",');
+  });
+
   test("retains the first-party package coverage guard", () => {
     const result = checkQuarantineExcludes({
       bunfig: createBunfig('"better-result",'),

--- a/scripts/check-stll-quarantine-excludes.ts
+++ b/scripts/check-stll-quarantine-excludes.ts
@@ -124,8 +124,15 @@ const readRegistryStllPackages = (lockfile: string): Set<string> =>
           return [];
         }
         // The entry's own resolution follows the name; workspace members
-        // carry the workspace protocol instead of a registry tarball.
-        const entry = lockfile.slice(match.index, match.index + 400);
+        // carry the workspace protocol instead of a registry tarball. Read to
+        // the end of that line and no further: a fixed-width window spills
+        // into the next entry, and one workspace neighbour then hides a
+        // registry-resolved package from the coverage check entirely.
+        const lineEnd = lockfile.indexOf("\n", match.index);
+        const entry = lockfile.slice(
+          match.index,
+          lineEnd === -1 ? undefined : lineEnd,
+        );
         return entry.includes(WORKSPACE_PROTOCOL) ? [] : [name];
       },
     ),
@@ -157,9 +164,11 @@ export const checkQuarantineExcludes = ({
 
   if (missing.length > 0) {
     errors.push(
-      `${BUNFIG} minimumReleaseAgeExcludes is missing ${missing.length} first-party package(s):\n${ 
-        missing.map((name) => `  "${name}",`).join("\n") 
-        }\n\nAdd them. Until then, a fresh publish of any of these installs ` +
+      `${BUNFIG} minimumReleaseAgeExcludes is missing ${missing.length} first-party package(s):\n${missing
+        .map((name) => `  "${name}",`)
+        .join(
+          "\n",
+        )}\n\nAdd them. Until then, a fresh publish of any of these installs ` +
         `partially: the quarantine blocks it, and an optionalDependency that ` +
         `is blocked is skipped silently, so the failure surfaces at runtime ` +
         `rather than at install.`,


### PR DESCRIPTION
The lockfile scan read a fixed 400 characters past each package key to decide
whether that package resolved from the registry or from the workspace. The
window spills into the entries that follow, so a workspace member on a nearby
line marked its registry-resolved neighbour as a workspace member too, and the
coverage check silently stopped requiring it in the excludes.

It hid 4 of this repo's 14 registry-backed first-party packages. The hidden set
included platform binaries, which is precisely what the guard exists to catch:
a quarantined `optionalDependency` is skipped without a word, so the package
resolves, imports cleanly, and throws on first use.

All 14 are excluded today, so nothing is broken. Nothing was enforcing it
either, which is the part worth fixing.

The scan now reads to the end of the entry's own line. Found while checking
whether this guard was worth sharing with the other `@stll` repositories: their
lockfiles put a workspace member directly after a registry one, which is what
exposed the boundary.
