### PR TITLE
fix: recognize dynamic CI test runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -761,8 +761,9 @@ jobs:
           bun run test -- --concurrency=2 "${args[@]}"
 
       - name: Property-test convention guard
-        if: needs.ci-plan.outputs.package_checks_required == 'true'
-        run: bun test packages/property-testing/src/convention.test.ts
+        run: |
+          bun test packages/property-testing/src/convention.test.ts
+          bun test packages/property-testing/src/ci-gate-coverage.test.ts
 
       - name: Test marketing recording verification guard
         if: needs.ci-plan.outputs.package_checks_required == 'true'

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -131,5 +131,13 @@
     "vite": "catalog:",
     "vite-plugin-singlefile": "^2.3.0"
   },
+  "ciGateTestRunners": {
+    "test:postgres": {
+      "gate": "STELLA_RUN_POSTGRES_TESTS",
+      "gateValue": "true",
+      "runner": "scripts/run-postgres-tests.ts",
+      "testFileGlob": "src/**/*.test.{ts,tsx}"
+    }
+  },
   "crawlPosture": "unserved"
 }

--- a/apps/api/scripts/run-postgres-tests.ts
+++ b/apps/api/scripts/run-postgres-tests.ts
@@ -1,8 +1,10 @@
 import path from "node:path";
 
-import { POSTGRES_TEST_MARKER } from "../src/tests/test-database-environment";
+import packageJson from "../package.json" with { type: "json" };
 
