### PR TITLE
docs: bootstrap missing dev dependencies

### DIFF
--- a/.agents/skills/dev/SKILL.md
+++ b/.agents/skills/dev/SKILL.md
@@ -22,6 +22,11 @@ checks.
    bun run dev --dry-run --skip-install --no-browser
    ```
 
+   If this exits before the runner starts with a missing-package or
+   module-resolution error, run `bun install` once and retry the exact same
+   dry-run command. Do not treat other failures as bootstrap errors or retry
+   them this way.
+
    Parse the numeric `offset:` and the `web:` and `api:` URLs. This
    offset covers application ports only; do not copy it into
    `--infra-offset` without the independent ownership check below.

--- a/.agents/skills/dev/SKILL.md
+++ b/.agents/skills/dev/SKILL.md
@@ -23,7 +23,7 @@ checks.
    ```
 
    If this exits before the runner starts with a missing-package or
-   module-resolution error, run `bun install` once and retry the exact same
+   module-resolution error, run `bun ci` once and retry the exact same
    dry-run command. Do not treat other failures as bootstrap errors or retry
    them this way.
 

--- a/.ai/local-skills/dev/SKILL.md
+++ b/.ai/local-skills/dev/SKILL.md
@@ -22,6 +22,11 @@ checks.
    bun run dev --dry-run --skip-install --no-browser
    ```
 
+   If this exits before the runner starts with a missing-package or
+   module-resolution error, run `bun install` once and retry the exact same
+   dry-run command. Do not treat other failures as bootstrap errors or retry
+   them this way.
+
    Parse the numeric `offset:` and the `web:` and `api:` URLs. This
    offset covers application ports only; do not copy it into
    `--infra-offset` without the independent ownership check below.

--- a/.ai/local-skills/dev/SKILL.md
+++ b/.ai/local-skills/dev/SKILL.md
@@ -23,7 +23,7 @@ checks.
    ```
 
    If this exits before the runner starts with a missing-package or
-   module-resolution error, run `bun install` once and retry the exact same
+   module-resolution error, run `bun ci` once and retry the exact same
    dry-run command. Do not treat other failures as bootstrap errors or retry
    them this way.
 

--- a/.claude/commands/dev.md
+++ b/.claude/commands/dev.md
@@ -18,7 +18,7 @@ checks.
    ```
 
    If this exits before the runner starts with a missing-package or
-   module-resolution error, run `bun install` once and retry the exact same
+   module-resolution error, run `bun ci` once and retry the exact same
    dry-run command. Do not treat other failures as bootstrap errors or retry
    them this way.
 

--- a/.claude/commands/dev.md
+++ b/.claude/commands/dev.md
@@ -17,6 +17,11 @@ checks.
    bun run dev --dry-run --skip-install --no-browser
    ```
 
+   If this exits before the runner starts with a missing-package or
+   module-resolution error, run `bun install` once and retry the exact same
+   dry-run command. Do not treat other failures as bootstrap errors or retry
+   them this way.
+
    Parse the numeric `offset:` and the `web:` and `api:` URLs. This
    offset covers application ports only; do not copy it into
    `--infra-offset` without the independent ownership check below.


### PR DESCRIPTION
The dev skill currently assumes workspace dependencies exist before its required dry run, so fresh worktrees can fail before the runner starts.

This adds a narrow recovery path for missing-package and module-resolution failures: install once, retry the exact dry run, and keep all other failures visible. The canonical skill source was updated and synced to generated agent commands.