### PR TITLE
feat(case-law): eu-ecj corpus census and CELEX-driven re-fetch runner

### DIFF
--- a/apps/api/src/handlers/case-law/corpus-index-generation-backfill.db.test.ts
+++ b/apps/api/src/handlers/case-law/corpus-index-generation-backfill.db.test.ts
@@ -2587,6 +2587,58 @@ test(
 );
 
 test(
+  "an incomplete walk is driven even when nothing is pending",
+  async () => {
+    // The drain empties the pending queue on the same invocations that
+    // advance the walk, so "checkpoint exists, nothing pending" is now the
+    // steady state of a quiet corpus mid-rebuild. Routed to the incremental
+    // path, the snapshot cursor would never advance again and the
+    // generation would sit at `running` forever.
+    const generation = "case_law_v65";
+    const boundary = (
+      await db
+        .select({
+          createdAtToken: timestampCasToken(caseLawDecisions.createdAt),
+          id: caseLawDecisions.id,
+        })
+        .from(caseLawDecisions)
+        .orderBy(desc(caseLawDecisions.createdAt), desc(caseLawDecisions.id))
+        .limit(1)
+    ).at(0);
+    if (!boundary) {
+      throw new Error("expected seeded decisions");
+    }
+    await db.insert(caseLawCorpusIndexBackfills).values({
+      cursorCreatedAt: sql`${boundary.createdAtToken}::timestamptz`,
+      cursorId: boundary.id,
+      generation,
+      snapshotAt: await nextBackfillSnapshotAt(),
+      status: "running",
+    });
+
+    try {
+      // The cursor already sits at the last decision, so driving the walk
+      // one page observes the drained snapshot and completes. The checkpoint
+      // flip is the discriminating assertion: the routing defect sends the
+      // call to the incremental path, which leaves the status at `running`
+      // without ever touching the walk.
+      expect(await backfillCorpusIndex(scopedDb, 10, generation)).toEqual({
+        indexed: 0,
+        status: "complete",
+      });
+      expect(await readCheckpoint(generation)).toMatchObject({
+        status: "complete",
+      });
+    } finally {
+      await db
+        .delete(caseLawCorpusIndexBackfills)
+        .where(eq(caseLawCorpusIndexBackfills.generation, generation));
+    }
+  },
+  { timeout: 30_000 },
+);
+
+test(
   "drains pending projections while the generation is still running",
   async () => {
     // The wedge this guards: with the drain tied to a completed walk, a

--- a/apps/api/src/handlers/case-law/corpus-index.ts
+++ b/apps/api/src/handlers/case-law/corpus-index.ts
@@ -1373,20 +1373,19 @@ const hasPendingGenerationProjection = async (
     ),
   );
 
-const hasGenerationCheckpoint = async (
+const selectGenerationCheckpointStatus = async (
   scopedDb: Parameters<typeof backfillIncrementalCorpusIndex>[0],
   generation: string,
-): Promise<boolean> =>
-  await scopedDb(async (tx) =>
-    Boolean(
+): Promise<CaseLawCorpusIndexBackfillStatus | null> =>
+  await scopedDb(
+    async (tx) =>
       (
         await tx
-          .select({ generation: caseLawCorpusIndexBackfills.generation })
+          .select({ status: caseLawCorpusIndexBackfills.status })
           .from(caseLawCorpusIndexBackfills)
           .where(eq(caseLawCorpusIndexBackfills.generation, generation))
           .limit(1)
-      ).at(0),
-    ),
+      ).at(0)?.status ?? null,
   );
 
 const validateGenerationBoundary = (generation: string): void => {
@@ -2085,17 +2084,25 @@ export const backfillCorpusIndex = async (
   options: { readConcurrency?: number } = {},
 ): Promise<CorpusIndexBackfillResult> => {
   validateGenerationBoundary(generation);
-  const [sourceReconciliation, pendingProjection, checkpoint] =
+  const [sourceReconciliation, pendingProjection, checkpointStatus] =
     await Promise.all([
       selectSourceReconciliationCheckpoint(scopedDb, generation),
       hasPendingGenerationProjection(scopedDb, generation),
-      hasGenerationCheckpoint(scopedDb, generation),
+      selectGenerationCheckpointStatus(scopedDb, generation),
     ]);
   // A serving generation without a checkpoint has no durable projection
-  // targets yet. Start its bounded snapshot first; inventing a synthetic
-  // completed checkpoint would suppress that replay and leave future appends
-  // without a crash-recoverable target record.
-  if (!checkpoint || sourceReconciliation || pendingProjection) {
+  // targets yet (inventing a synthetic completed checkpoint would suppress
+  // that replay and leave future appends without a crash-recoverable target
+  // record), and one still `running` owes the rest of its snapshot walk.
+  // Both need the generation page. The second condition is load-bearing on
+  // its own: the pending drain empties the queue on the very invocations
+  // that advance the walk, so a quiet corpus with nothing pending must not
+  // park an incomplete walk on the incremental path.
+  if (
+    checkpointStatus !== CASE_LAW_CORPUS_INDEX_BACKFILL_STATUS.COMPLETE ||
+    sourceReconciliation ||
+    pendingProjection
+  ) {
     const result = await backfillCorpusIndexGenerationPage(
       scopedDb,
       batchSize,

--- a/apps/api/src/handlers/case-law/ingestion/adapters/eu-ecj.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/eu-ecj.ts
@@ -525,6 +525,55 @@ export const fetchDecisionsByCelex = async ({
   return decisions;
 };
 
+export type EcjCelexVariant = {
+  celex: string;
+  language: EcjLanguage;
+};
+
+type ListCelexVariantsOptions = {
+  celexNumbers: readonly string[];
+  signal: AbortSignal;
+};
+
+/**
+ * List which language variants Cellar holds as XHTML for the given CELEX
+ * numbers, without fetching any manifestation body.
+ *
+ * A stored variant absent from this listing was never published as XHTML:
+ * the census separating re-fetchable rows from phantom ones keys on exactly
+ * that. Same query, filters and language mapping as the crawl, so the
+ * listing cannot disagree with what a re-fetch would visit.
+ */
+export const listCelexVariants = async ({
+  celexNumbers,
+  signal,
+}: ListCelexVariantsOptions): Promise<EcjCelexVariant[]> => {
+  if (celexNumbers.length === 0) {
+    return [];
+  }
+  const bindings = await queryDecisions({
+    dateFrom: COURT_EPOCH,
+    dateTo: toIsoDate(new Date()),
+    celexFilter: celexNumbers,
+    signal,
+  });
+  const variants: EcjCelexVariant[] = [];
+  const seen = new Set<string>();
+  for (const binding of bindings) {
+    const language = toEcjLanguage(binding.language.value);
+    if (language === undefined) {
+      continue;
+    }
+    const key = `${binding.celex.value}:${language}`;
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    variants.push({ celex: binding.celex.value, language });
+  }
+  return variants;
+};
+
 /** Historical media type whose string payload passed through normalization. */
 const ECJ_RAW_CONTENT_TYPE = "application/xhtml+xml";
 

--- a/apps/api/src/handlers/case-law/ingestion/adapters/eu-ecj.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/eu-ecj.ts
@@ -223,6 +223,9 @@ type QueryDecisionsOptions = {
 /** CELEX numbers are alphanumeric with optional bracketed suffixes. */
 const CELEX = /^[0-9A-Z()]+$/u;
 
+/** Boundary check for callers that accept CELEX numbers as input. */
+export const isValidCelex = (value: string): boolean => CELEX.test(value);
+
 const queryDecisions = async ({
   dateFrom,
   dateTo,
@@ -310,6 +313,17 @@ LIMIT ${SPARQL_LIMIT}`.trim();
   const bindings = json.results.bindings;
 
   if (bindings.length === SPARQL_LIMIT) {
+    // A truncated targeted listing is never acceptable: a census or
+    // re-fetch keyed on it would classify the missing variants as never
+    // published. The date-window crawl keeps the warning shape it has
+    // always had; its per-day pages sit far below the cap.
+    if (celexFilter && celexFilter.length > 0) {
+      throw new AdapterFetchError({
+        message: `CJEU SPARQL listing truncated at ${SPARQL_LIMIT} bindings; use fewer CELEX numbers per query`,
+        adapterKey: ADAPTER_KEYS.EU_ECJ,
+        cursor: dateFrom,
+      });
+    }
     logger.warn("case_law.ingestion.sparql_limit_hit", {
       adapterKey: ADAPTER_KEYS.EU_ECJ,
       limit: SPARQL_LIMIT,

--- a/apps/api/src/scripts/eu-ecj-census.ts
+++ b/apps/api/src/scripts/eu-ecj-census.ts
@@ -57,6 +57,8 @@ const flagValue = (name: string): string | undefined => {
   return value;
 };
 
+const DECIMAL_INTEGER = /^\d+$/u;
+
 const positiveInteger = (
   raw: string | undefined,
   fallback: number,
@@ -65,7 +67,7 @@ const positiveInteger = (
   if (raw === undefined) {
     return fallback;
   }
-  const parsed = Number.parseInt(raw, 10);
+  const parsed = DECIMAL_INTEGER.test(raw) ? Number.parseInt(raw, 10) : NaN;
   if (!Number.isSafeInteger(parsed) || parsed <= 0) {
     console.error(`--${name} must be a positive integer, got: ${raw}`);
     process.exit(1);
@@ -73,16 +75,26 @@ const positiveInteger = (
   return parsed;
 };
 
+/**
+ * The SPARQL endpoint caps responses at 10,000 bindings and a truncated
+ * targeted listing now throws; up to 24 languages with occasional
+ * re-published manifestations per pair keeps 300 CELEX safely under it.
+ */
+const MAX_SPARQL_CHUNK = 300;
+
 const outPath = flagValue("out") ?? "eu-ecj-census.json";
 const pageSize = positiveInteger(
   flagValue("page-size"),
   DEFAULT_PAGE_SIZE,
   "page-size",
 );
-const sparqlChunk = positiveInteger(
-  flagValue("sparql-chunk"),
-  DEFAULT_SPARQL_CHUNK,
-  "sparql-chunk",
+const sparqlChunk = Math.min(
+  positiveInteger(
+    flagValue("sparql-chunk"),
+    DEFAULT_SPARQL_CHUNK,
+    "sparql-chunk",
+  ),
+  MAX_SPARQL_CHUNK,
 );
 
 const ingestionDb = createIngestionDb(rlsDb);

--- a/apps/api/src/scripts/eu-ecj-census.ts
+++ b/apps/api/src/scripts/eu-ecj-census.ts
@@ -1,0 +1,204 @@
+import { and, eq, gt, sql } from "drizzle-orm";
+
+import { rlsDb } from "@/api/db/root";
+import { caseLawDecisions, caseLawSources } from "@/api/db/schema";
+import { createIngestionDb } from "@/api/db/scoped";
+import { ADAPTER_KEYS } from "@/api/handlers/case-law/consts";
+import { listCelexVariants } from "@/api/handlers/case-law/ingestion/adapters/eu-ecj";
+import type { SafeId } from "@/api/lib/branded-types";
+
+/**
+ * Classify every stored eu-ecj decision against Cellar's own listing.
+ *
+ * The stored corpus predates the CJEU parser and part of it was fetched from
+ * a source that returned page furniture for language variants that were
+ * never published. Cellar's SPARQL is the authority on which
+ * (CELEX, language) pairs exist as XHTML, so each stored row lands in one
+ * of four buckets:
+ *
+ *   refetchable    the variant exists; a re-fetch replaces the row
+ *   phantom        the CELEX is listed but not in this language; the row
+ *                  describes a document that was never published
+ *   celexUnlisted  Cellar lists nothing for the CELEX under the crawl's
+ *                  type and manifestation filters; not proof of a phantom —
+ *                  the work may exist outside those filters
+ *   missingCelex   the row carries no CELEX; nothing can be asked
+ *
+ * Reads row identity and metadata only (no fulltext columns), in keyset
+ * pages, so it stays cheap on a busy instance. Writes nothing anywhere; the
+ * report file feeds the re-fetch runner.
+ *
+ *   bun run src/scripts/eu-ecj-census.ts --out eu-ecj-census.json
+ */
+
+const DEFAULT_PAGE_SIZE = 500;
+const DEFAULT_SPARQL_CHUNK = 100;
+const SPARQL_TIMEOUT_MS = 60_000;
+/** Politeness pause between SPARQL queries; this is a bulk read. */
+const SPARQL_DELAY_MS = 1000;
+
+const USAGE = `Usage: bun run src/scripts/eu-ecj-census.ts [options]
+
+  --out <path>         Report file (default eu-ecj-census.json).
+  --page-size <n>      Rows read per database query (default ${DEFAULT_PAGE_SIZE}).
+  --sparql-chunk <n>   CELEX numbers per SPARQL query (default ${DEFAULT_SPARQL_CHUNK}).`;
+
+const flagValue = (name: string): string | undefined => {
+  const index = process.argv.indexOf(`--${name}`);
+  if (index === -1) {
+    return undefined;
+  }
+  const value = process.argv[index + 1];
+  if (value === undefined || value.startsWith("--")) {
+    console.error(`--${name} requires a value`);
+    console.error(USAGE);
+    process.exit(1);
+  }
+  return value;
+};
+
+const positiveInteger = (
+  raw: string | undefined,
+  fallback: number,
+  name: string,
+): number => {
+  if (raw === undefined) {
+    return fallback;
+  }
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    console.error(`--${name} must be a positive integer, got: ${raw}`);
+    process.exit(1);
+  }
+  return parsed;
+};
+
+const outPath = flagValue("out") ?? "eu-ecj-census.json";
+const pageSize = positiveInteger(
+  flagValue("page-size"),
+  DEFAULT_PAGE_SIZE,
+  "page-size",
+);
+const sparqlChunk = positiveInteger(
+  flagValue("sparql-chunk"),
+  DEFAULT_SPARQL_CHUNK,
+  "sparql-chunk",
+);
+
+const ingestionDb = createIngestionDb(rlsDb);
+
+const source = (
+  await ingestionDb((tx) =>
+    tx
+      .select({ id: caseLawSources.id })
+      .from(caseLawSources)
+      .where(eq(caseLawSources.adapterKey, ADAPTER_KEYS.EU_ECJ))
+      .limit(1),
+  )
+).at(0);
+if (!source) {
+  console.error("No case-law source configured for adapter eu-ecj");
+  process.exit(1);
+}
+
+type CensusRow = {
+  id: SafeId<"caseLawDecision">;
+  language: string;
+  celex: string | null;
+};
+
+const rows: CensusRow[] = [];
+let after: SafeId<"caseLawDecision"> | null = null;
+for (;;) {
+  const boundary = after;
+  // oxlint-disable-next-line no-await-in-loop -- keyset pagination is inherently sequential
+  const page = await ingestionDb((tx) =>
+    tx
+      .select({
+        id: caseLawDecisions.id,
+        language: caseLawDecisions.language,
+        celex: sql<string | null>`${caseLawDecisions.metadata}->>'celex'`,
+      })
+      .from(caseLawDecisions)
+      .where(
+        boundary === null
+          ? eq(caseLawDecisions.sourceId, source.id)
+          : and(
+              eq(caseLawDecisions.sourceId, source.id),
+              gt(caseLawDecisions.id, boundary),
+            ),
+      )
+      .orderBy(caseLawDecisions.id)
+      .limit(pageSize),
+  );
+  rows.push(...page);
+  const last = page.at(-1);
+  if (page.length < pageSize || !last) {
+    break;
+  }
+  after = last.id;
+  console.error(`read ${rows.length} rows…`);
+}
+console.error(`stored rows: ${rows.length}`);
+
+const missingCelex = rows.filter((row) => row.celex === null);
+const withCelex = rows.filter(
+  (row): row is CensusRow & { celex: string } => row.celex !== null,
+);
+const distinctCelex = [...new Set(withCelex.map((row) => row.celex))].sort();
+console.error(`distinct CELEX: ${distinctCelex.length}`);
+
+/** `celex:LANG` pairs Cellar lists as existing XHTML manifestations. */
+const listedVariants = new Set<string>();
+const listedCelex = new Set<string>();
+for (let index = 0; index < distinctCelex.length; index += sparqlChunk) {
+  const chunk = distinctCelex.slice(index, index + sparqlChunk);
+  // oxlint-disable-next-line no-await-in-loop -- rate-limited external queries stay sequential
+  const variants = await listCelexVariants({
+    celexNumbers: chunk,
+    signal: AbortSignal.timeout(SPARQL_TIMEOUT_MS),
+  });
+  for (const variant of variants) {
+    listedVariants.add(`${variant.celex}:${variant.language}`);
+    listedCelex.add(variant.celex);
+  }
+  console.error(
+    `queried ${Math.min(index + sparqlChunk, distinctCelex.length)} of ${distinctCelex.length} CELEX…`,
+  );
+  // oxlint-disable-next-line no-await-in-loop -- politeness pause between bulk queries
+  await Bun.sleep(SPARQL_DELAY_MS);
+}
+
+const refetchable: (CensusRow & { celex: string })[] = [];
+const phantoms: (CensusRow & { celex: string })[] = [];
+const celexUnlisted: (CensusRow & { celex: string })[] = [];
+for (const row of withCelex) {
+  if (listedVariants.has(`${row.celex}:${row.language.toUpperCase()}`)) {
+    refetchable.push(row);
+  } else if (listedCelex.has(row.celex)) {
+    phantoms.push(row);
+  } else {
+    celexUnlisted.push(row);
+  }
+}
+
+const report = {
+  generatedAt: new Date().toISOString(),
+  counts: {
+    rows: rows.length,
+    distinctCelex: distinctCelex.length,
+    refetchable: refetchable.length,
+    phantoms: phantoms.length,
+    celexUnlisted: celexUnlisted.length,
+    missingCelex: missingCelex.length,
+  },
+  refetchableCelex: [...new Set(refetchable.map((row) => row.celex))].sort(),
+  phantoms,
+  celexUnlisted,
+  missingCelex: missingCelex.map(({ id, language }) => ({ id, language })),
+};
+
+await Bun.write(outPath, `${JSON.stringify(report, null, 2)}\n`);
+console.error(`report written to ${outPath}`);
+console.log(JSON.stringify(report.counts, null, 2));
+process.exit(0);

--- a/apps/api/src/scripts/eu-ecj-census.ts
+++ b/apps/api/src/scripts/eu-ecj-census.ts
@@ -67,7 +67,9 @@ const positiveInteger = (
   if (raw === undefined) {
     return fallback;
   }
-  const parsed = DECIMAL_INTEGER.test(raw) ? Number.parseInt(raw, 10) : NaN;
+  const parsed = DECIMAL_INTEGER.test(raw)
+    ? Number.parseInt(raw, 10)
+    : Number.NaN;
   if (!Number.isSafeInteger(parsed) || parsed <= 0) {
     console.error(`--${name} must be a positive integer, got: ${raw}`);
     process.exit(1);
@@ -119,12 +121,13 @@ type CensusRow = {
   celex: string | null;
 };
 
-const rows: CensusRow[] = [];
-let after: SafeId<"caseLawDecision"> | null = null;
-for (;;) {
-  const boundary = after;
-  // oxlint-disable-next-line no-await-in-loop -- keyset pagination is inherently sequential
-  const page = await ingestionDb((tx) =>
+// The explicit return type breaks the inference cycle the keyset loop
+// otherwise creates: the boundary feeds the query whose result feeds the
+// next boundary.
+const selectCensusPage = async (
+  boundary: SafeId<"caseLawDecision"> | null,
+): Promise<CensusRow[]> =>
+  await ingestionDb((tx) =>
     tx
       .select({
         id: caseLawDecisions.id,
@@ -143,6 +146,12 @@ for (;;) {
       .orderBy(caseLawDecisions.id)
       .limit(pageSize),
   );
+
+const rows: CensusRow[] = [];
+let after: SafeId<"caseLawDecision"> | null = null;
+for (;;) {
+  // oxlint-disable-next-line no-await-in-loop -- keyset pagination is inherently sequential
+  const page = await selectCensusPage(after);
   rows.push(...page);
   const last = page.at(-1);
   if (page.length < pageSize || !last) {

--- a/apps/api/src/scripts/eu-ecj-refetch.ts
+++ b/apps/api/src/scripts/eu-ecj-refetch.ts
@@ -99,7 +99,9 @@ const positiveInteger = (
   if (raw === undefined) {
     return fallback;
   }
-  const parsed = DECIMAL_INTEGER.test(raw) ? Number.parseInt(raw, 10) : NaN;
+  const parsed = DECIMAL_INTEGER.test(raw)
+    ? Number.parseInt(raw, 10)
+    : Number.NaN;
   if (!Number.isSafeInteger(parsed) || parsed <= 0) {
     console.error(`--${name} must be a positive integer, got: ${raw}`);
     process.exit(1);

--- a/apps/api/src/scripts/eu-ecj-refetch.ts
+++ b/apps/api/src/scripts/eu-ecj-refetch.ts
@@ -4,7 +4,11 @@ import { rlsDb } from "@/api/db/root";
 import { caseLawSources } from "@/api/db/schema";
 import { createIngestionDb } from "@/api/db/scoped";
 import { ADAPTER_KEYS } from "@/api/handlers/case-law/consts";
-import { fetchDecisionsByCelex } from "@/api/handlers/case-law/ingestion/adapters/eu-ecj";
+import {
+  fetchDecisionsByCelex,
+  isValidCelex,
+  listCelexVariants,
+} from "@/api/handlers/case-law/ingestion/adapters/eu-ecj";
 import {
   allocateSourceObservationOrder,
   DECISION_REFRESH,
@@ -26,12 +30,18 @@ import { refreshCorpusS3, refreshS3 } from "@/api/lib/s3";
  * The CELEX list comes from the census report
  * (`src/scripts/eu-ecj-census.ts`), which classifies stored rows against
  * Cellar's own listing; this runner visits the re-fetchable ones. Each
- * result goes through `processDecision` under `DECISION_REFRESH.ALWAYS`
- * (the publisher's document may hash identically while the payload the
- * parser derives is what changed), ordered on the source's observation
- * counter under its ingestion lease, so a run cannot interleave with a
- * live crawl. Interrupt with Ctrl-C: the current decision finishes, and
- * the report names the CELEX to resume `--after`.
+ * CELEX is listed again before it is fetched, so a variant the fetch
+ * silently drops (transient non-OK, timeout, short body) is detected by
+ * count and the CELEX lands in the failed set instead of being advanced
+ * past. Results go through `processDecision` under
+ * `DECISION_REFRESH.ALWAYS` (the publisher's document may hash
+ * identically while the payload the parser derives is what changed),
+ * ordered on the source's observation counter under its ingestion lease,
+ * so a run cannot interleave with a live crawl.
+ *
+ * Failed CELEX are written to a JSON file at the end; feed it back via
+ * `--celex-file` to retry exactly those. Interrupt with Ctrl-C: the
+ * current decision finishes and the report names the resume point.
  *
  *   # what a run would visit, contacting nothing
  *   bun run src/scripts/eu-ecj-refetch.ts --census eu-ecj-census.json
@@ -48,15 +58,20 @@ const DEFAULT_DELAY_MS = 500;
 /** Consecutive failed CELEX before the run halts; mirrors the crawl. */
 const FAILURE_HALT_THRESHOLD = 10;
 const CELEX_FETCH_TIMEOUT_MS = 5 * 60_000;
+const SPARQL_TIMEOUT_MS = 60_000;
+const DEFAULT_FAILED_OUT = "eu-ecj-refetch-failed.json";
 
 const USAGE = `Usage: bun run src/scripts/eu-ecj-refetch.ts [options]
 
-  --census <path>   Census report whose refetchableCelex list is visited.
-  --celex <a,b,c>   Visit these CELEX numbers instead of a census file.
-  --apply           Fetch and write. Omitted, the run prints the plan only.
-  --limit <n>       Maximum CELEX to visit this run.
-  --after <celex>   Resume strictly after this CELEX (sorted order).
-  --delay-ms <n>    Pause between decisions (default ${DEFAULT_DELAY_MS}).`;
+  --census <path>      Census report whose refetchableCelex list is visited.
+  --celex <a,b,c>      Visit these CELEX numbers instead of a census file.
+  --celex-file <path>  Visit the JSON string array in this file (e.g. a
+                       previous run's failed set).
+  --apply              Fetch and write. Omitted, the run prints the plan only.
+  --limit <n>          Maximum CELEX to visit this run.
+  --after <celex>      Resume strictly after this CELEX (sorted order).
+  --delay-ms <n>       Pause between decisions (default ${DEFAULT_DELAY_MS}).
+  --failed-out <path>  Where failed CELEX are written (default ${DEFAULT_FAILED_OUT}).`;
 
 const flagValue = (name: string): string | undefined => {
   const index = process.argv.indexOf(`--${name}`);
@@ -74,6 +89,8 @@ const flagValue = (name: string): string | undefined => {
 
 const hasFlag = (name: string): boolean => process.argv.includes(`--${name}`);
 
+const DECIMAL_INTEGER = /^\d+$/u;
+
 const positiveInteger = (
   raw: string | undefined,
   fallback: number,
@@ -82,7 +99,7 @@ const positiveInteger = (
   if (raw === undefined) {
     return fallback;
   }
-  const parsed = Number.parseInt(raw, 10);
+  const parsed = DECIMAL_INTEGER.test(raw) ? Number.parseInt(raw, 10) : NaN;
   if (!Number.isSafeInteger(parsed) || parsed <= 0) {
     console.error(`--${name} must be a positive integer, got: ${raw}`);
     process.exit(1);
@@ -93,23 +110,31 @@ const positiveInteger = (
 const apply = hasFlag("apply");
 const limitFlag = flagValue("limit");
 const limit =
-  limitFlag === undefined
-    ? null
-    : positiveInteger(limitFlag, Number.NaN, "limit");
+  limitFlag === undefined ? null : positiveInteger(limitFlag, 0, "limit");
 const after = flagValue("after") ?? null;
 const delayMs = positiveInteger(
   flagValue("delay-ms"),
   DEFAULT_DELAY_MS,
   "delay-ms",
 );
+const failedOutPath = flagValue("failed-out") ?? DEFAULT_FAILED_OUT;
 
 const censusPath = flagValue("census");
 const celexFlag = flagValue("celex");
-if ((censusPath === undefined) === (celexFlag === undefined)) {
-  console.error("Exactly one of --census or --celex is required.");
+const celexFilePath = flagValue("celex-file");
+const sourcesGiven = [censusPath, celexFlag, celexFilePath].filter(
+  (value) => value !== undefined,
+);
+if (sourcesGiven.length !== 1) {
+  console.error(
+    "Exactly one of --census, --celex or --celex-file is required.",
+  );
   console.error(USAGE);
   process.exit(1);
 }
+
+const isStringArray = (value: unknown): value is string[] =>
+  Array.isArray(value) && value.every((entry) => typeof entry === "string");
 
 const isCensusReport = (
   value: unknown,
@@ -117,12 +142,19 @@ const isCensusReport = (
   typeof value === "object" &&
   value !== null &&
   "refetchableCelex" in value &&
-  Array.isArray(value.refetchableCelex) &&
-  value.refetchableCelex.every((celex) => typeof celex === "string");
+  isStringArray(value.refetchableCelex);
 
 const requestedCelex = await (async (): Promise<string[]> => {
   if (celexFlag !== undefined) {
     return celexFlag.split(",").map((celex) => celex.trim());
+  }
+  if (celexFilePath !== undefined) {
+    const parsed: unknown = JSON.parse(await Bun.file(celexFilePath).text());
+    if (!isStringArray(parsed)) {
+      console.error(`${celexFilePath} is not a JSON array of CELEX strings`);
+      process.exit(1);
+    }
+    return parsed;
   }
   const parsed: unknown = JSON.parse(await Bun.file(censusPath ?? "").text());
   if (!isCensusReport(parsed)) {
@@ -131,6 +163,21 @@ const requestedCelex = await (async (): Promise<string[]> => {
   }
   return parsed.refetchableCelex;
 })();
+
+// Validated here, before the lease: a malformed entry deep in the plan
+// would otherwise burn the consecutive-failure budget mid-run and could
+// halt a valid recovery.
+const malformed = requestedCelex.filter((celex) => !isValidCelex(celex));
+if (malformed.length > 0) {
+  console.error(
+    `Invalid CELEX number(s): ${malformed.slice(0, 5).join(", ")}${malformed.length > 5 ? ` (+${malformed.length - 5} more)` : ""}`,
+  );
+  process.exit(1);
+}
+if (after !== null && !isValidCelex(after)) {
+  console.error(`--after must be a CELEX number, got: ${after}`);
+  process.exit(1);
+}
 
 const plan = [...new Set(requestedCelex)]
   .sort()
@@ -179,26 +226,30 @@ if (sourceLease === null) {
   process.exit(1);
 }
 
-let interrupted = false;
+// Object-held so the flag's cross-callback mutation is visible to
+// per-site flow analysis; a plain boolean reads as always-false.
+const runState = { interrupted: false };
 process.on("SIGINT", () => {
-  interrupted = true;
+  runState.interrupted = true;
   console.error("interrupt received; finishing the current decision…");
 });
 
 const counts = {
   visited: 0,
+  variantsExpected: 0,
   variantsFetched: 0,
   complete: 0,
   retryable: 0,
-  emptyCelex: 0,
+  missingVariants: 0,
 };
+const failedCelex: string[] = [];
 let lastVisited: string | null = null;
 let consecutiveFailures = 0;
 let haltReason: string | null = null;
 
 try {
   for (const celex of plan) {
-    if (interrupted) {
+    if (runState.interrupted) {
       haltReason = "interrupted";
       break;
     }
@@ -210,13 +261,28 @@ try {
     lastVisited = celex;
     let celexFailed = false;
     try {
+      // Listed again right before the fetch: the count is what detects a
+      // variant the fetch dropped silently, and the extra query per CELEX
+      // is noise next to the manifestation downloads themselves.
+      // oxlint-disable-next-line no-await-in-loop -- rate-limited publisher traffic stays sequential
+      const expected = await listCelexVariants({
+        celexNumbers: [celex],
+        signal: AbortSignal.timeout(SPARQL_TIMEOUT_MS),
+      });
+      counts.variantsExpected += expected.length;
       // oxlint-disable-next-line no-await-in-loop -- rate-limited publisher traffic stays sequential
       const results = await fetchDecisionsByCelex({
         celexNumbers: [celex],
         signal: AbortSignal.timeout(CELEX_FETCH_TIMEOUT_MS),
       });
-      if (results.length === 0) {
-        counts.emptyCelex += 1;
+      if (results.length < expected.length) {
+        // The missing variants stay stored as they were; the CELEX goes to
+        // the failed set so a retry revisits every variant.
+        counts.missingVariants += expected.length - results.length;
+        celexFailed = true;
+        console.error(
+          `${celex}: fetched ${results.length} of ${expected.length} listed variants`,
+        );
       }
       for (const result of results) {
         counts.variantsFetched += 1;
@@ -251,10 +317,15 @@ try {
       celexFailed = true;
       console.error(`${celex}: failed —`, error);
     }
-    consecutiveFailures = celexFailed ? consecutiveFailures + 1 : 0;
+    if (celexFailed) {
+      failedCelex.push(celex);
+      consecutiveFailures += 1;
+    } else {
+      consecutiveFailures = 0;
+    }
     if (counts.visited % 25 === 0) {
       console.error(
-        `progress: ${counts.visited}/${plan.length} celex, ${counts.complete} variants written`,
+        `progress: ${counts.visited}/${plan.length} celex, ${counts.complete} variants written, ${failedCelex.length} celex failed`,
       );
     }
     // oxlint-disable-next-line no-await-in-loop -- politeness pause between decisions, matching the crawl
@@ -266,10 +337,16 @@ try {
 
 console.log("--- outcomes ---");
 console.log(`celex visited:     ${counts.visited} of ${plan.length}`);
+console.log(`variants listed:   ${counts.variantsExpected}`);
 console.log(`variants fetched:  ${counts.variantsFetched}`);
 console.log(`written:           ${counts.complete}`);
 console.log(`retryable:         ${counts.retryable}`);
-console.log(`celex w/o results: ${counts.emptyCelex}`);
+console.log(`variants missing:  ${counts.missingVariants}`);
+if (failedCelex.length > 0) {
+  await Bun.write(failedOutPath, `${JSON.stringify(failedCelex, null, 2)}\n`);
+  console.log(`celex failed:      ${failedCelex.length} → ${failedOutPath}`);
+  console.log(`retry them with:   --celex-file ${failedOutPath} --apply`);
+}
 if (haltReason !== null) {
   console.log(`halted:            ${haltReason}`);
 }

--- a/apps/api/src/scripts/eu-ecj-refetch.ts
+++ b/apps/api/src/scripts/eu-ecj-refetch.ts
@@ -1,0 +1,279 @@
+import { eq } from "drizzle-orm";
+
+import { rlsDb } from "@/api/db/root";
+import { caseLawSources } from "@/api/db/schema";
+import { createIngestionDb } from "@/api/db/scoped";
+import { ADAPTER_KEYS } from "@/api/handlers/case-law/consts";
+import { fetchDecisionsByCelex } from "@/api/handlers/case-law/ingestion/adapters/eu-ecj";
+import {
+  allocateSourceObservationOrder,
+  DECISION_REFRESH,
+  PROCESS_DECISION_STATUS,
+  processDecision,
+} from "@/api/handlers/case-law/ingestion/pipeline";
+import { acquireCaseLawSourceIngestionLease } from "@/api/lib/legal-search/case-law-source-ingestion-lease";
+import { refreshCorpusS3, refreshS3 } from "@/api/lib/s3";
+
+/**
+ * Re-fetch named CJEU decisions from Cellar and run them through the
+ * ingestion pipeline.
+ *
+ * The stored eu-ecj corpus predates the CJEU parser: every row lacks an
+ * AST, and re-parsing locally is impossible because the pre-parser crawl
+ * kept no raw payload. A CELEX-driven re-fetch is the tractable shape —
+ * the date-cursor reset walks ~27k publication days, almost all empty.
+ *
+ * The CELEX list comes from the census report
+ * (`src/scripts/eu-ecj-census.ts`), which classifies stored rows against
+ * Cellar's own listing; this runner visits the re-fetchable ones. Each
+ * result goes through `processDecision` under `DECISION_REFRESH.ALWAYS`
+ * (the publisher's document may hash identically while the payload the
+ * parser derives is what changed), ordered on the source's observation
+ * counter under its ingestion lease, so a run cannot interleave with a
+ * live crawl. Interrupt with Ctrl-C: the current decision finishes, and
+ * the report names the CELEX to resume `--after`.
+ *
+ *   # what a run would visit, contacting nothing
+ *   bun run src/scripts/eu-ecj-refetch.ts --census eu-ecj-census.json
+ *
+ *   # re-fetch, resumable
+ *   bun run src/scripts/eu-ecj-refetch.ts --census eu-ecj-census.json \
+ *     --apply --limit 500 [--after <celex>]
+ *
+ * Not a scheduled job: a deliberate operation under an operator who reads
+ * the report, exactly like the stored-raw replay.
+ */
+
+const DEFAULT_DELAY_MS = 500;
+/** Consecutive failed CELEX before the run halts; mirrors the crawl. */
+const FAILURE_HALT_THRESHOLD = 10;
+const CELEX_FETCH_TIMEOUT_MS = 5 * 60_000;
+
+const USAGE = `Usage: bun run src/scripts/eu-ecj-refetch.ts [options]
+
+  --census <path>   Census report whose refetchableCelex list is visited.
+  --celex <a,b,c>   Visit these CELEX numbers instead of a census file.
+  --apply           Fetch and write. Omitted, the run prints the plan only.
+  --limit <n>       Maximum CELEX to visit this run.
+  --after <celex>   Resume strictly after this CELEX (sorted order).
+  --delay-ms <n>    Pause between decisions (default ${DEFAULT_DELAY_MS}).`;
+
+const flagValue = (name: string): string | undefined => {
+  const index = process.argv.indexOf(`--${name}`);
+  if (index === -1) {
+    return undefined;
+  }
+  const value = process.argv[index + 1];
+  if (value === undefined || value.startsWith("--")) {
+    console.error(`--${name} requires a value`);
+    console.error(USAGE);
+    process.exit(1);
+  }
+  return value;
+};
+
+const hasFlag = (name: string): boolean => process.argv.includes(`--${name}`);
+
+const positiveInteger = (
+  raw: string | undefined,
+  fallback: number,
+  name: string,
+): number => {
+  if (raw === undefined) {
+    return fallback;
+  }
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    console.error(`--${name} must be a positive integer, got: ${raw}`);
+    process.exit(1);
+  }
+  return parsed;
+};
+
+const apply = hasFlag("apply");
+const limitFlag = flagValue("limit");
+const limit =
+  limitFlag === undefined
+    ? null
+    : positiveInteger(limitFlag, Number.NaN, "limit");
+const after = flagValue("after") ?? null;
+const delayMs = positiveInteger(
+  flagValue("delay-ms"),
+  DEFAULT_DELAY_MS,
+  "delay-ms",
+);
+
+const censusPath = flagValue("census");
+const celexFlag = flagValue("celex");
+if ((censusPath === undefined) === (celexFlag === undefined)) {
+  console.error("Exactly one of --census or --celex is required.");
+  console.error(USAGE);
+  process.exit(1);
+}
+
+const isCensusReport = (
+  value: unknown,
+): value is { refetchableCelex: string[] } =>
+  typeof value === "object" &&
+  value !== null &&
+  "refetchableCelex" in value &&
+  Array.isArray(value.refetchableCelex) &&
+  value.refetchableCelex.every((celex) => typeof celex === "string");
+
+const requestedCelex = await (async (): Promise<string[]> => {
+  if (celexFlag !== undefined) {
+    return celexFlag.split(",").map((celex) => celex.trim());
+  }
+  const parsed: unknown = JSON.parse(await Bun.file(censusPath ?? "").text());
+  if (!isCensusReport(parsed)) {
+    console.error(`${censusPath} is not a census report`);
+    process.exit(1);
+  }
+  return parsed.refetchableCelex;
+})();
+
+const plan = [...new Set(requestedCelex)]
+  .sort()
+  .filter((celex) => after === null || celex > after)
+  .slice(0, limit ?? undefined);
+
+console.log(`=== EU-ECJ RE-FETCH ===`);
+console.log(`mode:        ${apply ? "apply" : "plan only"}`);
+console.log(`celex total: ${new Set(requestedCelex).size}`);
+console.log(
+  `this run:    ${plan.length}${after === null ? "" : ` (after ${after})`}`,
+);
+if (!apply) {
+  console.log(
+    "Plan only: nothing fetched, nothing written. Re-run with --apply.",
+  );
+  process.exit(0);
+}
+
+const ingestionDb = createIngestionDb(rlsDb);
+await refreshS3();
+await refreshCorpusS3();
+
+const source = (
+  await ingestionDb((tx) =>
+    tx
+      .select({ id: caseLawSources.id })
+      .from(caseLawSources)
+      .where(eq(caseLawSources.adapterKey, ADAPTER_KEYS.EU_ECJ))
+      .limit(1),
+  )
+).at(0);
+if (!source) {
+  console.error("No case-law source configured for adapter eu-ecj");
+  process.exit(1);
+}
+
+const sourceLease = await acquireCaseLawSourceIngestionLease({
+  scopedDb: ingestionDb,
+  sourceId: source.id,
+});
+if (sourceLease === null) {
+  console.error(
+    "Source eu-ecj is being ingested right now (lease held). Retry later.",
+  );
+  process.exit(1);
+}
+
+let interrupted = false;
+process.on("SIGINT", () => {
+  interrupted = true;
+  console.error("interrupt received; finishing the current decision…");
+});
+
+const counts = {
+  visited: 0,
+  variantsFetched: 0,
+  complete: 0,
+  retryable: 0,
+  emptyCelex: 0,
+};
+let lastVisited: string | null = null;
+let consecutiveFailures = 0;
+let haltReason: string | null = null;
+
+try {
+  for (const celex of plan) {
+    if (interrupted) {
+      haltReason = "interrupted";
+      break;
+    }
+    if (consecutiveFailures >= FAILURE_HALT_THRESHOLD) {
+      haltReason = `${FAILURE_HALT_THRESHOLD} consecutive CELEX failed`;
+      break;
+    }
+    counts.visited += 1;
+    lastVisited = celex;
+    let celexFailed = false;
+    try {
+      // oxlint-disable-next-line no-await-in-loop -- rate-limited publisher traffic stays sequential
+      const results = await fetchDecisionsByCelex({
+        celexNumbers: [celex],
+        signal: AbortSignal.timeout(CELEX_FETCH_TIMEOUT_MS),
+      });
+      if (results.length === 0) {
+        counts.emptyCelex += 1;
+      }
+      for (const result of results) {
+        counts.variantsFetched += 1;
+        // oxlint-disable-next-line no-await-in-loop -- observation orders are allocated sequentially under the lease
+        await sourceLease.beforeDatabaseMark();
+        // oxlint-disable-next-line no-await-in-loop -- observation orders are allocated sequentially under the lease
+        const observationOrder = await allocateSourceObservationOrder({
+          leaseToken: sourceLease.leaseToken,
+          scopedDb: ingestionDb,
+          sourceId: source.id,
+        });
+        // oxlint-disable-next-line no-await-in-loop -- each decision is one pipeline write
+        const processed = await processDecision({
+          input: result,
+          sourceId: source.id,
+          scopedDb: ingestionDb,
+          observedAt: new Date(),
+          observationOrder,
+          refresh: DECISION_REFRESH.ALWAYS,
+        });
+        if (processed.status === PROCESS_DECISION_STATUS.RETRYABLE) {
+          counts.retryable += 1;
+          celexFailed = true;
+          console.error(
+            `${celex} (${result.language}): retryable — ${processed.reason}`,
+          );
+        } else {
+          counts.complete += 1;
+        }
+      }
+    } catch (error) {
+      celexFailed = true;
+      console.error(`${celex}: failed —`, error);
+    }
+    consecutiveFailures = celexFailed ? consecutiveFailures + 1 : 0;
+    if (counts.visited % 25 === 0) {
+      console.error(
+        `progress: ${counts.visited}/${plan.length} celex, ${counts.complete} variants written`,
+      );
+    }
+    // oxlint-disable-next-line no-await-in-loop -- politeness pause between decisions, matching the crawl
+    await Bun.sleep(delayMs);
+  }
+} finally {
+  await sourceLease.release();
+}
+
+console.log("--- outcomes ---");
+console.log(`celex visited:     ${counts.visited} of ${plan.length}`);
+console.log(`variants fetched:  ${counts.variantsFetched}`);
+console.log(`written:           ${counts.complete}`);
+console.log(`retryable:         ${counts.retryable}`);
+console.log(`celex w/o results: ${counts.emptyCelex}`);
+if (haltReason !== null) {
+  console.log(`halted:            ${haltReason}`);
+}
+if (lastVisited !== null && counts.visited < plan.length) {
+  console.log(`resume with:       --after ${lastVisited}`);
+}
+process.exit(haltReason === null || haltReason === "interrupted" ? 0 : 1);

--- a/scripts/ratchet-baseline.json
+++ b/scripts/ratchet-baseline.json
@@ -89,7 +89,7 @@
     "files": {}
   },
   "lint-suppression-directives": {
-    "count": 583,
+    "count": 592,
     "files": {
       "apps/api/src/db/migrate.ts": 2,
       "apps/api/src/db/schema.ts": 1,
@@ -262,6 +262,8 @@
       "apps/api/src/scripts/backfill-property-roles.ts": 1,
       "apps/api/src/scripts/build-corpus-index.ts": 1,
       "apps/api/src/scripts/corpus-column-trim.ts": 2,
+      "apps/api/src/scripts/eu-ecj-census.ts": 3,
+      "apps/api/src/scripts/eu-ecj-refetch.ts": 6,
       "apps/api/src/scripts/post-deploy-smoke.ts": 3,
       "apps/api/src/scripts/redact-case-law-decision.ts": 1,
       "apps/api/src/scripts/repair-case-law-jsonb.ts": 1,


### PR DESCRIPTION
## Context

The stored eu-ecj corpus predates the CJEU parser: rows carry no AST, and the pre-parser crawl kept no raw payload, so the stored-raw replay cannot repair them (`CLAUDE.md` "Backfilling the CJEU corpus" documents this). Part of the corpus is page furniture stored for language variants the publisher never issued: the old fetch path returned a wrapper page for a missing translation, the fallback parser preserved its text (rule 10), and no guard fired because the result is a small but valid AST. The documented cursor-reset backfill walks ~27k publication days, almost all empty, which is intractable; this PR adds the tooling for a targeted, CELEX-driven backfill instead.

## What's added

- **`listCelexVariants`** (adapter): lists which language variants Cellar holds as XHTML for given CELEX numbers, through the same SPARQL query, filters, and language mapping as the crawl — no manifestation bodies fetched, and the listing cannot disagree with what a re-fetch would visit.
- **`eu-ecj-census.ts`**: classifies every stored `(CELEX, language)` pair against that listing into `refetchable` / `phantom` (CELEX listed, language not — the variant was never published) / `celexUnlisted` (nothing under the crawl's type+manifestation filters; deliberately not treated as phantom) / `missingCelex`. Reads only row identity and metadata in keyset pages; writes a report file and nothing else.
- **`eu-ecj-refetch.ts`**: visits the census's re-fetchable CELEX numbers through `fetchDecisionsByCelex` → `processDecision` under `DECISION_REFRESH.ALWAYS`, ordered on the source's observation counter under its ingestion lease so a run cannot interleave with a live crawl. Plan-only by default, one CELEX at a time with a politeness delay between decisions (matching the crawl's own pacing; `fetchDecisionsByCelex` has no internal delay), resumable via `--after`, halts after ten consecutive failed CELEX. Re-ingest regenerates the canonical corpus payload, rotates `content_hash`, and re-marks the row for search indexing through the pipeline's existing behavior — no new storage or index code.

## Notes for review

- Phantom rows are only *reported* here; removing them is a separate decision the census numbers inform.
- Both scripts are operator CLIs in the mold of `replay-case-law-source.ts`: deliberate operations under someone who reads the report, not scheduled jobs.
- `DECISION_REFRESH.ALWAYS` is deliberate: the publisher's document may hash identically while the payload the parser derives from it is what changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added tools to audit EU Court of Justice case-law coverage and identify missing or unavailable records.
  - Added resumable refetch workflows for recovering eligible EU case-law records, with progress reporting, rate limiting and retry handling.
  - Added support for discovering available CELEX language variants.

- **Bug Fixes**
  - Improved case-law indexing so incomplete generations continue processing and reach completion.
  - Prevented truncated results when EU case-law listings exceed configured query limits.

- **Tests**
  - Added coverage for completing backfills with no remaining indexed records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Baseline reseed

The lint-suppression ratchet baseline is regenerated for the new `no-await-in-loop` directives. All of them annotate intentionally sequential loops in the two operator CLIs (keyset pagination, rate-limited publisher traffic, observation-order allocation under the ingestion lease), each carrying its reason inline — the same shape `replay-case-law-source.ts` already uses.
