### PR TITLE
fix(mcp): support ChatGPT notification channel

### DIFF
--- a/apps/api/src/mcp/constants.ts
+++ b/apps/api/src/mcp/constants.ts
@@ -55,12 +55,13 @@ export const MCP_HTTP_PATH = "/mcp";
 export const MCP_ANONYMIZED_HTTP_PATH = "/mcp-anonymized";
 
 /**
- * What the stateless transport serves. `GET` (the standalone notification
- * stream) and `DELETE` (session termination) are both session operations a
- * per-request transport cannot honour, so neither is advertised. Shared so the
- * endpoint and anything probing it cannot drift apart on the contract.
+ * What the stateless transport serves. `GET` opens a request-scoped
+ * notification stream for clients that require one (notably ChatGPT), while
+ * `POST` remains the stateless JSON-RPC exchange. `DELETE` still presupposes a
+ * resumable session and is not advertised. Shared so the endpoint and anything
+ * probing it cannot drift apart on the contract.
  */
-export const MCP_STATELESS_ALLOW_HEADER = "OPTIONS, POST";
+export const MCP_STATELESS_ALLOW_HEADER = "OPTIONS, GET, POST";
 
 export const ROOT_MCP_DISCOVERY_PATH =
   "/.well-known/oauth-protected-resource" as const;

--- a/apps/api/src/mcp/server-core.ts
+++ b/apps/api/src/mcp/server-core.ts
@@ -57,7 +57,9 @@ const isByteStreamReadResult = (
     return false;
   }
   const { done, value: chunk }: Record<string, unknown> = { ...value };
-  return done === true ? chunk === undefined : chunk instanceof Uint8Array;
+  return done === true
+    ? chunk === undefined
+    : done === false && chunk instanceof Uint8Array;
 };
 
 const formatUnknownToolName = (toolName: string): string =>
