### PR TITLE
chore: exercise the projection trigger with the reservation boundary

### DIFF
--- a/apps/api/src/handlers/case-law/corpus-index-generation-backfill.db.test.ts
+++ b/apps/api/src/handlers/case-law/corpus-index-generation-backfill.db.test.ts
@@ -2370,3 +2370,113 @@ test("rejects a pending hash without a pending action", async () => {
     "case_law_corpus_index_projections_pending_revision_nonnegative",
   );
 });
+
+test(
+  "a trigger-seeded projection reserves as append-safe until a reservation crosses the boundary",
+  async () => {
+    // The projection trigger seeds every pending decision at revision 1 with
+    // append targets, so revision alone cannot distinguish a first-ever
+    // append from a replay; only the boundary stamp can. This runs the real
+    // trigger and the real reservation together — the combination whose
+    // absence from the suite let a revision-based gate ship and never fire.
+    const generation = "case_law_v63";
+    const sourceId = toSafeId<"caseLawSource">(
+      "00000000-0000-4000-8000-000000000063",
+    );
+    const decisionId = toSafeId<"caseLawDecision">(
+      "00000000-0000-4000-8000-000000000163",
+    );
+    // pushSchema creates tables and constraints but not migration triggers;
+    // install the projection trigger so the decision insert exercises it.
+    const migration = await Bun.file(generationMigrationSource).text();
+    const projectionTriggerStatements = migration
+      .split("--> statement-breakpoint")
+      .map((statement) => statement.trim())
+      .filter((statement) =>
+        statement.includes("enqueue_case_law_corpus_index_projection"),
+      );
+    expect(projectionTriggerStatements).toHaveLength(2);
+    for (const statement of projectionTriggerStatements) {
+      // oxlint-disable-next-line no-await-in-loop -- function then trigger creation are order-dependent DDL
+      await db.execute(sql.raw(statement));
+    }
+    await db.insert(caseLawSources).values({
+      adapterKey: "boundary-seed",
+      id: sourceId,
+      name: "boundary seed",
+    });
+    await db.insert(caseLawCorpusIndexBackfills).values({
+      generation,
+      snapshotAt: await nextBackfillSnapshotAt(),
+      status: "complete",
+    });
+    // Inserting after the checkpoint fires the projection trigger.
+    await db.insert(caseLawDecisions).values({
+      caseNumber: "63 T 63/2026",
+      contentHash: "boundary-seed",
+      country: "CZE",
+      court: "Boundary court",
+      createdAt: CREATED_AT,
+      fulltext: "boundary seed",
+      id: decisionId,
+      language: "cs",
+      languageGroupKey: "boundary-seed",
+      slug: "boundary-seed",
+      sourceId,
+    });
+
+    try {
+      const seeded = await db
+        .select()
+        .from(caseLawCorpusIndexProjections)
+        .where(
+          and(
+            eq(caseLawCorpusIndexProjections.generation, generation),
+            eq(caseLawCorpusIndexProjections.decisionId, decisionId),
+          ),
+        );
+      expect(seeded).toHaveLength(1);
+      expect(seeded.at(0)?.pendingRevision).toBe(1);
+      expect(seeded.at(0)?.appendReservedAt).toBeNull();
+
+      const selected = await caseLawCorpusIndexAdapter.selectMissing(scopedDb, {
+        generation,
+        limit: 100,
+      });
+      const row = selected.find(({ id }) => id === decisionId);
+      expect(row).toBeDefined();
+      if (!row) {
+        return;
+      }
+
+      const first = await scopedDb(
+        async (tx) =>
+          await reserveGenerationProjectionTargets(tx, {
+            generation,
+            rows: [row],
+          }),
+      );
+      // Seeded by the trigger, never appended: safe to append with no delete.
+      expect(first.get(decisionId)?.mayHaveCopy).toBe(false);
+
+      const replay = await scopedDb(
+        async (tx) =>
+          await reserveGenerationProjectionTargets(tx, {
+            generation,
+            rows: [row],
+          }),
+      );
+      // The first reservation crossed the boundary; a replay must clean up.
+      expect(replay.get(decisionId)?.mayHaveCopy).toBe(true);
+    } finally {
+      await db
+        .delete(caseLawDecisions)
+        .where(eq(caseLawDecisions.id, decisionId));
+      await db
+        .delete(caseLawCorpusIndexBackfills)
+        .where(eq(caseLawCorpusIndexBackfills.generation, generation));
+      await db.delete(caseLawSources).where(eq(caseLawSources.id, sourceId));
+    }
+  },
+  { timeout: 30_000 },
+);


### PR DESCRIPTION
## Summary

- add a db-backed test that runs the real projection trigger and the real reservation SQL together, instead of mocking `reserveExternalAppend`
- the decision insert happens after a backfill checkpoint exists, so the trigger itself seeds the projection (revision 1, non-empty targets), matching how pending rows are actually produced
- asserts the append-boundary contract: a first-ever reservation reports no prior copy (`mayHaveCopy: false`); a second reservation of the same row reports one

## Why

pushSchema installs tables and constraints but not migration triggers, so no existing test exercised the trigger-seeded projection state through reservation. A delete gate keyed on `pending_revision` passes every mocked unit test yet never fires against trigger-seeded rows, because the trigger seeds at revision 1 and any reservation conflicts past it. This test fails under that gate and passes under the `append_reserved_at` boundary marker.

## Testing

- `bun test apps/api/src/handlers/case-law/corpus-index-generation-backfill.db.test.ts` — 28 pass