### PR TITLE
fix: handle renamed catalogue skills

### DIFF
--- a/packages/catalogue/entries/skills/contract-review/manifest.json
+++ b/packages/catalogue/entries/skills/contract-review/manifest.json
@@ -10,9 +10,9 @@
   "license": "Apache-2.0",
   "cost": "free",
   "setup": "none",
-  "homepage": "https://github.com/lawve-ai/awesome-legal-skills/tree/main/skills/contract-review-anthropic",
+  "homepage": "https://github.com/lawve-ai/awesome-legal-skills/tree/main/skills/playbook-reviewer-anthropic",
   "tags": ["commercial", "corporate"],
   "repo": "lawve-ai/awesome-legal-skills",
-  "rev": "a5334c66dda1a909c8ad3ef61892de446d6b68c4",
-  "directory": "skills/contract-review-anthropic"
+  "rev": "6f4f454728fac240c3688092bf4acda0b0f14dd6",
+  "directory": "skills/playbook-reviewer-anthropic"
 }

--- a/packages/catalogue/entries/skills/jurisrank-csjn-analysis/manifest.json
+++ b/packages/catalogue/entries/skills/jurisrank-csjn-analysis/manifest.json
@@ -9,10 +9,10 @@
   "license": "CC-BY-4.0",
   "cost": "free",
   "setup": "none",
-  "homepage": "https://github.com/lawve-ai/awesome-legal-skills/tree/main/skills/jurisrank-argentine-supreme-court-analysis-adrian-lerer",
+  "homepage": "https://github.com/lawve-ai/awesome-legal-skills/tree/main/skills/argentine-supreme-court-analysis-adrian-lerer",
   "tags": ["litigation", "dispute-resolution"],
   "jurisdictions": ["AR"],
   "repo": "lawve-ai/awesome-legal-skills",
-  "rev": "7f58aaf1fbc7b12904b15b622edb1f8ac0742f5a",
-  "directory": "skills/jurisrank-argentine-supreme-court-analysis-adrian-lerer"
+  "rev": "6f4f454728fac240c3688092bf4acda0b0f14dd6",
+  "directory": "skills/argentine-supreme-court-analysis-adrian-lerer"
 }

--- a/packages/catalogue/scripts/check-upstream.ts
+++ b/packages/catalogue/scripts/check-upstream.ts
@@ -3,11 +3,12 @@
  *
  * Each github skill pins an immutable commit SHA (`rev`). This script
  * asks the GitHub API for the latest commit touching the skill's
- * directory (or repo root) on the repo's default branch and reports the
- * entries whose upstream has advanced past the pinned SHA. It never
+ * directory (or repo root) on the repo's default branch. A directory's
+ * latest commit can be its deletion, so the script verifies that the
+ * expected SKILL.md still exists before reporting an update. It never
  * edits manifests: the scheduled `catalogue-upstream` workflow consumes
- * the `--json` output, bumps the revs, regenerates, and opens a PR for
- * a maintainer to review the upstream diff before merging.
+ * the `--json` output, bumps installable revisions, regenerates, and
+ * opens a PR for a maintainer to review before merging.
  *
  * Usage:
  *   bun scripts/check-upstream.ts          # human-readable summary
