### PR TITLE
feat(chat): capture sandbox console output and return it on all runs

### DIFF
--- a/apps/api/src/handlers/chat/tools/execute/sandbox/code-mode-driver.test.ts
+++ b/apps/api/src/handlers/chat/tools/execute/sandbox/code-mode-driver.test.ts
@@ -144,6 +144,34 @@ describe("createStellaIsolateDriver", () => {
     expect(result.error?.message).toContain("boom");
   });
 
+  it("returns console output captured before a failure", async () => {
+    // The class of transcript this guards: a script fetches data, logs it,
+    // then throws later; the logs must survive so the model can self-correct
+    // from the partial results instead of guessing them from memory.
+    const result = await runCode({
+      code: `
+        const docs = await external_list({});
+        console.log("docs:", docs);
+        throw new Error("boom");
+      `,
+      bindings: bindingsRecord(
+        binding("external_list", async () => ["doc-1", "doc-2"]),
+      ),
+    });
+    expect(result.success).toBe(false);
+    expect(result.error?.name).toBe("runtime");
+    expect(result.logs).toEqual(['docs: ["doc-1","doc-2"]']);
+  });
+
+  it("returns console output on success", async () => {
+    const result = await runCode({
+      code: `console.log("hello"); return 1;`,
+      bindings: bindingsRecord(binding("external_noop", async () => null)),
+    });
+    expect(result.success).toBe(true);
+    expect(result.logs).toEqual(["hello"]);
+  });
+
   it("maps forbidden syntax onto the forbidden-syntax reason", async () => {
     const result = await runCode({
       code: `import x from "fs"; return x;`,
@@ -151,6 +179,8 @@ describe("createStellaIsolateDriver", () => {
     });
     expect(result.success).toBe(false);
     expect(result.error?.name).toBe("forbidden-syntax");
+    // Pre-execution failures never carry logs: nothing has run yet.
+    expect(result.logs).toBeUndefined();
   });
 
   it("times out at the deadline instead of waiting for unfinished host work", async () => {

--- a/apps/api/src/handlers/chat/tools/execute/sandbox/code-mode-driver.ts
+++ b/apps/api/src/handlers/chat/tools/execute/sandbox/code-mode-driver.ts
@@ -74,10 +74,13 @@ const buildBindingAliasPrelude = (
   return `const { ${names.join(", ")} } = ${SANDBOX_READ_GLOBAL};`;
 };
 
-const toExecutionSuccess = <T>(value: unknown): ExecutionResult<T> => ({
+const toExecutionSuccess = <T>(
+  value: unknown,
+  logs: readonly string[],
+): ExecutionResult<T> => ({
   success: true,
   value: validateSandboxOutput<T>(value),
-  logs: [],
+  logs: [...logs],
 });
 
 // eslint-disable-next-line typescript/no-unnecessary-type-parameters -- T is imposed by the third-party IsolateDriver.execute<T> contract; runtime validation is JSON-shape only
@@ -137,16 +140,23 @@ export const createStellaIsolateDriver = ({
       });
 
       if (Result.isOk(result)) {
-        return toExecutionSuccess<T>(result.value.value);
+        return toExecutionSuccess<T>(result.value.value, result.value.logs);
       }
 
       // The SandboxError reason rides in `name`, so the tagged taxonomy
       // (timeout / host-call-limit / memory / return-too-large /
       // non-serialisable-return / forbidden-syntax / transpile / runtime)
       // survives code-mode's coarser `{ message, name }` error shape.
+      // Console output captured before the failure rides the top-level
+      // `logs` field: code-mode's execute_typescript output schema declares
+      // it on the failure shape too and forwards it verbatim, so the model
+      // keeps the partial progress a failed run already logged. Absent for
+      // pre-execution failures (transpile, forbidden-syntax).
+      const { logs } = result.error;
       return {
         success: false,
         error: { name: result.error.reason, message: result.error.message },
+        ...(logs === undefined ? {} : { logs: [...logs] }),
       };
     };
 

--- a/apps/api/src/handlers/chat/tools/execute/sandbox/run-sandbox-prelude.test.ts
+++ b/apps/api/src/handlers/chat/tools/execute/sandbox/run-sandbox-prelude.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, it } from "bun:test";
 import {
   SANDBOX_BLOCKED_GLOBALS,
   SANDBOX_BRIDGE_LOCAL_ALIAS,
+  SANDBOX_CONSOLE_BRIDGE_GLOBAL,
+  SANDBOX_CONSOLE_LOCAL_ALIAS,
   SANDBOX_CONSOLE_METHODS,
   SANDBOX_HOST_BRIDGE_GLOBAL,
   SANDBOX_READ_GLOBAL,
@@ -25,10 +27,19 @@ describe("buildHostBridgePrelude", () => {
     }
   });
 
-  it("stubs every console method", () => {
+  it("captures the console bridge global before deleting it", () => {
+    const prelude = buildHostBridgePrelude();
+    const capture = `const ${SANDBOX_CONSOLE_LOCAL_ALIAS} = globalThis.${SANDBOX_CONSOLE_BRIDGE_GLOBAL};`;
+    const deletion = `delete globalThis.${SANDBOX_CONSOLE_BRIDGE_GLOBAL};`;
+    expect(prelude.indexOf(capture)).toBeLessThan(prelude.indexOf(deletion));
+  });
+
+  it("wires every console method to the console bridge", () => {
     const prelude = buildHostBridgePrelude();
     for (const method of SANDBOX_CONSOLE_METHODS) {
-      expect(prelude).toContain(`${method}: () => {},`);
+      expect(prelude).toContain(
+        `${method}: (...args) => { ${SANDBOX_CONSOLE_LOCAL_ALIAS}("${method}", __formatConsoleArgs(args)); },`,
+      );
     }
   });
 

--- a/apps/api/src/handlers/chat/tools/execute/sandbox/run-sandbox-prelude.ts
+++ b/apps/api/src/handlers/chat/tools/execute/sandbox/run-sandbox-prelude.ts
@@ -7,6 +7,12 @@ export const SANDBOX_READ_GLOBAL = "read" as const;
 /** Local alias in emitted prelude for the captured bridge function. */
 export const SANDBOX_BRIDGE_LOCAL_ALIAS = "__readBridge" as const;
 
+/** Guest-visible name of the QuickJS console sink the host registers before prelude runs. */
+export const SANDBOX_CONSOLE_BRIDGE_GLOBAL = "__consoleCall" as const;
+
+/** Local alias in emitted prelude for the captured console sink. */
+export const SANDBOX_CONSOLE_LOCAL_ALIAS = "__consoleBridge" as const;
+
 export const SANDBOX_BLOCKED_GLOBALS = [
   "require",
   "process",
@@ -39,7 +45,8 @@ export const buildHostBridgePrelude = (): string => {
   ).join(" || ");
 
   const consoleBody = SANDBOX_CONSOLE_METHODS.map(
-    (method) => `    ${method}: () => {},`,
+    (method) =>
+      `    ${method}: (...args) => { ${SANDBOX_CONSOLE_LOCAL_ALIAS}("${method}", __formatConsoleArgs(args)); },`,
   ).join("\n");
 
   const blockedDeletes = SANDBOX_BLOCKED_GLOBALS.map(
@@ -49,6 +56,20 @@ export const buildHostBridgePrelude = (): string => {
   return `
   const ${SANDBOX_BRIDGE_LOCAL_ALIAS} = globalThis.${SANDBOX_HOST_BRIDGE_GLOBAL};
   delete globalThis.${SANDBOX_HOST_BRIDGE_GLOBAL};
+  const ${SANDBOX_CONSOLE_LOCAL_ALIAS} = globalThis.${SANDBOX_CONSOLE_BRIDGE_GLOBAL};
+  delete globalThis.${SANDBOX_CONSOLE_BRIDGE_GLOBAL};
+  const __formatConsoleArgs = (args) =>
+    args
+      .map((arg) => {
+        if (typeof arg === "string") return arg;
+        try {
+          const json = JSON.stringify(arg);
+          return json === undefined ? String(arg) : json;
+        } catch (error) {
+          return String(arg);
+        }
+      })
+      .join(" ");
   globalThis.console = {
 ${consoleBody}
   };

--- a/apps/api/src/handlers/chat/tools/execute/sandbox/run-sandbox.test.ts
+++ b/apps/api/src/handlers/chat/tools/execute/sandbox/run-sandbox.test.ts
@@ -8,6 +8,9 @@ import type {
   SandboxFunctionRegistry,
 } from "@/api/handlers/chat/tools/execute/sandbox/run-sandbox";
 import {
+  MAX_SANDBOX_LOG_ENTRIES,
+  MAX_SANDBOX_LOG_ENTRY_LENGTH,
+  SANDBOX_LOG_OVERFLOW_MARKER,
   SandboxAdmissionNotIdleError,
   awaitSandboxAdmissionIdle,
   getSandboxAdmissionSnapshot,
@@ -470,6 +473,8 @@ describe("runSandbox", () => {
     expect(Result.isError(result)).toBe(true);
     if (Result.isError(result)) {
       expect(result.error.reason).toBe("forbidden-syntax");
+      // Pre-execution failures never carry logs: nothing has run yet.
+      expect(result.error.logs).toBeUndefined();
     }
   });
 
@@ -511,10 +516,10 @@ describe("runSandbox", () => {
     }
   });
 
-  it("treats console.log as a no-op", async () => {
+  it("captures console output with level prefixes on success", async () => {
     const result = await runSandbox({
       source: `
-        console.log("hi");
+        console.log("hi", { a: 1 }, [2, 3]);
         console.warn("warn");
         console.error("err");
         console.info("info");
@@ -526,6 +531,80 @@ describe("runSandbox", () => {
     expect(Result.isOk(result)).toBe(true);
     if (Result.isOk(result)) {
       expect(result.value.value).toBe("ok");
+      expect(result.value.logs).toEqual([
+        'hi {"a":1} [2,3]',
+        "WARN: warn",
+        "ERROR: err",
+        "INFO: info",
+        "DEBUG: debug",
+      ]);
+    }
+  });
+
+  it("returns logs captured before a runtime failure", async () => {
+    const result = await runSandbox({
+      source: `
+        const doc = await read.echo({ value: "doc-1" });
+        console.log("found", doc.value);
+        throw new Error("boom");
+      `,
+      registry: baseRegistry,
+    });
+    expect(Result.isError(result)).toBe(true);
+    if (Result.isError(result)) {
+      expect(result.error.reason).toBe("runtime");
+      expect(result.error.logs).toEqual(["found doc-1"]);
+    }
+  });
+
+  it("returns logs captured before a wall-clock timeout", async () => {
+    const result = await runSandbox({
+      source: `
+        console.log("before-spin");
+        while (true) {}
+      `,
+      registry: baseRegistry,
+      limits: { maxDurationMs: 200 },
+    });
+    expect(Result.isError(result)).toBe(true);
+    if (Result.isError(result)) {
+      expect(result.error.reason).toBe("timeout");
+      expect(result.error.logs).toEqual(["before-spin"]);
+    }
+  });
+
+  it("caps captured log entries and marks the overflow", async () => {
+    const result = await runSandbox({
+      source: `
+        for (let i = 0; i < ${MAX_SANDBOX_LOG_ENTRIES + 50}; i++) {
+          console.log("line " + i);
+        }
+        throw new Error("boom");
+      `,
+      registry: baseRegistry,
+    });
+    expect(Result.isError(result)).toBe(true);
+    if (Result.isError(result)) {
+      const logs = result.error.logs ?? [];
+      expect(logs).toHaveLength(MAX_SANDBOX_LOG_ENTRIES + 1);
+      expect(logs.at(-1)).toBe(SANDBOX_LOG_OVERFLOW_MARKER);
+      expect(logs.at(0)).toBe("line 0");
+    }
+  });
+
+  it("truncates a single oversized log entry", async () => {
+    const result = await runSandbox({
+      source: `
+        console.log("y".repeat(${MAX_SANDBOX_LOG_ENTRY_LENGTH * 3}));
+        return "ok";
+      `,
+      registry: baseRegistry,
+    });
+    expect(Result.isOk(result)).toBe(true);
+    if (Result.isOk(result)) {
+      const entry = result.value.logs.at(0) ?? "";
+      expect(entry.startsWith("yyy")).toBe(true);
+      expect(entry.length).toBeLessThan(MAX_SANDBOX_LOG_ENTRY_LENGTH + 50);
     }
   });
 
@@ -942,15 +1021,15 @@ describe("runSandbox", () => {
     }
   });
 
-  it("does not expose the raw bridge function on globalThis", async () => {
+  it("does not expose the raw bridge functions on globalThis", async () => {
     const result = await runSandbox({
-      source: `return typeof globalThis.__readCall;`,
+      source: `return [typeof globalThis.__readCall, typeof globalThis.__consoleCall].join(":");`,
       registry: baseRegistry,
     });
 
     expect(Result.isOk(result)).toBe(true);
     if (Result.isOk(result)) {
-      expect(result.value.value).toBe("undefined");
+      expect(result.value.value).toBe("undefined:undefined");
     }
   });
 

--- a/apps/api/src/handlers/chat/tools/execute/sandbox/run-sandbox.ts
+++ b/apps/api/src/handlers/chat/tools/execute/sandbox/run-sandbox.ts
@@ -10,6 +10,7 @@ import { Scope } from "quickjs-emscripten-core";
 import { DEFAULT_SANDBOX_LIMITS } from "@/api/handlers/chat/tools/execute/sandbox/limits";
 import type { SandboxLimits } from "@/api/handlers/chat/tools/execute/sandbox/limits";
 import {
+  SANDBOX_CONSOLE_BRIDGE_GLOBAL,
   SANDBOX_HOST_BRIDGE_GLOBAL,
   buildHostBridgePrelude,
 } from "@/api/handlers/chat/tools/execute/sandbox/run-sandbox-prelude";
@@ -77,6 +78,7 @@ export type RunSandboxSuccess = {
   value: unknown;
   hostCalls: number;
   durationMs: number;
+  logs: readonly string[];
 };
 
 export type RunSandboxResult = Result<RunSandboxSuccess, SandboxError>;
@@ -282,6 +284,81 @@ const getUtf8ByteLength = (value: string): number =>
 
 const okUndefined = <TError = never>(): Result<undefined, TError> =>
   Result.ok<null, TError>(null).map(() => globalThis.undefined);
+
+/**
+ * Caps on captured console output. Logs ride along on success values AND on
+ * SandboxErrors (so a failed run keeps the progress it already logged), which
+ * means they land in tool results the model reads; the entry cap bounds a
+ * logging loop and the per-entry cap bounds a single huge line.
+ */
+export const MAX_SANDBOX_LOG_ENTRIES = 100;
+export const MAX_SANDBOX_LOG_ENTRY_LENGTH = 2000;
+export const SANDBOX_LOG_OVERFLOW_MARKER =
+  `[console output truncated after ${MAX_SANDBOX_LOG_ENTRIES} entries]` as const;
+const SANDBOX_LOG_ENTRY_TRUNCATION_SUFFIX = "… [truncated]";
+
+/**
+ * Prefixes match what `@tanstack/ai-code-mode` parses back out of log lines
+ * ("ERROR: ", "WARN: ", "INFO: ") when emitting `code_mode:console` events;
+ * plain `log` lines stay unprefixed.
+ */
+const SANDBOX_LOG_LEVEL_PREFIXES: Readonly<Record<string, string>> = {
+  warn: "WARN: ",
+  error: "ERROR: ",
+  info: "INFO: ",
+  debug: "DEBUG: ",
+};
+
+type SandboxLogCapture = {
+  entries: string[];
+  overflowed: boolean;
+};
+
+const createSandboxLogCapture = (): SandboxLogCapture => ({
+  entries: [],
+  overflowed: false,
+});
+
+type AppendSandboxLogProps = {
+  capture: SandboxLogCapture;
+  method: string;
+  text: string;
+};
+
+const appendSandboxLog = ({
+  capture,
+  method,
+  text,
+}: AppendSandboxLogProps): void => {
+  if (capture.overflowed) {
+    return;
+  }
+  if (capture.entries.length >= MAX_SANDBOX_LOG_ENTRIES) {
+    capture.overflowed = true;
+    capture.entries.push(SANDBOX_LOG_OVERFLOW_MARKER);
+    return;
+  }
+
+  const entry = `${SANDBOX_LOG_LEVEL_PREFIXES[method] ?? ""}${text}`;
+  capture.entries.push(
+    entry.length > MAX_SANDBOX_LOG_ENTRY_LENGTH
+      ? `${entry.slice(0, MAX_SANDBOX_LOG_ENTRY_LENGTH)}${SANDBOX_LOG_ENTRY_TRUNCATION_SUFFIX}`
+      : entry,
+  );
+};
+
+const attachSandboxLogsToError = (
+  error: SandboxError,
+  logs: readonly string[],
+): SandboxError =>
+  logs.length === 0
+    ? error
+    : new SandboxError({
+        reason: error.reason,
+        message: error.message,
+        logs,
+        cause: error.cause,
+      });
 
 const createTimeoutError = (limits: SandboxLimits): SandboxError =>
   new SandboxError({
@@ -514,6 +591,7 @@ export const runSandbox = async ({
         value: execution.value,
         hostCalls: execution.hostCalls,
         durationMs: Date.now() - startedAt,
+        logs: execution.logs,
       });
     });
   } finally {
@@ -564,6 +642,7 @@ const marshalReturnValue = (
 type ExecuteSandboxSuccess = {
   value: unknown;
   hostCalls: number;
+  logs: readonly string[];
 };
 
 type ExecuteSandboxScriptResult = Result<ExecuteSandboxSuccess, SandboxError>;
@@ -594,6 +673,7 @@ const executeSandboxScript = async ({
   deadline,
 }: ExecuteSandboxScriptProps): Promise<ExecuteSandboxScriptResult> => {
   const state = createHostBridgeState();
+  const logCapture = createSandboxLogCapture();
 
   return await Scope.withScopeAsync(async (scope) => {
     const sandboxContext = await createSandboxContext();
@@ -621,6 +701,22 @@ const executeSandboxScript = async ({
     scope.manage(readCall);
     ctx.setProp(ctx.global, SANDBOX_HOST_BRIDGE_GLOBAL, readCall);
 
+    // Console output is captured host-side (a synchronous sink outside the
+    // guest heap), so it survives every in-execution failure — timeout,
+    // memory, runtime throw — and never counts against the host-call cap.
+    const consoleCall = ctx.newFunction(
+      SANDBOX_CONSOLE_BRIDGE_GLOBAL,
+      (methodHandle, textHandle) => {
+        appendSandboxLog({
+          capture: logCapture,
+          method: ctx.getString(methodHandle),
+          text: ctx.getString(textHandle),
+        });
+      },
+    );
+    scope.manage(consoleCall);
+    ctx.setProp(ctx.global, SANDBOX_CONSOLE_BRIDGE_GLOBAL, consoleCall);
+
     try {
       return (
         await runScriptInContext({
@@ -631,10 +727,15 @@ const executeSandboxScript = async ({
           limits,
           deadline,
         })
-      ).map((value) => ({
-        value,
-        hostCalls: state.hostCalls,
-      }));
+      )
+        .map((value) => ({
+          value,
+          hostCalls: state.hostCalls,
+          logs: logCapture.entries,
+        }))
+        .mapError((error) =>
+          attachSandboxLogsToError(error, logCapture.entries),
+        );
     } finally {
       state.abortController.abort();
       state.closed = true;

--- a/apps/api/src/lib/errors/tagged-errors.ts
+++ b/apps/api/src/lib/errors/tagged-errors.ts
@@ -259,6 +259,12 @@ export class SandboxError extends TaggedError("SandboxError")<{
     | "return-too-large"
     | "non-serialisable-return";
   message: string;
+  /**
+   * Console output captured before the failure, so callers can surface the
+   * partial progress a failed run already made. Absent for failures that
+   * happen before execution starts (transpile, forbidden-syntax).
+   */
+  logs?: readonly string[];
   cause?: unknown;
 }> {}
 


### PR DESCRIPTION
The code-mode sandbox previously stubbed console methods as no-ops, so script `console.log` output went nowhere. This wires real capture and returns it on both outcomes, which lets the model carry forward intermediate results it printed before a script's later statements ran.

- Prelude: a `__consoleCall` host bridge (alias-captured then removed from globalThis, same pattern as `__readCall`); console args are formatted guest-side.
- Host: synchronous capture that never counts against `maxHostCalls`; caps of 100 entries (terminal overflow marker) and 2000 chars per entry (truncation suffix); `WARN:`/`ERROR:`/`INFO:`/`DEBUG:` prefixes match what code-mode parses for console events.
- `SandboxError` gains optional `logs`; execution-time failures attach captured output at a single choke point (pre-execution failures such as transpile stay logless), and the driver includes `logs` in both success and failure results — `executeTypescriptOutputSchema` already declares a top-level optional `logs` alongside `error`.

Tests cover: logs present on a failure after successful statements, logs on timeout, level prefixes, both caps, logless pre-execution failures, and the bridge being hidden from the guest global.