### PR TITLE
fix(chat): strip web-only plumbing ids so registry projections survive real payloads

### DIFF
--- a/apps/api/src/handlers/chat/tools/registry-adapter/ref-field-map.ts
+++ b/apps/api/src/handlers/chat/tools/registry-adapter/ref-field-map.ts
@@ -101,6 +101,16 @@ export type RefMediationEntry = {
    * it, which fails closed the same as an undeclared path.
    */
   passthroughIdPaths: readonly string[];
+  /**
+   * Output paths deleted from the chat projection before hydration and the
+   * UUID backstop run. For fields other surfaces need (web-UI field/file
+   * plumbing handles) that chat cannot act on: stripping keeps them out of
+   * the model context entirely instead of leaking them as passthrough noise.
+   * Same `a.b` / `a[].b` grammar as `outputRefs`. Required so every tool
+   * records an explicit decision, like `passthroughIdPaths`; the backstop
+   * still fails closed on any undeclared survivor.
+   */
+  stripPaths: readonly string[];
 };
 
 export type RegistryRefFieldMapEntry = RefMediationEntry & {
@@ -134,6 +144,7 @@ export const READ_TOOL_REF_FIELD_MAP = {
     inputRefs: [],
     outputRefs: [],
     passthroughIdPaths: ["id", "url", "workspaceId"],
+    stripPaths: [],
   },
   search: {
     chatProjectable: false,
@@ -144,6 +155,7 @@ export const READ_TOOL_REF_FIELD_MAP = {
       "results[].url",
       "results[].workspaceId",
     ],
+    stripPaths: [],
   },
 
   // --- Matters / contacts / content -----------------------------------------
@@ -174,6 +186,15 @@ export const READ_TOOL_REF_FIELD_MAP = {
       "members[].userId",
       "nextCursor",
     ],
+    // The overview feed's field/file plumbing ids exist for the web UI (mime
+    // icon, click-to-open); chat cannot act on them and they carry raw UUIDs
+    // whenever a recent entity has a primary field, which tripped the UUID
+    // backstop on every non-empty matter until they were stripped here.
+    stripPaths: [
+      "overview.recentEntities[].fieldId",
+      "overview.recentEntities[].propertyId",
+      "overview.recentEntities[].pdfFileId",
+    ],
   },
   list_contacts: {
     chatProjectable: true,
@@ -181,6 +202,7 @@ export const READ_TOOL_REF_FIELD_MAP = {
     outputRefs: [{ kind: "contact", path: "items[].id" }],
     // `nextCursor` is an opaque base64url pagination cursor.
     passthroughIdPaths: ["nextCursor"],
+    stripPaths: [],
   },
   search_across_matters: {
     chatProjectable: true,
@@ -194,6 +216,7 @@ export const READ_TOOL_REF_FIELD_MAP = {
       },
     ],
     passthroughIdPaths: [],
+    stripPaths: [],
   },
   read_content_across_matters: {
     chatProjectable: true,
@@ -207,12 +230,14 @@ export const READ_TOOL_REF_FIELD_MAP = {
       },
     ],
     passthroughIdPaths: [],
+    stripPaths: [],
   },
   read_contact: {
     chatProjectable: true,
     inputRefs: [{ kind: "contact", param: "contact_id" }],
     outputRefs: [{ kind: "contact", path: "contactId" }],
     passthroughIdPaths: [],
+    stripPaths: [],
   },
 
   // --- Documents / properties -----------------------------------------------
@@ -236,6 +261,7 @@ export const READ_TOOL_REF_FIELD_MAP = {
     ],
     // Opaque `[createdAt, id]` cursor; embeds an entity id, not UUID-formatted.
     passthroughIdPaths: ["nextCursor"],
+    stripPaths: [],
   },
   read_document: {
     chatProjectable: true,
@@ -267,6 +293,7 @@ export const READ_TOOL_REF_FIELD_MAP = {
       "diff.targetVersionId",
       "versionsNextCursor",
     ],
+    stripPaths: [],
   },
   list_properties: {
     chatProjectable: true,
@@ -274,6 +301,7 @@ export const READ_TOOL_REF_FIELD_MAP = {
     outputRefs: [{ kind: "property", path: "properties[].id" }],
     // Opaque `[createdAt, id]` cursor; not UUID-formatted.
     passthroughIdPaths: ["nextCursor"],
+    stripPaths: [],
   },
 
   // --- Tasks -----------------------------------------------------------------
@@ -316,6 +344,7 @@ export const READ_TOOL_REF_FIELD_MAP = {
       "task.links[].linkId",
       "nextCursor",
     ],
+    stripPaths: [],
   },
 
   // --- Knowledge: org-scoped handles, no tenant refs ------------------------
@@ -343,6 +372,7 @@ export const READ_TOOL_REF_FIELD_MAP = {
       "version.id",
       "nextCursor",
     ],
+    stripPaths: [],
   },
   list_playbooks: {
     chatProjectable: true,
@@ -357,6 +387,15 @@ export const READ_TOOL_REF_FIELD_MAP = {
       "playbook.positions.items[].sourceId",
       "playbook.positions.items[].standard.clauseId",
       "nextCursor",
+    ],
+    // Tier rule and fallback-entry ids are client-supplied stable ids inside
+    // the positions jsonb, UUID-shaped in practice; no chat tool accepts
+    // them, so the projection strips them instead of passing UUID noise
+    // through to the model.
+    stripPaths: [
+      "playbook.positions.items[].tiers.acceptable.rules[].id",
+      "playbook.positions.items[].tiers.fallback.entries[].id",
+      "playbook.positions.items[].tiers.notAcceptable.rules[].id",
     ],
   },
 
@@ -394,12 +433,14 @@ export const READ_TOOL_REF_FIELD_MAP = {
       "entry.userId",
       "nextCursor",
     ],
+    stripPaths: [],
   },
   resolve_rate: {
     chatProjectable: true,
     inputRefs: [{ kind: "matter", param: "matter_id" }],
     outputRefs: [],
     passthroughIdPaths: [],
+    stripPaths: [],
   },
   list_invoices: {
     chatProjectable: true,
@@ -442,6 +483,7 @@ export const READ_TOOL_REF_FIELD_MAP = {
       "invoice.expenses[].id",
       "nextCursor",
     ],
+    stripPaths: [],
   },
   get_usage: {
     chatProjectable: true,
@@ -449,6 +491,7 @@ export const READ_TOOL_REF_FIELD_MAP = {
     outputRefs: [],
     // Org billing-plan ids, not tenant refs.
     passthroughIdPaths: ["entitlement.id", "policy.id"],
+    stripPaths: [],
   },
 
   // --- Public corpora: public ids, no tenant refs ---------------------------
@@ -459,6 +502,7 @@ export const READ_TOOL_REF_FIELD_MAP = {
     // Public case-law corpus id; `source_id` is a request input, never an
     // output field, so it needs no output-path declaration here.
     passthroughIdPaths: ["results[].decisionId", "nextCursor"],
+    stripPaths: [],
   },
   read_case_law_decision: {
     chatProjectable: true,
@@ -478,6 +522,7 @@ export const READ_TOOL_REF_FIELD_MAP = {
       "decision.source.id",
       "nextCursor",
     ],
+    stripPaths: [],
   },
   search_legislation: {
     chatProjectable: true,
@@ -493,12 +538,14 @@ export const READ_TOOL_REF_FIELD_MAP = {
       "law.lawId",
       "data[].identificador",
     ],
+    stripPaths: [],
   },
   lookup_business_registry: {
     chatProjectable: true,
     inputRefs: [],
     outputRefs: [],
     passthroughIdPaths: [],
+    stripPaths: [],
   },
 
   // --- Templates: org-scoped template handles -------------------------------
@@ -510,6 +557,7 @@ export const READ_TOOL_REF_FIELD_MAP = {
     // field, so it needs no output-path declaration. Detail mode's describe
     // payload carries no id fields at all.
     passthroughIdPaths: ["templates[].id", "nextCursor"],
+    stripPaths: [],
   },
 
   // --- Audit log: not projected to chat -------------------------------------
@@ -531,6 +579,7 @@ export const READ_TOOL_REF_FIELD_MAP = {
     // this payload safe to walk. Moot in practice: `chatProjectable: false`
     // means the backstop never runs against this tool's output at all.
     passthroughIdPaths: ["items[].workspaceId", "items[].resourceId"],
+    stripPaths: [],
   },
 
   // --- Capability meta-tools: not projected to chat -------------------------
@@ -544,12 +593,14 @@ export const READ_TOOL_REF_FIELD_MAP = {
     inputRefs: [],
     outputRefs: [],
     passthroughIdPaths: [],
+    stripPaths: [],
   },
   describe_capability: {
     chatProjectable: false,
     inputRefs: [],
     outputRefs: [],
     passthroughIdPaths: [],
+    stripPaths: [],
   },
 } as const satisfies Record<RegistryReadToolName, RegistryRefFieldMapEntry>;
 
