### PR TITLE
fix: prevent caching raw documents

### DIFF
--- a/.oxlint-plugins/__fixtures__/security-guards.fixture.tsx
+++ b/.oxlint-plugins/__fixtures__/security-guards.fixture.tsx
@@ -2,11 +2,13 @@
 
 // oxlint-disable-next-line security-guards/no-unscoped-user-query -- fixture: user import lacks organization membership scope
 import { user } from "@/api/db/auth-schema";
+import { RAW_DOCUMENT_RESPONSE_SECURITY_HEADERS } from "@/api/lib/security-headers";
 
 declare const file: { name: string };
 declare const item: { url: string };
 declare const sanitizedName: string;
 declare const safeUrl: string;
+declare const bytes: Uint8Array;
 
 // oxlint-disable-next-line security-guards/no-raw-filename-write -- fixture: raw upload name reaches persisted filename
 export const rawFile = { fileName: file.name };
@@ -17,5 +19,12 @@ export const UnsafeLink = () => (
   <a href={item.url}>Open</a>
 );
 export const SafeLink = () => <a href={safeUrl}>Open</a>;
+
+// oxlint-disable-next-line security-guards/require-raw-document-security-headers -- fixture: privileged bytes omit the shared response policy
+export const unsafeDocumentResponse = new Response(bytes);
+export const safeDocumentResponse = new Response(bytes, {
+  headers: { ...RAW_DOCUMENT_RESPONSE_SECURITY_HEADERS },
+});
+export const emptyResponse = new Response(null, { status: 404 });
 
 void user;

