### PR TITLE
fix(ci): send AG-UI envelope in staging smoke

### DIFF
--- a/apps/api/src/scripts/post-deploy-smoke.test.ts
+++ b/apps/api/src/scripts/post-deploy-smoke.test.ts
@@ -316,21 +316,34 @@ describe("allChecksPassed", () => {
 });
 
 describe("buildChatSmokeBody", () => {
-  test("produces a fresh thread id and a user text message", () => {
+  test("produces a valid AG-UI envelope with a fresh thread and run", () => {
     const body = buildChatSmokeBody();
-    expect(body.sendMode).toBe("rawOverride");
     const uuid =
       /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/u;
     expect(body.threadId).toMatch(uuid);
-    const { message } = body;
+    expect(body.runId).toMatch(uuid);
+    expect(body.state).toEqual({});
+    expect(body.tools).toEqual([]);
+    expect(body.context).toEqual([]);
+
+    const { message } = body.forwardedProps;
+    expect(body.forwardedProps).toEqual({
+      threadId: body.threadId,
+      runId: body.runId,
+      sendMode: "rawOverride",
+      message,
+    });
+    expect(body.data).toEqual(body.forwardedProps);
+    expect(body.messages).toEqual([message]);
     expect(message.role).toBe("user");
     expect(message.id).toMatch(uuid);
     expect(message.parts).toEqual([{ type: "text", text: "ping" }]);
   });
 
   test("each call uses a distinct thread id", () => {
-    expect(buildChatSmokeBody().threadId).not.toBe(
-      buildChatSmokeBody().threadId,
-    );
+    const first = buildChatSmokeBody();
+    const second = buildChatSmokeBody();
+    expect(first.threadId).not.toBe(second.threadId);
+    expect(first.runId).not.toBe(second.runId);
   });
 });

--- a/apps/api/src/scripts/post-deploy-smoke.test.ts
+++ b/apps/api/src/scripts/post-deploy-smoke.test.ts
@@ -337,7 +337,7 @@ describe("buildChatSmokeBody", () => {
     expect(body.messages).toEqual([message]);
     expect(message.role).toBe("user");
     expect(message.id).toMatch(uuid);
-    expect(message.parts).toEqual([{ type: "text", text: "ping" }]);
+    expect(message.parts).toEqual([{ type: "text", content: "ping" }]);
   });
 
   test("each call uses a distinct thread id", () => {

--- a/apps/api/src/scripts/post-deploy-smoke.ts
+++ b/apps/api/src/scripts/post-deploy-smoke.ts
@@ -23,9 +23,15 @@
  */
 
 import { TaggedError } from "better-result";
+import type { Static } from "elysia";
 import * as v from "valibot";
 
+import type {
+  agUiSendMessageBodySchema,
+  ChatSendRequest,
+} from "@/api/handlers/chat/chat-schema";
 import type { ChatPart } from "@/api/handlers/chat/types";
+import { createSafeId } from "@/api/lib/branded-types";
 import { fetchWithTimeout } from "@/api/lib/fetch";
 
 const SMOKE_SESSION_TIMEOUT_MS = 15_000;
@@ -305,29 +311,7 @@ const parseSmokeSession = (value: unknown): SmokeSession => {
   });
 };
 
-type ChatSmokeMessage = {
-  id: string;
-  role: "user";
-  parts: Extract<ChatPart, { type: "text" }>[];
-};
-
-type ChatSmokeForwardedProps = {
-  threadId: string;
-  runId: string;
-  sendMode: "rawOverride";
-  message: ChatSmokeMessage;
-};
-
-type ChatSmokeBody = {
-  threadId: string;
-  runId: string;
-  state: Record<string, never>;
-  messages: ChatSmokeMessage[];
-  tools: never[];
-  context: never[];
-  forwardedProps: ChatSmokeForwardedProps;
-  data: ChatSmokeForwardedProps;
-};
+type ChatSmokeBody = Static<typeof agUiSendMessageBodySchema>;
 
 /**
  * Minimal valid AG-UI `POST /v1/chat/` envelope that triggers a real chat
@@ -336,19 +320,24 @@ type ChatSmokeBody = {
  * for the synthetic org.
  */
 export const buildChatSmokeBody = (): ChatSmokeBody => {
-  const threadId = Bun.randomUUIDv7();
+  const threadId = createSafeId<"chatThread">();
   const runId = Bun.randomUUIDv7();
-  const message: ChatSmokeMessage = {
-    id: Bun.randomUUIDv7(),
+  const message = {
+    id: createSafeId<"chatMessage">(),
     role: "user",
-    parts: [{ type: "text", content: "ping" }],
-  };
-  const forwardedProps: ChatSmokeForwardedProps = {
+    parts: [
+      {
+        type: "text",
+        content: "ping",
+      } satisfies Extract<ChatPart, { type: "text" }>,
+    ],
+  } as const satisfies ChatSendRequest["message"];
+  const forwardedProps = {
     threadId,
     runId,
     sendMode: "rawOverride",
     message,
-  };
+  } as const satisfies ChatSendRequest;
 
   return {
     threadId,
@@ -359,7 +348,7 @@ export const buildChatSmokeBody = (): ChatSmokeBody => {
     context: [],
     forwardedProps,
     data: forwardedProps,
-  };
+  } satisfies ChatSmokeBody;
 };
 
 const mintSmokeSession = async (

--- a/apps/api/src/scripts/post-deploy-smoke.ts
+++ b/apps/api/src/scripts/post-deploy-smoke.ts
@@ -25,6 +25,7 @@
 import { TaggedError } from "better-result";
 import * as v from "valibot";
 
+import type { ChatPart } from "@/api/handlers/chat/types";
 import { fetchWithTimeout } from "@/api/lib/fetch";
 
 const SMOKE_SESSION_TIMEOUT_MS = 15_000;
@@ -55,30 +56,6 @@ const smokeSessionSchema = v.strictObject({
 });
 
 type SmokeSession = v.InferOutput<typeof smokeSessionSchema>;
-
-type ChatSmokeMessage = {
-  id: string;
-  role: "user";
-  parts: { type: "text"; text: string }[];
-};
-
-type ChatSmokeForwardedProps = {
-  threadId: string;
-  runId: string;
-  sendMode: "rawOverride";
-  message: ChatSmokeMessage;
-};
-
-type ChatSmokeBody = {
-  threadId: string;
-  runId: string;
-  state: Record<string, never>;
-  messages: ChatSmokeMessage[];
-  tools: never[];
-  context: never[];
-  forwardedProps: ChatSmokeForwardedProps;
-  data: ChatSmokeForwardedProps;
-};
 
 const CHECK_MODE = {
   /** Pass only on a 2xx status (used for the auth precondition). */
@@ -328,6 +305,30 @@ const parseSmokeSession = (value: unknown): SmokeSession => {
   });
 };
 
+type ChatSmokeMessage = {
+  id: string;
+  role: "user";
+  parts: Extract<ChatPart, { type: "text" }>[];
+};
+
+type ChatSmokeForwardedProps = {
+  threadId: string;
+  runId: string;
+  sendMode: "rawOverride";
+  message: ChatSmokeMessage;
+};
+
+type ChatSmokeBody = {
+  threadId: string;
+  runId: string;
+  state: Record<string, never>;
+  messages: ChatSmokeMessage[];
+  tools: never[];
+  context: never[];
+  forwardedProps: ChatSmokeForwardedProps;
+  data: ChatSmokeForwardedProps;
+};
+
 /**
  * Minimal valid AG-UI `POST /v1/chat/` envelope that triggers a real chat
  * turn: a fresh global thread (the handler creates it) plus one user text
@@ -340,7 +341,7 @@ export const buildChatSmokeBody = (): ChatSmokeBody => {
   const message: ChatSmokeMessage = {
     id: Bun.randomUUIDv7(),
     role: "user",
-    parts: [{ type: "text", text: "ping" }],
+    parts: [{ type: "text", content: "ping" }],
   };
   const forwardedProps: ChatSmokeForwardedProps = {
     threadId,

--- a/apps/api/src/scripts/post-deploy-smoke.ts
+++ b/apps/api/src/scripts/post-deploy-smoke.ts
@@ -56,14 +56,28 @@ const smokeSessionSchema = v.strictObject({
 
 type SmokeSession = v.InferOutput<typeof smokeSessionSchema>;
 
+type ChatSmokeMessage = {
+  id: string;
+  role: "user";
+  parts: { type: "text"; text: string }[];
+};
+
+type ChatSmokeForwardedProps = {
+  threadId: string;
+  runId: string;
+  sendMode: "rawOverride";
+  message: ChatSmokeMessage;
+};
+
 type ChatSmokeBody = {
   threadId: string;
-  sendMode: "rawOverride";
-  message: {
-    id: string;
-    role: "user";
-    parts: { type: "text"; text: string }[];
-  };
+  runId: string;
+  state: Record<string, never>;
+  messages: ChatSmokeMessage[];
+  tools: never[];
+  context: never[];
+  forwardedProps: ChatSmokeForwardedProps;
+  data: ChatSmokeForwardedProps;
 };
 
 const CHECK_MODE = {
@@ -315,20 +329,37 @@ const parseSmokeSession = (value: unknown): SmokeSession => {
 };
 
 /**
- * Minimal valid `POST /v1/chat/` body that triggers a real chat turn: a
- * fresh global thread (the handler creates it) plus one user text
- * message. No workspace is referenced, so no matter provisioning is
- * needed for the synthetic org.
+ * Minimal valid AG-UI `POST /v1/chat/` envelope that triggers a real chat
+ * turn: a fresh global thread (the handler creates it) plus one user text
+ * message. No workspace is referenced, so no matter provisioning is needed
+ * for the synthetic org.
  */
-export const buildChatSmokeBody = (): ChatSmokeBody => ({
-  threadId: Bun.randomUUIDv7(),
-  sendMode: "rawOverride",
-  message: {
+export const buildChatSmokeBody = (): ChatSmokeBody => {
+  const threadId = Bun.randomUUIDv7();
+  const runId = Bun.randomUUIDv7();
+  const message: ChatSmokeMessage = {
     id: Bun.randomUUIDv7(),
     role: "user",
     parts: [{ type: "text", text: "ping" }],
-  },
-});
+  };
+  const forwardedProps: ChatSmokeForwardedProps = {
+    threadId,
+    runId,
+    sendMode: "rawOverride",
+    message,
+  };
+
+  return {
+    threadId,
+    runId,
+    state: {},
+    messages: [message],
+    tools: [],
+    context: [],
+    forwardedProps,
+    data: forwardedProps,
+  };
+};
 
 const mintSmokeSession = async (
   baseUrl: string,


### PR DESCRIPTION
## Summary

- update the post-deploy chat smoke to send the canonical TanStack AG-UI envelope
- mirror the strict Stella request under `forwardedProps` and `data`
- cover run correlation and the full transport shape in the smoke unit test

## Verification

- `bun test apps/api/src/scripts/post-deploy-smoke.test.ts`
- `bun --filter @stll/api typecheck`
- type-aware oxlint on the two changed files
- `bun run code-check:affected`
- generated body accepted by `agUiSendMessageBodySchema`

Fixes the staging failure in run 31263815085 / job 93119993994.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved post-deployment chat smoke checks to validate complete request details, including message data, identifiers, forwarded properties and supporting fields.
  - Ensured each chat request receives unique thread and run identifiers.
  - Improved detection of incomplete or incorrectly structured chat requests before they affect live service availability.

- **Tests**
  - Expanded automated coverage for request structure, mirrored message data and identifier uniqueness.
  - Strengthened integration checks to help identify deployment issues earlier.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->