### PR TITLE
fix(docx): omit source-bound template values from AI prompts

### DIFF
--- a/apps/api/src/lib/docx/ai-visible-values.test.ts
+++ b/apps/api/src/lib/docx/ai-visible-values.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "bun:test";
+
+import { omitSourceBoundValues } from "./ai-visible-values";
+import type { FieldMeta } from "./types";
+
+const source = {
+  kind: "contact",
+  field: "taxId",
+} as const satisfies NonNullable<FieldMeta["source"]>;
+
+describe("AI-visible template values", () => {
+  test("omits flat source-bound values without mutating fill values", () => {
+    const values = {
+      "client.taxId": "TAX-ID-SECRET-12345",
+      scope: "public context",
+    };
+
+    const visible = omitSourceBoundValues({
+      values,
+      fields: [{ path: "client.taxId", source }, { path: "scope" }],
+    });
+
+    expect(visible).toEqual({ scope: "public context" });
+    expect(values["client.taxId"]).toBe("TAX-ID-SECRET-12345");
+  });
+
+  test("omits nested source-bound values", () => {
+    const visible = omitSourceBoundValues({
+      values: {
+        client: {
+          taxId: "TAX-ID-SECRET-12345",
+          name: "ACME",
+        },
+      },
+      fields: [{ path: "client.taxId", source }],
+    });
+
+    expect(visible).toEqual({ client: { name: "ACME" } });
+  });
+
+  test("omits source-bound values from every array row", () => {
+    const values = {
+      clients: [
+        { taxId: "TAX-ID-SECRET-12345", name: "ACME" },
+        { taxId: "TAX-ID-SECRET-67890", name: "Globex" },
+      ],
+    };
+
+    const visible = omitSourceBoundValues({
+      values,
+      fields: [{ path: "clients.taxId", source }],
+    });
+
+    expect(visible).toEqual({
+      clients: [{ name: "ACME" }, { name: "Globex" }],
+    });
+    expect(values.clients.at(0)?.taxId).toBe("TAX-ID-SECRET-12345");
+  });
+
+  test("omits an unsafe source path from the flat values map", () => {
+    const visible = omitSourceBoundValues({
+      values: {
+        "client[secret]": "TAX-ID-SECRET-12345",
+        scope: "public context",
+      },
+      fields: [{ path: "client[secret]", source }],
+    });
+
+    expect(visible).toEqual({ scope: "public context" });
+  });
+});

--- a/apps/api/src/lib/docx/ai-visible-values.ts
+++ b/apps/api/src/lib/docx/ai-visible-values.ts
@@ -1,0 +1,88 @@
+import { isSafeFieldPath } from "@stll/template-conditions";
+
+import { isRecord, isUnknownArray } from "@/api/lib/type-guards";
+
+import type { FieldMeta } from "./types";
+
+type OmitSourceBoundValuesOptions = {
+  values: Record<string, unknown>;
+  fields: readonly FieldMeta[];
+  scopePath?: string | undefined;
+};
+
+export const omitSourceBoundValues = ({
+  values,
+  fields,
+  scopePath,
+}: OmitSourceBoundValuesOptions): Record<string, unknown> => {
+  const scopePrefix = scopePath === undefined ? undefined : `${scopePath}.`;
+  const hiddenPaths = fields
+    .filter((field) => field.source !== undefined)
+    .flatMap((field) => {
+      if (scopePath === undefined) {
+        return [field.path];
+      }
+      if (field.path === scopePath) {
+        return [""];
+      }
+      return scopePrefix !== undefined && field.path.startsWith(scopePrefix)
+        ? [field.path.slice(scopePrefix.length)]
+        : [];
+    });
+  if (hiddenPaths.length === 0) {
+    return values;
+  }
+
+  let visible = { ...values };
+  for (const path of hiddenPaths) {
+    if (path === "") {
+      return {};
+    }
+    visible = omitKey(visible, path);
+    if (isSafeFieldPath(path)) {
+      visible = deleteNestedPath(visible, path.split("."), 0);
+    }
+  }
+  return visible;
+};
+
+const deleteNestedPath = (
+  values: Record<string, unknown>,
+  segments: readonly string[],
+  index: number,
+): Record<string, unknown> => {
+  const segment = segments[index];
+  if (segment === undefined) {
+    return { ...values };
+  }
+
+  if (index === segments.length - 1) {
+    return omitKey(values, segment);
+  }
+
+  const root: Record<string, unknown> = { ...values };
+  const next = values[segment];
+  if (isUnknownArray(next)) {
+    root[segment] = next.map((item) =>
+      isRecord(item) ? deleteNestedPath(item, segments, index + 1) : item,
+    );
+    return root;
+  }
+  if (isRecord(next)) {
+    root[segment] = deleteNestedPath(next, segments, index + 1);
+  }
+  return root;
+};
+
+const omitKey = (
+  values: Record<string, unknown>,
+  omittedKey: string,
+): Record<string, unknown> => {
+  const visible: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(values)) {
+    if (key !== omittedKey) {
+      visible[key] = value;
+    }
+  }
+  return visible;
+};

