### PR TITLE
fix: isolate route smoke cleanup

### DIFF
--- a/apps/web/e2e/global-teardown.ts
+++ b/apps/web/e2e/global-teardown.ts
@@ -1,0 +1,109 @@
+import type { APIRequestContext, FullConfig } from "@playwright/test";
+import { request as apiRequestFactory } from "@playwright/test";
+import path from "node:path";
+
+import { apiDelete } from "./helpers/api";
+import {
+  clearDeferredE2eCleanup,
+  E2E_CLEANUP_TARGET_TYPE,
+  type E2eCleanupTarget,
+  readDeferredE2eCleanup,
+} from "./helpers/deferred-cleanup";
+
+const REPO_ROOT = path.resolve(import.meta.dirname, "../../..");
+const STORAGE_STATE = path.resolve(REPO_ROOT, ".playwright/storage-state.json");
+
+const cleanupTarget = async (
+  request: APIRequestContext,
+  target: E2eCleanupTarget,
+): Promise<void> => {
+  switch (target.type) {
+    case E2E_CLEANUP_TARGET_TYPE.CONTACT:
+      await apiDelete(request, `/contacts/${target.id}`);
+      return;
+    case E2E_CLEANUP_TARGET_TYPE.WORKSPACE:
+      await apiDelete(request, `/workspaces/${target.id}`);
+      return;
+    default:
+      return target satisfies never;
+  }
+};
+
+const cleanupTargets = async (
+  request: APIRequestContext,
+  targets: E2eCleanupTarget[],
+): Promise<unknown[]> => {
+  const results = await Promise.allSettled(
+    targets.map(async (target) => {
+      await cleanupTarget(request, target);
+    }),
+  );
+  const failures: unknown[] = [];
+  for (const result of results) {
+    if (result.status === "rejected") {
+      const reason: unknown = result.reason;
+      failures.push(reason);
+    }
+  }
+  return failures;
+};
+
+const globalTeardown = async (config: FullConfig): Promise<void> => {
+  const outputDirectories = [
+    ...new Set(config.projects.map((project) => project.outputDir)),
+  ];
+  const cleanupByDirectory = await Promise.all(
+    outputDirectories.map(async (outputDirectory) => ({
+      outputDirectory,
+      result: await readDeferredE2eCleanup(outputDirectory),
+    })),
+  );
+  const targets = cleanupByDirectory.flatMap(({ result }) => result.targets);
+  const failures = cleanupByDirectory.flatMap(({ result }) => result.failures);
+
+  if (targets.length === 0) {
+    if (failures.length > 0) {
+      throw new AggregateError(failures, "Deferred E2E fixture cleanup failed");
+    }
+    return;
+  }
+
+  const apiRequest = await apiRequestFactory.newContext({
+    storageState: STORAGE_STATE,
+  });
+  failures.push(
+    ...(await cleanupTargets(
+      apiRequest,
+      targets.filter(
+        (target) => target.type === E2E_CLEANUP_TARGET_TYPE.CONTACT,
+      ),
+    )),
+  );
+  failures.push(
+    ...(await cleanupTargets(
+      apiRequest,
+      targets.filter(
+        (target) => target.type === E2E_CLEANUP_TARGET_TYPE.WORKSPACE,
+      ),
+    )),
+  );
+  try {
+    await apiRequest.dispose();
+  } catch (error: unknown) {
+    failures.push(error);
+  }
+
+  if (failures.length > 0) {
+    throw new AggregateError(failures, "Deferred E2E fixture cleanup failed");
+  }
+
+  await Promise.all(
+    cleanupByDirectory
+      .filter(({ result }) => result.targets.length > 0)
+      .map(async ({ outputDirectory }) => {
+        await clearDeferredE2eCleanup(outputDirectory);
+      }),
+  );
+};
+
+export default globalTeardown;

