### PR TITLE
feat(case-law): eu-ecj listing reconciliation capability

### DIFF
--- a/apps/api/src/handlers/case-law/ingestion/adapters/eu-ecj-reparse.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/eu-ecj-reparse.test.ts
@@ -1,5 +1,12 @@
 /* eslint-disable typescript-eslint/promise-function-async -- fetch mock callbacks return Promise.resolve without being async */
-import { afterEach, describe, expect, mock, test } from "bun:test";
+import {
+  afterEach,
+  describe,
+  expect,
+  mock,
+  setDefaultTimeout,
+  test,
+} from "bun:test";
 
 import type {
   IngestionResult,
@@ -44,6 +51,15 @@ const originalFetch = globalThis.fetch;
 afterEach(() => {
   globalThis.fetch = originalFetch;
 });
+
+/**
+ * Every test here crawls the fixture judgment and the replay tests parse it
+ * twice, which runs for seconds — close enough to the 5s default that these
+ * fail on a loaded machine rather than on a defect. Stated once for the file
+ * because the cost is the file's, not one test's; a real hang still ends the
+ * run well inside the runner's own deadline.
+ */
+setDefaultTimeout(30_000);
 
 const crawlDecision = async (): Promise<IngestionResult> => {
   globalThis.fetch = asFetchMock(

--- a/apps/api/src/handlers/case-law/ingestion/adapters/eu-ecj.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/eu-ecj.test.ts
@@ -3,7 +3,15 @@ import { Result } from "better-result";
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 import { hasUsableAst } from "@/api/handlers/case-law/document-ast";
-import { celexToCaseNumber } from "@/api/handlers/case-law/ingestion/adapters/eu-ecj";
+import {
+  celexToCaseNumber,
+  ecjListingIdentity,
+  euEcjAdapter as ecjAdapter,
+  SPARQL_LIMIT,
+} from "@/api/handlers/case-law/ingestion/adapters/eu-ecj";
+import { tipWindowSlices } from "@/api/handlers/case-law/ingestion/reconciliation-plan";
+import type { SourceReconciliation } from "@/api/lib/legal-search/ingestion-types";
+import { listingIdentityKey } from "@/api/lib/legal-search/ingestion-types";
 import { asFetchMock } from "@/api/tests/helpers/test-tool-set";
 
 import sparqlFixture from "./__fixtures__/eu-ecj-sparql.json";
@@ -449,5 +457,404 @@ describe("euEcjAdapter.fetchPage", () => {
     }
     expect(result.value.decisions).toHaveLength(0);
     expect(externalFetches).toBe(0);
+  });
+});
+
+// -- Reconciliation --
+
+/**
+ * What the standing reconciliation loop drives this source through. Read once
+ * here so every test below exercises the capability the adapter actually
+ * publishes, not a copy of it.
+ */
+const reconciliation = ((): SourceReconciliation => {
+  const capability = ecjAdapter.reconciliation;
+  if (capability === undefined) {
+    throw new TypeError("eu-ecj must declare the reconciliation capability");
+  }
+  return capability;
+})();
+
+/**
+ * bun-types declares `.rejects.toThrow` as void, so awaiting it trips
+ * type-aware lint; capture the rejection explicitly instead.
+ */
+const rejectionOf = async (promise: Promise<unknown>): Promise<unknown> =>
+  await promise.then(
+    () => null,
+    (error: unknown) => error,
+  );
+
+const rejectionMessage = (rejection: unknown): string =>
+  rejection instanceof Error ? rejection.message : "";
+
+const LANGUAGE_PREFIX =
+  "http://publications.europa.eu/resource/authority/language/";
+
+/** The key the engine's held-lookup builds for a row stored without a
+ * publisher document id: the docket and the language, exactly the pair the
+ * decision identity index is keyed on. */
+const storedIdentityKey = (decision: {
+  caseNumber: string;
+  language: string;
+}): string | null =>
+  listingIdentityKey({
+    type: "case-number",
+    caseNumber: decision.caseNumber,
+    language: decision.language,
+  });
+
+/**
+ * Enough text for the adapter to accept the response as a document. These
+ * tests are about which variant is keyed, listed and built, so they stay off
+ * the parser's own fixture: parsing a real judgment for each of them costs
+ * seconds and proves nothing they assert.
+ */
+const shortDocumentHtml = `<html><body><p>${"Judgment of the Court. ".repeat(
+  20,
+)}</p></body></html>`;
+
+type SparqlMockOptions = {
+  bindings: readonly unknown[];
+  /** Manifestation ids Cellar serves a document for. */
+  served?: readonly string[];
+};
+
+const requestUrl = (input: string | URL | Request): string => {
+  if (typeof input === "string") {
+    return input;
+  }
+  return input instanceof URL ? input.href : input.url;
+};
+
+/** Queries the mock was asked, so a test can assert the range it listed. */
+const installSparqlMock = ({
+  bindings,
+  served = [],
+}: SparqlMockOptions): { queries: string[]; documentFetches: string[] } => {
+  const queries: string[] = [];
+  const documentFetches: string[] = [];
+  globalThis.fetch = asFetchMock(
+    mock((input: string | URL | Request, init?: RequestInit) => {
+      const url = requestUrl(input);
+      if (url.includes("sparql")) {
+        const body = typeof init?.body === "string" ? init.body : "";
+        queries.push(new URLSearchParams(body).get("query") ?? "");
+        return Promise.resolve(
+          new Response(JSON.stringify({ results: { bindings } }), {
+            status: 200,
+          }),
+        );
+      }
+      documentFetches.push(url);
+      return served.some((id) => url.includes(id))
+        ? Promise.resolve(
+            new Response(shortDocumentHtml, {
+              status: 200,
+              headers: { "Content-Type": "text/html" },
+            }),
+          )
+        : Promise.resolve(new Response("Not found", { status: 404 }));
+    }),
+  );
+  return { queries, documentFetches };
+};
+
+describe("ecjListingIdentity", () => {
+  test("keys a variant on the docket and the stored language tag", () => {
+    // This source publishes no document id of its own, so the fallback half
+    // of the identity index is the whole rule.
+    expect(
+      ecjListingIdentity({ celex: "62021CJ0128", language: "EN" }),
+    ).toEqual({ type: "case-number", caseNumber: "C-128/21", language: "en" });
+    expect(
+      ecjListingIdentity({ celex: "62023TJ0201", language: "MT" }),
+    ).toEqual({ type: "case-number", caseNumber: "T-201/23", language: "mt" });
+  });
+
+  test("the key it produces fits the ledger and reads back", () => {
+    const identity = ecjListingIdentity({
+      celex: "62009FJ0100",
+      language: "SV",
+    });
+    expect(listingIdentityKey(identity)).toBe("case-number:sv:F-100/09");
+  });
+
+  test("a CELEX in a format the adapter cannot parse still keys", () => {
+    // The crawl stores such a row under the raw CELEX as its docket, so the
+    // listing has to ask about it under the same key or the row reads as
+    // missing on every pass.
+    expect(
+      ecjListingIdentity({ celex: "62021XX0128", language: "EN" }),
+    ).toEqual({
+      type: "case-number",
+      caseNumber: "62021XX0128",
+      language: "en",
+    });
+  });
+});
+
+describe("euEcjAdapter.reconciliation slices", () => {
+  test("a slice is a decision year, and years sort in walk order", () => {
+    expect(reconciliation.firstSlice).toBe("1952");
+    expect(reconciliation.sliceOf(new Date("2024-06-30T12:00:00.000Z"))).toBe(
+      "2024",
+    );
+    // The boundary is UTC, like every other slice this loop compares.
+    expect(reconciliation.sliceOf(new Date("2023-12-31T23:30:00.000Z"))).toBe(
+      "2023",
+    );
+    expect(reconciliation.sliceOf(new Date("2024-01-01T00:30:00.000Z"))).toBe(
+      "2024",
+    );
+  });
+
+  test("the walk steps one year at a time in both directions", () => {
+    expect(reconciliation.nextSlice("2023")).toBe("2024");
+    expect(reconciliation.previousSlice("2024")).toBe("2023");
+    expect(reconciliation.previousSlice(reconciliation.firstSlice)).toBeNull();
+    expect(
+      reconciliation.nextSlice(reconciliation.sliceOf(new Date())),
+    ).toBeNull();
+  });
+
+  test("the sweep reaches the Court's first decisions and stops there", () => {
+    const walked: string[] = [];
+    let cursor: string | null = "1955";
+    while (cursor !== null) {
+      walked.push(cursor);
+      cursor = reconciliation.previousSlice(cursor);
+    }
+    expect(walked).toEqual(["1955", "1954", "1953", "1952"]);
+    // Lexicographic descending is the order the ledger is compared in.
+    expect(walked.toSorted().toReversed()).toEqual(walked);
+  });
+
+  test("the tip window is the current year and the one before it", () => {
+    // `tipWindowDays` counts slices, so with year slices the window is two
+    // years, not two days.
+    expect(
+      tipWindowSlices(reconciliation, new Date("2026-08-11T09:30:00Z")),
+    ).toEqual(["2026", "2025"]);
+    // A source younger than the window yields only the slices that exist.
+    expect(
+      tipWindowSlices(reconciliation, new Date("1952-03-04T09:30:00Z")),
+    ).toEqual(["1952"]);
+  });
+
+  test("a slice that is not a year is refused rather than guessed at", () => {
+    expect(() => reconciliation.nextSlice("2024-01")).toThrow();
+    expect(() => reconciliation.previousSlice("202")).toThrow();
+  });
+});
+
+describe("euEcjAdapter.reconciliation.listSlicePage", () => {
+  const originalFetch = globalThis.fetch;
+  const originalSleep = Bun.sleep;
+
+  beforeEach(() => {
+    Bun.sleep = () => Promise.resolve();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    Bun.sleep = originalSleep;
+  });
+
+  test("pages a year one calendar month at a time", async () => {
+    const { queries } = installSparqlMock({ bindings: [enBinding] });
+
+    const page = await reconciliation.listSlicePage({ slice: "2024", page: 1 });
+
+    expect(page.totalPages).toBe(12);
+    // February of a leap year: the range ends on the month's own last day.
+    expect(queries.at(0)).toContain('FILTER(STR(?date) >= "2024-02-01")');
+    expect(queries.at(0)).toContain('FILTER(STR(?date) <= "2024-02-29")');
+  });
+
+  test("the last page covers December", async () => {
+    const { queries } = installSparqlMock({ bindings: [] });
+
+    await reconciliation.listSlicePage({ slice: "1998", page: 11 });
+
+    expect(queries.at(0)).toContain('FILTER(STR(?date) >= "1998-12-01")');
+    expect(queries.at(0)).toContain('FILTER(STR(?date) <= "1998-12-31")');
+  });
+
+  test("lists one item per variant, whatever the manifestations", async () => {
+    const republishedEn = withManifestation(firstFixtureBinding, {
+      cellarLanguage: "ENG",
+      manifestationId: "5f978357-b5e4-11ee-b164-01aa75ed71a1.0002.05",
+    });
+    const unpublishedLanguage = withManifestation(firstFixtureBinding, {
+      cellarLanguage: "ZZZ",
+      manifestationId: "5f978357-b5e4-11ee-b164-01aa75ed71a1.0003.05",
+    });
+    installSparqlMock({
+      bindings: [enBinding, republishedEn, frBinding, unpublishedLanguage],
+    });
+
+    const page = await reconciliation.listSlicePage({ slice: "2024", page: 0 });
+
+    // The re-published EN manifestation is the same variant, and a language
+    // this adapter does not publish is one the crawl would never store.
+    expect(
+      page.items.map(({ identity }) => listingIdentityKey(identity)),
+    ).toEqual(["case-number:en:C-128/21", "case-number:fr:C-128/21"]);
+    expect(page.items.map(({ payload }) => payload)).toEqual([
+      { celex: "62021CJ0128", language: "EN" },
+      { celex: "62021CJ0128", language: "FR" },
+    ]);
+  });
+
+  test("refuses a listing the endpoint truncated", async () => {
+    // A short page banked as a whole slice reads as settled, and the
+    // variants the cap left out would be recorded as never published.
+    const capped = Array.from({ length: SPARQL_LIMIT }, (_, index) => ({
+      ecli: { type: "literal", value: `ECLI:EU:C:2024:${index}` },
+      date: { type: "literal", value: "2024-01-18" },
+      celex: {
+        type: "literal",
+        value: `62021CJ${String(index).padStart(4, "0")}`,
+      },
+      type: {
+        type: "uri",
+        value: "http://publications.europa.eu/ontology/cdm#judgement",
+      },
+      language: { type: "uri", value: `${LANGUAGE_PREFIX}ENG` },
+      manifestation: {
+        type: "uri",
+        value: `${CELLAR_RESOURCE_PREFIX}${EN_MANIFESTATION_ID}`,
+      },
+    }));
+    installSparqlMock({ bindings: capped });
+
+    const rejection = await rejectionOf(
+      reconciliation.listSlicePage({ slice: "2024", page: 0 }),
+    );
+
+    expect(rejection).toBeInstanceOf(Error);
+    expect(rejectionMessage(rejection)).toContain("truncated");
+  });
+
+  test("refuses a page the slice does not have", async () => {
+    installSparqlMock({ bindings: [] });
+
+    const rejection = await rejectionOf(
+      reconciliation.listSlicePage({ slice: "2024", page: 12 }),
+    );
+
+    expect(rejectionMessage(rejection)).toContain("slice page out of range");
+  });
+
+  test("keys a listed variant exactly as the crawl stores it", async () => {
+    // The drift this guards is silent in both directions: key a stored row
+    // differently and the loop re-fetches it forever, key a listed item
+    // differently and the slice never settles.
+    installSparqlMock({
+      bindings: [enBinding, frBinding],
+      served: [EN_MANIFESTATION_ID, FR_MANIFESTATION_ID],
+    });
+
+    const crawled = await ecjAdapter.fetchPage("2024-01-18", {});
+    if (!Result.isOk(crawled)) {
+      throw new TypeError("Expected Ok result");
+    }
+    const listed = await reconciliation.listSlicePage({
+      slice: "2024",
+      page: 0,
+    });
+
+    // The premise of the case-number identity: this adapter states no
+    // publisher document id, so its rows fall to the fallback index.
+    expect(
+      crawled.value.decisions.every(
+        ({ sourceDocumentId }) => sourceDocumentId === undefined,
+      ),
+    ).toBe(true);
+    expect(
+      listed.items.map(({ identity }) => listingIdentityKey(identity)),
+    ).toEqual(crawled.value.decisions.map(storedIdentityKey));
+  });
+});
+
+describe("euEcjAdapter.reconciliation.buildDecision", () => {
+  const originalFetch = globalThis.fetch;
+  const originalSleep = Bun.sleep;
+
+  beforeEach(() => {
+    Bun.sleep = () => Promise.resolve();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    Bun.sleep = originalSleep;
+  });
+
+  test("builds the variant a stored payload names", async () => {
+    installSparqlMock({
+      bindings: [enBinding, frBinding],
+      served: [EN_MANIFESTATION_ID, FR_MANIFESTATION_ID],
+    });
+
+    // Through JSON, as the loop stores a parked payload and replays it.
+    const parked = JSON.stringify({ celex: "62021CJ0128", language: "FR" });
+    const payload: unknown = JSON.parse(parked);
+    const outcome = await reconciliation.buildDecision(payload);
+
+    if (outcome.type !== "built") {
+      throw new TypeError(`Expected built, got ${outcome.type}`);
+    }
+    expect(outcome.decision.caseNumber).toBe("C-128/21");
+    expect(outcome.decision.language).toBe("fr");
+    expect(outcome.decision.documentUrl).toContain(FR_MANIFESTATION_ID);
+  });
+
+  test("reports a variant the publisher lists but does not serve", async () => {
+    installSparqlMock({ bindings: [enBinding, frBinding], served: [] });
+
+    const outcome = await reconciliation.buildDecision({
+      celex: "62021CJ0128",
+      language: "EN",
+    });
+
+    // Not an error and not a written row: the loop parks it, widens its
+    // schedule and eventually retires it, which is what settles the slice.
+    expect(outcome).toEqual({ type: "detail-unavailable" });
+  });
+
+  test("reports a language the publisher no longer lists", async () => {
+    installSparqlMock({
+      bindings: [frBinding],
+      served: [EN_MANIFESTATION_ID, FR_MANIFESTATION_ID],
+    });
+
+    expect(
+      await reconciliation.buildDecision({
+        celex: "62021CJ0128",
+        language: "EN",
+      }),
+    ).toEqual({ type: "detail-unavailable" });
+  });
+
+  test("reports a payload no current identity rule keys", async () => {
+    const { queries, documentFetches } = installSparqlMock({ bindings: [] });
+
+    // A payload parked by an older adapter version, or one whose CELEX the
+    // query boundary would reject. Retired rather than retried, and the
+    // publisher is not contacted about it at all.
+    for (const payload of [
+      { celex: "62021cj0128", language: "EN" },
+      { celex: "62021CJ0128", language: "XX" },
+      { celex: "62021CJ0128" },
+      "62021CJ0128",
+    ]) {
+      // oxlint-disable-next-line no-await-in-loop -- each payload is asserted in turn
+      expect(await reconciliation.buildDecision(payload)).toEqual({
+        type: "unkeyable",
+      });
+    }
+    expect(queries).toHaveLength(0);
+    expect(documentFetches).toHaveLength(0);
   });
 });

