### PR TITLE
refactor: close realtime event contracts

### DIFF
--- a/apps/api/src/handlers/entities/desktop-edit-session-events.ts
+++ b/apps/api/src/handlers/entities/desktop-edit-session-events.ts
@@ -1,5 +1,10 @@
 import { status, t } from "elysia";
 
+import type {
+  DesktopEditSessionClientEvent,
+  DesktopEditSessionRealtimeEvent,
+} from "@stll/api-contract";
+
 import { captureError } from "@/api/lib/analytics/capture";
 import type { SafeId } from "@/api/lib/branded-types";
 import { tSafeId } from "@/api/lib/custom-schema";
@@ -13,7 +18,6 @@ import {
   refreshDesktopEditSessionLiveness,
 } from "@/api/lib/desktop-edit-sessions";
 import { registerSessionDelivery } from "@/api/lib/sse";
-import type { SSEEvent } from "@/api/lib/sse";
 
 const SESSION_TOKEN_LENGTH = 64;
 const BEARER_PREFIX = "Bearer ";
@@ -45,7 +49,7 @@ const connections = new Map<
 
 const encoder = new TextEncoder();
 
-const formatSSE = (event: { type: string; data: unknown }): Uint8Array => {
+const formatSSE = (event: DesktopEditSessionClientEvent): Uint8Array => {
   const payload = JSON.stringify(event);
   return encoder.encode(`data: ${payload}\n\n`);
 };
@@ -58,7 +62,7 @@ const formatSSE = (event: { type: string; data: unknown }): Uint8Array => {
  */
 const deliverSessionEventLocal = (
   sessionId: SafeId<"desktopEditSession">,
-  event: SSEEvent,
+  event: DesktopEditSessionRealtimeEvent,
 ): void => {
   const conns = connections.get(sessionId);
   if (!conns) {

--- a/apps/api/src/lib/desktop-edit-session-notifications.ts
+++ b/apps/api/src/lib/desktop-edit-session-notifications.ts
@@ -1,27 +1,41 @@
+import {
+  REALTIME_EVENT_TYPE,
+  type DesktopEditSessionRealtimeEvent,
+} from "@stll/api-contract";
+
 import type { SafeId } from "@/api/lib/branded-types";
 import { broadcastSessionEvent } from "@/api/lib/sse";
-import type { SSEEvent } from "@/api/lib/sse-broadcast";
 
 export const DESKTOP_EDIT_SESSION_CLOSE_SIGNAL =
-  "__desktop_edit_session_closed__";
+  REALTIME_EVENT_TYPE.DESKTOP_EDIT_SESSION_CLOSED;
 
-export const desktopEditSessionClosedEvent = (reason: string): SSEEvent => ({
-  type: "session-closed",
+export const desktopEditSessionClosedEvent = (
+  reason: string,
+): DesktopEditSessionRealtimeEvent => ({
+  type: REALTIME_EVENT_TYPE.SESSION_CLOSED,
   data: { reason },
 });
 
-export const desktopEditSessionCloseSignal = (): SSEEvent => ({
-  type: DESKTOP_EDIT_SESSION_CLOSE_SIGNAL,
-  data: null,
-});
+type DesktopEditSessionCloseSignal = Extract<
+  DesktopEditSessionRealtimeEvent,
+  { type: typeof DESKTOP_EDIT_SESSION_CLOSE_SIGNAL }
+>;
 
-export const isDesktopEditSessionCloseSignal = (event: SSEEvent): boolean =>
+export const desktopEditSessionCloseSignal =
+  (): DesktopEditSessionCloseSignal => ({
+    type: DESKTOP_EDIT_SESSION_CLOSE_SIGNAL,
+    data: null,
+  });
+
+export const isDesktopEditSessionCloseSignal = (
+  event: DesktopEditSessionRealtimeEvent,
+): event is DesktopEditSessionCloseSignal =>
   event.type === DESKTOP_EDIT_SESSION_CLOSE_SIGNAL;
 
 /** Broadcast an event to this session's SSE streams on every API instance. */
 export const pushSessionEvent = (
   sessionId: SafeId<"desktopEditSession">,
-  event: SSEEvent,
+  event: DesktopEditSessionRealtimeEvent,
 ): void => {
   broadcastSessionEvent(sessionId, event);
 };

--- a/apps/api/src/lib/flows/flow-types.ts
+++ b/apps/api/src/lib/flows/flow-types.ts
@@ -1,5 +1,8 @@
 import * as v from "valibot";
 
+export { FLOW_RUN_STATUSES, FLOW_RUN_STEP_STATUSES } from "@stll/api-contract";
+export type { FlowRunStatus, FlowRunStepStatus } from "@stll/api-contract";
+
 /**
  * Shared types and boundary schemas for the Workflows feature.
  *
@@ -120,28 +123,6 @@ export type FlowDefinitionSnapshot = {
   name: string;
   steps: FlowStep[];
 };
-
-// -- Run / step status value unions --
-
-export const FLOW_RUN_STATUSES = [
-  "pending",
-  "running",
-  "awaiting_review",
-  "completed",
-  "failed",
-  "cancelled",
-] as const;
-export type FlowRunStatus = (typeof FLOW_RUN_STATUSES)[number];
-
-export const FLOW_RUN_STEP_STATUSES = [
-  "pending",
-  "running",
-  "awaiting_review",
-  "completed",
-  "failed",
-  "skipped",
-] as const;
-export type FlowRunStepStatus = (typeof FLOW_RUN_STEP_STATUSES)[number];
 
 // -- Boundary schemas (definition input validation) --
 

--- a/apps/api/src/lib/invalidate-query-macro.ts
+++ b/apps/api/src/lib/invalidate-query-macro.ts
@@ -1,5 +1,10 @@
 import Elysia, { t } from "elysia";
 
+import {
+  REALTIME_EVENT_TYPE,
+  type OrganizationRealtimeEvent,
+} from "@stll/api-contract";
+
 import { arrayOrEmpty } from "@/api/lib/array";
 import { authMacro } from "@/api/lib/auth";
 import type { SafeId } from "@/api/lib/branded-types";
@@ -13,8 +18,6 @@ const invalidateQueryBodySchema = t.Object({
   queryKeys: t.Optional(t.Array(queryKeySchema)),
 });
 
-const INVALIDATE_QUERY_EVENT_TYPE = "invalidate-query";
-
 // Elysia runs a macro's afterHandle even when an earlier beforeHandle
 // short-circuited the request (e.g. the /v1 rate limiter answering 429),
 // i.e. BEFORE validateAuth's resolve populated `session`. The static types
@@ -25,10 +28,11 @@ const INVALIDATE_QUERY_EVENT_TYPE = "invalidate-query";
 const didAuthResolve = (ctx: { session?: unknown }): boolean =>
   ctx.session !== undefined && ctx.session !== null;
 
-const createInvalidateQueryEvent = (queryKey: string[]) => ({
-  type: INVALIDATE_QUERY_EVENT_TYPE,
-  data: queryKey,
-});
+const createInvalidateQueryEvent = (queryKey: string[]) =>
+  ({
+    type: REALTIME_EVENT_TYPE.INVALIDATE_QUERY,
+    data: queryKey,
+  }) satisfies OrganizationRealtimeEvent;
 
 export const broadcastQueryInvalidationToOrganization = (
   organizationId: SafeId<"organization">,

--- a/apps/api/src/lib/scheduler/tasks/desktop-edit-session-expiry-notifications.ts
+++ b/apps/api/src/lib/scheduler/tasks/desktop-edit-session-expiry-notifications.ts
@@ -1,9 +1,13 @@
+import type {
+  DesktopEditSessionRealtimeEvent,
+  WorkspaceRealtimeEvent,
+} from "@stll/api-contract";
+
 import type { SafeId } from "@/api/lib/branded-types";
 import {
   desktopEditSessionClosedEvent,
   desktopEditSessionCloseSignal,
 } from "@/api/lib/desktop-edit-session-notifications";
-import type { SSEEvent } from "@/api/lib/sse-broadcast";
 
 export type ExpiredDesktopEditSessionNotification = {
   id: SafeId<"desktopEditSession">;
@@ -13,11 +17,11 @@ export type ExpiredDesktopEditSessionNotification = {
 export type DesktopEditSessionExpiryNotificationPublisher = {
   publishSessionEvent: (
     sessionId: SafeId<"desktopEditSession">,
-    event: SSEEvent,
+    event: DesktopEditSessionRealtimeEvent,
   ) => Promise<void>;
   publishWorkspaceEvent: (
     workspaceId: SafeId<"workspace">,
-    event: SSEEvent,
+    event: WorkspaceRealtimeEvent,
   ) => Promise<void>;
 };
 

--- a/apps/api/src/lib/scheduler/tasks/desktop-edit-session-expiry.test.ts
+++ b/apps/api/src/lib/scheduler/tasks/desktop-edit-session-expiry.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from "bun:test";
 
+import type {
+  DesktopEditSessionRealtimeEvent,
+  WorkspaceRealtimeEvent,
+} from "@stll/api-contract";
+
 import { toSafeId } from "@/api/lib/branded-types";
 import {
   buildExpiryAuditEvents,
@@ -10,7 +15,6 @@ import {
   publishDesktopEditSessionExpiryNotificationsWithRetry,
   type ExpiredDesktopEditSessionNotification,
 } from "@/api/lib/scheduler/tasks/desktop-edit-session-expiry-notifications";
-import type { SSEEvent } from "@/api/lib/sse-broadcast";
 
 const session = (id: string, createdBy: string) => ({
   id,
@@ -79,7 +83,7 @@ describe("buildExpiryAuditEvents", () => {
 type PublishedEvent = {
   scope: "session" | "workspace";
   id: string;
-  event: SSEEvent;
+  event: DesktopEditSessionRealtimeEvent | WorkspaceRealtimeEvent;
 };
 
 const notificationSession = (

--- a/apps/api/src/lib/sse-broadcast.test.ts
+++ b/apps/api/src/lib/sse-broadcast.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from "bun:test";
+
+import { REALTIME_EVENT_TYPE } from "@stll/api-contract";
+
+import { parseRedisPayload } from "@/api/lib/sse-broadcast";
+
+const redisPayload = (
+  scope: "organization" | "session" | "workspace",
+  event: unknown,
+) =>
+  JSON.stringify({ scope, id: "00000000-0000-4000-8000-000000000001", event });
+
+describe("SSE Redis payload parsing", () => {
+  test("accepts a valid event for each scope", () => {
+    expect(
+      parseRedisPayload(
+        redisPayload("workspace", {
+          type: REALTIME_EVENT_TYPE.FLOW_RUN_UPDATE,
+          data: {
+            runId: "00000000-0000-4000-8000-000000000002",
+            status: "running",
+            currentStepIndex: 0,
+            steps: [],
+          },
+        }),
+      )?.scope,
+    ).toBe("workspace");
+    expect(
+      parseRedisPayload(
+        redisPayload("organization", {
+          type: REALTIME_EVENT_TYPE.INVALIDATE_QUERY,
+          data: ["organizations"],
+        }),
+      )?.scope,
+    ).toBe("organization");
+    expect(
+      parseRedisPayload(
+        redisPayload("session", {
+          type: REALTIME_EVENT_TYPE.SESSION_CLOSED,
+          data: { reason: "expired" },
+        }),
+      )?.scope,
+    ).toBe("session");
+  });
+
+  test("rejects events that are malformed or invalid for their scope", () => {
+    expect(
+      parseRedisPayload(
+        redisPayload("workspace", {
+          type: REALTIME_EVENT_TYPE.INVALIDATE_QUERY,
+          data: ["entities", 42],
+        }),
+      ),
+    ).toBeNull();
+    expect(
+      parseRedisPayload(
+        redisPayload("organization", {
+          type: REALTIME_EVENT_TYPE.WORKFLOW_EXTRACTION_PREVIEW,
+          data: {
+            entityId: "00000000-0000-4000-8000-000000000002",
+            entityVersionId: "00000000-0000-4000-8000-000000000003",
+            propertyId: "00000000-0000-4000-8000-000000000004",
+            answer: "Draft answer",
+            status: "streaming",
+          },
+        }),
+      ),
+    ).toBeNull();
+    expect(
+      parseRedisPayload(
+        redisPayload("session", {
+          type: REALTIME_EVENT_TYPE.SESSION_TAKEN_OVER,
+          data: {},
+        }),
+      ),
+    ).toBeNull();
+  });
+});

--- a/apps/api/src/lib/sse-broadcast.ts
+++ b/apps/api/src/lib/sse-broadcast.ts
@@ -1,5 +1,14 @@
 import { TaggedError } from "better-result";
 
+import {
+  parseDesktopEditSessionRealtimeEvent,
+  parseOrganizationRealtimeEvent,
+  parseWorkspaceRealtimeEvent,
+  type DesktopEditSessionRealtimeEvent,
+  type OrganizationRealtimeEvent,
+  type WorkspaceRealtimeEvent,
+} from "@stll/api-contract";
+
 import type { SafeId } from "@/api/lib/branded-types";
 import { createRedisClient } from "@/api/lib/redis-client";
 
@@ -8,29 +17,24 @@ export const REDIS_CHANNEL = "sse:broadcast";
 
 export const INSTANCE_ID = `api:${process.pid}:${Bun.randomUUIDv7()}`;
 
-export type SSEEvent = {
-  type: string;
-  data: unknown;
-};
-
 type RedisPayload =
   | {
       scope: "organization";
       id: string;
-      event: SSEEvent;
+      event: OrganizationRealtimeEvent;
       originInstanceId?: string | undefined;
       deliveredInline?: boolean | undefined;
     }
   | {
       scope: "session";
       id: string;
-      event: SSEEvent;
+      event: DesktopEditSessionRealtimeEvent;
       originInstanceId?: string | undefined;
     }
   | {
       scope: "workspace";
       id: string;
-      event: SSEEvent;
+      event: WorkspaceRealtimeEvent;
       originInstanceId?: string | undefined;
       deliveredInline?: boolean | undefined;
     };
@@ -80,30 +84,32 @@ export const parseRedisPayload = (raw: string): RedisPayload | null => {
     return null;
   }
 
-  const event = parsed.event;
-  if (
-    typeof event !== "object" ||
-    event === null ||
-    !("type" in event) ||
-    typeof event.type !== "string"
-  ) {
-    return null;
+  const originInstanceId =
+    "originInstanceId" in parsed && typeof parsed.originInstanceId === "string"
+      ? parsed.originInstanceId
+      : undefined;
+
+  if (scope === "session") {
+    const event = parseDesktopEditSessionRealtimeEvent(parsed.event);
+    return event ? { scope, id: parsed.id, event, originInstanceId } : null;
   }
 
-  return {
-    scope,
-    id: parsed.id,
-    event: { type: event.type, data: "data" in event ? event.data : undefined },
-    originInstanceId:
-      "originInstanceId" in parsed &&
-      typeof parsed.originInstanceId === "string"
-        ? parsed.originInstanceId
-        : undefined,
-    deliveredInline:
-      "deliveredInline" in parsed && typeof parsed.deliveredInline === "boolean"
-        ? parsed.deliveredInline
-        : undefined,
-  };
+  const deliveredInline =
+    "deliveredInline" in parsed && typeof parsed.deliveredInline === "boolean"
+      ? parsed.deliveredInline
+      : undefined;
+
+  if (scope === "organization") {
+    const event = parseOrganizationRealtimeEvent(parsed.event);
+    return event
+      ? { scope, id: parsed.id, event, originInstanceId, deliveredInline }
+      : null;
+  }
+
+  const event = parseWorkspaceRealtimeEvent(parsed.event);
+  return event
+    ? { scope, id: parsed.id, event, originInstanceId, deliveredInline }
+    : null;
 };
 
 let publisher: ReturnType<typeof createRedisClient> | null = null;
@@ -127,7 +133,7 @@ const publishRedisPayload = async (payload: RedisPayload): Promise<void> => {
 
 export const publishWorkspaceEvent = async (
   workspaceId: SafeId<"workspace">,
-  event: SSEEvent,
+  event: WorkspaceRealtimeEvent,
   options: PublishOptions = {},
 ): Promise<void> => {
   await publishRedisPayload({
@@ -141,7 +147,7 @@ export const publishWorkspaceEvent = async (
 
 export const publishOrganizationEvent = async (
   organizationId: SafeId<"organization">,
-  event: SSEEvent,
+  event: OrganizationRealtimeEvent,
   options: PublishOptions = {},
 ): Promise<void> => {
   await publishRedisPayload({
@@ -155,7 +161,7 @@ export const publishOrganizationEvent = async (
 
 export const publishSessionEvent = async (
   sessionId: SafeId<"desktopEditSession">,
-  event: SSEEvent,
+  event: DesktopEditSessionRealtimeEvent,
   options: { originInstanceId?: string | undefined } = {},
 ): Promise<void> => {
   await publishRedisPayload({

--- a/apps/api/src/lib/sse.test.ts
+++ b/apps/api/src/lib/sse.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, mock, spyOn, test } from "bun:test";
 
+import {
+  REALTIME_EVENT_TYPE,
+  type WorkspaceRealtimeEvent,
+} from "@stll/api-contract";
+
 import { toSafeId } from "@/api/lib/branded-types";
 
 type MessageHandler = (message: string) => void;
@@ -128,6 +133,10 @@ const flushMicrotasks = async (): Promise<void> => {
 
 const workspaceId = toSafeId<"workspace">("ws_1");
 const organizationId = toSafeId<"organization">("org_1");
+const testEvent = (marker: string): WorkspaceRealtimeEvent => ({
+  type: REALTIME_EVENT_TYPE.INVALIDATE_QUERY,
+  data: ["sse-test", marker],
+});
 
 describe("sse module import", () => {
   test("importing the module opens no Redis connection and starts no timer", () => {
@@ -148,7 +157,7 @@ describe("sse module import", () => {
 
   test("broadcasting before startSse does not throw", async () => {
     expect(() =>
-      broadcast(workspaceId, { type: "test-event", data: null }),
+      broadcast(workspaceId, testEvent("before-start")),
     ).not.toThrow();
 
     await flushMicrotasks();
@@ -298,7 +307,7 @@ describe("subscribe: already-aborted signal", () => {
 
     // A subsequent broadcast must not resurrect or feed the dead stream:
     // nothing was registered, so there is nothing to enqueue into.
-    broadcast(workspaceId, { type: "after-abort", data: null });
+    broadcast(workspaceId, testEvent("after-abort"));
     await flushMicrotasks();
 
     const second = await reader.read();
@@ -317,7 +326,7 @@ describe("broadcast: local delivery without an attached subscriber", () => {
     const stream = subscribe(workspaceId, organizationId, controller.signal);
     const reader = stream.getReader();
 
-    broadcast(workspaceId, { type: "local-only", data: { n: 1 } });
+    broadcast(workspaceId, testEvent("local-only"));
 
     const { value } = await reader.read();
     const text = new TextDecoder().decode(value);
@@ -348,8 +357,8 @@ describe("broadcast: subscriber reconnect keeps delivery exactly-once", () => {
     // loopback (publish -> subscriber handler -> local delivery), never a
     // second inline copy. Reading two events in order proves the first was
     // delivered exactly once.
-    broadcast(workspaceId, { type: "event-a", data: null });
-    broadcast(workspaceId, { type: "event-b", data: null });
+    broadcast(workspaceId, testEvent("event-a"));
+    broadcast(workspaceId, testEvent("event-b"));
 
     expect(decode((await reader.read()).value)).toContain("event-a");
     expect(decode((await reader.read()).value)).toContain("event-b");
@@ -374,7 +383,7 @@ describe("broadcast: subscriber reconnect keeps delivery exactly-once", () => {
     const reader = stream.getReader();
 
     // Baseline: loopback delivery works while subscribed.
-    broadcast(workspaceId, { type: "before-drop", data: null });
+    broadcast(workspaceId, testEvent("before-drop"));
     expect(decode((await reader.read()).value)).toContain("before-drop");
 
     // Bun reconnects the socket but does NOT re-issue SUBSCRIBE: the client is
@@ -396,8 +405,8 @@ describe("broadcast: subscriber reconnect keeps delivery exactly-once", () => {
     // old code kept treating the reconnected client as attached, no loopback
     // would arrive and these reads would hang; if it re-subscribed on the same
     // client, each event would be delivered twice.
-    broadcast(workspaceId, { type: "after-reconnect-1", data: null });
-    broadcast(workspaceId, { type: "after-reconnect-2", data: null });
+    broadcast(workspaceId, testEvent("after-reconnect-1"));
+    broadcast(workspaceId, testEvent("after-reconnect-2"));
     expect(decode((await reader.read()).value)).toContain("after-reconnect-1");
     expect(decode((await reader.read()).value)).toContain("after-reconnect-2");
 
@@ -429,7 +438,7 @@ describe("broadcast: subscriber reconnect keeps delivery exactly-once", () => {
     }
     await flushMicrotasks();
 
-    broadcast(workspaceId, { type: "deaf-window", data: null });
+    broadcast(workspaceId, testEvent("deaf-window"));
     expect(decode((await reader.read()).value)).toContain("deaf-window");
 
     subscribeBehavior = "resolve";
@@ -466,14 +475,14 @@ describe("broadcast: subscriber reconnect keeps delivery exactly-once", () => {
     // Broadcast our own event in the window: delivered inline AND published with
     // our origin id + deliveredInline=true, so the copy that loops back through
     // the already-live subscription must be suppressed.
-    broadcast(workspaceId, { type: "own-in-window", data: null });
+    broadcast(workspaceId, testEvent("own-in-window"));
 
     // Exactly one copy (the inline one). Attaching the replacement and then
     // broadcasting a steady event that rides loopback only; reading it second
     // proves the windowed event was not delivered twice.
     expect(decode((await reader.read()).value)).toContain("own-in-window");
     await flushMicrotasks();
-    broadcast(workspaceId, { type: "after-window", data: null });
+    broadcast(workspaceId, testEvent("after-window"));
     expect(decode((await reader.read()).value)).toContain("after-window");
 
     controller.abort();
@@ -506,7 +515,7 @@ describe("broadcast: subscriber reconnect keeps delivery exactly-once", () => {
     const remotePayload = JSON.stringify({
       scope: "workspace",
       id: workspaceId,
-      event: { type: "remote-in-window", data: null },
+      event: testEvent("remote-in-window"),
       originInstanceId: "some-other-instance",
       deliveredInline: false,
     });
@@ -552,11 +561,11 @@ describe("broadcast: subscriber reconnect keeps delivery exactly-once", () => {
 
     // A loopback arrives on the OLD generation's still-live callback: the
     // generation gate must drop it. The replacement's loopback delivers once.
-    const workspacePayload = (type: string): string =>
+    const workspacePayload = (marker: string): string =>
       JSON.stringify({
         scope: "workspace",
         id: workspaceId,
-        event: { type, data: null },
+        event: testEvent(marker),
       });
     original?.messageHandler?.(workspacePayload("stale-old-generation"));
     replacement?.messageHandler?.(workspacePayload("fresh-new-generation"));

--- a/apps/api/src/lib/sse.ts
+++ b/apps/api/src/lib/sse.ts
@@ -1,3 +1,9 @@
+import type {
+  DesktopEditSessionRealtimeEvent,
+  OrganizationRealtimeEvent,
+  WorkspaceRealtimeEvent,
+} from "@stll/api-contract";
+
 import type { SafeId } from "@/api/lib/branded-types";
 import { connectionErrorFields, errorTag } from "@/api/lib/errors/utils";
 import { logger } from "@/api/lib/observability/logger";
@@ -15,12 +21,9 @@ import {
   publishWorkspaceEvent,
   REDIS_CHANNEL,
 } from "@/api/lib/sse-broadcast";
-import type { SSEEvent } from "@/api/lib/sse-broadcast";
 
 /** Keep-alive interval in milliseconds (20 seconds). */
 const KEEP_ALIVE_INTERVAL_MS = 20_000;
-
-export type { SSEEvent };
 
 type SSEConnection = {
   controller: ReadableStreamDefaultController;
@@ -32,7 +35,7 @@ const connections = new Map<SafeId<"workspace">, Set<SSEConnection>>();
 
 const encoder = new TextEncoder();
 
-const formatSSE = (event: SSEEvent): Uint8Array => {
+const formatSSE = (event: WorkspaceRealtimeEvent): Uint8Array => {
   const payload = JSON.stringify({ type: event.type, data: event.data });
   return encoder.encode(`data: ${payload}\n\n`);
 };
@@ -100,7 +103,7 @@ export const subscribe = (
 /** Push an SSE event to local connections for a workspace. */
 const broadcastLocal = (
   workspaceId: SafeId<"workspace">,
-  event: SSEEvent,
+  event: WorkspaceRealtimeEvent,
 ): void => {
   const set = connections.get(workspaceId);
   if (!set) {
@@ -125,7 +128,7 @@ const broadcastLocal = (
 /** Push an SSE event to local connections for an entire organization. */
 const broadcastLocalToOrganization = (
   organizationId: SafeId<"organization">,
-  event: SSEEvent,
+  event: OrganizationRealtimeEvent,
 ): void => {
   const chunk = formatSSE(event);
 
@@ -208,7 +211,7 @@ const handleMessage = (message: string) => {
  */
 export const broadcast = (
   workspaceId: SafeId<"workspace">,
-  event: SSEEvent,
+  event: WorkspaceRealtimeEvent,
 ): void => {
   // When this instance has no attached subscriber it never receives its
   // own published message back through the Redis loopback, so deliver
@@ -245,7 +248,7 @@ export const broadcast = (
 
 export const broadcastToOrganization = (
   organizationId: SafeId<"organization">,
-  event: SSEEvent,
+  event: OrganizationRealtimeEvent,
 ): void => {
   const deliveredLocally = !hasAttachedSubscriber();
   if (deliveredLocally) {
@@ -274,7 +277,7 @@ export const broadcastToOrganization = (
 
 type SessionDeliveryHandler = (
   sessionId: SafeId<"desktopEditSession">,
-  event: SSEEvent,
+  event: DesktopEditSessionRealtimeEvent,
 ) => void;
 
 let sessionDeliveryHandler: SessionDeliveryHandler | null = null;
@@ -296,7 +299,7 @@ export const registerSessionDelivery = (
  */
 export const broadcastSessionEvent = (
   sessionId: SafeId<"desktopEditSession">,
-  event: SSEEvent,
+  event: DesktopEditSessionRealtimeEvent,
 ): void => {
   sessionDeliveryHandler?.(sessionId, event);
 

--- a/apps/api/src/lib/workflow-queue.ts
+++ b/apps/api/src/lib/workflow-queue.ts
@@ -2407,7 +2407,7 @@ const broadcastWorkflowStatus = (
 
 const broadcastInvalidation = (
   workspaceId: SafeId<"workspace">,
-  queryKey: readonly string[],
+  queryKey: string[],
 ) => {
   broadcast(workspaceId, { type: "invalidate-query", data: queryKey });
 };

--- a/apps/web/src/lib/sse.ts
+++ b/apps/web/src/lib/sse.ts
@@ -1,44 +1,27 @@
 import { useQueryClient } from "@tanstack/react-query";
 
+import type { WorkspaceRealtimeEvent } from "@stll/api-contract";
+
 import { useExternalSyncEffect } from "@/hooks/use-effect";
 import { useLatestCallback } from "@/hooks/use-latest-callback";
 import { useAnalytics } from "@/lib/analytics/provider";
 import { apiUrl } from "@/lib/api-url";
 import { detached } from "@/lib/detached";
+import {
+  getWorkspaceRealtimeQueryKey,
+  parseWorkspaceRealtimeMessage,
+} from "@/lib/workspace-realtime";
 
-const INVALIDATE_QUERY_EVENT_TYPE = "invalidate-query";
 const WORKSPACE_SSE_EVENT_SOURCE_INIT = {
   withCredentials: true,
 } satisfies EventSourceInit;
 
-type WorkspaceSSEEvent = {
-  type: string;
-  data: unknown;
-};
-
 type UseWorkspaceSSEOptions = {
-  onEvent?: (event: WorkspaceSSEEvent) => void;
+  onEvent?: (event: WorkspaceRealtimeEvent) => void;
 };
 
 const getWorkspaceSSEUrl = (workspaceId: string) =>
   apiUrl(`/workspaces/${workspaceId}/events`);
-
-const parseWorkspaceSSEEvent = (data: string): WorkspaceSSEEvent | null => {
-  const parsed: unknown = JSON.parse(data);
-  if (
-    typeof parsed !== "object" ||
-    parsed === null ||
-    !("type" in parsed) ||
-    typeof parsed.type !== "string"
-  ) {
-    return null;
-  }
-
-  return {
-    type: parsed.type,
-    data: "data" in parsed ? parsed.data : undefined,
-  };
-};
 
 /**
  * Subscribe to workspace-scoped SSE events. On receiving an
@@ -55,19 +38,19 @@ export const useWorkspaceSSE = (
   const queryClient = useQueryClient();
   const analytics = useAnalytics();
 
-  const handleParsedEvent = useLatestCallback((event: WorkspaceSSEEvent) => {
-    options.onEvent?.(event);
+  const handleParsedEvent = useLatestCallback(
+    (event: WorkspaceRealtimeEvent) => {
+      options.onEvent?.(event);
 
-    if (
-      event.type === INVALIDATE_QUERY_EVENT_TYPE &&
-      Array.isArray(event.data)
-    ) {
-      detached(
-        queryClient.invalidateQueries({ queryKey: event.data }),
-        "useWorkspaceSSE",
-      );
-    }
-  });
+      const queryKey = getWorkspaceRealtimeQueryKey(event);
+      if (queryKey) {
+        detached(
+          queryClient.invalidateQueries({ queryKey }),
+          "useWorkspaceSSE",
+        );
+      }
+    },
+  );
   const captureClosedConnection = useLatestCallback(() => {
     analytics.captureError(
       new Error(`SSE connection closed for workspace ${workspaceId}`),
@@ -81,16 +64,12 @@ export const useWorkspaceSSE = (
     );
 
     const handleMessage = (event: MessageEvent) => {
-      try {
-        const parsed = parseWorkspaceSSEEvent(String(event.data));
-        if (!parsed) {
-          return;
-        }
-
-        handleParsedEvent(parsed);
-      } catch {
-        // Malformed SSE data; ignore.
+      const parsed = parseWorkspaceRealtimeMessage(String(event.data));
+      if (!parsed) {
+        return;
       }
+
+      handleParsedEvent(parsed);
     };
 
     const handleError = () => {

--- a/apps/web/src/lib/workspace-realtime.test.ts
+++ b/apps/web/src/lib/workspace-realtime.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "bun:test";
+
+import { REALTIME_EVENT_TYPE } from "@stll/api-contract";
+
+import {
+  getWorkspaceRealtimeQueryKey,
+  parseWorkspaceRealtimeMessage,
+} from "./workspace-realtime";
+
+describe("workspace realtime policy", () => {
+  test("returns the validated query key only for invalidation events", () => {
+    const event = parseWorkspaceRealtimeMessage(
+      JSON.stringify({
+        type: REALTIME_EVENT_TYPE.INVALIDATE_QUERY,
+        data: ["entities", "workspace-1"],
+      }),
+    );
+
+    expect(event).not.toBeNull();
+    if (!event) {
+      return;
+    }
+    expect(getWorkspaceRealtimeQueryKey(event)).toEqual([
+      "entities",
+      "workspace-1",
+    ]);
+  });
+
+  test("rejects malformed JSON, unknown events, and invalid query keys", () => {
+    expect(parseWorkspaceRealtimeMessage("not-json")).toBeNull();
+    expect(
+      parseWorkspaceRealtimeMessage(
+        JSON.stringify({ type: "unknown", data: null }),
+      ),
+    ).toBeNull();
+    expect(
+      parseWorkspaceRealtimeMessage(
+        JSON.stringify({
+          type: REALTIME_EVENT_TYPE.INVALIDATE_QUERY,
+          data: ["entities", 42],
+        }),
+      ),
+    ).toBeNull();
+  });
+
+  test("makes non-invalidation event behavior explicit", () => {
+    const event = parseWorkspaceRealtimeMessage(
+      JSON.stringify({
+        type: REALTIME_EVENT_TYPE.FLOW_RUN_UPDATE,
+        data: {
+          runId: "run-1",
+          status: "running",
+          currentStepIndex: 0,
+          steps: [],
+        },
+      }),
+    );
+
+    expect(event).not.toBeNull();
+    if (!event) {
+      return;
+    }
+    expect(getWorkspaceRealtimeQueryKey(event)).toBeNull();
+  });
+});

--- a/apps/web/src/lib/workspace-realtime.ts
+++ b/apps/web/src/lib/workspace-realtime.ts
@@ -1,0 +1,33 @@
+import {
+  parseWorkspaceRealtimeEvent,
+  REALTIME_EVENT_TYPE,
+  type WorkspaceRealtimeEvent,
+} from "@stll/api-contract";
+
+export const parseWorkspaceRealtimeMessage = (
+  data: string,
+): WorkspaceRealtimeEvent | null => {
+  try {
+    return parseWorkspaceRealtimeEvent(JSON.parse(data));
+  } catch {
+    return null;
+  }
+};
+
+/**
+ * Total query-cache policy for every workspace realtime event kind.
+ * A new union member cannot compile until its cache behavior is explicit.
+ */
+export const getWorkspaceRealtimeQueryKey = (
+  event: WorkspaceRealtimeEvent,
+): readonly string[] | null => {
+  switch (event.type) {
+    case REALTIME_EVENT_TYPE.INVALIDATE_QUERY:
+      return event.data;
+    case REALTIME_EVENT_TYPE.WORKFLOW_EXTRACTION_PREVIEW:
+    case REALTIME_EVENT_TYPE.FLOW_RUN_UPDATE:
+      return null;
+    default:
+      return event satisfies never;
+  }
+};

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/route.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/route.tsx
@@ -11,6 +11,10 @@ import {
 } from "@tanstack/react-router";
 import { useDebouncedCallback } from "use-debounce";
 
+import {
+  REALTIME_EVENT_TYPE,
+  type WorkspaceRealtimeEvent,
+} from "@stll/api-contract";
 import { stellaToast } from "@stll/ui/components/toast";
 
 import { useInspectorTabsStore } from "@/components/inspector/inspector-tabs-store";
@@ -36,38 +40,9 @@ import { useWorkspaceStore } from "@/lib/workspaces/store";
 import { ReportExportTracker } from "@/routes/_protected.workspaces/$workspaceId/-components/view/report-export-tracker";
 import { WorkspaceDropZone } from "@/routes/_protected.workspaces/$workspaceId/-components/workspace-drop-zone";
 
-const EXTRACTION_PREVIEW_EVENT_TYPE = "workflow-extraction-preview";
-const INVALIDATE_QUERY_EVENT_TYPE = "invalidate-query";
 const EXTRACTION_PREVIEW_CLIENT_TTL_MS = 5 * 60 * 1000;
 const ACTIVITY_INVALIDATION_DEBOUNCE_MS = 1000;
 const ACTIVITY_INVALIDATION_MAX_WAIT_MS = 5000;
-
-type ExtractionPreviewEventData = {
-  entityId: string;
-  propertyId: string;
-  answer: string | null;
-  status: "streaming" | "clear";
-};
-
-const isExtractionPreviewEventData = (
-  data: unknown,
-): data is ExtractionPreviewEventData => {
-  if (typeof data !== "object" || data === null) {
-    return false;
-  }
-  if (
-    !("entityId" in data) ||
-    typeof data.entityId !== "string" ||
-    !("propertyId" in data) ||
-    typeof data.propertyId !== "string" ||
-    !("status" in data) ||
-    (data.status !== "streaming" && data.status !== "clear") ||
-    !("answer" in data)
-  ) {
-    return false;
-  }
-  return typeof data.answer === "string" || data.answer === null;
-};
 
 const extractionPreviewKey = (entityId: string, propertyId: string) =>
   `${entityId}:${propertyId}`;
@@ -197,24 +172,22 @@ function RouteComponent() {
     { maxWait: ACTIVITY_INVALIDATION_MAX_WAIT_MS },
   );
 
-  const handleWorkspaceSSEEvent = ({
-    type,
-    data,
-  }: {
-    type: string;
-    data: unknown;
-  }) => {
-    if (type === INVALIDATE_QUERY_EVENT_TYPE) {
-      invalidateActivity(workspaceId);
+  const handleWorkspaceSSEEvent = (event: WorkspaceRealtimeEvent) => {
+    switch (event.type) {
+      case REALTIME_EVENT_TYPE.INVALIDATE_QUERY:
+        invalidateActivity(workspaceId);
+        return;
+      case REALTIME_EVENT_TYPE.FLOW_RUN_UPDATE:
+        return;
+      case REALTIME_EVENT_TYPE.WORKFLOW_EXTRACTION_PREVIEW:
+        break;
+      default:
+        event satisfies never;
+        return;
     }
 
+    const data = event.data;
     const workspaceStore = useWorkspaceStore.getState();
-    if (
-      type !== EXTRACTION_PREVIEW_EVENT_TYPE ||
-      !isExtractionPreviewEventData(data)
-    ) {
-      return;
-    }
 
     // Backend sends "clear" right after the entity-invalidation
     // broadcast, but the invalidation's refetch needs a network

--- a/packages/api-contract/src/flow-status.ts
+++ b/packages/api-contract/src/flow-status.ts
@@ -1,0 +1,21 @@
+export const FLOW_RUN_STATUSES = [
+  "pending",
+  "running",
+  "awaiting_review",
+  "completed",
+  "failed",
+  "cancelled",
+] as const;
+
+export type FlowRunStatus = (typeof FLOW_RUN_STATUSES)[number];
+
+export const FLOW_RUN_STEP_STATUSES = [
+  "pending",
+  "running",
+  "awaiting_review",
+  "completed",
+  "failed",
+  "skipped",
+] as const;
+
+export type FlowRunStepStatus = (typeof FLOW_RUN_STEP_STATUSES)[number];

--- a/packages/api-contract/src/index.ts
+++ b/packages/api-contract/src/index.ts
@@ -40,6 +40,20 @@ export type {
   DocumentVersionUploadReservationInput,
   UploadLifecycleInput,
 } from "./document-version-upload";
+export { FLOW_RUN_STATUSES, FLOW_RUN_STEP_STATUSES } from "./flow-status";
+export type { FlowRunStatus, FlowRunStepStatus } from "./flow-status";
+export {
+  parseDesktopEditSessionRealtimeEvent,
+  parseOrganizationRealtimeEvent,
+  parseWorkspaceRealtimeEvent,
+  REALTIME_EVENT_TYPE,
+} from "./realtime-events";
+export type {
+  DesktopEditSessionClientEvent,
+  DesktopEditSessionRealtimeEvent,
+  OrganizationRealtimeEvent,
+  WorkspaceRealtimeEvent,
+} from "./realtime-events";
 
 /** Path prefix shared by the REST router and direct-fetch clients. */
 export const STELLA_API_VERSION_PREFIX = "/v1" as const;

--- a/packages/api-contract/src/realtime-events.test.ts
+++ b/packages/api-contract/src/realtime-events.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  parseDesktopEditSessionRealtimeEvent,
+  parseOrganizationRealtimeEvent,
+  parseWorkspaceRealtimeEvent,
+  REALTIME_EVENT_TYPE,
+  type OrganizationRealtimeEvent,
+  type WorkspaceRealtimeEvent,
+} from "./realtime-events";
+
+const INVALIDATE_QUERY_EVENT = {
+  type: REALTIME_EVENT_TYPE.INVALIDATE_QUERY,
+  data: ["entities", "workspace-1"],
+} satisfies OrganizationRealtimeEvent;
+
+const WORKSPACE_EVENT_FIXTURES = [
+  INVALIDATE_QUERY_EVENT,
+  {
+    type: REALTIME_EVENT_TYPE.WORKFLOW_EXTRACTION_PREVIEW,
+    data: {
+      entityId: "entity-1",
+      entityVersionId: "entity-version-1",
+      propertyId: "property-1",
+      answer: "Draft answer",
+      status: "streaming",
+    },
+  },
+  {
+    type: REALTIME_EVENT_TYPE.FLOW_RUN_UPDATE,
+    data: {
+      runId: "run-1",
+      status: "running",
+      currentStepIndex: 0,
+      steps: [{ index: 0, status: "running" }],
+    },
+  },
+] satisfies WorkspaceRealtimeEvent[];
+
+describe("realtime event contracts", () => {
+  test("accepts every workspace event kind", () => {
+    expect(
+      WORKSPACE_EVENT_FIXTURES.map((event) =>
+        parseWorkspaceRealtimeEvent(event),
+      ),
+    ).toEqual(WORKSPACE_EVENT_FIXTURES);
+  });
+
+  test("rejects unknown and malformed workspace events", () => {
+    expect(
+      parseWorkspaceRealtimeEvent({ type: "unknown", data: null }),
+    ).toBeNull();
+    expect(
+      parseWorkspaceRealtimeEvent({
+        type: REALTIME_EVENT_TYPE.INVALIDATE_QUERY,
+        data: [],
+      }),
+    ).toBeNull();
+    expect(
+      parseWorkspaceRealtimeEvent({
+        type: REALTIME_EVENT_TYPE.INVALIDATE_QUERY,
+        data: ["entities", 42],
+      }),
+    ).toBeNull();
+    expect(
+      parseWorkspaceRealtimeEvent({
+        type: REALTIME_EVENT_TYPE.WORKFLOW_EXTRACTION_PREVIEW,
+        data: { entityId: "entity-1" },
+      }),
+    ).toBeNull();
+  });
+
+  test("limits organization events to organization-safe kinds", () => {
+    expect(parseOrganizationRealtimeEvent(INVALIDATE_QUERY_EVENT)).toEqual(
+      INVALIDATE_QUERY_EVENT,
+    );
+    expect(
+      parseOrganizationRealtimeEvent(WORKSPACE_EVENT_FIXTURES[1]),
+    ).toBeNull();
+  });
+
+  test("validates desktop session client events and the close signal", () => {
+    expect(
+      parseDesktopEditSessionRealtimeEvent({
+        type: REALTIME_EVENT_TYPE.TAKEOVER_REQUESTED,
+        data: {
+          requestedBy: "Another user",
+          requestedAt: "2026-08-08T12:00:00.000Z",
+        },
+      }),
+    ).not.toBeNull();
+    expect(
+      parseDesktopEditSessionRealtimeEvent({
+        type: REALTIME_EVENT_TYPE.DESKTOP_EDIT_SESSION_CLOSED,
+        data: null,
+      }),
+    ).not.toBeNull();
+    expect(
+      parseDesktopEditSessionRealtimeEvent({
+        type: REALTIME_EVENT_TYPE.SESSION_TAKEN_OVER,
+        data: {},
+      }),
+    ).toBeNull();
+  });
+});

--- a/packages/api-contract/src/realtime-events.test.ts
+++ b/packages/api-contract/src/realtime-events.test.ts
@@ -101,5 +101,14 @@ describe("realtime event contracts", () => {
         data: {},
       }),
     ).toBeNull();
+    expect(
+      parseDesktopEditSessionRealtimeEvent({
+        type: REALTIME_EVENT_TYPE.TAKEOVER_REQUESTED,
+        data: {
+          requestedBy: "Another user",
+          requestedAt: "not-a-timestamp",
+        },
+      }),
+    ).toBeNull();
   });
 });

--- a/packages/api-contract/src/realtime-events.ts
+++ b/packages/api-contract/src/realtime-events.ts
@@ -1,0 +1,120 @@
+import * as v from "valibot";
+
+import { FLOW_RUN_STATUSES, FLOW_RUN_STEP_STATUSES } from "./flow-status";
+
+export const REALTIME_EVENT_TYPE = {
+  DESKTOP_EDIT_SESSION_CLOSED: "__desktop_edit_session_closed__",
+  FLOW_RUN_UPDATE: "flow-run-update",
+  INVALIDATE_QUERY: "invalidate-query",
+  SESSION_CLOSED: "session-closed",
+  SESSION_TAKEN_OVER: "session-taken-over",
+  TAKEOVER_REQUESTED: "takeover-requested",
+  WORKFLOW_EXTRACTION_PREVIEW: "workflow-extraction-preview",
+} as const;
+
+const nonEmptyStringSchema = v.pipe(v.string(), v.minLength(1));
+
+const invalidateQueryEventSchema = v.object({
+  type: v.literal(REALTIME_EVENT_TYPE.INVALIDATE_QUERY),
+  data: v.pipe(v.array(nonEmptyStringSchema), v.minLength(1)),
+});
+
+const workflowExtractionPreviewEventSchema = v.object({
+  type: v.literal(REALTIME_EVENT_TYPE.WORKFLOW_EXTRACTION_PREVIEW),
+  data: v.object({
+    entityId: nonEmptyStringSchema,
+    entityVersionId: nonEmptyStringSchema,
+    propertyId: nonEmptyStringSchema,
+    answer: v.nullable(v.string()),
+    status: v.picklist(["streaming", "clear"]),
+  }),
+});
+
+const flowRunUpdateEventSchema = v.object({
+  type: v.literal(REALTIME_EVENT_TYPE.FLOW_RUN_UPDATE),
+  data: v.object({
+    runId: nonEmptyStringSchema,
+    status: v.picklist(FLOW_RUN_STATUSES),
+    currentStepIndex: v.number(),
+    steps: v.array(
+      v.object({
+        index: v.number(),
+        status: v.picklist(FLOW_RUN_STEP_STATUSES),
+      }),
+    ),
+  }),
+});
+
+const workspaceRealtimeEventSchema = v.variant("type", [
+  invalidateQueryEventSchema,
+  workflowExtractionPreviewEventSchema,
+  flowRunUpdateEventSchema,
+]);
+
+const organizationRealtimeEventSchema = invalidateQueryEventSchema;
+
+export type WorkspaceRealtimeEvent = v.InferOutput<
+  typeof workspaceRealtimeEventSchema
+>;
+export type OrganizationRealtimeEvent = v.InferOutput<
+  typeof organizationRealtimeEventSchema
+>;
+
+const takeoverRequestedEventSchema = v.object({
+  type: v.literal(REALTIME_EVENT_TYPE.TAKEOVER_REQUESTED),
+  data: v.object({
+    requestedBy: nonEmptyStringSchema,
+    requestedAt: nonEmptyStringSchema,
+  }),
+});
+
+const sessionTakenOverEventSchema = v.object({
+  type: v.literal(REALTIME_EVENT_TYPE.SESSION_TAKEN_OVER),
+  data: v.object({ message: nonEmptyStringSchema }),
+});
+
+const sessionClosedEventSchema = v.object({
+  type: v.literal(REALTIME_EVENT_TYPE.SESSION_CLOSED),
+  data: v.object({ reason: nonEmptyStringSchema }),
+});
+
+const desktopEditSessionClosedEventSchema = v.object({
+  type: v.literal(REALTIME_EVENT_TYPE.DESKTOP_EDIT_SESSION_CLOSED),
+  data: v.null(),
+});
+
+const desktopEditSessionRealtimeEventSchema = v.variant("type", [
+  takeoverRequestedEventSchema,
+  sessionTakenOverEventSchema,
+  sessionClosedEventSchema,
+  desktopEditSessionClosedEventSchema,
+]);
+
+export type DesktopEditSessionRealtimeEvent = v.InferOutput<
+  typeof desktopEditSessionRealtimeEventSchema
+>;
+export type DesktopEditSessionClientEvent = Exclude<
+  DesktopEditSessionRealtimeEvent,
+  { type: typeof REALTIME_EVENT_TYPE.DESKTOP_EDIT_SESSION_CLOSED }
+>;
+
+export const parseWorkspaceRealtimeEvent = (
+  input: unknown,
+): WorkspaceRealtimeEvent | null => {
+  const result = v.safeParse(workspaceRealtimeEventSchema, input);
+  return result.success ? result.output : null;
+};
+
+export const parseOrganizationRealtimeEvent = (
+  input: unknown,
+): OrganizationRealtimeEvent | null => {
+  const result = v.safeParse(organizationRealtimeEventSchema, input);
+  return result.success ? result.output : null;
+};
+
+export const parseDesktopEditSessionRealtimeEvent = (
+  input: unknown,
+): DesktopEditSessionRealtimeEvent | null => {
+  const result = v.safeParse(desktopEditSessionRealtimeEventSchema, input);
+  return result.success ? result.output : null;
+};

--- a/packages/api-contract/src/realtime-events.ts
+++ b/packages/api-contract/src/realtime-events.ts
@@ -64,7 +64,7 @@ const takeoverRequestedEventSchema = v.object({
   type: v.literal(REALTIME_EVENT_TYPE.TAKEOVER_REQUESTED),
   data: v.object({
     requestedBy: nonEmptyStringSchema,
-    requestedAt: nonEmptyStringSchema,
+    requestedAt: v.pipe(v.string(), v.isoTimestamp()),
   }),
 });
 


### PR DESCRIPTION
## Summary

- define shared, scope-specific realtime event schemas for workspace, organization, and desktop-session streams
- validate Redis and browser event payloads before delivery or query invalidation
- make workspace cache behavior exhaustive while preserving the existing `{ type, data }` wire format
- cover scope mismatches, malformed query keys, and transport lifecycle behavior

Validated with `bun run verify`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added shared, validated realtime event handling across workspace, organisation, and desktop editing sessions.
  * Added support for flow-run and step status values, including cancelled and skipped states.
* **Bug Fixes**
  * Invalid or malformed realtime messages are now safely ignored.
  * Improved filtering to prevent incorrectly scoped events from being processed.
* **Tests**
  * Expanded coverage for realtime message parsing, event validation, query invalidation, and session notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->