### PR TITLE
fix: repair overnight action failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -913,6 +913,62 @@ jobs:
             bun run check:result-consumption -- --base "origin/$BASE_REF"
           fi
 
+  # These suites use Postgres behavior that PGlite cannot reproduce (partial
+  # indexes, advisory locks, roles, and policies). The runner derives its file
+  # set from the gate each suite declares; PR and nightly coverage therefore
+  # share one source of truth instead of mirrored YAML manifests.
+  postgres-suites:
+    needs: ci-plan
+    if: >-
+      needs.ci-plan.outputs.package_checks_required == 'true'
+      && (needs.ci-plan.outputs.trusted == 'true'
+          || github.event_name == 'workflow_dispatch')
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+
+    services:
+      postgres:
+        image: postgres:18.3
+        env:
+          POSTGRES_USER: stella
+          POSTGRES_PASSWORD: stella
+          POSTGRES_DB: stella
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U stella -d stella"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Bun
+        uses: stella/.github/actions/setup-bun-cached@859a61ee0a799ba1028281329555cadee15bfc4f
+
+      - name: Install dependencies
+        run: bash scripts/bun-ci-retry.sh --ignore-scripts
+        env:
+          NPM_TOKEN: ""
+
+      - name: Apply migrations to service Postgres
+        working-directory: apps/api
+        env:
+          DATABASE_URL: postgres://stella:stella@127.0.0.1:5432/stella
+        run: bun run src/db/migrate.ts
+
+      - name: Run Postgres-gated API suites
+        working-directory: apps/api
+        env:
+          DATABASE_URL: postgres://stella:stella@127.0.0.1:5432/stella
+        run: bun run test:postgres
+
   # Typecheck-cost baseline guard. What silently rots is the compiler's
   # workload: an annotation-heavy or inference-exploding pattern in a hot
   # generic path (Eden surface, route trees, query options) lands as
@@ -1887,6 +1943,7 @@ jobs:
         agent-sandbox-docker,
         ci-checks,
         code-quality,
+        postgres-suites,
         typecheck-baseline,
         web-build,
         mobile-build,
@@ -1918,6 +1975,7 @@ jobs:
           OCR_IMAGE_RESULT: ${{ needs.ocr-image.result }}
           TRUSTED: ${{ needs.ci-plan.outputs.trusted }}
           PLAN_RESULT: ${{ needs.ci-plan.result }}
+          POSTGRES_SUITES_RESULT: ${{ needs.postgres-suites.result }}
           TYPECHECK_BASELINE_RESULT: ${{ needs.typecheck-baseline.result }}
           WEB_RESULT: ${{ needs.web-build.result }}
           WINDOWS_SCRIPTS_RESULT: ${{ needs.windows-scripts.result }}
