### PR TITLE
fix(case-law): back off a crawl that fetches without writing

### DIFF
--- a/apps/legal-atlas-runner/src/runners/case-law-ingest.ts
+++ b/apps/legal-atlas-runner/src/runners/case-law-ingest.ts
@@ -215,19 +215,18 @@ const CITATION_AUTHORITY_STARTUP_DELAY_MS = 5 * 60 * 1000;
 const CITATION_AUTHORITY_RETRY_DELAY_MS = 10 * 60 * 1000;
 
 // Cadence backoff (thresholds, delays and the state machine live in
-// ./cycle-progress): an adapter that is caught up, or one that keeps
-// re-fetching decisions it already holds, polls once a day instead of every
-// CYCLE_DELAY_MS. Either resets to the fast cadence on the next cycle that
-// writes a row. Keeps us from hammering court servers in steady state, and
-// keeps a source that writes nothing from holding a cycle slot against
-// sources that have work.
+// ./cycle-progress): a caught-up adapter polls daily. One that keeps
+// re-fetching decisions it already holds polls hourly because that signal can
+// also describe a legitimate forward re-ingest. Either resets to the fast
+// cadence on the next cycle that writes a row. This keeps us from hammering
+// court servers in steady state without stalling a catch-up walk for months.
 
 /** Log line for entering a cadence, so a transition is greppable. */
 const CADENCE_ENTRY_MESSAGE = {
   [CYCLE_CADENCE.FAST]: "Resuming fast cadence",
   [CYCLE_CADENCE.CAUGHT_UP]: "Caught up; switching to daily polling",
   [CYCLE_CADENCE.UNPRODUCTIVE_BACKOFF]:
-    "Re-fetching stored decisions without writing any; switching to daily polling",
+    "Re-fetching stored decisions without writing any; switching to hourly polling",
 } as const satisfies Record<CycleCadence, string>;
 
 // Liveness watchdog. A self-scheduling timer measures how late it fires

