### PR TITLE
fix: reject malformed development offsets

### DIFF
--- a/packages/scripts/src/dev-runner.test.ts
+++ b/packages/scripts/src/dev-runner.test.ts
@@ -81,6 +81,17 @@ describe("parseArgs", () => {
       skipInstall: true,
     });
   });
+
+  test.each(["8oops", "1.5", "1e2", "9007199254740992"])(
+    "rejects invalid offset value %s for both offset flags",
+    (value) => {
+      for (const flag of ["--port-offset", "--infra-offset"]) {
+        expect(() => parseArgs([flag, value])).toThrow(
+          `${flag} must be an integer`,
+        );
+      }
+    },
+  );
 });
 
 describe("resolveOffset", () => {

--- a/packages/scripts/src/dev-runner.ts
+++ b/packages/scripts/src/dev-runner.ts
@@ -195,6 +195,18 @@ const validateOffset = (offset: number, source: string) => {
   }
 };
 
+const parseIntegerValue = (value: string, source: string) => {
+  if (!/^[+-]?\d+$/u.test(value)) {
+    panic(`${source} must be an integer`);
+  }
+
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed)) {
+    panic(`${source} must be an integer`);
+  }
+  return parsed;
+};
+
 export const parseArgs = (args: readonly string[]): ParsedArgs => {
   let mode: DevMode = "dev";
   let portOffset: number | undefined;
@@ -241,7 +253,7 @@ export const parseArgs = (args: readonly string[]): ParsedArgs => {
       if (!value) {
         panic("--port-offset requires a value");
       }
-      portOffset = Number.parseInt(value, 10);
+      portOffset = parseIntegerValue(value, "--port-offset");
       i++;
       continue;
     }
@@ -261,7 +273,7 @@ export const parseArgs = (args: readonly string[]): ParsedArgs => {
       if (!value) {
         panic("--infra-offset requires a value");
       }
-      infraOffset = Number.parseInt(value, 10);
+      infraOffset = parseIntegerValue(value, "--infra-offset");
       i++;
       continue;
     }
@@ -1760,7 +1772,10 @@ const main = async () => {
   const infraOffset =
     parsedArgs.infraOffset ??
     (process.env["STELLA_INFRA_OFFSET"]
-      ? Number.parseInt(process.env["STELLA_INFRA_OFFSET"], 10)
+      ? parseIntegerValue(
+          process.env["STELLA_INFRA_OFFSET"],
+          "STELLA_INFRA_OFFSET",
+        )
       : 0);
   if (
     !Number.isInteger(infraOffset) ||
@@ -1794,7 +1809,10 @@ const main = async () => {
     portOffset:
       parsedArgs.portOffset ??
       (process.env["STELLA_PORT_OFFSET"]
-        ? Number.parseInt(process.env["STELLA_PORT_OFFSET"], 10)
+        ? parseIntegerValue(
+            process.env["STELLA_PORT_OFFSET"],
+            "STELLA_PORT_OFFSET",
+          )
         : undefined),
     worktreeName: path.basename(gitContext.currentRoot),
   });

--- a/packages/scripts/src/dev-runner.ts
+++ b/packages/scripts/src/dev-runner.ts
@@ -1769,6 +1769,14 @@ const main = async () => {
     mainRoot: gitContext.mainRoot,
   });
 
+  const portOffset =
+    parsedArgs.portOffset ??
+    (process.env["STELLA_PORT_OFFSET"]
+      ? parseIntegerValue(
+          process.env["STELLA_PORT_OFFSET"],
+          "STELLA_PORT_OFFSET",
+        )
+      : undefined);
   const infraOffset =
     parsedArgs.infraOffset ??
     (process.env["STELLA_INFRA_OFFSET"]
@@ -1806,14 +1814,7 @@ const main = async () => {
     branchName: gitContext.branchName,
     devInstance: parsedArgs.devInstance ?? process.env["STELLA_DEV_INSTANCE"],
     isWorktree: gitContext.isWorktree,
-    portOffset:
-      parsedArgs.portOffset ??
-      (process.env["STELLA_PORT_OFFSET"]
-        ? parseIntegerValue(
-            process.env["STELLA_PORT_OFFSET"],
-            "STELLA_PORT_OFFSET",
-          )
-        : undefined),
+    portOffset,
     worktreeName: path.basename(gitContext.currentRoot),
   });
   const resolvedOffset = await findFirstAvailableOffset({


### PR DESCRIPTION
Development offset inputs are parsed strictly before port selection.

- Reject malformed and unsafe integer values for CLI offsets.
- Apply the same validation to STELLA_PORT_OFFSET and STELLA_INFRA_OFFSET.
- Add regression coverage for both flags.