### PR TITLE
fix(web): seal the runner image and gate boot on the full SSR module graph

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,9 +202,13 @@ jobs:
                 ;;
             esac
             # The runner-image filesystem boundary: anything that changes what
-            # the image ships or how its runtime closure is staged.
+            # the image ships or how its runtime closure is staged. Workspace
+            # manifests shape staging (exports maps, build scripts) and
+            # vite.config.ts decides what stays external to the SSR bundle;
+            # ordinary app-source changes are covered by web-build's cheaper
+            # in-checkout boot smoke instead of a full image build.
             case "$file" in
-              apps/web/Dockerfile|apps/web/start-runtime.js|scripts/stage-web-runtime.ts|scripts/publish-manifest.ts|scripts/web-runtime-closure.ts|bun.lock|.dockerignore|.github/workflows/ci.yml)
+              apps/web/Dockerfile|apps/web/start-runtime.js|apps/web/vite.config.ts|packages/*/package.json|scripts/stage-web-runtime.ts|scripts/publish-manifest.ts|scripts/web-runtime-closure.ts|bun.lock|.dockerignore|.github/workflows/ci.yml)
                 web_image_smoke_required=true
                 ;;
             esac

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,7 @@ jobs:
       ocr_image_required: ${{ steps.changed-files.outputs.ocr_image_required }}
       package_checks_required: ${{ steps.changed-files.outputs.package_checks_required }}
       web_build_required: ${{ steps.changed-files.outputs.web_build_required }}
+      web_image_smoke_required: ${{ steps.changed-files.outputs.web_image_smoke_required }}
       windows_scripts_required: ${{ steps.changed-files.outputs.windows_scripts_required }}
     steps:
       - name: Check if PR is trusted
@@ -102,6 +103,7 @@ jobs:
               echo "ocr_image_required=true"
               echo "package_checks_required=true"
               echo "web_build_required=true"
+              echo "web_image_smoke_required=true"
               echo "windows_scripts_required=true"
             } >> "$GITHUB_OUTPUT"
             exit 0
@@ -123,6 +125,7 @@ jobs:
               echo "ocr_image_required=false"
               echo "package_checks_required=true"
               echo "web_build_required=false"
+              echo "web_image_smoke_required=false"
               echo "windows_scripts_required=false"
             } >> "$GITHUB_OUTPUT"
             exit 0
@@ -155,6 +158,7 @@ jobs:
           mobile_build_required=false
           ocr_image_required=false
           web_build_required=false
+          web_image_smoke_required=false
           windows_scripts_required=false
           for file in "${changed_files[@]}"; do
             case "$file" in
@@ -197,6 +201,13 @@ jobs:
                 windows_scripts_required=true
                 ;;
             esac
+            # The runner-image filesystem boundary: anything that changes what
+            # the image ships or how its runtime closure is staged.
+            case "$file" in
+              apps/web/Dockerfile|apps/web/start-runtime.js|scripts/stage-web-runtime.ts|scripts/publish-manifest.ts|scripts/web-runtime-closure.ts|bun.lock|.dockerignore|.github/workflows/ci.yml)
+                web_image_smoke_required=true
+                ;;
+            esac
           done
 
           # The production e2e shards consume web-build's artifact, so any
@@ -219,6 +230,7 @@ jobs:
             echo "ocr_image_required=$ocr_image_required"
             echo "package_checks_required=$package_checks_required"
             echo "web_build_required=$web_build_required"
+            echo "web_image_smoke_required=$web_image_smoke_required"
             echo "windows_scripts_required=$windows_scripts_required"
           } >> "$GITHUB_OUTPUT"
 
@@ -797,6 +809,13 @@ jobs:
       - name: Test @stll resolution pin
         run: bun test scripts/stll-registry-resolutions.test.ts
 
+      # The runner image stages workspace packages reached by externalized
+      # runtime dependencies. Guard the closure derivation and the
+      # manifest-only-fails / staged-succeeds property.
+      - name: Test web runtime staging
+        if: needs.ci-plan.outputs.package_checks_required == 'true'
+        run: bun test scripts/stage-web-runtime.test.ts
+
       # Release ordering is a safety property. This test has no workspace
       # dependencies, so it remains runnable when a PR changes only workflows
       # and the dependency install above is intentionally skipped.
@@ -1098,9 +1117,11 @@ jobs:
         # apps/web/Dockerfile's runner installs --production (deps-prod stage).
         # Reproduce that clean production tree and boot start-runtime.js: a
         # devDependency reached by the SSR server bundle (dist/server/server.js)
-        # fails to resolve here rather than at deploy time. /health is served by
-        # the runtime wrapper, so a clean boot proves the production module graph
-        # resolves.
+        # fails to resolve here rather than at deploy time. start-runtime.js
+        # imports the full server module graph before serving, so a reachable
+        # /health proves every chunk's dependencies resolve — but only against
+        # this checkout's filesystem; the web-image-smoke job covers the
+        # runner image's stricter boundary.
         env:
           NPM_TOKEN: ""
         run: |
@@ -1129,6 +1150,61 @@ jobs:
             echo "web SSR runtime failed to boot under --production deps" >&2
             exit 1
           fi
+
+  # The prod-deps boot smoke above runs inside a full checkout, where
+  # workspace sources exist and can mask the runner image's filesystem
+  # boundary. Build the real runner
+  # image: the Dockerfile stages the runtime workspace closure and proves the
+  # full server module graph resolves (`start-runtime.js --smoke`) against
+  # the exact tree that ships, then boot the container across that boundary.
+  web-image-smoke:
+    needs: ci-plan
+    if: >-
+      (needs.ci-plan.outputs.trusted == 'true'
+       || github.event_name == 'workflow_dispatch')
+      && needs.ci-plan.outputs.web_image_smoke_required == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Build runner image
+        run: >-
+          docker build
+          --file apps/web/Dockerfile
+          --build-arg PUBLIC_API_URL=https://api.smoke.invalid
+          --build-arg PUBLIC_APP_URL=https://app.smoke.invalid
+          --tag stella-web-runner:ci
+          .
+
+      - name: Boot runner container
+        run: |
+          set -euo pipefail
+          docker run --detach --name web-runner \
+            --publish 127.0.0.1:3199:3002 stella-web-runner:ci
+          ready=
+          for _ in $(seq 1 60); do
+            if curl -fsS http://127.0.0.1:3199/health >/dev/null 2>&1; then
+              ready=1
+              break
+            fi
+            sleep 1
+          done
+          docker logs web-runner
+          if [[ "$ready" != "1" ]]; then
+            echo "web runner image failed to serve /health" >&2
+            exit 1
+          fi
+
+      - name: Cleanup runner container
+        if: always()
+        run: docker rm --force web-runner 2>/dev/null || true
 
   # Expo/Metro bundle smoke. TypeScript and lint do not exercise Babel,
   # autolinking, or platform-specific module resolution, so keep one path-
@@ -1974,6 +2050,7 @@ jobs:
         postgres-suites,
         typecheck-baseline,
         web-build,
+        web-image-smoke,
         mobile-build,
         landing-build,
         e2e,
@@ -2006,6 +2083,7 @@ jobs:
           POSTGRES_SUITES_RESULT: ${{ needs.postgres-suites.result }}
           TYPECHECK_BASELINE_RESULT: ${{ needs.typecheck-baseline.result }}
           WEB_RESULT: ${{ needs.web-build.result }}
+          WEB_IMAGE_SMOKE_RESULT: ${{ needs.web-image-smoke.result }}
           WINDOWS_SCRIPTS_RESULT: ${{ needs.windows-scripts.result }}
         run: |
           # When the CI plan was skipped (draft PR or
@@ -2023,6 +2101,7 @@ jobs:
                   || "$POSTGRES_SUITES_RESULT" == "failure" || "$POSTGRES_SUITES_RESULT" == "cancelled" \
                   || "$TYPECHECK_BASELINE_RESULT" == "failure" || "$TYPECHECK_BASELINE_RESULT" == "cancelled" \
                   || "$WEB_RESULT" == "failure" || "$WEB_RESULT" == "cancelled" \
+                  || "$WEB_IMAGE_SMOKE_RESULT" == "failure" || "$WEB_IMAGE_SMOKE_RESULT" == "cancelled" \
                   || "$MOBILE_RESULT" == "failure" || "$MOBILE_RESULT" == "cancelled" \
                   || "$LANDING_RESULT" == "failure" || "$LANDING_RESULT" == "cancelled" \
                   || "$E2E_RESULT" == "failure" || "$E2E_RESULT" == "cancelled" \
@@ -2056,12 +2135,12 @@ jobs:
 
           # "cancelled" means cancel-in-progress replaced this
           # run with a newer one; the newer run is authoritative.
-          if [[ "$AGENT_SANDBOX_DOCKER_RESULT" == "cancelled" || "$CI_RESULT" == "cancelled" || "$CODE_QUALITY_RESULT" == "cancelled" || "$POSTGRES_SUITES_RESULT" == "cancelled" || "$TYPECHECK_BASELINE_RESULT" == "cancelled" || "$WEB_RESULT" == "cancelled" || "$MOBILE_RESULT" == "cancelled" || "$LANDING_RESULT" == "cancelled" || "$E2E_RESULT" == "cancelled" || "$API_IMAGE_DEPS_RESULT" == "cancelled" || "$OCR_IMAGE_RESULT" == "cancelled" || "$LEGAL_ATLAS_IMAGE_RESULT" == "cancelled" || "$WINDOWS_SCRIPTS_RESULT" == "cancelled" || "$CHANGESET_RESULT" == "cancelled" || "$DESKTOP_CLIPPY_RESULT" == "cancelled" ]]; then
+          if [[ "$AGENT_SANDBOX_DOCKER_RESULT" == "cancelled" || "$CI_RESULT" == "cancelled" || "$CODE_QUALITY_RESULT" == "cancelled" || "$POSTGRES_SUITES_RESULT" == "cancelled" || "$TYPECHECK_BASELINE_RESULT" == "cancelled" || "$WEB_RESULT" == "cancelled" || "$WEB_IMAGE_SMOKE_RESULT" == "cancelled" || "$MOBILE_RESULT" == "cancelled" || "$LANDING_RESULT" == "cancelled" || "$E2E_RESULT" == "cancelled" || "$API_IMAGE_DEPS_RESULT" == "cancelled" || "$OCR_IMAGE_RESULT" == "cancelled" || "$LEGAL_ATLAS_IMAGE_RESULT" == "cancelled" || "$WINDOWS_SCRIPTS_RESULT" == "cancelled" || "$CHANGESET_RESULT" == "cancelled" || "$DESKTOP_CLIPPY_RESULT" == "cancelled" ]]; then
             echo "CI run was superseded by a newer run (cancel-in-progress). Passing."
             exit 0
           fi
 
-          if [[ "$AGENT_SANDBOX_DOCKER_RESULT" == "failure" || "$CI_RESULT" == "failure" || "$CODE_QUALITY_RESULT" == "failure" || "$POSTGRES_SUITES_RESULT" == "failure" || "$TYPECHECK_BASELINE_RESULT" == "failure" || "$WEB_RESULT" == "failure" || "$MOBILE_RESULT" == "failure" || "$LANDING_RESULT" == "failure" || "$E2E_RESULT" == "failure" || "$API_IMAGE_DEPS_RESULT" == "failure" || "$OCR_IMAGE_RESULT" == "failure" || "$LEGAL_ATLAS_IMAGE_RESULT" == "failure" || "$WINDOWS_SCRIPTS_RESULT" == "failure" || "$CHANGESET_RESULT" == "failure" || "$DESKTOP_CLIPPY_RESULT" == "failure" ]]; then
+          if [[ "$AGENT_SANDBOX_DOCKER_RESULT" == "failure" || "$CI_RESULT" == "failure" || "$CODE_QUALITY_RESULT" == "failure" || "$POSTGRES_SUITES_RESULT" == "failure" || "$TYPECHECK_BASELINE_RESULT" == "failure" || "$WEB_RESULT" == "failure" || "$WEB_IMAGE_SMOKE_RESULT" == "failure" || "$MOBILE_RESULT" == "failure" || "$LANDING_RESULT" == "failure" || "$E2E_RESULT" == "failure" || "$API_IMAGE_DEPS_RESULT" == "failure" || "$OCR_IMAGE_RESULT" == "failure" || "$LEGAL_ATLAS_IMAGE_RESULT" == "failure" || "$WINDOWS_SCRIPTS_RESULT" == "failure" || "$CHANGESET_RESULT" == "failure" || "$DESKTOP_CLIPPY_RESULT" == "failure" ]]; then
             echo "::error::CI checks failed."
             exit 1
           fi

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -125,6 +125,20 @@ RUN VITE_API_URL="${PUBLIC_API_URL}" \
     VITE_SELFHOST="${VITE_SELFHOST}" \
     VITE_TERMS_URL="${VITE_TERMS_URL}" \
     bun --filter @stll/web build
+# Stage the workspace packages reached by externalized runtime dependencies
+# (closure derived from bun.lock) in their published dist shape. The runner
+# overlays this tree so it never resolves TypeScript source. Restore the
+# committed root manifest first: the out/full copy above overwrote it with
+# Turbo's pruned root package.json (an explicit workspace subset), and the
+# staging install resolving that subset against the committed lockfile fails
+# --frozen-lockfile. bun.lock is restored defensively alongside it: today
+# out/full carries no lockfile (Turbo emits its pruned one at out/bun.lock,
+# which no stage copies), so the committed one from the deps stage survives,
+# but this install must never depend on that staying true.
+COPY --from=install-inputs /json/bun.lock /json/package.json ./
+COPY --from=pruner /app/scripts/publish-manifest.ts /app/scripts/stage-web-runtime.ts /app/scripts/web-runtime-closure.ts ./scripts/
+RUN --mount=type=cache,target=/root/.bun/install/cache \
+    bun scripts/stage-web-runtime.ts /app/web-runtime-stage --install-build-deps
 
 FROM deps-prod AS runner
 ENV NODE_ENV=production
@@ -133,16 +147,18 @@ ENV PORT=3002
 RUN groupadd --system --gid 1001 stella && \
     useradd --system --uid 1001 --gid stella --no-create-home stella
 # Bun links workspace dependencies into /app/packages. Folio remains external
-# to the SSR bundle and imports these source-exporting workspaces at runtime;
-# keep that exact dependency closure without restoring the full pruned tree.
+# to the SSR bundle and imports those workspaces at runtime; overlay the
+# staged dist-shaped closure (derived from bun.lock at build time) onto the
+# manifest tree so the runner never ships or resolves TypeScript source.
 COPY --chown=stella:stella --from=pruner /app/out/json/ .
-COPY --chown=stella:stella --from=pruner /app/out/full/packages/conditions/src ./packages/conditions/src
-COPY --chown=stella:stella --from=pruner /app/out/full/packages/docx-utils/src ./packages/docx-utils/src
-COPY --chown=stella:stella --from=pruner /app/out/full/packages/template-conditions/src ./packages/template-conditions/src
+COPY --chown=stella:stella --from=builder /app/web-runtime-stage/ .
 COPY --chown=stella:stella --from=builder /app/apps/web/start-runtime.js ./apps/web/start-runtime.js
 COPY --chown=stella:stella --from=builder /app/apps/web/dist ./apps/web/dist
 WORKDIR /app/apps/web
-RUN bun -e 'await import("@stll/folio-core/docx/xmlParser"); await import("@stll/folio-core/prosemirror/plugins/templateDirectives")'
+# Prove the full production module graph resolves inside this filesystem
+# before the image can exist; a missing runtime dependency fails the build,
+# not the rollout.
+RUN bun start-runtime.js --smoke
 USER stella
 EXPOSE 3002
 CMD ["bun", "start-runtime.js"]

--- a/apps/web/start-runtime.js
+++ b/apps/web/start-runtime.js
@@ -1,4 +1,5 @@
 import { env, file, serve } from "bun";
+import { fileURLToPath } from "node:url";
 
 import handler from "./dist/server/server.js";
 
@@ -41,6 +42,85 @@ const createStartHandler = (candidate) => {
 };
 
 const startHandler = createStartHandler(handler);
+
+const SERVER_DIST_URL = new URL("dist/server/", import.meta.url);
+
+/**
+ * @param {unknown} error Import failure.
+ * @returns {boolean} Whether the failure is a module-resolution error.
+ */
+const isResolutionError = (error) =>
+  typeof error === "object" &&
+  error !== null &&
+  (("name" in error && error.name === "ResolveMessage") ||
+    ("code" in error && error.code === "ERR_MODULE_NOT_FOUND"));
+
+/**
+ * Import the entire server module graph before accepting traffic.
+ *
+ * The SSR bundle externalizes npm dependencies and splits routes into lazily
+ * imported chunks, so a missing runtime dependency otherwise surfaces on the
+ * first request that reaches it — after the deploy's health checks passed and
+ * the previous tasks drained. Loading every chunk here turns that class into
+ * a boot failure: the rollout never becomes healthy and the previous release
+ * keeps serving.
+ *
+ * Only resolution failures are fatal. Some route chunks are browser-only and
+ * throw on evaluation outside a browser (e.g. module-scope `window` reads);
+ * ESM links the full static subtree before evaluating, so tolerating those
+ * cannot hide a resolution failure.
+ *
+ * @returns {Promise<number>} Number of server modules resolved.
+ */
+const loadServerModuleGraph = async () => {
+  const chunkGlob = new Bun.Glob("**/*.js");
+  const chunkPaths = await Array.fromAsync(
+    chunkGlob.scan({ cwd: fileURLToPath(SERVER_DIST_URL) }),
+  );
+  if (chunkPaths.length === 0) {
+    throw new Error("dist/server contains no modules; broken build output");
+  }
+
+  const results = await Promise.all(
+    chunkPaths.map(async (chunkPath) => {
+      try {
+        await import(new URL(chunkPath, SERVER_DIST_URL).href);
+        return null;
+      } catch (error) {
+        return { chunkPath, error };
+      }
+    }),
+  );
+  const failures = results.filter((result) => result !== null);
+  const describe = ({ chunkPath, error }) =>
+    `dist/server/${chunkPath}: ${error instanceof Error ? error.message : String(error)}`;
+  for (const failure of failures.filter(
+    ({ error }) => !isResolutionError(error),
+  )) {
+    // eslint-disable-next-line no-console -- boot boundary; the wrapper has no logger and this must reach container logs
+    console.warn(
+      `server chunk threw on evaluation (browser-only chunk, tolerated) — ${describe(failure)}`,
+    );
+  }
+  const fatal = failures.filter(({ error }) => isResolutionError(error));
+  if (fatal.length > 0) {
+    throw new Error(
+      `server module graph failed to resolve:\n${fatal.map(describe).join("\n")}`,
+    );
+  }
+
+  return chunkPaths.length - failures.length;
+};
+
+const serverModuleCount = await loadServerModuleGraph();
+
+// `--smoke` proves the graph resolves inside a candidate filesystem (the
+// Docker runner stage, CI) without binding a port, then exits.
+if (process.argv.includes("--smoke")) {
+  // eslint-disable-next-line no-console -- smoke-mode proof line for image build and CI logs
+  console.log(`web runtime ok: ${serverModuleCount} server modules resolved`);
+  process.exit(0);
+}
 
 /**
  * @param {Response} response Response to make compatible with wasm worker isolation.

--- a/apps/web/start-runtime.js
+++ b/apps/web/start-runtime.js
@@ -47,13 +47,17 @@ const SERVER_DIST_URL = new URL("dist/server/", import.meta.url);
 
 /**
  * @param {unknown} error Import failure.
- * @returns {boolean} Whether the failure is a module-resolution error.
+ * @returns {boolean} Whether the failure broke module resolution or linking.
  */
