### PR TITLE
feat(chat): project tool payloads in a single schema-driven pass

### DIFF
--- a/apps/api/src/handlers/chat/tools/registry-adapter/follow-ups.test.ts
+++ b/apps/api/src/handlers/chat/tools/registry-adapter/follow-ups.test.ts
@@ -19,7 +19,7 @@ void mock.module("@/api/lib/analytics/capture", () => ({
 
 const { buildMcpContextFromChat } = await import("./mcp-chat-context");
 const { runRegistryReadTool } = await import("./run-registry-tool");
-const { containsRawUuid } = await import("./ref-mediation");
+const { containsRawUuid } = await import("./projection-schema");
 
 const WS_UUID = "0dc54d0c-10d7-501d-897e-e801dbd0998c";
 const ENTITY_UUID = "11111111-1111-4111-8111-111111111111";

--- a/apps/api/src/handlers/chat/tools/registry-adapter/projection-schema.test.ts
+++ b/apps/api/src/handlers/chat/tools/registry-adapter/projection-schema.test.ts
@@ -1,20 +1,41 @@
 import { Result } from "better-result";
-import { describe, expect, test } from "bun:test";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import * as v from "valibot";
+
+import { toSafeId } from "@/api/lib/branded-types";
 
 import type {
   ChatProjectionSchema,
+  DehydratedInput,
   OutputRefField,
   RefMediationLists,
 } from "./projection-schema";
-import {
-  applyProjectionSchema,
+
+// Mocked so the fail-closed tests can assert the exact telemetry contract
+// (paths only, never values) without touching the analytics client.
+const captureErrorMock = mock();
+void mock.module("@/api/lib/analytics/capture", () => ({
+  captureError: captureErrorMock,
+  captureRequestError: captureErrorMock,
+  getAnalytics: mock(() => ({ capture: mock(), flush: mock() })),
+}));
+
+const { createChatRefRegistry } = await import("@/api/lib/chat/ref-registry");
+const {
+  chatEntityRef,
+  chatRef,
+  containsRawUuid,
   deriveRefMediationEntry,
+  passthroughId,
+  PROJECTION_SCHEMA_FAILURE_MESSAGE,
+  projectForChat,
+  REF_PROJECTION_FAILURE_MESSAGE,
   renderProjectionShape,
-} from "./projection-schema";
-import {
-  READ_TOOL_REF_FIELD_MAP,
-  WRITE_TOOL_REF_FIELD_MAP,
-} from "./ref-field-map";
+  strippedField,
+  unenumeratedJson,
+} = await import("./projection-schema");
+const { READ_TOOL_REF_FIELD_MAP, WRITE_TOOL_REF_FIELD_MAP } =
+  await import("./ref-field-map");
 
 /**
  * The derivation contract: the mediation lists mechanically derived from a
@@ -607,16 +628,54 @@ describe("deriveRefMediationEntry", () => {
   });
 });
 
-describe("applyProjectionSchema", () => {
+describe("projectForChat", () => {
+  const WS_UUID = "0dc54d0c-10d7-501d-897e-e801dbd0998c";
   const ROGUE_UUID = "4e919658-a448-5354-8e3a-e99911214d2c";
+  const ENTITY_UUID = "c09ec856-d945-5ecc-82e3-bb5382165f34";
+  const LINKED_ENTITY_UUID = "1e7f7f2a-9b2b-4c40-8ab1-2f5b6c7d8e9f";
+  const CONTACT_UUID = "6111c8e9-1404-5b6f-8a9a-0e3a93e8179a";
+  const PROPERTY_UUID = "37286c24-6145-572e-ad27-15a1d4454d59";
+
+  const emptyDehydration = (): DehydratedInput => ({
+    args: {},
+    dehydratedEntityRefs: new Map(),
+    resolvedEntityParams: {},
+    resolvedMatterParams: {},
+  });
+
+  type ProjectArgs = {
+    schema: ChatProjectionSchema;
+    payload: unknown;
+    refRegistry?: ReturnType<typeof createChatRefRegistry>;
+    dehydration?: DehydratedInput;
+  };
+
+  const project = ({
+    schema,
+    payload,
+    refRegistry = createChatRefRegistry(),
+    dehydration = emptyDehydration(),
+  }: ProjectArgs) =>
+    projectForChat({
+      dehydration,
+      payload,
+      refRegistry,
+      schema,
+      source: "run-registry-tool",
+      toolName: "test_tool",
+    });
+
+  beforeEach(() => {
+    captureErrorMock.mockClear();
+  });
 
   test("an undeclared field fails the strict parse with its path, never its value", () => {
-    const result = applyProjectionSchema({
+    const result = project({
       schema: LIST_MATTERS_PROJECTION,
       payload: {
         matters: [
           {
-            id: "0dc54d0c-10d7-501d-897e-e801dbd0998c",
+            id: WS_UUID,
             name: "Acme",
             reference: "REF-1",
             status: "active",
@@ -633,16 +692,370 @@ describe("applyProjectionSchema", () => {
 
     expect(Result.isError(result)).toBe(true);
     if (Result.isError(result)) {
-      expect(result.error.issuePaths).toContain("matters[].plumbingId");
+      expect(result.error.kind).toBe("server-defect");
+      expect(result.error.message).toBe(PROJECTION_SCHEMA_FAILURE_MESSAGE);
       expect(JSON.stringify(result.error)).not.toContain(ROGUE_UUID);
     }
+    expect(captureErrorMock).toHaveBeenCalledWith(
+      expect.objectContaining({ message: PROJECTION_SCHEMA_FAILURE_MESSAGE }),
+      expect.objectContaining({
+        paths: expect.stringContaining("matters[].plumbingId"),
+        source: "run-registry-tool",
+        toolName: "test_tool",
+      }),
+    );
+    const [, telemetryContext] = captureErrorMock.mock.calls.at(0) ?? [];
+    expect(JSON.stringify(telemetryContext)).not.toContain(ROGUE_UUID);
   });
 
-  test("a matching payload parses to the declared shape", () => {
+  test("each simple ref kind hydrates to the registry's chat ref", () => {
+    const refRegistry = createChatRefRegistry();
+    const matterRef = refRegistry.toMatterRef(toSafeId<"workspace">(WS_UUID));
+    const contactRef = refRegistry.toContactRef(
+      toSafeId<"contact">(CONTACT_UUID),
+    );
+    const propertyRef = refRegistry.toPropertyRef(
+      toSafeId<"property">(PROPERTY_UUID),
+    );
+    const schema: ChatProjectionSchema = v.strictObject({
+      contactId: chatRef("contact"),
+      matterId: chatRef("matter"),
+      propertyId: chatRef("property"),
+    });
+
+    const projected = project({
+      payload: {
+        contactId: CONTACT_UUID,
+        matterId: WS_UUID,
+        propertyId: PROPERTY_UUID,
+      },
+      refRegistry,
+      schema,
+    }).unwrap();
+
+    expect(projected).toEqual({
+      contactId: contactRef,
+      matterId: matterRef,
+      propertyId: propertyRef,
+    });
+    expect(containsRawUuid(projected)).toBe(false);
+  });
+
+  test("strippedField leaves are omitted, UUIDs inside them and all", () => {
+    const schema: ChatProjectionSchema = v.strictObject({
+      name: v.string(),
+      pdfFileId: strippedField(),
+      thumbnail: v.optional(strippedField()),
+    });
+
+    const projected = project({
+      payload: {
+        name: "NDA draft",
+        pdfFileId: ROGUE_UUID,
+        thumbnail: { fileId: WS_UUID },
+      },
+      schema,
+    }).unwrap();
+
+    expect(projected).toEqual({ name: "NDA draft" });
+    expect(containsRawUuid(projected)).toBe(false);
+  });
+
+  test("passthroughId survives verbatim, UUID-shaped or not", () => {
+    const schema: ChatProjectionSchema = v.strictObject({
+      cursor: v.nullable(passthroughId()),
+      versionId: passthroughId(),
+    });
+
+    const projected = project({
+      payload: { cursor: null, versionId: WS_UUID },
+      schema,
+    }).unwrap();
+
+    expect(projected).toEqual({ cursor: null, versionId: WS_UUID });
+  });
+
+  test("sibling workspace source reads the raw payload, not the hydrated output", () => {
+    const refRegistry = createChatRefRegistry();
+    const schema: ChatProjectionSchema = v.strictObject({
+      hits: v.array(
+        v.strictObject({
+          // Declared (and emitted) BEFORE the entity id: a walk that hydrated
+          // in place would overwrite the sibling workspace UUID with `mat_N`
+          // before the entity ref could read it. The raw-snapshot guarantee is
+          // what this test pins.
+          workspaceId: chatRef("matter"),
+          entityId: chatEntityRef({ from: "sibling", key: "workspaceId" }),
+          name: v.string(),
+        }),
+      ),
+    });
+
+    const projected = project({
+      payload: {
+        hits: [{ workspaceId: WS_UUID, entityId: ENTITY_UUID, name: "Brief" }],
+      },
+      refRegistry,
+      schema,
+    }).unwrap();
+
+    expect(projected).toEqual({
+      hits: [
+        {
+          entityId: refRegistry.toEntityRef({
+            entityId: toSafeId<"entity">(ENTITY_UUID),
+            workspaceId: toSafeId<"workspace">(WS_UUID),
+          }),
+          name: "Brief",
+          workspaceId: refRegistry.toMatterRef(toSafeId<"workspace">(WS_UUID)),
+        },
+      ],
+    });
+    expect(containsRawUuid(projected)).toBe(false);
+  });
+
+  test("outputPath workspace source reads the raw payload across the tree", () => {
+    const refRegistry = createChatRefRegistry();
+    const schema: ChatProjectionSchema = v.strictObject({
+      invoice: v.strictObject({
+        workspaceId: chatRef("matter"),
+        items: v.array(
+          v.strictObject({
+            entityId: chatEntityRef({
+              from: "outputPath",
+              path: "invoice.workspaceId",
+            }),
+          }),
+        ),
+      }),
+    });
+
+    const projected = project({
+      payload: {
+        invoice: {
+          workspaceId: WS_UUID,
+          items: [{ entityId: ENTITY_UUID }],
+        },
+      },
+      refRegistry,
+      schema,
+    }).unwrap();
+
+    expect(projected).toEqual({
+      invoice: {
+        items: [
+          {
+            entityId: refRegistry.toEntityRef({
+              entityId: toSafeId<"entity">(ENTITY_UUID),
+              workspaceId: toSafeId<"workspace">(WS_UUID),
+            }),
+          },
+        ],
+        workspaceId: refRegistry.toMatterRef(toSafeId<"workspace">(WS_UUID)),
+      },
+    });
+    expect(containsRawUuid(projected)).toBe(false);
+  });
+
+  test("inputParam workspace source draws from the resolved matter input", () => {
+    const refRegistry = createChatRefRegistry();
+    const schema: ChatProjectionSchema = v.strictObject({
+      documents: v.array(
+        v.strictObject({
+          id: chatEntityRef({ from: "inputParam", param: "matter_id" }),
+        }),
+      ),
+    });
+
+    const projected = project({
+      dehydration: {
+        ...emptyDehydration(),
+        resolvedMatterParams: { matter_id: toSafeId<"workspace">(WS_UUID) },
+      },
+      payload: { documents: [{ id: ENTITY_UUID }] },
+      refRegistry,
+      schema,
+    }).unwrap();
+
+    expect(projected).toEqual({
+      documents: [
+        {
+          id: refRegistry.toEntityRef({
+            entityId: toSafeId<"entity">(ENTITY_UUID),
+            workspaceId: toSafeId<"workspace">(WS_UUID),
+          }),
+        },
+      ],
+    });
+  });
+
+  test("inputEntityWorkspace mints a new ref for a different entity in the input entity's workspace", () => {
+    const refRegistry = createChatRefRegistry();
+    const taskRef = refRegistry.toEntityRef({
+      entityId: toSafeId<"entity">(ENTITY_UUID),
+      workspaceId: toSafeId<"workspace">(WS_UUID),
+    });
+    const schema: ChatProjectionSchema = v.strictObject({
+      taskId: chatEntityRef({ from: "inputEntity", param: "task_id" }),
+      linked: v.strictObject({
+        id: chatEntityRef({ from: "inputEntityWorkspace", param: "task_id" }),
+      }),
+    });
+
+    const projected = project({
+      dehydration: {
+        ...emptyDehydration(),
+        dehydratedEntityRefs: new Map([[ENTITY_UUID, taskRef]]),
+        resolvedEntityParams: { task_id: toSafeId<"workspace">(WS_UUID) },
+      },
+      payload: { taskId: ENTITY_UUID, linked: { id: LINKED_ENTITY_UUID } },
+      refRegistry,
+      schema,
+    }).unwrap();
+
+    // The task's own id echoes the dehydrated input ref (no workspace lookup);
+    // the linked entity (a different uuid) mints a new ref scoped to the same
+    // workspace, not the task's own ref and not an un-hydrated raw uuid.
+    expect(projected).toEqual({
+      linked: {
+        id: refRegistry.toEntityRef({
+          entityId: toSafeId<"entity">(LINKED_ENTITY_UUID),
+          workspaceId: toSafeId<"workspace">(WS_UUID),
+        }),
+      },
+      taskId: taskRef,
+    });
+    expect(containsRawUuid(projected)).toBe(false);
+  });
+
+  test("an entity echo reuses the dehydrated ref even under another workspace source", () => {
+    const refRegistry = createChatRefRegistry();
+    const entityRef = refRegistry.toEntityRef({
+      entityId: toSafeId<"entity">(ENTITY_UUID),
+      workspaceId: toSafeId<"workspace">(WS_UUID),
+    });
+    // read_content_across_matters-style: the field declares a sibling source
+    // for non-echo payloads, but the output entity IS the request's own input,
+    // so the reuse map wins without consulting the sibling.
+    const schema: ChatProjectionSchema = v.strictObject({
+      entityId: chatEntityRef({ from: "sibling", key: "workspaceId" }),
+      workspaceId: chatRef("matter"),
+    });
+
+    const projected = project({
+      dehydration: {
+        ...emptyDehydration(),
+        dehydratedEntityRefs: new Map([[ENTITY_UUID, entityRef]]),
+      },
+      payload: { entityId: ENTITY_UUID, workspaceId: WS_UUID },
+      refRegistry,
+      schema,
+    }).unwrap();
+
+    expect(projected).toEqual({
+      entityId: entityRef,
+      workspaceId: refRegistry.toMatterRef(toSafeId<"workspace">(WS_UUID)),
+    });
+  });
+
+  test("unenumeratedJson passes through unmodified when it carries no UUID", () => {
+    const schema: ChatProjectionSchema = v.strictObject({
+      content: unenumeratedJson(),
+      question: v.string(),
+    });
+    const content = {
+      nodes: [{ kind: "text", value: "Limitation of liability" }],
+      type: "single-select",
+    };
+
+    const projected = project({
+      payload: { content, question: "Which cap applies?" },
+      schema,
+    }).unwrap();
+
+    expect(projected).toEqual({ content, question: "Which cap applies?" });
+  });
+
+  test("the UUID invariant still covers unenumeratedJson contents, unlicensed", () => {
+    const schema: ChatProjectionSchema = v.strictObject({
+      content: unenumeratedJson(),
+    });
+
+    const result = project({
+      payload: {
+        content: { nodes: [{ value: `see ${ROGUE_UUID}` }] },
+      },
+      schema,
+    });
+
+    expect(Result.isError(result)).toBe(true);
+    if (Result.isError(result)) {
+      expect(result.error.kind).toBe("server-defect");
+      expect(result.error.message).toBe(REF_PROJECTION_FAILURE_MESSAGE);
+    }
+    expect(captureErrorMock).toHaveBeenCalledWith(
+      expect.objectContaining({ message: REF_PROJECTION_FAILURE_MESSAGE }),
+      {
+        path: "content.nodes[].value",
+        source: "run-registry-tool",
+        toolName: "test_tool",
+      },
+    );
+    const [, telemetryContext] = captureErrorMock.mock.calls.at(0) ?? [];
+    expect(JSON.stringify(telemetryContext)).not.toContain(ROGUE_UUID);
+  });
+
+  test("a UUID embedded in a declared plain string fails closed with its path", () => {
+    const schema: ChatProjectionSchema = v.strictObject({
+      matters: v.array(v.strictObject({ reference: v.string() })),
+    });
+
+    const result = project({
+      payload: { matters: [{ reference: `REF-${ROGUE_UUID}` }] },
+      schema,
+    });
+
+    expect(Result.isError(result)).toBe(true);
+    if (Result.isError(result)) {
+      expect(result.error.message).toBe(REF_PROJECTION_FAILURE_MESSAGE);
+      expect(result.error.message).not.toContain(ROGUE_UUID);
+    }
+    expect(captureErrorMock).toHaveBeenCalledWith(
+      expect.objectContaining({ message: REF_PROJECTION_FAILURE_MESSAGE }),
+      expect.objectContaining({ path: "matters[].reference" }),
+    );
+  });
+
+  test("an entity ref whose workspace is unrecoverable fails closed instead of leaking", () => {
+    // The sibling workspace slot is null, so no ref can be minted; the raw
+    // entity UUID would survive at an entity-ref position, which is never
+    // licensed, so the invariant refuses the payload.
+    const schema: ChatProjectionSchema = v.strictObject({
+      entityId: chatEntityRef({ from: "sibling", key: "workspaceId" }),
+      workspaceId: v.nullable(chatRef("matter")),
+    });
+
+    const result = project({
+      payload: { entityId: ENTITY_UUID, workspaceId: null },
+      schema,
+    });
+
+    expect(Result.isError(result)).toBe(true);
+    if (Result.isError(result)) {
+      expect(result.error.kind).toBe("server-defect");
+      expect(result.error.message).toBe(REF_PROJECTION_FAILURE_MESSAGE);
+    }
+    expect(captureErrorMock).toHaveBeenCalledWith(
+      expect.objectContaining({ message: REF_PROJECTION_FAILURE_MESSAGE }),
+      expect.objectContaining({ path: "entityId" }),
+    );
+  });
+
+  test("a matching payload with no ids projects to the declared shape verbatim", () => {
     const payload = {
       matters: [
         {
-          id: "0dc54d0c-10d7-501d-897e-e801dbd0998c",
+          id: WS_UUID,
           name: "Acme",
           reference: "REF-1",
           status: "active",
@@ -652,14 +1065,28 @@ describe("applyProjectionSchema", () => {
       ],
       nextCursor: null,
     };
+    const refRegistry = createChatRefRegistry();
 
-    const result = applyProjectionSchema({
-      schema: LIST_MATTERS_PROJECTION,
+    const projected = project({
       payload,
-    });
+      refRegistry,
+      schema: LIST_MATTERS_PROJECTION,
+    }).unwrap();
 
-    expect(Result.isError(result)).toBe(false);
-    expect(result.unwrap()).toEqual(payload);
+    expect(projected).toEqual({
+      matters: [
+        {
+          id: refRegistry.toMatterRef(toSafeId<"workspace">(WS_UUID)),
+          name: "Acme",
+          reference: "REF-1",
+          status: "active",
+          lastActivityAt: "2026-01-01T00:00:00.000Z",
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+      ],
+      nextCursor: null,
+    });
+    expect(containsRawUuid(projected)).toBe(false);
   });
 });
 

--- a/apps/api/src/handlers/chat/tools/registry-adapter/projection-schema.ts
+++ b/apps/api/src/handlers/chat/tools/registry-adapter/projection-schema.ts
@@ -1,15 +1,27 @@
 import { panic, Result } from "better-result";
 import * as v from "valibot";
 
+import { captureError } from "@/api/lib/analytics/capture";
+import type { SafeId } from "@/api/lib/branded-types";
+import type { ChatRefRegistry } from "@/api/lib/chat/ref-registry";
+import { ChatToolError } from "@/api/lib/errors/tagged-errors";
+import {
+  brandPersistedContactId,
+  brandPersistedEntityId,
+  brandPersistedPropertyId,
+  brandPersistedWorkspaceId,
+} from "@/api/lib/safe-id-boundaries";
+
 /**
  * Chat projection schemas: one Valibot `strictObject` per converted tool that
  * describes exactly what the chat surface forwards, with each id-bearing
- * field's chat semantics attached via `v.metadata`. The strict parse makes an
- * undeclared handler field structurally unable to reach the model (an unknown
- * key fails the parse, fail-closed), and the ref-mediation path lists
- * (`outputRefs`/`passthroughIdPaths`/`stripPaths`) are derived mechanically
- * from the same artifact, so the shape and its ref decisions cannot drift
- * apart the way a hand-maintained path list can.
+ * field's chat semantics attached via `v.metadata`. `projectForChat` applies a
+ * schema in a single pass: one strict parse (an unknown handler field fails
+ * closed, structurally unable to reach the model), then one walk over the
+ * parsed value guided by the same annotations that strips declared fields,
+ * hydrates tenant UUIDs into chat refs, and enforces the "no raw tenant UUID
+ * reaches the model" invariant together — so the shape and its ref decisions
+ * cannot drift apart the way a hand-maintained path list can.
  */
 
 // --- Ref vocabulary -----------------------------------------------------------
@@ -59,25 +71,27 @@ export type OutputRefField =
   | { kind: "entity"; path: string; workspace: EntityWorkspaceSource };
 
 /**
- * The three output-side path lists the generic mediation cores
- * (`hydrateRefs`/`findUndeclaredUuidPathIn`/`stripDeclaredPaths`) consume,
- * derived from each map entry's projection schema. Hand-written lists no
- * longer exist: the schema is the only artifact these can come from.
+ * The three output-side path lists derived from a projection schema's
+ * annotations. The runtime transform (`projectForChat`) no longer consumes
+ * them — it walks the schema annotations directly — but the contract corpus
+ * (`registry-projection-contract.test.ts`) still derives them to prove its
+ * fixtures exercise every declared ref path and that every declared strip
+ * path is absent from the projected payload (its anti-vacuity guard).
  */
 export type RefMediationLists = {
   outputRefs: readonly OutputRefField[];
   /**
    * UUID-bearing output paths intentionally left un-refed: non-tenant handles
-   * (user/invoice/template/audit/public-corpus ids) or opaque cursors.
-   * Load-bearing allowlist for the runtime UUID backstop; an `outputRefs`
-   * path is deliberately NOT part of it — hydration must have already
-   * rewritten it, so a uuid still there fails closed.
+   * (user/invoice/template/audit/public-corpus ids) or opaque cursors. These
+   * are the positions licensed to survive the runtime UUID invariant; an
+   * `outputRefs` path is deliberately NOT part of it — hydration must have
+   * already rewritten it, so a uuid still there fails closed.
    */
   passthroughIdPaths: readonly string[];
   /**
-   * Output paths deleted from the chat projection before hydration and the
-   * UUID backstop run: ids other surfaces need (web-UI field/file plumbing
-   * handles) that chat cannot act on.
+   * Output paths deleted from the chat projection before the payload reaches
+   * the model: ids other surfaces need (web-UI field/file plumbing handles)
+   * that chat cannot act on.
    */
   stripPaths: readonly string[];
 };
@@ -198,8 +212,28 @@ export const unenumeratedJson = (): AnnotatedFieldSchema => v.unknown();
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value);
 
+// Memoized per schema node: `projectForChat` reads annotations on every
+// request's walk, and a node's annotation never changes after construction.
+// `null` records a node checked and found unannotated.
+const annotationCache = new WeakMap<
+  Record<string, unknown>,
+  ChatProjectionAnnotation | null
+>();
+
 /** Read the chat annotation off a schema node's metadata pipe items, if any. */
 const readAnnotation = (
+  node: Record<string, unknown>,
+): ChatProjectionAnnotation | undefined => {
+  const cached = annotationCache.get(node);
+  if (cached !== undefined) {
+    return cached ?? undefined;
+  }
+  const annotation = parseAnnotation(node);
+  annotationCache.set(node, annotation ?? null);
+  return annotation;
+};
+
+const parseAnnotation = (
   node: Record<string, unknown>,
 ): ChatProjectionAnnotation | undefined => {
   const pipe = node["pipe"];
@@ -257,7 +291,7 @@ type AnnotationVisitor = (
 
 /**
  * Walk one object-field value schema under `key`, recording annotated leaves
- * in the `a.b` / `a[].b` grammar `ref-mediation.ts` consumes. Wrappers are
+ * in the `a.b` / `a[].b` grammar the derived lists use. Wrappers are
  * transparent; an array descends as `key[]` into its item; unions merge every
  * option's contributions (the grammar has no discriminator — the paths are
  * allowlists, so a path only one variant produces is simply absent from the
@@ -398,8 +432,10 @@ const mediationListsCache = new WeakMap<
 
 /**
  * Mechanically derive a converted tool's `outputRefs`/`passthroughIdPaths`/
- * `stripPaths` from its projection schema's annotations. Memoized per schema:
- * the walk runs once per tool per process, not per request.
+ * `stripPaths` from its projection schema's annotations. The runtime path
+ * (`projectForChat`) does not consume these — its walk reads the annotations
+ * directly — but the contract corpus does, for its declared-vs-exercised
+ * anti-vacuity guard. Memoized per schema.
  */
 export const deriveRefMediationEntry = (
   schema: ChatProjectionSchema,
@@ -421,7 +457,7 @@ export const deriveRefMediationEntry = (
  * dot-paths of the issues, never any payload value, so it can reach telemetry
  * without leaking what it refused.
  */
-export type ProjectionSchemaViolation = { issuePaths: readonly string[] };
+type ProjectionSchemaViolation = { issuePaths: readonly string[] };
 
 /** Normalize a valibot issue path into the map's `a.b` / `a[].b` grammar. */
 const issueRefPath = (issue: v.BaseIssue<unknown>): string => {
@@ -460,11 +496,11 @@ const collectIssuePaths = (
 /**
  * Strict-parse a tool payload against its projection schema. The parse is the
  * structural guarantee: an unknown key anywhere in the declared object tree —
- * a field nobody classified — fails here, before strip/hydrate/backstop ever
- * see the payload, so an undeclared field cannot flow to the model by
+ * a field nobody classified — fails here, before the annotation walk ever
+ * sees the payload, so an undeclared field cannot flow to the model by
  * construction. On failure the violation carries issue paths only.
  */
-export const applyProjectionSchema = ({
+const strictParseProjection = ({
   payload,
   schema,
 }: {
@@ -480,6 +516,557 @@ export const applyProjectionSchema = ({
     collectIssuePaths(issue, issuePaths);
   }
   return Result.err({ issuePaths: [...new Set(issuePaths)] });
+};
+
+// --- Projecting a payload for chat ---------------------------------------------------
+// `projectForChat` is the single output-side transform for a projected tool
+// payload: one strict parse, then one walk over the parsed value guided by the
+// schema's annotations. The walk strips `strippedField` leaves, hydrates
+// `chatRef`/`chatEntityRef` leaves into chat refs, forwards `passthroughId`
+// leaves and `unenumeratedJson` subtrees, and enforces the terminal "no raw
+// tenant UUID reaches the model" invariant, all in the same pass.
+
+const UUID_REGEX =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/iu;
+const UUID_ANYWHERE_REGEX =
+  /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/iu;
+
+const isUuidString = (value: unknown): value is string =>
+  typeof value === "string" && UUID_REGEX.test(value);
+
+/**
+ * A verbatim-UUID guard for the "no tenant UUID reaches the model" invariant.
+ * A projected payload must serialize without any raw UUID: every tenant id is
+ * a ref and every `passthroughId` handle is documented as either
+ * non-UUID-formatted (opaque cursors) or an out-of-band handle. Tests assert
+ * this holds.
+ */
+export const containsRawUuid = (value: unknown): boolean =>
+  UUID_ANYWHERE_REGEX.test(JSON.stringify(value));
+
+/**
+ * What input dehydration resolved, carried into the output walk so entity
+ * refs can be minted (or reused) without fresh lookups. Produced by
+ * `dehydrateRefs` in `ref-mediation.ts`.
+ */
+export type DehydratedInput = {
+  args: Record<string, unknown>;
+  /** Resolved workspace uuid per matter input param, for entity output refs. */
+  resolvedMatterParams: Record<string, SafeId<"workspace">>;
+  /**
+   * Resolved workspace uuid per entity input param, for output entities that
+   * are *different* from the input entity but share its workspace (e.g. a
+   * task's linked entities). `resolvedMatterParams` covers the reverse case
+   * (workspace named directly); this covers the entity-ref case, where the
+   * workspace is recovered from the ref the caller already resolved rather
+   * than from a fresh lookup.
+   */
+  resolvedEntityParams: Record<string, SafeId<"workspace">>;
+  /** entity uuid -> the ref it was dehydrated from, for reuse on output. */
+  dehydratedEntityRefs: Map<string, string>;
+};
+
+/**
+ * Surfaced to the model when a projected payload still carries a raw uuid at
+ * a position the schema does not license. Deliberately does not say
+ * "anonymization": the anonymization feature (the anonymized MCP surface) is
+ * a different mechanism and is not involved — chat egress runs in default
+ * mode. This is the chat ref projection's own fail-closed invariant, it fires
+ * regardless of any anonymization setting, and the model can do nothing about
+ * it, so the message says both.
+ */
+export const REF_PROJECTION_FAILURE_MESSAGE =
+  "The tool result contained an internal identifier the chat projection " +
+  "could not map to a reference. This is a server-side defect, not a " +
+  "problem with your input; do not retry this call.";
+
+/**
+ * Surfaced to the model when a converted tool's payload fails its projection
+ * schema's strict parse: a handler emitted a field nobody classified (or a
+ * declared field changed shape). Same fail-closed semantics as
+ * `REF_PROJECTION_FAILURE_MESSAGE`; the parse fires before any field can be
+ * forwarded, so the undeclared field never reaches the model by construction.
+ */
+export const PROJECTION_SCHEMA_FAILURE_MESSAGE =
+  "The tool result did not match the shape the chat projection declares " +
+  "for this tool. This is a server-side defect, not a problem with your " +
+  "input; do not retry this call.";
+
+/** Sentinel a `strippedField` leaf projects to; the object builder omits it. */
+const OMITTED = Symbol("stripped-from-chat-projection");
+
+/**
+ * The state one projection walk threads through its recursion. `raw` is the
+ * pristine parse output the walk never mutates (hydrated values go into
+ * freshly built containers), so `sibling`/`outputPath` workspace sources
+ * always read the raw handler values — the guarantee the previous two-pass
+ * hydration provided by ordering entity refs before matter refs, which would
+ * otherwise overwrite a sibling workspace UUID with a `mat_N` ref before the
+ * entity ref could be minted.
+ */
+type ProjectWalkContext = {
+  raw: Record<string, unknown>;
+  refRegistry: ChatRefRegistry;
+  dehydration: DehydratedInput;
+  /**
+   * Offending paths of the terminal UUID invariant, recorded during the walk:
+   * a UUID-bearing string at any position not licensed by a `passthroughId`
+   * annotation (an ordinary declared field, an unenumerated subtree, a ref
+   * leaf hydration could not rewrite). Paths only, never values.
+   */
+  uuidViolations: string[];
+};
+
+const isSchemaNode = (value: unknown): value is v.GenericSchema =>
+  isRecord(value) &&
+  value["kind"] === "schema" &&
+  typeof value["type"] === "string";
+
+/**
+ * Record a violation if a string leaf carries a UUID anywhere in it. A
+ * substring match (not just a bare-UUID exact match) so a UUID embedded
+ * inside a longer string (a url, free text) is still caught.
+ */
+const checkStringLeaf = (
+  ctx: ProjectWalkContext,
+  value: unknown,
+  segments: readonly string[],
+): void => {
+  if (typeof value === "string" && UUID_ANYWHERE_REGEX.test(value)) {
+    ctx.uuidViolations.push(segments.join("."));
+  }
+};
+
+/**
+ * Scan an `unenumeratedJson` subtree, which is forwarded unmodified: every
+ * string inside stays subject to the UUID invariant, unlicensed. Paths use
+ * the same `a.b` / `a[].b` grammar as the rest of the walk (arrays collapsed
+ * to a `[]` suffix on their key).
+ */
+const scanUnenumerated = (
+  ctx: ProjectWalkContext,
+  node: unknown,
+  segments: readonly string[],
+): void => {
+  if (typeof node === "string") {
+    checkStringLeaf(ctx, node, segments);
+    return;
+  }
+  if (Array.isArray(node)) {
+    for (const item of node) {
+      scanUnenumerated(ctx, item, segments);
+    }
+    return;
+  }
+  if (!isRecord(node)) {
+    return;
+  }
+  for (const [key, value] of Object.entries(node)) {
+    const segment = Array.isArray(value) ? `${key}[]` : key;
+    scanUnenumerated(ctx, value, [...segments, segment]);
+  }
+};
+
+/** Read the first scalar a (non-array) dotted path resolves to in `raw`. */
+const readRawScalar = (ctx: ProjectWalkContext, path: string): unknown => {
+  let cursor: unknown = ctx.raw;
+  for (const key of path.split(".")) {
+    if (!isRecord(cursor)) {
+      return undefined;
+    }
+    cursor = cursor[key];
+  }
+  return cursor;
+};
+
+const resolveEntityWorkspaceUuid = (
+  ctx: ProjectWalkContext,
+  workspace: EntityWorkspaceSource,
+  container: Record<string, unknown>,
+): unknown => {
+  switch (workspace.from) {
+    case "sibling": {
+      // Reads the RAW container, untouched by hydration in this same walk.
+      return container[workspace.key];
+    }
+    case "outputPath": {
+      return readRawScalar(ctx, workspace.path);
+    }
+    case "inputParam": {
+      return ctx.dehydration.resolvedMatterParams[workspace.param];
+    }
+    case "inputEntityWorkspace": {
+      return ctx.dehydration.resolvedEntityParams[workspace.param];
+    }
+    case "inputEntity": {
+      // The output entity is the request's own entity input; its ref comes
+      // from the reuse map in `projectEntityLeaf`, never a workspace lookup.
+      return undefined;
+    }
+    default: {
+      workspace satisfies never;
+      return undefined;
+    }
+  }
+};
+
+type ProjectEntityLeafArgs = {
+  ctx: ProjectWalkContext;
+  value: unknown;
+  container: Record<string, unknown>;
+  workspace: EntityWorkspaceSource;
+  segments: readonly string[];
+};
+
+const projectEntityLeaf = ({
+  ctx,
+  value,
+  container,
+  workspace,
+  segments,
+}: ProjectEntityLeafArgs): unknown => {
+  if (!isUuidString(value)) {
+    // Not an exact UUID (an opaque or already-shaped value): forwarded, but
+    // an embedded UUID substring still fails closed.
+    checkStringLeaf(ctx, value, segments);
+    return value;
+  }
+
+  // The output entity IS one the request named on input: reuse the ref already
+  // minted for it, so no workspace lookup is needed.
+  const reused = ctx.dehydration.dehydratedEntityRefs.get(value);
+  if (reused !== undefined) {
+    return reused;
+  }
+
+  const workspaceUuid = resolveEntityWorkspaceUuid(ctx, workspace, container);
+  if (!isUuidString(workspaceUuid)) {
+    // Owning workspace not recoverable for this field: refusing to mint a ref
+    // against a guessed workspace leaves the raw UUID at an entity-ref
+    // position, which the terminal invariant refuses (never licensed).
+    ctx.uuidViolations.push(segments.join("."));
+    return value;
+  }
+
+  return ctx.refRegistry.toEntityRef({
+    entityId: brandPersistedEntityId(value),
+    workspaceId: brandPersistedWorkspaceId(workspaceUuid),
+  });
+};
+
+type ProjectRefLeafArgs = {
+  ctx: ProjectWalkContext;
+  value: unknown;
+  kind: SimpleRefKind;
+  segments: readonly string[];
+};
+
+const projectRefLeaf = ({
+  ctx,
+  value,
+  kind,
+  segments,
+}: ProjectRefLeafArgs): unknown => {
+  if (!isUuidString(value)) {
+    checkStringLeaf(ctx, value, segments);
+    return value;
+  }
+  switch (kind) {
+    case "matter": {
+      return ctx.refRegistry.toMatterRef(brandPersistedWorkspaceId(value));
+    }
+    case "contact": {
+      return ctx.refRegistry.toContactRef(brandPersistedContactId(value));
+    }
+    case "property": {
+      return ctx.refRegistry.toPropertyRef(brandPersistedPropertyId(value));
+    }
+    default: {
+      kind satisfies never;
+      return value;
+    }
+  }
+};
+
+/** Pick the union/variant option that admits `value` (the outer parse already
+ * proved one does), mirroring valibot's own first-match option order. */
+const matchUnionOption = (
+  unionNode: Record<string, unknown>,
+  value: unknown,
+): v.GenericSchema => {
+  const options = unionNode["options"];
+  if (!Array.isArray(options)) {
+    panic("union schema node has no options array");
+  }
+  for (const option of options) {
+    if (!isSchemaNode(option)) {
+      panic("union option is not a valibot schema");
+    }
+    if (v.safeParse(option, value).success) {
+      return option;
+    }
+  }
+  return panic("no union option matches a value the union already parsed");
+};
+
+type ProjectFieldArgs = {
+  ctx: ProjectWalkContext;
+  node: unknown;
+  value: unknown;
+  container: Record<string, unknown>;
+  segments: readonly string[];
+  key: string;
+};
+
+/**
+ * A field's annotation, read through transparent wrappers
+ * (optional/nullable/...): chat semantics attach to the field, not to a
+ * particular wrapping, so `v.optional(strippedField())` strips exactly like a
+ * bare `strippedField()` even when the present value is null.
+ */
+const readFieldAnnotation = (
+  node: Record<string, unknown>,
+): ReturnType<typeof readAnnotation> => {
+  const annotation = readAnnotation(node);
+  if (annotation !== undefined) {
+    return annotation;
+  }
+  const nodeType = node["type"];
+  if (typeof nodeType === "string" && WRAPPER_TYPES.has(nodeType)) {
+    return readFieldAnnotation(asSchemaNode(node["wrapped"]));
+  }
+  return undefined;
+};
+
+/**
+ * Project one object-field value. Annotated leaves get their chat semantics
+ * applied here, where the RAW containing object is in hand for `sibling`
+ * workspace sources; everything else descends structurally.
+ */
+const projectField = ({
+  ctx,
+  node,
+  value,
+  container,
+  segments,
+  key,
+}: ProjectFieldArgs): unknown => {
+  const schemaNode = asSchemaNode(node);
+  const annotation = readFieldAnnotation(schemaNode);
+  if (annotation !== undefined) {
+    switch (annotation.role) {
+      case "strip": {
+        return OMITTED;
+      }
+      case "passthroughId": {
+        // Licensed to survive verbatim, UUID-shaped or not.
+        return value;
+      }
+      case "ref": {
+        return projectRefLeaf({
+          ctx,
+          kind: annotation.kind,
+          segments: [...segments, key],
+          value,
+        });
+      }
+      case "entityRef": {
+        return projectEntityLeaf({
+          container,
+          ctx,
+          segments: [...segments, key],
+          value,
+          workspace: annotation.workspace,
+        });
+      }
+      default: {
+        annotation satisfies never;
+        return value;
+      }
+    }
+  }
+
+  const nodeType = schemaNode["type"];
+  if (typeof nodeType === "string" && WRAPPER_TYPES.has(nodeType)) {
+    if (value === null || value === undefined) {
+      return value;
+    }
+    return projectField({
+      container,
+      ctx,
+      key,
+      node: schemaNode["wrapped"],
+      segments,
+      value,
+    });
+  }
+  if (nodeType === "array") {
+    if (!Array.isArray(value)) {
+      panic("array projection schema admitted a non-array value");
+    }
+    const item = asSchemaNode(schemaNode["item"]);
+    if (readAnnotation(item) !== undefined) {
+      panic(
+        "the ref path grammar cannot address annotated array items; annotate an object field instead",
+      );
+    }
+    const itemSegments = [...segments, `${key}[]`];
+    return value.map((entry) => projectValue(ctx, item, entry, itemSegments));
+  }
+  if (nodeType === "unknown") {
+    // unenumeratedJson: forwarded unmodified; the invariant scan still covers
+    // every string inside, unlicensed.
+    const segment = Array.isArray(value) ? `${key}[]` : key;
+    scanUnenumerated(ctx, value, [...segments, segment]);
+    return value;
+  }
+  return projectValue(ctx, schemaNode, value, [...segments, key]);
+};
+
+/** Project a non-field position: a union option, object, or array item. */
+const projectValue = (
+  ctx: ProjectWalkContext,
+  node: unknown,
+  value: unknown,
+  segments: readonly string[],
+): unknown => {
+  const schemaNode = asSchemaNode(node);
+  if (readAnnotation(schemaNode) !== undefined) {
+    panic("chat projection annotations must sit on object fields");
+  }
+  const nodeType = schemaNode["type"];
+  if (typeof nodeType !== "string") {
+    panic("valibot schema node has no type");
+  }
+  if (WRAPPER_TYPES.has(nodeType)) {
+    if (value === null || value === undefined) {
+      return value;
+    }
+    return projectValue(ctx, schemaNode["wrapped"], value, segments);
+  }
+  if (UNION_TYPES.has(nodeType)) {
+    return projectValue(
+      ctx,
+      matchUnionOption(schemaNode, value),
+      value,
+      segments,
+    );
+  }
+  if (OBJECT_TYPES.has(nodeType)) {
+    const entries = schemaNode["entries"];
+    if (!isRecord(entries)) {
+      panic("object schema node has no entries record");
+    }
+    if (!isRecord(value)) {
+      panic("object projection schema admitted a non-object value");
+    }
+    const projectedEntries: [string, unknown][] = [];
+    for (const [key, child] of Object.entries(value)) {
+      const childSchema =
+        entries[key] ??
+        panic("strict parse admitted a key its schema does not declare");
+      const projected = projectField({
+        container: value,
+        ctx,
+        key,
+        node: childSchema,
+        segments,
+        value: child,
+      });
+      if (projected !== OMITTED) {
+        projectedEntries.push([key, projected]);
+      }
+    }
+    return Object.fromEntries(projectedEntries);
+  }
+  if (nodeType === "array") {
+    panic("the ref path grammar cannot address nested arrays");
+  }
+  if (nodeType === "unknown") {
+    scanUnenumerated(ctx, value, segments);
+    return value;
+  }
+  // A scalar leaf (string/number/boolean/literal/picklist/null): ordinary
+  // data. A UUID-bearing string here is undeclared and fails closed.
+  checkStringLeaf(ctx, value, segments);
+  return value;
+};
+
+/** Where a projection ran, for the fail-closed telemetry context. */
+type ProjectionTelemetrySource =
+  | "run-registry-tool"
+  | "run-registry-write-tool";
+
+export type ProjectForChatOptions = {
+  schema: ChatProjectionSchema;
+  payload: unknown;
+  refRegistry: ChatRefRegistry;
+  dehydration: DehydratedInput;
+  /** Telemetry context only; never part of the transform. */
+  source: ProjectionTelemetrySource;
+  toolName: string;
+};
+
+/**
+ * The single output-side transform for a projected tool payload:
+ *
+ * 1. Strict-parse against the projection schema. An unknown key anywhere in
+ *    the declared object tree — a field nobody classified — fails closed as a
+ *    `server-defect`, with the issue dot-paths (never values) to telemetry.
+ * 2. One walk over the parsed value, guided by the schema annotations:
+ *    `strippedField` leaves are omitted, `chatRef`/`chatEntityRef` leaves are
+ *    hydrated into chat refs (entity workspaces resolved per their declared
+ *    `EntityWorkspaceSource`, always against the raw parsed snapshot),
+ *    `passthroughId` leaves and `unenumeratedJson` subtrees pass through.
+ * 3. The terminal invariant, enforced in the same walk: no UUID survives at
+ *    any position a `passthroughId` annotation does not license. The schema
+ *    annotations are documentation the type system cannot fully enforce (a
+ *    wrong workspace source silently skips hydration), so every forwarded
+ *    string is checked rather than trusting the static mapping alone; a
+ *    survivor fails closed as a `server-defect`, its path (never its value)
+ *    to telemetry.
+ */
+export const projectForChat = ({
+  schema,
+  payload,
+  refRegistry,
+  dehydration,
+  source,
+  toolName,
+}: ProjectForChatOptions): Result<unknown, ChatToolError> => {
+  const parsed = strictParseProjection({ payload, schema });
+  if (Result.isError(parsed)) {
+    const error = new ChatToolError({
+      kind: "server-defect",
+      message: PROJECTION_SCHEMA_FAILURE_MESSAGE,
+    });
+    captureError(error, {
+      paths: parsed.error.issuePaths.join(", "),
+      source,
+      toolName,
+    });
+    return Result.err(error);
+  }
+
+  const ctx: ProjectWalkContext = {
+    dehydration,
+    raw: parsed.value,
+    refRegistry,
+    uuidViolations: [],
+  };
+  const projected = projectValue(ctx, schema, parsed.value, []);
+
+  const offendingPath = ctx.uuidViolations.at(0);
+  if (offendingPath !== undefined) {
+    const error = new ChatToolError({
+      kind: "server-defect",
+      message: REF_PROJECTION_FAILURE_MESSAGE,
+    });
+    captureError(error, { path: offendingPath, source, toolName });
+    return Result.err(error);
+  }
+
+  return Result.ok(projected);
 };
 
 // --- Model-facing shape rendering ---------------------------------------------------

--- a/apps/api/src/handlers/chat/tools/registry-adapter/ref-field-map.ts
+++ b/apps/api/src/handlers/chat/tools/registry-adapter/ref-field-map.ts
@@ -52,13 +52,11 @@ export type InputRefParam = { kind: RegistryRefKind; param: string };
 /**
  * The ref-mediation contract of one chat-projected tool: the input refs to
  * dehydrate, plus the projection schema that is the single output-side
- * artifact. The three mediation lists (`outputRefs`/`passthroughIdPaths`/
- * `stripPaths`) are derived mechanically from the schema's annotations
- * (`deriveRefMediationEntry`), and its strict parse makes an undeclared
- * handler field structurally unable to reach the model. Hand-written path
- * lists are deliberately unrepresentable here: there is no field to put them
- * in, so a new tool cannot reintroduce the hand-maintained mirror this map
- * used to be.
+ * artifact. `projectForChat` applies the schema in one pass (strict parse,
+ * strip, ref hydration, UUID invariant), so an undeclared handler field is
+ * structurally unable to reach the model. Hand-written path lists are
+ * deliberately unrepresentable here: there is no field to put them in, so a
+ * new tool cannot reintroduce the hand-maintained mirror this map used to be.
  */
 export type RefMediationEntry = {
   inputRefs: readonly InputRefParam[];
@@ -79,14 +77,13 @@ export type RegistryRefFieldMapEntry =
 // --- Chat projection schemas -------------------------------------------------
 // One artifact per projected tool: the exact shape the chat surface forwards,
 // with per-field chat semantics attached (`chatRef`/`chatEntityRef`/
-// `passthroughId`/`strippedField`). The strict parse in the orchestrator makes
-// an undeclared handler field fail closed BEFORE it can reach the model, and
-// `deriveRefMediationEntry` derives the entry's outputRefs/passthrough/strip
-// lists from the same annotations, so shape and ref decisions cannot drift.
-// Every schema is written from the handler's own payload construction
-// (`apps/api/src/mcp/*-tools.ts`), branch by branch; per-tool derivation tests
-// in `projection-schema.test.ts` pin each schema's derived lists to the hand
-// lists it replaced.
+// `passthroughId`/`strippedField`). `projectForChat` strict-parses each
+// payload against its schema (an undeclared handler field fails closed BEFORE
+// it can reach the model) and applies the annotations in the same walk, so
+// shape and ref decisions cannot drift. Every schema is written from the
+// handler's own payload construction (`apps/api/src/mcp/*-tools.ts`), branch
+// by branch; per-tool derivation tests in `projection-schema.test.ts` pin
+// each schema's derived lists to the hand lists they replaced.
 
 /**
  * list_matters, list branch. Source of truth: `handleListMattersTool`

--- a/apps/api/src/handlers/chat/tools/registry-adapter/ref-mediation.test.ts
+++ b/apps/api/src/handlers/chat/tools/registry-adapter/ref-mediation.test.ts
@@ -4,84 +4,55 @@ import { describe, expect, test } from "bun:test";
 import { toSafeId } from "@/api/lib/branded-types";
 import { createChatRefRegistry } from "@/api/lib/chat/ref-registry";
 
-import {
-  containsRawUuid,
-  dehydrateInputRefs,
-  findUndeclaredUuidPath,
-  hydrateOutputRefs,
-  stripDeclaredPaths,
-} from "./ref-mediation";
+import { dehydrateInputRefs, dehydrateRefs } from "./ref-mediation";
 
 const WS_UUID = "0dc54d0c-10d7-501d-897e-e801dbd0998c";
 const ENTITY_UUID = "c09ec856-d945-5ecc-82e3-bb5382165f34";
-const LINKED_ENTITY_UUID = "1e7f7f2a-9b2b-4c40-8ab1-2f5b6c7d8e9f";
 const PROPERTY_UUID = "37286c24-6145-572e-ad27-15a1d4454d59";
 const CONTACT_UUID = "6111c8e9-1404-5b6f-8a9a-0e3a93e8179a";
 
-const EMPTY_DEHYDRATION = {
-  args: {},
-  resolvedMatterParams: {},
-  resolvedEntityParams: {},
-  dehydratedEntityRefs: new Map<string, string>(),
-};
-
-describe("registry ref mediation", () => {
-  test("matter refs round-trip: dehydrate input, hydrate output, no UUID survives", () => {
+describe("registry input ref dehydration", () => {
+  test("a matter ref arg dehydrates to its workspace uuid and records it", () => {
     const registry = createChatRefRegistry();
     const matterRef = registry.toMatterRef(toSafeId<"workspace">(WS_UUID));
-    expect(matterRef).toBe("mat_1");
 
     const dehydrated = dehydrateInputRefs({
       args: { matter_id: matterRef },
       refRegistry: registry,
       toolName: "list_matters",
     }).unwrap();
+
     expect(dehydrated.args["matter_id"]).toBe(WS_UUID);
     expect(dehydrated.resolvedMatterParams["matter_id"]).toBe(
       toSafeId<"workspace">(WS_UUID),
     );
-
-    const hydrated = hydrateOutputRefs({
-      dehydration: EMPTY_DEHYDRATION,
-      output: { matters: [{ id: WS_UUID, name: "Acme" }], nextCursor: null },
-      refRegistry: registry,
-      toolName: "list_matters",
-    });
-    expect(hydrated).toEqual({
-      matters: [{ id: matterRef, name: "Acme" }],
-      nextCursor: null,
-    });
-    expect(containsRawUuid(hydrated)).toBe(false);
   });
 
-  test("entity refs round-trip via a sibling workspace id", () => {
+  test("an entity ref arg dehydrates, recording its workspace and reuse ref", () => {
     const registry = createChatRefRegistry();
-
-    const hydrated = hydrateOutputRefs({
-      dehydration: EMPTY_DEHYDRATION,
-      output: {
-        hits: [{ entityId: ENTITY_UUID, workspaceId: WS_UUID, name: "Brief" }],
-      },
-      refRegistry: registry,
-      toolName: "search_across_matters",
+    const entityRef = registry.toEntityRef({
+      entityId: toSafeId<"entity">(ENTITY_UUID),
+      workspaceId: toSafeId<"workspace">(WS_UUID),
     });
-    // The entity ref is minted from (entityId, sibling workspaceId); the
-    // workspace id itself becomes a matter ref. Neither UUID survives.
-    expect(hydrated).toEqual({
-      hits: [{ entityId: "ent_1", workspaceId: "mat_1", name: "Brief" }],
-    });
-    expect(containsRawUuid(hydrated)).toBe(false);
 
-    // Inverse: the same entity ref dehydrates back to its UUID on input.
     const dehydrated = dehydrateInputRefs({
-      args: { entity_id: "ent_1" },
+      args: { task_id: entityRef },
       refRegistry: registry,
-      toolName: "read_content_across_matters",
+      toolName: "list_tasks",
     }).unwrap();
-    expect(dehydrated.args["entity_id"]).toBe(ENTITY_UUID);
+
+    expect(dehydrated.args["task_id"]).toBe(ENTITY_UUID);
+    // The resolved workspace backs `inputEntityWorkspace` output sources
+    // (e.g. a task's linked entities)...
+    expect(dehydrated.resolvedEntityParams["task_id"]).toBe(
+      toSafeId<"workspace">(WS_UUID),
+    );
+    // ...and the reuse map lets an output echo of the same entity reuse the
+    // ref that was just dehydrated instead of a fresh workspace lookup.
+    expect(dehydrated.dehydratedEntityRefs.get(ENTITY_UUID)).toBe(entityRef);
   });
 
-  test("contact refs round-trip: dehydrate input, hydrate output", () => {
+  test("a contact ref arg dehydrates to its contact uuid", () => {
     const registry = createChatRefRegistry();
     const contactRef = registry.toContactRef(toSafeId<"contact">(CONTACT_UUID));
 
@@ -90,155 +61,34 @@ describe("registry ref mediation", () => {
       refRegistry: registry,
       toolName: "read_contact",
     }).unwrap();
+
     expect(dehydrated.args["contact_id"]).toBe(CONTACT_UUID);
-
-    const hydrated = hydrateOutputRefs({
-      dehydration: EMPTY_DEHYDRATION,
-      output: { contactId: CONTACT_UUID, displayName: "Jane" },
-      refRegistry: registry,
-      toolName: "read_contact",
-    });
-    expect(hydrated).toEqual({ contactId: contactRef, displayName: "Jane" });
-    expect(containsRawUuid(hydrated)).toBe(false);
   });
 
-  test("property refs hydrate and resolve back through the registry", () => {
+  test("a property ref arg dehydrates via the shared write core", () => {
     const registry = createChatRefRegistry();
-
-    const hydrated = hydrateOutputRefs({
-      dehydration: EMPTY_DEHYDRATION,
-      output: { properties: [{ id: PROPERTY_UUID, name: "Amount" }] },
-      refRegistry: registry,
-      toolName: "list_properties",
-    });
-    expect(hydrated).toEqual({
-      properties: [{ id: "prop_1", name: "Amount" }],
-    });
-    expect(registry.resolvePropertyRefs(["prop_1"]).unwrap()).toEqual([
+    const propertyRef = registry.toPropertyRef(
       toSafeId<"property">(PROPERTY_UUID),
-    ]);
-  });
-
-  test("an output entity that is the request's own input reuses its ref without a workspace lookup", () => {
-    const registry = createChatRefRegistry();
-    const entityRef = registry.toEntityRef({
-      entityId: toSafeId<"entity">(ENTITY_UUID),
-      workspaceId: toSafeId<"workspace">(WS_UUID),
-    });
-
-    const dehydrated = dehydrateInputRefs({
-      args: { entity_id: entityRef },
-      refRegistry: registry,
-      toolName: "read_document",
-    }).unwrap();
-    expect(dehydrated.dehydratedEntityRefs.get(ENTITY_UUID)).toBe(entityRef);
-
-    const hydrated = hydrateOutputRefs({
-      dehydration: dehydrated,
-      output: {
-        entityId: ENTITY_UUID,
-        name: "Contract",
-        fields: [{ propertyId: PROPERTY_UUID }],
-      },
-      refRegistry: registry,
-      toolName: "read_document",
-    });
-    expect(hydrated).toEqual({
-      entityId: entityRef,
-      name: "Contract",
-      fields: [{ propertyId: "prop_1" }],
-    });
-    expect(containsRawUuid(hydrated)).toBe(false);
-  });
-
-  test("an entity output ref draws its workspace from the resolved matter input", () => {
-    const registry = createChatRefRegistry();
-    const matterRef = registry.toMatterRef(toSafeId<"workspace">(WS_UUID));
-
-    const dehydrated = dehydrateInputRefs({
-      args: { matter_id: matterRef },
-      refRegistry: registry,
-      toolName: "list_documents",
-    }).unwrap();
-
-    const hydrated = hydrateOutputRefs({
-      dehydration: dehydrated,
-      output: {
-        documents: [{ id: ENTITY_UUID, parentId: null, name: "Draft" }],
-        nextCursor: null,
-      },
-      refRegistry: registry,
-      toolName: "list_documents",
-    });
-    expect(hydrated).toEqual({
-      documents: [{ id: "ent_1", parentId: null, name: "Draft" }],
-      nextCursor: null,
-    });
-    expect(containsRawUuid(hydrated)).toBe(false);
-  });
-
-  test("list_tasks: a linked entity ref draws its workspace from the task_id input, not the reuse map", () => {
-    const registry = createChatRefRegistry();
-    const taskRef = registry.toEntityRef({
-      entityId: toSafeId<"entity">(ENTITY_UUID),
-      workspaceId: toSafeId<"workspace">(WS_UUID),
-    });
-
-    const dehydrated = dehydrateInputRefs({
-      args: { task_id: taskRef },
-      refRegistry: registry,
-      toolName: "list_tasks",
-    }).unwrap();
-    expect(dehydrated.args["task_id"]).toBe(ENTITY_UUID);
-    expect(dehydrated.resolvedEntityParams["task_id"]).toBe(
-      toSafeId<"workspace">(WS_UUID),
     );
 
-    const hydrated = hydrateOutputRefs({
-      dehydration: dehydrated,
-      output: {
-        task: {
-          taskId: ENTITY_UUID,
-          name: "Draft reply",
-          links: [
-            {
-              linkId: "link-1",
-              linkType: "related",
-              direction: "outgoing",
-              entity: {
-                id: LINKED_ENTITY_UUID,
-                name: "Exhibit A",
-                kind: "document",
-              },
-            },
-          ],
-        },
-      },
+    const dehydrated = dehydrateRefs({
+      args: { property_id: propertyRef },
+      inputRefs: [{ kind: "property", param: "property_id" }],
       refRegistry: registry,
-      toolName: "list_tasks",
-    });
+    }).unwrap();
 
-    // The task's own id reuses its input ref; the linked entity (a different
-    // uuid) mints a new ref scoped to the same workspace, not the task's own
-    // ref and not an un-hydrated raw uuid.
-    expect(hydrated).toEqual({
-      task: {
-        taskId: taskRef,
-        name: "Draft reply",
-        links: [
-          {
-            linkId: "link-1",
-            linkType: "related",
-            direction: "outgoing",
-            entity: { id: "ent_2", name: "Exhibit A", kind: "document" },
-          },
-        ],
-      },
-    });
-    expect(containsRawUuid(hydrated)).toBe(false);
-    expect(registry.resolveEntityRefs(["ent_2"]).unwrap()).toEqual([
-      toSafeId<"entity">(LINKED_ENTITY_UUID),
-    ]);
+    expect(dehydrated.args["property_id"]).toBe(PROPERTY_UUID);
+  });
+
+  test("an absent optional ref param and plain args pass through untouched", () => {
+    const dehydrated = dehydrateInputRefs({
+      args: { query: "indemnity" },
+      refRegistry: createChatRefRegistry(),
+      toolName: "list_matters",
+    }).unwrap();
+
+    expect(dehydrated.args).toEqual({ query: "indemnity" });
+    expect(dehydrated.resolvedMatterParams).toEqual({});
   });
 
   test("an unknown ref surfaces the registry's ChatToolError", () => {
@@ -248,137 +98,5 @@ describe("registry ref mediation", () => {
       toolName: "list_matters",
     });
     expect(Result.isError(result)).toBe(true);
-  });
-
-  test("containsRawUuid flags an un-hydrated payload", () => {
-    expect(containsRawUuid({ id: WS_UUID })).toBe(true);
-    expect(containsRawUuid({ id: "mat_1" })).toBe(false);
-  });
-
-  describe("findUndeclaredUuidPath", () => {
-    const INVOICE_UUID = "9c9f2a9e-2f0a-4b7a-9a0e-2e7a1a2b3c4d";
-    const LINE_ITEM_UUID = "1a2b3c4d-5e6f-4a7b-8c9d-0e1f2a3b4c5d";
-    // A list_invoices-style detail-branch payload, post-hydration: the
-    // entity refs `hydrateOutputRefs` mints for the invoice's tenant
-    // content (an `outputRefs` path) already read as chat refs, while the
-    // invoice id and the time-entry's own id are non-tenant handles the
-    // map declares in `passthroughIdPaths` and never mediates.
-    const invoiceFixture = {
-      invoice: {
-        id: INVOICE_UUID,
-        status: "draft",
-        timeEntries: [
-          {
-            id: LINE_ITEM_UUID,
-            entityId: "ent_1",
-            entity: { id: "ent_1", name: "Brief" },
-          },
-        ],
-        expenses: [],
-      },
-    };
-
-    test("a list_invoices-style fixture with only declared passthrough ids passes", () => {
-      expect(
-        findUndeclaredUuidPath({
-          payload: invoiceFixture,
-          toolName: "list_invoices",
-        }),
-      ).toBeUndefined();
-    });
-
-    test("a rogue uuid at an undeclared path fails closed with that path", () => {
-      const doctored = {
-        invoice: {
-          ...invoiceFixture.invoice,
-          // Not one of list_invoices's outputRefs or passthroughIdPaths: an
-          // ordinary field nothing stops from holding a raw uuid.
-          notes: WS_UUID,
-        },
-      };
-
-      expect(
-        findUndeclaredUuidPath({
-          payload: doctored,
-          toolName: "list_invoices",
-        }),
-      ).toBe("invoice.notes");
-    });
-
-    test("a uuid surviving at a declared outputRefs path fails closed (simulated hydration miss)", () => {
-      // `invoice.timeEntries[].entityId` is a declared `outputRefs` entity
-      // path: `hydrateOutputRefs` should always have rewritten it to a chat
-      // ref. Leaving it a raw uuid simulates a hydration miss (an
-      // unresolved workspace source, say), which the passthrough allowlist
-      // must NOT paper over: `outputRefs` paths are deliberately excluded
-      // from it.
-      const doctored = {
-        invoice: {
-          ...invoiceFixture.invoice,
-          timeEntries: [
-            {
-              id: LINE_ITEM_UUID,
-              entityId: ENTITY_UUID,
-              entity: { id: "ent_1", name: "Brief" },
-            },
-          ],
-        },
-      };
-
-      expect(
-        findUndeclaredUuidPath({
-          payload: doctored,
-          toolName: "list_invoices",
-        }),
-      ).toBe("invoice.timeEntries[].entityId");
-    });
-  });
-
-  describe("stripDeclaredPaths", () => {
-    test("deletes declared paths in place and satisfies the backstop", () => {
-      const payload = {
-        matter: { id: "mat_1" },
-        overview: {
-          recentEntities: [
-            {
-              entityId: "ent_1",
-              name: "Brief",
-              fieldId: ENTITY_UUID,
-              propertyId: PROPERTY_UUID,
-              pdfFileId: LINKED_ENTITY_UUID,
-            },
-          ],
-        },
-      };
-
-      const stripped = stripDeclaredPaths({
-        output: payload,
-        stripPaths: [
-          "overview.recentEntities[].fieldId",
-          "overview.recentEntities[].propertyId",
-          "overview.recentEntities[].pdfFileId",
-        ],
-      });
-
-      expect(stripped).toEqual({
-        matter: { id: "mat_1" },
-        overview: { recentEntities: [{ entityId: "ent_1", name: "Brief" }] },
-      });
-      expect(containsRawUuid(stripped)).toBe(false);
-    });
-
-    test("tolerates paths the payload's branch never produces", () => {
-      // List mode carries `matters[]`, not the detail branch's `overview`;
-      // the detail-only strip paths must be a no-op, mirroring how
-      // hydration skips a path with no slots.
-      const payload = { matters: [{ id: "mat_1", name: "Acme" }] };
-
-      const stripped = stripDeclaredPaths({
-        output: payload,
-        stripPaths: ["overview.recentEntities[].fieldId"],
-      });
-
-      expect(stripped).toEqual({ matters: [{ id: "mat_1", name: "Acme" }] });
-    });
   });
 });

--- a/apps/api/src/handlers/chat/tools/registry-adapter/ref-mediation.ts
+++ b/apps/api/src/handlers/chat/tools/registry-adapter/ref-mediation.ts
@@ -1,21 +1,9 @@
 import { panic, Result } from "better-result";
 
-import type { SafeId } from "@/api/lib/branded-types";
 import type { ChatRefRegistry } from "@/api/lib/chat/ref-registry";
 import type { ChatToolError } from "@/api/lib/errors/tagged-errors";
-import {
-  brandPersistedContactId,
-  brandPersistedEntityId,
-  brandPersistedPropertyId,
-  brandPersistedWorkspaceId,
-} from "@/api/lib/safe-id-boundaries";
 
-import type {
-  EntityWorkspaceSource,
-  OutputRefField,
-  RefMediationLists,
-} from "./projection-schema";
-import { deriveRefMediationEntry } from "./projection-schema";
+import type { DehydratedInput } from "./projection-schema";
 import type {
   InputRefParam,
   RefMediationEntry,
@@ -24,8 +12,16 @@ import type {
 import { READ_TOOL_REF_FIELD_MAP } from "./ref-field-map";
 
 /**
+ * Input-side ref mediation: replace the chat refs a model passes as tool args
+ * with the real UUIDs the registry handlers expect. The output side (strip,
+ * hydrate, UUID invariant) lives in `projectForChat`
+ * (`projection-schema.ts`), which consumes the `DehydratedInput` produced
+ * here.
+ */
+
+/**
  * The chat-projected read entry for a tool name, for the read-tool
- * convenience wrappers below. The orchestrator refuses a non-projectable
+ * convenience wrapper below. The orchestrator refuses a non-projectable
  * tool before any mediation runs, so reaching this with one is programmer
  * misuse, not a data case: it panics rather than falling back.
  */
@@ -37,216 +33,6 @@ const requireProjectableReadEntry = (
     panic(`Read tool ${toolName} is not chat-projectable`);
   }
   return entry;
-};
-
-/**
- * The three output-side mediation lists for a projected read tool, derived
- * from its projection schema (memoized in `deriveRefMediationEntry`).
- */
-const readToolMediationLists = (
-  toolName: RegistryReadToolName,
-): RefMediationLists =>
-  deriveRefMediationEntry(requireProjectableReadEntry(toolName).projection);
-
-const UUID_REGEX =
-  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/iu;
-const UUID_ANYWHERE_REGEX =
-  /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/iu;
-
-const isUuidString = (value: unknown): value is string =>
-  typeof value === "string" && UUID_REGEX.test(value);
-
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === "object" && value !== null && !Array.isArray(value);
-
-/**
- * A verbatim-UUID guard for the "no tenant UUID reaches the model" invariant.
- * After ref hydration a projected read tool's payload must serialize without any
- * raw UUID: every tenant id is a ref and every non-tenant handle in the map's
- * `passthroughIdPaths` is documented as either non-UUID-formatted (opaque
- * cursors) or an out-of-band handle. Tests assert this holds.
- */
-export const containsRawUuid = (value: unknown): boolean =>
-  UUID_ANYWHERE_REGEX.test(JSON.stringify(value));
-
-// --- path-aware UUID backstop ------------------------------------------------
-
-export type UuidPathHit = { path: string; value: string };
-
-/**
- * Walk every string leaf in a payload, recording the normalized path (dot-
- * joined, arrays collapsed to `[]`, the same `a.b` / `a[].b` grammar
- * `outputRefs`/`passthroughIdPaths` use) of every value that matches the UUID
- * pattern anywhere in the string. A substring match (not just a bare-UUID
- * exact match) so a UUID embedded inside a longer string (a url, free text)
- * is still caught, matching the whole-payload check this replaces.
- */
-const walkUuidPaths = (
-  node: unknown,
-  path: readonly string[],
-  hits: UuidPathHit[],
-): void => {
-  if (typeof node === "string") {
-    if (UUID_ANYWHERE_REGEX.test(node)) {
-      hits.push({ path: path.join("."), value: node });
-    }
-    return;
-  }
-  if (Array.isArray(node)) {
-    for (const item of node) {
-      walkUuidPaths(item, path, hits);
-    }
-    return;
-  }
-  if (!isRecord(node)) {
-    return;
-  }
-  for (const [key, value] of Object.entries(node)) {
-    const segment = Array.isArray(value) ? `${key}[]` : key;
-    walkUuidPaths(value, [...path, segment], hits);
-  }
-};
-
-/** Every UUID-matching string value in a payload, with its normalized path. */
-export const collectUuidPaths = (payload: unknown): readonly UuidPathHit[] => {
-  const hits: UuidPathHit[] = [];
-  walkUuidPaths(payload, [], hits);
-  return hits;
-};
-
-/**
- * Find the first UUID surviving in a hydrated read-tool payload at a path the
- * tool's ref-field-map entry does not license. Only `passthroughIdPaths`
- * grants a path permission to still hold a raw UUID (a declared non-tenant
- * handle); an `outputRefs` path is deliberately excluded from this allowlist,
- * since `hydrateOutputRefs` should have already rewritten it to a chat ref —
- * a UUID still there means hydration missed it, which fails closed the same
- * as a wholly undeclared path. Returns the offending path, never the value,
- * so callers can log it without leaking the id it is refusing.
- */
-export const findUndeclaredUuidPathIn = ({
-  passthroughIdPaths,
-  payload,
-}: {
-  passthroughIdPaths: readonly string[];
-  payload: unknown;
-}): string | undefined => {
-  const allowedPaths = new Set<string>(passthroughIdPaths);
-  return collectUuidPaths(payload).find((hit) => !allowedPaths.has(hit.path))
-    ?.path;
-};
-
-export const findUndeclaredUuidPath = ({
-  toolName,
-  payload,
-}: {
-  toolName: RegistryReadToolName;
-  payload: unknown;
-}): string | undefined =>
-  findUndeclaredUuidPathIn({
-    passthroughIdPaths: readToolMediationLists(toolName).passthroughIdPaths,
-    payload,
-  });
-
-// --- path grammar -----------------------------------------------------------
-// Paths use the same `a.b` / `a[].b` shape as the egress text-field specs. A
-// step is one dotted token; a `[]` suffix means "descend into the array at this
-// key, then continue into each item". The final step is always a scalar key.
-
-type PathStep = { key: string; array: boolean };
-
-const parsePath = (path: string): readonly PathStep[] =>
-  path.split(".").map((token) => {
-    const array = token.endsWith("[]");
-    return { key: array ? token.slice(0, -2) : token, array };
-  });
-
-/**
- * Visit every `(container, key)` slot a path resolves to, mutating in place. The
- * caller owns the parsed JSON payload, so in-place edits are safe. Missing or
- * wrong-typed intermediates are skipped rather than thrown: a tool's optional
- * branch (list vs. detail) simply produces no slots for the other branch's
- * paths.
- */
-const visitPathSlots = (
-  root: unknown,
-  steps: readonly PathStep[],
-  visit: (container: Record<string, unknown>, key: string) => void,
-): void => {
-  const [step, ...rest] = steps;
-  if (step === undefined || !isRecord(root)) {
-    return;
-  }
-  if (rest.length === 0) {
-    visit(root, step.key);
-    return;
-  }
-  const child = root[step.key];
-  if (step.array) {
-    if (Array.isArray(child)) {
-      for (const item of child) {
-        visitPathSlots(item, rest, visit);
-      }
-    }
-    return;
-  }
-  visitPathSlots(child, rest, visit);
-};
-
-/** Read the first scalar a (non-array) absolute path resolves to. */
-const readScalarAtPath = (root: unknown, path: string): unknown => {
-  let cursor: unknown = root;
-  for (const step of parsePath(path)) {
-    if (!isRecord(cursor)) {
-      return undefined;
-    }
-    cursor = cursor[step.key];
-  }
-  return cursor;
-};
-
-// --- output stripping ---------------------------------------------------------
-
-/**
- * Delete every declared strip path from a tool payload, in place, before ref
- * hydration and the UUID backstop run. Strip paths carry ids other surfaces
- * need (web-UI field/file plumbing handles) but chat cannot act on: removing
- * them keeps the model context free of raw ids without widening the
- * passthrough allowlist. The payload is the caller-owned JSON.parsed object,
- * so in-place deletion is safe.
- */
-export const stripDeclaredPaths = ({
-  output,
-  stripPaths,
-}: {
-  output: unknown;
-  stripPaths: readonly string[];
-}): unknown => {
-  for (const path of stripPaths) {
-    visitPathSlots(output, parsePath(path), (container, key) => {
-      Reflect.deleteProperty(container, key);
-    });
-  }
-  return output;
-};
-
-// --- input dehydration ------------------------------------------------------
-
-export type DehydratedInput = {
-  args: Record<string, unknown>;
-  /** Resolved workspace uuid per matter input param, for entity output refs. */
-  resolvedMatterParams: Record<string, SafeId<"workspace">>;
-  /**
-   * Resolved workspace uuid per entity input param, for output entities that
-   * are *different* from the input entity but share its workspace (e.g. a
-   * task's linked entities). `resolvedMatterParams` covers the reverse case
-   * (workspace named directly); this covers the entity-ref case, where the
-   * workspace is recovered from the ref the caller already resolved rather
-   * than from a fresh lookup.
-   */
-  resolvedEntityParams: Record<string, SafeId<"workspace">>;
-  /** entity uuid -> the ref it was dehydrated from, for reuse on output. */
-  dehydratedEntityRefs: Map<string, string>;
 };
 
 const takeSingle = <T>(values: readonly T[]): T =>
@@ -269,8 +55,8 @@ export const dehydrateRefs = ({
   refRegistry: ChatRefRegistry;
 }): Result<DehydratedInput, ChatToolError> => {
   const nextArgs = { ...args };
-  const resolvedMatterParams: Record<string, SafeId<"workspace">> = {};
-  const resolvedEntityParams: Record<string, SafeId<"workspace">> = {};
+  const resolvedMatterParams: DehydratedInput["resolvedMatterParams"] = {};
+  const resolvedEntityParams: DehydratedInput["resolvedEntityParams"] = {};
   const dehydratedEntityRefs = new Map<string, string>();
 
   for (const { kind, param } of inputRefs) {
@@ -350,180 +136,4 @@ export const dehydrateInputRefs = ({
     inputRefs: requireProjectableReadEntry(toolName).inputRefs,
     args,
     refRegistry,
-  });
-
-// --- output hydration -------------------------------------------------------
-
-const resolveEntityWorkspaceUuid = ({
-  container,
-  dehydration,
-  root,
-  source,
-}: {
-  container: Record<string, unknown>;
-  dehydration: DehydratedInput;
-  root: unknown;
-  source: EntityWorkspaceSource;
-}): unknown => {
-  if (source.from === "sibling") {
-    return container[source.key];
-  }
-  if (source.from === "outputPath") {
-    return readScalarAtPath(root, source.path);
-  }
-  if (source.from === "inputParam") {
-    return dehydration.resolvedMatterParams[source.param];
-  }
-  if (source.from === "inputEntityWorkspace") {
-    return dehydration.resolvedEntityParams[source.param];
-  }
-  // "inputEntity": the output entity is the request's own entity input, so its
-  // ref is minted from the reuse map below, never from a workspace lookup.
-  source.from satisfies "inputEntity";
-  return undefined;
-};
-
-const hydrateEntitySlot = ({
-  container,
-  dehydration,
-  key,
-  refRegistry,
-  root,
-  source,
-}: {
-  container: Record<string, unknown>;
-  dehydration: DehydratedInput;
-  key: string;
-  refRegistry: ChatRefRegistry;
-  root: unknown;
-  source: EntityWorkspaceSource;
-}): void => {
-  const value = container[key];
-  if (!isUuidString(value)) {
-    return;
-  }
-
-  // The output entity IS one the request named on input: reuse the ref already
-  // minted for it, so no workspace lookup is needed.
-  const reused = dehydration.dehydratedEntityRefs.get(value);
-  if (reused !== undefined) {
-    container[key] = reused;
-    return;
-  }
-
-  const workspaceUuid = resolveEntityWorkspaceUuid({
-    container,
-    dehydration,
-    root,
-    source,
-  });
-  if (!isUuidString(workspaceUuid)) {
-    // Owning workspace not recoverable for this field (a deferred case, tracked
-    // in the map's passthroughIdPaths); leave the id untouched rather than mint
-    // a ref against a guessed workspace.
-    return;
-  }
-
-  container[key] = refRegistry.toEntityRef({
-    entityId: brandPersistedEntityId(value),
-    workspaceId: brandPersistedWorkspaceId(workspaceUuid),
-  });
-};
-
-const hydrateSimpleSlot = ({
-  container,
-  field,
-  key,
-  refRegistry,
-}: {
-  container: Record<string, unknown>;
-  field: Extract<OutputRefField, { kind: "matter" | "contact" | "property" }>;
-  key: string;
-  refRegistry: ChatRefRegistry;
-}): void => {
-  const value = container[key];
-  if (!isUuidString(value)) {
-    return;
-  }
-  if (field.kind === "matter") {
-    container[key] = refRegistry.toMatterRef(brandPersistedWorkspaceId(value));
-    return;
-  }
-  if (field.kind === "contact") {
-    container[key] = refRegistry.toContactRef(brandPersistedContactId(value));
-    return;
-  }
-  container[key] = refRegistry.toPropertyRef(brandPersistedPropertyId(value));
-};
-
-/**
- * Rewrite every tenant UUID a projected tool emits into its chat ref, in place,
- * driven by the passed output ref fields. The payload is the caller-owned
- * JSON.parsed object, so it is mutated and returned. Fields left un-refed
- * (non-tenant handles, deferred entity ids) are untouched. Shared by the read
- * and write orchestrators, each supplying its own tool's `outputRefs`.
- */
-export const hydrateRefs = ({
-  outputRefs,
-  output,
-  refRegistry,
-  dehydration,
-}: {
-  outputRefs: readonly OutputRefField[];
-  output: unknown;
-  refRegistry: ChatRefRegistry;
-  dehydration: DehydratedInput;
-}): unknown => {
-  // Entity refs first: an entity's `sibling`/`outputPath` workspace source reads
-  // a workspace UUID that a matter ref in the same payload would otherwise
-  // overwrite with a `mat_N` ref before the entity ref is minted.
-  for (const field of outputRefs) {
-    if (field.kind !== "entity") {
-      continue;
-    }
-    visitPathSlots(output, parsePath(field.path), (container, key) => {
-      hydrateEntitySlot({
-        container,
-        dehydration,
-        key,
-        refRegistry,
-        root: output,
-        source: field.workspace,
-      });
-    });
-  }
-
-  for (const field of outputRefs) {
-    if (field.kind === "entity") {
-      continue;
-    }
-    visitPathSlots(output, parsePath(field.path), (container, key) => {
-      hydrateSimpleSlot({ container, field, key, refRegistry });
-    });
-  }
-
-  return output;
-};
-
-/**
- * Rewrite every tenant UUID a projected read tool emits into its chat ref, in
- * place, driven by the read tool's declared output ref fields. Delegates to
- * `hydrateRefs` with the read tool's `outputRefs`.
- */
-export const hydrateOutputRefs = ({
-  toolName,
-  output,
-  refRegistry,
-  dehydration,
-}: {
-  toolName: RegistryReadToolName;
-  output: unknown;
-  refRegistry: ChatRefRegistry;
-  dehydration: DehydratedInput;
-}): unknown =>
-  hydrateRefs({
-    outputRefs: readToolMediationLists(toolName).outputRefs,
-    output,
-    refRegistry,
-    dehydration,
   });

--- a/apps/api/src/handlers/chat/tools/registry-adapter/run-registry-tool.test.ts
+++ b/apps/api/src/handlers/chat/tools/registry-adapter/run-registry-tool.test.ts
@@ -17,9 +17,10 @@ void mock.module("@/api/lib/analytics/capture", () => ({
 }));
 
 const { buildMcpContextFromChat } = await import("./mcp-chat-context");
-const { containsRawUuid, dehydrateInputRefs } = await import("./ref-mediation");
-const { PROJECTION_SCHEMA_FAILURE_MESSAGE, runRegistryReadTool } =
-  await import("./run-registry-tool");
+const { containsRawUuid, PROJECTION_SCHEMA_FAILURE_MESSAGE } =
+  await import("./projection-schema");
+const { dehydrateInputRefs } = await import("./ref-mediation");
+const { runRegistryReadTool } = await import("./run-registry-tool");
 
 const WS_UUID = "0dc54d0c-10d7-501d-897e-e801dbd0998c";
 const OTHER_WS_UUID = "4e919658-a448-5354-8e3a-e99911214d2c";

--- a/apps/api/src/handlers/chat/tools/registry-adapter/run-registry-tool.ts
+++ b/apps/api/src/handlers/chat/tools/registry-adapter/run-registry-tool.ts
@@ -1,7 +1,6 @@
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { panic, Result } from "better-result";
 
-import { captureError } from "@/api/lib/analytics/capture";
 import type { ChatRefRegistry } from "@/api/lib/chat/ref-registry";
 import type { ChatToolErrorKind } from "@/api/lib/errors/tagged-errors";
 import { ChatToolError } from "@/api/lib/errors/tagged-errors";
@@ -22,19 +21,10 @@ import { STELLA_TOOL_HANDLERS } from "@/api/mcp/stella-tools";
 import { TEMPLATE_TOOL_HANDLERS } from "@/api/mcp/template-tools";
 import type { McpToolHandler } from "@/api/mcp/tool-types";
 
-import type { ChatProjectionSchema } from "./projection-schema";
-import {
-  applyProjectionSchema,
-  deriveRefMediationEntry,
-} from "./projection-schema";
+import { projectForChat } from "./projection-schema";
 import type { RegistryReadToolName } from "./ref-field-map";
 import { READ_TOOL_REF_FIELD_MAP } from "./ref-field-map";
-import {
-  dehydrateInputRefs,
-  findUndeclaredUuidPathIn,
-  hydrateRefs,
-  stripDeclaredPaths,
-} from "./ref-mediation";
+import { dehydrateInputRefs } from "./ref-mediation";
 
 /**
  * The read-only registry handlers chat may drive, gathered from the per-domain
@@ -81,67 +71,6 @@ export const firstTextContent = (result: CallToolResult): string => {
 
 /** Fallback for an `isError` result whose content carries no text block. */
 export const DEFAULT_TOOL_ERROR_MESSAGE = "Tool execution failed.";
-
-/**
- * Surfaced to the model when a hydrated payload still carries a raw uuid.
- * Deliberately does not say "anonymization": the anonymization feature (the
- * anonymized MCP surface) is a different mechanism and is not involved —
- * chat egress runs in default mode. This is the chat ref projection's own
- * fail-closed invariant, it fires regardless of any anonymization setting,
- * and the model can do nothing about it, so the message says both.
- */
-export const REF_PROJECTION_FAILURE_MESSAGE =
-  "The tool result contained an internal identifier the chat projection " +
-  "could not map to a reference. This is a server-side defect, not a " +
-  "problem with your input; do not retry this call.";
-
-/**
- * Surfaced to the model when a converted tool's payload fails its projection
- * schema's strict parse: a handler emitted a field nobody classified (or a
- * declared field changed shape). Same fail-closed semantics as
- * `REF_PROJECTION_FAILURE_MESSAGE`; the parse fires before strip/hydrate, so
- * the undeclared field never reaches the model by construction.
- */
-export const PROJECTION_SCHEMA_FAILURE_MESSAGE =
-  "The tool result did not match the shape the chat projection declares " +
-  "for this tool. This is a server-side defect, not a problem with your " +
-  "input; do not retry this call.";
-
-/**
- * Strict-parse a projected tool's payload against its projection schema.
- * Shared by the read and write orchestrators. The failure carries only issue
- * paths (never values) to telemetry, mirroring the UUID backstop's no-leak
- * discipline.
- */
-export const applyEntryProjection = ({
-  payload,
-  projection,
-  source,
-  toolName,
-}: {
-  payload: unknown;
-  projection: ChatProjectionSchema;
-  source: "run-registry-tool" | "run-registry-write-tool";
-  toolName: string;
-}): Result<unknown, ChatToolError> => {
-  const projected = applyProjectionSchema({
-    payload,
-    schema: projection,
-  });
-  if (Result.isError(projected)) {
-    const error = new ChatToolError({
-      kind: "server-defect",
-      message: PROJECTION_SCHEMA_FAILURE_MESSAGE,
-    });
-    captureError(error, {
-      source,
-      toolName,
-      paths: projected.error.issuePaths.join(", "),
-    });
-    return Result.err(error);
-  }
-  return Result.ok(projected.value);
-};
 
 const MCP_CODE_TO_CHAT_KIND = {
   validation_error: "invalid-input",
@@ -234,7 +163,8 @@ export type RunRegistryReadToolProps = {
  * 3. Run the handler and finalize its egress in DEFAULT mode (chat is not the
  *    anonymized surface).
  * 4. Map an `isError` result into a `ChatToolError`; otherwise parse the JSON
- *    payload, hydrate its tenant UUIDs into chat refs, and return the object.
+ *    payload and project it for chat in a single schema-driven pass
+ *    (`projectForChat`: strict parse, strip, ref hydration, UUID invariant).
  */
 export const runRegistryReadTool = async ({
   toolName,
@@ -291,56 +221,16 @@ export const runRegistryReadTool = async ({
     return Result.err(payload.error);
   }
 
-  // Strict-parse the payload against the projection schema BEFORE
-  // strip/hydrate. An unknown key — a field nobody classified — fails closed
-  // here, so an undeclared field is structurally unable to reach the model;
-  // the error carries only issue paths (never values) to telemetry.
-  const projected = applyEntryProjection({
+  // One schema-driven pass: strict parse (an unknown key — a field nobody
+  // classified — fails closed before it can reach the model), then strip,
+  // ref hydration, and the fail-closed "no tenant UUID reaches the model"
+  // invariant in the same walk. Failures carry only paths to telemetry.
+  return projectForChat({
+    dehydration: dehydrated.value,
     payload: payload.value,
-    projection: entry.projection,
+    refRegistry,
+    schema: entry.projection,
     source: "run-registry-tool",
     toolName,
   });
-  if (Result.isError(projected)) {
-    return Result.err(projected.error);
-  }
-
-  const mediation = deriveRefMediationEntry(entry.projection);
-  const stripped = stripDeclaredPaths({
-    output: projected.value,
-    stripPaths: mediation.stripPaths,
-  });
-  const hydrated = hydrateRefs({
-    dehydration: dehydrated.value,
-    output: stripped,
-    outputRefs: mediation.outputRefs,
-    refRegistry,
-  });
-
-  // Runtime backstop for the "no tenant UUID reaches the model" invariant: the
-  // ref-field map is documentation the type system cannot fully enforce (a
-  // wrong or missing path silently skips hydration), so re-check the finished
-  // payload path-by-path rather than trusting the static mapping alone. A
-  // UUID surviving anywhere the tool's `passthroughIdPaths` does not license
-  // fails closed instead of leaking; the error message never repeats the
-  // payload or the path, so it cannot itself leak the value it is refusing,
-  // while the offending path (never the value) still reaches telemetry.
-  const offendingPath = findUndeclaredUuidPathIn({
-    passthroughIdPaths: mediation.passthroughIdPaths,
-    payload: hydrated,
-  });
-  if (offendingPath !== undefined) {
-    const error = new ChatToolError({
-      kind: "server-defect",
-      message: REF_PROJECTION_FAILURE_MESSAGE,
-    });
-    captureError(error, {
-      source: "run-registry-tool",
-      toolName,
-      path: offendingPath,
-    });
-    return Result.err(error);
-  }
-
-  return Result.ok(hydrated);
 };

--- a/apps/api/src/handlers/chat/tools/registry-adapter/run-registry-write-tool.test.ts
+++ b/apps/api/src/handlers/chat/tools/registry-adapter/run-registry-write-tool.test.ts
@@ -27,13 +27,9 @@ void mock.module("@/api/mcp/gateway/list-tools", () => ({
 }));
 
 const { buildMcpContextFromChat } = await import("./mcp-chat-context");
-const {
-  containsRawUuid,
-  dehydrateRefs,
-  findUndeclaredUuidPathIn,
-  hydrateRefs,
-} = await import("./ref-mediation");
-const { deriveRefMediationEntry } = await import("./projection-schema");
+const { dehydrateRefs } = await import("./ref-mediation");
+const { containsRawUuid, projectForChat, REF_PROJECTION_FAILURE_MESSAGE } =
+  await import("./projection-schema");
 const { WRITE_TOOL_REF_FIELD_MAP } = await import("./ref-field-map");
 const { applyChatApprovalConfirmation, runRegistryWriteTool } =
   await import("./run-registry-write-tool");
@@ -128,9 +124,9 @@ describe("runRegistryWriteTool (orchestration)", () => {
 });
 
 describe("write ref mediation (via the WRITE_TOOL_REF_FIELD_MAP)", () => {
-  // These drive the exact map entries runRegistryWriteTool feeds into the
-  // shared mediation cores, so they cover input dehydration and output
-  // hydration/backstop for writes without depending on a live MCP handler.
+  // These drive the exact map entries runRegistryWriteTool feeds into
+  // dehydration and `projectForChat`, so they cover input dehydration and
+  // output projection for writes without depending on a live MCP handler.
 
   test("save_matter: input refs dehydrate, the returned matter id hydrates", () => {
     const registry = createChatRefRegistry();
@@ -146,24 +142,16 @@ describe("write ref mediation (via the WRITE_TOOL_REF_FIELD_MAP)", () => {
     expect(dehydrated.args["client_id"]).toBe(CONTACT_UUID);
     expect(dehydrated.args["name"]).toBe("Acme");
 
-    const hydrated = hydrateRefs({
+    const projected = projectForChat({
       dehydration: dehydrated,
-      output: { matterId: WS_UUID, updated: true },
-      outputRefs: deriveRefMediationEntry(
-        WRITE_TOOL_REF_FIELD_MAP.save_matter.projection,
-      ).outputRefs,
+      payload: { matterId: WS_UUID, updated: true },
       refRegistry: registry,
-    });
-    expect(hydrated).toEqual({ matterId: matterRef, updated: true });
-    expect(containsRawUuid(hydrated)).toBe(false);
-    expect(
-      findUndeclaredUuidPathIn({
-        passthroughIdPaths: deriveRefMediationEntry(
-          WRITE_TOOL_REF_FIELD_MAP.save_matter.projection,
-        ).passthroughIdPaths,
-        payload: hydrated,
-      }),
-    ).toBeUndefined();
+      schema: WRITE_TOOL_REF_FIELD_MAP.save_matter.projection,
+      source: "run-registry-write-tool",
+      toolName: "save_matter",
+    }).unwrap();
+    expect(projected).toEqual({ matterId: matterRef, updated: true });
+    expect(containsRawUuid(projected)).toBe(false);
   });
 
   test("set_field_value dehydrates its entity and property refs", () => {
@@ -189,16 +177,41 @@ describe("write ref mediation (via the WRITE_TOOL_REF_FIELD_MAP)", () => {
     );
   });
 
-  test("the backstop fails closed on a raw uuid at a path the write map does not license", () => {
-    // save_matter declares only `matterId` as an output ref and no passthrough
-    // paths, so a raw uuid anywhere else is refused rather than leaked.
-    const offending = findUndeclaredUuidPathIn({
-      passthroughIdPaths: deriveRefMediationEntry(
-        WRITE_TOOL_REF_FIELD_MAP.save_matter.projection,
-      ).passthroughIdPaths,
-      payload: { matterId: "mat_1", leaked: OTHER_WS_UUID },
+  test("the UUID invariant fails closed on a raw uuid in a declared plain field", () => {
+    // manage_organization's settings echo declares `matterNumberPattern` as an
+    // ordinary string, which no annotation licenses to carry a UUID: a raw
+    // uuid there is refused rather than leaked, with only the path (never the
+    // value) reaching telemetry.
+    captureErrorMock.mockClear();
+    const result = projectForChat({
+      dehydration: {
+        args: {},
+        dehydratedEntityRefs: new Map(),
+        resolvedEntityParams: {},
+        resolvedMatterParams: {},
+      },
+      payload: { matterNumberPattern: OTHER_WS_UUID },
+      refRegistry: createChatRefRegistry(),
+      schema: WRITE_TOOL_REF_FIELD_MAP.manage_organization.projection,
+      source: "run-registry-write-tool",
+      toolName: "manage_organization",
     });
-    expect(offending).toBe("leaked");
+
+    expect(Result.isError(result)).toBe(true);
+    if (Result.isError(result)) {
+      expect(result.error.kind).toBe("server-defect");
+      expect(result.error.message).toBe(REF_PROJECTION_FAILURE_MESSAGE);
+    }
+    expect(captureErrorMock).toHaveBeenCalledWith(
+      expect.objectContaining({ message: REF_PROJECTION_FAILURE_MESSAGE }),
+      {
+        path: "matterNumberPattern",
+        source: "run-registry-write-tool",
+        toolName: "manage_organization",
+      },
+    );
+    const [, telemetryContext] = captureErrorMock.mock.calls.at(0) ?? [];
+    expect(JSON.stringify(telemetryContext)).not.toContain(OTHER_WS_UUID);
   });
 });
 

--- a/apps/api/src/handlers/chat/tools/registry-adapter/run-registry-write-tool.ts
+++ b/apps/api/src/handlers/chat/tools/registry-adapter/run-registry-write-tool.ts
@@ -1,6 +1,5 @@
 import { panic, Result } from "better-result";
 
-import { captureError } from "@/api/lib/analytics/capture";
 import type { ChatRefRegistry } from "@/api/lib/chat/ref-registry";
 import { ChatToolError } from "@/api/lib/errors/tagged-errors";
 import { BILLING_TOOL_HANDLERS } from "@/api/mcp/billing-tools";
@@ -18,22 +17,15 @@ import { STELLA_TOOL_HANDLERS } from "@/api/mcp/stella-tools";
 import { TEMPLATE_TOOL_HANDLERS } from "@/api/mcp/template-tools";
 import type { McpToolHandler } from "@/api/mcp/tool-types";
 
-import { deriveRefMediationEntry } from "./projection-schema";
+import { projectForChat } from "./projection-schema";
 import type { RegistryWriteToolName } from "./ref-field-map";
 import { WRITE_TOOL_REF_FIELD_MAP } from "./ref-field-map";
+import { dehydrateRefs } from "./ref-mediation";
 import {
-  dehydrateRefs,
-  findUndeclaredUuidPathIn,
-  hydrateRefs,
-  stripDeclaredPaths,
-} from "./ref-mediation";
-import {
-  applyEntryProjection,
   classifyRegistryErrorKind,
   DEFAULT_TOOL_ERROR_MESSAGE,
   firstTextContent,
   parsePayload,
-  REF_PROJECTION_FAILURE_MESSAGE,
 } from "./run-registry-tool";
 
 /**
@@ -181,51 +173,16 @@ export const runRegistryWriteTool = async ({
     return Result.err(payload.error);
   }
 
-  // Same strict-parse gate as the read path: the write tool's payload must
-  // match its projection schema before strip/hydrate, so an undeclared field
-  // fails closed by construction.
-  const projected = applyEntryProjection({
+  // Same single schema-driven pass as the read path: strict parse (an
+  // undeclared field fails closed by construction), then strip, ref
+  // hydration, and the fail-closed UUID invariant in one walk. Failures
+  // carry only paths to telemetry, never values.
+  return projectForChat({
+    dehydration: dehydrated.value,
     payload: payload.value,
-    projection: entry.projection,
+    refRegistry,
+    schema: entry.projection,
     source: "run-registry-write-tool",
     toolName,
   });
-  if (Result.isError(projected)) {
-    return Result.err(projected.error);
-  }
-
-  const mediation = deriveRefMediationEntry(entry.projection);
-  const stripped = stripDeclaredPaths({
-    output: projected.value,
-    stripPaths: mediation.stripPaths,
-  });
-  const hydrated = hydrateRefs({
-    dehydration: dehydrated.value,
-    output: stripped,
-    outputRefs: mediation.outputRefs,
-    refRegistry,
-  });
-
-  // Same fail-closed backstop the read path runs: a raw uuid surviving anywhere
-  // the tool's `passthroughIdPaths` does not license is refused rather than
-  // leaked. The message never repeats the payload or path, so it cannot itself
-  // leak the value; the offending path (never the value) reaches telemetry.
-  const offendingPath = findUndeclaredUuidPathIn({
-    passthroughIdPaths: mediation.passthroughIdPaths,
-    payload: hydrated,
-  });
-  if (offendingPath !== undefined) {
-    const error = new ChatToolError({
-      kind: "server-defect",
-      message: REF_PROJECTION_FAILURE_MESSAGE,
-    });
-    captureError(error, {
-      source: "run-registry-write-tool",
-      toolName,
-      path: offendingPath,
-    });
-    return Result.err(error);
-  }
-
-  return Result.ok(hydrated);
 };

--- a/apps/api/src/lib/chat/model-ingress-guard.ts
+++ b/apps/api/src/lib/chat/model-ingress-guard.ts
@@ -10,7 +10,7 @@ import { TelemetryError } from "@/api/lib/errors/tagged-errors";
  * Last-line guard for the "tenant workspace ids reach the model only as chat
  * refs" invariant, applied where every provider-bound surface converges in
  * `streamChat`. The tool-egress side already fails closed per tool
- * (`findUndeclaredUuidPath`); this covers the ingress side, where the exact
+ * (`projectForChat`'s UUID invariant); this covers the ingress side, where the exact
  * tenant set is known per request (the accessible-workspace ids are already
  * loaded on every send), so membership checks are precise: no pattern
  * heuristics, no false positives on public UUIDs (case-law decision ids,

--- a/apps/api/src/mcp/egress.ts
+++ b/apps/api/src/mcp/egress.ts
@@ -40,9 +40,9 @@ const ANONYMIZED_FIELD_MISSING_FALLBACK = "[REDACTED]";
  * not here. The chat registry adapter (`run-registry-tool.ts`) is the one
  * caller that also crosses into third-party model context: it runs this same
  * pipeline, then separately rewrites ids into opaque chat refs and fails
- * closed on any raw uuid that slips through (`findUndeclaredUuidPath` in
- * `ref-mediation.ts`). That backstop belongs there, not here, because this
- * pipeline itself never hands output to a model.
+ * closed on any raw uuid that slips through (`projectForChat` in
+ * `projection-schema.ts`). That backstop belongs there, not here, because
+ * this pipeline itself never hands output to a model.
  */
 export const finalizeMcpEgress = async ({
   context,


### PR DESCRIPTION
Consolidates the chat projection pipeline: the strict parse, field stripping, ref hydration, and the UUID invariant — previously four payload traversals driven by lists derived from the projection schema — become one annotation-guided walk, `projectForChat`.

- The walk builds a fresh output tree and never mutates the parsed payload, so `sibling`/`outputPath` workspace sources always read raw values — the ordering constraint the old two-pass hydration existed to satisfy disappears structurally.
- The terminal no-unlicensed-UUID invariant is enforced inline and is now union-branch-aware (strictly tighter than the previous cross-branch path allowlist). Telemetry contracts (structural paths, never values) are unchanged.
- Net deletion: the output-side path grammar and walkers leave `ref-mediation.ts` (530 → 139 lines, input dehydration only); annotation reads are memoized per schema node.
- The projection contract corpus passes with fixtures untouched, pinning zero behavior change; the projection test matrix covers every annotation kind and all five entity workspace-source variants.

Cost: ~+0.1% types/instantiations on apps/api; runtime does one parse + one walk per tool result instead of four traversals.