### PR TITLE
feat(api): durable asynchronous document review runs

### DIFF
--- a/.agents/plans/053-durable-document-review-runs.md
+++ b/.agents/plans/053-durable-document-review-runs.md
@@ -1,0 +1,177 @@
+# Plan: Durable document review runs
+
+Date: 2026-08-11. Extends `045-playbooks.md` / `047-playbooks-tiered-authoring.md`
+and the composable document review slice (PR #1920).
+
+## Goal
+
+A document review becomes a durable, asynchronous, version-pinned record instead
+of a 120-second HTTP call whose findings live only in browser memory. One run
+executes one confirmed basis (playbook and/or references) against one pinned
+document version and lands one finding row per confirmed topic per check kind.
+Reload restores in-progress and completed reviews; results remain intelligible
+after the playbook, references, or document move on.
+
+Principle carried from the review architecture decision: **data lives in cells,
+judgment lives in findings, everything visible is a projection.** This plan
+builds the findings side only; extraction columns are untouched.
+
+## Non-goals (this plan)
+
+- Table/bulk run convergence (properties stay canonical there for now)
+- Reviewer decision state, stale carry-over across document versions, badges
+- Folder consistency, document families, DD report feed
+- Reviewer assignments, approval workflows, notifications
+- A ReviewFact layer (the `fields` table already is the per-version fact store)
+
+The shapes below must not block any of these (ids everywhere, per-kind outcome
+vocabularies, run as provenance rather than the read axis).
+
+## Schema
+
+New file `apps/api/src/db/schema/document-reviews.ts`, `wsPolicies()` RLS on
+both tables, hand-authored migration.
+
+### `document_review_runs`
+
+One immutable execution record, modeled on `report_exports` (one-shot job) with
+`extraction_runs`-style progress. Columns:
+
+- `id SafeId<"documentReviewRun">`, `organizationId`, `workspaceId`
+- Target pin: `entityId`, `fileFieldId`, `entityVersionId`, `contentSha256`
+- `basis` jsonb (see below)
+- `topics` jsonb: the confirmed topic list (the plan snapshot), max
+  `documentReviewTopicsMax`
+- `status`: `queued | running | completed | failed | cancelled`, CHECK derived
+  from a canonical const (per the #1918 pattern); `errorCode` nullable
+- Progress: `total`, `completed` ints, `completed <= total` CHECK
+- `requestedBy` FK user SET NULL, `pipelineVersion` int, `modelRef` text
+- `createdAt`, `startedAt`, `finishedAt`
+- Partial index on active statuses; index `(workspaceId, entityId, fileFieldId,
+  createdAt)` for history reads
+
+`basis` jsonb, discriminated like the web `ReviewBasis`:
+
+```ts
+type RunBasis =
+  | { type: "playbook"; playbook: PinnedPlaybook }
+  | { type: "references"; references: PinnedReference[] }
+  | { type: "combined"; playbook: PinnedPlaybook; references: PinnedReference[] };
+
+type PinnedPlaybook = {
+  definitionId: string;            // plain id, NO FK — runs outlive definitions
+  versionId: string | null;        // playbook_definition_versions.id when approved
+  provenance: "approved" | "draft";
+  definitionSnapshot: { name: string; positions: PlaybookPositions };
+};
+
+type PinnedReference = {
+  entityId: string; fileFieldId: string; entityVersionId: string;
+  contentSha256: string; name: string;
+};
+```
+
+The snapshot is embedded even when `versionId` is set, so a run is
+self-contained: deleting a playbook (whose FK today CASCADEs through
+materialized properties) never destroys a run's meaning. Run creation resolves
+the latest **approved** snapshot; authors may run a draft, recorded as
+`provenance: "draft"`.
+
+### `document_review_findings`
+
+One row per confirmed topic per check kind. Columns:
+
+- `id`, `organizationId`, `workspaceId`, `runId` FK CASCADE
+- Denormalized read keys: `entityId`, `fileFieldId`, `entityVersionId`
+- `topicId` uuid, `topicTitle` (denormalized for reports), `checkKind`:
+  `playbook | reference`, `positionId` nullable (playbook kind only)
+- `outcome` text: verdict tiers for playbook kind, the six-value comparison
+  vocabulary for reference kind; CHECK per kind derived from the canonical
+  consts. Never merged into one vocabulary.
+- `payload` jsonb: extracted value, rationale/explanation, verified citations
+  (blockId + excerpt), reference citations per file, consensus, severity,
+  matchedRef, grounded fix. Shapes reuse the PR #1920 types verbatim.
+- `createdAt`; unique `(runId, topicId, checkKind)` — the upsert key
+
+Reads are keyed by document, not run: "current review state" = findings of the
+latest completed run per `(entityId, fileFieldId)`.
+
+## Execution
+
+### PR A (mechanical, first): move the engine into `lib/`
+
+The worker cannot import from handlers (`lib-to-handler-imports` ratchet is 0).
+Move, without behavior change:
+
+- `handlers/playbooks/review-extract.ts`, `review-grade.ts` →
+  `lib/document-review/`
+- The comparison core of `handlers/document-reviews/compare-references.ts`
+  (prompt build, normalization, evidence verification) →
+  `lib/document-review/reference-compare.ts`; the handler stays a thin caller
+- `review-selection.ts` resolution helpers likewise
+
+Handlers keep: config, params/body schemas, permission macros, audit calls.
+
+### PR B: runs, worker, endpoints, store
+
+**Queue** `lib/document-review/run-queue.ts`, modeled line-for-line on
+`report-export-queue.ts`: BullMQ queue + worker, `jobId = runId` (idempotency),
+claim via conditional `queued → running` transition, no-double-run guard (409
+while an active run exists for the same `(entityId, fileFieldId)`), orphan
+reconciliation interval, failures land `status: failed` + `errorCode` and stay
+retryable. Worker: load run → prepare pinned files → playbook and reference
+executors in parallel (as the client does today) → upsert findings on
+`(runId, topicId, checkKind)` → bump `completed` → mark `completed` only when
+the expected set (every confirmed topic × applicable kinds) is committed.
+Duplicate jobs converge on the same rows.
+
+**Endpoints** in the `document-reviews` slice:
+
+- `POST .../document-reviews/runs` → resolves selection + pins versions +
+  resolves playbook snapshot, inserts run transactionally, enqueues, returns
+  `{ runId }` (202). Audit event on create and on completion.
+- `GET .../document-reviews/runs/:runId` → run + findings
+- `GET .../document-reviews/runs?entityId=&fileFieldId=` → `Page<RunSummary>`
+- `/sources` and `/topics` (interactive, cheap) stay synchronous.
+- **Delete** `POST /playbooks/:id/review` and the execution half of
+  `POST /document-reviews/references`. No back-compat: neither has shipped
+  publicly; the web client migrates in the same PR.
+
+**Web**: `playbook-review-store` becomes a cache over server state. Sessions
+keyed by `runId`; facet open queries the latest run for the document (suspense
+query started per `require-loader-prefetch` rules where a loader exists; the
+facet is user-triggered otherwise); poll with `refetchInterval` while
+`queued|running`. Reload restores status and findings. `fixState` /
+`commentState` stay client-side in this slice (revision ids are
+editor-session-scoped; applied tracked changes themselves live in the
+document). Topic confirm flow is unchanged; `confirmTopics` now creates the
+run.
+
+MCP classification: `internal / document_processing` like the existing slice;
+regenerate the MCP coverage baseline.
+
+## Deletion + retention semantics
+
+- Playbook deleted → runs/findings untouched (snapshot embedded, no FK)
+- Reference or target document deleted → findings untouched; UI marks the
+  source unavailable when resolution fails
+- Workspace deletion cascades everything (existing tenant semantics)
+- `entity_versions` are already never hard-deleted; version pins stay valid
+
+## Risks / open edges
+
+- The run worker is a new consumer adjacent to `finishWorkflow`; per the 047
+  deferred finding, a third inline post-completion consumer should trigger
+  extracting a completion-hook registry. This worker is a separate queue, so it
+  does not add one — keep it that way.
+- Mock AI returns `{}` for structured output (known dev gap); dev-loop testing
+  of the worker needs the same workaround as the verdict engine.
+- `ci-checks` OOM flake on web-heavy PRs; PR B touches web moderately.
+
+## Success signals
+
+- Reload mid-run restores "reviewing" and then the same findings
+- Retry/duplicate jobs never duplicate finding rows
+- Every confirmed topic has exactly one finding per applicable kind
+- A completed review renders after its playbook is deleted
+- Zero properties created by a 200-position review

--- a/.changeset/durable-document-review-runs.md
+++ b/.changeset/durable-document-review-runs.md
@@ -1,5 +1,0 @@
----
-"@stll/cli": patch
----
-
-Expose the durable document review run endpoints (create run, read run, list runs for a document) in the generated capability catalog and route map.

--- a/.changeset/durable-document-review-runs.md
+++ b/.changeset/durable-document-review-runs.md
@@ -1,0 +1,5 @@
+---
+"@stll/cli": patch
+---
+
+Expose the durable document review run endpoints (create run, read run, list runs for a document) in the generated capability catalog and route map.

--- a/apps/api/drizzle/20260811140000_document_review_runs/migration.sql
+++ b/apps/api/drizzle/20260811140000_document_review_runs/migration.sql
@@ -1,0 +1,255 @@
+SET LOCAL lock_timeout = '1s';--> statement-breakpoint
+SET LOCAL statement_timeout = '5s';--> statement-breakpoint
+
+-- A document review becomes a durable record rather than the tail of one HTTP
+-- call. A run pins what was reviewed (one document version) and what it was
+-- reviewed against (a playbook snapshot and/or reference document versions),
+-- both by value: there is no foreign key from a run to a playbook or to the
+-- reviewed documents, so deleting either leaves the run's meaning intact.
+CREATE TABLE "document_review_runs" (
+  "id" uuid PRIMARY KEY NOT NULL,
+  "organization_id" varchar(128) NOT NULL,
+  "workspace_id" uuid NOT NULL,
+  "entity_id" uuid NOT NULL,
+  "file_field_id" uuid NOT NULL,
+  "entity_version_id" uuid NOT NULL,
+  "content_sha256" varchar(64) NOT NULL,
+  "basis" jsonb NOT NULL,
+  "topics" jsonb NOT NULL,
+  "status" text DEFAULT 'queued' NOT NULL,
+  "error_code" varchar(64),
+  "total" integer DEFAULT 0 NOT NULL,
+  "completed" integer DEFAULT 0 NOT NULL,
+  "requested_by" text,
+  "pipeline_version" integer DEFAULT 1 NOT NULL,
+  "model_ref" varchar(256),
+  "created_at" timestamptz DEFAULT now() NOT NULL,
+  "started_at" timestamptz,
+  "finished_at" timestamptz,
+  CONSTRAINT "document_review_runs_status_values_check"
+    CHECK ("status" IN ('queued', 'running', 'completed', 'failed', 'cancelled')),
+  CONSTRAINT "document_review_runs_error_code_values_check"
+    CHECK ("error_code" IS NULL OR "error_code" IN (
+      'pin_unresolved', 'pin_content_changed', 'unsupported_format',
+      'ai_unavailable', 'playbook_check_failed', 'reference_check_failed',
+      'enqueue_failed', 'internal'
+    )),
+  CONSTRAINT "document_review_runs_basis_type_check"
+    CHECK ("basis"->>'type' IN ('playbook', 'references', 'combined')),
+  CONSTRAINT "document_review_runs_progress_nonnegative_check"
+    CHECK ("total" >= 0 AND "completed" >= 0),
+  CONSTRAINT "document_review_runs_completed_within_total_check"
+    CHECK ("completed" <= "total"),
+  CONSTRAINT "document_review_runs_content_hash_check"
+    CHECK ("content_sha256" ~ '^[0-9a-f]{64}$'),
+  CONSTRAINT "document_review_runs_pipeline_version_check"
+    CHECK ("pipeline_version" > 0)
+);--> statement-breakpoint
+
+-- One judgment per confirmed topic per check kind. The unique key below is the
+-- upsert key, so a re-delivered job converges onto the rows it already wrote.
+CREATE TABLE "document_review_findings" (
+  "id" uuid PRIMARY KEY NOT NULL,
+  "organization_id" varchar(128) NOT NULL,
+  "workspace_id" uuid NOT NULL,
+  "run_id" uuid NOT NULL,
+  "entity_id" uuid NOT NULL,
+  "file_field_id" uuid NOT NULL,
+  "entity_version_id" uuid NOT NULL,
+  "topic_id" uuid NOT NULL,
+  "topic_title" varchar(256) NOT NULL,
+  "check_kind" text NOT NULL,
+  "position_id" uuid,
+  "outcome" varchar(64),
+  "payload" jsonb NOT NULL,
+  "created_at" timestamptz DEFAULT now() NOT NULL,
+  "updated_at" timestamptz DEFAULT now() NOT NULL,
+  CONSTRAINT "document_review_findings_check_kind_values_check"
+    CHECK ("check_kind" IN ('playbook', 'reference')),
+  -- The two outcome vocabularies stay separate: verdict tiers grade a playbook
+  -- position, the comparison vocabulary describes a reference difference. Only
+  -- a playbook-kind row names a position, and only it may omit an outcome (an
+  -- extract-only position yields a value with no verdict).
+  CONSTRAINT "document_review_findings_outcome_check" CHECK (
+    (
+      "check_kind" = 'playbook'
+      AND (
+        "outcome" IS NULL
+        OR "outcome" IN (
+          'compliant', 'fallback', 'deviation', 'missing', 'not-applicable'
+        )
+      )
+    ) OR (
+      "check_kind" = 'reference'
+      AND "outcome" IN (
+        'aligned', 'different', 'missing-from-target',
+        'additional-in-target', 'deal-specific', 'not-comparable'
+      )
+      AND "position_id" IS NULL
+    )
+  )
+);--> statement-breakpoint
+
+ALTER TABLE "document_review_runs"
+  ADD CONSTRAINT "document_review_runs_organization_id_organization_id_fk"
+  FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id")
+  ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "document_review_runs"
+  ADD CONSTRAINT "document_review_runs_workspace_id_workspaces_id_fk"
+  FOREIGN KEY ("workspace_id") REFERENCES "public"."workspaces"("id")
+  ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "document_review_runs"
+  ADD CONSTRAINT "document_review_runs_requested_by_user_id_fk"
+  FOREIGN KEY ("requested_by") REFERENCES "public"."user"("id")
+  ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+
+ALTER TABLE "document_review_findings"
+  ADD CONSTRAINT "document_review_findings_organization_id_organization_id_fk"
+  FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id")
+  ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "document_review_findings"
+  ADD CONSTRAINT "document_review_findings_workspace_id_workspaces_id_fk"
+  FOREIGN KEY ("workspace_id") REFERENCES "public"."workspaces"("id")
+  ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "document_review_findings"
+  ADD CONSTRAINT "document_review_findings_run_id_document_review_runs_id_fk"
+  FOREIGN KEY ("run_id") REFERENCES "public"."document_review_runs"("id")
+  ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+
+-- History read: the newest runs for one document, keyset-paginated.
+CREATE INDEX "document_review_runs_document_created_idx"
+  ON "document_review_runs" (
+    "workspace_id", "entity_id", "file_field_id", "created_at" DESC, "id" DESC
+  );--> statement-breakpoint
+
+-- At most one unfinished run per document. The create endpoint answers 409
+-- before reaching here; this index is what makes a lost race impossible rather
+-- than unlikely.
+CREATE UNIQUE INDEX "document_review_runs_active_document_uidx"
+  ON "document_review_runs" ("workspace_id", "entity_id", "file_field_id")
+  WHERE "status" IN ('queued', 'running');--> statement-breakpoint
+
+CREATE UNIQUE INDEX "document_review_findings_run_topic_kind_uidx"
+  ON "document_review_findings" ("run_id", "topic_id", "check_kind");--> statement-breakpoint
+
+CREATE INDEX "document_review_findings_document_idx"
+  ON "document_review_findings" ("workspace_id", "entity_id", "file_field_id");--> statement-breakpoint
+
+ALTER TABLE "document_review_runs"
+  ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+ALTER TABLE "document_review_findings"
+  ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+
+-- RLS restricts rows, grants restrict verbs — both are needed.
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE "document_review_runs" TO stella;--> statement-breakpoint
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE "document_review_findings" TO stella;--> statement-breakpoint
+
+-- Both scopes in every command. These tables persist an organization
+-- discriminator alongside the workspace, so requiring only the workspace pin
+-- would let a row whose organization_id came from elsewhere be reached through
+-- a legitimate workspace authorization.
+CREATE POLICY "document_review_runs_workspace_select"
+  ON "document_review_runs" AS PERMISSIVE FOR SELECT TO stella
+  USING ((CASE
+    WHEN workspace_id = ANY(COALESCE(NULLIF((SELECT pg_catalog.current_setting(
+      'app.workspace_ids', true)), '')::uuid[], ARRAY[]::uuid[]))
+    THEN true
+    ELSE workspace_id IN (
+      SELECT aw.authorized_workspace_id
+      FROM public.stella_authorized_workspaces aw
+    )
+  END) AND organization_id = (SELECT current_setting(
+    'app.organization_id', true
+  )));--> statement-breakpoint
+CREATE POLICY "document_review_runs_workspace_insert"
+  ON "document_review_runs" AS PERMISSIVE FOR INSERT TO stella
+  WITH CHECK ((CASE
+    WHEN workspace_id = ANY(COALESCE(NULLIF((SELECT pg_catalog.current_setting(
+      'app.workspace_ids', true)), '')::uuid[], ARRAY[]::uuid[]))
+    THEN true
+    ELSE workspace_id IN (
+      SELECT aw.authorized_workspace_id
+      FROM public.stella_authorized_workspaces aw
+    )
+  END) AND organization_id = (SELECT current_setting(
+    'app.organization_id', true
+  )));--> statement-breakpoint
+CREATE POLICY "document_review_runs_workspace_update"
+  ON "document_review_runs" AS PERMISSIVE FOR UPDATE TO stella
+  USING ((CASE
+    WHEN workspace_id = ANY(COALESCE(NULLIF((SELECT pg_catalog.current_setting(
+      'app.workspace_ids', true)), '')::uuid[], ARRAY[]::uuid[]))
+    THEN true
+    ELSE workspace_id IN (
+      SELECT aw.authorized_workspace_id
+      FROM public.stella_authorized_workspaces aw
+    )
+  END) AND organization_id = (SELECT current_setting(
+    'app.organization_id', true
+  )));--> statement-breakpoint
+CREATE POLICY "document_review_runs_workspace_delete"
+  ON "document_review_runs" AS PERMISSIVE FOR DELETE TO stella
+  USING ((CASE
+    WHEN workspace_id = ANY(COALESCE(NULLIF((SELECT pg_catalog.current_setting(
+      'app.workspace_ids', true)), '')::uuid[], ARRAY[]::uuid[]))
+    THEN true
+    ELSE workspace_id IN (
+      SELECT aw.authorized_workspace_id
+      FROM public.stella_authorized_workspaces aw
+    )
+  END) AND organization_id = (SELECT current_setting(
+    'app.organization_id', true
+  )));--> statement-breakpoint
+
+CREATE POLICY "document_review_findings_workspace_select"
+  ON "document_review_findings" AS PERMISSIVE FOR SELECT TO stella
+  USING ((CASE
+    WHEN workspace_id = ANY(COALESCE(NULLIF((SELECT pg_catalog.current_setting(
+      'app.workspace_ids', true)), '')::uuid[], ARRAY[]::uuid[]))
+    THEN true
+    ELSE workspace_id IN (
+      SELECT aw.authorized_workspace_id
+      FROM public.stella_authorized_workspaces aw
+    )
+  END) AND organization_id = (SELECT current_setting(
+    'app.organization_id', true
+  )));--> statement-breakpoint
+CREATE POLICY "document_review_findings_workspace_insert"
+  ON "document_review_findings" AS PERMISSIVE FOR INSERT TO stella
+  WITH CHECK ((CASE
+    WHEN workspace_id = ANY(COALESCE(NULLIF((SELECT pg_catalog.current_setting(
+      'app.workspace_ids', true)), '')::uuid[], ARRAY[]::uuid[]))
+    THEN true
+    ELSE workspace_id IN (
+      SELECT aw.authorized_workspace_id
+      FROM public.stella_authorized_workspaces aw
+    )
+  END) AND organization_id = (SELECT current_setting(
+    'app.organization_id', true
+  )));--> statement-breakpoint
+CREATE POLICY "document_review_findings_workspace_update"
+  ON "document_review_findings" AS PERMISSIVE FOR UPDATE TO stella
+  USING ((CASE
+    WHEN workspace_id = ANY(COALESCE(NULLIF((SELECT pg_catalog.current_setting(
+      'app.workspace_ids', true)), '')::uuid[], ARRAY[]::uuid[]))
+    THEN true
+    ELSE workspace_id IN (
+      SELECT aw.authorized_workspace_id
+      FROM public.stella_authorized_workspaces aw
+    )
+  END) AND organization_id = (SELECT current_setting(
+    'app.organization_id', true
+  )));--> statement-breakpoint
+CREATE POLICY "document_review_findings_workspace_delete"
+  ON "document_review_findings" AS PERMISSIVE FOR DELETE TO stella
+  USING ((CASE
+    WHEN workspace_id = ANY(COALESCE(NULLIF((SELECT pg_catalog.current_setting(
+      'app.workspace_ids', true)), '')::uuid[], ARRAY[]::uuid[]))
+    THEN true
+    ELSE workspace_id IN (
+      SELECT aw.authorized_workspace_id
+      FROM public.stella_authorized_workspaces aw
+    )
+  END) AND organization_id = (SELECT current_setting(
+    'app.organization_id', true
+  )));

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -13,6 +13,7 @@ export * from "./schema/chat";
 export * from "./schema/docx-suggestions";
 export * from "./schema/extraction-runs";
 export * from "./schema/document-processing";
+export * from "./schema/document-reviews";
 export * from "./schema/office-evidence";
 export * from "./schema/flows";
 export * from "./schema/mcp";

--- a/apps/api/src/db/schema/document-reviews.ts
+++ b/apps/api/src/db/schema/document-reviews.ts
@@ -1,0 +1,235 @@
+import { sql } from "drizzle-orm";
+
+import type { DocumentReviewTopic } from "@/api/lib/document-review/contract";
+import {
+  DOCUMENT_REVIEW_BASIS_TYPES,
+  DOCUMENT_REVIEW_CHECK_KIND,
+  DOCUMENT_REVIEW_CHECK_KINDS,
+  DOCUMENT_REVIEW_OUTCOMES,
+  DOCUMENT_REVIEW_RUN_ACTIVE_STATUSES,
+  DOCUMENT_REVIEW_RUN_ERROR_CODES,
+  DOCUMENT_REVIEW_RUN_STATUSES,
+} from "@/api/lib/document-review/run-contract";
+import type {
+  DocumentReviewFindingPayload,
+  DocumentReviewRunBasis,
+  DocumentReviewRunErrorCode,
+} from "@/api/lib/document-review/run-contract";
+
+import {
+  jsonb,
+  organization,
+  p,
+  pUuid,
+  safeOrganizationId,
+  safeUuid,
+  safeWorkspaceId,
+  timestamptz,
+  user,
+  wsOrganizationPolicies,
+} from "./common";
+import { workspaces } from "./contacts";
+
+const quoted = (values: readonly string[]) =>
+  sql.join(
+    values.map((value) => sql.raw(`'${value}'`)),
+    sql`, `,
+  );
+
+const RUN_STATUS_SQL_VALUES = quoted(DOCUMENT_REVIEW_RUN_STATUSES);
+const RUN_ACTIVE_STATUS_SQL_VALUES = quoted(
+  DOCUMENT_REVIEW_RUN_ACTIVE_STATUSES,
+);
+const RUN_ERROR_CODE_SQL_VALUES = quoted(DOCUMENT_REVIEW_RUN_ERROR_CODES);
+const BASIS_TYPE_SQL_VALUES = quoted(DOCUMENT_REVIEW_BASIS_TYPES);
+const CHECK_KIND_SQL_VALUES = quoted(DOCUMENT_REVIEW_CHECK_KINDS);
+const PLAYBOOK_OUTCOME_SQL_VALUES = quoted(DOCUMENT_REVIEW_OUTCOMES.playbook);
+const REFERENCE_OUTCOME_SQL_VALUES = quoted(DOCUMENT_REVIEW_OUTCOMES.reference);
+
+const PLAYBOOK_CHECK_KIND_SQL = sql.raw(
+  `'${DOCUMENT_REVIEW_CHECK_KIND.PLAYBOOK}'`,
+);
+const REFERENCE_CHECK_KIND_SQL = sql.raw(
+  `'${DOCUMENT_REVIEW_CHECK_KIND.REFERENCE}'`,
+);
+
+/**
+ * One immutable execution of a document review: a confirmed basis (a playbook,
+ * a set of reference documents, or both) measured against one pinned document
+ * version.
+ *
+ * The target and the basis are pinned by value, not by reference: `basis`
+ * embeds the whole playbook snapshot and every reference's version, and there
+ * is no foreign key from a run to a playbook or to the reviewed documents. A
+ * completed review therefore stays readable after the playbook is deleted or
+ * the document moves on. Workspace deletion still cascades everything.
+ */
+export const documentReviewRuns = p.pgTable(
+  "document_review_runs",
+  {
+    id: pUuid<"documentReviewRun">().primaryKey(),
+    organizationId: safeOrganizationId("organization_id")
+      .notNull()
+      .references(() => organization.id, { onDelete: "cascade" }),
+    workspaceId: safeWorkspaceId("workspace_id")
+      .notNull()
+      .references(() => workspaces.id, { onDelete: "cascade" }),
+    // Target pin. Plain identifier columns: a deleted document must not take
+    // its review history with it, so these deliberately carry no foreign key.
+    entityId: safeUuid<"entity">("entity_id").notNull(),
+    fileFieldId: safeUuid<"field">("file_field_id").notNull(),
+    entityVersionId: safeUuid<"entityVersion">("entity_version_id").notNull(),
+    contentSha256: p.varchar("content_sha256", { length: 64 }).notNull(),
+    basis: jsonb().$type<DocumentReviewRunBasis>().notNull(),
+    // The confirmed topic list exactly as the reviewer approved it. Capped by
+    // the request schema (`DOCUMENT_REVIEW_LIMITS.topicsMax`).
+    topics: jsonb().$type<DocumentReviewTopic[]>().notNull(),
+    status: p
+      .text("status", { enum: DOCUMENT_REVIEW_RUN_STATUSES })
+      .notNull()
+      .default("queued"),
+    errorCode: p
+      .varchar("error_code", { length: 64 })
+      .$type<DocumentReviewRunErrorCode>(),
+    // Coarse progress over the expected finding set (see `expectedFindings`).
+    total: p.integer().notNull().default(0),
+    completed: p.integer().notNull().default(0),
+    requestedBy: p
+      .text("requested_by")
+      .references(() => user.id, { onDelete: "set null" }),
+    // Bumped when the executed pipeline changes shape, so an old run is never
+    // silently read as if it had been produced by today's engine.
+    pipelineVersion: p.integer("pipeline_version").notNull().default(1),
+    // The model identity the run resolved to, recorded for reproducibility.
+    modelRef: p.varchar("model_ref", { length: 256 }),
+    createdAt: timestamptz("created_at").notNull().defaultNow(),
+    startedAt: timestamptz("started_at"),
+    finishedAt: timestamptz("finished_at"),
+  },
+  (table) => [
+    // History read: newest runs for one document, keyset-paginated.
+    p
+      .index("document_review_runs_document_created_idx")
+      .on(
+        table.workspaceId,
+        table.entityId,
+        table.fileFieldId,
+        table.createdAt.desc(),
+        table.id.desc(),
+      ),
+    // At most one unfinished run per document. The endpoint answers 409 before
+    // reaching here; this index is what makes a lost race impossible rather
+    // than unlikely.
+    p
+      .uniqueIndex("document_review_runs_active_document_uidx")
+      .on(table.workspaceId, table.entityId, table.fileFieldId)
+      .where(sql`${table.status} IN (${RUN_ACTIVE_STATUS_SQL_VALUES})`),
+    p.check(
+      "document_review_runs_status_values_check",
+      sql`${table.status} IN (${RUN_STATUS_SQL_VALUES})`,
+    ),
+    p.check(
+      "document_review_runs_error_code_values_check",
+      sql`${table.errorCode} IS NULL OR ${table.errorCode} IN (${RUN_ERROR_CODE_SQL_VALUES})`,
+    ),
+    p.check(
+      "document_review_runs_basis_type_check",
+      sql`${table.basis}->>'type' IN (${BASIS_TYPE_SQL_VALUES})`,
+    ),
+    p.check(
+      "document_review_runs_progress_nonnegative_check",
+      sql`${table.total} >= 0 AND ${table.completed} >= 0`,
+    ),
+    p.check(
+      "document_review_runs_completed_within_total_check",
+      sql`${table.completed} <= ${table.total}`,
+    ),
+    p.check(
+      "document_review_runs_content_hash_check",
+      sql`${table.contentSha256} ~ '^[0-9a-f]{64}$'`,
+    ),
+    p.check(
+      "document_review_runs_pipeline_version_check",
+      sql`${table.pipelineVersion} > 0`,
+    ),
+    // Both scopes in every command: the run row carries an organization
+    // discriminator, so a valid workspace pin must not authorize a row whose
+    // organization_id came from anywhere else.
+    ...wsOrganizationPolicies("document_review_runs"),
+  ],
+);
+
+/**
+ * One judgment per confirmed topic per check kind. `(runId, topicId,
+ * checkKind)` is the upsert key, so a re-delivered job converges onto the rows
+ * it already wrote instead of duplicating them.
+ *
+ * Reads are keyed by document rather than by run: the current review state of a
+ * document is the findings of its latest completed run.
+ */
+export const documentReviewFindings = p.pgTable(
+  "document_review_findings",
+  {
+    id: pUuid<"documentReviewFinding">().primaryKey(),
+    organizationId: safeOrganizationId("organization_id")
+      .notNull()
+      .references(() => organization.id, { onDelete: "cascade" }),
+    workspaceId: safeWorkspaceId("workspace_id")
+      .notNull()
+      .references(() => workspaces.id, { onDelete: "cascade" }),
+    runId: safeUuid<"documentReviewRun">("run_id")
+      .notNull()
+      .references(() => documentReviewRuns.id, { onDelete: "cascade" }),
+    // Denormalized read keys so the document-keyed read never joins the run.
+    entityId: safeUuid<"entity">("entity_id").notNull(),
+    fileFieldId: safeUuid<"field">("file_field_id").notNull(),
+    entityVersionId: safeUuid<"entityVersion">("entity_version_id").notNull(),
+    topicId: p.uuid("topic_id").notNull(),
+    // Denormalized so a report renders without the run's topic snapshot.
+    topicTitle: p.varchar("topic_title", { length: 256 }).notNull(),
+    checkKind: p
+      .text("check_kind", { enum: DOCUMENT_REVIEW_CHECK_KINDS })
+      .notNull(),
+    // Set only on a playbook-kind row, which grades one playbook position.
+    positionId: p.uuid("position_id"),
+    // Verdict tiers for the playbook kind, the comparison vocabulary for the
+    // reference kind. The two are never merged. Null only for an extract-only
+    // position, which produces a value with no verdict.
+    outcome: p.varchar("outcome", { length: 64 }),
+    payload: jsonb().$type<DocumentReviewFindingPayload>().notNull(),
+    createdAt: timestamptz("created_at").notNull().defaultNow(),
+    updatedAt: timestamptz("updated_at")
+      .notNull()
+      .defaultNow()
+      .$onUpdate(() => new Date()),
+  },
+  (table) => [
+    p
+      .uniqueIndex("document_review_findings_run_topic_kind_uidx")
+      .on(table.runId, table.topicId, table.checkKind),
+    p
+      .index("document_review_findings_document_idx")
+      .on(table.workspaceId, table.entityId, table.fileFieldId),
+    p.check(
+      "document_review_findings_check_kind_values_check",
+      sql`${table.checkKind} IN (${CHECK_KIND_SQL_VALUES})`,
+    ),
+    // Per-kind outcome vocabulary, plus the invariant that only a playbook-kind
+    // row names a position.
+    p.check(
+      "document_review_findings_outcome_check",
+      sql`(
+        ${table.checkKind} = ${PLAYBOOK_CHECK_KIND_SQL}
+        AND (
+          ${table.outcome} IS NULL
+          OR ${table.outcome} IN (${PLAYBOOK_OUTCOME_SQL_VALUES})
+        )
+      ) OR (
+        ${table.checkKind} = ${REFERENCE_CHECK_KIND_SQL}
+        AND ${table.outcome} IN (${REFERENCE_OUTCOME_SQL_VALUES})
+        AND ${table.positionId} IS NULL
+      )`,
+    ),
+    ...wsOrganizationPolicies("document_review_findings"),
+  ],
+);

--- a/apps/api/src/handlers/document-reviews/create-run.ts
+++ b/apps/api/src/handlers/document-reviews/create-run.ts
@@ -166,7 +166,7 @@ const createDocumentReviewRun = createSafeHandler(
           const latest = versions.at(0);
           return {
             definition,
-            latestApprovedVersion: latest === undefined ? null : latest,
+            latestApprovedVersion: latest ?? null,
           };
         }),
       );

