### PR TITLE
refactor: derive task status and priority option sets from one declaration

### DIFF
--- a/apps/api/src/handlers/entities/read-group-counts.ts
+++ b/apps/api/src/handlers/entities/read-group-counts.ts
@@ -3,6 +3,8 @@ import { and, eq, isNotNull, notInArray, sql } from "drizzle-orm";
 import type { SQL } from "drizzle-orm";
 import { t } from "elysia";
 
+import { TASK_STATUSES } from "@stll/api-contract";
+
 import { assertIdentifierLiteral } from "@/api/db/json-utils";
 import type { SafeDb } from "@/api/db/safe-db";
 import { entities, properties } from "@/api/db/schema";
@@ -25,13 +27,6 @@ const KIND_GROUP_ID = "_kind";
 // Folders and tasks are not rows in a document table view; the flat window query
 // excludes them, so the grouped counts must too.
 const TABLE_EXCLUDED_ENTITY_KINDS = ["folder", "task"] satisfies EntityKind[];
-const TASK_STATUS_VALUES = [
-  "open",
-  "in_progress",
-  "in_review",
-  "done",
-  "cancelled",
-] as const;
 // Inline the status literals with `sql.raw` rather than binding them: the
 // enclosing CASE expression is rendered into both the SELECT list and the
 // GROUP BY, and a bound value would get different placeholder numbers per
