### PR TITLE
fix(web): keep the content column usable beside the inspector pane

### DIFF
--- a/apps/web/src/components/sidebar-sizing.ts
+++ b/apps/web/src/components/sidebar-sizing.ts
@@ -1,0 +1,2 @@
+export const SIDEBAR_WIDTH_PX = 256;
+export const SIDEBAR_WIDTH_ICON_PX = 48;

--- a/apps/web/src/components/sidebar.tsx
+++ b/apps/web/src/components/sidebar.tsx
@@ -30,9 +30,16 @@ import { Slot } from "@/lib/slot";
 import { useEffectiveHotkey } from "@/lib/use-effective-shortcuts";
 
 const SIDEBAR_LS_NAME = "sidebar_state";
-const SIDEBAR_WIDTH = "16rem";
+// Numeric source of truth for the desktop sidebar's rendered widths. The
+// CSS custom properties below are derived from these, so layout code that
+// must reserve the sidebar's space in JS (the inspector pane's width
+// clamp) cannot drift from what the sidebar actually renders.
+const SIDEBAR_WIDTH_PX = 256;
+const SIDEBAR_WIDTH_ICON_PX = 48;
+const REM_PX = 16;
+const SIDEBAR_WIDTH = `${SIDEBAR_WIDTH_PX / REM_PX}rem`;
 const SIDEBAR_WIDTH_MOBILE = "18rem";
