### PR TITLE
fix(sidebar): normalize matter activity row sizing

### DIFF
--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -60,6 +60,7 @@ import { openEntityInInspector } from "@/components/chat/entity-open";
 import { navigateToWorkspaceFolder } from "@/components/chat/folder-navigation";
 import { FeedbackDialog } from "@/components/feedback-dialog";
 import { useInspectorTabsStore } from "@/components/inspector/inspector-tabs-store";
+import { MatterActivityRow } from "@/components/matter-activity-row";
 import { MatterIcon } from "@/components/matter-icon";
 import { SearchDialog } from "@/components/search-dialog";
 import {
@@ -1316,9 +1317,6 @@ const MatterItem = ({
   );
 };
 
-const ACTIVITY_ROW_CLASS =
-  "text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground flex h-7 w-full min-w-0 items-center gap-2 rounded-md px-2 text-xs outline-hidden focus-visible:ring-2";
-
 type MatterActivityListProps = {
   activeOrganizationId: string;
   id: string;
@@ -1406,16 +1404,16 @@ const MatterActivityList = ({
     return (
       <SidebarMenuSub className="border-0" id={id}>
         <SidebarMenuSubItem>
-          <Button
-            className={ACTIVITY_ROW_CLASS}
-            onClick={() => {
-              detached(refetch(), "MatterActivityList");
-            }}
-            size="sm"
-            variant="ghost"
-          >
-            {t("common.tryAgain")}
-          </Button>
+          <MatterActivityRow>
+            <button
+              onClick={() => {
+                detached(refetch(), "MatterActivityList");
+              }}
+              type="button"
+            >
+              {t("common.tryAgain")}
+            </button>
+          </MatterActivityRow>
         </SidebarMenuSubItem>
       </SidebarMenuSub>
     );
@@ -1470,45 +1468,43 @@ const MatterActivityList = ({
         return (
           <SidebarMenuSubItem key={`${item.type}-${item.id}`}>
             {item.type === "thread" ? (
-              <Link
-                activeProps={{ "data-active": true }}
-                className={ACTIVITY_ROW_CLASS}
-                params={{ threadId: item.id, workspaceId }}
-                to="/chat/workspaces/$workspaceId/$threadId"
-              >
-                {content}
-              </Link>
+              <MatterActivityRow>
+                <Link
+                  activeProps={{ "data-active": true }}
+                  params={{ threadId: item.id, workspaceId }}
+                  to="/chat/workspaces/$workspaceId/$threadId"
+                >
+                  {content}
+                </Link>
+              </MatterActivityRow>
             ) : (
-              <Button
-                className={ACTIVITY_ROW_CLASS}
-                onClick={() => {
-                  detached(openEntity(item), "MatterActivityList");
-                }}
-                size="sm"
-                variant="ghost"
-              >
-                {content}
-              </Button>
+              <MatterActivityRow>
+                <button
+                  onClick={() => {
+                    detached(openEntity(item), "MatterActivityList");
+                  }}
+                  type="button"
+                >
+                  {content}
+                </button>
+              </MatterActivityRow>
             )}
           </SidebarMenuSubItem>
         );
       })}
       {hasNextPage ? (
         <SidebarMenuSubItem>
-          <Button
-            className={cn(
-              ACTIVITY_ROW_CLASS,
-              "text-muted-foreground justify-start",
-            )}
-            disabled={isFetchingNextPage}
-            onClick={() => {
-              detached(fetchNextPage(), "MatterActivityList");
-            }}
-            size="sm"
-            variant="ghost"
-          >
-            {isFetchingNextPage ? t("common.loading") : t("common.showMore")}
-          </Button>
+          <MatterActivityRow className="text-muted-foreground justify-start">
+            <button
+              disabled={isFetchingNextPage}
+              onClick={() => {
+                detached(fetchNextPage(), "MatterActivityList");
+              }}
+              type="button"
+            >
+              {isFetchingNextPage ? t("common.loading") : t("common.showMore")}
+            </button>
+          </MatterActivityRow>
         </SidebarMenuSubItem>
       ) : null}
     </SidebarMenuSub>

--- a/apps/web/src/components/matter-activity-row.test.tsx
+++ b/apps/web/src/components/matter-activity-row.test.tsx
@@ -1,0 +1,32 @@
+import type * as React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { describe, expect, test } from "bun:test";
+
+import { MatterActivityRow } from "@/components/matter-activity-row";
+
+const CLASS_NAME_PATTERN = /class="([^"]+)"/u;
+
+const renderClassName = (element: React.ReactElement) => {
+  const markup = renderToStaticMarkup(
+    <MatterActivityRow>{element}</MatterActivityRow>,
+  );
+  return CLASS_NAME_PATTERN.exec(markup)?.at(1) ?? "";
+};
+
+describe("MatterActivityRow", () => {
+  test("keeps links and buttons on the same visual row contract", () => {
+    const linkClassName = renderClassName(
+      <a href="/matter">
+        <span aria-hidden />
+      </a>,
+    );
+    const buttonClassName = renderClassName(<button type="button" />);
+
+    expect(linkClassName).not.toBe("");
+    expect(buttonClassName).toBe(linkClassName);
+    expect(buttonClassName).toContain("text-xs");
+    expect(buttonClassName).not.toContain("sm:text-sm");
+    expect(buttonClassName).not.toContain("font-medium");
+  });
+});

--- a/apps/web/src/components/matter-activity-row.tsx
+++ b/apps/web/src/components/matter-activity-row.tsx
@@ -1,0 +1,19 @@
+import type * as React from "react";
+
+import { cn } from "@stll/ui/lib/utils";
+
+import { SidebarMenuSubButton } from "@/components/sidebar";
+
+type MatterActivityRowProps = {
+  children: React.ReactElement;
+  className?: string;
+};
+
+export const MatterActivityRow = ({
+  children,
+  className,
+}: MatterActivityRowProps) => (
+  <SidebarMenuSubButton asChild className={cn("w-full", className)} size="sm">
+    {children}
+  </SidebarMenuSubButton>
+);


### PR DESCRIPTION
## Summary

- render chat and entity activity entries through the same sidebar sub-row primitive
- remove general button typography and icon styling from entity rows
- keep retry and pagination controls on the same row contract
- add a regression test proving link and button rows resolve to identical classes

Fixes #1665

## Verification

- `bun run verify`
- `bun --filter @stll/web lint`
- `bun --filter @stll/web typecheck`
- `bun test src/components/matter-activity-row.test.tsx src/components/app-sidebar.logic.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a consistent row layout for matter activity items, including activity entries, errors, navigation links and pagination controls.
  * Added support for applying custom styling to activity rows while preserving existing actions and loading behaviour.

* **Bug Fixes**
  * Standardised the appearance and sizing of activity links and buttons for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->