### PR TITLE
chore(api): derive agenda enums from a single const set

### DIFF
--- a/apps/api/src/db/schema/common.ts
+++ b/apps/api/src/db/schema/common.ts
@@ -81,6 +81,7 @@ import type { SafeId, SafeIdType } from "@/api/lib/branded-types";
 import type { ClauseBody } from "@/api/lib/clauses/types";
 import type { DocumentSource } from "@/api/lib/document-source";
 import type { TemplateManifest } from "@/api/lib/docx/types";
+import type { AgendaAttendeeType } from "@/api/lib/entity-constants";
 import type { CorpusSourceDescriptor } from "@/api/lib/legal-search/corpus-source";
 import type {
   DecisionSection,
@@ -171,30 +172,21 @@ export type JustificationContent = {
   blocks: JustificationBlock[];
 };
 
-export type AgendaItemKind =
-  | "deadline"
-  | "event"
-  | "hearing"
-  | "meeting"
-  | "task";
-
-export type AgendaItemSource =
-  | "api"
-  | "calendar"
-  | "email"
-  | "import"
-  | "infosoud"
-  | "manual";
-
-export type AgendaAvailability =
-  | "busy"
-  | "free"
-  | "out_of_office"
-  | "tentative"
-  | "unknown"
-  | "working_elsewhere";
-
-export type AgendaSensitivity = "confidential" | "normal" | "private";
+/** Re-exported so the schema layer keeps one import surface; the agenda member
+ *  tuples are declared in `@/api/lib/entity-constants` and every other consumer
+ *  derives from them. */
+export {
+  AGENDA_AVAILABILITIES,
+  AGENDA_ITEM_KINDS,
+  AGENDA_ITEM_SOURCES,
+  AGENDA_SENSITIVITIES,
+} from "@/api/lib/entity-constants";
+export type {
+  AgendaAvailability,
+  AgendaItemKind,
+  AgendaItemSource,
+  AgendaSensitivity,
+} from "@/api/lib/entity-constants";
 
 export type AgendaParticipant = {
   email: string | null;
@@ -204,7 +196,7 @@ export type AgendaParticipant = {
 export type AgendaAttendee = AgendaParticipant & {
   optional?: boolean;
   responseStatus?: string | null;
-  type?: "optional" | "required" | "resource" | null;
+  type?: AgendaAttendeeType | null;
 };
 
 export type AgendaRecurrence = {

--- a/apps/api/src/db/schema/entities.ts
+++ b/apps/api/src/db/schema/entities.ts
@@ -1,6 +1,10 @@
 import { DESKTOP_EDIT_FILE_TYPES } from "@/api/lib/desktop-edit-file-types";
 
 import {
+  AGENDA_AVAILABILITIES,
+  AGENDA_ITEM_KINDS,
+  AGENDA_ITEM_SOURCES,
+  AGENDA_SENSITIVITIES,
   ENTITY_DELETION_CLEANUP_STATUSES,
   ENTITY_KINDS,
   LIST_ITEM_TYPES,
@@ -75,9 +79,7 @@ export const entities = p.pgTable(
     status: p.varchar({ length: 32 }),
     priority: p.varchar({ length: 16 }),
     dueDate: p.date("due_date", { mode: "string" }),
-    agendaKind: p.text("agenda_kind", {
-      enum: ["task", "deadline", "meeting", "hearing", "event"],
-    }),
+    agendaKind: p.text("agenda_kind", { enum: AGENDA_ITEM_KINDS }),
     startAt: timestamptz("start_at"),
     endAt: timestamptz("end_at"),
     occurredAt: timestamptz("occurred_at"),
@@ -86,25 +88,12 @@ export const entities = p.pgTable(
     timeZone: p.varchar("time_zone", { length: 64 }),
     location: p.text("location"),
     onlineMeetingUrl: p.text("online_meeting_url"),
-    availability: p.text("availability", {
-      enum: [
-        "free",
-        "tentative",
-        "busy",
-        "out_of_office",
-        "working_elsewhere",
-        "unknown",
-      ],
-    }),
-    sensitivity: p.text("sensitivity", {
-      enum: ["normal", "private", "confidential"],
-    }),
+    availability: p.text("availability", { enum: AGENDA_AVAILABILITIES }),
+    sensitivity: p.text("sensitivity", { enum: AGENDA_SENSITIVITIES }),
     organizer: jsonb("organizer").$type<AgendaParticipant | null>(),
     attendees: jsonb("attendees").$type<AgendaAttendee[] | null>(),
     recurrence: jsonb("recurrence").$type<AgendaRecurrence | null>(),
-    agendaSource: p.text("agenda_source", {
-      enum: ["manual", "infosoud", "calendar", "email", "import", "api"],
-    }),
+    agendaSource: p.text("agenda_source", { enum: AGENDA_ITEM_SOURCES }),
     externalSource: p.varchar("external_source", { length: 64 }),
     externalId: p.varchar("external_id", { length: 256 }),
     externalChangeKey: p.varchar("external_change_key", { length: 512 }),

--- a/apps/api/src/lib/entity-constants.ts
+++ b/apps/api/src/lib/entity-constants.ts
@@ -6,18 +6,78 @@ export {
 } from "@stll/api-contract";
 export type { EntityPriority, TaskStatus } from "@stll/api-contract";
 
+/**
+ * The agenda enums, declared once.
+ *
+ * Everything that needs the full set derives from these tuples: the union
+ * types, the Drizzle column enums on `entities`, and the request validators.
+ * They are tuples rather than `Object.values(...)` results because Drizzle's
+ * `text({ enum })` only narrows a column to a literal union for a readonly
+ * tuple.
+ */
+export const AGENDA_ITEM_KINDS = [
+  "task",
+  "deadline",
+  "meeting",
+  "hearing",
+  "event",
+] as const;
+
+export type AgendaItemKind = (typeof AGENDA_ITEM_KINDS)[number];
+
+export const AGENDA_ITEM_SOURCES = [
+  "manual",
+  "infosoud",
+  "calendar",
+  "email",
+  "import",
+  "api",
+] as const;
+
+export type AgendaItemSource = (typeof AGENDA_ITEM_SOURCES)[number];
+
+export const AGENDA_AVAILABILITIES = [
+  "free",
+  "tentative",
+  "busy",
+  "out_of_office",
+  "working_elsewhere",
+  "unknown",
+] as const;
+
+export type AgendaAvailability = (typeof AGENDA_AVAILABILITIES)[number];
+
+export const AGENDA_SENSITIVITIES = [
+  "normal",
+  "private",
+  "confidential",
+] as const;
+
+export type AgendaSensitivity = (typeof AGENDA_SENSITIVITIES)[number];
+
+export const AGENDA_ATTENDEE_TYPES = [
+  "required",
+  "optional",
+  "resource",
+] as const;
+
+export type AgendaAttendeeType = (typeof AGENDA_ATTENDEE_TYPES)[number];
+
+/**
+ * Binds a member tuple to its named-constant map: total (every member needs a
+ * key) and exact (a key cannot point at a different member, and an unknown key
+ * is rejected), so adding a member without its constant fails typecheck rather
+ * than drifting.
+ */
+type ConstantMap<T extends string> = { [K in T as Uppercase<K>]: K };
+
 export const AGENDA_ITEM_KIND = {
   TASK: "task",
   DEADLINE: "deadline",
   MEETING: "meeting",
   HEARING: "hearing",
   EVENT: "event",
-} as const;
-
-export type AgendaItemKind =
-  (typeof AGENDA_ITEM_KIND)[keyof typeof AGENDA_ITEM_KIND];
-
-export const AGENDA_ITEM_KINDS = Object.values(AGENDA_ITEM_KIND);
+} as const satisfies ConstantMap<AgendaItemKind>;
 
 export const AGENDA_ITEM_SOURCE = {
   MANUAL: "manual",
@@ -26,12 +86,7 @@ export const AGENDA_ITEM_SOURCE = {
   EMAIL: "email",
   IMPORT: "import",
   API: "api",
-} as const;
-
-export type AgendaItemSource =
-  (typeof AGENDA_ITEM_SOURCE)[keyof typeof AGENDA_ITEM_SOURCE];
-
-export const AGENDA_ITEM_SOURCES = Object.values(AGENDA_ITEM_SOURCE);
+} as const satisfies ConstantMap<AgendaItemSource>;
 
 export const AGENDA_AVAILABILITY = {
   FREE: "free",
@@ -40,31 +95,19 @@ export const AGENDA_AVAILABILITY = {
   OUT_OF_OFFICE: "out_of_office",
   WORKING_ELSEWHERE: "working_elsewhere",
   UNKNOWN: "unknown",
-} as const;
-
-export type AgendaAvailability =
-  (typeof AGENDA_AVAILABILITY)[keyof typeof AGENDA_AVAILABILITY];
-
-export const AGENDA_AVAILABILITIES = Object.values(AGENDA_AVAILABILITY);
+} as const satisfies ConstantMap<AgendaAvailability>;
 
 export const AGENDA_SENSITIVITY = {
   NORMAL: "normal",
   PRIVATE: "private",
   CONFIDENTIAL: "confidential",
-} as const;
-
-export type AgendaSensitivity =
-  (typeof AGENDA_SENSITIVITY)[keyof typeof AGENDA_SENSITIVITY];
-
-export const AGENDA_SENSITIVITIES = Object.values(AGENDA_SENSITIVITY);
+} as const satisfies ConstantMap<AgendaSensitivity>;
 
 export const AGENDA_ATTENDEE_TYPE = {
   REQUIRED: "required",
   OPTIONAL: "optional",
   RESOURCE: "resource",
-} as const;
-
-export const AGENDA_ATTENDEE_TYPES = Object.values(AGENDA_ATTENDEE_TYPE);
+} as const satisfies ConstantMap<AgendaAttendeeType>;
 
 const DOCUMENT_STATUS = {
   DRAFT: "draft",

--- a/apps/api/src/lib/tasks/agenda-fields.ts
+++ b/apps/api/src/lib/tasks/agenda-fields.ts
@@ -1,12 +1,12 @@
-import type {
-  AgendaAttendee,
-  AgendaAvailability,
-  AgendaSensitivity,
-} from "@/api/db/schema";
+import type { AgendaAttendee } from "@/api/db/schema";
 import {
   AGENDA_ATTENDEE_TYPES,
   AGENDA_AVAILABILITIES,
   AGENDA_SENSITIVITIES,
+} from "@/api/lib/entity-constants";
+import type {
+  AgendaAvailability,
+  AgendaSensitivity,
 } from "@/api/lib/entity-constants";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import { includes } from "@/api/lib/type-guards";


### PR DESCRIPTION
The agenda unions (item kind, source, availability, sensitivity, attendee type) were declared three times: const objects in `lib/entity-constants.ts`, hand-written type unions in `db/schema/common.ts` (exporting identically named types), and inline literal arrays in the drizzle enums in `db/schema/entities.ts`. `agenda-fields.ts` validated values from one copy against types from another.

`entity-constants.ts` is now the single declaration: `as const` tuples with types derived via `(typeof X)[number]`, and the singular constant objects bound to their tuple with an exact `ConstantMap` mapped type (`as const satisfies`), so a member added, removed, or misrouted in either form fails typecheck. `common.ts` re-exports for the schema layer (matching the existing `ENTITY_KINDS` re-export precedent) and `entities.ts` consumes the tuples. The schema layer already imports from `lib` in value position, so no new layering direction and no cycle.

No behavior or SQL change: the columns are bare `text` (no CHECK) and the inferred column types were verified identical before and after. Typecheck cost is a small net reduction against the baseline.

Same-class follow-up surfaced while here, left out to keep the diff scoped: `common.ts` and `entity-constants.ts` still declare `TASK_ASSIGNEE_ROLES` independently.