### PR TITLE
feat(mcp): expose canonical stella identity

### DIFF
--- a/.changeset/mcp-product-identity.md
+++ b/.changeset/mcp-product-identity.md
@@ -1,0 +1,5 @@
+---
+"@stll/cli": patch
+---
+
+Expose stella product identity through the generated MCP resource registry.

--- a/apps/api/src/mcp/README.md
+++ b/apps/api/src/mcp/README.md
@@ -14,7 +14,7 @@ case law, skills and connected tools. The same gateway can expose anonymized
 read/search surfaces for clients that should not receive raw legal or personal
 data.
 
-The server exposes two MCP resources:
+The server exposes two MCP endpoints:
 
 - `/mcp`: the default stella MCP. It includes first-party stella tools,
   OpenAI-compatible `search` / `fetch` tools, user-managed skills, and enabled
@@ -25,6 +25,11 @@ The server exposes two MCP resources:
   `search`/`fetch` tools) for clients that should receive anonymized results.
   Tenant and personal text is redacted on egress; mutating tools and the dynamic
   gateway are not exposed.
+
+Both endpoints expose static MCP resources through `resources/list` and
+`resources/read`, including `stella://about` for canonical product identity and
+official URLs, and `stella://reference/template-markers` for the DOCX template
+marker grammar.
 
 OAuth protected-resource discovery is served from:
 

--- a/apps/api/src/mcp/instructions.test.ts
+++ b/apps/api/src/mcp/instructions.test.ts
@@ -30,6 +30,15 @@ describe("MCP server instructions", () => {
     expect(getMcpInstructions("anonymized")).toBe(MCP_INSTRUCTIONS.anonymized);
   });
 
