### PR TITLE
fix(organization-settings): fail closed when stored AI config cannot be decrypted

### DIFF
--- a/apps/api/src/handlers/organization-settings/ai-config-decrypt-failure.test.ts
+++ b/apps/api/src/handlers/organization-settings/ai-config-decrypt-failure.test.ts
@@ -1,0 +1,104 @@
+import { Result } from "better-result";
+import { describe, expect, test } from "bun:test";
+
+import type { Transaction } from "@/api/db/root";
+import type { SafeDb } from "@/api/db/safe-db";
+import { AI_CONFIG_UNREADABLE_ERROR_CODE } from "@/api/lib/ai-config-response";
+import { createTestHandlerContext } from "@/api/tests/helpers/handler-context";
+import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
+
+import readAIConfig from "./read-ai-config";
+import updateAIConfig from "./update-ai-config";
+
+/**
+ * A stored row that cannot be decrypted with the org's current key: a
+ * non-zero IV (so the row is not the plaintext envelope) over bytes that fail
+ * the AES-GCM tag. `decryptAIConfig` rejects on it exactly as it would in
+ * production after a key rotation, so neither handler needs a module mock to
+ * reach its decrypt-failure branch.
+ */
+const undecryptableRow = {
+  aiConfigEncrypted: Buffer.from(
+    "9f3c1a77e5b40d28cc6f01935ae2d4b8a71c5e6039f8d24b7ce013a5b6082f4d",
+    "hex",
+  ),
+  aiConfigIv: Buffer.from("a1b2c3d4e5f60718293a4b5c", "hex"),
+};
+
+type UpdateContext = Parameters<typeof updateAIConfig.handler>[0];
+type ReadContext = Parameters<typeof readAIConfig.handler>[0];
+
+const updateBody = {
+  providers: [{ provider: "google", apiKey: "test-google-key" }],
+  overrideModels: {
+    fast: { provider: "google", modelId: "gemini-3.5-flash" },
+    chat: { provider: "google", modelId: "gemini-3.5-flash" },
+    reasoning: { provider: "google", modelId: "gemini-3.1-pro-preview" },
+    pdf: { provider: "google", modelId: "gemini-3.5-flash" },
+  },
+};
+
+const writeRejectingTx = asTestRaw<Transaction>({
+  insert: () => {
+    throw new Error("the stored AI config must not be overwritten");
+  },
+});
+
+/**
+ * Serves the settings row on the first operation. Both handlers read the row
+ * first, so any later operation is the write path a decrypt failure has to
+ * prevent; it runs against a transaction that refuses inserts.
+ */
+const createSettingsDb = (): {
+  safeDb: SafeDb;
+  operationCount: () => number;
+} => {
+  let operationCount = 0;
+  const safeDb: SafeDb = async <T>(
+    operation: (tx: Transaction) => Promise<T>,
+  ) => {
+    operationCount += 1;
+    return operationCount === 1
+      ? Result.ok(asTestRaw<T>(undecryptableRow))
+      : Result.ok(await operation(writeRejectingTx));
+  };
+  return { safeDb, operationCount: () => operationCount };
+};
+
+describe("AI config handlers with an undecryptable stored config", () => {
+  test("update fails closed instead of merging onto an empty config", async () => {
+    const { safeDb, operationCount } = createSettingsDb();
+
+    const result = await updateAIConfig.handler(
+      createTestHandlerContext<UpdateContext>({ body: updateBody, safeDb }),
+    );
+
+    if (!("code" in result)) {
+      throw new Error("Expected the decrypt failure to return a status");
+    }
+    expect(result.code).toBe(503);
+    expect(result.response).toMatchObject({
+      code: AI_CONFIG_UNREADABLE_ERROR_CODE,
+    });
+    // Only the settings read ran: the merge, the provider probe, and the
+    // write never start, so the request cannot narrow the stored providers
+    // down to the ones its body happens to carry.
+    expect(operationCount()).toBe(1);
+  });
+
+  test("read reports the failure instead of an unconfigured org", async () => {
+    const { safeDb } = createSettingsDb();
+
+    const result = await readAIConfig.handler(
+      createTestHandlerContext<ReadContext>({ safeDb }),
+    );
+
+    if (!("code" in result)) {
+      throw new Error("Expected the decrypt failure to return a status");
+    }
+    expect(result.code).toBe(503);
+    expect(result.response).toMatchObject({
+      code: AI_CONFIG_UNREADABLE_ERROR_CODE,
+    });
+  });
+});

