### PR TITLE
fix: recognize KIO docket-number citations as benign in citation probe

### DIFF
--- a/apps/api/src/scripts/citation-probe.ts
+++ b/apps/api/src/scripts/citation-probe.ts
@@ -179,6 +179,9 @@ const BENIGN: readonly RegExp[] = [
   // Polish procurement-tribunal rulings (KIO/UZP): quasi-judicial, not a
   // court source the corpus ingests, so never a resolvable citation.
   /\bKIO ?\/? ?UZP\b/u,
+  // KIO's own docket format ("KIO/2462/10", "KIO 2475 /10"): same
+  // out-of-corpus tribunal, cited by case number rather than by name.
+  /\bKIO\s{0,1}\/?\s{0,1}\d{1,5}\s{0,1}\/\s{0,1}\d{2,4}\b/u,
   // A case-number prefix ("sp. zn.", "sen. zn.", "sygn.[ akt]", "č. j.")
   // with no digit anywhere in the captured tail is never a real citation:
   // every actual docket carries a number. Covers Polish anonymization


### PR DESCRIPTION
## Proposed change

The citation-quality probe script's `BENIGN` list already excludes KIO (Krajowa Izba Odwoławcza, the Polish public-procurement tribunal) references by name (`KIO/UZP`), since it's a quasi-judicial body outside the case-law corpus. It did not recognize KIO's own docket-number format (`KIO/2462/10`, `KIO 2475 /10`), so those surfaced as residual candidates instead of being filtered as benign.

Adds a bounded-quantifier regex for the docket shape, verified against the observed variants (with/without slash, with/without spaces).

## Checklist

- [x] BUILD ASSURANCE | Code builds correctly and without any errors or warnings.
- [x] TESTING | `bunx oxfmt` on the touched file; `bun --smol test` for the ingestion citation-extractor suite (unaffected, included for scope confirmation).
- [ ] DARK MODE SUPPORT | N/A — backend-only script change, no UI.
- [ ] SCREENSHOT INCLUDED | N/A — no UI change.


---
_Generated by [Claude Code](https://claude.ai/code/session_01LzdHS7ijMTwWDBC7Sc4J96)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved filtering for Polish procurement tribunal references, including named references and KIO case-number formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->