### PR TITLE
fix(api): treat an AI configuration refusal as an anticipated failure

### DIFF
--- a/apps/api/src/handlers/chat/stream-chat.test.ts
+++ b/apps/api/src/handlers/chat/stream-chat.test.ts
@@ -1,7 +1,7 @@
 import { EventType, StreamProcessor } from "@tanstack/ai";
 import type { ModelMessage, StreamChunk, ToolCallPart } from "@tanstack/ai";
 import { Result } from "better-result";
-import { describe, expect, test } from "bun:test";
+import { describe, expect, spyOn, test } from "bun:test";
 
 import { CHAT_SEND_MODE } from "@stll/anonymize-chat";
 import { createPipelineContext } from "@stll/anonymize-wasm";
@@ -27,7 +27,9 @@ import { createChatRefRegistry } from "@/api/lib/chat/ref-registry";
 import {
   ChatEmptyCompletionError,
   ChatLoopDetectedError,
+  HandlerError,
 } from "@/api/lib/errors/tagged-errors";
+import { logger } from "@/api/lib/observability/logger";
 import { toUserFileUrl } from "@/api/lib/user-files/types";
 import { PDF_MIME_TYPE } from "@/api/mime-types";
 import { createScopedDbMock } from "@/api/tests/scoped-db-mock";
@@ -970,6 +972,46 @@ describe("outgoing chat stream message ids", () => {
       },
     ]);
     expect(outcomes).toEqual(["failed"]);