-const isResolutionError = (error) =>
+const isModuleGraphError = (error) =>
   typeof error === "object" &&
   error !== null &&
   (("name" in error && error.name === "ResolveMessage") ||
-    ("code" in error && error.code === "ERR_MODULE_NOT_FOUND"));
+    ("code" in error && error.code === "ERR_MODULE_NOT_FOUND") ||
+    // Linking failures (e.g. an import binding the resolved file does not
+    // export) surface as SyntaxError, never from evaluating browser-only
+    // code — evaluation happens after the whole subtree linked.
+    error instanceof SyntaxError);
 
 /**
  * Import the entire server module graph before accepting traffic.
@@ -65,10 +69,10 @@ const isResolutionError = (error) =>
  * a boot failure: the rollout never becomes healthy and the previous release
  * keeps serving.
  *
- * Only resolution failures are fatal. Some route chunks are browser-only and
- * throw on evaluation outside a browser (e.g. module-scope `window` reads);
- * ESM links the full static subtree before evaluating, so tolerating those
- * cannot hide a resolution failure.
+ * Only resolution and linking failures are fatal. Some route chunks are
+ * browser-only and throw on evaluation outside a browser (e.g. module-scope
+ * `window` reads); ESM links the full static subtree before evaluating, so
+ * tolerating those cannot hide a broken module graph.
  *
  * @returns {Promise<number>} Number of server modules resolved.
  */
