### PR TITLE
refactor: derive entity kinds from one declaration

### DIFF
--- a/apps/api/src/db/schema-validators.ts
+++ b/apps/api/src/db/schema-validators.ts
@@ -1,6 +1,8 @@
 import { t } from "elysia";
 import type { Static } from "elysia";
 
+import { ENTITY_KINDS } from "@stll/api-contract";
+
 import type { JsonObject } from "@/api/lib/json-value";
 import {
   positionRuleSchema,
@@ -47,14 +49,8 @@ const multiSelectType = t.Literal("multi-select");
 const dateType = t.Literal("date");
 const intType = t.Literal("int");
 
-export const entityKindSchema = t.UnionEnum([
-  "document",
-  "folder",
-  "task",
-  "message",
-  "link",
-]);
-export type EntityKind = Static<typeof entityKindSchema>;
+export const entityKindSchema = t.UnionEnum(ENTITY_KINDS);
+export type { EntityKind } from "@stll/api-contract";
 
 export const propertyContentTypeSchema = t.Union([
   fileType,

--- a/apps/api/src/db/schema/common.ts
+++ b/apps/api/src/db/schema/common.ts
@@ -316,13 +316,10 @@ export type PropertyStatus = (typeof PROPERTY_STATUSES)[number];
 export const PROPERTY_ROLES = ["document-type-classifier"] as const;
 export type PropertyRole = (typeof PROPERTY_ROLES)[number];
 
-export const ENTITY_KINDS = [
-  "document",
-  "folder",
-  "task",
-  "message",
-  "link",
-] as const satisfies readonly EntityKind[];
+/** Re-exported so the schema layer keeps one import surface; the array is
+ *  declared in `@stll/api-contract` and every other consumer derives from
+ *  it. */
+export { ENTITY_KINDS } from "@stll/api-contract";
 
 export const TASK_ASSIGNEE_ROLES = ["assignee", "reviewer"] as const;
 

--- a/apps/api/src/lib/entity-filters.differential.test.ts
+++ b/apps/api/src/lib/entity-filters.differential.test.ts
@@ -3,6 +3,7 @@ import { and, eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/pglite";
 import fc from "fast-check";
 
+import { ENTITY_KINDS } from "@stll/api-contract";
 import type { ConditionNode } from "@stll/conditions";
 import { propertyConfig, propertyTestTimeout } from "@stll/property-testing";
 
@@ -78,13 +79,6 @@ const propertyContent = (key: PropKey) => {
     fallback: null,
   };
 };
-
-const ENTITY_KINDS: readonly EntityKind[] = [
-  "document",
-  "task",
-  "message",
-  "link",
-];
 
 beforeAll(
   async () => {

--- a/apps/api/src/lib/entity-filters.test.ts
+++ b/apps/api/src/lib/entity-filters.test.ts
@@ -208,6 +208,21 @@ describe("applyFilters (in-memory)", () => {
     expect(filtered).toHaveLength(2);
   });
 
+  // A grouped filter is the same filter: the expansion must not depend on
+  // where the kind predicate sits in the tree, or SQL and memory disagree
+  // about folders for identical input.
+  test("kind filter with 'document' includes folders inside a group", () => {
+    const items = [
+      makeEntity("1", "document"),
+      makeEntity("2", "folder"),
+      makeEntity("3", "task"),
+    ];
+    const filtered = applyFilters(items, [
+      { type: "group", combinator: "and", children: [kindIn(["document"])] },
+    ]);
+    expect(filtered.map((entity) => entity.entityId)).toEqual(["1", "2"]);
+  });
+
   test("property eq filter matches exact value", () => {
     const items = [
       makeEntity("1", "task", [["p1", "alpha"]]),

--- a/apps/api/src/lib/entity-filters.ts
+++ b/apps/api/src/lib/entity-filters.ts
@@ -229,8 +229,16 @@ const isKindInPredicate = (node: ConditionNode): node is PredicateNode =>
 /**
  * Mirrors the SQL document→folder expansion in-memory: a kind filter
  * that includes "document" also matches folders.
+ *
+ * The SQL compiler expands every kind predicate it compiles, wherever it
+ * sits in the tree, so this recurses into groups the same way
+ * `gateMissingCompareFields` does. Matching only at the root left the two
+ * paths disagreeing about folders for one and the same grouped filter.
  */
 const expandKindNode = (node: ConditionNode): ConditionNode => {
+  if (node.type === "group") {
+    return { ...node, children: node.children.map(expandKindNode) };
+  }
   if (!isKindInPredicate(node)) {
     return node;
   }

--- a/apps/api/src/lib/entity-filters.ts
+++ b/apps/api/src/lib/entity-filters.ts
@@ -1,6 +1,7 @@
 import { and, asc, eq, inArray, isNull, ne, not, or, sql } from "drizzle-orm";
 import type { SQL } from "drizzle-orm";
 
+import { isEntityKind } from "@stll/api-contract";
 import {
   type CompareNode,
   type ConditionNode,
@@ -18,7 +19,6 @@ import { entities, entityVersions, fields, properties } from "@/api/db/schema";
 import type { EntityKind, FieldContent } from "@/api/db/schema-validators";
 import { compareByLocale } from "@/api/lib/collation";
 import { typedPgArray } from "@/api/lib/search/sql";
-import { includes } from "@/api/lib/type-guards";
 
 // -- Types --
 
@@ -388,25 +388,12 @@ const KIND_FOLDER = "folder" as const;
  * includes documents also matches folders.
  */
 const expandKindValues = (values: readonly string[]): EntityKind[] => {
-  const kinds = values.filter((value): value is EntityKind =>
-    isEntityKind(value),
-  );
+  const kinds = values.filter(isEntityKind);
   if (kinds.includes(KIND_DOCUMENT)) {
     return [...new Set([...kinds, KIND_FOLDER])];
   }
   return kinds;
 };
-
-const ENTITY_KINDS: readonly EntityKind[] = [
-  "document",
-  "folder",
-  "task",
-  "message",
-  "link",
-];
-
-const isEntityKind = (value: string): value is EntityKind =>
-  includes(ENTITY_KINDS, value);
 
 const asValueArray = (value: string | string[] | undefined): string[] => {
   if (Array.isArray(value)) {

--- a/apps/api/src/lib/search/types.ts
+++ b/apps/api/src/lib/search/types.ts
@@ -1,18 +1,20 @@
 import { panic } from "better-result";
 
+import { isEntityKind } from "@stll/api-contract";
+
 import { ENTITY_KINDS } from "@/api/db/schema";
 import type { ContactType } from "@/api/db/schema";
 import type { EntityKind, FieldContent } from "@/api/db/schema-validators";
 import type { SafeId } from "@/api/lib/branded-types";
 
-/** Narrow an unknown value to a valid EntityKind. */
+/** Narrow an unknown value to a valid EntityKind. Internal callers read
+ *  kinds straight off our own rows, so a miss is a broken invariant, not a
+ *  user input error. */
 export const parseEntityKind = (value: unknown): EntityKind => {
-  const s = String(value);
-  const match = ENTITY_KINDS.find((v) => v === s);
-  if (!match) {
-    panic(`Invalid entity kind: ${s}`);
+  if (!isEntityKind(value)) {
+    panic(`Invalid entity kind: ${String(value)}`);
   }
-  return match;
+  return value;
 };
 
 /**

--- a/packages/api-contract/src/entity-kinds.test.ts
+++ b/packages/api-contract/src/entity-kinds.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "bun:test";
+
+import { ENTITY_KINDS, isEntityKind } from "./entity-kinds";
+
+describe("isEntityKind", () => {
+  test("accepts every declared kind", () => {
+    expect(ENTITY_KINDS.filter(isEntityKind)).toEqual([...ENTITY_KINDS]);
+  });
+
+  // The guard's whole job is to keep "not a kind" distinguishable from a
+  // kind. A near miss that slipped through (or a default substituted for
+  // one) reaches the UI as a confident wrong answer rather than an
+  // unresolved one.
+  // Each case is wrapped in a tuple: `test.each` spreads a bare array case
+  // into the callback's arguments, which would quietly test "folder".
+  test.each([
+    ["Folder"],
+    ["folders"],
+    ["workspace"],
+    [""],
+    [" document"],
+    [null],
+    [undefined],
+    [0],
+    [["folder"]],
+    [{ kind: "folder" }],
+  ])("rejects %p", (value) => {
+    expect(isEntityKind(value)).toBe(false);
+  });
+});

--- a/packages/api-contract/src/entity-kinds.ts
+++ b/packages/api-contract/src/entity-kinds.ts
@@ -1,0 +1,29 @@
+/**
+ * The entity kinds, declared once.
+ *
+ * Everything that needs the full set derives from this array: the TypeBox
+ * validator and the Drizzle column enum in the API, the search facet bounds,
+ * the filter guard, and the property-test generators. The hand-written copies
+ * this replaces were bound with `satisfies readonly EntityKind[]`, a check
+ * that only rejects an extra member; a copy missing one still typechecks, so
+ * a new kind could land while a filter or generator silently kept ignoring
+ * it.
+ */
+export const ENTITY_KINDS = [
+  "document",
+  "folder",
+  "task",
+  "message",
+  "link",
+] as const;
+
+export type EntityKind = (typeof ENTITY_KINDS)[number];
+
+/**
+ * Narrow an untrusted value (a persisted editor attribute, a query string, a
+ * third-party payload) to a kind. Callers must keep a `false` result
+ * distinguishable from a real kind: substituting a default turns an
+ * unresolved value into a confident wrong one.
+ */
+export const isEntityKind = (value: unknown): value is EntityKind =>
+  typeof value === "string" && ENTITY_KINDS.some((kind) => kind === value);

--- a/packages/api-contract/src/index.ts
+++ b/packages/api-contract/src/index.ts
@@ -3,6 +3,8 @@ export const STELLA_REST_API_CONTRACT_VERSION = 1 as const;
 
 export { CHAT_TOOL_SCOPE, CHAT_TURN_INTENT } from "./chat";
 export type { ChatSendRequest, SafeId } from "./chat";
+export { ENTITY_KINDS, isEntityKind } from "./entity-kinds";
+export type { EntityKind } from "./entity-kinds";
 export { API_VALIDATION_ERROR_CODE, normalizeApiError } from "./error";
 export type {
   ApiErrorInput,


### PR DESCRIPTION
Declares the entity-kind set once and derives every consumer from it. First of three stacked PRs.

## Change

`ENTITY_KINDS` moves to `@stll/api-contract`, a dependency of both the API and the web app. Deriving from it:

- `entityKindSchema` becomes `t.UnionEnum(ENTITY_KINDS)`
- `EntityKind` is the array's element type; `schema-validators` re-exports it, so the type has one origin
- the Drizzle column enums, search facet bounds and saved-search picklists (behaviour unchanged)
- the entity filter guard and the differential test's row generator
- `isEntityKind` becomes the shared boundary guard, replacing a private copy in `entity-filters.ts` and the `String(value)`-then-find in `lib/search/types.ts`

The set was previously written out separately in the schema, the filter guard and the test generator. Those copies were bound with `as const satisfies readonly EntityKind[]` or annotated `readonly EntityKind[]`. Both checks reject an extra member but accept a missing one (`["document"] satisfies readonly EntityKind[]` typechecks), so they did not pin the copies to the set.

## Included fix

Deriving the differential test's generator restored `folder` to the generated rows. That exercised the document -> folder kind expansion for the first time and surfaced a divergence between the two filter implementations: `expandKindNode` applied the expansion only at the root of a condition tree, while the SQL compiler applies it to every kind predicate at any depth. A grouped `kind in ["document"]` filter therefore matched folders in SQL and not in memory.

Fixed in its own commit (`fix(filters): expand document kind to folders inside groups`) with a unit test that fails without it; the property test now covers the rule generally.

## Verification

- `bun --filter @stll/api typecheck`, `bun --filter @stll/web typecheck`: clean
- `bun --filter @stll/api lint`, `bun --filter @stll/api-contract lint`: clean
- `bun test apps/api/src/lib/entity-filters.test.ts apps/api/src/lib/entity-filters.differential.test.ts`: 35 pass
- the new unit test verified red on the parent commit

CC on behalf of jan-kubica