### PR TITLE
fix: derive mirrored client limits from the api contract

### DIFF
--- a/apps/api/src/handlers/chat/chat-prompt.ts
+++ b/apps/api/src/handlers/chat/chat-prompt.ts
@@ -10,6 +10,7 @@ import * as cheerio from "cheerio";
 import { and, asc, count, eq, isNull } from "drizzle-orm";
 import * as v from "valibot";
 
+import { CHAT_THREAD_PLACEHOLDER_TITLE } from "@stll/api-contract";
 import type { SkillMetadata } from "@stll/skills";
 
 import type { SafeDb, SafeDbError } from "@/api/db/safe-db";
@@ -36,7 +37,6 @@ import type {
 } from "@/api/handlers/chat/chat-schema";
 import { estimateTextTokens } from "@/api/handlers/chat/compaction";
 import { buildMemoryPromptParts } from "@/api/handlers/chat/memory-context";
-import { CHAT_THREAD_PLACEHOLDER_TITLE } from "@/api/handlers/chat/thread-title";
 import { CHAT_CODE_MODE_SYSTEM_PROMPT } from "@/api/handlers/chat/tools/execute/chat-code-mode";
 import { CHAT_REFERENCE_HREF_PREFIXES } from "@/api/handlers/chat/types";
 import type { ChatMessage } from "@/api/handlers/chat/types";

--- a/apps/api/src/handlers/chat/thread-title.test.ts
+++ b/apps/api/src/handlers/chat/thread-title.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, test } from "bun:test";
 
+import { CHAT_THREAD_PLACEHOLDER_TITLE } from "@stll/api-contract";
+
 import {
   aiTitlingMayReplace,
-  CHAT_THREAD_PLACEHOLDER_TITLE,
   shouldRefreshEmptyThreadTitle,
 } from "./thread-title";
 

--- a/apps/api/src/handlers/chat/thread-title.ts
+++ b/apps/api/src/handlers/chat/thread-title.ts
@@ -1,7 +1,7 @@
+import { CHAT_THREAD_PLACEHOLDER_TITLE } from "@stll/api-contract";
+
 import { CHAT_TITLE_SOURCE } from "@/api/db/schema";
 import type { ChatTitleSource } from "@/api/db/schema";
-
-export const CHAT_THREAD_PLACEHOLDER_TITLE = "New chat";
 
 /**
  * Whether background AI title generation may replace a thread's current title.

--- a/apps/api/src/handlers/chat/update-thread-model.ts
+++ b/apps/api/src/handlers/chat/update-thread-model.ts
@@ -2,10 +2,11 @@ import { Result } from "better-result";
 import { and, eq, isNull } from "drizzle-orm";
 import { t } from "elysia";
 
+import { CHAT_THREAD_PLACEHOLDER_TITLE } from "@stll/api-contract";
+
 import { defaultDatabaseRetry } from "@/api/db/safe-db";
 import { chatThreads } from "@/api/db/schema";
 import { resolveChatScope } from "@/api/handlers/chat/chat-scope";
-import { CHAT_THREAD_PLACEHOLDER_TITLE } from "@/api/handlers/chat/thread-title";
 import { createSafeRootHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
 import { AUDIT_ACTION, AUDIT_RESOURCE_TYPE } from "@/api/lib/audit-log";

--- a/apps/api/src/handlers/chat/update-thread.ts
+++ b/apps/api/src/handlers/chat/update-thread.ts
@@ -2,10 +2,11 @@ import { Result } from "better-result";
 import { and, eq, isNull } from "drizzle-orm";
 import { t } from "elysia";
 
+import { CHAT_THREAD_PLACEHOLDER_TITLE } from "@stll/api-contract";
+
 import { defaultDatabaseRetry } from "@/api/db/safe-db";
 import { chatThreads } from "@/api/db/schema";
 import { resolveChatScope } from "@/api/handlers/chat/chat-scope";
-import { CHAT_THREAD_PLACEHOLDER_TITLE } from "@/api/handlers/chat/thread-title";
 import { createSafeRootHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
 import { AUDIT_ACTION, AUDIT_RESOURCE_TYPE } from "@/api/lib/audit-log";

--- a/apps/api/src/handlers/docx-suggestions/read.ts
+++ b/apps/api/src/handlers/docx-suggestions/read.ts
@@ -2,6 +2,8 @@ import { Result } from "better-result";
 import { and, asc, eq } from "drizzle-orm";
 import { t } from "elysia";
 
+import { DOCX_SUGGESTIONS_PAGE_SIZE_MAX } from "@stll/api-contract";
+
 import { docxSuggestions } from "@/api/db/schema";
 import { createSafeHandler } from "@/api/lib/api-handlers";
 import {
@@ -13,10 +15,7 @@ import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import { createCursorPage } from "@/api/lib/pagination";
 
 import { docxSuggestionCursor } from "./cursor";
-import {
-  DOCX_SUGGESTIONS_PAGE_SIZE_DEFAULT,
-  DOCX_SUGGESTIONS_PAGE_SIZE_MAX,
-} from "./schemas";
+import { DOCX_SUGGESTIONS_PAGE_SIZE_DEFAULT } from "./schemas";
 
 /**
  * List an entity's persisted suggestions (pending and resolved), oldest

--- a/apps/api/src/handlers/docx-suggestions/schemas.ts
+++ b/apps/api/src/handlers/docx-suggestions/schemas.ts
@@ -4,9 +4,10 @@ import { tSafeId } from "@/api/lib/custom-schema";
 
 /** Ceiling on one persist batch; mirrors the edit tool's operation cap. */
 export const MAX_DOCX_SUGGESTIONS_PER_BATCH = 200;
