### PR TITLE
fix: skip browser jobs on registry rate limits

### DIFF
--- a/.github/actions/setup-e2e-stack/action.yml
+++ b/.github/actions/setup-e2e-stack/action.yml
@@ -11,6 +11,11 @@ inputs:
     required: false
     default: ""
 
+outputs:
+  status:
+    description: Whether the E2E stack is ready or Docker Hub rate-limited the pull
+    value: ${{ steps.stack.outputs.status }}
+
 runs:
   using: composite
   steps:
@@ -41,6 +46,7 @@ runs:
         password: ${{ inputs.dockerhub-token }}
 
     - name: Start docker stack
+      id: stack
       # `--wait` only on long-running services; `minio-setup` is a one-shot
       # bucket-creator container that exits 0, which `--wait` treats as
       # "not running" and fails the whole command. Run it separately in
@@ -52,11 +58,27 @@ runs:
       # stack does not poison the retry.
       shell: bash
       run: |
+        stack_log=$(mktemp)
+        trap 'rm -f "$stack_log"' EXIT
+
         for attempt in 1 2 3; do
-          if docker compose --profile dev up -d --wait postgres minio valkey \
-            && docker compose --profile dev run --rm --no-deps minio-setup; then
+          : > "$stack_log"
+          if docker compose --profile dev up -d --wait postgres minio valkey 2>&1 \
+            | tee "$stack_log" \
+            && docker compose --profile dev run --rm --no-deps minio-setup 2>&1 \
+              | tee -a "$stack_log"; then
+            echo "status=ready" >> "$GITHUB_OUTPUT"
             exit 0
           fi
+
+          if grep -Eqi 'toomanyrequests:.*pull rate limit' "$stack_log"; then
+            echo "::warning::Docker Hub rate-limited E2E infrastructure pulls; skipping browser execution for this job"
+            echo "Docker Hub rate-limited E2E infrastructure pulls; browser execution was skipped." >> "$GITHUB_STEP_SUMMARY"
+            docker compose --profile dev down --volumes --remove-orphans || true
+            echo "status=rate-limited" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           echo "::warning::docker stack start failed (attempt ${attempt}/3); tearing down and retrying"
           docker compose --profile dev down --volumes --remove-orphans || true
           sleep "$((attempt * 20))"
@@ -71,6 +93,7 @@ runs:
       run: docker logout
 
     - name: Run database migrations
+      if: steps.stack.outputs.status == 'ready'
       # `db:migrate` (not `db:push`) so role bootstrap migrations such as
       # `20260516000000_case_law_ingestion_role` actually execute. `db:push`
       # only diffs the declarative schema, which references `stella_ingestion`
@@ -79,10 +102,12 @@ runs:
       run: bun --filter @stll/api db:migrate
 
     - name: Seed test user
+      if: steps.stack.outputs.status == 'ready'
       shell: bash
       run: bun --filter @stll/api db:seed-test-user
 
     - name: Start API server
+      if: steps.stack.outputs.status == 'ready'
       # `--watch` is for local dev; CI runs the server flat. Logs land in
       # /tmp/api.log so the "Upload server logs" step can publish them on
       # failure for debugging.
@@ -96,6 +121,7 @@ runs:
         echo $! > /tmp/api.pid
 
     - name: Wait for API
+      if: steps.stack.outputs.status == 'ready'
       shell: bash
       run: |
         for i in {1..60}; do

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1232,6 +1232,7 @@ jobs:
           cp .env.example .env
 
       - name: Start docker stack and API server
+        id: e2e-stack
         # Docker Hub secrets stay confined to the action's credential check
         # and login steps, never the whole job environment where
         # repository-controlled code can read them.
@@ -1241,9 +1242,11 @@ jobs:
           dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Install Playwright browsers
+        if: steps.e2e-stack.outputs.status == 'ready'
         uses: ./.github/actions/setup-playwright
 
       - name: Wait for production web build
+        if: steps.e2e-stack.outputs.status == 'ready'
         env:
           ARTIFACT_NAME: e2e-web-build
           GH_TOKEN: ${{ github.token }}
@@ -1281,12 +1284,14 @@ jobs:
           exit 1
 
       - name: Download production web build
+        if: steps.e2e-stack.outputs.status == 'ready'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.0
         with:
           name: e2e-web-build
           path: apps/web/dist
 
       - name: Validate production web build
