### PR TITLE
fix(corpus-index): batch replay deletes into one task per index

### DIFF
--- a/apps/api/src/lib/corpus-index/core.test.ts
+++ b/apps/api/src/lib/corpus-index/core.test.ts
@@ -6,6 +6,7 @@ import { toSafeId } from "@/api/lib/branded-types";
 import type { CorpusJobInput } from "@/api/lib/corpus-index/core";
 import {
   createCorpusIndexer,
+  deleteQueryChunks,
   settleAll,
   settleAllCleanup,
   settleBoth,
@@ -13,6 +14,7 @@ import {
 } from "@/api/lib/corpus-index/core";
 import type { TimestampCasToken } from "@/api/lib/db/timestamp-cas";
 import { corpusIndexId } from "@/api/lib/legal-search/index-naming";
+import { isRecord } from "@/api/lib/type-guards";
 
 /**
  * A batch is sized in rows, but a passage family turns one row into as many
@@ -947,5 +949,155 @@ describe("first-ever fenced appends", () => {
       [],
     );
     expect(calls.some(({ url }) => url.includes("/ingest"))).toBe(true);
+  });
+});
+
+/**
+ * The engine plans every delete task against every split whose delete opstamp
+ * is behind it, so the cost of N tasks is O(N x splits) and it is charged to
+ * the janitor asynchronously, long after the calls that created them returned.
+ * A per-row delete therefore looks free at the call site and is not: it is the
+ * shape that stops the planner converging at all.
+ *
+ * The invariant is not "a converged batch does nothing" — a re-projection
+ * legitimately re-deletes. It is that the number of remote delete tasks scales
+ * with the indexes a batch touches, never with the rows it carries. Measuring
+ * two batch sizes is what makes that a property rather than an example: the
+ * per-row shape fails it for any pair of sizes.
+ */
+describe("delete-task amplification", () => {
+  const GENERATION = "case_law_v2";
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  type DeleteCall = { url: string; query: string };
+
+  const runBatch = async (
+    rowCount: number,
+  ): Promise<{ deletes: DeleteCall[]; indexed: number }> => {
+    const deletes: DeleteCall[] = [];
+    const stub = async (
+      input: Parameters<typeof fetch>[0],
+      init?: Parameters<typeof fetch>[1],
+    ) => {
+      let url: string;
+      if (typeof input === "string") {
+        url = input;
+      } else if (input instanceof URL) {
+        url = input.href;
+      } else {
+        url = input.url;
+      }
+      // The client always sends a serialized string body; anything else is a
+      // test-harness mistake, not a case to coerce.
+      const body = typeof init?.body === "string" ? init.body : "";
+      if (url.includes("/delete-tasks")) {
+        const parsed: unknown = JSON.parse(body.length > 0 ? body : "{}");
+        const query =
+          isRecord(parsed) && typeof parsed["query"] === "string"
+            ? parsed["query"]
+            : "";
+        deletes.push({ url, query });
+      }
+      if (url.includes("/ingest")) {
+        const sent = body.split("\n").filter((line) => line.length > 0).length;
+        return new Response(JSON.stringify({ num_docs_for_processing: sent }), {
+          status: 200,
+        });
+      }
+      return new Response(JSON.stringify({}), { status: 200 });
+    };
+    globalThis.fetch = Object.assign(stub, {
+      preconnect: originalFetch.preconnect,
+    });
+
+    // One jurisdiction, so every row's previous copy lives in the same index:
+    // the batch touches exactly one index however many rows it carries.
+    const indexId = corpusIndexId(GENERATION, "CZ");
+    const rows = Array.from({ length: rowCount }, (_, seq) => ({
+      id: toSafeId<"caseLawDecision">(`dec-${seq}`),
+      country: "CZ",
+      textS3Key: null,
+      astS3Key: null,
+      contentHash: `hash-${seq}`,
+      indexedHash: `stale-${seq}`,
+      indexedGeneration: indexId,
+      // SAFETY: tests fabricate the branded token the adapters normally
+      // select as `updated_at::text`.
+      // eslint-disable-next-line typescript/no-unsafe-type-assertion
+      updatedAtToken: "2026-01-01 00:00:00" as TimestampCasToken,
+      projectionIndexId: indexId,
+    }));
+    const scopedDb: ScopedDb = async (callback) =>
+      // SAFETY: this test's adapter ignores the transaction; the callback
+      // boundary itself is what the indexer must cross before reporting success.
+      // oxlint-disable-next-line node/callback-return, typescript/no-unsafe-type-assertion -- the fake transaction is deliberately inert
+      await callback({} as Transaction);
+    const indexer = createCorpusIndexer<"caseLawDecision", (typeof rows)[0]>({
+      family: "case_law",
+      captureStep: "test",
+      granularity: "document",
+      generationProjectionIndexIds: (selected) => [selected.projectionIndexId],
+      buildDocs: (selected) => [{ document_id: selected.id, text: "body" }],
+      readCorpusText: async () => "body",
+      selectMissing: async () => rows,
+      selectStale: async () => [],
+      fetchFulltext: async () => "body",
+      markIndexedBatch: async (_tx, { rows: markedRows }) =>
+        new Set(markedRows.map((selected) => selected.id)),
+      insertSucceededJobs: async () => undefined,
+      recordJobs: async () => undefined,
+    });
+
+    const indexed = await indexer.backfillRows(scopedDb, rows, GENERATION, {
+      beforeDatabaseMark: async () => undefined,
+      beforeRemoteEffect: async ({ effect }) => await effect(),
+      recoverRemoteEffectLeaseLoss: async () => await Promise.resolve(),
+      // A committed copy exists, so the replay delete genuinely has to run.
+      reserveExternalAppend: async (_tx, { rows: reservedRows }) =>
+        new Map(
+          reservedRows.map((selected) => [
+            selected.id,
+            { indexIds: [indexId], revision: 2, mayHaveCopy: true },
+          ]),
+        ),
+    });
+    return { deletes, indexed };
+  };
+
+  test("delete-task count does not grow with batch size", async () => {
+    const small = await runBatch(4);
+    const large = await runBatch(40);
+
+    expect(small.indexed).toBe(4);
+    expect(large.indexed).toBe(40);
+    // The load-bearing assertion. Restore a per-row delete and this reads
+    // 4 vs 40.
+    expect(large.deletes).toHaveLength(small.deletes.length);
+    expect(small.deletes).toHaveLength(1);
+  });
+
+  test("every row still reaches a delete query", async () => {
+    const { deletes } = await runBatch(40);
+    const queried = deletes.map(({ query }) => query).join(" ");
+
+    for (let seq = 0; seq < 40; seq += 1) {
+      expect(queried).toContain(`document_id:"dec-${seq}"`);
+    }
+  });
+
+  test("chunking bounds one task's query without dropping ids", () => {
+    const ids = Array.from({ length: 300 }, (_, seq) => `id-${seq}`);
+
+    const chunks = deleteQueryChunks(ids);
+
+    // Every id lands in exactly one chunk, and no chunk outgrows the bound.
+    expect(chunks.flat()).toEqual(ids);
+    for (const chunk of chunks) {
+      expect(chunk.length).toBeLessThanOrEqual(128);
+    }
   });
 });

--- a/apps/api/src/lib/corpus-index/core.test.ts
+++ b/apps/api/src/lib/corpus-index/core.test.ts
@@ -5,6 +5,7 @@ import type { ScopedDb } from "@/api/db/safe-db";
 import { toSafeId } from "@/api/lib/branded-types";
 import type { CorpusJobInput } from "@/api/lib/corpus-index/core";
 import {
+  corpusDocumentsDeleteQuery,
   createCorpusIndexer,
   deleteQueryChunks,
   settleAll,
@@ -1087,6 +1088,18 @@ describe("delete-task amplification", () => {
     for (let seq = 0; seq < 40; seq += 1) {
       expect(queried).toContain(`document_id:"dec-${seq}"`);
     }
+  });
+
+  test("an id that could alter the query is rejected, not escaped", () => {
+    // The terms are OR-joined, so one id that breaks out of its quotes
+    // changes what the whole task deletes. Ids come from `uuid` columns; one
+    // that reaches here in another shape is a defect upstream.
+    expect(() =>
+      corpusDocumentsDeleteQuery(['a" OR document_id:"b']),
+    ).toThrow();
+    expect(corpusDocumentsDeleteQuery(["a1b2-c3", "d4e5_f6"])).toBe(
+      'document_id:"a1b2-c3" OR document_id:"d4e5_f6"',
+    );
   });
 
   test("chunking bounds one task's query without dropping ids", () => {

--- a/apps/api/src/lib/corpus-index/core.ts
+++ b/apps/api/src/lib/corpus-index/core.ts
@@ -64,13 +64,42 @@ const corpusIndexErrorFromThrown = (error: unknown): CorpusIndexError =>
       });
 
 /**
- * Delete-task query selecting every search document a row projects to. Keyed
- * on the stable Postgres id, which every one of the row's documents carries,
- * so it is exactly as correct for a passage-split row as for a whole one — and
- * it needs no record of how many documents the previous version emitted.
+ * Delete-task query selecting every search document a batch of rows projects
+ * to. Keyed on the stable Postgres id, which every one of a row's documents
+ * carries, so it is exactly as correct for a passage-split row as for a whole
+ * one, and it needs no record of how many documents the previous version
+ * emitted.
+ *
+ * Terms are OR-joined rather than written as an engine set query: the joined
+ * form parses identically across query-language versions, and a delete query
+ * that silently changes meaning removes the wrong documents.
  */
+export const corpusDocumentsDeleteQuery = (
+  entityIds: readonly string[],
+): string => entityIds.map((id) => `document_id:"${id}"`).join(" OR ");
+
+/** Single-row delete query; the batch of one. */
 export const corpusDocumentDeleteQuery = (entityId: string): string =>
-  `document_id:"${entityId}"`;
+  corpusDocumentsDeleteQuery([entityId]);
+
+/**
+ * Ids per delete task. The engine plans every delete task against every split
+ * whose delete opstamp is behind it, so task COUNT (not task size) is what
+ * costs: one task per row makes planning O(rows x splits) and the planner
+ * stops converging once the backlog outruns it. Batching is therefore the
+ * point, and this bound only keeps the query a single task carries from
+ * growing without limit.
+ */
+const DELETE_QUERY_MAX_IDS = 128;
+
+/** Partition ids into per-task groups, each within {@link DELETE_QUERY_MAX_IDS}. */
+export const deleteQueryChunks = <T>(entityIds: readonly T[]): T[][] => {
+  const chunks: T[][] = [];
+  for (let index = 0; index < entityIds.length; index += DELETE_QUERY_MAX_IDS) {
+    chunks.push([...entityIds.slice(index, index + DELETE_QUERY_MAX_IDS)]);
+  }
+  return chunks;
+};
 
 /** One row and every search document it projects to. */
 type BuiltRow<TRow> = { row: TRow; docs: Record<string, unknown>[] };
@@ -800,12 +829,13 @@ export const createCorpusIndexer = <
    * stable Postgres id keeps erasure and re-index correct without that
    * bookkeeping.
    */
-  type RemoveWithOptionsArgs = {
-    entityId: SafeId<TBrand>;
-    indexId: string;
-    operation: "delete" | "redact";
-    scopedDb: ScopedDb;
-  } & (
+  /**
+   * Fenced callers pass both halves of the guard or neither. Kept as its own
+   * union and intersected at each use: routing it through `Omit` flattens the
+   * branches into independent optional properties, and the pair stops being
+   * correlated for narrowing.
+   */
+  type RemoteEffectGuard =
     | {
         beforeRemoteEffect: GuardRemoteEffect;
         onLeaseLost: () => Promise<void>;
@@ -813,21 +843,37 @@ export const createCorpusIndexer = <
     | {
         beforeRemoteEffect?: undefined;
         onLeaseLost?: undefined;
-      }
-  );
+      };
 
-  const removeWithOptions = async ({
+  type RemoveTargets = {
+    indexId: string;
+    operation: "delete" | "redact";
+    scopedDb: ScopedDb;
+  };
+
+  type RemoveManyWithOptionsArgs = RemoveTargets & {
+    entityIds: readonly SafeId<TBrand>[];
+  } & RemoteEffectGuard;
+
+  type RemoveWithOptionsArgs = RemoveTargets & {
+    entityId: SafeId<TBrand>;
+  } & RemoteEffectGuard;
+
+  const removeManyWithOptions = async ({
     beforeRemoteEffect,
-    entityId,
+    entityIds,
     indexId,
     onLeaseLost,
     operation,
     scopedDb,
-  }: RemoveWithOptionsArgs): Promise<Result<void, CorpusIndexError>> => {
+  }: RemoveManyWithOptionsArgs): Promise<Result<void, CorpusIndexError>> => {
+    if (entityIds.length === 0) {
+      return Result.ok(undefined);
+    }
     const deleteByQuery = async () =>
       await getCorpusIndexClient().deleteByQuery(
         indexId,
-        corpusDocumentDeleteQuery(entityId),
+        corpusDocumentsDeleteQuery(entityIds),
       );
     let deleted: Awaited<ReturnType<typeof deleteByQuery>>;
     if (beforeRemoteEffect === undefined) {
@@ -850,22 +896,43 @@ export const createCorpusIndexer = <
       deleted.isErr() && deleted.error.status === 404
         ? Result.ok(undefined)
         : deleted;
+    // One audit row per entity however many entities shared the task: the
+    // trail records what happened to a document, not what carried it.
     await adapter.recordJobs(
       scopedDb,
-      [
-        {
-          entityId,
-          contentHash: null,
-          operation,
-          status: result.isErr() ? "failed" : "succeeded",
-          ...(result.isErr()
-            ? { errorMessage: result.error.message.slice(0, 2048) }
-            : {}),
-        },
-      ],
+      entityIds.map((entityId) => ({
+        entityId,
+        contentHash: null,
+        operation,
+        status: result.isErr() ? ("failed" as const) : ("succeeded" as const),
+        ...(result.isErr()
+          ? { errorMessage: result.error.message.slice(0, 2048) }
+          : {}),
+      })),
       indexId,
     );
     return result;
+  };
+
+  // Narrows on `args`, not on destructured locals: destructuring splits the
+  // guard pair into independent variables, and testing one of them then tells
+  // the checker nothing about the other.
+  const removeWithOptions = async (
+    args: RemoveWithOptionsArgs,
+  ): Promise<Result<void, CorpusIndexError>> => {
+    const { entityId, indexId, operation, scopedDb } = args;
+    return await removeManyWithOptions(
+      args.beforeRemoteEffect === undefined
+        ? { entityIds: [entityId], indexId, operation, scopedDb }
+        : {
+            beforeRemoteEffect: args.beforeRemoteEffect,
+            entityIds: [entityId],
+            indexId,
+            onLeaseLost: args.onLeaseLost,
+            operation,
+            scopedDb,
+          },
+    );
   };
 
   const remove = async (
@@ -1126,22 +1193,48 @@ export const createCorpusIndexer = <
             oldIndexId,
           }));
         });