-/** Default and max page size for the entity suggestion list. */
+/** Default page size for the entity suggestion list. The max is
+ *  `DOCX_SUGGESTIONS_PAGE_SIZE_MAX` in @stll/api-contract, which the client
+ *  requests per hydration fetch. */
 export const DOCX_SUGGESTIONS_PAGE_SIZE_DEFAULT = 100;
-export const DOCX_SUGGESTIONS_PAGE_SIZE_MAX = 200;
 
 export const tDocxSuggestionSeverity = t.Union([
   t.Literal("low"),

--- a/apps/api/src/lib/limits.ts
+++ b/apps/api/src/lib/limits.ts
@@ -1,4 +1,8 @@
-import { CHAT_RICH_PART_LIMITS } from "@stll/api-contract";
+import {
+  AGENT_SKILLS_CHAT_METADATA_MAX,
+  CHAT_RICH_PART_LIMITS,
+  FLOW_RUN_INPUT_ENTITIES_MAX,
+} from "@stll/api-contract";
 import {
   CHAT_CONTEXT_FILE_MAX_BYTES,
   CHAT_CONTEXT_FILE_MAX_MEGABYTES,
@@ -82,7 +86,7 @@ export const LIMITS = {
   flowRunsPageSizeDefault: 50,
   flowRunsPageSizeMax: 100,
   /** Max input documents a single flow run may be launched against. */
-  flowRunInputEntitiesMax: 50,
+  flowRunInputEntitiesMax: FLOW_RUN_INPUT_ENTITIES_MAX,
   /** Per-org cap on the editable document-type taxonomy. The taxonomy is
    *  inherently bounded (a few dozen contract categories), so the list
    *  endpoint returns a plain ordered array rather than a paginated page. */
@@ -109,7 +113,7 @@ export const LIMITS = {
    *  (org-wide) plus the caller's private skills. Kept >=
    *  agentSkillsTeamPerOrganization + agentSkillsPerUser so the catalogue never
    *  truncates and silently hides a skill from the model. */
-  agentSkillsChatMetadataMax: 200,
+  agentSkillsChatMetadataMax: AGENT_SKILLS_CHAT_METADATA_MAX,
   /** Per-org cap on team-scoped skills, enforced on create/install. With
    *  agentSkillsPerUser it keeps team (org-wide) + the caller's private skills
    *  within agentSkillsChatMetadataMax (100 + 100 <= 200). Mirrors

--- a/apps/web/src/components/chat-editor-slash-items.ts
+++ b/apps/web/src/components/chat-editor-slash-items.ts
@@ -1,3 +1,5 @@
+import { AGENT_SKILLS_CHAT_METADATA_MAX } from "@stll/api-contract";
+
 import type {
   SlashItem,
   SlashSkillScope,
@@ -36,10 +38,6 @@ type SlashSkillPage = {
   builtIn: readonly SlashSkillRow[];
   installed: readonly SlashSkillRow[];
 };
-
-// Mirrors LIMITS.agentSkillsChatMetadataMax on the API side. The chat backend
-// only exposes this many enabled installed skills to `load-skill`.
-const CHAT_VISIBLE_INSTALLED_SKILL_LIMIT = 200;
 
 type BuildChatSlashItemsInput = {
   shortcuts: readonly SlashShortcutRow[];
@@ -156,7 +154,7 @@ const getChatVisibleInstalledSkillRows = (
   const chatVisibleEnabled = installedRows
     .filter((row) => row.enabled)
     .toSorted(compareChatInstalledSkillRows)
-    .slice(0, CHAT_VISIBLE_INSTALLED_SKILL_LIMIT);
+    .slice(0, AGENT_SKILLS_CHAT_METADATA_MAX);
   // Every chat-visible installed slug shadows the built-in entry of
   // the same name — including ones that carry a command. The
   // backend load-skill resolves the slug to the installed row, so

--- a/apps/web/src/lib/chat-thread-title.ts
+++ b/apps/web/src/lib/chat-thread-title.ts
@@ -1,12 +1,10 @@
-// New chat threads are persisted with an English sentinel title until
-// their first message generates a real one (see the backend
-// `CHAT_THREAD_PLACEHOLDER_TITLE` in
-// apps/api/src/handlers/chat/thread-title.ts). The UI must show the
-// localized `t("chat.newChat")` in its place rather than the raw "New
-// chat". This is the single mirror of that sentinel on the client.
-const CHAT_THREAD_PLACEHOLDER_TITLE = "New chat";
+import { CHAT_THREAD_PLACEHOLDER_TITLE } from "@stll/api-contract";
 
-/** True when `title` is the untitled-thread sentinel (or empty). */
+/**
+ * True when `title` is the untitled-thread sentinel (or empty). The UI shows
+ * the localized `t("chat.newChat")` in its place rather than the raw
+ * English sentinel the thread was persisted with.
+ */
 export const isPlaceholderThreadTitle = (
   title: string | null | undefined,
 ): boolean => !title || title === CHAT_THREAD_PLACEHOLDER_TITLE;

--- a/apps/web/src/lib/workspaces/queries/docx-suggestions.ts
+++ b/apps/web/src/lib/workspaces/queries/docx-suggestions.ts
@@ -1,13 +1,14 @@
 import { queryOptions } from "@tanstack/react-query";
 
+import { DOCX_SUGGESTIONS_PAGE_SIZE_MAX } from "@stll/api-contract";
+
 import { getAnalytics } from "@/lib/analytics/provider";
 import { api } from "@/lib/api";
 import { unwrapEden } from "@/lib/errors/api";
 
 import { entitiesKeys } from "./entities";
 
-// Server page-size ceiling; each hydration fetch requests a full page.
-const DOCX_SUGGESTIONS_HYDRATION_LIMIT = 200;
+// Each hydration fetch requests a full page.
 // Page ALL pending rows up to this safety cap: pending drives the actionable
 // panel and must never be crowded out of hydration by resolved history. Well
 // past any realistic pending set for one entity; a capped pending hydration is
@@ -46,7 +47,7 @@ export const docxSuggestionsOptions = ({
         max: number,
       ) => {
         const firstPage = await endpoint.get({
-          query: { status, limit: DOCX_SUGGESTIONS_HYDRATION_LIMIT },
+          query: { status, limit: DOCX_SUGGESTIONS_PAGE_SIZE_MAX },
           fetch: { signal },
         });
         const firstData = unwrapEden(firstPage);
@@ -59,7 +60,7 @@ export const docxSuggestionsOptions = ({
           const page = await endpoint.get({
             query: {
               status,
-              limit: DOCX_SUGGESTIONS_HYDRATION_LIMIT,
+              limit: DOCX_SUGGESTIONS_PAGE_SIZE_MAX,
               cursor: nextCursor,
             },
             fetch: { signal },

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/flows/run-launcher.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/flows/run-launcher.tsx
@@ -4,6 +4,7 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { PlayIcon } from "lucide-react";
 import { useFormatter, useTranslations } from "use-intl";
 
+import { FLOW_RUN_INPUT_ENTITIES_MAX } from "@stll/api-contract";
 import { Button } from "@stll/ui/components/button";
 import { Checkbox } from "@stll/ui/components/checkbox";
 import { Input } from "@stll/ui/components/input";
@@ -31,12 +32,6 @@ type RunLauncherProps = {
   organizationId: string;
   onStarted: (runId: string) => void;
 };
-
-// Mirrors `flowRunInputEntitiesMax` in apps/api/src/lib/limits.ts. apps/api
-// types are not importable from apps/web, so this is kept as a local
-// constant; the backend rejects a run start past this count regardless of
-// what the client enforces.
-const FLOW_RUN_INPUT_ENTITIES_MAX = 50;
 
 export const RunLauncher = ({
   workspaceId,

--- a/packages/api-contract/src/chat.ts
+++ b/packages/api-contract/src/chat.ts
@@ -2,6 +2,13 @@ import type { ChatSendMode } from "@stll/anonymize-chat";
 
 import type { SafeId } from "./safe-id";
 
+/**
+ * Title a thread is persisted with until its first message generates a real
+ * one. Deliberately untranslated: it is a sentinel both sides compare
+ * against, and the UI substitutes a localized label when it matches.
+ */
+export const CHAT_THREAD_PLACEHOLDER_TITLE = "New chat";
+
 export const CHAT_TOOL_SCOPE = {
   suggestTemplateFields: "suggest-template-fields",
 } as const;

--- a/packages/api-contract/src/index.ts
+++ b/packages/api-contract/src/index.ts
@@ -24,7 +24,12 @@ export {
   isBusinessRegistrySlug,
 } from "./business-registries";
 export type { BusinessRegistrySlug } from "./business-registries";
-export { CHAT_RUN_MODE, CHAT_TOOL_SCOPE, CHAT_TURN_INTENT } from "./chat";
+export {
+  CHAT_RUN_MODE,
+  CHAT_THREAD_PLACEHOLDER_TITLE,
+  CHAT_TOOL_SCOPE,
+  CHAT_TURN_INTENT,
+} from "./chat";
 export type {
   ChatContinuation,
   ChatInterruptResolution,
@@ -155,6 +160,11 @@ export type {
   FlowTriggerType,
   TerminalFlowRunStatus,
 } from "./flow-status";
+export {
+  AGENT_SKILLS_CHAT_METADATA_MAX,
+  DOCX_SUGGESTIONS_PAGE_SIZE_MAX,
+  FLOW_RUN_INPUT_ENTITIES_MAX,
+} from "./limits";
 export { GLOBAL_SEARCH_RESULT_TYPES } from "./search";
 export type { GlobalSearchResultType } from "./search";
 export {

--- a/packages/api-contract/src/limits.ts
+++ b/packages/api-contract/src/limits.ts
@@ -1,0 +1,22 @@
+/**
+ * Bounds the server enforces and the client also has to know.
+ *
+ * Each value here was a literal copied into apps/web with a comment naming
+ * the API-side constant it tracked. A comment is not a check: a raised or
+ * lowered server bound leaves the copy compiling and silently wrong, so the
+ * client under- or over-fetches, or disables a control at the wrong count.
+ * Both sides import from here instead; apps/api re-exports them through its
+ * own `LIMITS` so server call sites keep one lookup table.
+ */
+
+/** Max input documents a single flow run may be launched against. */
+export const FLOW_RUN_INPUT_ENTITIES_MAX = 50;
+
+/**
+ * Enabled installed skills the chat backend exposes to `load-skill`. The
+ * composer's slash menu must not offer a skill the model cannot load.
+ */
+export const AGENT_SKILLS_CHAT_METADATA_MAX = 200;
+
+/** Max page size for one entity's DOCX suggestion list. */
+export const DOCX_SUGGESTIONS_PAGE_SIZE_MAX = 200;


### PR DESCRIPTION
apps/web carried hand-mirrored copies of backend limits, bound only by comments ("Mirrors `flowRunInputEntitiesMax` in apps/api/src/lib/limits.ts"). The comment's own justification was stale: both apps already depend on `@stll/api-contract`, which is the established home for cross-package constants.

Four mirrors converged on the contract (new `packages/api-contract/src/limits.ts`, plus the chat placeholder-title sentinel in `chat.ts`):
- `FLOW_RUN_INPUT_ENTITIES_MAX` (50) — run launcher vs `LIMITS.flowRunInputEntitiesMax`
- `AGENT_SKILLS_CHAT_METADATA_MAX` (200) — chat slash items vs `LIMITS.agentSkillsChatMetadataMax`
- `DOCX_SUGGESTIONS_PAGE_SIZE_MAX` (200) — hydration limit vs the docx-suggestions schema bound
- `CHAT_THREAD_PLACEHOLDER_TITLE` ("New chat") — thread-title helper vs the backend sentinel

`LIMITS` keeps its entries but sources the values from the contract, so server call sites keep one lookup table.

Deliberately left alone, listed for the record: ~12 client page-size constants that equal backend defaults without claiming to mirror them (a client page size is legitimately its own decision; converging them is the "move LIMITS into the contract" refactor), the picker limits whose correctness rests on an org-cap-equals-page-size relationship, a loosely-coupled staleness threshold, and three duplicated-logic (not constant) mirrors that need shared modules.

Follow-up worth considering: a ratchet counting "mirrors the backend"-style comments near const declarations in apps/web, which shrinks the remaining sites over time; or the structural endpoint, exporting `LIMITS` itself from the contract.