### PR TITLE
feat: add email attachment preview workbench

### DIFF
--- a/apps/api/src/handlers/files/email-attachment-loader.ts
+++ b/apps/api/src/handlers/files/email-attachment-loader.ts
@@ -147,10 +147,9 @@ export const loadEmailAttachment = async function* ({
         ),
     ),
   );
-  const parsedResult = await Result.tryPromise({
-    try: async () => await parseEmail(sourceBuffer, emailMimeType),
-    catch: (cause) => cause,
-  });
+  const parsedResult = await Result.tryPromise(
+    async () => await parseEmail(sourceBuffer, emailMimeType),
+  );
   if (Result.isError(parsedResult)) {
     captureError(parsedResult.error, {
       fieldId,

--- a/apps/api/src/handlers/files/email-attachment-loader.ts
+++ b/apps/api/src/handlers/files/email-attachment-loader.ts
@@ -37,12 +37,12 @@ type EmailAttachmentLoadResult =
   | { status: typeof EMAIL_ATTACHMENT_LOAD_STATUS.tooLarge }
   | { status: typeof EMAIL_ATTACHMENT_LOAD_STATUS.unreadable };
 
-const emailAttachmentFieldQuery = async (
+const emailAttachmentFieldQuery = (
   scopedDb: ScopedDb,
   fieldId: SafeId<"field">,
   workspaceId: SafeId<"workspace">,
 ) =>
-  await scopedDb((tx) =>
+  scopedDb((tx) =>
     tx
       .select({
         content: fields.content,
@@ -70,7 +70,7 @@ const normalizedAttachmentMimeType = ({
 }: {
   fileName: string;
   mimeType: string | null;
-}): string =>
+}) =>
   resolveUploadMime({
     declaredMime:
       mimeType?.split(";").at(0)?.trim().toLowerCase() ||

--- a/apps/api/src/handlers/files/email-attachment-loader.ts
+++ b/apps/api/src/handlers/files/email-attachment-loader.ts
@@ -37,12 +37,12 @@ type EmailAttachmentLoadResult =
   | { status: typeof EMAIL_ATTACHMENT_LOAD_STATUS.tooLarge }
   | { status: typeof EMAIL_ATTACHMENT_LOAD_STATUS.unreadable };
 
-const emailAttachmentFieldQuery = (
+const emailAttachmentFieldQuery = async (
   scopedDb: ScopedDb,
   fieldId: SafeId<"field">,
   workspaceId: SafeId<"workspace">,
 ) =>
-  scopedDb((tx) =>
+  await scopedDb((tx) =>
     tx
       .select({
         content: fields.content,

--- a/apps/api/src/handlers/files/email-attachment-loader.ts
+++ b/apps/api/src/handlers/files/email-attachment-loader.ts
@@ -1,0 +1,193 @@
+import { Result } from "better-result";
+import { and, eq, isNull } from "drizzle-orm";
+
+import type { ScopedDb } from "@/api/db/safe-db";
+import { entities, entityVersions, fields } from "@/api/db/schema";
+import { captureError } from "@/api/lib/analytics/capture";
+import type { SafeId } from "@/api/lib/branded-types";
+import {
+  createEmailAttachmentDescriptor,
+  findEmailAttachmentIndex,
+} from "@/api/lib/files/email-attachment-token";
+import {
+  buildEmailPreview,
+  parseEmail,
+  resolveEmailMimeType,
+} from "@/api/lib/files/email-to-html";
+import { createFileKey, resolveUploadMime } from "@/api/lib/files/utils";
+import { FILE_SIZE_LIMIT_BYTES } from "@/api/lib/limits";
+import { readS3ArrayBuffer } from "@/api/lib/s3";
+
+export const EMAIL_ATTACHMENT_LOAD_STATUS = {
+  loaded: "loaded",
+  notFound: "not-found",
+  tooLarge: "too-large",
+  unreadable: "unreadable",
+} as const;
+
+type EmailAttachmentLoadResult =
+  | {
+      status: typeof EMAIL_ATTACHMENT_LOAD_STATUS.loaded;
+      bytes: Uint8Array;
+      fileName: string;
+      mimeType: string;
+      sourceEntityId: SafeId<"entity">;
+    }
+  | { status: typeof EMAIL_ATTACHMENT_LOAD_STATUS.notFound }
+  | { status: typeof EMAIL_ATTACHMENT_LOAD_STATUS.tooLarge }
+  | { status: typeof EMAIL_ATTACHMENT_LOAD_STATUS.unreadable };
+
+const emailAttachmentFieldQuery = async (
+  scopedDb: ScopedDb,
+  fieldId: SafeId<"field">,
+  workspaceId: SafeId<"workspace">,
+) =>
+  await scopedDb((tx) =>
+    tx
+      .select({
+        content: fields.content,
+        entityId: entities.id,
+        entityVersionId: entityVersions.id,
+      })
+      .from(fields)
+      .innerJoin(entityVersions, eq(fields.entityVersionId, entityVersions.id))
+      .innerJoin(
+        entities,
+        and(
+          eq(entityVersions.entityId, entities.id),
+          eq(entities.workspaceId, workspaceId),
+        ),
+      )
+      // Withdrawn versions remain under legal hold, but their bytes must not
+      // remain reachable through a previously captured field identifier.
+      .where(and(eq(fields.id, fieldId), isNull(entityVersions.deletedAt)))
+      .limit(1),
+  );
+
+const normalizedAttachmentMimeType = ({
+  fileName,
+  mimeType,
+}: {
+  fileName: string;
+  mimeType: string | null;
+}): string =>
+  resolveUploadMime({
+    declaredMime:
+      mimeType?.split(";").at(0)?.trim().toLowerCase() ||
+      "application/octet-stream",
+    fileName,
+  });
+
+export const loadEmailAttachment = async function* ({
+  attachmentId,
+  fieldId,
+  organizationId,
+  scopedDb,
+  secret,
+  workspaceId,
+}: {
+  attachmentId: string;
+  fieldId: SafeId<"field">;
+  organizationId: SafeId<"organization">;
+  scopedDb: ScopedDb;
+  secret: string;
+  workspaceId: SafeId<"workspace">;
+}) {
+  const rows = yield* Result.await(
+    Result.tryPromise(
+      async () =>
+        await emailAttachmentFieldQuery(scopedDb, fieldId, workspaceId),
+    ),
+  );
+  const row = rows.at(0);
+  if (!row || row.content.type !== "file" || row.content.encrypted) {
+    return {
+      status: EMAIL_ATTACHMENT_LOAD_STATUS.notFound,
+    } as const satisfies EmailAttachmentLoadResult;
+  }
+
+  const content = row.content;
+  const emailMimeType = resolveEmailMimeType({
+    fileName: content.fileName,
+    mimeType: content.mimeType,
+  });
+  if (!emailMimeType) {
+    return {
+      status: EMAIL_ATTACHMENT_LOAD_STATUS.notFound,
+    } as const satisfies EmailAttachmentLoadResult;
+  }
+
+  const attachmentIndex = findEmailAttachmentIndex({
+    descriptor: attachmentId,
+    secret,
+    sourceFileId: content.id,
+    sourceVersionId: row.entityVersionId,
+  });
+  if (attachmentIndex === null) {
+    return {
+      status: EMAIL_ATTACHMENT_LOAD_STATUS.notFound,
+    } as const satisfies EmailAttachmentLoadResult;
+  }
+  if (content.sizeBytes > FILE_SIZE_LIMIT_BYTES.document) {
+    return {
+      status: EMAIL_ATTACHMENT_LOAD_STATUS.tooLarge,
+    } as const satisfies EmailAttachmentLoadResult;
+  }
+
+  const sourceBuffer = yield* Result.await(
+    Result.tryPromise(
+      async () =>
+        await readS3ArrayBuffer(
+          createFileKey({
+            organizationId,
+            workspaceId,
+            fileId: content.id,
+            mimeType: content.mimeType,
+          }),
+        ),
+    ),
+  );
+  const parsedResult = await Result.tryPromise({
+    try: async () => await parseEmail(sourceBuffer, emailMimeType),
+    catch: (cause) => cause,
+  });
+  if (Result.isError(parsedResult)) {
+    captureError(parsedResult.error, {
+      fieldId,
+      mimeType: emailMimeType,
+      workspaceId,
+    });
+    return {
+      status: EMAIL_ATTACHMENT_LOAD_STATUS.unreadable,
+    } as const satisfies EmailAttachmentLoadResult;
+  }
+
+  const preview = buildEmailPreview(parsedResult.value, {
+    createAttachmentId: (index) =>
+      createEmailAttachmentDescriptor({
+        attachmentIndex: index,
+        secret,
+        sourceFileId: content.id,
+        sourceVersionId: row.entityVersionId,
+      }),
+  });
+  const descriptor = preview.attachments.find(({ id }) => id === attachmentId);
+  const attachment = parsedResult.value.attachments.at(attachmentIndex);
+  if (!descriptor || !attachment) {
+    return {
+      status: EMAIL_ATTACHMENT_LOAD_STATUS.notFound,
+    } as const satisfies EmailAttachmentLoadResult;
+  }
+
+  const fileName = attachment.fileName ?? "attachment";
+  return {
+    status: EMAIL_ATTACHMENT_LOAD_STATUS.loaded,
+    bytes: attachment.bytes,
+    fileName,
+    mimeType: normalizedAttachmentMimeType({
+      fileName,
+      mimeType: attachment.mimeType,
+    }),
+    sourceEntityId: row.entityId,
+  } as const satisfies EmailAttachmentLoadResult;
+};

--- a/apps/api/src/handlers/files/email-attachment.ts
+++ b/apps/api/src/handlers/files/email-attachment.ts
@@ -29,6 +29,8 @@ import { readS3ArrayBuffer } from "@/api/lib/s3";
 import { sanitizeFilename } from "@/api/lib/sanitize-filename";
 import { RAW_DOCUMENT_RESPONSE_SECURITY_HEADERS } from "@/api/lib/security-headers";
 
+const EMAIL_ATTACHMENT_DISPOSITION_PATTERN = "^(?:inline|download)$";
+
 const emailAttachmentFieldQuery = async (
   scopedDb: ScopedDb,
   fieldId: SafeId<"field">,
@@ -59,7 +61,9 @@ const emailAttachmentFieldQuery = async (
 const config = {
   permissions: { workspace: ["read"] },
   mcp: { type: "internal", reason: "document_processing" },
-  query: t.Object({ disposition: t.UnionEnum(["inline", "download"]) }),
+  query: t.Object({
+    disposition: t.String({ pattern: EMAIL_ATTACHMENT_DISPOSITION_PATTERN }),
+  }),
   params: workspaceParams({
     fieldId: tSafeId("field"),
     attachmentId: t.String({ minLength: 1, maxLength: 64 }),

--- a/apps/api/src/handlers/files/email-attachment.ts
+++ b/apps/api/src/handlers/files/email-attachment.ts
@@ -1,62 +1,25 @@
 import { Result } from "better-result";
-import { and, eq, isNull } from "drizzle-orm";
 import { t } from "elysia";
 
-import type { ScopedDb } from "@/api/db/safe-db";
-import { entities, entityVersions, fields } from "@/api/db/schema";
 import { env } from "@/api/env";
-import { captureError } from "@/api/lib/analytics/capture";
 import { createSafeHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
 import { AUDIT_ACTION, AUDIT_RESOURCE_TYPE } from "@/api/lib/audit-log";
-import type { SafeId } from "@/api/lib/branded-types";
 import { contentDisposition } from "@/api/lib/content-disposition";
 import { tSafeId } from "@/api/lib/custom-schema";
 import {
-  createEmailAttachmentDescriptor,
-  findEmailAttachmentIndex,
-} from "@/api/lib/files/email-attachment-token";
-import {
-  parseEmail,
-  buildEmailPreview,
   isEmailAttachmentPreviewable,
   resolveEmailAttachmentMimeType,
-  resolveEmailMimeType,
 } from "@/api/lib/files/email-to-html";
-import { createFileKey } from "@/api/lib/files/utils";
-import { FILE_SIZE_LIMIT_BYTES } from "@/api/lib/limits";
-import { readS3ArrayBuffer } from "@/api/lib/s3";
 import { sanitizeFilename } from "@/api/lib/sanitize-filename";
 import { RAW_DOCUMENT_RESPONSE_SECURITY_HEADERS } from "@/api/lib/security-headers";
 
-const EMAIL_ATTACHMENT_DISPOSITION_PATTERN = "^(?:inline|download)$";
+import {
+  EMAIL_ATTACHMENT_LOAD_STATUS,
+  loadEmailAttachment,
+} from "./email-attachment-loader";
 
-const emailAttachmentFieldQuery = async (
-  scopedDb: ScopedDb,
-  fieldId: SafeId<"field">,
-  workspaceId: SafeId<"workspace">,
-) =>
-  await scopedDb((tx) =>
-    tx
-      .select({
-        content: fields.content,
-        entityId: entities.id,
-        entityVersionId: entityVersions.id,
-      })
-      .from(fields)
-      .innerJoin(entityVersions, eq(fields.entityVersionId, entityVersions.id))
-      .innerJoin(
-        entities,
-        and(
-          eq(entityVersions.entityId, entities.id),
-          eq(entities.workspaceId, workspaceId),
-        ),
-      )
-      // Withdrawn versions remain under legal hold, but their bytes must not
-      // remain reachable through a previously captured field identifier.
-      .where(and(eq(fields.id, fieldId), isNull(entityVersions.deletedAt)))
-      .limit(1),
-  );
+const EMAIL_ATTACHMENT_DISPOSITION_PATTERN = "^(?:inline|download)$";
 
 const config = {
   permissions: { workspace: ["read"] },
@@ -94,79 +57,22 @@ export default createSafeHandler(
     session,
     workspaceId,
   }) {
-    const rows = yield* Result.await(
-      Result.tryPromise(
-        async () =>
-          await emailAttachmentFieldQuery(scopedDb, fieldId, workspaceId),
-      ),
-    );
-    const row = rows.at(0);
-    if (!row || row.content.type !== "file" || row.content.encrypted) {
-      return Result.ok(attachmentNotFound());
-    }
-
-    const content = row.content;
-    const emailMimeType = resolveEmailMimeType({
-      fileName: content.fileName,
-      mimeType: content.mimeType,
-    });
-    if (!emailMimeType) {
-      return Result.ok(attachmentNotFound());
-    }
-
-    const attachmentIndex = findEmailAttachmentIndex({
-      descriptor: attachmentId,
+    const attachment = yield* loadEmailAttachment({
+      attachmentId,
+      fieldId,
+      organizationId: session.activeOrganizationId,
+      scopedDb,
       secret: env.BETTER_AUTH_SECRET,
-      sourceFileId: content.id,
-      sourceVersionId: row.entityVersionId,
+      workspaceId,
     });
-    if (attachmentIndex === null) {
+    if (attachment.status === EMAIL_ATTACHMENT_LOAD_STATUS.notFound) {
       return Result.ok(attachmentNotFound());
     }
-    if (content.sizeBytes > FILE_SIZE_LIMIT_BYTES.document) {
+    if (attachment.status === EMAIL_ATTACHMENT_LOAD_STATUS.tooLarge) {
       return Result.ok(attachmentSourceTooLarge());
     }
-
-    const sourceBuffer = yield* Result.await(
-      Result.tryPromise(
-        async () =>
-          await readS3ArrayBuffer(
-            createFileKey({
-              organizationId: session.activeOrganizationId,
-              workspaceId,
-              fileId: content.id,
-              mimeType: content.mimeType,
-            }),
-          ),
-      ),
-    );
-    const parsedResult = await Result.tryPromise({
-      try: async () => await parseEmail(sourceBuffer, emailMimeType),
-      catch: (cause) => cause,
-    });
-    if (Result.isError(parsedResult)) {
-      captureError(parsedResult.error, {
-        fieldId,
-        mimeType: emailMimeType,
-        workspaceId,
-      });
+    if (attachment.status === EMAIL_ATTACHMENT_LOAD_STATUS.unreadable) {
       return Result.ok(attachmentUnreadable());
-    }
-    const preview = buildEmailPreview(parsedResult.value, {
-      createAttachmentId: (index) =>
-        createEmailAttachmentDescriptor({
-          attachmentIndex: index,
-          secret: env.BETTER_AUTH_SECRET,
-          sourceFileId: content.id,
-          sourceVersionId: row.entityVersionId,
-        }),
-    });
-    const descriptor = preview.attachments.find(
-      ({ id }) => id === attachmentId,
-    );
-    const attachment = parsedResult.value.attachments.at(attachmentIndex);
-    if (!descriptor || !attachment) {
-      return Result.ok(attachmentNotFound());
     }
     const attachmentMimeType = resolveEmailAttachmentMimeType({
       fileName: attachment.fileName,
@@ -183,7 +89,7 @@ export default createSafeHandler(
       disposition === "inline"
         ? (attachmentMimeType ?? "application/octet-stream")
         : "application/octet-stream";
-    const fileName = sanitizeFilename(attachment.fileName ?? "attachment");
+    const fileName = sanitizeFilename(attachment.fileName);
     const safeDisposition = contentDisposition(
       fileName,
       disposition === "download" ? "attachment" : "inline",
@@ -197,7 +103,7 @@ export default createSafeHandler(
                 await recordAuditEvent(tx, {
                   action: AUDIT_ACTION.DOWNLOAD,
                   resourceType: AUDIT_RESOURCE_TYPE.ENTITY,
-                  resourceId: row.entityId,
+                  resourceId: attachment.sourceEntityId,
                   metadata: {
                     attachmentId,
                     fieldId,

--- a/apps/api/src/handlers/files/email-attachment.ts
+++ b/apps/api/src/handlers/files/email-attachment.ts
@@ -3,7 +3,10 @@ import { t } from "elysia";
 
 import { env } from "@/api/env";
 import { createSafeHandler } from "@/api/lib/api-handlers";
-import type { HandlerConfig } from "@/api/lib/api-handlers";
+import type {
+  HandlerConfig,
+  SafeHandlerGenerator,
+} from "@/api/lib/api-handlers";
 import { AUDIT_ACTION, AUDIT_RESOURCE_TYPE } from "@/api/lib/audit-log";
 import { contentDisposition } from "@/api/lib/content-disposition";
 import { tSafeId } from "@/api/lib/custom-schema";
@@ -56,7 +59,7 @@ export default createSafeHandler(
     scopedDb,
     session,
     workspaceId,
-  }) {
+  }): SafeHandlerGenerator<Response> {
     const attachment = yield* loadEmailAttachment({
       attachmentId,
       fieldId,

--- a/apps/api/src/handlers/files/email-attachment.ts
+++ b/apps/api/src/handlers/files/email-attachment.ts
@@ -66,7 +66,7 @@ const config = {
   }),
   params: workspaceParams({
     fieldId: tSafeId("field"),
-    attachmentId: t.String({ minLength: 1, maxLength: 64 }),
+    attachmentId: t.String(),
   }),
 } satisfies HandlerConfig;
 

--- a/apps/api/src/handlers/files/email-attachment.ts
+++ b/apps/api/src/handlers/files/email-attachment.ts
@@ -9,16 +9,21 @@ import { createSafeHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
 import type { SafeId } from "@/api/lib/branded-types";
 import { contentDisposition } from "@/api/lib/content-disposition";
-import { parseEmail, buildEmailPreview, isEmailAttachmentPreviewable, resolveEmailMimeType } from "@/api/lib/files/email-to-html";
+import { tSafeId, workspaceParams } from "@/api/lib/custom-schema";
 import {
   createEmailAttachmentDescriptor,
   findEmailAttachmentIndex,
 } from "@/api/lib/files/email-attachment-token";
+import {
+  parseEmail,
+  buildEmailPreview,
+  isEmailAttachmentPreviewable,
+  resolveEmailMimeType,
+} from "@/api/lib/files/email-to-html";
 import { createFileKey } from "@/api/lib/files/utils";
 import { readS3ArrayBuffer } from "@/api/lib/s3";
-import { RAW_DOCUMENT_RESPONSE_SECURITY_HEADERS } from "@/api/lib/security-headers";
 import { sanitizeFilename } from "@/api/lib/sanitize-filename";
-import { tSafeId, workspaceParams } from "@/api/lib/custom-schema";
+import { RAW_DOCUMENT_RESPONSE_SECURITY_HEADERS } from "@/api/lib/security-headers";
 
 const emailAttachmentFieldQuery = async (
   scopedDb: ScopedDb,
@@ -111,7 +116,9 @@ export default createSafeHandler(
       catch: (cause) => cause,
     });
     if (Result.isError(parsedResult)) {
-      return Result.ok(status(422, { message: "Failed to parse email attachment" }));
+      return Result.ok(
+        status(422, { message: "Failed to parse email attachment" }),
+      );
     }
     const preview = buildEmailPreview(parsedResult.value, {
       createAttachmentId: (index) =>
@@ -122,7 +129,9 @@ export default createSafeHandler(
           sourceVersionId: row.entityVersionId,
         }),
     });
-    const descriptor = preview.attachments.find(({ id }) => id === attachmentId);
+    const descriptor = preview.attachments.find(
+      ({ id }) => id === attachmentId,
+    );
     const attachment = parsedResult.value.attachments.at(attachmentIndex);
     if (!descriptor || !attachment) {
       return Result.ok(status(404));

--- a/apps/api/src/handlers/files/email-attachment.ts
+++ b/apps/api/src/handlers/files/email-attachment.ts
@@ -5,11 +5,13 @@ import { status, t } from "elysia";
 import type { ScopedDb } from "@/api/db/safe-db";
 import { entities, entityVersions, fields } from "@/api/db/schema";
 import { env } from "@/api/env";
+import { captureError } from "@/api/lib/analytics/capture";
 import { createSafeHandler } from "@/api/lib/api-handlers";
 import type {
   HandlerConfig,
   SafeHandlerGenerator,
 } from "@/api/lib/api-handlers";
+import { AUDIT_ACTION, AUDIT_RESOURCE_TYPE } from "@/api/lib/audit-log";
 import type { SafeId } from "@/api/lib/branded-types";
 import { contentDisposition } from "@/api/lib/content-disposition";
 import { tSafeId, workspaceParams } from "@/api/lib/custom-schema";
@@ -24,6 +26,7 @@ import {
   resolveEmailMimeType,
 } from "@/api/lib/files/email-to-html";
 import { createFileKey } from "@/api/lib/files/utils";
+import { FILE_SIZE_LIMIT_BYTES } from "@/api/lib/limits";
 import { readS3ArrayBuffer } from "@/api/lib/s3";
 import { sanitizeFilename } from "@/api/lib/sanitize-filename";
 import { RAW_DOCUMENT_RESPONSE_SECURITY_HEADERS } from "@/api/lib/security-headers";
@@ -37,6 +40,7 @@ const emailAttachmentFieldQuery = async (
     tx
       .select({
         content: fields.content,
+        entityId: entities.id,
         entityVersionId: entityVersions.id,
       })
       .from(fields)
@@ -48,13 +52,15 @@ const emailAttachmentFieldQuery = async (
           eq(entities.workspaceId, workspaceId),
         ),
       )
+      // Withdrawn versions remain under legal hold, but their bytes must not
+      // remain reachable through a previously captured field identifier.
       .where(and(eq(fields.id, fieldId), isNull(entityVersions.deletedAt)))
       .limit(1),
   );
 
 const config = {
   permissions: { workspace: ["read"] },
-  mcp: { type: "internal", reason: "upload_mechanics" },
+  mcp: { type: "internal", reason: "document_processing" },
   query: t.Object({ disposition: t.UnionEnum(["inline", "download"]) }),
   params: workspaceParams({
     fieldId: tSafeId("field"),
@@ -64,12 +70,15 @@ const config = {
 
 const attachmentNotFound = () => status(404);
 const attachmentNotPreviewable = () => status(415);
+const attachmentSourceTooLarge = () =>
+  status(413, { message: "Email exceeds the preview size limit" });
 const attachmentUnreadable = () =>
   status(422, { message: "Failed to parse email attachment" });
 
 type EmailAttachmentResult =
   | ReturnType<typeof attachmentNotFound>
   | ReturnType<typeof attachmentNotPreviewable>
+  | ReturnType<typeof attachmentSourceTooLarge>
   | ReturnType<typeof attachmentUnreadable>
   | Response;
 
@@ -78,6 +87,7 @@ export default createSafeHandler(
   async function* ({
     params: { attachmentId, fieldId },
     query: { disposition },
+    recordAuditEvent,
     scopedDb,
     session,
     workspaceId,
@@ -111,6 +121,9 @@ export default createSafeHandler(
     if (attachmentIndex === null) {
       return Result.ok(attachmentNotFound());
     }
+    if (content.sizeBytes > FILE_SIZE_LIMIT_BYTES.document) {
+      return Result.ok(attachmentSourceTooLarge());
+    }
 
     const sourceBuffer = yield* Result.await(
       Result.tryPromise(
@@ -130,6 +143,11 @@ export default createSafeHandler(
       catch: (cause) => cause,
     });
     if (Result.isError(parsedResult)) {
+      captureError(parsedResult.error, {
+        fieldId,
+        mimeType: emailMimeType,
+        workspaceId,
+      });
       return Result.ok(attachmentUnreadable());
     }
     const preview = buildEmailPreview(parsedResult.value, {
@@ -161,10 +179,28 @@ export default createSafeHandler(
           "application/octet-stream")
         : "application/octet-stream";
     const fileName = sanitizeFilename(attachment.fileName ?? "attachment");
-    const safeDisposition = contentDisposition(fileName).replace(
-      /^attachment;/u,
-      () => `${disposition};`,
-    );
+    const safeDisposition = contentDisposition(fileName, disposition);
+    if (disposition === "download") {
+      yield* Result.await(
+        Result.tryPromise(
+          async () =>
+            await scopedDb(
+              async (tx) =>
+                await recordAuditEvent(tx, {
+                  action: AUDIT_ACTION.DOWNLOAD,
+                  resourceType: AUDIT_RESOURCE_TYPE.ENTITY,
+                  resourceId: row.entityId,
+                  metadata: {
+                    attachmentId,
+                    fieldId,
+                    mimeType,
+                    sizeBytes: attachment.bytes.byteLength,
+                  },
+                }),
+            ),
+        ),
+      );
+    }
     return Result.ok(
       new Response(new Uint8Array(attachment.bytes), {
         headers: {

--- a/apps/api/src/handlers/files/email-attachment.ts
+++ b/apps/api/src/handlers/files/email-attachment.ts
@@ -6,7 +6,10 @@ import type { ScopedDb } from "@/api/db/safe-db";
 import { entities, entityVersions, fields } from "@/api/db/schema";
 import { env } from "@/api/env";
 import { createSafeHandler } from "@/api/lib/api-handlers";
-import type { HandlerConfig } from "@/api/lib/api-handlers";
+import type {
+  HandlerConfig,
+  SafeHandlerGenerator,
+} from "@/api/lib/api-handlers";
 import type { SafeId } from "@/api/lib/branded-types";
 import { contentDisposition } from "@/api/lib/content-disposition";
 import { tSafeId, workspaceParams } from "@/api/lib/custom-schema";
@@ -59,6 +62,17 @@ const config = {
   }),
 } satisfies HandlerConfig;
 
+const attachmentNotFound = () => status(404);
+const attachmentNotPreviewable = () => status(415);
+const attachmentUnreadable = () =>
+  status(422, { message: "Failed to parse email attachment" });
+
+type EmailAttachmentResult =
+  | ReturnType<typeof attachmentNotFound>
+  | ReturnType<typeof attachmentNotPreviewable>
+  | ReturnType<typeof attachmentUnreadable>
+  | Response;
+
 export default createSafeHandler(
   config,
   async function* ({
@@ -67,7 +81,7 @@ export default createSafeHandler(
     scopedDb,
     session,
     workspaceId,
-  }) {
+  }): SafeHandlerGenerator<EmailAttachmentResult> {
     const rows = yield* Result.await(
       Result.tryPromise(
         async () =>
@@ -76,7 +90,7 @@ export default createSafeHandler(
     );
     const row = rows.at(0);
     if (!row || row.content.type !== "file" || row.content.encrypted) {
-      return Result.ok(status(404));
+      return Result.ok(attachmentNotFound());
     }
 
     const content = row.content;
@@ -85,7 +99,7 @@ export default createSafeHandler(
       mimeType: content.mimeType,
     });
     if (!emailMimeType) {
-      return Result.ok(status(404));
+      return Result.ok(attachmentNotFound());
     }
 
     const attachmentIndex = findEmailAttachmentIndex({
@@ -95,7 +109,7 @@ export default createSafeHandler(
       sourceVersionId: row.entityVersionId,
     });
     if (attachmentIndex === null) {
-      return Result.ok(status(404));
+      return Result.ok(attachmentNotFound());
     }
 
     const sourceBuffer = yield* Result.await(
@@ -116,9 +130,7 @@ export default createSafeHandler(
       catch: (cause) => cause,
     });
     if (Result.isError(parsedResult)) {
-      return Result.ok(
-        status(422, { message: "Failed to parse email attachment" }),
-      );
+      return Result.ok(attachmentUnreadable());
     }
     const preview = buildEmailPreview(parsedResult.value, {
       createAttachmentId: (index) =>
@@ -134,13 +146,13 @@ export default createSafeHandler(
     );
     const attachment = parsedResult.value.attachments.at(attachmentIndex);
     if (!descriptor || !attachment) {
-      return Result.ok(status(404));
+      return Result.ok(attachmentNotFound());
     }
     if (
       disposition === "inline" &&
       !isEmailAttachmentPreviewable(attachment.mimeType)
     ) {
-      return Result.ok(status(415));
+      return Result.ok(attachmentNotPreviewable());
     }
 
     const mimeType =
@@ -151,7 +163,7 @@ export default createSafeHandler(
     const fileName = sanitizeFilename(attachment.fileName ?? "attachment");
     const safeDisposition = contentDisposition(fileName).replace(
       /^attachment;/u,
-      `${disposition};`,
+      () => `${disposition};`,
     );
     return Result.ok(
       new Response(attachment.bytes, {

--- a/apps/api/src/handlers/files/email-attachment.ts
+++ b/apps/api/src/handlers/files/email-attachment.ts
@@ -166,7 +166,7 @@ export default createSafeHandler(
       () => `${disposition};`,
     );
     return Result.ok(
-      new Response(attachment.bytes, {
+      new Response(new Uint8Array(attachment.bytes), {
         headers: {
           ...RAW_DOCUMENT_RESPONSE_SECURITY_HEADERS,
           "Cache-Control": "private, no-store",

--- a/apps/api/src/handlers/files/email-attachment.ts
+++ b/apps/api/src/handlers/files/email-attachment.ts
@@ -200,7 +200,7 @@ export default createSafeHandler(
                   metadata: {
                     attachmentId,
                     fieldId,
-                    mimeType,
+                    mimeType: attachmentMimeType ?? "application/octet-stream",
                     sizeBytes: attachment.bytes.byteLength,
                   },
                 }),

--- a/apps/api/src/handlers/files/email-attachment.ts
+++ b/apps/api/src/handlers/files/email-attachment.ts
@@ -1,0 +1,159 @@
+import { Result } from "better-result";
+import { and, eq, isNull } from "drizzle-orm";
+import { status, t } from "elysia";
+
+import type { ScopedDb } from "@/api/db/safe-db";
+import { entities, entityVersions, fields } from "@/api/db/schema";
+import { env } from "@/api/env";
+import { createSafeHandler } from "@/api/lib/api-handlers";
+import type { HandlerConfig } from "@/api/lib/api-handlers";
+import type { SafeId } from "@/api/lib/branded-types";
+import { contentDisposition } from "@/api/lib/content-disposition";
+import { parseEmail, buildEmailPreview, isEmailAttachmentPreviewable, resolveEmailMimeType } from "@/api/lib/files/email-to-html";
+import {
+  createEmailAttachmentDescriptor,
+  findEmailAttachmentIndex,
+} from "@/api/lib/files/email-attachment-token";
+import { createFileKey } from "@/api/lib/files/utils";
+import { readS3ArrayBuffer } from "@/api/lib/s3";
+import { RAW_DOCUMENT_RESPONSE_SECURITY_HEADERS } from "@/api/lib/security-headers";
+import { sanitizeFilename } from "@/api/lib/sanitize-filename";
+import { tSafeId, workspaceParams } from "@/api/lib/custom-schema";
+
+const emailAttachmentFieldQuery = async (
+  scopedDb: ScopedDb,
+  fieldId: SafeId<"field">,
+  workspaceId: SafeId<"workspace">,
+) =>
+  await scopedDb((tx) =>
+    tx
+      .select({
+        content: fields.content,
+        entityVersionId: entityVersions.id,
+      })
+      .from(fields)
+      .innerJoin(entityVersions, eq(fields.entityVersionId, entityVersions.id))
+      .innerJoin(
+        entities,
+        and(
+          eq(entityVersions.entityId, entities.id),
+          eq(entities.workspaceId, workspaceId),
+        ),
+      )
+      .where(and(eq(fields.id, fieldId), isNull(entityVersions.deletedAt)))
+      .limit(1),
+  );
+
+const config = {
+  permissions: { workspace: ["read"] },
+  mcp: { type: "internal", reason: "upload_mechanics" },
+  query: t.Object({ disposition: t.UnionEnum(["inline", "download"]) }),
+  params: workspaceParams({
+    fieldId: tSafeId("field"),
+    attachmentId: t.String({ minLength: 1, maxLength: 64 }),
+  }),
+} satisfies HandlerConfig;
+
+export default createSafeHandler(
+  config,
+  async function* ({
+    params: { attachmentId, fieldId },
+    query: { disposition },
+    scopedDb,
+    session,
+    workspaceId,
+  }) {
+    const rows = yield* Result.await(
+      Result.tryPromise(
+        async () =>
+          await emailAttachmentFieldQuery(scopedDb, fieldId, workspaceId),
+      ),
+    );
+    const row = rows.at(0);
+    if (!row || row.content.type !== "file" || row.content.encrypted) {
+      return Result.ok(status(404));
+    }
+
+    const content = row.content;
+    const emailMimeType = resolveEmailMimeType({
+      fileName: content.fileName,
+      mimeType: content.mimeType,
+    });
+    if (!emailMimeType) {
+      return Result.ok(status(404));
+    }
+
+    const attachmentIndex = findEmailAttachmentIndex({
+      descriptor: attachmentId,
+      secret: env.BETTER_AUTH_SECRET,
+      sourceFileId: content.id,
+      sourceVersionId: row.entityVersionId,
+    });
+    if (attachmentIndex === null) {
+      return Result.ok(status(404));
+    }
+
+    const sourceBuffer = yield* Result.await(
+      Result.tryPromise(
+        async () =>
+          await readS3ArrayBuffer(
+            createFileKey({
+              organizationId: session.activeOrganizationId,
+              workspaceId,
+              fileId: content.id,
+              mimeType: content.mimeType,
+            }),
+          ),
+      ),
+    );
+    const parsedResult = await Result.tryPromise({
+      try: async () => await parseEmail(sourceBuffer, emailMimeType),
+      catch: (cause) => cause,
+    });
+    if (Result.isError(parsedResult)) {
+      return Result.ok(status(422, { message: "Failed to parse email attachment" }));
+    }
+    const preview = buildEmailPreview(parsedResult.value, {
+      createAttachmentId: (index) =>
+        createEmailAttachmentDescriptor({
+          attachmentIndex: index,
+          secret: env.BETTER_AUTH_SECRET,
+          sourceFileId: content.id,
+          sourceVersionId: row.entityVersionId,
+        }),
+    });
+    const descriptor = preview.attachments.find(({ id }) => id === attachmentId);
+    const attachment = parsedResult.value.attachments.at(attachmentIndex);
+    if (!descriptor || !attachment) {
+      return Result.ok(status(404));
+    }
+    if (
+      disposition === "inline" &&
+      !isEmailAttachmentPreviewable(attachment.mimeType)
+    ) {
+      return Result.ok(status(415));
+    }
+
+    const mimeType =
+      disposition === "inline"
+        ? (attachment.mimeType?.split(";").at(0)?.trim().toLowerCase() ??
+          "application/octet-stream")
+        : "application/octet-stream";
+    const fileName = sanitizeFilename(attachment.fileName ?? "attachment");
+    const safeDisposition = contentDisposition(fileName).replace(
+      /^attachment;/u,
+      `${disposition};`,
+    );
+    return Result.ok(
+      new Response(attachment.bytes, {
+        headers: {
+          ...RAW_DOCUMENT_RESPONSE_SECURITY_HEADERS,
+          "Cache-Control": "private, no-store",
+          "Content-Disposition": safeDisposition,
+          "Content-Length": String(attachment.bytes.byteLength),
+          "Content-Type": mimeType,
+        },
+      }),
+    );
+  },
+);

--- a/apps/api/src/handlers/files/email-attachment.ts
+++ b/apps/api/src/handlers/files/email-attachment.ts
@@ -1,16 +1,13 @@
 import { Result } from "better-result";
 import { and, eq, isNull } from "drizzle-orm";
-import { status, t } from "elysia";
+import { t } from "elysia";
 
 import type { ScopedDb } from "@/api/db/safe-db";
 import { entities, entityVersions, fields } from "@/api/db/schema";
 import { env } from "@/api/env";
 import { captureError } from "@/api/lib/analytics/capture";
 import { createSafeHandler } from "@/api/lib/api-handlers";
-import type {
-  HandlerConfig,
-  SafeHandlerGenerator,
-} from "@/api/lib/api-handlers";
+import type { HandlerConfig } from "@/api/lib/api-handlers";
 import { AUDIT_ACTION, AUDIT_RESOURCE_TYPE } from "@/api/lib/audit-log";
 import type { SafeId } from "@/api/lib/branded-types";
 import { contentDisposition } from "@/api/lib/content-disposition";
@@ -69,19 +66,18 @@ const config = {
   }),
 } satisfies HandlerConfig;
 
-const attachmentNotFound = () => status(404);
-const attachmentNotPreviewable = () => status(415);
+const attachmentNotFound = () => new Response(null, { status: 404 });
+const attachmentNotPreviewable = () => new Response(null, { status: 415 });
 const attachmentSourceTooLarge = () =>
-  status(413, { message: "Email exceeds the preview size limit" });
+  Response.json(
+    { message: "Email exceeds the preview size limit" },
+    { status: 413 },
+  );
 const attachmentUnreadable = () =>
-  status(422, { message: "Failed to parse email attachment" });
-
-type EmailAttachmentResult =
-  | ReturnType<typeof attachmentNotFound>
-  | ReturnType<typeof attachmentNotPreviewable>
-  | ReturnType<typeof attachmentSourceTooLarge>
-  | ReturnType<typeof attachmentUnreadable>
-  | Response;
+  Response.json(
+    { message: "Failed to parse email attachment" },
+    { status: 422 },
+  );
 
 export default createSafeHandler(
   config,
@@ -92,7 +88,7 @@ export default createSafeHandler(
     scopedDb,
     session,
     workspaceId,
-  }): SafeHandlerGenerator<EmailAttachmentResult> {
+  }) {
     const rows = yield* Result.await(
       Result.tryPromise(
         async () =>

--- a/apps/api/src/handlers/files/email-attachment.ts
+++ b/apps/api/src/handlers/files/email-attachment.ts
@@ -68,6 +68,7 @@ const config = {
     fieldId: tSafeId("field"),
     attachmentId: t.String(),
   }),
+  response: t.Unknown(),
 } satisfies HandlerConfig;
 
 const attachmentNotFound = () => new Response(null, { status: 404 });

--- a/apps/api/src/handlers/files/email-attachment.ts
+++ b/apps/api/src/handlers/files/email-attachment.ts
@@ -179,7 +179,10 @@ export default createSafeHandler(
           "application/octet-stream")
         : "application/octet-stream";
     const fileName = sanitizeFilename(attachment.fileName ?? "attachment");
-    const safeDisposition = contentDisposition(fileName, disposition);
+    const safeDisposition = contentDisposition(
+      fileName,
+      disposition === "download" ? "attachment" : "inline",
+    );
     if (disposition === "download") {
       yield* Result.await(
         Result.tryPromise(

--- a/apps/api/src/handlers/files/email-attachment.ts
+++ b/apps/api/src/handlers/files/email-attachment.ts
@@ -23,6 +23,7 @@ import {
   parseEmail,
   buildEmailPreview,
   isEmailAttachmentPreviewable,
+  resolveEmailAttachmentMimeType,
   resolveEmailMimeType,
 } from "@/api/lib/files/email-to-html";
 import { createFileKey } from "@/api/lib/files/utils";
@@ -166,17 +167,20 @@ export default createSafeHandler(
     if (!descriptor || !attachment) {
       return Result.ok(attachmentNotFound());
     }
+    const attachmentMimeType = resolveEmailAttachmentMimeType({
+      fileName: attachment.fileName,
+      mimeType: attachment.mimeType,
+    });
     if (
       disposition === "inline" &&
-      !isEmailAttachmentPreviewable(attachment.mimeType)
+      !isEmailAttachmentPreviewable(attachmentMimeType)
     ) {
       return Result.ok(attachmentNotPreviewable());
     }
 
     const mimeType =
       disposition === "inline"
-        ? (attachment.mimeType?.split(";").at(0)?.trim().toLowerCase() ??
-          "application/octet-stream")
+        ? (attachmentMimeType ?? "application/octet-stream")
         : "application/octet-stream";
     const fileName = sanitizeFilename(attachment.fileName ?? "attachment");
     const safeDisposition = contentDisposition(

--- a/apps/api/src/handlers/files/email-attachment.ts
+++ b/apps/api/src/handlers/files/email-attachment.ts
@@ -11,7 +11,7 @@ import type { HandlerConfig } from "@/api/lib/api-handlers";
 import { AUDIT_ACTION, AUDIT_RESOURCE_TYPE } from "@/api/lib/audit-log";
 import type { SafeId } from "@/api/lib/branded-types";
 import { contentDisposition } from "@/api/lib/content-disposition";
-import { tSafeId, workspaceParams } from "@/api/lib/custom-schema";
+import { tSafeId } from "@/api/lib/custom-schema";
 import {
   createEmailAttachmentDescriptor,
   findEmailAttachmentIndex,
@@ -64,11 +64,11 @@ const config = {
   query: t.Object({
     disposition: t.String({ pattern: EMAIL_ATTACHMENT_DISPOSITION_PATTERN }),
   }),
-  params: workspaceParams({
+  params: t.Object({
+    workspaceId: tSafeId("workspace"),
     fieldId: tSafeId("field"),
     attachmentId: t.String(),
   }),
-  response: t.Unknown(),
 } satisfies HandlerConfig;
 
 const attachmentNotFound = () => new Response(null, { status: 404 });

--- a/apps/api/src/handlers/files/get.ts
+++ b/apps/api/src/handlers/files/get.ts
@@ -13,11 +13,11 @@ import type { SafeId } from "@/api/lib/branded-types";
 import { contentDisposition } from "@/api/lib/content-disposition";
 import { injectStamp, isStampableDocx } from "@/api/lib/docx-stamp";
 import { fetchWithTimeout } from "@/api/lib/fetch";
+import { createEmailAttachmentDescriptor } from "@/api/lib/files/email-attachment-token";
 import {
   emailToPreview,
   resolveEmailMimeType,
 } from "@/api/lib/files/email-to-html";
-import { createEmailAttachmentDescriptor } from "@/api/lib/files/email-attachment-token";
 import {
   convertToPdf,
   isConvertibleMimeType,

--- a/apps/api/src/handlers/files/get.ts
+++ b/apps/api/src/handlers/files/get.ts
@@ -305,7 +305,7 @@ const pdfFileName = (fileName: string): string => {
 };
 
 const inlineContentDisposition = (fileName: string): string =>
-  contentDisposition(fileName).replace(/^attachment;/u, "inline;");
+  contentDisposition(fileName, "inline");
 
 const fetchStoredFileResponse = async (
   key: string,

--- a/apps/api/src/handlers/files/get.ts
+++ b/apps/api/src/handlers/files/get.ts
@@ -14,9 +14,16 @@ import { contentDisposition } from "@/api/lib/content-disposition";
 import { injectStamp, isStampableDocx } from "@/api/lib/docx-stamp";
 import { fetchWithTimeout } from "@/api/lib/fetch";
 import {
+  buildEmailPreview,
+  isEmailAttachmentPreviewable,
+  parseEmail,
   emailToPreview,
   resolveEmailMimeType,
 } from "@/api/lib/files/email-to-html";
+import {
+  createEmailAttachmentDescriptor,
+  findEmailAttachmentIndex,
+} from "@/api/lib/files/email-attachment-token";
 import {
   convertToPdf,
   isConvertibleMimeType,
@@ -26,6 +33,7 @@ import { createFileKey } from "@/api/lib/files/utils";
 import { getS3, readS3ArrayBuffer } from "@/api/lib/s3";
 import { presignDownloadUrl } from "@/api/lib/s3-presign";
 import { RAW_DOCUMENT_RESPONSE_SECURITY_HEADERS } from "@/api/lib/security-headers";
+import { sanitizeFilename } from "@/api/lib/sanitize-filename";
 import { PDF_MIME_TYPE } from "@/api/mime-types";
 
 const FILE_READ_URL_EXPIRY_SECONDS = 15 * 60;
@@ -53,6 +61,7 @@ const fileFieldQuery = async (
       .select({
         content: fields.content,
         entityId: entities.id,
+        entityVersionId: entityVersions.id,
         versionStamp: entityVersions.stamp,
         verificationCode: entityVersions.verificationCode,
       })
@@ -254,7 +263,15 @@ export const readEmailHtmlPreviewHandler = async ({
     mimeType: content.mimeType,
   });
   const fileBuffer = await readS3ArrayBuffer(fileKey);
-  const previewResult = await emailToPreview(fileBuffer, emailMimeType);
+  const previewResult = await emailToPreview(fileBuffer, emailMimeType, {
+    createAttachmentId: (attachmentIndex) =>
+      createEmailAttachmentDescriptor({
+        attachmentIndex,
+        secret: env.BETTER_AUTH_SECRET,
+        sourceFileId: content.id,
+        sourceVersionId: row.entityVersionId,
+      }),
+  });
 
   if (Result.isError(previewResult)) {
     captureError(previewResult.error, {
@@ -266,6 +283,108 @@ export const readEmailHtmlPreviewHandler = async ({
   }
 
   return previewResult.value;
+};
+
+type EmailAttachmentDisposition = "inline" | "download";
+
+type ReadEmailAttachmentHandlerProps = {
+  attachmentId: string;
+  disposition: EmailAttachmentDisposition;
+  scopedDb: ScopedDb;
+  fieldId: SafeId<"field">;
+  organizationId: SafeId<"organization">;
+  workspaceId: SafeId<"workspace">;
+};
+
+/** Reauthorize and reparse the source before serving attachment bytes. */
+export const readEmailAttachmentHandler = async ({
+  attachmentId,
+  disposition,
+  scopedDb,
+  fieldId,
+  organizationId,
+  workspaceId,
+}: ReadEmailAttachmentHandlerProps) => {
+  const rows = await fileFieldQuery(scopedDb, fieldId, workspaceId);
+  const row = rows.at(0);
+  if (!row || row.content.type !== "file" || row.content.encrypted) {
+    return status(404);
+  }
+
+  const content = row.content;
+  const emailMimeType = resolveEmailMimeType({
+    fileName: content.fileName,
+    mimeType: content.mimeType,
+  });
+  if (!emailMimeType) {
+    return status(404);
+  }
+
+  const attachmentIndex = findEmailAttachmentIndex({
+    descriptor: attachmentId,
+    secret: env.BETTER_AUTH_SECRET,
+    sourceFileId: content.id,
+    sourceVersionId: row.entityVersionId,
+  });
+  if (attachmentIndex === null) {
+    return status(404);
+  }
+
+  const fileKey = createFileKey({
+    organizationId,
+    workspaceId,
+    fileId: content.id,
+    mimeType: content.mimeType,
+  });
+  const sourceBuffer = await readS3ArrayBuffer(fileKey);
+  const parsedResult = await Result.tryPromise({
+    try: async () => await parseEmail(sourceBuffer, emailMimeType),
+    catch: (cause) => cause,
+  });
+  if (Result.isError(parsedResult)) {
+    return status(422, { message: "Failed to parse email attachment" });
+  }
+
+  const preview = buildEmailPreview(parsedResult.value, {
+    createAttachmentId: (index) =>
+      createEmailAttachmentDescriptor({
+        attachmentIndex: index,
+        secret: env.BETTER_AUTH_SECRET,
+        sourceFileId: content.id,
+        sourceVersionId: row.entityVersionId,
+      }),
+  });
+  const descriptor = preview.attachments.find(({ id }) => id === attachmentId);
+  const attachment = parsedResult.value.attachments.at(attachmentIndex);
+  if (!descriptor || !attachment) {
+    return status(404);
+  }
+  if (
+    disposition === "inline" &&
+    !isEmailAttachmentPreviewable(attachment.mimeType)
+  ) {
+    return status(415);
+  }
+
+  const mimeType =
+    disposition === "inline"
+      ? (attachment.mimeType?.split(";").at(0)?.trim().toLowerCase() ??
+        "application/octet-stream")
+      : "application/octet-stream";
+  const fileName = sanitizeFilename(attachment.fileName ?? "attachment");
+  const safeDisposition = contentDisposition(fileName).replace(
+    /^attachment;/u,
+    `${disposition};`,
+  );
+  return new Response(attachment.bytes, {
+    headers: {
+      ...RAW_DOCUMENT_RESPONSE_SECURITY_HEADERS,
+      "Cache-Control": "private, no-store",
+      "Content-Disposition": safeDisposition,
+      "Content-Length": String(attachment.bytes.byteLength),
+      "Content-Type": mimeType,
+    },
+  });
 };
 
 // ── Stamped download (separate endpoint) ────────────────

--- a/apps/api/src/handlers/files/get.ts
+++ b/apps/api/src/handlers/files/get.ts
@@ -14,16 +14,10 @@ import { contentDisposition } from "@/api/lib/content-disposition";
 import { injectStamp, isStampableDocx } from "@/api/lib/docx-stamp";
 import { fetchWithTimeout } from "@/api/lib/fetch";
 import {
-  buildEmailPreview,
-  isEmailAttachmentPreviewable,
-  parseEmail,
   emailToPreview,
   resolveEmailMimeType,
 } from "@/api/lib/files/email-to-html";
-import {
-  createEmailAttachmentDescriptor,
-  findEmailAttachmentIndex,
-} from "@/api/lib/files/email-attachment-token";
+import { createEmailAttachmentDescriptor } from "@/api/lib/files/email-attachment-token";
 import {
   convertToPdf,
   isConvertibleMimeType,
@@ -33,7 +27,6 @@ import { createFileKey } from "@/api/lib/files/utils";
 import { getS3, readS3ArrayBuffer } from "@/api/lib/s3";
 import { presignDownloadUrl } from "@/api/lib/s3-presign";
 import { RAW_DOCUMENT_RESPONSE_SECURITY_HEADERS } from "@/api/lib/security-headers";
-import { sanitizeFilename } from "@/api/lib/sanitize-filename";
 import { PDF_MIME_TYPE } from "@/api/mime-types";
 
 const FILE_READ_URL_EXPIRY_SECONDS = 15 * 60;
@@ -283,108 +276,6 @@ export const readEmailHtmlPreviewHandler = async ({
   }
 
   return previewResult.value;
-};
-
-type EmailAttachmentDisposition = "inline" | "download";
-
-type ReadEmailAttachmentHandlerProps = {
-  attachmentId: string;
-  disposition: EmailAttachmentDisposition;
-  scopedDb: ScopedDb;
-  fieldId: SafeId<"field">;
-  organizationId: SafeId<"organization">;
-  workspaceId: SafeId<"workspace">;
-};
-
-/** Reauthorize and reparse the source before serving attachment bytes. */
-export const readEmailAttachmentHandler = async ({
-  attachmentId,
-  disposition,
-  scopedDb,
-  fieldId,
-  organizationId,
-  workspaceId,
-}: ReadEmailAttachmentHandlerProps) => {
-  const rows = await fileFieldQuery(scopedDb, fieldId, workspaceId);
-  const row = rows.at(0);
-  if (!row || row.content.type !== "file" || row.content.encrypted) {
-    return status(404);
-  }
-
-  const content = row.content;
-  const emailMimeType = resolveEmailMimeType({
-    fileName: content.fileName,
-    mimeType: content.mimeType,
-  });
-  if (!emailMimeType) {
-    return status(404);
-  }
-
-  const attachmentIndex = findEmailAttachmentIndex({
-    descriptor: attachmentId,
-    secret: env.BETTER_AUTH_SECRET,
-    sourceFileId: content.id,
-    sourceVersionId: row.entityVersionId,
-  });
-  if (attachmentIndex === null) {
-    return status(404);
-  }
-
-  const fileKey = createFileKey({
-    organizationId,
-    workspaceId,
-    fileId: content.id,
-    mimeType: content.mimeType,
-  });
-  const sourceBuffer = await readS3ArrayBuffer(fileKey);
-  const parsedResult = await Result.tryPromise({
-    try: async () => await parseEmail(sourceBuffer, emailMimeType),
-    catch: (cause) => cause,
-  });
-  if (Result.isError(parsedResult)) {
-    return status(422, { message: "Failed to parse email attachment" });
-  }
-
-  const preview = buildEmailPreview(parsedResult.value, {
-    createAttachmentId: (index) =>
-      createEmailAttachmentDescriptor({
-        attachmentIndex: index,
-        secret: env.BETTER_AUTH_SECRET,
-        sourceFileId: content.id,
-        sourceVersionId: row.entityVersionId,
-      }),
-  });
-  const descriptor = preview.attachments.find(({ id }) => id === attachmentId);
-  const attachment = parsedResult.value.attachments.at(attachmentIndex);
-  if (!descriptor || !attachment) {
-    return status(404);
-  }
-  if (
-    disposition === "inline" &&
-    !isEmailAttachmentPreviewable(attachment.mimeType)
-  ) {
-    return status(415);
-  }
-
-  const mimeType =
-    disposition === "inline"
-      ? (attachment.mimeType?.split(";").at(0)?.trim().toLowerCase() ??
-        "application/octet-stream")
-      : "application/octet-stream";
-  const fileName = sanitizeFilename(attachment.fileName ?? "attachment");
-  const safeDisposition = contentDisposition(fileName).replace(
-    /^attachment;/u,
-    `${disposition};`,
-  );
-  return new Response(attachment.bytes, {
-    headers: {
-      ...RAW_DOCUMENT_RESPONSE_SECURITY_HEADERS,
-      "Cache-Control": "private, no-store",
-      "Content-Disposition": safeDisposition,
-      "Content-Length": String(attachment.bytes.byteLength),
-      "Content-Type": mimeType,
-    },
-  });
 };
 
 // ── Stamped download (separate endpoint) ────────────────

--- a/apps/api/src/handlers/files/routes.ts
+++ b/apps/api/src/handlers/files/routes.ts
@@ -209,6 +209,5 @@ filesRoute.get(
     params: emailAttachmentEndpoint.config.params,
     permissions: emailAttachmentEndpoint.config.permissions,
     query: emailAttachmentEndpoint.config.query,
-    response: emailAttachmentEndpoint.config.response,
   },
 );

--- a/apps/api/src/handlers/files/routes.ts
+++ b/apps/api/src/handlers/files/routes.ts
@@ -3,11 +3,11 @@ import Elysia, { t } from "elysia";
 
 import {
   printPdfHandler,
-  readEmailAttachmentHandler,
   readEmailHtmlPreviewHandler,
   readFileHandler,
   stampedDownloadHandler,
 } from "@/api/handlers/files/get";
+import emailAttachmentEndpoint from "@/api/handlers/files/email-attachment";
 import {
   OCR_EXPORT_FORMATS,
   readOcrExport,
@@ -71,40 +71,6 @@ const readEmailHtmlPreviewEndpoint = createSafeHandler(
       ),
     );
 
-    return Result.ok(response);
-  },
-);
-
-const readEmailAttachmentEndpoint = createSafeHandler(
-  {
-    permissions: { workspace: ["read"] },
-    mcp: { type: "internal", reason: "upload_mechanics" },
-    query: t.Object({ disposition: t.UnionEnum(["inline", "download"]) }),
-    params: workspaceParams({
-      fieldId: tSafeId("field"),
-      attachmentId: t.String({ minLength: 1, maxLength: 64 }),
-    }),
-  } satisfies HandlerConfig,
-  async function* ({
-    params: { attachmentId, fieldId },
-    query: { disposition },
-    scopedDb,
-    session,
-    workspaceId,
-  }) {
-    const response = yield* Result.await(
-      Result.tryPromise(
-        async () =>
-          await readEmailAttachmentHandler({
-            attachmentId,
-            disposition,
-            fieldId,
-            organizationId: session.activeOrganizationId,
-            scopedDb,
-            workspaceId,
-          }),
-      ),
-    );
     return Result.ok(response);
   },
 );
@@ -221,11 +187,11 @@ export const filesRoute = new Elysia({
   })
   .get(
     "/email-attachment/:fieldId/:attachmentId",
-    readEmailAttachmentEndpoint.handler,
+    emailAttachmentEndpoint.handler,
     {
-      params: readEmailAttachmentEndpoint.config.params,
-      permissions: readEmailAttachmentEndpoint.config.permissions,
-      query: readEmailAttachmentEndpoint.config.query,
+      params: emailAttachmentEndpoint.config.params,
+      permissions: emailAttachmentEndpoint.config.permissions,
+      query: emailAttachmentEndpoint.config.query,
     },
   )
   .get("/print-pdf/:fieldId", printPdfEndpoint.handler, {

--- a/apps/api/src/handlers/files/routes.ts
+++ b/apps/api/src/handlers/files/routes.ts
@@ -209,5 +209,6 @@ filesRoute.get(
     params: emailAttachmentEndpoint.config.params,
     permissions: emailAttachmentEndpoint.config.permissions,
     query: emailAttachmentEndpoint.config.query,
+    response: emailAttachmentEndpoint.config.response,
   },
 );

--- a/apps/api/src/handlers/files/routes.ts
+++ b/apps/api/src/handlers/files/routes.ts
@@ -3,6 +3,7 @@ import Elysia, { t } from "elysia";
 
 import {
   printPdfHandler,
+  readEmailAttachmentHandler,
   readEmailHtmlPreviewHandler,
   readFileHandler,
   stampedDownloadHandler,
@@ -70,6 +71,40 @@ const readEmailHtmlPreviewEndpoint = createSafeHandler(
       ),
     );
 
+    return Result.ok(response);
+  },
+);
+
+const readEmailAttachmentEndpoint = createSafeHandler(
+  {
+    permissions: { workspace: ["read"] },
+    mcp: { type: "internal", reason: "upload_mechanics" },
+    query: t.Object({ disposition: t.UnionEnum(["inline", "download"]) }),
+    params: workspaceParams({
+      fieldId: tSafeId("field"),
+      attachmentId: t.String({ minLength: 1, maxLength: 64 }),
+    }),
+  } satisfies HandlerConfig,
+  async function* ({
+    params: { attachmentId, fieldId },
+    query: { disposition },
+    scopedDb,
+    session,
+    workspaceId,
+  }) {
+    const response = yield* Result.await(
+      Result.tryPromise(
+        async () =>
+          await readEmailAttachmentHandler({
+            attachmentId,
+            disposition,
+            fieldId,
+            organizationId: session.activeOrganizationId,
+            scopedDb,
+            workspaceId,
+          }),
+      ),
+    );
     return Result.ok(response);
   },
 );
@@ -184,6 +219,15 @@ export const filesRoute = new Elysia({
     params: readEmailHtmlPreviewEndpoint.config.params,
     permissions: readEmailHtmlPreviewEndpoint.config.permissions,
   })
+  .get(
+    "/email-attachment/:fieldId/:attachmentId",
+    readEmailAttachmentEndpoint.handler,
+    {
+      params: readEmailAttachmentEndpoint.config.params,
+      permissions: readEmailAttachmentEndpoint.config.permissions,
+      query: readEmailAttachmentEndpoint.config.query,
+    },
+  )
   .get("/print-pdf/:fieldId", printPdfEndpoint.handler, {
     params: printPdfEndpoint.config.params,
     permissions: printPdfEndpoint.config.permissions,

--- a/apps/api/src/handlers/files/routes.ts
+++ b/apps/api/src/handlers/files/routes.ts
@@ -185,15 +185,6 @@ export const filesRoute = new Elysia({
     params: readEmailHtmlPreviewEndpoint.config.params,
     permissions: readEmailHtmlPreviewEndpoint.config.permissions,
   })
-  .get(
-    "/email-attachment/:fieldId/:attachmentId",
-    emailAttachmentEndpoint.handler,
-    {
-      params: emailAttachmentEndpoint.config.params,
-      permissions: emailAttachmentEndpoint.config.permissions,
-      query: emailAttachmentEndpoint.config.query,
-    },
-  )
   .get("/print-pdf/:fieldId", printPdfEndpoint.handler, {
     params: printPdfEndpoint.config.params,
     permissions: printPdfEndpoint.config.permissions,
@@ -208,3 +199,15 @@ export const filesRoute = new Elysia({
     query: ocrExportEndpoint.config.query,
     response: ocrExportEndpoint.config.response,
   });
+
+// This raw-response endpoint intentionally stays outside the exported Eden
+// contract. Elysia still registers it with the same guards and macros above.
+filesRoute.get(
+  "/email-attachment/:fieldId/:attachmentId",
+  emailAttachmentEndpoint.handler,
+  {
+    params: emailAttachmentEndpoint.config.params,
+    permissions: emailAttachmentEndpoint.config.permissions,
+    query: emailAttachmentEndpoint.config.query,
+  },
+);

--- a/apps/api/src/handlers/files/routes.ts
+++ b/apps/api/src/handlers/files/routes.ts
@@ -1,13 +1,13 @@
 import { Result } from "better-result";
 import Elysia, { t } from "elysia";
 
+import emailAttachmentEndpoint from "@/api/handlers/files/email-attachment";
 import {
   printPdfHandler,
   readEmailHtmlPreviewHandler,
   readFileHandler,
   stampedDownloadHandler,
 } from "@/api/handlers/files/get";
-import emailAttachmentEndpoint from "@/api/handlers/files/email-attachment";
 import {
   OCR_EXPORT_FORMATS,
   readOcrExport,

--- a/apps/api/src/lib/content-disposition.test.ts
+++ b/apps/api/src/lib/content-disposition.test.ts
@@ -13,6 +13,9 @@ describe("contentDisposition", () => {
     expect(contentDisposition("report.pdf", "inline")).toBe(
       'inline; filename="report.pdf"',
     );
+    expect(contentDisposition("nález ÚS.pdf", "inline")).toBe(
+      "inline; filename=\"n_lez _S.pdf\"; filename*=UTF-8''n%C3%A1lez%20%C3%9AS.pdf",
+    );
   });
 
   test("uses fallback and UTF-8 filename* for non-ASCII names", () => {
@@ -24,6 +27,19 @@ describe("contentDisposition", () => {
   test("sanitizes quotes and backslashes in the ASCII fallback", () => {
     expect(contentDisposition('report\\"final".pdf')).toBe(
       "attachment; filename=\"report__final_.pdf\"; filename*=UTF-8''report%5C%22final%22.pdf",
+    );
+  });
+
+  test("removes every HTTP control character from filename parameters", () => {
+    const controls = Array.from({ length: 160 }, (_, codePoint) => codePoint)
+      .filter(
+        (codePoint) => codePoint < 32 || (codePoint >= 127 && codePoint <= 159),
+      )
+      .map((codePoint) => String.fromCodePoint(codePoint))
+      .join("");
+
+    expect(contentDisposition(`evidence${controls}.pdf`, "inline")).toBe(
+      'inline; filename="evidence.pdf"',
     );
   });
 });

--- a/apps/api/src/lib/content-disposition.test.ts
+++ b/apps/api/src/lib/content-disposition.test.ts
@@ -9,6 +9,12 @@ describe("contentDisposition", () => {
     );
   });
 
+  test("supports inline responses without rewriting the header", () => {
+    expect(contentDisposition("report.pdf", "inline")).toBe(
+      'inline; filename="report.pdf"',
+    );
+  });
+
   test("uses fallback and UTF-8 filename* for non-ASCII names", () => {
     expect(contentDisposition("nález ÚS.pdf")).toBe(
       "attachment; filename=\"n_lez _S.pdf\"; filename*=UTF-8''n%C3%A1lez%20%C3%9AS.pdf",

--- a/apps/api/src/lib/content-disposition.ts
+++ b/apps/api/src/lib/content-disposition.ts
@@ -1,4 +1,6 @@
 const ASCII_FILENAME_RE = /^[\u0020-\u007E]+$/u;
+const HTTP_CONTROL_CHARACTER_RE = /[\u0000-\u001F\u007F-\u009F]/gu;
+const FALLBACK_FILENAME = "attachment";
 
 /**
  * Build a Content-Disposition header value per RFC 6266.
@@ -11,19 +13,23 @@ export const contentDisposition = (
   name: string,
   disposition: "attachment" | "inline" = "attachment",
 ): string => {
+  const headerSafeName =
+    name.replaceAll(HTTP_CONTROL_CHARACTER_RE, "") || FALLBACK_FILENAME;
   const isSafeAscii =
-    ASCII_FILENAME_RE.test(name) && !name.includes('"') && !name.includes("\\");
+    ASCII_FILENAME_RE.test(headerSafeName) &&
+    !headerSafeName.includes('"') &&
+    !headerSafeName.includes("\\");
 
   if (isSafeAscii) {
-    return `${disposition}; filename="${name}"`;
+    return `${disposition}; filename="${headerSafeName}"`;
   }
 
   // Sanitise fallback: strip non-ASCII and unsafe chars
-  const fallback = name
+  const fallback = headerSafeName
     .replaceAll(/[^\u0020-\u007E]/gu, "_")
     .replaceAll('"', "_")
     .replaceAll("\\", "_");
-  const encoded = encodeURIComponent(name).replaceAll("'", "%27");
+  const encoded = encodeURIComponent(headerSafeName).replaceAll("'", "%27");
 
   return `${disposition}; filename="${fallback}"; filename*=UTF-8''${encoded}`;
 };

--- a/apps/api/src/lib/content-disposition.ts
+++ b/apps/api/src/lib/content-disposition.ts
@@ -7,12 +7,15 @@ const ASCII_FILENAME_RE = /^[\u0020-\u007E]+$/u;
  * `filename="..."` form. All others get a sanitised ASCII
  * fallback plus `filename*=UTF-8''...` for correct decoding.
  */
-export const contentDisposition = (name: string): string => {
+export const contentDisposition = (
+  name: string,
+  disposition: "attachment" | "inline" = "attachment",
+): string => {
   const isSafeAscii =
     ASCII_FILENAME_RE.test(name) && !name.includes('"') && !name.includes("\\");
 
   if (isSafeAscii) {
-    return `attachment; filename="${name}"`;
+    return `${disposition}; filename="${name}"`;
   }
 
   // Sanitise fallback: strip non-ASCII and unsafe chars
@@ -22,5 +25,5 @@ export const contentDisposition = (name: string): string => {
     .replaceAll("\\", "_");
   const encoded = encodeURIComponent(name).replaceAll("'", "%27");
 
-  return `attachment; filename="${fallback}"; filename*=UTF-8''${encoded}`;
+  return `${disposition}; filename="${fallback}"; filename*=UTF-8''${encoded}`;
 };

--- a/apps/api/src/lib/content-disposition.ts
+++ b/apps/api/src/lib/content-disposition.ts
@@ -1,6 +1,20 @@
 const ASCII_FILENAME_RE = /^[\u0020-\u007E]+$/u;
-const HTTP_CONTROL_CHARACTER_RE = /[\u0000-\u001F\u007F-\u009F]/gu;
 const FALLBACK_FILENAME = "attachment";
+
+const stripHttpControlCharacters = (name: string): string => {
+  const characters: string[] = [];
+  for (const character of name) {
+    const codePoint = character.codePointAt(0);
+    if (
+      codePoint !== undefined &&
+      (codePoint <= 31 || (codePoint >= 127 && codePoint <= 159))
+    ) {
+      continue;
+    }
+    characters.push(character);
+  }
+  return characters.join("");
+};
 
 /**
  * Build a Content-Disposition header value per RFC 6266.
@@ -13,8 +27,7 @@ export const contentDisposition = (
   name: string,
   disposition: "attachment" | "inline" = "attachment",
 ): string => {
-  const headerSafeName =
-    name.replaceAll(HTTP_CONTROL_CHARACTER_RE, "") || FALLBACK_FILENAME;
+  const headerSafeName = stripHttpControlCharacters(name) || FALLBACK_FILENAME;
   const isSafeAscii =
     ASCII_FILENAME_RE.test(headerSafeName) &&
     !headerSafeName.includes('"') &&

--- a/apps/api/src/lib/files/email-attachment-token.test.ts
+++ b/apps/api/src/lib/files/email-attachment-token.test.ts
@@ -24,11 +24,12 @@ describe("email attachment descriptors", () => {
     );
     expect(descriptor).not.toContain(source.sourceFileId);
     expect(findEmailAttachmentIndex({ ...source, descriptor })).toBe(2);
-    for (
-      let attachmentIndex = 0;
-      attachmentIndex < MAX_EMAIL_ATTACHMENT_DESCRIPTORS;
-      attachmentIndex += 1
-    ) {
+    for (const attachmentIndex of [
+      0,
+      MAX_EMAIL_ATTACHMENT_DESCRIPTORS - 1,
+      MAX_EMAIL_ATTACHMENT_DESCRIPTORS,
+      10_000,
+    ]) {
       const indexedDescriptor = createEmailAttachmentDescriptor({
         ...source,
         attachmentIndex,
@@ -73,7 +74,13 @@ describe("email attachment descriptors", () => {
     expect(() =>
       createEmailAttachmentDescriptor({
         ...source,
-        attachmentIndex: 100,
+        attachmentIndex: -1,
+      }),
+    ).toThrow();
+    expect(() =>
+      createEmailAttachmentDescriptor({
+        ...source,
+        attachmentIndex: Number.MAX_SAFE_INTEGER + 1,
       }),
     ).toThrow();
   });

--- a/apps/api/src/lib/files/email-attachment-token.test.ts
+++ b/apps/api/src/lib/files/email-attachment-token.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "bun:test";
 import {
   createEmailAttachmentDescriptor,
   findEmailAttachmentIndex,
+  MAX_EMAIL_ATTACHMENT_DESCRIPTORS,
 } from "./email-attachment-token";
 
 const source = {
@@ -23,11 +24,40 @@ describe("email attachment descriptors", () => {
     );
     expect(descriptor).not.toContain(source.sourceFileId);
     expect(findEmailAttachmentIndex({ ...source, descriptor })).toBe(2);
+    for (let attachmentIndex = 0; attachmentIndex < MAX_EMAIL_ATTACHMENT_DESCRIPTORS; attachmentIndex += 1) {
+      const indexedDescriptor = createEmailAttachmentDescriptor({
+        ...source,
+        attachmentIndex,
+      });
+      expect(findEmailAttachmentIndex({ ...source, descriptor: indexedDescriptor })).toBe(
+        attachmentIndex,
+      );
+    }
     expect(
       findEmailAttachmentIndex({
         ...source,
         descriptor,
         sourceVersionId: "version-2",
+      }),
+    ).toBeNull();
+    expect(
+      findEmailAttachmentIndex({
+        ...source,
+        descriptor,
+        sourceFileId: "file-2",
+      }),
+    ).toBeNull();
+    expect(
+      findEmailAttachmentIndex({
+        ...source,
+        descriptor,
+        secret: "tampered-secret",
+      }),
+    ).toBeNull();
+    expect(
+      findEmailAttachmentIndex({
+        ...source,
+        descriptor: `${descriptor.slice(0, -1)}x`,
       }),
     ).toBeNull();
   });

--- a/apps/api/src/lib/files/email-attachment-token.test.ts
+++ b/apps/api/src/lib/files/email-attachment-token.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  createEmailAttachmentDescriptor,
+  findEmailAttachmentIndex,
+} from "./email-attachment-token";
+
+const source = {
+  secret: "test-secret",
+  sourceFileId: "file-1",
+  sourceVersionId: "version-1",
+};
+
+describe("email attachment descriptors", () => {
+  test("are stable opaque handles bound to the source version", () => {
+    const descriptor = createEmailAttachmentDescriptor({
+      ...source,
+      attachmentIndex: 2,
+    });
+
+    expect(descriptor).toBe(
+      createEmailAttachmentDescriptor({ ...source, attachmentIndex: 2 }),
+    );
+    expect(descriptor).not.toContain(source.sourceFileId);
+    expect(findEmailAttachmentIndex({ ...source, descriptor })).toBe(2);
+    expect(
+      findEmailAttachmentIndex({
+        ...source,
+        descriptor,
+        sourceVersionId: "version-2",
+      }),
+    ).toBeNull();
+  });
+
+  test("rejects malformed or out-of-range handles", () => {
+    expect(
+      findEmailAttachmentIndex({ ...source, descriptor: "ea1.invalid" }),
+    ).toBeNull();
+    expect(() =>
+      createEmailAttachmentDescriptor({
+        ...source,
+        attachmentIndex: 100,
+      }),
+    ).toThrow();
+  });
+});

--- a/apps/api/src/lib/files/email-attachment-token.test.ts
+++ b/apps/api/src/lib/files/email-attachment-token.test.ts
@@ -24,14 +24,18 @@ describe("email attachment descriptors", () => {
     );
     expect(descriptor).not.toContain(source.sourceFileId);
     expect(findEmailAttachmentIndex({ ...source, descriptor })).toBe(2);
-    for (let attachmentIndex = 0; attachmentIndex < MAX_EMAIL_ATTACHMENT_DESCRIPTORS; attachmentIndex += 1) {
+    for (
+      let attachmentIndex = 0;
+      attachmentIndex < MAX_EMAIL_ATTACHMENT_DESCRIPTORS;
+      attachmentIndex += 1
+    ) {
       const indexedDescriptor = createEmailAttachmentDescriptor({
         ...source,
         attachmentIndex,
       });
-      expect(findEmailAttachmentIndex({ ...source, descriptor: indexedDescriptor })).toBe(
-        attachmentIndex,
-      );
+      expect(
+        findEmailAttachmentIndex({ ...source, descriptor: indexedDescriptor }),
+      ).toBe(attachmentIndex);
     }
     expect(
       findEmailAttachmentIndex({

--- a/apps/api/src/lib/files/email-attachment-token.ts
+++ b/apps/api/src/lib/files/email-attachment-token.ts
@@ -1,4 +1,4 @@
-import { createHmac } from "node:crypto";
+import { createHmac, timingSafeEqual } from "node:crypto";
 
 /** Maximum descriptors exposed by one email preview. */
 export const MAX_EMAIL_ATTACHMENT_DESCRIPTORS = 100;
@@ -25,11 +25,7 @@ export const createEmailAttachmentDescriptor = ({
   sourceVersionId,
   secret,
 }: EmailAttachmentDescriptorInput & { secret: string }): string => {
-  if (
-    !Number.isInteger(attachmentIndex) ||
-    attachmentIndex < 0 ||
-    attachmentIndex >= MAX_EMAIL_ATTACHMENT_DESCRIPTORS
-  ) {
+  if (!Number.isSafeInteger(attachmentIndex) || attachmentIndex < 0) {
     throw new RangeError("Email attachment index is out of bounds");
   }
 
@@ -38,7 +34,7 @@ export const createEmailAttachmentDescriptor = ({
       descriptorMessage({ attachmentIndex, sourceFileId, sourceVersionId }),
     )
     .digest("base64url");
-  return `${DESCRIPTOR_PREFIX}.${digest}`;
+  return `${DESCRIPTOR_PREFIX}.${String(attachmentIndex)}.${digest}`;
 };
 
 export const findEmailAttachmentIndex = ({
@@ -52,26 +48,25 @@ export const findEmailAttachmentIndex = ({
   sourceFileId: string;
   sourceVersionId: string;
 }): number | null => {
-  if (!/^ea1\.[A-Za-z0-9_-]{43}$/u.test(descriptor)) {
+  const match = /^ea1\.([0-9]{1,16})\.[A-Za-z0-9_-]{43}$/u.exec(descriptor);
+  const attachmentIndexText = match?.at(1);
+  if (!attachmentIndexText) {
     return null;
   }
-
-  for (
-    let attachmentIndex = 0;
-    attachmentIndex < MAX_EMAIL_ATTACHMENT_DESCRIPTORS;
-    attachmentIndex += 1
+  const attachmentIndex = Number(attachmentIndexText);
+  if (
+    !Number.isSafeInteger(attachmentIndex) ||
+    String(attachmentIndex) !== attachmentIndexText
   ) {
-    if (
-      createEmailAttachmentDescriptor({
-        attachmentIndex,
-        secret,
-        sourceFileId,
-        sourceVersionId,
-      }) === descriptor
-    ) {
-      return attachmentIndex;
-    }
+    return null;
   }
-
-  return null;
+  const expected = createEmailAttachmentDescriptor({
+    attachmentIndex,
+    secret,
+    sourceFileId,
+    sourceVersionId,
+  });
+  return timingSafeEqual(Buffer.from(descriptor), Buffer.from(expected))
+    ? attachmentIndex
+    : null;
 };

--- a/apps/api/src/lib/files/email-attachment-token.ts
+++ b/apps/api/src/lib/files/email-attachment-token.ts
@@ -34,7 +34,9 @@ export const createEmailAttachmentDescriptor = ({
   }
 
   const digest = createHmac("sha256", secret)
-    .update(descriptorMessage({ attachmentIndex, sourceFileId, sourceVersionId }))
+    .update(
+      descriptorMessage({ attachmentIndex, sourceFileId, sourceVersionId }),
+    )
     .digest("base64url");
   return `${DESCRIPTOR_PREFIX}.${digest}`;
 };
@@ -54,7 +56,11 @@ export const findEmailAttachmentIndex = ({
     return null;
   }
 
-  for (let attachmentIndex = 0; attachmentIndex < MAX_EMAIL_ATTACHMENT_DESCRIPTORS; attachmentIndex += 1) {
+  for (
+    let attachmentIndex = 0;
+    attachmentIndex < MAX_EMAIL_ATTACHMENT_DESCRIPTORS;
+    attachmentIndex += 1
+  ) {
     if (
       createEmailAttachmentDescriptor({
         attachmentIndex,

--- a/apps/api/src/lib/files/email-attachment-token.ts
+++ b/apps/api/src/lib/files/email-attachment-token.ts
@@ -1,0 +1,71 @@
+import { createHmac } from "node:crypto";
+
+/** Maximum descriptors exposed by one email preview. */
+export const MAX_EMAIL_ATTACHMENT_DESCRIPTORS = 100;
+
+const DESCRIPTOR_PREFIX = "ea1";
+
+type EmailAttachmentDescriptorInput = {
+  attachmentIndex: number;
+  sourceFileId: string;
+  sourceVersionId: string;
+};
+
+const descriptorMessage = ({
+  attachmentIndex,
+  sourceFileId,
+  sourceVersionId,
+}: EmailAttachmentDescriptorInput): string =>
+  `${DESCRIPTOR_PREFIX}:${sourceFileId}:${sourceVersionId}:${String(attachmentIndex)}`;
+
+/** Create a stable, opaque handle bound to one immutable email version. */
+export const createEmailAttachmentDescriptor = ({
+  attachmentIndex,
+  sourceFileId,
+  sourceVersionId,
+  secret,
+}: EmailAttachmentDescriptorInput & { secret: string }): string => {
+  if (
+    !Number.isInteger(attachmentIndex) ||
+    attachmentIndex < 0 ||
+    attachmentIndex >= MAX_EMAIL_ATTACHMENT_DESCRIPTORS
+  ) {
+    throw new RangeError("Email attachment index is out of bounds");
+  }
+
+  const digest = createHmac("sha256", secret)
+    .update(descriptorMessage({ attachmentIndex, sourceFileId, sourceVersionId }))
+    .digest("base64url");
+  return `${DESCRIPTOR_PREFIX}.${digest}`;
+};
+
+export const findEmailAttachmentIndex = ({
+  descriptor,
+  secret,
+  sourceFileId,
+  sourceVersionId,
+}: {
+  descriptor: string;
+  secret: string;
+  sourceFileId: string;
+  sourceVersionId: string;
+}): number | null => {
+  if (!/^ea1\.[A-Za-z0-9_-]{43}$/u.test(descriptor)) {
+    return null;
+  }
+
+  for (let attachmentIndex = 0; attachmentIndex < MAX_EMAIL_ATTACHMENT_DESCRIPTORS; attachmentIndex += 1) {
+    if (
+      createEmailAttachmentDescriptor({
+        attachmentIndex,
+        secret,
+        sourceFileId,
+        sourceVersionId,
+      }) === descriptor
+    ) {
+      return attachmentIndex;
+    }
+  }
+
+  return null;
+};

--- a/apps/api/src/lib/files/email-to-html.test.ts
+++ b/apps/api/src/lib/files/email-to-html.test.ts
@@ -67,6 +67,8 @@ describe("email attachment preview policy", () => {
   test("allows passive image and PDF types but not active or unknown content", () => {
     expect(isEmailAttachmentPreviewable("application/pdf")).toBe(true);
     expect(isEmailAttachmentPreviewable("image/png")).toBe(true);
+    expect(isEmailAttachmentPreviewable("image/bmp")).toBe(false);
+    expect(isEmailAttachmentPreviewable("image/tiff")).toBe(false);
     expect(isEmailAttachmentPreviewable("image/svg+xml")).toBe(false);
     expect(isEmailAttachmentPreviewable("text/html")).toBe(false);
     expect(isEmailAttachmentPreviewable(null)).toBe(false);

--- a/apps/api/src/lib/files/email-to-html.test.ts
+++ b/apps/api/src/lib/files/email-to-html.test.ts
@@ -10,6 +10,7 @@ import {
   type ParsedEmail,
   renderEmailBodyHtml,
   renderEmailHtml,
+  resolveEmailAttachmentMimeType,
   resolveEmailMimeType,
   isEmailAttachmentPreviewable,
 } from "./email-to-html";
@@ -72,6 +73,27 @@ describe("email attachment preview policy", () => {
     expect(isEmailAttachmentPreviewable("image/svg+xml")).toBe(false);
     expect(isEmailAttachmentPreviewable("text/html")).toBe(false);
     expect(isEmailAttachmentPreviewable(null)).toBe(false);
+  });
+
+  test("recovers passive preview types from generic MIME declarations", () => {
+    expect(
+      resolveEmailAttachmentMimeType({
+        fileName: "EVIDENCE.PDF",
+        mimeType: "application/octet-stream",
+      }),
+    ).toBe("application/pdf");
+    expect(
+      resolveEmailAttachmentMimeType({
+        fileName: "scan.PNG",
+        mimeType: null,
+      }),
+    ).toBe("image/png");
+    expect(
+      resolveEmailAttachmentMimeType({
+        fileName: "payload.SVG",
+        mimeType: "application/octet-stream",
+      }),
+    ).toBe("application/octet-stream");
   });
 });
 

--- a/apps/api/src/lib/files/email-to-html.test.ts
+++ b/apps/api/src/lib/files/email-to-html.test.ts
@@ -408,7 +408,7 @@ describe("renderEmailHtml", () => {
 
     expect(preview.attachments).toEqual([
       {
-        id: "attachment-1",
+        id: "attachment-0",
         fileName: "evidence.png",
         mimeType: "image/png",
         sizeBytes: 3,
@@ -789,7 +789,7 @@ describe("emailToHtml (.eml)", () => {
 
     expect(result.value.attachments).toEqual([
       {
-        id: "attachment-0",
+        id: "attachment-1",
         fileName: "notes.txt",
         mimeType: "text/plain",
         sizeBytes: 16,

--- a/apps/api/src/lib/files/email-to-html.test.ts
+++ b/apps/api/src/lib/files/email-to-html.test.ts
@@ -11,6 +11,7 @@ import {
   renderEmailBodyHtml,
   renderEmailHtml,
   resolveEmailMimeType,
+  isEmailAttachmentPreviewable,
 } from "./email-to-html";
 
 const toArrayBuffer = (value: string): ArrayBuffer => {
@@ -59,6 +60,16 @@ describe("resolveEmailMimeType", () => {
         mimeType: "application/octet-stream",
       }),
     ).toBeNull();
+  });
+});
+
+describe("email attachment preview policy", () => {
+  test("allows passive image and PDF types but not active or unknown content", () => {
+    expect(isEmailAttachmentPreviewable("application/pdf")).toBe(true);
+    expect(isEmailAttachmentPreviewable("image/png")).toBe(true);
+    expect(isEmailAttachmentPreviewable("image/svg+xml")).toBe(false);
+    expect(isEmailAttachmentPreviewable("text/html")).toBe(false);
+    expect(isEmailAttachmentPreviewable(null)).toBe(false);
   });
 });
 
@@ -335,16 +346,20 @@ describe("renderEmailHtml", () => {
       bcc: ["عائشة <aisha@example.ae>"],
       attachments: [
         {
+          id: "attachment-0",
           fileName: "evidence.pdf",
           mimeType: "application/pdf",
           sizeBytes: 3,
+          previewable: true,
         },
       ],
     });
     expect(Object.keys(preview.attachments.at(0) ?? {})).toEqual([
+      "id",
       "fileName",
       "mimeType",
       "sizeBytes",
+      "previewable",
     ]);
     expect(preview.bodyHtml).toStartWith("<!DOCTYPE html>");
     expect(preview.bodyHtml).toContain(
@@ -391,9 +406,11 @@ describe("renderEmailHtml", () => {
 
     expect(preview.attachments).toEqual([
       {
+        id: "attachment-0",
         fileName: "evidence.png",
         mimeType: "image/png",
         sizeBytes: 3,
+        previewable: true,
       },
     ]);
     expect(preview.bodyHtml).toContain("Visible body");
@@ -724,14 +741,18 @@ describe("emailToHtml (.eml)", () => {
 
     expect(result.value.attachments).toEqual([
       {
+        id: "attachment-0",
         fileName: "notes.txt",
         mimeType: "text/plain",
         sizeBytes: 16,
+        previewable: false,
       },
       {
+        id: "attachment-1",
         fileName: "evidence.png",
         mimeType: "image/png",
         sizeBytes: Buffer.from(PNG_BASE64, "base64").byteLength,
+        previewable: true,
       },
     ]);
   });

--- a/apps/api/src/lib/files/email-to-html.test.ts
+++ b/apps/api/src/lib/files/email-to-html.test.ts
@@ -420,6 +420,52 @@ describe("renderEmailHtml", () => {
     expect(preview.bodyHtml).not.toContain("<form");
   });
 
+  test("caps descriptors after removing referenced inline parts", () => {
+    const inlineAttachments = Array.from({ length: 100 }, (_, index) => ({
+      contentId: `inline-${String(index)}`,
+      fileName: `inline-${String(index)}.png`,
+      mimeType: "image/png",
+      bytes: new Uint8Array([index]),
+    }));
+    const preview = buildEmailPreview(
+      htmlEmail({
+        body: {
+          type: "html",
+          html: inlineAttachments
+            .map(
+              ({ contentId }) =>
+                `<img src="cid:${contentId}" alt="inline image">`,
+            )
+            .join(""),
+        },
+        inlineImages: inlineAttachments.map(({ contentId }) => ({
+          cid: contentId,
+          mimeType: "image/png",
+          dataBase64: PNG_BASE64,
+        })),
+        attachments: [
+          ...inlineAttachments,
+          {
+            contentId: null,
+            fileName: "evidence.pdf",
+            mimeType: "application/pdf",
+            bytes: new Uint8Array([1, 2, 3]),
+          },
+        ],
+      }),
+    );
+
+    expect(preview.attachments).toEqual([
+      {
+        id: "attachment-100",
+        fileName: "evidence.pdf",
+        mimeType: "application/pdf",
+        sizeBytes: 3,
+        previewable: true,
+      },
+    ]);
+  });
+
   test("folds trailing HTML history and signatures without removing content", () => {
     const preview = buildEmailPreview(
       htmlEmail({

--- a/apps/api/src/lib/files/email-to-html.test.ts
+++ b/apps/api/src/lib/files/email-to-html.test.ts
@@ -408,7 +408,7 @@ describe("renderEmailHtml", () => {
 
     expect(preview.attachments).toEqual([
       {
-        id: "attachment-0",
+        id: "attachment-1",
         fileName: "evidence.png",
         mimeType: "image/png",
         sizeBytes: 3,
@@ -796,7 +796,7 @@ describe("emailToHtml (.eml)", () => {
         previewable: false,
       },
       {
-        id: "attachment-1",
+        id: "attachment-2",
         fileName: "evidence.png",
         mimeType: "image/png",
         sizeBytes: Buffer.from(PNG_BASE64, "base64").byteLength,

--- a/apps/api/src/lib/files/email-to-html.ts
+++ b/apps/api/src/lib/files/email-to-html.ts
@@ -178,11 +178,10 @@ export const buildEmailPreview = (
     attachments: parsed.attachments
       .map((attachment, attachmentIndex) => ({ attachment, attachmentIndex }))
       .filter(
-        ({ attachment: { contentId }, attachmentIndex }) =>
-          attachmentIndex < MAX_EMAIL_ATTACHMENT_DESCRIPTORS &&
-          (!contentId ||
-            !inlineContentIds.has(contentId.toLowerCase()) ||
-            !renderedBody.referencedContentIds.has(contentId.toLowerCase())),
+        ({ attachment: { contentId } }) =>
+          !contentId ||
+          !inlineContentIds.has(contentId.toLowerCase()) ||
+          !renderedBody.referencedContentIds.has(contentId.toLowerCase()),
       )
       .slice(0, MAX_EMAIL_ATTACHMENT_DESCRIPTORS)
       .map(({ attachment, attachmentIndex }) => ({

--- a/apps/api/src/lib/files/email-to-html.ts
+++ b/apps/api/src/lib/files/email-to-html.ts
@@ -17,6 +17,7 @@ import { type Element, isTag, isText } from "domhandler";
 import PostalMime, { type Address } from "postal-mime";
 
 import { arrayOrEmpty } from "@/api/lib/array";
+import { MAX_EMAIL_ATTACHMENT_DESCRIPTORS } from "@/api/lib/files/email-attachment-token";
 import { parseOutlookMsg } from "@/api/lib/files/outlook-msg";
 
 export const EML_MIME_TYPE = "message/rfc822";
@@ -75,6 +76,14 @@ export type EmailAttachment = {
   bytes: Uint8Array;
 };
 
+export type EmailAttachmentDescriptor = {
+  id: string;
+  fileName: string | null;
+  mimeType: string | null;
+  sizeBytes: number;
+  previewable: boolean;
+};
+
 type EmailBody =
   | { type: "html"; html: string }
   | { type: "text"; text: string };
@@ -97,18 +106,14 @@ export type ParsedEmail = {
  * returns attachment bytes or links. Safe inline CID image bytes may be
  * embedded in bodyHtml so the sandbox can render the message faithfully.
  */
-type EmailPreview = {
+export type EmailPreview = {
   subject: string | null;
   from: string | null;
   to: string[];
   cc: string[];
   bcc: string[];
   date: string | null;
-  attachments: {
-    fileName: string | null;
-    mimeType: string | null;
-    sizeBytes: number;
-  }[];
+  attachments: EmailAttachmentDescriptor[];
   bodyFolds: EmailBodyFold[];
   bodyHtml: string;
 };
@@ -138,9 +143,11 @@ export const emailToHtml = async (
 export const emailToPreview = async (
   fileBuffer: ArrayBuffer,
   mimeType: string,
+  options: { createAttachmentId?: (attachmentIndex: number) => string } = {},
 ): Promise<Result<EmailPreview, EmailParseError>> =>
   await Result.tryPromise({
-    try: async () => buildEmailPreview(await parseEmail(fileBuffer, mimeType)),
+    try: async () =>
+      buildEmailPreview(await parseEmail(fileBuffer, mimeType), options),
     catch: (cause) =>
       new EmailParseError({
         message: "Failed to parse email preview",
@@ -149,7 +156,12 @@ export const emailToPreview = async (
       }),
   });
 
-export const buildEmailPreview = (parsed: ParsedEmail): EmailPreview => {
+export const buildEmailPreview = (
+  parsed: ParsedEmail,
+  {
+    createAttachmentId = (attachmentIndex) => `attachment-${String(attachmentIndex)}`,
+  }: { createAttachmentId?: (attachmentIndex: number) => string } = {},
+): EmailPreview => {
   const inlineContentIds = new Set(
     parsed.inlineImages.map(({ cid }) => cid.toLowerCase()),
   );
@@ -163,20 +175,35 @@ export const buildEmailPreview = (parsed: ParsedEmail): EmailPreview => {
     bcc: parsed.bcc,
     date: parsed.date,
     attachments: parsed.attachments
+      .map((attachment, attachmentIndex) => ({ attachment, attachmentIndex }))
       .filter(
-        ({ contentId }) =>
-          !contentId ||
-          !inlineContentIds.has(contentId.toLowerCase()) ||
-          !renderedBody.referencedContentIds.has(contentId.toLowerCase()),
+        ({ attachment: { contentId }, attachmentIndex }) =>
+          attachmentIndex < MAX_EMAIL_ATTACHMENT_DESCRIPTORS &&
+          (!contentId ||
+            !inlineContentIds.has(contentId.toLowerCase()) ||
+            !renderedBody.referencedContentIds.has(contentId.toLowerCase())),
       )
-      .map(({ fileName, mimeType, bytes }) => ({
-        fileName,
-        mimeType,
-        sizeBytes: bytes.byteLength,
+      .slice(0, MAX_EMAIL_ATTACHMENT_DESCRIPTORS)
+      .map(({ attachment, attachmentIndex }) => ({
+        id: createAttachmentId(attachmentIndex),
+        fileName: attachment.fileName,
+        mimeType: attachment.mimeType,
+        sizeBytes: attachment.bytes.byteLength,
+        previewable: isEmailAttachmentPreviewable(attachment.mimeType),
       })),
     bodyFolds: renderedBody.bodyFolds,
     bodyHtml: renderedBody.bodyHtml,
   };
+};
+
+export const isEmailAttachmentPreviewable = (
+  mimeType: string | null,
+): boolean => {
+  const normalized = mimeType?.split(";").at(0)?.trim().toLowerCase() ?? "";
+  return (
+    normalized === "application/pdf" ||
+    /^image\/(?:png|jpe?g|gif|webp|bmp|tiff)$/u.test(normalized)
+  );
 };
 
 export const parseEmail = async (

--- a/apps/api/src/lib/files/email-to-html.ts
+++ b/apps/api/src/lib/files/email-to-html.ts
@@ -159,7 +159,8 @@ export const emailToPreview = async (
 export const buildEmailPreview = (
   parsed: ParsedEmail,
   {
-    createAttachmentId = (attachmentIndex) => `attachment-${String(attachmentIndex)}`,
+    createAttachmentId = (attachmentIndex) =>
+      `attachment-${String(attachmentIndex)}`,
   }: { createAttachmentId?: (attachmentIndex: number) => string } = {},
 ): EmailPreview => {
   const inlineContentIds = new Set(
@@ -202,7 +203,7 @@ export const isEmailAttachmentPreviewable = (
   const normalized = mimeType?.split(";").at(0)?.trim().toLowerCase() ?? "";
   return (
     normalized === "application/pdf" ||
-    /^image\/(?:png|jpe?g|gif|webp|bmp|tiff)$/u.test(normalized)
+    /^image\/(?:png|jpe?g|gif|webp)$/u.test(normalized)
   );
 };
 

--- a/apps/api/src/lib/files/email-to-html.ts
+++ b/apps/api/src/lib/files/email-to-html.ts
@@ -33,6 +33,21 @@ const EMAIL_EXTENSION_MIME_TYPES: Record<string, string> = {
   msg: MSG_MIME_TYPE,
 };
 
+const EMAIL_ATTACHMENT_PREVIEW_EXTENSION_MIME_TYPES: Record<string, string> = {
+  gif: "image/gif",
+  jpeg: "image/jpeg",
+  jpg: "image/jpeg",
+  pdf: "application/pdf",
+  png: "image/png",
+  webp: "image/webp",
+};
+
+const GENERIC_ATTACHMENT_MIME_TYPES = {
+  "": null,
+  "application/octet-stream": null,
+  "binary/octet-stream": null,
+} as const satisfies Record<string, null>;
+
 const EMAIL_WRITING_DIRECTIONS = {
   auto: null,
   ltr: null,
@@ -184,13 +199,19 @@ export const buildEmailPreview = (
           !renderedBody.referencedContentIds.has(contentId.toLowerCase()),
       )
       .slice(0, MAX_EMAIL_ATTACHMENT_DESCRIPTORS)
-      .map(({ attachment, attachmentIndex }) => ({
-        id: createAttachmentId(attachmentIndex),
-        fileName: attachment.fileName,
-        mimeType: attachment.mimeType,
-        sizeBytes: attachment.bytes.byteLength,
-        previewable: isEmailAttachmentPreviewable(attachment.mimeType),
-      })),
+      .map(({ attachment, attachmentIndex }) => {
+        const mimeType = resolveEmailAttachmentMimeType({
+          fileName: attachment.fileName,
+          mimeType: attachment.mimeType,
+        });
+        return {
+          id: createAttachmentId(attachmentIndex),
+          fileName: attachment.fileName,
+          mimeType,
+          sizeBytes: attachment.bytes.byteLength,
+          previewable: isEmailAttachmentPreviewable(mimeType),
+        };
+      }),
     bodyFolds: renderedBody.bodyFolds,
     bodyHtml: renderedBody.bodyHtml,
   };
@@ -204,6 +225,25 @@ export const isEmailAttachmentPreviewable = (
     normalized === "application/pdf" ||
     /^image\/(?:png|jpe?g|gif|webp)$/u.test(normalized)
   );
+};
+
+export const resolveEmailAttachmentMimeType = ({
+  fileName,
+  mimeType,
+}: {
+  fileName: string | null;
+  mimeType: string | null;
+}): string | null => {
+  const normalized = mimeType?.split(";").at(0)?.trim().toLowerCase() ?? "";
+  if (!Object.hasOwn(GENERIC_ATTACHMENT_MIME_TYPES, normalized)) {
+    return normalized;
+  }
+  const dotIndex = fileName?.lastIndexOf(".") ?? -1;
+  if (!fileName || dotIndex === -1) {
+    return mimeType;
+  }
+  const extension = fileName.slice(dotIndex + 1).toLowerCase();
+  return EMAIL_ATTACHMENT_PREVIEW_EXTENSION_MIME_TYPES[extension] ?? mimeType;
 };
 
 export const parseEmail = async (

--- a/apps/api/src/lib/files/email-to-html.ts
+++ b/apps/api/src/lib/files/email-to-html.ts
@@ -42,7 +42,7 @@ const EMAIL_ATTACHMENT_PREVIEW_EXTENSION_MIME_TYPES: Record<string, string> = {
   webp: "image/webp",
 };
 
-const GENERIC_ATTACHMENT_MIME_TYPES = {
+const GENERIC_PREVIEW_ATTACHMENT_MIME_TYPES = {
   "": null,
   "application/octet-stream": null,
   "binary/octet-stream": null,
@@ -235,7 +235,7 @@ export const resolveEmailAttachmentMimeType = ({
   mimeType: string | null;
 }): string | null => {
   const normalized = mimeType?.split(";").at(0)?.trim().toLowerCase() ?? "";
-  if (!Object.hasOwn(GENERIC_ATTACHMENT_MIME_TYPES, normalized)) {
+  if (!Object.hasOwn(GENERIC_PREVIEW_ATTACHMENT_MIME_TYPES, normalized)) {
     return normalized;
   }
   const dotIndex = fileName?.lastIndexOf(".") ?? -1;

--- a/apps/api/src/lib/sanitize-filename.test.ts
+++ b/apps/api/src/lib/sanitize-filename.test.ts
@@ -35,6 +35,21 @@ describe("sanitizeFilename", () => {
     expect(typeof _branded).toBe("string");
   });
 
+  test("truncates at Unicode code-point boundaries", () => {
+    const result = sanitizeFilename(`${"a".repeat(254)}😀z`);
+
+    expect(Array.from(result)).toHaveLength(255);
+    expect(result.endsWith("😀")).toBe(true);
+    expect(() => encodeURIComponent(result)).not.toThrow();
+  });
+
+  test("replaces an existing unpaired surrogate", () => {
+    const result = sanitizeFilename(`${"a".repeat(254)}\uD83Dx`);
+
+    expect(result.endsWith("�")).toBe(true);
+    expect(() => encodeURIComponent(result)).not.toThrow();
+  });
+
   test("preserves the DOCX extension when truncating a long name", () => {
     const fileName = sanitizeFilenamePreservingExtension(
       `${"a".repeat(256)}.docx`,

--- a/apps/api/src/lib/sanitize-filename.test.ts
+++ b/apps/api/src/lib/sanitize-filename.test.ts
@@ -36,10 +36,18 @@ describe("sanitizeFilename", () => {
   });
 
   test("truncates at Unicode code-point boundaries", () => {
-    const result = sanitizeFilename(`${"a".repeat(254)}😀z`);
+    const result = sanitizeFilename(`${"a".repeat(253)}😀z`);
 
-    expect(Array.from(result)).toHaveLength(255);
+    expect(result).toHaveLength(255);
     expect(result.endsWith("😀")).toBe(true);
+    expect(() => encodeURIComponent(result)).not.toThrow();
+  });
+
+  test("bounds astral filenames by UTF-16 length", () => {
+    const result = sanitizeFilename("😀".repeat(255));
+
+    expect(result).toHaveLength(254);
+    expect(Array.from(result)).toHaveLength(127);
     expect(() => encodeURIComponent(result)).not.toThrow();
   });
 

--- a/apps/api/src/lib/sanitize-filename.ts
+++ b/apps/api/src/lib/sanitize-filename.ts
@@ -24,10 +24,18 @@ const UNSAFE_CHARS_RE = /["/\\<>\r\n\0|*?:]/gu;
 const PATH_TRAVERSAL_RE = /\.\./gu;
 const MAX_FILENAME_LENGTH = 255;
 
-const truncateUnicode = (value: string, maxLength: number): string =>
-  Array.from(value).slice(0, maxLength).join("");
-
-const unicodeLength = (value: string): number => Array.from(value).length;
+const truncateUnicode = (value: string, maxLength: number): string => {
+  const characters: string[] = [];
+  let length = 0;
+  for (const character of value) {
+    if (length + character.length > maxLength) {
+      break;
+    }
+    characters.push(character);
+    length += character.length;
+  }
+  return characters.join("");
+};
 
 const stripLeadingAndTrailingDots = (name: string): string => {
   let start = 0;
@@ -73,7 +81,7 @@ export const sanitizeFilenamePreservingExtension = (
 
   const extension = wellFormedName.slice(lastDot);
   const sanitizedBase = sanitizeFilename(wellFormedName.slice(0, lastDot));
-  const maxBaseLength = MAX_FILENAME_LENGTH - unicodeLength(extension);
+  const maxBaseLength = MAX_FILENAME_LENGTH - extension.length;
 
   if (maxBaseLength <= 0) {
     return sanitizeFilename(wellFormedName);

--- a/apps/api/src/lib/sanitize-filename.ts
+++ b/apps/api/src/lib/sanitize-filename.ts
@@ -24,6 +24,11 @@ const UNSAFE_CHARS_RE = /["/\\<>\r\n\0|*?:]/gu;
 const PATH_TRAVERSAL_RE = /\.\./gu;
 const MAX_FILENAME_LENGTH = 255;
 
+const truncateUnicode = (value: string, maxLength: number): string =>
+  Array.from(value).slice(0, maxLength).join("");
+
+const unicodeLength = (value: string): number => Array.from(value).length;
+
 const stripLeadingAndTrailingDots = (name: string): string => {
   let start = 0;
   let end = name.length;
@@ -42,13 +47,14 @@ const stripLeadingAndTrailingDots = (name: string): string => {
 
 export const sanitizeFilename = (name: string): SanitizedFileName => {
   const sanitized = name
+    .toWellFormed()
     .replace(UNSAFE_CHARS_RE, "_")
     .replace(PATH_TRAVERSAL_RE, "__");
   const sanitizedWithoutEdgeDots = stripLeadingAndTrailingDots(sanitized);
 
   return v.parse(
     sanitizedFileNameSchema,
-    sanitizedWithoutEdgeDots.slice(0, 255) || "file",
+    truncateUnicode(sanitizedWithoutEdgeDots, MAX_FILENAME_LENGTH) || "file",
   );
 };
 
@@ -59,20 +65,23 @@ export const sanitizeFilename = (name: string): SanitizedFileName => {
 export const sanitizeFilenamePreservingExtension = (
   name: string,
 ): SanitizedFileName => {
-  const lastDot = name.lastIndexOf(".");
+  const wellFormedName = name.toWellFormed();
+  const lastDot = wellFormedName.lastIndexOf(".");
   if (lastDot === -1) {
-    return sanitizeFilename(name);
+    return sanitizeFilename(wellFormedName);
   }
 
-  const extension = name.slice(lastDot);
-  const sanitizedBase = sanitizeFilename(name.slice(0, lastDot));
-  const maxBaseLength = MAX_FILENAME_LENGTH - extension.length;
+  const extension = wellFormedName.slice(lastDot);
+  const sanitizedBase = sanitizeFilename(wellFormedName.slice(0, lastDot));
+  const maxBaseLength = MAX_FILENAME_LENGTH - unicodeLength(extension);
 
   if (maxBaseLength <= 0) {
-    return sanitizeFilename(name);
+    return sanitizeFilename(wellFormedName);
   }
 
-  return sanitizeFilename(sanitizedBase.slice(0, maxBaseLength) + extension);
+  return sanitizeFilename(
+    truncateUnicode(sanitizedBase, maxBaseLength) + extension,
+  );
 };
 
 /** Matches a trailing `.docx` extension (case-insensitive). */

--- a/apps/web/src/components/inspector/email-attachments-facet.tsx
+++ b/apps/web/src/components/inspector/email-attachments-facet.tsx
@@ -111,7 +111,7 @@ const AttachmentPreview = ({
   useExternalSyncEffect(() => {
     if (!pdfQuery.data) {
       setPdfObjectUrl(null);
-      return;
+      return undefined;
     }
     const objectUrl = URL.createObjectURL(
       new Blob([pdfQuery.data], { type: "application/pdf" }),

--- a/apps/web/src/components/inspector/email-attachments-facet.tsx
+++ b/apps/web/src/components/inspector/email-attachments-facet.tsx
@@ -1,0 +1,156 @@
+import { useState } from "react";
+import type { ReactNode } from "react";
+
+import { useQuery } from "@tanstack/react-query";
+import { AlertTriangleIcon, ArrowLeftIcon, PaperclipIcon } from "lucide-react";
+import { useTranslations } from "use-intl";
+
+import { BidiText } from "@stll/ui/components/bidi-text";
+import { Button } from "@stll/ui/components/button";
+import { Skeleton } from "@stll/ui/components/skeleton";
+
+import { DocumentIcon } from "@/components/document-icon";
+import { useExternalSyncEffect } from "@/hooks/use-effect";
+import { emailAttachmentPreviewOptions, emailHtmlPreviewOptions } from "@/lib/files/queries";
+
+type EmailAttachmentsFacetProps = {
+  fieldId: string;
+  workspaceId: string;
+};
+
+export const EmailAttachmentsFacet = ({
+  fieldId,
+  workspaceId,
+}: EmailAttachmentsFacetProps) => {
+  const t = useTranslations();
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const previewQuery = useQuery(emailHtmlPreviewOptions({ fieldId, workspaceId }));
+  const selected = previewQuery.data?.attachments.find(({ id }) => id === selectedId);
+  const attachmentQuery = useQuery(
+    emailAttachmentPreviewOptions({
+      attachmentId: selected?.id ?? "",
+      fieldId,
+      workspaceId,
+    }),
+  );
+  const [objectUrl, setObjectUrl] = useState<string | null>(null);
+
+  useExternalSyncEffect(() => {
+    if (!attachmentQuery.data) {
+      setObjectUrl(null);
+      return;
+    }
+    const url = URL.createObjectURL(
+      new Blob([attachmentQuery.data.buffer], {
+        type: attachmentQuery.data.mimeType,
+      }),
+    );
+    setObjectUrl(url);
+    return () => {
+      URL.revokeObjectURL(url);
+      setObjectUrl(null);
+    };
+  }, [attachmentQuery.data]);
+
+  if (previewQuery.isPending) {
+    return <Skeleton className="m-3 h-24 rounded-sm" />;
+  }
+  if (previewQuery.isError) {
+    return <FacetMessage icon={<AlertTriangleIcon aria-hidden="true" className="size-5" />} message={t("common.somethingWentWrong")} />;
+  }
+  if (selected) {
+    return (
+      <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+        <div className="flex min-h-12 shrink-0 items-center gap-2 border-b px-3">
+          <Button
+            aria-label={t("common.back")}
+            onClick={() => setSelectedId(null)}
+            size="icon-xs"
+            variant="ghost"
+          >
+            <ArrowLeftIcon aria-hidden="true" className="size-3.5" />
+          </Button>
+          <BidiText as="span" className="min-w-0 truncate text-sm font-medium">
+            {selected.fileName ?? t("emailViewer.unnamedAttachment")}
+          </BidiText>
+        </div>
+        <div className="bg-muted/30 flex min-h-0 flex-1 items-center justify-center p-2">
+          {attachmentQuery.isPending ? <Skeleton className="size-full rounded-sm" /> : null}
+          {attachmentQuery.isError ? (
+            <FacetMessage
+              icon={<AlertTriangleIcon aria-hidden="true" className="size-5" />}
+              message={t("common.somethingWentWrong")}
+            />
+          ) : null}
+          {objectUrl ? (
+            selected.mimeType?.toLowerCase().startsWith("image/") ? (
+              <img
+                alt={selected.fileName ?? t("emailViewer.unnamedAttachment")}
+                className="max-h-full max-w-full object-contain"
+                src={objectUrl}
+              />
+            ) : (
+              <iframe
+                className="bg-background size-full border-0"
+                referrerPolicy="no-referrer"
+                sandbox=""
+                src={objectUrl}
+                title={selected.fileName ?? t("emailViewer.unnamedAttachment")}
+              />
+            )
+          ) : null}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <section aria-labelledby={`${fieldId}-attachment-facet`} className="min-h-0 flex-1 overflow-y-auto p-3">
+      <h2 className="text-muted-foreground mb-2 flex items-center gap-1.5 text-xs font-medium" id={`${fieldId}-attachment-facet`}>
+        <PaperclipIcon aria-hidden="true" className="size-3.5" />
+        {t("emailViewer.attachments")}
+      </h2>
+      {previewQuery.data.attachments.length === 0 ? (
+        <p className="text-muted-foreground text-sm">{t("common.noResults")}</p>
+      ) : (
+        <ul className="grid gap-1.5">
+          {previewQuery.data.attachments.map((attachment) => (
+            <li key={attachment.id}>
+              <button
+                className="hover:bg-muted/60 flex min-h-11 w-full items-center gap-2 rounded-md border px-2 text-start text-xs"
+                disabled={!attachment.previewable}
+                onClick={() => setSelectedId(attachment.id)}
+                type="button"
+              >
+                <DocumentIcon
+                  className="text-muted-foreground size-4 shrink-0"
+                  fileName={attachment.fileName ?? t("emailViewer.unnamedAttachment")}
+                  mimeType={attachment.mimeType ?? "application/octet-stream"}
+                />
+                <BidiText as="span" className="min-w-0 flex-1 truncate">
+                  {attachment.fileName ?? t("emailViewer.unnamedAttachment")}
+                </BidiText>
+                {!attachment.previewable ? (
+                  <span className="text-muted-foreground shrink-0">{t("chat.unsupportedFileType")}</span>
+                ) : null}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+};
+
+const FacetMessage = ({
+  icon,
+  message,
+}: {
+  icon: ReactNode;
+  message: string;
+}) => (
+  <div className="text-muted-foreground flex min-h-0 flex-1 flex-col items-center justify-center gap-2 p-6 text-center text-sm">
+    {icon}
+    <p>{message}</p>
+  </div>
+);

--- a/apps/web/src/components/inspector/email-attachments-facet.tsx
+++ b/apps/web/src/components/inspector/email-attachments-facet.tsx
@@ -6,6 +6,7 @@ import { useTranslations } from "use-intl";
 
 import { BidiText } from "@stll/ui/components/bidi-text";
 import { Button } from "@stll/ui/components/button";
+import { DirectionalIcon } from "@stll/ui/components/directional-icon";
 import { Skeleton } from "@stll/ui/components/skeleton";
 
 import { DocumentIcon } from "@/components/document-icon";
@@ -137,7 +138,7 @@ const AttachmentPreview = ({
           size="icon-xs"
           variant="ghost"
         >
-          <ArrowLeftIcon aria-hidden="true" className="size-3.5" />
+          <DirectionalIcon className="size-3.5" icon={ArrowLeftIcon} />
         </Button>
         <BidiText as="span" className="min-w-0 truncate text-sm font-medium">
           {fileName}

--- a/apps/web/src/components/inspector/email-attachments-facet.tsx
+++ b/apps/web/src/components/inspector/email-attachments-facet.tsx
@@ -1,5 +1,4 @@
-import { useState } from "react";
-import type { ReactNode } from "react";
+import { useState, type ReactNode } from "react";
 
 import { useQuery } from "@tanstack/react-query";
 import { AlertTriangleIcon, ArrowLeftIcon, PaperclipIcon } from "lucide-react";
@@ -11,11 +10,22 @@ import { Skeleton } from "@stll/ui/components/skeleton";
 
 import { DocumentIcon } from "@/components/document-icon";
 import { useExternalSyncEffect } from "@/hooks/use-effect";
-import { emailAttachmentPreviewOptions, emailHtmlPreviewOptions } from "@/lib/files/queries";
+import {
+  emailAttachmentPdfOptions,
+  emailAttachmentPreviewUrl,
+  emailHtmlPreviewOptions,
+} from "@/lib/files/queries";
 
 type EmailAttachmentsFacetProps = {
   fieldId: string;
   workspaceId: string;
+};
+
+type AttachmentDescriptor = {
+  id: string;
+  fileName: string | null;
+  mimeType: string | null;
+  previewable: boolean;
 };
 
 export const EmailAttachmentsFacet = ({
@@ -24,121 +34,248 @@ export const EmailAttachmentsFacet = ({
 }: EmailAttachmentsFacetProps) => {
   const t = useTranslations();
   const [selectedId, setSelectedId] = useState<string | null>(null);
-  const previewQuery = useQuery(emailHtmlPreviewOptions({ fieldId, workspaceId }));
-  const selected = previewQuery.data?.attachments.find(({ id }) => id === selectedId);
-  const attachmentQuery = useQuery(
-    emailAttachmentPreviewOptions({
-      attachmentId: selected?.id ?? "",
-      fieldId,
-      workspaceId,
-    }),
+  const previewQuery = useQuery(
+    emailHtmlPreviewOptions({ fieldId, workspaceId }),
   );
-  const [objectUrl, setObjectUrl] = useState<string | null>(null);
-
-  useExternalSyncEffect(() => {
-    if (!attachmentQuery.data) {
-      setObjectUrl(null);
-      return;
-    }
-    const url = URL.createObjectURL(
-      new Blob([attachmentQuery.data.buffer], {
-        type: attachmentQuery.data.mimeType,
-      }),
-    );
-    setObjectUrl(url);
-    return () => {
-      URL.revokeObjectURL(url);
-      setObjectUrl(null);
-    };
-  }, [attachmentQuery.data]);
 
   if (previewQuery.isPending) {
     return <Skeleton className="m-3 h-24 rounded-sm" />;
   }
   if (previewQuery.isError) {
-    return <FacetMessage icon={<AlertTriangleIcon aria-hidden="true" className="size-5" />} message={t("common.somethingWentWrong")} />;
-  }
-  if (selected) {
     return (
-      <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
-        <div className="flex min-h-12 shrink-0 items-center gap-2 border-b px-3">
-          <Button
-            aria-label={t("common.back")}
-            onClick={() => setSelectedId(null)}
-            size="icon-xs"
-            variant="ghost"
-          >
-            <ArrowLeftIcon aria-hidden="true" className="size-3.5" />
-          </Button>
-          <BidiText as="span" className="min-w-0 truncate text-sm font-medium">
-            {selected.fileName ?? t("emailViewer.unnamedAttachment")}
-          </BidiText>
-        </div>
-        <div className="bg-muted/30 flex min-h-0 flex-1 items-center justify-center p-2">
-          {attachmentQuery.isPending ? <Skeleton className="size-full rounded-sm" /> : null}
-          {attachmentQuery.isError ? (
-            <FacetMessage
-              icon={<AlertTriangleIcon aria-hidden="true" className="size-5" />}
-              message={t("common.somethingWentWrong")}
-            />
-          ) : null}
-          {objectUrl ? (
-            selected.mimeType?.toLowerCase().startsWith("image/") ? (
-              <img
-                alt={selected.fileName ?? t("emailViewer.unnamedAttachment")}
-                className="max-h-full max-w-full object-contain"
-                src={objectUrl}
-              />
-            ) : (
-              <iframe
-                className="bg-background size-full border-0"
-                referrerPolicy="no-referrer"
-                sandbox=""
-                src={objectUrl}
-                title={selected.fileName ?? t("emailViewer.unnamedAttachment")}
-              />
-            )
-          ) : null}
-        </div>
-      </div>
+      <FacetMessage
+        icon={<AlertTriangleIcon aria-hidden="true" className="size-5" />}
+        message={t("common.somethingWentWrong")}
+      />
+    );
+  }
+
+  const selected = previewQuery.data.attachments.find(
+    ({ id }) => id === selectedId,
+  );
+  if (selectedId !== null && selected === undefined) {
+    return (
+      <FacetMessage
+        icon={<AlertTriangleIcon aria-hidden="true" className="size-5" />}
+        message={t("common.somethingWentWrong")}
+      />
+    );
+  }
+  if (selected !== undefined) {
+    return (
+      <AttachmentPreview
+        attachment={selected}
+        fieldId={fieldId}
+        onBack={() => setSelectedId(null)}
+        t={t}
+        workspaceId={workspaceId}
+      />
     );
   }
 
   return (
-    <section aria-labelledby={`${fieldId}-attachment-facet`} className="min-h-0 flex-1 overflow-y-auto p-3">
-      <h2 className="text-muted-foreground mb-2 flex items-center gap-1.5 text-xs font-medium" id={`${fieldId}-attachment-facet`}>
-        <PaperclipIcon aria-hidden="true" className="size-3.5" />
-        {t("emailViewer.attachments")}
-      </h2>
-      {previewQuery.data.attachments.length === 0 ? (
-        <p className="text-muted-foreground text-sm">{t("common.noResults")}</p>
-      ) : (
-        <ul className="grid gap-1.5">
-          {previewQuery.data.attachments.map((attachment) => (
-            <li key={attachment.id}>
-              <button
-                className="hover:bg-muted/60 flex min-h-11 w-full items-center gap-2 rounded-md border px-2 text-start text-xs"
-                disabled={!attachment.previewable}
-                onClick={() => setSelectedId(attachment.id)}
-                type="button"
-              >
-                <DocumentIcon
-                  className="text-muted-foreground size-4 shrink-0"
-                  fileName={attachment.fileName ?? t("emailViewer.unnamedAttachment")}
-                  mimeType={attachment.mimeType ?? "application/octet-stream"}
-                />
-                <BidiText as="span" className="min-w-0 flex-1 truncate">
-                  {attachment.fileName ?? t("emailViewer.unnamedAttachment")}
-                </BidiText>
-                {!attachment.previewable ? (
-                  <span className="text-muted-foreground shrink-0">{t("chat.unsupportedFileType")}</span>
-                ) : null}
-              </button>
-            </li>
-          ))}
-        </ul>
-      )}
-    </section>
+    <AttachmentList
+      attachments={previewQuery.data.attachments}
+      fieldId={fieldId}
+      onSelect={setSelectedId}
+      t={t}
+    />
+  );
+};
+
+const AttachmentPreview = ({
+  attachment,
+  fieldId,
+  onBack,
+  t,
+  workspaceId,
+}: {
+  attachment: AttachmentDescriptor;
+  fieldId: string;
+  onBack: () => void;
+  t: ReturnType<typeof useTranslations>;
+  workspaceId: string;
+}) => {
+  const fileName = attachment.fileName ?? t("emailViewer.unnamedAttachment");
+  const isPdf = attachment.mimeType?.split(";").at(0)?.trim().toLowerCase() === "application/pdf";
+  const pdfQuery = useQuery(
+    emailAttachmentPdfOptions({
+      attachmentId: isPdf ? attachment.id : "",
+      fieldId,
+      workspaceId,
+    }),
+  );
+  const [pdfObjectUrl, setPdfObjectUrl] = useState<string | null>(null);
+
+  useExternalSyncEffect(() => {
+    if (!pdfQuery.data) {
+      setPdfObjectUrl(null);
+      return;
+    }
+    const objectUrl = URL.createObjectURL(
+      new Blob([pdfQuery.data], { type: "application/pdf" }),
+    );
+    setPdfObjectUrl(objectUrl);
+    return () => {
+      URL.revokeObjectURL(objectUrl);
+      setPdfObjectUrl(null);
+    };
+  }, [pdfQuery.data]);
+
+  const previewUrl = emailAttachmentPreviewUrl({
+    attachmentId: attachment.id,
+    fieldId,
+    workspaceId,
+  });
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+      <div className="flex min-h-12 shrink-0 items-center gap-2 border-b px-3">
+        <Button
+          aria-label={t("common.back")}
+          onClick={onBack}
+          size="icon-xs"
+          variant="ghost"
+        >
+          <ArrowLeftIcon aria-hidden="true" className="size-3.5" />
+        </Button>
+        <BidiText as="span" className="min-w-0 truncate text-sm font-medium">
+          {fileName}
+        </BidiText>
+      </div>
+      <div className="bg-muted/30 flex min-h-0 flex-1 items-center justify-center p-2">
+        {renderAttachmentPreview({
+          fileName,
+          mimeType: attachment.mimeType,
+          previewUrl: isPdf ? pdfObjectUrl : previewUrl,
+          previewError: pdfQuery.isError,
+          t,
+        })}
+      </div>
+    </div>
+  );
+};
+
+const renderAttachmentPreview = ({
+  fileName,
+  mimeType,
+  previewUrl,
+  previewError,
+  t,
+}: {
+  fileName: string;
+  mimeType: string | null;
+  previewUrl: string | null;
+  previewError: boolean;
+  t: ReturnType<typeof useTranslations>;
+}) => {
+  if (previewError) {
+    return (
+      <FacetMessage
+        icon={<AlertTriangleIcon aria-hidden="true" className="size-5" />}
+        message={t("common.somethingWentWrong")}
+      />
+    );
+  }
+  if (previewUrl === null) {
+    return <Skeleton className="size-full rounded-sm" />;
+  }
+  if (mimeType?.toLowerCase().startsWith("image/") === true) {
+    return (
+      <img
+        alt={fileName}
+        className="max-h-full max-w-full object-contain"
+        referrerPolicy="no-referrer"
+        src={previewUrl}
+      />
+    );
+  }
+
+  return (
+    <iframe
+      className="bg-background size-full border-0"
+      referrerPolicy="no-referrer"
+      sandbox=""
+      src={previewUrl}
+      title={t("emailViewer.bodyTitle")}
+    />
+  );
+};
+
+const AttachmentList = ({
+  attachments,
+  fieldId,
+  onSelect,
+  t,
+}: {
+  attachments: readonly AttachmentDescriptor[];
+  fieldId: string;
+  onSelect: (id: string) => void;
+  t: ReturnType<typeof useTranslations>;
+}) => (
+  <section
+    aria-labelledby={`${fieldId}-attachment-facet`}
+    className="min-h-0 flex-1 overflow-y-auto p-3"
+  >
+    <h2
+      className="text-muted-foreground mb-2 flex items-center gap-1.5 text-xs font-medium"
+      id={`${fieldId}-attachment-facet`}
+    >
+      <PaperclipIcon aria-hidden="true" className="size-3.5" />
+      {t("emailViewer.attachments")}
+    </h2>
+    {attachments.length === 0 ? (
+      <p className="text-muted-foreground text-sm">{t("common.noResults")}</p>
+    ) : (
+      <ul className="grid gap-1.5">
+        {attachments.map((attachment) => (
+          <AttachmentListItem
+            attachment={attachment}
+            key={attachment.id}
+            onSelect={onSelect}
+            t={t}
+          />
+        ))}
+      </ul>
+    )}
+  </section>
+);
+
+const AttachmentListItem = ({
+  attachment,
+  onSelect,
+  t,
+}: {
+  attachment: AttachmentDescriptor;
+  onSelect: (id: string) => void;
+  t: ReturnType<typeof useTranslations>;
+}) => {
+  const fileName = attachment.fileName ?? t("emailViewer.unnamedAttachment");
+  const unsupportedLabel = t("chat.unsupportedFileType");
+
+  return (
+    <li>
+      <button
+        className="hover:bg-muted/60 flex min-h-11 w-full items-center gap-2 rounded-md border px-2 text-start text-xs"
+        disabled={!attachment.previewable}
+        onClick={() => onSelect(attachment.id)}
+        type="button"
+      >
+        <DocumentIcon
+          className="text-muted-foreground size-4 shrink-0"
+          fileName={fileName}
+          mimeType={attachment.mimeType ?? "application/octet-stream"}
+        />
+        <BidiText as="span" className="min-w-0 flex-1 truncate">
+          {fileName}
+        </BidiText>
+        {!attachment.previewable ? (
+          <span className="text-muted-foreground shrink-0">
+            {unsupportedLabel}
+          </span>
+        ) : null}
+      </button>
+    </li>
   );
 };
 

--- a/apps/web/src/components/inspector/email-attachments-facet.tsx
+++ b/apps/web/src/components/inspector/email-attachments-facet.tsx
@@ -97,7 +97,9 @@ const AttachmentPreview = ({
   workspaceId: string;
 }) => {
   const fileName = attachment.fileName ?? t("emailViewer.unnamedAttachment");
-  const isPdf = attachment.mimeType?.split(";").at(0)?.trim().toLowerCase() === "application/pdf";
+  const isPdf =
+    attachment.mimeType?.split(";").at(0)?.trim().toLowerCase() ===
+    "application/pdf";
   const pdfQuery = useQuery(
     emailAttachmentPdfOptions({
       attachmentId: isPdf ? attachment.id : "",
@@ -106,6 +108,8 @@ const AttachmentPreview = ({
     }),
   );
   const [pdfObjectUrl, setPdfObjectUrl] = useState<string | null>(null);
+  const [imageFailed, setImageFailed] = useState(false);
+  const [imageAttempt, setImageAttempt] = useState(0);
 
   useExternalSyncEffect(() => {
     if (!pdfQuery.data) {
@@ -147,6 +151,13 @@ const AttachmentPreview = ({
         {renderAttachmentPreview({
           fileName,
           mimeType: attachment.mimeType,
+          imageFailed,
+          onImageError: () => setImageFailed(true),
+          onRetryImage: () => {
+            setImageFailed(false);
+            setImageAttempt((attempt) => attempt + 1);
+          },
+          imageAttempt,
           previewUrl: isPdf ? pdfObjectUrl : previewUrl,
           previewError: pdfQuery.isError,
           t,
@@ -158,13 +169,21 @@ const AttachmentPreview = ({
 
 const renderAttachmentPreview = ({
   fileName,
+  imageFailed,
+  imageAttempt,
   mimeType,
+  onImageError,
+  onRetryImage,
   previewUrl,
   previewError,
   t,
 }: {
   fileName: string;
+  imageFailed: boolean;
+  imageAttempt: number;
   mimeType: string | null;
+  onImageError: () => void;
+  onRetryImage: () => void;
   previewUrl: string | null;
   previewError: boolean;
   t: ReturnType<typeof useTranslations>;
@@ -172,6 +191,19 @@ const renderAttachmentPreview = ({
   if (previewError) {
     return (
       <FacetMessage
+        icon={<AlertTriangleIcon aria-hidden="true" className="size-5" />}
+        message={t("common.somethingWentWrong")}
+      />
+    );
+  }
+  if (imageFailed) {
+    return (
+      <FacetMessage
+        action={
+          <Button onClick={onRetryImage} size="sm" variant="outline">
+            {t("common.tryAgain")}
+          </Button>
+        }
         icon={<AlertTriangleIcon aria-hidden="true" className="size-5" />}
         message={t("common.somethingWentWrong")}
       />
@@ -185,6 +217,8 @@ const renderAttachmentPreview = ({
       <img
         alt={fileName}
         className="max-h-full max-w-full object-contain"
+        key={imageAttempt}
+        onError={onImageError}
         referrerPolicy="no-referrer"
         src={previewUrl}
       />
@@ -280,14 +314,17 @@ const AttachmentListItem = ({
 };
 
 const FacetMessage = ({
+  action,
   icon,
   message,
 }: {
+  action?: ReactNode;
   icon: ReactNode;
   message: string;
 }) => (
   <div className="text-muted-foreground flex min-h-0 flex-1 flex-col items-center justify-center gap-2 p-6 text-center text-sm">
     {icon}
     <p>{message}</p>
+    {action}
   </div>
 );

--- a/apps/web/src/components/inspector/email-attachments-facet.tsx
+++ b/apps/web/src/components/inspector/email-attachments-facet.tsx
@@ -67,7 +67,6 @@ export const EmailAttachmentsFacet = ({
         attachment={selected}
         fieldId={fieldId}
         onBack={() => setSelectedId(null)}
-        t={t}
         workspaceId={workspaceId}
       />
     );
@@ -78,7 +77,6 @@ export const EmailAttachmentsFacet = ({
       attachments={previewQuery.data.attachments}
       fieldId={fieldId}
       onSelect={setSelectedId}
-      t={t}
     />
   );
 };
@@ -87,15 +85,14 @@ const AttachmentPreview = ({
   attachment,
   fieldId,
   onBack,
-  t,
   workspaceId,
 }: {
   attachment: AttachmentDescriptor;
   fieldId: string;
   onBack: () => void;
-  t: ReturnType<typeof useTranslations>;
   workspaceId: string;
 }) => {
+  const t = useTranslations();
   const fileName = attachment.fileName ?? t("emailViewer.unnamedAttachment");
   const isPdf =
     attachment.mimeType?.split(";").at(0)?.trim().toLowerCase() ===
@@ -122,7 +119,6 @@ const AttachmentPreview = ({
     setPdfObjectUrl(objectUrl);
     return () => {
       URL.revokeObjectURL(objectUrl);
-      setPdfObjectUrl(null);
     };
   }, [pdfQuery.data]);
 
@@ -148,26 +144,25 @@ const AttachmentPreview = ({
         </BidiText>
       </div>
       <div className="bg-muted/30 flex min-h-0 flex-1 items-center justify-center p-2">
-        {renderAttachmentPreview({
-          fileName,
-          mimeType: attachment.mimeType,
-          imageFailed,
-          onImageError: () => setImageFailed(true),
-          onRetryImage: () => {
+        <AttachmentPreviewContent
+          fileName={fileName}
+          imageAttempt={imageAttempt}
+          imageFailed={imageFailed}
+          mimeType={attachment.mimeType}
+          onImageError={() => setImageFailed(true)}
+          onRetryImage={() => {
             setImageFailed(false);
             setImageAttempt((attempt) => attempt + 1);
-          },
-          imageAttempt,
-          previewUrl: isPdf ? pdfObjectUrl : previewUrl,
-          previewError: pdfQuery.isError,
-          t,
-        })}
+          }}
+          previewUrl={isPdf ? pdfObjectUrl : previewUrl}
+          previewError={pdfQuery.isError}
+        />
       </div>
     </div>
   );
 };
 
-const renderAttachmentPreview = ({
+const AttachmentPreviewContent = ({
   fileName,
   imageFailed,
   imageAttempt,
@@ -176,7 +171,6 @@ const renderAttachmentPreview = ({
   onRetryImage,
   previewUrl,
   previewError,
-  t,
 }: {
   fileName: string;
   imageFailed: boolean;
@@ -186,8 +180,8 @@ const renderAttachmentPreview = ({
   onRetryImage: () => void;
   previewUrl: string | null;
   previewError: boolean;
-  t: ReturnType<typeof useTranslations>;
 }) => {
+  const t = useTranslations();
   if (previewError) {
     return (
       <FacetMessage
@@ -240,50 +234,50 @@ const AttachmentList = ({
   attachments,
   fieldId,
   onSelect,
-  t,
 }: {
   attachments: readonly AttachmentDescriptor[];
   fieldId: string;
   onSelect: (id: string) => void;
-  t: ReturnType<typeof useTranslations>;
-}) => (
-  <section
-    aria-labelledby={`${fieldId}-attachment-facet`}
-    className="min-h-0 flex-1 overflow-y-auto p-3"
-  >
-    <h2
-      className="text-muted-foreground mb-2 flex items-center gap-1.5 text-xs font-medium"
-      id={`${fieldId}-attachment-facet`}
+}) => {
+  const t = useTranslations();
+
+  return (
+    <section
+      aria-labelledby={`${fieldId}-attachment-facet`}
+      className="min-h-0 flex-1 overflow-y-auto p-3"
     >
-      <PaperclipIcon aria-hidden="true" className="size-3.5" />
-      {t("emailViewer.attachments")}
-    </h2>
-    {attachments.length === 0 ? (
-      <p className="text-muted-foreground text-sm">{t("common.noResults")}</p>
-    ) : (
-      <ul className="grid gap-1.5">
-        {attachments.map((attachment) => (
-          <AttachmentListItem
-            attachment={attachment}
-            key={attachment.id}
-            onSelect={onSelect}
-            t={t}
-          />
-        ))}
-      </ul>
-    )}
-  </section>
-);
+      <h2
+        className="text-muted-foreground mb-2 flex items-center gap-1.5 text-xs font-medium"
+        id={`${fieldId}-attachment-facet`}
+      >
+        <PaperclipIcon aria-hidden="true" className="size-3.5" />
+        {t("emailViewer.attachments")}
+      </h2>
+      {attachments.length === 0 ? (
+        <p className="text-muted-foreground text-sm">{t("common.noResults")}</p>
+      ) : (
+        <ul className="grid gap-1.5">
+          {attachments.map((attachment) => (
+            <AttachmentListItem
+              attachment={attachment}
+              key={attachment.id}
+              onSelect={onSelect}
+            />
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+};
 
 const AttachmentListItem = ({
   attachment,
   onSelect,
-  t,
 }: {
   attachment: AttachmentDescriptor;
   onSelect: (id: string) => void;
-  t: ReturnType<typeof useTranslations>;
 }) => {
+  const t = useTranslations();
   const fileName = attachment.fileName ?? t("emailViewer.unnamedAttachment");
   const unsupportedLabel = t("chat.unsupportedFileType");
 

--- a/apps/web/src/components/inspector/email-attachments-facet.tsx
+++ b/apps/web/src/components/inspector/email-attachments-facet.tsx
@@ -12,8 +12,7 @@ import { Skeleton } from "@stll/ui/components/skeleton";
 import { DocumentIcon } from "@/components/document-icon";
 import { useExternalSyncEffect } from "@/hooks/use-effect";
 import {
-  emailAttachmentPdfOptions,
-  emailAttachmentPreviewUrl,
+  emailAttachmentPreviewOptions,
   emailHtmlPreviewOptions,
 } from "@/lib/files/queries";
 
@@ -95,39 +94,32 @@ const AttachmentPreview = ({
 }) => {
   const t = useTranslations();
   const fileName = attachment.fileName ?? t("emailViewer.unnamedAttachment");
-  const isPdf =
-    attachment.mimeType?.split(";").at(0)?.trim().toLowerCase() ===
-    "application/pdf";
-  const pdfQuery = useQuery(
-    emailAttachmentPdfOptions({
-      attachmentId: isPdf ? attachment.id : "",
+  const attachmentQuery = useQuery(
+    emailAttachmentPreviewOptions({
+      attachmentId: attachment.id,
       fieldId,
       workspaceId,
     }),
   );
-  const [pdfObjectUrl, setPdfObjectUrl] = useState<string | null>(null);
+  const [previewObjectUrl, setPreviewObjectUrl] = useState<string | null>(null);
   const [imageFailed, setImageFailed] = useState(false);
   const [imageAttempt, setImageAttempt] = useState(0);
 
   useExternalSyncEffect(() => {
-    if (!pdfQuery.data) {
-      setPdfObjectUrl(null);
+    if (!attachmentQuery.data) {
+      setPreviewObjectUrl(null);
       return undefined;
     }
     const objectUrl = URL.createObjectURL(
-      new Blob([pdfQuery.data], { type: "application/pdf" }),
+      new Blob([attachmentQuery.data], {
+        type: attachment.mimeType ?? "application/octet-stream",
+      }),
     );
-    setPdfObjectUrl(objectUrl);
+    setPreviewObjectUrl(objectUrl);
     return () => {
       URL.revokeObjectURL(objectUrl);
     };
-  }, [pdfQuery.data]);
-
-  const previewUrl = emailAttachmentPreviewUrl({
-    attachmentId: attachment.id,
-    fieldId,
-    workspaceId,
-  });
+  }, [attachment.mimeType, attachmentQuery.data]);
 
   return (
     <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
@@ -155,8 +147,8 @@ const AttachmentPreview = ({
             setImageFailed(false);
             setImageAttempt((attempt) => attempt + 1);
           }}
-          previewUrl={isPdf ? pdfObjectUrl : previewUrl}
-          previewError={pdfQuery.isError}
+          previewUrl={previewObjectUrl}
+          previewError={attachmentQuery.isError}
         />
       </div>
     </div>
@@ -226,7 +218,7 @@ const AttachmentPreviewContent = ({
       referrerPolicy="no-referrer"
       sandbox=""
       src={previewUrl}
-      title={t("emailViewer.bodyTitle")}
+      title={fileName}
     />
   );
 };
@@ -317,7 +309,10 @@ const FacetMessage = ({
   icon: ReactNode;
   message: string;
 }) => (
-  <div className="text-muted-foreground flex min-h-0 flex-1 flex-col items-center justify-center gap-2 p-6 text-center text-sm">
+  <div
+    className="text-muted-foreground flex min-h-0 flex-1 flex-col items-center justify-center gap-2 p-6 text-center text-sm"
+    role="alert"
+  >
     {icon}
     <p>{message}</p>
     {action}

--- a/apps/web/src/components/inspector/email-html-viewer.test.tsx
+++ b/apps/web/src/components/inspector/email-html-viewer.test.tsx
@@ -178,8 +178,10 @@ describe("email viewer", () => {
     queryClient.setQueryData(options.queryKey, {
       attachments: [
         {
+          id: "attachment-1",
           fileName: "contract.pdf",
           mimeType: "application/pdf",
+          previewable: true,
           sizeBytes: 2048,
         },
       ],

--- a/apps/web/src/components/inspector/file-facets.tsx
+++ b/apps/web/src/components/inspector/file-facets.tsx
@@ -8,13 +8,16 @@ import { stellaToast } from "@stll/ui/components/toast";
 
 import { useReviewStore } from "@/components/ai-suggestions/review-store";
 import { FacetBar } from "@/components/inspector/inspector-facet-bar";
-import type { FileTab } from "@/components/inspector/inspector-tabs-store";
+import type {
+  FileFacet,
+  FileTab,
+} from "@/components/inspector/inspector-store-types";
 import { useExternalSyncEffect } from "@/hooks/use-effect";
 import { usePlaybooksPreviewEnabled } from "@/hooks/use-playbooks-preview";
 import { DOCX_MIME, isEmailFile } from "@/lib/consts";
 import { entityVersionsOptions } from "@/lib/workspaces/queries/entity-versions";
 
-export type Facet = NonNullable<FileTab["facet"]>;
+export type Facet = FileFacet;
 
 /**
  * Mounted only inside the fullscreen branch. If the user enters Full
@@ -136,7 +139,15 @@ export const TabFacetBar = ({
       facets: gated.filter((f) => isEmail || f !== "attachments"),
       disabledFacets: undefined,
     };
-  }, [baseFacets, fileName, isDocx, isEmail, mimeType, suggestionCount, playbooksEnabled]);
+  }, [
+    baseFacets,
+    fileName,
+    isDocx,
+    isEmail,
+    mimeType,
+    suggestionCount,
+    playbooksEnabled,
+  ]);
 
   const labels: Record<Facet, string> = {
     preview: t("common.preview"),

--- a/apps/web/src/components/inspector/file-facets.tsx
+++ b/apps/web/src/components/inspector/file-facets.tsx
@@ -139,15 +139,7 @@ export const TabFacetBar = ({
       facets: gated.filter((f) => isEmail || f !== "attachments"),
       disabledFacets: undefined,
     };
-  }, [
-    baseFacets,
-    fileName,
-    isDocx,
-    isEmail,
-    mimeType,
-    suggestionCount,
-    playbooksEnabled,
-  ]);
+  }, [baseFacets, isDocx, isEmail, suggestionCount, playbooksEnabled]);
 
   const labels: Record<Facet, string> = {
     preview: t("common.preview"),

--- a/apps/web/src/components/inspector/file-facets.tsx
+++ b/apps/web/src/components/inspector/file-facets.tsx
@@ -11,7 +11,7 @@ import { FacetBar } from "@/components/inspector/inspector-facet-bar";
 import type { FileTab } from "@/components/inspector/inspector-tabs-store";
 import { useExternalSyncEffect } from "@/hooks/use-effect";
 import { usePlaybooksPreviewEnabled } from "@/hooks/use-playbooks-preview";
-import { DOCX_MIME } from "@/lib/consts";
+import { DOCX_MIME, isEmailFile } from "@/lib/consts";
 import { entityVersionsOptions } from "@/lib/workspaces/queries/entity-versions";
 
 export type Facet = NonNullable<FileTab["facet"]>;
@@ -70,6 +70,7 @@ type TabFacetBarProps = {
   workspaceId: string;
   entityId: string;
   fieldId: string;
+  fileName: string;
   mimeType: string | undefined;
   /**
    * Base list before this component drops/disables the suggestions
@@ -86,6 +87,7 @@ export const TabFacetBar = ({
   workspaceId,
   entityId,
   fieldId,
+  fileName,
   mimeType,
   baseFacets,
 }: TabFacetBarProps) => {
@@ -97,6 +99,7 @@ export const TabFacetBar = ({
     (state) => state.sessions[entityId]?.length ?? 0,
   );
   const isDocx = mimeType === DOCX_MIME;
+  const isEmail = isEmailFile({ fileName, mimeType });
   const playbooksEnabled = usePlaybooksPreviewEnabled();
 
   const { facets, disabledFacets } = useMemo(() => {
@@ -114,21 +117,30 @@ export const TabFacetBar = ({
     // chat queues a proposal.
     if (!isDocx) {
       return {
-        facets: gated.filter((f) => f !== "suggestions" && f !== "playbook"),
+        facets: gated.filter(
+          (f) =>
+            f !== "suggestions" &&
+            f !== "playbook" &&
+            (isEmail || f !== "attachments"),
+        ),
         disabledFacets: undefined,
       };
     }
     if (suggestionCount === 0) {
       return {
-        facets: gated,
+        facets: gated.filter((f) => isEmail || f !== "attachments"),
         disabledFacets: new Set<Facet>(["suggestions"]),
       };
     }
-    return { facets: gated, disabledFacets: undefined };
-  }, [baseFacets, isDocx, suggestionCount, playbooksEnabled]);
+    return {
+      facets: gated.filter((f) => isEmail || f !== "attachments"),
+      disabledFacets: undefined,
+    };
+  }, [baseFacets, fileName, isDocx, isEmail, mimeType, suggestionCount, playbooksEnabled]);
 
   const labels: Record<Facet, string> = {
     preview: t("common.preview"),
+    attachments: t("emailViewer.attachments"),
     metadata: t("common.metadata"),
     versions: t("fileDetail.versionHistory"),
     suggestions: t("docxReview.title"),

--- a/apps/web/src/components/inspector/file-tab-panel.logic.ts
+++ b/apps/web/src/components/inspector/file-tab-panel.logic.ts
@@ -1,4 +1,7 @@
-import type { Facet } from "@/components/inspector/file-facets";
+import {
+  FILE_FACETS,
+  type FileFacet as Facet,
+} from "@/components/inspector/inspector-store-types";
 import { isEmailFile, isMarkdownFile } from "@/lib/consts";
 
 // Sidepeek shows every facet, including Preview (the file viewer
@@ -7,23 +10,10 @@ import { isEmailFile, isMarkdownFile } from "@/lib/consts";
 // FullViewPreviewGuard handles users who land in Full view with a
 // stale "preview" facet by swapping to Metadata + flashing the
 // Minimize button.
-export const FACETS: readonly Facet[] = [
-  "preview",
-  "attachments",
-  "metadata",
-  "versions",
-  "suggestions",
-  "playbook",
-  "anonymization",
-];
-export const FULLVIEW_FACETS: readonly Facet[] = [
-  "attachments",
-  "metadata",
-  "versions",
-  "suggestions",
-  "playbook",
-  "anonymization",
-];
+export const FACETS: readonly Facet[] = FILE_FACETS;
+export const FULLVIEW_FACETS: readonly Facet[] = FILE_FACETS.filter(
+  (facet) => facet !== "preview",
+);
 
 export type FileTabNativePreviewKind = "email" | "markdown" | "pdf";
 

--- a/apps/web/src/components/inspector/file-tab-panel.logic.ts
+++ b/apps/web/src/components/inspector/file-tab-panel.logic.ts
@@ -9,6 +9,7 @@ import { isEmailFile, isMarkdownFile } from "@/lib/consts";
 // Minimize button.
 export const FACETS: readonly Facet[] = [
   "preview",
+  "attachments",
   "metadata",
   "versions",
   "suggestions",
@@ -16,6 +17,7 @@ export const FACETS: readonly Facet[] = [
   "anonymization",
 ];
 export const FULLVIEW_FACETS: readonly Facet[] = [
+  "attachments",
   "metadata",
   "versions",
   "suggestions",

--- a/apps/web/src/components/inspector/file-tab-panel.tsx
+++ b/apps/web/src/components/inspector/file-tab-panel.tsx
@@ -25,6 +25,7 @@ import { getDocxEditBlockReason } from "@/components/docx/docx-browser-editor.lo
 import { AnonymizationFacet } from "@/components/inspector/anonymization-facet";
 import { DesktopOpenButton } from "@/components/inspector/desktop-open-button";
 import { DocumentAiSourceBar } from "@/components/inspector/document-ai-source-bar";
+import { EmailAttachmentsFacet } from "@/components/inspector/email-attachments-facet";
 import { EmailFileViewer } from "@/components/inspector/email-html-viewer";
 import {
   EMAIL_CHAT_MODE,
@@ -456,6 +457,7 @@ export const FileTabPanel = ({
           entityId={tab.entityId}
           facet={tab.facet ?? "metadata"}
           fieldId={tab.id}
+          fileName={tab.fileName}
           mimeType={tab.mimeType}
           onChange={(next) => {
             setFileFacet(tab.id, next);
@@ -508,6 +510,12 @@ export const FileTabPanel = ({
                 workspaceId={tab.workspaceId}
               />
             </Suspense>
+          )}
+          {tab.facet === "attachments" && isEmailDisplay && (
+            <EmailAttachmentsFacet
+              fieldId={tab.id}
+              workspaceId={tab.workspaceId}
+            />
           )}
           {tab.facet === "versions" && (
             <VersionsFacet
@@ -952,6 +960,7 @@ export const FileTabPanel = ({
       entityId={tab.entityId}
       facet={sidepeekFacet}
       fieldId={tab.id}
+      fileName={tab.fileName}
       mimeType={tab.mimeType}
       onChange={(next) => {
         setFileFacet(tab.id, next);
@@ -1018,6 +1027,12 @@ export const FileTabPanel = ({
                 workspaceId={tab.workspaceId}
               />
             </Suspense>
+          )}
+          {sidepeekFacet === "attachments" && isEmailDisplay && (
+            <EmailAttachmentsFacet
+              fieldId={tab.id}
+              workspaceId={tab.workspaceId}
+            />
           )}
           {sidepeekFacet === "versions" && (
             <VersionsFacet

--- a/apps/web/src/components/inspector/inspector-broadcast.ts
+++ b/apps/web/src/components/inspector/inspector-broadcast.ts
@@ -4,11 +4,12 @@ import type { StoreApi } from "zustand";
 import { isTaskStatus } from "@stll/api-contract";
 
 import { useInspectorCommandStore } from "@/components/inspector/inspector-command-store";
-import type {
-  ChatTab,
-  FileTab,
-  InspectorTab,
-  InspectorTabsStore,
+import {
+  FILE_FACETS,
+  type ChatTab,
+  type FileTab,
+  type InspectorTab,
+  type InspectorTabsStore,
 } from "@/components/inspector/inspector-store-types";
 import {
   isGenericInspectorTab,
@@ -159,17 +160,11 @@ const isOptionalString = (value: unknown): value is string | undefined =>
 const isOptionalNumber = (value: unknown): value is number | undefined =>
   value === undefined || typeof value === "number";
 
-export const isPdfFacet = (
+export const isFileFacet = (
   value: unknown,
 ): value is NonNullable<FileTab["facet"]> | undefined =>
   value === undefined ||
-  value === "preview" ||
-  value === "attachments" ||
-  value === "metadata" ||
-  value === "versions" ||
-  value === "suggestions" ||
-  value === "playbook" ||
-  value === "anonymization";
+  (typeof value === "string" && FILE_FACETS.some((facet) => facet === value));
 
 const isMetadataLane = (value: unknown): value is FileTab["metadataLane"] =>
   value === undefined || value === "closed" || value === "expanded";
@@ -269,7 +264,7 @@ const isInspectorTab = (value: unknown): value is InspectorTab => {
       isOptionalString(value["justificationFieldId"]) &&
       isOptionalString(value["propertyId"]) &&
       isMetadataLane(value["metadataLane"]) &&
-      isPdfFacet(value["facet"]) &&
+      isFileFacet(value["facet"]) &&
       isOptionalNumber(value["facetPulseSeq"])
     );
   }

--- a/apps/web/src/components/inspector/inspector-broadcast.ts
+++ b/apps/web/src/components/inspector/inspector-broadcast.ts
@@ -159,11 +159,12 @@ const isOptionalString = (value: unknown): value is string | undefined =>
 const isOptionalNumber = (value: unknown): value is number | undefined =>
   value === undefined || typeof value === "number";
 
-const isPdfFacet = (
+export const isPdfFacet = (
   value: unknown,
 ): value is NonNullable<FileTab["facet"]> | undefined =>
   value === undefined ||
   value === "preview" ||
+  value === "attachments" ||
   value === "metadata" ||
   value === "versions" ||
   value === "suggestions" ||

--- a/apps/web/src/components/inspector/inspector-store-types.ts
+++ b/apps/web/src/components/inspector/inspector-store-types.ts
@@ -22,6 +22,7 @@ export type FileTab = {
   metadataLane?: "closed" | "expanded" | undefined;
   facet?:
     | "preview"
+    | "attachments"
     | "metadata"
     | "versions"
     | "suggestions"

--- a/apps/web/src/components/inspector/inspector-store-types.ts
+++ b/apps/web/src/components/inspector/inspector-store-types.ts
@@ -7,6 +7,19 @@ import type { ChatThreadId } from "@/lib/chat-thread-ref";
 
 export type ExternalTabId = `external:${string}`;
 
+/** Canonical file-inspector facet domain shared by state, UI, and broadcast validation. */
+export const FILE_FACETS = [
+  "preview",
+  "attachments",
+  "metadata",
+  "versions",
+  "suggestions",
+  "playbook",
+  "anonymization",
+] as const;
+
+export type FileFacet = (typeof FILE_FACETS)[number];
+
 export type FileTab = {
   type: "pdf";
   id: string;
@@ -20,15 +33,7 @@ export type FileTab = {
   justificationFieldId?: string | undefined;
   propertyId?: string | undefined;
   metadataLane?: "closed" | "expanded" | undefined;
-  facet?:
-    | "preview"
-    | "attachments"
-    | "metadata"
-    | "versions"
-    | "suggestions"
-    | "playbook"
-    | "anonymization"
-    | undefined;
+  facet?: FileFacet | undefined;
   facetPulseSeq?: number | undefined;
 };
 

--- a/apps/web/src/components/inspector/inspector-tabs-slice.ts
+++ b/apps/web/src/components/inspector/inspector-tabs-slice.ts
@@ -13,6 +13,7 @@ import type {
 import { getInspectorView } from "@/components/inspector/view-registry";
 import { normalizeOptionalArray } from "@/lib/arrays";
 import { createChatThreadId } from "@/lib/chat-thread-ref";
+import { isEmailFile } from "@/lib/consts";
 
 export const buildSkillResourceTabId = ({
   skillName,
@@ -98,6 +99,12 @@ const upsertFileTab = (
   existing.fileName = tab.fileName;
   if (tab.mimeType !== undefined) {
     existing.mimeType = tab.mimeType;
+  }
+  if (
+    existing.facet === "attachments" &&
+    !isEmailFile({ fileName: tab.fileName, mimeType: tab.mimeType })
+  ) {
+    existing.facet = "preview";
   }
   existing.pdfFileId = tab.pdfFileId;
   if (

--- a/apps/web/src/components/inspector/inspector-tabs-slice.ts
+++ b/apps/web/src/components/inspector/inspector-tabs-slice.ts
@@ -65,6 +65,15 @@ type UpsertFileTabOptions = {
   renderIdPolicy: (typeof FILE_TAB_RENDER_ID_POLICY)[keyof typeof FILE_TAB_RENDER_ID_POLICY];
 };
 
+const normalizeFileTabFacet = (tab: Draft<FileTab>): void => {
+  if (
+    tab.facet === "attachments" &&
+    !isEmailFile({ fileName: tab.fileName, mimeType: tab.mimeType })
+  ) {
+    tab.facet = "preview";
+  }
+};
+
 const upsertFileTab = (
   state: Draft<InspectorTabsStore>,
   tab: Omit<FileTab, "type">,
@@ -100,12 +109,7 @@ const upsertFileTab = (
   if (tab.mimeType !== undefined) {
     existing.mimeType = tab.mimeType;
   }
-  if (
-    existing.facet === "attachments" &&
-    !isEmailFile({ fileName: tab.fileName, mimeType: tab.mimeType })
-  ) {
-    existing.facet = "preview";
-  }
+  normalizeFileTabFacet(existing);
   existing.pdfFileId = tab.pdfFileId;
   if (
     renderIdPolicy === FILE_TAB_RENDER_ID_POLICY.always ||
@@ -545,6 +549,7 @@ export const createInspectorTabsSlice = (
       if (next.propertyId !== undefined) {
         tab.propertyId = next.propertyId;
       }
+      normalizeFileTabFacet(tab);
       if (state.activeId === oldFieldId) {
         state.activeId = next.id;
       }

--- a/apps/web/src/components/inspector/inspector-tabs-store.test.ts
+++ b/apps/web/src/components/inspector/inspector-tabs-store.test.ts
@@ -542,6 +542,32 @@ describe("replaceFileFieldId", () => {
     expect(tab.pdfFileId).toBe("pdf-1");
     expect(tab.propertyId).toBe("property-2");
   });
+
+  test("resets attachments when a version replacement stops being an email", () => {
+    useInspectorTabsStore.getState().openFile({
+      id: "field-old",
+      entityId: "entity-1",
+      label: "Message",
+      fileName: "message.eml",
+      mimeType: "message/rfc822",
+      pdfFileId: null,
+      propertyId: "property-1",
+      workspaceId: "workspace-1",
+    });
+    useInspectorTabsStore.getState().setFileFacet("field-old", "attachments");
+
+    useInspectorTabsStore.getState().replaceFileFieldId("field-old", {
+      id: "field-new",
+      fileName: "contract.pdf",
+      mimeType: "application/pdf",
+    });
+
+    expect(
+      useInspectorTabsStore
+        .getState()
+        .tabs.find(({ id }) => id === "field-new"),
+    ).toMatchObject({ facet: "preview", type: "pdf" });
+  });
 });
 
 const openFullscreenFileTab = () => {

--- a/apps/web/src/components/inspector/inspector-tabs-store.test.ts
+++ b/apps/web/src/components/inspector/inspector-tabs-store.test.ts
@@ -8,6 +8,7 @@ import {
   useInspectorTabsStore,
 } from "@/components/inspector/inspector-tabs-store";
 import { registerInspectorView } from "@/components/inspector/view-registry";
+import { isPdfFacet } from "@/components/inspector/inspector-broadcast";
 import { toChatThreadId } from "@/lib/chat-thread-ref";
 
 let cleanupInspectorBroadcast: (() => void) | null = null;
@@ -805,6 +806,11 @@ describe("closeTabsForEntities", () => {
 });
 
 describe("Inspector tab broadcast", () => {
+  test("preserves the email attachments facet in the broadcast domain", () => {
+    expect(isPdfFacet("attachments")).toBe(true);
+    expect(isPdfFacet("unknown")).toBe(false);
+  });
+
   test("publishes tab set metadata without sharing local active state", () => {
     installFakeBroadcastChannel();
     const scope = { organizationId: "org-1", userId: "user-1" };

--- a/apps/web/src/components/inspector/inspector-tabs-store.test.ts
+++ b/apps/web/src/components/inspector/inspector-tabs-store.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, test } from "bun:test";
 
+import { isFileFacet } from "@/components/inspector/inspector-broadcast";
 import {
   buildSkillResourceTabId,
   closeInspectorTabsForEntities,
@@ -8,7 +9,6 @@ import {
   useInspectorTabsStore,
 } from "@/components/inspector/inspector-tabs-store";
 import { registerInspectorView } from "@/components/inspector/view-registry";
-import { isPdfFacet } from "@/components/inspector/inspector-broadcast";
 import { toChatThreadId } from "@/lib/chat-thread-ref";
 
 let cleanupInspectorBroadcast: (() => void) | null = null;
@@ -807,8 +807,8 @@ describe("closeTabsForEntities", () => {
 
 describe("Inspector tab broadcast", () => {
   test("preserves the email attachments facet in the broadcast domain", () => {
-    expect(isPdfFacet("attachments")).toBe(true);
-    expect(isPdfFacet("unknown")).toBe(false);
+    expect(isFileFacet("attachments")).toBe(true);
+    expect(isFileFacet("unknown")).toBe(false);
   });
 
   test("publishes tab set metadata without sharing local active state", () => {

--- a/apps/web/src/components/inspector/inspector-tabs-store.test.ts
+++ b/apps/web/src/components/inspector/inspector-tabs-store.test.ts
@@ -411,6 +411,36 @@ describe("replaceFileFieldId", () => {
     expect(useInspectorTabsStore.getState().activeId).toBe("field-v2");
   });
 
+  test("resets the attachments facet when the reused tab stops showing an email", () => {
+    useInspectorTabsStore.getState().openFile({
+      id: "field-email",
+      entityId: "entity-1",
+      label: "Message",
+      fileName: "message.eml",
+      mimeType: "message/rfc822",
+      pdfFileId: null,
+      propertyId: "property-1",
+      workspaceId: "workspace-1",
+    });
+    useInspectorTabsStore.getState().setFileFacet("field-email", "attachments");
+
+    useInspectorTabsStore.getState().openFile({
+      id: "field-pdf",
+      entityId: "entity-1",
+      label: "Contract",
+      fileName: "contract.pdf",
+      mimeType: "application/pdf",
+      pdfFileId: null,
+      propertyId: "property-1",
+      workspaceId: "workspace-1",
+    });
+
+    const tab = useInspectorTabsStore
+      .getState()
+      .tabs.find((item) => item.id === "field-pdf");
+    expect(tab).toMatchObject({ facet: "preview", type: "pdf" });
+  });
+
   test("openFileForEntity drops a stale tab whose id collides with the new field", () => {
     useInspectorTabsStore.getState().openFile({
       id: "field-shared",

--- a/apps/web/src/lib/files/queries.ts
+++ b/apps/web/src/lib/files/queries.ts
@@ -1,6 +1,7 @@
 import { queryOptions } from "@tanstack/react-query";
 
 import { api } from "@/lib/api";
+import { apiUrl } from "@/lib/api-url";
 import { unwrapEden } from "@/lib/errors/api";
 import type { EmailBodyFold } from "@/lib/files/email-preview";
 import {
@@ -122,14 +123,30 @@ export const emailHtmlPreviewOptions = (props: FileOptionsProps) =>
     },
   });
 
-export const emailAttachmentPreviewOptions = ({
+export const emailAttachmentPreviewUrl = ({
+  attachmentId,
+  fieldId,
+  workspaceId,
+}: FileOptionsProps & { attachmentId: string }): string =>
+  apiUrl(
+    `/files/${encodeURIComponent(workspaceId)}/email-attachment/${encodeURIComponent(fieldId)}/${encodeURIComponent(attachmentId)}?disposition=inline`,
+  );
+
+export const emailAttachmentPdfOptions = ({
   attachmentId,
   fieldId,
   workspaceId,
 }: FileOptionsProps & { attachmentId: string }) =>
   queryOptions({
     enabled: attachmentId.length > 0,
-    queryKey: [...filesKeys.emailHtmlByFieldId({ fieldId, workspaceId }), "attachment", attachmentId],
+    gcTime: 0,
+    retry: false,
+    staleTime: 0,
+    queryKey: [
+      ...filesKeys.emailHtmlByFieldId({ fieldId, workspaceId }),
+      "attachment-pdf",
+      attachmentId,
+    ],
     queryFn: async ({ signal }) => {
       const response = await api
         .files({ workspaceId })
@@ -139,10 +156,7 @@ export const emailAttachmentPreviewOptions = ({
       if (!(data instanceof Response)) {
         throw new TypeError("Email attachment preview returned no bytes");
       }
-      return {
-        buffer: await data.arrayBuffer(),
-        mimeType: data.headers.get("content-type") ?? "application/octet-stream",
-      };
+      return await data.arrayBuffer();
     },
   });
 

--- a/apps/web/src/lib/files/queries.ts
+++ b/apps/web/src/lib/files/queries.ts
@@ -30,9 +30,11 @@ type EmailHtmlPreviewData = {
   bcc: string[];
   date: string | null;
   attachments: {
+    id: string;
     fileName: string | null;
     mimeType: string | null;
     sizeBytes: number;
+    previewable: boolean;
   }[];
   bodyFolds: EmailBodyFold[];
   bodyHtml: string;
@@ -117,6 +119,30 @@ export const emailHtmlPreviewOptions = (props: FileOptionsProps) =>
         bodyFolds: data.bodyFolds,
         bodyHtml: data.bodyHtml,
       } satisfies EmailHtmlPreviewData;
+    },
+  });
+
+export const emailAttachmentPreviewOptions = ({
+  attachmentId,
+  fieldId,
+  workspaceId,
+}: FileOptionsProps & { attachmentId: string }) =>
+  queryOptions({
+    enabled: attachmentId.length > 0,
+    queryKey: [...filesKeys.emailHtmlByFieldId({ fieldId, workspaceId }), "attachment", attachmentId],
+    queryFn: async ({ signal }) => {
+      const response = await api
+        .files({ workspaceId })
+        ["email-attachment"]({ fieldId, attachmentId })
+        .get({ query: { disposition: "inline" }, fetch: { signal } });
+      const data = unwrapEden(response);
+      if (!(data instanceof Response)) {
+        throw new TypeError("Email attachment preview returned no bytes");
+      }
+      return {
+        buffer: await data.arrayBuffer(),
+        mimeType: data.headers.get("content-type") ?? "application/octet-stream",
+      };
     },
   });
 

--- a/apps/web/src/lib/files/queries.ts
+++ b/apps/web/src/lib/files/queries.ts
@@ -150,7 +150,7 @@ export const emailAttachmentPdfOptions = ({
     queryFn: async ({ signal }) => {
       const response = await api
         .files({ workspaceId })
-        ["email-attachment"]({ fieldId, attachmentId })
+        ["email-attachment"]({ fieldId })({ attachmentId })
         .get({ query: { disposition: "inline" }, fetch: { signal } });
       const data = unwrapEden(response);
       if (!(data instanceof Response)) {

--- a/apps/web/src/lib/files/queries.ts
+++ b/apps/web/src/lib/files/queries.ts
@@ -133,7 +133,7 @@ export const emailAttachmentPreviewUrl = ({
     `/files/${encodeURIComponent(workspaceId)}/email-attachment/${encodeURIComponent(fieldId)}/${encodeURIComponent(attachmentId)}?disposition=inline`,
   );
 
-export const emailAttachmentPdfOptions = ({
+export const emailAttachmentPreviewOptions = ({
   attachmentId,
   fieldId,
   workspaceId,
@@ -145,7 +145,7 @@ export const emailAttachmentPdfOptions = ({
     staleTime: 0,
     queryKey: [
       ...filesKeys.emailHtmlByFieldId({ fieldId, workspaceId }),
-      "attachment-pdf",
+      "attachment-preview",
       attachmentId,
     ],
     queryFn: async ({ signal }) => {

--- a/apps/web/src/lib/files/queries.ts
+++ b/apps/web/src/lib/files/queries.ts
@@ -2,7 +2,8 @@ import { queryOptions } from "@tanstack/react-query";
 
 import { api } from "@/lib/api";
 import { apiUrl } from "@/lib/api-url";
-import { unwrapEden } from "@/lib/errors/api";
+import { APIError, unwrapEden } from "@/lib/errors/api";
+import { fetchWithTimeout } from "@/lib/fetch";
 import type { EmailBodyFold } from "@/lib/files/email-preview";
 import {
   fileContentQueryKey,
@@ -148,15 +149,17 @@ export const emailAttachmentPdfOptions = ({
       attachmentId,
     ],
     queryFn: async ({ signal }) => {
-      const response = await api
-        .files({ workspaceId })
-        ["email-attachment"]({ fieldId })({ attachmentId })
-        .get({ query: { disposition: "inline" }, fetch: { signal } });
-      const data = unwrapEden(response);
-      if (!(data instanceof Response)) {
-        throw new TypeError("Email attachment preview returned no bytes");
+      const response = await fetchWithTimeout(
+        emailAttachmentPreviewUrl({ attachmentId, fieldId, workspaceId }),
+        { credentials: "include", signal, timeoutMs: 60_000 },
+      );
+      if (!response.ok) {
+        throw new APIError({
+          status: response.status,
+          message: "Failed to preview email attachment",
+        });
       }
-      return await data.arrayBuffer();
+      return await response.arrayBuffer();
     },
   });
 

--- a/docs/capability-coverage.md
+++ b/docs/capability-coverage.md
@@ -496,7 +496,7 @@ mechanics, and similar), not gaps in coverage.
 | chat_thread_ui         | 1     |
 | compound_consent       | 1     |
 | deploy_mechanics       | 1     |
-| document_processing    | 9     |
+| document_processing    | 10    |
 | health_infra           | 1     |
 | hosted_billing         | 3     |
 | mcp_transport          | 11    |
@@ -509,4 +509,4 @@ mechanics, and similar), not gaps in coverage.
 | upload_mechanics       | 5     |
 | url_preview            | 2     |
 
-Total: 108
+Total: 109

--- a/scripts/typecheck-baseline.json
+++ b/scripts/typecheck-baseline.json
@@ -1,11 +1,11 @@
 {
   "api": {
     "types": 975451,
-    "instantiations": 5230813
+    "instantiations": 5240000
   },
   "web": {
     "types": 1293058,
-    "instantiations": 9716697
+    "instantiations": 9723000
   },
   "web-e2e": {
     "types": 23880,


### PR DESCRIPTION
Adds a dedicated Attachments facet to email files in the Inspector.

- Lists bounded attachment descriptors without exposing attachment bytes or storage URLs in email metadata.
- Opens authenticated temporary previews for passive image and PDF formats.
- Reauthorizes and reparses the immutable source email for every preview request; unsupported active content fails closed.
- Covers descriptor binding, tamper resistance, preview policy, and Inspector facet state.
- Adjusts the committed typecheck instantiation baselines by 0.18% for API and 0.07% for web after bounding the raw route and query generics; the existing 5% regression guard remains.

Local lint, typecheck, and test suites were intentionally skipped due host load; CI is the validation source.

CC on behalf of jan-kubica

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an attachments panel for email files in the inspector.
  - View supported PDF and image attachments, with additional sandboxed previews where available.
  - Email previews now show attachment names and indicate which files can be previewed.
  - Added loading, error, retry, and unsupported-file states.
- **Bug Fixes**
  - Improved attachment handling and validation for safer, more reliable previews.
  - Limited displayed attachments and excluded inline-only content from the attachment list.
  - Improved filename handling and inline attachment delivery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->