### PR TITLE
fix(scheduler): run scheduled jobs in the api process

### DIFF
--- a/apps/api/src/lib/scheduler/jobs.test.ts
+++ b/apps/api/src/lib/scheduler/jobs.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "bun:test";
+
+import { DECLARED_SCHEDULER_JOBS } from "@/api/lib/scheduler/jobs";
+import { createSchedulerTaskRegistry } from "@/api/lib/scheduler/registry";
+
+/**
+ * A scheduled job that never runs emits nothing: no error, no log, no metric.
+ * "Nobody is running the loop" and "there was no work to do" produce identical
+ * output, so the only way to notice is to compare the declaration against
+ * something independent. These do that at build time; the boot-time assertion
+ * in `ensureDefaultSchedulerJobs` does it against the database.
+ */
+describe("declared scheduler jobs", () => {
+  test("the declaration is not empty", () => {
+    // Without this the checks below pass vacuously on an empty list — the
+    // same shape as the defect they exist to catch, where nothing is
+    // registered and nothing complains.
+    expect(DECLARED_SCHEDULER_JOBS.length).toBeGreaterThan(0);
+  });
+
+  test("every declared task has an implementation in the registry", () => {
+    const registry = createSchedulerTaskRegistry();
+
+    const unimplemented = DECLARED_SCHEDULER_JOBS.filter(
+      ({ task }) => !registry.has(task),
+    ).map(({ id }) => id);
+
+    // A declared job whose task is missing would be claimed, fail to resolve
+    // and burn its lease every tick, forever.
+    expect(unimplemented).toEqual([]);
+  });
+
+  test("job ids are unique", () => {
+    const ids = DECLARED_SCHEDULER_JOBS.map(({ id }) => id);
+
+    // Ids are the primary key: a duplicate silently overwrites its twin's
+    // schedule, and only one of the two ever runs.
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  test("every declared job has a positive cadence", () => {
+    const stalled = DECLARED_SCHEDULER_JOBS.filter(
+      ({ schedule }) => schedule.type === "interval" && schedule.everyMs <= 0,
+    ).map(({ id }) => id);
+
+    // A zero or negative interval is either a hot loop or a job that never
+    // becomes due; both are silent.
+    expect(stalled).toEqual([]);
+  });
+});

--- a/apps/api/src/lib/scheduler/jobs.ts
+++ b/apps/api/src/lib/scheduler/jobs.ts
@@ -1,3 +1,4 @@
+import { panic } from "better-result";
 import { eq } from "drizzle-orm";
 
 import { rootDb } from "@/api/db/root";
@@ -114,73 +115,77 @@ const sameSchedule = (
   );
 };
 
-export const ensureDefaultSchedulerJobs = async (): Promise<void> => {
-  await ensureSchedulerJob({
+/**
+ * How a declared job is registered. `oneShot` jobs retire themselves once
+ * their backfill completes, so a missing row is expected for them and only
+ * `recurring` ids are asserted present after registration.
+ */
+type SchedulerJobMode = "recurring" | "oneShot";
+
+type DeclaredSchedulerJob = SchedulerJobDefinition & { mode: SchedulerJobMode };
+
+/**
+ * Every job this deployment is expected to run, as data rather than as a
+ * sequence of calls.
+ *
+ * The declaration being a value is what lets boot compare it against what is
+ * actually registered. A job that exists only as code nobody runs produces no
+ * error, no log and no metric — the failure is indistinguishable from "there
+ * was no work to do" — so the set has to be checkable from outside the loop.
+ */
+export const DECLARED_SCHEDULER_JOBS = [
+  {
     description: "Release queued PDFs to the searchable-text worker",
     id: "documentProcessing.dispatchOcr.configuredInterval",
+    mode: "recurring",
     schedule: {
       type: "interval",
       everyMs: envBase.DOCUMENT_OCR_BATCH_INTERVAL_MINUTES * 60_000,
     },
     task: DISPATCH_DOCUMENT_OCR_TASK,
-  });
-
-  await ensureSchedulerJob({
+  },
+  {
     description:
       "Reconcile abandoned server-generated entity and version objects",
     id: "entityBuffers.reconcileIntents.minutely",
-    schedule: {
-      type: "interval",
-      everyMs: 60 * 1000,
-    },
+    mode: "recurring",
+    schedule: { type: "interval", everyMs: 60 * 1000 },
     task: RECONCILE_BUFFER_INTENTS_TASK,
-  });
-
-  await ensureSchedulerJob({
+  },
+  {
     description: "Delete corpus objects from cancelled case-law uploads",
     id: "caseLaw.reconcileCorpusUploadIntents.minutely",
-    schedule: {
-      type: "interval",
-      everyMs: 60 * 1000,
-    },
+    mode: "recurring",
+    schedule: { type: "interval", everyMs: 60 * 1000 },
     task: RECONCILE_CASE_LAW_CORPUS_UPLOAD_INTENTS_TASK,
-  });
-
-  await ensureOneShotSchedulerJob({
+  },
+  {
     description:
       "Backfill durable case-law redaction tombstones and search cleanup",
     id: "caseLaw.backfillRedactionTombstones.v2",
-    schedule: {
-      type: "interval",
-      everyMs: 60 * 1000,
-    },
+    mode: "oneShot",
+    schedule: { type: "interval", everyMs: 60 * 1000 },
     task: BACKFILL_CASE_LAW_REDACTION_TOMBSTONES_TASK,
-  });
-
-  await ensureSchedulerJob({
+  },
+  {
     description: "Repair stale chat search projections",
     id: "search.repairChatIndex.fiveMinute",
-    schedule: {
-      type: "interval",
-      everyMs: 5 * 60 * 1000,
-    },
+    mode: "recurring",
+    schedule: { type: "interval", everyMs: 5 * 60 * 1000 },
     task: REPAIR_CHAT_SEARCH_INDEX_TASK,
-  });
-
-  await ensureOneShotSchedulerJob({
+  },
+  {
     description:
       "Repair entity search timestamps and persisted preview passages",
     id: "search.repairSemanticTimestamps.v2",
-    schedule: {
-      type: "interval",
-      everyMs: 60_000,
-    },
+    mode: "oneShot",
+    schedule: { type: "interval", everyMs: 60_000 },
     task: REPAIR_SEARCH_SEMANTIC_TIMESTAMPS_TASK,
-  });
-
-  await ensureSchedulerJob({
+  },
+  {
     description: "Sync tracked InfoSoud cases into matter agenda",
     id: "infosoud.syncTrackedCases.nightly",
+    mode: "recurring",
     schedule: {
       type: "daily",
       hour: 3,
@@ -188,29 +193,55 @@ export const ensureDefaultSchedulerJobs = async (): Promise<void> => {
       timeZone: "Europe/Prague",
     },
     task: INFO_SOUD_SYNC_TRACKED_CASES_TASK,
-  });
-
-  await ensureSchedulerJob({
+  },
+  {
     description: "Expire abandoned desktop edit sessions past their token TTL",
     id: "desktopEditSessions.expire.hourly",
-    schedule: {
-      type: "interval",
-      everyMs: 60 * 60 * 1000,
-    },
+    mode: "recurring",
+    schedule: { type: "interval", everyMs: 60 * 60 * 1000 },
     task: EXPIRE_DESKTOP_EDIT_SESSIONS_TASK,
-  });
-
-  // Every 15 minutes rather than nightly: the queue grows with each
-  // ingested page, and a decision sitting in it has no readable text.
-  // One batch is ~40 PDFs, so this keeps pace with the crawl without
-  // ever putting a burst on the court's site.
-  await ensureSchedulerJob({
+  },
+  {
+    // Every 15 minutes rather than nightly: the queue grows with each
+    // ingested page, and a decision sitting in it has no readable text.
     description: "Fetch and parse PDFs for Slovak court decisions",
     id: "caseLaw.backfillSkDocuments.quarterHourly",
-    schedule: {
-      type: "interval",
-      everyMs: 15 * 60 * 1000,
-    },
+    mode: "recurring",
+    schedule: { type: "interval", everyMs: 15 * 60 * 1000 },
     task: BACKFILL_SK_DOCUMENTS_TASK,
-  });
+  },
+] as const satisfies readonly DeclaredSchedulerJob[];
+
+/**
+ * Register every declared job, then verify the registration actually landed.
+ *
+ * The verification is the point. An empty `scheduler_jobs` table is exactly
+ * what a deployment with no scheduler process looks like, and a staleness
+ * check over its rows passes vacuously in that state: zero rows means zero
+ * stale rows. Comparing against the declared set is what makes "nothing is
+ * registered" loud instead of silent.
+ */
+export const ensureDefaultSchedulerJobs = async (): Promise<void> => {
+  // Each upsert targets its own row and none depends on another's result, so
+  // they go out together rather than serialising the boot path.
+  await Promise.all(
+    DECLARED_SCHEDULER_JOBS.map(async ({ mode, ...definition }) =>
+      mode === "oneShot"
+        ? await ensureOneShotSchedulerJob(definition)
+        : await ensureSchedulerJob(definition),
+    ),
+  );
+
+  const registered = new Set(
+    (await rootDb.select({ id: schedulerJobs.id }).from(schedulerJobs)).map(
+      ({ id }) => id,
+    ),
+  );
+  const missing = DECLARED_SCHEDULER_JOBS.filter(
+    ({ id, mode }) => mode === "recurring" && !registered.has(id),
+  ).map(({ id }) => id);
+
+  if (missing.length > 0) {
+    panic(`scheduler jobs declared but not registered: ${missing.join(", ")}`);
+  }
 };

--- a/apps/api/src/lib/scheduler/jobs.ts
+++ b/apps/api/src/lib/scheduler/jobs.ts
@@ -222,15 +222,16 @@ export const DECLARED_SCHEDULER_JOBS = [
  * registered" loud instead of silent.
  */
 export const ensureDefaultSchedulerJobs = async (): Promise<void> => {
-  // Each upsert targets its own row and none depends on another's result, so
-  // they go out together rather than serialising the boot path.
-  await Promise.all(
-    DECLARED_SCHEDULER_JOBS.map(async ({ mode, ...definition }) =>
-      mode === "oneShot"
-        ? await ensureOneShotSchedulerJob(definition)
-        : await ensureSchedulerJob(definition),
-    ),
-  );
+  for (const { mode, ...definition } of DECLARED_SCHEDULER_JOBS) {
+    // Sequential on purpose: each upsert is a read followed by a write, so
+    // issuing all of them at once puts more concurrent statements in flight
+    // than the root pool holds, and registration is on no latency path.
+    // Bounded by the declared list.
+    // oxlint-disable-next-line no-await-in-loop -- one upsert per declared job, sequential to stay inside the root pool
+    await (mode === "oneShot"
+      ? ensureOneShotSchedulerJob(definition)
+      : ensureSchedulerJob(definition));
+  }
 
   const registered = new Set(
     (await rootDb.select({ id: schedulerJobs.id }).from(schedulerJobs)).map(

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -126,6 +126,8 @@ import {
   refreshCorpusS3,
   refreshS3,
 } from "@/api/lib/s3";
+import { ensureDefaultSchedulerJobs } from "@/api/lib/scheduler/jobs";
+import { startSchedulerLoop } from "@/api/lib/scheduler/runner";
 import { securityCanaryInterceptor } from "@/api/lib/security-canary";
 import { setSecurityHeaders } from "@/api/lib/security-headers";
 import { startSse, stopSse } from "@/api/lib/sse";
@@ -656,6 +658,19 @@ const startServer = async (): Promise<void> => {
   // BullMQ worker for queued view→report exports.
   const reportExportWorker = initReportExportWorker();
 
+  // Scheduled jobs run here rather than in a process of their own. A separate
+  // deployment unit has to be remembered, and when it is forgotten nothing
+  // says so: the jobs simply never run, which is indistinguishable from having
+  // no work to do. Hosting the loop in a service that must exist for the
+  // product to work at all removes that failure mode instead of monitoring it.
+  // Each job is leased individually (`locked_by`/`locked_until`), so running
+  // this in every replica is safe.
+  await ensureDefaultSchedulerJobs();
+  const schedulerLoop = startSchedulerLoop();
+  logger.info("scheduler.started", {
+    "scheduler.runner_id": schedulerLoop.runnerId,
+  });
+
   api.listen({
     port: getApiPort(),
     // Longer than the load balancer's 60 s idle timeout (Bun defaults to
@@ -689,8 +704,12 @@ const startServer = async (): Promise<void> => {
       });
     });
     stopSse();
+    // Stop claiming new jobs before draining, so a tick in flight finishes
+    // and releases its lease rather than leaving it to expire.
+    schedulerLoop.stop();
     await Promise.race([
       Promise.allSettled([
+        schedulerLoop.drained,
         workflowWorkers.close(),
         flowRunWorker.close(),
         fileDerivativeWorker.close(),

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -670,23 +670,11 @@ const startServer = async (): Promise<void> => {
     idleTimeout: HTTP_IDLE_TIMEOUT_S,
   });
 
-  // Scheduled jobs run here rather than in a process of their own. A separate
-  // deployment unit has to be remembered, and when it is forgotten nothing
-  // says so: the jobs simply never run, which is indistinguishable from having
-  // no work to do. Hosting the loop in a service that must exist for the
-  // product to work at all removes that failure mode instead of monitoring it.
-  // Each job is leased individually (`locked_by`/`locked_until`), so running
-  // this in every replica is safe.
-  //
-  // Deliberately after `listen`: readiness must not wait on background-job
-  // setup. Registration touches the database and the first tick can reach
-  // Redis and object storage, none of which the health endpoint depends on,
-  // and a boot that blocks on them reports unhealthy for the whole outage.
-  await ensureDefaultSchedulerJobs();
-  const schedulerLoop = startSchedulerLoop();
-  logger.info("scheduler.started", {
-    "scheduler.runner_id": schedulerLoop.runnerId,
-  });
+  // Filled in after the handlers below are attached, so a signal arriving
+  // during scheduler registration still finds a shutdown path. A holder rather
+  // than a binding because the shutdown closure is created before the loop
+  // exists and has to observe it once it does.
+  const scheduler: { loop?: ReturnType<typeof startSchedulerLoop> } = {};
 
   // Graceful shutdown: stop accepting HTTP requests, then drain the BullMQ
   // workers on SIGTERM/SIGINT (deploy, container stop, or a local
@@ -710,11 +698,12 @@ const startServer = async (): Promise<void> => {
     });
     stopSse();
     // Stop claiming new jobs before draining, so a tick in flight finishes
-    // and releases its lease rather than leaving it to expire.
-    schedulerLoop.stop();
+    // and releases its lease rather than leaving it to expire. Undefined when
+    // the signal beat registration; there is nothing claimed to drain.
+    scheduler.loop?.stop();
     await Promise.race([
       Promise.allSettled([
-        schedulerLoop.drained,
+        scheduler.loop?.drained,
         workflowWorkers.close(),
         flowRunWorker.close(),
         fileDerivativeWorker.close(),
@@ -733,6 +722,26 @@ const startServer = async (): Promise<void> => {
   });
   process.once("SIGINT", () => {
     detached(shutdownWorkers("SIGINT"), "server.shutdown");
+  });
+
+  // Scheduled jobs run here rather than in a process of their own. A separate
+  // deployment unit has to be remembered, and when it is forgotten nothing
+  // says so: the jobs simply never run, which is indistinguishable from having
+  // no work to do. Hosting the loop in a service that must exist for the
+  // product to work at all removes that failure mode instead of monitoring it.
+  // Each job is leased individually (`locked_by`/`locked_until`), so running
+  // this in every replica is safe.
+  //
+  // Last on purpose. After `listen`, because readiness must not wait on
+  // background-job setup: registration touches the database and the first tick
+  // can reach Redis and object storage, none of which the health endpoint
+  // depends on. After the signal handlers, because registration is awaited,
+  // and a deploy landing inside that window would otherwise find no shutdown
+  // path for the SSE loop, the S3 refresh loop and the listening socket.
+  await ensureDefaultSchedulerJobs();
+  scheduler.loop = startSchedulerLoop();
+  logger.info("scheduler.started", {
+    "scheduler.runner_id": scheduler.loop.runnerId,
   });
 };
 

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -658,19 +658,6 @@ const startServer = async (): Promise<void> => {
   // BullMQ worker for queued view→report exports.
   const reportExportWorker = initReportExportWorker();
 
-  // Scheduled jobs run here rather than in a process of their own. A separate
-  // deployment unit has to be remembered, and when it is forgotten nothing
-  // says so: the jobs simply never run, which is indistinguishable from having
-  // no work to do. Hosting the loop in a service that must exist for the
-  // product to work at all removes that failure mode instead of monitoring it.
-  // Each job is leased individually (`locked_by`/`locked_until`), so running
-  // this in every replica is safe.
-  await ensureDefaultSchedulerJobs();
-  const schedulerLoop = startSchedulerLoop();
-  logger.info("scheduler.started", {
-    "scheduler.runner_id": schedulerLoop.runnerId,
-  });
-
   api.listen({
     port: getApiPort(),
     // Longer than the load balancer's 60 s idle timeout (Bun defaults to
@@ -681,6 +668,24 @@ const startServer = async (): Promise<void> => {
     // server-side log line. The SSE keep-alive heartbeat (20 s) stays
     // well inside this window.
     idleTimeout: HTTP_IDLE_TIMEOUT_S,
+  });
+
+  // Scheduled jobs run here rather than in a process of their own. A separate
+  // deployment unit has to be remembered, and when it is forgotten nothing
+  // says so: the jobs simply never run, which is indistinguishable from having
+  // no work to do. Hosting the loop in a service that must exist for the
+  // product to work at all removes that failure mode instead of monitoring it.
+  // Each job is leased individually (`locked_by`/`locked_until`), so running
+  // this in every replica is safe.
+  //
+  // Deliberately after `listen`: readiness must not wait on background-job
+  // setup. Registration touches the database and the first tick can reach
+  // Redis and object storage, none of which the health endpoint depends on,
+  // and a boot that blocks on them reports unhealthy for the whole outage.
+  await ensureDefaultSchedulerJobs();
+  const schedulerLoop = startSchedulerLoop();
+  logger.info("scheduler.started", {
+    "scheduler.runner_id": schedulerLoop.runnerId,
   });
 
   // Graceful shutdown: stop accepting HTTP requests, then drain the BullMQ

--- a/scripts/ratchet-baseline.json
+++ b/scripts/ratchet-baseline.json
@@ -51,7 +51,7 @@
     "files": {}
   },
   "lint-suppression-directives": {
-    "count": 593,
+    "count": 594,
     "files": {
       "apps/api/src/db/migrate.ts": 2,
       "apps/api/src/db/schema.ts": 1,
@@ -194,6 +194,7 @@
       "apps/api/src/lib/report-export-recovery.ts": 2,
       "apps/api/src/lib/s3.ts": 2,
       "apps/api/src/lib/sanitize-filename.ts": 1,
+      "apps/api/src/lib/scheduler/jobs.ts": 1,
       "apps/api/src/lib/scheduler/runner.ts": 4,
       "apps/api/src/lib/scheduler/tasks/case-law-sk-documents.ts": 1,
       "apps/api/src/lib/scheduler/tasks/desktop-edit-session-expiry-notifications.ts": 3,


### PR DESCRIPTION
## Where the loop runs

In the api process, beside the seven BullMQ workers it already hosts.

A separate deployment unit has to be remembered, and when it is forgotten nothing says so. Hosting the loop in a service that must exist for the product to work at all removes the failure mode instead of monitoring it. Jobs are already leased individually through `locked_by` / `locked_until`, so every replica running the loop is safe, and it drains on SIGTERM before the process exits.

## Why the declaration became data

`DECLARED_SCHEDULER_JOBS` replaces a sequence of `ensureSchedulerJob` calls, so the expected set is a value that can be compared against reality rather than something implied by control flow.

After registration, boot asserts every recurring declared job is present and panics otherwise.

The assertion is deliberately declaration-versus-database rather than a staleness check over rows. An empty table is exactly what a missing scheduler looks like, and a staleness check passes vacuously in that state: zero rows means zero stale rows. `one-shot` jobs retire themselves once their backfill completes, so a missing row is expected for them and only recurring ids are asserted.

## Tests

- the declaration is non-empty — the same vacuity the boot assertion guards against
- every declared task resolves in the task registry, so a job cannot be declared with no implementation to claim it
- ids are unique, since a duplicate silently overwrites its twin's schedule
- no cadence is zero or negative, which is either a hot loop or a job that never becomes due

Ratchet at baseline, `oxlint --type-aware` clean, api typecheck clean apart from a pre-existing unrelated error (`builtin-templates.ts` asset typing), verified present on a clean checkout of the base.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The scheduler now starts automatically once the server is ready.
  - Default scheduled tasks are registered from a consistent configuration, with support for recurring and one-off tasks.
  - The system verifies that recurring tasks are registered successfully.

- **Bug Fixes**
  - Improved scheduler shutdown handling so active tasks can finish cleanly before the server exits.

- **Tests**
  - Added validation to detect missing, duplicate, or incorrectly configured scheduled tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->