### PR TITLE
feat(case-law): sk-courts listing reconciliation capability

### DIFF
--- a/apps/api/src/handlers/case-law/ingestion/adapters/sk-courts-reconciliation.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/sk-courts-reconciliation.test.ts
@@ -1,0 +1,469 @@
+/**
+ * The sk-courts listing reconciliation capability.
+ *
+ * Four things here are silent when wrong and cheap to pin. Slice arithmetic
+ * has to round-trip and order lexicographically, because the ledger orders
+ * `(source, slice)` rows by byte comparison and a walk that steps wrong looks
+ * like a slow loop rather than a broken one. The listing request has to name
+ * the slice's own date and translate the contract's zero-based page onto this
+ * endpoint's one-based one, or a walk reads a different day than the row it
+ * writes. The identity a listed item maps to has to be the identity the built
+ * decision stores, or the walk hunts rows the crawl already wrote. And
+ * `detail-unavailable` has to stay distinct from a decision built out of the
+ * listing alone: this source states `documentUrl` only in the per-decision
+ * record, and the document walk finds its work by that column, so writing the
+ * listing half alone makes the identity held and the text unreachable at once.
+ */
+
+import { afterEach, describe, expect, setSystemTime, test } from "bun:test";
+
+import type { SkApiItem } from "@/api/handlers/case-law/ingestion/adapters/sk-courts";
+import {
+  buildSkCourtsDecision,
+  SK_COURTS_FIRST_SLICE,
+  SK_COURTS_LANGUAGE,
+  skCourtsAdapter,
+  skCourtsListingIdentity,
+} from "@/api/handlers/case-law/ingestion/adapters/sk-courts";
+import { tipWindowSlices } from "@/api/handlers/case-law/ingestion/reconciliation-plan";
+import { toUtcDateString } from "@/api/lib/dates";
+import { AdapterFetchError } from "@/api/lib/errors/tagged-errors";
+import {
+  listingIdentityKey,
+  parseListingIdentityKey,
+} from "@/api/lib/legal-search/ingestion-types";
+import { asFetchMock } from "@/api/tests/helpers/test-tool-set";
+
+const { reconciliation } = skCourtsAdapter;
+if (reconciliation === undefined) {
+  throw new Error("sk-courts must declare a reconciliation capability");
+}
+
+const LIST_PATH = "/v1/rozhodnutie";
+const SLICE = "2026-06-10";
+
+/**
+ * Items shaped the way this publisher answers: its compound `<uuid>:<uuid>`
+ * guid, the court's own docket spelling and its `DD.MM.YYYY` dates. A
+ * shortened stand-in would let an identity or date rule pass here and fail on
+ * live traffic.
+ */
+const GALANTA_ITEM = {
+  guid: "00e46f1f-38a5-4457-86bb-88c8440bae47:5ece2b40-ef98-4f3e-acba-d7071425f39d",
+  formaRozhodnutia: "Uznesenie bez odôvodnenia",
+  povaha: ["Prvostupňové nenapadnuté opravnými prostriedkami"],
+  sud: { registreGuid: "sud_112", nazov: "Okresný súd Galanta" },
+  sudca: { registreGuid: "sudca_2151", meno: "JUDr. Andrea Sátorová" },
+  identifikacneCislo: "2326201348",
+  spisovaZnacka: "32Ps/10/2026",
+  datumVydania: "10.06.2026",
+} satisfies SkApiItem;
+
+const BARDEJOV_ITEM = {
+  guid: "01df3d2d-9876-4506-89f0-c3ef23ce9d85:a9584606-4e65-4fa7-9c21-bea2d4a71ed3",
+  formaRozhodnutia: "Rozsudok",
+  povaha: ["Prvostupňové nenapadnuté opravnými prostriedkami"],
+  sud: { registreGuid: "sud_157", nazov: "Okresný súd Bardejov" },
+  sudca: { registreGuid: "sudca_1720", meno: "Mgr. Ivana Hanuščaková" },
+  identifikacneCislo: "8225201991",
+  spisovaZnacka: "19Pc/3/2025",
+  datumVydania: "10.06.2026",
+} satisfies SkApiItem;
+
+/** The per-decision record, exactly as the publisher answers it. */
+const GALANTA_DETAIL = {
+  ...GALANTA_ITEM,
+  ecli: "ECLI:SK:OSGA:2026:2326201348.1",
+  oblast: ["Rodinné právo"],
+  podOblast: ["Opatrovníctvo"],
+  odkazovanePredpisy: [
+    {
+      nazov: "/SK/ZZ/2015/160",
+      url: "https://www.slov-lex.sk/pravne-predpisy/SK/ZZ/2015/160",
+    },
+  ],
+  dokument: {
+    name: "Uznesenie_bez_odôvodnenia_32Ps-10-2026.pdf",
+    fileExtension: "PDF",
+    size: 55_892,
+    url: "https://obcan.justice.sk/content/public/item/5ece2b40-ef98-4f3e-acba-d7071425f39d",
+  },
+  updateDate: "12.06.2026",
+} as const;
+
+type MockResponse = { body: string; status?: number };
+
+const originalFetch = globalThis.fetch;
+const requestedUrls: string[] = [];
+
+/** The list endpoint and the per-decision record share a path prefix. */
+const isDetailRequest = (url: string): boolean =>
+  new URL(url).pathname.split(LIST_PATH).at(-1) !== "";
+
+const mockJustice = (routes: {
+  list?: MockResponse;
+  detail?: MockResponse;
+}): void => {
+  globalThis.fetch = asFetchMock(
+    async (input: string | URL | Request): Promise<Response> => {
+      const url = (() => {
+        if (typeof input === "string") {
+          return input;
+        }
+        if (input instanceof URL) {
+          return input.href;
+        }
+        return input.url;
+      })();
+      requestedUrls.push(url);
+
+      const route = isDetailRequest(url) ? routes.detail : routes.list;
+      if (route === undefined) {
+        return await Promise.resolve(
+          new Response("Not found", { status: 404 }),
+        );
+      }
+      return await Promise.resolve(
+        new Response(route.body, {
+          status: route.status ?? 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+    },
+  );
+};
+
+const listBody = (items: readonly unknown[], numFound: number): string =>
+  JSON.stringify({ rozhodnutieList: items, numFound, page: 0, size: 1000 });
+
+/**
+ * bun-types declares `.rejects.toBeInstanceOf` as void, so awaiting it trips
+ * type-aware lint; capture the rejection explicitly instead.
+ */
+const sliceRejection = async (slice: string): Promise<unknown> =>
+  await reconciliation.listSlicePage({ slice, page: 0 }).then(
+    () => null,
+    (error: unknown) => error,
+  );
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  requestedUrls.length = 0;
+  setSystemTime();
+});
+
+describe("sk-courts slice arithmetic", () => {
+  test("a step forward and back returns the same slice", () => {
+    for (const slice of [
+      SK_COURTS_FIRST_SLICE,
+      "1999-12-31",
+      "2024-02-28",
+      "2024-02-29",
+      "2024-12-31",
+      SLICE,
+    ]) {
+      const next = reconciliation.nextSlice(slice);
+      expect(next).not.toBeNull();
+      expect(next === null ? null : reconciliation.previousSlice(next)).toBe(
+        slice,
+      );
+    }
+  });
+
+  test("steps across month, year and leap-day boundaries", () => {
+    expect(reconciliation.nextSlice("2024-02-28")).toBe("2024-02-29");
+    expect(reconciliation.nextSlice("2024-02-29")).toBe("2024-03-01");
+    expect(reconciliation.previousSlice("2024-03-01")).toBe("2024-02-29");
+    expect(reconciliation.nextSlice("2023-02-28")).toBe("2023-03-01");
+    expect(reconciliation.nextSlice("1999-12-31")).toBe("2000-01-01");
+    expect(reconciliation.previousSlice("2000-01-01")).toBe("1999-12-31");
+  });
+
+  test("the walk order is the lexicographic order", () => {
+    let slice: string | null = "2013-06-25";
+    const walked: string[] = [];
+    while (slice !== null && walked.length < 10) {
+      walked.push(slice);
+      slice = reconciliation.nextSlice(slice);
+    }
+    expect(walked).toEqual([...walked].toSorted());
+    expect(walked.at(0)).toBe("2013-06-25");
+    expect(walked.at(-1)).toBe("2013-07-04");
+  });
+
+  test("the tip window is a fixed run of slices, newest first", () => {
+    const now = new Date("2026-08-11T09:30:00.000Z");
+    const slices = tipWindowSlices(reconciliation, now);
+
+    expect(slices).toHaveLength(reconciliation.tipWindowDays);
+    expect(slices.at(0)).toBe("2026-08-11");
+    // The publisher fills a decision date in for months after it happens, so
+    // the window has to still be over the date once it has settled.
+    expect(slices.at(-1)).toBe("2026-04-14");
+    expect(slices).toEqual([...slices].toSorted().toReversed());
+  });
+
+  test("the walk stops at the publisher's first date and at the tip", () => {
+    expect(reconciliation.previousSlice(SK_COURTS_FIRST_SLICE)).toBeNull();
+    expect(reconciliation.nextSlice("2999-12-30")).toBeNull();
+    expect(reconciliation.nextSlice(SK_COURTS_FIRST_SLICE)).toBe("1965-07-12");
+    expect(reconciliation.sliceOf(new Date("2026-06-10T23:59:59.999Z"))).toBe(
+      SLICE,
+    );
+    expect(reconciliation.sliceOf(new Date())).toBe(
+      toUtcDateString(new Date()),
+    );
+  });
+
+  test("a slice that is not a UTC calendar day is refused", () => {
+    expect(() => reconciliation.nextSlice("2026-06")).toThrow();
+    expect(() => reconciliation.previousSlice("2026-02-30")).toThrow();
+    expect(() => reconciliation.nextSlice("10.06.2026")).toThrow();
+  });
+});
+
+describe("sk-courts listing identity", () => {
+  test("keys a listed decision on the publisher's own guid", () => {
+    expect(skCourtsListingIdentity(GALANTA_ITEM)).toEqual({
+      type: "document",
+      sourceDocumentId: GALANTA_ITEM.guid,
+    });
+    expect(skCourtsListingIdentity(BARDEJOV_ITEM)).toEqual({
+      type: "document",
+      sourceDocumentId: BARDEJOV_ITEM.guid,
+    });
+  });
+
+  test("falls back to the docket and the language without a guid", () => {
+    const { guid: _guid, ...withoutGuid } = GALANTA_ITEM;
+
+    expect(skCourtsListingIdentity(withoutGuid)).toEqual({
+      type: "case-number",
+      caseNumber: "32Ps/10/2026",
+      language: SK_COURTS_LANGUAGE,
+    });
+  });
+
+  test("a guid too long for the identity column falls back to the docket", () => {
+    // The pipeline refuses to store an id past the column's limit, so keying
+    // the listing on one would hunt a row nothing can ever write.
+    expect(
+      skCourtsListingIdentity({ ...GALANTA_ITEM, guid: "x".repeat(257) }),
+    ).toEqual({
+      type: "case-number",
+      caseNumber: "32Ps/10/2026",
+      language: SK_COURTS_LANGUAGE,
+    });
+  });
+
+  test("an item the crawl would drop is unidentifiable", () => {
+    // The crawl keeps neither of these, so a slice that counted them would
+    // stay short forever.
+    expect(
+      skCourtsListingIdentity({ ...GALANTA_ITEM, spisovaZnacka: "" }),
+    ).toEqual({ type: "unidentifiable" });
+    expect(skCourtsListingIdentity({ ...GALANTA_ITEM, sud: null })).toEqual({
+      type: "unidentifiable",
+    });
+    // A payload no current shape recognises: the crawl drops it at the same
+    // validator rather than storing a row from it.
+    expect(skCourtsListingIdentity({ guid: 42 })).toEqual({
+      type: "unidentifiable",
+    });
+    expect(skCourtsListingIdentity(null)).toEqual({ type: "unidentifiable" });
+  });
+
+  test("every keyable identity round-trips through its stored key", () => {
+    const { guid: _guid, ...withoutGuid } = GALANTA_ITEM;
+    for (const identity of [
+      skCourtsListingIdentity(GALANTA_ITEM),
+      skCourtsListingIdentity(withoutGuid),
+    ]) {
+      const key = listingIdentityKey(identity);
+      expect(key).not.toBeNull();
+      // The compound guid carries a colon, which is also this key's own
+      // separator; the round trip is what proves it survives that.
+      expect(key === null ? null : parseListingIdentityKey(key)).toEqual(
+        identity,
+      );
+    }
+  });
+});
+
+describe("sk-courts listSlicePage", () => {
+  test("asks the publisher for exactly the slice's decision date", async () => {
+    mockJustice({ list: { body: listBody([GALANTA_ITEM], 2559) } });
+
+    await reconciliation.listSlicePage({ slice: SLICE, page: 2 });
+
+    const requested = new URL(requestedUrls.at(0) ?? "");
+    expect(requested.searchParams.get("vydaniaOd")).toBe(SLICE);
+    expect(requested.searchParams.get("vydaniaDo")).toBe(SLICE);
+    // This endpoint numbers pages from one; the contract numbers them from
+    // zero, and asking for page 0 here would re-read the first page.
+    expect(requested.searchParams.get("page")).toBe("3");
+    expect(requested.searchParams.get("size")).toBe("1000");
+    // A guid is unique and never reassigned, so a decision indexed mid-walk
+    // pushes later items back rather than displacing one onto a page already
+    // read.
+    expect(requested.searchParams.get("sortProperty")).toBe("guid");
+    expect(requested.searchParams.get("sortDirection")).toBe("ASC");
+  });
+
+  test("maps a filtered page to identity-tagged, replayable items", async () => {
+    mockJustice({
+      list: { body: listBody([GALANTA_ITEM, BARDEJOV_ITEM], 2559) },
+    });
+
+    const page = await reconciliation.listSlicePage({ slice: SLICE, page: 0 });
+
+    // 2,559 at 1000 a page is three pages; the endpoint states no page count
+    // of its own, only the count of what the filter matched.
+    expect(page.totalPages).toBe(3);
+    expect(page.items.map(({ identity }) => identity)).toEqual([
+      { type: "document", sourceDocumentId: GALANTA_ITEM.guid },
+      { type: "document", sourceDocumentId: BARDEJOV_ITEM.guid },
+    ]);
+    // The loop parks a payload as JSON and replays it days later, so what a
+    // page hands back has to survive that round trip unchanged.
+    const serialized = JSON.stringify(page.items.map(({ payload }) => payload));
+    expect(JSON.parse(serialized)).toEqual([GALANTA_ITEM, BARDEJOV_ITEM]);
+  });
+
+  test("a date the publisher lists nothing for reports no pages", async () => {
+    mockJustice({ list: { body: listBody([], 0) } });
+
+    const page = await reconciliation.listSlicePage({
+      slice: "1965-07-12",
+      page: 0,
+    });
+
+    expect(page.items).toEqual([]);
+    expect(page.totalPages).toBe(0);
+  });
+
+  test("one malformed item does not make the whole date unwalkable", async () => {
+    mockJustice({
+      list: { body: listBody([GALANTA_ITEM, { guid: 42 }], 2) },
+    });
+
+    const page = await reconciliation.listSlicePage({ slice: SLICE, page: 0 });
+
+    // Counted as listed but unkeyable, exactly as the crawl drops it. Refusing
+    // the page instead would leave the date permanently unreconcilable.
+    expect(page.items.map(({ identity }) => identity)).toEqual([
+      { type: "document", sourceDocumentId: GALANTA_ITEM.guid },
+      { type: "unidentifiable" },
+    ]);
+  });
+
+  test("a payload without a count is refused, not read as an empty date", async () => {
+    mockJustice({ list: { body: JSON.stringify({ rozhodnutieList: [] }) } });
+
+    expect(await sliceRejection(SLICE)).toBeInstanceOf(AdapterFetchError);
+  });
+
+  test("an upstream failure is raised rather than reported as an empty date", async () => {
+    // A publisher this timeout-prone answers 5xx under load, and a slice
+    // recorded empty from one is a slice settled at zero forever.
+    mockJustice({ list: { body: "Service Unavailable", status: 503 } });
+
+    expect(await sliceRejection(SLICE)).toBeInstanceOf(AdapterFetchError);
+  });
+});
+
+describe("sk-courts buildDecision", () => {
+  test("builds through the adapter's own detail parse path", async () => {
+    mockJustice({ detail: { body: JSON.stringify(GALANTA_DETAIL) } });
+
+    const built = await reconciliation.buildDecision(GALANTA_ITEM);
+
+    expect(built.type).toBe("built");
+    if (built.type !== "built") {
+      return;
+    }
+    expect(built.decision).toMatchObject({
+      caseNumber: "32Ps/10/2026",
+      court: "Okresný súd Galanta",
+      country: "SVK",
+      language: SK_COURTS_LANGUAGE,
+      decisionDate: "2026-06-10",
+      decisionType: "Uznesenie bez odôvodnenia",
+      ecli: "ECLI:SK:OSGA:2026:2326201348.1",
+      sourceDocumentId: GALANTA_ITEM.guid,
+      // Only the per-decision record states this, and the document walk
+      // selects the rows it still owes text by exactly this column.
+      documentUrl: GALANTA_DETAIL.dokument.url,
+    });
+    // The one identity rule: what the walk keyed this item on is what the
+    // decision it builds actually stores.
+    expect(listingIdentityKey(skCourtsListingIdentity(GALANTA_ITEM))).toBe(
+      listingIdentityKey({
+        type: "document",
+        sourceDocumentId: built.decision.sourceDocumentId ?? "",
+      }),
+    );
+  });
+
+  test("a record nothing came back for is unavailable, never built empty", async () => {
+    mockJustice({ detail: { body: "Not found", status: 404 } });
+
+    // The listing item alone carries a docket and a court, so the build path
+    // could have produced a decision from it. Doing so would make the identity
+    // held with no document URL for the walk that fills its text to find.
+    expect(await reconciliation.buildDecision(GALANTA_ITEM)).toEqual({
+      type: "detail-unavailable",
+    });
+  });
+
+  test("a record that is not a decision payload is unavailable", async () => {
+    mockJustice({ detail: { body: JSON.stringify({ ecli: 42 }) } });
+
+    expect(await reconciliation.buildDecision(BARDEJOV_ITEM)).toEqual({
+      type: "detail-unavailable",
+    });
+  });
+
+  test("the crawl keeps the row the reconciliation refuses", async () => {
+    mockJustice({ detail: { body: "Not found", status: 404 } });
+
+    const built = await buildSkCourtsDecision(GALANTA_ITEM);
+
+    // Same call, opposite disposition: the crawl's cursor moves past this item
+    // either way, so it stores the listing observation, while the loop filling
+    // gaps must not. The decision has to survive the shared path for that.
+    expect(built.type).toBe("detail-unavailable");
+    if (built.type !== "detail-unavailable") {
+      return;
+    }
+    expect(built.decision).toMatchObject({
+      caseNumber: "32Ps/10/2026",
+      sourceDocumentId: GALANTA_ITEM.guid,
+    });
+    expect(built.decision.documentUrl).toBeUndefined();
+  });
+
+  test("a payload no current shape recognises is unkeyable", async () => {
+    mockJustice({});
+
+    expect(await reconciliation.buildDecision(GALANTA_ITEM.guid)).toEqual({
+      type: "unkeyable",
+    });
+    expect(await reconciliation.buildDecision(null)).toEqual({
+      type: "unkeyable",
+    });
+    expect(await reconciliation.buildDecision({ guid: 42 })).toEqual({
+      type: "unkeyable",
+    });
+    // A record the validator accepts but the adapter refuses to key: no docket
+    // to store it under.
+    expect(
+      await reconciliation.buildDecision({
+        ...GALANTA_ITEM,
+        spisovaZnacka: null,
+      }),
+    ).toEqual({ type: "unkeyable" });
+    // Nothing was asked of the publisher for any of these.
+    expect(requestedUrls).toEqual([]);
+  });
+});

--- a/apps/api/src/handlers/case-law/ingestion/adapters/sk-courts-reconciliation.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/sk-courts-reconciliation.test.ts
@@ -197,9 +197,10 @@ describe("sk-courts slice arithmetic", () => {
 
     expect(slices).toHaveLength(reconciliation.tipWindowDays);
     expect(slices.at(0)).toBe("2026-08-11");
-    // The publisher fills a decision date in for months after it happens, so
-    // the window has to still be over the date once it has settled.
-    expect(slices.at(-1)).toBe("2026-04-14");
+    // The publisher fills a decision date in for months after it happens, and
+    // a date recorded fully collected is settled for good, so the window has
+    // to reach past the point where the date stops growing.
+    expect(slices.at(-1)).toBe("2026-03-25");
     expect(slices).toEqual([...slices].toSorted().toReversed());
   });
 
@@ -361,6 +362,48 @@ describe("sk-courts listSlicePage", () => {
     mockJustice({ list: { body: JSON.stringify({ rozhodnutieList: [] }) } });
 
     expect(await sliceRejection(SLICE)).toBeInstanceOf(AdapterFetchError);
+  });
+
+  test("a count with no item list is refused, not read as an empty date", async () => {
+    // The single worst envelope to accept: the date would be recorded holding
+    // nothing, and a date recorded empty is settled and never revisited.
+    mockJustice({ list: { body: JSON.stringify({ numFound: 800 }) } });
+    const absent = await sliceRejection(SLICE);
+
+    mockJustice({
+      list: { body: JSON.stringify({ numFound: 800, rozhodnutieList: null }) },
+    });
+    const nulled = await sliceRejection(SLICE);
+
+    expect(absent).toBeInstanceOf(AdapterFetchError);
+    expect(nulled).toBeInstanceOf(AdapterFetchError);
+  });
+
+  test("a page the count says is populated cannot come back empty", async () => {
+    // 2,559 at 1000 a page means page 1 holds items. Answering it with none is
+    // the publisher contradicting its own count, and taking it at face value
+    // would write that page's decisions out of the date's ledger row.
+    mockJustice({ list: { body: listBody([], 2559) } });
+
+    const rejection = await reconciliation
+      .listSlicePage({ slice: SLICE, page: 1 })
+      .then(
+        () => null,
+        (error: unknown) => error,
+      );
+
+    expect(rejection).toBeInstanceOf(AdapterFetchError);
+  });
+
+  test("the page past the last one may be empty", async () => {
+    // The same shape is legitimate once the offset is past the count, which is
+    // where the walk stops; refusing it would make every slice unwalkable.
+    mockJustice({ list: { body: listBody([], 2559) } });
+
+    const page = await reconciliation.listSlicePage({ slice: SLICE, page: 3 });
+
+    expect(page.items).toEqual([]);
+    expect(page.totalPages).toBe(3);
   });
 
   test("an upstream failure is raised rather than reported as an empty date", async () => {

--- a/apps/api/src/handlers/case-law/ingestion/adapters/sk-courts.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/sk-courts.ts
@@ -1,3 +1,5 @@
+import { panic } from "better-result";
+
 import {
   ADAPTER_KEYS,
   ADAPTER_TIMEOUT,
@@ -6,10 +8,18 @@ import {
 import {
   defineSourceAdapter,
   EMPTY_AST,
+  isPersistableSourceDocumentId,
 } from "@/api/handlers/case-law/ingestion/adapter";
-import type { IngestionResult } from "@/api/handlers/case-law/ingestion/adapter";
+import type {
+  IngestionResult,
+  ListingIdentity,
+  ReconciliationBuildOutcome,
+  ReconciliationSlicePage,
+  ReconciliationSlicePageOptions,
+} from "@/api/handlers/case-law/ingestion/adapter";
 import { createPagePaginatedFetch } from "@/api/handlers/case-law/ingestion/adapters/pagination";
 import {
+  INGESTION_USER_AGENT,
   hashContent,
   isNullishArrayOf,
   isNullishNumber,
@@ -18,6 +28,8 @@ import {
   parseCeDate,
   toOptionalValue,
 } from "@/api/handlers/case-law/ingestion/adapters/utils";
+import { addUtcDays, isoCalendarDay, toUtcDateString } from "@/api/lib/dates";
+import { AdapterFetchError } from "@/api/lib/errors/tagged-errors";
 import { fetchWithTimeout } from "@/api/lib/fetch";
 import { restrictSkCourtDocumentUrl } from "@/api/lib/legal-search/sk-court-document-url";
 import { logger } from "@/api/lib/observability/logger";
@@ -34,6 +46,10 @@ import { isRecord } from "@/api/lib/type-guards";
  * ECLI, document URL, and referenced legislation.
  *
  * Cursor format: item offset as string (e.g. "offset:100").
+ *
+ * The same list endpoint is addressable by a decision-date range, which is
+ * what makes this source reconcilable: one date can be listed on its own,
+ * without the crawl cursor ever reaching it. See `reconciliation` below.
  */
 
 const BASE_URL =
@@ -41,6 +57,7 @@ const BASE_URL =
 const PAGE_SIZE = 100;
 const LEGACY_PAGE_SIZE = 100;
 const ITEM_CONCURRENCY = 10;
+const LIST_TIMEOUT_MS = 60_000;
 /**
  * How far back the newest-first walk reaches before returning to the head.
  * Comfortably more than this source publishes between cycles, so a slow or
@@ -48,6 +65,9 @@ const ITEM_CONCURRENCY = 10;
  * decisions in the overlap cost a list read and are then deduplicated.
  */
 const LIVE_WINDOW_ITEMS = 5000;
+
+/** The only language this source publishes; half of the fallback identity. */
+export const SK_COURTS_LANGUAGE = "sk";
 
 const arrayOrEmpty = <T>(value: T[] | null | undefined): T[] => {
   if (value === undefined || value === null) {
@@ -66,7 +86,7 @@ type SkSudca = {
   meno?: string | null;
 };
 
-type SkApiItem = {
+export type SkApiItem = {
   guid?: string | null;
   spisovaZnacka?: string | null;
   identifikacneCislo?: string | null;
@@ -230,21 +250,117 @@ const sourceUrlForDecision = (
   documentUrl: string | null | undefined,
 ): string => documentUrl ?? `${BASE_URL}/${encodeURIComponent(guid)}`;
 
-const parseItemWithDetail = async (
-  raw: unknown,
+/**
+ * The publisher's own document id for a listing item, or undefined where the
+ * item states none this store can hold.
+ *
+ * Stated here rather than at each use so the crawl and the reconciliation
+ * cannot key a decision differently. The bound is not decoration: an id past
+ * the column's limit is refused by the pipeline's own normalization, so an
+ * item carrying one is storable only under the docket, and keying it on the
+ * id would hunt a row nothing can ever write.
+ */
+const skCourtsSourceDocumentId = (
+  guid: string | null | undefined,
+): string | undefined => {
+  const value = toOptionalValue(guid);
+  return value !== undefined && isPersistableSourceDocumentId(value)
+    ? value
+    : undefined;
+};
+
+/** The two fields this adapter refuses to store a decision without. */
+type SkCourtsIdentityFields = { caseNumber: string; court: string };
+
+/**
+ * The docket and the court an item must state for this adapter to keep it.
+ *
+ * Stated once, because the crawl, the identity rule and the listing walk must
+ * agree exactly on which items exist: an item one of them keeps and another
+ * drops is either a decision nothing ever stores or a slice that stays short
+ * forever.
+ */
+const skCourtsIdentityFields = (
+  item: SkApiItem,
+): SkCourtsIdentityFields | null => {
+  const caseNumber = item.spisovaZnacka;
+  const court = item.sud?.nazov;
+  if (!caseNumber || !court) {
+    return null;
+  }
+  return { caseNumber, court };
+};
+
+/**
+ * The identity the ingest would store for this listing item.
+ *
+ * Takes the raw item rather than a validated one, because the shape check is
+ * itself part of the rule: the crawl drops a payload it cannot validate, so a
+ * walk must count it as unidentifiable rather than as a decision it is missing.
+ */
+export const skCourtsListingIdentity = (item: unknown): ListingIdentity => {
+  if (!isSkApiItem(item)) {
+    return { type: "unidentifiable" };
+  }
+  const fields = skCourtsIdentityFields(item);
+  if (fields === null) {
+    return { type: "unidentifiable" };
+  }
+  const sourceDocumentId = skCourtsSourceDocumentId(item.guid);
+  if (sourceDocumentId !== undefined) {
+    return { type: "document", sourceDocumentId };
+  }
+  return {
+    type: "case-number",
+    caseNumber: fields.caseNumber,
+    language: SK_COURTS_LANGUAGE,
+  };
+};
+
+/**
+ * What asking the publisher's per-decision record about a listed item produced.
+ *
+ * `listing-only` and `unavailable` are kept apart on purpose. The crawl treats
+ * both as "no detail" and stores the listing observation either way, which is
+ * right for a page that must keep moving. A caller filling gaps needs the
+ * difference, and here it is sharper than elsewhere: `documentUrl` is stated
+ * only by this record, and the document walk selects the rows it still owes
+ * text by that column. So a detail-less row is held — taking the decision out
+ * of every later reconciliation — and invisible to the walk that would have
+ * given it its text.
+ */
+type SkCourtsDetailFetch =
+  | { type: "detail"; detail: SkDetailItem }
+  /** The item names no record to ask about. */
+  | { type: "listing-only" }
+  /** A record was asked about and nothing came back. */
+  | { type: "unavailable" };
+
+const fetchDetailForItem = async (
+  item: SkApiItem,
   signal?: AbortSignal,
-): Promise<IngestionResult | null> => {
-  if (!isSkApiItem(raw)) {
-    return null;
+): Promise<SkCourtsDetailFetch> => {
+  const guid = toOptionalValue(item.guid);
+  if (guid === undefined || guid.length === 0) {
+    return { type: "listing-only" };
   }
-  const item = raw;
+  const detail = await fetchDetail(guid, signal);
+  return detail === null ? { type: "unavailable" } : { type: "detail", detail };
+};
 
-  if (!item.spisovaZnacka || !item.sud?.nazov) {
-    return null;
-  }
+type SkCourtsDecisionParts = {
+  /** The item exactly as the publisher listed it. */
+  item: SkApiItem;
+  fields: SkCourtsIdentityFields;
+  /** The per-decision record, where one was read. */
+  detail: SkDetailItem | null;
+};
 
-  const detail = item.guid ? await fetchDetail(item.guid, signal) : null;
-
+const buildDecisionFromParts = ({
+  detail,
+  fields: { caseNumber, court },
+  item,
+}: SkCourtsDecisionParts): IngestionResult => {
   // Hash only the list-endpoint payload so the
   // change-detection key stays stable regardless of
   // transient detail-fetch failures.
@@ -262,14 +378,8 @@ const parseItemWithDetail = async (
   // the walk reaches them. Until it does, the decision has
   // no readable text, so the two must ship together.
 
-  const caseNumber = item.spisovaZnacka;
-  const courtInfo = Reflect.get(item, "sud");
-  if (!caseNumber || !isSkSud(courtInfo) || !courtInfo.nazov) {
-    return null;
-  }
   const decisionDate = parseSkDate(item.datumVydania);
   const decisionType = toOptionalValue(item.formaRozhodnutia);
-  const court = courtInfo.nazov;
   const ecli = toOptionalValue(detail?.ecli);
 
   return {
@@ -277,10 +387,10 @@ const parseItemWithDetail = async (
     ecli,
     court,
     country: "SVK",
-    language: "sk",
+    language: SK_COURTS_LANGUAGE,
     decisionDate,
     decisionType,
-    sourceDocumentId: toOptionalValue(item.guid),
+    sourceDocumentId: skCourtsSourceDocumentId(item.guid),
     sourceUrl: item.guid
       ? sanitizeUrl(sourceUrlForDecision(item.guid, detail?.dokument?.url))
       : undefined,
@@ -298,7 +408,7 @@ const parseItemWithDetail = async (
       identifikacneCislo: toOptionalValue(item.identifikacneCislo),
       judge: toOptionalValue(item.sudca?.meno),
       judgeRegistreGuid: toOptionalValue(item.sudca?.registreGuid),
-      courtRegistreGuid: toOptionalValue(courtInfo.registreGuid),
+      courtRegistreGuid: toOptionalValue(item.sud?.registreGuid),
       decisionNature: item.povaha,
       subArea: detail?.podOblast,
       referencedLegislation: detail?.odkazovanePredpisy,
@@ -315,6 +425,70 @@ const parseItemWithDetail = async (
   };
 };
 
+/**
+ * What building one listed item produced.
+ *
+ * `detail-unavailable` still carries the decision the listing alone describes,
+ * because the two callers dispose of it differently: the crawl's cursor moves
+ * past this item either way, so a listing-only row is worth more to it than
+ * nothing, while the reconciliation must refuse it.
+ */
+export type SkCourtsBuildResult =
+  | { type: "built"; decision: IngestionResult }
+  /** No docket or no court to key on; nothing can store this item. */
+  | { type: "unkeyable" }
+  /** The publisher served no record for the id the listing states. */
+  | { type: "detail-unavailable"; decision: IngestionResult };
+
+/**
+ * Build one decision from a listing item, through this adapter's own parse and
+ * enrichment path. Shared by the crawl and the reconciliation walk so neither
+ * can key, parse or enrich an item differently from the other.
+ */
+export const buildSkCourtsDecision = async (
+  item: SkApiItem,
+  signal?: AbortSignal,
+): Promise<SkCourtsBuildResult> => {
+  const fields = skCourtsIdentityFields(item);
+  if (fields === null) {
+    return { type: "unkeyable" };
+  }
+  const fetched = await fetchDetailForItem(item, signal);
+  const decision = buildDecisionFromParts({
+    item,
+    fields,
+    detail: fetched.type === "detail" ? fetched.detail : null,
+  });
+  return fetched.type === "unavailable"
+    ? { type: "detail-unavailable", decision }
+    : { type: "built", decision };
+};
+
+const parseItemWithDetail = async (
+  raw: unknown,
+  signal?: AbortSignal,
+): Promise<IngestionResult | null> => {
+  if (!isSkApiItem(raw)) {
+    return null;
+  }
+  const built = await buildSkCourtsDecision(raw, signal);
+  switch (built.type) {
+    case "unkeyable":
+      return null;
+    // The page has to keep moving, and the listing observation is still worth
+    // storing; the reconciliation refuses the same row, see `buildDecision`.
+    case "detail-unavailable":
+    case "built":
+      return built.decision;
+    default: {
+      const exhaustive: never = built;
+      return panic(
+        `Unhandled sk-courts build result: ${JSON.stringify(exhaustive)}`,
+      );
+    }
+  }
+};
+
 /** One list page, in the given order. */
 const listRequest = (
   page: number,
@@ -328,6 +502,233 @@ const listRequest = (
   }).toString()}`,
   init: { headers: { Accept: "application/json" } },
 });
+
+// ── Reconciliation ───────────────────────────────────────
+
+/**
+ * Earliest `datumVydania` the publisher lists, and so the oldest slice the
+ * historical sweep walks back to.
+ *
+ * Read from the source: the list sorted by `datumVydania` ascending opens on
+ * this date, and the same date filter closed one day earlier states a count of
+ * zero. What sits either side of it is nearly empty — two decisions before
+ * 1990, six across the 1990s, 81 across 2000-2004, against 4.6M since — but
+ * the sweep runs newest-first, so that sparse tail is surveyed last rather
+ * than standing between the loop and the dense years.
+ */
+export const SK_COURTS_FIRST_SLICE = "1965-07-11";
+
+/**
+ * Days near the tip that get re-walked on a fast cadence.
+ *
+ * A slice here is the decision date, and this publisher posts a decision long
+ * after it is handed down. Measured against the volume the same weekday
+ * settles at, a date holds under half its eventual decisions at seven weeks
+ * and only flattens out around four months. That is the whole reason this
+ * number is not the fortnight a same-day publisher needs: a slice recorded as
+ * fully collected is settled, and a settled slice is never re-walked and never
+ * swept again, so a date walked while it is still filling is a date the loop
+ * has finished with at a fraction of its content.
+ *
+ * Four months is where the curve flattens, not where it ends, and this
+ * deliberately stops there: every tip slice is re-walked daily, so each extra
+ * day of window is a standing daily request for good. The thin tail arriving
+ * past the window is left to the crawl, which reaches it by walking the newest
+ * decision dates each cycle.
+ */
+const SK_COURTS_TIP_WINDOW_DAYS = 120;
+
+/**
+ * Page size for a listing walk. The crawl takes 100 at a time because every
+ * item on its page costs a detail fetch; a listing walk fetches nothing per
+ * item, so it asks for the largest page that stays quick — 1000 items answered
+ * in ~2.3s, where 2000 took ~5.6s for no fewer requests per decision. The
+ * busiest decision date observed holds 2,559, so a slice is at most three
+ * pages, and a date still filling in at the tip is always one.
+ */
+const LISTING_PAGE_SIZE = 1000;
+
+/**
+ * This endpoint numbers pages from one and clamps below it: `page=0` and
+ * `page=1` both answer the first page, and the response echoes `page` one
+ * lower than the request asked for. The contract numbers a slice's pages from
+ * zero, so a page is requested one higher than it is named.
+ */
+const LISTING_FIRST_PAGE = 1;
+
+/**
+ * Ordering for a slice listing. `guid` is unique and never reassigned, so it
+ * is a total order over the slice that existing items keep whatever the
+ * publisher adds to it: a decision indexed between two page requests can only
+ * push later items further back, which a walk sees as a repeat — the loop keys
+ * items and drops the duplicate — rather than as an item that slipped past.
+ * The endpoint's default ordering offers no such guarantee.
+ */
+const SLICE_SORT_PROPERTY = "guid";
+const SLICE_SORT_DIRECTION = "ASC";
+
+/**
+ * A reconciliation slice for this source is one UTC calendar day of decision
+ * dates, `YYYY-MM-DD`, which sorts lexicographically in chronological order —
+ * the ordering the ledger relies on.
+ *
+ * The day, and this date, because the publisher answers a `vydaniaOd`/
+ * `vydaniaDo` range precisely and exhaustively: a single-day range comes back
+ * holding only that date, adjacent days sum to the range that spans them, and
+ * the disjoint date buckets covering the corpus add up to exactly the total
+ * the endpoint reports for no filter at all. So every decision falls in one
+ * slice and none falls outside all of them.
+ *
+ * The publisher also filters on the date it indexed a decision, which would
+ * give slices that never change once past. That axis is unusable here for the
+ * opposite reason: it puts 4.19M of the 4.68M decisions on the index dates of
+ * a single year, and a slice of that size cannot be walked to the end, so the
+ * ledger could never record it at all.
+ */
+const skCourtsDayStart = (slice: string): Date => {
+  const day = isoCalendarDay(slice);
+  if (day === null || day !== slice) {
+    panic(`sk-courts slice is not a UTC calendar day: ${slice}`);
+  }
+  return new Date(`${day}T00:00:00.000Z`);
+};
+
+const skCourtsStepSlice = (slice: string, days: number): string =>
+  toUtcDateString(addUtcDays(skCourtsDayStart(slice), days));
+
+const skCourtsNextSlice = (slice: string): string | null => {
+  const next = skCourtsStepSlice(slice, 1);
+  return next > toUtcDateString(new Date()) ? null : next;
+};
+
+const skCourtsPreviousSlice = (slice: string): string | null => {
+  const previous = skCourtsStepSlice(slice, -1);
+  return previous < SK_COURTS_FIRST_SLICE ? null : previous;
+};
+
+/**
+ * The envelope a slice walk reads.
+ *
+ * Deliberately looser than {@link isSkApiResponse}, which requires every item
+ * to validate: one malformed item would make the whole date unwalkable and so
+ * permanently unreconcilable. The items stay unknown here and are validated
+ * one at a time by the identity rule, exactly as the crawl validates them.
+ */
+type SkSliceResponse = {
+  rozhodnutieList?: Record<string, unknown>[] | null;
+  numFound?: number | null;
+};
+
+const isSkSliceResponse = (value: unknown): value is SkSliceResponse =>
+  isRecord(value) &&
+  isNullishArrayOf(value["rozhodnutieList"], isRecord) &&
+  isOptionalNumber(value["numFound"]);
+
+/**
+ * One page of the publisher's own listing for a decision date.
+ *
+ * A failed request is thrown, never flattened into an empty page. The crawl
+ * can afford to read a dead page as "nothing here" because a cursor that moves
+ * on can be walked again; a ledger row cannot, since an outage recorded as an
+ * empty date settles that date and it is never revisited. So only a body that
+ * states a count answers what a date holds: `numFound: 0` is an empty slice,
+ * and everything else — a 5xx, a timeout, a body without a count — is an error
+ * the engine retries on a later pass.
+ */
+const listSkCourtsSlicePage = async ({
+  page,
+  signal,
+  slice,
+}: ReconciliationSlicePageOptions): Promise<ReconciliationSlicePage> => {
+  // Refused here rather than at the publisher: this endpoint ignores a date it
+  // cannot parse and answers the whole 4.6M-decision collection instead, which
+  // a walk would read as one date holding all of it.
+  skCourtsDayStart(slice);
+  const url = `${BASE_URL}?${new URLSearchParams({
+    page: String(page + LISTING_FIRST_PAGE),
+    size: String(LISTING_PAGE_SIZE),
+    sortProperty: SLICE_SORT_PROPERTY,
+    sortDirection: SLICE_SORT_DIRECTION,
+    vydaniaOd: slice,
+    vydaniaDo: slice,
+  }).toString()}`;
+
+  const response = await fetchWithTimeout(url, {
+    signal,
+    timeoutMs: LIST_TIMEOUT_MS,
+    headers: {
+      Accept: "application/json",
+      "User-Agent": INGESTION_USER_AGENT,
+    },
+  });
+
+  if (!response.ok) {
+    throw new AdapterFetchError({
+      message: `SK courts listing API error: ${response.status}`,
+      adapterKey: ADAPTER_KEYS.SK_COURTS,
+      cursor: slice,
+      httpStatus: response.status,
+    });
+  }
+
+  const json: unknown = await response.json();
+  if (!isSkSliceResponse(json)) {
+    throw new AdapterFetchError({
+      message: "SK courts listing API returned an invalid payload",
+      adapterKey: ADAPTER_KEYS.SK_COURTS,
+      cursor: slice,
+    });
+  }
+
+  const total = toOptionalValue(json.numFound);
+  if (total === undefined) {
+    throw new AdapterFetchError({
+      message: "SK courts listing API stated no count for the slice",
+      adapterKey: ADAPTER_KEYS.SK_COURTS,
+      cursor: slice,
+    });
+  }
+
+  return {
+    items: arrayOrEmpty(json.rozhodnutieList).map((item) => ({
+      identity: skCourtsListingIdentity(item),
+      payload: item,
+    })),
+    totalPages: Math.ceil(total / LISTING_PAGE_SIZE),
+  };
+};
+
+/**
+ * Rebuild a decision from a payload the loop stored verbatim. The payload is
+ * revalidated rather than trusted: it may have been parked for days, and a
+ * shape the adapter no longer recognises has to be reported as unbuildable
+ * instead of parsed on faith.
+ */
+const buildSkCourtsFromPayload = async (
+  payload: unknown,
+  signal?: AbortSignal,
+): Promise<ReconciliationBuildOutcome> => {
+  if (!isSkApiItem(payload)) {
+    return { type: "unkeyable" };
+  }
+  const built = await buildSkCourtsDecision(payload, signal);
+  switch (built.type) {
+    case "built":
+      return { type: "built", decision: built.decision };
+    case "unkeyable":
+      return { type: "unkeyable" };
+    // Written as a decision it would make the identity held with the document
+    // still unread, and unread is how the document walk finds its work.
+    case "detail-unavailable":
+      return { type: "detail-unavailable" };
+    default: {
+      const exhaustive: never = built;
+      return panic(
+        `Unhandled sk-courts build result: ${JSON.stringify(exhaustive)}`,
+      );
+    }
+  }
+};
 
 export const skCourtsAdapter = defineSourceAdapter({
   key: ADAPTER_KEYS.SK_COURTS,
@@ -367,6 +768,22 @@ export const skCourtsAdapter = defineSourceAdapter({
     }
     const total = json["numFound"];
     return typeof total === "number" && total > 0 ? total : null;
+  },
+
+  /**
+   * The publisher lists each decision date independently of the crawl's offset
+   * cursor, so what a date holds is answerable without re-crawling to it:
+   * enumerate the date, key each item the way the ingest would, and compare
+   * against what is held.
+   */
+  reconciliation: {
+    firstSlice: SK_COURTS_FIRST_SLICE,
+    sliceOf: toUtcDateString,
+    nextSlice: skCourtsNextSlice,
+    previousSlice: skCourtsPreviousSlice,
+    tipWindowDays: SK_COURTS_TIP_WINDOW_DAYS,
+    listSlicePage: listSkCourtsSlicePage,
+    buildDecision: buildSkCourtsFromPayload,
   },
 
   fetchPage: createPagePaginatedFetch<SkApiResponse>({

--- a/apps/api/src/handlers/case-law/ingestion/adapters/sk-courts.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/sk-courts.ts
@@ -21,6 +21,7 @@ import { createPagePaginatedFetch } from "@/api/handlers/case-law/ingestion/adap
 import {
   INGESTION_USER_AGENT,
   hashContent,
+  isArrayOf,
   isNullishArrayOf,
   isNullishNumber,
   isNullishString,
@@ -522,21 +523,33 @@ export const SK_COURTS_FIRST_SLICE = "1965-07-11";
  * Days near the tip that get re-walked on a fast cadence.
  *
  * A slice here is the decision date, and this publisher posts a decision long
- * after it is handed down. Measured against the volume the same weekday
- * settles at, a date holds under half its eventual decisions at seven weeks
- * and only flattens out around four months. That is the whole reason this
- * number is not the fortnight a same-day publisher needs: a slice recorded as
- * fully collected is settled, and a settled slice is never re-walked and never
- * swept again, so a date walked while it is still filling is a date the loop
- * has finished with at a fraction of its content.
+ * after it is handed down. That is the whole reason this is not the fortnight
+ * a same-day publisher needs: a slice recorded as fully collected is settled,
+ * and a settled slice is never re-walked and never swept again, so a date
+ * walked while it is still filling is a date the loop has finished with at a
+ * fraction of its content. Measured against the volume the same weekday
+ * settles at, a date holds under half its eventual decisions at seven weeks.
  *
- * Four months is where the curve flattens, not where it ends, and this
- * deliberately stops there: every tip slice is re-walked daily, so each extra
- * day of window is a standing daily request for good. The thin tail arriving
- * past the window is left to the crawl, which reaches it by walking the newest
- * decision dates each cycle.
+ * The window is sized past where that filling stops, sampling ten Wednesdays
+ * per age band so court sitting patterns cannot explain the difference: the
+ * median at 130-200 days old is 615 decisions, at 330-400 days 621, and at
+ * 700-770 days 637. A date has therefore effectively stopped growing well
+ * inside a window this wide, and the ~3% still arriving over the two years
+ * after that is the residual below.
+ *
+ * Known limit, stated because it is invisible otherwise: a decision published
+ * past the window is not recovered. Its slice is settled, so no reconciliation
+ * unit selects it again, and the crawl does not reach it either — the
+ * newest-first lap orders by decision date and stops after
+ * {@link LIVE_WINDOW_ITEMS}, which at this source's volume spans about two
+ * months of dates, so an old-dated new record is nowhere near the head it
+ * walks. Closing it needs the loop to re-survey settled slices on a slow
+ * cadence, which is the engine's decision to make, not an adapter's: the
+ * capability's only lever over what gets re-walked is this number, and buying
+ * the last few percent with it would mean re-walking hundreds of dates daily
+ * for good.
  */
-const SK_COURTS_TIP_WINDOW_DAYS = 120;
+const SK_COURTS_TIP_WINDOW_DAYS = 140;
 
 /**
  * Page size for a listing walk. The crawl takes 100 at a time because every
@@ -609,20 +622,24 @@ const skCourtsPreviousSlice = (slice: string): string | null => {
 /**
  * The envelope a slice walk reads.
  *
- * Deliberately looser than {@link isSkApiResponse}, which requires every item
- * to validate: one malformed item would make the whole date unwalkable and so
- * permanently unreconcilable. The items stay unknown here and are validated
- * one at a time by the identity rule, exactly as the crawl validates them.
+ * Both fields are required, unlike {@link isSkApiResponse}, whose optionality
+ * exists so the crawl can shrug off a page: an envelope that states a count
+ * but no list would otherwise read as a date holding nothing, which is the one
+ * answer a ledger row must never be written from. The items themselves stay
+ * unknown, because the opposite mistake is just as bad — requiring every item
+ * to validate would let one malformed row make a date permanently unwalkable —
+ * so they are validated one at a time by the identity rule, exactly as the
+ * crawl validates them.
  */
 type SkSliceResponse = {
-  rozhodnutieList?: Record<string, unknown>[] | null;
-  numFound?: number | null;
+  rozhodnutieList: Record<string, unknown>[];
+  numFound: number;
 };
 
 const isSkSliceResponse = (value: unknown): value is SkSliceResponse =>
   isRecord(value) &&
-  isNullishArrayOf(value["rozhodnutieList"], isRecord) &&
-  isOptionalNumber(value["numFound"]);
+  isArrayOf(value["rozhodnutieList"], isRecord) &&
+  typeof value["numFound"] === "number";
 
 /**
  * One page of the publisher's own listing for a decision date.
@@ -674,23 +691,29 @@ const listSkCourtsSlicePage = async ({
   const json: unknown = await response.json();
   if (!isSkSliceResponse(json)) {
     throw new AdapterFetchError({
-      message: "SK courts listing API returned an invalid payload",
+      message:
+        "SK courts listing API stated no count and item list for the slice",
       adapterKey: ADAPTER_KEYS.SK_COURTS,
       cursor: slice,
     });
   }
 
-  const total = toOptionalValue(json.numFound);
-  if (total === undefined) {
+  const { numFound: total, rozhodnutieList: listed } = json;
+  // The count and the list have to agree about this page existing. They are
+  // read from one response, so an offset the count says is populated answering
+  // with nothing is the publisher contradicting itself, not a date running out
+  // — and a page dropped here is not merely lost, it is written to the ledger
+  // as part of what the date holds.
+  if (total > page * LISTING_PAGE_SIZE && listed.length === 0) {
     throw new AdapterFetchError({
-      message: "SK courts listing API stated no count for the slice",
+      message: `SK courts listing API stated ${total} for ${slice} but listed nothing at page ${page}`,
       adapterKey: ADAPTER_KEYS.SK_COURTS,
       cursor: slice,
     });
   }
 
   return {
-    items: arrayOrEmpty(json.rozhodnutieList).map((item) => ({
+    items: listed.map((item) => ({
       identity: skCourtsListingIdentity(item),
       payload: item,
     })),


### PR DESCRIPTION
Implements the `reconciliation` capability on the sk-courts adapter.

The endpoint's own OpenAPI description settles the parameter surface: `vydaniaOd`/`vydaniaDo` filter by decision date, ISO format only (a dotted date is silently ignored — guarded). Verified live that the filter partitions the corpus exactly: disjoint day buckets over 1965–2026 sum to the unfiltered total with zero delta, so no decision is invisible to every slice. Slice = one UTC decision day (`YYYY-MM-DD`), `firstSlice = 1965-07-11` (the corpus floor, probed), page size 1000, and the pagination quirk is documented and compensated: the endpoint is 1-indexed and clamps below (`page=0` and `page=1` return identical items), so the listing requests `page + 1`. Intra-slice ordering pins `sortProperty=guid&sortDirection=ASC` — guids are unique and never reassigned, so a mid-walk insertion can only append (a dedupe), never hide an item.

`tipWindowDays = 120`, sized from measured fill-in: a decision date lists ~10% of its eventual content at 14 days and keeps accruing past 8 months (D-1 = 1, D-29 = 151, D-76 = 802, D-258 = 960 in the probe series). The index-date axis was evaluated and rejected: it also partitions exactly, but 4.19M of 4.68M rows share 2023 index dates, exceeding what a slice walk can list.

Identity is stated once (`skCourtsListingIdentity`): docket + court required (else unidentifiable, matching the crawl's own drop), guid where it fits the identity column, docket fallback otherwise — which also fixes a pre-existing edge where an over-long guid made a row unstorable at all. This source is metadata-only at ingest by design (a separate walk fills documents), so `detail-unavailable` is grounded in the per-decision record fetch the crawl already performs: a record-less row would be held and permanently textless, so reconciliation refuses it while the crawl keeps it (crawl behaviour byte-identical). One malformed listing item yields `unidentifiable` rather than making the date unwalkable.

Also documented in-code (fix deferred to its own change because it alters cursor semantics on a live crawl with persisted offset cursors): the crawl's paginated fetch is configured zero-indexed against this 1-indexed endpoint, so it re-reads its first page each traversal and its live window covers 4,900 of the intended 5,000.

Tests: 22 new (slice arithmetic, identity, listing semantics incl. the 1-index compensation, stated-zero vs transient-failure, build outcomes); full non-db adapter suite green (125 tests).
