### PR TITLE
fix: repair nightly locale typecheck

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,7 @@ jobs:
       mobile_build_required: ${{ steps.changed-files.outputs.mobile_build_required }}
       ocr_image_required: ${{ steps.changed-files.outputs.ocr_image_required }}
       package_checks_required: ${{ steps.changed-files.outputs.package_checks_required }}
+      release_typecheck_required: ${{ steps.changed-files.outputs.release_typecheck_required }}
       web_build_required: ${{ steps.changed-files.outputs.web_build_required }}
       web_image_smoke_required: ${{ steps.changed-files.outputs.web_image_smoke_required }}
       windows_scripts_required: ${{ steps.changed-files.outputs.windows_scripts_required }}
@@ -102,6 +103,7 @@ jobs:
               echo "mobile_build_required=true"
               echo "ocr_image_required=true"
               echo "package_checks_required=true"
+              echo "release_typecheck_required=false"
               echo "web_build_required=true"
               echo "web_image_smoke_required=true"
               echo "windows_scripts_required=true"
@@ -124,6 +126,7 @@ jobs:
               echo "mobile_build_required=false"
               echo "ocr_image_required=false"
               echo "package_checks_required=true"
+              echo "release_typecheck_required=false"
               echo "web_build_required=false"
               echo "web_image_smoke_required=false"
               echo "windows_scripts_required=false"
@@ -157,10 +160,14 @@ jobs:
           legal_atlas_image_required=false
           mobile_build_required=false
           ocr_image_required=false
+          release_typecheck_required=false
           web_build_required=false
           web_image_smoke_required=false
           windows_scripts_required=false
           for file in "${changed_files[@]}"; do
