### PR TITLE
fix: validate contact numeric edits strictly

### DIFF
--- a/apps/web/src/routes/_protected.contacts/$contactId.tsx
+++ b/apps/web/src/routes/_protected.contacts/$contactId.tsx
@@ -316,7 +316,6 @@ function ContactDetailPage() {
                 contact={contact}
                 field="defaultHourlyRate"
                 label={t("contacts.fields.defaultHourlyRate")}
-                type="number"
                 value={
                   contact.defaultHourlyRate !== null
                     ? String(contact.defaultHourlyRate)
@@ -333,7 +332,6 @@ function ContactDetailPage() {
                 contact={contact}
                 field="paymentTermDays"
                 label={t("contacts.fields.paymentTermDays")}
-                type="number"
                 value={
                   contact.paymentTermDays !== null
                     ? String(contact.paymentTermDays)

--- a/apps/web/src/routes/_protected.contacts/-components/editable-row.logic.test.ts
+++ b/apps/web/src/routes/_protected.contacts/-components/editable-row.logic.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "bun:test";
 
-import { buildNumericContactPayload } from "@/routes/_protected.contacts/-components/editable-row.logic";
+import {
+  buildNumericContactPayload,
+  getEditableFieldInputAttributes,
+} from "@/routes/_protected.contacts/-components/editable-row.logic";
 
 describe("contact numeric editable fields", () => {
   test("builds exact payloads for valid integers and clearing", () => {
@@ -47,6 +50,17 @@ describe("contact numeric editable fields", () => {
 
     expect(buildNumericContactPayload("paymentTermDays", "366")).toEqual({
       status: "invalid",
+    });
+  });
+
+  test("preserves raw numeric tokens for validation", () => {
+    expect(getEditableFieldInputAttributes("defaultHourlyRate")).toEqual({
+      type: "text",
+      inputMode: "numeric",
+    });
+    expect(getEditableFieldInputAttributes("paymentTermDays")).toEqual({
+      type: "text",
+      inputMode: "numeric",
     });
   });
 });

--- a/apps/web/src/routes/_protected.contacts/-components/editable-row.logic.test.ts
+++ b/apps/web/src/routes/_protected.contacts/-components/editable-row.logic.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "bun:test";
+
+import { buildNumericContactPayload } from "@/routes/_protected.contacts/-components/editable-row.logic";
+
+describe("contact numeric editable fields", () => {
+  test("builds exact payloads for valid integers and clearing", () => {
+    expect(buildNumericContactPayload("defaultHourlyRate", "0012")).toEqual({
+      status: "valid",
+      payload: { defaultHourlyRate: 12 },
+    });
+    expect(buildNumericContactPayload("defaultHourlyRate", "")).toEqual({
+      status: "valid",
+      payload: { defaultHourlyRate: null },
+    });
+    expect(buildNumericContactPayload("paymentTermDays", "0")).toEqual({
+      status: "valid",
+      payload: { paymentTermDays: 0 },
+    });
+    expect(buildNumericContactPayload("paymentTermDays", "365")).toEqual({
+      status: "valid",
+      payload: { paymentTermDays: 365 },
+    });
+    expect(buildNumericContactPayload("paymentTermDays", "")).toEqual({
+      status: "valid",
+      payload: { paymentTermDays: null },
+    });
+  });
+
+  test("rejects partial, non-integer, negative, unsafe, and out-of-range tokens", () => {
+    const numericFields = ["defaultHourlyRate", "paymentTermDays"] as const;
+    const invalidInputs = [
+      "12oops",
+      "1e3",
+      "12.5",
+      "-1",
+      "+12",
+      "9007199254740992",
+    ];
+
+    for (const field of numericFields) {
+      for (const input of invalidInputs) {
+        expect(buildNumericContactPayload(field, input)).toEqual({
+          status: "invalid",
+        });
+      }
+    }
+
+    expect(buildNumericContactPayload("paymentTermDays", "366")).toEqual({
+      status: "invalid",
+    });
+  });
+});

--- a/apps/web/src/routes/_protected.contacts/-components/editable-row.logic.ts
+++ b/apps/web/src/routes/_protected.contacts/-components/editable-row.logic.ts
@@ -1,27 +1,27 @@
 import type { EditableField } from "@/routes/_protected.contacts/-components/types";
 
 type EditableFieldPolicy =
-  | { inputType: "text"; maxLength: number | null }
-  | { inputType: "number"; maximum: number | null };
+  | { valueKind: "text"; maxLength: number | null }
+  | { valueKind: "nonNegativeInteger"; maximum: number | null };
 
 export const EDITABLE_FIELD_POLICY = {
-  prefix: { inputType: "text", maxLength: 32 },
-  firstName: { inputType: "text", maxLength: 256 },
-  middleName: { inputType: "text", maxLength: 256 },
-  lastName: { inputType: "text", maxLength: 256 },
-  suffix: { inputType: "text", maxLength: 32 },
-  organizationName: { inputType: "text", maxLength: 512 },
-  displayName: { inputType: "text", maxLength: 512 },
-  notes: { inputType: "text", maxLength: null },
-  registrationNumber: { inputType: "text", maxLength: 64 },
-  taxId: { inputType: "text", maxLength: 64 },
-  defaultHourlyRate: { inputType: "number", maximum: null },
-  currency: { inputType: "text", maxLength: 3 },
-  paymentTermDays: { inputType: "number", maximum: 365 },
+  prefix: { valueKind: "text", maxLength: 32 },
+  firstName: { valueKind: "text", maxLength: 256 },
+  middleName: { valueKind: "text", maxLength: 256 },
+  lastName: { valueKind: "text", maxLength: 256 },
+  suffix: { valueKind: "text", maxLength: 32 },
+  organizationName: { valueKind: "text", maxLength: 512 },
+  displayName: { valueKind: "text", maxLength: 512 },
+  notes: { valueKind: "text", maxLength: null },
+  registrationNumber: { valueKind: "text", maxLength: 64 },
+  taxId: { valueKind: "text", maxLength: 64 },
+  defaultHourlyRate: { valueKind: "nonNegativeInteger", maximum: null },
+  currency: { valueKind: "text", maxLength: 3 },
+  paymentTermDays: { valueKind: "nonNegativeInteger", maximum: 365 },
 } as const satisfies Record<EditableField, EditableFieldPolicy>;
 
 type NumericEditableField = {
-  [Field in EditableField]: (typeof EDITABLE_FIELD_POLICY)[Field]["inputType"] extends "number"
+  [Field in EditableField]: (typeof EDITABLE_FIELD_POLICY)[Field]["valueKind"] extends "nonNegativeInteger"
     ? Field
     : never;
 }[EditableField];
@@ -29,7 +29,14 @@ type NumericEditableField = {
 export const isNumericEditableField = (
   field: EditableField,
 ): field is NumericEditableField =>
-  EDITABLE_FIELD_POLICY[field].inputType === "number";
+  EDITABLE_FIELD_POLICY[field].valueKind === "nonNegativeInteger";
+
+export const getEditableFieldInputAttributes = (field: EditableField) => {
+  if (EDITABLE_FIELD_POLICY[field].valueKind === "nonNegativeInteger") {
+    return { type: "text", inputMode: "numeric" } as const;
+  }
+  return { type: "text" } as const;
+};
 
 type NumericContactPayload =
   | { defaultHourlyRate: number | null }

--- a/apps/web/src/routes/_protected.contacts/-components/editable-row.logic.ts
+++ b/apps/web/src/routes/_protected.contacts/-components/editable-row.logic.ts
@@ -1,0 +1,87 @@
+import type { EditableField } from "@/routes/_protected.contacts/-components/types";
+
+type EditableFieldPolicy =
+  | { inputType: "text"; maxLength: number | null }
+  | { inputType: "number"; maximum: number | null };
+
+export const EDITABLE_FIELD_POLICY = {
+  prefix: { inputType: "text", maxLength: 32 },
+  firstName: { inputType: "text", maxLength: 256 },
+  middleName: { inputType: "text", maxLength: 256 },
+  lastName: { inputType: "text", maxLength: 256 },
+  suffix: { inputType: "text", maxLength: 32 },
+  organizationName: { inputType: "text", maxLength: 512 },
+  displayName: { inputType: "text", maxLength: 512 },
+  notes: { inputType: "text", maxLength: null },
+  registrationNumber: { inputType: "text", maxLength: 64 },
+  taxId: { inputType: "text", maxLength: 64 },
+  defaultHourlyRate: { inputType: "number", maximum: null },
+  currency: { inputType: "text", maxLength: 3 },
+  paymentTermDays: { inputType: "number", maximum: 365 },
+} as const satisfies Record<EditableField, EditableFieldPolicy>;
+
+type NumericEditableField = {
+  [Field in EditableField]: (typeof EDITABLE_FIELD_POLICY)[Field]["inputType"] extends "number"
+    ? Field
+    : never;
+}[EditableField];
+
+export const isNumericEditableField = (
+  field: EditableField,
+): field is NumericEditableField =>
+  EDITABLE_FIELD_POLICY[field].inputType === "number";
+
+type NumericContactPayload =
+  | { defaultHourlyRate: number | null }
+  | { paymentTermDays: number | null };
+
+type NumericContactPayloadResult =
+  | { status: "valid"; payload: NumericContactPayload }
+  | { status: "invalid" };
+
+const NON_NEGATIVE_INTEGER_TOKEN = /^[0-9]+$/u;
+
+const buildNumericPayload = (
+  field: NumericEditableField,
+  value: number | null,
+): NumericContactPayload => {
+  switch (field) {
+    case "defaultHourlyRate":
+      return { defaultHourlyRate: value };
+    case "paymentTermDays":
+      return { paymentTermDays: value };
+    default:
+      return field satisfies never;
+  }
+};
+
+export const buildNumericContactPayload = (
+  field: NumericEditableField,
+  trimmedInput: string,
+): NumericContactPayloadResult => {
+  if (trimmedInput === "") {
+    return {
+      status: "valid",
+      payload: buildNumericPayload(field, null),
+    };
+  }
+
+  if (!NON_NEGATIVE_INTEGER_TOKEN.test(trimmedInput)) {
+    return { status: "invalid" };
+  }
+
+  const value = Number(trimmedInput);
+  const policy = EDITABLE_FIELD_POLICY[field];
+  if (
+    !Number.isSafeInteger(value) ||
+    value < 0 ||
+    (policy.maximum !== null && value > policy.maximum)
+  ) {
+    return { status: "invalid" };
+  }
+
+  return {
+    status: "valid",
+    payload: buildNumericPayload(field, value),
+  };
+};

--- a/apps/web/src/routes/_protected.contacts/-components/editable-row.tsx
+++ b/apps/web/src/routes/_protected.contacts/-components/editable-row.tsx
@@ -12,6 +12,7 @@ import { invalidateContactCaches } from "@/routes/_protected.contacts/-component
 import {
   buildNumericContactPayload,
   EDITABLE_FIELD_POLICY,
+  getEditableFieldInputAttributes,
   isNumericEditableField,
 } from "@/routes/_protected.contacts/-components/editable-row.logic";
 import type {
@@ -42,6 +43,7 @@ export const EditableRow = ({
   });
 
   const policy = EDITABLE_FIELD_POLICY[field];
+  const inputAttributes = getEditableFieldInputAttributes(field);
 
   const rename = useInlineRename({
     initial: value ?? "",
@@ -54,9 +56,9 @@ export const EditableRow = ({
     // optional rows such as prefix, tax ID, currency, default
     // hourly rate, or payment terms back to empty.
     validate: () => null,
-    onCommit: (trimmed) => {
+    onCommit: (trimmed, { setError }) => {
       if (
-        policy.inputType === "text" &&
+        policy.valueKind === "text" &&
         policy.maxLength !== null &&
         trimmed.length > policy.maxLength
       ) {
@@ -71,6 +73,9 @@ export const EditableRow = ({
       if (isNumericEditableField(field)) {
         const result = buildNumericContactPayload(field, trimmed);
         if (result.status === "invalid") {
+          const message = t("errors.actionFailed");
+          stellaToast.add({ title: message, type: "error" });
+          setError(message);
           return;
         }
         payload = result.payload;
@@ -118,11 +123,12 @@ export const EditableRow = ({
           <span className="text-muted-foreground w-32 shrink-0">{label}</span>
         )}
         <Input
+          {...inputAttributes}
           autoFocus
           className="h-auto min-w-0 flex-1 border-0 bg-transparent p-0 text-sm shadow-none outline-none focus-visible:ring-0"
-          dir={policy.inputType === "number" ? undefined : "auto"}
+          dir={policy.valueKind === "nonNegativeInteger" ? undefined : "auto"}
           maxLength={
-            policy.inputType === "text"
+            policy.valueKind === "text"
               ? (policy.maxLength ?? undefined)
               : undefined
           }
@@ -139,7 +145,6 @@ export const EditableRow = ({
               e.currentTarget.blur();
             }
           }}
-          type={policy.inputType}
           value={rename.state.draft}
         />
       </div>

--- a/apps/web/src/routes/_protected.contacts/-components/editable-row.tsx
+++ b/apps/web/src/routes/_protected.contacts/-components/editable-row.tsx
@@ -9,6 +9,11 @@ import { useInlineRename } from "@/hooks/use-inline-rename";
 import { useUpdateContact } from "@/lib/contacts/mutations";
 import { detached } from "@/lib/detached";
 import { invalidateContactCaches } from "@/routes/_protected.contacts/-components/contact-caches";
+import {
+  buildNumericContactPayload,
+  EDITABLE_FIELD_POLICY,
+  isNumericEditableField,
+} from "@/routes/_protected.contacts/-components/editable-row.logic";
 import type {
   ContactData,
   EditableField,
@@ -16,25 +21,11 @@ import type {
 
 const protectedRouteApi = getRouteApi("/_protected");
 
-const FIELD_MAX_LENGTH: Partial<Record<EditableField, number>> = {
-  prefix: 32,
-  firstName: 256,
-  middleName: 256,
-  lastName: 256,
-  suffix: 32,
-  organizationName: 512,
-  displayName: 512,
-  registrationNumber: 64,
-  taxId: 64,
-  currency: 3,
-};
-
 type EditableRowProps = {
   label: string;
   value: string | null | undefined;
   field: EditableField;
   contact: ContactData;
-  type?: "text" | "number";
 };
 
 export const EditableRow = ({
@@ -42,7 +33,6 @@ export const EditableRow = ({
   value,
   field,
   contact,
-  type = "text",
 }: EditableRowProps) => {
   const t = useTranslations();
   const queryClient = useQueryClient();
@@ -51,7 +41,7 @@ export const EditableRow = ({
     select: (ctx) => ctx.user.activeOrganizationId,
   });
 
-  const maxLength = FIELD_MAX_LENGTH[field];
+  const policy = EDITABLE_FIELD_POLICY[field];
 
   const rename = useInlineRename({
     initial: value ?? "",
@@ -65,7 +55,11 @@ export const EditableRow = ({
     // hourly rate, or payment terms back to empty.
     validate: () => null,
     onCommit: (trimmed) => {
-      if (maxLength !== undefined && trimmed.length > maxLength) {
+      if (
+        policy.inputType === "text" &&
+        policy.maxLength !== null &&
+        trimmed.length > policy.maxLength
+      ) {
         stellaToast.add({
           title: t("errors.actionFailed"),
           type: "error",
@@ -74,15 +68,12 @@ export const EditableRow = ({
       }
 
       let payload: Record<string, unknown>;
-      if (field === "defaultHourlyRate" || field === "paymentTermDays") {
-        const parsed = trimmed ? Number.parseInt(trimmed, 10) : null;
-        if (parsed !== null && (Number.isNaN(parsed) || parsed < 0)) {
+      if (isNumericEditableField(field)) {
+        const result = buildNumericContactPayload(field, trimmed);
+        if (result.status === "invalid") {
           return;
         }
-        if (field === "paymentTermDays" && parsed !== null && parsed > 365) {
-          return;
-        }
-        payload = { [field]: parsed };
+        payload = result.payload;
       } else if (field === "displayName") {
         if (!trimmed) {
           stellaToast.add({
@@ -129,8 +120,12 @@ export const EditableRow = ({
         <Input
           autoFocus
           className="h-auto min-w-0 flex-1 border-0 bg-transparent p-0 text-sm shadow-none outline-none focus-visible:ring-0"
-          dir={type === "number" ? undefined : "auto"}
-          maxLength={maxLength}
+          dir={policy.inputType === "number" ? undefined : "auto"}
+          maxLength={
+            policy.inputType === "text"
+              ? (policy.maxLength ?? undefined)
+              : undefined
+          }
           onBlur={() => {
             detached(rename.commit(), "EditableRow");
           }}
@@ -144,7 +139,7 @@ export const EditableRow = ({
               e.currentTarget.blur();
             }
           }}
-          type={type}
+          type={policy.inputType}
           value={rename.state.draft}
         />
       </div>


### PR DESCRIPTION
Derive every editable contact field's input type and limits from one exhaustive policy map.

Reject partial, signed, decimal, exponential, out-of-range, and unsafe numeric tokens before constructing mutation payloads. Preserve field-specific clearing behavior and cover the numeric boundary matrix with focused tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for editable contact billing fields.
  * Prevented invalid, negative, fractional, unsafe, or out-of-range numeric values from being saved.
  * Allowed billing fields to be cleared safely when appropriate.

* **Tests**
  * Added coverage for valid numeric values, clearing fields, and invalid input scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->