### PR TITLE
fix(lint): load oxlint plugins under Node as well as Bun

### DIFF
--- a/.oxlint-plugins/no-physical-properties.ts
+++ b/.oxlint-plugins/no-physical-properties.ts
@@ -8,7 +8,11 @@
 //
 // Replaces: scripts/lint-logical-properties.sh
 
-import { hasPhysicalProperty } from "./physical-properties";
+// Extension is required, not stylistic. Plugin sources are loaded by Node's
+// ESM resolver as well as Bun's, and Node does not infer one. Without it the
+// whole plugin set fails to load under Node, and the error names this file's
+// import rather than whatever the caller was linting.
+import { hasPhysicalProperty } from "./physical-properties.ts";
 
 export default {
   meta: { name: "no-physical-properties" },

--- a/scripts/lint-oxlint-fixtures.sh
+++ b/scripts/lint-oxlint-fixtures.sh
@@ -11,6 +11,31 @@
 # in turbo's affected-packages graph.
 set -euo pipefail
 
+# Plugin sources have to load under Node's ESM resolver, not only Bun's.
+#
+# The lint below runs them through `bun --bun`, which infers a missing file
+# extension on a relative import. `node_modules/.bin/oxlint` is a Node shim and
+# does not, so a plugin importing a sibling without its extension loads in one
+# invocation and not the other. That asymmetry is expensive to meet in the
+# wild: the whole plugin set fails at config-parse time, and the error names
+# the offending import rather than whatever was being linted, which reads like
+# a broken toolchain rather than a one-character omission.
+#
+# Lint target is irrelevant — plugins load while the config is parsed, so any
+# file exercises it. The lint result is discarded on purpose; only the loader
+# is under test here.
+plugin_load_output=$(./node_modules/.bin/oxlint \
+  .oxlint-plugins/physical-properties.ts 2>&1 || true)
+
+if grep -qE "Failed to load JS plugin|ERR_MODULE_NOT_FOUND" \
+  <<<"$plugin_load_output"; then
+  echo "An oxlint plugin does not load under Node." >&2
+  echo "Usual cause: a relative import missing its file extension." >&2
+  echo "" >&2
+  echo "$plugin_load_output" >&2
+  exit 1
+fi
+
 exec bun --bun oxlint -c oxlint.config.ts \
   --report-unused-disable-directives-severity=error \
   --deny-warnings \


### PR DESCRIPTION
`.oxlint-plugins/no-physical-properties.ts` imported a sibling helper without its file extension. Bun infers one; Node does not.

Plugins are loaded while the config is parsed, so that single import decides whether the **whole set** loads. Through `bun --bun oxlint` it does. Through `node_modules/.bin/oxlint`, which is a Node shim, it does not:

```
x Failed to load JS plugin: ./.oxlint-plugins/no-physical-properties.ts
| Error [ERR_MODULE_NOT_FOUND]: Cannot find module '.../.oxlint-plugins/physical-properties'
|   imported from '.../.oxlint-plugins/no-physical-properties.ts'
```

The failure is expensive to meet because of how it reads. It names an import in a file the caller never touched, not the file being linted, and it arrives as `Failed to parse oxlint configuration file`. Nothing points at the one-character cause, and the reasonable-looking conclusion is that linting is unavailable in this checkout — so it gets skipped.

## Change

Add the extension. `allowImportingTsExtensions` is already set for the plugins project, so this typechecks unchanged.

Guard the property in `scripts/lint-oxlint-fixtures.sh`, which already owns "the plugins work" and already runs in root `lint`: load the set through the Node shim before linting the fixtures, and fail with the cause named.

The lint target for that probe is irrelevant and its result is discarded — plugins load at config-parse time, so any file exercises the loader, and only the loader is under test.

## Verification

- Harness exits 0 with the extension present.
- Confirmed non-vacuous: with the extension removed the harness fails with `An oxlint plugin does not load under Node. / Usual cause: a relative import missing its file extension.`
- `tsc-native --noEmit -p tsconfig.oxlint-plugins.json` clean.
- One other extensionless relative import exists under `.oxlint-plugins/`, inside a comment, so this was the only live instance.
