### PR TITLE
fix(api): adopt anonymize-wasm 2.7.6 and load its assets from a real path

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -133,6 +133,7 @@ ENV FEATURE_TODOS=true
 ENV REQUIRE_PERSONAL_AI_KEY=true
 ENV STELLA_WORKER_DIR=/\$bunfs/root/workers
 ENV STELLA_OCR_PDF_FONT_PATH=/\$bunfs/root/fonts/CabinetGrotesk-Regular.otf
+ENV STLL_ANONYMIZE_ASSET_DIR=/app/anonymize-native
 RUN groupadd --system --gid 1001 stella && \
     useradd --system --uid 1001 --gid stella --no-create-home stella
 COPY --chown=stella:stella --from=builder /app/server /app/server
@@ -150,12 +151,13 @@ COPY --chown=stella:stella --from=install-inputs \
     /app/apps/landing/public/fonts/CabinetGrotesk-Regular.otf \
     /\$bunfs/root/fonts/CabinetGrotesk-Regular.otf
 COPY --chown=stella:stella --from=builder /app/apps/api/src/lib/file-scan/yara /\$bunfs/root/yara
-# @stll/anonymize-wasm resolves its native glue, WASM, and prepared pipeline
-# packages relative to `dist/wasm.mjs`; Bun's compiled binary resolves those
-# bundled asset URLs under `$bunfs/root/native`.
+# @stll/anonymize-wasm loads its native glue via ESM import(), which a
+# compiled binary resolves against its embedded filesystem only — fs APIs
+# fall back to disk, import() does not. STLL_ANONYMIZE_ASSET_DIR points the
+# loader at a real directory instead.
 COPY --chown=stella:stella --from=deps \
     /app/node_modules/@stll/anonymize-wasm/dist/native/ \
-    /\$bunfs/root/native/
+    /app/anonymize-native/
 # quickjs-emscripten loads this WASM file at runtime from the
 # compiled Bun binary's `$bunfs/root` asset directory.
 COPY --chown=stella:stella --from=deps \

--- a/apps/api/src/scripts/image-smoke.ts
+++ b/apps/api/src/scripts/image-smoke.ts
@@ -87,32 +87,14 @@ await probe("ocr pdf font", async () => {
   }
 });
 