--- a/apps/web/e2e/helpers/deferred-cleanup.ts
+++ b/apps/web/e2e/helpers/deferred-cleanup.ts
@@ -1,0 +1,153 @@
+import { panic, Result } from "better-result";
+import { randomUUID } from "node:crypto";
+import { existsSync } from "node:fs";
+import {
+  mkdir,
+  readFile,
+  readdir,
+  rename,
+  rmdir,
+  rm,
+  unlink,
+  writeFile,
+} from "node:fs/promises";
+import path from "node:path";
+import * as v from "valibot";
+
+const CLEANUP_DIRECTORY = "route-smoke-cleanup";
+const CLEANUP_RECORD_EXTENSION = ".json";
+const CLEANUP_TEMP_EXTENSION = ".tmp";
+
+export const E2E_CLEANUP_TARGET_TYPE = {
+  CONTACT: "contact",
+  WORKSPACE: "workspace",
+} as const;
+
+const cleanupTargetSchema = v.variant("type", [
+  v.object({
+    type: v.literal(E2E_CLEANUP_TARGET_TYPE.CONTACT),
+    id: v.pipe(v.string(), v.uuid()),
+  }),
+  v.object({
+    type: v.literal(E2E_CLEANUP_TARGET_TYPE.WORKSPACE),
+    id: v.pipe(v.string(), v.uuid()),
+  }),
+]);
+
+export type E2eCleanupTarget = v.InferOutput<typeof cleanupTargetSchema>;
+
+export type E2eCleanupReadResult = {
+  failures: unknown[];
+  targets: E2eCleanupTarget[];
+};
+
+const cleanupDirectory = (outputDirectory: string): string =>
+  path.join(outputDirectory, CLEANUP_DIRECTORY);
+
+export const registerDeferredE2eCleanup = async (
+  outputDirectory: string,
+  target: E2eCleanupTarget,
+): Promise<void> => {
+  const directory = cleanupDirectory(outputDirectory);
+  await mkdir(directory, { recursive: true });
+  const recordId = randomUUID();
+  const temporaryPath = path.join(
+    directory,
+    `${recordId}${CLEANUP_TEMP_EXTENSION}`,
+  );
+  const recordPath = path.join(
+    directory,
+    `${recordId}${CLEANUP_RECORD_EXTENSION}`,
+  );
+  const published = await Result.tryPromise(async () => {
+    await writeFile(temporaryPath, `${JSON.stringify(target)}\n`, {
+      encoding: "utf-8",
+      flag: "wx",
+    });
+    await rename(temporaryPath, recordPath);
+  });
+  if (Result.isOk(published)) {
+    return;
+  }
+
+  const rolledBack = await Result.tryPromise(async () => {
+    await rm(temporaryPath, { force: true });
+  });
+  if (Result.isError(rolledBack)) {
+    throw new AggregateError(
+      [published.error.cause, rolledBack.error.cause],
+      "Deferred E2E cleanup registration and rollback failed",
+    );
+  }
+  throw published.error.cause;
+};
+
+export const readDeferredE2eCleanup = async (
+  outputDirectory: string,
+): Promise<E2eCleanupReadResult> => {
+  const directory = cleanupDirectory(outputDirectory);
+  if (!existsSync(directory)) {
+    return { failures: [], targets: [] };
+  }
+  const entries = await readdir(directory, {
+    encoding: "utf-8",
+    withFileTypes: true,
+  });
+
+  const results = await Promise.allSettled(
+    entries.map(async (entry) => {
+      if (
+        !(
+          entry.isFile() &&
+          (entry.name.endsWith(CLEANUP_RECORD_EXTENSION) ||
+            entry.name.endsWith(CLEANUP_TEMP_EXTENSION))
+        )
+      ) {
+        return panic(`Unexpected deferred E2E cleanup entry: ${entry.name}`);
+      }
+
+      const serialized = await readFile(
+        path.join(directory, entry.name),
+        "utf-8",
+      );
+      const input = Result.try((): unknown => JSON.parse(serialized));
+      if (Result.isError(input)) {
+        return panic(`Invalid deferred E2E cleanup target: ${entry.name}`);
+      }
+
+      const parsed = v.safeParse(cleanupTargetSchema, input.value);
+      if (!parsed.success) {
+        return panic(`Invalid deferred E2E cleanup target: ${entry.name}`);
+      }
+      return parsed.output;
+    }),
+  );
+
+  const failures: unknown[] = [];
+  const targets: E2eCleanupTarget[] = [];
+  for (const result of results) {
+    if (result.status === "fulfilled") {
+      targets.push(result.value);
+      continue;
+    }
+    const reason: unknown = result.reason;
+    failures.push(reason);
+  }
+  return { failures, targets };
+};
+
+export const clearDeferredE2eCleanup = async (
+  outputDirectory: string,
+): Promise<void> => {
+  const directory = cleanupDirectory(outputDirectory);
+  const entries = await readdir(directory, { withFileTypes: true });
+  await Promise.all(
+    entries.map(async (entry) => {
+      if (!entry.isFile()) {
+        panic(`Unexpected deferred E2E cleanup entry: ${entry.name}`);
+      }
+      await unlink(path.join(directory, entry.name));
+    }),
+  );
+  await rmdir(directory);
+};

