### PR TITLE
feat(case-law): persisted per-source reported totals

### DIFF
--- a/apps/api/drizzle/20260811090000_case_law_source_reported_totals/migration.sql
+++ b/apps/api/drizzle/20260811090000_case_law_source_reported_totals/migration.sql
@@ -1,0 +1,19 @@
+SET lock_timeout = '1s';--> statement-breakpoint
+SET statement_timeout = '5s';--> statement-breakpoint
+
+-- The count a publisher reports holding, so held-vs-total coverage is
+-- computable for sources that expose no cheap public count. Nullable adds
+-- with no default: the columns start empty and are filled by the single
+-- writer, which polls the adapter where one exposes a total and otherwise
+-- takes an operator-supplied number.
+ALTER TABLE "case_law_sources"
+  ADD COLUMN IF NOT EXISTS "reported_total" integer;--> statement-breakpoint
+ALTER TABLE "case_law_sources"
+  ADD COLUMN IF NOT EXISTS "reported_total_as_of" timestamptz;--> statement-breakpoint
+
+-- Provenance of the number ('adapter-poll' or 'operator'), not a boolean:
+-- a further origin must be able to land as a new value. The trio moves
+-- together (all set or all null); that is the writer's invariant, since the
+-- writer is also what validates the number itself.
+ALTER TABLE "case_law_sources"
+  ADD COLUMN IF NOT EXISTS "reported_total_origin" varchar(16);

--- a/apps/api/drizzle/20260811090000_case_law_source_reported_totals/migration.sql
+++ b/apps/api/drizzle/20260811090000_case_law_source_reported_totals/migration.sql
@@ -7,13 +7,66 @@ SET statement_timeout = '5s';--> statement-breakpoint
 -- writer, which polls the adapter where one exposes a total and otherwise
 -- takes an operator-supplied number.
 ALTER TABLE "case_law_sources"
-  ADD COLUMN IF NOT EXISTS "reported_total" integer;--> statement-breakpoint
-ALTER TABLE "case_law_sources"
-  ADD COLUMN IF NOT EXISTS "reported_total_as_of" timestamptz;--> statement-breakpoint
+  ADD COLUMN IF NOT EXISTS "reported_total" integer,
+  ADD COLUMN IF NOT EXISTS "reported_total_as_of" timestamptz,
+  ADD COLUMN IF NOT EXISTS "reported_total_origin" varchar(16);--> statement-breakpoint
 
--- Provenance of the number ('adapter-poll' or 'operator'), not a boolean:
--- a further origin must be able to land as a new value. The trio moves
--- together (all set or all null); that is the writer's invariant, since the
--- writer is also what validates the number itself.
+-- The three columns are one fact and move together; a partial trio is a
+-- total with no provenance, or a provenance with no total. The writer
+-- validates the number before it is stored, and these checks keep any other
+-- path (a correction, a later query) from leaving the fact half-written,
+-- half-dated, or attributed to an origin the code cannot read back.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'case_law_sources_reported_total_trio'
+      AND conrelid = 'case_law_sources'::regclass
+  ) THEN
+    ALTER TABLE "case_law_sources"
+      ADD CONSTRAINT "case_law_sources_reported_total_trio"
+      CHECK (
+        ("reported_total" IS NULL) = ("reported_total_as_of" IS NULL)
+        AND ("reported_total" IS NULL) = ("reported_total_origin" IS NULL)
+      ) NOT VALID;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'case_law_sources_reported_total_positive'
+      AND conrelid = 'case_law_sources'::regclass
+  ) THEN
+    ALTER TABLE "case_law_sources"
+      ADD CONSTRAINT "case_law_sources_reported_total_positive"
+      CHECK ("reported_total" IS NULL OR "reported_total" > 0) NOT VALID;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'case_law_sources_reported_total_origin_allowed'
+      AND conrelid = 'case_law_sources'::regclass
+  ) THEN
+    ALTER TABLE "case_law_sources"
+      ADD CONSTRAINT "case_law_sources_reported_total_origin_allowed"
+      CHECK (
+        "reported_total_origin" IS NULL
+        OR "reported_total_origin" IN ('adapter-poll', 'operator')
+      ) NOT VALID;
+  END IF;
+END
+$$;--> statement-breakpoint
+
 ALTER TABLE "case_law_sources"
-  ADD COLUMN IF NOT EXISTS "reported_total_origin" varchar(16);
+  VALIDATE CONSTRAINT "case_law_sources_reported_total_trio";--> statement-breakpoint
+ALTER TABLE "case_law_sources"
+  VALIDATE CONSTRAINT "case_law_sources_reported_total_positive";--> statement-breakpoint
+ALTER TABLE "case_law_sources"
+  VALIDATE CONSTRAINT "case_law_sources_reported_total_origin_allowed";--> statement-breakpoint
+
+-- The ingestion role's UPDATE on this table is column-scoped, so the poll and
+-- the operator set both write through it only if these three columns are
+-- named. Without the grant every write is rejected. Drizzle's $onUpdate also
+-- touches updated_at, which the role already holds.
+GRANT UPDATE (reported_total, reported_total_as_of, reported_total_origin)
+  ON TABLE "case_law_sources"
+  TO stella_ingestion;

--- a/apps/api/drizzle/20260811090000_case_law_source_reported_totals/migration.sql
+++ b/apps/api/drizzle/20260811090000_case_law_source_reported_totals/migration.sql
@@ -16,52 +16,32 @@ ALTER TABLE "case_law_sources"
 -- validates the number before it is stored, and these checks keep any other
 -- path (a correction, a later query) from leaving the fact half-written,
 -- half-dated, or attributed to an origin the code cannot read back.
-DO $$
-BEGIN
-  IF NOT EXISTS (
-    SELECT 1 FROM pg_constraint
-    WHERE conname = 'case_law_sources_reported_total_trio'
-      AND conrelid = 'case_law_sources'::regclass
-  ) THEN
-    ALTER TABLE "case_law_sources"
-      ADD CONSTRAINT "case_law_sources_reported_total_trio"
-      CHECK (
-        ("reported_total" IS NULL) = ("reported_total_as_of" IS NULL)
-        AND ("reported_total" IS NULL) = ("reported_total_origin" IS NULL)
-      ) NOT VALID;
-  END IF;
-
-  IF NOT EXISTS (
-    SELECT 1 FROM pg_constraint
-    WHERE conname = 'case_law_sources_reported_total_positive'
-      AND conrelid = 'case_law_sources'::regclass
-  ) THEN
-    ALTER TABLE "case_law_sources"
-      ADD CONSTRAINT "case_law_sources_reported_total_positive"
-      CHECK ("reported_total" IS NULL OR "reported_total" > 0) NOT VALID;
-  END IF;
-
-  IF NOT EXISTS (
-    SELECT 1 FROM pg_constraint
-    WHERE conname = 'case_law_sources_reported_total_origin_allowed'
-      AND conrelid = 'case_law_sources'::regclass
-  ) THEN
-    ALTER TABLE "case_law_sources"
-      ADD CONSTRAINT "case_law_sources_reported_total_origin_allowed"
-      CHECK (
-        "reported_total_origin" IS NULL
-        OR "reported_total_origin" IN ('adapter-poll', 'operator')
-      ) NOT VALID;
-  END IF;
-END
-$$;--> statement-breakpoint
+--
+-- Added validating, not NOT VALID + VALIDATE. This table holds one row per
+-- adapter key in the code-defined registry, so the scan is bounded by that
+-- registry rather than by corpus size. The two-step form would not help
+-- here in any case: the migrator wraps a migration in one transaction, so
+-- the locks a split is meant to release are held to commit regardless.
+ALTER TABLE "case_law_sources"
+  -- squawk-ignore constraint-missing-not-valid
+  ADD CONSTRAINT "case_law_sources_reported_total_trio"
+  CHECK (
+    ("reported_total" IS NULL) = ("reported_total_as_of" IS NULL)
+    AND ("reported_total" IS NULL) = ("reported_total_origin" IS NULL)
+  );--> statement-breakpoint
 
 ALTER TABLE "case_law_sources"
