### PR TITLE
feat(sidebar): hide the matter activity disclosure when it is empty

### DIFF
--- a/apps/web/src/components/app-sidebar.logic.test.ts
+++ b/apps/web/src/components/app-sidebar.logic.test.ts
@@ -134,15 +134,31 @@ describe("sidebar matter activity disclosure", () => {
 
   test("keeps the disclosure when any page carries an item", () => {
     expect(
-      matterActivityIsKnownEmpty([{ items: [] }, { items: [{ id: "a" }] }]),
+      matterActivityIsKnownEmpty([
+        { items: [], nextCursor: "cursor" },
+        { items: [{ id: "a" }], nextCursor: null },
+      ]),
     ).toBe(false);
   });
 
-  test("drops the disclosure once every resolved page is empty", () => {
-    expect(matterActivityIsKnownEmpty([{ items: [] }])).toBe(true);
-    expect(matterActivityIsKnownEmpty([{ items: [] }, { items: [] }])).toBe(
+  test("keeps the disclosure while a continuation cursor remains", () => {
+    // An empty page that can still be followed by one holding activity: hiding
+    // the toggle here would strand the user with no way to load that page.
+    expect(
+      matterActivityIsKnownEmpty([{ items: [], nextCursor: "cursor" }]),
+    ).toBe(false);
+  });
+
+  test("drops the disclosure once a drained result holds no item", () => {
+    expect(matterActivityIsKnownEmpty([{ items: [], nextCursor: null }])).toBe(
       true,
     );
+    expect(
+      matterActivityIsKnownEmpty([
+        { items: [], nextCursor: "cursor" },
+        { items: [], nextCursor: null },
+      ]),
+    ).toBe(true);
   });
 });
 

--- a/apps/web/src/components/app-sidebar.logic.test.ts
+++ b/apps/web/src/components/app-sidebar.logic.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  matterActivityIsKnownEmpty,
   resolveEntityActivityDestination,
   resolveAutomaticExpandedMatterId,
   resolveSidebarWorkspaceId,
@@ -120,6 +121,28 @@ describe("sidebar matter context", () => {
         activeWorkspaceId: undefined,
       }),
     ).toBeNull();
+  });
+});
+
+describe("sidebar matter activity disclosure", () => {
+  test("keeps the disclosure while the activity result is unknown", () => {
+    // Never fetched, and a page-less result: neither proves the matter is empty,
+    // so the toggle stays rather than flickering out under the pointer.
+    expect(matterActivityIsKnownEmpty(undefined)).toBe(false);
+    expect(matterActivityIsKnownEmpty([])).toBe(false);
+  });
+
+  test("keeps the disclosure when any page carries an item", () => {
+    expect(
+      matterActivityIsKnownEmpty([{ items: [] }, { items: [{ id: "a" }] }]),
+    ).toBe(false);
+  });
+
+  test("drops the disclosure once every resolved page is empty", () => {
+    expect(matterActivityIsKnownEmpty([{ items: [] }])).toBe(true);
+    expect(matterActivityIsKnownEmpty([{ items: [] }, { items: [] }])).toBe(
+      true,
+    );
   });
 });
 

