### PR TITLE
feat(chat): derive tool projections from annotated schemas

### DIFF
--- a/apps/api/src/handlers/chat/tools/execute/chat-code-mode.test.ts
+++ b/apps/api/src/handlers/chat/tools/execute/chat-code-mode.test.ts
@@ -84,6 +84,29 @@ describe("buildChatCodeMode", () => {
     expect(codeMode.systemPrompt).toContain("external_search_case_law");
   });
 
+  test("a converted tool's description carries its schema-derived Returns shape", async () => {
+    const codeMode = buildChatCodeMode(buildProps(selectScopedDb([])));
+
+    // Eager path: list_matters' Returns line lands in the system prompt stub.
+    expect(codeMode.systemPrompt).toContain("Returns: {");
+
+    // Lazy path: read_document's full description is served by discover_tools.
+    const discover = codeMode.discoveryTool?.execute ?? undefined;
+    if (discover === undefined) {
+      throw new Error("discover_tools has no server execute");
+    }
+    const discovered = JSON.stringify(
+      await discover({ toolNames: ["read_document"] }),
+    );
+    expect(discovered).toContain("Returns:");
+    expect(discovered).toContain("entityId");
+    expect(discovered).toContain("propertyId");
+    expect(discovered).toContain("versions?");
+    expect(discovered).toContain("diff");
+    // Stripped file plumbing is not advertised to the model.
+    expect(discovered).not.toContain("sha256Hex");
+  });
+
   test("runs a projected read tool end-to-end through the sandbox with refs, no raw UUIDs", async () => {
     const rows = [
       {

--- a/apps/api/src/handlers/chat/tools/execute/chat-code-mode.ts
+++ b/apps/api/src/handlers/chat/tools/execute/chat-code-mode.ts
@@ -17,7 +17,11 @@ import {
   buildMcpContextFromChat,
   type ChatRegistryContextDeps,
 } from "@/api/handlers/chat/tools/registry-adapter/mcp-chat-context";
-import type { RegistryReadToolName } from "@/api/handlers/chat/tools/registry-adapter/ref-field-map";
+import { renderProjectionShape } from "@/api/handlers/chat/tools/registry-adapter/projection-schema";
+import type {
+  RegistryReadToolName,
+  RegistryRefFieldMapEntry,
+} from "@/api/handlers/chat/tools/registry-adapter/ref-field-map";
 import { READ_TOOL_REF_FIELD_MAP } from "@/api/handlers/chat/tools/registry-adapter/ref-field-map";
 import { runRegistryReadTool } from "@/api/handlers/chat/tools/registry-adapter/run-registry-tool";
 import { toToolInputSchema } from "@/api/handlers/chat/tools/registry-adapter/tool-input-schema";
@@ -104,6 +108,25 @@ const CODE_MODE_RUNTIME_CONFIG = {
  * lazy flags) back both the runtime tools (real registry runner) and the static
  * system-prompt constant (no-op runner, never invoked for prompt generation).
  */
+/**
+ * The registry description, plus — for a tool with a projection schema — a
+ * compact `Returns:` shape derived from that same schema. The runtime
+ * strict-parses payloads against the schema, so the shape the model plans
+ * against here is exactly the shape it will receive: this closes the
+ * "model guesses output keys and iterates a field that isn't there" failure
+ * class for converted tools.
+ */
+const chatReadToolDescription = (toolName: RegistryReadToolName): string => {
+  const definition =
+    getStaticMcpToolDefinition(toolName) ??
+    panic(`Chat read tool ${toolName} is missing from the static registry`);
+  const entry: RegistryRefFieldMapEntry = READ_TOOL_REF_FIELD_MAP[toolName];
+  if (entry.projection === undefined) {
+    return definition.description;
+  }
+  return `${definition.description}\nReturns: ${renderProjectionShape(entry.projection)}`;
+};
+
 const buildChatReadTools = (
   runReadTool: (toolName: RegistryReadToolName, args: unknown) => unknown,
 ): CodeModeTool[] =>
@@ -114,7 +137,7 @@ const buildChatReadTools = (
 
     return toolDefinition({
       name: toolName,
-      description: definition.description,
+      description: chatReadToolDescription(toolName),
       inputSchema: toToolInputSchema(definition.inputSchema),
       lazy: !EAGER_CHAT_READ_TOOLS.has(toolName),
     }).server(async (args: unknown) => await runReadTool(toolName, args));

--- a/apps/api/src/handlers/chat/tools/registry-adapter/projection-schema.test.ts
+++ b/apps/api/src/handlers/chat/tools/registry-adapter/projection-schema.test.ts
@@ -1,0 +1,231 @@
+import { Result } from "better-result";
+import { describe, expect, test } from "bun:test";
+
+import type { OutputRefField } from "./projection-schema";
+import {
+  applyProjectionSchema,
+  deriveRefMediationEntry,
+  renderProjectionShape,
+} from "./projection-schema";
+import { READ_TOOL_REF_FIELD_MAP } from "./ref-field-map";
+
+/**
+ * The derivation contract: the mediation lists mechanically derived from a
+ * converted tool's projection schema must reproduce the hand-written lists
+ * they replaced (copied below as literals from the pre-conversion map), so
+ * the conversion is provably behavior-preserving. The lists are allowlists,
+ * so order is irrelevant: both sides are compared sorted.
+ */
+
+const sortedPaths = (paths: readonly string[]): readonly string[] =>
+  [...paths].sort();
+
+// Paths are unique non-linguistic keys, so a plain code-point comparison
+// (not the app-locale collator) is the right sort here.
+const sortedRefs = (
+  refs: readonly OutputRefField[],
+): readonly OutputRefField[] =>
+  [...refs].sort((a, b) => (a.path < b.path ? -1 : 1));
+
+const LIST_MATTERS_PROJECTION = READ_TOOL_REF_FIELD_MAP.list_matters.projection;
+const READ_DOCUMENT_PROJECTION =
+  READ_TOOL_REF_FIELD_MAP.read_document.projection;
+
+// The hand-written list_matters entry the projection schema replaced.
+const LIST_MATTERS_HAND_LISTS = {
+  outputRefs: [
+    { kind: "matter", path: "matters[].id" },
+    { kind: "matter", path: "matter.id" },
+    { kind: "contact", path: "contacts[].contactId" },
+    {
+      kind: "entity",
+      path: "overview.recentEntities[].entityId",
+      workspace: { from: "outputPath", path: "matter.id" },
+    },
+  ],
+  passthroughIdPaths: [
+    "contacts[].workspaceContactId",
+    "members[].userId",
+    "nextCursor",
+  ],
+  stripPaths: [
+    "overview.recentEntities[].fieldId",
+    "overview.recentEntities[].propertyId",
+    "overview.recentEntities[].pdfFileId",
+  ],
+} as const satisfies {
+  outputRefs: readonly OutputRefField[];
+  passthroughIdPaths: readonly string[];
+  stripPaths: readonly string[];
+};
+
+// The hand-written read_document entry the projection schema replaced.
+const READ_DOCUMENT_HAND_LISTS = {
+  outputRefs: [
+    {
+      kind: "entity",
+      path: "entityId",
+      workspace: { from: "inputEntity", param: "entity_id" },
+    },
+    { kind: "property", path: "fields[].propertyId" },
+    { kind: "property", path: "version.fields[].propertyId" },
+  ],
+  passthroughIdPaths: [
+    "version.id",
+    "versions[].id",
+    "version.fields[].id",
+    "fields[].id",
+    "diff.baseVersionId",
+    "diff.targetVersionId",
+    "versionsNextCursor",
+  ],
+  stripPaths: [],
+} as const satisfies {
+  outputRefs: readonly OutputRefField[];
+  passthroughIdPaths: readonly string[];
+  stripPaths: readonly string[];
+};
+
+/**
+ * The one deliberate delta over the hand entry: the `FieldContent` file
+ * variant's storage/derivative plumbing, which the hand lists never declared
+ * and which tripped the prod UUID backstop on any document whose field held a
+ * file (`content.id`/`content.pdfFileId`). The schema strips it at both field
+ * paths (default and specific-version branch).
+ */
+const FILE_CONTENT_PLUMBING_KEYS = [
+  "id",
+  "sha256Hex",
+  "pdfFileId",
+  "pdfDerivative",
+  "thumbnailFileId",
+  "placeholder",
+  "thumbnailDerivative",
+] as const;
+
+const READ_DOCUMENT_CONTENT_STRIPS = [
+  "fields[].content",
+  "version.fields[].content",
+].flatMap((base) => FILE_CONTENT_PLUMBING_KEYS.map((key) => `${base}.${key}`));
+
+describe("deriveRefMediationEntry", () => {
+  test("list_matters: derived lists equal the previous hand-written entry", () => {
+    const derived = deriveRefMediationEntry(LIST_MATTERS_PROJECTION);
+
+    expect(sortedRefs(derived.outputRefs)).toEqual(
+      sortedRefs(LIST_MATTERS_HAND_LISTS.outputRefs),
+    );
+    expect(sortedPaths(derived.passthroughIdPaths)).toEqual(
+      sortedPaths(LIST_MATTERS_HAND_LISTS.passthroughIdPaths),
+    );
+    expect(sortedPaths(derived.stripPaths)).toEqual(
+      sortedPaths(LIST_MATTERS_HAND_LISTS.stripPaths),
+    );
+  });
+
+  test("read_document: derived lists equal the previous hand-written entry plus the file-content strips", () => {
+    const derived = deriveRefMediationEntry(READ_DOCUMENT_PROJECTION);
+
+    expect(sortedRefs(derived.outputRefs)).toEqual(
+      sortedRefs(READ_DOCUMENT_HAND_LISTS.outputRefs),
+    );
+    expect(sortedPaths(derived.passthroughIdPaths)).toEqual(
+      sortedPaths(READ_DOCUMENT_HAND_LISTS.passthroughIdPaths),
+    );
+    expect(sortedPaths(derived.stripPaths)).toEqual(
+      sortedPaths([
+        ...READ_DOCUMENT_HAND_LISTS.stripPaths,
+        ...READ_DOCUMENT_CONTENT_STRIPS,
+      ]),
+    );
+  });
+
+  test("is memoized per schema", () => {
+    expect(deriveRefMediationEntry(LIST_MATTERS_PROJECTION)).toBe(
+      deriveRefMediationEntry(LIST_MATTERS_PROJECTION),
+    );
+  });
+});
+
+describe("applyProjectionSchema", () => {
+  const ROGUE_UUID = "4e919658-a448-5354-8e3a-e99911214d2c";
+
+  test("an undeclared field fails the strict parse with its path, never its value", () => {
+    const result = applyProjectionSchema({
+      schema: LIST_MATTERS_PROJECTION,
+      payload: {
+        matters: [
+          {
+            id: "0dc54d0c-10d7-501d-897e-e801dbd0998c",
+            name: "Acme",
+            reference: "REF-1",
+            status: "active",
+            lastActivityAt: "2026-01-01T00:00:00.000Z",
+            createdAt: "2026-01-01T00:00:00.000Z",
+            // The class under guard: a handler field nobody classified,
+            // carrying a UUID. The strict parse refuses it by construction.
+            plumbingId: ROGUE_UUID,
+          },
+        ],
+        nextCursor: null,
+      },
+    });
+
+    expect(Result.isError(result)).toBe(true);
+    if (Result.isError(result)) {
+      expect(result.error.issuePaths).toContain("matters[].plumbingId");
+      expect(JSON.stringify(result.error)).not.toContain(ROGUE_UUID);
+    }
+  });
+
+  test("a matching payload parses to the declared shape", () => {
+    const payload = {
+      matters: [
+        {
+          id: "0dc54d0c-10d7-501d-897e-e801dbd0998c",
+          name: "Acme",
+          reference: "REF-1",
+          status: "active",
+          lastActivityAt: "2026-01-01T00:00:00.000Z",
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+      ],
+      nextCursor: null,
+    };
+
+    const result = applyProjectionSchema({
+      schema: LIST_MATTERS_PROJECTION,
+      payload,
+    });
+
+    expect(Result.isError(result)).toBe(false);
+    expect(result.unwrap()).toEqual(payload);
+  });
+});
+
+describe("renderProjectionShape", () => {
+  test("read_document renders a terse shape naming the model-facing keys", () => {
+    const shape = renderProjectionShape(READ_DOCUMENT_PROJECTION);
+
+    expect(shape).toContain("entityId");
+    expect(shape).toContain("fields: { id, propertyId, content: … }[]");
+    expect(shape).toContain("versions?");
+    expect(shape).toContain("versionsNextCursor?");
+    expect(shape).toContain("diff");
+    // Stripped file plumbing must not be advertised to the model.
+    expect(shape).not.toContain("sha256Hex");
+    expect(shape).not.toContain("pdfFileId");
+  });
+
+  test("list_matters renders both branches joined as a union", () => {
+    const shape = renderProjectionShape(LIST_MATTERS_PROJECTION);
+
+    expect(shape).toContain(
+      "matters: { id, name, reference, status, lastActivityAt, createdAt }[]",
+    );
+    expect(shape).toContain(" | ");
+    expect(shape).toContain("contacts");
+    // Stripped overview plumbing must not be advertised either.
+    expect(shape).not.toContain("fieldId");
+  });
+});

--- a/apps/api/src/handlers/chat/tools/registry-adapter/projection-schema.ts
+++ b/apps/api/src/handlers/chat/tools/registry-adapter/projection-schema.ts
@@ -1,0 +1,596 @@
+import { panic, Result } from "better-result";
+import * as v from "valibot";
+
+/**
+ * Chat projection schemas: one Valibot `strictObject` per converted tool that
+ * describes exactly what the chat surface forwards, with each id-bearing
+ * field's chat semantics attached via `v.metadata`. The strict parse makes an
+ * undeclared handler field structurally unable to reach the model (an unknown
+ * key fails the parse, fail-closed), and the ref-mediation path lists
+ * (`outputRefs`/`passthroughIdPaths`/`stripPaths`) are derived mechanically
+ * from the same artifact, so the shape and its ref decisions cannot drift
+ * apart the way a hand-maintained path list can.
+ */
+
+// --- Ref vocabulary -----------------------------------------------------------
+// The id-kind types the annotations carry. They live here (not in
+// ref-field-map.ts) so this module has no import back into the map and the
+// module graph stays cycle-free; the map imports the vocabulary from here.
+
+/**
+ * The four tenant-content id kinds the chat ref registry mediates
+ * (`createChatRefRegistry`). Every other id a registry handler emits (user,
+ * task-link, invoice, time-entry, template, clause, playbook, audit-log,
+ * usage-plan, or public case-law/BOE corpus id) is a handle the model may pass
+ * back verbatim, not a tenant-content reference, so it stays outside this set.
+ */
+export type RegistryRefKind = "matter" | "entity" | "contact" | "property";
+
+export type SimpleRefKind = Exclude<RegistryRefKind, "entity">;
+
+/**
+ * How an entity output ref recovers its owning workspace id, which
+ * `toEntityRef` needs alongside the entity id. MCP handlers name these fields
+ * differently per tool (a sibling `workspaceId`, a fixed `matter.id`, or the
+ * tool's resolved `matter_id` input), so the source is declared per field
+ * rather than guessed from key names.
+ */
+export type EntityWorkspaceSource =
+  | { from: "sibling"; key: string }
+  | { from: "outputPath"; path: string }
+  | { from: "inputParam"; param: string }
+  // The output entity is a *different* entity than the request's own entity
+  // input named by `param`, but is validated (at write time, outside this
+  // orchestrator) to share its workspace, e.g. a task's linked entities. The
+  // workspace is the one already resolved when `param`'s ref was dehydrated,
+  // not a fresh lookup.
+  | { from: "inputEntityWorkspace"; param: string }
+  // The output entity IS the request's own entity input; the orchestrator
+  // reuses the ref it dehydrated on the way in, so no workspace lookup runs.
+  | { from: "inputEntity"; param: string };
+
+/**
+ * One UUID-bearing output path and the tenant ref kind it carries. `path` uses
+ * the same `a.b` / `a[].b` grammar as the egress text-field specs. Entity
+ * fields additionally declare where their owning workspace id lives.
+ */
+export type OutputRefField =
+  | { kind: SimpleRefKind; path: string }
+  | { kind: "entity"; path: string; workspace: EntityWorkspaceSource };
+
+/**
+ * The three output-side path lists the generic mediation cores
+ * (`hydrateRefs`/`findUndeclaredUuidPathIn`/`stripDeclaredPaths`) consume:
+ * hand-written on unconverted map entries, derived from the projection schema
+ * on converted ones.
+ */
+export type RefMediationLists = {
+  outputRefs: readonly OutputRefField[];
+  /**
+   * UUID-bearing output paths intentionally left un-refed: non-tenant handles
+   * (user/invoice/template/audit/public-corpus ids) or opaque cursors.
+   * Load-bearing allowlist for the runtime UUID backstop; an `outputRefs`
+   * path is deliberately NOT part of it — hydration must have already
+   * rewritten it, so a uuid still there fails closed.
+   */
+  passthroughIdPaths: readonly string[];
+  /**
+   * Output paths deleted from the chat projection before hydration and the
+   * UUID backstop run: ids other surfaces need (web-UI field/file plumbing
+   * handles) that chat cannot act on.
+   */
+  stripPaths: readonly string[];
+};
+
+// --- Annotated field wrappers ---------------------------------------------------
+
+/**
+ * The chat semantics one projected field carries, stored under
+ * `CHAT_PROJECTION_METADATA_KEY` in the field schema's `v.metadata` pipe item
+ * and read back by the schema walker below.
+ */
+const workspaceSourceSchema = v.variant("from", [
+  v.strictObject({ from: v.literal("sibling"), key: v.string() }),
+  v.strictObject({ from: v.literal("outputPath"), path: v.string() }),
+  v.strictObject({ from: v.literal("inputParam"), param: v.string() }),
+  v.strictObject({
+    from: v.literal("inputEntityWorkspace"),
+    param: v.string(),
+  }),
+  v.strictObject({ from: v.literal("inputEntity"), param: v.string() }),
+]);
+
+const annotationSchema = v.variant("role", [
+  v.strictObject({
+    role: v.literal("ref"),
+    kind: v.picklist(["matter", "contact", "property"]),
+  }),
+  v.strictObject({
+    role: v.literal("entityRef"),
+    workspace: workspaceSourceSchema,
+  }),
+  v.strictObject({ role: v.literal("passthroughId") }),
+  v.strictObject({ role: v.literal("strip") }),
+]);
+
+type ChatProjectionAnnotation = v.InferOutput<typeof annotationSchema>;
+
+const CHAT_PROJECTION_METADATA_KEY = "chatProjection";
+
+/**
+ * The widened schema type every projection value and annotated field carries.
+ * Deliberately not the inferred builder type: the payload arrives as `unknown`
+ * from `JSON.parse`, so nothing consumes the precise input/output types, and
+ * widening at the wrapper boundary keeps valibot's generic instantiation cost
+ * out of the map (per the type-cost guard).
+ */
+export type ChatProjectionSchema = v.GenericSchema<
+  Record<string, unknown>,
+  Record<string, unknown>
+>;
+
+type AnnotatedFieldSchema = v.GenericSchema;
+
+/** A tenant id field hydrated into a `mat_N`/`contact_N`/`prop_N` chat ref. */
+export const chatRef = (kind: SimpleRefKind): AnnotatedFieldSchema =>
+  v.pipe(
+    v.string(),
+    v.metadata({ [CHAT_PROJECTION_METADATA_KEY]: { role: "ref", kind } }),
+  );
+
+/**
+ * A tenant entity id field hydrated into an `ent_N` chat ref, declaring where
+ * its owning workspace id is recovered from.
+ */
+export const chatEntityRef = (
+  workspace: EntityWorkspaceSource,
+): AnnotatedFieldSchema =>
+  v.pipe(
+    v.string(),
+    v.metadata({
+      [CHAT_PROJECTION_METADATA_KEY]: { role: "entityRef", workspace },
+    }),
+  );
+
+/**
+ * A non-tenant handle (user/version/link/library id, opaque cursor) the model
+ * may pass back verbatim; licensed to survive the runtime UUID backstop.
+ */
+export const passthroughId = (): AnnotatedFieldSchema =>
+  v.pipe(
+    v.string(),
+    v.metadata({ [CHAT_PROJECTION_METADATA_KEY]: { role: "passthroughId" } }),
+  );
+
+/**
+ * A field other surfaces need but chat deletes from the projection before the
+ * payload reaches the model (web-UI field/file plumbing handles). `v.unknown()`
+ * base: the strict parse admits it at its declared key, then the derived
+ * `stripPaths` remove it.
+ */
+export const strippedField = (): AnnotatedFieldSchema =>
+  v.pipe(
+    v.unknown(),
+    v.metadata({ [CHAT_PROJECTION_METADATA_KEY]: { role: "strip" } }),
+  );
+
+// --- Schema AST walking ---------------------------------------------------------
+// Valibot schemas are plain objects: `v.pipe` spreads its base schema and adds
+// a `pipe` array whose items include `{ type: "metadata", metadata }` actions;
+// wrappers carry `wrapped`; objects carry `entries`; arrays carry `item`;
+// unions/variants carry `options`. The walker reads that runtime AST through
+// structural guards, so it needs no valibot generics at all.
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+/** Read the chat annotation off a schema node's metadata pipe items, if any. */
+const readAnnotation = (
+  node: Record<string, unknown>,
+): ChatProjectionAnnotation | undefined => {
+  const pipe = node["pipe"];
+  if (!Array.isArray(pipe)) {
+    return undefined;
+  }
+  for (const item of pipe) {
+    if (!isRecord(item) || item["type"] !== "metadata") {
+      continue;
+    }
+    const metadata = item["metadata"];
+    if (!isRecord(metadata)) {
+      continue;
+    }
+    const raw = metadata[CHAT_PROJECTION_METADATA_KEY];
+    if (raw === undefined) {
+      continue;
+    }
+    const parsed = v.safeParse(annotationSchema, raw);
+    if (!parsed.success) {
+      panic("chat projection metadata does not match the annotation shape");
+    }
+    return parsed.output;
+  }
+  return undefined;
+};
+
+const WRAPPER_TYPES = new Set([
+  "optional",
+  "exact_optional",
+  "nullable",
+  "nullish",
+  "undefinedable",
+  "non_optional",
+  "non_nullable",
+  "non_nullish",
+]);
+
+const OBJECT_TYPES = new Set([
+  "object",
+  "strict_object",
+  "loose_object",
+  "object_with_rest",
+]);
+
+const UNION_TYPES = new Set(["union", "variant"]);
+
+const asSchemaNode = (value: unknown): Record<string, unknown> =>
+  isRecord(value) ? value : panic("expected a valibot schema node");
+
+type AnnotationVisitor = (
+  path: string,
+  annotation: ChatProjectionAnnotation,
+) => void;
+
+/**
+ * Walk one object-field value schema under `key`, recording annotated leaves
+ * in the `a.b` / `a[].b` grammar `ref-mediation.ts` consumes. Wrappers are
+ * transparent; an array descends as `key[]` into its item; unions merge every
+ * option's contributions (the grammar has no discriminator — the paths are
+ * allowlists, so a path only one variant produces is simply absent from the
+ * other variant's payloads).
+ */
+const walkFieldSchema = (
+  value: unknown,
+  segments: readonly string[],
+  key: string,
+  visit: AnnotationVisitor,
+): void => {
+  const node = asSchemaNode(value);
+  const annotation = readAnnotation(node);
+  if (annotation !== undefined) {
+    visit([...segments, key].join("."), annotation);
+    return;
+  }
+  if (typeof node["type"] === "string" && WRAPPER_TYPES.has(node["type"])) {
+    walkFieldSchema(node["wrapped"], segments, key, visit);
+    return;
+  }
+  if (node["type"] === "array") {
+    const item = asSchemaNode(node["item"]);
+    if (readAnnotation(item) !== undefined) {
+      panic(
+        "the ref path grammar cannot address annotated array items; annotate an object field instead",
+      );
+    }
+    walkContainerSchema(item, [...segments, `${key}[]`], visit);
+    return;
+  }
+  walkContainerSchema(node, [...segments, key], visit);
+};
+
+/** Walk a non-leaf schema (object, union, wrapped container) at `segments`. */
+const walkContainerSchema = (
+  value: unknown,
+  segments: readonly string[],
+  visit: AnnotationVisitor,
+): void => {
+  const node = asSchemaNode(value);
+  const nodeType = node["type"];
+  if (typeof nodeType !== "string") {
+    panic("valibot schema node has no type");
+  }
+  if (WRAPPER_TYPES.has(nodeType)) {
+    walkContainerSchema(node["wrapped"], segments, visit);
+    return;
+  }
+  if (UNION_TYPES.has(nodeType)) {
+    const options = node["options"];
+    if (!Array.isArray(options)) {
+      panic("union schema node has no options array");
+    }
+    for (const option of options) {
+      walkContainerSchema(option, segments, visit);
+    }
+    return;
+  }
+  if (OBJECT_TYPES.has(nodeType)) {
+    const entries = node["entries"];
+    if (!isRecord(entries)) {
+      panic("object schema node has no entries record");
+    }
+    for (const [key, child] of Object.entries(entries)) {
+      walkFieldSchema(child, segments, key, visit);
+    }
+    return;
+  }
+  if (nodeType === "array") {
+    panic("the ref path grammar cannot address nested arrays");
+  }
+  // A scalar leaf (string/number/boolean/literal/picklist/unknown/null):
+  // ordinary data, nothing to record.
+};
+
+// --- Deriving the mediation lists -------------------------------------------------
+
+const sameRefField = (a: OutputRefField, b: OutputRefField): boolean =>
+  JSON.stringify(a) === JSON.stringify(b);
+
+const buildMediationLists = (
+  schema: ChatProjectionSchema,
+): RefMediationLists => {
+  const outputRefsByPath = new Map<string, OutputRefField>();
+  const passthroughIdPaths = new Set<string>();
+  const stripPaths = new Set<string>();
+
+  const recordRefField = (field: OutputRefField): void => {
+    const existing = outputRefsByPath.get(field.path);
+    if (existing !== undefined && !sameRefField(existing, field)) {
+      panic(
+        `conflicting chat projection annotations at output path ${field.path}`,
+      );
+    }
+    outputRefsByPath.set(field.path, field);
+  };
+
+  walkContainerSchema(schema, [], (path, annotation) => {
+    switch (annotation.role) {
+      case "ref": {
+        recordRefField({ kind: annotation.kind, path });
+        return;
+      }
+      case "entityRef": {
+        recordRefField({
+          kind: "entity",
+          path,
+          workspace: annotation.workspace,
+        });
+        return;
+      }
+      case "passthroughId": {
+        passthroughIdPaths.add(path);
+        return;
+      }
+      case "strip": {
+        stripPaths.add(path);
+        return;
+      }
+      default: {
+        annotation satisfies never;
+      }
+    }
+  });
+
+  return {
+    outputRefs: [...outputRefsByPath.values()],
+    passthroughIdPaths: [...passthroughIdPaths],
+    stripPaths: [...stripPaths],
+  };
+};
+
+const mediationListsCache = new WeakMap<
+  ChatProjectionSchema,
+  RefMediationLists
+>();
+
+/**
+ * Mechanically derive a converted tool's `outputRefs`/`passthroughIdPaths`/
+ * `stripPaths` from its projection schema's annotations. Memoized per schema:
+ * the walk runs once per tool per process, not per request.
+ */
+export const deriveRefMediationEntry = (
+  schema: ChatProjectionSchema,
+): RefMediationLists => {
+  const cached = mediationListsCache.get(schema);
+  if (cached !== undefined) {
+    return cached;
+  }
+  const lists = buildMediationLists(schema);
+  mediationListsCache.set(schema, lists);
+  return lists;
+};
+
+// --- Applying a projection schema ---------------------------------------------------
+
+/**
+ * A payload that failed its projection schema: a handler emitted a field
+ * nobody classified (or a declared field changed shape). Carries only the
+ * dot-paths of the issues, never any payload value, so it can reach telemetry
+ * without leaking what it refused.
+ */
+export type ProjectionSchemaViolation = { issuePaths: readonly string[] };
+
+/** Normalize a valibot issue path into the map's `a.b` / `a[].b` grammar. */
+const issueRefPath = (issue: v.BaseIssue<unknown>): string => {
+  const segments: string[] = [];
+  for (const item of issue.path ?? []) {
+    if (typeof item.key === "number") {
+      const last = segments.pop();
+      if (last !== undefined) {
+        segments.push(last.endsWith("[]") ? last : `${last}[]`);
+      }
+      continue;
+    }
+    segments.push(String(item.key));
+  }
+  return segments.length > 0 ? segments.join(".") : "(root)";
+};
+
+/**
+ * Collect the leaf paths of an issue tree. A union/variant that matched no
+ * option emits one top-level issue whose specifics live in its nested
+ * `issues`; the leaves carry the paths worth logging.
+ */
+const collectIssuePaths = (
+  issue: v.BaseIssue<unknown>,
+  paths: string[],
+): void => {
+  if (issue.issues !== undefined && issue.issues.length > 0) {
+    for (const nested of issue.issues) {
+      collectIssuePaths(nested, paths);
+    }
+    return;
+  }
+  paths.push(issueRefPath(issue));
+};
+
+/**
+ * Strict-parse a tool payload against its projection schema. The parse is the
+ * structural guarantee: an unknown key anywhere in the declared object tree —
+ * a field nobody classified — fails here, before strip/hydrate/backstop ever
+ * see the payload, so an undeclared field cannot flow to the model by
+ * construction. On failure the violation carries issue paths only.
+ */
+export const applyProjectionSchema = ({
+  payload,
+  schema,
+}: {
+  schema: ChatProjectionSchema;
+  payload: unknown;
+}): Result<Record<string, unknown>, ProjectionSchemaViolation> => {
+  const parsed = v.safeParse(schema, payload);
+  if (parsed.success) {
+    return Result.ok(parsed.output);
+  }
+  const issuePaths: string[] = [];
+  for (const issue of parsed.issues) {
+    collectIssuePaths(issue, issuePaths);
+  }
+  return Result.err({ issuePaths: [...new Set(issuePaths)] });
+};
+
+// --- Model-facing shape rendering ---------------------------------------------------
+
+/**
+ * Objects nested deeper than this render as `{…}`; unions below the top level
+ * render as `…`. Keeps the `Returns:` line in a tool description terse enough
+ * for the provider-visible catalog while still naming the keys the model
+ * actually iterates over.
+ */
+const MAX_RENDERED_OBJECT_DEPTH = 2;
+
+const COLLAPSED_OBJECT = "{…}";
+const COLLAPSED_VALUE = "…";
+
+type RenderedField = { key: string; optional: boolean; shape: string };
+
+/**
+ * Render one field's value shape; empty string means "bare key" (a scalar or
+ * an id/ref leaf whose type adds nothing), `undefined` means the field is
+ * stripped from the projection and must not be shown at all.
+ */
+const renderFieldShape = (
+  value: unknown,
+  depth: number,
+  optional: boolean,
+): RenderedFieldShape => {
+  const node = asSchemaNode(value);
+  const annotation = readAnnotation(node);
+  if (annotation !== undefined) {
+    return annotation.role === "strip"
+      ? { render: false }
+      : { render: true, optional, shape: "" };
+  }
+  const nodeType = node["type"];
+  if (typeof nodeType === "string" && WRAPPER_TYPES.has(nodeType)) {
+    return renderFieldShape(
+      node["wrapped"],
+      depth,
+      optional || nodeType === "optional" || nodeType === "exact_optional",
+    );
+  }
+  if (nodeType === "array") {
+    const item = renderFieldShape(node["item"], depth, false);
+    const itemShape = item.render && item.shape !== "" ? item.shape : "";
+    return { render: true, optional, shape: `${itemShape}[]` };
+  }
+  if (typeof nodeType === "string" && UNION_TYPES.has(nodeType)) {
+    return { render: true, optional, shape: COLLAPSED_VALUE };
+  }
+  if (typeof nodeType === "string" && OBJECT_TYPES.has(nodeType)) {
+    return {
+      render: true,
+      optional,
+      shape: renderObjectShape(node, depth + 1),
+    };
+  }
+  return { render: true, optional, shape: "" };
+};
+
+type RenderedFieldShape =
+  | { render: false }
+  | { render: true; optional: boolean; shape: string };
+
+const renderObjectShape = (
+  node: Record<string, unknown>,
+  depth: number,
+): string => {
+  if (depth > MAX_RENDERED_OBJECT_DEPTH) {
+    return COLLAPSED_OBJECT;
+  }
+  const entries = node["entries"];
+  if (!isRecord(entries)) {
+    panic("object schema node has no entries record");
+  }
+  const fields: RenderedField[] = [];
+  for (const [key, child] of Object.entries(entries)) {
+    const rendered = renderFieldShape(child, depth, false);
+    if (rendered.render) {
+      fields.push({ key, optional: rendered.optional, shape: rendered.shape });
+    }
+  }
+  const body = fields
+    .map(({ key, optional, shape }) => {
+      const name = optional ? `${key}?` : key;
+      return shape === "" ? name : `${name}: ${shape}`;
+    })
+    .join(", ");
+  return `{ ${body} }`;
+};
+
+const renderTopLevel = (value: unknown): string => {
+  const node = asSchemaNode(value);
+  const nodeType = node["type"];
+  if (typeof nodeType === "string" && WRAPPER_TYPES.has(nodeType)) {
+    return renderTopLevel(node["wrapped"]);
+  }
+  if (typeof nodeType === "string" && UNION_TYPES.has(nodeType)) {
+    const options = node["options"];
+    if (!Array.isArray(options)) {
+      panic("union schema node has no options array");
+    }
+    return options.map((option) => renderTopLevel(option)).join(" | ");
+  }
+  if (typeof nodeType === "string" && OBJECT_TYPES.has(nodeType)) {
+    return renderObjectShape(node, 1);
+  }
+  return COLLAPSED_VALUE;
+};
+
+const renderedShapeCache = new WeakMap<ChatProjectionSchema, string>();
+
+/**
+ * A terse TS-ish `Returns:` shape for a converted tool's description, derived
+ * from the same projection schema that gates its payload — so the shape the
+ * model plans against and the shape the runtime enforces cannot drift.
+ * Stripped fields are omitted (they never reach the model); depth-capped so
+ * the provider-visible catalog stays short. Memoized per schema.
+ */
+export const renderProjectionShape = (schema: ChatProjectionSchema): string => {
+  const cached = renderedShapeCache.get(schema);
+  if (cached !== undefined) {
+    return cached;
+  }
+  const rendered = renderTopLevel(schema);
+  renderedShapeCache.set(schema, rendered);
+  return rendered;
+};

--- a/apps/api/src/handlers/chat/tools/registry-adapter/ref-field-map.ts
+++ b/apps/api/src/handlers/chat/tools/registry-adapter/ref-field-map.ts
@@ -1,4 +1,18 @@
+import * as v from "valibot";
+
 import type { DEFAULT_MCP_TOOL_DEFINITIONS } from "@/api/mcp/static-tool-definitions";
+
+import type {
+  ChatProjectionSchema,
+  RefMediationLists,
+  RegistryRefKind,
+} from "./projection-schema";
+import {
+  chatEntityRef,
+  chatRef,
+  passthroughId,
+  strippedField,
+} from "./projection-schema";
 
 /**
  * The read-only slice of the MCP registry, derived structurally from the single
@@ -32,86 +46,39 @@ type WriteToolDefinition = Extract<
 
 export type RegistryWriteToolName = WriteToolDefinition["name"];
 
-/**
- * The four tenant-content id kinds the chat ref registry mediates
- * (`createChatRefRegistry`). Every other id a registry handler emits (user,
- * task-link, invoice, time-entry, template, clause, playbook, audit-log,
- * usage-plan, or public case-law/BOE corpus id) is a handle the model may pass
- * back verbatim, not a tenant-content reference, so it stays outside this set.
- */
-export type RegistryRefKind = "matter" | "entity" | "contact" | "property";
-
-type SimpleRefKind = Exclude<RegistryRefKind, "entity">;
-
-/**
- * How an entity output ref recovers its owning workspace id, which
- * `toEntityRef` needs alongside the entity id. MCP handlers name these fields
- * differently per tool (a sibling `workspaceId`, a fixed `matter.id`, or the
- * tool's resolved `matter_id` input), so the source is declared per field
- * rather than guessed from key names.
- */
-export type EntityWorkspaceSource =
-  | { from: "sibling"; key: string }
-  | { from: "outputPath"; path: string }
-  | { from: "inputParam"; param: string }
-  // The output entity is a *different* entity than the request's own entity
-  // input named by `param`, but is validated (at write time, outside this
-  // orchestrator) to share its workspace, e.g. a task's linked entities. The
-  // workspace is the one already resolved when `param`'s ref was dehydrated,
-  // not a fresh lookup.
-  | { from: "inputEntityWorkspace"; param: string }
-  // The output entity IS the request's own entity input; the orchestrator
-  // reuses the ref it dehydrated on the way in, so no workspace lookup runs.
-  | { from: "inputEntity"; param: string };
-
-/**
- * One UUID-bearing output path and the tenant ref kind it carries. `path` uses
- * the same `a.b` / `a[].b` grammar as the egress text-field specs. Entity
- * fields additionally declare where their owning workspace id lives.
- */
-export type OutputRefField =
-  | { kind: SimpleRefKind; path: string }
-  | { kind: "entity"; path: string; workspace: EntityWorkspaceSource };
-
 /** One input parameter that accepts a chat ref, and the id kind it resolves to. */
 export type InputRefParam = { kind: RegistryRefKind; param: string };
 
 /**
  * The ref-mediation contract shared by the read and write ref-field maps: the
- * input refs to dehydrate, the output paths to hydrate into chat refs, and the
- * UUID-bearing output paths intentionally left un-refed. The generic mediation
- * cores (`dehydrateRefs`/`hydrateRefs`/`findUndeclaredUuidPathIn`) read exactly
- * these three lists, so a read entry and a write entry drive the same code.
+ * input refs to dehydrate, plus the output-side decision. The output side is
+ * one of two mutually exclusive artifacts:
+ *
+ * - a chat projection schema (`projection`), from which the three mediation
+ *   lists are derived mechanically (`deriveRefMediationEntry`) and whose
+ *   strict parse makes an undeclared handler field structurally unable to
+ *   reach the model; or
+ * - the hand-written lists (unconverted tools), where the runtime UUID
+ *   backstop alone guards undeclared fields.
+ *
+ * The `never`-typed exclusions make an entry that carries both a projection
+ * and hand lists fail typecheck, so a converted tool cannot keep a stale hand
+ * copy of what the schema now owns. Resolve the lists for either shape with
+ * `resolveMediationLists` (`ref-mediation.ts`); the generic mediation cores
+ * (`dehydrateRefs`/`hydrateRefs`/`findUndeclaredUuidPathIn`) read exactly
+ * those three lists, so a read entry and a write entry drive the same code.
  */
 export type RefMediationEntry = {
   inputRefs: readonly InputRefParam[];
-  outputRefs: readonly OutputRefField[];
-  /**
-   * UUID-bearing output paths intentionally left un-refed. Each path uses the
-   * same `a.b` / `a[].b` grammar as `outputRefs`. Forces an explicit decision
-   * per tool: an id here is either a non-tenant handle (user/invoice/
-   * template/audit/public-corpus id) or an entity id whose owning workspace is
-   * not statically recoverable and is deferred to the manifest-swap step.
-   *
-   * Load-bearing, not documentation: `findUndeclaredUuidPathIn`
-   * (`ref-mediation.ts`) walks the hydrated payload and allows a surviving
-   * raw uuid only at one of these exact paths. An `outputRefs` path is
-   * deliberately NOT part of this allowlist — hydration must have already
-   * rewritten it to a chat ref, so a uuid still there means hydration missed
-   * it, which fails closed the same as an undeclared path.
-   */
-  passthroughIdPaths: readonly string[];
-  /**
-   * Output paths deleted from the chat projection before hydration and the
-   * UUID backstop run. For fields other surfaces need (web-UI field/file
-   * plumbing handles) that chat cannot act on: stripping keeps them out of
-   * the model context entirely instead of leaking them as passthrough noise.
-   * Same `a.b` / `a[].b` grammar as `outputRefs`. Required so every tool
-   * records an explicit decision, like `passthroughIdPaths`; the backstop
-   * still fails closed on any undeclared survivor.
-   */
-  stripPaths: readonly string[];
-};
+} & (
+  | ({ projection?: never } & RefMediationLists)
+  | {
+      projection: ChatProjectionSchema;
+      outputRefs?: never;
+      passthroughIdPaths?: never;
+      stripPaths?: never;
+    }
+);
 
 export type RegistryRefFieldMapEntry = RefMediationEntry & {
   /**
@@ -123,6 +90,261 @@ export type RegistryRefFieldMapEntry = RefMediationEntry & {
    */
   chatProjectable: boolean;
 };
+
+// --- Chat projection schemas (converted tools) ------------------------------------
+// One artifact per converted tool: the exact shape the chat surface forwards,
+// with per-field chat semantics attached (`chatRef`/`chatEntityRef`/
+// `passthroughId`/`strippedField`). The strict parse in the orchestrator makes
+// an undeclared handler field fail closed BEFORE it can reach the model, and
+// `deriveRefMediationEntry` derives the entry's outputRefs/passthrough/strip
+// lists from the same annotations, so shape and ref decisions cannot drift.
+
+/**
+ * list_matters, list branch. Source of truth: `handleListMattersTool`
+ * (`stella-tools.ts`) — one row per matter plus the opaque page cursor.
+ */
+const listMattersListProjection = v.strictObject({
+  matters: v.array(
+    v.strictObject({
+      // A matter's id IS its workspace id: a matter chat ref.
+      id: chatRef("matter"),
+      name: v.string(),
+      reference: v.string(),
+      status: v.string(),
+      lastActivityAt: v.string(),
+      createdAt: v.string(),
+    }),
+  ),
+  // Opaque base64 cursor (boundary matter id), not UUID-formatted.
+  nextCursor: v.nullable(passthroughId()),
+});
+
+/**
+ * list_matters, detail branch (one matter's overview). Source of truth:
+ * `readMatterOverview` (`stella-tools.ts`) composing `readWorkspaceHandler`,
+ * `readOverviewHandler` (avatar URLs stripped at the handler), and the
+ * contact/member card mappers.
+ */
+const listMattersDetailProjection = v.strictObject({
+  matter: v.strictObject({
+    id: chatRef("matter"),
+    name: v.string(),
+    reference: v.string(),
+    status: v.string(),
+    clientName: v.nullable(v.string()),
+  }),
+  overview: v.strictObject({
+    entityCount: v.number(),
+    documentCount: v.number(),
+    taskCount: v.number(),
+    recentEntities: v.array(
+      v.strictObject({
+        // The overview handler's item field is `entityId`, not `id`
+        // (`readOverviewHandler` returns `{ entityId: e.id, ... }`). Every
+        // recent entity belongs to the one matter this response describes,
+        // so its workspace is the payload's `matter.id`.
+        entityId: chatEntityRef({ from: "outputPath", path: "matter.id" }),
+        name: v.string(),
+        kind: v.string(),
+        status: v.nullable(v.string()),
+        priority: v.nullable(v.string()),
+        dueDate: v.nullable(v.string()),
+        mimeType: v.nullable(v.string()),
+        // The primary-field plumbing ids exist for the web UI (mime icon,
+        // click-to-open); chat cannot act on them and they carry raw UUIDs
+        // whenever a recent entity has a primary field, which tripped the
+        // UUID backstop on every non-empty matter until they were stripped.
+        fieldId: strippedField(),
+        propertyId: strippedField(),
+        pdfFileId: strippedField(),
+        encrypted: v.boolean(),
+        createdAt: v.string(),
+        updatedAt: v.nullable(v.string()),
+        createdBy: v.nullable(v.string()),
+        createdByDeletedAt: v.nullable(v.string()),
+        assignedTo: v.nullable(v.string()),
+        assignedToDeletedAt: v.nullable(v.string()),
+      }),
+    ),
+  }),
+  contacts: v.array(
+    v.strictObject({
+      // The matter-contact link id, so link_matter_contact can unlink a
+      // precise role even when the contact holds several: a handle, no chat
+      // ref kind.
+      workspaceContactId: passthroughId(),
+      contactId: chatRef("contact"),
+      displayName: v.string(),
+      role: v.string(),
+      type: v.string(),
+    }),
+  ),
+  members: v.array(
+    v.strictObject({
+      // Workspace member (user) id: a handle save_task assignees accept.
+      userId: passthroughId(),
+      name: v.string(),
+    }),
+  ),
+});
+
+const LIST_MATTERS_PROJECTION: ChatProjectionSchema = v.union([
+  listMattersListProjection,
+  listMattersDetailProjection,
+]);
+
+/**
+ * The `FieldContent` union (`schema-validators.ts`), modeled variant by
+ * variant so a new file-plumbing field cannot slip past the strict parse. The
+ * file variant's storage/derivative plumbing (file ids, integrity hash,
+ * derivative statuses, thumbnail placeholder) is web-UI/file-pipeline
+ * machinery chat cannot act on: stripped, which is what keeps the raw
+ * `content.id`/`content.pdfFileId` file UUIDs (the second prod backstop trip)
+ * out of the model context entirely.
+ */
+const documentFieldContentProjection: ChatProjectionSchema = v.variant("type", [
+  v.strictObject({ version: v.literal(1), type: v.literal("error") }),
+  v.strictObject({ version: v.literal(1), type: v.literal("pending") }),
+  v.strictObject({ version: v.literal(1), type: v.literal("unsupported") }),
+  v.strictObject({
+    version: v.literal(1),
+    type: v.literal("file"),
+    id: strippedField(),
+    fileName: v.string(),
+    mimeType: v.string(),
+    sizeBytes: v.number(),
+    encrypted: v.boolean(),
+    sha256Hex: strippedField(),
+    pdfFileId: strippedField(),
+    pdfDerivative: v.optional(strippedField()),
+    thumbnailFileId: v.optional(strippedField()),
+    placeholder: v.optional(strippedField()),
+    thumbnailDerivative: v.optional(strippedField()),
+    scanWarnings: v.optional(v.array(v.string())),
+  }),
+  v.strictObject({
+    version: v.literal(1),
+    type: v.literal("text"),
+    value: v.string(),
+  }),
+  v.strictObject({
+    version: v.literal(1),
+    type: v.literal("single-select"),
+    value: v.nullable(v.string()),
+  }),
+  v.strictObject({
+    version: v.literal(1),
+    type: v.literal("multi-select"),
+    value: v.array(v.string()),
+  }),
+  v.strictObject({
+    version: v.literal(1),
+    type: v.literal("date"),
+    value: v.nullable(v.string()),
+  }),
+  v.strictObject({
+    version: v.literal(1),
+    type: v.literal("int"),
+    value: v.number(),
+    currency: v.nullable(v.string()),
+  }),
+  v.strictObject({
+    version: v.literal(1),
+    type: v.literal("clip"),
+    url: v.string(),
+    snippet: v.optional(v.string()),
+    citation: v.optional(v.string()),
+    jurisdiction: v.optional(v.string()),
+    sourceType: v.optional(v.string()),
+  }),
+]);
+
+/**
+ * One field row of a document version, shared by read_document's default and
+ * specific-version branches (both select `{ id, propertyId, content }`).
+ */
+const documentFieldProjection = v.strictObject({
+  // Field-row handle, no chat ref kind.
+  id: passthroughId(),
+  propertyId: chatRef("property"),
+  content: documentFieldContentProjection,
+});
+
+/** One version-history entry (`loadVersionHistory`, `document-tools.ts`). */
+const documentVersionEntryProjection = v.strictObject({
+  // Entity-version handle, no chat ref kind.
+  id: passthroughId(),
+  versionNumber: v.number(),
+  stamp: v.nullable(v.string()),
+  label: v.nullable(v.string()),
+  description: v.nullable(v.string()),
+  createdAt: v.string(),
+});
+
+// The output entity IS the request's own `entity_id` input in every branch;
+// hydration reuses the ref dehydrated on the way in.
+const readDocumentEntityId = () =>
+  chatEntityRef({ from: "inputEntity", param: "entity_id" });
+
+/**
+ * read_document, all three branches (`handleReadDocumentTool`,
+ * `document-tools.ts`): default (current version, optionally with version
+ * history), specific version, and version diff.
+ */
+const READ_DOCUMENT_PROJECTION: ChatProjectionSchema = v.union([
+  // Default branch: current version metadata + field values, plus the
+  // version-history page when `include_versions` was requested.
+  v.strictObject({
+    entityId: readDocumentEntityId(),
+    kind: v.string(),
+    name: v.string(),
+    fields: v.array(documentFieldProjection),
+    versions: v.optional(v.array(documentVersionEntryProjection)),
+    // Opaque `[versionNumber, entityVersionId]` cursor, not UUID-formatted.
+    versionsNextCursor: v.optional(v.nullable(passthroughId())),
+  }),
+  // version_id branch: one version's metadata + field values.
+  v.strictObject({
+    entityId: readDocumentEntityId(),
+    name: v.string(),
+    version: v.strictObject({
+      id: passthroughId(),
+      versionNumber: v.number(),
+      stamp: v.nullable(v.string()),
+      label: v.nullable(v.string()),
+      description: v.nullable(v.string()),
+      createdAt: v.string(),
+      fields: v.array(documentFieldProjection),
+    }),
+  }),
+  // compare_with_version_id branch: plain-text line diff between two versions.
+  v.strictObject({
+    entityId: readDocumentEntityId(),
+    name: v.string(),
+    diff: v.strictObject({
+      // Entity-version handles, no chat ref kind.
+      baseVersionId: passthroughId(),
+      targetVersionId: passthroughId(),
+      segments: v.array(
+        v.variant("kind", [
+          v.strictObject({
+            kind: v.picklist(["added", "removed", "unchanged", "gap"]),
+            text: v.string(),
+          }),
+          v.strictObject({
+            kind: v.literal("changed"),
+            runs: v.array(
+              v.strictObject({
+                kind: v.picklist(["same", "del", "ins"]),
+                text: v.string(),
+              }),
+            ),
+          }),
+        ]),
+      ),
+    }),
+  }),
+]);
 
 /**
  * Per-tool ref decision for every read tool in the MCP registry. Keyed by the
@@ -159,42 +381,13 @@ export const READ_TOOL_REF_FIELD_MAP = {
   },
 
   // --- Matters / contacts / content -----------------------------------------
+  // Converted: the projection schema above is the single output-side artifact;
+  // its strict parse fails closed on any handler field the schema does not
+  // declare, and the mediation lists are derived from its annotations.
   list_matters: {
     chatProjectable: true,
     inputRefs: [{ kind: "matter", param: "matter_id" }],
-    outputRefs: [
-      { kind: "matter", path: "matters[].id" },
-      { kind: "matter", path: "matter.id" },
-      { kind: "contact", path: "contacts[].contactId" },
-      {
-        kind: "entity",
-        // The overview handler's item field is `entityId`, not `id`
-        // (`readOverviewHandler` returns `{ entityId: e.id, ... }`); the path
-        // must match the actual key or the walker silently skips every slot
-        // and the raw entity uuid reaches the model.
-        path: "overview.recentEntities[].entityId",
-        // Detail mode: every recent entity belongs to the one matter this
-        // response describes, so its workspace is the payload's `matter.id`.
-        workspace: { from: "outputPath", path: "matter.id" },
-      },
-    ],
-    // Matter-contact link ids and workspace member (user) ids are handles
-    // with no chat ref kind; `nextCursor` is an opaque base64 cursor (not
-    // UUID-formatted).
-    passthroughIdPaths: [
-      "contacts[].workspaceContactId",
-      "members[].userId",
-      "nextCursor",
-    ],
-    // The overview feed's field/file plumbing ids exist for the web UI (mime
-    // icon, click-to-open); chat cannot act on them and they carry raw UUIDs
-    // whenever a recent entity has a primary field, which tripped the UUID
-    // backstop on every non-empty matter until they were stripped here.
-    stripPaths: [
-      "overview.recentEntities[].fieldId",
-      "overview.recentEntities[].propertyId",
-      "overview.recentEntities[].pdfFileId",
-    ],
+    projection: LIST_MATTERS_PROJECTION,
   },
   list_contacts: {
     chatProjectable: true,
@@ -263,46 +456,15 @@ export const READ_TOOL_REF_FIELD_MAP = {
     passthroughIdPaths: ["nextCursor"],
     stripPaths: [],
   },
+  // Converted: see READ_DOCUMENT_PROJECTION above. Beyond reproducing the
+  // previous hand lists, the schema strips the file-content plumbing UUIDs
+  // (`fields[].content.id`/`.pdfFileId` and the version-branch twins) that
+  // the hand entry never declared and that tripped the prod backstop on any
+  // document whose field held a file.
   read_document: {
     chatProjectable: true,
     inputRefs: [{ kind: "entity", param: "entity_id" }],
-    outputRefs: [
-      {
-        kind: "entity",
-        path: "entityId",
-        workspace: { from: "inputEntity", param: "entity_id" },
-      },
-      // Both field branches select `{ id, propertyId, content }`: the default
-      // branch via `readEntityByIdHandler` (`fields`), the specific-version
-      // branch via the `version_id` field query (`version.fields`). So
-      // `propertyId` is the property id at both paths, pinned by test.
-      { kind: "property", path: "fields[].propertyId" },
-      { kind: "property", path: "version.fields[].propertyId" },
-    ],
-    // Entity-version handles (`version.id`/`versions[].id`, the specific-
-    // version branch's own `version.fields[].id`, and the diff branch's
-    // `diff.baseVersionId`/`diff.targetVersionId`), field-row handles
-    // (`fields[].id`), and `versionsNextCursor`, an opaque
-    // `[versionNumber, entityVersionId]` cursor — none carry a chat ref kind.
-    passthroughIdPaths: [
-      "version.id",
-      "versions[].id",
-      "version.fields[].id",
-      "fields[].id",
-      "diff.baseVersionId",
-      "diff.targetVersionId",
-      "versionsNextCursor",
-    ],
-    // File-type field content embeds storage plumbing UUIDs (`content.id`,
-    // `content.pdfFileId`) chat cannot act on; every uploaded document has a
-    // file field, so leaving them undeclared tripped the UUID backstop on
-    // real matters. `fileName`/`mimeType` stay for the model.
-    stripPaths: [
-      "fields[].content.id",
-      "fields[].content.pdfFileId",
-      "version.fields[].content.id",
-      "version.fields[].content.pdfFileId",
-    ],
+    projection: READ_DOCUMENT_PROJECTION,
   },
   list_properties: {
     chatProjectable: true,

--- a/apps/api/src/handlers/chat/tools/registry-adapter/ref-mediation.ts
+++ b/apps/api/src/handlers/chat/tools/registry-adapter/ref-mediation.ts
@@ -12,11 +12,33 @@ import {
 
 import type {
   EntityWorkspaceSource,
-  InputRefParam,
   OutputRefField,
+  RefMediationLists,
+} from "./projection-schema";
+import { deriveRefMediationEntry } from "./projection-schema";
+import type {
+  InputRefParam,
+  RefMediationEntry,
   RegistryReadToolName,
 } from "./ref-field-map";
 import { READ_TOOL_REF_FIELD_MAP } from "./ref-field-map";
+
+/**
+ * The three output-side mediation lists for a map entry, whichever artifact
+ * carries them: derived from the entry's projection schema when the tool is
+ * converted (memoized in `deriveRefMediationEntry`), or the entry's own
+ * hand-written lists otherwise.
+ */
+export const resolveMediationLists = (
+  entry: RefMediationEntry,
+): RefMediationLists =>
+  entry.projection === undefined
+    ? {
+        outputRefs: entry.outputRefs,
+        passthroughIdPaths: entry.passthroughIdPaths,
+        stripPaths: entry.stripPaths,
+      }
+    : deriveRefMediationEntry(entry.projection);
 
 const UUID_REGEX =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/iu;
@@ -114,7 +136,8 @@ export const findUndeclaredUuidPath = ({
   payload: unknown;
 }): string | undefined =>
   findUndeclaredUuidPathIn({
-    passthroughIdPaths: READ_TOOL_REF_FIELD_MAP[toolName].passthroughIdPaths,
+    passthroughIdPaths: resolveMediationLists(READ_TOOL_REF_FIELD_MAP[toolName])
+      .passthroughIdPaths,
     payload,
   });
 
@@ -492,7 +515,8 @@ export const hydrateOutputRefs = ({
   dehydration: DehydratedInput;
 }): unknown =>
   hydrateRefs({
-    outputRefs: READ_TOOL_REF_FIELD_MAP[toolName].outputRefs,
+    outputRefs: resolveMediationLists(READ_TOOL_REF_FIELD_MAP[toolName])
+      .outputRefs,
     output,
     refRegistry,
     dehydration,

--- a/apps/api/src/handlers/chat/tools/registry-adapter/registry-projection-contract.test.ts
+++ b/apps/api/src/handlers/chat/tools/registry-adapter/registry-projection-contract.test.ts
@@ -12,6 +12,7 @@ import { toSafeDbMock } from "@/api/tests/scoped-db-mock";
 
 import type { RegistryReadToolName } from "./ref-field-map";
 import { READ_TOOL_REF_FIELD_MAP } from "./ref-field-map";
+import { resolveMediationLists } from "./ref-mediation";
 
 /**
  * Contract corpus over every chat-projectable read tool: run the real MCP
@@ -1261,8 +1262,9 @@ describe("registry projection contract", () => {
 
   test("every declared outputRef path is exercised by some fixture call", () => {
     for (const [toolName, calls] of corpusEntries()) {
-      const entry = READ_TOOL_REF_FIELD_MAP[toolName];
-      const declared = entry.outputRefs.map((field) => field.path).sort();
+      // Hand-written or schema-derived, whichever artifact the entry carries.
+      const lists = resolveMediationLists(READ_TOOL_REF_FIELD_MAP[toolName]);
+      const declared = lists.outputRefs.map((field) => field.path).sort();
       const exercised = [
         ...new Set(calls.flatMap((call) => call.expectRefPaths)),
       ].sort();
@@ -1325,7 +1327,9 @@ describe("registry projection contract", () => {
         // merely tolerated by the backstop. This stays meaningful even if a
         // path were ever declared as both strip and passthrough, where a
         // broken strip would otherwise survive the ok result.
-        for (const path of READ_TOOL_REF_FIELD_MAP[toolName].stripPaths) {
+        for (const path of resolveMediationLists(
+          READ_TOOL_REF_FIELD_MAP[toolName],
+        ).stripPaths) {
           expect(
             readPathValues(payload, path).length,
             `${toolName} (${call.mode}): declared stripPath "${path}" must ` +

--- a/apps/api/src/handlers/chat/tools/registry-adapter/run-registry-tool.test.ts
+++ b/apps/api/src/handlers/chat/tools/registry-adapter/run-registry-tool.test.ts
@@ -18,7 +18,8 @@ void mock.module("@/api/lib/analytics/capture", () => ({
 
 const { buildMcpContextFromChat } = await import("./mcp-chat-context");
 const { containsRawUuid, dehydrateInputRefs } = await import("./ref-mediation");
-const { runRegistryReadTool } = await import("./run-registry-tool");
+const { PROJECTION_SCHEMA_FAILURE_MESSAGE, runRegistryReadTool } =
+  await import("./run-registry-tool");
 
 const WS_UUID = "0dc54d0c-10d7-501d-897e-e801dbd0998c";
 const OTHER_WS_UUID = "4e919658-a448-5354-8e3a-e99911214d2c";
@@ -165,6 +166,138 @@ describe("runRegistryReadTool", () => {
     );
     const [, telemetryContext] = captureErrorMock.mock.calls.at(0) ?? [];
     expect(JSON.stringify(telemetryContext)).not.toContain(OTHER_WS_UUID);
+  });
+
+  // A scopedDb whose relational query double serves read_document's two
+  // entity reads (workspace resolution, then the current-version load) from
+  // one superset row, mirroring the contract corpus' fixture style.
+  const readDocumentScopedDb = (fieldRows: readonly unknown[]): ScopedDb => {
+    const tx = {
+      query: {
+        entities: {
+          findFirst: async () => ({
+            workspaceId: WS_UUID,
+            kind: "document",
+            name: "NDA draft",
+            currentVersion: { id: "version-1", fields: fieldRows },
+          }),
+        },
+      },
+    };
+    return asTestRaw<ScopedDb>(
+      async (run: (transaction: unknown) => unknown) => await run(tx),
+    );
+  };
+
+  const FIELD_UUID = "37286c24-6145-572e-ad27-15a1d4454d59";
+  const PROPERTY_UUID = "6111c8e9-1404-5b6f-8a9a-0e3a93e8179a";
+  const ENTITY_UUID = "c09ec856-d945-5ecc-82e3-bb5382165f34";
+
+  test("strict projection parse refuses an undeclared handler field before it can flow", async () => {
+    const registry = createChatRefRegistry();
+    const entityRef = registry.toEntityRef({
+      entityId: toSafeId<"entity">(ENTITY_UUID),
+      workspaceId: toSafeId<"workspace">(WS_UUID),
+    });
+    // Doctored field row: `extractorRunId` is a handler field nobody
+    // classified in the projection schema, carrying a UUID. Unlike the
+    // runtime backstop (which only fires on UUID-shaped values), the strict
+    // parse refuses the undeclared KEY itself, so the class is closed even
+    // for payload slots that happen to be null or non-UUID today.
+    const result = await runRegistryReadTool({
+      args: { entity_id: entityRef },
+      context: buildContext({
+        scopedDb: readDocumentScopedDb([
+          {
+            id: FIELD_UUID,
+            propertyId: PROPERTY_UUID,
+            content: { version: 1, type: "text", value: "Body text" },
+            extractorRunId: OTHER_WS_UUID,
+          },
+        ]),
+      }),
+      refRegistry: registry,
+      toolName: "read_document",
+    });
+
+    expect(Result.isError(result)).toBe(true);
+    if (Result.isError(result)) {
+      expect(result.error.kind).toBe("server-defect");
+      expect(result.error.message).toBe(PROJECTION_SCHEMA_FAILURE_MESSAGE);
+      expect(result.error.message).not.toContain(OTHER_WS_UUID);
+    }
+    // Telemetry carries the offending path(s), never the refused value.
+    expect(captureErrorMock).toHaveBeenCalledWith(
+      expect.objectContaining({ message: PROJECTION_SCHEMA_FAILURE_MESSAGE }),
+      expect.objectContaining({
+        source: "run-registry-tool",
+        toolName: "read_document",
+        paths: expect.stringContaining("fields[].extractorRunId"),
+      }),
+    );
+    const [, telemetryContext] = captureErrorMock.mock.calls.at(0) ?? [];
+    expect(JSON.stringify(telemetryContext)).not.toContain(OTHER_WS_UUID);
+  });
+
+  test("file-content plumbing UUIDs are stripped from the projected payload", async () => {
+    const registry = createChatRefRegistry();
+    const entityRef = registry.toEntityRef({
+      entityId: toSafeId<"entity">(ENTITY_UUID),
+      workspaceId: toSafeId<"workspace">(WS_UUID),
+    });
+    // The second prod backstop trip: a file field's `content.id`/
+    // `content.pdfFileId` UUIDs. The projection schema declares them as
+    // stripped, so the call succeeds and the plumbing never reaches the model.
+    const result = await runRegistryReadTool({
+      args: { entity_id: entityRef },
+      context: buildContext({
+        scopedDb: readDocumentScopedDb([
+          {
+            id: FIELD_UUID,
+            propertyId: PROPERTY_UUID,
+            content: {
+              version: 1,
+              type: "file",
+              id: OTHER_WS_UUID,
+              fileName: "nda.docx",
+              mimeType:
+                "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+              sizeBytes: 1234,
+              encrypted: false,
+              sha256Hex: "a".repeat(64),
+              pdfFileId: OTHER_WS_UUID,
+              pdfDerivative: { status: "ready" },
+              thumbnailFileId: null,
+            },
+          },
+        ]),
+      }),
+      refRegistry: registry,
+      toolName: "read_document",
+    });
+
+    expect(Result.isError(result)).toBe(false);
+    expect(result.unwrap()).toEqual({
+      entityId: entityRef,
+      kind: "document",
+      name: "NDA draft",
+      fields: [
+        {
+          // Field-row handle: declared passthrough, survives verbatim.
+          id: FIELD_UUID,
+          propertyId: "prop_1",
+          content: {
+            version: 1,
+            type: "file",
+            fileName: "nda.docx",
+            mimeType:
+              "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            sizeBytes: 1234,
+            encrypted: false,
+          },
+        },
+      ],
+    });
   });
 
   test("refuses a read tool the ref map keeps off the chat surface", async () => {

--- a/apps/api/src/handlers/chat/tools/registry-adapter/run-registry-tool.ts
+++ b/apps/api/src/handlers/chat/tools/registry-adapter/run-registry-tool.ts
@@ -22,12 +22,17 @@ import { STELLA_TOOL_HANDLERS } from "@/api/mcp/stella-tools";
 import { TEMPLATE_TOOL_HANDLERS } from "@/api/mcp/template-tools";
 import type { McpToolHandler } from "@/api/mcp/tool-types";
 
-import type { RegistryReadToolName } from "./ref-field-map";
+import { applyProjectionSchema } from "./projection-schema";
+import type {
+  RegistryReadToolName,
+  RegistryRefFieldMapEntry,
+} from "./ref-field-map";
 import { READ_TOOL_REF_FIELD_MAP } from "./ref-field-map";
 import {
   dehydrateInputRefs,
-  findUndeclaredUuidPath,
-  hydrateOutputRefs,
+  findUndeclaredUuidPathIn,
+  hydrateRefs,
+  resolveMediationLists,
   stripDeclaredPaths,
 } from "./ref-mediation";
 
@@ -89,6 +94,57 @@ export const REF_PROJECTION_FAILURE_MESSAGE =
   "The tool result contained an internal identifier the chat projection " +
   "could not map to a reference. This is a server-side defect, not a " +
   "problem with your input; do not retry this call.";
+
+/**
+ * Surfaced to the model when a converted tool's payload fails its projection
+ * schema's strict parse: a handler emitted a field nobody classified (or a
+ * declared field changed shape). Same fail-closed semantics as
+ * `REF_PROJECTION_FAILURE_MESSAGE`; the parse fires before strip/hydrate, so
+ * the undeclared field never reaches the model by construction.
+ */
+export const PROJECTION_SCHEMA_FAILURE_MESSAGE =
+  "The tool result did not match the shape the chat projection declares " +
+  "for this tool. This is a server-side defect, not a problem with your " +
+  "input; do not retry this call.";
+
+/**
+ * Strict-parse a converted tool's payload against its projection schema; an
+ * unconverted entry passes through untouched. Shared by the read and write
+ * orchestrators. The failure carries only issue paths (never values) to
+ * telemetry, mirroring the UUID backstop's no-leak discipline.
+ */
+export const applyEntryProjection = ({
+  entry,
+  payload,
+  source,
+  toolName,
+}: {
+  entry: RegistryRefFieldMapEntry;
+  payload: unknown;
+  source: "run-registry-tool" | "run-registry-write-tool";
+  toolName: string;
+}): Result<unknown, ChatToolError> => {
+  if (entry.projection === undefined) {
+    return Result.ok(payload);
+  }
+  const projected = applyProjectionSchema({
+    payload,
+    schema: entry.projection,
+  });
+  if (Result.isError(projected)) {
+    const error = new ChatToolError({
+      kind: "server-defect",
+      message: PROJECTION_SCHEMA_FAILURE_MESSAGE,
+    });
+    captureError(error, {
+      source,
+      toolName,
+      paths: projected.error.issuePaths.join(", "),
+    });
+    return Result.err(error);
+  }
+  return Result.ok(projected.value);
+};
 
 const MCP_CODE_TO_CHAT_KIND = {
   validation_error: "invalid-input",
@@ -189,7 +245,8 @@ export const runRegistryReadTool = async ({
   context,
   refRegistry,
 }: RunRegistryReadToolProps): Promise<Result<unknown, ChatToolError>> => {
-  if (!READ_TOOL_REF_FIELD_MAP[toolName].chatProjectable) {
+  const entry = READ_TOOL_REF_FIELD_MAP[toolName];
+  if (!entry.chatProjectable) {
     return Result.err(
       new ChatToolError({
         kind: "unavailable",
@@ -237,15 +294,30 @@ export const runRegistryReadTool = async ({
     return Result.err(payload.error);
   }
 
-  const stripped = stripDeclaredPaths({
-    output: payload.value,
-    stripPaths: READ_TOOL_REF_FIELD_MAP[toolName].stripPaths,
+  // Converted tools: strict-parse the payload against the projection schema
+  // BEFORE strip/hydrate. An unknown key — a field nobody classified — fails
+  // closed here, so an undeclared field is structurally unable to reach the
+  // model; the error carries only issue paths (never values) to telemetry.
+  const projected = applyEntryProjection({
+    entry,
+    payload: payload.value,
+    source: "run-registry-tool",
+    toolName,
   });
-  const hydrated = hydrateOutputRefs({
+  if (Result.isError(projected)) {
+    return Result.err(projected.error);
+  }
+
+  const mediation = resolveMediationLists(entry);
+  const stripped = stripDeclaredPaths({
+    output: projected.value,
+    stripPaths: mediation.stripPaths,
+  });
+  const hydrated = hydrateRefs({
     dehydration: dehydrated.value,
     output: stripped,
+    outputRefs: mediation.outputRefs,
     refRegistry,
-    toolName,
   });
 
   // Runtime backstop for the "no tenant UUID reaches the model" invariant: the
@@ -256,7 +328,10 @@ export const runRegistryReadTool = async ({
   // fails closed instead of leaking; the error message never repeats the
   // payload or the path, so it cannot itself leak the value it is refusing,
   // while the offending path (never the value) still reaches telemetry.
-  const offendingPath = findUndeclaredUuidPath({ toolName, payload: hydrated });
+  const offendingPath = findUndeclaredUuidPathIn({
+    passthroughIdPaths: mediation.passthroughIdPaths,
+    payload: hydrated,
+  });
   if (offendingPath !== undefined) {
     const error = new ChatToolError({
       kind: "server-defect",

--- a/apps/api/src/handlers/chat/tools/registry-adapter/run-registry-write-tool.ts
+++ b/apps/api/src/handlers/chat/tools/registry-adapter/run-registry-write-tool.ts
@@ -24,9 +24,11 @@ import {
   dehydrateRefs,
   findUndeclaredUuidPathIn,
   hydrateRefs,
+  resolveMediationLists,
   stripDeclaredPaths,
 } from "./ref-mediation";
 import {
+  applyEntryProjection,
   classifyRegistryErrorKind,
   DEFAULT_TOOL_ERROR_MESSAGE,
   firstTextContent,
@@ -179,14 +181,29 @@ export const runRegistryWriteTool = async ({
     return Result.err(payload.error);
   }
 
+  // Same strict-parse gate as the read path: a converted write tool's payload
+  // must match its projection schema before strip/hydrate, so an undeclared
+  // field fails closed by construction. No write tool is converted yet; the
+  // gate is a pass-through until a write entry gains a `projection`.
+  const projected = applyEntryProjection({
+    entry,
+    payload: payload.value,
+    source: "run-registry-write-tool",
+    toolName,
+  });
+  if (Result.isError(projected)) {
+    return Result.err(projected.error);
+  }
+
+  const mediation = resolveMediationLists(entry);
   const stripped = stripDeclaredPaths({
-    output: payload.value,
-    stripPaths: entry.stripPaths,
+    output: projected.value,
+    stripPaths: mediation.stripPaths,
   });
   const hydrated = hydrateRefs({
     dehydration: dehydrated.value,
     output: stripped,
-    outputRefs: entry.outputRefs,
+    outputRefs: mediation.outputRefs,
     refRegistry,
   });
 
@@ -195,7 +212,7 @@ export const runRegistryWriteTool = async ({
   // leaked. The message never repeats the payload or path, so it cannot itself
   // leak the value; the offending path (never the value) reaches telemetry.
   const offendingPath = findUndeclaredUuidPathIn({
-    passthroughIdPaths: entry.passthroughIdPaths,
+    passthroughIdPaths: mediation.passthroughIdPaths,
     payload: hydrated,
   });
   if (offendingPath !== undefined) {


### PR DESCRIPTION
The chat registry projection's per-tool field decisions (ref hydration, passthrough ids, stripped fields) have lived in hand-maintained path lists beside the handlers they describe. This PR introduces per-tool projection schemas as the single artifact for both shape and semantics, and converts `list_matters` and `read_document`.

- `projection-schema.ts`: field wrappers (`chatRef`, `chatEntityRef`, `passthroughId`, `strippedField`) attach chat semantics via `v.metadata`; a memoized AST walker derives the exact ref-mediation lists in the existing path grammar; `applyProjectionSchema` strict-parses the payload before strip/hydrate, so a field nobody classified cannot flow through — parse issues surface as structural dot-paths, never values. A depth-capped renderer appends a `Returns: {…}` line to converted tools' provider-visible descriptions, so output shapes are documented where the model reads them.\n- A converted entry cannot also carry hand lists (mutually exclusive at the type level), removing the possibility of stale duplicates.\n- Derived lists are pinned equal to the previous hand-written entries for both tools, with `read_document` additionally stripping the file-content plumbing fields (storage ids, digests, derivative statuses) that chat has no use for — a superset of #1703.\n- Cost: +0.28% types / +0.29% instantiations on apps/api versus main; no baseline reseed.\n\nRemaining tools keep their hand lists and migrate incrementally; the projection contract corpus covers both forms unchanged.