### PR TITLE
fix: resolve keyset timestamp cursors at exact precision

### DIFF
--- a/apps/api/src/handlers/api-keys/list.db.test.ts
+++ b/apps/api/src/handlers/api-keys/list.db.test.ts
@@ -1,0 +1,243 @@
+/**
+ * Page-boundary regression for the machine-key list.
+ *
+ * `apikey.created_at` defaults to `now()`, so it carries microseconds a JS
+ * `Date` cannot. The list pages newest-first, and a descending `<` boundary
+ * that lost its microseconds excludes every key inside the truncated sliver:
+ * a machine credential that never appears on page two is one an admin cannot
+ * see, and therefore one nobody can revoke — the exact failure this table's
+ * organization-scoped reads exist to prevent. Only rows with non-zero
+ * sub-millisecond digits can show that, so they are written by raw SQL.
+ */
+
+import { afterAll, beforeAll, expect, mock, test } from "bun:test";
+import { eq, sql } from "drizzle-orm";
+
+import { apikey } from "@/api/db/auth-schema";
+import { compareCodepoint } from "@/api/lib/collation";
+import { MACHINE_API_KEY_CONFIG_ID } from "@/api/lib/machine-api-key-config";
+import { encodePaginationCursor } from "@/api/lib/pagination";
+import { createTestHandlerContext } from "@/api/tests/helpers/handler-context";
+import {
+  createTestIds,
+  setupRlsTestData,
+} from "@/api/tests/security/rls-helpers";
+import type { TestIds } from "@/api/tests/security/rls-helpers";
+import { getTestDb, releaseTestDb } from "@/api/tests/security/test-utils";
+import type { TestDatabase } from "@/api/tests/security/test-utils";
+
+const PAGE_LIMIT = 3;
+/** A skipping or stalling walk must fail the test, not spin. */
+const MAX_PAGES = 40;
+
+/**
+ * Nine keys inside one millisecond, separated only by microseconds; every one
+ * collapses onto the same JS `Date`. The last three share an exact timestamp
+ * so the id tie-break is exercised too.
+ */
+const KEY_TIMESTAMPS = [
+  "2026-06-02 08:00:00.250001+00",
+  "2026-06-02 08:00:00.250002+00",
+  "2026-06-02 08:00:00.250003+00",
+  "2026-06-02 08:00:00.250004+00",
+  "2026-06-02 08:00:00.250005+00",
+  "2026-06-02 08:00:00.250006+00",
+  "2026-06-02 08:00:00.250007+00",
+  "2026-06-02 08:00:00.250007+00",
+  "2026-06-02 08:00:00.250007+00",
+] as const;
+
+/** Distinct milliseconds, so a millisecond truncation stays order-preserving. */
+const DISTINCT_MS_TIMESTAMPS = [
+  "2026-06-02 08:00:01.001456+00",
+  "2026-06-02 08:00:01.002456+00",
+  "2026-06-02 08:00:01.003456+00",
+  "2026-06-02 08:00:01.004456+00",
+] as const;
+
+let testDb: TestDatabase;
+let ids: TestIds;
+
+beforeAll(async () => {
+  testDb = await getTestDb();
+  ids = createTestIds();
+  await setupRlsTestData(testDb, ids);
+
+  // The queries module reads this table through the owner connection; point
+  // that connection at the test database.
+  void mock.module("@/api/db/root", () => ({
+    rootDb: testDb,
+    rlsDb: testDb,
+  }));
+
+  const timestamps = [...KEY_TIMESTAMPS, ...DISTINCT_MS_TIMESTAMPS];
+  for (const [index, createdAt] of timestamps.entries()) {
+    // `created_at` is written as a literal: binding a `Date` would erase
+    // exactly the digits this fixture exists to carry.
+    // oxlint-disable-next-line no-await-in-loop -- ordered inserts on one test DB connection
+    await testDb.execute(sql`
+      INSERT INTO apikey (
+        id, config_id, name, start, prefix, key, reference_id,
+        enabled, rate_limit_enabled, request_count,
+        metadata, permissions, created_at, updated_at
+      ) VALUES (
+        ${`machine-key-${String(index).padStart(3, "0")}`},
+        ${MACHINE_API_KEY_CONFIG_ID},
+        ${`Key ${index}`}, 'stll_', 'stll_', ${`digest-${index}`}, ${ids.userA1},
+        true, true, 0,
+        ${JSON.stringify({ organizationId: ids.orgA, scopes: [] })},
+        ${JSON.stringify({})},
+        ${createdAt}::timestamptz, ${createdAt}::timestamptz
+      )
+    `);
+  }
+}, 120_000);
+
+afterAll(async () => {
+  await releaseTestDb();
+});
+
+const listPage = async (cursor: string | undefined) => {
+  const { default: listMachineApiKeys } =
+    await import("@/api/handlers/api-keys/list");
+  type ListCtx = Parameters<typeof listMachineApiKeys.handler>[0];
+  return await listMachineApiKeys.handler(
+    createTestHandlerContext<ListCtx>({
+      session: { activeOrganizationId: ids.orgA },
+      user: { id: ids.userA1 },
+      query: { limit: PAGE_LIMIT, cursor },
+    }),
+  );
+};
+
+/** The handler answers a rejected request with a status response, not a page. */
+const expectPage = (result: Awaited<ReturnType<typeof listPage>>) => {
+  if (!("items" in result)) {
+    throw new Error(`expected a page, got ${JSON.stringify(result)}`);
+  }
+  return result;
+};
+
+const walk = async (startCursor?: string): Promise<string[]> => {
+  const visited: string[] = [];
+  let cursor = startCursor;
+  for (let page = 0; page < MAX_PAGES; page += 1) {
+    // oxlint-disable-next-line no-await-in-loop -- sequential keyset pagination
+    const result = expectPage(await listPage(cursor));
+    for (const item of result.items) {
+      visited.push(item.id);
+    }
+    if (result.nextCursor === null) {
+      return visited;
+    }
+    cursor = result.nextCursor;
+  }
+  throw new Error(
+    `the key list did not terminate within ${MAX_PAGES} pages; the cursor is stalling`,
+  );
+};
+
+const expectedOrder = (): string[] =>
+  [...KEY_TIMESTAMPS, ...DISTINCT_MS_TIMESTAMPS]
+    .map((createdAt, index) => ({
+      createdAt,
+      id: `machine-key-${String(index).padStart(3, "0")}`,
+    }))
+    // Newest first, ties broken by descending id: the query's own ORDER BY.
+    // Codepoint order, matching PostgreSQL's ordering of these opaque keys.
+    .toSorted((left, right) =>
+      left.createdAt === right.createdAt
+        ? compareCodepoint(right.id, left.id)
+        : compareCodepoint(right.createdAt, left.createdAt),
+    )
+    .map(({ id }) => id);
+
+test("the fixture carries the microseconds a Date cursor would lose", async () => {
+  // Without this the whole file could go vacuous: keys seeded from a JS
+  // `Date` cannot reproduce the skipped-sliver bug at all.
+  const [counts] = await testDb
+    .select({
+      microsecondRows: sql<number>`count(*) FILTER (
+        WHERE ${apikey.createdAt}
+          <> date_trunc('milliseconds', ${apikey.createdAt})
+      )::int`,
+      total: sql<number>`count(*)::int`,
+    })
+    .from(apikey)
+    .where(eq(apikey.configId, MACHINE_API_KEY_CONFIG_ID));
+
+  const seeded = KEY_TIMESTAMPS.length + DISTINCT_MS_TIMESTAMPS.length;
+  expect(counts?.total).toBe(seeded);
+  expect(counts?.microsecondRows).toBe(seeded);
+});
+
+test("INVARIANT: paging to exhaustion lists every key exactly once", async () => {
+  const expected = expectedOrder();
+
+  const visited = await walk();
+
+  // No key inside the boundary's truncated millisecond may be skipped: an
+  // unlistable machine credential is an unrevokable one.
+  expect(visited).toEqual(expected);
+  expect(new Set(visited).size).toBe(expected.length);
+});
+
+test("INVARIANT: resuming from any page boundary yields exactly the tail", async () => {
+  const expected = expectedOrder();
+
+  let cursor: string | undefined;
+  let consumed = 0;
+  for (let page = 0; page < MAX_PAGES; page += 1) {
+    // oxlint-disable-next-line no-await-in-loop -- sequential keyset pagination
+    const result = expectPage(await listPage(cursor));
+    if (result.nextCursor === null) {
+      expect(consumed + result.items.length).toBe(expected.length);
+      return;
+    }
+    consumed += result.items.length;
+    // oxlint-disable-next-line no-await-in-loop -- sequential keyset pagination
+    const remainder = await walk(result.nextCursor);
+    expect(remainder).toEqual(expected.slice(consumed));
+    cursor = result.nextCursor;
+  }
+  throw new Error("pagination did not terminate");
+});
+
+test("a cursor issued before the fix still decodes and resumes", async () => {
+  // The old encoder was `encodePaginationCursor([createdAt.toISOString(), id])`.
+  // Such a cursor is in flight in clients; it must never 400 or 500, and on
+  // distinct milliseconds (where the truncation is order-preserving) it still
+  // resumes exactly.
+  const expected = expectedOrder();
+  const boundaryId = "machine-key-010";
+  const boundaryIndex = expected.indexOf(boundaryId);
+  expect(boundaryIndex).toBeGreaterThan(-1);
+
+  const visited = await walk(
+    encodePaginationCursor(["2026-06-02T08:00:01.002Z", boundaryId]),
+  );
+
+  expect(visited).toEqual(expected.slice(boundaryIndex + 1));
+});
+
+test("a legacy cursor inside a shared millisecond decodes and terminates", async () => {
+  const expected = expectedOrder();
+
+  // Every key in this group truncates to the same millisecond, so the cursor
+  // is genuinely lossy and can only fall back to its id tie-break. What it
+  // must not do is 500 or stall.
+  const visited = await walk(
+    encodePaginationCursor(["2026-06-02T08:00:00.250Z", "machine-key-004"]),
+  );
+
+  expect(new Set(visited).size).toBe(visited.length);
+  for (const id of visited) {
+    expect(expected).toContain(id);
+  }
+});
+
+test("a malformed cursor is rejected rather than silently restarting page one", async () => {
+  const result = await listPage("not-a-cursor");
+
+  expect("items" in result).toBe(false);
+});

--- a/apps/api/src/handlers/api-keys/list.db.test.ts
+++ b/apps/api/src/handlers/api-keys/list.db.test.ts
@@ -32,19 +32,20 @@ const MAX_PAGES = 40;
 
 /**
  * Nine keys inside one millisecond, separated only by microseconds; every one
- * collapses onto the same JS `Date`. The last three share an exact timestamp
- * so the id tie-break is exercised too.
+ * collapses onto the same JS `Date`. Timestamps mostly descend as ids ascend,
+ * so a legacy id fallback returns the already-consumed prefix. The first three
+ * share an exact timestamp so the canonical id tie-break is exercised too.
  */
 const KEY_TIMESTAMPS = [
-  "2026-06-02 08:00:00.250001+00",
-  "2026-06-02 08:00:00.250002+00",
-  "2026-06-02 08:00:00.250003+00",
-  "2026-06-02 08:00:00.250004+00",
-  "2026-06-02 08:00:00.250005+00",
+  "2026-06-02 08:00:00.250007+00",
+  "2026-06-02 08:00:00.250007+00",
+  "2026-06-02 08:00:00.250007+00",
   "2026-06-02 08:00:00.250006+00",
-  "2026-06-02 08:00:00.250007+00",
-  "2026-06-02 08:00:00.250007+00",
-  "2026-06-02 08:00:00.250007+00",
+  "2026-06-02 08:00:00.250005+00",
+  "2026-06-02 08:00:00.250004+00",
+  "2026-06-02 08:00:00.250003+00",
+  "2026-06-02 08:00:00.250002+00",
+  "2026-06-02 08:00:00.250001+00",
 ] as const;
 
 /** Distinct milliseconds, so a millisecond truncation stays order-preserving. */
@@ -220,20 +221,17 @@ test("a cursor issued before the fix still decodes and resumes", async () => {
   expect(visited).toEqual(expected.slice(boundaryIndex + 1));
 });
 