-const TEST_FILE_GLOB = "src/**/*.test.{ts,tsx}";
+const POSTGRES_TEST_RUNNER = packageJson.ciGateTestRunners["test:postgres"];
+const POSTGRES_TEST_MARKER = POSTGRES_TEST_RUNNER.gate;
+
 const apiRoot = path.resolve(import.meta.dir, "..");
 
 if (!process.env["DATABASE_URL"]) {
@@ -11,7 +13,7 @@ if (!process.env["DATABASE_URL"]) {
 }
 
 const discoveredTests = [
-  ...new Bun.Glob(TEST_FILE_GLOB).scanSync({
+  ...new Bun.Glob(POSTGRES_TEST_RUNNER.testFileGlob).scanSync({
     cwd: apiRoot,
     onlyFiles: true,
   }),
@@ -52,7 +54,7 @@ const testProcess = Bun.spawn({
   cwd: apiRoot,
   env: {
     ...process.env,
-    STELLA_RUN_POSTGRES_TESTS: "true",
+    [POSTGRES_TEST_MARKER]: POSTGRES_TEST_RUNNER.gateValue,
   },
   stdin: "inherit",
   stdout: "inherit",

--- a/apps/api/src/tests/test-database-environment.ts
+++ b/apps/api/src/tests/test-database-environment.ts
@@ -1,4 +1,7 @@
-export const POSTGRES_TEST_MARKER = "STELLA_RUN_POSTGRES_TESTS";
+import packageJson from "../../package.json" with { type: "json" };
+
+const POSTGRES_TEST_RUNNER = packageJson.ciGateTestRunners["test:postgres"];
+export const POSTGRES_TEST_MARKER = POSTGRES_TEST_RUNNER.gate;
 
 const DEFAULT_TEST_DATABASE_URL =
   "postgres://postgres:postgres@localhost:5432/stella";
@@ -6,7 +9,7 @@ const DEFAULT_TEST_DATABASE_URL =
 export const configureTestDatabaseEnvironment = (
   environment: NodeJS.ProcessEnv = process.env,
 ) => {
-  if (environment[POSTGRES_TEST_MARKER] === "true") {
+  if (environment[POSTGRES_TEST_MARKER] === POSTGRES_TEST_RUNNER.gateValue) {
     return;
   }
   environment["DATABASE_URL"] = DEFAULT_TEST_DATABASE_URL;

--- a/packages/property-testing/src/ci-gate-coverage.test.ts
+++ b/packages/property-testing/src/ci-gate-coverage.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { existsSync, statSync } from "node:fs";
 import path from "node:path";
 
 // Repo root, four levels up from this file (packages/property-testing/src).
@@ -7,7 +8,7 @@ const REPO_ROOT = path.resolve(import.meta.dir, "../../..");
 /**
  * Guard: every environment variable a test suite reads to decide whether to
  * run (a "CI gate") must be turned on by a workflow that also runs that
- * suite's test file.
+ * suite, either directly or through a declared dynamic runner.
  *
  * Env-gated suites (`describe.skipIf(process.env["X"] !== "1")`, or an
  * `if (...) describe.skip else describe`) look like coverage but execute
@@ -24,12 +25,18 @@ const REPO_ROOT = path.resolve(import.meta.dir, "../../..");
  * because a workflow happens to mention the same string for a different
  * file.
  *
- * Gates are discovered by pattern, not a hardcoded list: any test file that
- * compares an UPPER_SNAKE_CASE `process.env` entry (dot or bracket access)
- * against a string literal (`=== "true"`, `!== "1"`, or their loose-equality
- * forms) declares a gate. New gates of the same shape are picked up
- * automatically. Always-present config such as `DATABASE_URL` is not
- * matched, because tests read it without a literal comparison.
+ * Gates are discovered by pattern, not a hardcoded list. The comparison must
+ * participate in a recognized skip predicate whose inverse makes the suite
+ * active when the environment value equals the literal. Ambiguous inverse
+ * gates fail this guard instead of treating a disabling value as activation.
+ * Always-present config such as `DATABASE_URL` is not matched, because tests
+ * read it without a literal comparison.
+ *
+ * Dynamic runners declare their gate, activation value, and discovery glob in
+ * their workspace's `package.json#ciGateTestRunners`. The workflow must invoke
+ * the matching package script from that workspace. The runner reads the same
+ * declaration, so its runtime discovery and this guard cannot drift into
+ * mirrored lists.
  *
  * Extension points:
  * - LOCAL_ONLY_GATES: a gate intentionally exercised only in local runs
@@ -64,42 +71,226 @@ const UNWIRED_TEST_FILES = new Set<string>([
 ]);
 
 const TEST_FILE_GLOB = "{apps,packages}/**/*.test.{ts,tsx}";
+const PACKAGE_JSON_GLOB = "{apps,packages}/*/package.json";
 const WORKFLOW_GLOB = ".github/workflows/*.{yml,yaml}";
 
 // process.env.NAME or process.env["NAME"], compared with ===, !==, ==, or !=
 // against a string literal.
 const GATE_PATTERN =
-  /process\.env(?:\s*\.\s*([A-Z][A-Z0-9_]*)|\[\s*["']([A-Z][A-Z0-9_]*)["']\s*\])\s*(?:===|!==|==|!=)\s*["'][^"']*["']/gu;
+  /process\.env(?:\s*\.\s*([A-Z][A-Z0-9_]*)|\[\s*["']([A-Z][A-Z0-9_]*)["']\s*\])\s*(===|!==|==|!=)\s*["']([^"']*)["']/gu;
 
 // This guard's own source names the gate variables in prose; skip it so it
 // does not report itself as a gate declaration.
 const SELF_PATH = "packages/property-testing/src/ci-gate-coverage.test.ts";
 
-type GateDeclaration = { gate: string; file: string };
+type GateDeclaration = { gate: string; gateValue: string; file: string };
 
-const collectGates = async (): Promise<GateDeclaration[]> => {
+type GateScanResult = {
+  declarations: GateDeclaration[];
+  unsupported: string[];
+};
+
+const directIfComparisonActivatesSuite = (
+  sourceAfterComparison: string,
+  comparisonTrueWhenEqual: boolean,
+): boolean | undefined => {
+  const branches =
+    /^\s*\)\s*\{\s*(describe(?:\.skip)?)\b[\s\S]*?\}\s*else\s*\{\s*(describe(?:\.skip)?)\b/u.exec(
+      sourceAfterComparison,
+    );
+  if (!branches) {
+    return undefined;
+  }
+  const comparisonTrueSkips = branches[1] === "describe.skip";
+  const comparisonFalseSkips = branches[2] === "describe.skip";
+  if (comparisonTrueSkips === comparisonFalseSkips) {
+    return undefined;
+  }
+  const activeWhenComparisonTrue = comparisonFalseSkips;
+  return comparisonTrueWhenEqual === activeWhenComparisonTrue;
+};
+
+const comparisonLiteralActivatesSuite = (
+  source: string,
+  match: RegExpMatchArray,
+): boolean => {
+  const operator = match[3];
+  const comparisonTrueWhenEqual = operator === "===" || operator === "==";
+  const prefix = source.slice(0, match.index);
+  if (/describe\.skipIf\(\s*$/u.test(prefix)) {
+    return !comparisonTrueWhenEqual;
+  }
+  if (/if\s*\(\s*$/u.test(prefix)) {
+    const sourceAfterComparison = source.slice(
+      (match.index ?? 0) + match[0].length,
+    );
+    return (
+      directIfComparisonActivatesSuite(
+        sourceAfterComparison,
+        comparisonTrueWhenEqual,
+      ) ?? false
+    );
+  }
+
+  const assignment = /const\s+([A-Za-z_][A-Za-z0-9_]*)\s*=\s*$/u.exec(prefix);
+  const identifier = assignment?.[1];
+  if (!identifier) {
+    return false;
+  }
+
+  const skipWhenTrue = new RegExp(
+    `describe\\.skipIf\\(\\s*${identifier}\\s*\\)`,
+    "u",
+  ).test(source);
+  const skipWhenFalse =
+    new RegExp(`describe\\.skipIf\\(\\s*!\\s*${identifier}\\s*\\)`, "u").test(
+      source,
+    ) ||
+    new RegExp(
+      `if\\s*\\([^)]*!\\s*${identifier}\\b[^)]*\\)\\s*\\{\\s*describe\\.skip`,
+      "su",
+    ).test(source);
+  if (skipWhenTrue === skipWhenFalse) {
+    return false;
+  }
+  const activeWhenComparisonTrue = skipWhenFalse;
+  return comparisonTrueWhenEqual === activeWhenComparisonTrue;
+};
+
+type ScanGatesOptions = {
+  file: string;
+  source: string;
+};
+
+const scanGates = ({ file, source }: ScanGatesOptions): GateScanResult => {
+  const declarations: GateDeclaration[] = [];
+  const unsupported: string[] = [];
+  for (const match of source.matchAll(GATE_PATTERN)) {
+    const gate = match[1] || match[2];
+    const gateValue = match[4];
+    if (!gate || gateValue === undefined || LOCAL_ONLY_GATES.has(gate)) {
+      continue;
+    }
+    if (!comparisonLiteralActivatesSuite(source, match)) {
+      unsupported.push(`${gate} (declared in ${file})`);
+      continue;
+    }
+    declarations.push({ gate, gateValue, file });
+  }
+  return { declarations, unsupported };
+};
+
+const collectGates = async (): Promise<GateScanResult> => {
   const glob = new Bun.Glob(TEST_FILE_GLOB);
   const declarations: GateDeclaration[] = [];
+  const unsupported: string[] = [];
   const seen = new Set<string>();
   for await (const relativePath of glob.scan({ cwd: REPO_ROOT })) {
     if (relativePath.includes("node_modules") || relativePath === SELF_PATH) {
       continue;
     }
     const source = await Bun.file(path.resolve(REPO_ROOT, relativePath)).text();
-    for (const match of source.matchAll(GATE_PATTERN)) {
-      const gate = match[1] || match[2];
-      const key = `${gate} ${relativePath}`;
-      if (!gate || LOCAL_ONLY_GATES.has(gate) || seen.has(key)) {
+    const scan = scanGates({ file: relativePath, source });
+    unsupported.push(...scan.unsupported);
+    for (const declaration of scan.declarations) {
+      const key = `${declaration.gate} ${declaration.gateValue} ${relativePath}`;
+      if (seen.has(key)) {
         continue;
       }
       seen.add(key);
-      declarations.push({ gate, file: relativePath });
+      declarations.push(declaration);
     }
   }
-  return declarations;
+  return { declarations, unsupported };
 };
 
 type Workflow = { path: string; text: string };
+
+type CiGateTestRunner = {
+  gate: string;
+  gateValue: string;
+  packageRoot: string;
+  script: string;
+  testFileGlob: string;
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const requireString = (
+  record: Record<string, unknown>,
+  key: string,
+  sourcePath: string,
+): string => {
+  const value = record[key];
+  if (typeof value !== "string") {
+    throw new TypeError(`${sourcePath} must declare a string ${key}`);
+  }
+  return value;
+};
+
+const isStandaloneRunnerPath = (runner: string): boolean =>
+  runner === path.posix.normalize(runner) &&
+  !path.posix.isAbsolute(runner) &&
+  !runner.startsWith("../") &&
+  /^(?:[A-Za-z0-9_.-]+\/)*[A-Za-z0-9_.-]+\.[cm]?[jt]sx?$/u.test(runner);
+
+const readCiGateTestRunners = async (): Promise<CiGateTestRunner[]> => {
+  const glob = new Bun.Glob(PACKAGE_JSON_GLOB);
+  const runners: CiGateTestRunner[] = [];
+  for await (const relativePath of glob.scan({ cwd: REPO_ROOT })) {
+    const packageJson: unknown = JSON.parse(
+      await Bun.file(path.resolve(REPO_ROOT, relativePath)).text(),
+    );
+    if (!isRecord(packageJson)) {
+      throw new TypeError(`${relativePath} must contain a JSON object`);
+    }
+    const runnerDeclarations = packageJson["ciGateTestRunners"];
+    if (runnerDeclarations === undefined) {
+      continue;
+    }
+    const scripts = packageJson["scripts"];
+    if (!isRecord(runnerDeclarations) || !isRecord(scripts)) {
+      throw new TypeError(
+        `${relativePath} must declare ciGateTestRunners and scripts as objects`,
+      );
+    }
+    const packageRoot = path.posix.dirname(relativePath);
+    for (const [script, declaration] of Object.entries(runnerDeclarations)) {
+      if (!isRecord(declaration)) {
+        throw new TypeError(
+          `${relativePath}#ciGateTestRunners.${script} must be an object`,
+        );
+      }
+      const runner = requireString(declaration, "runner", relativePath);
+      if (!isStandaloneRunnerPath(runner)) {
+        throw new TypeError(
+          `${relativePath}#ciGateTestRunners.${script}.runner must be a standalone relative script path`,
+        );
+      }
+      const runnerPath = path.resolve(REPO_ROOT, packageRoot, runner);
+      if (!existsSync(runnerPath) || !statSync(runnerPath).isFile()) {
+        throw new TypeError(
+          `${relativePath}#ciGateTestRunners.${script}.runner must exist`,
+        );
+      }
+      const scriptCommand = requireString(scripts, script, relativePath);
+      if (scriptCommand !== `bun ${runner}`) {
+        throw new TypeError(
+          `${relativePath}#scripts.${script} must invoke its declared runner`,
+        );
+      }
+      runners.push({
+        gate: requireString(declaration, "gate", relativePath),
+        gateValue: requireString(declaration, "gateValue", relativePath),
+        packageRoot,
+        script,
+        testFileGlob: requireString(declaration, "testFileGlob", relativePath),
+      });
+    }
+  }
+  return runners;
+};
 
 const readWorkflows = async (): Promise<Workflow[]> => {
   const glob = new Bun.Glob(WORKFLOW_GLOB);
@@ -112,6 +303,160 @@ const readWorkflows = async (): Promise<Workflow[]> => {
     });
   }
   return workflows;
+};
+
+type WorkflowStep = {
+  allowsFailure: boolean;
+  isUnconditional: boolean;
+  run: string;
+  workingDirectory: string;
+};
+
+const parseWorkflow = (workflow: Workflow): Record<string, unknown> => {
+  const parsed: unknown = Bun.YAML.parse(workflow.text);
+  if (!isRecord(parsed)) {
+    throw new TypeError(`${workflow.path} must contain a YAML object`);
+  }
+  return parsed;
+};
+
+const collectWorkflowSteps = (workflow: Workflow): WorkflowStep[] => {
+  const parsed = parseWorkflow(workflow);
+  const jobs = parsed["jobs"];
+  if (!isRecord(jobs)) {
+    return [];
+  }
+
+  const workflowSteps: WorkflowStep[] = [];
+  for (const job of Object.values(jobs)) {
+    if (!isRecord(job)) {
+      continue;
+    }
+    const jobContinueOnError = job["continue-on-error"];
+    const jobAllowsFailure =
+      jobContinueOnError !== undefined && jobContinueOnError !== false;
+    const jobCondition = job["if"];
+    const jobIsUnconditional =
+      jobCondition === undefined || jobCondition === true;
+    const steps = job["steps"];
+    if (!Array.isArray(steps)) {
+      continue;
+    }
+    for (const step of steps) {
+      if (!isRecord(step)) {
+        continue;
+      }
+      const run = step["run"];
+      const workingDirectory = step["working-directory"];
+      if (typeof run === "string" && typeof workingDirectory === "string") {
+        const stepContinueOnError = step["continue-on-error"];
+        const stepCondition = step["if"];
+        workflowSteps.push({
+          allowsFailure:
+            jobAllowsFailure ||
+            (stepContinueOnError !== undefined &&
+              stepContinueOnError !== false),
+          isUnconditional:
+            jobIsUnconditional &&
+            (stepCondition === undefined || stepCondition === true),
+          run,
+          workingDirectory,
+        });
+      }
+    }
+  }
+  return workflowSteps;
+};
+
+const workflowRunsPackageScript = (
+  workflow: Workflow,
+  runner: CiGateTestRunner,
+): boolean => {
+  const invocation = `bun run ${runner.script}`;
+  return collectWorkflowSteps(workflow).some(
+    ({ allowsFailure, isUnconditional, run, workingDirectory }) =>
+      !allowsFailure &&
+      isUnconditional &&
+      workingDirectory === runner.packageRoot &&
+      run.trim() === invocation,
+  );
+};
+
+type RunnerCoversOptions = {
+  declaration: GateDeclaration;
+  runner: CiGateTestRunner;
+  workflows: Workflow[];
+};
+
+const runnerCovers = ({
+  declaration,
+  runner,
+  workflows,
+}: RunnerCoversOptions): boolean => {
+  if (
+    runner.gate !== declaration.gate ||
+    runner.gateValue !== declaration.gateValue
+  ) {
+    return false;
+  }
+  const relativeFile = path.posix.relative(
+    runner.packageRoot,
+    declaration.file,
+  );
+  if (relativeFile.startsWith("../")) {
+    return false;
+  }
+  return (
+    new Bun.Glob(runner.testFileGlob).match(relativeFile) &&
+    workflows.some((workflow) => workflowRunsPackageScript(workflow, runner))
+  );
+};
+
+const workflowSetsGate = (
+  workflow: Workflow,
+  declaration: GateDeclaration,
+): boolean => {
+  const environmentSetsGate = (environment: unknown): boolean => {
+    if (!isRecord(environment)) {
+      return false;
+    }
+    const value = environment[declaration.gate];
+    if (
+      typeof value !== "string" &&
+      typeof value !== "number" &&
+      typeof value !== "boolean"
+    ) {
+      return false;
+    }
+    return String(value) === declaration.gateValue;
+  };
+
+  const parsed = parseWorkflow(workflow);
+  if (environmentSetsGate(parsed["env"])) {
+    return true;
+  }
+  const jobs = parsed["jobs"];
+  if (!isRecord(jobs)) {
+    return false;
+  }
+  for (const job of Object.values(jobs)) {
+    if (!isRecord(job)) {
+      continue;
+    }
+    if (environmentSetsGate(job["env"])) {
+      return true;
+    }
+    const steps = job["steps"];
+    if (!Array.isArray(steps)) {
+      continue;
+    }
+    for (const step of steps) {
+      if (isRecord(step) && environmentSetsGate(step["env"])) {
+        return true;
+      }
+    }
+  }
+  return false;
 };
 
 // Suffixes of a repo-relative path, longest first, dropping at least one
@@ -134,24 +479,256 @@ const pathSuffixes = (file: string): string[] => {
 // runs the declaring file. Checking the gate name against the whole
 // workflow corpus alone is not enough: see the UNWIRED_TEST_FILES doc above
 // for why that produces false coverage.
-const isWired = (
-  declaration: GateDeclaration,
-  workflows: Workflow[],
-): boolean => {
+type IsWiredOptions = {
+  declaration: GateDeclaration;
+  runners: CiGateTestRunner[];
+  workflows: Workflow[];
+};
+
+const isWired = ({
+  declaration,
+  runners,
+  workflows,
+}: IsWiredOptions): boolean => {
   const suffixes = pathSuffixes(declaration.file);
-  return workflows.some(
+  const directlyWired = workflows.some(
     (workflow) =>
-      workflow.text.includes(declaration.gate) &&
+      workflowSetsGate(workflow, declaration) &&
       suffixes.some((suffix) => workflow.text.includes(suffix)),
+  );
+  return (
+    directlyWired ||
+    runners.some((runner) => runnerCovers({ declaration, runner, workflows }))
   );
 };
 
 describe("ci-gate coverage convention", () => {
+  test("requires standalone runner paths", () => {
+    expect(isStandaloneRunnerPath("scripts/run-postgres-tests.ts")).toBe(true);
+    expect(
+      isStandaloneRunnerPath("scripts/run-postgres-tests.ts || true"),
+    ).toBe(false);
+    expect(isStandaloneRunnerPath("../run-postgres-tests.ts")).toBe(false);
+    expect(isStandaloneRunnerPath("/tmp/run-postgres-tests.ts")).toBe(false);
+  });
+
+  test("matches workflow gate values as complete YAML scalars", () => {
+    const declaration = {
+      file: "apps/api/src/example.test.ts",
+      gate: "EXAMPLE_GATE",
+      gateValue: "1",
+    };
+    const workflowWithPrefix = {
+      path: ".github/workflows/ci.yml",
+      text: `jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - env:
+          EXAMPLE_GATE: 10
+        run: bun test apps/api/src/example.test.ts`,
+    };
+    const workflowWithExactValue = {
+      path: ".github/workflows/ci.yml",
+      text: `jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - env:
+          EXAMPLE_GATE: "1"
+        run: bun test apps/api/src/example.test.ts`,
+    };
+
+    expect(workflowSetsGate(workflowWithPrefix, declaration)).toBe(false);
+    expect(workflowSetsGate(workflowWithExactValue, declaration)).toBe(true);
+  });
+
+  test("recognizes direct if-gate predicates and their polarity", () => {
+    const file = "apps/api/src/example.test.ts";
+    const scan = scanGates({
+      file,
+      source: `if (process.env["ENABLED_GATE"] !== "1") {
+  describe.skip("enabled", () => {});
+} else {
+  describe("enabled", () => {});
+}
+if (process.env["INVERSE_GATE"] === "1") {
+  describe.skip("inverse", () => {});
+} else {
+  describe("inverse", () => {});
+}`,
+    });
+
+    expect(scan).toEqual({
+      declarations: [{ file, gate: "ENABLED_GATE", gateValue: "1" }],
+      unsupported: [`INVERSE_GATE (declared in ${file})`],
+    });
+  });
+
+  test("rejects compared values that disable their suites", () => {
+    const file = "apps/api/src/example.test.ts";
+    const scan = scanGates({
+      file,
+      source: `describe.skipIf(process.env["DIRECT_GATE"] === "1")("direct", () => {});
+const SKIP_INDIRECT = process.env["INDIRECT_GATE"] === "1";
+describe.skipIf(SKIP_INDIRECT)("indirect", () => {});`,
+    });
+
+    expect(scan).toEqual({
+      declarations: [],
+      unsupported: [
+        `DIRECT_GATE (declared in ${file})`,
+        `INDIRECT_GATE (declared in ${file})`,
+      ],
+    });
+  });
+
+  test("does not cover a suite with a different activation value", () => {
+    const declaration = {
+      file: "apps/api/src/db/root.test.ts",
+      gate: "STELLA_RUN_POSTGRES_TESTS",
+      gateValue: "1",
+    };
+    const runner = {
+      gate: "STELLA_RUN_POSTGRES_TESTS",
+      gateValue: "true",
+      packageRoot: "apps/api",
+      script: "test:postgres",
+      testFileGlob: "src/**/*.test.{ts,tsx}",
+    };
+    const workflows = [
+      {
+        path: ".github/workflows/ci.yml",
+        text: `jobs:
+  postgres-suites:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run gated tests
+        working-directory: apps/api
+        run: bun run test:postgres`,
+      },
+    ];
+
+    expect(runnerCovers({ declaration, runner, workflows })).toBe(false);
+  });
+
+  test("does not accept a longer package script name", () => {
+    const runner = {
+      gate: "STELLA_RUN_POSTGRES_TESTS",
+      gateValue: "true",
+      packageRoot: "apps/api",
+      script: "test:postgres",
+      testFileGlob: "src/**/*.test.{ts,tsx}",
+    };
+    const workflow = {
+      path: ".github/workflows/ci.yml",
+      text: `jobs:
+  postgres-suites:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run gated tests
+        working-directory: apps/api
+        run: bun run test:postgres-disabled`,
+    };
+
+    expect(workflowRunsPackageScript(workflow, runner)).toBe(false);
+  });
+
+  test("does not accept a runner that can be skipped or masked", () => {
+    const runner = {
+      gate: "STELLA_RUN_POSTGRES_TESTS",
+      gateValue: "true",
+      packageRoot: "apps/api",
+      script: "test:postgres",
+      testFileGlob: "src/**/*.test.{ts,tsx}",
+    };
+    const shellMasked = {
+      path: ".github/workflows/ci.yml",
+      text: `jobs:
+  postgres-suites:
+    runs-on: ubuntu-latest
+    steps:
+      - working-directory: apps/api
+        run: bun run test:postgres || true`,
+    };
+    const continueOnError = {
+      path: ".github/workflows/ci.yml",
+      text: `jobs:
+  postgres-suites:
+    runs-on: ubuntu-latest
+    steps:
+      - continue-on-error: true
+        working-directory: apps/api
+        run: bun run test:postgres`,
+    };
+    const disabled = {
+      path: ".github/workflows/ci.yml",
+      text: `jobs:
+  postgres-suites:
+    runs-on: ubuntu-latest
+    steps:
+      - if: false
+        working-directory: apps/api
+        run: bun run test:postgres`,
+    };
+    const disabledJob = {
+      path: ".github/workflows/ci.yml",
+      text: `jobs:
+  postgres-suites:
+    if: false
+    runs-on: ubuntu-latest
+    steps:
+      - working-directory: apps/api
+        run: bun run test:postgres`,
+    };
+
+    expect(workflowRunsPackageScript(shellMasked, runner)).toBe(false);
+    expect(workflowRunsPackageScript(continueOnError, runner)).toBe(false);
+    expect(workflowRunsPackageScript(disabled, runner)).toBe(false);
+    expect(workflowRunsPackageScript(disabledJob, runner)).toBe(false);
+  });
+
+  test("keeps the package directory and invocation in one workflow step", () => {
+    const runner = {
+      gate: "STELLA_RUN_POSTGRES_TESTS",
+      gateValue: "true",
+      packageRoot: "apps/api",
+      script: "test:postgres",
+      testFileGlob: "src/**/*.test.{ts,tsx}",
+    };
+    const separateSteps = {
+      path: ".github/workflows/ci.yml",
+      text: `jobs:
+  postgres-suites:
+    runs-on: ubuntu-latest
+    steps:
+      - working-directory: apps/api
+        run: bun run src/db/migrate.ts
+      - run: bun run test:postgres`,
+    };
+    const sameUnnamedStep = {
+      path: ".github/workflows/ci.yml",
+      text: `jobs:
+  postgres-suites:
+    runs-on: ubuntu-latest
+    steps:
+      - run: bun run test:postgres
+        working-directory: apps/api`,
+    };
+
+    expect(workflowRunsPackageScript(separateSteps, runner)).toBe(false);
+    expect(workflowRunsPackageScript(sameUnnamedStep, runner)).toBe(true);
+  });
+
   test("every env-gated test suite has a workflow that runs it with its gate set", async () => {
-    const [declarations, workflows] = await Promise.all([
+    const [gateScan, workflows, runners] = await Promise.all([
       collectGates(),
       readWorkflows(),
+      readCiGateTestRunners(),
     ]);
+    const { declarations, unsupported } = gateScan;
+
+    expect(unsupported.sort()).toEqual([]);
 
     // Sanity: the known gates must still be discovered by the pattern.
     // A miss here means the detection rotted, not that coverage is fine.
@@ -166,7 +743,7 @@ describe("ci-gate coverage convention", () => {
       .filter(
         (declaration) =>
           !UNWIRED_TEST_FILES.has(declaration.file) &&
-          !isWired(declaration, workflows),
+          !isWired({ declaration, runners, workflows }),
       )
       .map(({ gate, file }) => `${gate} (declared in ${file})`)
       .sort();


### PR DESCRIPTION
Teach the CI gate-coverage guard to recognize package-declared dynamic test runners.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * PostgreSQL test execution can now be explicitly enabled through the configured CI setting.
  * Test runners automatically use the declared test markers, file patterns and activation values.
  * CI coverage checks now validate that test gates and workflow commands remain correctly aligned.
  * Added validation for incorrect activation values and similarly named script prefixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->