### PR TITLE
fix: eliminate production type assertions

### DIFF
--- a/apps/api/src/handlers/chat/tools/active-docx-edit-tool.ts
+++ b/apps/api/src/handlers/chat/tools/active-docx-edit-tool.ts
@@ -66,18 +66,27 @@ type AcceptedFolioOperation = Exclude<
 >;
 
 // Distributes over the union so the `type` discriminator survives: drop the
-// rejected `precondition`, make the operation `id` optional, and require the
-// review metadata (`severity` / `area`).
-type NarrowToActiveDocxEditOperation<TOperation> = TOperation extends unknown
-  ? Omit<TOperation, "id" | "precondition" | "severity" | "area"> & {
-      id?: string;
-      severity: FolioAIEditSeverity;
-      area: string;
-    }
-  : never;
+// rejected `precondition` and require the review metadata (`severity` /
+// `area`). The parser-facing form keeps folio's required id; the tool-facing
+// form makes it optional because execution generates omitted ids.
+type NarrowValidatedActiveDocxEditOperation<TOperation> =
+  TOperation extends unknown
+    ? Omit<TOperation, "precondition" | "severity" | "area"> & {
+        severity: FolioAIEditSeverity;
+        area: string;
+        precondition?: never;
+      }
+    : never;
+
+type WithOptionalOperationId<TOperation> = TOperation extends { id: string }
+  ? Omit<TOperation, "id"> & { id?: string }
+  : TOperation;
+
+type ValidatedActiveDocxEditOperation =
+  NarrowValidatedActiveDocxEditOperation<AcceptedFolioOperation>;
 
 type ActiveDocxEditOperation =
