### PR TITLE
fix(landing): do not double the ellipsis on a cut social card headline

### DIFF
--- a/apps/landing/src/lib/og-card-text.test.ts
+++ b/apps/landing/src/lib/og-card-text.test.ts
@@ -49,6 +49,19 @@ describe("fitHeadline", () => {
     expect(fontSize).toBe(104);
   });
 
+  // The last kept line can be truncated for width and then marked again for
+  // the lines dropped after it. One marker says both things; two look broken.
+  test("never doubles the dropped-content marker", () => {
+    // Wide characters: the cut leaves enough slack for a second marker to fit
+    // where a narrower run would have had it trimmed back off again.
+    const tooWideToWrap = "m".repeat(30);
+    const { lines } = fitHeadline(
+      Array.from({ length: 4 }, () => tooWideToWrap).join(" "),
+    );
+    expect(lines.filter((line) => line.includes("……"))).toEqual([]);
+    expect(lines.at(-1)).toEndWith("…");
+  });
+
   test("marks dropped content on the last line it keeps", () => {
     const { lines } = fitHeadline(
       Array.from({ length: 40 }, () => "workspace").join(" "),

--- a/apps/landing/src/lib/og-card-text.ts
+++ b/apps/landing/src/lib/og-card-text.ts
@@ -79,7 +79,13 @@ const clampToBox = (lines: string[], fontSize: number): string[] => {
   if (lines.length <= HEADLINE_MAX_LINES || last === undefined) {
     return kept;
   }
-  // Lines were dropped, so the last kept one has to show that it is not the end.
+  // Lines were dropped, so the last kept one has to show that it is not the
+  // end — unless truncating it for width already did. One marker covers both;
+  // appending regardless can leave "……", since the cut can leave enough slack
+  // for a second one to fit rather than be trimmed back off.
+  if (last.endsWith(ELLIPSIS)) {
+    return kept;
+  }
   return [
     ...kept.slice(0, -1),
     truncateToWidth(`${last}${ELLIPSIS}`, fontSize),


### PR DESCRIPTION
Follow-up to #1772, which merged before this fix was pushed.

When the last kept headline line was truncated for width *and* further lines were dropped, `clampToBox` appended the dropped-content marker to a line that already carried one, so the card read `……`.

The append is not always trimmed back off. `truncateToWidth` cuts whole characters until the line plus one ellipsis fits, which can leave up to a character's worth of slack — enough for a second ellipsis to fit rather than be cut. Wide characters make that likely: `fitHeadline` on four 30-character runs of `m` produces `mmmmmmmmmmmmmmmmmmmm……`.

One marker says both things, so the line is left alone when it already ends in one.

The test reproduces with the wide-character shape, and fails against the previous code. An earlier attempt using `a` did not — the narrower run left too little slack, and the second ellipsis was trimmed away. Worth noting for anyone tempted to simplify the fixture.