--- a/apps/api/src/handlers/organization-settings/read-ai-config.ts
+++ b/apps/api/src/handlers/organization-settings/read-ai-config.ts
@@ -5,6 +5,7 @@ import { decryptAIConfig, maskApiKey } from "@/api/lib/ai-config-crypto";
 import {
   providerResponseExtras,
   providerResponseRegion,
+  storedAIConfigUnreadableError,
 } from "@/api/lib/ai-config-response";
 import { captureError } from "@/api/lib/analytics/capture";
 import { createSafeRootHandler } from "@/api/lib/api-handlers";
@@ -81,20 +82,23 @@ const readAIConfig = createSafeRootHandler(
 
       if (decryptResult.isErr()) {
         captureError(decryptResult.error);
-      } else {
-        const aiConfig = decryptResult.value;
-        result = {
-          configured: true,
-          providers: aiConfig.providers.map((providerConfig) => ({
-            provider: providerConfig.provider,
-            apiKeyMasked: maskApiKey(providerConfig.apiKey),
-            region: providerResponseRegion(providerConfig),
-            ...providerResponseExtras(providerConfig),
-          })),
-          overrideModels: aiConfig.overrideModels,
-          instanceProvisioned,
-        };
+        // Reporting the default here would present a stored-but-unreadable
+        // config as an unconfigured org and invite re-entry of the key.
+        return Result.err(storedAIConfigUnreadableError(decryptResult.error));
       }
+
+      const aiConfig = decryptResult.value;
+      result = {
+        configured: true,
+        providers: aiConfig.providers.map((providerConfig) => ({
+          provider: providerConfig.provider,
+          apiKeyMasked: maskApiKey(providerConfig.apiKey),
+          region: providerResponseRegion(providerConfig),
+          ...providerResponseExtras(providerConfig),
+        })),
+        overrideModels: aiConfig.overrideModels,
+        instanceProvisioned,
+      };
     }
 
     return Result.ok(result);