@@ -1934,6 +1992,7 @@ jobs:
             if [[ "$CI_RESULT" == "failure" || "$CI_RESULT" == "cancelled" \
                   || "$AGENT_SANDBOX_DOCKER_RESULT" == "failure" || "$AGENT_SANDBOX_DOCKER_RESULT" == "cancelled" \
                   || "$CODE_QUALITY_RESULT" == "failure" || "$CODE_QUALITY_RESULT" == "cancelled" \
+                  || "$POSTGRES_SUITES_RESULT" == "failure" || "$POSTGRES_SUITES_RESULT" == "cancelled" \
                   || "$TYPECHECK_BASELINE_RESULT" == "failure" || "$TYPECHECK_BASELINE_RESULT" == "cancelled" \
                   || "$WEB_RESULT" == "failure" || "$WEB_RESULT" == "cancelled" \
                   || "$MOBILE_RESULT" == "failure" || "$MOBILE_RESULT" == "cancelled" \
@@ -1969,12 +2028,12 @@ jobs:
 
           # "cancelled" means cancel-in-progress replaced this
           # run with a newer one; the newer run is authoritative.
-          if [[ "$AGENT_SANDBOX_DOCKER_RESULT" == "cancelled" || "$CI_RESULT" == "cancelled" || "$CODE_QUALITY_RESULT" == "cancelled" || "$TYPECHECK_BASELINE_RESULT" == "cancelled" || "$WEB_RESULT" == "cancelled" || "$MOBILE_RESULT" == "cancelled" || "$LANDING_RESULT" == "cancelled" || "$E2E_RESULT" == "cancelled" || "$API_IMAGE_DEPS_RESULT" == "cancelled" || "$OCR_IMAGE_RESULT" == "cancelled" || "$LEGAL_ATLAS_IMAGE_RESULT" == "cancelled" || "$WINDOWS_SCRIPTS_RESULT" == "cancelled" || "$CHANGESET_RESULT" == "cancelled" || "$DESKTOP_CLIPPY_RESULT" == "cancelled" ]]; then
+          if [[ "$AGENT_SANDBOX_DOCKER_RESULT" == "cancelled" || "$CI_RESULT" == "cancelled" || "$CODE_QUALITY_RESULT" == "cancelled" || "$POSTGRES_SUITES_RESULT" == "cancelled" || "$TYPECHECK_BASELINE_RESULT" == "cancelled" || "$WEB_RESULT" == "cancelled" || "$MOBILE_RESULT" == "cancelled" || "$LANDING_RESULT" == "cancelled" || "$E2E_RESULT" == "cancelled" || "$API_IMAGE_DEPS_RESULT" == "cancelled" || "$OCR_IMAGE_RESULT" == "cancelled" || "$LEGAL_ATLAS_IMAGE_RESULT" == "cancelled" || "$WINDOWS_SCRIPTS_RESULT" == "cancelled" || "$CHANGESET_RESULT" == "cancelled" || "$DESKTOP_CLIPPY_RESULT" == "cancelled" ]]; then
             echo "CI run was superseded by a newer run (cancel-in-progress). Passing."
             exit 0
           fi
 
-          if [[ "$AGENT_SANDBOX_DOCKER_RESULT" == "failure" || "$CI_RESULT" == "failure" || "$CODE_QUALITY_RESULT" == "failure" || "$TYPECHECK_BASELINE_RESULT" == "failure" || "$WEB_RESULT" == "failure" || "$MOBILE_RESULT" == "failure" || "$LANDING_RESULT" == "failure" || "$E2E_RESULT" == "failure" || "$API_IMAGE_DEPS_RESULT" == "failure" || "$OCR_IMAGE_RESULT" == "failure" || "$LEGAL_ATLAS_IMAGE_RESULT" == "failure" || "$WINDOWS_SCRIPTS_RESULT" == "failure" || "$CHANGESET_RESULT" == "failure" || "$DESKTOP_CLIPPY_RESULT" == "failure" ]]; then
+          if [[ "$AGENT_SANDBOX_DOCKER_RESULT" == "failure" || "$CI_RESULT" == "failure" || "$CODE_QUALITY_RESULT" == "failure" || "$POSTGRES_SUITES_RESULT" == "failure" || "$TYPECHECK_BASELINE_RESULT" == "failure" || "$WEB_RESULT" == "failure" || "$MOBILE_RESULT" == "failure" || "$LANDING_RESULT" == "failure" || "$E2E_RESULT" == "failure" || "$API_IMAGE_DEPS_RESULT" == "failure" || "$OCR_IMAGE_RESULT" == "failure" || "$LEGAL_ATLAS_IMAGE_RESULT" == "failure" || "$WINDOWS_SCRIPTS_RESULT" == "failure" || "$CHANGESET_RESULT" == "failure" || "$DESKTOP_CLIPPY_RESULT" == "failure" ]]; then
             echo "::error::CI checks failed."
             exit 1
           fi

--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -271,10 +271,11 @@ jobs:
 
   # Postgres-backed API suites that gate on STELLA_RUN_POSTGRES_TESTS=true and a
   # real DATABASE_URL. The plain `bun run test` above skips them (they no-op in
-  # the skip branch), so they only ever execute here against a service Postgres
-  # with migrations applied. Failures are real regressions (pool isolation,
-  # JSONB persistence), so this job is kept separate from the network smoke
-  # canary below whose failures mean "upstream changed", not "we broke something".
+  # the skip branch); the shared runner executes them here and in required PR
+  # CI against a service Postgres with migrations applied. Failures are real
+  # regressions (pool isolation, JSONB persistence), so this job is kept
+  # separate from the network smoke canary below whose failures mean "upstream
+  # changed", not "we broke something".
   postgres-suites:
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -326,20 +327,9 @@ jobs:
         working-directory: apps/api
         env:
           DATABASE_URL: postgres://stella:stella@127.0.0.1:5432/stella
-          STELLA_RUN_POSTGRES_TESTS: "true"
-        # setup-env.ts supplies the remaining test env via `??=`; the explicit
-        # DATABASE_URL above wins. These files never call `mock.module`, so a
-        # shared process is fine.
-        run: >-
-          bun test --preload ./src/tests/setup-env.ts
-          src/db/root.test.ts
-          src/handlers/case-law/decisions/get-document-state.db.test.ts
-          src/handlers/case-law/ingestion/pipeline.db.test.ts
-          src/handlers/case-law/ingestion/pipeline-identity.db.test.ts
-          src/handlers/case-law/ingestion/pipeline-refresh.db.test.ts
-          src/handlers/case-law/ingestion/sk-document-backfill.db.test.ts
-          src/handlers/case-law/ingestion/sk-document-backfill-corpus.db.test.ts
-          src/lib/scheduler/tasks/case-law-redaction-tombstone-backfill.db.test.ts
+        # The runner discovers every suite that declares the Postgres gate, so
+        # adding a gated test cannot silently omit it from this workflow.
+        run: bun run test:postgres
 
   # Upstream-API drift canary for the CJEU adapter. Hits live Cellar SPARQL +
   # EUR-Lex endpoints, so a failure most often means an upstream schema/endpoint

--- a/.github/workflows/scheduled-run-alerts.yml
+++ b/.github/workflows/scheduled-run-alerts.yml
@@ -1,6 +1,8 @@
 name: Scheduled run alerts
 
 on:
+  # Deliberate delivery test after configuring or rotating webhook credentials.
+  workflow_dispatch:
   workflow_run:
     workflows:
       - Nightly Full Test
@@ -16,7 +18,9 @@ permissions: {}
 
 jobs:
   notify:
-    if: github.event.workflow_run.conclusion == 'failure'
+    if: >-
+      github.event_name == 'workflow_dispatch'
+      || github.event.workflow_run.conclusion == 'failure'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -25,11 +29,12 @@ jobs:
           WEBHOOK_URL: ${{ secrets.SCHEDULED_ALERTS_WEBHOOK_URL }}
           WEBHOOK_TOKEN: ${{ secrets.SCHEDULED_ALERTS_WEBHOOK_TOKEN }}
           WEBHOOK_HEADERS: ${{ secrets.SCHEDULED_ALERTS_WEBHOOK_HEADERS }}
-          WORKFLOW_NAME: ${{ github.event.workflow_run.name }}
-          RUN_URL: ${{ github.event.workflow_run.html_url }}
-          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
-          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
-          RUN_EVENT: ${{ github.event.workflow_run.event }}
+          ALERT_KIND: ${{ github.event_name == 'workflow_dispatch' && 'Alert delivery test' || 'Failed workflow' }}
+          WORKFLOW_NAME: ${{ github.event.workflow_run.name || github.workflow }}
+          RUN_URL: ${{ github.event.workflow_run.html_url || format('{0}/{1}/actions/runs/{2}', github.server_url, github.repository, github.run_id) }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch || github.ref_name }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
+          RUN_EVENT: ${{ github.event.workflow_run.event || github.event_name }}
         run: |
           if [ -z "$WEBHOOK_URL" ]; then
             echo "::error::scheduled-run alert webhook URL is not configured"
@@ -50,7 +55,7 @@ jobs:
             echo "::error::scheduled-run alert webhook credentials are not configured"
             exit 1
           fi
-          jq -n --arg text "Failed workflow: $WORKFLOW_NAME (event: $RUN_EVENT, branch: $HEAD_BRANCH, head sha: $HEAD_SHA). Run: $RUN_URL" '{text: $text}' |
+          jq -n --arg text "$ALERT_KIND: $WORKFLOW_NAME (event: $RUN_EVENT, branch: $HEAD_BRANCH, head sha: $HEAD_SHA). Run: $RUN_URL" '{text: $text}' |
             curl --fail-with-body -sS -X POST \
               -H "content-type: application/json" \
               "${header_args[@]}" \

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -10,6 +10,7 @@
     "build": "bun run build:mcp-apps",
     "build:mcp-apps": "MCP_APP_INPUT=app.html vite build --config scripts/mcp-app.vite.config.ts",
     "test": "bun scripts/run-tests.ts",
+    "test:postgres": "bun scripts/run-postgres-tests.ts",
     "test:property": "bun scripts/run-tests.ts --property",
     "dev": "bun run docker:dev && NODE_ENV=development bun --port 3001 --preload ./src/dev/register-mock-ai.ts --watch src/server.ts",
     "docker:dev": "docker compose --profile dev up -d",

--- a/apps/api/scripts/run-postgres-tests.ts
+++ b/apps/api/scripts/run-postgres-tests.ts
@@ -1,0 +1,61 @@
+import path from "node:path";
+
+const POSTGRES_TEST_MARKER = "STELLA_RUN_POSTGRES_TESTS";
+const TEST_FILE_GLOB = "src/**/*.test.{ts,tsx}";
+const apiRoot = path.resolve(import.meta.dir, "..");
+
+if (!process.env["DATABASE_URL"]) {
+  console.error("DATABASE_URL is required for Postgres-gated tests.");
+  process.exit(1);
+}
+
+const discoveredTests = [
+  ...new Bun.Glob(TEST_FILE_GLOB).scanSync({
+    cwd: apiRoot,
+    onlyFiles: true,
+  }),
+];
+const testFiles = (
+  await Promise.all(
+    discoveredTests.map(async (testFile) => ({
+      isPostgresTest: (
+        await Bun.file(path.join(apiRoot, testFile)).text()
+      ).includes(POSTGRES_TEST_MARKER),
+      testFile,
+    })),
+  )
+)
+  .filter(({ isPostgresTest }) => isPostgresTest)
+  .map(({ testFile }) => testFile)
+  .sort();
+
+if (testFiles.length === 0) {
+  console.error(
+    `No test files declaring ${POSTGRES_TEST_MARKER} were discovered.`,
+  );
+  process.exit(1);
+}
+
+console.log(`Running ${String(testFiles.length)} Postgres-gated test files.`);
+const testProcess = Bun.spawn({
+  cmd: [
+    process.execPath,
+    "test",
+    // Keep suites isolated from one another's connection pools. Tests that
+    // exercise concurrency still do so internally, without runner-load races.
+    "--max-concurrency=1",
+    "--preload",
+    "./src/tests/setup-env.ts",
+    ...testFiles,
+  ],
+  cwd: apiRoot,
+  env: {
+    ...process.env,
+    STELLA_RUN_POSTGRES_TESTS: "true",
+  },
+  stdin: "inherit",
+  stdout: "inherit",
+  stderr: "inherit",
+});
+
+process.exitCode = await testProcess.exited;

--- a/apps/api/src/handlers/case-law/ingestion/pipeline-identity.db.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/pipeline-identity.db.test.ts
@@ -316,7 +316,13 @@ if (!databaseUrl || !runPostgresTests) {
       });
       await db
         .update(caseLawDecisions)
-        .set({ redactedAt: new Date("2026-07-31T12:00:01.000Z") })
+        .set({
+          contentHash: null,
+          documentAst: null,
+          fulltext: null,
+          redactedAt: new Date("2026-07-31T12:00:01.000Z"),
+          sections: null,
+        })
         .where(
           and(
             eq(caseLawDecisions.sourceId, sourceId),
@@ -1287,29 +1293,23 @@ if (!databaseUrl || !runPostgresTests) {
       const firstScopedDb: ScopedDb = async (transactionWork) => {
         const call = firstCallCount;
         firstCallCount += 1;
-        return await scopedDb(async (tx) => {
-          if (call === 0) {
-            const result = await transactionWork(tx);
-            await synchronizeInitialRead();
-            return result;
-          }
-          return await transactionWork(tx);
-        });
+        const result = await scopedDb(async (tx) => await transactionWork(tx));
+        if (call === 0) {
+          await synchronizeInitialRead();
+        }
+        return result;
       };
 
       let secondCallCount = 0;
       const secondScopedDb: ScopedDb = async (transactionWork) => {
         const call = secondCallCount;
         secondCallCount += 1;
-        return await scopedDb(async (tx) => {
-          if (call === 0) {
-            const result = await transactionWork(tx);
-            await synchronizeInitialRead();
-            await firstWriteCompleted;
-            return result;
-          }
-          return await transactionWork(tx);
-        });
+        const result = await scopedDb(async (tx) => await transactionWork(tx));
+        if (call === 0) {
+          await synchronizeInitialRead();
+          await firstWriteCompleted;
+        }
+        return result;
       };
 
       // Gate the second writer on the first writer finishing, not on a

--- a/apps/api/src/handlers/case-law/ingestion/pipeline.ts
+++ b/apps/api/src/handlers/case-law/ingestion/pipeline.ts
@@ -571,6 +571,8 @@ type CaseLawDecisionIdentityOptions = Pick<
   "caseNumber" | "language" | "sourceDocumentId"
 > & { sourceId: SafeId<"caseLawSource"> };
 
+const NULL_SOURCE_DOCUMENT_ID_FILTER = { isNull: true } as const;
+
 /** Match exactly the two partial unique indexes that define source identity. */
 const caseLawDecisionIdentityWhere = ({
   caseNumber,
@@ -584,6 +586,7 @@ const caseLawDecisionIdentityWhere = ({
         sourceId: { eq: sourceId },
         caseNumber,
         language,
+        sourceDocumentId: NULL_SOURCE_DOCUMENT_ID_FILTER,
       };
 
 /**

--- a/apps/api/src/mcp/constants.ts
+++ b/apps/api/src/mcp/constants.ts
@@ -80,6 +80,13 @@ export const MCP_ANONYMIZED_HTTP_PATH = "/mcp-anonymized";
  */
 export const MCP_STATELESS_ALLOW_HEADER = "OPTIONS, GET, POST";
 
+/**
+ * The first frame on an otherwise idle notification stream. Keep this well
+ * below edge/request deadlines: the canary derives its fetch timeout from the
+ * same value, so transport and observer cannot silently drift apart.
+ */
+export const MCP_NOTIFICATION_KEEP_ALIVE_MS = 5000;
+
 export const ROOT_MCP_DISCOVERY_PATH =
   "/.well-known/oauth-protected-resource" as const;
 

--- a/apps/api/src/mcp/server-core.ts
+++ b/apps/api/src/mcp/server-core.ts
@@ -17,6 +17,7 @@ import { panic } from "better-result";
 import { detached } from "@/api/lib/detached";
 import type { McpSession } from "@/api/mcp/auth";
 import {
+  MCP_NOTIFICATION_KEEP_ALIVE_MS,
   MCP_STATELESS_ALLOW_HEADER,
   type McpMode,
   STELLA_MCP_ORGANIZATION_HEADER,
@@ -515,6 +516,7 @@ export const createMcpHttpRequestHandler = ({
     const server = await createMcpServer({ clientIp, mode, request, session });
     const transport = new WebStandardStreamableHTTPServerTransport({
       enableJsonResponse: true,
+      keepAliveMs: MCP_NOTIFICATION_KEEP_ALIVE_MS,
     });
     const reportTransportError = (error: unknown, operation: string) => {
       captureError(error, {

--- a/apps/api/src/scripts/mcp-canary.test.ts
+++ b/apps/api/src/scripts/mcp-canary.test.ts
@@ -11,6 +11,7 @@ import {
   evaluateToolsList,
   evaluateUnauthenticated,
   runAuthenticatedStreamProbe,
+  runNamedProbe,
   summarize,
 } from "./mcp-canary";
 
@@ -290,4 +291,53 @@ describe("skip reporting", () => {
 
     expect(summary).toEqual({ failed: 1, skipped: 1 });
   });
+});
+
+describe("probe failure reporting", () => {
+  test("attributes a timeout to its probe without printing exception details", async () => {
+    const result = await runNamedProbe("GET /mcp", async () => {
+      throw new DOMException(
+        "request URL and credentials must not reach diagnostics",
+        "TimeoutError",
+      );
+    });
+
+    expect(result).toEqual({
+      detail: "request timed out after 20000 ms",
+      name: "GET /mcp",
+      status: "failed",
+    });
+  });
+
+  test.each([
+    [
+      "an abort",
+      new DOMException("credentials must not reach diagnostics", "AbortError"),
+      "request was aborted",
+    ],
+    [
+      "a network failure",
+      new TypeError("credentials must not reach diagnostics"),
+      "network request failed",
+    ],
+    [
+      "an unknown thrown value",
+      "credentials must not reach diagnostics",
+      "probe threw an unknown error",
+    ],
+  ] as const)(
+    "attributes %s to its probe without printing exception details",
+    async (_classification, error, detail) => {
+      const result = await runNamedProbe("GET /mcp", async () => {
+        // eslint-disable-next-line typescript/only-throw-error -- exercises the unknown rejection branch
+        throw error;
+      });
+
+      expect(result).toEqual({
+        detail,
+        name: "GET /mcp",
+        status: "failed",
+      });
+    },
+  );
 });

--- a/apps/api/src/scripts/mcp-canary.ts
+++ b/apps/api/src/scripts/mcp-canary.ts
@@ -27,9 +27,13 @@ import {
 import * as v from "valibot";
 
 import { fetchWithTimeout } from "@/api/lib/fetch";
-import { MCP_DISCOVERY_PATH, MCP_HTTP_PATH } from "@/api/mcp/constants";
+import {
+  MCP_DISCOVERY_PATH,
+  MCP_HTTP_PATH,
+  MCP_NOTIFICATION_KEEP_ALIVE_MS,
+} from "@/api/mcp/constants";
 
-const PROBE_TIMEOUT_MS = 20_000;
+const PROBE_TIMEOUT_MS = MCP_NOTIFICATION_KEEP_ALIVE_MS * 4;
 const STREAM_OPEN_OBSERVATION_MS = 100;
 const SSE_CONTENT_TYPE = "text/event-stream";
 const CANARY_CLIENT_NAME = "stella-mcp-canary";
@@ -61,6 +65,34 @@ const failed = (name: string, detail: string): ProbeResult => ({
   status: PROBE_STATUS.failed,
   detail,
 });
+
+const describeProbeFailure = (error: unknown): string => {
+  if (error instanceof DOMException) {
+    if (error.name === "TimeoutError") {
+      return `request timed out after ${String(PROBE_TIMEOUT_MS)} ms`;
+    }
+    if (error.name === "AbortError") {
+      return "request was aborted";
+    }
+    return "request failed (DOMException)";
+  }
+  if (error instanceof TypeError) {
+    return "network request failed";
+  }
+  return `probe threw ${error instanceof Error ? error.constructor.name : "an unknown error"}`;
+};
+
+/** Convert every transport exception into a named, credential-safe result. */
+export const runNamedProbe = async (
+  name: string,
+  operation: () => Promise<ProbeResult>,
+): Promise<ProbeResult> => {
+  try {
+    return await operation();
+  } catch (error) {
+    return failed(name, describeProbeFailure(error));
+  }
+};
 
 const skipped = (name: string, detail: string): ProbeResult => ({
   name,
@@ -291,31 +323,39 @@ const postJsonRpc = async (call: JsonRpcCall): Promise<ProbeResponse> =>
     }),
   );
 
-const runPublicProbes = async (baseUrl: string): Promise<ProbeResult[]> => {
-  const discovery = await readProbeResponse(
-    await fetchWithTimeout(new URL(MCP_DISCOVERY_PATH, baseUrl), {
-      headers: { accept: "application/json" },
-      method: "GET",
-      timeoutMs: PROBE_TIMEOUT_MS,
-    }),
-  );
-  const unauthenticated = await readProbeResponse(
-    await fetchWithTimeout(new URL(MCP_HTTP_PATH, baseUrl), {
-      body: JSON.stringify({ id: 1, jsonrpc: "2.0", method: "tools/list" }),
-      headers: {
-        accept: "application/json, text/event-stream",
-        "content-type": "application/json",
-      },
-      method: "POST",
-      timeoutMs: PROBE_TIMEOUT_MS,
-    }),
-  );
-
-  return [
-    evaluateDiscovery(discovery),
-    evaluateUnauthenticated(unauthenticated),
-  ];
-};
+const runPublicProbes = async (baseUrl: string): Promise<ProbeResult[]> =>
+  await Promise.all([
+    runNamedProbe(PROBE_NAMES.discovery, async () =>
+      evaluateDiscovery(
+        await readProbeResponse(
+          await fetchWithTimeout(new URL(MCP_DISCOVERY_PATH, baseUrl), {
+            headers: { accept: "application/json" },
+            method: "GET",
+            timeoutMs: PROBE_TIMEOUT_MS,
+          }),
+        ),
+      ),
+    ),
+    runNamedProbe(PROBE_NAMES.unauthenticated, async () =>
+      evaluateUnauthenticated(
+        await readProbeResponse(
+          await fetchWithTimeout(new URL(MCP_HTTP_PATH, baseUrl), {
+            body: JSON.stringify({
+              id: 1,
+              jsonrpc: "2.0",
+              method: "tools/list",
+            }),
+            headers: {
+              accept: "application/json, text/event-stream",
+              "content-type": "application/json",
+            },
+            method: "POST",
+            timeoutMs: PROBE_TIMEOUT_MS,
+          }),
+        ),
+      ),
+    ),
+  ]);
 
 export type CanaryTarget = { baseUrl: string; token: string };
 export type CanaryFetcher = typeof fetchWithTimeout;
@@ -458,7 +498,10 @@ const runAuthenticatedProbes = async (
   target: CanaryTarget,
 ): Promise<ProbeResult[]> =>
   await Promise.all(
-    AUTHENTICATED_PROBES.map(async ({ run }) => await run(target)),
+    AUTHENTICATED_PROBES.map(
+      async ({ name, run }) =>
+        await runNamedProbe(name, async () => await run(target)),
+    ),
   );
 
 export const summarize = (results: readonly ProbeResult[]) => ({


### PR DESCRIPTION
Fixes the case-law identity regression and MCP stream heartbeat race.

Also moves Postgres-gated suites into required PR CI and adds a manual scheduled-alert delivery check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved case-law ingestion handling for redacted and source-less records.
  * Prevented individual MCP connectivity failures from stopping the complete health check.
  * Standardised timeout reporting without exposing sensitive error details.

* **Reliability**
  * Added keep-alive messages for idle MCP notification streams.
  * Expanded PostgreSQL test coverage in required continuous integration checks.

* **Monitoring**
  * Added support for manually testing scheduled alert delivery.
  * Improved alert labelling and fallback information for failed workflow notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->