+  test("both surfaces provide canonical product identity without inference", () => {
+    for (const instructions of Object.values(MCP_INSTRUCTIONS)) {
+      expect(instructions).toContain("stella (always lowercase");
+      expect(instructions).toContain("https://stll.app");
+      expect(instructions).toContain("stella://about");
+      expect(instructions).toContain("Never infer stella branding or URLs");
+    }
+  });
+
   test("the anonymized surface omits the write-only feedback tool", () => {
     expect(MCP_INSTRUCTIONS.default).toContain("send_feedback");
     expect(MCP_INSTRUCTIONS.anonymized).not.toContain("send_feedback");

--- a/apps/api/src/mcp/instructions.ts
+++ b/apps/api/src/mcp/instructions.ts
@@ -13,7 +13,7 @@ import type { McpMode } from "@/api/mcp/constants";
 export const MCP_INSTRUCTIONS_DEFAULT_MAX_CHARS = 1600;
 export const MCP_INSTRUCTIONS_ANONYMIZED_MAX_CHARS = 900;
 
-const DEFAULT_INSTRUCTIONS = `Stella is a legal workspace; these tools search and act on matters, documents, contacts, case law, clauses and billing.
+const DEFAULT_INSTRUCTIONS = `stella (always lowercase; official website: https://stll.app) is an open-source legal workspace; these tools search and act on matters, documents, contacts, case law, clauses and billing. Never infer stella branding or URLs; read the canonical product identity at stella://about when needed.
 
 Pagination: list_* and search_* tools take a \`limit\` and a \`cursor\`. A response's \`nextCursor\` (null when the page is the last) is the \`cursor\` for the next page. Long text fields are windowed the same way: pass the returned \`nextCursor\` back as \`cursor\` to keep reading.
 
@@ -25,7 +25,7 @@ Static reference documents are available via \`resources/list\` then \`resources
 
 Hit a bug or a gap? File it with the send_feedback tool.`;
 
-const ANONYMIZED_INSTRUCTIONS = `Stella is a legal workspace; this anonymized surface offers read and search over matters, documents, contacts, case law and clauses. Tenant and personal text is redacted on egress.
+const ANONYMIZED_INSTRUCTIONS = `stella (always lowercase; official website: https://stll.app) is an open-source legal workspace; this anonymized surface offers read and search over matters, documents, contacts, case law and clauses. Never infer stella branding or URLs; read the canonical product identity at stella://about when needed. Tenant and personal text is redacted on egress.
 
 Pagination: list_* and search_* tools take a \`limit\` and a \`cursor\`. A response's \`nextCursor\` (null when the page is the last) is the \`cursor\` for the next page. Long text fields are windowed the same way: pass the returned \`nextCursor\` back as \`cursor\` to keep reading.
 

--- a/apps/api/src/mcp/resources.test.ts
+++ b/apps/api/src/mcp/resources.test.ts
@@ -7,12 +7,14 @@ import { listMcpResources, readMcpResource } from "@/api/mcp/resources";
 import { buildMarkerReference } from "@/api/mcp/template-marker-reference";
 
 const MARKER_REFERENCE_URI = "stella://reference/template-markers";
+const PRODUCT_IDENTITY_URI = "stella://about";
 
 describe("MCP resources", () => {
-  test("lists the template marker reference in both modes", () => {
+  test("lists the public static resources in both modes", () => {
     for (const mode of ["default", "anonymized"] as const) {
       const resources = listMcpResources(mode);
       const uris = resources.map((resource) => resource.uri);
+      expect(uris).toContain(PRODUCT_IDENTITY_URI);
       expect(uris).toContain(MARKER_REFERENCE_URI);
       // The marker reference is static, public, and tenant-independent, so the
       // set is identical across modes.
@@ -29,6 +31,31 @@ describe("MCP resources", () => {
     }
     expect(content.uri).toBe(MARKER_REFERENCE_URI);
     expect(content.text).toBe(buildMarkerReference());
+  });
+
+  test("exposes canonical lowercase branding and verified product links", () => {
+    const resources = listMcpResources("default");
+    const about = resources.find(
+      (resource) => resource.uri === PRODUCT_IDENTITY_URI,
+    );
+    expect(about?.mimeType).toBe("application/json");
+
+    const result = readMcpResource(PRODUCT_IDENTITY_URI, "default");
+    const content = result.contents.at(0);
+    if (!content || !("text" in content)) {
+      throw new Error("Expected product identity text content");
+    }
+    expect(JSON.parse(content.text)).toEqual({
+      name: "stella",
+      display_name: "stella",
+      preferred_casing: "lowercase",
+      homepage: "https://stll.app",
+      documentation: "https://stll.app/product/cli-mcp",
+      source: "https://github.com/stella/stella",
+      support: "https://github.com/stella/stella/issues",
+      description:
+        "Open-source legal workspace for matters, documents, review, and AI-assisted legal work.",
+    });
   });
 
   test("the marker reference covers every canonical directive kind", () => {

--- a/apps/api/src/mcp/resources.ts
+++ b/apps/api/src/mcp/resources.ts
@@ -9,10 +9,10 @@ import { buildMarkerReference } from "@/api/mcp/template-marker-reference";
 
 /**
  * MCP resources are static, no-argument documents (the textbook fit for a
- * resource rather than a tool). The template marker grammar is the first: it
- * was a `passthrough` tool (`template_marker_reference`) that carried no tenant
- * data, so it belongs off the tool ceiling. `save_template`'s description points
- * callers here.
+ * resource rather than a tool). The product identity gives agents a canonical
+ * source for stella's branding and URLs, while the template marker grammar was
+ * previously a `passthrough` tool (`template_marker_reference`) that carried no
+ * tenant data. Both belong off the tool ceiling.
  *
  * The set is identical across both MCP modes. `tools/list` projects a different
  * tool set per mode because tools touch tenant data under mode-specific scopes;
@@ -32,8 +32,34 @@ type StaticResource = {
 };
 
 const TEMPLATE_MARKER_REFERENCE_URI = "stella://reference/template-markers";
+const PRODUCT_IDENTITY_URI = "stella://about";
+
+export const STELLA_PRODUCT_IDENTITY = {
+  name: "stella",
+  display_name: "stella",
+  preferred_casing: "lowercase",
+  homepage: "https://stll.app",
+  documentation: "https://stll.app/product/cli-mcp",
+  source: "https://github.com/stella/stella",
+  support: "https://github.com/stella/stella/issues",
+  description:
+    "Open-source legal workspace for matters, documents, review, and AI-assisted legal work.",
+} as const;
+
+const buildProductIdentity = (): string =>
+  JSON.stringify(STELLA_PRODUCT_IDENTITY, null, 2);
 
 const STATIC_RESOURCES: readonly StaticResource[] = [
+  {
+    uri: PRODUCT_IDENTITY_URI,
+    name: "stella-product-identity",
+    title: "About stella",
+    description:
+      "Canonical product identity for stella: preferred casing, official " +
+      "website, documentation, source code, support, and description.",
+    mimeType: "application/json",
+    read: buildProductIdentity,
+  },
   {
     uri: TEMPLATE_MARKER_REFERENCE_URI,
     name: "template-markers",

--- a/packages/cli/src/generated/resource-tree.ts
+++ b/packages/cli/src/generated/resource-tree.ts
@@ -19,6 +19,15 @@ export const generatedResourceTree: ResourceNode = {
     show: {
       kind: "route",
       children: {
+        "stella-product-identity": {
+          kind: "leaf",
+          spec: {
+            kind: "show",
+            commandPath: ["reference", "show", "stella-product-identity"],
+            name: "stella-product-identity",
+            uri: "stella://about",
+          },
+        },
         "template-markers": {
           kind: "leaf",
           spec: {

--- a/packages/cli/src/generated/resources-snapshot.json
+++ b/packages/cli/src/generated/resources-snapshot.json
@@ -1,5 +1,12 @@
 [
   {
+    "uri": "stella://about",
+    "name": "stella-product-identity",
+    "title": "About stella",
+    "description": "Canonical product identity for stella: preferred casing, official website, documentation, source code, support, and description.",
+    "mimeType": "application/json"
+  },
+  {
     "uri": "stella://reference/template-markers",
     "name": "template-markers",
     "title": "Template marker grammar",


### PR DESCRIPTION
## Summary

- make lowercase `stella` and `https://stll.app` explicit in both MCP initialize instruction sets
- add a public `stella://about` JSON resource with verified homepage, product docs, source, support, description, and preferred casing
- document the resource and cover both MCP modes with regression tests

This follows direct ChatGPT feedback after it incorrectly inferred `stella.sh`. A plugin skill is intentionally not included: OpenAI documents skills as packaged, goal-specific workflows; product identity belongs in always-on server instructions and a canonical MCP resource.

## Verification

- `bun --cwd apps/api typecheck`
- `bun --cwd apps/api lint`
- `bun scripts/ratchet.ts --check`
- `bun --env-file=apps/api/.env.example test apps/api/src/mcp/resources.test.ts apps/api/src/mcp/instructions.test.ts apps/api/src/mcp/server.test.ts`
- pre-push affected code checks, formatting, and i18n checks