### PR TITLE
fix(mcp): allow CLI 0.4.3

### DIFF
--- a/apps/api/src/mcp/constants.ts
+++ b/apps/api/src/mcp/constants.ts
@@ -107,7 +107,7 @@ export const STELLA_MCP_API_CONTRACT_VERSION = 1;
 const CLI_SUPPORT_BAND = declareCliSupportBand({
   minimum: "0.3.0",
   latest: "0.3.0",
-  maximum: "0.4.2",
+  maximum: "0.4.3",
 });
 
 export const STELLA_CLI_MINIMUM_VERSION = CLI_SUPPORT_BAND.minimum;


### PR DESCRIPTION
## Summary

- extend the advertised CLI compatibility ceiling to 0.4.3
- keep the latest-version nudge unchanged until 0.4.3 is published
- unblock the generated package-version PR without publishing ahead of production support

## Validation

- `bun test --preload ./apps/api/src/tests/setup-env.ts scripts/check-api-cli-contract.test.ts apps/api/src/mcp/cli-mirror-drift.test.ts apps/api/src/mcp/metadata.test.ts apps/api/src/mcp/server.test.ts`
- `bun --cwd apps/api typecheck`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the supported CLI version range to include version 0.4.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->