### PR TITLE
feat: upgrade email viewer

### DIFF
--- a/apps/api/src/handlers/files/get.ts
+++ b/apps/api/src/handlers/files/get.ts
@@ -14,7 +14,7 @@ import { contentDisposition } from "@/api/lib/content-disposition";
 import { injectStamp, isStampableDocx } from "@/api/lib/docx-stamp";
 import { fetchWithTimeout } from "@/api/lib/fetch";
 import {
-  emailToHtml,
+  emailToPreview,
   resolveEmailMimeType,
 } from "@/api/lib/files/email-to-html";
 import {
@@ -254,10 +254,10 @@ export const readEmailHtmlPreviewHandler = async ({
     mimeType: content.mimeType,
   });
   const fileBuffer = await readS3ArrayBuffer(fileKey);
-  const htmlResult = await emailToHtml(fileBuffer, emailMimeType);
+  const previewResult = await emailToPreview(fileBuffer, emailMimeType);
 
-  if (Result.isError(htmlResult)) {
-    captureError(htmlResult.error, {
+  if (Result.isError(previewResult)) {
+    captureError(previewResult.error, {
       fieldId,
       mimeType: emailMimeType,
       workspaceId,
@@ -265,13 +265,7 @@ export const readEmailHtmlPreviewHandler = async ({
     return status(422, { message: "Failed to render email preview" });
   }
 
-  return {
-    fileId: content.id,
-    fileName: content.fileName,
-    html: htmlResult.value,
-    mimeType: "text/html",
-    originalMimeType: emailMimeType,
-  };
+  return previewResult.value;
 };
 
 // ── Stamped download (separate endpoint) ────────────────

--- a/apps/api/src/lib/files/email-to-html.test.ts
+++ b/apps/api/src/lib/files/email-to-html.test.ts
@@ -380,6 +380,13 @@ describe("emailToHtml (.eml)", () => {
     'Content-Disposition: attachment; filename="notes.txt"',
     "",
     "Attachment text",
+    "--BND",
+    "Content-Type: image/png",
+    "Content-Transfer-Encoding: base64",
+    "Content-ID: <evidence456>",
+    'Content-Disposition: attachment; filename="evidence.png"',
+    "",
+    PNG_BASE64,
     "--BND--",
     "",
   ].join("\r\n");
@@ -453,7 +460,7 @@ describe("emailToHtml (.eml)", () => {
     );
   });
 
-  test("lists ordinary attachments without duplicating inline CID images", async () => {
+  test("hides referenced inline images but preserves unreferenced CID attachments", async () => {
     const result = await emailToPreview(toArrayBuffer(eml), "message/rfc822");
     expect(Result.isOk(result)).toBe(true);
     if (Result.isError(result)) {
@@ -465,6 +472,11 @@ describe("emailToHtml (.eml)", () => {
         fileName: "notes.txt",
         mimeType: "text/plain",
         sizeBytes: 16,
+      },
+      {
+        fileName: "evidence.png",
+        mimeType: "image/png",
+        sizeBytes: Buffer.from(PNG_BASE64, "base64").byteLength,
       },
     ]);
   });

--- a/apps/api/src/lib/files/email-to-html.test.ts
+++ b/apps/api/src/lib/files/email-to-html.test.ts
@@ -8,6 +8,7 @@ import {
   parsedEmailToText,
   parseEmail,
   type ParsedEmail,
+  renderEmailBodyHtml,
   renderEmailHtml,
   resolveEmailMimeType,
 } from "./email-to-html";
@@ -117,6 +118,38 @@ describe("renderEmailHtml", () => {
   test("keeps benign body markup", () => {
     const html = renderEmailHtml(htmlEmail());
     expect(html).toContain("Hello <b>world</b>");
+  });
+
+  test("preserves explicit body direction and defaults direction when absent", () => {
+    const bodyDirection = renderEmailBodyHtml(
+      htmlEmail({
+        body: {
+          type: "html",
+          html: '<html><body dir="rtl"><p>Hello مرحبا</p></body></html>',
+        },
+      }),
+    );
+    const documentDirection = renderEmailBodyHtml(
+      htmlEmail({
+        body: {
+          type: "html",
+          html: '<html dir="ltr"><body><p>Hello مرحبا</p></body></html>',
+        },
+      }),
+    );
+    const inferredDirection = renderEmailBodyHtml(
+      htmlEmail({
+        body: {
+          type: "html",
+          html: "<html><body><p>Hello مرحبا</p></body></html>",
+        },
+      }),
+    );
+
+    expect(bodyDirection).toContain('<body dir="rtl">');
+    expect(documentDirection).toContain('<html dir="ltr">');
+    expect(documentDirection).not.toContain('<body dir="auto">');
+    expect(inferredDirection).toContain('<body dir="auto">');
   });
 
   test("inlines cid: images and drops the cid reference", () => {

--- a/apps/api/src/lib/files/email-to-html.test.ts
+++ b/apps/api/src/lib/files/email-to-html.test.ts
@@ -2,7 +2,9 @@ import { Result } from "better-result";
 import { describe, expect, test } from "bun:test";
 
 import {
+  buildEmailPreview,
   emailToHtml,
+  emailToPreview,
   parsedEmailToText,
   parseEmail,
   type ParsedEmail,
@@ -65,6 +67,7 @@ describe("renderEmailHtml", () => {
     from: "Jane Lawyer <jane@example.com>",
     to: ["client@example.org"],
     cc: [],
+    bcc: [],
     date: "Mon, 02 Jun 2026 10:00:00 +0000",
     body: {
       type: "html",
@@ -254,6 +257,80 @@ describe("renderEmailHtml", () => {
     expect(html).toContain("&lt;not a tag&gt;");
   });
 
+  test("keeps nested message headers while stripping duplicate raw headers and fetch vectors", () => {
+    const preview = buildEmailPreview(
+      htmlEmail({
+        subject: "Návrh smlouvy ⚖️",
+        from: "Žofie Nováková <zofie@example.cz>",
+        to: ["李雷 <li@example.cn>"],
+        cc: ["Renée <renee@example.fr>"],
+        bcc: ["عائشة <aisha@example.ae>"],
+        body: {
+          type: "html",
+          html: [
+            '<div class="postal-email-header">',
+            '<div class="postal-email-header-value">Forwarded message</div>',
+            "</div>",
+            "<div>",
+            "From: Žofie Nováková &lt;zofie@example.cz&gt;<br>",
+            "To: 李雷 &lt;li@example.cn&gt;<br>",
+            "Subject: Návrh smlouvy ⚖️<br><br>",
+            '<p style="background: url(https://attacker.example/style)">Message content</p>',
+            '<img src="https://attacker.example/pixel.gif" onerror="steal()">',
+            '<a href="https://attacker.example/link" ping="https://attacker.example/ping">safe text</a>',
+            '<form action="https://attacker.example/submit"><input value="x"></form>',
+            "<script>steal()</script><style>@import url(https://attacker.example/css)</style>",
+            "</div>",
+          ].join(""),
+        },
+        attachments: [
+          {
+            contentId: "attachment-id",
+            fileName: "evidence.pdf",
+            mimeType: "application/pdf",
+            bytes: new Uint8Array([1, 2, 3]),
+          },
+        ],
+      }),
+    );
+
+    expect(preview).toMatchObject({
+      subject: "Návrh smlouvy ⚖️",
+      from: "Žofie Nováková <zofie@example.cz>",
+      to: ["李雷 <li@example.cn>"],
+      cc: ["Renée <renee@example.fr>"],
+      bcc: ["عائشة <aisha@example.ae>"],
+      attachments: [
+        {
+          fileName: "evidence.pdf",
+          mimeType: "application/pdf",
+          sizeBytes: 3,
+        },
+      ],
+    });
+    expect(Object.keys(preview.attachments.at(0) ?? {})).toEqual([
+      "fileName",
+      "mimeType",
+      "sizeBytes",
+    ]);
+    expect(preview.bodyHtml).toStartWith("<!DOCTYPE html>");
+    expect(preview.bodyHtml).toContain(
+      "Content-Security-Policy\" content=\"default-src 'none'; img-src data:",
+    );
+    expect(preview.bodyHtml).toContain('<body dir="auto">');
+    expect(preview.bodyHtml).toContain("Forwarded message");
+    expect(preview.bodyHtml).toContain("Message content");
+    expect(preview.bodyHtml).not.toContain("Návrh smlouvy ⚖️");
+    expect(preview.bodyHtml).not.toContain("zofie@example.cz");
+    expect(preview.bodyHtml).not.toContain("li@example.cn");
+    expect(preview.bodyHtml).not.toContain("attacker.example");
+    expect(preview.bodyHtml).not.toContain("<script");
+    expect(preview.bodyHtml).not.toContain("@import");
+    expect(preview.bodyHtml).not.toContain('style="');
+    expect(preview.bodyHtml).not.toContain("<form");
+    expect(preview.bodyHtml).not.toContain("onerror");
+  });
+
   test("formats sanitized headers and body text for extraction", () => {
     const text = parsedEmailToText(
       htmlEmail({
@@ -374,5 +451,46 @@ describe("emailToHtml (.eml)", () => {
     expect(new TextDecoder().decode(attachment.bytes).trim()).toBe(
       "Attachment text",
     );
+  });
+
+  test("lists ordinary attachments without duplicating inline CID images", async () => {
+    const result = await emailToPreview(toArrayBuffer(eml), "message/rfc822");
+    expect(Result.isOk(result)).toBe(true);
+    if (Result.isError(result)) {
+      return;
+    }
+
+    expect(result.value.attachments).toEqual([
+      {
+        fileName: "notes.txt",
+        mimeType: "text/plain",
+        sizeBytes: 16,
+      },
+    ]);
+  });
+
+  test("preserves internationalized recipients, Bcc, and a received date in preview metadata", async () => {
+    const unicodeEml = [
+      "From: Žofie Nováková <zofie@example.cz>",
+      "To: 李雷 <li@example.cn>",
+      "Cc: Renée <renee@example.fr>",
+      "Bcc: عائشة <aisha@example.ae>",
+      "Subject: Návrh smlouvy ⚖️",
+      "Date: Tue, 02 Jun 2026 12:30:00 +0200",
+      "Content-Type: text/plain; charset=utf-8",
+      "",
+      "Dobrý den",
+    ].join("\r\n");
+
+    const preview = buildEmailPreview(
+      await parseEmail(toArrayBuffer(unicodeEml), "message/rfc822"),
+    );
+
+    expect(preview.from).toBe("Žofie Nováková <zofie@example.cz>");
+    expect(preview.to).toEqual(["李雷 <li@example.cn>"]);
+    expect(preview.cc).toEqual(["Renée <renee@example.fr>"]);
+    expect(preview.bcc).toEqual(["عائشة <aisha@example.ae>"]);
+    expect(preview.date).toBe("2026-06-02T10:30:00.000Z");
+    expect(preview.bodyHtml).toContain("Dobrý den");
   });
 });

--- a/apps/api/src/lib/files/email-to-html.test.ts
+++ b/apps/api/src/lib/files/email-to-html.test.ts
@@ -364,6 +364,43 @@ describe("renderEmailHtml", () => {
     expect(preview.bodyHtml).not.toContain("onerror");
   });
 
+  test("keeps a CID attachment when sanitization removes its only reference", () => {
+    const preview = buildEmailPreview(
+      htmlEmail({
+        body: {
+          type: "html",
+          html: '<form><img src="cid:evidence"></form><p>Visible body</p>',
+        },
+        inlineImages: [
+          {
+            cid: "evidence",
+            mimeType: "image/png",
+            dataBase64: PNG_BASE64,
+          },
+        ],
+        attachments: [
+          {
+            contentId: "evidence",
+            fileName: "evidence.png",
+            mimeType: "image/png",
+            bytes: new Uint8Array([1, 2, 3]),
+          },
+        ],
+      }),
+    );
+
+    expect(preview.attachments).toEqual([
+      {
+        fileName: "evidence.png",
+        mimeType: "image/png",
+        sizeBytes: 3,
+      },
+    ]);
+    expect(preview.bodyHtml).toContain("Visible body");
+    expect(preview.bodyHtml).not.toContain("cid:evidence");
+    expect(preview.bodyHtml).not.toContain("<form");
+  });
+
   test("formats sanitized headers and body text for extraction", () => {
     const text = parsedEmailToText(
       htmlEmail({

--- a/apps/api/src/lib/files/email-to-html.ts
+++ b/apps/api/src/lib/files/email-to-html.ts
@@ -32,6 +32,12 @@ const EMAIL_EXTENSION_MIME_TYPES: Record<string, string> = {
   msg: MSG_MIME_TYPE,
 };
 
+const EMAIL_WRITING_DIRECTIONS = {
+  auto: null,
+  ltr: null,
+  rtl: null,
+} as const;
+
 export const isEmailMimeType = (mimeType: string): boolean =>
   mimeType in EMAIL_MIME_TYPES;
 
@@ -559,9 +565,21 @@ export const renderEmailBodyHtml = (parsed: ParsedEmail): string => {
   );
   $("head").append('<meta name="color-scheme" content="light">');
   $("head").append(`<style>${EMAIL_PREVIEW_CSS}</style>`);
-  $("body").attr("dir", "auto");
+  if (!hasExplicitWritingDirection($)) {
+    $("body").attr("dir", "auto");
+  }
 
   return `<!DOCTYPE html>${$.html()}`;
+};
+
+const hasExplicitWritingDirection = ($: CheerioApi): boolean => {
+  const htmlDirection = $("html").attr("dir")?.trim().toLowerCase();
+  const bodyDirection = $("body").attr("dir")?.trim().toLowerCase();
+  return (
+    (htmlDirection !== undefined &&
+      htmlDirection in EMAIL_WRITING_DIRECTIONS) ||
+    (bodyDirection !== undefined && bodyDirection in EMAIL_WRITING_DIRECTIONS)
+  );
 };
 
 const emailBodyToText = (body: EmailBody): string => {

--- a/apps/api/src/lib/files/email-to-html.ts
+++ b/apps/api/src/lib/files/email-to-html.ts
@@ -152,7 +152,7 @@ export const buildEmailPreview = (parsed: ParsedEmail): EmailPreview => {
   const inlineContentIds = new Set(
     parsed.inlineImages.map(({ cid }) => cid.toLowerCase()),
   );
-  const referencedContentIds = getReferencedInlineContentIds(parsed.body);
+  const renderedBody = renderEmailBody(parsed);
 
   return {
     subject: parsed.subject,
@@ -166,32 +166,15 @@ export const buildEmailPreview = (parsed: ParsedEmail): EmailPreview => {
         ({ contentId }) =>
           !contentId ||
           !inlineContentIds.has(contentId.toLowerCase()) ||
-          !referencedContentIds.has(contentId.toLowerCase()),
+          !renderedBody.referencedContentIds.has(contentId.toLowerCase()),
       )
       .map(({ fileName, mimeType, bytes }) => ({
         fileName,
         mimeType,
         sizeBytes: bytes.byteLength,
       })),
-    bodyHtml: renderEmailBodyHtml(parsed),
+    bodyHtml: renderedBody.bodyHtml,
   };
-};
-
-const getReferencedInlineContentIds = (body: EmailBody): Set<string> => {
-  const contentIds = new Set<string>();
-  if (body.type !== "html") {
-    return contentIds;
-  }
-
-  const $ = load(body.html);
-  $("img").each((_, element) => {
-    const src = $(element).attr("src")?.trim();
-    if (!src || !src.toLowerCase().startsWith("cid:")) {
-      return;
-    }
-    contentIds.add(stripAngleBrackets(src.slice("cid:".length)).toLowerCase());
-  });
-  return contentIds;
 };
 
 export const parseEmail = async (
@@ -547,14 +530,23 @@ export const renderEmailHtml = (parsed: ParsedEmail): string => {
  * display it once, outside untrusted email HTML. Nested message headers are
  * retained because they describe forwarded message content.
  */
-export const renderEmailBodyHtml = (parsed: ParsedEmail): string => {
+type RenderedEmailBody = {
+  bodyHtml: string;
+  referencedContentIds: Set<string>;
+};
+
+const renderEmailBody = (parsed: ParsedEmail): RenderedEmailBody => {
   if (parsed.body.type === "text") {
-    return `<!DOCTYPE html><html><head><meta charset="utf-8"><meta http-equiv="Content-Security-Policy" content="${EMAIL_PREVIEW_CSP}"><meta name="color-scheme" content="light"><style>${EMAIL_PREVIEW_CSS}</style></head><body dir="auto"><pre style="${PRE_STYLE}">${escapeHtml(parsed.body.text)}</pre></body></html>`;
+    return {
+      bodyHtml: `<!DOCTYPE html><html><head><meta charset="utf-8"><meta http-equiv="Content-Security-Policy" content="${EMAIL_PREVIEW_CSP}"><meta name="color-scheme" content="light"><style>${EMAIL_PREVIEW_CSS}</style></head><body dir="auto"><pre style="${PRE_STYLE}">${escapeHtml(parsed.body.text)}</pre></body></html>`,
+      referencedContentIds: new Set(),
+    };
   }
 
   const $ = load(parsed.body.html);
   sanitizeDom($);
   stripDuplicateNestedMessageHeaders($);
+  const referencedContentIds = getReferencedInlineContentIds($);
   inlineCidImages($, parsed.inlineImages);
 
   if ($("meta[charset]").length === 0) {
@@ -569,7 +561,25 @@ export const renderEmailBodyHtml = (parsed: ParsedEmail): string => {
     $("body").attr("dir", "auto");
   }
 
-  return `<!DOCTYPE html>${$.html()}`;
+  return {
+    bodyHtml: `<!DOCTYPE html>${$.html()}`,
+    referencedContentIds,
+  };
+};
+
+export const renderEmailBodyHtml = (parsed: ParsedEmail): string =>
+  renderEmailBody(parsed).bodyHtml;
+
+const getReferencedInlineContentIds = ($: CheerioApi): Set<string> => {
+  const contentIds = new Set<string>();
+  $("img").each((_, element) => {
+    const src = $(element).attr("src")?.trim();
+    if (!src || !src.toLowerCase().startsWith("cid:")) {
+      return;
+    }
+    contentIds.add(stripAngleBrackets(src.slice("cid:".length)).toLowerCase());
+  });
+  return contentIds;
 };
 
 const hasExplicitWritingDirection = ($: CheerioApi): boolean => {

--- a/apps/api/src/lib/files/email-to-html.ts
+++ b/apps/api/src/lib/files/email-to-html.ts
@@ -146,6 +146,7 @@ export const buildEmailPreview = (parsed: ParsedEmail): EmailPreview => {
   const inlineContentIds = new Set(
     parsed.inlineImages.map(({ cid }) => cid.toLowerCase()),
   );
+  const referencedContentIds = getReferencedInlineContentIds(parsed.body);
 
   return {
     subject: parsed.subject,
@@ -157,7 +158,9 @@ export const buildEmailPreview = (parsed: ParsedEmail): EmailPreview => {
     attachments: parsed.attachments
       .filter(
         ({ contentId }) =>
-          !contentId || !inlineContentIds.has(contentId.toLowerCase()),
+          !contentId ||
+          !inlineContentIds.has(contentId.toLowerCase()) ||
+          !referencedContentIds.has(contentId.toLowerCase()),
       )
       .map(({ fileName, mimeType, bytes }) => ({
         fileName,
@@ -166,6 +169,23 @@ export const buildEmailPreview = (parsed: ParsedEmail): EmailPreview => {
       })),
     bodyHtml: renderEmailBodyHtml(parsed),
   };
+};
+
+const getReferencedInlineContentIds = (body: EmailBody): Set<string> => {
+  const contentIds = new Set<string>();
+  if (body.type !== "html") {
+    return contentIds;
+  }
+
+  const $ = load(body.html);
+  $("img").each((_, element) => {
+    const src = $(element).attr("src")?.trim();
+    if (!src || !src.toLowerCase().startsWith("cid:")) {
+      return;
+    }
+    contentIds.add(stripAngleBrackets(src.slice("cid:".length)).toLowerCase());
+  });
+  return contentIds;
 };
 
 export const parseEmail = async (

--- a/apps/api/src/lib/files/email-to-html.ts
+++ b/apps/api/src/lib/files/email-to-html.ts
@@ -78,10 +78,32 @@ export type ParsedEmail = {
   from: string | null;
   to: string[];
   cc: string[];
+  bcc: string[];
   date: string | null;
   body: EmailBody;
   inlineImages: InlineImage[];
   attachments: EmailAttachment[];
+};
+
+/**
+ * The safe, structured representation returned to the email inspector.
+ * Downloadable attachment content remains parser-local: the preview never
+ * returns attachment bytes or links. Safe inline CID image bytes may be
+ * embedded in bodyHtml so the sandbox can render the message faithfully.
+ */
+type EmailPreview = {
+  subject: string | null;
+  from: string | null;
+  to: string[];
+  cc: string[];
+  bcc: string[];
+  date: string | null;
+  attachments: {
+    fileName: string | null;
+    mimeType: string | null;
+    sizeBytes: number;
+  }[];
+  bodyHtml: string;
 };
 
 /**
@@ -106,6 +128,46 @@ export const emailToHtml = async (
       }),
   });
 
+export const emailToPreview = async (
+  fileBuffer: ArrayBuffer,
+  mimeType: string,
+): Promise<Result<EmailPreview, EmailParseError>> =>
+  await Result.tryPromise({
+    try: async () => buildEmailPreview(await parseEmail(fileBuffer, mimeType)),
+    catch: (cause) =>
+      new EmailParseError({
+        message: "Failed to parse email preview",
+        mimeType,
+        cause,
+      }),
+  });
+
+export const buildEmailPreview = (parsed: ParsedEmail): EmailPreview => {
+  const inlineContentIds = new Set(
+    parsed.inlineImages.map(({ cid }) => cid.toLowerCase()),
+  );
+
+  return {
+    subject: parsed.subject,
+    from: parsed.from,
+    to: parsed.to,
+    cc: parsed.cc,
+    bcc: parsed.bcc,
+    date: parsed.date,
+    attachments: parsed.attachments
+      .filter(
+        ({ contentId }) =>
+          !contentId || !inlineContentIds.has(contentId.toLowerCase()),
+      )
+      .map(({ fileName, mimeType, bytes }) => ({
+        fileName,
+        mimeType,
+        sizeBytes: bytes.byteLength,
+      })),
+    bodyHtml: renderEmailBodyHtml(parsed),
+  };
+};
+
 export const parseEmail = async (
   fileBuffer: ArrayBuffer,
   mimeType: string,
@@ -122,6 +184,7 @@ export const parsedEmailToText = (parsed: ParsedEmail): string => {
     ["From", parsed.from],
     ["To", parsed.to.join(", ")],
     ["Cc", parsed.cc.join(", ")],
+    ["Bcc", parsed.bcc.join(", ")],
     ["Date", parsed.date],
     ["Subject", parsed.subject],
   ] as const;
@@ -193,12 +256,20 @@ const parseEml = async (fileBuffer: ArrayBuffer): Promise<ParsedEmail> => {
       cc.push(formatted);
     }
   }
+  const bcc: string[] = [];
+  for (const address of arrayOrEmpty(email.bcc)) {
+    const formatted = formatAddress(address);
+    if (nonEmpty(formatted)) {
+      bcc.push(formatted);
+    }
+  }
 
   return {
     subject: email.subject ?? null,
     from: email.from ? formatAddress(email.from) : null,
     to,
     cc,
+    bcc,
     date: email.date ?? null,
     body: email.html
       ? { type: "html", html: email.html }
@@ -293,12 +364,20 @@ const parseMsg = (fileBuffer: ArrayBuffer): ParsedEmail => {
       cc.push(formatted);
     }
   }
+  const bcc: string[] = [];
+  for (const recipient of data.bcc) {
+    const formatted = formatNameAddress(recipient.name, recipient.email);
+    if (nonEmpty(formatted)) {
+      bcc.push(formatted);
+    }
+  }
 
   return {
     subject: data.subject ?? null,
     from: formatNameAddress(data.fromName, data.fromEmail),
     to,
     cc,
+    bcc,
     date: data.date,
     body: data.html
       ? { type: "html", html: data.html }
@@ -337,6 +416,8 @@ const isSafeInlineImage = (
 const HR_STYLE = "border: none; border-top: 1px solid #d4d4d8; margin: 12px 0;";
 const PRE_STYLE =
   "white-space: pre-wrap; word-break: break-word; font-family: ui-monospace, monospace; font-size: 13px; margin: 0;";
+const EMAIL_PREVIEW_CSP =
+  "default-src 'none'; img-src data:; style-src 'unsafe-inline'; base-uri 'none'; form-action 'none'";
 const EMAIL_PREVIEW_CSS = `
 :root {
   color-scheme: light;
@@ -413,7 +494,7 @@ export const renderEmailHtml = (parsed: ParsedEmail): string => {
   const header = buildHeaderHtml(parsed);
 
   if (parsed.body.type === "text") {
-    return `<!DOCTYPE html><html><head><meta charset="utf-8"><meta name="color-scheme" content="light"><style>${EMAIL_PREVIEW_CSS}</style></head><body>${header}<hr style="${HR_STYLE}"><pre style="${PRE_STYLE}">${escapeHtml(parsed.body.text)}</pre></body></html>`;
+    return `<!DOCTYPE html><html><head><meta charset="utf-8"><meta http-equiv="Content-Security-Policy" content="${EMAIL_PREVIEW_CSP}"><meta name="color-scheme" content="light"><style>${EMAIL_PREVIEW_CSS}</style></head><body>${header}<hr style="${HR_STYLE}"><pre style="${PRE_STYLE}">${escapeHtml(parsed.body.text)}</pre></body></html>`;
   }
 
   const $ = load(parsed.body.html);
@@ -424,11 +505,43 @@ export const renderEmailHtml = (parsed: ParsedEmail): string => {
   if ($("meta[charset]").length === 0) {
     $("head").prepend('<meta charset="utf-8">');
   }
+  $("head").append(
+    `<meta http-equiv="Content-Security-Policy" content="${EMAIL_PREVIEW_CSP}">`,
+  );
   $("head").append('<meta name="color-scheme" content="light">');
   $("head").append(`<style>${EMAIL_PREVIEW_CSS}</style>`);
   $("body").prepend(`${header}<hr style="${HR_STYLE}">`);
 
   return $.html();
+};
+
+/**
+ * Render a self-contained document suitable for a sandboxed iframe. The
+ * primary message metadata is intentionally excluded so the inspector can
+ * display it once, outside untrusted email HTML. Nested message headers are
+ * retained because they describe forwarded message content.
+ */
+export const renderEmailBodyHtml = (parsed: ParsedEmail): string => {
+  if (parsed.body.type === "text") {
+    return `<!DOCTYPE html><html><head><meta charset="utf-8"><meta http-equiv="Content-Security-Policy" content="${EMAIL_PREVIEW_CSP}"><meta name="color-scheme" content="light"><style>${EMAIL_PREVIEW_CSS}</style></head><body dir="auto"><pre style="${PRE_STYLE}">${escapeHtml(parsed.body.text)}</pre></body></html>`;
+  }
+
+  const $ = load(parsed.body.html);
+  sanitizeDom($);
+  stripDuplicateNestedMessageHeaders($);
+  inlineCidImages($, parsed.inlineImages);
+
+  if ($("meta[charset]").length === 0) {
+    $("head").prepend('<meta charset="utf-8">');
+  }
+  $("head").append(
+    `<meta http-equiv="Content-Security-Policy" content="${EMAIL_PREVIEW_CSP}">`,
+  );
+  $("head").append('<meta name="color-scheme" content="light">');
+  $("head").append(`<style>${EMAIL_PREVIEW_CSS}</style>`);
+  $("body").attr("dir", "auto");
+
+  return `<!DOCTYPE html>${$.html()}`;
 };
 
 const emailBodyToText = (body: EmailBody): string => {
@@ -473,6 +586,7 @@ const URL_ATTRIBUTES = new Set([
   "background",
   "formaction",
   "poster",
+  "ping",
   "srcset",
   "xlink:href",
 ]);
@@ -480,6 +594,7 @@ const FETCHING_URL_ATTRIBUTES = new Set([
   "src",
   "background",
   "poster",
+  "ping",
   "srcset",
   "xlink:href",
 ]);
@@ -547,29 +662,33 @@ const sanitizeDom = ($: CheerioApi): void => {
 const stripDuplicateNestedMessageHeaders = ($: CheerioApi): void => {
   $(".postal-email-header").each((_, header) => {
     const body = $(header).next();
-    const bodyNode = body.get(0);
-    if (!bodyNode || !isTag(bodyNode)) {
-      return;
-    }
-
-    const html = body.html();
-    if (!html) {
-      return;
-    }
-
-    const parts = html.split(BR_TAG_RE);
-    const blankIndex = parts.findIndex((part) => part.trim() === "");
-    if (blankIndex <= 0) {
-      return;
-    }
-
-    const headerLines = parts.slice(0, blankIndex);
-    if (!headerLines.every((part) => RFC822_HEADER_LINE_RE.test(part.trim()))) {
-      return;
-    }
-
-    body.html(parts.slice(blankIndex + 1).join("<br>"));
+    stripLeadingRfc822Headers(body);
   });
+};
+
+const stripLeadingRfc822Headers = (body: ReturnType<CheerioApi>): void => {
+  const bodyNode = body.get(0);
+  if (!bodyNode || !isTag(bodyNode)) {
+    return;
+  }
+
+  const html = body.html();
+  if (!html) {
+    return;
+  }
+
+  const parts = html.split(BR_TAG_RE);
+  const blankIndex = parts.findIndex((part) => part.trim() === "");
+  if (blankIndex <= 0) {
+    return;
+  }
+
+  const headerLines = parts.slice(0, blankIndex);
+  if (!headerLines.every((part) => RFC822_HEADER_LINE_RE.test(part.trim()))) {
+    return;
+  }
+
+  body.html(parts.slice(blankIndex + 1).join("<br>"));
 };
 
 const normalizeUrlAttribute = (value: string): string => {
@@ -633,6 +752,7 @@ const buildHeaderHtml = (parsed: ParsedEmail): string => {
   addRow("From", parsed.from);
   addRow("To", parsed.to.join(", "));
   addRow("Cc", parsed.cc.join(", "));
+  addRow("Bcc", parsed.bcc.join(", "));
   addRow("Date", parsed.date);
   addRow("Subject", parsed.subject);
 

--- a/apps/api/src/lib/files/outlook-msg.test.ts
+++ b/apps/api/src/lib/files/outlook-msg.test.ts
@@ -68,6 +68,13 @@ describe("parseOutlookMsg", () => {
         "001f",
         utf16Property("copy@example.org"),
       ),
+      storageProperty("__recip_version1.0_00000002", "0c15", "0003", int32(3)),
+      storageProperty(
+        "__recip_version1.0_00000002",
+        "3003",
+        "001f",
+        utf16Property("blind@example.org"),
+      ),
       storageProperty(
         "__attach_version1.0_00000000",
         "3712",
@@ -131,6 +138,9 @@ describe("parseOutlookMsg", () => {
     expect(message.cc).toEqual([
       { name: null, email: "copy@example.org", type: "cc" },
     ]);
+    expect(message.bcc).toEqual([
+      { name: null, email: "blind@example.org", type: "bcc" },
+    ]);
     expect(message.attachments).toHaveLength(2);
     expect(message.attachments.at(0)).toMatchObject({
       contentId: "logo",
@@ -151,6 +161,7 @@ describe("parseOutlookMsg", () => {
     const text = parsedEmailToText(parsedEmail);
     expect(text).toContain("From: Jane Lawyer <jane@example.com>");
     expect(text).toContain("To: Client One <client@example.org>");
+    expect(text).toContain("Bcc: blind@example.org");
     expect(text).toContain("Subject: Contract draft");
     expect(text).toContain("Hello world");
 

--- a/apps/api/src/lib/files/outlook-msg.ts
+++ b/apps/api/src/lib/files/outlook-msg.ts
@@ -83,6 +83,7 @@ export type OutlookMsgEmail = {
   fromEmail: string | null;
   to: OutlookMsgRecipient[];
   cc: OutlookMsgRecipient[];
+  bcc: OutlookMsgRecipient[];
   date: string | null;
   html: string | null;
   text: string | null;
@@ -125,6 +126,7 @@ export const parseOutlookMsg = (fileBuffer: ArrayBuffer): OutlookMsgEmail => {
       getString(rootProperties, PROPERTY_ID.senderEmail),
     to: recipients.filter((recipient) => recipient.type === "to"),
     cc: recipients.filter((recipient) => recipient.type === "cc"),
+    bcc: recipients.filter((recipient) => recipient.type === "bcc"),
     date:
       getFileTime(rootProperties, PROPERTY_ID.messageDeliveryTime) ??
       getFileTime(rootProperties, PROPERTY_ID.clientSubmitTime),

--- a/apps/api/src/tests/security/cross-tenant-handlers.test.ts
+++ b/apps/api/src/tests/security/cross-tenant-handlers.test.ts
@@ -22,7 +22,10 @@ import readEntityById from "@/api/handlers/entities/get";
 import readVersionById from "@/api/handlers/entities/read-version-by-id";
 import readVersions from "@/api/handlers/entities/read-versions";
 import readExpenses from "@/api/handlers/expenses/list";
-import { readFileHandler } from "@/api/handlers/files/get";
+import {
+  readEmailHtmlPreviewHandler,
+  readFileHandler,
+} from "@/api/handlers/files/get";
 import readInvoiceById from "@/api/handlers/invoices/get";
 import listLegalLists from "@/api/handlers/lists/list";
 import listMemories from "@/api/handlers/memories/list";
@@ -209,6 +212,27 @@ const isolationCases: IsolationCase[] = [
         recordAuditEvent: noopAuditRecorder,
       }),
     expectDenied: expectStatus(404),
+    expectPositive: expectStatus(400),
+  },
+  {
+    name: "email preview file lookup",
+    runAAgainstB: async ({ ids: testIds, workspaceA }) =>
+      await runHandler(readEmailHtmlPreviewHandler, workspaceA, {
+        scopedDb: asTestRaw<ScopedDb>(workspaceA.scopedDb),
+        fieldId: testIds.fieldB1,
+        organizationId: testIds.orgA,
+        workspaceId: testIds.wsA1,
+      }),
+    runBPositive: async ({ ids: testIds, workspaceB }) =>
+      await runHandler(readEmailHtmlPreviewHandler, workspaceB, {
+        scopedDb: asTestRaw<ScopedDb>(workspaceB.scopedDb),
+        fieldId: testIds.fieldB1,
+        organizationId: testIds.orgB,
+        workspaceId: testIds.wsB1,
+      }),
+    expectDenied: expectStatus(404),
+    // The shared isolation fixture has a text field. A same-workspace lookup
+    // reaches the MIME boundary and is rejected before any object read.
     expectPositive: expectStatus(400),
   },
   {

--- a/apps/web/src/components/inspector/email-html-viewer.logic.test.ts
+++ b/apps/web/src/components/inspector/email-html-viewer.logic.test.ts
@@ -19,17 +19,21 @@ describe("email viewer metadata", () => {
 
   test("selects a readable unit for attachment sizes", () => {
     expect(getEmailAttachmentSize(512)).toEqual({ unit: "byte", value: 512 });
-    expect(getEmailAttachmentSize(2048)).toEqual({
+    expect(getEmailAttachmentSize(2000)).toEqual({
       unit: "kilobyte",
       value: 2,
     });
-    expect(getEmailAttachmentSize(2 * 1024 * 1024)).toEqual({
+    expect(getEmailAttachmentSize(2 * 1000 * 1000)).toEqual({
       unit: "megabyte",
       value: 2,
     });
-    expect(getEmailAttachmentSize(2 * 1024 * 1024 * 1024)).toEqual({
+    expect(getEmailAttachmentSize(2 * 1000 * 1000 * 1000)).toEqual({
       unit: "gigabyte",
       value: 2,
+    });
+    expect(getEmailAttachmentSize(1_000_000)).toEqual({
+      unit: "megabyte",
+      value: 1,
     });
   });
 });

--- a/apps/web/src/components/inspector/email-html-viewer.logic.test.ts
+++ b/apps/web/src/components/inspector/email-html-viewer.logic.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  getEmailAttachmentSize,
+  parseEmailDate,
+} from "@/components/inspector/email-html-viewer.logic";
+
+describe("email viewer metadata", () => {
+  test("rejects missing and malformed dates without throwing", () => {
+    expect(parseEmailDate(null)).toBeNull();
+    expect(parseEmailDate("not a date")).toBeNull();
+  });
+
+  test("parses valid RFC email dates", () => {
+    expect(parseEmailDate("Mon, 02 Jun 2026 10:00:00 +0000")).toEqual(
+      new Date("2026-06-02T10:00:00.000Z"),
+    );
+  });
+
+  test("selects a readable unit for attachment sizes", () => {
+    expect(getEmailAttachmentSize(512)).toEqual({ unit: "byte", value: 512 });
+    expect(getEmailAttachmentSize(2048)).toEqual({
+      unit: "kilobyte",
+      value: 2,
+    });
+    expect(getEmailAttachmentSize(2 * 1024 * 1024)).toEqual({
+      unit: "megabyte",
+      value: 2,
+    });
+    expect(getEmailAttachmentSize(2 * 1024 * 1024 * 1024)).toEqual({
+      unit: "gigabyte",
+      value: 2,
+    });
+  });
+});

--- a/apps/web/src/components/inspector/email-html-viewer.logic.ts
+++ b/apps/web/src/components/inspector/email-html-viewer.logic.ts
@@ -15,17 +15,17 @@ export type EmailAttachmentSize = {
 export const getEmailAttachmentSize = (
   sizeBytes: number,
 ): EmailAttachmentSize => {
-  if (sizeBytes < 1024) {
+  if (sizeBytes < 1000) {
     return { unit: "byte", value: sizeBytes };
   }
 
-  if (sizeBytes < 1024 * 1024) {
-    return { unit: "kilobyte", value: sizeBytes / 1024 };
+  if (sizeBytes < 1000 * 1000) {
+    return { unit: "kilobyte", value: sizeBytes / 1000 };
   }
 
-  if (sizeBytes < 1024 * 1024 * 1024) {
-    return { unit: "megabyte", value: sizeBytes / (1024 * 1024) };
+  if (sizeBytes < 1000 * 1000 * 1000) {
+    return { unit: "megabyte", value: sizeBytes / (1000 * 1000) };
   }
 
-  return { unit: "gigabyte", value: sizeBytes / (1024 * 1024 * 1024) };
+  return { unit: "gigabyte", value: sizeBytes / (1000 * 1000 * 1000) };
 };

--- a/apps/web/src/components/inspector/email-html-viewer.logic.ts
+++ b/apps/web/src/components/inspector/email-html-viewer.logic.ts
@@ -1,0 +1,31 @@
+export const parseEmailDate = (value: string | null): Date | null => {
+  if (!value) {
+    return null;
+  }
+
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+};
+
+export type EmailAttachmentSize = {
+  unit: "byte" | "gigabyte" | "kilobyte" | "megabyte";
+  value: number;
+};
+
+export const getEmailAttachmentSize = (
+  sizeBytes: number,
+): EmailAttachmentSize => {
+  if (sizeBytes < 1024) {
+    return { unit: "byte", value: sizeBytes };
+  }
+
+  if (sizeBytes < 1024 * 1024) {
+    return { unit: "kilobyte", value: sizeBytes / 1024 };
+  }
+
+  if (sizeBytes < 1024 * 1024 * 1024) {
+    return { unit: "megabyte", value: sizeBytes / (1024 * 1024) };
+  }
+
+  return { unit: "gigabyte", value: sizeBytes / (1024 * 1024 * 1024) };
+};

--- a/apps/web/src/components/inspector/email-html-viewer.test.tsx
+++ b/apps/web/src/components/inspector/email-html-viewer.test.tsx
@@ -12,6 +12,8 @@ import messages from "@/i18n/langs/en.json";
 import type Messages from "@/i18n/langs/messages.gen";
 import { emailHtmlPreviewOptions } from "@/lib/files/queries";
 
+const FORMATTING_LOCALE = "en-u-nu-arab";
+
 const renderWithProviders = (children: ReactNode, queryClient: QueryClient) =>
   renderToStaticMarkup(
     <QueryClientProvider client={queryClient}>
@@ -23,7 +25,7 @@ const renderWithProviders = (children: ReactNode, queryClient: QueryClient) =>
         messages={messages as Messages}
         timeZone="UTC"
       >
-        <FormattingProvider locale="en" timeZone="UTC">
+        <FormattingProvider locale={FORMATTING_LOCALE} timeZone="UTC">
           {children}
         </FormattingProvider>
       </IntlProvider>
@@ -66,7 +68,7 @@ describe("email viewer", () => {
     expect(html).toContain('dateTime="2026-06-02T10:00:00.000Z"');
     expect(html).toContain("Show details");
     expect(html).toContain("contract.pdf");
-    expect(html).toContain(">2 kB</span>");
+    expect(html).toContain(">٢ kB</span>");
     expect(html).toContain('sandbox=""');
     expect(html).toContain("srcDoc=");
     expect(html).toContain("Message body");

--- a/apps/web/src/components/inspector/email-html-viewer.test.tsx
+++ b/apps/web/src/components/inspector/email-html-viewer.test.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { Result } from "better-result";
 import { describe, expect, test } from "bun:test";
 import { IntlProvider } from "use-intl";
 
@@ -97,14 +98,22 @@ describe("email viewer", () => {
       fieldId: "field-3",
       workspaceId: "workspace-3",
     });
-    await expect(
-      queryClient.fetchQuery({
-        ...options,
-        queryFn: async () => {
-          throw new Error("preview unavailable");
-        },
-      }),
-    ).rejects.toThrow("preview unavailable");
+    const fetchResult = await Result.tryPromise({
+      try: async () =>
+        await queryClient.fetchQuery({
+          ...options,
+          queryFn: async () => {
+            throw new Error("preview unavailable");
+          },
+        }),
+      catch: (cause) => cause,
+    });
+    expect(Result.isError(fetchResult)).toBe(true);
+    if (Result.isError(fetchResult)) {
+      expect(fetchResult.error).toMatchObject({
+        message: "preview unavailable",
+      });
+    }
 
     const html = renderWithProviders(
       <EmailHtmlViewer fieldId="field-3" workspaceId="workspace-3" />,

--- a/apps/web/src/components/inspector/email-html-viewer.test.tsx
+++ b/apps/web/src/components/inspector/email-html-viewer.test.tsx
@@ -1,0 +1,85 @@
+import type { ReactNode } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { describe, expect, test } from "bun:test";
+import { IntlProvider } from "use-intl";
+
+import { EmailHtmlViewer } from "@/components/inspector/email-html-viewer";
+import { FormattingProvider } from "@/i18n/formatting-context";
+import messages from "@/i18n/langs/en.json";
+import type Messages from "@/i18n/langs/messages.gen";
+import { emailHtmlPreviewOptions } from "@/lib/files/queries";
+
+const renderWithProviders = (children: ReactNode, queryClient: QueryClient) =>
+  renderToStaticMarkup(
+    <QueryClientProvider client={queryClient}>
+      <IntlProvider
+        locale="en"
+        // SAFETY: locale catalogs are checked by i18n:check; this mirrors the
+        // app's provider boundary used by the other static component tests.
+        // eslint-disable-next-line typescript/no-unsafe-type-assertion
+        messages={messages as Messages}
+        timeZone="UTC"
+      >
+        <FormattingProvider locale="en" timeZone="UTC">
+          {children}
+        </FormattingProvider>
+      </IntlProvider>
+    </QueryClientProvider>,
+  );
+
+describe("email viewer", () => {
+  test("renders native metadata and keeps attachments informational", () => {
+    const queryClient = new QueryClient();
+    const options = emailHtmlPreviewOptions({
+      fieldId: "field-1",
+      workspaceId: "workspace-1",
+    });
+    queryClient.setQueryData(options.queryKey, {
+      attachments: [
+        {
+          fileName: "contract.pdf",
+          mimeType: "application/pdf",
+          sizeBytes: 2048,
+        },
+      ],
+      bcc: ["blind@example.org"],
+      bodyHtml: "<p>Message body</p>",
+      cc: ["copy@example.org"],
+      date: "Mon, 02 Jun 2026 10:00:00 +0000",
+      from: "Sender <sender@example.org>",
+      subject: "Contract draft",
+      to: ["client@example.org", "عائشة <aisha@example.ae>"],
+    });
+
+    const html = renderWithProviders(
+      <EmailHtmlViewer fieldId="field-1" workspaceId="workspace-1" />,
+      queryClient,
+    );
+
+    expect(html).toContain(">Contract draft</span></h1>");
+    expect(html).toContain(">Sender &lt;sender@example.org&gt;</bdi>");
+    expect(html).toContain(">client@example.org</bdi>");
+    expect(html).toContain(">عائشة &lt;aisha@example.ae&gt;</bdi>");
+    expect(html).toContain('dateTime="2026-06-02T10:00:00.000Z"');
+    expect(html).toContain("Show details");
+    expect(html).toContain("contract.pdf");
+    expect(html).toContain(">2 kB</span>");
+    expect(html).toContain('sandbox=""');
+    expect(html).toContain("srcDoc=");
+    expect(html).toContain("Message body");
+    expect(html).not.toContain("href=");
+    expect(html).not.toContain('role="button"');
+  });
+
+  test("renders the scoped loading state", () => {
+    const html = renderWithProviders(
+      <EmailHtmlViewer fieldId="field-2" workspaceId="workspace-2" />,
+      new QueryClient(),
+    );
+
+    expect(html).toContain('role="status"');
+    expect(html).toContain('aria-label="Loading"');
+  });
+});

--- a/apps/web/src/components/inspector/email-html-viewer.test.tsx
+++ b/apps/web/src/components/inspector/email-html-viewer.test.tsx
@@ -67,13 +67,14 @@ describe("email viewer", () => {
     expect(html).toContain(">عائشة &lt;aisha@example.ae&gt;</bdi>");
     expect(html).toContain('dateTime="2026-06-02T10:00:00.000Z"');
     expect(html).toContain("Show details");
+    expect(html).toContain(">blind@example.org</bdi>");
     expect(html).toContain("contract.pdf");
     expect(html).toContain(">٢ kB</span>");
     expect(html).toContain('sandbox=""');
     expect(html).toContain("srcDoc=");
     expect(html).toContain("Message body");
     expect(html).not.toContain("href=");
-    expect(html).not.toContain('role="button"');
+    expect(html).not.toContain("<button");
   });
 
   test("renders the scoped loading state", () => {

--- a/apps/web/src/components/inspector/email-html-viewer.test.tsx
+++ b/apps/web/src/components/inspector/email-html-viewer.test.tsx
@@ -82,4 +82,37 @@ describe("email viewer", () => {
     expect(html).toContain('role="status"');
     expect(html).toContain('aria-label="Loading"');
   });
+
+  test("renders the scoped error state with a retry control", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          refetchOnMount: false,
+          retry: false,
+          retryOnMount: false,
+        },
+      },
+    });
+    const options = emailHtmlPreviewOptions({
+      fieldId: "field-3",
+      workspaceId: "workspace-3",
+    });
+    await expect(
+      queryClient.fetchQuery({
+        ...options,
+        queryFn: async () => {
+          throw new Error("preview unavailable");
+        },
+      }),
+    ).rejects.toThrow("preview unavailable");
+
+    const html = renderWithProviders(
+      <EmailHtmlViewer fieldId="field-3" workspaceId="workspace-3" />,
+      queryClient,
+    );
+
+    expect(html).toContain('role="alert"');
+    expect(html).toContain("Something went wrong");
+    expect(html).toContain(">Try again</button>");
+  });
 });

--- a/apps/web/src/components/inspector/email-html-viewer.tsx
+++ b/apps/web/src/components/inspector/email-html-viewer.tsx
@@ -1,12 +1,21 @@
-import { useQuery } from "@tanstack/react-query";
-import { AlertTriangleIcon } from "lucide-react";
-import { useTranslations } from "use-intl";
+import { Fragment, useState } from "react";
 
+import { useQuery } from "@tanstack/react-query";
+import { AlertTriangleIcon, PaperclipIcon } from "lucide-react";
+import { useFormatter, useTranslations } from "use-intl";
+
+import { BidiText } from "@stll/ui/components/bidi-text";
 import { Button } from "@stll/ui/components/button";
 import { Skeleton } from "@stll/ui/components/skeleton";
 
+import { DocumentIcon } from "@/components/document-icon";
+import {
+  getEmailAttachmentSize,
+  parseEmailDate,
+} from "@/components/inspector/email-html-viewer.logic";
 import { detached } from "@/lib/detached";
 import { emailHtmlPreviewOptions } from "@/lib/files/queries";
+import { formatFullTimestamp } from "@/lib/relative-time";
 
 type EmailHtmlViewerProps = {
   fieldId: string;
@@ -18,14 +27,20 @@ export const EmailHtmlViewer = ({
   workspaceId,
 }: EmailHtmlViewerProps) => {
   const t = useTranslations();
+  const format = useFormatter();
+  const [detailsOpen, setDetailsOpen] = useState(false);
   const previewQuery = useQuery(
     emailHtmlPreviewOptions({ workspaceId, fieldId }),
   );
 
   if (previewQuery.isPending) {
     return (
-      <div className="bg-muted/30 flex min-h-0 flex-1 flex-col gap-2 p-3">
-        <Skeleton className="h-8 w-full rounded-sm" />
+      <div
+        aria-label={t("common.loading")}
+        className="bg-muted/30 flex min-h-0 flex-1 flex-col gap-2 p-3"
+        role="status"
+      >
+        <Skeleton className="h-24 w-full rounded-sm" />
         <Skeleton className="min-h-0 flex-1 rounded-sm" />
       </div>
     );
@@ -33,7 +48,10 @@ export const EmailHtmlViewer = ({
 
   if (previewQuery.isError) {
     return (
-      <div className="flex min-h-0 flex-1 flex-col items-center justify-center gap-3 p-6 text-center">
+      <div
+        className="flex min-h-0 flex-1 flex-col items-center justify-center gap-3 p-6 text-center"
+        role="alert"
+      >
         <AlertTriangleIcon className="text-foreground-disabled size-8" />
         <p className="text-muted-foreground text-sm">
           {t("common.somethingWentWrong")}
@@ -51,13 +69,175 @@ export const EmailHtmlViewer = ({
     );
   }
 
+  const preview = previewQuery.data;
+  const subject = preview.subject?.trim() || t("emailViewer.noSubject");
+  const parsedDate = parseEmailDate(preview.date);
+  const formattedDate = parsedDate
+    ? formatFullTimestamp(parsedDate)
+    : preview.date;
+  const hasAdditionalParticipants =
+    preview.cc.length > 0 || preview.bcc.length > 0;
+  const attachmentKeyOccurrences = new Map<string, number>();
+
   return (
-    <iframe
-      className="bg-background size-full border-0"
-      referrerPolicy="no-referrer"
-      sandbox=""
-      srcDoc={previewQuery.data.html}
-      title={previewQuery.data.fileName}
-    />
+    <article className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
+      <header className="bg-background max-h-[45%] shrink-0 overflow-y-auto overscroll-contain border-b px-4 py-3">
+        <h1 className="text-foreground text-base font-semibold text-balance">
+          <BidiText as="span">{subject}</BidiText>
+        </h1>
+        <dl className="mt-3 grid min-w-0 gap-1.5 text-xs">
+          <EmailParticipantRow
+            label={t("emailViewer.from")}
+            values={preview.from ? [preview.from] : []}
+          />
+          <EmailParticipantRow
+            label={t("emailViewer.to")}
+            values={preview.to}
+          />
+          {formattedDate ? (
+            <div className="text-muted-foreground grid min-w-0 grid-cols-[auto_minmax(0,1fr)] gap-x-3">
+              <dt>{t("common.date")}</dt>
+              <dd className="min-w-0 truncate">
+                <time dateTime={parsedDate?.toISOString()}>
+                  {formattedDate}
+                </time>
+              </dd>
+            </div>
+          ) : null}
+        </dl>
+        {hasAdditionalParticipants ? (
+          <details
+            className="mt-2 text-xs"
+            onToggle={(event) => setDetailsOpen(event.currentTarget.open)}
+          >
+            <summary className="text-muted-foreground hover:text-foreground focus-visible:ring-ring inline-flex min-h-11 cursor-pointer items-center rounded-md py-2 text-start underline-offset-4 hover:underline focus-visible:ring-2 focus-visible:outline-none">
+              {detailsOpen ? t("common.hideDetails") : t("common.showDetails")}
+            </summary>
+            <dl className="grid gap-1.5 pb-1">
+              <EmailParticipantRow
+                label={t("emailViewer.cc")}
+                values={preview.cc}
+              />
+              <EmailParticipantRow
+                label={t("emailViewer.bcc")}
+                values={preview.bcc}
+              />
+            </dl>
+          </details>
+        ) : null}
+        {preview.attachments.length > 0 ? (
+          <section
+            aria-labelledby={`${fieldId}-attachments`}
+            className="mt-3 border-t pt-3"
+          >
+            <h2
+              className="text-muted-foreground mb-2 flex items-center gap-1.5 text-xs font-medium"
+              id={`${fieldId}-attachments`}
+            >
+              <PaperclipIcon aria-hidden="true" className="size-3.5" />
+              {t("emailViewer.attachments")}
+            </h2>
+            <ul className="flex flex-wrap gap-1.5">
+              {preview.attachments.map((attachment) => (
+                <li
+                  className="bg-muted/50 inline-flex min-h-11 max-w-full items-center gap-1.5 rounded-md border px-2 text-xs"
+                  key={getAttachmentKey(attachment, attachmentKeyOccurrences)}
+                >
+                  <DocumentIcon
+                    className="text-muted-foreground size-4 shrink-0"
+                    fileName={
+                      attachment.fileName ?? t("emailViewer.unnamedAttachment")
+                    }
+                    mimeType={attachment.mimeType ?? "application/octet-stream"}
+                  />
+                  <BidiText as="span" className="max-w-48 min-w-0 truncate">
+                    {attachment.fileName ?? t("emailViewer.unnamedAttachment")}
+                  </BidiText>
+                  {attachment.sizeBytes > 0 ? (
+                    <span className="text-muted-foreground shrink-0">
+                      {formatAttachmentSize(attachment.sizeBytes, format)}
+                    </span>
+                  ) : null}
+                </li>
+              ))}
+            </ul>
+          </section>
+        ) : null}
+      </header>
+      <div className="bg-muted/30 min-h-0 min-w-0 flex-1 overflow-hidden p-2">
+        <iframe
+          className="bg-background size-full border-0"
+          referrerPolicy="no-referrer"
+          sandbox=""
+          srcDoc={preview.bodyHtml}
+          title={t("emailViewer.bodyTitle")}
+        />
+      </div>
+    </article>
   );
+};
+
+const formatAttachmentSize = (
+  sizeBytes: number,
+  format: ReturnType<typeof useFormatter>,
+): string => {
+  const size = getEmailAttachmentSize(sizeBytes);
+  return format.number(size.value, {
+    maximumFractionDigits: 1,
+    style: "unit",
+    unit: size.unit,
+    unitDisplay: "short",
+  });
+};
+
+const EmailParticipantRow = ({
+  label,
+  values,
+}: {
+  label: string;
+  values: readonly string[];
+}) => {
+  if (values.length === 0) {
+    return null;
+  }
+  const valueOccurrences = new Map<string, number>();
+
+  return (
+    <div className="text-muted-foreground grid min-w-0 grid-cols-[auto_minmax(0,1fr)] gap-x-3">
+      <dt>{label}</dt>
+      <dd className="min-w-0 text-start break-words">
+        {values.map((value, index) => (
+          <Fragment key={getOccurrenceKey(value, valueOccurrences)}>
+            {index > 0 ? ", " : null}
+            <BidiText>{value}</BidiText>
+          </Fragment>
+        ))}
+      </dd>
+    </div>
+  );
+};
+
+const getAttachmentKey = (
+  attachment: {
+    fileName: string | null;
+    mimeType: string | null;
+    sizeBytes: number;
+  },
+  occurrences: Map<string, number>,
+): string => {
+  const signature = JSON.stringify([
+    attachment.fileName,
+    attachment.mimeType,
+    attachment.sizeBytes,
+  ]);
+  return getOccurrenceKey(signature, occurrences);
+};
+
+const getOccurrenceKey = (
+  value: string,
+  occurrences: Map<string, number>,
+): string => {
+  const occurrence = occurrences.get(value) ?? 0;
+  occurrences.set(value, occurrence + 1);
+  return `${value}:${occurrence}`;
 };

--- a/apps/web/src/components/inspector/email-html-viewer.tsx
+++ b/apps/web/src/components/inspector/email-html-viewer.tsx
@@ -2,7 +2,7 @@ import { Fragment, useState } from "react";
 
 import { useQuery } from "@tanstack/react-query";
 import { AlertTriangleIcon, PaperclipIcon } from "lucide-react";
-import { useFormatter, useTranslations } from "use-intl";
+import { useTranslations } from "use-intl";
 
 import { BidiText } from "@stll/ui/components/bidi-text";
 import { Button } from "@stll/ui/components/button";
@@ -13,6 +13,7 @@ import {
   getEmailAttachmentSize,
   parseEmailDate,
 } from "@/components/inspector/email-html-viewer.logic";
+import { useFormatter } from "@/i18n/formatting-context";
 import { detached } from "@/lib/detached";
 import { emailHtmlPreviewOptions } from "@/lib/files/queries";
 import { formatFullTimestamp } from "@/lib/relative-time";

--- a/apps/web/src/i18n/langs/ar.json
+++ b/apps/web/src/i18n/langs/ar.json
@@ -1223,6 +1223,16 @@
     "wordShortcut": "الأحرف الأولى",
     "wordShortcutPlaceholder": "مثال: JK"
   },
+  "emailViewer": {
+    "attachments": "المرفقات",
+    "bcc": "نسخة مخفية",
+    "bodyTitle": "محتوى البريد الإلكتروني",
+    "cc": "نسخة",
+    "from": "المرسل",
+    "noSubject": "(بلا موضوع)",
+    "to": "المستلمون",
+    "unnamedAttachment": "مرفق بلا اسم"
+  },
   "errors": {
     "actionFailed": "فشل الإجراء",
     "api": {

--- a/apps/web/src/i18n/langs/cs.json
+++ b/apps/web/src/i18n/langs/cs.json
@@ -1223,6 +1223,16 @@
     "wordShortcut": "Iniciály",
     "wordShortcutPlaceholder": "např. JK"
   },
+  "emailViewer": {
+    "attachments": "Přílohy",
+    "bcc": "Skrytá kopie",
+    "bodyTitle": "Tělo e-mailu",
+    "cc": "Kopie",
+    "from": "Odesílatel",
+    "noSubject": "(Bez předmětu)",
+    "to": "Příjemci",
+    "unnamedAttachment": "Nepojmenovaná příloha"
+  },
   "errors": {
     "actionFailed": "Akce se nezdařila",
     "api": {

--- a/apps/web/src/i18n/langs/de.json
+++ b/apps/web/src/i18n/langs/de.json
@@ -1223,6 +1223,16 @@
     "wordShortcut": "Initialen",
     "wordShortcutPlaceholder": "z. B. JK"
   },
+  "emailViewer": {
+    "attachments": "Anhänge",
+    "bcc": "Blindkopie",
+    "bodyTitle": "E-Mail-Inhalt",
+    "cc": "Kopie",
+    "from": "Absender",
+    "noSubject": "(Kein Betreff)",
+    "to": "Empfänger",
+    "unnamedAttachment": "Unbenannter Anhang"
+  },
   "errors": {
     "actionFailed": "Aktion fehlgeschlagen",
     "api": {

--- a/apps/web/src/i18n/langs/en.json
+++ b/apps/web/src/i18n/langs/en.json
@@ -1223,6 +1223,16 @@
     "wordShortcut": "Initials",
     "wordShortcutPlaceholder": "e.g. JK"
   },
+  "emailViewer": {
+    "attachments": "Attachments",
+    "bcc": "Bcc",
+    "bodyTitle": "Email body",
+    "cc": "Cc",
+    "from": "Sender",
+    "noSubject": "(No subject)",
+    "to": "Recipients",
+    "unnamedAttachment": "Unnamed attachment"
+  },
   "errors": {
     "actionFailed": "Action failed",
     "api": {

--- a/apps/web/src/i18n/langs/es.json
+++ b/apps/web/src/i18n/langs/es.json
@@ -1223,6 +1223,16 @@
     "wordShortcut": "Iniciales",
     "wordShortcutPlaceholder": "p. ej. JK"
   },
+  "emailViewer": {
+    "attachments": "Archivos adjuntos",
+    "bcc": "Cco",
+    "bodyTitle": "Cuerpo del correo",
+    "cc": "Copia",
+    "from": "Remitente",
+    "noSubject": "(Sin asunto)",
+    "to": "Destinatarios",
+    "unnamedAttachment": "Archivo adjunto sin nombre"
+  },
   "errors": {
     "actionFailed": "Acción fallida",
     "api": {

--- a/apps/web/src/i18n/langs/et.json
+++ b/apps/web/src/i18n/langs/et.json
@@ -1223,6 +1223,16 @@
     "wordShortcut": "Initsiaalid",
     "wordShortcutPlaceholder": "nt JK"
   },
+  "emailViewer": {
+    "attachments": "Manused",
+    "bcc": "Pimekoopia",
+    "bodyTitle": "E-kirja sisu",
+    "cc": "Koopia",
+    "from": "Saatja",
+    "noSubject": "(Teema puudub)",
+    "to": "Saajad",
+    "unnamedAttachment": "Nimetu manus"
+  },
   "errors": {
     "actionFailed": "Toiming ebaõnnestus",
     "api": {

--- a/apps/web/src/i18n/langs/fr.json
+++ b/apps/web/src/i18n/langs/fr.json
@@ -1223,6 +1223,16 @@
     "wordShortcut": "Initiales",
     "wordShortcutPlaceholder": "ex. JK"
   },
+  "emailViewer": {
+    "attachments": "Pièces jointes",
+    "bcc": "Cci",
+    "bodyTitle": "Corps de l’e-mail",
+    "cc": "Copie",
+    "from": "Expéditeur",
+    "noSubject": "(Sans objet)",
+    "to": "Destinataires",
+    "unnamedAttachment": "Pièce jointe sans nom"
+  },
   "errors": {
     "actionFailed": "Action échouée",
     "api": {

--- a/apps/web/src/i18n/langs/hu.json
+++ b/apps/web/src/i18n/langs/hu.json
@@ -1223,6 +1223,16 @@
     "wordShortcut": "Monogram",
     "wordShortcutPlaceholder": "pl. JK"
   },
+  "emailViewer": {
+    "attachments": "Mellékletek",
+    "bcc": "Titkos másolat",
+    "bodyTitle": "E-mail törzse",
+    "cc": "Másolat",
+    "from": "Feladó",
+    "noSubject": "(Nincs tárgy)",
+    "to": "Címzettek",
+    "unnamedAttachment": "Névtelen melléklet"
+  },
   "errors": {
     "actionFailed": "A művelet sikertelen",
     "api": {

--- a/apps/web/src/i18n/langs/lt.json
+++ b/apps/web/src/i18n/langs/lt.json
@@ -1223,6 +1223,16 @@
     "wordShortcut": "Inicialai",
     "wordShortcutPlaceholder": "pvz., JK"
   },
+  "emailViewer": {
+    "attachments": "Priedai",
+    "bcc": "Nematomos kopijos",
+    "bodyTitle": "El. laiško tekstas",
+    "cc": "Kopija",
+    "from": "Siuntėjas",
+    "noSubject": "(Nėra temos)",
+    "to": "Gavėjai",
+    "unnamedAttachment": "Nepavadintas priedas"
+  },
   "errors": {
     "actionFailed": "Veiksmas nepavyko",
     "api": {

--- a/apps/web/src/i18n/langs/lv.json
+++ b/apps/web/src/i18n/langs/lv.json
@@ -1223,6 +1223,16 @@
     "wordShortcut": "Iniciāļi",
     "wordShortcutPlaceholder": "piem., JK"
   },
+  "emailViewer": {
+    "attachments": "Pielikumi",
+    "bcc": "Diskrētā kopija",
+    "bodyTitle": "E-pasta pamatteksts",
+    "cc": "Kopija",
+    "from": "Sūtītājs",
+    "noSubject": "(Bez tēmas)",
+    "to": "Saņēmēji",
+    "unnamedAttachment": "Nepārdēvēts pielikums"
+  },
   "errors": {
     "actionFailed": "Darbība neizdevās",
     "api": {

--- a/apps/web/src/i18n/langs/lv.json
+++ b/apps/web/src/i18n/langs/lv.json
@@ -1231,7 +1231,7 @@
     "from": "Sūtītājs",
     "noSubject": "(Bez tēmas)",
     "to": "Saņēmēji",
-    "unnamedAttachment": "Nepārdēvēts pielikums"
+    "unnamedAttachment": "Pielikums bez nosaukuma"
   },
   "errors": {
     "actionFailed": "Darbība neizdevās",

--- a/apps/web/src/i18n/langs/messages.gen.ts
+++ b/apps/web/src/i18n/langs/messages.gen.ts
@@ -1226,6 +1226,16 @@ type Messages = {
     "wordShortcut": "Initials";
     "wordShortcutPlaceholder": "e.g. JK";
   };
+  "emailViewer": {
+    "attachments": "Attachments";
+    "bcc": "Bcc";
+    "bodyTitle": "Email body";
+    "cc": "Cc";
+    "from": "Sender";
+    "noSubject": "(No subject)";
+    "to": "Recipients";
+    "unnamedAttachment": "Unnamed attachment";
+  };
   "errors": {
     "actionFailed": "Action failed";
     "api": {

--- a/apps/web/src/i18n/langs/pl.json
+++ b/apps/web/src/i18n/langs/pl.json
@@ -1223,6 +1223,16 @@
     "wordShortcut": "Inicjały",
     "wordShortcutPlaceholder": "np. JK"
   },
+  "emailViewer": {
+    "attachments": "Załączniki",
+    "bcc": "UDW",
+    "bodyTitle": "Treść e-maila",
+    "cc": "DW",
+    "from": "Nadawca",
+    "noSubject": "(Brak tematu)",
+    "to": "Odbiorcy",
+    "unnamedAttachment": "Nienazwany załącznik"
+  },
   "errors": {
     "actionFailed": "Akcja nie powiodła się",
     "api": {

--- a/apps/web/src/i18n/langs/pt-BR.json
+++ b/apps/web/src/i18n/langs/pt-BR.json
@@ -1223,6 +1223,16 @@
     "wordShortcut": "Iniciais",
     "wordShortcutPlaceholder": "por exemplo JK"
   },
+  "emailViewer": {
+    "attachments": "Anexos",
+    "bcc": "Cco",
+    "bodyTitle": "Corpo do e-mail",
+    "cc": "Cópia",
+    "from": "Remetente",
+    "noSubject": "(Sem assunto)",
+    "to": "Destinatários",
+    "unnamedAttachment": "Anexo sem nome"
+  },
   "errors": {
     "actionFailed": "Falha na ação",
     "api": {

--- a/apps/web/src/i18n/langs/sk.json
+++ b/apps/web/src/i18n/langs/sk.json
@@ -1223,6 +1223,16 @@
     "wordShortcut": "Iniciály",
     "wordShortcutPlaceholder": "napr. JK"
   },
+  "emailViewer": {
+    "attachments": "Prílohy",
+    "bcc": "Skrytá kópia",
+    "bodyTitle": "Telo e-mailu",
+    "cc": "Kópia",
+    "from": "Odosielateľ",
+    "noSubject": "(Bez predmetu)",
+    "to": "Príjemcovia",
+    "unnamedAttachment": "Nepomenovaná príloha"
+  },
   "errors": {
     "actionFailed": "Akcia zlyhala",
     "api": {

--- a/apps/web/src/lib/files/queries.ts
+++ b/apps/web/src/lib/files/queries.ts
@@ -22,11 +22,18 @@ type FileData = {
 };
 
 type EmailHtmlPreviewData = {
-  fileId: string;
-  fileName: string;
-  html: string;
-  mimeType: string;
-  originalMimeType: string;
+  subject: string | null;
+  from: string | null;
+  to: string[];
+  cc: string[];
+  bcc: string[];
+  date: string | null;
+  attachments: {
+    fileName: string | null;
+    mimeType: string | null;
+    sizeBytes: number;
+  }[];
+  bodyHtml: string;
 };
 
 type TextFileData = {
@@ -98,11 +105,14 @@ export const emailHtmlPreviewOptions = (props: FileOptionsProps) =>
       const data = unwrapEden(response);
 
       return {
-        fileId: data.fileId,
-        fileName: data.fileName,
-        html: data.html,
-        mimeType: data.mimeType,
-        originalMimeType: data.originalMimeType,
+        subject: data.subject,
+        from: data.from,
+        to: data.to,
+        cc: data.cc,
+        bcc: data.bcc,
+        date: data.date,
+        attachments: data.attachments,
+        bodyHtml: data.bodyHtml,
       } satisfies EmailHtmlPreviewData;
     },
   });


### PR DESCRIPTION
## Summary

- replace the iframe-only email preview with localized, bidirectional metadata and attachment details
- return a structured preview while keeping untrusted message HTML sandboxed, sanitized, and network-blocked
- extend EML and MSG parsing for Bcc and cover parser, viewer, inline attachments, and tenant boundaries

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a structured email preview showing subject, sender, recipients, CC/BCC, date, message content and attachment details.
  - Added improved attachment size formatting, localised date display and support for bidirectional text.
- **Bug Fixes**
  - Added safer sanitised HTML rendering and improved nested-message and internationalised header handling.
  - Prevented cross-workspace email preview access.
  - Improved loading and error states, including retry support.
- **Localisation**
  - Added email viewer translations across supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->