### PR TITLE
fix(case-law): carry corpus-index cursors at exact timestamp precision

### DIFF
--- a/apps/api/src/handlers/case-law/corpus-index-generation-backfill.db.test.ts
+++ b/apps/api/src/handlers/case-law/corpus-index-generation-backfill.db.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeAll, expect, test } from "bun:test";
-import { and, desc, eq, sql } from "drizzle-orm";
+import { and, desc, eq, inArray, sql } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/pglite";
 
 import type { Transaction } from "@/api/db/root";
@@ -22,6 +22,7 @@ import {
 } from "@/api/handlers/case-law/corpus-index";
 import { toSafeId } from "@/api/lib/branded-types";
 import type { SafeId } from "@/api/lib/branded-types";
+import { timestampCasToken } from "@/api/lib/db/timestamp-cas";
 import { ConcurrentModificationError } from "@/api/lib/errors/tagged-errors";
 import {
   caseLawCorpusProjectionJoin,
@@ -198,7 +199,7 @@ const queueSourceReconciliation = async (
   const boundary = (
     await db
       .select({
-        createdAt: caseLawDecisions.createdAt,
+        createdAtToken: timestampCasToken(caseLawDecisions.createdAt),
         id: caseLawDecisions.id,
       })
       .from(caseLawDecisions)
@@ -206,12 +207,17 @@ const queueSourceReconciliation = async (
       .orderBy(desc(caseLawDecisions.createdAt), desc(caseLawDecisions.id))
       .limit(1)
   ).at(0);
+  // The SQL trigger stamps the watermark in the database, so the fixture
+  // carries the exact stored timestamp rather than a truncated `Date`.
+  const upperCreatedAt = boundary
+    ? sql`${boundary.createdAtToken}::timestamptz`
+    : null;
   await db
     .insert(caseLawCorpusIndexSourceReconciliations)
     .values({
       generation,
       sourceId,
-      upperCreatedAt: boundary?.createdAt ?? null,
+      upperCreatedAt,
       upperId: boundary?.id ?? null,
     })
     .onConflictDoUpdate({
@@ -223,7 +229,7 @@ const queueSourceReconciliation = async (
         cursorCreatedAt: null,
         cursorId: null,
         revision: sql`${caseLawCorpusIndexSourceReconciliations.revision} + 1`,
-        upperCreatedAt: boundary?.createdAt ?? null,
+        upperCreatedAt,
         upperId: boundary?.id ?? null,
       },
     });
@@ -2354,6 +2360,119 @@ test("rejects a pending hash without a pending action", async () => {
     "case_law_corpus_index_projections_pending_revision_nonnegative",
   );
 });
+
+test(
+  "a microsecond-precision keyset drains instead of re-serving its cursor row",
+  async () => {
+    // Postgres timestamps carry microseconds, a JS `Date` carries
+    // milliseconds. A cursor read back as a `Date` is truncated, so the page
+    // predicate re-selects the row the cursor was written from and the walk
+    // never empties. These fixtures share one millisecond and differ only
+    // below it: the only shape that tells an exact cursor from a truncated
+    // one.
+    const generation = "case_law_v40";
+    const microsecondFixtures = [
+      "2026-07-30 21:38:52.982238+00",
+      "2026-07-30 21:38:52.982239+00",
+      "2026-07-30 21:38:52.982240+00",
+      "2026-07-30 21:38:52.982999+00",
+    ].map((createdAt, index) => ({
+      createdAt,
+      id: toSafeId<"caseLawDecision">(
+        `00000000-0000-4000-8000-00000000040${index}`,
+      ),
+    }));
+    const microsecondIds = microsecondFixtures.map(({ id }) => id);
+
+    await db.insert(caseLawDecisions).values(
+      microsecondFixtures.map(({ createdAt, id }, index) => ({
+        caseNumber: `40 T ${index}/2026`,
+        contentHash: `microsecond-${index}`,
+        country: "CZE",
+        court: "Microsecond court",
+        createdAt: sql`${createdAt}::timestamptz`,
+        decisionDate: "2026-01-01",
+        fulltext: "text",
+        id,
+        language: "cs",
+        languageGroupKey: `microsecond-${index}`,
+        slug: `microsecond-${index}`,
+        sourceId: publicSourceId,
+      })),
+    );
+
+    try {
+      // Guards the fixture itself: a millisecond-seeded row cannot reproduce
+      // the defect, so the seed must survive the round trip with distinct
+      // microseconds that collapse to a single millisecond.
+      const precision = (
+        await db
+          .select({
+            exact: sql<number>`count(distinct ${caseLawDecisions.createdAt})::int`,
+            truncated: sql<number>`count(distinct date_trunc('milliseconds', ${caseLawDecisions.createdAt}))::int`,
+          })
+          .from(caseLawDecisions)
+          .where(inArray(caseLawDecisions.id, microsecondIds))
+      ).at(0);
+      expect(precision).toEqual({
+        exact: microsecondFixtures.length,
+        truncated: 1,
+      });
+
+      const indexed: SafeId<"caseLawDecision">[] = [];
+      const backfill = createCaseLawGenerationBackfill({
+        backfillRows: async (_runnerDb, rows, _generation, options) => {
+          await options.beforeRemoteEffect({
+            effect: completeRemoteEffect,
+            onLeaseLost: noRemoteEffectCompensation,
+          });
+          indexed.push(...rows.map(({ id }) => id));
+          return rows.length;
+        },
+        newLeaseToken: () => "00000000-0000-4000-8000-000000000940",
+        removeProjection: ignoreProjectionRemoval,
+      });
+
+      // One row per page, so a correct walk needs at most one drive per
+      // decision plus the drive that observes the drained snapshot.
+      const decisionCount = (
+        await db
+          .select({ value: sql<number>`count(*)::int` })
+          .from(caseLawDecisions)
+      ).at(0)?.value;
+      if (decisionCount === undefined) {
+        throw new Error("expected a decision count");
+      }
+      const driveLimit = decisionCount + 2;
+      const driveUntilComplete = async (drives = 0): Promise<number> => {
+        if (drives >= driveLimit) {
+          return drives;
+        }
+        const { status } = await backfill(scopedDb, 1, generation);
+        return status === "complete"
+          ? drives + 1
+          : await driveUntilComplete(drives + 1);
+      };
+
+      expect(await driveUntilComplete()).toBeLessThan(driveLimit);
+      expect(await readCheckpoint(generation)).toMatchObject({
+        status: "complete",
+      });
+      expect(indexed).toHaveLength(new Set(indexed).size);
+      expect(indexed.filter((id) => microsecondIds.includes(id))).toEqual(
+        microsecondIds,
+      );
+    } finally {
+      await db
+        .delete(caseLawDecisions)
+        .where(inArray(caseLawDecisions.id, microsecondIds));
+      await db
+        .delete(caseLawCorpusIndexBackfills)
+        .where(eq(caseLawCorpusIndexBackfills.generation, generation));
+    }
+  },
+  { timeout: 30_000 },
+);
 
 test(
   "a trigger-seeded projection reserves as append-safe until a reservation crosses the boundary",

--- a/apps/api/src/handlers/case-law/corpus-index.ts
+++ b/apps/api/src/handlers/case-law/corpus-index.ts
@@ -42,6 +42,7 @@ import {
 import {
   timestampCasToken,
   type TimestampCasToken,
+  timestampMatchesCasToken,
 } from "@/api/lib/db/timestamp-cas";
 import { ConcurrentModificationError } from "@/api/lib/errors/tagged-errors";
 import { CorpusIndexError } from "@/api/lib/legal-search/corpus-index-client";
@@ -126,7 +127,7 @@ const SELECT_COLUMNS = {
   generationPendingAction: sql<CaseLawCorpusIndexProjectionAction | null>`null`,
   generationPendingIndexIds: sql<string[]>`'{}'::varchar(64)[]`,
   generationPendingRevision: sql<number>`0`,
-  createdAt: caseLawDecisions.createdAt,
+  createdAtToken: timestampCasToken(caseLawDecisions.createdAt),
   updatedAtToken: timestampCasToken(caseLawDecisions.updatedAt),
 };
 
@@ -1026,27 +1027,43 @@ const backfillIncrementalCorpusIndex = async (
   }
 };
 
+/**
+ * Keyset and snapshot timestamps travel as exact-precision text tokens, never
+ * as `Date`: Postgres keeps microseconds, a `Date` keeps milliseconds, and a
+ * truncated cursor re-selects the row it was written from forever.
+ */
 type GenerationBackfillCheckpoint = {
-  cursorCreatedAt: Date | null;
+  cursorCreatedAt: TimestampCasToken | null;
   cursorId: SafeId<"caseLawDecision"> | null;
   generation: string;
   generationOrder: number;
-  snapshotAt: Date;
+  snapshotAt: TimestampCasToken;
+};
+
+const GENERATION_CHECKPOINT_COLUMNS = {
+  cursorCreatedAt: timestampCasToken(
+    caseLawCorpusIndexBackfills.cursorCreatedAt,
+  ),
+  cursorId: caseLawCorpusIndexBackfills.cursorId,
+  generation: caseLawCorpusIndexBackfills.generation,
+  generationOrder: caseLawCorpusIndexBackfills.generationOrder,
+  snapshotAt: timestampCasToken(caseLawCorpusIndexBackfills.snapshotAt),
+  status: caseLawCorpusIndexBackfills.status,
 };
 
 type GenerationBackfillRow = IndexableRow & {
-  createdAt: Date;
+  createdAtToken: TimestampCasToken;
   generationIndexedHash: string | null;
   sourceDescriptor: CorpusSourceDescriptor | null;
 };
 
 type SourceReconciliationCheckpoint = {
-  cursorCreatedAt: Date | null;
+  cursorCreatedAt: TimestampCasToken | null;
   cursorId: SafeId<"caseLawDecision"> | null;
   generation: string;
   revision: number;
   sourceId: SafeId<"caseLawSource">;
-  upperCreatedAt: Date | null;
+  upperCreatedAt: TimestampCasToken | null;
   upperId: SafeId<"caseLawDecision"> | null;
 };
 
@@ -1161,8 +1178,13 @@ const sameCursor = ({
 }: {
   checkpoint: GenerationBackfillCheckpoint;
 }) =>
-  sql`${caseLawCorpusIndexBackfills.cursorCreatedAt} IS NOT DISTINCT FROM ${checkpoint.cursorCreatedAt}
-      AND ${caseLawCorpusIndexBackfills.cursorId} IS NOT DISTINCT FROM ${checkpoint.cursorId}`;
+  and(
+    timestampMatchesCasToken(
+      caseLawCorpusIndexBackfills.cursorCreatedAt,
+      checkpoint.cursorCreatedAt,
+    ),
+    sql`${caseLawCorpusIndexBackfills.cursorId} IS NOT DISTINCT FROM ${checkpoint.cursorId}`,
+  );
 
 const nextLeaseExpiry = () =>
   sql<Date>`now() + (${BACKFILL_LEASE_MS} * interval '1 millisecond')`;
@@ -1207,10 +1229,10 @@ const selectGenerationBackfillPage = async (
       )
       .where(
         and(
-          lte(caseLawDecisions.createdAt, checkpoint.snapshotAt),
+          sql`${caseLawDecisions.createdAt} <= ${checkpoint.snapshotAt}::timestamptz`,
           checkpoint.cursorCreatedAt === null
             ? undefined
-            : sql`(${caseLawDecisions.createdAt}, ${caseLawDecisions.id}) > (${checkpoint.cursorCreatedAt}, ${checkpoint.cursorId})`,
+            : sql`(${caseLawDecisions.createdAt}, ${caseLawDecisions.id}) > (${checkpoint.cursorCreatedAt}::timestamptz, ${checkpoint.cursorId})`,
         ),
       )
       .orderBy(asc(caseLawDecisions.createdAt), asc(caseLawDecisions.id))
@@ -1270,10 +1292,10 @@ const selectGenerationEligibilityPage = async (
           eq(caseLawDecisions.sourceId, checkpoint.sourceId),
           checkpoint.upperCreatedAt === null
             ? sql`false`
-            : sql`(${caseLawDecisions.createdAt}, ${caseLawDecisions.id}) <= (${checkpoint.upperCreatedAt}, ${checkpoint.upperId})`,
+            : sql`(${caseLawDecisions.createdAt}, ${caseLawDecisions.id}) <= (${checkpoint.upperCreatedAt}::timestamptz, ${checkpoint.upperId})`,
           checkpoint.cursorCreatedAt === null
             ? undefined
-            : sql`(${caseLawDecisions.createdAt}, ${caseLawDecisions.id}) > (${checkpoint.cursorCreatedAt}, ${checkpoint.cursorId})`,
+            : sql`(${caseLawDecisions.createdAt}, ${caseLawDecisions.id}) > (${checkpoint.cursorCreatedAt}::timestamptz, ${checkpoint.cursorId})`,
         ),
       )
       .orderBy(asc(caseLawDecisions.createdAt), asc(caseLawDecisions.id))
@@ -1288,14 +1310,16 @@ const selectSourceReconciliationCheckpoint = async (
     (
       await tx
         .select({
-          cursorCreatedAt:
+          cursorCreatedAt: timestampCasToken(
             caseLawCorpusIndexSourceReconciliations.cursorCreatedAt,
+          ),
           cursorId: caseLawCorpusIndexSourceReconciliations.cursorId,
           generation: caseLawCorpusIndexSourceReconciliations.generation,
           revision: caseLawCorpusIndexSourceReconciliations.revision,
           sourceId: caseLawCorpusIndexSourceReconciliations.sourceId,
-          upperCreatedAt:
+          upperCreatedAt: timestampCasToken(
             caseLawCorpusIndexSourceReconciliations.upperCreatedAt,
+          ),
           upperId: caseLawCorpusIndexSourceReconciliations.upperId,
         })
         .from(caseLawCorpusIndexSourceReconciliations)
@@ -1360,9 +1384,15 @@ const sameSourceReconciliation = (checkpoint: SourceReconciliationCheckpoint) =>
     ),
     eq(caseLawCorpusIndexSourceReconciliations.sourceId, checkpoint.sourceId),
     eq(caseLawCorpusIndexSourceReconciliations.revision, checkpoint.revision),
-    sql`${caseLawCorpusIndexSourceReconciliations.cursorCreatedAt} IS NOT DISTINCT FROM ${checkpoint.cursorCreatedAt}`,
+    timestampMatchesCasToken(
+      caseLawCorpusIndexSourceReconciliations.cursorCreatedAt,
+      checkpoint.cursorCreatedAt,
+    ),
     sql`${caseLawCorpusIndexSourceReconciliations.cursorId} IS NOT DISTINCT FROM ${checkpoint.cursorId}`,
-    sql`${caseLawCorpusIndexSourceReconciliations.upperCreatedAt} IS NOT DISTINCT FROM ${checkpoint.upperCreatedAt}`,
+    timestampMatchesCasToken(
+      caseLawCorpusIndexSourceReconciliations.upperCreatedAt,
+      checkpoint.upperCreatedAt,
+    ),
     sql`${caseLawCorpusIndexSourceReconciliations.upperId} IS NOT DISTINCT FROM ${checkpoint.upperId}`,
   );
 
@@ -1416,7 +1446,7 @@ export const createCaseLawGenerationBackfill =
         // audit: skip — the checkpoint is the durable audit trail for this derived projection rebuild
         const existing = (
           await tx
-            .select()
+            .select(GENERATION_CHECKPOINT_COLUMNS)
             .from(caseLawCorpusIndexBackfills)
             .where(eq(caseLawCorpusIndexBackfills.generation, generation))
             .limit(1)
@@ -1436,7 +1466,7 @@ export const createCaseLawGenerationBackfill =
           .insert(caseLawCorpusIndexBackfills)
           .values({ generation, snapshotAt: sql`clock_timestamp()` })
           .onConflictDoNothing()
-          .returning();
+          .returning(GENERATION_CHECKPOINT_COLUMNS);
         const created = inserted.at(0);
         if (created) {
           return created;
@@ -1444,7 +1474,7 @@ export const createCaseLawGenerationBackfill =
 
         const concurrent = (
           await tx
-            .select()
+            .select(GENERATION_CHECKPOINT_COLUMNS)
             .from(caseLawCorpusIndexBackfills)
             .where(eq(caseLawCorpusIndexBackfills.generation, generation))
             .limit(1)
@@ -1602,7 +1632,7 @@ export const createCaseLawGenerationBackfill =
             const rows = await tx
               .update(caseLawCorpusIndexSourceReconciliations)
               .set({
-                cursorCreatedAt: lastSourceRow.createdAt,
+                cursorCreatedAt: sql`${lastSourceRow.createdAtToken}::timestamptz`,
                 cursorId: lastSourceRow.id,
                 updatedAt: sql`now()`,
               })
@@ -1730,7 +1760,7 @@ export const createCaseLawGenerationBackfill =
                 ),
               ),
             )
-            .returning();
+            .returning(GENERATION_CHECKPOINT_COLUMNS);
           return claimedRows.at(0);
         });
         if (!claimedReconciliation) {
@@ -1777,7 +1807,7 @@ export const createCaseLawGenerationBackfill =
               ),
             ),
           )