--- a/.oxlint-plugins/__fixtures__/security-guards.fixture.tsx
+++ b/.oxlint-plugins/__fixtures__/security-guards.fixture.tsx
@@ -21,9 +21,22 @@ export const UnsafeLink = () => (
 export const SafeLink = () => <a href={safeUrl}>Open</a>;
 
 // oxlint-disable-next-line security-guards/require-raw-document-security-headers -- fixture: privileged bytes omit the shared response policy
-export const unsafeDocumentResponse = new Response(bytes);
+export const unsafeDocumentResponse = new Response(bytes, {
+  headers: { "Content-Disposition": 'attachment; filename="unsafe.pdf"' },
+});
 export const safeDocumentResponse = new Response(bytes, {
-  headers: { ...RAW_DOCUMENT_RESPONSE_SECURITY_HEADERS },
+  headers: {
+    ...RAW_DOCUMENT_RESPONSE_SECURITY_HEADERS,
+    "Content-Disposition": 'attachment; filename="safe.pdf"',
+  },
+});
+// oxlint-disable-next-line security-guards/require-raw-document-security-headers -- fixture: a later protected override defeats the shared response policy
+export const overriddenDocumentResponse = new Response(bytes, {
+  headers: {
+    ...RAW_DOCUMENT_RESPONSE_SECURITY_HEADERS,
+    "Cache-Control": "public",
+    "Content-Disposition": 'attachment; filename="unsafe.pdf"',
+  },
 });
 export const emptyResponse = new Response(null, { status: 404 });
 

--- a/.oxlint-plugins/security-guards.ts
+++ b/.oxlint-plugins/security-guards.ts
@@ -100,16 +100,23 @@ const AUTH_SCHEMA_MODULE = "@/api/db/auth-schema";
 
 // ── Rule 4: require-raw-document-security-headers ─────────────
 //
-// Production file handlers return privileged document bytes through the
-// global Response constructor. Null-body status responses carry no document
-// data; every other Response must spread the shared security-header policy.
+// Production file handlers and attachment responses return privileged bytes
+// through the global Response constructor. Null-body status responses carry no
+// document data; every download must spread the shared security-header policy.
 
 const RAW_DOCUMENT_SECURITY_HEADERS = "RAW_DOCUMENT_RESPONSE_SECURITY_HEADERS";
 const SECURITY_HEADERS_MODULE = "@/api/lib/security-headers";
+const PROTECTED_RAW_DOCUMENT_HEADERS = new Set([
+  "cache-control",
+  "content-security-policy",
+  "referrer-policy",
+  "x-content-type-options",
+  "x-frame-options",
+]);
 
-const hasRawDocumentSecurityHeaders = (node): boolean => {
+const getHeadersObject = (node) => {
   if (node.type !== "ObjectExpression") {
-    return false;
+    return null;
   }
 
   const headersProperty = node.properties.find(
@@ -118,18 +125,81 @@ const hasRawDocumentSecurityHeaders = (node): boolean => {
       getPropertyName(property.key) === "headers",
   );
   if (!headersProperty || headersProperty.type !== "Property") {
-    return false;
+    return null;
   }
-  if (headersProperty.value.type !== "ObjectExpression") {
+
+  return headersProperty.value;
+};
+
+const hasAttachmentDisposition = (node): boolean => {
+  if (node.type !== "ObjectExpression") {
     return false;
   }
 
-  return headersProperty.value.properties.some(
+  const disposition = node.properties.find(
+    (property) =>
+      property.type === "Property" &&
+      getPropertyName(property.key)?.toLowerCase() === "content-disposition",
+  );
+  if (!disposition || disposition.type !== "Property") {
+    return false;
+  }
+
+  if (
+    disposition.value.type === "Literal" &&
+    typeof disposition.value.value === "string"
+  ) {
+    return disposition.value.value.toLowerCase().startsWith("attachment;");
+  }
+
+  return isCallTo(disposition.value, "contentDisposition");
+};
+
+const hasRawDocumentSecurityHeaders = (
+  node,
+  secureHeadersIdentifiers: Set<string>,
+): boolean => {
+  const headers = getHeadersObject(node);
+  if (!headers) {
+    return false;
+  }
+
+  if (headers.type === "Identifier") {
+    return secureHeadersIdentifiers.has(headers.name);
+  }
+  if (headers.type !== "ObjectExpression") {
+    return false;
+  }
+
+  return hasUnshadowedRawDocumentSecurityHeaders(headers);
+};
+
+const hasUnshadowedRawDocumentSecurityHeaders = (headers): boolean => {
+  const sharedHeadersIndex = headers.properties.findIndex(
     (property) =>
       property.type === "SpreadElement" &&
       isIdentifier(property.argument, RAW_DOCUMENT_SECURITY_HEADERS),
   );
+  if (sharedHeadersIndex === -1) {
+    return false;
+  }
+
+  return headers.properties.slice(sharedHeadersIndex + 1).every((property) => {
+    if (property.type === "SpreadElement") {
+      return false;
+    }
+    if (property.type !== "Property") {
+      return true;
+    }
+    const propertyName = getPropertyName(property.key)?.toLowerCase();
+    return !propertyName || !PROTECTED_RAW_DOCUMENT_HEADERS.has(propertyName);
+  });
 };
+
+const isFileHandler = (context): boolean =>
+  (context.filename ?? context.getFilename?.() ?? "")
+    .replaceAll("\\", "/")
+    .includes("/apps/api/src/handlers/files/");
 
 export default eslintCompatPlugin({
   meta: { name: "security-guards" },
@@ -400,10 +470,16 @@ export default eslintCompatPlugin({
       },
       createOnce(context) {
         let hasSecurityHeadersImport = false;
+        let fileHandler = false;
+        const downloadHeadersIdentifiers = new Set<string>();
+        const secureHeadersIdentifiers = new Set<string>();
 
         return {
           before() {
             hasSecurityHeadersImport = false;
+            fileHandler = isFileHandler(context);
+            downloadHeadersIdentifiers.clear();
+            secureHeadersIdentifiers.clear();
           },
           ImportDeclaration(node) {
             if (node.source.value !== SECURITY_HEADERS_MODULE) {
@@ -416,6 +492,26 @@ export default eslintCompatPlugin({
                 isIdentifier(specifier.local, RAW_DOCUMENT_SECURITY_HEADERS),
             );
           },
+          VariableDeclarator(node) {
+            if (
+              !isIdentifier(node.id) ||
+              node.init?.type !== "NewExpression" ||
+              !isIdentifier(node.init.callee, "Headers")
+            ) {
+              return;
+            }
+
+            const init = node.init.arguments.at(0);
+            if (!init || init.type !== "ObjectExpression") {
+              return;
+            }
+            if (hasAttachmentDisposition(init)) {
+              downloadHeadersIdentifiers.add(node.id.name);
+            }
+            if (hasUnshadowedRawDocumentSecurityHeaders(init)) {
+              secureHeadersIdentifiers.add(node.id.name);
+            }
+          },
           NewExpression(node) {
             if (!isIdentifier(node.callee, "Response")) {
               return;
@@ -427,10 +523,21 @@ export default eslintCompatPlugin({
             }
 
             const init = node.arguments.at(1);
+            const headers = init ? getHeadersObject(init) : null;
+            const isDownloadResponse =
+              fileHandler ||
+              (headers?.type === "ObjectExpression" &&
+                hasAttachmentDisposition(headers)) ||
+              (headers?.type === "Identifier" &&
+                downloadHeadersIdentifiers.has(headers.name));
+            if (!isDownloadResponse) {
+              return;
+            }
+
             if (
               hasSecurityHeadersImport &&
               init &&
-              hasRawDocumentSecurityHeaders(init)
+              hasRawDocumentSecurityHeaders(init, secureHeadersIdentifiers)
             ) {
               return;
             }

--- a/.oxlint-plugins/security-guards.ts
+++ b/.oxlint-plugins/security-guards.ts
@@ -4,6 +4,8 @@
 //   1. no-raw-filename-write  — raw user input in fileName properties
 //   2. no-unsanitized-href    — dynamic href without sanitization
 //   3. no-unscoped-user-query — user table import without member scoping
+//   4. require-raw-document-security-headers — raw document responses
+//      without the shared cache/sniff/frame/CSP policy
 
 import { eslintCompatPlugin, type Ranged } from "@oxlint/plugins";
 
@@ -95,6 +97,39 @@ const isSanitizeHrefCall = (node): boolean => isCallTo(node, "sanitizeHref");
 // Only applies to handler files (configured via overrides).
 
 const AUTH_SCHEMA_MODULE = "@/api/db/auth-schema";
+
+// ── Rule 4: require-raw-document-security-headers ─────────────
+//
+// Production file handlers return privileged document bytes through the
+// global Response constructor. Null-body status responses carry no document
+// data; every other Response must spread the shared security-header policy.
+
+const RAW_DOCUMENT_SECURITY_HEADERS = "RAW_DOCUMENT_RESPONSE_SECURITY_HEADERS";
+const SECURITY_HEADERS_MODULE = "@/api/lib/security-headers";
+
+const hasRawDocumentSecurityHeaders = (node): boolean => {
+  if (node.type !== "ObjectExpression") {
+    return false;
+  }
+
+  const headersProperty = node.properties.find(
+    (property) =>
+      property.type === "Property" &&
+      getPropertyName(property.key) === "headers",
+  );
+  if (!headersProperty || headersProperty.type !== "Property") {
+    return false;
+  }
+  if (headersProperty.value.type !== "ObjectExpression") {
+    return false;
+  }
+
+  return headersProperty.value.properties.some(
+    (property) =>
+      property.type === "SpreadElement" &&
+      isIdentifier(property.argument, RAW_DOCUMENT_SECURITY_HEADERS),
+  );
+};
 
 export default eslintCompatPlugin({
   meta: { name: "security-guards" },
@@ -348,6 +383,59 @@ export default eslintCompatPlugin({
                 messageId: "unscopedUserQuery",
               });
             }
+          },
+        };
+      },
+    },
+
+    // ── require-raw-document-security-headers ─────────────────
+    "require-raw-document-security-headers": {
+      meta: {
+        type: "problem",
+        messages: {
+          missingHeaders:
+            "Raw document responses must spread " +
+            "RAW_DOCUMENT_RESPONSE_SECURITY_HEADERS into their headers.",
+        },
+      },
+      createOnce(context) {
+        let hasSecurityHeadersImport = false;
+
+        return {
+          before() {
+            hasSecurityHeadersImport = false;
+          },
+          ImportDeclaration(node) {
+            if (node.source.value !== SECURITY_HEADERS_MODULE) {
+              return;
+            }
+
+            hasSecurityHeadersImport = node.specifiers.some(
+              (specifier) =>
+                getImportedName(specifier) === RAW_DOCUMENT_SECURITY_HEADERS &&
+                isIdentifier(specifier.local, RAW_DOCUMENT_SECURITY_HEADERS),
+            );
+          },
+          NewExpression(node) {
+            if (!isIdentifier(node.callee, "Response")) {
+              return;
+            }
+
+            const body = node.arguments.at(0);
+            if (!body || (body.type === "Literal" && body.value === null)) {
+              return;
+            }
+
+            const init = node.arguments.at(1);
+            if (
+              hasSecurityHeadersImport &&
+              init &&
+              hasRawDocumentSecurityHeaders(init)
+            ) {
+              return;
+            }
+
+            context.report({ node, messageId: "missingHeaders" });
           },
         };
       },

--- a/apps/api/src/handlers/clauses/export.ts
+++ b/apps/api/src/handlers/clauses/export.ts
@@ -12,6 +12,7 @@ import type { SafeId } from "@/api/lib/branded-types";
 import { escapeCSV } from "@/api/lib/csv";
 import { LIMITS } from "@/api/lib/limits";
 import { brandPersistedClauseId } from "@/api/lib/safe-id-boundaries";
+import { RAW_DOCUMENT_RESPONSE_SECURITY_HEADERS } from "@/api/lib/security-headers";
 import { isRecord } from "@/api/lib/type-guards";
 
 import { buildClauseCategoryPath } from "./category-path";
@@ -108,6 +109,7 @@ export const exportHandler = async function* ({
       new Response(csvContent, {
         status: 200,
         headers: {
+          ...RAW_DOCUMENT_RESPONSE_SECURITY_HEADERS,
           "Content-Type": "text/csv",
           "Content-Disposition": 'attachment; filename="clauses-export.csv"',
         },
@@ -188,6 +190,7 @@ export const exportHandler = async function* ({
     new Response(JSON.stringify(payload, null, 2), {
       status: 200,
       headers: {
+        ...RAW_DOCUMENT_RESPONSE_SECURITY_HEADERS,
         "Content-Type": "application/json",
         "Content-Disposition": 'attachment; filename="clauses-export.json"',
       },

--- a/apps/api/src/handlers/entities/download-zip.ts
+++ b/apps/api/src/handlers/entities/download-zip.ts
@@ -33,6 +33,7 @@ import { createFileKey } from "@/api/lib/files/utils";
 import { getS3 } from "@/api/lib/s3";
 import { brandPersistedEntityId } from "@/api/lib/safe-id-boundaries";
 import { sanitizeFilename } from "@/api/lib/sanitize-filename";
+import { RAW_DOCUMENT_RESPONSE_SECURITY_HEADERS } from "@/api/lib/security-headers";
 
 const downloadZipParamsSchema = workspaceParams({
   entityId: tSafeId("entity"),
@@ -315,6 +316,7 @@ const downloadZipHandler = async function* ({
   return Result.ok(
     new Response(makeZip(archiveEntries()), {
       headers: {
+        ...RAW_DOCUMENT_RESPONSE_SECURITY_HEADERS,
         "Content-Type": "application/zip",
         "Content-Disposition": contentDisposition(zipFileName),
       },

--- a/apps/api/src/handlers/files/email-attachment.ts
+++ b/apps/api/src/handlers/files/email-attachment.ts
@@ -134,7 +134,6 @@ export default createSafeHandler(
       new Response(new Uint8Array(responseBytes), {
         headers: {
           ...RAW_DOCUMENT_RESPONSE_SECURITY_HEADERS,
-          "Cache-Control": "private, no-store",
           "Content-Disposition": safeDisposition,
           "Content-Length": String(responseBytes.byteLength),
           "Content-Type": mimeType,

--- a/apps/api/src/handlers/files/get.ts
+++ b/apps/api/src/handlers/files/get.ts
@@ -358,12 +358,12 @@ const pdfResponse = (buffer: ArrayBuffer, fileName: string) =>
 const streamedPdfResponse = (response: Response, fileName: string) =>
   new Response(response.body, {
     headers: {
-      ...RAW_DOCUMENT_RESPONSE_SECURITY_HEADERS,
-      "Content-Type": PDF_MIME_TYPE,
-      "Content-Disposition": inlineContentDisposition(fileName),
       ...(response.headers.has("Content-Length")
         ? { "Content-Length": response.headers.get("Content-Length") ?? "" }
         : {}),
+      ...RAW_DOCUMENT_RESPONSE_SECURITY_HEADERS,
+      "Content-Type": PDF_MIME_TYPE,
+      "Content-Disposition": inlineContentDisposition(fileName),
     },
   });
 

--- a/apps/api/src/handlers/templates/fill-by-id.ts
+++ b/apps/api/src/handlers/templates/fill-by-id.ts
@@ -38,6 +38,7 @@ import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import { convertToPdf } from "@/api/lib/files/gotenberg";
 import { readS3ArrayBuffer } from "@/api/lib/s3";
 import { DOCX_EXT_RE } from "@/api/lib/sanitize-filename";
+import { RAW_DOCUMENT_RESPONSE_SECURITY_HEADERS } from "@/api/lib/security-headers";
 import { recordTemplateUse } from "@/api/lib/templates/record-use";
 import { containsNull } from "@/api/lib/templates/template-data";
 import { isRecord } from "@/api/lib/type-guards";
@@ -402,6 +403,7 @@ const fillByIdHandler = async function* ({
       new Response(new Uint8Array(pdfResult.value.buffer), {
         status: 200,
         headers: {
+          ...RAW_DOCUMENT_RESPONSE_SECURITY_HEADERS,
           // Octet-stream, not application/pdf: see OCTET_STREAM_MIME_TYPE.
           "Content-Type": OCTET_STREAM_MIME_TYPE,
           "Content-Disposition": contentDisposition(pdfName),
@@ -411,6 +413,7 @@ const fillByIdHandler = async function* ({
   }
 
   const headers = new Headers({
+    ...RAW_DOCUMENT_RESPONSE_SECURITY_HEADERS,
     // Octet-stream, not the DOCX mime type: the Eden treaty client
     // text-decodes unrecognized content types, which corrupts the ZIP
     // container (Word then reports unreadable content). See

--- a/apps/api/src/handlers/templates/fill.ts
+++ b/apps/api/src/handlers/templates/fill.ts
@@ -34,6 +34,7 @@ import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import { convertToPdf } from "@/api/lib/files/gotenberg";
 import { FILE_SIZE_LIMITS } from "@/api/lib/limits";
 import { DOCX_EXT_RE, sanitizeFilename } from "@/api/lib/sanitize-filename";
+import { RAW_DOCUMENT_RESPONSE_SECURITY_HEADERS } from "@/api/lib/security-headers";
 import { hasTanStackInstanceProvider } from "@/api/lib/tanstack-ai-models";
 import { containsNull } from "@/api/lib/templates/template-data";
 import { isRecord } from "@/api/lib/type-guards";
@@ -379,6 +380,7 @@ export const fillHandler = async ({
     return new Response(new Uint8Array(pdfResult.value.buffer), {
       status: 200,
       headers: {
+        ...RAW_DOCUMENT_RESPONSE_SECURITY_HEADERS,
         // Octet-stream, not application/pdf: see OCTET_STREAM_MIME_TYPE.
         "Content-Type": OCTET_STREAM_MIME_TYPE,
         "Content-Disposition": contentDisposition(pdfName),
@@ -387,6 +389,7 @@ export const fillHandler = async ({
   }
 
   const headers = new Headers({
+    ...RAW_DOCUMENT_RESPONSE_SECURITY_HEADERS,
     // Octet-stream, not the DOCX mime type: the Eden treaty client
     // text-decodes unrecognized content types, which corrupts the ZIP
     // container (Word then reports unreadable content). See

--- a/apps/api/src/handlers/templates/manifest.ts
+++ b/apps/api/src/handlers/templates/manifest.ts
@@ -9,6 +9,7 @@ import type { TemplateManifest } from "@/api/lib/docx/types";
 import { isFieldMeta } from "@/api/lib/docx/types";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import { FILE_SIZE_LIMITS } from "@/api/lib/limits";
+import { RAW_DOCUMENT_RESPONSE_SECURITY_HEADERS } from "@/api/lib/security-headers";
 import { isRecord } from "@/api/lib/type-guards";
 import { DOCX_MIME_TYPE } from "@/api/mime-types";
 
@@ -103,6 +104,7 @@ export const manifestHandler = async ({
   return new Response(new Uint8Array(resultBuffer), {
     status: 200,
     headers: {
+      ...RAW_DOCUMENT_RESPONSE_SECURITY_HEADERS,
       "Content-Type":
         "application/vnd.openxmlformats-officedocument" +
         ".wordprocessingml.document",

--- a/apps/api/src/handlers/views/table-export.ts
+++ b/apps/api/src/handlers/views/table-export.ts
@@ -19,6 +19,7 @@ import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import { LIMITS } from "@/api/lib/limits";
 import { extractFormattingLocale } from "@/api/lib/locale";
 import { sanitizeFilename } from "@/api/lib/sanitize-filename";
+import { RAW_DOCUMENT_RESPONSE_SECURITY_HEADERS } from "@/api/lib/security-headers";
 import { excludedEntityKindsForView } from "@/api/lib/views";
 import { parseViewLayout } from "@/api/lib/views-schema";
 import {
@@ -768,6 +769,7 @@ const exportTableView = createSafeHandler(
     return Result.ok(
       new Response(body, {
         headers: {
+          ...RAW_DOCUMENT_RESPONSE_SECURITY_HEADERS,
           "Content-Disposition": contentDisposition(filename),
           "Content-Type": contentType,
         },

--- a/apps/api/src/lib/s3-presign.test.ts
+++ b/apps/api/src/lib/s3-presign.test.ts
@@ -7,6 +7,7 @@ import {
   hasScopedSessionTimeForPresign,
   headObject,
   isS3KeyInSigningScope,
+  presignDownloadUrl,
   presignUploadUrl,
   resetAwsS3ClientForTesting,
 } from "@/api/lib/s3-presign";
@@ -181,6 +182,18 @@ describe("presignUploadUrl", () => {
     expect(parsed.searchParams.has("x-amz-tagging")).toBe(false);
     expect(result.value.headers["x-amz-tagging"]).toBe(
       "stella-upload-stage=tmp",
+    );
+  });
+});
+
+describe("presignDownloadUrl", () => {
+  test("requires storage to return the shared no-store cache policy", async () => {
+    const url = await presignDownloadUrl("org_1/ws_1/file_1.pdf", {
+      expiresIn: 60,
+    });
+
+    expect(new URL(url).searchParams.get("response-cache-control")).toBe(
+      "private, no-store",
     );
   });
 });

--- a/apps/api/src/lib/s3-presign.ts
+++ b/apps/api/src/lib/s3-presign.ts
@@ -34,6 +34,7 @@ import { Result, TaggedError } from "better-result";
 import { envBase } from "@/api/env-base";
 import { contentDisposition } from "@/api/lib/content-disposition";
 import { resolveS3Credentials } from "@/api/lib/s3";
+import { RAW_DOCUMENT_RESPONSE_SECURITY_HEADERS } from "@/api/lib/security-headers";
 
 export class S3PresignError extends TaggedError("S3PresignError")<{
   message: string;
@@ -515,6 +516,8 @@ export const presignDownloadUrl = async (
         new GetObjectCommand({
           Bucket: envBase.S3_BUCKET,
           Key: key,
+          ResponseCacheControl:
+            RAW_DOCUMENT_RESPONSE_SECURITY_HEADERS["Cache-Control"],
           ...(fileName
             ? { ResponseContentDisposition: contentDisposition(fileName) }
             : {}),

--- a/apps/api/src/lib/security-headers.test.ts
+++ b/apps/api/src/lib/security-headers.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from "bun:test";
+
+import { RAW_DOCUMENT_RESPONSE_SECURITY_HEADERS } from "@/api/lib/security-headers";
+
+describe("raw document response security", () => {
+  test("prevents sensitive document bytes from being cached", () => {
+    const response = new Response(new Uint8Array([1]), {
+      headers: RAW_DOCUMENT_RESPONSE_SECURITY_HEADERS,
+    });
+
+    expect(response.headers.get("Cache-Control")).toBe("private, no-store");
+  });
+});

--- a/apps/api/src/lib/security-headers.ts
+++ b/apps/api/src/lib/security-headers.ts
@@ -32,9 +32,11 @@ export const setSecurityHeaders = (set: Context["set"]) => {
  * would otherwise be served without nosniff/frame/CSP protection and could be
  * MIME-sniffed (e.g. a `text/html` upload rendered inline) or framed. Every
  * raw document `Response` must spread these into its headers so that class of
- * gap cannot recur per-endpoint.
+ * gap cannot recur per-endpoint. Sensitive document bytes must also remain out
+ * of browser and intermediary caches.
  */
 export const RAW_DOCUMENT_RESPONSE_SECURITY_HEADERS = {
+  "Cache-Control": "private, no-store",
   "X-Content-Type-Options": "nosniff",
   "X-Frame-Options": "DENY",
   "Referrer-Policy": "no-referrer",

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -1935,8 +1935,8 @@ export default defineConfig({
       },
     },
     {
-      files: ["apps/api/src/handlers/files/**/*.ts"],
-      excludeFiles: ["apps/api/src/handlers/files/**/*.test.ts"],
+      files: ["apps/api/src/handlers/**/*.ts"],
+      excludeFiles: ["apps/api/src/handlers/**/*.test.ts"],
       rules: {
         "security-guards/require-raw-document-security-headers": "error",
       },

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -107,6 +107,7 @@ const fixtureRuleOverrides = [
     "security-guards/no-raw-filename-write",
     "security-guards/no-unsanitized-href",
     "security-guards/no-unscoped-user-query",
+    "security-guards/require-raw-document-security-headers",
   ]),
   fixtureRuleOverride("stella-toast.fixture.ts", ["stella-toast/stella-toast"]),
   fixtureRuleOverride("suppression-hygiene.fixture.ts", [
@@ -1413,8 +1414,7 @@ export default defineConfig({
         ".oxlint-plugins/__fixtures__/no-unowned-file-version-write.fixture.ts",
       ],
       rules: {
-        "no-unowned-file-version-write/no-unowned-file-version-write":
-          "error",
+        "no-unowned-file-version-write/no-unowned-file-version-write": "error",
       },
     },
     {
@@ -1903,8 +1903,7 @@ export default defineConfig({
       files: ["apps/api/src/**/*.ts"],
       excludeFiles: ["apps/api/src/**/*.test.ts", "apps/api/src/tests/**/*.ts"],
       rules: {
-        "no-unowned-file-version-write/no-unowned-file-version-write":
-          "error",
+        "no-unowned-file-version-write/no-unowned-file-version-write": "error",
       },
     },
     {
@@ -1933,6 +1932,13 @@ export default defineConfig({
           { drizzleObjectName: ["db", "tx"] },
         ],
         "security-guards/no-raw-filename-write": "error",
+      },
+    },
+    {
+      files: ["apps/api/src/handlers/files/**/*.ts"],
+      excludeFiles: ["apps/api/src/handlers/files/**/*.test.ts"],
+      rules: {
+        "security-guards/require-raw-document-security-headers": "error",
       },
     },
     {


### PR DESCRIPTION
## Summary

- prevent browser and intermediary caching of raw document responses
- enforce shared raw-document security headers in file handlers with an oxlint guard
- add regression coverage for the cache policy and lint invariant