### PR TITLE
fix: fold maintenance changelog releases

### DIFF
--- a/apps/landing/src/lib/changelog-release.test.ts
+++ b/apps/landing/src/lib/changelog-release.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, test } from "bun:test";
 
-import { getReleaseKind, isStellaReleaseTag } from "./changelog-release";
+import {
+  formatMaintenanceReleaseRange,
+  groupMaintenanceReleases,
+  getMaintenanceReleaseTitle,
+  getReleaseKind,
+  isStellaReleaseTag,
+} from "./changelog-release";
 
 describe("Stella changelog releases", () => {
   test("accepts stable stella release tags", () => {
@@ -18,5 +24,43 @@ describe("Stella changelog releases", () => {
     expect(getReleaseKind("v1.0.0")).toBe("major");
     expect(getReleaseKind("v1.2.0")).toBe("minor");
     expect(getReleaseKind("v1.2.3")).toBe("patch");
+  });
+
+  test("folds each consecutive run titled Maintenance release", () => {
+    const releases = [
+      { tagName: "v0.6.3", title: "Maintenance release" },
+      { tagName: "v0.6.2", title: "Maintenance release" },
+      { tagName: "v0.6.1", title: "Maintenance release" },
+      { tagName: "v0.6.0", title: "Connected tools" },
+      { tagName: "v0.5.3", title: "Maintenance release" },
+      { tagName: "v0.5.2", title: "Maintenance release" },
+    ];
+
+    const entries = groupMaintenanceReleases(releases, ({ title }) => title);
+    expect(
+      entries.map((entry) =>
+        entry.type === "maintenance"
+          ? entry.releases.map(({ tagName }) => tagName)
+          : entry.release.tagName,
+      ),
+    ).toEqual([["v0.6.3", "v0.6.2", "v0.6.1"], "v0.6.0", ["v0.5.3", "v0.5.2"]]);
+    expect(
+      formatMaintenanceReleaseRange(
+        [releases[0], releases[1], releases[2]],
+        ({ tagName }) => tagName,
+      ),
+    ).toBe("0.6.1 – 0.6.3");
+    expect(getMaintenanceReleaseTitle(3)).toBe("Maintenance releases");
+  });
+
+  test("does not fold titles that only resemble Maintenance release", () => {
+    const release = {
+      tagName: "v0.6.1",
+      title: "Maintenance release notes",
+    };
+
+    expect(groupMaintenanceReleases([release], ({ title }) => title)).toEqual([
+      { type: "release", release },
+    ]);
   });
 });

--- a/apps/landing/src/lib/changelog-release.test.ts
+++ b/apps/landing/src/lib/changelog-release.test.ts
@@ -50,6 +50,13 @@ describe("Stella changelog releases", () => {
         ({ tagName }) => tagName,
       ),
     ).toBe("0.6.1 – 0.6.3");
+    expect(
+      formatMaintenanceReleaseRange(
+        [{ tagName: "v0.6.3", title: "Maintenance release" }],
+        ({ tagName }) => tagName,
+      ),
+    ).toBe("0.6.3");
+    expect(getMaintenanceReleaseTitle(1)).toBe("Maintenance release");
     expect(getMaintenanceReleaseTitle(3)).toBe("Maintenance releases");
   });
 

--- a/apps/landing/src/lib/changelog-release.ts
+++ b/apps/landing/src/lib/changelog-release.ts
@@ -1,6 +1,14 @@
 export type ReleaseKind = "major" | "minor" | "patch";
 
+export type ChangelogReleaseEntry<T> =
+  | { type: "maintenance"; releases: [T, ...T[]] }
+  | { type: "release"; release: T };
+
+export const CHANGELOG_ENTRIES_PER_PAGE = 12;
+
 const STELLA_RELEASE_TAG_PATTERN = /^v\d+\.\d+\.\d+$/u;
+const MAINTENANCE_RELEASE_TITLE = "Maintenance release";
+const MAINTENANCE_RELEASES_TITLE = "Maintenance releases";
 
 export const isStellaReleaseTag = (tagName: string) =>
   STELLA_RELEASE_TAG_PATTERN.test(tagName);
@@ -13,4 +21,45 @@ export const getReleaseKind = (tagName: string): ReleaseKind => {
   }
 
   return minor === 0 ? "major" : "minor";
