### PR TITLE
feat(case-law): resumable cursor for the corpus column trim

### DIFF
--- a/apps/api/src/scripts/corpus-column-trim-plan.test.ts
+++ b/apps/api/src/scripts/corpus-column-trim-plan.test.ts
@@ -213,22 +213,40 @@ describe("columnTrimGate", () => {
 });
 
 describe("parseColumnTrimArgs", () => {
-  test("defaults to an uncapped, mutating, gated run", () => {
+  test("defaults to an uncapped, mutating, gated run from the start", () => {
     expect(parseColumnTrimArgs([])).toEqual({
       type: "parsed",
-      args: { limit: null, dryRun: false, force: false },
+      args: { limit: null, after: null, dryRun: false, force: false },
     });
   });
 
   test("accepts both --limit forms alongside the flags", () => {
     expect(parseColumnTrimArgs(["--limit", "25", "--dry-run"])).toEqual({
       type: "parsed",
-      args: { limit: 25, dryRun: true, force: false },
+      args: { limit: 25, after: null, dryRun: true, force: false },
     });
     expect(parseColumnTrimArgs(["--limit=25", "--force"])).toEqual({
       type: "parsed",
-      args: { limit: 25, dryRun: false, force: true },
+      args: { limit: 25, after: null, dryRun: false, force: true },
     });
+  });
+
+  test("accepts both --after forms and requires a UUID", () => {
+    const id = "019dd0c5-f3bc-7000-84b2-cf5f7a95ce5f";
+    expect(parseColumnTrimArgs(["--after", id])).toEqual({
+      type: "parsed",
+      args: { limit: null, after: id, dryRun: false, force: false },
+    });
+    expect(parseColumnTrimArgs([`--after=${id}`, "--dry-run"])).toEqual({
+      type: "parsed",
+      args: { limit: null, after: id, dryRun: true, force: false },
+    });
+    for (const argv of [["--after"], ["--after", "not-a-uuid"]]) {
+      expect(parseColumnTrimArgs(argv)).toEqual({
+        type: "invalid",
+        message: "--after requires a decision id (UUID)",
+      });
+    }
   });
 
   test("rejects a non-positive, non-numeric, or absent limit", () => {

--- a/apps/api/src/scripts/corpus-column-trim-plan.ts
+++ b/apps/api/src/scripts/corpus-column-trim-plan.ts
@@ -177,6 +177,13 @@ export const columnTrimGate = ({
 export type ColumnTrimArgs = {
   /** null = no cap; process every candidate row. */
   limit: number | null;
+  /**
+   * Resume the keyset walk strictly after this decision id. A restart
+   * without it re-skips every already-trimmed row from the start of the
+   * id space, and once enough rows are trimmed that scan no longer fits a
+   * statement timeout: the run dies on its first page forever.
+   */
+  after: string | null;
   dryRun: boolean;
   force: boolean;
 };
@@ -193,10 +200,13 @@ const parseLimit = (raw: string | undefined): number | null => {
   return parsed > 0 ? parsed : null;
 };
 
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/u;
+
 export const parseColumnTrimArgs = (
   argv: readonly string[],
 ): ParsedColumnTrimArgs => {
   let limit: number | null = null;
+  let after: string | null = null;
   let dryRun = false;
   let force = false;
 
@@ -227,8 +237,21 @@ export const parseColumnTrimArgs = (
       limit = parsed;
       continue;
     }
+    if (argument === "--after" || argument.startsWith("--after=")) {
+      const raw = argument.startsWith("--after=")
+        ? argument.slice("--after=".length)
+        : argv[++i];
+      if (raw === undefined || !UUID.test(raw)) {
+        return {
+          type: "invalid",
+          message: "--after requires a decision id (UUID)",
+        };
+      }
+      after = raw;
+      continue;
+    }
     return { type: "invalid", message: `Unknown argument: ${argument}` };
   }
 
-  return { type: "parsed", args: { limit, dryRun, force } };
+  return { type: "parsed", args: { limit, after, dryRun, force } };
 };

--- a/apps/api/src/scripts/corpus-column-trim.ts
+++ b/apps/api/src/scripts/corpus-column-trim.ts
@@ -1,4 +1,4 @@
-import { and, asc, eq, gt, isNotNull, or, sql } from "drizzle-orm";
+import { and, asc, eq, gt, inArray, isNotNull, or, sql } from "drizzle-orm";
 import type { SQL } from "drizzle-orm";
 
 /**
@@ -30,7 +30,6 @@ import { corpusStorageMode } from "@/api/env-base";
 import { payloadCarriesDocument } from "@/api/handlers/case-law/stored-payload";
 import { captureError } from "@/api/lib/analytics/capture";
 import type { SafeId } from "@/api/lib/branded-types";
-import { toSafeId } from "@/api/lib/branded-types";
 import {
   timestampCasToken,
   type TimestampCasToken,
@@ -55,6 +54,7 @@ import {
   parseColumnTrimArgs,
   planColumnTrim,
 } from "@/api/scripts/corpus-column-trim-plan";
+import { toSafeId } from "@/api/types";
 
 const BATCH_SIZE = 50;
 const CONCURRENCY = 4;
@@ -106,6 +106,19 @@ let lastId: SafeId<"caseLawDecision"> | null =
 let trimmed = 0;
 let skipped = 0;
 let failed = 0;
+/** Rows whose first attempt threw; re-attempted by id before the summary. */
+const failedIds: SafeId<"caseLawDecision">[] = [];
+
+const TRIM_ROW_COLUMNS = {
+  id: caseLawDecisions.id,
+  textS3Key: caseLawDecisions.textS3Key,
+  normalizedS3Key: caseLawDecisions.normalizedS3Key,
+  astS3Key: caseLawDecisions.astS3Key,
+  contentHash: caseLawDecisions.contentHash,
+  fulltext: caseLawDecisions.fulltext,
+  sections: caseLawDecisions.sections,
+  documentAst: caseLawDecisions.documentAst,
+};
 let scanned = 0;
 
 // Rows whose payload is in object storage but whose Postgres columns are
@@ -269,7 +282,15 @@ const trimRow = async (row: TrimRow): Promise<void> => {
     console.log(`  skip ${row.id}: row changed under the scan`);
   } catch (error) {
     failed += 1;
+    failedIds.push(row.id);
     captureError(error, { decisionId: row.id, step: "corpusColumnTrim" });
+  }
+};
+
+const trimInChunks = async (rows: TrimRow[]): Promise<void> => {
+  for (let i = 0; i < rows.length; i += CONCURRENCY) {
+    // oxlint-disable-next-line no-await-in-loop, no-db-await-in-loop/no-db-await-in-loop -- bounded concurrency: drain one CONCURRENCY-sized chunk before starting the next
+    await Promise.all(rows.slice(i, i + CONCURRENCY).map(trimRow));
   }
 };
 
@@ -286,14 +307,7 @@ while (true) {
   const rows: TrimRow[] = await ingestionDb((tx) =>
     tx
       .select({
-        id: caseLawDecisions.id,
-        textS3Key: caseLawDecisions.textS3Key,
-        normalizedS3Key: caseLawDecisions.normalizedS3Key,
-        astS3Key: caseLawDecisions.astS3Key,
-        contentHash: caseLawDecisions.contentHash,
-        fulltext: caseLawDecisions.fulltext,
-        sections: caseLawDecisions.sections,
-        documentAst: caseLawDecisions.documentAst,
+        ...TRIM_ROW_COLUMNS,
         updatedAtToken: timestampCasToken(caseLawDecisions.updatedAt),
       })
       .from(caseLawDecisions)
@@ -306,16 +320,38 @@ while (true) {
     break;
   }
 
-  for (let i = 0; i < rows.length; i += CONCURRENCY) {
-    // oxlint-disable-next-line no-await-in-loop, no-db-await-in-loop/no-db-await-in-loop -- bounded concurrency: drain one CONCURRENCY-sized chunk before starting the next
-    await Promise.all(rows.slice(i, i + CONCURRENCY).map(trimRow));
-  }
+  await trimInChunks(rows);
 
   scanned += rows.length;
   lastId = rows.at(-1)?.id ?? lastId;
   console.log(
     `  trimmed=${trimmed} skipped=${skipped} failed=${failed} cursor=${lastId}`,
   );
+}
+
+// A failed row sits behind the published cursor, so a supervisor resuming
+// from a progress line would never revisit it, and a later clean run would
+// mask it. Re-attempt each one by id — indexed lookups, no prefix scan —
+// so a transient failure heals inside the run; only rows failing twice
+// reach the summary, printed with ids an operator can act on directly.
+if (failedIds.length > 0) {
+  console.log(`retrying ${failedIds.length} failed row(s) by id`);
+  const retryIds = [...failedIds];
+  failedIds.length = 0;
+  failed = 0;
+  const retryRows: TrimRow[] = await ingestionDb((tx) =>
+    tx
+      .select({
+        ...TRIM_ROW_COLUMNS,
+        updatedAtToken: timestampCasToken(caseLawDecisions.updatedAt),
+      })
+      .from(caseLawDecisions)
+      .where(and(candidateFilter, inArray(caseLawDecisions.id, retryIds))),
+  );
+  await trimInChunks(retryRows);
+  for (const id of failedIds) {
+    console.log(`failed-row=${id}`);
+  }
 }
 
 console.log(

--- a/apps/api/src/scripts/corpus-column-trim.ts
+++ b/apps/api/src/scripts/corpus-column-trim.ts
@@ -320,6 +320,7 @@ while (true) {
     break;
   }
 
+  // oxlint-disable-next-line no-await-in-loop -- sequential keyset pages: the next page's cursor depends on this one completing
   await trimInChunks(rows);
 
   scanned += rows.length;

--- a/apps/api/src/scripts/corpus-column-trim.ts
+++ b/apps/api/src/scripts/corpus-column-trim.ts
@@ -30,6 +30,7 @@ import { corpusStorageMode } from "@/api/env-base";
 import { payloadCarriesDocument } from "@/api/handlers/case-law/stored-payload";
 import { captureError } from "@/api/lib/analytics/capture";
 import type { SafeId } from "@/api/lib/branded-types";
+import { toSafeId } from "@/api/lib/branded-types";
 import {
   timestampCasToken,
   type TimestampCasToken,
@@ -76,7 +77,7 @@ if (parsed.type === "invalid") {
   console.error(parsed.message);
   process.exit(2);
 }
-const { limit, dryRun, force } = parsed.args;
+const { limit, after, dryRun, force } = parsed.args;
 
 const gate = columnTrimGate({ mode: corpusStorageMode, force });
 if (gate.type === "refused") {
@@ -96,7 +97,12 @@ const runLabel = [
 
 console.log(`=== CORPUS COLUMN TRIM (${runLabel}) ===`);
 
-let lastId: SafeId<"caseLawDecision"> | null = null;
+// Resuming from --after keeps a restart's first page from re-skipping the
+// whole trimmed prefix of the id space, a scan that stops fitting a
+// statement timeout once enough rows are trimmed. The cursor rides on every
+// progress line, so a supervisor can pass the last one back in.
+let lastId: SafeId<"caseLawDecision"> | null =
+  after === null ? null : toSafeId<"caseLawDecision">(after);
 let trimmed = 0;
 let skipped = 0;
 let failed = 0;
@@ -307,7 +313,9 @@ while (true) {
 
   scanned += rows.length;
   lastId = rows.at(-1)?.id ?? lastId;
-  console.log(`  trimmed=${trimmed} skipped=${skipped} failed=${failed}`);
+  console.log(
+    `  trimmed=${trimmed} skipped=${skipped} failed=${failed} cursor=${lastId}`,
+  );
 }
 
 console.log(

--- a/scripts/ratchet-baseline.json
+++ b/scripts/ratchet-baseline.json
@@ -89,7 +89,7 @@
     "files": {}
   },
   "lint-suppression-directives": {
-    "count": 592,
+    "count": 593,
     "files": {
       "apps/api/src/db/migrate.ts": 2,
       "apps/api/src/db/schema.ts": 1,
@@ -261,7 +261,7 @@
       "apps/api/src/scripts/backfill-fulltext.ts": 6,
       "apps/api/src/scripts/backfill-property-roles.ts": 1,
       "apps/api/src/scripts/build-corpus-index.ts": 1,
-      "apps/api/src/scripts/corpus-column-trim.ts": 2,
+      "apps/api/src/scripts/corpus-column-trim.ts": 3,
       "apps/api/src/scripts/eu-ecj-census.ts": 3,
       "apps/api/src/scripts/eu-ecj-refetch.ts": 6,
       "apps/api/src/scripts/post-deploy-smoke.ts": 3,


### PR DESCRIPTION
## Defect

The column trim's keyset walk restarts from the top of the id space: every restart re-skips the whole already-trimmed prefix before reaching its first candidate. Once enough rows are trimmed, that first-page scan stops fitting a statement timeout, and every attempt dies on its first page — a supervising retry loop turns into a permanent restart cycle that trims nothing.

## Fix

- `--after <decision id>` resumes the walk strictly after a cursor, validated as a UUID at the argument boundary.
- Every progress line carries the current cursor, so a supervising loop can persist the last one and pass it back in on restart.
- Parser covered for both flag forms and rejection of malformed ids.

Rows behind a resumed cursor that failed or were skipped stay reachable: a final pass without `--after` sweeps them once the bulk of the walk is done and the prefix scan fits again.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added resumable corpus column trimming using an `--after <decision ID>` cursor.
  * Supports both spaced and equals-sign argument formats.
  * Progress output now reports the cursor needed to continue a later run.
  * Supports combining the cursor with dry-run mode.

* **Bug Fixes**
  * Added validation and clear errors for missing or invalid decision IDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Baseline reseed

The lint-suppression baseline is reseeded for one net no-await-in-loop directive: the page loop awaits its chunked trims sequentially by design (the next keyset page depends on the previous one completing), with the reason inline.
