### PR TITLE
fix(mcp): support CLI 0.4.2

### DIFF
--- a/apps/api/src/mcp/constants.ts
+++ b/apps/api/src/mcp/constants.ts
@@ -107,7 +107,7 @@ export const STELLA_MCP_API_CONTRACT_VERSION = 1;
 const CLI_SUPPORT_BAND = declareCliSupportBand({
   minimum: "0.3.0",
   latest: "0.3.0",
-  maximum: "0.4.1",
+  maximum: "0.4.2",
 });
 
 export const STELLA_CLI_MINIMUM_VERSION = CLI_SUPPORT_BAND.minimum;


### PR DESCRIPTION
## Summary

- extend the API's advertised CLI compatibility ceiling to 0.4.2
- keep the published-version marker unchanged until the CLI is published

## Test plan

- `bun test --preload ./apps/api/src/tests/setup-env.ts scripts/check-api-cli-contract.test.ts`
- `bun --smol test --preload ./src/tests/setup-env.ts ./src/mcp/metadata.test.ts ./src/mcp/cli-mirror-drift.test.ts ./src/handlers/mcp/routes.test.ts`
- `bun run code-check`