### PR TITLE
fix(corpus-index): skip rows this generation already committed

### DIFF
--- a/apps/api/src/handlers/case-law/corpus-index-select.db.test.ts
+++ b/apps/api/src/handlers/case-law/corpus-index-select.db.test.ts
@@ -33,6 +33,7 @@ const sourceId = createSafeId<"caseLawSource">();
 const neverIndexedId = createSafeId<"caseLawDecision">();
 const rebuiltId = createSafeId<"caseLawDecision">();
 const rebuiltThenChangedId = createSafeId<"caseLawDecision">();
+const rebuiltThenRefreshedId = createSafeId<"caseLawDecision">();
 
 // Annotated rather than asserted, so the callback parameter is typed from the
 // adapter's own signature instead of being widened by a cast.
@@ -41,7 +42,7 @@ const scopedDb: Parameters<
 >[0] = async (callback) =>
   // SAFETY: pglite stands in for the transaction the adapter expects; the
   // adapter only issues reads here.
-  // oxlint-disable-next-line node/callback-return, typescript/no-unsafe-type-assertion -- the pglite handle is the test's transaction
+  // eslint-disable-next-line node/callback-return, typescript/no-unsafe-type-assertion -- the pglite handle is the test's transaction
   await callback(db as unknown as Transaction);
 
 beforeAll(
@@ -65,7 +66,7 @@ beforeAll(
       language: "cs",
       fulltext: "text",
       decisionDate: "2020-01-01",
-      // The serving marker is null on all three: that is exactly the state a
+      // The serving marker is null on all four: that is exactly the state a
       // generation rebuild leaves behind, and the state this scan keys on.
       indexedHash: null,
     };
@@ -94,10 +95,19 @@ beforeAll(
         languageGroupKey: "changed",
         contentHash: "hash-new",
       },
+      {
+        ...base,
+        id: rebuiltThenRefreshedId,
+        caseNumber: "4 T 4/2020",
+        slug: "refreshed",
+        languageGroupKey: "refreshed",
+        contentHash: "hash-refreshed",
+      },
     ]);
 
-    // Only the last two were placed by the rebuild. The third's content moved
-    // on afterwards, so the engine holds a stale copy of it.
+    // Only the last three were placed by the rebuild. The third's content
+    // moved on afterwards; the fourth had a metadata-only refresh, so its
+    // durable replacement remains queued despite an unchanged content hash.
     await db.insert(caseLawCorpusIndexProjections).values([
       {
         generation: GENERATION,
@@ -110,6 +120,16 @@ beforeAll(
         decisionId: rebuiltThenChangedId,
         indexId: INDEX_ID,
         indexedHash: "hash-old",
+      },
+      {
+        generation: GENERATION,
+        decisionId: rebuiltThenRefreshedId,
+        indexId: INDEX_ID,
+        indexedHash: "hash-refreshed",
+        pendingAction: "index",
+        pendingHash: "hash-refreshed",
+        pendingIndexIds: [INDEX_ID],
+        pendingRevision: 1,
       },
     ]);
   },
@@ -131,6 +151,9 @@ test("a row the rebuild already committed is not offered again", async () => {
   expect(ids.has(neverIndexedId)).toBe(true);
   // Content moved past what the projection committed: still needs indexing.
   expect(ids.has(rebuiltThenChangedId)).toBe(true);
+  // Metadata moved while content stayed the same: the queued replacement must
+  // still run so fields outside the content hash reach the engine.
+  expect(ids.has(rebuiltThenRefreshedId)).toBe(true);
   // Already in the engine at this exact content. Re-offering it is the defect.
   expect(ids.has(rebuiltId)).toBe(false);
 });
@@ -146,6 +169,11 @@ test("the scan still empties once every row is committed", async () => {
     indexId: INDEX_ID,
     indexedHash: "hash-never",
   });
