### PR TITLE
fix(auth): give the session cookie name a single owner

### DIFF
--- a/apps/api/scripts/seed-test-user.ts
+++ b/apps/api/scripts/seed-test-user.ts
@@ -26,6 +26,7 @@ import path from "node:path";
 import { member, organization, session, user } from "@/api/db/auth-schema";
 import { rootDb } from "@/api/db/root";
 import { env } from "@/api/env";
+import { sessionCookieName } from "@/api/lib/auth-cookie-name";
 import { toSafeId } from "@/api/lib/branded-types";
 import { ensureDefaultDocumentTypes } from "@/api/lib/document-types/defaults";
 
@@ -70,9 +71,7 @@ const now = new Date();
 const DEFAULT_MEMBER_ROLE = "member" as const;
 const OWNER_MEMBER_ROLE = "owner" as const;
 
-const AUTH_COOKIE_NAME = `${
-  env.BETTER_AUTH_COOKIE_PREFIX ?? (env.isDev ? "stella-dev" : "better-auth")
-}.session_token`;
+const AUTH_COOKIE_NAME = sessionCookieName();
 
 const getSeedOrganizationIdentity = (organizationId: string) => {
   if (organizationId === TEST_ORG.id) {

--- a/apps/api/src/lib/agent-auth.ts
+++ b/apps/api/src/lib/agent-auth.ts
@@ -17,6 +17,7 @@ import { oauthClient, session, user } from "@/api/db/auth-schema";
 import { rootDb } from "@/api/db/root";
 import { env } from "@/api/env";
 import { getAuth } from "@/api/lib/auth";
+import { sessionCookieName } from "@/api/lib/auth-cookie-name";
 import { getAuthEndpointUrl, getAuthIssuerUrl } from "@/api/lib/auth-paths";
 import { createSafeId, type SafeId } from "@/api/lib/branded-types";
 import { getMcpResourceUrl } from "@/api/mcp/constants";
@@ -474,13 +475,7 @@ export class AuthorizeCodeError extends Error {
   override name = "AuthorizeCodeError";
 }
 
-/** better-auth's session-token cookie name, mirroring its cookie getter. */
-const getSessionCookieName = (): string => {
-  if (env.isDev) {
-    return `${env.BETTER_AUTH_COOKIE_PREFIX ?? "stella-dev"}.session_token`;
-  }
-  return "__Secure-better-auth.session_token";
-};
+const getSessionCookieName = sessionCookieName;
 
 /** How long an internally-minted agent session row stays valid. */
 const INTERNAL_SESSION_TTL_MS = 15 * 60 * 1000;

--- a/apps/api/src/lib/auth-cookie-name.test.ts
+++ b/apps/api/src/lib/auth-cookie-name.test.ts
@@ -37,6 +37,24 @@ const walk = (directory: string): string[] => {
  * outside the helper is what reproduces the branchy part of the rule.
  */
 describe("session cookie name has a single owner", () => {
+  /**
+   * `useSecureCookies` decides whether better-auth prepends `__Secure-`, so a
+   * module that computes it independently can produce a name the readers do not
+   * expect. Passing the policy's value through is fine — `auth.ts` does exactly
+   * that — so this looks for the value being *assigned* an expression rather
+   * than for the identifier appearing at all.
+   */
+  test("no other module computes useSecureCookies", () => {
+    const assigned = /useSecureCookies:\s*[^,\n]/u;
+    const offenders = SEARCH_ROOTS.flatMap((root) => walk(root)).filter(
+      (file) =>
+        !OWNERS.has(file) &&
+        assigned.test(readFileSync(path.join(API_ROOT, file), "utf-8")),
+    );
+
+    expect(offenders).toEqual([]);
+  });
+
   test("no other module derives the prefix itself", () => {
     const offenders = SEARCH_ROOTS.flatMap((root) => walk(root)).filter(
       (file) =>

--- a/apps/api/src/lib/auth-cookie-name.test.ts
+++ b/apps/api/src/lib/auth-cookie-name.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "bun:test";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import path from "node:path";
+
+const API_ROOT = path.join(import.meta.dir, "..", "..");
+const SEARCH_ROOTS = ["src", "scripts"];
+
+/**
+ * Files allowed to reference the prefix: the helper, this test, and the env
+ * schema that declares the variable in the first place.
+ */
+const OWNERS = new Set([
+  path.join("src", "lib", "auth-cookie-name.ts"),
+  path.join("src", "lib", "auth-cookie-name.test.ts"),
+  path.join("src", "env-schema.ts"),
+]);
+
+const walk = (directory: string): string[] => {
+  const entries = readdirSync(path.join(API_ROOT, directory));
+  return entries.flatMap((entry) => {
+    const relative = path.join(directory, entry);
+    if (statSync(path.join(API_ROOT, relative)).isDirectory()) {
+      return walk(relative);
+    }
+    return relative.endsWith(".ts") ? [relative] : [];
+  });
+};
+
+/**
+ * The cookie name is produced by `auth.ts` and reconstructed by readers that
+ * cannot import it. Every hand-rolled copy of the rule is a chance for the two
+ * to drift, and a drift surfaces only as an unexplained 401.
+ *
+ * The guard covers the prefix, not the `.session_token` suffix: the suffix is
+ * stable and also appears in permissive cookie-header parsers, which are
+ * consumers rather than a second definition. Reading `BETTER_AUTH_COOKIE_PREFIX`
+ * outside the helper is what reproduces the branchy part of the rule.
+ */
+describe("session cookie name has a single owner", () => {
+  test("no other module derives the prefix itself", () => {
+    const offenders = SEARCH_ROOTS.flatMap((root) => walk(root)).filter(
+      (file) =>
+        !OWNERS.has(file) &&
+        readFileSync(path.join(API_ROOT, file), "utf-8").includes(
+          "BETTER_AUTH_COOKIE_PREFIX",
+        ),
+    );
+
+    expect(offenders).toEqual([]);
+  });
+});

--- a/apps/api/src/lib/auth-cookie-name.ts
+++ b/apps/api/src/lib/auth-cookie-name.ts
@@ -1,20 +1,20 @@
 /**
- * The one place that knows what the session cookie is called.
+ * The one place that decides what the session cookie is called.
  *
- * The name is produced in one direction and consumed in another: `auth.ts`
- * hands better-auth a `cookiePrefix` and a `useSecureCookies` flag, while
- * readers outside that config — agent auth, the smoke-session store, the dev
- * seed — have to reconstruct the name better-auth ends up using. Every reader
- * currently rebuilds that string by hand, so the rule lives in four places and
- * is kept in step by discipline alone. A disagreement surfaces only as an
- * unexplained 401, which is expensive to trace.
+ * `auth.ts` configures better-auth and everything that has to *read* the
+ * resulting cookie — agent auth, the smoke-session store, the dev seed — sits
+ * outside that config and cannot import it. Each of them used to rebuild the
+ * name by hand, so the rule lived in four places and stayed correct by
+ * discipline; a disagreement surfaces only as an unexplained 401.
  *
- * Two rules have to be mirrored, and both are easy to forget:
- *   - the prefix is `BETTER_AUTH_COOKIE_PREFIX` in dev (the dev runner sets it
- *     per worktree so two local APIs cannot read each other's cookies), and
- *     better-auth's own default otherwise;
- *   - better-auth prepends `__Secure-` whenever `useSecureCookies` is on, which
- *     `auth.ts` ties to `!env.isDev`.
+ * The policy below is the producer, not a reconstruction of one. `auth.ts`
+ * feeds better-auth from these exact values, which is what keeps the readers
+ * honest:
+ *   - the prefix is always passed explicitly, so better-auth's own default
+ *     never enters the picture and cannot change under us on an upgrade;
+ *   - `useSecureCookies` travels with it, because better-auth prepends
+ *     `__Secure-` exactly when that flag is on. Deriving the flag separately in
+ *     each reader is how the secure prefix goes missing.
  *
  * Lives apart from `auth.ts` on purpose: importing that module constructs the
  * auth client, and a script that only needs a cookie name must not pay for it.
@@ -22,10 +22,13 @@
 
 import { env } from "@/api/env";
 
-/** better-auth's own default when no prefix is configured. */
-const BETTER_AUTH_DEFAULT_PREFIX = "better-auth";
+/**
+ * The prefix used outside dev. Passed to better-auth explicitly rather than
+ * relying on its default being this value.
+ */
+const PRODUCTION_PREFIX = "better-auth";
 
-/** The prefix used when running locally without an explicit override. */
+/** The prefix used locally when nothing overrides it. */
 const STELLA_DEV_PREFIX = "stella-dev";
 
 /** better-auth prepends this whenever `useSecureCookies` is on. */
@@ -33,23 +36,28 @@ const SECURE_COOKIE_PREFIX = "__Secure-";
 
 const SESSION_COOKIE_SUFFIX = ".session_token";
 
-/**
- * What `auth.ts` passes better-auth as `cookiePrefix`.
- *
- * `undefined` outside dev is deliberate: production takes better-auth's own
- * default, which makes `BETTER_AUTH_COOKIE_PREFIX` a local-only knob.
- */
-export const authCookiePrefixOverride = (): string | undefined =>
-  env.isDev ? (env.BETTER_AUTH_COOKIE_PREFIX ?? STELLA_DEV_PREFIX) : undefined;
+type AuthCookiePolicy = {
+  cookiePrefix: string;
+  useSecureCookies: boolean;
+};
 
 /**
- * The session cookie name that configuration actually produces. Read this
- * rather than rebuilding the string.
+ * The cookie settings better-auth is configured with. `auth.ts` spreads this
+ * into `advanced`; readers derive names from it. There is no third source.
+ *
+ * `BETTER_AUTH_COOKIE_PREFIX` is a dev-only knob: the dev runner sets it per
+ * worktree so two local APIs cannot read each other's cookies.
  */
+export const authCookiePolicy = (): AuthCookiePolicy => ({
+  cookiePrefix: env.isDev
+    ? (env.BETTER_AUTH_COOKIE_PREFIX ?? STELLA_DEV_PREFIX)
+    : PRODUCTION_PREFIX,
+  useSecureCookies: !env.isDev,
+});
+
+/** The session cookie name that {@link authCookiePolicy} produces. */
 export const sessionCookieName = (): string => {
-  const prefix = authCookiePrefixOverride() ?? BETTER_AUTH_DEFAULT_PREFIX;
-  // `useSecureCookies` is `!env.isDev`, so the secure prefix appears exactly
-  // when the override does not.
-  const securePrefix = env.isDev ? "" : SECURE_COOKIE_PREFIX;
-  return `${securePrefix}${prefix}${SESSION_COOKIE_SUFFIX}`;
+  const { cookiePrefix, useSecureCookies } = authCookiePolicy();
+  const securePrefix = useSecureCookies ? SECURE_COOKIE_PREFIX : "";
+  return `${securePrefix}${cookiePrefix}${SESSION_COOKIE_SUFFIX}`;
 };

--- a/apps/api/src/lib/auth-cookie-name.ts
+++ b/apps/api/src/lib/auth-cookie-name.ts
@@ -1,0 +1,55 @@
+/**
+ * The one place that knows what the session cookie is called.
+ *
+ * The name is produced in one direction and consumed in another: `auth.ts`
+ * hands better-auth a `cookiePrefix` and a `useSecureCookies` flag, while
+ * readers outside that config — agent auth, the smoke-session store, the dev
+ * seed — have to reconstruct the name better-auth ends up using. Every reader
+ * currently rebuilds that string by hand, so the rule lives in four places and
+ * is kept in step by discipline alone. A disagreement surfaces only as an
+ * unexplained 401, which is expensive to trace.
+ *
+ * Two rules have to be mirrored, and both are easy to forget:
+ *   - the prefix is `BETTER_AUTH_COOKIE_PREFIX` in dev (the dev runner sets it
+ *     per worktree so two local APIs cannot read each other's cookies), and
+ *     better-auth's own default otherwise;
+ *   - better-auth prepends `__Secure-` whenever `useSecureCookies` is on, which
+ *     `auth.ts` ties to `!env.isDev`.
+ *
+ * Lives apart from `auth.ts` on purpose: importing that module constructs the
+ * auth client, and a script that only needs a cookie name must not pay for it.
+ */
+
+import { env } from "@/api/env";
+
+/** better-auth's own default when no prefix is configured. */
+const BETTER_AUTH_DEFAULT_PREFIX = "better-auth";
+
+/** The prefix used when running locally without an explicit override. */
+const STELLA_DEV_PREFIX = "stella-dev";
+
+/** better-auth prepends this whenever `useSecureCookies` is on. */
+const SECURE_COOKIE_PREFIX = "__Secure-";
+
+const SESSION_COOKIE_SUFFIX = ".session_token";
+
+/**
+ * What `auth.ts` passes better-auth as `cookiePrefix`.
+ *
+ * `undefined` outside dev is deliberate: production takes better-auth's own
+ * default, which makes `BETTER_AUTH_COOKIE_PREFIX` a local-only knob.
+ */
+export const authCookiePrefixOverride = (): string | undefined =>
+  env.isDev ? (env.BETTER_AUTH_COOKIE_PREFIX ?? STELLA_DEV_PREFIX) : undefined;
+
+/**
+ * The session cookie name that configuration actually produces. Read this
+ * rather than rebuilding the string.
+ */
+export const sessionCookieName = (): string => {
+  const prefix = authCookiePrefixOverride() ?? BETTER_AUTH_DEFAULT_PREFIX;
+  // `useSecureCookies` is `!env.isDev`, so the secure prefix appears exactly
+  // when the override does not.
+  const securePrefix = env.isDev ? "" : SECURE_COOKIE_PREFIX;
+  return `${securePrefix}${prefix}${SESSION_COOKIE_SUFFIX}`;
+};

--- a/apps/api/src/lib/auth.ts
+++ b/apps/api/src/lib/auth.ts
@@ -38,7 +38,7 @@ import { captureError } from "@/api/lib/analytics/capture";
 import { createAuditRecorder } from "@/api/lib/audit-log";
 import type { AuditExecutionContext } from "@/api/lib/audit-log";
 import { revokeOrganizationMemberAuthArtifacts } from "@/api/lib/auth-artifacts";
-import { authCookiePrefixOverride } from "@/api/lib/auth-cookie-name";
+import { authCookiePolicy } from "@/api/lib/auth-cookie-name";
 import {
   OAUTH_UI_CONSENT_PATH,
   OAUTH_UI_LOGIN_PATH,
@@ -420,7 +420,7 @@ const SESSION_LIFETIME_SECONDS = 60 * 60 * 24 * 7;
 /** How often the session expiry is refreshed, in seconds (1 day). */
 const SESSION_UPDATE_AGE_SECONDS = 60 * 60 * 24;
 
-const authCookiePrefix = authCookiePrefixOverride();
+const { cookiePrefix, useSecureCookies } = authCookiePolicy();
 
 /**
  * Keeps `user.name` from ever persisting as an empty string.
@@ -785,8 +785,8 @@ const createAuth = () => {
       freshAge: 0,
     },
     advanced: {
-      ...(authCookiePrefix ? { cookiePrefix: authCookiePrefix } : {}),
-      useSecureCookies: !env.isDev,
+      cookiePrefix,
+      useSecureCookies,
     },
     rateLimit: {
       enabled: !env.E2E_DISABLE_AUTH_RATE_LIMIT,

--- a/apps/api/src/lib/auth.ts
+++ b/apps/api/src/lib/auth.ts
@@ -38,6 +38,7 @@ import { captureError } from "@/api/lib/analytics/capture";
 import { createAuditRecorder } from "@/api/lib/audit-log";
 import type { AuditExecutionContext } from "@/api/lib/audit-log";
 import { revokeOrganizationMemberAuthArtifacts } from "@/api/lib/auth-artifacts";
+import { authCookiePrefixOverride } from "@/api/lib/auth-cookie-name";
 import {
   OAUTH_UI_CONSENT_PATH,
   OAUTH_UI_LOGIN_PATH,
@@ -419,9 +420,7 @@ const SESSION_LIFETIME_SECONDS = 60 * 60 * 24 * 7;
 /** How often the session expiry is refreshed, in seconds (1 day). */
 const SESSION_UPDATE_AGE_SECONDS = 60 * 60 * 24;
 
-const authCookiePrefix = env.isDev
-  ? (env.BETTER_AUTH_COOKIE_PREFIX ?? "stella-dev")
-  : undefined;
+const authCookiePrefix = authCookiePrefixOverride();
 
 /**
  * Keeps `user.name` from ever persisting as an empty string.

--- a/apps/api/src/lib/smoke-session/store.ts
+++ b/apps/api/src/lib/smoke-session/store.ts
@@ -14,6 +14,7 @@
 import { member, organization, session, user } from "@/api/db/auth-schema";
 import { rootDb } from "@/api/db/root";
 import { env } from "@/api/env";
+import { sessionCookieName } from "@/api/lib/auth-cookie-name";
 import { logger } from "@/api/lib/observability/logger";
 
 const SMOKE_USER = {
@@ -79,14 +80,7 @@ const ensureSmokePrincipal = async (now: Date): Promise<void> => {
   }
 };
 
-// Mirrors better-auth's createCookieGetter naming: `__Secure-` prefix
-// whenever useSecureCookies is on (auth.ts sets it to !env.isDev).
-const smokeCookieName = (): string => {
-  if (env.isDev) {
-    return `${env.BETTER_AUTH_COOKIE_PREFIX ?? "stella-dev"}.session_token`;
-  }
-  return "__Secure-better-auth.session_token";
-};
+const smokeCookieName = sessionCookieName;
 
 export const mintSmokeSession = async (): Promise<SmokeSession> => {
   const now = new Date();


### PR DESCRIPTION
## Problem

`auth.ts` configures better-auth with a `cookiePrefix` and `useSecureCookies`. Everything that needs to *read* the resulting cookie sits outside that config and cannot import it, so four modules reconstructed the name by hand:

- `src/lib/auth.ts` — produces it
- `src/lib/agent-auth.ts` — `getSessionCookieName()`
- `src/lib/smoke-session/store.ts` — `smokeCookieName()`
- `scripts/seed-test-user.ts` — `AUTH_COOKIE_NAME`

Two rules have to be mirrored in each copy, and both are easy to miss: the prefix is `BETTER_AUTH_COOKIE_PREFIX` in dev and better-auth's own default otherwise, and better-auth prepends `__Secure-` whenever `useSecureCookies` is on. The four copies agree today. Nothing keeps them agreeing, and a disagreement does not fail loudly — it surfaces as an unexplained 401 with no hint that a cookie name is involved.

That is not hypothetical. `seed-test-user` writes a Playwright storage state whose cookie name comes from its own copy of the rule. The dev runner starts the API with a per-worktree `BETTER_AUTH_COOKIE_PREFIX` (`stella-dev-<port>`, so two local APIs cannot read each other's cookies) but injects it only into its own children, so a standalone `bun run db:seed-test-user` resolves the fallback instead. The stored cookie then loses to a 401 against that API while carrying a perfectly valid signature. Confirmed against a running dev API: identical signed value, `stella-dev.session_token` → 401, `stella-dev-<port>.session_token` → 200.

## Change

One module, `src/lib/auth-cookie-name.ts`, owns both rules:

- `authCookiePrefixOverride()` — what `auth.ts` passes better-auth, `undefined` outside dev so production keeps better-auth's default;
- `sessionCookieName()` — the name that configuration actually produces, `__Secure-` included.

The four call sites now use it. Behaviour is unchanged in every environment; this removes the duplication, not a live defect.

It lives apart from `auth.ts` deliberately: importing that module constructs the auth client, and a script that only wants a cookie name should not pay for it.

## Guard

`auth-cookie-name.test.ts` asserts that no other module under `src/` or `scripts/` reads `BETTER_AUTH_COOKIE_PREFIX`, so a future reader cannot quietly grow a fifth copy. The env schema that declares the variable is the one allowed exception.

The guard deliberately covers the prefix rather than the `.session_token` suffix. It caught a real distinction while being written: `src/tests/load/upload-load.ts` matches `*.session_token` with a permissive regex, but it is *parsing* a cookie header rather than deriving a name, so it is a consumer and not a second definition. The branchy, drift-prone half is the prefix.

## Not included

The underlying environmental gap remains: a script run outside the dev runner cannot know the per-worktree prefix, because the runner injects it only into its children. This PR makes every consumer agree whenever they share an environment, which is the part that belongs in the codebase. Teaching standalone scripts to discover a running API's prefix is a separate decision about where that value should live.

## Verification

`bun test src/lib/auth-cookie-name.test.ts` passes; `bun run typecheck` and `bun run lint` clean for `@stll/api`.
