### PR TITLE
fix(reports): embed the built-in report DOCX so it resolves in the compiled server

### DIFF
--- a/apps/api/src/docx.d.ts
+++ b/apps/api/src/docx.d.ts
@@ -1,0 +1,10 @@
+/**
+ * DOCX assets imported with `with { type: "file" }`. The import evaluates to a
+ * path the Bun runtime can read: the file's own location when the source runs
+ * directly, and a path inside the embedded asset directory once `bun build
+ * --compile` links it into the server binary.
+ */
+declare module "*.docx" {
+  const path: string;
+  export default path;
+}

--- a/apps/api/src/handlers/reports/builtin-templates.ts
+++ b/apps/api/src/handlers/reports/builtin-templates.ts
@@ -10,9 +10,21 @@
  * The manifest is embedded in the DOCX (customXml) by the generation script, so
  * the fill pipeline reads it from the buffer; it is also exported here for the
  * picker read surface and the generation script.
+ *
+ * The asset is pulled in through a `with { type: "file" }` import rather than
+ * resolved from `import.meta.url`. `bun build --compile` (see
+ * `apps/api/Dockerfile`) links the server into a standalone binary whose
+ * `import.meta.url` is `file:///$bunfs/root/server`, so a URL built relative to
+ * it points at `/$bunfs/root/assets/dd-report.docx`: a path that exists in the
+ * source tree but not in the binary, making every read fail with ENOENT. The
+ * import attribute instead makes the bundler embed the asset and resolve the
+ * specifier to a readable path, so the bytes travel with the code and cannot
+ * drift out of the build.
  */
 
 import type { TemplateManifest } from "@/api/lib/docx/types";
+
+import ddReportDocx from "./assets/dd-report.docx" with { type: "file" };
 
 export type BuiltinReportTemplate = {
   key: string;
@@ -63,11 +75,8 @@ const ddReportTemplate: BuiltinReportTemplate = {
   key: DD_REPORT_KEY,
   name: "Due Diligence Report",
   manifest: DD_REPORT_MANIFEST,
-  loadBuffer: async () => {
-    // Resolved relative to this module; the asset ships in the deployment image.
-    const url = new URL("assets/dd-report.docx", import.meta.url);
-    return Buffer.from(await Bun.file(url).arrayBuffer());
-  },
+  loadBuffer: async () =>
+    Buffer.from(await Bun.file(ddReportDocx).arrayBuffer()),
 };
 
 const BUILTIN_REPORT_TEMPLATES: readonly BuiltinReportTemplate[] = [

--- a/types/docx.d.ts
+++ b/types/docx.d.ts
@@ -3,6 +3,9 @@
  * path the Bun runtime can read: the file's own location when the source runs
  * directly, and a path inside the embedded asset directory once `bun build
  * --compile` links it into the server binary.
+ *
+ * This declaration lives in the shared types directory because the web
+ * typecheck follows the API route types through its `@/api/*` path alias.
  */
 declare module "*.docx" {
   const path: string;


### PR DESCRIPTION
## Proposed change

`builtin-templates.ts` located the shipped Due Diligence DOCX by URL:

```ts
const url = new URL("assets/dd-report.docx", import.meta.url);
return Buffer.from(await Bun.file(url).arrayBuffer());
```

`apps/api/Dockerfile` links the server into a standalone binary with `bun build --compile`. In that binary `import.meta.url` is `file:///$bunfs/root/server`, so the URL above resolves to `/$bunfs/root/assets/dd-report.docx`: a path that exists in the source tree but not in the binary. The Dockerfile materializes its other runtime assets under `/$bunfs/root/` (the runtime workers, the Cabinet Grotesk font, the YARA rules, the anonymize-wasm native glue, the quickjs wasm) and has no entry for this one, so `loadBuffer()` fails with `ENOENT: no such file or directory, open '/$bunfs/root/assets/dd-report.docx'`.

Both callers of `loadBuffer()` are affected, and both answer 500:

- `handlers/reports/clone-builtin.ts`, cloning the built-in into an organization's templates
- `handlers/reports/report-export-queue.ts`, filling a report export from the built-in layout

The picker is unaffected: `list-templates.ts` reads only `key` and `name` and never opens the file, so the built-in lists normally and fails at use.

This change imports the asset with `with { type: "file" }`. The bundler embeds it and rewrites the specifier to a path that resolves both when the source runs directly and inside the compiled binary, so the bytes travel with the code instead of depending on an image entry kept in sync by hand. `types/docx.d.ts` types the import.

### Verification

Compiled a binary around the real module (`bun build --compile` over an entry calling `loadBuffer()`) and ran it from `/` with no source tree present:

- before: `ENOENT ... open '/$bunfs/root/assets/dd-report.docx'`
- after: reads the 28,808-byte DOCX (`PK` magic)

`bun test apps/api/src/handlers/reports/clone-builtin.test.ts` passes (3 tests; it exercises the real `loadBuffer`), and the CI `typecheck-baseline --check` guard (API, web, and web e2e projects), focused test, scoped oxlint, and formatting checks are clean.

## Checklist

- [x] **BUILD ASSURANCE** | Code builds correctly and without any errors or warnings.
- [x] **TESTING** | Changes tested, including in different conditions (dark mode, language, narrow screen, etc).
- [ ] DARK MODE SUPPORT | Not applicable: server-side asset resolution, no UI surface.
- [ ] ISSUE LINKED | No existing issue.
- [ ] SCREENSHOT INCLUDED | Not applicable: no user-visible UI change.


---
_Generated by [Claude Code](https://claude.ai/code/session_01SC4BbWPAFngZv6GH76DPVo)_