### PR TITLE
fix: scope document worker storage sessions

### DIFF
--- a/apps/api/src/lib/document-processing-queue.test.ts
+++ b/apps/api/src/lib/document-processing-queue.test.ts
@@ -126,9 +126,9 @@ describe("OCR derivative durability", () => {
 
     expect(stageStart).toBeGreaterThan(-1);
     for (const storageCall of [
-      "readS3ArrayBuffer(sourceKey, lifecycleSignal)",
+      "await readTenantS3ArrayBuffer(",
       "await createOcrSearchablePdf(",
-      "await getS3().write(",
+      "await writeTenantS3Object(",
     ]) {
       expect(stageSource).toContain(storageCall);
     }

--- a/apps/api/src/lib/document-processing-queue.ts
+++ b/apps/api/src/lib/document-processing-queue.ts
@@ -65,8 +65,11 @@ import {
   createRedisClient,
 } from "@/api/lib/redis-client";
 import { broadcastWorkspaceResourceUpdated } from "@/api/lib/resource-realtime";
-import { getS3, readS3ArrayBuffer } from "@/api/lib/s3";
-import { presignDownloadUrl } from "@/api/lib/s3-presign";
+import {
+  presignDownloadUrl,
+  readScopedS3ArrayBuffer,
+  writeScopedS3Object,
+} from "@/api/lib/s3-presign";
 import {
   executeNativeExtraction,
   requiresDurableNativeExtraction,
@@ -196,7 +199,15 @@ const writeOcrSearchablePdfDerivative = async ({
 }): Promise<void> => {
   const written = await Result.tryPromise({
     try: async () => {
-      const sourceBuffer = await readS3ArrayBuffer(sourceKey, lifecycleSignal);
+      const scope = {
+        organizationId: run.organizationId,
+        workspaceId: run.workspaceId,
+      };
+      const sourceBuffer = await readScopedS3ArrayBuffer({
+        key: sourceKey,
+        scope,
+        signal: lifecycleSignal,
+      });
       lifecycleSignal.throwIfAborted();
       const searchablePdf = await createOcrSearchablePdf(sourceBuffer, payload);
       if (Result.isError(searchablePdf)) {
@@ -204,15 +215,17 @@ const writeOcrSearchablePdfDerivative = async ({
       }
       lifecycleSignal.throwIfAborted();
 
-      await getS3().write(
-        createOcrSearchablePdfKey({
+      await writeScopedS3Object({
+        contentType: PDF_MIME_TYPE,
+        data: searchablePdf.value,
+        key: createOcrSearchablePdfKey({
           organizationId: run.organizationId,
           workspaceId: run.workspaceId,
           runId: run.id,
         }),
-        searchablePdf.value,
-        { type: PDF_MIME_TYPE },
-      );
+        scope,
+        signal: lifecycleSignal,
+      });
     },
     catch: (cause) => cause,
   });
@@ -1109,6 +1122,15 @@ export const processDocumentProcessingRun = async (
           const extractionOutcome = await executeNativeExtraction({
             fileField: source.content,
             lifecycleSignal,
+            readSource: async (key, signal) =>
+              await readScopedS3ArrayBuffer({
+                key,
+                scope: {
+                  organizationId: run.organizationId,
+                  workspaceId: run.workspaceId,
+                },
+                signal,
+              }),
             run,
           });
           switch (extractionOutcome) {

--- a/apps/api/src/lib/document-processing-queue.ts
+++ b/apps/api/src/lib/document-processing-queue.ts
@@ -67,8 +67,8 @@ import {
 import { broadcastWorkspaceResourceUpdated } from "@/api/lib/resource-realtime";
 import {
   presignDownloadUrl,
-  readScopedS3ArrayBuffer,
-  writeScopedS3Object,
+  readTenantS3ArrayBuffer,
+  writeTenantS3Object,
 } from "@/api/lib/s3-presign";
 import {
   executeNativeExtraction,
@@ -203,7 +203,7 @@ const writeOcrSearchablePdfDerivative = async ({
         organizationId: run.organizationId,
         workspaceId: run.workspaceId,
       };
-      const sourceBuffer = await readScopedS3ArrayBuffer({
+      const sourceBuffer = await readTenantS3ArrayBuffer({
         key: sourceKey,
         scope,
         signal: lifecycleSignal,
@@ -215,7 +215,7 @@ const writeOcrSearchablePdfDerivative = async ({
       }
       lifecycleSignal.throwIfAborted();
 
-      await writeScopedS3Object({
+      await writeTenantS3Object({
         contentType: PDF_MIME_TYPE,
         data: searchablePdf.value,
         key: createOcrSearchablePdfKey({
@@ -1123,7 +1123,7 @@ export const processDocumentProcessingRun = async (
             fileField: source.content,
             lifecycleSignal,
             readSource: async (key, signal) =>
-              await readScopedS3ArrayBuffer({
+              await readTenantS3ArrayBuffer({
                 key,
                 scope: {
                   organizationId: run.organizationId,

--- a/apps/api/src/lib/s3-presign.test.ts
+++ b/apps/api/src/lib/s3-presign.test.ts
@@ -9,7 +9,9 @@ import {
   isS3KeyInSigningScope,
   presignDownloadUrl,
   presignUploadUrl,
+  readScopedS3ArrayBuffer,
   resetAwsS3ClientForTesting,
+  writeScopedS3Object,
 } from "@/api/lib/s3-presign";
 
 const sha256Base64 = (data: string): string =>
@@ -214,6 +216,39 @@ describe("hasScopedSessionTimeForPresign", () => {
         now: 0,
       }),
     ).toBe(false);
+  });
+});
+
+describe("scoped object operations", () => {
+  const scope = {
+    organizationId: "org_1",
+    workspaceId: "ws_1",
+  } as const;
+
+  test("rejects a cross-workspace read before resolving credentials", async () => {
+    await expect(
+      readScopedS3ArrayBuffer({
+        key: "org_1/ws_2/file.pdf",
+        scope,
+        signal: new AbortController().signal,
+      }),
+    ).rejects.toMatchObject({
+      message: "S3 key is outside the requested signing scope",
+    });
+  });
+
+  test("rejects a cross-workspace write before resolving credentials", async () => {
+    await expect(
+      writeScopedS3Object({
+        contentType: "application/pdf",
+        data: new Uint8Array(),
+        key: "org_2/ws_1/derivative.pdf",
+        scope,
+        signal: new AbortController().signal,
+      }),
+    ).rejects.toMatchObject({
+      message: "S3 key is outside the requested signing scope",
+    });
   });
 });
 

--- a/apps/api/src/lib/s3-presign.test.ts
+++ b/apps/api/src/lib/s3-presign.test.ts
@@ -9,9 +9,9 @@ import {
   isS3KeyInSigningScope,
   presignDownloadUrl,
   presignUploadUrl,
-  readScopedS3ArrayBuffer,
+  readTenantS3ArrayBuffer,
   resetAwsS3ClientForTesting,
-  writeScopedS3Object,
+  writeTenantS3Object,
 } from "@/api/lib/s3-presign";
 
 const sha256Base64 = (data: string): string =>
@@ -227,7 +227,7 @@ describe("scoped object operations", () => {
 
   test("rejects a cross-workspace read before resolving credentials", async () => {
     await expect(
-      readScopedS3ArrayBuffer({
+      readTenantS3ArrayBuffer({
         key: "org_1/ws_2/file.pdf",
         scope,
         signal: new AbortController().signal,
@@ -239,7 +239,7 @@ describe("scoped object operations", () => {
 
   test("rejects a cross-workspace write before resolving credentials", async () => {
     await expect(
-      writeScopedS3Object({
+      writeTenantS3Object({
         contentType: "application/pdf",
         data: new Uint8Array(),
         key: "org_2/ws_1/derivative.pdf",

--- a/apps/api/src/lib/s3-presign.test.ts
+++ b/apps/api/src/lib/s3-presign.test.ts
@@ -13,6 +13,7 @@ import {
 import { getS3 } from "@/api/lib/s3";
 import {
   copyObject,
+  createTenantS3RequestSignal,
   hasScopedSessionTimeForPresign,
   headObject,
   isS3KeyInSigningScope,
@@ -253,6 +254,27 @@ describe("scoped object operations", () => {
 
   afterEach(() => {
     resetAwsS3ClientForTesting();
+  });
+
+  test("bounds tenant requests by caller cancellation and request timeout", async () => {
+    const controller = new AbortController();
+    const callerSignal = createTenantS3RequestSignal(controller.signal);
+    const callerReason = new Error("Caller cancelled");
+    controller.abort(callerReason);
+
+    expect(callerSignal.aborted).toBe(true);
+    expect(callerSignal.reason).toBe(callerReason);
+
+    const timeoutSignal = createTenantS3RequestSignal(
+      new AbortController().signal,
+      1,
+    );
+    await new Promise<void>((resolve) => {
+      timeoutSignal.addEventListener("abort", () => resolve(), { once: true });
+    });
+
+    expect(timeoutSignal.aborted).toBe(true);
+    expect(timeoutSignal.reason).toMatchObject({ name: "TimeoutError" });
   });
 
   test("executes an allowed tenant read with the requested key and signal", async () => {

--- a/apps/api/src/lib/s3-presign.test.ts
+++ b/apps/api/src/lib/s3-presign.test.ts
@@ -1,5 +1,14 @@
+import { S3Client as AwsS3Client } from "@aws-sdk/client-s3";
 import { Result } from "better-result";
-import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
 
 import { getS3 } from "@/api/lib/s3";
 import {
@@ -11,6 +20,7 @@ import {
   presignUploadUrl,
   readTenantS3ArrayBuffer,
   resetAwsS3ClientForTesting,
+  setTenantS3OperationHooksForTesting,
   writeTenantS3Object,
 } from "@/api/lib/s3-presign";
 
@@ -224,31 +234,106 @@ describe("scoped object operations", () => {
     organizationId: "org_1",
     workspaceId: "ws_1",
   } as const;
+  const client = new AwsS3Client({
+    credentials: {
+      accessKeyId: "test-access-key",
+      secretAccessKey: "test-secret-key",
+    },
+    region: "us-east-1",
+  });
+  const installHooks = () => {
+    const hooks = {
+      readObject: mock(async (_client, _command, _signal) => HELLO_BYTES),
+      resolveClient: mock(async () => client),
+      writeObject: mock(async (_client, _command, _signal) => undefined),
+    } satisfies Parameters<typeof setTenantS3OperationHooksForTesting>[0];
+    setTenantS3OperationHooksForTesting(hooks);
+    return hooks;
+  };
+
+  afterEach(() => {
+    resetAwsS3ClientForTesting();
+  });
+
+  test("executes an allowed tenant read with the requested key and signal", async () => {
+    const signal = new AbortController().signal;
+    const hooks = installHooks();
+
+    const result = await readTenantS3ArrayBuffer({
+      key: "org_1/ws_1/file.pdf",
+      scope,
+      signal,
+    });
+
+    expect(new Uint8Array(result)).toEqual(HELLO_BYTES);
+    expect(hooks.readObject).toHaveBeenCalledTimes(1);
+    const call = hooks.readObject.mock.calls.at(0);
+    expect(call?.at(0)).toBe(client);
+    expect(call?.at(1).input).toEqual({
+      Bucket: "stella",
+      Key: "org_1/ws_1/file.pdf",
+    });
+    expect(call?.at(2)).toBe(signal);
+  });
+
+  test("executes an allowed tenant write with the requested object and signal", async () => {
+    const signal = new AbortController().signal;
+    const hooks = installHooks();
+
+    await writeTenantS3Object({
+      contentType: "application/pdf",
+      data: HELLO_BYTES,
+      key: "org_1/ws_1/derivative.pdf",
+      scope,
+      signal,
+    });
+
+    expect(hooks.writeObject).toHaveBeenCalledTimes(1);
+    const call = hooks.writeObject.mock.calls.at(0);
+    expect(call?.at(0)).toBe(client);
+    expect(call?.at(1).input).toEqual({
+      Body: HELLO_BYTES,
+      Bucket: "stella",
+      ContentType: "application/pdf",
+      Key: "org_1/ws_1/derivative.pdf",
+    });
+    expect(call?.at(2)).toBe(signal);
+  });
 
   test("rejects a cross-workspace read before resolving credentials", async () => {
-    await expect(
-      readTenantS3ArrayBuffer({
-        key: "org_1/ws_2/file.pdf",
-        scope,
-        signal: new AbortController().signal,
-      }),
-    ).rejects.toMatchObject({
+    const hooks = installHooks();
+    const rejection = await readTenantS3ArrayBuffer({
+      key: "org_1/ws_2/file.pdf",
+      scope,
+      signal: new AbortController().signal,
+    }).then(
+      () => null,
+      (error: unknown) => error,
+    );
+
+    expect(rejection).toMatchObject({
       message: "S3 key is outside the requested signing scope",
     });
+    expect(hooks.resolveClient).not.toHaveBeenCalled();
   });
 
   test("rejects a cross-workspace write before resolving credentials", async () => {
-    await expect(
-      writeTenantS3Object({
-        contentType: "application/pdf",
-        data: new Uint8Array(),
-        key: "org_2/ws_1/derivative.pdf",
-        scope,
-        signal: new AbortController().signal,
-      }),
-    ).rejects.toMatchObject({
+    const hooks = installHooks();
+    const rejection = await writeTenantS3Object({
+      contentType: "application/pdf",
+      data: new Uint8Array(),
+      key: "org_2/ws_1/derivative.pdf",
+      scope,
+      signal: new AbortController().signal,
+    }).then(
+      () => null,
+      (error: unknown) => error,
+    );
+
+    expect(rejection).toMatchObject({
       message: "S3 key is outside the requested signing scope",
     });
+    expect(hooks.resolveClient).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/api/src/lib/s3-presign.ts
+++ b/apps/api/src/lib/s3-presign.ts
@@ -371,7 +371,7 @@ const getScopedAwsS3Client = async (
   return built.client;
 };
 
-const getRequiredScopedAwsS3Client = async ({
+const getTenantAwsS3Client = async ({
   actions,
   key,
   scope,
@@ -386,15 +386,13 @@ const getRequiredScopedAwsS3Client = async ({
     });
   }
   if (!shouldUseScopedSigning()) {
-    throw new S3PresignError({
-      message: "Scoped S3 access is not configured for this runtime",
-    });
+    return await getAwsS3Client();
   }
   return await getScopedAwsS3Client(scope, actions, 0);
 };
 
-/** Read an object through a required organization/workspace-scoped STS session. */
-export const readScopedS3ArrayBuffer = async ({
+/** Read an object after enforcing its organization/workspace key scope. */
+export const readTenantS3ArrayBuffer = async ({
   key,
   scope,
   signal,
@@ -403,7 +401,7 @@ export const readScopedS3ArrayBuffer = async ({
   scope: S3SigningScope;
   signal: AbortSignal;
 }): Promise<ArrayBuffer> => {
-  const client = await getRequiredScopedAwsS3Client({
+  const client = await getTenantAwsS3Client({
     actions: ["s3:GetObject"],
     key,
     scope,
@@ -429,8 +427,8 @@ export const readScopedS3ArrayBuffer = async ({
   return buffer;
 };
 
-/** Write an object through a required organization/workspace-scoped STS session. */
-export const writeScopedS3Object = async ({
+/** Write an object after enforcing its organization/workspace key scope. */
+export const writeTenantS3Object = async ({
   contentType,
   data,
   key,
@@ -443,7 +441,7 @@ export const writeScopedS3Object = async ({
   scope: S3SigningScope;
   signal: AbortSignal;
 }): Promise<void> => {
-  const client = await getRequiredScopedAwsS3Client({
+  const client = await getTenantAwsS3Client({
     actions: ["s3:PutObject"],
     key,
     scope,

--- a/apps/api/src/lib/s3-presign.ts
+++ b/apps/api/src/lib/s3-presign.ts
@@ -391,6 +391,45 @@ const getTenantAwsS3Client = async ({
   return await getScopedAwsS3Client(scope, actions, 0);
 };
 
+type TenantS3OperationHooks = {
+  resolveClient: typeof getTenantAwsS3Client;
+  readObject: (
+    client: AwsS3Client,
+    command: GetObjectCommand,
+    signal: AbortSignal,
+  ) => Promise<Uint8Array>;
+  writeObject: (
+    client: AwsS3Client,
+    command: PutObjectCommand,
+    signal: AbortSignal,
+  ) => Promise<void>;
+};
+
+const DEFAULT_TENANT_S3_OPERATION_HOOKS: TenantS3OperationHooks = {
+  resolveClient: getTenantAwsS3Client,
+  readObject: async (client, command, signal) => {
+    const response = await client.send(command, { abortSignal: signal });
+    if (!response.Body) {
+      throw new S3PresignError({
+        message: "S3 returned an object without a response body",
+      });
+    }
+    return await response.Body.transformToByteArray();
+  },
+  writeObject: async (client, command, signal) => {
+    await client.send(command, { abortSignal: signal });
+  },
+};
+
+let tenantS3OperationHooks = DEFAULT_TENANT_S3_OPERATION_HOOKS;
+
+/** Replace tenant-object I/O seams for unit tests. */
+export const setTenantS3OperationHooksForTesting = (
+  hooks: TenantS3OperationHooks,
+): void => {
+  tenantS3OperationHooks = hooks;
+};
+
 /** Read an object after enforcing its organization/workspace key scope. */
 export const readTenantS3ArrayBuffer = async ({
   key,
@@ -401,21 +440,21 @@ export const readTenantS3ArrayBuffer = async ({
   scope: S3SigningScope;
   signal: AbortSignal;
 }): Promise<ArrayBuffer> => {
-  const client = await getTenantAwsS3Client({
+  if (!isS3KeyInSigningScope(key, scope)) {
+    throw new S3PresignError({
+      message: "S3 key is outside the requested signing scope",
+    });
+  }
+  const client = await tenantS3OperationHooks.resolveClient({
     actions: ["s3:GetObject"],
     key,
     scope,
   });
-  const response = await client.send(
+  const bytes = await tenantS3OperationHooks.readObject(
+    client,
     new GetObjectCommand({ Bucket: envBase.S3_BUCKET, Key: key }),
-    { abortSignal: signal },
+    signal,
   );
-  if (!response.Body) {
-    throw new S3PresignError({
-      message: "S3 returned an object without a response body",
-    });
-  }
-  const bytes = await response.Body.transformToByteArray();
   if (bytes.buffer instanceof ArrayBuffer) {
     return bytes.buffer.slice(
       bytes.byteOffset,
@@ -441,19 +480,25 @@ export const writeTenantS3Object = async ({
   scope: S3SigningScope;
   signal: AbortSignal;
 }): Promise<void> => {
-  const client = await getTenantAwsS3Client({
+  if (!isS3KeyInSigningScope(key, scope)) {
+    throw new S3PresignError({
+      message: "S3 key is outside the requested signing scope",
+    });
+  }
+  const client = await tenantS3OperationHooks.resolveClient({
     actions: ["s3:PutObject"],
     key,
     scope,
   });
-  await client.send(
+  await tenantS3OperationHooks.writeObject(
+    client,
     new PutObjectCommand({
       Body: data,
       Bucket: envBase.S3_BUCKET,
       ContentType: contentType,
       Key: key,
     }),
-    { abortSignal: signal },
+    signal,
   );
 };
 
@@ -490,6 +535,7 @@ export const resetAwsS3ClientForTesting = (): void => {
   _clientPromise = null;
   _stsClientPromise = null;
   _scopedClientPromises = new Map();
+  tenantS3OperationHooks = DEFAULT_TENANT_S3_OPERATION_HOOKS;
 };
 
 /**

--- a/apps/api/src/lib/s3-presign.ts
+++ b/apps/api/src/lib/s3-presign.ts
@@ -405,10 +405,17 @@ type TenantS3OperationHooks = {
   ) => Promise<void>;
 };
 
+export const createTenantS3RequestSignal = (
+  signal: AbortSignal,
+  timeoutMs = AWS_SDK_REQUEST_TIMEOUT_MS,
+): AbortSignal => AbortSignal.any([signal, AbortSignal.timeout(timeoutMs)]);
+
 const DEFAULT_TENANT_S3_OPERATION_HOOKS: TenantS3OperationHooks = {
   resolveClient: getTenantAwsS3Client,
   readObject: async (client, command, signal) => {
-    const response = await client.send(command, { abortSignal: signal });
+    const response = await client.send(command, {
+      abortSignal: createTenantS3RequestSignal(signal),
+    });
     if (!response.Body) {
       throw new S3PresignError({
         message: "S3 returned an object without a response body",
@@ -417,7 +424,9 @@ const DEFAULT_TENANT_S3_OPERATION_HOOKS: TenantS3OperationHooks = {
     return await response.Body.transformToByteArray();
   },
   writeObject: async (client, command, signal) => {
-    await client.send(command, { abortSignal: signal });
+    await client.send(command, {
+      abortSignal: createTenantS3RequestSignal(signal),
+    });
   },
 };
 

--- a/apps/api/src/lib/s3-presign.ts
+++ b/apps/api/src/lib/s3-presign.ts
@@ -371,6 +371,94 @@ const getScopedAwsS3Client = async (
   return built.client;
 };
 
+const getRequiredScopedAwsS3Client = async ({
+  actions,
+  key,
+  scope,
+}: {
+  actions: readonly S3SigningAction[];
+  key: string;
+  scope: S3SigningScope;
+}): Promise<AwsS3Client> => {
+  if (!isS3KeyInSigningScope(key, scope)) {
+    throw new S3PresignError({
+      message: "S3 key is outside the requested signing scope",
+    });
+  }
+  if (!shouldUseScopedSigning()) {
+    throw new S3PresignError({
+      message: "Scoped S3 access is not configured for this runtime",
+    });
+  }
+  return await getScopedAwsS3Client(scope, actions, 0);
+};
+
+/** Read an object through a required organization/workspace-scoped STS session. */
+export const readScopedS3ArrayBuffer = async ({
+  key,
+  scope,
+  signal,
+}: {
+  key: string;
+  scope: S3SigningScope;
+  signal: AbortSignal;
+}): Promise<ArrayBuffer> => {
+  const client = await getRequiredScopedAwsS3Client({
+    actions: ["s3:GetObject"],
+    key,
+    scope,
+  });
+  const response = await client.send(
+    new GetObjectCommand({ Bucket: envBase.S3_BUCKET, Key: key }),
+    { abortSignal: signal },
+  );
+  if (!response.Body) {
+    throw new S3PresignError({
+      message: "S3 returned an object without a response body",
+    });
+  }
+  const bytes = await response.Body.transformToByteArray();
+  if (bytes.buffer instanceof ArrayBuffer) {
+    return bytes.buffer.slice(
+      bytes.byteOffset,
+      bytes.byteOffset + bytes.byteLength,
+    );
+  }
+  const buffer = new ArrayBuffer(bytes.byteLength);
+  new Uint8Array(buffer).set(bytes);
+  return buffer;
+};
+
+/** Write an object through a required organization/workspace-scoped STS session. */
+export const writeScopedS3Object = async ({
+  contentType,
+  data,
+  key,
+  scope,
+  signal,
+}: {
+  contentType: string;
+  data: Uint8Array;
+  key: string;
+  scope: S3SigningScope;
+  signal: AbortSignal;
+}): Promise<void> => {
+  const client = await getRequiredScopedAwsS3Client({
+    actions: ["s3:PutObject"],
+    key,
+    scope,
+  });
+  await client.send(
+    new PutObjectCommand({
+      Body: data,
+      Bucket: envBase.S3_BUCKET,
+      ContentType: contentType,
+      Key: key,
+    }),
+    { abortSignal: signal },
+  );
+};
+
 const getPresignClient = async ({
   actions,
   expiresIn,

--- a/apps/api/src/lib/search/process-extraction.test.ts
+++ b/apps/api/src/lib/search/process-extraction.test.ts
@@ -384,6 +384,49 @@ describe("processExtraction", () => {
     expect(getS3ObjectWithSignalMock).not.toHaveBeenCalled();
   });
 
+  test("propagates lifecycle cancellation to the caller-provided storage reader", async () => {
+    const controller = new AbortController();
+    const started = Promise.withResolvers<void>();
+    const observedSignals: AbortSignal[] = [];
+    const readSource = mock(async (_key: string, signal: AbortSignal) => {
+      observedSignals.push(signal);
+      started.resolve();
+      await new Promise<void>((_resolve, reject) => {
+        signal.addEventListener("abort", () => reject(signal.reason), {
+          once: true,
+        });
+      });
+      return new ArrayBuffer();
+    });
+
+    const extraction = executeNativeExtraction({
+      fileField: fileContent,
+      lifecycleSignal: controller.signal,
+      readSource,
+      run: {
+        entityId,
+        entityVersionId,
+        fieldId,
+        organizationId,
+        sourceFileId: fileContent.id,
+        sourceSha256Hex: fileContent.sha256Hex,
+        workspaceId,
+      },
+    });
+    await started.promise;
+    controller.abort("test cancellation");
+    const rejection = await extraction.then(
+      () => null,
+      (error: unknown) => error,
+    );
+
+    expect(observedSignals).toHaveLength(1);
+    expect(observedSignals.at(0)?.aborted).toBe(true);
+    expect(rejection).not.toBeNull();
+    expect(getS3ObjectWithSignalMock).not.toHaveBeenCalled();
+    expect(encryptContentMock).not.toHaveBeenCalled();
+  });
+
   test("restores manual OCR after native PDF extraction without automatic eligibility", async () => {
     const outcome = await executeNativeExtraction({
       fileField: fileContent,

--- a/apps/api/src/lib/search/process-extraction.test.ts
+++ b/apps/api/src/lib/search/process-extraction.test.ts
@@ -386,15 +386,19 @@ describe("processExtraction", () => {
 
   test("propagates lifecycle cancellation to the caller-provided storage reader", async () => {
     const controller = new AbortController();
-    const started = Promise.withResolvers<void>();
+    const started = Promise.withResolvers<undefined>();
     const observedSignals: AbortSignal[] = [];
     const readSource = mock(async (_key: string, signal: AbortSignal) => {
       observedSignals.push(signal);
-      started.resolve();
+      started.resolve(undefined);
       await new Promise<void>((_resolve, reject) => {
-        signal.addEventListener("abort", () => reject(signal.reason), {
-          once: true,
-        });
+        signal.addEventListener(
+          "abort",
+          () => reject(new Error("Storage read aborted")),
+          {
+            once: true,
+          },
+        );
       });
       return new ArrayBuffer();
     });

--- a/apps/api/src/lib/search/process-extraction.test.ts
+++ b/apps/api/src/lib/search/process-extraction.test.ts
@@ -359,6 +359,31 @@ describe("processExtraction", () => {
     expect(restoreManualOcrRunAfterProjectionLossMock).not.toHaveBeenCalled();
   });
 
+  test("reads native extraction input through the caller-provided storage scope", async () => {
+    const readSource = mock(async () => new ArrayBuffer(8));
+
+    await executeNativeExtraction({
+      fileField: fileContent,
+      lifecycleSignal: new AbortController().signal,
+      readSource,
+      run: {
+        entityId,
+        entityVersionId,
+        fieldId,
+        organizationId,
+        sourceFileId: fileContent.id,
+        sourceSha256Hex: fileContent.sha256Hex,
+        workspaceId,
+      },
+    });
+
+    expect(readSource).toHaveBeenCalledWith(
+      `${organizationId}/${workspaceId}/${fileContent.id}.pdf`,
+      expect.any(AbortSignal),
+    );
+    expect(getS3ObjectWithSignalMock).not.toHaveBeenCalled();
+  });
+
   test("restores manual OCR after native PDF extraction without automatic eligibility", async () => {
     const outcome = await executeNativeExtraction({
       fileField: fileContent,

--- a/apps/api/src/lib/search/process-extraction.ts
+++ b/apps/api/src/lib/search/process-extraction.ts
@@ -238,10 +238,12 @@ type NativeExtractionRun = Pick<
 export const executeNativeExtraction = async ({
   fileField,
   lifecycleSignal,
+  readSource = getS3ObjectWithSignal,
   run,
 }: {
   fileField: Extract<FieldContent, { type: "file" }>;
   lifecycleSignal: AbortSignal;
+  readSource?: (key: string, signal: AbortSignal) => Promise<ArrayBuffer>;
   run: NativeExtractionRun;
 }): Promise<NativeExtractionProjectionOutcome> => {
   const source = pickExtractionSource(fileField);
@@ -252,7 +254,7 @@ export const executeNativeExtraction = async ({
     mimeType: source.storageMimeType,
   });
   const buffer = await withTimeout(
-    async (signal) => await getS3ObjectWithSignal(key, signal),
+    async (signal) => await readSource(key, signal),
     {
       label: "native extraction source read",
       signal: lifecycleSignal,


### PR DESCRIPTION
## Summary

- require workspace-scoped STS sessions for document-worker object reads and OCR derivative writes
- inject the scoped reader into native extraction so the dedicated worker never falls back to its base task credentials
- reject cross-workspace object keys before resolving credentials

## Validation

- `bun test apps/api/src/lib/s3-presign.test.ts apps/api/src/lib/search/process-extraction.test.ts` (25 passed, 4 integration tests skipped without MinIO)
- `bun --filter @stll/api typecheck`
- affected code check, repository format check, i18n check, staged lint, and secret scan

CC on behalf of jan-kubica

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved document processing with organisation- and workspace-scoped storage access.
  - Prevented access to files outside the permitted scope.
  - Added cancellation support for storage operations.
  - Improved validation when retrieving document data.
  - Ensured native extraction uses the correct source and respects cancellation.

- **Tests**
  - Added coverage for scoped storage operations, rejected cross-scope access, cancellation, and native extraction handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->