### PR TITLE
fix(api): validate configured database URL protocol

### DIFF
--- a/apps/api/src/db-url.test.ts
+++ b/apps/api/src/db-url.test.ts
@@ -11,11 +11,41 @@ const components = {
 };
 
 describe("resolveDatabaseUrl", () => {
-  test("returns DATABASE_URL when present", () => {
-    expect(
-      resolveDatabaseUrl({ DATABASE_URL: "postgres://x/y", ...components }),
-    ).toBe("postgres://x/y");
-  });
+  test.each([["postgres://x/y"], ["postgresql://x/y"]])(
+    "returns supported DATABASE_URL unchanged: %s",
+    (databaseUrl) => {
+      expect(
+        resolveDatabaseUrl({ DATABASE_URL: databaseUrl, ...components }),
+      ).toBe(databaseUrl);
+    },
+  );
+
+  test.each([["not a URL"], ["://missing-scheme"]])(
+    "throws on malformed DATABASE_URL: %s",
+    (databaseUrl) => {
+      expect(() => resolveDatabaseUrl({ DATABASE_URL: databaseUrl })).toThrow(
+        "DATABASE_URL is not a valid URL",
+      );
+    },
+  );
+
+  test.each([["https://x/y"], ["mysql://x/y"]])(
+    "throws on unsupported DATABASE_URL protocol: %s",
+    (databaseUrl) => {
+      expect(() => resolveDatabaseUrl({ DATABASE_URL: databaseUrl })).toThrow(
+        "DATABASE_URL must use the postgres:// or postgresql:// scheme",
+      );
+    },
+  );
+
+  test.each([["postgres:db.example"], ["postgresql:db.example"]])(
+    "throws when DATABASE_URL omits the scheme separator: %s",
+    (databaseUrl) => {
+      expect(() => resolveDatabaseUrl({ DATABASE_URL: databaseUrl })).toThrow(
+        "DATABASE_URL must use the postgres:// or postgresql:// scheme",
+      );
+    },
+  );
 
   test("returns undefined when nothing is set", () => {
     expect(resolveDatabaseUrl({})).toBeUndefined();

--- a/apps/api/src/db-url.ts
+++ b/apps/api/src/db-url.ts
@@ -22,12 +22,31 @@ const COMPONENT_KEYS = [
 // `allow`, and `prefer` would silently downgrade transport security
 // and have no legitimate reason to appear in a managed deploy.
 const ALLOWED_SSLMODES = ["require", "verify-ca", "verify-full"] as const;
+const SUPPORTED_DATABASE_PROTOCOLS = ["postgres:", "postgresql:"] as const;
 
 export const resolveDatabaseUrl = (
   env: NodeJS.ProcessEnv = process.env,
 ): string | undefined => {
   if (env["DATABASE_URL"]) {
-    return env["DATABASE_URL"];
+    const databaseUrl = env["DATABASE_URL"];
+    let parsed: URL;
+    try {
+      parsed = new URL(databaseUrl);
+    } catch {
+      panic("DATABASE_URL is not a valid URL");
+    }
+    const hasAuthoritySyntax = databaseUrl
+      .slice(parsed.protocol.length)
+      .startsWith("//");
+    if (
+      !hasAuthoritySyntax ||
+      !SUPPORTED_DATABASE_PROTOCOLS.some(
+        (protocol) => protocol === parsed.protocol,
+      )
+    ) {
+      panic("DATABASE_URL must use the postgres:// or postgresql:// scheme");
+    }
+    return databaseUrl;
   }
 
   const { DB_HOST, DB_PORT, DB_USER, DB_PASSWORD, DB_NAME, DB_SSLMODE } = env;


### PR DESCRIPTION
## Summary

- parse `DATABASE_URL` before returning it
- accept only the `postgres://` and `postgresql://` schemes
- preserve supported URLs unchanged
- cover malformed URLs, unsupported protocols, and both supported protocols

## Context

Supersedes #1383 with the narrower scope agreed in review. This intentionally does not enforce `sslmode` for direct URLs; deployed-versus-local TLS policy needs separate treatment.

## Testing

- `bun test apps/api/src/db-url.test.ts`
- `bun run verify`

CC on behalf of jan-kubica

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database connection URL validation.
  * Valid PostgreSQL URLs are accepted unchanged.
  * Invalid URLs and unsupported protocols now produce clear validation errors.

* **Tests**
  * Added coverage for supported PostgreSQL schemes, malformed URLs, and unsupported protocols.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->