+        if: steps.e2e-stack.outputs.status == 'ready'
         run: |
           for side in client server; do
             manifest="apps/web/dist/$side/version.json"
@@ -1298,12 +1303,14 @@ jobs:
           done
 
       - name: Start production web server
+        if: steps.e2e-stack.outputs.status == 'ready'
         run: |
           cd apps/web
           NODE_ENV=production PORT=3000 nohup bun start-runtime.js > /tmp/web-production.log 2>&1 &
           echo $! > /tmp/web-production.pid
 
       - name: Wait for production web server
+        if: steps.e2e-stack.outputs.status == 'ready'
         run: |
           for i in {1..60}; do
             if curl --connect-timeout 2 --max-time 5 -sf http://localhost:3000/health > /dev/null 2>&1; then
@@ -1317,6 +1324,7 @@ jobs:
           exit 1
 
       - name: Run Playwright shard
+        if: steps.e2e-stack.outputs.status == 'ready'
         env:
           E2E_EXECUTION_PROFILE: ci-production-parallel
           E2E_EXPECT_DEV_ROUTES: "false"
@@ -1326,7 +1334,7 @@ jobs:
           --shard=${{ matrix.shard }}/2
 
       - name: Upload Playwright blob report
-        if: always()
+        if: always() && steps.e2e-stack.outputs.status == 'ready'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: playwright-blob-${{ matrix.shard }}
@@ -1334,7 +1342,7 @@ jobs:
           retention-days: 7
 
       - name: Upload server logs
-        if: failure()
+        if: failure() && steps.e2e-stack.outputs.status == 'ready'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: server-logs-production-${{ matrix.shard }}
@@ -1376,6 +1384,7 @@ jobs:
           cp .env.example .env
 
       - name: Start docker stack and API server
+        id: e2e-stack
         # Secrets stay scoped to the action's credential check and login
         # steps; application code runs only after the runner has logged
         # out again.
@@ -1385,12 +1394,14 @@ jobs:
           dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Start web dev server
+        if: steps.e2e-stack.outputs.status == 'ready'
         run: |
           cd apps/web
           nohup bun --bun vite --port 3000 > /tmp/web.log 2>&1 &
           echo $! > /tmp/web.pid
 
       - name: Wait for web dev server
+        if: steps.e2e-stack.outputs.status == 'ready'
         run: |
           for i in {1..60}; do
             if curl --connect-timeout 2 --max-time 5 -sf http://localhost:3000 > /dev/null 2>&1; then
@@ -1404,9 +1415,11 @@ jobs:
           exit 1
 
       - name: Install Playwright browsers
+        if: steps.e2e-stack.outputs.status == 'ready'
         uses: ./.github/actions/setup-playwright
 
       - name: Run Vite dependency canary
+        if: steps.e2e-stack.outputs.status == 'ready'
         env:
           E2E_EXPECT_DEV_ROUTES: "true"
           PLAYWRIGHT_BLOB_OUTPUT_NAME: report-vite-canary.zip
@@ -1418,7 +1431,7 @@ jobs:
       # These imports load only through cold lazy routes; a mid-test optimizer
       # restart would make the apparent canary result nondeterministic.
       - name: Guard against mid-test Vite re-optimize
-        if: always()
+        if: always() && steps.e2e-stack.outputs.status == 'ready'
         run: |
           if grep -q "optimized dependencies changed. reloading" /tmp/web.log; then
             echo "::error::Vite re-optimized dependencies mid-session and forced a reload. Add the lazy/runtime dependency named below to optimizeDeps.include in apps/web/vite.config.ts."
@@ -1428,7 +1441,7 @@ jobs:
           echo "No mid-session dep re-optimize detected."
 
       - name: Stop web dev server
-        if: always()
+        if: always() && steps.e2e-stack.outputs.status == 'ready'
         run: |
           if [[ -f /tmp/web.pid ]]; then
             kill "$(cat /tmp/web.pid)" || true
@@ -1436,7 +1449,7 @@ jobs:
           fi
 
       - name: Upload Playwright blob report
-        if: always()
+        if: always() && steps.e2e-stack.outputs.status == 'ready'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: playwright-blob-vite-canary
@@ -1444,7 +1457,7 @@ jobs:
           retention-days: 7
 
       - name: Upload server logs
-        if: failure()
+        if: failure() && steps.e2e-stack.outputs.status == 'ready'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: server-logs-vite-canary

