### PR TITLE
feat(case-law): cz-nss listing reconciliation capability

### DIFF
--- a/apps/api/src/handlers/case-law/ingestion/adapters/cz-nss.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/cz-nss.test.ts
@@ -22,6 +22,7 @@ import {
   czNssAdapter,
   czNssListingIdentity,
   CZ_NSS_FIRST_SLICE,
+  CZ_NSS_RESULTS_PER_PAGE,
   parseResultRows,
 } from "@/api/handlers/case-law/ingestion/adapters/cz-nss";
 import type { ParsedRow } from "@/api/handlers/case-law/ingestion/adapters/cz-nss";
@@ -96,6 +97,20 @@ const REGIONAL_ROW = {
   court: "Krajsk&#xE9;ho soudu v Hradci Kr&#xE1;lov&#xE9;",
   date: "10.06.2026",
 } as const satisfies RowFixture;
+
+/**
+ * A page's worth of distinct rows. Sized from the adapter's own page constant
+ * so the fixture cannot drift from the cardinality the walk enforces.
+ */
+const fullPageRows = (count: number): RowFixture[] =>
+  Array.from({ length: count }, (_, index) => ({
+    index,
+    documentId: String(780_000 + index),
+    citedCaseNumber: `${index + 1} As ${index + 1}/2026-10`,
+    displayedCaseNumber: `${index + 1}&#xA0;As&#xA0;${index + 1}/2026&#xA0;-&#xA0;10`,
+    court: "Nejvy&#x161;&#x161;&#xED; spr&#xE1;vn&#xED; soud",
+    date: "10.06.2026",
+  }));
 
 /** The pagination state the portal hands to its own infinite scroll. */
 const CURR_PARAMS_JSON =
