### PR TITLE
feat(case-law): sk-us listing reconciliation capability

### DIFF
--- a/apps/api/src/handlers/case-law/ingestion/adapters/sk-us.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/sk-us.test.ts
@@ -1,0 +1,528 @@
+/* eslint-disable typescript-eslint/promise-function-async -- fetch mock callbacks return Promise.resolve without being async */
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  setSystemTime,
+  test,
+} from "bun:test";
+
+import {
+  buildSkUsDecision,
+  skUsAdapter,
+  skUsListingIdentity,
+  SK_US_FIRST_SLICE,
+} from "@/api/handlers/case-law/ingestion/adapters/sk-us";
+import { tipWindowSlices } from "@/api/handlers/case-law/ingestion/reconciliation-plan";
+import { listingIdentityKey } from "@/api/lib/legal-search/ingestion-types";
+import { asFetchMock } from "@/api/tests/helpers/test-tool-set";
+
+const { reconciliation } = skUsAdapter;
+if (reconciliation === undefined) {
+  throw new Error("sk-us must declare a reconciliation capability");
+}
+
+const SEARCH_PATH = "/o/v1/dms/search";
+const DOWNLOAD_PREFIX = "/docDownload/";
+
+/**
+ * Items shaped like the DMS actually answers: real document ids, the court's
+ * own docket spelling, and its `MM/DD/YYYY HH:mm:ss` dates. A shortened stand-in
+ * would let an identity or date rule pass here and fail on live traffic.
+ */
+const PLENARY_OPINION = {
+  documentId: "7964d54e-6708-48e9-92cc-5cc400aab1e3",
+  mkDocumentType: "Rozhodnutie - Nález",
+  mkRSAPNumberOfFile: "PL. ÚS 4/2020",
+  mkECLI: "ECLI:SK:USSR:2020:PL.US.4.2020.1",
+  mkDateOfDecision: "03/12/2020 00:00:00",
+  mkFormOfDecision: "Nález",
+  mkJudgeReporter: "Ivan Fiačan",
+} as const;
+
+const CHAMBER_RESOLUTION = {
+  documentId: "2d6903ee-0dd6-4281-8edc-8c814a52b0b1",
+  mkDocumentType: "Rozhodnutie - Uznesenie z predbežného prerokovania",
+  mkRSAPNumberOfFile: "I. ÚS 132/93",
+  mkDateOfDecision: "12/15/1993 00:00:00",
+  mkFormOfDecision: "Uznesenie",
+} as const;
+
+/** The DMS lists metadata rows with no downloadable document behind them. */
+const WITHOUT_DOCUMENT_ID = {
+  mkDocumentType: "Rozhodnutie - Uznesenie z predbežného prerokovania",
+  mkRSAPNumberOfFile: "I. ÚS 132/93",
+  mkDateOfDecision: "12/15/1993 00:00:00",
+} as const;
+
+type SearchBody = {
+  start: number;
+  pageSize: number;
+  docType: string;
+  searchFilter: {
+    filterNameValue: {
+      type: string;
+      fieldName: string;
+      fieldValue: { FROM: string; TO: string };
+    }[];
+  };
+};
+
+const parseSearchBody = (init: RequestInit | undefined): SearchBody => {
+  const body: unknown = JSON.parse(
+    typeof init?.body === "string" ? init.body : "{}",
+  );
+  // The mock feeds back exactly what the adapter serialized; the assertions
+  // below are what actually check its shape.
+  // eslint-disable-next-line typescript/no-unsafe-type-assertion -- test-local narrowing of the adapter's own request body
+  return body as SearchBody;
+};
+
+const dateRangeOf = (body: SearchBody): { FROM: string; TO: string } => {
+  const filter = body.searchFilter.filterNameValue.at(0);
+  if (filter === undefined) {
+    throw new Error("search body carried no filter");
+  }
+  return filter.fieldValue;
+};
+
+/** How the stubbed DMS answers one search request. */
+type SearchStub =
+  | {
+      type: "page";
+      documents: readonly Record<string, unknown>[];
+      numFound: number;
+    }
+  /** A 2xx body the response validator has to judge on its own. */
+  | { type: "body"; json: string }
+  | { type: "status"; status: number };
+
+type MockOptions = {
+  /** Search responses, one per request, in order. */
+  search: readonly SearchStub[];
+  /** Status the document download answers with. */
+  downloadStatus?: number;
+  onSearch?: (body: SearchBody, headers: Headers) => void;
+};
+
+/**
+ * bun-types declares `.rejects.toThrow` as void, so awaiting it trips
+ * type-aware lint; capture the rejection explicitly instead.
+ */
+const rejectionOf = async (promise: Promise<unknown>): Promise<unknown> =>
+  await promise.then(
+    () => null,
+    (error: unknown) => error,
+  );
+
+const JSON_HEADERS = { "Content-Type": "application/json" } as const;
+
+const searchResponse = (stub: SearchStub): Response => {
+  switch (stub.type) {
+    case "page":
+      return new Response(
+        JSON.stringify({ documents: stub.documents, numFound: stub.numFound }),
+        { headers: JSON_HEADERS },
+      );
+    case "body":
+      return new Response(stub.json, { headers: JSON_HEADERS });
+    case "status":
+      return new Response(stub.status === 204 ? null : "upstream failure", {
+        status: stub.status,
+      });
+    default: {
+      const exhaustive: never = stub;
+      throw new Error(`unhandled search stub: ${JSON.stringify(exhaustive)}`);
+    }
+  }
+};
+
+const mockFetch = ({
+  downloadStatus = 200,
+  onSearch,
+  search,
+}: MockOptions): { calls: () => number } => {
+  let searchCall = 0;
+  globalThis.fetch = asFetchMock(
+    (input: string | URL | Request, init?: RequestInit) => {
+      const url = new URL(input instanceof Request ? input.url : String(input));
+      if (url.pathname === SEARCH_PATH) {
+        onSearch?.(parseSearchBody(init), new Headers(init?.headers));
+        const next = search.at(Math.min(searchCall, search.length - 1));
+        searchCall += 1;
+        return Promise.resolve(
+          next === undefined
+            ? new Response("no search response stubbed", { status: 500 })
+            : searchResponse(next),
+        );
+      }
+      if (url.pathname.startsWith(DOWNLOAD_PREFIX)) {
+        return Promise.resolve(
+          downloadStatus === 200
+            ? new Response(new Uint8Array([37, 80, 68, 70]), {
+                headers: { "Content-Type": "application/pdf" },
+              })
+            : new Response(null, { status: downloadStatus }),
+        );
+      }
+      return Promise.resolve(
+        new Response(`unexpected request: ${url.toString()}`, { status: 500 }),
+      );
+    },
+  );
+  return { calls: () => searchCall };
+};
+
+describe("sk-us reconciliation slices", () => {
+  beforeAll(() => {
+    setSystemTime(new Date("2026-08-11T09:30:00.000Z"));
+  });
+
+  afterAll(() => {
+    setSystemTime();
+  });
+
+  test("starts at the first month the API publishes for", () => {
+    expect(reconciliation.firstSlice).toBe("1993-01");
+    expect(SK_US_FIRST_SLICE).toBe(reconciliation.firstSlice);
+  });
+
+  test("slices a UTC instant to its calendar month", () => {
+    expect(reconciliation.sliceOf(new Date("2026-01-31T23:59:59.999Z"))).toBe(
+      "2026-01",
+    );
+    // A local-time month would answer 2026-01 here in any negative offset.
+    expect(reconciliation.sliceOf(new Date("2026-02-01T00:00:00.000Z"))).toBe(
+      "2026-02",
+    );
+  });
+
+  test("steps across the year boundary in both directions", () => {
+    expect(reconciliation.nextSlice("2020-12")).toBe("2021-01");
+    expect(reconciliation.previousSlice("2021-01")).toBe("2020-12");
+  });
+
+  test("stops at the ends of the walk", () => {
+    expect(reconciliation.previousSlice(SK_US_FIRST_SLICE)).toBeNull();
+    expect(reconciliation.previousSlice("1993-02")).toBe(SK_US_FIRST_SLICE);
+    // The tip is the current month; there is no slice past it to walk into.
+    expect(reconciliation.nextSlice("2026-08")).toBeNull();
+    expect(reconciliation.nextSlice("2026-07")).toBe("2026-08");
+  });
+
+  test("walk order is the ledger's lexicographic order", () => {
+    let slice = SK_US_FIRST_SLICE;
+    let walked = 0;
+    // Bounded so a broken step cannot spin the suite; far above the ~400
+    // months between the feed's first slice and the frozen clock.
+    for (; walked < 1000; walked += 1) {
+      const next = reconciliation.nextSlice(slice);
+      if (next === null) {
+        break;
+      }
+      // The ledger orders slices as plain strings, so every step forward must
+      // also be a step up in byte order.
+      expect(next > slice).toBe(true);
+      expect(reconciliation.previousSlice(next)).toBe(slice);
+      slice = next;
+    }
+    expect(slice).toBe(reconciliation.sliceOf(new Date()));
+    expect(walked).toBe(403);
+  });
+
+  test("tip window is six months, newest first", () => {
+    expect(tipWindowSlices(reconciliation, new Date())).toEqual([
+      "2026-08",
+      "2026-07",
+      "2026-06",
+      "2026-05",
+      "2026-04",
+      "2026-03",
+    ]);
+  });
+
+  test("tip window truncates at the first slice for a young source", () => {
+    expect(tipWindowSlices(reconciliation, new Date("1993-03-15T00:00:00Z"))) //
+      .toEqual(["1993-03", "1993-02", "1993-01"]);
+  });
+});
+
+describe("sk-us listing identity", () => {
+  test("keys an item on its docket and language, as the crawl stores it", () => {
+    expect(skUsListingIdentity(PLENARY_OPINION)).toEqual({
+      type: "case-number",
+      caseNumber: "PL. ÚS 4/2020",
+      language: "sk",
+    });
+    expect(listingIdentityKey(skUsListingIdentity(PLENARY_OPINION))).toBe(
+      "case-number:sk:PL. ÚS 4/2020",
+    );
+  });
+
+  test("an item the crawl would drop is unidentifiable, not keyed on nothing", () => {
+    expect(
+      skUsListingIdentity({ ...CHAMBER_RESOLUTION, mkRSAPNumberOfFile: "" }),
+    ).toEqual({ type: "unidentifiable" });
+    expect(skUsListingIdentity(WITHOUT_DOCUMENT_ID)).toEqual({
+      type: "unidentifiable",
+    });
+    expect(
+      listingIdentityKey(skUsListingIdentity(WITHOUT_DOCUMENT_ID)),
+    ).toBeNull();
+  });
+});
+
+describe("sk-us listSlicePage", () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  test("asks the publisher for exactly the slice's month", async () => {
+    const ranges: { FROM: string; TO: string }[] = [];
+    const authHeaders: (string | null)[] = [];
+    mockFetch({
+      search: [{ type: "page", documents: [], numFound: 0 }],
+      onSearch: (body, headers) => {
+        ranges.push(dateRangeOf(body));
+        authHeaders.push(headers.get("Authorization"));
+        expect(body.docType).toBe("USSR_DECISION_MK");
+        expect(body.pageSize).toBe(100);
+      },
+    });
+
+    await reconciliation.listSlicePage({ slice: "2020-03", page: 0 });
+    await reconciliation.listSlicePage({ slice: "2020-02", page: 2 });
+    await reconciliation.listSlicePage({ slice: "2021-02", page: 0 });
+
+    expect(ranges).toEqual([
+      { FROM: "2020-03-01", TO: "2020-03-31" },
+      // February's last day is derived, not assumed: a leap year and a
+      // common one must not ask for the same window.
+      { FROM: "2020-02-01", TO: "2020-02-29" },
+      { FROM: "2021-02-01", TO: "2021-02-28" },
+    ]);
+    // The endpoint rejects a request carrying a token it cannot verify.
+    expect(authHeaders).toEqual([null, null, null]);
+  });
+
+  test("pages a month by the listing page size", async () => {
+    const starts: number[] = [];
+    mockFetch({
+      search: [{ type: "page", documents: [PLENARY_OPINION], numFound: 361 }],
+      onSearch: (body) => {
+        starts.push(body.start);
+      },
+    });
+
+    const first = await reconciliation.listSlicePage({
+      slice: "2026-06",
+      page: 0,
+    });
+    const last = await reconciliation.listSlicePage({
+      slice: "2026-06",
+      page: 3,
+    });
+
+    expect(starts).toEqual([0, 300]);
+    expect(first.totalPages).toBe(4);
+    expect(last.totalPages).toBe(4);
+    expect(first.items).toHaveLength(1);
+    expect(first.items.at(0)?.identity).toEqual({
+      type: "case-number",
+      caseNumber: "PL. ÚS 4/2020",
+      language: "sk",
+    });
+  });
+
+  test("the parked payload is the listing item verbatim and JSON-replayable", async () => {
+    mockFetch({
+      search: [{ type: "page", documents: [PLENARY_OPINION], numFound: 1 }],
+    });
+
+    const { items } = await reconciliation.listSlicePage({
+      slice: "2020-03",
+      page: 0,
+    });
+    const payload: unknown = items.at(0)?.payload;
+    // The loop parks this verbatim in JSONB and replays it days later.
+    const serialized = JSON.stringify(payload);
+    const parked: unknown = JSON.parse(serialized);
+
+    expect(payload).toEqual(PLENARY_OPINION);
+    expect(parked).toEqual(PLENARY_OPINION);
+  });
+
+  test("a month the publisher lists nothing for is an empty slice", async () => {
+    mockFetch({ search: [{ type: "page", documents: [], numFound: 0 }] });
+
+    expect(
+      await reconciliation.listSlicePage({ slice: "1993-01", page: 0 }),
+    ).toEqual({ items: [], totalPages: 0 });
+  });
+
+  test("a server error throws instead of reading as an empty slice", async () => {
+    const stub = mockFetch({
+      search: [{ type: "status", status: 500 }],
+    });
+
+    const rejection = await rejectionOf(
+      reconciliation.listSlicePage({ slice: "2026-06", page: 0 }),
+    );
+
+    expect(rejection).toBeInstanceOf(Error);
+    // Retried once, then surfaced: a slice recorded empty during an outage
+    // would settle and never be walked again.
+    expect(stub.calls()).toBe(2);
+  });
+
+  test("an empty 204 throws rather than settling the slice", async () => {
+    mockFetch({ search: [{ type: "status", status: 204 }] });
+
+    const rejection = await rejectionOf(
+      reconciliation.listSlicePage({ slice: "2026-06", page: 0 }),
+    );
+
+    expect(rejection instanceof Error ? rejection.message : "").toContain(
+      "no body",
+    );
+  });
+
+  test("a payload without a count throws rather than reporting zero pages", async () => {
+    mockFetch({
+      search: [{ type: "body", json: JSON.stringify({ documents: [] }) }],
+    });
+
+    expect(
+      await rejectionOf(
+        reconciliation.listSlicePage({ slice: "2026-06", page: 0 }),
+      ),
+    ).toBeInstanceOf(Error);
+  });
+});
+
+describe("sk-us buildDecision", () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  test("builds the decision the crawl would have stored", async () => {
+    mockFetch({ search: [] });
+
+    const outcome = await reconciliation.buildDecision(PLENARY_OPINION);
+
+    expect(outcome.type).toBe("built");
+    if (outcome.type !== "built") {
+      return;
+    }
+    expect(outcome.decision.caseNumber).toBe("PL. ÚS 4/2020");
+    expect(outcome.decision.language).toBe("sk");
+    expect(outcome.decision.country).toBe("SVK");
+    expect(outcome.decision.decisionDate).toBe("2020-03-12");
+    expect(outcome.decision.documentUrl).toBe(
+      "https://www.ustavnysud.sk/docDownload/7964d54e-6708-48e9-92cc-5cc400aab1e3",
+    );
+    expect(outcome.decision.sourceRawContentType).toBe("application/pdf");
+    expect(outcome.decision.isListingOnly).toBeUndefined();
+  });
+
+  test("the identity the walk keys is the identity the build stores", async () => {
+    mockFetch({ search: [] });
+
+    const outcome = await reconciliation.buildDecision(PLENARY_OPINION);
+    expect(outcome.type).toBe("built");
+    if (outcome.type !== "built") {
+      return;
+    }
+    // Silent drift here is the whole failure mode: a walk that keys an item
+    // one way and a build that stores it another leaves the slice permanently
+    // short and re-fetches the same document forever.
+    expect(
+      listingIdentityKey({
+        type: "case-number",
+        caseNumber: outcome.decision.caseNumber,
+        language: outcome.decision.language,
+      }),
+    ).toBe(listingIdentityKey(skUsListingIdentity(PLENARY_OPINION)));
+  });
+
+  test("a document the court does not serve is never written", async () => {
+    mockFetch({ search: [], downloadStatus: 404 });
+
+    expect(await reconciliation.buildDecision(CHAMBER_RESOLUTION)).toEqual({
+      type: "detail-unavailable",
+    });
+  });
+
+  test("a payload that no longer states an identity is unkeyable", async () => {
+    mockFetch({ search: [] });
+
+    expect(await reconciliation.buildDecision({})).toEqual({
+      type: "unkeyable",
+    });
+    expect(
+      await reconciliation.buildDecision({
+        ...PLENARY_OPINION,
+        mkRSAPNumberOfFile: "",
+      }),
+    ).toEqual({ type: "unkeyable" });
+    // A field whose type the DMS changed under us keys nothing either.
+    expect(
+      await reconciliation.buildDecision({ ...PLENARY_OPINION, documentId: 7 }),
+    ).toEqual({ type: "unkeyable" });
+  });
+
+  test("replays a payload that round-tripped through storage", async () => {
+    mockFetch({
+      search: [{ type: "page", documents: [PLENARY_OPINION], numFound: 1 }],
+    });
+    const { items } = await reconciliation.listSlicePage({
+      slice: "2020-03",
+      page: 0,
+    });
+    const serialized = JSON.stringify(items.at(0)?.payload ?? null);
+    const parked: unknown = JSON.parse(serialized);
+
+    const outcome = await reconciliation.buildDecision(parked);
+
+    expect(outcome.type).toBe("built");
+  });
+});
+
+describe("sk-us crawl and reconciliation dispose of a missing document differently", () => {
+  const originalFetch = globalThis.fetch;
+  const originalSleep = Bun.sleep;
+
+  beforeEach(() => {
+    Bun.sleep = () => Promise.resolve();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    Bun.sleep = originalSleep;
+  });
+
+  test("the crawl keeps the listing-only row the reconciliation refuses", async () => {
+    mockFetch({ search: [], downloadStatus: 404 });
+
+    const built = await buildSkUsDecision(CHAMBER_RESOLUTION);
+
+    expect(built.type).toBe("detail-unavailable");
+    if (built.type !== "detail-unavailable") {
+      return;
+    }
+    // The crawl's cursor moves past this document either way, so it stores
+    // what the listing proves — flagged, so a later refresh cannot overwrite
+    // detail a successful fetch recovered.
+    expect(built.decision.caseNumber).toBe("I. ÚS 132/93");
+    expect(built.decision.isListingOnly).toBe(true);
+    expect(built.decision.fulltext).toBeUndefined();
+    expect(built.decision.sourceRawContentType).toBe("application/json");
+  });
+});

