### PR TITLE
feat(chat): complete projection-schema coverage for registry tools

### DIFF
--- a/apps/api/src/handlers/chat/tools/execute/chat-code-mode.test.ts
+++ b/apps/api/src/handlers/chat/tools/execute/chat-code-mode.test.ts
@@ -105,6 +105,16 @@ describe("buildChatCodeMode", () => {
     expect(discovered).toContain("diff");
     // Stripped file plumbing is not advertised to the model.
     expect(discovered).not.toContain("sha256Hex");
+
+    // Every projectable read tool carries a schema now, so the Returns line
+    // applies across the catalog, not only to the first-wave conversions;
+    // list_documents stands in for the rest.
+    const discoveredDocuments = JSON.stringify(
+      await discover({ toolNames: ["list_documents"] }),
+    );
+    expect(discoveredDocuments).toContain("Returns:");
+    expect(discoveredDocuments).toContain("documents");
+    expect(discoveredDocuments).toContain("parentId");
   });
 
   test("runs a projected read tool end-to-end through the sandbox with refs, no raw UUIDs", async () => {

--- a/apps/api/src/handlers/chat/tools/execute/chat-code-mode.ts
+++ b/apps/api/src/handlers/chat/tools/execute/chat-code-mode.ts
@@ -18,10 +18,7 @@ import {
   type ChatRegistryContextDeps,
 } from "@/api/handlers/chat/tools/registry-adapter/mcp-chat-context";
 import { renderProjectionShape } from "@/api/handlers/chat/tools/registry-adapter/projection-schema";
-import type {
-  RegistryReadToolName,
-  RegistryRefFieldMapEntry,
-} from "@/api/handlers/chat/tools/registry-adapter/ref-field-map";
+import type { RegistryReadToolName } from "@/api/handlers/chat/tools/registry-adapter/ref-field-map";
 import { READ_TOOL_REF_FIELD_MAP } from "@/api/handlers/chat/tools/registry-adapter/ref-field-map";
 import { runRegistryReadTool } from "@/api/handlers/chat/tools/registry-adapter/run-registry-tool";
 import { toToolInputSchema } from "@/api/handlers/chat/tools/registry-adapter/tool-input-schema";
@@ -109,19 +106,22 @@ const CODE_MODE_RUNTIME_CONFIG = {
  * system-prompt constant (no-op runner, never invoked for prompt generation).
  */
 /**
- * The registry description, plus — for a tool with a projection schema — a
- * compact `Returns:` shape derived from that same schema. The runtime
- * strict-parses payloads against the schema, so the shape the model plans
- * against here is exactly the shape it will receive: this closes the
- * "model guesses output keys and iterates a field that isn't there" failure
- * class for converted tools.
+ * The registry description, plus a compact `Returns:` shape derived from the
+ * tool's projection schema. Every chat-projectable tool carries a schema, so
+ * every advertised read tool gets the line. The runtime strict-parses
+ * payloads against the same schema, so the shape the model plans against
+ * here is exactly the shape it will receive: this closes the "model guesses
+ * output keys and iterates a field that isn't there" failure class.
  */
 const chatReadToolDescription = (toolName: RegistryReadToolName): string => {
   const definition =
     getStaticMcpToolDefinition(toolName) ??
     panic(`Chat read tool ${toolName} is missing from the static registry`);
-  const entry: RegistryRefFieldMapEntry = READ_TOOL_REF_FIELD_MAP[toolName];
-  if (entry.projection === undefined) {
+  const entry = READ_TOOL_REF_FIELD_MAP[toolName];
+  if (!entry.chatProjectable) {
+    // Non-projectable tools never enter the chat catalog
+    // (`chatProjectableReadToolNames` filters them out); the plain
+    // description satisfies the type without inventing a shape.
     return definition.description;
   }
   return `${definition.description}\nReturns: ${renderProjectionShape(entry.projection)}`;

--- a/apps/api/src/handlers/chat/tools/registry-adapter/projection-schema.test.ts
+++ b/apps/api/src/handlers/chat/tools/registry-adapter/projection-schema.test.ts
@@ -1,20 +1,29 @@
 import { Result } from "better-result";
 import { describe, expect, test } from "bun:test";
 
-import type { OutputRefField } from "./projection-schema";
+import type {
+  ChatProjectionSchema,
+  OutputRefField,
+  RefMediationLists,
+} from "./projection-schema";
 import {
   applyProjectionSchema,
   deriveRefMediationEntry,
   renderProjectionShape,
 } from "./projection-schema";
-import { READ_TOOL_REF_FIELD_MAP } from "./ref-field-map";
+import {
+  READ_TOOL_REF_FIELD_MAP,
+  WRITE_TOOL_REF_FIELD_MAP,
+} from "./ref-field-map";
 
 /**
  * The derivation contract: the mediation lists mechanically derived from a
  * converted tool's projection schema must reproduce the hand-written lists
  * they replaced (copied below as literals from the pre-conversion map), so
  * the conversion is provably behavior-preserving. The lists are allowlists,
- * so order is irrelevant: both sides are compared sorted.
+ * so order is irrelevant: both sides are compared sorted. Where a schema
+ * deliberately departs from its hand list (drift the hand list could never
+ * surface), the departure is asserted explicitly with its reason.
  */
 
 const sortedPaths = (paths: readonly string[]): readonly string[] =>
@@ -30,6 +39,22 @@ const sortedRefs = (
 const LIST_MATTERS_PROJECTION = READ_TOOL_REF_FIELD_MAP.list_matters.projection;
 const READ_DOCUMENT_PROJECTION =
   READ_TOOL_REF_FIELD_MAP.read_document.projection;
+
+const expectDerivedEquals = (
+  projection: ChatProjectionSchema,
+  expected: RefMediationLists,
+): void => {
+  const derived = deriveRefMediationEntry(projection);
+  expect(sortedRefs(derived.outputRefs)).toEqual(
+    sortedRefs(expected.outputRefs),
+  );
+  expect(sortedPaths(derived.passthroughIdPaths)).toEqual(
+    sortedPaths(expected.passthroughIdPaths),
+  );
+  expect(sortedPaths(derived.stripPaths)).toEqual(
+    sortedPaths(expected.stripPaths),
+  );
+};
 
 // The hand-written list_matters entry the projection schema replaced.
 const LIST_MATTERS_HAND_LISTS = {
@@ -53,11 +78,7 @@ const LIST_MATTERS_HAND_LISTS = {
     "overview.recentEntities[].propertyId",
     "overview.recentEntities[].pdfFileId",
   ],
-} as const satisfies {
-  outputRefs: readonly OutputRefField[];
-  passthroughIdPaths: readonly string[];
-  stripPaths: readonly string[];
-};
+} as const satisfies RefMediationLists;
 
 // The hand-written read_document entry the projection schema replaced.
 const READ_DOCUMENT_HAND_LISTS = {
@@ -80,11 +101,7 @@ const READ_DOCUMENT_HAND_LISTS = {
     "versionsNextCursor",
   ],
   stripPaths: [],
-} as const satisfies {
-  outputRefs: readonly OutputRefField[];
-  passthroughIdPaths: readonly string[];
-  stripPaths: readonly string[];
-};
+} as const satisfies RefMediationLists;
 
 /**
  * The one deliberate delta over the hand entry: the `FieldContent` file
@@ -108,36 +125,479 @@ const READ_DOCUMENT_CONTENT_STRIPS = [
   "version.fields[].content",
 ].flatMap((base) => FILE_CONTENT_PLUMBING_KEYS.map((key) => `${base}.${key}`));
 
+/**
+ * The remaining pre-conversion hand lists, one per tool, copied verbatim from
+ * the map they were deleted from. Each case's `expected` is those lists plus
+ * any documented departure. Empty lists are stated explicitly: a tool whose
+ * payload carries no ids at all (resolve_rate, lookup_business_registry) is
+ * an assertion too.
+ */
+type DerivationCase = {
+  tool: string;
+  projection: ChatProjectionSchema;
+  expected: RefMediationLists;
+};
+
+const DERIVATION_CASES: readonly DerivationCase[] = [
+  {
+    tool: "list_contacts",
+    projection: READ_TOOL_REF_FIELD_MAP.list_contacts.projection,
+    expected: {
+      outputRefs: [{ kind: "contact", path: "items[].id" }],
+      passthroughIdPaths: ["nextCursor"],
+      stripPaths: [],
+    },
+  },
+  {
+    tool: "search_across_matters",
+    projection: READ_TOOL_REF_FIELD_MAP.search_across_matters.projection,
+    expected: {
+      outputRefs: [
+        { kind: "matter", path: "hits[].workspaceId" },
+        {
+          kind: "entity",
+          path: "hits[].entityId",
+          workspace: { from: "sibling", key: "workspaceId" },
+        },
+      ],
+      passthroughIdPaths: [],
+      stripPaths: [],
+    },
+  },
+  {
+    tool: "read_content_across_matters",
+    projection: READ_TOOL_REF_FIELD_MAP.read_content_across_matters.projection,
+    expected: {
+      outputRefs: [
+        { kind: "matter", path: "workspaceId" },
+        {
+          kind: "entity",
+          path: "entityId",
+          workspace: { from: "sibling", key: "workspaceId" },
+        },
+      ],
+      passthroughIdPaths: [],
+      stripPaths: [],
+    },
+  },
+  {
+    tool: "read_contact",
+    projection: READ_TOOL_REF_FIELD_MAP.read_contact.projection,
+    expected: {
+      outputRefs: [{ kind: "contact", path: "contactId" }],
+      passthroughIdPaths: [],
+      stripPaths: [],
+    },
+  },
+  {
+    tool: "list_documents",
+    projection: READ_TOOL_REF_FIELD_MAP.list_documents.projection,
+    expected: {
+      outputRefs: [
+        {
+          kind: "entity",
+          path: "documents[].id",
+          workspace: { from: "inputParam", param: "matter_id" },
+        },
+        {
+          kind: "entity",
+          path: "documents[].parentId",
+          workspace: { from: "inputParam", param: "matter_id" },
+        },
+      ],
+      passthroughIdPaths: ["nextCursor"],
+      stripPaths: [],
+    },
+  },
+  {
+    tool: "list_properties",
+    projection: READ_TOOL_REF_FIELD_MAP.list_properties.projection,
+    expected: {
+      outputRefs: [{ kind: "property", path: "properties[].id" }],
+      passthroughIdPaths: ["nextCursor"],
+      stripPaths: [],
+    },
+  },
+  {
+    tool: "list_tasks",
+    projection: READ_TOOL_REF_FIELD_MAP.list_tasks.projection,
+    expected: {
+      outputRefs: [
+        {
+          kind: "entity",
+          path: "tasks[].id",
+          workspace: { from: "inputParam", param: "matter_id" },
+        },
+        {
+          kind: "entity",
+          path: "task.taskId",
+          workspace: { from: "inputEntity", param: "task_id" },
+        },
+        {
+          kind: "entity",
+          path: "task.links[].entity.id",
+          workspace: { from: "inputEntityWorkspace", param: "task_id" },
+        },
+      ],
+      passthroughIdPaths: [
+        "task.assignees[].userId",
+        "task.links[].linkId",
+        "nextCursor",
+      ],
+      stripPaths: [],
+    },
+  },
+  {
+    tool: "list_clauses",
+    projection: READ_TOOL_REF_FIELD_MAP.list_clauses.projection,
+    expected: {
+      outputRefs: [],
+      passthroughIdPaths: [
+        "clauses[].id",
+        "clauses[].categoryId",
+        "clause.id",
+        "clause.categoryId",
+        "clause.variants[].id",
+        "clause.versions[].id",
+        "clause.createdBy",
+        "categories[].id",
+        "categories[].parentId",
+        "version.id",
+        "nextCursor",
+      ],
+      stripPaths: [],
+    },
+  },
+  {
+    tool: "list_playbooks",
+    projection: READ_TOOL_REF_FIELD_MAP.list_playbooks.projection,
+    expected: {
+      outputRefs: [],
+      passthroughIdPaths: [
+        "items[].id",
+        "playbook.id",
+        "playbook.positions.items[].sourceId",
+        // Departure from the hand list, which licensed
+        // `playbook.positions.items[].standard.clauseId`: `standard` was the
+        // pre-v2 positions shape and no handler emits it, so the license was
+        // stale documentation. The positions-v2 clause link lives at the
+        // acceptable tier's ideal language, and it is the same org-scoped
+        // clause-library handle list_clauses licenses.
+        "playbook.positions.items[].tiers.acceptable.ideal.clauseId",
+        "nextCursor",
+      ],
+      stripPaths: [
+        "playbook.positions.items[].tiers.acceptable.rules[].id",
+        "playbook.positions.items[].tiers.fallback.entries[].id",
+        "playbook.positions.items[].tiers.notAcceptable.rules[].id",
+      ],
+    },
+  },
+  {
+    tool: "list_time_entries",
+    projection: READ_TOOL_REF_FIELD_MAP.list_time_entries.projection,
+    expected: {
+      outputRefs: [
+        {
+          kind: "entity",
+          path: "entries[].entityId",
+          workspace: { from: "inputParam", param: "matter_id" },
+        },
+        {
+          kind: "entity",
+          path: "entry.entityId",
+          workspace: { from: "sibling", key: "workspaceId" },
+        },
+        { kind: "matter", path: "entry.workspaceId" },
+      ],
+      passthroughIdPaths: [
+        "entries[].id",
+        "entry.id",
+        "entries[].userId",
+        "entry.userId",
+        "nextCursor",
+      ],
+      stripPaths: [],
+    },
+  },
+  {
+    tool: "resolve_rate",
+    projection: READ_TOOL_REF_FIELD_MAP.resolve_rate.projection,
+    expected: { outputRefs: [], passthroughIdPaths: [], stripPaths: [] },
+  },
+  {
+    tool: "list_invoices",
+    projection: READ_TOOL_REF_FIELD_MAP.list_invoices.projection,
+    expected: {
+      outputRefs: [
+        {
+          kind: "entity",
+          path: "invoice.timeEntries[].entityId",
+          workspace: { from: "outputPath", path: "invoice.workspaceId" },
+        },
+        {
+          kind: "entity",
+          path: "invoice.timeEntries[].entity.id",
+          workspace: { from: "outputPath", path: "invoice.workspaceId" },
+        },
+        {
+          kind: "entity",
+          path: "invoice.expenses[].entityId",
+          workspace: { from: "outputPath", path: "invoice.workspaceId" },
+        },
+        {
+          kind: "entity",
+          path: "invoice.expenses[].entity.id",
+          workspace: { from: "outputPath", path: "invoice.workspaceId" },
+        },
+        { kind: "matter", path: "invoice.workspaceId" },
+      ],
+      passthroughIdPaths: [
+        "invoices[].id",
+        "invoice.id",
+        "invoice.timeEntries[].id",
+        "invoice.expenses[].id",
+        "nextCursor",
+      ],
+      stripPaths: [],
+    },
+  },
+  {
+    tool: "get_usage",
+    projection: READ_TOOL_REF_FIELD_MAP.get_usage.projection,
+    expected: {
+      outputRefs: [],
+      passthroughIdPaths: ["entitlement.id", "policy.id"],
+      stripPaths: [],
+    },
+  },
+  {
+    tool: "search_case_law",
+    projection: READ_TOOL_REF_FIELD_MAP.search_case_law.projection,
+    expected: {
+      outputRefs: [],
+      passthroughIdPaths: ["results[].decisionId", "nextCursor"],
+      stripPaths: [],
+    },
+  },
+  {
+    tool: "read_case_law_decision",
+    projection: READ_TOOL_REF_FIELD_MAP.read_case_law_decision.projection,
+    expected: {
+      outputRefs: [],
+      passthroughIdPaths: [
+        "decision.decisionId",
+        "decision.citationsFrom[].id",
+        "decision.citationsFrom[].citedDecisionId",
+        "decision.citationsTo[].id",
+        "decision.citationsTo[].citingDecisionId",
+        "decision.source.id",
+        "nextCursor",
+      ],
+      stripPaths: [],
+    },
+  },
+  {
+    tool: "search_legislation",
+    projection: READ_TOOL_REF_FIELD_MAP.search_legislation.projection,
+    expected: {
+      outputRefs: [],
+      passthroughIdPaths: [
+        "lawId",
+        "blockId",
+        "law.lawId",
+        "data[].identificador",
+      ],
+      stripPaths: [],
+    },
+  },
+  {
+    tool: "lookup_business_registry",
+    projection: READ_TOOL_REF_FIELD_MAP.lookup_business_registry.projection,
+    expected: { outputRefs: [], passthroughIdPaths: [], stripPaths: [] },
+  },
+  {
+    tool: "list_templates",
+    projection: READ_TOOL_REF_FIELD_MAP.list_templates.projection,
+    expected: {
+      outputRefs: [],
+      passthroughIdPaths: ["templates[].id", "nextCursor"],
+      stripPaths: [],
+    },
+  },
+
+  // --- Write tools ------------------------------------------------------
+  {
+    tool: "save_matter",
+    projection: WRITE_TOOL_REF_FIELD_MAP.save_matter.projection,
+    expected: {
+      outputRefs: [{ kind: "matter", path: "matterId" }],
+      passthroughIdPaths: [],
+      stripPaths: [],
+    },
+  },
+  {
+    tool: "delete_matter",
+    projection: WRITE_TOOL_REF_FIELD_MAP.delete_matter.projection,
+    expected: { outputRefs: [], passthroughIdPaths: [], stripPaths: [] },
+  },
+  {
+    tool: "save_contact",
+    projection: WRITE_TOOL_REF_FIELD_MAP.save_contact.projection,
+    expected: {
+      outputRefs: [{ kind: "contact", path: "contactId" }],
+      passthroughIdPaths: [],
+      stripPaths: [],
+    },
+  },
+  {
+    tool: "delete_contact",
+    projection: WRITE_TOOL_REF_FIELD_MAP.delete_contact.projection,
+    expected: { outputRefs: [], passthroughIdPaths: [], stripPaths: [] },
+  },
+  {
+    tool: "save_task",
+    projection: WRITE_TOOL_REF_FIELD_MAP.save_task.projection,
+    expected: {
+      outputRefs: [
+        {
+          kind: "entity",
+          path: "taskId",
+          workspace: { from: "inputParam", param: "matter_id" },
+        },
+      ],
+      passthroughIdPaths: [],
+      stripPaths: [],
+    },
+  },
+  {
+    tool: "link_matter_contact",
+    projection: WRITE_TOOL_REF_FIELD_MAP.link_matter_contact.projection,
+    expected: {
+      outputRefs: [],
+      passthroughIdPaths: ["workspaceContactId"],
+      stripPaths: [],
+    },
+  },
+  {
+    tool: "save_document",
+    projection: WRITE_TOOL_REF_FIELD_MAP.save_document.projection,
+    expected: {
+      outputRefs: [
+        {
+          kind: "entity",
+          path: "entityId",
+          workspace: { from: "inputParam", param: "matter_id" },
+        },
+      ],
+      passthroughIdPaths: [],
+      stripPaths: [],
+    },
+  },
+  {
+    tool: "delete_document",
+    projection: WRITE_TOOL_REF_FIELD_MAP.delete_document.projection,
+    expected: { outputRefs: [], passthroughIdPaths: [], stripPaths: [] },
+  },
+  {
+    tool: "set_field_value",
+    projection: WRITE_TOOL_REF_FIELD_MAP.set_field_value.projection,
+    expected: { outputRefs: [], passthroughIdPaths: [], stripPaths: [] },
+  },
+  {
+    tool: "save_time_entry",
+    projection: WRITE_TOOL_REF_FIELD_MAP.save_time_entry.projection,
+    expected: {
+      outputRefs: [],
+      passthroughIdPaths: ["timeEntryId"],
+      stripPaths: [],
+    },
+  },
+  {
+    tool: "delete_time_entry",
+    projection: WRITE_TOOL_REF_FIELD_MAP.delete_time_entry.projection,
+    expected: { outputRefs: [], passthroughIdPaths: [], stripPaths: [] },
+  },
+  {
+    tool: "save_clause",
+    projection: WRITE_TOOL_REF_FIELD_MAP.save_clause.projection,
+    expected: {
+      outputRefs: [],
+      passthroughIdPaths: ["clauseId"],
+      stripPaths: [],
+    },
+  },
+  {
+    tool: "delete_clause",
+    projection: WRITE_TOOL_REF_FIELD_MAP.delete_clause.projection,
+    expected: { outputRefs: [], passthroughIdPaths: [], stripPaths: [] },
+  },
+  {
+    tool: "run_playbook",
+    projection: WRITE_TOOL_REF_FIELD_MAP.run_playbook.projection,
+    expected: { outputRefs: [], passthroughIdPaths: [], stripPaths: [] },
+  },
+  {
+    tool: "manage_organization",
+    projection: WRITE_TOOL_REF_FIELD_MAP.manage_organization.projection,
+    expected: {
+      outputRefs: [],
+      passthroughIdPaths: ["memberId", "id"],
+      stripPaths: [],
+    },
+  },
+  {
+    tool: "set_practice_jurisdictions",
+    projection: WRITE_TOOL_REF_FIELD_MAP.set_practice_jurisdictions.projection,
+    expected: { outputRefs: [], passthroughIdPaths: [], stripPaths: [] },
+  },
+  {
+    tool: "save_template",
+    projection: WRITE_TOOL_REF_FIELD_MAP.save_template.projection,
+    expected: {
+      outputRefs: [],
+      passthroughIdPaths: ["templateId"],
+      stripPaths: [],
+    },
+  },
+];
+
 describe("deriveRefMediationEntry", () => {
   test("list_matters: derived lists equal the previous hand-written entry", () => {
-    const derived = deriveRefMediationEntry(LIST_MATTERS_PROJECTION);
-
-    expect(sortedRefs(derived.outputRefs)).toEqual(
-      sortedRefs(LIST_MATTERS_HAND_LISTS.outputRefs),
-    );
-    expect(sortedPaths(derived.passthroughIdPaths)).toEqual(
-      sortedPaths(LIST_MATTERS_HAND_LISTS.passthroughIdPaths),
-    );
-    expect(sortedPaths(derived.stripPaths)).toEqual(
-      sortedPaths(LIST_MATTERS_HAND_LISTS.stripPaths),
-    );
+    expectDerivedEquals(LIST_MATTERS_PROJECTION, LIST_MATTERS_HAND_LISTS);
   });
 
   test("read_document: derived lists equal the previous hand-written entry plus the file-content strips", () => {
-    const derived = deriveRefMediationEntry(READ_DOCUMENT_PROJECTION);
-
-    expect(sortedRefs(derived.outputRefs)).toEqual(
-      sortedRefs(READ_DOCUMENT_HAND_LISTS.outputRefs),
-    );
-    expect(sortedPaths(derived.passthroughIdPaths)).toEqual(
-      sortedPaths(READ_DOCUMENT_HAND_LISTS.passthroughIdPaths),
-    );
-    expect(sortedPaths(derived.stripPaths)).toEqual(
-      sortedPaths([
+    expectDerivedEquals(READ_DOCUMENT_PROJECTION, {
+      outputRefs: READ_DOCUMENT_HAND_LISTS.outputRefs,
+      passthroughIdPaths: READ_DOCUMENT_HAND_LISTS.passthroughIdPaths,
+      stripPaths: [
         ...READ_DOCUMENT_HAND_LISTS.stripPaths,
         ...READ_DOCUMENT_CONTENT_STRIPS,
-      ]),
-    );
+      ],
+    });
+  });
+
+  for (const { tool, projection, expected } of DERIVATION_CASES) {
+    test(`${tool}: derived lists equal the previous hand-written entry`, () => {
+      expectDerivedEquals(projection, expected);
+    });
+  }
+
+  test("every chat-projectable entry in both maps has a derivation test", () => {
+    const projectable = [
+      ...Object.entries(READ_TOOL_REF_FIELD_MAP),
+      ...Object.entries(WRITE_TOOL_REF_FIELD_MAP),
+    ]
+      .filter(([, entry]) => entry.chatProjectable)
+      .map(([name]) => name)
+      .sort();
+    const covered = [
+      "list_matters",
+      "read_document",
+      ...DERIVATION_CASES.map(({ tool }) => tool),
+    ].sort();
+    expect(covered).toEqual(projectable);
   });
 
   test("is memoized per schema", () => {

--- a/apps/api/src/handlers/chat/tools/registry-adapter/projection-schema.ts
+++ b/apps/api/src/handlers/chat/tools/registry-adapter/projection-schema.ts
@@ -60,9 +60,9 @@ export type OutputRefField =
 
 /**
  * The three output-side path lists the generic mediation cores
- * (`hydrateRefs`/`findUndeclaredUuidPathIn`/`stripDeclaredPaths`) consume:
- * hand-written on unconverted map entries, derived from the projection schema
- * on converted ones.
+ * (`hydrateRefs`/`findUndeclaredUuidPathIn`/`stripDeclaredPaths`) consume,
+ * derived from each map entry's projection schema. Hand-written lists no
+ * longer exist: the schema is the only artifact these can come from.
  */
 export type RefMediationLists = {
   outputRefs: readonly OutputRefField[];
@@ -173,6 +173,20 @@ export const strippedField = (): AnnotatedFieldSchema =>
     v.unknown(),
     v.metadata({ [CHAT_PROJECTION_METADATA_KEY]: { role: "strip" } }),
   );
+
+/**
+ * A free-form JSON subtree the schema cannot enumerate by path: public-source
+ * jsonb (`decision.metadata`), an external API envelope (BOE sections,
+ * registry `details`), or a structural config with no stable leaf grammar
+ * (playbook ask content, condition ASTs). Deliberately NOT an annotation:
+ * the strict parse admits any value at the declared key, the walker records
+ * nothing beneath it (an unannotated `unknown` leaf contributes no mediation
+ * paths), and therefore the runtime UUID backstop still applies, unlicensed,
+ * to every string inside — a UUID-shaped value in the subtree fails closed
+ * exactly as it did under the hand-written entries, which never enumerated
+ * these subtrees either.
+ */
+export const unenumeratedJson = (): AnnotatedFieldSchema => v.unknown();
 
 // --- Schema AST walking ---------------------------------------------------------
 // Valibot schemas are plain objects: `v.pipe` spreads its base schema and adds

--- a/apps/api/src/handlers/chat/tools/registry-adapter/ref-field-map.ts
+++ b/apps/api/src/handlers/chat/tools/registry-adapter/ref-field-map.ts
@@ -4,7 +4,6 @@ import type { DEFAULT_MCP_TOOL_DEFINITIONS } from "@/api/mcp/static-tool-definit
 
 import type {
   ChatProjectionSchema,
-  RefMediationLists,
   RegistryRefKind,
 } from "./projection-schema";
 import {
@@ -12,6 +11,7 @@ import {
   chatRef,
   passthroughId,
   strippedField,
+  unenumeratedJson,
 } from "./projection-schema";
 
 /**
@@ -50,54 +50,43 @@ export type RegistryWriteToolName = WriteToolDefinition["name"];
 export type InputRefParam = { kind: RegistryRefKind; param: string };
 
 /**
- * The ref-mediation contract shared by the read and write ref-field maps: the
- * input refs to dehydrate, plus the output-side decision. The output side is
- * one of two mutually exclusive artifacts:
- *
- * - a chat projection schema (`projection`), from which the three mediation
- *   lists are derived mechanically (`deriveRefMediationEntry`) and whose
- *   strict parse makes an undeclared handler field structurally unable to
- *   reach the model; or
- * - the hand-written lists (unconverted tools), where the runtime UUID
- *   backstop alone guards undeclared fields.
- *
- * The `never`-typed exclusions make an entry that carries both a projection
- * and hand lists fail typecheck, so a converted tool cannot keep a stale hand
- * copy of what the schema now owns. Resolve the lists for either shape with
- * `resolveMediationLists` (`ref-mediation.ts`); the generic mediation cores
- * (`dehydrateRefs`/`hydrateRefs`/`findUndeclaredUuidPathIn`) read exactly
- * those three lists, so a read entry and a write entry drive the same code.
+ * The ref-mediation contract of one chat-projected tool: the input refs to
+ * dehydrate, plus the projection schema that is the single output-side
+ * artifact. The three mediation lists (`outputRefs`/`passthroughIdPaths`/
+ * `stripPaths`) are derived mechanically from the schema's annotations
+ * (`deriveRefMediationEntry`), and its strict parse makes an undeclared
+ * handler field structurally unable to reach the model. Hand-written path
+ * lists are deliberately unrepresentable here: there is no field to put them
+ * in, so a new tool cannot reintroduce the hand-maintained mirror this map
+ * used to be.
  */
 export type RefMediationEntry = {
   inputRefs: readonly InputRefParam[];
-} & (
-  | ({ projection?: never } & RefMediationLists)
-  | {
-      projection: ChatProjectionSchema;
-      outputRefs?: never;
-      passthroughIdPaths?: never;
-      stripPaths?: never;
-    }
-);
-
-export type RegistryRefFieldMapEntry = RefMediationEntry & {
-  /**
-   * Whether chat may project this read tool at all. `false` marks a read tool
-   * deliberately kept off the chat surface (rationale in the entry's comment);
-   * the orchestrator refuses to dispatch it, so a tool that cannot satisfy the
-   * "no tenant UUID reaches the model" invariant by static field mapping is
-   * never reachable from chat.
-   */
-  chatProjectable: boolean;
+  projection: ChatProjectionSchema;
 };
 
-// --- Chat projection schemas (converted tools) ------------------------------------
-// One artifact per converted tool: the exact shape the chat surface forwards,
+/**
+ * Per-tool chat decision. `chatProjectable: false` marks a tool deliberately
+ * kept off the chat surface (rationale in the entry's comment) and carries
+ * nothing else: the orchestrator refuses to dispatch it, so no input refs or
+ * projection can apply. `chatProjectable: true` requires the full mediation
+ * contract, so a projectable entry without a projection schema cannot compile.
+ */
+export type RegistryRefFieldMapEntry =
+  | { chatProjectable: false }
+  | ({ chatProjectable: true } & RefMediationEntry);
+
+// --- Chat projection schemas -------------------------------------------------
+// One artifact per projected tool: the exact shape the chat surface forwards,
 // with per-field chat semantics attached (`chatRef`/`chatEntityRef`/
 // `passthroughId`/`strippedField`). The strict parse in the orchestrator makes
 // an undeclared handler field fail closed BEFORE it can reach the model, and
 // `deriveRefMediationEntry` derives the entry's outputRefs/passthrough/strip
 // lists from the same annotations, so shape and ref decisions cannot drift.
+// Every schema is written from the handler's own payload construction
+// (`apps/api/src/mcp/*-tools.ts`), branch by branch; per-tool derivation tests
+// in `projection-schema.test.ts` pin each schema's derived lists to the hand
+// lists it replaced.
 
 /**
  * list_matters, list branch. Source of truth: `handleListMattersTool`
@@ -192,6 +181,133 @@ const LIST_MATTERS_PROJECTION: ChatProjectionSchema = v.union([
   listMattersListProjection,
   listMattersDetailProjection,
 ]);
+
+/**
+ * One directory email/phone as persisted in the contacts jsonb columns
+ * (`contactEmailSchema`/`contactPhoneSchema`, `db/schema-validators.ts`):
+ * a closed-set `type`, the address/number, an `isPrimary` flag, and an
+ * optional free-text label.
+ */
+const contactEmailProjection = v.strictObject({
+  type: v.string(),
+  address: v.string(),
+  isPrimary: v.boolean(),
+  label: v.optional(v.string()),
+});
+
+const contactPhoneProjection = v.strictObject({
+  type: v.string(),
+  number: v.string(),
+  isPrimary: v.boolean(),
+  label: v.optional(v.string()),
+});
+
+/**
+ * list_contacts. Source of truth: `listContactsPage`
+ * (`handlers/contacts/list-query.ts`), whose whole `Page` envelope
+ * (`items`/`limit`/`nextCursor`) is forwarded verbatim by
+ * `handleListContactsTool`. The jsonb directory columns
+ * (`emails`/`phones`/`tags`) are nullable at the column level.
+ */
+const LIST_CONTACTS_PROJECTION: ChatProjectionSchema = v.strictObject({
+  items: v.array(
+    v.strictObject({
+      id: chatRef("contact"),
+      type: v.string(),
+      displayName: v.string(),
+      firstName: v.nullable(v.string()),
+      lastName: v.nullable(v.string()),
+      organizationName: v.nullable(v.string()),
+      emails: v.nullable(v.array(contactEmailProjection)),
+      phones: v.nullable(v.array(contactPhoneProjection)),
+      tags: v.nullable(v.array(v.string())),
+      color: v.nullable(v.string()),
+      createdAt: v.string(),
+      clientMatterCount: v.number(),
+    }),
+  ),
+  limit: v.number(),
+  // Opaque `[displayName, id]` cursor; embeds a contact id but is
+  // base64url-encoded, not UUID-formatted.
+  nextCursor: v.nullable(passthroughId()),
+});
+
+/**
+ * search_across_matters. Source of truth: `handleSearchAcrossMattersTool`
+ * (`stella-tools.ts`) mapping the search provider's hits. Hits span multiple
+ * matters, so each entity recovers its workspace from the sibling
+ * `workspaceId` field.
+ */
+const SEARCH_ACROSS_MATTERS_PROJECTION: ChatProjectionSchema = v.strictObject({
+  totalCount: v.number(),
+  // Opaque provider cursor, never UUID-formatted: plain data, not a handle.
+  nextCursor: v.nullable(v.string()),
+  hits: v.array(
+    v.strictObject({
+      entityId: chatEntityRef({ from: "sibling", key: "workspaceId" }),
+      workspaceId: chatRef("matter"),
+      workspaceName: v.string(),
+      name: v.string(),
+      kind: v.string(),
+      headline: v.nullable(v.string()),
+    }),
+  ),
+});
+
+/**
+ * read_content_across_matters. Source of truth:
+ * `handleReadContentAcrossMattersTool` (`stella-tools.ts`); `nextCursor` is
+ * the numeric char-offset window cursor the egress pipeline writes back.
+ */
+const READ_CONTENT_ACROSS_MATTERS_PROJECTION: ChatProjectionSchema =
+  v.strictObject({
+    charCount: v.number(),
+    // The output entity is the request's own `entity_id` input, so hydration
+    // reuses the dehydrated ref; the sibling source (the hand entry's
+    // declaration, kept verbatim) only backs a non-echo payload.
+    entityId: chatEntityRef({ from: "sibling", key: "workspaceId" }),
+    kind: v.string(),
+    name: v.string(),
+    text: v.string(),
+    truncated: v.boolean(),
+    nextCursor: v.nullable(v.string()),
+    workspaceId: chatRef("matter"),
+  });
+
+/**
+ * read_contact. Source of truth: `handleReadContactTool` (`stella-tools.ts`);
+ * `emails`/`phones` pass through `arrayOrEmpty`, so they are always arrays.
+ */
+const READ_CONTACT_PROJECTION: ChatProjectionSchema = v.strictObject({
+  contactId: chatRef("contact"),
+  type: v.string(),
+  displayName: v.string(),
+  firstName: v.nullable(v.string()),
+  lastName: v.nullable(v.string()),
+  organizationName: v.nullable(v.string()),
+  emails: v.array(contactEmailProjection),
+  phones: v.array(contactPhoneProjection),
+});
+
+/**
+ * list_documents. Source of truth: `handleListDocumentsTool`
+ * (`document-tools.ts`) — the selected entity columns minus the cursor
+ * timestamp. `matter_id` is required input, so it is every row's workspace.
+ */
+const LIST_DOCUMENTS_PROJECTION: ChatProjectionSchema = v.strictObject({
+  documents: v.array(
+    v.strictObject({
+      id: chatEntityRef({ from: "inputParam", param: "matter_id" }),
+      name: v.string(),
+      kind: v.string(),
+      parentId: v.nullable(
+        chatEntityRef({ from: "inputParam", param: "matter_id" }),
+      ),
+    }),
+  ),
+  // Opaque `[createdAt, id]` cursor; embeds an entity id, not UUID-formatted.
+  nextCursor: v.nullable(passthroughId()),
+});
 
 /**
  * The `FieldContent` union (`schema-validators.ts`), modeled variant by
@@ -347,6 +463,848 @@ const READ_DOCUMENT_PROJECTION: ChatProjectionSchema = v.union([
 ]);
 
 /**
+ * list_properties. Source of truth: `handleListPropertiesTool`
+ * (`document-tools.ts`) — selected property columns mapped to
+ * `{ id, name, valueType, status }`.
+ */
+const LIST_PROPERTIES_PROJECTION: ChatProjectionSchema = v.strictObject({
+  properties: v.array(
+    v.strictObject({
+      id: chatRef("property"),
+      name: v.string(),
+      valueType: v.string(),
+      status: v.string(),
+    }),
+  ),
+  // Opaque `[createdAt, id]` cursor; not UUID-formatted.
+  nextCursor: v.nullable(passthroughId()),
+});
+
+/**
+ * list_tasks, list branch. Source of truth: `handleListTasksTool`
+ * (`matter-tools.ts`) — selected entity columns minus the cursor timestamp.
+ */
+const listTasksListProjection = v.strictObject({
+  tasks: v.array(
+    v.strictObject({
+      id: chatEntityRef({ from: "inputParam", param: "matter_id" }),
+      name: v.string(),
+      status: v.nullable(v.string()),
+      priority: v.nullable(v.string()),
+      dueDate: v.nullable(v.string()),
+    }),
+  ),
+  // Opaque `[createdAt, id]` cursor embedding an entity id, not
+  // UUID-formatted.
+  nextCursor: v.nullable(passthroughId()),
+});
+
+/**
+ * list_tasks, detail branch: one task's fields, assignees, and entity links
+ * (`readTaskDetail` + the mappers in `handleListTasksTool`).
+ */
+const listTasksDetailProjection = v.strictObject({
+  task: v.strictObject({
+    taskId: chatEntityRef({ from: "inputEntity", param: "task_id" }),
+    name: v.string(),
+    status: v.nullable(v.string()),
+    priority: v.nullable(v.string()),
+    dueDate: v.nullable(v.string()),
+    startAt: v.nullable(v.string()),
+    endAt: v.nullable(v.string()),
+    location: v.nullable(v.string()),
+    agendaKind: v.nullable(v.string()),
+    assignees: v.array(
+      v.strictObject({
+        // Workspace-member (user) handle save_task assignee args accept.
+        userId: passthroughId(),
+        name: v.string(),
+        role: v.string(),
+      }),
+    ),
+    links: v.array(
+      v.strictObject({
+        // Entity-link handle save_task's unlink_link_id accepts.
+        linkId: passthroughId(),
+        linkType: v.string(),
+        direction: v.string(),
+        entity: v.strictObject({
+          // Entity links are validated same-workspace at creation:
+          // `createEntityLinkHandler` (entity-links-create.ts, shared by the
+          // HTTP route and save_task) looks up both the source and target
+          // entities scoped to one ambient `workspaceId` before inserting
+          // the link row, so a linked entity always belongs to the task's
+          // own workspace. Detail mode only reaches this path via `task_id`
+          // (list mode's `tasks[]` carries no `links`), so the workspace
+          // already resolved for that input entity is the correct source.
+          id: v.nullable(
+            chatEntityRef({ from: "inputEntityWorkspace", param: "task_id" }),
+          ),
+          name: v.nullable(v.string()),
+          kind: v.nullable(v.string()),
+        }),
+      }),
+    ),
+  }),
+});
+
+const LIST_TASKS_PROJECTION: ChatProjectionSchema = v.union([
+  listTasksListProjection,
+  listTasksDetailProjection,
+]);
+
+/**
+ * One clause-body paragraph (`ClauseParagraph`, `lib/clauses/types.ts`): the
+ * text plus optional style/list/directive metadata. Org-authored data, no
+ * ids.
+ */
+const clauseParagraphProjection = v.strictObject({
+  text: v.string(),
+  style: v.optional(v.string()),
+  level: v.optional(v.number()),
+  runs: v.optional(
+    v.array(
+      v.strictObject({
+        text: v.string(),
+        bold: v.optional(v.boolean()),
+        italic: v.optional(v.boolean()),
+      }),
+    ),
+  ),
+  isDirective: v.optional(v.boolean()),
+  directiveKind: v.optional(v.string()),
+  directiveExpression: v.optional(v.string()),
+  listKind: v.optional(v.string()),
+  listLevel: v.optional(v.number()),
+});
+
+const clauseBodyProjection: v.GenericSchema = v.array(
+  clauseParagraphProjection,
+);
+
+/**
+ * list_clauses, list branch. Source of truth: `handleListClausesTool`
+ * (`knowledge-tools.ts`) forwarding `listClausesHandler` items, plus the
+ * optional `listCategoriesHandler` catalog. Clause, category, and
+ * clause-version ids are org-scoped library handles, not tenant refs.
+ */
+const listClausesListProjection = v.strictObject({
+  clauses: v.array(
+    v.strictObject({
+      id: passthroughId(),
+      title: v.string(),
+      categoryId: v.nullable(passthroughId()),
+      language: v.nullable(v.string()),
+      description: v.nullable(v.string()),
+      currentVersion: v.number(),
+      createdAt: v.string(),
+      updatedAt: v.string(),
+    }),
+  ),
+  categories: v.optional(
+    v.array(
+      v.strictObject({
+        id: passthroughId(),
+        parentId: v.nullable(passthroughId()),
+        name: v.string(),
+        description: v.nullable(v.string()),
+        sortOrder: v.number(),
+        createdAt: v.string(),
+        updatedAt: v.string(),
+      }),
+    ),
+  ),
+  // Opaque `${isoDate}|${clauseId}` cursor.
+  nextCursor: v.nullable(passthroughId()),
+});
+
+/**
+ * list_clauses, detail branch (`readClauseDetail` + `getClauseHandler`).
+ * `metadata` is set to `undefined` at the handler, so it never survives the
+ * JSON round-trip; `createdBy` is the authoring user's id (a `text` column,
+ * not a uuid column, but licensed defensively in case a deployment's user
+ * ids happen to be uuid-shaped).
+ */
+const listClausesDetailProjection = v.strictObject({
+  clause: v.strictObject({
+    id: passthroughId(),
+    title: v.string(),
+    categoryId: v.nullable(passthroughId()),
+    description: v.nullable(v.string()),
+    usageNotes: v.nullable(v.string()),
+    language: v.nullable(v.string()),
+    body: clauseBodyProjection,
+    currentVersion: v.number(),
+    createdBy: passthroughId(),
+    createdAt: v.string(),
+    updatedAt: v.string(),
+    variants: v.array(
+      v.strictObject({
+        id: passthroughId(),
+        label: v.string(),
+        body: clauseBodyProjection,
+        sortOrder: v.number(),
+        createdAt: v.string(),
+      }),
+    ),
+    versions: v.array(
+      v.strictObject({
+        id: passthroughId(),
+        version: v.number(),
+        createdAt: v.string(),
+      }),
+    ),
+  }),
+});
+
+/** list_clauses, version branch (`getClauseVersionHandler`). */
+const listClausesVersionProjection = v.strictObject({
+  version: v.strictObject({
+    id: passthroughId(),
+    version: v.number(),
+    body: clauseBodyProjection,
+    createdAt: v.string(),
+  }),
+});
+
+const LIST_CLAUSES_PROJECTION: ChatProjectionSchema = v.union([
+  listClausesListProjection,
+  listClausesDetailProjection,
+  listClausesVersionProjection,
+]);
+
+/**
+ * The acceptable tier's ideal language (`idealLanguageSchema`,
+ * `lib/workflow/playbook-positions.ts`): a clause-library link or inline
+ * text. The clause id is the same org-scoped library handle `list_clauses`
+ * licenses. The hand-written entry licensed a stale
+ * `items[].standard.clauseId` path from the pre-v2 positions shape instead —
+ * exactly the silent drift a hand list cannot surface; the derivation test
+ * documents the swap.
+ */
+const playbookIdealLanguageProjection: ChatProjectionSchema = v.variant(
+  "source",
+  [
+    v.strictObject({
+      source: v.literal("clause"),
+      clauseId: passthroughId(),
+      clauseVersion: v.optional(v.number()),
+    }),
+    v.strictObject({ source: v.literal("inline"), text: v.string() }),
+  ],
+);
+
+/**
+ * The Acceptable / Fallback / Not acceptable ladder (`tiersSchema`). Tier
+ * rule and fallback-entry ids are client-supplied stable ids inside the
+ * positions jsonb, UUID-shaped in practice; no chat tool accepts them, so
+ * the projection strips them instead of passing UUID noise to the model.
+ */
+const playbookTiersProjection = v.strictObject({
+  acceptable: v.strictObject({
+    rules: v.array(v.strictObject({ id: strippedField(), text: v.string() })),
+    ideal: v.optional(playbookIdealLanguageProjection),
+  }),
+  fallback: v.strictObject({
+    entries: v.array(
+      v.strictObject({
+        id: strippedField(),
+        text: v.string(),
+        label: v.optional(v.string()),
+      }),
+    ),
+  }),
+  notAcceptable: v.strictObject({
+    rules: v.array(v.strictObject({ id: strippedField(), text: v.string() })),
+  }),
+});
+
+// `content` is a `PropertyContent` config (a structural type descriptor with
+// no stable leaf grammar across its variants): an unenumerated subtree, so
+// the UUID backstop still guards its contents unlicensed.
+const playbookAskManualProjection = v.strictObject({
+  question: v.string(),
+  content: unenumeratedJson(),
+});
+
+const playbookAskConfigProjection: ChatProjectionSchema = v.variant("mode", [
+  v.strictObject({
+    mode: v.literal("auto"),
+    derived: v.optional(
+      v.strictObject({
+        question: v.string(),
+        content: unenumeratedJson(),
+        rulesHash: v.string(),
+      }),
+    ),
+  }),
+  v.strictObject({
+    mode: v.literal("manual"),
+    question: v.string(),
+    content: unenumeratedJson(),
+  }),
+]);
+
+/**
+ * One playbook position (`positionSchema`): the `extract` and `graded`
+ * variants. `check` carries a recursive condition AST (`tConditionNode`):
+ * unenumerated, so the backstop still guards it.
+ */
+const playbookPositionProjection: ChatProjectionSchema = v.variant("mode", [
+  v.strictObject({
+    mode: v.literal("extract"),
+    // Client-supplied stable id that maps a position back to its
+    // materialized column across edits; run_playbook accepts none of these,
+    // but the id survives as a documented handle rather than UUID noise the
+    // strict parse would refuse.
+    sourceId: passthroughId(),
+    issue: v.string(),
+    ask: playbookAskManualProjection,
+    guidance: v.optional(v.string()),
+    enabled: v.boolean(),
+  }),
+  v.strictObject({
+    mode: v.literal("graded"),
+    sourceId: passthroughId(),
+    issue: v.string(),
+    severity: v.string(),
+    tiers: playbookTiersProjection,
+    check: v.optional(unenumeratedJson()),
+    ask: playbookAskConfigProjection,
+    guidance: v.optional(v.string()),
+    negotiation: v.optional(
+      v.strictObject({
+        rationale: v.optional(v.string()),
+        talkingPoints: v.optional(v.array(v.string())),
+        escalation: v.optional(v.string()),
+      }),
+    ),
+    enabled: v.boolean(),
+  }),
+]);
+
+/**
+ * list_playbooks, list branch. Source of truth:
+ * `listPlaybookDefinitionsHandler` (`handlers/playbooks/read.ts`), forwarded
+ * verbatim as `{ items, nextCursor }`.
+ */
+const listPlaybooksListProjection = v.strictObject({
+  items: v.array(
+    v.strictObject({
+      id: passthroughId(),
+      name: v.string(),
+      description: v.nullable(v.string()),
+      status: v.string(),
+      createdAt: v.string(),
+      updatedAt: v.string(),
+    }),
+  ),
+  // Opaque `[playbookId]` cursor, base64url-encoded.
+  nextCursor: v.nullable(passthroughId()),
+});
+
+/**
+ * list_playbooks, detail branch (`getPlaybookDefinitionHandler`): the full
+ * definition including the versioned positions jsonb.
+ */
+const listPlaybooksDetailProjection = v.strictObject({
+  playbook: v.strictObject({
+    id: passthroughId(),
+    name: v.string(),
+    description: v.nullable(v.string()),
+    scope: v.nullable(
+      v.strictObject({
+        documentTypeKey: v.optional(v.string()),
+        perspective: v.optional(v.string()),
+        trigger: v.optional(v.string()),
+      }),
+    ),
+    positions: v.strictObject({
+      version: v.literal(2),
+      items: v.array(playbookPositionProjection),
+    }),
+    status: v.string(),
+    approvedAt: v.nullable(v.string()),
+    createdAt: v.string(),
+    updatedAt: v.string(),
+  }),
+});
+
+const LIST_PLAYBOOKS_PROJECTION: ChatProjectionSchema = v.union([
+  listPlaybooksListProjection,
+  listPlaybooksDetailProjection,
+]);
+
+/**
+ * The time-entry columns both list_time_entries branches select
+ * (`timeEntryColumns`, `billing-tools.ts`), plus the `userName` the handler
+ * resolves. `entityId` is the entry's matter entity; `id`/`userId` are
+ * billing/user handles, not tenant refs.
+ */
+const timeEntryFieldEntries = (workspace: { from: "inputParam" | "sibling" }) =>
+  ({
+    id: passthroughId(),
+    entityId: chatEntityRef(
+      workspace.from === "inputParam"
+        ? { from: "inputParam", param: "matter_id" }
+        : { from: "sibling", key: "workspaceId" },
+    ),
+    userId: v.nullable(passthroughId()),
+    dateWorked: v.string(),
+    durationMinutes: v.number(),
+    billedMinutes: v.number(),
+    rateAtEntry: v.number(),
+    currency: v.string(),
+    narrative: v.string(),
+    invoiceNarrative: v.nullable(v.string()),
+    billable: v.boolean(),
+    noCharge: v.boolean(),
+    status: v.string(),
+    userName: v.nullable(v.string()),
+  }) as const;
+
+const LIST_TIME_ENTRIES_PROJECTION: ChatProjectionSchema = v.union([
+  // List mode: matter_id is schema-required, so it is every row's workspace.
+  v.strictObject({
+    entries: v.array(
+      v.strictObject(timeEntryFieldEntries({ from: "inputParam" })),
+    ),
+    // Opaque `[dateWorked, id]` cursor, not UUID-formatted.
+    nextCursor: v.nullable(passthroughId()),
+  }),
+  // Detail mode may be reached by time_entry_id alone, so the entry carries
+  // its resolved owning workspace: a matter ref, and the entity's workspace
+  // source.
+  v.strictObject({
+    entry: v.strictObject({
+      ...timeEntryFieldEntries({ from: "sibling" }),
+      workspaceId: chatRef("matter"),
+    }),
+  }),
+]);
+
+/**
+ * resolve_rate. Source of truth: `handleResolveRateTool` (`billing-tools.ts`)
+ * — a rate amount in minor units and a currency code, or nulls when no rate
+ * table matches.
+ */
+const RESOLVE_RATE_PROJECTION: ChatProjectionSchema = v.strictObject({
+  hourlyRate: v.nullable(v.number()),
+  currency: v.nullable(v.string()),
+});
+
+/** One invoiced line item's matter entity card (`{ id, name }`). */
+const invoiceLineEntityProjection = () =>
+  v.strictObject({
+    id: chatEntityRef({ from: "outputPath", path: "invoice.workspaceId" }),
+    name: v.string(),
+  });
+
+/**
+ * list_invoices. Source of truth: `handleListInvoicesTool`
+ * (`billing-tools.ts`). Detail mode (invoice_id) may omit matter_id, so every
+ * line item's entity recovers its workspace from the invoice's own resolved
+ * `workspaceId` rather than from the (absent) input arg; list mode returns no
+ * line items.
+ */
+const LIST_INVOICES_PROJECTION: ChatProjectionSchema = v.union([
+  v.strictObject({
+    invoices: v.array(
+      v.strictObject({
+        id: passthroughId(),
+        invoiceNumber: v.string(),
+        reference: v.nullable(v.string()),
+        status: v.string(),
+        invoiceDate: v.string(),
+        dueDate: v.nullable(v.string()),
+        currency: v.string(),
+        totalAmount: v.number(),
+      }),
+    ),
+    // Opaque `[createdAt, id]` cursor, not UUID-formatted.
+    nextCursor: v.nullable(passthroughId()),
+  }),
+  v.strictObject({
+    invoice: v.strictObject({
+      id: passthroughId(),
+      // The detail invoice's own owning workspace is a matter ref.
+      workspaceId: chatRef("matter"),
+      invoiceNumber: v.string(),
+      reference: v.nullable(v.string()),
+      status: v.string(),
+      invoiceDate: v.string(),
+      dueDate: v.nullable(v.string()),
+      currency: v.string(),
+      totalAmount: v.number(),
+      notes: v.nullable(v.string()),
+      paidAt: v.nullable(v.string()),
+      createdAt: v.string(),
+      updatedAt: v.string(),
+      timeEntries: v.array(
+        v.strictObject({
+          id: passthroughId(),
+          entityId: chatEntityRef({
+            from: "outputPath",
+            path: "invoice.workspaceId",
+          }),
+          dateWorked: v.string(),
+          billedMinutes: v.number(),
+          rateAtEntry: v.number(),
+          currency: v.string(),
+          narrative: v.string(),
+          invoiceNarrative: v.nullable(v.string()),
+          status: v.string(),
+          entity: invoiceLineEntityProjection(),
+        }),
+      ),
+      expenses: v.array(
+        v.strictObject({
+          id: passthroughId(),
+          entityId: chatEntityRef({
+            from: "outputPath",
+            path: "invoice.workspaceId",
+          }),
+          dateIncurred: v.string(),
+          amount: v.number(),
+          currency: v.string(),
+          category: v.string(),
+          description: v.string(),
+          invoiceDescription: v.nullable(v.string()),
+          billable: v.boolean(),
+          markup: v.number(),
+          entity: invoiceLineEntityProjection(),
+        }),
+      ),
+    }),
+  }),
+]);
+
+/**
+ * get_usage. Source of truth: `readOrgEntitlementHandler`
+ * (`handlers/usage/get-entitlement.ts`): `{ entitlement: null }` when the
+ * organization has no active plan, otherwise the plan/seat/period shape.
+ * Entitlement and policy ids are org billing-plan handles, not tenant refs.
+ */
+const GET_USAGE_PROJECTION: ChatProjectionSchema = v.union([
+  v.strictObject({ entitlement: v.null() }),
+  v.strictObject({
+    entitlement: v.strictObject({
+      id: passthroughId(),
+      status: v.string(),
+      seats: v.number(),
+      source: v.string(),
+      currentPeriodStart: v.string(),
+      currentPeriodEnd: v.string(),
+      cancelAtPeriodEnd: v.boolean(),
+    }),
+    policy: v.strictObject({
+      id: passthroughId(),
+      key: v.string(),
+      displayName: v.string(),
+      monthlyUsageUnitsPerSeat: v.number(),
+    }),
+    remainingUsageUnits: v.number(),
+  }),
+]);
+
+/** One facet bucket of the case-law search response. */
+const caseLawFacetBucketProjection = v.strictObject({
+  value: v.string(),
+  count: v.number(),
+});
+
+/**
+ * search_case_law. Source of truth: `handleSearchCaseLawTool`
+ * (`stella-tools.ts`) mapping `searchDecisionsHandler` hits; `facets` and
+ * `totalCount` are null on cursor pages. Decision ids are public case-law
+ * corpus ids, not tenant refs.
+ */
+const SEARCH_CASE_LAW_PROJECTION: ChatProjectionSchema = v.strictObject({
+  facets: v.nullable(
+    v.strictObject({
+      court: v.array(caseLawFacetBucketProjection),
+      country: v.array(caseLawFacetBucketProjection),
+      language: v.array(caseLawFacetBucketProjection),
+    }),
+  ),
+  // Opaque `[score, decisionId]` cursor, base64url-encoded.
+  nextCursor: v.nullable(passthroughId()),
+  results: v.array(
+    v.strictObject({
+      appUrl: v.string(),
+      caseNumber: v.string(),
+      citationCount: v.number(),
+      country: v.string(),
+      court: v.string(),
+      decisionDate: v.nullable(v.string()),
+      decisionId: passthroughId(),
+      decisionType: v.nullable(v.string()),
+      ecli: v.nullable(v.string()),
+      language: v.string(),
+      snippet: v.nullable(v.string()),
+      sourceUrl: v.nullable(v.string()),
+    }),
+  ),
+  totalCount: v.nullable(v.number()),
+});
+
+/**
+ * read_case_law_decision. Source of truth: `handleReadCaseLawDecisionTool`
+ * (`stella-tools.ts`) mapping `readDecisionWithDocumentHandler`. All ids are
+ * public case-law corpus ids (decision, citation, source). `metadata` is
+ * free-form public jsonb straight from the court source and cannot be
+ * enumerated by path (same unenumerable-payload caveat as `list_audit_log`'s
+ * `metadata`/`changes`, just over public rather than tenant data): declared
+ * as an unenumerated subtree the walker skips, so the strict parse admits it
+ * while the UUID backstop still guards every string inside, unlicensed.
+ */
+const READ_CASE_LAW_DECISION_PROJECTION: ChatProjectionSchema = v.strictObject({
+  // Opaque compound `[textOffset, fromOffset, toOffset]` cursor.
+  nextCursor: v.nullable(passthroughId()),
+  decision: v.strictObject({
+    appUrl: v.string(),
+    caseNumber: v.string(),
+    citationsFrom: v.array(
+      v.strictObject({
+        id: passthroughId(),
+        citationText: v.string(),
+        citedDecisionId: v.nullable(passthroughId()),
+        sectionIndex: v.nullable(v.number()),
+      }),
+    ),
+    citationsFromTotal: v.number(),
+    citationsTo: v.array(
+      v.strictObject({
+        id: passthroughId(),
+        citationText: v.string(),
+        citingDecisionId: passthroughId(),
+        sectionIndex: v.nullable(v.number()),
+      }),
+    ),
+    citationsToTotal: v.number(),
+    country: v.string(),
+    court: v.string(),
+    decisionDate: v.nullable(v.string()),
+    decisionId: passthroughId(),
+    decisionType: v.nullable(v.string()),
+    documentUrl: v.nullable(v.string()),
+    ecli: v.nullable(v.string()),
+    language: v.string(),
+    metadata: unenumeratedJson(),
+    source: v.strictObject({
+      id: passthroughId(),
+      name: v.string(),
+      adapterKey: v.string(),
+      allowsDerivedAi: v.boolean(),
+    }),
+    sourceUrl: v.nullable(v.string()),
+    text: v.nullable(v.string()),
+    charCount: v.nullable(v.number()),
+    truncated: v.boolean(),
+    textWithheldReason: v.optional(v.string()),
+  }),
+});
+
+/**
+ * search_legislation, all four branches (`handleSearchLegislationTool`,
+ * `research-admin-tools.ts`). Public BOE statutory data throughout; the BOE
+ * envelopes (`metadata`/`analysis`/`structure`) are deliberately `unknown` in
+ * `@stll/boe` (undocumented upstream schema), so they project as
+ * unenumerated subtrees the backstop still guards. Ids are BOE identifiers
+ * (`BOE-A-…`), never UUID-formatted in practice (`lawId` is schema-validated
+ * against the BOE id pattern; `blockId` and `data[].identificador` are
+ * licensed defensively since `blockId` is an unvalidated request-argument
+ * echo).
+ */
+const SEARCH_LEGISLATION_PROJECTION: ChatProjectionSchema = v.union([
+  // block branch: one article/disposition as raw XML.
+  v.strictObject({
+    lawId: passthroughId(),
+    blockId: passthroughId(),
+    block: v.string(),
+  }),
+  // related branch: `findRelatedLaws` (`@stll/boe`).
+  v.strictObject({
+    lawId: passthroughId(),
+    relationType: v.string(),
+    analysis: unenumeratedJson(),
+  }),
+  // default read branch: `{ law, structure }` (`getConsolidatedLaw` +
+  // `getLawStructure`).
+  v.strictObject({
+    law: v.strictObject({
+      lawId: passthroughId(),
+      metadata: unenumeratedJson(),
+      analysis: unenumeratedJson(),
+      fullText: v.nullable(v.string()),
+      eli: v.nullable(v.string()),
+    }),
+    structure: unenumeratedJson(),
+  }),
+  // search branch: the raw `BoeSearchResponse` envelope (every field
+  // optional upstream).
+  v.strictObject({
+    data: v.optional(
+      v.array(
+        v.strictObject({
+          identificador: passthroughId(),
+          titulo: v.optional(v.string()),
+          fecha_publicacion: v.optional(v.string()),
+          fecha_disposicion: v.optional(v.string()),
+          departamento: v.optional(
+            v.strictObject({
+              codigo: v.optional(v.string()),
+              texto: v.optional(v.string()),
+            }),
+          ),
+          rango: v.optional(
+            v.strictObject({
+              codigo: v.optional(v.string()),
+              texto: v.optional(v.string()),
+            }),
+          ),
+          estado_consolidacion: v.optional(
+            v.strictObject({
+              codigo: v.optional(v.string()),
+              texto: v.optional(v.string()),
+            }),
+          ),
+          url_eli: v.optional(v.string()),
+          url_html_consolidada: v.optional(v.string()),
+        }),
+      ),
+    ),
+    status: v.optional(
+      v.strictObject({
+        code: v.optional(v.string()),
+        text: v.optional(v.string()),
+      }),
+    ),
+  }),
+]);
+
+/**
+ * One cross-registry hit (`BusinessRegistryHit`,
+ * `lib/business-registries/dispatch.ts`). `id` is the external registry's
+ * own identifier (company/registration number), plain public data — not a
+ * UUID handle, so it needs no license. `details` is the adapter-specific
+ * upstream payload (a different typed shape per registry): an unenumerated
+ * subtree the backstop still guards.
+ */
+const businessRegistryHitProjection = v.strictObject({
+  registry: v.string(),
+  id: v.string(),
+  name: v.string(),
+  legalForm: v.nullable(v.string()),
+  address: v.nullable(
+    v.strictObject({
+      line1: v.nullable(v.string()),
+      line2: v.nullable(v.string()),
+      postalCode: v.nullable(v.string()),
+      city: v.nullable(v.string()),
+      region: v.nullable(v.string()),
+      country: v.nullable(v.string()),
+      textAddress: v.nullable(v.string()),
+    }),
+  ),
+  registryUrl: v.string(),
+  details: v.optional(unenumeratedJson()),
+});
+
+/**
+ * lookup_business_registry. Source of truth: `executeRegistryLookup`'s
+ * `RegistryLookupResponse` union, forwarded verbatim by
+ * `handleLookupBusinessRegistryTool` (`matter-tools.ts`).
+ */
+const LOOKUP_BUSINESS_REGISTRY_PROJECTION: ChatProjectionSchema = v.variant(
+  "type",
+  [
+    v.strictObject({
+      type: v.literal("lookup"),
+      registry: v.string(),
+      hit: v.nullable(businessRegistryHitProjection),
+    }),
+    v.strictObject({
+      type: v.literal("search"),
+      registry: v.string(),
+      hits: v.array(businessRegistryHitProjection),
+    }),
+  ],
+);
+
+/**
+ * The describe shape (`DescribeTemplateResult` success variant,
+ * `lib/templates/template-fill-service.ts`) served by list_templates' detail
+ * mode and echoed by save_template's configure branch. Field paths, input
+ * types, options, and condition/formula expressions are structural
+ * org-authored data; no ids anywhere.
+ */
+const templateDescribeProjection = v.strictObject({
+  name: v.string(),
+  fields: v.array(
+    v.strictObject({
+      path: v.string(),
+      label: v.nullable(v.string()),
+      inputType: v.string(),
+      required: v.boolean(),
+      hint: v.nullable(v.string()),
+      options: v.nullable(v.array(v.string())),
+      formats: v.nullable(
+        v.array(v.strictObject({ key: v.string(), template: v.string() })),
+      ),
+      aiPrompt: v.nullable(v.string()),
+      aiAdapt: v.boolean(),
+      optionsFrom: v.nullable(v.string()),
+      dateFormat: v.nullable(
+        v.strictObject({ locale: v.string(), style: v.string() }),
+      ),
+      parts: v.nullable(
+        v.array(
+          v.strictObject({
+            key: v.string(),
+            label: v.optional(v.string()),
+            inputType: v.string(),
+            options: v.optional(v.array(v.string())),
+            pattern: v.optional(v.string()),
+          }),
+        ),
+      ),
+      format: v.nullable(v.string()),
+    }),
+  ),
+  conditions: v.array(
+    v.strictObject({ name: v.string(), expression: v.string() }),
+  ),
+  computed: v.array(
+    v.strictObject({ name: v.string(), expression: v.string() }),
+  ),
+});
+
+/**
+ * list_templates. Source of truth: `handleListTemplatesTool` +
+ * `describeTemplateDetail` (`template-tools.ts`). Template ids are org
+ * template handles; detail mode's describe payload carries no id fields at
+ * all.
+ */
+const LIST_TEMPLATES_PROJECTION: ChatProjectionSchema = v.union([
+  v.strictObject({
+    templates: v.array(
+      v.strictObject({
+        id: passthroughId(),
+        name: v.string(),
+        fieldCount: v.number(),
+        tags: v.nullable(v.array(v.string())),
+        whenToUse: v.nullable(v.string()),
+        whenNotToUse: v.nullable(v.string()),
+      }),
+    ),
+    // Opaque `[templateId]` cursor, base64url-encoded.
+    nextCursor: v.nullable(passthroughId()),
+  }),
+  templateDescribeProjection,
+]);
+
+/**
  * Per-tool ref decision for every read tool in the MCP registry. Keyed by the
  * derived `RegistryReadToolName` union via `satisfies`, so the map is
  * exhaustive by construction: a read tool with no entry here cannot compile.
@@ -357,33 +1315,12 @@ export const READ_TOOL_REF_FIELD_MAP = {
   // search_across_matters and additionally emit `url` (and `metadata`) fields
   // that embed raw workspace/entity UUIDs inside a string the ref walker cannot
   // rewrite without reparsing URLs. Chat projects the native equivalents
-  // instead, so these are kept off the chat surface: `chatProjectable: false`
-  // makes the paths below inert (the orchestrator refuses the tool before the
-  // backstop ever walks its payload), they are listed only so the shape stays
-  // documented if that ever changes.
-  fetch: {
-    chatProjectable: false,
-    inputRefs: [],
-    outputRefs: [],
-    passthroughIdPaths: ["id", "url", "workspaceId"],
-    stripPaths: [],
-  },
-  search: {
-    chatProjectable: false,
-    inputRefs: [],
-    outputRefs: [],
-    passthroughIdPaths: [
-      "results[].id",
-      "results[].url",
-      "results[].workspaceId",
-    ],
-    stripPaths: [],
-  },
+  // instead, so these are kept off the chat surface: the orchestrator refuses
+  // the tool before any projection could run.
+  fetch: { chatProjectable: false },
+  search: { chatProjectable: false },
 
   // --- Matters / contacts / content -----------------------------------------
-  // Converted: the projection schema above is the single output-side artifact;
-  // its strict parse fails closed on any handler field the schema does not
-  // declare, and the mediation lists are derived from its annotations.
   list_matters: {
     chatProjectable: true,
     inputRefs: [{ kind: "matter", param: "matter_id" }],
@@ -392,45 +1329,22 @@ export const READ_TOOL_REF_FIELD_MAP = {
   list_contacts: {
     chatProjectable: true,
     inputRefs: [],
-    outputRefs: [{ kind: "contact", path: "items[].id" }],
-    // `nextCursor` is an opaque base64url pagination cursor.
-    passthroughIdPaths: ["nextCursor"],
-    stripPaths: [],
+    projection: LIST_CONTACTS_PROJECTION,
   },
   search_across_matters: {
     chatProjectable: true,
     inputRefs: [],
-    outputRefs: [
-      { kind: "matter", path: "hits[].workspaceId" },
-      {
-        kind: "entity",
-        path: "hits[].entityId",
-        workspace: { from: "sibling", key: "workspaceId" },
-      },
-    ],
-    passthroughIdPaths: [],
-    stripPaths: [],
+    projection: SEARCH_ACROSS_MATTERS_PROJECTION,
   },
   read_content_across_matters: {
     chatProjectable: true,
     inputRefs: [{ kind: "entity", param: "entity_id" }],
-    outputRefs: [
-      { kind: "matter", path: "workspaceId" },
-      {
-        kind: "entity",
-        path: "entityId",
-        workspace: { from: "sibling", key: "workspaceId" },
-      },
-    ],
-    passthroughIdPaths: [],
-    stripPaths: [],
+    projection: READ_CONTENT_ACROSS_MATTERS_PROJECTION,
   },
   read_contact: {
     chatProjectable: true,
     inputRefs: [{ kind: "contact", param: "contact_id" }],
-    outputRefs: [{ kind: "contact", path: "contactId" }],
-    passthroughIdPaths: [],
-    stripPaths: [],
+    projection: READ_CONTACT_PROJECTION,
   },
 
   // --- Documents / properties -----------------------------------------------
@@ -440,27 +1354,8 @@ export const READ_TOOL_REF_FIELD_MAP = {
       { kind: "matter", param: "matter_id" },
       { kind: "entity", param: "parent_id" },
     ],
-    outputRefs: [
-      {
-        kind: "entity",
-        path: "documents[].id",
-        workspace: { from: "inputParam", param: "matter_id" },
-      },
-      {
-        kind: "entity",
-        path: "documents[].parentId",
-        workspace: { from: "inputParam", param: "matter_id" },
-      },
-    ],
-    // Opaque `[createdAt, id]` cursor; embeds an entity id, not UUID-formatted.
-    passthroughIdPaths: ["nextCursor"],
-    stripPaths: [],
+    projection: LIST_DOCUMENTS_PROJECTION,
   },
-  // Converted: see READ_DOCUMENT_PROJECTION above. Beyond reproducing the
-  // previous hand lists, the schema strips the file-content plumbing UUIDs
-  // (`fields[].content.id`/`.pdfFileId` and the version-branch twins) that
-  // the hand entry never declared and that tripped the prod backstop on any
-  // document whose field held a file.
   read_document: {
     chatProjectable: true,
     inputRefs: [{ kind: "entity", param: "entity_id" }],
@@ -469,10 +1364,7 @@ export const READ_TOOL_REF_FIELD_MAP = {
   list_properties: {
     chatProjectable: true,
     inputRefs: [{ kind: "matter", param: "matter_id" }],
-    outputRefs: [{ kind: "property", path: "properties[].id" }],
-    // Opaque `[createdAt, id]` cursor; not UUID-formatted.
-    passthroughIdPaths: ["nextCursor"],
-    stripPaths: [],
+    projection: LIST_PROPERTIES_PROJECTION,
   },
 
   // --- Tasks -----------------------------------------------------------------
@@ -482,40 +1374,7 @@ export const READ_TOOL_REF_FIELD_MAP = {
       { kind: "matter", param: "matter_id" },
       { kind: "entity", param: "task_id" },
     ],
-    outputRefs: [
-      {
-        kind: "entity",
-        path: "tasks[].id",
-        workspace: { from: "inputParam", param: "matter_id" },
-      },
-      {
-        kind: "entity",
-        path: "task.taskId",
-        workspace: { from: "inputEntity", param: "task_id" },
-      },
-      {
-        kind: "entity",
-        path: "task.links[].entity.id",
-        // Entity links are validated same-workspace at creation:
-        // `createEntityLinkHandler` (entity-links-create.ts, shared by the
-        // HTTP route and save_task) looks up both the source and target
-        // entities scoped to one ambient `workspaceId` before inserting the
-        // link row, so a linked entity always belongs to the task's own
-        // workspace. Detail mode only reaches this path via `task_id`
-        // (list mode's `tasks[]` carries no `links`), so the workspace
-        // already resolved for that input entity is the correct source.
-        workspace: { from: "inputEntityWorkspace", param: "task_id" },
-      },
-    ],
-    // Assignee ids are user handles, link ids are entity-link handles
-    // (neither carries a chat ref kind); `nextCursor` is an opaque
-    // `[createdAt, id]` cursor embedding an entity id, not UUID-formatted.
-    passthroughIdPaths: [
-      "task.assignees[].userId",
-      "task.links[].linkId",
-      "nextCursor",
-    ],
-    stripPaths: [],
+    projection: LIST_TASKS_PROJECTION,
   },
 
   // --- Knowledge: org-scoped handles, no tenant refs ------------------------
@@ -524,50 +1383,12 @@ export const READ_TOOL_REF_FIELD_MAP = {
   list_clauses: {
     chatProjectable: true,
     inputRefs: [],
-    outputRefs: [],
-    // Clause, category, variant, and clause-version ids are org-scoped
-    // library handles; `clause.createdBy` is the authoring user's id (a
-    // `text` column, not a uuid column, but declared defensively in case a
-    // deployment's user ids happen to be uuid-shaped); `nextCursor` is an
-    // opaque `${isoDate}|${clauseId}` cursor.
-    passthroughIdPaths: [
-      "clauses[].id",
-      "clauses[].categoryId",
-      "clause.id",
-      "clause.categoryId",
-      "clause.variants[].id",
-      "clause.versions[].id",
-      "clause.createdBy",
-      "categories[].id",
-      "categories[].parentId",
-      "version.id",
-      "nextCursor",
-    ],
-    stripPaths: [],
+    projection: LIST_CLAUSES_PROJECTION,
   },
   list_playbooks: {
     chatProjectable: true,
     inputRefs: [],
-    outputRefs: [],
-    // Playbook ids are org-scoped library handles; a position's `sourceId` is
-    // a client-supplied stable id; a "clause"-sourced standard's `clauseId`
-    // is the same clause-library handle `list_clauses` declares.
-    passthroughIdPaths: [
-      "items[].id",
-      "playbook.id",
-      "playbook.positions.items[].sourceId",
-      "playbook.positions.items[].standard.clauseId",
-      "nextCursor",
-    ],
-    // Tier rule and fallback-entry ids are client-supplied stable ids inside
-    // the positions jsonb, UUID-shaped in practice; no chat tool accepts
-    // them, so the projection strips them instead of passing UUID noise
-    // through to the model.
-    stripPaths: [
-      "playbook.positions.items[].tiers.acceptable.rules[].id",
-      "playbook.positions.items[].tiers.fallback.entries[].id",
-      "playbook.positions.items[].tiers.notAcceptable.rules[].id",
-    ],
+    projection: LIST_PLAYBOOKS_PROJECTION,
   },
 
   // --- Billing: entity refs on line items, rest are billing handles ---------
@@ -577,203 +1398,196 @@ export const READ_TOOL_REF_FIELD_MAP = {
       { kind: "matter", param: "matter_id" },
       { kind: "entity", param: "entity_id" },
     ],
-    outputRefs: [
-      {
-        kind: "entity",
-        path: "entries[].entityId",
-        // List mode always has matter_id (schema-enforced), so the input arg is
-        // the workspace source.
-        workspace: { from: "inputParam", param: "matter_id" },
-      },
-      {
-        kind: "entity",
-        path: "entry.entityId",
-        // Detail mode may omit matter_id (time_entry_id alone), so recover the
-        // workspace from the fetched entry row, which now carries it.
-        workspace: { from: "sibling", key: "workspaceId" },
-      },
-      // The detail entry's own owning workspace is a matter ref.
-      { kind: "matter", path: "entry.workspaceId" },
-    ],
-    // Time-entry ids and user ids carry no chat ref kind; `nextCursor` is an
-    // opaque `[dateWorked, id]` cursor, not UUID-formatted.
-    passthroughIdPaths: [
-      "entries[].id",
-      "entry.id",
-      "entries[].userId",
-      "entry.userId",
-      "nextCursor",
-    ],
-    stripPaths: [],
+    projection: LIST_TIME_ENTRIES_PROJECTION,
   },
   resolve_rate: {
     chatProjectable: true,
     inputRefs: [{ kind: "matter", param: "matter_id" }],
-    outputRefs: [],
-    passthroughIdPaths: [],
-    stripPaths: [],
+    projection: RESOLVE_RATE_PROJECTION,
   },
   list_invoices: {
     chatProjectable: true,
     inputRefs: [{ kind: "matter", param: "matter_id" }],
-    // Detail mode (invoice_id) may omit matter_id, so every line item's entity
-    // recovers its workspace from the invoice's own resolved `workspaceId`
-    // rather than from the (absent) input arg. List mode returns no line items,
-    // so these `invoice.*` paths only ever match the detail branch.
-    outputRefs: [
-      {
-        kind: "entity",
-        path: "invoice.timeEntries[].entityId",
-        workspace: { from: "outputPath", path: "invoice.workspaceId" },
-      },
-      {
-        kind: "entity",
-        path: "invoice.timeEntries[].entity.id",
-        workspace: { from: "outputPath", path: "invoice.workspaceId" },
-      },
-      {
-        kind: "entity",
-        path: "invoice.expenses[].entityId",
-        workspace: { from: "outputPath", path: "invoice.workspaceId" },
-      },
-      {
-        kind: "entity",
-        path: "invoice.expenses[].entity.id",
-        workspace: { from: "outputPath", path: "invoice.workspaceId" },
-      },
-      // The detail invoice's own owning workspace is a matter ref.
-      { kind: "matter", path: "invoice.workspaceId" },
-    ],
-    // Invoice ids and line-item ids (time entry / expense) carry no chat ref
-    // kind; `nextCursor` is an opaque `[createdAt, id]` cursor, not
-    // UUID-formatted.
-    passthroughIdPaths: [
-      "invoices[].id",
-      "invoice.id",
-      "invoice.timeEntries[].id",
-      "invoice.expenses[].id",
-      "nextCursor",
-    ],
-    stripPaths: [],
+    projection: LIST_INVOICES_PROJECTION,
   },
   get_usage: {
     chatProjectable: true,
     inputRefs: [],
-    outputRefs: [],
-    // Org billing-plan ids, not tenant refs.
-    passthroughIdPaths: ["entitlement.id", "policy.id"],
-    stripPaths: [],
+    projection: GET_USAGE_PROJECTION,
   },
 
   // --- Public corpora: public ids, no tenant refs ---------------------------
   search_case_law: {
     chatProjectable: true,
     inputRefs: [],
-    outputRefs: [],
-    // Public case-law corpus id; `source_id` is a request input, never an
-    // output field, so it needs no output-path declaration here.
-    passthroughIdPaths: ["results[].decisionId", "nextCursor"],
-    stripPaths: [],
+    projection: SEARCH_CASE_LAW_PROJECTION,
   },
   read_case_law_decision: {
     chatProjectable: true,
     inputRefs: [],
-    outputRefs: [],
-    // Public case-law corpus ids (decision, citation, and source ids);
-    // `decision.metadata` is free-form jsonb straight from the public court
-    // source and cannot be enumerated by path (same unenumerable-payload
-    // caveat as `list_audit_log`'s `metadata`/`changes`, just over public
-    // rather than tenant data).
-    passthroughIdPaths: [
-      "decision.decisionId",
-      "decision.citationsFrom[].id",
-      "decision.citationsFrom[].citedDecisionId",
-      "decision.citationsTo[].id",
-      "decision.citationsTo[].citingDecisionId",
-      "decision.source.id",
-      "nextCursor",
-    ],
-    stripPaths: [],
+    projection: READ_CASE_LAW_DECISION_PROJECTION,
   },
   search_legislation: {
     chatProjectable: true,
     inputRefs: [],
-    outputRefs: [],
-    // Public BOE statute ids, not tenant refs. Never actually UUID-formatted
-    // (`lawId` is schema-validated against the `BOE-*` id pattern; `blockId`
-    // and `data[].identificador` are declared defensively since `blockId` is
-    // an unvalidated request-argument echo).
-    passthroughIdPaths: [
-      "lawId",
-      "blockId",
-      "law.lawId",
-      "data[].identificador",
-    ],
-    stripPaths: [],
+    projection: SEARCH_LEGISLATION_PROJECTION,
   },
   lookup_business_registry: {
     chatProjectable: true,
     inputRefs: [],
-    outputRefs: [],
-    passthroughIdPaths: [],
-    stripPaths: [],
+    projection: LOOKUP_BUSINESS_REGISTRY_PROJECTION,
   },
 
   // --- Templates: org-scoped template handles -------------------------------
   list_templates: {
     chatProjectable: true,
     inputRefs: [],
-    outputRefs: [],
-    // Org template handle; `template_id` is a request input, not an output
-    // field, so it needs no output-path declaration. Detail mode's describe
-    // payload carries no id fields at all.
-    passthroughIdPaths: ["templates[].id", "nextCursor"],
-    stripPaths: [],
+    projection: LIST_TEMPLATES_PROJECTION,
   },
 
   // --- Audit log: not projected to chat -------------------------------------
   // Excluded from the anonymized surface (`dynamic_tenant_payload`) for the
   // same reason it cannot be safely ref-mediated: `metadata`/`changes` are
   // free-form JSON that may embed any tenant id or tenant text under keys the
-  // walker cannot enumerate, and `nextCursor` embeds the audit-log id verbatim.
-  // Static field mapping cannot guarantee no tenant UUID leaks, so it stays off
-  // the chat surface until a payload-shaping step handles it.
-  list_audit_log: {
-    chatProjectable: false,
-    // `resource_id` is polymorphic (its kind depends on `resource_type`), so it
-    // is deliberately not declared as any single ref kind; the tool is off the
-    // chat surface anyway, so no input dehydration runs.
-    inputRefs: [],
-    outputRefs: [],
-    // `items[].resourceId` is polymorphic and `metadata`/`changes` are
-    // unenumerable free-form tenant JSON, so no path list here could make
-    // this payload safe to walk. Moot in practice: `chatProjectable: false`
-    // means the backstop never runs against this tool's output at all.
-    passthroughIdPaths: ["items[].workspaceId", "items[].resourceId"],
-    stripPaths: [],
-  },
+  // walker cannot enumerate, `items[].resourceId` is polymorphic (its kind
+  // depends on `resource_type`), and `nextCursor` embeds the audit-log id
+  // verbatim. Static field mapping cannot guarantee no tenant UUID leaks, so
+  // it stays off the chat surface until a payload-shaping step handles it.
+  list_audit_log: { chatProjectable: false },
 
   // --- Capability meta-tools: not projected to chat -------------------------
   // The generic capability surface (list/describe/invoke) is reached over the
   // MCP/CLI transport, never from chat: chat has its own curated tool set and
-  // the generic path cannot prove per-capability ref safety. Kept off the chat
-  // surface (`chatProjectable: false`); the entries exist only to satisfy the
-  // typecheck-forced completeness guard.
-  list_capabilities: {
-    chatProjectable: false,
-    inputRefs: [],
-    outputRefs: [],
-    passthroughIdPaths: [],
-    stripPaths: [],
-  },
-  describe_capability: {
-    chatProjectable: false,
-    inputRefs: [],
-    outputRefs: [],
-    passthroughIdPaths: [],
-    stripPaths: [],
-  },
+  // the generic path cannot prove per-capability ref safety.
+  list_capabilities: { chatProjectable: false },
+  describe_capability: { chatProjectable: false },
 } as const satisfies Record<RegistryReadToolName, RegistryRefFieldMapEntry>;
+
+// --- Write-tool projections ---------------------------------------------------
+// Write payloads are small acks and ids; each schema below mirrors the
+// handler's `textResult(...)` construction branch by branch. Input-param ref
+// kinds were verified against each tool's actual `inputSchema` in
+// `apps/api/src/mcp/*-tools.ts`. Params that carry no chat ref kind (task
+// ids, user ids, template/clause/category/playbook ids, time-entry/version/
+// link ids, plain fields) are passed to the handler verbatim and are
+// documented per entry. The four mediated kinds are exactly the ones the chat
+// ref registry mints: matter, entity, contact, property.
+
+/** save_matter: create returns `{ matterId }`; update adds `updated: true`. */
+const SAVE_MATTER_PROJECTION: ChatProjectionSchema = v.strictObject({
+  matterId: chatRef("matter"),
+  updated: v.optional(v.literal(true)),
+});
+
+const DELETED_TRUE_PROJECTION: ChatProjectionSchema = v.strictObject({
+  deleted: v.literal(true),
+});
+
+/** save_contact: both branches return `{ contactId }`. */
+const SAVE_CONTACT_PROJECTION: ChatProjectionSchema = v.strictObject({
+  contactId: chatRef("contact"),
+});
+
+/**
+ * save_task: create returns `{ taskId }` (a new entity whose workspace is the
+ * resolved `matter_id`, required on create via `ensureActiveWorkspace`);
+ * update returns `{ taskId, updated: true }` echoing the input task, which
+ * hydration catches first via the dehydrated-entity reuse map, so the
+ * `inputParam` source only drives the create case.
+ */
+const SAVE_TASK_PROJECTION: ChatProjectionSchema = v.strictObject({
+  taskId: chatEntityRef({ from: "inputParam", param: "matter_id" }),
+  updated: v.optional(v.literal(true)),
+});
+
+/**
+ * link_matter_contact: link returns `{ workspaceContactId }` (a join-row
+ * handle, not a tenant ref); unlink returns `{ unlinked: true }`.
+ */
+const LINK_MATTER_CONTACT_PROJECTION: ChatProjectionSchema = v.union([
+  v.strictObject({ workspaceContactId: passthroughId() }),
+  v.strictObject({ unlinked: v.literal(true) }),
+]);
+
+/**
+ * save_document: create returns `{ entityId }` (a new document whose
+ * workspace is the resolved `matter_id`, required on create); update returns
+ * `{ updated: true }`.
+ */
+const SAVE_DOCUMENT_PROJECTION: ChatProjectionSchema = v.union([
+  v.strictObject({
+    entityId: chatEntityRef({ from: "inputParam", param: "matter_id" }),
+  }),
+  v.strictObject({ updated: v.literal(true) }),
+]);
+
+/** set_field_value returns `{}`. */
+const SET_FIELD_VALUE_PROJECTION: ChatProjectionSchema = v.strictObject({});
+
+/**
+ * save_time_entry: both branches return `{ timeEntryId }` (update adds
+ * `updated: true`); the time-entry id is a billing handle, not a tenant ref.
+ */
+const SAVE_TIME_ENTRY_PROJECTION: ChatProjectionSchema = v.strictObject({
+  timeEntryId: passthroughId(),
+  updated: v.optional(v.literal(true)),
+});
+
+/** delete_time_entry returns `{ deleted }` (a boolean from the handler). */
+const DELETE_TIME_ENTRY_PROJECTION: ChatProjectionSchema = v.strictObject({
+  deleted: v.boolean(),
+});
+
+/** save_clause: both branches return `{ clauseId }` (a library handle). */
+const SAVE_CLAUSE_PROJECTION: ChatProjectionSchema = v.strictObject({
+  clauseId: passthroughId(),
+});
+
+/** run_playbook returns `{ runPropertyCount }`: an integer, no id. */
+const RUN_PLAYBOOK_PROJECTION: ChatProjectionSchema = v.strictObject({
+  runPropertyCount: v.number(),
+});
+
+/**
+ * manage_organization: add_member returns `{ memberId }`, remove_member
+ * `{ removed: true, id }` (both membership-row handles, not tenant refs);
+ * update_org_settings echoes only the scalar settings it changed.
+ */
+const MANAGE_ORGANIZATION_PROJECTION: ChatProjectionSchema = v.union([
+  v.strictObject({ memberId: passthroughId() }),
+  v.strictObject({ removed: v.literal(true), id: passthroughId() }),
+  v.strictObject({
+    matterNumberPattern: v.optional(v.string()),
+    matterNumberPadding: v.optional(v.number()),
+    promptCachingEnabled: v.optional(v.boolean()),
+    documentProcessingMode: v.optional(v.string()),
+  }),
+]);
+
+/**
+ * set_practice_jurisdictions returns `{ practiceJurisdictions }`: country
+ * codes and booleans, no id.
+ */
+const SET_PRACTICE_JURISDICTIONS_PROJECTION: ChatProjectionSchema =
+  v.strictObject({
+    practiceJurisdictions: v.array(
+      v.strictObject({ countryCode: v.string(), isPrimary: v.boolean() }),
+    ),
+  });
+
+/**
+ * save_template: create returns `{ templateId, name, fieldCount }` (template
+ * handle); configure echoes the same describe shape list_templates' detail
+ * mode serves, so the agent sees exactly what is now configured.
+ */
+const SAVE_TEMPLATE_PROJECTION: ChatProjectionSchema = v.union([
+  v.strictObject({
+    templateId: passthroughId(),
+    name: v.string(),
+    fieldCount: v.number(),
+  }),
+  templateDescribeProjection,
+]);
 
 /**
  * Per-tool ref decision for every write tool in the MCP registry. Keyed by the
@@ -781,14 +1595,6 @@ export const READ_TOOL_REF_FIELD_MAP = {
  * exhaustive by construction: a write tool with no entry here cannot compile,
  * which is the class-guard that stops a future write tool being silently left
  * out of the chat projection.
- *
- * Input-param ref kinds were verified against each tool's actual `inputSchema`
- * in `apps/api/src/mcp/*-tools.ts`; output paths were verified against each
- * handler's `textResult(...)` payload. Params that carry no chat ref kind (task
- * ids, user ids, template/clause/category/playbook ids, time-entry/version/link
- * ids, plain fields) are passed to the handler verbatim and are documented per
- * entry. The four mediated kinds are exactly the ones the chat ref registry
- * mints: matter, entity, contact, property.
  */
 export const WRITE_TOOL_REF_FIELD_MAP = {
   // --- Matters / contacts / tasks -------------------------------------------
@@ -799,34 +1605,22 @@ export const WRITE_TOOL_REF_FIELD_MAP = {
       { kind: "matter", param: "matter_id" },
       { kind: "contact", param: "client_id" },
     ],
-    // Both the create and update branches return `{ matterId }` (update adds
-    // `updated: true`); the matter id is a workspace tenant id.
-    outputRefs: [{ kind: "matter", path: "matterId" }],
-    passthroughIdPaths: [],
-    stripPaths: [],
+    projection: SAVE_MATTER_PROJECTION,
   },
   delete_matter: {
     chatProjectable: true,
     inputRefs: [{ kind: "matter", param: "matter_id" }],
-    // Returns `{ deleted: true }`: an ack with no id.
-    outputRefs: [],
-    passthroughIdPaths: [],
-    stripPaths: [],
+    projection: DELETED_TRUE_PROJECTION,
   },
   save_contact: {
     chatProjectable: true,
     inputRefs: [{ kind: "contact", param: "contact_id" }],
-    // Both branches return `{ contactId }`.
-    outputRefs: [{ kind: "contact", path: "contactId" }],
-    passthroughIdPaths: [],
-    stripPaths: [],
+    projection: SAVE_CONTACT_PROJECTION,
   },
   delete_contact: {
     chatProjectable: true,
     inputRefs: [{ kind: "contact", param: "contact_id" }],
-    outputRefs: [],
-    passthroughIdPaths: [],
-    stripPaths: [],
+    projection: DELETED_TRUE_PROJECTION,
   },
   save_task: {
     chatProjectable: true,
@@ -839,20 +1633,7 @@ export const WRITE_TOOL_REF_FIELD_MAP = {
       { kind: "matter", param: "matter_id" },
       { kind: "entity", param: "link_entity_id" },
     ],
-    // Create returns `{ taskId }` (a new entity); update returns
-    // `{ taskId, updated: true }` echoing the input task. The task entity's
-    // workspace is the resolved `matter_id` (create requires it via
-    // `ensureActiveWorkspace`); the update echo is caught first by the
-    // dehydrated-entity reuse map, so this source only drives the create case.
-    outputRefs: [
-      {
-        kind: "entity",
-        path: "taskId",
-        workspace: { from: "inputParam", param: "matter_id" },
-      },
-    ],
-    passthroughIdPaths: [],
-    stripPaths: [],
+    projection: SAVE_TASK_PROJECTION,
   },
   link_matter_contact: {
     chatProjectable: true,
@@ -862,11 +1643,7 @@ export const WRITE_TOOL_REF_FIELD_MAP = {
       { kind: "matter", param: "matter_id" },
       { kind: "contact", param: "contact_id" },
     ],
-    // Link returns `{ workspaceContactId }` (a join-row handle); unlink returns
-    // `{ unlinked: true }`. The join-row id is a non-tenant handle.
-    outputRefs: [],
-    passthroughIdPaths: ["workspaceContactId"],
-    stripPaths: [],
+    projection: LINK_MATTER_CONTACT_PROJECTION,
   },
 
   // --- Documents / properties -----------------------------------------------
@@ -879,27 +1656,13 @@ export const WRITE_TOOL_REF_FIELD_MAP = {
       { kind: "matter", param: "matter_id" },
       { kind: "entity", param: "parent_id" },
     ],
-    // Create returns `{ entityId }` (new document); update returns
-    // `{ updated: true }`. A created document's workspace is the resolved
-    // `matter_id` (create requires it via `ensureActiveWorkspace`).
-    outputRefs: [
-      {
-        kind: "entity",
-        path: "entityId",
-        workspace: { from: "inputParam", param: "matter_id" },
-      },
-    ],
-    passthroughIdPaths: [],
-    stripPaths: [],
+    projection: SAVE_DOCUMENT_PROJECTION,
   },
   delete_document: {
     chatProjectable: true,
     // `version_id` is an entity-version handle: passes through.
     inputRefs: [{ kind: "entity", param: "entity_id" }],
-    // Returns `{ deleted: true }`.
-    outputRefs: [],
-    passthroughIdPaths: [],
-    stripPaths: [],
+    projection: DELETED_TRUE_PROJECTION,
   },
   set_field_value: {
     chatProjectable: true,
@@ -909,10 +1672,7 @@ export const WRITE_TOOL_REF_FIELD_MAP = {
       { kind: "entity", param: "entity_id" },
       { kind: "property", param: "property_id" },
     ],
-    // Returns `{}`.
-    outputRefs: [],
-    passthroughIdPaths: [],
-    stripPaths: [],
+    projection: SET_FIELD_VALUE_PROJECTION,
   },
 
   // --- Billing --------------------------------------------------------------
@@ -924,19 +1684,12 @@ export const WRITE_TOOL_REF_FIELD_MAP = {
       { kind: "matter", param: "matter_id" },
       { kind: "entity", param: "entity_id" },
     ],
-    // Both branches return `{ timeEntryId }` (update adds `updated: true`); the
-    // time-entry id is a billing handle, not a tenant ref.
-    outputRefs: [],
-    passthroughIdPaths: ["timeEntryId"],
-    stripPaths: [],
+    projection: SAVE_TIME_ENTRY_PROJECTION,
   },
   delete_time_entry: {
     chatProjectable: true,
     inputRefs: [],
-    // Returns `{ deleted }` (a boolean).
-    outputRefs: [],
-    passthroughIdPaths: [],
-    stripPaths: [],
+    projection: DELETE_TIME_ENTRY_PROJECTION,
   },
 
   // --- Knowledge ------------------------------------------------------------
@@ -945,26 +1698,18 @@ export const WRITE_TOOL_REF_FIELD_MAP = {
     // `clause_id` and `category_id` are org-scoped library handles, not chat
     // refs: they pass through as-is.
     inputRefs: [],
-    // Both branches return `{ clauseId }` (a library handle).
-    outputRefs: [],
-    passthroughIdPaths: ["clauseId"],
-    stripPaths: [],
+    projection: SAVE_CLAUSE_PROJECTION,
   },
   delete_clause: {
     chatProjectable: true,
     inputRefs: [],
-    outputRefs: [],
-    passthroughIdPaths: [],
-    stripPaths: [],
+    projection: DELETED_TRUE_PROJECTION,
   },
   run_playbook: {
     chatProjectable: true,
     // `playbook_id` is an org-scoped library handle: passes through.
     inputRefs: [{ kind: "matter", param: "matter_id" }],
-    // Returns `{ runPropertyCount }`: an integer, no id.
-    outputRefs: [],
-    passthroughIdPaths: [],
-    stripPaths: [],
+    projection: RUN_PLAYBOOK_PROJECTION,
   },
 
   // --- Organization ---------------------------------------------------------
@@ -974,22 +1719,14 @@ export const WRITE_TOOL_REF_FIELD_MAP = {
     // through. `matter_id` is a matter ref (used by the add/remove member
     // actions that scope to a matter).
     inputRefs: [{ kind: "matter", param: "matter_id" }],
-    // add_member returns `{ memberId }`, remove_member `{ removed: true, id }`;
-    // both are membership-row handles, not tenant refs. update_org_settings
-    // returns scalar settings only.
-    outputRefs: [],
-    passthroughIdPaths: ["memberId", "id"],
-    stripPaths: [],
+    projection: MANAGE_ORGANIZATION_PROJECTION,
   },
 
   // --- Practice profile -----------------------------------------------------
   set_practice_jurisdictions: {
     chatProjectable: true,
     inputRefs: [],
-    // Returns `{ practiceJurisdictions }`: country codes and booleans, no id.
-    outputRefs: [],
-    passthroughIdPaths: [],
-    stripPaths: [],
+    projection: SET_PRACTICE_JURISDICTIONS_PROJECTION,
   },
 
   // --- Templates ------------------------------------------------------------
@@ -998,35 +1735,18 @@ export const WRITE_TOOL_REF_FIELD_MAP = {
   // routes), so projecting it from the registry would collide on the tool name.
   // It stays off the registry write projection (`chatProjectable: false`) and
   // is instead classified `mutation` in the chat tool-policy map so the
-  // existing tool still asks for approval before filling. The entry is kept for
-  // the typecheck-forced completeness guard and its input `template_id` is a
-  // template handle (not a chat ref) either way.
-  fill_template: {
-    chatProjectable: false,
-    inputRefs: [],
-    outputRefs: [],
-    passthroughIdPaths: [],
-    stripPaths: [],
-  },
+  // existing tool still asks for approval before filling. Its input
+  // `template_id` is a template handle (not a chat ref) either way.
+  fill_template: { chatProjectable: false },
   // Compound template persistence is an MCP/CLI convenience for clients that
   // cannot PUT bytes. Chat already has first-class template/document flows;
   // projecting this would duplicate that surface and its approval UX.
-  save_filled_template: {
-    chatProjectable: false,
-    inputRefs: [],
-    outputRefs: [],
-    passthroughIdPaths: [],
-    stripPaths: [],
-  },
+  save_filled_template: { chatProjectable: false },
   save_template: {
     chatProjectable: true,
     // `template_id` is an org template handle, not a chat ref: passes through.
     inputRefs: [],
-    // Create returns `{ templateId, name, fieldCount }` (template handle);
-    // configure returns the describe shape (name + field configs, no ids).
-    outputRefs: [],
-    passthroughIdPaths: ["templateId"],
-    stripPaths: [],
+    projection: SAVE_TEMPLATE_PROJECTION,
   },
 
   // --- Feedback -------------------------------------------------------------
@@ -1034,28 +1754,13 @@ export const WRITE_TOOL_REF_FIELD_MAP = {
   // and runs its own human-approval handshake (preview -> confirmation token).
   // It is not a chat surface tool: it takes no entity references, returns no
   // tenant ids, and would double-gate on approval if projected. It stays off
-  // the chat write projection (`chatProjectable: false`, like `fill_template`),
-  // so it never enters `ProjectedWriteToolName` or the chat tool-policy map. The
-  // entry exists only to satisfy the typecheck-forced completeness guard.
-  send_feedback: {
-    chatProjectable: false,
-    inputRefs: [],
-    outputRefs: [],
-    passthroughIdPaths: [],
-    stripPaths: [],
-  },
+  // the chat write projection, so it never enters `ProjectedWriteToolName` or
+  // the chat tool-policy map.
+  send_feedback: { chatProjectable: false },
 
   // --- Capability meta-tool: not projected to chat --------------------------
   // `invoke_capability` runs an arbitrary catalog capability over the MCP/CLI
   // transport; its authority is enforced per capability inside the handler, and
-  // it is never dispatched from chat. Kept off the chat write projection
-  // (`chatProjectable: false`, like `fill_template`/`send_feedback`); the entry
-  // exists only for the typecheck-forced completeness guard.
-  invoke_capability: {
-    chatProjectable: false,
-    inputRefs: [],
-    outputRefs: [],
-    passthroughIdPaths: [],
-    stripPaths: [],
-  },
+  // it is never dispatched from chat.
+  invoke_capability: { chatProjectable: false },
 } as const satisfies Record<RegistryWriteToolName, RegistryRefFieldMapEntry>;

--- a/apps/api/src/handlers/chat/tools/registry-adapter/ref-mediation.ts
+++ b/apps/api/src/handlers/chat/tools/registry-adapter/ref-mediation.ts
@@ -24,21 +24,29 @@ import type {
 import { READ_TOOL_REF_FIELD_MAP } from "./ref-field-map";
 
 /**
- * The three output-side mediation lists for a map entry, whichever artifact
- * carries them: derived from the entry's projection schema when the tool is
- * converted (memoized in `deriveRefMediationEntry`), or the entry's own
- * hand-written lists otherwise.
+ * The chat-projected read entry for a tool name, for the read-tool
+ * convenience wrappers below. The orchestrator refuses a non-projectable
+ * tool before any mediation runs, so reaching this with one is programmer
+ * misuse, not a data case: it panics rather than falling back.
  */
-export const resolveMediationLists = (
-  entry: RefMediationEntry,
+const requireProjectableReadEntry = (
+  toolName: RegistryReadToolName,
+): RefMediationEntry => {
+  const entry = READ_TOOL_REF_FIELD_MAP[toolName];
+  if (!entry.chatProjectable) {
+    panic(`Read tool ${toolName} is not chat-projectable`);
+  }
+  return entry;
+};
+
+/**
+ * The three output-side mediation lists for a projected read tool, derived
+ * from its projection schema (memoized in `deriveRefMediationEntry`).
+ */
+const readToolMediationLists = (
+  toolName: RegistryReadToolName,
 ): RefMediationLists =>
-  entry.projection === undefined
-    ? {
-        outputRefs: entry.outputRefs,
-        passthroughIdPaths: entry.passthroughIdPaths,
-        stripPaths: entry.stripPaths,
-      }
-    : deriveRefMediationEntry(entry.projection);
+  deriveRefMediationEntry(requireProjectableReadEntry(toolName).projection);
 
 const UUID_REGEX =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/iu;
@@ -136,8 +144,7 @@ export const findUndeclaredUuidPath = ({
   payload: unknown;
 }): string | undefined =>
   findUndeclaredUuidPathIn({
-    passthroughIdPaths: resolveMediationLists(READ_TOOL_REF_FIELD_MAP[toolName])
-      .passthroughIdPaths,
+    passthroughIdPaths: readToolMediationLists(toolName).passthroughIdPaths,
     payload,
   });
 
@@ -340,7 +347,7 @@ export const dehydrateInputRefs = ({
   refRegistry: ChatRefRegistry;
 }): Result<DehydratedInput, ChatToolError> =>
   dehydrateRefs({
-    inputRefs: READ_TOOL_REF_FIELD_MAP[toolName].inputRefs,
+    inputRefs: requireProjectableReadEntry(toolName).inputRefs,
     args,
     refRegistry,
   });
@@ -515,8 +522,7 @@ export const hydrateOutputRefs = ({
   dehydration: DehydratedInput;
 }): unknown =>
   hydrateRefs({
-    outputRefs: resolveMediationLists(READ_TOOL_REF_FIELD_MAP[toolName])
-      .outputRefs,
+    outputRefs: readToolMediationLists(toolName).outputRefs,
     output,
     refRegistry,
     dehydration,

--- a/apps/api/src/handlers/chat/tools/registry-adapter/registry-projection-contract.test.ts
+++ b/apps/api/src/handlers/chat/tools/registry-adapter/registry-projection-contract.test.ts
@@ -22,9 +22,9 @@ import type { McpRequestContext } from "@/api/mcp/context";
 import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
 import { toSafeDbMock } from "@/api/tests/scoped-db-mock";
 
+import { deriveRefMediationEntry } from "./projection-schema";
 import type { RegistryReadToolName } from "./ref-field-map";
 import { READ_TOOL_REF_FIELD_MAP } from "./ref-field-map";
-import { resolveMediationLists } from "./ref-mediation";
 
 /**
  * Contract corpus over every chat-projectable read tool: run the real MCP
@@ -418,7 +418,11 @@ const CONTRACT_CORPUS = {
               firstName: "Jan",
               lastName: "Novák",
               organizationName: null,
-              emails: [{ label: "work", address: "jan@example.test" }],
+              // Production-shaped jsonb (`contactEmailSchema`): the strict
+              // projection parse refuses a thinned stand-in.
+              emails: [
+                { type: "work", address: "jan@example.test", isPrimary: true },
+              ],
               phones: [],
               tags: [],
               color: null,
@@ -493,8 +497,15 @@ const CONTRACT_CORPUS = {
               firstName: "Jan",
               lastName: "Novák",
               organizationName: null,
-              emails: [{ label: "work", address: "jan@example.test" }],
-              phones: [{ label: "mobile", number: "+420123456789" }],
+              // Production-shaped jsonb (`contactEmailSchema`/
+              // `contactPhoneSchema`): the strict projection parse refuses a
+              // thinned stand-in.
+              emails: [
+                { type: "work", address: "jan@example.test", isPrimary: true },
+              ],
+              phones: [
+                { type: "mobile", number: "+420123456789", isPrimary: true },
+              ],
             }),
           },
         },
@@ -817,6 +828,9 @@ const CONTRACT_CORPUS = {
               id: uid(35),
               name: "NDA review",
               description: "Mutual NDA playbook",
+              // Selected by the list handler; drift the hand list never
+              // surfaced (the strict parse requires every declared field).
+              status: "draft",
               createdAt: new Date("2026-01-01"),
               updatedAt: new Date("2026-01-01"),
             },
@@ -835,7 +849,13 @@ const CONTRACT_CORPUS = {
               id: uid(35),
               name: "NDA review",
               description: "Mutual NDA playbook",
-              scope: "organization",
+              // `scope` is a nullable `PlaybookScope` jsonb object
+              // (`playbookScopeSchema`), not a string; the previous
+              // string stand-in could never occur in production.
+              scope: { perspective: "buyer" },
+              // Selected by the detail handler; drift the hand list never
+              // surfaced (the strict parse requires every declared field).
+              status: "draft",
               positions: {
                 version: 2,
                 items: [
@@ -849,11 +869,16 @@ const CONTRACT_CORPUS = {
                     ask: {
                       mode: "manual",
                       question: "How long is the term?",
-                      content: { type: "text" },
+                      content: { version: 1, type: "text" },
                     },
                     tiers: {
                       acceptable: {
                         rules: [{ id: uid(37), text: "Max 3 years" }],
+                        // Exercises the ideal clause link the hand list
+                        // never declared (it licensed a stale pre-v2
+                        // `standard.clauseId` path instead); the backstop
+                        // verifies the schema licenses this handle.
+                        ideal: { source: "clause", clauseId: uid(70) },
                       },
                       fallback: {
                         entries: [
@@ -1329,8 +1354,10 @@ describe("registry projection contract", () => {
 
   test("every declared outputRef path is exercised by some fixture call", () => {
     for (const [toolName, calls] of corpusEntries()) {
-      // Hand-written or schema-derived, whichever artifact the entry carries.
-      const lists = resolveMediationLists(READ_TOOL_REF_FIELD_MAP[toolName]);
+      // Derived from the entry's projection schema, the only artifact.
+      const lists = deriveRefMediationEntry(
+        READ_TOOL_REF_FIELD_MAP[toolName].projection,
+      );
       const declared = lists.outputRefs.map((field) => field.path).sort();
       const exercised = [
         ...new Set(calls.flatMap((call) => call.expectRefPaths)),
@@ -1394,8 +1421,8 @@ describe("registry projection contract", () => {
         // merely tolerated by the backstop. This stays meaningful even if a
         // path were ever declared as both strip and passthrough, where a
         // broken strip would otherwise survive the ok result.
-        for (const path of resolveMediationLists(
-          READ_TOOL_REF_FIELD_MAP[toolName],
+        for (const path of deriveRefMediationEntry(
+          READ_TOOL_REF_FIELD_MAP[toolName].projection,
         ).stripPaths) {
           expect(
             readPathValues(payload, path).length,

--- a/apps/api/src/handlers/chat/tools/registry-adapter/run-registry-tool.ts
+++ b/apps/api/src/handlers/chat/tools/registry-adapter/run-registry-tool.ts
@@ -22,17 +22,17 @@ import { STELLA_TOOL_HANDLERS } from "@/api/mcp/stella-tools";
 import { TEMPLATE_TOOL_HANDLERS } from "@/api/mcp/template-tools";
 import type { McpToolHandler } from "@/api/mcp/tool-types";
 
-import { applyProjectionSchema } from "./projection-schema";
-import type {
-  RegistryReadToolName,
-  RegistryRefFieldMapEntry,
-} from "./ref-field-map";
+import type { ChatProjectionSchema } from "./projection-schema";
+import {
+  applyProjectionSchema,
+  deriveRefMediationEntry,
+} from "./projection-schema";
+import type { RegistryReadToolName } from "./ref-field-map";
 import { READ_TOOL_REF_FIELD_MAP } from "./ref-field-map";
 import {
   dehydrateInputRefs,
   findUndeclaredUuidPathIn,
   hydrateRefs,
-  resolveMediationLists,
   stripDeclaredPaths,
 } from "./ref-mediation";
 
@@ -108,28 +108,25 @@ export const PROJECTION_SCHEMA_FAILURE_MESSAGE =
   "input; do not retry this call.";
 
 /**
- * Strict-parse a converted tool's payload against its projection schema; an
- * unconverted entry passes through untouched. Shared by the read and write
- * orchestrators. The failure carries only issue paths (never values) to
- * telemetry, mirroring the UUID backstop's no-leak discipline.
+ * Strict-parse a projected tool's payload against its projection schema.
+ * Shared by the read and write orchestrators. The failure carries only issue
+ * paths (never values) to telemetry, mirroring the UUID backstop's no-leak
+ * discipline.
  */
 export const applyEntryProjection = ({
-  entry,
   payload,
+  projection,
   source,
   toolName,
 }: {
-  entry: RegistryRefFieldMapEntry;
   payload: unknown;
+  projection: ChatProjectionSchema;
   source: "run-registry-tool" | "run-registry-write-tool";
   toolName: string;
 }): Result<unknown, ChatToolError> => {
-  if (entry.projection === undefined) {
-    return Result.ok(payload);
-  }
   const projected = applyProjectionSchema({
     payload,
-    schema: entry.projection,
+    schema: projection,
   });
   if (Result.isError(projected)) {
     const error = new ChatToolError({
@@ -294,13 +291,13 @@ export const runRegistryReadTool = async ({
     return Result.err(payload.error);
   }
 
-  // Converted tools: strict-parse the payload against the projection schema
-  // BEFORE strip/hydrate. An unknown key — a field nobody classified — fails
-  // closed here, so an undeclared field is structurally unable to reach the
-  // model; the error carries only issue paths (never values) to telemetry.
+  // Strict-parse the payload against the projection schema BEFORE
+  // strip/hydrate. An unknown key — a field nobody classified — fails closed
+  // here, so an undeclared field is structurally unable to reach the model;
+  // the error carries only issue paths (never values) to telemetry.
   const projected = applyEntryProjection({
-    entry,
     payload: payload.value,
+    projection: entry.projection,
     source: "run-registry-tool",
     toolName,
   });
@@ -308,7 +305,7 @@ export const runRegistryReadTool = async ({
     return Result.err(projected.error);
   }
 
-  const mediation = resolveMediationLists(entry);
+  const mediation = deriveRefMediationEntry(entry.projection);
   const stripped = stripDeclaredPaths({
     output: projected.value,
     stripPaths: mediation.stripPaths,

--- a/apps/api/src/handlers/chat/tools/registry-adapter/run-registry-write-tool.test.ts
+++ b/apps/api/src/handlers/chat/tools/registry-adapter/run-registry-write-tool.test.ts
@@ -33,6 +33,7 @@ const {
   findUndeclaredUuidPathIn,
   hydrateRefs,
 } = await import("./ref-mediation");
+const { deriveRefMediationEntry } = await import("./projection-schema");
 const { WRITE_TOOL_REF_FIELD_MAP } = await import("./ref-field-map");
 const { applyChatApprovalConfirmation, runRegistryWriteTool } =
   await import("./run-registry-write-tool");
@@ -148,15 +149,18 @@ describe("write ref mediation (via the WRITE_TOOL_REF_FIELD_MAP)", () => {
     const hydrated = hydrateRefs({
       dehydration: dehydrated,
       output: { matterId: WS_UUID, updated: true },
-      outputRefs: WRITE_TOOL_REF_FIELD_MAP.save_matter.outputRefs,
+      outputRefs: deriveRefMediationEntry(
+        WRITE_TOOL_REF_FIELD_MAP.save_matter.projection,
+      ).outputRefs,
       refRegistry: registry,
     });
     expect(hydrated).toEqual({ matterId: matterRef, updated: true });
     expect(containsRawUuid(hydrated)).toBe(false);
     expect(
       findUndeclaredUuidPathIn({
-        passthroughIdPaths:
-          WRITE_TOOL_REF_FIELD_MAP.save_matter.passthroughIdPaths,
+        passthroughIdPaths: deriveRefMediationEntry(
+          WRITE_TOOL_REF_FIELD_MAP.save_matter.projection,
+        ).passthroughIdPaths,
         payload: hydrated,
       }),
     ).toBeUndefined();
@@ -189,8 +193,9 @@ describe("write ref mediation (via the WRITE_TOOL_REF_FIELD_MAP)", () => {
     // save_matter declares only `matterId` as an output ref and no passthrough
     // paths, so a raw uuid anywhere else is refused rather than leaked.
     const offending = findUndeclaredUuidPathIn({
-      passthroughIdPaths:
-        WRITE_TOOL_REF_FIELD_MAP.save_matter.passthroughIdPaths,
+      passthroughIdPaths: deriveRefMediationEntry(
+        WRITE_TOOL_REF_FIELD_MAP.save_matter.projection,
+      ).passthroughIdPaths,
       payload: { matterId: "mat_1", leaked: OTHER_WS_UUID },
     });
     expect(offending).toBe("leaked");

--- a/apps/api/src/handlers/chat/tools/registry-adapter/run-registry-write-tool.ts
+++ b/apps/api/src/handlers/chat/tools/registry-adapter/run-registry-write-tool.ts
@@ -18,13 +18,13 @@ import { STELLA_TOOL_HANDLERS } from "@/api/mcp/stella-tools";
 import { TEMPLATE_TOOL_HANDLERS } from "@/api/mcp/template-tools";
 import type { McpToolHandler } from "@/api/mcp/tool-types";
 
+import { deriveRefMediationEntry } from "./projection-schema";
 import type { RegistryWriteToolName } from "./ref-field-map";
 import { WRITE_TOOL_REF_FIELD_MAP } from "./ref-field-map";
 import {
   dehydrateRefs,
   findUndeclaredUuidPathIn,
   hydrateRefs,
-  resolveMediationLists,
   stripDeclaredPaths,
 } from "./ref-mediation";
 import {
@@ -181,13 +181,12 @@ export const runRegistryWriteTool = async ({
     return Result.err(payload.error);
   }
 
-  // Same strict-parse gate as the read path: a converted write tool's payload
-  // must match its projection schema before strip/hydrate, so an undeclared
-  // field fails closed by construction. No write tool is converted yet; the
-  // gate is a pass-through until a write entry gains a `projection`.
+  // Same strict-parse gate as the read path: the write tool's payload must
+  // match its projection schema before strip/hydrate, so an undeclared field
+  // fails closed by construction.
   const projected = applyEntryProjection({
-    entry,
     payload: payload.value,
+    projection: entry.projection,
     source: "run-registry-write-tool",
     toolName,
   });
@@ -195,7 +194,7 @@ export const runRegistryWriteTool = async ({
     return Result.err(projected.error);
   }
 
-  const mediation = resolveMediationLists(entry);
+  const mediation = deriveRefMediationEntry(entry.projection);
   const stripped = stripDeclaredPaths({
     output: projected.value,
     stripPaths: mediation.stripPaths,


### PR DESCRIPTION
Every chat-projectable registry tool (18 reads, 17 writes) now declares a projection schema; the entry type collapses to `{ chatProjectable: false } | { chatProjectable: true; inputRefs; projection }`, making hand-written path lists structurally unrepresentable. The hand-list resolution branch is deleted; orchestrators derive the mediation lists from the schemas.

- Derived lists are pinned equal to the previous hand lists per tool (sorted-compare), with one intentional delta: `list_playbooks`' pre-v2 `standard.clauseId` passthrough was a stale path no handler emits — replaced by the positions-v2 `tiers.acceptable.ideal.clauseId` clause-library handle, exercised in the corpus.
- `unenumeratedJson()` documents the semantics for free-form subtrees (public case-law metadata, BOE envelopes, registry details): admitted by the strict parse, no licensed paths, so the UUID backstop guards their contents.
- Corpus fixtures move to production-shaped values where schema-writing exposed thin stand-ins (contact email/phone jsonb, playbook scope/status/ask shapes) per the repo's testing conventions.
- `Returns: {…}` description lines now cover every read tool.
- Cost: +0.75% types / +0.82% instantiations on apps/api; no baseline reseeds; a completeness test requires a derivation test for every projectable entry.