### PR TITLE
fix(case-law): bound the cz-us steady-state sweep

### DIFF
--- a/apps/api/src/handlers/case-law/ingestion/adapters/cz-us.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/cz-us.test.ts
@@ -2,7 +2,10 @@
 import { Result } from "better-result";
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
-import { czUsAdapter } from "@/api/handlers/case-law/ingestion/adapters/cz-us";
+import {
+  czUsAdapter,
+  recentWindowFloor,
+} from "@/api/handlers/case-law/ingestion/adapters/cz-us";
 import { asFetchMock } from "@/api/tests/helpers/test-tool-set";
 
 // ── Helpers ──────────────────────────────────────────────
@@ -208,10 +211,11 @@ describe("czUsAdapter.fetchPage", () => {
     expect(caseNumbers).toContain("III.ÚS 3/24");
   });
 
-  test("parks cursor at current year after reaching 1993", async () => {
+  test("hands the exhausted descent over to the recent sweep", async () => {
     // Only year 1993 (93): n=1 has a decision.
-    // After 30 misses at FIRST_YEAR, cursor should park at
-    // the current year (not null) to avoid re-scanning history.
+    // After 30 misses at FIRST_YEAR the descent is complete, so the
+    // cursor parks at the top of the recent window in the recent
+    // phase (never null, and never another lap over history).
     globalThis.fetch = asFetchMock(
       mock((input: string | URL | Request) => {
         const url = resolveUrl(input);
@@ -239,9 +243,115 @@ describe("czUsAdapter.fetchPage", () => {
 
     expect(result.value.decisions).toHaveLength(1);
     expect(result.value.decisions[0]?.caseNumber).toBe("I.ÚS 1/93");
-    // Must NOT be null — parks at current year
     const currentYear = new Date().getFullYear();
-    expect(result.value.nextCursor).toBe(`1:${currentYear}`);
+    expect(result.value.nextCursor).toBe(`1:${currentYear}:recent`);
+  });
+
+  test("the parked sweep stays inside the recent window", async () => {
+    // Every year back to 1993 holds decisions, so a sweep that fell
+    // back into the descent would be visible twice over: in the years
+    // it probes, and in the cursors it returns. Neither may leave the
+    // window, however many times the adapter is driven from the park.
+    const currentYear = new Date().getFullYear();
+    const floor = recentWindowFloor(currentYear);
+    const suffix = (year: number): string =>
+      String(year % 100).padStart(2, "0");
+    const windowSuffixes = new Set(
+      Array.from({ length: currentYear - floor + 1 }, (_, i) =>
+        suffix(floor + i),
+      ),
+    );
+
+    const probedSuffixes = new Set<string>();
+    globalThis.fetch = asFetchMock(
+      mock((input: string | URL | Request) => {
+        const url = resolveUrl(input);
+        if (url.includes("GetAbstract")) {
+          return Promise.resolve(new Response(makeEmptyPage()));
+        }
+        const match = /sz=I-(?<n>\d+)-(?<yr>\d+)_1/u.exec(url);
+        const n = Number(match?.groups?.["n"]);
+        const yr = match?.groups?.["yr"];
+        if (yr === undefined) {
+          return Promise.resolve(new Response(makeEmptyPage()));
+        }
+        probedSuffixes.add(yr);
+        // Every year of the court's existence has decisions at n=1..2.
+        return Promise.resolve(
+          new Response(
+            n <= 2
+              ? makeTextPage(`I.ÚS ${n}/${yr}`, `1. 1. 20${yr}`)
+              : makeEmptyPage(),
+          ),
+        );
+      }),
+    );
+
+    let cursor = `1:${currentYear}:recent`;
+    let collected = 0;
+    for (let lap = 0; lap < 12; lap++) {
+      // oxlint-disable-next-line no-await-in-loop -- each lap resumes from the cursor the previous one returned
+      const result = await czUsAdapter.fetchPage(cursor, {});
+      expect(Result.isOk(result)).toBe(true);
+      if (!Result.isOk(result)) {
+        return;
+      }
+      collected += result.value.decisions.length;
+
+      const next = result.value.nextCursor;
+      expect(next).not.toBeNull();
+      const [, year, phase] = (next ?? "").split(":");
+      expect(phase).toBe("recent");
+      expect(Number(year)).toBeGreaterThanOrEqual(floor);
+      expect(Number(year)).toBeLessThanOrEqual(currentYear);
+      cursor = next ?? cursor;
+    }
+
+    expect(collected).toBeGreaterThan(0);
+    expect([...probedSuffixes].sort()).toEqual([...windowSuffixes].sort());
+  });
+
+  test("a legacy cursor without a phase resumes the historical descent", async () => {
+    // Stored cursors predating the phase segment are bare "number:year".
+    // 2001 holds two decisions, 2000 holds a full page of them: a
+    // descent below the recent window, which the recent phase never does.
+    globalThis.fetch = asFetchMock(
+      mock((input: string | URL | Request) => {
+        const url = resolveUrl(input);
+        if (url.includes("GetAbstract")) {
+          return Promise.resolve(new Response(makeEmptyPage()));
+        }
+        const match = /sz=I-(?<n>\d+)-(?<yr>\d+)_1/u.exec(url);
+        const n = match ? Number(match.groups?.["n"]) : 0;
+        const yr = match ? Number(match.groups?.["yr"]) : -1;
+        if (yr === 1 && n <= 2) {
+          return Promise.resolve(
+            new Response(makeTextPage(`I.ÚS ${n}/01`, "1. 1. 2001")),
+          );
+        }
+        if (yr === 0) {
+          return Promise.resolve(
+            new Response(makeTextPage(`II.ÚS ${n}/00`, "1. 1. 2000")),
+          );
+        }
+        return Promise.resolve(new Response(makeEmptyPage()));
+      }),
+    );
+
+    const result = await czUsAdapter.fetchPage("1:2001", {});
+
+    expect(Result.isOk(result)).toBe(true);
+    if (!Result.isOk(result)) {
+      return;
+    }
+
+    const caseNumbers = result.value.decisions.map((d) => d.caseNumber);
+    expect(caseNumbers).toContain("I.ÚS 1/01");
+    expect(caseNumbers).toContain("II.ÚS 1/00");
+
+    const [, year, phase] = (result.value.nextCursor ?? "").split(":");
+    expect(year).toBe("2000");
+    expect(phase).toBe("historical");
   });
 
   test("respects PAGE_SIZE limit", async () => {
@@ -267,7 +377,7 @@ describe("czUsAdapter.fetchPage", () => {
     }
 
     expect(result.value.decisions).toHaveLength(50);
-    expect(result.value.nextCursor).toBe("51:2025");
+    expect(result.value.nextCursor).toBe("51:2025:historical");
   });
 
   test("abstract failure does not drop the decision", async () => {

--- a/apps/api/src/handlers/case-law/ingestion/adapters/cz-us.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/cz-us.ts
@@ -1,4 +1,4 @@
-import { Result } from "better-result";
+import { Result, panic } from "better-result";
 import * as cheerio from "cheerio";
 
 import {
@@ -43,8 +43,10 @@ const COMMON_HEADERS = {
  * Empty pages (non-existent numbers) return HTTP 200 with
  * no "ze dne" in the registry sign.
  *
- * Cursor format: "number:year" (e.g. "100:2025").
- * A null cursor starts from the current year.
+ * Cursor format: "number:year:phase" (e.g. "100:2025:historical").
+ * The phase segment is optional: a stored "number:year" predates it
+ * and is read as a historical descent. A null cursor starts the
+ * historical descent at the current year.
  */
 
 const BASE_URL = "https://nalus.usoud.cz/Search/GetText.aspx";
@@ -65,6 +67,53 @@ const PROBE_CONCURRENCY = 5;
 
 /** First year of the Constitutional Court's existence. */
 const FIRST_YEAR = 1993;
+
+/**
+ * Which sweep the cursor is in.
+ *
+ * NALUS has no list endpoint, so decisions are discovered by probing case
+ * numbers. The first pass has to walk every year back to FIRST_YEAR; once
+ * it has, descending through those years again re-fetches the whole corpus
+ * to store nothing (rule 13). Holes the descent left behind belong to a
+ * reconciliation pass, not to the live cursor (rule 16).
+ */
+const SWEEP_PHASE = {
+  /** First pass: walking years backward toward FIRST_YEAR. */
+  HISTORICAL: "historical",
+  /** Descent done: only the recent window is swept, repeatedly. */
+  RECENT: "recent",
+} as const;
+
+type SweepPhase = (typeof SWEEP_PHASE)[keyof typeof SWEEP_PHASE];
+
+const SWEEP_PHASES: readonly SweepPhase[] = Object.values(SWEEP_PHASE);
+
+/**
+ * Years the steady-state sweep covers, counting the current one.
+ *
+ * A case number carries the year the case was filed, not the year it was
+ * decided, and the Court often rules a year or two after filing. A window
+ * of one year would therefore never see those decisions at all.
+ */
+const RECENT_WINDOW_YEARS = 3;
+
+/** Oldest year the steady-state sweep may reach. */
+export const recentWindowFloor = (currentYear: number): number =>
+  Math.max(FIRST_YEAR, currentYear - RECENT_WINDOW_YEARS + 1);
+
+/** Oldest year the given phase may descend to. */
+const sweepFloor = (phase: SweepPhase, currentYear: number): number => {
+  switch (phase) {
+    case SWEEP_PHASE.HISTORICAL:
+      return FIRST_YEAR;
+    case SWEEP_PHASE.RECENT:
+      return recentWindowFloor(currentYear);
+    default: {
+      const unhandled: never = phase;
+      return panic(`Unhandled cz-us sweep phase: ${String(unhandled)}`);
+    }
+  }
+};
 
 /** Zero-pad 2-digit year suffix for NALUS URLs. */
 const toYearSuffix = (year: number): string =>
@@ -330,7 +379,23 @@ const parseDecisionPage = (
   };
 };
 
-type CursorState = { number: number; year: number };
+type CursorState = { number: number; year: number; phase: SweepPhase };
+
+/**
+ * Read the phase segment. Cursors stored before it existed are bare
+ * "number:year" and are mid-descent by definition; an unrecognised
+ * segment is a corrupt cursor and must not silently restart a sweep.
+ */
+const parsePhase = (segment: string | undefined): SweepPhase => {
+  if (segment === undefined) {
+    return SWEEP_PHASE.HISTORICAL;
+  }
+  const phase = SWEEP_PHASES.find((candidate) => candidate === segment);
+  if (!phase) {
+    throw new TypeError("Invalid cz-us cursor phase");
+  }
+  return phase;
+};
 
 const parseCursor = (cursor: string): CursorState => {
   const parts = cursor.split(":");
@@ -344,10 +409,11 @@ const parseCursor = (cursor: string): CursorState => {
     throw new TypeError("Invalid cz-us cursor format");
   }
 
-  return { number, year };
+  return { number, year, phase: parsePhase(parts.at(2)) };
 };
 
-const makeCursor = (s: CursorState): string => `${s.number}:${s.year}`;
+const makeCursor = (s: CursorState): string =>
+  `${s.number}:${s.year}:${s.phase}`;
 
 export const czUsAdapter: SourceAdapter = {
   key: ADAPTER_KEYS.CZ_US,
@@ -355,10 +421,20 @@ export const czUsAdapter: SourceAdapter = {
   country: "CZE",
   language: "cs",
   minRequestIntervalMs: 100,
-  // Each fetchPage probes numbers in batches of PROBE_CONCURRENCY.
-  // ~50 hits + 30 miss gap = ~80 probes ÷ 5 = 16 batches × ~2s = 32s.
+  // Each fetchPage probes numbers in batches of PROBE_CONCURRENCY and
+  // then fetches one abstract per hit, serially:
+  // ~50 hits + 30 miss gap = ~80 probes ÷ 5 = 16 batches × ~2s = ~32s,
+  // plus ~50 abstract fetches × ~0.5s = ~25s, so ~55s per page.
+  //
+  // maxSyncPages × pageTimeoutMs (10 × 120s) is below maxCycleMs, so the
+  // page budget is reachable even when every page runs to its timeout.
+  // A cycle that cannot reach it always ends as TIMEOUT, and the runner
+  // only backs off (cycle-progress `cycleWasIdle`) on a COMPLETED cycle
+  // that inserted nothing, so an unreachable budget pins a caught-up
+  // adapter to the 5s cadence and starves the other adapters.
   pageTimeoutMs: 120_000,
-  maxSyncPages: 20,
+  maxSyncPages: 10,
+  maxCycleMs: 30 * 60 * 1000,
 
   /**
    * NALUS reports its total only on a search result page, and a search
@@ -449,7 +525,7 @@ export const czUsAdapter: SourceAdapter = {
 
         const state: CursorState = cursor
           ? parseCursor(cursor)
-          : { number: 1, year: currentYear };
+          : { number: 1, year: currentYear, phase: SWEEP_PHASE.HISTORICAL };
 
         const decisions: IngestionResult[] = [];
         let consecutiveMisses = 0;
@@ -584,13 +660,23 @@ export const czUsAdapter: SourceAdapter = {
             await Bun.sleep(backoffMs(0, 2000));
           }
 
-          // Too many consecutive numbers with no decisions:
-          // year exhausted, move to previous year (or park).
+          // Too many consecutive numbers with no decisions: year
+          // exhausted, move to the previous year within the phase's
+          // range. Below that range the sweep restarts at the top of
+          // the recent window; the historical descent hands over to the
+          // recent phase there and never walks the completed years again.
           if (consecutiveMisses >= MAX_CONSECUTIVE_MISSES) {
-            if (state.year <= FIRST_YEAR || state.year > currentYear) {
+            if (
+              state.year <= sweepFloor(state.phase, currentYear) ||
+              state.year > currentYear
+            ) {
               return {
                 decisions,
-                nextCursor: `1:${currentYear}`,
+                nextCursor: makeCursor({
+                  number: 1,
+                  year: currentYear,
+                  phase: SWEEP_PHASE.RECENT,
+                }),
               };
             }
             state.number = 1;


### PR DESCRIPTION
## Problem

NALUS publishes no list endpoint, so the cz-us adapter discovers decisions by probing case numbers, walking years backward from the current year to 1993. On exhausting the oldest year it returned `nextCursor: "1:<currentYear>"` — and from there the same year-decrement rule walked the entire range down again.

Each lap re-fetched every year already held, at two requests and a full parse per decision, and wrote nothing: the adapter's source hash is identity-only (`caseNumber|decisionDate`), so a stored decision can never produce a refresh. The work is unbounded and repeats indefinitely.

Rule 13 in the case-law guide asks an exhausted cursor to park where it re-scans only a *bounded recent window*. Parking at the current year satisfied the letter of that while leaving the sweep from the park point unbounded. The adapter's own unit test asserted the park value, so the behaviour was pinned rather than questioned.

## Change

The cursor gains an explicit phase, `<number>:<year>:<phase>`:

- `historical` — the first-pass descent toward 1993. Runs once.
- `recent` — the steady state, bounded to the recent window; years below it are never re-entered.

Reaching the bottom of the historical descent hands over to `recent` permanently. Holes the descent left behind (a failed fetch, a year cut short, years crawled before a parser fix) belong to a reconciliation pass rather than to the live cursor, per rule 16, so this change deliberately does not try to re-crawl them.

**Window size.** Three years, not one: a NALUS case number carries the year the case was *filed*, and the Court routinely rules a year or two after filing, so a one-year window would never see those decisions.

**Compatibility.** A stored two-segment cursor parses as `historical`, so existing state resumes its descent unchanged. A reverted deployment still reads the leading two segments and ignores the third. An unrecognised phase throws rather than silently defaulting, since a corrupt cursor must not quietly restart a sweep.

## Cycle budget

`maxSyncPages: 20` could not fit the ten-minute default cycle budget even in the best case, so every cycle ended in a timeout. That matters beyond the wasted time: the runner's idle backoff only counts a cycle as idle when it *completed*, so a permanently timing-out adapter never backs off and holds a cycle slot at the minimum delay.

Ten pages against an explicit thirty-minute budget is reachable. The budget comment now accounts for the ~50 serialized abstract fetches per page it previously omitted.

## Tests

The existing park test is retargeted to the corrected contract. Two added:

- driving repeatedly from a parked cursor never yields a year below the recent-window floor (the invariant, not one example);
- a legacy two-segment cursor still parses and resumes the historical descent.

## Tradeoff worth reviewing

With the idle backoff now able to engage, a fully quiet lap of the recent window takes considerably longer than the previous five-second cadence. Cadence returns to the fast path as soon as a page inserts anything, but discovery latency for an isolated new decision rises. The lever is `maxSyncPages`, not a wider sweep. A follow-up worth considering is probing the current year from the highest number downward, since new filings take high numbers — that would decouple discovery latency from lap length entirely.