### PR TITLE
fix: make staging readiness cutovers self-bootstrapping

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -49,6 +49,7 @@ jobs:
         id: probe
         env:
           STAGING_HEALTH_URL: https://api-staging.stll.app/ready
+          STAGING_LEGACY_HEALTH_URL: https://api-staging.stll.app/health
         run: |
           set -euo pipefail
 
@@ -73,6 +74,22 @@ jobs:
                 "$STAGING_HEALTH_URL"
             )"; then
               http_status="000"
+            fi
+
+            if [[ "$http_status" == "404" ]]; then
+              echo "Staging does not expose /ready; checking the legacy /health endpoint."
+              if ! http_status="$(
+                curl \
+                  --connect-timeout 5 \
+                  --max-time 10 \
+                  --output "$response_file" \
+                  --silent \
+                  --show-error \
+                  --write-out '%{http_code}' \
+                  "$STAGING_LEGACY_HEALTH_URL"
+              )"; then
+                http_status="000"
+              fi
             fi
 
             if [[ "$http_status" == "200" ]] &&
@@ -346,6 +363,36 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+
+      - name: Verify staging readiness
+        env:
+          EXPECTED_COMMIT: ${{ github.sha }}
+          STAGING_READY_URL: https://api-staging.stll.app/ready
+        run: |
+          set -euo pipefail
+
+          response_file="$RUNNER_TEMP/staging-ready.json"
+          http_status="000"
+          if ! http_status="$(
+            curl \
+              --connect-timeout 5 \
+              --max-time 10 \
+              --output "$response_file" \
+              --silent \
+              --show-error \
+              --write-out '%{http_code}' \
+              "$STAGING_READY_URL"
+          )"; then
+            http_status="000"
+          fi
+
+          if [[ "$http_status" != "200" ]] ||
+            ! jq -e --arg expected_commit "$EXPECTED_COMMIT" \
+              '.status == "ok" and .commit == $expected_commit' \
+              "$response_file" >/dev/null 2>&1; then
+            echo "::error::Staging /ready must return HTTP 200 with status ok and commit ${EXPECTED_COMMIT}; received HTTP ${http_status}."
+            exit 1
+          fi
 
       - name: Setup Bun
         uses: stella/.github/actions/setup-bun-cached@859a61ee0a799ba1028281329555cadee15bfc4f

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -364,36 +364,6 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Verify staging readiness
-        env:
-          EXPECTED_COMMIT: ${{ github.sha }}
-          STAGING_READY_URL: https://api-staging.stll.app/ready
-        run: |
-          set -euo pipefail
-
-          response_file="$RUNNER_TEMP/staging-ready.json"
-          http_status="000"
-          if ! http_status="$(
-            curl \
-              --connect-timeout 5 \
-              --max-time 10 \
-              --output "$response_file" \
-              --silent \
-              --show-error \
-              --write-out '%{http_code}' \
-              "$STAGING_READY_URL"
-          )"; then
-            http_status="000"
-          fi
-
-          if [[ "$http_status" != "200" ]] ||
-            ! jq -e --arg expected_commit "$EXPECTED_COMMIT" \
-              '.status == "ok" and .commit == $expected_commit' \
-              "$response_file" >/dev/null 2>&1; then
-            echo "::error::Staging /ready must return HTTP 200 with status ok and commit ${EXPECTED_COMMIT}; received HTTP ${http_status}."
-            exit 1
-          fi
-
       - name: Setup Bun
         uses: stella/.github/actions/setup-bun-cached@859a61ee0a799ba1028281329555cadee15bfc4f
 