--- a/apps/api/src/handlers/case-law/ingestion/adapters/eu-ecj.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/eu-ecj.test.ts
@@ -1,6 +1,14 @@
 import { Result } from "better-result";
 /* eslint-disable typescript-eslint/promise-function-async -- fetch mock callbacks return Promise.resolve without being async */
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  spyOn,
+  test,
+} from "bun:test";
 
 import { hasUsableAst } from "@/api/handlers/case-law/document-ast";
 import {
@@ -12,6 +20,7 @@ import {
 import { tipWindowSlices } from "@/api/handlers/case-law/ingestion/reconciliation-plan";
 import type { SourceReconciliation } from "@/api/lib/legal-search/ingestion-types";
 import { listingIdentityKey } from "@/api/lib/legal-search/ingestion-types";
+import { logger } from "@/api/lib/observability/logger";
 import { asFetchMock } from "@/api/tests/helpers/test-tool-set";
 
 import sparqlFixture from "./__fixtures__/eu-ecj-sparql.json";
@@ -768,6 +777,70 @@ describe("euEcjAdapter.reconciliation.listSlicePage", () => {
     expect(rejection).toBeInstanceOf(DOMException);
   });
 
+  test("records listed variants that share one stored identity", async () => {
+    // An opinion, a judgment and an order can settle one docket, and this
+    // source keys rows on the docket: those are one identity and one row, so
+    // the slice settles with one of the three held. The listing cannot key
+    // them apart without the persisted identity changing too — it must ask
+    // the question the ingest answers — so the collapse is counted instead of
+    // being left to look like completeness.
+    const orderBinding = {
+      ...withManifestation(firstFixtureBinding, {
+        cellarLanguage: "ENG",
+        manifestationId: "5f978357-b5e4-11ee-b164-01aa75ed71a1.0004.05",
+      }),
+      celex: { type: "literal", value: "62021CO0128" },
+    };
+    installSparqlMock({ bindings: [enBinding, orderBinding] });
+    const warn = spyOn(logger, "warn");
+
+    try {
+      const page = await reconciliation.listSlicePage({
+        slice: "2024",
+        page: 0,
+      });
+
+      // Both are listed; the engine is what collapses them, on the key the
+      // ingest would store.
+      expect(page.items.map(({ payload }) => payload)).toEqual([
+        { celex: "62021CJ0128", language: "EN" },
+        { celex: "62021CO0128", language: "EN" },
+      ]);
+      expect(
+        page.items.map(({ identity }) => listingIdentityKey(identity)),
+      ).toEqual(["case-number:en:C-128/21", "case-number:en:C-128/21"]);
+
+      const reported = warn.mock.calls.find(
+        ([message]) => message === "case_law.reconciliation.shared_identity",
+      );
+      expect(reported).toBeDefined();
+      expect(reported?.[1]?.["identities"]).toBe(1);
+      expect(reported?.[1]?.["documents"]).toBe(2);
+      expect(reported?.[1]?.["sample"]).toBe(
+        "case-number:en:C-128/21=62021CJ0128,62021CO0128",
+      );
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  test("says nothing when every listed variant keys to its own row", async () => {
+    installSparqlMock({ bindings: [enBinding, frBinding] });
+    const warn = spyOn(logger, "warn");
+
+    try {
+      await reconciliation.listSlicePage({ slice: "2024", page: 0 });
+
+      expect(
+        warn.mock.calls.filter(
+          ([message]) => message === "case_law.reconciliation.shared_identity",
+        ),
+      ).toEqual([]);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
   test("refuses a page the slice does not have", async () => {
     installSparqlMock({ bindings: [] });
 
@@ -839,6 +912,31 @@ describe("euEcjAdapter.reconciliation.buildDecision", () => {
     expect(outcome.decision.caseNumber).toBe("C-128/21");
     expect(outcome.decision.language).toBe("fr");
     expect(outcome.decision.documentUrl).toContain(FR_MANIFESTATION_ID);
+  });
+
+  test("builds from a later manifestation when the first is unreadable", async () => {
+    // A work can expose several XHTML manifestations of one language. The
+    // crawl treats a variant as done only once one of them builds, so a
+    // rebuild that stopped at the first would park — and eventually retire —
+    // a document the crawl ingests without trouble.
+    const staleManifestation = withManifestation(firstFixtureBinding, {
+      cellarLanguage: "ENG",
+      manifestationId: "5f978357-b5e4-11ee-b164-01aa75ed71a1.0005.05",
+    });
+    installSparqlMock({
+      bindings: [staleManifestation, enBinding],
+      served: [EN_MANIFESTATION_ID],
+    });
+
+    const outcome = await reconciliation.buildDecision({
+      celex: "62021CJ0128",
+      language: "EN",
+    });
+
+    if (outcome.type !== "built") {
+      throw new TypeError(`Expected built, got ${outcome.type}`);
+    }
+    expect(outcome.decision.documentUrl).toContain(EN_MANIFESTATION_ID);
   });
 
   test("reports a variant the publisher lists but does not serve", async () => {

--- a/apps/api/src/handlers/case-law/ingestion/adapters/eu-ecj.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/eu-ecj.test.ts
@@ -105,6 +105,14 @@ describe("celexToCaseNumber", () => {
 
 // -- fetchPage snapshot --
 
+/**
+ * Budget for a test that parses the fixture judgment. One parse runs for
+ * seconds, close enough to the 5s default that such a test fails on load
+ * rather than on a defect when the runner schedules another parse-heavy file
+ * beside this one. A real hang still ends the run.
+ */
+const PARSE_TEST_TIMEOUT = { timeout: 30_000 } as const;
+
 describe("euEcjAdapter.fetchPage", () => {
   const originalFetch = globalThis.fetch;
 
@@ -236,7 +244,7 @@ describe("euEcjAdapter.fetchPage", () => {
       expect(hasUsableAst(first.documentAst)).toBe(true);
       expect(first.sections?.length).toBeGreaterThan(1);
     },
-    { timeout: 30_000 },
+    PARSE_TEST_TIMEOUT,
   );
 
   test("handles SPARQL error", async () => {
@@ -284,56 +292,60 @@ describe("euEcjAdapter.fetchPage", () => {
     expect(page.nextCursor).toBe("2024-01-19");
   });
 
-  test("skips languages without fulltext", async () => {
-    globalThis.fetch = asFetchMock(
-      mock((url: string) => {
-        const urlStr = url;
+  test(
+    "skips languages without fulltext",
+    async () => {
+      globalThis.fetch = asFetchMock(
+        mock((url: string) => {
+          const urlStr = url;
 
-        if (urlStr.includes("sparql")) {
-          const fixture = {
-            results: {
-              bindings: [enBinding, frBinding, deBinding],
-            },
-          };
-          return Promise.resolve(
-            new Response(JSON.stringify(fixture), {
-              status: 200,
-            }),
-          );
-        }
+          if (urlStr.includes("sparql")) {
+            const fixture = {
+              results: {
+                bindings: [enBinding, frBinding, deBinding],
+              },
+            };
+            return Promise.resolve(
+              new Response(JSON.stringify(fixture), {
+                status: 200,
+              }),
+            );
+          }
 
-        // Only the EN and FR Cellar manifestations return fulltext.
-        if (
-          urlStr.includes(EN_MANIFESTATION_ID) ||
-          urlStr.includes(FR_MANIFESTATION_ID)
-        ) {
-          return Promise.resolve(
-            new Response(fulltextHtml, {
-              status: 200,
-              headers: { "Content-Type": "text/html" },
-            }),
-          );
-        }
+          // Only the EN and FR Cellar manifestations return fulltext.
+          if (
+            urlStr.includes(EN_MANIFESTATION_ID) ||
+            urlStr.includes(FR_MANIFESTATION_ID)
+          ) {
+            return Promise.resolve(
+              new Response(fulltextHtml, {
+                status: 200,
+                headers: { "Content-Type": "text/html" },
+              }),
+            );
+          }
 
-        return Promise.resolve(new Response("Not found", { status: 404 }));
-      }),
-    );
+          return Promise.resolve(new Response("Not found", { status: 404 }));
+        }),
+      );
 
-    const { euEcjAdapter } =
-      await import("@/api/handlers/case-law/ingestion/adapters/eu-ecj");
+      const { euEcjAdapter } =
+        await import("@/api/handlers/case-law/ingestion/adapters/eu-ecj");
 
-    const result = await euEcjAdapter.fetchPage("2024-01-18", {});
+      const result = await euEcjAdapter.fetchPage("2024-01-18", {});
 
-    if (!Result.isOk(result)) {
-      throw new TypeError("Expected Ok result");
-    }
-    const page = result.value;
+      if (!Result.isOk(result)) {
+        throw new TypeError("Expected Ok result");
+      }
+      const page = result.value;
 
-    // Only EN and FR variants
-    expect(page.decisions).toHaveLength(2);
-    const langs = page.decisions.map((d) => d.language).sort();
-    expect(langs).toEqual(["en", "fr"]);
-  });
+      // Only EN and FR variants
+      expect(page.decisions).toHaveLength(2);
+      const langs = page.decisions.map((d) => d.language).sort();
+      expect(langs).toEqual(["en", "fr"]);
+    },
+    PARSE_TEST_TIMEOUT,
+  );
 
   test("no decisions when all languages 404", async () => {
     globalThis.fetch = asFetchMock(
@@ -735,6 +747,25 @@ describe("euEcjAdapter.reconciliation.listSlicePage", () => {
 
     expect(rejection).toBeInstanceOf(Error);
     expect(rejectionMessage(rejection)).toContain("truncated");
+  });
+
+  test("a request that gives up throws rather than shortening the page", async () => {
+    // The other half of the truncation rule: an aborted or failed listing
+    // must reach the caller as a failure. Answering with the items that did
+    // arrive would bank a partial slice as the whole of it.
+    globalThis.fetch = asFetchMock(
+      mock(() =>
+        Promise.reject(
+          new DOMException("The operation timed out", "TimeoutError"),
+        ),
+      ),
+    );
+
+    const rejection = await rejectionOf(
+      reconciliation.listSlicePage({ slice: "2024", page: 0 }),
+    );
+
+    expect(rejection).toBeInstanceOf(DOMException);
   });
 
   test("refuses a page the slice does not have", async () => {

--- a/apps/api/src/handlers/case-law/ingestion/adapters/eu-ecj.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/eu-ecj.ts
@@ -241,10 +241,33 @@ const SPARQL_TRUNCATION = {
 type SparqlTruncation =
   (typeof SPARQL_TRUNCATION)[keyof typeof SPARQL_TRUNCATION];
 
+/**
+ * Budget for one bulk listing query: a census chunk, a re-fetch's pre-flight,
+ * a reconciliation slice page.
+ *
+ * Stated here so the callers that need it cannot state it separately and be
+ * overruled: a caller's `AbortSignal` and this budget both bound the request,
+ * so the shorter one wins, and a caller passing a 60s signal to a query
+ * hardcoded at 10s gets 10s while its own constant says otherwise.
+ *
+ * Generous next to the measured cost — a month-wide listing answers in around
+ * two seconds — because the callers are bulk operations without retries, where
+ * one slow response ends a run that has to start over. The live crawl keeps
+ * the tighter per-request default: its per-day pages are small, and a crawl
+ * that stalls should fail and move its cursor on.
+ */
+export const ECJ_LISTING_TIMEOUT_MS = 60_000;
+
 type QueryDecisionsOptions = {
   dateFrom: string;
   dateTo: string;
   signal: AbortSignal;
+  /**
+   * Budget for this request. Bounds it together with `signal`, so a caller
+   * gets the shorter of the two rather than whichever the query happens to
+   * hardcode.
+   */
+  timeoutMs: number;
   /** How a response that reached the binding cap is treated. */
   truncation: SparqlTruncation;
   /**
@@ -265,6 +288,7 @@ const queryDecisions = async ({
   dateFrom,
   dateTo,
   signal,
+  timeoutMs,
   truncation,
   celexFilter,
 }: QueryDecisionsOptions): Promise<SparqlResult[]> => {
@@ -319,7 +343,7 @@ LIMIT ${SPARQL_LIMIT}`.trim();
   const response = await fetchWithTimeout(SPARQL_URL, {
     method: "POST",
     signal,
-    timeoutMs: ADAPTER_TIMEOUT.REQUEST,
+    timeoutMs,
     headers: {
       Accept: "application/sparql-results+json",
       "Content-Type": "application/x-www-form-urlencoded",
@@ -612,6 +636,7 @@ export const fetchDecisionsByCelex = async ({
     dateFrom: COURT_EPOCH,
     dateTo: toIsoDate(new Date()),
     celexFilter: celexNumbers,
+    timeoutMs: ECJ_LISTING_TIMEOUT_MS,
     truncation: SPARQL_TRUNCATION.REFUSE,
     signal,
   });
@@ -665,6 +690,7 @@ export const listCelexVariants = async ({
       dateFrom: COURT_EPOCH,
       dateTo: toIsoDate(new Date()),
       celexFilter: celexNumbers,
+      timeoutMs: ECJ_LISTING_TIMEOUT_MS,
       truncation: SPARQL_TRUNCATION.REFUSE,
       signal,
     }),
@@ -1046,11 +1072,15 @@ const listEcjSlicePage = async ({
   signal,
 }: ReconciliationSlicePageOptions): Promise<ReconciliationSlicePage> => {
   const { dateFrom, dateTo } = ecjSlicePageRange(slice, page);
+  // A request that times out throws out of here, which halts the unit and
+  // leaves the slice's previous ledger row standing. Never a short page: a
+  // partial listing banked as the whole slice reads as reconciled.
   const bindings = await queryDecisions({
     dateFrom,
     dateTo,
+    timeoutMs: ECJ_LISTING_TIMEOUT_MS,
     truncation: SPARQL_TRUNCATION.REFUSE,
-    signal: signal ?? AbortSignal.timeout(ADAPTER_TIMEOUT.REQUEST),
+    signal: signal ?? AbortSignal.timeout(ECJ_LISTING_TIMEOUT_MS),
   });
   return {
     items: distinctVariants(bindings).map((variant) => ({
@@ -1097,7 +1127,7 @@ const buildEcjVariant = async (
   const decisions = await fetchDecisionsByCelex({
     celexNumbers: [payload.celex],
     languages: [payload.language],
-    signal: signal ?? AbortSignal.timeout(ADAPTER_TIMEOUT.REQUEST),
+    signal: signal ?? AbortSignal.timeout(ECJ_LISTING_TIMEOUT_MS),
   });
   const decision = decisions.at(0);
   return decision === undefined
@@ -1221,6 +1251,9 @@ WHERE {
         const bindings = await queryDecisions({
           dateFrom,
           dateTo,
+          // A live crawl fails fast and moves on; only the bulk listings buy
+          // headroom, because they have no cursor to come back to.
+          timeoutMs: ADAPTER_TIMEOUT.REQUEST,
           truncation: SPARQL_TRUNCATION.WARN,
           signal: abortSignal,
         });

--- a/apps/api/src/handlers/case-law/ingestion/adapters/eu-ecj.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/eu-ecj.ts
@@ -1,4 +1,4 @@
-import { Result } from "better-result";
+import { panic, Result } from "better-result";
 
 import {
   ADAPTER_KEYS,
@@ -14,6 +14,10 @@ import {
 import type {
   EmptyAst,
   IngestionResult,
+  ListingIdentity,
+  ReconciliationBuildOutcome,
+  ReconciliationSlicePage,
+  ReconciliationSlicePageOptions,
   StoredRawReparseInput,
   StoredRawReparseOutcome,
 } from "@/api/handlers/case-law/ingestion/adapter";
@@ -190,7 +194,13 @@ const isSparqlResponse = (value: unknown): value is SparqlResponse =>
   Array.isArray(value["results"]["bindings"]) &&
   value["results"]["bindings"].every(isSparqlResult);
 
-const SPARQL_LIMIT = 10_000;
+/**
+ * Bindings one response may carry. Exported because it is part of this
+ * adapter's listing contract rather than an internal detail: every caller that
+ * chunks a query sizes its chunk to stay under it, and a test that proves a
+ * capped response is refused has to reach exactly this many bindings.
+ */
+export const SPARQL_LIMIT = 10_000;
 
 const CDM_TYPE_MAP: Record<string, string> = {
   "http://publications.europa.eu/ontology/cdm#judgement": "judgment",
@@ -208,10 +218,35 @@ const CDM_TYPE_MAP: Record<string, string> = {
  */
 const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/u;
 
+/**
+ * What a query does when Cellar answers with exactly `SPARQL_LIMIT` bindings,
+ * which is indistinguishable from a listing cut off at the cap.
+ */
+const SPARQL_TRUNCATION = {
+  /**
+   * Refuse the page. Every caller that treats the listing as the statement of
+   * what exists — the census, a re-fetch, a slice walk — would otherwise read
+   * the bindings the cap left out as never published, and a partial listing
+   * banked as complete reads as settled.
+   */
+  REFUSE: "refuse",
+  /**
+   * Record it and continue. The crawl's per-day window sits orders of
+   * magnitude below the cap, so reaching it means the source changed shape
+   * rather than that this page is short.
+   */
+  WARN: "warn",
+} as const;
+
+type SparqlTruncation =
+  (typeof SPARQL_TRUNCATION)[keyof typeof SPARQL_TRUNCATION];
+
 type QueryDecisionsOptions = {
   dateFrom: string;
   dateTo: string;
   signal: AbortSignal;
+  /** How a response that reached the binding cap is treated. */
+  truncation: SparqlTruncation;
   /**
    * Restrict the page to these CELEX numbers. Used to record fixtures
    * for named decisions through the same query the crawl runs, instead
@@ -230,6 +265,7 @@ const queryDecisions = async ({
   dateFrom,
   dateTo,
   signal,
+  truncation,
   celexFilter,
 }: QueryDecisionsOptions): Promise<SparqlResult[]> => {
   if (!ISO_DATE.test(dateFrom) || !ISO_DATE.test(dateTo)) {
@@ -313,13 +349,9 @@ LIMIT ${SPARQL_LIMIT}`.trim();
   const bindings = json.results.bindings;
 
   if (bindings.length === SPARQL_LIMIT) {
-    // A truncated targeted listing is never acceptable: a census or
-    // re-fetch keyed on it would classify the missing variants as never
-    // published. The date-window crawl keeps the warning shape it has
-    // always had; its per-day pages sit far below the cap.
-    if (celexFilter && celexFilter.length > 0) {
+    if (truncation === SPARQL_TRUNCATION.REFUSE) {
       throw new AdapterFetchError({
-        message: `CJEU SPARQL listing truncated at ${SPARQL_LIMIT} bindings; use fewer CELEX numbers per query`,
+        message: `CJEU SPARQL listing truncated at ${SPARQL_LIMIT} bindings for ${dateFrom}..${dateTo}; narrow the date range or the CELEX chunk`,
         adapterKey: ADAPTER_KEYS.EU_ECJ,
         cursor: dateFrom,
       });
@@ -368,6 +400,70 @@ export const celexToCaseNumber = (celex: string): string => {
   const prefix = CELEX_PREFIX[typeStr] ?? "C";
 
   return `${prefix}-${caseNum}/${year}`;
+};
+
+/** One language variant of one decision, as Cellar lists it. */
+export type EcjCelexVariant = {
+  celex: string;
+  language: EcjLanguage;
+};
+
+/**
+ * The language tag a stored row carries, from the Cellar language this
+ * publisher lists. Cellar states languages in upper case and the schema stores
+ * them lower; the fallback identity index is keyed on the stored form, so the
+ * conversion lives here rather than at each call site.
+ */
+const ecjRowLanguage = (language: EcjLanguage): string =>
+  language.toLowerCase();
+
+/**
+ * The identity the ingest would store for one listed variant.
+ *
+ * This source publishes no document id of its own, so its rows are keyed on
+ * the docket and the language — the same pair `ecjDecisionFromHtml` writes,
+ * derived here by the same two rules. Stated once so the crawl's writes and
+ * the reconciliation's held-lookup cannot key the same variant differently:
+ * a second copy would let the loop read stored decisions as missing and
+ * re-fetch them forever.
+ *
+ * Always keyable: both halves come off the listing row itself, so there is no
+ * listed variant an ingest could not key.
+ */
+export const ecjListingIdentity = ({
+  celex,
+  language,
+}: EcjCelexVariant): ListingIdentity => ({
+  type: "case-number",
+  caseNumber: celexToCaseNumber(celex),
+  language: ecjRowLanguage(language),
+});
+
+/**
+ * The distinct (CELEX, language) variants a set of bindings names.
+ *
+ * A work can expose several XHTML manifestations of one language
+ * (re-publications), and bindings for a language this adapter does not
+ * publish are dropped exactly as the crawl drops them.
+ */
+const distinctVariants = (
+  bindings: readonly SparqlResult[],
+): EcjCelexVariant[] => {
+  const variants: EcjCelexVariant[] = [];
+  const seen = new Set<string>();
+  for (const binding of bindings) {
+    const language = toEcjLanguage(binding.language.value);
+    if (language === undefined) {
+      continue;
+    }
+    const key = `${binding.celex.value}:${language}`;
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    variants.push({ celex: binding.celex.value, language });
+  }
+  return variants;
 };
 
 // -- Fulltext --
@@ -479,8 +575,11 @@ const parseManifestation = (
 /** Crawl delay between decisions (not between language variants). */
 const CRAWL_DELAY_MS = 500;
 
+/** First year the Court sat; the oldest decisions Cellar can list. */
+const COURT_EPOCH_YEAR = "1952";
+
 /** First day the Court sat; the widest range a CELEX lookup can need. */
-const COURT_EPOCH = "1952-01-01";
+const COURT_EPOCH = `${COURT_EPOCH_YEAR}-01-01`;
 
 type FetchDecisionsByCelexOptions = {
   celexNumbers: readonly string[];
@@ -513,6 +612,7 @@ export const fetchDecisionsByCelex = async ({
     dateFrom: COURT_EPOCH,
     dateTo: toIsoDate(new Date()),
     celexFilter: celexNumbers,
+    truncation: SPARQL_TRUNCATION.REFUSE,
     signal,
   });
 
@@ -539,11 +639,6 @@ export const fetchDecisionsByCelex = async ({
   return decisions;
 };
 
-export type EcjCelexVariant = {
-  celex: string;
-  language: EcjLanguage;
-};
-
 type ListCelexVariantsOptions = {
   celexNumbers: readonly string[];
   signal: AbortSignal;
@@ -565,27 +660,15 @@ export const listCelexVariants = async ({
   if (celexNumbers.length === 0) {
     return [];
   }
-  const bindings = await queryDecisions({
-    dateFrom: COURT_EPOCH,
-    dateTo: toIsoDate(new Date()),
-    celexFilter: celexNumbers,
-    signal,
-  });
-  const variants: EcjCelexVariant[] = [];
-  const seen = new Set<string>();
-  for (const binding of bindings) {
-    const language = toEcjLanguage(binding.language.value);
-    if (language === undefined) {
-      continue;
-    }
-    const key = `${binding.celex.value}:${language}`;
-    if (seen.has(key)) {
-      continue;
-    }
-    seen.add(key);
-    variants.push({ celex: binding.celex.value, language });
-  }
-  return variants;
+  return distinctVariants(
+    await queryDecisions({
+      dateFrom: COURT_EPOCH,
+      dateTo: toIsoDate(new Date()),
+      celexFilter: celexNumbers,
+      truncation: SPARQL_TRUNCATION.REFUSE,
+      signal,
+    }),
+  );
 };
 
 /** Historical media type whose string payload passed through normalization. */
@@ -842,7 +925,7 @@ export const buildDecision = async (
     court,
     decisionDate: date,
     decisionType,
-    language: lang.toLowerCase(),
+    language: ecjRowLanguage(lang),
     sourceUrl: eurLexSourceUrl(lang, celex),
     documentUrl,
     html,
@@ -865,6 +948,163 @@ const addDays = (date: string, days: number): string => {
   return toIsoDate(d);
 };
 
+// -- Reconciliation --
+//
+// A slice for this source is one decision year. The listing surface is
+// addressed by decision date, so a year is a range the publisher can be asked
+// about directly, and `YYYY` sorts lexicographically in chronological order —
+// the ordering the ledger relies on. A day would be the finer unit, as it is
+// for the crawl, but the Court sits on a few hundred days a year: a day-sliced
+// sweep would spend most of its units proving that nothing was decided, and
+// would need about twenty-five thousand of them to reach the Court's first
+// decisions.
+
+const ECJ_SLICE_YEAR = /^\d{4}$/u;
+
+/**
+ * A year is listed one calendar month at a time.
+ *
+ * The cap on a SPARQL response is `SPARQL_LIMIT` bindings and a busy month
+ * measures around 1,500 of them, so a whole year in one query would sit close
+ * to the cap and a truncated listing is refused rather than banked. Twelve
+ * fixed pages also make the page number an offset nothing has to remember:
+ * every page is derived from the slice alone, so a re-walk asks the same
+ * questions in the same order.
+ */
+const ECJ_SLICE_PAGES = 12;
+
+/**
+ * Tip slices re-walked on the loop's fast cadence. `tipWindowDays` counts
+ * slices, not days, so with year slices this is the current year and the one
+ * before it.
+ *
+ * The window is what catches a slice the publisher adds to after it was first
+ * walked, and this publisher adds translations to a decision for a long time
+ * after the judgment date that files it under a year. Two slices give a
+ * decision between twelve and twenty-four months of tip coverage, depending on
+ * where in its year it was decided; anything later is left to the ledger's
+ * short-slice backlog.
+ */
+const ECJ_TIP_WINDOW_SLICES = 2;
+
+const ecjYearOf = (date: Date): string =>
+  toIsoDate(date).slice(0, COURT_EPOCH_YEAR.length);
+
+const ecjSliceYear = (slice: string): number => {
+  if (!ECJ_SLICE_YEAR.test(slice)) {
+    panic(`eu-ecj slice is not a four-digit year: ${slice}`);
+  }
+  return Number.parseInt(slice, 10);
+};
+
+/** Fixed width keeps the lexicographic ordering the ledger walks by. */
+const ecjSlice = (year: number): string =>
+  String(year).padStart(COURT_EPOCH_YEAR.length, "0");
+
+const ecjNextSlice = (slice: string): string | null => {
+  const next = ecjSlice(ecjSliceYear(slice) + 1);
+  return next > ecjYearOf(new Date()) ? null : next;
+};
+
+const ecjPreviousSlice = (slice: string): string | null => {
+  const previous = ecjSlice(ecjSliceYear(slice) - 1);
+  return previous < COURT_EPOCH_YEAR ? null : previous;
+};
+
+type EcjSliceRange = {
+  dateFrom: string;
+  dateTo: string;
+};
+
+/** The calendar month one page of a year slice covers, inclusive. */
+const ecjSlicePageRange = (slice: string, page: number): EcjSliceRange => {
+  if (!Number.isInteger(page) || page < 0 || page >= ECJ_SLICE_PAGES) {
+    panic(`eu-ecj slice page out of range: ${page}`);
+  }
+  const year = ecjSliceYear(slice);
+  const monthIndex = page;
+  return {
+    dateFrom: toIsoDate(new Date(Date.UTC(year, monthIndex, 1))),
+    // Day 0 of the following month is the last day of this one.
+    dateTo: toIsoDate(new Date(Date.UTC(year, monthIndex + 1, 0))),
+  };
+};
+
+/**
+ * One page of what the publisher lists for a slice, with no manifestation
+ * fetched.
+ *
+ * The crawl reaches a decision by walking its cursor to the publication date
+ * and downloads every language variant it finds there, which is the wrong
+ * shape for asking what a year contains. This is the same query, filters and
+ * language mapping as the crawl, stopping at the listing, so what it says the
+ * year holds cannot disagree with what a crawl of that year would store.
+ */
+const listEcjSlicePage = async ({
+  slice,
+  page,
+  signal,
+}: ReconciliationSlicePageOptions): Promise<ReconciliationSlicePage> => {
+  const { dateFrom, dateTo } = ecjSlicePageRange(slice, page);
+  const bindings = await queryDecisions({
+    dateFrom,
+    dateTo,
+    truncation: SPARQL_TRUNCATION.REFUSE,
+    signal: signal ?? AbortSignal.timeout(ADAPTER_TIMEOUT.REQUEST),
+  });
+  return {
+    items: distinctVariants(bindings).map((variant) => ({
+      identity: ecjListingIdentity(variant),
+      payload: variant,
+    })),
+    // Structural, not reported: the publisher answers a date range, so the
+    // months of the year are the pages whether or not it decided anything in
+    // them.
+    totalPages: ECJ_SLICE_PAGES,
+  };
+};
+
+const isEcjCelexVariant = (value: unknown): value is EcjCelexVariant =>
+  isRecord(value) &&
+  typeof value["celex"] === "string" &&
+  isValidCelex(value["celex"]) &&
+  ECJ_LANGUAGES.some((language) => language === value["language"]);
+
+/**
+ * Rebuild one listed variant, through the adapter's own query and build path.
+ *
+ * The payload is the variant, not the binding that named it: a parked item is
+ * replayed days later, and a manifestation URI recorded at listing time may
+ * by then point at a superseded version. Listing the CELEX again resolves the
+ * current manifestation, which is what a crawl reaching that decision today
+ * would fetch.
+ *
+ * A variant Cellar lists but does not serve — no manifestation for the
+ * language, or nothing behind the one it names — is reported as unavailable
+ * rather than written. It is an ordinary outcome, not a failure: the loop
+ * parks such an item, widens its schedule and eventually retires it, and a
+ * retired item is what lets its slice settle. Writing a detail-less row
+ * instead would make the identity held and take the document out of every
+ * later reconciliation.
+ */
+const buildEcjVariant = async (
+  payload: unknown,
+  signal?: AbortSignal,
+): Promise<ReconciliationBuildOutcome> => {
+  if (!isEcjCelexVariant(payload)) {
+    return { type: "unkeyable" };
+  }
+  const decisions = await fetchDecisionsByCelex({
+    celexNumbers: [payload.celex],
+    languages: [payload.language],
+    signal: signal ?? AbortSignal.timeout(ADAPTER_TIMEOUT.REQUEST),
+  });
+  const decision = decisions.at(0);
+  return decision === undefined
+    ? { type: "detail-unavailable" }
+    : { type: "built", decision };
+};
+
 // -- Adapter --
 
 /**
@@ -884,6 +1124,22 @@ export const euEcjAdapter = defineSourceAdapter({
   // One stored payload is one language variant of one decision, so a stored
   // manifestation maps back to exactly the row it was stored for.
   reparseStoredRaw,
+
+  /**
+   * The publisher lists a date range independently of the crawl cursor, so
+   * what a year contains is answerable without re-crawling it: enumerate the
+   * year, key each variant the way the ingest would, and compare against what
+   * is held.
+   */
+  reconciliation: {
+    firstSlice: COURT_EPOCH_YEAR,
+    sliceOf: ecjYearOf,
+    nextSlice: ecjNextSlice,
+    previousSlice: ecjPreviousSlice,
+    tipWindowDays: ECJ_TIP_WINDOW_SLICES,
+    listSlicePage: listEcjSlicePage,
+    buildDecision: buildEcjVariant,
+  },
 
   /**
    * Counts (work, language) pairs under the same type and manifestation
@@ -965,6 +1221,7 @@ WHERE {
         const bindings = await queryDecisions({
           dateFrom,
           dateTo,
+          truncation: SPARQL_TRUNCATION.WARN,
           signal: abortSignal,
         });
 

--- a/apps/api/src/handlers/case-law/ingestion/adapters/eu-ecj.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/eu-ecj.ts
@@ -9,6 +9,7 @@ import type { DocumentAst } from "@/api/handlers/case-law/document-ast";
 import {
   defineSourceAdapter,
   EMPTY_AST,
+  listingIdentityKey,
   STORED_RAW_REPARSE_REJECTION,
 } from "@/api/handlers/case-law/ingestion/adapter";
 import type {
@@ -642,24 +643,29 @@ export const fetchDecisionsByCelex = async ({
   });
 
   const decisions: IngestionResult[] = [];
-  const seen = new Set<string>();
+  const completedVariants = new Set<string>();
   for (const binding of bindings) {
     const lang = toEcjLanguage(binding.language.value);
     if (lang === undefined || (languages && !languages.includes(lang))) {
       continue;
     }
     // A work can expose several XHTML manifestations of one language
-    // (re-publications); the first is the one the crawl would take.
+    // (re-publications), and a variant is done only once one of them has
+    // built — the rule the crawl walks by. Marking it on sight instead
+    // would let an unreadable first manifestation stand for the variant
+    // while a later usable one goes unvisited, and every caller here reads
+    // an empty result as the publisher not serving the document at all.
     const variantKey = `${binding.celex.value}:${lang}`;
-    if (seen.has(variantKey)) {
+    if (completedVariants.has(variantKey)) {
       continue;
     }
-    seen.add(variantKey);
     // oxlint-disable-next-line no-await-in-loop -- rate-limited external calls stay sequential instead of fanning out across every manifestation
     const decision = await buildDecision(binding, signal);
-    if (decision) {
-      decisions.push(decision);
+    if (!decision) {
+      continue;
     }
+    decisions.push(decision);
+    completedVariants.add(variantKey);
   }
   return decisions;
 };
@@ -1008,8 +1014,15 @@ const ECJ_SLICE_PAGES = 12;
  * walked, and this publisher adds translations to a decision for a long time
  * after the judgment date that files it under a year. Two slices give a
  * decision between twelve and twenty-four months of tip coverage, depending on
- * where in its year it was decided; anything later is left to the ledger's
- * short-slice backlog.
+ * where in its year it was decided.
+ *
+ * And that is the whole of it: a year walked complete and left behind is not
+ * listed again. The ledger's backlog only revisits slices already recorded
+ * short, and the sweep only fills history never surveyed at all, so a
+ * translation arriving after its year leaves the window stays unseen until
+ * something re-surveys that year. Closing that means re-walking stale complete
+ * slices, which is the loop's selection policy and belongs with it rather than
+ * with one adapter's window.
  */
 const ECJ_TIP_WINDOW_SLICES = 2;
 
@@ -1056,6 +1069,66 @@ const ecjSlicePageRange = (slice: string, page: number): EcjSliceRange => {
   };
 };
 
+/** Shared identities named in the log line; enough to act on, bounded. */
+const SHARED_IDENTITY_SAMPLE = 3;
+
+/**
+ * Record listed variants that would be stored under one identity.
+ *
+ * Several document kinds settle one docket — an opinion, a judgment and an
+ * order all numbered C-100/23 — and this source keys its rows on the docket
+ * and the language, so those become one identity and one row. A slice's
+ * counts are computed over identities and stay self-consistent, but they
+ * cannot then speak for the documents behind a shared key: the slice settles
+ * while only one of them is held.
+ *
+ * The reconciliation must key items exactly as the ingest keys rows or it
+ * never reaches a fixed point, so this is not something the listing may fix
+ * on its own — the granularity is the persisted identity's. Counting it here
+ * is what keeps the gap measurable rather than silent, and gives a re-key the
+ * measurement it would need.
+ */
+const reportSharedIdentities = (
+  slice: string,
+  page: number,
+  variants: readonly EcjCelexVariant[],
+): void => {
+  const celexByIdentity = new Map<string, Set<string>>();
+  for (const variant of variants) {
+    const key = listingIdentityKey(ecjListingIdentity(variant));
+    if (key === null) {
+      continue;
+    }
+    const celexNumbers = celexByIdentity.get(key) ?? new Set<string>();
+    celexNumbers.add(variant.celex);
+    celexByIdentity.set(key, celexNumbers);
+  }
+  const shared = [...celexByIdentity].filter(
+    ([, celexNumbers]) => celexNumbers.size > 1,
+  );
+  if (shared.length === 0) {
+    return;
+  }
+  logger.warn("case_law.reconciliation.shared_identity", {
+    adapterKey: ADAPTER_KEYS.EU_ECJ,
+    slice,
+    page,
+    identities: shared.length,
+    documents: shared.reduce(
+      (total, [, celexNumbers]) => total + celexNumbers.size,
+      0,
+    ),
+    // One string, because a log attribute is a scalar: an array here is
+    // rejected at the type boundary rather than silently flattened.
+    sample: shared
+      .slice(0, SHARED_IDENTITY_SAMPLE)
+      .map(
+        ([key, celexNumbers]) => `${key}=${[...celexNumbers].sort().join(",")}`,
+      )
+      .join("; "),
+  });
+};
+
 /**
  * One page of what the publisher lists for a slice, with no manifestation
  * fetched.
@@ -1082,8 +1155,10 @@ const listEcjSlicePage = async ({
     truncation: SPARQL_TRUNCATION.REFUSE,
     signal: signal ?? AbortSignal.timeout(ECJ_LISTING_TIMEOUT_MS),
   });
+  const variants = distinctVariants(bindings);
+  reportSharedIdentities(slice, page, variants);
   return {
-    items: distinctVariants(bindings).map((variant) => ({
+    items: variants.map((variant) => ({
       identity: ecjListingIdentity(variant),
       payload: variant,
     })),

--- a/apps/api/src/scripts/eu-ecj-census.ts
+++ b/apps/api/src/scripts/eu-ecj-census.ts
@@ -4,7 +4,10 @@ import { rlsDb } from "@/api/db/root";
 import { caseLawDecisions, caseLawSources } from "@/api/db/schema";
 import { createIngestionDb } from "@/api/db/scoped";
 import { ADAPTER_KEYS } from "@/api/handlers/case-law/consts";
-import { listCelexVariants } from "@/api/handlers/case-law/ingestion/adapters/eu-ecj";
+import {
+  ECJ_LISTING_TIMEOUT_MS,
+  listCelexVariants,
+} from "@/api/handlers/case-law/ingestion/adapters/eu-ecj";
 import type { SafeId } from "@/api/lib/branded-types";
 
 /**
@@ -33,7 +36,6 @@ import type { SafeId } from "@/api/lib/branded-types";
 
 const DEFAULT_PAGE_SIZE = 500;
 const DEFAULT_SPARQL_CHUNK = 100;
-const SPARQL_TIMEOUT_MS = 60_000;
 /** Politeness pause between SPARQL queries; this is a bulk read. */
 const SPARQL_DELAY_MS = 1000;
 
@@ -177,7 +179,7 @@ for (let index = 0; index < distinctCelex.length; index += sparqlChunk) {
   // oxlint-disable-next-line no-await-in-loop -- rate-limited external queries stay sequential
   const variants = await listCelexVariants({
     celexNumbers: chunk,
-    signal: AbortSignal.timeout(SPARQL_TIMEOUT_MS),
+    signal: AbortSignal.timeout(ECJ_LISTING_TIMEOUT_MS),
   });
   for (const variant of variants) {
     listedVariants.add(`${variant.celex}:${variant.language}`);

--- a/apps/api/src/scripts/eu-ecj-refetch.ts
+++ b/apps/api/src/scripts/eu-ecj-refetch.ts
@@ -5,6 +5,7 @@ import { caseLawSources } from "@/api/db/schema";
 import { createIngestionDb } from "@/api/db/scoped";
 import { ADAPTER_KEYS } from "@/api/handlers/case-law/consts";
 import {
+  ECJ_LISTING_TIMEOUT_MS,
   fetchDecisionsByCelex,
   isValidCelex,
   listCelexVariants,
@@ -57,8 +58,8 @@ import { refreshCorpusS3, refreshS3 } from "@/api/lib/s3";
 const DEFAULT_DELAY_MS = 500;
 /** Consecutive failed CELEX before the run halts; mirrors the crawl. */
 const FAILURE_HALT_THRESHOLD = 10;
+/** Whole-CELEX budget: one listing plus every language variant behind it. */
 const CELEX_FETCH_TIMEOUT_MS = 5 * 60_000;
-const SPARQL_TIMEOUT_MS = 60_000;
 const DEFAULT_FAILED_OUT = "eu-ecj-refetch-failed.json";
 
 const USAGE = `Usage: bun run src/scripts/eu-ecj-refetch.ts [options]
@@ -269,7 +270,7 @@ try {
       // oxlint-disable-next-line no-await-in-loop -- rate-limited publisher traffic stays sequential
       const expected = await listCelexVariants({
         celexNumbers: [celex],
-        signal: AbortSignal.timeout(SPARQL_TIMEOUT_MS),
+        signal: AbortSignal.timeout(ECJ_LISTING_TIMEOUT_MS),
       });
       counts.variantsExpected += expected.length;
       // oxlint-disable-next-line no-await-in-loop -- rate-limited publisher traffic stays sequential


### PR DESCRIPTION
Implements the `reconciliation` capability on the eu-ecj adapter, reusing the existing CELEX enumeration machinery rather than adding a parallel one.

Slice = decision year (`YYYY`), paged as one calendar month per request (`totalPages` fixed at 12): the SPARQL surface filters on the document date, a probed month returned ~1,400 bindings in ~2s against the endpoint's 10,000-binding cap where a full year would truncate, and pages derive from the slice alone so a re-walk asks identical questions. `firstSlice` is 1952, now derived from the adapter's court-epoch constant so the two cannot drift. `tipWindowDays = 2` counts slices — current plus previous year — because this publisher files by judgment date and adds language variants long after.

Identity: the source emits no publisher document id, so rows key on `(caseNumber, language)`; the listing identity states exactly that through one exported rule the crawl's build path now shares, and a test asserts listing keys equal the keys of rows the real crawl path produces from the same bindings — adding a document id later breaks the test rather than silently desynchronising the loop. `buildDecision` replays a `{celex, language}` payload through the single-variant fetch, which re-lists first so a parked item replayed later resolves the current manifestation; nothing served is `detail-unavailable` (an ordinary outcome: park, widen, retire).

Truncation became an explicit `REFUSE | WARN` discriminator on the query layer: listing paths (census, re-fetch, slice walk) refuse a truncated result outright — a partial listing banked as complete reads as settled — while the crawl's per-day window keeps its warn-and-continue behaviour. The query limit is exported so the truncation test exercises the real cap.

Second commit fixes two pre-existing issues found on the way: the bulk-listing timeout was silently clamped to the 10s per-request default while callers passed 60s signals under a constant that therefore lied — `queryDecisions` now threads an explicit budget, stated once as `ECJ_LISTING_TIMEOUT_MS`, with the crawl unchanged at 10s and a test pinning that a timed-out listing throws rather than shortening the page; and the parse-heavy test files gained explicit budgets against their multi-second fixture cost.

Tests: 33 in the adapter suite (was 15); five-file neighbourhood green at 87.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved EU Court of Justice case-law ingestion reliability and reconciliation.
  * Prevented incomplete bulk listings from being processed, while allowing live crawls to continue safely.
  * Improved handling of language variants, duplicate identities, pagination, yearly boundaries and unavailable documents.
  * Added fallback behaviour for missing manifestations and unkeyable records.

* **Tests**
  * Expanded coverage for pagination, truncation, failed requests, identity sharing and listing consistency.
  * Added longer timeouts for parser-dependent test scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->