### PR TITLE
feat(case-law): settled-slice recheck and detail-aware heldness

### DIFF
--- a/apps/api/src/handlers/case-law/ingestion/adapters/sk-us.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/sk-us.test.ts
@@ -489,6 +489,22 @@ describe("sk-us buildDecision", () => {
     });
   });
 
+  test("the marker the crawl stores is what makes heldness require detail", async () => {
+    mockFetch({ search: [], download: { type: "status", status: 404 } });
+
+    // Two halves of one decision, asserted together because either alone is
+    // silently wrong. The crawl keeps the row the reconciliation refuses and
+    // marks it `isListingOnly`; the capability declares that such a row is not
+    // held. Drop the marker and the declaration filters nothing; drop the
+    // declaration and the marked row reads as held, the slice reads reconciled,
+    // and the court is never asked for that document again.
+    expect(await buildSkUsDecision(CHAMBER_RESOLUTION)).toMatchObject({
+      type: "detail-unavailable",
+      decision: { isListingOnly: true },
+    });
+    expect(reconciliation.heldRequiresDetail).toBe(true);
+  });
+
   test("a 200 that is not a PDF is no document either", async () => {
     mockFetch({ search: [], download: { type: "not-a-pdf" } });
 

--- a/apps/api/src/handlers/case-law/ingestion/adapters/sk-us.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/sk-us.ts
@@ -765,6 +765,10 @@ export const skUsAdapter = defineSourceAdapter({
     nextSlice: skUsNextSlice,
     previousSlice: skUsPreviousSlice,
     tipWindowDays: SK_US_TIP_WINDOW_SLICES,
+    // The crawl keeps the listing-only row a failed PDF leaves behind and
+    // `buildSkUsDecision` marks it `isListingOnly`; unset, that row would count
+    // as held and its document would never be hunted again.
+    heldRequiresDetail: true,
     listSlicePage: listSkUsSlicePage,
     buildDecision: buildSkUsFromPayload,
   },

--- a/apps/api/src/handlers/case-law/ingestion/adapters/sk-us.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/sk-us.ts
@@ -768,6 +768,16 @@ export const skUsAdapter = defineSourceAdapter({
     // The crawl keeps the listing-only row a failed PDF leaves behind and
     // `buildSkUsDecision` marks it `isListingOnly`; unset, that row would count
     // as held and its document would never be hunted again.
+    //
+    // Heldness stays a statement about the docket rather than the document,
+    // because this source stores one row per `(caseNumber, language)` and emits
+    // no `sourceDocumentId` at all — see `skUsListingIdentity`. A docket whose
+    // row carries detail is therefore held even where a sibling document
+    // failed, and a walk hunts one representative per docket, not all of them.
+    // That bound belongs to the identity model, not to this flag: without the
+    // flag the docket is held whatever its row carries, and fetching siblings
+    // before the stored rows carry `documentId` would only have them overwrite
+    // one another in the single row that exists for the docket.
     heldRequiresDetail: true,
     listSlicePage: listSkUsSlicePage,
     buildDecision: buildSkUsFromPayload,

--- a/apps/api/src/handlers/case-law/ingestion/reconciliation-engine.db.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/reconciliation-engine.db.test.ts
@@ -2,24 +2,35 @@ import { afterAll, beforeAll, beforeEach, expect, test } from "bun:test";
 import { and, eq, inArray } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/pglite";
 
+import { DAY_IN_MS } from "@stll/time";
+
 import { authRelationsPart } from "@/api/db/auth-schema";
 import type { Transaction } from "@/api/db/root";
 import type { ScopedDb } from "@/api/db/safe-db";
 import {
   caseLawCoverageSlices,
+  caseLawDecisions,
   caseLawReconciliationItems,
   caseLawSources,
   RECONCILIATION_ITEM_STATUS,
   relations,
 } from "@/api/db/schema";
 import { runReconciliationWorkUnit } from "@/api/handlers/case-law/ingestion/reconciliation-engine";
-import { SLICE_WALK_REASON } from "@/api/handlers/case-law/ingestion/reconciliation-plan";
+import {
+  RECONCILIATION_SETTLED_RECHECK_MS,
+  SLICE_WALK_REASON,
+} from "@/api/handlers/case-law/ingestion/reconciliation-plan";
 import { createSafeId } from "@/api/lib/branded-types";
 import type { SafeId } from "@/api/lib/branded-types";
 import { addUtcDays, toUtcDateString } from "@/api/lib/dates";
 import { AdapterFetchError } from "@/api/lib/errors/tagged-errors";
-import { listingIdentityKey } from "@/api/lib/legal-search/ingestion-types";
+import { sanitizeResult } from "@/api/lib/legal-search/ingestion-normalization";
+import {
+  EMPTY_AST,
+  listingIdentityKey,
+} from "@/api/lib/legal-search/ingestion-types";
 import type {
+  IngestionResult,
   ReconciliationSlicePage,
   ReconciliationSlicePageOptions,
   SourceReconciliation,
@@ -104,6 +115,11 @@ const LISTING_ITEMS = [
   },
 ] as const;
 
+/** Real dockets, so the fallback identity key is the shape the ledger keys. */
+const FIXTURE_CASE_NUMBERS = ["11 C 153/2025", "31 Cm 8/2024"] as const;
+const FIXTURE_COURT = "Krajský soud v Brně";
+const FIXTURE_LANGUAGE = "cs";
+
 /**
  * A publisher that lists two decisions and serves neither document. Enough to
  * drive a real walk without a pipeline write: what is under test is which
@@ -152,6 +168,28 @@ const stubReconciliation: SourceReconciliation = {
   buildDecision: async (payload) => {
     builds.push(payload);
     return await Promise.resolve({ type: "detail-unavailable" });
+  },
+};
+
+/**
+ * The same publisher, listing dockets instead of document ids: the other half
+ * of the identity index, which is answered by its own held query.
+ */
+const caseNumberStub: SourceReconciliation = {
+  ...stubReconciliation,
+  listSlicePage: async (options): Promise<ReconciliationSlicePage> => {
+    listed.push(options);
+    return await Promise.resolve({
+      items: FIXTURE_CASE_NUMBERS.map((caseNumber) => ({
+        identity: {
+          type: "case-number",
+          caseNumber,
+          language: FIXTURE_LANGUAGE,
+        },
+        payload: { caseNumber },
+      })),
+      totalPages: listing.totalPages,
+    });
   },
 };
 
@@ -229,11 +267,14 @@ const checkedAtBySlice = async (
     ).map(({ slice, checkedAt }) => [slice, checkedAt]),
   );
 
-const runUnit = async (sourceId: SafeId<"caseLawSource">) =>
+const runUnit = async (
+  sourceId: SafeId<"caseLawSource">,
+  reconciliation: SourceReconciliation = stubReconciliation,
+) =>
   await runReconciliationWorkUnit({
     adapterKey: "engine-fixture",
     sourceId,
-    reconciliation: stubReconciliation,
+    reconciliation,
     scopedDb,
     now: () => NOW,
     fetchDelayMs: 0,
@@ -591,4 +632,233 @@ test("a publisher claiming an absurd page count is refused, not walked", async (
     )
     .limit(1);
   expect(ledger).toEqual({ reported: 2, collected: 0 });
+});
+
+// ── Rechecking a settled slice ──────────────────────────
+
+/**
+ * A settled ledger row is the loop's blind spot. It records what the publisher
+ * listed on the day of the walk, nothing re-selects it, and a publisher that
+ * goes on adding to the slice for months makes that number quietly wrong, with
+ * no short row, no parked item and no failure to show for it. Both halves are
+ * asserted: that the recheck fires at all, and that it fires only once the row
+ * is old enough to be worth an otherwise-idle turn.
+ */
+const seedSettledHistory = async (
+  sourceId: SafeId<"caseLawSource">,
+  checkedAt: Date,
+): Promise<void> => {
+  await seedFreshTip(sourceId);
+  // Also the feed's first slice, so the historical sweep is exhausted and
+  // cannot answer the turn ahead of the recheck.
+  await seedSlice({
+    sourceId,
+    slice: OWED_SLICE,
+    reported: 1,
+    collected: 1,
+    checkedAt,
+  });
+};
+
+const ledgerRow = async (
+  sourceId: SafeId<"caseLawSource">,
+  slice: string,
+): Promise<{ reported: number; collected: number } | undefined> =>
+  (
+    await db
+      .select({
+        reported: caseLawCoverageSlices.reported,
+        collected: caseLawCoverageSlices.collected,
+      })
+      .from(caseLawCoverageSlices)
+      .where(
+        and(
+          eq(caseLawCoverageSlices.sourceId, sourceId),
+          eq(caseLawCoverageSlices.slice, slice),
+        ),
+      )
+      .limit(1)
+  ).at(0);
+
+test("a settled slice past the recheck window is re-walked, and a grown listing re-opens it", async () => {
+  const sourceId = await seedSource();
+  await seedSettledHistory(
+    sourceId,
+    new Date(NOW.getTime() - RECONCILIATION_SETTLED_RECHECK_MS - DAY_IN_MS),
+  );
+
+  const outcome = await runUnit(sourceId);
+
+  expect(outcome).toMatchObject({
+    type: "worked",
+    summary: {
+      unit: "slice",
+      slice: OWED_SLICE,
+      reason: SLICE_WALK_REASON.RECHECK,
+    },
+  });
+  expect(listed.map(({ slice }) => slice)).toEqual([OWED_SLICE]);
+
+  // The publisher now lists two where the row claimed one, and the walk held
+  // neither: the row records short and the slice rejoins the ordinary cycle at
+  // priority 3. The recheck itself repairs nothing; it only re-states.
+  expect(await ledgerRow(sourceId, OWED_SLICE)).toEqual({
+    reported: 2,
+    collected: 0,
+  });
+});
+
+test("a settled slice inside the recheck window is left alone", async () => {
+  // Otherwise proved history is re-walked at nearly the tip's own cadence, and
+  // the politeness budget spent on it is budget not spent on slices that are
+  // actually short.
+  const sourceId = await seedSource();
+  await seedSettledHistory(
+    sourceId,
+    new Date(NOW.getTime() - RECONCILIATION_SETTLED_RECHECK_MS + DAY_IN_MS),
+  );
+
+  expect(await runUnit(sourceId)).toEqual({ type: "idle" });
+  expect(listed).toEqual([]);
+});
+
+// ── Heldness that means detail-held ─────────────────────
+
+/**
+ * Metadata exactly as the pipeline writes it, produced by the pipeline's own
+ * normalizer rather than spelled out here. The engine's filter reads a path
+ * inside this blob; a hand-written stand-in could agree with the filter while
+ * both disagreed with the column, and the test would prove nothing.
+ */
+const storedMetadata = (isListingOnly: boolean): Record<string, unknown> =>
+  sanitizeResult({
+    caseNumber: FIXTURE_CASE_NUMBERS[0],
+    court: FIXTURE_COURT,
+    country: "CZE",
+    language: FIXTURE_LANGUAGE,
+    isListingOnly,
+    metadata: {},
+    rawHash: "0".repeat(64),
+    documentAst: EMPTY_AST,
+  } satisfies IngestionResult).metadata;
+
+type SeedDecisionInput = {
+  sourceId: SafeId<"caseLawSource">;
+  caseNumber: string;
+  sourceDocumentId: string | null;
+  isListingOnly: boolean;
+};
+
+const seedDecision = async ({
+  caseNumber,
+  isListingOnly,
+  sourceDocumentId,
+  sourceId,
+}: SeedDecisionInput): Promise<void> => {
+  await db.insert(caseLawDecisions).values({
+    id: createSafeId<"caseLawDecision">(),
+    sourceId,
+    caseNumber,
+    sourceDocumentId,
+    court: FIXTURE_COURT,
+    country: "CZE",
+    language: FIXTURE_LANGUAGE,
+    metadata: storedMetadata(isListingOnly),
+  });
+};
+
+/** A short, stale slice: the walk under test, with no other arm firing. */
+const seedWalkableSlice = async (
+  sourceId: SafeId<"caseLawSource">,
+): Promise<void> => {
+  await seedFreshTip(sourceId);
+  await seedSlice({
+    sourceId,
+    slice: OWED_SLICE,
+    reported: 2,
+    collected: 0,
+    checkedAt: addUtcDays(NOW, -2),
+  });
+};
+
+/** One row per listed document identity; only the second carries detail. */
+const seedDocumentIdentityRows = async (
+  sourceId: SafeId<"caseLawSource">,
+): Promise<void> => {
+  for (const [index, item] of LISTING_ITEMS.entries()) {
+    // oxlint-disable-next-line no-await-in-loop -- fixture seeding, sequential on one pglite handle
+    await seedDecision({
+      sourceId,
+      caseNumber: FIXTURE_CASE_NUMBERS[index] ?? "",
+      sourceDocumentId: item.odkaz.split("/").at(-1) ?? "",
+      isListingOnly: index === 0,
+    });
+  }
+};
+
+test("a listing-only row is not held where the source requires detail", async () => {
+  // Such a row exists because a document fetch failed: the identity is stored
+  // and the document is not. Counting it as held is what takes the decision out
+  // of every later reconciliation — the slice reads reconciled and nothing ever
+  // asks the publisher for the document again.
+  const sourceId = await seedSource();
+  await seedWalkableSlice(sourceId);
+  await seedDocumentIdentityRows(sourceId);
+
+  const outcome = await runUnit(sourceId, {
+    ...stubReconciliation,
+    heldRequiresDetail: true,
+  });
+
+  expect(outcome).toMatchObject({
+    type: "worked",
+    summary: { slice: OWED_SLICE, keyable: 2, heldBefore: 1, parked: 1 },
+  });
+  // The stub row was hunted again; the row carrying detail was left alone.
+  expect(builds).toHaveLength(1);
+});
+
+test("without the declaration both rows count as held, whatever they carry", async () => {
+  // The default, and it has to stay the default: a source that ingests
+  // metadata first and drains documents later holds a large, legitimately
+  // detail-less corpus, and filtering those rows out would report millions of
+  // decisions missing and re-ingest every one of them.
+  const sourceId = await seedSource();
+  await seedWalkableSlice(sourceId);
+  await seedDocumentIdentityRows(sourceId);
+
+  expect(await runUnit(sourceId)).toMatchObject({
+    type: "worked",
+    summary: { slice: OWED_SLICE, keyable: 2, heldBefore: 2, parked: 0 },
+  });
+  expect(builds).toEqual([]);
+});
+
+test("the docket half of the identity index applies the same filter", async () => {
+  // Two queries answer "held", one per half of the identity index. A filter
+  // added to one and not the other would make heldness mean two things for one
+  // source, decided by whether the publisher happened to state a document id.
+  const sourceId = await seedSource();
+  await seedWalkableSlice(sourceId);
+  for (const [index, caseNumber] of FIXTURE_CASE_NUMBERS.entries()) {
+    // oxlint-disable-next-line no-await-in-loop -- fixture seeding, sequential on one pglite handle
+    await seedDecision({
+      sourceId,
+      caseNumber,
+      // The fallback half is exactly the rows stored without a publisher id.
+      sourceDocumentId: null,
+      isListingOnly: index === 0,
+    });
+  }
+
+  const outcome = await runUnit(sourceId, {
+    ...caseNumberStub,
+    heldRequiresDetail: true,
+  });
+
+  expect(outcome).toMatchObject({
+    type: "worked",
+    summary: { slice: OWED_SLICE, keyable: 2, heldBefore: 1, parked: 1 },
+  });
+  expect(builds).toHaveLength(1);
 });

--- a/apps/api/src/handlers/case-law/ingestion/reconciliation-engine.ts
+++ b/apps/api/src/handlers/case-law/ingestion/reconciliation-engine.ts
@@ -24,7 +24,8 @@
  */
 
 import { panic } from "better-result";
-import { and, eq, inArray, isNull, lt, min } from "drizzle-orm";
+import type { SQL } from "drizzle-orm";
+import { and, eq, gte, inArray, isNull, lt, min } from "drizzle-orm";
 
 import type { ScopedDb } from "@/api/db/safe-db";
 import {
@@ -44,6 +45,7 @@ import type {
   SliceWalkReason,
 } from "@/api/handlers/case-law/ingestion/reconciliation-plan";
 import {
+  RECONCILIATION_SETTLED_RECHECK_MS,
   RECONCILIATION_SLICE_STALE_MS,
   partitionShortSliceCandidates,
   selectReconciliationWorkUnit,
@@ -54,6 +56,7 @@ import { AdapterFetchError } from "@/api/lib/errors/tagged-errors";
 import { errorTag } from "@/api/lib/errors/utils";
 import type { CaseLawSourceIngestionLease } from "@/api/lib/legal-search/case-law-source-ingestion-lease";
 import { acquireCaseLawSourceIngestionLease } from "@/api/lib/legal-search/case-law-source-ingestion-lease";
+import { storedObservationHasDetail } from "@/api/lib/legal-search/ingestion-normalization";
 import type {
   ListingIdentity,
   ReconciliationListingItem,
@@ -202,11 +205,30 @@ const forEachChunk = async <T>(
   }
 };
 
+/**
+ * The extra condition `heldRequiresDetail` adds to a held lookup, or nothing.
+ *
+ * Both halves of the identity index take it, and that is the point: a filter
+ * applied to one query and not the other would make a source's heldness mean
+ * two different things depending on whether the publisher happened to state a
+ * document id for the item.
+ */
+const detailCondition = (requireDetail: boolean): SQL | undefined =>
+  requireDetail
+    ? storedObservationHasDetail(caseLawDecisions.metadata)
+    : undefined;
+
+type HeldDocumentIdsOptions = {
+  sourceId: SafeId<"caseLawSource">;
+  documentIds: readonly string[];
+  /** See `SourceReconciliation.heldRequiresDetail`. */
+  requireDetail: boolean;
+};
+
 /** Which of these publisher document ids this source already has rows for. */
 const selectHeldDocumentIds = async (
   scopedDb: ScopedDb,
-  sourceId: SafeId<"caseLawSource">,
-  documentIds: readonly string[],
+  { documentIds, requireDetail, sourceId }: HeldDocumentIdsOptions,
 ): Promise<string[]> => {
   if (documentIds.length === 0) {
     return [];
@@ -220,6 +242,7 @@ const selectHeldDocumentIds = async (
           and(
             eq(caseLawDecisions.sourceId, sourceId),
             inArray(caseLawDecisions.sourceDocumentId, [...documentIds]),
+            detailCondition(requireDetail),
           ),
         )
         .limit(documentIds.length),
@@ -229,6 +252,14 @@ const selectHeldDocumentIds = async (
   );
 };
 
+type HeldCaseNumbersOptions = {
+  sourceId: SafeId<"caseLawSource">;
+  language: string;
+  caseNumbers: readonly string[];
+  /** See `SourceReconciliation.heldRequiresDetail`. */
+  requireDetail: boolean;
+};
+
 /**
  * The same question for the fallback half of the identity index: rows stored
  * without a publisher document id are keyed on the docket and the language, so
@@ -236,9 +267,7 @@ const selectHeldDocumentIds = async (
  */
 const selectHeldCaseNumbers = async (
   scopedDb: ScopedDb,
-  sourceId: SafeId<"caseLawSource">,
-  language: string,
-  caseNumbers: readonly string[],
+  { caseNumbers, language, requireDetail, sourceId }: HeldCaseNumbersOptions,
 ): Promise<string[]> => {
   if (caseNumbers.length === 0) {
     return [];
@@ -254,6 +283,7 @@ const selectHeldCaseNumbers = async (
             inArray(caseLawDecisions.caseNumber, [...caseNumbers]),
             eq(caseLawDecisions.language, language),
             isNull(caseLawDecisions.sourceDocumentId),
+            detailCondition(requireDetail),
           ),
         )
         .limit(caseNumbers.length),
@@ -273,11 +303,17 @@ const addHeldKey = (held: Set<string>, identity: ListingIdentity): void => {
   }
 };
 
+type HeldIdentityKeysOptions = {
+  sourceId: SafeId<"caseLawSource">;
+  identities: readonly ListingIdentity[];
+  /** See `SourceReconciliation.heldRequiresDetail`. */
+  requireDetail: boolean;
+};
+
 /** The identity keys, out of the given ones, this source already holds. */
 const selectHeldIdentityKeys = async (
   scopedDb: ScopedDb,
-  sourceId: SafeId<"caseLawSource">,
-  identities: readonly ListingIdentity[],
+  { identities, requireDetail, sourceId }: HeldIdentityKeysOptions,
 ): Promise<Set<string>> => {
   const documentIds = new Set<string>();
   const caseNumbersByLanguage = new Map<string, Set<string>>();
@@ -296,11 +332,11 @@ const selectHeldIdentityKeys = async (
 
   const held = new Set<string>();
   await forEachChunk([...documentIds], async (chunk) => {
-    for (const sourceDocumentId of await selectHeldDocumentIds(
-      scopedDb,
+    for (const sourceDocumentId of await selectHeldDocumentIds(scopedDb, {
       sourceId,
-      chunk,
-    )) {
+      documentIds: chunk,
+      requireDetail,
+    })) {
       addHeldKey(held, { type: "document", sourceDocumentId });
     }
   });
@@ -308,12 +344,12 @@ const selectHeldIdentityKeys = async (
   for (const [language, caseNumbers] of caseNumbersByLanguage) {
     // oxlint-disable-next-line no-await-in-loop -- one language's dockets at a time; the fallback identity is language-scoped and the chunks inside are already sequential
     await forEachChunk([...caseNumbers], async (chunk) => {
-      for (const caseNumber of await selectHeldCaseNumbers(
-        scopedDb,
+      for (const caseNumber of await selectHeldCaseNumbers(scopedDb, {
         sourceId,
         language,
-        chunk,
-      )) {
+        caseNumbers: chunk,
+        requireDetail,
+      })) {
         addHeldKey(held, { type: "case-number", caseNumber, language });
       }
     });
@@ -380,6 +416,65 @@ const selectStaleShortSlices = async (
         .orderBy(caseLawCoverageSlices.checkedAt)
         .limit(SHORT_SLICE_CANDIDATES),
   );
+
+/**
+ * The oldest-checked settled slice below the tip window, or null. Whether it
+ * is old enough to walk is the selection's decision, not this query's.
+ *
+ * Settled here means `collected >= reported`: the row says the publisher's own
+ * count was met. Nothing else in the loop ever looks at such a row again, so it
+ * keeps stating what the publisher listed on the day of the walk however long
+ * the publisher goes on adding to that slice.
+ *
+ * That predicate is also what keeps this from fighting the settled-row touch in
+ * the assembly below. The two populations are disjoint by construction: the
+ * touch only ever re-stamps rows that are *short* and settled by retirement, so
+ * those rows are permanently young, while the rows read here are never touched
+ * at all and age freely. Sharing a population would break both — an oldest-first
+ * read over the union would be answered by whichever half was larger, and the
+ * rows that genuinely went stale would sit behind rows something else is
+ * already re-stamping every turn.
+ *
+ * The boundary that leaves: a slice settled by retired items stays short, so it
+ * lives in the touch population and its age is unobservable from `checkedAt`,
+ * which today means both "walked" and "rotated out of the candidate window".
+ * Separating the two is a schema change, not a query.
+ *
+ * One row, ordered, limit 1. The source's rows are reachable through
+ * `case_law_coverage_slices_source_slice_idx`; the short partial index is the
+ * exact complement of this predicate and deliberately does not serve it.
+ */
+const selectRecheckCandidate = async (
+  scopedDb: ScopedDb,
+  sourceId: SafeId<"caseLawSource">,
+  /** The tip window's own start; slices at or above it are re-walked anyway. */
+  belowSlice: string,
+): Promise<LedgerSlice | null> =>
+  (
+    await scopedDb(
+      async (tx) =>
+        await tx
+          .select({
+            slice: caseLawCoverageSlices.slice,
+            reported: caseLawCoverageSlices.reported,
+            collected: caseLawCoverageSlices.collected,
+            checkedAt: caseLawCoverageSlices.checkedAt,
+          })
+          .from(caseLawCoverageSlices)
+          .where(
+            and(
+              eq(caseLawCoverageSlices.sourceId, sourceId),
+              lt(caseLawCoverageSlices.slice, belowSlice),
+              gte(
+                caseLawCoverageSlices.collected,
+                caseLawCoverageSlices.reported,
+              ),
+            ),
+          )
+          .orderBy(caseLawCoverageSlices.checkedAt)
+          .limit(1),
+    )
+  ).at(0) ?? null;
 
 /**
  * The oldest slice this source has any ledger row for.
@@ -617,11 +712,11 @@ const walkSlice = async ({
 
   const items = [...keyed.values()];
   summary.keyable = items.length;
-  const held = await selectHeldIdentityKeys(
-    scopedDb,
+  const held = await selectHeldIdentityKeys(scopedDb, {
     sourceId,
-    items.map(({ identity }) => identity),
-  );
+    identities: items.map(({ identity }) => identity),
+    requireDetail: reconciliation.heldRequiresDetail === true,
+  });
   const missing = items.filter(({ identityKey }) => !held.has(identityKey));
   summary.heldBefore = items.length - missing.length;
 
@@ -734,11 +829,11 @@ const retryParkedItems = async ({
     }),
   );
 
-  const held = await selectHeldIdentityKeys(
-    scopedDb,
+  const held = await selectHeldIdentityKeys(scopedDb, {
     sourceId,
-    outstanding.map(({ identity }) => identity),
-  );
+    identities: outstanding.map(({ identity }) => identity),
+    requireDetail: reconciliation.heldRequiresDetail === true,
+  });
   const settled = outstanding.filter(({ identityKey }) =>
     held.has(identityKey),
   );
@@ -797,13 +892,22 @@ export const runReconciliationWorkUnit = async ({
   const staleBefore = new Date(
     startedAt.getTime() - RECONCILIATION_SLICE_STALE_MS,
   );
+  // The tip window's own start, which is also the ceiling on everything the
+  // sweep and the recheck may reach for: the tip is re-walked on its own
+  // cadence and needs neither.
+  const tipStart = tipSlices.at(-1) ?? reconciliation.sliceOf(startedAt);
 
-  const [tipLedger, shortRows, oldestLedgerSlice, dueParked] =
+  const [tipLedger, shortRows, oldestLedgerSlice, dueParked, recheckCandidate] =
     await Promise.all([
       selectLedgerSlices(scopedDb, sourceId, tipSlices),
       selectStaleShortSlices(scopedDb, sourceId, staleBefore),
       selectOldestLedgerSlice(scopedDb, sourceId),
       hasDueParkedItems(scopedDb, sourceId, startedAt),
+      // Asked every turn rather than only once the higher priorities come up
+      // empty: idle is the steady state of a surveyed source, so the branch
+      // that skipped it would almost never be taken, and one more bounded read
+      // in the batch already in flight costs no extra round trip.
+      selectRecheckCandidate(scopedDb, sourceId, tipStart),
     ]);
 
   const terminalBySlice = await countTerminalReconciliationItemsBySlice(
@@ -844,7 +948,6 @@ export const runReconciliationWorkUnit = async ({
 
   // The sweep frontier: the oldest slice with any row, bounded above by the
   // tip window's own start so a source with only tip rows still sweeps.
-  const tipStart = tipSlices.at(-1) ?? reconciliation.sliceOf(startedAt);
   const frontier =
     oldestLedgerSlice === null || oldestLedgerSlice > tipStart
       ? tipStart
@@ -859,7 +962,9 @@ export const runReconciliationWorkUnit = async ({
     ),
     unsettledShortSlices: unsettled,
     sweepSlice: reconciliation.previousSlice(frontier),
+    recheckCandidate,
     staleAfterMs: RECONCILIATION_SLICE_STALE_MS,
+    recheckAfterMs: RECONCILIATION_SETTLED_RECHECK_MS,
   });
 
   if (unit.type === "idle") {

--- a/apps/api/src/handlers/case-law/ingestion/reconciliation-plan.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/reconciliation-plan.test.ts
@@ -15,12 +15,17 @@
 
 import { describe, expect, test } from "bun:test";
 
+import { DAY_IN_MS } from "@stll/time";
+
 import { czRegionalAdapter } from "@/api/handlers/case-law/ingestion/adapters/cz-regional";
 import type {
+  LedgerSlice,
   ShortSliceCandidate,
   SelectReconciliationWorkUnitInput,
+  SliceWalkReason,
 } from "@/api/handlers/case-law/ingestion/reconciliation-plan";
 import {
+  RECONCILIATION_SETTLED_RECHECK_MS,
   RECONCILIATION_SLICE_STALE_MS,
   SLICE_WALK_REASON,
   isSliceSettled,
@@ -56,9 +61,23 @@ const baseInput = (
   tipCheckedAt: new Map(),
   unsettledShortSlices: [],
   sweepSlice: null,
+  recheckCandidate: null,
   staleAfterMs: RECONCILIATION_SLICE_STALE_MS,
+  recheckAfterMs: RECONCILIATION_SETTLED_RECHECK_MS,
   ...overrides,
 });
+
+/** A settled ledger row, checked long enough ago to be worth proving again. */
+const recheckCandidate = (checkedAt: Date): LedgerSlice => ({
+  slice: "2024-01-01",
+  reported: 12,
+  collected: 12,
+  checkedAt,
+});
+
+const LONG_SETTLED = new Date(
+  NOW.getTime() - RECONCILIATION_SETTLED_RECHECK_MS - DAY_IN_MS,
+);
 
 const shortSlice = (
   overrides: Partial<ShortSliceCandidate> = {},
@@ -285,6 +304,105 @@ describe("selectReconciliationWorkUnit", () => {
         }),
       ),
     ).toEqual({ type: "idle" });
+  });
+
+  test("an otherwise idle source spends the turn re-proving a settled slice", () => {
+    // The only unit that walks a slice nothing is known to owe. Idle turns
+    // become slow verification, which is the whole of the argument for it: a
+    // slice that settled early keeps stating what the publisher listed that
+    // day, and publishers go on adding to slices for months afterwards.
+    expect(
+      selectReconciliationWorkUnit(
+        baseInput({
+          tipSlices: ["2026-08-11"],
+          tipCheckedAt: new Map([["2026-08-11", FRESH]]),
+          recheckCandidate: recheckCandidate(LONG_SETTLED),
+        }),
+      ),
+    ).toEqual({
+      type: "slice",
+      slice: "2024-01-01",
+      reason: SLICE_WALK_REASON.RECHECK,
+    });
+  });
+
+  test("a settled slice inside the recheck window is left alone", () => {
+    // The candidate is always read; the window is what decides. Without it the
+    // loop re-walks proved history at the idle cadence, spending on slices it
+    // has already accounted for the politeness budget that short slices need.
+    expect(
+      selectReconciliationWorkUnit(
+        baseInput({
+          recheckCandidate: recheckCandidate(
+            new Date(
+              NOW.getTime() - RECONCILIATION_SETTLED_RECHECK_MS + DAY_IN_MS,
+            ),
+          ),
+        }),
+      ),
+    ).toEqual({ type: "idle" });
+  });
+
+  test("every nearer priority outranks the recheck, one at a time", () => {
+    // Stated as one case per competing priority rather than all four at once:
+    // a chain that fell through on three of them and was saved by the fourth
+    // would pass a combined assertion unchanged.
+    const nearer = [
+      { hasDueParkedItems: true },
+      { tipSlices: ["2026-08-11"], tipCheckedAt: new Map<string, Date>() },
+      { unsettledShortSlices: [shortSlice()] },
+      { sweepSlice: "2023-06-01" },
+    ] as const satisfies readonly Partial<SelectReconciliationWorkUnitInput>[];
+
+    for (const [index, overrides] of nearer.entries()) {
+      const unit = selectReconciliationWorkUnit(
+        baseInput({
+          ...overrides,
+          recheckCandidate: recheckCandidate(LONG_SETTLED),
+        }),
+      );
+      const rechecked =
+        unit.type === "slice" && unit.reason === SLICE_WALK_REASON.RECHECK;
+      expect({ index, rechecked }).toEqual({ index, rechecked: false });
+    }
+  });
+
+  test("every walk reason is reachable, and each input reaches only its own", () => {
+    // Total over the union, so a reason cannot be added without an input that
+    // produces it; the loop asserts the other direction, that each input
+    // reaches exactly the reason it is filed under.
+    const inputByReason = {
+      [SLICE_WALK_REASON.TIP]: baseInput({ tipSlices: ["2026-08-11"] }),
+      [SLICE_WALK_REASON.SHORT]: baseInput({
+        unsettledShortSlices: [shortSlice()],
+      }),
+      [SLICE_WALK_REASON.SWEEP]: baseInput({ sweepSlice: "2023-06-01" }),
+      [SLICE_WALK_REASON.RECHECK]: baseInput({
+        recheckCandidate: recheckCandidate(LONG_SETTLED),
+      }),
+    } as const satisfies Record<
+      SliceWalkReason,
+      SelectReconciliationWorkUnitInput
+    >;
+
+    for (const [reason, input] of Object.entries(inputByReason)) {
+      expect(selectReconciliationWorkUnit(input)).toMatchObject({
+        type: "slice",
+        reason,
+      });
+    }
+  });
+});
+
+describe("RECONCILIATION_SETTLED_RECHECK_MS", () => {
+  test("a recheck is an order of magnitude rarer than the tip cadence", () => {
+    // The two constants describe opposite ends of the same ledger. If the
+    // recheck window ever approached the staleness window, every settled slice
+    // in a source's history would come due about as often as the tip does, and
+    // the loop would spend its life re-walking history it had already proved.
+    expect(RECONCILIATION_SETTLED_RECHECK_MS).toBeGreaterThan(
+      RECONCILIATION_SLICE_STALE_MS * 10,
+    );
   });
 });
 

--- a/apps/api/src/handlers/case-law/ingestion/reconciliation-plan.ts
+++ b/apps/api/src/handlers/case-law/ingestion/reconciliation-plan.ts
@@ -24,6 +24,25 @@ import type { SourceReconciliation } from "@/api/lib/legal-search/ingestion-type
  */
 export const RECONCILIATION_SLICE_STALE_MS = DAY_IN_MS;
 
+/**
+ * How long a settled slice's ledger row stands before the loop is willing to
+ * spend an otherwise-idle turn proving it again.
+ *
+ * A slice that settles early is never re-selected: the row records what the
+ * publisher listed on the day it was walked, and a publisher that keeps
+ * adding to a slice for months afterwards makes that number quietly wrong.
+ * Measured on one publisher's judgment-date slices, a slice holds roughly one
+ * item at a fortnight old, a couple of hundred at four months and several
+ * hundred at sixteen; the same happens wherever language variants or late
+ * publication arrive after the fact. Nothing surfaces it, because a settled
+ * row looks exactly like a complete one.
+ *
+ * A month is the trade: long enough that re-walking history is a rounding
+ * error against the tip's daily cadence, short enough that a slice which grew
+ * is found within one quarter of its own drift.
+ */
+export const RECONCILIATION_SETTLED_RECHECK_MS = 30 * DAY_IN_MS;
+
 /** Why a slice was chosen, for the summary and nothing else. */
 export const SLICE_WALK_REASON = {
   /** Inside the tip window, where the publisher is still filling in. */
@@ -32,6 +51,8 @@ export const SLICE_WALK_REASON = {
   SHORT: "short",
   /** Never surveyed at all; the sweep works backward through history. */
   SWEEP: "sweep",
+  /** Settled long ago; walked again to prove the ledger still describes it. */
+  RECHECK: "recheck",
 } as const;
 
 export type SliceWalkReason =
@@ -172,7 +193,15 @@ export type SelectReconciliationWorkUnitInput = {
   unsettledShortSlices: readonly ShortSliceCandidate[];
   /** The newest never-surveyed slice below the tip window, if any remain. */
   sweepSlice: string | null;
+  /**
+   * The oldest-checked settled slice below the tip window, if the source has
+   * one. Which rows count as settled is the assembly's question, since only it
+   * can read the ledger; whether this one is old enough to walk is decided
+   * here, against `recheckAfterMs`.
+   */
+  recheckCandidate: LedgerSlice | null;
   staleAfterMs: number;
+  recheckAfterMs: number;
 };
 
 /**
@@ -183,15 +212,25 @@ export type SelectReconciliationWorkUnitInput = {
  *  2. the tip, where the publisher is still adding to slices and a miss is
  *     both most likely and most visible;
  *  3. slices known to be short and gone stale — the ledger's own backlog;
- *  4. history never surveyed at all, newest first.
+ *  4. history never surveyed at all, newest first;
+ *  5. a slice that settled long enough ago that its ledger row is no longer
+ *     evidence of anything — the only work that re-does work.
  *
  * Anything else is idle. The order is deliberately not round-robin between
  * these: history is unbounded and the tip is not, so a sweep that competed
  * with the tip on equal terms would let fresh misses age behind old ones.
+ *
+ * The recheck sits last for the same reason it exists at all. It is the only
+ * unit that walks a slice nothing is known to owe, so it must never displace
+ * a slice something is: reaching it means the source is surveyed to its first
+ * slice, its tip is fresh and its backlog is empty. Idle turns become slow
+ * verification, and a source with real work never spends a turn on it.
  */
 export const selectReconciliationWorkUnit = ({
   hasDueParkedItems,
   now,
+  recheckAfterMs,
+  recheckCandidate,
   staleAfterMs,
   sweepSlice,
   tipCheckedAt,
@@ -246,6 +285,25 @@ export const selectReconciliationWorkUnit = ({
       type: "slice",
       slice: sweepSlice,
       reason: SLICE_WALK_REASON.SWEEP,
+    };
+  }
+
+  // An ordinary walk, deliberately: a slice the publisher has since grown
+  // records short afterwards and re-enters the normal cycle at priority 3,
+  // so the recheck needs no repair path of its own.
+  //
+  // The age test lives here rather than in the query that reads the row: it is
+  // the same clock arithmetic the tip's staleness runs on, and a cutoff pushed
+  // into SQL would be the one part of the priority order no test could reach
+  // without a database.
+  if (
+    recheckCandidate !== null &&
+    recheckCandidate.checkedAt.getTime() < now.getTime() - recheckAfterMs
+  ) {
+    return {
+      type: "slice",
+      slice: recheckCandidate.slice,
+      reason: SLICE_WALK_REASON.RECHECK,
     };
   }
 

--- a/apps/api/src/lib/legal-search/ingestion-normalization.ts
+++ b/apps/api/src/lib/legal-search/ingestion-normalization.ts
@@ -1,3 +1,6 @@
+import type { Column, SQL } from "drizzle-orm";
+import { sql } from "drizzle-orm";
+
 import { collapseSpacedLetters } from "@stll/text-normalize";
 
 import { isDocumentAst } from "@/api/lib/case-law/document-ast";
@@ -22,6 +25,17 @@ export type PartialObservation = {
   isListingOnly: boolean;
 };
 
+/**
+ * The marker's own field names, spelled once. The reader below and the SQL
+ * predicate beside it address the same stored path, and a literal repeated in
+ * both would be free to drift: a query looking under a key the pipeline stopped
+ * writing answers `false` for every row and says nothing about it.
+ */
+const PARTIAL_OBSERVATION_FIELD = {
+  CASE_NUMBER_IS_PLACEHOLDER: "caseNumberIsPlaceholder",
+  IS_LISTING_ONLY: "isListingOnly",
+} as const satisfies Record<string, keyof PartialObservation>;
+
 export const partialObservationFromMetadata = (
   metadata: unknown,
 ): PartialObservation => {
@@ -30,10 +44,33 @@ export const partialObservationFromMetadata = (
     : undefined;
   return {
     caseNumberIsPlaceholder:
-      isRecord(value) && value["caseNumberIsPlaceholder"] === true,
-    isListingOnly: isRecord(value) && value["isListingOnly"] === true,
+      isRecord(value) &&
+      value[PARTIAL_OBSERVATION_FIELD.CASE_NUMBER_IS_PLACEHOLDER] === true,
+    isListingOnly:
+      isRecord(value) &&
+      value[PARTIAL_OBSERVATION_FIELD.IS_LISTING_ONLY] === true,
   };
 };
+
+/**
+ * Rows this reader would answer `isListingOnly: false` for, as a predicate
+ * over a decision's metadata column.
+ *
+ * The marker lives inside the metadata blob rather than in a column of its
+ * own, so this is a JSONB path extraction. Written as
+ * `jsonb_extract_path_text` rather than `-> ... ->>` because the key is a
+ * bound parameter and Postgres cannot resolve `jsonb -> unknown` — the
+ * function's variadic `text[]` can. Every caller applies it inside an
+ * already-bounded lookup (identities the publisher just listed, a hundred at
+ * a time), where the extraction is evaluated on rows the identity index has
+ * already selected; it is not a predicate anything scans the corpus with.
+ *
+ * `IS DISTINCT FROM` rather than `<>`: the marker is written only when it is
+ * true, so almost every row has no such key and the extraction yields NULL.
+ * A row with no marker is a row that carries detail.
+ */
+export const storedObservationHasDetail = (metadata: Column): SQL =>
+  sql`jsonb_extract_path_text(${metadata}, ${PARTIAL_OBSERVATION_KEY}, ${PARTIAL_OBSERVATION_FIELD.IS_LISTING_ONLY}) is distinct from 'true'`;
 
 /**
  * Sanitize text fields before DB insertion. Postgres rejects null bytes in

--- a/apps/api/src/lib/legal-search/ingestion-types.ts
+++ b/apps/api/src/lib/legal-search/ingestion-types.ts
@@ -349,6 +349,28 @@ export type SourceReconciliation = {
   previousSlice: (slice: string) => string | null;
   /** Slices near the tip that get re-walked on a fast cadence. */
   tipWindowDays: number;
+  /**
+   * Whether a stored row counts as held only when it carries the document,
+   * and not when it carries the listing metadata alone.
+   *
+   * Defaults to false, and that default is load-bearing rather than lazy. A
+   * source may be metadata-only by design: sk-courts ingests the listing and
+   * a separate drain fetches documents afterwards, so at any moment a large
+   * part of its corpus legitimately holds no document. Treating those rows as
+   * not held would report millions of decisions missing and re-ingest them
+   * under reconciliation, which is a worse failure than the one this flag
+   * fixes.
+   *
+   * Set it only where a detail-less row means the document fetch failed for a
+   * decision the source otherwise stores whole. There the row is a stub the
+   * walk left behind, and reading it as held takes the decision out of every
+   * later reconciliation: the identity is present, the slice reads reconciled,
+   * and the document is never hunted again.
+   *
+   * Keyed on the pipeline's own `isListingOnly` marker, so it means the same
+   * thing for every source that opts in.
+   */
+  heldRequiresDetail?: boolean | undefined;
   listSlicePage: (
     options: ReconciliationSlicePageOptions,
   ) => Promise<ReconciliationSlicePage>;


### PR DESCRIPTION
Two engine-level follow-ups to the reconciliation loop, both surfaced by review rounds on the per-adapter capability PRs.

**Settled slices get a bounded recheck.** Some publishers keep adding to a slice long after it first settles (measured on one source: a date-keyed slice holds ~10% of its eventual content at two weeks and keeps accruing past a year). A slice recorded complete was never re-selected, so its ledger numbers went stale invisibly. A new lowest-priority work unit — it runs only when parked retries, the tip, the short backlog, and the historical sweep are all empty — re-walks the oldest-checked settled slice once its age exceeds `RECONCILIATION_SETTLED_RECHECK_MS` (30 days). A recheck is an ordinary walk (reason `recheck`), so a slice that grew records short and re-enters the normal cycle. The recheck population (`collected >= reported`) and the candidate-window touch population (short but settled by retirements) are exact complements, so neither can starve the other; the age cutoff is applied in the pure selection module, where it is exercised by unit tests.

**Heldness can require detail, per source.** The engine's held-lookups decided from identity columns alone, so a listing-only row (stored when a document fetch failed) counted as held and its document was never hunted again. A blanket filter would be wrong — at least one source is metadata-only at ingest by design — so the capability gains `heldRequiresDetail?: boolean` (default false, with the counterexample in its doc comment). When set, both held-lookup queries additionally require the row's stored partial-observation marker to be absent. The marker is the pipeline-owned `_stellaPartialObservation` written by `sanitizeResult` (and cleared when detail is later recovered); its field names live in one map addressed by both the TypeScript reader and the SQL predicate, so the two cannot drift. The filter is a jsonb extraction evaluated only on rows the bounded identity lookups already selected, never as a scan predicate.

sk-us declares the flag in this change — its build path is what marks failed-document rows — with a test binding both halves (marker produced ∧ flag declared), so dropping either fails. Any future capability on an adapter that produces the marker must declare it too (cz-us is the other producer today).

Tests: recheck priority and window in the pure suite (one case per competing priority), reason-map totality asserted in both directions, db tests for the recheck re-opening a grown slice and for heldness with the flag on (both identity halves) and off. No ratchet or typecheck-baseline movement.
