### PR TITLE
feat(case-law): cz-regional opendata listing reconciliation runner

### DIFF
--- a/apps/api/src/handlers/case-law/ingestion/adapters/cz-regional.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/cz-regional.ts
@@ -751,26 +751,44 @@ export const listCzRegionalDayPage = async ({
   };
 };
 
+export type CzRegionalBuildResult =
+  | { type: "built"; decision: IngestionResult }
+  /** No docket and court to key on; the crawl drops these too. */
+  | { type: "unkeyable" }
+  /** The item links a document, but nothing came back for it. */
+  | { type: "detail-unavailable" };
+
 /**
  * Build one decision from a listing item, through the adapter's own parse and
  * enrichment path.
  *
- * Returns null for an item the crawl would also drop: without a docket and a
- * court there is nothing to key the decision on.
+ * `fetchFinaldoc` degrades to empty enrichment when the document cannot be
+ * read, which is right for the crawl: the page keeps moving and the listing
+ * observation is still worth storing. A caller filling gaps needs the
+ * opposite, so the failure is reported instead of folded into the decision —
+ * storing a detail-less row would make the identity held and take the
+ * document out of every later reconciliation. The signal is `sourceRaw`,
+ * which is set whenever a response body was read at all (even one the
+ * validator then rejected), so its absence is exactly "nothing came back".
  */
 export const buildCzRegionalDecision = async (
   item: CzRegionalApiItem,
   signal?: AbortSignal,
-): Promise<IngestionResult | null> => {
+): Promise<CzRegionalBuildResult> => {
   const decision = parseItem(item);
-  if (!decision?.documentUrl) {
-    return decision;
+  if (decision === null) {
+    return { type: "unkeyable" };
   }
-  applyFinaldoc(
-    decision,
-    await fetchFinaldoc(decision.documentUrl, decision, signal),
-  );
-  return decision;
+  // The publisher linked no document; the listing metadata is all there is.
+  if (!decision.documentUrl) {
+    return { type: "built", decision };
+  }
+  const finaldoc = await fetchFinaldoc(decision.documentUrl, decision, signal);
+  if (finaldoc.sourceRaw === undefined) {
+    return { type: "detail-unavailable" };
+  }
+  applyFinaldoc(decision, finaldoc);
+  return { type: "built", decision };
 };
 
 export const czRegionalAdapter = defineSourceAdapter({

--- a/apps/api/src/handlers/case-law/ingestion/adapters/cz-regional.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/cz-regional.ts
@@ -96,7 +96,7 @@ const mapDecisionType = (type: string | undefined): string | undefined => {
 };
 
 /** Shape of a single item in the paginated day response. */
-type CzRegionalApiItem = {
+export type CzRegionalApiItem = {
   jednaciCislo?: string | null;
   ecli?: string | null;
   soud?: string | null;
@@ -233,7 +233,9 @@ const isCzRegionalFinaldoc = (value: unknown): value is CzRegionalFinaldoc =>
   isNullishArrayOf(value["styles"], isFinaldocStyle) &&
   isNullishValue(value["metadata"], isCzRegionalMetadata);
 
-const isCzRegionalApiItem = (value: unknown): value is CzRegionalApiItem =>
+export const isCzRegionalApiItem = (
+  value: unknown,
+): value is CzRegionalApiItem =>
   isRecord(value) &&
   isNullishString(value["jednaciCislo"]) &&
   isNullishString(value["ecli"]) &&
@@ -403,12 +405,42 @@ const fetchFinaldoc = async (
 };
 
 /**
+ * Merge a finaldoc fetch into the decision parsed from the listing item.
+ * Mutates in place, which is what the page enrichment already did; kept as
+ * one function so the listing walk and the crawl cannot enrich differently.
+ */
+const applyFinaldoc = (
+  decision: IngestionResult,
+  result: FinaldocResult,
+): void => {
+  if (result.fulltext) {
+    decision.fulltext = result.fulltext;
+  }
+  if (result.decisionType) {
+    decision.decisionType = result.decisionType;
+  }
+  decision.documentAst = result.documentAst;
+  decision.sourceRaw = result.sourceRaw;
+  decision.sourceRawContentType = "application/json";
+
+  const rm = result.richMetadata;
+  if (Object.keys(rm).length > 0) {
+    decision.metadata = {
+      ...decision.metadata,
+      ...rm,
+    };
+  }
+};
+
+/**
  * The publisher's document id, which this source states only as the last
  * segment of the item's link (`/api/finaldoc/<id>`). Returns undefined for a
  * link that carries no segment, so identity falls back to the case number
  * rather than keying every such row on the same empty string.
  */
-const documentIdFromLink = (link: string | undefined): string | undefined => {
+export const documentIdFromLink = (
+  link: string | undefined,
+): string | undefined => {
   if (link === undefined) {
     return undefined;
   }
@@ -657,6 +689,90 @@ const fetchListPage = async ({ cursor, signal, state }: FetchListPageOptions) =>
     },
   );
 
+type ListCzRegionalDayPageOptions = {
+  /** Publication day, `YYYY-MM-DD`. */
+  date: string;
+  /** 0-indexed page within the day. */
+  page: number;
+  signal?: AbortSignal | undefined;
+};
+
+export type CzRegionalDayPage = {
+  items: CzRegionalApiItem[];
+  /** 0 for a day the publisher lists nothing for (the API answers 404). */
+  totalPages: number;
+};
+
+/**
+ * One page of the publisher's own day listing, with no finaldoc enrichment.
+ *
+ * The crawl reaches a day by walking its cursor forward and pays a finaldoc
+ * fetch for every item on the page, which is the wrong shape for asking what
+ * a day contains. This is the same request, the same retries and the same
+ * payload validation as `fetchPage`, stopping at the listing.
+ */
+export const listCzRegionalDayPage = async ({
+  date,
+  page,
+  signal,
+}: ListCzRegionalDayPageOptions): Promise<CzRegionalDayPage> => {
+  const state: CursorState = { date, page, emptyDays: 0 };
+  const cursor = makeCursor(state);
+  const responseResult = await fetchListPage({ cursor, signal, state });
+  if (Result.isError(responseResult)) {
+    throw responseResult.error;
+  }
+  const response = responseResult.value;
+
+  // 404 is how this API says "nothing published that day".
+  if (response.status === 404) {
+    return { items: [], totalPages: 0 };
+  }
+  if (!response.ok) {
+    throw new AdapterFetchError({
+      message: `CZ Regional API error: ${response.status}`,
+      adapterKey: ADAPTER_KEYS.CZ_REGIONAL,
+      cursor,
+      httpStatus: response.status,
+    });
+  }
+
+  const json = await response.json();
+  if (!isCzRegionalPageResponse(json)) {
+    throw new AdapterFetchError({
+      message: "CZ Regional API returned an invalid payload",
+      adapterKey: ADAPTER_KEYS.CZ_REGIONAL,
+      cursor,
+    });
+  }
+  return {
+    items: arrayOrEmpty(json.items),
+    totalPages: json.totalPages ?? 1,
+  };
+};
+
+/**
+ * Build one decision from a listing item, through the adapter's own parse and
+ * enrichment path.
+ *
+ * Returns null for an item the crawl would also drop: without a docket and a
+ * court there is nothing to key the decision on.
+ */
+export const buildCzRegionalDecision = async (
+  item: CzRegionalApiItem,
+  signal?: AbortSignal,
+): Promise<IngestionResult | null> => {
+  const decision = parseItem(item);
+  if (!decision?.documentUrl) {
+    return decision;
+  }
+  applyFinaldoc(
+    decision,
+    await fetchFinaldoc(decision.documentUrl, decision, signal),
+  );
+  return decision;
+};
+
 export const czRegionalAdapter = defineSourceAdapter({
   key: ADAPTER_KEYS.CZ_REGIONAL,
   name: "Czech Regional Courts",
@@ -800,29 +916,10 @@ export const czRegionalAdapter = defineSourceAdapter({
             return;
           }
 
-          const result = await fetchFinaldoc(
-            decision.documentUrl,
+          applyFinaldoc(
             decision,
-            signal,
+            await fetchFinaldoc(decision.documentUrl, decision, signal),
           );
-
-          if (result.fulltext) {
-            decision.fulltext = result.fulltext;
-          }
-          if (result.decisionType) {
-            decision.decisionType = result.decisionType;
-          }
-          decision.documentAst = result.documentAst;
-          decision.sourceRaw = result.sourceRaw;
-          decision.sourceRawContentType = "application/json";
-
-          const rm = result.richMetadata;
-          if (Object.keys(rm).length > 0) {
-            decision.metadata = {
-              ...decision.metadata,
-              ...rm,
-            };
-          }
         };
 
         for (let i = 0; i < decisions.length; i += FINALDOC_CONCURRENCY) {

--- a/apps/api/src/scripts/cz-regional-repair-plan.test.ts
+++ b/apps/api/src/scripts/cz-regional-repair-plan.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
 import type { CzRegionalApiItem } from "@/api/handlers/case-law/ingestion/adapters/cz-regional";
+import type { CzRegionalListingIdentity } from "@/api/scripts/cz-regional-repair-plan";
 import {
   CZ_REGIONAL_FEED_START,
   checkRepairRange,
@@ -148,12 +149,20 @@ describe("czRegionalListingIdentity", () => {
   test("without a link, identity falls back to the docket alone", () => {
     // The sheet number is dropped: it names where the document sits in the
     // file, not the case, and the stored row is keyed on the docket.
-    for (const odkaz of [null, undefined, ""]) {
-      expect(czRegionalListingIdentity(listingItem({ odkaz }))).toEqual({
-        type: "case-number",
-        caseNumber: "11 C 153/2025",
-      });
+    const fallback = {
+      type: "case-number",
+      caseNumber: "11 C 153/2025",
+    } as const satisfies CzRegionalListingIdentity;
+    for (const odkaz of [null, ""] as const) {
+      expect(czRegionalListingIdentity(listingItem({ odkaz }))).toEqual(
+        fallback,
+      );
     }
+    // …and when the publisher omits the field altogether, which is a
+    // different shape from a null one under exactOptionalPropertyTypes.
+    const { odkaz, ...withoutLink } = listingItem();
+    expect(typeof odkaz).toBe("string");
+    expect(czRegionalListingIdentity(withoutLink)).toEqual(fallback);
   });
 
   test("an item the adapter would drop is unidentifiable", () => {

--- a/apps/api/src/scripts/cz-regional-repair-plan.test.ts
+++ b/apps/api/src/scripts/cz-regional-repair-plan.test.ts
@@ -1,0 +1,337 @@
+import { describe, expect, test } from "bun:test";
+
+import type { CzRegionalApiItem } from "@/api/handlers/case-law/ingestion/adapters/cz-regional";
+import {
+  CZ_REGIONAL_FEED_START,
+  checkRepairRange,
+  czRegionalListingIdentity,
+  czRegionalListingKeys,
+  diffCzRegionalListing,
+  enumerateUtcDays,
+  isUtcDateString,
+  toUtcDateString,
+} from "@/api/scripts/cz-regional-repair-plan";
+
+/**
+ * Listing items shaped exactly as the publisher emits them: the docket
+ * carries the sheet number, and the link is an `/api/finaldoc/<uuid>` URL on
+ * the publisher's own host. A shortened stand-in would never reach the
+ * identity rules being tested here.
+ */
+const listingItem = (
+  overrides: Partial<CzRegionalApiItem> = {},
+): CzRegionalApiItem => ({
+  jednaciCislo: "11 C 153/2025-28",
+  ecli: "ECLI:CZ:KSPH:2025:11.C.153.2025.1",
+  soud: "Krajský soud v Praze",
+  autor: "JUDr. Jana Nováková",
+  predmetRizeni: "Náhrada škody",
+  datumVydani: "2025-11-04",
+  datumZverejneni: "2025-11-20",
+  klicovaSlova: ["náhrada škody"],
+  zminenaUstanoveni: ["§ 2894 zákona č. 89/2012 Sb."],
+  odkaz:
+    "https://rozhodnuti.justice.cz/api/finaldoc/2f0a1d6c-9c7f-4a58-bd4a-6c1e0f7a1b23",
+  ...overrides,
+});
+
+describe("enumerateUtcDays", () => {
+  test("includes both bounds", () => {
+    expect(enumerateUtcDays({ from: "2026-02-27", to: "2026-03-02" })).toEqual([
+      "2026-02-27",
+      "2026-02-28",
+      "2026-03-01",
+      "2026-03-02",
+    ]);
+  });
+
+  test("a single-day range is that day", () => {
+    expect(enumerateUtcDays({ from: "2026-03-01", to: "2026-03-01" })).toEqual([
+      "2026-03-01",
+    ]);
+  });
+
+  test("a backwards range covers no days", () => {
+    expect(enumerateUtcDays({ from: "2026-03-02", to: "2026-03-01" })).toEqual(
+      [],
+    );
+  });
+
+  test("leap days and year ends are real days on the walk", () => {
+    expect(enumerateUtcDays({ from: "2028-02-28", to: "2028-03-01" })).toEqual([
+      "2028-02-28",
+      "2028-02-29",
+      "2028-03-01",
+    ]);
+    expect(enumerateUtcDays({ from: "2025-12-31", to: "2026-01-01" })).toEqual([
+      "2025-12-31",
+      "2026-01-01",
+    ]);
+  });
+
+  test("the step is a UTC day across a European DST boundary", () => {
+    // 2026-03-29 is the spring-forward night in Prague; a local-time walk
+    // would emit 2026-03-29 twice or skip it.
+    expect(enumerateUtcDays({ from: "2026-03-28", to: "2026-03-30" })).toEqual([
+      "2026-03-28",
+      "2026-03-29",
+      "2026-03-30",
+    ]);
+    // …and the autumn one.
+    expect(enumerateUtcDays({ from: "2026-10-24", to: "2026-10-26" })).toEqual([
+      "2026-10-24",
+      "2026-10-25",
+      "2026-10-26",
+    ]);
+  });
+
+  test("every emitted day is a day the range's length accounts for", () => {
+    const days = enumerateUtcDays({ from: "2020-10-01", to: "2021-10-01" });
+    expect(days.length).toBe(366);
+    expect(days.at(0)).toBe(CZ_REGIONAL_FEED_START);
+    expect(days.at(-1)).toBe("2021-10-01");
+    expect(new Set(days).size).toBe(days.length);
+  });
+});
+
+describe("isUtcDateString", () => {
+  test("accepts a real UTC day", () => {
+    for (const value of ["2020-10-01", "2028-02-29", "2026-12-31"]) {
+      expect(isUtcDateString(value)).toBe(true);
+    }
+  });
+
+  test("rejects what the shape alone would admit", () => {
+    for (const value of [
+      "2026-02-31",
+      "2026-13-01",
+      "2026-00-10",
+      "2026-1-1",
+      "26-01-01",
+      "2026-01-01T00:00:00Z",
+      "yesterday",
+      "",
+    ]) {
+      expect(isUtcDateString(value)).toBe(false);
+    }
+  });
+
+  test("round-trips a timestamp's own UTC day", () => {
+    // 23:30 in Prague on 2026-03-01 is already 2026-03-01 in UTC only
+    // because the offset is +01:00; the conversion is what decides.
+    const date = new Date("2026-03-01T23:30:00.000Z");
+    expect(toUtcDateString(date)).toBe("2026-03-01");
+    expect(isUtcDateString(toUtcDateString(date))).toBe(true);
+  });
+});
+
+describe("czRegionalListingIdentity", () => {
+  test("the finaldoc link's last segment is the identity", () => {
+    expect(czRegionalListingIdentity(listingItem())).toEqual({
+      type: "document",
+      sourceDocumentId: "2f0a1d6c-9c7f-4a58-bd4a-6c1e0f7a1b23",
+    });
+  });
+
+  test("a link with a query or trailing slash still names the document", () => {
+    for (const odkaz of [
+      "https://rozhodnuti.justice.cz/api/finaldoc/2f0a1d6c-9c7f-4a58-bd4a-6c1e0f7a1b23/",
+      "https://rozhodnuti.justice.cz/api/finaldoc/2f0a1d6c-9c7f-4a58-bd4a-6c1e0f7a1b23?format=json",
+    ]) {
+      expect(czRegionalListingIdentity(listingItem({ odkaz }))).toEqual({
+        type: "document",
+        sourceDocumentId: "2f0a1d6c-9c7f-4a58-bd4a-6c1e0f7a1b23",
+      });
+    }
+  });
+
+  test("without a link, identity falls back to the docket alone", () => {
+    // The sheet number is dropped: it names where the document sits in the
+    // file, not the case, and the stored row is keyed on the docket.
+    for (const odkaz of [null, undefined, ""]) {
+      expect(czRegionalListingIdentity(listingItem({ odkaz }))).toEqual({
+        type: "case-number",
+        caseNumber: "11 C 153/2025",
+      });
+    }
+  });
+
+  test("an item the adapter would drop is unidentifiable", () => {
+    for (const overrides of [
+      { jednaciCislo: null },
+      { jednaciCislo: "" },
+      { soud: null },
+      { soud: "" },
+    ] satisfies Partial<CzRegionalApiItem>[]) {
+      expect(czRegionalListingIdentity(listingItem(overrides))).toEqual({
+        type: "unidentifiable",
+      });
+    }
+  });
+});
+
+describe("czRegionalListingKeys", () => {
+  test("collects each identity half once, into its own lookup", () => {
+    const keys = czRegionalListingKeys([
+      listingItem(),
+      listingItem(),
+      listingItem({
+        jednaciCislo: "31 Cm 8/2024-102",
+        odkaz: null,
+      }),
+      listingItem({ jednaciCislo: "31 Cm 8/2024-115", odkaz: null }),
+      listingItem({ soud: null }),
+    ]);
+    expect(keys).toEqual({
+      documentIds: ["2f0a1d6c-9c7f-4a58-bd4a-6c1e0f7a1b23"],
+      // Both sheets of one docket ask the same question.
+      caseNumbers: ["31 Cm 8/2024"],
+    });
+  });
+});
+
+describe("diffCzRegionalListing", () => {
+  const held = {
+    documentIds: new Set(["2f0a1d6c-9c7f-4a58-bd4a-6c1e0f7a1b23"]),
+    caseNumbers: new Set(["31 Cm 8/2024"]),
+  };
+
+  test("an item whose document id is stored is held", () => {
+    const diff = diffCzRegionalListing({ items: [listingItem()], held });
+    expect(diff.held.length).toBe(1);
+    expect(diff.missing).toEqual([]);
+  });
+
+  test("an item whose document id is not stored is missing, verbatim", () => {
+    const item = listingItem({
+      odkaz:
+        "https://rozhodnuti.justice.cz/api/finaldoc/8b41c2de-5a90-4f11-9c33-af07b21d64ee",
+    });
+    const diff = diffCzRegionalListing({ items: [item], held });
+    expect(diff.missing).toEqual([item]);
+    expect(diff.held).toEqual([]);
+  });
+
+  test("a linkless item matches a row stored under the docket", () => {
+    const stored = listingItem({
+      jednaciCislo: "31 Cm 8/2024-102",
+      odkaz: null,
+    });
+    const absent = listingItem({
+      jednaciCislo: "44 Co 91/2023-7",
+      odkaz: null,
+    });
+    const diff = diffCzRegionalListing({ items: [stored, absent], held });
+    expect(diff.held).toEqual([stored]);
+    expect(diff.missing).toEqual([absent]);
+  });
+
+  test("a stored docket does not hold a linked item of the same case", () => {
+    // The two halves of the identity index are disjoint: a row keyed on the
+    // docket is stored without a document id, so it cannot answer for an
+    // item the publisher now links.
+    const linked = listingItem({
+      jednaciCislo: "31 Cm 8/2024-102",
+      odkaz:
+        "https://rozhodnuti.justice.cz/api/finaldoc/c93e77a1-2b04-4e6b-8f52-1d9a5c30e7f4",
+    });
+    expect(diffCzRegionalListing({ items: [linked], held }).missing).toEqual([
+      linked,
+    ]);
+  });
+
+  test("a repeated identity is not offered for ingest twice", () => {
+    const first = listingItem({
+      odkaz:
+        "https://rozhodnuti.justice.cz/api/finaldoc/8b41c2de-5a90-4f11-9c33-af07b21d64ee",
+    });
+    const repeat = listingItem({
+      jednaciCislo: "11 C 153/2025-31",
+      odkaz:
+        "https://rozhodnuti.justice.cz/api/finaldoc/8b41c2de-5a90-4f11-9c33-af07b21d64ee",
+    });
+    const diff = diffCzRegionalListing({ items: [first, repeat], held });
+    expect(diff.missing).toEqual([first]);
+    expect(diff.duplicate).toEqual([repeat]);
+  });
+
+  test("the four buckets partition the page", () => {
+    const items = [
+      listingItem(),
+      listingItem(),
+      listingItem({
+        odkaz:
+          "https://rozhodnuti.justice.cz/api/finaldoc/8b41c2de-5a90-4f11-9c33-af07b21d64ee",
+      }),
+      listingItem({ jednaciCislo: "31 Cm 8/2024-102", odkaz: null }),
+      listingItem({ jednaciCislo: "44 Co 91/2023-7", odkaz: null }),
+      listingItem({ soud: null }),
+    ];
+    const diff = diffCzRegionalListing({ items, held });
+    expect(
+      diff.missing.length +
+        diff.held.length +
+        diff.duplicate.length +
+        diff.unidentifiable.length,
+    ).toBe(items.length);
+    expect(diff.missing.length).toBe(2);
+    expect(diff.held.length).toBe(2);
+    expect(diff.duplicate.length).toBe(1);
+    expect(diff.unidentifiable.length).toBe(1);
+  });
+
+  test("an empty page diffs to empty buckets", () => {
+    expect(diffCzRegionalListing({ items: [], held })).toEqual({
+      missing: [],
+      held: [],
+      unidentifiable: [],
+      duplicate: [],
+    });
+  });
+});
+
+describe("checkRepairRange", () => {
+  test("accepts a forward range, with or without a resume point", () => {
+    expect(
+      checkRepairRange({ from: "2020-10-01", to: "2026-08-11", after: null }),
+    ).toEqual({ type: "valid" });
+    expect(
+      checkRepairRange({
+        from: "2020-10-01",
+        to: "2026-08-11",
+        after: "2024-01-31",
+      }),
+    ).toEqual({ type: "valid" });
+  });
+
+  test("a single-day range is valid", () => {
+    expect(
+      checkRepairRange({ from: "2026-03-01", to: "2026-03-01", after: null }),
+    ).toEqual({ type: "valid" });
+  });
+
+  test("a backwards range is refused before anything is contacted", () => {
+    const check = checkRepairRange({
+      from: "2026-03-02",
+      to: "2026-03-01",
+      after: null,
+    });
+    expect(check.type).toBe("invalid");
+    expect(check.type === "invalid" ? check.message : "").toContain("--from");
+  });
+
+  test("each bound is named in the refusal it causes", () => {
+    for (const [flag, input] of [
+      ["--from", { from: "2026-02-31", to: "2026-03-01", after: null }],
+      ["--to", { from: "2026-03-01", to: "not-a-date", after: null }],
+      [
+        "--after",
+        { from: "2026-03-01", to: "2026-03-02", after: "2026-13-01" },
+      ],
+    ] as const) {
+      const check = checkRepairRange(input);
+      expect(check.type).toBe("invalid");
+      expect(check.type === "invalid" ? check.message : "").toContain(flag);
+    }
+  });
+});

--- a/apps/api/src/scripts/cz-regional-repair-plan.ts
+++ b/apps/api/src/scripts/cz-regional-repair-plan.ts
@@ -1,0 +1,283 @@
+import { panic } from "better-result";
+
+import { DAY_IN_MS } from "@stll/time";
+
+import { splitCaseReference } from "@/api/handlers/case-law/case-number";
+import type { CzRegionalApiItem } from "@/api/handlers/case-law/ingestion/adapters/cz-regional";
+import { documentIdFromLink } from "@/api/handlers/case-law/ingestion/adapters/cz-regional";
+
+/**
+ * Day enumeration, identity derivation and the listing diff for the
+ * cz-regional reconciliation (`cz-regional-repair.ts`), kept apart from the
+ * runnable script so they can be exercised without a database or the
+ * publisher's API.
+ *
+ * The identity helpers come from the adapter rather than being restated
+ * here: what counts as this source's document id is one rule, and a second
+ * copy of it would let the reconciliation and the crawl disagree about which
+ * rows already exist. The adapter is imported for those functions only —
+ * nothing in this module performs I/O.
+ */
+
+/** The only language this source publishes; half of the fallback identity. */
+export const CZ_REGIONAL_LANGUAGE = "cs";
+
+/** First day of the publisher's open-data feed. */
+export const CZ_REGIONAL_FEED_START = "2020-10-01";
+
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/u;
+
+/** Midnight UTC on a `YYYY-MM-DD` day, as epoch milliseconds. */
+const utcDayStart = (date: string): number =>
+  new Date(`${date}T00:00:00.000Z`).getTime();
+
+/** The UTC calendar day a timestamp falls on, as `YYYY-MM-DD`. */
+export const toUtcDateString = (date: Date): string =>
+  date.toISOString().slice(0, 10);
+
+/**
+ * Whether a string names a real UTC calendar day. The round-trip rejects
+ * what the shape alone admits (`2026-02-31`, `2026-13-01`), which would
+ * otherwise silently walk a different day than the operator asked for.
+ */
+export const isUtcDateString = (value: string): boolean => {
+  if (!ISO_DATE.test(value)) {
+    return false;
+  }
+  const parsed = utcDayStart(value);
+  return !Number.isNaN(parsed) && toUtcDateString(new Date(parsed)) === value;
+};
+
+type UtcDayRange = {
+  from: string;
+  to: string;
+};
+
+/**
+ * Every UTC day in `[from, to]`, both bounds included. Empty when the range
+ * runs backwards. Every UTC day is exactly 24 hours, so the fixed step cannot
+ * drift the way a local-calendar walk does across a DST boundary; the
+ * publisher's day endpoint is addressed in UTC too.
+ */
+export const enumerateUtcDays = ({ from, to }: UtcDayRange): string[] => {
+  const end = utcDayStart(to);
+  const days: string[] = [];
+  for (let cursor = utcDayStart(from); cursor <= end; cursor += DAY_IN_MS) {
+    days.push(toUtcDateString(new Date(cursor)));
+  }
+  return days;
+};
+
+/**
+ * How a listing item would be keyed once stored, mirroring the two halves of
+ * the decision identity index: the publisher's document id where the item
+ * carries one, the docket otherwise.
+ */
+export type CzRegionalListingIdentity =
+  | { type: "document"; sourceDocumentId: string }
+  | { type: "case-number"; caseNumber: string }
+  | { type: "unidentifiable" };
+
+/**
+ * The identity the ingest would store for this listing item.
+ *
+ * `unidentifiable` is the item the crawl also drops: without a docket and a
+ * court there is nothing to key the decision on, so it can never be held and
+ * must not be counted as missing either.
+ */
+export const czRegionalListingIdentity = (
+  item: CzRegionalApiItem,
+): CzRegionalListingIdentity => {
+  if (!item.jednaciCislo || !item.soud) {
+    return { type: "unidentifiable" };
+  }
+  const sourceDocumentId = documentIdFromLink(item.odkaz ?? undefined);
+  if (sourceDocumentId !== undefined) {
+    return { type: "document", sourceDocumentId };
+  }
+  return {
+    type: "case-number",
+    caseNumber: splitCaseReference(item.jednaciCislo).caseNumber,
+  };
+};
+
+export type CzRegionalListingKeys = {
+  /** Distinct publisher document ids on the page. */
+  documentIds: string[];
+  /** Distinct dockets on the page, for the fallback half of the identity. */
+  caseNumbers: string[];
+};
+
+/**
+ * The identity values a page has to ask the database about. Distinct, so the
+ * lookups stay bounded by the page rather than by its repetitions.
+ */
+export const czRegionalListingKeys = (
+  items: readonly CzRegionalApiItem[],
+): CzRegionalListingKeys => {
+  const documentIds = new Set<string>();
+  const caseNumbers = new Set<string>();
+  for (const item of items) {
+    const identity = czRegionalListingIdentity(item);
+    switch (identity.type) {
+      case "document":
+        documentIds.add(identity.sourceDocumentId);
+        break;
+      case "case-number":
+        caseNumbers.add(identity.caseNumber);
+        break;
+      case "unidentifiable":
+        break;
+      default: {
+        const exhaustive: never = identity;
+        panic(`Unhandled listing identity: ${JSON.stringify(exhaustive)}`);
+      }
+    }
+  }
+  return { documentIds: [...documentIds], caseNumbers: [...caseNumbers] };
+};
+
+/** What the database already holds for this source, by identity half. */
+export type CzRegionalHeldIdentities = {
+  documentIds: ReadonlySet<string>;
+  /** Dockets of rows stored without a publisher document id. */
+  caseNumbers: ReadonlySet<string>;
+};
+
+/**
+ * Where every item on a listing page stands. The four buckets partition the
+ * page: an item lands in exactly one, and their sizes sum to the page's.
+ */
+export type CzRegionalListingDiff = {
+  missing: CzRegionalApiItem[];
+  held: CzRegionalApiItem[];
+  unidentifiable: CzRegionalApiItem[];
+  /** A repeat of an identity already classified on this page. */
+  duplicate: CzRegionalApiItem[];
+};
+
+type DiffListingInput = {
+  items: readonly CzRegionalApiItem[];
+  held: CzRegionalHeldIdentities;
+};
+
+/**
+ * Diff one listing page against the identities already stored.
+ *
+ * A repeated identity is separated out rather than repeated in `missing`:
+ * the publisher lists a document once per docket it settles, and ingesting
+ * the same identity twice in one run would have the second observation
+ * refresh the first for nothing.
+ */
+export const diffCzRegionalListing = ({
+  items,
+  held,
+}: DiffListingInput): CzRegionalListingDiff => {
+  const diff: CzRegionalListingDiff = {
+    missing: [],
+    held: [],
+    unidentifiable: [],
+    duplicate: [],
+  };
+  const seen = new Set<string>();
+  for (const item of items) {
+    const identity = czRegionalListingIdentity(item);
+    if (identity.type === "unidentifiable") {
+      diff.unidentifiable.push(item);
+      continue;
+    }
+    const key =
+      identity.type === "document"
+        ? `document:${identity.sourceDocumentId}`
+        : `case-number:${identity.caseNumber}`;
+    if (seen.has(key)) {
+      diff.duplicate.push(item);
+      continue;
+    }
+    seen.add(key);
+    const isHeld =
+      identity.type === "document"
+        ? held.documentIds.has(identity.sourceDocumentId)
+        : held.caseNumbers.has(identity.caseNumber);
+    if (isHeld) {
+      diff.held.push(item);
+    } else {
+      diff.missing.push(item);
+    }
+  }
+  return diff;
+};
+
+export type CzRegionalRepairArgs = {
+  from: string;
+  to: string;
+  /** false = walk and diff only; nothing is fetched in full and nothing written. */
+  apply: boolean;
+  outPath: string;
+  /** Process exactly these items instead of walking the listing. */
+  itemsFilePath: string | null;
+  /** null = no cap on the missing decisions processed this run. */
+  limit: number | null;
+  /** Resume strictly after this UTC day. */
+  after: string | null;
+  delayMs: number;
+  failedOutPath: string;
+};
+
+/** One day's reconciliation, as the report records it. */
+export type CzRegionalRepairDay = {
+  date: string;
+  listed: number;
+  held: number;
+  missing: number;
+};
+
+export type CzRegionalRepairReport = {
+  generatedAt: string;
+  from: string;
+  to: string;
+  days: CzRegionalRepairDay[];
+  /** Raw listing items, so a later run can be fed them with --items-file. */
+  missingItems: CzRegionalApiItem[];
+};
+
+export type CzRegionalRangeCheck =
+  | { type: "valid" }
+  | { type: "invalid"; message: string };
+
+type RangeCheckInput = {
+  from: string;
+  to: string;
+  after: string | null;
+};
+
+/**
+ * Validate the walk's bounds before anything is contacted or leased. A
+ * backwards range walks nothing, which would otherwise read as a source with
+ * no gaps at all.
+ */
+export const checkRepairRange = ({
+  from,
+  to,
+  after,
+}: RangeCheckInput): CzRegionalRangeCheck => {
+  for (const [name, value] of [
+    ["--from", from],
+    ["--to", to],
+    ...(after === null ? [] : [["--after", after] as const]),
+  ] as const) {
+    if (!isUtcDateString(value)) {
+      return {
+        type: "invalid",
+        message: `${name} must be a UTC date as YYYY-MM-DD, got: ${value}`,
+      };
+    }
+  }
+  if (from > to) {
+    return {
+      type: "invalid",
+      message: `--from (${from}) is after --to (${to}); the range covers no days`,
+    };
+  }
+  return { type: "valid" };
+};

--- a/apps/api/src/scripts/cz-regional-repair-plan.ts
+++ b/apps/api/src/scripts/cz-regional-repair-plan.ts
@@ -216,7 +216,10 @@ export type CzRegionalRepairArgs = {
   outPath: string;
   /** Process exactly these items instead of walking the listing. */
   itemsFilePath: string | null;
-  /** null = no cap on the missing decisions processed this run. */
+  /**
+   * Work items this run: decisions written when applying, missing items
+   * recorded when not. null only for an explicitly unbounded pass.
+   */
   limit: number | null;
   /** Resume strictly after this UTC day. */
   after: string | null;

--- a/apps/api/src/scripts/cz-regional-repair.ts
+++ b/apps/api/src/scripts/cz-regional-repair.ts
@@ -1,0 +1,612 @@
+import { panic } from "better-result";
+import { and, eq, inArray, isNull } from "drizzle-orm";
+
+import { rlsDb } from "@/api/db/root";
+import { caseLawDecisions, caseLawSources } from "@/api/db/schema";
+import { createIngestionDb } from "@/api/db/scoped";
+import type {
+  CzRegionalApiItem,
+  CzRegionalDayPage,
+} from "@/api/handlers/case-law/ingestion/adapters/cz-regional";
+import {
+  buildCzRegionalDecision,
+  isCzRegionalApiItem,
+  listCzRegionalDayPage,
+} from "@/api/handlers/case-law/ingestion/adapters/cz-regional";
+import {
+  allocateSourceObservationOrder,
+  PROCESS_DECISION_STATUS,
+  processDecision,
+} from "@/api/handlers/case-law/ingestion/pipeline";
+import { acquireCaseLawSourceIngestionLease } from "@/api/lib/legal-search/case-law-source-ingestion-lease";
+import type { CaseLawSourceIngestionLease } from "@/api/lib/legal-search/case-law-source-ingestion-lease";
+import { ADAPTER_KEYS } from "@/api/lib/legal-search/ingestion-constants";
+import { refreshCorpusS3, refreshS3 } from "@/api/lib/s3";
+import type {
+  CzRegionalHeldIdentities,
+  CzRegionalRepairArgs,
+  CzRegionalRepairDay,
+  CzRegionalRepairReport,
+} from "@/api/scripts/cz-regional-repair-plan";
+import {
+  CZ_REGIONAL_FEED_START,
+  CZ_REGIONAL_LANGUAGE,
+  checkRepairRange,
+  czRegionalListingKeys,
+  diffCzRegionalListing,
+  enumerateUtcDays,
+  toUtcDateString,
+} from "@/api/scripts/cz-regional-repair-plan";
+
+/**
+ * Reconcile the cz-regional source against the publisher's own day listings.
+ *
+ * The crawl reaches a decision by walking a date cursor forward, so anything
+ * a page dropped while the cursor moved past it is never revisited: the
+ * cursor is the only record of what was seen. The publisher's opendata
+ * endpoint lists each day independently of that cursor, which makes the
+ * question answerable — enumerate what a day lists, key each item the way
+ * the ingest would key it, and compare against the identities already
+ * stored.
+ *
+ * Only the missing ones are fetched in full. Each is built through the
+ * adapter's own parse and finaldoc path and written by the ingestion
+ * pipeline's `processDecision`, ordered on the source's observation counter
+ * under its ingestion lease, so a run cannot interleave with a live crawl.
+ * The default refresh policy is the right one here: this run exists to add
+ * rows the source never stored, and a row that is already held is left
+ * exactly as it is.
+ *
+ * Without `--apply` nothing is fetched in full, nothing is leased and
+ * nothing is written; the walk reports per-day and total missing counts and
+ * writes the report file. The report carries the missing listing items
+ * verbatim, so `--items-file` can process exactly them later. Failed items
+ * are written the same way at the end of an apply run. Interrupt with
+ * Ctrl-C: the current decision finishes and the report names the resume
+ * point.
+ *
+ *   # what a run would visit, writing nothing
+ *   bun run src/scripts/cz-regional-repair.ts --from 2026-01-01
+ *
+ *   # ingest the misses, resumable
+ *   bun run src/scripts/cz-regional-repair.ts --from 2026-01-01 \
+ *     --apply --limit 500 [--after <YYYY-MM-DD>]
+ *
+ *   # process exactly the items a previous run reported
+ *   bun run src/scripts/cz-regional-repair.ts --apply \
+ *     --items-file cz-regional-repair-failed.json
+ *
+ * Not a scheduled job: a deliberate operation under an operator who reads
+ * the report.
+ */
+
+const DEFAULT_DELAY_MS = 250;
+/** Consecutive failed items before the run halts; mirrors the re-fetch. */
+const FAILURE_HALT_THRESHOLD = 10;
+const LIST_TIMEOUT_MS = 60_000;
+/**
+ * Politeness pause between listing requests, matching the adapter's own
+ * `minRequestIntervalMs`. The walk asks for one page per request and a full
+ * range is thousands of them, so without a floor a plan-only run would hit
+ * the publisher harder than the crawl it reconciles.
+ */
+const LIST_DELAY_MS = 200;
+/** One finaldoc document; nothing here should take longer. */
+const ITEM_FETCH_TIMEOUT_MS = 2 * 60_000;
+const DEFAULT_OUT = "cz-regional-repair-plan.json";
+const DEFAULT_FAILED_OUT = "cz-regional-repair-failed.json";
+const PROGRESS_EVERY = 25;
+
+const USAGE = `Usage: bun run src/scripts/cz-regional-repair.ts [options]
+
+  --from <YYYY-MM-DD>  First day listed (default ${CZ_REGIONAL_FEED_START}, the feed's start).
+  --to <YYYY-MM-DD>    Last day listed (default today, UTC).
+  --apply              Fetch and write the missing decisions. Omitted, the
+                       run walks and diffs only.
+  --out <path>         Where the walk's report is written (default ${DEFAULT_OUT}).
+  --items-file <path>  Process exactly the listing items in this JSON array
+                       instead of walking; requires --apply.
+  --limit <n>          Maximum missing decisions processed this run.
+  --after <YYYY-MM-DD> Resume strictly after this day.
+  --delay-ms <n>       Pause between decisions (default ${DEFAULT_DELAY_MS}).
+  --failed-out <path>  Where failed items are written (default ${DEFAULT_FAILED_OUT}).`;
+
+const flagValue = (name: string): string | undefined => {
+  const index = process.argv.indexOf(`--${name}`);
+  if (index === -1) {
+    return undefined;
+  }
+  const value = process.argv[index + 1];
+  if (value === undefined || value.startsWith("--")) {
+    console.error(`--${name} requires a value`);
+    console.error(USAGE);
+    process.exit(1);
+  }
+  return value;
+};
+
+const hasFlag = (name: string): boolean => process.argv.includes(`--${name}`);
+
+const DECIMAL_INTEGER = /^\d+$/u;
+
+const positiveInteger = (
+  raw: string | undefined,
+  fallback: number,
+  name: string,
+): number => {
+  if (raw === undefined) {
+    return fallback;
+  }
+  const parsed = DECIMAL_INTEGER.test(raw)
+    ? Number.parseInt(raw, 10)
+    : Number.NaN;
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    console.error(`--${name} must be a positive integer, got: ${raw}`);
+    process.exit(1);
+  }
+  return parsed;
+};
+
+const limitFlag = flagValue("limit");
+
+const args = {
+  from: flagValue("from") ?? CZ_REGIONAL_FEED_START,
+  to: flagValue("to") ?? toUtcDateString(new Date()),
+  apply: hasFlag("apply"),
+  outPath: flagValue("out") ?? DEFAULT_OUT,
+  itemsFilePath: flagValue("items-file") ?? null,
+  limit:
+    limitFlag === undefined ? null : positiveInteger(limitFlag, 0, "limit"),
+  after: flagValue("after") ?? null,
+  delayMs: positiveInteger(flagValue("delay-ms"), DEFAULT_DELAY_MS, "delay-ms"),
+  failedOutPath: flagValue("failed-out") ?? DEFAULT_FAILED_OUT,
+} satisfies CzRegionalRepairArgs;
+
+const {
+  after,
+  apply,
+  delayMs,
+  failedOutPath,
+  from,
+  itemsFilePath,
+  limit,
+  outPath,
+  to,
+} = args;
+
+const range = checkRepairRange({ from, to, after });
+if (range.type === "invalid") {
+  console.error(range.message);
+  console.error(USAGE);
+  process.exit(1);
+}
+
+if (itemsFilePath !== null && !apply) {
+  console.error("--items-file names decisions to write; it requires --apply.");
+  console.error(USAGE);
+  process.exit(1);
+}
+
+const isCzRegionalItemArray = (value: unknown): value is CzRegionalApiItem[] =>
+  Array.isArray(value) && value.every(isCzRegionalApiItem);
+
+// Read and validated here, before the lease: a malformed entry deep in the
+// file would otherwise burn the consecutive-failure budget mid-run and could
+// halt a valid recovery.
+const suppliedItems = await (async (): Promise<CzRegionalApiItem[] | null> => {
+  if (itemsFilePath === null) {
+    return null;
+  }
+  const parsed: unknown = JSON.parse(await Bun.file(itemsFilePath).text());
+  if (!isCzRegionalItemArray(parsed)) {
+    console.error(`${itemsFilePath} is not a JSON array of listing items`);
+    process.exit(1);
+  }
+  return limit === null ? parsed : parsed.slice(0, limit);
+})();
+
+const days =
+  suppliedItems === null
+    ? enumerateUtcDays({ from, to }).filter(
+        (date) => after === null || date > after,
+      )
+    : [];
+
+console.log("=== CZ-REGIONAL LISTING RECONCILIATION ===");
+console.log(`mode:        ${apply ? "apply" : "plan only"}`);
+if (suppliedItems === null) {
+  console.log(`range:       ${from} … ${to}`);
+  console.log(
+    `days:        ${days.length}${after === null ? "" : ` (after ${after})`}`,
+  );
+} else {
+  console.log(`items file:  ${itemsFilePath} (${suppliedItems.length} items)`);
+}
+
+const ingestionDb = createIngestionDb(rlsDb);
+
+const source = (
+  await ingestionDb((tx) =>
+    tx
+      .select({ id: caseLawSources.id })
+      .from(caseLawSources)
+      .where(eq(caseLawSources.adapterKey, ADAPTER_KEYS.CZ_REGIONAL))
+      .limit(1),
+  )
+).at(0);
+if (!source) {
+  console.error("No case-law source configured for adapter cz-regional");
+  process.exit(1);
+}
+const sourceId = source.id;
+
+/**
+ * Which of a page's publisher document ids are already stored. Bounded by
+ * the page the ids came from, which this API caps at 100 items.
+ */
+const selectHeldDocumentIds = async (
+  documentIds: string[],
+): Promise<string[]> => {
+  if (documentIds.length === 0) {
+    return [];
+  }
+  const rows = await ingestionDb((tx) =>
+    tx
+      .select({ sourceDocumentId: caseLawDecisions.sourceDocumentId })
+      .from(caseLawDecisions)
+      .where(
+        and(
+          eq(caseLawDecisions.sourceId, sourceId),
+          inArray(caseLawDecisions.sourceDocumentId, documentIds),
+        ),
+      )
+      .limit(documentIds.length),
+  );
+  return rows.flatMap((row) =>
+    row.sourceDocumentId === null ? [] : [row.sourceDocumentId],
+  );
+};
+
+/**
+ * The same question for the fallback half of the identity index: rows this
+ * source stored without a publisher document id are keyed on the docket and
+ * the language, so only those rows can answer for a listing item that
+ * carries no link.
+ */
+const selectHeldCaseNumbers = async (
+  caseNumbers: string[],
+): Promise<string[]> => {
+  if (caseNumbers.length === 0) {
+    return [];
+  }
+  const rows = await ingestionDb((tx) =>
+    tx
+      .select({ caseNumber: caseLawDecisions.caseNumber })
+      .from(caseLawDecisions)
+      .where(
+        and(
+          eq(caseLawDecisions.sourceId, sourceId),
+          inArray(caseLawDecisions.caseNumber, caseNumbers),
+          eq(caseLawDecisions.language, CZ_REGIONAL_LANGUAGE),
+          isNull(caseLawDecisions.sourceDocumentId),
+        ),
+      )
+      .limit(caseNumbers.length),
+  );
+  return rows.map((row) => row.caseNumber);
+};
+
+const heldIdentities = async (
+  items: readonly CzRegionalApiItem[],
+): Promise<CzRegionalHeldIdentities> => {
+  const { documentIds, caseNumbers } = czRegionalListingKeys(items);
+  const [heldDocumentIds, heldCaseNumbers] = await Promise.all([
+    selectHeldDocumentIds(documentIds),
+    selectHeldCaseNumbers(caseNumbers),
+  ]);
+  return {
+    documentIds: new Set(heldDocumentIds),
+    caseNumbers: new Set(heldCaseNumbers),
+  };
+};
+
+const INGEST_OUTCOMES = {
+  WRITTEN: "written",
+  RETRYABLE: "retryable",
+  FAILED: "failed",
+  /** The adapter would drop this item; a retry can never write it. */
+  UNINGESTABLE: "uningestable",
+} as const;
+
+type IngestOutcome = (typeof INGEST_OUTCOMES)[keyof typeof INGEST_OUTCOMES];
+
+const ingestItem = async (
+  item: CzRegionalApiItem,
+  lease: CaseLawSourceIngestionLease,
+): Promise<IngestOutcome> => {
+  try {
+    const decision = await buildCzRegionalDecision(
+      item,
+      AbortSignal.timeout(ITEM_FETCH_TIMEOUT_MS),
+    );
+    if (decision === null) {
+      console.error(
+        `${item.jednaciCislo ?? "(no docket)"}: no docket and court to key on; skipped`,
+      );
+      return INGEST_OUTCOMES.UNINGESTABLE;
+    }
+    await lease.beforeDatabaseMark();
+    const observationOrder = await allocateSourceObservationOrder({
+      leaseToken: lease.leaseToken,
+      scopedDb: ingestionDb,
+      sourceId,
+    });
+    const processed = await processDecision({
+      input: decision,
+      sourceId,
+      scopedDb: ingestionDb,
+      observedAt: new Date(),
+      observationOrder,
+    });
+    if (processed.status === PROCESS_DECISION_STATUS.RETRYABLE) {
+      console.error(`${decision.caseNumber}: retryable — ${processed.reason}`);
+      return INGEST_OUTCOMES.RETRYABLE;
+    }
+    return INGEST_OUTCOMES.WRITTEN;
+  } catch (error) {
+    console.error(`${item.jednaciCislo ?? "(no docket)"}: failed —`, error);
+    return INGEST_OUTCOMES.FAILED;
+  }
+};
+
+if (!apply) {
+  console.log(
+    "Plan only: nothing fetched in full, nothing written. Re-run with --apply.",
+  );
+}
+
+if (apply) {
+  await refreshS3();
+  await refreshCorpusS3();
+}
+
+const sourceLease = apply
+  ? await acquireCaseLawSourceIngestionLease({
+      scopedDb: ingestionDb,
+      sourceId,
+    })
+  : null;
+if (apply && sourceLease === null) {
+  console.error(
+    "Source cz-regional is being ingested right now (lease held). Retry later.",
+  );
+  process.exit(1);
+}
+
+// Object-held so the flag's cross-callback mutation is visible to
+// per-site flow analysis; a plain boolean reads as always-false.
+const runState = { interrupted: false };
+process.on("SIGINT", () => {
+  runState.interrupted = true;
+  console.error("interrupt received; finishing the current decision…");
+});
+
+type Halt = {
+  reason: string;
+  /** Whether the run should exit non-zero; an operator stop should not. */
+  failure: boolean;
+};
+
+const counts = {
+  listed: 0,
+  held: 0,
+  missing: 0,
+  uningestable: 0,
+  duplicate: 0,
+  processed: 0,
+  written: 0,
+  retryable: 0,
+};
+const reportDays: CzRegionalRepairDay[] = [];
+const missingItems: CzRegionalApiItem[] = [];
+const failedItems: CzRegionalApiItem[] = [];
+let consecutiveFailures = 0;
+let halt: Halt | null = null;
+/** Whether a listing request has already gone out, so the pause has an "each subsequent" to apply to. */
+let listedAnyPage = false;
+/** Last day walked end to end; the only safe resume boundary. */
+let lastCompletedDate: string | null = null;
+
+const stopReason = (): Halt | null => {
+  if (runState.interrupted) {
+    return { reason: "interrupted", failure: false };
+  }
+  if (consecutiveFailures >= FAILURE_HALT_THRESHOLD) {
+    return {
+      reason: `${FAILURE_HALT_THRESHOLD} consecutive items failed`,
+      failure: true,
+    };
+  }
+  if (limit !== null && counts.processed >= limit) {
+    return { reason: `--limit ${limit} reached`, failure: false };
+  }
+  return null;
+};
+
+const recordOutcome = (item: CzRegionalApiItem, outcome: IngestOutcome) => {
+  counts.processed += 1;
+  switch (outcome) {
+    case INGEST_OUTCOMES.WRITTEN:
+      counts.written += 1;
+      consecutiveFailures = 0;
+      break;
+    case INGEST_OUTCOMES.UNINGESTABLE:
+      counts.uningestable += 1;
+      consecutiveFailures = 0;
+      break;
+    case INGEST_OUTCOMES.RETRYABLE:
+      counts.retryable += 1;
+      failedItems.push(item);
+      consecutiveFailures += 1;
+      break;
+    case INGEST_OUTCOMES.FAILED:
+      failedItems.push(item);
+      consecutiveFailures += 1;
+      break;
+    default: {
+      const exhaustive: never = outcome;
+      panic(`Unhandled ingest outcome: ${String(exhaustive)}`);
+    }
+  }
+  if (counts.processed % PROGRESS_EVERY === 0) {
+    console.error(
+      `progress: ${counts.processed} items, ${counts.written} written, ${failedItems.length} failed`,
+    );
+  }
+};
+
+try {
+  if (suppliedItems === null) {
+    for (const date of days) {
+      halt = stopReason();
+      if (halt !== null) {
+        break;
+      }
+      const day: CzRegionalRepairDay = {
+        date,
+        listed: 0,
+        held: 0,
+        missing: 0,
+      };
+      let dayComplete = true;
+      for (let page = 0; ; page += 1) {
+        if (listedAnyPage) {
+          // oxlint-disable-next-line no-await-in-loop -- politeness pause between listing requests, matching the adapter's minimum request interval
+          await Bun.sleep(LIST_DELAY_MS);
+        }
+        listedAnyPage = true;
+        let listed: CzRegionalDayPage;
+        try {
+          // oxlint-disable-next-line no-await-in-loop -- rate-limited publisher traffic stays sequential
+          listed = await listCzRegionalDayPage({
+            date,
+            page,
+            signal: AbortSignal.timeout(LIST_TIMEOUT_MS),
+          });
+        } catch (error) {
+          // The day is left unwalked rather than half-walked: advancing the
+          // resume boundary past it would turn a transient listing failure
+          // into a permanent gap.
+          console.error(`${date} page ${page}: listing failed —`, error);
+          halt = { reason: `listing failed on ${date}`, failure: true };
+          dayComplete = false;
+          break;
+        }
+        // oxlint-disable-next-line no-await-in-loop -- one bounded lookup per listing page, sequential with the page it describes
+        const held = await heldIdentities(listed.items);
+        const diff = diffCzRegionalListing({ items: listed.items, held });
+        day.listed += listed.items.length;
+        day.held += diff.held.length;
+        day.missing += diff.missing.length;
+        counts.listed += listed.items.length;
+        counts.held += diff.held.length;
+        counts.missing += diff.missing.length;
+        counts.uningestable += diff.unidentifiable.length;
+        counts.duplicate += diff.duplicate.length;
+        missingItems.push(...diff.missing);
+
+        if (sourceLease !== null) {
+          for (const item of diff.missing) {
+            halt = stopReason();
+            if (halt !== null) {
+              dayComplete = false;
+              break;
+            }
+            // oxlint-disable-next-line no-await-in-loop -- rate-limited publisher traffic and one pipeline write per decision stay sequential
+            recordOutcome(item, await ingestItem(item, sourceLease));
+            // oxlint-disable-next-line no-await-in-loop -- politeness pause between decisions, matching the crawl
+            await Bun.sleep(delayMs);
+          }
+        }
+
+        if (!dayComplete || page + 1 >= listed.totalPages) {
+          break;
+        }
+      }
+      reportDays.push(day);
+      if (!dayComplete) {
+        break;
+      }
+      lastCompletedDate = date;
+      if (day.missing > 0 || day.listed > 0) {
+        console.error(
+          `${date}: listed ${day.listed}, held ${day.held}, missing ${day.missing}`,
+        );
+      }
+    }
+  } else if (sourceLease !== null) {
+    for (const item of suppliedItems) {
+      halt = stopReason();
+      if (halt !== null) {
+        break;
+      }
+      // oxlint-disable-next-line no-await-in-loop -- rate-limited publisher traffic and one pipeline write per decision stay sequential
+      recordOutcome(item, await ingestItem(item, sourceLease));
+      // oxlint-disable-next-line no-await-in-loop -- politeness pause between decisions, matching the crawl
+      await Bun.sleep(delayMs);
+    }
+  }
+} finally {
+  if (sourceLease !== null) {
+    await sourceLease.release();
+  }
+}
+
+if (suppliedItems === null) {
+  const report: CzRegionalRepairReport = {
+    generatedAt: new Date().toISOString(),
+    from,
+    to,
+    days: reportDays,
+    missingItems,
+  };
+  await Bun.write(outPath, `${JSON.stringify(report, null, 2)}\n`);
+  console.log(`report written to ${outPath}`);
+}
+
+console.log("--- outcomes ---");
+if (suppliedItems === null) {
+  console.log(`days visited:      ${reportDays.length} of ${days.length}`);
+  console.log(`items listed:      ${counts.listed}`);
+  console.log(`already held:      ${counts.held}`);
+  console.log(`missing:           ${counts.missing}`);
+  console.log(`duplicate listing: ${counts.duplicate}`);
+}
+if (apply) {
+  console.log(`processed:         ${counts.processed}`);
+  console.log(`written:           ${counts.written}`);
+  console.log(`retryable:         ${counts.retryable}`);
+}
+console.log(`uningestable:      ${counts.uningestable}`);
+if (failedItems.length > 0) {
+  await Bun.write(failedOutPath, `${JSON.stringify(failedItems, null, 2)}\n`);
+  console.log(`failed:            ${failedItems.length} → ${failedOutPath}`);
+  console.log(`retry them with:   --items-file ${failedOutPath} --apply`);
+}
+if (halt !== null) {
+  console.log(`halted:            ${halt.reason}`);
+}
+// The resume point is the last day walked end to end, never the last day
+// touched: a day the run stopped inside is only partly reconciled.
+if (
+  suppliedItems === null &&
+  days.length > 0 &&
+  lastCompletedDate !== days.at(-1)
+) {
+  console.log(
+    lastCompletedDate === null
+      ? `resume with:       --from ${days.at(0) ?? from}`
+      : `resume with:       --after ${lastCompletedDate}`,
+  );
+}
+process.exit(halt?.failure === true ? 1 : 0);

--- a/apps/api/src/scripts/cz-regional-repair.ts
+++ b/apps/api/src/scripts/cz-regional-repair.ts
@@ -55,13 +55,20 @@ import {
  * under its ingestion lease, so a run cannot interleave with a live crawl.
  * The default refresh policy is the right one here: this run exists to add
  * rows the source never stored, and a row that is already held is left
- * exactly as it is.
+ * exactly as it is. Items whose document could not be read are left missing
+ * rather than stored listing-only, so a later run finds them again instead of
+ * reading the day as reconciled.
+ *
+ * Every run is bounded by `--limit` and continues from the resume point it
+ * prints, in both modes: the walk's own accumulation is the cost without
+ * `--apply`, just as pipeline writes are the cost with it.
  *
  * Without `--apply` nothing is fetched in full, nothing is leased and
  * nothing is written; the walk reports per-day and total missing counts and
  * writes the report file. The report carries the missing listing items
- * verbatim, so `--items-file` can process exactly them later. Failed items
- * are written the same way at the end of an apply run. Interrupt with
+ * verbatim, so `--items-file` can process exactly them later — diffed again
+ * first, because a file is a snapshot and the crawl keeps running. Failed
+ * items are written the same way at the end of an apply run. Interrupt with
  * Ctrl-C: the current decision finishes and the report names the resume
  * point.
  *
@@ -81,6 +88,17 @@ import {
  */
 
 const DEFAULT_DELAY_MS = 250;
+/**
+ * Work items per run, in both modes: decisions written under `--apply`,
+ * missing items recorded without it. The default range is the whole feed and
+ * a sparsely stored source can miss most of it, so an uncapped run would hold
+ * every raw item in memory and write one impractical report at the end. The
+ * cap makes a run finite and the printed resume point continues it; pass
+ * `--no-limit` for a deliberate single-pass census.
+ */
+const DEFAULT_LIMIT = 5000;
+/** Identity lookups per query, matching the publisher's own page size. */
+const HELD_LOOKUP_CHUNK = 100;
 /** Consecutive failed items before the run halts; mirrors the re-fetch. */
 const FAILURE_HALT_THRESHOLD = 10;
 const LIST_TIMEOUT_MS = 60_000;
@@ -104,9 +122,11 @@ const USAGE = `Usage: bun run src/scripts/cz-regional-repair.ts [options]
   --apply              Fetch and write the missing decisions. Omitted, the
                        run walks and diffs only.
   --out <path>         Where the walk's report is written (default ${DEFAULT_OUT}).
-  --items-file <path>  Process exactly the listing items in this JSON array
-                       instead of walking; requires --apply.
-  --limit <n>          Maximum missing decisions processed this run.
+  --items-file <path>  Process the listing items in this JSON array instead of
+                       walking, skipping any since stored; requires --apply.
+  --limit <n>          Work items this run: decisions written under --apply,
+                       missing items recorded without it (default ${DEFAULT_LIMIT}).
+  --no-limit           Run the whole range in one pass, however large.
   --after <YYYY-MM-DD> Resume strictly after this day.
   --delay-ms <n>       Pause between decisions (default ${DEFAULT_DELAY_MS}).
   --failed-out <path>  Where failed items are written (default ${DEFAULT_FAILED_OUT}).`;
@@ -147,7 +167,13 @@ const positiveInteger = (
   return parsed;
 };
 
+const noLimit = hasFlag("no-limit");
 const limitFlag = flagValue("limit");
+if (noLimit && limitFlag !== undefined) {
+  console.error("--no-limit and --limit contradict each other; pass one.");
+  console.error(USAGE);
+  process.exit(1);
+}
 
 const args = {
   from: flagValue("from") ?? CZ_REGIONAL_FEED_START,
@@ -155,8 +181,7 @@ const args = {
   apply: hasFlag("apply"),
   outPath: flagValue("out") ?? DEFAULT_OUT,
   itemsFilePath: flagValue("items-file") ?? null,
-  limit:
-    limitFlag === undefined ? null : positiveInteger(limitFlag, 0, "limit"),
+  limit: noLimit ? null : positiveInteger(limitFlag, DEFAULT_LIMIT, "limit"),
   after: flagValue("after") ?? null,
   delayMs: positiveInteger(flagValue("delay-ms"), DEFAULT_DELAY_MS, "delay-ms"),
   failedOutPath: flagValue("failed-out") ?? DEFAULT_FAILED_OUT,
@@ -202,7 +227,10 @@ const suppliedItems = await (async (): Promise<CzRegionalApiItem[] | null> => {
     console.error(`${itemsFilePath} is not a JSON array of listing items`);
     process.exit(1);
   }
-  return limit === null ? parsed : parsed.slice(0, limit);
+  // Not truncated to --limit: the run halts on the cap and a re-run with the
+  // same file picks up where it stopped, because everything already written
+  // is now held and skipped.
+  return parsed;
 })();
 
 const days =
@@ -310,6 +338,31 @@ const heldIdentities = async (
   };
 };
 
+/**
+ * The same question over an arbitrary number of items, in bounded queries.
+ * A report file carries as many items as a whole walk found, which is more
+ * than one lookup may name.
+ */
+const heldIdentitiesChunked = async (
+  items: readonly CzRegionalApiItem[],
+): Promise<CzRegionalHeldIdentities> => {
+  const documentIds = new Set<string>();
+  const caseNumbers = new Set<string>();
+  for (let index = 0; index < items.length; index += HELD_LOOKUP_CHUNK) {
+    // oxlint-disable-next-line no-await-in-loop -- bounded lookups stay sequential rather than fanning out across the connection pool
+    const held = await heldIdentities(
+      items.slice(index, index + HELD_LOOKUP_CHUNK),
+    );
+    for (const value of held.documentIds) {
+      documentIds.add(value);
+    }
+    for (const value of held.caseNumbers) {
+      caseNumbers.add(value);
+    }
+  }
+  return { documentIds, caseNumbers };
+};
+
 const INGEST_OUTCOMES = {
   WRITTEN: "written",
   RETRYABLE: "retryable",
@@ -324,17 +377,24 @@ const ingestItem = async (
   item: CzRegionalApiItem,
   lease: CaseLawSourceIngestionLease,
 ): Promise<IngestOutcome> => {
+  const docket = item.jednaciCislo ?? "(no docket)";
   try {
-    const decision = await buildCzRegionalDecision(
+    const built = await buildCzRegionalDecision(
       item,
       AbortSignal.timeout(ITEM_FETCH_TIMEOUT_MS),
     );
-    if (decision === null) {
-      console.error(
-        `${item.jednaciCislo ?? "(no docket)"}: no docket and court to key on; skipped`,
-      );
+    if (built.type === "unkeyable") {
+      console.error(`${docket}: no docket and court to key on; skipped`);
       return INGEST_OUTCOMES.UNINGESTABLE;
     }
+    if (built.type === "detail-unavailable") {
+      // Deliberately not written: a listing-only row would make the identity
+      // held, and the next walk would report the day as reconciled while the
+      // document stayed unread. Left missing, it is found again.
+      console.error(`${docket}: document unavailable; left for a retry`);
+      return INGEST_OUTCOMES.RETRYABLE;
+    }
+    const { decision } = built;
     await lease.beforeDatabaseMark();
     const observationOrder = await allocateSourceObservationOrder({
       leaseToken: lease.leaseToken,
@@ -354,7 +414,7 @@ const ingestItem = async (
     }
     return INGEST_OUTCOMES.WRITTEN;
   } catch (error) {
-    console.error(`${item.jednaciCislo ?? "(no docket)"}: failed —`, error);
+    console.error(`${docket}: failed —`, error);
     return INGEST_OUTCOMES.FAILED;
   }
 };
@@ -417,6 +477,14 @@ let listedAnyPage = false;
 /** Last day walked end to end; the only safe resume boundary. */
 let lastCompletedDate: string | null = null;
 
+/**
+ * What `--limit` counts. Under `--apply` the run's cost is the decisions it
+ * puts through the pipeline; without it, the cost is the missing items it
+ * accumulates for the report, and those must be capped just as hard or a
+ * plan-only run over a sparsely stored range grows without bound.
+ */
+const workDone = (): number => (apply ? counts.processed : missingItems.length);
+
 const stopReason = (): Halt | null => {
   if (runState.interrupted) {
     return { reason: "interrupted", failure: false };
@@ -427,7 +495,7 @@ const stopReason = (): Halt | null => {
       failure: true,
     };
   }
-  if (limit !== null && counts.processed >= limit) {
+  if (limit !== null && workDone() >= limit) {
     return { reason: `--limit ${limit} reached`, failure: false };
   }
   return null;
@@ -529,6 +597,13 @@ try {
           }
         }
 
+        // Checked per page, not only per item: without --apply nothing walks
+        // the missing list, so this is the only place the plan-only run's
+        // accumulation is bounded.
+        halt = stopReason();
+        if (halt !== null) {
+          dayComplete = false;
+        }
         if (!dayComplete || page + 1 >= listed.totalPages) {
           break;
         }
@@ -545,7 +620,18 @@ try {
       }
     }
   } else if (sourceLease !== null) {
-    for (const item of suppliedItems) {
+    // A file is a snapshot of what was missing when it was written, and the
+    // crawl keeps running. Diffed again here so the run stays what it claims
+    // to be — it adds rows the source does not hold — instead of replaying a
+    // stale item over a newer one the crawl has since stored.
+    const held = await heldIdentitiesChunked(suppliedItems);
+    const fileDiff = diffCzRegionalListing({ items: suppliedItems, held });
+    counts.listed += suppliedItems.length;
+    counts.held += fileDiff.held.length;
+    counts.missing += fileDiff.missing.length;
+    counts.uningestable += fileDiff.unidentifiable.length;
+    counts.duplicate += fileDiff.duplicate.length;
+    for (const item of fileDiff.missing) {
       halt = stopReason();
       if (halt !== null) {
         break;
@@ -577,11 +663,11 @@ if (suppliedItems === null) {
 console.log("--- outcomes ---");
 if (suppliedItems === null) {
   console.log(`days visited:      ${reportDays.length} of ${days.length}`);
-  console.log(`items listed:      ${counts.listed}`);
-  console.log(`already held:      ${counts.held}`);
-  console.log(`missing:           ${counts.missing}`);
-  console.log(`duplicate listing: ${counts.duplicate}`);
 }
+console.log(`items listed:      ${counts.listed}`);
+console.log(`already held:      ${counts.held}`);
+console.log(`missing:           ${counts.missing}`);
+console.log(`duplicate listing: ${counts.duplicate}`);
 if (apply) {
   console.log(`processed:         ${counts.processed}`);
   console.log(`written:           ${counts.written}`);

--- a/scripts/ratchet-baseline.json
+++ b/scripts/ratchet-baseline.json
@@ -87,7 +87,7 @@
     "files": {}
   },
   "lint-suppression-directives": {
-    "count": 593,
+    "count": 600,
     "files": {
       "apps/api/src/db/migrate.ts": 2,
       "apps/api/src/db/schema.ts": 1,
@@ -212,6 +212,7 @@
       "apps/api/src/lib/entity-deletion-cleanup-queue.ts": 1,
       "apps/api/src/lib/extraction-runs/store.ts": 1,
       "apps/api/src/lib/file-scan/scanner.ts": 1,
+      "apps/api/src/lib/files/document-properties.ts": 1,
       "apps/api/src/lib/files/email-to-html.ts": 1,
       "apps/api/src/lib/files/utils.ts": 1,
       "apps/api/src/lib/flows/automated-run-cap.ts": 1,
@@ -260,6 +261,7 @@
       "apps/api/src/scripts/backfill-property-roles.ts": 1,
       "apps/api/src/scripts/build-corpus-index.ts": 1,
       "apps/api/src/scripts/corpus-column-trim.ts": 3,
+      "apps/api/src/scripts/cz-regional-repair.ts": 7,
       "apps/api/src/scripts/eu-ecj-census.ts": 3,
       "apps/api/src/scripts/eu-ecj-refetch.ts": 6,
       "apps/api/src/scripts/post-deploy-smoke.ts": 3,
@@ -279,7 +281,7 @@
       "apps/web/src/components/chat/tool-approval-card.tsx": 2,
       "apps/web/src/components/chat/web-search-sources.tsx": 1,
       "apps/web/src/components/conditions/condition-builder.tsx": 2,
-      "apps/web/src/components/dev-sidebar-group.tsx": 3,
+      "apps/web/src/components/dev-sidebar-group.tsx": 2,
       "apps/web/src/components/dev/autocomplete-playground.tsx": 1,
       "apps/web/src/components/docx/docx-browser-editor.tsx": 5,
       "apps/web/src/components/docx/docx-edit-mode.logic.ts": 3,

--- a/scripts/ratchet-baseline.json
+++ b/scripts/ratchet-baseline.json
@@ -87,7 +87,7 @@
     "files": {}
   },
   "lint-suppression-directives": {
-    "count": 600,
+    "count": 601,
     "files": {
       "apps/api/src/db/migrate.ts": 2,
       "apps/api/src/db/schema.ts": 1,
@@ -261,7 +261,7 @@
       "apps/api/src/scripts/backfill-property-roles.ts": 1,
       "apps/api/src/scripts/build-corpus-index.ts": 1,
       "apps/api/src/scripts/corpus-column-trim.ts": 3,
-      "apps/api/src/scripts/cz-regional-repair.ts": 7,
+      "apps/api/src/scripts/cz-regional-repair.ts": 8,
       "apps/api/src/scripts/eu-ecj-census.ts": 3,
       "apps/api/src/scripts/eu-ecj-refetch.ts": 6,
       "apps/api/src/scripts/post-deploy-smoke.ts": 3,


### PR DESCRIPTION
The cz-regional crawl walks a date cursor forward, so an item a page dropped while the cursor moved past it is never revisited: the cursor is the only record of what was seen. The publisher's opendata day endpoint lists each day independently of that cursor, which makes the question answerable.

This adds a reconciliation runner (`apps/api/src/scripts/cz-regional-repair.ts`) that enumerates the listing day by day, keys each item the way the ingest would key it (publisher document id where the item carries a finaldoc link, docket otherwise, mirroring the two halves of the decision identity index), and diffs against the identities already stored. Only the misses are fetched in full, built through the adapter's own parse and finaldoc path, and written by `processDecision` under the source's ingestion lease, so a run cannot interleave with a live crawl.

Mechanics:

- Plan-only by default: walks and diffs, fetches nothing in full, takes no lease, writes a report whose `missingItems` are raw listing items so `--items-file` can process exactly them later. `--apply` ingests as it walks.
- The runner only ever *adds* rows the source does not hold; it never refreshes one. `--items-file` is diffed against held identities before anything is processed, so replaying an older report cannot put a stale item over a row the crawl has since stored, and re-running the same file is idempotent.
- An item whose finaldoc could not be read is left missing rather than stored listing-only. `buildCzRegionalDecision` returns a discriminated result and reports `detail-unavailable` instead of folding the failure into the decision; storing such a row would make the identity held and take the document out of every later reconciliation.
- Bounded: `--limit` counts the work of whichever mode is running (decisions written under `--apply`, missing items accumulated without it) and defaults to 5000, with `--no-limit` for a deliberate single-pass census.
- Resumable: the resume boundary advances only past days walked end to end; a listing failure halts the run and leaves the day unwalked rather than half-walked. `--after`, `--delay-ms`, and a ten-consecutive-failure halt mirror the existing re-fetch runner.
- Failed items are written back as raw listing items with the retry command printed.
- Listing requests carry a 200ms politeness floor matching the adapter's own `minRequestIntervalMs`, so a plan-only walk cannot hit the publisher harder than the crawl it reconciles.

The adapter gains an export-only surface (`listCzRegionalDayPage`, `buildCzRegionalDecision`, `documentIdFromLink`); the page-enrichment merge moved into one `applyFinaldoc` both paths call, so the walk and the crawl cannot enrich differently. `fetchPage` behaviour is unchanged.

Day enumeration, identity derivation, and the diff (a total partition into missing / held / duplicate / unidentifiable, asserted as an invariant) live in a sibling plan module with no I/O, tested directly (25 tests). The four touched adapter/parser suites stay green (80 tests).

**Ratchet reseed justification:** `lint-suppression-directives` baseline 593 → 601 — eight `no-await-in-loop` suppressions in the new operator script, each keeping publisher traffic and pipeline writes deliberately sequential (rate-limited listing fetches, politeness pauses, one bounded lookup per page, chunked identity lookups, one pipeline write per decision), the same class the eu-ecj re-fetch runner carries. The regen also refreshed two stale per-file entries whose earlier drifts cancelled out in the total (`apps/api/src/lib/files/document-properties.ts` +1, `apps/web/src/components/dev-sidebar-group.tsx` 3 → 2); no other metric moved.

**No typecheck-baseline reseed:** the guard only measures a green typecheck, and it first failed here because of a type error in the new test fixture (an omitted optional property is a different shape from a null one under `exactOptionalPropertyTypes`), not because the compiler workload grew. With that fixed the measured cost is Types 1,037,754 vs baseline 1,036,767 (+0.10%) and Instantiations 5,563,945 vs 5,562,609 (+0.02%), both far inside the 5% headroom — the ingestion pipeline was already reachable from the scripts surface via the existing re-fetch and replay runners, so these imports add no new project-graph edge. `bun scripts/typecheck-baseline.ts --check` passes unchanged.