-          .returning();
+          .returning(GENERATION_CHECKPOINT_COLUMNS);
         return rows.at(0);
       });
       if (!claimed) {
@@ -1823,7 +1853,7 @@ export const createCaseLawGenerationBackfill =
                 }),
               ),
             )
-            .returning();
+            .returning(GENERATION_CHECKPOINT_COLUMNS);
           return rows.at(0);
         });
         if (!completed) {
@@ -1903,7 +1933,7 @@ export const createCaseLawGenerationBackfill =
         const advancedRows = await tx
           .update(caseLawCorpusIndexBackfills)
           .set({
-            cursorCreatedAt: last.createdAt,
+            cursorCreatedAt: sql`${last.createdAtToken}::timestamptz`,
             cursorId: last.id,
             leaseExpiresAt: null,
             leaseToken: null,

--- a/apps/api/src/lib/db/timestamp-cas.ts
+++ b/apps/api/src/lib/db/timestamp-cas.ts
@@ -1,5 +1,5 @@
 import { sql } from "drizzle-orm";
-import type { AnyColumn, SQL } from "drizzle-orm";
+import type { AnyColumn, Column, SQL } from "drizzle-orm";
 
 /**
  * Compare-and-set token for a `timestamp` column.
@@ -16,12 +16,26 @@ export type TimestampCasToken = string & {
   readonly __timestampCasToken: "TimestampCasToken";
 };
 
-/** Select expression producing the column's exact-precision CAS token. */
-export const timestampCasToken = (column: AnyColumn): SQL<TimestampCasToken> =>
-  sql<TimestampCasToken>`${column}::text`;
+/**
+ * Token type for a column, derived from the column's own nullability so a
+ * nullable timestamp cannot be read back as a non-null token.
+ */
+type ColumnCasToken<TColumn extends Column> =
+  TColumn["_"]["notNull"] extends true
+    ? TimestampCasToken
+    : TimestampCasToken | null;
 
-/** WHERE fragment comparing the column against a previously selected token. */
+/** Select expression producing the column's exact-precision CAS token. */
+export const timestampCasToken = <TColumn extends Column>(
+  column: TColumn,
+): SQL<ColumnCasToken<TColumn>> => sql`${column}::text`;
+
+/**
+ * WHERE fragment comparing the column against a previously selected token.
+ * A `null` token matches only an unset column, which is what an absent cursor
+ * or watermark means.
+ */
 export const timestampMatchesCasToken = (
   column: AnyColumn,
-  token: TimestampCasToken,
+  token: TimestampCasToken | null,
 ): SQL => sql`${column} IS NOT DISTINCT FROM ${token}::timestamptz`;


### PR DESCRIPTION
## Problem

Postgres timestamps carry microseconds; a JavaScript `Date` carries milliseconds. The corpus-index generation rebuild read its keyset cursor, its snapshot bound and its lease compare-and-set operands back into `Date` values, narrowing each one on the way through.

A cursor written from a row whose `created_at` ends in `.982238` is stored as `.982000`. The page predicate is

```
(created_at, id) > (cursor_created_at, cursor_id)
```

so that row still compares as ahead of the cursor it produced. The page re-selects it on every pass and the walk cannot reach its end, which also means the rebuild never reports itself finished. The same narrowing leaves the lease compare-and-set (`IS NOT DISTINCT FROM`) unable to match an exact-precision stored value.

## Change

Carry those timestamps as the existing branded `TimestampCasToken` — the column's exact text form — and bind them back with `::timestamptz`. Passing a `Date` into a cursor, snapshot or compare-and-set operand is now a type error rather than something review has to catch.

- `timestampCasToken` derives its result nullability from the column, so a nullable cursor column cannot be read back as a non-null token.
- `timestampMatchesCasToken` accepts a null token: an unset cursor should match only an unset column.
- All five checkpoint reads share one `GENERATION_CHECKPOINT_COLUMNS` projection, so a later bare `select()` cannot reintroduce a `Date`.
- The source-reconciliation cursor and its bounds get the same treatment; both were affected.

## Test

`corpus-index-generation-backfill.db.test.ts` seeds four decisions inside a single millisecond (`.982238` … `.982999`) through raw SQL and drives the rebuild to completion under an iteration cap. A `Date`-seeded fixture cannot express sub-millisecond precision and so could not fail on this defect.

Verified non-vacuous: re-applying `date_trunc('milliseconds', …)` to the cursor write — precisely what a `Date` round trip does — fails the termination assertion.

## Notes

A test fixture helper mirrored the production trigger by writing its watermark as a `Date`; it carried the same defect in fixture form and is fixed alongside.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved corpus indexing backfills to preserve exact timestamp ordering.
  * Prevented records with closely spaced timestamps from being skipped or processed more than once.
  * Ensured backfill and reconciliation operations complete reliably, including when timestamps contain microsecond-level differences.
  * Improved handling of unset timestamp values during indexing and reconciliation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->