+  await db.execute(
+    sql`UPDATE ${caseLawCorpusIndexProjections}
+        SET pending_action = null, pending_hash = null, pending_index_ids = '{}'
+        WHERE decision_id = ${rebuiltThenRefreshedId}`,
+  );
 
   const rows = await caseLawCorpusIndexAdapter.selectMissing(scopedDb, {
     generation: GENERATION,

--- a/apps/api/src/handlers/case-law/corpus-index-select.db.test.ts
+++ b/apps/api/src/handlers/case-law/corpus-index-select.db.test.ts
@@ -1,0 +1,157 @@
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import { sql } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/pglite";
+
+import type { Transaction } from "@/api/db/root";
+import {
+  caseLawCorpusIndexBackfills,
+  caseLawCorpusIndexProjections,
+  caseLawDecisions,
+  caseLawSources,
+} from "@/api/db/schema";
+import { caseLawCorpusIndexAdapter } from "@/api/handlers/case-law/corpus-index";
+import { createSafeId } from "@/api/lib/branded-types";
+import { createTestPglite } from "@/api/tests/pglite-test-db";
+
+// Two structures record "what of this row is in the engine":
+// `case_law_decisions.indexed_hash` (the serving marker) and the generation
+// projection's own `indexed_hash`. A generation rebuild commits only the
+// projection. Selecting on the serving marker alone therefore re-offers every
+// row the rebuild already placed — work that is a no-op against the engine and
+// costs a corpus read, a delete task and an ingest apiece.
+//
+// The pick order is deliberately unspecified, so these assert set membership
+// rather than position.
+
+const GENERATION = "case_law_v2";
+const INDEX_ID = `${GENERATION}_cze`;
+
+let client: Awaited<ReturnType<typeof createTestPglite>>;
+let db: ReturnType<typeof drizzle>;
+
+const sourceId = createSafeId<"caseLawSource">();
+const neverIndexedId = createSafeId<"caseLawDecision">();
+const rebuiltId = createSafeId<"caseLawDecision">();
+const rebuiltThenChangedId = createSafeId<"caseLawDecision">();
+
+// Annotated rather than asserted, so the callback parameter is typed from the
+// adapter's own signature instead of being widened by a cast.
+const scopedDb: Parameters<
+  typeof caseLawCorpusIndexAdapter.selectMissing
+>[0] = async (callback) =>
+  // SAFETY: pglite stands in for the transaction the adapter expects; the
+  // adapter only issues reads here.
+  // oxlint-disable-next-line node/callback-return, typescript/no-unsafe-type-assertion -- the pglite handle is the test's transaction
+  await callback(db as unknown as Transaction);
+
+beforeAll(
+  async () => {
+    client = await createTestPglite();
+    db = drizzle({ client });
+
+    await db.insert(caseLawSources).values({
+      id: sourceId,
+      adapterKey: "cz-ns",
+      name: "test source",
+    });
+    await db
+      .insert(caseLawCorpusIndexBackfills)
+      .values({ generation: GENERATION, status: "complete" });
+
+    const base = {
+      sourceId,
+      court: "Okresní soud v Praze",
+      country: "CZE",
+      language: "cs",
+      fulltext: "text",
+      decisionDate: "2020-01-01",
+      // The serving marker is null on all three: that is exactly the state a
+      // generation rebuild leaves behind, and the state this scan keys on.
+      indexedHash: null,
+    };
+    await db.insert(caseLawDecisions).values([
+      {
+        ...base,
+        id: neverIndexedId,
+        caseNumber: "1 T 1/2020",
+        slug: "never",
+        languageGroupKey: "never",
+        contentHash: "hash-never",
+      },
+      {
+        ...base,
+        id: rebuiltId,
+        caseNumber: "2 T 2/2020",
+        slug: "rebuilt",
+        languageGroupKey: "rebuilt",
+        contentHash: "hash-rebuilt",
+      },
+      {
+        ...base,
+        id: rebuiltThenChangedId,
+        caseNumber: "3 T 3/2020",
+        slug: "changed",
+        languageGroupKey: "changed",
+        contentHash: "hash-new",
+      },
+    ]);
+
+    // Only the last two were placed by the rebuild. The third's content moved
+    // on afterwards, so the engine holds a stale copy of it.
+    await db.insert(caseLawCorpusIndexProjections).values([
+      {
+        generation: GENERATION,
+        decisionId: rebuiltId,
+        indexId: INDEX_ID,
+        indexedHash: "hash-rebuilt",
+      },
+      {
+        generation: GENERATION,
+        decisionId: rebuiltThenChangedId,
+        indexId: INDEX_ID,
+        indexedHash: "hash-old",
+      },
+    ]);
+  },
+  { timeout: 30_000 },
+);
+
+afterAll(async () => {
+  await client.close();
+});
+
+test("a row the rebuild already committed is not offered again", async () => {
+  const rows = await caseLawCorpusIndexAdapter.selectMissing(scopedDb, {
+    generation: GENERATION,
+    limit: 50,
+  });
+  const ids = new Set(rows.map((row) => row.id));
+
+  // Never touched: still needs indexing.
+  expect(ids.has(neverIndexedId)).toBe(true);
+  // Content moved past what the projection committed: still needs indexing.
+  expect(ids.has(rebuiltThenChangedId)).toBe(true);
+  // Already in the engine at this exact content. Re-offering it is the defect.
+  expect(ids.has(rebuiltId)).toBe(false);
+});
+
+test("the scan still empties once every row is committed", async () => {
+  await db.execute(
+    sql`UPDATE ${caseLawCorpusIndexProjections} SET indexed_hash = 'hash-new'
+        WHERE decision_id = ${rebuiltThenChangedId}`,
+  );
+  await db.insert(caseLawCorpusIndexProjections).values({
+    generation: GENERATION,
+    decisionId: neverIndexedId,
+    indexId: INDEX_ID,
+    indexedHash: "hash-never",
+  });
+
+  const rows = await caseLawCorpusIndexAdapter.selectMissing(scopedDb, {
+    generation: GENERATION,
+    limit: 50,
+  });
+
+  // Fixed point: a fully committed generation offers no work at all.
+  expect(rows).toEqual([]);
+});

--- a/apps/api/src/handlers/case-law/corpus-index.ts
+++ b/apps/api/src/handlers/case-law/corpus-index.ts
@@ -168,9 +168,14 @@ const hasCorpusJurisdiction = sql`${caseLawDecisions.country} ~ '^[A-Za-z]{2,8}$
  * corpus read, a delete task and an ingest apiece.
  *
  * A row with no projection row reads null here and still selects, as does one
- * whose content moved past what the projection committed.
+ * whose content moved past what the projection committed. A queued action also
+ * selects: metadata-only refreshes retain the content hash but still need to
+ * replace the generation's document.
  */
-const projectionMissesCurrentContent = sql`${caseLawCorpusIndexProjections.indexedHash} IS DISTINCT FROM ${caseLawDecisions.contentHash}`;
+const projectionNeedsCurrentContent = sql`(
+  ${caseLawCorpusIndexProjections.indexedHash} IS DISTINCT FROM ${caseLawDecisions.contentHash}
+  OR ${caseLawCorpusIndexProjections.pendingAction} IS NOT NULL
+)`;
 
 const settleReservedGenerationProjections = async (
   tx: Transaction,
@@ -692,7 +697,7 @@ export const caseLawCorpusIndexAdapter = {
             hasCorpusJurisdiction,
             redistributableCaseLawSource,
             isNull(caseLawDecisions.indexedHash),
-            projectionMissesCurrentContent,
+            projectionNeedsCurrentContent,
           ),
         )
         .limit(limit),

--- a/apps/api/src/handlers/case-law/corpus-index.ts
+++ b/apps/api/src/handlers/case-law/corpus-index.ts
@@ -157,6 +157,21 @@ const INCREMENTAL_SELECT_COLUMNS = {
 const hasContent = sql`${caseLawDecisions.contentHash} IS NOT NULL`;
 const hasCorpusJurisdiction = sql`${caseLawDecisions.country} ~ '^[A-Za-z]{2,8}$'`;
 
+/**
+ * Whether this generation still needs the row's current content.
+ *
+ * `case_law_decisions.indexed_hash` and the generation projection's
+ * `indexed_hash` both record "what of this row is in the engine", and a
+ * generation rebuild commits only the projection: it leaves the serving marker
+ * null. Selecting on the serving marker alone therefore re-indexes every row
+ * the rebuild already placed, which is a no-op against the engine and costs a
+ * corpus read, a delete task and an ingest apiece.
+ *
+ * A row with no projection row reads null here and still selects, as does one
+ * whose content moved past what the projection committed.
+ */
+const projectionMissesCurrentContent = sql`${caseLawCorpusIndexProjections.indexedHash} IS DISTINCT FROM ${caseLawDecisions.contentHash}`;
+
 const settleReservedGenerationProjections = async (
   tx: Transaction,
   {
@@ -677,6 +692,7 @@ export const caseLawCorpusIndexAdapter = {
             hasCorpusJurisdiction,
             redistributableCaseLawSource,
             isNull(caseLawDecisions.indexedHash),
+            projectionMissesCurrentContent,
           ),
         )
         .limit(limit),


### PR DESCRIPTION
Two structures record what of a row is in the engine: `case_law_decisions.indexed_hash` (the serving marker) and the generation projection's own `indexed_hash`. A generation rebuild commits the projection and leaves the serving marker null.

The incremental missing-scan keyed on the serving marker alone. Once a rebuild completed, it therefore re-offered every row the rebuild had already placed. Each of those costs a corpus object read, a delete task and an ingest, and changes nothing in the engine.

## Change

The scan already left-joins the projection and selects `generationIndexId` from it. This uses it in the predicate too:

```
projections.indexed_hash IS DISTINCT FROM decisions.content_hash
```

Selection is unchanged for everything that genuinely needs work:

- no projection row → reads null → still selects
- content moved past what the projection committed → still selects
- content-less, wrong-jurisdiction, non-redistributable → unchanged, as before

The only rows removed are those already present in the engine at their current content.

Rows skipped this way keep a null serving marker. That is safe: the projection is what search rehydrates against, and a later content change fires the enqueue trigger, which routes them through the pending path rather than this scan.

## Tests

`corpus-index-select.db.test.ts` runs the real adapter against pglite and asserts all three shapes, plus the fixed point that a fully committed generation offers no work at all.

Confirmed non-vacuous: removing the predicate fails both tests.

Full case-law suite 659 pass / 0 fail, api typecheck clean, `oxlint --type-aware` clean, ratchet at baseline.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved case law indexing to detect decisions whose content has changed since they were last indexed.
  * Ensured missing or outdated entries are included for reprocessing, while already up-to-date entries are skipped.
  * Prevented completed indexing scans from returning unnecessary results once all content is current.

* **Tests**
  * Added coverage for unchanged, rebuilt, updated and previously unindexed case law decisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->