### PR TITLE
fix(chat): repair update-entity-fields approval card and drop the guard's cast

### DIFF
--- a/apps/api/src/lib/chat/model-ingress-guard.test.ts
+++ b/apps/api/src/lib/chat/model-ingress-guard.test.ts
@@ -44,7 +44,8 @@ describe("redactTenantIdsDeep", () => {
     // Non-tenant UUIDs (public corpus ids, version handles) are untouched:
     // the guard is membership-exact, not pattern-based.
     expect(value.parts[1]?.content).toBe(`public ${PUBLIC_UUID} stays`);
-    expect(value.createdAt).toBe(createdAt);
+    // structuredClone copies the Date: same instant, fresh instance.
+    expect(value.createdAt).toEqual(createdAt);
     expect(value.count).toBe(2);
     expect(redactedPaths).toEqual(["$.parts[0].content"]);
     expect(captureErrorMock).toHaveBeenCalledTimes(1);

--- a/apps/api/src/lib/chat/model-ingress-guard.ts
+++ b/apps/api/src/lib/chat/model-ingress-guard.ts
@@ -68,36 +68,60 @@ const isPlainObject = (value: unknown): value is Record<string, unknown> => {
 
 type RedactionState = { paths: string[] };
 
-const redactValue = (
-  value: unknown,
+const redactString = (
+  value: string,
   workspaceIds: readonly string[],
   path: string,
   state: RedactionState,
-): unknown => {
-  if (typeof value === "string") {
-    let redacted = value;
-    for (const id of workspaceIds) {
-      if (redacted.includes(id)) {
-        state.paths.push(path);
-        redacted = redacted.replaceAll(id, TENANT_ID_REDACTION_PLACEHOLDER);
+): string => {
+  let redacted = value;
+  for (const id of workspaceIds) {
+    if (redacted.includes(id)) {
+      state.paths.push(path);
+      redacted = redacted.replaceAll(id, TENANT_ID_REDACTION_PLACEHOLDER);
+    }
+  }
+  return redacted;
+};
+
+/**
+ * Mutate a structuredClone'd container in place, replacing tenant ids inside
+ * every nested string. In-place mutation (instead of a rebuilding map) keeps
+ * the entry point's return type the caller's own `T` without a cast. Dates,
+ * class instances, and scalars pass through untouched.
+ */
+const redactContainerInPlace = (
+  container: Record<string, unknown> | unknown[],
+  workspaceIds: readonly string[],
+  path: string,
+  state: RedactionState,
+): void => {
+  const visit = (entry: unknown, key: string | number, entryPath: string) => {
+    if (typeof entry === "string") {
+      const redacted = redactString(entry, workspaceIds, entryPath, state);
+      if (redacted !== entry) {
+        if (Array.isArray(container) && typeof key === "number") {
+          container[key] = redacted;
+        } else if (!Array.isArray(container) && typeof key === "string") {
+          container[key] = redacted;
+        }
       }
+      return;
     }
-    return redacted;
-  }
-  if (Array.isArray(value)) {
-    return value.map((item, index) =>
-      redactValue(item, workspaceIds, `${path}[${index}]`, state),
+    if (Array.isArray(entry) || isPlainObject(entry)) {
+      redactContainerInPlace(entry, workspaceIds, entryPath, state);
+    }
+  };
+
+  if (Array.isArray(container)) {
+    container.forEach((entry, index) =>
+      visit(entry, index, `${path}[${index}]`),
     );
+    return;
   }
-  if (isPlainObject(value)) {
-    const next: Record<string, unknown> = {};
-    for (const [key, entry] of Object.entries(value)) {
-      next[key] = redactValue(entry, workspaceIds, `${path}.${key}`, state);
-    }
-    return next;
+  for (const [key, entry] of Object.entries(container)) {
+    visit(entry, key, `${path}.${key}`);
   }
-  // Dates, class instances, and scalars pass through untouched.
-  return value;
 };
 
 export type RedactTenantIdsResult<T> = {
@@ -112,7 +136,7 @@ export type RedactTenantIdsResult<T> = {
  * telemetry by path so residual ingress leaks stay visible while chat keeps
  * working for threads whose history predates ref mediation.
  */
-export const redactTenantIdsDeep = <T>({
+export const redactTenantIdsDeep = <T extends object>({
   value,
   workspaceIds,
 }: {
@@ -120,10 +144,10 @@ export const redactTenantIdsDeep = <T>({
   workspaceIds: readonly SafeId<"workspace">[];
 }): RedactTenantIdsResult<T> => {
   const state: RedactionState = { paths: [] };
-  // SAFETY: redactValue preserves structure exactly — strings map to
-  // strings, arrays to arrays, plain records to plain records, and every
-  // other value is returned by reference — so the output shape is T.
-  const redacted = redactValue(value, workspaceIds, "$", state) as T;
+  const redacted = structuredClone(value);
+  if (Array.isArray(redacted) || isPlainObject(redacted)) {
+    redactContainerInPlace(redacted, workspaceIds, "$", state);
+  }
   if (state.paths.length > 0) {
     captureError(
       new TelemetryError({

--- a/apps/web/src/components/chat/chat-thread-messages.tsx
+++ b/apps/web/src/components/chat/chat-thread-messages.tsx
@@ -1434,13 +1434,7 @@ const AssistantMessageParts = ({
             (part.state === "approval-requested" ||
               part.state === "approval-responded")
           ) {
-            return (
-              <ToolApprovalCard
-                key={part.id}
-                part={part}
-                workspaceId={workspaceId}
-              />
-            );
+            return <ToolApprovalCard key={part.id} part={part} />;
           }
           return <SpawnSubagentsCard key={part.id} part={part} />;
         }
@@ -1452,7 +1446,6 @@ const AssistantMessageParts = ({
                 activeFileName={activeFileName}
                 key={part.id}
                 part={part}
-                workspaceId={workspaceId}
               />
             );
           }

--- a/apps/web/src/components/chat/tool-approval-card.tsx
+++ b/apps/web/src/components/chat/tool-approval-card.tsx
@@ -1,6 +1,6 @@
 import { useRef, useState } from "react";
 
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { panic } from "better-result";
 import {
   CheckIcon,
@@ -44,18 +44,12 @@ import {
   humanizeIdentifier,
 } from "@/components/chat/tool-approval-summary";
 import { useInspectorTabsStore } from "@/components/inspector/inspector-tabs-store";
-import {
-  emptyColor,
-  resolveOptionColor,
-} from "@/components/workspaces/property-utils";
 import { useMountEffect } from "@/hooks/use-effect";
 import type { DocxEditRepresentation } from "@/lib/chat-edit-mode";
 import { DOCX_EDIT_REPRESENTATION } from "@/lib/chat-edit-mode";
 import { detached } from "@/lib/detached";
 import { mcpConnectorsOptions } from "@/lib/knowledge/queries";
 import { sanitizeHref } from "@/lib/sanitize-href";
-import type { WorkspaceProperty } from "@/lib/types";
-import { propertiesKeys } from "@/lib/workspaces/queries/properties";
 
 type UpdateEntityFieldsInput = ChatUITools["update-entity-fields"]["input"];
 type ActiveDocxEditInput = ChatUITools["apply-active-docx-edits"]["input"];
@@ -86,64 +80,20 @@ const getApprovalId = (part: ApprovalToolPart): string | null => {
 
 const getApprovalPartInput = (part: ApprovalToolPart): unknown => part.input;
 
-// -- Select badge (colored chip matching table UX) --
-
-type SelectBadgeProps = {
-  value: string | null;
-  property: WorkspaceProperty | undefined;
-};
-
-const SelectBadge = ({ value, property }: SelectBadgeProps) => {
-  const t = useTranslations();
-  let color = emptyColor;
-
-  if (value && property?.content.type === "single-select") {
-    const opt = property.content.options.find((o) => o.value === value);
-    if (opt) {
-      color = resolveOptionColor(opt.color);
-    }
-  }
-
-  return (
-    <span
-      className="inline-flex items-center rounded px-1.5 py-0.5 text-[11px] leading-none font-medium"
-      style={{
-        backgroundColor: color.background,
-        color: color.foreground,
-      }}
-    >
-      {value ?? t("common.empty")}
-    </span>
-  );
-};
-
 // -- Update summary (rich rendering) --
 
 type UpdateSummaryProps = {
   input: UpdateEntityFieldsInput;
-  workspaceId?: string | undefined;
 };
 
-const UpdateSummary = ({ input, workspaceId }: UpdateSummaryProps) => {
+const UpdateSummary = ({ input }: UpdateSummaryProps) => {
   const t = useTranslations();
-  const qc = useQueryClient();
   const newVal = input.value;
 
-  // Look up the property from cache for colors.
-  let property: WorkspaceProperty | undefined;
-  if (workspaceId) {
-    const cached = qc.getQueryData<WorkspaceProperty[]>(
-      propertiesKeys.all(workspaceId),
-    );
-    if (cached !== undefined) {
-      property = cached.find((p) => p.id === input.propertyId);
-    }
-  }
-  const propName = property?.name ?? input.propertyId;
-
-  const isSelect =
-    property?.content.type === "single-select" ||
-    property?.content.type === "multi-select";
+  // The tool input carries per-turn chat refs (prop_N/ent_N), not stable
+  // property/entity ids, so the property can no longer be resolved from the
+  // React Query cache for name/option colors; the refs are shown as-is.
+  const propName = input.propertyRef;
 
   let displayNew: string | null = null;
   if (Array.isArray(newVal)) {
@@ -157,16 +107,12 @@ const UpdateSummary = ({ input, workspaceId }: UpdateSummaryProps) => {
   return (
     <div className="border-border/50 flex flex-col gap-1.5 border-t px-3 py-2">
       <code className="text-muted-foreground text-xs break-all">
-        {input.entityId}
+        {input.entityRef}
       </code>
       {/* Property change */}
       <div className="flex items-center gap-1.5 text-xs">
         <span className="text-muted-foreground">{propName}:</span>
-        {isSelect ? (
-          <SelectBadge property={property} value={displayNew} />
-        ) : (
-          <span className="font-medium">{displayNew ?? t("common.empty")}</span>
-        )}
+        <span className="font-medium">{displayNew ?? t("common.empty")}</span>
       </div>
     </div>
   );
@@ -444,7 +390,6 @@ type ToolApprovalCardProps = {
    *  `ChatThreadMessagesProps.activeFileName`. */
   activeFileName?: string | undefined;
   part: ApprovalToolPart;
-  workspaceId?: string | undefined;
 };
 
 const AutomaticApprovalResponse = ({ respond }: { respond: () => void }) => {
@@ -458,7 +403,6 @@ const AutomaticApprovalResponse = ({ respond }: { respond: () => void }) => {
 export const ToolApprovalCard = ({
   activeFileName,
   part,
-  workspaceId,
 }: ToolApprovalCardProps) => {
   const {
     activeOrganizationId,
@@ -657,9 +601,7 @@ export const ToolApprovalCard = ({
       {/* Rich summary */}
       {part.name === "update-entity-fields" &&
         part.state !== "input-streaming" &&
-        part.input !== undefined && (
-          <UpdateSummary input={part.input} workspaceId={workspaceId} />
-        )}
+        part.input !== undefined && <UpdateSummary input={part.input} />}
       {part.name === "apply-active-docx-edits" &&
         part.state !== "input-streaming" &&
         part.input !== undefined && (

--- a/scripts/ratchet-baseline.json
+++ b/scripts/ratchet-baseline.json
@@ -45,7 +45,7 @@
     "files": {}
   },
   "lint-suppression-directives": {
-    "count": 568,
+    "count": 567,
     "files": {
       "apps/api/src/db/migrate.ts": 2,
       "apps/api/src/db/schema.ts": 1,
@@ -90,7 +90,6 @@
       "apps/api/src/handlers/chat/tools/execute/sandbox/run-sandbox.ts": 6,
       "apps/api/src/handlers/chat/tools/registry-adapter/mcp-chat-context.ts": 1,
       "apps/api/src/handlers/chat/tools/spawn-subagents-tool.ts": 1,
-      "apps/api/src/handlers/chat/tools/workspace-tools.ts": 1,
       "apps/api/src/handlers/chat/upload-files.ts": 3,
       "apps/api/src/handlers/clauses/search-vector.ts": 1,
       "apps/api/src/handlers/contacts/create.ts": 1,


### PR DESCRIPTION
Follow-ups to the ref-input conversion of `update-entity-fields`: the approval card renders the ref inputs directly (per-turn refs cannot be resolved against the client property cache, so the name/option-color lookup and its `SelectBadge`/`workspaceId` plumbing are removed), and `redactTenantIdsDeep` now structuredClones and redacts in place so its return type is the caller's own `T` without a cast. Ratchet baseline tightened in passing (`lint-suppression-directives` 568 → 567).