### PR TITLE
fix(web): keep chat process steps in one disclosure

### DIFF
--- a/apps/web/src/components/chat/chat-thread-messages.test.tsx
+++ b/apps/web/src/components/chat/chat-thread-messages.test.tsx
@@ -348,7 +348,7 @@ describe("chat thread messages", () => {
     expect(html).toContain("Searching chat history");
   });
 
-  test("folds a settled turn's process steps into one collapsed disclosure", () => {
+  test("folds process steps across invisible tool results into one disclosure", () => {
     const chatMessages: PersistedChatMessage[] = [
       {
         id: "message-A",
@@ -366,6 +366,28 @@ describe("chat thread messages", () => {
             output: {
               error: { name: "runtime", message: "value is not iterable" },
             },
+          },
+          {
+            type: "tool-result",
+            toolCallId: "tool-call-failed",
+            content: "value is not iterable",
+            state: "error",
+            error: "value is not iterable",
+          },
+          {
+            type: "tool-call",
+            id: "tool-call-complete",
+            name: "mcp__external-lookup",
+            arguments: JSON.stringify({ query: "governing law" }),
+            state: "complete",
+            input: { query: "governing law" },
+            output: { result: "Delaware" },
+          },
+          {
+            type: "tool-result",
+            toolCallId: "tool-call-complete",
+            content: "Delaware",
+            state: "complete",
           },
           { type: "text", content: "Here is the answer." },
         ],
@@ -389,7 +411,8 @@ describe("chat thread messages", () => {
     // The whole run sits behind one step-count summary, collapsed by
     // default; a failed step reads as a short human line with the raw
     // output tucked behind its own disclosure.
-    expect(html).toContain("2 steps");
+    expect(html).toContain("3 steps");
+    expect(html).not.toContain(">1 step<");
     expect(html).not.toContain("<details open");
     expect(html).toContain("This step failed — stella will work around it.");
     expect(html).toContain(">Show details<");

--- a/apps/web/src/components/chat/chat-thread-messages.tsx
+++ b/apps/web/src/components/chat/chat-thread-messages.tsx
@@ -1273,7 +1273,9 @@ const toAssistantPartRenderEntries = (
 };
 
 // "Process" parts are the low-emphasis progress rows of a turn: reasoning
-// trace disclosures and tool-step lines. Interactive tool cards (ask-user,
+// trace disclosures and tool-step lines. Tool-result parts are invisible
+// transport companions, so they stay inside a process run without becoming
+// visible steps or splitting the run. Interactive tool cards (ask-user,
 // create-document, approvals, subagent runs) read as answer content, so
 // they stay outside the folded process disclosure.
 const isProcessRenderEntry = (entry: AssistantPartRenderEntry): boolean => {
@@ -1282,6 +1284,9 @@ const isProcessRenderEntry = (entry: AssistantPartRenderEntry): boolean => {
   }
   const { part } = entry;
   if (part.type === "thinking") {
+    return true;
+  }
+  if (part.type === "tool-result") {
     return true;
   }
   return (
@@ -1303,6 +1308,9 @@ const isVisibleProcessEntry = (entry: AssistantPartRenderEntry): boolean => {
   const { part } = entry;
   if (part.type === "thinking") {
     return part.content.trim().length > 0;
+  }
+  if (part.type === "tool-result") {
+    return false;
   }
   if (part.type !== "tool-call") {
     return true;


### PR DESCRIPTION
## Summary

- keep invisible tool-result parts inside their surrounding process run
- exclude tool results from the visible step count
- cover realistic interleaved tool-call and tool-result sequences

## Problem

TanStack appends a tool-result part after each completed tool call. The renderer correctly emits no UI for those parts, but the grouping pass treated them as standard-content boundaries. A single reasoning run therefore appeared as several adjacent step disclosures.

## Verification

- 23 chat thread message tests passed
- web typecheck
- targeted type-aware lint and formatting checks
- pre-push code-check, format, and i18n checks

CC on behalf of sok0