### PR TITLE
fix(api): treat a chat stream's own terminal errors as anticipated failures

### DIFF
--- a/apps/api/src/handlers/chat/stream-chat.ts
+++ b/apps/api/src/handlers/chat/stream-chat.ts
@@ -108,6 +108,7 @@ import {
   ChatLoopDetectedError,
   HandlerError,
 } from "@/api/lib/errors/tagged-errors";
+import type { ChatTerminalError } from "@/api/lib/errors/tagged-errors";
 import { errorFingerprint } from "@/api/lib/errors/utils";
 import { logger } from "@/api/lib/observability/logger";
 import { providerSafeJsonSchemaOptionsForTanStackProvider } from "@/api/lib/provider-safe-json-schema";
@@ -473,7 +474,7 @@ export const recordChatAttemptFinish = ({
 
 const chatAttemptTerminalError = (
   state: ChatAttemptState,
-): ChatLoopDetectedError | ChatEmptyCompletionError | null =>
+): ChatTerminalError | null =>
   state.finalLoopDetection ?? state.emptyCompletion;
 
 const projectServerToolsForProvider = ({

--- a/apps/api/src/lib/ai-error.test.ts
+++ b/apps/api/src/lib/ai-error.test.ts
@@ -137,17 +137,20 @@ type UncoveredStatusCode = Exclude<
 >;
 
 // One instance per member of the union, bound to it in both directions: the
-// annotation rejects anything that is not a terminal error, and the alias
-// below stops compiling while a member has no instance here.
-const CHAT_TERMINAL_ERRORS = [
-  new ChatEmptyCompletionError({ message: "finished with zero output" }),
-  new ChatLoopDetectedError({ message: "repeated the same work" }),
-] as const satisfies readonly ChatTerminalError[];
-
-type UncoveredChatTerminalErrorTag = Exclude<
-  ChatTerminalError["_tag"],
-  (typeof CHAT_TERMINAL_ERRORS)[number]["_tag"]
->;
+// mapped type stops compiling when a member has no matching instance here.
+const CHAT_TERMINAL_ERRORS = {
+  ChatEmptyCompletionError: new ChatEmptyCompletionError({
+    message: "finished with zero output",
+  }),
+  ChatLoopDetectedError: new ChatLoopDetectedError({
+    message: "repeated the same work",
+  }),
+} as const satisfies {
+  readonly [Tag in ChatTerminalError["_tag"]]: Extract<
+    ChatTerminalError,
+    { readonly _tag: Tag }
+  >;
+};
 
 describe("isAnticipatedAIFailure", () => {
   test("exercises every HandlerError status", () => {
@@ -186,21 +189,12 @@ describe("isAnticipatedAIFailure", () => {
     }
   });
 
-  test("exercises every chat terminal error", () => {
-    const everyTerminalErrorCovered: [UncoveredChatTerminalErrorTag] extends [
-      never,
-    ]
-      ? true
-      : false = true;
-
-    expect(everyTerminalErrorCovered).toBe(true);
-  });
-
   test("anticipates every terminal outcome the chat stream raises itself", () => {
     // The stream models each of these and recovers from it, so none is a
     // defect, including the ones the classifier cannot name: an error this
     // service constructed carries no provider status to classify by.
-    for (const error of CHAT_TERMINAL_ERRORS) {
+    for (const error of Object.values(CHAT_TERMINAL_ERRORS)) {
+      expect(isAnticipatedAIFailure(error, "unknown")).toBe(true);
       expect(isAnticipatedAIFailure(error, classifyAIError(error))).toBe(true);
     }
   });

--- a/apps/api/src/lib/ai-error.test.ts
+++ b/apps/api/src/lib/ai-error.test.ts
@@ -2,10 +2,14 @@ import { describe, expect, test } from "bun:test";
 
 import { classifyAIError, isAnticipatedAIFailure } from "@/api/lib/ai-error";
 import {
+  ChatEmptyCompletionError,
   ChatLoopDetectedError,
   HandlerError,
 } from "@/api/lib/errors/tagged-errors";
-import type { HandlerErrorStatusCode } from "@/api/lib/errors/tagged-errors";
+import type {
+  ChatTerminalError,
+  HandlerErrorStatusCode,
+} from "@/api/lib/errors/tagged-errors";
 
 const apiCallError = (statusCode: number) =>
   ({
@@ -132,6 +136,19 @@ type UncoveredStatusCode = Exclude<
   (typeof CLIENT_STATUS_CODES)[number] | (typeof SERVER_STATUS_CODES)[number]
 >;
 
+// One instance per member of the union, bound to it in both directions: the
+// annotation rejects anything that is not a terminal error, and the alias
+// below stops compiling while a member has no instance here.
+const CHAT_TERMINAL_ERRORS = [
+  new ChatEmptyCompletionError({ message: "finished with zero output" }),
+  new ChatLoopDetectedError({ message: "repeated the same work" }),
+] as const satisfies readonly ChatTerminalError[];
+
+type UncoveredChatTerminalErrorTag = Exclude<
+  ChatTerminalError["_tag"],
+  (typeof CHAT_TERMINAL_ERRORS)[number]["_tag"]
+>;
+
 describe("isAnticipatedAIFailure", () => {
   test("exercises every HandlerError status", () => {
     // The guard is the annotation, which stops compiling while a status is
@@ -166,6 +183,25 @@ describe("isAnticipatedAIFailure", () => {
       const kind = classifyAIError(error);
 
       expect(isAnticipatedAIFailure(error, kind)).toBe(kind !== "unknown");
+    }
+  });
+
+  test("exercises every chat terminal error", () => {
+    const everyTerminalErrorCovered: [UncoveredChatTerminalErrorTag] extends [
+      never,
+    ]
+      ? true
+      : false = true;
+
+    expect(everyTerminalErrorCovered).toBe(true);
+  });
+
+  test("anticipates every terminal outcome the chat stream raises itself", () => {
+    // The stream models each of these and recovers from it, so none is a
+    // defect, including the ones the classifier cannot name: an error this
+    // service constructed carries no provider status to classify by.
+    for (const error of CHAT_TERMINAL_ERRORS) {
+      expect(isAnticipatedAIFailure(error, classifyAIError(error))).toBe(true);
     }
   });
 

--- a/apps/api/src/lib/ai-error.ts
+++ b/apps/api/src/lib/ai-error.ts
@@ -7,10 +7,14 @@
  * (and `chat-thread-messages.tsx`) together.
  */
 import {
+  ChatEmptyCompletionError,
   ChatLoopDetectedError,
   HandlerError,
 } from "@/api/lib/errors/tagged-errors";
-import type { HandlerErrorStatusCode } from "@/api/lib/errors/tagged-errors";
+import type {
+  ChatTerminalError,
+  HandlerErrorStatusCode,
+} from "@/api/lib/errors/tagged-errors";
 
 export const AI_ERROR_KINDS = [
   "quota_exhausted",
@@ -121,6 +125,21 @@ export const classifyAIError = (error: unknown): AIErrorKind => {
   return "unknown";
 };
 
+// Total over `ChatTerminalError`, so a new terminal outcome cannot be added to
+// that union without deciding how a failure sink grades it. Each guard is
+// wrapped because `is` reads the class off its receiver.
+const CHAT_TERMINAL_ERROR_GUARDS = {
+  ChatEmptyCompletionError: (error: unknown) =>
+    ChatEmptyCompletionError.is(error),
+  ChatLoopDetectedError: (error: unknown) => ChatLoopDetectedError.is(error),
+} as const satisfies Record<
+  ChatTerminalError["_tag"],
+  (error: unknown) => boolean
+>;
+
+const isChatTerminalError = (error: unknown): boolean =>
+  Object.values(CHAT_TERMINAL_ERROR_GUARDS).some((is) => is(error));
+
 /**
  * Whether a failure is one this service anticipated, so a telemetry sink can
  * record it as an operational state rather than a defect.
@@ -135,6 +154,13 @@ export const classifyAIError = (error: unknown): AIErrorKind => {
  * statuses, and falls through to `unknown`: "a shape this code does not
  * anticipate", the exact opposite of what it is.
  *
+ * A `ChatTerminalError` is invisible to the classifier for the same reason,
+ * and carries no status at all to fall back on: the chat stream constructs it
+ * for an outcome it models and recovers from, so it is anticipated whatever
+ * kind it classifies as. `ChatLoopDetectedError` already reaches
+ * `loop_detected`; without the union, its sibling empty completion would be
+ * the one modelled outcome graded as a defect.
+ *
  * The request layer already draws this line: `runSafeHandler` reports a
  * handler failure from 500 up and answers a 4xx as an ordinary response.
  */
@@ -143,6 +169,7 @@ export const isAnticipatedAIFailure = (
   kind: AIErrorKind,
 ): boolean =>
   kind !== "unknown" ||
+  isChatTerminalError(error) ||
   (HandlerError.is(error) && error.status < HTTP_SERVER_ERROR_MIN);
 
 type AIHandlerErrorFallback = {

--- a/apps/api/src/lib/errors/tagged-errors.ts
+++ b/apps/api/src/lib/errors/tagged-errors.ts
@@ -247,6 +247,17 @@ export class ChatLoopDetectedError extends TaggedError(
   message: string;
 }> {}
 
+/**
+ * Terminal outcomes the chat stream raises itself when a model attempt yields
+ * no usable assistant turn: an outcome it models, not a shape it failed to
+ * anticipate (an empty completion is even retried on the fallback model). A
+ * consumer that grades a failure has to treat the whole union that way; see
+ * `isAnticipatedAIFailure`.
+ */
+export type ChatTerminalError =
+  | ChatEmptyCompletionError
+  | ChatLoopDetectedError;
+
 /** Sandbox execution failure: transpile, runtime, limit, or marshalling. */
 export class SandboxError extends TaggedError("SandboxError")<{
   reason:


### PR DESCRIPTION
## Proposed change

`isAnticipatedAIFailure` decides whether a failed generation is recorded as an operational state or as a defect: both failure sinks (`reportStreamFailure` in `stream-chat.ts`, `tanstack_ai.generation.failed` in `analytics/tanstack-ai.ts`) log ERROR only for a shape the code did not anticipate. It anticipates a named `AIErrorKind`, plus a sub-500 `HandlerError`, and nothing else.

`classifyAIError` names a failure from the provider's HTTP status, so an error the chat stream constructs itself has nothing to be named by. `ChatLoopDetectedError` escapes that only because the classifier carries an explicit branch for it (`loop_detected`). `ChatEmptyCompletionError` is its sibling: same `ChatAttemptState`, same `chatAttemptTerminalError` accessor, and it is the one the stream actively recovers from by re-running the attempt on the fallback model. It has no branch, so it classifies `unknown` and is graded a defect: the only modelled chat outcome that is.

Reading the two together, the property that matters is not "which kinds are named" but "who raised the error". Both members of that union are outcomes the stream models, so:

- `ChatTerminalError` groups the two classes where they are declared.
- `chatAttemptTerminalError` returns it, replacing a hand-written union of the same two members, so producer and consumer share one definition.
- `isAnticipatedAIFailure` anticipates the union, through a guard map declared `as const satisfies Record<ChatTerminalError["_tag"], ...>`. A third terminal outcome therefore cannot be added without deciding how a failure sink grades it, rather than defaulting to "defect".

Behaviour change is limited to severity: an empty completion stops being logged at ERROR by `reportStreamFailure` and is logged at WARN by `tanstack_ai.generation.failed`. It is still captured (`recordChatAttemptFinish` already captures it with model, provider and thread context at construction), and the wire contract is untouched: the kind still crosses as `unknown` and the client renders the generic copy.

## Checklist

- [x] **BUILD ASSURANCE** | Code builds correctly and without any errors or warnings.
- [x] **TESTING** | Changes tested.
- [ ] DARK MODE SUPPORT | Not applicable: no UI surface.
- [ ] ISSUE LINKED | No issue.
- [ ] SCREENSHOT INCLUDED | Not applicable: no UI surface.

Verified locally, since a draft PR skips the repo's CI jobs:

- `bun test src/lib/ai-error.test.ts` (15 pass), `src/handlers/chat/stream-chat.test.ts` (38 pass), `src/lib/analytics src/lib/errors` (44 pass)
- `tsc --noEmit -p apps/api`, scoped `oxlint --type-aware --type-check --deny-warnings` on the four touched files, `bun run format`
- Checked that both totality guards bite: dropping `ChatLoopDetectedError` from the guard map fails to compile (`TS2741`), and dropping its instance from the test list fails the covered-tags alias.

---
_Generated by [Claude Code](https://claude.ai/code/session_0115bpg8pk9xhLkT2vbKHU1d)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of anticipated AI failures during chat interactions.
  * Empty completions and detected response loops are now recognised consistently, helping prevent these expected conditions from being treated as unexpected server errors.
* **Tests**
  * Added coverage to verify that all supported chat terminal errors are classified correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->