@@ -39,7 +34,7 @@ const TASK_STATUS_VALUES = [
 // constants, never user input, so inlining is byte-identical and safe.
 // `assertIdentifierLiteral` enforces that "fixed code constant" contract at
 // runtime, not just by convention.
-const TASK_STATUS_SQL_VALUES = TASK_STATUS_VALUES.map((statusValue) => {
+const TASK_STATUS_SQL_VALUES = TASK_STATUSES.map((statusValue) => {
   assertIdentifierLiteral(statusValue);
 
   return sql.raw(`'${statusValue}'`);

--- a/apps/api/src/lib/entities/kanban-group-condition.ts
+++ b/apps/api/src/lib/entities/kanban-group-condition.ts
@@ -3,6 +3,8 @@ import { and, eq, sql } from "drizzle-orm";
 import type { SQL } from "drizzle-orm";
 import { t } from "elysia";
 
+import { isEntityKind, TASK_STATUSES } from "@stll/api-contract";
+
 import { entities, fields } from "@/api/db/schema";
 import { tSafeId } from "@/api/lib/custom-schema";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
@@ -19,27 +21,7 @@ export const tGroupByPropertyId = t.Union([
   tSafeId("property"),
 ]);
 
-const TASK_STATUS_VALUES = [
-  "open",
-  "in_progress",
-  "in_review",
-  "done",
-  "cancelled",
-] as const;
-const TASK_STATUS_SQL_VALUES = TASK_STATUS_VALUES.map(
-  (status) => sql`${status}`,
-);
-const ENTITY_KIND_VALUES = [
-  "document",
-  "folder",
-  "task",
-  "message",
-  "link",
-] as const;
-type EntityKindValue = (typeof ENTITY_KIND_VALUES)[number];
-
-const isEntityKindValue = (value: string): value is EntityKindValue =>
-  ENTITY_KIND_VALUES.some((kind) => kind === value);
+const TASK_STATUS_SQL_VALUES = TASK_STATUSES.map((status) => sql`${status}`);
 
 const invalidKanbanGroup = () =>
   new HandlerError({ status: 400, message: "Invalid Kanban group" });
@@ -65,7 +47,7 @@ const buildKindGroupCondition = (
     return Result.err(invalidKanbanGroup());
   }
 
-  if (!isEntityKindValue(groupValue)) {
+  if (!isEntityKind(groupValue)) {
     return Result.err(invalidKanbanGroup());
   }
 

--- a/apps/api/src/lib/entity-constants.ts
+++ b/apps/api/src/lib/entity-constants.ts
@@ -1,15 +1,10 @@
-/** Valid status values per entity kind. */
-export const TASK_STATUS = {
-  OPEN: "open",
-  IN_PROGRESS: "in_progress",
-  IN_REVIEW: "in_review",
-  DONE: "done",
-  CANCELLED: "cancelled",
-} as const;
-
-export type TaskStatus = (typeof TASK_STATUS)[keyof typeof TASK_STATUS];
-
-export const TASK_STATUSES = Object.values(TASK_STATUS);
+export {
+  ENTITY_PRIORITIES,
+  ENTITY_PRIORITY,
+  TASK_STATUS,
+  TASK_STATUSES,
+} from "@stll/api-contract";
+export type { EntityPriority, TaskStatus } from "@stll/api-contract";
 
 export const AGENDA_ITEM_KIND = {
   TASK: "task",
@@ -79,19 +74,6 @@ const DOCUMENT_STATUS = {
 
 export type DocumentStatus =
   (typeof DOCUMENT_STATUS)[keyof typeof DOCUMENT_STATUS];
-
-const ENTITY_PRIORITY = {
-  NONE: "none",
-  URGENT: "urgent",
-  HIGH: "high",
-  MEDIUM: "medium",
-  LOW: "low",
-} as const;
-
-export type EntityPriority =
-  (typeof ENTITY_PRIORITY)[keyof typeof ENTITY_PRIORITY];
-
-export const ENTITY_PRIORITIES = Object.values(ENTITY_PRIORITY);
 
 export const TASK_ASSIGNEE_ROLE = {
   ASSIGNEE: "assignee",

--- a/apps/web/src/components/workspaces/tasks/task-detail-constants.ts
+++ b/apps/web/src/components/workspaces/tasks/task-detail-constants.ts
@@ -9,6 +9,20 @@ import {
   XCircleIcon,
 } from "lucide-react";
 
+import {
+  ENTITY_PRIORITIES as TASK_PRIORITIES,
+  isEntityPriority as isTaskPriority,
+  isTaskStatus,
+  TASK_STATUSES,
+} from "@stll/api-contract";
+import type {
+  EntityPriority as TaskPriority,
+  TaskStatus,
+} from "@stll/api-contract";
+
+export { isTaskPriority, isTaskStatus, TASK_PRIORITIES, TASK_STATUSES };
+export type { TaskPriority, TaskStatus };
+
 /** Normalize a date value that may be a Date object (Eden
  *  transforms `format: "date"`) or a YYYY-MM-DD string. */
 export const toISODate = (v: string | Date | null | undefined): string => {
@@ -23,31 +37,6 @@ export const toISODate = (v: string | Date | null | undefined): string => {
   }
   return v.slice(0, 10);
 };
-
-export const TASK_STATUSES = [
-  "open",
-  "in_progress",
-  "in_review",
-  "done",
-  "cancelled",
-] as const;
-
-export const TASK_PRIORITIES = [
-  "none",
-  "urgent",
-  "high",
-  "medium",
-  "low",
-] as const;
-
-export type TaskStatus = (typeof TASK_STATUSES)[number];
-export type TaskPriority = (typeof TASK_PRIORITIES)[number];
-
-export const isTaskStatus = (v: string | null): v is TaskStatus =>
-  v !== null && TASK_STATUSES.some((status) => status === v);
-
-export const isTaskPriority = (v: string | null): v is TaskPriority =>
-  v !== null && TASK_PRIORITIES.some((priority) => priority === v);
 
 export const STATUS_ICONS = {
   open: CircleIcon,

--- a/apps/web/src/lib/task-option-telemetry.ts
+++ b/apps/web/src/lib/task-option-telemetry.ts
@@ -1,0 +1,14 @@
+import { getAnalytics } from "@/lib/analytics/provider";
+import { ClientTelemetryError } from "@/lib/errors/telemetry";
+
+type TaskOption = "priority" | "status";
+
+/** Report an invalid task option without sending its untrusted value. */
+export const captureInvalidTaskOption = (option: TaskOption) => {
+  getAnalytics().captureError(
+    new ClientTelemetryError({
+      area: "task-option-rendering",
+      message: `[Task option rendering] Invalid ${option}`,
+    }),
+  );
+};

--- a/apps/web/src/routes/_protected.todos/index.tsx
+++ b/apps/web/src/routes/_protected.todos/index.tsx
@@ -31,11 +31,13 @@ import { cn } from "@stll/ui/lib/utils";
 import { useInspectorTabsStore } from "@/components/inspector/inspector-tabs-store";
 import { MatterRefLink } from "@/components/matter-ref-link";
 import { EntityKindIcon } from "@/components/workspaces/entity-kind-icon";
+import { useExternalSyncEffect } from "@/hooks/use-effect";
 import { getFormattingLocale } from "@/i18n/i18n-store";
 import { api } from "@/lib/api";
 import { detached } from "@/lib/detached";
 import { unwrapEden } from "@/lib/errors/api";
 import { pageTitle } from "@/lib/page-title";
+import { captureInvalidTaskOption } from "@/lib/task-option-telemetry";
 import { workspacesOptions } from "@/lib/workspaces/queries";
 import { entitiesKeys } from "@/lib/workspaces/queries/entities";
 import type { TaskItem } from "@/routes/_protected.todos/-queries";
@@ -281,16 +283,23 @@ const FilterButton = ({ label, active, onClick }: FilterButtonProps) => (
 );
 
 const TaskRow = ({ task }: { task: ValidTask }) => {
-  const statusColor = isTaskStatus(task.status)
-    ? STATUS_COLORS[task.status]
-    : STATUS_COLORS.open;
+  const status = isTaskStatus(task.status) ? task.status : null;
+  const priority = isEntityPriority(task.priority) ? task.priority : null;
 
-  const PriorityIcon = isEntityPriority(task.priority)
-    ? PRIORITY_ICONS[task.priority]
-    : null;
-  const priorityColor = isEntityPriority(task.priority)
-    ? PRIORITY_COLORS[task.priority]
-    : null;
+  useExternalSyncEffect(() => {
+    if (status === null) {
+      captureInvalidTaskOption("status");
+    }
+    if (priority === null) {
+      captureInvalidTaskOption("priority");
+    }
+  }, [priority, status]);
+
+  const statusColor =
+    status === null ? STATUS_COLORS.open : STATUS_COLORS[status];
+
+  const PriorityIcon = priority === null ? null : PRIORITY_ICONS[priority];
+  const priorityColor = priority === null ? null : PRIORITY_COLORS[priority];
 
   const isOverdue =
     task.dueDate !== null &&

--- a/apps/web/src/routes/_protected.todos/index.tsx
+++ b/apps/web/src/routes/_protected.todos/index.tsx
@@ -16,6 +16,8 @@ import {
 } from "lucide-react";
 import { useTranslations } from "use-intl";
 
+import { isEntityPriority, isTaskStatus } from "@stll/api-contract";
+import type { EntityPriority, TaskStatus } from "@stll/api-contract";
 import { Button } from "@stll/ui/components/button";
 import {
   Menu,
@@ -50,29 +52,29 @@ export const Route = createFileRoute("/_protected/todos/")({
   component: MyTodosPage,
 });
 
-const STATUS_COLORS: Record<string, string> = {
+const STATUS_COLORS = {
   open: "bg-muted-foreground",
   in_progress: "bg-foreground-strong-muted dark:bg-foreground-strong-muted",
   in_review: "bg-warning",
   done: "bg-success dark:bg-success",
   cancelled: "bg-destructive dark:bg-destructive",
-};
+} as const satisfies Record<TaskStatus, string>;
 
-const PRIORITY_ICONS: Record<string, typeof MinusIcon> = {
+const PRIORITY_ICONS = {
   none: MinusIcon,
   urgent: AlertCircleIcon,
   high: ArrowUpIcon,
   medium: MinusIcon,
   low: ArrowDownIcon,
-};
+} as const satisfies Record<EntityPriority, typeof MinusIcon>;
 
-const PRIORITY_COLORS: Record<string, string> = {
+const PRIORITY_COLORS = {
   none: "text-muted-foreground",
   urgent: "text-destructive",
   high: "text-warning",
   medium: "text-warning",
   low: "text-foreground-muted dark:text-foreground",
-};
+} as const satisfies Record<EntityPriority, string>;
 
 const SKELETON_GROUP_KEYS = ["alpha", "beta", "gamma"];
 const SKELETON_ROW_KEYS = ["one", "two", "three"];
@@ -279,14 +281,15 @@ const FilterButton = ({ label, active, onClick }: FilterButtonProps) => (
 );
 
 const TaskRow = ({ task }: { task: ValidTask }) => {
-  const statusColor =
-    STATUS_COLORS[task.status ?? "open"] ?? "bg-muted-foreground";
+  const statusColor = isTaskStatus(task.status)
+    ? STATUS_COLORS[task.status]
+    : STATUS_COLORS.open;
 
-  const PriorityIcon = task.priority
-    ? (PRIORITY_ICONS[task.priority] ?? MinusIcon)
+  const PriorityIcon = isEntityPriority(task.priority)
+    ? PRIORITY_ICONS[task.priority]
     : null;
-  const priorityColor = task.priority
-    ? (PRIORITY_COLORS[task.priority] ?? "text-muted-foreground")
+  const priorityColor = isEntityPriority(task.priority)
+    ? PRIORITY_COLORS[task.priority]
     : null;
 
   const isOverdue =

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/calendar/calendar-entity-chip.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/calendar/calendar-entity-chip.tsx
@@ -5,6 +5,8 @@ import { centerUnderPointer } from "@atlaskit/pragmatic-drag-and-drop/element/ce
 import { setCustomNativeDragPreview } from "@atlaskit/pragmatic-drag-and-drop/element/set-custom-native-drag-preview";
 import { useTranslations } from "use-intl";
 
+import { isTaskStatus } from "@stll/api-contract";
+import type { TaskStatus } from "@stll/api-contract";
 import {
   Tooltip,
   TooltipPopup,
@@ -22,13 +24,13 @@ import { ENTITY_DRAG_TYPE } from "@/lib/workspaces/drag-constants";
 import type { CalendarTask } from "@/lib/workspaces/queries/calendar-tasks";
 import { useInspectorFlash } from "@/routes/_protected.workspaces/$workspaceId/-hooks/use-inspector-flash";
 
-const TASK_STATUS_BORDER_COLORS: Record<string, string> = {
+const TASK_STATUS_BORDER_COLORS = {
   open: "border-s-muted-foreground",
   in_progress: "border-s-foreground-strong-muted",
   in_review: "border-s-warning",
   done: "border-s-success",
   cancelled: "border-s-destructive",
-};
+} as const satisfies Record<TaskStatus, string>;
 
 type CalendarEntityChipProps = {
   entity: CalendarTask;
@@ -98,10 +100,9 @@ export const CalendarEntityChip = ({
         "hover:bg-accent text-start text-xs",
         "truncate",
         isEditable && "cursor-grab active:cursor-grabbing",
-        entity.status
-          ? (TASK_STATUS_BORDER_COLORS[entity.status] ??
-              "border-s-muted-foreground")
-          : "border-s-muted-foreground",
+        isTaskStatus(entity.status)
+          ? TASK_STATUS_BORDER_COLORS[entity.status]
+          : TASK_STATUS_BORDER_COLORS.open,
       )}
       // eslint-disable-next-line react/react-compiler -- containedHandler house pattern; dragRef is handed to the helper, not read for rendered output
       onClick={containedHandler(dragRef, handleClick)}

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/calendar/calendar-entity-chip.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/calendar/calendar-entity-chip.tsx
@@ -20,6 +20,7 @@ import { renderDragPreview } from "@/components/drag-preview";
 import { useInspectorTabsStore } from "@/components/inspector/inspector-tabs-store";
 import { useExternalSyncEffect } from "@/hooks/use-effect";
 import { useLocale } from "@/i18n/formatting-context";
+import { captureInvalidTaskOption } from "@/lib/task-option-telemetry";
 import { ENTITY_DRAG_TYPE } from "@/lib/workspaces/drag-constants";
 import type { CalendarTask } from "@/lib/workspaces/queries/calendar-tasks";
 import { useInspectorFlash } from "@/routes/_protected.workspaces/$workspaceId/-hooks/use-inspector-flash";
@@ -47,10 +48,17 @@ export const CalendarEntityChip = ({
   const locale = useLocale();
   const name = entity.name || t("tasks.untitled");
   const openTask = useInspectorTabsStore((s) => s.openTask);
+  const status = isTaskStatus(entity.status) ? entity.status : null;
 
   const dragRef = useRef<HTMLButtonElement>(null);
 
   useInspectorFlash(entity.taskId, dragRef);
+
+  useExternalSyncEffect(() => {
+    if (status === null) {
+      captureInvalidTaskOption("status");
+    }
+  }, [status]);
 
   useExternalSyncEffect(() => {
     const el = dragRef.current;
@@ -100,9 +108,9 @@ export const CalendarEntityChip = ({
         "hover:bg-accent text-start text-xs",
         "truncate",
         isEditable && "cursor-grab active:cursor-grabbing",
-        isTaskStatus(entity.status)
-          ? TASK_STATUS_BORDER_COLORS[entity.status]
-          : TASK_STATUS_BORDER_COLORS.open,
+        status === null
+          ? TASK_STATUS_BORDER_COLORS.open
+          : TASK_STATUS_BORDER_COLORS[status],
       )}
       // eslint-disable-next-line react/react-compiler -- containedHandler house pattern; dragRef is handed to the helper, not read for rendered output
       onClick={containedHandler(dragRef, handleClick)}

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/calendar/calendar-utils.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/calendar/calendar-utils.ts
@@ -6,6 +6,8 @@
  * datestamp-only, no time component).
  */
 
+import type { TaskStatus } from "@stll/api-contract";
+
 import { getFirstWeekday } from "@/i18n/week";
 import type { WorkspaceFieldContent } from "@/lib/types";
 import { includesValue } from "@/lib/utils";
@@ -229,13 +231,13 @@ export const isTaskDateProperty = (id: string) =>
  * 2024-01-07 is a Sunday (getUTCDay() === 0); offsetting by the first
  * weekday yields labels starting from that day.
  */
-export const TASK_STATUS_DOT_COLORS: Record<string, string> = {
+export const TASK_STATUS_DOT_COLORS = {
   open: "var(--option-gray)",
   in_progress: "var(--option-blue)",
   in_review: "var(--option-amber)",
   done: "var(--option-emerald)",
   cancelled: "var(--option-red)",
-};
+} as const satisfies Record<TaskStatus, string>;
 
 export const getWeekdayLabels = (
   locale: string,

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/calendar/calendar-view.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/calendar/calendar-view.tsx
@@ -9,6 +9,7 @@ import { isTaskStatus } from "@stll/api-contract";
 import { stellaToast } from "@stll/ui/components/toast";
 
 import { useInspectorTabsStore } from "@/components/inspector/inspector-tabs-store";
+import { useExternalSyncEffect } from "@/hooks/use-effect";
 import { useLatestCallback } from "@/hooks/use-latest-callback";
 import { useLocale } from "@/i18n/formatting-context";
 import { getFirstWeekday, getWeekendDays } from "@/i18n/week";
@@ -17,6 +18,7 @@ import { normalizeOptionalArray } from "@/lib/arrays";
 import { detached } from "@/lib/detached";
 import { toAPIError } from "@/lib/errors/api";
 import { toSafeId } from "@/lib/safe-id";
+import { captureInvalidTaskOption } from "@/lib/task-option-telemetry";
 import type { EntityKind, WorkspaceView } from "@/lib/types";
 import { useUpsertField } from "@/lib/workspaces/mutations/entities";
 import {
@@ -223,6 +225,15 @@ export const CalendarView = ({ view, workspaceId }: CalendarViewProps) => {
     }),
     throwOnError: true,
   });
+
+  const hasInvalidYearTaskStatus =
+    mode === "year" && calendarTasks.some((task) => !isTaskStatus(task.status));
+
+  useExternalSyncEffect(() => {
+    if (hasInvalidYearTaskStatus) {
+      captureInvalidTaskOption("status");
+    }
+  }, [hasInvalidYearTaskStatus]);
 
   // Group tasks by date across all configured date properties
   const entitiesByDate = groupCalendarTasksByDate({

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/calendar/calendar-view.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/calendar/calendar-view.tsx
@@ -5,6 +5,7 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { CalendarIcon } from "lucide-react";
 import { useTranslations } from "use-intl";
 
+import { isTaskStatus } from "@stll/api-contract";
 import { stellaToast } from "@stll/ui/components/toast";
 
 import { useInspectorTabsStore } from "@/components/inspector/inspector-tabs-store";
@@ -508,9 +509,9 @@ export const CalendarView = ({ view, workspaceId }: CalendarViewProps) => {
       for (const { entity } of entries) {
         yearDots.push({
           date,
-          color: entity.status
-            ? (TASK_STATUS_DOT_COLORS[entity.status] ?? "var(--option-gray)")
-            : "var(--option-gray)",
+          color: isTaskStatus(entity.status)
+            ? TASK_STATUS_DOT_COLORS[entity.status]
+            : TASK_STATUS_DOT_COLORS.open,
         });
       }
     }

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/kanban/kanban-view.logic.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/kanban/kanban-view.logic.ts
@@ -157,12 +157,16 @@ const STATUS_OPTION_COLORS = {
   cancelled: "red",
 } as const satisfies Record<TaskStatus, OptionColor>;
 
-const getStatusGroupOptions = (labels: Record<string, string>): GroupOption[] =>
+/** Every status carries a label. A partial map would render a raw column
+ *  heading such as "in_progress" to the user. */
+export type TaskStatusLabels = Record<TaskStatus, string>;
+
+const getStatusGroupOptions = (labels: TaskStatusLabels): GroupOption[] =>
   TASK_STATUS_ORDER.map((status) => {
     const optColor = STATUS_OPTION_COLORS[status];
     return {
       value: status,
-      label: labels[status] ?? status,
+      label: labels[status],
       color: resolveOptionColor(optColor).color,
       colorBg: resolveOptionColor(optColor).background,
       optionColor: optColor,
@@ -187,33 +191,52 @@ const getBuiltInGroupOptions = ({
     ? getEntityKindGroupOptions(labels)
     : [];
 
-type ResolveGroupOptionsParams = {
-  grouping: KanbanGrouping;
-  groupByPropertyId: string;
-  statusLabels: Record<string, string>;
-  entityKindLabels: EntityKindLabels;
-};
+/**
+ * A grouping plus exactly the labels that grouping consumes.
+ *
+ * The label maps used to ride along as separate fields for every call, so a
+ * caller could pass an empty status map to a status board (the column
+ * headings then fell back to raw values like "in_progress") and a status
+ * board could be built with no labels at all. Carrying them on the arm that
+ * reads them makes both unrepresentable.
+ *
+ * The discriminant sits at the top level rather than nested under a
+ * `grouping` field because TypeScript narrows a union only by its own
+ * properties: `params.grouping.type === "status"` would not narrow `params`.
+ */
+export type ResolveGroupOptionsParams =
+  | (Extract<KanbanGrouping, { type: "status" }> & {
+      statusLabels: TaskStatusLabels;
+    })
+  | (Extract<KanbanGrouping, { type: "built-in" }> & {
+      groupByPropertyId: string;
+      entityKindLabels: EntityKindLabels;
+    })
+  | Extract<KanbanGrouping, { type: "none" } | { type: "property" }>;
 
 /** Resolve the static option list for a grouping (excludes uncategorized). */
-export const resolveGroupOptions = ({
-  grouping,
-  groupByPropertyId,
-  statusLabels,
-  entityKindLabels,
-}: ResolveGroupOptionsParams): GroupOption[] => {
-  if (grouping.type === "status") {
-    return getStatusGroupOptions(statusLabels);
+export const resolveGroupOptions = (
+  params: ResolveGroupOptionsParams,
+): GroupOption[] => {
+  switch (params.type) {
+    case "status":
+      return getStatusGroupOptions(params.statusLabels);
+    case "built-in":
+      return getBuiltInGroupOptions({
+        labels: params.entityKindLabels,
+        mode: params.groupByPropertyId,
+      });
+    case "property":
+      return isGroupableProperty(params.property)
+        ? getGroupOptions(params.property)
+        : [];
+    case "none":
+      return [];
+    default: {
+      const exhaustive: never = params;
+      return exhaustive;
+    }
   }
-  if (grouping.type === "built-in") {
-    return getBuiltInGroupOptions({
-      labels: entityKindLabels,
-      mode: groupByPropertyId,
-    });
-  }
-  if (grouping.type === "property" && isGroupableProperty(grouping.property)) {
-    return getGroupOptions(grouping.property);
-  }
-  return [];
 };
 
 /** Append the uncategorized bucket (null value) after the options. */

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/kanban/kanban-view.logic.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/kanban/kanban-view.logic.ts
@@ -1,5 +1,10 @@
 import { panic } from "better-result";
 
+import {
+  ENTITY_KINDS,
+  TASK_STATUSES as TASK_STATUS_ORDER,
+} from "@stll/api-contract";
+import type { EntityKind, TaskStatus } from "@stll/api-contract";
 import type { OptionColor } from "@stll/api/types";
 
 import {
@@ -138,15 +143,9 @@ const getGroupOptions = (property: WorkspaceProperty): GroupOption[] => {
 };
 
 /** All task statuses in the order they should appear as groups. */
-export const TASK_STATUS_ORDER = [
-  "open",
-  "in_progress",
-  "in_review",
-  "done",
-  "cancelled",
-] as const;
+export { TASK_STATUS_ORDER };
 
-const STATUS_OPTION_COLORS: Record<string, OptionColor> = {
+const STATUS_OPTION_COLORS = {
   // eslint-disable-next-line no-inline-style-colors/no-inline-style-colors -- OptionColor domain constant, not a CSS color value
   open: "gray",
   // eslint-disable-next-line no-inline-style-colors/no-inline-style-colors -- OptionColor domain constant, not a CSS color value
@@ -156,11 +155,11 @@ const STATUS_OPTION_COLORS: Record<string, OptionColor> = {
   done: "green",
   // eslint-disable-next-line no-inline-style-colors/no-inline-style-colors -- OptionColor domain constant, not a CSS color value
   cancelled: "red",
-};
+} as const satisfies Record<TaskStatus, OptionColor>;
 
 const getStatusGroupOptions = (labels: Record<string, string>): GroupOption[] =>
   TASK_STATUS_ORDER.map((status) => {
-    const optColor = STATUS_OPTION_COLORS[status] ?? "gray";
+    const optColor = STATUS_OPTION_COLORS[status];
     return {
       value: status,
       label: labels[status] ?? status,
@@ -170,18 +169,10 @@ const getStatusGroupOptions = (labels: Record<string, string>): GroupOption[] =>
     };
   });
 
-export type EntityKindLabels = Record<
-  "document" | "folder" | "task" | "message" | "link",
-  string
->;
+export type EntityKindLabels = Record<EntityKind, string>;
 
-const getEntityKindGroupOptions = (labels: EntityKindLabels): GroupOption[] => [
-  { value: "document", label: labels.document },
-  { value: "folder", label: labels.folder },
-  { value: "task", label: labels.task },
-  { value: "message", label: labels.message },
-  { value: "link", label: labels.link },
-];
+const getEntityKindGroupOptions = (labels: EntityKindLabels): GroupOption[] =>
+  ENTITY_KINDS.map((kind) => ({ value: kind, label: labels[kind] }));
 
 type BuiltInGroupOptionsParams = {
   labels: EntityKindLabels;

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/kanban/kanban-view.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/kanban/kanban-view.tsx
@@ -50,9 +50,11 @@ import {
   getKanbanGroupingPropertyId,
   resolveGroupOptions,
   resolveKanbanGrouping,
-  TASK_STATUS_ORDER,
 } from "@/routes/_protected.workspaces/$workspaceId/-components/kanban/kanban-view.logic";
-import type { EntityGroup } from "@/routes/_protected.workspaces/$workspaceId/-components/kanban/kanban-view.logic";
+import type {
+  EntityGroup,
+  ResolveGroupOptionsParams,
+} from "@/routes/_protected.workspaces/$workspaceId/-components/kanban/kanban-view.logic";
 import {
   uploadFileEntitiesBatched,
   useBatchUploadLabels,
@@ -284,11 +286,6 @@ export const KanbanView = ({ view, workspaceId }: KanbanViewProps) => {
 
   // -- Unified grouping: resolve options, then render one board --
 
-  const statusLabels: Record<string, string> = isStatusGrouping
-    ? Object.fromEntries(
-        TASK_STATUS_ORDER.map((s) => [s, t(`tasks.statusValues.${s}`)]),
-      )
-    : {};
   const entityKindLabels = {
     document: t("common.document"),
     folder: t("search.kinds.folder"),
@@ -297,12 +294,34 @@ export const KanbanView = ({ view, workspaceId }: KanbanViewProps) => {
     link: t("search.kinds.link"),
   };
 
-  const options = resolveGroupOptions({
-    grouping,
-    groupByPropertyId,
-    statusLabels,
-    entityKindLabels,
-  });
+  // Each arm carries only the labels its grouping reads, so the status
+  // board cannot be built without a complete set of status labels.
+  const groupParams = ((): ResolveGroupOptionsParams => {
+    if (grouping.type === "status") {
+      return {
+        type: "status",
+        propertyId: grouping.propertyId,
+        statusLabels: {
+          open: t("tasks.statusValues.open"),
+          in_progress: t("tasks.statusValues.in_progress"),
+          in_review: t("tasks.statusValues.in_review"),
+          done: t("tasks.statusValues.done"),
+          cancelled: t("tasks.statusValues.cancelled"),
+        },
+      };
+    }
+    if (grouping.type === "built-in") {
+      return {
+        type: "built-in",
+        propertyId: grouping.propertyId,
+        groupByPropertyId,
+        entityKindLabels,
+      };
+    }
+    return grouping;
+  })();
+
+  const options = resolveGroupOptions(groupParams);
 
   const groups = getEntityGroups(options, t("common.uncategorized"));
 

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table/grouped-table-layout.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table/grouped-table-layout.tsx
@@ -89,11 +89,6 @@ const GROUP_EAGER_LOAD_COUNT = 3;
 // group-counts) stay in sync.
 const GROUPED_TABLE_EXCLUDED_KINDS: EntityKind[] = ["folder", "task"];
 
-// Status grouping is rejected before a document table resolves its group
-// options, so it never needs status labels; shared so the empty object isn't
-// rebuilt every render.
-const EMPTY_STATUS_LABELS: Record<string, string> = {};
-
 // Stable key for a group. The null (uncategorized) bucket and real string values
 // live in disjoint namespaces so an option literally named "uncategorized"
 // can't collide with the null bucket.
@@ -296,9 +291,6 @@ export const GroupedTableLayout = ({
     );
   }
 
-  // Status grouping is rejected above (isUnsupportedGrouping), so a document
-  // table never needs status labels.
-  const statusLabels = EMPTY_STATUS_LABELS;
   const entityKindLabels = {
     document: t("common.document"),
     folder: t("search.kinds.folder"),
@@ -307,12 +299,19 @@ export const GroupedTableLayout = ({
     link: t("search.kinds.link"),
   };
 
-  const options = resolveGroupOptions({
-    grouping,
-    groupByPropertyId,
-    statusLabels,
-    entityKindLabels,
-  });
+  // Status grouping is rejected above (isUnsupportedGrouping), so this
+  // layout never supplies status labels; the params union means it cannot
+  // hand over an empty set by accident either.
+  const options = resolveGroupOptions(
+    grouping.type === "built-in"
+      ? {
+          type: "built-in",
+          propertyId: grouping.propertyId,
+          groupByPropertyId,
+          entityKindLabels,
+        }
+      : grouping,
+  );
   // Cells whose value is no longer a current option fold into the uncategorized
   // group server-side (the row/count queries treat "no current-option value" as
   // uncategorized), so the sections are just the option groups plus uncategorized.

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-toolbar-filters.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-toolbar-filters.tsx
@@ -10,6 +10,10 @@ import {
 } from "lucide-react";
 import { useTranslations } from "use-intl";
 
+import {
+  ENTITY_PRIORITIES as PRIORITY_VALUES,
+  TASK_STATUSES as STATUS_VALUES,
+} from "@stll/api-contract";
 import type { ConditionNode, GroupNode } from "@stll/conditions";
 import { Button } from "@stll/ui/components/button";
 import {
@@ -711,16 +715,6 @@ const KIND_LABEL_KEYS = {
   document: "common.document",
   task: "search.kinds.task",
 } as const satisfies Record<(typeof ENTITY_KINDS)[number], TranslationKey>;
-
-const STATUS_VALUES = [
-  "open",
-  "in_progress",
-  "in_review",
-  "done",
-  "cancelled",
-] as const;
-
-const PRIORITY_VALUES = ["none", "urgent", "high", "medium", "low"] as const;
 
 const STATUS_VALUE_LABEL_KEYS = {
   open: "tasks.statusValues.open",

--- a/packages/api-contract/src/entity-options.test.ts
+++ b/packages/api-contract/src/entity-options.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  ENTITY_PRIORITIES,
+  isEntityPriority,
+  isTaskStatus,
+  TASK_STATUSES,
+} from "./entity-options";
+
+describe("isTaskStatus", () => {
+  test("accepts every declared status", () => {
+    expect(TASK_STATUSES.filter(isTaskStatus)).toEqual([...TASK_STATUSES]);
+  });
+
+  // The guard's whole job is to keep "not a status" distinguishable from a
+  // status. A near miss that slipped through (or a default substituted for
+  // one) reaches the UI as a confident wrong answer rather than an
+  // unresolved one.
+  // Each case is wrapped in a tuple: `test.each` spreads a bare array case
+  // into the callback's arguments, which would quietly test "done".
+  test.each([
+    ["Done"],
+    ["dones"],
+    ["pending"],
+    [""],
+    [" open"],
+    [null],
+    [undefined],
+    [0],
+    [["done"]],
+    [{ status: "done" }],
+  ])("rejects %p", (value) => {
+    expect(isTaskStatus(value)).toBe(false);
+  });
+});
+
+describe("isEntityPriority", () => {
+  test("accepts every declared priority", () => {
+    expect(ENTITY_PRIORITIES.filter(isEntityPriority)).toEqual([
+      ...ENTITY_PRIORITIES,
+    ]);
+  });
+
+  test.each([
+    ["Urgent"],
+    ["urgents"],
+    ["critical"],
+    [""],
+    [" none"],
+    [null],
+    [undefined],
+    [0],
+    [["urgent"]],
+    [{ priority: "urgent" }],
+  ])("rejects %p", (value) => {
+    expect(isEntityPriority(value)).toBe(false);
+  });
+});

--- a/packages/api-contract/src/entity-options.test.ts
+++ b/packages/api-contract/src/entity-options.test.ts
@@ -6,9 +6,28 @@ import {
   isTaskStatus,
   TASK_STATUSES,
 } from "./entity-options";
+import type { EntityPriority, TaskStatus } from "./entity-options";
+
+const EXPECTED_TASK_STATUSES = [
+  "open",
+  "in_progress",
+  "in_review",
+  "done",
+  "cancelled",
+] as const satisfies readonly TaskStatus[];
+
+const EXPECTED_ENTITY_PRIORITIES = [
+  "none",
+  "urgent",
+  "high",
+  "medium",
+  "low",
+] as const satisfies readonly EntityPriority[];
 
 describe("isTaskStatus", () => {
   test("accepts every declared status", () => {
+    expect(TASK_STATUSES).toEqual(EXPECTED_TASK_STATUSES);
+    expect(Object.isFrozen(TASK_STATUSES)).toBe(true);
     expect(TASK_STATUSES.filter(isTaskStatus)).toEqual([...TASK_STATUSES]);
   });
 
@@ -36,6 +55,8 @@ describe("isTaskStatus", () => {
 
 describe("isEntityPriority", () => {
   test("accepts every declared priority", () => {
+    expect(ENTITY_PRIORITIES).toEqual(EXPECTED_ENTITY_PRIORITIES);
+    expect(Object.isFrozen(ENTITY_PRIORITIES)).toBe(true);
     expect(ENTITY_PRIORITIES.filter(isEntityPriority)).toEqual([
       ...ENTITY_PRIORITIES,
     ]);

--- a/packages/api-contract/src/entity-options.ts
+++ b/packages/api-contract/src/entity-options.ts
@@ -22,7 +22,12 @@ export const TASK_STATUS = {
 
 export type TaskStatus = (typeof TASK_STATUS)[keyof typeof TASK_STATUS];
 
-export const TASK_STATUSES = Object.values(TASK_STATUS);
+// Frozen and typed readonly: this is the one declaration every consumer
+// reads, so a stray `.push()` or in-place `.sort()` would reorder the kanban
+// columns and the filter menus everywhere at once.
+export const TASK_STATUSES: readonly TaskStatus[] = Object.freeze(
+  Object.values(TASK_STATUS),
+);
 
 export const isTaskStatus = (value: unknown): value is TaskStatus =>
   typeof value === "string" && TASK_STATUSES.some((status) => status === value);
@@ -38,7 +43,9 @@ export const ENTITY_PRIORITY = {
 export type EntityPriority =
   (typeof ENTITY_PRIORITY)[keyof typeof ENTITY_PRIORITY];
 
-export const ENTITY_PRIORITIES = Object.values(ENTITY_PRIORITY);
+export const ENTITY_PRIORITIES: readonly EntityPriority[] = Object.freeze(
+  Object.values(ENTITY_PRIORITY),
+);
 
 export const isEntityPriority = (value: unknown): value is EntityPriority =>
   typeof value === "string" &&

--- a/packages/api-contract/src/entity-options.ts
+++ b/packages/api-contract/src/entity-options.ts
@@ -1,0 +1,45 @@
+/**
+ * The option sets an entity's own columns range over, declared once.
+ *
+ * `entities.status` and `entities.priority` are plain varchar columns: the
+ * database constrains neither, so every consumer that enumerates them (the
+ * kanban columns, the grouped-count SQL, the filter dropdowns, the status
+ * icons) is interpreting an unconstrained string. Each of those used to
+ * carry its own copy of the list, bound to nothing, so a new status reached
+ * exactly none of them: rows would group into a column that does not exist
+ * and drop out of the counts.
+ *
+ * Declaration order is display order. The kanban board, the filter menu and
+ * the grouped counts all render these in the order given here.
+ */
+export const TASK_STATUS = {
+  OPEN: "open",
+  IN_PROGRESS: "in_progress",
+  IN_REVIEW: "in_review",
+  DONE: "done",
+  CANCELLED: "cancelled",
+} as const;
+
+export type TaskStatus = (typeof TASK_STATUS)[keyof typeof TASK_STATUS];
+
+export const TASK_STATUSES = Object.values(TASK_STATUS);
+
+export const isTaskStatus = (value: unknown): value is TaskStatus =>
+  typeof value === "string" && TASK_STATUSES.some((status) => status === value);
+
+export const ENTITY_PRIORITY = {
+  NONE: "none",
+  URGENT: "urgent",
+  HIGH: "high",
+  MEDIUM: "medium",
+  LOW: "low",
+} as const;
+
+export type EntityPriority =
+  (typeof ENTITY_PRIORITY)[keyof typeof ENTITY_PRIORITY];
+
+export const ENTITY_PRIORITIES = Object.values(ENTITY_PRIORITY);
+
+export const isEntityPriority = (value: unknown): value is EntityPriority =>
+  typeof value === "string" &&
+  ENTITY_PRIORITIES.some((priority) => priority === value);

--- a/packages/api-contract/src/index.ts
+++ b/packages/api-contract/src/index.ts
@@ -5,6 +5,15 @@ export { CHAT_TOOL_SCOPE, CHAT_TURN_INTENT } from "./chat";
 export type { ChatSendRequest, SafeId } from "./chat";
 export { ENTITY_KINDS, isEntityKind } from "./entity-kinds";
 export type { EntityKind } from "./entity-kinds";
+export {
+  ENTITY_PRIORITIES,
+  ENTITY_PRIORITY,
+  isEntityPriority,
+  isTaskStatus,
+  TASK_STATUS,
+  TASK_STATUSES,
+} from "./entity-options";
+export type { EntityPriority, TaskStatus } from "./entity-options";
 export { API_VALIDATION_ERROR_CODE, normalizeApiError } from "./error";
 export type {
   ApiErrorInput,


### PR DESCRIPTION
Extends the entity-kind consolidation to the option sets an entity's own columns range over, and makes the kanban grouping carry its own labels. Fourth in the stack; based on #1748.

## Option sets

`entities.status` and `entities.priority` are plain varchar columns, so every consumer that enumerates them is interpreting an unconstrained string. Each carried its own copy of the list:

- task status: `entity-constants.ts`, `kanban-group-condition.ts` (SQL `CASE` for kanban grouping), `read-group-counts.ts` (SQL `CASE` for grouped counts), `task-detail-constants.ts`, `kanban-view.logic.ts`, `view-toolbar-filters.tsx`
- priority: `entity-constants.ts`, `task-detail-constants.ts`, `view-toolbar-filters.tsx`

None referenced another, so a new member reached none of them: rows would group into a column that does not exist and drop out of the counts.

`TASK_STATUS` / `TaskStatus` / `isTaskStatus` and `ENTITY_PRIORITY` / `EntityPriority` / `isEntityPriority` now live in `@stll/api-contract`, following the `ENTITY_KINDS` pattern from #1746, and every site derives from them. The named-constant access (`TASK_STATUS.DONE`) used by the API call sites is preserved by re-export, so those files are untouched. The arrays are frozen and typed `readonly`: an in-place sort or push on the single declaration would reorder the kanban columns and the filter menus at once. Declaration order is display order and is unchanged.

## Two entity-kind copies #1746 did not reach

- `kanban-group-condition.ts` carried a full hand-written `ENTITY_KIND_VALUES` plus its own guard; both now come from `@stll/api-contract`
- `kanban-view.logic.ts` hand-typed the union in a `Record` key position (`Record<"document" | "folder" | ..., string>`) and hand-listed all five members again in `getEntityKindGroupOptions`; both derive from `EntityKind` / `ENTITY_KINDS`

## Grouping labels

`resolveGroupOptions` took the grouping plus every label map as sibling fields. A status board could therefore be resolved with an empty status map, in which case the column headings fell back to raw values such as `in_progress`, and a layout that never groups by status still had to supply one (`EMPTY_STATUS_LABELS = {}` existed for exactly that).

The params are now a discriminated union carrying only the labels each grouping consumes, with a `never` default over the four arms. `TaskStatusLabels` is total over `TaskStatus`, so the `labels[status] ?? status` fallback is gone and `EMPTY_STATUS_LABELS` is no longer representable.

Worth noting for reviewers: the discriminant sits at the top level of the params rather than nested under a `grouping` field, because TypeScript narrows a union only by its own properties. `params.grouping.type === "status"` does not narrow `params`; that shape was tried first and does not compile.

`STATUS_OPTION_COLORS` was `Record<string, OptionColor>` read as `STATUS_OPTION_COLORS[status] ?? "gray"`. It is now `as const satisfies Record<TaskStatus, OptionColor>` with the fallback removed, so a new status fails to typecheck rather than rendering gray.

## Verification

- `bun --filter @stll/api typecheck`, `bun --filter @stll/web typecheck`, `bun --filter @stll/api-contract typecheck`: clean
- `bun --filter @stll/api lint`, `bun --filter @stll/web lint`: clean
- `bun --filter @stll/api-contract test`: 39 pass
- `bun --filter @stll/web test`: 1494 + 54 pass, 0 fail
- `bun scripts/ratchet.ts --check`: OK, 22 metrics at or below baseline; no baseline reseeded, no suppressions added

CC on behalf of jan-kubica

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of unexpected task statuses and priorities, with safe fallback colours and icons.
  - Prevented invalid values from disrupting task rows, calendar views, or status displays.
  - Added telemetry for invalid task-option values to support monitoring.

- **Improvements**
  - Standardised task status, priority, and grouping options across Kanban, table, calendar, and filter views.
  - Improved grouping configuration so status and entity-kind options remain complete and consistent.
  - Added validation coverage for invalid, empty, null, and malformed status and priority values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->