### PR TITLE
fix(web): read identity from the provider in the docx editor

### DIFF
--- a/.oxlint-plugins/__fixtures__/no-strict-route-read-in-chrome.fixture.tsx
+++ b/.oxlint-plugins/__fixtures__/no-strict-route-read-in-chrome.fixture.tsx
@@ -1,0 +1,36 @@
+// Passive regression fixture for
+// `no-strict-route-read-in-chrome/no-strict-route-read-in-chrome`.
+
+import {
+  getRouteApi,
+  useMatch,
+  useParams,
+  useRouteContext,
+} from "@tanstack/react-router";
+
+// Route-bound module binding in chrome — MUST flag.
+// oxlint-disable-next-line no-strict-route-read-in-chrome/no-strict-route-read-in-chrome
+const routeApi = getRouteApi("/_protected");
+
+export function ChromeFixture() {
+  // Strict context read — MUST flag. This is the docx-editor crash.
+  // oxlint-disable-next-line no-strict-route-read-in-chrome/no-strict-route-read-in-chrome
+  const user = useRouteContext({
+    from: "/_protected",
+    select: (ctx: { user: { id: string } }) => ctx.user.id,
+  });
+
+  // Strict match — MUST flag.
+  // oxlint-disable-next-line no-strict-route-read-in-chrome/no-strict-route-read-in-chrome
+  const match = useMatch({ from: "/_protected" });
+
+  // Opted out via shouldThrow — must NOT flag.
+  const safeMatch = useMatch({ from: "/_protected", shouldThrow: false });
+
+  // Opted out via strict — must NOT flag.
+  const safeParams = useParams({ strict: false });
+
+  return `${user}${match.id}${safeMatch?.id ?? ""}${String(
+    safeParams === undefined,
+  )}${routeApi.id}`;
+}

--- a/.oxlint-plugins/no-strict-route-read-in-chrome.ts
+++ b/.oxlint-plugins/no-strict-route-read-in-chrome.ts
@@ -1,0 +1,129 @@
+// Ban strict, route-scoped reads in persistent chrome.
+//
+// TanStack Router's `from:` reads are strict by default: `useRouteContext`,
+// `useParams`, `useSearch`, `useMatch`, and `useLoaderData` throw
+// `Invariant failed` when the named route is not in the current match tree.
+// That is correct inside route content, which only renders under its own
+// route. It is a latent crash in persistent chrome — the inspector, the
+// sidebar, the docx editor — which stays mounted across navigation and
+// therefore outlives the route it reads from. The moment the user opens a
+// route in another tree (`/law/*` is top level, not under `/_protected`),
+// the read throws and the surrounding error boundary swallows the component.
+//
+// The escape hatches are already the house style: `shouldThrow: false` on
+// `useMatch`/`useRouteContext`, `strict: false` on `useParams`/`useSearch`
+// (see inspector-panel.tsx, app-sidebar.tsx, the breadcrumbs). For identity,
+// read `useMaybeAuthenticatedUser` from @/lib/authenticated-user-context
+// rather than route context: the provider wraps every tree that can mount
+// chrome, so the value does not disappear on navigation.
+//
+// Scope this rule with `overrides.files` in oxlint.config.ts for chrome
+// modules; route and page content stays free to read strictly.
+
+import { getImportedName, isIdentifier } from "./utils.ts";
+
+const ROUTER_MODULE = "@tanstack/react-router";
+
+// Route-scoped reads that throw when their `from` route is unmatched.
+const STRICT_ROUTE_READS = new Set([
+  "useLoaderData",
+  "useMatch",
+  "useParams",
+  "useRouteContext",
+  "useSearch",
+]);
+
+// Properties that opt a read out of throwing. `shouldThrow` covers
+// useMatch/useRouteContext; `strict` covers useParams/useSearch.
+const OPT_OUT_PROPERTIES = new Set(["shouldThrow", "strict"]);
+
+const isFalseLiteral = (node) =>
+  node?.type === "Literal" && node.value === false;
+
+/** True when the options object disables throwing on an unmatched route. */
+const optsOutOfThrowing = (objectExpression) =>
+  objectExpression.properties.some(
+    (property) =>
+      property.type === "Property" &&
+      property.computed === false &&
+      isIdentifier(property.key) &&
+      OPT_OUT_PROPERTIES.has(property.key.name) &&
+      isFalseLiteral(property.value),
+  );
+
+const namesRoute = (objectExpression) =>
+  objectExpression.properties.some(
+    (property) =>
+      property.type === "Property" &&
+      property.computed === false &&
+      isIdentifier(property.key, "from"),
+  );
+
+export default {
+  meta: { name: "no-strict-route-read-in-chrome" },
+  rules: {
+    "no-strict-route-read-in-chrome": {
+      meta: {
+        type: "problem",
+        messages: {
+          strictRouteRead:
+            "Persistent chrome outlives the route it renders under, so a strict `from:` read throws Invariant failed on any route outside that tree. Pass `shouldThrow: false` (useMatch/useRouteContext) or `strict: false` (useParams/useSearch) and handle the absent case, or read the value from a provider that wraps every tree — useMaybeAuthenticatedUser for the current user.",
+          routeApiInChrome:
+            "getRouteApi binds this module to one route, but persistent chrome mounts across routes. Read the value non-strictly, or from a provider that wraps every tree.",
+        },
+      },
+      create(context) {
+        const strictReadAliases = new Map();
+        const routeApiAliases = new Set();
+
+        return {
+          ImportDeclaration(node) {
+            if (node.source?.value !== ROUTER_MODULE) {
+              return;
+            }
+            for (const specifier of node.specifiers) {
+              if (specifier.type !== "ImportSpecifier") {
+                continue;
+              }
+              const imported = getImportedName(specifier);
+              if (imported === "getRouteApi") {
+                routeApiAliases.add(specifier.local.name);
+                continue;
+              }
+              if (imported && STRICT_ROUTE_READS.has(imported)) {
+                strictReadAliases.set(specifier.local.name, imported);
+              }
+            }
+          },
+
+          CallExpression(node) {
+            const callee = node.callee;
+            if (!isIdentifier(callee)) {
+              return;
+            }
+
+            if (routeApiAliases.has(callee.name)) {
+              context.report({ node, messageId: "routeApiInChrome" });
+              return;
+            }
+
+            if (!strictReadAliases.has(callee.name)) {
+              return;
+            }
+
+            const options = node.arguments[0];
+            // No options at all is the non-strict form (`useParams()`).
+            if (options?.type !== "ObjectExpression") {
+              return;
+            }
+            if (!namesRoute(options) || optsOutOfThrowing(options)) {
+              return;
+            }
+
+            context.report({ node, messageId: "strictRouteRead" });
+          },
+        };
+      },
+    },
+  },
+};

