### PR TITLE
fix: standardize settings icons

### DIFF
--- a/apps/web/src/components/sidebar-user-menu.tsx
+++ b/apps/web/src/components/sidebar-user-menu.tsx
@@ -3,11 +3,11 @@ import { useNavigate } from "@tanstack/react-router";
 import {
   BuildingIcon,
   ChevronsUpDownIcon,
+  CogIcon,
   GlobeIcon,
   LogOutIcon,
   MonitorIcon,
   MoonIcon,
-  Settings2Icon,
   SunIcon,
 } from "lucide-react";
 import { useTranslations } from "use-intl";
@@ -166,7 +166,7 @@ export function SidebarUserMenu({ user }: SidebarUserMenuProps) {
               );
             }}
           >
-            <Settings2Icon />
+            <CogIcon />
             {t("common.settings")}
           </MenuItem>
           <MenuSeparator />

--- a/apps/web/src/routes/_protected.knowledge/-components/catalogue/catalogue-detail-panel.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/catalogue/catalogue-detail-panel.tsx
@@ -2,13 +2,13 @@ import { useCallback, useState } from "react";
 
 import {
   BanknoteIcon,
+  CogIcon,
   ExternalLinkIcon,
   KeyRoundIcon,
   LinkIcon,
   LoaderIcon,
   PencilIcon,
   ScaleIcon,
-  Settings2Icon,
   TagIcon,
   UserIcon,
   XIcon,
@@ -158,7 +158,7 @@ export const CatalogueDetailPanel = ({
               )}
               <Field
                 ariaLabel={t("onboarding.catalogueDetailSetup")}
-                icon={Settings2Icon}
+                icon={CogIcon}
                 value={t(`catalogue.setup.${setupKey(entry.setup)}`)}
               />
             </div>

--- a/apps/web/src/routes/_protected.knowledge/-components/position-editor.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/position-editor.tsx
@@ -11,6 +11,7 @@ import { useQuery } from "@tanstack/react-query";
 import {
   ChevronDownIcon,
   ChevronUpIcon,
+  CogIcon,
   CopyIcon,
   FlagIcon,
   GripVerticalIcon,
@@ -19,7 +20,6 @@ import {
   PlusIcon,
   RepeatIcon,
   SearchIcon,
-  SlidersHorizontalIcon,
   SparklesIcon,
   Trash2Icon,
   XIcon,
@@ -1250,7 +1250,7 @@ const GradedFooter = ({
           aria-expanded={advancedOpen}
           onClick={() => setAdvancedOpen((prev) => !prev)}
         >
-          <SlidersHorizontalIcon className="size-3" />
+          <CogIcon className="size-3" />
           {t("knowledge.playbooks.advanced")}
         </InlineAction>
       </div>
@@ -1567,7 +1567,7 @@ const ExtractBody = ({
           aria-expanded={advancedOpen}
           onClick={() => setAdvancedOpen((prev) => !prev)}
         >
-          <SlidersHorizontalIcon className="size-3" />
+          <CogIcon className="size-3" />
           {t("knowledge.playbooks.advanced")}
         </InlineAction>
       </div>

--- a/apps/web/src/routes/_protected.knowledge/styles.tsx
+++ b/apps/web/src/routes/_protected.knowledge/styles.tsx
@@ -4,12 +4,12 @@ import type { ChangeEvent, PropsWithChildren, ReactNode } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { createFileRoute, getRouteApi } from "@tanstack/react-router";
 import {
+  CogIcon,
   DownloadIcon,
   FileTextIcon,
   PencilIcon,
   PlusIcon,
   RefreshCwIcon,
-  Settings2Icon,
   Trash2Icon,
   UploadIcon,
 } from "lucide-react";
@@ -225,7 +225,7 @@ const StyleSetsPage = () => {
                   size="icon-xs"
                   variant="ghost"
                 >
-                  <Settings2Icon />
+                  <CogIcon />
                 </Button>
               )}
             </div>
@@ -261,7 +261,7 @@ const StyleSetsPage = () => {
                       size="icon-xs"
                       variant="ghost"
                     >
-                      <Settings2Icon />
+                      <CogIcon />
                     </Button>
                     <Button
                       aria-label={t("common.rename")}

--- a/apps/web/src/routes/_protected.tsx
+++ b/apps/web/src/routes/_protected.tsx
@@ -9,6 +9,7 @@ import {
   useMatch,
 } from "@tanstack/react-router";
 import {
+  CogIcon,
   MessageSquarePlusIcon,
   PanelRightIcon,
   PinIcon,
@@ -46,7 +47,6 @@ import {
 } from "@/components/inspector/inspector-tabs-store";
 import type { InspectorTab } from "@/components/inspector/inspector-tabs-store";
 import { KeyboardShortcutsDialog } from "@/components/keyboard-shortcuts-dialog";
-import { MatterIcon } from "@/components/matter-icon";
 import { AIAvailabilityProvider } from "@/components/require-ai-key";
 import { SelfhostUpdateBanner } from "@/components/selfhost-update-banner";
 import { ShortcutEchoHud } from "@/components/shortcut-echo-hud";
@@ -492,10 +492,7 @@ function ProtectedContent() {
             title={t("workspaces.matterInfo")}
             variant="ghost"
           >
-            <MatterIcon
-              className="size-4"
-              matter={{ id: workspaceId, color: workspace?.color ?? null }}
-            />
+            <CogIcon className="size-4" />
           </Button>
         </>
       )}

--- a/apps/web/src/routes/dev/-components/ui-playground.tsx
+++ b/apps/web/src/routes/dev/-components/ui-playground.tsx
@@ -6,13 +6,13 @@ import {
   BellIcon,
   ChevronDownIcon,
   ClockIcon,
+  CogIcon,
   CopyIcon,
   FileTextIcon,
   FilterIcon,
   LinkIcon,
   MailIcon,
   SearchIcon,
-  SettingsIcon,
   ShieldIcon,
   Trash2Icon,
   UserIcon,
@@ -358,7 +358,7 @@ export function UiPlayground() {
                     Disabled
                   </Button>
                   <Button aria-label="Settings" size="icon" variant="ghost">
-                    <SettingsIcon />
+                    <CogIcon />
                   </Button>
                 </div>
               </PlaygroundSection>

--- a/apps/web/src/routes/onboarding/-components/catalogue-detail-preview.tsx
+++ b/apps/web/src/routes/onboarding/-components/catalogue-detail-preview.tsx
@@ -1,9 +1,9 @@
 import {
   AlertTriangleIcon,
   BanknoteIcon,
+  CogIcon,
   ExternalLinkIcon,
   ScaleIcon,
-  Settings2Icon,
   TagIcon,
   UserIcon,
   XIcon,
@@ -116,7 +116,7 @@ export const CatalogueDetailPreview = ({
                 />
                 <Field
                   ariaLabel={t("onboarding.catalogueDetailSetup")}
-                  icon={Settings2Icon}
+                  icon={CogIcon}
                   value={t(`catalogue.setup.${setupKey(entry.setup)}`)}
                 />
               </div>


### PR DESCRIPTION
Standardize settings and configuration affordances on Lucide Cog.

This updates the account settings entry, matter info control, style-set and playbook configuration actions, catalogue setup metadata, onboarding preview, and UI playground example. Matter identity, filter, sort, and developer-tool icons retain their distinct semantics.