### PR TITLE
fix: centralize dev-runner configuration parsing

### DIFF
--- a/.oxlint-plugins/__fixtures__/forbid-dev-runner-config-reads.fixture.ts
+++ b/.oxlint-plugins/__fixtures__/forbid-dev-runner-config-reads.fixture.ts
@@ -1,0 +1,13 @@
+// Passive regression fixture for
+// `forbid-dev-runner-config-reads/forbid-dev-runner-config-reads`.
+
+// MUST flag: CLI parsing belongs to the pure dev-runner config boundary.
+// oxlint-disable-next-line forbid-dev-runner-config-reads/forbid-dev-runner-config-reads -- fixture: raw argv reads must stay in the parser module
+export const rawArguments = process.argv.slice(2);
+
+// MUST flag: runner-specific environment parsing belongs to the same boundary.
+// oxlint-disable-next-line forbid-dev-runner-config-reads/forbid-dev-runner-config-reads, typescript/dot-notation -- fixture: raw config environment reads must stay in the parser module
+export const rawPortOffset = process.env["STELLA_PORT_OFFSET"];
+
+// Allowed: unrelated ambient environment values are forwarded by the runner.
+export const ambientEnvironment = process.env;

--- a/.oxlint-plugins/__fixtures__/forbid-dev-runner-config-reads.fixture.ts
+++ b/.oxlint-plugins/__fixtures__/forbid-dev-runner-config-reads.fixture.ts
@@ -5,9 +5,20 @@
 // oxlint-disable-next-line forbid-dev-runner-config-reads/forbid-dev-runner-config-reads -- fixture: raw argv reads must stay in the parser module
 export const rawArguments = process.argv.slice(2);
 
+// MUST flag: destructuring does not create an allowed configuration boundary.
+// oxlint-disable-next-line forbid-dev-runner-config-reads/forbid-dev-runner-config-reads -- fixture: destructured argv reads must stay in the parser module
+const { argv: destructuredArguments } = process;
+
 // MUST flag: runner-specific environment parsing belongs to the same boundary.
 // oxlint-disable-next-line forbid-dev-runner-config-reads/forbid-dev-runner-config-reads, typescript/dot-notation -- fixture: raw config environment reads must stay in the parser module
 export const rawPortOffset = process.env["STELLA_PORT_OFFSET"];
 
+// MUST flag: destructured runner-specific environment values are also reads.
+// oxlint-disable-next-line forbid-dev-runner-config-reads/forbid-dev-runner-config-reads -- fixture: destructured config environment reads must stay in the parser module
+const { STELLA_PORT_OFFSET: destructuredPortOffset } = process.env;
+
 // Allowed: unrelated ambient environment values are forwarded by the runner.
 export const ambientEnvironment = process.env;
+
+void destructuredArguments;
+void destructuredPortOffset;

--- a/.oxlint-plugins/__fixtures__/forbid-dev-runner-config-reads.fixture.ts
+++ b/.oxlint-plugins/__fixtures__/forbid-dev-runner-config-reads.fixture.ts
@@ -13,6 +13,13 @@ const { argv: destructuredArguments } = process;
 // oxlint-disable-next-line forbid-dev-runner-config-reads/forbid-dev-runner-config-reads, typescript/dot-notation -- fixture: raw config environment reads must stay in the parser module
 export const rawPortOffset = process.env["STELLA_PORT_OFFSET"];
 
+// MUST flag: every configured runner environment name stays behind the parser.
+// oxlint-disable-next-line forbid-dev-runner-config-reads/forbid-dev-runner-config-reads, typescript/dot-notation -- fixture: raw config environment reads must stay in the parser module
+export const rawInfraOffset = process.env["STELLA_INFRA_OFFSET"];
+
+// oxlint-disable-next-line forbid-dev-runner-config-reads/forbid-dev-runner-config-reads, typescript/dot-notation -- fixture: raw config environment reads must stay in the parser module
+export const rawDevInstance = process.env["STELLA_DEV_INSTANCE"];
+
 // MUST flag: destructured runner-specific environment values are also reads.
 // oxlint-disable-next-line forbid-dev-runner-config-reads/forbid-dev-runner-config-reads -- fixture: destructured config environment reads must stay in the parser module
 const { STELLA_PORT_OFFSET: destructuredPortOffset } = process.env;

--- a/.oxlint-plugins/forbid-dev-runner-config-reads.ts
+++ b/.oxlint-plugins/forbid-dev-runner-config-reads.ts
@@ -11,11 +11,12 @@ import {
   isStringLiteral,
 } from "./utils.ts";
 