--- a/scripts/detect-e2e-changes.test.ts
+++ b/scripts/detect-e2e-changes.test.ts
@@ -198,7 +198,9 @@ describe("detect-e2e-changes", () => {
   });
 
   test("skips browser execution only for an explicit Docker Hub pull rate limit", () => {
-    expect(e2eStackSetup).toContain("value: ${{ steps.stack.outputs.status }}");
+    expect(e2eStackSetup).toContain(
+      `value: ${githubExpression("steps.stack.outputs.status")}`,
+    );
     expect(e2eStackSetup).toContain(
       "grep -Eqi 'toomanyrequests:.*pull rate limit'",
     );

--- a/scripts/detect-e2e-changes.test.ts
+++ b/scripts/detect-e2e-changes.test.ts
@@ -40,7 +40,7 @@ const workflowJob = (jobId: string): string => {
     : workflow.slice(bodyStart, bodyStart + nextJob);
 };
 
-const workflowStepRun = (job: string, stepName: string): string => {
+const workflowStep = (job: string, stepName: string): string => {
   const marker = `\n      - name: ${stepName}\n`;
   const start = job.indexOf(marker);
   if (start === -1) {
@@ -52,6 +52,11 @@ const workflowStepRun = (job: string, stepName: string): string => {
     nextStep === -1
       ? job.slice(bodyStart)
       : job.slice(bodyStart, bodyStart + nextStep);
+  return step;
+};
+
+const workflowStepRun = (job: string, stepName: string): string => {
+  const step = workflowStep(job, stepName);
   const runMarker = "\n        run: ";
   const runStart = step.indexOf(runMarker);
   if (runStart === -1) {
@@ -187,9 +192,59 @@ describe("detect-e2e-changes", () => {
       .filter((line) => line.includes("docker compose --profile dev up"))
       .map((line) => line.trim());
     expect(composeStartLines).toEqual([
-      "if docker compose --profile dev up -d --wait postgres minio valkey \\",
+      "if docker compose --profile dev up -d --wait postgres minio valkey 2>&1 \\",
     ]);
     expect(e2eStackSetup).not.toContain("gotenberg");
+  });
+
+  test("skips browser execution only for an explicit Docker Hub pull rate limit", () => {
+    expect(e2eStackSetup).toContain("value: ${{ steps.stack.outputs.status }}");
+    expect(e2eStackSetup).toContain(
+      "grep -Eqi 'toomanyrequests:.*pull rate limit'",
+    );
+    expect(e2eStackSetup).toContain(
+      'echo "status=rate-limited" >> "$GITHUB_OUTPUT"',
+    );
+    expect(e2eStackSetup).toContain('echo "status=ready" >> "$GITHUB_OUTPUT"');
+    expect(
+      e2eStackSetup.match(/if: steps\.stack\.outputs\.status == 'ready'/gu),
+    ).toHaveLength(4);
+
+    const guardedSteps = {
+      "e2e-production-shard": [
+        "Install Playwright browsers",
+        "Wait for production web build",
+        "Download production web build",
+        "Validate production web build",
+        "Start production web server",
+        "Wait for production web server",
+        "Run Playwright shard",
+        "Upload Playwright blob report",
+        "Upload server logs",
+      ],
+      "e2e-vite-canary": [
+        "Start web dev server",
+        "Wait for web dev server",
+        "Install Playwright browsers",
+        "Run Vite dependency canary",
+        "Guard against mid-test Vite re-optimize",
+        "Stop web dev server",
+        "Upload Playwright blob report",
+        "Upload server logs",
+      ],
+    } as const;
+
+    for (const [jobId, stepNames] of Object.entries(guardedSteps)) {
+      const job = workflowJob(jobId);
+      expect(workflowStep(job, "Start docker stack and API server")).toContain(
+        "id: e2e-stack",
+      );
+      for (const stepName of stepNames) {
+        expect(workflowStep(job, stepName)).toContain(
+          "steps.e2e-stack.outputs.status == 'ready'",
+        );
+      }
+    }
   });
 
   test("keeps full code quality for manual sweeps and scopes pull requests", () => {


### PR DESCRIPTION
## Summary

- classify the explicit Docker Hub pull-rate-limit response as an unavailable E2E stack
- skip dependent browser steps while preserving a visible workflow warning and summary
- keep every other stack or test failure blocking
- enforce the downstream step guards with a workflow invariant test

CC on behalf of jan-kubica