### PR TITLE
fix: adding a view filter no longer creates an empty filter that hides rows

### DIFF
--- a/.changeset/blank-comparison-incomplete.md
+++ b/.changeset/blank-comparison-incomplete.md
@@ -1,0 +1,8 @@
+---
+"@stll/conditions": patch
+---
+
+Treat a comparison against a blank literal as an incomplete filter for every
+operator. `pruneIncomplete` previously excepted `eq`/`neq`, so a filter seeded
+by a picker and never given a value compiled to a real constraint and matched
+almost nothing. Blankness is expressed by `is_empty`.

--- a/apps/web/src/components/conditions/condition-builder-logic.test.ts
+++ b/apps/web/src/components/conditions/condition-builder-logic.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, test } from "bun:test";
 
 import type { RefOperand } from "@stll/conditions";
+import { pruneIncomplete } from "@stll/conditions";
 
-import { operandsEqual } from "./condition-builder-logic";
+import type { FieldOption, FieldValueType } from "./condition-builder-logic";
+import { leafFromField, operandsEqual } from "./condition-builder-logic";
 
 describe("operandsEqual", () => {
   test("two distinct path operands are not equal", () => {
@@ -44,4 +46,33 @@ describe("operandsEqual", () => {
     const b: RefOperand = { type: "property", propertyId: "rent" };
     expect(operandsEqual(a, b)).toBe(false);
   });
+});
+
+describe("leafFromField", () => {
+  // A seeded row must read as incomplete. Total over `FieldValueType`, and the
+  // cases are derived from it, so a new value type cannot land untested.
+  const SEEDED = {
+    text: { valueType: "text", type: "text" },
+    "single-select": { valueType: "single-select", type: "single-select" },
+    "multi-select": { valueType: "multi-select", type: "multi-select" },
+    date: { valueType: "date", type: "date" },
+    int: { valueType: "int", type: "int" },
+    kind: { valueType: "kind", type: "text" },
+    status: { valueType: "status", type: "single-select" },
+    priority: { valueType: "priority", type: "single-select" },
+  } as const satisfies Record<
+    FieldValueType,
+    Pick<FieldOption, "valueType" | "type">
+  >;
+
+  for (const seeded of Object.values(SEEDED)) {
+    test(`a seeded ${seeded.valueType} row prunes away`, () => {
+      const field: FieldOption = {
+        ...seeded,
+        operand: { type: "property", propertyId: "p1" },
+        label: seeded.valueType,
+      };
+      expect(pruneIncomplete(leafFromField(field))).toBeNull();
+    });
+  }
 });

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-toolbar-filters.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-toolbar-filters.tsx
@@ -85,8 +85,8 @@ export const FilterChips = ({
   const t = useTranslations();
   const fields = useFilterFields(properties);
   // Which filter chip's editor popover is open (simple or advanced; only one
-  // can be open at a time). Set when an advanced chip is created so it opens
-  // immediately (an unopened "1 rule" chip is otherwise a dead end).
+  // can be open at a time). Set on creation, since a new chip carries no value
+  // yet and is a dead end unopened.
   const [openIndex, setOpenIndex] = useState<number | null>(null);
 
   const replaceAt = (index: number, node: ConditionNode) => {
@@ -123,12 +123,17 @@ export const FilterChips = ({
     append(seededAdvancedGroup(pickerFields));
   };
 
+  const addField = (field: FieldOption) => {
+    setOpenIndex(filters.length);
+    append(leafFromField(field));
+  };
+
   if (filters.length === 0) {
     return (
       <AddFilterPicker
         fields={pickerFields}
         onAddAdvanced={addAdvanced}
-        onAddField={(field) => append(leafFromField(field))}
+        onAddField={addField}
         trigger={
           <Button
             aria-label={t("workspaces.views.filter")}
@@ -182,7 +187,7 @@ export const FilterChips = ({
       <AddFilterPicker
         fields={pickerFields}
         onAddAdvanced={addAdvanced}
-        onAddField={(field) => append(leafFromField(field))}
+        onAddField={addField}
         trigger={
           <Button
             aria-label={t("workspaces.views.filter")}

--- a/packages/conditions/src/evaluate.test.ts
+++ b/packages/conditions/src/evaluate.test.ts
@@ -8,6 +8,7 @@ import {
 } from "./evaluate";
 import {
   type CompareOp,
+  COMPARE_OPS,
   type ConditionNode,
   conditionNodeSchema,
   emptyCondition,
@@ -143,6 +144,19 @@ describe("compare operators", () => {
       }),
     ).toBeNull();
   });
+
+  // Blankness is `is_empty`, so no operator turns `""` into a real constraint.
+  // An invariant over the whole operator union: a per-operator exception like
+  // the `eq`/`neq` one this replaced cannot be reintroduced silently, and a new
+  // `CompareOp` is covered the moment it is added.
+  test.each([...COMPARE_OPS])(
+    "pruneIncomplete drops a blank `%s` comparison",
+    (op) => {
+      expect(
+        pruneIncomplete(compare({ type: "property", propertyId: "x" }, op, "")),
+      ).toBeNull();
+    },
+  );
 });
 
 describe("predicate operators", () => {

--- a/packages/conditions/src/evaluate.test.ts
+++ b/packages/conditions/src/evaluate.test.ts
@@ -117,11 +117,12 @@ describe("compare operators", () => {
       op: "is_empty",
     };
 
-    // Incomplete leaves prune away; complete ones (incl. `eq ""`, `is_empty`) stay.
+    // Incomplete leaves prune away, including `eq ""` — a seeded row whose
+    // value was never entered. Complete ones (incl. `is_empty`) stay.
     expect(pruneIncomplete(incompleteGt)).toBeNull();
     expect(pruneIncomplete(incompleteContains)).toBeNull();
+    expect(pruneIncomplete(eqEmpty)).toBeNull();
     expect(pruneIncomplete(real)).toEqual(real);
-    expect(pruneIncomplete(eqEmpty)).toEqual(eqEmpty);
     expect(pruneIncomplete(isEmpty)).toEqual(isEmpty);
 
     // A group keeps real children and drops incomplete ones...

--- a/packages/conditions/src/evaluate.ts
+++ b/packages/conditions/src/evaluate.ts
@@ -222,18 +222,16 @@ const matchesContains = (
 };
 
 /**
- * Whether a leaf is an incomplete filter — an ordered comparison or a
- * value-bearing predicate whose value has not been entered yet. `eq`/`neq`
- * against `""` and `is_empty`/`is_not_empty`/`is_truthy` are complete.
+ * Whether a leaf is an incomplete filter — a comparison or value-bearing
+ * predicate whose value has not been entered yet. `is_empty`/`is_not_empty`/
+ * `is_truthy` carry no value by design and are complete.
+ *
+ * A comparison against `""` is incomplete, `eq`/`neq` included: it is the row a
+ * picker seeds, and blankness is expressed by `is_empty`.
  */
 const isIncompleteLeaf = (node: CompareNode | PredicateNode): boolean => {
   if (node.type === "compare") {
-    return (
-      node.op !== "eq" &&
-      node.op !== "neq" &&
-      node.right.type === "literal" &&
-      String(node.right.value) === ""
-    );
+    return node.right.type === "literal" && String(node.right.value) === "";
   }
   return (
     node.op !== "is_empty" &&

--- a/packages/ui/src/components/popover.tsx
+++ b/packages/ui/src/components/popover.tsx
@@ -55,9 +55,8 @@ function PopoverPopup({
         alignOffset={alignOffset}
         anchor={anchor}
         className={cn(
-          "h-(--positioner-height) w-(--positioner-width) max-w-(--available-width) transition-[top,left,right,bottom,transform] data-instant:transition-none",
+          "h-(--positioner-height) w-(--positioner-width) max-w-(--available-width)",
           OVERLAY_LAYER_CLASS_NAMES[layer],
-          anchor && "transition-none",
         )}
         data-slot="popover-positioner"
         side={side}


### PR DESCRIPTION
Fixes a UX problem I noticed when adding a filter to a view.

Clicking "Filter" and choosing a field created the filter immediately and rendered a chip for it with no value. The user would then have to click on the chip to open the value selection overlay. This not only caused unnecessary additional clicks (bad UX), but also applied an empty filter to the table for custom values, causing the table's values to all be filtered out.

## Technical details on why an empty filter hid rows

`pruneIncomplete` exists to drop a filter whose value has not been entered yet,
so an in-progress filter constrains nothing. It made an exception for `eq` and
`neq` against an empty value and treated those as finished.

`eq` is the first operator offered for text, single-select, int, and date, so
those field types produced exactly the filter the exception let through. For a
`property` operand that compiled to `EXISTS (… value = '')`, which matches
almost nothing, so the view emptied out. Builtin `status` and `priority` avoided
it only because `compileBuiltinCompare` drops `eq ""` separately, which is why
the problem showed up on custom properties and not on those two.

## Changes

**A blank comparison now counts as incomplete instead of "Empty"**. No
surface lets a user express "equals the empty string" on purpose: blankness is
`is_empty`. A blank comparison is therefore only ever the seeded state of a
filter someone is still building.

The fix is in `pruneIncomplete` rather than in the SQL compiler, so the SQL
compiler, `applyFilters`, and `evaluateGatingCondition` all agree. Fixing only
the compiler would have left the in-memory evaluator treating the same node as a
real constraint, which is the divergence `pruneIncomplete`'s contract warns
about and which changes results under `or`.

**A new filter chip opens its editor on creation**, which advanced-filter chips
already did. Picking a field and setting its value is still two clicks, but the
value editor is in front of you rather than behind a chip you have to discover.

## Tests

An invariant over every `FieldValueType`: the row `leafFromField` seeds must
prune away. The cases are derived from a map that is total over the union, so a
new value type cannot land untested, and reordering an operator list so a
different default lands first fails the test.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Newly added filters now open their editor immediately, making filter setup faster and more intuitive.

- **Bug Fixes**
  - Empty-value comparisons are now correctly treated as incomplete and removed when appropriate.
  - Improved handling of incomplete seeded filter values.

- **Style**
  - Popover positioning no longer applies unwanted transition effects when anchored.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->