### PR TITLE
fix(api): derive entity kind request schemas from ENTITY_KINDS

### DIFF
--- a/apps/api/src/handlers/entities/list.ts
+++ b/apps/api/src/handlers/entities/list.ts
@@ -1,6 +1,8 @@
 import { panic, Result } from "better-result";
 import { t } from "elysia";
 
+import { ENTITY_KINDS } from "@stll/api-contract";
+
 import { createSafeHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
 import { arrayOrEmpty } from "@/api/lib/array";
@@ -37,8 +39,8 @@ const readEntitiesBodySchema = t.Object({
     }),
   ),
   excludedKinds: t.Optional(
-    t.Array(t.UnionEnum(["document", "folder", "task", "message", "link"]), {
-      maxItems: 5,
+    t.Array(t.UnionEnum([...ENTITY_KINDS]), {
+      maxItems: ENTITY_KINDS.length,
     }),
   ),
   previewableForAi: t.Optional(t.Boolean()),

--- a/apps/api/src/handlers/entities/read-kanban-group.ts
+++ b/apps/api/src/handlers/entities/read-kanban-group.ts
@@ -1,6 +1,8 @@
 import { panic, Result } from "better-result";
 import { t } from "elysia";
 
+import { ENTITY_KINDS } from "@stll/api-contract";
+
 import { createSafeHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
 import { arrayOrEmpty } from "@/api/lib/array";
@@ -41,8 +43,8 @@ const readKanbanGroupBodySchema = t.Object({
   // Document-table grouping passes ["folder", "task"] to match the flat window
   // query; the kanban board omits it so status columns keep their tasks.
   excludedKinds: t.Optional(
-    t.Array(t.UnionEnum(["document", "folder", "task", "message", "link"]), {
-      maxItems: 5,
+    t.Array(t.UnionEnum([...ENTITY_KINDS]), {
+      maxItems: ENTITY_KINDS.length,
     }),
   ),
   groupByPropertyId: tGroupByPropertyId,

--- a/apps/api/src/handlers/entities/read-window.ts
+++ b/apps/api/src/handlers/entities/read-window.ts
@@ -1,6 +1,8 @@
 import { panic, Result } from "better-result";
 import { t } from "elysia";
 
+import { ENTITY_KINDS } from "@stll/api-contract";
+
 import { createSafeHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
 import { arrayOrEmpty } from "@/api/lib/array";
@@ -30,8 +32,8 @@ const readEntitiesWindowBodySchema = t.Object({
   ),
   cursor: t.Optional(tPaginationCursor(ENTITIES_WINDOW_CURSOR_MAX_LENGTH)),
   excludedKinds: t.Optional(
-    t.Array(t.UnionEnum(["document", "folder", "task", "message", "link"]), {
-      maxItems: 5,
+    t.Array(t.UnionEnum([...ENTITY_KINDS]), {
+      maxItems: ENTITY_KINDS.length,
     }),
   ),
   fieldMode: t.Optional(t.Union([t.Literal("full"), t.Literal("visible")])),


### PR DESCRIPTION
`packages/api-contract/src/entity-kinds.ts` is the documented single source for entity kinds, but three handlers hand-listed the literals in their `excludedKinds` schemas, with `maxItems: 5` as a second copy of the list length. A new entity kind would have been accepted by the column enum and produced by the web filters, then rejected by these validators.

`entities/list.ts`, `entities/read-window.ts`, and `entities/read-kanban-group.ts` now use `t.UnionEnum([...ENTITY_KINDS])` with `maxItems: ENTITY_KINDS.length`, matching `flows/schema.ts`. The generated CLI route map is byte-identical (codegen run, no diff), since members and order are unchanged.

Follow-up worth considering: `search/search.ts` expresses the same field via the shared `entityKindSchema` from `db/schema-validators.ts`. Both shapes derive from `ENTITY_KINDS`, so neither can drift, but collapsing the four call sites onto the shared schema would leave one idiom.