### PR TITLE
fix(web): retain authenticated sidebar on law routes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -867,6 +867,7 @@ jobs:
           # These flags preserve the committed bundle baseline.
           VITE_FEATURE_TIME_BILLING: "true"
           VITE_PLAYBOOKS_ENABLED: "true"
+          VITE_PUBLIC_LAW_ENABLED: "true"
           VITE_WORKFLOWS_ENABLED: "true"
         run: bun --filter @stll/web build
 

--- a/.oxlint-plugins/__fixtures__/no-strict-route-read-in-chrome.fixture.tsx
+++ b/.oxlint-plugins/__fixtures__/no-strict-route-read-in-chrome.fixture.tsx
@@ -8,8 +8,6 @@ import {
   useRouteContext,
 } from "@tanstack/react-router";
 
-// Route-bound module binding in chrome — MUST flag.
-// oxlint-disable-next-line no-strict-route-read-in-chrome/no-strict-route-read-in-chrome
 const routeApi = getRouteApi("/_protected");
 
 export function ChromeFixture() {
@@ -30,7 +28,14 @@ export function ChromeFixture() {
   // Opted out via strict — must NOT flag.
   const safeParams = useParams({ strict: false });
 
+  // A route API's data hooks remain strict — MUST flag.
+  // oxlint-disable-next-line no-strict-route-read-in-chrome/no-strict-route-read-in-chrome
+  const routeUser = routeApi.useRouteContext();
+
+  // Navigation does not read the current route match — must NOT flag.
+  const navigate = routeApi.useNavigate();
+
   return `${user}${match.id}${safeMatch?.id ?? ""}${String(
     safeParams === undefined,
-  )}${routeApi.id}`;
+  )}${routeUser.user.id}${String(navigate)}`;
 }

--- a/.oxlint-plugins/no-strict-route-read-in-chrome.ts
+++ b/.oxlint-plugins/no-strict-route-read-in-chrome.ts
@@ -11,11 +11,13 @@
 // the read throws and the surrounding error boundary swallows the component.
 //
 // The escape hatches are already the house style: `shouldThrow: false` on
-// `useMatch`/`useRouteContext`, `strict: false` on `useParams`/`useSearch`
-// (see inspector-panel.tsx, app-sidebar.tsx, the breadcrumbs). For identity,
-// read `useMaybeAuthenticatedUser` from @/lib/authenticated-user-context
-// rather than route context: the provider wraps every tree that can mount
-// chrome, so the value does not disappear on navigation.
+// `useMatch`, `strict: false` on `useParams`/`useSearch`/`useRouteContext`
+// (see inspector-panel.tsx, app-sidebar.tsx, the breadcrumbs). A route API's
+// navigation helper is also safe because it does not read the current match;
+// its route-bound data hooks are not. For identity, read
+// `useMaybeAuthenticatedUser` from @/lib/authenticated-user-context rather
+// than route context: the provider wraps every tree that can mount chrome, so
+// the value does not disappear on navigation.
 //
 // Scope this rule with `overrides.files` in oxlint.config.ts for chrome
 // modules; route and page content stays free to read strictly.
@@ -33,8 +35,8 @@ const STRICT_ROUTE_READS = new Set([
   "useSearch",
 ]);
 
-// Properties that opt a read out of throwing. `shouldThrow` covers
-// useMatch/useRouteContext; `strict` covers useParams/useSearch.
+// Properties that opt a read out of throwing. `shouldThrow` covers useMatch;
+// `strict` covers the route data hooks.
 const OPT_OUT_PROPERTIES = new Set(["shouldThrow", "strict"]);
 
 const isFalseLiteral = (node) =>
@@ -67,14 +69,15 @@ export default {
         type: "problem",
         messages: {
           strictRouteRead:
-            "Persistent chrome outlives the route it renders under, so a strict `from:` read throws Invariant failed on any route outside that tree. Pass `shouldThrow: false` (useMatch/useRouteContext) or `strict: false` (useParams/useSearch) and handle the absent case, or read the value from a provider that wraps every tree — useMaybeAuthenticatedUser for the current user.",
-          routeApiInChrome:
-            "getRouteApi binds this module to one route, but persistent chrome mounts across routes. Read the value non-strictly, or from a provider that wraps every tree.",
+            "Persistent chrome outlives the route it renders under, so a strict `from:` read throws Invariant failed on any route outside that tree. Pass `shouldThrow: false` (useMatch) or `strict: false` (route data hooks) and handle the absent case, or read the value from a provider that wraps every tree — useMaybeAuthenticatedUser for the current user.",
+          routeApiStrictRead:
+            "This route API data hook is bound strictly to one route, but persistent chrome mounts across routes. Use a non-strict router hook, or read the value from a provider that wraps every tree.",
         },
       },
       create(context) {
+        const getRouteApiAliases = new Set();
+        const routeApiBindings = new Set();
         const strictReadAliases = new Map();
-        const routeApiAliases = new Set();
 
         return {
           ImportDeclaration(node) {
@@ -87,7 +90,7 @@ export default {
               }
               const imported = getImportedName(specifier);
               if (imported === "getRouteApi") {
-                routeApiAliases.add(specifier.local.name);
+                getRouteApiAliases.add(specifier.local.name);
                 continue;
               }
               if (imported && STRICT_ROUTE_READS.has(imported)) {
@@ -96,18 +99,36 @@ export default {
             }
           },
 
+          VariableDeclarator(node) {
+            if (!isIdentifier(node.id)) {
+              return;
+            }
+            const init = node.init;
+            if (
+              init?.type !== "CallExpression" ||
+              !isIdentifier(init.callee) ||
+              !getRouteApiAliases.has(init.callee.name)
+            ) {
+              return;
+            }
+            routeApiBindings.add(node.id.name);
+          },
+
           CallExpression(node) {
             const callee = node.callee;
-            if (!isIdentifier(callee)) {
+            if (
+              callee?.type === "MemberExpression" &&
+              callee.computed === false &&
+              isIdentifier(callee.object) &&
+              routeApiBindings.has(callee.object.name) &&
+              isIdentifier(callee.property) &&
+              STRICT_ROUTE_READS.has(callee.property.name)
+            ) {
+              context.report({ node, messageId: "routeApiStrictRead" });
               return;
             }
 
-            if (routeApiAliases.has(callee.name)) {
-              context.report({ node, messageId: "routeApiInChrome" });
-              return;
-            }
-
-            if (!strictReadAliases.has(callee.name)) {
+            if (!isIdentifier(callee) || !strictReadAliases.has(callee.name)) {
               return;
             }
 

--- a/apps/web/e2e/specs/law-authenticated-sidebar.spec.ts
+++ b/apps/web/e2e/specs/law-authenticated-sidebar.spec.ts
@@ -1,0 +1,24 @@
+import { expect, test } from "../helpers/test";
+import { createTestWorkspace, deleteTestWorkspace } from "../helpers/workspace";
+
+test("authenticated law pages retain the user's recent matters", async ({
+  page,
+  request,
+}) => {
+  const label = "law-sidebar";
+  const workspace = await createTestWorkspace(request, label);
+  const workspaceName = `${label}-${workspace.id.slice(0, 8)}`;
+
+  try {
+    await page.goto("/law/cases", { waitUntil: "domcontentloaded" });
+
+    await expect(page).toHaveURL(/\/law\/cases(?:[/?#]|$)/u);
+    await expect(
+      page
+        .locator('[data-slot="sidebar"]')
+        .getByText(workspaceName, { exact: true }),
+    ).toBeVisible({ timeout: 30_000 });
+  } finally {
+    await deleteTestWorkspace(request, workspace.id);
+  }
+});

--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -100,6 +100,7 @@ import { usePermissions } from "@/hooks/use-permissions";
 import { usePlaybooksPreviewEnabled } from "@/hooks/use-playbooks-preview";
 import { usePublicLawPreviewEnabled } from "@/hooks/use-public-law-preview";
 import { useWorkflowsPreviewEnabled } from "@/hooks/use-workflows-preview";
+import { useAuthenticatedUser } from "@/lib/authenticated-user-context";
 import { isPlaceholderThreadTitle } from "@/lib/chat-thread-title";
 import { SIDE_RAIL_ICON_BUTTON_SIZE } from "@/lib/consts";
 import { detached } from "@/lib/detached";
@@ -138,9 +139,7 @@ export function AppSidebar(props: AppSidebarProps) {
   const primaryNavItems = getWorkspacePrimaryNavItems({
     includePublicLaw: publicLawPreviewEnabled,
   });
-  const user = routeApi.useRouteContext({
-    select: (ctx) => ctx.user,
-  });
+  const user = useAuthenticatedUser();
 
   const [searchOpen, setSearchOpen] = useState(false);
   const [pendingEntityDrop, setPendingEntityDrop] =

--- a/apps/web/src/components/contact-picker.tsx
+++ b/apps/web/src/components/contact-picker.tsx
@@ -2,7 +2,6 @@ import { useState } from "react";
 import type * as React from "react";
 
 import { useQuery } from "@tanstack/react-query";
-import { useRouteContext } from "@tanstack/react-router";
 import { BuildingIcon, PlusIcon, SearchIcon, UserIcon } from "lucide-react";
 import { useDebouncedCallback } from "use-debounce";
 import { useTranslations } from "use-intl";
@@ -18,6 +17,7 @@ import {
 } from "@stll/ui/components/combobox";
 
 import { contactPickerSearchOptions } from "@/components/contact-picker-queries";
+import { useAuthenticatedUser } from "@/lib/authenticated-user-context";
 
 type ContactResult = {
   id: string;
@@ -62,10 +62,7 @@ export const ContactPicker = ({
   inputRef,
 }: ContactPickerProps) => {
   const t = useTranslations();
-  const activeOrganizationId = useRouteContext({
-    from: "/_protected",
-    select: (ctx) => ctx.user.activeOrganizationId,
-  });
+  const activeOrganizationId = useAuthenticatedUser().activeOrganizationId;
   const [query, setQuery] = useState("");
   const [debouncedQuery, setDebouncedQuery] = useState("");
 

--- a/apps/web/src/components/workspaces/create-matter-dialog.tsx
+++ b/apps/web/src/components/workspaces/create-matter-dialog.tsx
@@ -1,7 +1,7 @@
 import { useRef, useState } from "react";
 
 import { useQueryClient } from "@tanstack/react-query";
-import { getRouteApi, useNavigate } from "@tanstack/react-router";
+import { useNavigate } from "@tanstack/react-router";
 import { Result } from "better-result";
 import {
   BuildingIcon,
@@ -46,6 +46,7 @@ import {
 } from "@/components/workspaces/create-matter-dialog.logic";
 import { useChromeQuery } from "@/hooks/use-chrome-query";
 import { useLocale } from "@/i18n/formatting-context";
+import { useAuthenticatedUser } from "@/lib/authenticated-user-context";
 import { useCreateContact } from "@/lib/contacts/mutations";
 import { contactsKeys } from "@/lib/contacts/queries";
 import { detached } from "@/lib/detached";
@@ -56,8 +57,6 @@ import type { MatterDraftClient } from "@/lib/workspaces/create-matter-store";
 import { useCreateMatterStore } from "@/lib/workspaces/create-matter-store";
 import { useCreateWorkspace } from "@/lib/workspaces/mutations";
 import { workspacesOptions } from "@/lib/workspaces/queries";
-
-const routeApi = getRouteApi("/_protected");
 
 const SelectedClient = ({ client }: { client: MatterDraftClient }) => (
   <div className="bg-muted/40 flex items-center gap-2 rounded-lg border px-3 py-2">
@@ -197,9 +196,7 @@ const CreateMatterDialogBody = ({
   const t = useTranslations();
   const locale = useLocale();
   const navigate = useNavigate();
-  const currentUser = routeApi.useRouteContext({
-    select: (ctx) => ctx.user,
-  });
+  const currentUser = useAuthenticatedUser();
   const queryClient = useQueryClient();
   const createWorkspace = useCreateWorkspace();
   const createContact = useCreateContact();

--- a/apps/web/src/routes/law/-components/public-law-shell.tsx
+++ b/apps/web/src/routes/law/-components/public-law-shell.tsx
@@ -52,10 +52,21 @@ import {
 import { detached } from "@/lib/detached";
 import { HOTKEYS } from "@/lib/hotkeys";
 import { isPublicLawRouteEnabled } from "@/lib/public-law-launch";
+import { useCreateMatterStore } from "@/lib/workspaces/create-matter-store";
 
 const SignInDialog = lazy(async () => {
   const module = await import("@/components/auth/sign-in-dialog");
   return { default: module.SignInDialog };
+});
+
+const AppSidebar = lazy(async () => {
+  const module = await import("@/components/app-sidebar");
+  return { default: module.AppSidebar };
+});
+
+const CreateMatterDialog = lazy(async () => {
+  const module = await import("@/components/workspaces/create-matter-dialog");
+  return { default: module.CreateMatterDialog };
 });
 
 const SearchDialog = lazy(async () => {
@@ -65,6 +76,9 @@ const SearchDialog = lazy(async () => {
 
 export function PublicLawShell() {
   const authStatus = useClientAuthStatus();
+  const createMatterDialogOpen = useCreateMatterStore(
+    (state) => state.dialog.status === "open",
+  );
   const [authRedirectTo, setAuthRedirectTo] = useState<string | null>(null);
   const requestAuth = (redirectTo: string) => {
     setAuthRedirectTo(redirectTo);
@@ -72,7 +86,20 @@ export function PublicLawShell() {
 
   const shell = (
     <SidebarProvider>
-      <PublicLawSidebar authStatus={authStatus} requestAuth={requestAuth} />
+      {authStatus.isAuthenticated ? (
+        <Suspense
+          fallback={
+            <PublicLawSidebar
+              authStatus={authStatus}
+              requestAuth={requestAuth}
+            />
+          }
+        >
+          <AppSidebar />
+        </Suspense>
+      ) : (
+        <PublicLawSidebar authStatus={authStatus} requestAuth={requestAuth} />
+      )}
       <SidebarInset className="flex flex-col">
         <PublicLawTopBar />
         <Outlet />
@@ -91,6 +118,11 @@ export function PublicLawShell() {
             open
             redirectTo={authRedirectTo}
           />
+        </Suspense>
+      )}
+      {authStatus.isAuthenticated && createMatterDialogOpen && (
+        <Suspense fallback={null}>
+          <CreateMatterDialog />
         </Suspense>
       )}
     </SidebarProvider>

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -1408,9 +1408,9 @@ export default defineConfig({
       // See apps/web/src/lib/authenticated-user-context.tsx for the identity
       // read that survives navigation.
       //
-      // The sidebar and user menu are deliberately NOT listed: they render
-      // only inside `_protected` (`routes/_protected.tsx`), so a strict read
-      // bound to that tree can never outlive its match. Add a component here
+      // The authenticated sidebar and user menu render in both `_protected`
+      // and the top-level `/law` tree. Their create-matter flow does too, so
+      // those modules must remain route-neutral. Add another component here
       // when it can be mounted while a different top-level tree is active.
       files: [
         "apps/web/src/components/docx/**/*.tsx",
@@ -1419,6 +1419,10 @@ export default defineConfig({
         "apps/web/src/components/inspector/**/*.ts",
         "apps/web/src/components/ai-suggestions/**/*.tsx",
         "apps/web/src/components/ai-suggestions/**/*.ts",
+        "apps/web/src/components/app-sidebar.tsx",
+        "apps/web/src/components/contact-picker.tsx",
+        "apps/web/src/components/sidebar-user-menu.tsx",
+        "apps/web/src/components/workspaces/create-matter-dialog.tsx",
       ],
       rules: {
         "no-strict-route-read-in-chrome/no-strict-route-read-in-chrome":


### PR DESCRIPTION
Stacked on #1727.

Authenticated users currently receive the public-law sidebar on /law, so their pinned and recent matters disappear even though the route recognizes their session.

- Render the full application sidebar for authenticated law users while retaining the lightweight public sidebar for anonymous visitors and during lazy loading.
- Make sidebar identity, matter creation, and contact selection read from AuthenticatedUserProvider instead of the protected route tree.
- Refine the persistent-chrome lint rule so route-bound data reads remain forbidden while safe route API navigation remains available.
- Add an authenticated browser regression that creates a matter, opens /law/cases, and verifies the matter remains visible.

Validation:
- bun run code-check
- bun run --cwd apps/web typecheck
- bun run --cwd apps/web build
- bun test apps/web/src/components/app-sidebar.logic.test.ts
- Playwright test discovery for law-authenticated-sidebar.spec.ts

The live Playwright scenario requires the repository web/API test stack and is expected to run in CI.