### PR TITLE
feat(inspector): dock DOCX find in the pane

### DIFF
--- a/apps/web/src/components/docx/docx-browser-editor.tsx
+++ b/apps/web/src/components/docx/docx-browser-editor.tsx
@@ -61,8 +61,10 @@ import {
 } from "@/components/docx-preview-zoom";
 import { DocxEditor } from "@/components/docx/app-docx-editor";
 import type { DocxComments } from "@/components/docx/app-docx-editor";
+import { DocxFindBar } from "@/components/docx/docx-find-bar";
 import { DocxLoadingShell } from "@/components/docx/docx-loading-shell";
 import { useDocxBlockScroll } from "@/components/docx/use-docx-block-scroll";
+import { useDocxFind } from "@/components/docx/use-docx-find";
 import { useFolioCollaborationSession } from "@/components/docx/use-folio-collaboration-session";
 import { useSyncDocxSuggestions } from "@/components/docx/use-sync-docx-suggestions";
 import {
@@ -122,6 +124,9 @@ const colorFromStableId = (value: string) => {
   return `#${color.toString(16).padStart(6, "0")}`;
 };
 
+/** The inspector docks the editor beside the page; full view owns the page. */
+export type DocxEditorSurface = "fullView" | "inspector";
+
 type DocxBrowserEditorBaseProps = {
   workspaceId: string;
   entityId: string;
@@ -146,6 +151,8 @@ type DocxBrowserEditorBaseProps = {
   actionsRef?: RefObject<DocxBrowserEditorActions | null> | undefined;
   actionBarControls?: ReactNode | undefined;
   showActionBar?: boolean | undefined;
+  /** Which chrome hosts the editor; selects the find-bar behavior. */
+  surface: DocxEditorSurface;
   errorFallback?: ((props: { reset: () => void }) => ReactNode) | undefined;
   onError?: ((error: Error) => void) | undefined;
 };
@@ -209,6 +216,7 @@ const DocxBrowserEditorContent = (props: DocxBrowserEditorProps) => {
     onScrollTopChange,
     scaleOffset = 0,
     showActionBar = true,
+    surface,
   } = props;
   const editorRef = useRef<DocxEditorRef>(null);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -625,6 +633,13 @@ const DocxBrowserEditorContent = (props: DocxBrowserEditorProps) => {
     () => composeRefs(containerRef, fitZoomRef),
     [fitZoomRef],
   );
+  // Full view leaves Cmd+F to Folio's own dialog, which has the whole
+  // viewport to sit in; only the docked inspector needs its own bar.
+  const find = useDocxFind({
+    containerRef,
+    editorRef,
+    enabled: surface === "inspector",
+  });
   const t = useTranslations();
   /* eslint-disable react/react-compiler -- optimistic preview and its derived query data are deliberately carried across the finalize/refetch window in a mutable ref */
   const optimisticPreview = optimisticPreviewRef.current;
@@ -1582,6 +1597,7 @@ const DocxBrowserEditorContent = (props: DocxBrowserEditorProps) => {
       ref={composedContainerRef}
       className="flex h-full w-full min-w-0 flex-col"
     >
+      {find.isOpen && <DocxFindBar find={find} />}
       {/* Folio editor with AI overlay */}
       <div
         className="min-w-0 flex-1 overflow-hidden"

--- a/apps/web/src/components/docx/docx-find-bar.tsx
+++ b/apps/web/src/components/docx/docx-find-bar.tsx
@@ -1,0 +1,89 @@
+import { useRef } from "react";
+
+import { SearchIcon, XIcon } from "lucide-react";
+import { useTranslations } from "use-intl";
+
+import { Button } from "@stll/ui/components/button";
+import { Input } from "@stll/ui/components/input";
+
+import { SearchMatchControls } from "@/components/search-match-controls";
+import { useExternalSyncEffect } from "@/hooks/use-effect";
+
+import type { DocxFind } from "./use-docx-find";
+
+type DocxFindBarProps = {
+  find: DocxFind;
+};
+
+/**
+ * Find bar docked at the top of the inspector's DOCX pane, matching the
+ * external-reference panel's bar rather than floating over the page.
+ */
+export const DocxFindBar = ({ find }: DocxFindBarProps) => {
+  const t = useTranslations();
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const hasQuery = find.query.trim().length > 0;
+
+  // Mount, plus every later press of the shortcut, hands focus back to the
+  // query and selects what is there so retyping replaces it.
+  useExternalSyncEffect(() => {
+    const input = inputRef.current;
+    if (!input) {
+      return;
+    }
+    input.focus();
+    input.select();
+  }, [find.focusSeq]);
+
+  return (
+    <div className="flex h-10 shrink-0 items-center gap-1 border-b px-2">
+      <SearchIcon className="text-muted-foreground size-3.5 shrink-0" />
+      <Input
+        aria-label={t("folio.findReplace.findText")}
+        className="h-7 flex-1 rounded-md"
+        nativeInput
+        onChange={(event) => {
+          find.setQuery(event.currentTarget.value);
+        }}
+        onKeyDown={(event) => {
+          if (event.key === "Escape") {
+            event.preventDefault();
+            find.close();
+            return;
+          }
+          if (event.key !== "Enter") {
+            return;
+          }
+          event.preventDefault();
+          find.step(event.shiftKey ? "previous" : "next");
+        }}
+        placeholder={t("folio.findReplace.findPlaceholder")}
+        ref={inputRef}
+        size="sm"
+        type="search"
+        value={find.query}
+      />
+      {hasQuery && (
+        <SearchMatchControls
+          activeIndex={find.activeIndex}
+          matchCount={find.summary.count}
+          onNext={() => {
+            find.step("next");
+          }}
+          onPrevious={() => {
+            find.step("previous");
+          }}
+          truncated={find.summary.truncated}
+        />
+      )}
+      <Button
+        aria-label={t("folio.findReplace.close")}
+        onClick={find.close}
+        size="icon-xs"
+        variant="ghost"
+      >
+        <XIcon className="size-3.5" />
+      </Button>
+    </div>
+  );
+};

--- a/apps/web/src/components/docx/docx-find.logic.test.ts
+++ b/apps/web/src/components/docx/docx-find.logic.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "bun:test";
+
+import { classifyDocxFindKeydown } from "./docx-find.logic";
+
+const keyEvent = (
+  key: string,
+  modifiers: Partial<{
+    altKey: boolean;
+    ctrlKey: boolean;
+    metaKey: boolean;
+    shiftKey: boolean;
+  }> = {},
+) => ({
+  altKey: false,
+  ctrlKey: false,
+  key,
+  metaKey: false,
+  shiftKey: false,
+  ...modifiers,
+});
+
+describe("classifyDocxFindKeydown", () => {
+  test("claims the bare find shortcut on both platforms", () => {
+    for (const modifiers of [{ metaKey: true }, { ctrlKey: true }]) {
+      expect(
+        classifyDocxFindKeydown({
+          event: keyEvent("f", modifiers),
+          isOpen: false,
+        }),
+      ).toEqual({ type: "openFind" });
+    }
+  });
+
+  test("claims the shortcut regardless of key case", () => {
+    expect(
+      classifyDocxFindKeydown({
+        event: keyEvent("F", { metaKey: true }),
+        isOpen: false,
+      }),
+    ).toEqual({ type: "openFind" });
+  });
+
+  // Suppressing Folio's dialog costs a `stopPropagation`, so anything this
+  // bar does not handle itself must fall through untouched.
+  test("leaves every other modifier combination to Folio", () => {
+    const unclaimed = [
+      keyEvent("f"),
+      keyEvent("f", { altKey: true, metaKey: true }),
+      keyEvent("f", { metaKey: true, shiftKey: true }),
+      keyEvent("f", { altKey: true, ctrlKey: true }),
+      keyEvent("g", { metaKey: true }),
+    ];
+    for (const event of unclaimed) {
+      expect(classifyDocxFindKeydown({ event, isOpen: true })).toEqual({
+        type: "none",
+      });
+    }
+  });
+
+  test("takes Escape only while the bar is open", () => {
+    expect(
+      classifyDocxFindKeydown({ event: keyEvent("Escape"), isOpen: true }),
+    ).toEqual({ type: "closeFind" });
+    expect(
+      classifyDocxFindKeydown({ event: keyEvent("Escape"), isOpen: false }),
+    ).toEqual({ type: "none" });
+  });
+});

--- a/apps/web/src/components/docx/docx-find.logic.test.ts
+++ b/apps/web/src/components/docx/docx-find.logic.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "bun:test";
 
-import { classifyDocxFindKeydown } from "./docx-find.logic";
+import {
+  classifyDocxFindKeydown,
+  resetOpenDocxFindQuery,
+} from "./docx-find.logic";
 
 const keyEvent = (
   key: string,
@@ -48,6 +51,7 @@ describe("classifyDocxFindKeydown", () => {
       keyEvent("f", { altKey: true, metaKey: true }),
       keyEvent("f", { metaKey: true, shiftKey: true }),
       keyEvent("f", { altKey: true, ctrlKey: true }),
+      keyEvent("f", { ctrlKey: true, metaKey: true }),
       keyEvent("g", { metaKey: true }),
     ];
     for (const event of unclaimed) {
@@ -64,5 +68,28 @@ describe("classifyDocxFindKeydown", () => {
     expect(
       classifyDocxFindKeydown({ event: keyEvent("Escape"), isOpen: false }),
     ).toEqual({ type: "none" });
+  });
+});
+
+describe("resetOpenDocxFindQuery", () => {
+  test("invalidates stale navigation state before the new search runs", () => {
+    const state = resetOpenDocxFindQuery(
+      {
+        status: "open",
+        activeIndex: 2,
+        focusSeq: 4,
+        query: "old query",
+        summary: { count: 5, truncated: true },
+      },
+      "new query",
+    );
+
+    expect(state).toEqual({
+      status: "open",
+      activeIndex: 0,
+      focusSeq: 4,
+      query: "new query",
+      summary: { count: 0, truncated: false },
+    });
   });
 });

--- a/apps/web/src/components/docx/docx-find.logic.ts
+++ b/apps/web/src/components/docx/docx-find.logic.ts
@@ -1,3 +1,5 @@
+import type { SearchMatchSummary } from "@/lib/search-match-navigation";
+
 /**
  * Keyboard classification for the inspector's docked DOCX find bar.
  *
@@ -21,6 +23,30 @@ type ClassifyDocxFindKeydownOptions = {
   isOpen: boolean;
 };
 
+export type OpenDocxFindState = {
+  status: "open";
+  activeIndex: number;
+  focusSeq: number;
+  query: string;
+  summary: SearchMatchSummary;
+};
+
+export const EMPTY_DOCX_FIND_SUMMARY = {
+  count: 0,
+  truncated: false,
+} as const satisfies SearchMatchSummary;
+
+/** Invalidate navigation immediately while the replacement query debounces. */
+export const resetOpenDocxFindQuery = (
+  state: OpenDocxFindState,
+  query: string,
+): OpenDocxFindState => ({
+  ...state,
+  activeIndex: 0,
+  query,
+  summary: EMPTY_DOCX_FIND_SUMMARY,
+});
+
 export type DocxFindKeydownAction =
   | { type: "closeFind" }
   | { type: "none" }
@@ -38,7 +64,7 @@ export const classifyDocxFindKeydown = ({
 
   // Claim the bare Cmd/Ctrl+F only. Every other combination (Cmd+Alt+F,
   // Cmd+Shift+F) stays with Folio and the browser.
-  if (event.altKey || event.shiftKey) {
+  if (event.altKey || event.shiftKey || (event.metaKey && event.ctrlKey)) {
     return NO_ACTION;
   }
   if (!event.metaKey && !event.ctrlKey) {

--- a/apps/web/src/components/docx/docx-find.logic.ts
+++ b/apps/web/src/components/docx/docx-find.logic.ts
@@ -1,0 +1,48 @@
+/**
+ * Keyboard classification for the inspector's docked DOCX find bar.
+ *
+ * Folio ships its own find/replace dialog on a document-level `keydown`
+ * listener. In the inspector that dialog is a viewport overlay pushed clear
+ * of the docked pane, so it lands on top of unrelated page content. The
+ * inspector claims the shortcut instead; this module owns the decision of
+ * which key events it may claim, so the suppression stays testable.
+ */
+
+type DocxFindKeyEvent = {
+  altKey: boolean;
+  ctrlKey: boolean;
+  key: string;
+  metaKey: boolean;
+  shiftKey: boolean;
+};
+
+type ClassifyDocxFindKeydownOptions = {
+  event: DocxFindKeyEvent;
+  isOpen: boolean;
+};
+
+export type DocxFindKeydownAction =
+  | { type: "closeFind" }
+  | { type: "none" }
+  | { type: "openFind" };
+
+const NO_ACTION = { type: "none" } as const satisfies DocxFindKeydownAction;
+
+export const classifyDocxFindKeydown = ({
+  event,
+  isOpen,
+}: ClassifyDocxFindKeydownOptions): DocxFindKeydownAction => {
+  if (event.key === "Escape") {
+    return isOpen ? { type: "closeFind" } : NO_ACTION;
+  }
+
+  // Claim the bare Cmd/Ctrl+F only. Every other combination (Cmd+Alt+F,
+  // Cmd+Shift+F) stays with Folio and the browser.
+  if (event.altKey || event.shiftKey) {
+    return NO_ACTION;
+  }
+  if (!event.metaKey && !event.ctrlKey) {
+    return NO_ACTION;
+  }
+  return event.key.toLowerCase() === "f" ? { type: "openFind" } : NO_ACTION;
+};

--- a/apps/web/src/components/docx/use-docx-find.ts
+++ b/apps/web/src/components/docx/use-docx-find.ts
@@ -1,0 +1,257 @@
+import { useCallback, useRef, useState } from "react";
+import type { RefObject } from "react";
+
+import { useDebouncedCallback } from "use-debounce";
+
+import { resolveFindMatchRange } from "@stll/folio-core/prosemirror/findReplaceSelection";
+import type { FindMatch } from "@stll/folio-core/utils/findReplace";
+import type { DocxEditorRef } from "@stll/folio-react";
+
+import { useExternalSyncEffect } from "@/hooks/use-effect";
+import { findDocumentSearchResult } from "@/lib/document-search";
+import {
+  getAdjacentSearchMatchIndex,
+  MAX_SEARCH_PREVIEW_MATCHES,
+} from "@/lib/search-match-navigation";
+import type { SearchMatchSummary } from "@/lib/search-match-navigation";
+
+import { classifyDocxFindKeydown } from "./docx-find.logic";
+
+const SEARCH_DEBOUNCE_MS = 150;
+
+const EMPTY_SUMMARY: SearchMatchSummary = { count: 0, truncated: false };
+
+type DocxFindState =
+  | { status: "closed" }
+  | {
+      status: "open";
+      activeIndex: number;
+      focusSeq: number;
+      query: string;
+      summary: SearchMatchSummary;
+    };
+
+const CLOSED_STATE: DocxFindState = { status: "closed" };
+
+export type DocxFind = {
+  activeIndex: number;
+  close: () => void;
+  /**
+   * Bumped every time the shortcut is pressed. The bar owns its input, so it
+   * watches this to take (or retake) focus.
+   */
+  focusSeq: number;
+  isOpen: boolean;
+  query: string;
+  setQuery: (query: string) => void;
+  step: (direction: "next" | "previous") => void;
+  summary: SearchMatchSummary;
+};
+
+type UseDocxFindOptions = {
+  /** Pane root: bounds the visibility gate and the Escape shortcut. */
+  containerRef: RefObject<HTMLElement | null>;
+  editorRef: RefObject<DocxEditorRef | null>;
+  enabled: boolean;
+};
+
+/**
+ * Cmd/Ctrl+F for a DOCX rendered in the inspector pane.
+ *
+ * Folio's built-in dialog is a viewport overlay positioned clear of the
+ * docked inspector, which puts it over unrelated page content. This hook
+ * claims the shortcut before Folio's document-level listener sees it and
+ * drives a docked bar instead, reusing the passage-highlight search path
+ * the PDF peek viewer already uses.
+ */
+export const useDocxFind = ({
+  containerRef,
+  editorRef,
+  enabled,
+}: UseDocxFindOptions): DocxFind => {
+  const [state, setState] = useState<DocxFindState>(CLOSED_STATE);
+  const matchesRef = useRef<readonly FindMatch[]>([]);
+
+  const highlightMatch = (index: number) => {
+    const editor = editorRef.current;
+    const pagedEditor = editor?.getEditorRef();
+    const view = pagedEditor?.getView();
+    if (!pagedEditor || !view) {
+      return;
+    }
+
+    const match = matchesRef.current.at(index);
+    const range = match ? resolveFindMatchRange(view.state.doc, match) : null;
+    if (!range) {
+      pagedEditor.setPassageHighlight(null);
+      return;
+    }
+
+    pagedEditor.setPassageHighlight(range);
+    pagedEditor.scrollToPosition(range.from);
+  };
+
+  const clearHighlight = () => {
+    editorRef.current?.getEditorRef()?.setPassageHighlight(null);
+  };
+
+  const runSearch = (query: string) => {
+    const editor = editorRef.current;
+    if (!editor) {
+      return;
+    }
+
+    // The view is created lazily; the search needs it to resolve match
+    // offsets onto ProseMirror positions.
+    editor.ensureEditorView({ focus: false });
+
+    const trimmed = query.trim();
+    if (trimmed.length === 0) {
+      matchesRef.current = [];
+      clearHighlight();
+      setState((prev) =>
+        prev.status === "open"
+          ? { ...prev, activeIndex: 0, summary: EMPTY_SUMMARY }
+          : prev,
+      );
+      return;
+    }
+
+    const result = findDocumentSearchResult({
+      document: editor.getDocument(),
+      maxMatches: MAX_SEARCH_PREVIEW_MATCHES,
+      searchText: trimmed,
+    });
+    matchesRef.current = result.matches;
+    setState((prev) =>
+      prev.status === "open"
+        ? {
+            ...prev,
+            activeIndex: 0,
+            summary: {
+              count: result.matches.length,
+              truncated: result.truncated,
+            },
+          }
+        : prev,
+    );
+    highlightMatch(0);
+  };
+
+  const debouncedSearch = useDebouncedCallback(runSearch, SEARCH_DEBOUNCE_MS);
+
+  const setQuery = (query: string) => {
+    if (state.status !== "open") {
+      return;
+    }
+    setState({ ...state, query });
+    debouncedSearch(query);
+  };
+
+  // Stable identity: the keydown subscription below depends on it.
+  const close = useCallback(() => {
+    debouncedSearch.cancel();
+    matchesRef.current = [];
+    editorRef.current?.getEditorRef()?.setPassageHighlight(null);
+    setState(CLOSED_STATE);
+  }, [debouncedSearch, editorRef]);
+
+  const step = (direction: "next" | "previous") => {
+    if (state.status !== "open") {
+      return;
+    }
+    if (state.summary.count === 0) {
+      // Enter pressed inside the debounce window: run the pending search now
+      // so the first press lands on the first match.
+      debouncedSearch.flush();
+      return;
+    }
+    const activeIndex = getAdjacentSearchMatchIndex({
+      activeIndex: state.activeIndex,
+      direction,
+      matchCount: state.summary.count,
+    });
+    setState({ ...state, activeIndex });
+    highlightMatch(activeIndex);
+  };
+
+  const isOpen = state.status === "open";
+
+  useExternalSyncEffect(() => {
+    if (!enabled) {
+      return undefined;
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      const container = containerRef.current;
+      // `offsetParent` is null while an inspector tab is CSS-hidden, which is
+      // how the pane keeps background tabs mounted. Only the visible editor
+      // may claim the shortcut.
+      if (!container || container.offsetParent === null) {
+        return;
+      }
+
+      const action = classifyDocxFindKeydown({ event, isOpen });
+      if (action.type === "none") {
+        return;
+      }
+
+      if (action.type === "closeFind") {
+        // Leave Escape to whatever is layered over the pane (dialogs render
+        // in portals outside it).
+        if (
+          !(event.target instanceof Node) ||
+          !container.contains(event.target)
+        ) {
+          return;
+        }
+        event.preventDefault();
+        close();
+        return;
+      }
+
+      event.preventDefault();
+      // Folio listens for the same shortcut on `document` in the bubble
+      // phase; stopping propagation here keeps its overlay dialog closed.
+      event.stopPropagation();
+      const selection = window.getSelection();
+      const selected =
+        selection && !selection.isCollapsed ? selection.toString().trim() : "";
+      setState((prev) => {
+        if (prev.status === "open") {
+          return {
+            ...prev,
+            focusSeq: prev.focusSeq + 1,
+            query: selected.length > 0 ? selected : prev.query,
+          };
+        }
+        return {
+          status: "open",
+          activeIndex: 0,
+          focusSeq: 0,
+          query: selected,
+          summary: EMPTY_SUMMARY,
+        };
+      });
+      if (selected.length > 0) {
+        debouncedSearch(selected);
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown, { capture: true });
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown, { capture: true });
+    };
+  }, [close, containerRef, debouncedSearch, editorRef, enabled, isOpen]);
+
+  return {
+    activeIndex: state.status === "open" ? state.activeIndex : 0,
+    close,
+    focusSeq: state.status === "open" ? state.focusSeq : 0,
+    isOpen,
+    query: state.status === "open" ? state.query : "",
+    setQuery,
+    step,
+    summary: state.status === "open" ? state.summary : EMPTY_SUMMARY,
+  };
+};

--- a/apps/web/src/components/docx/use-docx-find.ts
+++ b/apps/web/src/components/docx/use-docx-find.ts
@@ -15,21 +15,16 @@ import {
 } from "@/lib/search-match-navigation";
 import type { SearchMatchSummary } from "@/lib/search-match-navigation";
 
-import { classifyDocxFindKeydown } from "./docx-find.logic";
+import {
+  classifyDocxFindKeydown,
+  EMPTY_DOCX_FIND_SUMMARY,
+  resetOpenDocxFindQuery,
+} from "./docx-find.logic";
+import type { OpenDocxFindState } from "./docx-find.logic";
 
 const SEARCH_DEBOUNCE_MS = 150;
 
-const EMPTY_SUMMARY: SearchMatchSummary = { count: 0, truncated: false };
-
-type DocxFindState =
-  | { status: "closed" }
-  | {
-      status: "open";
-      activeIndex: number;
-      focusSeq: number;
-      query: string;
-      summary: SearchMatchSummary;
-    };
+type DocxFindState = { status: "closed" } | OpenDocxFindState;
 
 const CLOSED_STATE: DocxFindState = { status: "closed" };
 
@@ -111,7 +106,11 @@ export const useDocxFind = ({
       clearHighlight();
       setState((prev) =>
         prev.status === "open"
-          ? { ...prev, activeIndex: 0, summary: EMPTY_SUMMARY }
+          ? {
+              ...prev,
+              activeIndex: 0,
+              summary: EMPTY_DOCX_FIND_SUMMARY,
+            }
           : prev,
       );
       return;
@@ -144,7 +143,11 @@ export const useDocxFind = ({
     if (state.status !== "open") {
       return;
     }
-    setState({ ...state, query });
+    matchesRef.current = [];
+    clearHighlight();
+    setState((prev) =>
+      prev.status === "open" ? resetOpenDocxFindQuery(prev, query) : prev,
+    );
     debouncedSearch(query);
   };
 
@@ -187,7 +190,12 @@ export const useDocxFind = ({
       // `offsetParent` is null while an inspector tab is CSS-hidden, which is
       // how the pane keeps background tabs mounted. Only the visible editor
       // may claim the shortcut.
-      if (!container || container.offsetParent === null) {
+      if (
+        !container ||
+        container.offsetParent === null ||
+        !(event.target instanceof Node) ||
+        !container.contains(event.target)
+      ) {
         return;
       }
 
@@ -217,20 +225,26 @@ export const useDocxFind = ({
       const selection = window.getSelection();
       const selected =
         selection && !selection.isCollapsed ? selection.toString().trim() : "";
+      if (selected.length > 0) {
+        matchesRef.current = [];
+        editorRef.current?.getEditorRef()?.setPassageHighlight(null);
+      }
       setState((prev) => {
         if (prev.status === "open") {
-          return {
+          const focused = {
             ...prev,
             focusSeq: prev.focusSeq + 1,
-            query: selected.length > 0 ? selected : prev.query,
           };
+          return selected.length > 0
+            ? resetOpenDocxFindQuery(focused, selected)
+            : focused;
         }
         return {
           status: "open",
           activeIndex: 0,
           focusSeq: 0,
           query: selected,
-          summary: EMPTY_SUMMARY,
+          summary: EMPTY_DOCX_FIND_SUMMARY,
         };
       });
       if (selected.length > 0) {
@@ -252,6 +266,6 @@ export const useDocxFind = ({
     query: state.status === "open" ? state.query : "",
     setQuery,
     step,
-    summary: state.status === "open" ? state.summary : EMPTY_SUMMARY,
+    summary: state.status === "open" ? state.summary : EMPTY_DOCX_FIND_SUMMARY,
   };
 };

--- a/apps/web/src/components/inspector/file-tab-panel.tsx
+++ b/apps/web/src/components/inspector/file-tab-panel.tsx
@@ -824,6 +824,7 @@ export const FileTabPanel = ({
           propertyId={tab.propertyId}
           scaleOffset={scaleOffsets.get(tab.id) ?? 0}
           showActionBar={false}
+          surface="inspector"
           workspaceId={tab.workspaceId}
         />
       );

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/$viewId.document.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/$viewId.document.tsx
@@ -761,6 +761,7 @@ function RouteComponentInner({
                         onUnlockedChange={setDocxUnlocked}
                         propertyId={filePropertyId}
                         scaleOffset={scaleOffset}
+                        surface="fullView"
                         workspaceId={workspaceId}
                       />
                     </Suspense>


### PR DESCRIPTION
## Problem

Cmd+F over a DOCX open in the inspector opens Folio's find dialog outside the pane, on top of whatever the main page is showing.

That placement is deliberate given the dialog's design: `FindReplaceDialog` is a fixed viewport overlay positioned from `--folio-find-replace-top/left/right` and packed to the inline-end edge. `apps/web/src/routes/_protected.tsx` sets the right offset to the inspector width plus rail so the dialog clears the docked pane. In full view that keeps the dialog off the document; in sidepeek it parks it over unrelated content.

## Change

The inspector claims the shortcut and renders its own bar instead:

- `useDocxFind` listens for Cmd/Ctrl+F on `document` in the capture phase and stops propagation, so Folio's bubble-phase listener never opens the overlay. Only the bare shortcut is claimed; `classifyDocxFindKeydown` leaves every other combination alone, since suppression costs a `stopPropagation`.
- `DocxFindBar` docks at the top of the pane: query input, match counter, prev/next, close. Same shape as the find bar in `external-reference-panel.tsx`, and it reuses `SearchMatchControls`.
- Search reuses the path already behind the PDF peek viewer: `findDocumentSearchResult` plus `resolveFindMatchRange`, then `setPassageHighlight` and `scrollToPosition` for the active match. Capped at `MAX_SEARCH_PREVIEW_MATCHES`, with the counter showing `200+` when truncated.
- A new `surface` prop (`"inspector" | "fullView"`) selects the behavior. Full view keeps Folio's dialog, which has the viewport to sit in.

Background inspector tabs stay mounted but CSS-hidden, so the listener gates on `offsetParent` and only the visible editor claims the shortcut. Escape is only taken when the event target is inside the pane, leaving portalled dialogs alone.

The bar renders above Folio's formatting toolbar, since the toolbar is rendered inside `DocxEditor`.

## Notes

- No new translation keys: the `folio.findReplace.*` set already covers the bar's labels in every supported language.
- Enter inside the debounce window flushes the pending search so the first press lands on the first match; Shift+Enter steps backwards.
- Highlights the active match only, matching the existing search-preview behavior rather than Word-style all-match highlighting.

## Verification

`bun run verify` on this branch passes except "AI skill sync", which fails on any checkout without the `.ai/shared` submodule, as `AGENTS.md` notes. Typecheck, lint, and `apps/web/src/components/docx` tests are green; the one failing test in that directory (`docx-edit-mode.logic.test.ts`) fails identically on a clean tree without `apps/web/.env`.

Not yet exercised in a browser.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added DOCX search in the inspector view, including keyboard shortcuts, match navigation, and a close button.
  * Search can now highlight matches in the document and jump between results.

* **Bug Fixes**
  * Improved keyboard handling so common shortcut combinations behave more consistently and Escape closes search only when appropriate.

* **Tests**
  * Added coverage for DOCX search shortcut behaviour and Escape handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->