### PR TITLE
fix(api): harden template and derivative storage writes

### DIFF
--- a/apps/api/src/handlers/templates/configure-template-fields-service.ts
+++ b/apps/api/src/handlers/templates/configure-template-fields-service.ts
@@ -7,8 +7,9 @@
  *
  * Backs the MCP `configure_template_fields` tool. Mirrors save-document's
  * restore-by-path discipline (overlay merged onto the source manifest fields by
- * path) but stays in place: no new version, no marker re-discovery, just the
- * manifest re-embedded into the same stored object.
+ * path) but stays on the same version: no new version, no marker re-discovery,
+ * just the manifest re-embedded and stored under a fresh key the current
+ * version's rows are repointed to.
  */
 
 import { Result } from "better-result";
@@ -29,6 +30,7 @@ import {
 import type { FieldMeta, TemplateManifest } from "@/api/lib/docx/types";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import { getS3, readS3ArrayBuffer } from "@/api/lib/s3";
+import { buildTemplateRevisionS3Key } from "@/api/lib/templates/storage-keys";
 
 type ConfigureTemplateFieldsOptions = {
   safeDb: SafeDb;
@@ -72,13 +74,14 @@ export const configureTemplateFields = async function* ({
     );
   }
 
-  // All S3 I/O (read the stored DOCX, re-embed the manifest, write it back) and
-  // the row updates happen under the advisory lock, after re-reading s3Key /
-  // currentVersion fresh. Reading the buffer and writing it back *outside* the
-  // lock let a concurrent save-document commit a new vN+1 (a fresh per-version
-  // s3Key) between this read and write, so the manifest would be embedded into
-  // the now-stale object while templates.s3Key points elsewhere, diverging the
-  // DB manifest from the bytes the row references. Mirrors save-document.ts.
+  // All S3 I/O (read the stored DOCX, re-embed the manifest, store the result)
+  // and the row updates happen under the advisory lock, after re-reading s3Key /
+  // currentVersion fresh. Reading the buffer and writing the result *outside*
+  // the lock let a concurrent save-document commit a new vN+1 (a fresh
+  // per-version s3Key) between this read and write, so the manifest would be
+  // embedded into the now-stale object while templates.s3Key points elsewhere,
+  // diverging the DB manifest from the bytes the row references. Mirrors
+  // save-document.ts.
   const txResult = yield* Result.await(
     safeDb(async (tx) => {
       await tx.execute(
@@ -140,10 +143,25 @@ export const configureTemplateFields = async function* ({
         fields: mergedFields,
       };
 
-      // Re-embed the manifest into the locked object; markers and every other
+      // Re-embed the manifest into the bytes just read; markers and every other
       // part of the DOCX are preserved by writeManifest.
       const updatedDocx = await writeManifest(buffer, manifest);
-      await getS3().write(locked.s3Key, new Uint8Array(updatedDocx));
+      const updatedBytes = new Uint8Array(updatedDocx);
+
+      // The result goes to a fresh key rather than over the object the rows
+      // still point at: this transaction can still roll back after the write
+      // (a later statement, a serialization failure), and an in-place overwrite
+      // would leave the stored bytes carrying an overlay the rows never
+      // recorded. Writing beside the current object leaves at worst an
+      // unreferenced one. Same discipline as save-document.ts / update.ts,
+      // which allocate a per-version key.
+      const revisionS3Key = buildTemplateRevisionS3Key({
+        contents: updatedBytes,
+        organizationId,
+        templateId,
+        version: locked.currentVersion,
+      });
+      await getS3().write(revisionS3Key, updatedBytes);
 
       await tx
         .update(templates)
@@ -151,16 +169,22 @@ export const configureTemplateFields = async function* ({
           manifest,
           fieldCount: mergedFields.length,
           sizeBytes: updatedDocx.byteLength,
+          s3Key: revisionS3Key,
           updatedAt: new Date(),
         })
         .where(eq(templates.id, templateId));
 
-      // Keep ONLY the current version row's manifest in sync so a later
-      // save-document / fill reads the configured fields back; historical
-      // versions stay immutable.
+      // Keep ONLY the current version row in sync (its manifest and the key
+      // holding the bytes that manifest is embedded in) so a later
+      // save-document / fill / version download reads the configured fields
+      // back; historical versions keep their own key and stay immutable.
       await tx
         .update(templateVersions)
-        .set({ manifest, fieldCount: mergedFields.length })
+        .set({
+          manifest,
+          fieldCount: mergedFields.length,
+          s3Key: revisionS3Key,
+        })
         .where(
           and(
             eq(templateVersions.templateId, templateId),
@@ -175,6 +199,7 @@ export const configureTemplateFields = async function* ({
         workspaceId: null,
         changes: {
           fieldCount: { old: null, new: mergedFields.length },
+          s3Key: { old: locked.s3Key, new: revisionS3Key },
         },
       });
 

--- a/apps/api/src/handlers/templates/configure-template-fields-service.ts
+++ b/apps/api/src/handlers/templates/configure-template-fields-service.ts
@@ -29,6 +29,9 @@ import {
 } from "@/api/lib/docx/template-manifest";
 import type { FieldMeta, TemplateManifest } from "@/api/lib/docx/types";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
+import { errorTag } from "@/api/lib/errors/utils";
+import { deleteS3Keys } from "@/api/lib/files/utils";
+import { logger } from "@/api/lib/observability/logger";
 import { getS3, readS3ArrayBuffer } from "@/api/lib/s3";
 import { buildTemplateRevisionS3Key } from "@/api/lib/templates/storage-keys";
 
@@ -203,7 +206,15 @@ export const configureTemplateFields = async function* ({
         },
       });
 
-      return { ok: true as const, manifest };
+      return {
+        ok: true as const,
+        manifest,
+        // Reclaimed after the commit, not here: only a committed transaction
+        // proves no row still names it. Identical bytes resolve to the same
+        // key, in which case there is nothing to reclaim.
+        supersededS3Key:
+          locked.s3Key === revisionS3Key ? undefined : locked.s3Key,
+      };
     }),
   );
 
@@ -222,6 +233,22 @@ export const configureTemplateFields = async function* ({
           "describe_template to list them).",
       }),
     );
+  }
+
+  // The superseded object is referenced by no row once the transaction has
+  // committed: template deletion discovers keys from templates.s3Key and the
+  // template_versions rows only (handlers/templates/delete.ts), so leaving it
+  // in place would strand it beyond the reach of every cleanup path. A failed
+  // delete is not a failed configuration: the rows are already consistent, so
+  // it is reported and the request still succeeds.
+  if (txResult.supersededS3Key !== undefined) {
+    const reclaimed = await deleteS3Keys([txResult.supersededS3Key]);
+    if (Result.isError(reclaimed)) {
+      logger.warn("templates.superseded_object_reclaim_failed", {
+        "error.type": errorTag(reclaimed.error),
+        templateId,
+      });
+    }
   }
 
   return Result.ok({ manifest: txResult.manifest });

--- a/apps/api/src/lib/file-derivative-queue.ts
+++ b/apps/api/src/lib/file-derivative-queue.ts
@@ -11,7 +11,10 @@ import type { SafeId } from "@/api/lib/branded-types";
 import { createBullMqJobId } from "@/api/lib/bullmq-job-id";
 import { connectionErrorFields, errorTag } from "@/api/lib/errors/utils";
 import { decidePdfDerivativeAction } from "@/api/lib/file-derivative-decision";
-import { allocateFileObject } from "@/api/lib/files/file-object-ids";
+import {
+  allocateFileObject,
+  resolveQueuedFileObject,
+} from "@/api/lib/files/file-object-ids";
 import {
   convertToPdf,
   shouldGeneratePdfDerivative,
@@ -26,7 +29,7 @@ import { logger } from "@/api/lib/observability/logger";
 import { createBullMqConnection } from "@/api/lib/redis-client";
 import { broadcastWorkspaceResourceUpdated } from "@/api/lib/resource-realtime";
 import { createRootScopedDb } from "@/api/lib/root-scoped-db";
-import { getS3, readS3ArrayBuffer } from "@/api/lib/s3";
+import { getS3, readS3ArrayBuffer, writeS3ObjectWithRetry } from "@/api/lib/s3";
 import {
   brandPersistedEntityId,
   brandPersistedFieldId,
@@ -45,6 +48,11 @@ const DEFAULT_JOB_ATTEMPTS = 3;
 // PDF and thumbnail jobs carry the same identifiers; the job name on the
 // BullMQ job distinguishes which derivative to produce.
 type FileDerivativeJobData = {
+  // Object id for the derivative this job produces, allocated by the producer
+  // and replayed to every attempt, so the storage key a retry writes is the one
+  // the previous attempt wrote. Absent only on jobs enqueued before the field
+  // existed; see resolveQueuedFileObject.
+  derivativeFileId?: string;
   entityId: string;
   fieldId: string;
   organizationId: string;
@@ -99,6 +107,7 @@ export const enqueuePdfDerivative = async ({
   await getQueue().add(
     GENERATE_PDF_JOB_NAME,
     {
+      derivativeFileId: allocateFileObject(),
       entityId,
       fieldId,
       organizationId,
@@ -154,6 +163,7 @@ export const enqueueImageThumbnail = async ({
   await getQueue().add(
     GENERATE_THUMBNAIL_JOB_NAME,
     {
+      derivativeFileId: allocateFileObject(),
       entityId,
       fieldId,
       organizationId,
@@ -260,6 +270,7 @@ export const initFileDerivativeWorker = () => {
 };
 
 const processPdfDerivativeJob = async ({
+  derivativeFileId,
   entityId,
   fieldId,
   organizationId,
@@ -322,7 +333,7 @@ const processPdfDerivativeJob = async ({
     throw conversionResult.error;
   }
 
-  const pdfFileId = allocateFileObject();
+  const pdfFileId = resolveQueuedFileObject(derivativeFileId);
   const sourceFileId = content.id;
   const pdfKey = createFileKey({
     organizationId: branded.organizationId,
@@ -331,7 +342,15 @@ const processPdfDerivativeJob = async ({
     mimeType: PDF_MIME_TYPE,
   });
 
-  await getS3().write(pdfKey, new Uint8Array(conversionResult.value.buffer));
+  // The key is fixed by the job's derivative id, so a retry after an attempt
+  // died mid-write addresses the object that attempt left behind instead of
+  // adding a second one. That is also the deterministic-key contract
+  // writeS3ObjectWithRetry documents for its own attempts, which can time out
+  // here and still land in the bucket.
+  await writeS3ObjectWithRetry({
+    data: new Uint8Array(conversionResult.value.buffer),
+    key: pdfKey,
+  });
 
   try {
     const updatedRows = await scopedDb((tx) =>
@@ -436,6 +455,7 @@ const markPdfDerivativeFailed = async ({
 };
 
 const processImageThumbnailJob = async ({
+  derivativeFileId,
   organizationId,
   fieldId,
   userId,
@@ -496,7 +516,7 @@ const processImageThumbnailJob = async ({
     throw thumbnailResult.error;
   }
 
-  const thumbnailFileId = allocateFileObject();
+  const thumbnailFileId = resolveQueuedFileObject(derivativeFileId);
   const sourceFileId = content.id;
   const thumbnailKey = createFileKey({
     organizationId: branded.organizationId,
@@ -505,7 +525,11 @@ const processImageThumbnailJob = async ({
     mimeType: THUMBNAIL_MIME_TYPE,
   });
 
-  await getS3().write(thumbnailKey, thumbnailResult.value.webp);
+  // Same fixed key across this job's attempts as the PDF path above.
+  await writeS3ObjectWithRetry({
+    data: thumbnailResult.value.webp,
+    key: thumbnailKey,
+  });
 
   try {
     const updatedRows = await scopedDb((tx) =>

--- a/apps/api/src/lib/files/file-object-ids.ts
+++ b/apps/api/src/lib/files/file-object-ids.ts
@@ -45,6 +45,20 @@ export type WritableFieldContent =
 export const allocateFileObject = (): MintedFileId =>
   brandMintedFileId(Bun.randomUUIDv7());
 
+/**
+ * The object id a queued derivative job carries, allocated once by the
+ * producer so every attempt of that job writes the same storage key. Allocating
+ * per attempt instead is what this replaces: an attempt that dies after its
+ * write leaves an object no row will ever name.
+ *
+ * The fallback covers jobs enqueued before the id moved into the payload, which
+ * carry none; it can go once no such job remains queued.
+ */
+export const resolveQueuedFileObject = (
+  fileId: string | undefined,
+): MintedFileId =>
+  fileId === undefined ? allocateFileObject() : brandMintedFileId(fileId);
+
 export const fileContentWithMintedObject = (
   content: MintedFileFieldContent,
 ): WritableFileFieldContent => {

--- a/apps/api/src/lib/templates/storage-keys.test.ts
+++ b/apps/api/src/lib/templates/storage-keys.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "bun:test";
+
+import { toSafeId } from "@/api/lib/branded-types";
+import {
+  buildTemplateRevisionS3Key,
+  buildTemplateS3Key,
+  buildTemplateVersionS3Key,
+} from "@/api/lib/templates/storage-keys";
+
+const organizationId = toSafeId<"organization">(
+  "6f1a3d2c-9b44-4e0f-8f2a-7c5d1e8b0a31",
+);
+const templateId = toSafeId<"template">("0c7e5b1a-2d43-4f9c-bb18-6a4e2f7d9c05");
+
+describe("buildTemplateRevisionS3Key", () => {
+  test("never lands on the key a re-embed reads from", () => {
+    // The re-embed path reads the live object (or the current version's
+    // snapshot) and stores the result under this key. Sharing a key with either
+    // would make the write destructive, which is what the separate key exists
+    // to prevent.
+    const revisionKey = buildTemplateRevisionS3Key({
+      contents: new Uint8Array([1, 2, 3]),
+      organizationId,
+      templateId,
+      version: 3,
+    });
+
+    expect(revisionKey).not.toBe(
+      buildTemplateS3Key(organizationId, templateId),
+    );
+    expect(revisionKey).not.toBe(
+      buildTemplateVersionS3Key(organizationId, templateId, 3),
+    );
+  });
+
+  test("addresses by content: same bytes reuse a key, changed bytes do not", () => {
+    const keyFor = (contents: Uint8Array) =>
+      buildTemplateRevisionS3Key({
+        contents,
+        organizationId,
+        templateId,
+        version: 3,
+      });
+
+    expect(keyFor(new Uint8Array([1, 2, 3]))).toBe(
+      keyFor(new Uint8Array([1, 2, 3])),
+    );
+    expect(keyFor(new Uint8Array([1, 2, 3]))).not.toBe(
+      keyFor(new Uint8Array([1, 2, 4])),
+    );
+  });
+
+  test("keeps revisions of different versions apart", () => {
+    const contents = new Uint8Array([1, 2, 3]);
+    expect(
+      buildTemplateRevisionS3Key({
+        contents,
+        organizationId,
+        templateId,
+        version: 3,
+      }),
+    ).not.toBe(
+      buildTemplateRevisionS3Key({
+        contents,
+        organizationId,
+        templateId,
+        version: 4,
+      }),
+    );
+  });
+});

--- a/apps/api/src/lib/templates/storage-keys.ts
+++ b/apps/api/src/lib/templates/storage-keys.ts
@@ -23,3 +23,33 @@ export const buildTemplateVersionS3Key = (
   templateId: SafeId<"template">,
   version: number,
 ) => `${templateKeyPrefix(organizationId, templateId)}/v${version}.docx`;
+
+type TemplateRevisionKeyOptions = {
+  contents: Uint8Array;
+  organizationId: SafeId<"organization">;
+  templateId: SafeId<"template">;
+  version: number;
+};
+
+/**
+ * Object key for re-embedded bytes of a version that already exists (a manifest
+ * overlay that adds no version). The writer stores them here and repoints the
+ * rows in the same transaction rather than overwriting the object those rows
+ * still reference, so a transaction that rolls back after the write leaves an
+ * unreferenced object instead of bytes the rows disagree with.
+ *
+ * The key is the digest of the bytes it holds, so re-applying an overlay that
+ * produces an identical document rewrites one key instead of adding another.
+ */
+export const buildTemplateRevisionS3Key = ({
+  contents,
+  organizationId,
+  templateId,
+  version,
+}: TemplateRevisionKeyOptions): string => {
+  const digest = new Bun.CryptoHasher("sha256")
+    .update(contents)
+    .digest("hex")
+    .slice(0, 16);
+  return `${templateKeyPrefix(organizationId, templateId)}/v${version}-${digest}.docx`;
+};


### PR DESCRIPTION
Two storage-write paths could leave object storage and the database pointing at different bytes after an interrupted request; both now follow the fresh-key discipline the sibling template handlers already use.

**Template field configuration** (`configure-template-fields-service.ts`): the re-embedded DOCX was written in place over the object the template rows still reference, inside a transaction that can roll back after the write. It now goes to a content-addressed revision key (`v{n}-{sha256[0..16]}.docx`, new `buildTemplateRevisionS3Key`), and the same transaction repoints `templates.s3Key` and the current `template_versions` row. A rollback now leaves at worst an unreferenced object instead of stored bytes the rows never recorded; re-applying an overlay that produces identical bytes reuses the same key. The audit event records the key transition.

**File derivatives** (`file-derivative-queue.ts`): each retry of a PDF/thumbnail job allocated a fresh object id, so every interrupted attempt stranded its predecessor's object. The job payload now carries a `derivativeFileId` allocated at enqueue time; workers resolve it via `resolveQueuedFileObject` and write through `writeS3ObjectWithRetry`, so retries reuse one deterministic key. The id is per-job rather than derived from the source file so a losing racer's cleanup can never delete an object a committed row names. `derivativeFileId` is optional during rollout: jobs already queued without it get one allocated on first processing, and the field can become required once the queue has drained (removal condition noted in the comment).

New `storage-keys.test.ts` pins the revision-key invariants (no collision with the live or per-version keys, content addressing). Typecheck and the targeted suites pass locally; queue workers are exercised by CI.