### PR TITLE
feat(case-law): pl-courts listing reconciliation capability

### DIFF
--- a/apps/api/src/handlers/case-law/ingestion/adapters/pl-courts-reconciliation.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/pl-courts-reconciliation.test.ts
@@ -310,6 +310,33 @@ describe("pl-courts listSlicePage", () => {
 
     expect(await sliceRejection(SLICE)).toBeInstanceOf(AdapterFetchError);
   });
+
+  test("a page the result total says has judgments must return them", async () => {
+    // Both spellings of the same malformed page do the same damage: the walk
+    // would record the slice from the identities it saw rather than the ones
+    // the publisher counted, leaving it settled with the rows never fetched.
+    for (const body of [
+      JSON.stringify({ items: [], info: { totalResults: 283 } }),
+      JSON.stringify({ info: { totalResults: 283 } }),
+    ]) {
+      mockFetchWithBodies([{ pattern: SEARCH_PATTERN, body }]);
+      // oxlint-disable-next-line no-await-in-loop -- one mocked response at a time; the mock is process-global
+      expect(await sliceRejection(SLICE)).toBeInstanceOf(AdapterFetchError);
+    }
+  });
+
+  test("a page past the stated total is empty rather than a failure", async () => {
+    // The last page of a day is genuinely empty when the total divides evenly;
+    // only a page the total still covers is a contradiction.
+    mockFetchWithBodies([
+      { pattern: SEARCH_PATTERN, body: searchBody([], 200) },
+    ]);
+
+    const page = await reconciliation.listSlicePage({ slice: SLICE, page: 2 });
+
+    expect(page.items).toEqual([]);
+    expect(page.totalPages).toBe(2);
+  });
 });
 
 describe("pl-courts buildDecision", () => {

--- a/apps/api/src/handlers/case-law/ingestion/adapters/pl-courts-reconciliation.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/pl-courts-reconciliation.test.ts
@@ -1,0 +1,400 @@
+/**
+ * The pl-courts listing reconciliation capability.
+ *
+ * Three things here are silent when wrong and cheap to pin. Slice arithmetic
+ * has to round-trip and order lexicographically, because the ledger orders
+ * `(source, slice)` rows by byte comparison and a walk that steps wrong looks
+ * like a slow loop rather than a broken one. The identity a listed item maps
+ * to has to be the identity the built decision stores, or the walk hunts rows
+ * the crawl already wrote. And `detail-unavailable` has to stay distinct from
+ * a decision built out of the listing alone: writing the latter would make the
+ * identity held and take the document out of every later reconciliation.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+
+import type { SaosItem } from "@/api/handlers/case-law/ingestion/adapters/pl-courts";
+import {
+  PL_COURTS_FIRST_SLICE,
+  PL_COURTS_LANGUAGE,
+  plCourtsAdapter,
+  plCourtsListingIdentity,
+} from "@/api/handlers/case-law/ingestion/adapters/pl-courts";
+import { tipWindowSlices } from "@/api/handlers/case-law/ingestion/reconciliation-plan";
+import { toUtcDateString } from "@/api/lib/dates";
+import { AdapterFetchError } from "@/api/lib/errors/tagged-errors";
+import {
+  listingIdentityKey,
+  parseListingIdentityKey,
+} from "@/api/lib/legal-search/ingestion-types";
+
+const reconciliation = plCourtsAdapter.reconciliation;
+if (reconciliation === undefined) {
+  throw new Error("pl-courts must declare the reconciliation capability");
+}
+
+const SEARCH_PATTERN = "/api/search/judgments";
+const DETAIL_PATTERN = "/api/judgments/";
+
+/** Real SAOS records: a district-court decision and a Supreme Court judgment. */
+const COMMON_COURT_ITEM = {
+  id: 130_600,
+  href: "https://www.saos.org.pl/api/judgments/130600",
+  courtType: "COMMON",
+  courtCases: [{ caseNumber: "II Co 433/15" }],
+  judgmentType: "DECISION",
+  judgmentDate: "2015-03-05",
+  division: {
+    id: 203,
+    name: "II Wydział Cywilny Sekcja Egzekucyjna",
+    court: { id: 36, code: "15050505", name: "Sąd Rejonowy w Białymstoku" },
+  },
+} as const satisfies SaosItem;
+
+const SUPREME_COURT_ITEM = {
+  id: 168_472,
+  href: "https://www.saos.org.pl/api/judgments/168472",
+  courtType: "SUPREME",
+  courtCases: [{ caseNumber: "V CSK 293/14" }],
+  judgmentType: "SENTENCE",
+  judgmentDate: "2015-03-05",
+} as const satisfies SaosItem;
+
+const SLICE = "2015-03-05";
+
+type MockRoute = {
+  pattern: string;
+  body: string;
+  status?: number | undefined;
+};
+
+const originalFetch = globalThis.fetch;
+const requestedUrls: string[] = [];
+
+const mockFetchWithBodies = (routes: MockRoute[]) => {
+  const mockedFetch: typeof fetch = Object.assign(
+    async (input: string | URL | Request): Promise<Response> => {
+      const url = (() => {
+        if (typeof input === "string") {
+          return input;
+        }
+        if (input instanceof URL) {
+          return input.href;
+        }
+        return input.url;
+      })();
+      requestedUrls.push(url);
+
+      const match = routes
+        .filter((route) => url.includes(route.pattern))
+        .toSorted((left, right) => right.pattern.length - left.pattern.length)
+        .at(0);
+
+      if (!match) {
+        return new Response("Not found", { status: 404 });
+      }
+      return new Response(match.body, {
+        status: match.status ?? 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    },
+    { preconnect: originalFetch.preconnect.bind(originalFetch) },
+  );
+
+  globalThis.fetch = mockedFetch;
+};
+
+const searchBody = (items: readonly SaosItem[], totalResults: number): string =>
+  JSON.stringify({ items, info: { totalResults } });
+
+/**
+ * bun-types declares `.rejects.toBeInstanceOf` as void, so awaiting it trips
+ * type-aware lint; capture the rejection explicitly instead.
+ */
+const sliceRejection = async (slice: string): Promise<unknown> =>
+  await reconciliation.listSlicePage({ slice, page: 0 }).then(
+    () => null,
+    (error: unknown) => error,
+  );
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  requestedUrls.length = 0;
+});
+
+describe("pl-courts slice arithmetic", () => {
+  test("a step forward and back returns the same slice", () => {
+    for (const slice of [
+      PL_COURTS_FIRST_SLICE,
+      "1999-12-31",
+      "2024-02-28",
+      "2024-02-29",
+      "2024-12-31",
+      "2015-03-05",
+    ]) {
+      const next = reconciliation.nextSlice(slice);
+      expect(next).not.toBeNull();
+      expect(next === null ? null : reconciliation.previousSlice(next)).toBe(
+        slice,
+      );
+    }
+  });
+
+  test("steps across month, year and leap-day boundaries", () => {
+    expect(reconciliation.nextSlice("2024-02-28")).toBe("2024-02-29");
+    expect(reconciliation.nextSlice("2024-02-29")).toBe("2024-03-01");
+    expect(reconciliation.previousSlice("2024-03-01")).toBe("2024-02-29");
+    expect(reconciliation.nextSlice("2023-02-28")).toBe("2023-03-01");
+    expect(reconciliation.nextSlice("1999-12-31")).toBe("2000-01-01");
+    expect(reconciliation.previousSlice("2000-01-01")).toBe("1999-12-31");
+  });
+
+  test("the walk order is the lexicographic order", () => {
+    let slice: string | null = "2014-12-28";
+    const walked: string[] = [];
+    while (slice !== null && walked.length < 10) {
+      walked.push(slice);
+      slice = reconciliation.nextSlice(slice);
+    }
+    expect(walked).toEqual([...walked].toSorted());
+    expect(walked.at(0)).toBe("2014-12-28");
+    expect(walked.at(-1)).toBe("2015-01-06");
+  });
+
+  test("the tip window is a fixed run of slices, newest first", () => {
+    const now = new Date("2026-08-11T09:30:00.000Z");
+    const slices = tipWindowSlices(reconciliation, now);
+
+    expect(slices).toHaveLength(reconciliation.tipWindowDays);
+    expect(slices.at(0)).toBe("2026-08-11");
+    expect(slices.at(-1)).toBe("2026-07-29");
+    expect(slices).toEqual([...slices].toSorted().toReversed());
+  });
+
+  test("the walk stops at the feed's first day and at the tip", () => {
+    expect(reconciliation.previousSlice(PL_COURTS_FIRST_SLICE)).toBeNull();
+    expect(reconciliation.nextSlice("2999-12-30")).toBeNull();
+    expect(reconciliation.nextSlice(PL_COURTS_FIRST_SLICE)).toBe("1986-05-29");
+    expect(reconciliation.sliceOf(new Date("2015-03-05T23:59:59.999Z"))).toBe(
+      SLICE,
+    );
+    expect(reconciliation.sliceOf(new Date())).toBe(
+      toUtcDateString(new Date()),
+    );
+  });
+
+  test("a slice that is not a UTC calendar day is refused", () => {
+    expect(() => reconciliation.nextSlice("2015-03")).toThrow();
+    expect(() => reconciliation.previousSlice("2015-02-30")).toThrow();
+  });
+});
+
+describe("pl-courts listing identity", () => {
+  test("keys a listed judgment on the publisher's own id", () => {
+    expect(plCourtsListingIdentity(COMMON_COURT_ITEM)).toEqual({
+      type: "document",
+      sourceDocumentId: "130600",
+    });
+    expect(plCourtsListingIdentity(SUPREME_COURT_ITEM)).toEqual({
+      type: "document",
+      sourceDocumentId: "168472",
+    });
+  });
+
+  test("falls back to the docket and the language without an id", () => {
+    expect(
+      plCourtsListingIdentity({ courtCases: [{ caseNumber: "V CSK 293/14" }] }),
+    ).toEqual({
+      type: "case-number",
+      caseNumber: "V CSK 293/14",
+      language: PL_COURTS_LANGUAGE,
+    });
+  });
+
+  test("an item with nothing to key on is unidentifiable", () => {
+    expect(plCourtsListingIdentity({})).toEqual({ type: "unidentifiable" });
+    expect(plCourtsListingIdentity({ courtCases: [] })).toEqual({
+      type: "unidentifiable",
+    });
+    expect(plCourtsListingIdentity({ id: null, judgmentDate: SLICE })).toEqual({
+      type: "unidentifiable",
+    });
+  });
+
+  test("every keyable identity round-trips through its stored key", () => {
+    for (const identity of [
+      plCourtsListingIdentity(COMMON_COURT_ITEM),
+      plCourtsListingIdentity({ courtCases: [{ caseNumber: "V CSK 293/14" }] }),
+    ]) {
+      const key = listingIdentityKey(identity);
+      expect(key).not.toBeNull();
+      expect(key === null ? null : parseListingIdentityKey(key)).toEqual(
+        identity,
+      );
+    }
+  });
+});
+
+describe("pl-courts listSlicePage", () => {
+  test("asks the publisher for exactly the slice's judgment date", async () => {
+    mockFetchWithBodies([
+      {
+        pattern: SEARCH_PATTERN,
+        body: searchBody([COMMON_COURT_ITEM, SUPREME_COURT_ITEM], 283),
+      },
+    ]);
+
+    await reconciliation.listSlicePage({ slice: SLICE, page: 2 });
+
+    const requested = new URL(requestedUrls.at(0) ?? "");
+    expect(requested.searchParams.get("judgmentDateFrom")).toBe(SLICE);
+    expect(requested.searchParams.get("judgmentDateTo")).toBe(SLICE);
+    expect(requested.searchParams.get("pageNumber")).toBe("2");
+    expect(requested.searchParams.get("pageSize")).toBe("100");
+    // Ids are assigned once, so a judgment published mid-walk appends past the
+    // last page instead of shifting items onto pages already read.
+    expect(requested.searchParams.get("sortingField")).toBe("DATABASE_ID");
+    expect(requested.searchParams.get("sortingDirection")).toBe("ASC");
+  });
+
+  test("maps a filtered page to identity-tagged, replayable items", async () => {
+    mockFetchWithBodies([
+      {
+        pattern: SEARCH_PATTERN,
+        body: searchBody([COMMON_COURT_ITEM, SUPREME_COURT_ITEM], 283),
+      },
+    ]);
+
+    const page = await reconciliation.listSlicePage({ slice: SLICE, page: 0 });
+
+    // 283 filtered results at 100 a page is three pages; the API states no
+    // page count of its own.
+    expect(page.totalPages).toBe(3);
+    expect(page.items.map(({ identity }) => identity)).toEqual([
+      { type: "document", sourceDocumentId: "130600" },
+      { type: "document", sourceDocumentId: "168472" },
+    ]);
+    // The loop parks a payload as JSON and replays it days later, so what a
+    // page hands back has to survive that round trip unchanged.
+    const serialized = JSON.stringify(page.items.map(({ payload }) => payload));
+    expect(JSON.parse(serialized)).toMatchObject([
+      { id: 130_600, courtCases: [{ caseNumber: "II Co 433/15" }] },
+      { id: 168_472, courtCases: [{ caseNumber: "V CSK 293/14" }] },
+    ]);
+  });
+
+  test("a day the publisher lists nothing for reports no pages", async () => {
+    mockFetchWithBodies([{ pattern: SEARCH_PATTERN, body: searchBody([], 0) }]);
+
+    const page = await reconciliation.listSlicePage({
+      slice: "1986-05-29",
+      page: 0,
+    });
+
+    expect(page.items).toEqual([]);
+    expect(page.totalPages).toBe(0);
+  });
+
+  test("a payload without a result total is refused, not read as empty", async () => {
+    mockFetchWithBodies([
+      { pattern: SEARCH_PATTERN, body: JSON.stringify({ items: [] }) },
+    ]);
+
+    expect(await sliceRejection(SLICE)).toBeInstanceOf(AdapterFetchError);
+  });
+
+  test("an upstream failure is raised rather than reported as an empty day", async () => {
+    mockFetchWithBodies([
+      { pattern: SEARCH_PATTERN, body: "boom", status: 503 },
+    ]);
+
+    expect(await sliceRejection(SLICE)).toBeInstanceOf(AdapterFetchError);
+  });
+});
+
+describe("pl-courts buildDecision", () => {
+  test("builds through the adapter's own detail parse path", async () => {
+    mockFetchWithBodies([
+      {
+        pattern: DETAIL_PATTERN,
+        body: JSON.stringify({
+          data: {
+            ...COMMON_COURT_ITEM,
+            textContent: "<p>POSTANOWIENIE z dnia 5 marca 2015 r.</p>",
+            ecli: "ECLI:PL:SRBIA:2015:II.Co.433.15",
+            source: {
+              code: "COMMON_COURT",
+              judgmentUrl: "https://orzeczenia.bialystok.sr.gov.pl/content/1",
+            },
+          },
+        }),
+      },
+    ]);
+
+    const built = await reconciliation.buildDecision(COMMON_COURT_ITEM);
+
+    expect(built.type).toBe("built");
+    if (built.type !== "built") {
+      return;
+    }
+    expect(built.decision).toMatchObject({
+      caseNumber: "II Co 433/15",
+      country: "POL",
+      language: PL_COURTS_LANGUAGE,
+      decisionDate: "2015-03-05",
+      decisionType: "postanowienie",
+      court: "Sąd Rejonowy w Białymstoku",
+      sourceDocumentId: "130600",
+      sourceUrl: "https://www.saos.org.pl/judgments/130600",
+    });
+    // The one identity rule: what the walk keyed this item on is what the
+    // decision it builds actually stores.
+    expect(listingIdentityKey(plCourtsListingIdentity(COMMON_COURT_ITEM))).toBe(
+      listingIdentityKey({
+        type: "document",
+        sourceDocumentId: built.decision.sourceDocumentId ?? "",
+      }),
+    );
+  });
+
+  test("a detail nothing came back for is unavailable, never built empty", async () => {
+    mockFetchWithBodies([
+      { pattern: DETAIL_PATTERN, body: "Not found", status: 404 },
+    ]);
+
+    // The listing item alone carries a docket and a court, so the build path
+    // could have produced a decision from it. Doing so would make the identity
+    // held with the document still unread.
+    expect(await reconciliation.buildDecision(COMMON_COURT_ITEM)).toEqual({
+      type: "detail-unavailable",
+    });
+  });
+
+  test("a detail that is not a judgment payload is unavailable", async () => {
+    mockFetchWithBodies([
+      { pattern: DETAIL_PATTERN, body: JSON.stringify({ error: "gone" }) },
+    ]);
+
+    expect(await reconciliation.buildDecision(SUPREME_COURT_ITEM)).toEqual({
+      type: "detail-unavailable",
+    });
+  });
+
+  test("a payload no current shape recognises is unkeyable", async () => {
+    mockFetchWithBodies([]);
+
+    expect(await reconciliation.buildDecision("130600")).toEqual({
+      type: "unkeyable",
+    });
+    expect(await reconciliation.buildDecision(null)).toEqual({
+      type: "unkeyable",
+    });
+    // A record with nothing to key on: no id to fetch a detail for and no
+    // docket to fall back to.
+    expect(await reconciliation.buildDecision({ judgmentDate: SLICE })).toEqual(
+      {
+        type: "unkeyable",
+      },
+    );
+  });
+});

--- a/apps/api/src/handlers/case-law/ingestion/adapters/pl-courts.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/pl-courts.ts
@@ -1,3 +1,5 @@
+import { panic } from "better-result";
+
 import {
   ADAPTER_KEYS,
   ADAPTER_TIMEOUT,
@@ -6,10 +8,15 @@ import {
 import {
   defineSourceAdapter,
   EMPTY_AST,
+  isPersistableSourceDocumentId,
 } from "@/api/handlers/case-law/ingestion/adapter";
 import type {
   EmptyAst,
   IngestionResult,
+  ListingIdentity,
+  ReconciliationBuildOutcome,
+  ReconciliationSlicePage,
+  ReconciliationSlicePageOptions,
 } from "@/api/handlers/case-law/ingestion/adapter";
 import { createPagePaginatedFetch } from "@/api/handlers/case-law/ingestion/adapters/pagination";
 import {
@@ -23,6 +30,8 @@ import {
   toOptionalValue,
 } from "@/api/handlers/case-law/ingestion/adapters/utils";
 import { parsePlDecisionContent } from "@/api/handlers/case-law/ingestion/parsers/pl-courts";
+import { addUtcDays, isoCalendarDay, toUtcDateString } from "@/api/lib/dates";
+import { AdapterFetchError } from "@/api/lib/errors/tagged-errors";
 import { fetchWithTimeout } from "@/api/lib/fetch";
 import { isRecord } from "@/api/lib/type-guards";
 
@@ -46,6 +55,50 @@ const PUBLIC_JUDGMENT_URL = "https://www.saos.org.pl/judgments";
 const PAGE_SIZE = 100;
 const LEGACY_PAGE_SIZE = 100;
 const ITEM_CONCURRENCY = 10;
+
+/** The only language this source publishes; half of the fallback identity. */
+export const PL_COURTS_LANGUAGE = "pl";
+
+/**
+ * Earliest judgment date the publisher holds, and so the oldest slice the
+ * historical sweep walks back to.
+ *
+ * Determined from the source itself: the search endpoint sorted
+ * `JUDGMENT_DATE` ascending answers with the Constitutional Tribunal's first
+ * rulings, of which `U 1/86` of this date is the earliest — the Tribunal began
+ * adjudicating in 1986, so the corpus has nothing genuinely older. The single
+ * row the sort puts ahead of it carries a mangled four-digit year and is a
+ * publisher typo rather than a judgment from that year; the crawl still
+ * ingests it, since `fetchPage` walks the dump in id order and never consults
+ * a date.
+ */
+export const PL_COURTS_FIRST_SLICE = "1986-05-28";
+
+/**
+ * Slices near the tip the reconciliation re-walks on a fast cadence.
+ *
+ * A slice here is the judgment date, not the date the publisher listed it, and
+ * SAOS posts a judgment some time after it is handed down. So the tip window
+ * is where the newest dates fill in, and it is deliberately not sized to the
+ * publication lag: the loop re-walks every tip slice daily, so a window wide
+ * enough to cover a months-long lag would spend the source's whole turn on
+ * dates that mostly gain nothing. A fortnight keeps the fast lane a fixed,
+ * small amount of work; a date that fills in later is reached by the ledger's
+ * standing re-check of short slices and by the historical sweep, and the crawl
+ * itself never misses one, since it walks the dump in id order and new
+ * judgments take new ids whatever date they carry.
+ */
+const PL_COURTS_TIP_WINDOW_DAYS = 14;
+
+/**
+ * Ordering for a slice listing. Database id ascending is the only ordering
+ * this API offers that is stable under concurrent publication: ids are
+ * assigned once and never move, so a judgment added between two page requests
+ * appends past the last page instead of shifting every item onto a page the
+ * walk has already read.
+ */
+const SLICE_SORTING_FIELD = "DATABASE_ID";
+const SLICE_SORTING_DIRECTION = "ASC";
 
 const COURT_TYPE_MAP: Record<string, string> = {
   COMMON: "Sąd powszechny",
@@ -131,7 +184,12 @@ type SaosReferencedCourtCase = {
   generated?: boolean | null;
 };
 
-type SaosItem = {
+/**
+ * One judgment as SAOS states it. The dump, the search listing and the
+ * per-judgment detail all answer with this shape; the listing endpoints simply
+ * leave more of it out.
+ */
+export type SaosItem = {
   id?: number | null | undefined;
   href?: string | null | undefined;
   courtType?: string | null | undefined;
@@ -512,30 +570,127 @@ const normalizeOptionalArray = <T>(
   return [];
 };
 
-const parseItemWithDetail = async (
-  raw: unknown,
-  signal?: AbortSignal,
-): Promise<IngestionResult | null> => {
-  if (!isRecord(raw)) {
-    return null;
+/**
+ * The publisher's own document id for an item, or undefined where the item
+ * carries none.
+ *
+ * Stated here rather than at each use so the crawl and the reconciliation
+ * cannot key a decision differently. Returning undefined for a missing id is
+ * the point: stringifying it would key every id-less item on the same literal
+ * `"undefined"` and collapse them onto one row.
+ */
+export const plCourtsSourceDocumentId = (
+  id: number | null | undefined,
+): string | undefined => {
+  if (id === undefined || id === null || !Number.isInteger(id)) {
+    return undefined;
   }
+  const candidate = String(id);
+  return isPersistableSourceDocumentId(candidate) ? candidate : undefined;
+};
 
+type PrimaryCaseNumberOptions = {
+  /** The record to read first; the detail where one was fetched. */
+  preferred: SaosItem;
+  /** Consulted only where the preferred record states no docket. */
+  fallback?: SaosItem | undefined;
+};
+
+/** The docket this source keys a decision on, preferring the richer record. */
+const primaryCaseNumber = ({
+  preferred,
+  fallback,
+}: PrimaryCaseNumberOptions): string | undefined =>
+  toOptionalValue(
+    (
+      preferred.courtCases?.find((courtCase) => courtCase.caseNumber) ??
+      fallback?.courtCases?.find((courtCase) => courtCase.caseNumber)
+    )?.caseNumber,
+  );
+
+/**
+ * The identity the ingest would store for this listing item.
+ *
+ * Stated once, here, rather than restated by every caller that has to decide
+ * whether a listed item is already held: the crawl and the reconciliation loop
+ * key rows the same way, and a second copy of the rule would let them disagree
+ * about which rows exist. Both halves are the same expressions the build path
+ * uses, so the two cannot drift apart.
+ */
+export const plCourtsListingIdentity = (item: SaosItem): ListingIdentity => {
+  const sourceDocumentId = plCourtsSourceDocumentId(item.id);
+  if (sourceDocumentId !== undefined) {
+    return { type: "document", sourceDocumentId };
+  }
+  const caseNumber = primaryCaseNumber({ preferred: item });
+  if (caseNumber === undefined) {
+    return { type: "unidentifiable" };
+  }
+  return {
+    type: "case-number",
+    caseNumber,
+    language: PL_COURTS_LANGUAGE,
+  };
+};
+
+/**
+ * What asking the per-judgment endpoint about a listed item produced.
+ *
+ * `listing-only` and `unavailable` are kept apart on purpose. The crawl treats
+ * both as "no detail" and stores the listing observation either way, which is
+ * right for a page that must keep moving. A caller filling gaps needs the
+ * difference: storing a detail-less row would make the identity held and take
+ * the document out of every later reconciliation, so a fetch that returned
+ * nothing has to be reported rather than folded into the decision.
+ */
+type PlCourtsDetailFetch =
+  | { type: "detail"; detail: SaosItem }
+  /** The item carries no id, so there is no detail record to ask for. */
+  | { type: "listing-only" }
+  /** An id was asked about and nothing came back. */
+  | { type: "unavailable" };
+
+const fetchDetailForItem = async (
+  item: SaosItem,
+  signal?: AbortSignal,
+): Promise<PlCourtsDetailFetch> => {
+  const id = item.id;
+  if (id === undefined || id === null) {
+    return { type: "listing-only" };
+  }
+  const detail = await fetchDetail(id, signal);
+  return detail === null ? { type: "unavailable" } : { type: "detail", detail };
+};
+
+type BuildPlDecisionOptions = {
+  /** The item exactly as the publisher listed it. */
+  listingItem: SaosItem;
+  /** The per-judgment record, where one was read. */
+  detail: SaosItem | null;
+};
+
+/**
+ * Build one decision from a listing item and whatever detail was read for it.
+ *
+ * Export-only refactor of what the crawl page already did, kept as one
+ * function so the listing walk and the crawl cannot parse or enrich
+ * differently.
+ */
+const buildPlDecision = ({
+  listingItem,
+  detail,
+}: BuildPlDecisionOptions): IngestionResult | null => {
   // SAFETY: All SaosItem fields are optional/nullable. The function
   // accesses them with optional chaining and null checks throughout.
   // Full isSaosItem validation was moved out of the hot path because
   // a single unexpected field type (e.g. dissentingOpinions as object)
   // would reject the entire page, blocking all ingestion.
-  const dumpItem = normalizeSaosDumpItem(raw);
-  const detail =
-    dumpItem.id !== undefined && dumpItem.id !== null
-      ? await fetchDetail(dumpItem.id, signal)
-      : null;
+  // Aliased rather than renamed throughout: the body below reads the listing
+  // half under this name in some sixty places, none of which changed.
+  const dumpItem = listingItem;
   const item = detail ?? dumpItem;
 
-  const primaryCase =
-    item.courtCases?.find((courtCase) => courtCase.caseNumber) ??
-    dumpItem.courtCases?.find((courtCase) => courtCase.caseNumber);
-  const caseNumber = toOptionalValue(primaryCase?.caseNumber);
+  const caseNumber = primaryCaseNumber({ preferred: item, fallback: dumpItem });
   const courtName =
     toOptionalValue(item.division?.court?.name) ??
     courtNameForItem(dumpItem) ??
@@ -620,7 +775,7 @@ const parseItemWithDetail = async (
     decisionDate,
     decisionType,
     fulltext,
-    sourceDocumentId: String(item.id ?? dumpItem.id),
+    sourceDocumentId: plCourtsSourceDocumentId(item.id ?? dumpItem.id),
     sourceUrl: publicSourceUrl(item.id ?? dumpItem.id),
     documentUrl,
     publisherCitedCases,
@@ -690,6 +845,202 @@ const parseItemWithDetail = async (
   };
 };
 
+const parseItemWithDetail = async (
+  raw: unknown,
+  signal?: AbortSignal,
+): Promise<IngestionResult | null> => {
+  if (!isRecord(raw)) {
+    return null;
+  }
+
+  const listingItem = normalizeSaosDumpItem(raw);
+  const fetched = await fetchDetailForItem(listingItem, signal);
+  return buildPlDecision({
+    listingItem,
+    detail: fetched.type === "detail" ? fetched.detail : null,
+  });
+};
+
+/**
+ * A reconciliation slice for this source is one judgment date, which is what
+ * the search endpoint's `judgmentDateFrom`/`judgmentDateTo` pair addresses
+ * — the API states both as `yyyy-MM-dd` in its own query template, and a
+ * filtered listing answers only with judgments carrying that date.
+ * `YYYY-MM-DD` sorts lexicographically in chronological order, which is the
+ * ordering the ledger relies on.
+ */
+const plCourtsDayStart = (slice: string): Date => {
+  const day = isoCalendarDay(slice);
+  if (day === null || day !== slice) {
+    panic(`pl-courts slice is not a UTC calendar day: ${slice}`);
+  }
+  return new Date(`${day}T00:00:00.000Z`);
+};
+
+const plCourtsStepSlice = (slice: string, days: number): string =>
+  toUtcDateString(addUtcDays(plCourtsDayStart(slice), days));
+
+const plCourtsNextSlice = (slice: string): string | null => {
+  const next = plCourtsStepSlice(slice, 1);
+  return next > toUtcDateString(new Date()) ? null : next;
+};
+
+const plCourtsPreviousSlice = (slice: string): string | null => {
+  const previous = plCourtsStepSlice(slice, -1);
+  return previous < PL_COURTS_FIRST_SLICE ? null : previous;
+};
+
+/** The search endpoint's answer, read only for what a slice walk needs. */
+type SaosSliceResponse = {
+  items?: Record<string, unknown>[] | null;
+  info?: { totalResults?: number | null } | null;
+};
+
+const isSaosSliceResponse = (value: unknown): value is SaosSliceResponse =>
+  isRecord(value) &&
+  isNullishArrayOf(value["items"], isRecord) &&
+  isSaosSearchResponse(value);
+
+type ListPlCourtsDayPageOptions = {
+  /** Judgment date, `YYYY-MM-DD`. */
+  date: string;
+  /** 0-indexed page within the day. */
+  page: number;
+  signal?: AbortSignal | undefined;
+};
+
+export type PlCourtsDayPage = {
+  items: SaosItem[];
+  /** 0 for a day the publisher lists no judgment for. */
+  totalPages: number;
+};
+
+/**
+ * One page of the publisher's own listing for a judgment date.
+ *
+ * The crawl reaches a judgment by walking the dump forward in id order and
+ * pays a detail fetch for every item on the page, which is the wrong shape for
+ * asking what a date contains. This is the same politeness, the same payload
+ * normalization and the same identity rule, stopping at the listing.
+ *
+ * The page count is derived from the filtered result total rather than read
+ * from the response, which states no page count. A payload without that total
+ * is refused rather than reported as a short day: an undercounted `reported`
+ * reads to the ledger as a fully collected slice.
+ */
+export const listPlCourtsDayPage = async ({
+  date,
+  page,
+  signal,
+}: ListPlCourtsDayPageOptions): Promise<PlCourtsDayPage> => {
+  const url = `${SEARCH_URL}?${new URLSearchParams({
+    pageSize: String(PAGE_SIZE),
+    pageNumber: String(page),
+    sortingField: SLICE_SORTING_FIELD,
+    sortingDirection: SLICE_SORTING_DIRECTION,
+    judgmentDateFrom: date,
+    judgmentDateTo: date,
+  }).toString()}`;
+
+  const response = await fetchWithTimeout(url, {
+    signal,
+    timeoutMs: ADAPTER_TIMEOUT.LIST,
+    headers: {
+      Accept: "application/json",
+      "User-Agent": INGESTION_USER_AGENT,
+    },
+  });
+
+  if (!response.ok) {
+    throw new AdapterFetchError({
+      message: `SAOS search API error: ${response.status}`,
+      adapterKey: ADAPTER_KEYS.PL_COURTS,
+      cursor: date,
+      httpStatus: response.status,
+    });
+  }
+
+  const json: unknown = await response.json();
+  if (!isSaosSliceResponse(json)) {
+    throw new AdapterFetchError({
+      message: "SAOS search API returned an invalid payload",
+      adapterKey: ADAPTER_KEYS.PL_COURTS,
+      cursor: date,
+    });
+  }
+
+  const totalResults = json.info?.totalResults;
+  if (totalResults === undefined || totalResults === null) {
+    throw new AdapterFetchError({
+      message: "SAOS search API stated no result total for the slice",
+      adapterKey: ADAPTER_KEYS.PL_COURTS,
+      cursor: date,
+    });
+  }
+
+  return {
+    items: normalizeOptionalArray(json.items).map(normalizeSaosDumpItem),
+    totalPages: Math.ceil(totalResults / PAGE_SIZE),
+  };
+};
+
+const listPlCourtsSlicePage = async ({
+  slice,
+  page,
+  signal,
+}: ReconciliationSlicePageOptions): Promise<ReconciliationSlicePage> => {
+  const { items, totalPages } = await listPlCourtsDayPage({
+    date: slice,
+    page,
+    ...(signal === undefined ? {} : { signal }),
+  });
+  return {
+    items: items.map((item) => ({
+      identity: plCourtsListingIdentity(item),
+      payload: item,
+    })),
+    totalPages,
+  };
+};
+
+/**
+ * Rebuild a decision from a payload the loop stored verbatim.
+ *
+ * The payload is renormalized rather than trusted: it may have been parked for
+ * days, and a shape the adapter no longer recognises has to be reported as
+ * unbuildable instead of parsed on faith.
+ */
+const buildPlCourtsFromPayload = async (
+  payload: unknown,
+  signal?: AbortSignal,
+): Promise<ReconciliationBuildOutcome> => {
+  if (!isRecord(payload)) {
+    return { type: "unkeyable" };
+  }
+  const listingItem = normalizeSaosDumpItem(payload);
+  const fetched = await fetchDetailForItem(listingItem, signal);
+  switch (fetched.type) {
+    case "unavailable":
+      return { type: "detail-unavailable" };
+    case "listing-only":
+    case "detail": {
+      const decision = buildPlDecision({
+        listingItem,
+        detail: fetched.type === "detail" ? fetched.detail : null,
+      });
+      return decision === null
+        ? { type: "unkeyable" }
+        : { type: "built", decision };
+    }
+    default: {
+      const exhaustive: never = fetched;
+      return panic(
+        `Unhandled pl-courts detail fetch: ${JSON.stringify(exhaustive)}`,
+      );
+    }
+  }
+};
+
 export const plCourtsAdapter = defineSourceAdapter({
   key: ADAPTER_KEYS.PL_COURTS,
   name: "Polish Courts (SAOS)",
@@ -731,6 +1082,22 @@ export const plCourtsAdapter = defineSourceAdapter({
     } catch {
       return null;
     }
+  },
+
+  /**
+   * The publisher lists each judgment date independently of the crawl's dump
+   * cursor, so what a date contains is answerable without re-crawling it:
+   * enumerate the date, key each item the way the ingest would, and compare
+   * against what is held.
+   */
+  reconciliation: {
+    firstSlice: PL_COURTS_FIRST_SLICE,
+    sliceOf: toUtcDateString,
+    nextSlice: plCourtsNextSlice,
+    previousSlice: plCourtsPreviousSlice,
+    tipWindowDays: PL_COURTS_TIP_WINDOW_DAYS,
+    listSlicePage: listPlCourtsSlicePage,
+    buildDecision: buildPlCourtsFromPayload,
   },
 
   fetchPage: createPagePaginatedFetch<SaosDumpResponse>({

--- a/apps/api/src/handlers/case-law/ingestion/adapters/pl-courts.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/pl-courts.ts
@@ -77,16 +77,27 @@ export const PL_COURTS_FIRST_SLICE = "1986-05-28";
 /**
  * Slices near the tip the reconciliation re-walks on a fast cadence.
  *
- * A slice here is the judgment date, not the date the publisher listed it, and
- * SAOS posts a judgment some time after it is handed down. So the tip window
- * is where the newest dates fill in, and it is deliberately not sized to the
- * publication lag: the loop re-walks every tip slice daily, so a window wide
- * enough to cover a months-long lag would spend the source's whole turn on
- * dates that mostly gain nothing. A fortnight keeps the fast lane a fixed,
- * small amount of work; a date that fills in later is reached by the ledger's
- * standing re-check of short slices and by the historical sweep, and the crawl
- * itself never misses one, since it walks the dump in id order and new
- * judgments take new ids whatever date they carry.
+ * A slice here is the judgment date, which is the only axis this API can
+ * filter on, and not the date the publisher posted it. SAOS posts a judgment
+ * long after it is handed down, and keeps posting against the same date for
+ * more than a year: measured against the search endpoint's own result totals,
+ * a fortnight of judgment dates held 1 judgment while it was the current
+ * fortnight, 232 at four months old, and 667 at sixteen months old.
+ *
+ * So this window is not where the newest dates fill in, and no width would
+ * make it so — the fill-in outlives any bounded window, and the loop re-walks
+ * every tip slice daily, so a window sized to it would be a standing
+ * re-survey rather than a fast lane. It is kept narrow for what it does do:
+ * re-check the active frontier cheaply, over dates that are nearly empty.
+ *
+ * The consequence is worth stating plainly. A date walked while it is fresh
+ * records `reported === collected` over almost nothing, which is not short, so
+ * the ledger never re-selects it and later arrivals into that date are not
+ * reconciled. Closing that needs a recheck cadence for settled slices, which
+ * belongs to `reconciliation-plan.ts` and applies to every reconciled source,
+ * not to this adapter. Until then the crawl remains the path that reaches a
+ * late arrival at all: it walks the dump in id order, and a judgment posted
+ * today takes a new id whatever date it carries.
  */
 const PL_COURTS_TIP_WINDOW_DAYS = 14;
 
@@ -978,10 +989,27 @@ export const listPlCourtsDayPage = async ({
     });
   }
 
-  return {
-    items: normalizeOptionalArray(json.items).map(normalizeSaosDumpItem),
-    totalPages: Math.ceil(totalResults / PAGE_SIZE),
-  };
+  const items = normalizeOptionalArray(json.items).map(normalizeSaosDumpItem);
+  const totalPages = Math.ceil(totalResults / PAGE_SIZE);
+
+  // A page the publisher's own total says holds judgments has to return them.
+  // Checked against the total rather than against the key's presence, because
+  // an omitted `items` and an empty one do the same damage and only this
+  // catches both: the walk would read the page as a date with nothing on it,
+  // record `reported` from the identities it saw instead of the ones the
+  // publisher counted, and leave a historical slice looking fully collected
+  // and never worth re-selecting. Refused rather than truncated, exactly as an
+  // over-long listing is: the slice keeps its previous ledger row and the
+  // failure surfaces in the loop's tally.
+  if (items.length === 0 && page < totalPages) {
+    throw new AdapterFetchError({
+      message: `SAOS search API returned no judgments on page ${page} of ${totalPages} for the slice`,
+      adapterKey: ADAPTER_KEYS.PL_COURTS,
+      cursor: date,
+    });
+  }
+
+  return { items, totalPages };
 };
 
 const listPlCourtsSlicePage = async ({


### PR DESCRIPTION
Implements the `reconciliation` capability on the pl-courts (SAOS) adapter so the standing listing-reconciliation loop can hunt this source's gaps.

Slice = one judgment date (`YYYY-MM-DD`): the search endpoint's own queryTemplate documents `judgmentDateFrom`/`judgmentDateTo` as day-precision, a filtered page returns only that day's judgments, and a busy day (~283 items) is three pages — well under the engine's page cap, where a month would be ~60 pages re-listed on every re-walk. The walk pins `sortingField=DATABASE_ID&sortingDirection=ASC` so a judgment published mid-walk appends past the last page instead of shifting items onto pages already read. `totalPages` derives from the stated `totalResults` (0 → an empty day); a payload that states no total is refused rather than read as empty, since an undercounted listing would bank as fully collected. `firstSlice` is 1986-05-28, the earliest genuine judgment the source lists ascending (one earlier row carries a publisher typo year and is still reached by the id-ordered crawl, which never consults dates).

Identity exists once: `plCourtsSourceDocumentId` and `primaryCaseNumber` are shared by the listing identity and the crawl's build path. This also fixes a pre-existing defect where an id-less item produced the literal string `"undefined"` as its document id, collapsing every such item onto one row.

The per-item build splits fetch from construction so reconciliation can refuse a `detail-unavailable` item (SAOS listings carry enough to build a hollow decision, which would read as held while the document stayed unread); the crawl's behaviour is unchanged.

Tests: 19 new (slice arithmetic, identity mapping over production-shaped fixtures, listing pagination and refusal cases, build-outcome discrimination); adapter/parser/conformance neighbours green (70 tests).
