### PR TITLE
fix(chat): strip file-content storage ids from read_document projections

### DIFF
--- a/apps/api/src/handlers/chat/tools/registry-adapter/ref-field-map.ts
+++ b/apps/api/src/handlers/chat/tools/registry-adapter/ref-field-map.ts
@@ -293,7 +293,16 @@ export const READ_TOOL_REF_FIELD_MAP = {
       "diff.targetVersionId",
       "versionsNextCursor",
     ],
-    stripPaths: [],
+    // File-type field content embeds storage plumbing UUIDs (`content.id`,
+    // `content.pdfFileId`) chat cannot act on; every uploaded document has a
+    // file field, so leaving them undeclared tripped the UUID backstop on
+    // real matters. `fileName`/`mimeType` stay for the model.
+    stripPaths: [
+      "fields[].content.id",
+      "fields[].content.pdfFileId",
+      "version.fields[].content.id",
+      "version.fields[].content.pdfFileId",
+    ],
   },
   list_properties: {
     chatProjectable: true,

--- a/apps/api/src/handlers/chat/tools/registry-adapter/registry-projection-contract.test.ts
+++ b/apps/api/src/handlers/chat/tools/registry-adapter/registry-projection-contract.test.ts
@@ -502,6 +502,25 @@ const CONTRACT_CORPUS = {
                     propertyId: uid(19),
                     content: { version: 1, type: "text", value: "Body text" },
                   },
+                  {
+                    // Every uploaded document carries a file field whose
+                    // content embeds storage UUIDs; a text-only fixture let
+                    // exactly that slip past this corpus into prod.
+                    id: uid(61),
+                    propertyId: uid(62),
+                    content: {
+                      version: 1,
+                      type: "file",
+                      id: uid(63),
+                      fileName: "NDA draft.docx",
+                      mimeType:
+                        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+                      sizeBytes: 12_345,
+                      encrypted: false,
+                      sha256Hex: "a".repeat(64),
+                      pdfFileId: uid(64),
+                    },
+                  },
                 ],
               },
             }),
@@ -550,6 +569,22 @@ const CONTRACT_CORPUS = {
                   id: uid(22),
                   propertyId: uid(23),
                   content: { version: 1, type: "text", value: "Old body" },
+                },
+                {
+                  id: uid(65),
+                  propertyId: uid(66),
+                  content: {
+                    version: 1,
+                    type: "file",
+                    id: uid(67),
+                    fileName: "Old draft.docx",
+                    mimeType:
+                      "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+                    sizeBytes: 9876,
+                    encrypted: false,
+                    sha256Hex: "b".repeat(64),
+                    pdfFileId: uid(68),
+                  },
                 },
               ],
             }),


### PR DESCRIPTION
File-type field content includes storage identifiers (`content.id`, `content.pdfFileId`) that the chat projection has no use for. Both `read_document` branches now strip them (`fileName`/`mimeType` remain model-visible), and the projection contract fixtures gain a file-type field in each branch so content-variant payload shapes are exercised alongside text fields.