### PR TITLE
chore(ci): allowlist stella-provenance-updater[bot] for CLA

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -40,6 +40,6 @@ jobs:
       )
     uses: stella/.github/.github/workflows/cla.yml@44c8092f11c2f454916c320aa7d2144c173329d8
     with:
-      allowlist: dependabot[bot],renovate[bot],github-actions[bot],google-labs-jules[bot],cursoragent,claude
+      allowlist: dependabot[bot],renovate[bot],github-actions[bot],google-labs-jules[bot],stella-provenance-updater[bot],cursoragent,claude
     secrets:
       CLA_APP_PRIVATE_KEY: ${{ secrets.CLA_APP_PRIVATE_KEY }}


### PR DESCRIPTION
Adds `stella-provenance-updater[bot]` to the CLA Assistant allowlist.

The app opens automated maintenance PRs (e.g. #1713) and cannot sign the CLA, so
every run stalls on a CLA comment. It joins the other bot identities already
allowlisted.

Because `cla.yml` runs under `pull_request_target`, the allowlist takes effect
from `main`; existing open PRs clear once `recheck` is commented after merge.