--- a/apps/api/src/handlers/document-reviews/create-run.ts
+++ b/apps/api/src/handlers/document-reviews/create-run.ts
@@ -1,0 +1,305 @@
+/**
+ * Start a durable document review.
+ *
+ * Everything the run will be judged by is pinned here, before any model call:
+ * the target document's version and content hash, each reference's version and
+ * hash, the playbook snapshot, and the confirmed topic list. The worker then
+ * executes from the row alone, so the result stays intelligible after the
+ * playbook, the references, or the document move on.
+ */
+
+import { panic, Result } from "better-result";
+import { and, desc, eq, inArray } from "drizzle-orm";
+
+import {
+  documentReviewRuns,
+  playbookDefinitionVersions,
+} from "@/api/db/schema";
+import { resolvePlaybookPin } from "@/api/handlers/document-reviews/resolve-playbook-pin";
+import { resolveReviewSelection } from "@/api/handlers/document-reviews/review-selection";
+import { validateReviewTopics } from "@/api/handlers/document-reviews/review-topics";
+import { createDocumentReviewRunBodySchema } from "@/api/handlers/document-reviews/schemas";
+import type { DocumentReviewTopic } from "@/api/handlers/document-reviews/schemas";
+import { createSafeHandler } from "@/api/lib/api-handlers";
+import type { HandlerConfig } from "@/api/lib/api-handlers";
+import { AUDIT_ACTION, AUDIT_RESOURCE_TYPE } from "@/api/lib/audit-log";
+import { createSafeId } from "@/api/lib/branded-types";
+import { workspaceParams } from "@/api/lib/custom-schema";
+import { DOCUMENT_REVIEW_RUN_ACTIVE_STATUSES } from "@/api/lib/document-review/run-contract";
+import type {
+  DocumentReviewRunBasis,
+  PinnedPlaybook,
+  PinnedReference,
+} from "@/api/lib/document-review/run-contract";
+import { planReviewRun } from "@/api/lib/document-review/run-plan";
+import { enqueueDocumentReviewRun } from "@/api/lib/document-review/run-queue";
+import { HandlerError } from "@/api/lib/errors/tagged-errors";
+
+const config = {
+  description:
+    "Start an asynchronous review of one document against a playbook and/or reference documents. Returns a run ID to poll.",
+  permissions: { workspace: ["read"] },
+  // Creating a run writes a row and enqueues metered model work, so it must
+  // never be reachable through a read-only consent even though the permission
+  // gate that fronts the whole review surface is a workspace read.
+  access: "write",
+  mcp: { type: "internal", reason: "document_processing" },
+  params: workspaceParams({}),
+  body: createDocumentReviewRunBodySchema,
+} satisfies HandlerConfig;
+
+/** Build the discriminated basis from what the request actually pinned. */
+const buildBasis = (
+  playbook: PinnedPlaybook | null,
+  references: readonly PinnedReference[],
+): DocumentReviewRunBasis | null => {
+  if (playbook !== null && references.length > 0) {
+    return { type: "combined", playbook, references: [...references] };
+  }
+  if (playbook !== null) {
+    return { type: "playbook", playbook };
+  }
+  if (references.length > 0) {
+    return { type: "references", references: [...references] };
+  }
+  return null;
+};
+
+const createDocumentReviewRun = createSafeHandler(
+  config,
+  async function* ({
+    body,
+    recordAuditEvent,
+    safeDb,
+    session,
+    user,
+    workspaceId,
+  }) {
+    const organizationId = session.activeOrganizationId;
+
+    const topics: DocumentReviewTopic[] = body.topics;
+    const validTopics = validateReviewTopics(topics, "comparison");
+    if (Result.isError(validTopics)) {
+      return Result.err(validTopics.error);
+    }
+
+    const entityIds = [
+      body.target.entityId,
+      ...body.references.map((reference) => reference.entityId),
+    ];
+    const entities = yield* Result.await(
+      safeDb((tx) =>
+        tx.query.entities.findMany({
+          where: {
+            id: { in: [...new Set(entityIds)] },
+            workspaceId: { eq: workspaceId },
+          },
+          columns: { id: true, name: true },
+          limit: body.references.length + 1,
+          with: {
+            currentVersion: {
+              columns: { id: true },
+              with: { fields: { columns: { id: true, content: true } } },
+            },
+          },
+        }),
+      ),
+    );
+
+    const selection = resolveReviewSelection({
+      target: body.target,
+      references: body.references,
+      entities,
+    });
+    if (Result.isError(selection)) {
+      return Result.err(selection.error);
+    }
+
+    const nameByEntityId = new Map(
+      entities.map((entity) => [entity.id, entity.name]),
+    );
+    const references: PinnedReference[] = [];
+    for (const reference of selection.value.references) {
+      const name = nameByEntityId.get(reference.entityId);
+      if (name === undefined) {
+        // Selection resolved this entity from the same rows, so a miss here
+        // means the two disagree about what was loaded.
+        return panic("Resolved review reference has no loaded entity row");
+      }
+      references.push({
+        entityId: reference.entityId,
+        fileFieldId: reference.file.fileFieldId,
+        entityVersionId: reference.entityVersionId,
+        contentSha256: reference.file.sha256Hex,
+        name,
+      });
+    }
+
+    const playbookId = body.playbookId;
+    let playbook: PinnedPlaybook | null = null;
+    if (playbookId !== undefined) {
+      const loaded = yield* Result.await(
+        safeDb(async (tx) => {
+          // RLS scopes both reads to the caller's organization.
+          const definition = await tx.query.playbookDefinitions.findFirst({
+            where: { id: { eq: playbookId } },
+            columns: { id: true, name: true, positions: true },
+          });
+          if (!definition) {
+            return null;
+          }
+          const versions = await tx
+            .select({
+              id: playbookDefinitionVersions.id,
+              name: playbookDefinitionVersions.name,
+              positions: playbookDefinitionVersions.positions,
+            })
+            .from(playbookDefinitionVersions)
+            .where(
+              and(
+                eq(playbookDefinitionVersions.playbookDefinitionId, playbookId),
+                eq(playbookDefinitionVersions.organizationId, organizationId),
+              ),
+            )
+            .orderBy(desc(playbookDefinitionVersions.version))
+            .limit(1);
+          const latest = versions.at(0);
+          return {
+            definition,
+            latestApprovedVersion: latest === undefined ? null : latest,
+          };
+        }),
+      );
+      if (loaded === null) {
+        return Result.err(
+          new HandlerError({ status: 404, message: "Playbook not found" }),
+        );
+      }
+      playbook = resolvePlaybookPin(loaded);
+    }
+
+    const basis = buildBasis(playbook, references);
+    if (basis === null) {
+      return Result.err(
+        new HandlerError({
+          status: 422,
+          message: "A review needs a playbook, a reference document, or both.",
+        }),
+      );
+    }
+
+    const plan = planReviewRun({ basis, topics });
+    if (plan.expectedFindingCount === 0) {
+      return Result.err(
+        new HandlerError({
+          status: 422,
+          message: "None of the confirmed topics can be reviewed.",
+        }),
+      );
+    }
+
+    const target = selection.value.target;
+    const runId = createSafeId<"documentReviewRun">();
+    const inserted = yield* Result.await(
+      safeDb(async (tx) => {
+        // One unfinished review per document: a second one would spend twice
+        // and race the first to the same findings. The partial unique index
+        // backs this up if two requests pass the check together.
+        const active = await tx
+          .select({ id: documentReviewRuns.id })
+          .from(documentReviewRuns)
+          .where(
+            and(
+              eq(documentReviewRuns.workspaceId, workspaceId),
+              eq(documentReviewRuns.entityId, target.entityId),
+              eq(documentReviewRuns.fileFieldId, target.file.fileFieldId),
+              inArray(documentReviewRuns.status, [
+                ...DOCUMENT_REVIEW_RUN_ACTIVE_STATUSES,
+              ]),
+            ),
+          )
+          .limit(1);
+        if (active.length > 0) {
+          return false;
+        }
+
+        await tx.insert(documentReviewRuns).values({
+          id: runId,
+          organizationId,
+          workspaceId,
+          entityId: target.entityId,
+          fileFieldId: target.file.fileFieldId,
+          entityVersionId: target.entityVersionId,
+          contentSha256: target.file.sha256Hex,
+          basis,
+          topics,
+          status: "queued",
+          total: plan.expectedFindingCount,
+          requestedBy: user.id,
+        });
+
+        await recordAuditEvent(tx, {
+          action: AUDIT_ACTION.EXECUTE,
+          resourceType: AUDIT_RESOURCE_TYPE.DOCUMENT_REVIEW_RUN,
+          resourceId: runId,
+          metadata: {
+            basisType: basis.type,
+            expectedFindingCount: plan.expectedFindingCount,
+            playbookProvenance:
+              playbook === null ? "none" : playbook.provenance,
+            referenceCount: references.length,
+          },
+        });
+        return true;
+      }),
+    );
+
+    if (!inserted) {
+      return Result.err(
+        new HandlerError({
+          status: 409,
+          message: "This document is already being reviewed.",
+        }),
+      );
+    }
+
+    const enqueued = await Result.tryPromise({
+      try: async () =>
+        await enqueueDocumentReviewRun({
+          runId,
+          workspaceId,
+          organizationId,
+          userId: user.id,
+        }),
+      catch: (cause) => cause,
+    });
+    if (Result.isError(enqueued)) {
+      // A never-enqueued run must not hold the document's active slot, so mark
+      // it failed immediately rather than waiting for the orphan reconciler.
+      yield* Result.await(
+        safeDb(async (tx) => {
+          // audit: skip — status bookkeeping on the run row audited at insert.
+          await tx
+            .update(documentReviewRuns)
+            .set({
+              status: "failed",
+              errorCode: "enqueue_failed",
+              finishedAt: new Date(),
+            })
+            .where(eq(documentReviewRuns.id, runId));
+        }),
+      );
+      return Result.err(
+        new HandlerError({
+          status: 500,
+          message: "Failed to start the review.",
+          cause: enqueued.error,
+        }),
+      );
+    }
+
+    return Result.ok({ runId });
+  },
+);
+
+export default createDocumentReviewRun;

