### PR TITLE
fix(ci): accept configured alert webhook headers

### DIFF
--- a/.github/workflows/scheduled-run-alerts.yml
+++ b/.github/workflows/scheduled-run-alerts.yml
@@ -31,11 +31,14 @@ jobs:
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
           RUN_EVENT: ${{ github.event.workflow_run.event }}
         run: |
-          if [ -z "$WEBHOOK_URL" ] || [ -z "$WEBHOOK_TOKEN" ]; then
-            echo "::error::scheduled-run alert webhook secrets are not configured"
+          if [ -z "$WEBHOOK_URL" ]; then
+            echo "::error::scheduled-run alert webhook URL is not configured"
             exit 1
           fi
           header_args=()
+          if [ -n "$WEBHOOK_TOKEN" ]; then
+            header_args+=(-H "Authorization: Bearer $WEBHOOK_TOKEN")
+          fi
           if [ -n "$WEBHOOK_HEADERS" ]; then
             while IFS= read -r header; do
               if [ -n "$header" ]; then
@@ -43,9 +46,12 @@ jobs:
               fi
             done <<< "$WEBHOOK_HEADERS"
           fi
+          if [ "${#header_args[@]}" -eq 0 ]; then
+            echo "::error::scheduled-run alert webhook credentials are not configured"
+            exit 1
+          fi
           jq -n --arg text "Failed workflow: $WORKFLOW_NAME (event: $RUN_EVENT, branch: $HEAD_BRANCH, head sha: $HEAD_SHA). Run: $RUN_URL" '{text: $text}' |
             curl --fail-with-body -sS -X POST \
-              -H "Authorization: Bearer $WEBHOOK_TOKEN" \
               -H "content-type: application/json" \
               "${header_args[@]}" \
               --data-binary @- \

--- a/scripts/check-api-deployment.test.ts
+++ b/scripts/check-api-deployment.test.ts
@@ -4,6 +4,23 @@ import { getApiHealthUrl, parseHealthCommit } from "./api-health";
 import { advanceDeploymentStability } from "./check-api-deployment";
 
 describe("API deployment health receipt", () => {
+  test("supports either scheduled-alert authentication mechanism", async () => {
+    const workflow = await Bun.file(
+      new URL("../.github/workflows/scheduled-run-alerts.yml", import.meta.url),
+    ).text();
+
+    expect(workflow).toContain('if [ -z "$WEBHOOK_URL" ]; then');
+    expect(workflow).toContain('if [ -n "$WEBHOOK_TOKEN" ]; then');
+    expect(workflow).toContain(
+      'header_args+=(-H "Authorization: Bearer $WEBHOOK_TOKEN")',
+    );
+    expect(workflow).toContain('done <<< "$WEBHOOK_HEADERS"');
+    expect(workflow).toContain(`if [ "\${#header_args[@]}" -eq 0 ]; then`);
+    expect(
+      workflow.match(/Authorization: Bearer \$WEBHOOK_TOKEN/gu),
+    ).toHaveLength(1);
+  });
+
   test("ties staging promotion to the current health gate", async () => {
     const workflow = await Bun.file(
       new URL("../.github/workflows/deploy-staging.yml", import.meta.url),


### PR DESCRIPTION
## Why

The scheduled-run alert workflow currently requires `SCHEDULED_ALERTS_WEBHOOK_TOKEN`, but this repository is intentionally configured with `SCHEDULED_ALERTS_WEBHOOK_HEADERS` instead. Every observed workflow failure therefore creates a second red alert run before it attempts delivery.

## What

- require the webhook URL independently
- accept either the bearer-token secret or one or more custom header lines
- still fail closed when neither credential mechanism is configured
- cover the workflow contract with a source invariant test

## Validation

- `bun test scripts/check-api-deployment.test.ts scripts/check-staging-deploy-decision.test.ts` (22 pass)
- `bash scripts/create-release-manifest.test.sh`
- `bun run typecheck:repo`
- pre-commit and pre-push hooks (code-check, format, i18n, secrets)

CC on behalf of jan-kubica

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Scheduled alert webhooks now support authentication through either a bearer token or configured custom headers.
  - Bearer authentication is applied only when a token is provided, allowing webhook services with alternative authentication methods.
- **Bug Fixes**
  - Improved validation provides clearer failure handling when the webhook URL or authentication credentials are missing.
  - Scheduled alerts no longer require a specifically named token configuration to authenticate successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->