### PR TITLE
fix(web): show where a dragged view lands, and keep the tab underline in sync

### DIFF
--- a/apps/web/src/components/docx/docx-browser-editor.tsx
+++ b/apps/web/src/components/docx/docx-browser-editor.tsx
@@ -45,14 +45,15 @@ import {
   SelectValue as StSelectValue,
 } from "@stll/ui/components/select";
 import { stellaToast } from "@stll/ui/components/toast";
+import { composeRefs } from "@stll/ui/lib/utils";
 
 import { useActiveDocxStore } from "@/components/ai-suggestions/active-docx-store";
 import type { ActiveDocxRegistrationToken } from "@/components/ai-suggestions/active-docx-store";
 import { FileViewerWithAI } from "@/components/ai-suggestions/file-viewer-with-ai";
 import { ReviewBar } from "@/components/ai-suggestions/review-bar";
-import { useReviewStore } from "@/components/ai-suggestions/review-store";
 import "@stll/folio-react/editor.css";
 
+import { useReviewStore } from "@/components/ai-suggestions/review-store";
 import { useAutocompleteStream } from "@/components/autocomplete/use-autocomplete-stream";
 import {
   useDocxFitZoom,
@@ -83,7 +84,6 @@ import { useMaybeAuthenticatedUser } from "@/lib/authenticated-user-context";
 import { detached } from "@/lib/detached";
 import { fileOptions } from "@/lib/files/queries";
 import { folioUIComponents } from "@/lib/folio-ui-components";
-import { composeRefs } from "@/lib/utils";
 import { anonymizationAllowlistOptions } from "@/lib/workspaces/queries/anonymization-allowlist";
 import "@/components/pdf/peek/peek-docx.css";
 import { anonymizationTermsOptions } from "@/lib/workspaces/queries/anonymization-terms";

--- a/apps/web/src/components/inspector/use-anchored-menu.tsx
+++ b/apps/web/src/components/inspector/use-anchored-menu.tsx
@@ -59,5 +59,5 @@ export const useAnchoredMenu = ({ children }: { children: ReactNode }) => {
     </Menu>
   );
 
-  return { openAt, close, element };
+  return { open, openAt, close, element };
 };

--- a/apps/web/src/components/markdown/markdown-folio-editor.impl.tsx
+++ b/apps/web/src/components/markdown/markdown-folio-editor.impl.tsx
@@ -9,7 +9,7 @@ import { fromMarkdown, toMarkdown } from "@stll/folio-react";
 import type { Document, MarkdownOptions } from "@stll/folio-react";
 import { Button } from "@stll/ui/components/button";
 import { Textarea } from "@stll/ui/components/textarea";