@@ -581,6 +632,7 @@ export const WRITE_TOOL_REF_FIELD_MAP = {
     // `updated: true`); the matter id is a workspace tenant id.
     outputRefs: [{ kind: "matter", path: "matterId" }],
     passthroughIdPaths: [],
+    stripPaths: [],
   },
   delete_matter: {
     chatProjectable: true,
@@ -588,6 +640,7 @@ export const WRITE_TOOL_REF_FIELD_MAP = {
     // Returns `{ deleted: true }`: an ack with no id.
     outputRefs: [],
     passthroughIdPaths: [],
+    stripPaths: [],
   },
   save_contact: {
     chatProjectable: true,
@@ -595,12 +648,14 @@ export const WRITE_TOOL_REF_FIELD_MAP = {
     // Both branches return `{ contactId }`.
     outputRefs: [{ kind: "contact", path: "contactId" }],
     passthroughIdPaths: [],
+    stripPaths: [],
   },
   delete_contact: {
     chatProjectable: true,
     inputRefs: [{ kind: "contact", param: "contact_id" }],
     outputRefs: [],
     passthroughIdPaths: [],
+    stripPaths: [],
   },
   save_task: {
     chatProjectable: true,
@@ -626,6 +681,7 @@ export const WRITE_TOOL_REF_FIELD_MAP = {
       },
     ],
     passthroughIdPaths: [],
+    stripPaths: [],
   },
   link_matter_contact: {
     chatProjectable: true,
@@ -639,6 +695,7 @@ export const WRITE_TOOL_REF_FIELD_MAP = {
     // `{ unlinked: true }`. The join-row id is a non-tenant handle.
     outputRefs: [],
     passthroughIdPaths: ["workspaceContactId"],
+    stripPaths: [],
   },
 
   // --- Documents / properties -----------------------------------------------
@@ -662,6 +719,7 @@ export const WRITE_TOOL_REF_FIELD_MAP = {
       },
     ],
     passthroughIdPaths: [],
+    stripPaths: [],
   },
   delete_document: {
     chatProjectable: true,
@@ -670,6 +728,7 @@ export const WRITE_TOOL_REF_FIELD_MAP = {
     // Returns `{ deleted: true }`.
     outputRefs: [],
     passthroughIdPaths: [],
+    stripPaths: [],
   },
   set_field_value: {
     chatProjectable: true,
@@ -682,6 +741,7 @@ export const WRITE_TOOL_REF_FIELD_MAP = {
     // Returns `{}`.
     outputRefs: [],
     passthroughIdPaths: [],
+    stripPaths: [],
   },
 
   // --- Billing --------------------------------------------------------------
@@ -697,6 +757,7 @@ export const WRITE_TOOL_REF_FIELD_MAP = {
     // time-entry id is a billing handle, not a tenant ref.
     outputRefs: [],
     passthroughIdPaths: ["timeEntryId"],
+    stripPaths: [],
   },
   delete_time_entry: {
     chatProjectable: true,
@@ -704,6 +765,7 @@ export const WRITE_TOOL_REF_FIELD_MAP = {
     // Returns `{ deleted }` (a boolean).
     outputRefs: [],
     passthroughIdPaths: [],
+    stripPaths: [],
   },
 
   // --- Knowledge ------------------------------------------------------------
@@ -715,12 +777,14 @@ export const WRITE_TOOL_REF_FIELD_MAP = {
     // Both branches return `{ clauseId }` (a library handle).
     outputRefs: [],
     passthroughIdPaths: ["clauseId"],
+    stripPaths: [],
   },
   delete_clause: {
     chatProjectable: true,
     inputRefs: [],
     outputRefs: [],
     passthroughIdPaths: [],
+    stripPaths: [],
   },
   run_playbook: {
     chatProjectable: true,
@@ -729,6 +793,7 @@ export const WRITE_TOOL_REF_FIELD_MAP = {
     // Returns `{ runPropertyCount }`: an integer, no id.
     outputRefs: [],
     passthroughIdPaths: [],
+    stripPaths: [],
   },
 
   // --- Organization ---------------------------------------------------------
@@ -743,6 +808,7 @@ export const WRITE_TOOL_REF_FIELD_MAP = {
     // returns scalar settings only.
     outputRefs: [],
     passthroughIdPaths: ["memberId", "id"],
+    stripPaths: [],
   },
 
   // --- Practice profile -----------------------------------------------------
@@ -752,6 +818,7 @@ export const WRITE_TOOL_REF_FIELD_MAP = {
     // Returns `{ practiceJurisdictions }`: country codes and booleans, no id.
     outputRefs: [],
     passthroughIdPaths: [],
+    stripPaths: [],
   },
 
   // --- Templates ------------------------------------------------------------
@@ -768,6 +835,7 @@ export const WRITE_TOOL_REF_FIELD_MAP = {
     inputRefs: [],
     outputRefs: [],
     passthroughIdPaths: [],
+    stripPaths: [],
   },
   // Compound template persistence is an MCP/CLI convenience for clients that
   // cannot PUT bytes. Chat already has first-class template/document flows;
@@ -777,6 +845,7 @@ export const WRITE_TOOL_REF_FIELD_MAP = {
     inputRefs: [],
     outputRefs: [],
     passthroughIdPaths: [],
+    stripPaths: [],
   },
   save_template: {
     chatProjectable: true,
@@ -786,6 +855,7 @@ export const WRITE_TOOL_REF_FIELD_MAP = {
     // configure returns the describe shape (name + field configs, no ids).
     outputRefs: [],
     passthroughIdPaths: ["templateId"],
+    stripPaths: [],
   },
 
   // --- Feedback -------------------------------------------------------------
@@ -801,6 +871,7 @@ export const WRITE_TOOL_REF_FIELD_MAP = {
     inputRefs: [],
     outputRefs: [],
     passthroughIdPaths: [],
+    stripPaths: [],
   },
 
   // --- Capability meta-tool: not projected to chat --------------------------
@@ -814,5 +885,6 @@ export const WRITE_TOOL_REF_FIELD_MAP = {
     inputRefs: [],
     outputRefs: [],
     passthroughIdPaths: [],
+    stripPaths: [],
   },
 } as const satisfies Record<RegistryWriteToolName, RegistryRefFieldMapEntry>;

--- a/apps/api/src/handlers/chat/tools/registry-adapter/ref-mediation.test.ts
+++ b/apps/api/src/handlers/chat/tools/registry-adapter/ref-mediation.test.ts
@@ -9,6 +9,7 @@ import {
   dehydrateInputRefs,
   findUndeclaredUuidPath,
   hydrateOutputRefs,
+  stripDeclaredPaths,
 } from "./ref-mediation";
 
 const WS_UUID = "0dc54d0c-10d7-501d-897e-e801dbd0998c";
@@ -330,6 +331,54 @@ describe("registry ref mediation", () => {
           toolName: "list_invoices",
         }),
       ).toBe("invoice.timeEntries[].entityId");
+    });
+  });
+
+  describe("stripDeclaredPaths", () => {
+    test("deletes declared paths in place and satisfies the backstop", () => {
+      const payload = {
+        matter: { id: "mat_1" },
+        overview: {
+          recentEntities: [
+            {
+              entityId: "ent_1",
+              name: "Brief",
+              fieldId: ENTITY_UUID,
+              propertyId: PROPERTY_UUID,
+              pdfFileId: LINKED_ENTITY_UUID,
+            },
+          ],
+        },
+      };
+
+      const stripped = stripDeclaredPaths({
+        output: payload,
+        stripPaths: [
+          "overview.recentEntities[].fieldId",
+          "overview.recentEntities[].propertyId",
+          "overview.recentEntities[].pdfFileId",
+        ],
+      });
+
+      expect(stripped).toEqual({
+        matter: { id: "mat_1" },
+        overview: { recentEntities: [{ entityId: "ent_1", name: "Brief" }] },
+      });
+      expect(containsRawUuid(stripped)).toBe(false);
+    });
+
+    test("tolerates paths the payload's branch never produces", () => {
+      // List mode carries `matters[]`, not the detail branch's `overview`;
+      // the detail-only strip paths must be a no-op, mirroring how
+      // hydration skips a path with no slots.
+      const payload = { matters: [{ id: "mat_1", name: "Acme" }] };
+
+      const stripped = stripDeclaredPaths({
+        output: payload,
+        stripPaths: ["overview.recentEntities[].fieldId"],
+      });
+
+      expect(stripped).toEqual({ matters: [{ id: "mat_1", name: "Acme" }] });
     });
   });
 });

