### PR TITLE
chore(ci): bump the shared release workflow to v1.7.0

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -358,7 +358,7 @@ jobs:
       contents: write # Create immutable package tags and GitHub releases.
       id-token: write # Exchange a short-lived npm trusted-publishing credential.
     # The repository owner publishes this versioned shared contract.
-    uses: stella/.github/.github/workflows/npm-independent-release.yml@v1.6.0 # zizmor: ignore[unpinned-uses]
+    uses: stella/.github/.github/workflows/npm-independent-release.yml@v1.7.0 # zizmor: ignore[unpinned-uses]
     with:
       artifact-pattern: npm-tarball-*
       package-files: ${{ needs.pack.outputs.package_files }}


### PR DESCRIPTION
## Why

The shared release action re-reads `releases?per_page=100` through `gh api --paginate` immediately after creating its draft releases, and failed hard if one `tag_name` appeared twice across pages.

Once a repository holds more than one page of releases, that condition is reachable: a draft becoming visible between two page requests shifts every later entry down one position, so the entry sitting on the page boundary is returned on both pages. The action treated that as a duplicate release and stopped the publish after tagging and staging, with nothing on npm.

`stella/.github` v1.7.0 distinguishes the two cases by release id. The same release seen twice is tolerated and the action's existing bounded backoff absorbs the shift; two distinct releases sharing one tag still fails, because publishing an arbitrary one of them is not a safe choice.

This repository has 80 releases, so it has not hit the boundary yet. Bumping now rather than at 101.

## Change

Bumps `npm-independent-release.yml` from v1.7.0's predecessor tag to v1.7.0, keeping the version-tag reference this contract already uses.

v1.7.0 also carries what was unreleased on the shared repository's default branch: a Dependabot actions bump, a code of conduct, label-manifest reorganisation, a `setup-bun-cached` composite action, and a PR-title rule. None of them touch this repository's release path.

## Verification

The workflow only runs on a release commit, so there is nothing to exercise before merge. The fix is covered upstream by tests for both the tolerated repeat and the still-rejected genuine duplicate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release automation to use the latest shared publishing workflow.
  * No changes to release behaviour are expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->