### PR TITLE
fix(chat): keep tenant workspace ids out of the model context

### DIFF
--- a/apps/api/src/handlers/chat/persist-message.test.ts
+++ b/apps/api/src/handlers/chat/persist-message.test.ts
@@ -17,7 +17,6 @@ const workspaceId = toSafeId<"workspace">(
 );
 const entityId = toSafeId<"entity">("c09ec856-d945-5ecc-82e3-bb5382165f34");
 const fieldId = toSafeId<"field">("12549e0d-f3dd-589a-8012-d4f27b8cd641");
-const propertyId = toSafeId<"property">("750890f7-42ce-59ab-9627-9171e5dc6346");
 const chatMessageId = (id: string) => toSafeId<"chatMessage">(id);
 
 const stored = (message: PersistableChatMessage) => ({
@@ -90,16 +89,16 @@ const updateFieldsApprovalRespondedMessage = toPersistableChatMessage({
       id: "tool-update-entity-fields-1",
       name: "update-entity-fields",
       arguments: JSON.stringify({
-        workspaceId,
-        entityId,
-        propertyId,
+        matterRef: "mat_1",
+        entityRef: "ent_1",
+        propertyRef: "prop_1",
         value: "Reviewed",
       }),
       state: "approval-responded",
       input: {
-        workspaceId,
-        entityId,
-        propertyId,
+        matterRef: "mat_1",
+        entityRef: "ent_1",
+        propertyRef: "prop_1",
         value: "Reviewed",
       },
       approval: {
@@ -119,22 +118,22 @@ const updateFieldsFinishedMessage = toPersistableChatMessage({
       id: "tool-update-entity-fields-1",
       name: "update-entity-fields",
       arguments: JSON.stringify({
-        workspaceId,
-        entityId,
-        propertyId,
+        matterRef: "mat_1",
+        entityRef: "ent_1",
+        propertyRef: "prop_1",
         value: "Reviewed",
       }),
       state: "complete",
       input: {
-        workspaceId,
-        entityId,
-        propertyId,
+        matterRef: "mat_1",
+        entityRef: "ent_1",
+        propertyRef: "prop_1",
         value: "Reviewed",
       },
       output: {
         success: true,
-        entityId,
-        propertyId,
+        entityRef: "ent_1",
+        propertyRef: "prop_1",
         newValue: "Reviewed",
       },
       approval: {

--- a/apps/api/src/handlers/chat/send-message.ts
+++ b/apps/api/src/handlers/chat/send-message.ts
@@ -1598,6 +1598,7 @@ const sendMessage = createSafeRootHandler(
                 resolveAssistantValueRefs:
                   refRegistry.resolveAssistantValueRefs,
                 safeDb,
+                tenantWorkspaceIds: accessibleWorkspaceIds,
                 thirdPartyBoundary,
                 threadId: body.threadId,
                 tools: streamingTools,
@@ -2508,14 +2509,27 @@ const hydrateAssistantMessageRefs = ({
     return hydrated;
   };
 
-  return messages.map((message) =>
-    message.role === "assistant"
-      ? {
-          ...message,
-          parts: message.parts.map(hydratePart),
-        }
-      : message,
-  );
+  // User text carries persisted mention hrefs too: composer mention chips
+  // serialize as `#stella-entity=<ws>:<ent>` / `#stella-workspace=<ws>`
+  // links (chat-message.ts `toMentionHref`), and compaction checkpoints are
+  // persisted as user-role messages. Hydrating them keeps raw tenant UUIDs
+  // out of the model context while preserving what the user pointed at.
+  const hydrateUserPart = (
+    part: ChatMessage["parts"][number],
+  ): ChatMessage["parts"][number] =>
+    part.type === "text"
+      ? { ...part, content: refRegistry.hydrateAssistantTextRefs(part.content) }
+      : part;
+
+  return messages.map((message) => {
+    if (message.role === "assistant") {
+      return { ...message, parts: message.parts.map(hydratePart) };
+    }
+    if (message.role === "user") {
+      return { ...message, parts: message.parts.map(hydrateUserPart) };
+    }
+    return message;
+  });
 };
 
 const insertMessages = async ({

--- a/apps/api/src/handlers/chat/stream-chat.ts
+++ b/apps/api/src/handlers/chat/stream-chat.ts
@@ -87,6 +87,10 @@ import {
   chatToolMapToArray,
   type ChatToolMap,
 } from "@/api/lib/chat/chat-tool-types";
+import {
+  assertModelSurfaceFreeOfTenantIds,
+  redactTenantIdsDeep,
+} from "@/api/lib/chat/model-ingress-guard";
 import { projectChatToolSchemasForProvider } from "@/api/lib/chat/provider-tool-projection";
 import type { ChatRefRegistry } from "@/api/lib/chat/ref-registry";
 import {
@@ -153,6 +157,12 @@ type StreamChatProps = {
   safeDb: SafeDb;
   systemSafe: ChatSafePrompt;
   systemUntrusted: ChatUntrustedPromptSuffix;
+  /**
+   * The org's accessible workspace ids, for the model-ingress guard: the
+   * exact tenant set whose raw ids must never reach the provider (only chat
+   * refs may). Already loaded on every send, so membership checks are free.
+   */
+  tenantWorkspaceIds: readonly SafeId<"workspace">[];
   thirdPartyBoundary: ChatThirdPartyBoundary;
   threadId: SafeId<"chatThread">;
   tools: ChatToolMap;
@@ -210,6 +220,7 @@ export const streamChat = async ({
   safeDb,
   systemSafe,
   systemUntrusted,
+  tenantWorkspaceIds,
   thirdPartyBoundary,
   threadId,
   tools,
@@ -229,14 +240,31 @@ export const streamChat = async ({
     preparedUntrusted.value.length > 0
       ? `${systemSafe}${preparedUntrusted.value.startsWith("\n") ? "" : "\n\n"}${preparedUntrusted.value}`
       : systemSafe;
+  // The system prompt is entirely server-built; a tenant workspace id in it
+  // is a Stella bug (matter scope, active-file, and connected-matter
+  // sections must all speak in chat refs), so this fails closed.
+  assertModelSurfaceFreeOfTenantIds({
+    serialized: system,
+    surface: "system-prompt",
+    workspaceIds: tenantWorkspaceIds,
+  });
 
-  const preparedMessages = await prepareMessagesForThirdParty({
+  const rawPreparedMessages = await prepareMessagesForThirdParty({
     boundary: thirdPartyBoundary,
     messages,
   });
-  if (Result.isError(preparedMessages)) {
-    return thirdPartyBoundaryRefusalResponse(preparedMessages.error);
+  if (Result.isError(rawPreparedMessages)) {
+    return thirdPartyBoundaryRefusalResponse(rawPreparedMessages.error);
   }
+  // Messages carry user-authored and historical text (mention hrefs from
+  // before ref hydration covered user text, pasted workspace URLs), so hits
+  // are redacted rather than refused: old threads keep working, telemetry
+  // records the path of every residual ingress leak, and the model loses
+  // only an id it could not legitimately use.
+  const preparedMessageList = redactTenantIdsDeep({
+    value: rawPreparedMessages.value,
+    workspaceIds: tenantWorkspaceIds,
+  }).value;
 
   const primaryModel = resolveTanStackTextModel({
     modelId: devModelId,
@@ -252,9 +280,8 @@ export const streamChat = async ({
   // chat model without gating by modality, so reject here — before dispatch —
   // any document whose format the model cannot ingest, rather than let the
   // adapter crash the stream.
-  const documentAttachmentMimeTypes = preparedMessages.value.flatMap(
-    (message) =>
-      message.parts.filter(isChatDocumentPart).map(getChatAttachmentMimeType),
+  const documentAttachmentMimeTypes = preparedMessageList.flatMap((message) =>
+    message.parts.filter(isChatDocumentPart).map(getChatAttachmentMimeType),
   );
   const modelRejectsAnyDocument = (model: ResolvedTanStackTextModel): boolean =>
     documentAttachmentMimeTypes.some(
@@ -294,11 +321,19 @@ export const streamChat = async ({
   const modelTools = chatToolMapToArray(
     prepareToolsForThirdParty({ boundary: thirdPartyBoundary, tools }),
   );
+  // Tool schemas are mostly server-built but may include org-configured
+  // external MCP tool descriptions, so a hit here is telemetry, not a
+  // turn-killing panic (the guard only panics for the system prompt).
+  assertModelSurfaceFreeOfTenantIds({
+    serialized: JSON.stringify(modelTools),
+    surface: "tool-schemas",
+    workspaceIds: tenantWorkspaceIds,
+  });
   const restorationPairs: ChatAnonRestoration[] = [];
   const mapAssistantMessageId = createChatMessageIdMapper();
   let responseMessage: ChatMessage | null = null;
   const processor = new StreamProcessor({
-    initialMessages: preparedMessages.value,
+    initialMessages: preparedMessageList,
     events: {
       onStreamEnd: (message) => {
         const convertedMessage = toChatMessage(message);
@@ -323,7 +358,7 @@ export const streamChat = async ({
     modelTools,
     organizationId,
     orgAIConfig,
-    preparedMessages: preparedMessages.value,
+    preparedMessages: preparedMessageList,
     primaryModel,
     promptCacheKey,
     promptCachingEnabled,
@@ -344,7 +379,7 @@ export const streamChat = async ({
         thirdPartyBoundary.type === "anonymized"
           ? collectInitialRestorationPlaceholders({
               latestMessageId,
-              messages: preparedMessages.value,
+              messages: preparedMessageList,
               redactionMap: thirdPartyBoundary.redactionMap,
             })
           : new Set<string>(),

--- a/apps/api/src/handlers/chat/tools/chat-history-tools.test.ts
+++ b/apps/api/src/handlers/chat/tools/chat-history-tools.test.ts
@@ -6,6 +6,7 @@ import { PgDialect } from "drizzle-orm/pg-core";
 import type { Transaction } from "@/api/db/root";
 import type { SafeDb } from "@/api/db/safe-db";
 import { toSafeId } from "@/api/lib/branded-types";
+import { createChatRefRegistry } from "@/api/lib/chat/ref-registry";
 import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
 
 import {
@@ -38,6 +39,7 @@ describe("chat history tools", () => {
   test("exclude replay-truncated messages from history search", async () => {
     const { queries, safeDb } = createSafeDbCapture();
     const tools = createChatHistoryTools({
+      refRegistry: createChatRefRegistry(),
       excludedMessageIds: [hiddenMessageId],
       safeDb,
       threadId,
@@ -63,6 +65,7 @@ describe("chat history tools", () => {
   test("does not expand a replay-truncated target message", async () => {
     const { queries, safeDb } = createSafeDbCapture();
     const tools = createChatHistoryTools({
+      refRegistry: createChatRefRegistry(),
       excludedMessageIds: [hiddenMessageId],
       safeDb,
       threadId,

--- a/apps/api/src/handlers/chat/tools/chat-history-tools.ts
+++ b/apps/api/src/handlers/chat/tools/chat-history-tools.ts
@@ -13,6 +13,7 @@ import type {
   ChatMessageRole,
 } from "@/api/handlers/chat/types";
 import type { SafeId } from "@/api/lib/branded-types";
+import type { ChatRefRegistry } from "@/api/lib/chat/ref-registry";
 import { ChatToolError } from "@/api/lib/errors/tagged-errors";
 import { LIMITS } from "@/api/lib/limits";
 import { brandPersistedChatMessageId } from "@/api/lib/safe-id-boundaries";
@@ -97,6 +98,7 @@ const expandChatHistoryOutputSchema = v.strictObject({
 
 type CreateChatHistoryToolsProps = {
   excludedMessageIds?: readonly SafeId<"chatMessage">[] | undefined;
+  refRegistry: ChatRefRegistry;
   safeDb: SafeDb;
   threadId: SafeId<"chatThread">;
 };
@@ -117,6 +119,7 @@ type ChatHistoryExpansionRow = {
 
 export const createChatHistoryTools = ({
   excludedMessageIds = [],
+  refRegistry,
   safeDb,
   threadId,
 }: CreateChatHistoryToolsProps) => {
@@ -181,7 +184,11 @@ export const createChatHistoryTools = ({
         results: result.value.map((row) => ({
           messageId: row.messageId,
           role: row.role,
-          excerpt: row.excerpt,
+          // Persisted text carries stable mention hrefs with raw tenant
+          // UUIDs; hand-written history tools bypass the registry adapter's
+          // hydration, so rewrite them into chat refs here before the text
+          // reaches the model.
+          excerpt: refRegistry.hydrateAssistantTextRefs(row.excerpt),
           createdAt: row.createdAt.toISOString(),
         })),
       };
@@ -263,7 +270,11 @@ export const createChatHistoryTools = ({
             messageId: row.id,
             role: row.role,
             createdAt: row.createdAt.toISOString(),
-            content: renderChatMessagesForCompaction([message]),
+            // Same rationale as the search excerpt: persisted mention hrefs
+            // must re-enter the model as chat refs, not raw tenant UUIDs.
+            content: refRegistry.hydrateAssistantTextRefs(
+              renderChatMessagesForCompaction([message]),
+            ),
           };
         }),
       };

--- a/apps/api/src/handlers/chat/tools/chat-tools.ts
+++ b/apps/api/src/handlers/chat/tools/chat-tools.ts
@@ -672,6 +672,7 @@ export const getChatTools = (props: GetChatToolsProps): ChatToolMap => {
     : {};
   const historyTools = createChatHistoryTools({
     excludedMessageIds: excludedChatHistoryMessageIds,
+    refRegistry,
     safeDb,
     threadId,
   });
@@ -686,6 +687,7 @@ export const getChatTools = (props: GetChatToolsProps): ChatToolMap => {
   // chat client (sticky thread-local matter or matter-pick UI).
   const workspaceTools = createWorkspaceTools({
     allowedWorkspaceIds: toolWorkspaceIds,
+    refRegistry,
     scopedDb,
   });
 

--- a/apps/api/src/handlers/chat/tools/tool-schema.test.ts
+++ b/apps/api/src/handlers/chat/tools/tool-schema.test.ts
@@ -462,9 +462,30 @@ describe("chat tool schemas", () => {
     expect(() =>
       createWorkspaceTools({
         allowedWorkspaceIds: [workspaceId],
+        refRegistry: createChatRefRegistry(),
         scopedDb: unusedScopedDb,
       }),
     ).not.toThrow();
+  });
+
+  test("workspace tool schemas enumerate matter refs, never workspace UUIDs", () => {
+    const registry = createChatRefRegistry();
+    const tools = createWorkspaceTools({
+      allowedWorkspaceIds: [workspaceId],
+      refRegistry: registry,
+      scopedDb: unusedScopedDb,
+    });
+    const serialized = JSON.stringify(
+      Object.values(tools).map((tool) => ({
+        description: tool.description,
+        inputSchema: convertSchemaToJsonSchema(tool.inputSchema),
+      })),
+    );
+    // The tool catalog is provider-visible every turn: enumerating raw
+    // workspace ids here is exactly how the model once learned (and used)
+    // a tenant UUID as a matter_id.
+    expect(serialized).toContain(registry.toMatterRef(workspaceId));
+    expect(serialized).not.toContain(workspaceId);
   });
 
   test("construct skill tools as JSON-schema-compatible AI tools", () => {

--- a/apps/api/src/handlers/chat/tools/workspace-tools.ts
+++ b/apps/api/src/handlers/chat/tools/workspace-tools.ts
@@ -1,5 +1,5 @@
 import { toolDefinition } from "@tanstack/ai";
-import { panic } from "better-result";
+import { panic, Result } from "better-result";
 import { and, eq } from "drizzle-orm";
 import * as v from "valibot";
 
@@ -12,15 +12,11 @@ import type { SafeId } from "@/api/lib/branded-types";
 import type { ChatRefRegistry } from "@/api/lib/chat/ref-registry";
 import { CHAT_ENTITY_REF_PREFIX } from "@/api/lib/chat/ref-registry";
 import { ChatToolError } from "@/api/lib/errors/tagged-errors";
-import {
-  brandPersistedEntityId,
-  brandPersistedPropertyId,
-} from "@/api/lib/safe-id-boundaries";
 import { getSearchProvider } from "@/api/lib/search/provider";
 import { isRecord } from "@/api/lib/type-guards";
 
-const idSchema = (description: string) =>
-  v.pipe(v.string(), v.uuid(), v.description(description));
+const refSchema = (description: string) =>
+  v.pipe(v.string(), v.description(description));
 
 // -----------------------------------------------------------------
 // Matter tools (workspace-scoped, explicit workspaceId)
@@ -68,6 +64,7 @@ const formatFieldValue = (content: FieldContent): string => {
 
 type WorkspaceToolsContext = {
   allowedWorkspaceIds: readonly SafeId<"workspace">[];
+  refRegistry: ChatRefRegistry;
   scopedDb: ScopedDb;
 };
 
@@ -102,65 +99,61 @@ export const buildCreatedDocumentToolOutput = ({
   };
 };
 
-const createAllowedWorkspaceIdMap = (
-  allowedIds: readonly SafeId<"workspace">[],
-) => {
-  const allowedIdsByValue = new Map<string, SafeId<"workspace">>(
-    allowedIds.map((id) => [id, id]),
-  );
-  return allowedIdsByValue;
-};
-
-const workspaceIdSchema = (allowedIds: readonly SafeId<"workspace">[]) =>
+/**
+ * Enumerate the allowed matters by their chat refs, never their UUIDs: this
+ * description is serialized into the provider-visible tool catalog every
+ * turn, so a raw workspace id here would hand the model exactly the tenant
+ * identifier the ref invariant exists to keep away from it (and did, before
+ * this took refs).
+ */
+const matterRefSchema = (allowedMatterRefs: readonly string[]) =>
   v.pipe(
     v.string(),
     v.description(
-      "The workspace/matter ID to operate on. " +
-        `Allowed values: ${allowedIds.join(", ")}`,
+      "The matter ref to operate on. " +
+        `Allowed values: ${allowedMatterRefs.join(", ")}`,
     ),
   );
 
 const updateEntityFieldsOutputSchema = v.strictObject({
   success: v.literal(true),
-  entityId: v.string(),
-  propertyId: v.string(),
+  entityRef: v.string(),
+  propertyRef: v.string(),
   newValue: v.string(),
 });
 
-// This is a brand-minting validator: workspaceId is an untrusted
-// string from chat-tool input (LLM-generated), looked up in the
-// allowed-set Map and returned as SafeId<"workspace"> on success.
-// The bare-string parameter is intentional and required.
 const requireAllowedWorkspaceId = ({
-  allowedIdsByValue,
+  allowedIds,
   workspaceId,
 }: {
-  allowedIdsByValue: Map<string, SafeId<"workspace">>;
-  // eslint-disable-next-line no-unbranded-ownership-id-param/no-unbranded-ownership-id-param -- brand-minting boundary: validates untrusted LLM string into SafeId
-  workspaceId: string;
+  allowedIds: ReadonlySet<string>;
+  workspaceId: SafeId<"workspace">;
 }): SafeId<"workspace"> => {
-  const allowedWorkspaceId = allowedIdsByValue.get(workspaceId);
-  if (!allowedWorkspaceId) {
+  if (!allowedIds.has(workspaceId)) {
     throw new ChatToolError({
       kind: "not-found",
-      message: "Workspace not in the allowed set.",
+      message: "Matter not in the allowed set.",
     });
   }
 
-  return allowedWorkspaceId;
+  return workspaceId;
 };
 
 export const createWorkspaceTools = ({
   allowedWorkspaceIds,
+  refRegistry,
   scopedDb,
 }: WorkspaceToolsContext) => {
   if (allowedWorkspaceIds.length === 0) {
     return {};
   }
 
-  const allowedWorkspaceIdsByValue =
-    createAllowedWorkspaceIdMap(allowedWorkspaceIds);
-  const wsSchema = workspaceIdSchema(allowedWorkspaceIds);
+  const allowedWorkspaceIdSet: ReadonlySet<string> = new Set(
+    allowedWorkspaceIds,
+  );
+  const wsSchema = matterRefSchema(
+    allowedWorkspaceIds.map((id) => refRegistry.toMatterRef(id)),
+  );
 
   return {
     "update-entity-fields": toolDefinition({
@@ -177,9 +170,13 @@ export const createWorkspaceTools = ({
       needsApproval: true,
       inputSchema: toTanStackToolSchema(
         v.strictObject({
-          workspaceId: wsSchema,
-          entityId: idSchema("The entity ID to update"),
-          propertyId: idSchema("The property ID (from read-entity)"),
+          matterRef: wsSchema,
+          entityRef: refSchema(
+            "The entity ref (ent_N) of the entity to update, from read tools",
+          ),
+          propertyRef: refSchema(
+            "The property ref (prop_N), from external_list_properties",
+          ),
           value: v.pipe(
             v.union([v.string(), v.number(), v.array(v.string()), v.null_()]),
             v.description("New value for the field"),
@@ -188,12 +185,41 @@ export const createWorkspaceTools = ({
       ),
       outputSchema: toTanStackToolSchema(updateEntityFieldsOutputSchema),
     }).server(async (input) => {
+      const resolvedMatter = refRegistry.resolveMatterRefs([input.matterRef]);
+      if (Result.isError(resolvedMatter)) {
+        throw resolvedMatter.error;
+      }
       const allowedWorkspaceId = requireAllowedWorkspaceId({
-        allowedIdsByValue: allowedWorkspaceIdsByValue,
-        workspaceId: input.workspaceId,
+        allowedIds: allowedWorkspaceIdSet,
+        workspaceId:
+          resolvedMatter.value.at(0) ??
+          panic("resolved matter ref list is unexpectedly empty"),
       });
-      const entityId = brandPersistedEntityId(input.entityId);
-      const propertyId = brandPersistedPropertyId(input.propertyId);
+      const resolvedEntity = refRegistry.resolveEntityRefTargets([
+        input.entityRef,
+      ]);
+      if (Result.isError(resolvedEntity)) {
+        throw resolvedEntity.error;
+      }
+      const entityTarget =
+        resolvedEntity.value.at(0) ??
+        panic("resolved entity ref list is unexpectedly empty");
+      if (entityTarget.workspaceId !== allowedWorkspaceId) {
+        throw new ChatToolError({
+          kind: "invalid-input",
+          message: `Entity "${input.entityRef}" does not belong to matter "${input.matterRef}".`,
+        });
+      }
+      const entityId = entityTarget.entityId;
+      const resolvedProperty = refRegistry.resolvePropertyRefs([
+        input.propertyRef,
+      ]);
+      if (Result.isError(resolvedProperty)) {
+        throw resolvedProperty.error;
+      }
+      const propertyId =
+        resolvedProperty.value.at(0) ??
+        panic("resolved property ref list is unexpectedly empty");
       const { value } = input;
       const property = await scopedDb((tx) =>
         tx.query.properties.findFirst({
@@ -208,7 +234,7 @@ export const createWorkspaceTools = ({
       if (!property) {
         throw new ChatToolError({
           kind: "not-found",
-          message: `Property "${propertyId}" not found. Check the system prompt for available property IDs.`,
+          message: `Property "${input.propertyRef}" not found in matter "${input.matterRef}". Discover property refs with external_list_properties.`,
         });
       }
 
@@ -324,20 +350,20 @@ export const createWorkspaceTools = ({
       if (!entity) {
         throw new ChatToolError({
           kind: "not-found",
-          message: `Entity "${entityId}" not found.`,
+          message: `Entity "${input.entityRef}" not found.`,
         });
       }
       if (entity.readOnly) {
         throw new ChatToolError({
           kind: "invalid-input",
-          message: `Entity "${entityId}" is read-only.`,
+          message: `Entity "${input.entityRef}" is read-only.`,
         });
       }
 
       if (!entity.currentVersionId) {
         throw new ChatToolError({
           kind: "not-found",
-          message: `Entity "${entityId}" has no current version and cannot be updated.`,
+          message: `Entity "${input.entityRef}" has no current version and cannot be updated.`,
         });
       }
 
@@ -377,8 +403,8 @@ export const createWorkspaceTools = ({
 
       return {
         success: true,
-        entityId,
-        propertyId,
+        entityRef: input.entityRef,
+        propertyRef: input.propertyRef,
         newValue: isEmpty ? "" : formatFieldValue(content),
       };
     }),

--- a/apps/api/src/lib/chat/model-ingress-guard.test.ts
+++ b/apps/api/src/lib/chat/model-ingress-guard.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, mock, test } from "bun:test";
+
+import { toSafeId } from "@/api/lib/branded-types";
+
+const captureErrorMock = mock();
+void mock.module("@/api/lib/analytics/capture", () => ({
+  captureError: captureErrorMock,
+  captureRequestError: captureErrorMock,
+  getAnalytics: mock(() => ({ capture: mock(), flush: mock() })),
+}));
+
+const {
+  assertModelSurfaceFreeOfTenantIds,
+  redactTenantIdsDeep,
+  TENANT_ID_REDACTION_PLACEHOLDER,
+} = await import("./model-ingress-guard");
+
+const WS_A = toSafeId<"workspace">("0dc54d0c-10d7-501d-897e-e801dbd0998c");
+const WS_B = toSafeId<"workspace">("4e919658-a448-5354-8e3a-e99911214d2c");
+const PUBLIC_UUID = "7c0f7d51-70a4-4d64-9f0e-0a4d64e9911b";
+
+describe("redactTenantIdsDeep", () => {
+  test("replaces tenant ids in nested strings, preserves everything else", () => {
+    captureErrorMock.mockClear();
+    const createdAt = new Date("2026-01-01");
+    const { value, redactedPaths } = redactTenantIdsDeep({
+      value: {
+        parts: [
+          {
+            type: "text",
+            content: `See https://my.stll.app/workspaces/${WS_A}/x`,
+          },
+          { type: "text", content: `public ${PUBLIC_UUID} stays` },
+        ],
+        createdAt,
+        count: 2,
+      },
+      workspaceIds: [WS_A, WS_B],
+    });
+
+    expect(value.parts[0]?.content).toBe(
+      `See https://my.stll.app/workspaces/${TENANT_ID_REDACTION_PLACEHOLDER}/x`,
+    );
+    // Non-tenant UUIDs (public corpus ids, version handles) are untouched:
+    // the guard is membership-exact, not pattern-based.
+    expect(value.parts[1]?.content).toBe(`public ${PUBLIC_UUID} stays`);
+    expect(value.createdAt).toBe(createdAt);
+    expect(value.count).toBe(2);
+    expect(redactedPaths).toEqual(["$.parts[0].content"]);
+    expect(captureErrorMock).toHaveBeenCalledTimes(1);
+    // Telemetry carries paths, never the id value.
+    const [, context] = captureErrorMock.mock.calls.at(0) ?? [];
+    expect(JSON.stringify(context)).not.toContain(WS_A);
+  });
+
+  test("clean input passes through without telemetry", () => {
+    captureErrorMock.mockClear();
+    const input = { parts: [{ type: "text", content: "all refs: mat_1" }] };
+    const { value, redactedPaths } = redactTenantIdsDeep({
+      value: input,
+      workspaceIds: [WS_A],
+    });
+    expect(value).toEqual(input);
+    expect(redactedPaths).toEqual([]);
+    expect(captureErrorMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("assertModelSurfaceFreeOfTenantIds", () => {
+  test("panics when the system prompt embeds a tenant id", () => {
+    captureErrorMock.mockClear();
+    expect(() =>
+      assertModelSurfaceFreeOfTenantIds({
+        serialized: `Connected to matter ${WS_A}`,
+        surface: "system-prompt",
+        workspaceIds: [WS_A],
+      }),
+    ).toThrow();
+    expect(captureErrorMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("captures but does not throw for tool schemas", () => {
+    captureErrorMock.mockClear();
+    expect(() =>
+      assertModelSurfaceFreeOfTenantIds({
+        serialized: `{"description":"Allowed values: ${WS_A}"}`,
+        surface: "tool-schemas",
+        workspaceIds: [WS_A],
+      }),
+    ).not.toThrow();
+    expect(captureErrorMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("clean surfaces pass silently", () => {
+    captureErrorMock.mockClear();
+    assertModelSurfaceFreeOfTenantIds({
+      serialized: "Allowed values: mat_1, mat_2",
+      surface: "system-prompt",
+      workspaceIds: [WS_A, WS_B],
+    });
+    expect(captureErrorMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/lib/chat/model-ingress-guard.ts
+++ b/apps/api/src/lib/chat/model-ingress-guard.ts
@@ -1,0 +1,140 @@
+import { panic } from "better-result";
+
+import { captureError } from "@/api/lib/analytics/capture";
+import type { SafeId } from "@/api/lib/branded-types";
+import { TelemetryError } from "@/api/lib/errors/tagged-errors";
+
+/**
+ * Last-line guard for the "tenant workspace ids reach the model only as chat
+ * refs" invariant, applied where every provider-bound surface converges in
+ * `streamChat`. The tool-egress side already fails closed per tool
+ * (`findUndeclaredUuidPath`); this covers the ingress side, where the exact
+ * tenant set is known per request (the accessible-workspace ids are already
+ * loaded on every send), so membership checks are precise: no pattern
+ * heuristics, no false positives on public UUIDs (case-law decision ids,
+ * entity-version handles).
+ *
+ * Enforcement is graduated by who authored the surface:
+ * - the system prompt is entirely server-built, so a hit is a Stella bug and
+ *   panics (fail closed);
+ * - tool schemas may include org-configured external MCP tools, so a hit is
+ *   captured to telemetry rather than taking the org's chat down;
+ * - messages carry user-authored and historical text, so hits are redacted
+ *   in place (the model loses an id it could not use legitimately anyway)
+ *   and captured to telemetry with the message path, never the value.
+ */
+
+export const TENANT_ID_REDACTION_PLACEHOLDER = "[internal-id-removed]";
+
+const findTenantId = (
+  text: string,
+  workspaceIds: readonly string[],
+): string | undefined => workspaceIds.find((id) => text.includes(id));
+
+export type ModelIngressSurface = "system-prompt" | "tool-schemas";
+
+/**
+ * Panic when a fully server-built surface embeds a tenant workspace id. The
+ * error message and telemetry name the surface, never the value.
+ */
+export const assertModelSurfaceFreeOfTenantIds = ({
+  serialized,
+  surface,
+  workspaceIds,
+}: {
+  serialized: string;
+  surface: ModelIngressSurface;
+  workspaceIds: readonly SafeId<"workspace">[];
+}): void => {
+  if (findTenantId(serialized, workspaceIds) === undefined) {
+    return;
+  }
+  const error = new TelemetryError({
+    message: `Model-bound ${surface} embeds a tenant workspace id`,
+  });
+  captureError(error, { source: "model-ingress-guard", surface });
+  if (surface === "system-prompt") {
+    panic(error.message);
+  }
+};
+
+const isPlainObject = (value: unknown): value is Record<string, unknown> => {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  const proto: unknown = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+};
+
+type RedactionState = { paths: string[] };
+
+const redactValue = (
+  value: unknown,
+  workspaceIds: readonly string[],
+  path: string,
+  state: RedactionState,
+): unknown => {
+  if (typeof value === "string") {
+    let redacted = value;
+    for (const id of workspaceIds) {
+      if (redacted.includes(id)) {
+        state.paths.push(path);
+        redacted = redacted.replaceAll(id, TENANT_ID_REDACTION_PLACEHOLDER);
+      }
+    }
+    return redacted;
+  }
+  if (Array.isArray(value)) {
+    return value.map((item, index) =>
+      redactValue(item, workspaceIds, `${path}[${index}]`, state),
+    );
+  }
+  if (isPlainObject(value)) {
+    const next: Record<string, unknown> = {};
+    for (const [key, entry] of Object.entries(value)) {
+      next[key] = redactValue(entry, workspaceIds, `${path}.${key}`, state);
+    }
+    return next;
+  }
+  // Dates, class instances, and scalars pass through untouched.
+  return value;
+};
+
+export type RedactTenantIdsResult<T> = {
+  value: T;
+  /** Structural paths where an id was redacted; never the id itself. */
+  redactedPaths: readonly string[];
+};
+
+/**
+ * Deep-copy `value` with every occurrence of a tenant workspace id inside any
+ * string replaced by `TENANT_ID_REDACTION_PLACEHOLDER`. Hits are captured to
+ * telemetry by path so residual ingress leaks stay visible while chat keeps
+ * working for threads whose history predates ref mediation.
+ */
+export const redactTenantIdsDeep = <T>({
+  value,
+  workspaceIds,
+}: {
+  value: T;
+  workspaceIds: readonly SafeId<"workspace">[];
+}): RedactTenantIdsResult<T> => {
+  const state: RedactionState = { paths: [] };
+  // SAFETY: redactValue preserves structure exactly — strings map to
+  // strings, arrays to arrays, plain records to plain records, and every
+  // other value is returned by reference — so the output shape is T.
+  const redacted = redactValue(value, workspaceIds, "$", state) as T;
+  if (state.paths.length > 0) {
+    captureError(
+      new TelemetryError({
+        message: "Model-bound message content embedded tenant workspace ids",
+      }),
+      {
+        source: "model-ingress-guard",
+        surface: "messages",
+        paths: state.paths.slice(0, 20).join(", "),
+      },
+    );
+  }
+  return { value: redacted, redactedPaths: state.paths };
+};


### PR DESCRIPTION
## Summary

The chat surface's design is that tenant ids reach the model only as chat refs. This PR extends that from tool-result egress to every ingress path and adds a guard at the boundary where all provider-bound surfaces converge.

- `update-entity-fields` speaks refs end to end: the schema enumerates allowed matter refs, inputs are `matterRef`/`entityRef`/`propertyRef` resolved through the turn's ref registry (with a cross-check that the entity belongs to the named matter), outputs echo refs.
- User-message text is ref-hydrated at prompt time, the same way assistant text already was, so composer mentions and compaction checkpoints replay as refs.
- The chat-history tools hydrate persisted excerpts and transcripts before returning them.
- A model-ingress guard runs in `streamChat` using the request's accessible-workspace id set (membership check, so public UUIDs such as case-law decision ids are untouched): the server-built system prompt asserts, tool schemas record to telemetry, message content is rewritten in place with structural paths (never values) recorded.

## Class guards

- Schema test: workspace tool schemas must enumerate matter refs and must not contain the workspace UUID.
- Guard unit tests: rewriting preserves structure and non-tenant UUIDs; telemetry carries paths only.