--- a/apps/web/src/components/app-sidebar.logic.test.ts
+++ b/apps/web/src/components/app-sidebar.logic.test.ts
@@ -125,19 +125,52 @@ describe("sidebar matter context", () => {
 });
 
 describe("sidebar matter activity disclosure", () => {
+  const knownEmptyInput = (
+    pages: { items: readonly unknown[]; nextCursor: string | null }[],
+  ) => ({ isInvalidated: false, pages, status: "success" as const });
+
   test("keeps the disclosure while the activity result is unknown", () => {
-    // Never fetched, and a page-less result: neither proves the matter is empty,
-    // so the toggle stays rather than flickering out under the pointer.
-    expect(matterActivityIsKnownEmpty(undefined)).toBe(false);
-    expect(matterActivityIsKnownEmpty([])).toBe(false);
+    // Never fetched, still loading, or failed: none of these prove the matter
+    // is empty, so the toggle stays rather than flickering out under the
+    // pointer.
+    expect(
+      matterActivityIsKnownEmpty({
+        isInvalidated: false,
+        pages: undefined,
+        status: "pending",
+      }),
+    ).toBe(false);
+    expect(
+      matterActivityIsKnownEmpty({
+        isInvalidated: false,
+        pages: [{ items: [], nextCursor: null }],
+        status: "error",
+      }),
+    ).toBe(false);
+    expect(matterActivityIsKnownEmpty(knownEmptyInput([]))).toBe(false);
+  });
+
+  test("keeps the disclosure once the cached result is invalidated", () => {
+    // The sidebar's observer is disabled, so an invalidated empty result is
+    // never refetched: a matter that just gained activity would keep a hidden
+    // toggle forever.
+    expect(
+      matterActivityIsKnownEmpty({
+        isInvalidated: true,
+        pages: [{ items: [], nextCursor: null }],
+        status: "success",
+      }),
+    ).toBe(false);
   });
 
   test("keeps the disclosure when any page carries an item", () => {
     expect(
-      matterActivityIsKnownEmpty([
-        { items: [], nextCursor: "cursor" },
-        { items: [{ id: "a" }], nextCursor: null },
-      ]),
+      matterActivityIsKnownEmpty(
+        knownEmptyInput([
+          { items: [], nextCursor: "cursor" },
+          { items: [{ id: "a" }], nextCursor: null },
+        ]),
+      ),
     ).toBe(false);
   });
 
@@ -145,19 +178,25 @@ describe("sidebar matter activity disclosure", () => {
     // An empty page that can still be followed by one holding activity: hiding
     // the toggle here would strand the user with no way to load that page.
     expect(
-      matterActivityIsKnownEmpty([{ items: [], nextCursor: "cursor" }]),
+      matterActivityIsKnownEmpty(
+        knownEmptyInput([{ items: [], nextCursor: "cursor" }]),
+      ),
     ).toBe(false);
   });
 
   test("drops the disclosure once a drained result holds no item", () => {
-    expect(matterActivityIsKnownEmpty([{ items: [], nextCursor: null }])).toBe(
-      true,
-    );
     expect(
-      matterActivityIsKnownEmpty([
-        { items: [], nextCursor: "cursor" },
-        { items: [], nextCursor: null },
-      ]),
+      matterActivityIsKnownEmpty(
+        knownEmptyInput([{ items: [], nextCursor: null }]),
+      ),
+    ).toBe(true);
+    expect(
+      matterActivityIsKnownEmpty(
+        knownEmptyInput([
+          { items: [], nextCursor: "cursor" },
+          { items: [], nextCursor: null },
+        ]),
+      ),
     ).toBe(true);
   });
 });