+  });
+
+  test("does not report an in-band configuration refusal as a defect", async () => {
+    const messageId = toSafeId<"chatMessage">(
+      "11111111-1111-4111-8111-111111111111",
+    );
+    const errorSpy = spyOn(logger, "error");
+    try {
+      const stream = processServerChatStream({
+        abortSignal: new AbortController().signal,
+        getResponseMessage: () => null,
+        mapMessageId: createChatMessageIdMapper(() => messageId),
+        onFinish: () => undefined,
+        processor: new StreamProcessor(),
+        source: streamChunks([
+          { type: EventType.RUN_STARTED, runId: "run-1", threadId: "thread-1" },
+          {
+            type: EventType.RUN_ERROR,
+            message: "AI is not configured for this role",
+            rawEvent: new HandlerError({
+              status: 403,
+              message: "AI is not configured for this role",
+            }),
+          },
+        ]),
+      });
+
+      expect(stripTimestamps(await collectChunks(stream)).at(-1)).toEqual({
+        type: EventType.RUN_ERROR,
+        message: "unknown",
+        code: "unknown",
+        rawEvent: expect.any(HandlerError),
+      });
+      expect(errorSpy).not.toHaveBeenCalledWith(
+        "chat.stream_failed",
+        expect.anything(),
+      );
+    } finally {
+      errorSpy.mockRestore();
+    }
   });
 
   test("classifies a run error whose body arrives in the message", async () => {

--- a/apps/api/src/handlers/chat/stream-chat.ts
+++ b/apps/api/src/handlers/chat/stream-chat.ts
@@ -1093,12 +1093,19 @@ const providerErrorBody = (
   return isErrorBodyRecord(parsed.value) ? parsed.value : undefined;
 };
 
-const classifyRunErrorChunk = (chunk: RunErrorChunk): AIErrorKind =>
-  classifyAIError(
-    chunk.rawEvent ??
-      providerErrorBody(runErrorMessage(chunk)) ??
-      errorFromRunErrorChunk(chunk),
+const errorForRunErrorChunk = (chunk: RunErrorChunk): unknown => {
+  const rawEvent: unknown = chunk.rawEvent;
+  return (
+    rawEvent ??
+    providerErrorBody(runErrorMessage(chunk)) ??
+    errorFromRunErrorChunk(chunk)
   );
+};
+
+const classifyRunErrorChunk = (chunk: RunErrorChunk): AIErrorKind => {
+  const error = errorForRunErrorChunk(chunk);
+  return classifyAIError(error);
+};
 
 // Classified kinds (quota, billing, retired model, provider outage) are
 // expected operational states, and so is a sub-500 `HandlerError` this
@@ -1113,8 +1120,9 @@ const reportStreamFailure = (error: unknown, kind: AIErrorKind): void => {
 };
 
 const normalizeRunErrorChunk = (chunk: RunErrorChunk): RunErrorChunk => {
-  const kind = classifyRunErrorChunk(chunk);
-  reportStreamFailure(errorFromRunErrorChunk(chunk), kind);
+  const error = errorForRunErrorChunk(chunk);
+  const kind = classifyAIError(error);
+  reportStreamFailure(error, kind);
   return {
     ...chunk,
     message: kind,

--- a/apps/api/src/handlers/chat/stream-chat.ts
+++ b/apps/api/src/handlers/chat/stream-chat.ts
@@ -76,7 +76,7 @@ import type {
 import { hydrateFilePart } from "@/api/handlers/chat/upload-files";
 import type { OrgAIConfig } from "@/api/lib/ai-config";
 import { getTemperatureForRole, resolveCaching } from "@/api/lib/ai-config";
-import { classifyAIError } from "@/api/lib/ai-error";
+import { classifyAIError, isAnticipatedAIFailure } from "@/api/lib/ai-error";
 import type { AIErrorKind } from "@/api/lib/ai-error";
 import { captureError } from "@/api/lib/analytics/capture";
 import { createTanStackAIAnalyticsCallbacks } from "@/api/lib/analytics/tanstack-ai";
@@ -1101,12 +1101,13 @@ const classifyRunErrorChunk = (chunk: RunErrorChunk): AIErrorKind =>
   );
 
 // Classified kinds (quota, billing, retired model, provider outage) are
-// expected operational states; `unknown` means a failure shape this code
-// does not anticipate, so it is the only kind logged at ERROR severity.
+// expected operational states, and so is a sub-500 `HandlerError` this
+// service raised for a configuration state the caller can act on; only an
+// unanticipated shape is logged at ERROR severity.
 // Fingerprint only — provider error messages can echo request content.
 const reportStreamFailure = (error: unknown, kind: AIErrorKind): void => {
   captureError(error, { kind });
-  if (kind === "unknown") {
+  if (!isAnticipatedAIFailure(error, kind)) {
     logger.error("chat.stream_failed", { kind, ...errorFingerprint(error) });
   }
 };

--- a/apps/api/src/lib/ai-error.test.ts
+++ b/apps/api/src/lib/ai-error.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, test } from "bun:test";
 
-import { classifyAIError } from "@/api/lib/ai-error";
-import { ChatLoopDetectedError } from "@/api/lib/errors/tagged-errors";
+import { classifyAIError, isAnticipatedAIFailure } from "@/api/lib/ai-error";
+import {
+  ChatLoopDetectedError,
+  HandlerError,
+} from "@/api/lib/errors/tagged-errors";
+import type { HandlerErrorStatusCode } from "@/api/lib/errors/tagged-errors";
 
 const apiCallError = (statusCode: number) =>
   ({
@@ -110,5 +114,64 @@ describe("classifyAIError", () => {
     expect(
       classifyAIError({ error: { code: 14, message: "unavailable" } }),
     ).toBe("unknown");
+  });
+});
+
+// Split so the exhaustiveness alias below fails to compile when a status is
+// added to `HandlerErrorStatusCode` without deciding which side it falls on.
+const CLIENT_STATUS_CODES = [
+  400, 401, 402, 403, 404, 409, 413, 422, 429,
+] as const satisfies readonly HandlerErrorStatusCode[];
+
+const SERVER_STATUS_CODES = [
+  500, 502,
+] as const satisfies readonly HandlerErrorStatusCode[];
+
+type UncoveredStatusCode = Exclude<
+  HandlerErrorStatusCode,
+  (typeof CLIENT_STATUS_CODES)[number] | (typeof SERVER_STATUS_CODES)[number]
+>;
+
+describe("isAnticipatedAIFailure", () => {
+  test("exercises every HandlerError status", () => {
+    // The guard is the annotation, which stops compiling while a status is
+    // unaccounted for; the assertion just gives it a home.
+    const everyStatusCovered: [UncoveredStatusCode] extends [never]
+      ? true
+      : false = true;
+
+    expect(everyStatusCovered).toBe(true);
+  });
+
+  test("anticipates every client-actionable HandlerError", () => {
+    // These are raised by the AI stack itself for a configuration state, so
+    // none of them is a defect, including the ones the classifier cannot
+    // name (such as the 403 for a role with no key configured).
+    for (const status of CLIENT_STATUS_CODES) {
+      const error = new HandlerError({
+        status,
+        message: `refused with ${status}`,
+      });
+
+      expect(isAnticipatedAIFailure(error, classifyAIError(error))).toBe(true);
+    }
+  });
+
+  test("leaves a server-side HandlerError to the classifier", () => {
+    for (const status of SERVER_STATUS_CODES) {
+      const error = new HandlerError({
+        status,
+        message: `failed with ${status}`,
+      });
+      const kind = classifyAIError(error);
+
+      expect(isAnticipatedAIFailure(error, kind)).toBe(kind !== "unknown");
+    }
+  });
+
+  test("does not anticipate a shape the classifier cannot name", () => {
+    const error = new Error("stream ended before completion");
+
+    expect(isAnticipatedAIFailure(error, classifyAIError(error))).toBe(false);
   });
 });

--- a/apps/api/src/lib/ai-error.ts
+++ b/apps/api/src/lib/ai-error.ts
@@ -25,6 +25,7 @@ export type AIErrorKind = (typeof AI_ERROR_KINDS)[number];
 
 const HTTP_STATUS_MIN = 100;
 const HTTP_STATUS_MAX = 599;
+const HTTP_SERVER_ERROR_MIN = 500;
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   value !== null && typeof value === "object";
@@ -104,7 +105,7 @@ export const classifyAIError = (error: unknown): AIErrorKind => {
     if (statusCode === 404) {
       return "model_unavailable";
     }
-    if (statusCode !== null && statusCode >= 500) {
+    if (statusCode !== null && statusCode >= HTTP_SERVER_ERROR_MIN) {
       return "provider_unavailable";
     }
   }
@@ -119,6 +120,30 @@ export const classifyAIError = (error: unknown): AIErrorKind => {
   }
   return "unknown";
 };
+
+/**
+ * Whether a failure is one this service anticipated, so a telemetry sink can
+ * record it as an operational state rather than a defect.
+ *
+ * A named kind is anticipated by construction. So is a `HandlerError` below
+ * 500: the AI stack raises those itself, with curated user-facing copy, for a
+ * configuration state the caller can act on (no key for the role, 403; a
+ * provider or model that does not serve it, 400). They are invisible to
+ * `classifyAIError`, which names failures from the provider's HTTP status;
+ * `HandlerError` carries a `status` of its own, so a 403 reaches the
+ * classifier looking like a provider error, matches none of the mapped
+ * statuses, and falls through to `unknown`: "a shape this code does not
+ * anticipate", the exact opposite of what it is.
+ *
+ * The request layer already draws this line: `runSafeHandler` reports a
+ * handler failure from 500 up and answers a 4xx as an ordinary response.
+ */
+export const isAnticipatedAIFailure = (
+  error: unknown,
+  kind: AIErrorKind,
+): boolean =>
+  kind !== "unknown" ||
+  (HandlerError.is(error) && error.status < HTTP_SERVER_ERROR_MIN);
 
 type AIHandlerErrorFallback = {
   status: HandlerErrorStatusCode;

--- a/apps/api/src/lib/analytics/tanstack-ai.test.ts
+++ b/apps/api/src/lib/analytics/tanstack-ai.test.ts
@@ -461,4 +461,47 @@ describe("createTanStackAIAnalyticsCallbacks", () => {
       }
     });
   }
+
+  test("logs a configuration refusal at WARN with its status", async () => {
+    const { createTanStackAIAnalyticsCallbacks } =
+      await loadTanStackAIAnalytics();
+    const { classifyAIError } = await import("@/api/lib/ai-error");
+    const { logger } = await import("@/api/lib/observability/logger");
+    const { HandlerError } = await import("@/api/lib/errors/tagged-errors");
+    // What the model resolver raises when the role has no key configured.
+    const error = new HandlerError({
+      status: 403,
+      message: 'AI is not available for the "fast" role on this deployment.',
+    });
+
+    // The classifier names failures by provider status, so it cannot name
+    // this one; severity must not follow from that alone.
+    expect(classifyAIError(error)).toBe("unknown");
+
+    const errorSpy = spyOn(logger, "error");
+    const warnSpy = spyOn(logger, "warn");
+
+    try {
+      createTanStackAIAnalyticsCallbacks({
+        analytics: { capture: () => undefined, flush: async () => undefined },
+        feature: "templates.suggestFields",
+        traceId: "trace_byok_role",
+      }).captureError(error);
+
+      expect(errorSpy).not.toHaveBeenCalledWith(
+        "tanstack_ai.generation.failed",
+        expect.anything(),
+      );
+      expect(warnSpy).toHaveBeenCalledWith(
+        "tanstack_ai.generation.failed",
+        expect.objectContaining({
+          "ai.error_kind": "unknown",
+          "error.status_code": 403,
+        }),
+      );
+    } finally {
+      errorSpy.mockRestore();
+      warnSpy.mockRestore();
+    }
+  });
 });

--- a/apps/api/src/lib/analytics/tanstack-ai.ts
+++ b/apps/api/src/lib/analytics/tanstack-ai.ts
@@ -6,9 +6,10 @@ import type { ModelRole } from "@stll/ai-catalog";
 import type { SafeDb } from "@/api/db/safe-db";
 import type { UsageActionType, UsageServiceTier } from "@/api/db/schema";
 import type { OrgAIConfig } from "@/api/lib/ai-config";
-import { classifyAIError } from "@/api/lib/ai-error";
+import { classifyAIError, isAnticipatedAIFailure } from "@/api/lib/ai-error";
 import { captureError as captureTelemetryError } from "@/api/lib/analytics/capture";
 import type { SafeId } from "@/api/lib/branded-types";
+import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import { errorTag } from "@/api/lib/errors/utils";
 import { logger } from "@/api/lib/observability/logger";
 import {
@@ -300,15 +301,18 @@ export const createTanStackAIAnalyticsCallbacks = ({
     const resolvedModelInfo = resolveAnalyticsModelInfo();
 
     // Classified kinds (quota, billing, retired model, provider outage) are
-    // expected operational states of an upstream account, not faults in this
-    // service, so they log at WARN; `unknown` is a failure shape this code
-    // does not anticipate and is the only kind logged at ERROR. Same split as
-    // `reportStreamFailure` in the chat stream handler.
+    // expected operational states of an upstream account, and a sub-500
+    // `HandlerError` is a configuration state this service raised itself, so
+    // both log at WARN; an unanticipated shape is the only one logged at
+    // ERROR. Same split as `reportStreamFailure` in the chat stream handler.
+    // The status is what names an anticipated failure once `ai.error_kind`
+    // cannot, and a number carries no request content.
     const kind = classifyAIError(error);
     const attributes = {
       "error.type": errorTag(error),
       "ai.error_kind": kind,
       "ai.feature": config.feature,
+      ...(HandlerError.is(error) ? { "error.status_code": error.status } : {}),
       ...(resolvedModelInfo
         ? {
             "ai.provider": resolvedModelInfo.provider,
@@ -316,10 +320,10 @@ export const createTanStackAIAnalyticsCallbacks = ({
           }
         : {}),
     };
-    if (kind === "unknown") {
-      logger.error("tanstack_ai.generation.failed", attributes);
-    } else {
+    if (isAnticipatedAIFailure(error, kind)) {
       logger.warn("tanstack_ai.generation.failed", attributes);
+    } else {
+      logger.error("tanstack_ai.generation.failed", attributes);
     }
     captureTelemetryError(error, {
       feature: config.feature,


### PR DESCRIPTION
## Proposed change

`classifyAIError` names a failure from the provider's HTTP status, and `HandlerError` carries a `status` of its own. So the errors the AI stack raises itself for a configuration state reach the classifier looking like provider errors, match none of the mapped statuses, and fall through to `unknown`:

- `byokRoleNotConfiguredError` / `missingProviderCredentialError` (403): no key configured for the role.
- `byokProviderRoleUnsupportedError` / `byokModelRoleUnsupportedError` (400): a provider or model that does not serve the role.

Both telemetry sinks define `unknown` as "a failure shape this code does not anticipate" and log exactly that kind at ERROR. The result is inverted: the most anticipated failures in the module, the ones raised here with curated user-facing copy, are recorded as the least anticipated kind, while the request layer answers the very same error as an ordinary 4xx response (`runSafeHandler` reports a handler failure only from 500 up).

The fix adds `isAnticipatedAIFailure(error, kind)` next to the classifier and uses it for the severity split in `captureGenerationError` (`tanstack_ai.generation.failed`) and `reportStreamFailure` (`chat.stream_failed`), so one predicate owns the boundary instead of each sink re-deriving it from the kind. Nothing else changes: a named kind stays where it was, a 5xx `HandlerError` is still left to the classifier, and an unnamed shape is still ERROR.

`tanstack_ai.generation.failed` also records `error.status_code` now. Severity follows the status, so the status belongs in the line; it is a number, so it stays as non-PII as the rest of that sink, which deliberately records no provider message.

Tests: the `HandlerError` status union is exercised in both directions, with a compile-time alias that fails when a status is added to `HandlerErrorStatusCode` without deciding which side it falls on, plus a sink-level case asserting the 403 refusal logs at WARN with its status.

## Checklist

- [x] **BUILD ASSURANCE** | Code builds correctly and without any errors or warnings.
- [x] **TESTING** | `bun test src/lib/ai-error.test.ts src/lib/analytics/tanstack-ai.test.ts src/handlers/chat/stream-chat.test.ts` (62 pass), `tsc --noEmit -p apps/api`, type-aware oxlint and oxfmt on the touched files.
- [ ] DARK MODE SUPPORT | Not applicable, backend only.
- [ ] ISSUE LINKED | No issue.
- [ ] SCREENSHOT INCLUDED | Not applicable, backend only.

---
_Generated by [Claude Code](https://claude.ai/code/session_012PXNoqoHpuhnrT2nnHsUzT)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of AI service failures during chat generation.
  * Expected configuration and client-side errors are now treated as warnings rather than critical errors.
  * Unexpected server-side failures continue to be clearly flagged for investigation.
  * Error logs now include relevant status codes where available, making troubleshooting easier.
* **Tests**
  * Added coverage for anticipated failures, server errors, unknown error formats and unavailable AI configuration scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->