### PR TITLE
fix(observability): mirror every structured record above debug to the stream

### DIFF
--- a/apps/api/src/lib/observability/logger.test.ts
+++ b/apps/api/src/lib/observability/logger.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, test } from "bun:test";
 
+import type { LoggerAttributes } from "@/api/lib/observability/logger";
 import { logger, sanitizeLogAttributes } from "@/api/lib/observability/logger";
 
 const originalStderrWrite = process.stderr.write;
@@ -69,6 +70,46 @@ describe("logger attributes", () => {
     expect(output).not.toContain("secret.pdf");
     expect(output).not.toContain("fileName");
     expect(output).not.toContain('"body"');
+  });
+
+  // A record that reaches no sink is indistinguishable from one that was
+  // never emitted, so every severity needs a stated disposition rather than
+  // one example per direction. `satisfies` over the logger's own severity
+  // methods keeps the map total: a new method fails to typecheck until
+  // someone decides whether it is readable in the deployed runtime.
+  // Each entry carries its own emitter, so the loop iterates the map rather
+  // than a parallel list of names that could drift away from it.
+  const STREAM_DISPOSITION = {
+    debug: { emit: logger.debug, reaches: "no-sink" },
+    error: { emit: logger.error, reaches: "stream" },
+    info: { emit: logger.info, reaches: "stream" },
+    warn: { emit: logger.warn, reaches: "stream" },
+  } as const satisfies Record<
+    Exclude<keyof typeof logger, "request">,
+    {
+      emit: (message: string, attributes?: LoggerAttributes) => void;
+      reaches: "no-sink" | "stream";
+    }
+  >;
+
+  test("mirrors every severity above debug to the stream, and only those", () => {
+    for (const { emit, reaches } of Object.values(STREAM_DISPOSITION)) {
+      const chunks: string[] = [];
+      process.stderr.write = (chunk: string | Uint8Array): boolean => {
+        chunks.push(typeof chunk === "string" ? chunk : chunk.toString());
+        return true;
+      };
+
+      emit("test.event", { "http.route": "/test" });
+
+      const output = chunks.join("");
+      if (reaches === "stream") {
+        expect(output).toContain('"message":"test.event"');
+        expect(output).toContain('"http.route":"/test"');
+      } else {
+        expect(output).toBe("");
+      }
+    }
   });
 
   test("request sink emits only structured operational fields", () => {

--- a/apps/api/src/lib/observability/logger.ts
+++ b/apps/api/src/lib/observability/logger.ts
@@ -100,13 +100,22 @@ const emit = ({
     otelLogger.emit(record);
   }
 
-  // Stdout backstop for ERROR records. The OTel pipeline above
-  // can be wired to a remote exporter later; until it is, this
-  // mirrors ERROR records to stdout so incidents are debuggable
-  // from the runtime's standard log stream. ERROR-only by
-  // default keeps volume small and avoids surfacing request
-  // payloads that might appear at lower severities.
-  if (severityNumber === SeverityNumber.ERROR) {
+  // Backstop for every structured record above DEBUG. The OTel pipeline
+  // above deliberately has no exporter (see `otel.ts`), so this stream is
+  // the only place a record is readable at all.
+  //
+  // Severity answers how bad a record is. It must not also decide whether
+  // anyone can ever read it: an INFO or WARN record that reaches no sink is
+  // indistinguishable from one that was never emitted, and a consumer built
+  // on it silently measures nothing. This previously mirrored ERROR alone,
+  // which made every structured non-error event invisible in the deployed
+  // runtime while looking healthy in the source.
+  //
+  // Payload exposure is handled one layer down: `sanitizeLogAttributes`
+  // drops payload- and credential-shaped keys from every record regardless
+  // of severity, so severity was never what kept payloads out. DEBUG stays
+  // unmirrored as the escape hatch for hot loops.
+  if (severityNumber >= SeverityNumber.INFO) {
     process.stderr.write(
       `${JSON.stringify({
         severity: severityText,


### PR DESCRIPTION
`lib/observability/otel.ts` deliberately configures no external log exporter, so the process stream is the only place a log record can be read. `emit()` mirrored a record there only when its severity was ERROR, which meant every structured info and warning event was unreadable in the deployed runtime while looking perfectly healthy in the source.

That is around fifty event names. Two worth naming: `scheduler.started`, and the case-law citation-recall measurement — whose consumer therefore measured nothing, and could not distinguish that from a clean result.

Severity answers how bad a record is. It must not also decide whether anyone can ever read it: a record that reaches no sink is indistinguishable from one that was never emitted. This mirrors INFO and above and keeps DEBUG as the escape hatch for hot loops (`case_law.ingestion.page_completed` is the obvious candidate if volume bites).

### On the rationale being replaced

The old comment justified ERROR-only as keeping request payloads out of the stream. That reasoning no longer holds on two counts:

- `sanitizeLogAttributes` already drops payload- and credential-shaped keys (`body|content|email|fileName|message|name|title|password|secret|credential|authorization|cookie|bearer|api[_-]?key|prompt|snippet|subject|phone`) from **every** record regardless of severity. Severity was never what kept payloads out.
- `emitRequest` already writes every request log to the stream at all severities, so the restriction was not even applied consistently.

### Test

The disposition is stated per severity as a total map over the logger's own methods, so a new logger method cannot be added without deciding whether its records are readable. Each entry carries its own emitter, so the loop iterates the map rather than a parallel list of names that could drift from it.

Verified non-vacuous: reverting the condition to `=== SeverityNumber.ERROR` fails the test with `Expected to contain: "message":"test.event" / Received: ""`.

The trade-off is CloudWatch ingest volume, which is the reason DEBUG stays unmirrored.