### PR TITLE
feat(case-law): cz-us listing reconciliation capability

### DIFF
--- a/apps/api/src/handlers/case-law/ingestion/adapters/cz-us-reconciliation.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/cz-us-reconciliation.test.ts
@@ -1,0 +1,633 @@
+/* eslint-disable typescript-eslint/promise-function-async -- fetch mock callbacks return Promise.resolve without being async */
+import { panic } from "better-result";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  mock,
+  setSystemTime,
+  test,
+} from "bun:test";
+
+import {
+  listingIdentityKey,
+  parseListingIdentityKey,
+} from "@/api/handlers/case-law/ingestion/adapter";
+import type {
+  ReconciliationListingItem,
+  ReconciliationSlicePage,
+  SourceReconciliation,
+} from "@/api/handlers/case-law/ingestion/adapter";
+import {
+  czUsAdapter,
+  czUsListingIdentity,
+} from "@/api/handlers/case-law/ingestion/adapters/cz-us";
+import type { ListedDecision } from "@/api/handlers/case-law/ingestion/adapters/cz-us";
+import { asFetchMock } from "@/api/tests/helpers/test-tool-set";
+
+/** Frozen so "the current year" and "yesterday" are the same in every test. */
+const NOW = new Date("2026-08-08T12:00:00.000Z");
+const LATEST_CLOSED_DAY = "7.8.2026";
+const LISTING_PAGE_SIZE = 80;
+
+const reconciliation: SourceReconciliation =
+  czUsAdapter.reconciliation ?? panic("cz-us states no reconciliation");
+
+// ── Publisher fixtures ───────────────────────────────────
+
+/**
+ * A NALUS result row as the court renders it: a ResultDetail anchor carrying
+ * the internal record id, an ECLI, and a second row whose ShowLink action
+ * carries the GetText retrieval identifier.
+ */
+type MockRow = {
+  /** Internal record id; absent renders the malformed detail link NALUS emits. */
+  id?: string | undefined;
+  /** GetText `sz`; null renders a row whose text action was withdrawn. */
+  sz?: string | null | undefined;
+  caseNumber: string;
+  date: string;
+  ecli?: string | undefined;
+};
+
+const makeSearchForm = (): string => `
+<html><body>
+  <input id="__VIEWSTATE" value="view-state" />
+  <input id="__VIEWSTATEGENERATOR" value="generator" />
+  <input id="__EVENTVALIDATION" value="validation" />
+</body></html>`;
+
+const makeNoResultsPage = (): string => `
+<html><body>
+  <span id="ctl00_MainContent_lbError" class="labelError">
+    Pro zadaná kritéria nebyly nalezeny žádné záznamy.
+  </span>
+  <input id="ctl00_bResults" disabled="disabled" />
+</body></html>`;
+
+const makeTextPage = (row: MockRow, counter: string): string => `
+<html><body>
+  <span id="lblRegistrySign">${row.caseNumber} ze dne ${row.date}</span>
+  <span id="lblDecisionForm">Nález</span>
+  <span id="lblParallelQuotation"></span>
+  <span id="lblPopularName"></span>
+  <input name="registrySignHidden" value="${row.caseNumber} #${counter} ze dne ${row.date}" />
+  <table class="DocContent"><tr><td>
+    ${"Lorem ipsum dolor sit amet. ".repeat(10)}
+    Jan Novák (soudce zpravodaj)
+  </td></tr></table>
+</body></html>`;
+
+const makeAbstractPage = (): string => `
+<html><body>
+  <table class="abstractContent"><tr><td></td></tr></table>
+  <table class="legalSentenceContent"><tr><td></td></tr></table>
+</body></html>`;
+
+const counterOf = (row: MockRow): string =>
+  /_(?<counter>\d+)$/u.exec(row.sz ?? "")?.groups?.["counter"] ?? "1";
+
+const makeResultsPage = ({
+  rows,
+  rangeFrom,
+  reported,
+  banner,
+}: {
+  rows: readonly MockRow[];
+  rangeFrom: number;
+  reported: number;
+  banner?: string | undefined;
+}): string => {
+  const body = rows
+    .map((row, index) => {
+      const detailHref =
+        row.id === undefined
+          ? `ResultDetail.aspx?malformed=true&pos=${rangeFrom + index}&cnt=${reported}`
+          : `ResultDetail.aspx?id=${row.id}&pos=${rangeFrom + index}&cnt=${reported}&typ=result`;
+      const textAction =
+        row.sz === null || row.sz === undefined
+          ? ""
+          : `<img onclick='javascript:ShowLink("https://nalus.usoud.cz:443/Search/GetText.aspx?sz=${row.sz}", "Odkaz", "")' />`;
+      return `
+<tr class='resultData${index % 2}'>
+  <td></td>
+  <td><a href='${detailHref}'>${row.caseNumber} #${counterOf(row)}</a><br />${row.ecli ?? ""}<br />Jan Novák</td>
+</tr>
+<tr class='resultData${index % 2}' valign="top">
+  <td>${textAction}</td>
+</tr>`;
+    })
+    .join("");
+  const rendered =
+    banner ??
+    `Výsledky ${rangeFrom} - ${rangeFrom + rows.length - 1} z celkem ${reported}`;
+  return `<html><body>${rendered}<table>${body}</table>${rendered}</body></html>`;
+};
+
+// ── Fetch harness ────────────────────────────────────────
+
+type MockOptions = {
+  rows?: readonly MockRow[];
+  rangeFrom?: number;
+  reported?: number;
+  /** Render the publisher's own "no records" answer instead of results. */
+  statedEmpty?: boolean;
+  /** Replace the result count banner, e.g. to drop it entirely. */
+  banner?: string | undefined;
+  formStatus?: number;
+  resultsStatus?: number;
+  textStatus?: number;
+  /** Serve a GetText page the decision parser cannot read. */
+  unparseableText?: boolean;
+  onPost?: (form: URLSearchParams) => void;
+  onResults?: (url: URL) => void;
+};
+
+const resolveUrl = (input: string | URL | Request): string => {
+  if (typeof input === "string") {
+    return input;
+  }
+  return input instanceof URL ? input.href : input.url;
+};
+
+const requestMethod = (
+  input: string | URL | Request,
+  init?: RequestInit,
+): string => init?.method ?? (input instanceof Request ? input.method : "GET");
+
+const installSearchMock = ({
+  rows = [],
+  rangeFrom = 1,
+  reported = rows.length,
+  statedEmpty = false,
+  banner,
+  formStatus = 200,
+  resultsStatus = 200,
+  textStatus = 200,
+  unparseableText = false,
+  onPost,
+  onResults,
+}: MockOptions): void => {
+  const bySz = new Map(
+    rows.flatMap((row) => (row.sz ? [[row.sz, row] as const] : [])),
+  );
+  globalThis.fetch = asFetchMock(
+    mock((input: string | URL | Request, init?: RequestInit) => {
+      const url = new URL(resolveUrl(input));
+      const method = requestMethod(input, init);
+      if (url.pathname.endsWith("/Search/Search.aspx") && method === "GET") {
+        return Promise.resolve(
+          new Response(makeSearchForm(), {
+            status: formStatus,
+            headers: { "Set-Cookie": "ASP.NET_SessionId=test-session; Path=/" },
+          }),
+        );
+      }
+      if (url.pathname.endsWith("/Search/Search.aspx")) {
+        onPost?.(
+          new URLSearchParams(typeof init?.body === "string" ? init.body : ""),
+        );
+        return Promise.resolve(
+          statedEmpty
+            ? new Response(makeNoResultsPage())
+            : new Response(null, {
+                status: 302,
+                headers: { Location: "/Search/Results.aspx" },
+              }),
+        );
+      }
+      if (url.pathname.endsWith("/Search/Results.aspx")) {
+        onResults?.(url);
+        return Promise.resolve(
+          new Response(makeResultsPage({ rows, rangeFrom, reported, banner }), {
+            status: resultsStatus,
+          }),
+        );
+      }
+      if (url.pathname.endsWith("/Search/GetText.aspx")) {
+        const row = bySz.get(url.searchParams.get("sz") ?? "");
+        if (row === undefined) {
+          return Promise.resolve(new Response("missing", { status: 404 }));
+        }
+        return Promise.resolve(
+          new Response(
+            unparseableText
+              ? "<html><body>detail unavailable</body></html>"
+              : makeTextPage(row, counterOf(row)),
+            { status: textStatus },
+          ),
+        );
+      }
+      if (url.pathname.endsWith("/Search/GetAbstract.aspx")) {
+        return Promise.resolve(new Response(makeAbstractPage()));
+      }
+      return Promise.resolve(new Response("unexpected", { status: 500 }));
+    }),
+  );
+};
+
+/**
+ * The error a promise rejected with, or null. bun-types declares
+ * `.rejects.toThrow` as void, so awaiting it trips type-aware lint.
+ */
+const rejectionOf = async (promise: Promise<unknown>): Promise<unknown> =>
+  await promise.then(
+    () => null,
+    (error: unknown) => error,
+  );
+
+const listSlice = async (
+  slice: string,
+  page = 0,
+): Promise<ReconciliationSlicePage> =>
+  await reconciliation.listSlicePage({ slice, page });
+
+/** The one item a single-row fixture lists, as the ledger would park it. */
+const onlyItem = (
+  listed: ReconciliationSlicePage,
+): ReconciliationListingItem => {
+  const item = listed.items.at(0);
+  expect(item).toBeDefined();
+  return item ?? { identity: { type: "unidentifiable" }, payload: null };
+};
+
+// ── Slice arithmetic ─────────────────────────────────────
+
+describe("cz-us reconciliation slices", () => {
+  beforeAll(() => {
+    setSystemTime(NOW);
+  });
+
+  afterAll(() => {
+    setSystemTime();
+  });
+
+  test("starts at the court's first year and steps one year at a time", () => {
+    expect(reconciliation.firstSlice).toBe("1993");
+    expect(reconciliation.sliceOf(NOW)).toBe("2026");
+    expect(reconciliation.nextSlice("1993")).toBe("1994");
+    expect(reconciliation.previousSlice("1994")).toBe("1993");
+  });
+
+  test("stops at the tip and at the first slice", () => {
+    expect(reconciliation.nextSlice("2026")).toBeNull();
+    expect(reconciliation.nextSlice("2025")).toBe("2026");
+    expect(reconciliation.previousSlice("1993")).toBeNull();
+  });
+
+  test("walks every year between the first slice and the tip, once", () => {
+    const walked: string[] = [];
+    let cursor: string | null = reconciliation.firstSlice;
+    while (cursor !== null) {
+      walked.push(cursor);
+      cursor = reconciliation.nextSlice(cursor);
+    }
+
+    expect(walked.at(0)).toBe("1993");
+    expect(walked.at(-1)).toBe(reconciliation.sliceOf(NOW));
+    expect(walked).toHaveLength(2026 - 1993 + 1);
+    expect(new Set(walked).size).toBe(walked.length);
+    // The ledger orders `(source, slice)` rows by byte comparison, so walk
+    // order and lexicographic order have to be the same sequence.
+    expect([...walked].sort()).toEqual(walked);
+  });
+
+  test("previousSlice inverts nextSlice across the whole walk", () => {
+    for (let year = 1993; year < 2026; year += 1) {
+      const slice = String(year);
+      const next = reconciliation.nextSlice(slice);
+      expect(next).not.toBeNull();
+      expect(reconciliation.previousSlice(next ?? "")).toBe(slice);
+    }
+  });
+
+  test("the tip window is the current year and the one before it", () => {
+    expect(reconciliation.tipWindowDays).toBe(2);
+    const window: string[] = [];
+    let cursor: string | null = reconciliation.sliceOf(NOW);
+    while (cursor !== null && window.length < reconciliation.tipWindowDays) {
+      window.push(cursor);
+      cursor = reconciliation.previousSlice(cursor);
+    }
+    expect(window).toEqual(["2026", "2025"]);
+  });
+
+  test("refuses a slice that is not a decision year", () => {
+    expect(() => reconciliation.nextSlice("2026-08")).toThrow();
+    expect(() => reconciliation.previousSlice("")).toThrow();
+    expect(() => reconciliation.nextSlice("199")).toThrow();
+  });
+});
+
+// ── Identity mapping ─────────────────────────────────────
+
+describe("czUsListingIdentity", () => {
+  const listedWith = (fields: Partial<ListedDecision>): ListedDecision => ({
+    caseNumber: "I.ÚS 1057/24",
+    quarantineId: "e3b0c44298fc1c149afbf4c8996fb924",
+    quarantineRepairIds: ["e3b0c44298fc1c149afbf4c8996fb924"],
+    listingHtml: "<tr></tr>",
+    sourceDocumentId: "nalus-record:104387",
+    sourceUrl: "https://nalus.usoud.cz/Search/GetText.aspx?sz=1-1057-24_1",
+    ...fields,
+  });
+
+  test("keys a row on the publisher identity the ingest stores", () => {
+    for (const sourceDocumentId of [
+      "nalus-record:104387",
+      "nalus-sz:1-1057-24_1",
+      "nalus-ecli:ECLI:CZ:US:2024:1.US.1057.24.1",
+      "nalus-quarantine:e3b0c44298fc1c149afbf4c8996fb924",
+    ]) {
+      expect(czUsListingIdentity(listedWith({ sourceDocumentId }))).toEqual({
+        type: "document",
+        sourceDocumentId,
+      });
+    }
+  });
+
+  test("round-trips through the ledger's key format", () => {
+    const identity = czUsListingIdentity(
+      listedWith({ sourceDocumentId: "nalus-record:104387" }),
+    );
+    const key = listingIdentityKey(identity);
+
+    expect(key).toBe("document:nalus-record:104387");
+    expect(parseListingIdentityKey(key ?? "")).toEqual(identity);
+  });
+
+  test("refuses an id the decision table could never store", () => {
+    // Longer than SOURCE_DOCUMENT_ID_MAX_LENGTH: a row keyed on it would be
+    // counted as missing on every pass, because no held row can ever match it.
+    expect(
+      czUsListingIdentity(
+        listedWith({ sourceDocumentId: `nalus-sz:${"9".repeat(300)}` }),
+      ),
+    ).toEqual({ type: "unidentifiable" });
+    expect(czUsListingIdentity(listedWith({ sourceDocumentId: "" }))).toEqual({
+      type: "unidentifiable",
+    });
+  });
+});
+
+// ── Listing walk ─────────────────────────────────────────
+
+describe("cz-us listSlicePage", () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeAll(() => {
+    setSystemTime(NOW);
+  });
+
+  afterAll(() => {
+    setSystemTime();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  const rowsFor = (count: number, offset = 0): MockRow[] =>
+    Array.from({ length: count }, (_, index) => ({
+      id: String(104_387 + offset + index),
+      sz: `1-${1057 + offset + index}-24_1`,
+      caseNumber: `I.ÚS ${1057 + offset + index}/24`,
+      date: "12. 3. 2024",
+      ecli: `ECLI:CZ:US:2024:1.US.${1057 + offset + index}.24.1`,
+    }));
+
+  test("asks the publisher for the whole decision year, at the listing page size", async () => {
+    let submitted: URLSearchParams | undefined;
+    let requested: URL | undefined;
+    installSearchMock({
+      rows: rowsFor(3),
+      reported: 3,
+      onPost: (form) => {
+        submitted = form;
+      },
+      onResults: (url) => {
+        requested = url;
+      },
+    });
+
+    await listSlice("2024");
+
+    expect(submitted?.get("ctl00$MainContent$decidedFrom")).toBe("1.1.2024");
+    expect(submitted?.get("ctl00$MainContent$decidedTo")).toBe("31.12.2024");
+    expect(submitted?.get("ctl00$MainContent$resultsPageSize")).toBe("80");
+    // NALUS keeps the current day's result set live, so the walk is pinned to
+    // the last closed publication day exactly as the crawl is.
+    expect(submitted?.get("ctl00$MainContent$availableTo")).toBe(
+      LATEST_CLOSED_DAY,
+    );
+    expect(requested?.searchParams.get("page")).toBeNull();
+  });
+
+  test("keys every listed record and derives the page count from the banner", async () => {
+    installSearchMock({ rows: rowsFor(80), rangeFrom: 1, reported: 200 });
+
+    const listed = await listSlice("2024");
+
+    expect(listed.items).toHaveLength(80);
+    expect(listed.totalPages).toBe(Math.ceil(200 / LISTING_PAGE_SIZE));
+    expect(listed.items.at(0)?.identity).toEqual({
+      type: "document",
+      sourceDocumentId: "nalus-record:104387",
+    });
+    expect(
+      new Set(listed.items.map(({ identity }) => listingIdentityKey(identity)))
+        .size,
+    ).toBe(80);
+  });
+
+  test("requests a later page and reads the banner against it", async () => {
+    let requested: URL | undefined;
+    installSearchMock({
+      rows: rowsFor(40, 160),
+      rangeFrom: 161,
+      reported: 200,
+      onResults: (url) => {
+        requested = url;
+      },
+    });
+
+    const listed = await listSlice("2024", 2);
+
+    expect(requested?.searchParams.get("page")).toBe("2");
+    expect(listed.items).toHaveLength(40);
+    expect(listed.totalPages).toBe(3);
+  });
+
+  test("reports a stated-empty year as zero pages", async () => {
+    installSearchMock({ statedEmpty: true });
+
+    expect(await listSlice("1993")).toEqual({ items: [], totalPages: 0 });
+  });
+
+  test.each([
+    ["a failed search form", { formStatus: 500 }],
+    ["a failed results page", { resultsStatus: 503 }],
+    ["a results page with no count banner", { banner: "" }],
+  ] as const)(
+    "throws on %s rather than reporting an empty year",
+    async (_label, options) => {
+      installSearchMock({ rows: rowsFor(1), reported: 1, ...options });
+
+      // Flattened to an empty page this would record the year as settled, and
+      // the ledger would never revisit it.
+      expect(await rejectionOf(listSlice("2024"))).toBeInstanceOf(Error);
+    },
+  );
+
+  test("throws when the requested page is not the page served", async () => {
+    installSearchMock({ rows: rowsFor(80), rangeFrom: 1, reported: 200 });
+
+    expect(await rejectionOf(listSlice("2024", 1))).toBeInstanceOf(Error);
+  });
+});
+
+// ── Building one listed record ───────────────────────────
+
+describe("cz-us buildDecision", () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeAll(() => {
+    setSystemTime(NOW);
+  });
+
+  afterAll(() => {
+    setSystemTime();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  const servedRow: MockRow = {
+    id: "104387",
+    sz: "1-1057-24_1",
+    caseNumber: "I.ÚS 1057/24",
+    date: "12. 3. 2024",
+    ecli: "ECLI:CZ:US:2024:1.US.1057.24.1",
+  };
+
+  const itemFor = async (
+    options: MockOptions,
+  ): Promise<ReconciliationListingItem> => {
+    installSearchMock(options);
+    return onlyItem(await listSlice("2024"));
+  };
+
+  test("builds the decision the walk keyed, under the same identity", async () => {
+    const item = await itemFor({ rows: [servedRow], reported: 1 });
+
+    const built = await reconciliation.buildDecision(item.payload);
+
+    expect(built.type).toBe("built");
+    if (built.type !== "built") {
+      return;
+    }
+    // The key the walk parks under has to be the key the stored decision is
+    // later found under; if the two ever drift the slice records short forever.
+    expect(listingIdentityKey(item.identity)).toBe(
+      `document:${built.decision.sourceDocumentId ?? ""}`,
+    );
+    expect(built.decision.sourceDocumentId).toBe("nalus-record:104387");
+    expect(built.decision).toMatchObject({
+      caseNumber: "I.ÚS 1057/24",
+      country: "CZE",
+      language: "cs",
+      decisionDate: "2024-03-12",
+    });
+    expect(built.decision.isListingOnly).toBeUndefined();
+    expect(built.decision.fulltext).toContain("Lorem ipsum");
+  });
+
+  test.each([
+    [
+      "a record NALUS serves no text for",
+      { rows: [servedRow], reported: 1, textStatus: 404 },
+    ],
+    [
+      "a record whose text is unreadable",
+      { rows: [servedRow], reported: 1, unparseableText: true },
+    ],
+    [
+      "a row whose text action was withdrawn",
+      { rows: [{ ...servedRow, sz: null }], reported: 1 },
+    ],
+    [
+      "a counted row exposing no NALUS identity at all",
+      {
+        rows: [{ caseNumber: "Pl.ÚS 10/24", date: "4. 1. 2024" }],
+        reported: 1,
+      },
+    ],
+  ] as const)("reports %s as detail-unavailable", async (_label, options) => {
+    const item = await itemFor(options);
+
+    // Never `built`: writing the listing-only row the crawl keeps would make
+    // the identity held and take the document out of every later pass.
+    expect(await reconciliation.buildDecision(item.payload)).toEqual({
+      type: "detail-unavailable",
+    });
+  });
+
+  test("throws on a transient text failure instead of retiring the record", async () => {
+    const item = await itemFor({
+      rows: [servedRow],
+      reported: 1,
+      textStatus: 502,
+    });
+
+    expect(
+      await rejectionOf(reconciliation.buildDecision(item.payload)),
+    ).toBeInstanceOf(Error);
+  });
+
+  test.each([
+    ["an empty object", {}],
+    ["a shape from before the search rewrite", { sz: "1-1057-24_1" }],
+    [
+      "a payload missing its listing markup",
+      {
+        caseNumber: "I.ÚS 1057/24",
+        sourceDocumentId: "nalus-record:104387",
+        quarantineId: "e3b0c44298fc1c149afbf4c8996fb924",
+        quarantineRepairIds: ["e3b0c44298fc1c149afbf4c8996fb924"],
+        sourceUrl: "https://nalus.usoud.cz/Search/GetText.aspx?sz=1-1057-24_1",
+      },
+    ],
+    [
+      "a well-formed payload keyed on an unstorable id",
+      {
+        caseNumber: "I.ÚS 1057/24",
+        sourceDocumentId: `nalus-sz:${"9".repeat(300)}`,
+        quarantineId: "e3b0c44298fc1c149afbf4c8996fb924",
+        quarantineRepairIds: ["e3b0c44298fc1c149afbf4c8996fb924"],
+        listingHtml: "<tr></tr>",
+        sourceUrl: "https://nalus.usoud.cz/Search/GetText.aspx?sz=1-1057-24_1",
+        sz: "1-1057-24_1",
+      },
+    ],
+    ["a JSON scalar", "nalus-record:104387"],
+    ["a JSON null", null],
+  ] as const)("reports %s as unkeyable", async (_label, payload) => {
+    installSearchMock({ rows: [servedRow], reported: 1 });
+
+    expect(await reconciliation.buildDecision(payload)).toEqual({
+      type: "unkeyable",
+    });
+  });
+
+  test("survives the JSON round-trip the ledger parks payloads through", async () => {
+    const item = await itemFor({ rows: [servedRow], reported: 1 });
+
+    const serialized = JSON.stringify(item.payload);
+    const parked: unknown = JSON.parse(serialized);
+
+    expect((await reconciliation.buildDecision(parked)).type).toBe("built");
+  });
+});

--- a/apps/api/src/handlers/case-law/ingestion/adapters/cz-us-reconciliation.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/cz-us-reconciliation.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable typescript-eslint/promise-function-async -- fetch mock callbacks return Promise.resolve without being async */
-import { panic } from "better-result";
+import { Result, panic } from "better-result";
 import {
   afterAll,
   afterEach,
@@ -620,6 +620,28 @@ describe("cz-us buildDecision", () => {
     expect(await reconciliation.buildDecision(payload)).toEqual({
       type: "unkeyable",
     });
+  });
+
+  test("the marker the crawl stores is what makes heldness require detail", async () => {
+    installSearchMock({ rows: [servedRow], reported: 1, textStatus: 404 });
+
+    const crawled = await czUsAdapter.fetchPage(null, {});
+    const item = onlyItem(await listSlice("2024"));
+
+    // Three halves of one decision, asserted together because each alone is
+    // silently wrong. The crawl keeps the row the reconciliation refuses and
+    // marks it `isListingOnly`; the capability declares that such a row is not
+    // held. Drop the marker and the declaration filters nothing; drop the
+    // declaration and the marked row reads as held, the slice reads
+    // reconciled, and NALUS is never asked for that text again.
+    expect(Result.isOk(crawled)).toBe(true);
+    expect(
+      Result.isOk(crawled) ? crawled.value.decisions.at(0) : null,
+    ).toMatchObject({ isListingOnly: true });
+    expect(await reconciliation.buildDecision(item.payload)).toEqual({
+      type: "detail-unavailable",
+    });
+    expect(reconciliation.heldRequiresDetail).toBe(true);
   });
 
   test("survives the JSON round-trip the ledger parks payloads through", async () => {

--- a/apps/api/src/handlers/case-law/ingestion/adapters/cz-us.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/cz-us.test.ts
@@ -334,11 +334,7 @@ describe("czUsAdapter.fetchPage", () => {
 
     const verified = unwrap(await czUsAdapter.fetchPage(page.nextCursor, {}));
     expect(verified.nextCursor).toBe(historicalCursor(1994));
-    expect(verified.coverage).toEqual({
-      slice: "decision-year:1993",
-      reported: 3,
-      collected: 3,
-    });
+    expect(verified.coverage).toBeUndefined();
   });
 
   test("keeps multiple published decisions under one docket distinct", async () => {
@@ -457,7 +453,7 @@ describe("czUsAdapter.fetchPage", () => {
     ).toBe(true);
   });
 
-  test("uses the result banner for pagination and slice coverage", async () => {
+  test("uses the result banner for pagination and slice completion", async () => {
     const firstRows = Array.from({ length: 40 }, (_, index) => ({
       id: String(3000 + index),
       sz: `1-${index + 1}-24_1`,
@@ -522,11 +518,8 @@ describe("czUsAdapter.fetchPage", () => {
     const verified = unwrap(
       await czUsAdapter.fetchPage(verifyFirst.nextCursor, {}),
     );
-    expect(verified.coverage).toEqual({
-      slice: "decision-year:2024",
-      reported: 42,
-      collected: 42,
-    });
+    expect(verified.nextCursor).toBe(historicalCursor(2025));
+    expect(verified.coverage).toBeUndefined();
   });
 
   test("restarts a traversal when a saved result page disappears", async () => {
@@ -559,7 +552,7 @@ describe("czUsAdapter.fetchPage", () => {
     }
   });
 
-  test("verifies a single-page slice before advancing coverage", async () => {
+  test("verifies a single-page slice before advancing", async () => {
     const firstRow = {
       id: "3100",
       sz: "1-1-24_1",
@@ -605,11 +598,7 @@ describe("czUsAdapter.fetchPage", () => {
 
     expect(submitted?.get("ctl00$MainContent$decidedFrom")).toBe("1.1.1993");
     expect(page.nextCursor).toBe(historicalCursor(1994));
-    expect(page.coverage).toEqual({
-      slice: "decision-year:1993",
-      reported: 0,
-      collected: 0,
-    });
+    expect(page.coverage).toBeUndefined();
   });
 
   test("finishing the current decision year hands over to availability polling", async () => {
@@ -664,11 +653,7 @@ describe("czUsAdapter.fetchPage", () => {
     expect(submitted?.get("ctl00$MainContent$availableFrom")).toBe("24.6.2026");
     expect(submitted?.get("ctl00$MainContent$availableTo")).toBe("7.8.2026");
     expect(submitted?.get("ctl00$MainContent$decidedFrom")).toBeNull();
-    expect(page.coverage).toEqual({
-      slice: "availability:2026-06-24:2026-08-07",
-      reported: 0,
-      collected: 0,
-    });
+    expect(page.coverage).toBeUndefined();
   });
 
   test("abstract failure does not drop a listed decision", async () => {
@@ -864,7 +849,7 @@ describe("czUsAdapter.fetchPage", () => {
     expect(page.decisions[0]?.sourceRaw).toContain("ResultDetail.aspx?id=7201");
     expect(page.decisions[0]?.sourceRawContentType).toBe("text/html");
     const verified = unwrap(await czUsAdapter.fetchPage(page.nextCursor, {}));
-    expect(verified.coverage?.collected).toBe(1);
+    expect(verified.nextCursor).toBe(historicalCursor(2025));
   });
 
   test("uses an exact text identity when ResultDetail id is malformed", async () => {
@@ -1039,11 +1024,7 @@ describe("czUsAdapter.fetchPage", () => {
       renderPositionOffset: 1,
     });
     const verified = unwrap(await czUsAdapter.fetchPage(page.nextCursor, {}));
-    expect(verified.coverage).toEqual({
-      slice: "decision-year:2024",
-      reported: 1,
-      collected: 1,
-    });
+    expect(verified.nextCursor).toBe(historicalCursor(2025));
 
     installSearchMock({
       rows: [
@@ -1275,7 +1256,7 @@ describe("czUsAdapter.fetchPage", () => {
       textHtml: expect.stringContaining("detail unavailable"),
     });
     const verified = unwrap(await czUsAdapter.fetchPage(page.nextCursor, {}));
-    expect(verified.coverage?.collected).toBe(1);
+    expect(verified.nextCursor).toBe(historicalCursor(2025));
   });
 
   test("catches up recent availability in contiguous bounded windows", async () => {

--- a/apps/api/src/handlers/case-law/ingestion/adapters/cz-us.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/cz-us.ts
@@ -1612,6 +1612,12 @@ export const czUsAdapter = defineSourceAdapter({
     nextSlice: czUsNextSlice,
     previousSlice: czUsPreviousSlice,
     tipWindowDays: CZ_US_TIP_WINDOW_SLICES,
+    // The crawl keeps the row `listedOnlyDecision` builds when NALUS serves no
+    // readable text, and marks it `isListingOnly`; unset, that stub would count
+    // as held and its document would never be hunted again. This source stores
+    // whole decisions by design, so a detail-less row here is always a failed
+    // fetch rather than a legitimate metadata-only state.
+    heldRequiresDetail: true,
     listSlicePage: listCzUsSlicePage,
     buildDecision: buildCzUsFromPayload,
   },

--- a/apps/api/src/handlers/case-law/ingestion/adapters/cz-us.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/cz-us.ts
@@ -15,6 +15,10 @@ import {
 import type {
   EmptyAst,
   IngestionResult,
+  ListingIdentity,
+  ReconciliationBuildOutcome,
+  ReconciliationSlicePage,
+  ReconciliationSlicePageOptions,
 } from "@/api/handlers/case-law/ingestion/adapter";
 import {
   INGESTION_USER_AGENT,
@@ -25,6 +29,7 @@ import {
 } from "@/api/handlers/case-law/ingestion/adapters/utils";
 import { parseUsDecisionHtml } from "@/api/handlers/case-law/ingestion/parsers/cz-us";
 import { fetchWithTimeout } from "@/api/lib/fetch";
+import { isRecord, isUnknownArray } from "@/api/lib/type-guards";
 
 const COMMON_HEADERS = {
   "User-Agent": INGESTION_USER_AGENT,
@@ -52,6 +57,11 @@ const COMMON_HEADERS = {
  * A null or legacy probe cursor starts the search-based historical repair at
  * FIRST_YEAR. This intentionally re-enumerates history once: it migrates the
  * incomplete probe crawl onto publisher-stated document identities.
+ *
+ * The same search form takes an arbitrary decision-date range, which is what
+ * makes this source reconcilable: a decision year can be listed on its own,
+ * without the crawl cursor ever reaching it. See `reconciliation` at the
+ * bottom of this file.
  */
 
 const ABSTRACT_URL = "https://nalus.usoud.cz/Search/GetAbstract.aspx";
@@ -103,6 +113,15 @@ const nalusIdentities = ({
 
 /** Largest result size that keeps one page's text fetches reasonably bounded. */
 const RESULTS_PAGE_SIZE = 40;
+
+/**
+ * Result size for a listing walk, the largest the search form offers. The
+ * crawl takes forty at a time because every row it keeps costs a text and an
+ * abstract fetch; a listing walk fetches no documents, so it asks for the whole
+ * eighty. NALUS honours it: a 2013 query answers `Výsledky 1 - 80 z celkem
+ * 4345`, and `?page=1` answers `81 - 160`.
+ */
+const LISTING_PAGE_SIZE = 80;
 
 /** Detail/abstract pairs fetched concurrently from the court. */
 const DOCUMENT_CONCURRENCY = 5;
@@ -493,7 +512,13 @@ type RecentCursor = {
 
 type CursorState = HistoricalCursor | RecentCursor;
 
-type ListedDecision = {
+/**
+ * One row of a NALUS result page, as {@link parseResultPage} reads it. This is
+ * also the reconciliation payload: the loop parks it verbatim as JSON and
+ * replays it through {@link buildCzUsFromPayload}, so every field the fetch
+ * and the identity depend on has to live here rather than in the walk.
+ */
+export type ListedDecision = {
   caseNumber: string;
   counter?: number | undefined;
   identityQuarantined?: true | undefined;
@@ -507,6 +532,26 @@ type ListedDecision = {
   sz?: string | undefined;
   ecli?: string | undefined;
 };
+
+/**
+ * The identity the ingest would store for this listed record.
+ *
+ * `sourceDocumentId` is the whole rule, and it is minted once, in
+ * {@link parseResultPage}: the exact publisher identity where the row exposes
+ * one, the content-addressed quarantine identity where it exposes none. Every
+ * decision this adapter writes — a parsed one, a listing-only one — carries
+ * that same string, so reading it back here is what keeps the crawl, the
+ * reconciliation loop and the ledger agreeing about which rows exist.
+ *
+ * `unidentifiable` is unreachable from a row {@link parseResultPage} built,
+ * since both branches produce a persistable id. It is stated anyway because
+ * the alternative is silence: an id the decision table would reject can never
+ * be held, so counting it as missing would keep the slice short forever.
+ */
+export const czUsListingIdentity = (listed: ListedDecision): ListingIdentity =>
+  isPersistableSourceDocumentId(listed.sourceDocumentId)
+    ? { type: "document", sourceDocumentId: listed.sourceDocumentId }
+    : { type: "unidentifiable" };
 
 type SearchPage = {
   listed: ListedDecision[];
@@ -723,19 +768,6 @@ const rollingPageDigest = (digest: string, page: SearchPage): string =>
       .join("|")}`,
   );
 
-const coverageSlice = (state: CursorState): string => {
-  switch (state.phase) {
-    case SWEEP_PHASE.HISTORICAL:
-      return `decision-year:${state.year}`;
-    case SWEEP_PHASE.RECENT:
-      return `availability:${state.availableFrom}:${state.availableTo}`;
-    default: {
-      const unhandled: never = state;
-      return panic(`Unhandled cz-us cursor: ${String(unhandled)}`);
-    }
-  }
-};
-
 const hiddenField = (html: string, name: string): string | undefined =>
   cheerio.load(html)(`#${name}`).attr("value");
 
@@ -811,7 +843,19 @@ const searchFields = (state: CursorState): Record<string, string> => {
   }
 };
 
-const parseResultPage = (html: string, expectedPage: number): SearchPage => {
+type ParseResultPageOptions = {
+  html: string;
+  /** 0-indexed page the request asked for. */
+  expectedPage: number;
+  /** Rows per page the request asked for; the banner is read against it. */
+  pageSize: number;
+};
+
+const parseResultPage = ({
+  html,
+  expectedPage,
+  pageSize,
+}: ParseResultPageOptions): SearchPage => {
   const banners = [
     ...html.matchAll(
       /Výsledky\s+(?<from>\d+)\s*-\s*(?<to>\d+)\s+z\s+celkem\s+(?<total>\d+)/gu,
@@ -836,7 +880,7 @@ const parseResultPage = (html: string, expectedPage: number): SearchPage => {
     throw new TypeError("NALUS result count banners disagree");
   }
 
-  const expectedFrom = expectedPage * RESULTS_PAGE_SIZE + 1;
+  const expectedFrom = expectedPage * pageSize + 1;
   if (banner.rangeFrom !== expectedFrom) {
     throw new SearchPageDriftError("NALUS result page moved during traversal");
   }
@@ -979,10 +1023,17 @@ const parseResultPage = (html: string, expectedPage: number): SearchPage => {
   return { listed, ...banner };
 };
 
-const fetchSearchPage = async (
-  state: CursorState,
-  signal: AbortSignal | undefined,
-): Promise<SearchPage | null> => {
+type FetchSearchPageOptions = {
+  state: CursorState;
+  pageSize: number;
+  signal?: AbortSignal | undefined;
+};
+
+const fetchSearchPage = async ({
+  state,
+  pageSize,
+  signal,
+}: FetchSearchPageOptions): Promise<SearchPage | null> => {
   const first = await fetchWithTimeout(SEARCH_URL, {
     headers: COMMON_HEADERS,
     redirect: "manual",
@@ -1013,7 +1064,7 @@ const fetchSearchPage = async (
     ctl00$MainContent$nalezy: "on",
     ctl00$MainContent$usneseni: "on",
     ctl00$MainContent$stanoviska_plena: "on",
-    ctl00$MainContent$resultsPageSize: String(RESULTS_PAGE_SIZE),
+    ctl00$MainContent$resultsPageSize: String(pageSize),
     ctl00$MainContent$resultsFontSize: "10",
     ctl00$MainContent$but_search: "Vyhledat",
     ...searchFields(state),
@@ -1058,18 +1109,43 @@ const fetchSearchPage = async (
   if (!results.ok) {
     throw new TypeError(`NALUS results returned HTTP ${results.status}`);
   }
-  return parseResultPage(await results.text(), state.page);
+  return parseResultPage({
+    html: await results.text(),
+    expectedPage: state.page,
+    pageSize,
+  });
 };
+
+/**
+ * What building one listed record produced.
+ *
+ * `detail-unavailable` still carries the decision the listing alone describes,
+ * because the two callers dispose of it differently: the crawl's cursor moves
+ * past this record either way, so a listing-only row is worth more to it than
+ * nothing, while the reconciliation must refuse it — a detail-less row would
+ * make the identity held and take the document out of every later
+ * reconciliation.
+ */
+export type CzUsBuildResult =
+  | { type: "built"; decision: IngestionResult }
+  /** NALUS lists the record but serves no readable text for it. */
+  | { type: "detail-unavailable"; decision: IngestionResult };
 
 const fetchListedDecision = async (
   listed: ListedDecision,
   signal: AbortSignal | undefined,
-): Promise<IngestionResult> => {
+): Promise<CzUsBuildResult> => {
   if (listed.identityQuarantined) {
-    return listedOnlyDecision(listed, "missing-record-identity");
+    return {
+      type: "detail-unavailable",
+      decision: listedOnlyDecision(listed, "missing-record-identity"),
+    };
   }
   if (listed.sz === undefined) {
-    return listedOnlyDecision(listed, "missing-text-action");
+    return {
+      type: "detail-unavailable",
+      decision: listedOnlyDecision(listed, "missing-text-action"),
+    };
   }
   const response = await fetchWithTimeout(listed.sourceUrl, {
     headers: COMMON_HEADERS,
@@ -1079,7 +1155,10 @@ const fetchListedDecision = async (
   });
   if (!response.ok) {
     if (response.status === 404 || response.status === 410) {
-      return listedOnlyDecision(listed, `http-${response.status}`);
+      return {
+        type: "detail-unavailable",
+        decision: listedOnlyDecision(listed, `http-${response.status}`),
+      };
     }
     throw new TypeError(
       `NALUS decision ${listed.sourceDocumentId} returned HTTP ${response.status}`,
@@ -1097,14 +1176,17 @@ const fetchListedDecision = async (
     nalusQuarantineIds: listed.quarantineRepairIds,
   });
   if (!decision) {
-    return listedOnlyDecision(
-      listed,
-      "unparseable-detail",
-      multiResponseSourceRaw({
-        listingHtml: listed.listingHtml,
-        textHtml: responseHtml,
-      }),
-    );
+    return {
+      type: "detail-unavailable",
+      decision: listedOnlyDecision(
+        listed,
+        "unparseable-detail",
+        multiResponseSourceRaw({
+          listingHtml: listed.listingHtml,
+          textHtml: responseHtml,
+        }),
+      ),
+    };
   }
   if (listed.listingDocketMissing) {
     decision.metadata["listingDocketMissing"] = true;
@@ -1147,7 +1229,7 @@ const fetchListedDecision = async (
       abstractHtml,
     }),
   );
-  return decision;
+  return { type: "built", decision };
 };
 
 const multiResponseSourceRaw = ({
@@ -1231,9 +1313,14 @@ const fetchListedDecisions = async (
   for (let start = 0; start < listed.length; start += DOCUMENT_CONCURRENCY) {
     const batch = listed.slice(start, start + DOCUMENT_CONCURRENCY);
     decisions.push(
+      // The crawl keeps a listing-only row for a record NALUS serves no text
+      // for: its cursor moves past that record either way, so the observation
+      // is worth more than nothing. Only the reconciliation refuses it.
       // oxlint-disable-next-line no-await-in-loop -- bounded batches pace the court while preserving result order
       ...(await Promise.all(
-        batch.map(async (item) => await fetchListedDecision(item, signal)),
+        batch.map(
+          async (item) => (await fetchListedDecision(item, signal)).decision,
+        ),
       )),
     );
     if (start + DOCUMENT_CONCURRENCY < listed.length) {
@@ -1243,6 +1330,176 @@ const fetchListedDecisions = async (
   }
   return decisions;
 };
+
+// ── Reconciliation ───────────────────────────────────────
+
+/**
+ * A reconciliation slice is one decision year, `YYYY`, which is exactly what
+ * the search form's `decidedFrom`/`decidedTo` pair addresses and what the
+ * crawl's historical phase already walks. Four digits sort lexicographically
+ * in chronological order, which is the ordering the ledger relies on.
+ *
+ * The year rather than a finer unit because NALUS states a total for whatever
+ * range it is asked about, and a year is comfortably walkable: the court's
+ * busiest years are around four thousand decisions (4,345 decided in 2013), so
+ * a slice is roughly 55 pages of {@link LISTING_PAGE_SIZE} against the engine's
+ * 200-page ceiling. A month would triple the request count to prove the same
+ * thing, and the court sits few enough days that most days would be empty.
+ */
+const CZ_US_FIRST_SLICE = String(FIRST_YEAR);
+
+const SLICE_PATTERN = /^\d{4}$/u;
+
+const parseSlice = (slice: string): number => {
+  if (!SLICE_PATTERN.test(slice)) {
+    panic(`cz-us slice is not a decision year: ${slice}`);
+  }
+  return Number.parseInt(slice, 10);
+};
+
+const czUsSliceOf = (now: Date): string => String(now.getUTCFullYear());
+
+const czUsNextSlice = (slice: string): string | null => {
+  const next = parseSlice(slice) + 1;
+  return next > new Date().getUTCFullYear() ? null : String(next);
+};
+
+const czUsPreviousSlice = (slice: string): string | null => {
+  const previous = parseSlice(slice) - 1;
+  return previous < FIRST_YEAR ? null : String(previous);
+};
+
+/**
+ * Slices near the tip that get re-walked on a fast cadence. The contract
+ * counts slices, not days, so for this adapter the window is two years: the
+ * current one and the one before it.
+ *
+ * Two rather than one because a decision made in December is often released
+ * the following spring, so on any January day the year that still gains
+ * documents is last year's. A slice outside the window is re-walked only when
+ * the ledger already recorded it short, which is exactly what a completed
+ * older year is not.
+ */
+const CZ_US_TIP_WINDOW_SLICES = 2;
+
+/**
+ * One page of the publisher's own listing for a decision year, with no text or
+ * abstract fetches.
+ *
+ * The availability filter is pinned to the latest closed publication day, the
+ * same bound the crawl uses: NALUS keeps the current day's result set live, so
+ * a walk that included it would list rows that move underneath it.
+ *
+ * A failed request is thrown, never flattened into an empty page. The crawl
+ * can afford to read a dead search as "nothing here" because a cursor that
+ * moves on can be walked again; a ledger row cannot, since an outage recorded
+ * as an empty year makes that year settled and it is never revisited. So only
+ * the publisher's own stated-empty answer — the no-records message with the
+ * results button disabled, which {@link fetchSearchPage} alone returns `null`
+ * for — is an empty slice. A missing count banner, a 5xx, a page that moved
+ * underneath the request: all throw, and the engine retries on a later pass.
+ */
+const listCzUsSlicePage = async ({
+  slice,
+  page,
+  signal,
+}: ReconciliationSlicePageOptions): Promise<ReconciliationSlicePage> => {
+  const listing = await fetchSearchPage({
+    state: {
+      phase: SWEEP_PHASE.HISTORICAL,
+      availableTo: latestClosedAvailabilityDay(new Date()),
+      year: parseSlice(slice),
+      pass: CRAWL_PASS.COLLECT,
+      page,
+      digest: DIGEST_SEED,
+    },
+    pageSize: LISTING_PAGE_SIZE,
+    signal,
+  });
+  if (listing === null) {
+    return { items: [], totalPages: 0 };
+  }
+  return {
+    items: listing.listed.map((listed) => ({
+      identity: czUsListingIdentity(listed),
+      payload: listed,
+    })),
+    totalPages: Math.ceil(listing.reported / LISTING_PAGE_SIZE),
+  };
+};
+
+/**
+ * Validate a payload the loop stored verbatim.
+ *
+ * Revalidated rather than trusted: it may have been parked for days, and a
+ * shape this adapter no longer produces has to be reported as unbuildable
+ * instead of replayed on faith. Every field {@link fetchListedDecision} reads
+ * is checked, because a payload missing one of them would otherwise fetch the
+ * wrong document or mint a different identity than the walk keyed it under.
+ */
+const isListedDecision = (value: unknown): value is ListedDecision => {
+  if (!isRecord(value)) {
+    return false;
+  }
+  // Field names are typed against `ListedDecision`, so renaming one here is a
+  // typecheck failure rather than a guard that silently stops checking it.
+  const isString = (field: keyof ListedDecision): boolean =>
+    typeof value[field] === "string";
+  const isOptionalString = (field: keyof ListedDecision): boolean =>
+    value[field] === undefined || isString(field);
+  const isOptionalTrue = (field: keyof ListedDecision): boolean =>
+    value[field] === undefined || value[field] === true;
+  return (
+    isString("caseNumber") &&
+    isString("sourceDocumentId") &&
+    isString("quarantineId") &&
+    isString("listingHtml") &&
+    isString("sourceUrl") &&
+    isUnknownArray(value["quarantineRepairIds"]) &&
+    value["quarantineRepairIds"].every((id) => typeof id === "string") &&
+    (value["counter"] === undefined || typeof value["counter"] === "number") &&
+    isOptionalString("nalusRecordId") &&
+    isOptionalString("sz") &&
+    isOptionalString("ecli") &&
+    isOptionalTrue("identityQuarantined") &&
+    isOptionalTrue("listingDocketMissing")
+  );
+};
+
+/**
+ * Replay one listed record through the adapter's own fetch and parse path.
+ *
+ * A record the listing names but whose text NALUS does not serve is reported,
+ * not stored: the listing-only row {@link fetchListedDecision} still builds is
+ * right for the crawl and wrong here, because writing it would make the
+ * identity held and take the document out of every later reconciliation.
+ */
+const buildCzUsFromPayload = async (
+  payload: unknown,
+  signal?: AbortSignal,
+): Promise<ReconciliationBuildOutcome> => {
+  if (
+    !isListedDecision(payload) ||
+    czUsListingIdentity(payload).type === "unidentifiable"
+  ) {
+    return { type: "unkeyable" };
+  }
+  const built = await fetchListedDecision(payload, signal);
+  switch (built.type) {
+    case "built":
+      return { type: "built", decision: built.decision };
+    case "detail-unavailable":
+      return { type: "detail-unavailable" };
+    default: {
+      const exhaustive: never = built;
+      return panic(
+        `Unhandled cz-us build result: ${JSON.stringify(exhaustive)}`,
+      );
+    }
+  }
+};
+
+// ── Adapter ──────────────────────────────────────────────
 
 export const czUsAdapter = defineSourceAdapter({
   key: ADAPTER_KEYS.CZ_US,
@@ -1342,6 +1599,23 @@ export const czUsAdapter = defineSourceAdapter({
     }
   },
 
+  /**
+   * The search form answers a decision-date range on its own, so what a year
+   * holds is answerable without the crawl cursor ever reaching it: list the
+   * year, key each record the way the ingest would, and compare against what
+   * is held. This loop is the only writer of coverage for this source; the
+   * crawl states no `SliceCoverage`.
+   */
+  reconciliation: {
+    firstSlice: CZ_US_FIRST_SLICE,
+    sliceOf: czUsSliceOf,
+    nextSlice: czUsNextSlice,
+    previousSlice: czUsPreviousSlice,
+    tipWindowDays: CZ_US_TIP_WINDOW_SLICES,
+    listSlicePage: listCzUsSlicePage,
+    buildDecision: buildCzUsFromPayload,
+  },
+
   async fetchPage(cursor, _config, signal) {
     return await Result.tryPromise({
       try: async () => {
@@ -1349,7 +1623,11 @@ export const czUsAdapter = defineSourceAdapter({
         const state = cursor ? parseCursor(cursor, now) : historicalStart(now);
         let page: SearchPage | null;
         try {
-          page = await fetchSearchPage(state, signal);
+          page = await fetchSearchPage({
+            state,
+            pageSize: RESULTS_PAGE_SIZE,
+            signal,
+          });
         } catch (error) {
           if (state.page > 0 && error instanceof SearchPageDriftError) {
             return {
@@ -1369,11 +1647,6 @@ export const czUsAdapter = defineSourceAdapter({
           return {
             decisions: [],
             nextCursor: makeCursor(nextSlice(state, now)),
-            coverage: {
-              slice: coverageSlice(state),
-              reported: 0,
-              collected: 0,
-            },
           };
         }
 
@@ -1399,11 +1672,6 @@ export const czUsAdapter = defineSourceAdapter({
           return {
             decisions: [],
             nextCursor: makeCursor(nextSlice(state, now)),
-            coverage: {
-              slice: coverageSlice(state),
-              reported: page.reported,
-              collected: page.reported,
-            },
           };
         }
 


### PR DESCRIPTION
Implements the `reconciliation` capability on the cz-us (NALUS) adapter.

Slice = decision year (`YYYY`, lexicographic): the search form's `decidedFrom`/`decidedTo` is the axis the crawl's historical phase already drives, and probed year volumes (~4,300 at the maximum) fit a listing walk with several-fold headroom. `firstSlice` reuses the adapter's first-year constant; `tipWindowDays = 2` slices (current + previous year), since December decisions are often released the following spring. Listing pages use the form's largest server-honoured page size (80, verified across consecutive pages); the crawl keeps its smaller size because its rows each cost document fetches. `fetchPage` and the cursor grammar are byte-identical — the deployed mid-history cursor is undisturbed.

Identity was already minted in exactly one place per row (exact publisher identity or the content-addressed quarantine fallback); the listing identity reads that same string back. `detail-unavailable` covers what NALUS lists but does not serve readably (quarantined identity, withdrawn text, 404/410, unparseable detail); the crawl keeps the listing-only row while reconciliation refuses it, via a discriminated build result both paths share. Stated-empty is only the publisher's own no-records answer; a missing or contradictory count banner, a 5xx, or a page that moved under the request all throw.

The crawl-side coverage emission is removed: it wrote `collected = reported` on a verified slice ("verified present at the publisher"), a different semantic from the ledger's "identities held", and two ledgers for one source is a drift class. The reconciliation loop now owns coverage accounting for this source; pre-existing rows under the old prefixed keys are untouched and do not collide with the loop's bare year keys. Assertions that used coverage as evidence of slice advancement now assert the advanced cursor.

Tests: 30 new; 119 across the adapter/parser/conformance/plan suites green.