-  VALIDATE CONSTRAINT "case_law_sources_reported_total_trio";--> statement-breakpoint
+  -- squawk-ignore constraint-missing-not-valid
+  ADD CONSTRAINT "case_law_sources_reported_total_positive"
+  CHECK ("reported_total" IS NULL OR "reported_total" > 0);--> statement-breakpoint
+
 ALTER TABLE "case_law_sources"
-  VALIDATE CONSTRAINT "case_law_sources_reported_total_positive";--> statement-breakpoint
-ALTER TABLE "case_law_sources"
-  VALIDATE CONSTRAINT "case_law_sources_reported_total_origin_allowed";--> statement-breakpoint
+  -- squawk-ignore constraint-missing-not-valid
+  ADD CONSTRAINT "case_law_sources_reported_total_origin_allowed"
+  CHECK (
+    "reported_total_origin" IS NULL
+    OR "reported_total_origin" IN ('adapter-poll', 'operator')
+  );--> statement-breakpoint
 
 -- The ingestion role's UPDATE on this table is column-scoped, so the poll and
 -- the operator set both write through it only if these three columns are

--- a/apps/api/src/db/schema/case-law.ts
+++ b/apps/api/src/db/schema/case-law.ts
@@ -40,6 +40,19 @@ export const CASE_LAW_CORPUS_UPLOAD_INTENT_STATUS = {
   CLEANUP: CASE_LAW_CORPUS_UPLOAD_INTENT_STATUSES[1],
 } as const;
 