--- a/apps/api/src/handlers/document-reviews/list-runs.ts
+++ b/apps/api/src/handlers/document-reviews/list-runs.ts
@@ -111,20 +111,20 @@ const listDocumentReviewRuns = createSafeHandler(
         runHistoryCursor.encode(item.createdAtCursor, item.id),
     });
 
+    // The cursor projection is a pagination mechanism, not part of the run, so
+    // the response object is listed out rather than spread from the row.
     return Result.ok({
       ...page,
-      items: page.items.map(
-        ({
-          createdAtCursor: _createdAtCursor,
-          createdAt,
-          finishedAt,
-          ...run
-        }) => ({
-          ...run,
-          createdAt: createdAt.toISOString(),
-          finishedAt: finishedAt === null ? null : finishedAt.toISOString(),
-        }),
-      ),
+      items: page.items.map((run) => ({
+        id: run.id,
+        status: run.status,
+        errorCode: run.errorCode,
+        entityVersionId: run.entityVersionId,
+        total: run.total,
+        completed: run.completed,
+        createdAt: run.createdAt.toISOString(),
+        finishedAt: run.finishedAt?.toISOString() ?? null,
+      })),
     });
   },
 );

--- a/apps/api/src/handlers/document-reviews/list-runs.ts
+++ b/apps/api/src/handlers/document-reviews/list-runs.ts
@@ -1,0 +1,132 @@
+/**
+ * Review history for one document, newest first.
+ *
+ * Keyset-paginated on `(created_at, id)` descending, matching the
+ * `(workspace_id, entity_id, file_field_id, created_at DESC, id DESC)` index,
+ * so a document with a long review history pages at constant cost.
+ */
+
+import { Result } from "better-result";
+import { and, desc, eq } from "drizzle-orm";
+import type { SQL } from "drizzle-orm";
+import { t } from "elysia";
+
+import { documentReviewRuns } from "@/api/db/schema";
+import { createSafeHandler } from "@/api/lib/api-handlers";
+import type { HandlerConfig } from "@/api/lib/api-handlers";
+import { tSafeId, workspaceParams } from "@/api/lib/custom-schema";
+import { createTimestampIdCursorCodec } from "@/api/lib/db-pagination";
+import { HandlerError } from "@/api/lib/errors/tagged-errors";
+import { createCursorPage } from "@/api/lib/pagination";
+import { brandPersistedDocumentReviewRunId } from "@/api/lib/safe-id-boundaries";
+
+const RUNS_PAGE_SIZE_DEFAULT = 20;
+const RUNS_PAGE_SIZE_MAX = 50;
+
+const runHistoryCursor = createTimestampIdCursorCodec({
+  column: documentReviewRuns.createdAt,
+  brandId: brandPersistedDocumentReviewRunId,
+});
+
+/** Decode the opaque cursor into its keyset predicate. A malformed cursor is a
+ *  client error, not an empty page, so it fails the request. */
+const runHistoryCursorCondition = (
+  cursor: string | undefined,
+): Result<SQL | undefined, HandlerError> => {
+  if (cursor === undefined) {
+    return Result.ok(undefined);
+  }
+  const decoded = runHistoryCursor.decode(cursor);
+  if (decoded === null) {
+    return Result.err(
+      new HandlerError({ status: 400, message: "Invalid cursor" }),
+    );
+  }
+  return Result.ok(
+    runHistoryCursor.keysetAfter({
+      cursor: decoded,
+      direction: "descending",
+      idColumn: documentReviewRuns.id,
+    }),
+  );
+};
+
+const config = {
+  description:
+    "List review runs for one document in a matter, newest first with cursor pagination.",
+  permissions: { workspace: ["read"] },
+  access: "read",
+  mcp: { type: "internal", reason: "document_processing" },
+  params: workspaceParams({}),
+  query: t.Object({
+    entityId: tSafeId("entity"),
+    fileFieldId: tSafeId("field"),
+    cursor: t.Optional(t.String({ maxLength: 512 })),
+    limit: t.Optional(t.Integer({ minimum: 1, maximum: RUNS_PAGE_SIZE_MAX })),
+  }),
+} satisfies HandlerConfig;
+
+const listDocumentReviewRuns = createSafeHandler(
+  config,
+  async function* ({ query, safeDb, workspaceId }) {
+    const limit = query.limit ?? RUNS_PAGE_SIZE_DEFAULT;
+    const cursorCondition = yield* runHistoryCursorCondition(query.cursor);
+
+    const rows = yield* Result.await(
+      safeDb((tx) =>
+        tx
+          .select({
+            id: documentReviewRuns.id,
+            status: documentReviewRuns.status,
+            errorCode: documentReviewRuns.errorCode,
+            entityVersionId: documentReviewRuns.entityVersionId,
+            total: documentReviewRuns.total,
+            completed: documentReviewRuns.completed,
+            createdAt: documentReviewRuns.createdAt,
+            finishedAt: documentReviewRuns.finishedAt,
+            createdAtCursor:
+              runHistoryCursor.cursorValue.as("created_at_cursor"),
+          })
+          .from(documentReviewRuns)
+          .where(
+            and(
+              eq(documentReviewRuns.workspaceId, workspaceId),
+              eq(documentReviewRuns.entityId, query.entityId),
+              eq(documentReviewRuns.fileFieldId, query.fileFieldId),
+              cursorCondition,
+            ),
+          )
+          .orderBy(
+            desc(documentReviewRuns.createdAt),
+            desc(documentReviewRuns.id),
+          )
+          .limit(limit + 1),
+      ),
+    );
+
+    const page = createCursorPage({
+      rows,
+      limit,
+      cursorForItem: (item) =>
+        runHistoryCursor.encode(item.createdAtCursor, item.id),
+    });
+
+    return Result.ok({
+      ...page,
+      items: page.items.map(
+        ({
+          createdAtCursor: _createdAtCursor,
+          createdAt,
+          finishedAt,
+          ...run
+        }) => ({
+          ...run,
+          createdAt: createdAt.toISOString(),
+          finishedAt: finishedAt === null ? null : finishedAt.toISOString(),
+        }),
+      ),
+    });
+  },
+);
+
+export default listDocumentReviewRuns;

--- a/apps/api/src/handlers/document-reviews/read-run.ts
+++ b/apps/api/src/handlers/document-reviews/read-run.ts
@@ -1,0 +1,117 @@
+/**
+ * Read one document review run and its findings.
+ *
+ * Bounded by construction: a run holds at most one finding per confirmed topic
+ * per check kind, and the confirmed topic list is capped at creation, so this
+ * is a point read rather than an unbounded list.
+ */
+
+import { Result } from "better-result";
+import { and, asc, eq } from "drizzle-orm";
+
+import { DOCUMENT_REVIEW_LIMITS } from "@stll/api-contract";
+
+import { documentReviewFindings, documentReviewRuns } from "@/api/db/schema";
+import { createSafeHandler } from "@/api/lib/api-handlers";
+import type { HandlerConfig } from "@/api/lib/api-handlers";
+import { tSafeId, workspaceParams } from "@/api/lib/custom-schema";
+import { DOCUMENT_REVIEW_CHECK_KINDS } from "@/api/lib/document-review/run-contract";
+import { HandlerError } from "@/api/lib/errors/tagged-errors";
+
+/** The most rows a single run can hold: one per confirmed topic per check
+ *  kind. Derived from the same caps the create endpoint enforces, so the read
+ *  cannot silently outgrow them. */
+const FINDINGS_MAX =
+  DOCUMENT_REVIEW_LIMITS.topicsMax * DOCUMENT_REVIEW_CHECK_KINDS.length;
+
+const config = {
+  description:
+    "Read one document review run: its status, progress, pinned basis, and the findings committed so far.",
+  permissions: { workspace: ["read"] },
+  access: "read",
+  mcp: { type: "internal", reason: "document_processing" },
+  params: workspaceParams({ runId: tSafeId("documentReviewRun") }),
+} satisfies HandlerConfig;
+
+const readDocumentReviewRun = createSafeHandler(
+  config,
+  async function* ({ params, safeDb, workspaceId }) {
+    const runs = yield* Result.await(
+      safeDb((tx) =>
+        tx
+          .select({
+            id: documentReviewRuns.id,
+            status: documentReviewRuns.status,
+            errorCode: documentReviewRuns.errorCode,
+            entityId: documentReviewRuns.entityId,
+            fileFieldId: documentReviewRuns.fileFieldId,
+            entityVersionId: documentReviewRuns.entityVersionId,
+            contentSha256: documentReviewRuns.contentSha256,
+            basis: documentReviewRuns.basis,
+            topics: documentReviewRuns.topics,
+            total: documentReviewRuns.total,
+            completed: documentReviewRuns.completed,
+            pipelineVersion: documentReviewRuns.pipelineVersion,
+            createdAt: documentReviewRuns.createdAt,
+            startedAt: documentReviewRuns.startedAt,
+            finishedAt: documentReviewRuns.finishedAt,
+          })
+          .from(documentReviewRuns)
+          .where(
+            and(
+              eq(documentReviewRuns.id, params.runId),
+              eq(documentReviewRuns.workspaceId, workspaceId),
+            ),
+          )
+          .limit(1),
+      ),
+    );
+    const run = runs.at(0);
+    if (run === undefined) {
+      return Result.err(
+        new HandlerError({ status: 404, message: "Review run not found" }),
+      );
+    }
+
+    const findings = yield* Result.await(
+      safeDb((tx) =>
+        tx
+          .select({
+            id: documentReviewFindings.id,
+            topicId: documentReviewFindings.topicId,
+            topicTitle: documentReviewFindings.topicTitle,
+            checkKind: documentReviewFindings.checkKind,
+            positionId: documentReviewFindings.positionId,
+            outcome: documentReviewFindings.outcome,
+            payload: documentReviewFindings.payload,
+          })
+          .from(documentReviewFindings)
+          .where(
+            and(
+              eq(documentReviewFindings.runId, params.runId),
+              eq(documentReviewFindings.workspaceId, workspaceId),
+            ),
+          )
+          .orderBy(
+            asc(documentReviewFindings.checkKind),
+            asc(documentReviewFindings.createdAt),
+            asc(documentReviewFindings.id),
+          )
+          .limit(FINDINGS_MAX),
+      ),
+    );
+
+    return Result.ok({
+      run: {
+        ...run,
+        createdAt: run.createdAt.toISOString(),
+        startedAt: run.startedAt === null ? null : run.startedAt.toISOString(),
+        finishedAt:
+          run.finishedAt === null ? null : run.finishedAt.toISOString(),
+      },
+      findings,
+    });
+  },
+);
+
+export default readDocumentReviewRun;

