### PR TITLE
fix(web): retire remaining translation debt

### DIFF
--- a/apps/web/src/i18n/TERMINOLOGY.md
+++ b/apps/web/src/i18n/TERMINOLOGY.md
@@ -329,21 +329,25 @@ Slavic, Baltic, Germanic, Finno-Ugric:
 
 <!-- glossary-gen:legal-slavic-baltic start -->
 
-| Concept      | Czech      | Slovak      | Polish             | German         | Estonian      | Hungarian            | Lithuanian             | Latvian             |
-| ------------ | ---------- | ----------- | ------------------ | -------------- | ------------- | -------------------- | ---------------------- | ------------------- |
-| **Matter**   | Spis       | Spis        | Sprawa             | Akte           | Toimik        | Ügy                  | Byla                   | Lieta               |
-| **Team**     | Tým        | Tím         | Zespół             | Team           | Meeskond      | Csapat               | Komanda                | Komanda             |
-| **Case law** | Judikatura | Judikatúra  | Orzecznictwo       | Rechtsprechung | Kohtupraktika | Ítélkezési gyakorlat | Teismų praktika        | Tiesu prakse        |
-| **Court**    | Soud       | Súd         | Sąd                | Gericht        | Kohus         | Bíróság              | Teismas                | Tiesa               |
-| **Party**    | Strana     | Strana      | Strona             | Partei         | Osapool       | Fél                  | Šalis                  | Puse                |
-| **Clause**   | Ustanovení | Ustanovenie | Klauzula           | Klausel        | Klausel       | Kikötés              | Sąlyga                 | Klauzula            |
-| **Template** | Vzor       | Vzor        | Szablon            | Vorlage        | Mall          | Sablon               | Šablonas               | Veidne              |
-| **View**     | Zobrazení  | Zobrazenie  | Widok              | Ansicht        | Vaade         | Nézet                | Rodinys                | Skats               |
-| **Preset**   | Předvolba  | Predvoľba   | Ustawienie wstępne | Voreinstellung | Eelseade      | Előbeállítás         | Išankstinis nustatymas | Iepriekšiestatījums |
-| **Folder**   | Složka     | Priečinok   | Folder             | Ordner         | Kaust         | Mappa                | Aplankas               | Mape                |
-| **Tag**      | Štítek     | Štítok      | Tag                | Schlagwort     | Silt          | Címke                | Žyma                   | Birka               |
-| **Draft**    | Koncept    | Koncept     | Wersja robocza     | Entwurf        | Mustand       | Piszkozat            | Juodraštis             | Melnraksts          |
-| **Contact**  | Kontakt    | Kontakt     | Kontakt            | Kontakt        | Kontakt       | Kapcsolat            | Kontaktas              | Kontakts            |
+| Concept           | Czech         | Slovak        | Polish             | German                | Estonian       | Hungarian            | Lithuanian                    | Latvian             |
+| ----------------- | ------------- | ------------- | ------------------ | --------------------- | -------------- | -------------------- | ----------------------------- | ------------------- |
+| **Matter**        | Spis          | Spis          | Sprawa             | Akte                  | Toimik         | Ügy                  | Byla                          | Lieta               |
+| **Team**          | Tým           | Tím           | Zespół             | Team                  | Meeskond       | Csapat               | Komanda                       | Komanda             |
+| **Case law**      | Judikatura    | Judikatúra    | Orzecznictwo       | Rechtsprechung        | Kohtupraktika  | Ítélkezési gyakorlat | Teismų praktika               | Tiesu prakse        |
+| **Court**         | Soud          | Súd           | Sąd                | Gericht               | Kohus          | Bíróság              | Teismas                       | Tiesa               |
+| **Party**         | Strana        | Strana        | Strona             | Partei                | Osapool        | Fél                  | Šalis                         | Puse                |
+| **Clause**        | Ustanovení    | Ustanovenie   | Klauzula           | Klausel               | Klausel        | Kikötés              | Sąlyga                        | Klauzula            |
+| **Template**      | Vzor          | Vzor          | Szablon            | Vorlage               | Mall           | Sablon               | Šablonas                      | Veidne              |
+| **View**          | Zobrazení     | Zobrazenie    | Widok              | Ansicht               | Vaade          | Nézet                | Rodinys                       | Skats               |
+| **Preset**        | Předvolba     | Predvoľba     | Ustawienie wstępne | Voreinstellung        | Eelseade       | Előbeállítás         | Išankstinis nustatymas        | Iepriekšiestatījums |
+| **Folder**        | Složka        | Priečinok     | Folder             | Ordner                | Kaust          | Mappa                | Aplankas                      | Mape                |
+| **Tag**           | Štítek        | Štítok        | Tag                | Schlagwort            | Silt           | Címke                | Žyma                          | Birka               |
+| **Draft**         | Koncept       | Koncept       | Wersja robocza     | Entwurf               | Mustand        | Piszkozat            | Juodraštis                    | Melnraksts          |
+| **Contact**       | Kontakt       | Kontakt       | Kontakt            | Kontakt               | Kontakt        | Kapcsolat            | Kontaktas                     | Kontakts            |
+| **Playbook**      | Playbook      | Playbook      | Playbook           | Playbook              | Playbook       | Playbook             | Peržiūros vadovas             | Pārbaudes ceļvedis  |
+| **Due diligence** | Due diligence | Due diligence | Due diligence      | Due-Diligence-Prüfung | Õiguslik audit | Jogi átvilágítás     | Išsamus teisinis patikrinimas | Padziļinātā izpēte  |
+| **Escalation**    | Eskalace      | Eskalácia     | Eskalacja          | Eskalation            | Eskaleerimine  | Eszkaláció           | Eskalavimas                   | Eskalācija          |
+| **Rationale**     | Odůvodnění    | Odôvodnenie   | Uzasadnienie       | Begründung            | Põhjendus      | Indoklás             | Pagrindimas                   | Pamatojums          |
 
 <!-- glossary-gen:legal-slavic-baltic end -->
 
@@ -351,21 +355,25 @@ Romance:
 
 <!-- glossary-gen:legal-romance start -->
 
-| Concept      | Spanish        | French        | Brazilian Portuguese |
-| ------------ | -------------- | ------------- | -------------------- |
-| **Matter**   | Asunto         | Dossier       | Caso                 |
-| **Team**     | Equipo         | Équipe        | Equipe               |
-| **Case law** | Jurisprudencia | Jurisprudence | Jurisprudência       |
-| **Court**    | Tribunal       | Juridiction   | Tribunal             |
-| **Party**    | Parte          | Partie        | Parte                |
-| **Clause**   | Cláusula       | Clause        | Cláusula             |
-| **Template** | Plantilla      | Modèle        | Modelo               |
-| **View**     | Vista          | Vue           | Visualização         |
-| **Preset**   | Preajuste      | Préréglage    | Predefinição         |
-| **Folder**   | Carpeta        | Dossier       | Pasta                |
-| **Tag**      | Etiqueta       | Étiquette     | Etiqueta             |
-| **Draft**    | Borrador       | Brouillon     | Rascunho             |
-| **Contact**  | Contacto       | Contact       | Contato              |
+| Concept           | Spanish           | French        | Brazilian Portuguese |
+| ----------------- | ----------------- | ------------- | -------------------- |
+| **Matter**        | Asunto            | Dossier       | Caso                 |
+| **Team**          | Equipo            | Équipe        | Equipe               |
+| **Case law**      | Jurisprudencia    | Jurisprudence | Jurisprudência       |
+| **Court**         | Tribunal          | Juridiction   | Tribunal             |
+| **Party**         | Parte             | Partie        | Parte                |
+| **Clause**        | Cláusula          | Clause        | Cláusula             |
+| **Template**      | Plantilla         | Modèle        | Modelo               |
+| **View**          | Vista             | Vue           | Visualização         |
+| **Preset**        | Preajuste         | Préréglage    | Predefinição         |
+| **Folder**        | Carpeta           | Dossier       | Pasta                |
+| **Tag**           | Etiqueta          | Étiquette     | Etiqueta             |
+| **Draft**         | Borrador          | Brouillon     | Rascunho             |
+| **Contact**       | Contacto          | Contact       | Contato              |
+| **Playbook**      | Playbook          | Playbook      | Playbook             |
+| **Due diligence** | Diligencia debida | Due diligence | Devida diligência    |
+| **Escalation**    | Escalado          | Escalade      | Escalonamento        |
+| **Rationale**     | Justificación     | Justification | Justificativa        |
 
 <!-- glossary-gen:legal-romance end -->
 
@@ -373,21 +381,25 @@ Arabic:
 
 <!-- glossary-gen:legal-arabic start -->
 
-| Concept      | Arabic           |
-| ------------ | ---------------- |
-| **Matter**   | ملف قانوني       |
-| **Team**     | فريق             |
-| **Case law** | الاجتهاد القضائي |
-| **Court**    | محكمة            |
-| **Party**    | طرف              |
-| **Clause**   | بند              |
-| **Template** | قالب             |
-| **View**     | عرض              |
-| **Preset**   | إعداد مسبق       |
-| **Folder**   | مجلد             |
-| **Tag**      | وسم              |
-| **Draft**    | مسودة            |
-| **Contact**  | جهة اتصال        |
+| Concept           | Arabic           |
+| ----------------- | ---------------- |
+| **Matter**        | ملف قانوني       |
+| **Team**          | فريق             |
+| **Case law**      | الاجتهاد القضائي |
+| **Court**         | محكمة            |
+| **Party**         | طرف              |
+| **Clause**        | بند              |
+| **Template**      | قالب             |
+| **View**          | عرض              |
+| **Preset**        | إعداد مسبق       |
+| **Folder**        | مجلد             |
+| **Tag**           | وسم              |
+| **Draft**         | مسودة            |
+| **Contact**       | جهة اتصال        |
+| **Playbook**      | دليل مراجعة      |
+| **Due diligence** | العناية الواجبة  |
+| **Escalation**    | التصعيد          |
+| **Rationale**     | المبررات         |
 
 <!-- glossary-gen:legal-arabic end -->
 

--- a/apps/web/src/i18n/glossary.json
+++ b/apps/web/src/i18n/glossary.json
@@ -818,6 +818,200 @@
         "fr": "Contact",
         "pt-BR": "Contato"
       }
+    },
+    {
+      "id": "playbook",
+      "en": "Playbook",
+      "note": "A maintained legal-review and negotiation rule set: preferred positions, fallback wording, risk rules, and escalation guidance. Research across German, Czech, Slovak, Polish, Estonian, Hungarian, Spanish, French, and Brazilian legal-tech usage supports the declined English loanword; Arabic, Lithuanian, and Latvian use the established native review-guide term. Never render this named concept as a literal book of games.",
+      "forbidden": {
+        "ar": ["كتاب اللعب", "كتب اللعب", "بلايبوك", "بلاي بوك"],
+        "cs": [
+          "herní plán",
+          "herního plánu",
+          "herní plány",
+          "herních plánů",
+          "kniha her",
+          "knihy her"
+        ],
+        "sk": [
+          "herný plán",
+          "herného plánu",
+          "herné plány",
+          "herných plánov",
+          "kniha hier",
+          "knihy hier"
+        ],
+        "pl": [
+          "książka gry",
+          "książki gry",
+          "książką gry",
+          "plan gry",
+          "planu gry",
+          "plany gry",
+          "planów gry"
+        ],
+        "de": ["Spielbuch", "Spielbuchs", "Spielbücher", "Spielbüchern"],
+        "et": [
+          "mänguraamat",
+          "mänguraamatu",
+          "mänguraamatud",
+          "mänguraamatute"
+        ],
+        "hu": ["játékkönyv", "játékkönyvet", "játékkönyvek", "játékkönyveket"],
+        "lt": [
+          "žaidimo knyga",
+          "žaidimo knygos",
+          "žaidimo knygą",
+          "žaidimo knygoje",
+          "žaidimų knyga"
+        ],
+        "lv": [
+          "spēļu grāmata",
+          "spēļu grāmatas",
+          "spēļu grāmatai",
+          "spēļu grāmatu",
+          "spēļu grāmatā",
+          "spēļu grāmatām",
+          "spēļu grāmatās"
+        ]
+      },
+      "translations": {
+        "ar": "دليل مراجعة",
+        "cs": "Playbook",
+        "sk": "Playbook",
+        "pl": "Playbook",
+        "de": "Playbook",
+        "et": "Playbook",
+        "hu": "Playbook",
+        "lt": "Peržiūros vadovas",
+        "lv": "Pārbaudes ceļvedis",
+        "es": "Playbook",
+        "fr": "Playbook",
+        "pt-BR": "Playbook"
+      }
+    },
+    {
+      "id": "transaction-due-diligence",
+      "en": "Due diligence",
+      "note": "The transactional M&A investigation represented by Stella's data-room red-flag workflow, not the separate corporate-sustainability duty-of-care concept. Official transaction materials and local legal practice support the preferred terms below. German Sorgfaltspflicht, Estonian hoolsuskohustus, and Hungarian kellő gondosság remain valid for regulatory duties, but are forbidden on this workflow's keys so that context cannot drift.",
+      "forbidden": {
+        "ar": ["الاجتهاد المستحق", "الاجتهاد الواجب"]
+      },
+      "forbiddenOnKey": {
+        "de": ["Sorgfaltspflicht", "Sorgfaltspflichten"],
+        "et": [
+          "hoolsuskohustus",
+          "hoolsuskohustuse",
+          "hoolsuskohustust",
+          "hoolsuskohustused",
+          "hoolsuskohustuste"
+        ],
+        "hu": ["kellő gondosság", "kellő gondosságot", "kellő gondossági"]
+      },
+      "keyTriggers": ["flows.examples.dueDiligence"],
+      "sourceExempt": ["due diligence"],
+      "translations": {
+        "ar": "العناية الواجبة",
+        "cs": "Due diligence",
+        "sk": "Due diligence",
+        "pl": "Due diligence",
+        "de": "Due-Diligence-Prüfung",
+        "et": "Õiguslik audit",
+        "hu": "Jogi átvilágítás",
+        "lt": "Išsamus teisinis patikrinimas",
+        "lv": "Padziļinātā izpēte",
+        "es": "Diligencia debida",
+        "fr": "Due diligence",
+        "pt-BR": "Devida diligência"
+      }
+    },
+    {
+      "id": "escalation",
+      "en": "Escalation",
+      "note": "Routing a negotiation exception or unresolved issue to a designated person or higher approval level. Official approval, risk, procurement, and legal-tech sources support these terms; do not translate it as a promotion, upgrade, or team selection.",
+      "forbidden": {
+        "ar": ["الترقية", "ترقية", "للترقية", "بالترقية"],
+        "cs": ["povýšení", "povýšením", "povýšeními"],
+        "sk": ["povýšenie", "povýšenia", "povýšeniu", "povýšením"],
+        "pl": ["awans", "awansu", "awansem", "awanse", "awansów", "awansami"],
+        "pt-BR": ["escalação", "escalações"]
+      },
+      "translations": {
+        "ar": "التصعيد",
+        "cs": "Eskalace",
+        "sk": "Eskalácia",
+        "pl": "Eskalacja",
+        "de": "Eskalation",
+        "et": "Eskaleerimine",
+        "hu": "Eszkaláció",
+        "lt": "Eskalavimas",
+        "lv": "Eskalācija",
+        "es": "Escalado",
+        "fr": "Escalade",
+        "pt-BR": "Escalonamento"
+      }
+    },
+    {
+      "id": "rationale",
+      "en": "Rationale",
+      "note": "The stated reason supporting a negotiation position. Use the ordinary legal/business justification term below, not a false friend meaning rationality or post-hoc rationalization.",
+      "forbidden": {
+        "cs": ["racionalizace", "racionalizaci", "racionalizací", "racionále"],
+        "sk": [
+          "racionalizácia",
+          "racionalizácie",
+          "racionalizácii",
+          "racionalizáciou",
+          "racionále"
+        ],
+        "pl": [
+          "racjonalizacja",
+          "racjonalizacji",
+          "racjonalizacją",
+          "racjonalizacje",
+          "racjonalizacjami"
+        ],
+        "de": ["Rationalität", "Rationalitäten"],
+        "et": ["ratsionaalsus", "ratsionaalsuse", "ratsionaalsust"],
+        "hu": ["racionalitás", "racionalitást", "racionalitások"],
+        "lt": ["racionalumas", "racionalumo", "racionalumą"],
+        "lv": [
+          "racionalizācija",
+          "racionalizācijas",
+          "racionalizācijai",
+          "racionalizāciju",
+          "racionalizācijā",
+          "racionalizācijām",
+          "racionalizācijās"
+        ],
+        "es": ["racionalización", "racionalizaciones"],
+        "fr": [
+          "rationalisation",
+          "rationalisations",
+          "rationalité",
+          "rationalités"
+        ],
+        "pt-BR": [
+          "racionalização",
+          "racionalizações",
+          "racionalidade",
+          "racionalidades"
+        ]
+      },
+      "translations": {
+        "ar": "المبررات",
+        "cs": "Odůvodnění",
+        "sk": "Odôvodnenie",
+        "pl": "Uzasadnienie",
+        "de": "Begründung",
+        "et": "Põhjendus",
+        "hu": "Indoklás",
+        "lt": "Pagrindimas",
+        "lv": "Pamatojums",
+        "es": "Justificación",
+        "fr": "Justification",
+        "pt-BR": "Justificativa"
+      }
     }
   ],
   "ptBR": [

--- a/apps/web/src/i18n/i18n-check-baseline.json
+++ b/apps/web/src/i18n/i18n-check-baseline.json
@@ -403,19 +403,6 @@
     "common.actions": [
       "fr"
     ],
-    "common.and": [
-      "cs",
-      "de",
-      "es",
-      "et",
-      "fr",
-      "hu",
-      "lt",
-      "lv",
-      "pl",
-      "pt-BR",
-      "sk"
-    ],
     "common.anonymizationLabels.date": [
       "fr"
     ],
@@ -455,38 +442,11 @@
     "common.name": [
       "de"
     ],
-    "common.none": [
-      "ar",
-      "cs",
-      "de",
-      "es",
-      "et",
-      "fr",
-      "hu",
-      "lt",
-      "lv",
-      "pl",
-      "pt-BR",
-      "sk"
-    ],
     "common.notes": [
       "fr"
     ],
     "common.options": [
       "fr"
-    ],
-    "common.or": [
-      "cs",
-      "de",
-      "es",
-      "et",
-      "fr",
-      "hu",
-      "lt",
-      "lv",
-      "pl",
-      "pt-BR",
-      "sk"
     ],
     "common.playbooks": [
       "de",
@@ -513,20 +473,6 @@
     ],
     "common.type": [
       "fr"
-    ],
-    "common.undo": [
-      "ar",
-      "cs",
-      "de",
-      "es",
-      "et",
-      "fr",
-      "hu",
-      "lt",
-      "lv",
-      "pl",
-      "pt-BR",
-      "sk"
     ],
     "common.urlIdentifier": [
       "cs",
@@ -627,407 +573,10 @@
       "pl",
       "pt-BR"
     ],
-    "flows.editor.newFlowIntro": [
-      "ar",
-      "de",
-      "es",
-      "et",
-      "fr",
-      "hu",
-      "lt",
-      "lv",
-      "pl",
-      "pt-BR",
-      "sk"
-    ],
-    "flows.emptyState.blankAction": [
-      "ar",
-      "de",
-      "es",
-      "et",
-      "fr",
-      "hu",
-      "lt",
-      "lv",
-      "pl",
-      "pt-BR",
-      "sk"
-    ],
-    "flows.emptyState.description": [
-      "ar",
-      "de",
-      "es",
-      "et",
-      "fr",
-      "hu",
-      "lt",
-      "lv",
-      "pl",
-      "pt-BR",
-      "sk"
-    ],
-    "flows.emptyState.examplesTitle": [
-      "ar",
-      "de",
-      "es",
-      "et",
-      "fr",
-      "hu",
-      "lt",
-      "lv",
-      "pl",
-      "pt-BR",
-      "sk"
-    ],
-    "flows.emptyState.title": [
-      "ar",
-      "de",
-      "es",
-      "et",
-      "fr",
-      "hu",
-      "lt",
-      "lv",
-      "pl",
-      "pt-BR",
-      "sk"
-    ],
-    "flows.examples.documentSummary.createStepName": [
-      "ar",
-      "de",
-      "es",
-      "et",
-      "fr",
-      "hu",
-      "lt",
-      "lv",
-      "pl",
-      "pt-BR",
-      "sk"
-    ],
-    "flows.examples.documentSummary.description": [
-      "ar",
-      "de",
-      "es",
-      "et",
-      "fr",
-      "hu",
-      "lt",
-      "lv",
-      "pl",
-      "pt-BR",
-      "sk"
-    ],
-    "flows.examples.documentSummary.documentTitle": [
-      "ar",
-      "de",
-      "es",
-      "et",
-      "fr",
-      "hu",
-      "lt",
-      "lv",
-      "pl",
-      "pt-BR",
-      "sk"
-    ],
-    "flows.examples.documentSummary.name": [
-      "ar",
-      "de",
-      "es",
-      "et",
-      "fr",
-      "hu",
-      "lt",
-      "lv",
-      "pl",
-      "pt-BR",
-      "sk"
-    ],
-    "flows.examples.documentSummary.summaryStepName": [
-      "ar",
-      "de",
-      "es",
-      "et",
-      "fr",
-      "hu",
-      "lt",
-      "lv",
-      "pl",
-      "pt-BR",
-      "sk"
-    ],
-    "flows.examples.documentSummary.summaryStepPrompt": [
-      "ar",
-      "de",
-      "es",
-      "et",
-      "fr",
-      "hu",
-      "lt",
-      "lv",
-      "pl",
-      "pt-BR",
-      "sk"
-    ],
-    "flows.examples.dueDiligence.createStepName": [
-      "ar",
-      "de",
-      "es",
-      "et",
-      "fr",
-      "hu",
-      "lt",
-      "lv",
-      "pl",
-      "pt-BR",
-      "sk"
-    ],
-    "flows.examples.dueDiligence.description": [
-      "ar",
-      "de",
-      "es",
-      "et",
-      "fr",
-      "hu",
-      "lt",
-      "lv",
-      "pl",
-      "pt-BR",
-      "sk"
-    ],
-    "flows.examples.dueDiligence.documentTitle": [
-      "ar",
-      "de",
-      "es",
-      "et",
-      "fr",
-      "hu",
-      "lt",
-      "lv",
-      "pl",
-      "pt-BR",
-      "sk"
-    ],
-    "flows.examples.dueDiligence.name": [
-      "ar",
-      "de",
-      "es",
-      "et",
-      "fr",
-      "hu",
-      "lt",
-      "lv",
-      "pl",
-      "pt-BR",
-      "sk"
-    ],
-    "flows.examples.dueDiligence.reviewGateInstructions": [
-      "ar",
-      "de",
-      "es",
-      "et",
-      "fr",
-      "hu",
-      "lt",
-      "lv",
-      "pl",
-      "pt-BR",
-      "sk"
-    ],
-    "flows.examples.dueDiligence.reviewGateStepName": [
-      "ar",
-      "de",
-      "es",
-      "et",
-      "fr",
-      "hu",
-      "lt",
-      "lv",
-      "pl",
-      "pt-BR",
-      "sk"
-    ],
-    "flows.examples.dueDiligence.reviewStepName": [
-      "ar",
-      "de",
-      "es",
-      "et",
-      "fr",
-      "hu",
-      "lt",
-      "lv",
-      "pl",
-      "pt-BR",
-      "sk"
-    ],
-    "flows.examples.dueDiligence.reviewStepPrompt": [
-      "ar",
-      "de",
-      "es",
-      "et",
-      "fr",
-      "hu",
-      "lt",
-      "lv",
-      "pl",
-      "pt-BR",
-      "sk"
-    ],
-    "flows.examples.ndaIntake.createStepName": [
-      "ar",
-      "de",
-      "es",
-      "et",
-      "fr",
-      "hu",
-      "lt",
-      "lv",
-      "pl",
-      "pt-BR",
-      "sk"
-    ],
-    "flows.examples.ndaIntake.description": [
-      "ar",
-      "de",
-      "es",
-      "et",
-      "fr",
-      "hu",
-      "lt",
-      "lv",
-      "pl",
-      "pt-BR",
-      "sk"
-    ],
-    "flows.examples.ndaIntake.documentTitle": [
-      "ar",
-      "de",
-      "es",
-      "et",
-      "fr",
-      "hu",
-      "lt",
-      "lv",
-      "pl",
-      "pt-BR",
-      "sk"
-    ],
-    "flows.examples.ndaIntake.name": [
-      "ar",
-      "de",
-      "es",
-      "et",
-      "fr",
-      "hu",
-      "lt",
-      "lv",
-      "pl",
-      "pt-BR",
-      "sk"
-    ],
-    "flows.examples.ndaIntake.reviewGateInstructions": [
-      "ar",
-      "de",
-      "es",
-      "et",
-      "fr",
-      "hu",
-      "lt",
-      "lv",
-      "pl",
-      "pt-BR",
-      "sk"
-    ],
-    "flows.examples.ndaIntake.reviewGateStepName": [
-      "ar",
-      "de",
-      "es",
-      "et",
-      "fr",
-      "hu",
-      "lt",
-      "lv",
-      "pl",
-      "pt-BR",
-      "sk"
-    ],
-    "flows.examples.ndaIntake.reviewStepName": [
-      "ar",
-      "de",
-      "es",
-      "et",
-      "fr",
-      "hu",
-      "lt",
-      "lv",
-      "pl",
-      "pt-BR",
-      "sk"
-    ],
-    "flows.examples.ndaIntake.reviewStepPrompt": [
-      "ar",
-      "de",
-      "es",
-      "et",
-      "fr",
-      "hu",
-      "lt",
-      "lv",
-      "pl",
-      "pt-BR",
-      "sk"
-    ],
-    "flows.steps.aiHelp": [
-      "ar",
-      "de",
-      "es",
-      "et",
-      "fr",
-      "hu",
-      "lt",
-      "lv",
-      "pl",
-      "pt-BR",
-      "sk"
-    ],
-    "flows.steps.createDocumentHelp": [
-      "ar",
-      "de",
-      "es",
-      "et",
-      "fr",
-      "hu",
-      "lt",
-      "lv",
-      "pl",
-      "pt-BR",
-      "sk"
-    ],
-    "flows.steps.instructions": [
-      "fr"
-    ],
     "flows.steps.prompt": [
       "cs",
       "de",
-      "es",
-      "fr",
-      "hu",
       "pl",
-      "pt-BR",
-      "sk"
-    ],
-    "flows.steps.reviewGateHelp": [
-      "ar",
-      "de",
-      "es",
-      "et",
-      "fr",
-      "hu",
-      "lt",
-      "lv",
-      "pl",
-      "pt-BR",
       "sk"
     ],
     "flows.trigger.manual": [
@@ -1043,37 +592,11 @@
       "fr",
       "pt-BR"
     ],
-    "knowledge.agentSkills.coaching.publish": [
-      "cs",
-      "de",
-      "es",
-      "et",
-      "fr",
-      "hu",
-      "lt",
-      "lv",
-      "pl",
-      "pt-BR",
-      "sk"
-    ],
     "knowledge.agentSkills.formDescription": [
       "fr"
     ],
     "knowledge.agentSkills.formName": [
       "de"
-    ],
-    "knowledge.agentSkills.howItRuns": [
-      "cs",
-      "de",
-      "es",
-      "et",
-      "fr",
-      "hu",
-      "lt",
-      "lv",
-      "pl",
-      "pt-BR",
-      "sk"
     ],
     "knowledge.agentSkills.newFileFilenamePlaceholder": [
       "ar",
@@ -1095,19 +618,6 @@
       "hu",
       "lv",
       "pl",
-      "sk"
-    ],
-    "knowledge.agentSkills.selectFileHint": [
-      "cs",
-      "de",
-      "es",
-      "et",
-      "fr",
-      "hu",
-      "lt",
-      "lv",
-      "pl",
-      "pt-BR",
       "sk"
     ],
     "knowledge.agentSkills.urlPlaceholder": [
@@ -1152,90 +662,6 @@
       "pt-BR",
       "sk"
     ],
-    "knowledge.playbooks.approval.approve": [
-      "ar",
-      "cs",
-      "de",
-      "es",
-      "et",
-      "fr",
-      "hu",
-      "lt",
-      "lv",
-      "pl",
-      "pt-BR",
-      "sk"
-    ],
-    "knowledge.playbooks.approval.approvedOn": [
-      "ar",
-      "cs",
-      "de",
-      "es",
-      "et",
-      "fr",
-      "hu",
-      "lt",
-      "lv",
-      "pl",
-      "pt-BR",
-      "sk"
-    ],
-    "knowledge.playbooks.approval.approvedToast": [
-      "ar",
-      "cs",
-      "de",
-      "es",
-      "et",
-      "fr",
-      "hu",
-      "lt",
-      "lv",
-      "pl",
-      "pt-BR",
-      "sk"
-    ],
-    "knowledge.playbooks.approval.approveFailed": [
-      "ar",
-      "cs",
-      "de",
-      "es",
-      "et",
-      "fr",
-      "hu",
-      "lt",
-      "lv",
-      "pl",
-      "pt-BR",
-      "sk"
-    ],
-    "knowledge.playbooks.approval.statusApproved": [
-      "ar",
-      "cs",
-      "de",
-      "es",
-      "et",
-      "fr",
-      "hu",
-      "lt",
-      "lv",
-      "pl",
-      "pt-BR",
-      "sk"
-    ],
-    "knowledge.playbooks.approval.statusDraft": [
-      "ar",
-      "cs",
-      "de",
-      "es",
-      "et",
-      "fr",
-      "hu",
-      "lt",
-      "lv",
-      "pl",
-      "pt-BR",
-      "sk"
-    ],
     "knowledge.playbooks.askQuestionLabel": [
       "fr"
     ],
@@ -1248,132 +674,6 @@
     "knowledge.playbooks.extractionManual": [
       "es",
       "pt-BR"
-    ],
-    "knowledge.playbooks.manageTypes": [
-      "ar",
-      "cs",
-      "de",
-      "es",
-      "et",
-      "fr",
-      "hu",
-      "lt",
-      "lv",
-      "pl",
-      "pt-BR",
-      "sk"
-    ],
-    "knowledge.playbooks.negotiation.addTalkingPoint": [
-      "ar",
-      "cs",
-      "de",
-      "es",
-      "et",
-      "fr",
-      "hu",
-      "lt",
-      "lv",
-      "pl",
-      "pt-BR",
-      "sk"
-    ],
-    "knowledge.playbooks.negotiation.escalationLabel": [
-      "ar",
-      "cs",
-      "de",
-      "es",
-      "et",
-      "fr",
-      "hu",
-      "lt",
-      "lv",
-      "pl",
-      "pt-BR",
-      "sk"
-    ],
-    "knowledge.playbooks.negotiation.escalationPlaceholder": [
-      "ar",
-      "cs",
-      "de",
-      "es",
-      "et",
-      "fr",
-      "hu",
-      "lt",
-      "lv",
-      "pl",
-      "pt-BR",
-      "sk"
-    ],
-    "knowledge.playbooks.negotiation.rationaleLabel": [
-      "ar",
-      "cs",
-      "de",
-      "es",
-      "et",
-      "fr",
-      "hu",
-      "lt",
-      "lv",
-      "pl",
-      "pt-BR",
-      "sk"
-    ],
-    "knowledge.playbooks.negotiation.rationalePlaceholder": [
-      "ar",
-      "cs",
-      "de",
-      "es",
-      "et",
-      "fr",
-      "hu",
-      "lt",
-      "lv",
-      "pl",
-      "pt-BR",
-      "sk"
-    ],
-    "knowledge.playbooks.negotiation.talkingPointPlaceholder": [
-      "ar",
-      "cs",
-      "de",
-      "es",
-      "et",
-      "fr",
-      "hu",
-      "lt",
-      "lv",
-      "pl",
-      "pt-BR",
-      "sk"
-    ],
-    "knowledge.playbooks.negotiation.talkingPointsLabel": [
-      "ar",
-      "cs",
-      "de",
-      "es",
-      "et",
-      "fr",
-      "hu",
-      "lt",
-      "lv",
-      "pl",
-      "pt-BR",
-      "sk"
-    ],
-    "knowledge.playbooks.negotiation.title": [
-      "ar",
-      "cs",
-      "de",
-      "es",
-      "et",
-      "fr",
-      "hu",
-      "lt",
-      "lv",
-      "pl",
-      "pt-BR",
-      "sk"
     ],
     "knowledge.playbooks.optionsLabel": [
       "fr"
@@ -1389,246 +689,8 @@
       "pt-BR",
       "sk"
     ],
-    "knowledge.playbooks.risk.flaggedCount": [
-      "ar",
-      "cs",
-      "de",
-      "es",
-      "et",
-      "fr",
-      "hu",
-      "lt",
-      "lv",
-      "pl",
-      "pt-BR",
-      "sk"
-    ],
-    "knowledge.playbooks.risk.riskLevel.critical": [
-      "ar",
-      "cs",
-      "de",
-      "es",
-      "et",
-      "fr",
-      "hu",
-      "lt",
-      "lv",
-      "pl",
-      "pt-BR",
-      "sk"
-    ],
-    "knowledge.playbooks.risk.riskLevel.high": [
-      "ar",
-      "cs",
-      "de",
-      "es",
-      "et",
-      "fr",
-      "hu",
-      "lt",
-      "lv",
-      "pl",
-      "pt-BR",
-      "sk"
-    ],
-    "knowledge.playbooks.risk.riskLevel.low": [
-      "ar",
-      "cs",
-      "de",
-      "es",
-      "et",
-      "fr",
-      "hu",
-      "lt",
-      "lv",
-      "pl",
-      "pt-BR",
-      "sk"
-    ],
-    "knowledge.playbooks.risk.riskLevel.medium": [
-      "ar",
-      "cs",
-      "de",
-      "es",
-      "et",
-      "fr",
-      "hu",
-      "lt",
-      "lv",
-      "pl",
-      "pt-BR",
-      "sk"
-    ],
-    "knowledge.playbooks.risk.riskLevel.none": [
-      "ar",
-      "cs",
-      "de",
-      "es",
-      "et",
-      "fr",
-      "hu",
-      "lt",
-      "lv",
-      "pl",
-      "pt-BR",
-      "sk"
-    ],
-    "knowledge.playbooks.risk.summaryTitle": [
-      "ar",
-      "cs",
-      "de",
-      "es",
-      "et",
-      "fr",
-      "hu",
-      "lt",
-      "lv",
-      "pl",
-      "pt-BR",
-      "sk"
-    ],
-    "knowledge.playbooks.risk.topIssuesTitle": [
-      "ar",
-      "cs",
-      "de",
-      "es",
-      "et",
-      "fr",
-      "hu",
-      "lt",
-      "lv",
-      "pl",
-      "pt-BR",
-      "sk"
-    ],
-    "knowledge.playbooks.starters.addedToast": [
-      "ar",
-      "cs",
-      "de",
-      "es",
-      "et",
-      "fr",
-      "hu",
-      "lt",
-      "lv",
-      "pl",
-      "pt-BR",
-      "sk"
-    ],
-    "knowledge.playbooks.starters.browseButton": [
-      "ar",
-      "cs",
-      "de",
-      "es",
-      "et",
-      "fr",
-      "hu",
-      "lt",
-      "lv",
-      "pl",
-      "pt-BR",
-      "sk"
-    ],
-    "knowledge.playbooks.starters.positionCount": [
-      "ar",
-      "cs",
-      "de",
-      "es",
-      "et",
-      "fr",
-      "hu",
-      "lt",
-      "lv",
-      "pl",
-      "pt-BR",
-      "sk"
-    ],
-    "knowledge.playbooks.starters.subtitle": [
-      "ar",
-      "cs",
-      "de",
-      "es",
-      "et",
-      "fr",
-      "hu",
-      "lt",
-      "lv",
-      "pl",
-      "pt-BR",
-      "sk"
-    ],
-    "knowledge.playbooks.starters.title": [
-      "ar",
-      "cs",
-      "de",
-      "es",
-      "et",
-      "fr",
-      "hu",
-      "lt",
-      "lv",
-      "pl",
-      "pt-BR",
-      "sk"
-    ],
     "knowledge.playbooks.tier.acceptable": [
       "fr"
-    ],
-    "knowledge.playbooks.versions.confirmRestore": [
-      "ar",
-      "cs",
-      "de",
-      "es",
-      "et",
-      "fr",
-      "hu",
-      "lt",
-      "lv",
-      "pl",
-      "pt-BR",
-      "sk"
-    ],
-    "knowledge.playbooks.versions.restoredToast": [
-      "ar",
-      "cs",
-      "de",
-      "es",
-      "et",
-      "fr",
-      "hu",
-      "lt",
-      "lv",
-      "pl",
-      "pt-BR",
-      "sk"
-    ],
-    "knowledge.playbooks.versions.restoreFailed": [
-      "ar",
-      "cs",
-      "de",
-      "es",
-      "et",
-      "fr",
-      "hu",
-      "lt",
-      "lv",
-      "pl",
-      "pt-BR",
-      "sk"
-    ],
-    "knowledge.playbooks.versions.versionHistory": [
-      "ar",
-      "cs",
-      "de",
-      "es",
-      "et",
-      "fr",
-      "hu",
-      "lt",
-      "lv",
-      "pl",
-      "pt-BR",
-      "sk"
     ],
     "knowledge.sections.prompts.title": [
       "de"
@@ -1636,230 +698,11 @@
     "knowledge.sections.tools.title": [
       "de"
     ],
-    "knowledge.skills.blueprintGallery.cards.answerFromSources.blurb": [
-      "de",
-      "es",
-      "et",
-      "fr",
-      "hu",
-      "lt",
-      "lv",
-      "pl",
-      "pt-BR",
-      "sk"
-    ],
-    "knowledge.skills.blueprintGallery.cards.answerFromSources.inside": [
-      "de",
-      "es",
-      "et",
-      "fr",
-      "hu",
-      "lt",
-      "lv",
-      "pl",
-      "pt-BR",
-      "sk"
-    ],
-    "knowledge.skills.blueprintGallery.cards.answerFromSources.title": [
-      "de",
-      "es",
-      "et",
-      "fr",
-      "hu",
-      "lt",
-      "lv",
-      "pl",
-      "pt-BR",
-      "sk"
-    ],
-    "knowledge.skills.blueprintGallery.cards.checkAgainstRules.blurb": [
-      "de",
-      "es",
-      "et",
-      "fr",
-      "hu",
-      "lt",
-      "lv",
-      "pl",
-      "pt-BR",
-      "sk"
-    ],
-    "knowledge.skills.blueprintGallery.cards.checkAgainstRules.inside": [
-      "de",
-      "es",
-      "et",
-      "fr",
-      "hu",
-      "lt",
-      "lv",
-      "pl",
-      "pt-BR",
-      "sk"
-    ],
-    "knowledge.skills.blueprintGallery.cards.checkAgainstRules.title": [
-      "de",
-      "es",
-      "et",
-      "fr",
-      "hu",
-      "lt",
-      "lv",
-      "pl",
-      "pt-BR",
-      "sk"
-    ],
-    "knowledge.skills.blueprintGallery.cards.intakeToDraft.blurb": [
-      "de",
-      "es",
-      "et",
-      "fr",
-      "hu",
-      "lt",
-      "lv",
-      "pl",
-      "pt-BR",
-      "sk"
-    ],
-    "knowledge.skills.blueprintGallery.cards.intakeToDraft.inside": [
-      "de",
-      "es",
-      "et",
-      "fr",
-      "hu",
-      "lt",
-      "lv",
-      "pl",
-      "pt-BR",
-      "sk"
-    ],
-    "knowledge.skills.blueprintGallery.cards.intakeToDraft.title": [
-      "de",
-      "es",
-      "et",
-      "fr",
-      "hu",
-      "lt",
-      "lv",
-      "pl",
-      "pt-BR",
-      "sk"
-    ],
-    "knowledge.skills.blueprintGallery.insideLabel": [
-      "de",
-      "es",
-      "et",
-      "fr",
-      "hu",
-      "lt",
-      "lv",
-      "pl",
-      "pt-BR",
-      "sk"
-    ],
-    "knowledge.skills.blueprintGallery.startBlank": [
-      "de",
-      "es",
-      "et",
-      "fr",
-      "hu",
-      "lt",
-      "lv",
-      "pl",
-      "pt-BR",
-      "sk"
-    ],
-    "knowledge.skills.blueprintGallery.startBlankHint": [
-      "de",
-      "es",
-      "et",
-      "fr",
-      "hu",
-      "lt",
-      "lv",
-      "pl",
-      "pt-BR",
-      "sk"
-    ],
-    "knowledge.skills.blueprintGallery.subtitle": [
-      "de",
-      "es",
-      "et",
-      "fr",
-      "hu",
-      "lt",
-      "lv",
-      "pl",
-      "pt-BR",
-      "sk"
-    ],
-    "knowledge.skills.blueprintGallery.title": [
-      "de",
-      "es",
-      "et",
-      "fr",
-      "hu",
-      "lt",
-      "lv",
-      "pl",
-      "pt-BR",
-      "sk"
-    ],
-    "knowledge.skills.commandHelp": [
-      "de",
-      "es",
-      "et",
-      "fr",
-      "hu",
-      "lt",
-      "lv",
-      "pl",
-      "pt-BR",
-      "sk"
-    ],
     "knowledge.skills.form.description": [
       "fr"
     ],
     "knowledge.skills.form.name": [
       "de"
-    ],
-    "markdownEditor.rawLabel": [
-      "cs",
-      "de",
-      "es",
-      "et",
-      "fr",
-      "hu",
-      "lt",
-      "lv",
-      "pl",
-      "pt-BR",
-      "sk"
-    ],
-    "markdownEditor.showFormatted": [
-      "cs",
-      "de",
-      "es",
-      "et",
-      "fr",
-      "hu",
-      "lt",
-      "lv",
-      "pl",
-      "pt-BR",
-      "sk"
-    ],
-    "markdownEditor.showRaw": [
-      "cs",
-      "de",
-      "es",
-      "et",
-      "fr",
-      "hu",
-      "lt",
-      "lv",
-      "pl",
-      "pt-BR",
-      "sk"
     ],
     "memory.kinds.instruction": [
       "fr"
@@ -2003,90 +846,6 @@
     "settings.organization.auditLogsAction": [
       "fr"
     ],
-    "settings.organization.documentTypes.addPlaceholder": [
-      "ar",
-      "cs",
-      "de",
-      "es",
-      "et",
-      "fr",
-      "hu",
-      "lt",
-      "lv",
-      "pl",
-      "pt-BR",
-      "sk"
-    ],
-    "settings.organization.documentTypes.deleteFailed": [
-      "ar",
-      "cs",
-      "de",
-      "es",
-      "et",
-      "fr",
-      "hu",
-      "lt",
-      "lv",
-      "pl",
-      "pt-BR",
-      "sk"
-    ],
-    "settings.organization.documentTypes.description": [
-      "ar",
-      "cs",
-      "de",
-      "es",
-      "et",
-      "fr",
-      "hu",
-      "lt",
-      "lv",
-      "pl",
-      "pt-BR",
-      "sk"
-    ],
-    "settings.organization.documentTypes.labelAria": [
-      "ar",
-      "cs",
-      "de",
-      "es",
-      "et",
-      "fr",
-      "hu",
-      "lt",
-      "lv",
-      "pl",
-      "pt-BR",
-      "sk"
-    ],
-    "settings.organization.documentTypes.reorder": [
-      "ar",
-      "cs",
-      "de",
-      "es",
-      "et",
-      "fr",
-      "hu",
-      "lt",
-      "lv",
-      "pl",
-      "pt-BR",
-      "sk"
-    ],
-    "settings.organization.documentTypes.title": [
-      "ar",
-      "cs",
-      "de",
-      "es",
-      "et",
-      "fr",
-      "hu",
-      "lt",
-      "lv",
-      "pl",
-      "pt-BR",
-      "sk"
-    ],
     "styleSets.stellaStyle": [
       "ar",
       "cs",
@@ -2112,19 +871,6 @@
     "templates.conditionCount": [
       "fr"
     ],
-    "templates.conditionFormulaPlaceholder": [
-      "ar",
-      "de",
-      "es",
-      "et",
-      "fr",
-      "hu",
-      "lt",
-      "lv",
-      "pl",
-      "pt-BR",
-      "sk"
-    ],
     "templates.conditionOperator": [
       "de",
       "pl"
@@ -2132,69 +878,17 @@
     "templates.conditionsTitle": [
       "fr"
     ],
-    "templates.conditionUseFieldInstead": [
-      "ar",
-      "de",
-      "es",
-      "et",
-      "fr",
-      "hu",
-      "lt",
-      "lv",
-      "pl",
-      "pt-BR",
-      "sk"
-    ],
-    "templates.conditionUseFormula": [
-      "ar",
-      "de",
-      "es",
-      "et",
-      "fr",
-      "hu",
-      "lt",
-      "lv",
-      "pl",
-      "pt-BR",
-      "sk"
-    ],
     "templates.fieldFormulaExpression": [
       "fr"
     ],
     "templates.fieldOptions": [
       "fr"
     ],
-    "templates.studio.conditionRuleFallbackLabel": [
-      "ar",
-      "de",
-      "es",
-      "et",
-      "fr",
-      "hu",
-      "lt",
-      "lv",
-      "pl",
-      "pt-BR",
-      "sk"
-    ],
     "templates.studio.expressionPlaceholder": [
       "fr"
     ],
     "templates.studio.filledByPerson": [
       "de"
-    ],
-    "templates.studio.insertConditionIntoTemplate": [
-      "ar",
-      "de",
-      "es",
-      "et",
-      "fr",
-      "hu",
-      "lt",
-      "lv",
-      "pl",
-      "pt-BR",
-      "sk"
     ],
     "templates.studio.questions": [
       "fr"
@@ -2243,34 +937,6 @@
       "pt-BR",
       "sk"
     ],
-    "webSearch.settings.platformFallback": [
-      "ar",
-      "cs",
-      "de",
-      "es",
-      "et",
-      "fr",
-      "hu",
-      "lt",
-      "lv",
-      "pl",
-      "pt-BR",
-      "sk"
-    ],
-    "webSearch.settings.title": [
-      "ar",
-      "cs",
-      "de",
-      "es",
-      "et",
-      "fr",
-      "hu",
-      "lt",
-      "lv",
-      "pl",
-      "pt-BR",
-      "sk"
-    ],
     "workspaces.files.defaultPropertyName": [
       "fr"
     ],
@@ -2286,14 +952,10 @@
       "fr"
     ],
     "workspaces.filters.team.lead": [
-      "de",
-      "et",
-      "lv"
+      "de"
     ],
     "workspaces.filters.team.leadActive": [
-      "de",
-      "et",
-      "lv"
+      "de"
     ],
     "workspaces.infosoud.spisZn": [
       "cs",
@@ -2341,19 +1003,6 @@
     "workspaces.parties.personalLabel": [
       "es"
     ],
-    "workspaces.properties.addCondition": [
-      "cs",
-      "de",
-      "es",
-      "et",
-      "fr",
-      "hu",
-      "lt",
-      "lv",
-      "pl",
-      "pt-BR",
-      "sk"
-    ],
     "workspaces.properties.chipSingle": [
       "pl"
     ],
@@ -2362,56 +1011,14 @@
       "de",
       "sk"
     ],
-    "workspaces.properties.clip": [
-      "pl"
-    ],
     "workspaces.properties.conditions": [
       "fr"
     ],
     "workspaces.properties.documentsLabel": [
       "fr"
     ],
-    "workspaces.properties.editConditionsWhen": [
-      "cs",
-      "de",
-      "es",
-      "et",
-      "fr",
-      "hu",
-      "lt",
-      "lv",
-      "pl",
-      "pt-BR",
-      "sk"
-    ],
-    "workspaces.properties.noConditionFields": [
-      "cs",
-      "de",
-      "es",
-      "et",
-      "fr",
-      "hu",
-      "lt",
-      "lv",
-      "pl",
-      "pt-BR",
-      "sk"
-    ],
     "workspaces.properties.optionsLabel": [
       "fr"
-    ],
-    "workspaces.properties.selectField": [
-      "cs",
-      "de",
-      "es",
-      "et",
-      "fr",
-      "hu",
-      "lt",
-      "lv",
-      "pl",
-      "pt-BR",
-      "sk"
     ],
     "workspaces.properties.text": [
       "cs",
@@ -2435,20 +1042,6 @@
     ],
     "workspaces.views.calendar.additionalDates": [
       "fr"
-    ],
-    "workspaces.views.groupItemCount": [
-      "ar",
-      "cs",
-      "de",
-      "es",
-      "et",
-      "fr",
-      "hu",
-      "lt",
-      "lv",
-      "pl",
-      "pt-BR",
-      "sk"
     ],
     "workspaces.views.layouts.kanban": [
       "cs",

--- a/apps/web/src/i18n/langs/ar.json
+++ b/apps/web/src/i18n/langs/ar.json
@@ -959,7 +959,7 @@
     "next": "التالي",
     "noResults": "لا توجد نتائج",
     "noVersions": "لا يوجد سجل إصدارات",
-    "none": "None",
+    "none": "لا شيء",
     "notes": "الملاحظات",
     "open": "فتح",
     "openInNewTab": "فتح في علامة تبويب جديدة",
@@ -1020,7 +1020,7 @@
     "type": "النوع",
     "typeNameToConfirm": "اكتب الاسم للتأكيد",
     "uncategorized": "غير مصنّف",
-    "undo": "Undo",
+    "undo": "تراجع",
     "unexpectedError": "حدث خطأ غير متوقع. يُرجى التواصل مع الدعم.",
     "unknownUser": "مستخدم غير معروف",
     "unpin": "إلغاء التثبيت",
@@ -1399,47 +1399,47 @@
     "descriptionPlaceholder": "ما الذي يقوم به مسار العمل هذا",
     "disableFlow": "تعطيل مسار العمل",
     "editor": {
-      "newFlowIntro": "Define the steps once, then run this workflow from any matter. Runs pause at review checkpoints for approval."
+      "newFlowIntro": "حدِّد الخطوات مرة واحدة، ثم شغِّل مسار العمل هذا من أي ملف قانوني. تتوقف عمليات التشغيل عند نقاط المراجعة لحين الموافقة."
     },
     "empty": "لا توجد مسارات عمل بعد",
     "emptyDescription": "أنشئ مسار عمل لتحويل المستندات وهدف محدد إلى مُخرَج نهائي.",
     "emptyState": {
-      "blankAction": "Start blank",
-      "description": "Start it from a matter's Workflows tab, on a schedule, or when files are uploaded. It pauses at checkpoints for a person to approve before anything is final, and the result can be saved as a document in the matter.",
-      "examplesTitle": "Start from an example",
-      "title": "A workflow is a saved sequence of AI and review steps your team reruns on matter documents to produce a consistent deliverable."
+      "blankAction": "البدء من الصفر",
+      "description": "ابدأ تشغيله من علامة تبويب «مسارات العمل» في ملف قانوني، أو وفق جدول زمني، أو عند تحميل ملفات. يتوقف عند نقاط المراجعة كي يوافق شخص على النتيجة قبل اعتمادها نهائيًا، ويمكن حفظ الناتج كمستند في الملف القانوني.",
+      "examplesTitle": "البدء من مثال",
+      "title": "مسار العمل هو تسلسل محفوظ من خطوات الذكاء الاصطناعي والمراجعة يعيد فريقك تشغيله على مستندات الملف القانوني لإنتاج مخرج متسق."
     },
     "enableFlow": "تفعيل مسار العمل",
     "enabledDescription": "لا يمكن تشغيل مسارات العمل المعطّلة أو تفعيل مشغّلاتها.",
     "enabledLabel": "مُفعَّل",
     "examples": {
       "documentSummary": {
-        "createStepName": "Create the summary",
-        "description": "Summarize the matter's documents for a colleague who has not read them.",
-        "documentTitle": "Document summary",
-        "name": "Document summary for the file",
-        "summaryStepName": "Summarize the documents",
-        "summaryStepPrompt": "Summarize each input document: parties, subject, key dates, obligations, and open points. Write for a colleague who has not read it."
+        "createStepName": "إنشاء الملخص",
+        "description": "تلخيص مستندات الملف القانوني لزميل لم يقرأها.",
+        "documentTitle": "ملخص المستندات",
+        "name": "ملخص مستندات الملف",
+        "summaryStepName": "تلخيص المستندات",
+        "summaryStepPrompt": "لخِّص كل مستند من مستندات الإدخال، بما يشمل الأطراف والموضوع والتواريخ الرئيسية والالتزامات والنقاط العالقة. اكتب لزميل لم يقرأ المستند."
       },
       "dueDiligence": {
-        "createStepName": "Create the report",
-        "description": "Surface change-of-control, assignment, and liability risks across a data room.",
-        "documentTitle": "Red-flag report",
-        "name": "Due diligence red flags",
-        "reviewGateInstructions": "Check the red flags before the report is created.",
-        "reviewGateStepName": "Check the red flags",
-        "reviewStepName": "Find red flags",
-        "reviewStepPrompt": "Read the input documents and produce a red-flag report: change-of-control, assignment restrictions, termination rights, exclusivity, and liability caps. Quote the relevant language."
+        "createStepName": "إنشاء التقرير",
+        "description": "إبراز مخاطر تغيير السيطرة والتنازل والمسؤولية في جميع مستندات غرفة البيانات.",
+        "documentTitle": "تقرير مؤشرات الخطر",
+        "name": "مؤشرات الخطر في العناية الواجبة",
+        "reviewGateInstructions": "تحقَّق من مؤشرات الخطر قبل إنشاء التقرير.",
+        "reviewGateStepName": "التحقق من مؤشرات الخطر",
+        "reviewStepName": "استخراج مؤشرات الخطر",
+        "reviewStepPrompt": "اقرأ مستندات الإدخال وأعد تقريرًا بمؤشرات الخطر، يشمل تغيير السيطرة وقيود التنازل وحقوق الإنهاء والحصرية وحدود المسؤولية. اقتبس النص ذا الصلة."
       },
       "ndaIntake": {
-        "createStepName": "Create the memo",
-        "description": "Flag unusual clauses in an NDA before your team relies on it.",
-        "documentTitle": "NDA review memo",
-        "name": "NDA intake review",
-        "reviewGateInstructions": "Check the flagged clauses before the memo is created.",
-        "reviewGateStepName": "Check the flagged clauses",
-        "reviewStepName": "Review the NDA",
-        "reviewStepPrompt": "Review the attached NDA against common market standards: term, confidentiality scope, carve-outs, and governing law. Flag unusual clauses with a severity rating and cite the clause."
+        "createStepName": "إنشاء المذكرة",
+        "description": "تحديد البنود غير المعتادة في اتفاقية عدم الإفصاح قبل أن يعتمد عليها فريقك.",
+        "documentTitle": "مذكرة مراجعة اتفاقية عدم الإفصاح",
+        "name": "مراجعة اتفاقية عدم الإفصاح الواردة",
+        "reviewGateInstructions": "تحقَّق من البنود المحددة قبل إنشاء المذكرة.",
+        "reviewGateStepName": "التحقق من البنود المحددة",
+        "reviewStepName": "مراجعة اتفاقية عدم الإفصاح",
+        "reviewStepPrompt": "راجع اتفاقية عدم الإفصاح المرفقة مقارنةً بالمعايير الشائعة في السوق، بما يشمل المدة ونطاق السرية والاستثناءات والقانون الحاكم. حدِّد البنود غير المعتادة مع درجة خطورتها واستشهد بالبند."
       }
     },
     "fileUpload": {
@@ -1509,9 +1509,9 @@
     "steps": {
       "add": "إضافة خطوة:",
       "ai": "خطوة AI",
-      "aiHelp": "Writes text from your instructions and can read the selected input documents.",
+      "aiHelp": "ينشئ نصًا وفق تعليماتك، ويمكنه قراءة مستندات الإدخال المحددة.",
       "createDocument": "إنشاء مستند",
-      "createDocumentHelp": "Saves the most recent AI output as a document in the matter where the run started.",
+      "createDocumentHelp": "يحفظ أحدث ناتج للذكاء الاصطناعي كمستند في الملف القانوني الذي بدأ فيه التشغيل.",
       "documentTitle": "عنوان المستند",
       "documentTitlePlaceholder": "مثال: مذكرة ملخّص",
       "documentTitleRequired": "أدخل عنوان المستند.",
@@ -1526,7 +1526,7 @@
       "promptRequired": "أدخل مُوجَّهًا لخطوة AI.",
       "required": "أضف خطوة واحدة على الأقل.",
       "reviewGate": "بوابة المراجعة",
-      "reviewGateHelp": "Pauses the run until a person approves or rejects.",
+      "reviewGateHelp": "يوقف التشغيل حتى يوافق شخص أو يرفض.",
       "title": "الخطوات"
     },
     "trigger": {
@@ -2001,12 +2001,12 @@
       "addRule": "القاعدة",
       "advanced": "متقدم",
       "approval": {
-        "approve": "Approve",
-        "approveFailed": "Failed to approve playbook",
-        "approvedOn": "Approved {date}",
-        "approvedToast": "Playbook approved",
-        "statusApproved": "Approved",
-        "statusDraft": "Draft"
+        "approve": "موافقة",
+        "approveFailed": "تعذرت الموافقة على دليل المراجعة",
+        "approvedOn": "تمت الموافقة في {date}",
+        "approvedToast": "تمت الموافقة على دليل المراجعة",
+        "statusApproved": "معتمد",
+        "statusDraft": "مسودة"
       },
       "askContentLabel": "نوع الإجابة",
       "askQuestionLabel": "السؤال",
@@ -2069,18 +2069,18 @@
       "issuePlaceholder": "مثال: تحديد المسؤولية",
       "loadFailed": "فشل تحميل أدلّة المراجعة",
       "loading": "جارٍ تحميل أدلّة المراجعة…",
-      "manageTypes": "Manage types…",
+      "manageTypes": "إدارة الأنواع…",
       "namePlaceholder": "مثال: مراجعة اتفاقية عدم الإفصاح",
       "nameRequired": "أضِف اسمًا.",
       "negotiation": {
-        "addTalkingPoint": "Add talking point",
-        "escalationLabel": "Escalation",
-        "escalationPlaceholder": "When/to whom to escalate (optional)",
-        "rationaleLabel": "Rationale",
-        "rationalePlaceholder": "Why we want this (optional)",
-        "talkingPointPlaceholder": "What to say",
-        "talkingPointsLabel": "Talking points",
-        "title": "Negotiation"
+        "addTalkingPoint": "إضافة نقطة نقاش",
+        "escalationLabel": "التصعيد",
+        "escalationPlaceholder": "متى وإلى مَن يتم التصعيد (اختياري)",
+        "rationaleLabel": "المبررات",
+        "rationalePlaceholder": "سبب تمسّكنا بهذا الموقف (اختياري)",
+        "talkingPointPlaceholder": "ما ينبغي قوله",
+        "talkingPointsLabel": "نقاط النقاش",
+        "title": "التفاوض"
       },
       "noPositions": "لا توجد مواقف بعد. أضِف الأول.",
       "optionPlaceholder": "قيمة الخيار",
@@ -2117,17 +2117,17 @@
       },
       "risk": {
         "complianceLabel": "الامتثال",
-        "flaggedCount": "{flagged} of {total} positions flagged",
+        "flaggedCount": "المواقف المحددة: {flagged} من {total}",
         "notApplicableExcluded": "({count} غير قابلة للتطبيق، مستبعدة)",
         "riskLevel": {
-          "critical": "Critical",
-          "high": "High",
-          "low": "Low",
-          "medium": "Medium",
-          "none": "No risk"
+          "critical": "حرج",
+          "high": "مرتفع",
+          "low": "منخفض",
+          "medium": "متوسط",
+          "none": "لا مخاطر"
         },
-        "summaryTitle": "Risk summary",
-        "topIssuesTitle": "Top issues"
+        "summaryTitle": "ملخص المخاطر",
+        "topIssuesTitle": "أهم المسائل"
       },
       "ruleNumber": "القاعدة {index}",
       "rulePlaceholder": "قاعدة بلغة بسيطة",
@@ -2140,11 +2140,11 @@
       },
       "severityLabel": "الخطورة",
       "starters": {
-        "addedToast": "Playbook added",
-        "browseButton": "Browse starter playbooks",
-        "positionCount": "{count, plural, one {# position} other {# positions}}",
-        "subtitle": "Ready-made playbooks you can add and then tailor to your standards.",
-        "title": "Starter playbooks"
+        "addedToast": "تمت إضافة دليل المراجعة",
+        "browseButton": "استعراض أدلّة المراجعة الجاهزة",
+        "positionCount": "{count, plural, zero {لا مواقف} one {موقف واحد} two {موقفان} few {# مواقف} many {# موقفًا} other {# موقف}}",
+        "subtitle": "أدلّة مراجعة جاهزة يمكنك إضافتها ثم تكييفها مع معاييرك.",
+        "title": "أدلّة مراجعة جاهزة"
       },
       "switchToAuto": "العودة إلى التلقائي",
       "switchToManual": "التحويل إلى اليدوي",
@@ -2163,10 +2163,10 @@
         "notApplicable": "غير قابل للتطبيق"
       },
       "versions": {
-        "confirmRestore": "Your current draft will be replaced with this version's content.",
-        "restoreFailed": "Failed to restore version",
-        "restoredToast": "Version restored",
-        "versionHistory": "Version history"
+        "confirmRestore": "ستُستبدل مسودتك الحالية بمحتوى هذا الإصدار.",
+        "restoreFailed": "تعذرت استعادة الإصدار",
+        "restoredToast": "تمت استعادة الإصدار",
+        "versionHistory": "سجل الإصدارات"
       }
     },
     "sections": {
@@ -2902,12 +2902,12 @@
         "updated": "تم تحديث إعداد التعرّف على النص"
       },
       "documentTypes": {
-        "addPlaceholder": "Add a document type (e.g. Employment Agreement)",
-        "deleteFailed": "Couldn't delete document type",
-        "description": "Define the document types your organisation reviews. Playbooks scope to these, and the AI classifier sorts documents into them.",
-        "labelAria": "Document type name",
-        "reorder": "Reorder document type",
-        "title": "Document types"
+        "addPlaceholder": "إضافة نوع مستند (مثل عقد عمل)",
+        "deleteFailed": "تعذر حذف نوع المستند",
+        "description": "حدِّد أنواع المستندات التي تراجعها مؤسستك. تُطبَّق أدلّة المراجعة على هذه الأنواع، ويصنِّف مصنِّف الذكاء الاصطناعي المستندات ضمنها.",
+        "labelAria": "اسم نوع المستند",
+        "reorder": "إعادة ترتيب نوع المستند",
+        "title": "أنواع المستندات"
       },
       "matterNumbering": "ترقيم الملفات القانونية",
       "matterNumberingDescription": "اضبط كيفية توليد أرقام مراجع الملفات القانونية الجديدة",
@@ -3177,7 +3177,7 @@
     "conditionAnd": "و",
     "conditionCount": "{count, plural, zero {# شرط} one {شرط واحد} two {شرطان} few {# شروط} many {# شرطًا} other {# شرط}}",
     "conditionField": "الحقل",
-    "conditionFormulaPlaceholder": "Enter a formula…",
+    "conditionFormulaPlaceholder": "أدخل صيغة…",
     "conditionMatch": "المطابقة",
     "conditionNamePlaceholder": "اسم الشرط (مثل NPF)",
     "conditionOpAfter": "بعد",
@@ -3196,8 +3196,8 @@
     "conditionOpOnOrBefore": "في أو قبل",
     "conditionOperator": "المُعامِل",
     "conditionOr": "أو",
-    "conditionUseFieldInstead": "Use a field instead",
-    "conditionUseFormula": "ƒ Calculated value…",
+    "conditionUseFieldInstead": "استخدام حقل بدلاً من ذلك",
+    "conditionUseFormula": "ƒ قيمة محسوبة…",
     "conditionValue": "القيمة",
     "conditionWhen": "عندما",
     "conditionsTitle": "الشروط",
@@ -3349,7 +3349,7 @@
       "conditionOrBuildNew": "أو أنشئ شرطاً جديداً",
       "conditionReuse": "إعادة استخدام شرط",
       "conditionReusePick": "اختر شرطًا موجودًا…",
-      "conditionRuleFallbackLabel": "Calculated condition",
+      "conditionRuleFallbackLabel": "شرط محسوب",
       "conditionSource": "كيف يُتّخذ القرار",
       "conditionSourceAi": "الذكاء الاصطناعي يقرّر",
       "conditionSourceAsked": "مطروح",
@@ -3375,7 +3375,7 @@
       "gettingStartedTitle": "للبدء",
       "insert": "إدراج",
       "insertAtCaret": "إدراج عند المؤشّر",
-      "insertConditionIntoTemplate": "Insert condition",
+      "insertConditionIntoTemplate": "إدراج شرط",
       "insertFormatDefault": "افتراضي",
       "insertIntoTemplate": "إدراج في القالب",
       "insertItemNumber": "رقم العنصر",
@@ -3518,9 +3518,9 @@
     "settings": {
       "description": "Bring your own web-search API keys so chat can search the web and read pages with your own provider account. Without them, chat uses the platform's shared keys when available.",
       "fetchTitle": "Page reader key",
-      "platformFallback": "The platform's shared key is in use. Add your own to use your own provider account and quota.",
+      "platformFallback": "يُستخدم مفتاح المنصة المشترك. أضف مفتاحك الخاص لاستخدام حسابك وحصتك لدى مزود الخدمة.",
       "searchTitle": "Search provider key",
-      "title": "Web search keys"
+      "title": "مفاتيح البحث على الويب"
     }
   },
   "workspaces": {
@@ -4135,7 +4135,7 @@
       "filterByPlaceholder": "التصفية حسب…",
       "filtersWithCount": "{count, plural, zero {لا عوامل تصفية} one {عامل تصفية واحد} two {عاملا تصفية} few {# عوامل تصفية} many {# عامل تصفية} other {# عامل تصفية}}",
       "groupBy": "التجميع حسب:",
-      "groupItemCount": "{count, plural, one {# item} other {# items}}",
+      "groupItemCount": "{count, plural, zero {لا عناصر} one {عنصر واحد} two {عنصران} few {# عناصر} many {# عنصرًا} other {# عنصر}}",
       "hideColumn": "إخفاء العمود",
       "layouts": {
         "calendar": "تقويم",

--- a/apps/web/src/i18n/langs/cs.json
+++ b/apps/web/src/i18n/langs/cs.json
@@ -800,7 +800,7 @@
     "active": "Aktivní",
     "add": "Přidat",
     "all": "Vše",
-    "and": "And",
+    "and": "A",
     "anonymizationLabels": {
       "address": "Adresa",
       "bankAccountNumber": "Číslo bankovního účtu",
@@ -959,12 +959,12 @@
     "next": "Pokračovat",
     "noResults": "Žádné výsledky",
     "noVersions": "Žádná historie verzí",
-    "none": "None",
+    "none": "Žádné",
     "notes": "Poznámky",
     "open": "Otevřít",
     "openInNewTab": "Otevřít na nové kartě",
     "options": "Možnosti",
-    "or": "Or",
+    "or": "Nebo",
     "organization": "Organizace",
     "organizationName": "Název organizace",
     "pin": "Připnout",
@@ -1020,7 +1020,7 @@
     "type": "Typ",
     "typeNameToConfirm": "Pro potvrzení napište název",
     "uncategorized": "Nekategorizováno",
-    "undo": "Undo",
+    "undo": "Zpět",
     "unexpectedError": "Došlo k neočekávané chybě. Kontaktujte podporu.",
     "unknownUser": "Neznámý uživatel",
     "unpin": "Odepnout",
@@ -1878,7 +1878,7 @@
       "builtInSection": "Vestavěné dovednosti",
       "chooseFile": "Vyberte soubor nebo ho sem přetáhněte",
       "coaching": {
-        "publish": "Publish skill"
+        "publish": "Publikovat dovednost"
       },
       "deleteConfirmDescription": "Dovednost „{name}“ bude z tohoto pracovního prostoru odebrána.",
       "deleteFile": "Smazat soubor",
@@ -1919,7 +1919,7 @@
       "generateSkill": "Vygenerovat pomocí AI",
       "generateTitle": "Vygenerovat dovednost pomocí AI",
       "generating": "Generuji…",
-      "howItRuns": "How it runs",
+      "howItRuns": "Jak se spouští",
       "importFailureFetch": "Zdroj dovednosti se nepodařilo načíst.",
       "importFailureIntegrity": "Zdroj dovednosti se po nalezení změnil. Zkontrolujte ho znovu.",
       "importFailureLimit": "Byl dosažen limit dovedností.",
@@ -1941,7 +1941,7 @@
       "resources": "{count, plural, one {# zdroj} few {# zdroje} other {# zdrojů}}",
       "scopePrivate": "Jen já",
       "scopeTeam": "Všichni v týmu",
-      "selectFileHint": "Select a file from the list to open it in the editor panel on the right.",
+      "selectFileHint": "Výběrem souboru v seznamu jej otevřete v panelu editoru vpravo.",
       "selectedFile": "Vybráno: {name}",
       "selectionLimit": "Najednou můžete vybrat nejvýše {count} dovedností.",
       "sourceUpload": "Nahráno",
@@ -2001,12 +2001,12 @@
       "addRule": "Pravidlo",
       "advanced": "Pokročilé",
       "approval": {
-        "approve": "Approve",
-        "approveFailed": "Failed to approve playbook",
-        "approvedOn": "Approved {date}",
-        "approvedToast": "Playbook approved",
-        "statusApproved": "Approved",
-        "statusDraft": "Draft"
+        "approve": "Schválit",
+        "approveFailed": "Playbook se nepodařilo schválit",
+        "approvedOn": "Schváleno {date}",
+        "approvedToast": "Playbook schválen",
+        "statusApproved": "Schváleno",
+        "statusDraft": "Koncept"
       },
       "askContentLabel": "Typ odpovědi",
       "askQuestionLabel": "Otázka",
@@ -2069,18 +2069,18 @@
       "issuePlaceholder": "např. Omezení odpovědnosti",
       "loadFailed": "Playbooky se nepodařilo načíst",
       "loading": "Načítám playbooky…",
-      "manageTypes": "Manage types…",
+      "manageTypes": "Spravovat typy…",
       "namePlaceholder": "např. revize NDA",
       "nameRequired": "Zadejte název.",
       "negotiation": {
-        "addTalkingPoint": "Add talking point",
-        "escalationLabel": "Escalation",
-        "escalationPlaceholder": "When/to whom to escalate (optional)",
-        "rationaleLabel": "Rationale",
-        "rationalePlaceholder": "Why we want this (optional)",
-        "talkingPointPlaceholder": "What to say",
-        "talkingPointsLabel": "Talking points",
-        "title": "Negotiation"
+        "addTalkingPoint": "Přidat argument",
+        "escalationLabel": "Eskalace",
+        "escalationPlaceholder": "Kdy a komu eskalovat (volitelné)",
+        "rationaleLabel": "Odůvodnění",
+        "rationalePlaceholder": "Proč tuto pozici požadujeme (volitelné)",
+        "talkingPointPlaceholder": "Co říct",
+        "talkingPointsLabel": "Argumenty",
+        "title": "Vyjednávání"
       },
       "noPositions": "Zatím žádné pozice. Přidejte první.",
       "optionPlaceholder": "Hodnota možnosti",
@@ -2117,17 +2117,17 @@
       },
       "risk": {
         "complianceLabel": "Soulad",
-        "flaggedCount": "{flagged} of {total} positions flagged",
+        "flaggedCount": "Označeno {flagged} z {total} pozic",
         "notApplicableExcluded": "({count} nerelevantní, vyloučeno)",
         "riskLevel": {
-          "critical": "Critical",
-          "high": "High",
-          "low": "Low",
-          "medium": "Medium",
-          "none": "No risk"
+          "critical": "Kritické",
+          "high": "Vysoké",
+          "low": "Nízké",
+          "medium": "Střední",
+          "none": "Bez rizika"
         },
-        "summaryTitle": "Risk summary",
-        "topIssuesTitle": "Top issues"
+        "summaryTitle": "Souhrn rizik",
+        "topIssuesTitle": "Hlavní problémy"
       },
       "ruleNumber": "Pravidlo {index}",
       "rulePlaceholder": "Pravidlo v prostém jazyce",
@@ -2140,11 +2140,11 @@
       },
       "severityLabel": "Závažnost",
       "starters": {
-        "addedToast": "Playbook added",
-        "browseButton": "Browse starter playbooks",
-        "positionCount": "{count, plural, one {# position} other {# positions}}",
-        "subtitle": "Ready-made playbooks you can add and then tailor to your standards.",
-        "title": "Starter playbooks"
+        "addedToast": "Playbook přidán",
+        "browseButton": "Procházet úvodní playbooky",
+        "positionCount": "{count, plural, one {# pozice} few {# pozice} other {# pozic}}",
+        "subtitle": "Hotové playbooky, které můžete přidat a upravit podle svých standardů.",
+        "title": "Úvodní playbooky"
       },
       "switchToAuto": "Zpět na automatický režim",
       "switchToManual": "Přepnout na ruční zadání",
@@ -2163,10 +2163,10 @@
         "notApplicable": "Nerelevantní"
       },
       "versions": {
-        "confirmRestore": "Your current draft will be replaced with this version's content.",
-        "restoreFailed": "Failed to restore version",
-        "restoredToast": "Version restored",
-        "versionHistory": "Version history"
+        "confirmRestore": "Obsah aktuálního konceptu bude nahrazen obsahem této verze.",
+        "restoreFailed": "Verzi se nepodařilo obnovit",
+        "restoredToast": "Verze obnovena",
+        "versionHistory": "Historie verzí"
       }
     },
     "sections": {
@@ -2257,9 +2257,9 @@
     }
   },
   "markdownEditor": {
-    "rawLabel": "Markdown source",
-    "showFormatted": "Formatted",
-    "showRaw": "Show raw"
+    "rawLabel": "Zdroj Markdownu",
+    "showFormatted": "Formátovaný text",
+    "showRaw": "Zobrazit zdroj"
   },
   "memory": {
     "addPlaceholder": "Přidejte poznámku, kterou si má asistent zapamatovat…",
@@ -2902,12 +2902,12 @@
         "updated": "Nastavení rozpoznávání textu aktualizováno"
       },
       "documentTypes": {
-        "addPlaceholder": "Add a document type (e.g. Employment Agreement)",
-        "deleteFailed": "Couldn't delete document type",
-        "description": "Define the document types your organisation reviews. Playbooks scope to these, and the AI classifier sorts documents into them.",
-        "labelAria": "Document type name",
-        "reorder": "Reorder document type",
-        "title": "Document types"
+        "addPlaceholder": "Přidat typ dokumentu (např. pracovní smlouva)",
+        "deleteFailed": "Typ dokumentu se nepodařilo smazat",
+        "description": "Určete typy dokumentů, které vaše organizace kontroluje. Playbooky se vztahují k těmto typům a klasifikátor AI do nich dokumenty zařazuje.",
+        "labelAria": "Název typu dokumentu",
+        "reorder": "Změnit pořadí typu dokumentu",
+        "title": "Typy dokumentů"
       },
       "matterNumbering": "Číslování spisů",
       "matterNumberingDescription": "Nastavte, jak se generují referenční čísla nových spisů",
@@ -3518,9 +3518,9 @@
     "settings": {
       "description": "Bring your own web-search API keys so chat can search the web and read pages with your own provider account. Without them, chat uses the platform's shared keys when available.",
       "fetchTitle": "Page reader key",
-      "platformFallback": "The platform's shared key is in use. Add your own to use your own provider account and quota.",
+      "platformFallback": "Používá se sdílený klíč platformy. Přidejte vlastní klíč, chcete-li používat svůj účet a kvótu u poskytovatele.",
       "searchTitle": "Search provider key",
-      "title": "Web search keys"
+      "title": "Klíče pro webové vyhledávání"
     }
   },
   "workspaces": {
@@ -3950,7 +3950,7 @@
     },
     "possibleDuplicates": "Možné duplicity",
     "properties": {
-      "addCondition": "Add condition",
+      "addCondition": "Přidat podmínku",
       "addInputProperty": "Přidejte alespoň jednu vstupní vlastnost pomocí \"@\"",
       "addOption": "Přidat možnost",
       "addPromptForBetterResults": "Přidejte prompt pro lepší výsledky",
@@ -3990,7 +3990,7 @@
       "editColumn": "Upravit sloupec",
       "editConditions": "Upravit podmínky",
       "editConditionsDescription": "Nastavte podmínky, za kterých se má tato vlastnost generovat.",
-      "editConditionsWhen": "Only run extraction when …",
+      "editConditionsWhen": "Spouštět extrakci pouze tehdy, když…",
       "enterAValue": "Zadejte hodnotu",
       "extractEntityType": "Vytěžit informaci",
       "extractEntityTypeDescription": "Sloupec doplňovaný AI.",
@@ -4018,7 +4018,7 @@
       "newColumn": "Nový sloupec",
       "newColumnDescription": "Vyberte, jak se má tento sloupec tabulky vyplňovat.",
       "newColumnName": "Název sloupce",
-      "noConditionFields": "No fields available to filter on.",
+      "noConditionFields": "Nejsou k dispozici žádná pole, podle kterých lze filtrovat.",
       "noFirstDocument": "Zatím žádné dokumenty pro náhled.",
       "noPropertiesFound": "Nebyly nalezeny žádné vlastnosti",
       "optionsHelp": "Zadej hodnoty, ze kterých může AI vybírat.",
@@ -4041,7 +4041,7 @@
       "scopeMatterDescription": "Použít všechny sloupce souborů a spustit celý spis.",
       "searchOrAddOptions": "Hledat nebo přidat možnosti",
       "selectColor": "Vyberte barvu",
-      "selectField": "Select field",
+      "selectField": "Vybrat pole",
       "selectOperator": "Vyberte operátor",
       "setPromptPlaceholder": "Nastavte prompt pro extrakci informací",
       "singleSelect": "Jednoduchý výběr",
@@ -4135,7 +4135,7 @@
       "filterByPlaceholder": "Filtrovat podle…",
       "filtersWithCount": "{count, plural, one {# filtr} few {# filtry} other {# filtrů}}",
       "groupBy": "Seskupit podle:",
-      "groupItemCount": "{count, plural, one {# item} other {# items}}",
+      "groupItemCount": "{count, plural, one {# položka} few {# položky} other {# položek}}",
       "hideColumn": "Skrýt sloupec",
       "layouts": {
         "calendar": "Kalendář",

--- a/apps/web/src/i18n/langs/de.json
+++ b/apps/web/src/i18n/langs/de.json
@@ -800,7 +800,7 @@
     "active": "Aktiv",
     "add": "Hinzufügen",
     "all": "Alle",
-    "and": "And",
+    "and": "Und",
     "anonymizationLabels": {
       "address": "Adresse",
       "bankAccountNumber": "Bankkontonummer",
@@ -959,12 +959,12 @@
     "next": "Weiter",
     "noResults": "Keine Ergebnisse",
     "noVersions": "Kein Versionsverlauf",
-    "none": "None",
+    "none": "Keine",
     "notes": "Notizen",
     "open": "Öffnen",
     "openInNewTab": "In neuem Tab öffnen",
     "options": "Optionen",
-    "or": "Or",
+    "or": "Oder",
     "organization": "Organisation",
     "organizationName": "Organisationsname",
     "pin": "Anheften",
@@ -1020,7 +1020,7 @@
     "type": "Typ",
     "typeNameToConfirm": "Geben Sie zur Bestätigung den Namen ein",
     "uncategorized": "Nicht kategorisiert",
-    "undo": "Undo",
+    "undo": "Rückgängig",
     "unexpectedError": "Ein unerwarteter Fehler ist aufgetreten. Bitte kontaktieren Sie den Support.",
     "unknownUser": "Unbekannter Benutzer",
     "unpin": "Lösen",
@@ -1399,47 +1399,47 @@
     "descriptionPlaceholder": "Was dieser Workflow tut",
     "disableFlow": "Workflow deaktivieren",
     "editor": {
-      "newFlowIntro": "Define the steps once, then run this workflow from any matter. Runs pause at review checkpoints for approval."
+      "newFlowIntro": "Legen Sie die Schritte einmal fest und führen Sie diesen Workflow dann aus jeder Akte heraus aus. Ausführungen werden an Prüfpunkten zur Genehmigung angehalten."
     },
     "empty": "Noch keine Workflows",
     "emptyDescription": "Erstellen Sie einen Workflow, um aus Dokumenten und einem Ziel ein fertiges Ergebnis zu erstellen.",
     "emptyState": {
-      "blankAction": "Start blank",
-      "description": "Start it from a matter's Workflows tab, on a schedule, or when files are uploaded. It pauses at checkpoints for a person to approve before anything is final, and the result can be saved as a document in the matter.",
-      "examplesTitle": "Start from an example",
-      "title": "A workflow is a saved sequence of AI and review steps your team reruns on matter documents to produce a consistent deliverable."
+      "blankAction": "Ohne Vorlage beginnen",
+      "description": "Starten Sie ihn über die Registerkarte „Workflows“ einer Akte, nach einem Zeitplan oder beim Hochladen von Dateien. An Prüfpunkten wird er angehalten, damit eine Person das Ergebnis genehmigt, bevor es endgültig wird. Das Ergebnis kann als Dokument in der Akte gespeichert werden.",
+      "examplesTitle": "Mit einem Beispiel beginnen",
+      "title": "Ein Workflow ist eine gespeicherte Abfolge von KI- und Prüfschritten, die Ihr Team wiederholt auf Aktendokumente anwendet, um ein einheitliches Ergebnis zu erstellen."
     },
     "enableFlow": "Workflow aktivieren",
     "enabledDescription": "Deaktivierte Workflows können nicht ausgeführt oder ausgelöst werden.",
     "enabledLabel": "Aktiviert",
     "examples": {
       "documentSummary": {
-        "createStepName": "Create the summary",
-        "description": "Summarize the matter's documents for a colleague who has not read them.",
-        "documentTitle": "Document summary",
-        "name": "Document summary for the file",
-        "summaryStepName": "Summarize the documents",
-        "summaryStepPrompt": "Summarize each input document: parties, subject, key dates, obligations, and open points. Write for a colleague who has not read it."
+        "createStepName": "Zusammenfassung erstellen",
+        "description": "Fassen Sie die Dokumente der Akte für eine Person zusammen, die sie noch nicht gelesen hat.",
+        "documentTitle": "Dokumentenzusammenfassung",
+        "name": "Dokumentenzusammenfassung für die Akte",
+        "summaryStepName": "Dokumente zusammenfassen",
+        "summaryStepPrompt": "Fassen Sie jedes Eingabedokument zusammen: Parteien, Gegenstand, wichtige Daten, Pflichten und offene Punkte. Schreiben Sie für eine Person, die das Dokument noch nicht gelesen hat."
       },
       "dueDiligence": {
-        "createStepName": "Create the report",
-        "description": "Surface change-of-control, assignment, and liability risks across a data room.",
-        "documentTitle": "Red-flag report",
-        "name": "Due diligence red flags",
-        "reviewGateInstructions": "Check the red flags before the report is created.",
-        "reviewGateStepName": "Check the red flags",
-        "reviewStepName": "Find red flags",
-        "reviewStepPrompt": "Read the input documents and produce a red-flag report: change-of-control, assignment restrictions, termination rights, exclusivity, and liability caps. Quote the relevant language."
+        "createStepName": "Bericht erstellen",
+        "description": "Ermitteln Sie in einem Datenraum Risiken aus Kontrollwechseln, Abtretungen und Haftung.",
+        "documentTitle": "Red-Flag-Bericht",
+        "name": "Warnhinweise aus der Due-Diligence-Prüfung",
+        "reviewGateInstructions": "Prüfen Sie die Warnhinweise, bevor der Bericht erstellt wird.",
+        "reviewGateStepName": "Warnhinweise prüfen",
+        "reviewStepName": "Warnhinweise ermitteln",
+        "reviewStepPrompt": "Lesen Sie die Eingabedokumente und erstellen Sie einen Red-Flag-Bericht zu Kontrollwechseln, Abtretungsbeschränkungen, Kündigungsrechten, Ausschließlichkeitsklauseln und Haftungsobergrenzen. Zitieren Sie die einschlägigen Formulierungen."
       },
       "ndaIntake": {
-        "createStepName": "Create the memo",
-        "description": "Flag unusual clauses in an NDA before your team relies on it.",
-        "documentTitle": "NDA review memo",
-        "name": "NDA intake review",
-        "reviewGateInstructions": "Check the flagged clauses before the memo is created.",
-        "reviewGateStepName": "Check the flagged clauses",
-        "reviewStepName": "Review the NDA",
-        "reviewStepPrompt": "Review the attached NDA against common market standards: term, confidentiality scope, carve-outs, and governing law. Flag unusual clauses with a severity rating and cite the clause."
+        "createStepName": "Vermerk erstellen",
+        "description": "Kennzeichnen Sie ungewöhnliche Klauseln in einer Geheimhaltungsvereinbarung, bevor sich Ihr Team darauf verlässt.",
+        "documentTitle": "Prüfvermerk zur Geheimhaltungsvereinbarung",
+        "name": "Erstprüfung einer Geheimhaltungsvereinbarung",
+        "reviewGateInstructions": "Prüfen Sie die gekennzeichneten Klauseln, bevor der Vermerk erstellt wird.",
+        "reviewGateStepName": "Gekennzeichnete Klauseln prüfen",
+        "reviewStepName": "Geheimhaltungsvereinbarung prüfen",
+        "reviewStepPrompt": "Prüfen Sie die beigefügte Geheimhaltungsvereinbarung anhand üblicher Marktstandards: Laufzeit, Umfang der Vertraulichkeit, Ausnahmen und anwendbares Recht. Kennzeichnen Sie ungewöhnliche Klauseln mit einem Schweregrad und zitieren Sie die jeweilige Klausel."
       }
     },
     "fileUpload": {
@@ -1509,9 +1509,9 @@
     "steps": {
       "add": "Schritt hinzufügen:",
       "ai": "AI-Schritt",
-      "aiHelp": "Writes text from your instructions and can read the selected input documents.",
+      "aiHelp": "Erstellt anhand Ihrer Anweisungen Text und kann die ausgewählten Eingabedokumente lesen.",
       "createDocument": "Dokument erstellen",
-      "createDocumentHelp": "Saves the most recent AI output as a document in the matter where the run started.",
+      "createDocumentHelp": "Speichert die neueste KI-Ausgabe als Dokument in der Akte, aus der die Ausführung gestartet wurde.",
       "documentTitle": "Dokumenttitel",
       "documentTitlePlaceholder": "z. B. Zusammenfassung",
       "documentTitleRequired": "Geben Sie einen Dokumenttitel ein.",
@@ -1526,7 +1526,7 @@
       "promptRequired": "Geben Sie einen Prompt für den AI-Schritt ein.",
       "required": "Fügen Sie mindestens einen Schritt hinzu.",
       "reviewGate": "Prüfschritt",
-      "reviewGateHelp": "Pauses the run until a person approves or rejects.",
+      "reviewGateHelp": "Hält die Ausführung an, bis eine Person sie genehmigt oder ablehnt.",
       "title": "Schritte"
     },
     "trigger": {
@@ -1878,7 +1878,7 @@
       "builtInSection": "Integrierte Skills",
       "chooseFile": "Datei auswählen oder hierher ziehen",
       "coaching": {
-        "publish": "Publish skill"
+        "publish": "Skill veröffentlichen"
       },
       "deleteConfirmDescription": "„{name}“ wird aus diesem Arbeitsbereich entfernt.",
       "deleteFile": "Datei löschen",
@@ -1919,7 +1919,7 @@
       "generateSkill": "Mit KI generieren",
       "generateTitle": "Skill mit KI generieren",
       "generating": "Wird generiert…",
-      "howItRuns": "How it runs",
+      "howItRuns": "Ausführung",
       "importFailureFetch": "Die Skill-Quelle konnte nicht geladen werden.",
       "importFailureIntegrity": "Die Skill-Quelle hat sich nach der Erkennung geändert. Prüfe sie erneut.",
       "importFailureLimit": "Das Skill-Limit wurde erreicht.",
@@ -1941,7 +1941,7 @@
       "resources": "{count, plural, one {# Ressource} other {# Ressourcen}}",
       "scopePrivate": "Nur ich",
       "scopeTeam": "Alle im Team",
-      "selectFileHint": "Select a file from the list to open it in the editor panel on the right.",
+      "selectFileHint": "Wählen Sie eine Datei aus der Liste aus, um sie rechts im Editor zu öffnen.",
       "selectedFile": "Ausgewählt: {name}",
       "selectionLimit": "Wähle höchstens {count} Skills gleichzeitig aus.",
       "sourceUpload": "Hochgeladen",
@@ -2001,12 +2001,12 @@
       "addRule": "Regel",
       "advanced": "Erweitert",
       "approval": {
-        "approve": "Approve",
-        "approveFailed": "Failed to approve playbook",
-        "approvedOn": "Approved {date}",
-        "approvedToast": "Playbook approved",
-        "statusApproved": "Approved",
-        "statusDraft": "Draft"
+        "approve": "Genehmigen",
+        "approveFailed": "Playbook konnte nicht genehmigt werden",
+        "approvedOn": "Genehmigt am {date}",
+        "approvedToast": "Playbook genehmigt",
+        "statusApproved": "Genehmigt",
+        "statusDraft": "Entwurf"
       },
       "askContentLabel": "Antworttyp",
       "askQuestionLabel": "Frage",
@@ -2069,18 +2069,18 @@
       "issuePlaceholder": "z.B. Haftungsbeschränkung",
       "loadFailed": "Playbooks konnten nicht geladen werden",
       "loading": "Playbooks werden geladen…",
-      "manageTypes": "Manage types…",
+      "manageTypes": "Typen verwalten…",
       "namePlaceholder": "z.B. NDA-Prüfung",
       "nameRequired": "Fügen Sie einen Namen hinzu.",
       "negotiation": {
-        "addTalkingPoint": "Add talking point",
-        "escalationLabel": "Escalation",
-        "escalationPlaceholder": "When/to whom to escalate (optional)",
-        "rationaleLabel": "Rationale",
-        "rationalePlaceholder": "Why we want this (optional)",
-        "talkingPointPlaceholder": "What to say",
-        "talkingPointsLabel": "Talking points",
-        "title": "Negotiation"
+        "addTalkingPoint": "Gesprächspunkt hinzufügen",
+        "escalationLabel": "Eskalation",
+        "escalationPlaceholder": "Wann und an wen eskaliert werden soll (optional)",
+        "rationaleLabel": "Begründung",
+        "rationalePlaceholder": "Warum wir dies anstreben (optional)",
+        "talkingPointPlaceholder": "Was gesagt werden soll",
+        "talkingPointsLabel": "Gesprächspunkte",
+        "title": "Verhandlung"
       },
       "noPositions": "Noch keine Standpunkte. Fügen Sie den ersten hinzu.",
       "optionPlaceholder": "Optionswert",
@@ -2117,17 +2117,17 @@
       },
       "risk": {
         "complianceLabel": "Konformität",
-        "flaggedCount": "{flagged} of {total} positions flagged",
+        "flaggedCount": "{flagged} von {total} Positionen gekennzeichnet",
         "notApplicableExcluded": "({count} nicht zutreffend, ausgeschlossen)",
         "riskLevel": {
-          "critical": "Critical",
-          "high": "High",
-          "low": "Low",
-          "medium": "Medium",
-          "none": "No risk"
+          "critical": "Kritisch",
+          "high": "Hoch",
+          "low": "Niedrig",
+          "medium": "Mittel",
+          "none": "Kein Risiko"
         },
-        "summaryTitle": "Risk summary",
-        "topIssuesTitle": "Top issues"
+        "summaryTitle": "Risikoübersicht",
+        "topIssuesTitle": "Wichtigste Punkte"
       },
       "ruleNumber": "Regel {index}",
       "rulePlaceholder": "Regel in einfacher Sprache",
@@ -2140,11 +2140,11 @@
       },
       "severityLabel": "Schweregrad",
       "starters": {
-        "addedToast": "Playbook added",
-        "browseButton": "Browse starter playbooks",
-        "positionCount": "{count, plural, one {# position} other {# positions}}",
-        "subtitle": "Ready-made playbooks you can add and then tailor to your standards.",
-        "title": "Starter playbooks"
+        "addedToast": "Playbook hinzugefügt",
+        "browseButton": "Playbook-Vorlagen durchsuchen",
+        "positionCount": "{count, plural, one {# Position} other {# Positionen}}",
+        "subtitle": "Vorgefertigte Playbooks, die Sie hinzufügen und an Ihre Standards anpassen können.",
+        "title": "Playbook-Vorlagen"
       },
       "switchToAuto": "Zurück zu automatisch",
       "switchToManual": "Zu manuell wechseln",
@@ -2163,10 +2163,10 @@
         "notApplicable": "Nicht zutreffend"
       },
       "versions": {
-        "confirmRestore": "Your current draft will be replaced with this version's content.",
-        "restoreFailed": "Failed to restore version",
-        "restoredToast": "Version restored",
-        "versionHistory": "Version history"
+        "confirmRestore": "Ihr aktueller Entwurf wird durch den Inhalt dieser Version ersetzt.",
+        "restoreFailed": "Version konnte nicht wiederhergestellt werden",
+        "restoredToast": "Version wiederhergestellt",
+        "versionHistory": "Versionsverlauf"
       }
     },
     "sections": {
@@ -2203,29 +2203,29 @@
       "blueprintGallery": {
         "cards": {
           "answerFromSources": {
-            "blurb": "Answer a question grounded in authoritative sources.",
-            "inside": "a source hierarchy · a research prompt",
-            "title": "Answer from sources"
+            "blurb": "Beantworten Sie eine Frage anhand maßgeblicher Quellen.",
+            "inside": "eine Quellenhierarchie · ein Recherche-Prompt",
+            "title": "Aus Quellen beantworten"
           },
           "checkAgainstRules": {
-            "blurb": "Review a document and flag what fails, with citations.",
-            "inside": "references by jurisdiction · a checklist · a review prompt",
-            "title": "Check against rules"
+            "blurb": "Prüfen Sie ein Dokument und kennzeichnen Sie mit Fundstellen, was die Vorgaben nicht erfüllt.",
+            "inside": "Referenzen nach Rechtsordnung · eine Checkliste · ein Prüf-Prompt",
+            "title": "Anhand von Vorgaben prüfen"
           },
           "intakeToDraft": {
-            "blurb": "Ask for the facts, then draft a document.",
-            "inside": "an interview · model documents · a draft prompt",
-            "title": "Intake to draft"
+            "blurb": "Fragen Sie die Fakten ab und erstellen Sie anschließend einen Dokumententwurf.",
+            "inside": "ein Interview · Musterdokumente · ein Entwurfs-Prompt",
+            "title": "Von der Erfassung zum Entwurf"
           }
         },
-        "insideLabel": "Inside",
-        "startBlank": "Start from blank",
-        "startBlankHint": "An empty skill, for when you know exactly what you want.",
-        "subtitle": "Pick a starting shape. We set up the folders and walk you through filling them in.",
-        "title": "How should your skill work?"
+        "insideLabel": "Enthalten",
+        "startBlank": "Ohne Vorlage beginnen",
+        "startBlankHint": "Ein leerer Skill, wenn Sie genau wissen, was Sie benötigen.",
+        "subtitle": "Wählen Sie eine Ausgangsstruktur. Wir richten die Ordner ein und führen Sie durch deren Befüllung.",
+        "title": "Wie soll Ihr Skill arbeiten?"
       },
       "commandConflict": "Ein Skill mit diesem / Befehl existiert bereits",
-      "commandHelp": "Type it in chat to run this skill.",
+      "commandHelp": "Geben Sie den Befehl im Chat ein, um diesen Skill auszuführen.",
       "commandLabel": "Schrägstrich-Befehl (optional)",
       "commandPlaceholder": "z. B. zusammenfassen",
       "createTitle": "Neuer Skill",
@@ -2257,9 +2257,9 @@
     }
   },
   "markdownEditor": {
-    "rawLabel": "Markdown source",
-    "showFormatted": "Formatted",
-    "showRaw": "Show raw"
+    "rawLabel": "Markdown-Quelltext",
+    "showFormatted": "Formatiert",
+    "showRaw": "Quelltext anzeigen"
   },
   "memory": {
     "addPlaceholder": "Fügen Sie eine Notiz hinzu, die sich der Assistent merken soll…",
@@ -2902,12 +2902,12 @@
         "updated": "Einstellung für Dokumenttexterkennung aktualisiert"
       },
       "documentTypes": {
-        "addPlaceholder": "Add a document type (e.g. Employment Agreement)",
-        "deleteFailed": "Couldn't delete document type",
-        "description": "Define the document types your organisation reviews. Playbooks scope to these, and the AI classifier sorts documents into them.",
-        "labelAria": "Document type name",
-        "reorder": "Reorder document type",
-        "title": "Document types"
+        "addPlaceholder": "Dokumentart hinzufügen (z. B. Arbeitsvertrag)",
+        "deleteFailed": "Dokumentart konnte nicht gelöscht werden",
+        "description": "Legen Sie die Dokumentarten fest, die Ihre Organisation prüft. Playbooks werden diesen zugeordnet; der KI-Klassifikator sortiert Dokumente entsprechend ein.",
+        "labelAria": "Name der Dokumentart",
+        "reorder": "Dokumentart neu anordnen",
+        "title": "Dokumentarten"
       },
       "matterNumbering": "Aktennummerierung",
       "matterNumberingDescription": "Konfigurieren Sie, wie neue Aktenzeichen erzeugt werden",
@@ -3177,7 +3177,7 @@
     "conditionAnd": "Und",
     "conditionCount": "{count, plural, one {# Bedingung} other {# Bedingungen}}",
     "conditionField": "Feld",
-    "conditionFormulaPlaceholder": "Enter a formula…",
+    "conditionFormulaPlaceholder": "Formel eingeben…",
     "conditionMatch": "Übereinstimmung",
     "conditionNamePlaceholder": "Bedingungsname (z. B. NPF)",
     "conditionOpAfter": "nach",
@@ -3196,8 +3196,8 @@
     "conditionOpOnOrBefore": "am oder vor",
     "conditionOperator": "Operator",
     "conditionOr": "Oder",
-    "conditionUseFieldInstead": "Use a field instead",
-    "conditionUseFormula": "ƒ Calculated value…",
+    "conditionUseFieldInstead": "Stattdessen ein Feld verwenden",
+    "conditionUseFormula": "ƒ Berechneter Wert…",
     "conditionValue": "Wert",
     "conditionWhen": "Wenn",
     "conditionsTitle": "Bedingungen",
@@ -3349,7 +3349,7 @@
       "conditionOrBuildNew": "oder eine neue erstellen",
       "conditionReuse": "Bedingung wiederverwenden",
       "conditionReusePick": "Vorhandene Bedingung wählen…",
-      "conditionRuleFallbackLabel": "Calculated condition",
+      "conditionRuleFallbackLabel": "Berechnete Bedingung",
       "conditionSource": "Wie es entschieden wird",
       "conditionSourceAi": "KI entscheidet",
       "conditionSourceAsked": "Abgefragt",
@@ -3375,7 +3375,7 @@
       "gettingStartedTitle": "Erste Schritte",
       "insert": "Einfügen",
       "insertAtCaret": "An der Cursorposition einfügen",
-      "insertConditionIntoTemplate": "Insert condition",
+      "insertConditionIntoTemplate": "Bedingung einfügen",
       "insertFormatDefault": "Standard",
       "insertIntoTemplate": "In Vorlage einfügen",
       "insertItemNumber": "Positionsnummer",
@@ -3518,9 +3518,9 @@
     "settings": {
       "description": "Bring your own web-search API keys so chat can search the web and read pages with your own provider account. Without them, chat uses the platform's shared keys when available.",
       "fetchTitle": "Page reader key",
-      "platformFallback": "The platform's shared key is in use. Add your own to use your own provider account and quota.",
+      "platformFallback": "Der gemeinsam genutzte Schlüssel der Plattform wird verwendet. Fügen Sie einen eigenen hinzu, um Ihr eigenes Anbieterkonto und Kontingent zu nutzen.",
       "searchTitle": "Search provider key",
-      "title": "Web search keys"
+      "title": "Schlüssel für die Websuche"
     }
   },
   "workspaces": {
@@ -3950,7 +3950,7 @@
     },
     "possibleDuplicates": "Mögliche Duplikate",
     "properties": {
-      "addCondition": "Add condition",
+      "addCondition": "Bedingung hinzufügen",
       "addInputProperty": "Fügen Sie mindestens eine Eingabeeigenschaft mit \"@\" hinzu",
       "addOption": "Option hinzufügen",
       "addPromptForBetterResults": "Fügen Sie einen Prompt für bessere Ergebnisse hinzu",
@@ -3990,7 +3990,7 @@
       "editColumn": "Spalte bearbeiten",
       "editConditions": "Bedingungen bearbeiten",
       "editConditionsDescription": "Legen Sie Bedingungen fest, wann diese Eigenschaft generiert werden soll.",
-      "editConditionsWhen": "Only run extraction when …",
+      "editConditionsWhen": "Extraktion nur ausführen, wenn …",
       "enterAValue": "Wert eingeben",
       "extractEntityType": "Entitätstyp extrahieren",
       "extractEntityTypeDescription": "Erstellen Sie eine KI-gefüllte Tabellenspalte.",
@@ -4018,7 +4018,7 @@
       "newColumn": "Neue Spalte",
       "newColumnDescription": "Wählen Sie, wie diese Tabellenspalte gefüllt werden soll.",
       "newColumnName": "Spaltenname",
-      "noConditionFields": "No fields available to filter on.",
+      "noConditionFields": "Keine Felder zum Filtern verfügbar.",
       "noFirstDocument": "Noch keine Dokumente für die Vorschau.",
       "noPropertiesFound": "Keine Eigenschaften gefunden",
       "optionsHelp": "Lege die Werte fest, aus denen die KI wählen darf.",
@@ -4041,7 +4041,7 @@
       "scopeMatterDescription": "Alle Dateispalten verwenden und die Akte ausführen.",
       "searchOrAddOptions": "Optionen suchen oder hinzufügen",
       "selectColor": "Farbe auswählen",
-      "selectField": "Select field",
+      "selectField": "Feld auswählen",
       "selectOperator": "Operator auswählen",
       "setPromptPlaceholder": "Prompt zum Extrahieren der Informationen festlegen",
       "singleSelect": "Einfachauswahl",
@@ -4135,7 +4135,7 @@
       "filterByPlaceholder": "Filtern nach…",
       "filtersWithCount": "{count, plural, one {# Filter} other {# Filter}}",
       "groupBy": "Gruppieren nach:",
-      "groupItemCount": "{count, plural, one {# item} other {# items}}",
+      "groupItemCount": "{count, plural, one {# Element} other {# Elemente}}",
       "hideColumn": "Spalte ausblenden",
       "layouts": {
         "calendar": "Kalender",

--- a/apps/web/src/i18n/langs/es.json
+++ b/apps/web/src/i18n/langs/es.json
@@ -800,7 +800,7 @@
     "active": "Activo",
     "add": "Añadir",
     "all": "Todos",
-    "and": "And",
+    "and": "Y",
     "anonymizationLabels": {
       "address": "Dirección",
       "bankAccountNumber": "Número de cuenta bancaria",
@@ -959,12 +959,12 @@
     "next": "Siguiente",
     "noResults": "Sin resultados",
     "noVersions": "Sin historial de versiones",
-    "none": "None",
+    "none": "Ninguno",
     "notes": "Notas",
     "open": "Abrir",
     "openInNewTab": "Abrir en una pestaña nueva",
     "options": "Opciones",
-    "or": "Or",
+    "or": "O",
     "organization": "Organización",
     "organizationName": "Nombre de la organización",
     "pin": "Fijar",
@@ -1020,7 +1020,7 @@
     "type": "Tipo",
     "typeNameToConfirm": "Escriba el nombre para confirmar",
     "uncategorized": "Sin categorizar",
-    "undo": "Undo",
+    "undo": "Deshacer",
     "unexpectedError": "Se produjo un error inesperado. Contacte con soporte.",
     "unknownUser": "Usuario desconocido",
     "unpin": "Desfijar",
@@ -1399,47 +1399,47 @@
     "descriptionPlaceholder": "Qué hace este flujo de trabajo",
     "disableFlow": "Desactivar flujo de trabajo",
     "editor": {
-      "newFlowIntro": "Define the steps once, then run this workflow from any matter. Runs pause at review checkpoints for approval."
+      "newFlowIntro": "Define los pasos una vez y después ejecuta este flujo de trabajo desde cualquier asunto. Las ejecuciones se detienen en los puntos de control para su aprobación."
     },
     "empty": "Aún no hay flujos de trabajo",
     "emptyDescription": "Crea un flujo de trabajo para convertir documentos y un objetivo en un entregable terminado.",
     "emptyState": {
-      "blankAction": "Start blank",
-      "description": "Start it from a matter's Workflows tab, on a schedule, or when files are uploaded. It pauses at checkpoints for a person to approve before anything is final, and the result can be saved as a document in the matter.",
-      "examplesTitle": "Start from an example",
-      "title": "A workflow is a saved sequence of AI and review steps your team reruns on matter documents to produce a consistent deliverable."
+      "blankAction": "Empezar desde cero",
+      "description": "Inícialo desde la pestaña Flujos de trabajo de un asunto, según una programación o al cargar archivos. Se detiene en los puntos de control para que una persona lo apruebe antes de finalizar; el resultado se puede guardar como documento en el asunto.",
+      "examplesTitle": "Empezar con un ejemplo",
+      "title": "Un flujo de trabajo es una secuencia guardada de pasos de IA y revisión que el equipo vuelve a ejecutar en los documentos de un asunto para obtener un resultado uniforme."
     },
     "enableFlow": "Activar flujo de trabajo",
     "enabledDescription": "Los flujos de trabajo desactivados no se pueden ejecutar ni activar.",
     "enabledLabel": "Activado",
     "examples": {
       "documentSummary": {
-        "createStepName": "Create the summary",
-        "description": "Summarize the matter's documents for a colleague who has not read them.",
-        "documentTitle": "Document summary",
-        "name": "Document summary for the file",
-        "summaryStepName": "Summarize the documents",
-        "summaryStepPrompt": "Summarize each input document: parties, subject, key dates, obligations, and open points. Write for a colleague who has not read it."
+        "createStepName": "Crear el resumen",
+        "description": "Resume los documentos del asunto para un compañero que no los haya leído.",
+        "documentTitle": "Resumen de documentos",
+        "name": "Resumen de los documentos del asunto",
+        "summaryStepName": "Resumir los documentos",
+        "summaryStepPrompt": "Resume cada documento de entrada: partes, objeto, fechas clave, obligaciones y cuestiones pendientes. Escribe para un compañero que no lo haya leído."
       },
       "dueDiligence": {
-        "createStepName": "Create the report",
-        "description": "Surface change-of-control, assignment, and liability risks across a data room.",
-        "documentTitle": "Red-flag report",
-        "name": "Due diligence red flags",
-        "reviewGateInstructions": "Check the red flags before the report is created.",
-        "reviewGateStepName": "Check the red flags",
-        "reviewStepName": "Find red flags",
-        "reviewStepPrompt": "Read the input documents and produce a red-flag report: change-of-control, assignment restrictions, termination rights, exclusivity, and liability caps. Quote the relevant language."
+        "createStepName": "Crear el informe",
+        "description": "Detecta riesgos de cambio de control, cesión y responsabilidad en toda una sala de datos.",
+        "documentTitle": "Informe de señales de alerta",
+        "name": "Señales de alerta de la diligencia debida",
+        "reviewGateInstructions": "Comprueba las señales de alerta antes de crear el informe.",
+        "reviewGateStepName": "Comprobar las señales de alerta",
+        "reviewStepName": "Detectar señales de alerta",
+        "reviewStepPrompt": "Lee los documentos de entrada y elabora un informe de señales de alerta: cambio de control, restricciones a la cesión, derechos de resolución, exclusividad y límites de responsabilidad. Cita el texto pertinente."
       },
       "ndaIntake": {
-        "createStepName": "Create the memo",
-        "description": "Flag unusual clauses in an NDA before your team relies on it.",
-        "documentTitle": "NDA review memo",
-        "name": "NDA intake review",
-        "reviewGateInstructions": "Check the flagged clauses before the memo is created.",
-        "reviewGateStepName": "Check the flagged clauses",
-        "reviewStepName": "Review the NDA",
-        "reviewStepPrompt": "Review the attached NDA against common market standards: term, confidentiality scope, carve-outs, and governing law. Flag unusual clauses with a severity rating and cite the clause."
+        "createStepName": "Crear el informe interno",
+        "description": "Señala las cláusulas inusuales de un acuerdo de confidencialidad antes de que el equipo se base en él.",
+        "documentTitle": "Informe de revisión del acuerdo de confidencialidad",
+        "name": "Revisión inicial del acuerdo de confidencialidad",
+        "reviewGateInstructions": "Comprueba las cláusulas señaladas antes de crear el informe interno.",
+        "reviewGateStepName": "Comprobar las cláusulas señaladas",
+        "reviewStepName": "Revisar el acuerdo de confidencialidad",
+        "reviewStepPrompt": "Revisa el acuerdo de confidencialidad adjunto conforme a las prácticas habituales del mercado: vigencia, alcance de la confidencialidad, exclusiones y ley aplicable. Señala las cláusulas inusuales, asígnales un nivel de gravedad y cita la cláusula."
       }
     },
     "fileUpload": {
@@ -1509,9 +1509,9 @@
     "steps": {
       "add": "Añadir paso:",
       "ai": "Paso de IA",
-      "aiHelp": "Writes text from your instructions and can read the selected input documents.",
+      "aiHelp": "Redacta texto a partir de tus instrucciones y puede leer los documentos de entrada seleccionados.",
       "createDocument": "Crear documento",
-      "createDocumentHelp": "Saves the most recent AI output as a document in the matter where the run started.",
+      "createDocumentHelp": "Guarda la salida más reciente de la IA como documento en el asunto donde se inició la ejecución.",
       "documentTitle": "Título del documento",
       "documentTitlePlaceholder": "p. ej. Memorando de resumen",
       "documentTitleRequired": "Introduce un título de documento.",
@@ -1521,12 +1521,12 @@
       "instructionsPlaceholder": "Qué debe comprobar el revisor",
       "namePlaceholder": "Nombre del paso",
       "nameRequired": "Introduce un nombre para cada paso.",
-      "prompt": "Prompt",
+      "prompt": "Instrucción",
       "promptPlaceholder": "Instrucciones para el paso de IA",
       "promptRequired": "Introduce un prompt para el paso de IA.",
       "required": "Añade al menos un paso.",
       "reviewGate": "Punto de revisión",
-      "reviewGateHelp": "Pauses the run until a person approves or rejects.",
+      "reviewGateHelp": "Detiene la ejecución hasta que una persona la apruebe o rechace.",
       "title": "Pasos"
     },
     "trigger": {
@@ -1878,7 +1878,7 @@
       "builtInSection": "Habilidades integradas",
       "chooseFile": "Elige un archivo o arrástralo aquí",
       "coaching": {
-        "publish": "Publish skill"
+        "publish": "Publicar habilidad"
       },
       "deleteConfirmDescription": "“{name}” se eliminará de este espacio de trabajo.",
       "deleteFile": "Eliminar archivo",
@@ -1919,7 +1919,7 @@
       "generateSkill": "Generar con IA",
       "generateTitle": "Generar habilidad con IA",
       "generating": "Generando…",
-      "howItRuns": "How it runs",
+      "howItRuns": "Cómo se ejecuta",
       "importFailureFetch": "No se pudo cargar la fuente de la habilidad.",
       "importFailureIntegrity": "La fuente de la habilidad cambió después de detectarla. Revísala de nuevo.",
       "importFailureLimit": "Se alcanzó el límite de habilidades.",
@@ -1941,7 +1941,7 @@
       "resources": "{count, plural, one {# recurso} other {# recursos}}",
       "scopePrivate": "Solo yo",
       "scopeTeam": "Todos en el equipo",
-      "selectFileHint": "Select a file from the list to open it in the editor panel on the right.",
+      "selectFileHint": "Selecciona un archivo de la lista para abrirlo en el panel del editor de la derecha.",
       "selectedFile": "Seleccionado: {name}",
       "selectionLimit": "Selecciona hasta {count} habilidades a la vez.",
       "sourceUpload": "Subido",
@@ -2001,12 +2001,12 @@
       "addRule": "Regla",
       "advanced": "Avanzado",
       "approval": {
-        "approve": "Approve",
-        "approveFailed": "Failed to approve playbook",
-        "approvedOn": "Approved {date}",
-        "approvedToast": "Playbook approved",
-        "statusApproved": "Approved",
-        "statusDraft": "Draft"
+        "approve": "Aprobar",
+        "approveFailed": "No se pudo aprobar el playbook",
+        "approvedOn": "Aprobado el {date}",
+        "approvedToast": "Playbook aprobado",
+        "statusApproved": "Aprobado",
+        "statusDraft": "Borrador"
       },
       "askContentLabel": "Tipo de respuesta",
       "askQuestionLabel": "Pregunta",
@@ -2069,18 +2069,18 @@
       "issuePlaceholder": "p. ej. Limitación de responsabilidad",
       "loadFailed": "No se pudieron cargar los playbooks",
       "loading": "Cargando playbooks…",
-      "manageTypes": "Manage types…",
+      "manageTypes": "Gestionar tipos…",
       "namePlaceholder": "p. ej. Revisión de NDA",
       "nameRequired": "Añade un nombre.",
       "negotiation": {
-        "addTalkingPoint": "Add talking point",
-        "escalationLabel": "Escalation",
-        "escalationPlaceholder": "When/to whom to escalate (optional)",
-        "rationaleLabel": "Rationale",
-        "rationalePlaceholder": "Why we want this (optional)",
-        "talkingPointPlaceholder": "What to say",
-        "talkingPointsLabel": "Talking points",
-        "title": "Negotiation"
+        "addTalkingPoint": "Añadir argumento de negociación",
+        "escalationLabel": "Escalado",
+        "escalationPlaceholder": "Cuándo y a quién escalar (opcional)",
+        "rationaleLabel": "Justificación",
+        "rationalePlaceholder": "Por qué queremos esto (opcional)",
+        "talkingPointPlaceholder": "Qué decir",
+        "talkingPointsLabel": "Argumentos de negociación",
+        "title": "Negociación"
       },
       "noPositions": "Aún no hay posiciones. Añade la primera.",
       "optionPlaceholder": "Valor de la opción",
@@ -2117,17 +2117,17 @@
       },
       "risk": {
         "complianceLabel": "Cumplimiento",
-        "flaggedCount": "{flagged} of {total} positions flagged",
+        "flaggedCount": "{flagged} de {total} posiciones señaladas",
         "notApplicableExcluded": "({count} no aplicables, excluidas)",
         "riskLevel": {
-          "critical": "Critical",
-          "high": "High",
-          "low": "Low",
-          "medium": "Medium",
-          "none": "No risk"
+          "critical": "Crítico",
+          "high": "Alto",
+          "low": "Bajo",
+          "medium": "Medio",
+          "none": "Sin riesgo"
         },
-        "summaryTitle": "Risk summary",
-        "topIssuesTitle": "Top issues"
+        "summaryTitle": "Resumen de riesgos",
+        "topIssuesTitle": "Principales problemas"
       },
       "ruleNumber": "Regla {index}",
       "rulePlaceholder": "Regla en lenguaje sencillo",
@@ -2140,11 +2140,11 @@
       },
       "severityLabel": "Gravedad",
       "starters": {
-        "addedToast": "Playbook added",
-        "browseButton": "Browse starter playbooks",
-        "positionCount": "{count, plural, one {# position} other {# positions}}",
-        "subtitle": "Ready-made playbooks you can add and then tailor to your standards.",
-        "title": "Starter playbooks"
+        "addedToast": "Playbook añadido",
+        "browseButton": "Explorar playbooks de inicio",
+        "positionCount": "{count, plural, one {# posición} other {# posiciones}}",
+        "subtitle": "Playbooks listos para añadir y adaptar a tus estándares.",
+        "title": "Playbooks de inicio"
       },
       "switchToAuto": "Volver a automático",
       "switchToManual": "Cambiar a manual",
@@ -2163,10 +2163,10 @@
         "notApplicable": "No aplicable"
       },
       "versions": {
-        "confirmRestore": "Your current draft will be replaced with this version's content.",
-        "restoreFailed": "Failed to restore version",
-        "restoredToast": "Version restored",
-        "versionHistory": "Version history"
+        "confirmRestore": "El borrador actual se sustituirá por el contenido de esta versión.",
+        "restoreFailed": "No se pudo restaurar la versión",
+        "restoredToast": "Versión restaurada",
+        "versionHistory": "Historial de versiones"
       }
     },
     "sections": {
@@ -2203,29 +2203,29 @@
       "blueprintGallery": {
         "cards": {
           "answerFromSources": {
-            "blurb": "Answer a question grounded in authoritative sources.",
-            "inside": "a source hierarchy · a research prompt",
-            "title": "Answer from sources"
+            "blurb": "Responde a una pregunta basándote en fuentes autorizadas.",
+            "inside": "una jerarquía de fuentes · una instrucción de investigación",
+            "title": "Responder a partir de fuentes"
           },
           "checkAgainstRules": {
-            "blurb": "Review a document and flag what fails, with citations.",
-            "inside": "references by jurisdiction · a checklist · a review prompt",
-            "title": "Check against rules"
+            "blurb": "Revisa un documento y señala los incumplimientos con citas.",
+            "inside": "referencias por jurisdicción · una lista de comprobación · una instrucción de revisión",
+            "title": "Comprobar conforme a las reglas"
           },
           "intakeToDraft": {
-            "blurb": "Ask for the facts, then draft a document.",
-            "inside": "an interview · model documents · a draft prompt",
-            "title": "Intake to draft"
+            "blurb": "Solicita los hechos y después redacta un documento.",
+            "inside": "una entrevista · documentos modelo · una instrucción de redacción",
+            "title": "De la recopilación a la redacción"
           }
         },
-        "insideLabel": "Inside",
-        "startBlank": "Start from blank",
-        "startBlankHint": "An empty skill, for when you know exactly what you want.",
-        "subtitle": "Pick a starting shape. We set up the folders and walk you through filling them in.",
-        "title": "How should your skill work?"
+        "insideLabel": "Contenido",
+        "startBlank": "Empezar desde cero",
+        "startBlankHint": "Una habilidad vacía para cuando sabes exactamente lo que quieres.",
+        "subtitle": "Elige una estructura inicial. Prepararemos las carpetas y te guiaremos para completarlas.",
+        "title": "¿Cómo debe funcionar tu habilidad?"
       },
       "commandConflict": "Ya existe una habilidad con este comando /",
-      "commandHelp": "Type it in chat to run this skill.",
+      "commandHelp": "Escríbelo en el chat para ejecutar esta habilidad.",
       "commandLabel": "Comando con barra (opcional)",
       "commandPlaceholder": "p. ej. resumir",
       "createTitle": "Nueva habilidad",
@@ -2257,9 +2257,9 @@
     }
   },
   "markdownEditor": {
-    "rawLabel": "Markdown source",
-    "showFormatted": "Formatted",
-    "showRaw": "Show raw"
+    "rawLabel": "Código fuente Markdown",
+    "showFormatted": "Con formato",
+    "showRaw": "Mostrar código fuente"
   },
   "memory": {
     "addPlaceholder": "Añada una nota para que el asistente la recuerde…",
@@ -2902,12 +2902,12 @@
         "updated": "Configuración de reconocimiento de texto actualizada"
       },
       "documentTypes": {
-        "addPlaceholder": "Add a document type (e.g. Employment Agreement)",
-        "deleteFailed": "Couldn't delete document type",
-        "description": "Define the document types your organisation reviews. Playbooks scope to these, and the AI classifier sorts documents into them.",
-        "labelAria": "Document type name",
-        "reorder": "Reorder document type",
-        "title": "Document types"
+        "addPlaceholder": "Añadir un tipo de documento (p. ej., contrato de trabajo)",
+        "deleteFailed": "No se pudo eliminar el tipo de documento",
+        "description": "Define los tipos de documentos que revisa tu organización. Los playbooks se aplican a estos tipos y el clasificador de IA ordena los documentos en ellos.",
+        "labelAria": "Nombre del tipo de documento",
+        "reorder": "Reordenar tipo de documento",
+        "title": "Tipos de documentos"
       },
       "matterNumbering": "Numeración de asuntos",
       "matterNumberingDescription": "Configura cómo se generan los números de referencia de los asuntos nuevos",
@@ -3177,7 +3177,7 @@
     "conditionAnd": "Y",
     "conditionCount": "{count, plural, one {# condición} other {# condiciones}}",
     "conditionField": "Campo",
-    "conditionFormulaPlaceholder": "Enter a formula…",
+    "conditionFormulaPlaceholder": "Introduce una fórmula…",
     "conditionMatch": "Coincidencia",
     "conditionNamePlaceholder": "Nombre de la condición (p. ej. NPF)",
     "conditionOpAfter": "después de",
@@ -3196,8 +3196,8 @@
     "conditionOpOnOrBefore": "el o antes de",
     "conditionOperator": "Operador",
     "conditionOr": "O",
-    "conditionUseFieldInstead": "Use a field instead",
-    "conditionUseFormula": "ƒ Calculated value…",
+    "conditionUseFieldInstead": "Usar un campo en su lugar",
+    "conditionUseFormula": "ƒ Valor calculado…",
     "conditionValue": "Valor",
     "conditionWhen": "Cuando",
     "conditionsTitle": "Condiciones",
@@ -3349,7 +3349,7 @@
       "conditionOrBuildNew": "o crea una nueva",
       "conditionReuse": "Reutilizar una condición",
       "conditionReusePick": "Elige una condición existente…",
-      "conditionRuleFallbackLabel": "Calculated condition",
+      "conditionRuleFallbackLabel": "Condición calculada",
       "conditionSource": "Cómo se decide",
       "conditionSourceAi": "Decide la IA",
       "conditionSourceAsked": "Preguntada",
@@ -3375,7 +3375,7 @@
       "gettingStartedTitle": "Primeros pasos",
       "insert": "Insertar",
       "insertAtCaret": "Insertar en el cursor",
-      "insertConditionIntoTemplate": "Insert condition",
+      "insertConditionIntoTemplate": "Insertar condición",
       "insertFormatDefault": "Predeterminada",
       "insertIntoTemplate": "Insertar en la plantilla",
       "insertItemNumber": "Número de elemento",
@@ -3518,9 +3518,9 @@
     "settings": {
       "description": "Bring your own web-search API keys so chat can search the web and read pages with your own provider account. Without them, chat uses the platform's shared keys when available.",
       "fetchTitle": "Page reader key",
-      "platformFallback": "The platform's shared key is in use. Add your own to use your own provider account and quota.",
+      "platformFallback": "Se está usando la clave compartida de la plataforma. Añade la tuya para usar tu propia cuenta y cuota del proveedor.",
       "searchTitle": "Search provider key",
-      "title": "Web search keys"
+      "title": "Claves de búsqueda web"
     }
   },
   "workspaces": {
@@ -3950,7 +3950,7 @@
     },
     "possibleDuplicates": "Posibles duplicados",
     "properties": {
-      "addCondition": "Add condition",
+      "addCondition": "Añadir condición",
       "addInputProperty": "Añada al menos una propiedad de entrada usando \"@\"",
       "addOption": "Añadir opción",
       "addPromptForBetterResults": "Añada una instrucción para mejores resultados",
@@ -3990,7 +3990,7 @@
       "editColumn": "Editar columna",
       "editConditions": "Editar condiciones",
       "editConditionsDescription": "Establezca las condiciones para generar esta propiedad.",
-      "editConditionsWhen": "Only run extraction when …",
+      "editConditionsWhen": "Ejecutar la extracción solo cuando…",
       "enterAValue": "Introduzca un valor",
       "extractEntityType": "Extraer tipo de entidad",
       "extractEntityTypeDescription": "Cree una columna de tabla extraída por IA.",
@@ -4018,7 +4018,7 @@
       "newColumn": "Nueva columna",
       "newColumnDescription": "Elija cómo se debe rellenar esta columna de la tabla.",
       "newColumnName": "Nombre de columna",
-      "noConditionFields": "No fields available to filter on.",
+      "noConditionFields": "No hay campos disponibles para filtrar.",
       "noFirstDocument": "Aún no hay documentos para previsualizar.",
       "noPropertiesFound": "No se encontraron propiedades",
       "optionsHelp": "Define los valores entre los que la IA puede elegir.",
@@ -4041,7 +4041,7 @@
       "scopeMatterDescription": "Use todas las columnas de archivo y ejecute el Matter.",
       "searchOrAddOptions": "Buscar o añadir opciones",
       "selectColor": "Seleccionar color",
-      "selectField": "Select field",
+      "selectField": "Seleccionar campo",
       "selectOperator": "Seleccionar operador",
       "setPromptPlaceholder": "Defina una instrucción para extraer la información",
       "singleSelect": "Selección única",
@@ -4135,7 +4135,7 @@
       "filterByPlaceholder": "Filtrar por…",
       "filtersWithCount": "{count, plural, one {# filtro} other {# filtros}}",
       "groupBy": "Agrupar por:",
-      "groupItemCount": "{count, plural, one {# item} other {# items}}",
+      "groupItemCount": "{count, plural, one {# elemento} other {# elementos}}",
       "hideColumn": "Ocultar columna",
       "layouts": {
         "calendar": "Calendario",

--- a/apps/web/src/i18n/langs/et.json
+++ b/apps/web/src/i18n/langs/et.json
@@ -800,7 +800,7 @@
     "active": "Aktiivne",
     "add": "Lisa",
     "all": "Kõik",
-    "and": "And",
+    "and": "Ja",
     "anonymizationLabels": {
       "address": "Aadress",
       "bankAccountNumber": "Pangakonto number",
@@ -959,12 +959,12 @@
     "next": "Edasi",
     "noResults": "Tulemused puuduvad",
     "noVersions": "Versiooniajalogu pole",
-    "none": "None",
+    "none": "Puudub",
     "notes": "Märkused",
     "open": "Ava",
     "openInNewTab": "Ava uuel vahekaardil",
     "options": "Valikud",
-    "or": "Or",
+    "or": "Või",
     "organization": "Organisatsioon",
     "organizationName": "Organisatsiooni nimi",
     "pin": "Kinnita",
@@ -1020,7 +1020,7 @@
     "type": "Tüüp",
     "typeNameToConfirm": "Kinnitamiseks sisestage nimi",
     "uncategorized": "Kategoriseerimata",
-    "undo": "Undo",
+    "undo": "Võta tagasi",
     "unexpectedError": "Ilmnes ootamatu viga. Palun pöörduge klienditoe poole.",
     "unknownUser": "Tundmatu kasutaja",
     "unpin": "Eemalda kinnitamine",
@@ -1399,47 +1399,47 @@
     "descriptionPlaceholder": "Mida see töövoog teeb",
     "disableFlow": "Keela töövoog",
     "editor": {
-      "newFlowIntro": "Define the steps once, then run this workflow from any matter. Runs pause at review checkpoints for approval."
+      "newFlowIntro": "Määrake sammud üks kord ja käivitage seejärel töövoog mis tahes toimikust. Käitamine peatub heakskiitmiseks ülevaatuse kontrollpunktides."
     },
     "empty": "Töövoogusid veel pole",
     "emptyDescription": "Loo töövoog, et muuta dokumendid ja eesmärk valmis tulemuseks.",
     "emptyState": {
-      "blankAction": "Start blank",
-      "description": "Start it from a matter's Workflows tab, on a schedule, or when files are uploaded. It pauses at checkpoints for a person to approve before anything is final, and the result can be saved as a document in the matter.",
-      "examplesTitle": "Start from an example",
-      "title": "A workflow is a saved sequence of AI and review steps your team reruns on matter documents to produce a consistent deliverable."
+      "blankAction": "Alusta tühjalt lehelt",
+      "description": "Käivitage see toimiku vahekaardilt „Töövood“, ajakava järgi või failide üleslaadimisel. Töövoog peatub kontrollpunktides, et inimene saaks tulemuse enne lõplikuks muutmist heaks kiita, ning tulemuse saab salvestada toimikusse dokumendina.",
+      "examplesTitle": "Alusta näitest",
+      "title": "Töövoog on salvestatud tehisintellekti- ja ülevaatussammude jada, mida teie meeskond käitab toimiku dokumentidel korduvalt, et saada ühtlane tulemus."
     },
     "enableFlow": "Luba töövoog",
     "enabledDescription": "Keelatud töövoogusid ei saa käivitada ega vallandada.",
     "enabledLabel": "Lubatud",
     "examples": {
       "documentSummary": {
-        "createStepName": "Create the summary",
-        "description": "Summarize the matter's documents for a colleague who has not read them.",
-        "documentTitle": "Document summary",
-        "name": "Document summary for the file",
-        "summaryStepName": "Summarize the documents",
-        "summaryStepPrompt": "Summarize each input document: parties, subject, key dates, obligations, and open points. Write for a colleague who has not read it."
+        "createStepName": "Koosta kokkuvõte",
+        "description": "Tee toimiku dokumentidest kokkuvõte kolleegile, kes pole neid lugenud.",
+        "documentTitle": "Dokumentide kokkuvõte",
+        "name": "Toimiku dokumentide kokkuvõte",
+        "summaryStepName": "Tee dokumentidest kokkuvõte",
+        "summaryStepPrompt": "Tee igast sisenddokumendist kokkuvõte: pooled, ese, olulised kuupäevad, kohustused ja lahtised küsimused. Kirjuta kolleegile, kes pole dokumenti lugenud."
       },
       "dueDiligence": {
-        "createStepName": "Create the report",
-        "description": "Surface change-of-control, assignment, and liability risks across a data room.",
-        "documentTitle": "Red-flag report",
-        "name": "Due diligence red flags",
-        "reviewGateInstructions": "Check the red flags before the report is created.",
-        "reviewGateStepName": "Check the red flags",
-        "reviewStepName": "Find red flags",
-        "reviewStepPrompt": "Read the input documents and produce a red-flag report: change-of-control, assignment restrictions, termination rights, exclusivity, and liability caps. Quote the relevant language."
+        "createStepName": "Koosta aruanne",
+        "description": "Tuvasta andmeruumis kontrolli muutumise, loovutamise ja vastutusega seotud riskid.",
+        "documentTitle": "Ohukohtade aruanne",
+        "name": "Õigusliku auditi ohukohad",
+        "reviewGateInstructions": "Kontrolli ohukohti enne aruande koostamist.",
+        "reviewGateStepName": "Kontrolli ohukohti",
+        "reviewStepName": "Leia ohukohad",
+        "reviewStepPrompt": "Loe sisenddokumente ja koosta ohukohtade aruanne, mis käsitleb kontrolli muutumist, loovutamispiiranguid, lõpetamisõigusi, ainuõigust ja vastutuse ülempiire. Tsiteeri asjakohast sõnastust."
       },
       "ndaIntake": {
-        "createStepName": "Create the memo",
-        "description": "Flag unusual clauses in an NDA before your team relies on it.",
-        "documentTitle": "NDA review memo",
-        "name": "NDA intake review",
-        "reviewGateInstructions": "Check the flagged clauses before the memo is created.",
-        "reviewGateStepName": "Check the flagged clauses",
-        "reviewStepName": "Review the NDA",
-        "reviewStepPrompt": "Review the attached NDA against common market standards: term, confidentiality scope, carve-outs, and governing law. Flag unusual clauses with a severity rating and cite the clause."
+        "createStepName": "Koosta memo",
+        "description": "Märgi konfidentsiaalsuslepingus ebatavalised klauslid enne, kui teie meeskond sellele tugineb.",
+        "documentTitle": "Konfidentsiaalsuslepingu ülevaatuse memo",
+        "name": "Konfidentsiaalsuslepingu esmane ülevaatus",
+        "reviewGateInstructions": "Kontrolli märgitud klausleid enne memo koostamist.",
+        "reviewGateStepName": "Kontrolli märgitud klausleid",
+        "reviewStepName": "Vaata konfidentsiaalsusleping üle",
+        "reviewStepPrompt": "Vaata lisatud konfidentsiaalsusleping üle tavapäraste turustandardite alusel: kehtivusaeg, konfidentsiaalsuskohustuse ulatus, erandid ja kohaldatav õigus. Märgi ebatavalised klauslid koos raskusastmega ja tsiteeri klauslit."
       }
     },
     "fileUpload": {
@@ -1509,9 +1509,9 @@
     "steps": {
       "add": "Lisa samm:",
       "ai": "AI samm",
-      "aiHelp": "Writes text from your instructions and can read the selected input documents.",
+      "aiHelp": "Koostab teie juhiste järgi teksti ja saab lugeda valitud sisenddokumente.",
       "createDocument": "Loo dokument",
-      "createDocumentHelp": "Saves the most recent AI output as a document in the matter where the run started.",
+      "createDocumentHelp": "Salvestab uusima tehisintellekti väljundi dokumendina toimikusse, millest käitamine alustati.",
       "documentTitle": "Dokumendi pealkiri",
       "documentTitlePlaceholder": "nt Kokkuvõtte memo",
       "documentTitleRequired": "Sisesta dokumendi pealkiri.",
@@ -1526,7 +1526,7 @@
       "promptRequired": "Sisesta AI sammu jaoks viip.",
       "required": "Lisa vähemalt üks samm.",
       "reviewGate": "Ülevaatuse värav",
-      "reviewGateHelp": "Pauses the run until a person approves or rejects.",
+      "reviewGateHelp": "Peatab käitamise, kuni inimene selle heaks kiidab või tagasi lükkab.",
       "title": "Sammud"
     },
     "trigger": {
@@ -1878,7 +1878,7 @@
       "builtInSection": "Sisseehitatud oskused",
       "chooseFile": "Vali fail või lohista see siia",
       "coaching": {
-        "publish": "Publish skill"
+        "publish": "Avalda oskus"
       },
       "deleteConfirmDescription": "„{name}” eemaldatakse sellest tööruumist.",
       "deleteFile": "Kustuta fail",
@@ -1919,7 +1919,7 @@
       "generateSkill": "Genereeri AI-ga",
       "generateTitle": "Genereeri oskus AI-ga",
       "generating": "Genereerimine…",
-      "howItRuns": "How it runs",
+      "howItRuns": "Kuidas see käitub",
       "importFailureFetch": "Oskuse allikat ei saanud laadida.",
       "importFailureIntegrity": "Oskuse allikas muutus pärast avastamist. Vaata see uuesti üle.",
       "importFailureLimit": "Oskuste limiit on täis.",
@@ -1941,7 +1941,7 @@
       "resources": "{count, plural, one {# ressurss} other {# ressurssi}}",
       "scopePrivate": "Ainult mina",
       "scopeTeam": "Kõik meeskonnas",
-      "selectFileHint": "Select a file from the list to open it in the editor panel on the right.",
+      "selectFileHint": "Valige loendist fail, et avada see paremal asuval redigeerimispaanil.",
       "selectedFile": "Valitud: {name}",
       "selectionLimit": "Vali korraga kuni {count} oskust.",
       "sourceUpload": "Üles laaditud",
@@ -2001,12 +2001,12 @@
       "addRule": "Reegel",
       "advanced": "Täpsem",
       "approval": {
-        "approve": "Approve",
-        "approveFailed": "Failed to approve playbook",
-        "approvedOn": "Approved {date}",
-        "approvedToast": "Playbook approved",
-        "statusApproved": "Approved",
-        "statusDraft": "Draft"
+        "approve": "Kiida heaks",
+        "approveFailed": "Playbooki heakskiitmine nurjus",
+        "approvedOn": "Heaks kiidetud {date}",
+        "approvedToast": "Playbook heaks kiidetud",
+        "statusApproved": "Heaks kiidetud",
+        "statusDraft": "Mustand"
       },
       "askContentLabel": "Vastuse tüüp",
       "askQuestionLabel": "Küsimus",
@@ -2069,18 +2069,18 @@
       "issuePlaceholder": "nt Vastutuse piiramine",
       "loadFailed": "Playbookide laadimine ebaõnnestus",
       "loading": "Playbookide laadimine…",
-      "manageTypes": "Manage types…",
+      "manageTypes": "Halda liike…",
       "namePlaceholder": "nt NDA ülevaatus",
       "nameRequired": "Lisage nimi.",
       "negotiation": {
-        "addTalkingPoint": "Add talking point",
-        "escalationLabel": "Escalation",
-        "escalationPlaceholder": "When/to whom to escalate (optional)",
-        "rationaleLabel": "Rationale",
-        "rationalePlaceholder": "Why we want this (optional)",
-        "talkingPointPlaceholder": "What to say",
-        "talkingPointsLabel": "Talking points",
-        "title": "Negotiation"
+        "addTalkingPoint": "Lisa jutupunkt",
+        "escalationLabel": "Eskaleerimine",
+        "escalationPlaceholder": "Millal ja kellele eskaleerida (valikuline)",
+        "rationaleLabel": "Põhjendus",
+        "rationalePlaceholder": "Miks me seda soovime (valikuline)",
+        "talkingPointPlaceholder": "Mida öelda",
+        "talkingPointsLabel": "Jutupunktid",
+        "title": "Läbirääkimised"
       },
       "noPositions": "Seisukohti veel pole. Lisage esimene.",
       "optionPlaceholder": "Valiku väärtus",
@@ -2117,17 +2117,17 @@
       },
       "risk": {
         "complianceLabel": "Vastavus",
-        "flaggedCount": "{flagged} of {total} positions flagged",
+        "flaggedCount": "{flagged} positsiooni {total}-st on märgitud",
         "notApplicableExcluded": "({count} ei kohaldu, välja jäetud)",
         "riskLevel": {
-          "critical": "Critical",
-          "high": "High",
-          "low": "Low",
-          "medium": "Medium",
-          "none": "No risk"
+          "critical": "Kriitiline",
+          "high": "Kõrge",
+          "low": "Madal",
+          "medium": "Keskmine",
+          "none": "Risk puudub"
         },
-        "summaryTitle": "Risk summary",
-        "topIssuesTitle": "Top issues"
+        "summaryTitle": "Riskide kokkuvõte",
+        "topIssuesTitle": "Olulisemad küsimused"
       },
       "ruleNumber": "Reegel {index}",
       "rulePlaceholder": "Tavakeelne reegel",
@@ -2140,11 +2140,11 @@
       },
       "severityLabel": "Raskusaste",
       "starters": {
-        "addedToast": "Playbook added",
-        "browseButton": "Browse starter playbooks",
-        "positionCount": "{count, plural, one {# position} other {# positions}}",
-        "subtitle": "Ready-made playbooks you can add and then tailor to your standards.",
-        "title": "Starter playbooks"
+        "addedToast": "Playbook lisatud",
+        "browseButton": "Sirvi valmis playbooke",
+        "positionCount": "{count, plural, one {# positsioon} other {# positsiooni}}",
+        "subtitle": "Valmis playbookid, mille saate lisada ja seejärel oma standarditele kohandada.",
+        "title": "Valmis playbookid"
       },
       "switchToAuto": "Tagasi automaatsele",
       "switchToManual": "Lülitu käsitsile",
@@ -2163,10 +2163,10 @@
         "notApplicable": "Ei kohaldu"
       },
       "versions": {
-        "confirmRestore": "Your current draft will be replaced with this version's content.",
-        "restoreFailed": "Failed to restore version",
-        "restoredToast": "Version restored",
-        "versionHistory": "Version history"
+        "confirmRestore": "Teie praegune mustand asendatakse selle versiooni sisuga.",
+        "restoreFailed": "Versiooni taastamine nurjus",
+        "restoredToast": "Versioon taastatud",
+        "versionHistory": "Versiooniajalugu"
       }
     },
     "sections": {
@@ -2203,29 +2203,29 @@
       "blueprintGallery": {
         "cards": {
           "answerFromSources": {
-            "blurb": "Answer a question grounded in authoritative sources.",
-            "inside": "a source hierarchy · a research prompt",
-            "title": "Answer from sources"
+            "blurb": "Vasta küsimusele usaldusväärsete allikate põhjal.",
+            "inside": "allikate hierarhia · uurimispäring",
+            "title": "Vasta allikate põhjal"
           },
           "checkAgainstRules": {
-            "blurb": "Review a document and flag what fails, with citations.",
-            "inside": "references by jurisdiction · a checklist · a review prompt",
-            "title": "Check against rules"
+            "blurb": "Vaata dokument üle ja märgi koos viidetega, mis nõuetele ei vasta.",
+            "inside": "viited õigusruumide kaupa · kontroll-loend · ülevaatuspäring",
+            "title": "Kontrolli nõuete alusel"
           },
           "intakeToDraft": {
-            "blurb": "Ask for the facts, then draft a document.",
-            "inside": "an interview · model documents · a draft prompt",
-            "title": "Intake to draft"
+            "blurb": "Küsi asjaolusid ja koosta seejärel dokumendi mustand.",
+            "inside": "intervjuu · näidisdokumendid · koostamispäring",
+            "title": "Andmete kogumisest mustandini"
           }
         },
-        "insideLabel": "Inside",
-        "startBlank": "Start from blank",
-        "startBlankHint": "An empty skill, for when you know exactly what you want.",
-        "subtitle": "Pick a starting shape. We set up the folders and walk you through filling them in.",
-        "title": "How should your skill work?"
+        "insideLabel": "Sisaldab",
+        "startBlank": "Alusta tühjalt lehelt",
+        "startBlankHint": "Tühi oskus juhuks, kui teate täpselt, mida vajate.",
+        "subtitle": "Valige lähtekuju. Seadistame kaustad ja juhendame teid nende täitmisel.",
+        "title": "Kuidas peaks teie oskus töötama?"
       },
       "commandConflict": "Selle / käsuga oskus on juba olemas",
-      "commandHelp": "Type it in chat to run this skill.",
+      "commandHelp": "Selle oskuse käivitamiseks sisestage käsk vestlusse.",
       "commandLabel": "Kaldkriipsu käsk (valikuline)",
       "commandPlaceholder": "nt kokku võtta",
       "createTitle": "Uus oskus",
@@ -2257,9 +2257,9 @@
     }
   },
   "markdownEditor": {
-    "rawLabel": "Markdown source",
-    "showFormatted": "Formatted",
-    "showRaw": "Show raw"
+    "rawLabel": "Markdowni lähtekood",
+    "showFormatted": "Vormindatud",
+    "showRaw": "Kuva lähtekood"
   },
   "memory": {
     "addPlaceholder": "Lisage märkus, mille assistent peaks meelde jätma…",
@@ -2902,12 +2902,12 @@
         "updated": "Dokumenditeksti tuvastamise seadistus uuendatud"
       },
       "documentTypes": {
-        "addPlaceholder": "Add a document type (e.g. Employment Agreement)",
-        "deleteFailed": "Couldn't delete document type",
-        "description": "Define the document types your organisation reviews. Playbooks scope to these, and the AI classifier sorts documents into them.",
-        "labelAria": "Document type name",
-        "reorder": "Reorder document type",
-        "title": "Document types"
+        "addPlaceholder": "Lisa dokumendiliik (nt tööleping)",
+        "deleteFailed": "Dokumendiliigi kustutamine nurjus",
+        "description": "Määrake dokumendiliigid, mida teie organisatsioon üle vaatab. Playbookid rakenduvad neile ning tehisintellekti klassifikaator liigitab dokumendid nende alusel.",
+        "labelAria": "Dokumendiliigi nimi",
+        "reorder": "Muuda dokumendiliigi järjestust",
+        "title": "Dokumendiliigid"
       },
       "matterNumbering": "Toimikute nummerdamine",
       "matterNumberingDescription": "Seadistage, kuidas uute toimikute viitenumbreid genereeritakse",
@@ -3177,7 +3177,7 @@
     "conditionAnd": "Ja",
     "conditionCount": "{count, plural, one {# tingimus} other {# tingimust}}",
     "conditionField": "Väli",
-    "conditionFormulaPlaceholder": "Enter a formula…",
+    "conditionFormulaPlaceholder": "Sisesta valem…",
     "conditionMatch": "Vastavus",
     "conditionNamePlaceholder": "Tingimuse nimi (nt NPF)",
     "conditionOpAfter": "pärast",
@@ -3196,8 +3196,8 @@
     "conditionOpOnOrBefore": "kuupäeval või enne",
     "conditionOperator": "Operaator",
     "conditionOr": "Või",
-    "conditionUseFieldInstead": "Use a field instead",
-    "conditionUseFormula": "ƒ Calculated value…",
+    "conditionUseFieldInstead": "Kasuta selle asemel välja",
+    "conditionUseFormula": "ƒ Arvutatud väärtus…",
     "conditionValue": "Väärtus",
     "conditionWhen": "Kui",
     "conditionsTitle": "Tingimused",
@@ -3349,7 +3349,7 @@
       "conditionOrBuildNew": "või loo uus",
       "conditionReuse": "Kasuta olemasolevat tingimust",
       "conditionReusePick": "Vali olemasolev tingimus…",
-      "conditionRuleFallbackLabel": "Calculated condition",
+      "conditionRuleFallbackLabel": "Arvutatud tingimus",
       "conditionSource": "Kuidas otsustatakse",
       "conditionSourceAi": "Otsustab tehisintellekt",
       "conditionSourceAsked": "Küsitud",
@@ -3375,7 +3375,7 @@
       "gettingStartedTitle": "Alustamine",
       "insert": "Lisa",
       "insertAtCaret": "Sisesta kursori kohale",
-      "insertConditionIntoTemplate": "Insert condition",
+      "insertConditionIntoTemplate": "Lisa tingimus",
       "insertFormatDefault": "Vaikimisi",
       "insertIntoTemplate": "Lisa malli",
       "insertItemNumber": "Üksuse number",
@@ -3518,9 +3518,9 @@
     "settings": {
       "description": "Bring your own web-search API keys so chat can search the web and read pages with your own provider account. Without them, chat uses the platform's shared keys when available.",
       "fetchTitle": "Page reader key",
-      "platformFallback": "The platform's shared key is in use. Add your own to use your own provider account and quota.",
+      "platformFallback": "Kasutusel on platvormi jagatud võti. Oma teenusepakkuja konto ja kvoodi kasutamiseks lisage isiklik võti.",
       "searchTitle": "Search provider key",
-      "title": "Web search keys"
+      "title": "Veebiotsingu võtmed"
     }
   },
   "workspaces": {
@@ -3689,8 +3689,8 @@
       "team": {
         "filterAsLead": "Määra vastutaja filtriks",
         "hasLead": "On mõni Lead",
-        "lead": "Lead",
-        "leadActive": "Lead",
+        "lead": "Vastutav",
+        "leadActive": "Vastutav",
         "leadInactive": "Määra vastutaja",
         "noLead": "Vastutajat pole",
         "searchMembers": "Otsi liikmeid…"
@@ -3950,7 +3950,7 @@
     },
     "possibleDuplicates": "Võimalikud duplikaadid",
     "properties": {
-      "addCondition": "Add condition",
+      "addCondition": "Lisa tingimus",
       "addInputProperty": "Lisage vähemalt üks sisestusomadus, kasutades \"@\"",
       "addOption": "Lisa valik",
       "addPromptForBetterResults": "Lisage paremaks tulemuseks päring",
@@ -3990,7 +3990,7 @@
       "editColumn": "Muuda veergu",
       "editConditions": "Muuda tingimusi",
       "editConditionsDescription": "Määrake tingimused, millal seda omadust genereeritakse.",
-      "editConditionsWhen": "Only run extraction when …",
+      "editConditionsWhen": "Käivita eraldamine ainult siis, kui …",
       "enterAValue": "Sisestage väärtus",
       "extractEntityType": "Ekstrakti olemi tüüp",
       "extractEntityTypeDescription": "Looge AI täidetav tabeliveerg.",
@@ -4018,7 +4018,7 @@
       "newColumn": "Uus veerg",
       "newColumnDescription": "Valige, kuidas seda tabeli veergu täidetakse.",
       "newColumnName": "Veeru nimi",
-      "noConditionFields": "No fields available to filter on.",
+      "noConditionFields": "Filtreerimiseks sobivaid välju pole.",
       "noFirstDocument": "Eelvaateks pole veel dokumente.",
       "noPropertiesFound": "Omadusi ei leitud",
       "optionsHelp": "Määra väärtused, mille hulgast AI võib valida.",
@@ -4041,7 +4041,7 @@
       "scopeMatterDescription": "Kasutage kõiki failiveerge ja käivitage toimik.",
       "searchOrAddOptions": "Otsi või lisa valikuid",
       "selectColor": "Valige värv",
-      "selectField": "Select field",
+      "selectField": "Vali väli",
       "selectOperator": "Valige operaator",
       "setPromptPlaceholder": "Määrake päring teabe eraldamiseks",
       "singleSelect": "Ühekordne valik",
@@ -4135,7 +4135,7 @@
       "filterByPlaceholder": "Filtreeri välja järgi…",
       "filtersWithCount": "{count, plural, one {# filter} other {# filtrit}}",
       "groupBy": "Rühmita:",
-      "groupItemCount": "{count, plural, one {# item} other {# items}}",
+      "groupItemCount": "{count, plural, one {# üksus} other {# üksust}}",
       "hideColumn": "Peida veerg",
       "layouts": {
         "calendar": "Kalender",

--- a/apps/web/src/i18n/langs/fr.json
+++ b/apps/web/src/i18n/langs/fr.json
@@ -800,7 +800,7 @@
     "active": "Actif",
     "add": "Ajouter",
     "all": "Tous",
-    "and": "And",
+    "and": "Et",
     "anonymizationLabels": {
       "address": "Adresse",
       "bankAccountNumber": "Numéro de compte bancaire",
@@ -959,12 +959,12 @@
     "next": "Suivant",
     "noResults": "Aucun résultat",
     "noVersions": "Aucun historique de versions",
-    "none": "None",
+    "none": "Aucun",
     "notes": "Notes",
     "open": "Ouvrir",
     "openInNewTab": "Ouvrir dans un nouvel onglet",
     "options": "Options",
-    "or": "Or",
+    "or": "Ou",
     "organization": "Organisation",
     "organizationName": "Nom de l'organisation",
     "pin": "Épingler",
@@ -1020,7 +1020,7 @@
     "type": "Type",
     "typeNameToConfirm": "Saisissez le nom pour confirmer",
     "uncategorized": "Non catégorisé",
-    "undo": "Undo",
+    "undo": "Annuler",
     "unexpectedError": "Une erreur inattendue est survenue. Veuillez contacter le support.",
     "unknownUser": "Utilisateur inconnu",
     "unpin": "Désépingler",
@@ -1399,47 +1399,47 @@
     "descriptionPlaceholder": "Ce que fait ce flux de travail",
     "disableFlow": "Désactiver le flux de travail",
     "editor": {
-      "newFlowIntro": "Define the steps once, then run this workflow from any matter. Runs pause at review checkpoints for approval."
+      "newFlowIntro": "Définissez les étapes une fois, puis exécutez ce flux de travail depuis n’importe quel dossier. Les exécutions s’interrompent aux points de contrôle pour approbation."
     },
     "empty": "Aucun flux de travail pour l’instant",
     "emptyDescription": "Créez un flux de travail pour transformer des documents et un objectif en un livrable finalisé.",
     "emptyState": {
-      "blankAction": "Start blank",
-      "description": "Start it from a matter's Workflows tab, on a schedule, or when files are uploaded. It pauses at checkpoints for a person to approve before anything is final, and the result can be saved as a document in the matter.",
-      "examplesTitle": "Start from an example",
-      "title": "A workflow is a saved sequence of AI and review steps your team reruns on matter documents to produce a consistent deliverable."
+      "blankAction": "Partir de zéro",
+      "description": "Lancez-le depuis l’onglet Flux de travail d’un dossier, selon une planification ou lors du téléversement de fichiers. Il s’interrompt aux points de contrôle afin qu’une personne l’approuve avant sa finalisation ; le résultat peut être enregistré comme document dans le dossier.",
+      "examplesTitle": "Partir d’un exemple",
+      "title": "Un flux de travail est une séquence enregistrée d’étapes d’IA et de révision que votre équipe réexécute sur les documents d’un dossier afin de produire un livrable cohérent."
     },
     "enableFlow": "Activer le flux de travail",
     "enabledDescription": "Les flux de travail désactivés ne peuvent pas être exécutés ni déclenchés.",
     "enabledLabel": "Activé",
     "examples": {
       "documentSummary": {
-        "createStepName": "Create the summary",
-        "description": "Summarize the matter's documents for a colleague who has not read them.",
-        "documentTitle": "Document summary",
-        "name": "Document summary for the file",
-        "summaryStepName": "Summarize the documents",
-        "summaryStepPrompt": "Summarize each input document: parties, subject, key dates, obligations, and open points. Write for a colleague who has not read it."
+        "createStepName": "Créer la synthèse",
+        "description": "Résumez les documents du dossier pour un collègue qui ne les a pas lus.",
+        "documentTitle": "Synthèse des documents",
+        "name": "Synthèse des documents du dossier",
+        "summaryStepName": "Résumer les documents",
+        "summaryStepPrompt": "Résumez chaque document fourni : parties, objet, dates clés, obligations et points en suspens. Rédigez pour un collègue qui ne l’a pas lu."
       },
       "dueDiligence": {
-        "createStepName": "Create the report",
-        "description": "Surface change-of-control, assignment, and liability risks across a data room.",
-        "documentTitle": "Red-flag report",
-        "name": "Due diligence red flags",
-        "reviewGateInstructions": "Check the red flags before the report is created.",
-        "reviewGateStepName": "Check the red flags",
-        "reviewStepName": "Find red flags",
-        "reviewStepPrompt": "Read the input documents and produce a red-flag report: change-of-control, assignment restrictions, termination rights, exclusivity, and liability caps. Quote the relevant language."
+        "createStepName": "Créer le rapport",
+        "description": "Repérez les risques liés au changement de contrôle, à la cession et à la responsabilité dans l’ensemble d’une data room.",
+        "documentTitle": "Rapport sur les principaux risques",
+        "name": "Principaux risques de la due diligence",
+        "reviewGateInstructions": "Vérifiez les principaux risques avant la création du rapport.",
+        "reviewGateStepName": "Vérifier les principaux risques",
+        "reviewStepName": "Repérer les principaux risques",
+        "reviewStepPrompt": "Lisez les documents fournis et produisez un rapport sur les principaux risques : changement de contrôle, restrictions de cession, droits de résiliation, exclusivité et plafonds de responsabilité. Citez les passages pertinents."
       },
       "ndaIntake": {
-        "createStepName": "Create the memo",
-        "description": "Flag unusual clauses in an NDA before your team relies on it.",
-        "documentTitle": "NDA review memo",
-        "name": "NDA intake review",
-        "reviewGateInstructions": "Check the flagged clauses before the memo is created.",
-        "reviewGateStepName": "Check the flagged clauses",
-        "reviewStepName": "Review the NDA",
-        "reviewStepPrompt": "Review the attached NDA against common market standards: term, confidentiality scope, carve-outs, and governing law. Flag unusual clauses with a severity rating and cite the clause."
+        "createStepName": "Créer la note",
+        "description": "Signalez les clauses inhabituelles d’un accord de confidentialité avant que votre équipe ne s’y fie.",
+        "documentTitle": "Note de révision de l’accord de confidentialité",
+        "name": "Révision initiale de l’accord de confidentialité",
+        "reviewGateInstructions": "Vérifiez les clauses signalées avant la création de la note.",
+        "reviewGateStepName": "Vérifier les clauses signalées",
+        "reviewStepName": "Réviser l’accord de confidentialité",
+        "reviewStepPrompt": "Examinez l’accord de confidentialité joint au regard des pratiques courantes du marché : durée, étendue de la confidentialité, exclusions et droit applicable. Signalez les clauses inhabituelles, attribuez-leur un niveau de gravité et citez la clause."
       }
     },
     "fileUpload": {
@@ -1509,24 +1509,24 @@
     "steps": {
       "add": "Ajouter une étape :",
       "ai": "Étape IA",
-      "aiHelp": "Writes text from your instructions and can read the selected input documents.",
+      "aiHelp": "Rédige un texte à partir de vos instructions et peut lire les documents d’entrée sélectionnés.",
       "createDocument": "Créer un document",
-      "createDocumentHelp": "Saves the most recent AI output as a document in the matter where the run started.",
+      "createDocumentHelp": "Enregistre la dernière sortie de l’IA comme document dans le dossier où l’exécution a commencé.",
       "documentTitle": "Titre du document",
       "documentTitlePlaceholder": "p. ex. Note de synthèse",
       "documentTitleRequired": "Saisissez un titre de document.",
       "empty": "Ajoutez au moins une étape.",
       "includeDocuments": "Inclure les documents d’entrée",
-      "instructions": "Instructions",
+      "instructions": "Consignes",
       "instructionsPlaceholder": "Ce que le relecteur doit vérifier",
       "namePlaceholder": "Nom de l’étape",
       "nameRequired": "Saisissez un nom pour chaque étape.",
-      "prompt": "Prompt",
+      "prompt": "Instruction",
       "promptPlaceholder": "Instructions pour l’étape IA",
       "promptRequired": "Saisissez un prompt pour l’étape IA.",
       "required": "Ajoutez au moins une étape.",
       "reviewGate": "Point de contrôle",
-      "reviewGateHelp": "Pauses the run until a person approves or rejects.",
+      "reviewGateHelp": "Interrompt l’exécution jusqu’à ce qu’une personne l’approuve ou la rejette.",
       "title": "Étapes"
     },
     "trigger": {
@@ -1878,7 +1878,7 @@
       "builtInSection": "Compétences intégrées",
       "chooseFile": "Choisissez un fichier ou déposez-le ici",
       "coaching": {
-        "publish": "Publish skill"
+        "publish": "Publier la compétence"
       },
       "deleteConfirmDescription": "« {name} » sera supprimée de cet espace de travail.",
       "deleteFile": "Supprimer le fichier",
@@ -1919,7 +1919,7 @@
       "generateSkill": "Générer avec l'IA",
       "generateTitle": "Générer une compétence avec l'IA",
       "generating": "Génération en cours…",
-      "howItRuns": "How it runs",
+      "howItRuns": "Mode d’exécution",
       "importFailureFetch": "La source de la compétence n’a pas pu être chargée.",
       "importFailureIntegrity": "La source de la compétence a changé après sa détection. Vérifiez-la à nouveau.",
       "importFailureLimit": "La limite de compétences a été atteinte.",
@@ -1941,7 +1941,7 @@
       "resources": "{count, plural, one {# ressource} other {# ressources}}",
       "scopePrivate": "Moi uniquement",
       "scopeTeam": "Toute l’équipe",
-      "selectFileHint": "Select a file from the list to open it in the editor panel on the right.",
+      "selectFileHint": "Sélectionnez un fichier dans la liste pour l’ouvrir dans le volet d’édition à droite.",
       "selectedFile": "Sélectionné : {name}",
       "selectionLimit": "Sélectionnez jusqu’à {count} compétences à la fois.",
       "sourceUpload": "Importé",
@@ -2001,12 +2001,12 @@
       "addRule": "Règle",
       "advanced": "Avancé",
       "approval": {
-        "approve": "Approve",
-        "approveFailed": "Failed to approve playbook",
-        "approvedOn": "Approved {date}",
-        "approvedToast": "Playbook approved",
-        "statusApproved": "Approved",
-        "statusDraft": "Draft"
+        "approve": "Approuver",
+        "approveFailed": "Échec de l’approbation du playbook",
+        "approvedOn": "Approuvé le {date}",
+        "approvedToast": "Playbook approuvé",
+        "statusApproved": "Approuvé",
+        "statusDraft": "Brouillon"
       },
       "askContentLabel": "Type de réponse",
       "askQuestionLabel": "Question",
@@ -2069,18 +2069,18 @@
       "issuePlaceholder": "p. ex. Limitation de responsabilité",
       "loadFailed": "Échec du chargement des playbooks",
       "loading": "Chargement des playbooks…",
-      "manageTypes": "Manage types…",
+      "manageTypes": "Gérer les types…",
       "namePlaceholder": "p. ex. Revue de NDA",
       "nameRequired": "Ajoutez un nom.",
       "negotiation": {
-        "addTalkingPoint": "Add talking point",
-        "escalationLabel": "Escalation",
-        "escalationPlaceholder": "When/to whom to escalate (optional)",
-        "rationaleLabel": "Rationale",
-        "rationalePlaceholder": "Why we want this (optional)",
-        "talkingPointPlaceholder": "What to say",
-        "talkingPointsLabel": "Talking points",
-        "title": "Negotiation"
+        "addTalkingPoint": "Ajouter un argument de négociation",
+        "escalationLabel": "Escalade",
+        "escalationPlaceholder": "Quand et à qui transmettre pour arbitrage (facultatif)",
+        "rationaleLabel": "Justification",
+        "rationalePlaceholder": "Pourquoi nous le souhaitons (facultatif)",
+        "talkingPointPlaceholder": "Ce qu’il faut dire",
+        "talkingPointsLabel": "Arguments de négociation",
+        "title": "Négociation"
       },
       "noPositions": "Aucun critère pour le moment. Ajoutez le premier.",
       "optionPlaceholder": "Valeur de l'option",
@@ -2117,17 +2117,17 @@
       },
       "risk": {
         "complianceLabel": "Conformité",
-        "flaggedCount": "{flagged} of {total} positions flagged",
+        "flaggedCount": "{flagged} positions signalées sur {total}",
         "notApplicableExcluded": "({count} non applicable, exclu)",
         "riskLevel": {
-          "critical": "Critical",
-          "high": "High",
-          "low": "Low",
-          "medium": "Medium",
-          "none": "No risk"
+          "critical": "Critique",
+          "high": "Élevé",
+          "low": "Faible",
+          "medium": "Moyen",
+          "none": "Aucun risque"
         },
-        "summaryTitle": "Risk summary",
-        "topIssuesTitle": "Top issues"
+        "summaryTitle": "Synthèse des risques",
+        "topIssuesTitle": "Principaux problèmes"
       },
       "ruleNumber": "Règle {index}",
       "rulePlaceholder": "Règle en langage clair",
@@ -2140,11 +2140,11 @@
       },
       "severityLabel": "Gravité",
       "starters": {
-        "addedToast": "Playbook added",
-        "browseButton": "Browse starter playbooks",
-        "positionCount": "{count, plural, one {# position} other {# positions}}",
-        "subtitle": "Ready-made playbooks you can add and then tailor to your standards.",
-        "title": "Starter playbooks"
+        "addedToast": "Playbook ajouté",
+        "browseButton": "Parcourir les playbooks de démarrage",
+        "positionCount": "{count, plural, one {# position de négociation} other {# positions de négociation}}",
+        "subtitle": "Des playbooks prêts à l’emploi, à ajouter puis à adapter à vos référentiels.",
+        "title": "Playbooks de démarrage"
       },
       "switchToAuto": "Revenir à l'automatique",
       "switchToManual": "Passer en manuel",
@@ -2163,10 +2163,10 @@
         "notApplicable": "Non applicable"
       },
       "versions": {
-        "confirmRestore": "Your current draft will be replaced with this version's content.",
-        "restoreFailed": "Failed to restore version",
-        "restoredToast": "Version restored",
-        "versionHistory": "Version history"
+        "confirmRestore": "Votre brouillon actuel sera remplacé par le contenu de cette version.",
+        "restoreFailed": "Échec de la restauration de la version",
+        "restoredToast": "Version restaurée",
+        "versionHistory": "Historique des versions"
       }
     },
     "sections": {
@@ -2203,29 +2203,29 @@
       "blueprintGallery": {
         "cards": {
           "answerFromSources": {
-            "blurb": "Answer a question grounded in authoritative sources.",
-            "inside": "a source hierarchy · a research prompt",
-            "title": "Answer from sources"
+            "blurb": "Répondez à une question en vous appuyant sur des sources faisant autorité.",
+            "inside": "une hiérarchie des sources · une instruction de recherche",
+            "title": "Répondre à partir de sources"
           },
           "checkAgainstRules": {
-            "blurb": "Review a document and flag what fails, with citations.",
-            "inside": "references by jurisdiction · a checklist · a review prompt",
-            "title": "Check against rules"
+            "blurb": "Examinez un document et signalez les non-conformités avec des citations.",
+            "inside": "des références par juridiction · une liste de contrôle · une instruction de révision",
+            "title": "Vérifier au regard des règles"
           },
           "intakeToDraft": {
-            "blurb": "Ask for the facts, then draft a document.",
-            "inside": "an interview · model documents · a draft prompt",
-            "title": "Intake to draft"
+            "blurb": "Recueillez les faits, puis rédigez un document.",
+            "inside": "un entretien · des documents modèles · une instruction de rédaction",
+            "title": "De la collecte à la rédaction"
           }
         },
-        "insideLabel": "Inside",
-        "startBlank": "Start from blank",
-        "startBlankHint": "An empty skill, for when you know exactly what you want.",
-        "subtitle": "Pick a starting shape. We set up the folders and walk you through filling them in.",
-        "title": "How should your skill work?"
+        "insideLabel": "Contenu",
+        "startBlank": "Partir de zéro",
+        "startBlankHint": "Une compétence vide, lorsque vous savez exactement ce que vous voulez.",
+        "subtitle": "Choisissez une structure de départ. Nous préparons les dossiers et vous guidons pour les remplir.",
+        "title": "Comment votre compétence doit-elle fonctionner ?"
       },
       "commandConflict": "Une compétence avec cette commande / existe déjà",
-      "commandHelp": "Type it in chat to run this skill.",
+      "commandHelp": "Saisissez-la dans la discussion pour exécuter cette compétence.",
       "commandLabel": "Commande slash (facultatif)",
       "commandPlaceholder": "p. ex. résumer",
       "createTitle": "Nouvelle compétence",
@@ -2257,9 +2257,9 @@
     }
   },
   "markdownEditor": {
-    "rawLabel": "Markdown source",
-    "showFormatted": "Formatted",
-    "showRaw": "Show raw"
+    "rawLabel": "Source Markdown",
+    "showFormatted": "Mis en forme",
+    "showRaw": "Afficher le code source"
   },
   "memory": {
     "addPlaceholder": "Ajoutez une note dont l'assistant se souviendra…",
@@ -2902,12 +2902,12 @@
         "updated": "Paramètre de reconnaissance de texte mis à jour"
       },
       "documentTypes": {
-        "addPlaceholder": "Add a document type (e.g. Employment Agreement)",
-        "deleteFailed": "Couldn't delete document type",
-        "description": "Define the document types your organisation reviews. Playbooks scope to these, and the AI classifier sorts documents into them.",
-        "labelAria": "Document type name",
-        "reorder": "Reorder document type",
-        "title": "Document types"
+        "addPlaceholder": "Ajouter un type de document (p. ex. contrat de travail)",
+        "deleteFailed": "Impossible de supprimer le type de document",
+        "description": "Définissez les types de documents examinés par votre organisation. Les playbooks s’appliquent à ces types et le classificateur d’IA y classe les documents.",
+        "labelAria": "Nom du type de document",
+        "reorder": "Réorganiser le type de document",
+        "title": "Types de documents"
       },
       "matterNumbering": "Numérotation des dossiers",
       "matterNumberingDescription": "Configurez la génération des nouveaux numéros de référence des dossiers",
@@ -3177,7 +3177,7 @@
     "conditionAnd": "Et",
     "conditionCount": "{count, plural, one {# condition} other {# conditions}}",
     "conditionField": "Champ",
-    "conditionFormulaPlaceholder": "Enter a formula…",
+    "conditionFormulaPlaceholder": "Saisissez une formule…",
     "conditionMatch": "Correspondance",
     "conditionNamePlaceholder": "Nom de la condition (par ex. NPF)",
     "conditionOpAfter": "après",
@@ -3196,8 +3196,8 @@
     "conditionOpOnOrBefore": "le ou avant",
     "conditionOperator": "Opérateur",
     "conditionOr": "Ou",
-    "conditionUseFieldInstead": "Use a field instead",
-    "conditionUseFormula": "ƒ Calculated value…",
+    "conditionUseFieldInstead": "Utiliser plutôt un champ",
+    "conditionUseFormula": "ƒ Valeur calculée…",
     "conditionValue": "Valeur",
     "conditionWhen": "Lorsque",
     "conditionsTitle": "Conditions",
@@ -3349,7 +3349,7 @@
       "conditionOrBuildNew": "ou créez-en une nouvelle",
       "conditionReuse": "Réutiliser une condition",
       "conditionReusePick": "Choisir une condition existante…",
-      "conditionRuleFallbackLabel": "Calculated condition",
+      "conditionRuleFallbackLabel": "Condition calculée",
       "conditionSource": "Comment c'est décidé",
       "conditionSourceAi": "L'IA décide",
       "conditionSourceAsked": "Demandée",
@@ -3375,7 +3375,7 @@
       "gettingStartedTitle": "Pour commencer",
       "insert": "Insérer",
       "insertAtCaret": "Insérer au curseur",
-      "insertConditionIntoTemplate": "Insert condition",
+      "insertConditionIntoTemplate": "Insérer la condition",
       "insertFormatDefault": "Par défaut",
       "insertIntoTemplate": "Insérer dans le modèle",
       "insertItemNumber": "Numéro de l'élément",
@@ -3518,9 +3518,9 @@
     "settings": {
       "description": "Bring your own web-search API keys so chat can search the web and read pages with your own provider account. Without them, chat uses the platform's shared keys when available.",
       "fetchTitle": "Page reader key",
-      "platformFallback": "The platform's shared key is in use. Add your own to use your own provider account and quota.",
+      "platformFallback": "La clé partagée de la plateforme est utilisée. Ajoutez la vôtre pour utiliser votre propre compte et quota auprès du fournisseur.",
       "searchTitle": "Search provider key",
-      "title": "Web search keys"
+      "title": "Clés de recherche web"
     }
   },
   "workspaces": {
@@ -3950,7 +3950,7 @@
     },
     "possibleDuplicates": "Doublons possibles",
     "properties": {
-      "addCondition": "Add condition",
+      "addCondition": "Ajouter une condition",
       "addInputProperty": "Ajoutez au moins une propriété d'entrée avec « @ »",
       "addOption": "Ajouter une option",
       "addPromptForBetterResults": "Ajoutez un prompt pour de meilleurs résultats",
@@ -3990,7 +3990,7 @@
       "editColumn": "Modifier la colonne",
       "editConditions": "Modifier les conditions",
       "editConditionsDescription": "Définissez les conditions de génération de cette propriété.",
-      "editConditionsWhen": "Only run extraction when …",
+      "editConditionsWhen": "Exécuter l’extraction uniquement lorsque…",
       "enterAValue": "Saisir une valeur",
       "extractEntityType": "Extraire un type d'entité",
       "extractEntityTypeDescription": "Créez une colonne de tableau extraite par l'IA.",
@@ -4018,7 +4018,7 @@
       "newColumn": "Nouvelle colonne",
       "newColumnDescription": "Choisissez comment cette colonne du tableau doit être remplie.",
       "newColumnName": "Nom de la colonne",
-      "noConditionFields": "No fields available to filter on.",
+      "noConditionFields": "Aucun champ disponible pour le filtrage.",
       "noFirstDocument": "Aucun document à prévisualiser.",
       "noPropertiesFound": "Aucune propriété trouvée",
       "optionsHelp": "Définis les valeurs parmi lesquelles l'IA peut choisir.",
@@ -4041,7 +4041,7 @@
       "scopeMatterDescription": "Utiliser toutes les colonnes de fichiers et lancer le Matter.",
       "searchOrAddOptions": "Rechercher ou ajouter des options",
       "selectColor": "Sélectionner une couleur",
-      "selectField": "Select field",
+      "selectField": "Sélectionner un champ",
       "selectOperator": "Sélectionner un opérateur",
       "setPromptPlaceholder": "Définir un prompt pour extraire l'information",
       "singleSelect": "Sélection unique",
@@ -4135,7 +4135,7 @@
       "filterByPlaceholder": "Filtrer par…",
       "filtersWithCount": "{count, plural, one {# filtre} other {# filtres}}",
       "groupBy": "Regrouper par :",
-      "groupItemCount": "{count, plural, one {# item} other {# items}}",
+      "groupItemCount": "{count, plural, one {# élément} other {# éléments}}",
       "hideColumn": "Masquer la colonne",
       "layouts": {
         "calendar": "Calendrier",

--- a/apps/web/src/i18n/langs/hu.json
+++ b/apps/web/src/i18n/langs/hu.json
@@ -800,7 +800,7 @@
     "active": "Aktív",
     "add": "Hozzáadás",
     "all": "Összes",
-    "and": "And",
+    "and": "És",
     "anonymizationLabels": {
       "address": "Cím",
       "bankAccountNumber": "Bankszámlaszám",
@@ -959,12 +959,12 @@
     "next": "Tovább",
     "noResults": "Nincs találat",
     "noVersions": "Nincs verzióelőzmény",
-    "none": "None",
+    "none": "Nincs",
     "notes": "Megjegyzések",
     "open": "Megnyitás",
     "openInNewTab": "Megnyitás új lapon",
     "options": "Beállítások",
-    "or": "Or",
+    "or": "Vagy",
     "organization": "Szervezet",
     "organizationName": "Szervezet neve",
     "pin": "Rögzítés",
@@ -1020,7 +1020,7 @@
     "type": "Típus",
     "typeNameToConfirm": "A megerősítéshez írja be a nevet",
     "uncategorized": "Kategória nélküli",
-    "undo": "Undo",
+    "undo": "Visszavonás",
     "unexpectedError": "Váratlan hiba történt. Kérjük, lépjen kapcsolatba az ügyfélszolgálattal.",
     "unknownUser": "Ismeretlen felhasználó",
     "unpin": "Rögzítés feloldása",
@@ -1399,47 +1399,47 @@
     "descriptionPlaceholder": "Mit csinál ez a munkafolyamat",
     "disableFlow": "Munkafolyamat letiltása",
     "editor": {
-      "newFlowIntro": "Define the steps once, then run this workflow from any matter. Runs pause at review checkpoints for approval."
+      "newFlowIntro": "Határozza meg egyszer a lépéseket, majd futtassa ezt a munkafolyamatot bármely ügyből. A futások a felülvizsgálati ellenőrzőpontokon jóváhagyásra várva megállnak."
     },
     "empty": "Még nincsenek munkafolyamatok",
     "emptyDescription": "Hozzon létre munkafolyamatot, amely a dokumentumokból és egy célból kész eredményt készít.",
     "emptyState": {
-      "blankAction": "Start blank",
-      "description": "Start it from a matter's Workflows tab, on a schedule, or when files are uploaded. It pauses at checkpoints for a person to approve before anything is final, and the result can be saved as a document in the matter.",
-      "examplesTitle": "Start from an example",
-      "title": "A workflow is a saved sequence of AI and review steps your team reruns on matter documents to produce a consistent deliverable."
+      "blankAction": "Kezdés üresen",
+      "description": "Indítsa el egy ügy Munkafolyamatok lapjáról, ütemezés szerint vagy fájlok feltöltésekor. A munkafolyamat az ellenőrzőpontokon megáll, hogy egy személy jóváhagyhassa, mielőtt bármi véglegessé válik; az eredmény dokumentumként menthető az ügybe.",
+      "examplesTitle": "Kezdés példából",
+      "title": "A munkafolyamat MI- és felülvizsgálati lépések mentett sorozata, amelyet csapata ismételten lefuttat az ügy dokumentumain az egységes eredmény érdekében."
     },
     "enableFlow": "Munkafolyamat engedélyezése",
     "enabledDescription": "A letiltott munkafolyamatokat nem lehet futtatni vagy elindítani.",
     "enabledLabel": "Engedélyezve",
     "examples": {
       "documentSummary": {
-        "createStepName": "Create the summary",
-        "description": "Summarize the matter's documents for a colleague who has not read them.",
-        "documentTitle": "Document summary",
-        "name": "Document summary for the file",
-        "summaryStepName": "Summarize the documents",
-        "summaryStepPrompt": "Summarize each input document: parties, subject, key dates, obligations, and open points. Write for a colleague who has not read it."
+        "createStepName": "Összefoglaló létrehozása",
+        "description": "Foglalja össze az ügy dokumentumait egy olyan kollégának, aki még nem olvasta őket.",
+        "documentTitle": "Dokumentum-összefoglaló",
+        "name": "Az ügy dokumentumainak összefoglalója",
+        "summaryStepName": "Dokumentumok összefoglalása",
+        "summaryStepPrompt": "Foglalja össze az egyes bemeneti dokumentumokat: felek, tárgy, fontos dátumok, kötelezettségek és nyitott kérdések. Olyan kollégának írjon, aki még nem olvasta a dokumentumot."
       },
       "dueDiligence": {
-        "createStepName": "Create the report",
-        "description": "Surface change-of-control, assignment, and liability risks across a data room.",
-        "documentTitle": "Red-flag report",
-        "name": "Due diligence red flags",
-        "reviewGateInstructions": "Check the red flags before the report is created.",
-        "reviewGateStepName": "Check the red flags",
-        "reviewStepName": "Find red flags",
-        "reviewStepPrompt": "Read the input documents and produce a red-flag report: change-of-control, assignment restrictions, termination rights, exclusivity, and liability caps. Quote the relevant language."
+        "createStepName": "Jelentés létrehozása",
+        "description": "Tárja fel az adatszobában az irányításváltozással, az engedményezéssel és a felelősséggel kapcsolatos kockázatokat.",
+        "documentTitle": "Kockázatfeltáró jelentés",
+        "name": "A jogi átvilágítás kockázatos pontjai",
+        "reviewGateInstructions": "A jelentés létrehozása előtt ellenőrizze a kockázatos pontokat.",
+        "reviewGateStepName": "Kockázatos pontok ellenőrzése",
+        "reviewStepName": "Kockázatos pontok feltárása",
+        "reviewStepPrompt": "Olvassa el a bemeneti dokumentumokat, és készítsen kockázatfeltáró jelentést az irányításváltozásról, az engedményezési korlátozásokról, a megszüntetési jogokról, a kizárólagosságról és a felelősségi korlátokról. Idézze a vonatkozó szöveget."
       },
       "ndaIntake": {
-        "createStepName": "Create the memo",
-        "description": "Flag unusual clauses in an NDA before your team relies on it.",
-        "documentTitle": "NDA review memo",
-        "name": "NDA intake review",
-        "reviewGateInstructions": "Check the flagged clauses before the memo is created.",
-        "reviewGateStepName": "Check the flagged clauses",
-        "reviewStepName": "Review the NDA",
-        "reviewStepPrompt": "Review the attached NDA against common market standards: term, confidentiality scope, carve-outs, and governing law. Flag unusual clauses with a severity rating and cite the clause."
+        "createStepName": "Feljegyzés létrehozása",
+        "description": "Jelölje meg a szokatlan kikötéseket egy titoktartási megállapodásban, mielőtt csapata hagyatkozik rá.",
+        "documentTitle": "Titoktartási megállapodás felülvizsgálati feljegyzése",
+        "name": "Titoktartási megállapodás előzetes felülvizsgálata",
+        "reviewGateInstructions": "A feljegyzés létrehozása előtt ellenőrizze a megjelölt kikötéseket.",
+        "reviewGateStepName": "Megjelölt kikötések ellenőrzése",
+        "reviewStepName": "Titoktartási megállapodás felülvizsgálata",
+        "reviewStepPrompt": "Vizsgálja felül a csatolt titoktartási megállapodást a szokásos piaci normák alapján: időtartam, a titoktartás hatálya, kivételek és irányadó jog. Súlyossági besorolással jelölje meg a szokatlan kikötéseket, és idézze a kikötést."
       }
     },
     "fileUpload": {
@@ -1509,9 +1509,9 @@
     "steps": {
       "add": "Lépés hozzáadása:",
       "ai": "AI-lépés",
-      "aiHelp": "Writes text from your instructions and can read the selected input documents.",
+      "aiHelp": "Az utasításai alapján szöveget ír, és el tudja olvasni a kiválasztott bemeneti dokumentumokat.",
       "createDocument": "Dokumentum létrehozása",
-      "createDocumentHelp": "Saves the most recent AI output as a document in the matter where the run started.",
+      "createDocumentHelp": "A legutóbbi MI-kimenetet dokumentumként menti abba az ügybe, amelyből a futás indult.",
       "documentTitle": "Dokumentum címe",
       "documentTitlePlaceholder": "pl. Összefoglaló feljegyzés",
       "documentTitleRequired": "Adja meg a dokumentum címét.",
@@ -1521,12 +1521,12 @@
       "instructionsPlaceholder": "Mit ellenőrizzen az ellenőr",
       "namePlaceholder": "Lépés neve",
       "nameRequired": "Adjon nevet minden lépésnek.",
-      "prompt": "Prompt",
+      "prompt": "Utasítás",
       "promptPlaceholder": "Utasítások az AI-lépéshez",
       "promptRequired": "Adjon meg egy promptot az AI-lépéshez.",
       "required": "Adjon hozzá legalább egy lépést.",
       "reviewGate": "Ellenőrzési pont",
-      "reviewGateHelp": "Pauses the run until a person approves or rejects.",
+      "reviewGateHelp": "Szünetelteti a futást, amíg egy személy jóvá nem hagyja vagy el nem utasítja.",
       "title": "Lépések"
     },
     "trigger": {
@@ -1878,7 +1878,7 @@
       "builtInSection": "Beépített készségek",
       "chooseFile": "Válassz fájlt, vagy húzd ide",
       "coaching": {
-        "publish": "Publish skill"
+        "publish": "Készség közzététele"
       },
       "deleteConfirmDescription": "A(z) „{name}” eltávolításra kerül ebből a munkaterületből.",
       "deleteFile": "Fájl törlése",
@@ -1919,7 +1919,7 @@
       "generateSkill": "Generálás AI-val",
       "generateTitle": "Készség generálása AI-val",
       "generating": "Generálás…",
-      "howItRuns": "How it runs",
+      "howItRuns": "Működés",
       "importFailureFetch": "A készség forrását nem sikerült betölteni.",
       "importFailureIntegrity": "A készség forrása a felderítés után megváltozott. Ellenőrizd újra.",
       "importFailureLimit": "Elérted a készségek maximális számát.",
@@ -1941,7 +1941,7 @@
       "resources": "{count, plural, one {# erőforrás} other {# erőforrás}}",
       "scopePrivate": "Csak én",
       "scopeTeam": "Mindenki a csapatban",
-      "selectFileHint": "Select a file from the list to open it in the editor panel on the right.",
+      "selectFileHint": "Válasszon ki egy fájlt a listából, hogy megnyissa a jobb oldali szerkesztőpanelen.",
       "selectedFile": "Kiválasztva: {name}",
       "selectionLimit": "Egyszerre legfeljebb {count} készséget válassz ki.",
       "sourceUpload": "Feltöltve",
@@ -2001,12 +2001,12 @@
       "addRule": "Szabály",
       "advanced": "Speciális",
       "approval": {
-        "approve": "Approve",
-        "approveFailed": "Failed to approve playbook",
-        "approvedOn": "Approved {date}",
-        "approvedToast": "Playbook approved",
-        "statusApproved": "Approved",
-        "statusDraft": "Draft"
+        "approve": "Jóváhagyás",
+        "approveFailed": "Nem sikerült jóváhagyni a playbookot",
+        "approvedOn": "Jóváhagyva: {date}",
+        "approvedToast": "Playbook jóváhagyva",
+        "statusApproved": "Jóváhagyva",
+        "statusDraft": "Piszkozat"
       },
       "askContentLabel": "Válasz típusa",
       "askQuestionLabel": "A kérdés szövege",
@@ -2069,18 +2069,18 @@
       "issuePlaceholder": "pl. Felelősség korlátozása",
       "loadFailed": "A playbookok betöltése nem sikerült",
       "loading": "Playbookok betöltése…",
-      "manageTypes": "Manage types…",
+      "manageTypes": "Típusok kezelése…",
       "namePlaceholder": "pl. NDA felülvizsgálata",
       "nameRequired": "Adjon meg egy nevet.",
       "negotiation": {
-        "addTalkingPoint": "Add talking point",
-        "escalationLabel": "Escalation",
-        "escalationPlaceholder": "When/to whom to escalate (optional)",
-        "rationaleLabel": "Rationale",
-        "rationalePlaceholder": "Why we want this (optional)",
-        "talkingPointPlaceholder": "What to say",
-        "talkingPointsLabel": "Talking points",
-        "title": "Negotiation"
+        "addTalkingPoint": "Tárgyalási pont hozzáadása",
+        "escalationLabel": "Eszkaláció",
+        "escalationPlaceholder": "Mikor és kihez kell eszkalálni (nem kötelező)",
+        "rationaleLabel": "Indoklás",
+        "rationalePlaceholder": "Miért szeretnénk ezt (nem kötelező)",
+        "talkingPointPlaceholder": "Mit mondjunk",
+        "talkingPointsLabel": "Tárgyalási pontok",
+        "title": "Tárgyalás"
       },
       "noPositions": "Még nincsenek álláspontok. Adja hozzá az elsőt.",
       "optionPlaceholder": "Lehetőség értéke",
@@ -2117,17 +2117,17 @@
       },
       "risk": {
         "complianceLabel": "Megfelelőség",
-        "flaggedCount": "{flagged} of {total} positions flagged",
+        "flaggedCount": "{flagged} megjelölt pozíció a(z) {total} közül",
         "notApplicableExcluded": "({count} nem alkalmazható, kizárva)",
         "riskLevel": {
-          "critical": "Critical",
-          "high": "High",
-          "low": "Low",
-          "medium": "Medium",
-          "none": "No risk"
+          "critical": "Kritikus",
+          "high": "Magas",
+          "low": "Alacsony",
+          "medium": "Közepes",
+          "none": "Nincs kockázat"
         },
-        "summaryTitle": "Risk summary",
-        "topIssuesTitle": "Top issues"
+        "summaryTitle": "Kockázati összefoglaló",
+        "topIssuesTitle": "Legfontosabb kérdések"
       },
       "ruleNumber": "{index}. szabály",
       "rulePlaceholder": "Egyszerű nyelvű szabály",
@@ -2140,11 +2140,11 @@
       },
       "severityLabel": "Súlyosság",
       "starters": {
-        "addedToast": "Playbook added",
-        "browseButton": "Browse starter playbooks",
-        "positionCount": "{count, plural, one {# position} other {# positions}}",
-        "subtitle": "Ready-made playbooks you can add and then tailor to your standards.",
-        "title": "Starter playbooks"
+        "addedToast": "Playbook hozzáadva",
+        "browseButton": "Kezdő playbookok böngészése",
+        "positionCount": "{count, plural, one {# pozíció} other {# pozíció}}",
+        "subtitle": "Előre elkészített playbookok, amelyeket hozzáadhat, majd saját normáihoz igazíthat.",
+        "title": "Kezdő playbookok"
       },
       "switchToAuto": "Vissza az automatikus módra",
       "switchToManual": "Váltás kézi bevitelre",
@@ -2163,10 +2163,10 @@
         "notApplicable": "Nem alkalmazható"
       },
       "versions": {
-        "confirmRestore": "Your current draft will be replaced with this version's content.",
-        "restoreFailed": "Failed to restore version",
-        "restoredToast": "Version restored",
-        "versionHistory": "Version history"
+        "confirmRestore": "A jelenlegi piszkozatot ennek a verziónak a tartalma váltja fel.",
+        "restoreFailed": "Nem sikerült visszaállítani a verziót",
+        "restoredToast": "Verzió visszaállítva",
+        "versionHistory": "Verzióelőzmények"
       }
     },
     "sections": {
@@ -2203,29 +2203,29 @@
       "blueprintGallery": {
         "cards": {
           "answerFromSources": {
-            "blurb": "Answer a question grounded in authoritative sources.",
-            "inside": "a source hierarchy · a research prompt",
-            "title": "Answer from sources"
+            "blurb": "Válaszoljon meg egy kérdést hiteles forrásokra támaszkodva.",
+            "inside": "forráshierarchia · kutatási utasítás",
+            "title": "Válaszadás források alapján"
           },
           "checkAgainstRules": {
-            "blurb": "Review a document and flag what fails, with citations.",
-            "inside": "references by jurisdiction · a checklist · a review prompt",
-            "title": "Check against rules"
+            "blurb": "Vizsgáljon felül egy dokumentumot, és hivatkozásokkal jelölje meg, ami nem felel meg a szabályoknak.",
+            "inside": "jogrendszerenkénti hivatkozások · ellenőrzőlista · felülvizsgálati utasítás",
+            "title": "Ellenőrzés szabályok alapján"
           },
           "intakeToDraft": {
-            "blurb": "Ask for the facts, then draft a document.",
-            "inside": "an interview · model documents · a draft prompt",
-            "title": "Intake to draft"
+            "blurb": "Kérdezze meg a tényeket, majd készítsen dokumentumtervezetet.",
+            "inside": "interjú · iratminták · szövegezési utasítás",
+            "title": "Adatfelvételtől a tervezetig"
           }
         },
-        "insideLabel": "Inside",
-        "startBlank": "Start from blank",
-        "startBlankHint": "An empty skill, for when you know exactly what you want.",
-        "subtitle": "Pick a starting shape. We set up the folders and walk you through filling them in.",
-        "title": "How should your skill work?"
+        "insideLabel": "Tartalma",
+        "startBlank": "Kezdés üresen",
+        "startBlankHint": "Üres készség arra az esetre, ha pontosan tudja, mire van szüksége.",
+        "subtitle": "Válasszon kiindulási szerkezetet. Beállítjuk a mappákat, és végigvezetjük a kitöltésükön.",
+        "title": "Hogyan működjön a készsége?"
       },
       "commandConflict": "Már létezik készség ezzel a / paranccsal",
-      "commandHelp": "Type it in chat to run this skill.",
+      "commandHelp": "A készség futtatásához írja be a parancsot a csevegésbe.",
       "commandLabel": "Perjeles parancs (nem kötelező)",
       "commandPlaceholder": "pl. összefoglalás",
       "createTitle": "Új készség",
@@ -2257,9 +2257,9 @@
     }
   },
   "markdownEditor": {
-    "rawLabel": "Markdown source",
-    "showFormatted": "Formatted",
-    "showRaw": "Show raw"
+    "rawLabel": "Markdown-forrás",
+    "showFormatted": "Formázott",
+    "showRaw": "Forrás megjelenítése"
   },
   "memory": {
     "addPlaceholder": "Adjon hozzá egy megjegyzést, amelyet az asszisztensnek meg kell jegyeznie…",
@@ -2902,12 +2902,12 @@
         "updated": "A dokumentumszöveg-felismerés beállítása frissítve"
       },
       "documentTypes": {
-        "addPlaceholder": "Add a document type (e.g. Employment Agreement)",
-        "deleteFailed": "Couldn't delete document type",
-        "description": "Define the document types your organisation reviews. Playbooks scope to these, and the AI classifier sorts documents into them.",
-        "labelAria": "Document type name",
-        "reorder": "Reorder document type",
-        "title": "Document types"
+        "addPlaceholder": "Dokumentumtípus hozzáadása (pl. munkaszerződés)",
+        "deleteFailed": "Nem sikerült törölni a dokumentumtípust",
+        "description": "Határozza meg a szervezet által felülvizsgált dokumentumtípusokat. A playbookok ezekre vonatkoznak, az MI-osztályozó pedig ezekbe sorolja a dokumentumokat.",
+        "labelAria": "Dokumentumtípus neve",
+        "reorder": "Dokumentumtípus átrendezése",
+        "title": "Dokumentumtípusok"
       },
       "matterNumbering": "Ügyszámozás",
       "matterNumberingDescription": "Beállíthatja, hogyan generálódjanak az új ügyek hivatkozási számai",
@@ -3177,7 +3177,7 @@
     "conditionAnd": "És",
     "conditionCount": "{count, plural, one {# feltétel} other {# feltétel}}",
     "conditionField": "Mező",
-    "conditionFormulaPlaceholder": "Enter a formula…",
+    "conditionFormulaPlaceholder": "Adjon meg egy képletet…",
     "conditionMatch": "Egyezés",
     "conditionNamePlaceholder": "Feltétel neve (pl. NPF)",
     "conditionOpAfter": "után",
@@ -3196,8 +3196,8 @@
     "conditionOpOnOrBefore": "napon vagy előtt",
     "conditionOperator": "Operátor",
     "conditionOr": "Vagy",
-    "conditionUseFieldInstead": "Use a field instead",
-    "conditionUseFormula": "ƒ Calculated value…",
+    "conditionUseFieldInstead": "Használjon inkább mezőt",
+    "conditionUseFormula": "ƒ Számított érték…",
     "conditionValue": "Érték",
     "conditionWhen": "Ha",
     "conditionsTitle": "Feltételek",
@@ -3349,7 +3349,7 @@
       "conditionOrBuildNew": "vagy hozzon létre újat",
       "conditionReuse": "Meglévő feltétel újrafelhasználása",
       "conditionReusePick": "Válasszon meglévő feltételt…",
-      "conditionRuleFallbackLabel": "Calculated condition",
+      "conditionRuleFallbackLabel": "Számított feltétel",
       "conditionSource": "Hogyan dől el",
       "conditionSourceAi": "Az MI dönt",
       "conditionSourceAsked": "Megkérdezett",
@@ -3375,7 +3375,7 @@
       "gettingStartedTitle": "Első lépések",
       "insert": "Beszúrás",
       "insertAtCaret": "Beszúrás a kurzorhoz",
-      "insertConditionIntoTemplate": "Insert condition",
+      "insertConditionIntoTemplate": "Feltétel beszúrása",
       "insertFormatDefault": "Alapértelmezett",
       "insertIntoTemplate": "Beszúrás a sablonba",
       "insertItemNumber": "Tétel sorszáma",
@@ -3518,9 +3518,9 @@
     "settings": {
       "description": "Bring your own web-search API keys so chat can search the web and read pages with your own provider account. Without them, chat uses the platform's shared keys when available.",
       "fetchTitle": "Page reader key",
-      "platformFallback": "The platform's shared key is in use. Add your own to use your own provider account and quota.",
+      "platformFallback": "A platform megosztott kulcsa van használatban. Saját szolgáltatói fiókja és kvótája használatához adja hozzá a saját kulcsát.",
       "searchTitle": "Search provider key",
-      "title": "Web search keys"
+      "title": "Webes keresési kulcsok"
     }
   },
   "workspaces": {
@@ -3950,7 +3950,7 @@
     },
     "possibleDuplicates": "Lehetséges duplikátumok",
     "properties": {
-      "addCondition": "Add condition",
+      "addCondition": "Feltétel hozzáadása",
       "addInputProperty": "Adjon hozzá legalább egy bemeneti tulajdonságot a \"@\" használatával",
       "addOption": "Opció hozzáadása",
       "addPromptForBetterResults": "Adjon hozzá promptot a jobb eredményekért",
@@ -3990,7 +3990,7 @@
       "editColumn": "Oszlop szerkesztése",
       "editConditions": "Feltételek szerkesztése",
       "editConditionsDescription": "Adja meg a feltételeket, amelyek mellett ez a tulajdonság generálódjon.",
-      "editConditionsWhen": "Only run extraction when …",
+      "editConditionsWhen": "Kinyerés futtatása csak akkor, ha …",
       "enterAValue": "Adjon meg egy értéket",
       "extractEntityType": "Entitástípus kinyerése",
       "extractEntityTypeDescription": "Hozzon létre AI által kitöltött táblázatoszlopot.",
@@ -4018,7 +4018,7 @@
       "newColumn": "Új oszlop",
       "newColumnDescription": "Válassza ki, hogyan töltődjön ki ez a táblázatoszlop.",
       "newColumnName": "Oszlop neve",
-      "noConditionFields": "No fields available to filter on.",
+      "noConditionFields": "Nincs szűrésre használható mező.",
       "noFirstDocument": "Még nincsenek dokumentumok az előnézethez.",
       "noPropertiesFound": "Nincsenek tulajdonságok",
       "optionsHelp": "Add meg az értékeket, amelyek közül az AI választhat.",
@@ -4041,7 +4041,7 @@
       "scopeMatterDescription": "Használja az összes fájloszlopot, és futtassa az ügyet.",
       "searchOrAddOptions": "Opciók keresése vagy hozzáadása",
       "selectColor": "Szín kiválasztása",
-      "selectField": "Select field",
+      "selectField": "Mező kiválasztása",
       "selectOperator": "Operátor kiválasztása",
       "setPromptPlaceholder": "Adjon meg promptot az információ kinyeréséhez",
       "singleSelect": "Egyszeres választás",
@@ -4135,7 +4135,7 @@
       "filterByPlaceholder": "Szűrés…",
       "filtersWithCount": "{count, plural, one {# szűrő} other {# szűrő}}",
       "groupBy": "Csoportosítás:",
-      "groupItemCount": "{count, plural, one {# item} other {# items}}",
+      "groupItemCount": "{count, plural, one {# elem} other {# elem}}",
       "hideColumn": "Oszlop elrejtése",
       "layouts": {
         "calendar": "Naptár",

--- a/apps/web/src/i18n/langs/lt.json
+++ b/apps/web/src/i18n/langs/lt.json
@@ -800,7 +800,7 @@
     "active": "Aktyvus",
     "add": "Pridėti",
     "all": "Visi",
-    "and": "And",
+    "and": "Ir",
     "anonymizationLabels": {
       "address": "Adresas",
       "bankAccountNumber": "Banko sąskaitos numeris",
@@ -959,12 +959,12 @@
     "next": "Toliau",
     "noResults": "Rezultatų nėra",
     "noVersions": "Nėra versijų istorijos",
-    "none": "None",
+    "none": "Nėra",
     "notes": "Pastabos",
     "open": "Atidaryti",
     "openInNewTab": "Atidaryti naujame skirtuke",
     "options": "Parinktys",
-    "or": "Or",
+    "or": "Arba",
     "organization": "Organizacija",
     "organizationName": "Organizacijos pavadinimas",
     "pin": "Prisegti",
@@ -1020,7 +1020,7 @@
     "type": "Tipas",
     "typeNameToConfirm": "Įveskite pavadinimą, kad patvirtintumėte",
     "uncategorized": "Nekategorizuota",
-    "undo": "Undo",
+    "undo": "Anuliuoti",
     "unexpectedError": "Įvyko netikėta klaida. Susisiekite su palaikymo tarnyba.",
     "unknownUser": "Nežinomas naudotojas",
     "unpin": "Atsegti",
@@ -1399,47 +1399,47 @@
     "descriptionPlaceholder": "Ką atlieka ši darbo eiga",
     "disableFlow": "Išjungti darbo eigą",
     "editor": {
-      "newFlowIntro": "Define the steps once, then run this workflow from any matter. Runs pause at review checkpoints for approval."
+      "newFlowIntro": "Vieną kartą nustatykite veiksmus, tada vykdykite šią darbo eigą iš bet kurios bylos. Vykdymas sustabdomas peržiūros kontroliniuose taškuose, kad būtų patvirtintas."
     },
     "empty": "Darbo eigų dar nėra",
     "emptyDescription": "Sukurkite darbo eigą, kad iš dokumentų ir tikslo gautumėte baigtą rezultatą.",
     "emptyState": {
-      "blankAction": "Start blank",
-      "description": "Start it from a matter's Workflows tab, on a schedule, or when files are uploaded. It pauses at checkpoints for a person to approve before anything is final, and the result can be saved as a document in the matter.",
-      "examplesTitle": "Start from an example",
-      "title": "A workflow is a saved sequence of AI and review steps your team reruns on matter documents to produce a consistent deliverable."
+      "blankAction": "Pradėti nuo tuščio lapo",
+      "description": "Paleiskite ją bylos skirtuke „Darbo eigos“, pagal tvarkaraštį arba įkėlus failus. Kontroliniuose taškuose darbo eiga sustabdoma, kad žmogus galėtų ją patvirtinti prieš galutinį rezultatą; rezultatą galima išsaugoti byloje kaip dokumentą.",
+      "examplesTitle": "Pradėti nuo pavyzdžio",
+      "title": "Darbo eiga yra išsaugota DI ir peržiūros veiksmų seka, kurią jūsų komanda pakartotinai vykdo su bylos dokumentais, kad gautų nuoseklų rezultatą."
     },
     "enableFlow": "Įjungti darbo eigą",
     "enabledDescription": "Išjungtų darbo eigų negalima paleisti ar suaktyvinti.",
     "enabledLabel": "Įjungta",
     "examples": {
       "documentSummary": {
-        "createStepName": "Create the summary",
-        "description": "Summarize the matter's documents for a colleague who has not read them.",
-        "documentTitle": "Document summary",
-        "name": "Document summary for the file",
-        "summaryStepName": "Summarize the documents",
-        "summaryStepPrompt": "Summarize each input document: parties, subject, key dates, obligations, and open points. Write for a colleague who has not read it."
+        "createStepName": "Sukurti santrauką",
+        "description": "Apibendrinkite bylos dokumentus kolegai, kuris jų dar neskaitė.",
+        "documentTitle": "Dokumentų santrauka",
+        "name": "Bylos dokumentų santrauka",
+        "summaryStepName": "Apibendrinti dokumentus",
+        "summaryStepPrompt": "Apibendrinkite kiekvieną įvesties dokumentą: šalis, dalyką, svarbias datas, įsipareigojimus ir neišspręstus klausimus. Rašykite kolegai, kuris dokumento dar neskaitė."
       },
       "dueDiligence": {
-        "createStepName": "Create the report",
-        "description": "Surface change-of-control, assignment, and liability risks across a data room.",
-        "documentTitle": "Red-flag report",
-        "name": "Due diligence red flags",
-        "reviewGateInstructions": "Check the red flags before the report is created.",
-        "reviewGateStepName": "Check the red flags",
-        "reviewStepName": "Find red flags",
-        "reviewStepPrompt": "Read the input documents and produce a red-flag report: change-of-control, assignment restrictions, termination rights, exclusivity, and liability caps. Quote the relevant language."
+        "createStepName": "Sukurti ataskaitą",
+        "description": "Duomenų kambaryje nustatykite riziką, susijusią su kontrolės pasikeitimu, teisių perleidimu ir atsakomybe.",
+        "documentTitle": "Rizikos signalų ataskaita",
+        "name": "Išsamaus teisinio patikrinimo rizikos signalai",
+        "reviewGateInstructions": "Prieš kurdami ataskaitą patikrinkite rizikos signalus.",
+        "reviewGateStepName": "Patikrinti rizikos signalus",
+        "reviewStepName": "Rasti rizikos signalus",
+        "reviewStepPrompt": "Perskaitykite įvesties dokumentus ir parenkite rizikos signalų ataskaitą apie kontrolės pasikeitimą, teisių perleidimo apribojimus, nutraukimo teises, išimtinumą ir atsakomybės ribas. Pacituokite atitinkamą formuluotę."
       },
       "ndaIntake": {
-        "createStepName": "Create the memo",
-        "description": "Flag unusual clauses in an NDA before your team relies on it.",
-        "documentTitle": "NDA review memo",
-        "name": "NDA intake review",
-        "reviewGateInstructions": "Check the flagged clauses before the memo is created.",
-        "reviewGateStepName": "Check the flagged clauses",
-        "reviewStepName": "Review the NDA",
-        "reviewStepPrompt": "Review the attached NDA against common market standards: term, confidentiality scope, carve-outs, and governing law. Flag unusual clauses with a severity rating and cite the clause."
+        "createStepName": "Sukurti pažymą",
+        "description": "Pažymėkite neįprastas konfidencialumo susitarimo sąlygas prieš jūsų komandai pradedant juo remtis.",
+        "documentTitle": "Konfidencialumo susitarimo peržiūros pažyma",
+        "name": "Pirminė konfidencialumo susitarimo peržiūra",
+        "reviewGateInstructions": "Prieš kurdami pažymą patikrinkite pažymėtas sąlygas.",
+        "reviewGateStepName": "Patikrinti pažymėtas sąlygas",
+        "reviewStepName": "Peržiūrėti konfidencialumo susitarimą",
+        "reviewStepPrompt": "Peržiūrėkite pridėtą konfidencialumo susitarimą pagal įprastus rinkos standartus: trukmę, konfidencialumo apimtį, išimtis ir taikytiną teisę. Pažymėkite neįprastas sąlygas, nurodykite jų reikšmingumo lygį ir pacituokite sąlygą."
       }
     },
     "fileUpload": {
@@ -1509,9 +1509,9 @@
     "steps": {
       "add": "Pridėti žingsnį:",
       "ai": "DI žingsnis",
-      "aiHelp": "Writes text from your instructions and can read the selected input documents.",
+      "aiHelp": "Rašo tekstą pagal jūsų nurodymus ir gali skaityti pasirinktus įvesties dokumentus.",
       "createDocument": "Sukurti dokumentą",
-      "createDocumentHelp": "Saves the most recent AI output as a document in the matter where the run started.",
+      "createDocumentHelp": "Išsaugo naujausią DI išvestį kaip dokumentą byloje, kurioje pradėtas vykdymas.",
       "documentTitle": "Dokumento pavadinimas",
       "documentTitlePlaceholder": "pvz., Santraukos memorandumas",
       "documentTitleRequired": "Įveskite dokumento pavadinimą.",
@@ -1526,7 +1526,7 @@
       "promptRequired": "Įveskite DI žingsnio užklausą.",
       "required": "Pridėkite bent vieną žingsnį.",
       "reviewGate": "Peržiūros kontrolė",
-      "reviewGateHelp": "Pauses the run until a person approves or rejects.",
+      "reviewGateHelp": "Sustabdo vykdymą, kol žmogus jį patvirtina arba atmeta.",
       "title": "Žingsniai"
     },
     "trigger": {
@@ -1878,7 +1878,7 @@
       "builtInSection": "Integruoti įgūdžiai",
       "chooseFile": "Pasirinkite failą arba vilkite jį čia",
       "coaching": {
-        "publish": "Publish skill"
+        "publish": "Paskelbti įgūdį"
       },
       "deleteConfirmDescription": "„{name}“ bus pašalintas iš šios darbo srities.",
       "deleteFile": "Ištrinti failą",
@@ -1919,7 +1919,7 @@
       "generateSkill": "Generuoti su DI",
       "generateTitle": "Generuoti įgūdį su DI",
       "generating": "Generuojama…",
-      "howItRuns": "How it runs",
+      "howItRuns": "Kaip jis veikia",
       "importFailureFetch": "Nepavyko įkelti įgūdžio šaltinio.",
       "importFailureIntegrity": "Įgūdžio šaltinis po aptikimo pasikeitė. Peržiūrėkite jį dar kartą.",
       "importFailureLimit": "Pasiektas įgūdžių limitas.",
@@ -1941,7 +1941,7 @@
       "resources": "{count, plural, one {# išteklius} few {# ištekliai} other {# išteklių}}",
       "scopePrivate": "Tik man",
       "scopeTeam": "Visiems komandoje",
-      "selectFileHint": "Select a file from the list to open it in the editor panel on the right.",
+      "selectFileHint": "Pasirinkite failą iš sąrašo, kad atidarytumėte jį dešinėje esančiame redagavimo skydelyje.",
       "selectedFile": "Pasirinkta: {name}",
       "selectionLimit": "Vienu metu pasirinkite iki {count} įgūdžių.",
       "sourceUpload": "Įkelta",
@@ -2001,12 +2001,12 @@
       "addRule": "Taisyklė",
       "advanced": "Išplėstinis",
       "approval": {
-        "approve": "Approve",
-        "approveFailed": "Failed to approve playbook",
-        "approvedOn": "Approved {date}",
-        "approvedToast": "Playbook approved",
-        "statusApproved": "Approved",
-        "statusDraft": "Draft"
+        "approve": "Patvirtinti",
+        "approveFailed": "Nepavyko patvirtinti peržiūros vadovo",
+        "approvedOn": "Patvirtinta {date}",
+        "approvedToast": "Peržiūros vadovas patvirtintas",
+        "statusApproved": "Patvirtinta",
+        "statusDraft": "Juodraštis"
       },
       "askContentLabel": "Atsakymo tipas",
       "askQuestionLabel": "Klausimas",
@@ -2069,18 +2069,18 @@
       "issuePlaceholder": "pvz., Atsakomybės ribojimas",
       "loadFailed": "Nepavyko įkelti peržiūros vadovų",
       "loading": "Įkeliami peržiūros vadovai…",
-      "manageTypes": "Manage types…",
+      "manageTypes": "Tvarkyti tipus…",
       "namePlaceholder": "pvz., NDA peržiūra",
       "nameRequired": "Pridėkite pavadinimą.",
       "negotiation": {
-        "addTalkingPoint": "Add talking point",
-        "escalationLabel": "Escalation",
-        "escalationPlaceholder": "When/to whom to escalate (optional)",
-        "rationaleLabel": "Rationale",
-        "rationalePlaceholder": "Why we want this (optional)",
-        "talkingPointPlaceholder": "What to say",
-        "talkingPointsLabel": "Talking points",
-        "title": "Negotiation"
+        "addTalkingPoint": "Pridėti derybų punktą",
+        "escalationLabel": "Eskalavimas",
+        "escalationPlaceholder": "Kada ir kam eskaluoti (pasirinktinai)",
+        "rationaleLabel": "Pagrindimas",
+        "rationalePlaceholder": "Kodėl to siekiame (pasirinktinai)",
+        "talkingPointPlaceholder": "Ką sakyti",
+        "talkingPointsLabel": "Derybų punktai",
+        "title": "Derybos"
       },
       "noPositions": "Pozicijų dar nėra. Pridėkite pirmąją.",
       "optionPlaceholder": "Parinkties reikšmė",
@@ -2117,17 +2117,17 @@
       },
       "risk": {
         "complianceLabel": "Atitiktis",
-        "flaggedCount": "{flagged} of {total} positions flagged",
+        "flaggedCount": "Pažymėta {flagged} iš {total} pozicijų",
         "notApplicableExcluded": "({count} netaikoma, neįtraukta)",
         "riskLevel": {
-          "critical": "Critical",
-          "high": "High",
-          "low": "Low",
-          "medium": "Medium",
-          "none": "No risk"
+          "critical": "Kritinė",
+          "high": "Didelė",
+          "low": "Maža",
+          "medium": "Vidutinė",
+          "none": "Rizikos nėra"
         },
-        "summaryTitle": "Risk summary",
-        "topIssuesTitle": "Top issues"
+        "summaryTitle": "Rizikos santrauka",
+        "topIssuesTitle": "Svarbiausi klausimai"
       },
       "ruleNumber": "Taisyklė {index}",
       "rulePlaceholder": "Paprasta kalba suformuluota taisyklė",
@@ -2140,11 +2140,11 @@
       },
       "severityLabel": "Svarba",
       "starters": {
-        "addedToast": "Playbook added",
-        "browseButton": "Browse starter playbooks",
-        "positionCount": "{count, plural, one {# position} other {# positions}}",
-        "subtitle": "Ready-made playbooks you can add and then tailor to your standards.",
-        "title": "Starter playbooks"
+        "addedToast": "Peržiūros vadovas pridėtas",
+        "browseButton": "Naršyti parengtus peržiūros vadovus",
+        "positionCount": "{count, plural, one {# pozicija} few {# pozicijos} many {# pozicijos} other {# pozicijų}}",
+        "subtitle": "Parengti peržiūros vadovai, kuriuos galite pridėti ir pritaikyti savo standartams.",
+        "title": "Parengti peržiūros vadovai"
       },
       "switchToAuto": "Grįžti į automatinį režimą",
       "switchToManual": "Perjungti į rankinį režimą",
@@ -2163,10 +2163,10 @@
         "notApplicable": "Netaikoma"
       },
       "versions": {
-        "confirmRestore": "Your current draft will be replaced with this version's content.",
-        "restoreFailed": "Failed to restore version",
-        "restoredToast": "Version restored",
-        "versionHistory": "Version history"
+        "confirmRestore": "Dabartinį juodraštį pakeis šios versijos turinys.",
+        "restoreFailed": "Nepavyko atkurti versijos",
+        "restoredToast": "Versija atkurta",
+        "versionHistory": "Versijų istorija"
       }
     },
     "sections": {
@@ -2203,29 +2203,29 @@
       "blueprintGallery": {
         "cards": {
           "answerFromSources": {
-            "blurb": "Answer a question grounded in authoritative sources.",
-            "inside": "a source hierarchy · a research prompt",
-            "title": "Answer from sources"
+            "blurb": "Atsakykite į klausimą remdamiesi patikimais šaltiniais.",
+            "inside": "šaltinių hierarchija · tyrimo užklausa",
+            "title": "Atsakyti pagal šaltinius"
           },
           "checkAgainstRules": {
-            "blurb": "Review a document and flag what fails, with citations.",
-            "inside": "references by jurisdiction · a checklist · a review prompt",
-            "title": "Check against rules"
+            "blurb": "Peržiūrėkite dokumentą ir su nuorodomis pažymėkite, kas neatitinka reikalavimų.",
+            "inside": "šaltiniai pagal jurisdikciją · kontrolinis sąrašas · peržiūros užklausa",
+            "title": "Patikrinti pagal taisykles"
           },
           "intakeToDraft": {
-            "blurb": "Ask for the facts, then draft a document.",
-            "inside": "an interview · model documents · a draft prompt",
-            "title": "Intake to draft"
+            "blurb": "Surinkite faktus, tada parenkite dokumento juodraštį.",
+            "inside": "apklausa · dokumentų pavyzdžiai · rengimo užklausa",
+            "title": "Nuo duomenų surinkimo iki juodraščio"
           }
         },
-        "insideLabel": "Inside",
-        "startBlank": "Start from blank",
-        "startBlankHint": "An empty skill, for when you know exactly what you want.",
-        "subtitle": "Pick a starting shape. We set up the folders and walk you through filling them in.",
-        "title": "How should your skill work?"
+        "insideLabel": "Sudėtis",
+        "startBlank": "Pradėti nuo tuščio lapo",
+        "startBlankHint": "Tuščias įgūdis, kai tiksliai žinote, ko reikia.",
+        "subtitle": "Pasirinkite pradinę struktūrą. Parengsime aplankus ir padėsime juos užpildyti.",
+        "title": "Kaip turėtų veikti jūsų įgūdis?"
       },
       "commandConflict": "Įgūdis su šia / komanda jau yra",
-      "commandHelp": "Type it in chat to run this skill.",
+      "commandHelp": "Įveskite komandą pokalbyje, kad paleistumėte šį įgūdį.",
       "commandLabel": "Įstrižo brūkšnio komanda (neprivaloma)",
       "commandPlaceholder": "pvz. apibendrinti",
       "createTitle": "Naujas įgūdis",
@@ -2257,9 +2257,9 @@
     }
   },
   "markdownEditor": {
-    "rawLabel": "Markdown source",
-    "showFormatted": "Formatted",
-    "showRaw": "Show raw"
+    "rawLabel": "Markdown pirminis tekstas",
+    "showFormatted": "Suformatuota",
+    "showRaw": "Rodyti pirminį tekstą"
   },
   "memory": {
     "addPlaceholder": "Pridėkite pastabą, kurią asistentas turėtų įsiminti…",
@@ -2902,12 +2902,12 @@
         "updated": "Dokumentų teksto atpažinimo nustatymas atnaujintas"
       },
       "documentTypes": {
-        "addPlaceholder": "Add a document type (e.g. Employment Agreement)",
-        "deleteFailed": "Couldn't delete document type",
-        "description": "Define the document types your organisation reviews. Playbooks scope to these, and the AI classifier sorts documents into them.",
-        "labelAria": "Document type name",
-        "reorder": "Reorder document type",
-        "title": "Document types"
+        "addPlaceholder": "Pridėti dokumento tipą (pvz., darbo sutartį)",
+        "deleteFailed": "Nepavyko ištrinti dokumento tipo",
+        "description": "Nustatykite dokumentų tipus, kuriuos peržiūri jūsų organizacija. Peržiūros vadovai taikomi šiems tipams, o DI klasifikatorius pagal juos suskirsto dokumentus.",
+        "labelAria": "Dokumento tipo pavadinimas",
+        "reorder": "Keisti dokumento tipo eilės tvarką",
+        "title": "Dokumentų tipai"
       },
       "matterNumbering": "Bylų numeravimas",
       "matterNumberingDescription": "Nustatykite, kaip generuojami naujų bylų numeriai",
@@ -3177,7 +3177,7 @@
     "conditionAnd": "Ir",
     "conditionCount": "{count, plural, one {# sąlyga} few {# sąlygos} other {# sąlygų}}",
     "conditionField": "Laukas",
-    "conditionFormulaPlaceholder": "Enter a formula…",
+    "conditionFormulaPlaceholder": "Įveskite formulę…",
     "conditionMatch": "Atitiktis",
     "conditionNamePlaceholder": "Sąlygos pavadinimas (pvz., NPF)",
     "conditionOpAfter": "po",
@@ -3196,8 +3196,8 @@
     "conditionOpOnOrBefore": "dieną arba prieš",
     "conditionOperator": "Operatorius",
     "conditionOr": "Arba",
-    "conditionUseFieldInstead": "Use a field instead",
-    "conditionUseFormula": "ƒ Calculated value…",
+    "conditionUseFieldInstead": "Vietoje to naudoti lauką",
+    "conditionUseFormula": "ƒ Apskaičiuota reikšmė…",
     "conditionValue": "Reikšmė",
     "conditionWhen": "Kai",
     "conditionsTitle": "Sąlygos",
@@ -3349,7 +3349,7 @@
       "conditionOrBuildNew": "arba sukurkite naują",
       "conditionReuse": "Pakartotinai naudoti sąlygą",
       "conditionReusePick": "Pasirinkite esamą sąlygą…",
-      "conditionRuleFallbackLabel": "Calculated condition",
+      "conditionRuleFallbackLabel": "Apskaičiuota sąlyga",
       "conditionSource": "Kaip nustatoma",
       "conditionSourceAi": "Sprendžia DI",
       "conditionSourceAsked": "Klausiama",
@@ -3375,7 +3375,7 @@
       "gettingStartedTitle": "Pradžia",
       "insert": "Įterpti",
       "insertAtCaret": "Įterpti ties žymekliu",
-      "insertConditionIntoTemplate": "Insert condition",
+      "insertConditionIntoTemplate": "Įterpti sąlygą",
       "insertFormatDefault": "Numatytasis",
       "insertIntoTemplate": "Įterpti į šabloną",
       "insertItemNumber": "Elemento numeris",
@@ -3518,9 +3518,9 @@
     "settings": {
       "description": "Bring your own web-search API keys so chat can search the web and read pages with your own provider account. Without them, chat uses the platform's shared keys when available.",
       "fetchTitle": "Page reader key",
-      "platformFallback": "The platform's shared key is in use. Add your own to use your own provider account and quota.",
+      "platformFallback": "Naudojamas bendras platformos raktas. Pridėkite savo raktą, kad naudotumėte savo teikėjo paskyrą ir kvotą.",
       "searchTitle": "Search provider key",
-      "title": "Web search keys"
+      "title": "Žiniatinklio paieškos raktai"
     }
   },
   "workspaces": {
@@ -3950,7 +3950,7 @@
     },
     "possibleDuplicates": "Galimi dublikatai",
     "properties": {
-      "addCondition": "Add condition",
+      "addCondition": "Pridėti sąlygą",
       "addInputProperty": "Pridėkite bent vieną įvesties savybę naudodami \"@\"",
       "addOption": "Pridėti parinktį",
       "addPromptForBetterResults": "Pridėkite užklausą geresniems rezultatams",
@@ -3990,7 +3990,7 @@
       "editColumn": "Redaguoti stulpelį",
       "editConditions": "Redaguoti sąlygas",
       "editConditionsDescription": "Nustatykite sąlygas, kada ši savybė turi būti generuojama.",
-      "editConditionsWhen": "Only run extraction when …",
+      "editConditionsWhen": "Gavybą vykdyti tik tada, kai …",
       "enterAValue": "Įveskite reikšmę",
       "extractEntityType": "Ištraukti subjekto tipą",
       "extractEntityTypeDescription": "Sukurkite AI pildomą lentelės stulpelį.",
@@ -4018,7 +4018,7 @@
       "newColumn": "Naujas stulpelis",
       "newColumnDescription": "Pasirinkite, kaip šis lentelės stulpelis turi būti pildomas.",
       "newColumnName": "Stulpelio pavadinimas",
-      "noConditionFields": "No fields available to filter on.",
+      "noConditionFields": "Nėra laukų, pagal kuriuos galima filtruoti.",
       "noFirstDocument": "Dar nėra dokumentų peržiūrai.",
       "noPropertiesFound": "Savybių nerasta",
       "optionsHelp": "Apibrėžk reikšmes, iš kurių AI gali rinktis.",
@@ -4041,7 +4041,7 @@
       "scopeMatterDescription": "Naudokite visus failų stulpelius ir paleiskite bylą.",
       "searchOrAddOptions": "Ieškoti arba pridėti parinktis",
       "selectColor": "Pasirinkite spalvą",
-      "selectField": "Select field",
+      "selectField": "Pasirinkti lauką",
       "selectOperator": "Pasirinkite operatorių",
       "setPromptPlaceholder": "Nustatykite užklausą informacijos išgavimui",
       "singleSelect": "Vienas pasirinkimas",
@@ -4135,7 +4135,7 @@
       "filterByPlaceholder": "Filtruoti pagal…",
       "filtersWithCount": "{count, plural, one {# filtras} few {# filtrai} other {# filtrų}}",
       "groupBy": "Grupuoti pagal:",
-      "groupItemCount": "{count, plural, one {# item} other {# items}}",
+      "groupItemCount": "{count, plural, one {# elementas} few {# elementai} many {# elemento} other {# elementų}}",
       "hideColumn": "Slėpti stulpelį",
       "layouts": {
         "calendar": "Kalendorius",

--- a/apps/web/src/i18n/langs/lv.json
+++ b/apps/web/src/i18n/langs/lv.json
@@ -800,7 +800,7 @@
     "active": "Aktīvs",
     "add": "Pievienot",
     "all": "Visi",
-    "and": "And",
+    "and": "Un",
     "anonymizationLabels": {
       "address": "Adrese",
       "bankAccountNumber": "Bankas konta numurs",
@@ -959,12 +959,12 @@
     "next": "Tālāk",
     "noResults": "Nav rezultātu",
     "noVersions": "Nav versiju vēstures",
-    "none": "None",
+    "none": "Nav",
     "notes": "Piezīmes",
     "open": "Atvērt",
     "openInNewTab": "Atvērt jaunā cilnē",
     "options": "Iespējas",
-    "or": "Or",
+    "or": "Vai",
     "organization": "Organizācija",
     "organizationName": "Organizācijas nosaukums",
     "pin": "Piespraust",
@@ -1020,7 +1020,7 @@
     "type": "Tips",
     "typeNameToConfirm": "Ievadiet nosaukumu, lai apstiprinātu",
     "uncategorized": "Nekategorizēts",
-    "undo": "Undo",
+    "undo": "Atsaukt",
     "unexpectedError": "Radās neparedzēta kļūda. Lūdzu, sazinieties ar atbalsta dienestu.",
     "unknownUser": "Nezināms lietotājs",
     "unpin": "Atspraust",
@@ -1399,47 +1399,47 @@
     "descriptionPlaceholder": "Ko šī darbplūsma dara",
     "disableFlow": "Atspējot darbplūsmu",
     "editor": {
-      "newFlowIntro": "Define the steps once, then run this workflow from any matter. Runs pause at review checkpoints for approval."
+      "newFlowIntro": "Definējiet soļus vienreiz un pēc tam palaidiet šo darbplūsmu no jebkuras lietas. Izpilde tiek apturēta pārbaudes kontrolpunktos, lai saņemtu apstiprinājumu."
     },
     "empty": "Vēl nav darbplūsmu",
     "emptyDescription": "Izveidojiet darbplūsmu, lai no dokumentiem un mērķa iegūtu pabeigtu rezultātu.",
     "emptyState": {
-      "blankAction": "Start blank",
-      "description": "Start it from a matter's Workflows tab, on a schedule, or when files are uploaded. It pauses at checkpoints for a person to approve before anything is final, and the result can be saved as a document in the matter.",
-      "examplesTitle": "Start from an example",
-      "title": "A workflow is a saved sequence of AI and review steps your team reruns on matter documents to produce a consistent deliverable."
+      "blankAction": "Sākt ar tukšu darbplūsmu",
+      "description": "Palaidiet to lietas cilnē Darbplūsmas, pēc grafika vai failu augšupielādes laikā. Kontrolpunktos izpilde tiek apturēta, lai persona to apstiprinātu pirms rezultāta pabeigšanas; rezultātu var saglabāt kā dokumentu lietā.",
+      "examplesTitle": "Sākt ar piemēru",
+      "title": "Darbplūsma ir saglabāta MI un pārbaudes soļu secība, ko komanda atkārtoti izpilda lietas dokumentiem, lai vienmēr iegūtu konsekventu rezultātu."
     },
     "enableFlow": "Iespējot darbplūsmu",
     "enabledDescription": "Atspējotas darbplūsmas nevar palaist vai aktivizēt.",
     "enabledLabel": "Iespējota",
     "examples": {
       "documentSummary": {
-        "createStepName": "Create the summary",
-        "description": "Summarize the matter's documents for a colleague who has not read them.",
-        "documentTitle": "Document summary",
-        "name": "Document summary for the file",
-        "summaryStepName": "Summarize the documents",
-        "summaryStepPrompt": "Summarize each input document: parties, subject, key dates, obligations, and open points. Write for a colleague who has not read it."
+        "createStepName": "Izveidot kopsavilkumu",
+        "description": "Apkopojiet lietas dokumentus kolēģim, kurš tos nav lasījis.",
+        "documentTitle": "Dokumentu kopsavilkums",
+        "name": "Lietas dokumentu kopsavilkums",
+        "summaryStepName": "Apkopot dokumentus",
+        "summaryStepPrompt": "Apkopojiet katru ievades dokumentu: puses, priekšmetu, galvenos datumus, saistības un neatrisinātos jautājumus. Rakstiet kolēģim, kurš dokumentu nav lasījis."
       },
       "dueDiligence": {
-        "createStepName": "Create the report",
-        "description": "Surface change-of-control, assignment, and liability risks across a data room.",
-        "documentTitle": "Red-flag report",
-        "name": "Due diligence red flags",
-        "reviewGateInstructions": "Check the red flags before the report is created.",
-        "reviewGateStepName": "Check the red flags",
-        "reviewStepName": "Find red flags",
-        "reviewStepPrompt": "Read the input documents and produce a red-flag report: change-of-control, assignment restrictions, termination rights, exclusivity, and liability caps. Quote the relevant language."
+        "createStepName": "Izveidot ziņojumu",
+        "description": "Atklājiet kontroles maiņas, tiesību nodošanas un atbildības riskus visā datu telpā.",
+        "documentTitle": "Būtisko risku ziņojums",
+        "name": "Padziļinātās izpētes būtiskie riski",
+        "reviewGateInstructions": "Pirms ziņojuma izveides pārbaudiet būtiskos riskus.",
+        "reviewGateStepName": "Pārbaudīt būtiskos riskus",
+        "reviewStepName": "Atrast būtiskos riskus",
+        "reviewStepPrompt": "Izlasiet ievades dokumentus un sagatavojiet būtisko risku ziņojumu: kontroles maiņa, tiesību nodošanas ierobežojumi, izbeigšanas tiesības, ekskluzivitāte un atbildības ierobežojumi. Citējiet attiecīgo formulējumu."
       },
       "ndaIntake": {
-        "createStepName": "Create the memo",
-        "description": "Flag unusual clauses in an NDA before your team relies on it.",
-        "documentTitle": "NDA review memo",
-        "name": "NDA intake review",
-        "reviewGateInstructions": "Check the flagged clauses before the memo is created.",
-        "reviewGateStepName": "Check the flagged clauses",
-        "reviewStepName": "Review the NDA",
-        "reviewStepPrompt": "Review the attached NDA against common market standards: term, confidentiality scope, carve-outs, and governing law. Flag unusual clauses with a severity rating and cite the clause."
+        "createStepName": "Izveidot memorandu",
+        "description": "Atzīmējiet neparastus konfidencialitātes līguma noteikumus, pirms komanda uz to paļaujas.",
+        "documentTitle": "Konfidencialitātes līguma pārbaudes memorands",
+        "name": "Saņemtā konfidencialitātes līguma pārbaude",
+        "reviewGateInstructions": "Pirms memoranda izveides pārbaudiet atzīmētos noteikumus.",
+        "reviewGateStepName": "Pārbaudīt atzīmētos noteikumus",
+        "reviewStepName": "Pārbaudīt konfidencialitātes līgumu",
+        "reviewStepPrompt": "Pārbaudiet pievienoto konfidencialitātes līgumu atbilstoši ierastajiem tirgus standartiem: termiņu, konfidencialitātes tvērumu, izņēmumus un piemērojamos tiesību aktus. Atzīmējiet neparastus noteikumus, norādiet to nopietnību un citējiet attiecīgo noteikumu."
       }
     },
     "fileUpload": {
@@ -1509,9 +1509,9 @@
     "steps": {
       "add": "Pievienot soli:",
       "ai": "AI solis",
-      "aiHelp": "Writes text from your instructions and can read the selected input documents.",
+      "aiHelp": "Raksta tekstu atbilstoši jūsu norādījumiem un var lasīt atlasītos ievades dokumentus.",
       "createDocument": "Izveidot dokumentu",
-      "createDocumentHelp": "Saves the most recent AI output as a document in the matter where the run started.",
+      "createDocumentHelp": "Saglabā jaunāko MI rezultātu kā dokumentu lietā, kurā tika sākta izpilde.",
       "documentTitle": "Dokumenta nosaukums",
       "documentTitlePlaceholder": "piem., Kopsavilkuma memorands",
       "documentTitleRequired": "Ievadiet dokumenta nosaukumu.",
@@ -1526,7 +1526,7 @@
       "promptRequired": "Ievadiet uzvedni AI solim.",
       "required": "Pievienojiet vismaz vienu soli.",
       "reviewGate": "Pārbaudes kontrolpunkts",
-      "reviewGateHelp": "Pauses the run until a person approves or rejects.",
+      "reviewGateHelp": "Aptur izpildi, līdz persona to apstiprina vai noraida.",
       "title": "Soļi"
     },
     "trigger": {
@@ -1878,7 +1878,7 @@
       "builtInSection": "Iebūvētās prasmes",
       "chooseFile": "Izvēlieties failu vai ievelciet to šeit",
       "coaching": {
-        "publish": "Publish skill"
+        "publish": "Publicēt prasmi"
       },
       "deleteConfirmDescription": "„{name}“ tiks noņemta no šīs darbvietas.",
       "deleteFile": "Dzēst failu",
@@ -1919,7 +1919,7 @@
       "generateSkill": "Ģenerēt ar AI",
       "generateTitle": "Ģenerēt prasmi ar AI",
       "generating": "Ģenerē…",
-      "howItRuns": "How it runs",
+      "howItRuns": "Kā tā darbojas",
       "importFailureFetch": "Prasmes avotu neizdevās ielādēt.",
       "importFailureIntegrity": "Prasmes avots pēc atrašanas ir mainījies. Pārskatiet to vēlreiz.",
       "importFailureLimit": "Ir sasniegts prasmju ierobežojums.",
@@ -1941,7 +1941,7 @@
       "resources": "{count, plural, zero {# resursu} one {# resurss} other {# resursi}}",
       "scopePrivate": "Tikai es",
       "scopeTeam": "Visi komandā",
-      "selectFileHint": "Select a file from the list to open it in the editor panel on the right.",
+      "selectFileHint": "Atlasiet sarakstā failu, lai to atvērtu redaktora panelī pa labi.",
       "selectedFile": "Atlasīts: {name}",
       "selectionLimit": "Vienlaikus atlasiet ne vairāk kā {count} prasmes.",
       "sourceUpload": "Augšupielādēts",
@@ -2001,12 +2001,12 @@
       "addRule": "Noteikums",
       "advanced": "Papildu",
       "approval": {
-        "approve": "Approve",
-        "approveFailed": "Failed to approve playbook",
-        "approvedOn": "Approved {date}",
-        "approvedToast": "Playbook approved",
-        "statusApproved": "Approved",
-        "statusDraft": "Draft"
+        "approve": "Apstiprināt",
+        "approveFailed": "Neizdevās apstiprināt pārbaudes ceļvedi",
+        "approvedOn": "Apstiprināts {date}",
+        "approvedToast": "Pārbaudes ceļvedis apstiprināts",
+        "statusApproved": "Apstiprināts",
+        "statusDraft": "Melnraksts"
       },
       "askContentLabel": "Atbildes tips",
       "askQuestionLabel": "Jautājums",
@@ -2069,18 +2069,18 @@
       "issuePlaceholder": "piem., Atbildības ierobežojums",
       "loadFailed": "Neizdevās ielādēt pārbaudes ceļvežus",
       "loading": "Ielādē pārbaudes ceļvežus…",
-      "manageTypes": "Manage types…",
+      "manageTypes": "Pārvaldīt tipus…",
       "namePlaceholder": "piem., NDA pārbaude",
       "nameRequired": "Pievienojiet nosaukumu.",
       "negotiation": {
-        "addTalkingPoint": "Add talking point",
-        "escalationLabel": "Escalation",
-        "escalationPlaceholder": "When/to whom to escalate (optional)",
-        "rationaleLabel": "Rationale",
-        "rationalePlaceholder": "Why we want this (optional)",
-        "talkingPointPlaceholder": "What to say",
-        "talkingPointsLabel": "Talking points",
-        "title": "Negotiation"
+        "addTalkingPoint": "Pievienot sarunu argumentu",
+        "escalationLabel": "Eskalācija",
+        "escalationPlaceholder": "Kad un kam nodot izskatīšanai (neobligāti)",
+        "rationaleLabel": "Pamatojums",
+        "rationalePlaceholder": "Kāpēc mēs to vēlamies (neobligāti)",
+        "talkingPointPlaceholder": "Ko teikt",
+        "talkingPointsLabel": "Sarunu argumenti",
+        "title": "Sarunas"
       },
       "noPositions": "Vēl nav pozīciju. Pievienojiet pirmo.",
       "optionPlaceholder": "Iespējas vērtība",
@@ -2117,17 +2117,17 @@
       },
       "risk": {
         "complianceLabel": "Atbilstība",
-        "flaggedCount": "{flagged} of {total} positions flagged",
+        "flaggedCount": "Atzīmētas {flagged} no {total} pozīcijām",
         "notApplicableExcluded": "({count} nav piemērojams, izslēgts)",
         "riskLevel": {
-          "critical": "Critical",
-          "high": "High",
-          "low": "Low",
-          "medium": "Medium",
-          "none": "No risk"
+          "critical": "Kritisks",
+          "high": "Augsts",
+          "low": "Zems",
+          "medium": "Vidējs",
+          "none": "Nav riska"
         },
-        "summaryTitle": "Risk summary",
-        "topIssuesTitle": "Top issues"
+        "summaryTitle": "Risku kopsavilkums",
+        "topIssuesTitle": "Būtiskākās problēmas"
       },
       "ruleNumber": "Noteikums {index}",
       "rulePlaceholder": "Vienkāršā valodā formulēts noteikums",
@@ -2140,11 +2140,11 @@
       },
       "severityLabel": "Nopietnība",
       "starters": {
-        "addedToast": "Playbook added",
-        "browseButton": "Browse starter playbooks",
-        "positionCount": "{count, plural, one {# position} other {# positions}}",
-        "subtitle": "Ready-made playbooks you can add and then tailor to your standards.",
-        "title": "Starter playbooks"
+        "addedToast": "Pārbaudes ceļvedis pievienots",
+        "browseButton": "Pārlūkot sākuma pārbaudes ceļvežus",
+        "positionCount": "{count, plural, zero {# pozīciju} one {# pozīcija} other {# pozīcijas}}",
+        "subtitle": "Gatavi pārbaudes ceļveži, ko varat pievienot un pēc tam pielāgot saviem standartiem.",
+        "title": "Sākuma pārbaudes ceļveži"
       },
       "switchToAuto": "Atpakaļ uz automātisko režīmu",
       "switchToManual": "Pārslēgt uz manuālo režīmu",
@@ -2163,10 +2163,10 @@
         "notApplicable": "Nav piemērojams"
       },
       "versions": {
-        "confirmRestore": "Your current draft will be replaced with this version's content.",
-        "restoreFailed": "Failed to restore version",
-        "restoredToast": "Version restored",
-        "versionHistory": "Version history"
+        "confirmRestore": "Pašreizējais melnraksts tiks aizstāts ar šīs versijas saturu.",
+        "restoreFailed": "Neizdevās atjaunot versiju",
+        "restoredToast": "Versija atjaunota",
+        "versionHistory": "Versiju vēsture"
       }
     },
     "sections": {
@@ -2203,29 +2203,29 @@
       "blueprintGallery": {
         "cards": {
           "answerFromSources": {
-            "blurb": "Answer a question grounded in authoritative sources.",
-            "inside": "a source hierarchy · a research prompt",
-            "title": "Answer from sources"
+            "blurb": "Atbildiet uz jautājumu, balstoties uz autoritatīviem avotiem.",
+            "inside": "avotu hierarhija · izpētes uzvedne",
+            "title": "Atbildēt, izmantojot avotus"
           },
           "checkAgainstRules": {
-            "blurb": "Review a document and flag what fails, with citations.",
-            "inside": "references by jurisdiction · a checklist · a review prompt",
-            "title": "Check against rules"
+            "blurb": "Pārbaudiet dokumentu un ar atsaucēm atzīmējiet neatbilstības.",
+            "inside": "atsauces pēc jurisdikcijas · kontrolsaraksts · pārbaudes uzvedne",
+            "title": "Pārbaudīt atbilstību noteikumiem"
           },
           "intakeToDraft": {
-            "blurb": "Ask for the facts, then draft a document.",
-            "inside": "an interview · model documents · a draft prompt",
-            "title": "Intake to draft"
+            "blurb": "Apkopojiet faktus un pēc tam sagatavojiet dokumenta projektu.",
+            "inside": "intervija · paraugdokumenti · projekta uzvedne",
+            "title": "No faktu apkopošanas līdz projektam"
           }
         },
-        "insideLabel": "Inside",
-        "startBlank": "Start from blank",
-        "startBlankHint": "An empty skill, for when you know exactly what you want.",
-        "subtitle": "Pick a starting shape. We set up the folders and walk you through filling them in.",
-        "title": "How should your skill work?"
+        "insideLabel": "Saturs",
+        "startBlank": "Sākt no jauna",
+        "startBlankHint": "Tukša prasme gadījumiem, kad precīzi zināt, ko vēlaties.",
+        "subtitle": "Izvēlieties sākuma struktūru. Mēs izveidosim mapes un soli pa solim palīdzēsim tās aizpildīt.",
+        "title": "Kā jādarbojas jūsu prasmei?"
       },
       "commandConflict": "Prasme ar šo / komandu jau pastāv",
-      "commandHelp": "Type it in chat to run this skill.",
+      "commandHelp": "Ierakstiet to tērzēšanā, lai palaistu šo prasmi.",
       "commandLabel": "Slīpsvītras komanda (nav obligāta)",
       "commandPlaceholder": "piem. apkopot",
       "createTitle": "Jauna prasme",
@@ -2257,9 +2257,9 @@
     }
   },
   "markdownEditor": {
-    "rawLabel": "Markdown source",
-    "showFormatted": "Formatted",
-    "showRaw": "Show raw"
+    "rawLabel": "Markdown avotteksts",
+    "showFormatted": "Formatēts",
+    "showRaw": "Rādīt avottekstu"
   },
   "memory": {
     "addPlaceholder": "Pievienojiet piezīmi, kas asistentam jāatceras…",
@@ -2902,12 +2902,12 @@
         "updated": "Dokumentu teksta atpazīšanas iestatījums atjaunināts"
       },
       "documentTypes": {
-        "addPlaceholder": "Add a document type (e.g. Employment Agreement)",
-        "deleteFailed": "Couldn't delete document type",
-        "description": "Define the document types your organisation reviews. Playbooks scope to these, and the AI classifier sorts documents into them.",
-        "labelAria": "Document type name",
-        "reorder": "Reorder document type",
-        "title": "Document types"
+        "addPlaceholder": "Pievienojiet dokumenta tipu (piem., darba līgums)",
+        "deleteFailed": "Neizdevās izdzēst dokumenta tipu",
+        "description": "Definējiet dokumentu tipus, ko jūsu organizācija pārbauda. Pārbaudes ceļveži attiecas uz šiem tipiem, un MI klasifikators sašķiro dokumentus atbilstoši tiem.",
+        "labelAria": "Dokumenta tipa nosaukums",
+        "reorder": "Pārkārtot dokumenta tipu",
+        "title": "Dokumentu tipi"
       },
       "matterNumbering": "Lietu numerācija",
       "matterNumberingDescription": "Konfigurējiet, kā tiek ģenerēti jauno lietu atsauces numuri",
@@ -3177,7 +3177,7 @@
     "conditionAnd": "Un",
     "conditionCount": "{count, plural, zero {# nosacījumu} one {# nosacījums} other {# nosacījumi}}",
     "conditionField": "Lauks",
-    "conditionFormulaPlaceholder": "Enter a formula…",
+    "conditionFormulaPlaceholder": "Ievadiet formulu…",
     "conditionMatch": "Atbilstība",
     "conditionNamePlaceholder": "Nosacījuma nosaukums (piem., NPF)",
     "conditionOpAfter": "pēc",
@@ -3196,8 +3196,8 @@
     "conditionOpOnOrBefore": "datumā vai pirms",
     "conditionOperator": "Operators",
     "conditionOr": "Vai",
-    "conditionUseFieldInstead": "Use a field instead",
-    "conditionUseFormula": "ƒ Calculated value…",
+    "conditionUseFieldInstead": "Tā vietā izmantot lauku",
+    "conditionUseFormula": "ƒ Aprēķināta vērtība…",
     "conditionValue": "Vērtība",
     "conditionWhen": "Kad",
     "conditionsTitle": "Nosacījumi",
@@ -3349,7 +3349,7 @@
       "conditionOrBuildNew": "vai izveidojiet jaunu",
       "conditionReuse": "Atkārtoti izmantot nosacījumu",
       "conditionReusePick": "Izvēlieties esošu nosacījumu…",
-      "conditionRuleFallbackLabel": "Calculated condition",
+      "conditionRuleFallbackLabel": "Aprēķināts nosacījums",
       "conditionSource": "Kā tas tiek noteikts",
       "conditionSourceAi": "Izlemj MI",
       "conditionSourceAsked": "Jautāts",
@@ -3375,7 +3375,7 @@
       "gettingStartedTitle": "Darba sākšana",
       "insert": "Ievietot",
       "insertAtCaret": "Ievietot pie kursora",
-      "insertConditionIntoTemplate": "Insert condition",
+      "insertConditionIntoTemplate": "Ievietot nosacījumu",
       "insertFormatDefault": "Noklusējuma",
       "insertIntoTemplate": "Ievietot veidnē",
       "insertItemNumber": "Vienuma numurs",
@@ -3518,9 +3518,9 @@
     "settings": {
       "description": "Bring your own web-search API keys so chat can search the web and read pages with your own provider account. Without them, chat uses the platform's shared keys when available.",
       "fetchTitle": "Page reader key",
-      "platformFallback": "The platform's shared key is in use. Add your own to use your own provider account and quota.",
+      "platformFallback": "Tiek izmantota platformas koplietotā atslēga. Pievienojiet savu atslēgu, lai izmantotu savu pakalpojumu sniedzēja kontu un kvotu.",
       "searchTitle": "Search provider key",
-      "title": "Web search keys"
+      "title": "Meklēšanas tīmeklī atslēgas"
     }
   },
   "workspaces": {
@@ -3689,8 +3689,8 @@
       "team": {
         "filterAsLead": "Iestatīt kā vadītāja filtru",
         "hasLead": "Ir vadītājs",
-        "lead": "Lead",
-        "leadActive": "Lead",
+        "lead": "Atbildīgais",
+        "leadActive": "Atbildīgais",
         "leadInactive": "Iestatīt vadītāju",
         "noLead": "Nav atbildīgā",
         "searchMembers": "Meklēt dalībniekus…"
@@ -3950,7 +3950,7 @@
     },
     "possibleDuplicates": "Iespējamie dublikāti",
     "properties": {
-      "addCondition": "Add condition",
+      "addCondition": "Pievienot nosacījumu",
       "addInputProperty": "Pievienojiet vismaz vienu ievades rekvizītu, izmantojot \"@\"",
       "addOption": "Pievienot opciju",
       "addPromptForBetterResults": "Pievienojiet uzvedni labākiem rezultātiem",
@@ -3990,7 +3990,7 @@
       "editColumn": "Rediģēt kolonnu",
       "editConditions": "Rediģēt nosacījumus",
       "editConditionsDescription": "Iestatiet nosacījumus, kad šis rekvizīts tiks ģenerēts.",
-      "editConditionsWhen": "Only run extraction when …",
+      "editConditionsWhen": "Veikt izvilkšanu tikai tad, ja…",
       "enterAValue": "Ievadiet vērtību",
       "extractEntityType": "Izvilkt entītijas tipu",
       "extractEntityTypeDescription": "Izveidojiet AI aizpildītu tabulas kolonnu.",
@@ -4018,7 +4018,7 @@
       "newColumn": "Jauna kolonna",
       "newColumnDescription": "Izvēlieties, kā šī tabulas kolonna jāaizpilda.",
       "newColumnName": "Kolonnas nosaukums",
-      "noConditionFields": "No fields available to filter on.",
+      "noConditionFields": "Nav lauku, pēc kuriem filtrēt.",
       "noFirstDocument": "Vēl nav dokumentu priekšskatījumam.",
       "noPropertiesFound": "Rekvizīti nav atrasti",
       "optionsHelp": "Definē vērtības, no kurām AI var izvēlēties.",
@@ -4041,7 +4041,7 @@
       "scopeMatterDescription": "Izmantojiet visas failu kolonnas un palaidiet lietu.",
       "searchOrAddOptions": "Meklēt vai pievienot opcijas",
       "selectColor": "Izvēlieties krāsu",
-      "selectField": "Select field",
+      "selectField": "Atlasiet lauku",
       "selectOperator": "Izvēlieties operatoru",
       "setPromptPlaceholder": "Iestatiet uzvedni informācijas ieguvei",
       "singleSelect": "Vienas izvēles",
@@ -4135,7 +4135,7 @@
       "filterByPlaceholder": "Filtrēt pēc…",
       "filtersWithCount": "{count, plural, zero {nav filtru} one {# filtrs} other {# filtri}}",
       "groupBy": "Grupēt pēc:",
-      "groupItemCount": "{count, plural, one {# item} other {# items}}",
+      "groupItemCount": "{count, plural, zero {# vienumu} one {# vienums} other {# vienumi}}",
       "hideColumn": "Paslēpt kolonnu",
       "layouts": {
         "calendar": "Kalendārs",

--- a/apps/web/src/i18n/langs/pl.json
+++ b/apps/web/src/i18n/langs/pl.json
@@ -800,7 +800,7 @@
     "active": "Aktywny",
     "add": "Dodaj",
     "all": "Wszystkie",
-    "and": "And",
+    "and": "I",
     "anonymizationLabels": {
       "address": "Adres",
       "bankAccountNumber": "Numer rachunku bankowego",
@@ -959,12 +959,12 @@
     "next": "Dalej",
     "noResults": "Brak wyników",
     "noVersions": "Brak historii wersji",
-    "none": "None",
+    "none": "Brak",
     "notes": "Notatki",
     "open": "Otwórz",
     "openInNewTab": "Otwórz w nowej karcie",
     "options": "Opcje",
-    "or": "Or",
+    "or": "Lub",
     "organization": "Organizacja",
     "organizationName": "Nazwa organizacji",
     "pin": "Przypnij",
@@ -1020,7 +1020,7 @@
     "type": "Typ",
     "typeNameToConfirm": "Wpisz nazwę, aby potwierdzić",
     "uncategorized": "Bez kategorii",
-    "undo": "Undo",
+    "undo": "Cofnij",
     "unexpectedError": "Wystąpił nieoczekiwany błąd. Skontaktuj się z pomocą techniczną.",
     "unknownUser": "Nieznany użytkownik",
     "unpin": "Odepnij",
@@ -1399,47 +1399,47 @@
     "descriptionPlaceholder": "Co robi ten przepływ pracy",
     "disableFlow": "Wyłącz przepływ pracy",
     "editor": {
-      "newFlowIntro": "Define the steps once, then run this workflow from any matter. Runs pause at review checkpoints for approval."
+      "newFlowIntro": "Zdefiniuj kroki raz, a następnie uruchamiaj ten przepływ pracy z dowolnej sprawy. Wykonanie zatrzymuje się w punktach przeglądu do czasu zatwierdzenia."
     },
     "empty": "Brak przepływów pracy",
     "emptyDescription": "Utwórz przepływ pracy, aby z dokumentów i celu utworzyć gotowy rezultat.",
     "emptyState": {
-      "blankAction": "Start blank",
-      "description": "Start it from a matter's Workflows tab, on a schedule, or when files are uploaded. It pauses at checkpoints for a person to approve before anything is final, and the result can be saved as a document in the matter.",
-      "examplesTitle": "Start from an example",
-      "title": "A workflow is a saved sequence of AI and review steps your team reruns on matter documents to produce a consistent deliverable."
+      "blankAction": "Zacznij od pustego przepływu",
+      "description": "Uruchom go z karty Przepływy pracy w sprawie, zgodnie z harmonogramem lub po przesłaniu plików. W punktach przeglądu przepływ zatrzymuje się, aby ktoś zatwierdził wynik przed jego ukończeniem. Wynik można zapisać jako dokument w sprawie.",
+      "examplesTitle": "Zacznij od przykładu",
+      "title": "Przepływ pracy to zapisany ciąg kroków AI i przeglądu, który zespół może ponownie uruchamiać na dokumentach sprawy, aby za każdym razem uzyskać spójny rezultat."
     },
     "enableFlow": "Włącz przepływ pracy",
     "enabledDescription": "Wyłączonych przepływów pracy nie można uruchomić ani wyzwolić.",
     "enabledLabel": "Włączony",
     "examples": {
       "documentSummary": {
-        "createStepName": "Create the summary",
-        "description": "Summarize the matter's documents for a colleague who has not read them.",
-        "documentTitle": "Document summary",
-        "name": "Document summary for the file",
-        "summaryStepName": "Summarize the documents",
-        "summaryStepPrompt": "Summarize each input document: parties, subject, key dates, obligations, and open points. Write for a colleague who has not read it."
+        "createStepName": "Utwórz podsumowanie",
+        "description": "Podsumuj dokumenty sprawy dla osoby, która jeszcze ich nie czytała.",
+        "documentTitle": "Podsumowanie dokumentów",
+        "name": "Podsumowanie dokumentów sprawy",
+        "summaryStepName": "Podsumuj dokumenty",
+        "summaryStepPrompt": "Podsumuj każdy dokument wejściowy: strony, przedmiot, kluczowe daty, zobowiązania i nierozstrzygnięte kwestie. Pisz z myślą o osobie, która go nie czytała."
       },
       "dueDiligence": {
-        "createStepName": "Create the report",
-        "description": "Surface change-of-control, assignment, and liability risks across a data room.",
-        "documentTitle": "Red-flag report",
-        "name": "Due diligence red flags",
-        "reviewGateInstructions": "Check the red flags before the report is created.",
-        "reviewGateStepName": "Check the red flags",
-        "reviewStepName": "Find red flags",
-        "reviewStepPrompt": "Read the input documents and produce a red-flag report: change-of-control, assignment restrictions, termination rights, exclusivity, and liability caps. Quote the relevant language."
+        "createStepName": "Utwórz raport",
+        "description": "Wskaż w dokumentach z data roomu ryzyka związane ze zmianą kontroli, cesją i odpowiedzialnością.",
+        "documentTitle": "Raport red flag",
+        "name": "Kluczowe ryzyka due diligence",
+        "reviewGateInstructions": "Sprawdź kluczowe ryzyka przed utworzeniem raportu.",
+        "reviewGateStepName": "Sprawdź kluczowe ryzyka",
+        "reviewStepName": "Znajdź kluczowe ryzyka",
+        "reviewStepPrompt": "Przeczytaj dokumenty wejściowe i przygotuj raport red flag obejmujący zmianę kontroli, ograniczenia cesji, prawa do wypowiedzenia, wyłączność i limity odpowiedzialności. Przytocz odpowiednie postanowienia."
       },
       "ndaIntake": {
-        "createStepName": "Create the memo",
-        "description": "Flag unusual clauses in an NDA before your team relies on it.",
-        "documentTitle": "NDA review memo",
-        "name": "NDA intake review",
-        "reviewGateInstructions": "Check the flagged clauses before the memo is created.",
-        "reviewGateStepName": "Check the flagged clauses",
-        "reviewStepName": "Review the NDA",
-        "reviewStepPrompt": "Review the attached NDA against common market standards: term, confidentiality scope, carve-outs, and governing law. Flag unusual clauses with a severity rating and cite the clause."
+        "createStepName": "Utwórz notatkę",
+        "description": "Wskaż nietypowe postanowienia umowy o zachowaniu poufności, zanim zespół zacznie na niej polegać.",
+        "documentTitle": "Notatka z przeglądu umowy o zachowaniu poufności",
+        "name": "Wstępny przegląd umowy o zachowaniu poufności",
+        "reviewGateInstructions": "Sprawdź oznaczone postanowienia przed utworzeniem notatki.",
+        "reviewGateStepName": "Sprawdź oznaczone postanowienia",
+        "reviewStepName": "Przejrzyj umowę o zachowaniu poufności",
+        "reviewStepPrompt": "Przejrzyj załączoną umowę o zachowaniu poufności pod kątem typowych standardów rynkowych: okresu obowiązywania, zakresu poufności, wyłączeń i prawa właściwego. Oznacz nietypowe postanowienia, określ ich wagę i wskaż odpowiedni punkt umowy."
       }
     },
     "fileUpload": {
@@ -1509,9 +1509,9 @@
     "steps": {
       "add": "Dodaj krok:",
       "ai": "Krok AI",
-      "aiHelp": "Writes text from your instructions and can read the selected input documents.",
+      "aiHelp": "Tworzy tekst na podstawie Twoich instrukcji i może odczytać wybrane dokumenty wejściowe.",
       "createDocument": "Utwórz dokument",
-      "createDocumentHelp": "Saves the most recent AI output as a document in the matter where the run started.",
+      "createDocumentHelp": "Zapisuje najnowszy wynik AI jako dokument w sprawie, w której rozpoczęto wykonanie.",
       "documentTitle": "Tytuł dokumentu",
       "documentTitlePlaceholder": "np. Notatka podsumowująca",
       "documentTitleRequired": "Wprowadź tytuł dokumentu.",
@@ -1526,7 +1526,7 @@
       "promptRequired": "Wprowadź prompt dla kroku AI.",
       "required": "Dodaj co najmniej jeden krok.",
       "reviewGate": "Punkt przeglądu",
-      "reviewGateHelp": "Pauses the run until a person approves or rejects.",
+      "reviewGateHelp": "Zatrzymuje wykonanie do czasu zatwierdzenia lub odrzucenia przez użytkownika.",
       "title": "Kroki"
     },
     "trigger": {
@@ -1878,7 +1878,7 @@
       "builtInSection": "Wbudowane umiejętności",
       "chooseFile": "Wybierz plik lub przeciągnij go tutaj",
       "coaching": {
-        "publish": "Publish skill"
+        "publish": "Opublikuj umiejętność"
       },
       "deleteConfirmDescription": "„{name}” zostanie usunięta z tego obszaru roboczego.",
       "deleteFile": "Usuń plik",
@@ -1919,7 +1919,7 @@
       "generateSkill": "Wygeneruj z AI",
       "generateTitle": "Wygeneruj umiejętność z AI",
       "generating": "Generowanie…",
-      "howItRuns": "How it runs",
+      "howItRuns": "Jak działa",
       "importFailureFetch": "Nie udało się wczytać źródła umiejętności.",
       "importFailureIntegrity": "Źródło umiejętności zmieniło się po jego wykryciu. Przejrzyj je ponownie.",
       "importFailureLimit": "Osiągnięto limit umiejętności.",
@@ -1941,7 +1941,7 @@
       "resources": "{count, plural, one {# zasób} few {# zasoby} many {# zasobów} other {# zasobu}}",
       "scopePrivate": "Tylko ja",
       "scopeTeam": "Wszyscy w zespole",
-      "selectFileHint": "Select a file from the list to open it in the editor panel on the right.",
+      "selectFileHint": "Wybierz plik z listy, aby otworzyć go w panelu edytora po prawej stronie.",
       "selectedFile": "Wybrano: {name}",
       "selectionLimit": "Wybierz jednocześnie maksymalnie {count} umiejętności.",
       "sourceUpload": "Przesłano",
@@ -2001,12 +2001,12 @@
       "addRule": "Reguła",
       "advanced": "Zaawansowane",
       "approval": {
-        "approve": "Approve",
-        "approveFailed": "Failed to approve playbook",
-        "approvedOn": "Approved {date}",
-        "approvedToast": "Playbook approved",
-        "statusApproved": "Approved",
-        "statusDraft": "Draft"
+        "approve": "Zatwierdź",
+        "approveFailed": "Nie udało się zatwierdzić playbooka",
+        "approvedOn": "Zatwierdzono {date}",
+        "approvedToast": "Playbook zatwierdzony",
+        "statusApproved": "Zatwierdzony",
+        "statusDraft": "Wersja robocza"
       },
       "askContentLabel": "Typ odpowiedzi",
       "askQuestionLabel": "Treść pytania",
@@ -2069,18 +2069,18 @@
       "issuePlaceholder": "np. Ograniczenie odpowiedzialności",
       "loadFailed": "Nie udało się załadować playbooków",
       "loading": "Ładowanie playbooków…",
-      "manageTypes": "Manage types…",
+      "manageTypes": "Zarządzaj typami…",
       "namePlaceholder": "np. przegląd NDA",
       "nameRequired": "Podaj nazwę.",
       "negotiation": {
-        "addTalkingPoint": "Add talking point",
-        "escalationLabel": "Escalation",
-        "escalationPlaceholder": "When/to whom to escalate (optional)",
-        "rationaleLabel": "Rationale",
-        "rationalePlaceholder": "Why we want this (optional)",
-        "talkingPointPlaceholder": "What to say",
-        "talkingPointsLabel": "Talking points",
-        "title": "Negotiation"
+        "addTalkingPoint": "Dodaj argument",
+        "escalationLabel": "Eskalacja",
+        "escalationPlaceholder": "Kiedy i do kogo eskalować (opcjonalnie)",
+        "rationaleLabel": "Uzasadnienie",
+        "rationalePlaceholder": "Dlaczego zależy nam na tym stanowisku (opcjonalnie)",
+        "talkingPointPlaceholder": "Co powiedzieć",
+        "talkingPointsLabel": "Argumenty",
+        "title": "Negocjacje"
       },
       "noPositions": "Brak stanowisk. Dodaj pierwsze.",
       "optionPlaceholder": "Wartość opcji",
@@ -2117,17 +2117,17 @@
       },
       "risk": {
         "complianceLabel": "Zgodność",
-        "flaggedCount": "{flagged} of {total} positions flagged",
+        "flaggedCount": "Oznaczono {flagged} z {total} pozycji",
         "notApplicableExcluded": "({count} nie dotyczy, wykluczono)",
         "riskLevel": {
-          "critical": "Critical",
-          "high": "High",
-          "low": "Low",
-          "medium": "Medium",
-          "none": "No risk"
+          "critical": "Krytyczne",
+          "high": "Wysokie",
+          "low": "Niskie",
+          "medium": "Średnie",
+          "none": "Brak ryzyka"
         },
-        "summaryTitle": "Risk summary",
-        "topIssuesTitle": "Top issues"
+        "summaryTitle": "Podsumowanie ryzyka",
+        "topIssuesTitle": "Najważniejsze kwestie"
       },
       "ruleNumber": "Reguła {index}",
       "rulePlaceholder": "Reguła w prostym języku",
@@ -2140,11 +2140,11 @@
       },
       "severityLabel": "Waga",
       "starters": {
-        "addedToast": "Playbook added",
-        "browseButton": "Browse starter playbooks",
-        "positionCount": "{count, plural, one {# position} other {# positions}}",
-        "subtitle": "Ready-made playbooks you can add and then tailor to your standards.",
-        "title": "Starter playbooks"
+        "addedToast": "Dodano playbook",
+        "browseButton": "Przeglądaj gotowe playbooki",
+        "positionCount": "{count, plural, one {# pozycja} few {# pozycje} many {# pozycji} other {# pozycji}}",
+        "subtitle": "Gotowe playbooki, które możesz dodać i dostosować do swoich standardów.",
+        "title": "Gotowe playbooki"
       },
       "switchToAuto": "Powrót do trybu automatycznego",
       "switchToManual": "Przełącz na tryb ręczny",
@@ -2163,10 +2163,10 @@
         "notApplicable": "Nie dotyczy"
       },
       "versions": {
-        "confirmRestore": "Your current draft will be replaced with this version's content.",
-        "restoreFailed": "Failed to restore version",
-        "restoredToast": "Version restored",
-        "versionHistory": "Version history"
+        "confirmRestore": "Treść bieżącej wersji roboczej zostanie zastąpiona treścią tej wersji.",
+        "restoreFailed": "Nie udało się przywrócić wersji",
+        "restoredToast": "Przywrócono wersję",
+        "versionHistory": "Historia wersji"
       }
     },
     "sections": {
@@ -2203,29 +2203,29 @@
       "blueprintGallery": {
         "cards": {
           "answerFromSources": {
-            "blurb": "Answer a question grounded in authoritative sources.",
-            "inside": "a source hierarchy · a research prompt",
-            "title": "Answer from sources"
+            "blurb": "Odpowiedz na pytanie na podstawie wiarygodnych źródeł.",
+            "inside": "hierarchia źródeł · prompt badawczy",
+            "title": "Odpowiedź na podstawie źródeł"
           },
           "checkAgainstRules": {
-            "blurb": "Review a document and flag what fails, with citations.",
-            "inside": "references by jurisdiction · a checklist · a review prompt",
-            "title": "Check against rules"
+            "blurb": "Przejrzyj dokument, wskaż niezgodności i poprzyj je odwołaniami do źródeł.",
+            "inside": "materiały według jurysdykcji · lista kontrolna · prompt przeglądu",
+            "title": "Weryfikacja zgodności z regułami"
           },
           "intakeToDraft": {
-            "blurb": "Ask for the facts, then draft a document.",
-            "inside": "an interview · model documents · a draft prompt",
-            "title": "Intake to draft"
+            "blurb": "Zbierz informacje, a następnie opracuj projekt dokumentu.",
+            "inside": "wywiad · dokumenty wzorcowe · prompt do opracowania projektu",
+            "title": "Od zebrania informacji do projektu"
           }
         },
-        "insideLabel": "Inside",
-        "startBlank": "Start from blank",
-        "startBlankHint": "An empty skill, for when you know exactly what you want.",
-        "subtitle": "Pick a starting shape. We set up the folders and walk you through filling them in.",
-        "title": "How should your skill work?"
+        "insideLabel": "W środku",
+        "startBlank": "Zacznij od pustej umiejętności",
+        "startBlankHint": "Pusta umiejętność na wypadek, gdy dokładnie wiesz, czego potrzebujesz.",
+        "subtitle": "Wybierz punkt wyjścia. Przygotujemy foldery i przeprowadzimy Cię przez ich uzupełnianie.",
+        "title": "Jak ma działać Twoja umiejętność?"
       },
       "commandConflict": "Umiejętność z tym poleceniem / już istnieje",
-      "commandHelp": "Type it in chat to run this skill.",
+      "commandHelp": "Wpisz to na czacie, aby uruchomić tę umiejętność.",
       "commandLabel": "Polecenie ukośnikowe (opcjonalne)",
       "commandPlaceholder": "np. podsumuj",
       "createTitle": "Nowa umiejętność",
@@ -2257,9 +2257,9 @@
     }
   },
   "markdownEditor": {
-    "rawLabel": "Markdown source",
-    "showFormatted": "Formatted",
-    "showRaw": "Show raw"
+    "rawLabel": "Źródło Markdown",
+    "showFormatted": "Sformatowany tekst",
+    "showRaw": "Pokaż źródło"
   },
   "memory": {
     "addPlaceholder": "Dodaj notatkę, którą asystent ma zapamiętać…",
@@ -2902,12 +2902,12 @@
         "updated": "Ustawienie rozpoznawania tekstu dokumentów zaktualizowane"
       },
       "documentTypes": {
-        "addPlaceholder": "Add a document type (e.g. Employment Agreement)",
-        "deleteFailed": "Couldn't delete document type",
-        "description": "Define the document types your organisation reviews. Playbooks scope to these, and the AI classifier sorts documents into them.",
-        "labelAria": "Document type name",
-        "reorder": "Reorder document type",
-        "title": "Document types"
+        "addPlaceholder": "Dodaj typ dokumentu (np. umowa o pracę)",
+        "deleteFailed": "Nie udało się usunąć typu dokumentu",
+        "description": "Zdefiniuj typy dokumentów przeglądanych przez Twoją organizację. Playbooki odnoszą się do tych typów, a klasyfikator AI przypisuje do nich dokumenty.",
+        "labelAria": "Nazwa typu dokumentu",
+        "reorder": "Zmień kolejność typu dokumentu",
+        "title": "Typy dokumentów"
       },
       "matterNumbering": "Numeracja spraw",
       "matterNumberingDescription": "Skonfiguruj sposób generowania numerów referencyjnych nowych spraw",
@@ -3177,7 +3177,7 @@
     "conditionAnd": "I",
     "conditionCount": "{count, plural, one {# warunek} few {# warunki} many {# warunków} other {# warunków}}",
     "conditionField": "Pole",
-    "conditionFormulaPlaceholder": "Enter a formula…",
+    "conditionFormulaPlaceholder": "Wprowadź formułę…",
     "conditionMatch": "Dopasowanie",
     "conditionNamePlaceholder": "Nazwa warunku (np. NPF)",
     "conditionOpAfter": "po",
@@ -3196,8 +3196,8 @@
     "conditionOpOnOrBefore": "dnia lub przed",
     "conditionOperator": "Operator",
     "conditionOr": "Lub",
-    "conditionUseFieldInstead": "Use a field instead",
-    "conditionUseFormula": "ƒ Calculated value…",
+    "conditionUseFieldInstead": "Zamiast tego użyj pola",
+    "conditionUseFormula": "ƒ Wartość obliczana…",
     "conditionValue": "Wartość",
     "conditionWhen": "Gdy",
     "conditionsTitle": "Warunki",
@@ -3349,7 +3349,7 @@
       "conditionOrBuildNew": "albo utwórz nowy",
       "conditionReuse": "Użyj istniejącego warunku",
       "conditionReusePick": "Wybierz istniejący warunek…",
-      "conditionRuleFallbackLabel": "Calculated condition",
+      "conditionRuleFallbackLabel": "Warunek obliczany",
       "conditionSource": "Jak jest ustalany",
       "conditionSourceAi": "Decyduje AI",
       "conditionSourceAsked": "Pytany",
@@ -3375,7 +3375,7 @@
       "gettingStartedTitle": "Wprowadzenie",
       "insert": "Wstaw",
       "insertAtCaret": "Wstaw przy kursorze",
-      "insertConditionIntoTemplate": "Insert condition",
+      "insertConditionIntoTemplate": "Wstaw warunek",
       "insertFormatDefault": "Domyślny",
       "insertIntoTemplate": "Wstaw do szablonu",
       "insertItemNumber": "Numer elementu",
@@ -3518,9 +3518,9 @@
     "settings": {
       "description": "Bring your own web-search API keys so chat can search the web and read pages with your own provider account. Without them, chat uses the platform's shared keys when available.",
       "fetchTitle": "Page reader key",
-      "platformFallback": "The platform's shared key is in use. Add your own to use your own provider account and quota.",
+      "platformFallback": "Używany jest współdzielony klucz platformy. Dodaj własny klucz, aby korzystać ze swojego konta i limitu u dostawcy.",
       "searchTitle": "Search provider key",
-      "title": "Web search keys"
+      "title": "Klucze wyszukiwania w internecie"
     }
   },
   "workspaces": {
@@ -3950,7 +3950,7 @@
     },
     "possibleDuplicates": "Możliwe duplikaty",
     "properties": {
-      "addCondition": "Add condition",
+      "addCondition": "Dodaj warunek",
       "addInputProperty": "Dodaj co najmniej jedną właściwość wejściową za pomocą \"@\"",
       "addOption": "Dodaj opcję",
       "addPromptForBetterResults": "Dodaj prompt, aby uzyskać lepsze wyniki",
@@ -3970,7 +3970,7 @@
       "chipNumber": "Liczba",
       "chipSingle": "Tag",
       "chipText": "Tekst",
-      "clip": "Clip",
+      "clip": "Wycinek",
       "composerTitle": "Co stella ma znaleźć?",
       "conditionSeparator": "I",
       "conditions": "Warunki ({count})",
@@ -3990,7 +3990,7 @@
       "editColumn": "Edytuj kolumnę",
       "editConditions": "Edytuj warunki",
       "editConditionsDescription": "Ustaw warunki, kiedy ta właściwość ma być generowana.",
-      "editConditionsWhen": "Only run extraction when …",
+      "editConditionsWhen": "Uruchamiaj wyodrębnianie tylko wtedy, gdy…",
       "enterAValue": "Wprowadź wartość",
       "extractEntityType": "Wyodrębnij typ encji",
       "extractEntityTypeDescription": "Utwórz kolumnę tabeli wypełnianą przez AI.",
@@ -4018,7 +4018,7 @@
       "newColumn": "Nowa kolumna",
       "newColumnDescription": "Wybierz, jak ta kolumna tabeli ma być wypełniana.",
       "newColumnName": "Nazwa kolumny",
-      "noConditionFields": "No fields available to filter on.",
+      "noConditionFields": "Brak pól, według których można filtrować.",
       "noFirstDocument": "Brak dokumentów do podglądu.",
       "noPropertiesFound": "Nie znaleziono właściwości",
       "optionsHelp": "Określ wartości, spośród których AI może wybierać.",
@@ -4041,7 +4041,7 @@
       "scopeMatterDescription": "Użyj wszystkich kolumn plików i uruchom sprawę.",
       "searchOrAddOptions": "Szukaj lub dodaj opcje",
       "selectColor": "Wybierz kolor",
-      "selectField": "Select field",
+      "selectField": "Wybierz pole",
       "selectOperator": "Wybierz operator",
       "setPromptPlaceholder": "Ustaw prompt do wyodrębnienia informacji",
       "singleSelect": "Jednokrotny wybór",
@@ -4135,7 +4135,7 @@
       "filterByPlaceholder": "Filtruj według…",
       "filtersWithCount": "{count, plural, one {# filtr} few {# filtry} many {# filtrów} other {# filtra}}",
       "groupBy": "Grupuj według:",
-      "groupItemCount": "{count, plural, one {# item} other {# items}}",
+      "groupItemCount": "{count, plural, one {# element} few {# elementy} many {# elementów} other {# elementu}}",
       "hideColumn": "Ukryj kolumnę",
       "layouts": {
         "calendar": "Kalendarz",

--- a/apps/web/src/i18n/langs/pt-BR.json
+++ b/apps/web/src/i18n/langs/pt-BR.json
@@ -800,7 +800,7 @@
     "active": "Ativo",
     "add": "Adicionar",
     "all": "Todos",
-    "and": "And",
+    "and": "E",
     "anonymizationLabels": {
       "address": "Endereço",
       "bankAccountNumber": "Número da conta bancária",
@@ -959,12 +959,12 @@
     "next": "Próximo",
     "noResults": "Nenhum resultado",
     "noVersions": "Sem histórico de versões",
-    "none": "None",
+    "none": "Nenhum",
     "notes": "Notas",
     "open": "Abrir",
     "openInNewTab": "Abrir em nova aba",
     "options": "Opções",
-    "or": "Or",
+    "or": "Ou",
     "organization": "Organização",
     "organizationName": "Nome da organização",
     "pin": "Fixar",
@@ -1020,7 +1020,7 @@
     "type": "Tipo",
     "typeNameToConfirm": "Digite o nome para confirmar",
     "uncategorized": "Sem categoria",
-    "undo": "Undo",
+    "undo": "Desfazer",
     "unexpectedError": "Ocorreu um erro inesperado. Entre em contato com o suporte.",
     "unknownUser": "Usuário desconhecido",
     "unpin": "Desafixar",
@@ -1399,47 +1399,47 @@
     "descriptionPlaceholder": "O que este fluxo de trabalho faz",
     "disableFlow": "Desativar fluxo de trabalho",
     "editor": {
-      "newFlowIntro": "Define the steps once, then run this workflow from any matter. Runs pause at review checkpoints for approval."
+      "newFlowIntro": "Defina as etapas uma vez e depois execute este fluxo de trabalho a partir de qualquer caso. As execuções são pausadas nos pontos de revisão para aprovação."
     },
     "empty": "Ainda não há fluxos de trabalho",
     "emptyDescription": "Crie um fluxo de trabalho para transformar documentos e um objetivo em um resultado finalizado.",
     "emptyState": {
-      "blankAction": "Start blank",
-      "description": "Start it from a matter's Workflows tab, on a schedule, or when files are uploaded. It pauses at checkpoints for a person to approve before anything is final, and the result can be saved as a document in the matter.",
-      "examplesTitle": "Start from an example",
-      "title": "A workflow is a saved sequence of AI and review steps your team reruns on matter documents to produce a consistent deliverable."
+      "blankAction": "Começar do zero",
+      "description": "Inicie na aba Fluxos de trabalho de um caso, de acordo com um agendamento ou quando arquivos forem enviados. A execução é pausada nos pontos de revisão para que uma pessoa aprove antes da conclusão; o resultado pode ser salvo como documento no caso.",
+      "examplesTitle": "Começar com um exemplo",
+      "title": "Um fluxo de trabalho é uma sequência salva de etapas de IA e revisão que sua equipe executa novamente nos documentos de um caso para produzir um resultado consistente."
     },
     "enableFlow": "Ativar fluxo de trabalho",
     "enabledDescription": "Fluxos de trabalho desativados não podem ser executados nem acionados.",
     "enabledLabel": "Ativado",
     "examples": {
       "documentSummary": {
-        "createStepName": "Create the summary",
-        "description": "Summarize the matter's documents for a colleague who has not read them.",
-        "documentTitle": "Document summary",
-        "name": "Document summary for the file",
-        "summaryStepName": "Summarize the documents",
-        "summaryStepPrompt": "Summarize each input document: parties, subject, key dates, obligations, and open points. Write for a colleague who has not read it."
+        "createStepName": "Criar o resumo",
+        "description": "Resuma os documentos do caso para um colega que não os leu.",
+        "documentTitle": "Resumo dos documentos",
+        "name": "Resumo dos documentos do caso",
+        "summaryStepName": "Resumir os documentos",
+        "summaryStepPrompt": "Resuma cada documento de entrada: partes, objeto, datas importantes, obrigações e questões pendentes. Escreva para um colega que não o leu."
       },
       "dueDiligence": {
-        "createStepName": "Create the report",
-        "description": "Surface change-of-control, assignment, and liability risks across a data room.",
-        "documentTitle": "Red-flag report",
-        "name": "Due diligence red flags",
-        "reviewGateInstructions": "Check the red flags before the report is created.",
-        "reviewGateStepName": "Check the red flags",
-        "reviewStepName": "Find red flags",
-        "reviewStepPrompt": "Read the input documents and produce a red-flag report: change-of-control, assignment restrictions, termination rights, exclusivity, and liability caps. Quote the relevant language."
+        "createStepName": "Criar o relatório",
+        "description": "Identifique riscos de mudança de controle, cessão e responsabilidade em uma sala de dados.",
+        "documentTitle": "Relatório de riscos relevantes",
+        "name": "Riscos relevantes da devida diligência",
+        "reviewGateInstructions": "Verifique os riscos relevantes antes de criar o relatório.",
+        "reviewGateStepName": "Verificar os riscos relevantes",
+        "reviewStepName": "Identificar riscos relevantes",
+        "reviewStepPrompt": "Leia os documentos de entrada e produza um relatório de riscos relevantes: mudança de controle, restrições à cessão, direitos de rescisão, exclusividade e limites de responsabilidade. Cite o texto pertinente."
       },
       "ndaIntake": {
-        "createStepName": "Create the memo",
-        "description": "Flag unusual clauses in an NDA before your team relies on it.",
-        "documentTitle": "NDA review memo",
-        "name": "NDA intake review",
-        "reviewGateInstructions": "Check the flagged clauses before the memo is created.",
-        "reviewGateStepName": "Check the flagged clauses",
-        "reviewStepName": "Review the NDA",
-        "reviewStepPrompt": "Review the attached NDA against common market standards: term, confidentiality scope, carve-outs, and governing law. Flag unusual clauses with a severity rating and cite the clause."
+        "createStepName": "Criar o memorando",
+        "description": "Sinalize cláusulas incomuns em um acordo de confidencialidade antes que sua equipe se baseie nele.",
+        "documentTitle": "Memorando de revisão do acordo de confidencialidade",
+        "name": "Revisão inicial do acordo de confidencialidade",
+        "reviewGateInstructions": "Verifique as cláusulas sinalizadas antes de criar o memorando.",
+        "reviewGateStepName": "Verificar as cláusulas sinalizadas",
+        "reviewStepName": "Revisar o acordo de confidencialidade",
+        "reviewStepPrompt": "Revise o acordo de confidencialidade anexado de acordo com as práticas comuns do mercado: vigência, escopo da confidencialidade, exceções e lei aplicável. Sinalize cláusulas incomuns, atribua um nível de gravidade e cite a cláusula."
       }
     },
     "fileUpload": {
@@ -1509,9 +1509,9 @@
     "steps": {
       "add": "Adicionar etapa:",
       "ai": "Etapa de IA",
-      "aiHelp": "Writes text from your instructions and can read the selected input documents.",
+      "aiHelp": "Escreve textos com base nas suas instruções e pode ler os documentos de entrada selecionados.",
       "createDocument": "Criar documento",
-      "createDocumentHelp": "Saves the most recent AI output as a document in the matter where the run started.",
+      "createDocumentHelp": "Salva a saída mais recente da IA como documento no caso em que a execução foi iniciada.",
       "documentTitle": "Título do documento",
       "documentTitlePlaceholder": "ex.: Memorando de resumo",
       "documentTitleRequired": "Insira um título de documento.",
@@ -1521,12 +1521,12 @@
       "instructionsPlaceholder": "O que o revisor deve verificar",
       "namePlaceholder": "Nome da etapa",
       "nameRequired": "Insira um nome para cada etapa.",
-      "prompt": "Prompt",
+      "prompt": "Instrução",
       "promptPlaceholder": "Instruções para a etapa de IA",
       "promptRequired": "Insira um prompt para a etapa de IA.",
       "required": "Adicione pelo menos uma etapa.",
       "reviewGate": "Ponto de revisão",
-      "reviewGateHelp": "Pauses the run until a person approves or rejects.",
+      "reviewGateHelp": "Pausa a execução até que uma pessoa aprove ou rejeite.",
       "title": "Etapas"
     },
     "trigger": {
@@ -1878,7 +1878,7 @@
       "builtInSection": "Habilidades integradas",
       "chooseFile": "Escolha um arquivo ou arraste-o aqui",
       "coaching": {
-        "publish": "Publish skill"
+        "publish": "Publicar habilidade"
       },
       "deleteConfirmDescription": "“{name}” será removida deste espaço de trabalho.",
       "deleteFile": "Excluir arquivo",
@@ -1919,7 +1919,7 @@
       "generateSkill": "Gerar com IA",
       "generateTitle": "Gerar habilidade com IA",
       "generating": "Gerando…",
-      "howItRuns": "How it runs",
+      "howItRuns": "Como funciona",
       "importFailureFetch": "Não foi possível carregar a origem da habilidade.",
       "importFailureIntegrity": "A origem da habilidade mudou após a descoberta. Revise-a novamente.",
       "importFailureLimit": "O limite de habilidades foi atingido.",
@@ -1941,7 +1941,7 @@
       "resources": "{count, plural, one {# recurso} other {# recursos}}",
       "scopePrivate": "Só eu",
       "scopeTeam": "Todos na equipe",
-      "selectFileHint": "Select a file from the list to open it in the editor panel on the right.",
+      "selectFileHint": "Selecione um arquivo da lista para abri-lo no painel do editor à direita.",
       "selectedFile": "Selecionado: {name}",
       "selectionLimit": "Selecione até {count} habilidades por vez.",
       "sourceUpload": "Enviada",
@@ -2001,12 +2001,12 @@
       "addRule": "Regra",
       "advanced": "Avançado",
       "approval": {
-        "approve": "Approve",
-        "approveFailed": "Failed to approve playbook",
-        "approvedOn": "Approved {date}",
-        "approvedToast": "Playbook approved",
-        "statusApproved": "Approved",
-        "statusDraft": "Draft"
+        "approve": "Aprovar",
+        "approveFailed": "Não foi possível aprovar o playbook",
+        "approvedOn": "Aprovado em {date}",
+        "approvedToast": "Playbook aprovado",
+        "statusApproved": "Aprovado",
+        "statusDraft": "Rascunho"
       },
       "askContentLabel": "Tipo de resposta",
       "askQuestionLabel": "Pergunta",
@@ -2069,18 +2069,18 @@
       "issuePlaceholder": "ex.: Limitação de responsabilidade",
       "loadFailed": "Não foi possível carregar os playbooks",
       "loading": "Carregando playbooks…",
-      "manageTypes": "Manage types…",
+      "manageTypes": "Gerenciar tipos…",
       "namePlaceholder": "ex.: Revisão de NDA",
       "nameRequired": "Adicione um nome.",
       "negotiation": {
-        "addTalkingPoint": "Add talking point",
-        "escalationLabel": "Escalation",
-        "escalationPlaceholder": "When/to whom to escalate (optional)",
-        "rationaleLabel": "Rationale",
-        "rationalePlaceholder": "Why we want this (optional)",
-        "talkingPointPlaceholder": "What to say",
-        "talkingPointsLabel": "Talking points",
-        "title": "Negotiation"
+        "addTalkingPoint": "Adicionar argumento de negociação",
+        "escalationLabel": "Escalonamento",
+        "escalationPlaceholder": "Quando e para quem escalar (opcional)",
+        "rationaleLabel": "Justificativa",
+        "rationalePlaceholder": "Por que queremos isso (opcional)",
+        "talkingPointPlaceholder": "O que dizer",
+        "talkingPointsLabel": "Argumentos de negociação",
+        "title": "Negociação"
       },
       "noPositions": "Ainda não há posições. Adicione a primeira.",
       "optionPlaceholder": "Valor da opção",
@@ -2117,17 +2117,17 @@
       },
       "risk": {
         "complianceLabel": "Conformidade",
-        "flaggedCount": "{flagged} of {total} positions flagged",
+        "flaggedCount": "{flagged} de {total} posições sinalizadas",
         "notApplicableExcluded": "({count} não aplicável, excluídas)",
         "riskLevel": {
-          "critical": "Critical",
-          "high": "High",
-          "low": "Low",
-          "medium": "Medium",
-          "none": "No risk"
+          "critical": "Crítico",
+          "high": "Alto",
+          "low": "Baixo",
+          "medium": "Médio",
+          "none": "Sem risco"
         },
-        "summaryTitle": "Risk summary",
-        "topIssuesTitle": "Top issues"
+        "summaryTitle": "Resumo dos riscos",
+        "topIssuesTitle": "Principais problemas"
       },
       "ruleNumber": "Regra {index}",
       "rulePlaceholder": "Regra em linguagem simples",
@@ -2140,11 +2140,11 @@
       },
       "severityLabel": "Gravidade",
       "starters": {
-        "addedToast": "Playbook added",
-        "browseButton": "Browse starter playbooks",
-        "positionCount": "{count, plural, one {# position} other {# positions}}",
-        "subtitle": "Ready-made playbooks you can add and then tailor to your standards.",
-        "title": "Starter playbooks"
+        "addedToast": "Playbook adicionado",
+        "browseButton": "Explorar playbooks iniciais",
+        "positionCount": "{count, plural, one {# posição} other {# posições}}",
+        "subtitle": "Playbooks prontos que você pode adicionar e depois adaptar aos seus padrões.",
+        "title": "Playbooks iniciais"
       },
       "switchToAuto": "Voltar para automático",
       "switchToManual": "Mudar para manual",
@@ -2163,10 +2163,10 @@
         "notApplicable": "Não aplicável"
       },
       "versions": {
-        "confirmRestore": "Your current draft will be replaced with this version's content.",
-        "restoreFailed": "Failed to restore version",
-        "restoredToast": "Version restored",
-        "versionHistory": "Version history"
+        "confirmRestore": "Seu rascunho atual será substituído pelo conteúdo desta versão.",
+        "restoreFailed": "Não foi possível restaurar a versão",
+        "restoredToast": "Versão restaurada",
+        "versionHistory": "Histórico de versões"
       }
     },
     "sections": {
@@ -2203,29 +2203,29 @@
       "blueprintGallery": {
         "cards": {
           "answerFromSources": {
-            "blurb": "Answer a question grounded in authoritative sources.",
-            "inside": "a source hierarchy · a research prompt",
-            "title": "Answer from sources"
+            "blurb": "Responda a uma pergunta com base em fontes confiáveis.",
+            "inside": "uma hierarquia de fontes · uma instrução de pesquisa",
+            "title": "Responder com base em fontes"
           },
           "checkAgainstRules": {
-            "blurb": "Review a document and flag what fails, with citations.",
-            "inside": "references by jurisdiction · a checklist · a review prompt",
-            "title": "Check against rules"
+            "blurb": "Revise um documento e sinalize as não conformidades com citações.",
+            "inside": "referências por jurisdição · uma lista de verificação · uma instrução de revisão",
+            "title": "Verificar de acordo com as regras"
           },
           "intakeToDraft": {
-            "blurb": "Ask for the facts, then draft a document.",
-            "inside": "an interview · model documents · a draft prompt",
-            "title": "Intake to draft"
+            "blurb": "Colete os fatos e depois redija um documento.",
+            "inside": "uma entrevista · documentos-modelo · uma instrução de redação",
+            "title": "Da coleta à redação"
           }
         },
-        "insideLabel": "Inside",
-        "startBlank": "Start from blank",
-        "startBlankHint": "An empty skill, for when you know exactly what you want.",
-        "subtitle": "Pick a starting shape. We set up the folders and walk you through filling them in.",
-        "title": "How should your skill work?"
+        "insideLabel": "Conteúdo",
+        "startBlank": "Começar do zero",
+        "startBlankHint": "Uma habilidade vazia para quando você sabe exatamente o que quer.",
+        "subtitle": "Escolha uma estrutura inicial. Configuraremos as pastas e orientaremos você no preenchimento.",
+        "title": "Como sua habilidade deve funcionar?"
       },
       "commandConflict": "Já existe uma habilidade com este comando /",
-      "commandHelp": "Type it in chat to run this skill.",
+      "commandHelp": "Digite no chat para executar esta habilidade.",
       "commandLabel": "Comando com barra (opcional)",
       "commandPlaceholder": "p. ex. resumir",
       "createTitle": "Nova habilidade",
@@ -2257,9 +2257,9 @@
     }
   },
   "markdownEditor": {
-    "rawLabel": "Markdown source",
-    "showFormatted": "Formatted",
-    "showRaw": "Show raw"
+    "rawLabel": "Código-fonte Markdown",
+    "showFormatted": "Formatado",
+    "showRaw": "Mostrar código-fonte"
   },
   "memory": {
     "addPlaceholder": "Adicione uma nota para o assistente lembrar…",
@@ -2902,12 +2902,12 @@
         "updated": "Configuração de reconhecimento de texto atualizada"
       },
       "documentTypes": {
-        "addPlaceholder": "Add a document type (e.g. Employment Agreement)",
-        "deleteFailed": "Couldn't delete document type",
-        "description": "Define the document types your organisation reviews. Playbooks scope to these, and the AI classifier sorts documents into them.",
-        "labelAria": "Document type name",
-        "reorder": "Reorder document type",
-        "title": "Document types"
+        "addPlaceholder": "Adicionar um tipo de documento (por exemplo, contrato de trabalho)",
+        "deleteFailed": "Não foi possível excluir o tipo de documento",
+        "description": "Defina os tipos de documentos que sua organização revisa. Os playbooks se aplicam a esses tipos, e o classificador de IA organiza os documentos neles.",
+        "labelAria": "Nome do tipo de documento",
+        "reorder": "Reordenar tipo de documento",
+        "title": "Tipos de documentos"
       },
       "matterNumbering": "Numeração de casos",
       "matterNumberingDescription": "Configure como os novos números de referência de casos são gerados",
@@ -3177,7 +3177,7 @@
     "conditionAnd": "E",
     "conditionCount": "{count, plural, one {# condição} other {# condições}}",
     "conditionField": "Campo",
-    "conditionFormulaPlaceholder": "Enter a formula…",
+    "conditionFormulaPlaceholder": "Insira uma fórmula…",
     "conditionMatch": "Correspondência",
     "conditionNamePlaceholder": "Nome da condição (ex.: NPF)",
     "conditionOpAfter": "depois de",
@@ -3196,8 +3196,8 @@
     "conditionOpOnOrBefore": "em ou antes de",
     "conditionOperator": "Operador",
     "conditionOr": "Ou",
-    "conditionUseFieldInstead": "Use a field instead",
-    "conditionUseFormula": "ƒ Calculated value…",
+    "conditionUseFieldInstead": "Usar um campo em vez disso",
+    "conditionUseFormula": "ƒ Valor calculado…",
     "conditionValue": "Valor",
     "conditionWhen": "Quando",
     "conditionsTitle": "Condições",
@@ -3349,7 +3349,7 @@
       "conditionOrBuildNew": "ou crie uma nova",
       "conditionReuse": "Reutilizar uma condição",
       "conditionReusePick": "Escolha uma condição existente…",
-      "conditionRuleFallbackLabel": "Calculated condition",
+      "conditionRuleFallbackLabel": "Condição calculada",
       "conditionSource": "Como é decidido",
       "conditionSourceAi": "A IA decide",
       "conditionSourceAsked": "Perguntada",
@@ -3375,7 +3375,7 @@
       "gettingStartedTitle": "Primeiros passos",
       "insert": "Inserir",
       "insertAtCaret": "Inserir no cursor",
-      "insertConditionIntoTemplate": "Insert condition",
+      "insertConditionIntoTemplate": "Inserir condição",
       "insertFormatDefault": "Padrão",
       "insertIntoTemplate": "Inserir no modelo",
       "insertItemNumber": "Número do item",
@@ -3518,9 +3518,9 @@
     "settings": {
       "description": "Bring your own web-search API keys so chat can search the web and read pages with your own provider account. Without them, chat uses the platform's shared keys when available.",
       "fetchTitle": "Page reader key",
-      "platformFallback": "The platform's shared key is in use. Add your own to use your own provider account and quota.",
+      "platformFallback": "A chave compartilhada da plataforma está em uso. Adicione a sua para usar sua própria conta e cota do provedor.",
       "searchTitle": "Search provider key",
-      "title": "Web search keys"
+      "title": "Chaves de pesquisa na web"
     }
   },
   "workspaces": {
@@ -3950,7 +3950,7 @@
     },
     "possibleDuplicates": "Possíveis duplicatas",
     "properties": {
-      "addCondition": "Add condition",
+      "addCondition": "Adicionar condição",
       "addInputProperty": "Adicione pelo menos uma propriedade de entrada usando \"@\"",
       "addOption": "Adicionar opção",
       "addPromptForBetterResults": "Adicione um prompt para obter melhores resultados",
@@ -3990,7 +3990,7 @@
       "editColumn": "Editar coluna",
       "editConditions": "Editar condições",
       "editConditionsDescription": "Defina condições para quando esta propriedade deve ser gerada.",
-      "editConditionsWhen": "Only run extraction when …",
+      "editConditionsWhen": "Executar a extração somente quando…",
       "enterAValue": "Insira um valor",
       "extractEntityType": "Extrair tipo de entidade",
       "extractEntityTypeDescription": "Crie uma coluna de tabela extraída de IA.",
@@ -4018,7 +4018,7 @@
       "newColumn": "Nova coluna",
       "newColumnDescription": "Escolha como esta coluna da tabela deve ser preenchida.",
       "newColumnName": "Nome da coluna",
-      "noConditionFields": "No fields available to filter on.",
+      "noConditionFields": "Não há campos disponíveis para filtrar.",
       "noFirstDocument": "Ainda não há documentos para visualizar.",
       "noPropertiesFound": "Nenhuma propriedade encontrada",
       "optionsHelp": "Defina os valores que a IA pode escolher.",
@@ -4041,7 +4041,7 @@
       "scopeMatterDescription": "Use todas as colunas de arquivo e execute o caso.",
       "searchOrAddOptions": "Pesquise ou adicione opções",
       "selectColor": "Selecione a cor",
-      "selectField": "Select field",
+      "selectField": "Selecionar campo",
       "selectOperator": "Selecione o operador",
       "setPromptPlaceholder": "Defina um prompt para extrair as informações",
       "singleSelect": "Seleção única",
@@ -4135,7 +4135,7 @@
       "filterByPlaceholder": "Filtrar por…",
       "filtersWithCount": "{count, plural, one {# filtro} other {# filtros}}",
       "groupBy": "Agrupar por:",
-      "groupItemCount": "{count, plural, one {# item} other {# items}}",
+      "groupItemCount": "{count, plural, one {# item} other {# itens}}",
       "hideColumn": "Ocultar coluna",
       "layouts": {
         "calendar": "Calendário",

--- a/apps/web/src/i18n/langs/sk.json
+++ b/apps/web/src/i18n/langs/sk.json
@@ -800,7 +800,7 @@
     "active": "Aktívny",
     "add": "Pridať",
     "all": "Všetko",
-    "and": "And",
+    "and": "A",
     "anonymizationLabels": {
       "address": "Adresa",
       "bankAccountNumber": "Číslo bankového účtu",
@@ -959,12 +959,12 @@
     "next": "Pokračovať",
     "noResults": "Žiadne výsledky",
     "noVersions": "Žiadna história verzií",
-    "none": "None",
+    "none": "Žiadne",
     "notes": "Poznámky",
     "open": "Otvoriť",
     "openInNewTab": "Otvoriť na novej karte",
     "options": "Možnosti",
-    "or": "Or",
+    "or": "Alebo",
     "organization": "Organizácia",
     "organizationName": "Názov organizácie",
     "pin": "Pripnúť",
@@ -1020,7 +1020,7 @@
     "type": "Typ",
     "typeNameToConfirm": "Na potvrdenie napíšte názov",
     "uncategorized": "Nekategorizované",
-    "undo": "Undo",
+    "undo": "Späť",
     "unexpectedError": "Vyskytla sa neočakávaná chyba. Kontaktujte podporu.",
     "unknownUser": "Neznámy používateľ",
     "unpin": "Odopnúť",
@@ -1399,47 +1399,47 @@
     "descriptionPlaceholder": "Čo tento pracovný postup robí",
     "disableFlow": "Zakázať pracovný postup",
     "editor": {
-      "newFlowIntro": "Define the steps once, then run this workflow from any matter. Runs pause at review checkpoints for approval."
+      "newFlowIntro": "Definujte kroky raz a potom tento pracovný postup spúšťajte z ľubovoľného spisu. Spustenie sa zastaví v kontrolných bodoch, kým ho niekto neschváli."
     },
     "empty": "Zatiaľ žiadne pracovné postupy",
     "emptyDescription": "Vytvorte pracovný postup, ktorý z dokumentov a cieľa vytvorí hotový výstup.",
     "emptyState": {
-      "blankAction": "Start blank",
-      "description": "Start it from a matter's Workflows tab, on a schedule, or when files are uploaded. It pauses at checkpoints for a person to approve before anything is final, and the result can be saved as a document in the matter.",
-      "examplesTitle": "Start from an example",
-      "title": "A workflow is a saved sequence of AI and review steps your team reruns on matter documents to produce a consistent deliverable."
+      "blankAction": "Začať od prázdneho postupu",
+      "description": "Spustite ho z karty Pracovné postupy v spise, podľa plánu alebo po nahratí súborov. V kontrolných bodoch sa zastaví, aby výsledok pred dokončením niekto schválil. Výstup možno uložiť ako dokument v spise.",
+      "examplesTitle": "Začať z príkladu",
+      "title": "Pracovný postup je uložená postupnosť krokov AI a kontroly, ktorú tím opakovane spúšťa na dokumentoch spisu, aby zakaždým vytvoril konzistentný výstup."
     },
     "enableFlow": "Povoliť pracovný postup",
     "enabledDescription": "Zakázané pracovné postupy nie je možné spustiť ani vyvolať.",
     "enabledLabel": "Povolené",
     "examples": {
       "documentSummary": {
-        "createStepName": "Create the summary",
-        "description": "Summarize the matter's documents for a colleague who has not read them.",
-        "documentTitle": "Document summary",
-        "name": "Document summary for the file",
-        "summaryStepName": "Summarize the documents",
-        "summaryStepPrompt": "Summarize each input document: parties, subject, key dates, obligations, and open points. Write for a colleague who has not read it."
+        "createStepName": "Vytvoriť súhrn",
+        "description": "Zhrnúť dokumenty spisu pre kolegu, ktorý ich ešte nečítal.",
+        "documentTitle": "Súhrn dokumentov",
+        "name": "Súhrn dokumentov spisu",
+        "summaryStepName": "Zhrnúť dokumenty",
+        "summaryStepPrompt": "Zhrňte každý vstupný dokument: strany, predmet, kľúčové dátumy, povinnosti a otvorené otázky. Píšte pre kolegu, ktorý ho ešte nečítal."
       },
       "dueDiligence": {
-        "createStepName": "Create the report",
-        "description": "Surface change-of-control, assignment, and liability risks across a data room.",
-        "documentTitle": "Red-flag report",
-        "name": "Due diligence red flags",
-        "reviewGateInstructions": "Check the red flags before the report is created.",
-        "reviewGateStepName": "Check the red flags",
-        "reviewStepName": "Find red flags",
-        "reviewStepPrompt": "Read the input documents and produce a red-flag report: change-of-control, assignment restrictions, termination rights, exclusivity, and liability caps. Quote the relevant language."
+        "createStepName": "Vytvoriť správu",
+        "description": "Odhaliť v dokumentoch dátovej miestnosti riziká zmeny kontroly, postúpenia a zodpovednosti.",
+        "documentTitle": "Správa o kľúčových rizikách",
+        "name": "Kľúčové riziká due diligence",
+        "reviewGateInstructions": "Pred vytvorením správy skontrolujte kľúčové riziká.",
+        "reviewGateStepName": "Skontrolovať kľúčové riziká",
+        "reviewStepName": "Nájsť kľúčové riziká",
+        "reviewStepPrompt": "Prečítajte vstupné dokumenty a pripravte správu o kľúčových rizikách: zmene kontroly, obmedzeniach postúpenia, právach na ukončenie, výlučnosti a obmedzeniach zodpovednosti. Citujte príslušné znenie."
       },
       "ndaIntake": {
-        "createStepName": "Create the memo",
-        "description": "Flag unusual clauses in an NDA before your team relies on it.",
-        "documentTitle": "NDA review memo",
-        "name": "NDA intake review",
-        "reviewGateInstructions": "Check the flagged clauses before the memo is created.",
-        "reviewGateStepName": "Check the flagged clauses",
-        "reviewStepName": "Review the NDA",
-        "reviewStepPrompt": "Review the attached NDA against common market standards: term, confidentiality scope, carve-outs, and governing law. Flag unusual clauses with a severity rating and cite the clause."
+        "createStepName": "Vytvoriť memorandum",
+        "description": "Označiť neobvyklé ustanovenia v NDA skôr, než sa na ňu váš tím spoľahne.",
+        "documentTitle": "Memorandum z kontroly NDA",
+        "name": "Vstupná kontrola NDA",
+        "reviewGateInstructions": "Pred vytvorením memoranda skontrolujte označené ustanovenia.",
+        "reviewGateStepName": "Skontrolovať označené ustanovenia",
+        "reviewStepName": "Skontrolovať NDA",
+        "reviewStepPrompt": "Skontrolujte priloženú NDA podľa bežných trhových štandardov: dobu trvania, rozsah dôvernosti, výnimky a rozhodné právo. Označte neobvyklé ustanovenia, určte ich závažnosť a citujte príslušné ustanovenie."
       }
     },
     "fileUpload": {
@@ -1509,9 +1509,9 @@
     "steps": {
       "add": "Pridať krok:",
       "ai": "Krok AI",
-      "aiHelp": "Writes text from your instructions and can read the selected input documents.",
+      "aiHelp": "Vytvára text podľa vašich pokynov a môže čítať vybrané vstupné dokumenty.",
       "createDocument": "Vytvoriť dokument",
-      "createDocumentHelp": "Saves the most recent AI output as a document in the matter where the run started.",
+      "createDocumentHelp": "Uloží najnovší výstup AI ako dokument v spise, v ktorom sa spustenie začalo.",
       "documentTitle": "Názov dokumentu",
       "documentTitlePlaceholder": "napr. Súhrnná správa",
       "documentTitleRequired": "Zadajte názov dokumentu.",
@@ -1526,7 +1526,7 @@
       "promptRequired": "Zadajte prompt pre krok AI.",
       "required": "Pridajte aspoň jeden krok.",
       "reviewGate": "Kontrolný bod",
-      "reviewGateHelp": "Pauses the run until a person approves or rejects.",
+      "reviewGateHelp": "Pozastaví spustenie, kým ho používateľ neschváli alebo nezamietne.",
       "title": "Kroky"
     },
     "trigger": {
@@ -1878,7 +1878,7 @@
       "builtInSection": "Vstavané zručnosti",
       "chooseFile": "Vyberte súbor alebo ho sem presuňte",
       "coaching": {
-        "publish": "Publish skill"
+        "publish": "Publikovať zručnosť"
       },
       "deleteConfirmDescription": "Zručnosť „{name}“ bude odstránená z tohto pracovného priestoru.",
       "deleteFile": "Vymazať súbor",
@@ -1919,7 +1919,7 @@
       "generateSkill": "Vygenerovať pomocou AI",
       "generateTitle": "Vygenerovať zručnosť pomocou AI",
       "generating": "Generovanie…",
-      "howItRuns": "How it runs",
+      "howItRuns": "Ako sa spúšťa",
       "importFailureFetch": "Zdroj zručnosti sa nepodarilo načítať.",
       "importFailureIntegrity": "Zdroj zručnosti sa po nájdení zmenil. Skontrolujte ho znova.",
       "importFailureLimit": "Bol dosiahnutý limit zručností.",
@@ -1941,7 +1941,7 @@
       "resources": "{count, plural, one {# zdroj} few {# zdroje} many {# zdroja} other {# zdrojov}}",
       "scopePrivate": "Iba ja",
       "scopeTeam": "Všetci v tíme",
-      "selectFileHint": "Select a file from the list to open it in the editor panel on the right.",
+      "selectFileHint": "Výberom súboru v zozname ho otvoríte v paneli editora vpravo.",
       "selectedFile": "Vybraté: {name}",
       "selectionLimit": "Naraz môžete vybrať najviac {count} zručností.",
       "sourceUpload": "Nahraté",
@@ -2001,12 +2001,12 @@
       "addRule": "Pravidlo",
       "advanced": "Pokročilé",
       "approval": {
-        "approve": "Approve",
-        "approveFailed": "Failed to approve playbook",
-        "approvedOn": "Approved {date}",
-        "approvedToast": "Playbook approved",
-        "statusApproved": "Approved",
-        "statusDraft": "Draft"
+        "approve": "Schváliť",
+        "approveFailed": "Playbook sa nepodarilo schváliť",
+        "approvedOn": "Schválené {date}",
+        "approvedToast": "Playbook schválený",
+        "statusApproved": "Schválené",
+        "statusDraft": "Koncept"
       },
       "askContentLabel": "Typ odpovede",
       "askQuestionLabel": "Znenie otázky",
@@ -2069,18 +2069,18 @@
       "issuePlaceholder": "napr. Obmedzenie zodpovednosti",
       "loadFailed": "Playbooky sa nepodarilo načítať",
       "loading": "Načítavam playbooky…",
-      "manageTypes": "Manage types…",
+      "manageTypes": "Spravovať typy…",
       "namePlaceholder": "napr. revízia NDA",
       "nameRequired": "Zadajte názov.",
       "negotiation": {
-        "addTalkingPoint": "Add talking point",
-        "escalationLabel": "Escalation",
-        "escalationPlaceholder": "When/to whom to escalate (optional)",
-        "rationaleLabel": "Rationale",
-        "rationalePlaceholder": "Why we want this (optional)",
-        "talkingPointPlaceholder": "What to say",
-        "talkingPointsLabel": "Talking points",
-        "title": "Negotiation"
+        "addTalkingPoint": "Pridať argument",
+        "escalationLabel": "Eskalácia",
+        "escalationPlaceholder": "Kedy a komu eskalovať (voliteľné)",
+        "rationaleLabel": "Odôvodnenie",
+        "rationalePlaceholder": "Prečo túto pozíciu požadujeme (voliteľné)",
+        "talkingPointPlaceholder": "Čo povedať",
+        "talkingPointsLabel": "Argumenty",
+        "title": "Vyjednávanie"
       },
       "noPositions": "Zatiaľ žiadne pozície. Pridajte prvú.",
       "optionPlaceholder": "Hodnota možnosti",
@@ -2117,17 +2117,17 @@
       },
       "risk": {
         "complianceLabel": "Súlad",
-        "flaggedCount": "{flagged} of {total} positions flagged",
+        "flaggedCount": "Označených {flagged} z {total} pozícií",
         "notApplicableExcluded": "({count} neaplikovateľné, vylúčené)",
         "riskLevel": {
-          "critical": "Critical",
-          "high": "High",
-          "low": "Low",
-          "medium": "Medium",
-          "none": "No risk"
+          "critical": "Kritické",
+          "high": "Vysoké",
+          "low": "Nízke",
+          "medium": "Stredné",
+          "none": "Bez rizika"
         },
-        "summaryTitle": "Risk summary",
-        "topIssuesTitle": "Top issues"
+        "summaryTitle": "Súhrn rizík",
+        "topIssuesTitle": "Hlavné problémy"
       },
       "ruleNumber": "Pravidlo {index}",
       "rulePlaceholder": "Pravidlo v jednoduchom jazyku",
@@ -2140,11 +2140,11 @@
       },
       "severityLabel": "Závažnosť",
       "starters": {
-        "addedToast": "Playbook added",
-        "browseButton": "Browse starter playbooks",
-        "positionCount": "{count, plural, one {# position} other {# positions}}",
-        "subtitle": "Ready-made playbooks you can add and then tailor to your standards.",
-        "title": "Starter playbooks"
+        "addedToast": "Playbook pridaný",
+        "browseButton": "Prehľadávať úvodné playbooky",
+        "positionCount": "{count, plural, one {# pozícia} few {# pozície} other {# pozícií}}",
+        "subtitle": "Hotové playbooky, ktoré môžete pridať a upraviť podľa svojich štandardov.",
+        "title": "Úvodné playbooky"
       },
       "switchToAuto": "Späť na automatický režim",
       "switchToManual": "Prepnúť na ručné zadanie",
@@ -2163,10 +2163,10 @@
         "notApplicable": "Neaplikovateľné"
       },
       "versions": {
-        "confirmRestore": "Your current draft will be replaced with this version's content.",
-        "restoreFailed": "Failed to restore version",
-        "restoredToast": "Version restored",
-        "versionHistory": "Version history"
+        "confirmRestore": "Obsah aktuálneho konceptu bude nahradený obsahom tejto verzie.",
+        "restoreFailed": "Verziu sa nepodarilo obnoviť",
+        "restoredToast": "Verzia obnovená",
+        "versionHistory": "História verzií"
       }
     },
     "sections": {
@@ -2203,29 +2203,29 @@
       "blueprintGallery": {
         "cards": {
           "answerFromSources": {
-            "blurb": "Answer a question grounded in authoritative sources.",
-            "inside": "a source hierarchy · a research prompt",
-            "title": "Answer from sources"
+            "blurb": "Odpovedzte na otázku na základe dôveryhodných zdrojov.",
+            "inside": "hierarchia zdrojov · výskumný prompt",
+            "title": "Odpoveď zo zdrojov"
           },
           "checkAgainstRules": {
-            "blurb": "Review a document and flag what fails, with citations.",
-            "inside": "references by jurisdiction · a checklist · a review prompt",
-            "title": "Check against rules"
+            "blurb": "Skontrolujte dokument, označte nesúlad a doložte ho citáciami.",
+            "inside": "zdroje podľa jurisdikcie · kontrolný zoznam · prompt na kontrolu",
+            "title": "Kontrola podľa pravidiel"
           },
           "intakeToDraft": {
-            "blurb": "Ask for the facts, then draft a document.",
-            "inside": "an interview · model documents · a draft prompt",
-            "title": "Intake to draft"
+            "blurb": "Získajte potrebné fakty a potom vypracujte návrh dokumentu.",
+            "inside": "rozhovor · vzorové dokumenty · prompt na vypracovanie návrhu",
+            "title": "Od zistenia údajov k návrhu"
           }
         },
-        "insideLabel": "Inside",
-        "startBlank": "Start from blank",
-        "startBlankHint": "An empty skill, for when you know exactly what you want.",
-        "subtitle": "Pick a starting shape. We set up the folders and walk you through filling them in.",
-        "title": "How should your skill work?"
+        "insideLabel": "Obsah",
+        "startBlank": "Začať s prázdnou zručnosťou",
+        "startBlankHint": "Prázdna zručnosť pre prípad, že presne viete, čo potrebujete.",
+        "subtitle": "Vyberte si východiskovú štruktúru. Pripravíme priečinky a prevedieme vás ich vyplnením.",
+        "title": "Ako má vaša zručnosť fungovať?"
       },
       "commandConflict": "Zručnosť s týmto / príkazom už existuje",
-      "commandHelp": "Type it in chat to run this skill.",
+      "commandHelp": "Napíšte tento príkaz do chatu a spustite zručnosť.",
       "commandLabel": "Lomkový príkaz (voliteľné)",
       "commandPlaceholder": "napr. zhrnúť",
       "createTitle": "Nová zručnosť",
@@ -2257,9 +2257,9 @@
     }
   },
   "markdownEditor": {
-    "rawLabel": "Markdown source",
-    "showFormatted": "Formatted",
-    "showRaw": "Show raw"
+    "rawLabel": "Zdroj Markdownu",
+    "showFormatted": "Formátovaný text",
+    "showRaw": "Zobraziť zdroj"
   },
   "memory": {
     "addPlaceholder": "Pridajte poznámku, ktorú si má asistent zapamätať…",
@@ -2902,12 +2902,12 @@
         "updated": "Nastavenie rozpoznávania textu dokumentov aktualizované"
       },
       "documentTypes": {
-        "addPlaceholder": "Add a document type (e.g. Employment Agreement)",
-        "deleteFailed": "Couldn't delete document type",
-        "description": "Define the document types your organisation reviews. Playbooks scope to these, and the AI classifier sorts documents into them.",
-        "labelAria": "Document type name",
-        "reorder": "Reorder document type",
-        "title": "Document types"
+        "addPlaceholder": "Pridať typ dokumentu (napr. pracovná zmluva)",
+        "deleteFailed": "Typ dokumentu sa nepodarilo odstrániť",
+        "description": "Definujte typy dokumentov, ktoré vaša organizácia kontroluje. Playbooky sa vzťahujú na tieto typy a klasifikátor AI do nich dokumenty zaraďuje.",
+        "labelAria": "Názov typu dokumentu",
+        "reorder": "Zmeniť poradie typu dokumentu",
+        "title": "Typy dokumentov"
       },
       "matterNumbering": "Číslovanie spisov",
       "matterNumberingDescription": "Nakonfigurujte, ako sa generujú referenčné čísla nových spisov",
@@ -3177,7 +3177,7 @@
     "conditionAnd": "A",
     "conditionCount": "{count, plural, one {# podmienka} few {# podmienky} other {# podmienok}}",
     "conditionField": "Pole",
-    "conditionFormulaPlaceholder": "Enter a formula…",
+    "conditionFormulaPlaceholder": "Zadajte vzorec…",
     "conditionMatch": "Zhoda",
     "conditionNamePlaceholder": "Názov podmienky (napr. NPF)",
     "conditionOpAfter": "po",
@@ -3196,8 +3196,8 @@
     "conditionOpOnOrBefore": "dňa alebo pred",
     "conditionOperator": "Operátor",
     "conditionOr": "Alebo",
-    "conditionUseFieldInstead": "Use a field instead",
-    "conditionUseFormula": "ƒ Calculated value…",
+    "conditionUseFieldInstead": "Namiesto toho použiť pole",
+    "conditionUseFormula": "ƒ Vypočítaná hodnota…",
     "conditionValue": "Hodnota",
     "conditionWhen": "Keď",
     "conditionsTitle": "Podmienky",
@@ -3349,7 +3349,7 @@
       "conditionOrBuildNew": "alebo vytvorte novú",
       "conditionReuse": "Použiť existujúcu podmienku",
       "conditionReusePick": "Vyberte existujúcu podmienku…",
-      "conditionRuleFallbackLabel": "Calculated condition",
+      "conditionRuleFallbackLabel": "Vypočítaná podmienka",
       "conditionSource": "Ako sa rozhoduje",
       "conditionSourceAi": "Rozhodne AI",
       "conditionSourceAsked": "Opýtané",
@@ -3375,7 +3375,7 @@
       "gettingStartedTitle": "Začíname",
       "insert": "Vložiť",
       "insertAtCaret": "Vložiť na pozíciu kurzora",
-      "insertConditionIntoTemplate": "Insert condition",
+      "insertConditionIntoTemplate": "Vložiť podmienku",
       "insertFormatDefault": "Predvolená",
       "insertIntoTemplate": "Vložiť do vzoru",
       "insertItemNumber": "Číslo položky",
@@ -3518,9 +3518,9 @@
     "settings": {
       "description": "Bring your own web-search API keys so chat can search the web and read pages with your own provider account. Without them, chat uses the platform's shared keys when available.",
       "fetchTitle": "Page reader key",
-      "platformFallback": "The platform's shared key is in use. Add your own to use your own provider account and quota.",
+      "platformFallback": "Používa sa zdieľaný kľúč platformy. Ak chcete používať vlastný účet a kvótu u poskytovateľa, pridajte svoj kľúč.",
       "searchTitle": "Search provider key",
-      "title": "Web search keys"
+      "title": "Kľúče na vyhľadávanie na webe"
     }
   },
   "workspaces": {
@@ -3950,7 +3950,7 @@
     },
     "possibleDuplicates": "Možné duplicity",
     "properties": {
-      "addCondition": "Add condition",
+      "addCondition": "Pridať podmienku",
       "addInputProperty": "Pridajte aspoň jednu vstupnú vlastnosť pomocou \"@\"",
       "addOption": "Pridať možnosť",
       "addPromptForBetterResults": "Pridajte prompt pre lepšie výsledky",
@@ -3990,7 +3990,7 @@
       "editColumn": "Upraviť stĺpec",
       "editConditions": "Upraviť podmienky",
       "editConditionsDescription": "Nastavte podmienky, kedy sa má táto vlastnosť generovať.",
-      "editConditionsWhen": "Only run extraction when …",
+      "editConditionsWhen": "Spustiť extrakciu iba vtedy, keď…",
       "enterAValue": "Zadajte hodnotu",
       "extractEntityType": "Extrahovať typ entity",
       "extractEntityTypeDescription": "Vytvorte tabuľkový stĺpec vypĺňaný AI.",
@@ -4018,7 +4018,7 @@
       "newColumn": "Nový stĺpec",
       "newColumnDescription": "Vyberte, ako sa má tento stĺpec tabuľky vypĺňať.",
       "newColumnName": "Názov stĺpca",
-      "noConditionFields": "No fields available to filter on.",
+      "noConditionFields": "Nie sú k dispozícii žiadne polia, podľa ktorých možno filtrovať.",
       "noFirstDocument": "Zatiaľ žiadne dokumenty pre náhľad.",
       "noPropertiesFound": "Neboli nájdené žiadne vlastnosti",
       "optionsHelp": "Zadaj hodnoty, z ktorých si AI môže vybrať.",
@@ -4041,7 +4041,7 @@
       "scopeMatterDescription": "Použiť všetky stĺpce súborov a spustiť celý spis.",
       "searchOrAddOptions": "Hľadať alebo pridať možnosti",
       "selectColor": "Vyberte farbu",
-      "selectField": "Select field",
+      "selectField": "Vybrať pole",
       "selectOperator": "Vyberte operátor",
       "setPromptPlaceholder": "Nastavte prompt na extrakciu informácií",
       "singleSelect": "Jednoduchý výber",
@@ -4135,7 +4135,7 @@
       "filterByPlaceholder": "Filtrovať podľa…",
       "filtersWithCount": "{count, plural, one {# filter} few {# filtre} other {# filtrov}}",
       "groupBy": "Zoskupiť podľa:",
-      "groupItemCount": "{count, plural, one {# item} other {# items}}",
+      "groupItemCount": "{count, plural, one {# položka} few {# položky} other {# položiek}}",
       "hideColumn": "Skryť stĺpec",
       "layouts": {
         "calendar": "Kalendár",


### PR DESCRIPTION
## Summary

- translate 1,193 genuinely untranslated catalog entries across all 12 web locales
- add researched preferred and forbidden terminology for legal-review playbooks, transactional due diligence, escalation, and rationale
- regenerate the terminology guide and reduce the structural grandfather baseline from 1,656 to 463 entries; the remainder is audited technical literals, proper names, and valid cognates or loanwords

## Terminology research

Terms were checked against official EU and national materials, localized Microsoft approval terminology, and established local legal-tech usage. The glossary distinguishes transactional due diligence from regulatory duty-of-care terminology and scopes context-valid bans to the M&A workflow.

## Validation

- `bun run i18n:check`
- `bun test packages/scripts/src/glossary-gen.test.ts packages/scripts/src/i18n-lint.test.ts`
- `oxfmt --check` and `git diff --check`

The full repository verifier reached type-aware lint, where its `tsgolint` subprocess was killed by the host after prolonged multi-worktree resource contention; it emitted no finding. CI will rerun the full gate in isolation.