--- a/apps/api/src/handlers/case-law/ingestion/adapters/sk-us.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/sk-us.test.ts
@@ -100,12 +100,43 @@ type SearchStub =
   | { type: "body"; json: string }
   | { type: "status"; status: number };
 
+/** How the stubbed document download answers. */
+type DownloadStub =
+  | { type: "pdf" }
+  /** A 200 carrying the portal's error page instead of the document. */
+  | { type: "not-a-pdf" }
+  | { type: "status"; status: number };
+
 type MockOptions = {
   /** Search responses, one per request, in order. */
   search: readonly SearchStub[];
-  /** Status the document download answers with. */
-  downloadStatus?: number;
+  download?: DownloadStub;
   onSearch?: (body: SearchBody, headers: Headers) => void;
+};
+
+/** A payload that opens like a real PDF; its body is not a parseable one. */
+const PDF_BYTES = new TextEncoder().encode("%PDF-1.4\n1 0 obj\n<<>>\n");
+
+const downloadResponse = (stub: DownloadStub): Response => {
+  switch (stub.type) {
+    case "pdf":
+      return new Response(PDF_BYTES, {
+        headers: { "Content-Type": "application/pdf" },
+      });
+    case "not-a-pdf":
+      return new Response(
+        "<html><body>Dokument nie je dostupný</body></html>",
+        {
+          headers: { "Content-Type": "text/html" },
+        },
+      );
+    case "status":
+      return new Response(null, { status: stub.status });
+    default: {
+      const exhaustive: never = stub;
+      throw new Error(`unhandled download stub: ${JSON.stringify(exhaustive)}`);
+    }
+  }
 };
 
 /**
@@ -141,7 +172,7 @@ const searchResponse = (stub: SearchStub): Response => {
 };
 
 const mockFetch = ({
-  downloadStatus = 200,
+  download = { type: "pdf" },
   onSearch,
   search,
 }: MockOptions): { calls: () => number } => {
@@ -160,13 +191,7 @@ const mockFetch = ({
         );
       }
       if (url.pathname.startsWith(DOWNLOAD_PREFIX)) {
-        return Promise.resolve(
-          downloadStatus === 200
-            ? new Response(new Uint8Array([37, 80, 68, 70]), {
-                headers: { "Content-Type": "application/pdf" },
-              })
-            : new Response(null, { status: downloadStatus }),
-        );
+        return Promise.resolve(downloadResponse(download));
       }
       return Promise.resolve(
         new Response(`unexpected request: ${url.toString()}`, { status: 500 }),
@@ -430,6 +455,10 @@ describe("sk-us buildDecision", () => {
     );
     expect(outcome.decision.sourceRawContentType).toBe("application/pdf");
     expect(outcome.decision.isListingOnly).toBeUndefined();
+    // A PDF this parser cannot read is still the document: the bytes are kept
+    // verbatim, so recovering its text is a re-parse of what was stored rather
+    // than another download of the same payload.
+    expect(outcome.decision.sourceRawBytes).toEqual(PDF_BYTES);
   });
 
   test("the identity the walk keys is the identity the build stores", async () => {
@@ -453,8 +482,19 @@ describe("sk-us buildDecision", () => {
   });
 
   test("a document the court does not serve is never written", async () => {
-    mockFetch({ search: [], downloadStatus: 404 });
+    mockFetch({ search: [], download: { type: "status", status: 404 } });
 
+    expect(await reconciliation.buildDecision(CHAMBER_RESOLUTION)).toEqual({
+      type: "detail-unavailable",
+    });
+  });
+
+  test("a 200 that is not a PDF is no document either", async () => {
+    mockFetch({ search: [], download: { type: "not-a-pdf" } });
+
+    // The portal answers a missing document with an error page under a 200.
+    // Kept apart from a PDF this parser cannot read: those bytes are the
+    // decision and are stored for re-parsing, an error page never is.
     expect(await reconciliation.buildDecision(CHAMBER_RESOLUTION)).toEqual({
       type: "detail-unavailable",
     });
@@ -509,7 +549,7 @@ describe("sk-us crawl and reconciliation dispose of a missing document different
   });
 
   test("the crawl keeps the listing-only row the reconciliation refuses", async () => {
-    mockFetch({ search: [], downloadStatus: 404 });
+    mockFetch({ search: [], download: { type: "status", status: 404 } });
 
     const built = await buildSkUsDecision(CHAMBER_RESOLUTION);
 

--- a/apps/api/src/handlers/case-law/ingestion/adapters/sk-us.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/sk-us.ts
@@ -24,6 +24,12 @@
  * Cursor format: "YYYY:offset" (e.g. "1993:0", "2020:1500").
  * Legacy cursors (plain offset like "3060") are migrated
  * to the current year on first use.
+ *
+ * The same search endpoint is addressable by an arbitrary
+ * decision-date range, which is what makes this source
+ * reconcilable: a month can be listed on its own, without
+ * the crawl cursor ever reaching it. See `reconciliation`
+ * at the bottom of this file.
  */
 
 import { Result, panic } from "better-result";