--- a/apps/legal-atlas-runner/src/runners/case-law-ingest.ts
+++ b/apps/legal-atlas-runner/src/runners/case-law-ingest.ts
@@ -55,11 +55,16 @@ import {
 } from "../db";
 import { LEGAL_ATLAS_RUNNER_ENV } from "../env";
 import {
+  CYCLE_CADENCE,
+  CYCLE_CADENCE_DELAY_MS,
   CYCLE_OUTCOME,
+  type CadenceStreaks,
+  type CycleCadence,
   type CycleOutcome,
   type CycleResult,
+  INITIAL_CADENCE_STREAKS,
   cycleMadeProgress,
-  cycleWasIdle,
+  stepCadence,
 } from "./cycle-progress";
 import {
   RECOMPUTE_OUTCOME,
@@ -176,7 +181,8 @@ type SourceDef = {
 };
 
 const HEARTBEAT_PATH = "/tmp/ingestion.lock";
-const CYCLE_DELAY_MS = 5000;
+/** Base of the failure backoff, and the cadence a healthy adapter runs at. */
+const CYCLE_DELAY_MS = CYCLE_CADENCE_DELAY_MS[CYCLE_CADENCE.FAST];
 const HEALTH_INTERVAL_MS = 30_000;
 const SUSTAINED_FAILURE_THRESHOLD = 5;
 const SEARCH_INDEX_INTERVAL_MS = 10_000;
@@ -208,13 +214,21 @@ const CITATION_AUTHORITY_STARTUP_DELAY_MS = 5 * 60 * 1000;
 // `nextRecomputeDelayMs`.
 const CITATION_AUTHORITY_RETRY_DELAY_MS = 10 * 60 * 1000;
 
-// Idle backoff: once an adapter is caught up (no new decisions
-// for IDLE_THRESHOLD consecutive cycles), poll once a day instead
-// of every CYCLE_DELAY_MS. Resets to fast cadence on the next
-// non-zero insert. Keeps us from hammering court servers in
-// steady state.
-const IDLE_THRESHOLD = 3;
-const IDLE_DELAY_MS = 24 * 60 * 60 * 1000;
+// Cadence backoff (thresholds, delays and the state machine live in
+// ./cycle-progress): an adapter that is caught up, or one that keeps
+// re-fetching decisions it already holds, polls once a day instead of every
+// CYCLE_DELAY_MS. Either resets to the fast cadence on the next cycle that
+// writes a row. Keeps us from hammering court servers in steady state, and
+// keeps a source that writes nothing from holding a cycle slot against
+// sources that have work.
+
+/** Log line for entering a cadence, so a transition is greppable. */
+const CADENCE_ENTRY_MESSAGE = {
+  [CYCLE_CADENCE.FAST]: "Resuming fast cadence",
+  [CYCLE_CADENCE.CAUGHT_UP]: "Caught up; switching to daily polling",
+  [CYCLE_CADENCE.UNPRODUCTIVE_BACKOFF]:
+    "Re-fetching stored decisions without writing any; switching to daily polling",
+} as const satisfies Record<CycleCadence, string>;
 
 // Liveness watchdog. A self-scheduling timer measures how late it fires
 // versus its interval; sustained lag means the event loop is starved (a
@@ -638,6 +652,7 @@ const runOneCycle = async (
     return {
       outcome: CYCLE_OUTCOME.FAILED,
       inserted: 0,
+      skipped: 0,
       pagesProcessed: 0,
     };
   }
@@ -742,6 +757,7 @@ const runOneCycle = async (
   return {
     outcome,
     inserted: result?.inserted ?? 0,
+    skipped: result?.skipped ?? 0,
     pagesProcessed: result?.pagesProcessed ?? 0,
   };
 };
@@ -761,8 +777,9 @@ const runAdapterLoop = async ({ adapterKey, name }: SourceDef) => {
   let noProgressStreak = 0;
   /** Separate counter for backoff; not reset by the alert threshold. */
   let backoffFailures = 0;
-  /** Consecutive completed cycles with zero inserts; drives idle backoff. */
-  let idleCycles = 0;
+  /** Quiet and unproductive streaks; drive the inter-cycle delay. */
+  let streaks: CadenceStreaks = INITIAL_CADENCE_STREAKS;
+  let cadence: CycleCadence = CYCLE_CADENCE.FAST;
 
   while (true) {
     if (isDraining()) {
@@ -813,24 +830,22 @@ const runAdapterLoop = async ({ adapterKey, name }: SourceDef) => {
         backoffFailures++;
       } else {
         backoffFailures = 0;
-        // Idle means caught up with nothing to do, so only a clean cycle that
-        // found nothing counts toward it. Every other cycle reaching here
-        // moved through the source, and a halt or a timeout partway in is a
-        // source with work left rather than a quiet one: it has to clear the
-        // idle state, or the delay below parks a working adapter on the daily
-        // cadence for a day at a time.
-        if (cycleWasIdle(cycle)) {
-          idleCycles++;
-          if (idleCycles === IDLE_THRESHOLD) {
-            logInfo(`[${adapterKey}] Caught up; switching to daily polling`);
-          }
-        } else {
-          if (idleCycles >= IDLE_THRESHOLD) {
-            logInfo(
-              `[${adapterKey}] New decisions found; resuming fast cadence`,
-            );
-          }
-          idleCycles = 0;
+        // How the cycle ended does not decide the cadence; what it wrote
+        // does. An adapter whose page budget outlasts its cycle deadline
+        // times out every cycle, so keying the cadence on a clean outcome
+        // pinned a source re-fetching its stored corpus to the fast cadence
+        // forever, holding a cycle slot against sources with work.
+        const step = stepCadence(streaks, cycle);
+        streaks = step.streaks;
+        if (step.cadence !== cadence) {
+          cadence = step.cadence;
+          logInfo(`[${adapterKey}] ${CADENCE_ENTRY_MESSAGE[cadence]}`);
+        }
+        if (step.unproductiveRescan) {
+          logger.error("case_law.ingestion.unproductive_rescan", {
+            adapterKey,
+            ...step.unproductiveRescan,
+          });
         }
       }
     } catch (error) {
@@ -860,15 +875,11 @@ const runAdapterLoop = async ({ adapterKey, name }: SourceDef) => {
 
     writeHeartbeat();
     // Failure backoff wins when active (5s, 10s, 20s, 40s, cap 60s).
-    // Otherwise: idle delay if caught up, else fast cadence.
-    let delayMs: number;
-    if (backoffFailures > 0) {
-      delayMs = Math.min(CYCLE_DELAY_MS * 2 ** backoffFailures, 60_000);
-    } else if (idleCycles >= IDLE_THRESHOLD) {
-      delayMs = IDLE_DELAY_MS;
-    } else {
-      delayMs = CYCLE_DELAY_MS;
-    }
+    // Otherwise the cadence the last returned cycle earned.
+    const delayMs =
+      backoffFailures > 0
+        ? Math.min(CYCLE_DELAY_MS * 2 ** backoffFailures, 60_000)
+        : CYCLE_CADENCE_DELAY_MS[cadence];
     // oxlint-disable-next-line no-await-in-loop -- inter-cycle backoff/idle delay; the loop must pause before the next cycle, so this await is intentionally sequential
     await Bun.sleep(delayMs);
   }

--- a/apps/legal-atlas-runner/src/runners/cycle-progress.test.ts
+++ b/apps/legal-atlas-runner/src/runners/cycle-progress.test.ts
@@ -1,22 +1,107 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  CYCLE_CADENCE,
+  CYCLE_CADENCE_DELAY_MS,
   CYCLE_OUTCOME,
+  CYCLE_PRODUCTIVITY,
+  type CadenceStep,
+  type CadenceStreaks,
   type CycleOutcome,
+  type CycleResult,
+  INITIAL_CADENCE_STREAKS,
+  QUIET_THRESHOLD,
+  UNPRODUCTIVE_THRESHOLD,
+  classifyCycleProductivity,
   cycleMadeProgress,
-  cycleWasIdle,
+  stepCadence,
 } from "./cycle-progress";
 
 const OUTCOMES = Object.values(CYCLE_OUTCOME) satisfies readonly CycleOutcome[];
 
 /** Rows written in a cycle, spanning none through many. */
 const INSERTED = [0, 1, 250] as const;
+/** Decisions the dedup short-circuit dropped; 550 is a whole stored corpus. */
+const SKIPPED = [0, 1, 550] as const;
+const PAGES = [0, 1] as const;
+
+/** Every shape a returned cycle can take. */
+const CYCLES = OUTCOMES.flatMap((outcome) =>
+  INSERTED.flatMap((inserted) =>
+    SKIPPED.flatMap((skipped) =>
+      PAGES.map((pagesProcessed) => ({
+        outcome,
+        inserted,
+        skipped,
+        pagesProcessed,
+      })),
+    ),
+  ),
+) satisfies readonly CycleResult[];
+
+/**
+ * The cycle that escaped detection in production: the page budget could not
+ * fit the cycle deadline, so every cycle timed out after re-fetching the whole
+ * stored corpus and writing nothing.
+ */
+const RESCAN_CYCLE = {
+  outcome: CYCLE_OUTCOME.TIMEOUT,
+  inserted: 0,
+  skipped: 550,
+  pagesProcessed: 12,
+} satisfies CycleResult;
+
+/** The same adapter while it is genuinely writing rows, still too slow to finish. */
+const SLOW_PRODUCTIVE_CYCLE = {
+  outcome: CYCLE_OUTCOME.TIMEOUT,
+  inserted: 40,
+  skipped: 510,
+  pagesProcessed: 12,
+} satisfies CycleResult;
+
+const QUIET_CYCLE = {
+  outcome: CYCLE_OUTCOME.COMPLETED,
+  inserted: 0,
+  skipped: 0,
+  pagesProcessed: 1,
+} satisfies CycleResult;
+
+const INCONCLUSIVE_CYCLE = {
+  outcome: CYCLE_OUTCOME.TIMEOUT,
+  inserted: 0,
+  skipped: 0,
+  pagesProcessed: 0,
+} satisfies CycleResult;
+
+const repeat = (cycle: CycleResult, times: number): CycleResult[] =>
+  Array.from({ length: times }, () => cycle);
+
+/** Fold a run of cycles the way the adapter loop does, keeping every step. */
+const runCycles = (cycles: readonly CycleResult[]): CadenceStep[] => {
+  let streaks: CadenceStreaks = INITIAL_CADENCE_STREAKS;
+  const steps: CadenceStep[] = [];
+  for (const cycle of cycles) {
+    const step = stepCadence(streaks, cycle);
+    streaks = step.streaks;
+    steps.push(step);
+  }
+  return steps;
+};
+
+const lastStep = (cycles: readonly CycleResult[]): CadenceStep => {
+  const steps = runCycles(cycles);
+  const last = steps.at(-1);
+  if (!last) {
+    throw new Error("runCycles needs at least one cycle");
+  }
+  return last;
+};
 
 describe("cycleMadeProgress", () => {
   test("a cycle that advanced a page is progress, however it ended", () => {
-    const stalls = OUTCOMES.flatMap((outcome) =>
-      INSERTED.map((inserted) => ({ outcome, inserted, pagesProcessed: 1 })),
-    ).filter((cycle) => !cycleMadeProgress(cycle));
+    const stalls = CYCLES.filter(
+      (cycle) => cycle.pagesProcessed > 0 && !cycleMadeProgress(cycle),
+    );
 
     expect(stalls).toEqual([]);
   });
@@ -25,17 +110,12 @@ describe("cycleMadeProgress", () => {
     // A corpus-write failure parks the page and preserves the row's previous
     // source hash, so the same decisions are rewritten on every retry. Counting
     // that as progress would reset the streak and backoff forever.
-    const progressed = OUTCOMES.filter(
-      (outcome) => outcome !== CYCLE_OUTCOME.COMPLETED,
-    )
-      .flatMap((outcome) =>
-        INSERTED.filter((inserted) => inserted > 0).map((inserted) => ({
-          outcome,
-          inserted,
-          pagesProcessed: 0,
-        })),
-      )
-      .filter(cycleMadeProgress);
+    const progressed = CYCLES.filter(
+      (cycle) =>
+        cycle.outcome !== CYCLE_OUTCOME.COMPLETED &&
+        cycle.inserted > 0 &&
+        cycle.pagesProcessed === 0,
+    ).filter(cycleMadeProgress);
 
     expect(progressed).toEqual([]);
   });
@@ -45,16 +125,11 @@ describe("cycleMadeProgress", () => {
       cycleMadeProgress({
         outcome: CYCLE_OUTCOME.FAILED,
         inserted: 0,
+        skipped: 0,
         pagesProcessed: 0,
       }),
     ).toBe(false);
-    expect(
-      cycleMadeProgress({
-        outcome: CYCLE_OUTCOME.TIMEOUT,
-        inserted: 0,
-        pagesProcessed: 0,
-      }),
-    ).toBe(false);
+    expect(cycleMadeProgress(INCONCLUSIVE_CYCLE)).toBe(false);
   });
 
   test("a completed cycle with nothing to do is not a stall", () => {
@@ -62,47 +137,226 @@ describe("cycleMadeProgress", () => {
       cycleMadeProgress({
         outcome: CYCLE_OUTCOME.COMPLETED,
         inserted: 0,
+        skipped: 0,
         pagesProcessed: 0,
       }),
     ).toBe(true);
   });
 });
 
-describe("cycleWasIdle", () => {
-  test("a cycle that halted or timed out is never idle", () => {
-    // Such a cycle stopped partway through a source that still has work.
-    // Reading it as quiet would hold an adapter on the daily cadence.
-    const idle = OUTCOMES.filter(
-      (outcome) => outcome !== CYCLE_OUTCOME.COMPLETED,
-    )
-      .flatMap((outcome) =>
-        INSERTED.flatMap((inserted) =>
-          [0, 1].map((pagesProcessed) => ({
-            outcome,
-            inserted,
-            pagesProcessed,
-          })),
-        ),
-      )
-      .filter(cycleWasIdle);
+describe("classifyCycleProductivity", () => {
+  test("the declared states are exactly the reachable ones", () => {
+    const produced = new Set(CYCLES.map(classifyCycleProductivity));
 
-    expect(idle).toEqual([]);
+    expect([...produced].toSorted()).toEqual(
+      Object.values(CYCLE_PRODUCTIVITY).toSorted(),
+    );
   });
 
-  test("only a completed cycle that found nothing is idle", () => {
+  test("re-fetching stored decisions and writing none is an unproductive re-scan", () => {
+    // The production case: every cycle ended on a timeout, so any check keyed
+    // on CYCLE_OUTCOME.COMPLETED read this as a source that was keeping up.
+    expect(classifyCycleProductivity(RESCAN_CYCLE)).toBe(
+      CYCLE_PRODUCTIVITY.UNPRODUCTIVE_RESCAN,
+    );
+
+    const misread = CYCLES.filter(
+      (cycle) => cycle.inserted === 0 && cycle.skipped > 0,
+    ).filter(
+      (cycle) =>
+        classifyCycleProductivity(cycle) !==
+        CYCLE_PRODUCTIVITY.UNPRODUCTIVE_RESCAN,
+    );
+
+    expect(misread).toEqual([]);
+  });
+
+  test("a cycle that wrote rows is productive whatever it skipped or how it ended", () => {
+    const misread = CYCLES.filter((cycle) => cycle.inserted > 0).filter(
+      (cycle) =>
+        classifyCycleProductivity(cycle) !== CYCLE_PRODUCTIVITY.PRODUCTIVE,
+    );
+
+    expect(misread).toEqual([]);
+  });
+
+  test("only a clean cycle that fetched nothing is quiet", () => {
+    expect(classifyCycleProductivity(QUIET_CYCLE)).toBe(
+      CYCLE_PRODUCTIVITY.QUIET,
+    );
+    // The same counts on a cycle that ended early say nothing: the source may
+    // still have work, so it must not read as caught up.
+    expect(classifyCycleProductivity(INCONCLUSIVE_CYCLE)).toBe(
+      CYCLE_PRODUCTIVITY.INCONCLUSIVE,
+    );
+
+    const quiet = CYCLES.filter(
+      (cycle) => classifyCycleProductivity(cycle) === CYCLE_PRODUCTIVITY.QUIET,
+    );
+
     expect(
-      cycleWasIdle({
-        outcome: CYCLE_OUTCOME.COMPLETED,
-        inserted: 0,
-        pagesProcessed: 4,
-      }),
+      quiet.every(
+        (cycle) =>
+          cycle.outcome === CYCLE_OUTCOME.COMPLETED &&
+          cycle.inserted === 0 &&
+          cycle.skipped === 0,
+      ),
     ).toBe(true);
+  });
+});
+
+describe("stepCadence", () => {
+  test("the delay map covers exactly the declared cadences", () => {
+    expect(Object.keys(CYCLE_CADENCE_DELAY_MS).toSorted()).toEqual(
+      Object.values(CYCLE_CADENCE).toSorted(),
+    );
+  });
+
+  test("a sustained re-scan backs off and raises the signal", () => {
+    const steps = runCycles(repeat(RESCAN_CYCLE, UNPRODUCTIVE_THRESHOLD));
+    const tripped = steps.at(-1);
+
+    expect(steps.slice(0, -1).map((step) => step.cadence)).toEqual(
+      Array.from(
+        { length: UNPRODUCTIVE_THRESHOLD - 1 },
+        () => CYCLE_CADENCE.FAST,
+      ),
+    );
+    expect(steps.slice(0, -1).map((step) => step.unproductiveRescan)).toEqual(
+      Array.from({ length: UNPRODUCTIVE_THRESHOLD - 1 }, () => null),
+    );
+    expect(tripped?.cadence).toBe(CYCLE_CADENCE.UNPRODUCTIVE_BACKOFF);
+    expect(tripped?.unproductiveRescan).toEqual({
+      unproductiveCycles: UNPRODUCTIVE_THRESHOLD,
+      decisionsProcessed: RESCAN_CYCLE.skipped,
+      decisionsWritten: 0,
+    });
     expect(
-      cycleWasIdle({
-        outcome: CYCLE_OUTCOME.COMPLETED,
-        inserted: 1,
-        pagesProcessed: 4,
-      }),
-    ).toBe(false);
+      CYCLE_CADENCE_DELAY_MS[CYCLE_CADENCE.UNPRODUCTIVE_BACKOFF],
+    ).toBeGreaterThan(CYCLE_CADENCE_DELAY_MS[CYCLE_CADENCE.FAST]);
+  });
+
+  test("the signal keeps firing while the condition holds", () => {
+    // Once backed off the adapter cycles about once a day, so re-reporting is
+    // not a flood; going silent would look exactly like a cleared condition.
+    const steps = runCycles(repeat(RESCAN_CYCLE, UNPRODUCTIVE_THRESHOLD + 2));
+
+    expect(
+      steps
+        .slice(UNPRODUCTIVE_THRESHOLD - 1)
+        .map((step) => step.unproductiveRescan),
+    ).toEqual([
+      {
+        unproductiveCycles: UNPRODUCTIVE_THRESHOLD,
+        decisionsProcessed: RESCAN_CYCLE.skipped,
+        decisionsWritten: 0,
+      },
+      {
+        unproductiveCycles: UNPRODUCTIVE_THRESHOLD + 1,
+        decisionsProcessed: RESCAN_CYCLE.skipped,
+        decisionsWritten: 0,
+      },
+      {
+        unproductiveCycles: UNPRODUCTIVE_THRESHOLD + 2,
+        decisionsProcessed: RESCAN_CYCLE.skipped,
+        decisionsWritten: 0,
+      },
+    ]);
+  });
+
+  test("a slow but productive adapter is never throttled", () => {
+    // The correctness constraint on the whole change: a cycle that times out
+    // while writing rows must keep the fast cadence, however long it runs.
+    const steps = runCycles(repeat(SLOW_PRODUCTIVE_CYCLE, 50));
+
+    expect(steps.filter((step) => step.cadence !== CYCLE_CADENCE.FAST)).toEqual(
+      [],
+    );
+    expect(steps.filter((step) => step.unproductiveRescan !== null)).toEqual(
+      [],
+    );
+  });
+
+  test("any cycle that wrote a row restores the fast cadence, from any history", () => {
+    const histories = [
+      repeat(RESCAN_CYCLE, UNPRODUCTIVE_THRESHOLD + 2),
+      repeat(QUIET_CYCLE, QUIET_THRESHOLD + 2),
+      repeat(INCONCLUSIVE_CYCLE, 4),
+    ];
+    const productive = CYCLES.filter((cycle) => cycle.inserted > 0);
+
+    const throttled = histories.flatMap((history) =>
+      productive
+        .map((cycle) => lastStep([...history, cycle]))
+        .filter((step) => step.cadence !== CYCLE_CADENCE.FAST),
+    );
+
+    expect(throttled).toEqual([]);
+  });
+
+  test("a quiet source reaches the caught-up cadence as before", () => {
+    const steps = runCycles(repeat(QUIET_CYCLE, QUIET_THRESHOLD));
+
+    expect(steps.map((step) => step.cadence)).toEqual([
+      ...Array.from({ length: QUIET_THRESHOLD - 1 }, () => CYCLE_CADENCE.FAST),
+      CYCLE_CADENCE.CAUGHT_UP,
+    ]);
+    expect(steps.at(-1)?.unproductiveRescan).toBeNull();
+  });
+
+  test("a quiet cycle ends a re-scan streak", () => {
+    // Nothing left to fetch is the source being caught up, not a stall.
+    const step = lastStep([
+      ...repeat(RESCAN_CYCLE, UNPRODUCTIVE_THRESHOLD),
+      QUIET_CYCLE,
+    ]);
+
+    expect(step.cadence).toBe(CYCLE_CADENCE.FAST);
+    expect(step.streaks).toEqual({ quietCycles: 1, unproductiveCycles: 0 });
+  });
+
+  test("a cycle that fetched nothing and ended early holds the re-scan streak", () => {
+    // It is evidence of neither state, so it must not silently clear a
+    // running re-scan; it does clear the quiet streak, since the source has
+    // work outstanding.
+    const held = lastStep([
+      ...repeat(RESCAN_CYCLE, UNPRODUCTIVE_THRESHOLD - 1),
+      INCONCLUSIVE_CYCLE,
+      RESCAN_CYCLE,
+    ]);
+    expect(held.cadence).toBe(CYCLE_CADENCE.UNPRODUCTIVE_BACKOFF);
+
+    const cleared = lastStep([
+      ...repeat(QUIET_CYCLE, QUIET_THRESHOLD - 1),
+      INCONCLUSIVE_CYCLE,
+      QUIET_CYCLE,
+    ]);
+    expect(cleared.cadence).toBe(CYCLE_CADENCE.FAST);
+  });
+
+  test("the signal fires exactly when the cadence is the unproductive backoff", () => {
+    const mismatched = CYCLES.flatMap((cycle) =>
+      runCycles(repeat(cycle, UNPRODUCTIVE_THRESHOLD + 1)),
+    ).filter(
+      (step) =>
+        (step.unproductiveRescan !== null) !==
+        (step.cadence === CYCLE_CADENCE.UNPRODUCTIVE_BACKOFF),
+    );
+
+    expect(mismatched).toEqual([]);
+  });
+
+  test("every declared cadence is reachable", () => {
+    const reached = new Set(
+      CYCLES.flatMap((cycle) =>
+        runCycles(
+          repeat(cycle, Math.max(QUIET_THRESHOLD, UNPRODUCTIVE_THRESHOLD)),
+        ),
+      ).map((step) => step.cadence),
+    );
+
+    expect([...reached].toSorted()).toEqual(
+      Object.values(CYCLE_CADENCE).toSorted(),
+    );
   });
 });

--- a/apps/legal-atlas-runner/src/runners/cycle-progress.test.ts
+++ b/apps/legal-atlas-runner/src/runners/cycle-progress.test.ts
@@ -231,13 +231,13 @@ describe("stepCadence", () => {
       decisionsProcessed: RESCAN_CYCLE.skipped,
       decisionsWritten: 0,
     });
-    expect(
-      CYCLE_CADENCE_DELAY_MS[CYCLE_CADENCE.UNPRODUCTIVE_BACKOFF],
-    ).toBeGreaterThan(CYCLE_CADENCE_DELAY_MS[CYCLE_CADENCE.FAST]);
+    expect(CYCLE_CADENCE_DELAY_MS[CYCLE_CADENCE.UNPRODUCTIVE_BACKOFF]).toBe(
+      60 * 60 * 1000,
+    );
   });
 
   test("the signal keeps firing while the condition holds", () => {
-    // Once backed off the adapter cycles about once a day, so re-reporting is
+    // Once backed off the adapter cycles about once an hour, so re-reporting is
     // not a flood; going silent would look exactly like a cleared condition.
     const steps = runCycles(repeat(RESCAN_CYCLE, UNPRODUCTIVE_THRESHOLD + 2));
 

--- a/apps/legal-atlas-runner/src/runners/cycle-progress.ts
+++ b/apps/legal-atlas-runner/src/runners/cycle-progress.ts
@@ -1,9 +1,12 @@
 /**
- * How an ingestion cycle ended, and whether that counts as forward progress.
+ * How an ingestion cycle ended, whether that counts as forward progress, and
+ * what cadence the next cycle deserves.
  *
  * Kept free of the runner's DB and env imports so the classification can be
  * exercised on its own.
  */
+
+import { panic } from "better-result";
 
 export const CYCLE_OUTCOME = {
   COMPLETED: "completed",
@@ -15,7 +18,10 @@ export type CycleOutcome = (typeof CYCLE_OUTCOME)[keyof typeof CYCLE_OUTCOME];
 
 export type CycleResult = {
   outcome: CycleOutcome;
+  /** Decisions written: inserts and updates both. */
   inserted: number;
+  /** Decisions the dedup short-circuit dropped as already stored, unchanged. */
+  skipped: number;
   pagesProcessed: number;
 };
 
@@ -50,13 +56,204 @@ export const cycleMadeProgress = ({
   outcome === CYCLE_OUTCOME.COMPLETED || pagesProcessed > 0;
 
 /**
- * Whether a cycle is evidence the source is caught up, which drives the idle
- * (daily) polling cadence.
+ * What a cycle says about the source's productivity, independent of how the
+ * cycle ended.
  *
- * Only a clean cycle that found nothing qualifies. A halt or a timeout means
- * the cycle stopped partway through a source that still has work, so it must
- * not read as quiet: an adapter already on the idle cadence would otherwise
- * stay there, taking a day per page.
+ * The outcome alone cannot answer this. An adapter whose page budget does not
+ * fit its cycle deadline ends every cycle on a timeout, so any classification
+ * keyed on `CYCLE_OUTCOME.COMPLETED` reads a source that re-fetches its whole
+ * stored corpus every cycle, writing nothing, as indistinguishable from a
+ * source that is keeping up.
  */
-export const cycleWasIdle = ({ outcome, inserted }: CycleResult): boolean =>
-  outcome === CYCLE_OUTCOME.COMPLETED && inserted === 0;
+export const CYCLE_PRODUCTIVITY = {
+  /** Rows written. The source is moving, however the cycle ended. */
+  PRODUCTIVE: "productive",
+  /** Nothing fetched and nothing written: the source is caught up. */
+  QUIET: "quiet",
+  /**
+   * Decisions fetched, none written: the adapter re-read ground it already
+   * holds. Sustained, this is work without progress.
+   */
+  UNPRODUCTIVE_RESCAN: "unproductive_rescan",
+  /**
+   * Ended before a decision was fetched, and not cleanly. Evidence of neither
+   * quiet nor re-scan; a stall of this shape is what `cycleMadeProgress`
+   * covers.
+   */
+  INCONCLUSIVE: "inconclusive",
+} as const;
+
+export type CycleProductivity =
+  (typeof CYCLE_PRODUCTIVITY)[keyof typeof CYCLE_PRODUCTIVITY];
+
+/**
+ * Decisions the pipeline handled this cycle.
+ *
+ * The pipeline counts every decision it reaches as either written
+ * (`inserted`, covering inserts and updates) or `skipped` (already stored and
+ * unchanged, or failed), so the sum separates "fetched decisions and wrote
+ * none" from "found nothing to fetch".
+ */
+export const cycleDecisionsProcessed = ({
+  inserted,
+  skipped,
+}: CycleResult): number => inserted + skipped;
+
+export const classifyCycleProductivity = (
+  cycle: CycleResult,
+): CycleProductivity => {
+  if (cycle.inserted > 0) {
+    return CYCLE_PRODUCTIVITY.PRODUCTIVE;
+  }
+  if (cycleDecisionsProcessed(cycle) > 0) {
+    return CYCLE_PRODUCTIVITY.UNPRODUCTIVE_RESCAN;
+  }
+  return cycle.outcome === CYCLE_OUTCOME.COMPLETED
+    ? CYCLE_PRODUCTIVITY.QUIET
+    : CYCLE_PRODUCTIVITY.INCONCLUSIVE;
+};
+
+/** How often the adapter loop should start the next cycle. */
+export const CYCLE_CADENCE = {
+  FAST: "fast",
+  /** Caught up: poll once a day instead of hammering court servers. */
+  CAUGHT_UP: "caught_up",
+  /** Re-fetching stored decisions: hold the slot for adapters with work. */
+  UNPRODUCTIVE_BACKOFF: "unproductive_backoff",
+} as const;
+
+export type CycleCadence = (typeof CYCLE_CADENCE)[keyof typeof CYCLE_CADENCE];
+
+const FAST_DELAY_MS = 5000;
+const DAILY_DELAY_MS = 24 * 60 * 60 * 1000;
+
+const HOURLY_DELAY_MS = 60 * 60 * 1000;
+
+/**
+ * Being caught up is a conclusion; re-fetching stored decisions is only
+ * evidence, so the two do not earn the same delay.
+ *
+ * A source with nothing left to give has told us so, and daily is the right
+ * cadence for asking again. A source writing nothing while it fetches is
+ * either the pathology this classifier exists to catch or a re-ingest walking
+ * forward through ground it already holds, and those two look identical from
+ * here: both fetch, neither writes. Only the second is harmed by waiting, and
+ * it is harmed badly, since it advances no further than one cycle per delay
+ * and a long stored stretch would take months at a daily cadence.
+ *
+ * So the backoff is hourly. Against the pathology that is still a 720-fold
+ * reduction on the fast cadence and the telemetry below names it either way;
+ * against a legitimate catch-up walk it costs a day rather than a season.
+ * Either way a cycle that writes returns to the fast cadence immediately.
+ */
+export const CYCLE_CADENCE_DELAY_MS = {
+  [CYCLE_CADENCE.FAST]: FAST_DELAY_MS,
+  [CYCLE_CADENCE.CAUGHT_UP]: DAILY_DELAY_MS,
+  [CYCLE_CADENCE.UNPRODUCTIVE_BACKOFF]: HOURLY_DELAY_MS,
+} as const satisfies Record<CycleCadence, number>;
+
+/**
+ * Consecutive cycles an adapter has spent caught up, and consecutive cycles it
+ * has spent re-fetching stored decisions. Separate counters: only one can be
+ * running at a time, and each escalates on its own evidence.
+ */
+export type CadenceStreaks = {
+  quietCycles: number;
+  unproductiveCycles: number;
+};
+
+export const INITIAL_CADENCE_STREAKS = {
+  quietCycles: 0,
+  unproductiveCycles: 0,
+} as const satisfies CadenceStreaks;
+
+/** Consecutive cycles of a kind before the cadence escalates. */
+export const QUIET_THRESHOLD = 3;
+export const UNPRODUCTIVE_THRESHOLD = 3;
+
+const advanceStreaks = (
+  streaks: CadenceStreaks,
+  productivity: CycleProductivity,
+): CadenceStreaks => {
+  switch (productivity) {
+    case CYCLE_PRODUCTIVITY.PRODUCTIVE:
+      return { quietCycles: 0, unproductiveCycles: 0 };
+    case CYCLE_PRODUCTIVITY.QUIET:
+      // Nothing left to fetch ends a re-scan as surely as a written row does.
+      return { quietCycles: streaks.quietCycles + 1, unproductiveCycles: 0 };
+    case CYCLE_PRODUCTIVITY.UNPRODUCTIVE_RESCAN:
+      return {
+        quietCycles: 0,
+        unproductiveCycles: streaks.unproductiveCycles + 1,
+      };
+    case CYCLE_PRODUCTIVITY.INCONCLUSIVE:
+      // No evidence either way, so it is not evidence against: a cycle that
+      // dies before its first fetch must not silently clear a running
+      // re-scan. It does clear the quiet streak, because a cycle that ended
+      // early left a source with work outstanding.
+      return { quietCycles: 0, unproductiveCycles: streaks.unproductiveCycles };
+    default:
+      return panic(
+        `Unhandled cycle productivity: ${productivity satisfies never}`,
+      );
+  }
+};
+
+const cadenceForStreaks = ({
+  quietCycles,
+  unproductiveCycles,
+}: CadenceStreaks): CycleCadence => {
+  if (unproductiveCycles >= UNPRODUCTIVE_THRESHOLD) {
+    return CYCLE_CADENCE.UNPRODUCTIVE_BACKOFF;
+  }
+  return quietCycles >= QUIET_THRESHOLD
+    ? CYCLE_CADENCE.CAUGHT_UP
+    : CYCLE_CADENCE.FAST;
+};
+
+/** Telemetry payload for a re-scan that has crossed the threshold. */
+export type UnproductiveRescanSignal = {
+  unproductiveCycles: number;
+  decisionsProcessed: number;
+  decisionsWritten: number;
+};
+
+export type CadenceStep = {
+  productivity: CycleProductivity;
+  streaks: CadenceStreaks;
+  cadence: CycleCadence;
+  /**
+   * Non-null on every cycle at or past the threshold, not only the one that
+   * crosses it: the escalated cadence means at most one signal a day, and a
+   * condition that stops being reported looks identical to one that cleared.
+   */
+  unproductiveRescan: UnproductiveRescanSignal | null;
+};
+
+/**
+ * Fold one cycle into an adapter's cadence state.
+ *
+ * Pure so the escalation can be exercised over whole cycle sequences: the
+ * production defect this replaces was a streak that never reached its
+ * threshold, which no single-cycle assertion can catch.
+ */
+export const stepCadence = (
+  streaks: CadenceStreaks,
+  cycle: CycleResult,
+): CadenceStep => {
+  const productivity = classifyCycleProductivity(cycle);
+  const next = advanceStreaks(streaks, productivity);
+  return {
+    productivity,
+    streaks: next,
+    cadence: cadenceForStreaks(next),
+    unproductiveRescan:
+      next.unproductiveCycles >= UNPRODUCTIVE_THRESHOLD
+        ? {
+            unproductiveCycles: next.unproductiveCycles,
+            decisionsProcessed: cycleDecisionsProcessed(cycle),
+            decisionsWritten: cycle.inserted,
+          }
+        : null,
+  };
+};

--- a/apps/legal-atlas-runner/src/runners/cycle-progress.ts
+++ b/apps/legal-atlas-runner/src/runners/cycle-progress.ts
@@ -192,10 +192,10 @@ const advanceStreaks = (
       // re-scan. It does clear the quiet streak, because a cycle that ended
       // early left a source with work outstanding.
       return { quietCycles: 0, unproductiveCycles: streaks.unproductiveCycles };
-    default:
-      return panic(
-        `Unhandled cycle productivity: ${productivity satisfies never}`,
-      );
+    default: {
+      const unhandled: never = productivity;
+      return panic(`Unhandled cycle productivity: ${String(unhandled)}`);
+    }
   }
 };
 
@@ -224,7 +224,7 @@ export type CadenceStep = {
   cadence: CycleCadence;
   /**
    * Non-null on every cycle at or past the threshold, not only the one that
-   * crosses it: the escalated cadence means at most one signal a day, and a
+   * crosses it: the hourly cadence bounds the signal rate, and a
    * condition that stops being reported looks identical to one that cleared.
    */
   unproductiveRescan: UnproductiveRescanSignal | null;


### PR DESCRIPTION
## Problem

`cycleWasIdle` counted a cycle as idle only when it *completed* with nothing written:

```ts
outcome === CYCLE_OUTCOME.COMPLETED && inserted === 0
```

An adapter whose page budget cannot fit inside its cycle deadline ends every cycle in a timeout instead, so it never qualified. The streak reset on each cycle, the escalated delay was never reached, and the adapter held a cycle-semaphore slot at the minimum delay indefinitely while writing nothing — starving the other jurisdictions sharing that semaphore. Nothing surfaced the condition; it was visible only by reading logs.

This is the shape the repo guidelines call out: a lookup whose miss means a bug must emit telemetry rather than fall back silently to a default.

## Change

Judge useful work from what a cycle *did*, not from how it *ended*.

`CycleResult` carries the dedup short-circuit count alongside the write count, which makes "fetched decisions, wrote none" representable — the signature of a crawl re-walking ground it already holds. Note the pipeline counts an update as written, so a zero write count really does mean nothing changed.

Productivity becomes a named classification rather than a boolean:

- `productive` — rows written, whatever the outcome
- `quiet` — nothing fetched, nothing written, clean outcome: caught up
- `unproductive_rescan` — decisions fetched, none written
- `inconclusive` — ended before fetching anything, so evidence of neither

The fourth state is not padding. Without it a timeout that fetched nothing has to be misfiled as either quiet (which parks a working source on daily polling) or a re-scan (which backs off on no evidence). It clears the quiet streak without clearing a running re-scan streak; the no-page-advanced stall it resembles is already `cycleMadeProgress`'s job, which is left untouched.

The cadence it feeds is named too — `fast` / `caught_up` / `unproductive_backoff` — with a total delay map, so the delay reads as a state rather than counters compared inline in the loop. The classifier and the cadence fold are pure, so whole cycle *sequences* are testable rather than single verdicts.

## Delay calibration

Being caught up and re-fetching stored decisions do **not** share a delay.

A caught-up source has told us it has nothing left; daily is the right cadence for asking again. A source writing nothing while fetching is either the pathology above **or** a re-ingest walking forward through ground it already holds — and from here those are indistinguishable, since both fetch and neither writes. Only the second is harmed by waiting, and it is harmed badly: it advances no further than one cycle per delay, so a long stored stretch would take months at a daily cadence.

Hence hourly. Against the pathology that is still a 720-fold reduction on the fast cadence, and the telemetry names it either way. Against a legitimate catch-up walk it costs a day rather than a season. Any cycle that writes returns to the fast cadence immediately.

Separating the two exactly would need the cycle's start cursor threaded into `CycleResult` — an unchanged cursor across cycles distinguishes them — which is a larger change than this one.

## Telemetry

The re-scan signal goes through the shared logger with the counts that justify it (adapter key, consecutive unproductive cycles, decisions processed, decisions written), so the condition is queryable rather than inferred from a delay.

It re-fires on every cycle at or past the threshold rather than only on the crossing one: after backoff that is at most hourly, and a signal that goes silent is indistinguishable from a cleared condition. The neighbouring sustained-failure alert takes the opposite approach and is left as-is.

## Tests

The existing `cycleMadeProgress` coverage is kept and re-expressed over a shared outcome × written × skipped × pages matrix, plus tests asserting: a timeout with decisions fetched and none written classifies as an unproductive re-scan; N consecutive such cycles escalate the cadence and emit the signal; a timeout that *did* write is neither; and a genuinely quiet source behaves as before. The invariant "signal is non-null exactly when the cadence is `unproductive_backoff`" is asserted at the pure layer.

26 pass, 0 fail. One log line's wording changed, since resuming the fast cadence no longer implies new decisions were found.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Polling cadence now adapts between fast, hourly and daily schedules based on processing activity.
  - Unproductive rescans are detected and reported, while productive cycles can reset cadence delays.
  - Cycle results now clearly account for skipped decisions.

- **Bug Fixes**
  - Failure backoff continues to take priority over normal cadence delays.
  - Lease-conflict and completed cycles now return consistent result details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->