### PR TITLE
fix: make native document extraction durable

### DIFF
--- a/apps/api/drizzle/20260805120000_document_processing_native_extraction/migration.sql
+++ b/apps/api/drizzle/20260805120000_document_processing_native_extraction/migration.sql
@@ -1,0 +1,36 @@
+SET lock_timeout = '1s';--> statement-breakpoint
+SET statement_timeout = '5s';--> statement-breakpoint
+
+ALTER TABLE "document_processing_runs"
+  DROP CONSTRAINT "document_processing_runs_kind_values_check";--> statement-breakpoint
+ALTER TABLE "document_processing_runs"
+  ADD CONSTRAINT "document_processing_runs_kind_values_check"
+  CHECK ("kind" IN ('native-extraction', 'ocr')) NOT VALID;--> statement-breakpoint
+
+-- Drizzle wraps migrations in a transaction. Validate outside it so existing
+-- document-processing rows do not hold a long blocking lock during rollout.
+-- squawk-ignore transaction-nesting
+COMMIT;
+--> statement-breakpoint
+SET statement_timeout = 0;
+--> statement-breakpoint
+SET lock_timeout = 0;
+--> statement-breakpoint
+ALTER TABLE "document_processing_runs"
+  VALIDATE CONSTRAINT "document_processing_runs_kind_values_check";
+--> statement-breakpoint
+-- stella-migration-safety: reviewed destructive-change - replaces the PDF-only recovery index with the broader native-extraction recovery index.
+DROP INDEX CONCURRENTLY IF EXISTS "fields_document_processing_pdf_candidate_idx";
+--> statement-breakpoint
+-- squawk-ignore prefer-robust-stmts -- IF NOT EXISTS would retain an INVALID index left by an interrupted concurrent build
+CREATE INDEX CONCURRENTLY "fields_document_processing_native_candidate_idx"
+  ON "fields" ("id", "workspace_id", "entity_version_id")
+  WHERE "content"->>'type' = 'file'
+    AND "content"->>'encrypted' = 'false';
+--> statement-breakpoint
+SET statement_timeout = '5s';
+--> statement-breakpoint
+SET lock_timeout = '1s';
+--> statement-breakpoint
+-- squawk-ignore transaction-nesting, ban-uncommitted-transaction
+BEGIN;

--- a/apps/api/drizzle/20260805120000_document_processing_native_extraction/migration.sql
+++ b/apps/api/drizzle/20260805120000_document_processing_native_extraction/migration.sql
@@ -19,14 +19,14 @@ SET lock_timeout = 0;
 ALTER TABLE "document_processing_runs"
   VALIDATE CONSTRAINT "document_processing_runs_kind_values_check";
 --> statement-breakpoint
--- stella-migration-safety: reviewed destructive-change - replaces the PDF-only recovery index with the broader native-extraction recovery index.
-DROP INDEX CONCURRENTLY IF EXISTS "fields_document_processing_pdf_candidate_idx";
---> statement-breakpoint
 -- squawk-ignore prefer-robust-stmts -- IF NOT EXISTS would retain an INVALID index left by an interrupted concurrent build
 CREATE INDEX CONCURRENTLY "fields_document_processing_native_candidate_idx"
   ON "fields" ("id", "workspace_id", "entity_version_id")
   WHERE "content"->>'type' = 'file'
     AND "content"->>'encrypted' = 'false';
+--> statement-breakpoint
+-- stella-migration-safety: reviewed destructive-change - replaces the PDF-only recovery index with the broader native-extraction recovery index.
+DROP INDEX CONCURRENTLY IF EXISTS "fields_document_processing_pdf_candidate_idx";
 --> statement-breakpoint
 SET statement_timeout = '5s';
 --> statement-breakpoint

--- a/apps/api/src/db/schema/document-processing.ts
+++ b/apps/api/src/db/schema/document-processing.ts
@@ -18,7 +18,7 @@ import { entities, entityVersions, fields } from "./entities";
  * than an OCR boolean: future processors can share the immutable-source and
  * durable-retry contract without a schema rewrite.
  */
-export const DOCUMENT_PROCESSING_KINDS = ["ocr"] as const;
+export const DOCUMENT_PROCESSING_KINDS = ["native-extraction", "ocr"] as const;
 export type DocumentProcessingKind = (typeof DOCUMENT_PROCESSING_KINDS)[number];
 
 /** Durable lifecycle for one immutable processing request. */
@@ -186,7 +186,7 @@ export const documentProcessingRuns = p.pgTable(
       .onDelete("cascade"),
     p.check(
       "document_processing_runs_kind_values_check",
-      sql`${table.kind} IN ('ocr')`,
+      sql`${table.kind} IN ('native-extraction', 'ocr')`,
     ),
     p.check(
       "document_processing_runs_status_values_check",

--- a/apps/api/src/db/schema/entities.ts
+++ b/apps/api/src/db/schema/entities.ts
@@ -902,11 +902,10 @@ export const fields = p.pgTable(
     // Bounded document-processing recovery has a global ID cursor, so its
     // partial candidate index must start with that cursor column.
     p
-      .index("fields_document_processing_pdf_candidate_idx")
+      .index("fields_document_processing_native_candidate_idx")
       .on(table.id, table.workspaceId, table.entityVersionId)
       .where(
         sql`${table.content}->>'type' = 'file'
-          AND ${table.content}->>'mimeType' = 'application/pdf'
           AND ${table.content}->>'encrypted' = 'false'`,
       ),
     p

--- a/apps/api/src/lib/document-processing-contract.ts
+++ b/apps/api/src/lib/document-processing-contract.ts
@@ -1,6 +1,9 @@
 /** Persisted-output contract: v2 adds page geometry and a searchable PDF. */
 export const DOCUMENT_OCR_PROCESSOR_VERSION = 2;
 
+/** Persisted-output contract for sandboxed native text extraction. */
+export const DOCUMENT_NATIVE_EXTRACTION_PROCESSOR_VERSION = 1;
+
 export type DocumentOcrLine = {
   box: readonly [number, number, number, number];
   confidence: number;

--- a/apps/api/src/lib/document-processing-queue.test.ts
+++ b/apps/api/src/lib/document-processing-queue.test.ts
@@ -149,21 +149,6 @@ describe("OCR derivative durability", () => {
       }),
     ).toBe(false);
   });
-
-  test("retries derivative failures within the bounded attempt budget", () => {
-    expect(
-      isRetryableOcrDerivativeFailure({
-        attemptCount: 1,
-        errorCode: "searchable_pdf_failed",
-      }),
-    ).toBe(true);
-    expect(
-      isRetryableOcrDerivativeFailure({
-        attemptCount: 5,
-        errorCode: "searchable_pdf_failed",
-      }),
-    ).toBe(false);
-  });
 });
 
 describe("lease heartbeat", () => {
@@ -445,6 +430,45 @@ describe("isCurrentNativeExtractionSource", () => {
         content: { ...selectedFileContent, sha256Hex: "c".repeat(64) },
       }),
     ).toBe(false);
+  });
+
+  test("rejects every stale or ineligible native source state", () => {
+    const rejectionCases = {
+      deletedVersion: {
+        ...docxSource,
+        versionDeletedAt: new Date(),
+      },
+      encryptedFile: {
+        ...docxSource,
+        content: { ...selectedFileContent, encrypted: true },
+      },
+      mismatchedCurrentVersion: {
+        ...docxSource,
+        currentVersionId: toSafeId<"entityVersion">("other_version"),
+      },
+      mismatchedFieldVersion: {
+        ...docxSource,
+        fieldEntityVersionId: toSafeId<"entityVersion">("other_version"),
+      },
+      readOnlyEntity: {
+        ...docxSource,
+        entityReadOnly: true,
+      },
+    } satisfies Record<
+      string,
+      Parameters<typeof isCurrentNativeExtractionSource>[1]
+    >;
+
+    expect(Object.keys(rejectionCases).sort()).toEqual([
+      "deletedVersion",
+      "encryptedFile",
+      "mismatchedCurrentVersion",
+      "mismatchedFieldVersion",
+      "readOnlyEntity",
+    ]);
+    for (const candidate of Object.values(rejectionCases)) {
+      expect(isCurrentNativeExtractionSource(docxRun, candidate)).toBe(false);
+    }
   });
 });
 