@@ -41,13 +47,20 @@ import {
 import type {
   EmptyAst,
   IngestionResult,
+  ListingIdentity,
+  ReconciliationBuildOutcome,
+  ReconciliationSlicePage,
+  ReconciliationSlicePageOptions,
 } from "@/api/handlers/case-law/ingestion/adapter";
 import {
   INGESTION_USER_AGENT,
   adapterCatch,
   hashContent,
 } from "@/api/handlers/case-law/ingestion/adapters/utils";
-import { FetchBoundaryError } from "@/api/lib/errors/tagged-errors";
+import {
+  AdapterFetchError,
+  FetchBoundaryError,
+} from "@/api/lib/errors/tagged-errors";
 import { fetchWithTimeout } from "@/api/lib/fetch";
 import { parseSkDecisionPdf } from "@/api/lib/legal-search/parsers/sk-courts";
 import { isRecord } from "@/api/lib/type-guards";
@@ -61,8 +74,19 @@ const DOC_DOWNLOAD_URL = `${BASE_URL}/docDownload`;
 const PAGE_SIZE = 10;
 const SEARCH_RETRY_DELAY_MS = 500;
 
+/**
+ * Page size for a listing walk. The crawl takes ten at a time because every
+ * item it keeps costs a PDF download; a listing walk downloads nothing, so it
+ * asks for the largest page the DMS was observed to honour (a 361-decision
+ * month answers 100, 100, 100, 61).
+ */
+const LISTING_PAGE_SIZE = 100;
+
 /** First year with decisions in the API. */
 const FIRST_YEAR = 1993;
+
+/** The only language this source publishes; half of the stored identity. */
+const SK_US_LANGUAGE = "sk";
 
 /**
  * Fields to request from the search API. Empty array
@@ -206,14 +230,88 @@ const fetchPdfBytes = async (
 const dedupe = (arr: readonly string[] | undefined): string[] =>
   arr ? [...new Set(arr)] : [];
 
-const parseDocument = async (
+/**
+ * The two fields an item must state for this adapter to keep it: the docket it
+ * is stored under and the id its document is downloaded by. Stated once,
+ * because the crawl, the identity rule and the listing walk must agree exactly
+ * on which items exist — an item one of them keeps and another drops is either
+ * a decision nothing ever stores or a slice that can never be filled.
+ */
+const skUsIdentityFields = (
   doc: SearchDocument,
-  signal?: AbortSignal,
-): Promise<IngestionResult | null> => {
-  const caseNumber = doc.mkRSAPNumberOfFile;
-  if (!caseNumber || !doc.documentId) {
+): { caseNumber: string; documentId: string } | null => {
+  const { documentId, mkRSAPNumberOfFile: caseNumber } = doc;
+  if (
+    typeof caseNumber !== "string" ||
+    caseNumber.length === 0 ||
+    typeof documentId !== "string" ||
+    documentId.length === 0
+  ) {
     return null;
   }
+  return { caseNumber, documentId };
+};
+
+/**
+ * The identity the ingest would store for this listing item.
+ *
+ * The docket and the language, never the DMS `documentId`: this adapter emits
+ * no `sourceDocumentId`, so every row it has ever written is keyed on
+ * `(caseNumber, language)` with a null document id. Keying the listing on the
+ * id the publisher does supply would match no held row at all, and the loop
+ * would read the entire archive as missing.
+ *
+ * The cost of that is real and measurable — the court publishes each opinion
+ * of a plenary decision as its own document under one docket (19 documents
+ * under `PL. ÚS 4/2020` in March 2020 alone), and the crawl collapses them
+ * into a single row. Recovering them is an identity migration of the source
+ * (adopt `documentId` as `sourceDocumentId`, with the deterministic
+ * `docDownload/{id}` URL as the `legacySourceUrls` hint that attaches it to
+ * the right null-id row), not something a reconciliation pass may decide on
+ * its own: until the stored rows carry that id, this is what "held" means.
+ */
+export const skUsListingIdentity = (doc: SearchDocument): ListingIdentity => {
+  const fields = skUsIdentityFields(doc);
+  return fields === null
+    ? { type: "unidentifiable" }
+    : {
+        type: "case-number",
+        caseNumber: fields.caseNumber,
+        language: SK_US_LANGUAGE,
+      };
+};
+
+/**
+ * What building one listed item produced.
+ *
+ * `detail-unavailable` still carries the decision the listing alone describes,
+ * because the two callers dispose of it differently: the crawl's cursor moves
+ * past this document either way, so a listing-only row is worth more to it
+ * than nothing, while the reconciliation must refuse it — a detail-less row
+ * would make the identity held and take the document out of every later
+ * reconciliation.
+ */
+export type SkUsBuildResult =
+  | { type: "built"; decision: IngestionResult }
+  /** No docket or no document id to key on; nothing can store this item. */
+  | { type: "unkeyable" }
+  /** The court served no document for the id the listing states. */
+  | { type: "detail-unavailable"; decision: IngestionResult };
+
+/**
+ * Build one decision from a search-listing item, downloading and parsing its
+ * PDF. Shared by the crawl and the reconciliation walk so neither can key,
+ * parse or enrich an item differently from the other.
+ */
+export const buildSkUsDecision = async (
+  doc: SearchDocument,
+  signal?: AbortSignal,
+): Promise<SkUsBuildResult> => {
+  const fields = skUsIdentityFields(doc);
+  if (fields === null) {
+    return { type: "unkeyable" };
+  }
+  const { caseNumber, documentId } = fields;
 
   const decisionDate = parseApiDate(doc.mkDateOfDecision);
   const decisionType = doc.mkFormOfDecision?.toLowerCase();
@@ -221,7 +319,7 @@ const parseDocument = async (
   const court = "Ústavný súd SR";
 
   // Fetch and parse PDF
-  const pdfBytes = await fetchPdfBytes(doc.documentId, signal);
+  const pdfBytes = await fetchPdfBytes(documentId, signal);
 
   let documentAst: DocumentAst | EmptyAst = EMPTY_AST;
   let fulltext: string | undefined;
@@ -246,24 +344,27 @@ const parseDocument = async (
 
   const rawHash = hashContent(JSON.stringify(doc));
 
-  return {
+  const decision: IngestionResult = {
     caseNumber,
     ecli,
     court,
     country: "SVK",
-    language: "sk",
+    language: SK_US_LANGUAGE,
     decisionDate,
     decisionType,
     fulltext,
-    sourceUrl: `${DOC_DOWNLOAD_URL}/${doc.documentId}`,
-    documentUrl: `${DOC_DOWNLOAD_URL}/${doc.documentId}`,
+    // The listing proves the document exists; without its PDF this row carries
+    // metadata only, and must never overwrite detail a later fetch recovered.
+    ...(pdfBytes === undefined ? { isListingOnly: true } : {}),
+    sourceUrl: `${DOC_DOWNLOAD_URL}/${documentId}`,
+    documentUrl: `${DOC_DOWNLOAD_URL}/${documentId}`,
     metadata: {
       caseNumber,
       ecli,
       court,
       decisionDate,
       decisionType,
-      documentId: doc.documentId,
+      documentId,
       documentType: doc.mkDocumentType,
       rvpNumber: doc.mkRVPNumberOfFile,
       judge: doc.mkJudgeReporter,
@@ -304,6 +405,10 @@ const parseDocument = async (
     sourceRawBytes: pdfBytes,
     sourceRawContentType: pdfBytes ? "application/pdf" : "application/json",
   };
+
+  return pdfBytes === undefined
+    ? { type: "detail-unavailable", decision }
+    : { type: "built", decision };
 };
 
 // ── Search helper ───────────────────────────────────────
@@ -316,11 +421,26 @@ const isAuthFailure = (error: unknown): boolean =>
   error.status !== undefined &&
   AUTH_FAILURE_STATUSES.has(error.status);
 
-const executeSearch = async (
-  year: number,
-  offset: number,
-  signal?: AbortSignal,
-): Promise<SearchResponse | null> => {
+/**
+ * A closed decision-date window, `YYYY-MM-DD` on both ends, as the DMS
+ * `DATE_RANGE` filter states it. The crawl windows by year to stay under the
+ * endpoint's internal pagination cap; the reconciliation windows by month.
+ */
+type SearchDateRange = { from: string; to: string };
+
+type ExecuteSearchOptions = {
+  offset: number;
+  pageSize: number;
+  range: SearchDateRange;
+  signal?: AbortSignal | undefined;
+};
+
+const executeSearch = async ({
+  offset,
+  pageSize,
+  range,
+  signal,
+}: ExecuteSearchOptions): Promise<SearchResponse | null> => {
   const response = await fetchWithTimeout(SEARCH_URL, {
     method: "POST",
     headers: {
@@ -330,15 +450,15 @@ const executeSearch = async (
     body: JSON.stringify({
       docType: "USSR_DECISION_MK",
       start: offset,
-      pageSize: PAGE_SIZE,
+      pageSize,
       searchFilter: {
         filterNameValue: [
           {
             type: "DATE_RANGE",
             fieldName: "mkDateOfDecision",
             fieldValue: {
-              FROM: `${year}-01-01`,
-              TO: `${year}-12-31`,
+              FROM: range.from,
+              TO: range.to,
             },
           },
         ],
@@ -377,18 +497,16 @@ const executeSearch = async (
   return data;
 };
 
-type ExecuteSearchWithRetryOptions = {
+type ExecuteSearchWithRetryOptions = ExecuteSearchOptions & {
   cursor: string | null;
-  offset: number;
-  signal?: AbortSignal | undefined;
-  year: number;
 };
 
 const executeSearchWithRetry = async ({
   cursor,
   offset,
+  pageSize,
+  range,
   signal,
-  year,
 }: ExecuteSearchWithRetryOptions) =>
   await Result.tryPromise(
     {
@@ -396,7 +514,12 @@ const executeSearchWithRetry = async ({
         if (attemptSignal?.aborted) {
           throw new DOMException("Cycle aborted", "AbortError");
         }
-        return await executeSearch(year, offset, attemptSignal);
+        return await executeSearch({
+          offset,
+          pageSize,
+          range,
+          ...(attemptSignal === undefined ? {} : { signal: attemptSignal }),
+        });
       },
       catch: adapterCatch(ADAPTER_KEYS.SK_US, cursor),
     },
@@ -411,6 +534,171 @@ const executeSearchWithRetry = async ({
       },
     },
   );
+
+// ── Reconciliation ───────────────────────────────────────
+
+/**
+ * A reconciliation slice is one calendar month of decision dates, `YYYY-MM`,
+ * which sorts lexicographically in chronological order — the ordering the
+ * ledger relies on.
+ *
+ * The month rather than the year, even though the crawl windows by year: the
+ * DMS honours an arbitrary `DATE_RANGE`, and a year is too coarse to walk
+ * safely. The endpoint caps pagination at roughly 3,000 results per query, and
+ * the recent years are already close to it (2,454 decisions in 2020, 361 in
+ * June 2026 alone), so a year slice would silently stop listing the moment the
+ * court has a busy enough year — and a slice that cannot be listed to the end
+ * is a slice the ledger can never call complete. A month is a few hundred
+ * decisions, four pages of {@link LISTING_PAGE_SIZE}.
+ *
+ * The day, which would be finer still, is the wrong unit in the other
+ * direction: the court sits in panels on a handful of days a month, so most
+ * days are empty and the walk would spend its requests proving that.
+ */
+export const SK_US_FIRST_SLICE = `${FIRST_YEAR}-01`;
+
+/**
+ * Slices near the tip that get re-walked on a fast cadence. The contract
+ * counts slices, not days, so for this adapter the window is six months: a
+ * decision is listed only once the court has released it, this API states no
+ * publication date to measure that lag from (`mkPublicationDate` and
+ * `mkEntryDate` come back empty on current-year items), and a slice outside
+ * the window is re-walked only if the ledger already recorded it short. Six
+ * months of half-yearly-lagged releases is generous, and still a smaller fast
+ * lane than a day-sliced source's fortnight.
+ */
+const SK_US_TIP_WINDOW_SLICES = 6;
+
+const SLICE_PATTERN = /^(?<year>\d{4})-(?<month>0[1-9]|1[0-2])$/u;
+
+type SliceMonth = { year: number; month: number };
+
+const parseSlice = (slice: string): SliceMonth => {
+  const groups = SLICE_PATTERN.exec(slice)?.groups;
+  if (!groups?.["year"] || !groups["month"]) {
+    panic(`sk-us slice is not a calendar month: ${slice}`);
+  }
+  return {
+    year: Number.parseInt(groups["year"], 10),
+    month: Number.parseInt(groups["month"], 10),
+  };
+};
+
+const formatSlice = ({ month, year }: SliceMonth): string =>
+  `${String(year).padStart(4, "0")}-${String(month).padStart(2, "0")}`;
+
+const skUsSliceOf = (now: Date): string =>
+  formatSlice({ year: now.getUTCFullYear(), month: now.getUTCMonth() + 1 });
+
+/** Step a slice by whole months, normalizing the year through UTC. */
+const stepSlice = (slice: string, months: number): string => {
+  const { month, year } = parseSlice(slice);
+  return skUsSliceOf(new Date(Date.UTC(year, month - 1 + months, 1)));
+};
+
+const skUsNextSlice = (slice: string): string | null => {
+  const next = stepSlice(slice, 1);
+  return next > skUsSliceOf(new Date()) ? null : next;
+};
+
+const skUsPreviousSlice = (slice: string): string | null => {
+  const previous = stepSlice(slice, -1);
+  return previous < SK_US_FIRST_SLICE ? null : previous;
+};
+
+/** The publisher's own filter bounds for a slice: the month, end to end. */
+const sliceDateRange = (slice: string): SearchDateRange => {
+  const { month, year } = parseSlice(slice);
+  // Day 0 of the next month is the last day of this one.
+  const lastDay = new Date(Date.UTC(year, month, 0)).getUTCDate();
+  return { from: `${slice}-01`, to: `${slice}-${String(lastDay)}` };
+};
+
+/**
+ * One page of the publisher's own listing for a month, with no PDF downloads.
+ *
+ * A failed request is thrown, never flattened into an empty page. The crawl
+ * can afford to read a 204 or a dead window as "nothing here" because a cursor
+ * that moves on can be walked again; a ledger row cannot, since an outage
+ * recorded as an empty month makes that month settled and it is never revisited.
+ * So only a body that states a count answers what a month holds: `numFound: 0`
+ * is an empty slice, and everything else — a 5xx (this endpoint has been
+ * observed answering 500 and 524 under load), a 204, a body the validator
+ * rejects — is an error the engine retries on a later pass.
+ */
+const listSkUsSlicePage = async ({
+  page,
+  signal,
+  slice,
+}: ReconciliationSlicePageOptions): Promise<ReconciliationSlicePage> => {
+  const searchResult = await executeSearchWithRetry({
+    cursor: slice,
+    offset: page * LISTING_PAGE_SIZE,
+    pageSize: LISTING_PAGE_SIZE,
+    range: sliceDateRange(slice),
+    signal,
+  });
+  if (Result.isError(searchResult)) {
+    throw searchResult.error;
+  }
+
+  const data = searchResult.value;
+  if (data === null) {
+    throw new AdapterFetchError({
+      message: `SK ÚS search returned no body for ${slice}`,
+      adapterKey: ADAPTER_KEYS.SK_US,
+      cursor: slice,
+    });
+  }
+
+  return {
+    items: data.documents.map((doc) => ({
+      identity: skUsListingIdentity(doc),
+      payload: doc,
+    })),
+    totalPages: Math.ceil(data.numFound / LISTING_PAGE_SIZE),
+  };
+};
+
+/**
+ * Validate a payload the loop stored verbatim well enough to key it.
+ *
+ * Deliberately as lenient as {@link isSearchResponse}, and for the same
+ * reason: the DMS adds fields and changes their types without notice, and all
+ * of it lands in JSONB. Only the two fields the identity is made of are
+ * checked, so a parked payload that no longer states them is reported rather
+ * than parsed on faith.
+ */
+const isSearchDocument = (value: unknown): value is SearchDocument =>
+  isRecord(value) &&
+  (value["documentId"] === undefined ||
+    typeof value["documentId"] === "string") &&
+  (value["mkRSAPNumberOfFile"] === undefined ||
+    typeof value["mkRSAPNumberOfFile"] === "string");
+
+const buildSkUsFromPayload = async (
+  payload: unknown,
+  signal?: AbortSignal,
+): Promise<ReconciliationBuildOutcome> => {
+  if (!isSearchDocument(payload)) {
+    return { type: "unkeyable" };
+  }
+  const built = await buildSkUsDecision(payload, signal);
+  switch (built.type) {
+    case "built":
+      return { type: "built", decision: built.decision };
+    case "unkeyable":
+      return { type: "unkeyable" };
+    case "detail-unavailable":
+      // The decision the listing describes is deliberately dropped: storing it
+      // would make the identity held while its document stayed unread.
+      return { type: "detail-unavailable" };
+    default: {
+      const exhaustive: never = built;
+      return panic(`Unhandled SK ÚS build result: ${String(exhaustive)}`);
+    }
+  }
+};
 
 // ── Adapter ──────────────────────────────────────────────
 
@@ -434,6 +722,21 @@ export const skUsAdapter = defineSourceAdapter({
     return await Promise.resolve(null);
   },
 
+  /**
+   * The DMS answers a decision-date range on its own, so what a month holds is
+   * answerable without the crawl cursor ever reaching it: list the month, key
+   * each item the way the ingest would, and compare against what is held.
+   */
+  reconciliation: {
+    firstSlice: SK_US_FIRST_SLICE,
+    sliceOf: skUsSliceOf,
+    nextSlice: skUsNextSlice,
+    previousSlice: skUsPreviousSlice,
+    tipWindowDays: SK_US_TIP_WINDOW_SLICES,
+    listSlicePage: listSkUsSlicePage,
+    buildDecision: buildSkUsFromPayload,
+  },
+
   async fetchPage(cursor, _config, signal) {
     return await Result.tryPromise({
       try: async () => {
@@ -443,8 +746,9 @@ export const skUsAdapter = defineSourceAdapter({
         const searchResult = await executeSearchWithRetry({
           cursor,
           offset,
+          pageSize: PAGE_SIZE,
+          range: { from: `${year}-01-01`, to: `${year}-12-31` },
           signal,
-          year,
         });
         if (Result.isError(searchResult)) {
           if (signal?.aborted) {
@@ -476,9 +780,21 @@ export const skUsAdapter = defineSourceAdapter({
         for (const doc of data.documents) {
           try {
             // oxlint-disable-next-line no-await-in-loop -- sequential per-document PDF download/parse, rate-limited via Bun.sleep below
-            const result = await parseDocument(doc, signal);
-            if (result) {
-              decisions.push(result);
+            const built = await buildSkUsDecision(doc, signal);
+            switch (built.type) {
+              case "unkeyable":
+                break;
+              // The cursor moves past this document either way, so the crawl
+              // keeps the listing-only row a failed PDF still describes; only
+              // the reconciliation refuses it.
+              case "detail-unavailable":
+              case "built":
+                decisions.push(built.decision);
+                break;
+              default: {
+                const exhaustive: never = built;
+                panic(`Unhandled SK ÚS build result: ${String(exhaustive)}`);
+              }
             }
           } catch (error) {
             if (error instanceof DOMException) {

--- a/apps/api/src/handlers/case-law/ingestion/adapters/sk-us.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/sk-us.ts
@@ -61,8 +61,10 @@ import {
   AdapterFetchError,
   FetchBoundaryError,
 } from "@/api/lib/errors/tagged-errors";
+import { errorTag } from "@/api/lib/errors/utils";
 import { fetchWithTimeout } from "@/api/lib/fetch";
 import { parseSkDecisionPdf } from "@/api/lib/legal-search/parsers/sk-courts";
+import { logger } from "@/api/lib/observability/logger";
 import { isRecord } from "@/api/lib/type-guards";
 
 // ── Constants ─────────────────────────────────────────────
@@ -203,6 +205,26 @@ const parseApiDate = (raw: string | undefined): string | undefined => {
 
 // ── PDF download ─────────────────────────────────────────
 
+/** Every PDF starts with this; nothing else the portal serves does. */
+const PDF_SIGNATURE = "%PDF-";
+
+const PDF_SIGNATURE_BYTES = new TextEncoder().encode(PDF_SIGNATURE);
+
+const isPdf = (bytes: Uint8Array): boolean =>
+  bytes.length >= PDF_SIGNATURE_BYTES.length &&
+  PDF_SIGNATURE_BYTES.every((byte, index) => bytes[index] === byte);
+
+/**
+ * The decision's PDF, or `undefined` when the court served no document.
+ *
+ * The status alone does not answer that: this portal answers a document
+ * request with a 200 error page, and those bytes taken on faith would be
+ * stored as the decision's raw payload under `application/pdf` — an
+ * unparseable blob every later re-parse would read as the document itself.
+ * Checking the signature is what makes "the court served something else" and
+ * "the court served a PDF this parser cannot read" different answers: only the
+ * second is a payload worth keeping.
+ */
 const fetchPdfBytes = async (
   documentId: string,
   signal?: AbortSignal,
@@ -219,7 +241,8 @@ const fetchPdfBytes = async (
     if (!response.ok) {
       return undefined;
     }
-    return new Uint8Array(await response.arrayBuffer());
+    const bytes = new Uint8Array(await response.arrayBuffer());
+    return isPdf(bytes) ? bytes : undefined;
   } catch {
     return undefined;
   }
@@ -337,8 +360,17 @@ export const buildSkUsDecision = async (
       });
       documentAst = parsed.documentAst;
       fulltext = parsed.fulltext;
-    } catch {
-      // Parser failed; keep empty AST
+    } catch (error) {
+      // The document itself came back and is stored verbatim, so its text is
+      // recoverable by re-parsing what was kept rather than by asking the
+      // court again. Reported rather than swallowed: a parser that starts
+      // failing across a whole page is otherwise indistinguishable from
+      // decisions that genuinely carry no text.
+      logger.warn("case_law.ingestion.document_parse_failed", {
+        adapterKey: ADAPTER_KEYS.SK_US,
+        caseNumber,
+        "error.type": errorTag(error),
+      });
     }
   }
 


### PR DESCRIPTION
Implements the `reconciliation` capability on the sk-us (Constitutional Court DMS) adapter.

Slice = calendar month (`YYYY-MM`): the DMS honours an arbitrary `DATE_RANGE` precisely, and months stay well inside the endpoint's ~3,000-result pagination ceiling that full recent years plausibly exceed — a slice that cannot be listed to the end can never be recorded complete. Listing uses page size 100 (the crawl keeps 10 because each crawl item costs a document fetch); `totalPages = ceil(numFound/100)`. `firstSlice` is 1993-01, from the adapter's own first-year constant. `tipWindowDays = 6` counts slices, i.e. the last six months, documented at the field.

Resilience is the deliberate divergence from `fetchPage`: only a parsed body stating a count answers what a month holds. `numFound: 0` is an empty slice; a 5xx (after one retry), a bodyless response, or a payload the validator rejects all throw, so the engine halts the unit and retries later instead of recording a settled empty month — safe for a cursor, fatal for a ledger row.

Identity exists once (`skUsIdentityFields`), shared by the crawl, the listing identity, and the build path. Two behaviour notes: `detail-unavailable` still lets the crawl store the listing-only row (its cursor moves on either way) while reconciliation refuses it; and such rows now set `isListingOnly`, so a failed re-observation cannot overwrite detail an earlier fetch recovered (the same mechanism cz-us uses).

A pre-existing identity coarseness is documented at the identity rule rather than fixed here: the source emits no publisher document id, so documents sharing a docket collapse into one row per language (plenary opinions do share dockets). The reconciliation deliberately mirrors that so held-ness means what the store means; adopting the DMS document id is an identity re-key with corpus backfill and follows separately.

Tests: 22 new; adapter-registry, cursor-conformance, nullish-optional-fields, validate-fixtures, reconciliation-plan neighbours green (49 tests).
