### PR TITLE
feat(case-law): daemon poll of publisher-reported source totals

### DIFF
--- a/apps/legal-atlas-runner/src/runners/case-law-ingest.ts
+++ b/apps/legal-atlas-runner/src/runners/case-law-ingest.ts
@@ -19,7 +19,7 @@
 
 import { panic } from "better-result";
 
-import { caseLawIngestionEvents } from "@/api/db/schema";
+import { SOURCE_TOTAL_ORIGIN, caseLawIngestionEvents } from "@/api/db/schema";
 import { corpusStorageMode, envBase } from "@/api/env-base";
 import {
   hasResolvedCitations,
@@ -31,9 +31,16 @@ import {
   BACKFILL_STATUS,
   backfillCorpusIndex,
 } from "@/api/handlers/case-law/corpus-index";
-import { getAdapter } from "@/api/handlers/case-law/ingestion/adapters/adapter-registry";
+import {
+  getAdapter,
+  listAdapters,
+} from "@/api/handlers/case-law/ingestion/adapters/adapter-registry";
 import { runIngestionPipeline } from "@/api/handlers/case-law/ingestion/pipeline";
 import { runReconciliationWorkUnit } from "@/api/handlers/case-law/ingestion/reconciliation-engine";
+import {
+  readSourceReportedTotals,
+  setSourceReportedTotal,
+} from "@/api/handlers/case-law/ingestion/source-totals";
 import { backfillLegislationCorpusIndex } from "@/api/handlers/legislation/corpus-index";
 import { backfillLegislationSearchIndex } from "@/api/handlers/legislation/search-index";
 import { TimeoutError } from "@/api/lib/errors/tagged-errors";
@@ -99,6 +106,10 @@ import {
   SK_DOCUMENT_DRAIN_TIMING,
   runSkDocumentDrain,
 } from "./sk-document-drain";
+import {
+  SOURCE_TOTAL_POLL_TIMING,
+  runSourceTotalPoll,
+} from "./source-total-poll";
 
 const formatLogDetail = (detail: unknown): string => {
   if (detail === undefined) {
@@ -1528,6 +1539,43 @@ export const runCaseLawIngest = async (
     });
   })();
 
+  // Publisher-reported totals: the denominator held-vs-total coverage is
+  // measured against. Only some publishers expose a count; those adapters
+  // are asked here, and the rest keep the figure an operator recorded. The
+  // cadence is the recorded date rather than this loop's interval, so a
+  // deployment neither loses a cycle nor re-asks every publisher on boot.
+  const sourceTotalLoop = (async () => {
+    await runSourceTotalPoll({
+      adapters: listAdapters(),
+      isDraining,
+      now: Date.now,
+      readTotals: async () => await readSourceReportedTotals(ingestionDb),
+      recordTotal: async ({ adapterKey, asOf, total }) =>
+        await setSourceReportedTotal({
+          scopedDb: ingestionDb,
+          adapterKey,
+          total,
+          asOf,
+          origin: SOURCE_TOTAL_ORIGIN.ADAPTER_POLL,
+        }),
+      report: (summary) => {
+        logInfo(
+          `[source-totals] case_law.source_totals.polled ` +
+            `polled=${summary.polled} ` +
+            `recorded=${summary.recorded} ` +
+            `noCount=${summary.noCount} ` +
+            `failed=${summary.failed} ` +
+            `unknownSource=${summary.unknownSource} ` +
+            `lastErrorType=${summary.lastError === undefined ? "none" : errorTag(summary.lastError)}`,
+        );
+      },
+      sleep: async (ms) => {
+        await Bun.sleep(ms);
+      },
+      timing: SOURCE_TOTAL_POLL_TIMING,
+    });
+  })();
+
   await Promise.all([
     ...adapterLoops,
     healthLoop,
@@ -1538,6 +1586,7 @@ export const runCaseLawIngest = async (
     legislationCorpusIndexLoop,
     skDocumentLoop,
     reconciliationLoop,
+    sourceTotalLoop,
   ]);
   return 0;
 };

--- a/apps/legal-atlas-runner/src/runners/case-law-ingest.ts
+++ b/apps/legal-atlas-runner/src/runners/case-law-ingest.ts
@@ -31,10 +31,7 @@ import {
   BACKFILL_STATUS,
   backfillCorpusIndex,
 } from "@/api/handlers/case-law/corpus-index";