+};
+
+export const getMaintenanceReleaseTitle = (releaseCount: number) =>
+  releaseCount === 1 ? MAINTENANCE_RELEASE_TITLE : MAINTENANCE_RELEASES_TITLE;
+
+export const formatMaintenanceReleaseRange = <T>(
+  releases: readonly [T, ...T[]],
+  getTagName: (release: T) => string,
+) => {
+  const newestRelease = releases[0];
+  const oldestRelease = releases.at(-1) ?? newestRelease;
+  const newestVersion = getTagName(newestRelease).replace(/^v/u, "");
+  const oldestVersion = getTagName(oldestRelease).replace(/^v/u, "");
+
+  return newestVersion === oldestVersion
+    ? newestVersion
+    : `${oldestVersion} – ${newestVersion}`;
+};
+
+export const groupMaintenanceReleases = <T>(
+  releases: readonly T[],
+  getTitle: (release: T) => string | null,
+): ChangelogReleaseEntry<T>[] => {
+  const entries: ChangelogReleaseEntry<T>[] = [];
+
+  for (const release of releases) {
+    if (getTitle(release) !== MAINTENANCE_RELEASE_TITLE) {
+      entries.push({ type: "release", release });
+      continue;
+    }
+
+    const previousEntry = entries.at(-1);
+    if (previousEntry?.type === "maintenance") {
+      previousEntry.releases.push(release);
+      continue;
+    }
+
+    entries.push({ type: "maintenance", releases: [release] });
+  }
+
+  return entries;
 };

--- a/apps/landing/src/lib/changelog.test.ts
+++ b/apps/landing/src/lib/changelog.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
-import { getChangelogReleases } from "./changelog";
+import { getChangelogReleaseEntries, getChangelogReleases } from "./changelog";
 
 describe("changelog release dates", () => {
   // A release page without a date entry renders dateless silently; the entry
@@ -15,5 +15,16 @@ describe("changelog release dates", () => {
       .filter((release) => release.publishedAt === null)
       .map((release) => release.tagName);
     expect(undated).toEqual([]);
+  });
+
+  test("grouped entries preserve every release exactly once", () => {
+    const releases = getChangelogReleases();
+    const groupedReleases = getChangelogReleaseEntries().flatMap((entry) =>
+      entry.type === "maintenance" ? entry.releases : [entry.release],
+    );
+
+    expect(groupedReleases.map(({ tagName }) => tagName)).toEqual(
+      releases.map(({ tagName }) => tagName),
+    );
   });
 });

--- a/apps/landing/src/lib/changelog.ts
+++ b/apps/landing/src/lib/changelog.ts
@@ -2,7 +2,7 @@ import { existsSync, readdirSync, readFileSync } from "node:fs";
 import path from "node:path";
 
 import releaseDates from "../data/changelog-release-dates.json";