--- a/apps/api/src/handlers/document-reviews/resolve-playbook-pin.test.ts
+++ b/apps/api/src/handlers/document-reviews/resolve-playbook-pin.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "bun:test";
+
+import { resolvePlaybookPin } from "@/api/handlers/document-reviews/resolve-playbook-pin";
+import type {
+  PlaybookDefinitionForPin,
+  PlaybookVersionForPin,
+} from "@/api/handlers/document-reviews/resolve-playbook-pin";
+import { toSafeId } from "@/api/lib/branded-types";
+import type { PlaybookPositions } from "@/api/lib/workflow/playbook-positions";
+
+const positionsWithIssue = (issue: string): PlaybookPositions => ({
+  version: 2,
+  items: [
+    {
+      mode: "extract",
+      sourceId: "11111111-1111-4111-8111-111111111111",
+      issue,
+      ask: {
+        question: "What is the notice period?",
+        content: { version: 1, type: "text" },
+      },
+      enabled: true,
+    },
+  ],
+});
+
+const definition: PlaybookDefinitionForPin = {
+  id: toSafeId<"playbookDefinition">(Bun.randomUUIDv7()),
+  name: "Live draft name",
+  positions: positionsWithIssue("Edited after approval"),
+};
+
+const approvedVersion: PlaybookVersionForPin = {
+  id: toSafeId<"playbookDefinitionVersion">(Bun.randomUUIDv7()),
+  name: "Approved name",
+  positions: positionsWithIssue("As approved"),
+};
+
+describe("resolvePlaybookPin", () => {
+  test("pins the approved snapshot, not the edited live definition", () => {
+    const pin = resolvePlaybookPin({
+      definition,
+      latestApprovedVersion: approvedVersion,
+    });
+
+    expect(pin).toMatchObject({
+      definitionId: definition.id,
+      versionId: approvedVersion.id,
+      provenance: "approved",
+    });
+    expect(pin.definitionSnapshot).toEqual({
+      name: approvedVersion.name,
+      positions: approvedVersion.positions,
+    });
+  });
+
+  test("records draft provenance when the playbook was never approved", () => {
+    const pin = resolvePlaybookPin({
+      definition,
+      latestApprovedVersion: null,
+    });
+
+    expect(pin).toMatchObject({
+      definitionId: definition.id,
+      versionId: null,
+      provenance: "draft",
+    });
+    expect(pin.definitionSnapshot).toEqual({
+      name: definition.name,
+      positions: definition.positions,
+    });
+  });
+});

--- a/apps/api/src/handlers/document-reviews/resolve-playbook-pin.ts
+++ b/apps/api/src/handlers/document-reviews/resolve-playbook-pin.ts
@@ -1,0 +1,61 @@
+import type { SafeId } from "@/api/lib/branded-types";
+import type { PinnedPlaybook } from "@/api/lib/document-review/run-contract";
+import type { PlaybookPositions } from "@/api/lib/workflow/playbook-positions";
+
+/** The live definition, as it stands right now. */
+export type PlaybookDefinitionForPin = {
+  id: SafeId<"playbookDefinition">;
+  name: string;
+  positions: PlaybookPositions;
+};
+
+/** The newest row in `playbook_definition_versions` for that definition. */
+export type PlaybookVersionForPin = {
+  id: SafeId<"playbookDefinitionVersion">;
+  name: string;
+  positions: PlaybookPositions;
+};
+
+type ResolvePlaybookPinArgs = {
+  definition: PlaybookDefinitionForPin;
+  latestApprovedVersion: PlaybookVersionForPin | null;
+};
+
+/**
+ * Pin the playbook a run executes against.
+ *
+ * An approved snapshot wins over the live definition: approving is what makes
+ * a playbook citable, and a definition edited after approval must not
+ * retroactively change what an approved review measured. A definition that has
+ * never been approved is still runnable — an author reviewing their own draft
+ * is the normal authoring loop — but the run records `provenance: "draft"` so
+ * the result is never mistaken for an approved one.
+ *
+ * Either way the whole definition is embedded by value: the run outlives the
+ * playbook and both of its tables.
+ */
+export const resolvePlaybookPin = ({
+  definition,
+  latestApprovedVersion,
+}: ResolvePlaybookPinArgs): PinnedPlaybook => {
+  if (latestApprovedVersion !== null) {
+    return {
+      definitionId: definition.id,
+      versionId: latestApprovedVersion.id,
+      provenance: "approved",
+      definitionSnapshot: {
+        name: latestApprovedVersion.name,
+        positions: latestApprovedVersion.positions,
+      },
+    };
+  }
+  return {
+    definitionId: definition.id,
+    versionId: null,
+    provenance: "draft",
+    definitionSnapshot: {
+      name: definition.name,
+      positions: definition.positions,
+    },
+  };
+};

--- a/apps/api/src/handlers/document-reviews/routes.ts
+++ b/apps/api/src/handlers/document-reviews/routes.ts
@@ -1,8 +1,11 @@
 import Elysia from "elysia";
 
 import compareReferences from "@/api/handlers/document-reviews/compare-references";
+import createDocumentReviewRun from "@/api/handlers/document-reviews/create-run";
+import listDocumentReviewRuns from "@/api/handlers/document-reviews/list-runs";
 import listDocumentReviewSources from "@/api/handlers/document-reviews/list-sources";
 import proposeTopics from "@/api/handlers/document-reviews/propose-topics";