@@ -411,21 +426,12 @@ describe("cz-nss listing rows", () => {
 
 describe("cz-nss listSlicePage", () => {
   const originalFetch = globalThis.fetch;
-  let clock = 0;
-
-  beforeEach(() => {
-    // Every test starts past the cached session's TTL, so each one exercises
-    // session establishment rather than inheriting its predecessor's.
-    clock += 1;
-    setSystemTime(new Date(Date.UTC(2026, 7, 11, clock)));
-  });
 
   afterEach(() => {
     globalThis.fetch = originalFetch;
-    setSystemTime();
   });
 
-  test("establishes a session, then searches the day", async () => {
+  test("searches the day the slice names", async () => {
     const { requests } = installStub({
       search: [
         htmlResponse(
@@ -439,16 +445,38 @@ describe("cz-nss listSlicePage", () => {
       page: 0,
     });
 
-    expect(requests.map(({ method, url }) => `${method} ${url}`)).toEqual([
-      `GET ${BASE_URL}/`,
+    const search = requests.at(-1);
+    expect(`${search?.method} ${search?.url}`).toBe(
       `POST ${BASE_URL}/Home/Index`,
-    ]);
+    );
     // The court's own date field, in its own format.
-    expect(requests.at(1)?.body).toContain("HodnotaDatumACasOd=10.06.2026");
+    expect(search?.body).toContain("HodnotaDatumACasOd=10.06.2026");
     expect(listed.totalPages).toBe(1);
     expect(listed.items.map(({ identity }) => identity)).toEqual([
       { type: "case-number", caseNumber: "1 Az 4/2026", language: "cs" },
       { type: "case-number", caseNumber: "52 Af 4/2026", language: "cs" },
+    ]);
+  });
+
+  test("establishes its own session when it holds none", async () => {
+    // The adapter's session cache is module-level, so it is shared with every
+    // other suite in this process and its state cannot be assumed. A failed
+    // search drops it, which is the adapter's own way of reaching the one
+    // state this asserts about.
+    const { requests } = installStub({
+      search: [
+        htmlResponse("upstream failure", 503),
+        htmlResponse(searchPage({ statedCount: 1, rows: [MUNICIPAL_ROW] })),
+      ],
+    });
+    await rejectionOf(reconciliation.listSlicePage({ slice: SLICE, page: 0 }));
+    requests.length = 0;
+
+    await reconciliation.listSlicePage({ slice: SLICE, page: 0 });
+
+    expect(requests.map(({ method, url }) => `${method} ${url}`)).toEqual([
+      `GET ${BASE_URL}/`,
+      `POST ${BASE_URL}/Home/Index`,
     ]);
   });
 
@@ -494,6 +522,29 @@ describe("cz-nss listSlicePage", () => {
   });
 
   test("derives the page count from the court's own record count", async () => {
+    const statedCount = CZ_NSS_RESULTS_PER_PAGE + 10;
+    installStub({
+      search: [
+        htmlResponse(
+          searchPage({
+            statedCount,
+            rows: fullPageRows(CZ_NSS_RESULTS_PER_PAGE),
+          }),
+        ),
+      ],
+    });
+
+    // A day whose count runs past one page is two pages.
+    expect(
+      (await reconciliation.listSlicePage({ slice: SLICE, page: 0 }))
+        .totalPages,
+    ).toBe(2);
+  });
+
+  test("refuses a first page shorter than the stated count requires", async () => {
+    // The exact shape a changed results table would produce: the count still
+    // says 50, the parser recovers two rows. Returning them would record the
+    // day as holding two decisions and settle it.
     installStub({
       search: [
         htmlResponse(
@@ -502,17 +553,45 @@ describe("cz-nss listSlicePage", () => {
       ],
     });
 
-    // 50 records at 40 per page is two pages, whatever one page renders.
+    const error = await rejectionOf(
+      reconciliation.listSlicePage({ slice: SLICE, page: 0 }),
+    );
+    expect(error).toBeInstanceOf(Error);
+    expect(String(error)).toContain("carried 2 of the 40 rows");
+  });
+
+  test("refuses a continuation page the endpoint answered empty", async () => {
+    // A 200 with no body is how the endpoint answers a query it does not
+    // recognise; read as the end of the day it would lose every row past the
+    // first page, permanently.
+    installStub({
+      search: [
+        htmlResponse(
+          searchPage({
+            statedCount: CZ_NSS_RESULTS_PER_PAGE + 10,
+            rows: fullPageRows(CZ_NSS_RESULTS_PER_PAGE),
+          }),
+        ),
+      ],
+      continuation: [htmlResponse("")],
+    });
+
     expect(
-      (await reconciliation.listSlicePage({ slice: SLICE, page: 0 }))
-        .totalPages,
-    ).toBe(2);
+      await rejectionOf(
+        reconciliation.listSlicePage({ slice: SLICE, page: 1 }),
+      ),
+    ).toBeInstanceOf(Error);
   });
 
   test("asks the portal's own continuation endpoint for a later page", async () => {
     const { requests } = installStub({
       search: [
-        htmlResponse(searchPage({ statedCount: 50, rows: [MUNICIPAL_ROW] })),
+        htmlResponse(
+          searchPage({
+            statedCount: CZ_NSS_RESULTS_PER_PAGE + 1,
+            rows: fullPageRows(CZ_NSS_RESULTS_PER_PAGE),
+          }),
+        ),
       ],
       continuation: [htmlResponse(rowBlock(REGIONAL_ROW))],
     });
@@ -622,16 +701,9 @@ describe("cz-nss listSlicePage", () => {
 
 describe("cz-nss buildDecision", () => {
   const originalFetch = globalThis.fetch;
-  let clock = 100;
-
-  beforeEach(() => {
-    clock += 1;
-    setSystemTime(new Date(Date.UTC(2026, 7, 11, clock)));
-  });
 
   afterEach(() => {
     globalThis.fetch = originalFetch;
-    setSystemTime();
   });
 
   const listedRow = async (): Promise<unknown> => {

--- a/apps/api/src/handlers/case-law/ingestion/adapters/cz-nss.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/cz-nss.test.ts
@@ -1,205 +1,730 @@
-import { describe, expect, test } from "bun:test";
-
 /**
- * parseResultRows is not exported, so we extract it via a
- * dynamic import trick. Alternatively, we inline the function
- * signature here and test the same regex logic directly.
+ * The cz-nss listing reconciliation capability, and the parser it keys on.
  *
- * Since the function is module-private, we re-implement the
- * parsing logic identically to verify correctness against
- * representative HTML fixtures from vyhledavac.nssoud.cz.
+ * Everything here drives the adapter's own exports against a stubbed portal.
+ * A test that re-implemented the parser would certify its own copy of the
+ * regexes rather than the ones the crawl runs, which is how this suite's
+ * predecessor came to assert a citation pattern the adapter no longer had.
  */
 
-const stripHtml = (html: string): string =>
-  html
-    .replace(/<[^>]+>/gu, " ")
-    .replace(/\s+/gu, " ")
-    .trim();
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  setSystemTime,
+  test,
+} from "bun:test";
 
-type ParsedRow = {
-  caseNumber: string;
-  decisionDate: string | undefined;
-  decisionType: string | undefined;
-  documentUrl: string | undefined;
-};
+import {
+  buildCzNssDecision,
+  czNssAdapter,
+  czNssListingIdentity,
+  CZ_NSS_FIRST_SLICE,
+  parseResultRows,
+} from "@/api/handlers/case-law/ingestion/adapters/cz-nss";
+import type { ParsedRow } from "@/api/handlers/case-law/ingestion/adapters/cz-nss";
+import { tipWindowSlices } from "@/api/handlers/case-law/ingestion/reconciliation-plan";
+import { listingIdentityKey } from "@/api/lib/legal-search/ingestion-types";
+import { asFetchMock } from "@/api/tests/helpers/test-tool-set";
+
+const { reconciliation } = czNssAdapter;
+if (reconciliation === undefined) {
+  throw new Error("cz-nss must declare a reconciliation capability");
+}
 
 const BASE_URL = "https://vyhledavac.nssoud.cz";
 
-const parseResultRows = (html: string): ParsedRow[] => {
-  const rows: ParsedRow[] = [];
+// ── Portal-shaped fixtures ───────────────────────────────
 
-  const tbodyPattern = /<tbody>(?<block>[\s\S]*?)<\/tbody>/giu;
-  let tbodyMatch: RegExpExecArray | null;
-
-  while ((tbodyMatch = tbodyPattern.exec(html)) !== null) {
-    const block = tbodyMatch.groups?.["block"];
-    if (!block?.includes("Citace")) {
-      continue;
-    }
-
-    const citMatch =
-      /title="Citace:[^"]*?(?:čj\.|č\.\s*j\.)[\s]*(?<caseNumber>[^"]+?)(?:-\d+)?"/iu.exec(
-        block,
-      );
-    const caseNumber = citMatch?.groups?.["caseNumber"]?.trim();
-    if (!caseNumber) {
-      continue;
-    }
-
-    const detailMatch =
-      /href="(?<documentPath>\/DokumentDetail\/Index\/\d+)"/u.exec(block);
-    const documentPath = detailMatch?.groups?.["documentPath"];
-    const documentUrl = documentPath ? `${BASE_URL}${documentPath}` : undefined;
-
-    const cells: string[] = [];
-    const cellPattern = /<td[^>]*>(?<cell>[\s\S]*?)<\/td>/giu;
-    let cellMatch: RegExpExecArray | null;
-    while ((cellMatch = cellPattern.exec(block)) !== null) {
-      const cell = cellMatch.groups?.["cell"];
-      if (cell) {
-        cells.push(stripHtml(cell).trim());
-      }
-    }
-
-    let decisionDate: string | undefined;
-    let decisionType: string | undefined;
-    for (const cell of cells) {
-      if (!decisionDate && /\d{1,2}\.\s*\d{1,2}\.\s*\d{4}/u.test(cell)) {
-        decisionDate = cell;
-      } else if (
-        !decisionType &&
-        cell !== caseNumber &&
-        cell.length > 2 &&
-        cell.length < 50 &&
-        !/^\d+$/u.test(cell)
-      ) {
-        decisionType = cell;
-      }
-    }
-
-    rows.push({
-      caseNumber,
-      decisionDate,
-      decisionType,
-      documentUrl,
-    });
-  }
-
-  return rows;
+/**
+ * A results row exactly as the portal renders one: entity-escaped Czech, the
+ * docket carrying its sheet number, and the citation anchor the docket is read
+ * from. Shortened stand-ins would let a citation or id rule pass here and fail
+ * on live traffic.
+ */
+type RowFixture = {
+  index: number;
+  documentId: string;
+  /** The docket as the citation states it, sheet number included. */
+  citedCaseNumber: string;
+  displayedCaseNumber: string;
+  court: string;
+  date: string;
 };
 
-describe("parseResultRows", () => {
-  test("extracts case number, date, and type from tbody block", () => {
-    const html = `
-      <tbody>
-        <tr>
-          <td><a href="/DokumentDetail/Index/12345"
-                 title="Citace: NSS, rozsudek, čj. 1 As 123/2024">
-            1 As 123/2024</a></td>
-          <td>15. 3. 2024</td>
-          <td>rozsudek</td>
-        </tr>
-      </tbody>
-    `;
+const rowBlock = ({
+  citedCaseNumber,
+  court,
+  date,
+  displayedCaseNumber,
+  documentId,
+  index,
+}: RowFixture): string => `<tbody>
+  <tr>
+    <td scope="row" rowspan="1" class="font-weight-bold"> ${index + 1} </td>
+    <td rowspan="1">
+      <input name="ZobrazeneVysledky[${index}].ID" id="ZobrazeneVysledky_${index}__ID" type="hidden" value="${documentId}">
+    </td>
+    <td> ${date} </td>
+    <td> ${displayedCaseNumber} </td>
+    <td> ${court} </td>
+    <td> Rozsudek </td>
+    <td rowspan="1" class="text-nowrap">
+      <a target="_blank" href="/DokumentOriginal/Html/${documentId}"><span title="Html soubor"></span></a>
+      <a target="_blank" href="/DokumentDetail/Index/${documentId}"><span title="Detail dokumentu"></span></a>
+      <a onclick="javascript: return CopyToCB(this);" title="Citace: rozsudek ${court} ze dne ${date}, &#x10D;j. ${citedCaseNumber}"><span></span></a>
+    </td>
+  </tr>
+</tbody>`;
 
-    const rows = parseResultRows(html);
-    expect(rows).toHaveLength(1);
-    expect(rows[0]?.caseNumber).toBe("1 As 123/2024");
-    expect(rows[0]?.decisionDate).toBe("15. 3. 2024");
-    expect(rows[0]?.decisionType).toBe("rozsudek");
-    expect(rows[0]?.documentUrl).toBe(
-      "https://vyhledavac.nssoud.cz/DokumentDetail/Index/12345",
+const MUNICIPAL_ROW = {
+  index: 0,
+  documentId: "784237",
+  citedCaseNumber: "1 Az 4/2026-79",
+  displayedCaseNumber: "1&#xA0;Az&#xA0;4/2026&#xA0;-&#xA0;79",
+  court: "M&#x11B;stsk&#xFD; soud v Praze",
+  date: "10.06.2026",
+} as const satisfies RowFixture;
+
+const REGIONAL_ROW = {
+  index: 1,
+  documentId: "783863",
+  citedCaseNumber: "52 Af 4/2026-66",
+  displayedCaseNumber: "52&#xA0;Af&#xA0;4/2026&#xA0;-&#xA0;66",
+  court: "Krajsk&#xE9;ho soudu v Hradci Kr&#xE1;lov&#xE9;",
+  date: "10.06.2026",
+} as const satisfies RowFixture;
+
+/** The pagination state the portal hands to its own infinite scroll. */
+const CURR_PARAMS_JSON =
+  "[{\\u0022Id\\u0022:19,\\u0022TechnickyNazev\\u0022:\\u0022datumvydanirozhodnuti\\u0022,\\u0022vyhledavaciPodminkaHodnota\\u0022:[{\\u0022HodnotaDatumACasOd\\u0022:\\u00222026-06-10T00:00:00\\u0022,\\u0022HodnotaDatumACasDo\\u0022:\\u00222026-06-10T00:00:00\\u0022}]}]";
+const CURR_PARAMS_DECODED =
+  '[{"Id":19,"TechnickyNazev":"datumvydanirozhodnuti","vyhledavaciPodminkaHodnota":[{"HodnotaDatumACasOd":"2026-06-10T00:00:00","HodnotaDatumACasDo":"2026-06-10T00:00:00"}]}]';
+const CURR_SORT = " order by  zvht38.Hodnota NOOR , zvhdt1.Hodnota DESC ";
+
+const scriptBlock = `<script type="text/javascript">
+    var moreRowsUrl = '/Home/MyResTRowsCont';
+    var currParams = '${CURR_PARAMS_JSON}';
+    var currViewId = '1';
+    var currSort = '${CURR_SORT}';
+</script>`;
+
+type SearchPageOptions = {
+  statedCount: number;
+  rows: readonly RowFixture[];
+  withScript?: boolean;
+};
+
+const searchPage = ({
+  rows,
+  statedCount,
+  withScript = true,
+}: SearchPageOptions): string => `<html><body>
+  <div id="contenttable"><div class="col-12"><div class="row justify-content-left">
+    <h6>Počet nalezených záznamů: ${statedCount}</h6>
+  </div></div></div>
+  <table class="infinite-scroll">${rows.map(rowBlock).join("\n")}</table>
+  ${withScript ? scriptBlock : ""}
+</body></html>`;
+
+/** The landing page, which only hands out an antiforgery token. */
+const SESSION_PAGE = `<html><body><form>
+  <input type="hidden" name="__RequestVerificationToken" value="token-for-tests" />
+  <input type="text" name="vyhledavaciSekce[1].vyhledavaciPodminka[0].vyhledavaciPodminkaHodnota[0].HodnotaDatumACasOd" />
+</form></body></html>`;
+
+const DOCUMENT_HTML = `<html><body>
+  <p>Nejvyšší správní soud rozhodl v senátě složeném z předsedy JUDr. Karla Šimky
+  a soudců JUDr. Jaroslava Vlašína a Mgr. Evy Šonkové v právní věci žalobce:
+  A. B., proti žalovanému: Ministerstvo vnitra, o kasační stížnosti.</p>
+  <p>Kasační stížnost se zamítá. Žádný z účastníků nemá právo na náhradu nákladů
+  řízení o kasační stížnosti.</p>
+</body></html>`;
+
+const detailPage = (ecli: string): string => `<html><body>
+  <div id="ecli"><span class="det-textitle">ECLI:</span><span class="det-textval" title="${ecli}">${ecli}</span></div>
+  <div id="druhdokumentuavyrokrozhodnuti"><span class="det-textval">Rozsudek</span></div>
+  <div id="datumvydanirozhodnuti"><span class="det-textval">10.06.2026</span></div>
+</body></html>`;
+
+// ── Fetch stub ───────────────────────────────────────────
+
+type RecordedRequest = { method: string; url: string; body: string };
+
+type StubOptions = {
+  /** Search responses, one per POST /Home/Index, last one repeats. */
+  search?: readonly Response[];
+  /** Continuation responses, one per POST /Home/MyResTRowsCont. */
+  continuation?: readonly Response[];
+  /** Status for both document endpoints; 200 serves the fixture. */
+  documentStatus?: number;
+};
+
+const htmlResponse = (body: string, status = 200): Response =>
+  new Response(body, {
+    status,
+    headers: { "Content-Type": "text/html; charset=utf-8" },
+  });
+
+const installStub = ({
+  continuation = [],
+  documentStatus = 200,
+  search = [],
+}: StubOptions): { requests: RecordedRequest[] } => {
+  const requests: RecordedRequest[] = [];
+  let searchCalls = 0;
+  let continuationCalls = 0;
+
+  globalThis.fetch = asFetchMock(
+    async (input: string | URL | Request, init?: RequestInit) => {
+      const url = new URL(input instanceof Request ? input.url : String(input));
+      const method = init?.method ?? "GET";
+      requests.push({
+        method,
+        url: url.toString(),
+        body: typeof init?.body === "string" ? init.body : "",
+      });
+
+      const answer = (): Response => {
+        if (url.pathname === "/Home/Index" && method === "POST") {
+          const next = search.at(Math.min(searchCalls, search.length - 1));
+          searchCalls += 1;
+          return next ?? htmlResponse("no search response stubbed", 500);
+        }
+        if (url.pathname === "/Home/MyResTRowsCont") {
+          const next = continuation.at(
+            Math.min(continuationCalls, continuation.length - 1),
+          );
+          continuationCalls += 1;
+          return next ?? htmlResponse("", 200);
+        }
+        if (url.pathname.startsWith("/DokumentDetail/Index/")) {
+          return documentStatus === 200
+            ? htmlResponse(detailPage("ECLI:CZ:NSS:2026:1.Az.4.2026.79"))
+            : htmlResponse("", documentStatus);
+        }
+        if (url.pathname.startsWith("/DokumentOriginal/Html/")) {
+          return documentStatus === 200
+            ? htmlResponse(DOCUMENT_HTML)
+            : htmlResponse("", documentStatus);
+        }
+        if (url.pathname.startsWith("/DokumentOriginal/Text/")) {
+          return documentStatus === 200
+            ? new Response(DOCUMENT_HTML)
+            : new Response(null, { status: documentStatus });
+        }
+        if (url.pathname === "/") {
+          return htmlResponse(SESSION_PAGE);
+        }
+        return htmlResponse(`unexpected request: ${url.toString()}`, 500);
+      };
+
+      return await Promise.resolve(answer());
+    },
+  );
+
+  return { requests };
+};
+
+/**
+ * bun-types declares `.rejects.toThrow` as void, so awaiting it trips
+ * type-aware lint; capture the rejection explicitly instead.
+ */
+const rejectionOf = async (promise: Promise<unknown>): Promise<unknown> =>
+  await promise.then(
+    () => null,
+    (error: unknown) => error,
+  );
+
+/**
+ * A payload as the loop hands it back: parked as JSONB, so keys whose value
+ * was `undefined` are simply gone. `structuredClone` would keep them, which is
+ * why the round trip has to be JSON.
+ */
+const throughJsonb = (value: unknown): unknown =>
+  // oxlint-disable-next-line unicorn/prefer-structured-clone -- the JSON round trip is the property under test, not an incidental deep clone
+  JSON.parse(JSON.stringify(value));
+
+const SLICE = "2026-06-10";
+
+// ── Slice arithmetic ─────────────────────────────────────
+
+describe("cz-nss reconciliation slices", () => {
+  beforeEach(() => {
+    setSystemTime(new Date("2026-08-11T09:30:00.000Z"));
+  });
+
+  afterAll(() => {
+    setSystemTime();
+  });
+
+  test("starts at the first day the portal publishes a decision for", () => {
+    expect(reconciliation.firstSlice).toBe("2003-02-04");
+    expect(CZ_NSS_FIRST_SLICE).toBe(reconciliation.firstSlice);
+  });
+
+  test("slices a UTC instant to its calendar day", () => {
+    expect(reconciliation.sliceOf(new Date("2026-06-10T23:59:59.999Z"))).toBe(
+      "2026-06-10",
+    );
+    // A local-time day would answer 2026-06-10 here in any negative offset.
+    expect(reconciliation.sliceOf(new Date("2026-06-11T00:00:00.000Z"))).toBe(
+      "2026-06-11",
     );
   });
 
-  test("skips tbody blocks without Citace", () => {
-    const html = `
-      <tbody>
-        <tr><td>Header row</td></tr>
-      </tbody>
-      <tbody>
-        <tr>
-          <td><a title="Citace: NSS, usnesení, čj. 2 Afs 50/2023">
-            2 Afs 50/2023</a></td>
-          <td>1. 1. 2023</td>
-          <td>usnesení</td>
-        </tr>
-      </tbody>
-    `;
-
-    const rows = parseResultRows(html);
-    expect(rows).toHaveLength(1);
-    expect(rows[0]?.caseNumber).toBe("2 Afs 50/2023");
+  test("steps across month and year boundaries in both directions", () => {
+    expect(reconciliation.nextSlice("2024-02-28")).toBe("2024-02-29");
+    expect(reconciliation.previousSlice("2024-03-01")).toBe("2024-02-29");
+    expect(reconciliation.nextSlice("2025-12-31")).toBe("2026-01-01");
+    expect(reconciliation.previousSlice("2026-01-01")).toBe("2025-12-31");
   });
 
-  test("does not assign case number text as decisionType", () => {
-    // The citation anchor's visible text matches the case number;
-    // it must be skipped when searching for decisionType.
-    const html = `
-      <tbody>
-        <tr>
-          <td><a href="/DokumentDetail/Index/99"
-                 title="Citace: NSS, rozsudek, čj. 5 As 77/2024">
-            5 As 77/2024</a></td>
-          <td>5 As 77/2024</td>
-          <td>20. 6. 2024</td>
-          <td>rozsudek</td>
-        </tr>
-      </tbody>
-    `;
-
-    const rows = parseResultRows(html);
-    expect(rows).toHaveLength(1);
-    expect(rows[0]?.decisionType).toBe("rozsudek");
-    expect(rows[0]?.decisionType).not.toBe("5 As 77/2024");
+  test("stops at the ends of the walk", () => {
+    expect(reconciliation.previousSlice(CZ_NSS_FIRST_SLICE)).toBeNull();
+    expect(reconciliation.previousSlice("2003-02-05")).toBe(CZ_NSS_FIRST_SLICE);
+    // The tip is today; there is no slice past it to walk into.
+    expect(reconciliation.nextSlice("2026-08-11")).toBeNull();
+    expect(reconciliation.nextSlice("2026-08-10")).toBe("2026-08-11");
   });
 
-  test("handles missing date gracefully", () => {
-    const html = `
-      <tbody>
-        <tr>
-          <td><a title="Citace: NSS, č. j. 3 Ads 10/2025">
-            3 Ads 10/2025</a></td>
-          <td>rozsudek</td>
-        </tr>
-      </tbody>
-    `;
-
-    const rows = parseResultRows(html);
-    expect(rows).toHaveLength(1);
-    expect(rows[0]?.caseNumber).toBe("3 Ads 10/2025");
-    expect(rows[0]?.decisionDate).toBeUndefined();
-    expect(rows[0]?.decisionType).toBe("rozsudek");
+  test("refuses a slice that is not a UTC calendar day", () => {
+    expect(() => reconciliation.nextSlice("2026-06")).toThrow();
+    expect(() =>
+      reconciliation.previousSlice("2026-06-10T00:00:00Z"),
+    ).toThrow();
+    expect(() => reconciliation.nextSlice("2026-02-30")).toThrow();
   });
 
-  test("handles empty HTML", () => {
+  test("walk order is the ledger's lexicographic order", () => {
+    // The ledger orders slices as plain strings, so every step forward must
+    // also be a step up in byte order, and stepping back must undo it.
+    let slice = "2025-12-27";
+    for (let walked = 0; walked < 40; walked += 1) {
+      const next = reconciliation.nextSlice(slice);
+      expect(next).not.toBeNull();
+      if (next === null) {
+        return;
+      }
+      expect(next > slice).toBe(true);
+      expect(reconciliation.previousSlice(next)).toBe(slice);
+      slice = next;
+    }
+  });
+
+  test("tip window is a fortnight, newest first", () => {
+    const window = tipWindowSlices(reconciliation, new Date());
+    expect(window).toHaveLength(14);
+    expect(window.at(0)).toBe("2026-08-11");
+    expect(window.at(-1)).toBe("2026-07-29");
+  });
+
+  test("tip window truncates at the first slice for a young source", () => {
+    expect(
+      tipWindowSlices(reconciliation, new Date("2003-02-06T00:00:00.000Z")),
+    ).toEqual(["2003-02-06", "2003-02-05", "2003-02-04"]);
+  });
+});
+
+// ── Parser and identity ──────────────────────────────────
+
+describe("cz-nss listing rows", () => {
+  test("reads the docket, the document id and the date off a row", () => {
+    const rows = parseResultRows(rowBlock(MUNICIPAL_ROW));
+    expect(rows).toHaveLength(1);
+    // The sheet number is dropped: a citation names the docket alone.
+    expect(rows.at(0)?.caseNumber).toBe("1 Az 4/2026");
+    expect(rows.at(0)?.documentId).toBe("784237");
+    expect(rows.at(0)?.documentUrl).toBe(
+      `${BASE_URL}/DokumentDetail/Index/784237`,
+    );
+    expect(rows.at(0)?.decisionDate).toBe("10.06.2026");
+  });
+
+  test("skips blocks that carry no citation", () => {
+    const rows = parseResultRows(
+      `<tbody><tr><td>Header row</td></tr></tbody>${rowBlock(REGIONAL_ROW)}`,
+    );
+    expect(rows.map((row) => row.caseNumber)).toEqual(["52 Af 4/2026"]);
+  });
+
+  test("parses every block of a page", () => {
+    const rows = parseResultRows(
+      searchPage({ statedCount: 2, rows: [MUNICIPAL_ROW, REGIONAL_ROW] }),
+    );
+    expect(rows.map((row) => row.caseNumber)).toEqual([
+      "1 Az 4/2026",
+      "52 Af 4/2026",
+    ]);
+  });
+
+  test("finds nothing in a page that lists nothing", () => {
     expect(parseResultRows("")).toHaveLength(0);
-    expect(parseResultRows("<div>no results</div>")).toHaveLength(0);
+    expect(parseResultRows(searchPage({ statedCount: 0, rows: [] }))).toEqual(
+      [],
+    );
   });
 
-  test("parses multiple tbody blocks", () => {
-    const html = `
-      <tbody>
-        <tr>
-          <td><a title="Citace: NSS, rozsudek, čj. 1 As 1/2024">
-            1 As 1/2024</a></td>
-          <td>1. 1. 2024</td>
-          <td>rozsudek</td>
-        </tr>
-      </tbody>
-      <tbody>
-        <tr>
-          <td><a title="Citace: NSS, usnesení, čj. 2 As 2/2024">
-            2 As 2/2024</a></td>
-          <td>2. 2. 2024</td>
-          <td>usnesení</td>
-        </tr>
-      </tbody>
-    `;
+  test("keys a row on its docket and this source's language", () => {
+    const row = parseResultRows(rowBlock(MUNICIPAL_ROW)).at(0);
+    expect(row).toBeDefined();
+    if (row === undefined) {
+      return;
+    }
+    expect(czNssListingIdentity(row)).toEqual({
+      type: "case-number",
+      caseNumber: "1 Az 4/2026",
+      language: "cs",
+    });
+    expect(listingIdentityKey(czNssListingIdentity(row))).toBe(
+      "case-number:cs:1 Az 4/2026",
+    );
+  });
 
-    const rows = parseResultRows(html);
-    expect(rows).toHaveLength(2);
-    expect(rows[0]?.caseNumber).toBe("1 As 1/2024");
-    expect(rows[1]?.caseNumber).toBe("2 As 2/2024");
+  test("keys on the docket even where the portal states a document id", () => {
+    // The store holds no `sourceDocumentId` for this source, so a document
+    // identity would match no held row and read the archive as missing.
+    const row = parseResultRows(rowBlock(REGIONAL_ROW)).at(0);
+    expect(row?.documentId).toBe("783863");
+    expect(row === undefined ? null : czNssListingIdentity(row).type).toBe(
+      "case-number",
+    );
+  });
+
+  test("a row with no docket has nothing to key on", () => {
+    const row: ParsedRow = {
+      caseNumber: "",
+      decisionDate: undefined,
+      decisionType: undefined,
+      outcome: undefined,
+      documentUrl: undefined,
+      documentId: "784237",
+    };
+    expect(czNssListingIdentity(row)).toEqual({ type: "unidentifiable" });
+    expect(listingIdentityKey(czNssListingIdentity(row))).toBeNull();
+  });
+});
+
+// ── Listing walk ─────────────────────────────────────────
+
+describe("cz-nss listSlicePage", () => {
+  const originalFetch = globalThis.fetch;
+  let clock = 0;
+
+  beforeEach(() => {
+    // Every test starts past the cached session's TTL, so each one exercises
+    // session establishment rather than inheriting its predecessor's.
+    clock += 1;
+    setSystemTime(new Date(Date.UTC(2026, 7, 11, clock)));
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    setSystemTime();
+  });
+
+  test("establishes a session, then searches the day", async () => {
+    const { requests } = installStub({
+      search: [
+        htmlResponse(
+          searchPage({ statedCount: 2, rows: [MUNICIPAL_ROW, REGIONAL_ROW] }),
+        ),
+      ],
+    });
+
+    const listed = await reconciliation.listSlicePage({
+      slice: SLICE,
+      page: 0,
+    });
+
+    expect(requests.map(({ method, url }) => `${method} ${url}`)).toEqual([
+      `GET ${BASE_URL}/`,
+      `POST ${BASE_URL}/Home/Index`,
+    ]);
+    // The court's own date field, in its own format.
+    expect(requests.at(1)?.body).toContain("HodnotaDatumACasOd=10.06.2026");
+    expect(listed.totalPages).toBe(1);
+    expect(listed.items.map(({ identity }) => identity)).toEqual([
+      { type: "case-number", caseNumber: "1 Az 4/2026", language: "cs" },
+      { type: "case-number", caseNumber: "52 Af 4/2026", language: "cs" },
+    ]);
+  });
+
+  test("lists without fetching any document", async () => {
+    const { requests } = installStub({
+      search: [
+        htmlResponse(
+          searchPage({ statedCount: 2, rows: [MUNICIPAL_ROW, REGIONAL_ROW] }),
+        ),
+      ],
+    });
+
+    await reconciliation.listSlicePage({ slice: SLICE, page: 0 });
+
+    expect(
+      requests.filter(({ url }) => url.includes("/Dokument")),
+    ).toHaveLength(0);
+  });
+
+  test("payloads replay through buildDecision", async () => {
+    installStub({
+      search: [
+        htmlResponse(searchPage({ statedCount: 1, rows: [MUNICIPAL_ROW] })),
+      ],
+    });
+
+    const listed = await reconciliation.listSlicePage({
+      slice: SLICE,
+      page: 0,
+    });
+    const payload = listed.items.at(0)?.payload;
+    // The loop parks the payload as JSONB, so the round trip is the contract.
+    expect(throughJsonb(payload)).toEqual({
+      caseNumber: "1 Az 4/2026",
+      decisionDate: "10.06.2026",
+      // The results table states no decision type of its own, so the row's
+      // heuristic picks up the displayed reference, non-breaking spaces and
+      // all; the detail page's structured type overrides it in the build.
+      decisionType: "1 Az 4/2026 - 79",
+      documentUrl: `${BASE_URL}/DokumentDetail/Index/784237`,
+      documentId: "784237",
+    });
+  });
+
+  test("derives the page count from the court's own record count", async () => {
+    installStub({
+      search: [
+        htmlResponse(
+          searchPage({ statedCount: 50, rows: [MUNICIPAL_ROW, REGIONAL_ROW] }),
+        ),
+      ],
+    });
+
+    // 50 records at 40 per page is two pages, whatever one page renders.
+    expect(
+      (await reconciliation.listSlicePage({ slice: SLICE, page: 0 }))
+        .totalPages,
+    ).toBe(2);
+  });
+
+  test("asks the portal's own continuation endpoint for a later page", async () => {
+    const { requests } = installStub({
+      search: [
+        htmlResponse(searchPage({ statedCount: 50, rows: [MUNICIPAL_ROW] })),
+      ],
+      continuation: [htmlResponse(rowBlock(REGIONAL_ROW))],
+    });
+
+    const listed = await reconciliation.listSlicePage({
+      slice: SLICE,
+      page: 1,
+    });
+
+    const paginated = requests.at(-1);
+    expect(paginated?.url).toBe(`${BASE_URL}/Home/MyResTRowsCont`);
+    const body = new URLSearchParams(paginated?.body ?? "");
+    // The field names infiniteScroll.js posts, and the query decoded out of
+    // the page's JavaScript string literal.
+    expect(body.get("vyhledavaciPodminky")).toBe(CURR_PARAMS_DECODED);
+    expect(body.get("zobrazeniVysledkuId")).toBe("1");
+    expect(body.get("pageNum")).toBe("1");
+    expect(body.get("resultOrder")).toBe(CURR_SORT);
+    expect(listed.items.map(({ identity }) => identity)).toEqual([
+      { type: "case-number", caseNumber: "52 Af 4/2026", language: "cs" },
+    ]);
+  });
+
+  test("a day the court states no records for is empty, not short", async () => {
+    installStub({
+      search: [htmlResponse(searchPage({ statedCount: 0, rows: [] }))],
+    });
+
+    expect(
+      await reconciliation.listSlicePage({ slice: "2026-08-09", page: 0 }),
+    ).toEqual({ items: [], totalPages: 0 });
+  });
+
+  test("a failed search throws rather than reporting an empty day", async () => {
+    installStub({ search: [htmlResponse("upstream failure", 503)] });
+
+    expect(
+      await rejectionOf(
+        reconciliation.listSlicePage({ slice: SLICE, page: 0 }),
+      ),
+    ).toBeInstanceOf(Error);
+  });
+
+  test("a page stating no count throws rather than reporting an empty day", async () => {
+    // What the portal serves when the search silently no-ops: the form again,
+    // with no record count on it.
+    installStub({ search: [htmlResponse(SESSION_PAGE)] });
+
+    const error = await rejectionOf(
+      reconciliation.listSlicePage({ slice: SLICE, page: 0 }),
+    );
+    expect(error).toBeInstanceOf(Error);
+    expect(String(error)).toContain("stated no result count");
+  });
+
+  test("a page contradicting its own count throws", async () => {
+    installStub({
+      search: [
+        htmlResponse(searchPage({ statedCount: 0, rows: [MUNICIPAL_ROW] })),
+      ],
+    });
+
+    expect(
+      await rejectionOf(
+        reconciliation.listSlicePage({ slice: SLICE, page: 0 }),
+      ),
+    ).toBeInstanceOf(Error);
+  });
+
+  test("a results page with no pagination state throws", async () => {
+    installStub({
+      search: [
+        htmlResponse(
+          searchPage({
+            statedCount: 50,
+            rows: [MUNICIPAL_ROW],
+            withScript: false,
+          }),
+        ),
+      ],
+    });
+
+    expect(
+      await rejectionOf(
+        reconciliation.listSlicePage({ slice: SLICE, page: 1 }),
+      ),
+    ).toBeInstanceOf(Error);
+  });
+
+  test("a failed continuation request throws", async () => {
+    installStub({
+      search: [
+        htmlResponse(searchPage({ statedCount: 50, rows: [MUNICIPAL_ROW] })),
+      ],
+      continuation: [htmlResponse("upstream failure", 500)],
+    });
+
+    expect(
+      await rejectionOf(
+        reconciliation.listSlicePage({ slice: SLICE, page: 1 }),
+      ),
+    ).toBeInstanceOf(Error);
+  });
+});
+
+// ── Per-item build ───────────────────────────────────────
+
+describe("cz-nss buildDecision", () => {
+  const originalFetch = globalThis.fetch;
+  let clock = 100;
+
+  beforeEach(() => {
+    clock += 1;
+    setSystemTime(new Date(Date.UTC(2026, 7, 11, clock)));
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    setSystemTime();
+  });
+
+  const listedRow = async (): Promise<unknown> => {
+    installStub({
+      search: [
+        htmlResponse(searchPage({ statedCount: 1, rows: [MUNICIPAL_ROW] })),
+      ],
+    });
+    const listed = await reconciliation.listSlicePage({
+      slice: SLICE,
+      page: 0,
+    });
+    const payload = listed.items.at(0)?.payload;
+    // Through JSON, because that is how the loop hands a payload back.
+    return throughJsonb(payload);
+  };
+
+  test("builds a decision from a listed payload", async () => {
+    const payload = await listedRow();
+    installStub({ search: [] });
+
+    const built = await reconciliation.buildDecision(payload);
+
+    expect(built.type).toBe("built");
+    if (built.type !== "built") {
+      return;
+    }
+    expect(built.decision.caseNumber).toBe("1 Az 4/2026");
+    expect(built.decision.language).toBe("cs");
+    expect(built.decision.court).toBe("Nejvyšší správní soud");
+    expect(built.decision.ecli).toBe("ECLI:CZ:NSS:2026:1.Az.4.2026.79");
+    expect(built.decision.sourceDocumentId).toBeUndefined();
+    expect(built.decision.fulltext ?? "").not.toBe("");
+  });
+
+  test("refuses to write a row whose document the court did not serve", async () => {
+    const payload = await listedRow();
+    installStub({ search: [], documentStatus: 404 });
+
+    // Deliberately not `built`: a detail-less row would make the identity held
+    // and take the document out of every later reconciliation.
+    expect((await reconciliation.buildDecision(payload)).type).toBe(
+      "detail-unavailable",
+    );
+  });
+
+  test("refuses a row that names no document at all", async () => {
+    installStub({ search: [] });
+
+    expect(
+      (
+        await reconciliation.buildDecision({
+          caseNumber: "1 Az 4/2026",
+          decisionDate: "10.06.2026",
+        })
+      ).type,
+    ).toBe("detail-unavailable");
+  });
+
+  test("reports a payload it no longer recognises as unkeyable", async () => {
+    installStub({ search: [] });
+
+    for (const payload of [
+      null,
+      "1 Az 4/2026",
+      { documentId: "784237" },
+      { caseNumber: 4, documentId: "784237" },
+      { caseNumber: "1 Az 4/2026", documentId: 784_237 },
+    ]) {
+      // oxlint-disable-next-line no-await-in-loop -- one assertion per shape; nothing here does I/O
+      expect((await reconciliation.buildDecision(payload)).type).toBe(
+        "unkeyable",
+      );
+    }
+  });
+
+  test("the crawl keeps the row the reconciliation refuses", async () => {
+    installStub({ search: [], documentStatus: 404 });
+    const row = parseResultRows(rowBlock(MUNICIPAL_ROW)).at(0);
+    expect(row).toBeDefined();
+    if (row === undefined) {
+      return;
+    }
+
+    const built = await buildCzNssDecision({
+      row,
+      session: { cookies: "", token: "token-for-tests", formFields: new Map() },
+      signal: AbortSignal.timeout(5000),
+    });
+
+    // Same call, one outcome, two dispositions: the crawl stores the decision
+    // this carries, the reconciliation drops it.
+    expect(built.type).toBe("detail-unavailable");
+    expect(built.decision.caseNumber).toBe("1 Az 4/2026");
   });
 });

--- a/apps/api/src/handlers/case-law/ingestion/adapters/cz-nss.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/cz-nss.ts
@@ -77,7 +77,7 @@ const CZ_NSS_COURT = "Nejvyšší správní soud";
  * assumed: a day-filtered search stating 50 records renders 40 rows inline and
  * serves the remaining 10 as the next page.
  */
-const RESULTS_PER_PAGE = 40;
+export const CZ_NSS_RESULTS_PER_PAGE = 40;
 
 /**
  * How many records the court says its own search matched, as the results page
@@ -971,11 +971,21 @@ export const CZ_NSS_FIRST_SLICE = "2003-02-04";
 /**
  * Days near the tip that the reconciliation re-walks on a fast cadence.
  *
- * A slice is the decision date, and the portal posts a decision some time
- * after it is handed down, so the tip window is where the newest dates fill
- * in. A fortnight keeps the fast lane a fixed, small amount of work; a date
- * that fills in later is reached by the ledger's standing re-check of short
- * slices and by the historical sweep.
+ * A slice is the decision date, not the date the portal published it, and the
+ * portal posts a decision some time after it is handed down. So the tip window
+ * is where the newest dates fill in, and a fortnight keeps the fast lane a
+ * fixed, small amount of work.
+ *
+ * What that does NOT cover, stated plainly rather than assumed away: a
+ * decision published more than this window after its decision date lands in a
+ * slice the loop has already walked and recorded complete. The ledger's
+ * standing re-check only revisits rows recorded short, and the historical
+ * sweep only reaches slices never surveyed, so neither returns to it; the
+ * crawl cannot either, since its date cursor is forward-only. Closing that
+ * needs a bounded periodic resurvey of settled slices in
+ * `reconciliation-plan.ts`, which is engine-level and applies to every
+ * date-sliced source, not something this adapter can decide for itself.
+ * Widening the window here would only move the boundary, not remove it.
  */
 const CZ_NSS_TIP_WINDOW_DAYS = 14;
 
@@ -1074,6 +1084,11 @@ const listCzNssSlicePage = async ({
   const search = await executeSearch(session, slice, effectiveSignal);
 
   if (search.statedCount === null) {
+    // A 200 that is not a results page is what an expired ASP.NET session
+    // looks like: the portal re-renders the unsubmitted form. Dropping the
+    // session turns one expiry into one failed request instead of ten minutes
+    // of them.
+    invalidateSession();
     throw new AdapterFetchError({
       message: `NSS stated no result count for ${slice}`,
       adapterKey: ADAPTER_KEYS.CZ_NSS,
@@ -1097,6 +1112,10 @@ const listCzNssSlicePage = async ({
 
   const { continuation } = search;
   if (continuation === undefined) {
+    // Same reasoning as the missing count: a results page always carries the
+    // state its own infinite scroll pages with, so a page without it is not
+    // one the current session produced.
+    invalidateSession();
     throw new AdapterFetchError({
       message: `NSS results for ${slice} carried no pagination state`,
       adapterKey: ADAPTER_KEYS.CZ_NSS,
@@ -1117,12 +1136,33 @@ const listCzNssSlicePage = async ({
           }),
         );
 
+  // How many rows this page must carry, from the count the portal stated for
+  // the whole day. A short page is refused rather than returned, because the
+  // engine measures a slice by the identities the walk produced: a page that
+  // quietly came back empty (the continuation endpoint answers 200 with no
+  // body when it does not recognise the query) or that a changed table markup
+  // parsed only part of would undercount `reported`, and an undercounted
+  // `reported` reads as a fully collected day and settles it forever. Left
+  // unwritten, the day keeps its previous row and the failure surfaces in the
+  // loop's tally.
+  const expectedRows = Math.min(
+    CZ_NSS_RESULTS_PER_PAGE,
+    search.statedCount - page * CZ_NSS_RESULTS_PER_PAGE,
+  );
+  if (rows.length < expectedRows) {
+    throw new AdapterFetchError({
+      message: `NSS page ${page} of ${slice} carried ${rows.length} of the ${expectedRows} rows its stated count of ${search.statedCount} requires`,
+      adapterKey: ADAPTER_KEYS.CZ_NSS,
+      cursor: slice,
+    });
+  }
+
   return {
     items: rows.map((row) => ({
       identity: czNssListingIdentity(row),
       payload: row,
     })),
-    totalPages: Math.ceil(search.statedCount / RESULTS_PER_PAGE),
+    totalPages: Math.ceil(search.statedCount / CZ_NSS_RESULTS_PER_PAGE),
   };
 };
 
@@ -1351,7 +1391,7 @@ export const czNssAdapter = defineSourceAdapter({
         }
 
         // Determine next cursor
-        if (rows.length >= RESULTS_PER_PAGE) {
+        if (rows.length >= CZ_NSS_RESULTS_PER_PAGE) {
           // More pages for this date
           return {
             decisions,

--- a/apps/api/src/handlers/case-law/ingestion/adapters/cz-nss.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/cz-nss.ts
@@ -13,7 +13,10 @@ import {
 import type {
   EmptyAst,
   IngestionResult,
-  SliceCoverage,
+  ListingIdentity,
+  ReconciliationBuildOutcome,
+  ReconciliationSlicePage,
+  ReconciliationSlicePageOptions,
 } from "@/api/handlers/case-law/ingestion/adapter";
 import {
   INGESTION_USER_AGENT,
@@ -23,10 +26,11 @@ import {
   stripHtml,
 } from "@/api/handlers/case-law/ingestion/adapters/utils";
 import { parseNssDecisionHtml } from "@/api/handlers/case-law/ingestion/parsers/cz-nss";
-import { addUtcDays } from "@/api/lib/dates";
+import { addUtcDays, isoCalendarDay, toUtcDateString } from "@/api/lib/dates";
 import { AdapterFetchError } from "@/api/lib/errors/tagged-errors";
 import { fetchWithTimeout } from "@/api/lib/fetch";
 import { logger } from "@/api/lib/observability/logger";
+import { isRecord } from "@/api/lib/type-guards";
 
 /**
  * Czech Supreme Administrative Court adapter.
@@ -44,45 +48,67 @@ import { logger } from "@/api/lib/observability/logger";
  *
  * Cursor format: "YYYY-MM-DD:page" where page is 0-indexed.
  * A null cursor starts 30 days ago at page 0.
+ *
+ * The search is addressed by decision date and answers with the court's own
+ * record count for it, which is what makes this source reconcilable: a day can
+ * be listed on its own, without the crawl cursor ever reaching it. See
+ * `reconciliation` at the bottom of this file.
  */
 
 const BASE_URL = "https://vyhledavac.nssoud.cz";
-const RESULTS_PER_PAGE = 20;
+
+/** The only language this source publishes; half of the stored identity. */
+const CZ_NSS_LANGUAGE = "cs";
 
 /**
- * How many records the court says its own search matched.
+ * The court every row is stored under.
  *
- * The count is grouped ("1 234"), so digit runs may be separated by
- * spaces. `(?:\s\d+)*` keeps the separator and the digits disjoint; a
- * `[\d\s]*` class would overlap the `\s+` that follows, letting the
- * engine re-split every trailing space and costing time quadratic in the
- * length of the page.
- *
- * Read from a date-filtered search this is the day's expected total, which
- * is what makes a partial crawl detectable rather than silent.
+ * Coarser than the portal, which also carries the regional and city
+ * administrative courts whose judgments the NSS reviews (a single day's
+ * listing mixes `1 Az 4/2026` of the Městský soud v Praze with `52 Af 4/2026`
+ * of the Krajský soud v Hradci Králové). Recording that distinction is a
+ * source-metadata migration, not something the listing walk may decide.
  */
-const RESULT_COUNT_PATTERNS = [
-  /Nalezeno\s+(?<count>\d+(?:\s\d+)*)\s+záznam/iu,
-  /Celkem\s+(?<count>\d+(?:\s\d+)*)\s+záznam/iu,
-  /(?<!\d)(?<count>\d+(?:\s\d+)*)\s+výsledk/iu,
-  /resCount[^>]*>(?<count>\d[\d\s]*)</iu,
-  /myResCount[^>]*>(?<count>\d[\d\s]*)</iu,
-  /pocetZaznamu[^>]*>(?<count>\d[\d\s]*)</iu,
-];
+const CZ_NSS_COURT = "Nejvyšší správní soud";
 
-const reportedResultCount = (html: string): number | null => {
-  for (const pattern of RESULT_COUNT_PATTERNS) {
-    const match = pattern.exec(html);
-    const raw = match?.groups?.["count"];
-    if (raw === undefined) {
-      continue;
-    }
-    const parsed = Number.parseInt(raw.replace(/\s/gu, ""), 10);
-    if (!Number.isNaN(parsed) && parsed > 0) {
-      return parsed;
-    }
+/**
+ * Results the portal renders per page, matching the page size its own
+ * infinite-scroll script requests. Read from the live search rather than
+ * assumed: a day-filtered search stating 50 records renders 40 rows inline and
+ * serves the remaining 10 as the next page.
+ */
+const RESULTS_PER_PAGE = 40;
+
+/**
+ * How many records the court says its own search matched, as the results page
+ * states it: `<h6>Počet nalezených záznamů: 50</h6>`.
+ *
+ * Anchored on the label's ASCII-safe stem and the colon that precedes the
+ * number, because the page mixes literal Czech text with HTML entities and
+ * only the stem is stable under both. The `{0,20}` bound keeps the label span
+ * finite, and `[^:<]` stops it crossing into another tag or another colon.
+ *
+ * The count is grouped ("1 234"), so digit runs may be separated by spaces.
+ * `(?:\s\d+)*` keeps the separator and the digits disjoint; a `[\d\s]*` class
+ * would overlap the `\s+` that follows, letting the engine re-split every
+ * trailing space and costing time quadratic in the length of the page.
+ */
+const RESULT_COUNT_PATTERN = /nalezen[^:<]{0,20}:\s*(?<count>\d+(?:\s\d+)*)/iu;
+
+/**
+ * The count the page states, or `null` where it states none.
+ *
+ * Zero is an answer, not an absence: a day the court matched nothing for says
+ * so, and callers that must tell an empty slice from an unreadable page depend
+ * on the difference.
+ */
+const statedResultCount = (html: string): number | null => {
+  const raw = RESULT_COUNT_PATTERN.exec(html)?.groups?.["count"];
+  if (raw === undefined) {
+    return null;
   }
-  return null;
+  const parsed = Number.parseInt(raw.replace(/\s/gu, ""), 10);
+  return Number.isNaN(parsed) ? null : parsed;
 };
 
 /** Default lookback when no cursor is provided. */
@@ -147,24 +173,56 @@ const extractAntiforgeryToken = (html: string): string | undefined =>
   extractHiddenField(html, "__RequestVerificationToken");
 
 /**
- * Extract the currParams value from the search results page.
- * This is a URL-encoded string that the server needs for
- * pagination via MyResTRowsCont.
+ * Decode the `\uXXXX` escapes a JavaScript string literal carries.
+ *
+ * The results page hands its pagination state to `infiniteScroll.js` inside
+ * single-quoted literals in which every double quote is escaped. The browser
+ * posts the decoded value; anything else posts a query the server does not
+ * recognise and answers with an empty body, which reads as a finished day.
  */
-const extractCurrParams = (html: string): string | undefined => {
-  // currParams is passed to the JavaScript pagination function
-  const match = /currParams\s*[:=]\s*["'](?<value>[^"']+)["']/u.exec(html);
-  const value = match?.groups?.["value"];
-  if (value) {
-    try {
-      return decodeURIComponent(value);
-    } catch {
-      return value;
-    }
-  }
+const unescapeJsStringLiteral = (value: string): string =>
+  value.replace(/\\u(?<hex>[0-9a-fA-F]{4})/gu, (_match, hex: string) =>
+    String.fromCodePoint(Number.parseInt(hex, 16)),
+  );
 
-  // Fallback: look for it as a hidden field
-  return extractHiddenField(html, "currParams");
+/** Read a `var name = '...';` initializer out of the page's inline script. */
+const extractScriptString = (
+  html: string,
+  name: string,
+): string | undefined => {
+  const match = new RegExp(
+    `var\\s+${name}\\s*=\\s*'(?<value>[^']*)'`,
+    "u",
+  ).exec(html);
+  const value = match?.groups?.["value"];
+  return value === undefined ? undefined : unescapeJsStringLiteral(value);
+};
+
+/**
+ * Everything `/Home/MyResTRowsCont` needs to serve the next page of a search.
+ *
+ * The field names are the ones `infiniteScroll.js` posts, and the whole query
+ * travels in `conditions`: the endpoint reconstructs the search from the body
+ * rather than from session state, so a page can be asked for without replaying
+ * the search that first produced it.
+ */
+type ListingContinuation = {
+  /** `currParams`: the search conditions, including the date range. */
+  conditions: string;
+  /** `currViewId`: which result view the rows are rendered in. */
+  viewId: string;
+  /** `currSort`: the ORDER BY the first page was rendered with. */
+  order: string;
+};
+
+const extractContinuation = (html: string): ListingContinuation | undefined => {
+  const conditions = extractScriptString(html, "currParams");
+  const viewId = extractScriptString(html, "currViewId");
+  const order = extractScriptString(html, "currSort");
+  if (conditions === undefined || viewId === undefined || order === undefined) {
+    return undefined;
+  }
+  return { conditions, viewId, order };
 };
 
 /**
@@ -242,7 +300,14 @@ const todayIso = (): string => {
   return iso ?? "1970-01-01";
 };
 
-type ParsedRow = {
+/**
+ * One row of the portal's own results table.
+ *
+ * Flat and JSON-serializable on purpose: the reconciliation loop parks a
+ * listed item verbatim and replays it into `buildDecision` days later, so
+ * anything a row carries has to survive a round trip through JSONB.
+ */
+export type ParsedRow = {
   caseNumber: string;
   decisionDate: string | undefined;
   decisionType: string | undefined;
@@ -257,8 +322,12 @@ type ParsedRow = {
  *
  * The 2025 redesign renders results as <tbody> blocks
  * with citation <a title="Citace: ... čj. X"> elements.
+ *
+ * Exported so the crawl, the listing walk and their tests read one parser:
+ * a second copy of these patterns would certify itself rather than the
+ * adapter.
  */
-const parseResultRows = (html: string): ParsedRow[] => {
+export const parseResultRows = (html: string): ParsedRow[] => {
   const rows: ParsedRow[] = [];
 
   const tbodyPattern = /<tbody>(?<block>[\s\S]*?)<\/tbody>/giu;
@@ -374,7 +443,7 @@ const fetchDecisionContent = async (
         const parsed = parseNssDecisionHtml({
           caseNumber: row.caseNumber,
           ecli: detail.ecli,
-          court: "Nejvyšší správní soud",
+          court: CZ_NSS_COURT,
           decisionDate: (() => {
             if (detail.decisionDate) {
               return parseCeDate(detail.decisionDate);
@@ -561,9 +630,9 @@ const rowToResult = (
   return {
     caseNumber: row.caseNumber,
     ecli: detail.ecli,
-    court: "Nejvyšší správní soud",
+    court: CZ_NSS_COURT,
     country: "CZE",
-    language: "cs",
+    language: CZ_NSS_LANGUAGE,
     decisionDate: (() => {
       if (detail.decisionDate) {
         return parseCeDate(detail.decisionDate);
@@ -581,7 +650,7 @@ const rowToResult = (
     documentUrl: row.documentUrl,
     metadata: {
       caseNumber: row.caseNumber,
-      court: "Nejvyšší správní soud" as const,
+      court: CZ_NSS_COURT,
       ecli: detail.ecli,
       judge: detail.judge,
       senate: detail.senate,
@@ -682,12 +751,6 @@ const invalidateSession = () => {
   cachedSession = null;
 };
 
-/**
- * Execute a search for a specific date by submitting the
- * form to /Home/Index with the date range set to one day.
- *
- * Returns the results HTML and the currParams for pagination.
- */
 /** Date field paths in the vyhledavaciSekce form model. */
 const DATE_FROM_FIELD =
   "vyhledavaciSekce[1].vyhledavaciPodminka[0]" +
@@ -696,11 +759,29 @@ const DATE_TO_FIELD =
   "vyhledavaciSekce[1].vyhledavaciPodminka[0]" +
   ".vyhledavaciPodminkaHodnota[0].HodnotaDatumACasDo";
 
+/**
+ * What one day-filtered search answered with.
+ *
+ * `statedCount` is the court's own record count for the day and `null` where
+ * the page states none — the difference between a day that holds nothing and a
+ * page that is not a results page at all.
+ */
+type SearchResult = {
+  html: string;
+  continuation: ListingContinuation | undefined;
+  statedCount: number | null;
+};
+
+/**
+ * Execute a search for a specific date by submitting the form to /Home/Index
+ * with the date range set to one day. The response carries the first page of
+ * results inline, plus the state the remaining pages are requested with.
+ */
 const executeSearch = async (
   session: SessionState,
   date: string,
   signal: AbortSignal,
-): Promise<{ html: string; currParams: string | undefined }> => {
+): Promise<SearchResult> => {
   const czDate = formatCzDate(parseCursorDate(date));
 
   const formData = new URLSearchParams();
@@ -744,27 +825,42 @@ const executeSearch = async (
   }
 
   const html = await response.text();
-  const currParams = extractCurrParams(html);
 
-  return { html, currParams };
+  return {
+    html,
+    continuation: extractContinuation(html),
+    statedCount: statedResultCount(html),
+  };
+};
+
+type FetchResultPageOptions = {
+  session: SessionState;
+  continuation: ListingContinuation;
+  /** The date being searched; error context only. */
+  date: string;
+  /** 0-indexed page within the day. */
+  page: number;
+  signal: AbortSignal;
 };
 
 /**
- * Fetch a specific page of results using the currParams
- * obtained from the initial search.
- *
- * @param date - The date being searched (for error context)
+ * Fetch one page of results beyond the first, exactly as the portal's own
+ * infinite scroll does: the field names, and the whole search query in the
+ * body. The endpoint answers a body-only request, so a page is reachable
+ * without the session that first ran the search.
  */
-const fetchResultPage = async (
-  session: SessionState,
-  currParams: string,
-  date: string,
-  page: number,
-  signal: AbortSignal,
-): Promise<string> => {
+const fetchResultPage = async ({
+  continuation,
+  date,
+  page,
+  session,
+  signal,
+}: FetchResultPageOptions): Promise<string> => {
   const formData = new URLSearchParams();
-  formData.set("currParams", currParams);
-  formData.set("page", String(page));
+  formData.set("vyhledavaciPodminky", continuation.conditions);
+  formData.set("zobrazeniVysledkuId", continuation.viewId);
+  formData.set("pageNum", String(page));
+  formData.set("resultOrder", continuation.order);
 
   const response = await fetchWithTimeout(`${BASE_URL}/Home/MyResTRowsCont`, {
     method: "POST",
@@ -791,6 +887,293 @@ const fetchResultPage = async (
   }
 
   return await response.text();
+};
+
+// ── Shared build path ────────────────────────────────────
+
+const EMPTY_CONTENT: DecisionContent = {
+  fulltext: undefined,
+  documentAst: undefined,
+  sourceRaw: undefined,
+};
+
+/**
+ * What building one listed row produced.
+ *
+ * `detail-unavailable` still carries the decision the listing alone describes,
+ * because the two callers dispose of it differently: the crawl's cursor moves
+ * past this document either way, so a listing-only row is worth more to it
+ * than nothing, while the reconciliation must refuse it — a detail-less row
+ * would make the identity held and take the document out of every later
+ * reconciliation.
+ */
+export type CzNssBuildResult =
+  | { type: "built"; decision: IngestionResult }
+  | { type: "detail-unavailable"; decision: IngestionResult };
+
+type BuildCzNssDecisionOptions = {
+  row: ParsedRow;
+  session: SessionState;
+  signal: AbortSignal;
+};
+
+/**
+ * Build one decision from a result row, reading the court's detail page and
+ * document for it. Shared by the crawl and the reconciliation walk so neither
+ * can parse or enrich a row differently from the other.
+ */
+export const buildCzNssDecision = async ({
+  row,
+  session,
+  signal,
+}: BuildCzNssDecisionOptions): Promise<CzNssBuildResult> => {
+  const { documentId } = row;
+  if (documentId === undefined || documentId.length === 0) {
+    // The row names no document, so nothing can be read for it — now or on
+    // any later attempt. Not `unkeyable`: the docket is there and the ingest
+    // would store it, which is exactly why the reconciliation must not.
+    return {
+      type: "detail-unavailable",
+      decision: rowToResult(row, EMPTY_CONTENT, EMPTY_DETAIL),
+    };
+  }
+
+  const detail = await fetchDetailMetadata(documentId, session, signal);
+  const content = await fetchDecisionContent(
+    documentId,
+    row,
+    detail,
+    session,
+    signal,
+  );
+  const decision = rowToResult(row, content, detail);
+
+  // Both document endpoints answered with nothing usable. The metadata row is
+  // still a decision to the crawl; to the reconciliation it is a document that
+  // has not been read yet.
+  return content.sourceRaw === undefined && content.fulltext === undefined
+    ? { type: "detail-unavailable", decision }
+    : { type: "built", decision };
+};
+
+// ── Reconciliation ───────────────────────────────────────
+
+/**
+ * Earliest decision date the portal publishes, and so the oldest slice the
+ * historical sweep walks back to.
+ *
+ * Determined from the source itself rather than from the court's founding
+ * date: the NSS took up its work on 1 January 2003, but the portal states no
+ * records at all for any range ending 3 February 2003, and four for this day.
+ */
+export const CZ_NSS_FIRST_SLICE = "2003-02-04";
+
+/**
+ * Days near the tip that the reconciliation re-walks on a fast cadence.
+ *
+ * A slice is the decision date, and the portal posts a decision some time
+ * after it is handed down, so the tip window is where the newest dates fill
+ * in. A fortnight keeps the fast lane a fixed, small amount of work; a date
+ * that fills in later is reached by the ledger's standing re-check of short
+ * slices and by the historical sweep.
+ */
+const CZ_NSS_TIP_WINDOW_DAYS = 14;
+
+/**
+ * Ceiling for one listing request when the loop supplies no signal. The engine
+ * always does; this only keeps a direct caller from hanging on the court.
+ */
+const CZ_NSS_LISTING_TIMEOUT_MS = 60_000;
+
+/**
+ * The identity the ingest would store for this listing row.
+ *
+ * The docket and the language, never the portal's `documentId`: this adapter
+ * emits no `sourceDocumentId`, so every row it has ever written is keyed on
+ * `(caseNumber, language)` with a null document id. Keying the listing on the
+ * id the portal does supply would match no held row at all, and the loop would
+ * read the entire archive as missing.
+ *
+ * The cost of that is real. The portal carries the regional and city
+ * administrative courts alongside the NSS, and their dockets are numbered per
+ * court, so one `(caseNumber, "cs")` can name decisions of different courts;
+ * the sheet number that would separate two rulings in the same file is also
+ * dropped from the docket, since a citation names the docket alone. Both
+ * collapse several published documents onto one stored row. Recovering them is
+ * an identity migration of the source (adopt the portal's document id as
+ * `sourceDocumentId`, with the deterministic `/DokumentDetail/Index/{id}` URL
+ * as the `legacySourceUrls` hint that attaches it to the right null-id row),
+ * not something a reconciliation pass may decide on its own: until the stored
+ * rows carry that id, this is what "held" means.
+ */
+export const czNssListingIdentity = (row: ParsedRow): ListingIdentity =>
+  row.caseNumber.length === 0
+    ? { type: "unidentifiable" }
+    : {
+        type: "case-number",
+        caseNumber: row.caseNumber,
+        language: CZ_NSS_LANGUAGE,
+      };
+
+/**
+ * A reconciliation slice for this source is one UTC decision day, which is
+ * exactly what the portal's search is addressed by — the crawl already queries
+ * it a day at a time. `YYYY-MM-DD` sorts lexicographically in chronological
+ * order, which is the ordering the ledger relies on.
+ */
+const czNssDayStart = (slice: string): Date => {
+  const day = isoCalendarDay(slice);
+  if (day === null || day !== slice) {
+    panic(`cz-nss slice is not a UTC calendar day: ${slice}`);
+  }
+  return new Date(`${day}T00:00:00.000Z`);
+};
+
+const czNssStepSlice = (slice: string, days: number): string =>
+  toUtcDateString(addUtcDays(czNssDayStart(slice), days));
+
+const czNssNextSlice = (slice: string): string | null => {
+  const next = czNssStepSlice(slice, 1);
+  return next > todayIso() ? null : next;
+};
+
+const czNssPreviousSlice = (slice: string): string | null => {
+  const previous = czNssStepSlice(slice, -1);
+  return previous < CZ_NSS_FIRST_SLICE ? null : previous;
+};
+
+/**
+ * One page of the portal's own listing for a decision day, with no detail or
+ * document fetches.
+ *
+ * Self-sufficient by construction: it establishes or reuses the session and
+ * replays the day's search itself, because the loop calls it one page at a
+ * time and carries nothing between the calls.
+ *
+ * A failed request is thrown, never flattened into an empty page. The crawl
+ * can afford to read an unreadable page as "nothing here" because a cursor
+ * that moves on can be walked again; a ledger row cannot, since an outage
+ * recorded as an empty day makes that day settled and it is never revisited.
+ * So only the court's own count answers what a day holds: `Počet nalezených
+ * záznamů: 0` is an empty slice, and everything else — a non-2xx, a session
+ * page served instead of results, a results page stating no count — is an
+ * error the engine retries on a later pass.
+ */
+const listCzNssSlicePage = async ({
+  page,
+  signal,
+  slice,
+}: ReconciliationSlicePageOptions): Promise<ReconciliationSlicePage> => {
+  // Refuse a slice this adapter cannot have produced before it reaches the
+  // date formatter, which would silently query some other day for it.
+  czNssDayStart(slice);
+  const effectiveSignal =
+    signal ?? AbortSignal.timeout(CZ_NSS_LISTING_TIMEOUT_MS);
+
+  const session = await getSession(effectiveSignal);
+  const search = await executeSearch(session, slice, effectiveSignal);
+
+  if (search.statedCount === null) {
+    throw new AdapterFetchError({
+      message: `NSS stated no result count for ${slice}`,
+      adapterKey: ADAPTER_KEYS.CZ_NSS,
+      cursor: slice,
+    });
+  }
+
+  const firstPageRows = parseResultRows(search.html);
+  if (search.statedCount === 0) {
+    if (firstPageRows.length > 0) {
+      // The page contradicts itself, so neither number can be trusted for a
+      // ledger row. Refused rather than resolved in either direction.
+      throw new AdapterFetchError({
+        message: `NSS stated no records for ${slice} while rendering ${firstPageRows.length}`,
+        adapterKey: ADAPTER_KEYS.CZ_NSS,
+        cursor: slice,
+      });
+    }
+    return { items: [], totalPages: 0 };
+  }
+
+  const { continuation } = search;
+  if (continuation === undefined) {
+    throw new AdapterFetchError({
+      message: `NSS results for ${slice} carried no pagination state`,
+      adapterKey: ADAPTER_KEYS.CZ_NSS,
+      cursor: slice,
+    });
+  }
+
+  const rows =
+    page === 0
+      ? firstPageRows
+      : parseResultRows(
+          await fetchResultPage({
+            continuation,
+            date: slice,
+            page,
+            session,
+            signal: effectiveSignal,
+          }),
+        );
+
+  return {
+    items: rows.map((row) => ({
+      identity: czNssListingIdentity(row),
+      payload: row,
+    })),
+    totalPages: Math.ceil(search.statedCount / RESULTS_PER_PAGE),
+  };
+};
+
+const isOptionalString = (value: unknown): value is string | undefined =>
+  value === undefined || typeof value === "string";
+
+/**
+ * Validate a payload the loop stored verbatim.
+ *
+ * Every field is checked, because the row is this adapter's whole listing
+ * observation: a parked payload that no longer matches what the parser
+ * produces has to be reported as unbuildable instead of parsed on faith. The
+ * optional fields are absent rather than `undefined` after a JSONB round trip,
+ * which is what {@link isOptionalString} accepts.
+ */
+const isCzNssListingRow = (value: unknown): value is ParsedRow =>
+  isRecord(value) &&
+  typeof value["caseNumber"] === "string" &&
+  isOptionalString(value["decisionDate"]) &&
+  isOptionalString(value["decisionType"]) &&
+  isOptionalString(value["outcome"]) &&
+  isOptionalString(value["documentUrl"]) &&
+  isOptionalString(value["documentId"]);
+
+const buildCzNssFromPayload = async (
+  payload: unknown,
+  signal?: AbortSignal,
+): Promise<ReconciliationBuildOutcome> => {
+  if (!isCzNssListingRow(payload)) {
+    return { type: "unkeyable" };
+  }
+  const effectiveSignal =
+    signal ?? AbortSignal.timeout(CZ_NSS_LISTING_TIMEOUT_MS);
+  const session = await getSession(effectiveSignal);
+  const built = await buildCzNssDecision({
+    row: payload,
+    session,
+    signal: effectiveSignal,
+  });
+  switch (built.type) {
+    case "built":
+      return { type: "built", decision: built.decision };
+    case "detail-unavailable":
+      // The decision the listing describes is deliberately dropped: storing it
+      // would make the identity held while its document stayed unread.
+      return { type: "detail-unavailable" };
+    default: {
+      const exhaustive: never = built;
+      return panic(`Unhandled NSS build result: ${JSON.stringify(exhaustive)}`);
+    }
+  }
 };
 
 /** Parse cursor string "YYYY-MM-DD:page" or null. */
@@ -872,17 +1255,30 @@ export const czNssAdapter = defineSourceAdapter({
         return null;
       }
 
-      const html = await response.text();
+      const count = statedResultCount(await response.text());
 
-      // The count is grouped ("1 234"), so digit runs may be separated
-      // by spaces. `(?:\s\d+)*` keeps the separator and the digits
-      // disjoint; a `[\d\s]*` class would overlap the `\s+` that
-      // follows, letting the engine re-split every trailing space and
-      // costing time quadratic in the length of the page.
-      return reportedResultCount(html);
+      // A zero here is not a corpus of nothing; it is a search that did not
+      // run. The benchmark reports nothing rather than a false floor.
+      return count === null || count === 0 ? null : count;
     } catch {
       return null;
     }
+  },
+
+  /**
+   * The portal lists each decision day independently of the crawl cursor, so
+   * what a day contains is answerable without re-crawling it: enumerate the
+   * day, key each row the way the ingest would, and compare against what is
+   * held.
+   */
+  reconciliation: {
+    firstSlice: CZ_NSS_FIRST_SLICE,
+    sliceOf: toUtcDateString,
+    nextSlice: czNssNextSlice,
+    previousSlice: czNssPreviousSlice,
+    tipWindowDays: CZ_NSS_TIP_WINDOW_DAYS,
+    listSlicePage: listCzNssSlicePage,
+    buildDecision: buildCzNssFromPayload,
   },
 
   async fetchPage(cursor, _config, signal) {
@@ -916,8 +1312,9 @@ export const czNssAdapter = defineSourceAdapter({
           effectiveSignal,
         );
 
-        if (!searchResult.currParams || searchResult.currParams === "[]") {
-          // No results for this date; advance to next day
+        const { continuation } = searchResult;
+        if (continuation === undefined || continuation.conditions === "[]") {
+          // Not a results page; advance to next day
           const next = nextDay(date);
           return {
             decisions: [],
@@ -925,59 +1322,36 @@ export const czNssAdapter = defineSourceAdapter({
           };
         }
 
-        let html: string;
-
-        if (page === 0) {
-          // Page 0 results are inline in the search response
-          html = searchResult.html;
-        } else {
-          html = await fetchResultPage(
-            session,
-            searchResult.currParams,
-            date,
-            page,
-            effectiveSignal,
-          );
-        }
+        // Page 0 results are inline in the search response.
+        const html =
+          page === 0
+            ? searchResult.html
+            : await fetchResultPage({
+                continuation,
+                date,
+                page,
+                session,
+                signal: effectiveSignal,
+              });
 
         const rows = parseResultRows(html);
         const decisions: IngestionResult[] = [];
 
         for (const row of rows) {
-          let detail: DetailMetadata = EMPTY_DETAIL;
-
-          if (row.documentId) {
-            // Fetch detail metadata first (needed by parser)
-            // oxlint-disable-next-line no-await-in-loop -- sequential per-row crawl against one court session; content fetch below depends on this detail
-            detail = await fetchDetailMetadata(
-              row.documentId,
-              session,
-              effectiveSignal,
-            );
-          }
-
-          let content: DecisionContent = {
-            fulltext: undefined,
-            documentAst: undefined,
-            sourceRaw: undefined,
-          };
-
-          if (row.documentId) {
-            // oxlint-disable-next-line no-await-in-loop -- sequential per-row crawl; consumes detail fetched above and shares one court session
-            content = await fetchDecisionContent(
-              row.documentId,
-              row,
-              detail,
-              session,
-              effectiveSignal,
-            );
-          }
-
-          decisions.push(rowToResult(row, content, detail));
+          // oxlint-disable-next-line no-await-in-loop -- sequential per-row crawl against one court session, paced by minRequestIntervalMs
+          const built = await buildCzNssDecision({
+            row,
+            session,
+            signal: effectiveSignal,
+          });
+          // The cursor moves past this document either way, so the crawl keeps
+          // the listing-only row an unreadable document still describes; only
+          // the reconciliation refuses it.
+          decisions.push(built.decision);
         }
 
         // Determine next cursor
-        if (rows.length >= RESULTS_PER_PAGE && searchResult.currParams) {
+        if (rows.length >= RESULTS_PER_PAGE) {
           // More pages for this date
           return {
             decisions,
@@ -985,39 +1359,17 @@ export const czNssAdapter = defineSourceAdapter({
           };
         }
 
-        // Day-completeness: the court states how many records its own
-        // search matched, so a partial crawl is measurable rather than
-        // inferred. Reported on the page that finishes the day, where the
-        // running total is known (see CLAUDE.md rule 15).
-        const reported = reportedResultCount(searchResult.html);
-        const dayCoverage: SliceCoverage | undefined =
-          reported === null
-            ? undefined
-            : {
-                slice: date,
-                reported,
-                collected: page * RESULTS_PER_PAGE + rows.length,
-              };
-
-        // A full page with no continuation token is not the end of the day
-        // — it is a day whose remainder is unreachable. Advancing here
-        // drops it permanently, because the date cursor only moves forward
-        // and nothing revisits a day once passed. Fail instead: the cursor
-        // is held and the day is retried.
-        if (rows.length >= RESULTS_PER_PAGE) {
-          throw new AdapterFetchError({
-            message: `NSS returned a full page for ${date} (page ${page}) without a continuation token; the rest of the day is unreachable`,
-            adapterKey: ADAPTER_KEYS.CZ_NSS,
-            cursor,
-          });
-        }
+        // No coverage row here: the reconciliation loop owns this source's
+        // ledger. It keys the same `(source, YYYY-MM-DD)` rows but counts
+        // something else — keyable identities listed against identities held,
+        // not items one crawl page walked — so a crawl-side write would
+        // overwrite the loop's answer with a different question's.
 
         // No more pages; advance to next day
         const next = nextDay(date);
         return {
           decisions,
           nextCursor: next <= today ? `${next}:0` : `${today}:0`,
-          ...(dayCoverage === undefined ? {} : { coverage: dayCoverage }),
         };
       },
       catch: adapterCatch(ADAPTER_KEYS.CZ_NSS, cursor),


### PR DESCRIPTION
Implements the `reconciliation` capability on the cz-nss adapter, and fixes two pre-existing listing defects that were prerequisites for walking a day end to end.

Slice = one UTC decision day (the unit the crawl already queries). `firstSlice = 2003-02-04`, probed from the source (every earlier range answers zero). `listSlicePage` is self-sufficient: it establishes the portal session on demand (the existing cached session helper) and replays the day's search itself, verified live that the continuation endpoint reconstructs the query from the request body on a fresh session. The count marker is the page's own `Počet nalezených záznamů: N`; zero is an empty slice, while a non-2xx, a session page served instead of results, a stated-zero page rendering rows, or a page stating no count all throw — an outage is never banked as a settled empty day.

The two fixed defects, both live-verified:
1. The result-count patterns matched nothing the portal renders, so `getTotalCount` always returned null and the crawl's coverage row was never written.
2. Pagination posted field names the endpoint ignores; the response was an empty 200, so the crawl read zero rows past the first page of every day and advanced — silently dropping the tail of any day larger than one page. The continuation now sends the fields the portal's own infinite-scroll script sends (verified: the missing rows return, zero overlap), and the page size constant matches the 40 the portal actually serves. The reconciliation capability this change adds is also the mechanism that will re-find the historically dropped rows.

Identity is `(caseNumber, cs)` — this source stores no publisher document id, so the listing must mirror the stored keys; the collapse that implies (per-court docket reuse across the aggregated administrative courts, sheet-number stripping) is documented at the rule as an identity migration, not changed here.

The crawl-side `SyncPage.coverage` emission for this source is removed: it upserted the same day-keyed ledger rows the reconciliation loop now owns while counting a different thing (items walked vs identities held). The mechanism itself stays for non-reconciled adapters.

Tests: 31 new; 191 across the adapter/parser/conformance/plan suites green.
