### PR TITLE
chore(web): pre-bundle lazy-route deps to stop dev re-optimize reloads

### DIFF
--- a/apps/web/vite.config.test.ts
+++ b/apps/web/vite.config.test.ts
@@ -79,6 +79,12 @@ describe("vite config", () => {
       "@silurus/ooxml",
     );
   });
+
+  test("serves the PDF.js worker outside the dependency optimizer", () => {
+    expect(resolveConfig("test").optimizeDeps?.exclude).toContain(
+      "pdfjs-dist/build/pdf.worker.mjs",
+    );
+  });
 });
 
 const resolveConfig = (mode: string): UserConfig => {

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -422,10 +422,6 @@ export default defineConfig(({ mode }) => {
         "diff",
         "y-prosemirror",
         "yjs",
-        // pdfjs-dist/build/pdf.worker.mjs is deliberately left out: it is a
-        // worker entrypoint, and pre-bundling those rewrites the worker URL
-        // into .vite/deps (the same failure the exclude list below guards
-        // against). It costs one reload the first time a PDF opens.
       ],
       // @stll/*-wasm packages and @silurus/ooxml load their .wasm binaries via
       // `new URL("./foo.wasm32-wasi.wasm", import.meta.url)`. Vite's dep
@@ -438,6 +434,9 @@ export default defineConfig(({ mode }) => {
       // above), which does the same thing for its napi-rs wasm32-wasip1-threads
       // binding + glue.
       exclude: [
+        // Keep this worker entrypoint at its source URL. Leaving it out of
+        // `include` is insufficient because Vite discovers it on first use.
+        "pdfjs-dist/build/pdf.worker.mjs",
         "@silurus/ooxml",
         "@stll/text-search-wasm",
         "@stll/aho-corasick-wasm",

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -383,6 +383,49 @@ export default defineConfig(({ mode }) => {
         "jszip",
         "fast-xml-parser",
         "marked",
+        // 4. Editor, chat, table, and drag-and-drop deps reached only through
+        //    lazy route splits, so the cold crawl misses every one of them.
+        //    Observed in a dev session as three optimize passes (and three
+        //    full-page reloads) inside one minute while navigating between the
+        //    chat, inspector, and document routes. Vite already pre-bundles all
+        //    of these on discovery; listing them only moves that work into the
+        //    cold pass.
+        "@atlaskit/pragmatic-drag-and-drop-auto-scroll/element",
+        "@atlaskit/pragmatic-drag-and-drop-auto-scroll/external",
+        "@atlaskit/pragmatic-drag-and-drop-hitbox/closest-edge",
+        "@atlaskit/pragmatic-drag-and-drop/element/center-under-pointer",
+        "@atlaskit/pragmatic-drag-and-drop/element/set-custom-native-drag-preview",
+        "@atlaskit/pragmatic-drag-and-drop/external/adapter",
+        "@atlaskit/pragmatic-drag-and-drop/external/file",
+        "@base-ui/react/context-menu",
+        "@base-ui/react/preview-card",
+        "@base-ui/react/tabs",
+        "@hocuspocus/provider",
+        "@libpdf/core",
+        "@stll/anonymize-data",
+        "@stll/folio-agents",
+        "@stll/folio-core",
+        "@stll/folio-core/ai-edits",
+        "@stll/folio-core/docx/documentParser",
+        "@stll/folio-core/docx/serializer/paragraphSerializer",
+        "@stll/folio-core/prosemirror/commands/comments",
+        "@stll/folio-core/prosemirror/findReplaceSelection",
+        "@stll/folio-core/utils/findReplace",
+        "@streamdown/cjk",
+        "@streamdown/math",
+        "@streamdown/mermaid",
+        "@tanstack/react-table",
+        "@tanstack/react-table/static-functions",
+        "@tiptap/extension-heading",
+        "@tiptap/extension-italic",
+        "@tiptap/extension-list",
+        "diff",
+        "y-prosemirror",
+        "yjs",
+        // pdfjs-dist/build/pdf.worker.mjs is deliberately left out: it is a
+        // worker entrypoint, and pre-bundling those rewrites the worker URL
+        // into .vite/deps (the same failure the exclude list below guards
+        // against). It costs one reload the first time a PDF opens.
       ],
       // @stll/*-wasm packages and @silurus/ooxml load their .wasm binaries via
       // `new URL("./foo.wasm32-wasi.wasm", import.meta.url)`. Vite's dep


### PR DESCRIPTION
## What

Add ~30 entries to `optimizeDeps.include` in `apps/web/vite.config.ts`: editor
(tiptap, prosemirror, yjs, hocuspocus), chat (`@streamdown/*`), table
(`@tanstack/react-table` + `/static-functions`), drag-and-drop
(`@atlaskit/pragmatic-drag-and-drop*`), `@base-ui/react` subpaths,
`@stll/folio-core` subpaths, `@stll/anonymize-data`, `@stll/folio-agents`,
`@libpdf/core`, and `diff`.

## Why

These deps are reached only through lazy route splits, so Vite's cold crawl
never sees them. Each is discovered mid-session on first navigation, and every
discovery triggers a re-optimize pass plus a forced full-page reload that
discards app state (observed: three passes and three reloads inside one minute
while navigating between the chat, inspector, and document routes). Listing the
deps upfront moves the same pre-bundling work into the cold startup pass; no new
work is performed, only its timing changes.

## Scope

Dev server only. `vite build` ignores `optimizeDeps`, so production output,
bundle-size budgets, and the network baseline are untouched.

`pdfjs-dist/build/pdf.worker.mjs` is deliberately excluded: pre-bundling a
worker entrypoint rewrites its URL into `.vite/deps`, the same failure class the
config's wasm `exclude` list guards against. Cost is one reload the first time a
PDF opens.

## Drift posture

The include list is hand-maintained and will drift as dependencies change, but
drift degrades gracefully in both directions: a missing entry re-optimizes on
discovery (today's behavior), a stale entry is at worst a startup warning. That
is why no derivation guard or generated list accompanies the change.

## Verification

- Clean dev-server boot with the change; optimizer logs no resolution failures.
- `.vite/deps/_metadata.json` after a cold start contains every added entry
  (none missing); the pdf worker is absent, as intended.
- Requesting dep-heavy lazy modules through the transform pipeline
  (collaboration session hook, streamdown message renderer, table features)
  triggered no "new dependencies optimized" reloads; the only re-optimize logged
  was the expected one-time "vite config has changed".
- Limitation: modules were exercised via direct HTTP requests to the dev server,
  not a full browser route walk, so an unlisted dep on an untouched route
  remains possible. That failure mode is the status quo (one re-optimize on
  first visit), not a regression.

An unrelated local SSR failure encountered during testing (Node < 22.18
resolving a workspace package's raw-TS exports through an externalized
dependency) was A/B-reproduced against main's config and is environmental, out
of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved initial loading and runtime performance by pre-bundling additional editor, chat, table, drag-and-drop, collaboration and PDF-related functionality.
  * Preserved PDF worker loading behaviour for reliable document handling.

* **Bug Fixes**
  * Improved PDF document processing by ensuring the PDF worker continues to load correctly during application startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->