### PR TITLE
chore(runner): take day-length constants from @stll/time

### DIFF
--- a/.oxlint-plugins/no-raw-date-parsing.ts
+++ b/.oxlint-plugins/no-raw-date-parsing.ts
@@ -19,8 +19,8 @@ import type { ESTree } from "@oxlint/plugins";
 //    the clocks-change day is 23 or 25 hours, not 24. Calendar math must
 //    use `addDays` from `lib/dates.ts`; a genuine 24-hour DURATION (TTL,
 //    staleness window, polling interval) must use the named `DAY_IN_MS`
-//    from the `@stll/time` package (its one home, outside this rule's
-//    apps/{web,api}/src scope).
+//    from the `@stll/time` package (its one home, which sits outside the
+//    app source trees this rule is scoped to in oxlint.config.ts).
 //
 // Flagged:
 //   new Date("2024-01-01")

--- a/apps/legal-atlas-runner/package.json
+++ b/apps/legal-atlas-runner/package.json
@@ -36,6 +36,7 @@
   "dependencies": {
     "@stll/api": "workspace:*",
     "@stll/legal-atlas": "workspace:*",
+    "@stll/time": "workspace:*",
     "better-result": "catalog:"
   },
   "devDependencies": {

--- a/apps/legal-atlas-runner/src/runners/case-law-ingest.ts
+++ b/apps/legal-atlas-runner/src/runners/case-law-ingest.ts
@@ -19,6 +19,8 @@
 
 import { panic } from "better-result";
 
+import { DAY_IN_MS } from "@stll/time";
+
 import { SOURCE_TOTAL_ORIGIN, caseLawIngestionEvents } from "@/api/db/schema";
 import { corpusStorageMode, envBase } from "@/api/env-base";
 import {
@@ -657,7 +659,7 @@ const ensureSource = async (
 };
 
 const daysAgoCursor = (n: number): string => {
-  const d = new Date(Date.now() - n * 24 * 60 * 60 * 1000);
+  const d = new Date(Date.now() - n * DAY_IN_MS);
   const date = d.toISOString().split("T")[0];
   if (!date) {
     panic("Invalid date format");

--- a/apps/legal-atlas-runner/src/runners/cycle-progress.ts
+++ b/apps/legal-atlas-runner/src/runners/cycle-progress.ts
@@ -8,6 +8,8 @@
 
 import { panic } from "better-result";
 
+import { DAY_IN_MS } from "@stll/time";
+
 export const CYCLE_OUTCOME = {
   COMPLETED: "completed",
   FAILED: "failed",
@@ -125,7 +127,6 @@ export const CYCLE_CADENCE = {
 export type CycleCadence = (typeof CYCLE_CADENCE)[keyof typeof CYCLE_CADENCE];
 
 const FAST_DELAY_MS = 5000;
-const DAILY_DELAY_MS = 24 * 60 * 60 * 1000;
 
 const HOURLY_DELAY_MS = 60 * 60 * 1000;
 
@@ -148,7 +149,7 @@ const HOURLY_DELAY_MS = 60 * 60 * 1000;
  */
 export const CYCLE_CADENCE_DELAY_MS = {
   [CYCLE_CADENCE.FAST]: FAST_DELAY_MS,
-  [CYCLE_CADENCE.CAUGHT_UP]: DAILY_DELAY_MS,
+  [CYCLE_CADENCE.CAUGHT_UP]: DAY_IN_MS,
   [CYCLE_CADENCE.UNPRODUCTIVE_BACKOFF]: HOURLY_DELAY_MS,
 } as const satisfies Record<CycleCadence, number>;
 

--- a/apps/legal-atlas-runner/src/runners/source-total-outcomes.ts
+++ b/apps/legal-atlas-runner/src/runners/source-total-outcomes.ts
@@ -8,16 +8,10 @@
 
 import { panic } from "better-result";
 
+import { DAY_IN_MS } from "@stll/time";
+
 import type { SourceReportedTotal } from "@/api/handlers/case-law/ingestion/source-totals";
 import type { SourceAdapter } from "@/api/lib/legal-search/ingestion-types";
-
-/**
- * A plain 24-hour day. The window below is an elapsed duration, not
- * calendar arithmetic, so no DST-aware helper applies. Spelled out here
- * rather than taken from `@stll/time`, which this package does not depend
- * on.
- */
-const DAY_MS = 24 * 60 * 60 * 1000;
 
 /**
  * How old a recorded total may be before its source is asked again.
@@ -27,8 +21,11 @@ const DAY_MS = 24 * 60 * 60 * 1000;
  * after a poll finds every total fresh and asks nobody. Set below the
  * effective weekly cadence it produces, so a wake that lands slightly early
  * still refreshes rather than deferring a whole extra interval.
+ *
+ * An elapsed duration, not calendar arithmetic, so `DAY_IN_MS` applies and
+ * no DST-aware helper is needed.
  */
-export const SOURCE_TOTAL_STALE_AFTER_MS = 6 * DAY_MS;
+export const SOURCE_TOTAL_STALE_AFTER_MS = 6 * DAY_IN_MS;
 
 export const SOURCE_TOTAL_POLL_OUTCOME = {
   /** The publisher stated a number and it is now the recorded total. */

--- a/apps/legal-atlas-runner/tsconfig.json
+++ b/apps/legal-atlas-runner/tsconfig.json
@@ -24,6 +24,7 @@
       "@stll/money": ["../../packages/money/src/index.ts"],
       "@stll/permissions": ["../../packages/permissions/src/index.ts"],
       "@stll/skills": ["../../packages/skills/src/index.ts"],
+      "@stll/time": ["../../packages/time/src/index.ts"],
       "@stll/transactional": ["../../packages/transactional/src/index.ts"],
       "@stll/transactional/*": ["../../packages/transactional/*"],
       "@/api/*": ["../api/src/*"]

--- a/bun.lock
+++ b/bun.lock
@@ -211,6 +211,7 @@
       "dependencies": {
         "@stll/api": "workspace:*",
         "@stll/legal-atlas": "workspace:*",
+        "@stll/time": "workspace:*",
         "better-result": "catalog:",
       },
       "devDependencies": {

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -1148,6 +1148,7 @@ export default defineConfig({
       files: [
         "apps/api/src/**/*.{ts,tsx}",
         "apps/web/src/**/*.{ts,tsx}",
+        "apps/legal-atlas-runner/src/**/*.{ts,tsx}",
         ".oxlint-plugins/__fixtures__/no-raw-date-parsing.fixture.ts",
       ],
       rules: {
@@ -1159,10 +1160,11 @@ export default defineConfig({
       // deliberately demonstrate the footguns (e.g. the dates.test.ts DST
       // assertions), so the date-parsing rule stays out of them. The day-length
       // literal's one home now lives in the `@stll/time` package, which this
-      // rule (scoped to apps/{api,web}/src) does not cover.
+      // rule (scoped to the app source trees above) does not cover.
       files: [
         "apps/api/src/**/*.{test,spec}.{ts,tsx}",
         "apps/web/src/**/*.{test,spec}.{ts,tsx}",
+        "apps/legal-atlas-runner/src/**/*.{test,spec}.{ts,tsx}",
         "apps/api/src/**/__tests__/**",
         "apps/api/src/tests/**",
       ],


### PR DESCRIPTION
Declares `@stll/time` in `apps/legal-atlas-runner` (workspace protocol + tsconfig path, one-line lockfile addition) and converts the runner's three raw day-length literals to its constants.

The literals survived because the `no-raw-date-parsing` rule's file scope hand-listed only two apps — so this also adds the runner to the rule's scope (with its test files exempted like the others') and rewrites the plugin's header comment to reference the config instead of restating the app list, so the comment cannot drift when scope changes again. The scope change was verified live with a probe file that correctly failed the rule and linted clean once renamed to a test.

No install-policy change is included: the release-age quarantine's internal-package exemption already exists (exact-name list plus a CI guard plus an hourly prune workflow for dated third-party exceptions). Two facts recorded for reviewers: the exclusion list must stay exact names because Bun accepts glob patterns there and silently ignores them (verified empirically), and `@silurus/ooxml` is third-party — its current entry is a dated temporary exception that the prune workflow removes on expiry, and it must not become permanent.

Proposed follow-up, not built here: derive the lint rule's file scope from the workspace listing so a new app cannot silently opt out.

Runner suite green (77 tests), workspace hygiene, lockfile-version and quarantine-exclude guards all pass.