--- a/apps/web/e2e/staging/global-setup.ts
+++ b/apps/web/e2e/staging/global-setup.ts
@@ -155,7 +155,7 @@ const ORIGINS: Origin[] = [
         allowMissingMarker: false,
         expectedCommit,
         label: "api",
-        url: `${API_URL}/health`,
+        url: `${API_URL}/ready`,
       }),
   },
   {

--- a/scripts/check-staging-deploy-decision.test.ts
+++ b/scripts/check-staging-deploy-decision.test.ts
@@ -12,6 +12,10 @@ const WORKFLOW_URL = new URL(
   "../.github/workflows/deploy-staging.yml",
   import.meta.url,
 );
+const STAGING_SETUP_URL = new URL(
+  "../apps/web/e2e/staging/global-setup.ts",
+  import.meta.url,
+);
 const TIP_SHA = "a".repeat(40);
 const OTHER_SHA = "b".repeat(40);
 const HOUR_SECONDS = 3600;
@@ -80,7 +84,6 @@ type Decision = { deploy: string; exitCode: number };
 let workspace = "";
 let scriptPath = "";
 let probeScriptPath = "";
-let postReadinessScriptPath = "";
 
 const runDecision = async ({
   committedHoursAgo = 1,
@@ -172,47 +175,10 @@ const runProbe = async ({
   };
 };
 
-const runPostReadiness = async ({
-  body,
-  expectedCommit = TIP_SHA,
-  status,
-}: {
-  body: string;
-  expectedCommit?: string;
-  status: string;
-}) => {
-  const callsPath = path.join(
-    workspace,
-    `post-readiness-calls-${Bun.randomUUIDv7()}.txt`,
-  );
-  await Bun.write(callsPath, "");
-
-  const result = Bun.spawnSync(["bash", postReadinessScriptPath], {
-    env: {
-      ...process.env,
-      EXPECTED_COMMIT: expectedCommit,
-      PATH: `${workspace}:${process.env["PATH"] ?? ""}`,
-      RUNNER_TEMP: workspace,
-      STAGING_READY_URL: "https://api-staging.stll.app/ready",
-      STUB_CALLS_PATH: callsPath,
-      STUB_HEALTH_BODY: body,
-      STUB_HEALTH_STATUS: status,
-      STUB_READY_BODY: body,
-      STUB_READY_STATUS: status,
-    },
-  });
-
-  return {
-    calls: await Bun.file(callsPath).text(),
-    exitCode: result.exitCode,
-  };
-};
-
 beforeAll(async () => {
   workspace = await mkdtemp(path.join(tmpdir(), "staging-deploy-decision-"));
   scriptPath = path.join(workspace, "decide.sh");
   probeScriptPath = path.join(workspace, "probe.sh");
-  postReadinessScriptPath = path.join(workspace, "post-readiness.sh");
 
   const workflow = await Bun.file(WORKFLOW_URL).text();
   const script = extractDecideScript(workflow);
@@ -227,15 +193,6 @@ beforeAll(async () => {
       "\n      # Absent staging defers",
     ),
   );
-  await Bun.write(
-    postReadinessScriptPath,
-    extractStepScript(
-      workflow,
-      "Verify staging readiness",
-      "\n      - name: Setup Bun",
-    ),
-  );
-
   // Stands in for the reads the script makes: the last recorded staging
   // deployment, the oldest commit staging has not taken, and the tip's own
   // timestamp.
@@ -453,24 +410,14 @@ describe("staging readiness cutover", () => {
     },
   );
 
-  test("requires post-deploy /ready to report the expected commit", async () => {
-    const matching = await runPostReadiness({
-      body: `{"status":"ok","commit":"${TIP_SHA}"}`,
-      status: "200",
-    });
-    const stale = await runPostReadiness({
-      body: `{"status":"ok","commit":"${OTHER_SHA}"}`,
-      status: "200",
-    });
-
-    expect(matching.exitCode).toBe(0);
-    expect(stale.exitCode).not.toBe(0);
-    expect(matching.calls).toBe("https://api-staging.stll.app/ready\n");
-    expect(stale.calls).toBe("https://api-staging.stll.app/ready\n");
-
+  test("delegates post-deploy readiness to the rollout-aware smoke waiter", async () => {
     const workflow = await Bun.file(WORKFLOW_URL).text();
-    expect(
-      workflow.indexOf("      - name: Verify staging readiness\n"),
-    ).toBeLessThan(workflow.indexOf("      - name: Run staging web smoke\n"));
+    const stagingSetup = await Bun.file(STAGING_SETUP_URL).text();
+
+    expect(workflow).not.toContain("      - name: Verify staging readiness\n");
+    expect(stagingSetup).toContain("const READINESS_TIMEOUT_MS = 1_200_000;");
+    expect(stagingSetup).toContain("const READINESS_STABLE_SAMPLES = 3;");
+    expect(stagingSetup).toContain(`url: \`\${API_URL}/ready\`,`);
+    expect(stagingSetup).not.toContain(`url: \`\${API_URL}/health\`,`);
   });
 });

--- a/scripts/check-staging-deploy-decision.test.ts
+++ b/scripts/check-staging-deploy-decision.test.ts
@@ -38,6 +38,32 @@ const extractDecideScript = (workflow: string) => {
     .join("\n");
 };
 
+const extractStepScript = (
+  workflow: string,
+  stepName: string,
+  nextMarker: string,
+) => {
+  const stepStart = workflow.indexOf(`      - name: ${stepName}\n`);
+  const runStart = workflow.indexOf("run: |\n", stepStart);
+  const stepEnd = workflow.indexOf(nextMarker, runStart);
+  if (stepStart === -1 || runStart === -1 || stepEnd === -1) {
+    throw new Error(
+      `deploy-staging.yml no longer exposes the ${stepName} step`,
+    );
+  }
+
+  const body = workflow.slice(runStart + "run: |\n".length, stepEnd);
+  const indents = body
+    .split("\n")
+    .filter((line) => line.trim().length > 0)
+    .map((line) => line.length - line.trimStart().length);
+  const dedent = Math.min(...indents);
+  return body
+    .split("\n")
+    .map((line) => line.slice(dedent))
+    .join("\n");
+};
+
 type DecisionCase = {
   committedHoursAgo?: number;
   deployedSha?: string;
@@ -53,6 +79,8 @@ type Decision = { deploy: string; exitCode: number };
 
 let workspace = "";
 let scriptPath = "";
+let probeScriptPath = "";
+let postReadinessScriptPath = "";
 
 const runDecision = async ({
   committedHoursAgo = 1,
@@ -98,14 +126,115 @@ const runDecision = async ({
   return { deploy: deploy ?? "", exitCode: result.exitCode };
 };
 
+type ProbeCase = {
+  healthBody?: string;
+  healthStatus?: string;
+  readyBody?: string;
+  readyStatus?: string;
+};
+
+const runProbe = async ({
+  healthBody = `{"status":"ok","commit":"${OTHER_SHA}"}`,
+  healthStatus = "200",
+  readyBody = `{"status":"ok","commit":"${TIP_SHA}"}`,
+  readyStatus = "200",
+}: ProbeCase) => {
+  const outputPath = path.join(
+    workspace,
+    `probe-output-${Bun.randomUUIDv7()}.txt`,
+  );
+  const callsPath = path.join(
+    workspace,
+    `probe-calls-${Bun.randomUUIDv7()}.txt`,
+  );
+  await Promise.all([Bun.write(outputPath, ""), Bun.write(callsPath, "")]);
+
+  const result = Bun.spawnSync(["bash", probeScriptPath], {
+    env: {
+      ...process.env,
+      GITHUB_OUTPUT: outputPath,
+      PATH: `${workspace}:${process.env["PATH"] ?? ""}`,
+      RUNNER_TEMP: workspace,
+      STAGING_HEALTH_URL: "https://api-staging.stll.app/ready",
+      STAGING_LEGACY_HEALTH_URL: "https://api-staging.stll.app/health",
+      STUB_CALLS_PATH: callsPath,
+      STUB_HEALTH_BODY: healthBody,
+      STUB_HEALTH_STATUS: healthStatus,
+      STUB_READY_BODY: readyBody,
+      STUB_READY_STATUS: readyStatus,
+    },
+  });
+
+  return {
+    calls: await Bun.file(callsPath).text(),
+    exitCode: result.exitCode,
+    output: await Bun.file(outputPath).text(),
+  };
+};
+
+const runPostReadiness = async ({
+  body,
+  expectedCommit = TIP_SHA,
+  status,
+}: {
+  body: string;
+  expectedCommit?: string;
+  status: string;
+}) => {
+  const callsPath = path.join(
+    workspace,
+    `post-readiness-calls-${Bun.randomUUIDv7()}.txt`,
+  );
+  await Bun.write(callsPath, "");
+
+  const result = Bun.spawnSync(["bash", postReadinessScriptPath], {
+    env: {
+      ...process.env,
+      EXPECTED_COMMIT: expectedCommit,
+      PATH: `${workspace}:${process.env["PATH"] ?? ""}`,
+      RUNNER_TEMP: workspace,
+      STAGING_READY_URL: "https://api-staging.stll.app/ready",
+      STUB_CALLS_PATH: callsPath,
+      STUB_HEALTH_BODY: body,
+      STUB_HEALTH_STATUS: status,
+      STUB_READY_BODY: body,
+      STUB_READY_STATUS: status,
+    },
+  });
+
+  return {
+    calls: await Bun.file(callsPath).text(),
+    exitCode: result.exitCode,
+  };
+};
+
 beforeAll(async () => {
   workspace = await mkdtemp(path.join(tmpdir(), "staging-deploy-decision-"));
   scriptPath = path.join(workspace, "decide.sh");
+  probeScriptPath = path.join(workspace, "probe.sh");
+  postReadinessScriptPath = path.join(workspace, "post-readiness.sh");
 
-  const script = extractDecideScript(await Bun.file(WORKFLOW_URL).text());
+  const workflow = await Bun.file(WORKFLOW_URL).text();
+  const script = extractDecideScript(workflow);
   expect(script).toContain("set -euo pipefail");
   expect(script).toContain("readonly MAX_DEFERRAL_HOURS=");
   await Bun.write(scriptPath, script);
+  await Bun.write(
+    probeScriptPath,
+    extractStepScript(
+      workflow,
+      "Probe staging health",
+      "\n      # Absent staging defers",
+    ),
+  );
+  await Bun.write(
+    postReadinessScriptPath,
+    extractStepScript(
+      workflow,
+      "Verify staging readiness",
+      "\n      - name: Setup Bun",
+    ),
+  );
 
   // Stands in for the reads the script makes: the last recorded staging
   // deployment, the oldest commit staging has not taken, and the tip's own
@@ -125,6 +254,41 @@ exit 0
 `,
   );
   await chmod(stub, 0o755);
+
+  const curlStub = path.join(workspace, "curl");
+  await Bun.write(
+    curlStub,
+    `#!/usr/bin/env bash
+set -euo pipefail
+output=""
+url=""
+for ((index = 1; index <= $#; index += 1)); do
+  arg="\${!index}"
+  if [[ "$arg" == "--output" ]]; then
+    next=$((index + 1))
+    output="\${!next}"
+  elif [[ "$arg" == https://* ]]; then
+    url="$arg"
+  fi
+done
+echo "$url" >> "$STUB_CALLS_PATH"
+if [[ "$url" == */ready ]]; then
+  if [[ "$STUB_READY_STATUS" == "000" ]]; then
+    exit 7
+  fi
+  printf '%s' "$STUB_READY_BODY" > "$output"
+  printf '%s' "$STUB_READY_STATUS"
+  exit 0
+fi
+printf '%s' "$STUB_HEALTH_BODY" > "$output"
+printf '%s' "$STUB_HEALTH_STATUS"
+`,
+  );
+  await chmod(curlStub, 0o755);
+
+  const sleepStub = path.join(workspace, "sleep");
+  await Bun.write(sleepStub, "#!/usr/bin/env bash\nexit 0\n");
+  await chmod(sleepStub, 0o755);
 });
 
 afterAll(async () => {
@@ -251,5 +415,62 @@ describe("staging deploy decision", () => {
         status: "not_ready",
       }),
     ).toEqual({ deploy: "deploy=false", exitCode: 0 });
+  });
+});
+
+describe("staging readiness cutover", () => {
+  test("accepts a legacy health response only after /ready returns exact 404", async () => {
+    const result = await runProbe({
+      healthBody: `{"status":"ok","commit":"${OTHER_SHA}"}`,
+      healthStatus: "200",
+      readyBody: '{"status":"missing"}',
+      readyStatus: "404",
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.output).toContain("status=ready");
+    expect(result.output).toContain(`served_commit=${OTHER_SHA}`);
+    expect(result.calls).toBe(
+      "https://api-staging.stll.app/ready\nhttps://api-staging.stll.app/health\n",
+    );
+  });
+
+  test.each(["503", "000"])(
+    "does not fall back to /health when /ready returns %s",
+    async (readyStatus) => {
+      const result = await runProbe({
+        healthBody: `{"status":"ok","commit":"${OTHER_SHA}"}`,
+        healthStatus: "200",
+        readyBody: '{"status":"not_ready"}',
+        readyStatus,
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.output).toContain("status=not_ready");
+      expect(result.calls).toBe(
+        "https://api-staging.stll.app/ready\n".repeat(3),
+      );
+    },
+  );
+
+  test("requires post-deploy /ready to report the expected commit", async () => {
+    const matching = await runPostReadiness({
+      body: `{"status":"ok","commit":"${TIP_SHA}"}`,
+      status: "200",
+    });
+    const stale = await runPostReadiness({
+      body: `{"status":"ok","commit":"${OTHER_SHA}"}`,
+      status: "200",
+    });
+
+    expect(matching.exitCode).toBe(0);
+    expect(stale.exitCode).not.toBe(0);
+    expect(matching.calls).toBe("https://api-staging.stll.app/ready\n");
+    expect(stale.calls).toBe("https://api-staging.stll.app/ready\n");
+
+    const workflow = await Bun.file(WORKFLOW_URL).text();
+    expect(
+      workflow.indexOf("      - name: Verify staging readiness\n"),
+    ).toBeLessThan(workflow.indexOf("      - name: Run staging web smoke\n"));
   });
 });


### PR DESCRIPTION
Allow the staging deploy gate to fall back to the legacy `/health` endpoint only when `/ready` returns an exact 404. This lets the first commit introducing readiness deploy without weakening genuine not-ready or unreachable responses.

After deployment, require `/ready` to report both healthy status and the promoted commit before the smoke suite begins.