-        let staleError: CorpusIndexError | null = null;
+        // Grouped by target index, never issued per row. A delete task is
+        // planned against every split whose delete opstamp is behind it, so
+        // one task per row makes planning O(rows x splits) — a cost the
+        // engine pays asynchronously, long after these calls return, and one
+        // that compounds until the planner can no longer converge. The number
+        // of tasks a batch emits must scale with the indexes it touches
+        // (jurisdictions), not with the rows it carries.
+        const movedByIndex = new Map<string, SafeId<TBrand>[]>();
         for (const entry of moved) {
-          // oxlint-disable-next-line no-await-in-loop -- sequential deletes that early-break on the first error
-          const removed = await removeWithOptions({
+          const forIndex = movedByIndex.get(entry.oldIndexId);
+          if (forIndex === undefined) {
+            movedByIndex.set(entry.oldIndexId, [entry.id]);
+          } else {
+            forIndex.push(entry.id);
+          }
+        }
+        // Chunked here rather than inside the remove: the batch is what knows
+        // how many ids there are, and one call staying one remote task is what
+        // keeps the task count readable at this call site.
+        const deleteUnits: { entityIds: SafeId<TBrand>[]; indexId: string }[] =
+          [];
+        for (const [oldIndexId, ids] of movedByIndex) {
+          for (const chunk of deleteQueryChunks(ids)) {
+            deleteUnits.push({ entityIds: chunk, indexId: oldIndexId });
+          }
+        }
+        let staleError: CorpusIndexError | null = null;
+        for (const unit of deleteUnits) {
+          // oxlint-disable-next-line no-await-in-loop -- one task per (index, chunk): bounded by the batch's distinct indexes, not by its rows; sequential so the first failure stops before the ingest below
+          const removed = await removeManyWithOptions({
             ...(options.type === "incremental"
               ? {}
               : {
                   beforeRemoteEffect: options.beforeRemoteEffect,
                   onLeaseLost: async () =>
                     await options.recoverRemoteEffectLeaseLoss({
-                      entityIds: [entry.id],
-                      indexId: entry.oldIndexId,
+                      entityIds: unit.entityIds,
+                      indexId: unit.indexId,
                     }),
                 }),
-            entityId: entry.id,
-            indexId: entry.oldIndexId,
+            entityIds: unit.entityIds,
+            indexId: unit.indexId,
             operation: "delete",
             scopedDb,
           });

--- a/apps/api/src/lib/corpus-index/core.ts
+++ b/apps/api/src/lib/corpus-index/core.ts
@@ -64,6 +64,13 @@ const corpusIndexErrorFromThrown = (error: unknown): CorpusIndexError =>
       });
 
 /**
+ * Ids a delete term can carry verbatim. `SafeId` is a compile-time brand over
+ * `string` and asserts nothing about the characters, so the quoted term needs
+ * its own guarantee.
+ */
+const DELETABLE_DOCUMENT_ID = /^[A-Za-z0-9_-]+$/u;
+
+/**
  * Delete-task query selecting every search document a batch of rows projects
  * to. Keyed on the stable Postgres id, which every one of a row's documents
  * carries, so it is exactly as correct for a passage-split row as for a whole
@@ -76,7 +83,19 @@ const corpusIndexErrorFromThrown = (error: unknown): CorpusIndexError =>
  */
 export const corpusDocumentsDeleteQuery = (
   entityIds: readonly string[],
-): string => entityIds.map((id) => `document_id:"${id}"`).join(" OR ");
+): string =>
+  entityIds
+    .map((id) =>
+      DELETABLE_DOCUMENT_ID.test(id)
+        ? `document_id:"${id}"`
+        : // Not escaped, rejected: these ids come from `uuid` columns, so one
+          // that could alter the query is a defect upstream, not input to
+          // sanitize. Escaping would let the defect through silently, and the
+          // OR-join means a single crafted term changes what the whole task
+          // deletes.
+          panic(`corpus delete query received an unusable document id: ${id}`),
+    )
+    .join(" OR ");
 
 /** Single-row delete query; the batch of one. */
 export const corpusDocumentDeleteQuery = (entityId: string): string =>