--- a/apps/web/src/components/app-sidebar.logic.ts
+++ b/apps/web/src/components/app-sidebar.logic.ts
@@ -88,18 +88,25 @@ export const selectRecentWorkspaces = <TWorkspace extends RecentWorkspace>({
 
 type MatterActivityPage = {
   items: readonly unknown[];
+  nextCursor: string | null;
 };
 
 // Whether a matter's cached activity pages prove there is nothing to disclose.
-// Undefined pages mean the activity query has never resolved for this matter,
-// so emptiness is unknown and the disclosure must stay available; only a
-// resolved, fully empty result counts as known-empty.
+// Emptiness must be proven, never assumed: an unresolved query, or one whose
+// last page still carries a cursor, may yet yield activity, so the disclosure
+// stays available. Only a drained, item-free result counts as known-empty.
 export const matterActivityIsKnownEmpty = (
   pages: readonly MatterActivityPage[] | undefined,
 ): boolean => {
-  if (pages === undefined || pages.length === 0) {
+  if (pages === undefined) {
     return false;
   }
+
+  const lastPage = pages.at(-1);
+  if (lastPage === undefined || lastPage.nextCursor !== null) {
+    return false;
+  }
+
   return pages.every((page) => page.items.length === 0);
 };
 

--- a/apps/web/src/components/app-sidebar.logic.ts
+++ b/apps/web/src/components/app-sidebar.logic.ts
@@ -86,6 +86,23 @@ export const selectRecentWorkspaces = <TWorkspace extends RecentWorkspace>({
   return [...sorted.slice(0, Math.max(limit - 1, 0)), activeWorkspace];
 };
 
+type MatterActivityPage = {
+  items: readonly unknown[];
+};
+
+// Whether a matter's cached activity pages prove there is nothing to disclose.
+// Undefined pages mean the activity query has never resolved for this matter,
+// so emptiness is unknown and the disclosure must stay available; only a
+// resolved, fully empty result counts as known-empty.
+export const matterActivityIsKnownEmpty = (
+  pages: readonly MatterActivityPage[] | undefined,
+): boolean => {
+  if (pages === undefined || pages.length === 0) {
+    return false;
+  }
+  return pages.every((page) => page.items.length === 0);
+};
+
 export type EntityActivityDestination =
   | { type: "document" }
   | { type: "all-view" }

--- a/apps/web/src/components/app-sidebar.logic.ts
+++ b/apps/web/src/components/app-sidebar.logic.ts
@@ -91,14 +91,25 @@ type MatterActivityPage = {
   nextCursor: string | null;
 };
 
-// Whether a matter's cached activity pages prove there is nothing to disclose.
-// Emptiness must be proven, never assumed: an unresolved query, or one whose
-// last page still carries a cursor, may yet yield activity, so the disclosure
-// stays available. Only a drained, item-free result counts as known-empty.
-export const matterActivityIsKnownEmpty = (
-  pages: readonly MatterActivityPage[] | undefined,
-): boolean => {
-  if (pages === undefined) {
+type MatterActivityIsKnownEmptyOptions = {
+  isInvalidated: boolean;
+  pages: readonly MatterActivityPage[] | undefined;
+  status: "error" | "pending" | "success";
+};
+
+// Whether a matter's cached activity proves there is nothing to disclose.
+// Emptiness must be proven, never assumed. A query that has not succeeded has
+// nothing to prove it with; an invalidated one describes the matter as it was
+// before the mutation that invalidated it, and the sidebar's disabled observer
+// will not refetch it; and a last page that still carries a cursor may be
+// followed by one holding activity. Only a fresh, drained, item-free result
+// counts as known-empty.
+export const matterActivityIsKnownEmpty = ({
+  isInvalidated,
+  pages,
+  status,
+}: MatterActivityIsKnownEmptyOptions): boolean => {
+  if (status !== "success" || isInvalidated || pages === undefined) {
     return false;
   }
 

--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -1,5 +1,11 @@
 import type * as React from "react";
-import { useMemo, useRef, useState } from "react";
+import {
+  useCallback,
+  useMemo,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from "react";
 
 import { combine } from "@atlaskit/pragmatic-drag-and-drop/combine";
 import {
@@ -7,7 +13,7 @@ import {
   dropTargetForElements,
 } from "@atlaskit/pragmatic-drag-and-drop/element/adapter";
 import { formatForDisplay, useHotkey } from "@tanstack/react-hotkeys";
-import { useInfiniteQuery } from "@tanstack/react-query";
+import { useInfiniteQuery, useQueryClient } from "@tanstack/react-query";
 import {
   getRouteApi,
   Link,
@@ -116,6 +122,7 @@ import { ENTITY_DRAG_TYPE } from "@/lib/workspaces/drag-constants";
 import { useUpdateWorkspace } from "@/lib/workspaces/mutations";
 import {
   workspaceActivityOptions,
+  workspacesKeys,
   workspacesNavigationOptions,
 } from "@/lib/workspaces/queries";
 
@@ -972,16 +979,34 @@ const MatterItem = ({
   // ever issuing a request: the expanded row owns the fetch, so `enabled: false`
   // keeps the sidebar at its current request count while still re-rendering the
   // disclosure once that fetch resolves.
-  const { data: cachedActivity } = useInfiniteQuery({
+  const { data: cachedActivity, status: activityStatus } = useInfiniteQuery({
     ...workspaceActivityOptions({
       activeOrganizationId,
       key: { workspaceId: ws.id },
     }),
     enabled: false,
   });
-  const activityIsKnownEmpty = matterActivityIsKnownEmpty(
-    cachedActivity?.pages,
+  // `invalidateQueries` does not refetch a disabled observer, so the cached
+  // pages can outlive the matter they describe. The invalidation flag lives on
+  // the cache entry rather than the observer result, so read it from there.
+  const queryClient = useQueryClient();
+  const activityQueryKey = workspacesKeys.activity(activeOrganizationId, {
+    workspaceId: ws.id,
+  });
+  const activityIsInvalidated = useSyncExternalStore(
+    useCallback(
+      (onStoreChange: () => void) =>
+        queryClient.getQueryCache().subscribe(onStoreChange),
+      [queryClient],
+    ),
+    () => queryClient.getQueryState(activityQueryKey)?.isInvalidated ?? false,
+    () => false,
   );
+  const activityIsKnownEmpty = matterActivityIsKnownEmpty({
+    isInvalidated: activityIsInvalidated,
+    pages: cachedActivity?.pages,
+    status: activityStatus,
+  });
 
   const canDrag = isPinned && !!onReorder;
   const isCollapsed = state === "collapsed" && !isMobile;

--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -1397,8 +1397,10 @@ const MatterActivityList = ({
 
   // Nothing to disclose: render no list at all rather than an empty one, so the
   // matter row never opens onto a dead end. The row drops its disclosure toggle
-  // on the same resolved-empty result.
-  if (items.length === 0) {
+  // on the same drained, item-free result. An empty page that still has a
+  // continuation keeps the list mounted so its "show more" control stays
+  // reachable.
+  if (items.length === 0 && !hasNextPage) {
     return null;
   }
 

--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -44,6 +44,7 @@ import { stellaToast } from "@stll/ui/components/toast";
 import { cn } from "@stll/ui/lib/utils";
 
 import {
+  matterActivityIsKnownEmpty,
   resolveEntityActivityDestination,
   resolveAutomaticExpandedMatterId,
   resolveSidebarWorkspaceId,
@@ -967,6 +968,21 @@ const MatterItem = ({
     },
   });
 
+  // Read whatever the activity query has already cached for this matter without
+  // ever issuing a request: the expanded row owns the fetch, so `enabled: false`
+  // keeps the sidebar at its current request count while still re-rendering the
+  // disclosure once that fetch resolves.
+  const { data: cachedActivity } = useInfiniteQuery({
+    ...workspaceActivityOptions({
+      activeOrganizationId,
+      key: { workspaceId: ws.id },
+    }),
+    enabled: false,
+  });
+  const activityIsKnownEmpty = matterActivityIsKnownEmpty(
+    cachedActivity?.pages,
+  );
+
   const canDrag = isPinned && !!onReorder;
   const isCollapsed = state === "collapsed" && !isMobile;
 
@@ -1135,32 +1151,34 @@ const MatterItem = ({
         }}
         ref={dropRef}
       >
-        <Tooltip
-          content={isExpanded ? t("common.showLess") : t("common.showMore")}
-          render={
-            <Button
-              aria-controls={`matter-activity-${ws.id}`}
-              aria-expanded={isExpanded}
-              aria-label={
-                isExpanded ? t("common.showLess") : t("common.showMore")
-              }
-              className="text-muted-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground absolute start-1 top-1 z-10 border-0 group-data-[collapsible=icon]:hidden before:hidden focus-visible:ring-1 focus-visible:ring-offset-0"
-              onClick={onExpandedChange}
-              size="icon-xs"
-              type="button"
-              variant="ghost"
+        {activityIsKnownEmpty ? null : (
+          <Tooltip
+            content={isExpanded ? t("common.showLess") : t("common.showMore")}
+            render={
+              <Button
+                aria-controls={`matter-activity-${ws.id}`}
+                aria-expanded={isExpanded}
+                aria-label={
+                  isExpanded ? t("common.showLess") : t("common.showMore")
+                }
+                className="text-muted-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground absolute start-1 top-1 z-10 border-0 group-data-[collapsible=icon]:hidden before:hidden focus-visible:ring-1 focus-visible:ring-offset-0"
+                onClick={onExpandedChange}
+                size="icon-xs"
+                type="button"
+                variant="ghost"
+              />
+            }
+          >
+            <DirectionalIcon
+              className={cn(
+                "size-3.5 transition-transform duration-150",
+                isExpanded && "rotate-90",
+              )}
+              flip={!isExpanded}
+              icon={ChevronRightIcon}
             />
-          }
-        >
-          <DirectionalIcon
-            className={cn(
-              "size-3.5 transition-transform duration-150",
-              isExpanded && "rotate-90",
-            )}
-            flip={!isExpanded}
-            icon={ChevronRightIcon}
-          />
-        </Tooltip>
+          </Tooltip>
+        )}
         <SidebarMenuButton
           asChild
           className="ps-8 pe-12 group-data-[collapsible=icon]:ps-2"
@@ -1377,8 +1395,11 @@ const MatterActivityList = ({
     );
   }
 
+  // Nothing to disclose: render no list at all rather than an empty one, so the
+  // matter row never opens onto a dead end. The row drops its disclosure toggle
+  // on the same resolved-empty result.
   if (items.length === 0) {
-    return <SidebarMenuSub className="border-0" id={id} />;
+    return null;
   }
 
   return (


### PR DESCRIPTION
## Proposed change

Closes #1669.

A matter row's activity disclosure rendered an empty `SidebarMenuSub` when the matter had no entities and no threads, so the chevron opened onto nothing. Because the active matter auto-expands (`resolveAutomaticExpandedMatterId`), a fresh matter showed that dead end without a click.

- `MatterActivityList` returns `null` on a resolved-empty result instead of an empty list.
- `MatterItem` drops the chevron once that result is known to be empty.

Emptiness is read from the cache the expanded row already populates, with `enabled: false`, so the sidebar issues no extra requests and its network baseline is unchanged. An unresolved query stays "unknown" and keeps the disclosure available, so the toggle never disappears under the pointer.

`matterActivityIsKnownEmpty` lives in `app-sidebar.logic.ts` with cases in `app-sidebar.logic.test.ts` for the unresolved, partially populated, and fully empty page sets.

The row keeps its `ps-8` inset so a matter without a chevron stays aligned with its siblings.

## Checklist

- [x] **BUILD ASSURANCE** | Code builds correctly and without any errors or warnings.
- [x] **TESTING** | Changes tested, including in different conditions (dark mode, language, narrow screen, etc).
- [x] **DARK MODE SUPPORT** | User can use the webapp in dark mode. Make sure your changes are visible in both light and dark mode.
- [x] **ISSUE LINKED** | Link an issue to this PR (not by mentioning it in the description, but by using the GitHub issue linking feature)
- [ ] SCREENSHOT INCLUDED | If relevant, please include a screenshot / video of the functionality added (allows for a quick check of minor ux changes)

The change only removes UI, so there is no new surface to screenshot: the disclosure and its chevron are absent where an empty list used to render. No colours, tokens, or strings were touched, so dark mode and the translated labels are unaffected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Matter navigation no longer shows an activity disclosure when activity is confirmed to be empty.
  - Empty activity sections are now hidden instead of displaying a blank submenu.
  - Activity controls remain available while results are still loading or incomplete.
- **Tests**
  - Added coverage for unknown, paginated and fully empty activity results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->