### PR TITLE
fix(chat): draw mention icons from the entity kind, not the label text

### DIFF
--- a/apps/web/src/components/chat-mention-extension.test.ts
+++ b/apps/web/src/components/chat-mention-extension.test.ts
@@ -1,7 +1,18 @@
 import { describe, expect, test } from "bun:test";
 
-import type { ChatMentionOption } from "@/components/chat-mention-extension";
+import type {
+  ChatMentionKind,
+  ChatMentionOption,
+} from "@/components/chat-mention-extension";
 import { selectChatSuggestionItems } from "@/components/chat-mention-extension";
+
+// A real producer never emits the category as the kind: an entity row
+// carries an entity kind, and the other categories carry their own marker.
+const KIND_BY_CATEGORY = {
+  entity: "document",
+  workspace: "workspace",
+  decision: "decision",
+} as const satisfies Record<ChatMentionOption["category"], ChatMentionKind>;
 
 const option = ({
   category = "entity",
@@ -15,7 +26,7 @@ const option = ({
   id,
   label,
   category,
-  kind: category,
+  kind: KIND_BY_CATEGORY[category],
   mimeType: null,
 });
 

--- a/apps/web/src/components/chat-mention-extension.ts
+++ b/apps/web/src/components/chat-mention-extension.ts
@@ -7,6 +7,8 @@ import {
 } from "@tiptap/react";
 import type { SuggestionOptions, SuggestionProps } from "@tiptap/suggestion";
 
+import type { EntityKind } from "@stll/api-contract";
+
 import { ChatMentionList } from "@/components/chat-mention-list";
 import { ChatMentionNode } from "@/components/chat-mention-node";
 import type { MentionCategory } from "@/components/chat/chat-mention-href";
@@ -15,12 +17,17 @@ export type { MentionCategory } from "@/components/chat/chat-mention-href";
 
 export type ChatReferenceCategory = MentionCategory | "decision";
 
+/** What a mention row points at: an entity kind when the category is
+ *  "entity", otherwise the category's own marker. Typed as the closed set
+ *  rather than `string` so an icon or label lookup cannot silently accept a
+ *  value nothing produces. */
+export type ChatMentionKind = EntityKind | "workspace" | "decision";
+
 export type ChatMentionOption = {
   id: string;
   label: string;
   category: ChatReferenceCategory;
-  /** Entity kind (document, folder, etc.) or workspace. */
-  kind: string;
+  kind: ChatMentionKind;
   mimeType: string | null;
   sourceViewId?: string;
   /** Set when the entity comes from a different workspace

--- a/apps/web/src/components/chat-mention-list.tsx
+++ b/apps/web/src/components/chat-mention-list.tsx
@@ -6,24 +6,24 @@ import type { SuggestionOptions, SuggestionProps } from "@tiptap/suggestion";
 import {
   ArrowLeftIcon,
   ChevronRightIcon,
-  FileTextIcon,
-  FolderIcon,
   LandmarkIcon,
   LoaderIcon,
 } from "lucide-react";
 import { useTranslations } from "use-intl";
 
+import { isEntityKind } from "@stll/api-contract";
 import { Button } from "@stll/ui/components/button";
 import { DirectionalIcon } from "@stll/ui/components/directional-icon";
 import { Popover, PopoverPopup } from "@stll/ui/components/popover";
 import { cn } from "@stll/ui/lib/utils";
 
 import type {
+  ChatMentionKind,
   ChatMentionOption,
   ChatReferenceCategory,
 } from "@/components/chat-mention-extension";
-import { DocumentIcon } from "@/components/document-icon";
 import { MatterIcon } from "@/components/matter-icon";
+import { EntityIcon } from "@/components/workspaces/entity-kind-icon";
 import { useExternalSyncEffect } from "@/hooks/use-effect";
 
 export const ChatMentionList = ({
@@ -417,11 +417,9 @@ export const MentionIcon = ({
 }: {
   id: string;
   category: ChatReferenceCategory;
-  kind: string;
+  kind: ChatMentionKind;
   mimeType: string | null;
 }) => {
-  const cls = "size-3.5 shrink-0 text-muted-foreground";
-
   if (category === "workspace") {
     return (
       <MatterIcon className="size-3.5 shrink-0" matter={{ id, color: null }} />
@@ -429,17 +427,19 @@ export const MentionIcon = ({
   }
 
   if (category === "decision") {
-    return <LandmarkIcon className={cls} />;
+    return <LandmarkIcon className="text-muted-foreground size-3.5 shrink-0" />;
   }
 
-  // Entity category: use document/folder icons
-  if (kind === "folder") {
-    return <FolderIcon className={cls} />;
-  }
-  if (mimeType) {
-    return <DocumentIcon className="size-3.5 shrink-0" mimeType={mimeType} />;
-  }
-  return <FileTextIcon className={cls} />;
+  return (
+    <EntityIcon
+      className="text-muted-foreground size-3.5 shrink-0"
+      source={
+        isEntityKind(kind)
+          ? { type: "resolved", kind, mimeType }
+          : { type: "unknown" }
+      }
+    />
+  );
 };
 
 /** Group items by category, preserving a stable order. */

--- a/apps/web/src/components/chat-mention-node.tsx
+++ b/apps/web/src/components/chat-mention-node.tsx
@@ -1,13 +1,15 @@
 import { NodeViewWrapper } from "@tiptap/react";
 import type { NodeViewProps } from "@tiptap/react";
-import { FileTextIcon, FolderIcon, LandmarkIcon } from "lucide-react";
+import { LandmarkIcon } from "lucide-react";
 
+import { isEntityKind } from "@stll/api-contract";
+import type { EntityKind } from "@stll/api-contract";
 import { cn } from "@stll/ui/lib/utils";
 
 import type { ChatReferenceCategory } from "@/components/chat-mention-extension";
 import { isMentionCategory } from "@/components/chat/chat-mention-href";
-import { DocumentIcon } from "@/components/document-icon";
 import { MatterIcon } from "@/components/matter-icon";
+import { EntityIcon } from "@/components/workspaces/entity-kind-icon";
 import { getMatterColor } from "@/lib/matter-colors";
 
 export const ChatMentionNode = (props: NodeViewProps) => {
@@ -56,7 +58,7 @@ type ChatMentionAttrs = {
   id: string;
   label: string;
   category: ChatReferenceCategory;
-  kind: string;
+  kind: EntityKind | null;
   mimeType: string | null;
   sourceWorkspaceId: string | null;
 };
@@ -76,7 +78,7 @@ const readChatMentionAttrs = (value: unknown): ChatMentionAttrs => {
       id: "",
       label: "",
       category: "entity",
-      kind: "document",
+      kind: null,
       mimeType: null,
       sourceWorkspaceId: null,
     };
@@ -93,7 +95,7 @@ const readChatMentionAttrs = (value: unknown): ChatMentionAttrs => {
     id: typeof id === "string" ? id : "",
     label: typeof label === "string" ? label : "",
     category: isChatReferenceCategory(category) ? category : "entity",
-    kind: typeof kind === "string" ? kind : "document",
+    kind: isEntityKind(kind) ? kind : null,
     mimeType: typeof mimeType === "string" ? mimeType : null,
     sourceWorkspaceId:
       typeof sourceWorkspaceId === "string" ? sourceWorkspaceId : null,
@@ -109,8 +111,10 @@ const CategoryIcon = ({
   category: ChatReferenceCategory;
   /** Entity/workspace ID stored in the TipTap node. */
   attrId: string;
-  /** Kind stored in the TipTap node (fallback). */
-  attrKind: string;
+  /** Kind stored in the TipTap node; null when the stored attribute is
+   *  not a kind (a workspace mention, or content written before the
+   *  attribute existed). */
+  attrKind: EntityKind | null;
   /** MIME type stored in the TipTap node (fallback). */
   attrMimeType: string | null;
 }) => {
@@ -122,11 +126,14 @@ const CategoryIcon = ({
     return <LandmarkIcon className={cls} />;
   }
 
-  if (attrKind === "folder") {
-    return <FolderIcon className={cls} />;
-  }
-  if (attrMimeType) {
-    return <DocumentIcon className={cls} mimeType={attrMimeType} />;
-  }
-  return <FileTextIcon className={cls} />;
+  return (
+    <EntityIcon
+      className={cls}
+      source={
+        attrKind === null
+          ? { type: "unknown" }
+          : { type: "resolved", kind: attrKind, mimeType: attrMimeType }
+      }
+    />
+  );
 };

--- a/apps/web/src/components/chat/entity-icon-source.ts
+++ b/apps/web/src/components/chat/entity-icon-source.ts
@@ -1,0 +1,55 @@
+import { skipToken, useQuery } from "@tanstack/react-query";
+
+import type { EntityIconSource } from "@/components/workspaces/entity-kind-icon";
+import { entityOptions } from "@/lib/workspaces/queries/entities";
+
+/**
+ * Resolve a chat mention's entity to an icon source.
+ *
+ * A mention href carries only `workspaceId:entityId`, so the kind has to
+ * come from the entity itself; the label is the entity's name and says
+ * nothing about what it is. Rendering starts before the query settles, and
+ * `pending` keeps that moment honest instead of guessing a glyph.
+ */
+export const useEntityIconSource = ({
+  entityId,
+  workspaceId,
+}: {
+  entityId: string | undefined;
+  workspaceId: string | undefined;
+}): EntityIconSource => {
+  // staleTime: Infinity — one fetch per entity ref; later renders and the
+  // click handler read the same cache entry, so a thread full of mentions
+  // stays cheap.
+  const { data, isError } = useQuery({
+    ...(workspaceId && entityId
+      ? entityOptions(workspaceId, entityId)
+      : {
+          queryKey: ["mention-entity-disabled"] as const,
+          queryFn: skipToken,
+        }),
+    enabled: workspaceId !== undefined && entityId !== undefined,
+    staleTime: Number.POSITIVE_INFINITY,
+  });
+
+  if (!workspaceId || !entityId || isError) {
+    return { type: "unknown" };
+  }
+
+  if (!data) {
+    return { type: "pending" };
+  }
+
+  for (const field of data.fields) {
+    if (field.content.type === "file" && field.content.mimeType.length > 0) {
+      return {
+        type: "resolved",
+        kind: data.kind,
+        fileName: field.content.fileName,
+        mimeType: field.content.mimeType,
+      };
+    }
+  }
+
+  return { type: "resolved", kind: data.kind };
+};

--- a/apps/web/src/components/chat/entity-link.tsx
+++ b/apps/web/src/components/chat/entity-link.tsx
@@ -1,47 +1,20 @@
-import { skipToken, useQuery } from "@tanstack/react-query";
 import { useNavigate, useRouterState } from "@tanstack/react-router";
-import {
-  FileTextIcon,
-  FolderIcon,
-  LandmarkIcon,
-  ListTodoIcon,
-} from "lucide-react";
+import { LandmarkIcon } from "lucide-react";
 
 import { cn } from "@stll/ui/lib/utils";
 
 import { openCaseLawDecision } from "@/components/chat/case-law-open";
 import { parseStellaMentionHref } from "@/components/chat/chat-mention-href";
+import { useEntityIconSource } from "@/components/chat/entity-icon-source";
 import { openEntityInInspector } from "@/components/chat/entity-open";
 import { navigateToWorkspaceFolder } from "@/components/chat/folder-navigation";
-import { DocumentIcon } from "@/components/document-icon";
 import { MatterIcon } from "@/components/matter-icon";
+import { EntityIcon } from "@/components/workspaces/entity-kind-icon";
 import { detached } from "@/lib/detached";
-import { entityOptions } from "@/lib/workspaces/queries/entities";
 
 const DECISION_HASH_PREFIX = "#stella-decision=";
 
 const ICON_CLASS = "inline size-3 shrink-0";
-
-const useResolvedEntity = ({
-  entityId,
-  workspaceId,
-}: {
-  entityId: string;
-  workspaceId: string | undefined;
-}) => {
-  const { data } = useQuery({
-    ...(workspaceId
-      ? entityOptions(workspaceId, entityId)
-      : {
-          queryKey: ["entity-link-disabled"] as const,
-          queryFn: skipToken,
-        }),
-    enabled: workspaceId !== undefined,
-    staleTime: Number.POSITIVE_INFINITY,
-  });
-
-  return data;
-};
 
 export const EntityMentionIcon = ({
   entityId,
@@ -50,28 +23,8 @@ export const EntityMentionIcon = ({
   entityId: string;
   workspaceId: string | undefined;
 }) => {
-  const entity = useResolvedEntity({ entityId, workspaceId });
-
-  if (entity?.kind === "folder") {
-    return <FolderIcon className={ICON_CLASS} />;
-  }
-
-  if (entity?.kind === "task") {
-    return <ListTodoIcon className={ICON_CLASS} />;
-  }
-
-  for (const field of Object.values(entity?.fields ?? {})) {
-    if (field.content.type === "file" && field.content.mimeType.length > 0) {
-      return (
-        <DocumentIcon
-          className={ICON_CLASS}
-          mimeType={field.content.mimeType}
-        />
-      );
-    }
-  }
-
-  return <FileTextIcon className={ICON_CLASS} />;
+  const source = useEntityIconSource({ entityId, workspaceId });
+  return <EntityIcon className={ICON_CLASS} source={source} />;
 };
 
 /** Renders `#stella-*=` and `#stella-decision=` links as

--- a/apps/web/src/components/chat/source-chips.tsx
+++ b/apps/web/src/components/chat/source-chips.tsx
@@ -2,8 +2,9 @@ import { useState } from "react";
 
 import { useQuery } from "@tanstack/react-query";
 import { useNavigate, useRouterState } from "@tanstack/react-router";
-import { ExternalLinkIcon, FileTextIcon, FolderIcon } from "lucide-react";
+import { ExternalLinkIcon } from "lucide-react";
 
+import { isEntityKind } from "@stll/api-contract";
 import type { ChatMessage, ChatSourceDocument } from "@stll/api/types";
 import { BidiText } from "@stll/ui/components/bidi-text";
 import { cn } from "@stll/ui/lib/utils";
@@ -20,8 +21,8 @@ import {
   collectExternalSources,
   collectSourceDocuments,
 } from "@/components/chat/source-chips.logic";
-import { DocumentIcon } from "@/components/document-icon";
 import { useInspectorTabsStore } from "@/components/inspector/inspector-tabs-store";
+import { EntityIcon } from "@/components/workspaces/entity-kind-icon";
 import { useExternalSyncEffect } from "@/hooks/use-effect";
 import { detached } from "@/lib/detached";
 import { mcpConnectorsOptions } from "@/lib/knowledge/queries";
@@ -206,15 +207,18 @@ const SourceIcon = ({
 }: {
   kind: string;
   mimeType: string | null;
-}) => {
-  if (kind === "folder") {
-    return <FolderIcon className={cls} />;
-  }
-  if (mimeType) {
-    return <DocumentIcon className={cls} mimeType={mimeType} />;
-  }
-  return <FileTextIcon className={cn(cls, "text-muted-foreground")} />;
-};
+}) => (
+  // `EntityIcon` mutes the unresolved placeholder itself, which is what the
+  // previous fallback glyph did here.
+  <EntityIcon
+    className={cls}
+    source={
+      isEntityKind(kind)
+        ? { type: "resolved", kind, mimeType }
+        : { type: "unknown" }
+    }
+  />
+);
 
 const ExternalSourceChip = ({
   source,

--- a/apps/web/src/components/chat/streamdown-mention-link.tsx
+++ b/apps/web/src/components/chat/streamdown-mention-link.tsx
@@ -1,14 +1,11 @@
 import type React from "react";
 import { Fragment, isValidElement, useState } from "react";
 
-import { skipToken, useQuery } from "@tanstack/react-query";
 import { useNavigate, useRouterState } from "@tanstack/react-router";
 import {
   FileTextIcon,
-  FolderIcon,
   GlobeIcon,
   LandmarkIcon,
-  ListTodoIcon,
   WandSparklesIcon,
 } from "lucide-react";
 import { useTranslations } from "use-intl";
@@ -18,20 +15,20 @@ import { cn } from "@stll/ui/lib/utils";
 
 import { openCaseLawDecision } from "@/components/chat/case-law-open";
 import { parseStellaMentionHref } from "@/components/chat/chat-mention-href";
+import { useEntityIconSource } from "@/components/chat/entity-icon-source";
 import { openEntityInInspector } from "@/components/chat/entity-open";
 import { useExternalSourceStore } from "@/components/chat/external-source-store";
 import { navigateToWorkspaceFolder } from "@/components/chat/folder-navigation";
-import { DocumentIcon } from "@/components/document-icon";
 import { InlinePill } from "@/components/inline-pill";
 import { useInspectorCommandStore } from "@/components/inspector/inspector-command-store";
 import { useInspectorTabsStore } from "@/components/inspector/inspector-tabs-store";
 import { MatterIcon } from "@/components/matter-icon";
+import { EntityIcon } from "@/components/workspaces/entity-kind-icon";
 import { PDF_MIME_TYPE } from "@/consts";
 import { DOCX_MIME } from "@/lib/consts";
 import { detached } from "@/lib/detached";
 import { FOLIO_SCROLL_EVENT } from "@/lib/folio-scroll-event";
 import { sanitizeHref } from "@/lib/sanitize-href";
-import { entityOptions } from "@/lib/workspaces/queries/entities";
 
 const DECISION_HASH_PREFIX = "#stella-decision=";
 const ENTITY_REF_HASH_PREFIX = "#stella-entity-ref=";
@@ -72,9 +69,6 @@ const DOCUMENT_MIME_BY_EXTENSION: Record<string, string> = {
 };
 
 const ENTITY_EXTENSION_RE = /\.(?<ext>[A-Za-z0-9]{1,8})$/u;
-const FOLDER_LABEL_RE = /^(?:folder|složka|priečinok)\b/iu;
-const TASK_LABEL_RE = /^(?:task|úkol|úloha)\b/iu;
-
 const SKILL_CHIP_ICON = <WandSparklesIcon className="size-3 shrink-0" />;
 
 const isReactNodeArray = (
@@ -152,78 +146,15 @@ const getEntityDisplayLabel = (label: React.ReactNode): React.ReactNode => {
   return stripDocumentExtension(text);
 };
 
-/**
- * Read an entity's first file-field mime type from React Query
- * cache. The mention link already carries the entity ref, so we
- * never need the AI to encode the file extension in the visible
- * label — the right icon comes from the resolved entity itself.
- */
-const useResolvedEntityMime = ({
-  workspaceId,
-  entityId,
-}: {
-  workspaceId: string | undefined;
-  entityId: string | undefined;
-}): string | null => {
-  // staleTime: Infinity — first render fires one fetch per entity
-  // ref; subsequent renders (and the click handler) hit the same
-  // cache entry. Keeps mention rendering cheap even with many
-  // mentions in a thread.
-  const { data } = useQuery({
-    ...(workspaceId && entityId
-      ? entityOptions(workspaceId, entityId)
-      : {
-          queryKey: ["mention-entity-disabled"] as const,
-          queryFn: skipToken,
-        }),
-    enabled: workspaceId !== undefined && entityId !== undefined,
-    staleTime: Number.POSITIVE_INFINITY,
-  });
-  if (!data?.fields) {
-    return null;
-  }
-  for (const field of data.fields) {
-    if (field.content.type === "file" && field.content.mimeType.length > 0) {
-      return field.content.mimeType;
-    }
-  }
-  return null;
-};
-
 const EntityChipIcon = ({
-  label,
   workspaceId,
   entityId,
 }: {
-  label: React.ReactNode;
   workspaceId?: string | undefined;
   entityId?: string | undefined;
 }) => {
-  const resolvedMime = useResolvedEntityMime({ workspaceId, entityId });
-  const text = getPlainText(label);
-
-  if (resolvedMime) {
-    return <DocumentIcon className="size-3 shrink-0" mimeType={resolvedMime} />;
-  }
-
-  if (!text) {
-    return <FileTextIcon className="size-3 shrink-0" />;
-  }
-
-  if (TASK_LABEL_RE.test(text)) {
-    return <ListTodoIcon className="size-3 shrink-0" />;
-  }
-
-  if (FOLDER_LABEL_RE.test(text)) {
-    return <FolderIcon className="size-3 shrink-0" />;
-  }
-
-  const mimeType = getDocumentMimeFromLabel(text);
-  if (mimeType) {
-    return <DocumentIcon className="size-3 shrink-0" mimeType={mimeType} />;
-  }
-
-  return <FileTextIcon className="size-3 shrink-0" />;
+  const source = useEntityIconSource({ entityId, workspaceId });
+  return <EntityIcon className="size-3 shrink-0" source={source} />;
 };
 
 type MentionChipProps = {
@@ -290,11 +221,7 @@ const EntityRefChip = ({
     return <span>{label}</span>;
   }
   const icon = (
-    <EntityChipIcon
-      entityId={refEntityId}
-      label={label}
-      workspaceId={refWorkspaceId}
-    />
+    <EntityChipIcon entityId={refEntityId} workspaceId={refWorkspaceId} />
   );
   const displayLabel = getEntityDisplayLabel(label);
 
@@ -460,11 +387,7 @@ const ParsedMentionChip = ({
 
   if (category === "entity") {
     const icon = (
-      <EntityChipIcon
-        entityId={id}
-        label={label}
-        workspaceId={mentionWorkspaceId}
-      />
+      <EntityChipIcon entityId={id} workspaceId={mentionWorkspaceId} />
     );
     const displayLabel = getEntityDisplayLabel(label);
     if (!interactive || !mentionWorkspaceId) {

--- a/apps/web/src/components/drag-preview-content.tsx
+++ b/apps/web/src/components/drag-preview-content.tsx
@@ -1,9 +1,9 @@
 import { createElement } from "react";
 
-import { FolderIcon } from "lucide-react";
+import { isEntityKind } from "@stll/api-contract";
 
-import { DocumentIcon } from "@/components/document-icon";
 import type { DragPreviewData } from "@/components/drag-preview";
+import { EntityIcon } from "@/components/workspaces/entity-kind-icon";
 
 const cardStyle = {
   display: "flex",
@@ -23,18 +23,17 @@ const cardStyle = {
 } as const;
 
 const ItemIcon = ({ data }: { data: DragPreviewData }) => {
-  if (data.kind === "folder") {
-    return createElement(FolderIcon, {
-      className: "size-3.5 shrink-0 text-muted-foreground",
-    });
+  if (!isEntityKind(data.kind)) {
+    return null;
   }
-  if (data.mimeType) {
-    return createElement(DocumentIcon, {
+  return createElement(EntityIcon, {
+    className: "size-3.5 shrink-0 text-muted-foreground",
+    source: {
+      type: "resolved",
+      kind: data.kind,
       mimeType: data.mimeType,
-      className: "size-3.5 shrink-0",
-    });
-  }
-  return null;
+    },
+  });
 };
 
 export const PreviewContent = ({ data }: { data: DragPreviewData }) =>

--- a/apps/web/src/components/workspaces/entity-kind-icon.test.tsx
+++ b/apps/web/src/components/workspaces/entity-kind-icon.test.tsx
@@ -1,0 +1,59 @@
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { describe, expect, test } from "bun:test";
+
+import { ENTITY_KINDS } from "@stll/api-contract";
+
+import {
+  EntityIcon,
+  EntityKindIcon,
+} from "@/components/workspaces/entity-kind-icon";
+
+// lucide tags every glyph with a `lucide-<name>` class, which identifies
+// the drawing independently of the sizing/colour classes a caller passes.
+const glyphOf = (markup: string): string | undefined =>
+  markup
+    .split('"')
+    .flatMap((chunk) => chunk.split(" "))
+    .find((token) => token.startsWith("lucide-"));
+
+const kindGlyph = (kind: (typeof ENTITY_KINDS)[number], status?: string) =>
+  glyphOf(renderToStaticMarkup(<EntityKindIcon kind={kind} status={status} />));
+
+describe("EntityKindIcon", () => {
+  // Declared set equals drawn set, in both directions: a kind added to
+  // ENTITY_KINDS without a glyph fails the switch's `never` check at
+  // compile time, and a kind quietly mapped onto another's glyph fails
+  // here.
+  test("every kind draws a distinct glyph", () => {
+    const glyphs = ENTITY_KINDS.map((kind) => kindGlyph(kind));
+
+    expect(glyphs.filter((glyph) => glyph !== undefined)).toHaveLength(
+      ENTITY_KINDS.length,
+    );
+    expect(new Set(glyphs).size).toBe(ENTITY_KINDS.length);
+  });
+
+  test("no kind draws the unresolved placeholder", () => {
+    const placeholder = glyphOf(
+      renderToStaticMarkup(<EntityIcon source={{ type: "unknown" }} />),
+    );
+
+    expect(placeholder).toBeDefined();
+    for (const kind of ENTITY_KINDS) {
+      expect(kindGlyph(kind)).not.toBe(placeholder);
+    }
+  });
+
+  // A status glyph asserts a status. Rendering one for a task whose status
+  // the caller never had (chat mentions read an entity endpoint that does
+  // not return it) labels every done task "open".
+  test("a task without a status does not draw a status glyph", () => {
+    const statusless = kindGlyph("task");
+
+    expect(statusless).toBeDefined();
+    expect(statusless).not.toBe(kindGlyph("task", "open"));
+    expect(statusless).not.toBe(kindGlyph("task", "done"));
+    expect(kindGlyph("task", "done")).not.toBe(kindGlyph("task", "cancelled"));
+  });
+});

--- a/apps/web/src/components/workspaces/entity-kind-icon.tsx
+++ b/apps/web/src/components/workspaces/entity-kind-icon.tsx
@@ -1,4 +1,11 @@
-import { FileIcon, FolderIcon, LinkIcon, MailIcon } from "lucide-react";
+import {
+  CircleDashedIcon,
+  FileIcon,
+  FolderIcon,
+  LinkIcon,
+  ListTodoIcon,
+  MailIcon,
+} from "lucide-react";
 
 import { cn } from "@stll/ui/lib/utils";
 
@@ -10,6 +17,64 @@ import {
 } from "@/components/workspaces/tasks/task-detail-constants";
 import type { EntityKind } from "@/lib/types";
 
+/**
+ * What a renderer knows about the entity it is drawing an icon for.
+ *
+ * `pending` and `unknown` exist so a caller that has not resolved the
+ * entity yet cannot express its ignorance as a document: an icon picked
+ * from a proxy signal (the visible label, the presence of a mime type) is
+ * wrong in a way that looks right, which is how chat mentions came to draw
+ * folders and tasks as documents.
+ */
+export type EntityIconSource =
+  | {
+      type: "resolved";
+      kind: EntityKind;
+      fileName?: string | null | undefined;
+      mimeType?: string | null | undefined;
+      /** Task status, when the caller has it. Absent means "a task", not
+       *  "an open task". */
+      status?: string | null | undefined;
+    }
+  | { type: "pending" }
+  | { type: "unknown" };
+
+/** Draws an entity's icon from whatever the caller actually knows. */
+export const EntityIcon = ({
+  source,
+  className,
+}: {
+  source: EntityIconSource;
+  className?: string | undefined;
+}) => {
+  switch (source.type) {
+    case "resolved":
+      return (
+        <EntityKindIcon
+          className={className}
+          fileName={source.fileName}
+          kind={source.kind}
+          mimeType={source.mimeType}
+          status={source.status}
+        />
+      );
+    case "pending":
+      return (
+        <CircleDashedIcon
+          className={cn("text-muted-foreground animate-pulse", className)}
+        />
+      );
+    case "unknown":
+      return (
+        <CircleDashedIcon className={cn("text-muted-foreground", className)} />
+      );
+    default: {
+      const exhaustive: never = source;
+      return exhaustive;
+    }
+  }
+};
+
 type EntityKindIconProps = {
   kind: EntityKind;
   className?: string | undefined;
@@ -18,6 +83,12 @@ type EntityKindIconProps = {
   status?: string | null | undefined;
 };
 
+/**
+ * The single kind -> glyph mapping. The `switch` is exhaustive over
+ * `EntityKind` (see the `never` default), so a kind added to
+ * `ENTITY_KINDS` fails to typecheck here until someone gives it a glyph,
+ * instead of silently inheriting the document fallback.
+ */
 export const EntityKindIcon = ({
   kind,
   className,
@@ -25,36 +96,36 @@ export const EntityKindIcon = ({
   mimeType,
   status,
 }: EntityKindIconProps) => {
-  if (kind === "task") {
-    const statusKey = status ?? null;
-    const resolved = isTaskStatus(statusKey) ? statusKey : "open";
-    const Icon = STATUS_ICONS[resolved];
-    const color = STATUS_COLORS[resolved];
-    return <Icon className={cn(color, className)} />;
+  switch (kind) {
+    case "task": {
+      // A status icon states a status. Without one, say "task" rather than
+      // defaulting to "open" and mislabelling every done task.
+      const statusKey = status ?? null;
+      if (!isTaskStatus(statusKey)) {
+        return <ListTodoIcon className={className} />;
+      }
+      const Icon = STATUS_ICONS[statusKey];
+      return <Icon className={cn(STATUS_COLORS[statusKey], className)} />;
+    }
+    case "folder":
+      return <FolderIcon className={className} />;
+    case "message":
+      return <MailIcon className={className} />;
+    case "link":
+      return <LinkIcon className={className} />;
+    case "document":
+      return mimeType ? (
+        <DocumentIcon
+          className={className}
+          fileName={fileName}
+          mimeType={mimeType}
+        />
+      ) : (
+        <FileIcon className={className} />
+      );
+    default: {
+      const exhaustive: never = kind;
+      return exhaustive;
+    }
   }
-
-  if (kind === "folder") {
-    return <FolderIcon className={className} />;
-  }
-
-  if (kind === "message") {
-    return <MailIcon className={className} />;
-  }
-
-  if (kind === "link") {
-    return <LinkIcon className={className} />;
-  }
-
-  // document / file
-  if (mimeType) {
-    return (
-      <DocumentIcon
-        className={className}
-        fileName={fileName}
-        mimeType={mimeType}
-      />
-    );
-  }
-
-  return <FileIcon className={className} />;
 };


### PR DESCRIPTION
Closes #1720. Draws a chat mention's icon from the entity's kind rather than from its label text. Second of three stacked PRs; based on #1746.

## Change

`EntityChipIcon` in `streamdown-mention-link.tsx` selected a mention chip's glyph by testing the visible link label against `/^(?:folder|slozka|priecinok)\b/iu` and a matching task pattern. The label is the entity's name (the API mints mentions as `[<name>](#stella-entity-ref=<ws>:<id>)`), so the patterns only matched an entity literally named "Folder ..."; folders and tasks carry no file field either, so the mime branch did not apply and both fell through to the generic document glyph. The patterns also covered only English, Czech and Slovak.

The component already resolved the entity to read its mime type, and that endpoint returns `kind` (`apps/api/src/handlers/entities/get.ts`), so the kind is available in the query cache.

Four components carried their own kind-to-glyph dispatch, three of them branching on `"folder"` alone, so tasks, messages and links drew as documents in the mention picker, the source chips and the composer node view as well. All four now route through `EntityKindIcon`:

- `EntityKindIcon` becomes a `switch` over `EntityKind` with a `never` default, so a kind added to `ENTITY_KINDS` fails to typecheck here until it is given a glyph
- a new `EntityIcon` takes an `EntityIconSource` union (`resolved` / `pending` / `unknown`), so a caller that has not resolved the entity renders a neutral placeholder rather than a glyph it cannot justify
- `useEntityIconSource` resolves the entity once and is shared by the streamdown renderer and `entity-link`
- `ChatMentionOption.kind` is the closed `ChatMentionKind` union rather than `string`; untrusted TipTap attributes narrow through `isEntityKind` and yield `null`

`EntityKindIcon`'s task branch previously resolved `status ?? "open"` and drew that status's glyph. The entity endpoint does not return status, so callers without one now draw a generic task glyph instead.

`chat-mention-extension.test.ts` built its fixture as `kind: category`, a value no producer emits; the tighter type surfaced it, and the fixture now maps category to a realistic kind through a total `satisfies Record<...>` map.

## Behaviour notes for review

- Source chips: the placeholder carries its own muted tone, so resolved glyphs keep their existing styling.
- Mention picker: generic (non-Office) file glyphs now inherit the row's muted tone. The colourful file-type icons draw their own fills and are unaffected.
- The workspace overview's "New task" menu item passes `kind="task"` with no status, so it moves from the open-status circle to the generic task glyph.

## Verification

- `bun --filter @stll/web typecheck`, `lint`: clean
- `bun --filter @stll/web test`: 1494 + 54 pass, 0 fail
- `entity-kind-icon.test.tsx` asserts every kind draws a distinct glyph, that none equals the placeholder, and pins the task-status behaviour; verified red against the previous implementation

CC on behalf of jan-kubica