@@ -92,17 +96,18 @@ const loadServerModuleGraph = async () => {
     }),
   );
   const failures = results.filter((result) => result !== null);
+  /** @param {{ chunkPath: string, error: unknown }} failure Failed chunk import. */
   const describe = ({ chunkPath, error }) =>
     `dist/server/${chunkPath}: ${error instanceof Error ? error.message : String(error)}`;
   for (const failure of failures.filter(
-    ({ error }) => !isResolutionError(error),
+    ({ error }) => !isModuleGraphError(error),
   )) {
     // eslint-disable-next-line no-console -- boot boundary; the wrapper has no logger and this must reach container logs
     console.warn(
       `server chunk threw on evaluation (browser-only chunk, tolerated) — ${describe(failure)}`,
     );
   }
-  const fatal = failures.filter(({ error }) => isResolutionError(error));
+  const fatal = failures.filter(({ error }) => isModuleGraphError(error));
   if (fatal.length > 0) {
     throw new Error(
       `server module graph failed to resolve:\n${fatal.map(describe).join("\n")}`,

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -854,6 +854,13 @@ export default defineConfig({
       rules: { "no-bare-error/no-bare-error": "off" },
     },
     {
+      // The web runtime boot wrapper must stay dependency-free: importing
+      // better-result would itself rely on the runtime module resolution
+      // the wrapper exists to verify before serving traffic.
+      files: ["apps/web/start-runtime.js"],
+      rules: { "no-bare-error/no-bare-error": "off" },
+    },
+    {
       // Test-only adapter helper consumed exclusively from
       // `**/*.test.ts`. Not part of any production code path.
       files: [

--- a/scripts/check-web-docker-platform.test.ts
+++ b/scripts/check-web-docker-platform.test.ts
@@ -60,27 +60,37 @@ describe("web container platform boundary", () => {
     expect(crossPlatformCopies).toEqual([
       "deps-prod: COPY --from=install-inputs /json/ .",
       "runner: COPY --chown=stella:stella --from=pruner /app/out/json/ .",
-      ...runtimeWorkspacePaths.map(
-        (workspacePath) =>
-          `runner: COPY --chown=stella:stella --from=pruner /app/out/full/${workspacePath}/src ./${workspacePath}/src`,
-      ),
+      "runner: COPY --chown=stella:stella --from=builder /app/web-runtime-stage/ .",
       "runner: COPY --chown=stella:stella --from=builder /app/apps/web/start-runtime.js ./apps/web/start-runtime.js",
       "runner: COPY --chown=stella:stella --from=builder /app/apps/web/dist ./apps/web/dist",
     ]);
   });
 
-  test("ships only the workspace source required by external runtime packages", () => {
+  test("seals the runtime against workspace TypeScript source", () => {
+    const builder = stagesByName.get("builder");
+    expect(builder?.body).toContain(
+      "bun scripts/stage-web-runtime.ts /app/web-runtime-stage --install-build-deps",
+    );
+    // The committed lockfile and root manifest drive the staged closure and
+    // its install; Turbo's pruned approximations in out/full must not.
+    expect(builder?.body).toContain(
+      "COPY --from=install-inputs /json/bun.lock /json/package.json ./",
+    );
+
     const runner = stagesByName.get("runner");
-    expect(runner?.body).not.toContain("/app/out/full/ .");
+    // The pruned source tree (out/full) belongs to the build stages only; the
+    // runtime gets manifests, the staged dist closure, the server entry, and
+    // dist/.
+    expect(runner?.body).not.toContain("out/full");
     expect(runner?.body).toContain(
       "COPY --chown=stella:stella --from=pruner /app/out/json/ .",
     );
     expect(runner?.body).toContain(
-      'await import("@stll/folio-core/docx/xmlParser")',
+      "COPY --chown=stella:stella --from=builder /app/web-runtime-stage/ .",
     );
-    expect(runner?.body).toContain(
-      'await import("@stll/folio-core/prosemirror/plugins/templateDirectives")',
-    );
+    // Boot-time proof that the whole production module graph resolves inside
+    // the image filesystem: a missing runtime dependency fails the build.
+    expect(runner?.body).toContain("RUN bun start-runtime.js --smoke");
   });
 
   test("uses the same pinned multi-architecture base for build and runtime", () => {
@@ -116,95 +126,6 @@ function parseStages(source: string): DockerStage[] {
 
   return parsed;
 }
-
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === "object" && value !== null && !Array.isArray(value);
-
-const readDependencyNames = (manifest: unknown): string[] => {
-  if (!isRecord(manifest)) {
-    return [];
-  }
-
-  const dependencies = manifest["dependencies"];
-  return isRecord(dependencies) ? Object.keys(dependencies) : [];
-};
-
-type ResolvedPackage = {
-  dependencyNames: string[];
-  workspacePath: string | undefined;
-};
-
-const findExternalRuntimeWorkspacePaths = (source: unknown): string[] => {
-  if (!isRecord(source)) {
-    throw new TypeError("bun.lock must contain an object");
-  }
-
-  const packages = source["packages"];
-  const workspaces = source["workspaces"];
-  if (!isRecord(packages) || !isRecord(workspaces)) {
-    throw new TypeError("bun.lock must contain packages and workspaces maps");
-  }
-
-  const resolvePackage = (name: string): ResolvedPackage | undefined => {
-    const entry = packages[name];
-    if (!Array.isArray(entry)) {
-      return undefined;
-    }
-
-    const resolution = entry.at(0);
-    if (typeof resolution !== "string") {
-      throw new TypeError(`bun.lock package ${name} has no resolution`);
-    }
-
-    const workspaceMarker = "@workspace:";
-    const markerIndex = resolution.indexOf(workspaceMarker);
-    if (markerIndex !== -1) {
-      const workspacePath = resolution.slice(
-        markerIndex + workspaceMarker.length,
-      );
-      return {
-        dependencyNames: readDependencyNames(workspaces[workspacePath]),
-        workspacePath,
-      };
-    }
-
-    return {
-      dependencyNames: readDependencyNames(entry.at(2)),
-      workspacePath: undefined,
-    };
-  };
-
-  const webWorkspace = workspaces["apps/web"];
-  const queue = readDependencyNames(webWorkspace).filter(
-    (name) => resolvePackage(name)?.workspacePath === undefined,
-  );
-  const visited = new Set<string>();
-  const runtimeWorkspaces = new Set<string>();
-
-  while (queue.length > 0) {
-    const name = queue.shift();
-    if (name === undefined || visited.has(name)) {
-      continue;
-    }
-    visited.add(name);
-
-    const resolved = resolvePackage(name);
-    if (!resolved) {
-      continue;
-    }
-    if (resolved.workspacePath) {
-      runtimeWorkspaces.add(resolved.workspacePath);
-    }
-    queue.push(...resolved.dependencyNames);
-  }
-
-  return [...runtimeWorkspaces].sort();
-};
-
-const lockfilePath = new URL("../bun.lock", import.meta.url);
-const runtimeWorkspacePaths = findExternalRuntimeWorkspacePaths(
-  Bun.JSONC.parse(await Bun.file(lockfilePath).text()),
-);
 
 function resolvePlatform(stageName: string, seen = new Set<string>()): string {
   if (seen.has(stageName)) {

--- a/scripts/prepare-publish.ts
+++ b/scripts/prepare-publish.ts
@@ -1,65 +1,24 @@
 #!/usr/bin/env bun
-// Transform a package.json from its in-repo "source" shape to the published
-// "dist" shape, in place.
-//
-// The monorepo consumes these packages from source: `exports` point at
-// `./src/*.ts`, so every consumer (Bun, tgo, Vite) resolves source directly
-// with no aliases or conditions. The published package must instead expose the
-// built artifacts — real `.d.ts` + `.js`, no source — so external consumers do
-// not depend on our `.ts` or our bundler resolution.
+// Rewrite a package.json from its in-repo "source" shape to the published
+// "dist" shape, in place. The transformation itself lives in
+// scripts/publish-manifest.ts.
 //
 // Run this after `bun run build`, immediately before `bun pm pack` /
-// `bun publish`. It rewrites `exports` (deriving each dist target from the
-// source path), `main`, `types`, and `files`. Restore the working tree
-// afterward (`git checkout -- package.json`) — the publish workflow runs on an
+// `bun publish`. Restore the working tree afterward
+// (`git checkout -- package.json`) — the publish workflow runs on an
 // ephemeral checkout; the bootstrap script restores explicitly.
 
 import { panic } from "better-result";
 import path from "node:path";
 
-type DistEntry = { types: string; import: string };
+import { toPublishedManifest } from "./publish-manifest";
 
 const pkgDir =
   process.argv[2] ??
   panic("usage: bun scripts/prepare-publish.ts <package-dir>");
 
 const pkgPath = path.resolve(pkgDir, "package.json");
-const pkg = await Bun.file(pkgPath).json();
-
-// "./src/model/document.ts" -> "./dist/model/document"
-const distBase = (srcPath: string): string =>
-  srcPath.replace(/^\.\/src\//u, "./dist/").replace(/\.ts$/u, "");
-
-const distExports: Record<string, DistEntry> = {};
-for (const [subpath, target] of Object.entries(pkg.exports)) {
-  if (typeof target !== "string" || !target.startsWith("./src/")) {
-    panic(
-      `${pkg.name}: expected source export "${subpath}" to be a ./src/*.ts string, got ${JSON.stringify(target)}`,
-    );
-  }
-  const base = distBase(target);
-  distExports[subpath] = { types: `${base}.d.ts`, import: `${base}.js` };
-}
-
-const root =
-  distExports["."] ?? panic(`${pkg.name}: exports must include a "." entry`);
-
-pkg.exports = distExports;
-pkg.main = root.import;
-pkg.types = root.types;
-// Ship built artifacts and the README; drop `src`. Carry over any non-`src`
-// asset dirs the source `files` allowlist opted in (e.g. TanStack Intent's
-// `skills/`), so published tarballs keep shipping them.
-const carried = Array.isArray(pkg.files)
-  ? pkg.files.filter(
-      (entry: unknown): entry is string =>
-        typeof entry === "string" &&
-        entry !== "src" &&
-        entry !== "dist" &&
-        entry !== "README.md",
-    )
-  : [];
-pkg.files = ["dist", "README.md", ...carried];
+const pkg = toPublishedManifest(await Bun.file(pkgPath).json());
 
 await Bun.write(pkgPath, `${JSON.stringify(pkg, null, 2)}\n`);
 console.log(

--- a/scripts/publish-manifest.ts
+++ b/scripts/publish-manifest.ts
@@ -41,7 +41,11 @@ export const sourceExportTargets = (
 
   const targets: Record<string, string> = {};
   for (const [subpath, target] of Object.entries(exportsField)) {
-    if (typeof target !== "string" || !target.startsWith("./src/")) {
+    if (
+      typeof target !== "string" ||
+      !target.startsWith("./src/") ||
+      !target.endsWith(".ts")
+    ) {
       panic(
         `${manifest["name"]}: expected source export "${subpath}" to be a ./src/*.ts string, got ${JSON.stringify(target)}`,
       );

--- a/scripts/publish-manifest.ts
+++ b/scripts/publish-manifest.ts
@@ -1,0 +1,95 @@
+// Transform a package.json from its in-repo "source" shape to the published
+// "dist" shape.
+//
+// The monorepo consumes these packages from source: `exports` point at
+// `./src/*.ts`, so every consumer (Bun, tsgo, Vite) resolves source directly
+// with no aliases or conditions. The published package must instead expose the
+// built artifacts — real `.d.ts` + `.js`, no source — so external consumers do
+// not depend on our `.ts` or our bundler resolution.
+//
+// Shared by scripts/prepare-publish.ts (npm publish) and
+// scripts/stage-web-runtime.ts (web runner image staging).
+
+import { panic } from "better-result";
+
+type DistEntry = { types: string; import: string };
+
+export type PublishedManifest = Record<string, unknown> & {
+  exports: Record<string, DistEntry>;
+  name: string;
+  version: string;
+};
+
+// "./src/model/document.ts" -> "./dist/model/document"
+const distBase = (srcPath: string): string =>
+  srcPath.replace(/^\.\/src\//u, "./dist/").replace(/\.ts$/u, "");
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+// Validated `exports` map of a source-shaped manifest: subpath -> ./src/*.ts.
+export const sourceExportTargets = (
+  manifest: unknown,
+): Record<string, string> => {
+  if (!isRecord(manifest) || typeof manifest["name"] !== "string") {
+    panic("package.json must be an object with a name");
+  }
+  const exportsField = manifest["exports"];
+  if (!isRecord(exportsField)) {
+    panic(`${manifest["name"]}: exports must be an object`);
+  }
+
+  const targets: Record<string, string> = {};
+  for (const [subpath, target] of Object.entries(exportsField)) {
+    if (typeof target !== "string" || !target.startsWith("./src/")) {
+      panic(
+        `${manifest["name"]}: expected source export "${subpath}" to be a ./src/*.ts string, got ${JSON.stringify(target)}`,
+      );
+    }
+    targets[subpath] = target;
+  }
+  return targets;
+};
+
+export const toPublishedManifest = (manifest: unknown): PublishedManifest => {
+  const sourceTargets = sourceExportTargets(manifest);
+  if (!isRecord(manifest) || typeof manifest["name"] !== "string") {
+    panic("package.json must be an object with a name");
+  }
+  if (typeof manifest["version"] !== "string") {
+    panic(`${manifest["name"]}: package.json must have a version`);
+  }
+
+  const distExports: Record<string, DistEntry> = {};
+  for (const [subpath, target] of Object.entries(sourceTargets)) {
+    const base = distBase(target);
+    distExports[subpath] = { types: `${base}.d.ts`, import: `${base}.js` };
+  }
+
+  const root =
+    distExports["."] ??
+    panic(`${manifest["name"]}: exports must include a "." entry`);
+
+  // Ship built artifacts and the README; drop `src`. Carry over any non-`src`
+  // asset dirs the source `files` allowlist opted in (e.g. TanStack Intent's
+  // `skills/`), so published tarballs keep shipping them.
+  const carried = Array.isArray(manifest["files"])
+    ? manifest["files"].filter(
+        (entry: unknown): entry is string =>
+          typeof entry === "string" &&
+          entry !== "src" &&
+          entry !== "dist" &&
+          entry !== "README.md",
+      )
+    : [];
+
+  return {
+    ...manifest,
+    exports: distExports,
+    files: ["dist", "README.md", ...carried],
+    main: root.import,
+    name: manifest["name"],
+    types: root.types,
+    version: manifest["version"],
+  };
+};

--- a/scripts/stage-web-runtime.test.ts
+++ b/scripts/stage-web-runtime.test.ts
@@ -13,6 +13,42 @@ const runtimeWorkspacePaths = findExternalRuntimeWorkspacePaths(
 );
 
 describe("external runtime workspace closure", () => {
+  // Bun stores a dependency under a consumer-scoped key ("parent/name") when
+  // its resolution differs from the hoisted copy, and platform bindings ride
+  // optionalDependencies. Both must feed the walk: following the hoisted
+  // copy's dependency list here would miss packages/ws entirely.
+  test("follows consumer-scoped entries and optional dependencies", () => {
+    const lock = {
+      packages: {
+        "@x/external": [
+          "@x/external@1.0.0",
+          "",
+          {
+            dependencies: { shared: "^2.0.0" },
+            optionalDependencies: { "@x/opt-native": "^1.0.0" },
+          },
+        ],
+        "@x/external/shared": [
+          "shared@2.0.0",
+          "",
+          { dependencies: { "@x/ws": "^1.0.0" } },
+        ],
+        "@x/opt-native": ["@x/opt-native@workspace:packages/opt-native"],
+        "@x/ws": ["@x/ws@workspace:packages/ws"],
+        shared: ["shared@1.0.0", "", { dependencies: {} }],
+      },
+      workspaces: {
+        "apps/web": { dependencies: { "@x/external": "^1.0.0" } },
+        "packages/opt-native": { name: "@x/opt-native" },
+        "packages/ws": { name: "@x/ws" },
+      },
+    };
+    expect(findExternalRuntimeWorkspacePaths(lock)).toEqual([
+      "packages/opt-native",
+      "packages/ws",
+    ]);
+  });
+
   // The closure is derived, not declared, so its exact members may change
   // with the dependency graph. Pin @stll/folio-core's currently known
   // workspace-linked runtime deps: the derivation regressing to miss them —
@@ -65,10 +101,12 @@ describe("stageWorkspacePackage", () => {
     await symlink(target, path.join(scopeDir, "stage-fixture"), "dir");
   };
 
-  let workDir: string;
+  let workDir: string | undefined;
 
   afterAll(async () => {
-    await rm(workDir, { force: true, recursive: true });
+    if (workDir !== undefined) {
+      await rm(workDir, { force: true, recursive: true });
+    }
   });
 
   test("manifest-only tree fails to import; staged tree succeeds", async () => {

--- a/scripts/stage-web-runtime.test.ts
+++ b/scripts/stage-web-runtime.test.ts
@@ -1,0 +1,139 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, rm, symlink } from "node:fs/promises";
+import path from "node:path";
+
+import { stageWorkspacePackage } from "./stage-web-runtime";
+import { findExternalRuntimeWorkspacePaths } from "./web-runtime-closure";
+
+const repoRoot = path.resolve(import.meta.dir, "..");
+
+const lockfilePath = new URL("../bun.lock", import.meta.url);
+const runtimeWorkspacePaths = findExternalRuntimeWorkspacePaths(
+  Bun.JSONC.parse(await Bun.file(lockfilePath).text()),
+);
+
+describe("external runtime workspace closure", () => {
+  // The closure is derived, not declared, so its exact members may change
+  // with the dependency graph. Pin @stll/folio-core's currently known
+  // workspace-linked runtime deps: the derivation regressing to miss them —
+  // or to an empty set — must fail here, not in a production rollout.
+  test("reaches folio-core's workspace-linked runtime dependencies", () => {
+    expect(runtimeWorkspacePaths).toEqual(
+      expect.arrayContaining([
+        "packages/conditions",
+        "packages/docx-utils",
+        "packages/template-conditions",
+      ]),
+    );
+  });
+});
+
+// The fixture reproduces the runner-image layout: node_modules/@stll/* is a
+// symlink into packages/*, and the package manifest is source-shaped
+// (exports -> ./src/*.ts) with the conventions of the real publishable
+// packages (sideEffects: false, explicit .ts specifiers, tsdown build). A
+// tree carrying only the manifest — what the runner ships from out/json —
+// must fail to import; the staged dist-shaped tree must succeed. Exercises
+// the sourceless-manifest failure mode end to end through Bun's real
+// resolver.
+describe("stageWorkspacePackage", () => {
+  const fixtureManifest = {
+    exports: { ".": "./src/index.ts" },
+    files: ["dist", "src", "README.md"],
+    name: "@stll/stage-fixture",
+    scripts: { build: "tsdown" },
+    sideEffects: false,
+    type: "module",
+    version: "0.0.1",
+  };
+
+  const probe = async (appDir: string) =>
+    await Bun.spawn({
+      cmd: [
+        process.execPath,
+        "-e",
+        'const { answer } = await import("@stll/stage-fixture"); if (answer() !== 42) { process.exit(2); }',
+      ],
+      cwd: appDir,
+      stderr: "ignore",
+      stdout: "ignore",
+    }).exited;
+
+  const linkFixture = async (appDir: string, target: string) => {
+    const scopeDir = path.join(appDir, "node_modules", "@stll");
+    await mkdir(scopeDir, { recursive: true });
+    await symlink(target, path.join(scopeDir, "stage-fixture"), "dir");
+  };
+
+  let workDir: string;
+
+  afterAll(async () => {
+    await rm(workDir, { force: true, recursive: true });
+  });
+
+  test("manifest-only tree fails to import; staged tree succeeds", async () => {
+    // Inside the repo (not the OS tmpdir) so the fixture's `bun run build`
+    // resolves the workspace's real tsdown toolchain, like every closure
+    // member does in the Docker builder.
+    const cacheRoot = path.join(repoRoot, "node_modules", ".cache");
+    await mkdir(cacheRoot, { recursive: true });
+    workDir = await mkdtemp(path.join(cacheRoot, "stage-web-runtime-test-"));
+
+    const pkgDir = path.join(workDir, "packages", "stage-fixture");
+    await mkdir(path.join(pkgDir, "src"), { recursive: true });
+    await Bun.write(
+      path.join(pkgDir, "package.json"),
+      `${JSON.stringify(fixtureManifest, null, 2)}\n`,
+    );
+    await Bun.write(
+      path.join(pkgDir, "tsdown.config.ts"),
+      [
+        'import { defineConfig } from "tsdown";',
+        "",
+        "export default defineConfig({",
+        '  entry: ["src/index.ts"],',
+        '  format: ["esm"],',
+        '  platform: "neutral",',
+        "  dts: false,",
+        '  outDir: "dist",',
+        "  clean: true,",
+        "});",
+        "",
+      ].join("\n"),
+    );
+    // Explicit .ts specifier, matching how workspace source imports its own
+    // modules; the build must rewrite or inline it rather than emit a
+    // dangling .ts specifier.
+    await Bun.write(
+      path.join(pkgDir, "src", "index.ts"),
+      'export { answer } from "./impl.ts";\n',
+    );
+    await Bun.write(
+      path.join(pkgDir, "src", "impl.ts"),
+      "export const answer = (): number => 42;\n",
+    );
+
+    // Manifest-only: the source-shaped package.json without src, which is
+    // exactly what the runner's out/json overlay provides.
+    const manifestOnlyDir = path.join(
+      workDir,
+      "manifest-only",
+      "stage-fixture",
+    );
+    await mkdir(manifestOnlyDir, { recursive: true });
+    await Bun.write(
+      path.join(manifestOnlyDir, "package.json"),
+      `${JSON.stringify(fixtureManifest, null, 2)}\n`,
+    );
+    const brokenApp = path.join(workDir, "app-broken");
+    await linkFixture(brokenApp, manifestOnlyDir);
+    expect(await probe(brokenApp)).not.toBe(0);
+
+    const stagedDir = path.join(workDir, "staged", "stage-fixture");
+    const staged = await stageWorkspacePackage({ pkgDir, stagedDir });
+    expect(staged.exports["."]?.import).toBe("./dist/index.js");
+    const stagedApp = path.join(workDir, "app-staged");
+    await linkFixture(stagedApp, stagedDir);
+    expect(await probe(stagedApp)).toBe(0);
+  }, 30_000);
+});

--- a/scripts/stage-web-runtime.test.ts
+++ b/scripts/stage-web-runtime.test.ts
@@ -34,17 +34,31 @@ describe("external runtime workspace closure", () => {
           { dependencies: { "@x/ws": "^1.0.0" } },
         ],
         "@x/opt-native": ["@x/opt-native@workspace:packages/opt-native"],
+        "@x/web/dual": [
+          "dual@2.0.0",
+          "",
+          { dependencies: { "@x/web-scoped-ws": "^1.0.0" } },
+        ],
+        "@x/web-scoped-ws": [
+          "@x/web-scoped-ws@workspace:packages/web-scoped-ws",
+        ],
         "@x/ws": ["@x/ws@workspace:packages/ws"],
+        dual: ["dual@1.0.0", "", { dependencies: {} }],
         shared: ["shared@1.0.0", "", { dependencies: {} }],
       },
       workspaces: {
-        "apps/web": { dependencies: { "@x/external": "^1.0.0" } },
+        "apps/web": {
+          dependencies: { "@x/external": "^1.0.0", dual: "^2.0.0" },
+          name: "@x/web",
+        },
         "packages/opt-native": { name: "@x/opt-native" },
+        "packages/web-scoped-ws": { name: "@x/web-scoped-ws" },
         "packages/ws": { name: "@x/ws" },
       },
     };
     expect(findExternalRuntimeWorkspacePaths(lock)).toEqual([
       "packages/opt-native",
+      "packages/web-scoped-ws",
       "packages/ws",
     ]);
   });

--- a/scripts/stage-web-runtime.ts
+++ b/scripts/stage-web-runtime.ts
@@ -1,0 +1,146 @@
+#!/usr/bin/env bun
+// Stage the workspace packages that externalized npm dependencies of
+// @stll/web import at runtime, in their published (dist) shape.
+//
+// Bun links workspace-published dependencies of external packages (e.g.
+// @stll/folio-core -> @stll/docx-utils) to the local workspaces, so the
+// production install's node_modules symlinks point into /app/packages/*.
+// Those manifests export ./src/*.ts, which the runner image must not ship.
+// This script derives the closure from bun.lock, runs each member's own
+// `build` script (the same artifact npm publish ships), and emits
+// <out>/<workspace-path>/{package.json,dist/} with the same manifest
+// transformation the publish uses — a sealed artifact with no TypeScript
+// source and no hand-maintained package list. apps/web/Dockerfile runs it in
+// the builder stage and overlays the output onto the runner's manifest tree.
+
+import { panic } from "better-result";
+import { cp, mkdir, rm } from "node:fs/promises";
+import path from "node:path";
+
+import {
+  type PublishedManifest,
+  sourceExportTargets,
+  toPublishedManifest,
+} from "./publish-manifest";
+import { findExternalRuntimeWorkspacePaths } from "./web-runtime-closure";
+
+type StageWorkspacePackageOptions = {
+  pkgDir: string;
+  stagedDir: string;
+};
+
+const run = async (cmd: string[], cwd: string): Promise<void> => {
+  const proc = Bun.spawn({ cmd, cwd, stderr: "inherit", stdout: "inherit" });
+  if ((await proc.exited) !== 0) {
+    panic(`command failed in ${cwd}: ${cmd.join(" ")}`);
+  }
+};
+
+export const stageWorkspacePackage = async ({
+  pkgDir,
+  stagedDir,
+}: StageWorkspacePackageOptions): Promise<PublishedManifest> => {
+  const rawManifest = await Bun.file(path.join(pkgDir, "package.json")).json();
+  // Validate the source shape before spending a build on it.
+  sourceExportTargets(rawManifest);
+
+  // Build with the package's own `build` script so the staged artifact is the
+  // same one `bun publish` ships — the build config stays the package's
+  // single source of truth. Do not replace this with Bun.build: independent
+  // of parity, Bun's bundler currently drops re-exported implementations
+  // when the entry package declares sideEffects (empty bundle with dangling
+  // exports; oven-sh/bun#27709, regression in 1.3.10, still present in
+  // 1.4.0-canary as of 2026-08). scripts/stage-web-runtime.test.ts fails on
+  // hollow output from any builder, so a future switch stays honest.
+  // --bun: run the build's node-shebang binaries (tsdown) under Bun — the
+  // Docker builder image has no Node, and Bun loads .ts configs natively.
+  await run([process.execPath, "run", "--bun", "build"], pkgDir);
+
+  const manifest = toPublishedManifest(rawManifest);
+  await rm(stagedDir, { force: true, recursive: true });
+  await mkdir(stagedDir, { recursive: true });
+  await cp(path.join(pkgDir, "dist"), path.join(stagedDir, "dist"), {
+    recursive: true,
+  });
+  await Bun.write(
+    path.join(stagedDir, "package.json"),
+    `${JSON.stringify(manifest, null, 2)}\n`,
+  );
+
+  // A package whose build config misses an exported entry must fail here,
+  // not on the first runtime import of the missing file.
+  await Promise.all(
+    Object.entries(manifest.exports).map(async ([subpath, entry]) => {
+      const built = await Bun.file(path.join(stagedDir, entry.import)).exists();
+      if (!built) {
+        panic(
+          `${manifest.name}: staged export "${subpath}" is missing ${entry.import}`,
+        );
+      }
+    }),
+  );
+
+  return manifest;
+};
+
+if (import.meta.main) {
+  const [outDir, ...flags] = process.argv.slice(2);
+  if (outDir === undefined) {
+    panic(
+      "usage: bun scripts/stage-web-runtime.ts <out-dir> [--install-build-deps]",
+    );
+  }
+  const repoRoot = path.resolve(import.meta.dir, "..");
+  await mkdir(outDir, { recursive: true });
+
+  const lock = Bun.JSONC.parse(
+    await Bun.file(path.join(repoRoot, "bun.lock")).text(),
+  );
+  const workspacePaths = findExternalRuntimeWorkspacePaths(lock);
+
+  // The Docker builder installs with `--filter @stll/web`, which omits the
+  // closure members' devDependencies (their build toolchain). Widen that
+  // install to the derived closure; additive, so it must include the filters
+  // the base install used.
+  if (flags.includes("--install-build-deps") && workspacePaths.length > 0) {
+    const memberNames = await Promise.all(
+      workspacePaths.map(async (workspacePath) => {
+        const manifest = await Bun.file(
+          path.join(repoRoot, workspacePath, "package.json"),
+        ).json();
+        return typeof manifest.name === "string"
+          ? manifest.name
+          : panic(`${workspacePath}/package.json has no name`);
+      }),
+    );
+    await run(
+      [
+        process.execPath,
+        "install",
+        "--filter",
+        "@stll/web",
+        ...memberNames.flatMap((name) => ["--filter", name]),
+        "--frozen-lockfile",
+        "--ignore-scripts",
+      ],
+      repoRoot,
+    );
+  }
+
+  await Promise.all(
+    workspacePaths.map(async (workspacePath) => {
+      const manifest = await stageWorkspacePackage({
+        pkgDir: path.join(repoRoot, workspacePath),
+        stagedDir: path.join(outDir, workspacePath),
+      });
+      console.log(
+        `staged ${manifest.name}@${manifest.version} -> ${workspacePath} (exports -> dist)`,
+      );
+    }),
+  );
+  if (workspacePaths.length === 0) {
+    console.log(
+      "no workspace packages reached by externalized runtime dependencies",
+    );
+  }
+}

--- a/scripts/web-runtime-closure.ts
+++ b/scripts/web-runtime-closure.ts
@@ -11,18 +11,23 @@
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value);
 
+// Production install graph: dependencies plus optionalDependencies (platform
+// binding packages ride the optional field). devDependencies never install in
+// the runner; peerDependencies of an externalized package resolve against a
+// consumer instance that is reachable through its own dependency edge.
 const readDependencyNames = (manifest: unknown): string[] => {
   if (!isRecord(manifest)) {
     return [];
   }
 
-  const dependencies = manifest["dependencies"];
-  return isRecord(dependencies) ? Object.keys(dependencies) : [];
-};
-
-type ResolvedPackage = {
-  dependencyNames: string[];
-  workspacePath: string | undefined;
+  const names: string[] = [];
+  for (const field of ["dependencies", "optionalDependencies"]) {
+    const value = manifest[field];
+    if (isRecord(value)) {
+      names.push(...Object.keys(value));
+    }
+  }
+  return names;
 };
 
 export const findExternalRuntimeWorkspacePaths = (
@@ -38,16 +43,57 @@ export const findExternalRuntimeWorkspacePaths = (
     throw new TypeError("bun.lock must contain packages and workspaces maps");
   }
 
-  const resolvePackage = (name: string): ResolvedPackage | undefined => {
-    const entry = packages[name];
-    if (!Array.isArray(entry)) {
-      return undefined;
-    }
+  const visited = new Set<string>();
+  const runtimeWorkspaces = new Set<string>();
 
+  // Bun stores a dependency at a consumer-scoped key ("parent/name", chained
+  // for deeper conflicts) when its resolution differs from the hoisted one.
+  // Resolve the deepest matching key for this consumer chain first, so the
+  // walk follows the copy this consumer actually gets, not the hoisted one.
+  const entryKeyFor = (name: string, parentChain: string[]): string => {
+    for (let index = 0; index < parentChain.length; index += 1) {
+      const candidate = [...parentChain.slice(index), name].join("/");
+      if (candidate in packages) {
+        return candidate;
+      }
+    }
+    return name;
+  };
+
+  const chainFromKey = (
+    entryKey: string,
+    name: string,
+    parentChain: string[],
+  ): string[] => {
+    for (let index = 0; index < parentChain.length; index += 1) {
+      const candidate = [...parentChain.slice(index), name];
+      if (candidate.join("/") === entryKey) {
+        return candidate;
+      }
+    }
+    return [name];
+  };
+
+  const visit = (name: string, parentChain: string[]): void => {
+    const entryKey = entryKeyFor(name, parentChain);
+    if (visited.has(entryKey)) {
+      return;
+    }
+    visited.add(entryKey);
+
+    const entry = packages[entryKey];
+    if (!Array.isArray(entry)) {
+      return;
+    }
     const resolution = entry.at(0);
     if (typeof resolution !== "string") {
-      throw new TypeError(`bun.lock package ${name} has no resolution`);
+      throw new TypeError(`bun.lock package ${entryKey} has no resolution`);
     }
+
+    // The chain that reproduces this entry's key, so children resolve their
+    // own consumer-scoped copies beneath it.
+    const childChain =
+      entryKey === name ? [name] : chainFromKey(entryKey, name, parentChain);
 
     const workspaceMarker = "@workspace:";
     const markerIndex = resolution.indexOf(workspaceMarker);
@@ -55,40 +101,33 @@ export const findExternalRuntimeWorkspacePaths = (
       const workspacePath = resolution.slice(
         markerIndex + workspaceMarker.length,
       );
-      return {
-        dependencyNames: readDependencyNames(workspaces[workspacePath]),
-        workspacePath,
-      };
+      runtimeWorkspaces.add(workspacePath);
+      for (const child of readDependencyNames(workspaces[workspacePath])) {
+        visit(child, childChain);
+      }
+      return;
     }
 
-    return {
-      dependencyNames: readDependencyNames(entry.at(2)),
-      workspacePath: undefined,
-    };
+    for (const child of readDependencyNames(entry.at(2))) {
+      visit(child, childChain);
+    }
   };
 
-  const webWorkspace = workspaces["apps/web"];
-  const queue = readDependencyNames(webWorkspace).filter(
-    (name) => resolvePackage(name)?.workspacePath === undefined,
-  );
-  const visited = new Set<string>();
-  const runtimeWorkspaces = new Set<string>();
-
-  while (queue.length > 0) {
-    const name = queue.shift();
-    if (name === undefined || visited.has(name)) {
-      continue;
+  // Seed with the web app's external dependencies only: @stll/web's own
+  // workspace dependencies are bundled into dist by Vite, so their sources
+  // never need to exist in the runner.
+  const isWorkspaceResolved = (name: string): boolean => {
+    const entry = packages[name];
+    return (
+      Array.isArray(entry) &&
+      typeof entry.at(0) === "string" &&
+      String(entry.at(0)).includes("@workspace:")
+    );
+  };
+  for (const name of readDependencyNames(workspaces["apps/web"])) {
+    if (!isWorkspaceResolved(name)) {
+      visit(name, []);
     }
-    visited.add(name);
-
-    const resolved = resolvePackage(name);
-    if (!resolved) {
-      continue;
-    }
-    if (resolved.workspacePath) {
-      runtimeWorkspaces.add(resolved.workspacePath);
-    }
-    queue.push(...resolved.dependencyNames);
   }
 
   return [...runtimeWorkspaces].sort();

--- a/scripts/web-runtime-closure.ts
+++ b/scripts/web-runtime-closure.ts
@@ -1,0 +1,95 @@
+// Derive, from bun.lock, the workspace packages that externalized npm
+// dependencies of @stll/web import at runtime.
+//
+// The SSR server bundle externalizes npm packages; when such a package (e.g.
+// @stll/folio-core) declares a dependency whose name matches a local
+// workspace, Bun links the workspace instead of the registry copy. Every
+// workspace reached that way must exist inside the runner image in a
+// runtime-loadable shape. scripts/stage-web-runtime.ts stages that closure;
+// scripts/stage-web-runtime.test.ts guards the derivation.
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const readDependencyNames = (manifest: unknown): string[] => {
+  if (!isRecord(manifest)) {
+    return [];
+  }
+
+  const dependencies = manifest["dependencies"];
+  return isRecord(dependencies) ? Object.keys(dependencies) : [];
+};
+
+type ResolvedPackage = {
+  dependencyNames: string[];
+  workspacePath: string | undefined;
+};
+
+export const findExternalRuntimeWorkspacePaths = (
+  source: unknown,
+): string[] => {
+  if (!isRecord(source)) {
+    throw new TypeError("bun.lock must contain an object");
+  }
+
+  const packages = source["packages"];
+  const workspaces = source["workspaces"];
+  if (!isRecord(packages) || !isRecord(workspaces)) {
+    throw new TypeError("bun.lock must contain packages and workspaces maps");
+  }
+
+  const resolvePackage = (name: string): ResolvedPackage | undefined => {
+    const entry = packages[name];
+    if (!Array.isArray(entry)) {
+      return undefined;
+    }
+
+    const resolution = entry.at(0);
+    if (typeof resolution !== "string") {
+      throw new TypeError(`bun.lock package ${name} has no resolution`);
+    }
+
+    const workspaceMarker = "@workspace:";
+    const markerIndex = resolution.indexOf(workspaceMarker);
+    if (markerIndex !== -1) {
+      const workspacePath = resolution.slice(
+        markerIndex + workspaceMarker.length,
+      );
+      return {
+        dependencyNames: readDependencyNames(workspaces[workspacePath]),
+        workspacePath,
+      };
+    }
+
+    return {
+      dependencyNames: readDependencyNames(entry.at(2)),
+      workspacePath: undefined,
+    };
+  };
+
+  const webWorkspace = workspaces["apps/web"];
+  const queue = readDependencyNames(webWorkspace).filter(
+    (name) => resolvePackage(name)?.workspacePath === undefined,
+  );
+  const visited = new Set<string>();
+  const runtimeWorkspaces = new Set<string>();
+
+  while (queue.length > 0) {
+    const name = queue.shift();
+    if (name === undefined || visited.has(name)) {
+      continue;
+    }
+    visited.add(name);
+
+    const resolved = resolvePackage(name);
+    if (!resolved) {
+      continue;
+    }
+    if (resolved.workspacePath) {
+      runtimeWorkspaces.add(resolved.workspacePath);
+    }
+    queue.push(...resolved.dependencyNames);
+  }
+
+  return [...runtimeWorkspaces].sort();
+};

--- a/scripts/web-runtime-closure.ts
+++ b/scripts/web-runtime-closure.ts
@@ -115,18 +115,25 @@ export const findExternalRuntimeWorkspacePaths = (
 
   // Seed with the web app's external dependencies only: @stll/web's own
   // workspace dependencies are bundled into dist by Vite, so their sources
-  // never need to exist in the runner.
+  // never need to exist in the runner. Seeds resolve in the web consumer
+  // context too — Bun can store a web dependency under "<web name>/<dep>"
+  // when its resolution differs from the hoisted copy.
+  const webWorkspace = workspaces["apps/web"];
+  if (!isRecord(webWorkspace) || typeof webWorkspace["name"] !== "string") {
+    throw new TypeError("bun.lock apps/web workspace must have a name");
+  }
+  const webChain = [webWorkspace["name"]];
   const isWorkspaceResolved = (name: string): boolean => {
-    const entry = packages[name];
+    const entry = packages[entryKeyFor(name, webChain)];
     return (
       Array.isArray(entry) &&
       typeof entry.at(0) === "string" &&
       String(entry.at(0)).includes("@workspace:")
     );
   };
-  for (const name of readDependencyNames(workspaces["apps/web"])) {
+  for (const name of readDependencyNames(webWorkspace)) {
     if (!isWorkspaceResolved(name)) {
-      visit(name, []);
+      visit(name, webChain);
     }
   }
 


### PR DESCRIPTION
## Summary

The web runner image previously shipped a hand-listed set of workspace source directories for the packages that externalized runtime dependencies (`@stll/folio-core`) import, and `start-runtime.js` answered `/health` before any SSR module had loaded. A missing runtime dependency could therefore only surface on the first request that reached it. This PR makes that class fail at build or boot instead, and removes the hand-maintained closure.

### Boot gate (`apps/web/start-runtime.js`)

- Imports every `dist/server` chunk before `serve()`. A module-resolution failure (`ResolveMessage` / `ERR_MODULE_NOT_FOUND`) now crashes the boot, so a bad rollout never becomes healthy and the previous tasks keep serving.
- Browser-only chunks that throw on evaluation (module-scope `window` reads in the PDF-viewer family) are tolerated with a warning; ESM links the full static subtree before evaluating, so tolerating evaluation errors cannot hide a resolution failure.
- `--smoke` runs the same proof without binding a port; the Dockerfile runner stage executes it at image build, so a broken module graph fails the build.

### Sealed runtime staging (`scripts/stage-web-runtime.ts`)

- The workspace closure reached by externalized runtime dependencies is derived from `bun.lock` (`scripts/web-runtime-closure.ts`), never hand-listed.
- Each member is built by its own `build` script and staged as `dist/` plus a publish-shaped manifest, using the same transformation as `bun publish` (`scripts/publish-manifest.ts`, extracted from `prepare-publish.ts`; output verified byte-identical across six packages including multi-export and carried-`files` cases).
- The runner overlays the staged tree over `out/json`; no `packages/*/src` ships (verified: zero non-`.d.ts` `.ts` files in the built image).
- Staging must not use `Bun.build`: the bundler currently emits hollow bundles (export list without bindings) when the entry package declares `sideEffects` (oven-sh/bun#27709, regression in 1.3.10, still present in 1.4.0-canary). The design does not depend on that bug either way; the staging test fails on hollow output from any builder.
- The staging install restores the committed root `package.json` first: `turbo prune` writes a pruned root manifest (an explicit workspace subset) into `out/full`, and a filtered install resolving that subset against the committed lockfile fails `--frozen-lockfile`. `bun.lock` is restored defensively alongside it.

### CI: `web-image-smoke`

The existing prod-deps boot smoke runs inside a full checkout, where workspace sources exist and can mask the image's filesystem boundary. The new path-gated job builds the real runner image (which runs the `--smoke` module-graph proof against the exact tree that ships) and boots the container. Gated on the files that define the boundary: `apps/web/Dockerfile`, `start-runtime.js`, the staging scripts, `bun.lock`, `.dockerignore`.

### Tests

- `scripts/stage-web-runtime.test.ts`: closure derivation reaches folio-core's workspace-linked runtime deps, and a manifest-only tree (what `out/json` provides) fails to import while the staged tree succeeds, through Bun's real resolver.
- `scripts/check-web-docker-platform.test.ts` updated to assert the staged overlay and the boot-time smoke instead of the removed hand-listed copies.

No performance baselines were reseeded. Negative validation: building the image without the staged overlay fails at the smoke layer with `Cannot find module '@stll/docx-utils' from '.../folio-core/dist/docx/xmlParser.js'`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Reliability**
  - Improved production web runtime packaging by staging only required dependencies and build outputs.
  - Added startup validation to detect missing or unresolved server modules before traffic is served.
  - Added a smoke mode to confirm the production web image starts successfully.

- **Quality**
  - Expanded automated checks for image builds, runtime contents, dependency staging and startup behaviour.
  - Improved package publishing validation and generated manifests for more consistent distribution artefacts.
  - Added coverage for runtime dependency closure and staged package contents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->