--- a/apps/api/src/lib/docx/resolve-ai-conditions.test.ts
+++ b/apps/api/src/lib/docx/resolve-ai-conditions.test.ts
@@ -40,6 +40,37 @@ describe("resolveAiConditions", () => {
     expect(result["is_consumer"]).toBe(false);
   });
 
+  test("does not disclose source-bound values to the AI decider", async () => {
+    let seenValues: Record<string, unknown> | undefined;
+
+    const result = await resolveAiConditions({
+      values: {
+        "client.iban": "CZ6508000000192000145399",
+        "client.name": "ACME",
+      },
+      fields: [
+        {
+          path: "client.iban",
+          inputType: "text",
+          source: { kind: "contact", field: "iban" },
+        },
+        {
+          path: "is_consumer",
+          inputType: "boolean",
+          aiPrompt: "Is this a consumer?",
+        },
+      ],
+      decide: async ({ values }) => {
+        seenValues = values;
+        return true;
+      },
+    });
+
+    expect(seenValues).toEqual({ "client.name": "ACME" });
+    expect(result["client.iban"]).toBe("CZ6508000000192000145399");
+    expect(result["is_consumer"]).toBe(true);
+  });
+
   test("leaves the condition unset with no decider (block then excluded)", async () => {
     const result = await resolveAiConditions({
       values: {},

--- a/apps/api/src/lib/docx/resolve-ai-conditions.ts
+++ b/apps/api/src/lib/docx/resolve-ai-conditions.ts
@@ -15,6 +15,7 @@
 
 import { resolvePath } from "@stll/template-conditions";
 
+import { omitSourceBoundValues } from "./ai-visible-values";
 import type { FieldMeta } from "./types";
 
 export type AiConditionDecider = (input: {
@@ -60,7 +61,7 @@ export const resolveAiConditions = async ({
     const value = await decide({
       prompt,
       fieldPath: field.path,
-      values: resolved,
+      values: omitSourceBoundValues({ values: resolved, fields }),
     });
     if (value !== undefined) {
       resolved[field.path] = value;

--- a/apps/api/src/lib/docx/resolve-ai-fields.test.ts
+++ b/apps/api/src/lib/docx/resolve-ai-fields.test.ts
@@ -54,6 +54,32 @@ describe("resolveAiFields", () => {
     expect(result["company.scope"]).toBe("manually written scope");
   });
 
+  test("does not disclose source-bound values to the AI generator", async () => {
+    let seenValues: Record<string, unknown> | undefined;
+
+    const result = await resolveAiFields({
+      values: {
+        "client.taxId": "TAX-ID-SECRET-12345",
+        "client.name": "ACME",
+      },
+      fields: [
+        {
+          path: "client.taxId",
+          source: { kind: "contact", field: "taxId" },
+        },
+        { path: "summary", aiPrompt: "Draft a summary" },
+      ],
+      generate: async ({ values }) => {
+        seenValues = values;
+        return "safe draft";
+      },
+    });
+
+    expect(seenValues).toEqual({ "client.name": "ACME" });
+    expect(result["client.taxId"]).toBe("TAX-ID-SECRET-12345");
+    expect(result["summary"]).toBe("safe draft");
+  });
+
   test("leaves AI fields unfilled when no generator is supplied", async () => {
     const result = await resolveAiFields({
       values: {},
@@ -153,6 +179,40 @@ describe("resolveAiFields — array-scoped (per-item) fields", () => {
       ],
     });
     expect("contracts.summary" in result).toBe(false);
+  });
+
+  test("does not disclose source-bound row values to the AI generator", async () => {
+    const seenValues: Record<string, unknown>[] = [];
+    const result = await resolveAiFields({
+      values: {
+        contracts: [
+          {
+            name: "Alpha",
+            client: { taxId: "TAX-ID-SECRET-12345", name: "ACME" },
+          },
+        ],
+      },
+      fields: [
+        {
+          path: "contracts.client.taxId",
+          source: { kind: "contact", field: "taxId" },
+        },
+        { path: "contracts.summary", aiPrompt: "Summarize this contract" },
+      ],
+      generate: async ({ values }) => {
+        seenValues.push(values);
+        return "SAFE SUMMARY";
+      },
+    });
+
+    expect(seenValues).toEqual([{ name: "Alpha", client: { name: "ACME" } }]);
+    expect(result["contracts"]).toEqual([
+      {
+        name: "Alpha",
+        client: { taxId: "TAX-ID-SECRET-12345", name: "ACME" },
+        summary: "SAFE SUMMARY",
+      },
+    ]);
   });
 
   test("passes 1-based item index and total count per row", async () => {

--- a/apps/api/src/lib/docx/resolve-ai-fields.ts
+++ b/apps/api/src/lib/docx/resolve-ai-fields.ts
@@ -23,6 +23,7 @@ import { isSafeFieldPath, resolvePath } from "@stll/template-conditions";
 
 import { isRecord } from "@/api/lib/type-guards";
 
+import { omitSourceBoundValues } from "./ai-visible-values";
 import type { FieldMeta } from "./types";
 
 export type AiFieldGenerator = (input: {
@@ -89,6 +90,8 @@ export const resolveAiFields = async ({
       // oxlint-disable-next-line no-await-in-loop -- awaited at its position to preserve declaration order; rows fan out internally
       await resolveArrayField({
         rows: boundary.rows,
+        fields,
+        scopePath: boundary.scopePath,
         remainder: boundary.remainder,
         fieldPath: field.path,
         prompt,
@@ -110,7 +113,7 @@ export const resolveAiFields = async ({
     const value = await generate({
       prompt,
       fieldPath: field.path,
-      values: resolved,
+      values: omitSourceBoundValues({ values: resolved, fields }),
       // Only opted-in fields pay the token cost of the document context; the
       // generator omits the section entirely when this is undefined.
       documentText: docText,
@@ -127,6 +130,8 @@ type ArrayBoundary = {
   rows: Record<string, unknown>[];
   /** Path segment(s) after the array, resolved against each row. */
   remainder: string;
+  /** Path to the array itself, used to make field paths row-relative. */
+  scopePath: string;
 };
 
 /**
@@ -151,6 +156,7 @@ const findArrayBoundary = (
     return {
       rows: value.filter(isRecord),
       remainder: segments.slice(i).join("."),
+      scopePath: segments.slice(0, i).join("."),
     };
   }
   return undefined;
@@ -206,6 +212,8 @@ const setNestedPath = (
  */
 const resolveArrayField = async ({
   rows,
+  fields,
+  scopePath,
   remainder,
   fieldPath,
   prompt,
@@ -213,6 +221,8 @@ const resolveArrayField = async ({
   generate,
 }: {
   rows: Record<string, unknown>[];
+  fields: readonly FieldMeta[];
+  scopePath: string;
   remainder: string;
   fieldPath: string;
   prompt: string;
@@ -250,6 +260,8 @@ const resolveArrayField = async ({
       // oxlint-disable-next-line no-await-in-loop -- bounded-concurrency worker draining a shared queue; the pool runs in parallel
       const value = await draftRow({
         row: task.row,
+        fields,
+        scopePath,
         index: task.index,
         count,
         fieldPath,
@@ -269,6 +281,8 @@ const resolveArrayField = async ({
  *  unfilled draft (undefined) so it never aborts the sibling rows. */
 const draftRow = async ({
   row,
+  fields,
+  scopePath,
   index,
   count,
   fieldPath,
@@ -277,6 +291,8 @@ const draftRow = async ({
   generate,
 }: {
   row: Record<string, unknown>;
+  fields: readonly FieldMeta[];
+  scopePath: string;
   index: number;
   count: number;
   fieldPath: string;
@@ -288,7 +304,7 @@ const draftRow = async ({
     return await generate({
       prompt,
       fieldPath,
-      values: row,
+      values: omitSourceBoundValues({ values: row, fields, scopePath }),
       documentText,
       item: { index: index + 1, count },
     });


### PR DESCRIPTION
### Motivation
- Prevent server-resolved source-bound matter and contact fields, such as tax identifiers and bank details, from being serialized into external AI provider prompts during template fills.

### Description
- Add omitSourceBoundValues in apps/api/src/lib/docx/ai-visible-values.ts.
- Remove source-bound values from flat, nested, array, and row-scoped AI prompt payloads without mutating fill data.
- Fail closed for unsafe source paths by removing their exact flat keys.
- Apply sanitization to AI field generation and AI condition decisions while preserving bound values for normal document substitution.
- Keep opted-in document context sourced from the original unfilled template, so it contains template markers rather than resolved values.

### Testing
- bun test apps/api/src/lib/docx/ai-visible-values.test.ts apps/api/src/lib/docx/resolve-ai-fields.test.ts apps/api/src/lib/docx/resolve-ai-conditions.test.ts: 28 passed.
- bun --filter @stll/api lint: passed.
- bun --filter @stll/api typecheck: passed.
- bun run verify: passed.
- Pre-push affected checks: passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * AI-generated fields now exclude values linked to source-bound fields, including nested and array-based data.
  * AI-assisted conditions no longer receive source-bound values, while non-source-bound values continue to be available.
  * Original document values remain unchanged after AI fields and conditions are resolved.
  * Improved handling of scoped, nested, and repeated data structures for more consistent AI-generated results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->