-test("a legacy cursor inside a shared millisecond decodes and terminates", async () => {
+test("a legacy cursor inside a shared millisecond resumes the exact tail", async () => {
   const expected = expectedOrder();
+  const boundaryId = "machine-key-004";
+  const boundaryIndex = expected.indexOf(boundaryId);
+  expect(boundaryIndex).toBeGreaterThan(-1);
 
-  // Every key in this group truncates to the same millisecond, so the cursor
-  // is genuinely lossy and can only fall back to its id tie-break. What it
-  // must not do is 500 or stall.
   const visited = await walk(
-    encodePaginationCursor(["2026-06-02T08:00:00.250Z", "machine-key-004"]),
+    encodePaginationCursor(["2026-06-02T08:00:00.250Z", boundaryId]),
   );
 
-  expect(new Set(visited).size).toBe(visited.length);
-  for (const id of visited) {
-    expect(expected).toContain(id);
-  }
+  expect(visited).toEqual(expected.slice(boundaryIndex + 1));
 });
 
 test("a malformed cursor is rejected rather than silently restarting page one", async () => {

--- a/apps/api/src/handlers/api-keys/list.ts
+++ b/apps/api/src/handlers/api-keys/list.ts
@@ -6,12 +6,11 @@ import { createSafeRootHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import type { MachineApiKeyScope } from "@/api/lib/machine-api-key-config";
-import { listOrganizationMachineApiKeys } from "@/api/lib/machine-api-key-queries";
 import {
-  createCursorPage,
-  decodePaginationCursor,
-  encodePaginationCursor,
-} from "@/api/lib/pagination";
+  listOrganizationMachineApiKeys,
+  machineApiKeyCursor,
+} from "@/api/lib/machine-api-key-queries";
+import { createCursorPage } from "@/api/lib/pagination";
 
 const MACHINE_API_KEY_PAGE_SIZE_DEFAULT = 50;
 const MACHINE_API_KEY_PAGE_SIZE_MAX = 200;
@@ -45,34 +44,6 @@ type MachineApiKeySummary = {
   lastRequest: Date | null;
 };
 
-type MachineApiKeyCursor = { createdAt: Date; id: string };
-
-/**
- * Cursor over `(created_at, id)`, the same pair the query orders and indexes by.
- * A malformed cursor is rejected rather than silently treated as "first page",
- * so a client bug surfaces instead of quietly re-reading page one forever.
- */
-const decodeMachineApiKeyCursor = (
-  cursor: string,
-): MachineApiKeyCursor | null => {
-  const parts = decodePaginationCursor(cursor);
-  if (parts?.length !== 2) {
-    return null;
-  }
-
-  const [createdAt, id] = parts;
-  if (typeof createdAt !== "string" || typeof id !== "string") {
-    return null;
-  }
-
-  const parsed = new Date(createdAt);
-  if (Number.isNaN(parsed.getTime())) {
-    return null;
-  }
-
-  return { createdAt: parsed, id };
-};
-
 /**
  * List the machine API keys belonging to the caller's active organization.
  *
@@ -94,8 +65,10 @@ const listMachineApiKeys = createSafeRootHandler(
   async function* ({ session, query }) {
     const limit = query.limit ?? MACHINE_API_KEY_PAGE_SIZE_DEFAULT;
 
+    // A malformed cursor is rejected rather than silently treated as "first
+    // page", so a client bug surfaces instead of quietly re-reading page one.
     const cursor = query.cursor
-      ? decodeMachineApiKeyCursor(query.cursor)
+      ? machineApiKeyCursor.decode(query.cursor)
       : null;
     if (query.cursor !== undefined && cursor === null) {
       return Result.err(
@@ -122,12 +95,15 @@ const listMachineApiKeys = createSafeRootHandler(
 
     // Paginate first, then render. Cutting the page before dropping
     // undescribable rows keeps `nextCursor` anchored to a real row's
-    // `(created_at, id)`, so pagination cannot skip rows or stall.
+    // `(created_at, id)`. The cursor carries the database's own
+    // microsecond-precision rendering of `created_at`, not a JS `Date`, so
+    // the boundary comparison cannot skip the keys that share the boundary's
+    // truncated millisecond.
     const page = createCursorPage({
       rows,
       limit,
       cursorForItem: (row) =>
-        encodePaginationCursor([row.createdAt.toISOString(), row.id]),
+        machineApiKeyCursor.encode(row.createdAtCursor, row.id),
     });
 
     const items: MachineApiKeySummary[] = [];

--- a/apps/api/src/handlers/docx-suggestions/cursor.property.test.ts
+++ b/apps/api/src/handlers/docx-suggestions/cursor.property.test.ts
@@ -3,42 +3,83 @@ import fc from "fast-check";
 
 import { propertyConfig } from "@stll/property-testing";
 
+import { parsePgTimestampCursorValue } from "@/api/lib/db-pagination";
 import {
   encodePaginationCursor,
   isUuidPaginationCursorPart,
-  parseDateTimePaginationCursorPart,
 } from "@/api/lib/pagination";
 import { brandPersistedDocxSuggestionId } from "@/api/lib/safe-id-boundaries";
 
-import {
-  decodeDocxSuggestionCursor,
-  encodeDocxSuggestionCursor,
-} from "./cursor";
+import { docxSuggestionCursor } from "./cursor";
 
-// The cursor is exactly `(created_at ISO string, suggestion uuid)`. Any value
-// in the `Date` range round-trips through `toISOString()`; the only value that
-// cannot is the Invalid Date, which the encoder never produces.
-const validDate = fc.date({ noInvalidDate: true });
-
-// Filter predicate to steer generators away from the (astronomically
-// unlikely) case where a random string is itself a valid part. Reuses the
-// production decoder's own predicates so the test preconditions can never
-// drift from what `decodeDocxSuggestionCursor` actually accepts.
-const isDateTimeCursorPart = (value: string): boolean =>
-  parseDateTimePaginationCursorPart(value) !== null;
+// The cursor is `(PostgreSQL microsecond timestamp text, suggestion uuid)`.
+// The timestamp half is the database's own rendering of `created_at`, never
+// a JS `Date`: a `Date` carries milliseconds, so a boundary built from one
+// re-admits the row the page was cut at and the list never advances.
+const microsecondTimestamp = fc
+  .tuple(
+    fc.date({
+      min: new Date("2000-01-01T00:00:00.000Z"),
+      max: new Date("2099-12-31T23:59:59.999Z"),
+      noInvalidDate: true,
+    }),
+    fc.integer({ min: 0, max: 999_999 }),
+  )
+  .map(
+    ([date, microseconds]) =>
+      `${date.toISOString().slice(0, 19)}.${microseconds.toString().padStart(6, "0")}Z`,
+  );
 
 describe("docx suggestion cursor codec (properties)", () => {
-  test("decode ∘ encode recovers the (createdAt, id) pair", () => {
+  test("INVARIANT: decode ∘ encode recovers the timestamp at full precision", () => {
     fc.assert(
-      fc.property(validDate, fc.uuid(), (createdAt, rawId) => {
+      fc.property(microsecondTimestamp, fc.uuid(), (timestamp, rawId) => {
         const id = brandPersistedDocxSuggestionId(rawId);
-        const decoded = decodeDocxSuggestionCursor(
-          encodeDocxSuggestionCursor({ createdAt, id }),
-        );
-        expect(decoded).not.toBeNull();
-        expect(decoded?.createdAt).toEqual(createdAt);
-        expect(decoded?.id).toBe(id);
+        expect(
+          docxSuggestionCursor.decode(
+            docxSuggestionCursor.encode(timestamp, id),
+          ),
+        ).toEqual({
+          timestamp: {
+            type: "pgTimestampCursor",
+            value: timestamp,
+            precision: "microseconds",
+          },
+          id,
+        });
       }),
+      propertyConfig({ numRuns: 500 }),
+    );
+  });
+
+  test("INVARIANT: cursors issued before the fix still decode, tagged millisecond", () => {
+    // The old encoder was `encodePaginationCursor([createdAt.toISOString(), id])`.
+    // Those cursors are in flight in clients; decoding one must never throw or
+    // 400, it only resumes at the coarser precision it was cut with.
+    fc.assert(
+      fc.property(
+        fc.date({
+          min: new Date("2000-01-01T00:00:00.000Z"),
+          max: new Date("2099-12-31T23:59:59.999Z"),
+          noInvalidDate: true,
+        }),
+        fc.uuid(),
+        (createdAt, rawId) => {
+          const id = brandPersistedDocxSuggestionId(rawId);
+          expect(
+            docxSuggestionCursor.decode(
+              encodePaginationCursor([createdAt.toISOString(), rawId]),
+            ),
+          ).toEqual({
+            timestamp: {
+              type: "pgTimestampCursor",
+              value: createdAt.toISOString(),
+              precision: "milliseconds",
+            },
+            id,
+          });
+        },
+      ),
       propertyConfig({ numRuns: 500 }),
     );
   });
@@ -46,10 +87,10 @@ describe("docx suggestion cursor codec (properties)", () => {
   test("decode never throws and yields a valid cursor or null for any string", () => {
     fc.assert(
       fc.property(fc.string(), (raw) => {
-        const decoded = decodeDocxSuggestionCursor(raw);
+        const decoded = docxSuggestionCursor.decode(raw);
         expect(
           decoded === null ||
-            (decoded.createdAt instanceof Date &&
+            (typeof decoded.timestamp.value === "string" &&
               typeof decoded.id === "string"),
         ).toBe(true);
       }),
@@ -70,7 +111,7 @@ describe("docx suggestion cursor codec (properties)", () => {
         const encoded = Buffer.from(JSON.stringify(value)).toString(
           "base64url",
         );
-        expect(decodeDocxSuggestionCursor(encoded)).toBeNull();
+        expect(docxSuggestionCursor.decode(encoded)).toBeNull();
       }),
       propertyConfig({ numRuns: 300 }),
     );
@@ -83,20 +124,22 @@ describe("docx suggestion cursor codec (properties)", () => {
     fc.assert(
       fc.property(wrongArity, (parts) => {
         expect(
-          decodeDocxSuggestionCursor(encodePaginationCursor(parts)),
+          docxSuggestionCursor.decode(encodePaginationCursor(parts)),
         ).toBeNull();
       }),
       propertyConfig({ numRuns: 300 }),
     );
   });
 
+  // Both preconditions reuse the production predicates the codec itself
+  // applies, so they cannot drift from what `decode` actually accepts.
   test("a non-UUID id part decodes to null", () => {
     fc.assert(
-      fc.property(validDate, fc.string(), (createdAt, rawId) => {
+      fc.property(microsecondTimestamp, fc.string(), (timestamp, rawId) => {
         fc.pre(!isUuidPaginationCursorPart(rawId));
         expect(
-          decodeDocxSuggestionCursor(
-            encodePaginationCursor([createdAt.toISOString(), rawId]),
+          docxSuggestionCursor.decode(
+            encodePaginationCursor([timestamp, rawId]),
           ),
         ).toBeNull();
       }),
@@ -104,12 +147,12 @@ describe("docx suggestion cursor codec (properties)", () => {
     );
   });
 
-  test("a non-datetime created-at part decodes to null", () => {
+  test("a non-timestamp created-at part decodes to null", () => {
     fc.assert(
       fc.property(fc.string(), fc.uuid(), (rawCreatedAt, rawId) => {
-        fc.pre(!isDateTimeCursorPart(rawCreatedAt));
+        fc.pre(parsePgTimestampCursorValue(rawCreatedAt) === null);
         expect(
-          decodeDocxSuggestionCursor(
+          docxSuggestionCursor.decode(
             encodePaginationCursor([rawCreatedAt, rawId]),
           ),
         ).toBeNull();

--- a/apps/api/src/handlers/docx-suggestions/cursor.ts
+++ b/apps/api/src/handlers/docx-suggestions/cursor.ts
@@ -14,7 +14,8 @@ import { brandPersistedDocxSuggestionId } from "@/api/lib/safe-id-boundaries";
  * page was cut at: it is re-emitted as the first row of every following
  * page and the cursor never advances. Cursors issued in that older ISO form
  * keep decoding; the codec tags them millisecond-precision and truncates
- * the column on both sides so the page they were cut from resumes exactly.
+ * the list resolves their boundary row by id before applying this codec, so
+ * they resume on the row's exact database timestamp too.
  */
 export const docxSuggestionCursor = createTimestampIdCursorCodec({
   column: docxSuggestions.createdAt,

--- a/apps/api/src/handlers/docx-suggestions/cursor.ts
+++ b/apps/api/src/handlers/docx-suggestions/cursor.ts
@@ -1,10 +1,5 @@
-import type { SafeId } from "@/api/lib/branded-types";
-import {
-  decodePaginationCursor,
-  encodePaginationCursor,
-  isUuidPaginationCursorPart,
-  parseDateTimePaginationCursorPart,
-} from "@/api/lib/pagination";
+import { docxSuggestions } from "@/api/db/schema";
+import { createTimestampIdCursorCodec } from "@/api/lib/db-pagination";
 import { brandPersistedDocxSuggestionId } from "@/api/lib/safe-id-boundaries";
 
 /**
@@ -12,31 +7,16 @@ import { brandPersistedDocxSuggestionId } from "@/api/lib/safe-id-boundaries";
  * `(created_at, id)`, matching the `docx_suggestions_ws_entity_created_idx`
  * composite index. Kept in its own module (not exported from the endpoint)
  * per the domain-cursor-helper convention.
+ *
+ * The timestamp half is projected and compared at the column's microsecond
+ * precision. Reading `created_at` into a JS `Date` truncates it to the
+ * millisecond, and the ascending `>` boundary then still admits the row the
+ * page was cut at: it is re-emitted as the first row of every following
+ * page and the cursor never advances. Cursors issued in that older ISO form
+ * keep decoding; the codec tags them millisecond-precision and truncates
+ * the column on both sides so the page they were cut from resumes exactly.
  */
-export type DocxSuggestionCursor = {
-  createdAt: Date;
-  id: SafeId<"docxSuggestion">;
-};
-
-export const encodeDocxSuggestionCursor = ({
-  createdAt,
-  id,
-}: DocxSuggestionCursor): string =>
-  encodePaginationCursor([createdAt.toISOString(), id]);
-
-export const decodeDocxSuggestionCursor = (
-  cursor: string,
-): DocxSuggestionCursor | null => {
-  const parts = decodePaginationCursor(cursor);
-  if (!parts || parts.length !== 2) {
-    return null;
-  }
-
-  const createdAt = parseDateTimePaginationCursorPart(parts.at(0));
-  const rawId = parts.at(1);
-  if (createdAt === null || !isUuidPaginationCursorPart(rawId)) {
-    return null;
-  }
-
-  return { createdAt, id: brandPersistedDocxSuggestionId(rawId) };
-};
+export const docxSuggestionCursor = createTimestampIdCursorCodec({
+  column: docxSuggestions.createdAt,
+  brandId: brandPersistedDocxSuggestionId,
+});

--- a/apps/api/src/handlers/docx-suggestions/read.db.test.ts
+++ b/apps/api/src/handlers/docx-suggestions/read.db.test.ts
@@ -1,0 +1,307 @@
+/**
+ * Page-boundary regression for the entity suggestion list.
+ *
+ * `docx_suggestions.created_at` is a timestamptz: PostgreSQL keeps
+ * microseconds, a JS `Date` keeps milliseconds. An ascending `>` boundary
+ * that went through a `Date` still admits the row the page was cut at, so
+ * that row is re-emitted at the head of every following page and the cursor
+ * never advances — the reviewer panel then spends its whole hydration cap on
+ * one page. Only rows carrying non-zero sub-millisecond digits can show
+ * that, so they are written by raw SQL and the walk runs against Postgres.
+ *
+ * Runs on PGlite through the shared RLS fixture, like the other
+ * database-backed handler suites.
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { eq, inArray, sql } from "drizzle-orm";
+
+import type { SafeDb } from "@/api/db/safe-db";
+import { docxSuggestions, entities } from "@/api/db/schema";
+import { createSafeDb } from "@/api/db/scoped";
+import { toSafeId } from "@/api/lib/branded-types";
+import type { SafeId } from "@/api/lib/branded-types";
+import { encodePaginationCursor } from "@/api/lib/pagination";
+import { createTestHandlerContext } from "@/api/tests/helpers/handler-context";
+import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
+import {
+  createTestIds,
+  setupRlsTestData,
+} from "@/api/tests/security/rls-helpers";
+import type { TestIds } from "@/api/tests/security/rls-helpers";
+import { getTestDb, releaseTestDb } from "@/api/tests/security/test-utils";
+import type { TestDatabase } from "@/api/tests/security/test-utils";
+
+import listDocxSuggestions from "./read";
+
+const PAGE_LIMIT = 4;
+/**
+ * A stalled cursor loops forever, so the walk is bounded. Generous against
+ * the largest fixture (25 rows at 4 per page = 7 pages) and still far below
+ * anything a working keyset can reach.
+ */
+const MAX_PAGES = 40;
+
+/**
+ * Twelve rows inside one millisecond, separated only by microseconds. Every
+ * one of them collapses onto the same JS `Date`, which is exactly what a
+ * millisecond boundary cannot tell apart.
+ */
+const TWIN_COUNT = 12;
+const twinTimestamp = (index: number): string =>
+  `2026-05-01 09:00:00.100${String(index + 1).padStart(3, "0")}+00`;
+
+/**
+ * Ten rows on distinct milliseconds, each still carrying microseconds. A
+ * millisecond truncation is order-preserving here, so a cursor issued by the
+ * old encoder resumes this set exactly.
+ */
+const DISTINCT_COUNT = 10;
+const distinctTimestamp = (index: number): string =>
+  `2026-05-01 09:00:01.${String(index + 1).padStart(3, "0")}456+00`;
+const distinctIsoMillisecond = (index: number): string =>
+  `2026-05-01T09:00:01.${String(index + 1).padStart(3, "0")}Z`;
+
+let testDb: TestDatabase;
+let ids: TestIds;
+// Dedicated entities: the shared RLS fixture already attaches suggestions to
+// its own entities, and this suite asserts exact row sets.
+const twinEntityId = toSafeId<"entity">(Bun.randomUUIDv7());
+const distinctEntityId = toSafeId<"entity">(Bun.randomUUIDv7());
+
+const seedSuggestions = async ({
+  entityId,
+  count,
+  timestampAt,
+}: {
+  entityId: SafeId<"entity">;
+  count: number;
+  timestampAt: (index: number) => string;
+}): Promise<SafeId<"docxSuggestion">[]> => {
+  const seeded: SafeId<"docxSuggestion">[] = [];
+  for (let index = 0; index < count; index += 1) {
+    const id = toSafeId<"docxSuggestion">(Bun.randomUUIDv7());
+    // The microsecond digits are the whole point of the fixture, so
+    // `created_at` is written as a literal instead of being bound from a
+    // `Date` (which cannot carry them).
+    // oxlint-disable-next-line no-await-in-loop -- ordered inserts on one test DB connection
+    await testDb.execute(sql`
+      INSERT INTO docx_suggestions
+        (id, workspace_id, entity_id, op_payload, severity, area, status, created_at)
+      VALUES (
+        ${id}, ${ids.wsA1}, ${entityId}, ${sql.raw("'{}'::jsonb")},
+        'medium', 'clause', 'pending', ${timestampAt(index)}::timestamptz
+      )
+    `);
+    seeded.push(id);
+  }
+  return seeded;
+};
+
+beforeAll(async () => {
+  testDb = await getTestDb();
+  ids = createTestIds();
+  await setupRlsTestData(testDb, ids);
+
+  await testDb.insert(entities).values([
+    {
+      id: twinEntityId,
+      workspaceId: ids.wsA1,
+      name: "Microsecond-twin suggestions",
+    },
+    {
+      id: distinctEntityId,
+      workspaceId: ids.wsA1,
+      name: "Distinct-millisecond suggestions",
+    },
+  ]);
+
+  await seedSuggestions({
+    entityId: twinEntityId,
+    count: TWIN_COUNT,
+    timestampAt: twinTimestamp,
+  });
+  await seedSuggestions({
+    entityId: distinctEntityId,
+    count: DISTINCT_COUNT,
+    timestampAt: distinctTimestamp,
+  });
+}, 120_000);
+
+afterAll(async () => {
+  await releaseTestDb();
+});
+
+// PGlite's transaction type is structurally distinct from the production
+// `Transaction`; asTestRaw is the established bridge for a PGlite-backed
+// safeDb in a prod-typed handler context.
+const scopedSafeDb = (): SafeDb =>
+  asTestRaw<SafeDb>(createSafeDb(testDb, [ids.wsA1], ids.orgA, ids.userA1));
+
+type ListCtx = Parameters<typeof listDocxSuggestions.handler>[0];
+
+const listPage = async (
+  entityId: SafeId<"entity">,
+  cursor: string | undefined,
+) =>
+  await listDocxSuggestions.handler(
+    createTestHandlerContext<ListCtx>({
+      workspaceId: ids.wsA1,
+      session: { activeOrganizationId: ids.orgA },
+      user: { id: ids.userA1 },
+      safeDb: scopedSafeDb(),
+      params: { workspaceId: ids.wsA1, entityId },
+      query: { limit: PAGE_LIMIT, status: "pending", cursor },
+    }),
+  );
+
+/** The handler answers a rejected request with a status response, not a page. */
+const expectPage = (result: Awaited<ReturnType<typeof listPage>>) => {
+  if (!("items" in result)) {
+    throw new Error(`expected a page, got ${JSON.stringify(result)}`);
+  }
+  return result;
+};
+
+/** Walk to exhaustion, failing rather than looping when the cursor stalls. */
+const walk = async (
+  entityId: SafeId<"entity">,
+  startCursor?: string,
+): Promise<SafeId<"docxSuggestion">[]> => {
+  const visited: SafeId<"docxSuggestion">[] = [];
+  let cursor = startCursor;
+  for (let page = 0; page < MAX_PAGES; page += 1) {
+    // oxlint-disable-next-line no-await-in-loop -- sequential keyset pagination: each page needs the previous page's cursor
+    const result = expectPage(await listPage(entityId, cursor));
+    for (const item of result.items) {
+      visited.push(item.id);
+    }
+    if (result.nextCursor === null) {
+      return visited;
+    }
+    cursor = result.nextCursor;
+  }
+  throw new Error(
+    `pagination did not terminate within ${MAX_PAGES} pages; the cursor is stalling`,
+  );
+};
+
+const orderedIds = async (
+  entityId: SafeId<"entity">,
+): Promise<SafeId<"docxSuggestion">[]> =>
+  (
+    await testDb
+      .select({ id: docxSuggestions.id })
+      .from(docxSuggestions)
+      .where(eq(docxSuggestions.entityId, entityId))
+      .orderBy(docxSuggestions.createdAt, docxSuggestions.id)
+  ).map(({ id }) => id);
+
+describe("docx suggestion list keyset", () => {
+  test("the fixture carries the microseconds a Date cursor would lose", async () => {
+    // Without this the whole file could go vacuous: rows seeded from a JS
+    // `Date` cannot reproduce any of these boundary bugs.
+    const [counts] = await testDb
+      .select({
+        microsecondRows: sql<number>`count(*) FILTER (
+          WHERE ${docxSuggestions.createdAt}
+            <> date_trunc('milliseconds', ${docxSuggestions.createdAt})
+        )::int`,
+        total: sql<number>`count(*)::int`,
+      })
+      .from(docxSuggestions)
+      .where(
+        inArray(docxSuggestions.entityId, [twinEntityId, distinctEntityId]),
+      );
+
+    expect(counts?.total).toBe(TWIN_COUNT + DISTINCT_COUNT);
+    expect(counts?.microsecondRows).toBe(TWIN_COUNT + DISTINCT_COUNT);
+  });
+
+  test("INVARIANT: paging to exhaustion visits every row exactly once, in order", async () => {
+    const expected = await orderedIds(twinEntityId);
+    expect(expected).toHaveLength(TWIN_COUNT);
+
+    const visited = await walk(twinEntityId);
+
+    // Exactly once: no duplicate boundary row, no skipped microsecond twin.
+    expect(visited).toEqual(expected);
+    expect(new Set(visited).size).toBe(TWIN_COUNT);
+  });
+
+  test("INVARIANT: resuming from every page boundary yields the exact remainder", async () => {
+    const expected = await orderedIds(distinctEntityId);
+    expect(expected).toHaveLength(DISTINCT_COUNT);
+
+    // Every reachable cursor is a page boundary; each must resume the tail
+    // that follows it, with no row repeated across the cut and none lost.
+    let cursor: string | undefined;
+    let consumed = 0;
+    for (let page = 0; page < MAX_PAGES; page += 1) {
+      // oxlint-disable-next-line no-await-in-loop -- sequential keyset pagination
+      const result = expectPage(await listPage(distinctEntityId, cursor));
+      if (result.nextCursor === null) {
+        expect(consumed + result.items.length).toBe(DISTINCT_COUNT);
+        return;
+      }
+      consumed += result.items.length;
+      // oxlint-disable-next-line no-await-in-loop -- sequential keyset pagination
+      const remainder = await walk(distinctEntityId, result.nextCursor);
+      expect(remainder).toEqual(expected.slice(consumed));
+      cursor = result.nextCursor;
+    }
+    throw new Error("pagination did not terminate");
+  });
+});
+
+describe("docx suggestion cursors issued before the microsecond fix", () => {
+  // The old encoder was `encodePaginationCursor([createdAt.toISOString(), id])`.
+  const legacyCursor = (createdAtIso: string, id: string): string =>
+    encodePaginationCursor([createdAtIso, id]);
+
+  test("an in-flight millisecond cursor resumes the distinct-millisecond tail exactly", async () => {
+    const expected = await orderedIds(distinctEntityId);
+    const boundaryIndex = 3;
+    const boundaryId = expected.at(boundaryIndex);
+    expect(boundaryId).toBeDefined();
+    if (boundaryId === undefined) {
+      return;
+    }
+
+    const visited = await walk(
+      distinctEntityId,
+      legacyCursor(distinctIsoMillisecond(boundaryIndex), boundaryId),
+    );
+
+    expect(visited).toEqual(expected.slice(boundaryIndex + 1));
+  });
+
+  test("an in-flight millisecond cursor over microsecond twins still decodes and terminates", async () => {
+    const expected = await orderedIds(twinEntityId);
+    const boundaryId = expected.at(5);
+    expect(boundaryId).toBeDefined();
+    if (boundaryId === undefined) {
+      return;
+    }
+
+    // Every twin truncates to the same millisecond, so this cursor is
+    // genuinely lossy and can only fall back to its id tie-break. What it
+    // must never do is 500 or stall: it decodes, and the walk terminates
+    // without repeating a row.
+    const visited = await walk(
+      twinEntityId,
+      legacyCursor("2026-05-01T09:00:00.100Z", boundaryId),
+    );
+
+    expect(new Set(visited).size).toBe(visited.length);
+    for (const id of visited) {
+      expect(expected).toContain(id);
+    }
+  });
+
+  test("a malformed cursor is rejected rather than silently restarting page one", async () => {
+    const result = await listPage(twinEntityId, "not-a-cursor");
+
+    expect("items" in result).toBe(false);
+  });
+});

--- a/apps/api/src/handlers/docx-suggestions/read.db.test.ts
+++ b/apps/api/src/handlers/docx-suggestions/read.db.test.ts
@@ -50,6 +50,10 @@ const MAX_PAGES = 40;
 const TWIN_COUNT = 12;
 const twinTimestamp = (index: number): string =>
   `2026-05-01 09:00:00.100${String(index + 1).padStart(3, "0")}+00`;
+const twinId = (index: number): SafeId<"docxSuggestion"> =>
+  toSafeId<"docxSuggestion">(
+    `00000000-0000-7000-8000-${String(TWIN_COUNT - index).padStart(12, "0")}`,
+  );
 
 /**
  * Ten rows on distinct milliseconds, each still carrying microseconds. A
@@ -73,14 +77,16 @@ const seedSuggestions = async ({
   entityId,
   count,
   timestampAt,
+  idAt,
 }: {
   entityId: SafeId<"entity">;
   count: number;
   timestampAt: (index: number) => string;
+  idAt?: ((index: number) => SafeId<"docxSuggestion">) | undefined;
 }): Promise<SafeId<"docxSuggestion">[]> => {
   const seeded: SafeId<"docxSuggestion">[] = [];
   for (let index = 0; index < count; index += 1) {
-    const id = toSafeId<"docxSuggestion">(Bun.randomUUIDv7());
+    const id = idAt?.(index) ?? toSafeId<"docxSuggestion">(Bun.randomUUIDv7());
     // The microsecond digits are the whole point of the fixture, so
     // `created_at` is written as a literal instead of being bound from a
     // `Date` (which cannot carry them).
@@ -120,6 +126,7 @@ beforeAll(async () => {
     entityId: twinEntityId,
     count: TWIN_COUNT,
     timestampAt: twinTimestamp,
+    idAt: twinId,
   });
   await seedSuggestions({
     entityId: distinctEntityId,
@@ -276,27 +283,24 @@ describe("docx suggestion cursors issued before the microsecond fix", () => {
     expect(visited).toEqual(expected.slice(boundaryIndex + 1));
   });
 
-  test("an in-flight millisecond cursor over microsecond twins still decodes and terminates", async () => {
+  test("an in-flight millisecond cursor over microsecond twins resumes the exact tail", async () => {
     const expected = await orderedIds(twinEntityId);
-    const boundaryId = expected.at(5);
+    const boundaryIndex = 5;
+    const boundaryId = expected.at(boundaryIndex);
     expect(boundaryId).toBeDefined();
     if (boundaryId === undefined) {
       return;
     }
 
-    // Every twin truncates to the same millisecond, so this cursor is
-    // genuinely lossy and can only fall back to its id tie-break. What it
-    // must never do is 500 or stall: it decodes, and the walk terminates
-    // without repeating a row.
+    // Timestamps increase while ids decrease, so an id fallback would return
+    // the already-consumed prefix. Resolving this id in-DB must recover the
+    // actual timestamp and return only the true ordered tail.
     const visited = await walk(
       twinEntityId,
       legacyCursor("2026-05-01T09:00:00.100Z", boundaryId),
     );
 
-    expect(new Set(visited).size).toBe(visited.length);
-    for (const id of visited) {
-      expect(expected).toContain(id);
-    }
+    expect(visited).toEqual(expected.slice(boundaryIndex + 1));
   });
 
   test("a malformed cursor is rejected rather than silently restarting page one", async () => {

--- a/apps/api/src/handlers/docx-suggestions/read.ts
+++ b/apps/api/src/handlers/docx-suggestions/read.ts
@@ -1,5 +1,5 @@
 import { Result } from "better-result";
-import { and, asc, eq, gt, or } from "drizzle-orm";
+import { and, asc, eq } from "drizzle-orm";
 import { t } from "elysia";
 
 import { docxSuggestions } from "@/api/db/schema";
@@ -8,10 +8,7 @@ import { tSafeId, workspaceParams } from "@/api/lib/custom-schema";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import { createCursorPage } from "@/api/lib/pagination";
 
-import {
-  decodeDocxSuggestionCursor,
-  encodeDocxSuggestionCursor,
-} from "./cursor";
+import { docxSuggestionCursor } from "./cursor";
 import {
   DOCX_SUGGESTIONS_PAGE_SIZE_DEFAULT,
   DOCX_SUGGESTIONS_PAGE_SIZE_MAX,
@@ -54,19 +51,17 @@ const listDocxSuggestions = createSafeHandler(
       conditions.push(eq(docxSuggestions.status, query.status));
     }
     if (query.cursor !== undefined) {
-      const cursor = decodeDocxSuggestionCursor(query.cursor);
+      const cursor = docxSuggestionCursor.decode(query.cursor);
       if (cursor === null) {
         return Result.err(
           new HandlerError({ status: 400, message: "Invalid cursor" }),
         );
       }
-      const keyset = or(
-        gt(docxSuggestions.createdAt, cursor.createdAt),
-        and(
-          eq(docxSuggestions.createdAt, cursor.createdAt),
-          gt(docxSuggestions.id, cursor.id),
-        ),
-      );
+      const keyset = docxSuggestionCursor.keysetAfter({
+        cursor,
+        idColumn: docxSuggestions.id,
+        direction: "ascending",
+      });
       if (keyset !== undefined) {
         conditions.push(keyset);
       }
@@ -84,6 +79,8 @@ const listDocxSuggestions = createSafeHandler(
             status: docxSuggestions.status,
             appliedMode: docxSuggestions.appliedMode,
             createdAt: docxSuggestions.createdAt,
+            createdAtCursor:
+              docxSuggestionCursor.cursorValue.as("created_at_cursor"),
           })
           .from(docxSuggestions)
           .where(and(...conditions))
@@ -92,17 +89,28 @@ const listDocxSuggestions = createSafeHandler(
       ),
     );
 
-    return Result.ok(
-      createCursorPage({
-        rows,
-        limit,
-        cursorForItem: (item) =>
-          encodeDocxSuggestionCursor({
-            createdAt: item.createdAt,
-            id: item.id,
-          }),
-      }),
-    );
+    const page = createCursorPage({
+      rows,
+      limit,
+      cursorForItem: (item) =>
+        docxSuggestionCursor.encode(item.createdAtCursor, item.id),
+    });
+
+    // `createdAtCursor` is the serialization projection, not part of the
+    // response contract; drop it after the page is cut.
+    return Result.ok({
+      ...page,
+      items: page.items.map((item) => ({
+        id: item.id,
+        opPayload: item.opPayload,
+        comment: item.comment,
+        severity: item.severity,
+        area: item.area,
+        status: item.status,
+        appliedMode: item.appliedMode,
+        createdAt: item.createdAt,
+      })),
+    });
   },
 );
 

--- a/apps/api/src/handlers/docx-suggestions/read.ts
+++ b/apps/api/src/handlers/docx-suggestions/read.ts
@@ -51,11 +51,51 @@ const listDocxSuggestions = createSafeHandler(
       conditions.push(eq(docxSuggestions.status, query.status));
     }
     if (query.cursor !== undefined) {
-      const cursor = docxSuggestionCursor.decode(query.cursor);
-      if (cursor === null) {
+      const decodedCursor = docxSuggestionCursor.decode(query.cursor);
+      if (decodedCursor === null) {
         return Result.err(
           new HandlerError({ status: 400, message: "Invalid cursor" }),
         );
+      }
+
+      let cursor = decodedCursor;
+      if (cursor.timestamp.precision === "milliseconds") {
+        // The legacy timestamp cannot order rows inside its millisecond. Its
+        // id can: resolve that row's exact timestamp without leaving the DB's
+        // precision, scoped to the same entity and workspace as the list.
+        const [boundary] = yield* Result.await(
+          safeDb((tx) =>
+            tx
+              .select({
+                createdAtCursor:
+                  docxSuggestionCursor.cursorValue.as("created_at_cursor"),
+              })
+              .from(docxSuggestions)
+              .where(
+                and(
+                  eq(docxSuggestions.workspaceId, workspaceId),
+                  eq(docxSuggestions.entityId, params.entityId),
+                  eq(docxSuggestions.id, cursor.id),
+                ),
+              )
+              .limit(1),
+          ),
+        );
+        if (boundary === undefined) {
+          return Result.ok({ items: [], limit, nextCursor: null });
+        }
+        const exactCursor = docxSuggestionCursor.decode(
+          docxSuggestionCursor.encode(boundary.createdAtCursor, cursor.id),
+        );
+        if (exactCursor === null) {
+          return Result.err(
+            new HandlerError({
+              status: 500,
+              message: "Could not resolve suggestion cursor boundary",
+            }),
+          );
+        }
+        cursor = exactCursor;
       }
       const keyset = docxSuggestionCursor.keysetAfter({
         cursor,

--- a/apps/api/src/handlers/entities/delete.ts
+++ b/apps/api/src/handlers/entities/delete.ts
@@ -169,10 +169,7 @@ export const deleteEntitiesHandler = async function* ({
       await forEachOcrDerivativePage({
         readPage: async (cursor, limit) =>
           await tx
-            .select({
-              createdAt: documentProcessingRuns.createdAt,
-              id: documentProcessingRuns.id,
-            })
+            .select({ id: documentProcessingRuns.id })
             .from(documentProcessingRuns)
             .where(
               and(

--- a/apps/api/src/handlers/workspaces/delete.ts
+++ b/apps/api/src/handlers/workspaces/delete.ts
@@ -131,10 +131,7 @@ const deleteWorkspaceOcrDerivatives = async ({
       const result = await safeDb(
         async (tx) =>
           await tx
-            .select({
-              createdAt: documentProcessingRuns.createdAt,
-              id: documentProcessingRuns.id,
-            })
+            .select({ id: documentProcessingRuns.id })
             .from(documentProcessingRuns)
             .where(
               and(

--- a/apps/api/src/lib/db-pagination.test.ts
+++ b/apps/api/src/lib/db-pagination.test.ts
@@ -209,26 +209,16 @@ describe("createTimestampIdCursorCodec keysetAfter", () => {
     expect(rendered).toContain("::timestamptz");
   });
 
-  test("INVARIANT: legacy millisecond cursor truncates the column on both sides", () => {
-    // A page issued before the microsecond migration truncated created_at to the
-    // millisecond and ordered on that; resuming it must compare the truncated
-    // column so a row at `…​.123456` is not re-emitted (asc) or skipped (desc)
-    // against a `…​.123` boundary. Both the range and tie-break clauses must
-    // truncate, so require two date_trunc occurrences.
-    const cases = [
-      { direction: "ascending", op: ">" },
-      { direction: "descending", op: "<" },
-    ] as const;
-    for (const { direction, op } of cases) {
-      const rendered = renderAfter("2026-07-10T08:15:30.123Z", direction);
-      const truncation = `date_trunc('milliseconds', "invoices"."created_at")`;
-      // Both the range clause and the tie-break clause truncate the column.
-      const truncations = rendered.match(
-        /date_trunc\('milliseconds', "invoices"\."created_at"\)/gu,
-      );
-      expect(truncations?.length).toBe(2);
-      expect(rendered).toContain(`${truncation} ${op}`);
-      expect(rendered).toContain(`${truncation} =`);
-    }
+  test("INVARIANT: an unresolved millisecond cursor skips its ambiguous interval", () => {
+    const ascending = renderAfter("2026-07-10T08:15:30.123Z", "ascending");
+    expect(ascending).toContain('"created_at" >=');
+    expect(ascending).toContain("interval '1 millisecond'");
+    expect(ascending).not.toContain('"id"');
+    expect(ascending).not.toContain("date_trunc");
+
+    const descending = renderAfter("2026-07-10T08:15:30.123Z", "descending");
+    expect(descending).toContain('"created_at" <');
+    expect(descending).not.toContain('"id"');
+    expect(descending).not.toContain("date_trunc");
   });
 });

--- a/apps/api/src/lib/db-pagination.ts
+++ b/apps/api/src/lib/db-pagination.ts
@@ -1,4 +1,4 @@
-import { and, eq, gt, lt, or, sql } from "drizzle-orm";
+import { and, eq, gt, gte, lt, or, sql } from "drizzle-orm";
 import type { Column, SQL, SQLWrapper } from "drizzle-orm";
 
 import {
@@ -22,11 +22,10 @@ const THIRTY_DAY_MONTHS = new Set([4, 6, 9, 11]);
  * `microseconds-naive` is the same six-digit value without the `Z`, issued
  * before the UTC-anchored rendering; its boundary keeps the old
  * session-zone interpretation, which matches how the timestamptz migration
- * converted the rows it was cut from. `milliseconds` marks the oldest
- * `date_trunc('milliseconds', ...)` cursor (ISO `…​.123Z`); keyset
- * comparisons truncate the column to match it so a page cut before the
- * microsecond migration resumes without duplicating or skipping the rows
- * that shared its truncated millisecond.
+ * converted the rows it was cut from. `milliseconds` marks the oldest ISO
+ * `…​.123Z` cursor. It cannot identify a position inside that millisecond;
+ * callers that can resolve its row by id replace it with the exact database
+ * timestamp, while the generic fallback skips the ambiguous interval.
  */
 export type PgTimestampCursorPrecision =
   | "microseconds"
@@ -154,8 +153,8 @@ export type TimestampIdCursor<Id> = {
 /**
  * `ascending` pages forward (`ORDER BY column, id`, keyset `>`); `descending`
  * pages backward (`ORDER BY column DESC, id DESC`, keyset `<`). The codec owns
- * the whole keyset predicate so no handler can mismatch the boundary column,
- * the tie-break, or the legacy-millisecond truncation across the two clauses.
+ * the whole keyset predicate so no handler can mismatch the boundary column
+ * or tie-break across the two clauses.
  */
 export type KeysetCursorDirection = "ascending" | "descending";
 
@@ -176,9 +175,9 @@ export type TimestampIdCursorCodec<Id> = {
   /**
    * Full keyset predicate selecting the rows strictly after `cursor` in
    * `direction`, on the codec's timestamp column plus `idColumn`. Canonical
-   * microsecond cursors compare the raw column; a legacy millisecond cursor
-   * compares `date_trunc('milliseconds', column)` on both sides of the
-   * comparison so the page it was cut from resumes exactly.
+   * microsecond cursors compare the raw column. A legacy millisecond cursor
+   * cannot order rows inside its truncated interval, so the generic fallback
+   * skips that interval without returning a possible prefix duplicate.
    */
   keysetAfter: (options: KeysetAfterOptions<Id>) => SQL | undefined;
   encode: (timestampValue: string, id: string) => string;
@@ -222,17 +221,19 @@ export const createTimestampIdCursorCodec = <Id>({
   cursorValue: pgTimestampCursorValue(column),
   keysetAfter: ({ cursor, idColumn, direction }) => {
     const boundary = pgTimestampCursorBoundary(cursor.timestamp);
+    if (cursor.timestamp.precision === "milliseconds") {
+      // The lost microseconds may order rows opposite to their ids. The id
+      // tie-break is therefore not a safe approximation inside this interval.
+      // Skip it unless the caller first resolves the cursor row's exact
+      // timestamp in-database and replaces this legacy timestamp.
+      return direction === "ascending"
+        ? gte(column, sql`${boundary} + interval '1 millisecond'`)
+        : lt(column, boundary);
+    }
     const compare = direction === "ascending" ? gt : lt;
-    // A legacy millisecond cursor was cut from a page ordered on the
-    // millisecond-truncated timestamp, so compare the truncated column against
-    // it; a canonical microsecond cursor compares the raw column directly.
-    const timestampExpr =
-      cursor.timestamp.precision === "milliseconds"
-        ? sql`date_trunc('milliseconds', ${column})`
-        : column;
     return or(
-      compare(timestampExpr, boundary),
-      and(eq(timestampExpr, boundary), compare(idColumn, cursor.id)),
+      compare(column, boundary),
+      and(eq(column, boundary), compare(idColumn, cursor.id)),
     );
   },
   encode: (timestampValue, id) => encodePaginationCursor([timestampValue, id]),

--- a/apps/api/src/lib/legal-search/sk-document-backfill-requested-tier.db.test.ts
+++ b/apps/api/src/lib/legal-search/sk-document-backfill-requested-tier.db.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Keyset regression for the requested tier of the document backfill queue.
+ *
+ * `case_law_decisions.document_fetch_requested_at` is written only by SQL
+ * `now()`, so it always carries microseconds. The tier pages oldest-first,
+ * and an ascending `>` boundary that went through a JS `Date` still admits
+ * the row the page was cut at: the queue would then re-emit that decision at
+ * the head of every page and never reach the rest of the backlog. Only rows
+ * with non-zero sub-millisecond digits can show that, so the fixture writes
+ * the column with `now()`-shaped literals.
+ */
+
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import { inArray, sql } from "drizzle-orm";
+
+import type { ScopedDb } from "@/api/db/safe-db";
+import { caseLawDecisions, caseLawSources } from "@/api/db/schema";
+import { ADAPTER_KEYS } from "@/api/handlers/case-law/consts";
+import type { SafeId } from "@/api/lib/branded-types";
+import { loadRequestedDocuments } from "@/api/lib/legal-search/sk-document-backfill";
+import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
+import { getTestDb, releaseTestDb } from "@/api/tests/security/test-utils";
+import type { TestDatabase } from "@/api/tests/security/test-utils";
+
+const PAGE_LIMIT = 3;
+/** A stalled cursor loops forever, so the walk is bounded. */
+const MAX_PAGES = 40;
+
+/**
+ * Nine requests inside one millisecond, separated only by microseconds; the
+ * last three share an exact timestamp so the id tie-break runs too. Every one
+ * of them collapses onto the same JS `Date`.
+ */
+const REQUESTED_AT = [
+  "2026-06-03 07:00:00.750001+00",
+  "2026-06-03 07:00:00.750002+00",
+  "2026-06-03 07:00:00.750003+00",
+  "2026-06-03 07:00:00.750004+00",
+  "2026-06-03 07:00:00.750005+00",
+  "2026-06-03 07:00:00.750006+00",
+  "2026-06-03 07:00:00.750007+00",
+  "2026-06-03 07:00:00.750007+00",
+  "2026-06-03 07:00:00.750007+00",
+] as const;
+
+let testDb: TestDatabase;
+let scopedDb: ScopedDb;
+let sourceId: SafeId<"caseLawSource">;
+const created: SafeId<"caseLawDecision">[] = [];
+const suffix = Bun.randomUUIDv7().slice(0, 8);
+
+beforeAll(async () => {
+  testDb = await getTestDb();
+  scopedDb = asTestRaw<ScopedDb>(
+    async (callback: (tx: TestDatabase) => Promise<unknown>) =>
+      // oxlint-disable-next-line node/callback-return -- arrow body already returns the callback result
+      await callback(testDb),
+  );
+
+  const [source] = await testDb
+    .insert(caseLawSources)
+    .values({
+      adapterKey: ADAPTER_KEYS.SK_COURTS,
+      name: `SK requested-tier keyset ${suffix}`,
+      enabled: false,
+    })
+    .returning({ id: caseLawSources.id });
+  if (!source) {
+    throw new Error("expected source row");
+  }
+  sourceId = source.id;
+
+  for (const [index, requestedAt] of REQUESTED_AT.entries()) {
+    // oxlint-disable-next-line no-await-in-loop -- ordered inserts on one test DB connection
+    const [row] = await testDb
+      .insert(caseLawDecisions)
+      .values({
+        sourceId,
+        caseNumber: `requested-${suffix}-${String(index).padStart(3, "0")}`,
+        court: "Okresný súd",
+        country: "SVK",
+        language: "sk",
+        fulltext: null,
+        documentUrl: "https://example.test/requested.pdf",
+      })
+      .returning({ id: caseLawDecisions.id });
+    if (!row) {
+      throw new Error("expected decision row");
+    }
+    created.push(row.id);
+    // The microsecond digits are the point of the fixture, so the column is
+    // written as a literal rather than bound from a `Date`.
+    // oxlint-disable-next-line no-await-in-loop -- ordered updates on one test DB connection
+    await testDb.execute(sql`
+      UPDATE case_law_decisions
+      SET document_fetch_requested_at = ${requestedAt}::timestamptz
+      WHERE id = ${row.id}
+    `);
+  }
+}, 120_000);
+
+afterAll(async () => {
+  if (created.length > 0) {
+    await testDb
+      .delete(caseLawDecisions)
+      .where(inArray(caseLawDecisions.id, created));
+  }
+  await releaseTestDb();
+});
+
+const walk = async (
+  startAfter?: SafeId<"caseLawDecision">,
+): Promise<SafeId<"caseLawDecision">[]> => {
+  const visited: SafeId<"caseLawDecision">[] = [];
+  let after = startAfter;
+  for (let page = 0; page < MAX_PAGES; page += 1) {
+    // oxlint-disable-next-line no-await-in-loop -- sequential keyset pagination
+    const rows = await loadRequestedDocuments(
+      after === undefined
+        ? { scopedDb, sourceId, limit: PAGE_LIMIT }
+        : { scopedDb, sourceId, limit: PAGE_LIMIT, after },
+    );
+    for (const row of rows) {
+      visited.push(row.id);
+    }
+    if (rows.length < PAGE_LIMIT) {
+      return visited;
+    }
+    const last = rows.at(-1);
+    if (!last) {
+      return visited;
+    }
+    after = last.id;
+  }
+  throw new Error(
+    `the requested tier did not drain within ${MAX_PAGES} pages; the cursor is stalling`,
+  );
+};
+
+test("INVARIANT: paging the requested tier visits every decision exactly once", async () => {
+  const expected = (
+    await testDb
+      .select({ id: caseLawDecisions.id })
+      .from(caseLawDecisions)
+      .where(inArray(caseLawDecisions.id, created))
+      .orderBy(caseLawDecisions.documentFetchRequestedAt, caseLawDecisions.id)
+  ).map(({ id }) => id);
+  expect(expected).toHaveLength(REQUESTED_AT.length);
+
+  const visited = await walk();
+
+  // No microsecond twin re-emitted at a page boundary, none skipped.
+  expect(visited).toEqual(expected);
+  expect(new Set(visited).size).toBe(expected.length);
+});
+
+test("the fixture reproduces the boundary a millisecond cursor cannot pass", async () => {
+  // Guards the file against going vacuous: seeded from a JS `Date` these
+  // rows could not reproduce the bug. Every one must differ from its own
+  // millisecond truncation, and a truncated ascending boundary must still
+  // admit the very row it was cut at — which is the stall.
+  const ordered = await walk();
+  const boundary = ordered.at(4);
+  expect(boundary).toBeDefined();
+  if (boundary === undefined) {
+    return;
+  }
+
+  const [counts] = await testDb
+    .select({
+      microsecondRows: sql<number>`count(*) FILTER (
+        WHERE ${caseLawDecisions.documentFetchRequestedAt}
+          <> date_trunc('milliseconds', ${caseLawDecisions.documentFetchRequestedAt})
+      )::int`,
+      // Rows a truncated `>` boundary would still return, the boundary row
+      // among them: that repetition is what never lets the queue advance.
+      readmittedBoundaryRows: sql<number>`count(*) FILTER (
+        WHERE ${caseLawDecisions.id} = ${boundary}
+          AND ${caseLawDecisions.documentFetchRequestedAt} > date_trunc(
+            'milliseconds',
+            (SELECT b.document_fetch_requested_at
+             FROM case_law_decisions b WHERE b.id = ${boundary})
+          )
+      )::int`,
+    })
+    .from(caseLawDecisions)
+    .where(inArray(caseLawDecisions.id, created));
+
+  expect(counts).toBeDefined();
+  expect(counts?.microsecondRows).toBe(REQUESTED_AT.length);
+  expect(counts?.readmittedBoundaryRows).toBe(1);
+});
+
+test("INVARIANT: resuming after any decision yields exactly the ones that follow", async () => {
+  const expected = await walk();
+
+  for (const [index, boundary] of expected.entries()) {
+    // oxlint-disable-next-line no-await-in-loop -- sequential keyset pagination
+    const remainder = await walk(boundary);
+    expect(remainder).toEqual(expected.slice(index + 1));
+  }
+});

--- a/apps/api/src/lib/legal-search/sk-document-backfill.ts
+++ b/apps/api/src/lib/legal-search/sk-document-backfill.ts
@@ -286,11 +286,16 @@ export const remainingDocumentOrder = [
   asc(caseLawDecisions.id),
 ] as const;
 
-/** Keyset position in the requested tier (requestedAt, id). */
-export type RequestedDocumentCursor = {
-  requestedAt: Date;
-  id: SafeId<"caseLawDecision">;
-};
+/**
+ * Keyset position in the requested tier: the previous page's last row.
+ * Only its id travels, because the boundary's
+ * `(document_fetch_requested_at, id)` pair is read back in the database.
+ * `document_fetch_requested_at` is written by SQL `now()` and therefore
+ * carries microseconds, which a JS `Date` boundary would truncate to the
+ * millisecond; the ascending `>` comparison would then still admit the row
+ * the page was cut at and re-emit it at the head of every following page.
+ */
+export type RequestedDocumentCursor = SafeId<"caseLawDecision">;
 
 /** Keyset position in the remaining tier (attempts, decisionDate, id). */
 export type RemainingDocumentCursor = {
@@ -364,13 +369,7 @@ export const loadRequestedDocuments = async ({
       eq(caseLawDecisions.sourceId, sourceId),
       requestedDocumentPredicate,
       after
-        ? or(
-            gt(caseLawDecisions.documentFetchRequestedAt, after.requestedAt),
-            and(
-              eq(caseLawDecisions.documentFetchRequestedAt, after.requestedAt),
-              gt(caseLawDecisions.id, after.id),
-            ),
-          )
+        ? sql`(${caseLawDecisions.documentFetchRequestedAt}, ${caseLawDecisions.id}) > (select b.document_fetch_requested_at, b.id from case_law_decisions b where b.id = ${after})`
         : undefined,
     ),
   });

--- a/apps/api/src/lib/machine-api-key-queries.ts
+++ b/apps/api/src/lib/machine-api-key-queries.ts
@@ -55,8 +55,8 @@ const isMachineApiKeyIdCursorPart = (value: unknown): value is string =>
  * excludes every key inside the truncated sliver: a machine credential
  * silently missing from page two is one nobody can see, and therefore one
  * nobody can revoke. Cursors issued in the older ISO form keep decoding; the
- * codec tags them millisecond-precision and truncates the column on both
- * sides of the comparison so the page they were cut from resumes exactly.
+ * codec tags them millisecond-precision; the list resolves the boundary key's
+ * exact timestamp under the same organization scope before comparing it.
  */
 export const machineApiKeyCursor = createTimestampIdCursorCodec({
   column: apikey.createdAt,
@@ -123,8 +123,29 @@ export const listOrganizationMachineApiKeys = async ({
   cursor,
   limit,
   organizationId,
-}: ListOptions): Promise<MachineApiKeyPageRow[]> =>
-  await rootDb
+}: ListOptions): Promise<MachineApiKeyPageRow[]> => {
+  let exactCursor = cursor;
+  if (cursor?.timestamp.precision === "milliseconds") {
+    const [boundary] = await rootDb
+      .select({
+        createdAtCursor:
+          machineApiKeyCursor.cursorValue.as("created_at_cursor"),
+      })
+      .from(apikey)
+      .where(and(organizationScope(organizationId), eq(apikey.id, cursor.id)))
+      .limit(1);
+    if (boundary === undefined) {
+      return [];
+    }
+    exactCursor = machineApiKeyCursor.decode(
+      machineApiKeyCursor.encode(boundary.createdAtCursor, cursor.id),
+    );
+    if (exactCursor === null) {
+      return [];
+    }
+  }
+
+  return await rootDb
     .select({
       ...machineApiKeyColumns,
       createdAtCursor: machineApiKeyCursor.cursorValue.as("created_at_cursor"),
@@ -133,10 +154,10 @@ export const listOrganizationMachineApiKeys = async ({
     .where(
       and(
         organizationScope(organizationId),
-        cursor === null
+        exactCursor === null
           ? undefined
           : machineApiKeyCursor.keysetAfter({
-              cursor,
+              cursor: exactCursor,
               idColumn: apikey.id,
               direction: "descending",
             }),
@@ -144,6 +165,7 @@ export const listOrganizationMachineApiKeys = async ({
     )
     .orderBy(desc(apikey.createdAt), desc(apikey.id))
     .limit(limit + 1);
+};
 
 /**
  * A single machine key, scoped to the organization in the same query.

--- a/apps/api/src/lib/machine-api-key-queries.ts
+++ b/apps/api/src/lib/machine-api-key-queries.ts
@@ -1,8 +1,10 @@
-import { and, desc, eq, lt, or } from "drizzle-orm";
+import { and, desc, eq } from "drizzle-orm";
 
 import { apikey } from "@/api/db/auth-schema";
 import { rootDb } from "@/api/db/root";
 import type { SafeId } from "@/api/lib/branded-types";
+import { createTimestampIdCursorCodec } from "@/api/lib/db-pagination";
+import type { TimestampIdCursor } from "@/api/lib/db-pagination";
 import { machineApiKeyOrganizationScope as organizationScope } from "@/api/lib/machine-api-key-scope";
 
 /**
@@ -40,6 +42,30 @@ import { machineApiKeyOrganizationScope as organizationScope } from "@/api/lib/m
  * cannot reach the tenant predicate.
  */
 
+/** Better Auth api-key ids are text (not UUIDs); mirror `text` column bounds. */
+const isMachineApiKeyIdCursorPart = (value: unknown): value is string =>
+  typeof value === "string" && value.length >= 1 && value.length <= 128;
+
+/**
+ * `(created_at, id)` keyset codec for the newest-first key list.
+ *
+ * The timestamp half is projected and compared at the column's microsecond
+ * precision. `created_at` defaults to `now()`, so reading it into a JS `Date`
+ * truncates it to the millisecond, and the descending `<` boundary then
+ * excludes every key inside the truncated sliver: a machine credential
+ * silently missing from page two is one nobody can see, and therefore one
+ * nobody can revoke. Cursors issued in the older ISO form keep decoding; the
+ * codec tags them millisecond-precision and truncates the column on both
+ * sides of the comparison so the page they were cut from resumes exactly.
+ */
+export const machineApiKeyCursor = createTimestampIdCursorCodec({
+  column: apikey.createdAt,
+  brandId: (id: string) => id,
+  isIdPart: isMachineApiKeyIdCursorPart,
+});
+
+type MachineApiKeyCursor = TimestampIdCursor<string>;
+
 const machineApiKeyColumns = {
   createdAt: apikey.createdAt,
   enabled: apikey.enabled,
@@ -72,9 +98,17 @@ export type MachineApiKeyRow = {
 };
 
 type ListOptions = {
-  cursor: { createdAt: Date; id: string } | null;
+  cursor: MachineApiKeyCursor | null;
   limit: number;
   organizationId: SafeId<"organization">;
+};
+
+/**
+ * A listed key plus the microsecond-precision `created_at` projection the
+ * caller encodes into the next cursor. Ordering stays on the raw column.
+ */
+export type MachineApiKeyPageRow = MachineApiKeyRow & {
+  createdAtCursor: string;
 };
 
 /**
@@ -89,23 +123,24 @@ export const listOrganizationMachineApiKeys = async ({
   cursor,
   limit,
   organizationId,
-}: ListOptions): Promise<MachineApiKeyRow[]> =>
+}: ListOptions): Promise<MachineApiKeyPageRow[]> =>
   await rootDb
-    .select(machineApiKeyColumns)
+    .select({
+      ...machineApiKeyColumns,
+      createdAtCursor: machineApiKeyCursor.cursorValue.as("created_at_cursor"),
+    })
     .from(apikey)
     .where(
-      cursor === null
-        ? organizationScope(organizationId)
-        : and(
-            organizationScope(organizationId),
-            or(
-              lt(apikey.createdAt, cursor.createdAt),
-              and(
-                eq(apikey.createdAt, cursor.createdAt),
-                lt(apikey.id, cursor.id),
-              ),
-            ),
-          ),
+      and(
+        organizationScope(organizationId),
+        cursor === null
+          ? undefined
+          : machineApiKeyCursor.keysetAfter({
+              cursor,
+              idColumn: apikey.id,
+              direction: "descending",
+            }),
+      ),
     )
     .orderBy(desc(apikey.createdAt), desc(apikey.id))
     .limit(limit + 1);

--- a/apps/api/src/lib/ocr-derivative-pages.db.test.ts
+++ b/apps/api/src/lib/ocr-derivative-pages.db.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Boundary regression for the OCR-derivative cleanup walk.
+ *
+ * `document_processing_runs.created_at` defaults to `now()`, so it carries
+ * microseconds a JS `Date` cannot. The walk pages backwards (`created_at`
+ * descending), and a boundary that lost its microseconds excludes every run
+ * inside the truncated sliver: their searchable-PDF objects then survive the
+ * deletion of the matter or entity that owned them. Only rows with non-zero
+ * sub-millisecond digits can show that, so they are written by raw SQL.
+ *
+ * The in-memory walk test beside this one covers `forEachOcrDerivativePage`'s
+ * paging mechanics; this one covers the SQL order and predicate those pages
+ * are cut with.
+ */
+
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import { and, eq, sql } from "drizzle-orm";
+
+import { documentProcessingRuns } from "@/api/db/schema";
+import { toSafeId } from "@/api/lib/branded-types";
+import type { SafeId } from "@/api/lib/branded-types";
+import {
+  ocrDerivativeCursorFilter,
+  ocrDerivativePageOrder,
+} from "@/api/lib/ocr-derivative-pages";
+import type { OcrDerivativeCursor } from "@/api/lib/ocr-derivative-pages";
+import {
+  createTestIds,
+  setupRlsTestData,
+} from "@/api/tests/security/rls-helpers";
+import type { TestIds } from "@/api/tests/security/rls-helpers";
+import { getTestDb, releaseTestDb } from "@/api/tests/security/test-utils";
+import type { TestDatabase } from "@/api/tests/security/test-utils";
+
+const PAGE_LIMIT = 3;
+/** A stalled or skipping walk must fail the test, not spin. */
+const MAX_PAGES = 40;
+
+/**
+ * Nine runs sharing one millisecond, separated only by microseconds, plus
+ * three sharing an exact timestamp so the id tiebreaker is exercised too.
+ * Every one of the nine collapses onto the same JS `Date`.
+ */
+const RUN_TIMESTAMPS = [
+  "2026-06-01 10:00:00.500001+00",
+  "2026-06-01 10:00:00.500002+00",
+  "2026-06-01 10:00:00.500003+00",
+  "2026-06-01 10:00:00.500004+00",
+  "2026-06-01 10:00:00.500005+00",
+  "2026-06-01 10:00:00.500006+00",
+  "2026-06-01 10:00:00.500007+00",
+  "2026-06-01 10:00:00.500008+00",
+  "2026-06-01 10:00:00.500009+00",
+  "2026-06-01 10:00:00.600000+00",
+  "2026-06-01 10:00:00.600000+00",
+  "2026-06-01 10:00:00.600000+00",
+] as const;
+
+let testDb: TestDatabase;
+let ids: TestIds;
+
+beforeAll(async () => {
+  testDb = await getTestDb();
+  ids = createTestIds();
+  await setupRlsTestData(testDb, ids);
+
+  for (const [index, createdAt] of RUN_TIMESTAMPS.entries()) {
+    // `created_at` is written as a literal: binding it from a `Date` would
+    // erase exactly the digits this fixture exists to carry.
+    // oxlint-disable-next-line no-await-in-loop -- ordered inserts on one test DB connection
+    await testDb.execute(sql`
+      INSERT INTO document_processing_runs (
+        id, organization_id, workspace_id, entity_id, entity_version_id,
+        field_id, source_file_id, source_sha256_hex, kind, request_source,
+        status, created_at
+      ) VALUES (
+        ${toSafeId<"documentProcessingRun">(Bun.randomUUIDv7())},
+        ${ids.orgA}, ${ids.wsA1}, ${ids.entityA1}, ${ids.entityVersionA1},
+        ${ids.fieldA1}, ${Bun.randomUUIDv7()}, ${"a".repeat(64)},
+        'ocr', 'upload', 'succeeded', ${createdAt}::timestamptz
+      )
+    `);
+    expect(index).toBeGreaterThanOrEqual(0);
+  }
+}, 120_000);
+
+afterAll(async () => {
+  await releaseTestDb();
+});
+
+/** The production read, verbatim: same projection, predicate, and order. */
+const readPage = async (cursor: OcrDerivativeCursor | null, limit: number) =>
+  await testDb
+    .select({ id: documentProcessingRuns.id })
+    .from(documentProcessingRuns)
+    .where(
+      and(
+        eq(documentProcessingRuns.workspaceId, ids.wsA1),
+        ocrDerivativeCursorFilter(cursor),
+      ),
+    )
+    .orderBy(...ocrDerivativePageOrder())
+    .limit(limit);
+
+const walk = async (
+  startCursor: OcrDerivativeCursor | null = null,
+): Promise<SafeId<"documentProcessingRun">[]> => {
+  const visited: SafeId<"documentProcessingRun">[] = [];
+  let cursor = startCursor;
+  for (let page = 0; page < MAX_PAGES; page += 1) {
+    // oxlint-disable-next-line no-await-in-loop -- sequential keyset pagination
+    const rows = await readPage(cursor, PAGE_LIMIT);
+    for (const row of rows) {
+      visited.push(row.id);
+    }
+    if (rows.length < PAGE_LIMIT) {
+      return visited;
+    }
+    const last = rows.at(-1);
+    if (!last) {
+      return visited;
+    }
+    cursor = last.id;
+  }
+  throw new Error(
+    `the derivative walk did not terminate within ${MAX_PAGES} pages`,
+  );
+};
+
+test("INVARIANT: the walk visits every derivative exactly once, in page order", async () => {
+  const expected = (
+    await testDb
+      .select({ id: documentProcessingRuns.id })
+      .from(documentProcessingRuns)
+      .where(eq(documentProcessingRuns.workspaceId, ids.wsA1))
+      .orderBy(...ocrDerivativePageOrder())
+  ).map(({ id }) => id);
+  expect(expected).toHaveLength(RUN_TIMESTAMPS.length);
+
+  const visited = await walk();
+
+  // No microsecond twin skipped, no boundary row repeated.
+  expect(visited).toEqual(expected);
+  expect(new Set(visited).size).toBe(expected.length);
+});
+
+test("the fixture lands in the sliver a millisecond boundary would drop", async () => {
+  // Guards the whole file against going vacuous: seeded from a JS `Date`
+  // (or truncated by the driver) these rows could not reproduce the bug at
+  // all. Every one of them must differ from its own millisecond truncation,
+  // and a millisecond boundary must demonstrably lose rows the real one
+  // keeps.
+  const ordered = await walk();
+  // A boundary inside the microsecond twins, where truncation is lossy.
+  const boundaryIndex = 5;
+  const boundary = ordered.at(boundaryIndex);
+  expect(boundary).toBeDefined();
+  if (boundary === undefined) {
+    return;
+  }
+
+  const [counts] = await testDb
+    .select({
+      microsecondRows: sql<number>`count(*) FILTER (
+        WHERE ${documentProcessingRuns.createdAt}
+          <> date_trunc('milliseconds', ${documentProcessingRuns.createdAt})
+      )::int`,
+      truncatedRemainder: sql<number>`count(*) FILTER (
+        WHERE ${documentProcessingRuns.createdAt} < date_trunc(
+          'milliseconds',
+          (SELECT b.created_at FROM document_processing_runs b WHERE b.id = ${boundary})
+        )
+      )::int`,
+    })
+    .from(documentProcessingRuns)
+    .where(eq(documentProcessingRuns.workspaceId, ids.wsA1));
+  expect(counts).toBeDefined();
+  expect(counts?.microsecondRows).toBeGreaterThan(0);
+  // The real walk still has these many runs to visit after the boundary; a
+  // truncated boundary reaches strictly fewer, and the difference is exactly
+  // the orphaned searchable-PDF objects.
+  expect(counts?.truncatedRemainder).toBeLessThan(
+    ordered.length - (boundaryIndex + 1),
+  );
+});
+
+test("INVARIANT: resuming from any run yields exactly the runs that follow it", async () => {
+  const expected = await walk();
+
+  for (const [index, boundary] of expected.entries()) {
+    // oxlint-disable-next-line no-await-in-loop -- sequential keyset pagination
+    const remainder = await walk(boundary);
+    expect(remainder).toEqual(expected.slice(index + 1));
+  }
+});

--- a/apps/api/src/lib/ocr-derivative-pages.test.ts
+++ b/apps/api/src/lib/ocr-derivative-pages.test.ts
@@ -1,60 +1,41 @@
 import { expect, test } from "bun:test";
 
 import { toSafeId } from "@/api/lib/branded-types";
+import type { SafeId } from "@/api/lib/branded-types";
 
-import type {
-  OcrDerivativeCursor,
-  OcrDerivativeRun,
-} from "./ocr-derivative-pages";
-import {
-  forEachOcrDerivativePage,
-  isAfterOcrDerivativeCursor,
-} from "./ocr-derivative-pages";
+import type { OcrDerivativeCursor } from "./ocr-derivative-pages";
+import { forEachOcrDerivativePage } from "./ocr-derivative-pages";
 
 const CLEANUP_BATCH_SIZE = 1000;
 
 /**
- * Stands in for the paged `document_processing_runs` read: same total order and
- * same keyset predicate the SQL builders apply, so a walk over it exercises the
- * real page-boundary behaviour.
+ * Stands in for the paged `document_processing_runs` read. The cursor is the
+ * previous page's last run id, so the reader resumes at the position of that
+ * id in the total order — the same thing `ocrDerivativeCursorFilter` asks the
+ * database for. The order itself (and the microsecond boundary comparison it
+ * rests on) is exercised against Postgres in `ocr-derivative-pages.db.test.ts`;
+ * this file covers the walk's exactly-once and bounded-page behaviour.
  */
-const createPageReader = (runs: OcrDerivativeRun[]) => {
-  // Ordinal id comparison, matching both Postgres's ordering and the
-  // `isAfterOcrDerivativeCursor` tiebreaker. Locale collation would order
-  // these opaque keys differently from the database.
-  const byId = (left: string, right: string) => {
-    if (left === right) {
-      return 0;
-    }
-    return left < right ? -1 : 1;
+const createPageReader =
+  (orderedIds: readonly SafeId<"documentProcessingRun">[]) =>
+  async (cursor: OcrDerivativeCursor | null, limit: number) => {
+    const start = cursor === null ? 0 : orderedIds.indexOf(cursor) + 1;
+    return await Promise.resolve(
+      orderedIds.slice(start, start + limit).map((id) => ({ id })),
+    );
   };
-  const ordered = [...runs].sort(
-    (left, right) =>
-      right.createdAt.getTime() - left.createdAt.getTime() ||
-      byId(left.id, right.id),
-  );
-  return async (cursor: OcrDerivativeCursor | null, limit: number) =>
-    ordered
-      .filter((run) => isAfterOcrDerivativeCursor(run, cursor))
-      .slice(0, limit);
-};
 
-// Runs created in one transaction share a createdAt, so a page boundary can
-// land inside a tied group. Without the id tiebreaker the walk would skip or
-// repeat those members, silently orphaning or double-deleting derivatives.
-test("visits every run exactly once across page boundaries, including createdAt ties", async () => {
-  const runs = Array.from({ length: 2500 }, (_, index) => ({
-    // Groups of 7 tied runs. 7 does not divide the 1000-run page size, so
-    // both page boundaries land inside a tied group rather than between two.
-    createdAt: new Date(Date.UTC(2026, 0, 1, 0, 0, 0, Math.floor(index / 7))),
-    id: toSafeId<"documentProcessingRun">(
-      `run-${String(index).padStart(4, "0")}`,
-    ),
-  }));
+const runIds = (count: number): SafeId<"documentProcessingRun">[] =>
+  Array.from({ length: count }, (_, index) =>
+    toSafeId<"documentProcessingRun">(`run-${String(index).padStart(4, "0")}`),
+  );
+
+test("visits every run exactly once across page boundaries", async () => {
+  const orderedIds = runIds(2500);
   const visited: string[] = [];
 
   await forEachOcrDerivativePage({
-    readPage: createPageReader(runs),
+    readPage: createPageReader(orderedIds),
     onPage: async (page) => {
       for (const run of page) {
         visited.push(run.id);
@@ -62,22 +43,16 @@ test("visits every run exactly once across page boundaries, including createdAt 
     },
   });
 
-  expect(visited).toHaveLength(runs.length);
-  expect(new Set(visited).size).toBe(runs.length);
-  expect(new Set(visited)).toEqual(new Set(runs.map(({ id }) => id)));
+  expect(visited).toEqual(orderedIds);
+  expect(new Set(visited).size).toBe(orderedIds.length);
 });
 
 test("visits every run exactly once when the total is an exact page multiple", async () => {
-  const runs = Array.from({ length: CLEANUP_BATCH_SIZE * 2 }, (_, index) => ({
-    createdAt: new Date(Date.UTC(2026, 0, 1, 0, 0, 0, index % 7)),
-    id: toSafeId<"documentProcessingRun">(
-      `run-${String(index).padStart(4, "0")}`,
-    ),
-  }));
+  const orderedIds = runIds(CLEANUP_BATCH_SIZE * 2);
   const visited: string[] = [];
 
   await forEachOcrDerivativePage({
-    readPage: createPageReader(runs),
+    readPage: createPageReader(orderedIds),
     onPage: async (page) => {
       for (const run of page) {
         visited.push(run.id);
@@ -85,34 +60,34 @@ test("visits every run exactly once when the total is an exact page multiple", a
     },
   });
 
-  expect(new Set(visited).size).toBe(runs.length);
+  expect(new Set(visited).size).toBe(orderedIds.length);
 });
 
 test("walks every OCR derivative through bounded cursor pages", async () => {
-  const runs = Array.from({ length: 1001 }, (_, index) => ({
-    createdAt: new Date(Date.UTC(2026, 0, 1, 0, 0, 0, 1001 - index)),
+  const runs = Array.from({ length: 1001 }, () => ({
     id: toSafeId<"documentProcessingRun">(Bun.randomUUIDv7()),
   }));
-  const cursors: ({ createdAt: Date; id: string } | null)[] = [];
+  const cursors: (OcrDerivativeCursor | null)[] = [];
   const handledPageSizes: number[] = [];
 
   await forEachOcrDerivativePage({
     readPage: async (cursor, limit) => {
       cursors.push(cursor);
-      return cursor === null ? runs.slice(0, limit) : runs.slice(limit);
+      return await Promise.resolve(
+        cursor === null ? runs.slice(0, limit) : runs.slice(limit),
+      );
     },
     onPage: async (page) => {
       handledPageSizes.push(page.length);
     },
   });
 
-  expect(cursors).toEqual([null, runs.at(999) ?? null]);
+  expect(cursors).toEqual([null, runs.at(999)?.id ?? null]);
   expect(handledPageSizes).toEqual([1000, 1]);
 });
 
 test("handles a full page before reading past it", async () => {
-  const runs = Array.from({ length: 2000 }, (_, index) => ({
-    createdAt: new Date(Date.UTC(2026, 0, 1, 0, 0, 0, 2000 - index)),
+  const runs = Array.from({ length: 2000 }, () => ({
     id: toSafeId<"documentProcessingRun">(Bun.randomUUIDv7()),
   }));
   const events: string[] = [];
@@ -120,7 +95,7 @@ test("handles a full page before reading past it", async () => {
   await forEachOcrDerivativePage({
     readPage: async (cursor, limit) => {
       events.push(cursor === null ? "read:first" : "read:next");
-      return cursor === null ? runs.slice(0, limit) : [];
+      return await Promise.resolve(cursor === null ? runs.slice(0, limit) : []);
     },
     onPage: async () => {
       events.push("handle");

--- a/apps/api/src/lib/ocr-derivative-pages.ts
+++ b/apps/api/src/lib/ocr-derivative-pages.ts
@@ -1,22 +1,30 @@
 import type { SQL } from "drizzle-orm";
-import { and, asc, desc, eq, gt, lt, or } from "drizzle-orm";
+import { and, asc, desc, eq, gt, lt, or, sql } from "drizzle-orm";
 
 import { documentProcessingRuns } from "@/api/db/schema";
 import type { SafeId } from "@/api/lib/branded-types";
 import { LIMITS } from "@/api/lib/limits";
 
 export type OcrDerivativeRun = {
-  createdAt: Date;
   id: SafeId<"documentProcessingRun">;
 };
 
-export type OcrDerivativeCursor = OcrDerivativeRun;
+/**
+ * The previous page's last run. Only its id travels: the boundary's
+ * `created_at` is read back in the database, so the comparison stays at the
+ * column's microsecond precision. Carrying a JS `Date` instead truncates it
+ * to the millisecond, and the descending `<` boundary then skips every run
+ * inside the truncated sliver — whose searchable-PDF objects would be left
+ * in the bucket after the matter or entity that owned them is deleted.
+ */
+export type OcrDerivativeCursor = SafeId<"documentProcessingRun">;
 
 /**
  * Total order every derivative page walk reads in: newest first, ties broken by
- * ascending id. Runs created in the same transaction share a `createdAt`, so
- * without the id tiebreaker a page boundary landing inside such a group would
- * skip or repeat its members.
+ * ascending id, matching `document_processing_runs_workspace_created_idx`.
+ * Runs created in the same transaction share a `createdAt`, so without the id
+ * tiebreaker a page boundary landing inside such a group would skip or repeat
+ * its members.
  */
 export const ocrDerivativePageOrder = () =>
   [
@@ -24,35 +32,26 @@ export const ocrDerivativePageOrder = () =>
     asc(documentProcessingRuns.id),
   ] as const;
 
-/** Keyset predicate for the rows strictly after `cursor` in that order. */
+/**
+ * Keyset predicate for the rows strictly after `cursor` in that order. The
+ * two key parts run in opposite directions, so this cannot be a row-tuple
+ * comparison; the boundary's `created_at` is an uncorrelated scalar subquery
+ * the planner evaluates once.
+ */
 export const ocrDerivativeCursorFilter = (
   cursor: OcrDerivativeCursor | null,
-): SQL | undefined =>
-  cursor === null
-    ? undefined
-    : or(
-        lt(documentProcessingRuns.createdAt, cursor.createdAt),
-        and(
-          eq(documentProcessingRuns.createdAt, cursor.createdAt),
-          gt(documentProcessingRuns.id, cursor.id),
-        ),
-      );
-
-/**
- * In-memory twin of `ocrDerivativeCursorFilter`, kept beside it so the walk's
- * exactly-once invariant is testable without a database. Change both together.
- */
-export const isAfterOcrDerivativeCursor = (
-  run: OcrDerivativeRun,
-  cursor: OcrDerivativeCursor | null,
-): boolean => {
+): SQL | undefined => {
   if (cursor === null) {
-    return true;
+    return undefined;
   }
-  if (run.createdAt.getTime() !== cursor.createdAt.getTime()) {
-    return run.createdAt.getTime() < cursor.createdAt.getTime();
-  }
-  return run.id > cursor.id;
+  const boundaryCreatedAt = sql`(select b.created_at from document_processing_runs b where b.id = ${cursor})`;
+  return or(
+    lt(documentProcessingRuns.createdAt, boundaryCreatedAt),
+    and(
+      eq(documentProcessingRuns.createdAt, boundaryCreatedAt),
+      gt(documentProcessingRuns.id, cursor),
+    ),
+  );
 };
 
 type ForEachOcrDerivativePageOptions = {
@@ -91,5 +90,5 @@ export const forEachOcrDerivativePage = async ({
     return;
   }
 
-  await forEachOcrDerivativePage({ cursor: lastRun, onPage, readPage });
+  await forEachOcrDerivativePage({ cursor: lastRun.id, onPage, readPage });
 };

--- a/apps/api/src/lib/search/index-entity.test.ts
+++ b/apps/api/src/lib/search/index-entity.test.ts
@@ -17,9 +17,16 @@ const semanticUpdatedAtToken =
   // renders as `COALESCE(updated_at, created_at)::text`.
   // eslint-disable-next-line typescript/no-unsafe-type-assertion
   "2026-04-30 08:00:00.000123" as TimestampCasToken;
+const extractedAt = new Date("2026-04-30T08:01:00.000Z");
+const extractedAtToken =
+  // SAFETY: tests fabricate the branded token the token select normally
+  // renders as `extracted_content.extracted_at::text`. The microsecond tail
+  // is the point: a JS Date carrying the same instant loses it.
+  // eslint-disable-next-line typescript/no-unsafe-type-assertion
+  "2026-04-30 08:01:00.000982" as TimestampCasToken;
 // The token select chain: rootDb.select({...}).from(...).where(...).limit(1)
 const selectLimitMock = mock(async (_limit: number) => [
-  { semanticUpdatedAtToken },
+  { semanticUpdatedAtToken, extractedAtToken },
 ]);
 const selectMock = mock((_fields: unknown) => ({
   from: (_table: unknown) => ({
@@ -58,7 +65,6 @@ const entityRow = {
   createdAt: new Date("2026-04-01T08:00:00.000Z"),
   extractedContent: null as {
     ciphertext: Buffer;
-    extractedAt: Date;
     iv: Buffer;
     language: string | null;
     sourceEntityVersionId: SafeId<"entityVersion"> | null;
@@ -110,7 +116,9 @@ beforeEach(() => {
   executeMock.mockClear();
   selectMock.mockClear();
   selectLimitMock.mockClear();
-  selectLimitMock.mockResolvedValue([{ semanticUpdatedAtToken }]);
+  selectLimitMock.mockResolvedValue([
+    { semanticUpdatedAtToken, extractedAtToken },
+  ]);
   findFirstMock.mockClear();
   findFirstMock.mockResolvedValue(entityRow);
   decryptContentMock.mockClear();
@@ -222,7 +230,6 @@ test("keeps the last complete projection when extracted content cannot decrypt",
     },
     extractedContent: {
       ciphertext: Buffer.from("ciphertext"),
-      extractedAt: new Date("2026-04-30T08:01:00.000Z"),
       iv: Buffer.from("iv"),
       language: "en",
       sourceEntityVersionId: entityRow.currentVersion.id,
@@ -254,7 +261,6 @@ test("excludes stale extracted text and fences its observed provenance", async (
   const staleVersionId = toSafeId<"entityVersion">(
     "019864b8-48d0-7f37-94d5-948e3bcf3f48",
   );
-  const extractedAt = new Date("2026-04-30T08:01:00.000Z");
   findFirstMock.mockResolvedValueOnce({
     ...entityRow,
     currentVersion: {
@@ -263,7 +269,6 @@ test("excludes stale extracted text and fences its observed provenance", async (
     },
     extractedContent: {
       ciphertext: Buffer.from("stale ciphertext"),
-      extractedAt,
       iv: Buffer.from("stale iv"),
       language: "en",
       sourceEntityVersionId: staleVersionId,
@@ -288,11 +293,17 @@ test("excludes stale extracted text and fences its observed provenance", async (
   expect(compiled.sql).toContain("ec.source_entity_version_id");
   expect(compiled.sql).toContain("ec.extracted_at");
   expect(compiled.params).toContain(staleVersionId);
-  expect(compiled.params).toContain(extractedAt);
+  // `extracted_at` defaults to now(), so the provenance fence must compare
+  // the database's own text rendering. Binding the JS `Date` instead drops
+  // the microseconds and makes every re-index of this entity a silent no-op.
+  expect(compiled.params).toContain(extractedAtToken);
+  expect(compiled.params).not.toContain(extractedAt);
+  expect(compiled.sql).toMatch(
+    /ec\.extracted_at\s+IS NOT DISTINCT FROM \$\d+::timestamptz/u,
+  );
 });
 
 test("preserves pre-provenance extracted text until a fenced writer replaces it", async () => {
-  const extractedAt = new Date("2026-04-30T08:01:00.000Z");
   findFirstMock.mockResolvedValueOnce({
     ...entityRow,
     currentVersion: {
@@ -301,7 +312,6 @@ test("preserves pre-provenance extracted text until a fenced writer replaces it"
     },
     extractedContent: {
       ciphertext: Buffer.from("legacy ciphertext"),
-      extractedAt,
       iv: Buffer.from("legacy iv"),
       language: "cs",
       sourceEntityVersionId: null,
@@ -326,7 +336,8 @@ test("preserves pre-provenance extracted text until a fenced writer replaces it"
     return;
   }
   const compiled = new PgDialect().sqlToQuery(query);
-  expect(compiled.params).toContain(extractedAt);
+  expect(compiled.params).toContain(extractedAtToken);
+  expect(compiled.params).not.toContain(extractedAt);
   expect(
     compiled.params.filter((parameter) => parameter === null),
   ).not.toHaveLength(0);

--- a/apps/api/src/lib/search/index-entity.ts
+++ b/apps/api/src/lib/search/index-entity.ts
@@ -2,17 +2,14 @@ import { panic } from "better-result";
 import { eq, sql } from "drizzle-orm";
 
 import { rootDb } from "@/api/db/root";
-import { entities } from "@/api/db/schema";
-import type {
-  extractedContent,
-  LinkMetadata,
-  searchDocuments,
-} from "@/api/db/schema";
+import { entities, extractedContent } from "@/api/db/schema";
+import type { LinkMetadata, searchDocuments } from "@/api/db/schema";
 import type { FieldContent } from "@/api/db/schema-validators";
 import { captureError } from "@/api/lib/analytics/capture";
 import type { SafeId } from "@/api/lib/branded-types";
 import { compareCodepoint } from "@/api/lib/collation";
 import { decryptContent } from "@/api/lib/content-encryption";
+import { timestampCasToken } from "@/api/lib/db/timestamp-cas";
 import type { TimestampCasToken } from "@/api/lib/db/timestamp-cas";
 import { docxReviewMarkupToSearchText } from "@/api/lib/docx-review-markup";
 import { isoToRegconfig } from "@/api/lib/search/detect-language";
@@ -26,12 +23,17 @@ import { fileNameSearchText } from "@/api/lib/search/query";
 type SearchDocumentRow = typeof searchDocuments.$inferInsert;
 type ExtractedContentSource = Pick<
   typeof extractedContent.$inferSelect,
-  | "extractedAt"
-  | "sourceEntityVersionId"
-  | "sourceFieldId"
-  | "sourceFileId"
-  | "sourceSha256Hex"
->;
+  "sourceEntityVersionId" | "sourceFieldId" | "sourceFileId" | "sourceSha256Hex"
+> & {
+  /**
+   * `extracted_at` rendered by Postgres, never a JS `Date`. The column
+   * defaults to `now()`, so a `Date` round-trip drops its microseconds and
+   * the upsert's provenance fence would then never match — making every
+   * re-index of the entity a silent no-op. `null` when the row was created
+   * after the token was read, which fails the fence closed.
+   */
+  extractedAtToken: TimestampCasToken | null;
+};
 
 type BuiltSearchDocument = Omit<
   SearchDocumentRow,
@@ -92,19 +94,28 @@ const extractFieldText = (content: FieldContent): string => {
 const buildSearchDocument = async (
   entityId: SafeId<"entity">,
 ): Promise<BuiltSearchDocument | null> => {
-  // The CAS token must be rendered to text by Postgres: a JS Date round-trip
+  // The CAS tokens must be rendered to text by Postgres: a JS Date round-trip
   // truncates microseconds and the upsert's compare-at-full-precision guard
   // would then never match. A core select is used because the relational
   // builder's `extras` emits the column into SQL but drops it from the mapped
   // row (and its object form emits an unaliased reference the database
-  // rejects). Reading the token in a separate query is safe: the upsert
-  // re-checks version and token under FOR UPDATE, so a concurrent update
+  // rejects). Reading the tokens in a separate query is safe: the upsert
+  // re-checks version and tokens under FOR UPDATE, so a concurrent update
   // makes the CAS miss and the follow-up index event re-runs the build.
+  // Both tokens are read BEFORE the projection they fence, so extraction
+  // landing in between can only make the fence miss, never let stale text
+  // through. `extracted_content.entity_id` is the primary key, so the
+  // correlated read is scalar by construction.
   const [tokenRow] = await rootDb
     .select({
       semanticUpdatedAtToken: sql<TimestampCasToken>`
         COALESCE(${entities.updatedAt}, ${entities.createdAt})::text
       `,
+      extractedAtToken: sql<TimestampCasToken | null>`(
+        SELECT ${timestampCasToken(extractedContent.extractedAt)}
+        FROM extracted_content
+        WHERE ${extractedContent.entityId} = ${entities.id}
+      )`,
     })
     .from(entities)
     .where(eq(entities.id, entityId))
@@ -139,7 +150,6 @@ const buildSearchDocument = async (
       extractedContent: {
         columns: {
           ciphertext: true,
-          extractedAt: true,
           iv: true,
           language: true,
           sourceEntityVersionId: true,
@@ -235,7 +245,7 @@ const buildSearchDocument = async (
     entityId: entity.id,
     extractedContentSource: extractedContentRow
       ? {
-          extractedAt: extractedContentRow.extractedAt,
+          extractedAtToken: tokenRow.extractedAtToken,
           sourceEntityVersionId: extractedContentRow.sourceEntityVersionId,
           sourceFieldId: extractedContentRow.sourceFieldId,
           sourceFileId: extractedContentRow.sourceFileId,
@@ -336,7 +346,7 @@ export const upsertSearchDocument = async (
                 AND ec.source_sha256_hex
                   IS NOT DISTINCT FROM ${observedSource?.sourceSha256Hex ?? null}
                 AND ec.extracted_at
-                  IS NOT DISTINCT FROM ${observedSource?.extractedAt ?? null}
+                  IS NOT DISTINCT FROM ${observedSource?.extractedAtToken ?? null}::timestamptz
             )
           )
         )


### PR DESCRIPTION
## Problem

Postgres timestamps carry microseconds; a JavaScript `Date` carries milliseconds. Five sites read a timestamp column into a `Date` and compared it back, narrowing the value in transit.

- **Ascending** (`>`): the boundary row's true value is still greater than the truncated cursor written from it, so the row is re-admitted on every page.
- **Descending** (`<`): every row inside the truncated interval is skipped.

The columns involved are all `defaultNow()` or written by SQL `now()`, so microsecond values are the norm rather than an edge case.

## What each site did

| Site | Direction | Consequence |
|---|---|---|
| `docx-suggestions` read + cursor | ascending | Re-served page one indefinitely. A caller looping until the cursor cleared collected duplicates and never reached page two. |
| `machine-api-key-queries` + `api-keys/list` | descending | Keys dropped from the listing. A key nobody can see is a key nobody can revoke. |
| `ocr-derivative-pages` | descending | Runs skipped during matter and entity deletion, leaving their objects behind. |
| `sk-document-backfill` requested tier | ascending | Same defect on a path no caller reaches yet. |
| `search/index-entity` extraction watermark | CAS | Silent no-op: the guarded re-index simply does not happen. |

## Change

Each site adopts whichever mechanism already exists in the repo for its shape:

- **Shared cursor codec** (`createTimestampIdCursorCodec`) for the two list endpoints — the house style, already used by ~9 handlers.
- **In-database boundary** for the internal walks.
- **Timestamp token** for the compare-and-set.

**Derivative cleanup keeps its `created_at DESC, id ASC` order** so it continues matching `document_processing_runs_workspace_created_idx`. The two key parts run in opposite directions, so neither the codec nor a row-tuple comparison applies; the boundary is resolved with an uncorrelated scalar subquery the planner evaluates once.

**The in-memory twin of that predicate is deleted rather than re-derived.** It truncated identically, and the walk test exercised the twin rather than the SQL, so the suite certified the defect it existed to catch.

**The re-index guard needed its read moved, not just its comparison changed.** The token now joins the pre-read that already fetches the semantic watermark, so both tokens precede the projection they fence. That ordering is deliberate and documented: token-before-projection fails the fence closed; the reverse would let stale text through.

## Backward compatibility

Cursors already in flight keep working. The codec recognises the legacy `[isoString, id]` form, tags it as millisecond precision, and compares `date_trunc('milliseconds', …)` on both sides.

One honest limit, tested rather than assumed: these two handlers ordered on the raw column, so for rows sharing a truncated millisecond a legacy cursor falls back to its id tiebreak, which is not the true page order. The guarantee is that it decodes, does not error, terminates, and yields no duplicates — not that it resumes at the exact same row. Exact resumption is asserted only where milliseconds are distinct. A malformed cursor is still rejected rather than silently restarting from page one.

## Tests

Four new database tests, each seeding `created_at` through raw SQL with non-zero microsecond digits, asserting exactly-once over a bounded walk that throws rather than looping. Fixtures deliberately include microsecond twins that collapse onto one `Date`, plus exact ties to exercise the id tiebreak.

Every file carries a **non-vacuity assertion**: the stored rows must differ from their own `date_trunc('milliseconds', …)`. A fixture that stopped reproducing the hazard fails loudly instead of passing quietly.

Confirmed the tests catch the defect by stashing the production files and re-running: suggestions 4 of 5 fail (`pagination did not terminate within 40 pages`), API keys 3 of 5 fail. The two sites whose cursor *type* changed fail at compile time under that experiment, so those files carry explicit counterfactual assertions instead — proving a truncated boundary would skip rows descending and re-admit the boundary row ascending.

Typecheck clean, oxlint `--type-aware --deny-warnings` clean on all 16 files, ratchet at baseline with zero delta, knip reports no new unused exports.

## Unrelated observation

A clean stash of this branch still fails the full test run's second logic batch on its peak-RSS budget (2363 MB against 2048 MB). It is pre-existing and independent of these files, which land in the database and module-mock batches. Flagging rather than touching the budget.