+/**
+ * How a source's reported total was obtained. Not a boolean: a third
+ * provenance (an operator-approved import, say) must be able to land as a
+ * new member rather than as a second flag.
+ */
+export const SOURCE_TOTAL_ORIGIN = {
+  ADAPTER_POLL: "adapter-poll",
+  OPERATOR: "operator",
+} as const;
+
+export type SourceTotalOrigin =
+  (typeof SOURCE_TOTAL_ORIGIN)[keyof typeof SOURCE_TOTAL_ORIGIN];
+
 export const caseLawSources = p.pgTable(
   "case_law_sources",
   {
@@ -65,6 +78,20 @@ export const caseLawSources = p.pgTable(
     // migration-owned trigger validates inserts and descriptor changes while
     // permitting unrelated checkpoint updates on legacy malformed rows.
     descriptor: jsonb().$type<CorpusSourceDescriptor>(),
+    /**
+     * How many decisions the publisher itself reports holding, with when it
+     * was observed and where the number came from. Held-vs-total coverage is
+     * otherwise uncomputable for a publisher that exposes no cheap count.
+     *
+     * The three move together — all set or all null. That invariant belongs
+     * to the single writer (`ingestion/source-totals.ts`), not to a check
+     * constraint, because the writer is also what validates the number.
+     */
+    reportedTotal: p.integer("reported_total"),
+    reportedTotalAsOf: timestamptz("reported_total_as_of"),
+    reportedTotalOrigin: p
+      .varchar("reported_total_origin", { length: 16 })
+      .$type<SourceTotalOrigin>(),
     createdAt: timestamptz("created_at").defaultNow().notNull(),
     updatedAt: timestamptz("updated_at")
       .defaultNow()

--- a/apps/api/src/db/schema/case-law.ts
+++ b/apps/api/src/db/schema/case-law.ts
@@ -83,9 +83,10 @@ export const caseLawSources = p.pgTable(
      * was observed and where the number came from. Held-vs-total coverage is
      * otherwise uncomputable for a publisher that exposes no cheap count.
      *
-     * The three move together — all set or all null. That invariant belongs
-     * to the single writer (`ingestion/source-totals.ts`), not to a check
-     * constraint, because the writer is also what validates the number.
+     * The three are one fact and move together — all set or all null. The
+     * writer (`ingestion/source-totals.ts`) validates the number at the
+     * boundary so a caller gets a usable error; the check constraints below
+     * make the half-written states unrepresentable for every other path.
      */
     reportedTotal: p.integer("reported_total"),
     reportedTotalAsOf: timestamptz("reported_total_as_of"),
@@ -106,6 +107,25 @@ export const caseLawSources = p.pgTable(
     p.check(
       "case_law_sources_ingestion_lease_pair",
       sql`(${t.ingestionLeaseToken} IS NULL) = (${t.ingestionLeaseExpiresAt} IS NULL)`,
+    ),
+    p.check(
+      "case_law_sources_reported_total_trio",
+      sql`(${t.reportedTotal} IS NULL) = (${t.reportedTotalAsOf} IS NULL)
+        AND (${t.reportedTotal} IS NULL) = (${t.reportedTotalOrigin} IS NULL)`,
+    ),
+    p.check(
+      "case_law_sources_reported_total_positive",
+      sql`${t.reportedTotal} IS NULL OR ${t.reportedTotal} > 0`,
+    ),
+    // The accepted values are read off SOURCE_TOTAL_ORIGIN rather than
+    // re-listed, so a new origin cannot reach the database without also
+    // reaching this constraint.
+    p.check(
+      "case_law_sources_reported_total_origin_allowed",
+      sql`${t.reportedTotalOrigin} IS NULL OR ${t.reportedTotalOrigin} IN (${sql.join(
+        Object.values(SOURCE_TOTAL_ORIGIN).map((origin) => sql`${origin}`),
+        sql`, `,
+      )})`,
     ),
     p.uniqueIndex("case_law_sources_adapter_key_idx").on(t.adapterKey),
     ...globalCaseLawPolicies(),

--- a/apps/api/src/handlers/case-law/ingestion/pipeline-canonical.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/pipeline-canonical.test.ts
@@ -520,6 +520,9 @@ describe("runIngestionPipeline — canonical corpus write failure", () => {
       ingestionLeaseExpiresAt: null,
       config: {},
       descriptor: null,
+      reportedTotal: null,
+      reportedTotalAsOf: null,
+      reportedTotalOrigin: null,
       createdAt: new Date("2026-01-01T00:00:00.000Z"),
       updatedAt: new Date("2026-01-01T00:00:00.000Z"),
     } satisfies typeof caseLawSources.$inferSelect;
@@ -572,6 +575,9 @@ describe("runIngestionPipeline — canonical corpus write failure", () => {
       ingestionLeaseExpiresAt: null,
       config: {},
       descriptor: null,
+      reportedTotal: null,
+      reportedTotalAsOf: null,
+      reportedTotalOrigin: null,
       createdAt: new Date("2026-01-01T00:00:00.000Z"),
       updatedAt: new Date("2026-01-01T00:00:00.000Z"),
     } satisfies typeof caseLawSources.$inferSelect;

--- a/apps/api/src/handlers/case-law/ingestion/pipeline.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/pipeline.test.ts
@@ -440,6 +440,9 @@ describe("runIngestionPipeline — database timeouts", () => {
       ingestionLeaseExpiresAt: null,
       config: {},
       descriptor: null,
+      reportedTotal: null,
+      reportedTotalAsOf: null,
+      reportedTotalOrigin: null,
       createdAt: new Date("2026-01-01T00:00:00.000Z"),
       updatedAt: new Date("2026-01-01T00:00:00.000Z"),
     } satisfies typeof caseLawSources.$inferSelect;
@@ -515,6 +518,9 @@ describe("runIngestionPipeline — empty-page cursor progress", () => {
       ingestionLeaseExpiresAt: null,
       config: {},
       descriptor: null,
+      reportedTotal: null,
+      reportedTotalAsOf: null,
+      reportedTotalOrigin: null,
       createdAt: new Date("2026-01-01T00:00:00.000Z"),
       updatedAt: new Date("2026-01-01T00:00:00.000Z"),
     } satisfies typeof caseLawSources.$inferSelect;

--- a/apps/api/src/handlers/case-law/ingestion/source-totals.db.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/source-totals.db.test.ts
@@ -10,6 +10,7 @@ import {
   relations,
   SOURCE_TOTAL_ORIGIN,
 } from "@/api/db/schema";
+import type { SourceTotalOrigin } from "@/api/db/schema";
 import {
   readSourceReportedTotals,
   setSourceReportedTotal,
@@ -150,6 +151,96 @@ test("an adapter key no source carries reports back, and writes nothing", async 
 
   expect(applied).toBe(false);
   expect(await readTrio(present)).toEqual({
+    reportedTotal: null,
+    reportedTotalAsOf: null,
+    reportedTotalOrigin: null,
+  });
+});
+
+// The origin values live in two places by necessity: the TypeScript union and
+// the column's check constraint. Exercising every declared member against the
+// real constraint binds the two — a member added to one and not the other
+// fails here rather than at a write.
+test.each(Object.values(SOURCE_TOTAL_ORIGIN))(
+  "the database accepts the declared origin %p",
+  async (origin) => {
+    const adapterKey = await seedSource();
+
+    const applied = await setSourceReportedTotal({
+      scopedDb,
+      adapterKey,
+      total: 3,
+      asOf: new Date("2026-08-11T09:00:00.000Z"),
+      origin,
+    });
+
+    expect(applied).toBe(true);
+    expect((await readTrio(adapterKey))?.reportedTotalOrigin).toBe(origin);
+  },
+);
+
+test("the database refuses an origin outside the declared set", async () => {
+  const adapterKey = await seedSource();
+
+  const rejection = await db
+    .update(caseLawSources)
+    .set({
+      reportedTotal: 5,
+      reportedTotalAsOf: new Date("2026-08-11T09:00:00.000Z"),
+      // SAFETY: the point of this test is the value the union forbids, so
+      // the cast is what lets the constraint be the thing under test.
+      // eslint-disable-next-line typescript/no-unsafe-type-assertion -- exercising the database's own guard against an unlisted origin
+      reportedTotalOrigin: "guessed" as SourceTotalOrigin,
+    })
+    .where(eq(caseLawSources.adapterKey, adapterKey))
+    .catch((error: unknown) => error);
+
+  expect(rejection).toBeInstanceOf(Error);
+  expect(await readTrio(adapterKey)).toEqual({
+    reportedTotal: null,
+    reportedTotalAsOf: null,
+    reportedTotalOrigin: null,
+  });
+});
+
+// The writer always sets the three together, so only a path that bypasses it
+// can split them. That is exactly what the constraint exists for.
+test.each([
+  ["total alone", { reportedTotal: 5 }],
+  ["date alone", { reportedTotalAsOf: new Date("2026-08-11T09:00:00.000Z") }],
+  ["origin alone", { reportedTotalOrigin: SOURCE_TOTAL_ORIGIN.OPERATOR }],
+])("the database refuses a partial trio: %s", async (_label, patch) => {
+  const adapterKey = await seedSource();
+
+  const rejection = await db
+    .update(caseLawSources)
+    .set(patch)
+    .where(eq(caseLawSources.adapterKey, adapterKey))
+    .catch((error: unknown) => error);
+
+  expect(rejection).toBeInstanceOf(Error);
+  expect(await readTrio(adapterKey)).toEqual({
+    reportedTotal: null,
+    reportedTotalAsOf: null,
+    reportedTotalOrigin: null,
+  });
+});
+
+test("the database refuses a non-positive total written around the writer", async () => {
+  const adapterKey = await seedSource();
+
+  const rejection = await db
+    .update(caseLawSources)
+    .set({
+      reportedTotal: 0,
+      reportedTotalAsOf: new Date("2026-08-11T09:00:00.000Z"),
+      reportedTotalOrigin: SOURCE_TOTAL_ORIGIN.OPERATOR,
+    })
+    .where(eq(caseLawSources.adapterKey, adapterKey))
+    .catch((error: unknown) => error);
+
+  expect(rejection).toBeInstanceOf(Error);
+  expect(await readTrio(adapterKey)).toEqual({
     reportedTotal: null,
     reportedTotalAsOf: null,
     reportedTotalOrigin: null,

--- a/apps/api/src/handlers/case-law/ingestion/source-totals.db.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/source-totals.db.test.ts
@@ -115,28 +115,53 @@ test("a later set replaces every member, origin included", async () => {
   });
 });
 
-test.each([0, -1, 1.5, Number.NaN, Number.MAX_SAFE_INTEGER + 2])(
-  "a total of %p is refused and writes nothing",
-  async (total) => {
-    const adapterKey = await seedSource();
+// 2_147_483_648 is one past the `integer` column's range: without the
+// writer's own bound it satisfies every "positive whole number" check and is
+// refused by PostgreSQL instead, mid-transaction.
+test.each([
+  0,
+  -1,
+  1.5,
+  Number.NaN,
+  Number.POSITIVE_INFINITY,
+  Number.MAX_SAFE_INTEGER + 2,
+  2_147_483_648,
+])("a total of %p is refused and writes nothing", async (total) => {
+  const adapterKey = await seedSource();
 
-    const rejection = await setSourceReportedTotal({
-      scopedDb,
-      adapterKey,
-      total,
-      asOf: new Date("2026-08-11T09:00:00.000Z"),
-      origin: SOURCE_TOTAL_ORIGIN.ADAPTER_POLL,
-    }).catch((error: unknown) => error);
+  const rejection = await setSourceReportedTotal({
+    scopedDb,
+    adapterKey,
+    total,
+    asOf: new Date("2026-08-11T09:00:00.000Z"),
+    origin: SOURCE_TOTAL_ORIGIN.ADAPTER_POLL,
+  }).catch((error: unknown) => error);
 
-    expect(rejection).toBeInstanceOf(TypeError);
+  expect(rejection).toBeInstanceOf(TypeError);
 
-    expect(await readTrio(adapterKey)).toEqual({
-      reportedTotal: null,
-      reportedTotalAsOf: null,
-      reportedTotalOrigin: null,
-    });
-  },
-);
+  expect(await readTrio(adapterKey)).toEqual({
+    reportedTotal: null,
+    reportedTotalAsOf: null,
+    reportedTotalOrigin: null,
+  });
+});
+
+// The other side of the bound: the largest value the column can hold must
+// still go through, so the guard cannot drift into rejecting valid totals.
+test("the column's largest value is accepted", async () => {
+  const adapterKey = await seedSource();
+
+  const applied = await setSourceReportedTotal({
+    scopedDb,
+    adapterKey,
+    total: 2_147_483_647,
+    asOf: new Date("2026-08-11T09:00:00.000Z"),
+    origin: SOURCE_TOTAL_ORIGIN.ADAPTER_POLL,
+  });
+
+  expect(applied).toBe(true);
+  expect((await readTrio(adapterKey))?.reportedTotal).toBe(2_147_483_647);
+});
 
 test("an adapter key no source carries reports back, and writes nothing", async () => {
   const present = await seedSource();

--- a/apps/api/src/handlers/case-law/ingestion/source-totals.db.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/source-totals.db.test.ts
@@ -1,0 +1,157 @@
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import { eq } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/pglite";
+
+import { authRelationsPart } from "@/api/db/auth-schema";
+import type { Transaction } from "@/api/db/root";
+import type { ScopedDb } from "@/api/db/safe-db";
+import {
+  caseLawSources,
+  relations,
+  SOURCE_TOTAL_ORIGIN,
+} from "@/api/db/schema";
+import {
+  readSourceReportedTotals,
+  setSourceReportedTotal,
+} from "@/api/handlers/case-law/ingestion/source-totals";
+import { createSafeId } from "@/api/lib/branded-types";
+
+// The trio is nullable in the schema and only this module keeps it whole, so
+// what is asserted here is the writer's invariant rather than the columns:
+// a set lands as all three, a rewrite replaces all three, a value no
+// publisher could state is refused, and a key no source carries writes
+// nothing at all.
+
+const connect = (client: Awaited<ReturnType<typeof createTestPglite>>) =>
+  drizzle({ client, relations: { ...relations, ...authRelationsPart } });
+
+const { createTestPglite } = await import("@/api/tests/pglite-test-db");
+
+let client: Awaited<ReturnType<typeof createTestPglite>>;
+let db: ReturnType<typeof connect>;
+
+const scopedDb: ScopedDb = async (callback) =>
+  // SAFETY: pglite stands in for the transaction the helper expects.
+  // eslint-disable-next-line typescript/no-unsafe-type-assertion -- the pglite handle is the test's transaction
+  await callback(db as unknown as Transaction);
+
+beforeAll(async () => {
+  client = await createTestPglite();
+  db = connect(client);
+}, 120_000);
+
+afterAll(async () => {
+  await client.close();
+});
+
+const seedSource = async (): Promise<string> => {
+  const id = createSafeId<"caseLawSource">();
+  const adapterKey = `source-totals-${id}`;
+  await db
+    .insert(caseLawSources)
+    .values({ id, adapterKey, name: "source totals fixture" });
+  return adapterKey;
+};
+
+const readTrio = async (adapterKey: string) =>
+  (
+    await db
+      .select({
+        reportedTotal: caseLawSources.reportedTotal,
+        reportedTotalAsOf: caseLawSources.reportedTotalAsOf,
+        reportedTotalOrigin: caseLawSources.reportedTotalOrigin,
+      })
+      .from(caseLawSources)
+      .where(eq(caseLawSources.adapterKey, adapterKey))
+      .limit(1)
+  ).at(0);
+
+test("a set lands as the whole trio and reads back", async () => {
+  const adapterKey = await seedSource();
+  const asOf = new Date("2026-08-11T09:00:00.000Z");
+
+  const applied = await setSourceReportedTotal({
+    scopedDb,
+    adapterKey,
+    total: 903_412,
+    asOf,
+    origin: SOURCE_TOTAL_ORIGIN.OPERATOR,
+  });
+
+  expect(applied).toBe(true);
+  const rows = await readSourceReportedTotals(scopedDb);
+  expect(rows.find((row) => row.adapterKey === adapterKey)).toEqual({
+    adapterKey,
+    reportedTotal: 903_412,
+    reportedTotalAsOf: asOf,
+    reportedTotalOrigin: SOURCE_TOTAL_ORIGIN.OPERATOR,
+  });
+});
+
+test("a later set replaces every member, origin included", async () => {
+  const adapterKey = await seedSource();
+  await setSourceReportedTotal({
+    scopedDb,
+    adapterKey,
+    total: 10,
+    asOf: new Date("2026-08-01T00:00:00.000Z"),
+    origin: SOURCE_TOTAL_ORIGIN.OPERATOR,
+  });
+
+  const asOf = new Date("2026-08-11T12:00:00.000Z");
+  await setSourceReportedTotal({
+    scopedDb,
+    adapterKey,
+    total: 11,
+    asOf,
+    origin: SOURCE_TOTAL_ORIGIN.ADAPTER_POLL,
+  });
+
+  expect(await readTrio(adapterKey)).toEqual({
+    reportedTotal: 11,
+    reportedTotalAsOf: asOf,
+    reportedTotalOrigin: SOURCE_TOTAL_ORIGIN.ADAPTER_POLL,
+  });
+});
+
+test.each([0, -1, 1.5, Number.NaN, Number.MAX_SAFE_INTEGER + 2])(
+  "a total of %p is refused and writes nothing",
+  async (total) => {
+    const adapterKey = await seedSource();
+
+    const rejection = await setSourceReportedTotal({
+      scopedDb,
+      adapterKey,
+      total,
+      asOf: new Date("2026-08-11T09:00:00.000Z"),
+      origin: SOURCE_TOTAL_ORIGIN.ADAPTER_POLL,
+    }).catch((error: unknown) => error);
+
+    expect(rejection).toBeInstanceOf(TypeError);
+
+    expect(await readTrio(adapterKey)).toEqual({
+      reportedTotal: null,
+      reportedTotalAsOf: null,
+      reportedTotalOrigin: null,
+    });
+  },
+);
+
+test("an adapter key no source carries reports back, and writes nothing", async () => {
+  const present = await seedSource();
+
+  const applied = await setSourceReportedTotal({
+    scopedDb,
+    adapterKey: `${present}-absent`,
+    total: 7,
+    asOf: new Date("2026-08-11T09:00:00.000Z"),
+    origin: SOURCE_TOTAL_ORIGIN.OPERATOR,
+  });
+
+  expect(applied).toBe(false);
+  expect(await readTrio(present)).toEqual({
+    reportedTotal: null,
+    reportedTotalAsOf: null,
+    reportedTotalOrigin: null,
+  });
+});

--- a/apps/api/src/handlers/case-law/ingestion/source-totals.ts
+++ b/apps/api/src/handlers/case-law/ingestion/source-totals.ts
@@ -1,0 +1,98 @@
+import { eq } from "drizzle-orm";
+
+import type { ScopedDb } from "@/api/db/safe-db";
+import { caseLawSources } from "@/api/db/schema";
+import type { SourceTotalOrigin } from "@/api/db/schema";
+
+/**
+ * The count a publisher reports holding, per source. Held-vs-total coverage
+ * needs a total, and several publishers expose none cheaply, so the number is
+ * persisted rather than recomputed: polled from the adapter where one
+ * implements `getTotalCount`, supplied by an operator where none does.
+ *
+ * This module is the only writer of the trio. It is what keeps
+ * `reportedTotal`, `reportedTotalAsOf` and `reportedTotalOrigin` in the "all
+ * set" state — the columns are nullable so a source that has never been
+ * measured reads as unknown rather than as zero.
+ */
+
+/**
+ * The sources table holds one row per registered adapter key, a set fixed in
+ * code. The bound is the lint-visible statement of that.
+ */
+const SOURCE_READ_LIMIT = 100;
+
+type SetSourceReportedTotalOptions = {
+  scopedDb: ScopedDb;
+  adapterKey: string;
+  total: number;
+  asOf: Date;
+  origin: SourceTotalOrigin;
+};
+
+export type SourceReportedTotal = {
+  adapterKey: string;
+  reportedTotal: number | null;
+  reportedTotalAsOf: Date | null;
+  reportedTotalOrigin: SourceTotalOrigin | null;
+};
+
+/**
+ * Record what a publisher reports holding for one source.
+ *
+ * A total of zero or below is rejected rather than stored: no publisher this
+ * runs against reports holding nothing, so such a value is a caller bug (a
+ * parse that yielded NaN, a failed poll coerced to a number) and storing it
+ * would read downstream as complete coverage of an empty corpus.
+ *
+ * Returns false when no source carries `adapterKey`.
+ */
+export const setSourceReportedTotal = async ({
+  scopedDb,
+  adapterKey,
+  total,
+  asOf,
+  origin,
+}: SetSourceReportedTotalOptions): Promise<boolean> => {
+  if (!Number.isSafeInteger(total) || total <= 0) {
+    throw new TypeError(
+      `reported total must be a positive safe integer, got: ${total}`,
+    );
+  }
+  if (Number.isNaN(asOf.getTime())) {
+    throw new TypeError("reported total asOf must be a valid date");
+  }
+
+  return await scopedDb(async (tx) => {
+    // audit: skip — public case-law corpus bookkeeping, no workspace data
+    const updated = await tx
+      .update(caseLawSources)
+      .set({
+        reportedTotal: total,
+        reportedTotalAsOf: asOf,
+        reportedTotalOrigin: origin,
+      })
+      .where(eq(caseLawSources.adapterKey, adapterKey))
+      .returning({ adapterKey: caseLawSources.adapterKey });
+
+    return updated.length > 0;
+  });
+};
+
+/** Every source's reported total, for coverage reporting. */
+export const readSourceReportedTotals = async (
+  scopedDb: ScopedDb,
+): Promise<SourceReportedTotal[]> =>
+  await scopedDb(
+    async (tx) =>
+      await tx
+        .select({
+          adapterKey: caseLawSources.adapterKey,
+          reportedTotal: caseLawSources.reportedTotal,
+          reportedTotalAsOf: caseLawSources.reportedTotalAsOf,
+          reportedTotalOrigin: caseLawSources.reportedTotalOrigin,
+        })
+        .from(caseLawSources)
+        .orderBy(caseLawSources.adapterKey)
+        .limit(SOURCE_READ_LIMIT),
+  );

--- a/apps/api/src/handlers/case-law/ingestion/source-totals.ts
+++ b/apps/api/src/handlers/case-law/ingestion/source-totals.ts
@@ -22,6 +22,14 @@ import type { SourceTotalOrigin } from "@/api/db/schema";
  */
 const SOURCE_READ_LIMIT = 100;
 
+/**
+ * `reportedTotal` is a PostgreSQL `integer`. A larger value is rejected here
+ * so the caller gets the same boundary `TypeError` as any other unusable
+ * number, instead of a numeric-overflow raised mid-transaction by the
+ * database, which a batched caller cannot attribute to one source.
+ */
+const POSTGRES_INTEGER_MAX = 2_147_483_647;
+
 type SetSourceReportedTotalOptions = {
   scopedDb: ScopedDb;
   adapterKey: string;
@@ -40,10 +48,12 @@ export type SourceReportedTotal = {
 /**
  * Record what a publisher reports holding for one source.
  *
- * A total of zero or below is rejected rather than stored: no publisher this
- * runs against reports holding nothing, so such a value is a caller bug (a
- * parse that yielded NaN, a failed poll coerced to a number) and storing it
- * would read downstream as complete coverage of an empty corpus.
+ * This is the only place the number is judged, so it rejects everything the
+ * column cannot hold or the domain cannot mean: zero and below (no publisher
+ * reports holding nothing, and storing it would read downstream as complete
+ * coverage of an empty corpus), anything not a whole number (a parse that
+ * yielded NaN or infinity, a fraction), and anything past the column's
+ * range. Callers report the `TypeError` rather than restating these rules.
  *
  * Returns false when no source carries `adapterKey`.
  */
@@ -54,9 +64,13 @@ export const setSourceReportedTotal = async ({
   asOf,
   origin,
 }: SetSourceReportedTotalOptions): Promise<boolean> => {
-  if (!Number.isSafeInteger(total) || total <= 0) {
+  if (
+    !Number.isSafeInteger(total) ||
+    total <= 0 ||
+    total > POSTGRES_INTEGER_MAX
+  ) {
     throw new TypeError(
-      `reported total must be a positive safe integer, got: ${total}`,
+      `reported total must be a positive integer no greater than ${POSTGRES_INTEGER_MAX}, got: ${total}`,
     );
   }
   if (Number.isNaN(asOf.getTime())) {

--- a/apps/api/src/handlers/case-law/ingestion/status.ts
+++ b/apps/api/src/handlers/case-law/ingestion/status.ts
@@ -10,6 +10,7 @@ import {
   caseLawIngestionFailures,
   caseLawSources,
 } from "@/api/db/schema";
+import type { SourceTotalOrigin } from "@/api/db/schema";
 import { createSafeRootHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
 
@@ -19,6 +20,14 @@ type SourceStatus = {
   enabled: boolean;
   syncCursor: string | null;
   totalDecisions: number;
+  /**
+   * What the publisher reports holding, when that was observed, and where
+   * the number came from. Null until the source has been measured; the three
+   * always move together (see `ingestion/source-totals.ts`).
+   */
+  reportedTotal: number | null;
+  reportedTotalAsOf: string | null;
+  reportedTotalOrigin: SourceTotalOrigin | null;
   insertedLastHour: number;
   inserted24h: number;
   failures24h: number;
@@ -54,6 +63,9 @@ export const getIngestionStatus = async (
         name: caseLawSources.name,
         syncCursor: caseLawSources.syncCursor,
         enabled: caseLawSources.enabled,
+        reportedTotal: caseLawSources.reportedTotal,
+        reportedTotalAsOf: caseLawSources.reportedTotalAsOf,
+        reportedTotalOrigin: caseLawSources.reportedTotalOrigin,
       })
       .from(caseLawSources)
       // SAFETY: one row per ADAPTER_KEYS entry, enforced by the unique case_law_sources_adapter_key_idx
@@ -136,6 +148,9 @@ export const getIngestionStatus = async (
         enabled: source.enabled,
         syncCursor: source.syncCursor,
         totalDecisions: totalRow?.total ?? 0,
+        reportedTotal: source.reportedTotal,
+        reportedTotalAsOf: source.reportedTotalAsOf?.toISOString() ?? null,
+        reportedTotalOrigin: source.reportedTotalOrigin,
         insertedLastHour: hourRow?.inserted ?? 0,
         inserted24h: dayRow?.inserted ?? 0,
         failures24h: failRow?.total ?? 0,

--- a/apps/api/src/lib/dates.ts
+++ b/apps/api/src/lib/dates.ts
@@ -132,6 +132,27 @@ const isUtcCalendarDay = ({ year, month, day }: IsoDateParts): boolean => {
 };
 
 /**
+ * The `YYYY-MM-DD` form of a bare calendar date or of an ISO datetime whose
+ * date part names a real Gregorian day, or `null` when it is neither.
+ *
+ * The grammar and calendar check on their own, without the publication-year
+ * bounds `canonicalDecisionDate` adds: `"2024-02-30"` and `"01/02/2024"` are
+ * rejected here, a year of 1200 is not. For callers that need a real day but
+ * carry no decision semantics.
+ */
+export const isoCalendarDay = (raw: string): string | null => {
+  const candidate = isoDatePrefix(raw);
+  if (candidate === null) {
+    return null;
+  }
+  const parts = isoDateParts(candidate);
+  if (parts === null || !isUtcCalendarDay(parts)) {
+    return null;
+  }
+  return candidate;
+};
+
+/**
  * Canonical `YYYY-MM-DD` form of a published decision date, or `null` when
  * the value cannot be one.
  *
@@ -141,16 +162,13 @@ const isUtcCalendarDay = ({ year, month, day }: IsoDateParts): boolean => {
  * a correct one, so callers writing to one need this in front of the write.
  */
 export const canonicalDecisionDate = (raw: string): string | null => {
-  const candidate = isoDatePrefix(raw);
+  const candidate = isoCalendarDay(raw);
   if (candidate === null) {
     return null;
   }
-  const parts = isoDateParts(candidate);
-  if (parts === null || !isUtcCalendarDay(parts)) {
-    return null;
-  }
+  const year = Number(candidate.slice(0, 4));
   const maxYear = new Date().getUTCFullYear() + DECISION_YEAR_BOUNDS.yearsAhead;
-  if (parts.year < DECISION_YEAR_BOUNDS.min || parts.year > maxYear) {
+  if (year < DECISION_YEAR_BOUNDS.min || year > maxYear) {
     return null;
   }
   return candidate;

--- a/apps/api/src/scripts/case-law-source-total.ts
+++ b/apps/api/src/scripts/case-law-source-total.ts
@@ -9,6 +9,7 @@ import {
   readSourceReportedTotals,
   setSourceReportedTotal,
 } from "@/api/handlers/case-law/ingestion/source-totals";
+import { isoCalendarDay } from "@/api/lib/dates";
 
 /**
  * Read and set the total each case-law publisher reports holding.
@@ -52,7 +53,7 @@ Modes (exactly one):
 
 Options:
   --adapter <key>        Required with --total; narrows --poll to one source.
-  --as-of <ISO date>     When the figure was stated (default: now).
+  --as-of <YYYY-MM-DD>   The day the figure was stated (default: now).
 
 Adapter keys: ${listAdapterKeys().join(", ")}`;
 
@@ -73,14 +74,6 @@ const flagValue = (name: string): string | undefined => {
 const hasFlag = (name: string): boolean => process.argv.includes(`--${name}`);
 
 const DECIMAL_INTEGER = /^\d+$/u;
-
-/**
- * ISO 8601 calendar date, optionally with a time that must carry its own
- * zone. A zoneless time would be read as the operator's local time and
- * stored as a different instant depending on where it was typed.
- */
-const ISO_DATE =
-  /^(?<year>\d{4})-(?<month>\d{2})-(?<day>\d{2})(?:T\d{2}:\d{2}(?::\d{2}(?:\.\d{1,3})?)?(?:Z|[+-]\d{2}:\d{2}))?$/u;
 
 const list = hasFlag("list");
 const poll = hasFlag("poll");
@@ -109,40 +102,24 @@ const asOf = (() => {
   if (asOfFlag === undefined) {
     return new Date();
   }
-  // `new Date(string)` also accepts locale-ambiguous forms: "01/02/2026" is
-  // 2 January to its parser and 1 February to much of the world. Requiring
-  // the ISO grammar first means an operator cannot silently date a figure
-  // eleven months wrong by writing it the way their locale does. A time,
-  // when given, must carry its zone for the same reason.
-  const match = ISO_DATE.exec(asOfFlag);
-  if (!match?.groups) {
+  // `new Date(string)` accepts locale-ambiguous forms: "01/02/2026" is
+  // 2 January to its parser and 1 February to much of the world. It also
+  // rolls a day that does not exist ("2026-02-31") forward into the next
+  // month rather than rejecting it. `isoCalendarDay` is the shared guard
+  // against both, used here rather than restated.
+  const day = isoCalendarDay(asOfFlag);
+  // A datetime canonicalizes to its date part, so requiring the round-trip
+  // is what keeps an operator's time-of-day from being dropped in silence:
+  // a figure is stated on a day, and only a bare day is accepted.
+  if (day === null || day !== asOfFlag) {
     console.error(
-      `--as-of must be an ISO date (YYYY-MM-DD, or YYYY-MM-DDThh:mm:ssZ with a zone), got: ${asOfFlag}`,
+      `--as-of must be a bare ISO calendar date (YYYY-MM-DD), got: ${asOfFlag}`,
     );
     process.exit(1);
   }
-  // The grammar admits days that do not exist ("2026-02-31"), which the
-  // parser silently rolls forward into March. Check the calendar fields
-  // themselves: the parsed instant's UTC day is not usable here, because a
-  // legitimate zone offset moves it either way.
-  const year = Number(match.groups["year"]);
-  const month = Number(match.groups["month"]);
-  const day = Number(match.groups["day"]);
-  const calendar = new Date(Date.UTC(year, month - 1, day));
-  if (
-    calendar.getUTCFullYear() !== year ||
-    calendar.getUTCMonth() !== month - 1 ||
-    calendar.getUTCDate() !== day
-  ) {
-    console.error(`--as-of is not a real calendar date: ${asOfFlag}`);
-    process.exit(1);
-  }
-  const parsed = new Date(asOfFlag);
-  if (Number.isNaN(parsed.getTime())) {
-    console.error(`--as-of is not a valid date: ${asOfFlag}`);
-    process.exit(1);
-  }
-  return parsed;
+  // No zone to interpret, so the day is anchored at UTC midnight rather
+  // than at whatever local midnight the operator's machine is in.
+  return new Date(`${day}T00:00:00.000Z`);
 })();
 
 const ingestionDb = createIngestionDb(rlsDb);

--- a/apps/api/src/scripts/case-law-source-total.ts
+++ b/apps/api/src/scripts/case-law-source-total.ts
@@ -1,0 +1,235 @@
+import { rlsDb } from "@/api/db/root";
+import { SOURCE_TOTAL_ORIGIN } from "@/api/db/schema";
+import { createIngestionDb } from "@/api/db/scoped";
+import {
+  getAdapter,
+  listAdapterKeys,
+} from "@/api/handlers/case-law/ingestion/adapters/adapter-registry";
+import {
+  readSourceReportedTotals,
+  setSourceReportedTotal,
+} from "@/api/handlers/case-law/ingestion/source-totals";
+
+/**
+ * Read and set the total each case-law publisher reports holding.
+ *
+ * Held-vs-total coverage needs a denominator, and only some publishers
+ * expose a cheap count. Those adapters implement `getTotalCount` and are
+ * polled here; for the rest, an operator reads the publisher's own figure
+ * and records it, with the origin kept alongside so a reader can tell a
+ * measured number from a transcribed one.
+ *
+ * A poll that returns null or throws records NOTHING and says so. The
+ * stored total is the last number the publisher actually stated, and a
+ * failed probe is not evidence that it changed.
+ *
+ *   # what is recorded today
+ *   bun run src/scripts/case-law-source-total.ts --list
+ *
+ *   # transcribe a publisher's own figure
+ *   bun run src/scripts/case-law-source-total.ts \
+ *     --adapter cz-ns --total 123456 [--as-of 2026-08-11]
+ *
+ *   # poll every adapter that exposes a count, or just one
+ *   bun run src/scripts/case-law-source-total.ts --poll [--adapter cz-us]
+ *
+ * Not a scheduled job: a deliberate operation under an operator who reads
+ * the report.
+ */
+
+/** Publishers compute a full-range count slowly; the probe must outlast it. */
+const POLL_TIMEOUT_MS = 120_000;
+
+const USAGE = `Usage: bun run src/scripts/case-law-source-total.ts <mode> [options]
+
+Modes (exactly one):
+  --list                 Print the recorded total for every source.
+  --total <n>            Record <n> for --adapter, origin "operator".
+  --poll                 Poll adapters that expose a count, origin
+                         "adapter-poll".
+
+Options:
+  --adapter <key>        Required with --total; narrows --poll to one source.
+  --as-of <ISO date>     When the figure was stated (default: now).
+
+Adapter keys: ${listAdapterKeys().join(", ")}`;
+
+const flagValue = (name: string): string | undefined => {
+  const index = process.argv.indexOf(`--${name}`);
+  if (index === -1) {
+    return undefined;
+  }
+  const value = process.argv[index + 1];
+  if (value === undefined || value.startsWith("--")) {
+    console.error(`--${name} requires a value`);
+    console.error(USAGE);
+    process.exit(1);
+  }
+  return value;
+};
+
+const hasFlag = (name: string): boolean => process.argv.includes(`--${name}`);
+
+const DECIMAL_INTEGER = /^\d+$/u;
+
+const list = hasFlag("list");
+const poll = hasFlag("poll");
+const totalFlag = flagValue("total");
+const adapterFlag = flagValue("adapter");
+const asOfFlag = flagValue("as-of");
+
+const modes = [list, poll, totalFlag !== undefined].filter(Boolean);
+if (modes.length !== 1) {
+  console.error("Exactly one of --list, --total or --poll is required.");
+  console.error(USAGE);
+  process.exit(1);
+}
+
+const knownKeys = listAdapterKeys();
+if (
+  adapterFlag !== undefined &&
+  !knownKeys.some((candidate) => candidate === adapterFlag)
+) {
+  console.error(`Unknown adapter: ${adapterFlag}`);
+  console.error(USAGE);
+  process.exit(1);
+}
+
+const asOf = (() => {
+  if (asOfFlag === undefined) {
+    return new Date();
+  }
+  const parsed = new Date(asOfFlag);
+  if (Number.isNaN(parsed.getTime())) {
+    console.error(`--as-of must be an ISO date, got: ${asOfFlag}`);
+    process.exit(1);
+  }
+  return parsed;
+})();
+
+const ingestionDb = createIngestionDb(rlsDb);
+
+if (list) {
+  const rows = await readSourceReportedTotals(ingestionDb);
+  console.log("=== CASE-LAW SOURCE REPORTED TOTALS ===");
+  for (const row of rows) {
+    const total = row.reportedTotal?.toLocaleString() ?? "unrecorded";
+    const asOfText = row.reportedTotalAsOf?.toISOString() ?? "-";
+    const origin = row.reportedTotalOrigin ?? "-";
+    console.log(
+      `${row.adapterKey.padEnd(12)} ${total.padStart(12)}  ${asOfText}  ${origin}`,
+    );
+  }
+  process.exit(0);
+}
+
+if (totalFlag !== undefined) {
+  if (adapterFlag === undefined) {
+    console.error("--total requires --adapter.");
+    console.error(USAGE);
+    process.exit(1);
+  }
+  const parsed = DECIMAL_INTEGER.test(totalFlag)
+    ? Number.parseInt(totalFlag, 10)
+    : Number.NaN;
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    console.error(`--total must be a positive integer, got: ${totalFlag}`);
+    process.exit(1);
+  }
+  const applied = await setSourceReportedTotal({
+    scopedDb: ingestionDb,
+    adapterKey: adapterFlag,
+    total: parsed,
+    asOf,
+    origin: SOURCE_TOTAL_ORIGIN.OPERATOR,
+  });
+  if (!applied) {
+    console.error(`No case-law source configured for adapter ${adapterFlag}`);
+    process.exit(1);
+  }
+  console.log(
+    `${adapterFlag}: recorded ${parsed.toLocaleString()} as of ${asOf.toISOString()} (operator)`,
+  );
+  process.exit(0);
+}
+
+const POLL_OUTCOME = {
+  RECORDED: "recorded",
+  NO_ENDPOINT: "no-endpoint",
+  FAILED: "failed",
+} as const;
+
+type PollOutcome = (typeof POLL_OUTCOME)[keyof typeof POLL_OUTCOME];
+
+type PollResult = {
+  adapterKey: string;
+  outcome: PollOutcome;
+  line: string;
+};
+
+/**
+ * One probe against one publisher. A poll that yields no usable number
+ * writes nothing: the stored total is the last figure the publisher
+ * actually stated, and a failed probe is not a statement that it changed.
+ */
+const pollOne = async (adapterKey: string): Promise<PollResult> => {
+  const adapter = getAdapter(adapterKey);
+  if (!adapter?.getTotalCount) {
+    return {
+      adapterKey,
+      outcome: POLL_OUTCOME.NO_ENDPOINT,
+      line: `${adapterKey}: no count endpoint, nothing recorded`,
+    };
+  }
+
+  const total = await adapter
+    .getTotalCount(AbortSignal.timeout(POLL_TIMEOUT_MS))
+    .catch((error: unknown) => {
+      console.error(`${adapterKey}: poll failed —`, error);
+      return null;
+    });
+  if (total === null || total <= 0) {
+    return {
+      adapterKey,
+      outcome: POLL_OUTCOME.FAILED,
+      line: `${adapterKey}: poll returned no usable total, nothing recorded`,
+    };
+  }
+
+  const applied = await setSourceReportedTotal({
+    scopedDb: ingestionDb,
+    adapterKey,
+    total,
+    asOf,
+    origin: SOURCE_TOTAL_ORIGIN.ADAPTER_POLL,
+  });
+  return applied
+    ? {
+        adapterKey,
+        outcome: POLL_OUTCOME.RECORDED,
+        line: `${adapterKey}: recorded ${total.toLocaleString()} (adapter-poll)`,
+      }
+    : {
+        adapterKey,
+        outcome: POLL_OUTCOME.FAILED,
+        line: `${adapterKey}: no case-law source configured, not recorded`,
+      };
+};
+
+// One request per publisher, and each publisher is a different host, so the
+// sweep runs them together rather than serializing behind the slowest count.
+const pollKeys = adapterFlag === undefined ? knownKeys : [adapterFlag];
+const results = await Promise.all(pollKeys.map(pollOne));
+
+for (const result of results) {
+  console.log(result.line);
+}
+
+const tally = (outcome: PollOutcome): number =>
+  results.filter((result) => result.outcome === outcome).length;
+
+console.log("--- outcomes ---");
+console.log(`recorded:    ${tally(POLL_OUTCOME.RECORDED)}`);
+console.log(`no endpoint: ${tally(POLL_OUTCOME.NO_ENDPOINT)}`);
+console.log(`failed:      ${tally(POLL_OUTCOME.FAILED)}`);
+process.exit(tally(POLL_OUTCOME.FAILED) > 0 ? 1 : 0);

--- a/apps/api/src/scripts/case-law-source-total.ts
+++ b/apps/api/src/scripts/case-law-source-total.ts
@@ -151,14 +151,25 @@ if (totalFlag !== undefined) {
     console.error(`--total must be a positive integer, got: ${totalFlag}`);
     process.exit(1);
   }
-  const applied = await setSourceReportedTotal({
+  // The remaining bound on the number is the writer's, so it is reported
+  // rather than restated: a value the column cannot hold should read as a
+  // refused argument, not an unhandled rejection.
+  const write = await setSourceReportedTotal({
     scopedDb: ingestionDb,
     adapterKey: adapterFlag,
     total: parsed,
     asOf,
     origin: SOURCE_TOTAL_ORIGIN.OPERATOR,
-  });
-  if (!applied) {
+  })
+    .then((applied) => ({ ok: true, applied }) as const)
+    .catch((error: unknown) => ({ ok: false, error }) as const);
+  if (!write.ok) {
+    console.error(
+      `not recorded: ${write.error instanceof Error ? write.error.message : "the write failed"}`,
+    );
+    process.exit(1);
+  }
+  if (!write.applied) {
     console.error(`No case-law source configured for adapter ${adapterFlag}`);
     process.exit(1);
   }
@@ -227,25 +238,28 @@ const pollOne = async (adapterKey: string): Promise<PollResult> => {
       line: `${adapterKey}: exposes no count, nothing recorded`,
     };
   }
-  if (probe.total <= 0) {
-    // A publisher that answers with a count it cannot hold: refuse it here
-    // rather than let the writer's own validation throw mid-sweep.
-    return {
-      adapterKey,
-      outcome: POLL_OUTCOME.FAILED,
-      line: `${adapterKey}: poll returned an unusable total (${probe.total}), nothing recorded`,
-    };
-  }
+  // The writer owns what counts as a usable number, so its rules are not
+  // restated here — but its rejection must not escape. The probes run
+  // together, so a throw would reject the whole batch and lose the result of
+  // every other adapter, including the ones that succeeded.
   const { total } = probe;
-
-  const applied = await setSourceReportedTotal({
+  const write = await setSourceReportedTotal({
     scopedDb: ingestionDb,
     adapterKey,
     total,
     asOf,
     origin: SOURCE_TOTAL_ORIGIN.ADAPTER_POLL,
-  });
-  return applied
+  })
+    .then((applied) => ({ ok: true, applied }) as const)
+    .catch((error: unknown) => ({ ok: false, error }) as const);
+  if (!write.ok) {
+    return {
+      adapterKey,
+      outcome: POLL_OUTCOME.FAILED,
+      line: `${adapterKey}: ${write.error instanceof Error ? write.error.message : "poll write failed"}, nothing recorded`,
+    };
+  }
+  return write.applied
     ? {
         adapterKey,
         outcome: POLL_OUTCOME.RECORDED,

--- a/apps/api/src/scripts/case-law-source-total.ts
+++ b/apps/api/src/scripts/case-law-source-total.ts
@@ -21,7 +21,9 @@ import {
  *
  * A poll that returns null or throws records NOTHING and says so. The
  * stored total is the last number the publisher actually stated, and a
- * failed probe is not evidence that it changed.
+ * failed probe is not evidence that it changed. Only a broken probe moves
+ * the exit code: an adapter whose publisher simply states no total is
+ * reported and passed over, so a full sweep is not permanently red.
  *
  *   # what is recorded today
  *   bun run src/scripts/case-law-source-total.ts --list
@@ -72,6 +74,14 @@ const hasFlag = (name: string): boolean => process.argv.includes(`--${name}`);
 
 const DECIMAL_INTEGER = /^\d+$/u;
 
+/**
+ * ISO 8601 calendar date, optionally with a time that must carry its own
+ * zone. A zoneless time would be read as the operator's local time and
+ * stored as a different instant depending on where it was typed.
+ */
+const ISO_DATE =
+  /^(?<year>\d{4})-(?<month>\d{2})-(?<day>\d{2})(?:T\d{2}:\d{2}(?::\d{2}(?:\.\d{1,3})?)?(?:Z|[+-]\d{2}:\d{2}))?$/u;
+
 const list = hasFlag("list");
 const poll = hasFlag("poll");
 const totalFlag = flagValue("total");
@@ -99,9 +109,37 @@ const asOf = (() => {
   if (asOfFlag === undefined) {
     return new Date();
   }
+  // `new Date(string)` also accepts locale-ambiguous forms: "01/02/2026" is
+  // 2 January to its parser and 1 February to much of the world. Requiring
+  // the ISO grammar first means an operator cannot silently date a figure
+  // eleven months wrong by writing it the way their locale does. A time,
+  // when given, must carry its zone for the same reason.
+  const match = ISO_DATE.exec(asOfFlag);
+  if (!match?.groups) {
+    console.error(
+      `--as-of must be an ISO date (YYYY-MM-DD, or YYYY-MM-DDThh:mm:ssZ with a zone), got: ${asOfFlag}`,
+    );
+    process.exit(1);
+  }
+  // The grammar admits days that do not exist ("2026-02-31"), which the
+  // parser silently rolls forward into March. Check the calendar fields
+  // themselves: the parsed instant's UTC day is not usable here, because a
+  // legitimate zone offset moves it either way.
+  const year = Number(match.groups["year"]);
+  const month = Number(match.groups["month"]);
+  const day = Number(match.groups["day"]);
+  const calendar = new Date(Date.UTC(year, month - 1, day));
+  if (
+    calendar.getUTCFullYear() !== year ||
+    calendar.getUTCMonth() !== month - 1 ||
+    calendar.getUTCDate() !== day
+  ) {
+    console.error(`--as-of is not a real calendar date: ${asOfFlag}`);
+    process.exit(1);
+  }
   const parsed = new Date(asOfFlag);
   if (Number.isNaN(parsed.getTime())) {
-    console.error(`--as-of must be an ISO date, got: ${asOfFlag}`);
+    console.error(`--as-of is not a valid date: ${asOfFlag}`);
     process.exit(1);
   }
   return parsed;
@@ -155,7 +193,14 @@ if (totalFlag !== undefined) {
 
 const POLL_OUTCOME = {
   RECORDED: "recorded",
-  NO_ENDPOINT: "no-endpoint",
+  /**
+   * The adapter states no total. Covers both an adapter that implements no
+   * `getTotalCount` and one whose implementation answers null because its
+   * publisher exposes no readable count — `SourceAdapter.getTotalCount`
+   * defines null as exactly that. Not a failure: a sweep over every adapter
+   * would otherwise always end in one, whatever the count-capable sources did.
+   */
+  NO_COUNT: "no-count",
   FAILED: "failed",
 } as const;
 
@@ -177,24 +222,44 @@ const pollOne = async (adapterKey: string): Promise<PollResult> => {
   if (!adapter?.getTotalCount) {
     return {
       adapterKey,
-      outcome: POLL_OUTCOME.NO_ENDPOINT,
-      line: `${adapterKey}: no count endpoint, nothing recorded`,
+      outcome: POLL_OUTCOME.NO_COUNT,
+      line: `${adapterKey}: exposes no count, nothing recorded`,
     };
   }
 
-  const total = await adapter
+  // A throw is a failure of this probe; a null is the adapter's own answer
+  // that its publisher states no total. The two are kept apart so a broken
+  // probe still moves the exit code and a permanently countless source
+  // never does.
+  const probe = await adapter
     .getTotalCount(AbortSignal.timeout(POLL_TIMEOUT_MS))
-    .catch((error: unknown) => {
-      console.error(`${adapterKey}: poll failed —`, error);
-      return null;
-    });
-  if (total === null || total <= 0) {
+    .then((total) => ({ ok: true, total }) as const)
+    .catch((error: unknown) => ({ ok: false, error }) as const);
+  if (!probe.ok) {
+    console.error(`${adapterKey}: poll failed —`, probe.error);
     return {
       adapterKey,
       outcome: POLL_OUTCOME.FAILED,
-      line: `${adapterKey}: poll returned no usable total, nothing recorded`,
+      line: `${adapterKey}: poll failed, nothing recorded`,
     };
   }
+  if (probe.total === null) {
+    return {
+      adapterKey,
+      outcome: POLL_OUTCOME.NO_COUNT,
+      line: `${adapterKey}: exposes no count, nothing recorded`,
+    };
+  }
+  if (probe.total <= 0) {
+    // A publisher that answers with a count it cannot hold: refuse it here
+    // rather than let the writer's own validation throw mid-sweep.
+    return {
+      adapterKey,
+      outcome: POLL_OUTCOME.FAILED,
+      line: `${adapterKey}: poll returned an unusable total (${probe.total}), nothing recorded`,
+    };
+  }
+  const { total } = probe;
 
   const applied = await setSourceReportedTotal({
     scopedDb: ingestionDb,
@@ -230,6 +295,6 @@ const tally = (outcome: PollOutcome): number =>
 
 console.log("--- outcomes ---");
 console.log(`recorded:    ${tally(POLL_OUTCOME.RECORDED)}`);
-console.log(`no endpoint: ${tally(POLL_OUTCOME.NO_ENDPOINT)}`);
+console.log(`no count:    ${tally(POLL_OUTCOME.NO_COUNT)}`);
 console.log(`failed:      ${tally(POLL_OUTCOME.FAILED)}`);
 process.exit(tally(POLL_OUTCOME.FAILED) > 0 ? 1 : 0);


### PR DESCRIPTION
Held-vs-total coverage needs a denominator, and only some publishers expose a cheap count. `case_law_sources` gains three nullable columns — `reported_total`, `reported_total_as_of`, `reported_total_origin` — so the number a publisher states is stored rather than recomputed on every ask.

Origin is a two-value union (`adapter-poll` / `operator`), not a boolean: a further provenance must be able to land as a new member. The three columns move together, all set or all null; that invariant belongs to the single writer (`ingestion/source-totals.ts`), which also rejects a total no publisher could state (zero, negative, non-integer), rather than to a check constraint.

`src/scripts/case-law-source-total.ts` drives it:

- `--list` prints what is recorded per source.
- `--adapter <key> --total <n> [--as-of <date>]` transcribes a publisher's own figure.
- `--poll [--adapter <key>]` probes the adapters that implement `getTotalCount` (concurrently, matching the `adapter-health.ts` precedent — each probe hits a different publisher host). A poll that yields no usable number records nothing and says so, so a failed probe cannot overwrite the last figure actually observed.

The admin ingestion-status payload carries the trio per source, so coverage inputs are readable without a database session.

Migration is additive only (`ADD COLUMN IF NOT EXISTS`, nullable, no defaults); squawk and the migration-safety checks pass. The new columns surfaced in two hand-built `satisfies`-pinned source-row fixtures, which were extended — those four duplicated row literals across two test files are a fixture-builder candidate for a follow-up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Case-law source statuses now include reported totals, the date they were observed, and their source.
  - Added tooling to view, record, and poll publishers for reported case-law totals.
  - Totals are validated as positive integers and may be attributed to an adapter poll or operator entry.

- **Bug Fixes**
  - Improved calendar-date validation for case-law data, including dates extracted from ISO date-times.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->