### PR TITLE
fix(case-law): bound decision dates at the ingestion boundary

### DIFF
--- a/apps/api/src/handlers/case-law/ingestion/pipeline.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/pipeline.test.ts
@@ -678,6 +678,91 @@ describe("processDecision — corpus storage off", () => {
   });
 });
 
+describe("processDecision — decision date on an existing row", () => {
+  // An update omits an undefined column, so a rejected date has to be
+  // distinguishable from an unstated one all the way to the write: the
+  // first must clear whatever the row holds, the second must not.
+  const refreshedDecisionDate = async (
+    decisionDate: string | undefined,
+  ): Promise<Record<string, unknown> | undefined> => {
+    const existing = {
+      id: createSafeId<"caseLawDecision">(),
+      metadata: {},
+      sourceHash: "old-hash",
+      sourceRawS3Key: null,
+      sourceRawContentType: null,
+    };
+
+    let updated: Record<string, unknown> | undefined;
+    const scopedDb: ScopedDb = async (callback) => {
+      const tx = {
+        query: {
+          caseLawDecisions: {
+            findFirst: async () => await Promise.resolve(existing),
+          },
+        },
+        update: (table: unknown) => ({
+          set: (values: Record<string, unknown>) => {
+            if (table === caseLawDecisions) {
+              updated = values;
+            }
+            return {
+              where: () => ({
+                returning: async () => [{ id: existing.id }],
+              }),
+            };
+          },
+        }),
+        delete: () => ({ where: async () => undefined }),
+        insert: () => ({ values: async () => undefined }),
+      };
+
+      // SAFETY: the refresh path walks only these chains; anything else
+      // would throw and fail the test loudly.
+      // eslint-disable-next-line typescript/no-unsafe-type-assertion
+      return await callback(tx as unknown as Transaction);
+    };
+
+    await processDecision({
+      input: {
+        caseNumber: "X/1/2026",
+        court: "Test Court",
+        country: "SVK",
+        language: "sk",
+        decisionDate,
+        fulltext: "Rozhodnutie o veci samej.",
+        metadata: {},
+        rawHash: "new-hash",
+        documentAst: EMPTY_AST,
+      },
+      observationOrder: 1n,
+      sourceId: createSafeId<"caseLawSource">(),
+      scopedDb,
+      observedAt: new Date("2026-07-31T12:00:00.000Z"),
+    });
+
+    return updated;
+  };
+
+  test("clears the column when the source restates an unusable date", async () => {
+    const updated = await refreshedDecisionDate("2944-04-30");
+
+    expect(updated?.["decisionDate"]).toBeNull();
+  });
+
+  test("writes a usable date", async () => {
+    const updated = await refreshedDecisionDate("2026-04-15");
+
+    expect(updated?.["decisionDate"]).toBe("2026-04-15");
+  });
+
+  test("writes nothing when the source states no date", async () => {
+    const updated = await refreshedDecisionDate(undefined);
+
+    expect(updated?.["decisionDate"]).toBeUndefined();
+  });
+});
+
 describe("processDecision — source raw upload failure", () => {
   test("reports a new decision's failed raw upload as retryable, not thrown", async () => {
     // A thrown failure is caught by the decision loop, counted as skipped,

--- a/apps/api/src/handlers/case-law/ingestion/pipeline.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/pipeline.test.ts
@@ -116,6 +116,57 @@ describe("sanitizeResult — adapter-supplied sections", () => {
   });
 });
 
+describe("sanitizeResult — decision date bounds", () => {
+  // Adapters normalize dates differently or not at all, and the column
+  // takes an impossible year as readily as a real one. A document whose
+  // date is unusable is still worth storing, so the date drops and the
+  // row survives.
+  test("drops a year outside the range a decision can carry", () => {
+    expect(
+      sanitizeResult({
+        ...baseResult(EMPTY_AST),
+        decisionDate: "2944-04-30",
+      }).decisionDate,
+    ).toBeUndefined();
+
+    expect(
+      sanitizeResult({
+        ...baseResult(EMPTY_AST),
+        decisionDate: "0001-01-01",
+      }).decisionDate,
+    ).toBeUndefined();
+  });
+
+  test("drops a day that does not exist on the calendar", () => {
+    expect(
+      sanitizeResult({
+        ...baseResult(EMPTY_AST),
+        decisionDate: "2026-02-30",
+      }).decisionDate,
+    ).toBeUndefined();
+  });
+
+  test("keeps a date the sources actually publish", () => {
+    expect(
+      sanitizeResult({
+        ...baseResult(EMPTY_AST),
+        decisionDate: "2026-04-15",
+      }).decisionDate,
+    ).toBe("2026-04-15");
+
+    expect(
+      sanitizeResult({
+        ...baseResult(EMPTY_AST),
+        decisionDate: "2026-04-15T00:00:00Z",
+      }).decisionDate,
+    ).toBe("2026-04-15");
+  });
+
+  test("leaves an absent date absent", () => {
+    expect(sanitizeResult(baseResult(EMPTY_AST)).decisionDate).toBeUndefined();
+  });
+});
+
 describe("sanitizeResult — shared partial-observation quality", () => {
   test("persists adapter-neutral quality and removes it after detail recovery", () => {
     const partial = sanitizeResult({

--- a/apps/api/src/handlers/case-law/ingestion/pipeline.ts
+++ b/apps/api/src/handlers/case-law/ingestion/pipeline.ts
@@ -616,16 +616,24 @@ const processDecisionAttempt = async ({
   refresh,
 }: ProcessDecisionAttemptOptions): Promise<ProcessResult> => {
   const result = sanitizeResult(input);
-  if (input.decisionDate !== undefined && result.decisionDate === undefined) {
+  const rejectedDecisionDate =
+    result.decisionDate === undefined ? input.decisionDate : undefined;
+  if (rejectedDecisionDate !== undefined) {
     logger.warn(DECISION_DATE_OUT_OF_BOUNDS, {
       sourceId,
       caseNumber: result.caseNumber,
-      decisionDate: input.decisionDate.slice(
+      decisionDate: rejectedDecisionDate.slice(
         0,
         MAX_LOGGED_DECISION_DATE_LENGTH,
       ),
     });
   }
+  // The column needs all three states an observation can carry, and an
+  // update omits an undefined field: a usable date is written, a stated but
+  // unusable one clears the column rather than leaving in place the value it
+  // was meant to replace, and an unstated one leaves the row as it is.
+  const persistedDecisionDate =
+    rejectedDecisionDate === undefined ? result.decisionDate : null;
   const proposedDecisionId = createSafeId<"caseLawDecision">();
   const exactSourceIdentityCandidates = (() => {
     if (!result.sourceDocumentId) {
@@ -1406,7 +1414,7 @@ const processDecisionAttempt = async ({
                   language: result.language,
                   sheetNumber: result.sheetNumber,
                   languageGroupKey,
-                  decisionDate: result.decisionDate,
+                  decisionDate: persistedDecisionDate,
                   decisionType: result.decisionType,
                   sourceUrl: result.sourceUrl,
                   documentUrl: result.documentUrl,
@@ -1544,7 +1552,7 @@ const processDecisionAttempt = async ({
           country: result.country,
           language: result.language,
           languageGroupKey,
-          decisionDate: result.decisionDate,
+          decisionDate: persistedDecisionDate,
           decisionType: result.decisionType,
           ...payloadColumns,
           sourceUrl: result.sourceUrl,

--- a/apps/api/src/handlers/case-law/ingestion/pipeline.ts
+++ b/apps/api/src/handlers/case-law/ingestion/pipeline.ts
@@ -186,6 +186,19 @@ type DecisionRowWriteStatus =
 /** One canonical identity plus a small, explicit set of publisher aliases. */
 const MAX_SOURCE_IDENTITY_CANDIDATES = 8;
 
+/**
+ * Log event emitted when a source states a decision date the ingestion
+ * boundary cannot accept — a non-calendar day or a year outside the range a
+ * decision can carry. Reported at WARN: the document is still stored, with
+ * no date, and the raw value is carried so the publisher's shape is
+ * recoverable without re-fetching.
+ */
+export const DECISION_DATE_OUT_OF_BOUNDS =
+  "case_law.ingestion.decision_date_out_of_bounds";
+
+/** Enough of the rejected value to identify its shape, not a payload. */
+const MAX_LOGGED_DECISION_DATE_LENGTH = 64;
+
 export const DECISION_REFRESH = {
   /**
    * Skip a decision whose source hash and metadata are unchanged: a crawl
@@ -603,6 +616,16 @@ const processDecisionAttempt = async ({
   refresh,
 }: ProcessDecisionAttemptOptions): Promise<ProcessResult> => {
   const result = sanitizeResult(input);
+  if (input.decisionDate !== undefined && result.decisionDate === undefined) {
+    logger.warn(DECISION_DATE_OUT_OF_BOUNDS, {
+      sourceId,
+      caseNumber: result.caseNumber,
+      decisionDate: input.decisionDate.slice(
+        0,
+        MAX_LOGGED_DECISION_DATE_LENGTH,
+      ),
+    });
+  }
   const proposedDecisionId = createSafeId<"caseLawDecision">();
   const exactSourceIdentityCandidates = (() => {
     if (!result.sourceDocumentId) {

--- a/apps/api/src/lib/dates.test.ts
+++ b/apps/api/src/lib/dates.test.ts
@@ -119,6 +119,36 @@ describe("canonicalDecisionDate", () => {
     expect(canonicalDecisionDate("2024-03-05X00:00:00")).toBeNull();
     expect(canonicalDecisionDate("")).toBeNull();
   });
+
+  test("rejects a malformed suffix instead of taking the prefix on faith", () => {
+    // A value whose tail is not a time is not a datetime, and its first ten
+    // characters are not a date the source stated.
+    expect(canonicalDecisionDate("2024-03-05T")).toBeNull();
+    expect(canonicalDecisionDate("2024-03-05Tgarbage")).toBeNull();
+    expect(canonicalDecisionDate("2024-03-05T25:99:99Z")).toBeNull();
+    expect(canonicalDecisionDate("2024-03-05-extra")).toBeNull();
+  });
+
+  test("accepts the datetime forms sources publish", () => {
+    expect(canonicalDecisionDate("2024-03-05T14:30")).toBe("2024-03-05");
+    expect(canonicalDecisionDate("2024-03-05T14:30:59.123Z")).toBe(
+      "2024-03-05",
+    );
+    expect(canonicalDecisionDate("2024-03-05T14:30:00+02:00")).toBe(
+      "2024-03-05",
+    );
+  });
+
+  test("does not depend on the host timezone's calendar", () => {
+    // Samoa crossed the date line at the end of 2011, so 2011-12-30 never
+    // happened there in local time. A decision dated that day is still a
+    // real record, and ingestion must not accept or reject it based on
+    // where the code runs.
+    process.env.TZ = "Pacific/Apia";
+    expect(parseIsoDateLocal("2011-12-30")).toBeNull();
+
+    expect(canonicalDecisionDate("2011-12-30")).toBe("2011-12-30");
+  });
 });
 
 describe("addDays", () => {

--- a/apps/api/src/lib/dates.test.ts
+++ b/apps/api/src/lib/dates.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import {
   addDays,
   addUtcDays,
+  canonicalDecisionDate,
   isIsoDateString,
   parseIsoDateLocal,
 } from "./dates";
@@ -73,6 +74,50 @@ describe("parseIsoDateLocal", () => {
     expect(parseIsoDateLocal("not-a-date")).toBeNull();
     expect(parseIsoDateLocal("2024-01-01T00:00:00Z")).toBeNull();
     expect(parseIsoDateLocal("")).toBeNull();
+  });
+});
+
+describe("canonicalDecisionDate", () => {
+  test("accepts a bare calendar date unchanged", () => {
+    expect(canonicalDecisionDate("2024-03-05")).toBe("2024-03-05");
+  });
+
+  test("takes the date prefix of an ISO datetime", () => {
+    expect(canonicalDecisionDate("2024-03-05T00:00:00Z")).toBe("2024-03-05");
+    expect(canonicalDecisionDate("2024-03-05 00:00:00")).toBe("2024-03-05");
+  });
+
+  test("rejects a year below the lower bound", () => {
+    expect(canonicalDecisionDate("0001-01-01")).toBeNull();
+    expect(canonicalDecisionDate("1799-12-31")).toBeNull();
+  });
+
+  test("accepts the lower bound itself", () => {
+    expect(canonicalDecisionDate("1800-01-01")).toBe("1800-01-01");
+  });
+
+  test("accepts next year but not the one after", () => {
+    const currentYear = new Date().getUTCFullYear();
+
+    expect(canonicalDecisionDate(`${currentYear + 1}-06-15`)).toBe(
+      `${currentYear + 1}-06-15`,
+    );
+    expect(canonicalDecisionDate(`${currentYear + 2}-06-15`)).toBeNull();
+  });
+
+  test("rejects a far-future year", () => {
+    expect(canonicalDecisionDate("2944-04-30")).toBeNull();
+  });
+
+  test("rejects a day that does not exist on the calendar", () => {
+    expect(canonicalDecisionDate("2024-02-30")).toBeNull();
+  });
+
+  test("rejects a value that is not a date at all", () => {
+    expect(canonicalDecisionDate("not-a-date")).toBeNull();
+    expect(canonicalDecisionDate("05.03.2024")).toBeNull();
+    expect(canonicalDecisionDate("2024-03-05X00:00:00")).toBeNull();
+    expect(canonicalDecisionDate("")).toBeNull();
   });
 });
 

--- a/apps/api/src/lib/dates.ts
+++ b/apps/api/src/lib/dates.ts
@@ -26,18 +26,39 @@ export const isIsoDateString = (value: string): boolean =>
  * Returns `null` for a malformed string or a day/month that does not exist
  * on the calendar, instead of silently rolling over (e.g. "2024-02-30").
  */
-export const parseIsoDateLocal = (value: string): Date | null => {
-  const match = ISO_DATE_PATTERN.exec(value);
-  const yearStr = match?.groups?.["year"];
-  const monthStr = match?.groups?.["month"];
-  const dayStr = match?.groups?.["day"];
+type IsoDateParts = {
+  year: number;
+  month: number;
+  day: number;
+};
+
+/**
+ * Numeric parts of a `YYYY-MM-DD` string, or `null` when it does not have
+ * that shape. Says nothing about whether the parts name a real calendar day;
+ * the two callers below check that in the calendar each of them means.
+ */
+const isoDateParts = (value: string): IsoDateParts | null => {
+  const groups = ISO_DATE_PATTERN.exec(value)?.groups;
+  const yearStr = groups?.["year"];
+  const monthStr = groups?.["month"];
+  const dayStr = groups?.["day"];
   if (!yearStr || !monthStr || !dayStr) {
     return null;
   }
+  return {
+    year: Number(yearStr),
+    month: Number(monthStr),
+    day: Number(dayStr),
+  };
+};
 
-  const year = Number(yearStr);
-  const month = Number(monthStr);
-  const day = Number(dayStr);
+export const parseIsoDateLocal = (value: string): Date | null => {
+  const parts = isoDateParts(value);
+  if (parts === null) {
+    return null;
+  }
+
+  const { year, month, day } = parts;
   const date = new Date(year, month - 1, day);
 
   // `Date` rolls over out-of-range parts (e.g. Feb 30 -> Mar 2) instead of
@@ -68,18 +89,46 @@ const DECISION_YEAR_BOUNDS = {
 } as const;
 
 /**
- * The `YYYY-MM-DD` prefix of a bare calendar date or of an ISO datetime,
+ * An ISO time of day following a date: `T` or a space, then a bounded hour
+ * and minute, optionally seconds, a fractional part and a zone offset.
+ *
+ * The time itself is never read. Matching it is how a value that merely
+ * starts like a date ("2024-03-05Tgarbage", "2024-03-05T25:99:99Z") is told
+ * apart from a real datetime, rather than having its first ten characters
+ * taken on faith.
+ */
+const ISO_TIME_SUFFIX_PATTERN =
+  /^[T ](?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d{1,9})?)?(?:Z|[+-](?:[01]\d|2[0-3]):?[0-5]\d)?$/u;
+
+/**
+ * The `YYYY-MM-DD` prefix of a bare calendar date or of a full ISO datetime,
  * or `null` when `raw` is neither shape.
  */
 const isoDatePrefix = (raw: string): string | null => {
   if (raw.length === ISO_DATE_LENGTH) {
     return raw;
   }
-  const separator = raw.charAt(ISO_DATE_LENGTH);
-  if (separator !== "T" && separator !== " ") {
+  if (!ISO_TIME_SUFFIX_PATTERN.test(raw.slice(ISO_DATE_LENGTH))) {
     return null;
   }
   return raw.slice(0, ISO_DATE_LENGTH);
+};
+
+/**
+ * True when the parts name a day that exists on the Gregorian calendar.
+ *
+ * Checked with UTC fields: a local-time `Date` also rejects a day the host's
+ * timezone skipped (Pacific/Apia has no 2011-12-30, having crossed the date
+ * line), which would make the same record acceptable or not depending on
+ * where the code runs. UTC skips no days.
+ */
+const isUtcCalendarDay = ({ year, month, day }: IsoDateParts): boolean => {
+  const date = new Date(Date.UTC(year, month - 1, day));
+  return (
+    date.getUTCFullYear() === year &&
+    date.getUTCMonth() === month - 1 &&
+    date.getUTCDate() === day
+  );
 };
 
 /**
@@ -96,13 +145,12 @@ export const canonicalDecisionDate = (raw: string): string | null => {
   if (candidate === null) {
     return null;
   }
-  const parsed = parseIsoDateLocal(candidate);
-  if (parsed === null) {
+  const parts = isoDateParts(candidate);
+  if (parts === null || !isUtcCalendarDay(parts)) {
     return null;
   }
-  const year = parsed.getFullYear();
   const maxYear = new Date().getUTCFullYear() + DECISION_YEAR_BOUNDS.yearsAhead;
-  if (year < DECISION_YEAR_BOUNDS.min || year > maxYear) {
+  if (parts.year < DECISION_YEAR_BOUNDS.min || parts.year > maxYear) {
     return null;
   }
   return candidate;

--- a/apps/api/src/lib/dates.ts
+++ b/apps/api/src/lib/dates.ts
@@ -52,6 +52,62 @@ export const parseIsoDateLocal = (value: string): Date | null => {
   return date;
 };
 
+/** Length of the `YYYY-MM-DD` prefix a decision date is canonicalized to. */
+const ISO_DATE_LENGTH = 10;
+
+/**
+ * Year range a decision date may fall in. The floor predates any court whose
+ * decisions are published as machine-readable records, so a lower year is a
+ * transcription or parsing artifact rather than a real date. The ceiling is
+ * relative to the current year because a publisher may date a decision
+ * slightly ahead; a fixed upper year would go stale.
+ */
+const DECISION_YEAR_BOUNDS = {
+  min: 1800,
+  yearsAhead: 1,
+} as const;
+
+/**
+ * The `YYYY-MM-DD` prefix of a bare calendar date or of an ISO datetime,
+ * or `null` when `raw` is neither shape.
+ */
+const isoDatePrefix = (raw: string): string | null => {
+  if (raw.length === ISO_DATE_LENGTH) {
+    return raw;
+  }
+  const separator = raw.charAt(ISO_DATE_LENGTH);
+  if (separator !== "T" && separator !== " ") {
+    return null;
+  }
+  return raw.slice(0, ISO_DATE_LENGTH);
+};
+
+/**
+ * Canonical `YYYY-MM-DD` form of a published decision date, or `null` when
+ * the value cannot be one.
+ *
+ * Accepts a bare calendar date or an ISO datetime, and rejects anything that
+ * is not a real calendar day (e.g. "2024-02-30") or whose year falls outside
+ * `DECISION_YEAR_BOUNDS`. A date column takes a malformed year as readily as
+ * a correct one, so callers writing to one need this in front of the write.
+ */
+export const canonicalDecisionDate = (raw: string): string | null => {
+  const candidate = isoDatePrefix(raw);
+  if (candidate === null) {
+    return null;
+  }
+  const parsed = parseIsoDateLocal(candidate);
+  if (parsed === null) {
+    return null;
+  }
+  const year = parsed.getFullYear();
+  const maxYear = new Date().getUTCFullYear() + DECISION_YEAR_BOUNDS.yearsAhead;
+  if (year < DECISION_YEAR_BOUNDS.min || year > maxYear) {
+    return null;
+  }
+  return candidate;
+};
+
 /**
  * Add `n` calendar days to `date`, DST-safe.
  *

--- a/apps/api/src/lib/legal-search/ingestion-normalization.ts
+++ b/apps/api/src/lib/legal-search/ingestion-normalization.ts
@@ -1,6 +1,7 @@
 import { collapseSpacedLetters } from "@stll/text-normalize";
 
 import { isDocumentAst } from "@/api/lib/case-law/document-ast";
+import { canonicalDecisionDate } from "@/api/lib/dates";
 import {
   DANGEROUS_CHARS,
   sanitizeMetadata,
@@ -38,6 +39,11 @@ export const partialObservationFromMetadata = (
  * Sanitize text fields before DB insertion. Postgres rejects null bytes in
  * text columns. Keeping this at the ingestion boundary means adapters and
  * backfill jobs produce the same canonical representation.
+ *
+ * This is also where `decisionDate` is bounded: adapters normalize dates
+ * differently or not at all, and the date column accepts an impossible year
+ * as readily as a real one, so a value that cannot be a decision date is
+ * dropped here rather than at each publisher boundary.
  */
 export const sanitizeResult = (result: IngestionResult): IngestionResult => {
   const strip = (value: string | undefined): string | undefined =>
@@ -55,6 +61,15 @@ export const sanitizeResult = (result: IngestionResult): IngestionResult => {
     return (
       raw.replace(DECISION_TYPE_NOISE, "").trim().toLowerCase() || undefined
     );
+  };
+
+  // A listed document must survive a bad date, so an unusable value is
+  // dropped to null instead of failing the row.
+  const boundDecisionDate = (raw: string | undefined): string | undefined => {
+    if (raw === undefined) {
+      return undefined;
+    }
+    return canonicalDecisionDate(raw) ?? undefined;
   };
 
   const deepSanitize = (value: unknown, key?: string): unknown => {
@@ -134,6 +149,7 @@ export const sanitizeResult = (result: IngestionResult): IngestionResult => {
       ? collapseSpacedLetters(strip(result.fulltext) ?? "")
       : undefined,
     ecli: strip(result.ecli),
+    decisionDate: boundDecisionDate(result.decisionDate),
     decisionType: normalizeDecisionType(strip(result.decisionType)),
     sourceUrl: strip(result.sourceUrl),
     documentUrl: strip(result.documentUrl),


### PR DESCRIPTION
`decisionDate` reached the `decision_date` column verbatim. Adapters normalize it differently or not at all, so a non-calendar day or an impossible year was stored as readily as a real date — the cz-regional seed fixture alone carries `2359-11-17`, `2417-11-17`, and `2944-04-30`.

`canonicalDecisionDate` (`apps/api/src/lib/dates.ts`) reduces a bare ISO date or an ISO datetime to its `YYYY-MM-DD` prefix and returns it only for a real calendar day whose year falls between 1800 and next year. `sanitizeResult` applies it, so every adapter, backfill, and replay path shares one rule at the declared ingestion boundary rather than each publisher boundary restating (or forgetting) it.

An unusable date drops to null rather than failing the row: a listed document is still worth storing. The pipeline emits `case_law.ingestion.decision_date_out_of_bounds` at warn with the truncated raw value, so the rejection is visible and the publisher's original shape stays recoverable from the row's metadata.

Tests: helper edge cases in `dates.test.ts` (bounds years, non-calendar days, datetime prefixes, garbage) and a `sanitizeResult` describe in `pipeline.test.ts` over production-shaped fixtures. pl-courts' own inline year check becomes redundant but harmless; the boundary check subsumes it.
