### PR TITLE
fix: upgrade npm release workflow to v1.6.0

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -358,7 +358,7 @@ jobs:
       contents: write # Create immutable package tags and GitHub releases.
       id-token: write # Exchange a short-lived npm trusted-publishing credential.
     # The repository owner publishes this versioned shared contract.
-    uses: stella/.github/.github/workflows/npm-independent-release.yml@v1.5.1 # zizmor: ignore[unpinned-uses]
+    uses: stella/.github/.github/workflows/npm-independent-release.yml@v1.6.0 # zizmor: ignore[unpinned-uses]
     with:
       artifact-pattern: npm-tarball-*
       package-files: ${{ needs.pack.outputs.package_files }}


### PR DESCRIPTION
## Summary

- upgrade the shared npm release workflow from v1.5.1 to v1.6.0
- adopt bounded retries for GitHub draft-release visibility during staging verification

## Context

The previous workflow version hit the known read-after-write race in https://github.com/stella/stella/actions/runs/31021395118 after successfully creating the @stll/conditions@0.1.1 draft release.

## Verification

- git diff --check
- pre-push code-check, format, and i18n checks
- verified the v1.6.0 shared workflow tag and file

CC on behalf of jan-kubica

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the npm release workflow to use the latest reusable release configuration.
  * No changes were made to the application’s features or behaviour.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->