+            if [[ "$file" == "VERSION" ]]; then
+              release_typecheck_required=true
+            fi
             case "$file" in
               .github/workflows/agent-sandbox-canary.yml|.github/workflows/ci.yml|packages/agent-engine/*|package.json|bun.lock|scripts/bun-ci-retry.sh)
                 agent_sandbox_docker_required=true
@@ -233,6 +240,7 @@ jobs:
             echo "mobile_build_required=$mobile_build_required"
             echo "ocr_image_required=$ocr_image_required"
             echo "package_checks_required=$package_checks_required"
+            echo "release_typecheck_required=$release_typecheck_required"
             echo "web_build_required=$web_build_required"
             echo "web_image_smoke_required=$web_image_smoke_required"
             echo "windows_scripts_required=$windows_scripts_required"
@@ -999,6 +1007,39 @@ jobs:
         env:
           DATABASE_URL: postgres://stella_owner:stella@127.0.0.1:5432/stella
         run: bun run test:postgres
+
+  # A VERSION change is the last review boundary before tag creation. Pay the
+  # cost of the compiler's complete, uncached project graph there while keeping
+  # ordinary pull requests on the fast Oxc diagnostics path.
+  release-typecheck:
+    needs: ci-plan
+    if: >-
+      github.event_name == 'pull_request'
+      && needs.ci-plan.outputs.release_typecheck_required == 'true'
+      && needs.ci-plan.outputs.trusted == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Bun
+        uses: stella/.github/actions/setup-bun-cached@859a61ee0a799ba1028281329555cadee15bfc4f
+
+      - name: Install dependencies
+        run: bash scripts/bun-ci-retry.sh --ignore-scripts
+        env:
+          NPM_TOKEN: ""
+
+      - name: Full release typecheck
+        run: bun run typecheck && bun run typecheck:repo
+        env:
+          TURBO_FORCE: "true"
 
   # Typecheck-cost baseline guard. What silently rots is the compiler's
   # workload: an annotation-heavy or inference-exploding pattern in a hot
@@ -2052,6 +2093,7 @@ jobs:
         ci-checks,
         code-quality,
         postgres-suites,
+        release-typecheck,
         typecheck-baseline,
         web-build,
         web-image-smoke,
@@ -2085,6 +2127,7 @@ jobs:
           TRUSTED: ${{ needs.ci-plan.outputs.trusted }}
           PLAN_RESULT: ${{ needs.ci-plan.result }}
           POSTGRES_SUITES_RESULT: ${{ needs.postgres-suites.result }}
+          RELEASE_TYPECHECK_RESULT: ${{ needs.release-typecheck.result }}
           TYPECHECK_BASELINE_RESULT: ${{ needs.typecheck-baseline.result }}
           WEB_RESULT: ${{ needs.web-build.result }}
           WEB_IMAGE_SMOKE_RESULT: ${{ needs.web-image-smoke.result }}
@@ -2103,6 +2146,7 @@ jobs:
                   || "$AGENT_SANDBOX_DOCKER_RESULT" == "failure" || "$AGENT_SANDBOX_DOCKER_RESULT" == "cancelled" \
                   || "$CODE_QUALITY_RESULT" == "failure" || "$CODE_QUALITY_RESULT" == "cancelled" \
                   || "$POSTGRES_SUITES_RESULT" == "failure" || "$POSTGRES_SUITES_RESULT" == "cancelled" \
+                  || "$RELEASE_TYPECHECK_RESULT" == "failure" || "$RELEASE_TYPECHECK_RESULT" == "cancelled" \
                   || "$TYPECHECK_BASELINE_RESULT" == "failure" || "$TYPECHECK_BASELINE_RESULT" == "cancelled" \
                   || "$WEB_RESULT" == "failure" || "$WEB_RESULT" == "cancelled" \
                   || "$WEB_IMAGE_SMOKE_RESULT" == "failure" || "$WEB_IMAGE_SMOKE_RESULT" == "cancelled" \
@@ -2139,12 +2183,12 @@ jobs:
 
           # "cancelled" means cancel-in-progress replaced this
           # run with a newer one; the newer run is authoritative.
-          if [[ "$AGENT_SANDBOX_DOCKER_RESULT" == "cancelled" || "$CI_RESULT" == "cancelled" || "$CODE_QUALITY_RESULT" == "cancelled" || "$POSTGRES_SUITES_RESULT" == "cancelled" || "$TYPECHECK_BASELINE_RESULT" == "cancelled" || "$WEB_RESULT" == "cancelled" || "$WEB_IMAGE_SMOKE_RESULT" == "cancelled" || "$MOBILE_RESULT" == "cancelled" || "$LANDING_RESULT" == "cancelled" || "$E2E_RESULT" == "cancelled" || "$API_IMAGE_DEPS_RESULT" == "cancelled" || "$OCR_IMAGE_RESULT" == "cancelled" || "$LEGAL_ATLAS_IMAGE_RESULT" == "cancelled" || "$WINDOWS_SCRIPTS_RESULT" == "cancelled" || "$CHANGESET_RESULT" == "cancelled" || "$DESKTOP_CLIPPY_RESULT" == "cancelled" ]]; then
+          if [[ "$AGENT_SANDBOX_DOCKER_RESULT" == "cancelled" || "$CI_RESULT" == "cancelled" || "$CODE_QUALITY_RESULT" == "cancelled" || "$POSTGRES_SUITES_RESULT" == "cancelled" || "$RELEASE_TYPECHECK_RESULT" == "cancelled" || "$TYPECHECK_BASELINE_RESULT" == "cancelled" || "$WEB_RESULT" == "cancelled" || "$WEB_IMAGE_SMOKE_RESULT" == "cancelled" || "$MOBILE_RESULT" == "cancelled" || "$LANDING_RESULT" == "cancelled" || "$E2E_RESULT" == "cancelled" || "$API_IMAGE_DEPS_RESULT" == "cancelled" || "$OCR_IMAGE_RESULT" == "cancelled" || "$LEGAL_ATLAS_IMAGE_RESULT" == "cancelled" || "$WINDOWS_SCRIPTS_RESULT" == "cancelled" || "$CHANGESET_RESULT" == "cancelled" || "$DESKTOP_CLIPPY_RESULT" == "cancelled" ]]; then
             echo "CI run was superseded by a newer run (cancel-in-progress). Passing."
             exit 0
           fi
 
-          if [[ "$AGENT_SANDBOX_DOCKER_RESULT" == "failure" || "$CI_RESULT" == "failure" || "$CODE_QUALITY_RESULT" == "failure" || "$POSTGRES_SUITES_RESULT" == "failure" || "$TYPECHECK_BASELINE_RESULT" == "failure" || "$WEB_RESULT" == "failure" || "$WEB_IMAGE_SMOKE_RESULT" == "failure" || "$MOBILE_RESULT" == "failure" || "$LANDING_RESULT" == "failure" || "$E2E_RESULT" == "failure" || "$API_IMAGE_DEPS_RESULT" == "failure" || "$OCR_IMAGE_RESULT" == "failure" || "$LEGAL_ATLAS_IMAGE_RESULT" == "failure" || "$WINDOWS_SCRIPTS_RESULT" == "failure" || "$CHANGESET_RESULT" == "failure" || "$DESKTOP_CLIPPY_RESULT" == "failure" ]]; then
+          if [[ "$AGENT_SANDBOX_DOCKER_RESULT" == "failure" || "$CI_RESULT" == "failure" || "$CODE_QUALITY_RESULT" == "failure" || "$POSTGRES_SUITES_RESULT" == "failure" || "$RELEASE_TYPECHECK_RESULT" == "failure" || "$TYPECHECK_BASELINE_RESULT" == "failure" || "$WEB_RESULT" == "failure" || "$WEB_IMAGE_SMOKE_RESULT" == "failure" || "$MOBILE_RESULT" == "failure" || "$LANDING_RESULT" == "failure" || "$E2E_RESULT" == "failure" || "$API_IMAGE_DEPS_RESULT" == "failure" || "$OCR_IMAGE_RESULT" == "failure" || "$LEGAL_ATLAS_IMAGE_RESULT" == "failure" || "$WINDOWS_SCRIPTS_RESULT" == "failure" || "$CHANGESET_RESULT" == "failure" || "$DESKTOP_CLIPPY_RESULT" == "failure" ]]; then
             echo "::error::CI checks failed."
             exit 1
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -391,7 +391,7 @@ jobs:
             --volume "$RUNNER_TEMP/mcp-canary-server.mjs:/workspace/mcp-canary-server.mjs:ro" \
             "$AGENT_ENGINE_DOCKER_IMAGE" \
             node /workspace/mcp-canary-server.mjs
-          for attempt in {1..40}; do
+          for _ in {1..40}; do
             if docker exec "$NETWORK_CANARY_CONTAINER" node -e \
               'fetch("http://127.0.0.1:8787/health", { signal: AbortSignal.timeout(1000) }).then(async (response) => process.exit(response.ok && await response.text() === "sandbox-network-canary" ? 0 : 1), () => process.exit(1))'; then
               exit 0

--- a/packages/locales/src/directions.ts
+++ b/packages/locales/src/directions.ts
@@ -3,7 +3,7 @@ import type { UiLocale } from "./languages.js";
 
 export type TextDirection = "ltr" | "rtl";
 
-export const UI_LOCALE_DIRECTIONS = {
+export const UI_LOCALE_DIRECTIONS: Readonly<Record<UiLocale, TextDirection>> = {
   en: "ltr",
   ar: "rtl",
   cs: "ltr",
@@ -17,11 +17,11 @@ export const UI_LOCALE_DIRECTIONS = {
   pl: "ltr",
   "pt-BR": "ltr",
   sk: "ltr",
-} as const satisfies Record<UiLocale, TextDirection>;
+};
 
 export const getUiLocaleDirection = (locale: UiLocale): TextDirection =>
   UI_LOCALE_DIRECTIONS[locale];
 
-export const RTL_UI_LOCALES = UI_LOCALES.filter(
+export const RTL_UI_LOCALES: UiLocale[] = UI_LOCALES.filter(
   (locale) => UI_LOCALE_DIRECTIONS[locale] === "rtl",
 );

--- a/packages/locales/src/directions.ts
+++ b/packages/locales/src/directions.ts
@@ -3,7 +3,13 @@ import type { UiLocale } from "./languages.js";
 
 export type TextDirection = "ltr" | "rtl";
 
-export const UI_LOCALE_DIRECTIONS: Readonly<Record<UiLocale, TextDirection>> = {
+type RtlUiLocale = "ar";
+
+type UiLocaleDirections = {
+  readonly [Locale in UiLocale]: Locale extends RtlUiLocale ? "rtl" : "ltr";
+};
+
+export const UI_LOCALE_DIRECTIONS: UiLocaleDirections = {
   en: "ltr",
   ar: "rtl",
   cs: "ltr",

--- a/packages/locales/src/locales.test.ts
+++ b/packages/locales/src/locales.test.ts
@@ -7,8 +7,17 @@ import {
   LANGUAGES,
   resolveUiLocale,
   toLanguageCode,
+  UI_LOCALE_DIRECTIONS,
   UI_LANGUAGES,
 } from "./index.js";
+
+test("locale directions preserve their public literal types", () => {
+  const arabicDirection: "rtl" = UI_LOCALE_DIRECTIONS.ar;
+  const englishDirection: "ltr" = UI_LOCALE_DIRECTIONS.en;
+
+  expect(arabicDirection).toBe("rtl");
+  expect(englishDirection).toBe("ltr");
+});
 
 describe("LANGUAGES", () => {
   test("contains every code exactly once", () => {

--- a/scripts/detect-e2e-changes.test.ts
+++ b/scripts/detect-e2e-changes.test.ts
@@ -258,9 +258,37 @@ describe("detect-e2e-changes", () => {
       'if [[ "$EVENT_NAME" == "workflow_dispatch" ]]',
     );
     expect(codeQuality).toContain("bun run code-check\n");
+    expect(codeQuality).not.toContain("bun run typecheck\n");
     expect(codeQuality).toContain(
       'bun run code-check:affected -- --base "origin/$BASE_REF"',
     );
+  });
+
+  test("runs the full native compiler only at the release boundary", () => {
+    const plan = workflowJob("ci-plan");
+    expect(plan).toContain(
+      `release_typecheck_required: ${githubExpression("steps.changed-files.outputs.release_typecheck_required")}`,
+    );
+    expect(plan).toContain('if [[ "$file" == "VERSION" ]]');
+    expect(plan).toContain("release_typecheck_required=true");
+
+    const releaseTypecheck = workflowJob("release-typecheck");
+    expect(releaseTypecheck).toContain(
+      "needs.ci-plan.outputs.release_typecheck_required == 'true'",
+    );
+    expect(releaseTypecheck).toContain("github.event_name == 'pull_request'");
+    expect(releaseTypecheck).toContain(
+      "run: bun run typecheck && bun run typecheck:repo",
+    );
+    expect(releaseTypecheck).toContain('TURBO_FORCE: "true"');
+
+    const result = workflowJob("ci-result");
+    expect(result).toContain("release-typecheck");
+    expect(result).toContain(
+      `RELEASE_TYPECHECK_RESULT: ${githubExpression("needs.release-typecheck.result")}`,
+    );
+    expect(result).toContain('$RELEASE_TYPECHECK_RESULT" == "failure"');
+    expect(result).toContain('$RELEASE_TYPECHECK_RESULT" == "cancelled"');
   });
 
   test("builds the production web artifact once per workflow run", () => {


### PR DESCRIPTION
Fixes the isolated-declarations errors in the locale direction exports. Keeps ordinary pull requests on the fast Oxc diagnostics path and adds a separate full uncached native typecheck only when the root VERSION changes, before tag creation. Also removes an unused sandbox retry-loop counter reported by actionlint.