### PR TITLE
chore: isolate dependabot update groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -146,6 +146,8 @@ updates:
     cooldown:
       default-days: 5
     open-pull-requests-limit: 10
+    # Group related updates so they validate together; unmatched updates receive
+    # standalone PRs.
     groups:
       tanstack:
         patterns:
@@ -156,13 +158,19 @@ updates:
         patterns:
           - "astro"
           - "@astrojs/*"
+      expo:
+        patterns:
+          - "expo"
+          - "expo-*"
+          - "@expo/*"
       tailwind:
         patterns:
           - "tailwindcss"
           - "@tailwindcss/*"
       vite:
         patterns:
-          - "vite*"
+          - "vite"
+          - "@vitejs/*"
       react:
         patterns:
           - "react"
@@ -176,10 +184,11 @@ updates:
           - "oxfmt"
       ai:
         patterns:
-          - "ai*"
+          - "ai"
+          - "@ai-sdk/*"
       convex:
         patterns:
-          - "convex*"
+          - "convex"
           - "@convex-dev/*"
       posthog:
         patterns:
@@ -208,12 +217,6 @@ updates:
         patterns:
           - "streamdown*"
           - "@streamdown/*"
-      ultracite:
-        patterns:
-          - "ultracite"
-      misc:
-        patterns:
-          - "*"
     versioning-strategy: increase
     commit-message:
       prefix: "chore"


### PR DESCRIPTION
## Summary

- remove the catch-all Bun dependency group so unrelated updates receive standalone PRs
- keep related dependency families grouped across patch, minor, and major releases
- add an Expo family and narrow broad Vite, AI, and Convex patterns

Local validation was skipped; CI is the validation source.

CC on behalf of jan-kubica

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated dependency update grouping.
  * Added grouped updates for Expo dependencies.
  * Refined dependency matching for Vite, AI, and Convex packages.
  * Removed outdated and catch-all dependency groups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->