-import { getReleaseKind } from "./changelog-release";
+import { getReleaseKind, groupMaintenanceReleases } from "./changelog-release";
 
 export type ChangelogRelease = {
   description: string;
@@ -68,6 +68,12 @@ const readRelease = (tagName: string): ChangelogRelease => {
 
 export const getChangelogReleases = (): ChangelogRelease[] =>
   listReleaseTags().map(readRelease);
+
+export const getChangelogReleaseEntries = () =>
+  groupMaintenanceReleases(
+    getChangelogReleases(),
+    (release) => release.heading,
+  );
 
 export const getLatestFeatureRelease = (): ChangelogRelease | undefined => {
   const tagName = listReleaseTags().find(

--- a/apps/landing/src/pages/changelog.astro
+++ b/apps/landing/src/pages/changelog.astro
@@ -128,8 +128,17 @@ const formatReleaseDate = (publishedAt: string) =>
                             id={release.slug}
                             class="changelog-maintenance-item py-3"
                           >
-                            <summary class="cursor-pointer text-sm font-medium tabular-nums">
-                              {release.tagName}
+                            <summary class="flex cursor-pointer items-center justify-between gap-4 text-sm font-medium">
+                              <span class="tabular-nums">{release.tagName}</span>
+                              {release.publishedAt && (
+                                <time
+                                  datetime={release.publishedAt}
+                                  class="shrink-0 tabular-nums"
+                                  style="color: var(--muted-foreground)"
+                                >
+                                  {formatReleaseDate(release.publishedAt)}
+                                </time>
+                              )}
                             </summary>
                             <div class="changelog-body pb-2 pt-3">
                               <p>{release.description}</p>
@@ -1061,6 +1070,8 @@ const formatReleaseDate = (publishedAt: string) =>
       signal: AbortSignal,
     ) => {
       const releaseEntryOffset = (page - 1) * CHANGELOG_ENTRIES_PER_PAGE;
+      // The extra entry is never rendered. It proves that the page's trailing
+      // maintenance group is complete and supplies an accurate next-page flag.
       const releaseEntryLimit =
         releaseEntryOffset + CHANGELOG_ENTRIES_PER_PAGE + 1;
       const stellaReleases: GitHubRelease[] = [];
@@ -1291,6 +1302,9 @@ const formatReleaseDate = (publishedAt: string) =>
       previewReleaseSlugs = new Set(readPreviewReleaseSlugs());
       currentPage = readCurrentPage();
       hasNextPage = false;
+      // Expand a nested anchor in the server-rendered list immediately; the
+      // live GitHub feed may take a network round trip before replacing it.
+      scrollToCurrentHash();
       void loadReleases();
     };
 

--- a/apps/landing/src/pages/changelog.astro
+++ b/apps/landing/src/pages/changelog.astro
@@ -1,19 +1,31 @@
 ---
 import Base from "../layouts/Base.astro";
-import { getChangelogReleases, type ChangelogRelease } from "../lib/changelog";
-import { getReleaseKind } from "../lib/changelog-release";
+import {
+  getChangelogReleaseEntries,
+  getChangelogReleases,
+  type ChangelogRelease,
+} from "../lib/changelog";
+import {
+  CHANGELOG_ENTRIES_PER_PAGE,
+  formatMaintenanceReleaseRange,
+  getReleaseKind,
+  getMaintenanceReleaseTitle,
+} from "../lib/changelog-release";
 import LandingFooter from "../components/LandingFooter.astro";
 
 const githubUrl = "https://github.com/stella/stella";
 const releasesUrl = `${githubUrl}/releases`;
 const releases = getChangelogReleases();
+const releaseEntries = getChangelogReleaseEntries();
 const previewReleaseSlugs = releases.map((release) => release.slug);
 
 // Server-rendered first page of the changelog: real content for crawlers and
 // the no-JS/pre-JS state. The client script below replaces it with the live
 // GitHub feed once fresh data arrives (same page size as the live feed).
-const STATIC_RELEASES_PER_PAGE = 12;
-const staticReleases = releases.slice(0, STATIC_RELEASES_PER_PAGE);
+const staticReleaseEntries = releaseEntries.slice(
+  0,
+  CHANGELOG_ENTRIES_PER_PAGE,
+);
 const releaseUrl = (release: ChangelogRelease) =>
   `${releasesUrl}/tag/${release.tagName}`;
 const formatReleaseDate = (publishedAt: string) =>
@@ -66,7 +78,81 @@ const formatReleaseDate = (publishedAt: string) =>
         <div class="mx-auto max-w-5xl">
           <div id="changelog-releases" class="space-y-5" aria-live="polite">
             {
-              staticReleases.map((release) => {
+              staticReleaseEntries.map((entry) => {
+                if (entry.type === "maintenance") {
+                  const newestRelease = entry.releases[0];
+                  return (
+                    <details
+                      class="changelog-entry changelog-patch-release rounded-lg"
+                      data-static-release
+                    >
+                      <summary class="changelog-patch-summary flex min-h-14 cursor-pointer flex-wrap items-center gap-x-4 gap-y-1 px-5 py-3 sm:flex-nowrap sm:px-6">
+                        <span
+                          class="shrink-0 tabular-nums text-sm font-medium"
+                          style="color: var(--muted-foreground)"
+                        >
+                          {formatMaintenanceReleaseRange(
+                            entry.releases,
+                            (release) => release.tagName,
+                          )}
+                        </span>
+                        <h2
+                          class="min-w-0 flex-1 truncate font-display text-base font-medium sm:text-lg"
+                          style="color: var(--foreground)"
+                        >
+                          {getMaintenanceReleaseTitle(entry.releases.length)}
+                        </h2>
+                        {newestRelease.publishedAt && (
+                          <time
+                            datetime={newestRelease.publishedAt}
+                            class="shrink-0 text-sm tabular-nums"
+                            style="color: var(--muted-foreground)"
+                          >
+                            {formatReleaseDate(newestRelease.publishedAt)}
+                          </time>
+                        )}
+                        <span
+                          class="changelog-patch-marker inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-lg leading-none"
+                          aria-hidden="true"
+                          style="background: var(--muted); color: var(--foreground)"
+                        >
+                          +
+                        </span>
+                      </summary>
+                      <div
+                        class="changelog-maintenance-list px-5 pb-2 sm:px-6"
+                        style="border-top: 1px solid var(--border)"
+                      >
+                        {entry.releases.map((release) => (
+                          <details
+                            id={release.slug}
+                            class="changelog-maintenance-item py-3"
+                          >
+                            <summary class="cursor-pointer text-sm font-medium tabular-nums">
+                              {release.tagName}
+                            </summary>
+                            <div class="changelog-body pb-2 pt-3">
+                              <p>{release.description}</p>
+                              <div class="mt-4 flex flex-wrap items-center gap-3">
+                                <a
+                                  href={releaseUrl(release)}
+                                  target="_blank"
+                                  rel="noopener noreferrer"
+                                  class="inline-flex h-9 shrink-0 items-center justify-center rounded-[0.625rem] px-3 text-sm font-medium transition-opacity hover:opacity-80 whitespace-nowrap"
+                                  style="background: var(--background); border: 1px solid var(--border); color: var(--foreground)"
+                                >
+                                  View release on GitHub
+                                </a>
+                              </div>
+                            </div>
+                          </details>
+                        ))}
+                      </div>
+                    </details>
+                  );
+                }
+
+                const { release } = entry;
                 if (getReleaseKind(release.tagName) === "patch") {
                   return (
                     <details
@@ -287,6 +373,22 @@ const formatReleaseDate = (publishedAt: string) =>
       transform: rotate(45deg);
     }
 
+    :global(.changelog-maintenance-item) {
+      scroll-margin-top: 2rem;
+    }
+
+    :global(.changelog-maintenance-item + .changelog-maintenance-item) {
+      border-top: 1px solid var(--border);
+    }
+
+    :global(.changelog-maintenance-item > summary) {
+      color: var(--foreground);
+    }
+
+    :global(.changelog-maintenance-item > summary::marker) {
+      color: var(--muted-foreground);
+    }
+
     :global(.changelog-body h2),
     :global(.changelog-body h3) {
       color: var(--foreground);
@@ -362,7 +464,12 @@ const formatReleaseDate = (publishedAt: string) =>
 
   <script>
     import {
+      CHANGELOG_ENTRIES_PER_PAGE,
+      type ChangelogReleaseEntry,
+      formatMaintenanceReleaseRange,
       getReleaseKind,
+      getMaintenanceReleaseTitle,
+      groupMaintenanceReleases,
       isStellaReleaseTag,
     } from "../lib/changelog-release";
     import { parseChangelogMarkdown } from "../lib/changelog-markdown";
@@ -402,7 +509,6 @@ const formatReleaseDate = (publishedAt: string) =>
     const parseGitHubReleases = (value: unknown): GitHubRelease[] =>
       Array.isArray(value) ? value.filter(isGitHubRelease) : [];
 
-    const RELEASES_PER_PAGE = 12;
     const GITHUB_RELEASES_PER_PAGE = 100;
     const releasesApiBase = "https://api.github.com/repos/stella/stella/releases";
     const releasesEndpoint =
@@ -762,12 +868,115 @@ const formatReleaseDate = (publishedAt: string) =>
       return details;
     };
 
-    const renderRelease = (release: GitHubRelease) => {
-      if (getReleaseKind(release.tag_name) === "patch") {
-        return renderPatchRelease(release);
+    const renderMaintenanceItem = (release: GitHubRelease) => {
+      const details = document.createElement("details");
+      details.id = releaseAnchorId(release.tag_name);
+      details.className = "changelog-maintenance-item py-3";
+      details.open = decodeURIComponent(window.location.hash.slice(1)) === details.id;
+
+      const summary = document.createElement("summary");
+      summary.className =
+        "flex cursor-pointer items-center justify-between gap-4 text-sm font-medium";
+
+      const version = document.createElement("span");
+      version.className = "tabular-nums";
+      version.textContent = release.tag_name;
+
+      const date = document.createElement("span");
+      date.className = "shrink-0 tabular-nums";
+      date.style.color = "var(--muted-foreground)";
+      date.textContent = formatDate(release.published_at);
+      summary.append(version, date);
+
+      const body = document.createElement("div");
+      body.className = "changelog-body pb-2 pt-3";
+      body.append(
+        renderReleaseBody(
+          release.body
+            ? removeFirstMarkdownTitle(release.body)
+            : "No release notes published.",
+        ),
+      );
+
+      const releaseLink = createReleaseLink(release);
+      if (releaseLink) {
+        const footer = document.createElement("div");
+        footer.className = "mt-4 flex flex-wrap items-center gap-3";
+        footer.append(releaseLink);
+        body.append(footer);
       }
 
-      return renderFeatureRelease(release);
+      details.append(summary, body);
+      return details;
+    };
+
+    const renderMaintenanceReleases = (
+      releases: [GitHubRelease, ...GitHubRelease[]],
+    ) => {
+      const details = document.createElement("details");
+      details.className = "changelog-entry changelog-patch-release rounded-lg";
+      const currentHash = decodeURIComponent(window.location.hash.slice(1));
+      details.open = releases.some(
+        (release) => releaseAnchorId(release.tag_name) === currentHash,
+      );
+
+      const summary = document.createElement("summary");
+      summary.className =
+        "changelog-patch-summary flex min-h-14 cursor-pointer flex-wrap items-center gap-x-4 gap-y-1 px-5 py-3 sm:flex-nowrap sm:px-6";
+
+      const version = document.createElement("span");
+      version.className = "shrink-0 tabular-nums text-sm font-medium";
+      version.style.color = "var(--muted-foreground)";
+      version.textContent = formatMaintenanceReleaseRange(
+        releases,
+        (release) => release.tag_name,
+      );
+
+      const title = document.createElement("h2");
+      title.className =
+        "min-w-0 flex-1 truncate font-display text-base font-medium sm:text-lg";
+      title.style.color = "var(--foreground)";
+      title.textContent = getMaintenanceReleaseTitle(releases.length);
+
+      const newestRelease = releases[0];
+      const date = document.createElement("span");
+      date.className = "shrink-0 text-sm tabular-nums";
+      date.style.color = "var(--muted-foreground)";
+      date.textContent = formatDate(newestRelease.published_at);
+
+      const marker = document.createElement("span");
+      marker.className =
+        "changelog-patch-marker inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-lg leading-none";
+      marker.setAttribute("aria-hidden", "true");
+      marker.style.background = "var(--muted)";
+      marker.style.color = "var(--foreground)";
+      marker.textContent = "+";
+      summary.append(version, title, date, marker);
+
+      const body = document.createElement("div");
+      body.className = "changelog-maintenance-list px-5 pb-2 sm:px-6";
+      body.style.borderTop = "1px solid var(--border)";
+      body.append(...releases.map(renderMaintenanceItem));
+
+      details.append(summary, body);
+      return details;
+    };
+
+    const renderReleaseEntry = (
+      entry: ChangelogReleaseEntry<GitHubRelease>,
+    ) => {
+      switch (entry.type) {
+        case "maintenance":
+          return renderMaintenanceReleases(entry.releases);
+        case "release":
+          return getReleaseKind(entry.release.tag_name) === "patch"
+            ? renderPatchRelease(entry.release)
+            : renderFeatureRelease(entry.release);
+        default: {
+          const unreachable: never = entry;
+          return unreachable;
+        }
+      }
     };
 
     const renderMessage = (text: string) => {
@@ -851,13 +1060,15 @@ const formatReleaseDate = (publishedAt: string) =>
       page: number,
       signal: AbortSignal,
     ) => {
-      const stellaReleaseOffset = (page - 1) * RELEASES_PER_PAGE;
-      const stellaReleaseLimit = stellaReleaseOffset + RELEASES_PER_PAGE + 1;
+      const releaseEntryOffset = (page - 1) * CHANGELOG_ENTRIES_PER_PAGE;
+      const releaseEntryLimit =
+        releaseEntryOffset + CHANGELOG_ENTRIES_PER_PAGE + 1;
       const stellaReleases: GitHubRelease[] = [];
+      let releaseEntries: ChangelogReleaseEntry<GitHubRelease>[] = [];
       let githubPage = 1;
       let hasMoreGithubPages = true;
 
-      while (hasMoreGithubPages && stellaReleases.length < stellaReleaseLimit) {
+      while (hasMoreGithubPages && releaseEntries.length < releaseEntryLimit) {
         // eslint-disable-next-line no-await-in-loop -- GitHub pagination is sequential: the next page number and stop condition depend on this page's rel="next" link header, so pages cannot be fetched in parallel
         const response = await fetch(buildReleasesUrl(githubPage), {
           headers: { Accept: "application/vnd.github+json" },
@@ -877,17 +1088,22 @@ const formatReleaseDate = (publishedAt: string) =>
               isStellaReleaseTag(release.tag_name),
           ),
         );
+        releaseEntries = groupMaintenanceReleases(
+          stellaReleases,
+          getReleaseSummaryTitle,
+        );
         hasMoreGithubPages = responseHasNextPage(response);
         githubPage += 1;
       }
 
       return {
-        hasNextPage:
-          stellaReleases.length > stellaReleaseOffset + RELEASES_PER_PAGE,
-        releases: stellaReleases.slice(
-          stellaReleaseOffset,
-          stellaReleaseOffset + RELEASES_PER_PAGE,
+        entries: releaseEntries.slice(
+          releaseEntryOffset,
+          releaseEntryOffset + CHANGELOG_ENTRIES_PER_PAGE,
         ),
+        hasNextPage:
+          releaseEntries.length >
+          releaseEntryOffset + CHANGELOG_ENTRIES_PER_PAGE,
       };
     };
 
@@ -998,7 +1214,7 @@ const formatReleaseDate = (publishedAt: string) =>
         }
 
         hasNextPage = releasePage.hasNextPage;
-        if (releasePage.releases.length === 0) {
+        if (releasePage.entries.length === 0) {
           renderPagination();
           loadContainer.replaceChildren(
             renderMessage("No public releases are published yet. Check"),
@@ -1009,7 +1225,7 @@ const formatReleaseDate = (publishedAt: string) =>
         updatePageUrl();
         renderPagination();
         loadContainer.replaceChildren(
-          ...releasePage.releases.map(renderRelease),
+          ...releasePage.entries.map(renderReleaseEntry),
         );
         scrollToCurrentHash();
       } catch {

--- a/apps/landing/src/pages/changelog/[release].astro
+++ b/apps/landing/src/pages/changelog/[release].astro
@@ -1,12 +1,19 @@
 ---
 import Base from "../../layouts/Base.astro";
-import { getChangelogReleases } from "../../lib/changelog";
+import { getChangelogReleaseEntries } from "../../lib/changelog";
+import { CHANGELOG_ENTRIES_PER_PAGE } from "../../lib/changelog-release";
 
 export const getStaticPaths = () =>
-  getChangelogReleases().map((release, index) => ({
-    params: { release: release.slug },
-    props: { page: Math.floor(index / 5) + 1, release },
-  }));
+  getChangelogReleaseEntries().flatMap((entry, index) => {
+    const page = Math.floor(index / CHANGELOG_ENTRIES_PER_PAGE) + 1;
+    const releases =
+      entry.type === "maintenance" ? entry.releases : [entry.release];
+
+    return releases.map((release) => ({
+      params: { release: release.slug },
+      props: { page, release },
+    }));
+  });
 
 const { page, release } = Astro.props;
 const changelogHref =


### PR DESCRIPTION
## Summary

- Fold consecutive changelog entries titled Maintenance release into one expandable range card
- Preserve per-release notes, anchors, GitHub links, and grouped pagination in the server-rendered and live feeds
- Share grouping and page-size logic so release preview redirects land on the correct card

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Maintenance releases are now grouped into expandable changelog entries.
  * Grouped entries display version ranges and appropriate singular or plural titles.
  * Changelog pagination and release pages now support grouped maintenance entries.
  * Maintenance groups can be expanded directly from shared links.

* **Bug Fixes**
  * Preserved every release exactly once and in the original order when grouping changelog entries.
  * Prevented similarly named releases from being grouped incorrectly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->