--- a/apps/web/e2e/playwright.config.ts
+++ b/apps/web/e2e/playwright.config.ts
@@ -16,6 +16,7 @@ const executionProfile = resolveE2eExecutionProfile(
 
 export default defineConfig({
   testDir: "./specs",
+  globalTeardown: "./global-teardown.ts",
   // The production CI profile pairs two workers with four isolated route-smoke
   // groups. Other CI checks stay single-worker; local runs retain four workers.
   fullyParallel: true,

--- a/apps/web/e2e/specs/route-smoke.spec.ts
+++ b/apps/web/e2e/specs/route-smoke.spec.ts
@@ -14,6 +14,10 @@ import {
   resolveE2eExecutionProfile,
 } from "../execution-profile";
 import { apiDelete, apiPut } from "../helpers/api";
+import {
+  E2E_CLEANUP_TARGET_TYPE,
+  registerDeferredE2eCleanup,
+} from "../helpers/deferred-cleanup";
 import { createUploadedDocumentRoute } from "../helpers/document";
 import {
   type RouteNetworkMetrics,
@@ -253,12 +257,14 @@ const declareRouteSmokeGroup = ({
     let context: BrowserContext;
     let world: SmokeWorld | null = null;
     // Recorded the moment each fixture is created (not only after the whole
-    // setup succeeds), so a failure mid-setup still tears down what exists.
+    // setup succeeds), so a registry failure still tears down what exists.
     let createdWorkspace: SmokeWorld["workspace"] | null = null;
     let createdContactId: string | null = null;
+    let workspaceCleanupRegistered = false;
+    let contactCleanupRegistered = false;
     const networkResults = new Map<string, RouteNetworkMetrics>();
 
-    test.beforeAll(async ({ browser }) => {
+    test.beforeAll(async ({ browser }, testInfo) => {
       apiRequest = await apiRequestFactory.newContext({
         storageState: STORAGE_STATE,
       });
@@ -266,8 +272,18 @@ const declareRouteSmokeGroup = ({
 
       const workspace = await createTestWorkspace(apiRequest, "route-smoke");
       createdWorkspace = workspace;
+      await registerDeferredE2eCleanup(testInfo.project.outputDir, {
+        type: E2E_CLEANUP_TARGET_TYPE.WORKSPACE,
+        id: workspace.id,
+      });
+      workspaceCleanupRegistered = true;
       const contactId = await createContact(apiRequest);
       createdContactId = contactId;
+      await registerDeferredE2eCleanup(testInfo.project.outputDir, {
+        type: E2E_CLEANUP_TARGET_TYPE.CONTACT,
+        id: contactId,
+      });
+      contactCleanupRegistered = true;
       const documentRoute = await createUploadedDocumentRoute({
         fileName: "route-smoke.docx",
         request: apiRequest,
@@ -277,20 +293,18 @@ const declareRouteSmokeGroup = ({
     });
 
     test.afterAll(async () => {
-      // Best-effort but total: attempt every teardown step even if one throws,
-      // so a single failure cannot strand the other fixture or leak the browser
-      // context / request context. Runs on the beforeAll-owned request context
-      // (not a per-test fixture), so it cannot race a timing-out test body into
-      // the "context closed" masking error.
+      // Registered API fixtures are deleted by global teardown after every
+      // measured page is closed. Only registry failures fall back to immediate
+      // cleanup here; the run is already failing in that case.
       const failures: unknown[] = [];
-      if (createdContactId !== null) {
+      if (createdContactId !== null && !contactCleanupRegistered) {
         try {
           await apiDelete(apiRequest, `/contacts/${createdContactId}`);
         } catch (error) {
           failures.push(error);
         }
       }
-      if (createdWorkspace !== null) {
+      if (createdWorkspace !== null && !workspaceCleanupRegistered) {
         try {
           await deleteTestWorkspace(apiRequest, createdWorkspace.id);
         } catch (error) {

--- a/apps/web/e2e/unit/deferred-cleanup.test.ts
+++ b/apps/web/e2e/unit/deferred-cleanup.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { randomUUID } from "node:crypto";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import {
+  clearDeferredE2eCleanup,
+  E2E_CLEANUP_TARGET_TYPE,
+  type E2eCleanupTarget,
+  readDeferredE2eCleanup,
+  registerDeferredE2eCleanup,
+} from "../helpers/deferred-cleanup";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories.splice(0).map(async (directory) => {
+      await rm(directory, { force: true, recursive: true });
+    }),
+  );
+});
+
+describe("deferred E2E cleanup", () => {
+  test("preserves concurrent worker registrations until global teardown", async () => {
+    const outputDirectory = await mkdtemp(
+      path.join(tmpdir(), "stella-e2e-cleanup-"),
+    );
+    temporaryDirectories.push(outputDirectory);
+    const targets = [
+      {
+        type: E2E_CLEANUP_TARGET_TYPE.WORKSPACE,
+        id: randomUUID(),
+      },
+      {
+        type: E2E_CLEANUP_TARGET_TYPE.CONTACT,
+        id: randomUUID(),
+      },
+    ] satisfies E2eCleanupTarget[];
+
+    await Promise.all(
+      targets.map(async (target) => {
+        await registerDeferredE2eCleanup(outputDirectory, target);
+      }),
+    );
+
+    const registered = await readDeferredE2eCleanup(outputDirectory);
+    expect(registered.failures).toEqual([]);
+    expect(
+      registered.targets.toSorted((left, right) =>
+        left.type.localeCompare(right.type),
+      ),
+    ).toEqual(
+      targets.toSorted((left, right) => left.type.localeCompare(right.type)),
+    );
+
+    await clearDeferredE2eCleanup(outputDirectory);
+    expect(await readDeferredE2eCleanup(outputDirectory)).toEqual({
+      failures: [],
+      targets: [],
+    });
+  });
+
+  test("retains valid targets when a registry record is malformed", async () => {
+    const outputDirectory = await mkdtemp(
+      path.join(tmpdir(), "stella-e2e-cleanup-"),
+    );
+    temporaryDirectories.push(outputDirectory);
+    const target = {
+      type: E2E_CLEANUP_TARGET_TYPE.WORKSPACE,
+      id: randomUUID(),
+    } satisfies E2eCleanupTarget;
+    await registerDeferredE2eCleanup(outputDirectory, target);
+    const cleanupDirectory = path.join(outputDirectory, "route-smoke-cleanup");
+    await mkdir(cleanupDirectory, { recursive: true });
+    await writeFile(path.join(cleanupDirectory, "malformed.json"), "{");
+
+    const result = await readDeferredE2eCleanup(outputDirectory);
+
+    expect(result.targets).toEqual([target]);
+    expect(result.failures).toHaveLength(1);
+    expect(result.failures.at(0)).toMatchObject({
+      message: "Invalid deferred E2E cleanup target: malformed.json",
+    });
+  });
+});


### PR DESCRIPTION
Defers route-smoke fixture deletion until all measured browser contexts close.

CC on behalf of jan-kubica

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end test cleanup by deferring removal of test workspaces and contacts until the test suite completes.
  * Added automated checks to verify cleanup targets are recorded, processed, and cleared correctly.
  * Enhanced error handling so cleanup failures are reported without hiding other teardown issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->