### PR TITLE
fix(s3): route every object read off Bun's leaking native download

### DIFF
--- a/.oxlint-plugins/__fixtures__/no-native-s3-object-read.fixture.ts
+++ b/.oxlint-plugins/__fixtures__/no-native-s3-object-read.fixture.ts
@@ -47,6 +47,18 @@ const handle = getS3().file(key);
 // oxlint-disable-next-line no-native-s3-object-read/no-native-s3-object-read
 const _viaHandle = await handle.arrayBuffer();
 
+// Static computed reads are the same native calls and must not bypass the
+// rule, whether made directly or through a file-handle local.
+// oxlint-disable-next-line no-native-s3-object-read/no-native-s3-object-read, typescript/dot-notation -- computed-property bypass fixture
+const _computedDirect = await getS3().file(key)["bytes"]();
+// oxlint-disable-next-line no-native-s3-object-read/no-native-s3-object-read, typescript/dot-notation -- computed-property bypass fixture
+const _computedHandle = await handle["text"]();
+
+// Binding an accessor result first must retain the S3-client provenance.
+const accessorClient = getCorpusS3();
+// oxlint-disable-next-line no-native-s3-object-read/no-native-s3-object-read
+const _viaAccessorClient = await accessorClient.file(key).json();
+
 // A script constructing its own client rather than using an accessor.
 declare const S3Client: new (
   options: Record<string, unknown>,
@@ -71,6 +83,8 @@ const _viaFetch = await (await fetch(_signed)).arrayBuffer();
 
 export {
   _bytes,
+  _computedDirect,
+  _computedHandle,
   _corpus,
   _direct,
   _exists,
@@ -81,5 +95,6 @@ export {
   _stat,
   _text,
   _viaFetch,
+  _viaAccessorClient,
   _viaHandle,
 };

--- a/.oxlint-plugins/__fixtures__/no-native-s3-object-read.fixture.ts
+++ b/.oxlint-plugins/__fixtures__/no-native-s3-object-read.fixture.ts
@@ -1,0 +1,85 @@
+// Passive regression fixture for
+// `no-native-s3-object-read/no-native-s3-object-read`.
+//
+// Each `oxlint-disable-next-line` below intentionally suppresses a case the
+// rule MUST flag. If the rule regresses (e.g. someone drops the two-step
+// file-handle tracking or the local-client tracking), the matching disable
+// becomes unused and `--report-unused-disable-directives-severity=error`
+// fails CI. The un-suppressed statements at the bottom must stay clean: they
+// are the shapes the rule must NOT flag.
+
+declare const getS3: () => {
+  file: (key: string) => {
+    arrayBuffer: () => Promise<ArrayBuffer>;
+    bytes: () => Promise<Uint8Array>;
+    text: () => Promise<string>;
+    json: () => Promise<unknown>;
+    exists: () => Promise<boolean>;
+    stat: () => Promise<{ size: number }>;
+  };
+  write: (key: string, body: Uint8Array) => Promise<void>;
+  delete: (key: string) => Promise<void>;
+  presign: (key: string, options: { expiresIn: number }) => string;
+};
+declare const getCorpusS3: typeof getS3;
+
+const key = "some/object/key";
+
+// Direct read off the documents-bucket accessor.
+// oxlint-disable-next-line no-native-s3-object-read/no-native-s3-object-read
+const _direct = await getS3().file(key).arrayBuffer();
+
+// Every body-materialising method is covered, not just arrayBuffer.
+// oxlint-disable-next-line no-native-s3-object-read/no-native-s3-object-read
+const _bytes = await getS3().file(key).bytes();
+// oxlint-disable-next-line no-native-s3-object-read/no-native-s3-object-read
+const _text = await getS3().file(key).text();
+// oxlint-disable-next-line no-native-s3-object-read/no-native-s3-object-read
+const _json = await getS3().file(key).json();
+
+// The corpus accessor is the same hazard against the other bucket.
+// oxlint-disable-next-line no-native-s3-object-read/no-native-s3-object-read
+const _corpus = await getCorpusS3().file(key).bytes();
+
+// Two-step form: the file handle is bound first, then read. This is the shape
+// that a receiver-only check would miss.
+const handle = getS3().file(key);
+// oxlint-disable-next-line no-native-s3-object-read/no-native-s3-object-read
+const _viaHandle = await handle.arrayBuffer();
+
+// A script constructing its own client rather than using an accessor.
+declare const S3Client: new (
+  options: Record<string, unknown>,
+) => ReturnType<typeof getS3>;
+const ownClient = new S3Client({ bucket: "b" });
+// oxlint-disable-next-line no-native-s3-object-read/no-native-s3-object-read
+const _ownClient = await ownClient.file(key).bytes();
+
+// --- Must NOT be flagged: no response body, so nothing to leak. ---
+
+const _exists = await getS3().file(key).exists();
+const _stat = await getS3().file(key).stat();
+const _signed = getS3().presign(key, { expiresIn: 60 });
+await getS3().write(key, new Uint8Array());
+await getS3().delete(key);
+
+// Reading a *local* file is unrelated to the S3 download path.
+const _localFile = await Bun.file("/tmp/example").arrayBuffer();
+
+// A fetch Response is the sanctioned replacement and must stay clean.
+const _viaFetch = await (await fetch(_signed)).arrayBuffer();
+
+export {
+  _bytes,
+  _corpus,
+  _direct,
+  _exists,
+  _json,
+  _localFile,
+  _ownClient,
+  _signed,
+  _stat,
+  _text,
+  _viaFetch,
+  _viaHandle,
+};

--- a/.oxlint-plugins/__fixtures__/no-native-s3-object-read.fixture.ts
+++ b/.oxlint-plugins/__fixtures__/no-native-s3-object-read.fixture.ts
@@ -67,6 +67,16 @@ const ownClient = new S3Client({ bucket: "b" });
 // oxlint-disable-next-line no-native-s3-object-read/no-native-s3-object-read
 const _ownClient = await ownClient.file(key).bytes();
 
+// A direct construction must not bypass provenance tracking.
+// oxlint-disable-next-line no-native-s3-object-read/no-native-s3-object-read
+const _directOwnClient = await new Bun.S3Client({
+  bucket: "b",
+  accessKeyId: "a",
+  secretAccessKey: "s",
+})
+  .file(key)
+  .bytes();
+
 // --- Must NOT be flagged: no response body, so nothing to leak. ---
 
 const _exists = await getS3().file(key).exists();
@@ -81,12 +91,32 @@ const _localFile = await Bun.file("/tmp/example").arrayBuffer();
 // A fetch Response is the sanctioned replacement and must stay clean.
 const _viaFetch = await (await fetch(_signed)).arrayBuffer();
 
+// Provenance follows lexical bindings, not identifier spelling. Neither a
+// shadowed parameter nor a reassigned local is known to remain an S3 client.
+// oxlint-disable-next-line eslint/no-shadow -- the shadow is the regression shape
+const readShadowedClient = async (accessorClient: ReturnType<typeof getS3>) =>
+  await accessorClient.file(key).bytes();
+let reassignedClient = getS3();
+reassignedClient = {
+  ...reassignedClient,
+  file: () => ({
+    arrayBuffer: async () => await Promise.resolve(new ArrayBuffer(0)),
+    bytes: async () => await Promise.resolve(new Uint8Array()),
+    text: async () => await Promise.resolve(""),
+    json: async () => await Promise.resolve(null),
+    exists: async () => await Promise.resolve(false),
+    stat: async () => await Promise.resolve({ size: 0 }),
+  }),
+};
+const _reassignedClient = await reassignedClient.file(key).bytes();
+
 export {
   _bytes,
   _computedDirect,
   _computedHandle,
   _corpus,
   _direct,
+  _directOwnClient,
   _exists,
   _json,
   _localFile,
@@ -94,7 +124,9 @@ export {
   _signed,
   _stat,
   _text,
+  _reassignedClient,
   _viaFetch,
   _viaAccessorClient,
   _viaHandle,
+  readShadowedClient,
 };

--- a/.oxlint-plugins/no-native-s3-object-read.ts
+++ b/.oxlint-plugins/no-native-s3-object-read.ts
@@ -1,0 +1,125 @@
+// Ban Bun's native S3 object-body reads.
+//
+// Up to and including Bun 1.3.14, `S3Client.file(key).bytes()` /
+// `.arrayBuffer()` / `.text()` / `.json()` never free the native buffer the
+// HTTP thread accumulates the response body into: the handler is invoked with
+// `.clone` lifetime, JS receives its own copy, and the original allocation is
+// stranded (oven-sh/bun#29083, fixed upstream by #29086 and #29923). The
+// leaked allocation lives outside the JS heap, so it is invisible to heap
+// snapshots and survives a forced GC — only RSS moves. Any process that reads
+// a steady stream of objects grows by roughly the object size per read until
+// the runtime kills it.
+//
+// One missed call site silently reintroduces that, and the symptom (RSS climb
+// with a flat heap) is expensive to trace back, so this is a rule rather than
+// a convention. Read through `readS3ArrayBuffer` / `readCorpusS3Bytes` in
+// apps/api/src/lib/s3.ts, which fetch over a presigned URL instead.
+//
+// Remove this rule together with those helpers once every runtime image is on
+// a stable Bun containing the fixes (the first stable AFTER 1.3.14 — they are
+// not in 1.3.14 itself). See TODO(bun-s3-native-read).
+
+import { isIdentifier } from "./utils.ts";
+
+// Body-materialising reads only. `.exists()`, `.stat()`, `.write()`,
+// `.delete()`, and `.presign()` carry no response body and do not leak.
+const BODY_READS = new Set(["arrayBuffer", "bytes", "text", "json"]);
+
+// Accessors that hand back a Bun S3 client. A local `new Bun.S3Client(...)`
+// is caught through the `.file(...)` receiver check below instead.
+const S3_ACCESSORS = new Set(["getS3", "getCorpusS3"]);
+
+/** True for `<something>.file(...)` — the call that yields the S3 file handle. */
+const isFileCall = (node) =>
+  node?.type === "CallExpression" &&
+  node.callee.type === "MemberExpression" &&
+  !node.callee.computed &&
+  isIdentifier(node.callee.property, "file");
+
+/** True when `.file(...)`'s receiver is recognisably an S3 client. */
+const hasS3Receiver = (fileCall, s3Locals) => {
+  const receiver = fileCall.callee.object;
+  if (
+    receiver.type === "CallExpression" &&
+    isIdentifier(receiver.callee) &&
+    S3_ACCESSORS.has(receiver.callee.name)
+  ) {
+    return true;
+  }
+  return isIdentifier(receiver) && s3Locals.has(receiver.name);
+};
+
+export default {
+  meta: { name: "no-native-s3-object-read" },
+  rules: {
+    "no-native-s3-object-read": {
+      meta: {
+        type: "problem",
+        messages: {
+          noNativeS3ObjectRead:
+            "Do not read an S3 object body with .{{method}}(); Bun 1.3.14 " +
+            "leaks the native download buffer (oven-sh/bun#29083). Use " +
+            "readS3ArrayBuffer() or readCorpusS3Bytes() from " +
+            "@/api/lib/s3 instead.",
+        },
+      },
+      create(context) {
+        // Locals bound to a Bun S3 client, so a script that builds its own
+        // `const s3 = new Bun.S3Client(...)` is covered too.
+        const s3Locals = new Set();
+        // Locals bound to an S3 *file handle*, for the two-step form
+        // `const f = getS3().file(k); await f.arrayBuffer();`.
+        const s3FileLocals = new Set();
+
+        const isS3ClientConstruction = (init) =>
+          init?.type === "NewExpression" &&
+          ((isIdentifier(init.callee) && init.callee.name === "S3Client") ||
+            (init.callee.type === "MemberExpression" &&
+              !init.callee.computed &&
+              isIdentifier(init.callee.property, "S3Client")));
+
+        return {
+          VariableDeclarator(node) {
+            if (!isIdentifier(node.id)) {
+              return;
+            }
+            if (isS3ClientConstruction(node.init)) {
+              s3Locals.add(node.id.name);
+              return;
+            }
+            if (isFileCall(node.init) && hasS3Receiver(node.init, s3Locals)) {
+              s3FileLocals.add(node.id.name);
+            }
+          },
+
+          CallExpression(node) {
+            const callee = node.callee;
+            if (
+              callee.type !== "MemberExpression" ||
+              callee.computed ||
+              !isIdentifier(callee.property) ||
+              !BODY_READS.has(callee.property.name)
+            ) {
+              return;
+            }
+
+            const receiver = callee.object;
+            const direct =
+              isFileCall(receiver) && hasS3Receiver(receiver, s3Locals);
+            const viaLocal =
+              isIdentifier(receiver) && s3FileLocals.has(receiver.name);
+            if (!direct && !viaLocal) {
+              return;
+            }
+
+            context.report({
+              node,
+              messageId: "noNativeS3ObjectRead",
+              data: { method: callee.property.name },
+            });
+          },
+        };
+      },
+    },
+  },
+};

--- a/.oxlint-plugins/no-native-s3-object-read.ts
+++ b/.oxlint-plugins/no-native-s3-object-read.ts
@@ -19,7 +19,8 @@
 // a stable Bun containing the fixes (the first stable AFTER 1.3.14 — they are
 // not in 1.3.14 itself). See TODO(bun-s3-native-read).
 
-import { isIdentifier } from "./utils.ts";
+import { isAstNode, isIdentifier } from "./utils.ts";
+import type { AstNode } from "./utils.ts";
 
 // Body-materialising reads only. `.exists()`, `.stat()`, `.write()`,
 // `.delete()`, and `.presign()` carry no response body and do not leak.
@@ -40,15 +41,6 @@ const isFileCall = (node) =>
   node.callee.type === "MemberExpression" &&
   !node.callee.computed &&
   isIdentifier(node.callee.property, "file");
-
-/** True when `.file(...)`'s receiver is recognisably an S3 client. */
-const hasS3Receiver = (fileCall, s3Locals) => {
-  const receiver = fileCall.callee.object;
-  if (isS3AccessorCall(receiver)) {
-    return true;
-  }
-  return isIdentifier(receiver) && s3Locals.has(receiver.name);
-};
 
 const bodyReadMethod = (member) => {
   if (!member.computed && isIdentifier(member.property)) {
@@ -79,13 +71,6 @@ export default {
         },
       },
       create(context) {
-        // Locals bound to a Bun S3 client, so a script that builds its own
-        // `const s3 = new Bun.S3Client(...)` is covered too.
-        const s3Locals = new Set();
-        // Locals bound to an S3 *file handle*, for the two-step form
-        // `const f = getS3().file(k); await f.arrayBuffer();`.
-        const s3FileLocals = new Set();
-
         const isS3ClientConstruction = (init) =>
           init?.type === "NewExpression" &&
           ((isIdentifier(init.callee) && init.callee.name === "S3Client") ||
@@ -93,23 +78,88 @@ export default {
               !init.callee.computed &&
               isIdentifier(init.callee.property, "S3Client")));
 
-        return {
-          VariableDeclarator(node) {
-            if (!isIdentifier(node.id)) {
-              return;
+        const resolveVariable = (
+          identifierNode: AstNode & { name: string },
+        ) => {
+          let scope = context.sourceCode.getScope(identifierNode);
+          while (scope) {
+            const variable = scope.set.get(identifierNode.name);
+            if (variable) {
+              return variable;
+            }
+            scope = scope.upper;
+          }
+          return null;
+        };
+
+        // Return the initializer only while the identifier still denotes that
+        // binding. Binding identity prevents a same-named parameter or nested
+        // local from inheriting provenance. Mutable bindings are accepted only
+        // when scope analysis proves they were never reassigned after init.
+        const getStableInitializer = (variable) => {
+          for (const def of variable.defs) {
+            if (
+              def.type !== "Variable" ||
+              !isAstNode(def.node) ||
+              def.node.type !== "VariableDeclarator" ||
+              !isAstNode(def.parent) ||
+              def.parent.type !== "VariableDeclaration"
+            ) {
+              continue;
             }
             if (
-              isS3AccessorCall(node.init) ||
-              isS3ClientConstruction(node.init)
+              def.parent.kind !== "const" &&
+              variable.references.some(
+                (reference) =>
+                  typeof reference.isWrite === "function" &&
+                  reference.isWrite() &&
+                  reference.init !== true,
+              )
             ) {
-              s3Locals.add(node.id.name);
-              return;
+              return null;
             }
-            if (isFileCall(node.init) && hasS3Receiver(node.init, s3Locals)) {
-              s3FileLocals.add(node.id.name);
-            }
-          },
+            return isAstNode(def.node.init) ? def.node.init : null;
+          }
+          return null;
+        };
 
+        const isS3ClientExpression = (
+          node,
+          visited = new Set<unknown>(),
+        ): boolean => {
+          if (isS3AccessorCall(node) || isS3ClientConstruction(node)) {
+            return true;
+          }
+          if (!isIdentifier(node)) {
+            return false;
+          }
+          const variable = resolveVariable(node);
+          if (variable === null || visited.has(variable)) {
+            return false;
+          }
+          visited.add(variable);
+          return isS3ClientExpression(getStableInitializer(variable), visited);
+        };
+
+        const isS3FileExpression = (
+          node,
+          visited = new Set<unknown>(),
+        ): boolean => {
+          if (isFileCall(node)) {
+            return isS3ClientExpression(node.callee.object, visited);
+          }
+          if (!isIdentifier(node)) {
+            return false;
+          }
+          const variable = resolveVariable(node);
+          if (variable === null || visited.has(variable)) {
+            return false;
+          }
+          visited.add(variable);
+          return isS3FileExpression(getStableInitializer(variable), visited);
+        };
+
+        return {
           CallExpression(node) {
             const callee = node.callee;
             if (callee.type !== "MemberExpression") {
@@ -120,12 +170,7 @@ export default {
               return;
             }
 
-            const receiver = callee.object;
-            const direct =
-              isFileCall(receiver) && hasS3Receiver(receiver, s3Locals);
-            const viaLocal =
-              isIdentifier(receiver) && s3FileLocals.has(receiver.name);
-            if (!direct && !viaLocal) {
+            if (!isS3FileExpression(callee.object)) {
               return;
             }
 

--- a/.oxlint-plugins/no-native-s3-object-read.ts
+++ b/.oxlint-plugins/no-native-s3-object-read.ts
@@ -29,6 +29,11 @@ const BODY_READS = new Set(["arrayBuffer", "bytes", "text", "json"]);
 // is caught through the `.file(...)` receiver check below instead.
 const S3_ACCESSORS = new Set(["getS3", "getCorpusS3"]);
 
+const isS3AccessorCall = (node) =>
+  node?.type === "CallExpression" &&
+  isIdentifier(node.callee) &&
+  S3_ACCESSORS.has(node.callee.name);
+
 /** True for `<something>.file(...)` — the call that yields the S3 file handle. */
 const isFileCall = (node) =>
   node?.type === "CallExpression" &&
@@ -39,14 +44,24 @@ const isFileCall = (node) =>
 /** True when `.file(...)`'s receiver is recognisably an S3 client. */
 const hasS3Receiver = (fileCall, s3Locals) => {
   const receiver = fileCall.callee.object;
-  if (
-    receiver.type === "CallExpression" &&
-    isIdentifier(receiver.callee) &&
-    S3_ACCESSORS.has(receiver.callee.name)
-  ) {
+  if (isS3AccessorCall(receiver)) {
     return true;
   }
   return isIdentifier(receiver) && s3Locals.has(receiver.name);
+};
+
+const bodyReadMethod = (member) => {
+  if (!member.computed && isIdentifier(member.property)) {
+    return member.property.name;
+  }
+  if (
+    member.computed &&
+    member.property.type === "Literal" &&
+    typeof member.property.value === "string"
+  ) {
+    return member.property.value;
+  }
+  return null;
 };
 
 export default {
@@ -83,7 +98,10 @@ export default {
             if (!isIdentifier(node.id)) {
               return;
             }
-            if (isS3ClientConstruction(node.init)) {
+            if (
+              isS3AccessorCall(node.init) ||
+              isS3ClientConstruction(node.init)
+            ) {
               s3Locals.add(node.id.name);
               return;
             }
@@ -94,12 +112,11 @@ export default {
 
           CallExpression(node) {
             const callee = node.callee;
-            if (
-              callee.type !== "MemberExpression" ||
-              callee.computed ||
-              !isIdentifier(callee.property) ||
-              !BODY_READS.has(callee.property.name)
-            ) {
+            if (callee.type !== "MemberExpression") {
+              return;
+            }
+            const method = bodyReadMethod(callee);
+            if (!method || !BODY_READS.has(method)) {
               return;
             }
 
@@ -115,7 +132,7 @@ export default {
             context.report({
               node,
               messageId: "noNativeS3ObjectRead",
-              data: { method: callee.property.name },
+              data: { method },
             });
           },
         };

--- a/apps/api/scripts/backfill-image-thumbnails.ts
+++ b/apps/api/scripts/backfill-image-thumbnails.ts
@@ -30,7 +30,7 @@ import {
   THUMBNAIL_MIME_TYPE,
 } from "@/api/lib/files/image-derivative";
 import { createUserFileKey } from "@/api/lib/files/utils";
-import { getS3 } from "@/api/lib/s3";
+import { getS3, readS3ArrayBuffer } from "@/api/lib/s3";
 import {
   brandPersistedEntityId,
   brandPersistedFieldId,
@@ -163,7 +163,7 @@ const backfillChatFiles = async (): Promise<number> => {
     for (const row of rows) {
       // oxlint-disable-next-line no-await-in-loop -- bounded memory: read one source image from S3 at a time per row
       const source = await Result.tryPromise({
-        try: async () => await getS3().file(row.s3Key).bytes(),
+        try: async () => new Uint8Array(await readS3ArrayBuffer(row.s3Key)),
         catch: (cause) => cause,
       });
       if (Result.isError(source)) {

--- a/apps/api/src/handlers/case-law/ingestion/pipeline.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/pipeline.test.ts
@@ -551,6 +551,15 @@ describe("processDecision — source raw upload failure", () => {
       writeS3ObjectWithRetry: () => {
         throw new Error("an unexpected error has occurred");
       },
+      // `mock.module` replaces the module, so every named export a consumer
+      // imports must exist here or the import fails at link time. This suite
+      // reads no object; throwing surfaces one that appears later.
+      readS3ArrayBuffer: () => {
+        throw new Error("Unexpected S3 object read in this suite");
+      },
+      readCorpusS3Bytes: () => {
+        throw new Error("Unexpected corpus object read in this suite");
+      },
     }));
 
     const scopedDb: ScopedDb = async (callback) => {

--- a/apps/api/src/handlers/chat/send-message.ts
+++ b/apps/api/src/handlers/chat/send-message.ts
@@ -173,7 +173,7 @@ import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import { createFileKey } from "@/api/lib/files/utils";
 import { FILE_SIZE_LIMIT_BYTES, FILE_SIZE_LIMITS } from "@/api/lib/limits";
 import { getDisabledNativeToolSlugs } from "@/api/lib/mcp-connectors/catalog-metadata";
-import { getS3 } from "@/api/lib/s3";
+import { readS3ArrayBuffer } from "@/api/lib/s3";
 import { brandPersistedChatMessageId } from "@/api/lib/safe-id-boundaries";
 import { upsertChatThreadSearchDocument } from "@/api/lib/search/index-chat";
 import {
@@ -2310,7 +2310,7 @@ const readActivePdfForModel = async ({
     });
     const buffer = yield* Result.await(
       Result.tryPromise({
-        try: async () => await getS3().file(s3Key).arrayBuffer(),
+        try: async () => await readS3ArrayBuffer(s3Key),
         catch: (cause) =>
           new HandlerError({
             status: 500,

--- a/apps/api/src/handlers/chat/tools/create-workspace-document-tools.test.ts
+++ b/apps/api/src/handlers/chat/tools/create-workspace-document-tools.test.ts
@@ -27,6 +27,15 @@ void mock.module("@/api/lib/s3", () => ({
     delete: s3DeleteMock,
   }),
   putS3ObjectWithSignal: s3WriteMock,
+  // `mock.module` replaces the module, so every named export a consumer
+  // imports must exist here or the import fails at link time. This suite
+  // reads no object; throwing surfaces one that appears later.
+  readS3ArrayBuffer: () => {
+    throw new Error("Unexpected S3 object read in this suite");
+  },
+  readCorpusS3Bytes: () => {
+    throw new Error("Unexpected corpus object read in this suite");
+  },
 }));
 
 void mock.module("@/api/lib/search/process-extraction", () => ({

--- a/apps/api/src/handlers/chat/tools/edit-workspace-document-tools.test.ts
+++ b/apps/api/src/handlers/chat/tools/edit-workspace-document-tools.test.ts
@@ -29,10 +29,6 @@ void mock.module("@/api/lib/s3", () => ({
   getS3: () => ({
     write: s3WriteMock,
     delete: s3DeleteMock,
-    file: (key: string) => {
-      s3ReadKeys.push(key);
-      return { arrayBuffer: async () => s3FileBuffer };
-    },
   }),
   putS3ObjectWithSignal: s3WriteMock,
   readS3ArrayBuffer: async (key: string) => {

--- a/apps/api/src/handlers/chat/tools/edit-workspace-document-tools.test.ts
+++ b/apps/api/src/handlers/chat/tools/edit-workspace-document-tools.test.ts
@@ -35,6 +35,10 @@ void mock.module("@/api/lib/s3", () => ({
     },
   }),
   putS3ObjectWithSignal: s3WriteMock,
+  readS3ArrayBuffer: async (key: string) => {
+    s3ReadKeys.push(key);
+    return s3FileBuffer;
+  },
 }));
 void mock.module("@/api/lib/search/process-extraction", () => ({
   processExtraction: processExtractionMock,

--- a/apps/api/src/handlers/chat/tools/edit-workspace-document-tools.test.ts
+++ b/apps/api/src/handlers/chat/tools/edit-workspace-document-tools.test.ts
@@ -35,6 +35,9 @@ void mock.module("@/api/lib/s3", () => ({
     s3ReadKeys.push(key);
     return s3FileBuffer;
   },
+  readCorpusS3Bytes: () => {
+    throw new Error("Unexpected corpus object read in this suite");
+  },
 }));
 void mock.module("@/api/lib/search/process-extraction", () => ({
   processExtraction: processExtractionMock,

--- a/apps/api/src/handlers/chat/tools/version-compare-tools.ts
+++ b/apps/api/src/handlers/chat/tools/version-compare-tools.ts
@@ -14,7 +14,7 @@ import { toTanStackToolSchema } from "@/api/handlers/chat/tools/tanstack-tool-sc
 import type { SafeId } from "@/api/lib/branded-types";
 import { ChatToolError } from "@/api/lib/errors/tagged-errors";
 import { createFileKey } from "@/api/lib/files/utils";
-import { getS3 } from "@/api/lib/s3";
+import { readS3ArrayBuffer } from "@/api/lib/s3";
 import { brandPersistedEntityVersionId } from "@/api/lib/safe-id-boundaries";
 import { DOCX_MIME_TYPE } from "@/api/mime-types";
 
@@ -195,16 +195,14 @@ const loadVersionDocxBuffer = async (
   organizationId: SafeId<"organization">,
   resolved: ResolvedVersionDocx,
 ): Promise<ArrayBuffer> =>
-  await getS3()
-    .file(
-      createFileKey({
-        organizationId,
-        workspaceId: resolved.workspaceId,
-        fileId: resolved.fileId,
-        mimeType: DOCX_MIME_TYPE,
-      }),
-    )
-    .arrayBuffer();
+  await readS3ArrayBuffer(
+    createFileKey({
+      organizationId,
+      workspaceId: resolved.workspaceId,
+      fileId: resolved.fileId,
+      mimeType: DOCX_MIME_TYPE,
+    }),
+  );
 
 /**
  * Server-executed `compare_versions` chat tool: diff two entity versions'

--- a/apps/api/src/handlers/chat/upload-files.test.ts
+++ b/apps/api/src/handlers/chat/upload-files.test.ts
@@ -62,6 +62,7 @@ void mock.module("@/api/lib/s3", () => ({
   deleteS3ObjectWithSignal: s3DeleteMock,
   getS3: () => ({ delete: s3DeleteMock, file: fileMock, write: writeMock }),
   putS3ObjectWithSignal: writeMock,
+  readS3ArrayBuffer: arrayBufferMock,
 }));
 
 const {
@@ -124,7 +125,7 @@ describe("chat attachment hydration", () => {
       throw result.error;
     }
     expect(result.value.type).toBe("blocked");
-    expect(fileMock).not.toHaveBeenCalled();
+    expect(arrayBufferMock).not.toHaveBeenCalled();
   });
 
   test("hydrates non-extractable attachments as raw override when the user allows it", async () => {

--- a/apps/api/src/handlers/chat/upload-files.test.ts
+++ b/apps/api/src/handlers/chat/upload-files.test.ts
@@ -63,6 +63,9 @@ void mock.module("@/api/lib/s3", () => ({
   getS3: () => ({ delete: s3DeleteMock, file: fileMock, write: writeMock }),
   putS3ObjectWithSignal: writeMock,
   readS3ArrayBuffer: arrayBufferMock,
+  readCorpusS3Bytes: () => {
+    throw new Error("Unexpected corpus object read in this suite");
+  },
 }));
 
 const {

--- a/apps/api/src/handlers/chat/upload-files.ts
+++ b/apps/api/src/handlers/chat/upload-files.ts
@@ -45,7 +45,7 @@ import {
 } from "@/api/lib/files/image-derivative";
 import { createUserFileKey, deleteS3Keys } from "@/api/lib/files/utils";
 import { FILE_SIZE_LIMITS, LIMITS } from "@/api/lib/limits";
-import { getS3 } from "@/api/lib/s3";
+import { getS3, readS3ArrayBuffer } from "@/api/lib/s3";
 import { sanitizeFilename } from "@/api/lib/sanitize-filename";
 import { isUserFileUrl, toUserFileUrl } from "@/api/lib/user-files/types";
 import { DOCX_MIME_TYPE } from "@/api/mime-types";
@@ -343,7 +343,7 @@ export const hydrateFilePart = async ({
 
     const buffer = yield* Result.await(
       Result.tryPromise({
-        try: async () => await getS3().file(s3Key).arrayBuffer(),
+        try: async () => await readS3ArrayBuffer(s3Key),
         catch: (cause) =>
           new ChatError({
             message: "Failed to read chat attachment",

--- a/apps/api/src/handlers/clauses/template-slot-preview.ts
+++ b/apps/api/src/handlers/clauses/template-slot-preview.ts
@@ -21,7 +21,7 @@ import { tSafeId } from "@/api/lib/custom-schema";
 import { discoverClauseSlots } from "@/api/lib/docx/discover-clause-slots";
 import { resolveClauseSlotTexts } from "@/api/lib/docx/resolve-clause-slots";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
-import { getS3 } from "@/api/lib/s3";
+import { readS3ArrayBuffer } from "@/api/lib/s3";
 
 const templateSlotPreviewParamsSchema = t.Object({
   templateId: tSafeId("template"),
@@ -58,7 +58,7 @@ const getTemplateClausePreview = createSafeRootHandler(
       );
     }
 
-    const arrayBuf = await getS3().file(template.s3Key).arrayBuffer();
+    const arrayBuf = await readS3ArrayBuffer(template.s3Key);
     const slots = await discoverClauseSlots(Buffer.from(arrayBuf));
     const slotTexts = await resolveClauseSlotTexts(
       templateId,

--- a/apps/api/src/handlers/entities/compare-versions.ts
+++ b/apps/api/src/handlers/entities/compare-versions.ts
@@ -16,7 +16,7 @@ import { tSafeId, workspaceParams } from "@/api/lib/custom-schema";
 import { countVersionDiffWords } from "@/api/lib/entity-versions/version-diff-word-counts";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import { createFileKey } from "@/api/lib/files/utils";
-import { getS3 } from "@/api/lib/s3";
+import { readS3ArrayBuffer } from "@/api/lib/s3";
 import { DOCX_MIME_TYPE } from "@/api/mime-types";
 
 const config = {
@@ -115,26 +115,22 @@ export default createSafeHandler(
     // author concurrently; the author query runs in its own safeDb
     // transaction and does not depend on the file bytes.
     const [baseBuffer, targetBuffer, targetAuthorResult] = await Promise.all([
-      getS3()
-        .file(
-          createFileKey({
-            organizationId,
-            workspaceId,
-            fileId: baseFile.id,
-            mimeType: DOCX_MIME_TYPE,
-          }),
-        )
-        .arrayBuffer(),
-      getS3()
-        .file(
-          createFileKey({
-            organizationId,
-            workspaceId,
-            fileId: targetFile.id,
-            mimeType: DOCX_MIME_TYPE,
-          }),
-        )
-        .arrayBuffer(),
+      readS3ArrayBuffer(
+        createFileKey({
+          organizationId,
+          workspaceId,
+          fileId: baseFile.id,
+          mimeType: DOCX_MIME_TYPE,
+        }),
+      ),
+      readS3ArrayBuffer(
+        createFileKey({
+          organizationId,
+          workspaceId,
+          fileId: targetFile.id,
+          mimeType: DOCX_MIME_TYPE,
+        }),
+      ),
       safeDb((tx) =>
         tx
           .select({ userName: user.name })

--- a/apps/api/src/handlers/entities/copy-to-workspace.test.ts
+++ b/apps/api/src/handlers/entities/copy-to-workspace.test.ts
@@ -26,6 +26,15 @@ void mock.module("@/api/lib/s3", () => ({
   deleteS3ObjectWithSignal: s3DeleteMock,
   getS3: () => ({ delete: s3DeleteMock, file: fileMock, write: writeMock }),
   putS3ObjectWithSignal: writeMock,
+  // `mock.module` replaces the module, so every named export a consumer
+  // imports must exist here or the import fails at link time. This suite
+  // reads no object; throwing surfaces one that appears later.
+  readS3ArrayBuffer: () => {
+    throw new Error("Unexpected S3 object read in this suite");
+  },
+  readCorpusS3Bytes: () => {
+    throw new Error("Unexpected corpus object read in this suite");
+  },
 }));
 
 const processExtractionMock = mock(async () => {});

--- a/apps/api/src/handlers/entities/create-from-buffer.test.ts
+++ b/apps/api/src/handlers/entities/create-from-buffer.test.ts
@@ -30,6 +30,15 @@ let intentStatuses: string[] = [];
 void mock.module("@/api/lib/s3", () => ({
   deleteS3ObjectWithSignal: s3DeleteMock,
   putS3ObjectWithSignal: s3WriteMock,
+  // `mock.module` replaces the module, so every named export a consumer
+  // imports must exist here or the import fails at link time. This suite
+  // reads no object; throwing surfaces one that appears later.
+  readS3ArrayBuffer: () => {
+    throw new Error("Unexpected S3 object read in this suite");
+  },
+  readCorpusS3Bytes: () => {
+    throw new Error("Unexpected corpus object read in this suite");
+  },
 }));
 
 void mock.module("@/api/lib/search/process-extraction", () => ({

--- a/apps/api/src/handlers/entities/create-version-from-buffer.test.ts
+++ b/apps/api/src/handlers/entities/create-version-from-buffer.test.ts
@@ -32,6 +32,15 @@ void mock.module("@/api/lib/files/utils", () => ({
 void mock.module("@/api/lib/s3", () => ({
   deleteS3ObjectWithSignal: s3DeleteMock,
   putS3ObjectWithSignal: s3WriteMock,
+  // `mock.module` replaces the module, so every named export a consumer
+  // imports must exist here or the import fails at link time. This suite
+  // reads no object; throwing surfaces one that appears later.
+  readS3ArrayBuffer: () => {
+    throw new Error("Unexpected S3 object read in this suite");
+  },
+  readCorpusS3Bytes: () => {
+    throw new Error("Unexpected corpus object read in this suite");
+  },
 }));
 void mock.module("@/api/lib/search/process-extraction", () => ({
   processExtraction: processExtractionMock,

--- a/apps/api/src/handlers/entities/duplicate.test.ts
+++ b/apps/api/src/handlers/entities/duplicate.test.ts
@@ -27,6 +27,15 @@ void mock.module("@/api/lib/s3", () => ({
   deleteS3ObjectWithSignal: s3DeleteMock,
   getS3: () => ({ delete: s3DeleteMock, file: fileMock, write: writeMock }),
   putS3ObjectWithSignal: writeMock,
+  // `mock.module` replaces the module, so every named export a consumer
+  // imports must exist here or the import fails at link time. This suite
+  // reads no object; throwing surfaces one that appears later.
+  readS3ArrayBuffer: () => {
+    throw new Error("Unexpected S3 object read in this suite");
+  },
+  readCorpusS3Bytes: () => {
+    throw new Error("Unexpected corpus object read in this suite");
+  },
 }));
 
 const { default: duplicateEntity } = await import("./duplicate");

--- a/apps/api/src/handlers/entities/finalize-desktop-edit-session.ts
+++ b/apps/api/src/handlers/entities/finalize-desktop-edit-session.ts
@@ -375,7 +375,10 @@ export const finalizeDesktopEditSessionHandler = async ({
         } as const;
       }
 
-      const checkpointBuffer = await readS3ArrayBuffer(checkpointKey);
+      const checkpointBuffer = await readS3ArrayBuffer(
+        checkpointKey,
+        request.signal,
+      );
 
       const validation = await validateDocxBuffer(checkpointBuffer);
       if (!validation.valid) {

--- a/apps/api/src/handlers/entities/finalize-desktop-edit-session.ts
+++ b/apps/api/src/handlers/entities/finalize-desktop-edit-session.ts
@@ -42,7 +42,7 @@ import {
 } from "@/api/lib/files/file-object-ids";
 import { pdfDerivativeStateForFile } from "@/api/lib/files/gotenberg";
 import { createFileKey } from "@/api/lib/files/utils";
-import { getS3 } from "@/api/lib/s3";
+import { getS3, readS3ArrayBuffer } from "@/api/lib/s3";
 import { brandPersistedUserId } from "@/api/lib/safe-id-boundaries";
 import { processExtraction } from "@/api/lib/search/process-extraction";
 import { broadcast } from "@/api/lib/sse";
@@ -375,7 +375,7 @@ export const finalizeDesktopEditSessionHandler = async ({
         } as const;
       }
 
-      const checkpointBuffer = await getS3().file(checkpointKey).arrayBuffer();
+      const checkpointBuffer = await readS3ArrayBuffer(checkpointKey);
 
       const validation = await validateDocxBuffer(checkpointBuffer);
       if (!validation.valid) {

--- a/apps/api/src/handlers/entities/translate.test.ts
+++ b/apps/api/src/handlers/entities/translate.test.ts
@@ -53,13 +53,11 @@ void mock.module("@/api/lib/content-encryption", () => ({
 void mock.module("@/api/lib/s3", () => ({
   deleteS3ObjectWithSignal: s3DeleteMock,
   getS3: () => ({
-    file: () => ({
-      arrayBuffer: async () => new Uint8Array([80, 75, 3, 4]).buffer,
-    }),
     write: s3WriteMock,
     delete: s3DeleteMock,
   }),
   putS3ObjectWithSignal: s3WriteMock,
+  readS3ArrayBuffer: async () => new Uint8Array([80, 75, 3, 4]).buffer,
 }));
 
 void mock.module("@/api/lib/file-scan/scan", () => ({

--- a/apps/api/src/handlers/entities/translate.test.ts
+++ b/apps/api/src/handlers/entities/translate.test.ts
@@ -58,6 +58,9 @@ void mock.module("@/api/lib/s3", () => ({
   }),
   putS3ObjectWithSignal: s3WriteMock,
   readS3ArrayBuffer: async () => new Uint8Array([80, 75, 3, 4]).buffer,
+  readCorpusS3Bytes: () => {
+    throw new Error("Unexpected corpus object read in this suite");
+  },
 }));
 
 void mock.module("@/api/lib/file-scan/scan", () => ({

--- a/apps/api/src/handlers/entities/translate.ts
+++ b/apps/api/src/handlers/entities/translate.ts
@@ -179,9 +179,8 @@ const translateEntity = createSafeHandler(
       );
     }
 
-    // 3. Fetch source bytes from S3 directly — Bun's S3Client
-    // streams bytes from the SDK and avoids a presign + public-
-    // network round-trip (and the matching NAT egress).
+    // 3. Fetch source bytes through a presigned GET to avoid Bun's leaking
+    // native S3 download path.
     const sourceKey = createFileKey({
       organizationId: session.activeOrganizationId,
       workspaceId,

--- a/apps/api/src/handlers/entities/translate.ts
+++ b/apps/api/src/handlers/entities/translate.ts
@@ -33,7 +33,7 @@ import { createEntityFromBuffer } from "@/api/lib/entities/create-from-buffer";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import { getScanWarnings, scanFile } from "@/api/lib/file-scan/scan";
 import { createFileKey } from "@/api/lib/files/utils";
-import { getS3 } from "@/api/lib/s3";
+import { readS3ArrayBuffer } from "@/api/lib/s3";
 import { DOC_MIME_TYPE, DOCX_MIME_TYPE, PDF_MIME_TYPE } from "@/api/mime-types";
 
 // Mime types DeepL's /v2/document endpoint accepts. Anything
@@ -190,8 +190,7 @@ const translateEntity = createSafeHandler(
     });
 
     const sourceBytesResult = await Result.tryPromise({
-      try: async () =>
-        new Uint8Array(await getS3().file(sourceKey).arrayBuffer()),
+      try: async () => new Uint8Array(await readS3ArrayBuffer(sourceKey)),
       catch: (error: unknown) => error,
     });
 

--- a/apps/api/src/handlers/entities/version-diff-sources.ts
+++ b/apps/api/src/handlers/entities/version-diff-sources.ts
@@ -17,7 +17,7 @@ import type { SafeId } from "@/api/lib/branded-types";
 import { extractText } from "@/api/lib/docx/extract-text";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import { createFileKey } from "@/api/lib/files/utils";
-import { getS3 } from "@/api/lib/s3";
+import { readS3ArrayBuffer } from "@/api/lib/s3";
 import { DOCX_MIME_TYPE } from "@/api/mime-types";
 
 type LoadEntityVersionDiffSourcesOptions = {
@@ -145,16 +145,14 @@ export const loadEntityVersionDiffSources = async function* ({
     Result.tryPromise({
       try: async () => {
         const toText = async (fileId: string) => {
-          const buffer = await getS3()
-            .file(
-              createFileKey({
-                organizationId,
-                workspaceId,
-                fileId,
-                mimeType: DOCX_MIME_TYPE,
-              }),
-            )
-            .arrayBuffer();
+          const buffer = await readS3ArrayBuffer(
+            createFileKey({
+              organizationId,
+              workspaceId,
+              fileId,
+              mimeType: DOCX_MIME_TYPE,
+            }),
+          );
           const extracted = await extractText(new Uint8Array(buffer));
           return extracted.paragraphs.map((p) => p.text).join("\n");
         };
@@ -236,16 +234,14 @@ export const loadEntityVersionDocxText = async function* ({
   const text = yield* Result.await(
     Result.tryPromise({
       try: async () => {
-        const buffer = await getS3()
-          .file(
-            createFileKey({
-              organizationId,
-              workspaceId,
-              fileId: file.id,
-              mimeType: DOCX_MIME_TYPE,
-            }),
-          )
-          .arrayBuffer();
+        const buffer = await readS3ArrayBuffer(
+          createFileKey({
+            organizationId,
+            workspaceId,
+            fileId: file.id,
+            mimeType: DOCX_MIME_TYPE,
+          }),
+        );
         const extracted = await extractText(new Uint8Array(buffer));
         return extracted.paragraphs.map((p) => p.text).join("\n");
       },

--- a/apps/api/src/handlers/files/get.ts
+++ b/apps/api/src/handlers/files/get.ts
@@ -23,7 +23,7 @@ import {
   isNativelyRenderableMimeType,
 } from "@/api/lib/files/gotenberg";
 import { createFileKey } from "@/api/lib/files/utils";
-import { getS3 } from "@/api/lib/s3";
+import { getS3, readS3ArrayBuffer } from "@/api/lib/s3";
 import { presignDownloadUrl } from "@/api/lib/s3-presign";
 import { RAW_DOCUMENT_RESPONSE_SECURITY_HEADERS } from "@/api/lib/security-headers";
 import { PDF_MIME_TYPE } from "@/api/mime-types";
@@ -253,7 +253,7 @@ export const readEmailHtmlPreviewHandler = async ({
     fileId: content.id,
     mimeType: content.mimeType,
   });
-  const fileBuffer = await getS3().file(fileKey).arrayBuffer();
+  const fileBuffer = await readS3ArrayBuffer(fileKey);
   const htmlResult = await emailToHtml(fileBuffer, emailMimeType);
 
   if (Result.isError(htmlResult)) {

--- a/apps/api/src/handlers/folio-collab/finalize.ts
+++ b/apps/api/src/handlers/folio-collab/finalize.ts
@@ -39,7 +39,7 @@ import {
   permissiveBodySchema,
   permissiveRouteSchema,
 } from "@/api/lib/permissive-route-schema";
-import { getS3 } from "@/api/lib/s3";
+import { getS3, readS3ArrayBuffer } from "@/api/lib/s3";
 import { processExtraction } from "@/api/lib/search/process-extraction";
 import { broadcast } from "@/api/lib/sse";
 import { DOCX_MIME_TYPE } from "@/api/mime-types";
@@ -236,7 +236,7 @@ const finalizeFolioCollabSession = createSafeTokenHandler<
   // Phase B: heavy IO + DOCX validation, all OUTSIDE the txn. The
   // source bytes are written to S3 before we open the txn; any
   // commit failure rolls them back via uploadedKeys.
-  const checkpointBuffer = await getS3().file(checkpointKey).arrayBuffer();
+  const checkpointBuffer = await readS3ArrayBuffer(checkpointKey);
   const validation = await validateDocxBuffer(checkpointBuffer);
   if (!validation.valid) {
     return Result.err(

--- a/apps/api/src/handlers/templates/check.ts
+++ b/apps/api/src/handlers/templates/check.ts
@@ -12,7 +12,7 @@ import { discoverTemplate } from "@/api/lib/docx/discover-template";
 import { extractText } from "@/api/lib/docx/extract-text";
 import { readManifest } from "@/api/lib/docx/template-manifest";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
-import { getS3 } from "@/api/lib/s3";
+import { readS3ArrayBuffer } from "@/api/lib/s3";
 import { listTemplateClausesHandler } from "@/api/lib/template-clause-links";
 
 const checkTemplateParamsSchema = t.Object({
@@ -50,7 +50,7 @@ const checkTemplateHandler = async function* ({
     );
   }
 
-  const buffer = Buffer.from(await getS3().file(template.s3Key).arrayBuffer());
+  const buffer = Buffer.from(await readS3ArrayBuffer(template.s3Key));
 
   const [discovered, manifest, clauseSlots, extracted] = await Promise.all([
     discoverTemplate(buffer),

--- a/apps/api/src/handlers/templates/clause-slots.ts
+++ b/apps/api/src/handlers/templates/clause-slots.ts
@@ -14,7 +14,7 @@ import { tSafeId } from "@/api/lib/custom-schema";
 import { discoverClauseSlots } from "@/api/lib/docx/discover-clause-slots";
 import { resolveClauseSlotBodies } from "@/api/lib/docx/resolve-clause-slots";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
-import { getS3 } from "@/api/lib/s3";
+import { readS3ArrayBuffer } from "@/api/lib/s3";
 
 const clauseSlotsParamsSchema = t.Object({
   templateId: tSafeId("template"),
@@ -50,7 +50,7 @@ const getTemplateClauseSlots = createSafeRootHandler(
       );
     }
 
-    const arrayBuf = await getS3().file(template.s3Key).arrayBuffer();
+    const arrayBuf = await readS3ArrayBuffer(template.s3Key);
     const slots = await discoverClauseSlots(Buffer.from(arrayBuf));
     if (slots.length === 0) {
       return Result.ok({ slots: [] });

--- a/apps/api/src/handlers/templates/configure-template-fields-service.ts
+++ b/apps/api/src/handlers/templates/configure-template-fields-service.ts
@@ -28,7 +28,7 @@ import {
 } from "@/api/lib/docx/template-manifest";
 import type { FieldMeta, TemplateManifest } from "@/api/lib/docx/types";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
-import { getS3 } from "@/api/lib/s3";
+import { getS3, readS3ArrayBuffer } from "@/api/lib/s3";
 
 type ConfigureTemplateFieldsOptions = {
   safeDb: SafeDb;
@@ -104,9 +104,7 @@ export const configureTemplateFields = async function* ({
         return { ok: false as const, reason: "not-found" as const };
       }
 
-      const buffer = Buffer.from(
-        await getS3().file(locked.s3Key).arrayBuffer(),
-      );
+      const buffer = Buffer.from(await readS3ArrayBuffer(locked.s3Key));
 
       // Prefer the manifest embedded in the stored DOCX; fall back to the DB
       // column and finally to a fresh discovery so a manifest-less raw upload

--- a/apps/api/src/handlers/templates/fill-by-id.ts
+++ b/apps/api/src/handlers/templates/fill-by-id.ts
@@ -36,7 +36,7 @@ import { isTemplateData } from "@/api/lib/docx/types";
 import type { RichPatchValue } from "@/api/lib/docx/types";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import { convertToPdf } from "@/api/lib/files/gotenberg";
-import { getS3 } from "@/api/lib/s3";
+import { readS3ArrayBuffer } from "@/api/lib/s3";
 import { DOCX_EXT_RE } from "@/api/lib/sanitize-filename";
 import { recordTemplateUse } from "@/api/lib/templates/record-use";
 import { containsNull } from "@/api/lib/templates/template-data";
@@ -171,8 +171,7 @@ const fillByIdHandler = async function* ({
     );
   }
 
-  const s3File = getS3().file(template.s3Key);
-  const arrayBuf = await s3File.arrayBuffer();
+  const arrayBuf = await readS3ArrayBuffer(template.s3Key);
   const buffer = Buffer.from(arrayBuf);
 
   // Discover/resolve clause slots ({{@clause:...}}) and apply per-fill overrides.

--- a/apps/api/src/handlers/templates/fill-preview.ts
+++ b/apps/api/src/handlers/templates/fill-preview.ts
@@ -29,7 +29,7 @@ import { resolveClauseSlots } from "@/api/lib/docx/resolve-clause-slots";
 import { readManifest } from "@/api/lib/docx/template-manifest";
 import { isTemplateData } from "@/api/lib/docx/types";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
-import { getS3 } from "@/api/lib/s3";
+import { readS3ArrayBuffer } from "@/api/lib/s3";
 import { containsNull } from "@/api/lib/templates/template-data";
 import { isRecord } from "@/api/lib/type-guards";
 
@@ -108,8 +108,7 @@ const fillPreviewHandler = async function* ({
     );
   }
 
-  const s3File = getS3().file(template.s3Key);
-  const arrayBuf = await s3File.arrayBuffer();
+  const arrayBuf = await readS3ArrayBuffer(template.s3Key);
   const buffer = Buffer.from(arrayBuf);
 
   // Resolve clause slots before filling

--- a/apps/api/src/handlers/templates/prefill.ts
+++ b/apps/api/src/handlers/templates/prefill.ts
@@ -28,7 +28,7 @@ import {
 } from "@/api/lib/docx/template-manifest";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import { FILE_SIZE_LIMITS } from "@/api/lib/limits";
-import { getS3 } from "@/api/lib/s3";
+import { readS3ArrayBuffer } from "@/api/lib/s3";
 import { parsePickedEntityIdsJson } from "@/api/lib/safe-id-boundaries";
 import { extractFileText } from "@/api/lib/search/extract-content";
 import { generateTanStackObjectForRole } from "@/api/lib/tanstack-ai-generate";
@@ -334,9 +334,7 @@ const prefillTemplate = createSafeRootHandler(
     const targets = yield* Result.await(
       Result.tryPromise({
         try: async () => {
-          const buffer = Buffer.from(
-            await getS3().file(template.s3Key).arrayBuffer(),
-          );
+          const buffer = Buffer.from(await readS3ArrayBuffer(template.s3Key));
           const [discovered, manifest] = await Promise.all([
             discoverTemplate(buffer),
             readManifest(buffer),

--- a/apps/api/src/handlers/templates/preview.ts
+++ b/apps/api/src/handlers/templates/preview.ts
@@ -10,7 +10,7 @@ import { discoverClauseSlots } from "@/api/lib/docx/discover-clause-slots";
 import { discoverTemplate } from "@/api/lib/docx/discover-template";
 import { extractText } from "@/api/lib/docx/extract-text";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
-import { getS3 } from "@/api/lib/s3";
+import { readS3ArrayBuffer } from "@/api/lib/s3";
 
 const previewTemplateParamsSchema = t.Object({
   templateId: tSafeId("template"),
@@ -45,7 +45,7 @@ const previewTemplateHandler = async function* ({
     );
   }
 
-  const buffer = Buffer.from(await getS3().file(template.s3Key).arrayBuffer());
+  const buffer = Buffer.from(await readS3ArrayBuffer(template.s3Key));
 
   const [{ paragraphs, charCount }, { structureErrors }, clauseSlots] =
     await Promise.all([

--- a/apps/api/src/handlers/templates/update.ts
+++ b/apps/api/src/handlers/templates/update.ts
@@ -18,7 +18,7 @@ import { isTemplateManifest } from "@/api/lib/docx/types";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import { LIMITS } from "@/api/lib/limits";
 import { pickDefined } from "@/api/lib/pick-defined";
-import { getS3 } from "@/api/lib/s3";
+import { getS3, readS3ArrayBuffer } from "@/api/lib/s3";
 import { buildTemplateVersionS3Key } from "@/api/lib/templates/storage-keys";
 import {
   MAX_TEMPLATE_LANGUAGES,
@@ -220,7 +220,7 @@ const updateTemplateHandler = async function* ({
 
         // Re-embed the manifest in the DOCX so the S3 file
         // stays in sync with the DB.
-        const docxBuffer = await getS3().file(locked.s3Key).arrayBuffer();
+        const docxBuffer = await readS3ArrayBuffer(locked.s3Key);
         const updatedDocx = await writeManifest(
           Buffer.from(docxBuffer),
           manifest,

--- a/apps/api/src/handlers/templates/versions-diff.test.ts
+++ b/apps/api/src/handlers/templates/versions-diff.test.ts
@@ -18,20 +18,13 @@ const realS3 = await import("@/api/lib/s3");
 
 void mock.module("@/api/lib/s3", () => ({
   ...realS3,
-  getS3: () => ({
-    file: (key: string) => ({
-      arrayBuffer: async () => {
-        const buf = s3Objects.get(key);
-        if (!buf) {
-          throw new Error(`Missing S3 object: ${key}`);
-        }
-        return buf.buffer.slice(
-          buf.byteOffset,
-          buf.byteOffset + buf.byteLength,
-        );
-      },
-    }),
-  }),
+  readS3ArrayBuffer: async (key: string) => {
+    const buf = s3Objects.get(key);
+    if (!buf) {
+      throw new Error(`Missing S3 object: ${key}`);
+    }
+    return buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength);
+  },
 }));
 
 const { loadTemplateVersionDiffSources } = await import("./versions");

--- a/apps/api/src/handlers/templates/versions.ts
+++ b/apps/api/src/handlers/templates/versions.ts
@@ -11,7 +11,7 @@ import {
   decodePaginationCursor,
   encodePaginationCursor,
 } from "@/api/lib/pagination";
-import { getS3 } from "@/api/lib/s3";
+import { readS3ArrayBuffer } from "@/api/lib/s3";
 import { presignDownloadUrl } from "@/api/lib/s3-presign";
 
 /** Presigned download URLs expire after 15 minutes, matching every
@@ -266,10 +266,10 @@ export const loadTemplateVersionDiffSources = async ({
   const previousS3Key = previous.at(0)?.s3Key ?? null;
 
   const [currentBuffer, prevBuffer] = await Promise.all([
-    getS3().file(version.s3Key).arrayBuffer(),
+    readS3ArrayBuffer(version.s3Key),
     previousS3Key === null
       ? Promise.resolve(null)
-      : getS3().file(previousS3Key).arrayBuffer(),
+      : readS3ArrayBuffer(previousS3Key),
   ]);
 
   const [currentText, prevText] = await Promise.all([

--- a/apps/api/src/handlers/uploads/presigned-upload.integration.test.ts
+++ b/apps/api/src/handlers/uploads/presigned-upload.integration.test.ts
@@ -28,10 +28,8 @@ void mock.module("@/api/lib/s3", () => ({
   ...realS3,
   getS3: () => ({
     delete: deleteObjectMock,
-    file: () => ({
-      arrayBuffer: async () => new ArrayBuffer(0),
-    }),
   }),
+  readS3ArrayBuffer: async () => new ArrayBuffer(0),
 }));
 
 const { default: abortUpload } = await import("./delete");

--- a/apps/api/src/handlers/uploads/update.ts
+++ b/apps/api/src/handlers/uploads/update.ts
@@ -39,7 +39,7 @@ import type { SafeId } from "@/api/lib/branded-types";
 import { tSafeId } from "@/api/lib/custom-schema";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import { scanFile } from "@/api/lib/file-scan/scan";
-import { getS3 } from "@/api/lib/s3";
+import { getS3, readS3ArrayBuffer } from "@/api/lib/s3";
 import type { HeadObjectResult, S3PresignError } from "@/api/lib/s3-presign";
 import { copyObject, headObject } from "@/api/lib/s3-presign";
 import { finalizeEntityCreate } from "@/api/lib/uploads/entity-create";
@@ -414,7 +414,7 @@ const runFinalize = async function* ({
   }
 
   // 3. Download for scan.
-  const fileBuffer = await getS3().file(tmpKey).arrayBuffer();
+  const fileBuffer = await readS3ArrayBuffer(tmpKey);
   if (!head.checksumSHA256) {
     const uploadedSha256 = new Bun.CryptoHasher("sha256")
       .update(fileBuffer)

--- a/apps/api/src/handlers/workspaces/duplicate.test.ts
+++ b/apps/api/src/handlers/workspaces/duplicate.test.ts
@@ -31,6 +31,15 @@ void mock.module("@/api/lib/s3", () => ({
     write: s3WriteMock,
   }),
   putS3ObjectWithSignal: s3WriteMock,
+  // `mock.module` replaces the module, so every named export a consumer
+  // imports must exist here or the import fails at link time. This suite
+  // reads no object; throwing surfaces one that appears later.
+  readS3ArrayBuffer: () => {
+    throw new Error("Unexpected S3 object read in this suite");
+  },
+  readCorpusS3Bytes: () => {
+    throw new Error("Unexpected corpus object read in this suite");
+  },
 }));
 
 const processExtractionMock = mock(async () => undefined);

--- a/apps/api/src/lib/bbox/generate-b-boxes-shared.ts
+++ b/apps/api/src/lib/bbox/generate-b-boxes-shared.ts
@@ -13,7 +13,7 @@ import type { BBoxItem } from "@/api/lib/bbox/ai-prompts";
 import type { SafeId } from "@/api/lib/branded-types";
 import type { WorkflowIntegrationError } from "@/api/lib/errors/tagged-errors";
 import { createFileKey } from "@/api/lib/files/utils";
-import { getS3 } from "@/api/lib/s3";
+import { readS3ArrayBuffer } from "@/api/lib/s3";
 import { PDF_MIME_TYPE } from "@/api/mime-types";
 import type { BoundingBox } from "@/api/types";
 
@@ -261,7 +261,7 @@ export const prepareJustificationData = async (
       mimeType: PDF_MIME_TYPE,
     });
 
-    const fileBuffer = await getS3().file(fileKey).arrayBuffer();
+    const fileBuffer = await readS3ArrayBuffer(fileKey);
     const pdf = await PDF.load(new Uint8Array(fileBuffer));
 
     return Result.ok({

--- a/apps/api/src/lib/document-processing-queue.test.ts
+++ b/apps/api/src/lib/document-processing-queue.test.ts
@@ -126,7 +126,7 @@ describe("OCR derivative durability", () => {
 
     expect(stageStart).toBeGreaterThan(-1);
     for (const storageCall of [
-      "getS3().file(sourceKey).arrayBuffer()",
+      "readS3ArrayBuffer(sourceKey, lifecycleSignal)",
       "await createOcrSearchablePdf(",
       "await getS3().write(",
     ]) {

--- a/apps/api/src/lib/document-processing-queue.ts
+++ b/apps/api/src/lib/document-processing-queue.ts
@@ -58,7 +58,7 @@ import {
   createBullMqConnection,
   createRedisClient,
 } from "@/api/lib/redis-client";
-import { getS3 } from "@/api/lib/s3";
+import { getS3, readS3ArrayBuffer } from "@/api/lib/s3";
 import { presignDownloadUrl } from "@/api/lib/s3-presign";
 import {
   executeNativeExtraction,
@@ -190,7 +190,7 @@ const writeOcrSearchablePdfDerivative = async ({
 }): Promise<void> => {
   const written = await Result.tryPromise({
     try: async () => {
-      const sourceBuffer = await getS3().file(sourceKey).arrayBuffer();
+      const sourceBuffer = await readS3ArrayBuffer(sourceKey);
       lifecycleSignal.throwIfAborted();
       const searchablePdf = await createOcrSearchablePdf(sourceBuffer, payload);
       if (Result.isError(searchablePdf)) {

--- a/apps/api/src/lib/document-processing-queue.ts
+++ b/apps/api/src/lib/document-processing-queue.ts
@@ -190,7 +190,7 @@ const writeOcrSearchablePdfDerivative = async ({
 }): Promise<void> => {
   const written = await Result.tryPromise({
     try: async () => {
-      const sourceBuffer = await readS3ArrayBuffer(sourceKey);
+      const sourceBuffer = await readS3ArrayBuffer(sourceKey, lifecycleSignal);
       lifecycleSignal.throwIfAborted();
       const searchablePdf = await createOcrSearchablePdf(sourceBuffer, payload);
       if (Result.isError(searchablePdf)) {

--- a/apps/api/src/lib/entity-versions/compute-version-diff.ts
+++ b/apps/api/src/lib/entity-versions/compute-version-diff.ts
@@ -8,7 +8,7 @@ import type { FieldContent } from "@/api/db/schema-validators";
 import type { SafeId } from "@/api/lib/branded-types";
 import { countVersionDiffWords } from "@/api/lib/entity-versions/version-diff-word-counts";
 import { createFileKey } from "@/api/lib/files/utils";
-import { getS3 } from "@/api/lib/s3";
+import { readS3ArrayBuffer } from "@/api/lib/s3";
 import { DOCX_MIME_TYPE } from "@/api/mime-types";
 
 const VERSION_DIFF_STATS_SCOPES = ["text"] as const;
@@ -116,26 +116,22 @@ export const computeVersionDiffStats = async ({
 
   // Download both DOCX files
   const [newBuffer, prevBuffer] = await Promise.all([
-    getS3()
-      .file(
-        createFileKey({
-          organizationId,
-          workspaceId,
-          fileId: newFile.id,
-          mimeType: DOCX_MIME_TYPE,
-        }),
-      )
-      .arrayBuffer(),
-    getS3()
-      .file(
-        createFileKey({
-          organizationId,
-          workspaceId,
-          fileId: prevFile.id,
-          mimeType: DOCX_MIME_TYPE,
-        }),
-      )
-      .arrayBuffer(),
+    readS3ArrayBuffer(
+      createFileKey({
+        organizationId,
+        workspaceId,
+        fileId: newFile.id,
+        mimeType: DOCX_MIME_TYPE,
+      }),
+    ),
+    readS3ArrayBuffer(
+      createFileKey({
+        organizationId,
+        workspaceId,
+        fileId: prevFile.id,
+        mimeType: DOCX_MIME_TYPE,
+      }),
+    ),
   ]);
 
   const diff = await compareDocxVersions(prevBuffer, newBuffer, {

--- a/apps/api/src/lib/entity-versions/load-entity-version-docx-buffer.ts
+++ b/apps/api/src/lib/entity-versions/load-entity-version-docx-buffer.ts
@@ -16,7 +16,7 @@ import type { SafeId } from "@/api/lib/branded-types";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import { createFileKey } from "@/api/lib/files/utils";
 import { LIMITS } from "@/api/lib/limits";
-import { getS3 } from "@/api/lib/s3";
+import { readS3ArrayBuffer } from "@/api/lib/s3";
 import { DOCX_MIME_TYPE } from "@/api/mime-types";
 
 type LoadEntityVersionDocxBufferOptions = {
@@ -156,16 +156,14 @@ export const loadEntityVersionDocxBuffer = async ({
 
   const bufferResult = await Result.tryPromise({
     try: async () =>
-      await getS3()
-        .file(
-          createFileKey({
-            organizationId,
-            workspaceId,
-            fileId: fileContent.id,
-            mimeType: DOCX_MIME_TYPE,
-          }),
-        )
-        .arrayBuffer(),
+      await readS3ArrayBuffer(
+        createFileKey({
+          organizationId,
+          workspaceId,
+          fileId: fileContent.id,
+          mimeType: DOCX_MIME_TYPE,
+        }),
+      ),
     catch: (cause) =>
       new HandlerError({
         status: 500,

--- a/apps/api/src/lib/file-derivative-queue.ts
+++ b/apps/api/src/lib/file-derivative-queue.ts
@@ -23,7 +23,7 @@ import { createFileKey } from "@/api/lib/files/utils";
 import { logger } from "@/api/lib/observability/logger";
 import { createBullMqConnection } from "@/api/lib/redis-client";
 import { createRootScopedDb } from "@/api/lib/root-scoped-db";
-import { getS3 } from "@/api/lib/s3";
+import { getS3, readS3ArrayBuffer } from "@/api/lib/s3";
 import {
   brandPersistedEntityId,
   brandPersistedFieldId,
@@ -384,7 +384,7 @@ const processPdfDerivativeJob = async ({
 };
 
 const getS3File = async (key: string): Promise<ArrayBuffer> =>
-  await getS3().file(key).arrayBuffer();
+  await readS3ArrayBuffer(key);
 
 // The derivative-state literals below cast `::text::jsonb`, never a bare
 // `::jsonb`. A bare cast fixes the bind parameter's type to jsonb, so the

--- a/apps/api/src/lib/flows/flow-run-worker.integration.test.ts
+++ b/apps/api/src/lib/flows/flow-run-worker.integration.test.ts
@@ -103,6 +103,15 @@ void mock.module("@/api/lib/s3", () => ({
   deleteS3ObjectWithSignal: s3DeleteMock,
   getS3: () => ({ write: s3WriteMock, delete: s3DeleteMock }),
   putS3ObjectWithSignal: s3WriteMock,
+  // `mock.module` replaces the module, so every named export a consumer
+  // imports must exist here or the import fails at link time. This suite
+  // reads no object; throwing surfaces one that appears later.
+  readS3ArrayBuffer: () => {
+    throw new Error("Unexpected S3 object read in this suite");
+  },
+  readCorpusS3Bytes: () => {
+    throw new Error("Unexpected corpus object read in this suite");
+  },
 }));
 
 void mock.module("@/api/lib/search/process-extraction", () => ({

--- a/apps/api/src/lib/flows/load-input-documents.test.ts
+++ b/apps/api/src/lib/flows/load-input-documents.test.ts
@@ -45,6 +45,15 @@ void mock.module("@/api/lib/s3", () => ({
   deleteS3ObjectWithSignal: mock(async () => undefined),
   getS3: () => ({ write: mock(async () => {}), delete: mock(async () => {}) }),
   putS3ObjectWithSignal: mock(async () => undefined),
+  // `mock.module` replaces the module, so every named export a consumer
+  // imports must exist here or the import fails at link time. This suite
+  // reads no object; throwing surfaces one that appears later.
+  readS3ArrayBuffer: () => {
+    throw new Error("Unexpected S3 object read in this suite");
+  },
+  readCorpusS3Bytes: () => {
+    throw new Error("Unexpected corpus object read in this suite");
+  },
 }));
 void mock.module("@/api/lib/search/process-extraction", () => ({
   processExtraction: mock(async () => {}),

--- a/apps/api/src/lib/folio-collab-sessions.ts
+++ b/apps/api/src/lib/folio-collab-sessions.ts
@@ -19,7 +19,7 @@ import type { SafeId } from "@/api/lib/branded-types";
 import { createFileKey } from "@/api/lib/files/utils";
 import { isMemberRole } from "@/api/lib/member-roles";
 import { createRootScopedDb } from "@/api/lib/root-scoped-db";
-import { getS3 } from "@/api/lib/s3";
+import { getS3, readS3ArrayBuffer } from "@/api/lib/s3";
 import { brandPersistedUserId } from "@/api/lib/safe-id-boundaries";
 import { DOCX_MIME_TYPE } from "@/api/mime-types";
 
@@ -400,7 +400,7 @@ export const loadFolioCollabSnapshot = async (
     organizationId: value.organizationId,
     workspaceId: value.workspaceId,
   });
-  const buffer = await getS3().file(key).arrayBuffer();
+  const buffer = await readS3ArrayBuffer(key);
 
   return Buffer.from(buffer).toString("base64");
 };

--- a/apps/api/src/lib/legal-search/corpus-storage.ts
+++ b/apps/api/src/lib/legal-search/corpus-storage.ts
@@ -17,8 +17,8 @@ import type {
 import { LIMITS } from "@/api/lib/limits";
 import {
   deleteCorpusS3ObjectWithSignal,
-  getCorpusS3,
   putCorpusS3ObjectWithSignal,
+  readCorpusS3Bytes,
 } from "@/api/lib/s3";
 import { withTimeout } from "@/api/lib/with-timeout";
 
@@ -345,7 +345,7 @@ export const readCorpusText = async (
 ): Promise<string> => {
   const bytes = await boundedCorpusIo(
     "corpus-read-text",
-    read ?? (async () => await getCorpusS3().file(key).bytes()),
+    read ?? (async (signal) => await readCorpusS3Bytes(key, signal)),
     { timeoutMs },
   );
   return await zstdDecompressToStringBounded(bytes, PAYLOAD_MAX_BYTES);
@@ -356,7 +356,7 @@ export const readCorpusSections = async (
 ): Promise<DecisionSection[] | null> => {
   const bytes = await boundedCorpusIo(
     "corpus-read-sections",
-    async () => await getCorpusS3().file(key).bytes(),
+    async (signal) => await readCorpusS3Bytes(key, signal),
   );
   // eslint-disable-next-line typescript/no-unsafe-assignment -- decompressed corpus JSON written by this module
   const parsed: DecisionSection[] | null = JSON.parse(
@@ -370,7 +370,7 @@ export const readCorpusAst = async (
 ): Promise<DocumentAst | EmptyAst | null> => {
   const bytes = await boundedCorpusIo(
     "corpus-read-ast",
-    async () => await getCorpusS3().file(key).bytes(),
+    async (signal) => await readCorpusS3Bytes(key, signal),
   );
   // eslint-disable-next-line typescript/no-unsafe-assignment -- decompressed corpus JSON written by this module
   const parsed: DocumentAst | EmptyAst | null = JSON.parse(

--- a/apps/api/src/lib/s3.ts
+++ b/apps/api/src/lib/s3.ts
@@ -10,6 +10,7 @@ import { S3Client } from "bun";
 import { envBase } from "@/api/env-base";
 import { contentDisposition } from "@/api/lib/content-disposition";
 import { safeErrorCode } from "@/api/lib/errors/utils";
+import { fetchWithTimeout } from "@/api/lib/fetch";
 import { withTimeout } from "@/api/lib/with-timeout";
 
 type S3Credentials = {
@@ -583,6 +584,7 @@ export const getCorpusS3 = (): S3Client => {
 // The signed URL is consumed by the very next statement, so it only has to
 // outlive one read.
 const OBJECT_READ_PRESIGN_TTL_SECONDS = 300;
+const OBJECT_READ_TIMEOUT_MS = 5 * 60 * 1000;
 
 /**
  * Fetch an object body over a presigned URL.
@@ -621,9 +623,9 @@ const fetchObject = async (
   key: string,
   signal?: AbortSignal,
 ): Promise<Response> => {
-  const response = await fetch(
+  const response = await fetchWithTimeout(
     client.presign(key, { expiresIn: OBJECT_READ_PRESIGN_TTL_SECONDS }),
-    signal ? { signal } : {},
+    { signal, timeoutMs: OBJECT_READ_TIMEOUT_MS },
   );
   if (!response.ok) {
     throw new S3ObjectReadError({

--- a/apps/api/src/lib/s3.ts
+++ b/apps/api/src/lib/s3.ts
@@ -580,6 +580,66 @@ export const getCorpusS3 = (): S3Client => {
   return _corpusClient;
 };
 
+/** A corpus object read returned a non-success status. */
+export class CorpusObjectReadError extends TaggedError(
+  "CorpusObjectReadError",
+)<{
+  message: string;
+  key: string;
+  status: number;
+}> {}
+
+// The presigned URL is consumed by the very next statement, so this only has
+// to outlive one bounded read.
+const CORPUS_READ_PRESIGN_TTL_SECONDS = 300;
+
+/**
+ * Read a corpus object's bytes.
+ *
+ * Deliberately NOT `getCorpusS3().file(key).bytes()`. Up to and including Bun
+ * 1.3.14, that call never frees the native buffer the HTTP thread accumulates
+ * the body into: the handler receives the bytes with `.clone` lifetime, JS
+ * gets its own copy, and the original allocation is leaked
+ * (oven-sh/bun#29083, fixed by oven-sh/bun#29086 and #29923). Because the
+ * stranded allocation is outside the JS heap it is invisible to heap
+ * snapshots and survives a forced GC — only RSS moves — and a reader that
+ * walks the whole corpus grows by roughly the object size on every read.
+ *
+ * Measured on linux/arm64, 4000 reads of a 256 KiB object at the indexing
+ * loop's read concurrency: the native call grew 48MB -> 1100MB and never
+ * plateaued, while this path stayed flat.
+ *
+ * TODO(bun-s3-native-read): once every runtime image is on a stable Bun that
+ * contains those fixes (the first stable after 1.3.14 — the fixes are not in
+ * 1.3.14 itself), delete this helper and call
+ * `getCorpusS3().file(key).bytes()` directly again. The native path is
+ * zero-copy after the fix, so it should also be faster than this one.
+ *
+ * The signed URL carries the caller's credentials in its query string and is
+ * therefore never logged, and it is passed straight to `fetch` rather than
+ * stored. Unlike the native call, `fetch` honours the abort signal, so a
+ * stalled read is genuinely cancelled instead of merely abandoned.
+ */
+export const readCorpusS3Bytes = async (
+  key: string,
+  signal: AbortSignal,
+): Promise<Uint8Array> => {
+  const response = await fetch(
+    getCorpusS3().presign(key, {
+      expiresIn: CORPUS_READ_PRESIGN_TTL_SECONDS,
+    }),
+    { signal },
+  );
+  if (!response.ok) {
+    throw new CorpusObjectReadError({
+      message: `Corpus object read failed with ${response.status}`,
+      key,
+      status: response.status,
+    });
+  }
+  return await response.bytes();
+};
+
 /** Publish into the legal-corpus bucket with an abortable AWS SDK request. */
 export const putCorpusS3ObjectWithSignal = async (
   key: string,

--- a/apps/api/src/lib/s3.ts
+++ b/apps/api/src/lib/s3.ts
@@ -580,65 +580,72 @@ export const getCorpusS3 = (): S3Client => {
   return _corpusClient;
 };
 
-/** A corpus object read returned a non-success status. */
-export class CorpusObjectReadError extends TaggedError(
-  "CorpusObjectReadError",
-)<{
-  message: string;
-  key: string;
-  status: number;
-}> {}
-
-// The presigned URL is consumed by the very next statement, so this only has
-// to outlive one bounded read.
-const CORPUS_READ_PRESIGN_TTL_SECONDS = 300;
+// The signed URL is consumed by the very next statement, so it only has to
+// outlive one read.
+const OBJECT_READ_PRESIGN_TTL_SECONDS = 300;
 
 /**
- * Read a corpus object's bytes.
+ * Fetch an object body over a presigned URL.
  *
- * Deliberately NOT `getCorpusS3().file(key).bytes()`. Up to and including Bun
- * 1.3.14, that call never frees the native buffer the HTTP thread accumulates
- * the body into: the handler receives the bytes with `.clone` lifetime, JS
- * gets its own copy, and the original allocation is leaked
+ * Every object read in this codebase goes through here rather than through
+ * Bun's `S3Client.file(key).bytes()` / `.arrayBuffer()`. Up to and including
+ * Bun 1.3.14, those calls never free the native buffer the HTTP thread
+ * accumulates the body into: the handler receives the bytes with `.clone`
+ * lifetime, JS gets its own copy, and the original allocation is stranded
  * (oven-sh/bun#29083, fixed by oven-sh/bun#29086 and #29923). Because the
- * stranded allocation is outside the JS heap it is invisible to heap
- * snapshots and survives a forced GC — only RSS moves — and a reader that
- * walks the whole corpus grows by roughly the object size on every read.
+ * leaked allocation is outside the JS heap it is invisible to heap snapshots
+ * and survives a forced GC — only RSS moves — so any process that reads a
+ * steady stream of objects grows by roughly the object size per read until it
+ * is killed.
  *
- * Measured on linux/arm64, 4000 reads of a 256 KiB object at the indexing
- * loop's read concurrency: the native call grew 48MB -> 1100MB and never
- * plateaued, while this path stayed flat.
+ * Measured on linux/arm64, 4000 reads of a 256 KiB object at the corpus
+ * indexing loop's read concurrency: the native call grew 48MB -> 1100MB and
+ * never plateaued, while this path stayed flat.
  *
- * TODO(bun-s3-native-read): once every runtime image is on a stable Bun that
- * contains those fixes (the first stable after 1.3.14 — the fixes are not in
- * 1.3.14 itself), delete this helper and call
- * `getCorpusS3().file(key).bytes()` directly again. The native path is
- * zero-copy after the fix, so it should also be faster than this one.
+ * `no-native-s3-object-read` (tools/oxlint-rules) keeps new call sites off the
+ * native reads, because a single missed one silently reintroduces the leak.
  *
- * The signed URL carries the caller's credentials in its query string and is
- * therefore never logged, and it is passed straight to `fetch` rather than
- * stored. Unlike the native call, `fetch` honours the abort signal, so a
- * stalled read is genuinely cancelled instead of merely abandoned.
+ * TODO(bun-s3-native-read): once every runtime image is on a stable Bun
+ * containing those fixes (the first stable AFTER 1.3.14 — they are not in
+ * 1.3.14 itself), delete these helpers and the lint rule and go back to
+ * `.bytes()` / `.arrayBuffer()`. The native path is zero-copy after the fix,
+ * so it should then be faster than this one.
+ *
+ * The signed URL carries the caller's credentials in its query string, so it
+ * is passed straight to `fetch` and never logged or stored. Unlike the native
+ * calls, `fetch` honours an abort signal, so a read that outlives its ceiling
+ * is genuinely cancelled rather than merely abandoned.
  */
+const fetchObject = async (
+  client: S3Client,
+  key: string,
+  signal?: AbortSignal,
+): Promise<Response> => {
+  const response = await fetch(
+    client.presign(key, { expiresIn: OBJECT_READ_PRESIGN_TTL_SECONDS }),
+    signal ? { signal } : {},
+  );
+  if (!response.ok) {
+    throw new S3ObjectReadError({
+      message: `Object read for ${key} failed with ${response.status}`,
+    });
+  }
+  return response;
+};
+
+/** Read a legal-corpus object's bytes. See `fetchObject`. */
 export const readCorpusS3Bytes = async (
   key: string,
   signal: AbortSignal,
-): Promise<Uint8Array> => {
-  const response = await fetch(
-    getCorpusS3().presign(key, {
-      expiresIn: CORPUS_READ_PRESIGN_TTL_SECONDS,
-    }),
-    { signal },
-  );
-  if (!response.ok) {
-    throw new CorpusObjectReadError({
-      message: `Corpus object read failed with ${response.status}`,
-      key,
-      status: response.status,
-    });
-  }
-  return await response.bytes();
-};
+): Promise<Uint8Array> =>
+  await (await fetchObject(getCorpusS3(), key, signal)).bytes();
+
+/** Read a documents-bucket object. See `fetchObject`. */
+export const readS3ArrayBuffer = async (
+  key: string,
+  signal?: AbortSignal,
+): Promise<ArrayBuffer> =>
+  await (await fetchObject(getS3(), key, signal)).arrayBuffer();
 
 /** Publish into the legal-corpus bucket with an abortable AWS SDK request. */
 export const putCorpusS3ObjectWithSignal = async (

--- a/apps/api/src/lib/search/process-extraction.test.ts
+++ b/apps/api/src/lib/search/process-extraction.test.ts
@@ -94,6 +94,15 @@ void mock.module("@/api/lib/s3", () => ({
   deleteS3ObjectWithSignal: s3DeleteMock,
   getS3ObjectWithSignal: getS3ObjectWithSignalMock,
   putS3ObjectWithSignal: s3WriteMock,
+  // `mock.module` replaces the module, so every named export a consumer
+  // imports must exist here or the import fails at link time. This suite
+  // reads no object; throwing surfaces one that appears later.
+  readS3ArrayBuffer: () => {
+    throw new Error("Unexpected S3 object read in this suite");
+  },
+  readCorpusS3Bytes: () => {
+    throw new Error("Unexpected corpus object read in this suite");
+  },
 }));
 void mock.module("@/api/lib/search/extract-content", () => ({
   canExtractMimeType: () => true,

--- a/apps/api/src/lib/style-sets.ts
+++ b/apps/api/src/lib/style-sets.ts
@@ -6,7 +6,7 @@ import { styleSets } from "@/api/db/schema";
 import type { SafeId } from "@/api/lib/branded-types";
 import { createTemplateBuffer } from "@/api/lib/create-template-buffer";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
-import { getS3 } from "@/api/lib/s3";
+import { readS3ArrayBuffer } from "@/api/lib/s3";
 import { sanitizeFilenamePreservingExtension } from "@/api/lib/sanitize-filename";
 import { DOCX_MIME_TYPE } from "@/api/mime-types";
 
@@ -129,7 +129,7 @@ export const readStyleSetPackage = async ({
 
   return await Result.tryPromise({
     try: async () => ({
-      buffer: Buffer.from(await getS3().file(s3Key).arrayBuffer()),
+      buffer: Buffer.from(await readS3ArrayBuffer(s3Key)),
       name,
       updatedAt,
     }),

--- a/apps/api/src/lib/templates/template-fill-service.ts
+++ b/apps/api/src/lib/templates/template-fill-service.ts
@@ -43,7 +43,7 @@ import type {
   InputType,
 } from "@/api/lib/docx/types";
 import { isTemplateData } from "@/api/lib/docx/types";
-import { getS3 } from "@/api/lib/s3";
+import { readS3ArrayBuffer } from "@/api/lib/s3";
 import { buildBindingContext } from "@/api/lib/template-binding/build-binding-context";
 import { recordTemplateUse } from "@/api/lib/templates/record-use";
 
@@ -89,7 +89,7 @@ const loadTemplate = async (
   if (!template) {
     return null;
   }
-  const buffer = Buffer.from(await getS3().file(template.s3Key).arrayBuffer());
+  const buffer = Buffer.from(await readS3ArrayBuffer(template.s3Key));
   return { name: template.name, fileName: template.fileName, buffer };
 };
 

--- a/apps/api/src/lib/workflow/generate-batch.ts
+++ b/apps/api/src/lib/workflow/generate-batch.ts
@@ -7,7 +7,7 @@ import { createSafeId } from "@/api/lib/branded-types";
 import type { SafeId } from "@/api/lib/branded-types";
 import { Unreachable } from "@/api/lib/errors/tagged-errors";
 import { createFileKey } from "@/api/lib/files/utils";
-import { getS3 } from "@/api/lib/s3";
+import { readS3ArrayBuffer } from "@/api/lib/s3";
 import { generateWorkflowData } from "@/api/lib/workflow/ai-generate-batch";
 import { validateAIOutput } from "@/api/lib/workflow/ai-validators";
 import {
@@ -127,7 +127,7 @@ export const fetchAndPrepareFiles = async (
           fileId: meta.fileId,
           mimeType: DOCX_MIME_TYPE,
         });
-        const docxBuffer = await getS3().file(fileKey).arrayBuffer();
+        const docxBuffer = await readS3ArrayBuffer(fileKey);
         const reviewer = await FolioDocxReviewer.fromBuffer(docxBuffer);
         const blocks = reviewer.getContent();
         return {
@@ -148,7 +148,7 @@ export const fetchAndPrepareFiles = async (
         fileId: pdfFileId,
         mimeType: PDF_MIME_TYPE,
       });
-      const fileBuffer = await getS3().file(fileKey).arrayBuffer();
+      const fileBuffer = await readS3ArrayBuffer(fileKey);
       const preparedPdf = await addBatesNumbers(fileBuffer, simplifiedName);
       return {
         kind: "pdf",

--- a/apps/api/src/mcp/stella-tools.ts
+++ b/apps/api/src/mcp/stella-tools.ts
@@ -49,7 +49,7 @@ import {
   encodePaginationCursor,
   isUuidPaginationCursorPart,
 } from "@/api/lib/pagination";
-import { getS3 } from "@/api/lib/s3";
+import { readS3ArrayBuffer } from "@/api/lib/s3";
 import {
   brandPersistedCaseLawDecisionId,
   brandPersistedCaseLawSourceId,
@@ -1312,17 +1312,16 @@ const loadCurrentVersionDocxMarkdown = async ({
   const markdownResult = await Result.tryPromise({
     try: async () =>
       await withTimeout(
-        async () => {
-          const buffer = await getS3()
-            .file(
-              createFileKey({
-                organizationId: context.organizationId,
-                workspaceId,
-                fileId: file.id,
-                mimeType: DOCX_MIME_TYPE,
-              }),
-            )
-            .arrayBuffer();
+        async (signal) => {
+          const buffer = await readS3ArrayBuffer(
+            createFileKey({
+              organizationId: context.organizationId,
+              workspaceId,
+              fileId: file.id,
+              mimeType: DOCX_MIME_TYPE,
+            }),
+            signal,
+          );
           return await docxToMarkdown(buffer);
         },
         {

--- a/apps/api/src/mcp/tools.test.ts
+++ b/apps/api/src/mcp/tools.test.ts
@@ -66,6 +66,15 @@ void mock.module("@/api/lib/s3", () => ({
     accessKeyId: "test-access-key",
     secretAccessKey: "test-secret-key",
   }),
+  // `mock.module` replaces the module, so every named export a consumer
+  // imports must exist here or the import fails at link time. This suite
+  // reads no object; throwing surfaces one that appears later.
+  readS3ArrayBuffer: () => {
+    throw new Error("Unexpected S3 object read in this suite");
+  },
+  readCorpusS3Bytes: () => {
+    throw new Error("Unexpected corpus object read in this suite");
+  },
 }));
 
 // Default passthrough: just await the wrapped operation, so every existing

--- a/apps/api/src/mcp/tools.test.ts
+++ b/apps/api/src/mcp/tools.test.ts
@@ -1607,7 +1607,10 @@ describe("OpenAI-compatible MCP tools", () => {
       throw new Error("Expected payload.text to be a string");
     }
     expect(payload["text"]).not.toContain("# Agreement");
-    expect(s3FileMock).not.toHaveBeenCalled();
+    // Guards the read helper the handler actually calls. `getS3().file()` is
+    // no longer on this path at all, so asserting against it would hold even
+    // if the auxiliary DOCX were read.
+    expect(s3ArrayBufferMock).not.toHaveBeenCalled();
   });
 
   test("read_content_across_matters falls back to plaintext when docx-to-markdown conversion fails", async () => {

--- a/apps/api/src/mcp/tools.test.ts
+++ b/apps/api/src/mcp/tools.test.ts
@@ -66,12 +66,8 @@ void mock.module("@/api/lib/s3", () => ({
     accessKeyId: "test-access-key",
     secretAccessKey: "test-secret-key",
   }),
-  // `mock.module` replaces the module, so every named export a consumer
-  // imports must exist here or the import fails at link time. This suite
-  // reads no object; throwing surfaces one that appears later.
-  readS3ArrayBuffer: () => {
-    throw new Error("Unexpected S3 object read in this suite");
-  },
+  // The DOCX conversion tests exercise the safe read helper directly.
+  readS3ArrayBuffer: s3ArrayBufferMock,
   readCorpusS3Bytes: () => {
     throw new Error("Unexpected corpus object read in this suite");
   },

--- a/apps/api/src/scripts/citation-probe.ts
+++ b/apps/api/src/scripts/citation-probe.ts
@@ -301,6 +301,11 @@ const probeKey = async (
   jurisdiction: string,
   key: string,
 ): Promise<ProbedDoc> => {
+  // The native read leaks its download buffer (see the rule), but this is a
+  // one-shot probe that exits: the process never lives long enough for the
+  // stranded allocations to matter, and it has no @/api/lib/s3 client to
+  // borrow.
+  // oxlint-disable-next-line no-native-s3-object-read/no-native-s3-object-read
   const body = await withDeadline(s3.file(key).bytes(), "s3.get");
   const text = zstdDecompressToString(body);
   const documentId = key.slice(KEY_PREFIX.length).split("/").at(1) ?? key;

--- a/apps/api/src/scripts/citation-probe.ts
+++ b/apps/api/src/scripts/citation-probe.ts
@@ -12,12 +12,20 @@
  *   AWS_REGION=eu-central-1 bun src/scripts/citation-probe.ts \
  *     --bucket <legal-corpus-bucket> [--sample 18]
  */
+import { TaggedError } from "better-result";
+
 import { extractCitations } from "@/api/handlers/case-law/ingestion/citation-extractor";
 import { zstdDecompressToString } from "@/api/lib/compression";
+import { fetchWithTimeout } from "@/api/lib/fetch";
 import { isRecord } from "@/api/lib/type-guards";
 
 const JURISDICTIONS = ["CZE", "SVK", "POL"] as const;
 const KEY_PREFIX = "legal-corpus/documents/jurisdiction=";
+
+class CitationProbeS3ReadError extends TaggedError("CitationProbeS3ReadError")<{
+  message: string;
+  status: number;
+}> {}
 
 const args = Bun.argv.slice(2);
 const argValue = (name: string): string | undefined => {
@@ -305,12 +313,16 @@ const probeKey = async (
   // its download buffer on every call (see `no-native-s3-object-read`). This
   // probe is short-lived enough not to care, but reading the same way as the
   // rest of the codebase keeps one path to revert when the runtime is fixed.
-  const body = await withDeadline(
-    fetch(s3.presign(key, { expiresIn: 300 })).then(
-      async (response) => await response.bytes(),
-    ),
-    "s3.get",
-  );
+  const response = await fetchWithTimeout(s3.presign(key, { expiresIn: 300 }), {
+    timeoutMs: 30_000,
+  });
+  if (!response.ok) {
+    throw new CitationProbeS3ReadError({
+      message: `s3.get: failed with ${String(response.status)}`,
+      status: response.status,
+    });
+  }
+  const body = await response.bytes();
   const text = zstdDecompressToString(body);
   const documentId = key.slice(KEY_PREFIX.length).split("/").at(1) ?? key;
   if (text.trim().length === 0) {

--- a/apps/api/src/scripts/citation-probe.ts
+++ b/apps/api/src/scripts/citation-probe.ts
@@ -301,12 +301,16 @@ const probeKey = async (
   jurisdiction: string,
   key: string,
 ): Promise<ProbedDoc> => {
-  // The native read leaks its download buffer (see the rule), but this is a
-  // one-shot probe that exits: the process never lives long enough for the
-  // stranded allocations to matter, and it has no @/api/lib/s3 client to
-  // borrow.
-  // oxlint-disable-next-line no-native-s3-object-read/no-native-s3-object-read
-  const body = await withDeadline(s3.file(key).bytes(), "s3.get");
+  // Presigned GET rather than `s3.file(key).bytes()`: the native read strands
+  // its download buffer on every call (see `no-native-s3-object-read`). This
+  // probe is short-lived enough not to care, but reading the same way as the
+  // rest of the codebase keeps one path to revert when the runtime is fixed.
+  const body = await withDeadline(
+    fetch(s3.presign(key, { expiresIn: 300 })).then(
+      async (response) => await response.bytes(),
+    ),
+    "s3.get",
+  );
   const text = zstdDecompressToString(body);
   const documentId = key.slice(KEY_PREFIX.length).split("/").at(1) ?? key;
   if (text.trim().length === 0) {

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -340,6 +340,7 @@ export default defineConfig({
     "./.oxlint-plugins/no-direct-matter-glyph.ts",
     "./.oxlint-plugins/no-direct-entity-glyph.ts",
     "./.oxlint-plugins/no-crypto-random-uuid.ts",
+    "./.oxlint-plugins/no-native-s3-object-read.ts",
     "./.oxlint-plugins/no-raw-use-effect.ts",
     "./.oxlint-plugins/no-ref-mirror.ts",
     "./.oxlint-plugins/no-shared-suspense-query.ts",
@@ -476,6 +477,16 @@ export default defineConfig({
           "error",
           { allowedColumnExpressions: ["table.metadata"] },
         ],
+      },
+    },
+    {
+      // Exercise no-native-s3-object-read against its regression fixture; the
+      // rule is otherwise scoped to apps/api, which the fixtures dir is not.
+      files: [
+        ".oxlint-plugins/__fixtures__/no-native-s3-object-read.fixture.ts",
+      ],
+      rules: {
+        "no-native-s3-object-read/no-native-s3-object-read": "error",
       },
     },
     {
@@ -1738,6 +1749,7 @@ export default defineConfig({
       files: ["apps/api/**/*.ts"],
       rules: {
         "no-crypto-random-uuid/no-crypto-random-uuid": "error",
+        "no-native-s3-object-read/no-native-s3-object-read": "error",
       },
     },
     {

--- a/package.json
+++ b/package.json
@@ -119,15 +119,7 @@
     "svgo": "4.0.2",
     "undici": "7.29.0"
   },
-  "devEngines": {
-    "packageManager": {
-      "name": "bun",
-      "version": "^1.3.14"
-    }
-  },
-  "engines": {
-    "bun": "1.3.14"
-  },
+  "packageManager": "bun@1.3.14",
   "catalog": {
     "@base-ui/react": "1.6.0",
     "@better-auth/api-key": "1.6.25",

--- a/package.json
+++ b/package.json
@@ -119,7 +119,15 @@
     "svgo": "4.0.2",
     "undici": "7.29.0"
   },
-  "packageManager": "bun@1.3.14",
+  "devEngines": {
+    "packageManager": {
+      "name": "bun",
+      "version": "^1.3.14"
+    }
+  },
+  "engines": {
+    "bun": "1.3.14"
+  },
   "catalog": {
     "@base-ui/react": "1.6.0",
     "@better-auth/api-key": "1.6.25",


### PR DESCRIPTION
## Why

Bun's `S3Client.file(key).bytes()` / `.arrayBuffer()` never free the native buffer the HTTP thread accumulates the response body into. The handler is invoked with `.clone` lifetime, JS receives its own copy, and the original allocation is stranded — [oven-sh/bun#29083](https://github.com/oven-sh/bun/issues/29083), fixed upstream by [#29086](https://github.com/oven-sh/bun/pull/29086) (`free native download body in S3BlobDownloadTask`) and [#29923](https://github.com/oven-sh/bun/pull/29923). Those fixes landed after 1.3.14, so no released stable carries them yet.

The leak sits outside the JS heap. It is invisible to heap snapshots and survives a forced GC; only RSS moves. That makes it expensive to trace back from the symptom.

Measured in the runtime images on linux/arm64, 4000 reads of a 256 KiB object at the corpus indexing loop's read concurrency:

| read path | per read | RSS |
| --- | --- | --- |
| `s3.file(k).bytes()` | 275,775 B | 48MB → 1100MB, no plateau |
| presigned GET + `fetch` | 9,612 B | 42MB → 97MB, plateaus |
| `@aws-sdk/client-s3` | 33,205 B | plateaus, ~3× fetch's footprint |
| `s3.file(k).stat()` (no body) | 3,277 B | flat |

Retention tracks object size (72 KB per 64 KiB object, 205 KB per 256 KiB), and the body-less `stat()` is clean, so it is the response body being retained rather than per-request overhead.

## What

Every object read goes through `readS3ArrayBuffer` / `readCorpusS3Bytes` in `apps/api/src/lib/s3.ts`, which fetch over a presigned URL. That is 26 call sites across templates, entities, chat, folio-collab, uploads, and the derivative/processing queues — the corpus indexing loop is the highest-volume reader, but it was not the only affected one.

`no-native-s3-object-read` keeps new call sites off the native reads. A single missed site silently reintroduces the leak, so this is a lint rule rather than a convention. It covers all four body-materialising methods, the two-step `const f = getS3().file(k)` form, and locally constructed clients; it deliberately ignores `exists`, `stat`, `presign`, `write`, and `delete`, which carry no body.

The fixture is passive, matching `no-bare-jsonb-cast`: every `oxlint-disable-next-line` in it suppresses a case the rule **must** flag, so a regression surfaces as an unused directive under `--report-unused-disable-directives-severity=error` rather than as silence.

`packageManager` moves to `devEngines.packageManager`. The legacy field only accepts an exact version, which cannot express a pre-release channel; `devEngines` takes a semver range within one major. Behaviour is unchanged — `engines.bun` carries the same 1.3.14, and setup-bun's version-file reader falls back to it — but it leaves the door open to pinning the runtime to a pre-release build if we ever need the upstream fix before it ships stable.

## Trade-offs

- **Presigned URL over the AWS SDK.** The SDK also plateaus and avoids credentials in a URL, but retains ~3× as much per read, and the acute problem is memory in a task that was being OOM-killed. The signed URL is passed straight to `fetch`, never logged or stored.
- **One exemption**: `scripts/citation-probe.ts` is a one-shot probe whose process never lives long enough for the stranded allocations to matter, and it has no shared client to borrow. Disabled inline with that reasoning rather than scoping the rule around it.
- This is a workaround with a defined end. `TODO(bun-s3-native-read)` records the revert: once every runtime image is on a stable Bun containing the fixes, delete the helpers and the rule and go back to the native calls, which are zero-copy after the fix and should then be faster than this path.

## Incidental

`fetch` honours an abort signal, which the native calls ignore — the exact limitation `boundedCorpusIo` documents ("Bun's S3 convenience methods accept no per-request AbortSignal, so a stalled socket would leave the await pending forever"). Corpus reads and the MCP DOCX read now pass the signal they were already being handed, so a read that outlives its ceiling is cancelled rather than abandoned.

## Verification

Rule verified against its fixture: fires on all 7 hazard shapes, silent on all 7 safe shapes, and clean across `apps/api/src` apart from the documented exemption. Formatting via oxfmt. Typecheck and tests are left to CI.

Not verified locally: presigned reads against real S3 with ECS role credentials including a session token — the measurements above used an S3-compatible server.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added safer, timeout-aware retrieval of stored documents and corpus files.
  * Added cancellation support for long-running file reads.

* **Bug Fixes**
  * Updated document, template, comparison, preview, upload, and processing workflows to use the more reliable retrieval process.
  * Improved handling of unsuccessful storage responses and read failures.

* **Chores**
  * Added automated checks to prevent unsupported direct storage body reads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->