### PR TITLE
fix: prevent duplicate changeset release PRs

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -5,8 +5,8 @@ on:
     branches: [main]
 
 concurrency:
-  # Queue instead of cancel: this workflow pushes commits to the release PR
-  # branch, so a cancelled mid-push run could leave that branch half-updated.
+  # Let the active release mutation finish; newer main pushes replace obsolete
+  # pending runs, and the shared workflow rejects stale source revisions.
   group: release-pr-${{ github.ref }}
   cancel-in-progress: false
 
@@ -18,7 +18,7 @@ jobs:
     permissions:
       contents: read
     # The repository owner publishes this versioned shared contract.
-    uses: stella/.github/.github/workflows/changeset-release-pr.yml@v1.6.0 # zizmor: ignore[unpinned-uses]
+    uses: stella/.github/.github/workflows/changeset-release-pr.yml@5dafee16c28009f17d3bc088f8aecdf9ce47a6d5
     with:
       bun-version-file: package.json
     secrets:


### PR DESCRIPTION
Serialize the release caller by target branch without cancelling an active multi-step mutation. GitHub retains the newest pending run, while the shared workflow rejects stale source revisions before write access and cleans obsolete release PR and branch state on a current no-op run.

Pin the shared workflow to immutable merge commit `5dafee16c28009f17d3bc088f8aecdf9ce47a6d5`. That revision also serializes the reusable job without cancellation and carries contract tests for freshness, cleanup, and concurrency.

Validation:
- `bun run verify`
- `actionlint .github/workflows/release-pr.yml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release workflow reliability by ensuring active release operations can complete while outdated revisions are rejected.
  * Pinned the reusable release workflow to a specific verified version, helping provide more consistent and predictable releases.
  * No changes to the application’s features or user-facing interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->