--- a/apps/api/src/handlers/organization-settings/update-ai-config.ts
+++ b/apps/api/src/handlers/organization-settings/update-ai-config.ts
@@ -18,6 +18,7 @@ import {
 import {
   providerResponseExtras,
   providerResponseRegion,
+  storedAIConfigUnreadableError,
 } from "@/api/lib/ai-config-response";
 import { probeProvider } from "@/api/lib/ai-provider-probe";
 import type { ProviderProbeResult } from "@/api/lib/ai-provider-probe";
@@ -102,10 +103,11 @@ const updateAIConfig = createSafeRootHandler(
 
       if (decryptResult.isErr()) {
         captureError(decryptResult.error);
-        existingConfig = undefined;
-      } else {
-        existingConfig = decryptResult.value;
+        // The stored config is the merge base for a partial update, so an
+        // unreadable one cannot be treated as "no providers configured".
+        return Result.err(storedAIConfigUnreadableError(decryptResult.error));
       }
+      existingConfig = decryptResult.value;
     }
 
     const providerResult = resolveProviderConfigs(

--- a/apps/api/src/lib/ai-config-response.ts
+++ b/apps/api/src/lib/ai-config-response.ts
@@ -2,11 +2,29 @@ import { panic } from "better-result";
 
 import { normalizeProviderRegion } from "@/api/lib/ai-config";
 import type { DataRegion, OrgAIProviderConfig } from "@/api/lib/ai-config";
+import { HandlerError } from "@/api/lib/errors/tagged-errors";
 
 export type ProviderResponseExtras = {
   endpoint?: string;
   apiVersion?: string;
 };
+
+export const AI_CONFIG_UNREADABLE_ERROR_CODE = "ai_config_stored_unreadable";
+
+/**
+ * The org has a stored AI config that cannot be decrypted. Every caller must
+ * fail closed on it, so both settings handlers raise the identical error:
+ * answering the read with `configured: false` makes an encryption-key problem
+ * look like "nothing configured" and prompts for re-entry, and merging an
+ * update onto an empty base would drop the providers the request body omits.
+ */
+export const storedAIConfigUnreadableError = (cause: unknown) =>
+  new HandlerError({
+    code: AI_CONFIG_UNREADABLE_ERROR_CODE,
+    status: 503,
+    message: "Stored AI configuration could not be read",
+    cause,
+  });
 
 export const providerResponseRegion = (
   providerConfig: OrgAIProviderConfig,

--- a/apps/web/src/routes/_protected.settings/-components/organization/ai-config-card.tsx
+++ b/apps/web/src/routes/_protected.settings/-components/organization/ai-config-card.tsx
@@ -33,6 +33,7 @@ import type {
 } from "@/components/ai-config-role-models.logic";
 import { useAnalytics } from "@/lib/analytics/provider";
 import { api } from "@/lib/api";
+import { detached } from "@/lib/detached";
 import { toAPIError, unwrapEden } from "@/lib/errors/api";
 import { userErrorFromThrown } from "@/lib/errors/user-safe";
 import {
@@ -46,9 +47,26 @@ export const AIConfigCard = () => {
     from: "/_protected",
     select: (ctx) => ctx.user.activeOrganizationId,
   });
-  const { data: config } = useQuery(
-    aiConfigOptions({ organizationId: activeOrganizationId }),
-  );
+  const {
+    data: config,
+    isError,
+    refetch,
+  } = useQuery(aiConfigOptions({ organizationId: activeOrganizationId }));
+
+  // The read fails closed when the stored config cannot be decrypted, and the
+  // form below is the only place the stored config can be removed. Rendering
+  // nothing would strand an administrator with no way back, so the failure gets
+  // its own state carrying the same remove action.
+  if (isError) {
+    return (
+      <AIConfigUnreadable
+        onRetry={() => {
+          detached(refetch(), "ai-config-card.refetch");
+        }}
+        organizationId={activeOrganizationId}
+      />
+    );
+  }
 
   if (!config) {
     return null;
@@ -60,6 +78,76 @@ export const AIConfigCard = () => {
       key={activeOrganizationId}
       organizationId={activeOrganizationId}
     />
+  );
+};
+
+type AIConfigUnreadableProps = {
+  onRetry: () => void;
+  organizationId: string;
+};
+
+const AIConfigUnreadable = ({
+  onRetry,
+  organizationId,
+}: AIConfigUnreadableProps) => {
+  const tCommon = useTranslations("common");
+  const tErrors = useTranslations("errors");
+  const tSuccess = useTranslations("success");
+  const analytics = useAnalytics();
+  const queryClient = useQueryClient();
+
+  const deleteMutation = useMutation({
+    mutationFn: async () => {
+      const response = await api["organization-settings"]["ai-config"].delete(
+        {},
+      );
+      if (response.error) {
+        throw toAPIError(response.error);
+      }
+    },
+    onSuccess: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: aiConfigKeys.byOrganization({ organizationId }),
+        }),
+        queryClient.invalidateQueries({
+          queryKey: aiConfigKeys.availability({ organizationId }),
+        }),
+      ]);
+      stellaToast.add({
+        title: tSuccess("aiConfigDeleted"),
+        type: "success",
+      });
+    },
+    onError: (error) => {
+      analytics.captureError(error);
+      stellaToast.add({
+        title: tErrors("actionFailed"),
+        type: "error",
+      });
+    },
+  });
+
+  return (
+    <div className="flex items-center justify-between gap-3 py-4">
+      <p className="text-destructive text-sm">
+        {tCommon("somethingWentWrong")}
+      </p>
+      <div className="flex items-center gap-2">
+        <Button onClick={onRetry} size="sm" variant="outline">
+          {tCommon("retry")}
+        </Button>
+        <Button
+          loading={deleteMutation.isPending}
+          onClick={() => deleteMutation.mutate()}
+          size="sm"
+          variant="ghost"
+        >
+          <Trash2Icon className="size-4" />
+          {tCommon("remove")}
+        </Button>
+      </div>
+    </div>
   );
 };
 


### PR DESCRIPTION
Both AI-config settings handlers treated a decrypt failure of the stored config as an empty config. For the read handler that reports `configured: false`, so an encryption-key problem looks like "nothing configured" and the UI prompts for re-entry. For the update handler the stored config is the merge base of a partial update, so continuing with an empty base drops every provider the request body omits.

Both handlers now abort with a shared `storedAIConfigUnreadableError` (`HandlerError`, 503, code `ai_config_stored_unreadable`) from `ai-config-response.ts`, which both already import, so the two paths cannot drift. The update aborts before the merge, provider probe, and write; no audit event is emitted on that path.

`read-ai-availability.ts` intentionally keeps its existing behavior: the per-request auth resolve sets `orgAIConfig` to `null` on an unreadable row so one bad row cannot fail every request for the org (documented in `ai-config-loader-core.ts`); only the explicit settings surface fails closed.

New `ai-config-decrypt-failure.test.ts` covers both handlers without module mocks: a real settings row whose ciphertext cannot be decrypted, plus a fake `safeDb` that throws on any post-abort write and asserts the operation count. A web error state for the now-throwing settings query would be a reasonable follow-up; the card currently renders nothing on error.