--- a/apps/web/src/components/docx/docx-browser-editor.tsx
+++ b/apps/web/src/components/docx/docx-browser-editor.tsx
@@ -14,7 +14,6 @@ import {
 import type { CSSProperties, ReactNode, RefObject } from "react";
 
 import { keepPreviousData, useQuery } from "@tanstack/react-query";
-import { useRouteContext } from "@tanstack/react-router";
 import {
   CheckCircle2Icon,
   EyeIcon,
@@ -80,6 +79,7 @@ import { useExternalSyncEffect, useMountEffect } from "@/hooks/use-effect";
 import { useLatestCallback } from "@/hooks/use-latest-callback";
 import { getAnalytics } from "@/lib/analytics/provider";
 import { anonymizeChatTextInWorker } from "@/lib/anonymize/anonymize-chat-worker-client";
+import { useMaybeAuthenticatedUser } from "@/lib/authenticated-user-context";
 import { detached } from "@/lib/detached";
 import { fileOptions } from "@/lib/files/queries";
 import { folioUIComponents } from "@/lib/folio-ui-components";
@@ -1735,14 +1735,13 @@ const useDocxBrowserCollaboration = ({
     requestState.targetKey === targetKey
       ? requestState.requested
       : initiallyRequested;
-  const currentUser = useRouteContext({
-    from: "/_protected",
-    select: (ctx) => ({
-      email: ctx.user.email,
-      id: ctx.user.id,
-      name: ctx.user.name,
-    }),
-  });
+  // Read the identity from the provider, not from route context. The editor
+  // is persistent chrome: the inspector keeps it mounted across navigation,
+  // so a strict `useRouteContext({ from: "/_protected" })` throws the moment
+  // the user opens a route outside that tree (`/law/*` is top level).
+  // `AuthenticatedUserProvider` wraps both trees, and the maybe- variant keeps
+  // the editor renderable on public law routes that have no user at all.
+  const currentUser = useMaybeAuthenticatedUser();
   const collaborationEnabled =
     env.VITE_FEATURE_FOLIO_COLLAB && env.VITE_COLLAB_URL !== undefined;
   const collaborationState = useFolioCollaborationSession({
@@ -1750,10 +1749,12 @@ const useDocxBrowserCollaboration = ({
     entityId,
     fieldId,
     propertyId,
-    user: {
-      color: colorFromStableId(currentUser.id),
-      name: currentUser.name ?? currentUser.email,
-    },
+    user: currentUser
+      ? {
+          color: colorFromStableId(currentUser.id),
+          name: currentUser.name ?? currentUser.email,
+        }
+      : null,
     workspaceId,
   });
   useExternalSyncEffect(() => {

--- a/apps/web/src/components/docx/use-folio-collaboration-session.ts
+++ b/apps/web/src/components/docx/use-folio-collaboration-session.ts
@@ -58,10 +58,16 @@ type UseFolioCollaborationSessionOptions = {
   entityId: string;
   fieldId: string;
   propertyId: string;
+  /**
+   * Collaborator identity for awareness. Null when no authenticated user is
+   * in scope (the editor is persistent chrome and also mounts on public law
+   * routes), which disables the session: a collaboration cannot be opened
+   * without an identity to publish.
+   */
   user: {
     color: string;
     name: string;
-  };
+  } | null;
   workspaceId: string;
 };
 
@@ -130,10 +136,20 @@ export const useFolioCollaborationSession = ({
   });
 
   const collabUrl = env.VITE_COLLAB_URL;
-  const canConnect = enabled && collabUrl !== undefined;
+  // Read the identity as primitives: callers build the `user` object inline,
+  // so depending on the object itself would reconnect on every render.
+  const userColor = user?.color ?? null;
+  const userName = user?.name ?? null;
+  const canConnect =
+    enabled &&
+    collabUrl !== undefined &&
+    userColor !== null &&
+    userName !== null;
 
   useExternalSyncEffect(() => {
-    if (!canConnect) {
+    // The null checks are already folded into `canConnect`; repeating them
+    // here is what narrows the identity for the rest of the effect.
+    if (!canConnect || userColor === null || userName === null) {
       setState({ status: "idle", collaboration: null });
       return undefined;
     }
@@ -270,8 +286,8 @@ export const useFolioCollaborationSession = ({
         }
 
         awareness.setLocalStateField("user", {
-          color: user.color,
-          name: user.name,
+          color: userColor,
+          name: userName,
         });
 
         const invalidateSessionQueries = async () => {
@@ -427,8 +443,8 @@ export const useFolioCollaborationSession = ({
     propertyId,
     queryClient,
     t,
-    user.color,
-    user.name,
+    userColor,
+    userName,
     workspaceId,
   ]);
 

--- a/apps/web/src/components/docx/use-folio-collaboration-session.ts
+++ b/apps/web/src/components/docx/use-folio-collaboration-session.ts
@@ -147,9 +147,9 @@ export const useFolioCollaborationSession = ({
     userName !== null;
 
   useExternalSyncEffect(() => {
-    // The null checks are already folded into `canConnect`; repeating them
-    // here is what narrows the identity for the rest of the effect.
-    if (!canConnect || userColor === null || userName === null) {
+    // `canConnect` is a const boolean whose definition includes both null
+    // checks, so narrowing flows through it: the identity is non-null below.
+    if (!canConnect) {
       setState({ status: "idle", collaboration: null });
       return undefined;
     }

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -342,6 +342,7 @@ export default defineConfig({
     "./.oxlint-plugins/no-ref-mirror.ts",
     "./.oxlint-plugins/no-shared-suspense-query.ts",
     "./.oxlint-plugins/no-bare-chrome-query.ts",
+    "./.oxlint-plugins/no-strict-route-read-in-chrome.ts",
     "./.oxlint-plugins/require-router-select.ts",
     "./.oxlint-plugins/require-loader-prefetch.ts",
     "./.oxlint-plugins/require-matter-affordance.ts",
@@ -573,6 +574,15 @@ export default defineConfig({
       ],
       rules: {
         "require-loader-prefetch/require-loader-prefetch": "error",
+      },
+    },
+    {
+      files: [
+        ".oxlint-plugins/__fixtures__/no-strict-route-read-in-chrome.fixture.tsx",
+      ],
+      rules: {
+        "no-strict-route-read-in-chrome/no-strict-route-read-in-chrome":
+          "error",
       },
     },
     {
@@ -1389,6 +1399,27 @@ export default defineConfig({
       ],
       rules: {
         "no-bare-chrome-query/no-bare-chrome-query": "error",
+      },
+    },
+    {
+      // Persistent chrome outlives the route it renders under: the inspector
+      // keeps the document editor mounted across navigation, and `/law/*` is a
+      // top-level tree, so a strict `from:` read throws there. See
+      // apps/web/src/lib/authenticated-user-context.tsx for the identity read
+      // that survives navigation.
+      files: [
+        "apps/web/src/components/docx/**/*.tsx",
+        "apps/web/src/components/docx/**/*.ts",
+        "apps/web/src/components/inspector/**/*.tsx",
+        "apps/web/src/components/inspector/**/*.ts",
+        "apps/web/src/components/ai-suggestions/**/*.tsx",
+        "apps/web/src/components/ai-suggestions/**/*.ts",
+        "apps/web/src/components/app-sidebar.tsx",
+        "apps/web/src/components/sidebar-user-menu.tsx",
+      ],
+      rules: {
+        "no-strict-route-read-in-chrome/no-strict-route-read-in-chrome":
+          "error",
       },
     },
     {

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -1402,11 +1402,16 @@ export default defineConfig({
       },
     },
     {
-      // Persistent chrome outlives the route it renders under: the inspector
-      // keeps the document editor mounted across navigation, and `/law/*` is a
-      // top-level tree, so a strict `from:` read throws there. See
-      // apps/web/src/lib/authenticated-user-context.tsx for the identity read
-      // that survives navigation.
+      // Chrome that outlives the route tree it reads from: the inspector keeps
+      // the document editor mounted across navigation, and `/law/*` is a
+      // top-level tree, so a strict `from: "/_protected"` read throws there.
+      // See apps/web/src/lib/authenticated-user-context.tsx for the identity
+      // read that survives navigation.
+      //
+      // The sidebar and user menu are deliberately NOT listed: they render
+      // only inside `_protected` (`routes/_protected.tsx`), so a strict read
+      // bound to that tree can never outlive its match. Add a component here
+      // when it can be mounted while a different top-level tree is active.
       files: [
         "apps/web/src/components/docx/**/*.tsx",
         "apps/web/src/components/docx/**/*.ts",
@@ -1414,8 +1419,6 @@ export default defineConfig({
         "apps/web/src/components/inspector/**/*.ts",
         "apps/web/src/components/ai-suggestions/**/*.tsx",
         "apps/web/src/components/ai-suggestions/**/*.ts",
-        "apps/web/src/components/app-sidebar.tsx",
-        "apps/web/src/components/sidebar-user-menu.tsx",
       ],
       rules: {
         "no-strict-route-read-in-chrome/no-strict-route-read-in-chrome":


### PR DESCRIPTION
The docx editor is hosted by the inspector, which stays mounted across navigation, but it read its identity strictly from the `/_protected` route context. On a route tree that does not include `_protected` — the public law routes — that match no longer exists, so the read throws and the editor subtree falls into its error boundary until the user leaves the route. Reproducible in three steps: open a document in the inspector, open Case Law, open a decision. The read also sat above the collaboration feature check, so that flag could not gate it.

- The editor now reads `useMaybeAuthenticatedUser()`. `AuthenticatedUserProvider` wraps both the protected tree and the authenticated case-law workspace, so the identity survives navigation; the `maybe` variant exists for exactly this public-route case.
- `useFolioCollaborationSession` takes the identity as `{...} | null` and `canConnect` requires it, so a collaboration session cannot be opened without someone to publish as. Narrowing is on the name and colour primitives rather than the inline object, so the effect does not reconnect on every render.
- New `no-strict-route-read-in-chrome` oxlint rule: components that outlive their route (docx, inspector, ai-suggestions, sidebar, user menu) may not read route-scoped context strictly (`useRouteContext`, `useParams`, `useSearch`, `useMatch`, `useLoaderData`, `getRouteApi`) unless they opt out with `shouldThrow: false` / `strict: false`. The fixture asserts both directions. Scanning that scope found no other instances.

The inspector's own host component already read non-strict; the editor was the outlier.