--- a/apps/api/src/handlers/chat/tools/registry-adapter/ref-mediation.ts
+++ b/apps/api/src/handlers/chat/tools/registry-adapter/ref-mediation.ts
@@ -175,6 +175,31 @@ const readScalarAtPath = (root: unknown, path: string): unknown => {
   return cursor;
 };
 
+// --- output stripping ---------------------------------------------------------
+
+/**
+ * Delete every declared strip path from a tool payload, in place, before ref
+ * hydration and the UUID backstop run. Strip paths carry ids other surfaces
+ * need (web-UI field/file plumbing handles) but chat cannot act on: removing
+ * them keeps the model context free of raw ids without widening the
+ * passthrough allowlist. The payload is the caller-owned JSON.parsed object,
+ * so in-place deletion is safe.
+ */
+export const stripDeclaredPaths = ({
+  output,
+  stripPaths,
+}: {
+  output: unknown;
+  stripPaths: readonly string[];
+}): unknown => {
+  for (const path of stripPaths) {
+    visitPathSlots(output, parsePath(path), (container, key) => {
+      Reflect.deleteProperty(container, key);
+    });
+  }
+  return output;
+};
+
 // --- input dehydration ------------------------------------------------------
 
 export type DehydratedInput = {

--- a/apps/api/src/handlers/chat/tools/registry-adapter/registry-projection-contract.test.ts
+++ b/apps/api/src/handlers/chat/tools/registry-adapter/registry-projection-contract.test.ts
@@ -1,0 +1,1303 @@
+import { Result } from "better-result";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { ScopedDb } from "@/api/db/safe-db";
+import { resolveToolWorkspaceIds } from "@/api/handlers/chat/tools/authorized-workspace-ids";
+import { toSafeId } from "@/api/lib/branded-types";
+import type { ChatRefRegistry } from "@/api/lib/chat/ref-registry";
+import { createChatRefRegistry } from "@/api/lib/chat/ref-registry";
+import type { McpRequestContext } from "@/api/mcp/context";
+import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
+import { toSafeDbMock } from "@/api/tests/scoped-db-mock";
+
+import type { RegistryReadToolName } from "./ref-field-map";
+import { READ_TOOL_REF_FIELD_MAP } from "./ref-field-map";
+
+/**
+ * Contract corpus over every chat-projectable read tool: run the real MCP
+ * handler through `runRegistryReadTool` against fixtures whose every id-bearing
+ * column holds a UUID-formatted value, and require the projection to succeed.
+ *
+ * This is the structural guard for the bug class behind the prod
+ * "Tool output failed anonymization of internal identifiers" failures: the
+ * ref-field map is a hand-maintained description of each handler's payload
+ * shape, and a handler field the map does not declare only surfaces when a
+ * real payload carries a UUID there — at runtime, in prod, failing closed.
+ * The canary corpus (`egress-canary.test.ts`) cannot catch this class: its
+ * fixtures use non-UUID ids (`ws_1`, `entity_1`), so the UUID backstop never
+ * fires there. Here every id is UUID-formatted, so an undeclared field fails
+ * this suite instead of production chat.
+ *
+ * Three guards close the loop:
+ * 1. The corpus is keyed by `ProjectableReadToolName` via `satisfies`, so a
+ *    read tool marked `chatProjectable: true` without a fixture here fails
+ *    typecheck (plus a runtime both-ways check for `bun test` alone).
+ * 2. Every call must produce a payload free of undeclared UUIDs — this is
+ *    `runRegistryReadTool`'s own fail-closed backstop; the corpus asserts it
+ *    returns ok instead of the anonymization failure.
+ * 3. Anti-vacuity: per tool, the union of the calls' `expectRefPaths` must
+ *    equal the map's declared `outputRefs` paths, and each such path must
+ *    resolve to at least one minted chat ref in the actual payload. A fixture
+ *    too thin to reach a declared path fails loudly rather than passing
+ *    vacuously.
+ */
+
+// --- Module mocks (before dynamic imports, canary pattern) -------------------
+
+const captureErrorMock = mock();
+void mock.module("@/api/lib/analytics/capture", () => ({
+  captureError: captureErrorMock,
+  captureRequestError: captureErrorMock,
+  getAnalytics: mock(() => ({ capture: mock(), flush: mock() })),
+}));
+
+const readWorkspaceHandlerMock = mock();
+const readOverviewHandlerMock = mock();
+const readWorkspaceContactsHandlerMock = mock();
+const readWorkspaceMembersHandlerMock = mock();
+const describeStoredTemplateMock = mock();
+const searchProviderSearchMock = mock();
+const decryptContentMock = mock(async () => "decrypted text");
+const searchDecisionsHandlerMock = mock();
+const readDecisionWithDocumentHandlerMock = mock();
+const searchConsolidatedLegislationMock = mock();
+const getLawTextBlockMock = mock();
+const executeRegistryLookupMock = mock();
+
+const realContentEncryption = await import("@/api/lib/content-encryption");
+const realTemplateFillService =
+  await import("@/api/lib/templates/template-fill-service");
+const realCaseLawSearch =
+  await import("@/api/handlers/case-law/decisions/search");
+const realCaseLawGetDeferred =
+  await import("@/api/handlers/case-law/decisions/get-deferred-document");
+const realBoe = await import("@stll/boe");
+const realRegistryDispatch =
+  await import("@/api/lib/business-registries/dispatch");
+
+void mock.module("@/api/handlers/workspaces/get", () => ({
+  readWorkspaceHandler: readWorkspaceHandlerMock,
+}));
+void mock.module("@/api/handlers/workspaces/read-overview", () => ({
+  readOverviewHandler: readOverviewHandlerMock,
+}));
+void mock.module("@/api/handlers/workspaces/workspace-contacts-read", () => ({
+  readWorkspaceContactsHandler: readWorkspaceContactsHandlerMock,
+}));
+void mock.module("@/api/handlers/workspaces/workspace-members-read", () => ({
+  readWorkspaceMembersHandler: readWorkspaceMembersHandlerMock,
+}));
+void mock.module("@/api/lib/templates/template-fill-service", () => ({
+  ...realTemplateFillService,
+  describeStoredTemplate: describeStoredTemplateMock,
+}));
+void mock.module("@/api/lib/search/provider", () => ({
+  getSearchProvider: () => ({ search: searchProviderSearchMock }),
+}));
+void mock.module("@/api/lib/content-encryption", () => ({
+  ...realContentEncryption,
+  decryptContent: decryptContentMock,
+}));
+void mock.module("@/api/handlers/case-law/decisions/search", () => ({
+  ...realCaseLawSearch,
+  searchDecisionsHandler: searchDecisionsHandlerMock,
+}));
+void mock.module(
+  "@/api/handlers/case-law/decisions/get-deferred-document",
+  () => ({
+    ...realCaseLawGetDeferred,
+    readDecisionWithDocumentHandler: readDecisionWithDocumentHandlerMock,
+  }),
+);
+void mock.module("@stll/boe", () => ({
+  ...realBoe,
+  searchConsolidatedLegislation: searchConsolidatedLegislationMock,
+  getLawTextBlock: getLawTextBlockMock,
+}));
+void mock.module("@/api/lib/business-registries/dispatch", () => ({
+  ...realRegistryDispatch,
+  executeRegistryLookup: executeRegistryLookupMock,
+}));
+
+const { buildMcpContextFromChat } = await import("./mcp-chat-context");
+const { runRegistryReadTool } = await import("./run-registry-tool");
+
+// --- Fixture ids --------------------------------------------------------------
+
+/** Deterministic, unique, UUID-formatted fixture id. */
+const uid = (n: number): string =>
+  `00000000-0000-4000-8000-${String(n).padStart(12, "0")}`;
+
+/** The one accessible workspace every workspace-scoped fixture lives in. */
+const WS = uid(1);
+
+// --- DB doubles ---------------------------------------------------------------
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+type ThenableBuilder = {
+  from: () => ThenableBuilder;
+  where: () => ThenableBuilder;
+  orderBy: () => ThenableBuilder;
+  groupBy: () => ThenableBuilder;
+  innerJoin: () => ThenableBuilder;
+  leftJoin: () => ThenableBuilder;
+  limit: () => ThenableBuilder;
+  then: (
+    resolve: (rows: readonly unknown[]) => unknown,
+    reject?: (reason: unknown) => unknown,
+  ) => Promise<unknown>;
+};
+
+/**
+ * A drizzle-shaped select chain where every step returns the same builder and
+ * awaiting it (at any step) resolves to the fixture rows. Covers chains that
+ * terminate at `.limit()`, `.where()`, or a join alike, so one double serves
+ * every select in the corpus.
+ */
+const chainable = (rows: readonly unknown[]): ThenableBuilder => {
+  const builder: ThenableBuilder = {
+    from: () => builder,
+    where: () => builder,
+    orderBy: () => builder,
+    groupBy: () => builder,
+    innerJoin: () => builder,
+    leftJoin: () => builder,
+    limit: () => builder,
+    // eslint-disable-next-line unicorn/no-thenable -- drizzle query builders are deliberately thenable, and the double must be awaitable mid-chain the same way
+    then: async (resolve, reject) =>
+      await Promise.resolve(rows).then(resolve, reject),
+  };
+  return builder;
+};
+
+/**
+ * A `tx.select` double that serves one queued row set per select call, in the
+ * order the handler issues them. Over- or under-consuming the queue throws so
+ * a fixture cannot silently answer the wrong query.
+ */
+const selectQueue = (queue: readonly (readonly unknown[])[]) => {
+  const state = { call: 0 };
+  return (): ThenableBuilder => {
+    const rows = queue.at(state.call);
+    state.call += 1;
+    if (rows === undefined) {
+      throw new Error(
+        `tx.select call #${state.call} has no queued fixture rows (${queue.length} queued)`,
+      );
+    }
+    return chainable(rows);
+  };
+};
+
+const buildContext = (tx: unknown): McpRequestContext => {
+  const scopedDb = asTestRaw<ScopedDb>(
+    async (run: (transaction: unknown) => unknown) => await run(tx),
+  );
+  return buildMcpContextFromChat({
+    memberRole: "owner",
+    organizationId: toSafeId<"organization">("org_1"),
+    safeDb: toSafeDbMock(scopedDb),
+    scopedDb,
+    toolWorkspaceIds: resolveToolWorkspaceIds({
+      accessibleWorkspaceIds: [toSafeId<"workspace">(WS)],
+      pinnedIds: [],
+    }),
+    userId: toSafeId<"user">("user_1"),
+  });
+};
+
+// --- Path + ref assertions ------------------------------------------------------
+
+const CHAT_REF_PATTERN = /^(?:mat|ent|contact|prop)_\d+$/u;
+
+/** Resolve every value an `a.b` / `a[].b` grammar path addresses. */
+const readPathValues = (root: unknown, path: string): unknown[] => {
+  let cursors: unknown[] = [root];
+  for (const token of path.split(".")) {
+    const array = token.endsWith("[]");
+    const key = array ? token.slice(0, -2) : token;
+    const next: unknown[] = [];
+    for (const cursor of cursors) {
+      if (!isRecord(cursor)) {
+        continue;
+      }
+      const value = cursor[key];
+      if (array) {
+        if (Array.isArray(value)) {
+          next.push(...value);
+        }
+        continue;
+      }
+      if (value !== undefined) {
+        next.push(value);
+      }
+    }
+    cursors = next;
+  }
+  return cursors;
+};
+
+// --- Corpus -------------------------------------------------------------------
+
+type ContractCall = {
+  /** Distinguishes the tool's calls in test titles (list vs detail branch). */
+  mode: string;
+  buildArgs: (refRegistry: ChatRefRegistry) => Record<string, unknown>;
+  /** Fresh per-run `tx` double; omitted for handlers that never touch the DB. */
+  tx?: () => unknown;
+  /** Arms the module-level mocks this call depends on. */
+  setup?: () => void;
+  /** Declared outputRef paths this call exercises: each must resolve to ≥1 ref. */
+  expectRefPaths: readonly string[];
+};
+
+/**
+ * Read tools the chat projection serves, derived from the map's literal
+ * `chatProjectable` flags: the corpus below must cover exactly this union, so
+ * adding a projectable tool without a contract fixture fails typecheck.
+ */
+type ProjectableReadToolName = {
+  [K in RegistryReadToolName]: (typeof READ_TOOL_REF_FIELD_MAP)[K]["chatProjectable"] extends true
+    ? K
+    : never;
+}[RegistryReadToolName];
+
+const matterRef = (refRegistry: ChatRefRegistry): string =>
+  refRegistry.toMatterRef(toSafeId<"workspace">(WS));
+
+const entityRef = (refRegistry: ChatRefRegistry, entityId: string): string =>
+  refRegistry.toEntityRef({
+    entityId: toSafeId<"entity">(entityId),
+    workspaceId: toSafeId<"workspace">(WS),
+  });
+
+const CONTRACT_CORPUS = {
+  list_matters: [
+    {
+      mode: "list",
+      buildArgs: () => ({}),
+      tx: () => ({
+        select: selectQueue([
+          [
+            {
+              id: WS,
+              name: "Acme retainer",
+              reference: "REF-1",
+              status: "active",
+              lastActivityAt: new Date("2026-01-01T00:00:00.000Z"),
+              createdAt: new Date("2026-01-01T00:00:00.000Z"),
+            },
+          ],
+        ]),
+      }),
+      expectRefPaths: ["matters[].id"],
+    },
+    {
+      mode: "detail",
+      buildArgs: (refRegistry) => ({ matter_id: matterRef(refRegistry) }),
+      setup: () => {
+        readWorkspaceHandlerMock.mockResolvedValue({
+          id: WS,
+          name: "Acme retainer",
+          reference: "REF-1",
+          status: "active",
+          client: { displayName: "Acme s.r.o." },
+        });
+        readOverviewHandlerMock.mockResolvedValue({
+          entityCount: 1,
+          documentCount: 1,
+          taskCount: 0,
+          recentEntities: [
+            {
+              entityId: uid(2),
+              name: "NDA draft.docx",
+              kind: "document",
+              status: null,
+              priority: null,
+              dueDate: null,
+              mimeType:
+                "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+              // The exact trio that tripped the prod backstop on every
+              // non-empty matter: primary-field plumbing ids, now stripped.
+              fieldId: uid(3),
+              propertyId: uid(4),
+              pdfFileId: uid(5),
+              encrypted: false,
+              createdAt: "2026-01-01T00:00:00.000Z",
+              updatedAt: null,
+              createdBy: "Jana",
+              createdByImage: null,
+              createdByDeletedAt: null,
+              assignedTo: "Petr",
+              assignedToImage: null,
+              assignedToDeletedAt: null,
+            },
+          ],
+        });
+        readWorkspaceContactsHandlerMock.mockResolvedValue([
+          {
+            id: uid(6),
+            role: "client",
+            contact: { id: uid(7), type: "person", displayName: "Jan Novák" },
+          },
+        ]);
+        readWorkspaceMembersHandlerMock.mockResolvedValue([
+          {
+            id: uid(8),
+            userId: uid(9),
+            createdAt: new Date("2026-01-01"),
+            user: {
+              id: uid(9),
+              name: "Member One",
+              email: "member@example.test",
+              image: null,
+            },
+          },
+        ]);
+      },
+      expectRefPaths: [
+        "matter.id",
+        "contacts[].contactId",
+        "overview.recentEntities[].entityId",
+      ],
+    },
+  ],
+  list_contacts: [
+    {
+      mode: "list",
+      buildArgs: () => ({}),
+      tx: () => ({
+        select: selectQueue([
+          [
+            {
+              id: uid(10),
+              type: "person",
+              displayName: "Jan Novák",
+              firstName: "Jan",
+              lastName: "Novák",
+              organizationName: null,
+              emails: [{ label: "work", address: "jan@example.test" }],
+              phones: [],
+              tags: [],
+              color: null,
+              createdAt: new Date("2026-01-01"),
+              clientMatterCount: 0,
+            },
+          ],
+        ]),
+      }),
+      expectRefPaths: ["items[].id"],
+    },
+  ],
+  search_across_matters: [
+    {
+      mode: "search",
+      buildArgs: () => ({ query: "nda" }),
+      setup: () => {
+        searchProviderSearchMock.mockResolvedValue({
+          hits: [
+            {
+              entityId: uid(11),
+              workspaceId: WS,
+              title: "NDA draft",
+              headline: "…the <em>NDA</em>…",
+              workspaceName: "Acme retainer",
+              kind: "document",
+            },
+          ],
+          nextCursor: null,
+          totalCount: 1,
+        });
+      },
+      expectRefPaths: ["hits[].workspaceId", "hits[].entityId"],
+    },
+  ],
+  read_content_across_matters: [
+    {
+      mode: "read",
+      buildArgs: (refRegistry) => ({
+        entity_id: entityRef(refRegistry, uid(12)),
+      }),
+      tx: () => ({
+        query: {
+          extractedContent: {
+            findFirst: async () => ({
+              charCount: 14,
+              ciphertext: "cipher",
+              iv: "iv",
+              entity: { kind: "document", name: "NDA draft", workspaceId: WS },
+            }),
+          },
+        },
+      }),
+      expectRefPaths: ["workspaceId", "entityId"],
+    },
+  ],
+  read_contact: [
+    {
+      mode: "read",
+      buildArgs: (refRegistry) => ({
+        contact_id: refRegistry.toContactRef(toSafeId<"contact">(uid(13))),
+      }),
+      tx: () => ({
+        query: {
+          contacts: {
+            findFirst: async () => ({
+              id: uid(13),
+              type: "person",
+              displayName: "Jan Novák",
+              firstName: "Jan",
+              lastName: "Novák",
+              organizationName: null,
+              emails: [{ label: "work", address: "jan@example.test" }],
+              phones: [{ label: "mobile", number: "+420123456789" }],
+            }),
+          },
+        },
+      }),
+      expectRefPaths: ["contactId"],
+    },
+  ],
+  list_documents: [
+    {
+      mode: "list",
+      buildArgs: (refRegistry) => ({ matter_id: matterRef(refRegistry) }),
+      tx: () => ({
+        select: selectQueue([
+          [
+            {
+              createdAt: new Date("2026-01-01"),
+              id: uid(14),
+              name: "NDA draft.docx",
+              kind: "document",
+              parentId: uid(15),
+            },
+          ],
+        ]),
+      }),
+      expectRefPaths: ["documents[].id", "documents[].parentId"],
+    },
+  ],
+  read_document: [
+    {
+      mode: "default with versions",
+      buildArgs: (refRegistry) => ({
+        entity_id: entityRef(refRegistry, uid(16)),
+        include_versions: true,
+      }),
+      tx: () => ({
+        query: {
+          entities: {
+            findFirst: async () => ({
+              workspaceId: WS,
+              kind: "document",
+              name: "NDA draft",
+              currentVersion: {
+                id: uid(17),
+                fields: [
+                  {
+                    id: uid(18),
+                    propertyId: uid(19),
+                    content: { version: 1, type: "text", value: "Body text" },
+                  },
+                ],
+              },
+            }),
+          },
+        },
+        select: selectQueue([
+          [
+            {
+              id: uid(20),
+              versionNumber: 2,
+              stamp: null,
+              label: "v2",
+              description: "Second round",
+              createdAt: new Date("2026-01-01"),
+            },
+          ],
+        ]),
+      }),
+      expectRefPaths: ["entityId", "fields[].propertyId"],
+    },
+    {
+      mode: "specific version",
+      buildArgs: (refRegistry) => ({
+        entity_id: entityRef(refRegistry, uid(16)),
+        version_id: uid(21),
+      }),
+      tx: () => ({
+        query: {
+          entities: {
+            findFirst: async () => ({
+              workspaceId: WS,
+              kind: "document",
+              name: "NDA draft",
+            }),
+          },
+          entityVersions: {
+            findFirst: async () => ({
+              id: uid(21),
+              versionNumber: 1,
+              stamp: null,
+              label: null,
+              description: null,
+              createdAt: new Date("2026-01-01"),
+              fields: [
+                {
+                  id: uid(22),
+                  propertyId: uid(23),
+                  content: { version: 1, type: "text", value: "Old body" },
+                },
+              ],
+            }),
+          },
+        },
+      }),
+      expectRefPaths: ["version.fields[].propertyId"],
+    },
+  ],
+  list_properties: [
+    {
+      mode: "list",
+      buildArgs: (refRegistry) => ({ matter_id: matterRef(refRegistry) }),
+      tx: () => ({
+        select: selectQueue([
+          [
+            {
+              createdAt: new Date("2026-01-01"),
+              id: uid(24),
+              name: "Counterparty",
+              content: { type: "text" },
+              status: "active",
+            },
+          ],
+        ]),
+      }),
+      expectRefPaths: ["properties[].id"],
+    },
+  ],
+  list_tasks: [
+    {
+      mode: "list",
+      buildArgs: (refRegistry) => ({ matter_id: matterRef(refRegistry) }),
+      tx: () => ({
+        select: selectQueue([
+          [
+            {
+              createdAt: new Date("2026-01-01"),
+              id: uid(25),
+              name: "File the brief",
+              status: "open",
+              priority: "high",
+              dueDate: null,
+            },
+          ],
+        ]),
+      }),
+      expectRefPaths: ["tasks[].id"],
+    },
+    {
+      mode: "detail",
+      buildArgs: (refRegistry) => ({
+        task_id: entityRef(refRegistry, uid(26)),
+      }),
+      tx: () => ({
+        query: {
+          entities: {
+            findFirst: async () => ({
+              id: uid(26),
+              workspaceId: WS,
+              kind: "task",
+              name: "File the brief",
+              status: "open",
+              priority: "high",
+              dueDate: null,
+              startAt: null,
+              endAt: null,
+              location: "Prague",
+              agendaKind: null,
+            }),
+          },
+          taskAssignees: {
+            findMany: async () => [
+              { role: "assignee", user: { id: uid(27), name: "Member One" } },
+            ],
+          },
+          entityLinks: {
+            findMany: async (input?: {
+              where?: { sourceEntityId?: unknown; targetEntityId?: unknown };
+            }) =>
+              input?.where?.sourceEntityId === undefined
+                ? []
+                : [
+                    {
+                      id: uid(28),
+                      linkType: "related",
+                      sourceEntityId: uid(26),
+                      targetEntityId: uid(29),
+                      sourceEntity: {
+                        id: uid(26),
+                        name: "File the brief",
+                        kind: "task",
+                      },
+                      targetEntity: {
+                        id: uid(29),
+                        name: "NDA draft",
+                        kind: "document",
+                      },
+                    },
+                  ],
+          },
+        },
+      }),
+      expectRefPaths: ["task.taskId", "task.links[].entity.id"],
+    },
+  ],
+  list_clauses: [
+    {
+      mode: "list with categories",
+      buildArgs: () => ({ include_categories: true }),
+      tx: () => ({
+        select: selectQueue([
+          [
+            {
+              id: uid(30),
+              title: "Confidentiality",
+              categoryId: uid(31),
+              language: "en",
+              description: "Standard NDA clause",
+              currentVersion: 1,
+              createdAt: new Date("2026-01-01"),
+              updatedAt: new Date("2026-01-01"),
+            },
+          ],
+        ]),
+        query: {
+          clauseCategories: {
+            findMany: async () => [
+              {
+                id: uid(31),
+                parentId: uid(32),
+                name: "NDA",
+                description: "Non-disclosure",
+                sortOrder: 0,
+                createdAt: new Date("2026-01-01"),
+                updatedAt: new Date("2026-01-01"),
+              },
+            ],
+          },
+        },
+      }),
+      expectRefPaths: [],
+    },
+    {
+      mode: "detail",
+      buildArgs: () => ({ clause_id: uid(30) }),
+      tx: () => ({
+        query: {
+          clauses: {
+            findFirst: async () => ({
+              id: uid(30),
+              title: "Confidentiality",
+              categoryId: uid(31),
+              description: "Standard NDA clause",
+              usageNotes: "Use for mutual NDAs",
+              language: "en",
+              body: [{ text: "The parties shall keep confidential…" }],
+              metadata: null,
+              currentVersion: 1,
+              createdBy: uid(34),
+              createdAt: new Date("2026-01-01"),
+              updatedAt: new Date("2026-01-01"),
+              variants: [
+                {
+                  id: uid(33),
+                  label: "One-way",
+                  body: [{ text: "The receiving party shall…" }],
+                  sortOrder: 0,
+                  createdAt: new Date("2026-01-01"),
+                },
+              ],
+              versions: [],
+            }),
+          },
+        },
+      }),
+      expectRefPaths: [],
+    },
+  ],
+  list_playbooks: [
+    {
+      mode: "list",
+      buildArgs: () => ({}),
+      tx: () => ({
+        select: selectQueue([
+          [
+            {
+              id: uid(35),
+              name: "NDA review",
+              description: "Mutual NDA playbook",
+              createdAt: new Date("2026-01-01"),
+              updatedAt: new Date("2026-01-01"),
+            },
+          ],
+        ]),
+      }),
+      expectRefPaths: [],
+    },
+    {
+      mode: "detail",
+      buildArgs: () => ({ playbook_id: uid(35) }),
+      tx: () => ({
+        query: {
+          playbookDefinitions: {
+            findFirst: async () => ({
+              id: uid(35),
+              name: "NDA review",
+              description: "Mutual NDA playbook",
+              scope: "organization",
+              positions: {
+                version: 2,
+                items: [
+                  {
+                    mode: "graded",
+                    sourceId: uid(36),
+                    issue: "Confidentiality term",
+                    severity: "high",
+                    guidance: "Cap at 3 years",
+                    enabled: true,
+                    ask: {
+                      mode: "manual",
+                      question: "How long is the term?",
+                      content: { type: "text" },
+                    },
+                    tiers: {
+                      acceptable: {
+                        rules: [{ id: uid(37), text: "Max 3 years" }],
+                      },
+                      fallback: {
+                        entries: [
+                          { id: uid(38), text: "5 years", label: "Fallback" },
+                        ],
+                      },
+                      notAcceptable: {
+                        rules: [{ id: uid(39), text: "Indefinite" }],
+                      },
+                    },
+                  },
+                ],
+              },
+              createdAt: new Date("2026-01-01"),
+              updatedAt: new Date("2026-01-01"),
+            }),
+          },
+        },
+      }),
+      expectRefPaths: [],
+    },
+  ],
+  list_time_entries: [
+    {
+      mode: "list",
+      buildArgs: (refRegistry) => ({ matter_id: matterRef(refRegistry) }),
+      tx: () => ({
+        select: selectQueue([
+          [
+            {
+              id: uid(40),
+              entityId: uid(41),
+              userId: uid(42),
+              dateWorked: "2026-01-01",
+              durationMinutes: 60,
+              billedMinutes: 60,
+              rateAtEntry: 100,
+              currency: "EUR",
+              narrative: "Drafted the NDA",
+              invoiceNarrative: null,
+              billable: true,
+              noCharge: false,
+              status: "draft",
+            },
+          ],
+          [{ id: uid(42), name: "Member One" }],
+        ]),
+      }),
+      expectRefPaths: ["entries[].entityId"],
+    },
+    {
+      mode: "detail",
+      buildArgs: () => ({ time_entry_id: uid(40) }),
+      tx: () => ({
+        query: {
+          timeEntries: { findFirst: async () => ({ workspaceId: WS }) },
+        },
+        select: selectQueue([
+          [
+            {
+              id: uid(40),
+              entityId: uid(41),
+              userId: uid(42),
+              dateWorked: "2026-01-01",
+              durationMinutes: 60,
+              billedMinutes: 60,
+              rateAtEntry: 100,
+              currency: "EUR",
+              narrative: "Drafted the NDA",
+              invoiceNarrative: null,
+              billable: true,
+              noCharge: false,
+              status: "draft",
+            },
+          ],
+          [{ id: uid(42), name: "Member One" }],
+        ]),
+      }),
+      expectRefPaths: ["entry.entityId", "entry.workspaceId"],
+    },
+  ],
+  resolve_rate: [
+    {
+      mode: "resolve",
+      buildArgs: (refRegistry) => ({
+        matter_id: matterRef(refRegistry),
+        user_id: uid(43),
+        date: "2026-01-01",
+      }),
+      tx: () => ({
+        select: selectQueue([[{ userId: uid(43) }], [{ hourlyRate: 100 }]]),
+        query: {
+          rateTables: {
+            findFirst: async () => ({ id: uid(44), currency: "EUR" }),
+          },
+        },
+      }),
+      expectRefPaths: [],
+    },
+  ],
+  list_invoices: [
+    {
+      mode: "list",
+      buildArgs: (refRegistry) => ({ matter_id: matterRef(refRegistry) }),
+      tx: () => ({
+        select: selectQueue([
+          [
+            {
+              id: uid(45),
+              invoiceNumber: "INV-1",
+              reference: "Acme January",
+              status: "draft",
+              invoiceDate: "2026-01-01",
+              dueDate: "2026-02-01",
+              currency: "EUR",
+              totalAmount: 1000,
+              createdAtCursor: new Date("2026-01-01"),
+            },
+          ],
+        ]),
+      }),
+      expectRefPaths: [],
+    },
+    {
+      mode: "detail",
+      buildArgs: () => ({ invoice_id: uid(46) }),
+      tx: () => ({
+        query: {
+          invoices: {
+            findFirst: async () => ({
+              id: uid(46),
+              workspaceId: WS,
+              invoiceNumber: "INV-2",
+              reference: "Acme February",
+              status: "draft",
+              invoiceDate: "2026-02-01",
+              dueDate: "2026-03-01",
+              currency: "EUR",
+              totalAmount: 2000,
+              notes: "Net 30",
+              paidAt: null,
+              createdAt: new Date("2026-02-01"),
+              updatedAt: new Date("2026-02-01"),
+              timeEntries: [
+                {
+                  id: uid(47),
+                  matterId: uid(48),
+                  dateWorked: "2026-02-01",
+                  billedMinutes: 60,
+                  rateAtEntry: 100,
+                  currency: "EUR",
+                  narrative: "Drafted the NDA",
+                  invoiceNarrative: null,
+                  status: "invoiced",
+                  matter: { id: uid(48), name: "NDA draft" },
+                },
+              ],
+              expenses: [
+                {
+                  id: uid(49),
+                  matterId: uid(50),
+                  dateIncurred: "2026-02-01",
+                  amount: 100,
+                  currency: "EUR",
+                  category: "travel",
+                  description: "Court filing fee",
+                  invoiceDescription: null,
+                  billable: true,
+                  markup: 0,
+                  matter: { id: uid(50), name: "Filing bundle" },
+                },
+              ],
+            }),
+          },
+        },
+      }),
+      expectRefPaths: [
+        "invoice.workspaceId",
+        "invoice.timeEntries[].entityId",
+        "invoice.timeEntries[].entity.id",
+        "invoice.expenses[].entityId",
+        "invoice.expenses[].entity.id",
+      ],
+    },
+  ],
+  get_usage: [
+    {
+      mode: "read",
+      buildArgs: () => ({}),
+      tx: () => ({
+        select: selectQueue([
+          [
+            {
+              id: uid(51),
+              status: "active",
+              seats: 3,
+              source: "polar",
+              currentPeriodStart: new Date("2026-01-01"),
+              currentPeriodEnd: new Date("2026-02-01"),
+              cancelAtPeriodEnd: false,
+              policyId: uid(52),
+              policyKey: "pro",
+              policyDisplayName: "Pro",
+              policyMonthlyUsageUnits: 1000,
+            },
+          ],
+          [{ total: 3000 }],
+          [{ total: 1200 }],
+        ]),
+      }),
+      expectRefPaths: [],
+    },
+  ],
+  search_case_law: [
+    {
+      mode: "search",
+      buildArgs: () => ({ query: "dobré mravy" }),
+      setup: () => {
+        searchDecisionsHandlerMock.mockResolvedValue({
+          facets: null,
+          hits: [
+            {
+              caseNumber: "22 Cdo 1000/2020",
+              citationCount: 3,
+              country: "CZ",
+              court: "Nejvyšší soud",
+              decisionDate: "2020-05-01",
+              decisionId: uid(53),
+              decisionType: "judgment",
+              ecli: "ECLI:CZ:NS:2020:22.CDO.1000.2020.1",
+              headline: "…dobré <em>mravy</em>…",
+              language: "cs",
+              languageAlternateCount: 0,
+              slug: "ns-22-cdo-1000-2020",
+              sourceUrl: "https://example.test/decision",
+            },
+          ],
+          nextCursor: null,
+          totalCount: 1,
+        });
+      },
+      expectRefPaths: [],
+    },
+  ],
+  read_case_law_decision: [
+    {
+      mode: "read",
+      buildArgs: () => ({ decision_id: uid(54) }),
+      setup: () => {
+        readDecisionWithDocumentHandlerMock.mockResolvedValue({
+          id: uid(54),
+          caseNumber: "22 Cdo 1000/2020",
+          citationsFrom: [
+            {
+              id: uid(55),
+              citationText: "21 Cdo 500/2019",
+              citedDecisionId: uid(56),
+              sectionIndex: 0,
+            },
+          ],
+          citationsTo: [
+            {
+              id: uid(57),
+              citationText: "23 Cdo 200/2021",
+              citingDecisionId: uid(58),
+              sectionIndex: 1,
+            },
+          ],
+          country: "CZ",
+          court: "Nejvyšší soud",
+          decisionDate: new Date("2020-05-01"),
+          decisionType: "judgment",
+          documentAst: null,
+          documentUrl: null,
+          ecli: "ECLI:CZ:NS:2020:22.CDO.1000.2020.1",
+          fulltext: "Full decision text.",
+          language: "cs",
+          languageAlternates: [],
+          metadata: {},
+          slug: "ns-22-cdo-1000-2020",
+          source: {
+            id: uid(59),
+            name: "NS ČR",
+            adapterKey: "cz-ns",
+            allowsDerivedAi: true,
+          },
+          sourceUrl: "https://example.test/decision",
+        });
+      },
+      expectRefPaths: [],
+    },
+  ],
+  search_legislation: [
+    {
+      mode: "search",
+      buildArgs: () => ({ query: "impuesto" }),
+      setup: () => {
+        searchConsolidatedLegislationMock.mockResolvedValue({
+          data: [{ identificador: "BOE-A-2020-1", titulo: "Ley 1/2020" }],
+          status: { code: "200", text: "ok" },
+        });
+      },
+      expectRefPaths: [],
+    },
+    {
+      mode: "block",
+      buildArgs: () => ({ law_id: "BOE-A-2020-1", block_id: "a1" }),
+      setup: () => {
+        getLawTextBlockMock.mockResolvedValue("<bloque>Artículo 1</bloque>");
+      },
+      expectRefPaths: [],
+    },
+  ],
+  lookup_business_registry: [
+    {
+      mode: "lookup",
+      buildArgs: () => ({ registry: "ares", query: "12345678" }),
+      tx: () => ({
+        query: {
+          organizationSettings: {
+            findFirst: async () => ({
+              practiceJurisdictions: [],
+              nativeToolOverrides: { ares: true },
+            }),
+          },
+        },
+      }),
+      setup: () => {
+        executeRegistryLookupMock.mockResolvedValue({
+          type: "lookup",
+          registry: "ares",
+          hit: {
+            registry: "ares",
+            id: "12345678",
+            name: "Acme s.r.o.",
+            legalForm: "s.r.o.",
+            address: "Praha 1",
+            registryUrl: "https://ares.gov.cz/12345678",
+          },
+        });
+      },
+      expectRefPaths: [],
+    },
+  ],
+  list_templates: [
+    {
+      mode: "list",
+      buildArgs: () => ({}),
+      tx: () => ({
+        select: selectQueue([
+          [
+            {
+              id: uid(60),
+              name: "Engagement letter",
+              fieldCount: 2,
+              tags: [],
+              whenToUse: "New client intake",
+              whenNotToUse: "Existing engagements",
+            },
+          ],
+        ]),
+      }),
+      expectRefPaths: [],
+    },
+    {
+      mode: "detail",
+      buildArgs: () => ({ template_id: uid(60) }),
+      setup: () => {
+        describeStoredTemplateMock.mockResolvedValue({
+          name: "Engagement letter",
+          fields: [
+            {
+              path: "client_name",
+              label: "Client name",
+              inputType: "text",
+              required: true,
+              hint: null,
+              options: null,
+              formats: null,
+              aiPrompt: null,
+              aiAdapt: false,
+              optionsFrom: null,
+              dateFormat: null,
+              parts: null,
+              format: null,
+            },
+          ],
+          conditions: [],
+          computed: [],
+        });
+      },
+      expectRefPaths: [],
+    },
+  ],
+} as const satisfies Record<ProjectableReadToolName, readonly ContractCall[]>;
+
+/**
+ * Recover the key type `Object.entries` widens to string. Honest by
+ * construction: the corpus is a closed literal whose keys `satisfies` pins to
+ * exactly `ProjectableReadToolName`.
+ */
+const isCorpusToolName = (name: string): name is ProjectableReadToolName =>
+  name in CONTRACT_CORPUS;
+
+const corpusEntries = (): readonly (readonly [
+  ProjectableReadToolName,
+  readonly ContractCall[],
+])[] =>
+  Object.keys(CONTRACT_CORPUS).flatMap((name) =>
+    isCorpusToolName(name) ? [[name, CONTRACT_CORPUS[name]] as const] : [],
+  );
+
+// --- Suite --------------------------------------------------------------------
+
+const ALL_MOCKS = [
+  readWorkspaceHandlerMock,
+  readOverviewHandlerMock,
+  readWorkspaceContactsHandlerMock,
+  readWorkspaceMembersHandlerMock,
+  describeStoredTemplateMock,
+  searchProviderSearchMock,
+  searchDecisionsHandlerMock,
+  readDecisionWithDocumentHandlerMock,
+  searchConsolidatedLegislationMock,
+  getLawTextBlockMock,
+  executeRegistryLookupMock,
+];
+
+beforeEach(() => {
+  captureErrorMock.mockClear();
+  for (const handlerMock of ALL_MOCKS) {
+    handlerMock.mockReset();
+  }
+  decryptContentMock.mockReset();
+  decryptContentMock.mockResolvedValue("decrypted text");
+});
+
+describe("registry projection contract", () => {
+  test("the corpus covers exactly the chat-projectable read tools", () => {
+    const projectable = Object.entries(READ_TOOL_REF_FIELD_MAP)
+      .filter(([, entry]) => entry.chatProjectable)
+      .map(([name]) => name)
+      .sort();
+    const covered = Object.keys(CONTRACT_CORPUS).sort();
+    expect(covered).toEqual(projectable);
+  });
+
+  test("every declared outputRef path is exercised by some fixture call", () => {
+    for (const [toolName, calls] of corpusEntries()) {
+      const entry = READ_TOOL_REF_FIELD_MAP[toolName];
+      const declared = entry.outputRefs.map((field) => field.path).sort();
+      const exercised = [
+        ...new Set(calls.flatMap((call) => call.expectRefPaths)),
+      ].sort();
+      expect(
+        exercised,
+        `${toolName}: the corpus' expectRefPaths must equal the map's ` +
+          "declared outputRefs paths — an unexercised declaration is a " +
+          "vacuous fixture, an undeclared expectation is a stale test",
+      ).toEqual(declared);
+    }
+  });
+
+  for (const [toolName, calls] of corpusEntries()) {
+    for (const call of calls) {
+      test(`${toolName} (${call.mode}) projects with no undeclared UUID`, async () => {
+        call.setup?.();
+        const refRegistry = createChatRefRegistry();
+        const context = buildContext(call.tx?.() ?? {});
+
+        const result = await runRegistryReadTool({
+          args: call.buildArgs(refRegistry),
+          context,
+          refRegistry,
+          toolName,
+        });
+
+        if (Result.isError(result)) {
+          const leakPaths = captureErrorMock.mock.calls
+            .map((mockCall) => {
+              const [, telemetry] = mockCall;
+              return isRecord(telemetry) ? telemetry["path"] : undefined;
+            })
+            .filter((path): path is string => typeof path === "string");
+          const leakSuffix =
+            leakPaths.length > 0
+              ? ` — undeclared UUID at: ${leakPaths.join(", ")}`
+              : "";
+          throw new Error(
+            `${toolName} (${call.mode}) failed: ${result.error.message}${leakSuffix}`,
+          );
+        }
+
+        const payload = result.value;
+        for (const path of call.expectRefPaths) {
+          const values = readPathValues(payload, path);
+          expect(
+            values.length,
+            `${toolName} (${call.mode}): declared outputRef path "${path}" ` +
+              "resolved to nothing — the fixture never exercised it",
+          ).toBeGreaterThan(0);
+          for (const value of values) {
+            expect(
+              value,
+              `${toolName} (${call.mode}): "${path}" must hold a chat ref`,
+            ).toMatch(CHAT_REF_PATTERN);
+          }
+        }
+
+        // Declared strip paths must be gone from the projected payload — not
+        // merely tolerated by the backstop. This stays meaningful even if a
+        // path were ever declared as both strip and passthrough, where a
+        // broken strip would otherwise survive the ok result.
+        for (const path of READ_TOOL_REF_FIELD_MAP[toolName].stripPaths) {
+          expect(
+            readPathValues(payload, path).length,
+            `${toolName} (${call.mode}): declared stripPath "${path}" must ` +
+              "be absent from the projected payload",
+          ).toBe(0);
+        }
+      });
+    }
+  }
+});

--- a/apps/api/src/handlers/chat/tools/registry-adapter/run-registry-tool.ts
+++ b/apps/api/src/handlers/chat/tools/registry-adapter/run-registry-tool.ts
@@ -25,6 +25,7 @@ import {
   dehydrateInputRefs,
   findUndeclaredUuidPath,
   hydrateOutputRefs,
+  stripDeclaredPaths,
 } from "./ref-mediation";
 
 /**
@@ -73,9 +74,18 @@ export const firstTextContent = (result: CallToolResult): string => {
 /** Fallback for an `isError` result whose content carries no text block. */
 export const DEFAULT_TOOL_ERROR_MESSAGE = "Tool execution failed.";
 
-/** Surfaced to the model when a hydrated payload still carries a raw uuid. */
-export const ANONYMIZATION_FAILURE_MESSAGE =
-  "Tool output failed anonymization of internal identifiers.";
+/**
+ * Surfaced to the model when a hydrated payload still carries a raw uuid.
+ * Deliberately does not say "anonymization": the anonymization feature (the
+ * anonymized MCP surface) is a different mechanism and is not involved —
+ * chat egress runs in default mode. This is the chat ref projection's own
+ * fail-closed invariant, it fires regardless of any anonymization setting,
+ * and the model can do nothing about it, so the message says both.
+ */
+export const REF_PROJECTION_FAILURE_MESSAGE =
+  "The tool result contained an internal identifier the chat projection " +
+  "could not map to a reference. This is a server-side defect, not a " +
+  "problem with your input; do not retry this call.";
 
 /**
  * A finished registry result is a single text content block holding the
@@ -170,9 +180,13 @@ export const runRegistryReadTool = async ({
     return Result.err(payload.error);
   }
 
+  const stripped = stripDeclaredPaths({
+    output: payload.value,
+    stripPaths: READ_TOOL_REF_FIELD_MAP[toolName].stripPaths,
+  });
   const hydrated = hydrateOutputRefs({
     dehydration: dehydrated.value,
-    output: payload.value,
+    output: stripped,
     refRegistry,
     toolName,
   });
@@ -187,7 +201,9 @@ export const runRegistryReadTool = async ({
   // while the offending path (never the value) still reaches telemetry.
   const offendingPath = findUndeclaredUuidPath({ toolName, payload: hydrated });
   if (offendingPath !== undefined) {
-    const error = new ChatToolError({ message: ANONYMIZATION_FAILURE_MESSAGE });
+    const error = new ChatToolError({
+      message: REF_PROJECTION_FAILURE_MESSAGE,
+    });
     captureError(error, {
       source: "run-registry-tool",
       toolName,

--- a/apps/api/src/handlers/chat/tools/registry-adapter/run-registry-write-tool.ts
+++ b/apps/api/src/handlers/chat/tools/registry-adapter/run-registry-write-tool.ts
@@ -24,12 +24,13 @@ import {
   dehydrateRefs,
   findUndeclaredUuidPathIn,
   hydrateRefs,
+  stripDeclaredPaths,
 } from "./ref-mediation";
 import {
-  ANONYMIZATION_FAILURE_MESSAGE,
   DEFAULT_TOOL_ERROR_MESSAGE,
   firstTextContent,
   parsePayload,
+  REF_PROJECTION_FAILURE_MESSAGE,
 } from "./run-registry-tool";
 
 /**
@@ -173,9 +174,13 @@ export const runRegistryWriteTool = async ({
     return Result.err(payload.error);
   }
 
+  const stripped = stripDeclaredPaths({
+    output: payload.value,
+    stripPaths: entry.stripPaths,
+  });
   const hydrated = hydrateRefs({
     dehydration: dehydrated.value,
-    output: payload.value,
+    output: stripped,
     outputRefs: entry.outputRefs,
     refRegistry,
   });
@@ -189,7 +194,9 @@ export const runRegistryWriteTool = async ({
     payload: hydrated,
   });
   if (offendingPath !== undefined) {
-    const error = new ChatToolError({ message: ANONYMIZATION_FAILURE_MESSAGE });
+    const error = new ChatToolError({
+      message: REF_PROJECTION_FAILURE_MESSAGE,
+    });
     captureError(error, {
       source: "run-registry-write-tool",
       toolName,


### PR DESCRIPTION
## Summary

The chat registry projection's ref-field map is a hand-maintained description of each handler's payload shape. This PR adds a third lever beside ref hydration and passthrough — `stripPaths`, for fields other surfaces need but chat cannot act on — and a contract corpus that keeps the map and the handlers aligned.

- `stripPaths`: declared paths are deleted from the chat projection before hydration and the UUID backstop run. Wired into both the read and write orchestrators. Declarations added for `list_matters` (overview plumbing ids) and `list_playbooks` (tier rule/entry ids).
- The backstop's error message now names the ref projection and states the retry semantics explicitly.
- `registry-projection-contract.test.ts`: every chat-projectable read tool runs through `runRegistryReadTool` against fixtures whose every id-bearing column is UUID-formatted. Coverage is enforced by `satisfies` over the projectable-tool union, and an anti-vacuity check requires each declared outputRef path to resolve to a minted chat ref in the actual payload.