### PR TITLE
feat: fold email history and signatures

### DIFF
--- a/apps/api/src/lib/files/email-to-html.test.ts
+++ b/apps/api/src/lib/files/email-to-html.test.ts
@@ -482,6 +482,41 @@ describe("renderEmailHtml", () => {
     expect(preview.bodyHtml).toContain("Child");
   });
 
+  test("keeps fold markers expanded inside restricted table parents", () => {
+    const tableBodies = [
+      '<table><tbody class="gmail_quote"><tr><td>Section history</td></tr></tbody></table>',
+      '<table><tbody><tr class="gmail_quote"><td>Row history</td></tr></tbody></table>',
+      '<table><tbody><tr><td class="gmail_quote">Cell history</td></tr></tbody></table>',
+    ];
+
+    for (const html of tableBodies) {
+      const preview = buildEmailPreview(
+        htmlEmail({
+          body: { type: "html", html: `<p>Reply</p>${html}` },
+        }),
+      );
+
+      expect(preview.bodyFolds).toEqual([]);
+      expect(preview.bodyHtml).not.toContain("<details");
+      expect(preview.bodyHtml).toContain("history");
+    }
+
+    const flowContentInCell = buildEmailPreview(
+      htmlEmail({
+        body: {
+          type: "html",
+          html: '<p>Reply</p><table><tbody><tr><td><div class="gmail_quote">Nested history</div></td></tr></tbody></table>',
+        },
+      }),
+    );
+    expect(flowContentInCell.bodyFolds).toEqual([
+      { id: "fold-0", kind: "quoted-history" },
+    ]);
+    expect(flowContentInCell.bodyHtml).toContain(
+      '<td><details data-stella-email-fold="quoted-history">',
+    );
+  });
+
   test("folds only trailing plain-text quote runs and standard signatures", () => {
     const body = [
       "Aktuální odpověď",

--- a/apps/api/src/lib/files/email-to-html.test.ts
+++ b/apps/api/src/lib/files/email-to-html.test.ts
@@ -401,6 +401,156 @@ describe("renderEmailHtml", () => {
     expect(preview.bodyHtml).not.toContain("<form");
   });
 
+  test("folds trailing HTML history and signatures without removing content", () => {
+    const preview = buildEmailPreview(
+      htmlEmail({
+        body: {
+          type: "html",
+          html: [
+            "<p>Current reply</p>",
+            '<div class="gmail_signature" data-stella-email-fold="forged">Kind regards<br>Žofie</div>',
+            '<div class="gmail_quote"><blockquote type="cite">Earlier message<script>steal()</script></blockquote></div>',
+          ].join(""),
+        },
+      }),
+    );
+
+    expect(preview.bodyFolds).toEqual([
+      { id: "fold-0", kind: "signature" },
+      { id: "fold-1", kind: "quoted-history" },
+    ]);
+    expect(preview.bodyHtml).toContain(
+      '<details data-stella-email-fold="signature"><summary data-stella-email-fold-summary="fold-0"></summary>',
+    );
+    expect(preview.bodyHtml).toContain(
+      '<details data-stella-email-fold="quoted-history"><summary data-stella-email-fold-summary="fold-1"></summary>',
+    );
+    expect(preview.bodyHtml).toContain("Kind regards<br>Žofie");
+    expect(preview.bodyHtml).toContain("Earlier message");
+    expect(preview.bodyHtml).not.toContain("forged");
+    expect(preview.bodyHtml).not.toContain("<script");
+    expect(preview.bodyHtml).not.toContain("steal()");
+  });
+
+  test("keeps inline replies and quote-only messages expanded", () => {
+    const inlineReply = buildEmailPreview(
+      htmlEmail({
+        body: {
+          type: "html",
+          html: [
+            "<p>First answer</p>",
+            '<blockquote type="cite">Question</blockquote>',
+            "<p>Second answer</p>",
+          ].join(""),
+        },
+      }),
+    );
+    const quoteOnly = buildEmailPreview(
+      htmlEmail({
+        body: {
+          type: "html",
+          html: '<blockquote type="cite"><p>Only quoted content</p></blockquote>',
+        },
+      }),
+    );
+
+    expect(inlineReply.bodyFolds).toEqual([]);
+    expect(inlineReply.bodyHtml).not.toContain("data-stella-email-fold=");
+    expect(inlineReply.bodyHtml).toContain("Question");
+    expect(quoteOnly.bodyFolds).toEqual([]);
+    expect(quoteOnly.bodyHtml).not.toContain("data-stella-email-fold=");
+    expect(quoteOnly.bodyHtml).toContain("Only quoted content");
+  });
+
+  test("creates one fold for nested quoted HTML", () => {
+    const preview = buildEmailPreview(
+      htmlEmail({
+        body: {
+          type: "html",
+          html: '<p>Reply</p><div class="gmail_quote"><blockquote type="cite">Parent<blockquote type="cite">Child</blockquote></blockquote></div>',
+        },
+      }),
+    );
+
+    expect(preview.bodyFolds).toEqual([
+      { id: "fold-0", kind: "quoted-history" },
+    ]);
+    expect(
+      preview.bodyHtml.match(/data-stella-email-fold="quoted-history"/gu),
+    ).toHaveLength(1);
+    expect(preview.bodyHtml).toContain("Parent");
+    expect(preview.bodyHtml).toContain("Child");
+  });
+
+  test("folds only trailing plain-text quote runs and standard signatures", () => {
+    const body = [
+      "Aktuální odpověď",
+      "",
+      "-- ",
+      "Žofie Nováková",
+      "> Předchozí zpráva",
+      "> Druhý řádek",
+    ].join("\r\n");
+    const preview = buildEmailPreview(
+      htmlEmail({ body: { type: "text", text: body } }),
+    );
+
+    expect(preview.bodyFolds).toEqual([
+      { id: "fold-0", kind: "signature" },
+      { id: "fold-1", kind: "quoted-history" },
+    ]);
+    expect(preview.bodyHtml).toContain("Aktuální odpověď");
+    expect(preview.bodyHtml).toContain("Žofie Nováková");
+    expect(preview.bodyHtml).toContain("&gt; Předchozí zpráva");
+    expect(
+      parsedEmailToText(htmlEmail({ body: { type: "text", text: body } })),
+    ).toContain("> Druhý řádek");
+  });
+
+  test("keeps nonstandard and nonterminal plain-text delimiters visible", () => {
+    const nonstandardDelimiter = buildEmailPreview(
+      htmlEmail({
+        body: { type: "text", text: "Reply\n--\nNot a signature" },
+      }),
+    );
+    const inlineQuote = buildEmailPreview(
+      htmlEmail({
+        body: { type: "text", text: "Reply\n> Question\nAnswer" },
+      }),
+    );
+
+    expect(nonstandardDelimiter.bodyFolds).toEqual([]);
+    expect(nonstandardDelimiter.bodyHtml).toContain("--");
+    expect(inlineQuote.bodyFolds).toEqual([]);
+    expect(inlineQuote.bodyHtml).toContain("&gt; Question");
+  });
+
+  test("keeps declared folds and generated markers in exact correspondence", () => {
+    const bodies: ParsedEmail["body"][] = [
+      {
+        type: "html",
+        html: '<p>Reply</p><div class="gmail_signature">Name</div>',
+      },
+      {
+        type: "html",
+        html: '<p>Reply</p><blockquote type="cite">History</blockquote>',
+      },
+      { type: "text", text: "Reply\n-- \nName\n> History" },
+      { type: "text", text: "No folded content" },
+    ];
+
+    for (const body of bodies) {
+      const preview = buildEmailPreview(htmlEmail({ body }));
+      const markerIds = Array.from(
+        preview.bodyHtml.matchAll(
+          /data-stella-email-fold-summary="(?<id>fold-\d+)"/gu,
+        ),
+        (match) => match.groups?.["id"],
+      );
+      expect(markerIds).toEqual(preview.bodyFolds.map(({ id }) => id));
+    }
+  });
+
   test("formats sanitized headers and body text for extraction", () => {
     const text = parsedEmailToText(
       htmlEmail({

--- a/apps/api/src/lib/files/email-to-html.ts
+++ b/apps/api/src/lib/files/email-to-html.ts
@@ -720,11 +720,34 @@ const EMAIL_FOLD_KIND = {
   quote: "quoted-history",
   signature: "signature",
 } as const;
+const EMAIL_FOLD_FLOW_PARENT_TAGS = new Set([
+  "address",
+  "article",
+  "aside",
+  "blockquote",
+  "body",
+  "center",
+  "dd",
+  "details",
+  "dialog",
+  "div",
+  "fieldset",
+  "figcaption",
+  "figure",
+  "footer",
+  "form",
+  "header",
+  "li",
+  "main",
+  "nav",
+  "section",
+  "td",
+  "th",
+]);
 
-export type EmailFoldKind =
-  (typeof EMAIL_FOLD_KIND)[keyof typeof EMAIL_FOLD_KIND];
+type EmailFoldKind = (typeof EMAIL_FOLD_KIND)[keyof typeof EMAIL_FOLD_KIND];
 
-export type EmailBodyFold = {
+type EmailBodyFold = {
   id: string;
   kind: EmailFoldKind;
 };
@@ -859,7 +882,9 @@ const foldQuotedHistoryAndSignatures = ($: CheerioApi): EmailBodyFold[] => {
       id: `fold-${bodyFolds.length}`,
       kind: token.candidate.kind,
     } satisfies EmailBodyFold;
-    wrapEmailFold($, token.candidate, bodyFold.id);
+    if (!wrapEmailFold($, token.candidate, bodyFold.id)) {
+      continue;
+    }
     bodyFolds.push(bodyFold);
   }
   return bodyFolds;
@@ -869,12 +894,22 @@ const wrapEmailFold = (
   $: CheerioApi,
   { element, kind }: EmailFoldCandidate,
   id: string,
-): void => {
+): boolean => {
+  const parent = element.parent;
+  if (
+    !parent ||
+    !isTag(parent) ||
+    !EMAIL_FOLD_FLOW_PARENT_TAGS.has(parent.name)
+  ) {
+    return false;
+  }
+
   const details = $(
     `<details data-stella-email-fold="${kind}"><summary data-stella-email-fold-summary="${id}"></summary></details>`,
   );
   $(element).before(details);
   details.append(element);
+  return true;
 };
 
 type PlainTextSection = {

--- a/apps/api/src/lib/files/email-to-html.ts
+++ b/apps/api/src/lib/files/email-to-html.ts
@@ -13,7 +13,7 @@
  */
 import { Result, TaggedError } from "better-result";
 import { type Cheerio, load } from "cheerio";
-import { type Element, isTag } from "domhandler";
+import { type Element, isTag, isText } from "domhandler";
 import PostalMime, { type Address } from "postal-mime";
 
 import { arrayOrEmpty } from "@/api/lib/array";
@@ -109,6 +109,7 @@ type EmailPreview = {
     mimeType: string | null;
     sizeBytes: number;
   }[];
+  bodyFolds: EmailBodyFold[];
   bodyHtml: string;
 };
 
@@ -173,6 +174,7 @@ export const buildEmailPreview = (parsed: ParsedEmail): EmailPreview => {
         mimeType,
         sizeBytes: bytes.byteLength,
       })),
+    bodyFolds: renderedBody.bodyFolds,
     bodyHtml: renderedBody.bodyHtml,
   };
 };
@@ -497,6 +499,40 @@ body, table, td, div, p, span {
   color: inherit;
   text-decoration: none;
 }
+[data-stella-email-fold] {
+  margin: 8px 0;
+}
+[data-stella-email-fold] > summary {
+  align-items: center;
+  border-radius: 6px;
+  color: #71717a;
+  cursor: pointer;
+  display: inline-flex;
+  justify-content: center;
+  list-style: none;
+  min-height: 44px;
+  min-width: 44px;
+  user-select: none;
+}
+[data-stella-email-fold] > summary:hover {
+  background: #f4f4f5;
+  color: #3f3f46;
+}
+[data-stella-email-fold] > summary::-webkit-details-marker {
+  display: none;
+}
+[data-stella-email-fold-label="open"] {
+  display: none;
+}
+[data-stella-email-fold][open] > summary [data-stella-email-fold-label="closed"] {
+  display: none;
+}
+[data-stella-email-fold][open] > summary [data-stella-email-fold-label="open"] {
+  display: inline;
+}
+[data-stella-email-fold][open] > summary {
+  margin-bottom: 8px;
+}
 `;
 
 export const renderEmailHtml = (parsed: ParsedEmail): string => {
@@ -531,14 +567,17 @@ export const renderEmailHtml = (parsed: ParsedEmail): string => {
  * retained because they describe forwarded message content.
  */
 type RenderedEmailBody = {
+  bodyFolds: EmailBodyFold[];
   bodyHtml: string;
   referencedContentIds: Set<string>;
 };
 
 const renderEmailBody = (parsed: ParsedEmail): RenderedEmailBody => {
   if (parsed.body.type === "text") {
+    const renderedTextBody = renderPlainTextBody(parsed.body.text);
     return {
-      bodyHtml: `<!DOCTYPE html><html><head><meta charset="utf-8"><meta http-equiv="Content-Security-Policy" content="${EMAIL_PREVIEW_CSP}"><meta name="color-scheme" content="light"><style>${EMAIL_PREVIEW_CSS}</style></head><body dir="auto"><pre style="${PRE_STYLE}">${escapeHtml(parsed.body.text)}</pre></body></html>`,
+      bodyFolds: renderedTextBody.bodyFolds,
+      bodyHtml: `<!DOCTYPE html><html><head><meta charset="utf-8"><meta http-equiv="Content-Security-Policy" content="${EMAIL_PREVIEW_CSP}"><meta name="color-scheme" content="light"><style>${EMAIL_PREVIEW_CSS}</style></head><body dir="auto">${renderedTextBody.html}</body></html>`,
       referencedContentIds: new Set(),
     };
   }
@@ -546,6 +585,7 @@ const renderEmailBody = (parsed: ParsedEmail): RenderedEmailBody => {
   const $ = load(parsed.body.html);
   sanitizeDom($);
   stripDuplicateNestedMessageHeaders($);
+  const bodyFolds = foldQuotedHistoryAndSignatures($);
   const referencedContentIds = getReferencedInlineContentIds($);
   inlineCidImages($, parsed.inlineImages);
 
@@ -562,6 +602,7 @@ const renderEmailBody = (parsed: ParsedEmail): RenderedEmailBody => {
   }
 
   return {
+    bodyFolds,
     bodyHtml: `<!DOCTYPE html>${$.html()}`,
     referencedContentIds,
   };
@@ -657,6 +698,45 @@ const SAFE_DATA_IMAGE_RE =
   /^data:image\/(?:png|jpe?g|gif|webp|bmp|tiff);base64,/iu;
 const BR_TAG_RE = /<br\s*\/?>/iu;
 const RFC822_HEADER_LINE_RE = /^[A-Za-z0-9-]+:/u;
+const EMAIL_QUOTE_SELECTOR = [
+  "blockquote[type='cite']",
+  ".gmail_quote",
+  ".protonmail_quote",
+  ".yahoo_quoted",
+  ".zmail_extra",
+  "[data-marker='__QUOTED_TEXT__']",
+].join(",");
+const EMAIL_SIGNATURE_SELECTOR = [
+  "#Signature",
+  "#signature",
+  ".AppleMailSignature",
+  ".gmail_signature",
+  ".moz-signature",
+  ".protonmail_signature_block",
+  ".yahoo_signature",
+].join(",");
+const EMAIL_FOLD_SELECTOR = `${EMAIL_QUOTE_SELECTOR},${EMAIL_SIGNATURE_SELECTOR}`;
+const EMAIL_FOLD_KIND = {
+  quote: "quoted-history",
+  signature: "signature",
+} as const;
+
+export type EmailFoldKind =
+  (typeof EMAIL_FOLD_KIND)[keyof typeof EMAIL_FOLD_KIND];
+
+export type EmailBodyFold = {
+  id: string;
+  kind: EmailFoldKind;
+};
+
+type EmailFoldCandidate = {
+  element: Element;
+  kind: EmailFoldKind;
+};
+
+type EmailBodyToken =
+  | { type: "candidate"; candidate: EmailFoldCandidate }
+  | { type: "content" };
 
 type CheerioApi = ReturnType<typeof load>;
 
@@ -677,6 +757,10 @@ const sanitizeDom = ($: CheerioApi): void => {
     for (const attribute of Object.keys(node.attribs)) {
       const name = attribute.toLowerCase();
       if (PRESENTATION_COLOR_ATTRIBUTES.has(name)) {
+        $(node).removeAttr(attribute);
+        continue;
+      }
+      if (name.startsWith("data-stella-email-fold")) {
         $(node).removeAttr(attribute);
         continue;
       }
@@ -705,6 +789,179 @@ const sanitizeDom = ($: CheerioApi): void => {
       }
     }
   });
+};
+
+const foldQuotedHistoryAndSignatures = ($: CheerioApi): EmailBodyFold[] => {
+  const candidates: EmailFoldCandidate[] = [];
+  $(EMAIL_FOLD_SELECTOR).each((_, element) => {
+    if (!isTag(element) || $(element).parents(EMAIL_FOLD_SELECTOR).length > 0) {
+      return;
+    }
+    candidates.push({
+      element,
+      kind: $(element).is(EMAIL_QUOTE_SELECTOR)
+        ? EMAIL_FOLD_KIND.quote
+        : EMAIL_FOLD_KIND.signature,
+    });
+  });
+
+  if (candidates.length === 0) {
+    return [];
+  }
+
+  const candidateByElement = new Map(
+    candidates.map((candidate) => [candidate.element, candidate]),
+  );
+  const tokens: EmailBodyToken[] = [];
+  const visit = (element: Element): void => {
+    const candidate = candidateByElement.get(element);
+    if (candidate) {
+      tokens.push({ type: "candidate", candidate });
+      return;
+    }
+
+    if (element.name === "img" && nonEmpty($(element).attr("src"))) {
+      tokens.push({ type: "content" });
+    }
+
+    for (const child of element.children) {
+      if (isText(child)) {
+        if (nonEmpty(child.data)) {
+          tokens.push({ type: "content" });
+        }
+        continue;
+      }
+      if (isTag(child)) {
+        visit(child);
+      }
+    }
+  };
+
+  const body = $("body").get(0);
+  if (!body || !isTag(body)) {
+    return [];
+  }
+  visit(body);
+
+  const lastVisibleContentIndex = tokens.findLastIndex(
+    (token) => token.type === "content",
+  );
+  if (lastVisibleContentIndex === -1) {
+    return [];
+  }
+
+  const bodyFolds: EmailBodyFold[] = [];
+  for (const [index, token] of tokens.entries()) {
+    if (token.type !== "candidate" || index < lastVisibleContentIndex) {
+      continue;
+    }
+    const bodyFold = {
+      id: `fold-${bodyFolds.length}`,
+      kind: token.candidate.kind,
+    } satisfies EmailBodyFold;
+    wrapEmailFold($, token.candidate, bodyFold.id);
+    bodyFolds.push(bodyFold);
+  }
+  return bodyFolds;
+};
+
+const wrapEmailFold = (
+  $: CheerioApi,
+  { element, kind }: EmailFoldCandidate,
+  id: string,
+): void => {
+  const details = $(
+    `<details data-stella-email-fold="${kind}"><summary data-stella-email-fold-summary="${id}"></summary></details>`,
+  );
+  $(element).before(details);
+  details.append(element);
+};
+
+type PlainTextSection = {
+  type: "content" | EmailFoldKind;
+  text: string;
+};
+
+type RenderedPlainTextBody = {
+  bodyFolds: EmailBodyFold[];
+  html: string;
+};
+
+const renderPlainTextBody = (text: string): RenderedPlainTextBody => {
+  const sections = splitPlainTextBody(text);
+  const bodyFolds: EmailBodyFold[] = [];
+  const html = sections
+    .map(({ type, text: sectionText }) => {
+      const pre = `<pre style="${PRE_STYLE}">${escapeHtml(sectionText)}</pre>`;
+      if (type === "content") {
+        return pre;
+      }
+      const bodyFold = {
+        id: `fold-${bodyFolds.length}`,
+        kind: type,
+      } satisfies EmailBodyFold;
+      bodyFolds.push(bodyFold);
+      return `<details data-stella-email-fold="${type}"><summary data-stella-email-fold-summary="${bodyFold.id}"></summary>${pre}</details>`;
+    })
+    .join("");
+  return { bodyFolds, html };
+};
+
+const splitPlainTextBody = (text: string): PlainTextSection[] => {
+  const lines = text.split("\n");
+  let quoteStart = lines.length;
+  let foundQuote = false;
+
+  for (let index = lines.length - 1; index >= 0; index--) {
+    const line = lines[index]?.replace(/\r$/u, "") ?? "";
+    if (line.trim().length === 0) {
+      continue;
+    }
+    if (/^\s*>/u.test(line)) {
+      foundQuote = true;
+      quoteStart = index;
+      continue;
+    }
+    break;
+  }
+
+  if (!foundQuote) {
+    quoteStart = lines.length;
+  }
+
+  let signatureStart = -1;
+  for (let index = quoteStart - 1; index > 0; index--) {
+    const line = lines[index]?.replace(/\r$/u, "") ?? "";
+    if (line === "-- ") {
+      signatureStart = index;
+      break;
+    }
+  }
+
+  const firstFoldStart = signatureStart === -1 ? quoteStart : signatureStart;
+  if (firstFoldStart === lines.length) {
+    return [{ type: "content", text }];
+  }
+
+  const visibleText = lines.slice(0, firstFoldStart).join("\n");
+  if (!nonEmpty(visibleText)) {
+    return [{ type: "content", text }];
+  }
+
+  const sections: PlainTextSection[] = [{ type: "content", text: visibleText }];
+  if (signatureStart !== -1) {
+    sections.push({
+      type: EMAIL_FOLD_KIND.signature,
+      text: lines.slice(signatureStart, quoteStart).join("\n"),
+    });
+  }
+  if (foundQuote) {
+    sections.push({
+      type: EMAIL_FOLD_KIND.quote,
+      text: lines.slice(quoteStart).join("\n"),
+    });
+  }
+  return sections;
 };
 
 const stripDuplicateNestedMessageHeaders = ($: CheerioApi): void => {

--- a/apps/web/src/components/inspector/email-html-viewer.logic.test.ts
+++ b/apps/web/src/components/inspector/email-html-viewer.logic.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, test } from "bun:test";
 
 import {
   getEmailAttachmentSize,
+  localizeEmailBodyHtml,
   parseEmailDate,
 } from "@/components/inspector/email-html-viewer.logic";
+import { EMAIL_BODY_FOLD_KIND } from "@/lib/files/email-preview";
 
 describe("email viewer metadata", () => {
   test("rejects missing and malformed dates without throwing", () => {
@@ -35,5 +37,70 @@ describe("email viewer metadata", () => {
       unit: "megabyte",
       value: 1,
     });
+  });
+});
+
+describe("email body fold labels", () => {
+  const labels = {
+    [EMAIL_BODY_FOLD_KIND.quotedHistory]: {
+      hide: "Hide previous messages",
+      show: "Show previous messages",
+    },
+    [EMAIL_BODY_FOLD_KIND.signature]: {
+      hide: "Hide signature",
+      show: "Show signature",
+    },
+  };
+
+  test("localizes every declared marker and escapes labels", () => {
+    const html = localizeEmailBodyHtml({
+      bodyFolds: [
+        { id: "fold-0", kind: "quoted-history" },
+        { id: "fold-1", kind: "signature" },
+      ],
+      bodyHtml:
+        '<details data-stella-email-fold="quoted-history"><summary data-stella-email-fold-summary="fold-0"></summary><blockquote>History</blockquote></details><details data-stella-email-fold="signature"><summary data-stella-email-fold-summary="fold-1"></summary><p>Name</p></details>',
+      labels: {
+        ...labels,
+        [EMAIL_BODY_FOLD_KIND.signature]: {
+          hide: 'Hide "signature"',
+          show: "Show <signature>",
+        },
+      },
+    });
+
+    expect(html).toContain("Show previous messages");
+    expect(html).toContain("Hide previous messages");
+    expect(html).toContain("Show &lt;signature&gt;");
+    expect(html).toContain("Hide &quot;signature&quot;");
+    expect(html).toContain("History");
+    expect(html).toContain("Name");
+  });
+
+  test("rejects missing, extra, and duplicate markers", () => {
+    expect(() =>
+      localizeEmailBodyHtml({
+        bodyFolds: [{ id: "fold-0", kind: "quoted-history" }],
+        bodyHtml: "<p>No marker</p>",
+        labels,
+      }),
+    ).toThrow("Email fold metadata does not match its body markers");
+    expect(() =>
+      localizeEmailBodyHtml({
+        bodyFolds: [],
+        bodyHtml: '<summary data-stella-email-fold-summary="fold-0"></summary>',
+        labels,
+      }),
+    ).toThrow("Email fold metadata does not match its body markers");
+    expect(() =>
+      localizeEmailBodyHtml({
+        bodyFolds: [
+          { id: "fold-0", kind: "signature" },
+          { id: "fold-0", kind: "signature" },
+        ],
+        bodyHtml: '<summary data-stella-email-fold-summary="fold-0"></summary>',
+        labels,
+      }),
+    ).toThrow("Email fold metadata does not match its body markers");
   });
 });

--- a/apps/web/src/components/inspector/email-html-viewer.logic.ts
+++ b/apps/web/src/components/inspector/email-html-viewer.logic.ts
@@ -1,3 +1,10 @@
+import { panic } from "better-result";
+
+import type {
+  EmailBodyFold,
+  EmailBodyFoldKind,
+} from "@/lib/files/email-preview";
+
 export const parseEmailDate = (value: string | null): Date | null => {
   if (!value) {
     return null;
@@ -29,3 +36,58 @@ export const getEmailAttachmentSize = (
 
   return { unit: "gigabyte", value: sizeBytes / (1000 * 1000 * 1000) };
 };
+
+export type EmailBodyFoldLabels = Record<
+  EmailBodyFoldKind,
+  { hide: string; show: string }
+>;
+
+const EMPTY_FOLD_SUMMARY_RE =
+  /<summary data-stella-email-fold-summary="(?<id>fold-\d+)"><\/summary>/gu;
+
+export const localizeEmailBodyHtml = ({
+  bodyFolds,
+  bodyHtml,
+  labels,
+}: {
+  bodyFolds: readonly EmailBodyFold[];
+  bodyHtml: string;
+  labels: EmailBodyFoldLabels;
+}): string => {
+  const markerIds = Array.from(
+    bodyHtml.matchAll(EMPTY_FOLD_SUMMARY_RE),
+    (match) =>
+      match.groups?.["id"] ?? panic("Email fold marker is missing its id"),
+  );
+  const declaredIds = bodyFolds.map(({ id }) => id);
+  if (
+    new Set(markerIds).size !== markerIds.length ||
+    new Set(declaredIds).size !== declaredIds.length ||
+    markerIds.length !== declaredIds.length ||
+    markerIds.some((id) => !declaredIds.includes(id))
+  ) {
+    return panic("Email fold metadata does not match its body markers");
+  }
+
+  let localized = bodyHtml;
+  for (const { id, kind } of bodyFolds) {
+    const marker = `<summary data-stella-email-fold-summary="${id}"></summary>`;
+    const label = labels[kind];
+    const summary = [
+      `<summary data-stella-email-fold-summary="${id}">`,
+      `<span data-stella-email-fold-label="closed">${escapeHtml(label.show)}</span>`,
+      `<span data-stella-email-fold-label="open">${escapeHtml(label.hide)}</span>`,
+      "</summary>",
+    ].join("");
+    localized = localized.replace(marker, () => summary);
+  }
+  return localized;
+};
+
+const escapeHtml = (value: string): string =>
+  value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#039;");

--- a/apps/web/src/components/inspector/email-html-viewer.test.tsx
+++ b/apps/web/src/components/inspector/email-html-viewer.test.tsx
@@ -48,7 +48,9 @@ describe("email viewer", () => {
         },
       ],
       bcc: ["blind@example.org"],
-      bodyHtml: "<p>Message body</p>",
+      bodyFolds: [{ id: "fold-0", kind: "quoted-history" }],
+      bodyHtml:
+        '<p>Message body</p><details data-stella-email-fold="quoted-history"><summary data-stella-email-fold-summary="fold-0"></summary><blockquote>Previous message</blockquote></details>',
       cc: ["copy@example.org"],
       date: "Mon, 02 Jun 2026 10:00:00 +0000",
       from: "Sender <sender@example.org>",
@@ -73,6 +75,9 @@ describe("email viewer", () => {
     expect(html).toContain('sandbox=""');
     expect(html).toContain("srcDoc=");
     expect(html).toContain("Message body");
+    expect(html).toContain("Show previous messages");
+    expect(html).toContain("Hide previous messages");
+    expect(html).toContain("Previous message");
     expect(html).not.toContain("href=");
     expect(html).not.toContain("<button");
   });

--- a/apps/web/src/components/inspector/email-html-viewer.test.tsx
+++ b/apps/web/src/components/inspector/email-html-viewer.test.tsx
@@ -10,6 +10,7 @@ import { EmailHtmlViewer } from "@/components/inspector/email-html-viewer";
 import { FormattingProvider } from "@/i18n/formatting-context";
 import messages from "@/i18n/langs/en.json";
 import type Messages from "@/i18n/langs/messages.gen";
+import { EMAIL_BODY_FOLD_KIND } from "@/lib/files/email-preview";
 import { emailHtmlPreviewOptions } from "@/lib/files/queries";
 
 const FORMATTING_LOCALE = "en-u-nu-arab";
@@ -48,9 +49,12 @@ describe("email viewer", () => {
         },
       ],
       bcc: ["blind@example.org"],
-      bodyFolds: [{ id: "fold-0", kind: "quoted-history" }],
+      bodyFolds: [
+        { id: "fold-0", kind: EMAIL_BODY_FOLD_KIND.quotedHistory },
+        { id: "fold-1", kind: EMAIL_BODY_FOLD_KIND.signature },
+      ],
       bodyHtml:
-        '<p>Message body</p><details data-stella-email-fold="quoted-history"><summary data-stella-email-fold-summary="fold-0"></summary><blockquote>Previous message</blockquote></details>',
+        '<p>Message body</p><details data-stella-email-fold="quoted-history"><summary data-stella-email-fold-summary="fold-0"></summary><blockquote>Previous message</blockquote></details><details data-stella-email-fold="signature"><summary data-stella-email-fold-summary="fold-1"></summary><p>Kind regards</p></details>',
       cc: ["copy@example.org"],
       date: "Mon, 02 Jun 2026 10:00:00 +0000",
       from: "Sender <sender@example.org>",
@@ -78,6 +82,9 @@ describe("email viewer", () => {
     expect(html).toContain("Show previous messages");
     expect(html).toContain("Hide previous messages");
     expect(html).toContain("Previous message");
+    expect(html).toContain("Show signature");
+    expect(html).toContain("Hide signature");
+    expect(html).toContain("Kind regards");
     expect(html).not.toContain("href=");
     expect(html).not.toContain("<button");
   });

--- a/apps/web/src/components/inspector/email-html-viewer.tsx
+++ b/apps/web/src/components/inspector/email-html-viewer.tsx
@@ -11,10 +11,13 @@ import { Skeleton } from "@stll/ui/components/skeleton";
 import { DocumentIcon } from "@/components/document-icon";
 import {
   getEmailAttachmentSize,
+  localizeEmailBodyHtml,
   parseEmailDate,
+  type EmailBodyFoldLabels,
 } from "@/components/inspector/email-html-viewer.logic";
 import { useFormatter } from "@/i18n/formatting-context";
 import { detached } from "@/lib/detached";
+import { EMAIL_BODY_FOLD_KIND } from "@/lib/files/email-preview";
 import { emailHtmlPreviewOptions } from "@/lib/files/queries";
 import { formatFullTimestamp } from "@/lib/relative-time";
 
@@ -79,6 +82,20 @@ export const EmailHtmlViewer = ({
   const hasAdditionalParticipants =
     preview.cc.length > 0 || preview.bcc.length > 0;
   const attachmentKeyOccurrences = new Map<string, number>();
+  const bodyHtml = localizeEmailBodyHtml({
+    bodyFolds: preview.bodyFolds,
+    bodyHtml: preview.bodyHtml,
+    labels: {
+      [EMAIL_BODY_FOLD_KIND.quotedHistory]: {
+        hide: t("emailViewer.hideQuotedHistory"),
+        show: t("emailViewer.showQuotedHistory"),
+      },
+      [EMAIL_BODY_FOLD_KIND.signature]: {
+        hide: t("emailViewer.hideSignature"),
+        show: t("emailViewer.showSignature"),
+      },
+    } satisfies EmailBodyFoldLabels,
+  });
 
   return (
     <article className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
@@ -170,7 +187,7 @@ export const EmailHtmlViewer = ({
           className="bg-background size-full border-0"
           referrerPolicy="no-referrer"
           sandbox=""
-          srcDoc={preview.bodyHtml}
+          srcDoc={bodyHtml}
           title={t("emailViewer.bodyTitle")}
         />
       </div>

--- a/apps/web/src/i18n/langs/ar.json
+++ b/apps/web/src/i18n/langs/ar.json
@@ -1229,7 +1229,11 @@
     "bodyTitle": "محتوى البريد الإلكتروني",
     "cc": "نسخة",
     "from": "المرسل",
+    "hideQuotedHistory": "إخفاء الرسائل السابقة",
+    "hideSignature": "إخفاء التوقيع",
     "noSubject": "(بلا موضوع)",
+    "showQuotedHistory": "عرض الرسائل السابقة",
+    "showSignature": "عرض التوقيع",
     "to": "المستلمون",
     "unnamedAttachment": "مرفق بلا اسم"
   },

--- a/apps/web/src/i18n/langs/cs.json
+++ b/apps/web/src/i18n/langs/cs.json
@@ -1229,7 +1229,11 @@
     "bodyTitle": "Tělo e-mailu",
     "cc": "Kopie",
     "from": "Odesílatel",
+    "hideQuotedHistory": "Skrýt předchozí zprávy",
+    "hideSignature": "Skrýt podpis",
     "noSubject": "(Bez předmětu)",
+    "showQuotedHistory": "Zobrazit předchozí zprávy",
+    "showSignature": "Zobrazit podpis",
     "to": "Příjemci",
     "unnamedAttachment": "Nepojmenovaná příloha"
   },

--- a/apps/web/src/i18n/langs/de.json
+++ b/apps/web/src/i18n/langs/de.json
@@ -1229,7 +1229,11 @@
     "bodyTitle": "E-Mail-Inhalt",
     "cc": "Kopie",
     "from": "Absender",
+    "hideQuotedHistory": "Vorherige Nachrichten ausblenden",
+    "hideSignature": "Signatur ausblenden",
     "noSubject": "(Kein Betreff)",
+    "showQuotedHistory": "Vorherige Nachrichten anzeigen",
+    "showSignature": "Signatur anzeigen",
     "to": "Empfänger",
     "unnamedAttachment": "Unbenannter Anhang"
   },

--- a/apps/web/src/i18n/langs/en.json
+++ b/apps/web/src/i18n/langs/en.json
@@ -1229,7 +1229,11 @@
     "bodyTitle": "Email body",
     "cc": "Cc",
     "from": "Sender",
+    "hideQuotedHistory": "Hide previous messages",
+    "hideSignature": "Hide signature",
     "noSubject": "(No subject)",
+    "showQuotedHistory": "Show previous messages",
+    "showSignature": "Show signature",
     "to": "Recipients",
     "unnamedAttachment": "Unnamed attachment"
   },

--- a/apps/web/src/i18n/langs/es.json
+++ b/apps/web/src/i18n/langs/es.json
@@ -1229,7 +1229,11 @@
     "bodyTitle": "Cuerpo del correo",
     "cc": "Copia",
     "from": "Remitente",
+    "hideQuotedHistory": "Ocultar mensajes anteriores",
+    "hideSignature": "Ocultar firma",
     "noSubject": "(Sin asunto)",
+    "showQuotedHistory": "Mostrar mensajes anteriores",
+    "showSignature": "Mostrar firma",
     "to": "Destinatarios",
     "unnamedAttachment": "Archivo adjunto sin nombre"
   },

--- a/apps/web/src/i18n/langs/et.json
+++ b/apps/web/src/i18n/langs/et.json
@@ -1229,7 +1229,11 @@
     "bodyTitle": "E-kirja sisu",
     "cc": "Koopia",
     "from": "Saatja",
+    "hideQuotedHistory": "Peida varasemad kirjad",
+    "hideSignature": "Peida allkiri",
     "noSubject": "(Teema puudub)",
+    "showQuotedHistory": "Kuva varasemad kirjad",
+    "showSignature": "Kuva allkiri",
     "to": "Saajad",
     "unnamedAttachment": "Nimetu manus"
   },

--- a/apps/web/src/i18n/langs/fr.json
+++ b/apps/web/src/i18n/langs/fr.json
@@ -1229,7 +1229,11 @@
     "bodyTitle": "Corps de l’e-mail",
     "cc": "Copie",
     "from": "Expéditeur",
+    "hideQuotedHistory": "Masquer les messages précédents",
+    "hideSignature": "Masquer la signature",
     "noSubject": "(Sans objet)",
+    "showQuotedHistory": "Afficher les messages précédents",
+    "showSignature": "Afficher la signature",
     "to": "Destinataires",
     "unnamedAttachment": "Pièce jointe sans nom"
   },

--- a/apps/web/src/i18n/langs/hu.json
+++ b/apps/web/src/i18n/langs/hu.json
@@ -1229,7 +1229,11 @@
     "bodyTitle": "E-mail törzse",
     "cc": "Másolat",
     "from": "Feladó",
+    "hideQuotedHistory": "Korábbi üzenetek elrejtése",
+    "hideSignature": "Aláírás elrejtése",
     "noSubject": "(Nincs tárgy)",
+    "showQuotedHistory": "Korábbi üzenetek megjelenítése",
+    "showSignature": "Aláírás megjelenítése",
     "to": "Címzettek",
     "unnamedAttachment": "Névtelen melléklet"
   },

--- a/apps/web/src/i18n/langs/lt.json
+++ b/apps/web/src/i18n/langs/lt.json
@@ -1229,7 +1229,11 @@
     "bodyTitle": "El. laiško tekstas",
     "cc": "Kopija",
     "from": "Siuntėjas",
+    "hideQuotedHistory": "Slėpti ankstesnius laiškus",
+    "hideSignature": "Slėpti parašą",
     "noSubject": "(Nėra temos)",
+    "showQuotedHistory": "Rodyti ankstesnius laiškus",
+    "showSignature": "Rodyti parašą",
     "to": "Gavėjai",
     "unnamedAttachment": "Nepavadintas priedas"
   },

--- a/apps/web/src/i18n/langs/lv.json
+++ b/apps/web/src/i18n/langs/lv.json
@@ -1229,7 +1229,11 @@
     "bodyTitle": "E-pasta pamatteksts",
     "cc": "Kopija",
     "from": "Sūtītājs",
+    "hideQuotedHistory": "Paslēpt iepriekšējos ziņojumus",
+    "hideSignature": "Paslēpt parakstu",
     "noSubject": "(Bez tēmas)",
+    "showQuotedHistory": "Rādīt iepriekšējos ziņojumus",
+    "showSignature": "Rādīt parakstu",
     "to": "Saņēmēji",
     "unnamedAttachment": "Pielikums bez nosaukuma"
   },

--- a/apps/web/src/i18n/langs/messages.gen.ts
+++ b/apps/web/src/i18n/langs/messages.gen.ts
@@ -1232,7 +1232,11 @@ type Messages = {
     "bodyTitle": "Email body";
     "cc": "Cc";
     "from": "Sender";
+    "hideQuotedHistory": "Hide previous messages";
+    "hideSignature": "Hide signature";
     "noSubject": "(No subject)";
+    "showQuotedHistory": "Show previous messages";
+    "showSignature": "Show signature";
     "to": "Recipients";
     "unnamedAttachment": "Unnamed attachment";
   };

--- a/apps/web/src/i18n/langs/pl.json
+++ b/apps/web/src/i18n/langs/pl.json
@@ -1229,7 +1229,11 @@
     "bodyTitle": "Treść e-maila",
     "cc": "DW",
     "from": "Nadawca",
+    "hideQuotedHistory": "Ukryj poprzednie wiadomości",
+    "hideSignature": "Ukryj podpis",
     "noSubject": "(Brak tematu)",
+    "showQuotedHistory": "Pokaż poprzednie wiadomości",
+    "showSignature": "Pokaż podpis",
     "to": "Odbiorcy",
     "unnamedAttachment": "Nienazwany załącznik"
   },

--- a/apps/web/src/i18n/langs/pt-BR.json
+++ b/apps/web/src/i18n/langs/pt-BR.json
@@ -1229,7 +1229,11 @@
     "bodyTitle": "Corpo do e-mail",
     "cc": "Cópia",
     "from": "Remetente",
+    "hideQuotedHistory": "Ocultar mensagens anteriores",
+    "hideSignature": "Ocultar assinatura",
     "noSubject": "(Sem assunto)",
+    "showQuotedHistory": "Mostrar mensagens anteriores",
+    "showSignature": "Mostrar assinatura",
     "to": "Destinatários",
     "unnamedAttachment": "Anexo sem nome"
   },

--- a/apps/web/src/i18n/langs/sk.json
+++ b/apps/web/src/i18n/langs/sk.json
@@ -1229,7 +1229,11 @@
     "bodyTitle": "Telo e-mailu",
     "cc": "Kópia",
     "from": "Odosielateľ",
+    "hideQuotedHistory": "Skryť predchádzajúce správy",
+    "hideSignature": "Skryť podpis",
     "noSubject": "(Bez predmetu)",
+    "showQuotedHistory": "Zobraziť predchádzajúce správy",
+    "showSignature": "Zobraziť podpis",
     "to": "Príjemcovia",
     "unnamedAttachment": "Nepomenovaná príloha"
   },

--- a/apps/web/src/lib/files/email-preview.ts
+++ b/apps/web/src/lib/files/email-preview.ts
@@ -1,0 +1,12 @@
+export const EMAIL_BODY_FOLD_KIND = {
+  quotedHistory: "quoted-history",
+  signature: "signature",
+} as const;
+
+export type EmailBodyFoldKind =
+  (typeof EMAIL_BODY_FOLD_KIND)[keyof typeof EMAIL_BODY_FOLD_KIND];
+
+export type EmailBodyFold = {
+  id: string;
+  kind: EmailBodyFoldKind;
+};

--- a/apps/web/src/lib/files/queries.ts
+++ b/apps/web/src/lib/files/queries.ts
@@ -2,6 +2,7 @@ import { queryOptions } from "@tanstack/react-query";
 
 import { api } from "@/lib/api";
 import { unwrapEden } from "@/lib/errors/api";
+import type { EmailBodyFold } from "@/lib/files/email-preview";
 import {
   fileContentQueryKey,
   fileMetadataQueryKey,
@@ -33,6 +34,7 @@ type EmailHtmlPreviewData = {
     mimeType: string | null;
     sizeBytes: number;
   }[];
+  bodyFolds: EmailBodyFold[];
   bodyHtml: string;
 };
 
@@ -112,6 +114,7 @@ export const emailHtmlPreviewOptions = (props: FileOptionsProps) =>
         bcc: data.bcc,
         date: data.date,
         attachments: data.attachments,
+        bodyFolds: data.bodyFolds,
         bodyHtml: data.bodyHtml,
       } satisfies EmailHtmlPreviewData;
     },


### PR DESCRIPTION
## Summary

- fold trailing quoted history and signatures without removing sanitized content
- preserve inline replies and quote-only messages with native keyboard-accessible disclosures
- localize disclosure labels and bind response metadata to generated iframe markers
- retain the existing sandbox and content-security boundary while stripping reserved markers from input

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Email previews now collapse quoted message history and trailing signatures.
  * Added translated show/hide controls across supported languages.
  * Preserved email content while improving readability of long conversations.

* **Bug Fixes**
  * Improved handling of collapsible sections in HTML and plain-text emails.
  * Prevented unsafe or malformed fold markers from being rendered.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->