-import {
-  getAdapter,
-  listAdapters,
-} from "@/api/handlers/case-law/ingestion/adapters/adapter-registry";
+import { getAdapter } from "@/api/handlers/case-law/ingestion/adapters/adapter-registry";
 import { runIngestionPipeline } from "@/api/handlers/case-law/ingestion/pipeline";
 import { runReconciliationWorkUnit } from "@/api/handlers/case-law/ingestion/reconciliation-engine";
 import {
@@ -1542,11 +1539,26 @@ export const runCaseLawIngest = async (
   // Publisher-reported totals: the denominator held-vs-total coverage is
   // measured against. Only some publishers expose a count; those adapters
   // are asked here, and the rest keep the figure an operator recorded. The
-  // cadence is the recorded date rather than this loop's interval, so a
-  // deployment neither loses a cycle nor re-asks every publisher on boot.
+  // cadence is when a source was last recorded or asked, not this loop's
+  // interval, so a deployment neither loses a cycle nor re-asks every
+  // publisher on boot.
   const sourceTotalLoop = (async () => {
+    // The enabled set, not the registry: a poll is an external request like
+    // any other, so it must not reach a publisher an operator disabled, nor
+    // the adapter ALL_SOURCES holds back as not production-validated.
+    const pollableAdapters = SOURCES.flatMap(({ adapterKey }) => {
+      const adapter = getAdapter(adapterKey);
+      if (adapter === undefined) {
+        logError(
+          `[source-totals] No adapter registered for source ${adapterKey}`,
+        );
+        return [];
+      }
+      return [adapter];
+    });
+
     await runSourceTotalPoll({
-      adapters: listAdapters(),
+      adapters: pollableAdapters,
       isDraining,
       now: Date.now,
       readTotals: async () => await readSourceReportedTotals(ingestionDb),
@@ -1559,6 +1571,15 @@ export const runCaseLawIngest = async (
           origin: SOURCE_TOTAL_ORIGIN.ADAPTER_POLL,
         }),
       report: (summary) => {
+        // An adapter the sources table does not carry is registry drift: a
+        // number was read from a publisher and then had nowhere to go. That
+        // is a defect, not sweep noise, so it leaves a structured record of
+        // its own rather than a count inside the line below.
+        if (summary.unknownSource > 0) {
+          logger.error("case_law.source_totals.unknown_source", {
+            "caseLawSourceTotals.unknownSource": summary.unknownSource,
+          });
+        }
         logInfo(
           `[source-totals] case_law.source_totals.polled ` +
             `polled=${summary.polled} ` +

--- a/apps/legal-atlas-runner/src/runners/source-total-outcomes.test.ts
+++ b/apps/legal-atlas-runner/src/runners/source-total-outcomes.test.ts
@@ -15,7 +15,7 @@ import {
   SOURCE_TOTAL_POLL_OUTCOME,
   SOURCE_TOTAL_STALE_AFTER_MS,
   selectCountingAdapters,
-  selectStaleCountingAdapters,
+  selectDueCountingAdapters,
   tallySourceTotalPollOutcomes,
   type SourceTotalPollOutcome,
 } from "./source-total-outcomes";
@@ -37,6 +37,7 @@ const adapter = (
 
 const NOW = Date.UTC(2026, 7, 11, 12, 0, 0);
 const DAY_IN_MS = 24 * 60 * 60 * 1000;
+const NEVER_ASKED: ReadonlyMap<string, number> = new Map();
 
 const recorded = (
   adapterKey: SourceAdapter["key"],
@@ -70,7 +71,7 @@ describe("selectCountingAdapters", () => {
 const czUs = adapter(ADAPTER_KEYS.CZ_US, async () => 1);
 const czRegional = adapter(ADAPTER_KEYS.CZ_REGIONAL, async () => 2);
 
-describe("selectStaleCountingAdapters", () => {
+describe("selectDueCountingAdapters", () => {
   const capable = [czUs, czRegional];
 
   test("a restart does not re-ask a publisher that answered recently", () => {
@@ -82,8 +83,9 @@ describe("selectStaleCountingAdapters", () => {
     ];
 
     expect(
-      selectStaleCountingAdapters({
+      selectDueCountingAdapters({
         adapters: capable,
+        askedAt: NEVER_ASKED,
         now: NOW,
         staleAfterMs: SOURCE_TOTAL_STALE_AFTER_MS,
         totals,
@@ -98,8 +100,9 @@ describe("selectStaleCountingAdapters", () => {
     ];
 
     expect(
-      selectStaleCountingAdapters({
+      selectDueCountingAdapters({
         adapters: capable,
+        askedAt: NEVER_ASKED,
         now: NOW,
         staleAfterMs: SOURCE_TOTAL_STALE_AFTER_MS,
         totals,
@@ -111,8 +114,9 @@ describe("selectStaleCountingAdapters", () => {
     const totals = [recorded(ADAPTER_KEYS.CZ_US, null)];
 
     expect(
-      selectStaleCountingAdapters({
+      selectDueCountingAdapters({
         adapters: capable,
+        askedAt: NEVER_ASKED,
         now: NOW,
         staleAfterMs: SOURCE_TOTAL_STALE_AFTER_MS,
         totals,
@@ -122,8 +126,9 @@ describe("selectStaleCountingAdapters", () => {
 
   test("a stale total on an adapter that cannot count is not asked", () => {
     expect(
-      selectStaleCountingAdapters({
+      selectDueCountingAdapters({
         adapters: [adapter(ADAPTER_KEYS.CZ_NS)],
+        askedAt: NEVER_ASKED,
         now: NOW,
         staleAfterMs: SOURCE_TOTAL_STALE_AFTER_MS,
         totals: [recorded(ADAPTER_KEYS.CZ_NS, null)],
@@ -131,10 +136,50 @@ describe("selectStaleCountingAdapters", () => {
     ).toEqual([]);
   });
 
+  test("a source asked recently is not asked again, whatever it answered", () => {
+    // `getTotalCount` returns null both for a publisher exposing no count
+    // and for a request that failed, and neither persists a date. Gating on
+    // the recorded date alone would re-ask those sources every wake, hours
+    // apart, which no failure surfaces.
+    expect(
+      selectDueCountingAdapters({
+        adapters: capable,
+        askedAt: new Map([
+          [ADAPTER_KEYS.CZ_US, NOW - DAY_IN_MS],
+          [ADAPTER_KEYS.CZ_REGIONAL, NOW - SOURCE_TOTAL_STALE_AFTER_MS],
+        ]),
+        now: NOW,
+        staleAfterMs: SOURCE_TOTAL_STALE_AFTER_MS,
+        totals: [
+          recorded(ADAPTER_KEYS.CZ_US, null),
+          recorded(ADAPTER_KEYS.CZ_REGIONAL, null),
+        ],
+      }).map(({ key }) => key),
+    ).toEqual([ADAPTER_KEYS.CZ_REGIONAL]);
+  });
+
+  test("a recorded total still gates a source this process never asked", () => {
+    // The ask memory is per process; a restart must not undo the cadence a
+    // recorded date already proves.
+    expect(
+      selectDueCountingAdapters({
+        adapters: capable,
+        askedAt: NEVER_ASKED,
+        now: NOW,
+        staleAfterMs: SOURCE_TOTAL_STALE_AFTER_MS,
+        totals: [
+          recorded(ADAPTER_KEYS.CZ_US, new Date(NOW - DAY_IN_MS)),
+          recorded(ADAPTER_KEYS.CZ_REGIONAL, new Date(NOW - DAY_IN_MS)),
+        ],
+      }),
+    ).toEqual([]);
+  });
+
   test("a total dated ahead of the clock reads as fresh, not overdue", () => {
     expect(
-      selectStaleCountingAdapters({
+      selectDueCountingAdapters({
         adapters: [czUs],
+        askedAt: NEVER_ASKED,
         now: NOW,
         staleAfterMs: SOURCE_TOTAL_STALE_AFTER_MS,
         totals: [recorded(ADAPTER_KEYS.CZ_US, new Date(NOW + DAY_IN_MS))],

--- a/apps/legal-atlas-runner/src/runners/source-total-outcomes.test.ts
+++ b/apps/legal-atlas-runner/src/runners/source-total-outcomes.test.ts
@@ -1,0 +1,200 @@
+/**
+ * The gate decides who is asked, and both ways of getting it wrong are
+ * quiet: asking every publisher on every restart looks like a healthy
+ * sweep, and asking nobody looks like a corpus whose totals never change.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { SOURCE_TOTAL_ORIGIN } from "@/api/db/schema";
+import type { SourceReportedTotal } from "@/api/handlers/case-law/ingestion/source-totals";
+import { ADAPTER_KEYS } from "@/api/lib/legal-search/ingestion-constants";
+import type { SourceAdapter } from "@/api/lib/legal-search/ingestion-types";
+
+import {
+  SOURCE_TOTAL_POLL_OUTCOME,
+  SOURCE_TOTAL_STALE_AFTER_MS,
+  selectCountingAdapters,
+  selectStaleCountingAdapters,
+  tallySourceTotalPollOutcomes,
+  type SourceTotalPollOutcome,
+} from "./source-total-outcomes";
+
+const adapter = (
+  key: SourceAdapter["key"],
+  getTotalCount?: SourceAdapter["getTotalCount"],
+): SourceAdapter => ({
+  key,
+  name: `${key} fixture`,
+  country: "CZ",
+  language: "cs",
+  minRequestIntervalMs: 1000,
+  fetchPage: () => {
+    throw new Error("fetchPage is not exercised by outcome selection");
+  },
+  ...(getTotalCount && { getTotalCount }),
+});
+
+const NOW = Date.UTC(2026, 7, 11, 12, 0, 0);
+const DAY_IN_MS = 24 * 60 * 60 * 1000;
+
+const recorded = (
+  adapterKey: SourceAdapter["key"],
+  reportedTotalAsOf: Date | null,
+): SourceReportedTotal => ({
+  adapterKey,
+  reportedTotal: reportedTotalAsOf === null ? null : 1234,
+  reportedTotalAsOf,
+  reportedTotalOrigin:
+    reportedTotalAsOf === null ? null : SOURCE_TOTAL_ORIGIN.ADAPTER_POLL,
+});
+
+describe("selectCountingAdapters", () => {
+  test("asks by capability, so a new implementer joins on its own", () => {
+    const counting = adapter(ADAPTER_KEYS.CZ_US, async () => 42);
+    const alsoCounting = adapter(ADAPTER_KEYS.PL_COURTS, async () => null);
+    const silent = adapter(ADAPTER_KEYS.CZ_NS);
+
+    expect(
+      selectCountingAdapters([counting, silent, alsoCounting]).map(
+        ({ key }) => key,
+      ),
+    ).toEqual([ADAPTER_KEYS.CZ_US, ADAPTER_KEYS.PL_COURTS]);
+  });
+
+  test("an adapter stating no count is never probed", () => {
+    expect(selectCountingAdapters([adapter(ADAPTER_KEYS.CZ_NS)])).toEqual([]);
+  });
+});
+
+const czUs = adapter(ADAPTER_KEYS.CZ_US, async () => 1);
+const czRegional = adapter(ADAPTER_KEYS.CZ_REGIONAL, async () => 2);
+
+describe("selectStaleCountingAdapters", () => {
+  const capable = [czUs, czRegional];
+
+  test("a restart does not re-ask a publisher that answered recently", () => {
+    // The defect this pins: a wake-interval timer would poll every
+    // publisher on every deployment, which no failure surfaces.
+    const totals = [
+      recorded(ADAPTER_KEYS.CZ_US, new Date(NOW - DAY_IN_MS)),
+      recorded(ADAPTER_KEYS.CZ_REGIONAL, new Date(NOW - 5 * DAY_IN_MS)),
+    ];
+
+    expect(
+      selectStaleCountingAdapters({
+        adapters: capable,
+        now: NOW,
+        staleAfterMs: SOURCE_TOTAL_STALE_AFTER_MS,
+        totals,
+      }),
+    ).toEqual([]);
+  });
+
+  test("a total older than the window is asked again", () => {
+    const totals = [
+      recorded(ADAPTER_KEYS.CZ_US, new Date(NOW - SOURCE_TOTAL_STALE_AFTER_MS)),
+      recorded(ADAPTER_KEYS.CZ_REGIONAL, new Date(NOW - DAY_IN_MS)),
+    ];
+
+    expect(
+      selectStaleCountingAdapters({
+        adapters: capable,
+        now: NOW,
+        staleAfterMs: SOURCE_TOTAL_STALE_AFTER_MS,
+        totals,
+      }).map(({ key }) => key),
+    ).toEqual([ADAPTER_KEYS.CZ_US]);
+  });
+
+  test("a source never measured, and one with no row at all, are both asked", () => {
+    const totals = [recorded(ADAPTER_KEYS.CZ_US, null)];
+
+    expect(
+      selectStaleCountingAdapters({
+        adapters: capable,
+        now: NOW,
+        staleAfterMs: SOURCE_TOTAL_STALE_AFTER_MS,
+        totals,
+      }).map(({ key }) => key),
+    ).toEqual([ADAPTER_KEYS.CZ_US, ADAPTER_KEYS.CZ_REGIONAL]);
+  });
+
+  test("a stale total on an adapter that cannot count is not asked", () => {
+    expect(
+      selectStaleCountingAdapters({
+        adapters: [adapter(ADAPTER_KEYS.CZ_NS)],
+        now: NOW,
+        staleAfterMs: SOURCE_TOTAL_STALE_AFTER_MS,
+        totals: [recorded(ADAPTER_KEYS.CZ_NS, null)],
+      }),
+    ).toEqual([]);
+  });
+
+  test("a total dated ahead of the clock reads as fresh, not overdue", () => {
+    expect(
+      selectStaleCountingAdapters({
+        adapters: [czUs],
+        now: NOW,
+        staleAfterMs: SOURCE_TOTAL_STALE_AFTER_MS,
+        totals: [recorded(ADAPTER_KEYS.CZ_US, new Date(NOW + DAY_IN_MS))],
+      }),
+    ).toEqual([]);
+  });
+});
+
+describe("tallySourceTotalPollOutcomes", () => {
+  test("every declared outcome lands in exactly one counter", () => {
+    // Both directions: an outcome the tally forgot would leave the sweep
+    // uncounted, and a counter no outcome reaches would report a number
+    // nothing can produce.
+    const declared = Object.values(SOURCE_TOTAL_POLL_OUTCOME);
+
+    const counted = declared.map((outcome) => {
+      const { polled, ...counters } = tallySourceTotalPollOutcomes([outcome]);
+      expect(polled).toBe(1);
+      return Object.entries(counters).filter(([, count]) => count === 1);
+    });
+
+    expect(counted.map((entries) => entries.length)).toEqual(
+      declared.map(() => 1),
+    );
+    expect(new Set(counted.map((entries) => entries.at(0)?.at(0))).size).toBe(
+      declared.length,
+    );
+  });
+
+  test("the counters account for every polled source", () => {
+    const outcomes: SourceTotalPollOutcome[] = [
+      SOURCE_TOTAL_POLL_OUTCOME.RECORDED,
+      SOURCE_TOTAL_POLL_OUTCOME.RECORDED,
+      SOURCE_TOTAL_POLL_OUTCOME.NO_COUNT,
+      SOURCE_TOTAL_POLL_OUTCOME.FAILED,
+      SOURCE_TOTAL_POLL_OUTCOME.UNKNOWN_SOURCE,
+      SOURCE_TOTAL_POLL_OUTCOME.FAILED,
+    ];
+
+    const tally = tallySourceTotalPollOutcomes(outcomes);
+
+    expect(tally).toEqual({
+      polled: 6,
+      recorded: 2,
+      noCount: 1,
+      failed: 2,
+      unknownSource: 1,
+    });
+    expect(
+      tally.recorded + tally.noCount + tally.failed + tally.unknownSource,
+    ).toBe(tally.polled);
+  });
+
+  test("an empty sweep reports zero polled, not an absent number", () => {
+    expect(tallySourceTotalPollOutcomes([])).toEqual({
+      polled: 0,
+      recorded: 0,
+      noCount: 0,
+      failed: 0,
+      unknownSource: 0,
+    });
+  });
+});

--- a/apps/legal-atlas-runner/src/runners/source-total-outcomes.ts
+++ b/apps/legal-atlas-runner/src/runners/source-total-outcomes.ts
@@ -34,9 +34,15 @@ export const SOURCE_TOTAL_POLL_OUTCOME = {
   /** The publisher stated a number and it is now the recorded total. */
   RECORDED: "recorded",
   /**
-   * The publisher exposes no readable count, which `getTotalCount` reports as
-   * null. Not a failure: a sweep over sources that never state a total would
-   * otherwise always end in one.
+   * The adapter yielded no number. `SourceAdapter.getTotalCount` returns null
+   * both for a publisher that exposes no readable count and for a request
+   * that failed, and the contract keeps no way to tell them apart, so this
+   * cannot mean "the publisher states no total" — only that none was read.
+   *
+   * Not tallied as a failure: several publishers permanently expose no count,
+   * and a sweep over them would otherwise always end in one. What keeps a
+   * source that never answers from being re-asked every wake is the ask
+   * gate below, not this classification.
    */
   NO_COUNT: "no-count",
   /** The probe or the write did not complete. Nothing was recorded. */
@@ -75,8 +81,10 @@ export const selectCountingAdapters = (
       adapter.getTotalCount !== undefined,
   );
 
-type SelectStaleCountingAdaptersOptions = {
+type SelectDueCountingAdaptersOptions = {
   adapters: readonly SourceAdapter[];
+  /** When this process last asked each adapter, whatever it answered. */
+  askedAt: ReadonlyMap<string, number>;
   /** The sweep's clock, in ms. */
   now: number;
   staleAfterMs: number;
@@ -84,19 +92,27 @@ type SelectStaleCountingAdaptersOptions = {
 };
 
 /**
- * The adapters to ask on this wake: those that can answer and whose recorded
- * total is missing or old enough.
+ * The adapters to ask on this wake: those that can answer, and that have
+ * neither been recorded nor asked inside the window.
+ *
+ * The gate is the last ask, not the last success. A publisher that exposes
+ * no count and one whose request failed both come back as null and persist
+ * nothing, so a gate on the recorded date alone would ask them again every
+ * wake — hours apart rather than the window this loop exists to keep. The
+ * ask memory is per process, so a deployment costs one extra attempt for
+ * those sources and none for a source that answered.
  *
  * A source carrying no row and one never measured are the same case, so both
- * are asked. A total dated in the future (a clock that ran backwards, an
+ * are asked. A date ahead of the clock (a clock that ran backwards, an
  * operator's forward-dated figure) reads as fresh rather than as overdue.
  */
-export const selectStaleCountingAdapters = ({
+export const selectDueCountingAdapters = ({
   adapters,
+  askedAt,
   now,
   staleAfterMs,
   totals,
-}: SelectStaleCountingAdaptersOptions): CountingSourceAdapter[] => {
+}: SelectDueCountingAdaptersOptions): CountingSourceAdapter[] => {
   const recordedAt = new Map(
     totals.map(({ adapterKey, reportedTotalAsOf }) => [
       adapterKey,
@@ -105,8 +121,12 @@ export const selectStaleCountingAdapters = ({
   );
 
   return selectCountingAdapters(adapters).filter((adapter) => {
-    const asOf = recordedAt.get(adapter.key) ?? null;
-    return asOf === null || now - asOf.getTime() >= staleAfterMs;
+    const recorded = recordedAt.get(adapter.key)?.getTime();
+    const asked = askedAt.get(adapter.key);
+    // The later of the two is what the window runs from: a recorded total
+    // proves the publisher answered, an ask proves it was given the chance.
+    const lastTouched = Math.max(recorded ?? -1, asked ?? -1);
+    return lastTouched < 0 || now - lastTouched >= staleAfterMs;
   });
 };
 

--- a/apps/legal-atlas-runner/src/runners/source-total-outcomes.ts
+++ b/apps/legal-atlas-runner/src/runners/source-total-outcomes.ts
@@ -1,0 +1,153 @@
+/**
+ * Which sources a totals sweep should ask, and how the answers are counted.
+ *
+ * Kept free of the runner's DB, clock and process imports so the selection
+ * and the arithmetic can be exercised on their own: the loop owns the I/O,
+ * this module owns the decisions.
+ */
+
+import { panic } from "better-result";
+
+import type { SourceReportedTotal } from "@/api/handlers/case-law/ingestion/source-totals";
+import type { SourceAdapter } from "@/api/lib/legal-search/ingestion-types";
+
+/**
+ * A plain 24-hour day. The window below is an elapsed duration, not
+ * calendar arithmetic, so no DST-aware helper applies. Spelled out here
+ * rather than taken from `@stll/time`, which this package does not depend
+ * on.
+ */
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * How old a recorded total may be before its source is asked again.
+ *
+ * The gate is the recorded date, not an in-process timer, so a restart
+ * neither loses the cadence nor repeats the sweep: a deployment an hour
+ * after a poll finds every total fresh and asks nobody. Set below the
+ * effective weekly cadence it produces, so a wake that lands slightly early
+ * still refreshes rather than deferring a whole extra interval.
+ */
+export const SOURCE_TOTAL_STALE_AFTER_MS = 6 * DAY_MS;
+
+export const SOURCE_TOTAL_POLL_OUTCOME = {
+  /** The publisher stated a number and it is now the recorded total. */
+  RECORDED: "recorded",
+  /**
+   * The publisher exposes no readable count, which `getTotalCount` reports as
+   * null. Not a failure: a sweep over sources that never state a total would
+   * otherwise always end in one.
+   */
+  NO_COUNT: "no-count",
+  /** The probe or the write did not complete. Nothing was recorded. */
+  FAILED: "failed",
+  /** The adapter has no source row: registry drift, never silent. */
+  UNKNOWN_SOURCE: "unknown-source",
+} as const;
+
+export type SourceTotalPollOutcome =
+  (typeof SOURCE_TOTAL_POLL_OUTCOME)[keyof typeof SOURCE_TOTAL_POLL_OUTCOME];
+
+export type SourceTotalPollTally = {
+  polled: number;
+  recorded: number;
+  noCount: number;
+  failed: number;
+  unknownSource: number;
+};
+
+/** An adapter whose publisher exposes a count it can read. */
+export type CountingSourceAdapter = SourceAdapter & {
+  getTotalCount: NonNullable<SourceAdapter["getTotalCount"]>;
+};
+
+/**
+ * The adapters worth asking at all, by capability rather than by name. An
+ * adapter that starts implementing `getTotalCount` joins the sweep on its
+ * own; a hand-kept list would leave it out and report nothing about the
+ * omission.
+ */
+export const selectCountingAdapters = (
+  adapters: readonly SourceAdapter[],
+): CountingSourceAdapter[] =>
+  adapters.filter(
+    (adapter): adapter is CountingSourceAdapter =>
+      adapter.getTotalCount !== undefined,
+  );
+
+type SelectStaleCountingAdaptersOptions = {
+  adapters: readonly SourceAdapter[];
+  /** The sweep's clock, in ms. */
+  now: number;
+  staleAfterMs: number;
+  totals: readonly SourceReportedTotal[];
+};
+
+/**
+ * The adapters to ask on this wake: those that can answer and whose recorded
+ * total is missing or old enough.
+ *
+ * A source carrying no row and one never measured are the same case, so both
+ * are asked. A total dated in the future (a clock that ran backwards, an
+ * operator's forward-dated figure) reads as fresh rather than as overdue.
+ */
+export const selectStaleCountingAdapters = ({
+  adapters,
+  now,
+  staleAfterMs,
+  totals,
+}: SelectStaleCountingAdaptersOptions): CountingSourceAdapter[] => {
+  const recordedAt = new Map(
+    totals.map(({ adapterKey, reportedTotalAsOf }) => [
+      adapterKey,
+      reportedTotalAsOf,
+    ]),
+  );
+
+  return selectCountingAdapters(adapters).filter((adapter) => {
+    const asOf = recordedAt.get(adapter.key) ?? null;
+    return asOf === null || now - asOf.getTime() >= staleAfterMs;
+  });
+};
+
+/** Count a sweep. Every outcome lands in exactly one counter. */
+export const tallySourceTotalPollOutcomes = (
+  outcomes: readonly SourceTotalPollOutcome[],
+): SourceTotalPollTally => {
+  const tally: SourceTotalPollTally = {
+    polled: outcomes.length,
+    recorded: 0,
+    noCount: 0,
+    failed: 0,
+    unknownSource: 0,
+  };
+
+  for (const outcome of outcomes) {
+    switch (outcome) {
+      case SOURCE_TOTAL_POLL_OUTCOME.RECORDED: {
+        tally.recorded += 1;
+        break;
+      }
+      case SOURCE_TOTAL_POLL_OUTCOME.NO_COUNT: {
+        tally.noCount += 1;
+        break;
+      }
+      case SOURCE_TOTAL_POLL_OUTCOME.FAILED: {
+        tally.failed += 1;
+        break;
+      }
+      case SOURCE_TOTAL_POLL_OUTCOME.UNKNOWN_SOURCE: {
+        tally.unknownSource += 1;
+        break;
+      }
+      default: {
+        const exhaustive: never = outcome;
+        return panic(
+          `unhandled source-total poll outcome: ${JSON.stringify(exhaustive)}`,
+        );
+      }
+    }
+  }
+
+  return tally;
+};

--- a/apps/legal-atlas-runner/src/runners/source-total-poll.test.ts
+++ b/apps/legal-atlas-runner/src/runners/source-total-poll.test.ts
@@ -1,0 +1,281 @@
+/**
+ * A sweep that records the wrong thing is silent: a failed probe stored as
+ * a total looks exactly like a publisher whose corpus shrank, and a sweep
+ * that stops after one failure looks exactly like a corpus already fresh.
+ * Both are pinned here, along with the gate that keeps a restart from
+ * re-asking every publisher.
+ *
+ * Waits are sliced to stay interruptible, so assertions read the summed gap
+ * between sweeps, never individual sleeps.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { SOURCE_TOTAL_ORIGIN } from "@/api/db/schema";
+import type { SourceReportedTotal } from "@/api/handlers/case-law/ingestion/source-totals";
+import { ADAPTER_KEYS } from "@/api/lib/legal-search/ingestion-constants";
+import type { SourceAdapter } from "@/api/lib/legal-search/ingestion-types";
+
+import {
+  type RecordSourceTotalOptions,
+  type SourceTotalPollSummary,
+  type SourceTotalPollTiming,
+  runSourceTotalPoll,
+} from "./source-total-poll";
+
+const DAY_IN_MS = 24 * 60 * 60 * 1000;
+
+const TIMING = {
+  wakeIntervalMs: 4000,
+  staleAfterMs: 6 * DAY_IN_MS,
+  probeTimeoutMs: 1000,
+} as const satisfies SourceTotalPollTiming;
+
+const NOW = Date.UTC(2026, 7, 11, 12, 0, 0);
+
+const adapter = (
+  key: SourceAdapter["key"],
+  getTotalCount?: SourceAdapter["getTotalCount"],
+): SourceAdapter => ({
+  key,
+  name: `${key} fixture`,
+  country: "CZ",
+  language: "cs",
+  minRequestIntervalMs: 1000,
+  fetchPage: () => {
+    throw new Error("fetchPage is not exercised by the poll");
+  },
+  ...(getTotalCount && { getTotalCount }),
+});
+
+const unmeasured = (adapterKey: SourceAdapter["key"]): SourceReportedTotal => ({
+  adapterKey,
+  reportedTotal: null,
+  reportedTotalAsOf: null,
+  reportedTotalOrigin: null,
+});
+
+const measuredAt = (
+  adapterKey: SourceAdapter["key"],
+  reportedTotalAsOf: Date,
+): SourceReportedTotal => ({
+  adapterKey,
+  reportedTotal: 10,
+  reportedTotalAsOf,
+  reportedTotalOrigin: SOURCE_TOTAL_ORIGIN.ADAPTER_POLL,
+});
+
+type HarnessOptions = {
+  adapters: readonly SourceAdapter[];
+  readTotals?: () => Promise<readonly SourceReportedTotal[]>;
+  recordTotal?: (options: RecordSourceTotalOptions) => Promise<boolean>;
+  /** Sweeps to run before the harness drains. */
+  sweeps: number;
+  totals?: readonly SourceReportedTotal[];
+};
+
+type HarnessResult = {
+  reports: SourceTotalPollSummary[];
+  slept: number[];
+  written: RecordSourceTotalOptions[];
+};
+
+/**
+ * Run the loop for a fixed number of sweeps, then drain. The clock only
+ * advances through the sleeps the loop itself asks for, so the drain lands
+ * between sweeps rather than inside one, and the staleness gate sees
+ * exactly the time the pacing produced.
+ */
+const runHarness = async ({
+  adapters,
+  readTotals,
+  recordTotal,
+  sweeps,
+  totals = [],
+}: HarnessOptions): Promise<HarnessResult> => {
+  const reports: SourceTotalPollSummary[] = [];
+  const slept: number[] = [];
+  const written: RecordSourceTotalOptions[] = [];
+  const drainAt = NOW + sweeps * TIMING.wakeIntervalMs;
+  let clock = NOW;
+
+  await runSourceTotalPoll({
+    adapters,
+    isDraining: () => clock >= drainAt,
+    now: () => clock,
+    readTotals: readTotals ?? (async () => totals),
+    recordTotal:
+      recordTotal ??
+      (async (options) => {
+        written.push(options);
+        return true;
+      }),
+    report: (summary) => {
+      reports.push(summary);
+    },
+    sleep: async (ms) => {
+      slept.push(ms);
+      clock += ms;
+    },
+    timing: TIMING,
+  });
+
+  return { reports, slept, written };
+};
+
+describe("runSourceTotalPoll", () => {
+  test("records what a publisher states, once, and stays quiet while it is fresh", async () => {
+    const { reports, slept, written } = await runHarness({
+      adapters: [adapter(ADAPTER_KEYS.CZ_US, async () => 8000)],
+      sweeps: 3,
+      totals: [unmeasured(ADAPTER_KEYS.CZ_US)],
+    });
+
+    // The read answers "never measured" on every wake, so every sweep is due
+    // and every sweep writes: what the gate does with a recorded date is
+    // pinned by the fresh-total case below.
+    expect(written).toHaveLength(3);
+    expect(written.at(0)).toEqual({
+      adapterKey: ADAPTER_KEYS.CZ_US,
+      asOf: new Date(NOW),
+      total: 8000,
+    });
+    expect(reports.at(0)).toEqual({
+      polled: 1,
+      recorded: 1,
+      noCount: 0,
+      failed: 0,
+      unknownSource: 0,
+      lastError: undefined,
+    });
+    // Sliced pacing: the gap between sweeps is the interval, not one sleep.
+    expect(slept.reduce((sum, ms) => sum + ms, 0)).toBe(
+      TIMING.wakeIntervalMs * reports.length,
+    );
+  });
+
+  test("a fresh total asks nobody and reports nothing", async () => {
+    const { reports, written } = await runHarness({
+      adapters: [adapter(ADAPTER_KEYS.CZ_US, async () => 8000)],
+      sweeps: 2,
+      totals: [measuredAt(ADAPTER_KEYS.CZ_US, new Date(NOW - DAY_IN_MS))],
+    });
+
+    expect(written).toEqual([]);
+    expect(reports).toEqual([]);
+  });
+
+  test("a probe that fails or states no count records nothing", async () => {
+    const { reports, written } = await runHarness({
+      adapters: [
+        adapter(ADAPTER_KEYS.CZ_US, async () => {
+          throw new Error("publisher unreachable");
+        }),
+        adapter(ADAPTER_KEYS.CZ_REGIONAL, async () => null),
+      ],
+      sweeps: 1,
+      totals: [
+        unmeasured(ADAPTER_KEYS.CZ_US),
+        unmeasured(ADAPTER_KEYS.CZ_REGIONAL),
+      ],
+    });
+
+    // The stored total is the last figure a publisher actually stated; a
+    // failed probe is not evidence that it changed.
+    expect(written).toEqual([]);
+    expect(reports.at(0)).toMatchObject({
+      polled: 2,
+      recorded: 0,
+      noCount: 1,
+      failed: 1,
+      unknownSource: 0,
+    });
+    expect(reports.at(0)?.lastError).toBeInstanceOf(Error);
+  });
+
+  test("one publisher's failure does not lose another's answer", async () => {
+    const { reports, written } = await runHarness({
+      adapters: [
+        adapter(ADAPTER_KEYS.CZ_US, async () => {
+          throw new Error("publisher unreachable");
+        }),
+        adapter(ADAPTER_KEYS.CZ_REGIONAL, async () => 4321),
+      ],
+      sweeps: 1,
+      totals: [
+        unmeasured(ADAPTER_KEYS.CZ_US),
+        unmeasured(ADAPTER_KEYS.CZ_REGIONAL),
+      ],
+    });
+
+    expect(written.map(({ adapterKey }) => adapterKey)).toEqual([
+      ADAPTER_KEYS.CZ_REGIONAL,
+    ]);
+    expect(reports.at(0)).toMatchObject({ recorded: 1, failed: 1 });
+  });
+
+  test("a write rejection is counted, not thrown, and the loop continues", async () => {
+    const { reports } = await runHarness({
+      adapters: [adapter(ADAPTER_KEYS.CZ_US, async () => 8000)],
+      recordTotal: async () => {
+        throw new TypeError("reported total must be a positive integer");
+      },
+      sweeps: 2,
+      totals: [unmeasured(ADAPTER_KEYS.CZ_US)],
+    });
+
+    expect(reports).toHaveLength(2);
+    expect(reports.at(0)).toMatchObject({ polled: 1, failed: 1, recorded: 0 });
+  });
+
+  test("an adapter with no source row is counted as registry drift", async () => {
+    const { reports } = await runHarness({
+      adapters: [adapter(ADAPTER_KEYS.CZ_US, async () => 8000)],
+      recordTotal: async () => false,
+      sweeps: 1,
+      totals: [unmeasured(ADAPTER_KEYS.CZ_US)],
+    });
+
+    expect(reports.at(0)).toMatchObject({
+      polled: 1,
+      recorded: 0,
+      unknownSource: 1,
+    });
+  });
+
+  test("a failed read is reported rather than read as a fresh corpus", async () => {
+    let reads = 0;
+    const { reports } = await runHarness({
+      adapters: [adapter(ADAPTER_KEYS.CZ_US, async () => 8000)],
+      readTotals: async () => {
+        reads += 1;
+        throw new Error("database unreachable");
+      },
+      sweeps: 1,
+    });
+
+    expect(reads).toBeGreaterThan(0);
+    expect(reports.at(0)).toMatchObject({ polled: 0, failed: 0 });
+    expect(reports.at(0)?.lastError).toBeInstanceOf(Error);
+  });
+
+  test("a draining process is not asked for a sweep", async () => {
+    let reads = 0;
+
+    await runSourceTotalPoll({
+      adapters: [adapter(ADAPTER_KEYS.CZ_US, async () => 8000)],
+      isDraining: () => true,
+      now: () => NOW,
+      readTotals: async () => {
+        reads += 1;
+        return [];
+      },
+      recordTotal: async () => true,
+      report: () => undefined,
+      sleep: async () => undefined,
+      timing: TIMING,
+    });
+
+    expect(reads).toBe(0);
+  });
+});

--- a/apps/legal-atlas-runner/src/runners/source-total-poll.test.ts
+++ b/apps/legal-atlas-runner/src/runners/source-total-poll.test.ts
@@ -125,33 +125,56 @@ const runHarness = async ({
 
 describe("runSourceTotalPoll", () => {
   test("records what a publisher states, once, and stays quiet while it is fresh", async () => {
+    const sweeps = 3;
     const { reports, slept, written } = await runHarness({
       adapters: [adapter(ADAPTER_KEYS.CZ_US, async () => 8000)],
-      sweeps: 3,
+      sweeps,
       totals: [unmeasured(ADAPTER_KEYS.CZ_US)],
     });
 
-    // The read answers "never measured" on every wake, so every sweep is due
-    // and every sweep writes: what the gate does with a recorded date is
-    // pinned by the fresh-total case below.
-    expect(written).toHaveLength(3);
-    expect(written.at(0)).toEqual({
-      adapterKey: ADAPTER_KEYS.CZ_US,
-      asOf: new Date(NOW),
-      total: 8000,
-    });
-    expect(reports.at(0)).toEqual({
-      polled: 1,
-      recorded: 1,
-      noCount: 0,
-      failed: 0,
-      unknownSource: 0,
-      lastError: undefined,
-    });
+    // The read keeps answering "never measured", so only the ask gate stops
+    // the later sweeps: one write across three wakes, not one per wake.
+    expect(written).toEqual([
+      {
+        adapterKey: ADAPTER_KEYS.CZ_US,
+        asOf: new Date(NOW),
+        total: 8000,
+      },
+    ]);
+    expect(reports).toEqual([
+      {
+        polled: 1,
+        recorded: 1,
+        noCount: 0,
+        failed: 0,
+        unknownSource: 0,
+        lastError: undefined,
+      },
+    ]);
     // Sliced pacing: the gap between sweeps is the interval, not one sleep.
     expect(slept.reduce((sum, ms) => sum + ms, 0)).toBe(
-      TIMING.wakeIntervalMs * reports.length,
+      TIMING.wakeIntervalMs * sweeps,
     );
+  });
+
+  test("a source that answers nothing is not re-asked on the next wake", async () => {
+    let probes = 0;
+    const { reports, written } = await runHarness({
+      adapters: [
+        adapter(ADAPTER_KEYS.CZ_US, async () => {
+          probes += 1;
+          // What a failed request looks like through the adapter contract.
+          return null;
+        }),
+      ],
+      sweeps: 4,
+      totals: [unmeasured(ADAPTER_KEYS.CZ_US)],
+    });
+
+    expect(probes).toBe(1);
+    expect(written).toEqual([]);
+    expect(reports).toHaveLength(1);
+    expect(reports.at(0)).toMatchObject({ polled: 1, noCount: 1 });
   });
 
   test("a fresh total asks nobody and reports nothing", async () => {
@@ -215,17 +238,22 @@ describe("runSourceTotalPoll", () => {
   });
 
   test("a write rejection is counted, not thrown, and the loop continues", async () => {
-    const { reports } = await runHarness({
+    const sweeps = 2;
+    const { reports, slept } = await runHarness({
       adapters: [adapter(ADAPTER_KEYS.CZ_US, async () => 8000)],
       recordTotal: async () => {
         throw new TypeError("reported total must be a positive integer");
       },
-      sweeps: 2,
+      sweeps,
       totals: [unmeasured(ADAPTER_KEYS.CZ_US)],
     });
 
-    expect(reports).toHaveLength(2);
     expect(reports.at(0)).toMatchObject({ polled: 1, failed: 1, recorded: 0 });
+    // The rejection reached the tally instead of the loop: it kept pacing
+    // every wake rather than unwinding on the first bad write.
+    expect(slept.reduce((sum, ms) => sum + ms, 0)).toBe(
+      TIMING.wakeIntervalMs * sweeps,
+    );
   });
 
   test("an adapter with no source row is counted as registry drift", async () => {

--- a/apps/legal-atlas-runner/src/runners/source-total-poll.ts
+++ b/apps/legal-atlas-runner/src/runners/source-total-poll.ts
@@ -7,10 +7,10 @@
  * with the origin kept alongside so a reader can tell a measured number
  * from a transcribed one.
  *
- * What decides a sweep is the recorded date, not an interval this process
- * has been awake for. The wake is frequent and cheap; the staleness gate is
- * what makes the cadence weekly, and it is the reason a deployment neither
- * loses a cycle nor re-asks every publisher on boot.
+ * What decides a sweep is when each source was last recorded or asked, not
+ * an interval this process has been awake for. The wake is frequent and
+ * cheap; that gate is what makes the cadence weekly, and it is the reason a
+ * deployment neither loses a cycle nor re-asks every publisher on boot.
  *
  * A probe that yields no usable number records NOTHING. The stored total is
  * the last figure a publisher actually stated, and a failed probe is not
@@ -30,7 +30,7 @@ import {
   type CountingSourceAdapter,
   type SourceTotalPollOutcome,
   type SourceTotalPollTally,
-  selectStaleCountingAdapters,
+  selectDueCountingAdapters,
   tallySourceTotalPollOutcomes,
 } from "./source-total-outcomes";
 
@@ -180,7 +180,10 @@ const recordProbedTotal = async ({
   }
 };
 
-type SweepOptions = Omit<SourceTotalPollOptions, "report" | "sleep">;
+type SweepOptions = Omit<SourceTotalPollOptions, "report" | "sleep"> & {
+  /** Written as each source is asked, so the gate can run off the ask. */
+  askedAt: Map<string, number>;
+};
 
 /**
  * One wake. Returns null when there was nothing to say: every total fresh,
@@ -188,6 +191,7 @@ type SweepOptions = Omit<SourceTotalPollOptions, "report" | "sleep">;
  */
 const sweepSourceTotals = async ({
   adapters,
+  askedAt,
   isDraining,
   now,
   readTotals,
@@ -203,20 +207,28 @@ const sweepSourceTotals = async ({
     return { ...tallySourceTotalPollOutcomes([]), lastError: error };
   }
 
-  const stale = selectStaleCountingAdapters({
+  const askedAtSweepStart = now();
+  const due = selectDueCountingAdapters({
     adapters,
-    now: now(),
+    askedAt,
+    now: askedAtSweepStart,
     staleAfterMs: timing.staleAfterMs,
     totals,
   });
-  if (stale.length === 0) {
+  if (due.length === 0) {
     return null;
+  }
+
+  // Recorded before the probes, not after: a source that answers nothing has
+  // still been asked, and that is what the next gate must see.
+  for (const { key } of due) {
+    askedAt.set(key, askedAtSweepStart);
   }
 
   // One request per publisher, each a different host, so the sweep runs them
   // together rather than serializing behind the slowest count.
   const probed = await Promise.all(
-    stale.map(
+    due.map(
       async (adapter) =>
         await probeSourceTotal({ adapter, timeoutMs: timing.probeTimeoutMs }),
     ),
@@ -254,7 +266,7 @@ const sweepSourceTotals = async ({
  *
  * The first sweep runs before the first sleep, which is what lets a source
  * that has never been measured be filled on the next deployment instead of
- * a wake later. The staleness gate is what keeps that from re-asking every
+ * a wake later. The recorded date is what keeps that from re-asking every
  * publisher each time the daemon restarts.
  */
 export const runSourceTotalPoll = async ({
@@ -267,10 +279,15 @@ export const runSourceTotalPoll = async ({
   sleep,
   timing,
 }: SourceTotalPollOptions): Promise<void> => {
+  // Per process: the persisted date is what survives a restart, this only
+  // keeps a source that persists nothing from being asked every wake.
+  const askedAt = new Map<string, number>();
+
   while (!isDraining()) {
     // oxlint-disable-next-line no-await-in-loop -- one sweep per wake; the interval only starts once this sweep has settled
     const summary = await sweepSourceTotals({
       adapters,
+      askedAt,
       isDraining,
       now,
       readTotals,

--- a/apps/legal-atlas-runner/src/runners/source-total-poll.ts
+++ b/apps/legal-atlas-runner/src/runners/source-total-poll.ts
@@ -1,0 +1,294 @@
+/**
+ * The standing sweep over the totals publishers report holding.
+ *
+ * Held-vs-total coverage needs a denominator, and only some publishers
+ * expose a cheap count. Those adapters implement `getTotalCount` and are
+ * asked here; for the rest an operator records the publisher's own figure,
+ * with the origin kept alongside so a reader can tell a measured number
+ * from a transcribed one.
+ *
+ * What decides a sweep is the recorded date, not an interval this process
+ * has been awake for. The wake is frequent and cheap; the staleness gate is
+ * what makes the cadence weekly, and it is the reason a deployment neither
+ * loses a cycle nor re-asks every publisher on boot.
+ *
+ * A probe that yields no usable number records NOTHING. The stored total is
+ * the last figure a publisher actually stated, and a failed probe is not
+ * evidence that it changed.
+ *
+ * Kept free of the runner's DB, env and process imports so the gate and the
+ * pacing can be exercised on their own.
+ */
+
+import type { SourceReportedTotal } from "@/api/handlers/case-law/ingestion/source-totals";
+import type { SourceAdapter } from "@/api/lib/legal-search/ingestion-types";
+
+import { DRAIN_CHECK_SLICE_MS } from "./sk-document-drain";
+import {
+  SOURCE_TOTAL_POLL_OUTCOME,
+  SOURCE_TOTAL_STALE_AFTER_MS,
+  type CountingSourceAdapter,
+  type SourceTotalPollOutcome,
+  type SourceTotalPollTally,
+  selectStaleCountingAdapters,
+  tallySourceTotalPollOutcomes,
+} from "./source-total-outcomes";
+
+export type SourceTotalPollSummary = SourceTotalPollTally & {
+  /**
+   * The most recent throw, so an error rate has a cause beside it. Left
+   * raw: the caller renders it, and it renders a tag rather than a message,
+   * because a message can carry more than an operator asked to see.
+   */
+  lastError: unknown;
+};
+
+export type SourceTotalPollTiming = {
+  /** Gap between two staleness checks. Most of them ask nobody anything. */
+  wakeIntervalMs: number;
+  /** Age at which a recorded total is asked for again. */
+  staleAfterMs: number;
+  /** Per-probe budget. Publishers compute a full-range count slowly. */
+  probeTimeoutMs: number;
+};
+
+export const SOURCE_TOTAL_POLL_TIMING = {
+  // Well under the staleness window, so the effective cadence is the window
+  // rather than the wake: a total that falls due is refreshed within hours,
+  // and the checks in between cost one bounded read.
+  wakeIntervalMs: 6 * 60 * 60 * 1000,
+  staleAfterMs: SOURCE_TOTAL_STALE_AFTER_MS,
+  probeTimeoutMs: 120_000,
+} as const satisfies SourceTotalPollTiming;
+
+export type RecordSourceTotalOptions = {
+  adapterKey: string;
+  asOf: Date;
+  total: number;
+};
+
+export type SourceTotalPollOptions = {
+  adapters: readonly SourceAdapter[];
+  /** Stops the sweep without abandoning the probe already in flight. */
+  isDraining: () => boolean;
+  now: () => number;
+  readTotals: () => Promise<readonly SourceReportedTotal[]>;
+  /** Records one total; false when no source carries the adapter key. */
+  recordTotal: (options: RecordSourceTotalOptions) => Promise<boolean>;
+  /** Receives the tallies of a sweep that asked somebody. */
+  report: (summary: SourceTotalPollSummary) => void;
+  sleep: (ms: number) => Promise<void>;
+  timing: SourceTotalPollTiming;
+};
+
+type SourceTotalProbe =
+  | { status: "counted"; total: number }
+  | { status: "no-count" }
+  | { status: "failed"; error: unknown };
+
+type ProbedSourceTotal = {
+  adapter: CountingSourceAdapter;
+  probe: SourceTotalProbe;
+};
+
+type SettledSourceTotal = {
+  outcome: SourceTotalPollOutcome;
+  error: unknown;
+};
+
+type ProbeSourceTotalOptions = {
+  adapter: CountingSourceAdapter;
+  timeoutMs: number;
+};
+
+/**
+ * One probe against one publisher. A throw is a failure of this probe; a
+ * null is the adapter's own answer that its publisher states no total, so
+ * the two are kept apart rather than collapsed into "no number".
+ */
+const probeSourceTotal = async ({
+  adapter,
+  timeoutMs,
+}: ProbeSourceTotalOptions): Promise<ProbedSourceTotal> => {
+  try {
+    const total = await adapter.getTotalCount(AbortSignal.timeout(timeoutMs));
+
+    return {
+      adapter,
+      probe:
+        total === null ? { status: "no-count" } : { status: "counted", total },
+    };
+  } catch (error) {
+    return { adapter, probe: { status: "failed", error } };
+  }
+};
+
+type RecordProbedTotalOptions = {
+  asOf: Date;
+  probed: ProbedSourceTotal;
+  recordTotal: (options: RecordSourceTotalOptions) => Promise<boolean>;
+};
+
+/**
+ * Persist one probed count, or account for why none was persisted. The
+ * writer owns what counts as a usable number, so its rules are not restated
+ * here — but its rejection must not escape: the probes settle together, and
+ * a throw would lose the result of every other source in the sweep.
+ */
+const recordProbedTotal = async ({
+  asOf,
+  probed: { adapter, probe },
+  recordTotal,
+}: RecordProbedTotalOptions): Promise<SettledSourceTotal> => {
+  switch (probe.status) {
+    case "no-count": {
+      return { outcome: SOURCE_TOTAL_POLL_OUTCOME.NO_COUNT, error: undefined };
+    }
+    case "failed": {
+      return { outcome: SOURCE_TOTAL_POLL_OUTCOME.FAILED, error: probe.error };
+    }
+    case "counted": {
+      try {
+        const applied = await recordTotal({
+          adapterKey: adapter.key,
+          asOf,
+          total: probe.total,
+        });
+
+        // An adapter the sources table does not carry is registry drift: the
+        // number is unattributable, so it is counted and reported rather
+        // than dropped.
+        return {
+          outcome: applied
+            ? SOURCE_TOTAL_POLL_OUTCOME.RECORDED
+            : SOURCE_TOTAL_POLL_OUTCOME.UNKNOWN_SOURCE,
+          error: undefined,
+        };
+      } catch (error) {
+        return { outcome: SOURCE_TOTAL_POLL_OUTCOME.FAILED, error };
+      }
+    }
+    default: {
+      const exhaustive: never = probe;
+      return {
+        outcome: SOURCE_TOTAL_POLL_OUTCOME.FAILED,
+        error: new Error(
+          `unhandled source-total probe: ${JSON.stringify(exhaustive)}`,
+        ),
+      };
+    }
+  }
+};
+
+type SweepOptions = Omit<SourceTotalPollOptions, "report" | "sleep">;
+
+/**
+ * One wake. Returns null when there was nothing to say: every total fresh,
+ * or a drain that arrived before anything was written.
+ */
+const sweepSourceTotals = async ({
+  adapters,
+  isDraining,
+  now,
+  readTotals,
+  recordTotal,
+  timing,
+}: SweepOptions): Promise<SourceTotalPollSummary | null> => {
+  let totals: readonly SourceReportedTotal[];
+  try {
+    totals = await readTotals();
+  } catch (error) {
+    // A read that failed is not "everything is fresh", so it is reported
+    // rather than passed over in silence.
+    return { ...tallySourceTotalPollOutcomes([]), lastError: error };
+  }
+
+  const stale = selectStaleCountingAdapters({
+    adapters,
+    now: now(),
+    staleAfterMs: timing.staleAfterMs,
+    totals,
+  });
+  if (stale.length === 0) {
+    return null;
+  }
+
+  // One request per publisher, each a different host, so the sweep runs them
+  // together rather than serializing behind the slowest count.
+  const probed = await Promise.all(
+    stale.map(
+      async (adapter) =>
+        await probeSourceTotal({ adapter, timeoutMs: timing.probeTimeoutMs }),
+    ),
+  );
+
+  // A drain stops the sweep before it writes rather than part-way through
+  // it: a run that was cut short states nothing about the totals it read.
+  if (isDraining()) {
+    return null;
+  }
+
+  const asOf = new Date(now());
+  const settled = await Promise.all(
+    probed.map(
+      async (probe) =>
+        await recordProbedTotal({ asOf, probed: probe, recordTotal }),
+    ),
+  );
+
+  let lastError: unknown;
+  for (const { error } of settled) {
+    if (error !== undefined) {
+      lastError = error;
+    }
+  }
+
+  return {
+    ...tallySourceTotalPollOutcomes(settled.map(({ outcome }) => outcome)),
+    lastError,
+  };
+};
+
+/**
+ * Sweep until the process drains.
+ *
+ * The first sweep runs before the first sleep, which is what lets a source
+ * that has never been measured be filled on the next deployment instead of
+ * a wake later. The staleness gate is what keeps that from re-asking every
+ * publisher each time the daemon restarts.
+ */
+export const runSourceTotalPoll = async ({
+  adapters,
+  isDraining,
+  now,
+  readTotals,
+  recordTotal,
+  report,
+  sleep,
+  timing,
+}: SourceTotalPollOptions): Promise<void> => {
+  while (!isDraining()) {
+    // oxlint-disable-next-line no-await-in-loop -- one sweep per wake; the interval only starts once this sweep has settled
+    const summary = await sweepSourceTotals({
+      adapters,
+      isDraining,
+      now,
+      readTotals,
+      recordTotal,
+      timing,
+    });
+    if (summary !== null) {
+      report(summary);
+    }
+
+    // Sliced so a drain request interrupts an interval of hours within a
+    // second.
+    let remainingMs = timing.wakeIntervalMs;
+    while (remainingMs > 0 && !isDraining()) {
+      const sliceMs = Math.min(remainingMs, DRAIN_CHECK_SLICE_MS);
+      // oxlint-disable-next-line no-await-in-loop -- sequential wait, sliced only to re-check the drain flag
+      await sleep(sliceMs);
+      remainingMs -= sliceMs;
+    }
+  }
+};


### PR DESCRIPTION
The per-source reported totals (#1893) are written today only by a manual operator script, so the coverage denominators go stale unless someone remembers to poll. This makes the poll a standing, staleness-gated sweep in the ingest daemon.

`runSourceTotalPoll` mirrors the sk-document drain's injected-dependency shape (testable without db/env/process): wake every 6 hours, read the persisted totals, and probe only capable adapters whose `reported_total_as_of` is null or older than 6 days — an effective weekly cadence per source that survives deploy restarts without re-polling on every boot, and a wake where everything is fresh does nothing and logs nothing. Probes run concurrently with a 120s timeout each; a `null` result (no count endpoint or a failed request, per the `getTotalCount` contract), a thrown probe, or a writer rejection records nothing, so a bad sweep can never overwrite the last figure a publisher actually stated. An `applied === false` write is registry drift and is warned, never silent. Sweep summary: `case_law.source_totals.polled` with `polled/recorded/noCount/failed/unknownSource` counters.

Placement note: the poll lives in the runner rather than the scheduler deliberately. The scheduler registry sits in `lib`, and a task there polling adapters would import from `handlers`, opening the `lib-to-handler-imports` ratchet metric that currently stands at zero. The runner already depends on handlers in the sanctioned direction, so the dependency-direction guard stays closed.

The stale-gate and outcome-classification logic is a pure sibling module (`source-total-outcomes.ts`) with declared-set-equals-exercised-set tests over the outcome union in both directions; the loop module has its own pacing/gating tests (18 tests total, full runner suite green). One local constant (`DAY_MS`) stands in for `@stll/time`'s `DAY_IN_MS` because the runner does not declare that workspace dependency and the lockfile cannot currently be regenerated (an unrelated catalog entry is inside the minimum-release-age window); swapping it is a two-line change once that clears.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated polling of publisher-reported case-law totals.
  * Records successful totals and identifies missing, stale, failed, or unavailable results.
  * Runs polling continuously in the background, with configurable timing and prompt shutdown during draining.

* **Bug Fixes**
  * Isolates failures so one unavailable publisher does not interrupt polling for others.

* **Tests**
  * Added comprehensive coverage for polling, freshness checks, outcome reporting, persistence failures, timing, and shutdown behaviour.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->