### PR TITLE
fix: make DOCX source exports Node-loadable

### DIFF
--- a/.changeset/docx-source-resolution.md
+++ b/.changeset/docx-source-resolution.md
@@ -1,0 +1,5 @@
+---
+"@stll/docx-utils": patch
+---
+
+Make the TypeScript source export directly loadable by Node and Vite SSR.

--- a/packages/docx-utils/src/index.ts
+++ b/packages/docx-utils/src/index.ts
@@ -1,13 +1,13 @@
-export { OOXML_NS, type OoxmlPrefix } from "./namespaces";
+export { OOXML_NS, type OoxmlPrefix } from "./namespaces.ts";
 export {
   DOCX_COMPRESSION,
   loadDocx,
   extractText,
   extractBinary,
   repackZip,
-} from "./zip";
+} from "./zip.ts";
 export {
   findNextRId,
   ensureContentType,
   ensureRelationship,
-} from "./relationships";
+} from "./relationships.ts";

--- a/packages/docx-utils/tsconfig.json
+++ b/packages/docx-utils/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "@stll/typescript-config/base.json",
   "compilerOptions": {
-    "rewriteRelativeImportExtensions": true,
     "lib": ["ESNext"],
     "module": "ESNext",
     "types": ["bun"]

--- a/packages/docx-utils/tsconfig.json
+++ b/packages/docx-utils/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "@stll/typescript-config/base.json",
   "compilerOptions": {
+    "rewriteRelativeImportExtensions": true,
     "lib": ["ESNext"],
     "module": "ESNext",
     "types": ["bun"]

--- a/packages/typescript-config/base.json
+++ b/packages/typescript-config/base.json
@@ -12,6 +12,7 @@
     "lib": ["ESNext"],
     "resolveJsonModule": true,
     "moduleDetection": "force",
+    "rewriteRelativeImportExtensions": true,
     "verbatimModuleSyntax": true,
     "noUncheckedSideEffectImports": true,
     "module": "Preserve",


### PR DESCRIPTION
## Summary

- use explicit TypeScript extensions for the package source export consumed by Node and Vite SSR
- rewrite those extensions to JavaScript when emitting the package build
- add the required patch changeset for `@stll/docx-utils`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved direct loading of the TypeScript source export in Node.js and Vite SSR environments.
  - Ensured local module imports resolve correctly when using the package source directly.

- **Chores**
  - Updated package release information to reflect the compatibility improvement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->