@@ -26,8 +27,11 @@ class UpstreamFetchError extends TaggedError("UpstreamFetchError")<{
 
 const COMMITS_API_TIMEOUT_MS = 10_000;
 const COMMIT_SHA_PATTERN = /^[0-9a-f]{40}$/u;
+const SKILL_FILE_NAME = "SKILL.md";
 
-type GithubSkillTarget = {
+type Fetcher = (...args: Parameters<typeof fetch>) => ReturnType<typeof fetch>;
+
+export type GithubSkillTarget = {
   currentRev: string;
   directory: string | null;
   repo: string;
@@ -55,6 +59,11 @@ export type UpstreamCheckResult = {
   updates: UpstreamUpdate[];
 };
 
+export type UpstreamTargetState =
+  | { latestRev: string; status: "current" }
+  | { latestRev: string; status: "missing" }
+  | { latestRev: string; status: "update" };
+
 /**
  * GitHub commits API endpoint for the latest commit touching a path
  * (or the repo root when `directory` is null) on the default branch.
@@ -71,6 +80,25 @@ export const buildCommitsApiUrl = ({
   if (directory) {
     url.searchParams.set("path", directory);
   }
+  return url.toString();
+};
+
+/** GitHub Contents endpoint for the expected skill file at a candidate SHA. */
+export const buildSkillFileApiUrl = ({
+  directory,
+  repo,
+  rev,
+}: {
+  directory: string | null;
+  repo: string;
+  rev: string;
+}): string => {
+  const path = directory ? `${directory}/${SKILL_FILE_NAME}` : SKILL_FILE_NAME;
+  const encodedPath = path.split("/").map(encodeURIComponent).join("/");
+  const url = new URL(
+    `https://api.github.com/repos/${repo}/contents/${encodedPath}`,
+  );
+  url.searchParams.set("ref", rev);
   return url.toString();
 };
 
@@ -137,8 +165,11 @@ const githubHeaders = (): Record<string, string> => {
   return headers;
 };
 
-const fetchLatestRev = async (target: GithubSkillTarget): Promise<string> => {
-  const response = await fetch(
+const fetchLatestRev = async (
+  target: GithubSkillTarget,
+  fetcher: Fetcher,
+): Promise<string> => {
+  const response = await fetcher(
     buildCommitsApiUrl({ directory: target.directory, repo: target.repo }),
     {
       headers: githubHeaders(),
@@ -157,6 +188,61 @@ const fetchLatestRev = async (target: GithubSkillTarget): Promise<string> => {
     });
   }
   return sha;
+};
+
+const fetchCandidateStatus = async (
+  target: GithubSkillTarget,
+  latestRev: string,
+  fetcher: Fetcher,
+): Promise<"available" | "missing"> => {
+  const response = await fetcher(
+    buildSkillFileApiUrl({
+      directory: target.directory,
+      repo: target.repo,
+      rev: latestRev,
+    }),
+    {
+      headers: githubHeaders(),
+      signal: AbortSignal.timeout(COMMITS_API_TIMEOUT_MS),
+    },
+  );
+  if (response.status === 404) {
+    return "missing";
+  }
+  if (!response.ok) {
+    throw new UpstreamFetchError({
+      message: `GitHub contents API returned HTTP ${response.status}`,
+    });
+  }
+  const payload: unknown = await response.json();
+  if (!isRecord(payload) || payload["type"] !== "file") {
+    throw new UpstreamFetchError({
+      message: `GitHub contents response did not describe ${SKILL_FILE_NAME} as a file`,
+    });
+  }
+  return "available";
+};
+
+/**
+ * Resolve one target without turning a directory deletion into a revision bump.
+ */
+export const inspectUpstreamTarget = async (
+  target: GithubSkillTarget,
+  fetcher: Fetcher = fetch,
+): Promise<UpstreamTargetState> => {
+  const latestRev = await fetchLatestRev(target, fetcher);
+  if (!hasUpstreamUpdate(target.currentRev, latestRev)) {
+    return { latestRev, status: "current" };
+  }
+  const candidateStatus = await fetchCandidateStatus(
+    target,
+    latestRev,
+    fetcher,
+  );
+  return {
+    latestRev,
+    status: candidateStatus === "available" ? "update" : "missing",
+  };
 };
 
 const toUpdate = (
@@ -183,9 +269,22 @@ export const runUpstreamCheck = async (): Promise<UpstreamCheckResult> => {
   for (const target of collectGithubSkillTargets()) {
     try {
       // oxlint-disable-next-line no-await-in-loop -- sequential sweep keeps the GitHub API request rate low
-      const latestRev = await fetchLatestRev(target);
-      if (hasUpstreamUpdate(target.currentRev, latestRev)) {
-        updates.push(toUpdate(target, latestRev));
+      const state = await inspectUpstreamTarget(target);
+      switch (state.status) {
+        case "current":
+          break;
+        case "missing":
+          failures.push({
+            message: `${SKILL_FILE_NAME} is absent at the latest directory commit ${state.latestRev}; the tracked path may have moved (${buildCompareUrl({ currentRev: target.currentRev, latestRev: state.latestRev, repo: target.repo })})`,
+            repo: target.repo,
+            slug: target.slug,
+          });
+          break;
+        case "update":
+          updates.push(toUpdate(target, state.latestRev));
+          break;
+        default:
+          state satisfies never;
       }
     } catch (error) {
       failures.push({

--- a/packages/catalogue/src/check-upstream.test.ts
+++ b/packages/catalogue/src/check-upstream.test.ts
@@ -3,8 +3,10 @@ import { describe, expect, it } from "bun:test";
 import {
   buildCommitsApiUrl,
   buildCompareUrl,
+  buildSkillFileApiUrl,
   catalogueManifestPath,
   hasUpstreamUpdate,
+  inspectUpstreamTarget,
   parseLatestCommitSha,
 } from "../scripts/check-upstream";
 
@@ -62,6 +64,115 @@ describe("hasUpstreamUpdate", () => {
   });
 });
 
+describe("inspectUpstreamTarget", () => {
+  it("reports an installable candidate as an update", async () => {
+    let requestCount = 0;
+    const fetcher = async () => {
+      requestCount += 1;
+      if (requestCount === 1) {
+        return new Response(JSON.stringify([{ sha: OTHER_SHA }]), {
+          status: 200,
+        });
+      }
+      return new Response(JSON.stringify({ type: "file" }), { status: 200 });
+    };
+
+    const state = await inspectUpstreamTarget(
+      {
+        currentRev: FULL_SHA,
+        directory: "skills/german-law",
+        repo: "acme/legal",
+        slug: "german-law",
+      },
+      fetcher,
+    );
+
+    expect(state).toEqual({ latestRev: OTHER_SHA, status: "update" });
+    expect(requestCount).toBe(2);
+  });
+
+  it("keeps the reviewed pin when the latest directory commit deleted SKILL.md", async () => {
+    let requestCount = 0;
+    const fetcher = async () => {
+      requestCount += 1;
+      if (requestCount === 1) {
+        return new Response(JSON.stringify([{ sha: OTHER_SHA }]), {
+          status: 200,
+        });
+      }
+      return new Response(null, { status: 404 });
+    };
+
+    const state = await inspectUpstreamTarget(
+      {
+        currentRev: FULL_SHA,
+        directory: "skills/german-law",
+        repo: "acme/legal",
+        slug: "german-law",
+      },
+      fetcher,
+    );
+
+    expect(state).toEqual({ latestRev: OTHER_SHA, status: "missing" });
+    expect(requestCount).toBe(2);
+  });
+
+  it("does not probe SKILL.md when the tracked directory has not changed", async () => {
+    let requestCount = 0;
+    const fetcher = async () => {
+      requestCount += 1;
+      return new Response(JSON.stringify([{ sha: FULL_SHA }]), {
+        status: 200,
+      });
+    };
+
+    const state = await inspectUpstreamTarget(
+      {
+        currentRev: FULL_SHA,
+        directory: null,
+        repo: "acme/legal",
+        slug: "german-law",
+      },
+      fetcher,
+    );
+
+    expect(state).toEqual({ latestRev: FULL_SHA, status: "current" });
+    expect(requestCount).toBe(1);
+  });
+
+  it("surfaces candidate probe errors instead of treating them as missing", async () => {
+    let requestCount = 0;
+    const fetcher = async () => {
+      requestCount += 1;
+      if (requestCount === 1) {
+        return new Response(JSON.stringify([{ sha: OTHER_SHA }]), {
+          status: 200,
+        });
+      }
+      return new Response(null, { status: 503 });
+    };
+
+    // Bun types declare `.rejects.toThrow` as void; capture explicitly so
+    // type-aware lint and the runtime agree.
+    const rejection: unknown = await inspectUpstreamTarget(
+      {
+        currentRev: FULL_SHA,
+        directory: "skills/german-law",
+        repo: "acme/legal",
+        slug: "german-law",
+      },
+      fetcher,
+    ).then(
+      () => null,
+      (error: unknown) => error,
+    );
+
+    expect(rejection).toMatchObject({
+      message: "GitHub contents API returned HTTP 503",
+    });
+  });
+});
+
 describe("url and path helpers", () => {
   it("builds a compare url between the pinned and latest SHAs", () => {
     expect(
@@ -76,6 +187,27 @@ describe("url and path helpers", () => {
   it("builds the repo-root-relative manifest path", () => {
     expect(catalogueManifestPath("german-law")).toBe(
       "packages/catalogue/entries/skills/german-law/manifest.json",
+    );
+  });
+
+  it("builds the candidate SKILL.md contents URL", () => {
+    expect(
+      buildSkillFileApiUrl({
+        directory: "skills/german law",
+        repo: "acme/legal",
+        rev: FULL_SHA,
+      }),
+    ).toBe(
+      `https://api.github.com/repos/acme/legal/contents/skills/german%20law/SKILL.md?ref=${FULL_SHA}`,
+    );
+    expect(
+      buildSkillFileApiUrl({
+        directory: null,
+        repo: "acme/legal",
+        rev: FULL_SHA,
+      }),
+    ).toBe(
+      `https://api.github.com/repos/acme/legal/contents/SKILL.md?ref=${FULL_SHA}`,
     );
   });
 });


### PR DESCRIPTION
## Summary

- verify that an upstream catalogue candidate still contains SKILL.md before creating an automated revision bump
- surface moved or removed skill paths as failures without discarding other valid updates
- repoint the Contract Review and JurisRank entries to their renamed upstream directories at the verified revision

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - Updated catalogue entries for Contract Review and JurisRank CSJN Analysis to reference their latest locations and revisions.

- **Bug Fixes**
  - Improved upstream skill checks to confirm that required skill files exist at the latest revision.
  - Missing files are now reported clearly instead of being treated as successful updates.
  - Added comparison links and clearer statuses for unchanged, updated, or missing skills.

- **Tests**
  - Expanded coverage for repository paths, missing files, URL handling, and error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->