### PR TITLE
fix(case-law): log system fields for write failures

### DIFF
--- a/apps/api/src/handlers/case-law/ingestion/pipeline.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/pipeline.test.ts
@@ -598,4 +598,67 @@ describe("processDecision — source raw upload failure", () => {
     // only the status would pass on the corpus-write reason too.
     expect(outcome.reason).toBe("source-raw-write");
   });
+
+  test("logs the failure's system fields, not just its message", async () => {
+    // Bun's S3 client collapses every write failure to the same
+    // message, so `error.detail` alone cannot tell an access denial
+    // from a timeout. `errorSystemFields` carries the discriminating
+    // `code`/`errno`/`syscall`, which is what makes a held cursor
+    // diagnosable from the log.
+    const logged: Record<string, unknown>[] = [];
+    await mock.module("@/api/lib/observability/logger", () => ({
+      logger: {
+        error: (_event: string, attributes: Record<string, unknown>) => {
+          logged.push(attributes);
+        },
+        warn: () => undefined,
+        info: () => undefined,
+      },
+    }));
+    await mock.module("@/api/lib/s3", () => ({
+      getS3: () => ({
+        write: () => {
+          throw Object.assign(new Error("an unexpected error has occurred"), {
+            code: "AccessDenied",
+          });
+        },
+      }),
+    }));
+
+    const scopedDb: ScopedDb = async (callback) => {
+      const tx = {
+        query: {
+          caseLawDecisions: {
+            findFirst: async () => await Promise.resolve(undefined),
+          },
+        },
+      };
+
+      // SAFETY: the raw upload runs before any decision write, so the
+      // dedup lookup is the only chain this path reaches.
+      // eslint-disable-next-line typescript/no-unsafe-type-assertion
+      return await callback(tx as unknown as Transaction);
+    };
+
+    await processDecision({
+      input: {
+        caseNumber: "X/3/2026",
+        court: "Test Court",
+        country: "SVK",
+        language: "sk",
+        fulltext: "Rozhodnutie o veci samej.",
+        metadata: {},
+        rawHash: "new-hash",
+        documentAst: EMPTY_AST,
+        sourceRaw: "<html></html>",
+      },
+      observationOrder: 1n,
+      sourceId: createSafeId<"caseLawSource">(),
+      scopedDb,
+      observedAt: new Date("2026-08-05T00:00:00.000Z"),
+    });
+
+    const failure = logged.at(0);
+    expect(failure?.["error.code"]).toBe("AccessDenied");
+  });
 });

--- a/apps/api/src/handlers/case-law/ingestion/pipeline.ts
+++ b/apps/api/src/handlers/case-law/ingestion/pipeline.ts
@@ -52,7 +52,7 @@ import {
   ConcurrentModificationError,
   TimeoutError,
 } from "@/api/lib/errors/tagged-errors";
-import { errorTag } from "@/api/lib/errors/utils";
+import { errorSystemFields, errorTag } from "@/api/lib/errors/utils";
 import {
   reserveCaseLawCorpusUploadIntent,
   writeReservedCaseLawCorpusUpload,
@@ -696,7 +696,7 @@ const processDecisionAttempt = async ({
         logger.error("case_law.ingestion.source_raw_write_failed", {
           sourceId,
           caseNumber: result.caseNumber,
-          "error.type": errorTag(error),
+          ...errorSystemFields(error),
           "error.detail": corpusWriteErrorDetail(error),
         });
         captureError(error, { sourceId, step: "uploadSourceRaw" });
@@ -1316,7 +1316,7 @@ const processDecisionAttempt = async ({
         decisionId,
         caseNumber: result.caseNumber,
         country: result.country,
-        "error.type": errorTag(error),
+        ...errorSystemFields(error),
         "error.detail": corpusWriteErrorDetail(error),
       });
       captureError(error, { decisionId, step: "processDecision.corpusWrite" });


### PR DESCRIPTION
Both write-failure sinks in the ingestion pipeline built their log attributes by hand:

```ts
"error.type": errorTag(error),
"error.detail": corpusWriteErrorDetail(error),
```

`corpusWriteErrorDetail` derives from `error.message`, and Bun's S3 client collapses write failures to a single generic message. The two fields together therefore cannot distinguish an access denial from a timeout from a transport reset: every failure logs the same pair. The comment above the corpus-write sink states the line exists so "the cause of a held cursor is not invisible to an operator reading the log", which the current field selection does not achieve.

`errorSystemFields` in `lib/errors/utils.ts` is the codebase's structured sink for this. It supplies `error.type` plus the discriminating `error.code`, `error.errno`, `error.syscall`, and cause type/code, and deliberately omits the message, so this surfaces no provider-controlled text that was not already logged.

Both sinks now spread it and keep `error.detail` unchanged.

## Why it matters

A source-raw write failure returns a retryable outcome that holds the page's cursor, so the failure is the thing that decides whether a slice retries. Without the failure's code, a held cursor cannot be attributed to a cause from the log alone.

## Test

`pipeline.test.ts` gains a case alongside the existing source-raw-upload test: it throws an error carrying `code: "AccessDenied"` behind the same generic message and pins `error.code` on the logged attributes. Asserting only `error.detail` would pass on the pre-change behaviour.

## Verification

Verified locally: `bun test src/handlers/case-law/ingestion/pipeline.test.ts` (13 pass), `tsc --noEmit -p apps/api/tsconfig.json` clean, `oxlint --type-aware --type-check` clean on both changed files, `oxfmt` clean.

Note: `bun run code-check:affected -- --base origin/main` currently reports five pre-existing errors on `main` in `apps/api/scripts/chat-orientation-eval.ts`, `apps/api/src/lib/chat/workspace-url-mentions.ts`, and `apps/api/src/lib/chat/model-ingress-guard.ts`. They are outside this diff and left alone; because that check lints whole affected workspaces rather than changed files, it fails for any branch until they are addressed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HqWr9FVCS7RTkZC2jWyp8s)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ingestion error logging to include additional system details, such as access-denied error codes.
  * Added coverage to verify that upload failures are recorded with the relevant diagnostic information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->