-// KNOWN FAILURE, tolerated until @stll/anonymize-wasm ships a compiled-binary
-// safe loader: its glue is loaded via `import()` of a specifier computed from
-// import.meta.url at runtime, which a `bun build --compile` binary resolves
-// against its embedded filesystem only — the on-disk copy under $bunfs/root
-// is reachable by fs APIs but not by ESM import. Until the loader is fixed
-// upstream and the catalog bumped, a load failure reports instead of failing;
-// flip it to a hard failure in the same change that bumps the fix. Only the
-// load itself is tolerated: a loader that returns an unexpected binding
-// shape stays fatal.
-const anonymizeBinding = await getBinding().catch((error: unknown) => {
-  console.warn(
-    `image-smoke KNOWN FAILURE (tolerated): anonymize-wasm engine cannot load in the compiled binary — ${error instanceof Error ? error.message : String(error)}`,
-  );
-  return null;
-});
-if (anonymizeBinding !== null) {
-  if (!isNativeAnonymizeBinding(anonymizeBinding)) {
+// Requires STLL_ANONYMIZE_ASSET_DIR (set by the Dockerfile): the loader's
+// glue is loaded via ESM import(), which a compiled binary resolves against
+// its embedded filesystem only, unlike the fs-based probes above.
+await probe("anonymize-wasm native engine", async () => {
+  const binding = await getBinding();
+  if (!isNativeAnonymizeBinding(binding)) {
     panic("anonymize-wasm getBinding() returned an unexpected binding shape");
   }
-  console.log(
-    "image-smoke ok: anonymize-wasm native engine — loader fixed; make this probe fatal again",
-  );
-}
+});
 
-console.log(
-  anonymizeBinding === null
-    ? "image-smoke done: all probes passed except the tolerated known failure above"
-    : "image-smoke ok: all runtime assets loadable",
-);
+console.log("image-smoke ok: all runtime assets loadable");

--- a/bun.lock
+++ b/bun.lock
@@ -811,7 +811,7 @@
     "@oxlint/plugins": "1.75.0",
     "@silurus/ooxml": "0.76.2",
     "@stll/anonymize-data": "0.0.9",
-    "@stll/anonymize-wasm": "2.7.3",
+    "@stll/anonymize-wasm": "2.7.6",
     "@stll/folio-agents": "0.8.2",
     "@stll/folio-core": "0.15.13",
     "@stll/folio-react": "0.13.2",
@@ -2146,7 +2146,7 @@
 
     "@stll/anonymize-data": ["@stll/anonymize-data@0.0.9", "", {}, "sha512-15frKBbGsM4RhWHqqbSOs11umcXzEtnYR+OH4j1xosMh3HfrvIrqkJSk57HKyu2YgFr8LWYQ5d4dCQoU5Eu/Sg=="],
 
-    "@stll/anonymize-wasm": ["@stll/anonymize-wasm@2.7.3", "", { "peerDependencies": { "vite": ">=5 <10" }, "optionalPeers": ["vite"] }, "sha512-Tq3EyM1nOAsw9HJpaaOCA+ZLJ3n9rVbMMkhcxYq4bGNZItpIQu01GsGCprDqvcfs0TFNUzB5hUMN6jUnMj/T0Q=="],
+    "@stll/anonymize-wasm": ["@stll/anonymize-wasm@2.7.6", "", { "peerDependencies": { "vite": ">=5 <10" }, "optionalPeers": ["vite"] }, "sha512-WpPKjvKiTPTA47toTm1i4R/T5mHoZJwdif3b0M+FnAGk9OpDp9oAFRt43rigNsCPPkWTuz0Xo4XgN7YkYYOnBA=="],
 
     "@stll/api": ["@stll/api@workspace:apps/api"],
 

--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
     "@oxlint/plugins": "1.75.0",
     "@silurus/ooxml": "0.76.2",
     "@stll/anonymize-data": "0.0.9",
-    "@stll/anonymize-wasm": "2.7.3",
+    "@stll/anonymize-wasm": "2.7.6",
     "@stll/folio-agents": "0.8.2",
     "@stll/folio-core": "0.15.13",
     "@stll/folio-react": "0.13.2",


### PR DESCRIPTION
## Summary

- Bump `@stll/anonymize-wasm` to 2.7.6 in the root catalog (`@stll/anonymize-data` untouched).
- Cut the API runner over to the new asset-directory override: `dist/native/` now lands at `/app/anonymize-native` instead of `$bunfs/root/native`, and `STLL_ANONYMIZE_ASSET_DIR=/app/anonymize-native` tells the 2.7.6 loader where to find it.
- Flip the image-smoke anonymize probe from a tolerated failure to a hard failure, now that the loader can actually resolve its assets in a compiled binary.

## Why the asset-directory override

The loader resolves its native glue via ESM `import()` against a specifier computed at runtime. A `bun build --compile` binary resolves `import()` only against its embedded filesystem, so assets hand-copied to `$bunfs/root/native` (reachable by `fs` APIs, which is why the other hand-copied assets there work) were invisible to the loader. 2.7.6 adds `STLL_ANONYMIZE_ASSET_DIR` so the loader can be pointed at a real on-disk directory instead.

## Validation

- `oxfmt` + `oxlint --type-aware --deny-warnings` on `apps/api/src/scripts/image-smoke.ts`: clean.
- `bun test scripts/stll-registry-resolutions.test.ts`: 1 pass (pin still holds at 2.7.6).
- `bun test scripts/stage-web-runtime.test.ts scripts/check-web-docker-platform.test.ts`: 8 pass.
- `docker build --file apps/api/Dockerfile .`: succeeds; image-smoke output includes
  ```
  image-smoke ok: anonymize-wasm native engine
  image-smoke ok: all runtime assets loadable
  ```
  with no "KNOWN FAILURE" line.
- `bun --filter @stll/web build`: succeeds, no `stll-anonymize-wasm: could not find the assetUrl base` error.
- `bun --filter @stll/landing build`: succeeds (267 pages built).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved native anonymisation engine loading in the API runtime.
  * Smoke checks now identify native engine loading failures as errors.
  * Added validation to confirm the engine loads correctly before runtime use.

* **Chores**
  * Updated the anonymisation engine to a newer version.
  * Improved handling of native runtime assets for more reliable deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->