+import readDocumentReviewRun from "@/api/handlers/document-reviews/read-run";
 import { permissionMacro, workspaceAccessMacro } from "@/api/lib/auth";
 
 export const documentReviewsRoute = new Elysia({
@@ -22,4 +25,16 @@ export const documentReviewsRoute = new Elysia({
   .post("/topics", proposeTopics.handler, {
     body: proposeTopics.config.body,
     permissions: proposeTopics.config.permissions,
+  })
+  .post("/runs", createDocumentReviewRun.handler, {
+    body: createDocumentReviewRun.config.body,
+    permissions: createDocumentReviewRun.config.permissions,
+  })
+  .get("/runs", listDocumentReviewRuns.handler, {
+    query: listDocumentReviewRuns.config.query,
+    permissions: listDocumentReviewRuns.config.permissions,
+  })
+  .get("/runs/:runId", readDocumentReviewRun.handler, {
+    params: readDocumentReviewRun.config.params,
+    permissions: readDocumentReviewRun.config.permissions,
   });

--- a/apps/api/src/handlers/document-reviews/routes.ts
+++ b/apps/api/src/handlers/document-reviews/routes.ts
@@ -28,11 +28,13 @@ export const documentReviewsRoute = new Elysia({
   })
   .post("/runs", createDocumentReviewRun.handler, {
     body: createDocumentReviewRun.config.body,
+    params: createDocumentReviewRun.config.params,
     permissions: createDocumentReviewRun.config.permissions,
   })
   .get("/runs", listDocumentReviewRuns.handler, {
-    query: listDocumentReviewRuns.config.query,
+    params: listDocumentReviewRuns.config.params,
     permissions: listDocumentReviewRuns.config.permissions,
+    query: listDocumentReviewRuns.config.query,
   })
   .get("/runs/:runId", readDocumentReviewRun.handler, {
     params: readDocumentReviewRun.config.params,

--- a/apps/api/src/handlers/document-reviews/run-persistence.integration.test.ts
+++ b/apps/api/src/handlers/document-reviews/run-persistence.integration.test.ts
@@ -1,0 +1,332 @@
+/**
+ * The persistence invariants a durable review depends on, exercised against a
+ * real PostgreSQL schema because the schema is what enforces them:
+ *
+ *  - one unfinished run per document (the 409 the create endpoint returns is a
+ *    friendly restatement of this index, not the guarantee itself),
+ *  - `(runId, topicId, checkKind)` convergence, so a redelivered job overwrites
+ *    the judgment it already wrote instead of adding a second one,
+ *  - the per-kind outcome vocabularies staying unmerged.
+ */
+
+import {
+  afterAll,
+  beforeAll,
+  describe,
+  expect,
+  setDefaultTimeout,
+  test,
+} from "bun:test";
+import { and, eq, inArray } from "drizzle-orm";
+
+import { documentReviewFindings, documentReviewRuns } from "@/api/db/schema";
+import { toSafeId } from "@/api/lib/branded-types";
+import type { SafeId } from "@/api/lib/branded-types";
+import type { DocumentReviewRunStatus } from "@/api/lib/document-review/run-contract";
+import type {
+  DocumentReviewFindingPayload,
+  DocumentReviewRunBasis,
+} from "@/api/lib/document-review/run-contract";
+import {
+  getRlsFixture,
+  releaseRlsFixture,
+} from "@/api/tests/security/rls-fixture";
+import type { TestIds } from "@/api/tests/security/rls-helpers";
+import type { TestDatabase } from "@/api/tests/security/test-utils";
+
+setDefaultTimeout(120_000);
+
+let testDb: TestDatabase;
+let ids: TestIds;
+
+const seededRunIds: SafeId<"documentReviewRun">[] = [];
+
+const TOPIC_ID = "44444444-4444-4444-8444-444444444444";
+const POSITION_ID = "11111111-1111-4111-8111-111111111111";
+const CONTENT_SHA256 = "a".repeat(64);
+
+/** The reviewed document a case owns. Runs pin these by value (no foreign
+ *  keys), so each case can claim its own document without seeding entities. */
+type ReviewTarget = {
+  entityId: SafeId<"entity">;
+  fileFieldId: SafeId<"field">;
+  entityVersionId: SafeId<"entityVersion">;
+};
+
+const reviewTarget = (): ReviewTarget => ({
+  entityId: toSafeId<"entity">(Bun.randomUUIDv7()),
+  fileFieldId: toSafeId<"field">(Bun.randomUUIDv7()),
+  entityVersionId: toSafeId<"entityVersion">(Bun.randomUUIDv7()),
+});
+
+const referenceBasis: DocumentReviewRunBasis = {
+  type: "references",
+  references: [
+    {
+      entityId: toSafeId<"entity">(Bun.randomUUIDv7()),
+      fileFieldId: toSafeId<"field">(Bun.randomUUIDv7()),
+      entityVersionId: toSafeId<"entityVersion">(Bun.randomUUIDv7()),
+      contentSha256: "b".repeat(64),
+      name: "Precedent SPA",
+    },
+  ],
+};
+
+const referencePayload = (text: string): DocumentReviewFindingPayload => ({
+  checkKind: "reference",
+  finding: {
+    findingId: `reference-${TOPIC_ID}`,
+    topicId: TOPIC_ID,
+    issue: "Governing law",
+    assessment: "different",
+    consensus: "single",
+    explanation: { type: "comparison", text },
+    targetCitations: [],
+    referenceCitations: [],
+    fix: null,
+  },
+});
+
+const playbookPayload: DocumentReviewFindingPayload = {
+  checkKind: "playbook",
+  finding: {
+    positionId: POSITION_ID,
+    issue: "Governing law",
+    severity: "high",
+    verdict: "compliant",
+    extracted: null,
+    rationale: null,
+    citations: [],
+    fix: null,
+  },
+};
+
+const seedRun = async ({
+  runId,
+  status,
+  target,
+}: {
+  runId: SafeId<"documentReviewRun">;
+  status: DocumentReviewRunStatus;
+  target: ReviewTarget;
+}): Promise<void> => {
+  seededRunIds.push(runId);
+  await testDb.insert(documentReviewRuns).values({
+    id: runId,
+    organizationId: ids.orgA,
+    workspaceId: ids.wsA1,
+    entityId: target.entityId,
+    fileFieldId: target.fileFieldId,
+    entityVersionId: target.entityVersionId,
+    contentSha256: CONTENT_SHA256,
+    basis: referenceBasis,
+    topics: [
+      {
+        type: "reference",
+        topicId: TOPIC_ID,
+        title: "Governing law",
+        context: "",
+        included: true,
+      },
+    ],
+    status,
+    total: 1,
+    requestedBy: ids.userA1,
+    ...(status === "running" ? { startedAt: new Date() } : {}),
+  });
+};
+
+const upsertReferenceFinding = async (
+  runId: SafeId<"documentReviewRun">,
+  target: ReviewTarget,
+  text: string,
+): Promise<void> => {
+  const payload = referencePayload(text);
+  await testDb
+    .insert(documentReviewFindings)
+    .values({
+      id: toSafeId<"documentReviewFinding">(Bun.randomUUIDv7()),
+      organizationId: ids.orgA,
+      workspaceId: ids.wsA1,
+      runId,
+      entityId: target.entityId,
+      fileFieldId: target.fileFieldId,
+      entityVersionId: target.entityVersionId,
+      topicId: TOPIC_ID,
+      topicTitle: "Governing law",
+      checkKind: "reference",
+      positionId: null,
+      outcome: payload.finding.assessment,
+      payload,
+    })
+    .onConflictDoUpdate({
+      target: [
+        documentReviewFindings.runId,
+        documentReviewFindings.topicId,
+        documentReviewFindings.checkKind,
+      ],
+      set: { payload, outcome: payload.finding.assessment },
+    });
+};
+
+beforeAll(async () => {
+  const fixture = await getRlsFixture();
+  testDb = fixture.testDb;
+  ids = fixture.ids;
+});
+
+afterAll(async () => {
+  try {
+    if (seededRunIds.length > 0) {
+      await testDb
+        .delete(documentReviewRuns)
+        .where(inArray(documentReviewRuns.id, seededRunIds));
+    }
+  } finally {
+    await releaseRlsFixture();
+  }
+});
+
+describe("document review run persistence", () => {
+  test("refuses a second unfinished run for the same document", async () => {
+    const target = reviewTarget();
+    const first = toSafeId<"documentReviewRun">(Bun.randomUUIDv7());
+    await seedRun({ runId: first, status: "queued", target });
+
+    const second = toSafeId<"documentReviewRun">(Bun.randomUUIDv7());
+    await expect(
+      seedRun({ runId: second, status: "queued", target }),
+    ).rejects.toThrow();
+
+    // A claimed run still occupies the document: the guard covers the whole
+    // active window, not just the queued moment.
+    await testDb
+      .update(documentReviewRuns)
+      .set({ status: "running", startedAt: new Date() })
+      .where(eq(documentReviewRuns.id, first));
+    const third = toSafeId<"documentReviewRun">(Bun.randomUUIDv7());
+    await expect(
+      seedRun({ runId: third, status: "queued", target }),
+    ).rejects.toThrow();
+  });
+
+  test("allows a new run once the previous one is terminal", async () => {
+    const target = reviewTarget();
+    const previous = toSafeId<"documentReviewRun">(Bun.randomUUIDv7());
+    await seedRun({ runId: previous, status: "queued", target });
+    await testDb
+      .update(documentReviewRuns)
+      .set({ status: "completed", finishedAt: new Date() })
+      .where(eq(documentReviewRuns.id, previous));
+
+    const next = toSafeId<"documentReviewRun">(Bun.randomUUIDv7());
+    await seedRun({ runId: next, status: "queued", target });
+
+    const rows = await testDb
+      .select({ id: documentReviewRuns.id })
+      .from(documentReviewRuns)
+      .where(
+        and(
+          eq(documentReviewRuns.workspaceId, ids.wsA1),
+          eq(documentReviewRuns.entityId, target.entityId),
+        ),
+      );
+    expect(rows.map(({ id }) => id).toSorted()).toEqual(
+      [previous, next].toSorted(),
+    );
+  });
+
+  test("converges on one finding per topic per kind when a job replays", async () => {
+    const target = reviewTarget();
+    const runId = toSafeId<"documentReviewRun">(Bun.randomUUIDv7());
+    await seedRun({ runId, status: "running", target });
+
+    await upsertReferenceFinding(runId, target, "First pass");
+    await upsertReferenceFinding(runId, target, "Replayed pass");
+    await upsertReferenceFinding(runId, target, "Replayed pass");
+
+    const rows = await testDb
+      .select({ payload: documentReviewFindings.payload })
+      .from(documentReviewFindings)
+      .where(eq(documentReviewFindings.runId, runId));
+
+    expect(rows.length).toBe(1);
+    const stored = rows.at(0)?.payload;
+    expect(stored?.checkKind).toBe("reference");
+    if (stored?.checkKind === "reference") {
+      expect(stored.finding.explanation).toEqual({
+        type: "comparison",
+        text: "Replayed pass",
+      });
+    }
+  });
+
+  test("keeps the two outcome vocabularies apart", async () => {
+    const target = reviewTarget();
+    const runId = toSafeId<"documentReviewRun">(Bun.randomUUIDv7());
+    await seedRun({ runId, status: "running", target });
+
+    const insertOutcome = async ({
+      checkKind,
+      outcome,
+      positionId,
+    }: {
+      checkKind: "playbook" | "reference";
+      outcome: string;
+      positionId: string | null;
+    }) =>
+      await testDb.insert(documentReviewFindings).values({
+        id: toSafeId<"documentReviewFinding">(Bun.randomUUIDv7()),
+        organizationId: ids.orgA,
+        workspaceId: ids.wsA1,
+        runId,
+        entityId: target.entityId,
+        fileFieldId: target.fileFieldId,
+        entityVersionId: target.entityVersionId,
+        topicId: Bun.randomUUIDv7(),
+        topicTitle: "Governing law",
+        checkKind,
+        positionId,
+        outcome,
+        payload:
+          checkKind === "playbook"
+            ? playbookPayload
+            : referencePayload("vocabulary probe"),
+      });
+
+    // A verdict tier is not a comparison assessment, and vice versa.
+    await expect(
+      insertOutcome({
+        checkKind: "reference",
+        outcome: "compliant",
+        positionId: null,
+      }),
+    ).rejects.toThrow();
+    await expect(
+      insertOutcome({
+        checkKind: "playbook",
+        outcome: "different",
+        positionId: POSITION_ID,
+      }),
+    ).rejects.toThrow();
+    // Only a playbook-kind row grades a position.
+    await expect(
+      insertOutcome({
+        checkKind: "reference",
+        outcome: "aligned",
+        positionId: POSITION_ID,
+      }),
+    ).rejects.toThrow();
+
+    await insertOutcome({
+      checkKind: "playbook",
+      outcome: "compliant",
+      positionId: POSITION_ID,
+    });
+    await insertOutcome({
+      checkKind: "reference",
+      outcome: "aligned",
+      positionId: null,
+    });
+  });
+});

--- a/apps/api/src/handlers/document-reviews/run-persistence.integration.test.ts
+++ b/apps/api/src/handlers/document-reviews/run-persistence.integration.test.ts
@@ -22,10 +22,10 @@ import { and, eq, inArray } from "drizzle-orm";
 import { documentReviewFindings, documentReviewRuns } from "@/api/db/schema";
 import { toSafeId } from "@/api/lib/branded-types";
 import type { SafeId } from "@/api/lib/branded-types";
-import type { DocumentReviewRunStatus } from "@/api/lib/document-review/run-contract";
 import type {
   DocumentReviewFindingPayload,
   DocumentReviewRunBasis,
+  DocumentReviewRunStatus,
 } from "@/api/lib/document-review/run-contract";
 import {
   getRlsFixture,
@@ -72,7 +72,65 @@ const referenceBasis: DocumentReviewRunBasis = {
   ],
 };
 
-const referencePayload = (text: string): DocumentReviewFindingPayload => ({
+/** Each fixture is pinned to its own member of the payload union rather than
+ *  to the union itself, so a shape that drifts from the engine's finding type
+ *  fails here instead of being widened away. */
+type ReferenceFindingPayload = Extract<
+  DocumentReviewFindingPayload,
+  { checkKind: "reference" }
+>;
+type PlaybookFindingPayload = Extract<
+  DocumentReviewFindingPayload,
+  { checkKind: "playbook" }
+>;
+
+/** bun-types declares `.rejects.toThrow` as void, so awaiting it trips
+ *  type-aware lint; capture the rejection explicitly instead. */
+const rejectionOf = async (operation: Promise<unknown>): Promise<unknown> =>
+  await operation.then(
+    () => null,
+    (error: unknown) => error,
+  );
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null;
+
+/** The pg error fields that name the rule a statement broke. */
+const VIOLATION_FIELDS = ["message", "constraint", "detail"] as const;
+
+/**
+ * Everything a failure says about which rule it broke: the message chain plus
+ * the `constraint` field the driver exposes, walked through `cause` so it does
+ * not matter whether drizzle wraps the underlying error.
+ *
+ * Asserting on this rather than on "some error was thrown" is what stops a
+ * missing relation, a bad column, or a foreign-key failure from passing as
+ * proof that the constraint under test fired.
+ */
+const violationText = (error: unknown): string => {
+  const parts: string[] = [];
+  const seen = new Set<unknown>();
+  let current: unknown = error;
+  while (isRecord(current) && !seen.has(current)) {
+    seen.add(current);
+    for (const field of VIOLATION_FIELDS) {
+      const value = current[field];
+      if (typeof value === "string") {
+        parts.push(value);
+      }
+    }
+    current = current["cause"];
+  }
+  return parts.join(" | ");
+};
+
+// The exact objects under test, named as `db/schema/document-reviews.ts`
+// declares them. A rename there fails these assertions rather than quietly
+// leaving the constraint untested.
+const ACTIVE_RUN_INDEX = "document_review_runs_active_document_uidx";
+const FINDING_OUTCOME_CHECK = "document_review_findings_outcome_check";
+
+const referencePayload = (text: string): ReferenceFindingPayload => ({
   checkKind: "reference",
   finding: {
     findingId: `reference-${TOPIC_ID}`,
@@ -87,7 +145,7 @@ const referencePayload = (text: string): DocumentReviewFindingPayload => ({
   },
 });
 
-const playbookPayload: DocumentReviewFindingPayload = {
+const playbookPayload: PlaybookFindingPayload = {
   checkKind: "playbook",
   finding: {
     positionId: POSITION_ID,
@@ -194,9 +252,11 @@ describe("document review run persistence", () => {
     await seedRun({ runId: first, status: "queued", target });
 
     const second = toSafeId<"documentReviewRun">(Bun.randomUUIDv7());
-    await expect(
-      seedRun({ runId: second, status: "queued", target }),
-    ).rejects.toThrow();
+    expect(
+      violationText(
+        await rejectionOf(seedRun({ runId: second, status: "queued", target })),
+      ),
+    ).toContain(ACTIVE_RUN_INDEX);
 
     // A claimed run still occupies the document: the guard covers the whole
     // active window, not just the queued moment.
@@ -205,9 +265,11 @@ describe("document review run persistence", () => {
       .set({ status: "running", startedAt: new Date() })
       .where(eq(documentReviewRuns.id, first));
     const third = toSafeId<"documentReviewRun">(Bun.randomUUIDv7());
-    await expect(
-      seedRun({ runId: third, status: "queued", target }),
-    ).rejects.toThrow();
+    expect(
+      violationText(
+        await rejectionOf(seedRun({ runId: third, status: "queued", target })),
+      ),
+    ).toContain(ACTIVE_RUN_INDEX);
   });
 
   test("allows a new run once the previous one is terminal", async () => {
@@ -274,7 +336,7 @@ describe("document review run persistence", () => {
       checkKind: "playbook" | "reference";
       outcome: string;
       positionId: string | null;
-    }) =>
+    }): Promise<void> => {
       await testDb.insert(documentReviewFindings).values({
         id: toSafeId<"documentReviewFinding">(Bun.randomUUIDv7()),
         organizationId: ids.orgA,
@@ -293,30 +355,43 @@ describe("document review run persistence", () => {
             ? playbookPayload
             : referencePayload("vocabulary probe"),
       });
+    };
 
     // A verdict tier is not a comparison assessment, and vice versa.
-    await expect(
-      insertOutcome({
-        checkKind: "reference",
-        outcome: "compliant",
-        positionId: null,
-      }),
-    ).rejects.toThrow();
-    await expect(
-      insertOutcome({
-        checkKind: "playbook",
-        outcome: "different",
-        positionId: POSITION_ID,
-      }),
-    ).rejects.toThrow();
+    expect(
+      violationText(
+        await rejectionOf(
+          insertOutcome({
+            checkKind: "reference",
+            outcome: "compliant",
+            positionId: null,
+          }),
+        ),
+      ),
+    ).toContain(FINDING_OUTCOME_CHECK);
+    expect(
+      violationText(
+        await rejectionOf(
+          insertOutcome({
+            checkKind: "playbook",
+            outcome: "different",
+            positionId: POSITION_ID,
+          }),
+        ),
+      ),
+    ).toContain(FINDING_OUTCOME_CHECK);
     // Only a playbook-kind row grades a position.
-    await expect(
-      insertOutcome({
-        checkKind: "reference",
-        outcome: "aligned",
-        positionId: POSITION_ID,
-      }),
-    ).rejects.toThrow();
+    expect(
+      violationText(
+        await rejectionOf(
+          insertOutcome({
+            checkKind: "reference",
+            outcome: "aligned",
+            positionId: POSITION_ID,
+          }),
+        ),
+      ),
+    ).toContain(FINDING_OUTCOME_CHECK);
 
     await insertOutcome({
       checkKind: "playbook",

--- a/apps/api/src/handlers/document-reviews/schemas.ts
+++ b/apps/api/src/handlers/document-reviews/schemas.ts
@@ -68,3 +68,19 @@ export const compareReferencesBodySchema = t.Object({
     maxItems: DOCUMENT_REVIEW_LIMITS.topicsMax,
   }),
 });
+
+// A run's basis is a playbook, a set of references, or both, so `references`
+// may be empty here where the synchronous comparison endpoint requires one.
+// The handler rejects the empty basis with the reason, rather than the schema
+// rejecting it as a shape error.
+export const createDocumentReviewRunBodySchema = t.Object({
+  target: documentReviewRefSchema,
+  playbookId: t.Optional(tSafeId("playbookDefinition")),
+  references: t.Array(documentReviewRefSchema, {
+    maxItems: DOCUMENT_REVIEW_LIMITS.referencesMax,
+  }),
+  topics: t.Array(documentReviewTopicSchema, {
+    minItems: 1,
+    maxItems: DOCUMENT_REVIEW_LIMITS.topicsMax,
+  }),
+});

--- a/apps/api/src/lib/audit-log.ts
+++ b/apps/api/src/lib/audit-log.ts
@@ -49,6 +49,7 @@ export const AUDIT_RESOURCE_TYPE = {
   USAGE_ENTITLEMENT: "usage_entitlement",
   USAGE_EVENT: "usage_event",
   DESKTOP_EDIT_SESSION: "desktop_edit_session",
+  DOCUMENT_REVIEW_RUN: "document_review_run",
   ENTITY: "entity",
   ENTITY_VERSION: "entity_version",
   EXPENSE: "expense",

--- a/apps/api/src/lib/audit-log.ts
+++ b/apps/api/src/lib/audit-log.ts
@@ -270,6 +270,7 @@ const activityCategoryForEvent = (event: AuditEvent): AuditActivityCategory => {
       return "team";
     case "case_law_matter_link":
       return "court";
+    case "document_review_run":
     case "flow_run":
       return "automation";
     case "playbook":

--- a/apps/api/src/lib/branded-types.ts
+++ b/apps/api/src/lib/branded-types.ts
@@ -56,6 +56,8 @@ export type SafeIdType =
   | "documentCounter"
   | "entityDeletionCleanupRequest"
   | "documentProcessingRun"
+  | "documentReviewFinding"
+  | "documentReviewRun"
   | "documentType"
   | "entity"
   | "entityVersionAiSummary"

--- a/apps/api/src/lib/document-review/contract.ts
+++ b/apps/api/src/lib/document-review/contract.ts
@@ -15,3 +15,26 @@ export type DocumentReviewTopic =
   | (ReviewTopicBase & { type: "playbook"; positionId: string })
   | (ReviewTopicBase & { type: "reference" })
   | (ReviewTopicBase & { type: "custom" });
+
+// Reference-comparison outcome vocabulary. It lives here rather than in
+// `reference-compare.ts` so the persisted-run schema can derive its CHECK
+// constraint from the same const the model's output schema is built from,
+// without the database module importing the AI stack.
+export const REFERENCE_ASSESSMENTS = [
+  "aligned",
+  "different",
+  "missing-from-target",
+  "additional-in-target",
+  "deal-specific",
+  "not-comparable",
+] as const;
+export type ReferenceAssessment = (typeof REFERENCE_ASSESSMENTS)[number];
+
+// How consistently the references agreed about a topic. `single` is the
+// degenerate one-reference case, normalized after the model answers.
+export const REFERENCE_CONSENSUS_VALUES = [
+  "single",
+  "consistent",
+  "mixed",
+] as const;
+export type ReferenceConsensus = (typeof REFERENCE_CONSENSUS_VALUES)[number];

--- a/apps/api/src/lib/document-review/reference-compare.ts
+++ b/apps/api/src/lib/document-review/reference-compare.ts
@@ -8,7 +8,15 @@ import {
   type AIUsageMetering,
 } from "@/api/lib/analytics/tanstack-ai";
 import type { SafeId } from "@/api/lib/branded-types";
-import type { DocumentReviewTopic } from "@/api/lib/document-review/contract";
+import {
+  REFERENCE_ASSESSMENTS,
+  REFERENCE_CONSENSUS_VALUES,
+} from "@/api/lib/document-review/contract";
+import type {
+  DocumentReviewTopic,
+  ReferenceAssessment,
+  ReferenceConsensus,
+} from "@/api/lib/document-review/contract";
 import { WorkflowIntegrationError } from "@/api/lib/errors/tagged-errors";
 import {
   buildGroundedReviewFix,
@@ -22,17 +30,6 @@ const REFERENCE_REVIEW_TIMEOUT_MS = 120_000;
 const REFERENCE_REVIEW_ROLE = "pdf" as const;
 const MAX_VERIFIED_CITATIONS_PER_FINDING = 8;
 
-const assessmentValues = [
-  "aligned",
-  "different",
-  "missing-from-target",
-  "additional-in-target",
-  "deal-specific",
-  "not-comparable",
-] as const;
-
-const consensusValues = ["single", "consistent", "mixed"] as const;
-
 const rawCitationSchema = v.strictObject({
   sourceKey: v.string(),
   blockId: v.string(),
@@ -40,8 +37,8 @@ const rawCitationSchema = v.strictObject({
 
 const rawFindingSchema = v.strictObject({
   topicId: v.string(),
-  assessment: v.picklist(assessmentValues),
-  consensus: v.picklist(consensusValues),
+  assessment: v.picklist(REFERENCE_ASSESSMENTS),
+  consensus: v.picklist(REFERENCE_CONSENSUS_VALUES),
   rationale: v.string(),
   // Model-owned arrays are normalized below. A provider may ignore JSON Schema
   // cardinality constraints; rejecting the whole run would discard valid output.
@@ -56,8 +53,10 @@ export const referenceReviewSchema = v.strictObject({
 
 type RawReferenceFinding = v.InferOutput<typeof rawFindingSchema>;
 
-export type ReferenceAssessment = (typeof assessmentValues)[number];
-export type ReferenceConsensus = (typeof consensusValues)[number];
+// Re-exported from the plain contract module so existing importers keep the
+// `reference-compare` path while the persisted-run schema derives its CHECK
+// constraint from the same source.
+export type { ReferenceAssessment, ReferenceConsensus };
 
 export type ReferenceCitation = {
   blockId: string;

--- a/apps/api/src/lib/document-review/run-contract.ts
+++ b/apps/api/src/lib/document-review/run-contract.ts
@@ -1,0 +1,173 @@
+// Durable document-review run vocabulary and pinned-basis shapes.
+//
+// This module is deliberately dependency-light: the database schema
+// (`db/schema/document-reviews.ts`) derives its CHECK constraint enums from the
+// consts here, and only the type-level shapes reach in from the AI engine
+// modules (erased at build time). Nothing here imports a handler slice, so the
+// background worker and the endpoints share one definition of what a run is.
+
+import type { SafeId } from "@/api/lib/branded-types";
+import type { ConstantMap } from "@/api/lib/constant-map";
+import { REFERENCE_ASSESSMENTS } from "@/api/lib/document-review/contract";
+import type { ReferenceReviewFinding } from "@/api/lib/document-review/reference-compare";
+import type { ReviewFinding } from "@/api/lib/document-review/review-grade";
+import type { PlaybookPositions } from "@/api/lib/workflow/playbook-positions";
+import { VERDICT_TIERS } from "@/api/lib/workflow/verdict-tiers";
+
+/** Lifecycle of one review execution. `queued` on insert, `running` once the
+ *  worker claims it, then a terminal `completed` / `failed` / `cancelled`. */
+export const DOCUMENT_REVIEW_RUN_STATUSES = [
+  "queued",
+  "running",
+  "completed",
+  "failed",
+  "cancelled",
+] as const;
+export type DocumentReviewRunStatus =
+  (typeof DOCUMENT_REVIEW_RUN_STATUSES)[number];
+
+/** The statuses that still occupy a document: exactly one run may hold them
+ *  per `(entityId, fileFieldId)`, enforced by a partial unique index. */
+export const DOCUMENT_REVIEW_RUN_ACTIVE_STATUSES = [
+  "queued",
+  "running",
+] as const satisfies readonly DocumentReviewRunStatus[];
+
+/** Why a run ended in `failed`. A closed set so the surface can explain the
+ *  failure without parsing a message, and so no free-form model or provider
+ *  text ever lands on the row. */
+export const DOCUMENT_REVIEW_RUN_ERROR_CODES = [
+  /** A pinned document version or file field no longer resolves. */
+  "pin_unresolved",
+  /** The pinned file's content hash no longer matches the pin. */
+  "pin_content_changed",
+  /** A pinned document is not in a format the review engine reads. */
+  "unsupported_format",
+  /** No model is configured or usage is unavailable for this organization. */
+  "ai_unavailable",
+  /** The extraction or grading pass failed. */
+  "playbook_check_failed",
+  /** The reference comparison pass failed. */
+  "reference_check_failed",
+  /** The job could not be handed to the queue. */
+  "enqueue_failed",
+  /** Anything the worker could not attribute more precisely. */
+  "internal",
+] as const;
+export type DocumentReviewRunErrorCode =
+  (typeof DOCUMENT_REVIEW_RUN_ERROR_CODES)[number];
+
+/** Which executor produced a finding. Kept separate from the outcome so the
+ *  two vocabularies are never merged into one. */
+export const DOCUMENT_REVIEW_CHECK_KINDS = ["playbook", "reference"] as const;
+export type DocumentReviewCheckKind =
+  (typeof DOCUMENT_REVIEW_CHECK_KINDS)[number];
+export const DOCUMENT_REVIEW_CHECK_KIND = {
+  PLAYBOOK: "playbook",
+  REFERENCE: "reference",
+} as const satisfies ConstantMap<DocumentReviewCheckKind>;
+
+/** Outcome vocabulary per check kind. Total over the kind union by
+ *  construction, so a new kind cannot land without a decided vocabulary. */
+export const DOCUMENT_REVIEW_OUTCOMES = {
+  playbook: VERDICT_TIERS,
+  reference: REFERENCE_ASSESSMENTS,
+} as const satisfies Record<DocumentReviewCheckKind, readonly string[]>;
+
+/** Whether the pinned playbook came from an approved snapshot or from the
+ *  live (draft) definition an author chose to run. */
+export type PlaybookPinProvenance = "approved" | "draft";
+
+/**
+ * The playbook a run was executed against, embedded whole. The snapshot is
+ * carried even when `versionId` is set so a run stays intelligible after the
+ * definition (and its versions) are deleted; there is deliberately no foreign
+ * key from a run to a playbook.
+ */
+export type PinnedPlaybook = {
+  definitionId: SafeId<"playbookDefinition">;
+  versionId: SafeId<"playbookDefinitionVersion"> | null;
+  provenance: PlaybookPinProvenance;
+  definitionSnapshot: { name: string; positions: PlaybookPositions };
+};
+
+/** One reference document pinned to the exact version that was compared. */
+export type PinnedReference = {
+  entityId: SafeId<"entity">;
+  fileFieldId: SafeId<"field">;
+  entityVersionId: SafeId<"entityVersion">;
+  contentSha256: string;
+  name: string;
+};
+
+/** What the run was measured against, discriminated exactly like the review
+ *  basis the client confirms. */
+export type DocumentReviewRunBasis =
+  | { type: "playbook"; playbook: PinnedPlaybook }
+  | { type: "references"; references: PinnedReference[] }
+  | {
+      type: "combined";
+      playbook: PinnedPlaybook;
+      references: PinnedReference[];
+    };
+
+/** The basis discriminators the run row's CHECK constraint accepts, derived
+ *  from the union so a new basis shape cannot land without the constraint. */
+export const DOCUMENT_REVIEW_BASIS_TYPES = [
+  "playbook",
+  "references",
+  "combined",
+] as const satisfies readonly DocumentReviewRunBasis["type"][];
+
+/** The engine result a finding row carries, reused verbatim per check kind. */
+export type DocumentReviewFindingPayload =
+  | { checkKind: "playbook"; finding: ReviewFinding }
+  | { checkKind: "reference"; finding: ReferenceReviewFinding };
+
+export const basisPlaybook = (
+  basis: DocumentReviewRunBasis,
+): PinnedPlaybook | null => {
+  switch (basis.type) {
+    case "playbook":
+    case "combined":
+      return basis.playbook;
+    case "references":
+      return null;
+    default:
+      return basis satisfies never;
+  }
+};
+
+/** Shared empty result for a basis that pins no references. A fresh literal
+ *  per call would allocate on a hot read path and reads as "not yet known";
+ *  this constant means "this basis has none". */
+const NO_PINNED_REFERENCES: readonly PinnedReference[] = [];
+
+export const basisReferences = (
+  basis: DocumentReviewRunBasis,
+): readonly PinnedReference[] => {
+  switch (basis.type) {
+    case "references":
+    case "combined":
+      return basis.references;
+    case "playbook":
+      return NO_PINNED_REFERENCES;
+    default:
+      return basis satisfies never;
+  }
+};
+
+/** The stored outcome for a finding. `null` only for an extract-only playbook
+ *  position, which yields a value with no verdict. */
+export const findingOutcome = (
+  payload: DocumentReviewFindingPayload,
+): string | null => {
+  switch (payload.checkKind) {
+    case "playbook":
+      return payload.finding.verdict;
+    case "reference":
+      return payload.finding.assessment;
+    default:
+      return payload satisfies never;
+  }
+};

--- a/apps/api/src/lib/document-review/run-plan.test.ts
+++ b/apps/api/src/lib/document-review/run-plan.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, test } from "bun:test";
+
+import { toSafeId } from "@/api/lib/branded-types";
+import type { DocumentReviewTopic } from "@/api/lib/document-review/contract";
+import type {
+  DocumentReviewRunBasis,
+  PinnedPlaybook,
+  PinnedReference,
+} from "@/api/lib/document-review/run-contract";
+import { planReviewRun } from "@/api/lib/document-review/run-plan";
+import type { PlaybookPositions } from "@/api/lib/workflow/playbook-positions";
+
+const GRADEABLE_POSITION_ID = "11111111-1111-4111-8111-111111111111";
+const UNANSWERABLE_POSITION_ID = "22222222-2222-4222-8222-222222222222";
+const DISABLED_POSITION_ID = "33333333-3333-4333-8333-333333333333";
+const GRADEABLE_TOPIC_ID = "44444444-4444-4444-8444-444444444444";
+const UNANSWERABLE_TOPIC_ID = "55555555-5555-4555-8555-555555555555";
+const DISABLED_TOPIC_ID = "66666666-6666-4666-8666-666666666666";
+const REFERENCE_TOPIC_ID = "77777777-7777-4777-8777-777777777777";
+
+const textContent = { version: 1, type: "text" } as const;
+
+const positions: PlaybookPositions = {
+  version: 2,
+  items: [
+    {
+      mode: "extract",
+      sourceId: GRADEABLE_POSITION_ID,
+      issue: "Termination notice",
+      ask: { question: "What is the notice period?", content: textContent },
+      enabled: true,
+    },
+    {
+      // An empty question extracts nothing, so grading never emits a finding
+      // for it; promising one would leave the run permanently incomplete.
+      mode: "extract",
+      sourceId: UNANSWERABLE_POSITION_ID,
+      issue: "Unanswerable",
+      ask: { question: "   ", content: textContent },
+      enabled: true,
+    },
+    {
+      mode: "extract",
+      sourceId: DISABLED_POSITION_ID,
+      issue: "Retired position",
+      ask: { question: "Is this still required?", content: textContent },
+      enabled: false,
+    },
+  ],
+};
+
+const playbook: PinnedPlaybook = {
+  definitionId: toSafeId<"playbookDefinition">(Bun.randomUUIDv7()),
+  versionId: toSafeId<"playbookDefinitionVersion">(Bun.randomUUIDv7()),
+  provenance: "approved",
+  definitionSnapshot: { name: "Approved playbook", positions },
+};
+
+const reference: PinnedReference = {
+  entityId: toSafeId<"entity">(Bun.randomUUIDv7()),
+  fileFieldId: toSafeId<"field">(Bun.randomUUIDv7()),
+  entityVersionId: toSafeId<"entityVersion">(Bun.randomUUIDv7()),
+  contentSha256: "a".repeat(64),
+  name: "Precedent SPA",
+};
+
+const playbookTopic = (
+  topicId: string,
+  positionId: string,
+  included = true,
+): DocumentReviewTopic => ({
+  type: "playbook",
+  topicId,
+  positionId,
+  title: `Topic ${topicId}`,
+  context: "",
+  included,
+});
+
+const referenceTopic = (
+  topicId: string,
+  included = true,
+): DocumentReviewTopic => ({
+  type: "reference",
+  topicId,
+  title: `Topic ${topicId}`,
+  context: "",
+  included,
+});
+
+const allTopics: DocumentReviewTopic[] = [
+  playbookTopic(GRADEABLE_TOPIC_ID, GRADEABLE_POSITION_ID),
+  playbookTopic(UNANSWERABLE_TOPIC_ID, UNANSWERABLE_POSITION_ID),
+  playbookTopic(DISABLED_TOPIC_ID, DISABLED_POSITION_ID),
+  referenceTopic(REFERENCE_TOPIC_ID),
+];
+
+describe("planReviewRun", () => {
+  test("plans one playbook check per confirmed, executable position", () => {
+    const basis: DocumentReviewRunBasis = { type: "playbook", playbook };
+    const plan = planReviewRun({ basis, topics: allTopics });
+
+    expect(plan.playbookChecks.map((check) => check.positionId)).toEqual([
+      GRADEABLE_POSITION_ID,
+    ]);
+    expect(plan.referenceTopics).toEqual([]);
+    expect(plan.expectedFindingCount).toBe(1);
+  });
+
+  test("compares every confirmed topic when the basis pins references", () => {
+    const basis: DocumentReviewRunBasis = {
+      type: "references",
+      references: [reference],
+    };
+    const plan = planReviewRun({ basis, topics: allTopics });
+
+    expect(plan.playbookChecks).toEqual([]);
+    expect(plan.referenceTopics.map((topic) => topic.topicId)).toEqual([
+      GRADEABLE_TOPIC_ID,
+      UNANSWERABLE_TOPIC_ID,
+      DISABLED_TOPIC_ID,
+      REFERENCE_TOPIC_ID,
+    ]);
+    expect(plan.expectedFindingCount).toBe(4);
+  });
+
+  test("a combined basis expects both kinds for the same topics", () => {
+    const basis: DocumentReviewRunBasis = {
+      type: "combined",
+      playbook,
+      references: [reference],
+    };
+    const plan = planReviewRun({ basis, topics: allTopics });
+
+    // One playbook finding for the single executable position plus one
+    // comparison finding per confirmed topic: the exact row count the worker
+    // must observe before it may complete the run.
+    expect(plan.expectedFindingCount).toBe(5);
+  });
+
+  test("an unconfirmed topic is planned for neither kind", () => {
+    const basis: DocumentReviewRunBasis = {
+      type: "combined",
+      playbook,
+      references: [reference],
+    };
+    const plan = planReviewRun({
+      basis,
+      topics: [
+        playbookTopic(GRADEABLE_TOPIC_ID, GRADEABLE_POSITION_ID, false),
+        referenceTopic(REFERENCE_TOPIC_ID),
+      ],
+    });
+
+    expect(plan.playbookChecks).toEqual([]);
+    expect(plan.referenceTopics.map((topic) => topic.topicId)).toEqual([
+      REFERENCE_TOPIC_ID,
+    ]);
+    expect(plan.expectedFindingCount).toBe(1);
+  });
+
+  test("a playbook topic naming an unknown position is not planned", () => {
+    const basis: DocumentReviewRunBasis = { type: "playbook", playbook };
+    const plan = planReviewRun({
+      basis,
+      topics: [
+        playbookTopic(
+          GRADEABLE_TOPIC_ID,
+          "88888888-8888-4888-8888-888888888888",
+        ),
+      ],
+    });
+
+    expect(plan.expectedFindingCount).toBe(0);
+  });
+});

--- a/apps/api/src/lib/document-review/run-plan.ts
+++ b/apps/api/src/lib/document-review/run-plan.ts
@@ -1,0 +1,96 @@
+/**
+ * The executable plan derived from a run's pinned basis and confirmed topics.
+ *
+ * One function owns "what must this run produce": the create endpoint stores
+ * its size as `total`, and the worker completes a run only when exactly that
+ * many finding rows are committed. Deriving both from the same call is what
+ * keeps progress and the completion predicate from drifting apart.
+ *
+ * The plan is a pure function of the run row, so it is recomputable from the
+ * pinned snapshot alone — a replayed job plans identically to the first one.
+ */
+
+import type { DocumentReviewTopic } from "@/api/lib/document-review/contract";
+import {
+  basisPlaybook,
+  basisReferences,
+} from "@/api/lib/document-review/run-contract";
+import type { DocumentReviewRunBasis } from "@/api/lib/document-review/run-contract";
+import type { Position } from "@/api/lib/workflow/playbook-positions";
+import {
+  resolveEffectiveAsk,
+  selectEnabledPositions,
+} from "@/api/lib/workflow/position-runtime";
+
+/** One playbook position to grade, bound to the topic that confirmed it. */
+export type PlannedPlaybookCheck = {
+  topicId: string;
+  topicTitle: string;
+  positionId: string;
+  position: Position;
+};
+
+export type ReviewRunPlan = {
+  playbookChecks: PlannedPlaybookCheck[];
+  referenceTopics: DocumentReviewTopic[];
+  /** The exact number of finding rows a completed run holds. */
+  expectedFindingCount: number;
+};
+
+type PlanReviewRunArgs = {
+  basis: DocumentReviewRunBasis;
+  topics: readonly DocumentReviewTopic[];
+};
+
+/**
+ * A position produces a finding only when it carries an answerable ASK: an
+ * empty question or a file-typed ask column extracts nothing, so the grading
+ * pass skips it. Planning the same exclusion keeps `total` honest instead of
+ * promising a row the engine will never emit.
+ */
+const isGradeable = (position: Position): boolean => {
+  const ask = resolveEffectiveAsk(position);
+  return ask.question.trim().length > 0 && ask.content.type !== "file";
+};
+
+export const planReviewRun = ({
+  basis,
+  topics,
+}: PlanReviewRunArgs): ReviewRunPlan => {
+  const confirmed = topics.filter((topic) => topic.included);
+
+  const playbook = basisPlaybook(basis);
+  const playbookChecks: PlannedPlaybookCheck[] = [];
+  if (playbook !== null) {
+    const positionsBySourceId = new Map(
+      selectEnabledPositions(playbook.definitionSnapshot.positions.items).map(
+        (position) => [position.sourceId, position],
+      ),
+    );
+    for (const topic of confirmed) {
+      if (topic.type !== "playbook") {
+        continue;
+      }
+      const position = positionsBySourceId.get(topic.positionId);
+      if (position === undefined || !isGradeable(position)) {
+        continue;
+      }
+      playbookChecks.push({
+        topicId: topic.topicId,
+        topicTitle: topic.title,
+        positionId: topic.positionId,
+        position,
+      });
+    }
+  }
+
+  // A basis with no pinned references runs no comparison at all.
+  const referenceTopics: DocumentReviewTopic[] =
+    basisReferences(basis).length > 0 ? confirmed : [];
+
+  return {
+    playbookChecks,
+    referenceTopics,
+    expectedFindingCount: playbookChecks.length + referenceTopics.length,
+  };
+};

--- a/apps/api/src/lib/document-review/run-queue.ts
+++ b/apps/api/src/lib/document-review/run-queue.ts
@@ -1,0 +1,857 @@
+/**
+ * Background queue for durable document reviews.
+ *
+ * Reuses the BullMQ infrastructure that already backs the report-export and
+ * file-derivative queues (no new queue system). A review draws several metered
+ * model calls over a whole document and its references, which no synchronous
+ * request survives, so it is a one-shot background job from day one.
+ *
+ * One-shot semantics: `attempts: 1`. A retry would re-run metered model calls;
+ * instead ANY failure lands `status: "failed"` plus a closed-vocabulary
+ * `errorCode` on the run row, which the read endpoint surfaces and the client
+ * may retry deliberately by creating a new run.
+ *
+ * Convergence: the job id is derived from the run id, only a `queued` row is
+ * claimable, and findings upsert on `(runId, topicId, checkKind)`. A
+ * re-delivered job is therefore either a no-op or writes exactly the rows it
+ * wrote before.
+ */
+
+import { Result } from "better-result";
+import { Queue, Worker } from "bullmq";
+import { and, count, eq, inArray, lt, or, sql } from "drizzle-orm";
+
+import { DAY_IN_MS } from "@stll/time";
+
+import { rootDb } from "@/api/db/root";
+import type { SafeDb, ScopedDb } from "@/api/db/safe-db";
+import {
+  documentReviewFindings,
+  documentReviewRuns,
+  fields,
+} from "@/api/db/schema";
+import type { FieldContent } from "@/api/db/schema-validators";
+import type { OrgAIConfig } from "@/api/lib/ai-config";
+import {
+  loadOrgAIConfig,
+  loadPromptCachingPreference,
+} from "@/api/lib/ai-config-loader";
+import { captureError } from "@/api/lib/analytics/capture";
+import type { AIUsageMetering } from "@/api/lib/analytics/tanstack-ai";
+import { createSafeId } from "@/api/lib/branded-types";
+import type { SafeId } from "@/api/lib/branded-types";
+import { createBullMqJobId } from "@/api/lib/bullmq-job-id";
+import type { DocumentReviewTopic } from "@/api/lib/document-review/contract";
+import { compareReferenceDocuments } from "@/api/lib/document-review/reference-compare";
+import { extractAskContents } from "@/api/lib/document-review/review-extract";
+import type { ReviewAsk } from "@/api/lib/document-review/review-extract";
+import { buildFindings } from "@/api/lib/document-review/review-grade";
+import type { ReviewFinding } from "@/api/lib/document-review/review-grade";
+import {
+  basisPlaybook,
+  basisReferences,
+  findingOutcome,
+} from "@/api/lib/document-review/run-contract";
+import type {
+  DocumentReviewFindingPayload,
+  DocumentReviewRunBasis,
+  DocumentReviewRunErrorCode,
+} from "@/api/lib/document-review/run-contract";
+import { planReviewRun } from "@/api/lib/document-review/run-plan";
+import type { ReviewRunPlan } from "@/api/lib/document-review/run-plan";
+import { connectionErrorFields, errorTag } from "@/api/lib/errors/utils";
+import { logger } from "@/api/lib/observability/logger";
+import { createBullMqConnection } from "@/api/lib/redis-client";
+import { createRootSafeDb, createRootScopedDb } from "@/api/lib/root-scoped-db";
+import {
+  brandPersistedDocumentReviewRunId,
+  brandPersistedUserId,
+  brandValidatedWorkflowActorKey,
+} from "@/api/lib/safe-id-boundaries";
+import { fetchAndPrepareFiles } from "@/api/lib/workflow/generate-batch";
+import type { PreparedDocxFile } from "@/api/lib/workflow/generate-batch";
+import type { ResolvedFile } from "@/api/lib/workflow/generate-batch-shared";
+import type { ResolvedTiers } from "@/api/lib/workflow/playbook-positions";
+import { resolveEffectiveAsk } from "@/api/lib/workflow/position-runtime";
+import {
+  loadClauseSnapshots,
+  resolveTiers,
+} from "@/api/lib/workflow/resolve-standards";
+import { DOCX_MIME_TYPE } from "@/api/mime-types";
+
+const QUEUE_NAME = "document-review-runs";
+const JOB_NAME = "run-document-review";
+const WORKER_CONCURRENCY = 2;
+// One attempt: every pass runs metered model calls, so a BullMQ retry would
+// double the spend. Failures are persisted on the row instead.
+const JOB_ATTEMPTS = 1;
+const REVIEW_TIMEOUT_MS = 120_000;
+const SERVICE_TIER = "standard" as const;
+const ORPHAN_RECONCILE_INTERVAL_MS = 5 * 60 * 1000;
+/** A `running` row this old lost its worker to a hard death. */
+const STUCK_RUNNING_MS = 30 * 60 * 1000;
+/** A `queued` row this old lost its job to queue data loss; anything younger
+ *  may simply be backlogged and must be left for the worker. */
+const STUCK_QUEUED_MS = DAY_IN_MS;
+
+type DocumentReviewRunJobData = {
+  runId: string;
+  workspaceId: string;
+  organizationId: string;
+  userId: string;
+};
+
+export type EnqueueDocumentReviewRunArgs = {
+  runId: SafeId<"documentReviewRun">;
+  workspaceId: SafeId<"workspace">;
+  organizationId: SafeId<"organization">;
+  userId: SafeId<"user">;
+};
+
+let queue: Queue<DocumentReviewRunJobData> | null = null;
+let queueConnection: ReturnType<typeof createBullMqConnection> | null = null;
+
+const getQueueConnection = () => {
+  queueConnection ??= createBullMqConnection();
+  return queueConnection;
+};
+
+const getQueue = (): Queue<DocumentReviewRunJobData> => {
+  queue ??= new Queue<DocumentReviewRunJobData>(QUEUE_NAME, {
+    connection: getQueueConnection(),
+    defaultJobOptions: {
+      attempts: JOB_ATTEMPTS,
+      removeOnComplete: 100,
+      removeOnFail: 500,
+    },
+  });
+  return queue;
+};
+
+export const enqueueDocumentReviewRun = async ({
+  runId,
+  workspaceId,
+  organizationId,
+  userId,
+}: EnqueueDocumentReviewRunArgs): Promise<void> => {
+  await getQueue().add(
+    JOB_NAME,
+    { runId, workspaceId, organizationId, userId },
+    // The run id IS the job identity: a duplicate enqueue collapses onto the
+    // job already in flight instead of scheduling a second execution.
+    { jobId: createBullMqJobId(workspaceId, runId) },
+  );
+};
+
+/**
+ * Janitor for runs orphaned by a hard worker death. A job-level failure
+ * self-heals through the worker `failed` handler; a `kill -9` emits no event,
+ * and the claim guard turns BullMQ's stalled re-delivery into a no-op, so the
+ * row would sit `running` forever, and its document would stay blocked by the
+ * one-active-run index. Cross-workspace by necessity, hence the RLS-exempt
+ * root handle, exactly as the report-export reconciler does.
+ *
+ * The two states age at different rates: a `running` row is timed from the
+ * claim that set `started_at`, a `queued` row from its creation, because a
+ * queued job survives a restart and may simply be backlogged.
+ */
+export const reconcileStuckDocumentReviewRuns = async (
+  now: Date = new Date(),
+): Promise<number> => {
+  const runningCutoff = new Date(now.getTime() - STUCK_RUNNING_MS);
+  const queuedCutoff = new Date(now.getTime() - STUCK_QUEUED_MS);
+  // audit: skip — janitor bookkeeping on already-audited run rows; flips
+  // abandoned runs to failed so the read endpoint surfaces them instead of
+  // polling a stuck row forever.
+  const recovered = await rootDb
+    .update(documentReviewRuns)
+    .set({ status: "failed", errorCode: "internal", finishedAt: now })
+    .where(
+      or(
+        and(
+          eq(documentReviewRuns.status, "running"),
+          // oxlint-disable-next-line no-truncated-timestamp-comparison/no-truncated-timestamp-comparison -- cutoff read from the caller's clock, never round-tripped through the database
+          lt(documentReviewRuns.startedAt, runningCutoff),
+        ),
+        and(
+          eq(documentReviewRuns.status, "queued"),
+          // oxlint-disable-next-line no-truncated-timestamp-comparison/no-truncated-timestamp-comparison -- cutoff read from the caller's clock, never round-tripped through the database
+          lt(documentReviewRuns.createdAt, queuedCutoff),
+        ),
+      ),
+    )
+    .returning({ id: documentReviewRuns.id });
+  return recovered.length;
+};
+
+export const initDocumentReviewRunWorker = () => {
+  const workerConnection = createBullMqConnection();
+
+  const worker = new Worker<DocumentReviewRunJobData>(
+    QUEUE_NAME,
+    async (job) => {
+      await processDocumentReviewRunJob(job.data);
+    },
+    { connection: workerConnection, concurrency: WORKER_CONCURRENCY },
+  );
+
+  worker.on("failed", (job, error) => {
+    // The job body already persists failures onto the row; this is the last
+    // resort if the process itself threw before that could run.
+    if (job) {
+      markRunFailed(job.data, "internal").catch((markError: unknown) => {
+        captureError(markError, {
+          runId: job.data.runId,
+          workspaceId: job.data.workspaceId,
+        });
+      });
+    }
+    const runId = job ? job.data.runId : "";
+    const workspaceId = job ? job.data.workspaceId : "";
+    captureError(error, { runId, workspaceId });
+    logger.error("document_review_run.failed", {
+      runId,
+      "error.type": errorTag(error),
+      workspaceId,
+    });
+  });
+
+  worker.on("error", (error) => {
+    logger.error(
+      "document_review_run.worker_error",
+      connectionErrorFields(error),
+    );
+  });
+
+  let closing = false;
+  let activeReconcile: Promise<void> | null = null;
+  const scheduleReconcile = (): void => {
+    if (closing || activeReconcile !== null) {
+      return;
+    }
+    activeReconcile = reconcileStuckDocumentReviewRuns()
+      .then((recovered) => {
+        if (recovered > 0) {
+          logger.warn("document_review_run.recovered_stuck", {
+            count: String(recovered),
+          });
+        }
+      })
+      .catch((error: unknown) => {
+        captureError(error, { operation: "document_review_run.reconcile" });
+      })
+      .finally(() => {
+        activeReconcile = null;
+      });
+  };
+  scheduleReconcile();
+  const reconcileTimer = setInterval(
+    scheduleReconcile,
+    ORPHAN_RECONCILE_INTERVAL_MS,
+  );
+  reconcileTimer.unref();
+
+  logger.info("document_review_run.worker_started", {
+    concurrency: String(WORKER_CONCURRENCY),
+  });
+
+  return {
+    close: async () => {
+      closing = true;
+      clearInterval(reconcileTimer);
+      if (activeReconcile !== null) {
+        await activeReconcile;
+      }
+      await worker.close();
+    },
+  };
+};
+
+type RunActor = {
+  scopedDb: ScopedDb;
+  safeDb: SafeDb;
+  organizationId: SafeId<"organization">;
+  workspaceId: SafeId<"workspace">;
+  userId: SafeId<"user">;
+  runId: SafeId<"documentReviewRun">;
+};
+
+const brandActor = (data: DocumentReviewRunJobData): RunActor => {
+  const branded = brandValidatedWorkflowActorKey({
+    organizationId: data.organizationId,
+    workspaceId: data.workspaceId,
+  });
+  const userId = brandPersistedUserId(data.userId);
+  const tenant = {
+    organizationId: branded.organizationId,
+    userId,
+    workspaceIds: [branded.workspaceId],
+  };
+  return {
+    organizationId: branded.organizationId,
+    workspaceId: branded.workspaceId,
+    userId,
+    runId: brandPersistedDocumentReviewRunId(data.runId),
+    scopedDb: createRootScopedDb(tenant),
+    safeDb: createRootSafeDb(tenant),
+  };
+};
+
+/** The run fields the worker executes from, read at claim time. */
+type ClaimedRun = {
+  basis: DocumentReviewRunBasis;
+  topics: DocumentReviewTopic[];
+  entityId: SafeId<"entity">;
+  fileFieldId: SafeId<"field">;
+  entityVersionId: SafeId<"entityVersion">;
+  contentSha256: string;
+};
+
+/**
+ * Conditional `queued -> running` claim. The status predicate lives inside the
+ * UPDATE, so two deliveries of the same job cannot both proceed: the loser
+ * updates zero rows and returns nothing.
+ */
+const claimRun = async (actor: RunActor): Promise<ClaimedRun | null> => {
+  const claimed = await actor.scopedDb(async (tx) => {
+    // audit: skip — lifecycle bookkeeping on the run row audited at create.
+    const rows = await tx
+      .update(documentReviewRuns)
+      .set({ status: "running", startedAt: new Date() })
+      .where(
+        and(
+          eq(documentReviewRuns.id, actor.runId),
+          eq(documentReviewRuns.workspaceId, actor.workspaceId),
+          eq(documentReviewRuns.status, "queued"),
+        ),
+      )
+      .returning({
+        basis: documentReviewRuns.basis,
+        topics: documentReviewRuns.topics,
+        entityId: documentReviewRuns.entityId,
+        fileFieldId: documentReviewRuns.fileFieldId,
+        entityVersionId: documentReviewRuns.entityVersionId,
+        contentSha256: documentReviewRuns.contentSha256,
+      });
+    return rows.at(0);
+  });
+  return claimed === undefined ? null : claimed;
+};
+
+const processDocumentReviewRunJob = async (
+  data: DocumentReviewRunJobData,
+): Promise<void> => {
+  const actor = brandActor(data);
+  const claimed = await claimRun(actor);
+  // A re-delivered job, an already-terminal run, or a deleted row: nothing to
+  // do, and nothing to fail.
+  if (claimed === null) {
+    return;
+  }
+
+  const outcome = await Result.tryPromise({
+    try: async () => await executeRun(actor, claimed),
+    catch: (cause) => cause,
+  });
+  if (Result.isError(outcome)) {
+    captureError(outcome.error, {
+      runId: actor.runId,
+      workspaceId: actor.workspaceId,
+    });
+    await setRunFailed(actor, "internal");
+    return;
+  }
+  if (outcome.value !== null) {
+    await setRunFailed(actor, outcome.value);
+  }
+};
+
+/** A pinned document, as recorded on the run. */
+type PinnedDocument = {
+  fileFieldId: SafeId<"field">;
+  entityVersionId: SafeId<"entityVersion">;
+  contentSha256: string;
+};
+
+type ResolvePinnedFilesResult =
+  | { type: "resolved"; files: ResolvedFile[] }
+  | { type: "failed"; errorCode: DocumentReviewRunErrorCode };
+
+/**
+ * Resolve every pinned document back to the file it named, refusing anything
+ * that has moved. `pdfFileId` is forced to null exactly as the interactive
+ * path does: reference comparison and playbook citations both need folio block
+ * identities, which the PDF preparation path does not carry.
+ */
+const resolvePinnedFiles = async (
+  actor: RunActor,
+  pins: readonly PinnedDocument[],
+): Promise<ResolvePinnedFilesResult> => {
+  const rows = await actor.scopedDb((tx) =>
+    tx
+      .select({
+        id: fields.id,
+        entityVersionId: fields.entityVersionId,
+        content: fields.content,
+      })
+      .from(fields)
+      .where(
+        and(
+          eq(fields.workspaceId, actor.workspaceId),
+          inArray(
+            fields.id,
+            pins.map((pin) => pin.fileFieldId),
+          ),
+          inArray(
+            fields.entityVersionId,
+            pins.map((pin) => pin.entityVersionId),
+          ),
+        ),
+      ),
+  );
+
+  const contentByPin = new Map<string, FieldContent>();
+  for (const row of rows) {
+    contentByPin.set(`${row.id}:${row.entityVersionId}`, row.content);
+  }
+
+  const files: ResolvedFile[] = [];
+  for (const pin of pins) {
+    const content = contentByPin.get(
+      `${pin.fileFieldId}:${pin.entityVersionId}`,
+    );
+    if (content === undefined || content.type !== "file") {
+      return { type: "failed", errorCode: "pin_unresolved" };
+    }
+    if (content.sha256Hex !== pin.contentSha256) {
+      return { type: "failed", errorCode: "pin_content_changed" };
+    }
+    if (content.mimeType !== DOCX_MIME_TYPE) {
+      return { type: "failed", errorCode: "unsupported_format" };
+    }
+    files.push({
+      fileFieldId: pin.fileFieldId,
+      fileId: content.id,
+      mimeType: content.mimeType,
+      sha256Hex: content.sha256Hex,
+      encrypted: content.encrypted,
+      pdfFileId: null,
+    });
+  }
+  return { type: "resolved", files };
+};
+
+/** Everything both passes need from the organization's AI configuration,
+ *  resolved once per run. */
+type PassDeps = {
+  abortSignal: AbortSignal;
+  entityVersionId: SafeId<"entityVersion">;
+  orgAIConfig: OrgAIConfig | null;
+  organizationId: SafeId<"organization">;
+  promptCachingEnabled: boolean;
+  serviceTier: typeof SERVICE_TIER;
+  usageMetering: AIUsageMetering;
+  workspaceId: SafeId<"workspace">;
+};
+
+/**
+ * Execute one claimed run. Returns `null` on success, or the error code the
+ * run failed with — the caller owns the terminal write so the failure path is
+ * identical whether this returned or threw.
+ */
+const executeRun = async (
+  actor: RunActor,
+  run: ClaimedRun,
+): Promise<DocumentReviewRunErrorCode | null> => {
+  const plan = planReviewRun({ basis: run.basis, topics: run.topics });
+
+  const references = basisReferences(run.basis);
+  const pins: PinnedDocument[] = [
+    {
+      fileFieldId: run.fileFieldId,
+      entityVersionId: run.entityVersionId,
+      contentSha256: run.contentSha256,
+    },
+    ...references.map((reference) => ({
+      fileFieldId: reference.fileFieldId,
+      entityVersionId: reference.entityVersionId,
+      contentSha256: reference.contentSha256,
+    })),
+  ];
+
+  const resolved = await resolvePinnedFiles(actor, pins);
+  if (resolved.type === "failed") {
+    return resolved.errorCode;
+  }
+
+  const prepared = await fetchAndPrepareFiles(
+    resolved.files,
+    actor.organizationId,
+    actor.workspaceId,
+  );
+  const preparedTarget = prepared.at(0);
+  if (preparedTarget?.kind !== "docx") {
+    return "unsupported_format";
+  }
+  const preparedReferences: PreparedDocxFile[] = [];
+  for (const file of prepared.slice(1)) {
+    if (file.kind !== "docx") {
+      return "unsupported_format";
+    }
+    preparedReferences.push(file);
+  }
+
+  const config = await Result.tryPromise({
+    try: async () => ({
+      orgAIConfig: await loadOrgAIConfig(actor.organizationId),
+      promptCachingEnabled: await loadPromptCachingPreference(
+        actor.organizationId,
+      ),
+    }),
+    catch: (cause) => cause,
+  });
+  if (Result.isError(config)) {
+    captureError(config.error, {
+      runId: actor.runId,
+      workspaceId: actor.workspaceId,
+    });
+    return "ai_unavailable";
+  }
+
+  const deps: PassDeps = {
+    abortSignal: AbortSignal.timeout(REVIEW_TIMEOUT_MS),
+    entityVersionId: run.entityVersionId,
+    orgAIConfig: config.value.orgAIConfig,
+    organizationId: actor.organizationId,
+    promptCachingEnabled: config.value.promptCachingEnabled,
+    serviceTier: SERVICE_TIER,
+    usageMetering: {
+      actionType: "chat",
+      organizationId: actor.organizationId,
+      safeDb: actor.safeDb,
+      serviceTier: SERVICE_TIER,
+      userId: actor.userId,
+      workspaceId: actor.workspaceId,
+    },
+    workspaceId: actor.workspaceId,
+  };
+
+  // Both passes are independent reads over the same prepared blocks, so they
+  // run concurrently exactly as the interactive client dispatched them.
+  const [playbookOutcome, referenceOutcome] = await Promise.all([
+    runPlaybookPass({
+      actor,
+      deps,
+      plan,
+      run,
+      targetFile: resolved.files.slice(0, 1),
+    }),
+    runReferencePass({
+      actor,
+      deps,
+      plan,
+      run,
+      references: preparedReferences,
+      target: preparedTarget,
+    }),
+  ]);
+  if (playbookOutcome !== null) {
+    return playbookOutcome;
+  }
+  if (referenceOutcome !== null) {
+    return referenceOutcome;
+  }
+
+  return await finalizeRun(actor, plan);
+};
+
+const runPlaybookPass = async ({
+  actor,
+  deps,
+  plan,
+  run,
+  targetFile,
+}: {
+  actor: RunActor;
+  deps: PassDeps;
+  plan: ReviewRunPlan;
+  run: ClaimedRun;
+  targetFile: ResolvedFile[];
+}): Promise<DocumentReviewRunErrorCode | null> => {
+  if (basisPlaybook(run.basis) === null || plan.playbookChecks.length === 0) {
+    return null;
+  }
+
+  const positions = plan.playbookChecks.map((check) => check.position);
+  const clauseSnapshots = await actor.scopedDb((tx) =>
+    loadClauseSnapshots(tx, actor.organizationId, positions),
+  );
+  const tiersBySourceId = new Map<string, ResolvedTiers>();
+  const asks: ReviewAsk[] = [];
+  for (const position of positions) {
+    if (position.mode === "graded") {
+      tiersBySourceId.set(
+        position.sourceId,
+        resolveTiers(position, clauseSnapshots),
+      );
+    }
+    const ask = resolveEffectiveAsk(position);
+    const content = ask.content;
+    // `planReviewRun` already excluded file-typed and empty asks; this narrows
+    // the content union for the extractor rather than re-deciding eligibility.
+    if (content.type === "file") {
+      continue;
+    }
+    asks.push({
+      sourceId: position.sourceId,
+      question: ask.question.trim(),
+      content,
+    });
+  }
+
+  const extraction = await extractAskContents({
+    asks,
+    resolvedFiles: targetFile,
+    ...deps,
+  });
+  if (Result.isError(extraction)) {
+    return "playbook_check_failed";
+  }
+
+  const graded: ReviewFinding[] = await buildFindings({
+    positions,
+    contentBySourceId: extraction.value.contentBySourceId,
+    tiersBySourceId,
+    ...deps,
+  });
+
+  const checkByPositionId = new Map(
+    plan.playbookChecks.map((check) => [check.positionId, check]),
+  );
+  const rows: FindingRow[] = [];
+  for (const finding of graded) {
+    const check = checkByPositionId.get(finding.positionId);
+    if (check === undefined) {
+      continue;
+    }
+    rows.push(
+      buildFindingRow({
+        actor,
+        run,
+        topicId: check.topicId,
+        topicTitle: check.topicTitle,
+        positionId: check.positionId,
+        payload: { checkKind: "playbook", finding },
+      }),
+    );
+  }
+  await upsertFindings(actor, rows);
+  return null;
+};
+
+const runReferencePass = async ({
+  actor,
+  deps,
+  plan,
+  run,
+  references,
+  target,
+}: {
+  actor: RunActor;
+  deps: PassDeps;
+  plan: ReviewRunPlan;
+  run: ClaimedRun;
+  references: PreparedDocxFile[];
+  target: PreparedDocxFile;
+}): Promise<DocumentReviewRunErrorCode | null> => {
+  if (plan.referenceTopics.length === 0 || references.length === 0) {
+    return null;
+  }
+
+  const comparison = await compareReferenceDocuments({
+    abortSignal: deps.abortSignal,
+    orgAIConfig: deps.orgAIConfig,
+    organizationId: deps.organizationId,
+    promptCachingEnabled: deps.promptCachingEnabled,
+    references,
+    referenceEntityVersionIds: basisReferences(run.basis).map(
+      (reference) => reference.entityVersionId,
+    ),
+    serviceTier: deps.serviceTier,
+    target,
+    targetEntityVersionId: run.entityVersionId,
+    topics: plan.referenceTopics,
+    usageMetering: deps.usageMetering,
+    workspaceId: deps.workspaceId,
+  });
+  if (Result.isError(comparison)) {
+    return "reference_check_failed";
+  }
+
+  const titleByTopicId = new Map(
+    plan.referenceTopics.map((topic) => [topic.topicId, topic.title]),
+  );
+  const rows: FindingRow[] = [];
+  for (const finding of comparison.value) {
+    const topicTitle = titleByTopicId.get(finding.topicId);
+    if (topicTitle === undefined) {
+      continue;
+    }
+    rows.push(
+      buildFindingRow({
+        actor,
+        run,
+        topicId: finding.topicId,
+        topicTitle,
+        positionId: null,
+        payload: { checkKind: "reference", finding },
+      }),
+    );
+  }
+  await upsertFindings(actor, rows);
+  return null;
+};
+
+type FindingRow = typeof documentReviewFindings.$inferInsert;
+
+const buildFindingRow = ({
+  actor,
+  run,
+  topicId,
+  topicTitle,
+  positionId,
+  payload,
+}: {
+  actor: RunActor;
+  run: ClaimedRun;
+  topicId: string;
+  topicTitle: string;
+  positionId: string | null;
+  payload: DocumentReviewFindingPayload;
+}): FindingRow => ({
+  id: createSafeId<"documentReviewFinding">(),
+  organizationId: actor.organizationId,
+  workspaceId: actor.workspaceId,
+  runId: actor.runId,
+  entityId: run.entityId,
+  fileFieldId: run.fileFieldId,
+  entityVersionId: run.entityVersionId,
+  topicId,
+  topicTitle,
+  checkKind: payload.checkKind,
+  positionId,
+  outcome: findingOutcome(payload),
+  payload,
+});
+
+/**
+ * Commit one pass's findings on the `(runId, topicId, checkKind)` key. A
+ * replayed job overwrites the row it wrote before rather than adding a second
+ * judgment for the same topic, so duplicate delivery converges instead of
+ * doubling the review.
+ */
+const upsertFindings = async (
+  actor: RunActor,
+  rows: readonly FindingRow[],
+): Promise<void> => {
+  if (rows.length === 0) {
+    return;
+  }
+  await actor.scopedDb(async (tx) => {
+    // audit: skip — review output attached to the run row audited at create.
+    await tx
+      .insert(documentReviewFindings)
+      .values([...rows])
+      .onConflictDoUpdate({
+        target: [
+          documentReviewFindings.runId,
+          documentReviewFindings.topicId,
+          documentReviewFindings.checkKind,
+        ],
+        set: {
+          entityVersionId: sql`excluded.entity_version_id`,
+          topicTitle: sql`excluded.topic_title`,
+          positionId: sql`excluded.position_id`,
+          outcome: sql`excluded.outcome`,
+          payload: sql`excluded.payload`,
+          updatedAt: new Date(),
+        },
+      });
+  });
+};
+
+/**
+ * Complete the run only when the committed finding set is exactly the planned
+ * one. Counting the rows, rather than trusting what the passes returned, makes
+ * the terminal state a fact about the database instead of about this process.
+ */
+const finalizeRun = async (
+  actor: RunActor,
+  plan: ReviewRunPlan,
+): Promise<DocumentReviewRunErrorCode | null> => {
+  const committed = await actor.scopedDb(async (tx) => {
+    const rows = await tx
+      .select({ value: count() })
+      .from(documentReviewFindings)
+      .where(
+        and(
+          eq(documentReviewFindings.runId, actor.runId),
+          eq(documentReviewFindings.workspaceId, actor.workspaceId),
+        ),
+      );
+    const first = rows.at(0);
+    return first === undefined ? 0 : first.value;
+  });
+
+  if (committed !== plan.expectedFindingCount) {
+    return "internal";
+  }
+
+  await actor.scopedDb(async (tx) => {
+    // audit: skip — terminal bookkeeping on the run row audited at create.
+    await tx
+      .update(documentReviewRuns)
+      .set({
+        status: "completed",
+        errorCode: null,
+        completed: committed,
+        finishedAt: new Date(),
+      })
+      .where(
+        and(
+          eq(documentReviewRuns.id, actor.runId),
+          eq(documentReviewRuns.workspaceId, actor.workspaceId),
+          eq(documentReviewRuns.status, "running"),
+        ),
+      );
+  });
+  return null;
+};
+
+const setRunFailed = async (
+  actor: RunActor,
+  errorCode: DocumentReviewRunErrorCode,
+): Promise<void> => {
+  await actor.scopedDb(async (tx) => {
+    // audit: skip — failure bookkeeping on the run row audited at create.
+    await tx
+      .update(documentReviewRuns)
+      .set({ status: "failed", errorCode, finishedAt: new Date() })
+      .where(
+        and(
+          eq(documentReviewRuns.id, actor.runId),
+          eq(documentReviewRuns.workspaceId, actor.workspaceId),
+          inArray(documentReviewRuns.status, ["queued", "running"]),
+        ),
+      );
+  });
+};
+
+/** Last-resort failure marker used from the worker `failed` handler: rebrands
+ *  the actor from raw job data. */
+const markRunFailed = async (
+  data: DocumentReviewRunJobData,
+  errorCode: DocumentReviewRunErrorCode,
+): Promise<void> => {
+  await setRunFailed(brandActor(data), errorCode);
+};

--- a/apps/api/src/lib/document-review/run-queue.ts
+++ b/apps/api/src/lib/document-review/run-queue.ts
@@ -585,7 +585,8 @@ const runPlaybookPass = async ({
 
   const positions = plan.playbookChecks.map((check) => check.position);
   const clauseSnapshots = await actor.scopedDb(
-    async (tx) => await loadClauseSnapshots(tx, actor.organizationId, positions),
+    async (tx) =>
+      await loadClauseSnapshots(tx, actor.organizationId, positions),
   );
   const tiersBySourceId = new Map<string, ResolvedTiers>();
   const asks: ReviewAsk[] = [];

--- a/apps/api/src/lib/document-review/run-queue.ts
+++ b/apps/api/src/lib/document-review/run-queue.ts
@@ -155,27 +155,27 @@ export const enqueueDocumentReviewRun = async ({
  * claim that set `started_at`, a `queued` row from its creation, because a
  * queued job survives a restart and may simply be backlogged.
  */
-export const reconcileStuckDocumentReviewRuns = async (
-  now: Date = new Date(),
-): Promise<number> => {
-  const runningCutoff = new Date(now.getTime() - STUCK_RUNNING_MS);
-  const queuedCutoff = new Date(now.getTime() - STUCK_QUEUED_MS);
+export const reconcileStuckDocumentReviewRuns = async (): Promise<number> => {
+  // Both cutoffs read the clock directly rather than deriving from an injected
+  // `now`: a moving staleness boundary does not care about sub-millisecond
+  // drift, and a literal clock read is what makes these comparisons provably
+  // free of a database round-trip instead of asserting it in a comment.
+  const runningCutoff = new Date(Date.now() - STUCK_RUNNING_MS);
+  const queuedCutoff = new Date(Date.now() - STUCK_QUEUED_MS);
   // audit: skip — janitor bookkeeping on already-audited run rows; flips
   // abandoned runs to failed so the read endpoint surfaces them instead of
   // polling a stuck row forever.
   const recovered = await rootDb
     .update(documentReviewRuns)
-    .set({ status: "failed", errorCode: "internal", finishedAt: now })
+    .set({ status: "failed", errorCode: "internal", finishedAt: new Date() })
     .where(
       or(
         and(
           eq(documentReviewRuns.status, "running"),
-          // oxlint-disable-next-line no-truncated-timestamp-comparison/no-truncated-timestamp-comparison -- cutoff read from the caller's clock, never round-tripped through the database
           lt(documentReviewRuns.startedAt, runningCutoff),
         ),
         and(
           eq(documentReviewRuns.status, "queued"),
-          // oxlint-disable-next-line no-truncated-timestamp-comparison/no-truncated-timestamp-comparison -- cutoff read from the caller's clock, never round-tripped through the database
           lt(documentReviewRuns.createdAt, queuedCutoff),
         ),
       ),
@@ -225,18 +225,19 @@ export const initDocumentReviewRunWorker = () => {
 
   let closing = false;
   let activeReconcile: Promise<void> | null = null;
+  const runReconcile = async (): Promise<void> => {
+    const recovered = await reconcileStuckDocumentReviewRuns();
+    if (recovered > 0) {
+      logger.warn("document_review_run.recovered_stuck", {
+        count: String(recovered),
+      });
+    }
+  };
   const scheduleReconcile = (): void => {
     if (closing || activeReconcile !== null) {
       return;
     }
-    activeReconcile = reconcileStuckDocumentReviewRuns()
-      .then((recovered) => {
-        if (recovered > 0) {
-          logger.warn("document_review_run.recovered_stuck", {
-            count: String(recovered),
-          });
-        }
-      })
+    activeReconcile = runReconcile()
       .catch((error: unknown) => {
         captureError(error, { operation: "document_review_run.reconcile" });
       })
@@ -335,7 +336,7 @@ const claimRun = async (actor: RunActor): Promise<ClaimedRun | null> => {
       });
     return rows.at(0);
   });
-  return claimed === undefined ? null : claimed;
+  return claimed ?? null;
 };
 
 const processDocumentReviewRunJob = async (
@@ -420,7 +421,7 @@ const resolvePinnedFiles = async (
     const content = contentByPin.get(
       `${pin.fileFieldId}:${pin.entityVersionId}`,
     );
-    if (content === undefined || content.type !== "file") {
+    if (content?.type !== "file") {
       return { type: "failed", errorCode: "pin_unresolved" };
     }
     if (content.sha256Hex !== pin.contentSha256) {
@@ -583,8 +584,8 @@ const runPlaybookPass = async ({
   }
 
   const positions = plan.playbookChecks.map((check) => check.position);
-  const clauseSnapshots = await actor.scopedDb((tx) =>
-    loadClauseSnapshots(tx, actor.organizationId, positions),
+  const clauseSnapshots = await actor.scopedDb(
+    async (tx) => await loadClauseSnapshots(tx, actor.organizationId, positions),
   );
   const tiersBySourceId = new Map<string, ResolvedTiers>();
   const asks: ReviewAsk[] = [];

--- a/apps/api/src/lib/resource-identity.ts
+++ b/apps/api/src/lib/resource-identity.ts
@@ -102,6 +102,11 @@ export const RESOURCE_IDENTITY_DISPOSITION = {
   documentCounter: { type: "non_resource", reason: "projection" },
   entityDeletionCleanupRequest: { type: "non_resource", reason: "job" },
   documentProcessingRun: { type: "non_resource", reason: "job" },
+  // A review run is background execution provenance, like `extractionRun` and
+  // `documentProcessingRun`; a finding is only ever addressed through the run
+  // that produced it, so it is that run's subresource rather than a noun.
+  documentReviewFinding: { type: "non_resource", reason: "subresource" },
+  documentReviewRun: { type: "non_resource", reason: "job" },
   documentType: {
     type: "resource",
     resourceType: RESOURCE_TYPE.DOCUMENT_TYPE,

--- a/apps/api/src/lib/safe-id-boundaries.ts
+++ b/apps/api/src/lib/safe-id-boundaries.ts
@@ -56,6 +56,11 @@ export const brandPersistedEntityVersionId = (
 export const brandPersistedDocxSuggestionId = (
   docxSuggestionId: string,
 ): SafeId<"docxSuggestion"> => toSafeId<"docxSuggestion">(docxSuggestionId);
+
+export const brandPersistedDocumentReviewRunId = (
+  runId: string,
+): SafeId<"documentReviewRun"> => toSafeId<"documentReviewRun">(runId);
+
 export const brandPersistedLegalListId = (
   listId: string,
 ): SafeId<"legalList"> => toSafeId<"legalList">(listId);

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -105,6 +105,7 @@ import {
 import { assertMigrationsApplied } from "@/api/lib/db/assert-migrations-applied";
 import { detached } from "@/api/lib/detached";
 import { DEV_INSPECTOR_ORIGINS, frontendOrigins } from "@/api/lib/dev-origins";
+import { initDocumentReviewRunWorker } from "@/api/lib/document-review/run-queue";
 import { initEntityDeletionCleanupWorker } from "@/api/lib/entity-deletion-cleanup-queue";
 import { httpError } from "@/api/lib/errors/http-error";
 import { errorFingerprint, errorTag } from "@/api/lib/errors/utils";
@@ -671,6 +672,9 @@ const startServer = async (): Promise<void> => {
   // BullMQ worker for queued view→report exports.
   const reportExportWorker = initReportExportWorker();
 
+  // BullMQ worker for durable document review runs.
+  const documentReviewRunWorker = initDocumentReviewRunWorker();
+
   api.listen({
     port: getApiPort(),
     // Longer than the load balancer's 60 s idle timeout (Bun defaults to
@@ -724,6 +728,7 @@ const startServer = async (): Promise<void> => {
         entityDeletionCleanupWorker.close(),
         styleSetPackageCleanupWorker.close(),
         reportExportWorker.close(),
+        documentReviewRunWorker.close(),
       ]),
       Bun.sleep(WORKER_SHUTDOWN_TIMEOUT_MS),
     ]);

--- a/docs/capability-coverage.md
+++ b/docs/capability-coverage.md
@@ -498,7 +498,7 @@ mechanics, and similar), not gaps in coverage.
 | chat_thread_ui         | 1     |
 | compound_consent       | 1     |
 | deploy_mechanics       | 1     |
-| document_processing    | 14    |
+| document_processing    | 17    |
 | health_infra           | 1     |
 | hosted_billing         | 3     |
 | mcp_transport          | 11    |
@@ -511,4 +511,4 @@ mechanics, and similar), not gaps in coverage.
 | upload_mechanics       | 9     |
 | url_preview            | 2     |
 
-Total: 119
+Total: 122


### PR DESCRIPTION
Makes a document review a durable, asynchronous, version-pinned record. Design and sequencing in `.agents/plans/053-durable-document-review-runs.md` (included in this PR); this is the API half — the web client still uses the synchronous endpoints and migrates in a follow-up.

## Tables

`document_review_runs`: one immutable execution record per review. Pins the target (`entityId`, `fileFieldId`, `entityVersionId`, content sha256 — plain columns, no FKs, so deleting a document never deletes review history), the confirmed topic list, and the basis as jsonb: the playbook is resolved at creation to its latest approved `playbook_definition_versions` snapshot (`provenance: "approved"`) or to the live definition (`provenance: "draft"`), with the definition snapshot embedded so a run stays intelligible after its playbook is edited or deleted. Status transitions are CHECK-constrained from canonical consts; a partial unique index makes two active runs for the same document structurally impossible (the endpoint also returns a friendly 409).

`document_review_findings`: one row per confirmed topic per check kind, upsert-keyed `(runId, topicId, checkKind)`. Playbook and reference outcomes keep separate CHECK-constrained vocabularies; evidence, citations, extracted values, and grounded-fix proposals live in the payload. Both tables use the org-pinned RLS policy form (`wsOrganizationPolicies`), matching the most recent schema precedent.

## Worker

`lib/document-review/run-queue.ts`, modeled on the report-export queue: BullMQ with the run id as job idempotency key, a single conditional `queued → running` UPDATE as the claim, orphan reconciliation on boot and on an interval, and terminal `failed` states with typed error codes. Execution reuses the existing engine (`extractAskContents`, `buildFindings`, `compareReferenceDocuments`) unchanged, upserts findings, and marks a run completed only when the committed row count equals the expected set derived in `run-plan.ts` — the same derivation the create endpoint stores as `total`, so progress and completion cannot drift.

## Endpoints

- `POST /workspaces/:id/document-reviews/runs` → `{ runId }` (202); pins versions and basis transactionally, then enqueues; 409 while a run is active for the document.
- `GET .../runs/:runId` → run + findings.
- `GET .../runs?entityId&fileFieldId` → cursor-paginated `Page<RunSummary>` history.

Tests cover approved-over-draft playbook pin resolution, the double-run rejection across both active states, findings upsert convergence on replay, expected-set derivation across bases, and the per-kind outcome CHECKs, on RLS-enabled fixtures.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added asynchronous document review runs with queued processing and progress tracking.
  * Reviews now preserve the selected document, references and playbook context for consistent results.
  * Added run history, detailed run views and findings retrieval.
  * Added safeguards for failed or interrupted reviews, with automatic recovery and clear outcomes.
  * Added audit visibility for document review activity.

* **Documentation**
  * Updated capability coverage documentation to reflect the expanded document-processing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->