--- a/apps/api/src/lib/document-processing-queue.test.ts
+++ b/apps/api/src/lib/document-processing-queue.test.ts
@@ -9,18 +9,16 @@ import {
   classifyOcrWorkspaceDispatch,
   createDocumentProcessingLeaseRenewal,
   DocumentProcessingJobError,
-  indexOcrProjection,
-  isAutomaticOcrRepairCandidate,
+  indexDocumentProjection,
+  isCurrentNativeExtractionSource,
   isCurrentOcrSource,
   isPreservableAutomaticProjection,
-  isReversibleAutomaticOcrCancellation,
   isRetryableAutomaticOcrFailure,
   isRetryableOcrDerivativeFailure,
   isRetryableSearchIndexFailure,
   mapWithConcurrency,
   ownsPromotedManualOcrClaim,
   readRepairScanCursor,
-  revivableAutomaticOcrCancellationCodes,
   runDocumentProcessingReconciliationPhases,
   runSearchIndexReplayAttempt,
   settleDocumentProcessingAttemptError,
@@ -105,7 +103,10 @@ describe("OCR derivative durability", () => {
     const derivative = processSource.indexOf(
       "await writeOcrSearchablePdfDerivative",
     );
-    const searchIndex = processSource.indexOf("await indexOcrProjection");
+    const searchIndex = processSource.indexOf(
+      "await indexDocumentProjection",
+      derivative,
+    );
 
     expect(persistence).toBeGreaterThan(-1);
     expect(derivative).toBeGreaterThan(persistence);
@@ -246,6 +247,33 @@ describe("repair cursor Redis deadlines", () => {
 });
 
 describe("reconciliation fault isolation", () => {
+  test("dispatches every durable processing kind and repairs native gaps", () => {
+    const dispatchStart = queueSource.indexOf(
+      "export const dispatchQueuedDocumentProcessingRuns",
+    );
+    const dispatchEnd = queueSource.indexOf(
+      "const dispatchScheduledDocumentProcessingRetries",
+      dispatchStart,
+    );
+    const dispatchSource = queueSource.slice(dispatchStart, dispatchEnd);
+    const repairStart = queueSource.indexOf(
+      "const recoverMissingNativeExtractionRuns",
+    );
+    const repairEnd = queueSource.indexOf(
+      "const updateQueuedRunSchedule",
+      repairStart,
+    );
+    const repairSource = queueSource.slice(repairStart, repairEnd);
+
+    expect(dispatchStart).toBeGreaterThan(-1);
+    expect(dispatchSource).not.toContain(
+      'eq(documentProcessingRuns.kind, "ocr")',
+    );
+    expect(repairStart).toBeGreaterThan(-1);
+    expect(repairSource).toContain("persistMissingNativeExtractionRuns");
+    expect(repairSource).not.toContain("organizationSettings");
+  });
+
   test("prioritizes never-dispatched OCR runs ahead of visibility retries", () => {
     const dispatchStart = queueSource.indexOf(
       "export const dispatchQueuedDocumentProcessingRuns",
@@ -391,6 +419,35 @@ describe("isCurrentOcrSource", () => {
   });
 });
 
+describe("isCurrentNativeExtractionSource", () => {
+  const docxRun = {
+    entityVersionId: run.entityVersionId,
+    fieldId: selectedSourceField.id,
+    sourceFileId: selectedFileContent.id,
+    sourceSha256Hex: selectedFileContent.sha256Hex,
+  };
+  const docxSource = {
+    content: selectedFileContent,
+    currentVersionId: run.entityVersionId,
+    entityReadOnly: false,
+    fieldEntityVersionId: run.entityVersionId,
+    versionDeletedAt: null,
+  };
+
+  test("accepts the exact live immutable DOCX source", () => {
+    expect(isCurrentNativeExtractionSource(docxRun, docxSource)).toBe(true);
+  });
+
+  test("rejects a replaced DOCX source", () => {
+    expect(
+      isCurrentNativeExtractionSource(docxRun, {
+        ...docxSource,
+        content: { ...selectedFileContent, sha256Hex: "c".repeat(64) },
+      }),
+    ).toBe(false);
+  });
+});
+
 describe("classifyOcrProjectionSource", () => {
   test("preserves an inactive workspace cancellation for recovery", () => {
     expect(
@@ -460,25 +517,6 @@ describe("classifyOcrWorkspaceDispatch", () => {
   });
 });
 
-describe("isAutomaticOcrRepairCandidate", () => {
-  test("only repairs an unencrypted PDF source", () => {
-    expect(isAutomaticOcrRepairCandidate(fileContent)).toBe(true);
-    expect(
-      isAutomaticOcrRepairCandidate({
-        ...fileContent,
-        encrypted: true,
-      }),
-    ).toBe(false);
-    expect(
-      isAutomaticOcrRepairCandidate({
-        ...fileContent,
-        mimeType:
-          "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-      }),
-    ).toBe(false);
-  });
-});
-
 describe("requiresOcrPolicy", () => {
   test("applies opt-out to every automatic request source", () => {
     expect(requiresOcrPolicy("upload")).toBe(true);
@@ -524,44 +562,6 @@ describe("ownsPromotedManualOcrClaim", () => {
         false,
       );
     }
-  });
-});
-
-describe("isReversibleAutomaticOcrCancellation", () => {
-  test("revives policy and workspace cancellations, but not source cancellation", () => {
-    expect(
-      isReversibleAutomaticOcrCancellation({
-        errorCode: "policy_disabled",
-        status: "cancelled",
-      }),
-    ).toBe(true);
-    expect(
-      isReversibleAutomaticOcrCancellation({
-        errorCode: "workspace_unavailable",
-        status: "cancelled",
-      }),
-    ).toBe(true);
-    expect(
-      isReversibleAutomaticOcrCancellation({
-        errorCode: "source_superseded",
-        status: "cancelled",
-      }),
-    ).toBe(false);
-  });
-});
-
-describe("revivableAutomaticOcrCancellationCodes", () => {
-  test("revives a superseded run only after the source is locked and rechecked", () => {
-    expect(
-      revivableAutomaticOcrCancellationCodes({
-        hasLockedExactSource: false,
-      }),
-    ).not.toContain("source_superseded");
-    expect(
-      revivableAutomaticOcrCancellationCodes({
-        hasLockedExactSource: true,
-      }),
-    ).toContain("source_superseded");
   });
 });
 
@@ -637,7 +637,7 @@ describe("automatic projection ownership", () => {
 
 describe("bounded search-index replay", () => {
   test("classifies a stalled initial index write for durable replay", async () => {
-    const rejection: unknown = await indexOcrProjection({
+    const rejection: unknown = await indexDocumentProjection({
       indexEntity: async () => await new Promise<void>(() => {}),
       timeoutMs: 5,
     }).then(
@@ -653,10 +653,10 @@ describe("bounded search-index replay", () => {
     expect(isRetryableSearchIndexFailure(rejection.code)).toBe(true);
     expect(rejection.cause).toBeInstanceOf(TimeoutError);
     expect(rejection.cause).toMatchObject({
-      label: "document OCR initial search index",
+      label: "document processing initial search index",
       timeoutMs: 5,
     });
-    expect(queueSource).toContain("await indexOcrProjection({");
+    expect(queueSource).toContain("await indexDocumentProjection({");
   });
 
   test("recovers from the current projection rather than the failed run source", () => {
@@ -871,24 +871,21 @@ describe("automatic OCR failure recovery", () => {
 });
 
 describe("unconfigured worker lifecycle", () => {
-  test("keeps the entrypoint dormant without constructing a queue consumer", () => {
-    const unconfiguredBranchStart = queueSource.indexOf(
-      "if (!isDocumentOcrProviderConfigured())",
+  test("starts native processing while publishing OCR readiness only when configured", () => {
+    const providerCheck = queueSource.indexOf(
+      "const ocrProviderConfigured = isDocumentOcrProviderConfigured()",
     );
     const consumerStart = queueSource.indexOf(
       "const worker = new Worker<DocumentProcessingJobData>",
-      unconfiguredBranchStart,
     );
-    const unconfiguredBranch = queueSource.slice(
-      unconfiguredBranchStart,
+    const readinessGuard = queueSource.indexOf(
+      "if (ocrProviderConfigured)",
       consumerStart,
     );
 
-    expect(unconfiguredBranchStart).toBeGreaterThan(-1);
-    expect(consumerStart).toBeGreaterThan(unconfiguredBranchStart);
-    expect(unconfiguredBranch).toContain("setInterval(");
-    expect(unconfiguredBranch).toContain("clearInterval(keepAliveInterval)");
-    expect(unconfiguredBranch).not.toContain("new Worker");
+    expect(providerCheck).toBeGreaterThan(-1);
+    expect(consumerStart).toBeGreaterThan(providerCheck);
+    expect(readinessGuard).toBeGreaterThan(consumerStart);
   });
 });
 

--- a/apps/api/src/lib/document-processing-queue.ts
+++ b/apps/api/src/lib/document-processing-queue.ts
@@ -36,7 +36,7 @@ import { encryptContent } from "@/api/lib/content-encryption";
 import { detached } from "@/api/lib/detached";
 import type { DocumentOcrPayload } from "@/api/lib/document-processing-contract";
 import {
-  DOCUMENT_OCR_PROCESSOR_VERSION,
+  DOCUMENT_NATIVE_EXTRACTION_PROCESSOR_VERSION,
   serializeDocumentOcrPayload,
 } from "@/api/lib/document-processing-contract";
 import {
@@ -60,6 +60,10 @@ import {
 } from "@/api/lib/redis-client";
 import { getS3 } from "@/api/lib/s3";
 import { presignDownloadUrl } from "@/api/lib/s3-presign";
+import {
+  executeNativeExtraction,
+  requiresDurableNativeExtraction,
+} from "@/api/lib/search/process-extraction";
 import { getSearchProvider } from "@/api/lib/search/provider";
 import { broadcast } from "@/api/lib/sse";
 import { withTimeout } from "@/api/lib/with-timeout";
@@ -69,7 +73,6 @@ import { toSafeId } from "@/api/types";
 const OCR_SOURCE_URL_TTL_SECONDS = 35 * 60;
 const WORKER_CONCURRENCY = 2;
 const RECONCILE_INTERVAL_MS = 30_000;
-const DORMANT_WORKER_KEEP_ALIVE_MS = 60 * 60_000;
 const RECONCILE_BATCH_SIZE = 100;
 const ENQUEUE_VISIBILITY_TIMEOUT_MS = 5 * 60 * 1000;
 const ENQUEUE_FAILURE_RETRY_MS = 30_000;
@@ -111,13 +114,9 @@ const RETRYABLE_AUTOMATIC_OCR_FAILURE_CODES = [
   "processing_failed",
   "request_failed",
 ] as const;
-const REVERSIBLE_AUTOMATIC_OCR_CANCELLATION_CODES = [
-  "policy_disabled",
-  "workspace_unavailable",
-] as const;
 const SOURCE_SUPERSEDED_CANCELLATION_CODE = "source_superseded";
 
-type CurrentOcrSource = {
+type CurrentDocumentSource = {
   content: FieldContent;
   currentVersionId: SafeId<"entityVersion"> | null;
   entityReadOnly: boolean;
@@ -147,7 +146,7 @@ export class DocumentProcessingJobError extends TaggedError(
   cause?: unknown;
 }> {}
 
-export const indexOcrProjection = async ({
+export const indexDocumentProjection = async ({
   indexEntity,
   timeoutMs = SEARCH_INDEX_ATTEMPT_TIMEOUT_MS,
 }: {
@@ -157,7 +156,7 @@ export const indexOcrProjection = async ({
   const indexed = await Result.tryPromise({
     try: async () =>
       await withTimeout(indexEntity, {
-        label: "document OCR initial search index",
+        label: "document processing initial search index",
         timeoutMs,
       }),
     catch: (cause) => cause,
@@ -165,7 +164,7 @@ export const indexOcrProjection = async ({
   if (Result.isError(indexed)) {
     throw new DocumentProcessingJobError({
       code: SEARCH_INDEX_FAILURE_CODE,
-      message: "OCR text was stored but search indexing failed",
+      message: "Document text was stored but search indexing failed",
       cause: indexed.error,
     });
   }
@@ -231,7 +230,7 @@ export const isCurrentOcrSource = ({
     sourceFileId: string;
     sourceSha256Hex: string;
   };
-  source: CurrentOcrSource | null;
+  source: CurrentDocumentSource | null;
 }): boolean =>
   source !== null &&
   !source.entityReadOnly &&
@@ -243,6 +242,27 @@ export const isCurrentOcrSource = ({
   source.content.sha256Hex === run.sourceSha256Hex &&
   source.content.mimeType === PDF_MIME_TYPE &&
   !source.content.encrypted;
+
+export const isCurrentNativeExtractionSource = (
+  run: {
+    entityVersionId: SafeId<"entityVersion">;
+    fieldId: SafeId<"field">;
+    sourceFileId: string;
+    sourceSha256Hex: string;
+  },
+  source: CurrentDocumentSource | null,
+): source is CurrentDocumentSource & {
+  content: Extract<FieldContent, { type: "file" }>;
+} =>
+  source !== null &&
+  !source.entityReadOnly &&
+  source.versionDeletedAt === null &&
+  source.currentVersionId === run.entityVersionId &&
+  source.fieldEntityVersionId === run.entityVersionId &&
+  source.content.type === "file" &&
+  source.content.id === run.sourceFileId &&
+  source.content.sha256Hex === run.sourceSha256Hex &&
+  requiresDurableNativeExtraction(source.content);
 
 export const isPreservableAutomaticProjection = ({
   currentEntityVersionId,
@@ -304,7 +324,7 @@ export const classifyOcrProjectionSource = ({
     sourceFileId: string;
     sourceSha256Hex: string;
   };
-  source: CurrentOcrSource | null;
+  source: CurrentDocumentSource | null;
   workspaceStatus: (typeof workspaces.$inferSelect)["status"] | undefined;
 }): "current" | "source_superseded" | "workspace_unavailable" => {
   if (workspaceStatus !== "active") {
@@ -328,41 +348,6 @@ export const classifyOcrWorkspaceDispatch = ({
   }
   return "workspace_unavailable";
 };
-
-export const isAutomaticOcrRepairCandidate = (
-  content: FieldContent,
-): content is Extract<FieldContent, { type: "file" }> =>
-  content.type === "file" &&
-  content.mimeType === PDF_MIME_TYPE &&
-  !content.encrypted;
-
-export const isReversibleAutomaticOcrCancellation = ({
-  errorCode,
-  status,
-}: {
-  errorCode: string | null;
-  status: (typeof documentProcessingRuns.$inferSelect)["status"];
-}): boolean => {
-  if (status !== "cancelled") {
-    return false;
-  }
-  return (
-    errorCode === REVERSIBLE_AUTOMATIC_OCR_CANCELLATION_CODES[0] ||
-    errorCode === REVERSIBLE_AUTOMATIC_OCR_CANCELLATION_CODES[1]
-  );
-};
-
-export const revivableAutomaticOcrCancellationCodes = ({
-  hasLockedExactSource,
-}: {
-  hasLockedExactSource: boolean;
-}): readonly string[] =>
-  hasLockedExactSource
-    ? [
-        ...REVERSIBLE_AUTOMATIC_OCR_CANCELLATION_CODES,
-        SOURCE_SUPERSEDED_CANCELLATION_CODE,
-      ]
-    : REVERSIBLE_AUTOMATIC_OCR_CANCELLATION_CODES;
 
 const markRunCancelled = async (
   runId: SafeId<"documentProcessingRun">,
@@ -493,7 +478,7 @@ const startDocumentProcessingLeaseHeartbeat = ({
   };
 };
 
-const readCurrentOcrSource = async ({
+const readCurrentDocumentSource = async ({
   entityId,
   fieldId,
   organizationId,
@@ -503,7 +488,7 @@ const readCurrentOcrSource = async ({
   fieldId: SafeId<"field">;
   organizationId: SafeId<"organization">;
   workspaceId: SafeId<"workspace">;
-}): Promise<CurrentOcrSource | null> => {
+}): Promise<CurrentDocumentSource | null> => {
   const rows = await rootDb
     .select({
       content: fields.content,
@@ -839,6 +824,43 @@ export const settleDocumentProcessingAttemptError = async ({
   return "failed";
 };
 
+const completeDocumentProcessingRun = async ({
+  claimToken,
+  run,
+}: {
+  claimToken: string;
+  run: typeof documentProcessingRuns.$inferSelect;
+}): Promise<boolean> => {
+  const completed = await rootDb
+    .update(documentProcessingRuns)
+    .set({
+      claimedAt: null,
+      claimedBy: null,
+      errorAt: null,
+      errorCode: null,
+      finishedAt: new Date(),
+      nextAttemptAt: null,
+      status: "succeeded",
+      updatedAt: new Date(),
+    })
+    .where(
+      and(
+        eq(documentProcessingRuns.id, run.id),
+        eq(documentProcessingRuns.status, "running"),
+        eq(documentProcessingRuns.claimedBy, claimToken),
+      ),
+    )
+    .returning({ id: documentProcessingRuns.id });
+  if (!completed.at(0)) {
+    return false;
+  }
+  broadcast(run.workspaceId, {
+    type: "invalidate-query",
+    data: ["entities", run.workspaceId],
+  });
+  return true;
+};
+
 export const processDocumentProcessingRun = async (
   runId: SafeId<"documentProcessingRun">,
   lifecycleSignal: AbortSignal,
@@ -850,6 +872,7 @@ export const processDocumentProcessingRun = async (
       .select({
         entityId: documentProcessingRuns.entityId,
         entityVersionId: documentProcessingRuns.entityVersionId,
+        kind: documentProcessingRuns.kind,
         organizationId: documentProcessingRuns.organizationId,
         requestSource: documentProcessingRuns.requestSource,
         workspaceId: documentProcessingRuns.workspaceId,
@@ -958,6 +981,7 @@ export const processDocumentProcessingRun = async (
       .limit(1)
       .for("update");
     if (
+      runContext.kind === "ocr" &&
       requiresOcrPolicy(runContext.requestSource) &&
       settingsRows.at(0)?.documentProcessingMode !== "searchable-text"
     ) {
@@ -1026,6 +1050,7 @@ export const processDocumentProcessingRun = async (
         .where(eq(documentProcessingRuns.id, run.id))
         .limit(1);
       if (
+        run.kind === "ocr" &&
         requiresOcrPolicy(
           currentRuns.at(0)?.requestSource ?? run.requestSource,
         ) &&
@@ -1059,12 +1084,47 @@ export const processDocumentProcessingRun = async (
         }
       }
 
-      const source = await readCurrentOcrSource({
+      const source = await readCurrentDocumentSource({
         entityId: run.entityId,
         fieldId: run.fieldId,
         organizationId: run.organizationId,
         workspaceId: run.workspaceId,
       });
+      switch (run.kind) {
+        case "native-extraction": {
+          if (!isCurrentNativeExtractionSource(run, source)) {
+            await markRunCancelled(run.id, claimToken, "source_superseded");
+            return;
+          }
+          await executeNativeExtraction({
+            fileField: source.content,
+            lifecycleSignal,
+            run,
+          });
+          lifecycleSignal.throwIfAborted();
+          const persistedSource = await readCurrentDocumentSource({
+            entityId: run.entityId,
+            fieldId: run.fieldId,
+            organizationId: run.organizationId,
+            workspaceId: run.workspaceId,
+          });
+          if (!isCurrentNativeExtractionSource(run, persistedSource)) {
+            await markRunCancelled(run.id, claimToken, "source_superseded");
+            return;
+          }
+          await indexDocumentProjection({
+            indexEntity: async () =>
+              await getSearchProvider().indexEntity(run.entityId),
+          });
+          lifecycleSignal.throwIfAborted();
+          await completeDocumentProcessingRun({ claimToken, run });
+          return;
+        }
+        case "ocr":
+          break;
+        default:
+          run.kind satisfies never;
+      }
       if (!isCurrentOcrSource({ run, source })) {
         await markRunCancelled(run.id, claimToken, "source_superseded");
         return;
@@ -1140,39 +1200,13 @@ export const processDocumentProcessingRun = async (
         });
       }
 
-      await indexOcrProjection({
+      await indexDocumentProjection({
         indexEntity: async () =>
           await getSearchProvider().indexEntity(run.entityId),
       });
       lifecycleSignal.throwIfAborted();
 
-      const completed = await rootDb
-        .update(documentProcessingRuns)
-        .set({
-          claimedAt: null,
-          claimedBy: null,
-          errorAt: null,
-          errorCode: null,
-          finishedAt: new Date(),
-          status: "succeeded",
-          updatedAt: new Date(),
-        })
-        .where(
-          and(
-            eq(documentProcessingRuns.id, run.id),
-            eq(documentProcessingRuns.status, "running"),
-            eq(documentProcessingRuns.claimedBy, claimToken),
-          ),
-        )
-        .returning({ id: documentProcessingRuns.id });
-      if (!completed.at(0)) {
-        return;
-      }
-
-      broadcast(run.workspaceId, {
-        type: "invalidate-query",
-        data: ["entities", run.workspaceId],
-      });
+      await completeDocumentProcessingRun({ claimToken, run });
     },
     catch: (cause) => cause,
   });
@@ -1345,7 +1379,7 @@ const earlierFileFields = alias(
   "document_processing_earlier_file_fields",
 );
 
-type AutomaticOcrCandidate = {
+type DocumentProcessingCandidate = {
   content: Extract<FieldContent, { type: "file" }>;
   entityId: SafeId<"entity">;
   entityVersionId: SafeId<"entityVersion">;
@@ -1406,8 +1440,8 @@ export const writeRepairScanCursor = async ({
     ),
   ) === 1;
 
-const isSameAutomaticOcrSource = (
-  candidate: AutomaticOcrCandidate,
+const isSameNativeExtractionSource = (
+  candidate: DocumentProcessingCandidate,
   field: {
     content: FieldContent;
     entityVersionId: SafeId<"entityVersion">;
@@ -1415,15 +1449,16 @@ const isSameAutomaticOcrSource = (
     workspaceId: SafeId<"workspace">;
   },
 ): boolean =>
-  isAutomaticOcrRepairCandidate(field.content) &&
+  field.content.type === "file" &&
+  requiresDurableNativeExtraction(field.content) &&
   field.id === candidate.fieldId &&
   field.workspaceId === candidate.workspaceId &&
   field.entityVersionId === candidate.entityVersionId &&
   field.content.id === candidate.content.id &&
   field.content.sha256Hex === candidate.content.sha256Hex;
 
-const persistRepairableOcrRuns = async (
-  candidates: AutomaticOcrCandidate[],
+const persistMissingNativeExtractionRuns = async (
+  candidates: DocumentProcessingCandidate[],
 ): Promise<SafeId<"documentProcessingRun">[]> => {
   if (candidates.length === 0) {
     return [];
@@ -1475,135 +1510,118 @@ const persistRepairableOcrRuns = async (
             candidates.map((candidate) => candidate.workspaceId),
           ),
         ),
-      );
+      )
+      .limit(RECONCILE_BATCH_SIZE);
     const currentFieldById = new Map(
       currentFields.map((field) => [field.id, field]),
     );
-    const currentCandidates = candidates.filter((candidate) => {
+    const currentProjections = await tx
+      .select({
+        entityId: extractedContent.entityId,
+        sourceEntityVersionId: extractedContent.sourceEntityVersionId,
+        sourceFieldId: extractedContent.sourceFieldId,
+        sourceFileId: extractedContent.sourceFileId,
+        sourceSha256Hex: extractedContent.sourceSha256Hex,
+      })
+      .from(extractedContent)
+      .where(
+        and(
+          inArray(
+            extractedContent.organizationId,
+            candidates.map((candidate) => candidate.organizationId),
+          ),
+          inArray(
+            extractedContent.workspaceId,
+            candidates.map((candidate) => candidate.workspaceId),
+          ),
+          inArray(
+            extractedContent.entityId,
+            candidates.map(({ entityId }) => entityId),
+          ),
+        ),
+      )
+      .limit(RECONCILE_BATCH_SIZE);
+    const currentProjectionByEntityId = new Map(
+      currentProjections.map((projection) => [projection.entityId, projection]),
+    );
+    const values = candidates.flatMap((candidate) => {
       const entity = lockedEntityById.get(candidate.entityId);
       const field = currentFieldById.get(candidate.fieldId);
-      return (
-        entity?.currentVersionId === candidate.entityVersionId &&
-        entity.workspaceId === candidate.workspaceId &&
-        !entity.readOnly &&
-        field !== undefined &&
-        isSameAutomaticOcrSource(candidate, field)
-      );
-    });
-    if (currentCandidates.length === 0) {
-      return [];
-    }
-
-    const projectionScope = or(
-      ...currentCandidates.map((candidate) =>
-        and(
-          eq(extractedContent.organizationId, candidate.organizationId),
-          eq(extractedContent.workspaceId, candidate.workspaceId),
-          eq(extractedContent.entityId, candidate.entityId),
-        ),
-      ),
-    );
-    const projectedRows = projectionScope
-      ? await tx
-          .select({
-            entityId: extractedContent.entityId,
-            sourceEntityVersionId: extractedContent.sourceEntityVersionId,
-            sourceFieldId: extractedContent.sourceFieldId,
-            sourceFileId: extractedContent.sourceFileId,
-            sourceSha256Hex: extractedContent.sourceSha256Hex,
-          })
-          .from(extractedContent)
-          .where(projectionScope)
-      : [];
-    const projectionsByEntityId = new Map(
-      projectedRows.map((projection) => [projection.entityId, projection]),
-    );
-    const projectionSourceFieldIds = projectedRows.flatMap(
-      ({ sourceFieldId }) => (sourceFieldId === null ? [] : [sourceFieldId]),
-    );
-    const projectionSourceFields =
-      projectionSourceFieldIds.length === 0
-        ? []
-        : await tx
-            .select({
-              content: fields.content,
-              entityVersionId: fields.entityVersionId,
-              id: fields.id,
-              workspaceId: fields.workspaceId,
-            })
-            .from(fields)
-            .where(
-              and(
-                inArray(fields.id, projectionSourceFieldIds),
-                inArray(
-                  fields.workspaceId,
-                  currentCandidates.map((candidate) => candidate.workspaceId),
-                ),
-              ),
-            )
-            .limit(RECONCILE_BATCH_SIZE);
-    const projectionSourceFieldsById = new Map(
-      projectionSourceFields.map((field) => [field.id, field]),
-    );
-    const projectedEntityIds = new Set(
-      currentCandidates.flatMap((candidate) => {
-        const projection = projectionsByEntityId.get(candidate.entityId);
-        return projection &&
-          isPreservableAutomaticProjection({
-            currentEntityVersionId: candidate.entityVersionId,
-            currentWorkspaceId: candidate.workspaceId,
-            provenance: projection,
-            sourceField:
-              projection.sourceFieldId === null
-                ? null
-                : (projectionSourceFieldsById.get(projection.sourceFieldId) ??
-                  null),
-          })
-          ? [candidate.entityId]
-          : [];
-      }),
-    );
-    const values = currentCandidates
-      .filter(({ entityId }) => !projectedEntityIds.has(entityId))
-      .map(
-        (candidate) =>
-          ({
+      const projection = currentProjectionByEntityId.get(candidate.entityId);
+      const hasCurrentProjection =
+        projection !== undefined &&
+        ((projection.sourceEntityVersionId === null &&
+          projection.sourceFieldId === null &&
+          projection.sourceFileId === null &&
+          projection.sourceSha256Hex === null) ||
+          (projection.sourceEntityVersionId === candidate.entityVersionId &&
+            projection.sourceFieldId === candidate.fieldId &&
+            projection.sourceFileId === candidate.content.id &&
+            projection.sourceSha256Hex === candidate.content.sha256Hex));
+      if (
+        entity?.currentVersionId !== candidate.entityVersionId ||
+        entity.workspaceId !== candidate.workspaceId ||
+        entity.readOnly ||
+        !field ||
+        !isSameNativeExtractionSource(candidate, field)
+      ) {
+        return [];
+      }
+      if (hasCurrentProjection) {
+        const failedAt = new Date();
+        return [
+          {
             id: createSafeId<"documentProcessingRun">(),
             entityId: candidate.entityId,
             entityVersionId: candidate.entityVersionId,
+            errorAt: failedAt,
+            errorCode: SEARCH_INDEX_FAILURE_CODE,
             fieldId: candidate.fieldId,
-            kind: "ocr",
+            kind: "native-extraction",
+            nextAttemptAt: failedAt,
             organizationId: candidate.organizationId,
-            processorVersion: DOCUMENT_OCR_PROCESSOR_VERSION,
+            processorVersion: DOCUMENT_NATIVE_EXTRACTION_PROCESSOR_VERSION,
             requestedBy: null,
             requestSource: "repair",
             sourceFileId: candidate.content.id,
             sourceSha256Hex: candidate.content.sha256Hex,
+            status: "failed",
             workspaceId: candidate.workspaceId,
-          }) satisfies typeof documentProcessingRuns.$inferInsert,
-      );
+          } satisfies typeof documentProcessingRuns.$inferInsert,
+        ];
+      }
+      return [
+        {
+          id: createSafeId<"documentProcessingRun">(),
+          entityId: candidate.entityId,
+          entityVersionId: candidate.entityVersionId,
+          fieldId: candidate.fieldId,
+          kind: "native-extraction",
+          organizationId: candidate.organizationId,
+          processorVersion: DOCUMENT_NATIVE_EXTRACTION_PROCESSOR_VERSION,
+          requestedBy: null,
+          requestSource: "repair",
+          sourceFileId: candidate.content.id,
+          sourceSha256Hex: candidate.content.sha256Hex,
+          workspaceId: candidate.workspaceId,
+        } satisfies typeof documentProcessingRuns.$inferInsert,
+      ];
+    });
     if (values.length === 0) {
       return [];
     }
 
-    // `currentCandidates` passed the exact field/hash check after the entity's
-    // current version was locked above. Only that locked recheck may revive a
-    // source-superseded run for the same immutable source.
-    const cancellationCodes = revivableAutomaticOcrCancellationCodes({
-      hasLockedExactSource: currentCandidates.length > 0,
-    });
-    const repairableConflict = or(
-      eq(documentProcessingRuns.status, "succeeded"),
-      and(
-        inArray(documentProcessingRuns.requestSource, ["upload", "repair"]),
-        eq(documentProcessingRuns.status, "cancelled"),
-        inArray(documentProcessingRuns.errorCode, cancellationCodes),
-      ),
+    const repairableConflict = and(
+      eq(documentProcessingRuns.status, "cancelled"),
+      inArray(documentProcessingRuns.requestSource, ["upload", "repair"]),
+      inArray(documentProcessingRuns.errorCode, [
+        SOURCE_SUPERSEDED_CANCELLATION_CODE,
+        "workspace_unavailable",
+      ]),
     );
     if (!repairableConflict) {
       return [];
     }
-
     const queuedAt = new Date();
     const queued = await tx
       .insert(documentProcessingRuns)
@@ -1619,13 +1637,12 @@ const persistRepairableOcrRuns = async (
           documentProcessingRuns.processorVersion,
         ],
         set: {
-          errorAt: null,
-          errorCode: null,
+          errorAt: sql`excluded.error_at`,
+          errorCode: sql`excluded.error_code`,
           finishedAt: null,
-          nextAttemptAt: null,
-          requestedBy: null,
+          nextAttemptAt: sql`excluded.next_attempt_at`,
           requestSource: "repair",
-          status: "queued",
+          status: sql`excluded.status`,
           updatedAt: queuedAt,
         },
         setWhere: repairableConflict,
@@ -1671,7 +1688,7 @@ export const tryEnqueueDocumentProcessingRun = async ({
   return { runId, status: "enqueued" };
 };
 
-const recoverMissingAutomaticOcrRuns = async (): Promise<number> => {
+const recoverMissingNativeExtractionRuns = async (): Promise<number> => {
   const settledBefore = new Date(Date.now() - REPAIR_SETTLE_DELAY_MS);
   const cursor = await readRepairScanCursor();
   const candidates = await rootDb
@@ -1702,20 +1719,12 @@ const recoverMissingAutomaticOcrRuns = async (): Promise<number> => {
       ),
     )
     .innerJoin(workspaces, eq(workspaces.id, fields.workspaceId))
-    .innerJoin(
-      organizationSettings,
-      and(
-        eq(organizationSettings.organizationId, workspaces.organizationId),
-        eq(organizationSettings.documentProcessingMode, "searchable-text"),
-      ),
-    )
     .where(
       and(
         cursor === null ? undefined : gt(fields.id, cursor),
         lt(entityVersions.createdAt, settledBefore),
         eq(workspaces.status, "active"),
         sql`${fields.content}->>'type' = 'file'
-          AND ${fields.content}->>'mimeType' = 'application/pdf'
           AND ${fields.content}->>'encrypted' = 'false'`,
         notExists(
           rootDb
@@ -1743,12 +1752,15 @@ const recoverMissingAutomaticOcrRuns = async (): Promise<number> => {
   }
 
   const repairCandidates = candidates.flatMap((candidate) => {
-    if (!isAutomaticOcrRepairCandidate(candidate.content)) {
+    if (
+      candidate.content.type !== "file" ||
+      !requiresDurableNativeExtraction(candidate.content)
+    ) {
       return [];
     }
     return [{ ...candidate, content: candidate.content }];
   });
-  const runIds = await persistRepairableOcrRuns(repairCandidates);
+  const runIds = await persistMissingNativeExtractionRuns(repairCandidates);
   await writeRepairScanCursor({
     expectedCursor: cursor,
     nextCursor:
@@ -1800,7 +1812,6 @@ export const dispatchQueuedDocumentProcessingRuns = async ({
     .from(documentProcessingRuns)
     .where(
       and(
-        eq(documentProcessingRuns.kind, "ocr"),
         eq(documentProcessingRuns.status, "queued"),
         selection === QUEUED_OCR_SELECTION.SCHEDULED_RETRIES
           ? isNotNull(documentProcessingRuns.nextAttemptAt)
@@ -2415,7 +2426,7 @@ const reconcileDocumentProcessing = async ({
       phases: [
         {
           name: RECONCILIATION_PHASE.REPAIR,
-          run: recoverMissingAutomaticOcrRuns,
+          run: recoverMissingNativeExtractionRuns,
         },
         {
           name: RECONCILIATION_PHASE.REINDEX,
@@ -2480,30 +2491,7 @@ export const abortDocumentProcessingWorkerBeforeClose = async ({
 
 export const initDocumentProcessingWorker = () => {
   const lifecycle = new AbortController();
-  if (!isDocumentOcrProviderConfigured()) {
-    logger.info("document_processing.worker_not_started", {
-      reason: "ocr_provider_not_configured",
-    });
-    // Signal listeners do not keep Bun alive. The self-host worker service is
-    // still a long-lived process when OCR is unconfigured, so retain one
-    // dormant handle until the entrypoint asks this lifecycle to close.
-    const keepAliveInterval = setInterval(
-      () => undefined,
-      DORMANT_WORKER_KEEP_ALIVE_MS,
-    );
-    return {
-      close: async (): Promise<void> => {
-        lifecycle.abort();
-        clearInterval(keepAliveInterval);
-        const client = reconciliationRedisClient;
-        reconciliationRedisClient = null;
-        if (client) {
-          client.close();
-        }
-        await Promise.resolve();
-      },
-    };
-  }
+  const ocrProviderConfigured = isDocumentOcrProviderConfigured();
 
   const worker = new Worker<DocumentProcessingJobData>(
     DOCUMENT_PROCESSING_QUEUE_NAME,
@@ -2531,7 +2519,9 @@ export const initDocumentProcessingWorker = () => {
       if (closing) {
         return undefined;
       }
-      readiness = startDocumentOcrWorkerReadiness();
+      if (ocrProviderConfigured) {
+        readiness = startDocumentOcrWorkerReadiness();
+      }
       return undefined;
     }),
     "document-processing.publish-readiness",

--- a/apps/api/src/lib/document-processing-queue.ts
+++ b/apps/api/src/lib/document-processing-queue.ts
@@ -972,35 +972,38 @@ export const processDocumentProcessingRun = async (
     // automatic jobs. Either it wins and a later worker observes `off` before
     // claiming, or the worker wins and opt-out refuses until this dispatch is
     // terminal; neither path can acknowledge opt-out while it sends a file.
-    const settingsRows = await tx
-      .select({
-        documentProcessingMode: organizationSettings.documentProcessingMode,
-      })
-      .from(organizationSettings)
-      .where(eq(organizationSettings.organizationId, runContext.organizationId))
-      .limit(1)
-      .for("update");
-    if (
-      runContext.kind === "ocr" &&
-      requiresOcrPolicy(runContext.requestSource) &&
-      settingsRows.at(0)?.documentProcessingMode !== "searchable-text"
-    ) {
-      await tx
-        .update(documentProcessingRuns)
-        .set({
-          errorAt: new Date(),
-          errorCode: "policy_disabled",
-          finishedAt: new Date(),
-          status: "cancelled",
-          updatedAt: new Date(),
+    if (runContext.kind === "ocr") {
+      const settingsRows = await tx
+        .select({
+          documentProcessingMode: organizationSettings.documentProcessingMode,
         })
+        .from(organizationSettings)
         .where(
-          and(
-            eq(documentProcessingRuns.id, runId),
-            inArray(documentProcessingRuns.status, ["queued", "failed"]),
-          ),
-        );
-      return null;
+          eq(organizationSettings.organizationId, runContext.organizationId),
+        )
+        .limit(1)
+        .for("update");
+      if (
+        requiresOcrPolicy(runContext.requestSource) &&
+        settingsRows.at(0)?.documentProcessingMode !== "searchable-text"
+      ) {
+        await tx
+          .update(documentProcessingRuns)
+          .set({
+            errorAt: new Date(),
+            errorCode: "policy_disabled",
+            finishedAt: new Date(),
+            status: "cancelled",
+            updatedAt: new Date(),
+          })
+          .where(
+            and(
+              eq(documentProcessingRuns.id, runId),
+              inArray(documentProcessingRuns.status, ["queued", "failed"]),
+            ),
+          );
+        return null;
+      }
     }
 
     lifecycleSignal.throwIfAborted();
@@ -1040,47 +1043,48 @@ export const processDocumentProcessingRun = async (
   const processingResult = await Result.tryPromise({
     try: async () => {
       lifecycleSignal.throwIfAborted();
-      const settings = await rootDb.query.organizationSettings.findFirst({
-        where: { organizationId: { eq: run.organizationId } },
-        columns: { documentProcessingMode: true },
-      });
-      const currentRuns = await rootDb
-        .select({ requestSource: documentProcessingRuns.requestSource })
-        .from(documentProcessingRuns)
-        .where(eq(documentProcessingRuns.id, run.id))
-        .limit(1);
-      if (
-        run.kind === "ocr" &&
-        requiresOcrPolicy(
-          currentRuns.at(0)?.requestSource ?? run.requestSource,
-        ) &&
-        settings?.documentProcessingMode !== "searchable-text"
-      ) {
-        const cancelled = await markRunCancelled(
-          run.id,
-          claimToken,
-          "policy_disabled",
-        );
-        if (cancelled) {
-          return;
-        }
-
-        const promotedRuns = await rootDb
-          .select({
-            claimedBy: documentProcessingRuns.claimedBy,
-            requestSource: documentProcessingRuns.requestSource,
-            status: documentProcessingRuns.status,
-          })
+      if (run.kind === "ocr") {
+        const settings = await rootDb.query.organizationSettings.findFirst({
+          where: { organizationId: { eq: run.organizationId } },
+          columns: { documentProcessingMode: true },
+        });
+        const currentRuns = await rootDb
+          .select({ requestSource: documentProcessingRuns.requestSource })
           .from(documentProcessingRuns)
           .where(eq(documentProcessingRuns.id, run.id))
           .limit(1);
         if (
-          !ownsPromotedManualOcrClaim({
-            claimToken,
-            run: promotedRuns.at(0),
-          })
+          requiresOcrPolicy(
+            currentRuns.at(0)?.requestSource ?? run.requestSource,
+          ) &&
+          settings?.documentProcessingMode !== "searchable-text"
         ) {
-          return;
+          const cancelled = await markRunCancelled(
+            run.id,
+            claimToken,
+            "policy_disabled",
+          );
+          if (cancelled) {
+            return;
+          }
+
+          const promotedRuns = await rootDb
+            .select({
+              claimedBy: documentProcessingRuns.claimedBy,
+              requestSource: documentProcessingRuns.requestSource,
+              status: documentProcessingRuns.status,
+            })
+            .from(documentProcessingRuns)
+            .where(eq(documentProcessingRuns.id, run.id))
+            .limit(1);
+          if (
+            !ownsPromotedManualOcrClaim({
+              claimToken,
+              run: promotedRuns.at(0),
+            })
+          ) {
+            return;
+          }
         }
       }
 
@@ -1096,11 +1100,21 @@ export const processDocumentProcessingRun = async (
             await markRunCancelled(run.id, claimToken, "source_superseded");
             return;
           }
-          await executeNativeExtraction({
+          const extractionOutcome = await executeNativeExtraction({
             fileField: source.content,
             lifecycleSignal,
             run,
           });
+          switch (extractionOutcome) {
+            case "persisted":
+            case "preserved":
+              break;
+            case "source_cancelled":
+              await markRunCancelled(run.id, claimToken, "source_superseded");
+              return;
+            default:
+              extractionOutcome satisfies never;
+          }
           lifecycleSignal.throwIfAborted();
           const persistedSource = await readCurrentDocumentSource({
             entityId: run.entityId,
@@ -1611,17 +1625,17 @@ const persistMissingNativeExtractionRuns = async (
       return [];
     }
 
-    const repairableConflict = and(
-      eq(documentProcessingRuns.status, "cancelled"),
-      inArray(documentProcessingRuns.requestSource, ["upload", "repair"]),
-      inArray(documentProcessingRuns.errorCode, [
-        SOURCE_SUPERSEDED_CANCELLATION_CODE,
-        "workspace_unavailable",
-      ]),
+    const repairableConflict = sql.join(
+      [
+        eq(documentProcessingRuns.status, "cancelled"),
+        inArray(documentProcessingRuns.requestSource, ["upload", "repair"]),
+        inArray(documentProcessingRuns.errorCode, [
+          SOURCE_SUPERSEDED_CANCELLATION_CODE,
+          "workspace_unavailable",
+        ]),
+      ],
+      sql` AND `,
     );
-    if (!repairableConflict) {
-      return [];
-    }
     const queuedAt = new Date();
     const queued = await tx
       .insert(documentProcessingRuns)

--- a/apps/api/src/lib/files/gotenberg.test.ts
+++ b/apps/api/src/lib/files/gotenberg.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  isConvertibleMimeType,
+  isNativelyRenderableMimeType,
   pdfDerivativeStateForFile,
   shouldGeneratePdfDerivative,
 } from "@/api/lib/files/gotenberg";
@@ -63,5 +65,12 @@ describe("PDF derivative policy", () => {
         mimeType: "application/vnd.ms-outlook",
       }),
     ).toBe(false);
+  });
+
+  test("does not treat inherited object properties as MIME types", () => {
+    for (const inheritedProperty of ["constructor", "toString"]) {
+      expect(isConvertibleMimeType(inheritedProperty)).toBe(false);
+      expect(isNativelyRenderableMimeType(inheritedProperty)).toBe(false);
+    }
   });
 });

--- a/apps/api/src/lib/files/gotenberg.ts
+++ b/apps/api/src/lib/files/gotenberg.ts
@@ -4,81 +4,12 @@ import { env } from "@/api/env";
 import { fetchWithTimeout } from "@/api/lib/fetch";
 import { applyFitToPage } from "@/api/lib/files/xlsx-preprocess";
 
-/**
- * MIME types that Gotenberg's LibreOffice route can convert
- * to PDF. Derived from the official documentation:
- * https://gotenberg.dev/docs/convert-with-libreoffice/convert-to-pdf
- */
-const CONVERTIBLE_MIME_TYPES = {
-  // Word processing
-  "application/msword": null,
-  "application/vnd.openxmlformats-officedocument.wordprocessingml.document":
-    null,
-  "application/vnd.oasis.opendocument.text": null,
-  "application/rtf": null,
-  "text/plain": null,
-  "application/vnd.apple.pages": null,
-
-  // Spreadsheets
-  "application/vnd.ms-excel": null,
-  "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": null,
-  "application/vnd.oasis.opendocument.spreadsheet": null,
-  "text/csv": null,
-
-  // Presentations
-  "application/vnd.ms-powerpoint": null,
-  "application/vnd.openxmlformats-officedocument.presentationml.presentation":
-    null,
-  "application/vnd.oasis.opendocument.presentation": null,
-
-  // Images
-  "image/jpeg": null,
-  "image/png": null,
-  "image/gif": null,
-  "image/tiff": null,
-  "image/bmp": null,
-  "image/webp": null,
-
-  // Web
-  "text/html": null,
-  "application/xhtml+xml": null,
-} as const satisfies Record<string, null>;
-
-export const isConvertibleMimeType = (mimeType: string): boolean =>
-  mimeType in CONVERTIBLE_MIME_TYPES;
-
-/**
- * MIME types that the frontend can render natively without
- * Gotenberg conversion. Currently only DOCX (via Folio).
- * Images intentionally remain converted to PDF.
- */
-const NATIVELY_RENDERABLE_MIME_TYPES = {
-  "application/vnd.openxmlformats-officedocument.wordprocessingml.document":
-    null,
-} as const satisfies Record<string, null>;
-
-export const isNativelyRenderableMimeType = (mimeType: string): boolean =>
-  mimeType in NATIVELY_RENDERABLE_MIME_TYPES;
-
-type ShouldGeneratePdfDerivativeOptions = {
-  encrypted?: boolean;
-  mimeType: string;
-};
-
-export const shouldGeneratePdfDerivative = ({
-  encrypted = false,
-  mimeType,
-}: ShouldGeneratePdfDerivativeOptions): boolean =>
-  !encrypted &&
-  isConvertibleMimeType(mimeType) &&
-  !isNativelyRenderableMimeType(mimeType);
-
-export const pdfDerivativeStateForFile = (
-  options: ShouldGeneratePdfDerivativeOptions,
-) =>
-  shouldGeneratePdfDerivative(options)
-    ? ({ status: "pending" } as const)
-    : ({ status: "not-required" } as const);
+export {
+  isConvertibleMimeType,
+  isNativelyRenderableMimeType,
+  pdfDerivativeStateForFile,
+  shouldGeneratePdfDerivative,
+} from "@/api/lib/files/pdf-derivative-policy";
 
 /**
  * Spreadsheet MIME types (.xls, .xlsx) that benefit from the

--- a/apps/api/src/lib/files/pdf-derivative-policy.ts
+++ b/apps/api/src/lib/files/pdf-derivative-policy.ts
@@ -1,0 +1,58 @@
+/** MIME types accepted by Gotenberg's LibreOffice conversion route. */
+const CONVERTIBLE_MIME_TYPES = {
+  "application/msword": null,
+  "application/vnd.openxmlformats-officedocument.presentationml.presentation":
+    null,
+  "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": null,
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document":
+    null,
+  "application/vnd.ms-excel": null,
+  "application/vnd.ms-powerpoint": null,
+  "application/vnd.oasis.opendocument.presentation": null,
+  "application/vnd.oasis.opendocument.spreadsheet": null,
+  "application/vnd.oasis.opendocument.text": null,
+  "application/rtf": null,
+  "application/vnd.apple.pages": null,
+  "application/xhtml+xml": null,
+  "image/bmp": null,
+  "image/gif": null,
+  "image/jpeg": null,
+  "image/png": null,
+  "image/tiff": null,
+  "image/webp": null,
+  "text/csv": null,
+  "text/html": null,
+  "text/plain": null,
+} as const satisfies Record<string, null>;
+
+export const isConvertibleMimeType = (mimeType: string): boolean =>
+  mimeType in CONVERTIBLE_MIME_TYPES;
+
+/** DOCX is rendered by Folio and therefore has no derivative queue. */
+const NATIVELY_RENDERABLE_MIME_TYPES = {
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document":
+    null,
+} as const satisfies Record<string, null>;
+
+export const isNativelyRenderableMimeType = (mimeType: string): boolean =>
+  mimeType in NATIVELY_RENDERABLE_MIME_TYPES;
+
+type ShouldGeneratePdfDerivativeOptions = {
+  encrypted?: boolean;
+  mimeType: string;
+};
+
+export const shouldGeneratePdfDerivative = ({
+  encrypted = false,
+  mimeType,
+}: ShouldGeneratePdfDerivativeOptions): boolean =>
+  !encrypted &&
+  isConvertibleMimeType(mimeType) &&
+  !isNativelyRenderableMimeType(mimeType);
+
+export const pdfDerivativeStateForFile = (
+  options: ShouldGeneratePdfDerivativeOptions,
+) =>
+  shouldGeneratePdfDerivative(options)
+    ? ({ status: "pending" } as const)
+    : ({ status: "not-required" } as const);

--- a/apps/api/src/lib/files/pdf-derivative-policy.ts
+++ b/apps/api/src/lib/files/pdf-derivative-policy.ts
@@ -26,7 +26,7 @@ const CONVERTIBLE_MIME_TYPES = {
 } as const satisfies Record<string, null>;
 
 export const isConvertibleMimeType = (mimeType: string): boolean =>
-  mimeType in CONVERTIBLE_MIME_TYPES;
+  Object.hasOwn(CONVERTIBLE_MIME_TYPES, mimeType);
 
 /** DOCX is rendered by Folio and therefore has no derivative queue. */
 const NATIVELY_RENDERABLE_MIME_TYPES = {
@@ -35,7 +35,7 @@ const NATIVELY_RENDERABLE_MIME_TYPES = {
 } as const satisfies Record<string, null>;
 
 export const isNativelyRenderableMimeType = (mimeType: string): boolean =>
-  mimeType in NATIVELY_RENDERABLE_MIME_TYPES;
+  Object.hasOwn(NATIVELY_RENDERABLE_MIME_TYPES, mimeType);
 
 type ShouldGeneratePdfDerivativeOptions = {
   encrypted?: boolean;

--- a/apps/api/src/lib/limits.ts
+++ b/apps/api/src/lib/limits.ts
@@ -236,6 +236,8 @@ export const LIMITS = {
   ocrPdfGenerationTimeoutMs: 2 * 60_000,
   /** Hard timeout (ms) for the sandboxed extraction subprocess. */
   extractionTimeoutMs: 30_000,
+  /** Wall-clock ceiling for one document-processing object-storage read. */
+  documentProcessingObjectReadTimeoutMs: 30_000,
   /** Wall-clock ceiling (ms) for the live DOCX-to-Markdown read path in
    *  `read_content_across_matters`: the S3 file fetch plus the in-process
    *  folio conversion of a single document. Mirrors `extractionTimeoutMs`'s

--- a/apps/api/src/lib/s3.ts
+++ b/apps/api/src/lib/s3.ts
@@ -1,9 +1,10 @@
 import {
   DeleteObjectCommand,
+  GetObjectCommand,
   PutObjectCommand,
   S3Client as AwsS3Client,
 } from "@aws-sdk/client-s3";
-import { Result } from "better-result";
+import { Result, TaggedError } from "better-result";
 import { S3Client } from "bun";
 
 import { envBase } from "@/api/env-base";
@@ -492,6 +493,37 @@ export const writeS3ObjectWithRetry = async (
     }
   }
   throw lastError;
+};
+
+class S3ObjectReadError extends TaggedError("S3ObjectReadError")<{
+  message: string;
+}> {}
+
+/** Read one object while allowing the caller to cancel the HTTP request. */
+export const getS3ObjectWithSignal = async (
+  key: string,
+  signal: AbortSignal,
+): Promise<ArrayBuffer> => {
+  _abortableClient ??= buildAbortableS3Client(staticCredentialsFromEnv());
+  const response = await _abortableClient.send(
+    new GetObjectCommand({ Bucket: envBase.S3_BUCKET, Key: key }),
+    { abortSignal: signal },
+  );
+  if (!response.Body) {
+    throw new S3ObjectReadError({
+      message: "S3 returned an object without a response body",
+    });
+  }
+  const bytes = await response.Body.transformToByteArray();
+  if (bytes.buffer instanceof ArrayBuffer) {
+    return bytes.buffer.slice(
+      bytes.byteOffset,
+      bytes.byteOffset + bytes.byteLength,
+    );
+  }
+  const buffer = new ArrayBuffer(bytes.byteLength);
+  new Uint8Array(buffer).set(bytes);
+  return buffer;
 };
 
 /** Delete one object while allowing the caller to cancel the HTTP request. */

--- a/apps/api/src/lib/search/extract-content.ts
+++ b/apps/api/src/lib/search/extract-content.ts
@@ -95,14 +95,13 @@ export const resolveExtractionMimeType = ({
   return TEXT_EXTENSION_MIME_TYPES[extension] ?? normalized;
 };
 
-export const extractFileText = async (
+export const extractFileTextResult = async (
   buffer: ArrayBuffer,
   mimeType: string,
-  context?: Record<string, string>,
 ) => {
   const normalizedMimeType = normalizeMimeType(mimeType);
   if (!canExtractMimeType(normalizedMimeType)) {
-    return null;
+    return Result.ok(null);
   }
 
   const result = await spawnWorker({
@@ -117,14 +116,31 @@ export const extractFileText = async (
       message: result.error.message,
       exitCode: result.error.exitCode,
     });
-    captureError(error, {
-      mimeType: normalizedMimeType,
+    return Result.err(error);
+  }
+
+  return Result.ok(result.value || null);
+};
+
+/**
+ * Best-effort extraction for request paths where an empty fallback is valid.
+ * Durable document processing uses `extractFileTextResult` so a sandbox crash
+ * can never be mistaken for a successfully empty document.
+ */
+export const extractFileText = async (
+  buffer: ArrayBuffer,
+  mimeType: string,
+  context?: Record<string, string>,
+): Promise<string | null> => {
+  const result = await extractFileTextResult(buffer, mimeType);
+  if (Result.isError(result)) {
+    captureError(result.error, {
+      mimeType: normalizeMimeType(mimeType),
       sizeBytes: String(buffer.byteLength),
       exitCode: String(result.error.exitCode),
       ...context,
     });
     return null;
   }
-
-  return result.value || null;
+  return result.value;
 };

--- a/apps/api/src/lib/search/process-extraction.test.ts
+++ b/apps/api/src/lib/search/process-extraction.test.ts
@@ -56,10 +56,9 @@ const valuesMock = mock(() => ({
   onConflictDoNothing: onConflictDoNothingMock,
 }));
 const insertMock = mock(() => ({ values: valuesMock }));
-const arrayBufferMock = mock(async () => new ArrayBuffer(8));
-const getS3Mock = mock(() => ({
-  file: () => ({ arrayBuffer: arrayBufferMock }),
-}));
+const getS3ObjectWithSignalMock = mock(
+  async (_key: string, _signal: AbortSignal) => new ArrayBuffer(8),
+);
 const s3DeleteMock = mock(async () => undefined);
 const s3WriteMock = mock(async () => undefined);
 const extractFileTextResultMock = mock(
@@ -93,7 +92,7 @@ void mock.module("@/api/lib/document-processing-enqueue", () => ({
 }));
 void mock.module("@/api/lib/s3", () => ({
   deleteS3ObjectWithSignal: s3DeleteMock,
-  getS3: getS3Mock,
+  getS3ObjectWithSignal: getS3ObjectWithSignalMock,
   putS3ObjectWithSignal: s3WriteMock,
 }));
 void mock.module("@/api/lib/search/extract-content", () => ({
@@ -123,8 +122,7 @@ beforeEach(() => {
   onConflictDoNothingMock.mockClear();
   returningMock.mockReset();
   returningMock.mockImplementation(async () => [{ id: runId }]);
-  arrayBufferMock.mockClear();
-  getS3Mock.mockClear();
+  getS3ObjectWithSignalMock.mockClear();
   extractFileTextResultMock.mockReset();
   extractFileTextResultMock.mockImplementation(async () =>
     Result.ok("native text"),
@@ -140,7 +138,9 @@ beforeEach(() => {
 });
 
 describe("processExtraction", () => {
-  test("hands pending derivatives to their queue and durably extracts them once ready", () => {
+  // Files with a pending PDF derivative wait for it so extraction reads the
+  // rendered PDF rather than the original bytes.
+  test("requires durable extraction only after any pending PDF derivative exists", () => {
     expect(requiresDurableNativeExtraction(fileContent)).toBe(true);
     expect(
       requiresDurableNativeExtraction({
@@ -254,7 +254,7 @@ describe("processExtraction", () => {
       Result.ok(null),
     );
 
-    await executeNativeExtraction({
+    const outcome = await executeNativeExtraction({
       fileField: docxContent,
       lifecycleSignal: new AbortController().signal,
       run: {
@@ -268,6 +268,7 @@ describe("processExtraction", () => {
       },
     });
 
+    expect(outcome).toBe("persisted");
     expect(encryptContentMock).toHaveBeenCalledWith(organizationId, "");
     expect(executeMock).toHaveBeenCalledTimes(2);
     expect(requestAutomaticDocumentOcrMock).not.toHaveBeenCalled();
@@ -296,7 +297,7 @@ describe("processExtraction", () => {
       workspaceId: toSafeId<"workspace">("workspace_1"),
     });
 
-    expect(persisted).toBe(true);
+    expect(persisted).toBe("persisted");
     const lockQuery = executeMock.mock.calls.at(0)?.[0];
     const writeQuery = executeMock.mock.calls.at(1)?.[0];
     expect(lockQuery).toBeDefined();
@@ -361,7 +362,7 @@ describe("processExtraction", () => {
       workspaceId: toSafeId<"workspace">("workspace_1"),
     });
 
-    expect(persisted).toBe(false);
+    expect(persisted).toBe("source_cancelled");
     expect(executeMock).toHaveBeenCalledTimes(1);
   });
 
@@ -383,7 +384,31 @@ describe("processExtraction", () => {
       workspaceId: toSafeId<"workspace">("workspace_1"),
     });
 
-    expect(persisted).toBe(false);
+    expect(persisted).toBe("preserved");
     expect(executeMock).toHaveBeenCalledTimes(2);
+  });
+
+  test("surfaces preserved manual OCR ownership and skips automatic fallback", async () => {
+    executeMock.mockResolvedValueOnce([{ entityId }]).mockResolvedValueOnce([]);
+    extractFileTextResultMock.mockImplementationOnce(async () =>
+      Result.ok(null),
+    );
+
+    const outcome = await executeNativeExtraction({
+      fileField: fileContent,
+      lifecycleSignal: new AbortController().signal,
+      run: {
+        entityId,
+        entityVersionId,
+        fieldId,
+        organizationId,
+        sourceFileId: fileContent.id,
+        sourceSha256Hex: fileContent.sha256Hex,
+        workspaceId,
+      },
+    });
+
+    expect(outcome).toBe("preserved");
+    expect(requestAutomaticDocumentOcrMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/lib/search/process-extraction.test.ts
+++ b/apps/api/src/lib/search/process-extraction.test.ts
@@ -1,10 +1,12 @@
+import { Result } from "better-result";
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 import type { SQL } from "drizzle-orm";
 import { PgDialect } from "drizzle-orm/pg-core";
 
 import type { FieldContent } from "@/api/db/schema-validators";
 import { toSafeId } from "@/api/lib/branded-types";
-import { PDF_MIME_TYPE } from "@/api/mime-types";
+import { ExtractionWorkerError } from "@/api/lib/errors/tagged-errors";
+import { DOCX_MIME_TYPE, PDF_MIME_TYPE } from "@/api/mime-types";
 
 // `processExtraction` reads through the `rootDb` module-level singleton
 // directly (no injected `safeDb`), so the query call is captured by mocking
@@ -19,6 +21,7 @@ const fieldId = toSafeId<"field">("field_1");
 const propertyId = toSafeId<"property">("property_1");
 const organizationId = toSafeId<"organization">("org_1");
 const workspaceId = toSafeId<"workspace">("workspace_1");
+const runId = toSafeId<"documentProcessingRun">("run_1");
 const fileContent = {
   encrypted: false,
   fileName: "readable.pdf",
@@ -47,25 +50,34 @@ const transactionMock = mock(
     runTransaction: (tx: { execute: typeof executeMock }) => Promise<unknown>,
   ) => await runTransaction({ execute: executeMock }),
 );
+const returningMock = mock(async () => [{ id: runId }]);
+const onConflictDoNothingMock = mock(() => ({ returning: returningMock }));
+const valuesMock = mock(() => ({
+  onConflictDoNothing: onConflictDoNothingMock,
+}));
+const insertMock = mock(() => ({ values: valuesMock }));
 const arrayBufferMock = mock(async () => new ArrayBuffer(8));
 const getS3Mock = mock(() => ({
   file: () => ({ arrayBuffer: arrayBufferMock }),
 }));
 const s3DeleteMock = mock(async () => undefined);
 const s3WriteMock = mock(async () => undefined);
-const extractFileTextMock = mock(
-  async (): Promise<string | null> => "native text",
+const extractFileTextResultMock = mock(
+  async (): Promise<Result<string | null, ExtractionWorkerError>> =>
+    Result.ok("native text"),
 );
 const encryptContentMock = mock(async () => ({
   ciphertext: Buffer.from("ciphertext"),
   iv: Buffer.from("iv"),
 }));
 const requestAutomaticDocumentOcrMock = mock(async () => undefined);
+const enqueueDocumentProcessingRunMock = mock(async () => undefined);
 const indexEntityMock = mock(async () => undefined);
 
 void mock.module("@/api/db/root", () => ({
   rootDb: {
     execute: executeMock,
+    insert: insertMock,
     query: { entities: { findFirst: findFirstMock } },
     transaction: transactionMock,
   },
@@ -76,21 +88,29 @@ void mock.module("@/api/lib/content-encryption", () => ({
 void mock.module("@/api/lib/document-processing-automatic-request", () => ({
   requestAutomaticDocumentOcr: requestAutomaticDocumentOcrMock,
 }));
+void mock.module("@/api/lib/document-processing-enqueue", () => ({
+  enqueueDocumentProcessingRun: enqueueDocumentProcessingRunMock,
+}));
 void mock.module("@/api/lib/s3", () => ({
   deleteS3ObjectWithSignal: s3DeleteMock,
   getS3: getS3Mock,
   putS3ObjectWithSignal: s3WriteMock,
 }));
 void mock.module("@/api/lib/search/extract-content", () => ({
-  extractFileText: extractFileTextMock,
+  canExtractMimeType: () => true,
+  extractFileTextResult: extractFileTextResultMock,
   resolveExtractionMimeType: ({ mimeType }: { mimeType: string }) => mimeType,
 }));
 void mock.module("@/api/lib/search/provider", () => ({
   getSearchProvider: () => ({ indexEntity: indexEntityMock }),
 }));
 
-const { persistNativeExtractionProjection, processExtraction } =
-  await import("@/api/lib/search/process-extraction");
+const {
+  executeNativeExtraction,
+  persistNativeExtractionProjection,
+  processExtraction,
+  requiresDurableNativeExtraction,
+} = await import("@/api/lib/search/process-extraction");
 
 beforeEach(() => {
   findFirstResult = null;
@@ -98,20 +118,54 @@ beforeEach(() => {
   executeMock.mockReset();
   executeMock.mockImplementation(async (_query: SQL) => [{ entityId }]);
   transactionMock.mockClear();
+  insertMock.mockClear();
+  valuesMock.mockClear();
+  onConflictDoNothingMock.mockClear();
+  returningMock.mockReset();
+  returningMock.mockImplementation(async () => [{ id: runId }]);
   arrayBufferMock.mockClear();
   getS3Mock.mockClear();
-  extractFileTextMock.mockReset();
-  extractFileTextMock.mockImplementation(async () => "native text");
+  extractFileTextResultMock.mockReset();
+  extractFileTextResultMock.mockImplementation(async () =>
+    Result.ok("native text"),
+  );
   encryptContentMock.mockReset();
   encryptContentMock.mockImplementation(async () => ({
     ciphertext: Buffer.from("ciphertext"),
     iv: Buffer.from("iv"),
   }));
   requestAutomaticDocumentOcrMock.mockClear();
+  enqueueDocumentProcessingRunMock.mockClear();
   indexEntityMock.mockClear();
 });
 
 describe("processExtraction", () => {
+  test("hands pending derivatives to their queue and durably extracts them once ready", () => {
+    expect(requiresDurableNativeExtraction(fileContent)).toBe(true);
+    expect(
+      requiresDurableNativeExtraction({
+        ...fileContent,
+        fileName: "contract.docx",
+        mimeType: DOCX_MIME_TYPE,
+      }),
+    ).toBe(true);
+    expect(
+      requiresDurableNativeExtraction({
+        ...fileContent,
+        fileName: "notes.txt",
+        mimeType: "text/plain",
+      }),
+    ).toBe(false);
+    expect(
+      requiresDurableNativeExtraction({
+        ...fileContent,
+        fileName: "notes.txt",
+        mimeType: "text/plain",
+        pdfFileId: "derived_pdf_1",
+      }),
+    ).toBe(true);
+  });
+
   test("orders the current version's fields by id, matching readEntityByIdHandler, so 'first file field' selection is deterministic", async () => {
     await processExtraction(entityId);
 
@@ -138,60 +192,85 @@ describe("processExtraction", () => {
     );
   });
 
-  test("requests OCR when native PDF extraction yields no text", async () => {
+  test("commits and enqueues a durable native run before extraction", async () => {
     findFirstResult = extractionEntity;
-    extractFileTextMock.mockImplementationOnce(async () => null);
 
     await processExtraction(entityId);
 
-    expect(requestAutomaticDocumentOcrMock).toHaveBeenCalledWith(
+    expect(valuesMock).toHaveBeenCalledWith(
       expect.objectContaining({
         entityId,
         entityVersionId,
         fieldId,
+        kind: "native-extraction",
         sourceFileId: fileContent.id,
       }),
     );
-    expect(encryptContentMock).not.toHaveBeenCalled();
-    expect(indexEntityMock).toHaveBeenCalledWith(entityId);
+    expect(enqueueDocumentProcessingRunMock).toHaveBeenCalledWith(runId);
+    expect(extractFileTextResultMock).not.toHaveBeenCalled();
+    expect(requestAutomaticDocumentOcrMock).not.toHaveBeenCalled();
+    expect(indexEntityMock).not.toHaveBeenCalled();
   });
 
-  test("propagates encryption failure without sending readable text to OCR", async () => {
-    findFirstResult = extractionEntity;
-    const encryptionError = new Error("encryption unavailable");
-    encryptContentMock.mockImplementationOnce(async () => {
-      throw encryptionError;
+  test("keeps a sandbox failure distinct from a valid empty document", async () => {
+    const workerError = new ExtractionWorkerError({
+      exitCode: 1,
+      message: "sandbox crashed",
     });
+    extractFileTextResultMock.mockImplementationOnce(async () =>
+      Result.err(workerError),
+    );
 
-    const rejection: unknown = await processExtraction(entityId).then(
+    const rejection: unknown = await executeNativeExtraction({
+      fileField: fileContent,
+      lifecycleSignal: new AbortController().signal,
+      run: {
+        entityId,
+        entityVersionId,
+        fieldId,
+        organizationId,
+        sourceFileId: fileContent.id,
+        sourceSha256Hex: fileContent.sha256Hex,
+        workspaceId,
+      },
+    }).then(
       () => null,
       (error: unknown) => error,
     );
 
-    expect(rejection).toBe(encryptionError);
+    expect(rejection).toBe(workerError);
+    expect(encryptContentMock).not.toHaveBeenCalled();
     expect(requestAutomaticDocumentOcrMock).not.toHaveBeenCalled();
     expect(executeMock).not.toHaveBeenCalled();
-    expect(indexEntityMock).not.toHaveBeenCalled();
   });
 
-  test("propagates projection failure without sending readable text to OCR", async () => {
-    findFirstResult = extractionEntity;
-    const persistenceError = new Error("database unavailable");
-    executeMock
-      .mockResolvedValueOnce([{ entityId }])
-      .mockImplementationOnce(async () => {
-        throw persistenceError;
-      });
-
-    const rejection: unknown = await processExtraction(entityId).then(
-      () => null,
-      (error: unknown) => error,
+  test("persists a valid empty DOCX as a terminal zero-length projection", async () => {
+    const docxContent = {
+      ...fileContent,
+      fileName: "empty.docx",
+      mimeType: DOCX_MIME_TYPE,
+    } satisfies FieldContent;
+    extractFileTextResultMock.mockImplementationOnce(async () =>
+      Result.ok(null),
     );
 
-    expect(rejection).toBe(persistenceError);
-    expect(encryptContentMock).toHaveBeenCalled();
+    await executeNativeExtraction({
+      fileField: docxContent,
+      lifecycleSignal: new AbortController().signal,
+      run: {
+        entityId,
+        entityVersionId,
+        fieldId,
+        organizationId,
+        sourceFileId: docxContent.id,
+        sourceSha256Hex: docxContent.sha256Hex,
+        workspaceId,
+      },
+    });
+
+    expect(encryptContentMock).toHaveBeenCalledWith(organizationId, "");
+    expect(executeMock).toHaveBeenCalledTimes(2);
     expect(requestAutomaticDocumentOcrMock).not.toHaveBeenCalled();
-    expect(indexEntityMock).not.toHaveBeenCalled();
   });
 
   test("serializes native persistence and fences a current manual OCR selection", async () => {

--- a/apps/api/src/lib/search/process-extraction.ts
+++ b/apps/api/src/lib/search/process-extraction.ts
@@ -1,26 +1,24 @@
-/**
- * Async pipeline: download file from S3 → extract text →
- * encrypt → store → re-index.
- *
- * Called fire-and-forget after file uploads; failures are
- * captured by the caller via captureError.
- */
+/** Durable native extraction request and worker-side execution. */
 
 import { panic, Result } from "better-result";
-import { sql } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
 
 import { rootDb } from "@/api/db/root";
+import { documentProcessingRuns } from "@/api/db/schema";
 import type { FieldContent } from "@/api/db/schema-validators";
-import { captureError } from "@/api/lib/analytics/capture";
 import type { SafeId } from "@/api/lib/branded-types";
-import { toSafeId } from "@/api/lib/branded-types";
+import { createSafeId, toSafeId } from "@/api/lib/branded-types";
 import { encryptContent } from "@/api/lib/content-encryption";
 import { requestAutomaticDocumentOcr } from "@/api/lib/document-processing-automatic-request";
+import { DOCUMENT_NATIVE_EXTRACTION_PROCESSOR_VERSION } from "@/api/lib/document-processing-contract";
+import { enqueueDocumentProcessingRun } from "@/api/lib/document-processing-enqueue";
+import { shouldGeneratePdfDerivative } from "@/api/lib/files/pdf-derivative-policy";
 import { createFileKey } from "@/api/lib/files/utils";
 import { LIMITS } from "@/api/lib/limits";
 import { getS3 } from "@/api/lib/s3";
 import {
-  extractFileText,
+  canExtractMimeType,
+  extractFileTextResult,
   resolveExtractionMimeType,
 } from "@/api/lib/search/extract-content";
 import { getSearchProvider } from "@/api/lib/search/provider";
@@ -51,6 +49,24 @@ const pickExtractionSource = (
       mimeType: fileField.mimeType,
     }),
   };
+};
+
+export const requiresDurableNativeExtraction = (
+  fileField: Extract<FieldContent, { type: "file" }>,
+): boolean => {
+  if (fileField.encrypted) {
+    return false;
+  }
+  if (
+    fileField.pdfFileId === null &&
+    shouldGeneratePdfDerivative({
+      encrypted: fileField.encrypted,
+      mimeType: fileField.mimeType,
+    })
+  ) {
+    return false;
+  }
+  return canExtractMimeType(pickExtractionSource(fileField).extractionMimeType);
 };
 
 type NativeExtractionProjectionOptions = {
@@ -186,11 +202,80 @@ export const persistNativeExtractionProjection = async ({
     return persisted.at(0) !== undefined;
   });
 
+type NativeExtractionRun = Pick<
+  typeof documentProcessingRuns.$inferSelect,
+  | "entityId"
+  | "entityVersionId"
+  | "fieldId"
+  | "organizationId"
+  | "sourceFileId"
+  | "sourceSha256Hex"
+  | "workspaceId"
+>;
+
+export const executeNativeExtraction = async ({
+  fileField,
+  lifecycleSignal,
+  run,
+}: {
+  fileField: Extract<FieldContent, { type: "file" }>;
+  lifecycleSignal: AbortSignal;
+  run: NativeExtractionRun;
+}): Promise<void> => {
+  const source = pickExtractionSource(fileField);
+  const key = createFileKey({
+    organizationId: run.organizationId,
+    workspaceId: run.workspaceId,
+    fileId: source.fileId,
+    mimeType: source.storageMimeType,
+  });
+  const buffer = await getS3().file(key).arrayBuffer();
+  lifecycleSignal.throwIfAborted();
+  const extraction = await extractFileTextResult(
+    buffer,
+    source.extractionMimeType,
+  );
+  if (Result.isError(extraction)) {
+    throw extraction.error;
+  }
+  lifecycleSignal.throwIfAborted();
+
+  const text = extraction.value;
+  const persistedText = text ?? "";
+  const encrypted = await encryptContent(run.organizationId, persistedText);
+  lifecycleSignal.throwIfAborted();
+  await persistNativeExtractionProjection({
+    charCount: persistedText.length,
+    ciphertext: encrypted.ciphertext,
+    entityId: run.entityId,
+    entityVersionId: run.entityVersionId,
+    fieldId: run.fieldId,
+    iv: encrypted.iv,
+    organizationId: run.organizationId,
+    sourceFileId: run.sourceFileId,
+    sourceSha256Hex: run.sourceSha256Hex,
+    workspaceId: run.workspaceId,
+  });
+
+  if (text === null && fileField.mimeType === PDF_MIME_TYPE) {
+    await requestAutomaticDocumentOcr({
+      entityId: run.entityId,
+      entityVersionId: run.entityVersionId,
+      fieldId: run.fieldId,
+      organizationId: run.organizationId,
+      requestSource: "upload",
+      sourceFileId: run.sourceFileId,
+      sourceSha256Hex: run.sourceSha256Hex,
+      workspaceId: run.workspaceId,
+    });
+  }
+};
+
 /**
- * Extract text from the entity's file, encrypt it, store it,
- * and (re-)index the entity for search. This function always
- * indexes the entity at the end, even when extraction is
- * skipped, so callers don't need a separate indexEntity call.
+ * Durably request native extraction for the entity's selected file. The
+ * document-processing worker owns extraction, persistence, indexing, and
+ * retries; callers may still treat this as best-effort because the committed
+ * run and bounded repair scan own eventual completion.
  */
 export const processExtraction = async (
   entityId: SafeId<"entity">,
@@ -250,84 +335,70 @@ export const processExtraction = async (
       (options?.filePropertyId === undefined ||
         field.propertyId === options.filePropertyId),
   );
-  const canExtract = fileField && !fileField.encrypted;
-  let shouldRequestAutomaticOcr = false;
-
-  if (canExtract) {
-    const orgId = toSafeId<"organization">(workspace.organizationId);
-    const wsId = toSafeId<"workspace">(workspace.id);
-    const extraction = await Result.tryPromise({
-      try: async () => {
-        const source = pickExtractionSource(fileField);
-        const key = createFileKey({
-          organizationId: orgId,
-          workspaceId: wsId,
-          fileId: source.fileId,
-          mimeType: source.storageMimeType,
-        });
-        const buffer = await getS3().file(key).arrayBuffer();
-        return await extractFileText(buffer, source.extractionMimeType, {
-          entityId,
-          fileId: source.fileId,
-        });
-      },
-      catch: (cause) => cause,
-    });
-    if (Result.isError(extraction)) {
-      // Extraction failures must not prevent search
-      // indexing; the entity is still searchable by its
-      // field-level text.
-      captureError(extraction.error, {
-        entityId,
-        mimeType: fileField.mimeType,
-      });
-      shouldRequestAutomaticOcr = fileField.mimeType === PDF_MIME_TYPE;
-    } else {
-      const text = extraction.value;
-      shouldRequestAutomaticOcr = fileField.mimeType === PDF_MIME_TYPE && !text;
-      if (text) {
-        // Native extraction succeeded. Encryption and durable projection
-        // failures must propagate to the caller; they are not evidence that
-        // the legal document needs to be sent to an external OCR provider.
-        const encrypted = await encryptContent(workspace.organizationId, text);
-        const sourceField =
-          fileFieldRow ?? panic("Extraction source field is missing");
-        await persistNativeExtractionProjection({
-          charCount: text.length,
-          ciphertext: encrypted.ciphertext,
-          entityId,
-          entityVersionId: version.id,
-          fieldId: sourceField.id,
-          iv: encrypted.iv,
-          organizationId: orgId,
-          sourceFileId: fileField.id,
-          sourceSha256Hex: fileField.sha256Hex,
-          workspaceId: wsId,
-        });
-      }
-    }
+  if (
+    !(fileField && fileFieldRow && requiresDurableNativeExtraction(fileField))
+  ) {
+    await getSearchProvider().indexEntity(entityId);
+    return;
   }
 
-  if (shouldRequestAutomaticOcr && fileFieldRow && fileField) {
-    await requestAutomaticDocumentOcr({
+  const organizationId = toSafeId<"organization">(workspace.organizationId);
+  const workspaceId = toSafeId<"workspace">(workspace.id);
+  const inserted = await rootDb
+    .insert(documentProcessingRuns)
+    .values({
+      id: createSafeId<"documentProcessingRun">(),
       entityId,
       entityVersionId: version.id,
       fieldId: fileFieldRow.id,
-      organizationId: workspace.organizationId,
+      kind: "native-extraction",
+      organizationId,
+      processorVersion: DOCUMENT_NATIVE_EXTRACTION_PROCESSOR_VERSION,
+      requestedBy: null,
       requestSource: "upload",
       sourceFileId: fileField.id,
       sourceSha256Hex: fileField.sha256Hex,
-      workspaceId: workspace.id,
-    }).catch((error: unknown) => {
-      captureError(error, {
-        entityId,
-        fieldId: fileFieldRow.id,
-        mimeType: fileField.mimeType,
-      });
-    });
+      workspaceId,
+    })
+    .onConflictDoNothing({
+      target: [
+        documentProcessingRuns.organizationId,
+        documentProcessingRuns.kind,
+        documentProcessingRuns.entityVersionId,
+        documentProcessingRuns.fieldId,
+        documentProcessingRuns.sourceFileId,
+        documentProcessingRuns.sourceSha256Hex,
+        documentProcessingRuns.processorVersion,
+      ],
+    })
+    .returning({ id: documentProcessingRuns.id });
+  const created = inserted.at(0);
+  const queued =
+    created ??
+    (
+      await rootDb
+        .select({ id: documentProcessingRuns.id })
+        .from(documentProcessingRuns)
+        .where(
+          and(
+            eq(documentProcessingRuns.organizationId, organizationId),
+            eq(documentProcessingRuns.workspaceId, workspaceId),
+            eq(documentProcessingRuns.entityId, entityId),
+            eq(documentProcessingRuns.entityVersionId, version.id),
+            eq(documentProcessingRuns.fieldId, fileFieldRow.id),
+            eq(documentProcessingRuns.sourceFileId, fileField.id),
+            eq(documentProcessingRuns.sourceSha256Hex, fileField.sha256Hex),
+            eq(documentProcessingRuns.kind, "native-extraction"),
+            eq(
+              documentProcessingRuns.processorVersion,
+              DOCUMENT_NATIVE_EXTRACTION_PROCESSOR_VERSION,
+            ),
+            eq(documentProcessingRuns.status, "queued"),
+          ),
+        )
+        .limit(1)
+    ).at(0);
+  if (queued) {
+    await enqueueDocumentProcessingRun(queued.id);
   }
-
-  // Always index: includes extracted content when available,
-  // field-level text otherwise.
-  await getSearchProvider().indexEntity(entityId);
 };

--- a/apps/api/src/lib/search/process-extraction.ts
+++ b/apps/api/src/lib/search/process-extraction.ts
@@ -15,7 +15,7 @@ import { enqueueDocumentProcessingRun } from "@/api/lib/document-processing-enqu
 import { shouldGeneratePdfDerivative } from "@/api/lib/files/pdf-derivative-policy";
 import { createFileKey } from "@/api/lib/files/utils";
 import { LIMITS } from "@/api/lib/limits";
-import { getS3 } from "@/api/lib/s3";
+import { getS3ObjectWithSignal } from "@/api/lib/s3";
 import {
   canExtractMimeType,
   extractFileTextResult,
@@ -23,6 +23,7 @@ import {
 } from "@/api/lib/search/extract-content";
 import { getSearchProvider } from "@/api/lib/search/provider";
 import { findExtractionFileField } from "@/api/lib/search/types";
+import { withTimeout } from "@/api/lib/with-timeout";
 import { PDF_MIME_TYPE } from "@/api/mime-types";
 
 /**
@@ -86,6 +87,11 @@ type PersistedNativeExtractionProjection = {
   entityId: SafeId<"entity">;
 };
 
+export type NativeExtractionProjectionOutcome =
+  | "persisted"
+  | "preserved"
+  | "source_cancelled";
+
 export const persistNativeExtractionProjection = async ({
   charCount,
   ciphertext,
@@ -97,7 +103,7 @@ export const persistNativeExtractionProjection = async ({
   sourceFileId,
   sourceSha256Hex,
   workspaceId,
-}: NativeExtractionProjectionOptions): Promise<boolean> =>
+}: NativeExtractionProjectionOptions): Promise<NativeExtractionProjectionOutcome> =>
   await rootDb.transaction(async (tx) => {
     // Manual OCR request and projection transactions take this same lock first.
     // Keeping the conditional write in the next statement gives it a fresh
@@ -119,7 +125,7 @@ export const persistNativeExtractionProjection = async ({
         FOR UPDATE OF e
       `);
     if (!lockedSources.at(0)) {
-      return false;
+      return "source_cancelled";
     }
 
     const persisted = await tx.execute<PersistedNativeExtractionProjection>(sql`
@@ -199,7 +205,7 @@ export const persistNativeExtractionProjection = async ({
         WHERE NOT EXISTS (SELECT 1 FROM manual_projection_ownership)
         RETURNING entity_id AS "entityId"
       `);
-    return persisted.at(0) !== undefined;
+    return persisted.at(0) === undefined ? "preserved" : "persisted";
   });
 
 type NativeExtractionRun = Pick<
@@ -221,7 +227,7 @@ export const executeNativeExtraction = async ({
   fileField: Extract<FieldContent, { type: "file" }>;
   lifecycleSignal: AbortSignal;
   run: NativeExtractionRun;
-}): Promise<void> => {
+}): Promise<NativeExtractionProjectionOutcome> => {
   const source = pickExtractionSource(fileField);
   const key = createFileKey({
     organizationId: run.organizationId,
@@ -229,7 +235,14 @@ export const executeNativeExtraction = async ({
     fileId: source.fileId,
     mimeType: source.storageMimeType,
   });
-  const buffer = await getS3().file(key).arrayBuffer();
+  const buffer = await withTimeout(
+    async (signal) => await getS3ObjectWithSignal(key, signal),
+    {
+      label: "native extraction source read",
+      signal: lifecycleSignal,
+      timeoutMs: LIMITS.documentProcessingObjectReadTimeoutMs,
+    },
+  );
   lifecycleSignal.throwIfAborted();
   const extraction = await extractFileTextResult(
     buffer,
@@ -244,7 +257,7 @@ export const executeNativeExtraction = async ({
   const persistedText = text ?? "";
   const encrypted = await encryptContent(run.organizationId, persistedText);
   lifecycleSignal.throwIfAborted();
-  await persistNativeExtractionProjection({
+  const persistenceOutcome = await persistNativeExtractionProjection({
     charCount: persistedText.length,
     ciphertext: encrypted.ciphertext,
     entityId: run.entityId,
@@ -256,6 +269,9 @@ export const executeNativeExtraction = async ({
     sourceSha256Hex: run.sourceSha256Hex,
     workspaceId: run.workspaceId,
   });
+  if (persistenceOutcome !== "persisted") {
+    return persistenceOutcome;
+  }
 
   if (text === null && fileField.mimeType === PDF_MIME_TYPE) {
     await requestAutomaticDocumentOcr({
@@ -269,6 +285,7 @@ export const executeNativeExtraction = async ({
       workspaceId: run.workspaceId,
     });
   }
+  return persistenceOutcome;
 };
 
 /**

--- a/apps/api/src/mcp/tools.test.ts
+++ b/apps/api/src/mcp/tools.test.ts
@@ -59,6 +59,7 @@ const s3WriteMock = mock(async () => undefined);
 
 void mock.module("@/api/lib/s3", () => ({
   deleteS3ObjectWithSignal: s3DeleteMock,
+  getS3ObjectWithSignal: async () => await s3ArrayBufferMock(),
   getS3: () => ({ file: s3FileMock }),
   putS3ObjectWithSignal: s3WriteMock,
   resolveS3Credentials: async () => ({


### PR DESCRIPTION
## Summary

- persist native text extraction as durable document-processing runs
- reuse bounded retries, source fencing, reconciliation, and search-index replay for native extraction
- preserve PDF OCR fallback while covering DOCX and ready derivative-backed files
- add an online migration for the processing kind and recovery index

CC on behalf of jan-kubica


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for native document text extraction alongside OCR.
  * Expanded processing to cover more file types, including unencrypted files that can be handled without PDF conversion.

* **Bug Fixes**
  * Improved extraction reliability by using durable processing runs and better failure handling.
  * Updated indexing so extracted content is refreshed more consistently, including repair scenarios.

* **Documentation**
  * Updated supported processing behaviour and text-extraction handling across the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->