-  NarrowToActiveDocxEditOperation<AcceptedFolioOperation>;
+  WithOptionalOperationId<ValidatedActiveDocxEditOperation>;
 
 type ActiveDocxEditToolInput = {
   version?: typeof FOLIO_DOCUMENT_OPERATION_CONTRACT_VERSION;
@@ -253,6 +262,15 @@ const REJECTED_OPERATION_TYPE_SET: ReadonlySet<string> = new Set(
   REJECTED_OPERATION_TYPES,
 );
 
+const isValidatedActiveDocxEditOperation = (
+  operation: FolioAIEditOperation,
+): operation is ValidatedActiveDocxEditOperation =>
+  !REJECTED_OPERATION_TYPE_SET.has(operation.type) &&
+  operation.precondition === undefined &&
+  operation.severity !== undefined &&
+  typeof operation.area === "string" &&
+  operation.area.length > 0;
+
 const ACCEPTED_OPERATION_VARIANTS = FOLIO_DOCUMENT_OPERATION_JSON_SCHEMA.oneOf
   .map((variant) => deriveOperationVariant(variant))
   .filter((variant) => !REJECTED_OPERATION_TYPE_SET.has(variant.operationType));
@@ -421,6 +439,19 @@ const narrowOperation = ({
   return stripped;
 };
 
+const restoreOmittedOperationIds = (
+  validated: ValidatedActiveDocxEditOperation[],
+  original: JsonObject[],
+): ActiveDocxEditOperation[] =>
+  validated.map((operation, index) => {
+    if (original.at(index)?.["id"] !== undefined) {
+      return operation;
+    }
+
+    const { id: _validationId, ...withoutValidationId } = operation;
+    return withoutValidationId;
+  });
+
 const validateActiveDocxEditToolInput = (
   input: unknown,
 ): StandardSchemaV1.Result<ValidatedActiveDocxEditToolInput> => {
@@ -489,17 +520,25 @@ const validateActiveDocxEditToolInput = (
     return { issues: folioResult.issues };
   }
 
+  const validatedOperations: ValidatedActiveDocxEditOperation[] = [];
+  for (const operation of folioResult.value.operations) {
+    if (!isValidatedActiveDocxEditOperation(operation)) {
+      panic("Folio parser violated the active DOCX edit narrowings");
+    }
+    validatedOperations.push(operation);
+  }
+
+  const operationsWithoutValidationIds = restoreOmittedOperationIds(
+    validatedOperations,
+    stripped,
+  );
+
   return {
     value: {
       version: FOLIO_DOCUMENT_OPERATION_CONTRACT_VERSION,
-      // SAFETY: folio's strict batch parser just validated every
-      // operation's shape against the same contract the derived JSON
-      // schema advertises, and the loop above enforced stella's
-      // narrowings (accepted type, required severity/area). The stripped
-      // copies differ from the parsed batch only by the generated
-      // placeholder ids, which are validation-only.
-      // eslint-disable-next-line typescript/no-unsafe-type-assertion -- see the SAFETY note above; the parser validated the exact shape
-      operations: stripped as ActiveDocxEditOperation[],
+      // Folio owns the parsed operation values. Validation-only ids are
+      // removed so execution remains the one place that mints durable ids.
+      operations: operationsWithoutValidationIds,
     },
   };
 };

--- a/apps/api/src/lib/auth.ts
+++ b/apps/api/src/lib/auth.ts
@@ -16,7 +16,7 @@ import {
   organization,
   twoFactor,
 } from "better-auth/plugins";
-import { Result } from "better-result";
+import { panic, Result } from "better-result";
 import { and, eq, exists, inArray, isNotNull, or } from "drizzle-orm";
 import type { InferSelectModel } from "drizzle-orm";
 import Elysia, { t } from "elysia";
@@ -337,16 +337,12 @@ export const isSixDigitOtpBody = (body: unknown): body is { otp: string } =>
   typeof body.otp === "string" &&
   SIX_DIGIT_OTP_PATTERN.test(body.otp);
 
-/**
- * Structural shape `requireTwoFactorManageOtp` needs off the hook context.
- * Not `HookEndpointContext`: `createAuthMiddleware`'s single-argument
- * overload — used for this app's top-level `hooks.before` — infers its own
- * middleware context type, which is a structurally different (and
- * stricter-in-places) shape than the per-plugin `HookEndpointContext`. This
- * narrower type lets the function stay unit-testable with a minimal stub
- * instead of a fully constructed better-auth context of either shape.
- */
-type TwoFactorManageHookCtx = { path: string; body: unknown };
+type TwoFactorManageSession = Awaited<ReturnType<typeof getSessionFromCtx>>;
+
+type RequireTwoFactorManageOtpArgs = {
+  body: unknown;
+  session: TwoFactorManageSession;
+};
 
 /**
  * Requires a fresh, single-use email verification code before letting any
@@ -362,19 +358,10 @@ type TwoFactorManageHookCtx = { path: string; body: unknown };
  * (`/two-factor/enable` for a user without 2FA yet) is then left ungated as
  * a no-op for the plugin.
  */
-const requireTwoFactorManageOtp = async (
-  ctx: TwoFactorManageHookCtx,
-): Promise<void> => {
-  // `getSessionFromCtx` wants a `GenericEndpointContext`, which requires
-  // `request` to always be present. better-auth's own middleware context
-  // types `request` as optional to also cover programmatic `auth.api.*`
-  // calls made without an HTTP request, but this hook only ever runs from
-  // HTTP dispatch (see dispatch.mjs), where `request` is always set.
-  // `getSessionFromCtx` only reads headers/cookies off `ctx`, so the
-  // narrower structural shape here is sound at runtime.
-  // eslint-disable-next-line typescript/no-unsafe-type-assertion -- see comment above; ctx always carries a real Request when this hook fires
-  const genericCtx = ctx as unknown as Parameters<typeof getSessionFromCtx>[0];
-  const session = await getSessionFromCtx(genericCtx);
+const requireTwoFactorManageOtp = async ({
+  body,
+  session,
+}: RequireTwoFactorManageOtpArgs): Promise<void> => {
   if (!session) {
     return;
   }
@@ -383,7 +370,7 @@ const requireTwoFactorManageOtp = async (
     return;
   }
 
-  if (!isSixDigitOtpBody(ctx.body)) {
+  if (!isSixDigitOtpBody(body)) {
     throw new APIError("BAD_REQUEST", {
       message:
         "Verification code required to change two-factor authentication settings",
@@ -393,7 +380,7 @@ const requireTwoFactorManageOtp = async (
   const verifyResult = await verifyConfirmationOtp({
     purpose: "two-factor-manage",
     email: session.user.email,
-    code: ctx.body.otp,
+    code: body.otp,
   });
 
   if (Result.isError(verifyResult)) {
@@ -1130,7 +1117,14 @@ const createAuth = () => {
         await assertSelfhostEmailOtpAllowed(ctx.path);
 
         if (TWO_FACTOR_MANAGE_PATHS.has(ctx.path)) {
-          await requireTwoFactorManageOtp(ctx);
+          if (ctx.request === undefined) {
+            panic("Two-factor management hook ran outside HTTP dispatch");
+          }
+          const session = await getSessionFromCtx({
+            ...ctx,
+            request: ctx.request,
+          });
+          await requireTwoFactorManageOtp({ body: ctx.body, session });
           return;
         }
 

--- a/apps/web/src/app-providers.tsx
+++ b/apps/web/src/app-providers.tsx
@@ -20,7 +20,6 @@ import {
   bundledEnglishMessages,
   useI18nStore,
 } from "@/i18n/i18n-store";
-import type Messages from "@/i18n/langs/messages.gen";
 import { resolveAppTimeZone } from "@/i18n/time-zone";
 import { AnalyticsProvider } from "@/lib/analytics/analytics-provider";
 import { useAnalytics } from "@/lib/analytics/provider";
@@ -117,17 +116,7 @@ const I18nProvider = ({ children }: PropsWithChildren) => {
   return (
     <IntlProvider
       locale={messageLocale}
-      // SAFETY: activeMessages is the fully-populated catalog for the active
-      // locale. use-intl types its `messages` prop with the generated Messages
-      // schema (literal string leaves, which also drives `t()` ICU-argument
-      // inference app-wide), but locales load as dynamic JSON so LocaleMessages
-      // widens every leaf to `string`. The runtime values conform to the
-      // schema; only the literal-vs-string widening differs at this boundary.
-      // This is the single sanctioned as-cast in app source (ratchet baseline).
-      messages={
-        // eslint-disable-next-line typescript/no-unsafe-type-assertion -- documented i18n provider boundary (see comment above); translated locale JSON widens leaves to string vs use-intl's literal Messages schema
-        activeMessages as Messages
-      }
+      messages={activeMessages}
       timeZone={resolveAppTimeZone()}
     >
       <FormattingProvider

--- a/apps/web/src/components/chat/ask-user-card.test.tsx
+++ b/apps/web/src/components/chat/ask-user-card.test.tsx
@@ -7,7 +7,6 @@ import { IntlProvider } from "use-intl";
 import type { AskUserInput, ChatPart } from "@/components/chat/chat-ui-tools";
 import { withParsedToolCallInputs } from "@/components/chat/chat-ui-tools";
 import messages from "@/i18n/langs/en.json";
-import type Messages from "@/i18n/langs/messages.gen";
 
 type AskUserPart = Extract<ChatPart, { name: "ask-user" }>;
 
@@ -27,15 +26,7 @@ afterAll(() => {
 
 const renderWithIntl = (children: ReactNode) =>
   renderToStaticMarkup(
-    <IntlProvider
-      locale="en"
-      // SAFETY: this mirrors the app provider boundary; locale
-      // files are checked separately, while use-intl preserves
-      // English literal values in the generated Messages type.
-      // eslint-disable-next-line typescript/no-unsafe-type-assertion
-      messages={messages as Messages}
-      timeZone="UTC"
-    >
+    <IntlProvider locale="en" messages={messages} timeZone="UTC">
       {children}
     </IntlProvider>,
   );

--- a/apps/web/src/components/chat/chat-rich-message-part.test.ts
+++ b/apps/web/src/components/chat/chat-rich-message-part.test.ts
@@ -9,7 +9,6 @@ import { propertyConfig } from "@stll/property-testing";
 
 import type { RichChatPart } from "@/components/chat/chat-rich-message-part";
 import messages from "@/i18n/langs/en.json";
-import type Messages from "@/i18n/langs/messages.gen";
 
 process.env["VITE_API_URL"] ??= "https://api.example.test";
 
@@ -29,10 +28,7 @@ const renderMediaPart = (part: RichChatPart) =>
     createElement(IntlProvider, {
       children: createElement(ChatRichMessagePart, { part }),
       locale: "en",
-      // SAFETY: this mirrors the app provider boundary; locale files are
-      // checked separately, while use-intl preserves English literal values.
-      // eslint-disable-next-line typescript/no-unsafe-type-assertion
-      messages: messages as Messages,
+      messages,
       timeZone: "UTC",
     }),
   );

--- a/apps/web/src/components/chat/chat-thread-messages.test.tsx
+++ b/apps/web/src/components/chat/chat-thread-messages.test.tsx
@@ -9,7 +9,6 @@ import { ChatApprovalContext } from "@/components/chat/chat-approval-context";
 import { ChatMattersContext } from "@/components/chat/chat-matters-context";
 import type { PersistedChatMessage } from "@/components/chat/chat-ui-tools";
 import messages from "@/i18n/langs/en.json";
-import type Messages from "@/i18n/langs/messages.gen";
 import { toChatThreadId } from "@/lib/chat-thread-ref";
 
 const previousApiUrl = process.env["VITE_API_URL"];
@@ -31,15 +30,7 @@ afterAll(() => {
 const renderWithProviders = (children: ReactNode) =>
   renderToStaticMarkup(
     <QueryClientProvider client={new QueryClient()}>
-      <IntlProvider
-        locale="en"
-        // SAFETY: this mirrors the app provider boundary; locale
-        // files are checked separately, while use-intl preserves
-        // English literal values in the generated Messages type.
-        // eslint-disable-next-line typescript/no-unsafe-type-assertion -- mirrors app provider boundary; use-intl Messages keeps English literal values
-        messages={messages as Messages}
-        timeZone="UTC"
-      >
+      <IntlProvider locale="en" messages={messages} timeZone="UTC">
         <ChatMattersContext
           value={{
             createDocumentMatters: [],

--- a/apps/web/src/components/inspector/email-html-viewer.test.tsx
+++ b/apps/web/src/components/inspector/email-html-viewer.test.tsx
@@ -21,7 +21,6 @@ import {
 } from "@/components/inspector/email-html-viewer.logic";
 import { FormattingProvider } from "@/i18n/formatting-context";
 import messages from "@/i18n/langs/en.json";
-import type Messages from "@/i18n/langs/messages.gen";
 import { EMAIL_BODY_FOLD_KIND } from "@/lib/files/email-preview";
 import { emailHtmlPreviewOptions } from "@/lib/files/queries";
 
@@ -30,14 +29,7 @@ const FORMATTING_LOCALE = "en-u-nu-arab";
 const renderWithProviders = (children: ReactNode, queryClient: QueryClient) =>
   renderToStaticMarkup(
     <QueryClientProvider client={queryClient}>
-      <IntlProvider
-        locale="en"
-        // SAFETY: locale catalogs are checked by i18n:check; this mirrors the
-        // app's provider boundary used by the other static component tests.
-        // eslint-disable-next-line typescript/no-unsafe-type-assertion
-        messages={messages as Messages}
-        timeZone="UTC"
-      >
+      <IntlProvider locale="en" messages={messages} timeZone="UTC">
         <FormattingProvider locale={FORMATTING_LOCALE} timeZone="UTC">
           {children}
         </FormattingProvider>

--- a/apps/web/src/i18n/formatting-context.test.tsx
+++ b/apps/web/src/i18n/formatting-context.test.tsx
@@ -5,7 +5,6 @@ import { IntlProvider, useTranslations } from "use-intl";
 
 import { FormattingProvider, useFormatter } from "@/i18n/formatting-context";
 import messages from "@/i18n/langs/ar.json";
-import type Messages from "@/i18n/langs/messages.gen";
 
 const FormattingProbe = () => {
   const t = useTranslations("billing.invoices");
@@ -22,14 +21,7 @@ const FormattingProbe = () => {
 
 test("formatting locale does not replace translated-message plural rules", () => {
   const markup = renderToStaticMarkup(
-    <IntlProvider
-      locale="ar"
-      // SAFETY: locale catalogs are structurally checked against the generated
-      // Messages schema; dynamic JSON widens only the string literal leaves.
-      // eslint-disable-next-line typescript/no-unsafe-type-assertion
-      messages={messages as Messages}
-      timeZone="UTC"
-    >
+    <IntlProvider locale="ar" messages={messages} timeZone="UTC">
       <FormattingProvider locale="en-IN" timeZone="UTC">
         <FormattingProbe />
       </FormattingProvider>

--- a/apps/web/src/lib/workspaces/queries/legal-lists.ts
+++ b/apps/web/src/lib/workspaces/queries/legal-lists.ts
@@ -2,6 +2,7 @@ import { infiniteQueryOptions, queryOptions } from "@tanstack/react-query";
 
 import { api } from "@/lib/api";
 import { toAPIError } from "@/lib/errors/api";
+import { nullableStringCursorSeed } from "@/lib/infinite-query";
 import { toSafeId } from "@/lib/safe-id";
 
 export const legalListKeys = {
@@ -109,7 +110,7 @@ export const legalListItemsOptions = (workspaceId: string, listId: string) =>
       }
       return response.data;
     },
-    initialPageParam: null as string | null,
+    initialPageParam: nullableStringCursorSeed(),
     getNextPageParam: (page) => page.nextCursor,
     enabled: listId.length > 0,
   });

--- a/apps/web/src/routes/_protected.knowledge/-components/template-studio-inspector.test.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/template-studio-inspector.test.tsx
@@ -8,7 +8,6 @@ import { IntlProvider } from "use-intl";
 import { TemplateForm } from "@/components/templates/template-form";
 import { FormattingProvider } from "@/i18n/formatting-context";
 import messages from "@/i18n/langs/en.json";
-import type Messages from "@/i18n/langs/messages.gen";
 
 // Regression guard for the Template Studio Fill tab having no AI prefill
 // entry point: Studio's TemplateForm call now passes `prefill={{}}` (see
@@ -19,15 +18,7 @@ import type Messages from "@/i18n/langs/messages.gen";
 const renderWithProviders = (children: ReactNode) =>
   renderToStaticMarkup(
     <QueryClientProvider client={new QueryClient()}>
-      <IntlProvider
-        locale="en"
-        // SAFETY: mirrors the app provider boundary; locale files are
-        // checked separately, and use-intl preserves English literal
-        // values in the generated Messages type.
-        // eslint-disable-next-line typescript/no-unsafe-type-assertion
-        messages={messages as Messages}
-        timeZone="UTC"
-      >
+      <IntlProvider locale="en" messages={messages} timeZone="UTC">
         <FormattingProvider locale="en" timeZone="UTC">
           {children}
         </FormattingProvider>

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/advanced-filter-editor.test.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/advanced-filter-editor.test.tsx
@@ -8,7 +8,6 @@ import type { GroupNode } from "@stll/conditions";
 import type { FieldOption } from "@/components/conditions/condition-builder-logic";
 import { leafFromField } from "@/components/conditions/condition-builder-logic";
 import messages from "@/i18n/langs/en.json";
-import type Messages from "@/i18n/langs/messages.gen";
 
 import {
   ADVANCED_FILTER_POPUP_CLASS_NAME,
@@ -30,14 +29,7 @@ const FILTER = {
 
 const renderEditor = () =>
   renderToStaticMarkup(
-    <IntlProvider
-      locale="en"
-      // SAFETY: locale catalogs are structurally checked against the generated
-      // Messages schema; dynamic JSON widens only the string literal leaves.
-      // eslint-disable-next-line typescript/no-unsafe-type-assertion
-      messages={messages as Messages}
-      timeZone="UTC"
-    >
+    <IntlProvider locale="en" messages={messages} timeZone="UTC">
       <AdvancedFilterEditor
         fields={[FIELD]}
         node={FILTER}

--- a/apps/web/src/types/i18n.d.ts
+++ b/apps/web/src/types/i18n.d.ts
@@ -1,8 +1,23 @@
+import type { ReactNode } from "react";
+
+import type { LocaleMessages } from "@/i18n/i18n-store";
 import type I18nMessages from "@/i18n/langs/messages.gen";
+
+type LocalizedIntlProviderProps = {
+  children: ReactNode;
+  locale: string;
+  messages: LocaleMessages;
+  timeZone?: string;
+};
 
 declare module "use-intl" {
   // eslint-disable-next-line @typescript-eslint/consistent-type-definitions -- module augmentation requires interface merging
   interface AppConfig {
     Messages: I18nMessages;
   }
+
+  // AppConfig.Messages intentionally keeps the source-language literals so
+  // useTranslations can infer ICU arguments. At runtime, IntlProvider accepts
+  // the same total catalog shape with localized string leaves.
+  function IntlProvider(props: LocalizedIntlProviderProps): React.JSX.Element;
 }

--- a/scripts/ratchet-baseline.json
+++ b/scripts/ratchet-baseline.json
@@ -1,12 +1,7 @@
 {
   "as-casts": {
-    "count": 4,
-    "files": {
-      "apps/api/src/handlers/chat/tools/active-docx-edit-tool.ts": 1,
-      "apps/api/src/lib/auth.ts": 1,
-      "apps/web/src/app-providers.tsx": 1,
-      "apps/web/src/lib/workspaces/queries/legal-lists.ts": 1
-    }
+    "count": 0,
+    "files": {}
   },
   "super-linear-regexes": {
     "count": 0,
@@ -101,7 +96,7 @@
     "files": {}
   },
   "lint-suppression-directives": {
-    "count": 596,
+    "count": 592,
     "files": {
       "apps/api/src/db/migrate.ts": 2,
       "apps/api/src/db/schema.ts": 1,
@@ -144,7 +139,6 @@
       "apps/api/src/handlers/chat/history-window.ts": 5,
       "apps/api/src/handlers/chat/send-message.ts": 1,
       "apps/api/src/handlers/chat/stream-chat.ts": 1,
-      "apps/api/src/handlers/chat/tools/active-docx-edit-tool.ts": 1,
       "apps/api/src/handlers/chat/tools/boe-tools.ts": 1,
       "apps/api/src/handlers/chat/tools/execute/sandbox/code-mode-driver.ts": 4,
       "apps/api/src/handlers/chat/tools/execute/sandbox/run-sandbox.ts": 6,
@@ -207,12 +201,12 @@
       "apps/api/src/lib/agent-skills/skills.ts": 2,
       "apps/api/src/lib/analytics/posthog.ts": 1,
       "apps/api/src/lib/anonymization-blacklist.ts": 1,
-      "apps/api/src/lib/auth.ts": 4,
+      "apps/api/src/lib/auth.ts": 3,
       "apps/api/src/lib/cell-lock.ts": 1,
       "apps/api/src/lib/corpus-index/core.ts": 10,
       "apps/api/src/lib/deepl/client.ts": 3,
       "apps/api/src/lib/desktop-edit-session-predicates.ts": 2,
-      "apps/api/src/lib/document-processing-provider.ts": 2,
+      "apps/api/src/lib/document-processing-provider.ts": 1,
       "apps/api/src/lib/document-processing-queue.ts": 1,
       "apps/api/src/lib/document-reference.ts": 2,
       "apps/api/src/lib/docx-stamp.ts": 2,
@@ -283,7 +277,6 @@
       "apps/api/src/scripts/redact-case-law-decision.ts": 1,
       "apps/api/src/scripts/repair-case-law-jsonb.ts": 1,
       "apps/api/src/scripts/resolve-citations.ts": 8,
-      "apps/web/src/app-providers.tsx": 1,
       "apps/web/src/client.tsx": 1,
       "apps/web/src/components/ai-config-providers-editor.tsx": 2,
       "apps/web/src/components/ai-suggestions/file-chat-overlay.tsx": 1,


### PR DESCRIPTION
## Summary

- return validated Folio DOCX operations and make the Better Auth HTTP context invariant explicit
- type localized IntlProvider catalogs at the library boundary and reuse the shared nullable cursor seed
- reduce the production as-cast ratchet from four to zero