-import { cn } from "@stll/ui/lib/utils";
+import { cn, composeRefs } from "@stll/ui/lib/utils";
 
 import {
   DOCX_PAGE_WIDTH,
@@ -18,7 +18,6 @@ import {
 } from "@/components/docx-preview-zoom";
 import { DocxEditor } from "@/components/docx/app-docx-editor";
 import type { DocxEditorRef } from "@/components/docx/app-docx-editor";
-import { composeRefs } from "@/lib/utils";
 
 // Flatten Word constructs markdown can't carry so the emitted markdown stays
 // clean: drop comments/annotations, flatten tracked changes, inline links,

--- a/apps/web/src/components/pdf/peek/peek-pdf-viewer.tsx
+++ b/apps/web/src/components/pdf/peek/peek-pdf-viewer.tsx
@@ -27,6 +27,8 @@ import type { OverlayLayer } from "@stll/ui/lib/overlay-layer";
 import "@stll/folio-react/editor.css";
 
 import "./peek-docx.css";
+import { composeRefs } from "@stll/ui/lib/utils";
+
 import { FileViewerWithAI } from "@/components/ai-suggestions/file-viewer-with-ai";
 import {
   useDocxFitZoom,
@@ -56,7 +58,6 @@ import type { SearchMatchSummary } from "@/lib/search-match-navigation";
 import { MAX_SEARCH_PREVIEW_MATCHES } from "@/lib/search-match-navigation";
 import { searchTextQueryKey } from "@/lib/search-text";
 import type { SearchTextQuery } from "@/lib/search-text";
-import { composeRefs } from "@/lib/utils";
 
 const DocxEditor = lazy(async () => {
   const m = await import("@/components/docx/app-docx-editor");

--- a/apps/web/src/lib/pdf/pdf-viewport.tsx
+++ b/apps/web/src/lib/pdf/pdf-viewport.tsx
@@ -10,6 +10,7 @@ import { useShallow } from "zustand/react/shallow";
 import { Button } from "@stll/ui/components/button";
 import { Field, FieldError, FieldLabel } from "@stll/ui/components/field";
 import { ScrollArea } from "@stll/ui/components/scroll-area";
+import { composeRefs } from "@stll/ui/lib/utils";
 
 import { SecretInput } from "@/components/secret-input";
 import { useTheme } from "@/components/theme-provider";
@@ -31,7 +32,6 @@ import {
 } from "@/lib/search-match-navigation";
 import { getSearchTextCandidates } from "@/lib/search-text";
 import type { SearchTextQuery } from "@/lib/search-text";
-import { composeRefs } from "@/lib/utils";
 
 export { usePDFStore } from "@/lib/pdf/pdf-context";
 

--- a/apps/web/src/lib/utils.ts
+++ b/apps/web/src/lib/utils.ts
@@ -1,5 +1,3 @@
-import type * as React from "react";
-
 /**
  * Type-narrowing `.includes()` that avoids
  * `as readonly string[]` at every call site.
@@ -10,51 +8,6 @@ export const includesValue = <T extends string>(
   arr: readonly T[],
   value: string,
 ): value is T => arr.some((candidate) => candidate === value);
-
-/**
- * Compose multiple refs into a single ref callback.
- * Adapted from `@radix-ui/react-compose-refs` (MIT).
- *
- * Collects cleanup functions returned by React 19 ref
- * callbacks and returns a combined cleanup so React can
- * invoke it on unmount instead of re-calling with `null`.
- */
-export const composeRefs =
-  <T>(
-    ...refs: (React.Ref<T> | undefined)[]
-  ): ((node: T | null) => (() => void) | undefined) =>
-  (node) => {
-    const cleanups: (() => void)[] = [];
-    for (const ref of refs) {
-      if (typeof ref === "function") {
-        const cleanup = ref(node);
-        if (typeof cleanup === "function") {
-          cleanups.push(() => {
-            cleanup();
-          });
-        } else if (node !== null) {
-          cleanups.push(() => {
-            ref(null);
-          });
-        }
-      } else if (ref !== undefined && ref !== null) {
-        ref.current = node;
-        if (node !== null) {
-          cleanups.push(() => {
-            ref.current = null;
-          });
-        }
-      }
-    }
-    if (cleanups.length > 0) {
-      return () => {
-        for (const cleanup of cleanups) {
-          cleanup();
-        }
-      };
-    }
-    return undefined;
-  };
 
 export const shuffleArray = <T>(originalArray: readonly T[]): T[] => {
   const array = [...originalArray];

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/$viewId.document.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/$viewId.document.tsx
@@ -39,7 +39,7 @@ import {
   DialogTitle,
 } from "@stll/ui/components/dialog";
 import "@stll/folio-react/editor.css";
-import { cn } from "@stll/ui/lib/utils";
+import { cn, composeRefs } from "@stll/ui/lib/utils";
 
 import {
   useDocxFitZoom,
@@ -69,7 +69,6 @@ import {
 import { getPDFPageIdByNumber } from "@/lib/pdf/utils";
 import { ensureRouteQueryData, prefetchRouteQuery } from "@/lib/react-query";
 import { toSafeId } from "@/lib/safe-id";
-import { composeRefs } from "@/lib/utils";
 import { docxSuggestionsOptions } from "@/lib/workspaces/queries/docx-suggestions";
 import { entityOptions } from "@/lib/workspaces/queries/entities";
 import {

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-switcher.logic.test.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-switcher.logic.test.ts
@@ -16,8 +16,8 @@ describe("view tab reordering", () => {
             targetId,
             position,
           });
-          // A drop that changes nothing reports `null`; the resulting order is
-          // then the one already on screen, and must satisfy the same invariant.
+          // A drop that changes nothing reports `null`; the order on screen
+          // then stands, and must satisfy the same invariant.
           const order = reordered ?? [...IDS];
 
           expect([...order].sort()).toEqual([...IDS].sort());

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-switcher.logic.test.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-switcher.logic.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, test } from "bun:test";
+
+import { reorderViewIds, toViewDropPosition } from "./view-switcher.logic";
+
+const IDS = ["overview", "table", "files", "kanban", "calendar"] as const;
+const POSITIONS = ["before", "after"] as const;
+
+describe("view tab reordering", () => {
+  test("lands the dragged view beside the target on the requested side", () => {
+    for (const draggedId of IDS) {
+      for (const targetId of IDS) {
+        for (const position of POSITIONS) {
+          const reordered = reorderViewIds({
+            ids: IDS,
+            draggedId,
+            targetId,
+            position,
+          });
+          // A drop that changes nothing reports `null`; the resulting order is
+          // then the one already on screen, and must satisfy the same invariant.
+          const order = reordered ?? [...IDS];
+
+          expect([...order].sort()).toEqual([...IDS].sort());
+
+          if (draggedId === targetId) {
+            expect(reordered).toBeNull();
+            continue;
+          }
+
+          expect(order.indexOf(draggedId)).toBe(
+            order.indexOf(targetId) + (position === "after" ? 1 : -1),
+          );
+        }
+      }
+    }
+  });
+
+  test("reports no change when the view already sits on that side", () => {
+    expect(
+      reorderViewIds({
+        ids: IDS,
+        draggedId: "table",
+        targetId: "overview",
+        position: "after",
+      }),
+    ).toBeNull();
+    expect(
+      reorderViewIds({
+        ids: IDS,
+        draggedId: "table",
+        targetId: "files",
+        position: "before",
+      }),
+    ).toBeNull();
+  });
+
+  test("ignores views that are not in the list", () => {
+    expect(
+      reorderViewIds({
+        ids: IDS,
+        draggedId: "deleted-elsewhere",
+        targetId: "table",
+        position: "before",
+      }),
+    ).toBeNull();
+    expect(
+      reorderViewIds({
+        ids: IDS,
+        draggedId: "table",
+        targetId: "deleted-elsewhere",
+        position: "before",
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("drop edge resolution", () => {
+  test("mirrors the trailing edge under rtl", () => {
+    expect(toViewDropPosition("right", "ltr")).toBe("after");
+    expect(toViewDropPosition("left", "ltr")).toBe("before");
+    expect(toViewDropPosition("right", "rtl")).toBe("before");
+    expect(toViewDropPosition("left", "rtl")).toBe("after");
+  });
+
+  test("ignores edges off the inline axis", () => {
+    expect(toViewDropPosition("top", "ltr")).toBeNull();
+    expect(toViewDropPosition("bottom", "ltr")).toBeNull();
+    expect(toViewDropPosition(null, "ltr")).toBeNull();
+  });
+});

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-switcher.logic.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-switcher.logic.ts
@@ -3,9 +3,8 @@ import type { Edge } from "@atlaskit/pragmatic-drag-and-drop-hitbox/closest-edge
 import type { TextDirection } from "@/i18n/i18n-store";
 
 /**
- * Where a dragged view lands relative to the tab it was dropped on. Stated in
- * logical terms so the caller resolves the physical edge once, at the point
- * where the writing direction is known.
+ * Where a dragged view lands relative to the tab it was dropped on. Logical, so
+ * the caller resolves the physical edge once, where the direction is known.
  */
 export type ViewDropPosition = "before" | "after";
 
@@ -40,12 +39,8 @@ type ReorderViewIdsArgs = {
  * relative to the target rather than by its index, so the result depends only
  * on which edge was hit and never on the direction the tab was dragged from.
  *
- * Deliberately not `reorderWithEdge` from
- * `@atlaskit/pragmatic-drag-and-drop-hitbox/util/reorder-with-edge`, which is
- * already a dependency: it hardcodes `right` as "later in the order" and so
- * mirrors wrongly under an RTL UI, and it works in indexes, which is what made
- * the original drop ambiguous. Take a `ViewDropPosition` instead, resolved
- * against the writing direction by `toViewDropPosition`.
+ * Not `reorderWithEdge` from the hitbox package, already a dependency: it
+ * hardcodes `right` as later in the order, so it mirrors wrongly under RTL.
  */
 export const reorderViewIds = ({
   ids,

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-switcher.logic.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-switcher.logic.ts
@@ -39,6 +39,13 @@ type ReorderViewIdsArgs = {
  * `null` when the drop changes nothing. The insertion point is expressed
  * relative to the target rather than by its index, so the result depends only
  * on which edge was hit and never on the direction the tab was dragged from.
+ *
+ * Deliberately not `reorderWithEdge` from
+ * `@atlaskit/pragmatic-drag-and-drop-hitbox/util/reorder-with-edge`, which is
+ * already a dependency: it hardcodes `right` as "later in the order" and so
+ * mirrors wrongly under an RTL UI, and it works in indexes, which is what made
+ * the original drop ambiguous. Take a `ViewDropPosition` instead, resolved
+ * against the writing direction by `toViewDropPosition`.
  */
 export const reorderViewIds = ({
   ids,

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-switcher.logic.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-switcher.logic.ts
@@ -1,0 +1,66 @@
+import type { Edge } from "@atlaskit/pragmatic-drag-and-drop-hitbox/closest-edge";
+
+import type { TextDirection } from "@/i18n/i18n-store";
+
+/**
+ * Where a dragged view lands relative to the tab it was dropped on. Stated in
+ * logical terms so the caller resolves the physical edge once, at the point
+ * where the writing direction is known.
+ */
+export type ViewDropPosition = "before" | "after";
+
+/**
+ * Maps the physical edge the pointer is closest to onto a position in the view
+ * order. `right` means "later in the order" only under `ltr`; in `rtl` the tab
+ * strip is mirrored and the left edge is the trailing one.
+ */
+export const toViewDropPosition = (
+  edge: Edge | null,
+  direction: TextDirection,
+): ViewDropPosition | null => {
+  if (edge !== "left" && edge !== "right") {
+    return null;
+  }
+
+  const isTrailingEdge =
+    direction === "rtl" ? edge === "left" : edge === "right";
+  return isTrailingEdge ? "after" : "before";
+};
+
+type ReorderViewIdsArgs = {
+  ids: readonly string[];
+  draggedId: string;
+  targetId: string;
+  position: ViewDropPosition;
+};
+
+/**
+ * Returns the view order produced by dropping `draggedId` beside `targetId`, or
+ * `null` when the drop changes nothing. The insertion point is expressed
+ * relative to the target rather than by its index, so the result depends only
+ * on which edge was hit and never on the direction the tab was dragged from.
+ */
+export const reorderViewIds = ({
+  ids,
+  draggedId,
+  targetId,
+  position,
+}: ReorderViewIdsArgs): string[] | null => {
+  if (
+    draggedId === targetId ||
+    !ids.includes(draggedId) ||
+    !ids.includes(targetId)
+  ) {
+    return null;
+  }
+
+  const withoutDragged = ids.filter((id) => id !== draggedId);
+  const targetIndex = withoutDragged.indexOf(targetId);
+  const reordered = withoutDragged.toSpliced(
+    position === "after" ? targetIndex + 1 : targetIndex,
+    0,
+    draggedId,
+  );
+
+  return reordered.every((id, index) => id === ids[index]) ? null : reordered;
+};

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-switcher.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-switcher.tsx
@@ -58,6 +58,8 @@ import { useAnchoredMenu } from "@/components/inspector/use-anchored-menu";
 import { useExternalSyncEffect } from "@/hooks/use-effect";
 import { useLatestCallback } from "@/hooks/use-latest-callback";
 import { usePermissions } from "@/hooks/use-permissions";
+import type { TextDirection } from "@/i18n/i18n-store";
+import { getLangDir, useI18nStore } from "@/i18n/i18n-store";
 import type { TranslationKey } from "@/i18n/types";
 import type { WorkspaceView } from "@/lib/types";
 import { viewsOptions } from "@/lib/workspaces/queries/views";
@@ -81,18 +83,16 @@ import {
 const VIEW_DRAG_TYPE = "stella/view-id";
 
 type ViewDropTarget = {
-  element: Element;
   data: Record<string | symbol, unknown>;
 };
 
 // The strip mirrors under an RTL UI, so the physical edge the pointer is
 // nearest only names a position once it is read against the direction the tab
 // is laid out in.
-const resolveDropPosition = ({ element, data }: ViewDropTarget) =>
-  toViewDropPosition(
-    extractClosestEdge(data),
-    getComputedStyle(element).direction === "rtl" ? "rtl" : "ltr",
-  );
+const resolveDropPosition = (
+  { data }: ViewDropTarget,
+  direction: TextDirection,
+) => toViewDropPosition(extractClosestEdge(data), direction);
 
 const REQUIRED_VIEW_LAYOUTS: readonly ViewLayoutType[] = Object.freeze([
   "overview",
@@ -209,6 +209,25 @@ export const ViewSwitcher = ({
   const disallowedTemplateLayouts = new Set<ViewLayoutType>(
     hasOverviewView ? ["overview"] : [],
   );
+  const [stripContainer, setStripContainer] = useState<HTMLDivElement | null>(
+    null,
+  );
+
+  // Bounds the tabs' stickiness. A sticky drop target survives the pointer
+  // leaving it only while its parent target is unchanged, so without a target
+  // around the strip the tabs stay sticky across the whole page: the insertion
+  // line would stay lit over unrelated chrome, and releasing there would
+  // reorder. This target is not sticky itself, so leaving the strip drops the
+  // tab out with it.
+  useExternalSyncEffect(() => {
+    if (!stripContainer) {
+      return undefined;
+    }
+    return dropTargetForElements({
+      element: stripContainer,
+      canDrop: ({ source }) => source.data["type"] === VIEW_DRAG_TYPE,
+    });
+  }, [stripContainer]);
 
   const handleReorder = (
     draggedId: string,
@@ -240,7 +259,10 @@ export const ViewSwitcher = ({
   };
 
   return (
-    <div className="flex min-w-0 flex-1 [scrollbar-width:none] items-center gap-1 overflow-x-auto px-2 [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden">
+    <div
+      className="flex min-w-0 flex-1 [scrollbar-width:none] items-center gap-1 overflow-x-auto px-2 [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden"
+      ref={setStripContainer}
+    >
       <Tabs value={activeViewId}>
         <TabsList variant="underline">
           {views.map((view) => {
@@ -259,7 +281,7 @@ export const ViewSwitcher = ({
                       })
                     : null
                 }
-                isMenuOpen={viewActions.isMenuOpen}
+                isAnyMenuOpen={viewActions.isAnyMenuOpen}
                 isRenaming={renamingViewId === view.id}
                 key={view.id}
                 onOpenContextMenu={(event) =>
@@ -382,7 +404,7 @@ type ViewTabProps = {
   workspaceId: string;
   view: WorkspaceView;
   isRenaming: boolean;
-  isMenuOpen: boolean;
+  isAnyMenuOpen: boolean;
   actions: React.ReactNode;
   onSelect: () => void;
   onReorder: (
@@ -399,7 +421,7 @@ const ViewTab = ({
   workspaceId,
   view,
   isRenaming,
-  isMenuOpen,
+  isAnyMenuOpen,
   actions,
   onSelect,
   onReorder,
@@ -423,8 +445,10 @@ const ViewTab = ({
   // Read at drag start so opening or closing a menu does not re-register the
   // draggable. A press that lands on an open menu's dismiss layer still
   // reaches the tab, and the drag it starts previews that layer instead of
-  // the tab; refuse the drag until the menu is gone.
-  const canDragTab = useLatestCallback(() => !isMenuOpen);
+  // the tab; refuse the drag until the menu is gone. The layer spans the
+  // strip, so any open menu gates every tab.
+  const canDragTab = useLatestCallback(() => !isAnyMenuOpen);
+  const direction = useI18nStore((state) => getLangDir(state.lang));
 
   // Seed the draft from the current name each time rename begins,
   // since the trigger now lives in the parent (menu or double-click).
@@ -464,13 +488,15 @@ const ViewTab = ({
           ),
         // Keep this tab as the drop target while the pointer crosses the gap to
         // the next one, so the insertion line does not flicker between tabs.
+        // The strip's own drop target bounds how far the stickiness carries.
         getIsSticky: () => true,
-        onDrag: ({ self }) => setDropPosition(resolveDropPosition(self)),
+        onDrag: ({ self }) =>
+          setDropPosition(resolveDropPosition(self, direction)),
         onDragLeave: () => setDropPosition(null),
         onDrop: ({ source, self }) => {
           setDropPosition(null);
           const draggedViewId = source.data["viewId"];
-          const position = resolveDropPosition(self);
+          const position = resolveDropPosition(self, direction);
           if (typeof draggedViewId !== "string" || position === null) {
             return;
           }
@@ -478,7 +504,7 @@ const ViewTab = ({
         },
       }),
     );
-  }, [id, canUpdateView, canDragTab, handleReorder, tabContainer]);
+  }, [id, canUpdateView, canDragTab, direction, handleReorder, tabContainer]);
 
   const handleRename = () => {
     const trimmed = renameValue.trim();
@@ -826,9 +852,9 @@ const useViewActionsMenu = ({
   );
 
   // A drag started while a menu is open produces a native preview of the
-  // dismiss layer rather than the tab, so the tabs refuse to drag until the
-  // menu closes.
-  const isMenuOpen = isActionsOpen || contextMenu.open;
+  // dismiss layer rather than the tab. The layer covers the whole strip, so
+  // this gates every tab, not just the one whose menu is open.
+  const isAnyMenuOpen = isActionsOpen || contextMenu.open;
 
-  return { openFor, renderActions, overlays, isMenuOpen };
+  return { openFor, renderActions, overlays, isAnyMenuOpen };
 };

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-switcher.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-switcher.tsx
@@ -259,6 +259,7 @@ export const ViewSwitcher = ({
                       })
                     : null
                 }
+                isMenuOpen={viewActions.isMenuOpen}
                 isRenaming={renamingViewId === view.id}
                 key={view.id}
                 onOpenContextMenu={(event) =>
@@ -381,6 +382,7 @@ type ViewTabProps = {
   workspaceId: string;
   view: WorkspaceView;
   isRenaming: boolean;
+  isMenuOpen: boolean;
   actions: React.ReactNode;
   onSelect: () => void;
   onReorder: (
@@ -397,6 +399,7 @@ const ViewTab = ({
   workspaceId,
   view,
   isRenaming,
+  isMenuOpen,
   actions,
   onSelect,
   onReorder,
@@ -417,6 +420,11 @@ const ViewTab = ({
   // wrapper is replaced whenever the tab enters or leaves rename mode.
   const [tabContainer, setTabContainer] = useState<HTMLDivElement | null>(null);
   const handleReorder = useLatestCallback(onReorder);
+  // Read at drag start so opening or closing a menu does not re-register the
+  // draggable. A press that lands on an open menu's dismiss layer still
+  // reaches the tab, and the drag it starts previews that layer instead of
+  // the tab; refuse the drag until the menu is gone.
+  const canDragTab = useLatestCallback(() => !isMenuOpen);
 
   // Seed the draft from the current name each time rename begins,
   // since the trigger now lives in the parent (menu or double-click).
@@ -436,6 +444,7 @@ const ViewTab = ({
         ? [
             draggable({
               element: tabContainer,
+              canDrag: canDragTab,
               getInitialData: () => ({
                 type: VIEW_DRAG_TYPE,
                 viewId: id,
@@ -469,7 +478,7 @@ const ViewTab = ({
         },
       }),
     );
-  }, [id, canUpdateView, handleReorder, tabContainer]);
+  }, [id, canUpdateView, canDragTab, handleReorder, tabContainer]);
 
   const handleRename = () => {
     const trimmed = renameValue.trim();
@@ -579,6 +588,7 @@ const useViewActionsMenu = ({
   const convertView = useConvertView(workspaceId);
   const deleteView = useDeleteView(workspaceId);
   const [target, setTarget] = useState<ViewActionsTarget | null>(null);
+  const [isActionsOpen, setIsActionsOpen] = useState(false);
   const [isSaveTemplateOpen, setIsSaveTemplateOpen] = useState(false);
   const [isDeleteOpen, setIsDeleteOpen] = useState(false);
   const [convertPreview, setConvertPreview] = useState<ViewLayoutType | null>(
@@ -740,6 +750,7 @@ const useViewActionsMenu = ({
     return (
       <Menu
         onOpenChange={(open) => {
+          setIsActionsOpen(open);
           if (open) {
             setTarget({ view, canDelete });
           }
@@ -750,9 +761,10 @@ const useViewActionsMenu = ({
           render={
             <Button
               className="absolute inset-e-0 top-1/2 -translate-y-1/2"
-              // This button sits inside the tab, which is a draggable. Without
-              // this, pressing it to open the menu starts a tab drag whose
-              // native preview is not the tab. Dragging belongs to the tab.
+              // The tab around this button is a draggable; the button itself is
+              // not a drag affordance. This only covers presses that land on
+              // the button: once the menu is open its dismiss layer takes the
+              // press, which is why the tab also refuses to drag while open.
               draggable={false}
               size="icon-xs"
               variant="ghost"
@@ -813,5 +825,10 @@ const useViewActionsMenu = ({
     </>
   );
 
-  return { openFor, renderActions, overlays };
+  // A drag started while a menu is open produces a native preview of the
+  // dismiss layer rather than the tab, so the tabs refuse to drag until the
+  // menu closes.
+  const isMenuOpen = isActionsOpen || contextMenu.open;
+
+  return { openFor, renderActions, overlays, isMenuOpen };
 };

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-switcher.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-switcher.tsx
@@ -86,9 +86,8 @@ type ViewDropTarget = {
   data: Record<string | symbol, unknown>;
 };
 
-// The strip mirrors under an RTL UI, so the physical edge the pointer is
-// nearest only names a position once it is read against the direction the tab
-// is laid out in.
+// The strip mirrors under RTL, so the nearest physical edge only names a
+// position once read against the writing direction.
 const resolveDropPosition = (
   { data }: ViewDropTarget,
   direction: TextDirection,
@@ -213,12 +212,11 @@ export const ViewSwitcher = ({
     null,
   );
 
-  // Bounds the tabs' stickiness. A sticky drop target survives the pointer
-  // leaving it only while its parent target is unchanged, so without a target
-  // around the strip the tabs stay sticky across the whole page: the insertion
-  // line would stay lit over unrelated chrome, and releasing there would
-  // reorder. This target is not sticky itself, so leaving the strip drops the
-  // tab out with it.
+  // Bounds the tabs' stickiness: a sticky target survives the pointer leaving
+  // it only while its parent target is unchanged. Without this the tabs stay
+  // sticky page-wide, keeping the insertion line lit over unrelated chrome and
+  // reordering on release there. Not sticky itself, so leaving the strip
+  // clears the tab with it.
   useExternalSyncEffect(() => {
     if (!stripContainer) {
       return undefined;
@@ -442,11 +440,10 @@ const ViewTab = ({
   // wrapper is replaced whenever the tab enters or leaves rename mode.
   const [tabContainer, setTabContainer] = useState<HTMLDivElement | null>(null);
   const handleReorder = useLatestCallback(onReorder);
-  // Read at drag start so opening or closing a menu does not re-register the
-  // draggable. A press that lands on an open menu's dismiss layer still
-  // reaches the tab, and the drag it starts previews that layer instead of
-  // the tab; refuse the drag until the menu is gone. The layer spans the
-  // strip, so any open menu gates every tab.
+  // Read at drag start so opening a menu does not re-register the draggable.
+  // A press on the menu's dismiss layer still reaches the tab, and the drag it
+  // starts previews that layer instead of the tab. The layer spans the strip,
+  // so any open menu gates every tab.
   const canDragTab = useLatestCallback(() => !isAnyMenuOpen);
   const direction = useI18nStore((state) => getLangDir(state.lang));
 
@@ -486,9 +483,8 @@ const ViewTab = ({
             { viewId: id },
             { element, input, allowedEdges: ["left", "right"] },
           ),
-        // Keep this tab as the drop target while the pointer crosses the gap to
-        // the next one, so the insertion line does not flicker between tabs.
-        // The strip's own drop target bounds how far the stickiness carries.
+        // Hold the target while the pointer crosses the gap to the next tab so
+        // the insertion line does not flicker. The strip's target bounds it.
         getIsSticky: () => true,
         onDrag: ({ self }) =>
           setDropPosition(resolveDropPosition(self, direction)),
@@ -787,10 +783,9 @@ const useViewActionsMenu = ({
           render={
             <Button
               className="absolute inset-e-0 top-1/2 -translate-y-1/2"
-              // The tab around this button is a draggable; the button itself is
-              // not a drag affordance. This only covers presses that land on
-              // the button: once the menu is open its dismiss layer takes the
-              // press, which is why the tab also refuses to drag while open.
+              // The surrounding tab is a draggable; this button is not a drag
+              // affordance. Only covers presses on the button itself, which is
+              // why the tab separately refuses to drag while the menu is open.
               draggable={false}
               size="icon-xs"
               variant="ghost"
@@ -851,9 +846,8 @@ const useViewActionsMenu = ({
     </>
   );
 
-  // A drag started while a menu is open produces a native preview of the
-  // dismiss layer rather than the tab. The layer covers the whole strip, so
-  // this gates every tab, not just the one whose menu is open.
+  // The dismiss layer covers the whole strip, so an open menu anywhere gates
+  // dragging on every tab, not just its own.
   const isAnyMenuOpen = isActionsOpen || contextMenu.open;
 
   return { openFor, renderActions, overlays, isAnyMenuOpen };

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-switcher.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-switcher.tsx
@@ -1,5 +1,9 @@
 import { useRef, useState } from "react";
 
+import {
+  attachClosestEdge,
+  extractClosestEdge,
+} from "@atlaskit/pragmatic-drag-and-drop-hitbox/closest-edge";
 import { combine } from "@atlaskit/pragmatic-drag-and-drop/combine";
 import {
   draggable,
@@ -61,6 +65,11 @@ import { SaveAsTemplateDialog } from "@/routes/_protected.workspaces/$workspaceI
 import { TemplatePickerDialog } from "@/routes/_protected.workspaces/$workspaceId/-components/view/template-picker-dialog";
 import type { ViewLayoutPreviewKind } from "@/routes/_protected.workspaces/$workspaceId/-components/view/view-layout-preview";
 import { ViewLayoutPreview } from "@/routes/_protected.workspaces/$workspaceId/-components/view/view-layout-preview";
+import type { ViewDropPosition } from "@/routes/_protected.workspaces/$workspaceId/-components/view/view-switcher.logic";
+import {
+  reorderViewIds,
+  toViewDropPosition,
+} from "@/routes/_protected.workspaces/$workspaceId/-components/view/view-switcher.logic";
 import {
   useConvertView,
   useCreateView,
@@ -70,6 +79,20 @@ import {
 } from "@/routes/_protected.workspaces/$workspaceId/-mutations/views";
 
 const VIEW_DRAG_TYPE = "stella/view-id";
+
+type ViewDropTarget = {
+  element: Element;
+  data: Record<string | symbol, unknown>;
+};
+
+// The strip mirrors under an RTL UI, so the physical edge the pointer is
+// nearest only names a position once it is read against the direction the tab
+// is laid out in.
+const resolveDropPosition = ({ element, data }: ViewDropTarget) =>
+  toViewDropPosition(
+    extractClosestEdge(data),
+    getComputedStyle(element).direction === "rtl" ? "rtl" : "ltr",
+  );
 
 const REQUIRED_VIEW_LAYOUTS: readonly ViewLayoutType[] = Object.freeze([
   "overview",
@@ -187,17 +210,21 @@ export const ViewSwitcher = ({
     hasOverviewView ? ["overview"] : [],
   );
 
-  const handleReorder = (draggedId: string, targetId: string) => {
-    const ids = views.map((v) => v.id);
-    const fromIdx = ids.indexOf(draggedId);
-    const toIdx = ids.indexOf(targetId);
+  const handleReorder = (
+    draggedId: string,
+    targetId: string,
+    position: ViewDropPosition,
+  ) => {
+    const reordered = reorderViewIds({
+      ids: views.map((view) => view.id),
+      draggedId,
+      targetId,
+      position,
+    });
 
-    if (fromIdx === -1 || toIdx === -1 || fromIdx === toIdx) {
+    if (!reordered) {
       return;
     }
-
-    const reordered = ids.toSpliced(fromIdx, 1);
-    reordered.splice(toIdx, 0, draggedId);
 
     reorderViews.mutate(
       { viewIds: reordered },
@@ -356,7 +383,11 @@ type ViewTabProps = {
   isRenaming: boolean;
   actions: React.ReactNode;
   onSelect: () => void;
-  onReorder: (draggedId: string, targetId: string) => void;
+  onReorder: (
+    draggedId: string,
+    targetId: string,
+    position: ViewDropPosition,
+  ) => void;
   onStartRename: () => void;
   onStopRename: () => void;
   onOpenContextMenu: (event: React.MouseEvent<HTMLElement>) => void;
@@ -378,7 +409,9 @@ const ViewTab = ({
   const canUpdateView = usePermissions({ view: ["update"] });
   const [renameValue, setRenameValue] = useState(name);
   const [wasRenaming, setWasRenaming] = useState(isRenaming);
-  const [isDropTarget, setIsDropTarget] = useState(false);
+  const [dropPosition, setDropPosition] = useState<ViewDropPosition | null>(
+    null,
+  );
   const updateView = useUpdateView(workspaceId);
   const containerRef = useRef<HTMLDivElement>(null);
   const handleReorder = useLatestCallback(onReorder);
@@ -414,15 +447,24 @@ const ViewTab = ({
         canDrop: ({ source }) =>
           source.data["type"] === VIEW_DRAG_TYPE &&
           source.data["viewId"] !== id,
-        onDragEnter: () => setIsDropTarget(true),
-        onDragLeave: () => setIsDropTarget(false),
-        onDrop: ({ source }) => {
-          setIsDropTarget(false);
+        getData: ({ input, element }) =>
+          attachClosestEdge(
+            { viewId: id },
+            { element, input, allowedEdges: ["left", "right"] },
+          ),
+        // Keep this tab as the drop target while the pointer crosses the gap to
+        // the next one, so the insertion line does not flicker between tabs.
+        getIsSticky: () => true,
+        onDrag: ({ self }) => setDropPosition(resolveDropPosition(self)),
+        onDragLeave: () => setDropPosition(null),
+        onDrop: ({ source, self }) => {
+          setDropPosition(null);
           const draggedViewId = source.data["viewId"];
-          if (typeof draggedViewId !== "string") {
+          const position = resolveDropPosition(self);
+          if (typeof draggedViewId !== "string" || position === null) {
             return;
           }
-          handleReorder(draggedViewId, id);
+          handleReorder(draggedViewId, id, position);
         },
       }),
     );
@@ -473,10 +515,16 @@ const ViewTab = ({
   }
 
   return (
-    <div
-      className={cn("relative", isDropTarget && "ring-primary rounded ring-2")}
-      ref={containerRef}
-    >
+    <div className="relative" ref={containerRef}>
+      {dropPosition !== null && (
+        <span
+          aria-hidden="true"
+          className={cn(
+            "bg-primary pointer-events-none absolute inset-y-1 z-20 w-0.5 rounded-full",
+            dropPosition === "before" ? "-start-0.5" : "-end-0.5",
+          )}
+        />
+      )}
       <TabsTab
         className="pe-6.5"
         onClick={onSelect}

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-switcher.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-switcher.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from "react";
+import { useState } from "react";
 
 import {
   attachClosestEdge,
@@ -413,7 +413,9 @@ const ViewTab = ({
     null,
   );
   const updateView = useUpdateView(workspaceId);
-  const containerRef = useRef<HTMLDivElement>(null);
+  // Held as state rather than a ref so registration follows the node: the
+  // wrapper is replaced whenever the tab enters or leaves rename mode.
+  const [tabContainer, setTabContainer] = useState<HTMLDivElement | null>(null);
   const handleReorder = useLatestCallback(onReorder);
 
   // Seed the draft from the current name each time rename begins,
@@ -426,15 +428,14 @@ const ViewTab = ({
   }
 
   useExternalSyncEffect(() => {
-    const el = containerRef.current;
-    if (!el) {
+    if (!tabContainer) {
       return undefined;
     }
     return combine(
       ...(canUpdateView
         ? [
             draggable({
-              element: el,
+              element: tabContainer,
               getInitialData: () => ({
                 type: VIEW_DRAG_TYPE,
                 viewId: id,
@@ -443,7 +444,7 @@ const ViewTab = ({
           ]
         : []),
       dropTargetForElements({
-        element: el,
+        element: tabContainer,
         canDrop: ({ source }) =>
           source.data["type"] === VIEW_DRAG_TYPE &&
           source.data["viewId"] !== id,
@@ -468,7 +469,7 @@ const ViewTab = ({
         },
       }),
     );
-  }, [id, canUpdateView, handleReorder]);
+  }, [id, canUpdateView, handleReorder, tabContainer]);
 
   const handleRename = () => {
     const trimmed = renameValue.trim();
@@ -515,7 +516,7 @@ const ViewTab = ({
   }
 
   return (
-    <div className="relative" ref={containerRef}>
+    <div className="relative" ref={setTabContainer}>
       {dropPosition !== null && (
         <span
           aria-hidden="true"
@@ -749,6 +750,10 @@ const useViewActionsMenu = ({
           render={
             <Button
               className="absolute inset-e-0 top-1/2 -translate-y-1/2"
+              // This button sits inside the tab, which is a draggable. Without
+              // this, pressing it to open the menu starts a tab drag whose
+              // native preview is not the tab. Dragging belongs to the tab.
+              draggable={false}
               size="icon-xs"
               variant="ghost"
             />

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-mutations/views.logic.test.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-mutations/views.logic.test.ts
@@ -65,14 +65,18 @@ describe("optimistic view order", () => {
     }
   });
 
-  test("leaves the strip alone when the ids no longer match the cache", async () => {
+  test("leaves the strip alone when the ids are not a permutation of it", async () => {
     const { reorderCachedViews } = await import("./views.logic");
 
     const drifted = [
-      // A view created elsewhere since the drag started.
+      // A view created or renamed elsewhere since the drag started.
       ["overview", "table", "files", "created-elsewhere"],
       // One deleted elsewhere, so the drag carried a short list.
       ["overview", "table", "files"],
+      // Longer than the cache: every cached view resolves, one id does not.
+      [...CACHED_IDS, "created-elsewhere"],
+      // Right length, but a repeat would drop `kanban` off the strip.
+      ["overview", "table", "files", "files"],
     ];
 
     for (const viewIds of drifted) {

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-mutations/views.logic.test.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-mutations/views.logic.test.ts
@@ -127,6 +127,22 @@ describe("view reorder cache path", () => {
     expect(await cachedOrder(queryClient)).toEqual(CACHED_IDS);
   });
 
+  test("keeps a later drop's order when an earlier reorder fails", async () => {
+    const { viewOrderCache } = await import("./views.logic");
+    const queryClient = await seededClient();
+    const cache = viewOrderCache({ queryClient, workspaceId: WORKSPACE_ID });
+
+    // Two drops in flight at once: nothing disables the strip between them.
+    const first = ["kanban", ...CACHED_IDS.slice(0, 3)];
+    const second = [...CACHED_IDS.slice(1), "overview"];
+    const firstContext = await cache.apply(first);
+    await cache.apply(second);
+
+    cache.restore(firstContext);
+
+    expect(await cachedOrder(queryClient)).toEqual(second);
+  });
+
   test("invalidates every cached locale variant on settle", async () => {
     const { viewsKeys } = await import("@/lib/workspaces/queries/views");
     const { viewOrderCache } = await import("./views.logic");

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-mutations/views.logic.test.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-mutations/views.logic.test.ts
@@ -1,0 +1,143 @@
+import { QueryClient } from "@tanstack/react-query";
+import { beforeAll, describe, expect, test } from "bun:test";
+
+import type { ViewLayout, WorkspaceView } from "@/lib/types";
+
+// `viewsKeys` pulls in the Eden client, which reads the API URL at import time.
+beforeAll(() => {
+  process.env["VITE_API_URL"] ??= "https://api.example.test";
+});
+
+const WORKSPACE_ID = "ws_reorder";
+
+const TABLE_LAYOUT = {
+  version: 1,
+  type: "table",
+  filters: [],
+  sorts: [],
+  hiddenProperties: [],
+  columnOrder: [],
+  columnPinning: [],
+} as const satisfies ViewLayout;
+
+const view = (id: string, position: number) =>
+  ({
+    version: 1,
+    id,
+    name: id,
+    layout: TABLE_LAYOUT,
+    position,
+    createdAt: "2026-01-01T00:00:00.000Z",
+  }) satisfies WorkspaceView;
+
+const CACHED_VIEWS = ["overview", "table", "files", "kanban"].map(view);
+const CACHED_IDS = CACHED_VIEWS.map((cached) => cached.id);
+
+const seededClient = async () => {
+  const { viewsKeys } = await import("@/lib/workspaces/queries/views");
+  const queryClient = new QueryClient();
+  queryClient.setQueryData(viewsKeys.localized(WORKSPACE_ID), CACHED_VIEWS);
+  return queryClient;
+};
+
+const cachedOrder = async (queryClient: QueryClient) => {
+  const { viewsKeys } = await import("@/lib/workspaces/queries/views");
+  return queryClient
+    .getQueryData<WorkspaceView[]>(viewsKeys.localized(WORKSPACE_ID))
+    ?.map((cached) => cached.id);
+};
+
+describe("optimistic view order", () => {
+  test("applies every landing position a drag can produce", async () => {
+    const { reorderCachedViews } = await import("./views.logic");
+
+    // A drag lifts one view and reinserts it, so this is the full set of orders
+    // `reorderViewIds` can hand the mutation.
+    for (const draggedId of CACHED_IDS) {
+      const without = CACHED_IDS.filter((id) => id !== draggedId);
+
+      for (let landing = 0; landing <= without.length; landing++) {
+        const viewIds = without.toSpliced(landing, 0, draggedId);
+        const reordered = reorderCachedViews(CACHED_VIEWS, viewIds);
+
+        expect(reordered?.map((cached) => cached.id)).toEqual(viewIds);
+      }
+    }
+  });
+
+  test("leaves the strip alone when the ids no longer match the cache", async () => {
+    const { reorderCachedViews } = await import("./views.logic");
+
+    const drifted = [
+      // A view created elsewhere since the drag started.
+      ["overview", "table", "files", "created-elsewhere"],
+      // One deleted elsewhere, so the drag carried a short list.
+      ["overview", "table", "files"],
+    ];
+
+    for (const viewIds of drifted) {
+      expect(reorderCachedViews(CACHED_VIEWS, viewIds)).toBe(CACHED_VIEWS);
+    }
+  });
+
+  test("writes nothing when the strip has not been fetched", async () => {
+    const { reorderCachedViews } = await import("./views.logic");
+
+    expect(reorderCachedViews(undefined, CACHED_IDS)).toBeUndefined();
+  });
+});
+
+describe("view reorder cache path", () => {
+  test("reorders the cache and reports what it displaced", async () => {
+    const { viewOrderCache } = await import("./views.logic");
+    const queryClient = await seededClient();
+
+    const context = await viewOrderCache({
+      queryClient,
+      workspaceId: WORKSPACE_ID,
+    }).apply(["table", "overview", "files", "kanban"]);
+
+    expect(await cachedOrder(queryClient)).toEqual([
+      "table",
+      "overview",
+      "files",
+      "kanban",
+    ]);
+    expect(context.previousViews?.map((cached) => cached.id)).toEqual(
+      CACHED_IDS,
+    );
+  });
+
+  test("puts the previous order back when the reorder fails", async () => {
+    const { viewOrderCache } = await import("./views.logic");
+    const queryClient = await seededClient();
+    const cache = viewOrderCache({ queryClient, workspaceId: WORKSPACE_ID });
+
+    const moved = ["kanban", ...CACHED_IDS.slice(0, 3)];
+    const context = await cache.apply(moved);
+    // Without this the test would pass on an `apply` that never wrote.
+    expect(await cachedOrder(queryClient)).toEqual(moved);
+
+    cache.restore(context);
+
+    expect(await cachedOrder(queryClient)).toEqual(CACHED_IDS);
+  });
+
+  test("invalidates every cached locale variant on settle", async () => {
+    const { viewsKeys } = await import("@/lib/workspaces/queries/views");
+    const { viewOrderCache } = await import("./views.logic");
+    const queryClient = await seededClient();
+
+    // Default view names are localized server-side, so a reorder must reach the
+    // variants the current locale did not write to. Keyed off `all` rather than
+    // a second literal, so the test still covers the prefix if the key changes.
+    const otherLocaleKey = [...viewsKeys.all(WORKSPACE_ID), "xx-other"];
+    queryClient.setQueryData(otherLocaleKey, CACHED_VIEWS);
+
+    await viewOrderCache({ queryClient, workspaceId: WORKSPACE_ID }).settle();
+
+    for (const key of [viewsKeys.localized(WORKSPACE_ID), otherLocaleKey]) {
+      expect(queryClient.getQueryState(key)?.isInvalidated).toBe(true);
+    }
+  });
+});

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-mutations/views.logic.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-mutations/views.logic.ts
@@ -5,10 +5,12 @@ import { viewsKeys } from "@/lib/workspaces/queries/views";
 
 /**
  * Returns the cached view list in `viewIds` order, or `current` unchanged when
- * the cache has drifted from what was dragged.
+ * `viewIds` is not a permutation of what is cached.
  *
- * The server only accepts the workspace's full view set, so a partial write
- * would drop a view off the strip rather than leave it to the refetch.
+ * The endpoint takes the workspace's full view set, so a partial write would
+ * drop views off the strip until the refetch lands. Set equality, not just a
+ * length check: a repeated id fills the list to the right length while silently
+ * losing a view.
  */
 export const reorderCachedViews = (
   current: WorkspaceView[] | undefined,
@@ -23,7 +25,11 @@ export const reorderCachedViews = (
     .map((viewId) => byId.get(viewId))
     .filter((view) => view !== undefined);
 
-  return reordered.length === current.length ? reordered : current;
+  const isPermutation =
+    reordered.length === current.length &&
+    new Set(viewIds).size === current.length;
+
+  return isPermutation ? reordered : current;
 };
 
 /** What the optimistic write displaced, so a failed reorder can put it back. */

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-mutations/views.logic.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-mutations/views.logic.ts
@@ -1,0 +1,78 @@
+import type { QueryClient } from "@tanstack/react-query";
+
+import type { WorkspaceView } from "@/lib/types";
+import { viewsKeys } from "@/lib/workspaces/queries/views";
+
+/**
+ * Returns the cached view list in `viewIds` order, or `current` unchanged when
+ * the cache has drifted from what was dragged.
+ *
+ * The server only accepts the workspace's full view set, so a partial write
+ * would drop a view off the strip rather than leave it to the refetch.
+ */
+export const reorderCachedViews = (
+  current: WorkspaceView[] | undefined,
+  viewIds: readonly string[],
+): WorkspaceView[] | undefined => {
+  if (!current) {
+    return current;
+  }
+
+  const byId = new Map(current.map((view) => [view.id, view]));
+  const reordered = viewIds
+    .map((viewId) => byId.get(viewId))
+    .filter((view) => view !== undefined);
+
+  return reordered.length === current.length ? reordered : current;
+};
+
+/** What the optimistic write displaced, so a failed reorder can put it back. */
+export type ReorderViewsContext = {
+  previousViews: WorkspaceView[] | undefined;
+};
+
+type ViewOrderCacheOptions = {
+  queryClient: QueryClient;
+  workspaceId: string;
+};
+
+/**
+ * The cache side of a view reorder, split from the hook so the optimistic
+ * write, its rollback, and the settling invalidation are reachable from a test.
+ */
+export const viewOrderCache = ({
+  queryClient,
+  workspaceId,
+}: ViewOrderCacheOptions) => {
+  // Optimistic reads/writes target the concrete locale-specific entry; the
+  // final invalidation targets the locale-independent prefix so every cached
+  // locale variant refetches.
+  const localizedKey = viewsKeys.localized(workspaceId);
+
+  return {
+    apply: async (viewIds: readonly string[]): Promise<ReorderViewsContext> => {
+      await queryClient.cancelQueries({ queryKey: localizedKey });
+      const previousViews =
+        queryClient.getQueryData<WorkspaceView[]>(localizedKey);
+
+      queryClient.setQueryData<WorkspaceView[]>(localizedKey, (current) =>
+        reorderCachedViews(current, viewIds),
+      );
+
+      return { previousViews };
+    },
+
+    restore: (context: ReorderViewsContext | undefined) => {
+      if (!context?.previousViews) {
+        return;
+      }
+      queryClient.setQueryData(localizedKey, context.previousViews);
+    },
+
+    settle: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: viewsKeys.all(workspaceId),
+      });
+    },
+  };
+};

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-mutations/views.logic.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-mutations/views.logic.ts
@@ -35,6 +35,11 @@ export const reorderCachedViews = (
 /** What the optimistic write displaced, so a failed reorder can put it back. */
 export type ReorderViewsContext = {
   previousViews: WorkspaceView[] | undefined;
+  /**
+   * What the optimistic write left in the cache, so a rollback can tell whether
+   * the strip is still showing this reorder.
+   */
+  optimisticViews: WorkspaceView[] | undefined;
 };
 
 type ViewOrderCacheOptions = {
@@ -61,15 +66,25 @@ export const viewOrderCache = ({
       const previousViews =
         queryClient.getQueryData<WorkspaceView[]>(localizedKey);
 
-      queryClient.setQueryData<WorkspaceView[]>(localizedKey, (current) =>
-        reorderCachedViews(current, viewIds),
+      const optimisticViews = queryClient.setQueryData<WorkspaceView[]>(
+        localizedKey,
+        (current) => reorderCachedViews(current, viewIds),
       );
 
-      return { previousViews };
+      return { previousViews, optimisticViews };
     },
 
     restore: (context: ReorderViewsContext | undefined) => {
       if (!context?.previousViews) {
+        return;
+      }
+      // Nothing disables the strip while a reorder is in flight, so a second
+      // drop can land first. Rolling this one back would then undo the newer
+      // order and leave the strip wrong until the newer request settles. The
+      // cache holds what `apply` wrote until something replaces it, so an
+      // identity check answers "is this reorder still what the user sees?" for
+      // a later drop and a landed refetch alike.
+      if (queryClient.getQueryData(localizedKey) !== context.optimisticViews) {
         return;
       }
       queryClient.setQueryData(localizedKey, context.previousViews);

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-mutations/views.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-mutations/views.ts
@@ -13,6 +13,8 @@ import type {
 import { propertiesKeys } from "@/lib/workspaces/queries/properties";
 import { viewsKeys } from "@/lib/workspaces/queries/views";
 
+import { viewOrderCache } from "./views.logic";
+
 type CreateViewVars = {
   id: string;
   name: string;
@@ -155,7 +157,7 @@ type ReorderViewsVars = {
 export const useReorderViews = (workspaceId: string) => {
   const analytics = useAnalytics();
   const queryClient = useQueryClient();
-  const localizedKey = viewsKeys.localized(workspaceId);
+  const cache = viewOrderCache({ queryClient, workspaceId });
 
   return useMutation({
     mutationFn: async ({ viewIds }: ReorderViewsVars) => {
@@ -166,43 +168,12 @@ export const useReorderViews = (workspaceId: string) => {
         });
       return unwrapEden(response);
     },
-    onMutate: async ({ viewIds }) => {
-      await queryClient.cancelQueries({ queryKey: localizedKey });
-      const previousViews =
-        queryClient.getQueryData<WorkspaceView[]>(localizedKey);
-
-      queryClient.setQueryData<WorkspaceView[]>(
-        localizedKey,
-        (current): WorkspaceView[] | undefined => {
-          if (!current) {
-            return current;
-          }
-
-          const byId = new Map(current.map((view) => [view.id, view]));
-          const reordered = viewIds
-            .map((viewId) => byId.get(viewId))
-            .filter((view) => view !== undefined);
-
-          // The server only accepts the workspace's full view set. If the cache
-          // has drifted from what was dragged, leave it to the refetch rather
-          // than optimistically dropping a view off the strip.
-          return reordered.length === current.length ? reordered : current;
-        },
-      );
-
-      return { previousViews };
-    },
+    onMutate: async ({ viewIds }) => await cache.apply(viewIds),
     onError: (error, _variables, context) => {
-      if (context?.previousViews) {
-        queryClient.setQueryData(localizedKey, context.previousViews);
-      }
+      cache.restore(context);
       analytics.captureError(error);
     },
-    onSettled: async () => {
-      await queryClient.invalidateQueries({
-        queryKey: viewsKeys.all(workspaceId),
-      });
-    },
+    onSettled: cache.settle,
   });
 };
 

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-mutations/views.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-mutations/views.ts
@@ -155,6 +155,7 @@ type ReorderViewsVars = {
 export const useReorderViews = (workspaceId: string) => {
   const analytics = useAnalytics();
   const queryClient = useQueryClient();
+  const localizedKey = viewsKeys.localized(workspaceId);
 
   return useMutation({
     mutationFn: async ({ viewIds }: ReorderViewsVars) => {
@@ -165,13 +166,42 @@ export const useReorderViews = (workspaceId: string) => {
         });
       return unwrapEden(response);
     },
-    onSuccess: async () => {
+    onMutate: async ({ viewIds }) => {
+      await queryClient.cancelQueries({ queryKey: localizedKey });
+      const previousViews =
+        queryClient.getQueryData<WorkspaceView[]>(localizedKey);
+
+      queryClient.setQueryData<WorkspaceView[]>(
+        localizedKey,
+        (current): WorkspaceView[] | undefined => {
+          if (!current) {
+            return current;
+          }
+
+          const byId = new Map(current.map((view) => [view.id, view]));
+          const reordered = viewIds
+            .map((viewId) => byId.get(viewId))
+            .filter((view) => view !== undefined);
+
+          // The server only accepts the workspace's full view set. If the cache
+          // has drifted from what was dragged, leave it to the refetch rather
+          // than optimistically dropping a view off the strip.
+          return reordered.length === current.length ? reordered : current;
+        },
+      );
+
+      return { previousViews };
+    },
+    onError: (error, _variables, context) => {
+      if (context?.previousViews) {
+        queryClient.setQueryData(localizedKey, context.previousViews);
+      }
+      analytics.captureError(error);
+    },
+    onSettled: async () => {
       await queryClient.invalidateQueries({
         queryKey: viewsKeys.all(workspaceId),
       });
-    },
-    onError: (error) => {
-      analytics.captureError(error);
     },
   });
 };

--- a/packages/ui/src/components/tabs.tsx
+++ b/packages/ui/src/components/tabs.tsx
@@ -4,7 +4,8 @@ import { useEffect, useLayoutEffect, useRef, useState } from "react";
 
 import { Tabs as TabsPrimitive } from "@base-ui/react/tabs";
 
-import { cn } from "@stll/ui/lib/utils";
+import { hasTabOrderChanged } from "@stll/ui/lib/tab-order";
+import { cn, composeRefs } from "@stll/ui/lib/utils";
 
 type TabsVariant = "default" | "underline";
 
@@ -39,21 +40,15 @@ function TabsList({
   const tabOrderRef = useRef<readonly Element[]>([]);
   const [, setRemeasureToken] = useState(0);
 
-  // Base UI measures the indicator during render, so a commit that moves tabs
-  // (a drag reorder, an insertion, a removal) measures the pre-commit DOM and
-  // leaves the underline behind. Its ResizeObserver cannot correct that: the
-  // tabs changed position, not size. Re-render once the new order is committed
-  // so the measurement sees where the active tab actually is.
+  // Re-render once the new order is committed so Base UI's render-time
+  // measurement sees where the active tab actually is. See `hasTabOrderChanged`
+  // for why the library cannot correct this itself.
   useIsoLayoutEffect(() => {
     const tabs = listRef.current ? [...listRef.current.children] : [];
     const previousTabs = tabOrderRef.current;
     tabOrderRef.current = tabs;
 
-    const isSameOrder =
-      tabs.length === previousTabs.length &&
-      tabs.every((tab, index) => tab === previousTabs[index]);
-
-    if (!isSameOrder) {
+    if (hasTabOrderChanged(previousTabs, tabs)) {
       setRemeasureToken((token) => token + 1);
     }
   });
@@ -69,16 +64,7 @@ function TabsList({
         className,
       )}
       data-slot="tabs-list"
-      ref={(node) => {
-        listRef.current = node;
-        if (typeof ref === "function") {
-          return ref(node);
-        }
-        if (ref) {
-          ref.current = node;
-        }
-        return undefined;
-      }}
+      ref={composeRefs(listRef, ref)}
       {...props}
     >
       {children}

--- a/packages/ui/src/components/tabs.tsx
+++ b/packages/ui/src/components/tabs.tsx
@@ -1,10 +1,17 @@
 "use client";
 
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
+
 import { Tabs as TabsPrimitive } from "@base-ui/react/tabs";
 
 import { cn } from "@stll/ui/lib/utils";
 
 type TabsVariant = "default" | "underline";
+
+// Layout effects never run while rendering on the server, so fall back to
+// `useEffect` there to avoid React's server-side layout-effect warning.
+const useIsoLayoutEffect =
+  typeof window === "undefined" ? useEffect : useLayoutEffect;
 
 function Tabs({ className, ...props }: TabsPrimitive.Root.Props) {
   return (
@@ -23,10 +30,34 @@ function TabsList({
   variant = "default",
   className,
   children,
+  ref,
   ...props
 }: TabsPrimitive.List.Props & {
   variant?: TabsVariant;
 }) {
+  const listRef = useRef<HTMLDivElement | null>(null);
+  const tabOrderRef = useRef<readonly Element[]>([]);
+  const [, setRemeasureToken] = useState(0);
+
+  // Base UI measures the indicator during render, so a commit that moves tabs
+  // (a drag reorder, an insertion, a removal) measures the pre-commit DOM and
+  // leaves the underline behind. Its ResizeObserver cannot correct that: the
+  // tabs changed position, not size. Re-render once the new order is committed
+  // so the measurement sees where the active tab actually is.
+  useIsoLayoutEffect(() => {
+    const tabs = listRef.current ? [...listRef.current.children] : [];
+    const previousTabs = tabOrderRef.current;
+    tabOrderRef.current = tabs;
+
+    const isSameOrder =
+      tabs.length === previousTabs.length &&
+      tabs.every((tab, index) => tab === previousTabs[index]);
+
+    if (!isSameOrder) {
+      setRemeasureToken((token) => token + 1);
+    }
+  });
+
   return (
     <TabsPrimitive.List
       className={cn(
@@ -38,6 +69,16 @@ function TabsList({
         className,
       )}
       data-slot="tabs-list"
+      ref={(node) => {
+        listRef.current = node;
+        if (typeof ref === "function") {
+          return ref(node);
+        }
+        if (ref) {
+          ref.current = node;
+        }
+        return undefined;
+      }}
       {...props}
     >
       {children}

--- a/packages/ui/src/components/tabs.tsx
+++ b/packages/ui/src/components/tabs.tsx
@@ -41,8 +41,8 @@ function TabsList({
   const [, setRemeasureToken] = useState(0);
 
   // Re-render once the new order is committed so Base UI's render-time
-  // measurement sees where the active tab actually is. See `hasTabOrderChanged`
-  // for why the library cannot correct this itself.
+  // measurement sees where the active tab actually is. `hasTabOrderChanged`
+  // explains which case the library misses.
   useIsoLayoutEffect(() => {
     const tabs = listRef.current ? [...listRef.current.children] : [];
     const previousTabs = tabOrderRef.current;

--- a/packages/ui/src/lib/tab-order.test.ts
+++ b/packages/ui/src/lib/tab-order.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "bun:test";
+
+import { hasTabOrderChanged } from "./tab-order";
+
+// Stand-ins for tab elements. `hasTabOrderChanged` compares by identity, so
+// distinct objects are enough; the DOM adds nothing to the invariant.
+const makeTabs = (count: number) => Array.from({ length: count }, () => ({}));
+
+describe("tab order change detection", () => {
+  test("reports no change when the same elements stay in place", () => {
+    const tabs = makeTabs(5);
+
+    expect(hasTabOrderChanged(tabs, [...tabs])).toBe(false);
+    expect(hasTabOrderChanged([], [])).toBe(false);
+  });
+
+  test("reports every reordering of the same elements", () => {
+    const tabs = makeTabs(4);
+
+    // A drag reorder moves the same DOM nodes, so nothing but identity order
+    // distinguishes the commits. Cover every swap rather than one example.
+    for (let from = 0; from < tabs.length; from++) {
+      for (let to = 0; to < tabs.length; to++) {
+        const moved = tabs.filter((_, index) => index !== from);
+        const dragged = tabs[from];
+        if (dragged === undefined) {
+          continue;
+        }
+        moved.splice(to, 0, dragged);
+
+        expect(hasTabOrderChanged(tabs, moved)).toBe(from !== to);
+      }
+    }
+  });
+
+  test("reports insertions and removals", () => {
+    const tabs = makeTabs(3);
+    const [first, second, third] = tabs;
+    if (first === undefined || second === undefined || third === undefined) {
+      throw new Error("fixture must have three tabs");
+    }
+
+    expect(hasTabOrderChanged(tabs, [first, second])).toBe(true);
+    expect(hasTabOrderChanged([first, second], tabs)).toBe(true);
+    // A removal that shortens the list still differs at the surviving indexes.
+    expect(hasTabOrderChanged(tabs, [second, third])).toBe(true);
+  });
+
+  test("reports the first commit, when nothing has been measured yet", () => {
+    expect(hasTabOrderChanged([], makeTabs(3))).toBe(true);
+  });
+
+  test("reports a swap that preserves the element count", () => {
+    const tabs = makeTabs(2);
+    const [first, second] = tabs;
+    if (first === undefined || second === undefined) {
+      throw new Error("fixture must have two tabs");
+    }
+
+    // Guards the length-only comparison: same count, different order.
+    expect(hasTabOrderChanged(tabs, [second, first])).toBe(true);
+  });
+});

--- a/packages/ui/src/lib/tab-order.test.ts
+++ b/packages/ui/src/lib/tab-order.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, test } from "bun:test";
 
 import { hasTabOrderChanged } from "./tab-order";
 
-// Stand-ins for tab elements. `hasTabOrderChanged` compares by identity, so
-// distinct objects are enough; the DOM adds nothing to the invariant.
+// `hasTabOrderChanged` compares by identity, so distinct objects stand in for
+// tab elements; the DOM adds nothing to the invariant.
 const makeTabs = (count: number) => Array.from({ length: count }, () => ({}));
 
 describe("tab order change detection", () => {
@@ -17,8 +17,9 @@ describe("tab order change detection", () => {
   test("reports every reordering of the same elements", () => {
     const tabs = makeTabs(4);
 
-    // A drag reorder moves the same DOM nodes, so nothing but identity order
-    // distinguishes the commits. Cover every swap rather than one example.
+    // The reorder case is the one Base UI misses, and it moves the same nodes,
+    // so only identity order separates the commits. A length-only comparison
+    // passes every other test here and fails this one.
     for (let from = 0; from < tabs.length; from++) {
       for (let to = 0; to < tabs.length; to++) {
         const moved = tabs.filter((_, index) => index !== from);
@@ -42,22 +43,10 @@ describe("tab order change detection", () => {
 
     expect(hasTabOrderChanged(tabs, [first, second])).toBe(true);
     expect(hasTabOrderChanged([first, second], tabs)).toBe(true);
-    // A removal that shortens the list still differs at the surviving indexes.
     expect(hasTabOrderChanged(tabs, [second, third])).toBe(true);
   });
 
   test("reports the first commit, when nothing has been measured yet", () => {
     expect(hasTabOrderChanged([], makeTabs(3))).toBe(true);
-  });
-
-  test("reports a swap that preserves the element count", () => {
-    const tabs = makeTabs(2);
-    const [first, second] = tabs;
-    if (first === undefined || second === undefined) {
-      throw new Error("fixture must have two tabs");
-    }
-
-    // Guards the length-only comparison: same count, different order.
-    expect(hasTabOrderChanged(tabs, [second, first])).toBe(true);
   });
 });

--- a/packages/ui/src/lib/tab-order.ts
+++ b/packages/ui/src/lib/tab-order.ts
@@ -2,17 +2,12 @@
  * Whether a committed tab list holds different elements, or the same elements
  * in a different order, than the previous commit.
  *
- * Base UI measures the tabs indicator during render, from the DOM as it stood
- * *before* the commit. Its own correction is a `ResizeObserver` over the tab
- * elements, which cannot see a tab that moved without changing size. So a
- * commit that reorders, inserts, or removes a tab leaves the indicator on the
- * active tab's old coordinates until something else forces a re-render.
- *
- * Detecting that case is the whole of the workaround: compare element identity
- * rather than count or content, because React moves the same DOM nodes when it
- * reorders keyed children, and a pure move is exactly what the
- * `ResizeObserver` misses. Identity is all this needs, so it stays generic
- * rather than reaching for the DOM.
+ * Base UI measures the tabs indicator during render, so it reads the DOM as it
+ * stood before the commit. Its correction is a `ResizeObserver`, which catches
+ * an insertion or a removal (the list's own width changes) but not a reorder:
+ * there the tabs swap places without anything changing size. Detecting that is
+ * the whole of the workaround, so compare identity rather than count, because
+ * React moves the same nodes when it reorders keyed children.
  */
 export const hasTabOrderChanged = <T>(
   previous: readonly T[],

--- a/packages/ui/src/lib/tab-order.ts
+++ b/packages/ui/src/lib/tab-order.ts
@@ -1,0 +1,22 @@
+/**
+ * Whether a committed tab list holds different elements, or the same elements
+ * in a different order, than the previous commit.
+ *
+ * Base UI measures the tabs indicator during render, from the DOM as it stood
+ * *before* the commit. Its own correction is a `ResizeObserver` over the tab
+ * elements, which cannot see a tab that moved without changing size. So a
+ * commit that reorders, inserts, or removes a tab leaves the indicator on the
+ * active tab's old coordinates until something else forces a re-render.
+ *
+ * Detecting that case is the whole of the workaround: compare element identity
+ * rather than count or content, because React moves the same DOM nodes when it
+ * reorders keyed children, and a pure move is exactly what the
+ * `ResizeObserver` misses. Identity is all this needs, so it stays generic
+ * rather than reaching for the DOM.
+ */
+export const hasTabOrderChanged = <T>(
+  previous: readonly T[],
+  next: readonly T[],
+): boolean =>
+  previous.length !== next.length ||
+  next.some((tab, index) => tab !== previous[index]);

--- a/packages/ui/src/lib/utils.test.ts
+++ b/packages/ui/src/lib/utils.test.ts
@@ -1,0 +1,99 @@
+import type * as React from "react";
+
+import { describe, expect, test } from "bun:test";
+
+import { composeRefs } from "./utils";
+
+// React attaches by calling the composed ref and detaches by calling the
+// cleanup it returns. The package has no DOM environment, so the tests drive
+// that contract directly; a string stands in for the node.
+const NODE = "node";
+
+describe("composeRefs", () => {
+  test("runs a callback ref's own cleanup rather than detaching it again", () => {
+    const calls: (string | null)[] = [];
+    let cleaned = 0;
+    const ref = (node: string | null) => {
+      calls.push(node);
+      return () => {
+        cleaned += 1;
+      };
+    };
+
+    const cleanup = composeRefs(ref)(NODE);
+    cleanup?.();
+
+    expect(cleaned).toBe(1);
+    // Detaching on top of the ref's own cleanup would tear down twice.
+    expect(calls).toEqual([NODE]);
+  });
+
+  test("detaches a callback ref that returns no cleanup", () => {
+    const calls: (string | null)[] = [];
+
+    const cleanup = composeRefs((node: string | null) => {
+      calls.push(node);
+    })(NODE);
+    expect(calls).toEqual([NODE]);
+
+    cleanup?.();
+    expect(calls).toEqual([NODE, null]);
+  });
+
+  test("assigns and clears object refs", () => {
+    const objectRef: React.RefObject<string | null> = { current: null };
+
+    const cleanup = composeRefs(objectRef)(NODE);
+    expect(objectRef.current).toBe(NODE);
+
+    cleanup?.();
+    expect(objectRef.current).toBeNull();
+  });
+
+  test("returns no cleanup when there is nothing to undo", () => {
+    const detached: (string | null)[] = [];
+
+    // React still calls refs with `null` on the legacy detach path. Handing it
+    // a cleanup there would leave it holding teardown for a dropped node, and
+    // the object-ref branch would null out a ref that is already null.
+    const detaching = composeRefs((node: string | null) => {
+      detached.push(node);
+    })(null);
+
+    expect(detaching).toBeUndefined();
+    expect(detached).toEqual([null]);
+
+    // Optional forwarded refs arrive absent, which must not synthesize a
+    // cleanup for React to call.
+    expect(composeRefs(undefined, null)(NODE)).toBeUndefined();
+  });
+
+  test("reaches every ref on attach and on detach", () => {
+    const objectRef: React.RefObject<string | null> = { current: null };
+    const attached: string[] = [];
+    const detached: string[] = [];
+
+    const cleanup = composeRefs(
+      // Ordered so a ref that supplies its own cleanup sits between two that
+      // do not: whichever branch the loop takes, it must keep going.
+      (node: string | null) => {
+        attached.push(`first:${node}`);
+      },
+      (node: string | null) => {
+        attached.push(`second:${node}`);
+        return () => {
+          detached.push("second");
+        };
+      },
+      objectRef,
+    )(NODE);
+
+    expect(attached).toEqual([`first:${NODE}`, `second:${NODE}`]);
+    expect(objectRef.current).toBe(NODE);
+
+    cleanup?.();
+
+    expect(detached).toEqual(["second"]);
+    expect(objectRef.current).toBeNull();
+  });
+});

--- a/packages/ui/src/lib/utils.test.ts
+++ b/packages/ui/src/lib/utils.test.ts
@@ -93,6 +93,10 @@ describe("composeRefs", () => {
 
     cleanup?.();
 
+    // The first ref returns no cleanup of its own, so detaching it is a call
+    // with `null`; without this the branch that synthesizes that call could go
+    // missing unnoticed.
+    expect(attached).toEqual([`first:${NODE}`, `second:${NODE}`, "first:null"]);
     expect(detached).toEqual(["second"]);
     expect(objectRef.current).toBeNull();
   });

--- a/packages/ui/src/lib/utils.ts
+++ b/packages/ui/src/lib/utils.ts
@@ -1,3 +1,5 @@
+import type * as React from "react";
+
 import { clsx } from "clsx";
 import type { ClassValue } from "clsx";
 import { twMerge } from "tailwind-merge";
@@ -5,3 +7,53 @@ import { twMerge } from "tailwind-merge";
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
+
+/**
+ * Compose multiple refs into a single ref callback.
+ * Adapted from `@radix-ui/react-compose-refs` (MIT).
+ *
+ * Collects cleanup functions returned by React 19 ref
+ * callbacks and returns a combined cleanup so React can
+ * invoke it on unmount instead of re-calling with `null`.
+ *
+ * Use this rather than merging refs inline: forwarding a
+ * caller's return value verbatim makes React read whatever
+ * their callback happened to return as a cleanup, and warn
+ * when it is neither a function nor `undefined`.
+ */
+export const composeRefs =
+  <T>(
+    ...refs: (React.Ref<T> | undefined)[]
+  ): ((node: T | null) => (() => void) | undefined) =>
+  (node) => {
+    const cleanups: (() => void)[] = [];
+    for (const ref of refs) {
+      if (typeof ref === "function") {
+        const cleanup = ref(node);
+        if (typeof cleanup === "function") {
+          cleanups.push(() => {
+            cleanup();
+          });
+        } else if (node !== null) {
+          cleanups.push(() => {
+            ref(null);
+          });
+        }
+      } else if (ref !== undefined && ref !== null) {
+        ref.current = node;
+        if (node !== null) {
+          cleanups.push(() => {
+            ref.current = null;
+          });
+        }
+      }
+    }
+    if (cleanups.length > 0) {
+      return () => {
+        for (const cleanup of cleanups) {
+          cleanup();
+        }
+      };
+    }
+    return undefined;
+  };


### PR DESCRIPTION
## Proposed change

Fixes #1719.

Two separate defects sat behind the reported behaviour.

**The underline went stale.** Base UI measures the tabs indicator during render,
so a commit that reorders tabs measures the pre-commit DOM and leaves the
underline on the active tab's old coordinates. Its `ResizeObserver` corrects an
insertion or a removal, since the list's own width changes, but not a reorder:
there the tabs swap places without anything changing size. `TabsList` now
detects a committed order change and re-renders once, so the measurement runs
against the DOM as it actually stands.

**The drop target did not say where the view would land.** Highlighting the tab
under the pointer cannot express which side the view lands on. That is replaced
by an insertion line drawn on the edge the pointer is nearest, via
`attachClosestEdge` / `extractClosestEdge`. The reorder itself is now expressed
relative to the target (`before` / `after`) rather than by index, so the result
depends only on which edge was hit, never on the direction the tab was dragged
from.

Supporting changes in the same path:

- The tab strip carries its own non-sticky drop target. The tabs are sticky so
  the line does not flicker while the pointer crosses the gaps between them, and
  a sticky target survives only while its parent target is unchanged. Without a
  target around the strip the tabs would stay sticky page-wide, keeping the line
  lit over unrelated chrome and reordering on release there.
- The physical edge is resolved against the writing direction, so both the line
  and the landing position mirror correctly under RTL.
- Reordering applies optimistically, rolls back on error, and reconciles on
  settle. The endpoint takes the workspace's full view set, so the optimistic
  write applies only when the dragged ids are the same set the cache holds: a
  length check alone lets a repeated id fill the list to the right length while
  dropping a view off the strip. Nothing disables the strip between drops, so a
  rollback runs only while the cache still holds what that reorder wrote;
  otherwise it would undo a later drop.
- A view drag is refused while a view menu is open, because the drag would
  otherwise preview the menu's dismiss layer instead of the tab. The tab's
  actions button is likewise not a drag affordance.
- `composeRefs` moves from `apps/web` to `packages/ui` so `TabsList` can merge
  its list ref with a caller's without re-implementing it.

Covered by unit tests: `reorderViewIds` over the full dragged × target ×
position cross-product plus both RTL edge mappings, `hasTabOrderChanged` over
every reordering of a fixed set, and the reorder's cache path driven against a
real `QueryClient` (the optimistic write, its rollback, the rollback skipped
when a later drop has replaced it, and the settling invalidation reaching a
locale variant the write did not touch). `composeRefs` is covered for attach and
cleanup, including the ref that supplies its own cleanup.

## Checklist

- [x] BUILD ASSURANCE | Code builds correctly and without any errors or warnings.
- [x] TESTING | Changes tested, including in different conditions (dark mode, language, narrow screen, etc).
- [x] DARK MODE SUPPORT | User can use the webapp in dark mode. Make sure your changes are visible in both light and dark mode.
- [x] ISSUE LINKED | Link an issue to this PR (not by mentioning it in the description, but by using the GitHub issue linking feature)
- [ ] SCREENSHOT INCLUDED | If relevant, please include a screenshot / video of the functionality added (allows for a quick check of minor ux changes)

`bun run verify` passes, and the drag has been exercised in a running browser.
No screenshot is attached.

CC on behalf of shanehobson

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added drag-and-drop reordering for workspace view tabs.
- Supports before/after placement, RTL layouts, insertion indicators and protected drop areas.
- Prevents reordering while an actions menu is open.
- Added menu-open state reporting for improved interface behaviour.

## Bug Fixes
- View order updates now apply immediately, recover if saving fails and remain synchronised across locales.
- Improved tab rendering after items are reordered.

## Refactor
- Centralised shared reference handling across document, Markdown and PDF editors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


