### PR TITLE
chore(ci): bound Scorecard runtime and skip the scan on a hung checkout

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -14,6 +14,8 @@ permissions: read-all
 jobs:
   scorecard:
     runs-on: ubuntu-latest
+    # Backstop against a wedged runner squatting the default 6h budget.
+    timeout-minutes: 15
     permissions:
       # Required to checkout the repository
       contents: read
@@ -22,19 +24,32 @@ jobs:
       # Required for the GITHUB_TOKEN to make API calls
       id-token: write
     steps:
+      # A hung checkout is a runner/network fault, not a scan result, so it
+      # skips the scan instead of failing the run. The scan steps below still
+      # report failures normally.
       - name: Checkout
+        id: checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        timeout-minutes: 5
+        continue-on-error: true
         with:
           persist-credentials: false
 
+      - name: Report skipped scan
+        if: steps.checkout.outcome != 'success'
+        run: echo "::warning::Checkout did not complete; skipping the Scorecard scan for this commit."
+
       - name: Run OpenSSF Scorecard
+        if: steps.checkout.outcome == 'success'
         uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
+        timeout-minutes: 10
         with:
           results_file: results.sarif
           results_format: sarif
           publish_results: true
 
       - name: Upload SARIF to GitHub Security tab
+        if: steps.checkout.outcome == 'success'
         uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
The Scorecard job declares no timeout, so a checkout that never completes
holds the runner for the default six-hour budget and then fails the run,
reporting a runner fault as a scan result.

- Cap the job at 15 minutes and the checkout step at 5.
- Gate the scan steps on the checkout outcome, so an incomplete checkout
  skips them and records a warning annotation instead of failing.

Scorecard and SARIF upload failures still fail the run. GitHub Actions does
not distinguish a step timeout from a step failure, so a Scorecard step that
hangs past its 10-minute cap still reports as a failure; making that case
non-blocking would also silence genuine scan failures.

The workflow triggers on push to main, so this branch cannot exercise it.
After merge: `gh workflow run scorecard.yml`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved security scan workflow reliability with defined time limits.
  * Added clearer warnings when repository checkout is skipped or unsuccessful.
  * Ensured scans and result uploads run only after a successful checkout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->