### PR DESCRIPTION
Ingest appends and never replaces, so a re-projected row has its previous copies deleted by `document_id` before it is re-ingested. That delete was issued one row at a time.

The engine plans every delete task against every split whose delete opstamp is behind it. N tasks therefore cost O(N × splits) to plan, and that work happens asynchronously, long after the call that created the task returned. A per-row delete reads as free at the call site while making planning scale with rows; past a point, planning cannot keep up with creation.

## Change

Group a batch's replay deletes by target index and issue one delete task per index, chunked at 128 ids per query to bound the query a single task carries. Task count now scales with the indexes a batch touches (jurisdictions), not with the rows it carries.

Behaviour is unchanged:

- the same set of (document, index) pairs is deleted
- the audit trail still records one index-job row per entity, whatever chunking carried it
- the first failing chunk still stops the batch before the ingest that follows

Terms are OR-joined rather than written as an engine set query, so the form parses identically across query-language versions. A delete query that changes meaning between versions removes the wrong documents.

## Invariant

The property this lacked: remote delete-task count must scale with the indexes a batch touches, never with the rows it carries.

`delete-task amplification` asserts it by comparing two batch sizes rather than pinning an exact count, so the per-row shape fails it for any pair of sizes. Confirmed non-vacuous: reducing the chunk bound to 1 reproduces the per-row shape and the test fails 4 vs 40.

## Note on the type shapes

`RemoveManyWithOptionsArgs` intersects a named `RemoteEffectGuard` union rather than deriving the second signature with `Omit`. `Omit` over `Base & (A | B)` flattens the branches into independent optional properties, so the guard pair stops being correlated and narrowing no longer holds. For the same reason `removeWithOptions` narrows on `args`, not on destructured locals.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved the efficiency of bulk document deletion by processing records in batches.
  * Reduced the number of cleanup operations required when removing outdated documents.

* **Reliability**
  * Deletion operations now continue safely when an index is unavailable.
  * Cleanup stops appropriately after a failed batch while preserving recovery safeguards.
  * Added safeguards to ensure all selected records are included in deletion requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->