### PR TITLE
fix(mcp): preserve transport request bodies

### DIFF
--- a/apps/api/src/handlers/mcp/routes-core.ts
+++ b/apps/api/src/handlers/mcp/routes-core.ts
@@ -90,6 +90,10 @@ export const createMcpRoute = ({
         await handleMcpTransportRoute(request, {
           clientIp: resolveClientIp(request, server ?? null),
         }),
+      // The MCP transports own JSON parsing. If Elysia parses first, the
+      // web-standard Request reaches them with an already-consumed body and
+      // every valid JSON-RPC POST is rejected as a parse error.
+      { parse: "none" },
     )
     .all(
       MCP_ANONYMIZED_HTTP_PATH,
@@ -98,5 +102,6 @@ export const createMcpRoute = ({
           clientIp: resolveClientIp(request, server ?? null),
           mode: "anonymized",
         }),
+      { parse: "none" },
     );
 };

--- a/apps/api/src/handlers/mcp/routes.test.ts
+++ b/apps/api/src/handlers/mcp/routes.test.ts
@@ -129,6 +129,33 @@ describe("MCP protected resource discovery routes", () => {
     ]);
   });
 
+  test("leaves JSON-RPC request bodies unread for both MCP transports", async () => {
+    const bodies: unknown[] = [];
+    const route = createMcpRoute({
+      handleMcpHttpRequest: async (request) => {
+        expect(request.bodyUsed).toBe(false);
+        bodies.push(await request.json());
+        return new Response("ok");
+      },
+    });
+    const body = { id: 1, jsonrpc: "2.0", method: "tools/list" };
+
+    for (const path of [MCP_HTTP_PATH, MCP_ANONYMIZED_HTTP_PATH]) {
+      // oxlint-disable-next-line no-await-in-loop -- each request must reach the transport before the next assertion
+      const response = await route.handle(
+        new Request(`http://localhost${path}`, {
+          body: JSON.stringify(body),
+          headers: { "content-type": "application/json" },
+          method: "POST",
+        }),
+      );
+
+      expect(response.status).toBe(200);
+    }
+
+    expect(bodies).toEqual([body, body]);
+  });
+
   test("rejects unsupported MCP HTTP methods before transport handling", async () => {
     let calls = 0;
     const route = createMcpRoute({


### PR DESCRIPTION
## Summary
- disable Elysia body parsing on both MCP transport routes
- preserve the unread web-standard request for the legacy and modern SDK handlers
- cover both default and anonymized routes with a body-ownership regression test

## Verification
- 45 focused MCP tests pass
- API typecheck passes
- API lint passes
- full affected pre-push checks pass
- production diagnosis reproduced JSON-RPC -32700 before this fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MCP HTTP request handling so JSON-RPC payloads are parsed correctly across standard and anonymised transport endpoints.
  * Ensured requests receive successful responses with consistent parsed data.

* **Tests**
  * Added coverage for JSON-RPC POST requests across both MCP transport paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->