### PR TITLE
docs: note BrowserStack testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,8 @@ more information and our policy on AI-generated contributions.
 PRs must pass the linting and testing pipeline. You will be prompted
 to sign the Contributor License Agreement (CLA) by CI.
 
+This project is tested with BrowserStack.
+
 ## Contact
 
 1. Open an issue for questions, feedback or suggestions.


### PR DESCRIPTION
Adds BrowserStack's required testing acknowledgment to the README after validating stll.app in Safari on macOS and iOS.

CC on behalf of jan-kubica