### PR TITLE
fix: retry the source-raw S3 write, and rate-limit repeat error captures

### DIFF
--- a/apps/api/src/handlers/case-law/ingestion/pipeline.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/pipeline.test.ts
@@ -548,11 +548,9 @@ describe("processDecision — source raw upload failure", () => {
     // never returns to the decision and its raw source is lost. Only a
     // retryable outcome reaches the page-level cursor hold.
     await mock.module("@/api/lib/s3", () => ({
-      getS3: () => ({
-        write: () => {
-          throw new Error("an unexpected error has occurred");
-        },
-      }),
+      writeS3ObjectWithRetry: () => {
+        throw new Error("an unexpected error has occurred");
+      },
     }));
 
     const scopedDb: ScopedDb = async (callback) => {
@@ -616,13 +614,11 @@ describe("processDecision — source raw upload failure", () => {
       },
     }));
     await mock.module("@/api/lib/s3", () => ({
-      getS3: () => ({
-        write: () => {
-          throw Object.assign(new Error("an unexpected error has occurred"), {
-            code: "AccessDenied",
-          });
-        },
-      }),
+      writeS3ObjectWithRetry: () => {
+        throw Object.assign(new Error("an unexpected error has occurred"), {
+          code: "AccessDenied",
+        });
+      },
     }));
 
     const scopedDb: ScopedDb = async (callback) => {

--- a/apps/api/src/handlers/case-law/ingestion/pipeline.ts
+++ b/apps/api/src/handlers/case-law/ingestion/pipeline.ts
@@ -72,7 +72,7 @@ import { sanitizeResult } from "@/api/lib/legal-search/ingestion-normalization";
 import { storedDecisionSignal } from "@/api/lib/legal-search/parsers/validate-ast";
 import { logger } from "@/api/lib/observability/logger";
 import { isPgConstraintError, PG_ERROR } from "@/api/lib/pg-error";
-import { getS3 } from "@/api/lib/s3";
+import { writeS3ObjectWithRetry } from "@/api/lib/s3";
 
 export { sanitizeResult };
 
@@ -240,6 +240,11 @@ const allocateSourceObservationOrder = async ({
 /**
  * Upload sourceRaw to S3 under a content-addressable key.
  * Returns the S3 object key.
+ *
+ * The write is retried: failing here holds the page cursor (see the caller),
+ * so letting one transient transport failure through stalls the whole source
+ * until the next attempt happens to succeed. The key is the payload's own
+ * hash, so a retry that duplicates an attempt which landed late is a no-op.
  */
 const uploadSourceRaw = async (
   sourceId: SafeId<"caseLawSource">,
@@ -250,7 +255,7 @@ const uploadSourceRaw = async (
   hasher.update(data);
   const blobHash = hasher.digest("hex");
   const key = `case-law/raw/${sourceId}/${blobHash}`;
-  await getS3().write(key, data, { type: contentType });
+  await writeS3ObjectWithRetry({ contentType, data, key });
   return key;
 };
 

--- a/apps/api/src/lib/analytics/capture.test.ts
+++ b/apps/api/src/lib/analytics/capture.test.ts
@@ -1,0 +1,96 @@
+import {
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  setSystemTime,
+  test,
+} from "bun:test";
+
+const captured: { properties: Record<string, unknown> }[] = [];
+
+void mock.module("@/api/lib/analytics/client", () => ({
+  getAnalytics: () => ({
+    capture: (params: { properties: Record<string, unknown> }) => {
+      captured.push(params);
+    },
+    flush: async () => undefined,
+  }),
+}));
+
+const { captureError, resetCaptureWindows } =
+  await import("@/api/lib/analytics/capture");
+
+/**
+ * Both helpers construct their error on a single source line, so every
+ * occurrence from one helper shares a `error.frame` and therefore a
+ * suppression key — the shape of a loop that keeps failing at the same site.
+ * The two helpers sit on different lines, so they are different defects.
+ */
+const captureFromSiteA = (context?: Record<string, string>): void => {
+  captureError(new Error("boom"), context);
+};
+
+const captureFromSiteB = (): void => {
+  captureError(new Error("boom"));
+};
+
+beforeEach(() => {
+  captured.length = 0;
+  resetCaptureWindows();
+});
+
+describe("captureError repeat suppression", () => {
+  test("a loop failing at one site reports once, not once per iteration", () => {
+    // The shape that motivates the throttle: a held ingestion cursor re-runs
+    // every cycle and spends one ingested event per attempt for as long as it
+    // stays held. Each iteration builds a fresh Error, as the real loop does.
+    for (let i = 0; i < 50; i += 1) {
+      captureFromSiteA();
+    }
+
+    expect(captured).toHaveLength(1);
+  });
+
+  test("varying correlation context does not defeat the throttle", () => {
+    // The key excludes caller context on purpose. Each cycle of the case-law
+    // pipeline reports the same defect under a fresh sourceId, so a
+    // context-sensitive key would suppress nothing in the case that motivated
+    // the throttle.
+    for (let i = 0; i < 10; i += 1) {
+      captureFromSiteA({ sourceId: `source-${i}`, step: "uploadSourceRaw" });
+    }
+
+    expect(captured).toHaveLength(1);
+  });
+
+  test("distinct defects are never collapsed into one another", () => {
+    // Suppression must not hide an unrelated failure that happens to occur
+    // while a noisy one is throttled.
+    captureFromSiteA();
+    captureFromSiteB();
+
+    expect(captured).toHaveLength(2);
+  });
+
+  test("suppressed occurrences are counted onto the next reported event", () => {
+    // Nothing is silently swallowed: the rate stays recoverable from the
+    // dashboard even though the repeats themselves are not ingested.
+    const openedAt = new Date("2026-08-05T12:00:00.000Z");
+    setSystemTime(openedAt);
+
+    // One call site for every occurrence, so the window is only reopened by
+    // the clock moving past it, never by a different key.
+    for (let i = 0; i < 9; i += 1) {
+      if (i === 8) {
+        setSystemTime(new Date(openedAt.getTime() + 61_000));
+      }
+      captureFromSiteA();
+    }
+    setSystemTime();
+
+    expect(captured).toHaveLength(2);
+    expect(captured.at(0)?.properties["suppressed_repeats"]).toBeUndefined();
+    expect(captured.at(1)?.properties["suppressed_repeats"]).toBe("7");
+  });
+});

--- a/apps/api/src/lib/analytics/capture.ts
+++ b/apps/api/src/lib/analytics/capture.ts
@@ -41,6 +41,97 @@ type CaptureRequestErrorOptions = {
 
 const SERVER_DISTINCT_ID = "server";
 
+const CAPTURE_WINDOW_MS = 60_000;
+const CAPTURE_MAX_TRACKED_KEYS = 500;
+
+type CaptureWindow = { startedAt: number; suppressed: number };
+
+const captureWindows = new Map<string, CaptureWindow>();
+
+/**
+ * Structural key for repeat suppression: error class, stable code, and code
+ * location, deliberately excluding the caller's correlation context.
+ *
+ * A stuck loop re-reports the same defect with a fresh request or entity ID
+ * every cycle, so keying on context would defeat the throttle in exactly the
+ * case that motivates it. Two call sites that genuinely share a class, code,
+ * and frame are the same defect.
+ */
+const captureWindowKey = (properties: ExceptionProperties): string => {
+  // `ExceptionProperties` widens every value to include `$exception_list`, so
+  // read each field back as a string rather than stringifying whatever is there.
+  const field = (key: string): string => {
+    const value = properties[key];
+    return typeof value === "string" ? value : "";
+  };
+  return [
+    field("error.class"),
+    field("error.code"),
+    field("error.frame"),
+    field("error.cause.frame"),
+  ].join("|");
+};
+
+/**
+ * Drop the key whose window opened longest ago once the map is full, so a
+ * process that sees an unbounded variety of errors cannot grow this map
+ * without limit. Evicting an old window at worst re-reports its next
+ * occurrence immediately, which is the safe direction.
+ */
+const evictOldestCaptureWindow = (key: string): void => {
+  if (
+    captureWindows.has(key) ||
+    captureWindows.size < CAPTURE_MAX_TRACKED_KEYS
+  ) {
+    return;
+  }
+  let oldestKey: string | undefined;
+  let oldestStartedAt = Number.POSITIVE_INFINITY;
+  for (const [candidate, window] of captureWindows) {
+    if (window.startedAt < oldestStartedAt) {
+      oldestStartedAt = window.startedAt;
+      oldestKey = candidate;
+    }
+  }
+  if (oldestKey !== undefined) {
+    captureWindows.delete(oldestKey);
+  }
+};
+
+/**
+ * Rate-limit identical errors to one reported event per window.
+ *
+ * Returns the number of occurrences suppressed since the last report, or
+ * `null` when this occurrence is itself suppressed. A persistently failing
+ * loop otherwise spends one ingested event per iteration, all carrying the
+ * same structural payload, since the redaction contract above means repeats
+ * differ only in correlation IDs.
+ *
+ * The suppressed count rides along on the next reported event rather than
+ * being dropped, so the failure's rate stays recoverable and nothing is
+ * silently swallowed. Counting is lazy: the tail of a window that never sees
+ * another occurrence is not reported, which is the case where the error has
+ * stopped and the rate no longer matters.
+ */
+const admitCapture = (key: string, now: number): number | null => {
+  const open = captureWindows.get(key);
+  if (open !== undefined && now - open.startedAt < CAPTURE_WINDOW_MS) {
+    open.suppressed += 1;
+    return null;
+  }
+  evictOldestCaptureWindow(key);
+  captureWindows.set(key, { startedAt: now, suppressed: 0 });
+  return open?.suppressed ?? 0;
+};
+
+/**
+ * Reset the suppression state. Tests only: the windows are module state, so
+ * one test's captures would otherwise throttle the next test's.
+ */
+export const resetCaptureWindows = (): void => {
+  captureWindows.clear();
+};
+
 const captureErrorWithOptions = (
   error: unknown,
   options: CaptureErrorOptions,
@@ -72,12 +163,22 @@ const captureErrorWithOptions = (
     ...(options.sessionId ? { session_id: options.sessionId } : {}),
   };
 
+  // Before the throttle: dev sinks are local and unmetered, and a developer
+  // reproducing a tight failure loop needs every occurrence.
   logDevError(error, properties);
+
+  const suppressed = admitCapture(captureWindowKey(properties), Date.now());
+  if (suppressed === null) {
+    return;
+  }
 
   getAnalytics().capture({
     distinctId: options.distinctId ?? SERVER_DISTINCT_ID,
     event: SERVER_ANALYTICS_EVENTS.exception,
-    properties,
+    properties:
+      suppressed > 0
+        ? { ...properties, suppressed_repeats: String(suppressed) }
+        : properties,
   });
 };
 

--- a/apps/api/src/lib/s3.test.ts
+++ b/apps/api/src/lib/s3.test.ts
@@ -5,6 +5,7 @@ import {
   getS3,
   isS3Stale,
   resolveS3Credentials,
+  writeS3ObjectWithRetry,
 } from "@/api/lib/s3";
 
 const jsonResponse = (body: unknown): Response =>
@@ -200,5 +201,87 @@ describe("credentialsFromEnvValues", () => {
       credentialsFromEnvValues("  use-iam-role  ", "  use-iam-role  "),
     ).toBeNull();
     expect(credentialsFromEnvValues("Use-Iam-Role", "use-iam-role")).toBeNull();
+  });
+});
+
+describe("writeS3ObjectWithRetry", () => {
+  const object = {
+    contentType: "text/html",
+    data: "<html></html>",
+    key: "case-law/raw/source/hash",
+  };
+
+  const failingWriter =
+    (
+      attempts: { code?: string; count: number },
+      failuresBeforeSuccess: number,
+    ) =>
+    async (): Promise<string> => {
+      attempts.count += 1;
+      if (attempts.count > failuresBeforeSuccess) {
+        return await Promise.resolve("written");
+      }
+      throw Object.assign(new Error("an unexpected error has occurred"), {
+        ...(attempts.code === undefined ? {} : { code: attempts.code }),
+      });
+    };
+
+  test("a transient failure does not reach the caller", async () => {
+    // The failure this helper exists for: one `ConnectionClosed` from a
+    // dropped idle socket propagating out of a bare write. The case-law
+    // pipeline holds its page cursor on any raw-upload failure, so a single
+    // recoverable blip is enough to stall a whole source.
+    const attempts = { code: "ConnectionClosed", count: 0 };
+
+    await writeS3ObjectWithRetry(object, failingWriter(attempts, 1));
+
+    expect(attempts.count).toBe(2);
+  });
+
+  test("an unrecognised code retries rather than wedging the caller", async () => {
+    // Retryability is a denylist, so a transport code nobody enumerated
+    // still recovers. An allowlist would reintroduce the stall for every
+    // code the list happens to miss.
+    const attempts = { code: "SomeCodeNobodyEnumerated", count: 0 };
+
+    await writeS3ObjectWithRetry(object, failingWriter(attempts, 1));
+
+    expect(attempts.count).toBe(2);
+  });
+
+  test("a terminal rejection is not retried", async () => {
+    // AccessDenied is a decision, not a blip: replaying the same bytes
+    // reproduces it, so retrying only delays the caller's failure.
+    const attempts = { code: "AccessDenied", count: 0 };
+
+    // bun-types declares `.rejects.toThrow` as void, so awaiting it trips
+    // type-aware lint; capture the rejection explicitly instead.
+    const rejection = await writeS3ObjectWithRetry(
+      object,
+      failingWriter(attempts, Number.POSITIVE_INFINITY),
+    ).then(
+      () => null,
+      (error: unknown) => error,
+    );
+
+    expect(rejection).toBeInstanceOf(Error);
+    expect(attempts.count).toBe(1);
+  });
+
+  test("retries stay bounded and surface the last failure", async () => {
+    // A permanently transient-looking failure must still terminate: the
+    // caller needs to hear about it rather than have the write spin.
+    const attempts = { code: "ConnectionClosed", count: 0 };
+
+    const rejection = await writeS3ObjectWithRetry(
+      object,
+      failingWriter(attempts, Number.POSITIVE_INFINITY),
+    ).then(
+      () => null,
+      (error: unknown) => error,
+    );
+
+    expect(rejection).toBeInstanceOf(Error);
+    expect(attempts.count).toBe(3);
   });
 });

--- a/apps/api/src/lib/s3.test.ts
+++ b/apps/api/src/lib/s3.test.ts
@@ -272,16 +272,23 @@ describe("writeS3ObjectWithRetry", () => {
     // A permanently transient-looking failure must still terminate: the
     // caller needs to hear about it rather than have the write spin.
     const attempts = { code: "ConnectionClosed", count: 0 };
+    const failures: Error[] = [];
+    const write = async (): Promise<never> => {
+      attempts.count += 1;
+      const failure = Object.assign(
+        new Error(`write attempt ${attempts.count} failed`),
+        { code: attempts.code },
+      );
+      failures.push(failure);
+      throw failure;
+    };
 
-    const rejection = await writeS3ObjectWithRetry(
-      object,
-      failingWriter(attempts, Number.POSITIVE_INFINITY),
-    ).then(
+    const rejection = await writeS3ObjectWithRetry(object, write).then(
       () => null,
       (error: unknown) => error,
     );
 
-    expect(rejection).toBeInstanceOf(Error);
     expect(attempts.count).toBe(3);
+    expect(rejection).toBe(failures.at(2));
   });
 });

--- a/apps/api/src/lib/s3.ts
+++ b/apps/api/src/lib/s3.ts
@@ -3,10 +3,13 @@ import {
   PutObjectCommand,
   S3Client as AwsS3Client,
 } from "@aws-sdk/client-s3";
+import { Result } from "better-result";
 import { S3Client } from "bun";
 
 import { envBase } from "@/api/env-base";
 import { contentDisposition } from "@/api/lib/content-disposition";
+import { safeErrorCode } from "@/api/lib/errors/utils";
+import { withTimeout } from "@/api/lib/with-timeout";
 
 type S3Credentials = {
   accessKeyId: string;
@@ -390,6 +393,105 @@ let _clientCreatedAt = 0;
 export const getS3 = (): S3Client => {
   _client ??= buildS3Client(envBase.S3_BUCKET, staticCredentialsFromEnv());
   return _client;
+};
+
+const S3_WRITE_TIMEOUT_MS = 15_000;
+const S3_WRITE_MAX_ATTEMPTS = 3;
+const S3_WRITE_RETRY_BASE_DELAY_MS = 100;
+
+/**
+ * Write failures the service decided on: it received the request, applied a
+ * rule, and rejected it. Replaying the same bytes reproduces the same
+ * rejection, so a retry only makes the failure arrive later.
+ */
+const TERMINAL_S3_WRITE_CODES: ReadonlySet<string> = new Set([
+  "AccessDenied",
+  "EntityTooLarge",
+  "InvalidAccessKeyId",
+  "InvalidArgument",
+  "InvalidRequest",
+  "NoSuchBucket",
+  "SignatureDoesNotMatch",
+]);
+
+/**
+ * Everything outside `TERMINAL_S3_WRITE_CODES` retries, including codes we do
+ * not recognise. The direction is deliberate: an allowlist of known-transient
+ * codes lets the next unrecognised transport failure wedge its caller, which
+ * is the bug this helper exists to prevent, while over-retrying costs only the
+ * bounded backoff below.
+ */
+const isTerminalS3WriteError = (error: unknown): boolean =>
+  error instanceof Error &&
+  TERMINAL_S3_WRITE_CODES.has(safeErrorCode(error) ?? "");
+
+/** Full jitter: spreads concurrent writers instead of resynchronising them. */
+const s3WriteRetryDelayMs = (attempt: number): number =>
+  Math.random() * S3_WRITE_RETRY_BASE_DELAY_MS * 2 ** (attempt - 1);
+
+type S3ObjectWrite = {
+  contentType?: string | undefined;
+  data: Uint8Array | string;
+  /**
+   * Must be deterministic for the bytes written — a content-addressed key, or
+   * one derived from the record's stable identity. A timed-out attempt cannot
+   * be cancelled (Bun's S3 client takes no abort signal), so it may still land
+   * server-side after this helper has moved on to the next attempt. With a
+   * deterministic key that duplicate is a no-op; with a generated key it would
+   * leave an orphan object per attempt.
+   */
+  key: string;
+};
+
+type S3ObjectWriter = (write: S3ObjectWrite) => Promise<unknown>;
+
+const writeViaClient: S3ObjectWriter = async ({ contentType, data, key }) =>
+  await getS3().write(
+    key,
+    data,
+    contentType === undefined ? undefined : { type: contentType },
+  );
+
+/**
+ * Write one object with a per-attempt deadline and a bounded, jittered retry.
+ *
+ * A bare `getS3().write` has neither. Bun's S3 client holds long-lived
+ * connections, so a peer that drops an idle socket surfaces the next write as
+ * a transport failure (`ConnectionClosed`) rather than a rejection by the
+ * service — transient, and cleared by retrying. Without a retry that failure
+ * propagates to the caller, and a caller that holds an ingestion cursor on
+ * failure cannot make progress past it.
+ *
+ * `write` is injected only by tests; production always uses the shared client.
+ */
+export const writeS3ObjectWithRetry = async (
+  object: S3ObjectWrite,
+  write: S3ObjectWriter = writeViaClient,
+): Promise<void> => {
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= S3_WRITE_MAX_ATTEMPTS; attempt += 1) {
+    // oxlint-disable-next-line no-await-in-loop -- sequential by construction: each attempt must observe the previous one's failure
+    const written = await Result.tryPromise({
+      try: async () =>
+        await withTimeout(async () => await write(object), {
+          label: "s3 object write",
+          timeoutMs: S3_WRITE_TIMEOUT_MS,
+        }),
+      catch: (cause) => cause,
+    });
+    if (!Result.isError(written)) {
+      return;
+    }
+    lastError = written.error;
+    if (isTerminalS3WriteError(written.error)) {
+      break;
+    }
+    if (attempt < S3_WRITE_MAX_ATTEMPTS) {
+      // oxlint-disable-next-line no-await-in-loop -- backoff between attempts is the point of the loop
+      await Bun.sleep(s3WriteRetryDelayMs(attempt));
+    }
+  }
+  throw lastError;
 };
 
 /** Delete one object while allowing the caller to cancel the HTTP request. */


### PR DESCRIPTION
## `fix(case-law)`: retry the source-raw S3 write

`uploadSourceRaw` issued a bare `getS3().write`: no timeout, no retry.

Bun's S3 client holds long-lived connections, so a peer that drops an idle socket surfaces the next write as `ConnectionClosed` — a transport failure rather than a rejection by the service, and cleared by retrying. Without a retry it propagates to the caller, which returns `RETRYABLE / SOURCE_RAW_WRITE` and holds the page cursor, so the source cannot make progress past that decision.

`writeS3ObjectWithRetry` adds the per-attempt deadline and bounded jittered retry that `conventions-ingestion` rule 12 requires of every remote call.

Retryability is a denylist: codes the service decided on (`AccessDenied`, `EntityTooLarge`, …) fail fast, everything else retries. An allowlist would let an unrecognised transport code reach the caller the same way. The direction is sound only because callers pass deterministic keys — here the payload's own hash — so an attempt that lands late is a no-op. The `key` field documents that requirement.

Applied to the source-raw upload. The other bare `getS3().write` call sites share the shape but not the idempotency guarantees, so their keys want auditing before converting.

Poison-item isolation (rule 13) is not in scope: a permanently unwritable decision still holds the cursor once retries are exhausted.

## `fix(observability)`: rate-limit identical captured errors

`captureError` sent one event per call with no throttle, so a repeating failure spends one ingested event per iteration, all structurally identical — the redaction contract means repeats differ only in correlation IDs.

Suppressed to one reported event per key per window. The key is the structural fingerprint (class, stable code, frame) and excludes caller context deliberately: a re-run loop reports the same defect under a fresh entity ID each time, so a context-sensitive key would suppress nothing.

Nothing is swallowed — occurrences dropped during a window are counted onto the next reported event as `suppressed_repeats`. Dev sinks stay unthrottled. The window map is bounded, evicting the oldest entry when full.

## Tests

`writeS3ObjectWithRetry`: transient failure not reaching the caller, unrecognised code still retrying, terminal rejection not retried, retries bounded and surfacing the last failure.

`captureError` suppression: one report per site per window, varying correlation context not defeating the key, distinct defects not collapsed, suppressed count carried onto the next report.