### PR TITLE
fix(case-law): drain pending corpus projections under a running generation

### DIFF
--- a/apps/api/src/handlers/case-law/CLAUDE.md
+++ b/apps/api/src/handlers/case-law/CLAUDE.md
@@ -461,6 +461,22 @@ the exact allowed origins in the adapter and reject everything else before any
 request. Redirect handling needs the same boundary; a trusted start URL is not
 enough if the client can follow it to an arbitrary origin.
 
+### 22. Live indexing must never wait on a rebuild
+
+A queue that only drains when some other walk completes inherits every
+failure mode of that walk: a generation rebuild wedged at `running`
+(spinning cursor, failing page, leaked lease, abandoned checkpoint)
+silently stopped indexing every newly ingested decision. The corpus-index
+pending queue therefore drains on every generation invocation — under
+`running`, before the snapshot walk — so a wedged walk degrades to "rebuild
+stalled", never "nothing new is searchable".
+
+Keep that shape for any new projection or index queue: give it a drain
+path that does not depend on a bounded rebuild reaching its end, and
+classify the driving loop's no-progress outcomes (busy, failed) into
+sustained-stall telemetry. A loop that only logs its successes makes a
+leaked lease indistinguishable from an idle system.
+
 ## DocumentAst Conventions
 
 ```typescript

--- a/apps/api/src/handlers/case-law/corpus-index-generation-backfill.db.test.ts
+++ b/apps/api/src/handlers/case-law/corpus-index-generation-backfill.db.test.ts
@@ -1141,8 +1141,10 @@ test(
     });
     const completing = backfill(scopedDb, 100, generation);
     await reconciliationStartedPromise;
+    // The pending drain now runs under the running lease, before the walk
+    // observes its drained snapshot and completes.
     expect(await readCheckpoint(generation)).toMatchObject({
-      status: "complete",
+      status: "running",
     });
     expect((await readCheckpoint(generation))?.leaseToken).not.toBeNull();
     expect(await backfill(scopedDb, 100, generation)).toEqual({
@@ -2579,6 +2581,80 @@ test(
         .delete(caseLawCorpusIndexBackfills)
         .where(eq(caseLawCorpusIndexBackfills.generation, generation));
       await db.delete(caseLawSources).where(eq(caseLawSources.id, sourceId));
+    }
+  },
+  { timeout: 30_000 },
+);
+
+test(
+  "drains pending projections while the generation is still running",
+  async () => {
+    // The wedge this guards: with the drain tied to a completed walk, a
+    // generation stuck at `running` silently stopped indexing every newly
+    // ingested decision. The pending queue must drain on the same invocation
+    // that advances the walk, before the walk, and without completing it.
+    const generation = "case_law_v64";
+    await db.insert(caseLawCorpusIndexBackfills).values({
+      generation,
+      snapshotAt: await nextBackfillSnapshotAt(),
+      status: "running",
+    });
+    await db.insert(caseLawCorpusIndexProjections).values({
+      decisionId: publicLastId,
+      generation,
+      pendingAction: "index",
+      pendingHash: "last",
+      pendingIndexIds: [corpusIndexId(generation, "CZE")],
+    });
+
+    const sent: SafeId<"caseLawDecision">[][] = [];
+    const backfill = createCaseLawGenerationBackfill({
+      backfillRows: async (runnerDb, rows, rebuildGeneration, options) => {
+        await options.beforeRemoteEffect({
+          effect: completeRemoteEffect,
+          onLeaseLost: noRemoteEffectCompensation,
+        });
+        sent.push(rows.map((row) => row.id));
+        await runnerDb(async (tx) => {
+          await options.beforeDatabaseMark(tx);
+          await tx
+            .delete(caseLawCorpusIndexProjections)
+            .where(
+              eq(caseLawCorpusIndexProjections.generation, rebuildGeneration),
+            );
+        });
+        return rows.length;
+      },
+      newLeaseToken: () => "00000000-0000-4000-8000-000000000640",
+      removeProjection: ignoreProjectionRemoval,
+    });
+
+    try {
+      // batchSize 1 leaves the walk pages away from its snapshot end, so the
+      // generation stays running; the queued row must index anyway, first.
+      expect(await backfill(scopedDb, 1, generation)).toEqual({
+        indexed: 2,
+        status: "advanced",
+      });
+      expect(sent.at(0)).toEqual([publicLastId]);
+      expect(await readCheckpoint(generation)).toMatchObject({
+        leaseExpiresAt: null,
+        leaseToken: null,
+        status: "running",
+      });
+      expect(
+        await db
+          .select()
+          .from(caseLawCorpusIndexProjections)
+          .where(eq(caseLawCorpusIndexProjections.generation, generation)),
+      ).toHaveLength(0);
+    } finally {
+      await db
+        .delete(caseLawCorpusIndexProjections)
+        .where(eq(caseLawCorpusIndexProjections.generation, generation));
+      await db
+        .delete(caseLawCorpusIndexBackfills)
+        .where(eq(caseLawCorpusIndexBackfills.generation, generation));
     }
   },
   { timeout: 30_000 },

--- a/apps/api/src/handlers/case-law/corpus-index.ts
+++ b/apps/api/src/handlers/case-law/corpus-index.ts
@@ -1851,6 +1851,66 @@ export const createCaseLawGenerationBackfill =
         effect: completeRemoteEffect,
         onLeaseLost: async () => await Promise.resolve(),
       });
+
+      const releaseRunningLease = async (): Promise<void> => {
+        await scopedDb(async (tx) => {
+          // audit: skip — releasing a failed lease preserves the durable cursor for replay
+          await tx
+            .update(caseLawCorpusIndexBackfills)
+            .set({ leaseExpiresAt: null, leaseToken: null })
+            .where(
+              and(
+                eq(caseLawCorpusIndexBackfills.generation, generation),
+                ownsUnexpiredLease({
+                  checkpoint: claimedCheckpoint,
+                  leaseToken,
+                  status: CASE_LAW_CORPUS_INDEX_BACKFILL_STATUS.RUNNING,
+                }),
+              ),
+            );
+        });
+      };
+
+      // Drain the pending queue before walking the snapshot. Pending
+      // projections are live decision traffic; the walk is a bounded rebuild
+      // of pre-snapshot rows, and a generation can sit at `running` for a long
+      // time (or forever, when its walk is wedged). Draining under RUNNING
+      // keeps newly ingested decisions searchable regardless of walk state,
+      // and draining first means a row that wedges the walk cannot also wedge
+      // live indexing. The pending_revision epoch converges these appends with
+      // walk pages that later reach the same rows.
+      let drainedIndexed = 0;
+      try {
+        const drained = await reconcilePending({
+          checkpoint: claimedCheckpoint,
+          leaseToken,
+          status: CASE_LAW_CORPUS_INDEX_BACKFILL_STATUS.RUNNING,
+        });
+        if (drained.status === BACKFILL_STATUS.BUSY) {
+          await releaseRunningLease();
+          return drained;
+        }
+        drainedIndexed = drained.indexed;
+      } catch (error) {
+        await releaseRunningLease();
+        throw error;
+      }
+      // Reports this invocation's total durable movement: rows the drain
+      // indexed count as ADVANCED even when the walk itself could not.
+      const withDrained = (
+        result: CorpusIndexBackfillResult,
+      ): CorpusIndexBackfillResult => {
+        if (drainedIndexed === 0) {
+          return result;
+        }
+        return result.status === BACKFILL_STATUS.ADVANCED
+          ? {
+              indexed: result.indexed + drainedIndexed,
+              status: BACKFILL_STATUS.ADVANCED,
+            }
+          : { indexed: drainedIndexed, status: BACKFILL_STATUS.ADVANCED };
+      };
+
       const page = await selectGenerationBackfillPage(scopedDb, {
         batchSize,
         checkpoint: claimedCheckpoint,
@@ -1878,7 +1938,7 @@ export const createCaseLawGenerationBackfill =
           return rows.at(0);
         });
         if (!completed) {
-          return { indexed: 0, status: BACKFILL_STATUS.BUSY };
+          return withDrained({ indexed: 0, status: BACKFILL_STATUS.BUSY });
         }
         const completedCheckpoint: GenerationBackfillCheckpoint = {
           cursorCreatedAt: completed.cursorCreatedAt,
@@ -1888,11 +1948,13 @@ export const createCaseLawGenerationBackfill =
           snapshotAt: completed.snapshotAt,
         };
         try {
-          return await reconcilePending({
-            checkpoint: completedCheckpoint,
-            leaseToken,
-            status: CASE_LAW_CORPUS_INDEX_BACKFILL_STATUS.COMPLETE,
-          });
+          return withDrained(
+            await reconcilePending({
+              checkpoint: completedCheckpoint,
+              leaseToken,
+              status: CASE_LAW_CORPUS_INDEX_BACKFILL_STATUS.COMPLETE,
+            }),
+          );
         } finally {
           await releaseLease({
             leaseToken,
@@ -1911,7 +1973,12 @@ export const createCaseLawGenerationBackfill =
       );
       let indexed: number;
       try {
-        indexed = await backfillRows(scopedDb, rows, generation, runningGuards);
+        // The drain above may have brought every row on this page current, so
+        // skip the indexer rather than hand it an empty batch.
+        indexed =
+          rows.length === 0
+            ? 0
+            : await backfillRows(scopedDb, rows, generation, runningGuards);
         if (indexed !== rows.length) {
           throw new CorpusIndexError({
             message: "generation backfill page did not reach a fixed point",
@@ -1929,23 +1996,7 @@ export const createCaseLawGenerationBackfill =
       } catch (error) {
         // Keep the cursor intact, but do not make a transient search/S3 failure
         // wait for a stale lease before its durable retry.
-        await scopedDb(async (tx) => {
-          // audit: skip — releasing a failed lease preserves the durable cursor for replay
-          const released = await tx
-            .update(caseLawCorpusIndexBackfills)
-            .set({ leaseExpiresAt: null, leaseToken: null })
-            .where(
-              and(
-                eq(caseLawCorpusIndexBackfills.generation, generation),
-                ownsUnexpiredLease({
-                  checkpoint: claimedCheckpoint,
-                  leaseToken,
-                  status: CASE_LAW_CORPUS_INDEX_BACKFILL_STATUS.RUNNING,
-                }),
-              ),
-            );
-          return released;
-        });
+        await releaseRunningLease();
         throw error;
       }
 
@@ -1972,9 +2023,11 @@ export const createCaseLawGenerationBackfill =
           .returning({ generation: caseLawCorpusIndexBackfills.generation });
         return advancedRows.at(0);
       });
-      return advanced
-        ? { indexed, status: BACKFILL_STATUS.ADVANCED }
-        : { indexed: 0, status: BACKFILL_STATUS.BUSY };
+      return withDrained(
+        advanced
+          ? { indexed, status: BACKFILL_STATUS.ADVANCED }
+          : { indexed: 0, status: BACKFILL_STATUS.BUSY },
+      );
     } finally {
       await writerLease.release();
     }

--- a/apps/api/src/handlers/case-law/corpus-index.ts
+++ b/apps/api/src/handlers/case-law/corpus-index.ts
@@ -1668,6 +1668,18 @@ export const createCaseLawGenerationBackfill =
             : { indexed: 0, status: BACKFILL_STATUS.BUSY };
         }
 
+        return await reconcilePendingPage(guards);
+      };
+
+      // The pending queue is the live path: every newly ingested decision
+      // waits here, so it must be drainable on its own, without the
+      // source-first composition reconcilePending applies after a completed
+      // walk. A queued source repair can span the whole corpus of a source;
+      // routing the live drain behind it would recreate the wedge this
+      // ordering exists to prevent.
+      const reconcilePendingPage = async (
+        guards: ReturnType<typeof createLeaseGuards>,
+      ): Promise<CorpusIndexBackfillResult> => {
         const pendingPage = await selectGenerationPendingPage(scopedDb, {
           generation,
           limit: batchSize,
@@ -1753,6 +1765,27 @@ export const createCaseLawGenerationBackfill =
           ...terminalDeletes,
         ]);
         return { indexed, status: BACKFILL_STATUS.ADVANCED };
+      };
+
+      // Pending projections only: the running-arm drain. Source-eligibility
+      // revisions stay gated on a completed walk (their replay is
+      // authoritative over anything indexed here, so draining pending rows
+      // first cannot break that convergence).
+      const drainPendingProjections = async ({
+        checkpoint: ownedCheckpoint,
+        leaseToken,
+        status,
+      }: LeaseGuardOptions): Promise<CorpusIndexBackfillResult> => {
+        const guards = createLeaseGuards({
+          checkpoint: ownedCheckpoint,
+          leaseToken,
+          status,
+        });
+        await guards.beforeRemoteEffect({
+          effect: completeRemoteEffect,
+          onLeaseLost: async () => await Promise.resolve(),
+        });
+        return await reconcilePendingPage(guards);
       };
 
       if (
@@ -1881,7 +1914,7 @@ export const createCaseLawGenerationBackfill =
       // walk pages that later reach the same rows.
       let drainedIndexed = 0;
       try {
-        const drained = await reconcilePending({
+        const drained = await drainPendingProjections({
           checkpoint: claimedCheckpoint,
           leaseToken,
           status: CASE_LAW_CORPUS_INDEX_BACKFILL_STATUS.RUNNING,

--- a/apps/legal-atlas-runner/src/runners/case-law-ingest.ts
+++ b/apps/legal-atlas-runner/src/runners/case-law-ingest.ts
@@ -62,6 +62,7 @@ import {
   type CorpusIndexStepKind,
   type CorpusIndexStreaks,
   INITIAL_CORPUS_INDEX_STREAKS,
+  corpusIndexStallThreshold,
   stepCorpusIndexProgress,
 } from "./corpus-index-progress";
 import {
@@ -1181,8 +1182,13 @@ export const runCaseLawIngest = async (
     // A leaked lease (every step BUSY) and a failing backend (every step
     // throws) both look like idle silence in this loop unless counted.
     let corpusStreaks: CorpusIndexStreaks = INITIAL_CORPUS_INDEX_STREAKS;
+    const stallThreshold = corpusIndexStallThreshold(CORPUS_INDEX_INTERVAL_MS);
     const foldCorpusStep = (kind: CorpusIndexStepKind): void => {
-      const step = stepCorpusIndexProgress(corpusStreaks, kind);
+      const step = stepCorpusIndexProgress({
+        kind,
+        streaks: corpusStreaks,
+        threshold: stallThreshold,
+      });
       corpusStreaks = step.streaks;
       if (!step.stall) {
         return;

--- a/apps/legal-atlas-runner/src/runners/case-law-ingest.ts
+++ b/apps/legal-atlas-runner/src/runners/case-law-ingest.ts
@@ -27,7 +27,10 @@ import {
   tryRecomputeCitationAuthorityForAll,
 } from "@/api/handlers/case-law/citation-authority";
 import { ADAPTER_KEYS, MAX_CYCLE_MS } from "@/api/handlers/case-law/consts";
-import { backfillCorpusIndex } from "@/api/handlers/case-law/corpus-index";
+import {
+  BACKFILL_STATUS,
+  backfillCorpusIndex,
+} from "@/api/handlers/case-law/corpus-index";
 import { getAdapter } from "@/api/handlers/case-law/ingestion/adapters/adapter-registry";
 import { runIngestionPipeline } from "@/api/handlers/case-law/ingestion/pipeline";
 import { backfillLegislationCorpusIndex } from "@/api/handlers/legislation/corpus-index";
@@ -54,6 +57,13 @@ import {
   loadCourtWeightEntries,
 } from "../db";
 import { LEGAL_ATLAS_RUNNER_ENV } from "../env";
+import {
+  CORPUS_INDEX_STEP,
+  type CorpusIndexStepKind,
+  type CorpusIndexStreaks,
+  INITIAL_CORPUS_INDEX_STREAKS,
+  stepCorpusIndexProgress,
+} from "./corpus-index-progress";
 import {
   CYCLE_CADENCE,
   CYCLE_CADENCE_DELAY_MS,
@@ -1168,6 +1178,22 @@ export const runCaseLawIngest = async (
     }
     const generation = envBase.LEGAL_SEARCH_INDEX_GENERATION;
     logInfo(`[corpus-index] Enabled for generation ${generation}`);
+    // A leaked lease (every step BUSY) and a failing backend (every step
+    // throws) both look like idle silence in this loop unless counted.
+    let corpusStreaks: CorpusIndexStreaks = INITIAL_CORPUS_INDEX_STREAKS;
+    const foldCorpusStep = (kind: CorpusIndexStepKind): void => {
+      const step = stepCorpusIndexProgress(corpusStreaks, kind);
+      corpusStreaks = step.streaks;
+      if (!step.stall) {
+        return;
+      }
+      logger.error(
+        step.stall.kind === "sustained_busy"
+          ? "case_law.corpus_index.sustained_busy"
+          : "case_law.corpus_index.sustained_failure",
+        { generation, steps: step.stall.steps },
+      );
+    };
     while (true) {
       if (isDraining()) {
         return;
@@ -1193,7 +1219,23 @@ export const runCaseLawIngest = async (
         if (result.indexed > 0) {
           logInfo(`[corpus-index] Indexed ${result.indexed} decisions`);
         }
+        switch (result.status) {
+          case BACKFILL_STATUS.ADVANCED:
+            foldCorpusStep(CORPUS_INDEX_STEP.ADVANCED);
+            break;
+          case BACKFILL_STATUS.BUSY:
+            foldCorpusStep(CORPUS_INDEX_STEP.BUSY);
+            break;
+          case BACKFILL_STATUS.COMPLETE:
+            foldCorpusStep(CORPUS_INDEX_STEP.COMPLETE);
+            break;
+          default: {
+            const unhandled: never = result;
+            panic(`Unhandled corpus index result: ${String(unhandled)}`);
+          }
+        }
       } catch (error) {
+        foldCorpusStep(CORPUS_INDEX_STEP.FAILED);
         const msg = error instanceof Error ? error.message : String(error);
         if (isTransientConnectionError(error)) {
           logError(`[corpus-index] DB connection error (will retry): ${msg}`);

--- a/apps/legal-atlas-runner/src/runners/corpus-index-progress.test.ts
+++ b/apps/legal-atlas-runner/src/runners/corpus-index-progress.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  CORPUS_INDEX_STALL_THRESHOLD,
+  CORPUS_INDEX_STEP,
+  type CorpusIndexStepKind,
+  type CorpusIndexStreaks,
+  INITIAL_CORPUS_INDEX_STREAKS,
+  stepCorpusIndexProgress,
+} from "./corpus-index-progress";
+
+/** Fold a whole step sequence, collecting every reported stall. */
+const foldSequence = (kinds: readonly CorpusIndexStepKind[]) => {
+  let streaks: CorpusIndexStreaks = INITIAL_CORPUS_INDEX_STREAKS;
+  const stalls: NonNullable<
+    ReturnType<typeof stepCorpusIndexProgress>["stall"]
+  >[] = [];
+  for (const kind of kinds) {
+    const step = stepCorpusIndexProgress(streaks, kind);
+    streaks = step.streaks;
+    if (step.stall) {
+      stalls.push(step.stall);
+    }
+  }
+  return { stalls, streaks };
+};
+
+const repeat = (kind: CorpusIndexStepKind, count: number) =>
+  Array.from({ length: count }, () => kind);
+
+describe("stepCorpusIndexProgress", () => {
+  test("a streak one short of the threshold reports nothing", () => {
+    for (const kind of [CORPUS_INDEX_STEP.BUSY, CORPUS_INDEX_STEP.FAILED]) {
+      const { stalls } = foldSequence(
+        repeat(kind, CORPUS_INDEX_STALL_THRESHOLD - 1),
+      );
+      expect(stalls).toEqual([]);
+    }
+  });
+
+  test("a sustained condition reports once per threshold-run, not per step", () => {
+    const { stalls } = foldSequence(
+      repeat(CORPUS_INDEX_STEP.BUSY, CORPUS_INDEX_STALL_THRESHOLD * 3),
+    );
+    expect(stalls).toEqual([
+      { kind: "sustained_busy", steps: CORPUS_INDEX_STALL_THRESHOLD },
+      { kind: "sustained_busy", steps: CORPUS_INDEX_STALL_THRESHOLD },
+      { kind: "sustained_busy", steps: CORPUS_INDEX_STALL_THRESHOLD },
+    ]);
+  });
+
+  test("failure maps to sustained_failure", () => {
+    const { stalls } = foldSequence(
+      repeat(CORPUS_INDEX_STEP.FAILED, CORPUS_INDEX_STALL_THRESHOLD),
+    );
+    expect(stalls).toEqual([
+      { kind: "sustained_failure", steps: CORPUS_INDEX_STALL_THRESHOLD },
+    ]);
+  });
+
+  test("any live step clears both streaks", () => {
+    for (const liveKind of [
+      CORPUS_INDEX_STEP.ADVANCED,
+      CORPUS_INDEX_STEP.COMPLETE,
+    ]) {
+      const nearStall = [
+        ...repeat(CORPUS_INDEX_STEP.BUSY, CORPUS_INDEX_STALL_THRESHOLD - 1),
+        ...repeat(CORPUS_INDEX_STEP.FAILED, CORPUS_INDEX_STALL_THRESHOLD - 1),
+        liveKind,
+      ];
+      const { streaks, stalls } = foldSequence(nearStall);
+      expect(stalls).toEqual([]);
+      expect(streaks).toEqual(INITIAL_CORPUS_INDEX_STREAKS);
+    }
+  });
+
+  test("busy and failed do not reset each other", () => {
+    // A wedge alternating between a leaked lease and a failing backend must
+    // still cross a threshold; interleave the two so neither run is ever
+    // consecutive, and expect both to report.
+    const alternating = Array.from(
+      { length: CORPUS_INDEX_STALL_THRESHOLD * 2 },
+      (_, index) =>
+        index % 2 === 0 ? CORPUS_INDEX_STEP.BUSY : CORPUS_INDEX_STEP.FAILED,
+    );
+    const { stalls } = foldSequence(alternating);
+    expect(stalls).toEqual([
+      { kind: "sustained_busy", steps: CORPUS_INDEX_STALL_THRESHOLD },
+      { kind: "sustained_failure", steps: CORPUS_INDEX_STALL_THRESHOLD },
+    ]);
+  });
+});

--- a/apps/legal-atlas-runner/src/runners/corpus-index-progress.test.ts
+++ b/apps/legal-atlas-runner/src/runners/corpus-index-progress.test.ts
@@ -1,13 +1,16 @@
 import { describe, expect, test } from "bun:test";
 
 import {
-  CORPUS_INDEX_STALL_THRESHOLD,
+  CORPUS_INDEX_STALL_WINDOW_MS,
   CORPUS_INDEX_STEP,
   type CorpusIndexStepKind,
   type CorpusIndexStreaks,
   INITIAL_CORPUS_INDEX_STREAKS,
+  corpusIndexStallThreshold,
   stepCorpusIndexProgress,
 } from "./corpus-index-progress";
+
+const THRESHOLD = 4;
 
 /** Fold a whole step sequence, collecting every reported stall. */
 const foldSequence = (kinds: readonly CorpusIndexStepKind[]) => {
@@ -16,7 +19,11 @@ const foldSequence = (kinds: readonly CorpusIndexStepKind[]) => {
     ReturnType<typeof stepCorpusIndexProgress>["stall"]
   >[] = [];
   for (const kind of kinds) {
-    const step = stepCorpusIndexProgress(streaks, kind);
+    const step = stepCorpusIndexProgress({
+      kind,
+      streaks,
+      threshold: THRESHOLD,
+    });
     streaks = step.streaks;
     if (step.stall) {
       stalls.push(step.stall);
@@ -28,34 +35,48 @@ const foldSequence = (kinds: readonly CorpusIndexStepKind[]) => {
 const repeat = (kind: CorpusIndexStepKind, count: number) =>
   Array.from({ length: count }, () => kind);
 
+describe("corpusIndexStallThreshold", () => {
+  test("expresses the stall window in steps of the configured interval", () => {
+    expect(corpusIndexStallThreshold(15_000)).toBe(
+      CORPUS_INDEX_STALL_WINDOW_MS / 15_000,
+    );
+    // The fastest supported interval must not report within seconds.
+    expect(corpusIndexStallThreshold(250) * 250).toBeGreaterThanOrEqual(
+      CORPUS_INDEX_STALL_WINDOW_MS,
+    );
+  });
+
+  test("never lets a single step report, even past the window", () => {
+    for (const intervalMs of [CORPUS_INDEX_STALL_WINDOW_MS, 600_000]) {
+      expect(corpusIndexStallThreshold(intervalMs)).toBe(2);
+    }
+  });
+});
+
 describe("stepCorpusIndexProgress", () => {
   test("a streak one short of the threshold reports nothing", () => {
     for (const kind of [CORPUS_INDEX_STEP.BUSY, CORPUS_INDEX_STEP.FAILED]) {
-      const { stalls } = foldSequence(
-        repeat(kind, CORPUS_INDEX_STALL_THRESHOLD - 1),
-      );
+      const { stalls } = foldSequence(repeat(kind, THRESHOLD - 1));
       expect(stalls).toEqual([]);
     }
   });
 
   test("a sustained condition reports once per threshold-run, not per step", () => {
     const { stalls } = foldSequence(
-      repeat(CORPUS_INDEX_STEP.BUSY, CORPUS_INDEX_STALL_THRESHOLD * 3),
+      repeat(CORPUS_INDEX_STEP.BUSY, THRESHOLD * 3),
     );
     expect(stalls).toEqual([
-      { kind: "sustained_busy", steps: CORPUS_INDEX_STALL_THRESHOLD },
-      { kind: "sustained_busy", steps: CORPUS_INDEX_STALL_THRESHOLD },
-      { kind: "sustained_busy", steps: CORPUS_INDEX_STALL_THRESHOLD },
+      { kind: "sustained_busy", steps: THRESHOLD },
+      { kind: "sustained_busy", steps: THRESHOLD },
+      { kind: "sustained_busy", steps: THRESHOLD },
     ]);
   });
 
   test("failure maps to sustained_failure", () => {
     const { stalls } = foldSequence(
-      repeat(CORPUS_INDEX_STEP.FAILED, CORPUS_INDEX_STALL_THRESHOLD),
+      repeat(CORPUS_INDEX_STEP.FAILED, THRESHOLD),
     );
-    expect(stalls).toEqual([
-      { kind: "sustained_failure", steps: CORPUS_INDEX_STALL_THRESHOLD },
-    ]);
+    expect(stalls).toEqual([{ kind: "sustained_failure", steps: THRESHOLD }]);
   });
 
   test("any live step clears both streaks", () => {
@@ -64,8 +85,8 @@ describe("stepCorpusIndexProgress", () => {
       CORPUS_INDEX_STEP.COMPLETE,
     ]) {
       const nearStall = [
-        ...repeat(CORPUS_INDEX_STEP.BUSY, CORPUS_INDEX_STALL_THRESHOLD - 1),
-        ...repeat(CORPUS_INDEX_STEP.FAILED, CORPUS_INDEX_STALL_THRESHOLD - 1),
+        ...repeat(CORPUS_INDEX_STEP.BUSY, THRESHOLD - 1),
+        ...repeat(CORPUS_INDEX_STEP.FAILED, THRESHOLD - 1),
         liveKind,
       ];
       const { streaks, stalls } = foldSequence(nearStall);
@@ -78,15 +99,13 @@ describe("stepCorpusIndexProgress", () => {
     // A wedge alternating between a leaked lease and a failing backend must
     // still cross a threshold; interleave the two so neither run is ever
     // consecutive, and expect both to report.
-    const alternating = Array.from(
-      { length: CORPUS_INDEX_STALL_THRESHOLD * 2 },
-      (_, index) =>
-        index % 2 === 0 ? CORPUS_INDEX_STEP.BUSY : CORPUS_INDEX_STEP.FAILED,
+    const alternating = Array.from({ length: THRESHOLD * 2 }, (_, index) =>
+      index % 2 === 0 ? CORPUS_INDEX_STEP.BUSY : CORPUS_INDEX_STEP.FAILED,
     );
     const { stalls } = foldSequence(alternating);
     expect(stalls).toEqual([
-      { kind: "sustained_busy", steps: CORPUS_INDEX_STALL_THRESHOLD },
-      { kind: "sustained_failure", steps: CORPUS_INDEX_STALL_THRESHOLD },
+      { kind: "sustained_busy", steps: THRESHOLD },
+      { kind: "sustained_failure", steps: THRESHOLD },
     ]);
   });
 });

--- a/apps/legal-atlas-runner/src/runners/corpus-index-progress.ts
+++ b/apps/legal-atlas-runner/src/runners/corpus-index-progress.ts
@@ -36,12 +36,25 @@ export const INITIAL_CORPUS_INDEX_STREAKS = {
 } as const satisfies CorpusIndexStreaks;
 
 /**
- * Consecutive steps of a kind before the condition is reported. At the
- * loop's 15s interval this is five minutes of unbroken BUSY or failure —
- * long enough to skip lease handoffs and transient backend blips, short
- * enough to name a leaked lease well before its 30-minute expiry.
+ * How long a condition must hold before it is reported: long enough to skip
+ * lease handoffs and transient backend blips, short enough to name a leaked
+ * lease well before its 30-minute expiry.
  */
-export const CORPUS_INDEX_STALL_THRESHOLD = 20;
+export const CORPUS_INDEX_STALL_WINDOW_MS = 5 * 60_000;
+
+/**
+ * The window expressed as consecutive steps of the loop's configured
+ * interval, which spans 250ms to 5 minutes. A fixed step count would report
+ * after five seconds at the fast end and after 100 minutes at the slow end.
+ * The floor of two keeps a single step from reporting at intervals at or
+ * beyond the window, where one BUSY poll can still be a benign lease
+ * handoff.
+ */
+export const corpusIndexStallThreshold = (intervalMs: number): number =>
+  Math.max(
+    2,
+    Math.ceil(CORPUS_INDEX_STALL_WINDOW_MS / Math.max(1, intervalMs)),
+  );
 
 export type CorpusIndexStallSignal = {
   kind: "sustained_busy" | "sustained_failure";
@@ -59,6 +72,13 @@ export type CorpusIndexProgressStep = {
   stall: CorpusIndexStallSignal | null;
 };
 
+type CorpusIndexProgressOptions = {
+  kind: CorpusIndexStepKind;
+  streaks: CorpusIndexStreaks;
+  /** From corpusIndexStallThreshold(intervalMs), computed once per loop. */
+  threshold: number;
+};
+
 /**
  * Fold one step into the loop's stall state.
  *
@@ -68,17 +88,18 @@ export type CorpusIndexProgressStep = {
  * that proves the subsystem live — rows indexed, or a clean caught-up
  * probe — clears both.
  */
-export const stepCorpusIndexProgress = (
-  streaks: CorpusIndexStreaks,
-  kind: CorpusIndexStepKind,
-): CorpusIndexProgressStep => {
+export const stepCorpusIndexProgress = ({
+  kind,
+  streaks,
+  threshold,
+}: CorpusIndexProgressOptions): CorpusIndexProgressStep => {
   switch (kind) {
     case CORPUS_INDEX_STEP.ADVANCED:
     case CORPUS_INDEX_STEP.COMPLETE:
       return { streaks: INITIAL_CORPUS_INDEX_STREAKS, stall: null };
     case CORPUS_INDEX_STEP.BUSY: {
       const busySteps = streaks.busySteps + 1;
-      if (busySteps < CORPUS_INDEX_STALL_THRESHOLD) {
+      if (busySteps < threshold) {
         return { streaks: { ...streaks, busySteps }, stall: null };
       }
       return {
@@ -88,7 +109,7 @@ export const stepCorpusIndexProgress = (
     }
     case CORPUS_INDEX_STEP.FAILED: {
       const failedSteps = streaks.failedSteps + 1;
-      if (failedSteps < CORPUS_INDEX_STALL_THRESHOLD) {
+      if (failedSteps < threshold) {
         return { streaks: { ...streaks, failedSteps }, stall: null };
       }
       return {

--- a/apps/legal-atlas-runner/src/runners/corpus-index-progress.ts
+++ b/apps/legal-atlas-runner/src/runners/corpus-index-progress.ts
@@ -1,0 +1,104 @@
+/**
+ * How a corpus-index backfill step ended and whether a run of such endings
+ * is a stall worth reporting.
+ *
+ * The loop's raw signal is too coarse on its own: `BUSY` (another writer
+ * holds the generation lease) and a thrown step both look like idle silence
+ * unless counted, and a leaked lease or a persistently failing backend shows
+ * up only as such a run. Kept free of the runner's DB and env imports so the
+ * escalation can be exercised over whole step sequences.
+ */
+
+import { panic } from "better-result";
+
+export const CORPUS_INDEX_STEP = {
+  /** The step indexed rows or advanced the generation walk. */
+  ADVANCED: "advanced",
+  /** Another writer held the generation lease for the whole step. */
+  BUSY: "busy",
+  /** Nothing pending and the walk is done: the index is caught up. */
+  COMPLETE: "complete",
+  /** The step threw. */
+  FAILED: "failed",
+} as const;
+
+export type CorpusIndexStepKind =
+  (typeof CORPUS_INDEX_STEP)[keyof typeof CORPUS_INDEX_STEP];
+
+export type CorpusIndexStreaks = {
+  busySteps: number;
+  failedSteps: number;
+};
+
+export const INITIAL_CORPUS_INDEX_STREAKS = {
+  busySteps: 0,
+  failedSteps: 0,
+} as const satisfies CorpusIndexStreaks;
+
+/**
+ * Consecutive steps of a kind before the condition is reported. At the
+ * loop's 15s interval this is five minutes of unbroken BUSY or failure —
+ * long enough to skip lease handoffs and transient backend blips, short
+ * enough to name a leaked lease well before its 30-minute expiry.
+ */
+export const CORPUS_INDEX_STALL_THRESHOLD = 20;
+
+export type CorpusIndexStallSignal = {
+  kind: "sustained_busy" | "sustained_failure";
+  steps: number;
+};
+
+export type CorpusIndexProgressStep = {
+  streaks: CorpusIndexStreaks;
+  /**
+   * Non-null each time a streak reaches the threshold. The returned streaks
+   * reset the reported counter, so a persisting condition re-reports once
+   * per threshold-run rather than once per step — bounded rate, and a
+   * condition that stops being reported has actually cleared.
+   */
+  stall: CorpusIndexStallSignal | null;
+};
+
+/**
+ * Fold one step into the loop's stall state.
+ *
+ * BUSY and FAILED keep separate counters and do not reset each other: both
+ * are "no progress", and a wedge that alternates between them (a leaked
+ * lease racing a failing backend) must still cross a threshold. Any step
+ * that proves the subsystem live — rows indexed, or a clean caught-up
+ * probe — clears both.
+ */
+export const stepCorpusIndexProgress = (
+  streaks: CorpusIndexStreaks,
+  kind: CorpusIndexStepKind,
+): CorpusIndexProgressStep => {
+  switch (kind) {
+    case CORPUS_INDEX_STEP.ADVANCED:
+    case CORPUS_INDEX_STEP.COMPLETE:
+      return { streaks: INITIAL_CORPUS_INDEX_STREAKS, stall: null };
+    case CORPUS_INDEX_STEP.BUSY: {
+      const busySteps = streaks.busySteps + 1;
+      if (busySteps < CORPUS_INDEX_STALL_THRESHOLD) {
+        return { streaks: { ...streaks, busySteps }, stall: null };
+      }
+      return {
+        streaks: { ...streaks, busySteps: 0 },
+        stall: { kind: "sustained_busy", steps: busySteps },
+      };
+    }
+    case CORPUS_INDEX_STEP.FAILED: {
+      const failedSteps = streaks.failedSteps + 1;
+      if (failedSteps < CORPUS_INDEX_STALL_THRESHOLD) {
+        return { streaks: { ...streaks, failedSteps }, stall: null };
+      }
+      return {
+        streaks: { ...streaks, failedSteps: 0 },
+        stall: { kind: "sustained_failure", steps: failedSteps },
+      };
+    }
+    default: {
+      const unhandled: never = kind;
+      return panic(`Unhandled corpus index step: ${String(unhandled)}`);
+    }
+  }
+};


### PR DESCRIPTION
## Defect

The corpus-index pending queue drained only through `reconcilePending`, which ran solely when a generation rebuild reported `complete`. Any rebuild parked at `running` — a spinning cursor, a persistently failing page, a leaked writer lease, an abandoned checkpoint — therefore silently stopped indexing every newly ingested decision, and the search visibility gate excluded their still-pending projections from results. The driving loop compounded the silence: it logged only `indexed > 0`, so a sustained `BUSY` (contested or leaked lease) was indistinguishable from an idle system.

## Fix

- The generation runner now reconciles a bounded pending slice on **every** invocation, under the `running` lease and **before** the snapshot walk. Live decision traffic indexes regardless of walk state, and a row that wedges the walk cannot also wedge the drain. The existing `pending_revision` epoch converges these appends with walk pages that later reach the same rows; the walk skips pages the drain brought current instead of handing the indexer an empty batch.
- A thrown or contested drain releases the durable running lease before surfacing, so a failure never pins retries behind the 30-minute lease expiry.
- The loop classifies its no-progress outcomes via a new pure fold (`corpus-index-progress.ts`, same shape as `cycle-progress.ts`): 20 consecutive `BUSY` or failed steps (5 minutes at the default interval) emit `case_law.corpus_index.sustained_busy` / `sustained_failure`, re-reported once per threshold-run while the condition persists.

## Notes for review

- Drain-first ordering is deliberate: a poisoned pending row already blocked all pending drainage in the old design, so live traffic loses nothing; the rebuild gains a coupling to the drain, traded for live indexing never waiting on a rebuild.
- One existing test's mid-flight assertion moves from `status: "complete"` to `"running"`: reconciliation now legitimately runs under the running lease before the walk observes its drained snapshot and completes. The lease-retention property the test guards is unchanged (a concurrent runner still sees `busy`).
- CLAUDE.md rule 22 records the invariant so future projection queues keep an always-available drain path.

## Testing

- New regression test: a pending projection drains on the same invocation that advances a still-`running` walk, before the walk, without completing the generation.
- New classifier tests: threshold crossing, once-per-run re-reporting, busy/failed streak independence, reset on any live step.
- All 73 tests across the six touched suites pass (`corpus-index-generation-backfill.db`, `corpus-index-query-guard`, `corpus-index`, `corpus-index-mark.db`, `corpus-index-select.db`, `corpus-index/core`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Corpus indexing now processes pending work before continuing generation, improving consistency of index updates.
  * Generation progress and completion responses now include indexing activity.
  * Empty batches are handled more efficiently without unnecessary indexing.
  * Active generation leases are released when processing or page retrieval fails.
  * Ingestion progress now reports advancing, busy, completed, and failed states.
  * Sustained stalls and repeated failures are surfaced through telemetry and logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->