### PR TITLE
feat(case-law): cz-ns listing reconciliation capability

### DIFF
--- a/apps/api/src/handlers/case-law/ingestion/adapters/cz-ns-reconciliation.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/cz-ns-reconciliation.test.ts
@@ -428,6 +428,26 @@ describe("cz-ns listSlicePage", () => {
     expect(String(error)).toContain("50454");
   });
 
+  test("a counted size below the rows carried is refused too", async () => {
+    // A body contradicting itself: its rows are not the day it counted, and
+    // which of the two numbers is wrong is not knowable from here.
+    mockFetch({
+      listing: {
+        body: listingPageHtml({
+          rows: [
+            [UNID.FIRST, DOCKET.FIRST],
+            [UNID.SECOND, DOCKET.SECOND],
+          ],
+          shown: 2,
+          matched: 1,
+        }),
+      },
+    });
+
+    const error = await rejectionOf(listSlice("2026-07-01"));
+    expect(String(error)).toContain("counts 1 decisions and carries 2");
+  });
+
   test("a stated count the body does not carry is thrown", async () => {
     mockFetch({
       listing: {

--- a/apps/api/src/handlers/case-law/ingestion/adapters/cz-ns-reconciliation.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/cz-ns-reconciliation.test.ts
@@ -1,0 +1,566 @@
+/* eslint-disable typescript-eslint/promise-function-async -- fetch mock callbacks return Promise.resolve without being async */
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  setSystemTime,
+  test,
+} from "bun:test";
+
+import {
+  listingIdentityKey,
+  parseListingIdentityKey,
+} from "@/api/handlers/case-law/ingestion/adapter";
+import type { SourceReconciliation } from "@/api/handlers/case-law/ingestion/adapter";
+import {
+  CZ_NS_FIRST_SLICE,
+  buildCzNsDecision,
+  czNsAdapter,
+  czNsListingIdentity,
+} from "@/api/handlers/case-law/ingestion/adapters/cz-ns";
+import type { CzNsListingRow } from "@/api/handlers/case-law/ingestion/adapters/cz-ns";
+import { tipWindowSlices } from "@/api/handlers/case-law/ingestion/reconciliation-plan";
+import { asFetchMock } from "@/api/tests/helpers/test-tool-set";
+
+const reconciliation = ((): SourceReconciliation => {
+  const capability = czNsAdapter.reconciliation;
+  if (capability === undefined) {
+    throw new TypeError("cz-ns must declare the reconciliation capability");
+  }
+  return capability;
+})();
+
+// ── Production-shaped fixtures ──────────────────────────────
+//
+// The universal ids and dockets are the publisher's own, copied from the
+// search view: a 32-character uppercase hex id and a docket written the way
+// the court writes it, suffix and all.
+
+const UNID = {
+  FIRST: "05D11F4FB3ACC585C1258E27004D2F09",
+  SECOND: "137FECBC92321C61C1258E27004D2ECB",
+  THIRD: "2E70B2C9AF8044CFC1258E27004D2EF8",
+} as const;
+
+const DOCKET = {
+  FIRST: "30 Cdo 3000/2025",
+  SECOND: "29 ICdo 83/2026",
+  SUFFIXED: "21 Cdo 288/2026- III.",
+} as const;
+
+/** The anchor the search view prints for one result row. */
+const listingRowHtml = (unid: string, docket: string): string =>
+  `<tr><td class="td-short icons"><a href="/Judikatura/judikatura_ns.nsf/WebPrint/${unid}?openDocument"></td>` +
+  `<td class="td-short-wrap">Nejvyšší soud</td>` +
+  `<td class="td-short"><a class="odk" href="/Judikatura/judikatura_ns.nsf/WebSearch/${unid}?openDocument" >${docket}</a></td>` +
+  `<td class="td-short  category ">B  </td>` +
+  `<td class="td-shorter"><input type="checkbox" id="ids" name="ids" value="${unid}"></td></tr>`;
+
+type ListingPageOptions = {
+  rows: readonly (readonly [unid: string, docket: string])[];
+  /** The "z N zobrazovaných" number; omitted for a lone hit, as upstream. */
+  shown?: number | undefined;
+  /** The "(Podmínce vyhovuje: N )" number, printed only when truncated. */
+  matched?: number | undefined;
+};
+
+const listingPageHtml = ({
+  matched,
+  rows,
+  shown,
+}: ListingPageOptions): string => {
+  const header =
+    shown === undefined
+      ? ""
+      : `<h3 size="2">Výsledky 1 - ${rows.length} z ${shown} zobrazovaných dokumentů.${
+          matched === undefined ? "" : `  (Podmínce vyhovuje: ${matched} )`
+        }</h3>`;
+  return (
+    `<!DOCTYPE HTML><html><head><title>Vyhledávání - Nejvyšší soud</title></head><body>` +
+    `<div class="frame-container list-of-judgments"><div class="main_detail">${header}` +
+    `<table>${rows.map(([unid, docket]) => listingRowHtml(unid, docket)).join("")}</table>` +
+    `<ul class="pagination"></ul></div></div></body></html>`
+  );
+};
+
+/** What the publisher answers for a day it published nothing on. */
+const EMPTY_LISTING_HTML = `<!DOCTYPE HTML><html><body><div class="frame-container list-of-judgments"><div class="main_detail"><div class="list-intro-heading-actions"><h3 size="2">Nebyly nalezeny žádné výsledky vyhledávání.</h3></div><ul class="pagination">  </ul></div></div></body></html>`;
+
+/** A metadata row of the detail page, in the publisher's own markup. */
+const detailRowHtml = (label: string, value: string): string =>
+  `<tr valign="top"><td class="left-part" width="17%"><b><font face="Times New Roman">${label}:</font></b></td>` +
+  `<td class="right-part" width="83%"><b><font face="Times New Roman">${value}</font></b></td></tr>`;
+
+const DECISION_BODY =
+  "Nejvyšší soud rozhodl v senátě složeném z předsedy senátu JUDr. Pavla Horáka, Ph.D., " +
+  "ve věci žalobkyně proti žalované o zaplacení částky, vedené u Okresního soudu, " +
+  "takto: Dovolání se odmítá. Odůvodnění: Soud prvního stupně rozsudkem zamítl žalobu. " +
+  "JUDr. Pavel Horák, Ph.D.\npředseda senátu";
+
+const detailPageHtml = (docket: string): string => {
+  const rows = [
+    detailRowHtml("Datum rozhodnutí", "28. 5. 2026"),
+    detailRowHtml("Spisová značka", docket),
+    detailRowHtml("ECLI", "ECLI:CZ:NS:2026:30.CDO.3000.2025.1"),
+    detailRowHtml("Typ rozhodnutí", "ROZSUDEK"),
+    detailRowHtml("Heslo", "Dovolání"),
+    detailRowHtml("Kategorie rozhodnutí", "E"),
+  ].join("");
+  return `<!DOCTYPE HTML><html><body><table>${rows}</table><font face="Times New Roman">${DECISION_BODY}</font></body></html>`;
+};
+
+// ── Fetch mocking ───────────────────────────────────────────
+
+const originalFetch = globalThis.fetch;
+
+type MockOptions = {
+  listing?: { body: string; status?: number | undefined } | undefined;
+  detailStatus?: number | undefined;
+  printStatus?: number | undefined;
+};
+
+const requestedUrls: string[] = [];
+
+const mockFetch = ({ detailStatus, listing, printStatus }: MockOptions) => {
+  globalThis.fetch = asFetchMock((input: string | URL | Request) => {
+    const url = input instanceof Request ? input.url : String(input);
+    requestedUrls.push(url);
+    if (url.includes("SearchView")) {
+      return Promise.resolve(
+        new Response(listing?.body ?? "", {
+          status: listing?.status ?? 200,
+          headers: { "Content-Type": "text/html" },
+        }),
+      );
+    }
+    if (url.includes("/WebPrint/")) {
+      return Promise.resolve(
+        new Response("", {
+          status: printStatus ?? 404,
+          headers: { "Content-Type": "text/html" },
+        }),
+      );
+    }
+    if (url.includes("/WebSearch/")) {
+      return Promise.resolve(
+        new Response(detailPageHtml(DOCKET.FIRST), {
+          status: detailStatus ?? 200,
+          headers: { "Content-Type": "text/html" },
+        }),
+      );
+    }
+    return Promise.resolve(new Response("unexpected", { status: 500 }));
+  });
+};
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  requestedUrls.length = 0;
+});
+
+/**
+ * bun-types declares `.rejects.toBeInstanceOf` as void, so awaiting it trips
+ * type-aware lint; capture the rejection explicitly instead.
+ */
+const rejectionOf = async (promise: Promise<unknown>): Promise<unknown> =>
+  await promise.then(
+    () => null,
+    (error: unknown) => error,
+  );
+
+const listSlice = async (slice: string, page = 0) =>
+  await reconciliation.listSlicePage({ slice, page });
+
+// ── Slice arithmetic ────────────────────────────────────────
+
+describe("cz-ns reconciliation slices", () => {
+  beforeAll(() => {
+    setSystemTime(new Date("2026-08-11T09:30:00.000Z"));
+  });
+  afterAll(() => {
+    setSystemTime();
+  });
+
+  test("a slice is the UTC publication day, and sliceOf names the tip", () => {
+    expect(reconciliation.sliceOf(new Date("2026-08-11T23:59:59.999Z"))).toBe(
+      "2026-08-11",
+    );
+    expect(reconciliation.sliceOf(new Date("2026-08-12T00:00:00.000Z"))).toBe(
+      "2026-08-12",
+    );
+  });
+
+  test("stepping forward and back is a round trip, across month and leap-day boundaries", () => {
+    for (const slice of [
+      "2010-01-01",
+      "2019-12-31",
+      "2024-02-28",
+      "2024-02-29",
+      "2026-08-10",
+    ]) {
+      expect(
+        reconciliation.previousSlice(reconciliation.nextSlice(slice) ?? ""),
+      ).toBe(slice);
+    }
+    expect(reconciliation.nextSlice("2024-02-28")).toBe("2024-02-29");
+    expect(reconciliation.nextSlice("2023-02-28")).toBe("2023-03-01");
+  });
+
+  test("the walk is bounded by the first slice below and today above", () => {
+    expect(reconciliation.firstSlice).toBe(CZ_NS_FIRST_SLICE);
+    expect(reconciliation.previousSlice(CZ_NS_FIRST_SLICE)).toBeNull();
+    expect(reconciliation.previousSlice("2010-01-02")).toBe(CZ_NS_FIRST_SLICE);
+    expect(reconciliation.nextSlice("2026-08-11")).toBeNull();
+    expect(reconciliation.nextSlice("2026-08-10")).toBe("2026-08-11");
+  });
+
+  test("the bulk-load day the publisher cannot list sits below the first slice", () => {
+    // 2009-12-31 carries the whole legacy archive under one publication date,
+    // far past the window a single search addresses.
+    const bulkLoadDay = "2009-12-31";
+    expect(bulkLoadDay < reconciliation.firstSlice).toBe(true);
+    expect(reconciliation.previousSlice(reconciliation.firstSlice)).toBeNull();
+  });
+
+  test("walking forward yields slices in lexicographic order", () => {
+    const walked: string[] = [];
+    let cursor: string | null = "2026-07-28";
+    while (cursor !== null && walked.length < 20) {
+      walked.push(cursor);
+      cursor = reconciliation.nextSlice(cursor);
+    }
+    expect(walked).toEqual([...walked].toSorted());
+    expect(walked.at(-1)).toBe("2026-08-11");
+  });
+
+  test("the tip window is that many slices, newest first", () => {
+    const slices = tipWindowSlices(reconciliation, new Date());
+    expect(slices).toHaveLength(reconciliation.tipWindowDays);
+    expect(slices.at(0)).toBe("2026-08-11");
+    expect(slices).toEqual([...slices].toSorted().toReversed());
+  });
+
+  test("a slice that is not a UTC calendar day is refused", () => {
+    expect(() => reconciliation.nextSlice("2026-08")).toThrow();
+    expect(() => reconciliation.previousSlice("2026-02-30")).toThrow();
+    expect(() => reconciliation.nextSlice("11.08.2026")).toThrow();
+  });
+});
+
+// ── Identity ────────────────────────────────────────────────
+
+describe("czNsListingIdentity", () => {
+  test("keys on the docket and the language, never the universal id", () => {
+    const identity = czNsListingIdentity({
+      unid: UNID.FIRST,
+      caseNumber: DOCKET.FIRST,
+    });
+    expect(identity).toEqual({
+      type: "case-number",
+      caseNumber: DOCKET.FIRST,
+      language: "cs",
+    });
+    expect(listingIdentityKey(identity)).toBe(`case-number:cs:${DOCKET.FIRST}`);
+  });
+
+  test("keeps the docket exactly as the publisher writes it, suffix included", () => {
+    expect(
+      czNsListingIdentity({ unid: UNID.THIRD, caseNumber: DOCKET.SUFFIXED }),
+    ).toEqual({
+      type: "case-number",
+      caseNumber: DOCKET.SUFFIXED,
+      language: "cs",
+    });
+  });
+
+  test("a row missing either half is unidentifiable, matching what the crawl drops", () => {
+    expect(czNsListingIdentity({ unid: "", caseNumber: DOCKET.FIRST })).toEqual(
+      {
+        type: "unidentifiable",
+      },
+    );
+    expect(czNsListingIdentity({ unid: UNID.FIRST, caseNumber: "" })).toEqual({
+      type: "unidentifiable",
+    });
+    expect(
+      listingIdentityKey(czNsListingIdentity({ unid: "", caseNumber: "" })),
+    ).toBeNull();
+  });
+
+  test("every keyable identity round-trips through its key", () => {
+    for (const caseNumber of [DOCKET.FIRST, DOCKET.SECOND, DOCKET.SUFFIXED]) {
+      const identity = czNsListingIdentity({ unid: UNID.FIRST, caseNumber });
+      const key = listingIdentityKey(identity);
+      expect(key).not.toBeNull();
+      expect(parseListingIdentityKey(key ?? "")).toEqual(identity);
+    }
+  });
+
+  test("two documents under one docket collapse to one key, as the store does", () => {
+    const first = czNsListingIdentity({
+      unid: UNID.FIRST,
+      caseNumber: DOCKET.FIRST,
+    });
+    const second = czNsListingIdentity({
+      unid: UNID.SECOND,
+      caseNumber: DOCKET.FIRST,
+    });
+    expect(listingIdentityKey(first)).toBe(listingIdentityKey(second));
+  });
+});
+
+// ── listSlicePage ───────────────────────────────────────────
+
+describe("cz-ns listSlicePage", () => {
+  test("asks the publisher for exactly that day, in one request of the window", async () => {
+    mockFetch({
+      listing: {
+        body: listingPageHtml({
+          rows: [
+            [UNID.FIRST, DOCKET.FIRST],
+            [UNID.SECOND, DOCKET.SECOND],
+          ],
+          shown: 2,
+        }),
+      },
+    });
+
+    const listed = await listSlice("2026-07-01");
+
+    expect(listed.totalPages).toBe(1);
+    expect(listed.items.map(({ payload }) => payload)).toEqual([
+      { unid: UNID.FIRST, caseNumber: DOCKET.FIRST },
+      { unid: UNID.SECOND, caseNumber: DOCKET.SECOND },
+    ]);
+    expect(listed.items.map(({ identity }) => identity)).toEqual([
+      { type: "case-number", caseNumber: DOCKET.FIRST, language: "cs" },
+      { type: "case-number", caseNumber: DOCKET.SECOND, language: "cs" },
+    ]);
+
+    const url = requestedUrls.at(0) ?? "";
+    const query = new URL(url).searchParams.get("Query") ?? "";
+    expect(query).toBe(
+      "[datum_predani_na_web]>=01.07.2026 AND [datum_predani_na_web]<=01.07.2026",
+    );
+    expect(new URL(url).searchParams.get("Start")).toBe("1");
+    expect(new URL(url).searchParams.get("Count")).toBe("900");
+    expect(requestedUrls).toHaveLength(1);
+  });
+
+  test("asking the same slice twice asks the publisher the same question", async () => {
+    mockFetch({
+      listing: {
+        body: listingPageHtml({ rows: [[UNID.FIRST, DOCKET.FIRST]], shown: 1 }),
+      },
+    });
+
+    const first = await listSlice("2026-07-01");
+    const second = await listSlice("2026-07-01");
+
+    expect(second.items).toEqual(first.items);
+    expect(requestedUrls.at(1)).toBe(requestedUrls.at(0));
+  });
+
+  test("a payload survives being parked as JSON and read back", async () => {
+    mockFetch({
+      listing: {
+        body: listingPageHtml({
+          rows: [[UNID.FIRST, DOCKET.SUFFIXED]],
+          shown: 1,
+        }),
+      },
+    });
+
+    const listed = await listSlice("2026-07-01");
+    const parked = JSON.stringify(listed.items.at(0)?.payload);
+    const replayed: unknown = JSON.parse(parked);
+    expect(replayed).toEqual({ unid: UNID.FIRST, caseNumber: DOCKET.SUFFIXED });
+  });
+
+  test("a lone hit, which the publisher states no count for, still lists", async () => {
+    mockFetch({
+      listing: {
+        body: listingPageHtml({ rows: [[UNID.FIRST, DOCKET.FIRST]] }),
+      },
+    });
+
+    const listed = await listSlice("2026-07-01");
+    expect(listed.items).toHaveLength(1);
+    expect(listed.totalPages).toBe(1);
+  });
+
+  test("the publisher's own words for an empty day are an empty slice", async () => {
+    mockFetch({ listing: { body: EMPTY_LISTING_HTML } });
+
+    expect(await listSlice("2026-07-05")).toEqual({ items: [], totalPages: 0 });
+  });
+
+  test("a failed request is thrown, never read as an empty day", async () => {
+    mockFetch({ listing: { body: "", status: 503 } });
+
+    const error = await rejectionOf(listSlice("2026-07-01"));
+    expect(String(error)).toContain("503");
+  });
+
+  test("a body stating neither results nor emptiness is thrown", async () => {
+    mockFetch({ listing: { body: "<html><body>Údržba</body></html>" } });
+
+    const error = await rejectionOf(listSlice("2026-07-01"));
+    expect(String(error)).toContain("neither results nor emptiness");
+  });
+
+  test("a day past the window the publisher addresses is refused, not truncated", async () => {
+    // What 2009-12-31 answers: 900 rows printed, 50,454 matched.
+    const rows = Array.from({ length: 900 }, (_, index) => {
+      const suffix = index.toString(16).toUpperCase().padStart(4, "0");
+      return [
+        `${UNID.FIRST.slice(0, 28)}${suffix}`,
+        `30 Cdo ${index}/2009`,
+      ] as const;
+    });
+    mockFetch({
+      listing: { body: listingPageHtml({ rows, shown: 900, matched: 50_454 }) },
+    });
+
+    const error = await rejectionOf(listSlice("2026-07-01"));
+    expect(String(error)).toContain("50454");
+  });
+
+  test("a stated count the body does not carry is thrown", async () => {
+    mockFetch({
+      listing: {
+        body: listingPageHtml({
+          rows: [[UNID.FIRST, DOCKET.FIRST]],
+          shown: 40,
+        }),
+      },
+    });
+
+    const error = await rejectionOf(listSlice("2026-07-01"));
+    expect(String(error)).toContain("states 40 decisions and carries 1");
+  });
+
+  test("several rows under no stated count are thrown, not read as the day", async () => {
+    // The publisher omits the count for a lone hit and only for a lone hit,
+    // so this is how a change to the listing markup has to surface.
+    mockFetch({
+      listing: {
+        body: listingPageHtml({
+          rows: [
+            [UNID.FIRST, DOCKET.FIRST],
+            [UNID.SECOND, DOCKET.SECOND],
+          ],
+        }),
+      },
+    });
+
+    const error = await rejectionOf(listSlice("2026-07-01"));
+    expect(String(error)).toContain("states no decisions and carries 2");
+  });
+
+  test("a page the slice does not have is refused", async () => {
+    mockFetch({
+      listing: {
+        body: listingPageHtml({ rows: [[UNID.FIRST, DOCKET.FIRST]], shown: 1 }),
+      },
+    });
+
+    const error = await rejectionOf(listSlice("2026-07-01", 1));
+    expect(String(error)).toContain("slice page out of range");
+    expect(requestedUrls).toHaveLength(0);
+  });
+});
+
+// ── buildDecision ───────────────────────────────────────────
+
+describe("cz-ns buildDecision", () => {
+  test("builds one listed row through the adapter's own parse path", async () => {
+    mockFetch({ printStatus: 404 });
+
+    const built = await reconciliation.buildDecision({
+      unid: UNID.FIRST,
+      caseNumber: DOCKET.FIRST,
+    });
+
+    expect(built.type).toBe("built");
+    if (built.type !== "built") {
+      return;
+    }
+    expect(built.decision.caseNumber).toBe(DOCKET.FIRST);
+    expect(built.decision.language).toBe("cs");
+    expect(built.decision.decisionDate).toBe("2026-05-28");
+    expect(built.decision.decisionType).toBe("rozsudek");
+    expect(built.decision.sourceUrl).toContain(UNID.FIRST);
+  });
+
+  test("a built decision is keyed exactly as its listing item was", async () => {
+    mockFetch({ printStatus: 404 });
+
+    const row: CzNsListingRow = { unid: UNID.FIRST, caseNumber: DOCKET.FIRST };
+    const built = await reconciliation.buildDecision(row);
+    expect(built.type).toBe("built");
+    if (built.type !== "built") {
+      return;
+    }
+    // The adapter writes no document id, so the row is keyed on the docket —
+    // which is what the listing identity has to say too.
+    expect(built.decision.sourceDocumentId).toBeUndefined();
+    expect(
+      listingIdentityKey({
+        type: "case-number",
+        caseNumber: built.decision.caseNumber,
+        language: built.decision.language,
+      }),
+    ).toBe(listingIdentityKey(czNsListingIdentity(row)));
+  });
+
+  test("a detail page that does not come back is reported, never written", async () => {
+    mockFetch({ detailStatus: 404 });
+
+    expect(
+      await reconciliation.buildDecision({
+        unid: UNID.FIRST,
+        caseNumber: DOCKET.FIRST,
+      }),
+    ).toEqual({ type: "detail-unavailable" });
+  });
+
+  test("the crawl sees the status the reconciliation drops", async () => {
+    mockFetch({ detailStatus: 503 });
+
+    expect(
+      await buildCzNsDecision({ unid: UNID.FIRST, caseNumber: DOCKET.FIRST }),
+    ).toEqual({ type: "detail-unavailable", httpStatus: 503 });
+  });
+
+  test("a payload this adapter no longer recognises is unkeyable, unasked", async () => {
+    mockFetch({});
+
+    for (const payload of [
+      null,
+      "05D11F4FB3ACC585C1258E27004D2F09",
+      { unid: UNID.FIRST },
+      { unid: 7, caseNumber: DOCKET.FIRST },
+    ]) {
+      // oxlint-disable-next-line no-await-in-loop -- assertions over a fixed payload list, no I/O to overlap
+      expect(await reconciliation.buildDecision(payload)).toEqual({
+        type: "unkeyable",
+      });
+    }
+    expect(requestedUrls).toHaveLength(0);
+  });
+
+  test("a row naming no document is unkeyable without contacting the publisher", async () => {
+    mockFetch({});
+
+    expect(
+      await reconciliation.buildDecision({
+        unid: "",
+        caseNumber: DOCKET.FIRST,
+      }),
+    ).toEqual({ type: "unkeyable" });
+    expect(requestedUrls).toHaveLength(0);
+  });
+});

--- a/apps/api/src/handlers/case-law/ingestion/adapters/cz-ns.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/cz-ns.ts
@@ -623,10 +623,15 @@ const listCzNsSlicePage = async ({
     });
   }
 
+  // This count is the day's true size, printed only when it exceeds what the
+  // publisher will serve. Any disagreement with the rows carried is refused,
+  // in both directions: above, the window truncated the day; below, the body
+  // contradicts itself and its rows are not the day it counted. Neither is a
+  // listing this walk may bank as a whole slice.
   const matched = parseListingCount(html, LISTING_COUNT_PATTERN.MATCHED);
-  if (matched !== undefined && matched > rows.length) {
+  if (matched !== undefined && matched !== rows.length) {
     throw new AdapterFetchError({
-      message: `CZ Supreme Court listing for ${slice} holds ${matched} decisions, past the ${CZ_NS_LISTING_WINDOW} one search addresses`,
+      message: `CZ Supreme Court listing for ${slice} counts ${matched} decisions and carries ${rows.length}, against the ${CZ_NS_LISTING_WINDOW} one search addresses`,
       adapterKey: ADAPTER_KEYS.CZ_NS,
       cursor: slice,
     });

--- a/apps/api/src/handlers/case-law/ingestion/adapters/cz-ns.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/cz-ns.ts
@@ -1,4 +1,4 @@
-import { Result } from "better-result";
+import { Result, panic } from "better-result";
 
 import {
   ADAPTER_KEYS,
@@ -13,6 +13,10 @@ import {
 import type {
   EmptyAst,
   IngestionResult,
+  ListingIdentity,
+  ReconciliationBuildOutcome,
+  ReconciliationSlicePage,
+  ReconciliationSlicePageOptions,
 } from "@/api/handlers/case-law/ingestion/adapter";
 import {
   INGESTION_USER_AGENT,
@@ -27,6 +31,7 @@ import {
   toOptionalValue,
 } from "@/api/handlers/case-law/ingestion/adapters/utils";
 import { parseNsDecisionHtml } from "@/api/handlers/case-law/ingestion/parsers/cz-ns";
+import { addUtcDays, isoCalendarDay, toUtcDateString } from "@/api/lib/dates";
 import { AdapterFetchError } from "@/api/lib/errors/tagged-errors";
 import { fetchWithTimeout } from "@/api/lib/fetch";
 import { logger } from "@/api/lib/observability/logger";
@@ -50,6 +55,9 @@ const COMMON_HEADERS = {
 
 const BASE_URL = "https://rozhodnuti.nsoud.cz/Judikatura/judikatura_ns.nsf";
 const PAGE_SIZE = 40;
+
+/** The only language this court publishes; half of every identity it keys. */
+const CZ_NS_LANGUAGE = "cs";
 
 /** Domino ReadViewEntries JSON shape. */
 type DominoViewEntry = {
@@ -245,15 +253,481 @@ const parseDetailPage = (html: string): Record<string, string | undefined> => {
   return result;
 };
 
+/** One decision as the publisher lists it, whichever listing named it. */
+export type CzNsListingRow = {
+  /** Domino universal id: the last path segment of the document's own URL. */
+  unid: string;
+  /** `znacka`, the docket exactly as the publisher writes it. */
+  caseNumber: string;
+};
+
+/**
+ * What building one listed decision produced. `detail-unavailable` carries
+ * the status the publisher answered with so the crawl can log it; the
+ * reconciliation drops it, having only the three outcomes its contract names.
+ */
+type CzNsBuildResult =
+  | { type: "built"; decision: IngestionResult }
+  | { type: "unkeyable" }
+  | { type: "detail-unavailable"; httpStatus: number };
+
+/**
+ * Build one decision from a listed row, through this adapter's own fetch and
+ * parse path.
+ *
+ * The crawl and the reconciliation walk both come through here, so neither
+ * can parse a decision the other would parse differently. A detail page that
+ * does not come back is reported rather than folded into a decision: the
+ * crawl skips such an entry and will meet it again, while a reconciliation
+ * that stored the listing alone would make the identity held and take the
+ * document out of every later pass.
+ *
+ * The print page is the AST's source and is treated as enrichment, exactly as
+ * the crawl treats it: without it the decision still carries the fulltext and
+ * metadata the detail page states, and is stored with an empty AST.
+ */
+export const buildCzNsDecision = async (
+  { caseNumber, unid }: CzNsListingRow,
+  signal?: AbortSignal,
+): Promise<CzNsBuildResult> => {
+  if (unid.length === 0 || caseNumber.length === 0) {
+    return { type: "unkeyable" };
+  }
+
+  const webUrl = `${BASE_URL}/WebSearch/${unid}?openDocument`;
+  const printUrl = `${BASE_URL}/WebPrint/${unid}?openDocument`;
+
+  // Detail and print pages in parallel; the pair is one document's worth of
+  // work, and the caller paces the requests between documents.
+  const [detailResponse, printResponse] = await Promise.all([
+    fetchWithTimeout(webUrl, {
+      signal,
+      headers: COMMON_HEADERS,
+      timeoutMs: ADAPTER_TIMEOUT.REQUEST,
+    }),
+    fetchWithTimeout(printUrl, {
+      signal,
+      headers: COMMON_HEADERS,
+      timeoutMs: ADAPTER_TIMEOUT.REQUEST,
+    }),
+  ]);
+
+  if (!detailResponse.ok) {
+    return { type: "detail-unavailable", httpStatus: detailResponse.status };
+  }
+
+  const webHtml = await detailResponse.text();
+  const printHtml = printResponse.ok ? await printResponse.text() : "";
+
+  const meta = parseDetailPage(webHtml);
+  const raw = `${caseNumber}|${meta["ecli"] ?? ""}|${meta["decisionDate"] ?? ""}`;
+
+  // Parse AST from the print page (rich HTML)
+  let documentAst: DocumentAst | EmptyAst = EMPTY_AST;
+  let fulltext = meta["fulltext"];
+
+  // eslint-disable-next-line no-untyped-updates/no-untyped-updates -- court API metadata container, not a DB update
+  let sourceMetadata: Record<string, unknown> = {};
+
+  if (printHtml) {
+    const parsed = parseNsDecisionHtml({
+      documentId: unid,
+      webUrl,
+      printUrl,
+      webHtml,
+      printHtml,
+    });
+    documentAst = parsed.documentAst;
+    fulltext = parsed.fulltext;
+    sourceMetadata = parsed.sourceMetadata;
+  }
+
+  // Extract judge from fulltext signature block
+  const judge = fulltext ? extractJudge(fulltext) : undefined;
+
+  return {
+    type: "built",
+    decision: {
+      caseNumber,
+      ecli: meta["ecli"],
+      court: "Nejvyšší soud",
+      country: "CZE",
+      language: CZ_NS_LANGUAGE,
+      decisionDate: meta["decisionDate"]
+        ? parseCeDate(meta["decisionDate"])
+        : undefined,
+      decisionType: meta["decisionType"]?.toLowerCase(),
+      fulltext,
+      sourceUrl: webUrl,
+      documentUrl: webUrl,
+      metadata: {
+        caseNumber,
+        ecli: meta["ecli"],
+        court: "Nejvyšší soud" as const,
+        decisionDate: meta["decisionDate"]
+          ? parseCeDate(meta["decisionDate"])
+          : undefined,
+        decisionType: meta["decisionType"]?.toLowerCase(),
+        ...sourceMetadata,
+        judge,
+        legalSentence: meta["legalSentence"],
+        keywords: meta["keywords"]?.split("\n").flatMap((s) => {
+          const trimmed = s.trim();
+          return trimmed ? [trimmed] : [];
+        }),
+        statutes: meta["statutes"]?.split("\n").flatMap((s) => {
+          const trimmed = s.trim();
+          return trimmed ? [trimmed] : [];
+        }),
+        category: meta["category"]?.trim(),
+      },
+      rawHash: hashContent(raw),
+      parserVersion: PARSER_VERSION,
+      documentAst,
+      sourceRaw: JSON.stringify({ webHtml, printHtml }),
+      sourceRawContentType: "text/html",
+    },
+  };
+};
+
+// -- Reconciliation --
+//
+// The view the crawl walks is sorted by universal id, and a universal id says
+// nothing about when its document appeared. So a position in that view is not
+// a slice: insert one decision and every `Start=N` after it names a different
+// document, which would have a reconciliation double-count and miss in the
+// same pass. It is also why the crawl needs reconciling at all — parking its
+// cursor near the end of an id-ordered view leaves it watching a stretch of
+// the alphabet, not the newest decisions.
+//
+// The court's own search surface answers a date range instead, and a date
+// range is the same question however often it is asked. A slice is therefore
+// one UTC day of `datum_predani_na_web`, the day the publisher handed the
+// document to the web: `YYYY-MM-DD` sorts lexicographically in chronological
+// order, and a past day is closed, since a document published later carries
+// the later date. Decision date would have been the more evenly filled axis
+// and the wrong one: a 2015 decision first published today would land in a
+// 2015 slice the sweep had already settled.
+
+/** The search view, which the publisher's own date filter is addressed to. */
+const SEARCH_URL = `${BASE_URL}/$$WebSearch1`;
+
+/** Full-text field holding the day a document was handed to the web. */
+const PUBLICATION_DATE_FIELD = "datum_predani_na_web";
+
+/**
+ * Results one search can address. The publisher states the ceiling itself
+ * ("z 900 zobrazovaných dokumentů", printed alongside the true match count
+ * whenever the two differ) and it does not move: `SearchMax` of 300, 1000,
+ * 2000 and 5000 all answer 900. Rows past it are not served at all — `Start`
+ * of 5001 into a 50,454-result query answers with an empty table rather than
+ * the 5001st row — so a slice is asked for in a single request of this size,
+ * and a day that does not fit in the window is refused rather than truncated.
+ */
+const CZ_NS_LISTING_WINDOW = 900;
+
+/**
+ * Sent because the publisher's own form sends it and rejects a small value
+ * (`SearchMax=1` answers 500), not because it bounds anything: the window
+ * above is the publisher's and no value here raises or lowers it.
+ */
+const SEARCH_MAX = 1000;
+
+/** Keep the view's own order, so one slice's rows come back in a fixed one. */
+const SEARCH_ORDER_VIEW = 4;
+
+/**
+ * First publication day the search surface can enumerate.
+ *
+ * The publisher stamped its entire legacy archive with a single publication
+ * date when it went online: 2009-12-31 answers with 50,454 documents, 31% of
+ * the 164,389 the view holds, against a window that addresses 900. That day
+ * is not listable, and no sub-range of it is either — the field the search
+ * offers alongside it, the decision date, spreads those documents over some
+ * two hundred and forty months, which is past the walk's own page ceiling.
+ * The sweep is bounded to the era where the publication date is the date a
+ * document actually appeared, which begins the day after. The archive below
+ * it is what the crawl's full walk of the id-ordered view already covers;
+ * what that walk cannot see, and this capability exists for, is the tip.
+ */
+export const CZ_NS_FIRST_SLICE = "2010-01-01";
+
+/**
+ * Days near the tip that the reconciliation re-walks on a fast cadence. The
+ * court publishes on working days, so a fortnight is around ten days that
+ * carry anything, and covers a long weekend plus a public holiday without
+ * the fast lane growing.
+ */
+const CZ_NS_TIP_WINDOW_DAYS = 14;
+
+const czNsDayStart = (slice: string): Date => {
+  const day = isoCalendarDay(slice);
+  if (day === null || day !== slice) {
+    panic(`cz-ns slice is not a UTC calendar day: ${slice}`);
+  }
+  return new Date(`${day}T00:00:00.000Z`);
+};
+
+const czNsStepSlice = (slice: string, days: number): string =>
+  toUtcDateString(addUtcDays(czNsDayStart(slice), days));
+
+const czNsNextSlice = (slice: string): string | null => {
+  const next = czNsStepSlice(slice, 1);
+  return next > toUtcDateString(new Date()) ? null : next;
+};
+
+const czNsPreviousSlice = (slice: string): string | null => {
+  const previous = czNsStepSlice(slice, -1);
+  return previous < CZ_NS_FIRST_SLICE ? null : previous;
+};
+
+/** The publisher's own date literal for a slice: `DD.MM.YYYY`. */
+const czNsSliceDate = (slice: string): string => {
+  const start = czNsDayStart(slice);
+  const day = String(start.getUTCDate()).padStart(2, "0");
+  const month = String(start.getUTCMonth() + 1).padStart(2, "0");
+  return `${day}.${month}.${String(start.getUTCFullYear()).padStart(4, "0")}`;
+};
+
+/**
+ * A result row. The docket and the universal id come out of the same anchor,
+ * so a row that names one names the other, and a row that names neither is
+ * not a row at all.
+ */
+const LISTING_ROW_PATTERN =
+  /<a\s+class="odk"\s+href="[^"]*\/WebSearch\/(?<unid>[0-9A-Fa-f]{32})\?openDocument"[^>]*>(?<caseNumber>[^<]*)<\/a>/gu;
+
+/**
+ * The two counts the publisher may state about a listing, both captured under
+ * one group name so that reading either is the same operation.
+ */
+const LISTING_COUNT_PATTERN = {
+  /** "Výsledky 1 - 23 z 23 zobrazovaných dokumentů." Absent for a lone hit. */
+  SHOWN: /Výsledky\s+\d+\s*-\s*\d+\s+z\s+(?<count>\d+)\s+zobrazovaných/u,
+  /** "(Podmínce vyhovuje: 50454 )", printed only when the window truncated. */
+  MATCHED: /Podmínce vyhovuje:\s*(?<count>\d+)/u,
+} as const;
+
+/** The publisher's own words for a day it published nothing on. */
+const LISTING_EMPTY_MARKER = "Nebyly nalezeny žádné výsledky vyhledávání";
+
+const parseListingCount = (
+  html: string,
+  pattern: RegExp,
+): number | undefined => {
+  const raw = pattern.exec(html)?.groups?.["count"];
+  if (raw === undefined) {
+    return undefined;
+  }
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isNaN(parsed) ? undefined : parsed;
+};
+
+const parseListingRows = (html: string): CzNsListingRow[] =>
+  [...html.matchAll(LISTING_ROW_PATTERN)].map((match) => ({
+    unid: match.groups?.["unid"] ?? "",
+    caseNumber: stripHtml(match.groups?.["caseNumber"] ?? ""),
+  }));
+
+/**
+ * The identity the ingest would store for a listed row.
+ *
+ * The docket and the language, never the universal id the row also carries:
+ * this adapter sets no `sourceDocumentId`, so every row it has ever written
+ * is keyed on `(caseNumber, language)` against a null document id. Keying the
+ * listing on the id would match no held row at all and read the whole archive
+ * as missing.
+ *
+ * That key is coarser than the source is. The court publishes a docket's
+ * further decisions under the same `znacka`, sometimes distinguished only by
+ * a suffix it writes into the docket itself ("21 Cdo 288/2026- III."), and
+ * where it does not, the crawl already collapses them into one row. The walk
+ * inherits exactly that: two such rows in one slice are one identity, counted
+ * once. Giving them separate identities is an identity migration of the
+ * stored rows, not something a reconciliation pass may decide on its own —
+ * until those rows carry the universal id, this is what "held" means.
+ *
+ * A row missing either half is unidentifiable rather than keyed on what is
+ * left: the crawl drops such an entry, so a slice that counted it would stay
+ * short forever.
+ */
+export const czNsListingIdentity = ({
+  caseNumber,
+  unid,
+}: CzNsListingRow): ListingIdentity =>
+  unid.length === 0 || caseNumber.length === 0
+    ? { type: "unidentifiable" }
+    : { type: "case-number", caseNumber, language: CZ_NS_LANGUAGE };
+
+/**
+ * One publication day, in one request.
+ *
+ * There is no paging within a slice, and that is the point: the publisher
+ * pages this listing positionally, so a document arriving between two page
+ * requests would shift every row after it and have the walk count one twice
+ * and never see another. A day is asked for whole, inside the window the
+ * publisher will address, or not at all.
+ *
+ * Only a body that states its own outcome is an answer. The publisher says
+ * "Nebyly nalezeny žádné výsledky vyhledávání" for a day it published nothing
+ * on, and that is the empty slice. Everything else — a non-2xx, a body with
+ * neither rows nor that sentence, a body whose stated counts disagree with
+ * the rows it carries, a day larger than the window — is thrown, because a
+ * short listing banked as a whole slice records `reported` below the truth
+ * and reads ever after as fully collected.
+ */
+const listCzNsSlicePage = async ({
+  page,
+  signal,
+  slice,
+}: ReconciliationSlicePageOptions): Promise<ReconciliationSlicePage> => {
+  if (page !== 0) {
+    panic(`cz-ns slice page out of range: ${page}`);
+  }
+
+  const date = czNsSliceDate(slice);
+  const query =
+    `[${PUBLICATION_DATE_FIELD}]>=${date} AND ` +
+    `[${PUBLICATION_DATE_FIELD}]<=${date}`;
+  const url =
+    `${SEARCH_URL}?SearchView&Query=${encodeURIComponent(query)}` +
+    `&SearchMax=${SEARCH_MAX}` +
+    `&SearchOrder=${SEARCH_ORDER_VIEW}` +
+    `&Start=1&Count=${CZ_NS_LISTING_WINDOW}`;
+
+  const response = await fetchWithTimeout(url, {
+    signal,
+    headers: COMMON_HEADERS,
+    timeoutMs: ADAPTER_TIMEOUT.REQUEST,
+  });
+  if (!response.ok) {
+    throw new AdapterFetchError({
+      message: `CZ Supreme Court listing error: ${response.status}`,
+      adapterKey: ADAPTER_KEYS.CZ_NS,
+      cursor: slice,
+      httpStatus: response.status,
+    });
+  }
+
+  const html = await response.text();
+  const rows = parseListingRows(html);
+
+  if (rows.length === 0) {
+    if (html.includes(LISTING_EMPTY_MARKER)) {
+      return { items: [], totalPages: 0 };
+    }
+    throw new AdapterFetchError({
+      message: `CZ Supreme Court listing for ${slice} stated neither results nor emptiness`,
+      adapterKey: ADAPTER_KEYS.CZ_NS,
+      cursor: slice,
+    });
+  }
+
+  const matched = parseListingCount(html, LISTING_COUNT_PATTERN.MATCHED);
+  if (matched !== undefined && matched > rows.length) {
+    throw new AdapterFetchError({
+      message: `CZ Supreme Court listing for ${slice} holds ${matched} decisions, past the ${CZ_NS_LISTING_WINDOW} one search addresses`,
+      adapterKey: ADAPTER_KEYS.CZ_NS,
+      cursor: slice,
+    });
+  }
+
+  // The publisher counts the rows it is about to print, so its number and the
+  // rows parsed out of the same body have to agree. Where they do not, the
+  // listing is not the one this parser reads and its shortfall is not a fact
+  // about the day. It omits the count for a lone hit and only for a lone hit,
+  // so several rows under no count are the same disagreement stated by
+  // absence — which is how a change to this markup surfaces as an error
+  // rather than as a day that quietly lost most of its decisions.
+  const shown = parseListingCount(html, LISTING_COUNT_PATTERN.SHOWN);
+  if (shown === undefined ? rows.length > 1 : shown !== rows.length) {
+    throw new AdapterFetchError({
+      message: `CZ Supreme Court listing for ${slice} states ${shown ?? "no"} decisions and carries ${rows.length}`,
+      adapterKey: ADAPTER_KEYS.CZ_NS,
+      cursor: slice,
+    });
+  }
+
+  if (rows.length >= CZ_NS_LISTING_WINDOW) {
+    throw new AdapterFetchError({
+      message: `CZ Supreme Court listing for ${slice} filled the ${CZ_NS_LISTING_WINDOW} a search addresses`,
+      adapterKey: ADAPTER_KEYS.CZ_NS,
+      cursor: slice,
+    });
+  }
+
+  return {
+    items: rows.map((row) => ({
+      identity: czNsListingIdentity(row),
+      payload: row,
+    })),
+    totalPages: 1,
+  };
+};
+
+const isCzNsListingRow = (value: unknown): value is CzNsListingRow =>
+  isRecord(value) &&
+  typeof value["unid"] === "string" &&
+  typeof value["caseNumber"] === "string";
+
+/**
+ * Rebuild a decision from a row the loop stored verbatim. The payload is
+ * revalidated rather than trusted: it may have been parked for days, and a
+ * shape this adapter no longer recognises has to be reported as unbuildable
+ * instead of parsed on faith.
+ */
+const buildCzNsFromPayload = async (
+  payload: unknown,
+  signal?: AbortSignal,
+): Promise<ReconciliationBuildOutcome> => {
+  if (!isCzNsListingRow(payload)) {
+    return { type: "unkeyable" };
+  }
+  const built = await buildCzNsDecision(payload, signal);
+  switch (built.type) {
+    case "built":
+      return { type: "built", decision: built.decision };
+    case "unkeyable":
+      return { type: "unkeyable" };
+    case "detail-unavailable":
+      // The status the crawl logs is dropped, not the distinction: the loop
+      // parks this item and widens its schedule, and never writes a row that
+      // would make the identity held while its document stayed unread.
+      return { type: "detail-unavailable" };
+    default: {
+      const exhaustive: never = built;
+      return panic(
+        `Unhandled cz-ns build result: ${JSON.stringify(exhaustive)}`,
+      );
+    }
+  }
+};
+
 export const czNsAdapter = defineSourceAdapter({
   key: ADAPTER_KEYS.CZ_NS,
   name: "Czech Supreme Court",
   country: "CZE",
-  language: "cs",
+  language: CZ_NS_LANGUAGE,
   minRequestIntervalMs: 200,
   // Each page fetches 40 decisions + detail pages. ~40s/page.
   // 15 pages ≈ 10 min (within MAX_CYCLE_MS).
   maxSyncPages: 15,
+
+  /**
+   * The publisher lists a publication day independently of the crawl cursor,
+   * so what a day contains is answerable without walking the id-ordered view
+   * to it: enumerate the day, key each row the way the ingest would, and
+   * compare against what is held.
+   */
+  reconciliation: {
+    firstSlice: CZ_NS_FIRST_SLICE,
+    sliceOf: toUtcDateString,
+    nextSlice: czNsNextSlice,
+    previousSlice: czNsPreviousSlice,
+    tipWindowDays: CZ_NS_TIP_WINDOW_DAYS,
+    listSlicePage: listCzNsSlicePage,
+    buildDecision: buildCzNsFromPayload,
+  },
 
   async getTotalCount(signal) {
     try {
@@ -329,113 +803,37 @@ export const czNsAdapter = defineSourceAdapter({
           if (!entry) {
             continue;
           }
-          const unid = entry["@unid"];
-          const caseNumber = entryField(entry, "znacka");
+          const unid = entry["@unid"] ?? "";
+          const caseNumber = entryField(entry, "znacka") ?? "";
 
-          if (!unid || !caseNumber) {
-            continue;
-          }
-
-          const webUrl = `${BASE_URL}/WebSearch/${unid}?openDocument`;
-          const printUrl = `${BASE_URL}/WebPrint/${unid}?openDocument`;
-
-          // Fetch detail + print pages in parallel
           try {
             // oxlint-disable-next-line no-await-in-loop -- polite sequential crawl of one court detail page per entry, rate-limited via Bun.sleep below
-            const [detailResponse, printResponse] = await Promise.all([
-              fetchWithTimeout(webUrl, {
-                signal,
-                headers: COMMON_HEADERS,
-                timeoutMs: ADAPTER_TIMEOUT.REQUEST,
-              }),
-              fetchWithTimeout(printUrl, {
-                signal,
-                headers: COMMON_HEADERS,
-                timeoutMs: ADAPTER_TIMEOUT.REQUEST,
-              }),
-            ]);
+            const built = await buildCzNsDecision({ caseNumber, unid }, signal);
 
-            if (detailResponse.ok) {
-              // oxlint-disable-next-line no-await-in-loop -- reads the body of the per-entry detail fetch in this sequential crawl loop
-              const webHtml = await detailResponse.text();
-              let printHtml = "";
-              if (printResponse.ok) {
-                // oxlint-disable-next-line no-await-in-loop -- reads the body of the per-entry print fetch in this sequential crawl loop
-                printHtml = await printResponse.text();
+            switch (built.type) {
+              case "built": {
+                decisions.push(built.decision);
+                break;
               }
-
-              const meta = parseDetailPage(webHtml);
-              const raw = `${caseNumber}|${meta["ecli"] ?? ""}|${meta["decisionDate"] ?? ""}`;
-
-              // Parse AST from the print page (rich HTML)
-              let documentAst: DocumentAst | EmptyAst = EMPTY_AST;
-              let fulltext = meta["fulltext"];
-
-              // eslint-disable-next-line no-untyped-updates/no-untyped-updates -- court API metadata container, not a DB update
-              let sourceMetadata: Record<string, unknown> = {};
-
-              if (printHtml) {
-                const parsed = parseNsDecisionHtml({
+              case "detail-unavailable": {
+                logger.warn("case_law.ingestion.detail_fetch_failed", {
+                  adapterKey: ADAPTER_KEYS.CZ_NS,
                   documentId: unid,
-                  webUrl,
-                  printUrl,
-                  webHtml,
-                  printHtml,
+                  httpStatus: built.httpStatus,
                 });
-                documentAst = parsed.documentAst;
-                fulltext = parsed.fulltext;
-                sourceMetadata = parsed.sourceMetadata;
+                break;
               }
-
-              // Extract judge from fulltext signature block
-              const judge = fulltext ? extractJudge(fulltext) : undefined;
-
-              decisions.push({
-                caseNumber,
-                ecli: meta["ecli"],
-                court: "Nejvyšší soud",
-                country: "CZE",
-                language: "cs",
-                decisionDate: meta["decisionDate"]
-                  ? parseCeDate(meta["decisionDate"])
-                  : undefined,
-                decisionType: meta["decisionType"]?.toLowerCase(),
-                fulltext,
-                sourceUrl: webUrl,
-                documentUrl: webUrl,
-                metadata: {
-                  caseNumber,
-                  ecli: meta["ecli"],
-                  court: "Nejvyšší soud" as const,
-                  decisionDate: meta["decisionDate"]
-                    ? parseCeDate(meta["decisionDate"])
-                    : undefined,
-                  decisionType: meta["decisionType"]?.toLowerCase(),
-                  ...sourceMetadata,
-                  judge,
-                  legalSentence: meta["legalSentence"],
-                  keywords: meta["keywords"]?.split("\n").flatMap((s) => {
-                    const trimmed = s.trim();
-                    return trimmed ? [trimmed] : [];
-                  }),
-                  statutes: meta["statutes"]?.split("\n").flatMap((s) => {
-                    const trimmed = s.trim();
-                    return trimmed ? [trimmed] : [];
-                  }),
-                  category: meta["category"]?.trim(),
-                },
-                rawHash: hashContent(raw),
-                parserVersion: PARSER_VERSION,
-                documentAst,
-                sourceRaw: JSON.stringify({ webHtml, printHtml }),
-                sourceRawContentType: "text/html",
-              });
-            } else {
-              logger.warn("case_law.ingestion.detail_fetch_failed", {
-                adapterKey: ADAPTER_KEYS.CZ_NS,
-                documentId: unid,
-                httpStatus: detailResponse.status,
-              });
+              case "unkeyable": {
+                // The view entry names no document or no docket: there is
+                // nothing to fetch and nothing the pipeline could key.
+                break;
+              }
+              default: {
+                const exhaustive: never = built;
+                return panic(
+                  `Unhandled cz-ns build result: ${JSON.stringify(exhaustive)}`,
+                );
+              }
             }
           } catch (error) {
             // Caller cancelled: return partial results

--- a/scripts/ratchet-baseline.json
+++ b/scripts/ratchet-baseline.json
@@ -87,7 +87,7 @@
     "files": {}
   },
   "lint-suppression-directives": {
-    "count": 614,
+    "count": 612,
     "files": {
       "apps/api/src/db/migrate.ts": 2,
       "apps/api/src/db/schema.ts": 1,
@@ -103,7 +103,7 @@
       "apps/api/src/handlers/case-law/decisions/sitemap.ts": 1,
       "apps/api/src/handlers/case-law/decisions/slug-backfill.ts": 3,
       "apps/api/src/handlers/case-law/erasure.ts": 6,
-      "apps/api/src/handlers/case-law/ingestion/adapters/cz-ns.ts": 5,
+      "apps/api/src/handlers/case-law/ingestion/adapters/cz-ns.ts": 3,
       "apps/api/src/handlers/case-law/ingestion/adapters/cz-nss.ts": 2,
       "apps/api/src/handlers/case-law/ingestion/adapters/cz-regional.ts": 2,
       "apps/api/src/handlers/case-law/ingestion/adapters/cz-us.ts": 2,


### PR DESCRIPTION
Implements the `reconciliation` capability on the cz-ns adapter.

The crawl's Domino view is UNID-sorted, so positional addressing cannot be a slice key (one insertion renames every later position), and key-range addressing over UNIDs encodes nothing about time. The site's own search form, however, exposes a date-addressable GET surface over the publication date. Slice = one UTC publication day, chosen over decision date because a decision published late would land in an already-settled decision-date slice; publication-date slices only ever grow at the tip.

Two source facts bound the design, both probed live: the search surface has a hard 900-result addressable window (deep paging past it returns zero rows regardless of the stated match count), and 2009-12-31 carries 50,454 publications — the legacy bulk load, structurally unlistable. So `firstSlice = 2010-01-01`: the capability owns the region the crawl cannot watch (its UNID-ordered walk parks on a stretch of the alphabet, not the newest decisions), and the pre-2010 archive remains the crawl's full-walk territory. Every slice is a single request (`totalPages` ∈ {0,1}), immune to positional shifts; emptiness is only the publisher's own no-results message, and a match count exceeding rows, a stated count contradicting rows, rows filling the window, or a missing count with several rows all throw.

Identity is `(caseNumber, cs)` — this source stores no publisher document id, so the listing mirrors the stored keys; the docket collapse that implies is documented at the rule as an identity migration, unchanged here. The per-item build was extracted from `fetchPage` so crawl and walk share one fetch/parse/key path (crawl output unchanged; a missing print page stays non-fatal exactly as the crawl treats it, only a failed detail page is `detail-unavailable`).

Ratchet baseline tightens by two (the extraction removed two loop suppressions).

Tests: 29 new; 98 across the adapter/parser/conformance/plan suites green.
