### PR TITLE
fix: keep HTTP keep-alive idle timeout above the load balancer's

### DIFF
--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -134,6 +134,8 @@ import { initWorkflowWorkers } from "@/api/lib/workflow-queue";
 
 const HEALTH_PATH = "/health";
 const DEFAULT_API_PORT = 3001;
+// Keep-alive idle timeout in seconds; see the `api.listen` call.
+const HTTP_IDLE_TIMEOUT_S = 75;
 // Emit the per-request query count in local/CI runs only, so the e2e guard
 // can assert per-route budgets without deployed environments paying any
 // per-query cost. Must match the logger gate in db/root.ts.
@@ -654,7 +656,17 @@ const startServer = async (): Promise<void> => {
   // BullMQ worker for queued view→report exports.
   const reportExportWorker = initReportExportWorker();
 
-  api.listen(getApiPort());
+  api.listen({
+    port: getApiPort(),
+    // Longer than the load balancer's 60 s idle timeout (Bun defaults to
+    // 10 s). The balancer may reuse an idle backend connection any time
+    // before its own timeout expires, so the server must never close
+    // first: a request written onto a connection the server is closing is
+    // lost in flight and the client hangs with no response and no
+    // server-side log line. The SSE keep-alive heartbeat (20 s) stays
+    // well inside this window.
+    idleTimeout: HTTP_IDLE_TIMEOUT_S,
+  });
 
   // Graceful shutdown: stop accepting HTTP requests, then drain the BullMQ
   // workers on SIGTERM/SIGINT (deploy, container stop, or a local

--- a/apps/web/start-runtime.js
+++ b/apps/web/start-runtime.js
@@ -129,6 +129,12 @@ const serveClientAsset = async (request) => {
 serve({
   hostname,
   port,
+  // Longer than the load balancer's 60 s idle timeout (Bun defaults to
+  // 10 s). The balancer may reuse an idle backend connection any time
+  // before its own timeout expires, so the server must never close first:
+  // a request written onto a closing connection is lost in flight and the
+  // client hangs with no response.
+  idleTimeout: 75,
   async fetch(request) {
     const requestUrl = new URL(request.url);
 


### PR DESCRIPTION
Both Bun servers (the API's Elysia listen and the web SSR runtime) run Bun's default 10 s keep-alive idle timeout while sitting behind a load balancer whose idle timeout is 60 s. The balancer may reuse an idle backend connection at any point before its own timeout, so the backend closing first creates a race: a request written onto a just-closing connection is lost in flight — the client waits for a response that never comes, and the server logs nothing because the request never reached a handler. Affected clients see hanging fetches while fresh connections (curl, health probes) work, which makes the state near-invisible to monitoring.

Setting `idleTimeout: 75` on both servers guarantees the balancer always closes idle connections first, removing the race entirely. Streaming responses are unaffected: the timeout counts socket inactivity between requests, and SSE heartbeats fire every 20 s regardless.