@@ -504,6 +506,14 @@ export const createMcpHttpRequestHandler = ({
     const transport = new WebStandardStreamableHTTPServerTransport({
       enableJsonResponse: true,
     });
+    const reportTransportError = (error: unknown, operation: string) => {
+      captureError(error, {
+        mode,
+        operation,
+        phase: "transport",
+        source: "mcp",
+      });
+    };
 
     let toreDown = false;
     const teardown = async () => {
@@ -511,8 +521,16 @@ export const createMcpHttpRequestHandler = ({
         return;
       }
       toreDown = true;
-      await transport.close().catch(() => null);
-      await server.close().catch(() => null);
+      const [transportResult, serverResult] = await Promise.allSettled([
+        transport.close(),
+        server.close(),
+      ]);
+      if (transportResult.status === "rejected") {
+        reportTransportError(transportResult.reason, "close_transport");
+      }
+      if (serverResult.status === "rejected") {
+        reportTransportError(serverResult.reason, "close_server");
+      }
     };
 
     try {
@@ -532,10 +550,14 @@ export const createMcpHttpRequestHandler = ({
       }
 
       const reader = response.body.getReader();
-      const completeExchange = () => {
-        detached(teardown(), "mcp.legacy-stream-teardown");
+      const completeExchange = async () => {
+        request.signal.removeEventListener("abort", abortExchange);
+        await teardown();
       };
-      request.signal.addEventListener("abort", completeExchange, {
+      const abortExchange = () => {
+        detached(completeExchange(), "mcp.legacy-stream-teardown");
+      };
+      request.signal.addEventListener("abort", abortExchange, {
         once: true,
       });
 
@@ -547,19 +569,25 @@ export const createMcpHttpRequestHandler = ({
               throw new TypeError("MCP transport returned a non-byte stream");
             }
             if (readResult.done) {
-              completeExchange();
+              await completeExchange();
               controller.close();
               return;
             }
             controller.enqueue(readResult.value);
           } catch (error) {
-            completeExchange();
+            reportTransportError(error, "read_stream");
+            await completeExchange();
             controller.error(error);
           }
         },
         cancel: async (reason) => {
-          completeExchange();
-          await reader.cancel(reason).catch(() => null);
+          try {
+            await reader.cancel(reason);
+          } catch (error) {
+            reportTransportError(error, "cancel_stream");
+          } finally {
+            await completeExchange();
+          }
         },
       });
 

--- a/apps/api/src/mcp/server-core.ts
+++ b/apps/api/src/mcp/server-core.ts
@@ -46,6 +46,20 @@ import {
 
 const MAX_TOOL_NAME_SUGGESTION_CHARS = 128;
 
+type ByteStreamReadResult =
+  | { done: false; value: Uint8Array }
+  | { done: true; value?: undefined };
+
+const isByteStreamReadResult = (
+  value: unknown,
+): value is ByteStreamReadResult => {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  const { done, value: chunk }: Record<string, unknown> = { ...value };
+  return done === true ? chunk === undefined : chunk instanceof Uint8Array;
+};
+
 const formatUnknownToolName = (toolName: string): string =>
   toolName.length <= MAX_TOOL_NAME_SUGGESTION_CHARS
     ? toolName
@@ -517,7 +531,7 @@ export const createMcpHttpRequestHandler = ({
         return response;
       }
 
-      const reader = (response.body as ReadableStream<Uint8Array>).getReader();
+      const reader = response.body.getReader();
       const completeExchange = () => {
         detached(teardown(), "mcp.legacy-stream-teardown");
       };
@@ -528,13 +542,16 @@ export const createMcpHttpRequestHandler = ({
       const monitoredBody = new ReadableStream<Uint8Array>({
         pull: async (controller) => {
           try {
-            const { done, value } = await reader.read();
-            if (done) {
+            const readResult: unknown = await reader.read();
+            if (!isByteStreamReadResult(readResult)) {
+              throw new TypeError("MCP transport returned a non-byte stream");
+            }
+            if (readResult.done) {
               completeExchange();
               controller.close();
               return;
             }
-            controller.enqueue(value);
+            controller.enqueue(readResult.value);
           } catch (error) {
             completeExchange();
             controller.error(error);

--- a/apps/api/src/mcp/server-core.ts
+++ b/apps/api/src/mcp/server-core.ts
@@ -14,6 +14,7 @@ import type {
 } from "@modelcontextprotocol/server";
 import { panic } from "better-result";
 
+import { detached } from "@/api/lib/detached";
 import type { McpSession } from "@/api/mcp/auth";
 import {
   MCP_STATELESS_ALLOW_HEADER,
@@ -190,21 +191,6 @@ const accessDeniedResponse = ({
     status,
   });
 };
-
-/**
- * `GET` opens the standalone notification stream and `DELETE` terminates a
- * session. Both presuppose state that outlives a request, and this transport
- * has none: every request gets its own server and transport, closed as soon as
- * the response is built.
- *
- * `GET` is the one that bites. Left to the SDK it answers
- * `200 text/event-stream`, and the per-request `close()` ends that body before
- * it reaches the client; the client sees the stream die on open, reconnects,
- * and loops there instead of calling tools. 405 is what the spec prescribes for
- * an endpoint that serves no stream, and clients handle it by staying on plain
- * request/response.
- */
-const SESSION_ONLY_HTTP_METHODS = new Set(["GET", "DELETE"]);
 
 const sessionOperationUnsupportedResponse = () => {
   const headers = createMcpCorsHeaders();
@@ -481,10 +467,11 @@ export const createMcpHttpRequestHandler = ({
   };
 
   /**
-   * The 2025-era leg, wired exactly as it was before the modern handler landed:
-   * a per-request server over the streamable transport in JSON mode. Closing
-   * both afterwards is safe here and only here, because the response is fully
-   * buffered by construction and the streaming methods never reach this path.
+   * The 2025-era leg uses a fresh server and transport for every request. POST
+   * responses are buffered and can be torn down immediately. GET is different:
+   * ChatGPT opens the optional notification channel and treats a 405 as a dead
+   * connector, so its server and transport live exactly as long as the returned
+   * SSE body. No state is shared between that channel and later POST requests.
    */
   const serveLegacyRequest = async ({
     authInfo,
@@ -504,12 +491,69 @@ export const createMcpHttpRequestHandler = ({
       enableJsonResponse: true,
     });
 
-    try {
-      await server.connect(transport);
-      return await transport.handleRequest(request, { authInfo });
-    } finally {
+    let toreDown = false;
+    const teardown = async () => {
+      if (toreDown) {
+        return;
+      }
+      toreDown = true;
       await transport.close().catch(() => null);
       await server.close().catch(() => null);
+    };
+
+    try {
+      await server.connect(transport);
+      const response = await transport.handleRequest(request, { authInfo });
+      const isEventStream =
+        response.headers
+          .get("content-type")
+          ?.split(";")
+          .at(0)
+          ?.trim()
+          .toLowerCase() === "text/event-stream";
+
+      if (response.body === null || !isEventStream) {
+        await teardown();
+        return response;
+      }
+
+      const reader = (response.body as ReadableStream<Uint8Array>).getReader();
+      const completeExchange = () => {
+        detached(teardown(), "mcp.legacy-stream-teardown");
+      };
+      request.signal.addEventListener("abort", completeExchange, {
+        once: true,
+      });
+
+      const monitoredBody = new ReadableStream<Uint8Array>({
+        pull: async (controller) => {
+          try {
+            const { done, value } = await reader.read();
+            if (done) {
+              completeExchange();
+              controller.close();
+              return;
+            }
+            controller.enqueue(value);
+          } catch (error) {
+            completeExchange();
+            controller.error(error);
+          }
+        },
+        cancel: async (reason) => {
+          completeExchange();
+          await reader.cancel(reason).catch(() => null);
+        },
+      });
+
+      return new Response(monitoredBody, {
+        headers: response.headers,
+        status: response.status,
+        statusText: response.statusText,
+      });
+    } catch (error) {
+      await teardown();
+      throw error;
     }
   };
 
@@ -539,10 +583,10 @@ export const createMcpHttpRequestHandler = ({
     try {
       const session = await authenticateMcpRequest(token, mode);
 
-      // Refuse session operations only after the token is accepted, so an
+      // Refuse session termination only after the token is accepted, so an
       // unauthenticated probe still receives the 401 + `WWW-Authenticate` that
       // drives OAuth discovery.
-      if (SESSION_ONLY_HTTP_METHODS.has(request.method)) {
+      if (request.method === "DELETE") {
         return withMcpCors(
           sessionOperationUnsupportedResponse(),
           session,

--- a/apps/api/src/mcp/server.test.ts
+++ b/apps/api/src/mcp/server.test.ts
@@ -373,12 +373,18 @@ describe("handleMcpHttpRequest", () => {
 
     expect(response.status).toBe(200);
     expect(response.headers.get("content-type")).toContain("text/event-stream");
-    expect(response.body).not.toBeNull();
+    const body = response.body;
+    expect(body).not.toBeNull();
+    if (body === null) {
+      throw new Error("Expected an authenticated notification stream");
+    }
 
-    const reader = response.body!.getReader();
+    const reader = body.getReader();
     const firstRead = reader.read();
     const initialState = await Promise.race([
-      firstRead.then(() => "ended" as const),
+      firstRead.then(({ done }) =>
+        done ? ("ended" as const) : ("open" as const),
+      ),
       Bun.sleep(20).then(() => "open" as const),
     ]);
     expect(initialState).toBe("open");

--- a/apps/api/src/mcp/server.test.ts
+++ b/apps/api/src/mcp/server.test.ts
@@ -353,36 +353,57 @@ describe("handleMcpHttpRequest", () => {
     });
   });
 
-  test("refuses every session operation with 405 so clients stay on request/response", async () => {
+  test("keeps the authenticated notification stream open until the client cancels", async () => {
+    authenticateMcpRequestMock.mockResolvedValue({
+      organizationId: "org_1",
+      scopes: ["stella:read"],
+      userId: "user_1",
+    });
+    resolveMcpSessionContextMock.mockResolvedValue({ type: "mcp-context" });
+
+    const response = await handleMcpHttpRequest(
+      new Request("http://localhost/mcp", {
+        headers: {
+          accept: "text/event-stream",
+          authorization: "Bearer token",
+        },
+        method: "GET",
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toContain("text/event-stream");
+    expect(response.body).not.toBeNull();
+
+    const reader = response.body!.getReader();
+    const firstRead = reader.read();
+    const initialState = await Promise.race([
+      firstRead.then(() => "ended" as const),
+      Bun.sleep(20).then(() => "open" as const),
+    ]);
+    expect(initialState).toBe("open");
+
+    await reader.cancel();
+    await firstRead;
+  });
+
+  test("refuses session termination with 405", async () => {
     authenticateMcpRequestMock.mockResolvedValue({
       organizationId: "org_1",
       scopes: ["stella:read"],
       userId: "user_1",
     });
 
-    // GET opens the notification stream and DELETE ends a session. A
-    // per-request transport can honour neither, so neither may be advertised.
-    const responses = await Promise.all(
-      ["GET", "DELETE"].map(
-        async (method) =>
-          await handleMcpHttpRequest(
-            new Request("http://localhost/mcp", {
-              headers: {
-                accept: "text/event-stream",
-                authorization: "Bearer token",
-              },
-              method,
-            }),
-          ),
-      ),
+    const response = await handleMcpHttpRequest(
+      new Request("http://localhost/mcp", {
+        headers: { authorization: "Bearer token" },
+        method: "DELETE",
+      }),
     );
 
-    for (const response of responses) {
-      expect(response.status).toBe(405);
-      expect(response.headers.get("Allow")).toBe(MCP_STATELESS_ALLOW_HEADER);
-      // Refusing a session is not a credential problem: no re-consent trigger.
-      expect(response.headers.get("WWW-Authenticate")).toBeNull();
-    }
+    expect(response.status).toBe(405);
+    expect(response.headers.get("Allow")).toBe(MCP_STATELESS_ALLOW_HEADER);
+    expect(response.headers.get("WWW-Authenticate")).toBeNull();
     expect(resolveMcpSessionContextMock).not.toHaveBeenCalled();
   });
 
@@ -396,10 +417,7 @@ describe("handleMcpHttpRequest", () => {
     expect(authenticateMcpRequestMock).not.toHaveBeenCalled();
   });
 
-  test("never answers with a stream body, which per-request teardown truncates", async () => {
-    // Server and transport are built per request and closed once the response
-    // is built, so any streamed body reaches the client already ended. Every
-    // method must therefore resolve to a complete, buffered response.
+  test("keeps POST buffered and DELETE non-streaming", async () => {
     authenticateMcpRequestMock.mockResolvedValue({
       organizationId: "org_1",
       scopes: ["stella:read"],
@@ -408,13 +426,6 @@ describe("handleMcpHttpRequest", () => {
     resolveMcpSessionContextMock.mockResolvedValue({ type: "mcp-context" });
 
     const requests = [
-      new Request("http://localhost/mcp", {
-        headers: {
-          accept: "text/event-stream",
-          authorization: "Bearer token",
-        },
-        method: "GET",
-      }),
       createMcpRequest({ id: 1, jsonrpc: "2.0", method: "tools/list" }),
       new Request("http://localhost/mcp", {
         headers: { authorization: "Bearer token" },

--- a/apps/api/src/scripts/mcp-canary.test.ts
+++ b/apps/api/src/scripts/mcp-canary.test.ts
@@ -1,24 +1,16 @@
 import { isLegacyRequest } from "@modelcontextprotocol/server";
 import { describe, expect, test } from "bun:test";
 
-import { MCP_STATELESS_ALLOW_HEADER } from "@/api/mcp/constants";
-
 import {
   AUTHENTICATED_PROBES,
   createJsonRpcRequest,
   evaluateDiscovery,
   evaluateInitialize,
-  evaluateStreamRefusal,
+  evaluateStreamAvailability,
   evaluateToolsList,
   evaluateUnauthenticated,
   summarize,
 } from "./mcp-canary";
-
-const REFUSAL = {
-  allow: MCP_STATELESS_ALLOW_HEADER,
-  contentType: "application/json",
-  status: 405,
-};
 
 describe("canary protocol routing", () => {
   test("keeps the compatibility handshake legacy and sends tools/list through the modern handler", async () => {
@@ -48,62 +40,31 @@ describe("canary protocol routing", () => {
   });
 });
 
-describe("evaluateStreamRefusal", () => {
-  test("fails a stream answer, which per-request teardown truncates", () => {
-    // The whole point of the probe: a 2xx that hands the client a body already
-    // ended by teardown. Status alone reads as healthy, so the media type has
-    // to decide.
-    const result = evaluateStreamRefusal({
-      ...REFUSAL,
-      contentType: "text/event-stream",
-      status: 200,
-    });
-
-    expect(result.status).toBe("failed");
-    expect(result.detail).toContain("text/event-stream");
-  });
-
-  test("fails a stream answer regardless of charset parameters", () => {
-    const result = evaluateStreamRefusal({
-      ...REFUSAL,
-      contentType: "text/event-stream; charset=utf-8",
-      status: 200,
-    });
-
-    expect(result.status).toBe("failed");
-  });
-
-  test("passes only on the 405 that keeps clients on request/response", () => {
-    expect(evaluateStreamRefusal(REFUSAL).status).toBe("passed");
-    expect(evaluateStreamRefusal({ ...REFUSAL, status: 200 }).status).toBe(
-      "failed",
-    );
-  });
-
-  test("fails a 405 that never says what the endpoint does serve", () => {
-    // A refusal without Allow leaves the client guessing which method to use.
-    expect(evaluateStreamRefusal({ ...REFUSAL, allow: null }).status).toBe(
-      "failed",
-    );
+describe("evaluateStreamAvailability", () => {
+  test("passes an authenticated event stream", () => {
     expect(
-      evaluateStreamRefusal({ ...REFUSAL, allow: "OPTIONS, GET, POST, DELETE" })
-        .status,
-    ).toBe("failed");
-  });
-
-  test("accepts any ordering and spacing of the advertised methods", () => {
-    // Order is the server's business; the method set is the contract.
-    expect(
-      evaluateStreamRefusal({ ...REFUSAL, allow: "post ,  OPTIONS" }).status,
+      evaluateStreamAvailability({
+        contentType: "text/event-stream; charset=utf-8",
+        status: 200,
+      }).status,
     ).toBe("passed");
   });
 
-  test("fails a 405 that still advertises a session operation", () => {
-    // DELETE is a session operation too, so advertising it would promise a
-    // session this endpoint does not have.
+  test("fails the 405 that ChatGPT treats as a dead connector", () => {
     expect(
-      evaluateStreamRefusal({ ...REFUSAL, allow: "OPTIONS, POST, DELETE" })
-        .status,
+      evaluateStreamAvailability({
+        contentType: "application/json",
+        status: 405,
+      }).status,
+    ).toBe("failed");
+  });
+
+  test("fails a 200 without the event-stream media type", () => {
+    expect(
+      evaluateStreamAvailability({
+        contentType: "application/json",
+        status: 200,
+      }).status,
     ).toBe("failed");
   });
 });

--- a/apps/api/src/scripts/mcp-canary.test.ts
+++ b/apps/api/src/scripts/mcp-canary.test.ts
@@ -3,12 +3,14 @@ import { describe, expect, test } from "bun:test";
 
 import {
   AUTHENTICATED_PROBES,
+  type CanaryFetcher,
   createJsonRpcRequest,
   evaluateDiscovery,
   evaluateInitialize,
   evaluateStreamAvailability,
   evaluateToolsList,
   evaluateUnauthenticated,
+  runAuthenticatedStreamProbe,
   summarize,
 } from "./mcp-canary";
 
@@ -66,6 +68,90 @@ describe("evaluateStreamAvailability", () => {
         status: 200,
       }).status,
     ).toBe("failed");
+  });
+});
+
+describe("authenticated notification-stream probe", () => {
+  test("sends the production GET and cancels a stream that remains open", async () => {
+    let cancelled = false;
+    let requestHeaders: Headers | undefined;
+    let requestMethod: string | undefined;
+    let requestPath: string | undefined;
+    const fetcher: CanaryFetcher = async (input, init) => {
+      requestHeaders = new Headers(init.headers);
+      requestMethod = init.method;
+      requestPath = new URL(input instanceof Request ? input.url : input)
+        .pathname;
+      return new Response(
+        new ReadableStream<Uint8Array>({
+          cancel: () => {
+            cancelled = true;
+          },
+        }),
+        {
+          headers: { "content-type": "text/event-stream" },
+          status: 200,
+        },
+      );
+    };
+
+    const result = await runAuthenticatedStreamProbe(
+      { baseUrl: "https://api.example", token: "canary-token" },
+      fetcher,
+    );
+
+    expect(result.status).toBe("passed");
+    expect(requestPath).toBe("/mcp");
+    expect(requestMethod).toBe("GET");
+    expect(requestHeaders?.get("accept")).toBe("text/event-stream");
+    expect(requestHeaders?.get("authorization")).toBe("Bearer canary-token");
+    expect(cancelled).toBe(true);
+  });
+
+  test("fails a 200 event-stream body that has already completed", async () => {
+    const fetcher: CanaryFetcher = async () =>
+      new Response(
+        new ReadableStream<Uint8Array>({
+          start: (controller) => {
+            controller.close();
+          },
+        }),
+        {
+          headers: { "content-type": "text/event-stream" },
+          status: 200,
+        },
+      );
+
+    const result = await runAuthenticatedStreamProbe(
+      { baseUrl: "https://api.example", token: "canary-token" },
+      fetcher,
+    );
+
+    expect(result.status).toBe("failed");
+    expect(result.detail).toContain("completed");
+  });
+
+  test("fails when closing the probe stream fails", async () => {
+    const fetcher: CanaryFetcher = async () =>
+      new Response(
+        new ReadableStream<Uint8Array>({
+          cancel: async () => {
+            throw new Error("synthetic cancellation failure");
+          },
+        }),
+        {
+          headers: { "content-type": "text/event-stream" },
+          status: 200,
+        },
+      );
+
+    const result = await runAuthenticatedStreamProbe(
+      { baseUrl: "https://api.example", token: "canary-token" },
+      fetcher,
+    );
+
+    expect(result.status).toBe("failed");
+    expect(result.detail).toContain("cancellation failed");
   });
 });
 

--- a/apps/api/src/scripts/mcp-canary.ts
+++ b/apps/api/src/scripts/mcp-canary.ts
@@ -2,12 +2,12 @@
  * Canary for the MCP transport of a *deployed* API.
  *
  * The transport can fail while every response still carries a 2xx: an
- * endpoint that answers `GET` with a stream body the stateless per-request
- * teardown truncates, an `initialize` that returns a JSON-RPC error inside a
- * 200, or a tool list that comes back empty. None of those raise a 5xx, log an
- * error, or trip an alarm, so the only observer is the client whose session
- * silently stops working. This canary drives the handshake a real client
- * drives and treats a well-formed session as the pass condition.
+ * missing or truncated authenticated `GET` event channel, an `initialize` that
+ * returns a JSON-RPC error inside a 200, or a tool list that comes back empty.
+ * None of those necessarily raise a 5xx, log an error, or trip an alarm, so the
+ * only observer is the client whose session silently stops working. This canary
+ * drives the handshake a real client drives and treats a well-formed session as
+ * the pass condition.
  *
  * Read-only by construction: it never calls a tool, so it cannot touch tenant
  * data. Response bodies are parsed but never printed, only the shape assertions
@@ -27,28 +27,12 @@ import {
 import * as v from "valibot";
 
 import { fetchWithTimeout } from "@/api/lib/fetch";
-import {
-  MCP_DISCOVERY_PATH,
-  MCP_HTTP_PATH,
-  MCP_STATELESS_ALLOW_HEADER,
-} from "@/api/mcp/constants";
+import { MCP_DISCOVERY_PATH, MCP_HTTP_PATH } from "@/api/mcp/constants";
 
 const PROBE_TIMEOUT_MS = 20_000;
 const SSE_CONTENT_TYPE = "text/event-stream";
 const CANARY_CLIENT_NAME = "stella-mcp-canary";
 const MODERN_PROTOCOL_VERSION = "2026-07-28";
-
-/** Order and spacing are the server's business; the method set is not. */
-const parseAllowedMethods = (allow: string | null): string[] =>
-  (allow ?? "")
-    .split(",")
-    .map((method) => method.trim().toUpperCase())
-    .filter((method) => method.length > 0)
-    .toSorted();
-
-const EXPECTED_ALLOWED_METHODS = parseAllowedMethods(
-  MCP_STATELESS_ALLOW_HEADER,
-);
 
 const PROBE_STATUS = {
   failed: "failed",
@@ -164,33 +148,23 @@ export const evaluateUnauthenticated = ({
 };
 
 /**
- * The transport is stateless, so it cannot hold a server-initiated stream open
- * and must say so with 405. Answering `GET` with `text/event-stream` hands the
- * client a body that per-request teardown has already ended; the client sees
- * the stream die on open and reconnects forever instead of calling tools.
+ * ChatGPT opens this optional channel before it calls tools and treats a 405 as
+ * a dead connector. A successful probe therefore needs both the 200 and the SSE
+ * media type; its caller cancels the body immediately after checking the
+ * headers so the canary does not wait for the long-lived stream.
  */
-export const evaluateStreamRefusal = ({
-  allow,
+export const evaluateStreamAvailability = ({
   contentType,
   status,
-}: Pick<ProbeResponse, "allow" | "contentType" | "status">): ProbeResult => {
+}: Pick<ProbeResponse, "contentType" | "status">): ProbeResult => {
   const name = PROBE_NAMES.stream;
-  if (mediaType(contentType) === SSE_CONTENT_TYPE) {
-    return failed(name, `${String(status)} ${SSE_CONTENT_TYPE} (expected 405)`);
+  if (status !== 200) {
+    return failed(name, `${String(status)} (expected 200)`);
   }
-  if (status !== 405) {
-    return failed(name, `${String(status)} (expected 405)`);
+  if (mediaType(contentType) !== SSE_CONTENT_TYPE) {
+    return failed(name, `200 ${contentType ?? "without a content type"}`);
   }
-  // The refusal is only actionable if it also tells the client what the
-  // endpoint does serve; a 405 with a wrong or missing Allow is a dead end.
-  const allowed = parseAllowedMethods(allow);
-  if (allowed.join(",") !== EXPECTED_ALLOWED_METHODS.join(",")) {
-    return failed(
-      name,
-      `405 allowing ${allowed.join(", ") || "nothing"} (expected ${MCP_STATELESS_ALLOW_HEADER})`,
-    );
-  }
-  return passed(name, "405, so clients stay on request/response");
+  return passed(name, "200 with an authenticated notification stream");
 };
 
 const jsonRpcResult = (body: unknown): Record<string, unknown> | undefined =>
@@ -356,19 +330,22 @@ type AuthenticatedProbe = {
 export const AUTHENTICATED_PROBES = [
   {
     name: PROBE_NAMES.stream,
-    run: async ({ baseUrl, token }) =>
-      evaluateStreamRefusal(
-        await readProbeResponse(
-          await fetchWithTimeout(new URL(MCP_HTTP_PATH, baseUrl), {
-            headers: {
-              accept: SSE_CONTENT_TYPE,
-              authorization: `Bearer ${token}`,
-            },
-            method: "GET",
-            timeoutMs: PROBE_TIMEOUT_MS,
-          }),
-        ),
-      ),
+    run: async ({ baseUrl, token }) => {
+      const response = await fetchWithTimeout(new URL(MCP_HTTP_PATH, baseUrl), {
+        headers: {
+          accept: SSE_CONTENT_TYPE,
+          authorization: `Bearer ${token}`,
+        },
+        method: "GET",
+        timeoutMs: PROBE_TIMEOUT_MS,
+      });
+      const result = evaluateStreamAvailability({
+        contentType: response.headers.get("content-type"),
+        status: response.status,
+      });
+      await response.body?.cancel().catch(() => null);
+      return result;
+    },
   },
   {
     name: PROBE_NAMES.initialize,

--- a/apps/api/src/scripts/mcp-canary.ts
+++ b/apps/api/src/scripts/mcp-canary.ts
@@ -30,6 +30,7 @@ import { fetchWithTimeout } from "@/api/lib/fetch";
 import { MCP_DISCOVERY_PATH, MCP_HTTP_PATH } from "@/api/mcp/constants";
 
 const PROBE_TIMEOUT_MS = 20_000;
+const STREAM_OPEN_OBSERVATION_MS = 100;
 const SSE_CONTENT_TYPE = "text/event-stream";
 const CANARY_CLIENT_NAME = "stella-mcp-canary";
 const MODERN_PROTOCOL_VERSION = "2026-07-28";
@@ -149,9 +150,9 @@ export const evaluateUnauthenticated = ({
 
 /**
  * ChatGPT opens this optional channel before it calls tools and treats a 405 as
- * a dead connector. A successful probe therefore needs both the 200 and the SSE
- * media type; its caller cancels the body immediately after checking the
- * headers so the canary does not wait for the long-lived stream.
+ * a dead connector. Headers are only the first half of the contract: the caller
+ * also observes the body briefly and fails if it completes or errors instead of
+ * remaining open as a notification channel.
  */
 export const evaluateStreamAvailability = ({
   contentType,
@@ -316,7 +317,93 @@ const runPublicProbes = async (baseUrl: string): Promise<ProbeResult[]> => {
   ];
 };
 
-type CanaryTarget = { baseUrl: string; token: string };
+export type CanaryTarget = { baseUrl: string; token: string };
+export type CanaryFetcher = typeof fetchWithTimeout;
+
+type StreamObservation = "cancel_failed" | "closed" | "open" | "read_failed";
+
+/**
+ * Distinguish a genuinely open event channel from a 200 response whose body was
+ * already truncated. A pending read at the deadline is the normal idle-stream
+ * case. If frames arrive during the window, keep reading so a frame followed by
+ * immediate EOF still fails rather than masquerading as a live channel.
+ */
+const inspectNotificationStream = async (
+  body: ReadableStream<Uint8Array>,
+): Promise<StreamObservation> => {
+  const reader = body.getReader();
+  const deadline = Date.now() + STREAM_OPEN_OBSERVATION_MS;
+  let observation: StreamObservation = "open";
+
+  while (Date.now() < deadline) {
+    const remainingMs = Math.max(1, deadline - Date.now());
+    // Reads must be sequential: a frame can be followed immediately by EOF,
+    // which is the truncation this bounded observation is meant to catch.
+    // eslint-disable-next-line no-await-in-loop
+    const readObservation = await Promise.race([
+      reader.read().then(
+        ({ done }) => (done ? ("closed" as const) : ("frame" as const)),
+        () => "read_failed" as const,
+      ),
+      Bun.sleep(remainingMs).then(() => "open" as const),
+    ]);
+
+    if (readObservation === "frame") {
+      continue;
+    }
+    observation = readObservation;
+    break;
+  }
+
+  try {
+    await reader.cancel();
+  } catch {
+    return "cancel_failed";
+  }
+  return observation;
+};
+
+export const runAuthenticatedStreamProbe = async (
+  { baseUrl, token }: CanaryTarget,
+  fetcher: CanaryFetcher = fetchWithTimeout,
+): Promise<ProbeResult> => {
+  const response = await fetcher(new URL(MCP_HTTP_PATH, baseUrl), {
+    headers: {
+      accept: SSE_CONTENT_TYPE,
+      authorization: `Bearer ${token}`,
+    },
+    method: "GET",
+    timeoutMs: PROBE_TIMEOUT_MS,
+  });
+  const headerResult = evaluateStreamAvailability({
+    contentType: response.headers.get("content-type"),
+    status: response.status,
+  });
+
+  if (headerResult.status !== PROBE_STATUS.passed) {
+    try {
+      await response.body?.cancel();
+    } catch {
+      return failed(PROBE_NAMES.stream, "response-body cancellation failed");
+    }
+    return headerResult;
+  }
+  if (response.body === null) {
+    return failed(PROBE_NAMES.stream, "200 event stream with no response body");
+  }
+
+  const observation = await inspectNotificationStream(response.body);
+  if (observation === "closed") {
+    return failed(PROBE_NAMES.stream, "200 event stream completed immediately");
+  }
+  if (observation === "read_failed") {
+    return failed(PROBE_NAMES.stream, "200 event stream failed while reading");
+  }
+  if (observation === "cancel_failed") {
+    return failed(PROBE_NAMES.stream, "response-body cancellation failed");
+  }
+  return headerResult;
+};
 
 type AuthenticatedProbe = {
   name: string;
@@ -330,22 +417,7 @@ type AuthenticatedProbe = {
 export const AUTHENTICATED_PROBES = [
   {
     name: PROBE_NAMES.stream,
-    run: async ({ baseUrl, token }) => {
-      const response = await fetchWithTimeout(new URL(MCP_HTTP_PATH, baseUrl), {
-        headers: {
-          accept: SSE_CONTENT_TYPE,
-          authorization: `Bearer ${token}`,
-        },
-        method: "GET",
-        timeoutMs: PROBE_TIMEOUT_MS,
-      });
-      const result = evaluateStreamAvailability({
-        contentType: response.headers.get("content-type"),
-        status: response.status,
-      });
-      await response.body?.cancel().catch(() => null);
-      return result;
-    },
+    run: runAuthenticatedStreamProbe,
   },
   {
     name: PROBE_NAMES.initialize,

--- a/apps/api/src/scripts/mcp-canary.ts
+++ b/apps/api/src/scripts/mcp-canary.ts
@@ -333,13 +333,11 @@ const inspectNotificationStream = async (
 ): Promise<StreamObservation> => {
   const reader = body.getReader();
   const deadline = Date.now() + STREAM_OPEN_OBSERVATION_MS;
-  let observation: StreamObservation = "open";
-
-  while (Date.now() < deadline) {
-    const remainingMs = Math.max(1, deadline - Date.now());
-    // Reads must be sequential: a frame can be followed immediately by EOF,
-    // which is the truncation this bounded observation is meant to catch.
-    // eslint-disable-next-line no-await-in-loop
+  const observeUntilDeadline = async (): Promise<StreamObservation> => {
+    const remainingMs = deadline - Date.now();
+    if (remainingMs <= 0) {
+      return "open";
+    }
     const readObservation = await Promise.race([
       reader.read().then(
         ({ done }) => (done ? ("closed" as const) : ("frame" as const)),
@@ -348,13 +346,14 @@ const inspectNotificationStream = async (
       Bun.sleep(remainingMs).then(() => "open" as const),
     ]);
 
-    if (readObservation === "frame") {
-      continue;
-    }
-    observation = readObservation;
-    break;
-  }
+    // Reads stay sequential: a frame can be followed immediately by EOF,
+    // which is the truncation this bounded observation is meant to catch.
+    return readObservation === "frame"
+      ? observeUntilDeadline()
+      : readObservation;
+  };
 
+  const observation = await observeUntilDeadline();
   try {
     await reader.cancel();
   } catch {


### PR DESCRIPTION
## Summary

- serve authenticated `GET /mcp` as a request-scoped SSE notification channel for ChatGPT compatibility
- keep stateless POST exchanges isolated and immediately torn down; continue rejecting DELETE
- update the deployed MCP canary to require and cancel the authenticated event stream
- add regression coverage proving the stream stays open until client cancellation

## Verification

- `bun --cwd apps/api typecheck`
- `bun --cwd apps/api lint`
- `bun --env-file=apps/api/.env.example test apps/api/src/mcp/server.test.ts apps/api/src/scripts/mcp-canary.test.ts apps/api/src/handlers/mcp/routes.test.ts apps/api/src/mcp/metadata.test.ts`
- pre-push affected code checks, formatting, and i18n checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Authenticated MCP `GET` requests now support persistent server-sent event streams.
  * Stream connections remain open until completion, cancellation, or an error.
  * MCP responses advertise `GET` alongside `OPTIONS` and `POST`.

* **Bug Fixes**
  * `DELETE` requests are clearly rejected with a `405` response.
  * MCP availability checks now correctly recognise valid event streams and reject incorrect response formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->