### PR TITLE
feat(chat): rewrite pasted workspace URLs into workspace mentions

### DIFF
--- a/apps/api/src/handlers/chat/send-message.ts
+++ b/apps/api/src/handlers/chat/send-message.ts
@@ -166,6 +166,7 @@ import {
 } from "@/api/lib/chat/data-scope";
 import { createChatRefRegistry } from "@/api/lib/chat/ref-registry";
 import { createChatToolDefectMemo } from "@/api/lib/chat/tool-defect-memo";
+import { rewriteWorkspaceUrlsToMentions } from "@/api/lib/chat/workspace-url-mentions";
 import { detached } from "@/api/lib/detached";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import { createFileKey } from "@/api/lib/files/utils";
@@ -179,6 +180,7 @@ import {
   validateTanStackDevModelOverride,
 } from "@/api/lib/tanstack-ai-models";
 import { loadWebSearchProvidersForOrg } from "@/api/lib/web-search/load-org-keys";
+import { getAppBaseUrl } from "@/api/mcp/tool-utils";
 import { PDF_MIME_TYPE } from "@/api/mime-types";
 
 const CHAT_COMPACTION_CHECKPOINT_TIMEOUT_MS = 120_000;
@@ -2518,7 +2520,19 @@ const hydrateAssistantMessageRefs = ({
     part: ChatMessage["parts"][number],
   ): ChatMessage["parts"][number] =>
     part.type === "text"
-      ? { ...part, content: refRegistry.hydrateAssistantTextRefs(part.content) }
+      ? {
+          ...part,
+          content: refRegistry.hydrateAssistantTextRefs(
+            // Pasted workspace URLs first: "Copy link" and the URL bar give
+            // the user a raw workspace UUID the ingress guard would redact;
+            // rewriting to a mention keeps the pointing intent as a ref.
+            rewriteWorkspaceUrlsToMentions({
+              appBaseUrl: getAppBaseUrl(),
+              refRegistry,
+              text: part.content,
+            }),
+          ),
+        }
       : part;
 
   return messages.map((message) => {

--- a/apps/api/src/lib/chat/workspace-url-mentions.test.ts
+++ b/apps/api/src/lib/chat/workspace-url-mentions.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "bun:test";
+
+import { toSafeId } from "@/api/lib/branded-types";
+import { createChatRefRegistry } from "@/api/lib/chat/ref-registry";
+import { rewriteWorkspaceUrlsToMentions } from "@/api/lib/chat/workspace-url-mentions";
+
+const WS = "7a7c5299-15e2-45da-8190-0adfbb85184b";
+const VIEW = "019df710-7718-7001-b7a5-2ce9a7c9117e";
+const BASE = "https://my.stll.app";
+
+describe("rewriteWorkspaceUrlsToMentions", () => {
+  test("rewrites a pasted matter link into a workspace mention", () => {
+    const refRegistry = createChatRefRegistry();
+    const rewritten = rewriteWorkspaceUrlsToMentions({
+      appBaseUrl: BASE,
+      refRegistry,
+      text: `list things in ${BASE}/workspaces/${WS} please`,
+    });
+    const matterRef = refRegistry.toMatterRef(toSafeId<"workspace">(WS));
+    expect(rewritten).toBe(
+      `list things in [matter](#stella-workspace-ref=${matterRef}) please`,
+    );
+    expect(rewritten).not.toContain(WS);
+  });
+
+  test("consumes deeper path segments (view ids) into the same mention", () => {
+    const refRegistry = createChatRefRegistry();
+    const rewritten = rewriteWorkspaceUrlsToMentions({
+      appBaseUrl: BASE,
+      refRegistry,
+      text: `${BASE}/workspaces/${WS}/${VIEW}`,
+    });
+    expect(rewritten).toBe("[matter](#stella-workspace-ref=mat_1)");
+    expect(rewritten).not.toContain(VIEW);
+  });
+
+  test("reuses one ref for repeated links and leaves foreign URLs alone", () => {
+    const refRegistry = createChatRefRegistry();
+    const rewritten = rewriteWorkspaceUrlsToMentions({
+      appBaseUrl: BASE,
+      refRegistry,
+      text:
+        `${BASE}/workspaces/${WS} and again ${BASE}/workspaces/${WS} ` +
+        `but not https://example.test/workspaces/${WS}`,
+    });
+    expect(rewritten).toBe(
+      "[matter](#stella-workspace-ref=mat_1) and again " +
+        "[matter](#stella-workspace-ref=mat_1) " +
+        `but not https://example.test/workspaces/${WS}`,
+    );
+  });
+
+  test("text without workspace links passes through untouched", () => {
+    const refRegistry = createChatRefRegistry();
+    const text = "no links here, just words";
+    expect(
+      rewriteWorkspaceUrlsToMentions({ appBaseUrl: BASE, refRegistry, text }),
+    ).toBe(text);
+  });
+});

--- a/apps/api/src/lib/chat/workspace-url-mentions.ts
+++ b/apps/api/src/lib/chat/workspace-url-mentions.ts
@@ -1,0 +1,48 @@
+import { brandPersistedWorkspaceId } from "@/api/lib/safe-id-boundaries";
+
+import type { ChatRefRegistry } from "./ref-registry";
+import { CHAT_WORKSPACE_REF_PREFIX } from "./ref-registry";
+
+const UUID_PATTERN =
+  "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}";
+const REGEX_SPECIAL_CHARS = /[.*+?^${}()|[\]\\]/gu;
+
+type RewriteWorkspaceUrlsProps = {
+  /** `getAppBaseUrl()` — the deployment's frontend origin, no trailing slash. */
+  appBaseUrl: string;
+  refRegistry: ChatRefRegistry;
+  text: string;
+};
+
+/**
+ * Rewrite pasted stella workspace URLs in user text into workspace mention
+ * links before the text reaches the model. "Copy link" on a matter (and the
+ * browser URL bar) yields `<origin>/workspaces/<uuid>[/...]`; without this
+ * rewrite the model-ingress guard redacts the UUID and the user's intent
+ * ("this matter") is lost. The rewrite preserves it as a chat ref the model
+ * can act on. Deeper path segments (view ids, sub-routes) are consumed into
+ * the same workspace mention — views have no chat ref kind.
+ *
+ * Only the model-facing hydrated copy changes; the persisted user message
+ * keeps the original URL for display.
+ */
+export const rewriteWorkspaceUrlsToMentions = ({
+  appBaseUrl,
+  refRegistry,
+  text,
+}: RewriteWorkspaceUrlsProps): string => {
+  if (appBaseUrl.length === 0 || !text.includes("/workspaces/")) {
+    return text;
+  }
+  const escapedBase = appBaseUrl.replaceAll(REGEX_SPECIAL_CHARS, "\\$&");
+  const urlRegex = new RegExp(
+    `${escapedBase}/workspaces/(${UUID_PATTERN})(?:/[^\\s)\\]]*)?`,
+    "giu",
+  );
+  return text.replaceAll(urlRegex, (_url, workspaceId: string) => {
+    const matterRef = refRegistry.toMatterRef(
+      brandPersistedWorkspaceId(workspaceId),
+    );
+    return `[matter](${CHAT_WORKSPACE_REF_PREFIX}${matterRef})`;
+  });
+};


### PR DESCRIPTION
## Problem

"Copy link" on a matter and the browser URL bar both produce `<frontend>/workspaces/<uuid>` URLs. When a user pastes one into chat, the model-ingress guard (#1685) redacts the tenant UUID from the model-facing copy — correct for the invariant, but the user's pointing intent ("this matter") is lost with it.

## Change

At prompt time, user text rewrites `<frontend>/workspaces/<uuid>[/...]` into a workspace mention link carrying the turn's matter ref, so the model can act on exactly what the user pointed at with a ref it is allowed to hold. Deeper path segments (view ids — they have no chat ref kind) fold into the same workspace mention. Foreign origins pass through untouched. Only the model-facing hydrated copy changes; the persisted message keeps the original URL for display.

Runs just before mention-href hydration in the user-message path, so by the time the ingress guard scans, the UUID is already a ref rather than a redaction.

## Tests

Rewrite of plain and deep links, ref reuse across repeats, foreign-origin passthrough, no-op fast path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pasted workspace links in chat messages are now automatically converted into clickable workspace mentions.
  * Links remain recognised when pointing to deeper pages within a workspace.
  * Repeated links are handled consistently, while links from other websites remain unchanged.
* **Bug Fixes**
  * Improved workspace reference reuse when the same link appears multiple times in a message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->