### PR TITLE
feat(api): verify hand-copied runtime assets inside the image build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -790,6 +790,13 @@ jobs:
       - name: Test web container platform boundary
         run: bun test scripts/check-web-docker-platform.test.ts
 
+      # Bun links @stll dependencies to local workspaces only while versions
+      # match; a drift silently flips the resolution to the npm registry copy
+      # (or back). Needs only bun.lock, so it stays runnable when the
+      # dependency install is skipped.
+      - name: Test @stll resolution pin
+        run: bun test scripts/stll-registry-resolutions.test.ts
+
       # Release ordering is a safety property. This test has no workspace
       # dependencies, so it remains runnable when a PR changes only workflows
       # and the dependency install above is intentionally skipped.
@@ -1718,6 +1725,13 @@ jobs:
             --outdir /tmp/runtime-workers \
             apps/api/src/lib/search/extraction-worker.ts
           test -s /tmp/runtime-workers/extraction-worker.js
+          # Compile (not run) the runtime-asset smoke probe: it executes
+          # inside the image build, where the hand-copied assets exist.
+          bun build \
+            --compile \
+            --target bun \
+            --outfile /tmp/image-smoke \
+            apps/api/src/scripts/image-smoke.ts
         env:
           NPM_TOKEN: ""
 

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -99,6 +99,15 @@ RUN mkdir -p /app/runtime-workers && \
     cp node_modules/@silurus/ooxml/dist/pptx_parser_bg.wasm \
       /app/runtime-workers/pptx_parser_bg.wasm
 RUN bun --filter @stll/legal-atlas-runner build
+# Runtime-asset smoke probe: initializes every lazily loaded asset the runner
+# stage copies by hand (anonymize engine, quickjs wasm, yara rules, worker
+# bundles, OCR font). Compiled like the server so its bundled asset URLs
+# resolve under $bunfs/root the same way; run by the verification stage below.
+RUN bun build \
+    --compile \
+    --target bun \
+    --outfile /app/image-smoke \
+    apps/api/src/scripts/image-smoke.ts
 
 # Run the compiled API as non-root. Built from the bare base image: every
 # entrypoint is either the compiled binary or a self-contained
@@ -157,3 +166,15 @@ WORKDIR /app/apps/api
 USER stella
 EXPOSE 3001
 CMD ["/app/server"]
+
+# Throwaway verification stage: run the runtime-asset probe on the exact
+# runner filesystem, so a missing or unloadable hand-copied asset fails the
+# image build instead of the first request that reaches it. The probe binary
+# never ships; the final stage below re-selects the runner and forces this
+# stage into the build by copying its marker.
+FROM runner AS runtime-asset-smoke
+COPY --from=builder /app/image-smoke /tmp/image-smoke
+RUN /tmp/image-smoke && touch /tmp/image-smoke-ok
+
+FROM runner
+COPY --chown=stella:stella --from=runtime-asset-smoke /tmp/image-smoke-ok /tmp/image-smoke-ok

--- a/apps/api/src/lib/file-scan/yara.ts
+++ b/apps/api/src/lib/file-scan/yara.ts
@@ -8,8 +8,15 @@ import { isRecord } from "@/api/lib/type-guards";
 
 const YARA_DIR = path.join(import.meta.dir, "yara");
 
+const ruleFiles = [...new Bun.Glob("*.yar").scanSync(YARA_DIR)];
+
+// An empty rule directory compiles into a scanner that matches nothing, so a
+// missing rules deployment would pass silently. Exported for the image smoke
+// probe (scripts/image-smoke.ts), which asserts the count is non-zero.
+export const yaraRuleFileCount = ruleFiles.length;
+
 const compiled = compile(
-  [...new Bun.Glob("*.yar").scanSync(YARA_DIR)]
+  ruleFiles
     .map((f) => readFileSync(path.join(YARA_DIR, f), "utf-8"))
     .join("\n"),
 );

--- a/apps/api/src/lib/files/extract-office-evidence.ts
+++ b/apps/api/src/lib/files/extract-office-evidence.ts
@@ -8,11 +8,14 @@ import {
   type OfficeEvidenceFormat,
   type OfficeEvidenceWorkerResult,
 } from "@/api/lib/files/office-evidence-types";
