### PR TITLE
fix(test): isolate module mocks against importers and verify factory exports

### DIFF
--- a/apps/api/scripts/run-tests.ts
+++ b/apps/api/scripts/run-tests.ts
@@ -85,28 +85,33 @@ const apiRoot = path.resolve(import.meta.dir, "..");
 
 // A `mock.module(...)` call runs at import time and, because bun's module-mock
 // registry is process-wide, leaks to every other file sharing that process,
-// even with `--isolate`. The batcher therefore keeps tests that mock the same
-// target apart. It only sees `mock.module` when written in the test's OWN
-// source, though. A helper module (e.g. tests/helpers/mock-root-db)
-// that calls `mock.module` at import hides the call from that text scan, so a
-// test importing it would otherwise land in the shared-process batch and clobber
-// a module (e.g. rootDb) that concurrent tests depend on. Detect those helpers
-// by their import path so any importer is isolated too. Keyed by the path
-// suffix as it appears in an import specifier (`@/api/<suffix>` or a relative
-// path ending in `<suffix>`).
+// even with `--isolate`. The batcher therefore keeps a mocked module away from
+// both the other files that mock it and the other files that merely import it
+// (see src/tests/module-mock-batching.ts). It only sees `mock.module` when
+// written in the test's OWN source, though. A helper module (e.g.
+// tests/helpers/mock-root-db) that calls `mock.module` at import hides the call
+// from that text scan, so a test importing it would otherwise land in the
+// shared-process batch and clobber a module (e.g. rootDb) that concurrent tests
+// depend on. Detect those helpers by their import path so any importer is
+// isolated too, and fold the helper's own mock targets and imports into every
+// importing test. Keyed by the path suffix as it appears in an import specifier
+// (`@/api/<suffix>` or a relative path ending in `<suffix>`).
 const moduleMockHelpers = [
   ...new Bun.Glob(TEST_HELPER_GLOB).scanSync({ cwd: apiRoot, onlyFiles: true }),
 ]
   .filter((helperPath) => !/\.test\.tsx?$/u.test(helperPath))
   .map((helperPath) => ({
+    helperPath,
     source: readFileSync(path.join(apiRoot, helperPath), "utf-8"),
     suffix: helperPath.replace(/^src\//u, "").replace(/\.tsx?$/u, ""),
   }))
   .filter(({ source }) => MODULE_MOCK_PATTERN.test(source))
-  .map(({ source, suffix }) => {
-    const metadata = readModuleMockMetadata(source);
+  .map(({ helperPath, source, suffix }) => {
+    const metadata = readModuleMockMetadata(source, helperPath);
     return {
+      hasUnknownImport: metadata.hasUnknownImport,
       hasUnknownMock: metadata.hasUnknownMock,
+      importedModules: metadata.importedModules,
       mockedModules: metadata.mockedModules,
       suffix,
     };
@@ -115,17 +120,25 @@ const moduleMockHelpers = [
 const installsModuleMock = (source: string): boolean =>
   MODULE_MOCK_PATTERN.test(source) ||
   moduleMockHelpers.some(({ suffix }) => source.includes(suffix));
-const readTestModuleMockMetadata = (source: string) => {
-  const directMetadata = readModuleMockMetadata(source);
+const readTestModuleMockMetadata = (source: string, testPath: string) => {
+  const directMetadata = readModuleMockMetadata(source, testPath);
   const metadata = {
+    hasUnknownImport: directMetadata.hasUnknownImport,
     hasUnknownMock: directMetadata.hasUnknownMock,
+    importedModules: new Set(directMetadata.importedModules),
     mockedModules: new Set(directMetadata.mockedModules),
   };
   for (const helper of moduleMockHelpers) {
     if (!source.includes(helper.suffix)) {
       continue;
     }
+    metadata.hasUnknownImport ||= helper.hasUnknownImport;
     metadata.hasUnknownMock ||= helper.hasUnknownMock;
+    // The helper's own imports arrive in the process along with it, so they
+    // are exposed to the batch's mocks exactly like the test file's imports.
+    for (const importedModule of helper.importedModules) {
+      metadata.importedModules.add(importedModule);
+    }
     for (const mockedModule of helper.mockedModules) {
       metadata.mockedModules.add(mockedModule);
     }
@@ -172,7 +185,7 @@ for (const { source, testPath } of classifiedTests) {
 
   if (installsModuleMock(source)) {
     moduleMockTests.push({
-      ...readTestModuleMockMetadata(source),
+      ...readTestModuleMockMetadata(source, testPath),
       testPath,
     });
     continue;

--- a/apps/api/src/handlers/chat/stream-chat-model-ingress.test.ts
+++ b/apps/api/src/handlers/chat/stream-chat-model-ingress.test.ts
@@ -7,7 +7,6 @@ const captureErrorMock = mock();
 void mock.module("@/api/lib/analytics/capture", () => ({
   captureError: captureErrorMock,
   captureRequestError: captureErrorMock,
-  getAnalytics: mock(() => ({ capture: mock(), flush: mock() })),
 }));
 
 const { guardModelSystemPrompt } =

--- a/apps/api/src/handlers/chat/tools/execute/chat-code-mode.test.ts
+++ b/apps/api/src/handlers/chat/tools/execute/chat-code-mode.test.ts
@@ -18,7 +18,6 @@ const captureErrorMock = mock();
 void mock.module("@/api/lib/analytics/capture", () => ({
   captureError: captureErrorMock,
   captureRequestError: captureErrorMock,
-  getAnalytics: mock(() => ({ capture: mock(), flush: mock() })),
 }));
 
 const { buildChatCodeMode } = await import("./chat-code-mode");

--- a/apps/api/src/handlers/chat/tools/registry-adapter/follow-ups.test.ts
+++ b/apps/api/src/handlers/chat/tools/registry-adapter/follow-ups.test.ts
@@ -14,7 +14,6 @@ import { createScopedDbMock } from "@/api/tests/scoped-db-mock";
 void mock.module("@/api/lib/analytics/capture", () => ({
   captureError: mock(),
   captureRequestError: mock(),
-  getAnalytics: mock(() => ({ capture: mock(), flush: mock() })),
 }));
 
 const { buildMcpContextFromChat } = await import("./mcp-chat-context");

--- a/apps/api/src/handlers/chat/tools/registry-adapter/projection-schema.test.ts
+++ b/apps/api/src/handlers/chat/tools/registry-adapter/projection-schema.test.ts
@@ -19,7 +19,6 @@ const captureErrorMock = mock();
 void mock.module("@/api/lib/analytics/capture", () => ({
   captureError: captureErrorMock,
   captureRequestError: captureErrorMock,
-  getAnalytics: mock(() => ({ capture: mock(), flush: mock() })),
 }));
 
 const { createChatRefRegistry } = await import("@/api/lib/chat/ref-registry");

--- a/apps/api/src/handlers/chat/tools/registry-adapter/registry-projection-contract.test.ts
+++ b/apps/api/src/handlers/chat/tools/registry-adapter/registry-projection-contract.test.ts
@@ -61,7 +61,6 @@ const captureErrorMock = mock();
 void mock.module("@/api/lib/analytics/capture", () => ({
   captureError: captureErrorMock,
   captureRequestError: captureErrorMock,
-  getAnalytics: mock(() => ({ capture: mock(), flush: mock() })),
 }));
 
 const readWorkspaceHandlerMock = mock();

--- a/apps/api/src/handlers/chat/tools/registry-adapter/run-registry-tool.test.ts
+++ b/apps/api/src/handlers/chat/tools/registry-adapter/run-registry-tool.test.ts
@@ -13,7 +13,6 @@ const captureErrorMock = mock();
 void mock.module("@/api/lib/analytics/capture", () => ({
   captureError: captureErrorMock,
   captureRequestError: captureErrorMock,
-  getAnalytics: mock(() => ({ capture: mock(), flush: mock() })),
 }));
 
 const { buildMcpContextFromChat } = await import("./mcp-chat-context");

--- a/apps/api/src/handlers/chat/tools/registry-adapter/run-registry-write-tool.test.ts
+++ b/apps/api/src/handlers/chat/tools/registry-adapter/run-registry-write-tool.test.ts
@@ -14,7 +14,6 @@ const captureErrorMock = mock();
 void mock.module("@/api/lib/analytics/capture", () => ({
   captureError: captureErrorMock,
   captureRequestError: captureErrorMock,
-  getAnalytics: mock(() => ({ capture: mock(), flush: mock() })),
 }));
 
 // Gate FEATURE_TIME_BILLING off (every other feature stays enabled) so the

--- a/apps/api/src/handlers/entities/copy-to-workspace.test.ts
+++ b/apps/api/src/handlers/entities/copy-to-workspace.test.ts
@@ -50,8 +50,6 @@ const captureErrorMock = mock(() => undefined);
 void mock.module("@/api/lib/analytics/capture", () => ({
   captureError: captureErrorMock,
   captureRequestError: captureErrorMock,
-  getAnalytics: () => ({ capture: mock(() => undefined) }),
-  isLocalPostHogDebugEnabled: () => false,
 }));
 
 const syncWorkspaceSearchActivityMock = mock(async () => {});

--- a/apps/api/src/lib/chat/model-ingress-guard.test.ts
+++ b/apps/api/src/lib/chat/model-ingress-guard.test.ts
@@ -12,7 +12,6 @@ const captureErrorMock = mock();
 void mock.module("@/api/lib/analytics/capture", () => ({
   captureError: captureErrorMock,
   captureRequestError: captureErrorMock,
-  getAnalytics: mock(() => ({ capture: mock(), flush: mock() })),
 }));
 
 const {

--- a/apps/api/src/lib/entity-versions/create-entity-version-from-buffer.test.ts
+++ b/apps/api/src/lib/entity-versions/create-entity-version-from-buffer.test.ts
@@ -69,7 +69,6 @@ void mock.module("@/api/lib/sse", () => ({
 void mock.module("@/api/lib/analytics/capture", () => ({
   captureError: mock(),
   captureRequestError: mock(),
-  getAnalytics: () => ({ capture: mock(), flush: mock() }),
 }));
 
 const { createEntityVersionFromBuffer } =

--- a/apps/api/src/lib/search/process-extraction.test.ts
+++ b/apps/api/src/lib/search/process-extraction.test.ts
@@ -129,8 +129,17 @@ void mock.module("@/api/lib/s3", () => ({
     throw new Error("Unexpected corpus object read in this suite");
   },
 }));
-void mock.module("@/api/lib/search/extract-content", () => ({
+// `canExtractMimeType` is exported by extractable-mime-types, and that is the
+// module `process-extraction` imports it from, so the override has to land
+// there. Spread the real module: the rest of it is shared with every other
+// extraction consumer.
+const realExtractableMimeTypes =
+  await import("@/api/lib/search/extractable-mime-types");
+void mock.module("@/api/lib/search/extractable-mime-types", () => ({
+  ...realExtractableMimeTypes,
   canExtractMimeType: () => true,
+}));
+void mock.module("@/api/lib/search/extract-content", () => ({
   extractFileTextResult: extractFileTextResultMock,
   resolveExtractionMimeType: ({
     fileName,

--- a/apps/api/src/lib/tanstack-ai-generate.test.ts
+++ b/apps/api/src/lib/tanstack-ai-generate.test.ts
@@ -51,7 +51,6 @@ const captureErrorMock = mock();
 void mock.module("@/api/lib/analytics/capture", () => ({
   captureError: captureErrorMock,
   captureRequestError: captureErrorMock,
-  getAnalytics: mock(() => ({ capture: mock(), flush: mock() })),
 }));
 
 void mock.module("@/api/lib/tanstack-ai-models", () => ({

--- a/apps/api/src/lib/workflow/utils.test.ts
+++ b/apps/api/src/lib/workflow/utils.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, describe, expect, mock, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 
 import type { ConditionNode } from "@stll/conditions";
 
@@ -10,17 +10,9 @@ import type {
   PropertyBatch,
 } from "@/api/lib/workflow/get-execution-plan";
 
-// Stub registry-only side effects. Avoid mocking `@/api/db`: this test never
-// loads `root.ts`, and Bun's `mock.module` leaks process-wide across files.
-void mock.module("@/api/handlers/registry/utils", () => ({
-  broadcastEvent: () => {},
-  resetActorState: () => {},
-}));
-
-afterAll(() => {
-  mock.restore();
-});
-
+// `@/api/lib/workflow/utils` is loaded dynamically so it resolves after this
+// module's own bindings; it reaches no registry or database module, so nothing
+// here needs stubbing.
 const { evaluateGatingCondition, prepareBatch } =
   await import("@/api/lib/workflow/utils");
 

--- a/apps/api/src/mcp/internal-failure-envelope.test.ts
+++ b/apps/api/src/mcp/internal-failure-envelope.test.ts
@@ -19,7 +19,6 @@ const createTimeEntryHandlerMock = mock();
 void mock.module("@/api/lib/analytics/capture", () => ({
   captureError: captureErrorMock,
   captureRequestError: captureErrorMock,
-  getAnalytics: () => ({ capture: mock(), flush: mock(async () => undefined) }),
 }));
 
 // Stub the backing time-entry create handler so the tool site receives a chosen

--- a/apps/api/src/mcp/onboarding.test.ts
+++ b/apps/api/src/mcp/onboarding.test.ts
@@ -8,12 +8,6 @@ import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
 import { toSafeDbMock } from "@/api/tests/scoped-db-mock";
 
 const captureErrorMock = mock();
-const analyticsCaptureMock = mock();
-const analyticsFlushMock = mock(async () => undefined);
-const getAnalyticsMock = mock(() => ({
-  capture: analyticsCaptureMock,
-  flush: analyticsFlushMock,
-}));
 const searchDecisionsHandlerMock = mock();
 const readDecisionHandlerMock = mock();
 const APP_BASE_URL = env.FRONTEND_URL.replace(/\/$/u, "");
@@ -21,7 +15,6 @@ const APP_BASE_URL = env.FRONTEND_URL.replace(/\/$/u, "");
 void mock.module("@/api/lib/analytics/capture", () => ({
   captureError: captureErrorMock,
   captureRequestError: captureErrorMock,
-  getAnalytics: getAnalyticsMock,
 }));
 
 void mock.module("@/api/handlers/case-law/decisions/search", () => ({

--- a/apps/api/src/mcp/template-tools.test.ts
+++ b/apps/api/src/mcp/template-tools.test.ts
@@ -34,7 +34,6 @@ const realAnonymizationBlacklist =
 void mock.module("@/api/lib/analytics/capture", () => ({
   captureError: captureErrorMock,
   captureRequestError: captureErrorMock,
-  getAnalytics: () => ({ capture: mock(), flush: mock(async () => undefined) }),
 }));
 
 void mock.module("@/api/mcp/anonymization", () => ({

--- a/apps/api/src/mcp/tools.test.ts
+++ b/apps/api/src/mcp/tools.test.ts
@@ -90,12 +90,6 @@ const anonymizeTextFieldsMock = mock();
 const loadAnonymizationGazetteerEntriesMock = mock();
 const decryptContentMock = mock();
 const captureErrorMock = mock();
-const analyticsCaptureMock = mock();
-const analyticsFlushMock = mock(async () => undefined);
-const getAnalyticsMock = mock(() => ({
-  capture: analyticsCaptureMock,
-  flush: analyticsFlushMock,
-}));
 const searchAcrossMattersExecute = mock();
 const readContentAcrossMattersExecute = mock();
 const readContactExecute = mock();
@@ -204,7 +198,6 @@ const normalizeAnonymizationBlacklistEntriesMock = (
 void mock.module("@/api/lib/analytics/capture", () => ({
   captureError: captureErrorMock,
   captureRequestError: captureErrorMock,
-  getAnalytics: getAnalyticsMock,
 }));
 
 void mock.module("@/api/lib/content-encryption", () => ({

--- a/apps/api/src/tests/module-mock-batching.test.ts
+++ b/apps/api/src/tests/module-mock-batching.test.ts
@@ -4,21 +4,28 @@ import path from "node:path";
 import {
   batchModuleMockTests,
   readModuleMockMetadata,
+  resolveModuleSpecifier,
   type ModuleMockTest,
 } from "./module-mock-batching";
 
 type ModuleMockTestOptions = {
+  hasUnknownImport?: boolean;
   hasUnknownMock?: boolean;
+  importedModules?: readonly string[];
   mockedModules: readonly string[];
   testPath: string;
 };
 
 const moduleMockTest = ({
+  hasUnknownImport = false,
   hasUnknownMock = false,
+  importedModules = [],
   mockedModules,
   testPath,
 }: ModuleMockTestOptions): ModuleMockTest => ({
+  hasUnknownImport,
   hasUnknownMock,
+  importedModules: new Set(importedModules),
   mockedModules: new Set(mockedModules),
   testPath,
 });
@@ -69,13 +76,129 @@ describe("batchModuleMockTests", () => {
 
   test("extracts literal targets and fails closed for dynamic module mocks", () => {
     const literalMock = `${S3_MODULE_MOCK_CALL}, () => ({}));`;
-    const metadata = readModuleMockMetadata(`
+    const metadata = readModuleMockMetadata(
+      `
       ${literalMock}
       void mock.module(moduleName, () => ({}));
-    `);
+    `,
+      "src/lib/example.test.ts",
+    );
 
-    expect([...metadata.mockedModules]).toEqual(["@/api/lib/s3"]);
+    expect([...metadata.mockedModules]).toEqual(["src/lib/s3"]);
     expect(metadata.hasUnknownMock).toBe(true);
+  });
+
+  test("collects the modules a test imports, in every literal specifier form", () => {
+    const metadata = readModuleMockMetadata(
+      `
+      import { captureError } from "@/api/lib/analytics/capture";
+      import type { Never } from "@/api/lib/analytics/erased-by-the-scanner";
+      import { helper } from "./sibling";
+      export { reexported } from "../analytics/capture";
+      const loaded = await import("bullmq");
+    `,
+      "src/lib/chat/example.test.ts",
+    );
+
+    expect([...metadata.importedModules].toSorted()).toEqual([
+      "bullmq",
+      "src/lib/analytics/capture",
+      "src/lib/chat/sibling",
+    ]);
+    expect(metadata.hasUnknownImport).toBe(false);
+  });
+
+  test("fails closed for a dynamic import with a computed specifier", () => {
+    const metadata = readModuleMockMetadata(
+      `const loaded = await import(moduleName);`,
+      "src/lib/example.test.ts",
+    );
+
+    expect(metadata.hasUnknownImport).toBe(true);
+  });
+
+  test("canonicalizes alias, relative, and bare specifiers", () => {
+    expect(
+      resolveModuleSpecifier("@/api/lib/analytics/capture", "src/x.test.ts"),
+    ).toBe("src/lib/analytics/capture");
+    expect(
+      resolveModuleSpecifier("../analytics/capture", "src/lib/chat/x.test.ts"),
+    ).toBe("src/lib/analytics/capture");
+    expect(
+      resolveModuleSpecifier("./capture.ts", "src/lib/analytics/x.test.ts"),
+    ).toBe("src/lib/analytics/capture");
+    expect(resolveModuleSpecifier("bullmq", "src/x.test.ts")).toBe("bullmq");
+  });
+
+  test("never co-batches a module's mocker with a file that imports it", () => {
+    // The failure this prevents: a partial mock of a shared module drops the
+    // exports it does not declare, so a co-located file that imports one of
+    // those exports for real sees `undefined` instead of the function.
+    const tests = [
+      moduleMockTest({
+        mockedModules: ["src/lib/analytics/capture"],
+        testPath: "model-ingress-guard.test.ts",
+      }),
+      moduleMockTest({
+        importedModules: ["src/lib/analytics/capture"],
+        mockedModules: ["src/lib/posthog-client"],
+        testPath: "capture.test.ts",
+      }),
+      moduleMockTest({
+        importedModules: ["src/lib/audit-log"],
+        mockedModules: ["src/lib/s3"],
+        testPath: "audit.test.ts",
+      }),
+    ];
+
+    const batches = batchModuleMockTests(tests, 3);
+    const mockerBatch = batches.find((batch) =>
+      batch.includes("model-ingress-guard.test.ts"),
+    );
+
+    expect(mockerBatch).toBeDefined();
+    expect(mockerBatch).not.toContain("capture.test.ts");
+    expect(batches.flat().toSorted()).toEqual(
+      tests.map(({ testPath }) => testPath).toSorted(),
+    );
+  });
+
+  test("separates mocker from importer in either declaration order", () => {
+    const importerFirst = batchModuleMockTests(
+      [
+        moduleMockTest({
+          importedModules: ["src/lib/analytics/capture"],
+          mockedModules: ["src/lib/posthog-client"],
+          testPath: "importer.test.ts",
+        }),
+        moduleMockTest({
+          mockedModules: ["src/lib/analytics/capture"],
+          testPath: "mocker.test.ts",
+        }),
+      ],
+      3,
+    );
+
+    expect(importerFirst).toEqual([["importer.test.ts"], ["mocker.test.ts"]]);
+  });
+
+  test("gives a file with an unresolvable dynamic import its own batch", () => {
+    const batches = batchModuleMockTests(
+      [
+        moduleMockTest({
+          hasUnknownImport: true,
+          mockedModules: ["src/lib/s3"],
+          testPath: "unknown-import.test.ts",
+        }),
+        moduleMockTest({
+          mockedModules: ["src/lib/audit-log"],
+          testPath: "audit.test.ts",
+        }),
+      ],
+      3,
+    );
+
+    expect(batches).toEqual([["unknown-import.test.ts"], ["audit.test.ts"]]);
   });
 
   test("never co-batches tests that can overwrite the same module mock", () => {
@@ -121,6 +244,36 @@ describe("batchModuleMockTests", () => {
     expect(dynamicBatch).toEqual(["dynamic.test.ts"]);
     expect(batches.flat().toSorted()).toEqual(
       tests.map(({ testPath }) => testPath).toSorted(),
+    );
+  });
+
+  test("splits the real capture mocker/importer pairing", async () => {
+    // Read from source rather than restating the metadata: the pairing is only
+    // a regression pin while it reflects what those two files actually do.
+    const testPaths = [
+      "src/lib/chat/model-ingress-guard.test.ts",
+      "src/lib/analytics/capture.test.ts",
+    ];
+    const tests = await Promise.all(
+      testPaths.map(async (testPath) => ({
+        ...readModuleMockMetadata(
+          await Bun.file(path.join(API_ROOT, testPath)).text(),
+          testPath,
+        ),
+        testPath,
+      })),
+    );
+
+    const [mocker, importer] = tests;
+    if (mocker === undefined || importer === undefined) {
+      throw new TypeError("missing pairing fixture");
+    }
+    expect([...mocker.mockedModules]).toContain("src/lib/analytics/capture");
+    expect([...importer.importedModules]).toContain(
+      "src/lib/analytics/capture",
+    );
+    expect(batchModuleMockTests(tests, 3)).toEqual(
+      testPaths.map((testPath) => [testPath]),
     );
   });
 

--- a/apps/api/src/tests/module-mock-batching.ts
+++ b/apps/api/src/tests/module-mock-batching.ts
@@ -1,10 +1,54 @@
 import { panic } from "better-result";
+import path from "node:path";
 
 const MODULE_MOCK_CALL_PATTERN = /\bmock\.module\s*\(/gu;
 const MODULE_MOCK_TARGET_PATTERN = /\bmock\.module\s*\(\s*["']([^"']+)["']/gu;
+// `import(` only when it starts an expression: a preceding identifier or dot
+// makes it a property access or a longer identifier, never a dynamic import.
+const DYNAMIC_IMPORT_CALL_PATTERN = /(?<![.\w$])import\s*\(/gu;
+const MODULE_ALIAS_PREFIX = "@/api/";
+const MODULE_ALIAS_TARGET = "src/";
+const MODULE_EXTENSION_PATTERN = /\.[cm]?[jt]sx?$/u;
+
+const transpilers = new Map<string, Bun.Transpiler>();
+const transpilerFor = (modulePath: string): Bun.Transpiler => {
+  const loader = modulePath.endsWith("x") ? "tsx" : "ts";
+  const cached = transpilers.get(loader);
+  if (cached !== undefined) {
+    return cached;
+  }
+  const transpiler = new Bun.Transpiler({ loader });
+  transpilers.set(loader, transpiler);
+  return transpiler;
+};
+
+/**
+ * Canonicalize a module specifier so the alias, relative, and bare forms of the
+ * same module compare equal. `fromModulePath` is the api-package-relative path
+ * of the file the specifier was written in (e.g. `src/lib/analytics/x.test.ts`).
+ */
+export const resolveModuleSpecifier = (
+  specifier: string,
+  fromModulePath: string,
+): string => {
+  if (specifier.startsWith(MODULE_ALIAS_PREFIX)) {
+    return `${MODULE_ALIAS_TARGET}${specifier.slice(MODULE_ALIAS_PREFIX.length)}`.replace(
+      MODULE_EXTENSION_PATTERN,
+      "",
+    );
+  }
+  if (specifier.startsWith(".")) {
+    return path.posix
+      .join(path.posix.dirname(fromModulePath), specifier)
+      .replace(MODULE_EXTENSION_PATTERN, "");
+  }
+  return specifier;
+};
 
 export type ModuleMockMetadata = {
+  hasUnknownImport: boolean;
   hasUnknownMock: boolean;
+  importedModules: ReadonlySet<string>;
   mockedModules: ReadonlySet<string>;
 };
 
@@ -13,34 +57,75 @@ export type ModuleMockTest = ModuleMockMetadata & {
 };
 
 type ModuleMockBatch = {
+  hasUnknownImport: boolean;
   hasUnknownMock: boolean;
+  importedModules: Set<string>;
   mockedModules: Set<string>;
   testPaths: string[];
 };
 
-export const readModuleMockMetadata = (source: string): ModuleMockMetadata => {
+export const readModuleMockMetadata = (
+  source: string,
+  modulePath: string,
+): ModuleMockMetadata => {
   const mockedModules = new Set<string>();
-  let literalCallCount = 0;
+  let literalMockCount = 0;
   for (const match of source.matchAll(MODULE_MOCK_TARGET_PATTERN)) {
     const mockedModule = match.at(1);
     if (mockedModule !== undefined) {
-      mockedModules.add(mockedModule);
-      literalCallCount += 1;
+      mockedModules.add(resolveModuleSpecifier(mockedModule, modulePath));
+      literalMockCount += 1;
     }
   }
-  const callCount = [...source.matchAll(MODULE_MOCK_CALL_PATTERN)].length;
+  const mockCallCount = [...source.matchAll(MODULE_MOCK_CALL_PATTERN)].length;
+
+  // Static `import`/`export from` and dynamic `import()` with a literal
+  // specifier. Type-only imports are erased by the scanner, which is what we
+  // want: they bind nothing at runtime, so a mock cannot break them.
+  const { imports } = transpilerFor(modulePath).scan(source);
+  const importedModules = new Set(
+    imports.map(({ path: specifier }) =>
+      resolveModuleSpecifier(specifier, modulePath),
+    ),
+  );
+  const literalDynamicImportCount = imports.filter(
+    ({ kind }) => kind === "dynamic-import",
+  ).length;
+  const dynamicImportCallCount = [
+    ...source.matchAll(DYNAMIC_IMPORT_CALL_PATTERN),
+  ].length;
+
   return {
-    hasUnknownMock: literalCallCount < callCount,
+    hasUnknownImport: literalDynamicImportCount < dynamicImportCallCount,
+    hasUnknownMock: literalMockCount < mockCallCount,
+    importedModules,
     mockedModules,
   };
 };
 
+// bun's module-mock registry is process-wide, so a `mock.module` call in one
+// file rewrites that module for every other file in the same process, even
+// under `--isolate`. Two files therefore conflict when EITHER of them mocks a
+// module the other one touches: co-mockers overwrite each other's factory, and
+// a partial mock (one export overridden, the rest dropped) breaks any file that
+// merely imports the module for real. Both directions are checked here.
 const canShareBatch = (batch: ModuleMockBatch, test: ModuleMockTest) => {
   if (batch.hasUnknownMock || test.hasUnknownMock) {
     return false;
   }
+  if (batch.hasUnknownImport || test.hasUnknownImport) {
+    return false;
+  }
   for (const mockedModule of test.mockedModules) {
-    if (batch.mockedModules.has(mockedModule)) {
+    if (
+      batch.mockedModules.has(mockedModule) ||
+      batch.importedModules.has(mockedModule)
+    ) {
+      return false;
+    }
+  }
+  for (const importedModule of test.importedModules) {
+    if (batch.mockedModules.has(importedModule)) {
       return false;
     }
   }
@@ -64,7 +149,9 @@ export const batchModuleMockTests = (
     );
     if (batch === undefined) {
       batches.push({
+        hasUnknownImport: test.hasUnknownImport,
         hasUnknownMock: test.hasUnknownMock,
+        importedModules: new Set(test.importedModules),
         mockedModules: new Set(test.mockedModules),
         testPaths: [test.testPath],
       });
@@ -74,6 +161,9 @@ export const batchModuleMockTests = (
     batch.testPaths.push(test.testPath);
     for (const mockedModule of test.mockedModules) {
       batch.mockedModules.add(mockedModule);
+    }
+    for (const importedModule of test.importedModules) {
+      batch.importedModules.add(importedModule);
     }
   }
 

--- a/apps/api/src/tests/module-mock-factories.test.ts
+++ b/apps/api/src/tests/module-mock-factories.test.ts
@@ -3,6 +3,7 @@ import { readFileSync } from "node:fs";
 import path from "node:path";
 
 import {
+  countModuleMockCallSites,
   readModuleExports,
   readModuleMockFactories,
   resolveModuleFile,
@@ -79,6 +80,49 @@ describe("module mock factories", () => {
     );
 
     expect(allFactories.length).toBeGreaterThanOrEqual(callSites.length);
+  });
+
+  test("returns one factory per call site, in every file", () => {
+    // A file may hold many mocks, so a repository-wide count has slack: the
+    // reader could stop recognizing a body shape and stay above any floor.
+    // Per file and in both directions there is no slack, and the two guards
+    // above cannot quietly narrow to the mocks that still happen to parse.
+    const mismatches = apiSourceFiles.flatMap((filePath) => {
+      const source = readFileSync(path.join(API_ROOT, filePath), "utf-8");
+      const sites = countModuleMockCallSites(source);
+      const read = readModuleMockFactories(source, filePath).length;
+      if (sites === read) {
+        return [];
+      }
+      return [`${filePath}: ${sites} call sites, ${read} factories read`];
+    });
+
+    expect(mismatches).toEqual([]);
+  });
+
+  test("reports a factory body it cannot read as opaque, not as absent", () => {
+    // Dropping these would remove the call site from every guard built on the
+    // reader. Reported instead, with no keys and marked as spreading, so the
+    // key-drift comparisons skip a shape they cannot judge.
+    const factories = readModuleMockFactories(
+      [
+        `void ${MOCK_CALL}"@/api/lib/analytics/capture", () => {`,
+        "  return { captureError: () => {} };",
+        "});",
+        `void ${MOCK_CALL}"@/api/lib/s3", () => stub);`,
+      ].join("\n"),
+      "src/lib/example.test.ts",
+    );
+
+    expect(factories.map((factory) => factory.moduleId)).toEqual([
+      "src/lib/analytics/capture",
+      "src/lib/s3",
+    ]);
+    expect(factories.map((factory) => factory.spreadsAnother)).toEqual([
+      true,
+      true,
+    ]);
+    expect(factories.flatMap((factory) => factory.declaredKeys)).toEqual([]);
   });
 
   test("reads keys, spreads, and quoted keys out of a factory", () => {

--- a/apps/api/src/tests/module-mock-factories.test.ts
+++ b/apps/api/src/tests/module-mock-factories.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import {
+  readModuleExports,
+  readModuleMockFactories,
+  resolveModuleFile,
+} from "./module-mock-factories";
+
+const API_ROOT = path.resolve(import.meta.dir, "../..");
+// Assembled so this file does not read as a module-mock call site to the
+// runner's scan (scripts/run-tests.ts) or to the batcher.
+const MOCK_CALL = ["mock", "module("].join(".");
+
+const apiSourceFiles = [
+  ...new Bun.Glob("src/**/*.{ts,tsx}").scanSync({
+    cwd: API_ROOT,
+    onlyFiles: true,
+  }),
+].toSorted();
+
+const allFactories = apiSourceFiles.flatMap((filePath) =>
+  readModuleMockFactories(
+    readFileSync(path.join(API_ROOT, filePath), "utf-8"),
+    filePath,
+  ),
+);
+
+describe("module mock factories", () => {
+  test("every declared key is a real export of the mocked module", () => {
+    // A module mock is a plain object: a key the real module does not export
+    // overrides nothing, so the behaviour the suite believes it forced never
+    // happens and the assertions pass for the wrong reason. Compare the keys
+    // against the target's exports, read from its SOURCE — importing the
+    // module here would run its side effects and register it in the same
+    // process the mocks live in, which is the leak this whole file exists to
+    // police.
+    const drifted = allFactories.flatMap((factory) => {
+      const moduleFile = resolveModuleFile(factory.moduleId, API_ROOT);
+      if (moduleFile === undefined) {
+        return [];
+      }
+      const realExports = readModuleExports(moduleFile, API_ROOT);
+      const unknownKeys = factory.declaredKeys.filter(
+        (key) => !realExports.has(key),
+      );
+      if (unknownKeys.length === 0) {
+        return [];
+      }
+      return [
+        `${factory.filePath}:${factory.line} mocks ${factory.moduleId} ` +
+          `with keys it does not export: ${unknownKeys.join(", ")}`,
+      ];
+    });
+
+    expect(drifted).toEqual([]);
+  });
+
+  test("every in-package mock target resolves to a module file", () => {
+    // A specifier that resolves to nothing installs a mock nobody can load:
+    // the stub is inert and the real collaborator keeps running.
+    const unresolved = allFactories
+      .filter(
+        (factory) =>
+          factory.moduleId.startsWith("src/") &&
+          resolveModuleFile(factory.moduleId, API_ROOT) === undefined,
+      )
+      .map(
+        ({ filePath, line, moduleId }) => `${filePath}:${line} → ${moduleId}`,
+      );
+
+    expect(unresolved).toEqual([]);
+  });
+
+  test("scans the repository's factories rather than silently finding none", () => {
+    const callSites = apiSourceFiles.filter((filePath) =>
+      readFileSync(path.join(API_ROOT, filePath), "utf-8").includes(MOCK_CALL),
+    );
+
+    expect(allFactories.length).toBeGreaterThanOrEqual(callSites.length);
+  });
+
+  test("reads keys, spreads, and quoted keys out of a factory", () => {
+    const factories = readModuleMockFactories(
+      [
+        `void ${MOCK_CALL}"@/api/lib/analytics/capture", () => ({`,
+        "  ...realCapture,",
+        "  captureError: () => {},",
+        '  "captureRequestError": (input: { url: string }) => input,',
+        "  nested: { captureError: 1 },",
+        "  fromArray: [{ captureError: 2 }],",
+        "}));",
+      ].join("\n"),
+      "src/lib/example.test.ts",
+    );
+
+    expect(factories).toHaveLength(1);
+    expect(factories.at(0)?.moduleId).toBe("src/lib/analytics/capture");
+    expect(factories.at(0)?.spreadsAnother).toBe(true);
+    expect(factories.at(0)?.declaredKeys).toEqual([
+      "captureError",
+      "captureRequestError",
+      "nested",
+      "fromArray",
+    ]);
+  });
+
+  test("follows `export *` re-exports when reading a module's exports", () => {
+    const constsFile = resolveModuleFile(
+      "src/handlers/case-law/consts",
+      API_ROOT,
+    );
+    if (constsFile === undefined) {
+      throw new TypeError("missing re-export fixture");
+    }
+
+    // consts.ts declares nothing itself; every name comes through `export *`.
+    expect([...readModuleExports(constsFile, API_ROOT)]).toContain(
+      "PARSER_VERSION",
+    );
+  });
+
+  test("reads the exports a module declares, without its types", () => {
+    const captureFile = resolveModuleFile(
+      "src/lib/analytics/capture",
+      API_ROOT,
+    );
+    if (captureFile === undefined) {
+      throw new TypeError("missing capture fixture");
+    }
+
+    expect([...readModuleExports(captureFile, API_ROOT)].toSorted()).toEqual([
+      "captureError",
+      "captureRequestError",
+      "resetCaptureWindows",
+    ]);
+  });
+});

--- a/apps/api/src/tests/module-mock-factories.ts
+++ b/apps/api/src/tests/module-mock-factories.ts
@@ -1,0 +1,279 @@
+import { panic } from "better-result";
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+import { resolveModuleSpecifier } from "./module-mock-batching";
+
+// Written with an escaped dot so this module's own source does not read as a
+// `mock.module` call site to the runner's helper scan (scripts/run-tests.ts).
+const MODULE_MOCK_FACTORY_PATTERN =
+  /\bmock\.module\s*\(\s*["']([^"']+)["']\s*,\s*(?:async\s+)?\(\s*\)\s*=>\s*\(/gu;
+const STAR_REEXPORT_PATTERN = /\bexport\s*\*\s*from\s*["']([^"']+)["']/gu;
+const OBJECT_KEY_PATTERN =
+  /^(?:(?:get|set)\s+)?(?:([A-Za-z_$][\w$]*)|"([^"]+)"|'([^']+)')$/u;
+const MODULE_FILE_SUFFIXES = [
+  ".ts",
+  ".tsx",
+  "/index.ts",
+  "/index.tsx",
+] as const;
+
+const transpilers = new Map<string, Bun.Transpiler>();
+const transpilerFor = (modulePath: string): Bun.Transpiler => {
+  const loader = modulePath.endsWith("x") ? "tsx" : "ts";
+  const cached = transpilers.get(loader);
+  if (cached !== undefined) {
+    return cached;
+  }
+  const transpiler = new Bun.Transpiler({ loader });
+  transpilers.set(loader, transpiler);
+  return transpiler;
+};
+
+export type ModuleMockFactory = {
+  /** Keys the factory declares, spreads excluded. */
+  declaredKeys: string[];
+  /** Api-relative path of the file holding the `mock.module` call. */
+  filePath: string;
+  line: number;
+  /** Canonicalized mock target, e.g. `src/lib/analytics/capture`. */
+  moduleId: string;
+  /** Mock target exactly as written, e.g. `@/api/lib/analytics/capture`. */
+  specifier: string;
+  /** True when the factory spreads another object (`...realCapture`). */
+  spreadsAnother: boolean;
+};
+
+/**
+ * The text between the braces of the object literal starting at `openIndex`,
+ * respecting nesting, strings, and comments.
+ */
+const readObjectLiteral = (
+  source: string,
+  openIndex: number,
+): string | undefined => {
+  let depth = 0;
+  let index = openIndex;
+  while (index < source.length) {
+    const char = source[index];
+    if (char === undefined) {
+      return undefined;
+    }
+    if (char === '"' || char === "'" || char === "`") {
+      index = skipString(source, index);
+      continue;
+    }
+    if (char === "/" && source[index + 1] === "/") {
+      index = source.indexOf("\n", index);
+      if (index === -1) {
+        return undefined;
+      }
+      continue;
+    }
+    if (char === "/" && source[index + 1] === "*") {
+      const end = source.indexOf("*/", index + 2);
+      if (end === -1) {
+        return undefined;
+      }
+      index = end + 2;
+      continue;
+    }
+    if (char === "{" || char === "[" || char === "(") {
+      depth += 1;
+    } else if (char === "}" || char === "]" || char === ")") {
+      depth -= 1;
+      if (depth === 0) {
+        return source.slice(openIndex + 1, index);
+      }
+    }
+    index += 1;
+  }
+  return undefined;
+};
+
+const skipString = (source: string, openIndex: number): number => {
+  const quote = source[openIndex];
+  let index = openIndex + 1;
+  while (index < source.length) {
+    const char = source[index];
+    if (char === "\\") {
+      index += 2;
+      continue;
+    }
+    if (char === quote) {
+      return index + 1;
+    }
+    index += 1;
+  }
+  return source.length;
+};
+
+/** Split an object-literal body on its top-level commas. */
+const splitTopLevelEntries = (body: string): string[] => {
+  const entries: string[] = [];
+  let depth = 0;
+  let start = 0;
+  let index = 0;
+  while (index < body.length) {
+    const char = body[index];
+    if (char === undefined) {
+      break;
+    }
+    if (char === '"' || char === "'" || char === "`") {
+      index = skipString(body, index);
+      continue;
+    }
+    if (char === "/" && body[index + 1] === "/") {
+      const lineEnd = body.indexOf("\n", index);
+      index = lineEnd === -1 ? body.length : lineEnd;
+      continue;
+    }
+    if (char === "/" && body[index + 1] === "*") {
+      const end = body.indexOf("*/", index + 2);
+      index = end === -1 ? body.length : end + 2;
+      continue;
+    }
+    if (char === "{" || char === "[" || char === "(") {
+      depth += 1;
+    } else if (char === "}" || char === "]" || char === ")") {
+      depth -= 1;
+    } else if (char === "," && depth === 0) {
+      entries.push(body.slice(start, index));
+      start = index + 1;
+    }
+    index += 1;
+  }
+  entries.push(body.slice(start));
+  return entries.map((entry) => entry.trim()).filter((entry) => entry !== "");
+};
+
+const readEntryKey = (entry: string): string | undefined => {
+  const separator = entry.search(/[:(]/u);
+  const head = (separator === -1 ? entry : entry.slice(0, separator)).trim();
+  const match = OBJECT_KEY_PATTERN.exec(head);
+  return match?.at(1) ?? match?.at(2) ?? match?.at(3);
+};
+
+/**
+ * Every module-mock call in `source` that names a literal specifier and
+ * returns an object literal. A factory whose keys cannot be read (computed
+ * keys, a non-literal body) is reported with `declaredKeys: []` and
+ * `spreadsAnother: true`, so the drift guard stays quiet on shapes it cannot
+ * judge rather than guessing.
+ */
+export const readModuleMockFactories = (
+  source: string,
+  filePath: string,
+): ModuleMockFactory[] => {
+  const factories: ModuleMockFactory[] = [];
+  for (const match of source.matchAll(MODULE_MOCK_FACTORY_PATTERN)) {
+    const specifier = match.at(1);
+    const matchIndex = match.index;
+    if (specifier === undefined) {
+      continue;
+    }
+    const bodyStart = matchIndex + match[0].length;
+    const openIndex =
+      bodyStart + (source.slice(bodyStart).match(/^\s*/u)?.at(0)?.length ?? 0);
+    if (source[openIndex] !== "{") {
+      // The factory returns something other than an object literal; there are
+      // no keys to compare.
+      continue;
+    }
+    const literalBody = readObjectLiteral(source, openIndex);
+    if (literalBody === undefined) {
+      panic(`unterminated mock factory in ${filePath}`);
+    }
+    const entries = splitTopLevelEntries(literalBody);
+    const declaredKeys: string[] = [];
+    let spreadsAnother = false;
+    for (const entry of entries) {
+      if (entry.startsWith("...")) {
+        spreadsAnother = true;
+        continue;
+      }
+      const key = readEntryKey(entry);
+      if (key === undefined) {
+        // A computed or otherwise unreadable key: treat the whole factory as
+        // opaque rather than reporting keys we may have mis-parsed.
+        declaredKeys.length = 0;
+        spreadsAnother = true;
+        break;
+      }
+      declaredKeys.push(key);
+    }
+    factories.push({
+      declaredKeys,
+      filePath,
+      line: source.slice(0, matchIndex).split("\n").length,
+      moduleId: resolveModuleSpecifier(specifier, filePath),
+      specifier,
+      spreadsAnother,
+    });
+  }
+  return factories;
+};
+
+/**
+ * Resolve a canonicalized api-relative module id to a file on disk, or
+ * `undefined` for a specifier that does not live in this package (an npm or
+ * workspace package, whose exports are not statically readable here).
+ */
+export const resolveModuleFile = (
+  moduleId: string,
+  apiRoot: string,
+): string | undefined => {
+  if (!moduleId.startsWith("src/")) {
+    return undefined;
+  }
+  for (const suffix of MODULE_FILE_SUFFIXES) {
+    const candidate = path.join(apiRoot, `${moduleId}${suffix}`);
+    if (existsSync(candidate)) {
+      return candidate;
+    }
+  }
+  return undefined;
+};
+
+/**
+ * Names a module exports at runtime, read from its SOURCE rather than by
+ * importing it: importing a module inside the suite would run its side effects
+ * and, worse, register it in the same process the mocks live in. `export *`
+ * re-exports are followed so a facade module reports the names it forwards.
+ */
+export const readModuleExports = (
+  moduleFile: string,
+  apiRoot: string,
+  seen = new Set<string>(),
+): Set<string> => {
+  const exports = new Set<string>();
+  if (seen.has(moduleFile)) {
+    return exports;
+  }
+  seen.add(moduleFile);
+
+  const source = readFileSync(moduleFile, "utf-8");
+  for (const name of transpilerFor(moduleFile).scan(source).exports) {
+    exports.add(name);
+  }
+
+  const apiRelative = path.relative(apiRoot, moduleFile);
+  for (const match of source.matchAll(STAR_REEXPORT_PATTERN)) {
+    const specifier = match.at(1);
+    if (specifier === undefined) {
+      continue;
+    }
+    const reexportFile = resolveModuleFile(
+      resolveModuleSpecifier(specifier, apiRelative),
+      apiRoot,
+    );
+    if (reexportFile === undefined) {
+      continue;
+    }
+    for (const name of readModuleExports(reexportFile, apiRoot, seen)) {
+      exports.add(name);
+    }
+  }
+
+  return exports;
+};

--- a/apps/api/src/tests/module-mock-factories.ts
+++ b/apps/api/src/tests/module-mock-factories.ts
@@ -4,10 +4,16 @@ import path from "node:path";
 
 import { resolveModuleSpecifier } from "./module-mock-batching";
 
+// Every call site this reader must account for: a `mock.module` naming its
+// target with a string literal. A computed target names no module to compare
+// against and is out of scope for both this pattern and the reader.
+//
 // Written with an escaped dot so this module's own source does not read as a
 // `mock.module` call site to the runner's helper scan (scripts/run-tests.ts).
-const MODULE_MOCK_FACTORY_PATTERN =
-  /\bmock\.module\s*\(\s*["']([^"']+)["']\s*,\s*(?:async\s+)?\(\s*\)\s*=>\s*\(/gu;
+const MODULE_MOCK_CALL_PATTERN = /\bmock\.module\s*\(\s*["']([^"']+)["']\s*,/gu;
+// The `() => (` an object-literal factory opens with, measured from just past
+// the target literal's comma.
+const OBJECT_FACTORY_PREFIX_PATTERN = /^\s*(?:async\s+)?\(\s*\)\s*=>\s*\(\s*/u;
 const STAR_REEXPORT_PATTERN = /\bexport\s*\*\s*from\s*["']([^"']+)["']/gu;
 const OBJECT_KEY_PATTERN =
   /^(?:(?:get|set)\s+)?(?:([A-Za-z_$][\w$]*)|"([^"]+)"|'([^']+)')$/u;
@@ -154,65 +160,87 @@ const readEntryKey = (entry: string): string | undefined => {
   return match?.at(1) ?? match?.at(2) ?? match?.at(3);
 };
 
+type FactoryKeys = Pick<ModuleMockFactory, "declaredKeys" | "spreadsAnother">;
+
 /**
- * Every module-mock call in `source` that names a literal specifier and
- * returns an object literal. A factory whose keys cannot be read (computed
- * keys, a non-literal body) is reported with `declaredKeys: []` and
- * `spreadsAnother: true`, so the drift guard stays quiet on shapes it cannot
- * judge rather than guessing.
+ * A factory this reader cannot judge: a block body, a returned variable, a
+ * computed key. Reported with no declared keys and marked as spreading so the
+ * drift guards skip it rather than comparing keys that may be mis-parsed.
+ */
+const opaqueFactory = (): FactoryKeys => ({
+  declaredKeys: [],
+  spreadsAnother: true,
+});
+
+/** Keys of the object literal a factory returns, read from `bodyStart` (just
+ *  past the target literal's comma). */
+const readFactoryKeys = (
+  source: string,
+  bodyStart: number,
+  filePath: string,
+): FactoryKeys => {
+  const prefix = OBJECT_FACTORY_PREFIX_PATTERN.exec(source.slice(bodyStart));
+  if (prefix === null) {
+    return opaqueFactory();
+  }
+  const openIndex = bodyStart + prefix[0].length;
+  if (source[openIndex] !== "{") {
+    return opaqueFactory();
+  }
+  const literalBody = readObjectLiteral(source, openIndex);
+  if (literalBody === undefined) {
+    panic(`unterminated mock factory in ${filePath}`);
+  }
+  const declaredKeys: string[] = [];
+  let spreadsAnother = false;
+  for (const entry of splitTopLevelEntries(literalBody)) {
+    if (entry.startsWith("...")) {
+      spreadsAnother = true;
+      continue;
+    }
+    const key = readEntryKey(entry);
+    if (key === undefined) {
+      return opaqueFactory();
+    }
+    declaredKeys.push(key);
+  }
+  return { declaredKeys, spreadsAnother };
+};
+
+/**
+ * Every module-mock call in `source` that names a literal specifier, one entry
+ * per call site. A factory whose keys cannot be read is reported as opaque
+ * rather than skipped, so a body shape this reader stops recognizing cannot
+ * quietly narrow the guards built on it to the mocks that still parse.
  */
 export const readModuleMockFactories = (
   source: string,
   filePath: string,
 ): ModuleMockFactory[] => {
   const factories: ModuleMockFactory[] = [];
-  for (const match of source.matchAll(MODULE_MOCK_FACTORY_PATTERN)) {
+  for (const match of source.matchAll(MODULE_MOCK_CALL_PATTERN)) {
     const specifier = match.at(1);
     const matchIndex = match.index;
     if (specifier === undefined) {
       continue;
     }
-    const bodyStart = matchIndex + match[0].length;
-    const openIndex =
-      bodyStart + (source.slice(bodyStart).match(/^\s*/u)?.at(0)?.length ?? 0);
-    if (source[openIndex] !== "{") {
-      // The factory returns something other than an object literal; there are
-      // no keys to compare.
-      continue;
-    }
-    const literalBody = readObjectLiteral(source, openIndex);
-    if (literalBody === undefined) {
-      panic(`unterminated mock factory in ${filePath}`);
-    }
-    const entries = splitTopLevelEntries(literalBody);
-    const declaredKeys: string[] = [];
-    let spreadsAnother = false;
-    for (const entry of entries) {
-      if (entry.startsWith("...")) {
-        spreadsAnother = true;
-        continue;
-      }
-      const key = readEntryKey(entry);
-      if (key === undefined) {
-        // A computed or otherwise unreadable key: treat the whole factory as
-        // opaque rather than reporting keys we may have mis-parsed.
-        declaredKeys.length = 0;
-        spreadsAnother = true;
-        break;
-      }
-      declaredKeys.push(key);
-    }
     factories.push({
-      declaredKeys,
+      ...readFactoryKeys(source, matchIndex + match[0].length, filePath),
       filePath,
       line: source.slice(0, matchIndex).split("\n").length,
       moduleId: resolveModuleSpecifier(specifier, filePath),
       specifier,
-      spreadsAnother,
     });
   }
   return factories;
 };
+
+/**
+ * Call sites `readModuleMockFactories` is expected to return an entry for.
+ * Counted separately so the two can be compared per file, in both directions.
+ */
+export const countModuleMockCallSites = (source: string): number =>
+  [...source.matchAll(MODULE_MOCK_CALL_PATTERN)].length;
 
 /**
  * Resolve a canonicalized api-relative module id to a file on disk, or

--- a/apps/api/src/tests/security/oxlint-guardrails.test.ts
+++ b/apps/api/src/tests/security/oxlint-guardrails.test.ts
@@ -2,6 +2,12 @@ import { describe, expect, test } from "bun:test";
 import { existsSync, readdirSync, readFileSync } from "node:fs";
 import path from "node:path";
 
+import {
+  readModuleExports,
+  readModuleMockFactories,
+  resolveModuleFile,
+} from "@/api/tests/module-mock-factories";
+
 const readRootFixture = (relativePath: string) =>
   readFileSync(
     path.join(import.meta.dir, "../../../../..", relativePath),
@@ -546,47 +552,86 @@ describe("custom oxlint guardrails", () => {
     );
   });
 
-  test("mock.module of leaky shared modules spreads the real module", () => {
-    // bun's `mock.module` is process-global and cannot be restored, so a
-    // PARTIAL mock of a shared module (overriding one export, dropping the
-    // rest) deletes the other exports for every LATER test file in the run —
-    // any file that imports a dropped export then crashes with
-    // "Export ... not found", an order-dependent failure. For modules other
-    // test files import for real, the mock MUST spread the real module first
-    // (`...realX`) so nothing is dropped. Add modules here as leaks surface.
-    const leakyModules = ["@/api/lib/s3", "@/api/lib/redis-client", "bullmq"];
+  test("module mocks do not start dropping more of the real module's exports", () => {
+    // A PARTIAL module mock (one export overridden, the rest dropped) removes
+    // the other exports for every file sharing the process, so a file that
+    // imports a dropped export gets `undefined` back instead of the function.
+    //
+    // The api test runner now prevents the direct form of that on its own: the
+    // batcher (src/tests/module-mock-batching.ts) refuses to co-locate a
+    // module's mocker with a file that imports it, and the shared-process
+    // batches hold no mock-installing file at all. What neither can see is the
+    // TRANSITIVE importer, a co-batched file reaching the mocked module through
+    // a handler it imports. Walking the whole import graph instead would put
+    // nearly every mock file in a batch of one (src/lib/analytics/capture alone
+    // has ~130 non-test importers inside apps/api), so not dropping exports in
+    // the first place stays the defence there and this guard stays.
+    //
+    // It no longer carries a hand-kept module list. The property is read off
+    // each target module's own source: a factory is clean when it spreads the
+    // real module, or when it declares every export the module has. The
+    // opposite direction (a factory declaring keys the real module does NOT
+    // export) is guarded in src/tests/module-mock-factories.test.ts.
+    //
+    // Committed baseline, may only DECREASE: fix mocks and lower it. Raising it
+    // means a new mock started dropping exports, and needs the same
+    // justification as the other committed baselines in this repo.
+    const EXPORT_DROPPING_MOCK_BASELINE = 86;
     const root = path.join(import.meta.dir, "../../../../..");
-    const offenders: string[] = [];
-
-    for (const relative of new Bun.Glob("apps/api/src/**/*.test.ts").scanSync(
-      root,
-    )) {
-      const source = readFileSync(path.join(root, relative), "utf-8");
-      for (const moduleId of leakyModules) {
-        const marker = `mock.module("${moduleId}"`;
-        const hasRealImport = source.includes(`await import("${moduleId}")`);
-        let index = source.indexOf(marker);
-        while (index !== -1) {
-          // Skip quoted mentions (assertions referencing the pattern as a
-          // string, e.g. in this guardrail itself) — only real calls count.
-          const precedingChar = source[index - 1];
-          const isQuotedMention =
-            precedingChar === '"' ||
-            precedingChar === "'" ||
-            precedingChar === "`";
-          if (!isQuotedMention) {
-            const factoryStart = source.slice(index, index + 200);
-            const spreadsReal = /[=]>\s*\(\{\s*\.\.\.\w+/u.test(factoryStart);
-            if (!hasRealImport || !spreadsReal) {
-              offenders.push(`${relative} → ${moduleId}`);
-            }
-          }
-          index = source.indexOf(marker, index + marker.length);
-        }
+    const apiRoot = path.join(root, "apps/api");
+    const exportsByModuleFile = new Map<string, Set<string>>();
+    const realExportsOf = (moduleFile: string): Set<string> => {
+      const cached = exportsByModuleFile.get(moduleFile);
+      if (cached !== undefined) {
+        return cached;
       }
-    }
+      const moduleExports = readModuleExports(moduleFile, apiRoot);
+      exportsByModuleFile.set(moduleFile, moduleExports);
+      return moduleExports;
+    };
 
-    expect(offenders).toEqual([]);
+    const offenders = [
+      ...new Bun.Glob("src/**/*.test.{ts,tsx}").scanSync({
+        cwd: apiRoot,
+        onlyFiles: true,
+      }),
+    ]
+      .toSorted()
+      .flatMap((relative) => {
+        const source = readFileSync(path.join(apiRoot, relative), "utf-8");
+        return readModuleMockFactories(source, relative).flatMap((factory) => {
+          const moduleFile = resolveModuleFile(factory.moduleId, apiRoot);
+          // Only this package's modules can be read from source; an npm or
+          // workspace target has no statically readable export list.
+          if (moduleFile === undefined) {
+            return [];
+          }
+          if (
+            factory.spreadsAnother &&
+            source.includes(`await import("${factory.specifier}")`)
+          ) {
+            return [];
+          }
+          const declaredKeys = new Set(factory.declaredKeys);
+          const dropped = [...realExportsOf(moduleFile)].filter(
+            (name) => !declaredKeys.has(name),
+          );
+          if (dropped.length === 0) {
+            return [];
+          }
+          return [
+            `${factory.filePath}:${factory.line} → ${factory.moduleId} ` +
+              `drops ${dropped.join(", ")}`,
+          ];
+        });
+      });
+
+    // Listed rather than counted once over the baseline, so a regression names
+    // the mock that caused it.
+    expect(
+      offenders.length > EXPORT_DROPPING_MOCK_BASELINE ? offenders : [],
+    ).toEqual([]);
+    expect(offenders.length).toBeLessThanOrEqual(EXPORT_DROPPING_MOCK_BASELINE);
   });
 
   test("devtools shell lazy-loads TanStack panels", () => {


### PR DESCRIPTION
`mock.module` is process-global, and the API test batcher's invariant was "no two files mock the same module". That misses the sharper hazard: file A partially mocks module M while file B imports M. Such pairs currently avoid sharing a process only through bin-packing luck; pairing `model-ingress-guard.test.ts` with `capture.test.ts` by hand fails with `resetCaptureWindows is not a function`.

**Import-aware batching** (`module-mock-batching.ts`): file metadata now includes imported modules (via `Bun.Transpiler.scan`: static, `export from`, and literal dynamic imports; mock-helper imports folded in), with all specifiers canonicalized so alias/relative spellings compare equal. `canShareBatch` rejects a batch when either side mocks what the other imports; computed specifiers fail closed into a solo batch. Batch count moves 34 → 35. The reproduction pairing now lands in separate batches, both green.

**Factory export verification** (new `module-mock-factories.ts` + test): every `mock.module` object-literal factory's keys must exist as exports of the real module, read by static analysis of the target's source (importing targets at test time would itself leak into the process being policed). This replaces the hand-maintained three-module spread allowlist in `oxlint-guardrails.test.ts` with a property read off each factory: clean means spreading the real module or declaring its full export set. Factories that drop exports are pinned by a committed decrease-only baseline (86) that names offenders on regression; transitive importers (a co-batched file reaching a mocked module through a handler) remain covered by this guard, which is why it stays.

The guard caught 17 drifted fixtures, now fixed: one inert override re-pointed to the module the code actually imports (`canExtractMimeType`, verified live by inverting it), one mock of a nonexistent module removed, and 15 dead `getAnalytics`-style keys dropped from factories mocking the wrong module. All touched suites pass in isolation.

Follow-up scope decision left open: adding real-module spreads to the 24 remaining partial mocks of `analytics/capture` would shrink the baseline to ~62 but changes what those suites execute, so it belongs to its own pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test mock analysis to detect import conflicts and prevent incompatible test batching.
  * Added support for resolving static and dynamic imports, aliases and re-exported modules.

* **Tests**
  * Added repository-wide validation to identify incomplete module mocks.
  * Expanded coverage for mock factories, imports, export handling and module resolution.
  * Removed obsolete analytics mocks and refined test setup across API test suites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->