### PR TITLE
fix: restore manual OCR after version rollback

### DIFF
--- a/apps/api/src/lib/document-processing-automatic-request-state.test.ts
+++ b/apps/api/src/lib/document-processing-automatic-request-state.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
-import { shouldRequeueAutomaticOcrRun } from "@/api/lib/document-processing-automatic-request-state";
+import { shouldRequeueOcrRunAfterProjectionLoss } from "@/api/lib/document-processing-automatic-request-state";
 
 const source = {
   entityVersionId: "version_1",
@@ -21,13 +21,20 @@ const projection = {
   sourceSha256Hex: source.sourceSha256Hex,
 };
 
-describe("shouldRequeueAutomaticOcrRun", () => {
-  test("requeues succeeded automatic OCR when rollback removed its projection", () => {
+describe("shouldRequeueOcrRunAfterProjectionLoss", () => {
+  test("requeues succeeded OCR when rollback removed its projection", () => {
     expect(
-      shouldRequeueAutomaticOcrRun({ projection: null, run, source }),
+      shouldRequeueOcrRunAfterProjectionLoss({ projection: null, run, source }),
     ).toBe(true);
     expect(
-      shouldRequeueAutomaticOcrRun({
+      shouldRequeueOcrRunAfterProjectionLoss({
+        projection: null,
+        run: { ...run, requestSource: "upload" },
+        source,
+      }),
+    ).toBe(true);
+    expect(
+      shouldRequeueOcrRunAfterProjectionLoss({
         projection: { ...projection, ocrRunId: null },
         run,
         source,
@@ -35,22 +42,15 @@ describe("shouldRequeueAutomaticOcrRun", () => {
     ).toBe(true);
   });
 
-  test("keeps a succeeded automatic run whose OCR projection is intact", () => {
-    expect(shouldRequeueAutomaticOcrRun({ projection, run, source })).toBe(
-      false,
-    );
+  test("keeps a succeeded run whose OCR projection is intact", () => {
+    expect(
+      shouldRequeueOcrRunAfterProjectionLoss({ projection, run, source }),
+    ).toBe(false);
   });
 
-  test("does not convert manual or non-succeeded runs into automatic retries", () => {
+  test("does not retry non-succeeded runs", () => {
     expect(
-      shouldRequeueAutomaticOcrRun({
-        projection: null,
-        run: { ...run, requestSource: "manual" },
-        source,
-      }),
-    ).toBe(false);
-    expect(
-      shouldRequeueAutomaticOcrRun({
+      shouldRequeueOcrRunAfterProjectionLoss({
         projection: null,
         run: { ...run, status: "queued" },
         source,

--- a/apps/api/src/lib/document-processing-automatic-request-state.ts
+++ b/apps/api/src/lib/document-processing-automatic-request-state.ts
@@ -1,4 +1,4 @@
-type AutomaticOcrRun = {
+type OcrRun = {
   id: string;
   requestSource: string;
   status: string;
@@ -19,22 +19,30 @@ type AutomaticOcrSource = {
   sourceSha256Hex: string;
 };
 
-/** Restore an automatic OCR run only when its durable projection was lost. */
-export const shouldRequeueAutomaticOcrRun = ({
+export const isExactOcrProjection = ({
   projection,
   run,
   source,
 }: {
   projection: AutomaticOcrProjection | null;
-  run: AutomaticOcrRun;
+  run: Pick<OcrRun, "id">;
+  source: AutomaticOcrSource;
+}): boolean =>
+  projection?.ocrRunId === run.id &&
+  projection.sourceEntityVersionId === source.entityVersionId &&
+  projection.sourceFieldId === source.fieldId &&
+  projection.sourceFileId === source.sourceFileId &&
+  projection.sourceSha256Hex === source.sourceSha256Hex;
+
+/** Restore a successful OCR run only when its durable projection was lost. */
+export const shouldRequeueOcrRunAfterProjectionLoss = ({
+  projection,
+  run,
+  source,
+}: {
+  projection: AutomaticOcrProjection | null;
+  run: OcrRun;
   source: AutomaticOcrSource;
 }): boolean =>
   run.status === "succeeded" &&
-  run.requestSource !== "manual" &&
-  !(
-    projection?.ocrRunId === run.id &&
-    projection.sourceEntityVersionId === source.entityVersionId &&
-    projection.sourceFieldId === source.fieldId &&
-    projection.sourceFileId === source.sourceFileId &&
-    projection.sourceSha256Hex === source.sourceSha256Hex
-  );
+  !isExactOcrProjection({ projection, run, source });

--- a/apps/api/src/lib/document-processing-automatic-request.ts
+++ b/apps/api/src/lib/document-processing-automatic-request.ts
@@ -10,7 +10,7 @@ import {
 } from "@/api/db/schema";
 import type { SafeId } from "@/api/lib/branded-types";
 import { createSafeId } from "@/api/lib/branded-types";
-import { shouldRequeueAutomaticOcrRun } from "@/api/lib/document-processing-automatic-request-state";
+import { shouldRequeueOcrRunAfterProjectionLoss } from "@/api/lib/document-processing-automatic-request-state";
 import { DOCUMENT_OCR_PROCESSOR_VERSION } from "@/api/lib/document-processing-contract";
 import { resolveExtractionMimeType } from "@/api/lib/search/extract-content";
 import { PDF_MIME_TYPE } from "@/api/mime-types";
@@ -149,6 +149,9 @@ export const requestAutomaticDocumentOcr = async ({
     if (!existing) {
       return null;
     }
+    if (existing.requestSource === "manual") {
+      return null;
+    }
 
     const projectionRows =
       existing.status === "succeeded"
@@ -171,7 +174,7 @@ export const requestAutomaticDocumentOcr = async ({
             .limit(1)
         : [];
     if (
-      !shouldRequeueAutomaticOcrRun({
+      !shouldRequeueOcrRunAfterProjectionLoss({
         projection: projectionRows.at(0) ?? null,
         run: existing,
         source: {

--- a/apps/api/src/lib/document-processing-manual-ocr-restore.db.test.ts
+++ b/apps/api/src/lib/document-processing-manual-ocr-restore.db.test.ts
@@ -1,0 +1,270 @@
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+import { eq } from "drizzle-orm";
+
+import {
+  documentProcessingRuns,
+  extractedContent,
+  fields,
+} from "@/api/db/schema";
+import { toSafeId } from "@/api/lib/branded-types";
+import type { SafeId } from "@/api/lib/branded-types";
+import { DOCUMENT_OCR_PROCESSOR_VERSION } from "@/api/lib/document-processing-contract";
+import type { restoreManualOcrRunAfterProjectionLoss as RestoreManualOcrRunAfterProjectionLoss } from "@/api/lib/document-processing-manual-ocr-restore";
+import { PDF_MIME_TYPE } from "@/api/mime-types";
+import {
+  createTestIds,
+  setupRlsTestData,
+} from "@/api/tests/security/rls-helpers";
+import type { TestIds } from "@/api/tests/security/rls-helpers";
+import { getTestDb, releaseTestDb } from "@/api/tests/security/test-utils";
+import type { TestDatabase } from "@/api/tests/security/test-utils";
+
+const SOURCE_FILE_ID = Bun.randomUUIDv7();
+const SOURCE_SHA256_HEX = "a".repeat(64);
+const UNRELATED_FILE_ID = Bun.randomUUIDv7();
+const UNRELATED_SHA256_HEX = "b".repeat(64);
+
+let testDb: TestDatabase;
+let ids: TestIds;
+let restoreManualOcrRunAfterProjectionLoss: typeof RestoreManualOcrRunAfterProjectionLoss;
+
+beforeAll(async () => {
+  testDb = await getTestDb();
+  ids = createTestIds();
+  await setupRlsTestData(testDb, ids);
+  void mock.module("@/api/db/root", () => ({ rootDb: testDb, rlsDb: testDb }));
+  ({ restoreManualOcrRunAfterProjectionLoss } =
+    await import("@/api/lib/document-processing-manual-ocr-restore"));
+}, 120_000);
+
+beforeEach(async () => {
+  await testDb
+    .delete(extractedContent)
+    .where(eq(extractedContent.organizationId, ids.orgA));
+  await testDb
+    .delete(documentProcessingRuns)
+    .where(eq(documentProcessingRuns.organizationId, ids.orgA));
+  await testDb
+    .update(fields)
+    .set({
+      content: {
+        encrypted: false,
+        fileName: "scan.pdf",
+        id: SOURCE_FILE_ID,
+        mimeType: PDF_MIME_TYPE,
+        pdfFileId: null,
+        sha256Hex: SOURCE_SHA256_HEX,
+        sizeBytes: 128,
+        type: "file",
+        version: 1,
+      },
+    })
+    .where(eq(fields.id, ids.fieldA1));
+});
+
+afterAll(async () => {
+  await releaseTestDb();
+});
+
+const insertRun = async ({
+  entityId = ids.entityA1,
+  entityVersionId = ids.entityVersionA1,
+  errorCode = "prior_error",
+  fieldId = ids.fieldA1,
+  runId = toSafeId<"documentProcessingRun">(Bun.randomUUIDv7()),
+  sourceFileId = SOURCE_FILE_ID,
+  sourceSha256Hex = SOURCE_SHA256_HEX,
+  status = "succeeded",
+  workspaceId = ids.wsA1,
+}: {
+  entityId?: SafeId<"entity">;
+  entityVersionId?: SafeId<"entityVersion">;
+  errorCode?: string | null;
+  fieldId?: SafeId<"field">;
+  runId?: SafeId<"documentProcessingRun">;
+  sourceFileId?: string;
+  sourceSha256Hex?: string;
+  status?: "cancelled" | "failed" | "succeeded";
+  workspaceId?: SafeId<"workspace">;
+} = {}) => {
+  const lifecycleAt = new Date("2026-08-08T12:00:00.000Z");
+  await testDb.insert(documentProcessingRuns).values({
+    attemptCount: 2,
+    claimedAt: lifecycleAt,
+    claimedBy: "worker_1",
+    entityId,
+    entityVersionId,
+    errorAt: lifecycleAt,
+    errorCode,
+    fieldId,
+    finishedAt: lifecycleAt,
+    id: runId,
+    kind: "ocr",
+    nextAttemptAt: lifecycleAt,
+    organizationId: ids.orgA,
+    processorVersion: DOCUMENT_OCR_PROCESSOR_VERSION,
+    progressCompleted: 3,
+    progressTotal: 3,
+    requestSource: "manual",
+    requestedBy: ids.userA1,
+    sourceFileId,
+    sourceSha256Hex,
+    startedAt: lifecycleAt,
+    status,
+    workspaceId,
+  });
+  return runId;
+};
+
+const restore = async ({
+  sourceFileId = SOURCE_FILE_ID,
+  sourceSha256Hex = SOURCE_SHA256_HEX,
+} = {}) =>
+  await restoreManualOcrRunAfterProjectionLoss({
+    entityId: ids.entityA1,
+    entityVersionId: ids.entityVersionA1,
+    fieldId: ids.fieldA1,
+    organizationId: ids.orgA,
+    sourceFileId,
+    sourceSha256Hex,
+    workspaceId: ids.wsA1,
+  });
+
+const readRun = async (runId: SafeId<"documentProcessingRun">) =>
+  (
+    await testDb
+      .select({
+        claimedAt: documentProcessingRuns.claimedAt,
+        claimedBy: documentProcessingRuns.claimedBy,
+        errorAt: documentProcessingRuns.errorAt,
+        errorCode: documentProcessingRuns.errorCode,
+        finishedAt: documentProcessingRuns.finishedAt,
+        nextAttemptAt: documentProcessingRuns.nextAttemptAt,
+        progressCompleted: documentProcessingRuns.progressCompleted,
+        progressTotal: documentProcessingRuns.progressTotal,
+        startedAt: documentProcessingRuns.startedAt,
+        status: documentProcessingRuns.status,
+      })
+      .from(documentProcessingRuns)
+      .where(eq(documentProcessingRuns.id, runId))
+      .limit(1)
+  ).at(0);
+
+const insertProjection = async ({
+  ocrRunId,
+}: {
+  ocrRunId: SafeId<"documentProcessingRun"> | null;
+}) => {
+  await testDb.insert(extractedContent).values({
+    charCount: 0,
+    ciphertext: Buffer.from("ciphertext"),
+    entityId: ids.entityA1,
+    extractedAt: new Date(),
+    iv: Buffer.from("iv"),
+    ocrPayloadCiphertext: ocrRunId === null ? null : Buffer.from("ocr-payload"),
+    ocrPayloadIv: ocrRunId === null ? null : Buffer.from("ocr-iv"),
+    ocrProcessorVersion:
+      ocrRunId === null ? null : DOCUMENT_OCR_PROCESSOR_VERSION,
+    ocrRunId,
+    organizationId: ids.orgA,
+    sourceEntityVersionId: ids.entityVersionA1,
+    sourceFieldId: ids.fieldA1,
+    sourceFileId: SOURCE_FILE_ID,
+    sourceSha256Hex: SOURCE_SHA256_HEX,
+    workspaceId: ids.wsA1,
+  });
+};
+
+describe("restoreManualOcrRunAfterProjectionLoss", () => {
+  test("requeues a matching succeeded manual run when its projection is missing", async () => {
+    const runId = await insertRun();
+    const unrelatedRunId = await insertRun({
+      sourceFileId: UNRELATED_FILE_ID,
+      sourceSha256Hex: UNRELATED_SHA256_HEX,
+    });
+
+    await restore();
+
+    expect(await readRun(runId)).toEqual({
+      claimedAt: null,
+      claimedBy: null,
+      errorAt: null,
+      errorCode: null,
+      finishedAt: null,
+      nextAttemptAt: null,
+      progressCompleted: 0,
+      progressTotal: null,
+      startedAt: null,
+      status: "queued",
+    });
+    expect((await readRun(unrelatedRunId))?.status).toBe("succeeded");
+  });
+
+  test("requeues when a same-source native projection replaced manual OCR", async () => {
+    const runId = await insertRun();
+    await insertProjection({ ocrRunId: null });
+
+    await restore();
+
+    expect((await readRun(runId))?.status).toBe("queued");
+  });
+
+  test("leaves a succeeded run unchanged while it owns the exact projection", async () => {
+    const runId = await insertRun();
+    await insertProjection({ ocrRunId: runId });
+
+    await restore();
+
+    const restored = await readRun(runId);
+    expect(restored?.status).toBe("succeeded");
+    expect(restored?.finishedAt).not.toBeNull();
+    expect(restored?.progressCompleted).toBe(3);
+  });
+
+  test("requeues a search-index failure after its OCR projection is replaced", async () => {
+    const runId = await insertRun({
+      errorCode: "search_index_failed",
+      status: "failed",
+    });
+    await insertProjection({ ocrRunId: null });
+
+    await restore();
+
+    const restored = await readRun(runId);
+    expect(restored?.status).toBe("queued");
+    expect(restored?.errorCode).toBeNull();
+  });
+
+  test("requeues a source-superseded run after the source becomes current again", async () => {
+    const runId = await insertRun({
+      errorCode: "source_superseded",
+      status: "cancelled",
+    });
+
+    await restore();
+
+    expect((await readRun(runId))?.status).toBe("queued");
+  });
+
+  test("does not requeue a run after its file source stops being current", async () => {
+    const runId = await insertRun({
+      sourceFileId: UNRELATED_FILE_ID,
+      sourceSha256Hex: UNRELATED_SHA256_HEX,
+    });
+
+    await restore({
+      sourceFileId: UNRELATED_FILE_ID,
+      sourceSha256Hex: UNRELATED_SHA256_HEX,
+    });
+
+    expect((await readRun(runId))?.status).toBe("succeeded");
+  });
+});

--- a/apps/api/src/lib/document-processing-manual-ocr-restore.ts
+++ b/apps/api/src/lib/document-processing-manual-ocr-restore.ts
@@ -1,0 +1,196 @@
+import { and, eq, inArray, or } from "drizzle-orm";
+
+import { rootDb } from "@/api/db/root";
+import {
+  documentProcessingRuns,
+  entities,
+  extractedContent,
+  fields,
+  workspaces,
+} from "@/api/db/schema";
+import type { SafeId } from "@/api/lib/branded-types";
+import { isExactOcrProjection } from "@/api/lib/document-processing-automatic-request-state";
+import { DOCUMENT_OCR_PROCESSOR_VERSION } from "@/api/lib/document-processing-contract";
+
+const RETRYABLE_MANUAL_OCR_CANCELLATION_CODES = [
+  "policy_disabled",
+  "manual_selection_superseded",
+  "source_superseded",
+  "workspace_unavailable",
+] as const;
+const SEARCH_INDEX_FAILURE_CODE = "search_index_failed";
+
+const restorableRunFilter = () =>
+  or(
+    eq(documentProcessingRuns.status, "succeeded"),
+    and(
+      eq(documentProcessingRuns.status, "failed"),
+      eq(documentProcessingRuns.errorCode, SEARCH_INDEX_FAILURE_CODE),
+    ),
+    and(
+      eq(documentProcessingRuns.status, "cancelled"),
+      inArray(
+        documentProcessingRuns.errorCode,
+        RETRYABLE_MANUAL_OCR_CANCELLATION_CODES,
+      ),
+    ),
+  );
+
+export const restoreManualOcrRunAfterProjectionLoss = async ({
+  entityId,
+  entityVersionId,
+  fieldId,
+  organizationId,
+  sourceFileId,
+  sourceSha256Hex,
+  workspaceId,
+}: {
+  entityId: SafeId<"entity">;
+  entityVersionId: SafeId<"entityVersion">;
+  fieldId: SafeId<"field">;
+  organizationId: SafeId<"organization">;
+  sourceFileId: string;
+  sourceSha256Hex: string;
+  workspaceId: SafeId<"workspace">;
+}): Promise<void> => {
+  await rootDb.transaction(async (tx) => {
+    const currentRows = await tx
+      .select({ id: entities.id })
+      .from(entities)
+      .where(
+        and(
+          eq(entities.id, entityId),
+          eq(entities.workspaceId, workspaceId),
+          eq(entities.currentVersionId, entityVersionId),
+          eq(entities.readOnly, false),
+        ),
+      )
+      .limit(1)
+      .for("update");
+    if (!currentRows.at(0)) {
+      return;
+    }
+    const workspaceRows = await tx
+      .select({ id: workspaces.id })
+      .from(workspaces)
+      .where(
+        and(
+          eq(workspaces.id, workspaceId),
+          eq(workspaces.organizationId, organizationId),
+          eq(workspaces.status, "active"),
+        ),
+      )
+      .limit(1)
+      .for("update");
+    if (!workspaceRows.at(0)) {
+      return;
+    }
+    const sourceFieldRows = await tx
+      .select({ content: fields.content })
+      .from(fields)
+      .where(
+        and(
+          eq(fields.id, fieldId),
+          eq(fields.workspaceId, workspaceId),
+          eq(fields.entityVersionId, entityVersionId),
+        ),
+      )
+      .limit(1);
+    const sourceField = sourceFieldRows.at(0);
+    if (
+      sourceField?.content.type !== "file" ||
+      sourceField.content.id !== sourceFileId ||
+      sourceField.content.sha256Hex !== sourceSha256Hex
+    ) {
+      return;
+    }
+
+    const existingRows = await tx
+      .select({
+        errorCode: documentProcessingRuns.errorCode,
+        id: documentProcessingRuns.id,
+        requestSource: documentProcessingRuns.requestSource,
+        status: documentProcessingRuns.status,
+      })
+      .from(documentProcessingRuns)
+      .where(
+        and(
+          eq(documentProcessingRuns.organizationId, organizationId),
+          eq(documentProcessingRuns.workspaceId, workspaceId),
+          eq(documentProcessingRuns.entityId, entityId),
+          eq(documentProcessingRuns.entityVersionId, entityVersionId),
+          eq(documentProcessingRuns.fieldId, fieldId),
+          eq(documentProcessingRuns.sourceFileId, sourceFileId),
+          eq(documentProcessingRuns.sourceSha256Hex, sourceSha256Hex),
+          eq(documentProcessingRuns.kind, "ocr"),
+          eq(documentProcessingRuns.requestSource, "manual"),
+          eq(
+            documentProcessingRuns.processorVersion,
+            DOCUMENT_OCR_PROCESSOR_VERSION,
+          ),
+          restorableRunFilter(),
+        ),
+      )
+      .limit(1)
+      .for("update");
+    const existing = existingRows.at(0);
+    if (!existing) {
+      return;
+    }
+
+    const projectionRows = await tx
+      .select({
+        ocrRunId: extractedContent.ocrRunId,
+        sourceEntityVersionId: extractedContent.sourceEntityVersionId,
+        sourceFieldId: extractedContent.sourceFieldId,
+        sourceFileId: extractedContent.sourceFileId,
+        sourceSha256Hex: extractedContent.sourceSha256Hex,
+      })
+      .from(extractedContent)
+      .where(
+        and(
+          eq(extractedContent.entityId, entityId),
+          eq(extractedContent.organizationId, organizationId),
+          eq(extractedContent.workspaceId, workspaceId),
+        ),
+      )
+      .limit(1);
+    if (
+      isExactOcrProjection({
+        projection: projectionRows.at(0) ?? null,
+        run: existing,
+        source: {
+          entityVersionId,
+          fieldId,
+          sourceFileId,
+          sourceSha256Hex,
+        },
+      })
+    ) {
+      return;
+    }
+
+    await tx
+      .update(documentProcessingRuns)
+      .set({
+        claimedAt: null,
+        claimedBy: null,
+        errorAt: null,
+        errorCode: null,
+        finishedAt: null,
+        nextAttemptAt: null,
+        progressCompleted: 0,
+        progressTotal: null,
+        startedAt: null,
+        status: "queued",
+        updatedAt: new Date(),
+      })
+      .where(
+        and(
+          eq(documentProcessingRuns.id, existing.id),
+          eq(documentProcessingRuns.requestSource, "manual"),
+          restorableRunFilter(),
+        ),
+      );
+  });
+};

--- a/apps/api/src/lib/search/process-extraction.test.ts
+++ b/apps/api/src/lib/search/process-extraction.test.ts
@@ -81,6 +81,7 @@ const encryptContentMock = mock(async () => ({
   iv: Buffer.from("iv"),
 }));
 const requestAutomaticDocumentOcrMock = mock(async () => undefined);
+const restoreManualOcrRunAfterProjectionLossMock = mock(async () => undefined);
 const enqueueDocumentProcessingRunMock = mock(async () => undefined);
 const indexEntityMock = mock(async () => undefined);
 
@@ -105,6 +106,10 @@ void mock.module("@/api/lib/content-encryption", () => ({
 }));
 void mock.module("@/api/lib/document-processing-automatic-request", () => ({
   requestAutomaticDocumentOcr: requestAutomaticDocumentOcrMock,
+}));
+void mock.module("@/api/lib/document-processing-manual-ocr-restore", () => ({
+  restoreManualOcrRunAfterProjectionLoss:
+    restoreManualOcrRunAfterProjectionLossMock,
 }));
 void mock.module("@/api/lib/document-processing-enqueue", () => ({
   enqueueDocumentProcessingRun: enqueueDocumentProcessingRunMock,
@@ -183,6 +188,7 @@ beforeEach(() => {
     iv: Buffer.from("iv"),
   }));
   requestAutomaticDocumentOcrMock.mockClear();
+  restoreManualOcrRunAfterProjectionLossMock.mockClear();
   enqueueDocumentProcessingRunMock.mockClear();
   indexEntityMock.mockClear();
 });
@@ -350,6 +356,33 @@ describe("processExtraction", () => {
     expect(encryptContentMock).toHaveBeenCalledWith(organizationId, "");
     expect(executeMock).toHaveBeenCalledTimes(2);
     expect(requestAutomaticDocumentOcrMock).not.toHaveBeenCalled();
+    expect(restoreManualOcrRunAfterProjectionLossMock).not.toHaveBeenCalled();
+  });
+
+  test("restores manual OCR after native PDF extraction without automatic eligibility", async () => {
+    const outcome = await executeNativeExtraction({
+      fileField: fileContent,
+      lifecycleSignal: new AbortController().signal,
+      run: {
+        entityId,
+        entityVersionId,
+        fieldId,
+        organizationId,
+        sourceFileId: fileContent.id,
+        sourceSha256Hex: fileContent.sha256Hex,
+        workspaceId,
+      },
+    });
+
+    expect(outcome).toBe("persisted");
+    expect(restoreManualOcrRunAfterProjectionLossMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        entityId,
+        fieldId,
+        sourceFileId: fileContent.id,
+      }),
+    );
+    expect(requestAutomaticDocumentOcrMock).not.toHaveBeenCalled();
   });
 
   test("requests OCR for a textless extension-resolved PDF", async () => {
@@ -377,6 +410,7 @@ describe("processExtraction", () => {
     });
 
     expect(outcome).toBe("persisted");
+    expect(restoreManualOcrRunAfterProjectionLossMock).toHaveBeenCalled();
     expect(requestAutomaticDocumentOcrMock).toHaveBeenCalledWith(
       expect.objectContaining({
         entityId,
@@ -521,6 +555,13 @@ describe("processExtraction", () => {
     });
 
     expect(outcome).toBe("preserved");
+    expect(restoreManualOcrRunAfterProjectionLossMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        entityId,
+        fieldId,
+        sourceFileId: fileContent.id,
+      }),
+    );
     expect(requestAutomaticDocumentOcrMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/lib/search/process-extraction.ts
+++ b/apps/api/src/lib/search/process-extraction.ts
@@ -12,6 +12,7 @@ import { encryptContent } from "@/api/lib/content-encryption";
 import { requestAutomaticDocumentOcr } from "@/api/lib/document-processing-automatic-request";
 import { DOCUMENT_NATIVE_EXTRACTION_PROCESSOR_VERSION } from "@/api/lib/document-processing-contract";
 import { enqueueDocumentProcessingRun } from "@/api/lib/document-processing-enqueue";
+import { restoreManualOcrRunAfterProjectionLoss } from "@/api/lib/document-processing-manual-ocr-restore";
 import { shouldGeneratePdfDerivative } from "@/api/lib/files/pdf-derivative-policy";
 import { createFileKey } from "@/api/lib/files/utils";
 import { LIMITS } from "@/api/lib/limits";
@@ -284,6 +285,22 @@ export const executeNativeExtraction = async ({
     sourceSha256Hex: run.sourceSha256Hex,
     workspaceId: run.workspaceId,
   });
+  if (persistenceOutcome === "source_cancelled") {
+    return persistenceOutcome;
+  }
+
+  if (source.extractionMimeType === PDF_MIME_TYPE) {
+    await restoreManualOcrRunAfterProjectionLoss({
+      entityId: run.entityId,
+      entityVersionId: run.entityVersionId,
+      fieldId: run.fieldId,
+      organizationId: run.organizationId,
+      sourceFileId: run.sourceFileId,
+      sourceSha256Hex: run.sourceSha256Hex,
+      workspaceId: run.workspaceId,
+    });
+  }
+
   if (persistenceOutcome !== "persisted") {
     return persistenceOutcome;
   }


### PR DESCRIPTION
## Summary

- restore succeeded OCR runs after a version rollback when their exact OCR projection was replaced
- cover both manual and upload-originated OCR while leaving intact and non-succeeded runs unchanged
- retain native-extraction-before-OCR ordering and batch-scheduler delivery

Follow-up to #1812 and its final automated review finding.

## Verification

- focused OCR state and automatic-request tests
- process-extraction regression suite
- API typecheck
- affected-code, format, lint, secrets, and i18n checks

CC on behalf of jan-kubica

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OCR recovery when completed results are missing or no longer match the original request.
  * Manual and uploaded requests can now be restored or reprocessed when stored results are unavailable or inconsistent.
  * Native PDF extraction can restore previously completed manual OCR results when required.
  * Existing valid results remain unchanged.
  * Incomplete or unsuccessful OCR runs are not unnecessarily requeued.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->