-import { resolveRuntimeWorkerPath } from "@/api/lib/runtime-worker-path";
+import {
+  resolveRuntimeWorkerPath,
+  RUNTIME_WORKER_FILES,
+} from "@/api/lib/runtime-worker-path";
 import { spawnBinaryWorker } from "@/api/lib/subprocess";
 
 const WORKER_PATH = resolveRuntimeWorkerPath({
-  outputFile: "office-evidence-worker.js",
+  outputFile: RUNTIME_WORKER_FILES.officeEvidence,
   sourceDir: import.meta.dir,
   sourceFile: "office-evidence-worker.ts",
 });

--- a/apps/api/src/lib/files/pdf-utils.ts
+++ b/apps/api/src/lib/files/pdf-utils.ts
@@ -1,7 +1,10 @@
 import { Result, TaggedError } from "better-result";
 
 import { LIMITS } from "@/api/lib/limits";
-import { resolveRuntimeWorkerPath } from "@/api/lib/runtime-worker-path";
+import {
+  resolveRuntimeWorkerPath,
+  RUNTIME_WORKER_FILES,
+} from "@/api/lib/runtime-worker-path";
 import { spawnWorker } from "@/api/lib/subprocess";
 
 class CorruptedPdfError extends TaggedError("CorruptedPdfError")<{
@@ -9,7 +12,7 @@ class CorruptedPdfError extends TaggedError("CorruptedPdfError")<{
 }> {}
 
 const WORKER_PATH = resolveRuntimeWorkerPath({
-  outputFile: "pdf-worker.js",
+  outputFile: RUNTIME_WORKER_FILES.pdf,
   sourceDir: import.meta.dir,
   sourceFile: "pdf-worker.ts",
 });

--- a/apps/api/src/lib/ocr-searchable-pdf.ts
+++ b/apps/api/src/lib/ocr-searchable-pdf.ts
@@ -7,11 +7,12 @@ import { LIMITS } from "@/api/lib/limits";
 import {
   resolveOcrPdfFontPath,
   resolveRuntimeWorkerPath,
+  RUNTIME_WORKER_FILES,
 } from "@/api/lib/runtime-worker-path";
 import { spawnBinaryWorker } from "@/api/lib/subprocess";
 
 const WORKER_PATH = resolveRuntimeWorkerPath({
-  outputFile: "ocr-searchable-pdf-worker.js",
+  outputFile: RUNTIME_WORKER_FILES.ocrSearchablePdf,
   sourceDir: import.meta.dir,
   sourceFile: "ocr-searchable-pdf-worker.ts",
 });

--- a/apps/api/src/lib/runtime-worker-path.test.ts
+++ b/apps/api/src/lib/runtime-worker-path.test.ts
@@ -1,7 +1,10 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import path from "node:path";
 
-import { resolveRuntimeWorkerPath } from "@/api/lib/runtime-worker-path";
+import {
+  resolveRuntimeWorkerPath,
+  RUNTIME_WORKER_FILES,
+} from "@/api/lib/runtime-worker-path";
 
 const WORKER_DIR_ENV = "STELLA_WORKER_DIR";
 const originalWorkerDir = process.env[WORKER_DIR_ENV];
@@ -21,7 +24,7 @@ describe("runtime worker paths", () => {
 
     expect(
       resolveRuntimeWorkerPath({
-        outputFile: "worker.js",
+        outputFile: RUNTIME_WORKER_FILES.pdf,
         sourceDir: "/repo/apps/api/src/lib/search",
         sourceFile: "worker.ts",
       }),
@@ -33,10 +36,10 @@ describe("runtime worker paths", () => {
 
     expect(
       resolveRuntimeWorkerPath({
-        outputFile: "worker.js",
+        outputFile: RUNTIME_WORKER_FILES.pdf,
         sourceDir: "/repo/apps/api/src/lib/search",
         sourceFile: "worker.ts",
       }),
-    ).toBe(path.resolve("/runtime/workers", "worker.js"));
+    ).toBe(path.resolve("/runtime/workers", RUNTIME_WORKER_FILES.pdf));
   });
 });

--- a/apps/api/src/lib/runtime-worker-path.ts
+++ b/apps/api/src/lib/runtime-worker-path.ts
@@ -3,16 +3,45 @@ import path from "node:path";
 const WORKER_DIR_ENV = "STELLA_WORKER_DIR";
 const OCR_PDF_FONT_PATH_ENV = "STELLA_OCR_PDF_FONT_PATH";
 
+// Bundled worker entrypoints the API spawns at runtime. In the container
+// image they live in STELLA_WORKER_DIR (built by apps/api/Dockerfile); in dev
+// each call site falls back to its co-located source file. Call sites name
+// their bundle through this map (`RuntimeWorkerFile` narrows the parameter),
+// so the image smoke probe (scripts/image-smoke.ts) verifies exactly the set
+// the runtime can load.
+export const RUNTIME_WORKER_FILES = {
+  extraction: "extraction-worker.js",
+  officeEvidence: "office-evidence-worker.js",
+  ocrSearchablePdf: "ocr-searchable-pdf-worker.js",
+  pdf: "pdf-worker.js",
+} as const;
+
+export type RuntimeWorkerFile =
+  (typeof RUNTIME_WORKER_FILES)[keyof typeof RUNTIME_WORKER_FILES];
+
+// Sidecar assets the worker bundles load relative to their own location;
+// apps/api/Dockerfile copies them into the same runtime worker directory.
+export const RUNTIME_WORKER_SIDECAR_FILES = [
+  "pptx_parser_bg.wasm",
+  "xlsx_parser_bg.wasm",
+] as const;
+
+export const runtimeWorkerDir = (): string | undefined =>
+  process.env[WORKER_DIR_ENV];
+
+export const runtimeOcrPdfFontPath = (): string | undefined =>
+  process.env[OCR_PDF_FONT_PATH_ENV];
+
 export const resolveRuntimeWorkerPath = ({
   outputFile,
   sourceDir,
   sourceFile,
 }: {
-  outputFile: string;
+  outputFile: RuntimeWorkerFile;
   sourceDir: string;
   sourceFile: string;
 }): string => {
-  const workerDir = process.env[WORKER_DIR_ENV];
+  const workerDir = runtimeWorkerDir();
   if (workerDir) {
     return path.resolve(workerDir, outputFile);
   }
@@ -21,4 +50,4 @@ export const resolveRuntimeWorkerPath = ({
 };
 
 export const resolveOcrPdfFontPath = (localPath: string): string =>
-  process.env[OCR_PDF_FONT_PATH_ENV] || localPath;
+  runtimeOcrPdfFontPath() || localPath;

--- a/apps/api/src/lib/search/extract-content.ts
+++ b/apps/api/src/lib/search/extract-content.ts
@@ -15,7 +15,10 @@ import { captureError } from "@/api/lib/analytics/capture";
 import { ExtractionWorkerError } from "@/api/lib/errors/tagged-errors";
 import { resolveEmailMimeType } from "@/api/lib/files/email-to-html";
 import { LIMITS } from "@/api/lib/limits";
-import { resolveRuntimeWorkerPath } from "@/api/lib/runtime-worker-path";
+import {
+  resolveRuntimeWorkerPath,
+  RUNTIME_WORKER_FILES,
+} from "@/api/lib/runtime-worker-path";
 import {
   canExtractMimeType,
   normalizeMimeType,
@@ -40,7 +43,7 @@ import {
 } from "@/api/mime-types";
 
 const WORKER_PATH = resolveRuntimeWorkerPath({
-  outputFile: "extraction-worker.js",
+  outputFile: RUNTIME_WORKER_FILES.extraction,
   sourceDir: import.meta.dir,
   sourceFile: "extraction-worker.ts",
 });

--- a/apps/api/src/scripts/image-smoke.ts
+++ b/apps/api/src/scripts/image-smoke.ts
@@ -1,0 +1,111 @@
+/**
+ * Runtime-asset smoke for the compiled API image.
+ *
+ * The container ships hand-copied assets the binary loads lazily: the
+ * anonymization engine's native glue and WASM, the quickjs sandbox WASM, the
+ * compiled YARA rules, the bundled workers with their WASM sidecars, and the
+ * OCR PDF font. Nothing else exercises them before the first request that
+ * needs them. apps/api/Dockerfile compiles this entry like the server (so its
+ * bundled asset URLs resolve the same way) and runs it in a throwaway stage
+ * on top of the runner filesystem; a missing or unloadable asset fails the
+ * image build.
+ *
+ * Self-contained on purpose: no env module, no DB client. Each probe drives
+ * the real loader rather than checking existence, except the worker bundles
+ * (spawning them needs request-shaped input), where presence of the exact
+ * files the runtime resolves is the contract.
+ */
+
+import { panic } from "better-result";
+import path from "node:path";
+import { newAsyncContext } from "quickjs-emscripten";
+
+import { getBinding, isNativeAnonymizeBinding } from "@stll/anonymize-wasm";
+
+import { yaraRuleFileCount, yaraScanner } from "@/api/lib/file-scan/yara";
+import {
+  RUNTIME_WORKER_FILES,
+  RUNTIME_WORKER_SIDECAR_FILES,
+  runtimeOcrPdfFontPath,
+  runtimeWorkerDir,
+} from "@/api/lib/runtime-worker-path";
+
+const probe = async (label: string, run: () => Promise<void>) => {
+  await run();
+  console.log(`image-smoke ok: ${label}`);
+};
+
+await probe("quickjs sandbox wasm", async () => {
+  const context = await newAsyncContext();
+  const handle = context.unwrapResult(context.evalCode("6 * 7"));
+  const value = context.getNumber(handle);
+  handle.dispose();
+  context.dispose();
+  if (value !== 42) {
+    panic(`quickjs evaluated 6 * 7 to ${value}`);
+  }
+});
+
+await probe("yara rules", async () => {
+  if (yaraRuleFileCount === 0) {
+    panic("no YARA rule files were compiled; rules directory missing?");
+  }
+  const matches = await yaraScanner.scan(
+    new TextEncoder().encode("image smoke probe"),
+  );
+  if (!Array.isArray(matches)) {
+    panic("yara scan returned no match list");
+  }
+});
+
+await probe("runtime worker bundles", async () => {
+  const workerDir =
+    runtimeWorkerDir() ??
+    panic("STELLA_WORKER_DIR must be set for the image smoke");
+  const expected = [
+    ...Object.values(RUNTIME_WORKER_FILES),
+    ...RUNTIME_WORKER_SIDECAR_FILES,
+  ];
+  const missing = (
+    await Promise.all(
+      expected.map(async (file) =>
+        (await Bun.file(path.join(workerDir, file)).exists()) ? null : file,
+      ),
+    )
+  ).filter((file) => file !== null);
+  if (missing.length > 0) {
+    panic(`runtime worker dir is missing: ${missing.join(", ")}`);
+  }
+});
+
+await probe("ocr pdf font", async () => {
+  const fontPath =
+    runtimeOcrPdfFontPath() ??
+    panic("STELLA_OCR_PDF_FONT_PATH must be set for the image smoke");
+  if (!(await Bun.file(fontPath).exists())) {
+    panic(`missing OCR PDF font at ${fontPath}`);
+  }
+});
+
+// KNOWN FAILURE, tolerated until @stll/anonymize-wasm ships a compiled-binary
+// safe loader: its glue is loaded via `import()` of a specifier computed from
+// import.meta.url at runtime, which a `bun build --compile` binary resolves
+// against its embedded filesystem only — the on-disk copy under $bunfs/root
+// is reachable by fs APIs but not by ESM import. Until the loader is fixed
+// upstream and the catalog bumped, this probe reports instead of failing;
+// flip it to a hard failure in the same change that bumps the fix.
+try {
+  const binding = await getBinding();
+  if (!isNativeAnonymizeBinding(binding)) {
+    panic("anonymize-wasm getBinding() returned an unexpected binding shape");
+  }
+  console.log(
+    "image-smoke ok: anonymize-wasm native engine — loader fixed; make this probe fatal again",
+  );
+} catch (error) {
+  console.warn(
+    `image-smoke KNOWN FAILURE (tolerated): anonymize-wasm engine cannot load in the compiled binary — ${error instanceof Error ? error.message : String(error)}`,
+  );
+}
+
+console.log("image-smoke ok: all runtime assets loadable");

--- a/apps/api/src/scripts/image-smoke.ts
+++ b/apps/api/src/scripts/image-smoke.ts
@@ -92,20 +92,27 @@ await probe("ocr pdf font", async () => {
 // import.meta.url at runtime, which a `bun build --compile` binary resolves
 // against its embedded filesystem only — the on-disk copy under $bunfs/root
 // is reachable by fs APIs but not by ESM import. Until the loader is fixed
-// upstream and the catalog bumped, this probe reports instead of failing;
-// flip it to a hard failure in the same change that bumps the fix.
-try {
-  const binding = await getBinding();
-  if (!isNativeAnonymizeBinding(binding)) {
+// upstream and the catalog bumped, a load failure reports instead of failing;
+// flip it to a hard failure in the same change that bumps the fix. Only the
+// load itself is tolerated: a loader that returns an unexpected binding
+// shape stays fatal.
+const anonymizeBinding = await getBinding().catch((error: unknown) => {
+  console.warn(
+    `image-smoke KNOWN FAILURE (tolerated): anonymize-wasm engine cannot load in the compiled binary — ${error instanceof Error ? error.message : String(error)}`,
+  );
+  return null;
+});
+if (anonymizeBinding !== null) {
+  if (!isNativeAnonymizeBinding(anonymizeBinding)) {
     panic("anonymize-wasm getBinding() returned an unexpected binding shape");
   }
   console.log(
     "image-smoke ok: anonymize-wasm native engine — loader fixed; make this probe fatal again",
   );
-} catch (error) {
-  console.warn(
-    `image-smoke KNOWN FAILURE (tolerated): anonymize-wasm engine cannot load in the compiled binary — ${error instanceof Error ? error.message : String(error)}`,
-  );
 }
 
-console.log("image-smoke ok: all runtime assets loadable");
+console.log(
+  anonymizeBinding === null
+    ? "image-smoke done: all probes passed except the tolerated known failure above"
+    : "image-smoke ok: all runtime assets loadable",
+);

--- a/scripts/stll-registry-resolutions.test.ts
+++ b/scripts/stll-registry-resolutions.test.ts
@@ -28,27 +28,39 @@ const EXPECTED_REGISTRY_RESOLVED = [
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value);
 
+// A lockfile key is a chain of package names joined by "/", where scoped
+// names contribute two segments ("@stll/web/@babel/core" is the @babel/core
+// copy scoped to the @stll/web consumer). The trailing name is the package
+// the entry resolves.
+const trailingPackageName = (key: string): string => {
+  const segments = key.split("/");
+  const last = segments.at(-1) ?? key;
+  const scope = segments.at(-2);
+  return scope?.startsWith("@") ? `${scope}/${last}` : last;
+};
+
 const registryResolvedStllPackages = (source: unknown): string[] => {
   if (!isRecord(source) || !isRecord(source["packages"])) {
     throw new TypeError("bun.lock must contain a packages map");
   }
 
-  return Object.entries(source["packages"])
-    // Top-level entries only: "@stll/name" has exactly the scope slash.
-    // Nested keys ("@stll/web/@babel/core") are per-consumer resolution
-    // contexts, not packages of their own.
-    .filter(
-      ([key]) =>
-        key.startsWith("@stll/") && !key.slice("@stll/".length).includes("/"),
-    )
-    .filter(([, entry]) => {
-      if (!Array.isArray(entry) || typeof entry.at(0) !== "string") {
-        throw new TypeError("bun.lock package entry has no resolution");
-      }
-      return !String(entry.at(0)).includes("@workspace:");
-    })
-    .map(([key]) => key)
-    .sort();
+  const names = new Set<string>();
+  for (const [key, entry] of Object.entries(source["packages"])) {
+    // Consumer-scoped keys included: a registry copy of an otherwise
+    // workspace-linked name can hide under "consumer/@stll/name" when one
+    // consumer's range stops matching the workspace version.
+    const name = trailingPackageName(key);
+    if (!name.startsWith("@stll/")) {
+      continue;
+    }
+    if (!Array.isArray(entry) || typeof entry.at(0) !== "string") {
+      throw new TypeError(`bun.lock package ${key} has no resolution`);
+    }
+    if (!String(entry.at(0)).includes("@workspace:")) {
+      names.add(name);
+    }
+  }
+  return [...names].sort();
 };
 
 describe("@stll dependency resolutions", () => {

--- a/scripts/stll-registry-resolutions.test.ts
+++ b/scripts/stll-registry-resolutions.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "bun:test";
+
+// Bun links an @stll dependency to a local workspace only while the workspace
+// version satisfies the declared range; otherwise it installs the npm
+// registry copy. That means a version drift (workspace bumped, dependent's
+// range not) flips which code ships — silently, in both the web runner's
+// staged closure and the compiled API binary. Pin the set of @stll packages
+// that resolve from the registry so a flip in either direction fails here and
+// forces a deliberate decision: widen the range, release the package, or
+// update this pin with the reasoning in the PR.
+const EXPECTED_REGISTRY_RESOLVED = [
+  "@stll/anonymize-data",
+  "@stll/anonymize-wasm",
+  "@stll/docx-core",
+  "@stll/folio-agents",
+  "@stll/folio-core",
+  "@stll/folio-react",
+  "@stll/oxlint-config",
+  "@stll/stdnum",
+  "@stll/stdnum-darwin-arm64",
+  "@stll/stdnum-darwin-x64",
+  "@stll/stdnum-linux-arm64-gnu",
+  "@stll/stdnum-linux-x64-gnu",
+  "@stll/stdnum-wasm",
+  "@stll/stdnum-win32-x64-msvc",
+] as const;
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const registryResolvedStllPackages = (source: unknown): string[] => {
+  if (!isRecord(source) || !isRecord(source["packages"])) {
+    throw new TypeError("bun.lock must contain a packages map");
+  }
+
+  return Object.entries(source["packages"])
+    // Top-level entries only: "@stll/name" has exactly the scope slash.
+    // Nested keys ("@stll/web/@babel/core") are per-consumer resolution
+    // contexts, not packages of their own.
+    .filter(
+      ([key]) =>
+        key.startsWith("@stll/") && !key.slice("@stll/".length).includes("/"),
+    )
+    .filter(([, entry]) => {
+      if (!Array.isArray(entry) || typeof entry.at(0) !== "string") {
+        throw new TypeError("bun.lock package entry has no resolution");
+      }
+      return !String(entry.at(0)).includes("@workspace:");
+    })
+    .map(([key]) => key)
+    .sort();
+};
+
+describe("@stll dependency resolutions", () => {
+  test("registry-resolved set matches the pinned expectation", async () => {
+    const lock = Bun.JSONC.parse(
+      await Bun.file(new URL("../bun.lock", import.meta.url)).text(),
+    );
+    expect(registryResolvedStllPackages(lock)).toEqual([
+      ...EXPECTED_REGISTRY_RESOLVED,
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

The compiled API binary loads several runtime assets lazily from hand-listed Dockerfile COPYs: the anonymization engine's native glue and WASM, the quickjs sandbox WASM, the YARA rules, the worker bundles with their WASM sidecars, and the OCR PDF font. Nothing exercised them before the first request that needed them — CI compiles in a full checkout where the originals exist, and the container health check proves liveness only. This PR makes that class fail at image build, and adds a lockfile guard for silent workspace/registry resolution flips.

### Image-build runtime-asset smoke

`apps/api/src/scripts/image-smoke.ts` drives each real loader (quickjs `newAsyncContext` + eval, YARA compile + scan, anonymize `getBinding()`) and checks the exact worker-bundle set the runtime resolves. The Dockerfile compiles it like the server (so its bundled asset URLs resolve identically) and runs it in a throwaway `runtime-asset-smoke` stage on top of the runner filesystem; the final stage forces that stage via a marker copy. The probe binary never ships and the final image is unchanged apart from the marker.

Supporting changes:

- Worker bundle names move to `RUNTIME_WORKER_FILES` in `runtime-worker-path.ts`, and `resolveRuntimeWorkerPath` is typed to that map — a new worker must join the set the probe verifies, so the list cannot drift.
- `yara.ts` exports its compiled rule-file count; an empty rules directory previously compiled into a scanner that matches nothing, so a missing rules deployment would have passed silently.
- The `api-image-deps` CI job also compiles the probe, catching probe build breaks at PR time.

### Known failure surfaced by the probe (tolerated, reported)

`@stll/anonymize-wasm` loads its glue via `import()` of a specifier computed from `import.meta.url` at runtime. Inside a `bun build --compile` binary that resolves against the embedded filesystem only: the on-disk copy under `$bunfs/root/native` is reachable by fs APIs (the YARA/worker/font probes pass) but not by ESM import, so the engine cannot initialize in the compiled binary. The probe reports this loudly instead of failing the build; it flips to a hard failure in the same change that bumps the fixed loader. The fix belongs in the anonymize package (a compiled-binary-safe glue load path).

### `@stll` resolution pin

`scripts/stll-registry-resolutions.test.ts` pins which `@stll/*` packages resolve from the npm registry. Bun links a dependency to a local workspace only while the workspace version satisfies the declared range; a version drift silently flips the resolution (registry copy vs workspace source) and changes what ships — in the web runner's staged closure and in the compiled API binary alike. A flip in either direction now fails CI and demands a deliberate decision in the PR that causes it.

### Validation

Local image build: quickjs, YARA, worker-bundle, and font probes pass inside the image; the anonymize known-failure is reported as designed; the final image tags successfully. `runtime-worker-path` and `file-scan` test suites pass; the new resolution-pin test passes against the committed lockfile.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when loading document-processing workers, OCR resources and scanning rules.
  - Added safeguards to detect missing or invalid runtime assets during application image builds.

- **Tests**
  - Added automated checks to confirm required processing assets load successfully.
  - Added validation to ensure selected package resolutions remain pinned consistently.

- **Maintenance**
  - Standardised runtime asset resolution to reduce configuration-related failures across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->