### PR TITLE
chore(ci): allow @stll/time in dependency review

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -97,6 +97,7 @@ jobs:
             pkg:npm/@stll/conditions,
             pkg:npm/@stll/docx-core,
             pkg:npm/@stll/errors,
+            pkg:npm/@stll/time,
             pkg:npm/@t3-oss/env-core,
             pkg:npm/@ai-sdk/azure,
             pkg:npm/@ai-sdk/openai,


### PR DESCRIPTION
GitHub's dependency snapshot reports Bun workspace entries with a null license even when the manifest declares an allowed one, which this file's own comment already documents; `packages/time/package.json` declares Apache-2.0. `@stll/time` has been a workspace dependency of the api and web apps for a while, and the runner declaring it surfaced the warning because the action only scans manifests a change touches. Adds it package-scoped, alongside the other workspace packages listed for the same reason.