-const CONFIG_ENV_NAMES = new Set([
+export const DEV_RUNNER_CONFIG_ENV_NAMES = [
   "STELLA_DEV_INSTANCE",
   "STELLA_INFRA_OFFSET",
   "STELLA_PORT_OFFSET",
-]);
+] as const;
+const CONFIG_ENV_NAMES = new Set(DEV_RUNNER_CONFIG_ENV_NAMES);
 const ARGV_NAMES = new Set(["argv"]);
 
 const staticPropertyName = (node: Record<string, unknown>): string | null => {

--- a/.oxlint-plugins/forbid-dev-runner-config-reads.ts
+++ b/.oxlint-plugins/forbid-dev-runner-config-reads.ts
@@ -16,7 +16,7 @@ export const DEV_RUNNER_CONFIG_ENV_NAMES = [
   "STELLA_INFRA_OFFSET",
   "STELLA_PORT_OFFSET",
 ] as const;
-const CONFIG_ENV_NAMES = new Set(DEV_RUNNER_CONFIG_ENV_NAMES);
+const CONFIG_ENV_NAMES = new Set<string>(DEV_RUNNER_CONFIG_ENV_NAMES);
 const ARGV_NAMES = new Set(["argv"]);
 
 const staticPropertyName = (node: Record<string, unknown>): string | null => {

--- a/.oxlint-plugins/forbid-dev-runner-config-reads.ts
+++ b/.oxlint-plugins/forbid-dev-runner-config-reads.ts
@@ -16,6 +16,7 @@ const CONFIG_ENV_NAMES = new Set([
   "STELLA_INFRA_OFFSET",
   "STELLA_PORT_OFFSET",
 ]);
+const ARGV_NAMES = new Set(["argv"]);
 
 const staticPropertyName = (node: Record<string, unknown>): string | null => {
   if (node.computed === false) {
@@ -41,6 +42,39 @@ const isRunnerConfigEnvironmentAccess = (node: unknown): boolean => {
   return name !== null && CONFIG_ENV_NAMES.has(name);
 };
 
+const isObjectPatternWithProperty = (
+  node: unknown,
+  names: ReadonlySet<string>,
+): boolean => {
+  if (!isAstNode(node) || node.type !== "ObjectPattern") {
+    return false;
+  }
+  const properties = node.properties;
+  if (!Array.isArray(properties)) {
+    return false;
+  }
+  return properties.some((property) => {
+    if (!isAstNode(property) || property.type !== "Property") {
+      return false;
+    }
+    const key = getPropertyName(property.key);
+    return key !== null && names.has(key);
+  });
+};
+
+const isRunnerConfigDestructuring = (node: unknown): boolean => {
+  if (!isAstNode(node) || node.type !== "VariableDeclarator") {
+    return false;
+  }
+  if (isIdentifier(node.init, "process")) {
+    return isObjectPatternWithProperty(node.id, ARGV_NAMES);
+  }
+  return (
+    isProcessAccess(node.init, "env") &&
+    isObjectPatternWithProperty(node.id, CONFIG_ENV_NAMES)
+  );
+};
+
 export default eslintCompatPlugin({
   meta: { name: "forbid-dev-runner-config-reads" },
   rules: {
@@ -59,6 +93,11 @@ export default eslintCompatPlugin({
               isProcessAccess(node, "argv") ||
               isRunnerConfigEnvironmentAccess(node)
             ) {
+              context.report({ node, messageId: "configRead" });
+            }
+          },
+          VariableDeclarator(node) {
+            if (isRunnerConfigDestructuring(node)) {
               context.report({ node, messageId: "configRead" });
             }
           },

--- a/.oxlint-plugins/forbid-dev-runner-config-reads.ts
+++ b/.oxlint-plugins/forbid-dev-runner-config-reads.ts
@@ -1,0 +1,69 @@
+// Keep dev-runner configuration reads in dev-runner-config.ts. The runner may
+// still pass the ambient environment to child processes, but it must not parse
+// CLI or runner-specific environment inputs after side effects begin.
+
+import { eslintCompatPlugin } from "@oxlint/plugins";
+
+import {
+  getPropertyName,
+  isAstNode,
+  isIdentifier,
+  isStringLiteral,
+} from "./utils.ts";
+
+const CONFIG_ENV_NAMES = new Set([
+  "STELLA_DEV_INSTANCE",
+  "STELLA_INFRA_OFFSET",
+  "STELLA_PORT_OFFSET",
+]);
+
+const staticPropertyName = (node: Record<string, unknown>): string | null => {
+  if (node.computed === false) {
+    return getPropertyName(node.property);
+  }
+  return isStringLiteral(node.property) ? node.property.value : null;
+};
+
+const isProcessAccess = (node: unknown, property: string): boolean =>
+  isAstNode(node) &&
+  node.type === "MemberExpression" &&
+  isIdentifier(node.object, "process") &&
+  staticPropertyName(node) === property;
+
+const isRunnerConfigEnvironmentAccess = (node: unknown): boolean => {
+  if (!isAstNode(node) || node.type !== "MemberExpression") {
+    return false;
+  }
+  if (!isProcessAccess(node.object, "env")) {
+    return false;
+  }
+  const name = staticPropertyName(node);
+  return name !== null && CONFIG_ENV_NAMES.has(name);
+};
+
+export default eslintCompatPlugin({
+  meta: { name: "forbid-dev-runner-config-reads" },
+  rules: {
+    "forbid-dev-runner-config-reads": {
+      meta: {
+        type: "problem",
+        messages: {
+          configRead:
+            "Read dev-runner CLI and configuration environment values through dev-runner-config.ts.",
+        },
+      },
+      createOnce(context) {
+        return {
+          MemberExpression(node) {
+            if (
+              isProcessAccess(node, "argv") ||
+              isRunnerConfigEnvironmentAccess(node)
+            ) {
+              context.report({ node, messageId: "configRead" });
+            }
+          },
+        };
+      },
+    },
+  },
+});

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -26,6 +26,9 @@ const fixtureRuleOverrides = [
   fixtureRuleOverride("forbid-process-env-outside-env-ts.fixture.ts", [
     "forbid-process-env-outside-env-ts/forbid-process-env-outside-env-ts",
   ]),
+  fixtureRuleOverride("forbid-dev-runner-config-reads.fixture.ts", [
+    "forbid-dev-runner-config-reads/forbid-dev-runner-config-reads",
+  ]),
   fixtureRuleOverride("mcp-security.fixture.ts", [
     "mcp-security/no-direct-oauth-client-join",
     "mcp-security/redact-oauth-registration-response",
@@ -516,6 +519,7 @@ export default defineConfig({
     "./.oxlint-plugins/stella-toast.ts",
     "./.oxlint-plugins/no-untranslated-jsx-literal.ts",
     "./.oxlint-plugins/forbid-process-env-outside-env-ts.ts",
+    "./.oxlint-plugins/forbid-dev-runner-config-reads.ts",
     "./.oxlint-plugins/no-facade-imports.ts",
     "./.oxlint-plugins/no-secret-in-log-sink.ts",
     "./.oxlint-plugins/no-raw-api-url.ts",
@@ -1832,6 +1836,16 @@ export default defineConfig({
             ],
           },
         ],
+      },
+    },
+    {
+      // Configuration must be parsed before dev-runner starts any side effect.
+      // The parser adapter is the only owner of process.argv and runner offset
+      // environment reads; the orchestration module is guarded here.
+      files: ["packages/scripts/src/dev-runner.ts"],
+      rules: {
+        "forbid-dev-runner-config-reads/forbid-dev-runner-config-reads":
+          "error",
       },
     },
     {

--- a/packages/scripts/src/dev-runner-config.ts
+++ b/packages/scripts/src/dev-runner-config.ts
@@ -1,0 +1,258 @@
+import { Result, TaggedError, type TaggedErrorClass } from "better-result";
+
+export const DEV_MODES = ["dev", "dev:web", "dev:api", "dev:desktop"] as const;
+export type DevMode = (typeof DEV_MODES)[number];
+
+export const DEFAULT_PORTS = {
+  api: 3001,
+  desktopBridge: 45_901,
+  desktopView: 5177,
+  web: 3000,
+} as const;
+export const DEFAULT_INFRA_PORTS = {
+  gotenberg: 3003,
+  minio: 9000,
+  minioConsole: 9001,
+  postgres: 5432,
+  valkey: 6379,
+} as const;
+const MAX_PORT = 65_535;
+export const MAX_INFRA_OFFSET =
+  MAX_PORT - Math.max(...Object.values(DEFAULT_INFRA_PORTS));
+export const MAX_PORT_OFFSET =
+  MAX_PORT - Math.max(...Object.values(DEFAULT_PORTS));
+
+export type DevRunnerEnvironment = Readonly<Record<string, string | undefined>>;
+
+export type DevRunnerConfig = {
+  devInstance: string | undefined;
+  dryRun: boolean;
+  infraOffset: number;
+  mode: DevMode;
+  noBrowser: boolean;
+  portOffset: number | undefined;
+  skipDbPush: boolean;
+  skipInstall: boolean;
+};
+
+export type DevRunnerConfigInput = {
+  args: readonly string[];
+  environment: DevRunnerEnvironment;
+};
+
+export type DevRunnerConfigErrorCode =
+  | "invalid-integer"
+  | "missing-value"
+  | "out-of-range"
+  | "unknown-argument";
+
+const DevRunnerConfigErrorBase: TaggedErrorClass<"DevRunnerConfigError"> =
+  TaggedError("DevRunnerConfigError");
+
+export class DevRunnerConfigError extends DevRunnerConfigErrorBase<{
+  code: DevRunnerConfigErrorCode;
+  message: string;
+  source: string;
+}> {
+  constructor({
+    code,
+    message,
+    source,
+  }: {
+    code: DevRunnerConfigErrorCode;
+    message: string;
+    source: string;
+  }) {
+    super({ code, message, source });
+  }
+}
+
+const isDevMode = (value: string): value is DevMode =>
+  DEV_MODES.some((mode) => mode === value);
+
+const invalid = (
+  code: DevRunnerConfigErrorCode,
+  source: string,
+  message: string,
+) => Result.err(new DevRunnerConfigError({ code, message, source }));
+
+const parseInteger = (
+  value: string,
+  source: string,
+  maximum: number,
+): Result<number, DevRunnerConfigError> => {
+  if (!/^[+-]?\d+$/u.test(value) || !Number.isSafeInteger(Number(value))) {
+    return invalid("invalid-integer", source, `${source} must be an integer`);
+  }
+  const parsed = Number(value);
+  if (parsed < 0 || parsed > maximum) {
+    return invalid(
+      "out-of-range",
+      source,
+      `${source} must be an integer between 0 and ${String(maximum)}`,
+    );
+  }
+  return Result.ok(parsed);
+};
+
+const parseIntegerOption = (
+  value: string | undefined,
+  source: string,
+  maximum: number,
+): Result<number | undefined, DevRunnerConfigError> => {
+  if (value === undefined) {
+    return Result.ok(undefined);
+  }
+  return parseInteger(value, source, maximum);
+};
+
+const validateDevInstance = (
+  value: string | undefined,
+  source: string,
+): Result<string | undefined, DevRunnerConfigError> => {
+  if (value === undefined || !/^\d+$/u.test(value.trim())) {
+    return Result.ok(value);
+  }
+  const parsed = parseInteger(value.trim(), source, MAX_PORT_OFFSET);
+  if (Result.isError(parsed)) {
+    return Result.err(parsed.error);
+  }
+  return Result.ok(value);
+};
+
+const parseCliArgs = (
+  args: readonly string[],
+): Result<
+  Omit<DevRunnerConfig, "infraOffset" | "portOffset" | "devInstance"> & {
+    devInstance: string | undefined;
+    infraOffset: string | undefined;
+    portOffset: string | undefined;
+  },
+  DevRunnerConfigError
+> => {
+  let mode: DevMode = "dev";
+  let portOffset: string | undefined;
+  let infraOffset: string | undefined;
+  let devInstance: string | undefined;
+  let skipInstall = false;
+  let skipDbPush = false;
+  let dryRun = false;
+  let noBrowser = false;
+
+  for (let index = 0; index < args.length; index++) {
+    const arg = args[index];
+    if (!arg) {
+      continue;
+    }
+    if (isDevMode(arg)) {
+      mode = arg;
+      continue;
+    }
+    if (arg === "--skip-install") {
+      skipInstall = true;
+      continue;
+    }
+    if (arg === "--skip-db-push") {
+      skipDbPush = true;
+      continue;
+    }
+    if (arg === "--dry-run") {
+      dryRun = true;
+      continue;
+    }
+    if (arg === "--no-browser") {
+      noBrowser = true;
+      continue;
+    }
+
+    let option: "devInstance" | "infraOffset" | "portOffset" | undefined;
+    if (arg === "--port-offset") {
+      option = "portOffset";
+    } else if (arg === "--infra-offset") {
+      option = "infraOffset";
+    } else if (arg === "--dev-instance") {
+      option = "devInstance";
+    }
+    if (option === undefined) {
+      return invalid("unknown-argument", arg, `Unknown argument: ${arg}`);
+    }
+    const value = args[index + 1];
+    if (!value) {
+      return invalid("missing-value", arg, `${arg} requires a value`);
+    }
+    if (option === "portOffset") {
+      portOffset = value;
+    } else if (option === "infraOffset") {
+      infraOffset = value;
+    } else {
+      devInstance = value;
+    }
+    index++;
+  }
+
+  return Result.ok({
+    devInstance,
+    dryRun,
+    infraOffset,
+    mode,
+    noBrowser,
+    portOffset,
+    skipDbPush,
+    skipInstall,
+  });
+};
+
+export const parseDevRunnerConfig = ({
+  args,
+  environment,
+}: DevRunnerConfigInput): Result<DevRunnerConfig, DevRunnerConfigError> => {
+  const cli = parseCliArgs(args);
+  if (Result.isError(cli)) {
+    return cli;
+  }
+
+  const {
+    devInstance: cliDevInstance,
+    infraOffset: cliInfraOffset,
+    portOffset: cliPortOffset,
+    ...flags
+  } = cli.value;
+  const portOffset = parseIntegerOption(
+    cliPortOffset ?? environment.STELLA_PORT_OFFSET,
+    cliPortOffset === undefined ? "STELLA_PORT_OFFSET" : "--port-offset",
+    MAX_PORT_OFFSET,
+  );
+  if (Result.isError(portOffset)) {
+    return portOffset;
+  }
+  const infraOffset = parseIntegerOption(
+    cliInfraOffset ?? environment.STELLA_INFRA_OFFSET ?? "0",
+    cliInfraOffset === undefined ? "STELLA_INFRA_OFFSET" : "--infra-offset",
+    MAX_INFRA_OFFSET,
+  );
+  if (Result.isError(infraOffset)) {
+    return infraOffset;
+  }
+  const devInstance = validateDevInstance(
+    cliDevInstance ?? environment.STELLA_DEV_INSTANCE,
+    cliDevInstance === undefined
+      ? "numeric STELLA_DEV_INSTANCE"
+      : "--dev-instance",
+  );
+  if (Result.isError(devInstance)) {
+    return devInstance;
+  }
+
+  return Result.ok({
+    ...flags,
+    devInstance: devInstance.value,
+    infraOffset: infraOffset.value ?? 0,
+    portOffset: portOffset.value,
+  });
+};
+
+export const readDevRunnerConfig = () =>
+  parseDevRunnerConfig({
+    args: process.argv.slice(2),
+    environment: process.env,
+  });

--- a/packages/scripts/src/dev-runner-config.ts
+++ b/packages/scripts/src/dev-runner-config.ts
@@ -218,7 +218,7 @@ export const parseDevRunnerConfig = ({
     ...flags
   } = cli.value;
   const portOffset = parseIntegerOption(
-    cliPortOffset ?? environment.STELLA_PORT_OFFSET,
+    cliPortOffset ?? environment["STELLA_PORT_OFFSET"],
     cliPortOffset === undefined ? "STELLA_PORT_OFFSET" : "--port-offset",
     MAX_PORT_OFFSET,
   );
@@ -226,7 +226,7 @@ export const parseDevRunnerConfig = ({
     return portOffset;
   }
   const infraOffset = parseIntegerOption(
-    cliInfraOffset ?? environment.STELLA_INFRA_OFFSET ?? "0",
+    cliInfraOffset ?? environment["STELLA_INFRA_OFFSET"] ?? "0",
     cliInfraOffset === undefined ? "STELLA_INFRA_OFFSET" : "--infra-offset",
     MAX_INFRA_OFFSET,
   );
@@ -234,7 +234,7 @@ export const parseDevRunnerConfig = ({
     return infraOffset;
   }
   const devInstance = validateDevInstance(
-    cliDevInstance ?? environment.STELLA_DEV_INSTANCE,
+    cliDevInstance ?? environment["STELLA_DEV_INSTANCE"],
     cliDevInstance === undefined
       ? "numeric STELLA_DEV_INSTANCE"
       : "--dev-instance",

--- a/packages/scripts/src/dev-runner.test.ts
+++ b/packages/scripts/src/dev-runner.test.ts
@@ -18,7 +18,6 @@ import {
   parseDockerComposePsJson,
   loadEnvFile,
   expandEnvMap,
-  parseArgs,
   parseForeignPortOwners,
   portsForOffset,
   requiredPortsForMode,
@@ -26,6 +25,7 @@ import {
   resolveOffset,
   shouldAutoOpenBrowser,
 } from "./dev-runner";
+import { parseDevRunnerConfig } from "./dev-runner-config";
 
 const tempDirs: string[] = [];
 
@@ -41,57 +41,116 @@ afterEach(() => {
   }
 });
 
-describe("parseArgs", () => {
-  test("uses dev mode by default", () => {
-    expect(parseArgs([])).toEqual({
-      devInstance: undefined,
-      dryRun: false,
-      infraOffset: undefined,
-      mode: "dev",
-      noBrowser: false,
-      portOffset: undefined,
-      skipDbPush: false,
-      skipInstall: false,
+describe("parseDevRunnerConfig", () => {
+  test("uses dev mode and zero infrastructure offset by default", () => {
+    expect(parseDevRunnerConfig({ args: [], environment: {} })).toMatchObject({
+      status: "ok",
+      value: {
+        infraOffset: 0,
+        mode: "dev",
+      },
     });
   });
 
-  test("parses mode and flags", () => {
+  test("gives CLI offsets and instance precedence over environment values", () => {
     expect(
-      parseArgs([
-        "dev:desktop",
-        "--skip-install",
-        "--skip-db-push",
-        "--port-offset",
-        "8",
-        "--dev-instance",
-        "worktree-a",
-        "--dry-run",
-        "--no-browser",
-        "--infra-offset",
-        "10",
-      ]),
-    ).toEqual({
-      devInstance: "worktree-a",
-      dryRun: true,
-      infraOffset: 10,
-      mode: "dev:desktop",
-      noBrowser: true,
-      portOffset: 8,
-      skipDbPush: true,
-      skipInstall: true,
+      parseDevRunnerConfig({
+        args: [
+          "--port-offset",
+          "8",
+          "--infra-offset",
+          "10",
+          "--dev-instance",
+          "cli-instance",
+        ],
+        environment: {
+          STELLA_DEV_INSTANCE: "environment-instance",
+          STELLA_INFRA_OFFSET: "12",
+          STELLA_PORT_OFFSET: "14",
+        },
+      }),
+    ).toMatchObject({
+      status: "ok",
+      value: {
+        devInstance: "cli-instance",
+        infraOffset: 10,
+        portOffset: 8,
+      },
+    });
+  });
+
+  test("parses mode and control flags at the same boundary", () => {
+    expect(
+      parseDevRunnerConfig({
+        args: [
+          "dev:desktop",
+          "--skip-install",
+          "--skip-db-push",
+          "--dry-run",
+          "--no-browser",
+        ],
+        environment: {},
+      }),
+    ).toMatchObject({
+      status: "ok",
+      value: {
+        dryRun: true,
+        mode: "dev:desktop",
+        noBrowser: true,
+        skipDbPush: true,
+        skipInstall: true,
+      },
     });
   });
 
   test.each(["8oops", "1.5", "1e2", "9007199254740992"])(
-    "rejects invalid offset value %s for both offset flags",
+    "rejects malformed or unsafe values from both offset environment variables: %s",
     (value) => {
-      for (const flag of ["--port-offset", "--infra-offset"]) {
-        expect(() => parseArgs([flag, value])).toThrow(
-          `${flag} must be an integer`,
-        );
+      for (const variable of ["STELLA_PORT_OFFSET", "STELLA_INFRA_OFFSET"]) {
+        const result = parseDevRunnerConfig({
+          args: [],
+          environment: { [variable]: value },
+        });
+
+        expect(result.status).toBe("error");
+        if (result.status === "error") {
+          expect(result.error.code).toBe("invalid-integer");
+          expect(result.error.source).toBe(variable);
+        }
       }
     },
   );
+
+  test.each(["8oops", "1.5", "1e2", "9007199254740992"])(
+    "rejects malformed or unsafe values from both offset CLI flags: %s",
+    (value) => {
+      for (const flag of ["--port-offset", "--infra-offset"]) {
+        const result = parseDevRunnerConfig({
+          args: [flag, value],
+          environment: {},
+        });
+
+        expect(result.status).toBe("error");
+        if (result.status === "error") {
+          expect(result.error.code).toBe("invalid-integer");
+          expect(result.error.source).toBe(flag);
+        }
+      }
+    },
+  );
+
+  test("rejects an unsafe numeric dev instance before side effects", () => {
+    const result = parseDevRunnerConfig({
+      args: [],
+      environment: { STELLA_DEV_INSTANCE: "9007199254740992" },
+    });
+
+    expect(result.status).toBe("error");
+    if (result.status === "error") {
+      expect(result.error.code).toBe("invalid-integer");
+      expect(result.error.source).toBe("numeric STELLA_DEV_INSTANCE");
+    }
+  });
 });
 
 describe("resolveOffset", () => {

--- a/packages/scripts/src/dev-runner.test.ts
+++ b/packages/scripts/src/dev-runner.test.ts
@@ -25,7 +25,11 @@ import {
   resolveOffset,
   shouldAutoOpenBrowser,
 } from "./dev-runner";
-import { parseDevRunnerConfig } from "./dev-runner-config";
+import {
+  MAX_INFRA_OFFSET,
+  MAX_PORT_OFFSET,
+  parseDevRunnerConfig,
+} from "./dev-runner-config";
 
 const tempDirs: string[] = [];
 
@@ -151,6 +155,30 @@ describe("parseDevRunnerConfig", () => {
       expect(result.error.source).toBe("numeric STELLA_DEV_INSTANCE");
     }
   });
+
+  test.each([
+    ["STELLA_PORT_OFFSET", "--port-offset", MAX_PORT_OFFSET],
+    ["STELLA_INFRA_OFFSET", "--infra-offset", MAX_INFRA_OFFSET],
+  ] as const)(
+    "rejects values above the %s maximum from both sources",
+    (environmentName, flag, maximum) => {
+      const value = String(maximum + 1);
+      for (const input of [
+        { args: [], environment: { [environmentName]: value } },
+        { args: [flag, value], environment: {} },
+      ]) {
+        const result = parseDevRunnerConfig(input);
+
+        expect(result.status).toBe("error");
+        if (result.status === "error") {
+          expect(result.error.code).toBe("out-of-range");
+          expect(result.error.source).toBe(
+            input.args.length === 0 ? environmentName : flag,
+          );
+        }
+      }
+    },
+  );
 });
 
 describe("resolveOffset", () => {

--- a/packages/scripts/src/dev-runner.ts
+++ b/packages/scripts/src/dev-runner.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env bun
-import { panic } from "better-result";
+import { Result, panic } from "better-result";
 import {
   copyFileSync,
   existsSync,
@@ -11,7 +11,14 @@ import {
 import { createServer, Socket } from "node:net";
 import path from "node:path";
 
-const DEV_MODES = ["dev", "dev:web", "dev:api", "dev:desktop"] as const;
+import {
+  DEFAULT_INFRA_PORTS,
+  DEFAULT_PORTS,
+  MAX_PORT_OFFSET,
+  type DevMode,
+  readDevRunnerConfig,
+} from "./dev-runner-config";
+
 const ENV_FILE_SPECS = [
   {
     example: "apps/api/.env.example",
@@ -23,22 +30,9 @@ const ENV_FILE_SPECS = [
   },
 ] as const;
 const PORT_PROBE_HOSTS = ["127.0.0.1", "0.0.0.0"] as const;
-const DEFAULT_PORTS = {
-  api: 3001,
-  desktopBridge: 45_901,
-  desktopView: 5177,
-  web: 3000,
-} as const;
 const DEFAULT_HTTP_PROBE_TIMEOUT_MS = 1500;
 const DEFAULT_HTTP_READY_TIMEOUT_MS = 120_000;
 const DEFAULT_OPEN_BROWSER_TIMEOUT_MS = 5000;
-const DEFAULT_INFRA_PORTS = {
-  gotenberg: 3003,
-  minio: 9000,
-  minioConsole: 9001,
-  postgres: 5432,
-  valkey: 6379,
-} as const;
 const SHARED_DOCKER_PROJECT_BASE = "stella-dev";
 const SHARED_DOCKER_HEALTHY_SERVICES = [
   "postgres",
@@ -48,10 +42,6 @@ const SHARED_DOCKER_HEALTHY_SERVICES = [
 ] as const;
 const SHARED_DOCKER_COMPLETED_SERVICES = ["minio-setup"] as const;
 const MAX_HASH_OFFSET = 400;
-const MAX_PORT = 65_535;
-const MAX_INFRA_OFFSET =
-  MAX_PORT - Math.max(...Object.values(DEFAULT_INFRA_PORTS));
-const MAX_PORT_OFFSET = MAX_PORT - Math.max(...Object.values(DEFAULT_PORTS));
 const PORT_SEARCH_LIMIT = 2000;
 // The web app renders via TanStack Start SSR (root document from __root.tsx),
 // which mounts into <body> directly — there is no `<div id="app">` SPA mount.
@@ -59,25 +49,12 @@ const PORT_SEARCH_LIMIT = 2000;
 // (which can change with branding), so readiness reflects a real rendered shell.
 const WEB_HTML_MARKER = 'src="/prepaint-init.js"';
 
-export type DevMode = (typeof DEV_MODES)[number];
-
 export type InfraPorts = {
   gotenberg: number;
   minio: number;
   minioConsole: number;
   postgres: number;
   valkey: number;
-};
-
-type ParsedArgs = {
-  devInstance: string | undefined;
-  dryRun: boolean;
-  infraOffset: number | undefined;
-  mode: DevMode;
-  noBrowser: boolean;
-  portOffset: number | undefined;
-  skipDbPush: boolean;
-  skipInstall: boolean;
 };
 
 export type OffsetConfig = {
@@ -155,9 +132,6 @@ type ReadinessChecks = {
 
 type CheckReusableApiPort = (apiPort: number) => Promise<boolean>;
 
-const isDevMode = (value: string): value is DevMode =>
-  DEV_MODES.some((mode) => mode === value);
-
 const modeIncludesApi = (mode: DevMode) =>
   mode === "dev" || mode === "dev:api" || mode === "dev:desktop";
 
@@ -193,104 +167,6 @@ const validateOffset = (offset: number, source: string) => {
       `${source} must be an integer between 0 and ${String(MAX_PORT_OFFSET)}`,
     );
   }
-};
-
-const parseIntegerValue = (value: string, source: string) => {
-  if (!/^[+-]?\d+$/u.test(value)) {
-    panic(`${source} must be an integer`);
-  }
-
-  const parsed = Number(value);
-  if (!Number.isSafeInteger(parsed)) {
-    panic(`${source} must be an integer`);
-  }
-  return parsed;
-};
-
-export const parseArgs = (args: readonly string[]): ParsedArgs => {
-  let mode: DevMode = "dev";
-  let portOffset: number | undefined;
-  let infraOffset: number | undefined;
-  let devInstance: string | undefined;
-  let skipInstall = false;
-  let skipDbPush = false;
-  let dryRun = false;
-  let noBrowser = false;
-
-  for (let i = 0; i < args.length; i++) {
-    const arg = args[i];
-    if (!arg) {
-      continue;
-    }
-
-    if (isDevMode(arg)) {
-      mode = arg;
-      continue;
-    }
-
-    if (arg === "--skip-install") {
-      skipInstall = true;
-      continue;
-    }
-
-    if (arg === "--skip-db-push") {
-      skipDbPush = true;
-      continue;
-    }
-
-    if (arg === "--dry-run") {
-      dryRun = true;
-      continue;
-    }
-
-    if (arg === "--no-browser") {
-      noBrowser = true;
-      continue;
-    }
-
-    if (arg === "--port-offset") {
-      const value = args[i + 1];
-      if (!value) {
-        panic("--port-offset requires a value");
-      }
-      portOffset = parseIntegerValue(value, "--port-offset");
-      i++;
-      continue;
-    }
-
-    if (arg === "--dev-instance") {
-      const value = args[i + 1];
-      if (!value) {
-        panic("--dev-instance requires a value");
-      }
-      devInstance = value;
-      i++;
-      continue;
-    }
-
-    if (arg === "--infra-offset") {
-      const value = args[i + 1];
-      if (!value) {
-        panic("--infra-offset requires a value");
-      }
-      infraOffset = parseIntegerValue(value, "--infra-offset");
-      i++;
-      continue;
-    }
-
-    panic(`Unknown argument: ${arg}`);
-  }
-
-  return {
-    devInstance,
-    dryRun,
-    infraOffset,
-    mode,
-    noBrowser,
-    portOffset,
-    skipDbPush,
-    skipInstall,
-  };
 };
 
 export const resolveOffset = ({
@@ -1761,7 +1637,11 @@ const printDryRun = ({
 };
 
 const main = async () => {
-  const parsedArgs = parseArgs(process.argv.slice(2));
+  const config = readDevRunnerConfig();
+  if (Result.isError(config)) {
+    panic(config.error.message);
+  }
+  const parsedArgs = config.value;
   const gitContext = createGitContext(process.cwd());
   const preparedEnvFiles = ensureWorktreeEnvLinks({
     currentRoot: gitContext.currentRoot,
@@ -1769,34 +1649,10 @@ const main = async () => {
     mainRoot: gitContext.mainRoot,
   });
 
-  const portOffset =
-    parsedArgs.portOffset ??
-    (process.env["STELLA_PORT_OFFSET"]
-      ? parseIntegerValue(
-          process.env["STELLA_PORT_OFFSET"],
-          "STELLA_PORT_OFFSET",
-        )
-      : undefined);
-  const infraOffset =
-    parsedArgs.infraOffset ??
-    (process.env["STELLA_INFRA_OFFSET"]
-      ? parseIntegerValue(
-          process.env["STELLA_INFRA_OFFSET"],
-          "STELLA_INFRA_OFFSET",
-        )
-      : 0);
-  if (
-    !Number.isInteger(infraOffset) ||
-    infraOffset < 0 ||
-    infraOffset > MAX_INFRA_OFFSET
-  ) {
-    panic(
-      `STELLA_INFRA_OFFSET must be an integer between 0 and ${String(MAX_INFRA_OFFSET)}`,
-    );
-  }
+  const { devInstance, infraOffset, mode, portOffset } = parsedArgs;
   const infraPorts = infraPortsForOffset(infraOffset);
 
-  if (!parsedArgs.dryRun && modeIncludesApi(parsedArgs.mode)) {
+  if (!parsedArgs.dryRun && modeIncludesApi(mode)) {
     console.log("==> Checking Docker engine...");
     runStep({
       cmd: [resolveCommandPath("docker"), "ps"],
@@ -1812,13 +1668,13 @@ const main = async () => {
 
   const initialOffset = resolveOffset({
     branchName: gitContext.branchName,
-    devInstance: parsedArgs.devInstance ?? process.env["STELLA_DEV_INSTANCE"],
+    devInstance,
     isWorktree: gitContext.isWorktree,
     portOffset,
     worktreeName: path.basename(gitContext.currentRoot),
   });
   const resolvedOffset = await findFirstAvailableOffset({
-    mode: parsedArgs.mode,
+    mode,
     startOffset: initialOffset.offset,
   });
   const ports = portsForOffset(resolvedOffset);
@@ -1829,7 +1685,7 @@ const main = async () => {
   const preparationSteps = buildPreparationSteps({
     infraOffset,
     infraPorts,
-    mode: parsedArgs.mode,
+    mode,
     ports,
     rootDir: gitContext.currentRoot,
     skipDbPush: parsedArgs.skipDbPush,
@@ -1838,16 +1694,16 @@ const main = async () => {
   const persistentSteps = buildPersistentSteps({
     infraOffset,
     infraPorts,
-    mode: parsedArgs.mode,
+    mode,
     ports,
     rootDir: gitContext.currentRoot,
   });
   const readinessChecks = buildReadinessChecks({
-    mode: parsedArgs.mode,
+    mode,
     ports,
   });
   const browserWillOpen = shouldAutoOpenBrowser({
-    mode: parsedArgs.mode,
+    mode,
     noBrowser: parsedArgs.noBrowser,
   });
 
@@ -1857,7 +1713,7 @@ const main = async () => {
       infraOffset,
       infraPorts,
       preparedEnvFiles,
-      mode: parsedArgs.mode,
+      mode,
       offset: resolvedOffset,
       offsetSource,
       persistentSteps,
@@ -1948,7 +1804,7 @@ const main = async () => {
       infraOffset,
       infraPorts,
       preparedEnvFiles,
-      mode: parsedArgs.mode,
+      mode,
       offset: resolvedOffset,
       offsetSource,
       ports,

--- a/scripts/check-dev-runner-config-guard.test.ts
+++ b/scripts/check-dev-runner-config-guard.test.ts
@@ -14,7 +14,9 @@ const fixture = readFileSync(
 test("exercises every configured dev-runner environment name", () => {
   const exercisedNames = [
     ...fixture.matchAll(/process\.env\["(?<name>STELLA_[A-Z_]+)"\]/gu),
-  ].map((match) => match.groups?.["name"]);
+  ]
+    .map((match) => match.groups?.["name"])
+    .filter((name): name is string => name !== undefined);
 
   const compareNames = (left: string, right: string) =>
     left.localeCompare(right);

--- a/scripts/check-dev-runner-config-guard.test.ts
+++ b/scripts/check-dev-runner-config-guard.test.ts
@@ -16,7 +16,9 @@ test("exercises every configured dev-runner environment name", () => {
     ...fixture.matchAll(/process\.env\["(?<name>STELLA_[A-Z_]+)"\]/gu),
   ].map((match) => match.groups?.["name"]);
 
-  expect([...new Set(exercisedNames)].sort()).toEqual(
-    [...DEV_RUNNER_CONFIG_ENV_NAMES].sort(),
+  const compareNames = (left: string, right: string) =>
+    left.localeCompare(right);
+  expect([...new Set(exercisedNames)].sort(compareNames)).toEqual(
+    [...DEV_RUNNER_CONFIG_ENV_NAMES].sort(compareNames),
   );
 });

--- a/scripts/check-dev-runner-config-guard.test.ts
+++ b/scripts/check-dev-runner-config-guard.test.ts
@@ -1,8 +1,6 @@
 import { expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 
-import { DEV_RUNNER_CONFIG_ENV_NAMES } from "../.oxlint-plugins/forbid-dev-runner-config-reads";
-
 const fixture = readFileSync(
   new URL(
     "../.oxlint-plugins/__fixtures__/forbid-dev-runner-config-reads.fixture.ts",
@@ -10,8 +8,24 @@ const fixture = readFileSync(
   ),
   "utf-8",
 );
+const ruleSource = readFileSync(
+  new URL(
+    "../.oxlint-plugins/forbid-dev-runner-config-reads.ts",
+    import.meta.url,
+  ),
+  "utf-8",
+);
 
 test("exercises every configured dev-runner environment name", () => {
+  const configuredNamesSource =
+    /DEV_RUNNER_CONFIG_ENV_NAMES\s*=\s*\[(?<entries>[\s\S]*?)\]\s*as const/u.exec(
+      ruleSource,
+    )?.groups?.["entries"] ?? "";
+  const configuredNames = [
+    ...configuredNamesSource.matchAll(/"(?<name>STELLA_[A-Z_]+)"/gu),
+  ]
+    .map((match) => match.groups?.["name"])
+    .filter((name): name is string => name !== undefined);
   const exercisedNames = [
     ...fixture.matchAll(/process\.env\["(?<name>STELLA_[A-Z_]+)"\]/gu),
   ]
@@ -21,6 +35,6 @@ test("exercises every configured dev-runner environment name", () => {
   const compareNames = (left: string, right: string) =>
     left.localeCompare(right);
   expect([...new Set(exercisedNames)].sort(compareNames)).toEqual(
-    [...DEV_RUNNER_CONFIG_ENV_NAMES].sort(compareNames),
+    [...new Set(configuredNames)].sort(compareNames),
   );
 });

--- a/scripts/check-dev-runner-config-guard.test.ts
+++ b/scripts/check-dev-runner-config-guard.test.ts
@@ -1,0 +1,22 @@
+import { expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+import { DEV_RUNNER_CONFIG_ENV_NAMES } from "../.oxlint-plugins/forbid-dev-runner-config-reads";
+
+const fixture = readFileSync(
+  new URL(
+    "../.oxlint-plugins/__fixtures__/forbid-dev-runner-config-reads.fixture.ts",
+    import.meta.url,
+  ),
+  "utf-8",
+);
+
+test("exercises every configured dev-runner environment name", () => {
+  const exercisedNames = [
+    ...fixture.matchAll(/process\.env\["(?<name>STELLA_[A-Z_]+)"\]/gu),
+  ].map((match) => match.groups?.["name"]);
+
+  expect([...new Set(exercisedNames)].sort()).toEqual(
+    [...DEV_RUNNER_CONFIG_ENV_NAMES].sort(),
+  );
+});


### PR DESCRIPTION
Move dev-runner CLI and runner-specific environment parsing into a pure typed boundary with explicit CLI-over-environment precedence and structured invalid-input errors.

Add a focused oxlint rule and production-shaped fixture so orchestration cannot reintroduce raw configuration reads after side effects begin.

Validation: focused dev-runner tests, targeted oxlint, plugin registry and fixture checks, and dry-run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validated configuration handling for development modes, command-line options, environment variables, and port offsets.
  * Added clear errors for unsupported modes, invalid values, and unsafe port configurations.
  * Development runner configuration now applies consistent defaults and precedence rules.

* **Bug Fixes**
  * Prevented direct access to runner-specific command-line and environment settings outside the validated configuration flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->