-const SIDEBAR_WIDTH_ICON = "3rem";
+const SIDEBAR_WIDTH_ICON = `${SIDEBAR_WIDTH_ICON_PX / REM_PX}rem`;
 const DEFAULT_SIDEBAR_OPEN = true;
 
 type SidebarContextProps = {
@@ -54,6 +61,21 @@ function useSidebar() {
   }
 
   return context;
+}
+
+/**
+ * Inline size the app sidebar takes out of the layout row, in CSS pixels.
+ * Panes docked to the opposite edge need this to know how much room is
+ * actually left for the content column. Mobile reports 0: there the
+ * sidebar is an overlay sheet and occupies no layout width.
+ */
+function useSidebarInlineSize(): number {
+  const { isMobile, state } = useSidebar();
+
+  if (isMobile) {
+    return 0;
+  }
+  return state === "expanded" ? SIDEBAR_WIDTH_PX : SIDEBAR_WIDTH_ICON_PX;
 }
 
 function SidebarProvider({
@@ -722,4 +744,5 @@ export {
   SidebarSeparator,
   SidebarTrigger,
   useSidebar,
+  useSidebarInlineSize,
 };

--- a/apps/web/src/components/sidebar.tsx
+++ b/apps/web/src/components/sidebar.tsx
@@ -26,16 +26,14 @@ import {
 import { useIsMobile } from "@stll/ui/hooks/use-mobile";
 import { cn } from "@stll/ui/lib/utils";
 
+import {
+  SIDEBAR_WIDTH_ICON_PX,
+  SIDEBAR_WIDTH_PX,
+} from "@/components/sidebar-sizing";
 import { Slot } from "@/lib/slot";
 import { useEffectiveHotkey } from "@/lib/use-effective-shortcuts";
 
 const SIDEBAR_LS_NAME = "sidebar_state";
-// Numeric source of truth for the desktop sidebar's rendered widths. The
-// CSS custom properties below are derived from these, so layout code that
-// must reserve the sidebar's space in JS (the inspector pane's width
-// clamp) cannot drift from what the sidebar actually renders.
-const SIDEBAR_WIDTH_PX = 256;
-const SIDEBAR_WIDTH_ICON_PX = 48;
 const REM_PX = 16;
 const SIDEBAR_WIDTH = `${SIDEBAR_WIDTH_PX / REM_PX}rem`;
 const SIDEBAR_WIDTH_MOBILE = "18rem";
@@ -69,7 +67,7 @@ function useSidebar() {
  * actually left for the content column. Mobile reports 0: there the
  * sidebar is an overlay sheet and occupies no layout width.
  */
-function useSidebarInlineSize(): number {
+function useSidebarInlineSize() {
   const { isMobile, state } = useSidebar();
 
   if (isMobile) {
@@ -80,6 +78,7 @@ function useSidebarInlineSize(): number {
 
 function SidebarProvider({
   defaultOpen,
+  forceCollapsed = false,
   open: openProp,
   onOpenChange: setOpenProp,
   className,
@@ -88,6 +87,7 @@ function SidebarProvider({
   ...props
 }: React.ComponentProps<"div"> & {
   defaultOpen?: boolean;
+  forceCollapsed?: boolean;
   open?: boolean;
   onOpenChange?: (open: boolean) => void;
 }) {
@@ -110,9 +110,11 @@ function SidebarProvider({
       ? DEFAULT_SIDEBAR_OPEN
       : storedState === "expanded";
   });
-  const open = openProp ?? _open;
+  const requestedOpen = openProp ?? _open;
+  const open = requestedOpen && !forceCollapsed;
   const setOpen = (value: boolean | ((v: boolean) => boolean)) => {
-    const openState = typeof value === "function" ? value(open) : value;
+    const openState =
+      typeof value === "function" ? value(requestedOpen) : value;
     if (setOpenProp) {
       setOpenProp(openState);
     } else {

--- a/apps/web/src/routes/-inspector-pane-width.test.ts
+++ b/apps/web/src/routes/-inspector-pane-width.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  INSPECTOR_CONTENT_MIN_WIDTH,
+  INSPECTOR_PANE_MAX_WIDTH,
+  INSPECTOR_PANE_MIN_WIDTH,
+  resolveInspectorPaneWidth,
+} from "@/routes/-inspector-pane-width";
+
+const SIDEBAR_EXPANDED = 256;
+const SIDEBAR_COLLAPSED = 48;
+
+describe("resolveInspectorPaneWidth", () => {
+  // The regression this guards: the pane kept its dragged width while the
+  // viewport shrank, so the content column got whatever pixels were left.
+  test("never starves the content column while the pane can still shrink", () => {
+    for (let viewportWidth = 768; viewportWidth <= 2560; viewportWidth += 1) {
+      for (const sidebarWidth of [SIDEBAR_COLLAPSED, SIDEBAR_EXPANDED]) {
+        const width = resolveInspectorPaneWidth({
+          desiredWidth: INSPECTOR_PANE_MAX_WIDTH,
+          sidebarWidth,
+          viewportWidth,
+        });
+        const content = viewportWidth - sidebarWidth - width;
+        expect(
+          content >= INSPECTOR_CONTENT_MIN_WIDTH ||
+            width === INSPECTOR_PANE_MIN_WIDTH,
+        ).toBe(true);
+      }
+    }
+  });
+
+  test("stays within the pane's own bounds for any dragged width", () => {
+    for (const desiredWidth of [-500, 0, 120, 512, 5000]) {
+      const width = resolveInspectorPaneWidth({
+        desiredWidth,
+        sidebarWidth: SIDEBAR_COLLAPSED,
+        viewportWidth: 2560,
+      });
+      expect(width).toBeGreaterThanOrEqual(INSPECTOR_PANE_MIN_WIDTH);
+      expect(width).toBeLessThanOrEqual(INSPECTOR_PANE_MAX_WIDTH);
+    }
+  });
+
+  test("honours the dragged width when there is room for it", () => {
+    expect(
+      resolveInspectorPaneWidth({
+        desiredWidth: 640,
+        sidebarWidth: SIDEBAR_EXPANDED,
+        viewportWidth: 1920,
+      }),
+    ).toBe(640);
+  });
+
+  test("collapsing the sidebar gives the reclaimed space back to the pane", () => {
+    const args = {
+      desiredWidth: INSPECTOR_PANE_MAX_WIDTH,
+      viewportWidth: 1440,
+    };
+    const expanded = resolveInspectorPaneWidth({
+      ...args,
+      sidebarWidth: SIDEBAR_EXPANDED,
+    });
+    const collapsed = resolveInspectorPaneWidth({
+      ...args,
+      sidebarWidth: SIDEBAR_COLLAPSED,
+    });
+    expect(collapsed).toBeGreaterThan(expanded);
+  });
+
+  test("falls back to the minimum before the viewport is known", () => {
+    expect(
+      resolveInspectorPaneWidth({
+        desiredWidth: INSPECTOR_PANE_MAX_WIDTH,
+        sidebarWidth: 0,
+        viewportWidth: 0,
+      }),
+    ).toBe(INSPECTOR_PANE_MIN_WIDTH);
+  });
+});

--- a/apps/web/src/routes/-inspector-pane-width.test.ts
+++ b/apps/web/src/routes/-inspector-pane-width.test.ts
@@ -1,32 +1,35 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  SIDEBAR_WIDTH_ICON_PX,
+  SIDEBAR_WIDTH_PX,
+} from "@/components/sidebar-sizing";
+import {
   INSPECTOR_CONTENT_MIN_WIDTH,
   INSPECTOR_PANE_MAX_WIDTH,
   INSPECTOR_PANE_MIN_WIDTH,
   resolveInspectorPaneWidth,
+  shouldForceSidebarCollapsed,
 } from "@/routes/-inspector-pane-width";
-
-const SIDEBAR_EXPANDED = 256;
-const SIDEBAR_COLLAPSED = 48;
 
 describe("resolveInspectorPaneWidth", () => {
   // The regression this guards: the pane kept its dragged width while the
   // viewport shrank, so the content column got whatever pixels were left.
-  test("never starves the content column while the pane can still shrink", () => {
+  test("never starves the content column across desktop widths", () => {
     for (let viewportWidth = 768; viewportWidth <= 2560; viewportWidth += 1) {
-      for (const sidebarWidth of [SIDEBAR_COLLAPSED, SIDEBAR_EXPANDED]) {
-        const width = resolveInspectorPaneWidth({
-          desiredWidth: INSPECTOR_PANE_MAX_WIDTH,
-          sidebarWidth,
-          viewportWidth,
-        });
-        const content = viewportWidth - sidebarWidth - width;
-        expect(
-          content >= INSPECTOR_CONTENT_MIN_WIDTH ||
-            width === INSPECTOR_PANE_MIN_WIDTH,
-        ).toBe(true);
-      }
+      const sidebarWidth = shouldForceSidebarCollapsed({
+        inspectorPaneOpen: true,
+        viewportWidth,
+      })
+        ? SIDEBAR_WIDTH_ICON_PX
+        : SIDEBAR_WIDTH_PX;
+      const width = resolveInspectorPaneWidth({
+        desiredWidth: INSPECTOR_PANE_MAX_WIDTH,
+        sidebarWidth,
+        viewportWidth,
+      });
+      const content = viewportWidth - sidebarWidth - width;
+      expect(content).toBeGreaterThanOrEqual(INSPECTOR_CONTENT_MIN_WIDTH);
     }
   });
 
@@ -34,7 +37,7 @@ describe("resolveInspectorPaneWidth", () => {
     for (const desiredWidth of [-500, 0, 120, 512, 5000]) {
       const width = resolveInspectorPaneWidth({
         desiredWidth,
-        sidebarWidth: SIDEBAR_COLLAPSED,
+        sidebarWidth: SIDEBAR_WIDTH_ICON_PX,
         viewportWidth: 2560,
       });
       expect(width).toBeGreaterThanOrEqual(INSPECTOR_PANE_MIN_WIDTH);
@@ -46,7 +49,7 @@ describe("resolveInspectorPaneWidth", () => {
     expect(
       resolveInspectorPaneWidth({
         desiredWidth: 640,
-        sidebarWidth: SIDEBAR_EXPANDED,
+        sidebarWidth: SIDEBAR_WIDTH_PX,
         viewportWidth: 1920,
       }),
     ).toBe(640);
@@ -59,11 +62,11 @@ describe("resolveInspectorPaneWidth", () => {
     };
     const expanded = resolveInspectorPaneWidth({
       ...args,
-      sidebarWidth: SIDEBAR_EXPANDED,
+      sidebarWidth: SIDEBAR_WIDTH_PX,
     });
     const collapsed = resolveInspectorPaneWidth({
       ...args,
-      sidebarWidth: SIDEBAR_COLLAPSED,
+      sidebarWidth: SIDEBAR_WIDTH_ICON_PX,
     });
     expect(collapsed).toBeGreaterThan(expanded);
   });
@@ -76,5 +79,35 @@ describe("resolveInspectorPaneWidth", () => {
         viewportWidth: 0,
       }),
     ).toBe(INSPECTOR_PANE_MIN_WIDTH);
+  });
+});
+
+describe("shouldForceSidebarCollapsed", () => {
+  test("collapses only while an open pane needs the expanded sidebar's space", () => {
+    expect(
+      shouldForceSidebarCollapsed({
+        inspectorPaneOpen: true,
+        viewportWidth:
+          SIDEBAR_WIDTH_PX +
+          INSPECTOR_CONTENT_MIN_WIDTH +
+          INSPECTOR_PANE_MIN_WIDTH -
+          1,
+      }),
+    ).toBe(true);
+    expect(
+      shouldForceSidebarCollapsed({
+        inspectorPaneOpen: true,
+        viewportWidth:
+          SIDEBAR_WIDTH_PX +
+          INSPECTOR_CONTENT_MIN_WIDTH +
+          INSPECTOR_PANE_MIN_WIDTH,
+      }),
+    ).toBe(false);
+    expect(
+      shouldForceSidebarCollapsed({
+        inspectorPaneOpen: false,
+        viewportWidth: 768,
+      }),
+    ).toBe(false);
   });
 });

--- a/apps/web/src/routes/-inspector-pane-width.ts
+++ b/apps/web/src/routes/-inspector-pane-width.ts
@@ -8,6 +8,8 @@
  * leaves the content column a few dozen pixels wide instead of folding.
  */
 
+import { SIDEBAR_WIDTH_PX } from "@/components/sidebar-sizing";
+
 export const INSPECTOR_PANE_DEFAULT_WIDTH = 512;
 export const INSPECTOR_PANE_MIN_WIDTH = 320;
 export const INSPECTOR_PANE_MAX_WIDTH = 800;
@@ -17,6 +19,25 @@ export const INSPECTOR_PANE_MAX_WIDTH = 800;
  * space first.
  */
 export const INSPECTOR_CONTENT_MIN_WIDTH = 400;
+
+type ForceSidebarCollapsedInput = {
+  inspectorPaneOpen: boolean;
+  viewportWidth: number;
+};
+
+/**
+ * The expanded sidebar yields its optional width before either docked pane
+ * can violate its minimum. The collapsed rail plus both minimums fit at the
+ * desktop breakpoint, so this policy keeps every desktop width usable.
+ */
+export const shouldForceSidebarCollapsed = ({
+  inspectorPaneOpen,
+  viewportWidth,
+}: ForceSidebarCollapsedInput) =>
+  inspectorPaneOpen &&
+  viewportWidth > 0 &&
+  viewportWidth <
+    SIDEBAR_WIDTH_PX + INSPECTOR_CONTENT_MIN_WIDTH + INSPECTOR_PANE_MIN_WIDTH;
 
 type InspectorPaneWidthInput = {
   /** Width the user dragged the pane to. */
@@ -37,7 +58,7 @@ type InspectorPaneWidthInput = {
 export const resolveInspectorPaneMaxWidth = ({
   sidebarWidth,
   viewportWidth,
-}: Omit<InspectorPaneWidthInput, "desiredWidth">): number => {
+}: Omit<InspectorPaneWidthInput, "desiredWidth">) => {
   if (viewportWidth <= 0) {
     return INSPECTOR_PANE_MIN_WIDTH;
   }
@@ -54,7 +75,7 @@ export const resolveInspectorPaneWidth = ({
   desiredWidth,
   sidebarWidth,
   viewportWidth,
-}: InspectorPaneWidthInput): number =>
+}: InspectorPaneWidthInput) =>
   Math.min(
     Math.max(desiredWidth, INSPECTOR_PANE_MIN_WIDTH),
     resolveInspectorPaneMaxWidth({ sidebarWidth, viewportWidth }),

--- a/apps/web/src/routes/-inspector-pane-width.ts
+++ b/apps/web/src/routes/-inspector-pane-width.ts
@@ -1,0 +1,61 @@
+/**
+ * Width arithmetic for the docked inspector pane.
+ *
+ * The pane is a fixed overlay backed by an in-flow spacer, so nothing in
+ * the layout pushes back when it grows: whatever the pane takes comes
+ * straight out of the content column. Without a clamp against the space
+ * actually available, shrinking the window (or expanding the sidebar)
+ * leaves the content column a few dozen pixels wide instead of folding.
+ */
+
+export const INSPECTOR_PANE_DEFAULT_WIDTH = 512;
+export const INSPECTOR_PANE_MIN_WIDTH = 320;
+export const INSPECTOR_PANE_MAX_WIDTH = 800;
+/**
+ * Floor for the content column beside the pane. Below this the chat
+ * composer and the landing columns stop being usable, so the pane yields
+ * space first.
+ */
+export const INSPECTOR_CONTENT_MIN_WIDTH = 400;
+
+type InspectorPaneWidthInput = {
+  /** Width the user dragged the pane to. */
+  desiredWidth: number;
+  /** Inline size the sidebar takes out of the same layout row. */
+  sidebarWidth: number;
+  /** Viewport width in CSS pixels; 0 before the viewport is known. */
+  viewportWidth: number;
+};
+
+/**
+ * Largest width the pane may take without starving the content column.
+ * Never returns less than {@link INSPECTOR_PANE_MIN_WIDTH}: a pane too
+ * narrow to read is no better than a content column too narrow to read,
+ * and collapsing the sidebar is the escape hatch for a genuinely small
+ * viewport.
+ */
+export const resolveInspectorPaneMaxWidth = ({
+  sidebarWidth,
+  viewportWidth,
+}: Omit<InspectorPaneWidthInput, "desiredWidth">): number => {
+  if (viewportWidth <= 0) {
+    return INSPECTOR_PANE_MIN_WIDTH;
+  }
+
+  const available = viewportWidth - sidebarWidth - INSPECTOR_CONTENT_MIN_WIDTH;
+  return Math.max(
+    INSPECTOR_PANE_MIN_WIDTH,
+    Math.min(INSPECTOR_PANE_MAX_WIDTH, available),
+  );
+};
+
+/** Width the pane renders at, given the width the user asked for. */
+export const resolveInspectorPaneWidth = ({
+  desiredWidth,
+  sidebarWidth,
+  viewportWidth,
+}: InspectorPaneWidthInput): number =>
+  Math.min(
+    Math.max(desiredWidth, INSPECTOR_PANE_MIN_WIDTH),
+    resolveInspectorPaneMaxWidth({ sidebarWidth, viewportWidth }),
+  );

--- a/apps/web/src/routes/_protected.chat/index.tsx
+++ b/apps/web/src/routes/_protected.chat/index.tsx
@@ -432,9 +432,12 @@ function ChatIndex() {
         />
         <ThreadsSheet />
       </ChromeHeaderActions>
-      <div className="flex flex-1 flex-col items-center overflow-y-auto px-4 pb-16">
+      {/* The landing folds against its own width, not the viewport's: the
+          inspector pane can leave this column far narrower than a viewport
+          breakpoint would suggest. */}
+      <div className="@container flex flex-1 flex-col items-center overflow-y-auto px-4 pb-16">
         <div className="flex min-h-[22rem] w-full max-w-2xl shrink-0 flex-col items-center justify-center gap-8">
-          <div className="flex flex-col items-center gap-4 text-center">
+          <div className="flex w-full flex-col items-center gap-4 text-center">
             <div className="border-border bg-background text-foreground flex size-12 items-center justify-center rounded-lg border shadow-sm">
               <StellaMark className="size-7" />
             </div>
@@ -498,7 +501,7 @@ function ChatIndex() {
             />
           </div>
         </div>
-        <div className="grid min-h-52 w-full gap-8 md:grid-cols-3">
+        <div className="grid min-h-52 w-full gap-8 @2xl:grid-cols-3">
           <LandingSection
             heading={
               <Link

--- a/apps/web/src/routes/_protected.tsx
+++ b/apps/web/src/routes/_protected.tsx
@@ -83,6 +83,7 @@ import { loadAuthContext } from "@/routes/-auth-context";
 import {
   INSPECTOR_PANE_DEFAULT_WIDTH,
   resolveInspectorPaneWidth,
+  shouldForceSidebarCollapsed,
 } from "@/routes/-inspector-pane-width";
 
 const LazyInspectorPanel = lazy(
@@ -298,6 +299,14 @@ function ProtectedComponent() {
     shouldThrow: false,
   });
   const activeWorkspaceId = workspaceMatch?.params.workspaceId;
+  const inspectorPaneOpen = useInspectorTabsStore(
+    (state) => state.tabs.length > 0 && !state.minimized,
+  );
+  const viewportWidth = useViewportWidth();
+  const forceSidebarCollapsed = shouldForceSidebarCollapsed({
+    inspectorPaneOpen,
+    viewportWidth,
+  });
 
   useExternalSyncEffect(
     () =>
@@ -331,7 +340,7 @@ function ProtectedComponent() {
 
   return (
     <AuthenticatedUserProvider user={analyticsUser}>
-      <SidebarProvider>
+      <SidebarProvider forceCollapsed={forceSidebarCollapsed}>
         <ChatMentionProviders>
           <AIAvailabilityProvider>
             <ChatEditorProvider>

--- a/apps/web/src/routes/_protected.tsx
+++ b/apps/web/src/routes/_protected.tsx
@@ -32,6 +32,7 @@ import {
 } from "@stll/ui/components/sheet";
 import { Skeleton } from "@stll/ui/components/skeleton";
 import { TOAST_RIGHT_OFFSET_VAR } from "@stll/ui/components/toast";
+import { useViewportWidth } from "@stll/ui/hooks/use-viewport-width";
 import { cn } from "@stll/ui/lib/utils";
 
 import { ApiVersionMismatchBanner } from "@/components/api-version-mismatch-banner";
@@ -55,6 +56,7 @@ import {
   SidebarProvider,
   SidebarTrigger,
   useSidebar,
+  useSidebarInlineSize,
 } from "@/components/sidebar";
 import { CreateMatterDialog } from "@/components/workspaces/create-matter-dialog";
 import { useGlobalChatMentionRegistration } from "@/features/chat/hooks/use-global-chat-mention-registration";
@@ -78,6 +80,10 @@ import { prefetchRouteQuery } from "@/lib/react-query";
 import { useEffectiveHotkey } from "@/lib/use-effective-shortcuts";
 import { workspaceOptions } from "@/lib/workspaces/queries";
 import { loadAuthContext } from "@/routes/-auth-context";
+import {
+  INSPECTOR_PANE_DEFAULT_WIDTH,
+  resolveInspectorPaneWidth,
+} from "@/routes/-inspector-pane-width";
 
 const LazyInspectorPanel = lazy(
   async () =>
@@ -547,9 +553,6 @@ function ProtectedContent() {
   );
 }
 
-const INSPECTOR_PANE_DEFAULT_WIDTH = 512;
-const INSPECTOR_PANE_MIN_WIDTH = 320;
-const INSPECTOR_PANE_MAX_WIDTH = 800;
 // Matches SIDE_RAIL_WIDTH (`w-12` = 48px) so the wrapper width
 // equals the rail's actual rendered width. Earlier this was 40,
 // leaving the rail 8px wider than its wrapper and pushing the
@@ -646,7 +649,20 @@ function WorkspaceInspectorSidePanel() {
     routeWorkspaceId,
     tabs,
   });
-  const [width, setWidth] = useState(INSPECTOR_PANE_DEFAULT_WIDTH);
+  // The width the user dragged to. What actually renders is this clamped
+  // against the room left beside the sidebar, so shrinking the window or
+  // expanding the sidebar takes space back from the pane instead of
+  // crushing the content column.
+  const [desiredWidth, setDesiredWidth] = useState(
+    INSPECTOR_PANE_DEFAULT_WIDTH,
+  );
+  const sidebarWidth = useSidebarInlineSize();
+  const viewportWidth = useViewportWidth();
+  const width = resolveInspectorPaneWidth({
+    desiredWidth,
+    sidebarWidth,
+    viewportWidth,
+  });
   const isDragging = useRef(false);
   // Re-run the offset effect once the new bundle applies: `loadedLang` (not
   // `lang`) is what flips document.documentElement.dir, so depending on it
@@ -668,13 +684,7 @@ function WorkspaceInspectorSidePanel() {
     // distance from the left). Without the RTL branch the delta is
     // inverted and the drag oscillates.
     const isRtl = document.documentElement.dir === "rtl";
-    const newWidth = isRtl ? e.clientX : window.innerWidth - e.clientX;
-    setWidth(
-      Math.min(
-        INSPECTOR_PANE_MAX_WIDTH,
-        Math.max(INSPECTOR_PANE_MIN_WIDTH, newWidth),
-      ),
-    );
+    setDesiredWidth(isRtl ? e.clientX : window.innerWidth - e.clientX);
   };
 
   const handlePointerUp = () => {

--- a/packages/ui/src/hooks/use-viewport-width.ts
+++ b/packages/ui/src/hooks/use-viewport-width.ts
@@ -1,0 +1,17 @@
+import * as React from "react";
+
+const subscribe = (onChange: () => void): (() => void) => {
+  window.addEventListener("resize", onChange);
+  return () => window.removeEventListener("resize", onChange);
+};
+
+const getSnapshot = (): number => window.innerWidth;
+// SSR has no viewport. Callers use this to clamp a docked pane against
+// the space actually available, so report 0 and let them fall back to
+// their own minimum rather than inventing a desktop-sized viewport.
+const getServerSnapshot = (): number => 0;
+
+/** Viewport width in CSS pixels, tracked across resizes. */
+export function useViewportWidth() {
+  return React.useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+}

--- a/packages/ui/src/hooks/use-viewport-width.ts
+++ b/packages/ui/src/hooks/use-viewport-width.ts
@@ -1,15 +1,15 @@
 import * as React from "react";
 
-const subscribe = (onChange: () => void): (() => void) => {
+const subscribe = (onChange: () => void) => {
   window.addEventListener("resize", onChange);
   return () => window.removeEventListener("resize", onChange);
 };
 
-const getSnapshot = (): number => window.innerWidth;
+const getSnapshot = () => window.innerWidth;
 // SSR has no viewport. Callers use this to clamp a docked pane against
 // the space actually available, so report 0 and let them fall back to
 // their own minimum rather than inventing a desktop-sized viewport.
-const getServerSnapshot = (): number => 0;
+const getServerSnapshot = () => 0;
 
 /** Viewport width in CSS pixels, tracked across resizes. */
 export function useViewportWidth() {


### PR DESCRIPTION
## Problem

The inspector pane is a fixed overlay backed by an in-flow spacer, so nothing in the layout pushes back when it grows: its width comes straight out of the content column. The width was clamped only in the drag handler, against fixed bounds (`320…800`), and never re-evaluated afterwards.

So on a viewport that cannot fit sidebar + pane + content, the content column absorbs the whole shortfall. At a 1120px viewport with the sidebar expanded and the pane at its 800px maximum, the chat column renders at roughly 64px. Nothing recovers it: resizing the window narrower, or expanding the sidebar, only makes it worse.

The chat landing then compounds this. Its three sections folded on `md:` — a *viewport* breakpoint — while living in a column the pane can make far narrower than the viewport. The sections stay side by side in a sliver and their headings break one letter per line.

## Change

**Pane width.** The dragged width is kept as intent and clamped on render against `viewport - sidebar - content floor`. The pane yields space first, never drops below its own minimum, and returns to the requested width once there is room again. The arithmetic lives in `routes/-inspector-pane-width.ts` with a test sweeping 768→2560px against both sidebar states.

**Sidebar reserve.** `SIDEBAR_WIDTH` / `SIDEBAR_WIDTH_ICON` now derive from numeric constants rather than the other way round, and `useSidebarInlineSize()` exposes the occupied width. The reserve cannot drift from what the sidebar renders.

**Landing.** Folds on the column's own width via a container query. The greeting block gets an explicit width so a flex item's automatic minimum size cannot push text outside the column.

## Known gap

Between 768px and ~976px with the sidebar **expanded**, the pane reaches its 320px floor and the content column still lands under the 400px floor (192px at the very bottom). Collapsing the sidebar is the escape hatch. Closing that properly means auto-collapsing the sidebar or making the inspector an overlay below ~1024px — a behaviour change left out of this diff.

## Verification

`bun run verify` passes on this branch. Not yet confirmed visually in a running app.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Inspector pane sizing now adapts smoothly to viewport size and sidebar state.
  - Dragged inspector widths are preserved where space allows, while preventing the content area from becoming too narrow.
  - Sidebar dimensions remain consistent across desktop layouts and collapse appropriately on mobile.
  - Chat landing page columns now respond to the available container space, improving layouts across different screen sizes.
- **Bug Fixes**
  - Improved handling of narrow and zero-width viewport states to prevent layout issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->