### PR TITLE
fix(chat): show the matter behind a tool approval, and keep citation hrefs out of search snippets

### DIFF
--- a/apps/api/src/handlers/chat/send-message.ts
+++ b/apps/api/src/handlers/chat/send-message.ts
@@ -126,6 +126,7 @@ import type {
   LazyExternalMcpToolsLoader,
   LoadedExternalMcpTools,
 } from "@/api/handlers/chat/tools/external-mcp-tools";
+import { hydrateRegistryToolInputRefs } from "@/api/handlers/chat/tools/registry-adapter/input-ref-hydration";
 import { SPAWN_SUBAGENTS_TOOL_NAME } from "@/api/handlers/chat/tools/spawn-subagents-tool";
 import {
   type ChatToolScope,
@@ -2505,10 +2506,33 @@ const hydrateAssistantMessageRefs = ({
   messages,
   refRegistry,
 }: HydrateAssistantMessageRefsProps): ChatMessage[] => {
+  // A persisted tool call carries its input refs already resolved to real ids,
+  // and `arguments` (the provider-visible copy) still carries the *previous*
+  // turn's ref numbering. Re-mint both from the declared input-ref map before
+  // the generic walk, so the replayed call reaches `dehydrateRefs` and the
+  // model as this turn's refs rather than a stale ref beside a raw id.
+  const hydrateToolCallInput = (
+    part: ChatMessage["parts"][number],
+  ): unknown => {
+    if (part.type !== "tool-call" || !("input" in part)) {
+      return part;
+    }
+    const input = hydrateRegistryToolInputRefs({
+      input: part.input,
+      refRegistry,
+      toolName: part.name,
+    });
+    return input === part.input
+      ? part
+      : { ...part, input, arguments: JSON.stringify(input) };
+  };
+
   const hydratePart = (
     part: ChatMessage["parts"][number],
   ): ChatMessage["parts"][number] => {
-    const hydrated = refRegistry.hydrateAssistantValueRefs(part);
+    const hydrated = refRegistry.hydrateAssistantValueRefs(
+      hydrateToolCallInput(part),
+    );
     if (!isChatPart(hydrated)) {
       panic("Hydrating assistant refs changed the message part shape");
     }

--- a/apps/api/src/handlers/chat/stream-chat.ts
+++ b/apps/api/src/handlers/chat/stream-chat.ts
@@ -1764,14 +1764,11 @@ const createOutgoingChunkTransformer = ({
       buffers.delete(key);
       let input: unknown;
       if ("input" in chunk) {
-        input =
-          boundary.type === "anonymized"
-            ? deanonymizeUnknownStringsFromBoundary(
-                boundary,
-                chunk.input,
-                "lenient",
-              )
-            : chunk.input;
+        input = transformToolCallInput({
+          boundary,
+          input: chunk.input,
+          resolveAssistantValueRefs,
+        });
       }
       return [
         ...flushToolArguments({
@@ -1801,10 +1798,11 @@ const createOutgoingChunkTransformer = ({
     ) {
       const value = isRecord(chunk.value) ? chunk.value : {};
       const rawInput = value["input"];
-      const input =
-        boundary.type === "anonymized"
-          ? deanonymizeUnknownStringsFromBoundary(boundary, rawInput, "lenient")
-          : rawInput;
+      const input = transformToolCallInput({
+        boundary,
+        input: rawInput,
+        resolveAssistantValueRefs,
+      });
       return [
         ...emitRestorationDelta(
           collectUnknownStringPlaceholders(rawInput, lenientCollector),
@@ -2015,6 +2013,39 @@ const collectUnknownStringPlaceholders = (
   };
   walk(value);
   return placeholders;
+};
+
+type TransformToolCallInputOptions = {
+  boundary: ChatThirdPartyBoundary;
+  input: unknown;
+  resolveAssistantValueRefs?: AssistantValueRefResolver | undefined;
+};
+
+/**
+ * The client-bound copy of a tool call's input, deanonymized and with this
+ * turn's chat refs resolved back to real ids.
+ *
+ * Ref resolution matters twice here. The approval card renders this input
+ * verbatim, and a per-turn `mat_3` is meaningless to the person deciding
+ * whether to allow the write; with the real id the client resolves the matter's
+ * own name and colour. It also keeps the client's copy of the call equal to the
+ * one `resolveAssistantMessageRefs` persists, which the approval continuation
+ * compares field by field (`validateContinuationToolCallIntegrity`) before
+ * replaying the call. `arguments` (the provider-visible copy) keeps its refs on
+ * both sides and is not touched.
+ */
+const transformToolCallInput = ({
+  boundary,
+  input,
+  resolveAssistantValueRefs,
+}: TransformToolCallInputOptions): unknown => {
+  const visibleInput =
+    boundary.type === "anonymized"
+      ? deanonymizeUnknownStringsFromBoundary(boundary, input, "lenient")
+      : input;
+  return resolveAssistantValueRefs
+    ? resolveAssistantValueRefs(visibleInput)
+    : visibleInput;
 };
 
 type ParsedToolResultContent =

--- a/apps/api/src/handlers/chat/tools/registry-adapter/input-ref-hydration.test.ts
+++ b/apps/api/src/handlers/chat/tools/registry-adapter/input-ref-hydration.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, test } from "bun:test";
+
+import { toSafeId } from "@/api/lib/branded-types";
+import { createChatRefRegistry } from "@/api/lib/chat/ref-registry";
+
+import { hydrateRegistryToolInputRefs } from "./input-ref-hydration";
+import { WRITE_TOOL_REF_FIELD_MAP } from "./ref-field-map";
+import { dehydrateRefs } from "./ref-mediation";
+
+const WS_UUID = "0dc54d0c-10d7-501d-897e-e801dbd0998c";
+const TASK_UUID = "6d0f4b21-5c7e-4a0e-9f31-1b3a7c2d8e55";
+
+/** The same declaration the hydrator reads, so the round trip below is tied
+ *  to `save_task`'s real input-ref contract rather than a restated one. */
+const SAVE_TASK_INPUT_REFS = WRITE_TOOL_REF_FIELD_MAP.save_task.inputRefs;
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const asArgs = (value: unknown): Record<string, unknown> => {
+  if (!isRecord(value)) {
+    throw new Error("hydration must return a tool input record");
+  }
+  return { ...value };
+};
+
+describe("registry tool input ref hydration", () => {
+  /**
+   * The invariant the persisted approval flow depends on: a tool call stored
+   * with resolved ids, replayed on a later turn, must dehydrate back to exactly
+   * those ids. Before hydration ran on ingress, `dehydrateRefs` saw the raw
+   * UUID and failed the call with "Unknown matter ref".
+   */
+  test("round-trips a persisted tool input back to its resolved ids", () => {
+    const registry = createChatRefRegistry();
+    const persistedInput = {
+      matter_id: WS_UUID,
+      task_id: TASK_UUID,
+      name: "respond to outside counsel",
+    };
+
+    const hydrated = hydrateRegistryToolInputRefs({
+      input: persistedInput,
+      refRegistry: registry,
+      toolName: "save_task",
+    });
+
+    // The model-facing call carries refs again, never the tenant ids.
+    expect(hydrated).toEqual({
+      matter_id: "mat_1",
+      task_id: "ent_1",
+      name: "respond to outside counsel",
+    });
+
+    const dehydrated = dehydrateRefs({
+      args: asArgs(hydrated),
+      inputRefs: SAVE_TASK_INPUT_REFS,
+      refRegistry: registry,
+    }).unwrap();
+
+    expect(dehydrated.args).toEqual(persistedInput);
+    // The entity ref recovered its workspace from the sibling matter param,
+    // so output hydration can mint refs for entities in the same matter.
+    expect(dehydrated.resolvedEntityParams["task_id"]).toBe(
+      toSafeId<"workspace">(WS_UUID),
+    );
+  });
+
+  test("reuses the ref a matter already has this turn", () => {
+    const registry = createChatRefRegistry();
+    const existingRef = registry.toMatterRef(toSafeId<"workspace">(WS_UUID));
+
+    expect(
+      hydrateRegistryToolInputRefs({
+        input: { matter_id: WS_UUID },
+        refRegistry: registry,
+        toolName: "save_task",
+      }),
+    ).toEqual({ matter_id: existingRef });
+  });
+
+  test("leaves a call with no declared input refs untouched", () => {
+    const registry = createChatRefRegistry();
+    const input = { workspace_id: WS_UUID };
+
+    expect(
+      hydrateRegistryToolInputRefs({
+        input,
+        refRegistry: registry,
+        toolName: "spawn-subagents",
+      }),
+    ).toBe(input);
+  });
+
+  test("passes a value that is already a ref through unchanged", () => {
+    const registry = createChatRefRegistry();
+    const ref = registry.toMatterRef(toSafeId<"workspace">(WS_UUID));
+
+    expect(
+      hydrateRegistryToolInputRefs({
+        input: { matter_id: ref, name: "draft" },
+        refRegistry: registry,
+        toolName: "save_task",
+      }),
+    ).toEqual({ matter_id: ref, name: "draft" });
+  });
+});

--- a/apps/api/src/handlers/chat/tools/registry-adapter/input-ref-hydration.ts
+++ b/apps/api/src/handlers/chat/tools/registry-adapter/input-ref-hydration.ts
@@ -1,0 +1,105 @@
+import type { ChatRefRegistry } from "@/api/lib/chat/ref-registry";
+
+import type { InputRefParam, RegistryRefFieldMapEntry } from "./ref-field-map";
+import {
+  READ_TOOL_REF_FIELD_MAP,
+  WRITE_TOOL_REF_FIELD_MAP,
+} from "./ref-field-map";
+
+/**
+ * Ingress counterpart to `dehydrateRefs`, for a persisted tool call replayed on
+ * a later turn.
+ *
+ * A turn's refs are minted per turn, so an assistant tool call is persisted
+ * with its input refs already resolved to real ids
+ * (`resolveAssistantMessageRefs`); a `mat_3` written into the row would point
+ * at whatever the *next* turn happened to number third. Replaying that row
+ * therefore has to mint the ref again, or the call reaches `dehydrateRefs` as a
+ * raw UUID it cannot resolve, and reaches the model as an id the ingress guard
+ * redacts.
+ *
+ * `hydrateAssistantValueRefs` cannot do this on its own: it recognizes the
+ * *output* projection's key names (`matterRef`, `entityRef`, ...), while a tool
+ * call's input params are named per tool (`matter_id`, `task_id`). The kinds
+ * come from the same declared map that drives dehydration, so the two sides
+ * cannot drift.
+ */
+
+/**
+ * Declared input refs per chat-projected registry tool, read and write. Built
+ * from the two ref-field maps rather than restated, so a tool whose input refs
+ * change is hydrated by the same declaration that dehydrates it.
+ */
+const buildInputRefsByTool = (): ReadonlyMap<
+  string,
+  readonly InputRefParam[]
+> => {
+  const byTool = new Map<string, readonly InputRefParam[]>();
+  const entries: [string, RegistryRefFieldMapEntry][] = [
+    ...Object.entries(READ_TOOL_REF_FIELD_MAP),
+    ...Object.entries(WRITE_TOOL_REF_FIELD_MAP),
+  ];
+  for (const [toolName, entry] of entries) {
+    if (entry.chatProjectable && entry.inputRefs.length > 0) {
+      byTool.set(toolName, entry.inputRefs);
+    }
+  }
+  return byTool;
+};
+
+const INPUT_REFS_BY_TOOL = buildInputRefsByTool();
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+/**
+ * The workspace an entity param's ref key needs. Chat's write tools that take
+ * an entity id also take the matter it lives in (`save_task`'s `task_id` beside
+ * its `matter_id`), so the sibling matter param is the reliable source; without
+ * one the registry falls back to a ref it already minted for that entity id.
+ */
+const findWorkspaceId = ({
+  input,
+  inputRefs,
+}: {
+  input: Record<string, unknown>;
+  inputRefs: readonly InputRefParam[];
+}): unknown => {
+  for (const { kind, param } of inputRefs) {
+    if (kind === "matter" && typeof input[param] === "string") {
+      return input[param];
+    }
+  }
+  return undefined;
+};
+
+export type HydrateRegistryToolInputRefsProps = {
+  input: unknown;
+  refRegistry: ChatRefRegistry;
+  toolName: string;
+};
+
+export const hydrateRegistryToolInputRefs = ({
+  input,
+  refRegistry,
+  toolName,
+}: HydrateRegistryToolInputRefsProps): unknown => {
+  const inputRefs = INPUT_REFS_BY_TOOL.get(toolName);
+  if (inputRefs === undefined || !isRecord(input)) {
+    return input;
+  }
+
+  const workspaceId = findWorkspaceId({ input, inputRefs });
+  const hydrated = { ...input };
+  for (const { kind, param } of inputRefs) {
+    if (!(param in hydrated)) {
+      continue;
+    }
+    hydrated[param] = refRegistry.hydrateRefId({
+      kind,
+      value: hydrated[param],
+      workspaceId,
+    });
+  }
+  return hydrated;
+};

--- a/apps/api/src/lib/chat/projection-schema.ts
+++ b/apps/api/src/lib/chat/projection-schema.ts
@@ -3,7 +3,7 @@ import * as v from "valibot";
 
 import { captureError } from "@/api/lib/analytics/capture";
 import type { SafeId } from "@/api/lib/branded-types";
-import type { ChatRefRegistry } from "@/api/lib/chat/ref-registry";
+import type { ChatRefKind, ChatRefRegistry } from "@/api/lib/chat/ref-registry";
 import { ChatToolError } from "@/api/lib/errors/tagged-errors";
 import {
   brandPersistedContactId,
@@ -37,13 +37,13 @@ import {
 // module graph stays cycle-free; the map imports the vocabulary from here.
 
 /**
- * The four tenant-content id kinds the chat ref registry mediates
- * (`createChatRefRegistry`). Every other id a registry handler emits (user,
- * task-link, invoice, time-entry, template, clause, playbook, audit-log,
- * usage-plan, or public case-law/BOE corpus id) is a handle the model may pass
- * back verbatim, not a tenant-content reference, so it stays outside this set.
+ * The four tenant-content id kinds the chat ref registry mediates. Re-exported
+ * from `ref-registry.ts` rather than restated: the registry is the lowest
+ * module that must know all four (it keys one ref state per kind), and a second
+ * declaration here would be a hand-maintained mirror of that set.
  */
-export type RegistryRefKind = "matter" | "entity" | "contact" | "property";
+export type { ChatRefKind as RegistryRefKind } from "@/api/lib/chat/ref-registry";
+type RegistryRefKind = ChatRefKind;
 
 export type SimpleRefKind = Exclude<RegistryRefKind, "entity">;
 

--- a/apps/api/src/lib/chat/ref-registry.ts
+++ b/apps/api/src/lib/chat/ref-registry.ts
@@ -141,6 +141,29 @@ const isUnknownArray = (value: unknown): value is unknown[] =>
 const isUuidString = (value: unknown): value is string =>
   typeof value === "string" && UUID_REGEX.test(value);
 
+/**
+ * The four tenant-content id kinds this registry mediates. Every other id a
+ * registry handler emits (user, task-link, invoice, time-entry, template,
+ * clause, playbook, audit-log, usage-plan, or public case-law/BOE corpus id) is
+ * a handle the model may pass back verbatim, not a tenant-content reference, so
+ * it stays outside this set. `projection-schema.ts` re-exports this as
+ * `RegistryRefKind`; the vocabulary lives here because the registry is the
+ * lowest module that has to know all four.
+ */
+export type ChatRefKind = "matter" | "entity" | "contact" | "property";
+
+/**
+ * One id to turn back into a chat ref. `workspaceId` applies only to
+ * `kind: "entity"`, whose ref key is the (workspace, entity) pair; when it is
+ * absent or not a UUID the registry falls back to the unique ref it already
+ * minted for that entity id this turn, and otherwise leaves the value alone.
+ */
+export type HydrateRefIdProps = {
+  kind: ChatRefKind;
+  value: unknown;
+  workspaceId?: unknown;
+};
+
 export type ChatRefRegistry = {
   /**
    * Deduped union of every workspace id any tool (including subagents)
@@ -154,6 +177,16 @@ export type ChatRefRegistry = {
   getRegisteredWorkspaceIds: () => SafeId<"workspace">[];
   hydrateAssistantTextRefs: (text: string) => string;
   hydrateAssistantValueRefs: (value: unknown) => unknown;
+  /**
+   * Mint (or reuse) this turn's ref for one already-resolved id, chosen by
+   * kind rather than by key name. `hydrateAssistantValueRefs` recognizes the
+   * *output* projection's key names (`matterRef`, `entityRef`, ...); a tool
+   * call's own input params are named per tool (`matter_id`, `task_id`), so
+   * their kinds come from the registry adapter's declared input-ref map and
+   * land here. A non-UUID value (already a ref, or not an id at all) is
+   * returned unchanged.
+   */
+  hydrateRefId: (props: HydrateRefIdProps) => unknown;
   resolveAssistantTextRefs: (text: string) => string;
   resolveAssistantValueRefs: (value: unknown) => unknown;
   resolveContactRefs: (
@@ -470,6 +503,25 @@ export const createChatRefRegistry = (): ChatRefRegistry => {
     return Object.fromEntries(entries);
   };
 
+  const hydrateRefId = ({
+    kind,
+    value,
+    workspaceId,
+  }: HydrateRefIdProps): unknown => {
+    switch (kind) {
+      case "matter":
+        return toHydratedMatterRef(value);
+      case "entity":
+        return toHydratedEntityRef({ entityId: value, workspaceId });
+      case "contact":
+        return toHydratedContactRef(value);
+      case "property":
+        return toHydratedPropertyRef(value);
+      default:
+        return kind satisfies never;
+    }
+  };
+
   const getRegisteredWorkspaceIds = (): SafeId<"workspace">[] => {
     const ids = new Set<SafeId<"workspace">>([
       ...matterState.refToTarget.values(),
@@ -484,6 +536,7 @@ export const createChatRefRegistry = (): ChatRefRegistry => {
     getRegisteredWorkspaceIds,
     hydrateAssistantTextRefs,
     hydrateAssistantValueRefs,
+    hydrateRefId,
     resolveAssistantTextRefs,
     resolveAssistantValueRefs,
     resolveEntityRefs: (refs: string[]) => {

--- a/apps/api/src/lib/search/chat-search-generation.ts
+++ b/apps/api/src/lib/search/chat-search-generation.ts
@@ -1,7 +1,14 @@
 /**
- * Version marker for chat projections whose searchable source-document
- * metadata follows the current display-only contract. UUIDv7 generations
- * written by the previous indexer cannot equal this reserved UUID.
+ * Version marker for chat projections whose searchable text and
+ * source-document metadata follow the current display-only contract. UUIDv7
+ * generations written by the previous indexer cannot equal this reserved UUID,
+ * and neither can an earlier reserved generation, so bumping it is how a
+ * projection change re-indexes existing rows without a migration: the periodic
+ * repair task (`search.repairChatIndex`, every five minutes) picks up every
+ * thread whose `preview_generation` differs.
+ *
+ * `...0002` drops markdown link targets from the indexed text, so a chat hit's
+ * headline no longer exposes the mention href behind a citation.
  */
 export const CHAT_SEARCH_DISPLAY_METADATA_GENERATION =
-  "00000000-0000-0000-0000-000000000001" as const;
+  "00000000-0000-0000-0000-000000000002" as const;

--- a/apps/api/src/lib/search/index-chat.test.ts
+++ b/apps/api/src/lib/search/index-chat.test.ts
@@ -98,6 +98,33 @@ describe("chat search indexing", () => {
     ).toBe("Review the termination clause. Agreement.pdf @agreement document");
   });
 
+  test("indexes citation labels without their link targets", async () => {
+    const { extractMessageSearchText } = await import("./index-chat");
+    const workspaceId = "db9b500f-aa40-4bee-bd7e-624ef4be6193";
+    const entityId = "6d0f4b21-5c7e-4a0e-9f31-1b3a7c2d8e55";
+
+    const indexed = extractMessageSearchText({
+      version: 2,
+      data: [
+        {
+          type: "text",
+          content: [
+            `The matter **[FlightOps Cloud - IT & SaaS](#stella-workspace=${workspaceId})**`,
+            `holds [the retainer](#stella-entity=${workspaceId}:${entityId})`,
+            "and its [public filing](https://example.com/filing 'Filing').",
+          ].join(" "),
+        },
+      ],
+    });
+
+    expect(indexed).toBe(
+      "The matter **FlightOps Cloud - IT & SaaS** holds the retainer and its public filing.",
+    );
+    expect(indexed).not.toContain(workspaceId);
+    expect(indexed).not.toContain("#stella-");
+    expect(indexed).not.toContain("https://");
+  });
+
   test("indexes only source-document metadata that previews can display", async () => {
     const { extractMessageSearchText } = await import("./index-chat");
 

--- a/apps/api/src/lib/search/index-chat.ts
+++ b/apps/api/src/lib/search/index-chat.ts
@@ -40,15 +40,34 @@ type NormalizedSearchableChatMessageContent = {
   parts: SearchableChatTextPart[];
 };
 
+/** `[label](href)` and `![alt](src)`, with the target captured. Balanced
+ *  parentheses inside the target (a URL ending in `(1)`) are out of scope:
+ *  chat mention hrefs and ordinary links never carry them. */
+const MARKDOWN_LINK_REGEX =
+  /!?\[([^\]]*)\]\([^)\s]*(?:\s+(?:"[^"]*"|'[^']*'))?\)/gu;
+
+/**
+ * Drop link targets from persisted chat markdown, keeping the link label.
+ *
+ * Assistant text cites matters and entities as `[Name](#stella-workspace=<uuid>)`
+ * (see `resolveAssistantTextRefs`), so the raw text carries an href for every
+ * citation. Indexing it verbatim made the href both matchable and visible: a
+ * search hit rendered its `ts_headline` inline, so the result row showed the
+ * mention URL and could even highlight a fragment of the workspace UUID. The
+ * label is the only part a reader searches for or wants to see.
+ */
+const stripMarkdownLinkTargets = (text: string): string =>
+  text.replaceAll(MARKDOWN_LINK_REGEX, (_match, label: string) => label);
+
 const toSearchableTextPart = (part: unknown): SearchableChatTextPart | null => {
   if (!isRecord(part) || part["type"] !== "text") {
     return null;
   }
   if (typeof part["content"] === "string") {
-    return { type: "text", content: part["content"] };
+    return { type: "text", content: stripMarkdownLinkTargets(part["content"]) };
   }
   if (typeof part["text"] === "string") {
-    return { type: "text", content: part["text"] };
+    return { type: "text", content: stripMarkdownLinkTargets(part["text"]) };
   }
   return null;
 };

--- a/apps/api/src/lib/search/index-chat.ts
+++ b/apps/api/src/lib/search/index-chat.ts
@@ -40,11 +40,13 @@ type NormalizedSearchableChatMessageContent = {
   parts: SearchableChatTextPart[];
 };
 
-/** `[label](href)` and `![alt](src)`, with the target captured. Balanced
- *  parentheses inside the target (a URL ending in `(1)`) are out of scope:
- *  chat mention hrefs and ordinary links never carry them. */
-const MARKDOWN_LINK_REGEX =
-  /!?\[([^\]]*)\]\([^)\s]*(?:\s+(?:"[^"]*"|'[^']*'))?\)/gu;
+/** `[label](href)` and `![alt](src)`, with the label captured. Neither class
+ *  admits its own opening delimiter, which keeps the match linear in the
+ *  subject (`super-linear-regexes` is a ratcheted metric, and this runs over
+ *  whole persisted threads). The cost is that a label containing `[` or a
+ *  target containing `(` is left alone; a chat mention href never has either,
+ *  and an unstripped link is the safe direction to fail. */
+const MARKDOWN_LINK_REGEX = /!?\[([^[\]]*)\]\([^()]*\)/gu;
 
 /**
  * Drop link targets from persisted chat markdown, keeping the link label.

--- a/apps/web/src/components/chat/tool-approval-card.tsx
+++ b/apps/web/src/components/chat/tool-approval-card.tsx
@@ -737,7 +737,10 @@ const useMattersById = (): ReadonlyMap<string, SummaryMatter> => {
   const { activeOrganizationId } = useChatApproval();
   const { data } = useQuery(workspacesNavigationOptions(activeOrganizationId));
   const byId = new Map<string, SummaryMatter>();
-  for (const workspace of data?.workspaces ?? []) {
+  if (!data) {
+    return byId;
+  }
+  for (const workspace of data.workspaces) {
     byId.set(workspace.id, {
       color: workspace.color,
       id: workspace.id,
@@ -782,9 +785,10 @@ const RegistryWriteSummaryRow = ({
   </div>
 );
 
-/** "Matter id" -> "Matter": the id is no longer what the row shows. */
+/** "Matter id" -> "Matter": the id is no longer what the row shows. A single
+ *  space suffices because `humanizeIdentifier` has already collapsed runs. */
 const stripIdSuffix = (label: string): string =>
-  label.replace(/\s+id$/iu, "").trim() || label;
+  label.replace(/ id$/iu, "") || label;
 
 const RegistryWriteSummary = ({
   input,

--- a/apps/web/src/components/chat/tool-approval-card.tsx
+++ b/apps/web/src/components/chat/tool-approval-card.tsx
@@ -44,12 +44,14 @@ import {
   humanizeIdentifier,
 } from "@/components/chat/tool-approval-summary";
 import { useInspectorTabsStore } from "@/components/inspector/inspector-tabs-store";
+import { MatterIcon } from "@/components/matter-icon";
 import { useMountEffect } from "@/hooks/use-effect";
 import type { DocxEditRepresentation } from "@/lib/chat-edit-mode";
 import { DOCX_EDIT_REPRESENTATION } from "@/lib/chat-edit-mode";
 import { detached } from "@/lib/detached";
 import { mcpConnectorsOptions } from "@/lib/knowledge/queries";
 import { sanitizeHref } from "@/lib/sanitize-href";
+import { workspacesNavigationOptions } from "@/lib/workspaces/queries";
 
 type UpdateEntityFieldsInput = ChatUITools["update-entity-fields"]["input"];
 type ActiveDocxEditInput = ChatUITools["apply-active-docx-edits"]["input"];
@@ -722,6 +724,68 @@ export const ToolApprovalCard = ({
   );
 };
 
+type SummaryMatter = { color: string | null; id: string; name: string };
+
+/**
+ * The org's matters keyed by id, for turning a matter id in a write tool's
+ * input into the matter itself. The navigation list is already in flight on
+ * every chat surface (`chat-mention-providers`, the sidebar), so this is a
+ * cache read rather than a fetch; a miss (matter deleted, or outside the
+ * user's access) simply leaves the row's value as it came.
+ */
+const useMattersById = (): ReadonlyMap<string, SummaryMatter> => {
+  const { activeOrganizationId } = useChatApproval();
+  const { data } = useQuery(workspacesNavigationOptions(activeOrganizationId));
+  const byId = new Map<string, SummaryMatter>();
+  for (const workspace of data?.workspaces ?? []) {
+    byId.set(workspace.id, {
+      color: workspace.color,
+      id: workspace.id,
+      name: workspace.name,
+    });
+  }
+  return byId;
+};
+
+/**
+ * One approval-summary row. A value that is a matter id renders as the matter:
+ * its name beside the layers glyph in the matter's own colour, the same way it
+ * reads everywhere else in the app. The id itself is what the user least needs
+ * to see when deciding whether to allow a write.
+ */
+const RegistryWriteSummaryRow = ({
+  label,
+  matter,
+  value,
+}: {
+  label: string;
+  matter: SummaryMatter | undefined;
+  value: string;
+}) => (
+  <div className="grid gap-1 sm:grid-cols-[9rem_1fr]">
+    <dt className="text-muted-foreground text-xs">
+      {matter ? stripIdSuffix(label) : label}
+    </dt>
+    <dd className="text-xs break-words">
+      {matter ? (
+        <span className="inline-flex min-w-0 items-center gap-1.5">
+          <MatterIcon
+            className="size-3.5 shrink-0"
+            matter={{ color: matter.color, id: matter.id }}
+          />
+          <span className="truncate">{matter.name}</span>
+        </span>
+      ) : (
+        value
+      )}
+    </dd>
+  </div>
+);
+
+/** "Matter id" -> "Matter": the id is no longer what the row shows. */
+const stripIdSuffix = (label: string): string =>
+  label.replace(/\s+id$/iu, "").trim() || label;
+
 const RegistryWriteSummary = ({
   input,
   toolName,
@@ -730,6 +794,7 @@ const RegistryWriteSummary = ({
   toolName: string;
 }) => {
   const t = useTranslations();
+  const mattersById = useMattersById();
   const rows = buildRegistryWriteSummaryRows({
     documentLabel: t("common.document"),
     emptyLabel: t("common.empty"),
@@ -746,10 +811,12 @@ const RegistryWriteSummary = ({
     <div className="border-border/50 border-t px-3 py-2">
       <dl className="space-y-1.5">
         {rows.map((row) => (
-          <div className="grid gap-1 sm:grid-cols-[9rem_1fr]" key={row.key}>
-            <dt className="text-muted-foreground text-xs">{row.label}</dt>
-            <dd className="text-xs break-words">{row.value}</dd>
-          </div>
+          <RegistryWriteSummaryRow
+            key={row.key}
+            label={row.label}
+            matter={mattersById.get(row.value)}
+            value={row.value}
+          />
         ))}
       </dl>
     </div>


### PR DESCRIPTION
Two independent chat fixes, one commit each.

## `fix(chat): resolve tool-call input refs on the client-bound stream`

Tool-call `input` was the one client-bound surface with no ref mediation. Assistant text goes through `resolveAssistantTextRefs` and tool results through `resolveAssistantValueRefs` on the way out; a call's `input` was forwarded verbatim, so the approval card rendered the model's per-turn token (`mat_3`) where the user needs to see which matter a write targets.

Resolving it also settles a divergence between the two copies of a pending call. `resolveAssistantMessageRefs` already resolves `input` when persisting the assistant message, while the streamed copy kept its refs. `validateContinuationToolCallIntegrity` compares an incoming continuation against the persisted canonical call field by field, and `input` was the field that could not match; past that check the executor would reach `dehydrateRefs` with an id the registry never minted a ref for.

Both directions now mediate:

- **Egress** — `transformToolCallInput` applies the same deanonymize + ref resolution to `TOOL_CALL_END` and `tool-input-available` that `transformToolResultContent` already applied to results. `arguments` (the provider-visible copy) keeps its refs on both sides and is untouched.
- **Ingress** — `hydrateRegistryToolInputRefs` mints this turn's refs for a replayed call's input, so `dehydrateRefs` still receives refs and the model still sees its own prior call as refs rather than an id the ingress guard would redact. `hydrateAssistantValueRefs` cannot do this alone: it keys on the output projection's field names (`matterRef`, `entityRef`), while input params are named per tool (`matter_id`, `task_id`). The kinds come from the same `inputRefs` declarations that drive dehydration, so the two directions cannot drift. `arguments` is re-derived from the hydrated input, which also drops the previous turn's stale ref numbering it carried until now.

`hydrateRefId` on the registry is the kind-directed entry point, reusing the per-kind hydrators the value walk already used. `RegistryRefKind` now re-exports the registry's own `ChatRefKind` instead of restating the union.

On the client, an approval row whose value is a matter id renders as the matter: its name beside the layers glyph in the matter's colour, read from the navigation list already cached on every chat surface. A miss (matter deleted, or outside the user's access) leaves the value exactly as it came.

`input-ref-hydration.test.ts` pins the round trip against `save_task`'s real `inputRefs` declaration: persisted ids to refs and back to exactly those ids, including the entity param recovering its workspace from the sibling matter param.

## `fix(search): index chat citations without their link targets`

Assistant text cites matters and entities as markdown links (`[Name](#stella-workspace=<uuid>)`). The chat indexer stored that verbatim, so the href was both matchable and visible: `ts_headline` runs over the same stored text the result row renders, so a chat hit could show the mention URL in its snippet and highlight a fragment of the id inside it.

`toSearchableTextPart` now drops link targets and keeps labels, which covers the indexed text and the search preview in one place (both read `normalizeSearchableChatMessageContent`). `CHAT_SEARCH_DISPLAY_METADATA_GENERATION` moves to the next reserved UUID so the five-minute repair task re-indexes existing rows, the same mechanism the previous projection change used instead of a migration. Chat hits fall out of global search until a row is re-indexed, which is the tradeoff that marker was designed for.

## Verification

`lint`, `typecheck`, and `format` clean. Targeted suites green: `handlers/chat`, `handlers/chat/tools/registry-adapter`, `lib/chat`, `lib/search/index-chat`, plus the full web suite.
