### PR TITLE
feat(case-law): adopt publisher document identities and correct page origins

### DIFF
--- a/apps/api/src/handlers/case-law/ingestion/adapters/at-courts.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/at-courts.ts
@@ -44,6 +44,13 @@ const RIS_DOCUMENT_HOST_POLICY = {
 /** RIS API enforces a maximum page size of 20. */
 const PAGE_SIZE = 20;
 
+/**
+ * RIS numbers `Seitennummer` from one, which is also what the count probe
+ * below asks for. Stated once, so the crawl's page arithmetic and every direct
+ * request agree about where the collection starts.
+ */
+const FIRST_PAGE = 1;
+
 type RisContentUrl = {
   DataType?: string | null;
   Url?: string | null;
@@ -444,7 +451,7 @@ export const atCourtsAdapter = defineSourceAdapter({
     try {
       const response = await fetchWithTimeout(
         `${API_URL}?${new URLSearchParams({
-          Seitennummer: "1",
+          Seitennummer: String(FIRST_PAGE),
           Seitengroesse: String(PAGE_SIZE),
           Sortierung: "Aenderungsdatum",
           Aufsteigend: "false",
@@ -475,6 +482,7 @@ export const atCourtsAdapter = defineSourceAdapter({
     adapterKey: ADAPTER_KEYS.AT_COURTS,
     pageSize: PAGE_SIZE,
     legacyPageSize: PAGE_SIZE,
+    firstPage: FIRST_PAGE,
 
     buildRequest: (page) => ({
       url: `${API_URL}?${new URLSearchParams({

--- a/apps/api/src/handlers/case-law/ingestion/adapters/cursor-conformance.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/cursor-conformance.test.ts
@@ -169,13 +169,16 @@ const ADAPTER_CONFORMANCE = {
   },
   [ADAPTER_KEYS.SK_COURTS]: {
     disposition: "exercised",
+    // Numbered from one and clamped below it, as the endpoint is: `page=0`
+    // answers the first hundred records, exactly like `page=1`. Modelling it
+    // zero-indexed would hide a walk that re-reads its first page forever.
     exhaustedSource: ({ url }) => {
-      const page = Number(new URL(url).searchParams.get("page"));
+      const page = Math.max(1, Number(new URL(url).searchParams.get("page")));
       const pageSize = 100;
       const archiveEntries = 5100;
       const count = Math.max(
         0,
-        Math.min(pageSize, archiveEntries - page * pageSize),
+        Math.min(pageSize, archiveEntries - (page - 1) * pageSize),
       );
       return jsonResponse({
         rozhodnutieList: Array.from({ length: count }, () => ({})),

--- a/apps/api/src/handlers/case-law/ingestion/adapters/cz-ns-reconciliation.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/cz-ns-reconciliation.test.ts
@@ -12,6 +12,7 @@ import {
 import {
   listingIdentityKey,
   parseListingIdentityKey,
+  SOURCE_DOCUMENT_ID_MAX_LENGTH,
 } from "@/api/handlers/case-law/ingestion/adapter";
 import type { SourceReconciliation } from "@/api/handlers/case-law/ingestion/adapter";
 import {
@@ -252,27 +253,16 @@ describe("cz-ns reconciliation slices", () => {
 // ── Identity ────────────────────────────────────────────────
 
 describe("czNsListingIdentity", () => {
-  test("keys on the docket and the language, never the universal id", () => {
+  test("keys on the universal id, never the docket", () => {
     const identity = czNsListingIdentity({
       unid: UNID.FIRST,
       caseNumber: DOCKET.FIRST,
     });
     expect(identity).toEqual({
-      type: "case-number",
-      caseNumber: DOCKET.FIRST,
-      language: "cs",
+      type: "document",
+      sourceDocumentId: UNID.FIRST,
     });
-    expect(listingIdentityKey(identity)).toBe(`case-number:cs:${DOCKET.FIRST}`);
-  });
-
-  test("keeps the docket exactly as the publisher writes it, suffix included", () => {
-    expect(
-      czNsListingIdentity({ unid: UNID.THIRD, caseNumber: DOCKET.SUFFIXED }),
-    ).toEqual({
-      type: "case-number",
-      caseNumber: DOCKET.SUFFIXED,
-      language: "cs",
-    });
+    expect(listingIdentityKey(identity)).toBe(`document:${UNID.FIRST}`);
   });
 
   test("a row missing either half is unidentifiable, matching what the crawl drops", () => {
@@ -289,16 +279,27 @@ describe("czNsListingIdentity", () => {
     ).toBeNull();
   });
 
+  test("an id the decision column cannot hold keys nothing", () => {
+    // Storing it is impossible, so hunting a row under it would keep the slice
+    // short for a document nothing can ever write.
+    expect(
+      czNsListingIdentity({
+        unid: "F".repeat(SOURCE_DOCUMENT_ID_MAX_LENGTH + 1),
+        caseNumber: DOCKET.FIRST,
+      }),
+    ).toEqual({ type: "unidentifiable" });
+  });
+
   test("every keyable identity round-trips through its key", () => {
-    for (const caseNumber of [DOCKET.FIRST, DOCKET.SECOND, DOCKET.SUFFIXED]) {
-      const identity = czNsListingIdentity({ unid: UNID.FIRST, caseNumber });
+    for (const unid of [UNID.FIRST, UNID.SECOND, UNID.THIRD]) {
+      const identity = czNsListingIdentity({ unid, caseNumber: DOCKET.FIRST });
       const key = listingIdentityKey(identity);
       expect(key).not.toBeNull();
       expect(parseListingIdentityKey(key ?? "")).toEqual(identity);
     }
   });
 
-  test("two documents under one docket collapse to one key, as the store does", () => {
+  test("two documents under one docket are two keys, as the store now is", () => {
     const first = czNsListingIdentity({
       unid: UNID.FIRST,
       caseNumber: DOCKET.FIRST,
@@ -307,7 +308,7 @@ describe("czNsListingIdentity", () => {
       unid: UNID.SECOND,
       caseNumber: DOCKET.FIRST,
     });
-    expect(listingIdentityKey(first)).toBe(listingIdentityKey(second));
+    expect(listingIdentityKey(first)).not.toBe(listingIdentityKey(second));
   });
 });
 
@@ -335,8 +336,8 @@ describe("cz-ns listSlicePage", () => {
       { unid: UNID.SECOND, caseNumber: DOCKET.SECOND },
     ]);
     expect(listed.items.map(({ identity }) => identity)).toEqual([
-      { type: "case-number", caseNumber: DOCKET.FIRST, language: "cs" },
-      { type: "case-number", caseNumber: DOCKET.SECOND, language: "cs" },
+      { type: "document", sourceDocumentId: UNID.FIRST },
+      { type: "document", sourceDocumentId: UNID.SECOND },
     ]);
 
     const url = requestedUrls.at(0) ?? "";
@@ -524,16 +525,34 @@ describe("cz-ns buildDecision", () => {
     if (built.type !== "built") {
       return;
     }
-    // The adapter writes no document id, so the row is keyed on the docket —
-    // which is what the listing identity has to say too.
-    expect(built.decision.sourceDocumentId).toBeUndefined();
+    // Silent drift here is the whole failure mode: a walk that keys a row one
+    // way and a build that stores it another leaves the slice permanently
+    // short and re-fetches the same document forever.
+    expect(built.decision.sourceDocumentId).toBe(UNID.FIRST);
     expect(
       listingIdentityKey({
-        type: "case-number",
-        caseNumber: built.decision.caseNumber,
-        language: built.decision.language,
+        type: "document",
+        sourceDocumentId: built.decision.sourceDocumentId ?? "",
       }),
     ).toBe(listingIdentityKey(czNsListingIdentity(row)));
+  });
+
+  test("the built decision carries the URL its docket-keyed row was stored under", async () => {
+    mockFetch({ printStatus: 404 });
+
+    const built = await reconciliation.buildDecision({
+      unid: UNID.FIRST,
+      caseNumber: DOCKET.FIRST,
+    });
+    expect(built.type).toBe("built");
+    if (built.type !== "built") {
+      return;
+    }
+    // The hint the pipeline re-keys an existing null-id row by: it must be the
+    // URL that row carries, which is the one this build stores as `sourceUrl`.
+    expect(built.decision.legacySourceUrls).toEqual([
+      built.decision.sourceUrl ?? "",
+    ]);
   });
 
   test("a detail page that does not come back is reported, never written", async () => {

--- a/apps/api/src/handlers/case-law/ingestion/adapters/cz-ns.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/cz-ns.ts
@@ -9,6 +9,7 @@ import type { DocumentAst } from "@/api/handlers/case-law/document-ast";
 import {
   defineSourceAdapter,
   EMPTY_AST,
+  isPersistableSourceDocumentId,
 } from "@/api/handlers/case-law/ingestion/adapter";
 import type {
   EmptyAst,
@@ -56,7 +57,7 @@ const COMMON_HEADERS = {
 const BASE_URL = "https://rozhodnuti.nsoud.cz/Judikatura/judikatura_ns.nsf";
 const PAGE_SIZE = 40;
 
-/** The only language this court publishes; half of every identity it keys. */
+/** The only language this court publishes. */
 const CZ_NS_LANGUAGE = "cs";
 
 /** Domino ReadViewEntries JSON shape. */
@@ -262,6 +263,25 @@ export type CzNsListingRow = {
 };
 
 /**
+ * The two fields a row must state for this adapter to keep it: the docket it
+ * is stored under and the universal id its document is keyed on.
+ *
+ * Stated once, because the crawl, the identity rule and the listing walk must
+ * agree exactly on which rows exist — a row one of them keeps and another
+ * drops is either a decision nothing ever stores or a slice that can never be
+ * filled. The id is bounded here rather than at the pipeline, since it is the
+ * stored identity: one the column cannot hold would key a row nothing can
+ * write.
+ */
+const czNsIdentityFields = ({
+  caseNumber,
+  unid,
+}: CzNsListingRow): CzNsListingRow | null =>
+  caseNumber.length === 0 || !isPersistableSourceDocumentId(unid)
+    ? null
+    : { caseNumber, unid };
+
+/**
  * What building one listed decision produced. `detail-unavailable` carries
  * the status the publisher answered with so the crawl can log it; the
  * reconciliation drops it, having only the three outcomes its contract names.
@@ -287,12 +307,14 @@ type CzNsBuildResult =
  * metadata the detail page states, and is stored with an empty AST.
  */
 export const buildCzNsDecision = async (
-  { caseNumber, unid }: CzNsListingRow,
+  row: CzNsListingRow,
   signal?: AbortSignal,
 ): Promise<CzNsBuildResult> => {
-  if (unid.length === 0 || caseNumber.length === 0) {
+  const fields = czNsIdentityFields(row);
+  if (fields === null) {
     return { type: "unkeyable" };
   }
+  const { caseNumber, unid } = fields;
 
   const webUrl = `${BASE_URL}/WebSearch/${unid}?openDocument`;
   const printUrl = `${BASE_URL}/WebPrint/${unid}?openDocument`;
@@ -349,6 +371,15 @@ export const buildCzNsDecision = async (
     type: "built",
     decision: {
       caseNumber,
+      sourceDocumentId: unid,
+      // What every row this adapter wrote before it stated an id was stored
+      // under: one row per docket, carrying the document URL of whichever of
+      // the docket's decisions was written last. The URL names one document
+      // exactly, so it re-keys that row to the document it was built from
+      // rather than inserting a second one beside it; the docket's further
+      // decisions find no null-id row and are inserted, which is the collapse
+      // being undone.
+      legacySourceUrls: [webUrl],
       ecli: meta["ecli"],
       court: "Nejvyšší soud",
       country: "CZE",
@@ -532,32 +563,30 @@ const parseListingRows = (html: string): CzNsListingRow[] =>
 /**
  * The identity the ingest would store for a listed row.
  *
- * The docket and the language, never the universal id the row also carries:
- * this adapter sets no `sourceDocumentId`, so every row it has ever written
- * is keyed on `(caseNumber, language)` against a null document id. Keying the
- * listing on the id would match no held row at all and read the whole archive
- * as missing.
+ * The Domino universal id, which is stable and unique per document and is
+ * what {@link buildCzNsDecision} now stores as `sourceDocumentId`. The docket
+ * is not: the court publishes a docket's further decisions under the same
+ * `znacka`, sometimes distinguished only by a suffix it writes into the number
+ * itself ("21 Cdo 288/2026- III.") and often not at all, so a
+ * `(caseNumber, language)` key names a docket rather than a document and
+ * collapses those rows into one.
  *
- * That key is coarser than the source is. The court publishes a docket's
- * further decisions under the same `znacka`, sometimes distinguished only by
- * a suffix it writes into the docket itself ("21 Cdo 288/2026- III."), and
- * where it does not, the crawl already collapses them into one row. The walk
- * inherits exactly that: two such rows in one slice are one identity, counted
- * once. Giving them separate identities is an identity migration of the
- * stored rows, not something a reconciliation pass may decide on its own —
- * until those rows carry the universal id, this is what "held" means.
+ * Rows written before the adapter stated an id are re-keyed by the
+ * deterministic `WebSearch/{unid}` URL they carry — see `legacySourceUrls` in
+ * the build. The two must state one rule: a walk that keyed rows differently
+ * from the ingest would read stored decisions as missing and re-fetch them
+ * forever.
  *
  * A row missing either half is unidentifiable rather than keyed on what is
  * left: the crawl drops such an entry, so a slice that counted it would stay
  * short forever.
  */
-export const czNsListingIdentity = ({
-  caseNumber,
-  unid,
-}: CzNsListingRow): ListingIdentity =>
-  unid.length === 0 || caseNumber.length === 0
+export const czNsListingIdentity = (row: CzNsListingRow): ListingIdentity => {
+  const fields = czNsIdentityFields(row);
+  return fields === null
     ? { type: "unidentifiable" }
-    : { type: "case-number", caseNumber, language: CZ_NS_LANGUAGE };
+    : { type: "document", sourceDocumentId: fields.unid };
+};
 
 /**
  * One publication day, in one request.

--- a/apps/api/src/handlers/case-law/ingestion/adapters/cz-nss.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/cz-nss.test.ts
@@ -27,7 +27,10 @@ import {
 } from "@/api/handlers/case-law/ingestion/adapters/cz-nss";
 import type { ParsedRow } from "@/api/handlers/case-law/ingestion/adapters/cz-nss";
 import { tipWindowSlices } from "@/api/handlers/case-law/ingestion/reconciliation-plan";
-import { listingIdentityKey } from "@/api/lib/legal-search/ingestion-types";
+import {
+  listingIdentityKey,
+  SOURCE_DOCUMENT_ID_MAX_LENGTH,
+} from "@/api/lib/legal-search/ingestion-types";
 import { asFetchMock } from "@/api/tests/helpers/test-tool-set";
 
 const { reconciliation } = czNssAdapter;
@@ -382,43 +385,62 @@ describe("cz-nss listing rows", () => {
     );
   });
 
-  test("keys a row on its docket and this source's language", () => {
+  test("keys a row on the portal's own document id", () => {
     const row = parseResultRows(rowBlock(MUNICIPAL_ROW)).at(0);
     expect(row).toBeDefined();
     if (row === undefined) {
       return;
     }
     expect(czNssListingIdentity(row)).toEqual({
-      type: "case-number",
-      caseNumber: "1 Az 4/2026",
-      language: "cs",
+      type: "document",
+      sourceDocumentId: "784237",
     });
     expect(listingIdentityKey(czNssListingIdentity(row))).toBe(
-      "case-number:cs:1 Az 4/2026",
+      "document:784237",
     );
   });
 
-  test("keys on the docket even where the portal states a document id", () => {
-    // The store holds no `sourceDocumentId` for this source, so a document
-    // identity would match no held row and read the archive as missing.
-    const row = parseResultRows(rowBlock(REGIONAL_ROW)).at(0);
-    expect(row?.documentId).toBe("783863");
-    expect(row === undefined ? null : czNssListingIdentity(row).type).toBe(
-      "case-number",
+  test("two courts' decisions under one docket are two keys", () => {
+    // The portal carries the regional and city administrative courts
+    // alongside the NSS, and their dockets are numbered per court; keyed on
+    // the docket, two unrelated decisions were one row.
+    const municipal = parseResultRows(rowBlock(MUNICIPAL_ROW)).at(0);
+    const regional = parseResultRows(
+      rowBlock({
+        ...REGIONAL_ROW,
+        citedCaseNumber: MUNICIPAL_ROW.citedCaseNumber,
+      }),
+    ).at(0);
+    expect(municipal).toBeDefined();
+    expect(regional).toBeDefined();
+    if (municipal === undefined || regional === undefined) {
+      return;
+    }
+    expect(regional.caseNumber).toBe(municipal.caseNumber);
+    expect(listingIdentityKey(czNssListingIdentity(regional))).not.toBe(
+      listingIdentityKey(czNssListingIdentity(municipal)),
     );
   });
 
-  test("a row with no docket has nothing to key on", () => {
+  test("a row the portal lists without a document link has nothing to key on", () => {
     const row: ParsedRow = {
-      caseNumber: "",
+      caseNumber: "1 Az 4/2026",
       decisionDate: undefined,
       decisionType: undefined,
       outcome: undefined,
       documentUrl: undefined,
-      documentId: "784237",
+      documentId: undefined,
     };
+    // Nothing can be read for it, now or later, so counting it as missing
+    // would keep its slice short forever.
     expect(czNssListingIdentity(row)).toEqual({ type: "unidentifiable" });
     expect(listingIdentityKey(czNssListingIdentity(row))).toBeNull();
+    expect(
+      czNssListingIdentity({
+        ...row,
+        documentId: "9".repeat(SOURCE_DOCUMENT_ID_MAX_LENGTH + 1),
+      }),
+    ).toEqual({ type: "unidentifiable" });
   });
 });
 
@@ -453,8 +475,8 @@ describe("cz-nss listSlicePage", () => {
     expect(search?.body).toContain("HodnotaDatumACasOd=10.06.2026");
     expect(listed.totalPages).toBe(1);
     expect(listed.items.map(({ identity }) => identity)).toEqual([
-      { type: "case-number", caseNumber: "1 Az 4/2026", language: "cs" },
-      { type: "case-number", caseNumber: "52 Af 4/2026", language: "cs" },
+      { type: "document", sourceDocumentId: MUNICIPAL_ROW.documentId },
+      { type: "document", sourceDocumentId: REGIONAL_ROW.documentId },
     ]);
   });
 
@@ -611,7 +633,7 @@ describe("cz-nss listSlicePage", () => {
     expect(body.get("pageNum")).toBe("1");
     expect(body.get("resultOrder")).toBe(CURR_SORT);
     expect(listed.items.map(({ identity }) => identity)).toEqual([
-      { type: "case-number", caseNumber: "52 Af 4/2026", language: "cs" },
+      { type: "document", sourceDocumentId: REGIONAL_ROW.documentId },
     ]);
   });
 
@@ -735,8 +757,25 @@ describe("cz-nss buildDecision", () => {
     expect(built.decision.language).toBe("cs");
     expect(built.decision.court).toBe("Nejvyšší správní soud");
     expect(built.decision.ecli).toBe("ECLI:CZ:NSS:2026:1.Az.4.2026.79");
-    expect(built.decision.sourceDocumentId).toBeUndefined();
     expect(built.decision.fulltext ?? "").not.toBe("");
+    // Silent drift here is the whole failure mode: a walk that keys a row one
+    // way and a build that stores it another leaves the slice permanently
+    // short and re-fetches the same document forever.
+    expect(built.decision.sourceDocumentId).toBe(MUNICIPAL_ROW.documentId);
+    expect(
+      listingIdentityKey({
+        type: "document",
+        sourceDocumentId: built.decision.sourceDocumentId ?? "",
+      }),
+    ).toBe(`document:${MUNICIPAL_ROW.documentId}`);
+    // The hint the pipeline re-keys an existing null-id row by: it must be the
+    // URL that row carries, which is the one this build stores as `sourceUrl`.
+    expect(built.decision.legacySourceUrls).toEqual([
+      built.decision.sourceUrl ?? "",
+    ]);
+    expect(built.decision.sourceUrl).toBe(
+      `${BASE_URL}/DokumentDetail/Index/${MUNICIPAL_ROW.documentId}`,
+    );
   });
 
   test("refuses to write a row whose document the court did not serve", async () => {

--- a/apps/api/src/handlers/case-law/ingestion/adapters/cz-nss.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/cz-nss.ts
@@ -9,6 +9,7 @@ import type { DocumentAst } from "@/api/handlers/case-law/document-ast";
 import {
   defineSourceAdapter,
   EMPTY_AST,
+  isPersistableSourceDocumentId,
 } from "@/api/handlers/case-law/ingestion/adapter";
 import type {
   EmptyAst,
@@ -57,7 +58,7 @@ import { isRecord } from "@/api/lib/type-guards";
 
 const BASE_URL = "https://vyhledavac.nssoud.cz";
 
-/** The only language this source publishes; half of the stored identity. */
+/** The only language this source publishes. */
 const CZ_NSS_LANGUAGE = "cs";
 
 /**
@@ -66,8 +67,12 @@ const CZ_NSS_LANGUAGE = "cs";
  * Coarser than the portal, which also carries the regional and city
  * administrative courts whose judgments the NSS reviews (a single day's
  * listing mixes `1 Az 4/2026` of the Městský soud v Praze with `52 Af 4/2026`
- * of the Krajský soud v Hradci Králové). Recording that distinction is a
- * source-metadata migration, not something the listing walk may decide.
+ * of the Krajský soud v Hradci Králové). Their decisions no longer share a row
+ * — the identity is the portal's document id, see `czNssListingIdentity` — but
+ * they are still all labelled with this court. Recording the deciding court is
+ * a separate metadata migration: the row and the detail fields this adapter
+ * reads state no court, so it would have to come from another field (the ECLI
+ * carries a court code) and be rewritten across the rows already stored.
  */
 const CZ_NSS_COURT = "Nejvyšší správní soud";
 
@@ -318,6 +323,26 @@ export type ParsedRow = {
 };
 
 /**
+ * The publisher's own document id for a row, or undefined where the row states
+ * none this store can hold.
+ *
+ * Stated once, because the crawl, the identity rule and the listing walk must
+ * agree exactly on which documents exist. The bound is not decoration: an id
+ * past the column's limit is refused by the pipeline's own normalization, so
+ * keying a row on it would hunt a row nothing can ever write.
+ */
+const czNssSourceDocumentId = ({
+  documentId,
+}: ParsedRow): string | undefined =>
+  documentId !== undefined && isPersistableSourceDocumentId(documentId)
+    ? documentId
+    : undefined;
+
+/** The detail page of one document, which is also the row's stored URL. */
+const detailUrl = (documentId: string): string =>
+  `${BASE_URL}/DokumentDetail/Index/${documentId}`;
+
+/**
  * Parse result rows from the search response HTML.
  *
  * The 2025 redesign renders results as <tbody> blocks
@@ -362,9 +387,7 @@ export const parseResultRows = (html: string): ParsedRow[] => {
     const detailMatch =
       /href="\/DokumentDetail\/Index\/(?<documentId>\d+)"/u.exec(block);
     const documentId = detailMatch?.groups?.["documentId"];
-    const documentUrl = documentId
-      ? `${BASE_URL}/DokumentDetail/Index/${documentId}`
-      : undefined;
+    const documentUrl = documentId ? detailUrl(documentId) : undefined;
 
     const cells: string[] = [];
     const cellPattern = /<td[^>]*>(?<cell>[\s\S]*?)<\/td>/giu;
@@ -626,9 +649,22 @@ const rowToResult = (
   // Hash must be stable across runs regardless of transient
   // network failures — never include fulltext in the hash.
   const raw = `${row.caseNumber}|${row.decisionDate ?? ""}|${row.decisionType ?? ""}`;
+  const sourceDocumentId = czNssSourceDocumentId(row);
 
   return {
     caseNumber: row.caseNumber,
+    sourceDocumentId,
+    // What every row this adapter wrote before it stated an id was stored
+    // under: one row per docket, carrying the detail URL of whichever document
+    // was written last. The URL names one document exactly, so it re-keys that
+    // row to the document it was built from rather than inserting a second one
+    // beside it; the other documents the portal files under that docket — a
+    // regional court's decision numbered the same, or a further ruling in the
+    // same file — find no null-id row and are inserted, which is the collapse
+    // being undone.
+    ...(sourceDocumentId === undefined
+      ? {}
+      : { legacySourceUrls: [detailUrl(sourceDocumentId)] }),
     ecli: detail.ecli,
     court: CZ_NSS_COURT,
     country: "CZE",
@@ -927,11 +963,13 @@ export const buildCzNssDecision = async ({
   session,
   signal,
 }: BuildCzNssDecisionOptions): Promise<CzNssBuildResult> => {
-  const { documentId } = row;
-  if (documentId === undefined || documentId.length === 0) {
-    // The row names no document, so nothing can be read for it — now or on
-    // any later attempt. Not `unkeyable`: the docket is there and the ingest
-    // would store it, which is exactly why the reconciliation must not.
+  const documentId = czNssSourceDocumentId(row);
+  if (documentId === undefined) {
+    // The row names no document this adapter can address, so nothing can be
+    // read for it — now or on any later attempt. The crawl still stores what
+    // the listing states, under the docket alone; the walk counts such a row
+    // neither held nor missing, since `czNssListingIdentity` has nothing to
+    // key it on.
     return {
       type: "detail-unavailable",
       decision: rowToResult(row, EMPTY_CONTENT, EMPTY_DETAIL),
@@ -998,32 +1036,34 @@ const CZ_NSS_LISTING_TIMEOUT_MS = 60_000;
 /**
  * The identity the ingest would store for this listing row.
  *
- * The docket and the language, never the portal's `documentId`: this adapter
- * emits no `sourceDocumentId`, so every row it has ever written is keyed on
- * `(caseNumber, language)` with a null document id. Keying the listing on the
- * id the portal does supply would match no held row at all, and the loop would
- * read the entire archive as missing.
+ * The portal's own `documentId`, taken from the `/DokumentDetail/Index/{id}`
+ * link the results table puts on every row — the same id every detail and
+ * document request is addressed by, so a row that has one is a document the
+ * adapter can both key and read.
  *
- * The cost of that is real. The portal carries the regional and city
+ * The docket is not that identity. The portal carries the regional and city
  * administrative courts alongside the NSS, and their dockets are numbered per
  * court, so one `(caseNumber, "cs")` can name decisions of different courts;
  * the sheet number that would separate two rulings in the same file is also
  * dropped from the docket, since a citation names the docket alone. Both
- * collapse several published documents onto one stored row. Recovering them is
- * an identity migration of the source (adopt the portal's document id as
- * `sourceDocumentId`, with the deterministic `/DokumentDetail/Index/{id}` URL
- * as the `legacySourceUrls` hint that attaches it to the right null-id row),
- * not something a reconciliation pass may decide on its own: until the stored
- * rows carry that id, this is what "held" means.
+ * collapse several published documents onto one stored row.
+ *
+ * Rows written before the adapter stated an id are re-keyed by the
+ * deterministic `/DokumentDetail/Index/{id}` URL they carry — see
+ * `legacySourceUrls` in {@link rowToResult}. The two must state one rule: a
+ * walk that keyed rows differently from the ingest would read stored decisions
+ * as missing and re-fetch them forever.
+ *
+ * A row the portal lists without that link is unidentifiable rather than keyed
+ * on the docket alone: the ingest cannot read a document for it either, so a
+ * slice that counted it would stay short forever.
  */
-export const czNssListingIdentity = (row: ParsedRow): ListingIdentity =>
-  row.caseNumber.length === 0
+export const czNssListingIdentity = (row: ParsedRow): ListingIdentity => {
+  const sourceDocumentId = czNssSourceDocumentId(row);
+  return sourceDocumentId === undefined
     ? { type: "unidentifiable" }
-    : {
-        type: "case-number",
-        caseNumber: row.caseNumber,
-        language: CZ_NSS_LANGUAGE,
-      };
+    : { type: "document", sourceDocumentId };
+};
 
 /**
  * A reconciliation slice for this source is one UTC decision day, which is

--- a/apps/api/src/handlers/case-law/ingestion/adapters/eu-ecj.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/eu-ecj.test.ts
@@ -1,14 +1,6 @@
 import { Result } from "better-result";
 /* eslint-disable typescript-eslint/promise-function-async -- fetch mock callbacks return Promise.resolve without being async */
-import {
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  mock,
-  spyOn,
-  test,
-} from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 import { hasUsableAst } from "@/api/handlers/case-law/document-ast";
 import {
@@ -19,8 +11,10 @@ import {
 } from "@/api/handlers/case-law/ingestion/adapters/eu-ecj";
 import { tipWindowSlices } from "@/api/handlers/case-law/ingestion/reconciliation-plan";
 import type { SourceReconciliation } from "@/api/lib/legal-search/ingestion-types";
-import { listingIdentityKey } from "@/api/lib/legal-search/ingestion-types";
-import { logger } from "@/api/lib/observability/logger";
+import {
+  listingIdentityKey,
+  parseListingIdentityKey,
+} from "@/api/lib/legal-search/ingestion-types";
 import { asFetchMock } from "@/api/tests/helpers/test-tool-set";
 
 import sparqlFixture from "./__fixtures__/eu-ecj-sparql.json";
@@ -233,6 +227,10 @@ describe("euEcjAdapter.fetchPage", () => {
       expect(first.sourceUrl).toBe(
         "https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:62021CJ0128",
       );
+      expect(first.sourceDocumentId).toBe("62021CJ0128:en");
+      // The hint the pipeline re-keys an existing null-id row by: it must be
+      // the URL that row carries, which is this result's own `sourceUrl`.
+      expect(first.legacySourceUrls).toEqual([first.sourceUrl ?? ""]);
       expect(first.metadata).toMatchObject({
         celex: "62021CJ0128",
         ecli: "ECLI:EU:C:2024:49",
@@ -512,17 +510,15 @@ const rejectionMessage = (rejection: unknown): string =>
 const LANGUAGE_PREFIX =
   "http://publications.europa.eu/resource/authority/language/";
 
-/** The key the engine's held-lookup builds for a row stored without a
- * publisher document id: the docket and the language, exactly the pair the
- * decision identity index is keyed on. */
+/** The key the engine's held-lookup builds for a stored row: the publisher
+ * identity the ingest wrote, exactly the column the decision identity index
+ * is keyed on. */
 const storedIdentityKey = (decision: {
-  caseNumber: string;
-  language: string;
+  sourceDocumentId?: string | undefined;
 }): string | null =>
   listingIdentityKey({
-    type: "case-number",
-    caseNumber: decision.caseNumber,
-    language: decision.language,
+    type: "document",
+    sourceDocumentId: decision.sourceDocumentId ?? "",
   });
 
 /**
@@ -582,15 +578,13 @@ const installSparqlMock = ({
 };
 
 describe("ecjListingIdentity", () => {
-  test("keys a variant on the docket and the stored language tag", () => {
-    // This source publishes no document id of its own, so the fallback half
-    // of the identity index is the whole rule.
+  test("keys a variant on its CELEX and the stored language tag", () => {
     expect(
       ecjListingIdentity({ celex: "62021CJ0128", language: "EN" }),
-    ).toEqual({ type: "case-number", caseNumber: "C-128/21", language: "en" });
+    ).toEqual({ type: "document", sourceDocumentId: "62021CJ0128:en" });
     expect(
       ecjListingIdentity({ celex: "62023TJ0201", language: "MT" }),
-    ).toEqual({ type: "case-number", caseNumber: "T-201/23", language: "mt" });
+    ).toEqual({ type: "document", sourceDocumentId: "62023TJ0201:mt" });
   });
 
   test("the key it produces fits the ledger and reads back", () => {
@@ -598,20 +592,57 @@ describe("ecjListingIdentity", () => {
       celex: "62009FJ0100",
       language: "SV",
     });
-    expect(listingIdentityKey(identity)).toBe("case-number:sv:F-100/09");
+    expect(listingIdentityKey(identity)).toBe("document:62009FJ0100:sv");
+    expect(parseListingIdentityKey(listingIdentityKey(identity) ?? "")).toEqual(
+      identity,
+    );
+  });
+
+  test("the documents that settle one docket are separate identities", () => {
+    // A judgment and an order both numbered C-128/21, in one language: keyed
+    // on the docket they were one row and the second replaced the first.
+    const judgment = ecjListingIdentity({
+      celex: "62021CJ0128",
+      language: "EN",
+    });
+    const order = ecjListingIdentity({ celex: "62021CO0128", language: "EN" });
+    expect(celexToCaseNumber("62021CO0128")).toBe(
+      celexToCaseNumber("62021CJ0128"),
+    );
+    expect(listingIdentityKey(order)).not.toBe(listingIdentityKey(judgment));
+  });
+
+  test("one document's language variants are separate identities", () => {
+    // This source stores a row per language, so a single identity for the
+    // work would have each translation overwrite the last.
+    expect(
+      listingIdentityKey(
+        ecjListingIdentity({ celex: "62021CJ0128", language: "FR" }),
+      ),
+    ).not.toBe(
+      listingIdentityKey(
+        ecjListingIdentity({ celex: "62021CJ0128", language: "EN" }),
+      ),
+    );
   });
 
   test("a CELEX in a format the adapter cannot parse still keys", () => {
-    // The crawl stores such a row under the raw CELEX as its docket, so the
-    // listing has to ask about it under the same key or the row reads as
-    // missing on every pass.
+    // Only the docket is derived by pattern; the identity is the CELEX the
+    // publisher stated, so a sector or type this adapter has no rule for is
+    // still one document.
     expect(
       ecjListingIdentity({ celex: "62021XX0128", language: "EN" }),
-    ).toEqual({
-      type: "case-number",
-      caseNumber: "62021XX0128",
-      language: "en",
-    });
+    ).toEqual({ type: "document", sourceDocumentId: "62021XX0128:en" });
+  });
+
+  test("a CELEX no store can hold keys nothing", () => {
+    // Reserving it is impossible, so hunting a row under it would keep the
+    // slice short for a document nothing can ever write.
+    for (const celex of ["", "not a celex", "6".repeat(300)]) {
+      expect(ecjListingIdentity({ celex, language: "EN" })).toEqual({
+        type: "unidentifiable",
+      });
+    }
   });
 });
 
@@ -721,7 +752,7 @@ describe("euEcjAdapter.reconciliation.listSlicePage", () => {
     // this adapter does not publish is one the crawl would never store.
     expect(
       page.items.map(({ identity }) => listingIdentityKey(identity)),
-    ).toEqual(["case-number:en:C-128/21", "case-number:fr:C-128/21"]);
+    ).toEqual(["document:62021CJ0128:en", "document:62021CJ0128:fr"]);
     expect(page.items.map(({ payload }) => payload)).toEqual([
       { celex: "62021CJ0128", language: "EN" },
       { celex: "62021CJ0128", language: "FR" },
@@ -777,13 +808,11 @@ describe("euEcjAdapter.reconciliation.listSlicePage", () => {
     expect(rejection).toBeInstanceOf(DOMException);
   });
 
-  test("records listed variants that share one stored identity", async () => {
-    // An opinion, a judgment and an order can settle one docket, and this
-    // source keys rows on the docket: those are one identity and one row, so
-    // the slice settles with one of the three held. The listing cannot key
-    // them apart without the persisted identity changing too — it must ask
-    // the question the ingest answers — so the collapse is counted instead of
-    // being left to look like completeness.
+  test("keys the documents that settle one docket as separate rows", async () => {
+    // An opinion, a judgment and an order can settle one docket. Keyed on the
+    // docket they were one identity and one row, so the slice settled with
+    // one of them held and the others were never hunted again; keyed on the
+    // CELEX the publisher states, each is asked about on its own.
     const orderBinding = {
       ...withManifestation(firstFixtureBinding, {
         cellarLanguage: "ENG",
@@ -792,53 +821,19 @@ describe("euEcjAdapter.reconciliation.listSlicePage", () => {
       celex: { type: "literal", value: "62021CO0128" },
     };
     installSparqlMock({ bindings: [enBinding, orderBinding] });
-    const warn = spyOn(logger, "warn");
 
-    try {
-      const page = await reconciliation.listSlicePage({
-        slice: "2024",
-        page: 0,
-      });
+    const page = await reconciliation.listSlicePage({
+      slice: "2024",
+      page: 0,
+    });
 
-      // Both are listed; the engine is what collapses them, on the key the
-      // ingest would store.
-      expect(page.items.map(({ payload }) => payload)).toEqual([
-        { celex: "62021CJ0128", language: "EN" },
-        { celex: "62021CO0128", language: "EN" },
-      ]);
-      expect(
-        page.items.map(({ identity }) => listingIdentityKey(identity)),
-      ).toEqual(["case-number:en:C-128/21", "case-number:en:C-128/21"]);
-
-      const reported = warn.mock.calls.find(
-        ([message]) => message === "case_law.reconciliation.shared_identity",
-      );
-      expect(reported).toBeDefined();
-      expect(reported?.[1]?.["identities"]).toBe(1);
-      expect(reported?.[1]?.["documents"]).toBe(2);
-      expect(reported?.[1]?.["sample"]).toBe(
-        "case-number:en:C-128/21=62021CJ0128,62021CO0128",
-      );
-    } finally {
-      warn.mockRestore();
-    }
-  });
-
-  test("says nothing when every listed variant keys to its own row", async () => {
-    installSparqlMock({ bindings: [enBinding, frBinding] });
-    const warn = spyOn(logger, "warn");
-
-    try {
-      await reconciliation.listSlicePage({ slice: "2024", page: 0 });
-
-      expect(
-        warn.mock.calls.filter(
-          ([message]) => message === "case_law.reconciliation.shared_identity",
-        ),
-      ).toEqual([]);
-    } finally {
-      warn.mockRestore();
-    }
+    expect(page.items.map(({ payload }) => payload)).toEqual([
+      { celex: "62021CJ0128", language: "EN" },
+      { celex: "62021CO0128", language: "EN" },
+    ]);
+    expect(
+      page.items.map(({ identity }) => listingIdentityKey(identity)),
+    ).toEqual(["document:62021CJ0128:en", "document:62021CO0128:en"]);
   });
 
   test("refuses a page the slice does not have", async () => {
@@ -869,13 +864,11 @@ describe("euEcjAdapter.reconciliation.listSlicePage", () => {
       page: 0,
     });
 
-    // The premise of the case-number identity: this adapter states no
-    // publisher document id, so its rows fall to the fallback index.
+    // The premise of the document identity: every row this adapter writes
+    // states the publisher identity the walk hunts it by.
     expect(
-      crawled.value.decisions.every(
-        ({ sourceDocumentId }) => sourceDocumentId === undefined,
-      ),
-    ).toBe(true);
+      crawled.value.decisions.map(({ sourceDocumentId }) => sourceDocumentId),
+    ).toEqual(["62021CJ0128:en", "62021CJ0128:fr"]);
     expect(
       listed.items.map(({ identity }) => listingIdentityKey(identity)),
     ).toEqual(crawled.value.decisions.map(storedIdentityKey));

--- a/apps/api/src/handlers/case-law/ingestion/adapters/eu-ecj.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/eu-ecj.ts
@@ -9,7 +9,7 @@ import type { DocumentAst } from "@/api/handlers/case-law/document-ast";
 import {
   defineSourceAdapter,
   EMPTY_AST,
-  listingIdentityKey,
+  isPersistableSourceDocumentId,
   STORED_RAW_REPARSE_REJECTION,
 } from "@/api/handlers/case-law/ingestion/adapter";
 import type {
@@ -443,26 +443,44 @@ const ecjRowLanguage = (language: EcjLanguage): string =>
   language.toLowerCase();
 
 /**
- * The identity the ingest would store for one listed variant.
+ * The identity a stored row carries: the publisher's CELEX number and the
+ * language of the manifestation the row holds.
  *
- * This source publishes no document id of its own, so its rows are keyed on
- * the docket and the language — the same pair `ecjDecisionFromHtml` writes,
- * derived here by the same two rules. Stated once so the crawl's writes and
- * the reconciliation's held-lookup cannot key the same variant differently:
- * a second copy would let the loop read stored decisions as missing and
- * re-fetch them forever.
+ * The CELEX alone would not do, because this source stores one row per
+ * language variant of a document — the same judgment in 24 languages is 24
+ * rows, and a single identity for all of them would let each translation
+ * overwrite the last. The docket alone would not either, and that is the
+ * defect this replaces: several documents settle one docket (an opinion, a
+ * judgment and an order all numbered C-100/23), so `(caseNumber, language)`
+ * named a docket rather than a document and collapsed them onto one row.
  *
- * Always keyable: both halves come off the listing row itself, so there is no
- * listed variant an ingest could not key.
+ * Stated once so the crawl's writes and the reconciliation's held-lookup
+ * cannot key the same variant differently: a second copy would let the loop
+ * read stored decisions as missing and re-fetch them forever. `undefined` is
+ * the CELEX no store can hold, which is keyed on the docket instead and is
+ * therefore not an identity a walk may hunt.
  */
+export const ecjSourceDocumentId = (
+  celex: string,
+  language: string,
+): string | undefined => {
+  if (!isValidCelex(celex)) {
+    return undefined;
+  }
+  const identity = `${celex}:${language}`;
+  return isPersistableSourceDocumentId(identity) ? identity : undefined;
+};
+
+/** The identity the ingest would store for one listed variant. */
 export const ecjListingIdentity = ({
   celex,
   language,
-}: EcjCelexVariant): ListingIdentity => ({
-  type: "case-number",
-  caseNumber: celexToCaseNumber(celex),
-  language: ecjRowLanguage(language),
-});
+}: EcjCelexVariant): ListingIdentity => {
+  const sourceDocumentId = ecjSourceDocumentId(celex, ecjRowLanguage(language));
+  return sourceDocumentId === undefined
+    ? { type: "unidentifiable" }
+    : { type: "document", sourceDocumentId };
+};
 
 /**
  * The distinct (CELEX, language) variants a set of bindings names.
@@ -777,6 +795,15 @@ const ecjDecisionFromHtml = ({
 
   return {
     caseNumber,
+    sourceDocumentId: ecjSourceDocumentId(celex, language),
+    // What every row this adapter wrote before it stated an id was stored
+    // under: one row per docket and language, carrying the EUR-Lex URL of
+    // whichever of the docket's documents was written last. That URL names one
+    // CELEX in one language exactly, so it re-keys that row to the document it
+    // was built from rather than inserting a second one beside it; the
+    // docket's other documents find no null-id row and are inserted, which is
+    // the collapse being undone.
+    ...(sourceUrl === undefined ? {} : { legacySourceUrls: [sourceUrl] }),
     ecli,
     court,
     country: "EU",
@@ -1069,66 +1096,6 @@ const ecjSlicePageRange = (slice: string, page: number): EcjSliceRange => {
   };
 };
 
-/** Shared identities named in the log line; enough to act on, bounded. */
-const SHARED_IDENTITY_SAMPLE = 3;
-
-/**
- * Record listed variants that would be stored under one identity.
- *
- * Several document kinds settle one docket — an opinion, a judgment and an
- * order all numbered C-100/23 — and this source keys its rows on the docket
- * and the language, so those become one identity and one row. A slice's
- * counts are computed over identities and stay self-consistent, but they
- * cannot then speak for the documents behind a shared key: the slice settles
- * while only one of them is held.
- *
- * The reconciliation must key items exactly as the ingest keys rows or it
- * never reaches a fixed point, so this is not something the listing may fix
- * on its own — the granularity is the persisted identity's. Counting it here
- * is what keeps the gap measurable rather than silent, and gives a re-key the
- * measurement it would need.
- */
-const reportSharedIdentities = (
-  slice: string,
-  page: number,
-  variants: readonly EcjCelexVariant[],
-): void => {
-  const celexByIdentity = new Map<string, Set<string>>();
-  for (const variant of variants) {
-    const key = listingIdentityKey(ecjListingIdentity(variant));
-    if (key === null) {
-      continue;
-    }
-    const celexNumbers = celexByIdentity.get(key) ?? new Set<string>();
-    celexNumbers.add(variant.celex);
-    celexByIdentity.set(key, celexNumbers);
-  }
-  const shared = [...celexByIdentity].filter(
-    ([, celexNumbers]) => celexNumbers.size > 1,
-  );
-  if (shared.length === 0) {
-    return;
-  }
-  logger.warn("case_law.reconciliation.shared_identity", {
-    adapterKey: ADAPTER_KEYS.EU_ECJ,
-    slice,
-    page,
-    identities: shared.length,
-    documents: shared.reduce(
-      (total, [, celexNumbers]) => total + celexNumbers.size,
-      0,
-    ),
-    // One string, because a log attribute is a scalar: an array here is
-    // rejected at the type boundary rather than silently flattened.
-    sample: shared
-      .slice(0, SHARED_IDENTITY_SAMPLE)
-      .map(
-        ([key, celexNumbers]) => `${key}=${[...celexNumbers].sort().join(",")}`,
-      )
-      .join("; "),
-  });
-};
-
 /**
  * One page of what the publisher lists for a slice, with no manifestation
  * fetched.
@@ -1156,7 +1123,6 @@ const listEcjSlicePage = async ({
     signal: signal ?? AbortSignal.timeout(ECJ_LISTING_TIMEOUT_MS),
   });
   const variants = distinctVariants(bindings);
-  reportSharedIdentities(slice, page, variants);
   return {
     items: variants.map((variant) => ({
       identity: ecjListingIdentity(variant),

--- a/apps/api/src/handlers/case-law/ingestion/adapters/pagination.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/pagination.test.ts
@@ -6,6 +6,7 @@ import { propertyConfig } from "@stll/property-testing";
 import type { IngestionResult } from "@/api/handlers/case-law/ingestion/adapter";
 import { asTestRaw, readTestJson } from "@/api/tests/helpers/test-tool-set";
 
+import type { FirstPageNumber } from "./pagination";
 import {
   createPagePaginatedFetch,
   decodeOffsetCursor,
@@ -36,7 +37,7 @@ const itemToDecision = (item: TestItem): IngestionResult => ({
 const createTestFetch = (opts?: {
   pageSize?: number;
   legacyPageSize?: number;
-  zeroIndexed?: boolean;
+  firstPage?: FirstPageNumber;
   skipEven?: boolean;
 }) => {
   const pageSize = opts?.pageSize ?? 3;
@@ -45,7 +46,7 @@ const createTestFetch = (opts?: {
     adapterKey: "test",
     pageSize,
     legacyPageSize: opts?.legacyPageSize,
-    zeroIndexed: opts?.zeroIndexed,
+    firstPage: opts?.firstPage ?? 1,
 
     buildRequest: (page) => ({
       url: `https://example.com/test-api?page=${page}`,
@@ -167,7 +168,7 @@ describe("createPagePaginatedFetch", () => {
       { pattern: "/test-api", fixture: FIXTURE_NAME },
     ]);
 
-    const fetchPage = createTestFetch({ zeroIndexed: true });
+    const fetchPage = createTestFetch({ firstPage: 0 });
     const result = await fetchPage("offset:21", {});
     const page = result.unwrap();
     expect(page.nextCursor).toBe("offset:22");
@@ -183,7 +184,7 @@ describe("createPagePaginatedFetch", () => {
       { pattern: "/test-api", fixture: FIXTURE_NAME },
     ]);
 
-    const fetchPage = createTestFetch({ zeroIndexed: true });
+    const fetchPage = createTestFetch({ firstPage: 0 });
     const result = await fetchPage("10", {});
     const page = result.unwrap();
     expect(page.decisions).toHaveLength(0);
@@ -219,7 +220,7 @@ describe("createPagePaginatedFetch", () => {
 
     const fetchPage = createTestFetch({
       pageSize: 5,
-      zeroIndexed: true,
+      firstPage: 0,
     });
 
     const result = await fetchPage(null, {});
@@ -260,7 +261,7 @@ describe("createPagePaginatedFetch", () => {
     const fetchAtPageSize20 = createPagePaginatedFetch<TestResponse>({
       adapterKey: "test",
       pageSize: 20,
-      zeroIndexed: true,
+      firstPage: 0,
       buildRequest: (page) => ({
         url: `https://example.com/test-api?page=${page}&pageSize=20`,
       }),
@@ -286,7 +287,7 @@ describe("createPagePaginatedFetch", () => {
       adapterKey: "test",
       pageSize: 100,
       legacyPageSize: 20,
-      zeroIndexed: true,
+      firstPage: 0,
       buildRequest: (page) => ({
         url: `https://example.com/test-api?page=${page}&pageSize=100`,
       }),
@@ -321,7 +322,7 @@ describe("createPagePaginatedFetch", () => {
     const fetchPage = createPagePaginatedFetch<TestResponse>({
       adapterKey: "test",
       pageSize: 10,
-      zeroIndexed: true,
+      firstPage: 0,
       itemConcurrency: 3,
       buildRequest: (page) => ({
         url: `https://example.com/test-api?page=${page}`,
@@ -352,6 +353,129 @@ describe("createPagePaginatedFetch", () => {
     expect(page.decisions.at(-1)?.caseNumber).toBe("CASE-3");
     expect(page.nextCursor).toBe("offset:3");
   });
+});
+
+const requestUrl = (input: string | URL | Request): string => {
+  if (typeof input === "string") {
+    return input;
+  }
+  return input instanceof URL ? input.href : input.url;
+};
+
+/**
+ * A publisher that numbers pages from one usually clamps below it — asking for
+ * page zero answers page one rather than an error — so a walk configured with
+ * the wrong origin does not fail, it silently reads one page behind its own
+ * cursor. The model here clamps for exactly that reason.
+ */
+const mockClampedEndpoint = (
+  items: TestItem[],
+  firstPage: FirstPageNumber,
+  pageSize: number,
+): { restore: () => void; requestedPages: number[] } => {
+  const originalFetch = globalThis.fetch;
+  const requestedPages: number[] = [];
+
+  globalThis.fetch = Object.assign(
+    async (input: string | URL | Request): Promise<Response> => {
+      const url = new URL(requestUrl(input));
+      const requested = Number.parseInt(url.searchParams.get("page") ?? "", 10);
+      requestedPages.push(requested);
+      const start = (Math.max(firstPage, requested) - firstPage) * pageSize;
+      return await Promise.resolve(
+        new Response(
+          makeFixture(items.slice(start, start + pageSize), items.length),
+          { headers: { "Content-Type": "application/json; charset=utf-8" } },
+        ),
+      );
+    },
+    { preconnect: originalFetch.preconnect.bind(originalFetch) },
+  );
+
+  return {
+    restore: () => {
+      globalThis.fetch = originalFetch;
+    },
+    requestedPages,
+  };
+};
+
+describe("an offset names the same items whatever the publisher numbers from", () => {
+  const PAGE_SIZE = 10;
+  const dataset = Array.from({ length: 200 }, (_, index) => ({
+    id: index + 1,
+  }));
+  let restore: (() => void) | undefined;
+
+  afterEach(() => {
+    restore?.();
+    restore = undefined;
+  });
+
+  const firstPages = [0, 1] as const satisfies readonly FirstPageNumber[];
+
+  /** The offset a cursor names is the item the page it fetches begins at. */
+  const assertOffsetNamesItsPage = async (
+    firstPage: FirstPageNumber,
+  ): Promise<void> => {
+    const endpoint = mockClampedEndpoint(dataset, firstPage, PAGE_SIZE);
+    restore = endpoint.restore;
+    const fetchPage = createTestFetch({ pageSize: PAGE_SIZE, firstPage });
+
+    for (const offset of [0, PAGE_SIZE, 3 * PAGE_SIZE, 19 * PAGE_SIZE]) {
+      // oxlint-disable-next-line no-await-in-loop -- one offset at a time so a failure names the offset that broke
+      const result = await fetchPage(encodeOffsetCursor(offset), {});
+      const page = result.unwrap();
+      // The cursor is an item offset, so the first decision it yields is the
+      // item at that offset — the property a wrong page origin breaks while
+      // every count in the response still adds up.
+      expect(page.decisions.at(0)?.caseNumber).toBe(`CASE-${offset + 1}`);
+      expect(page.decisions).toHaveLength(PAGE_SIZE);
+      expect(page.nextCursor).toBe(encodeOffsetCursor(offset + PAGE_SIZE));
+    }
+
+    expect(endpoint.requestedPages).toEqual([
+      firstPage,
+      firstPage + 1,
+      firstPage + 3,
+      firstPage + 19,
+    ]);
+  };
+
+  /** Walking from the start reads every item once and none of them twice. */
+  const assertNoPageIsReadTwice = async (
+    firstPage: FirstPageNumber,
+  ): Promise<void> => {
+    const endpoint = mockClampedEndpoint(dataset, firstPage, PAGE_SIZE);
+    restore = endpoint.restore;
+    const fetchPage = createTestFetch({ pageSize: PAGE_SIZE, firstPage });
+
+    const seen: string[] = [];
+    let cursor: string | null = null;
+    for (let step = 0; step < 5; step += 1) {
+      // oxlint-disable-next-line no-await-in-loop -- each step's cursor is the previous step's output
+      const result = await fetchPage(cursor, {});
+      const page = result.unwrap();
+      seen.push(...page.decisions.map(({ caseNumber }) => caseNumber));
+      cursor = page.nextCursor;
+    }
+
+    // A first page re-read by a clamping publisher shows up here and nowhere
+    // else: the counts, the cursors and the page numbers all stay plausible.
+    expect(new Set(seen).size).toBe(seen.length);
+    expect(seen.at(0)).toBe("CASE-1");
+    expect(seen.at(-1)).toBe(`CASE-${5 * PAGE_SIZE}`);
+  };
+
+  for (const firstPage of firstPages) {
+    test(`INVARIANT: the page fetched for an offset begins at that offset (firstPage ${firstPage})`, async () => {
+      await assertOffsetNamesItsPage(firstPage);
+    });
+
+    test(`INVARIANT: no page is read twice while the offset advances (firstPage ${firstPage})`, async () => {
+      await assertNoPageIsReadTwice(firstPage);
+    });
+  }
 });
 
 describe("offset cursor codec", () => {

--- a/apps/api/src/handlers/case-law/ingestion/adapters/pagination.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/pagination.ts
@@ -53,11 +53,28 @@ export type TraversalMode = {
   windowItems?: number | undefined;
 };
 
+/**
+ * The number a publisher gives its own first page. Every endpoint numbers
+ * pages from one or from zero, and which one it is is a fact about that
+ * endpoint that the adapter must state rather than infer.
+ *
+ * Getting it wrong is silent, because a clamping endpoint answers an
+ * out-of-range page with its first one instead of an error: the walk then
+ * re-reads that page every traversal and reads every later page one page
+ * short of where its cursor says it is.
+ */
+export type FirstPageNumber = 0 | 1;
+
 type PagePaginationOptions<TResponse> = {
   /** Adapter key for error context. */
   adapterKey: string;
-  /** Whether page numbers are 0-indexed (default: false = 1-indexed). */
-  zeroIndexed?: boolean | undefined;
+  /**
+   * The page number this endpoint gives its first page. Cursors are item
+   * offsets either way: this is only how an offset is turned into the number
+   * the publisher is asked for, so the page fetched for offset `n` always
+   * begins at item `n - (n % pageSize)`.
+   */
+  firstPage: FirstPageNumber;
   /** Number of items per page (used to detect last page). */
   pageSize: number;
   /**
@@ -138,6 +155,7 @@ type PagePaginationOptions<TResponse> = {
  *   fetchPage: createPagePaginatedFetch({
  *     adapterKey: ADAPTER_KEYS.MY_ADAPTER,
  *     pageSize: 20,
+ *     firstPage: 1,
  *     buildRequest: (page) => ({
  *       url: `https://api.example.com/search?page=${page}`,
  *     }),
@@ -234,7 +252,7 @@ export const encodeTraversalCursor = (mode: string, offset: number): string =>
 export const createPagePaginatedFetch = <TResponse>(
   opts: PagePaginationOptions<TResponse>,
 ) => {
-  const firstPage = opts.zeroIndexed ? 0 : 1;
+  const { firstPage } = opts;
   const modes = opts.traversal;
 
   return async (

--- a/apps/api/src/handlers/case-law/ingestion/adapters/pl-courts.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/pl-courts.ts
@@ -56,6 +56,13 @@ const PAGE_SIZE = 100;
 const LEGACY_PAGE_SIZE = 100;
 const ITEM_CONCURRENCY = 10;
 
+/**
+ * SAOS numbers `pageNumber` from zero, on both the dump the crawl walks and
+ * the search the slice listing walks: the listing asks for the slice's page
+ * number unchanged, and the crawl derives the same number from its offset.
+ */
+const FIRST_PAGE = 0;
+
 /** The only language this source publishes; half of the fallback identity. */
 export const PL_COURTS_LANGUAGE = "pl";
 
@@ -946,7 +953,7 @@ export const listPlCourtsDayPage = async ({
 }: ListPlCourtsDayPageOptions): Promise<PlCourtsDayPage> => {
   const url = `${SEARCH_URL}?${new URLSearchParams({
     pageSize: String(PAGE_SIZE),
-    pageNumber: String(page),
+    pageNumber: String(page + FIRST_PAGE),
     sortingField: SLICE_SORTING_FIELD,
     sortingDirection: SLICE_SORTING_DIRECTION,
     judgmentDateFrom: date,
@@ -1083,7 +1090,7 @@ export const plCourtsAdapter = defineSourceAdapter({
       const response = await fetchWithTimeout(
         `${SEARCH_URL}?${new URLSearchParams({
           pageSize: "1",
-          pageNumber: "0",
+          pageNumber: String(FIRST_PAGE),
           sortingField: "JUDGMENT_DATE",
           sortingDirection: "DESC",
         }).toString()}`,
@@ -1132,7 +1139,7 @@ export const plCourtsAdapter = defineSourceAdapter({
     adapterKey: ADAPTER_KEYS.PL_COURTS,
     pageSize: PAGE_SIZE,
     legacyPageSize: LEGACY_PAGE_SIZE,
-    zeroIndexed: true,
+    firstPage: FIRST_PAGE,
     listTimeoutMs: 60_000,
     itemConcurrency: ITEM_CONCURRENCY,
 

--- a/apps/api/src/handlers/case-law/ingestion/adapters/sk-courts-pagination.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/sk-courts-pagination.test.ts
@@ -1,0 +1,163 @@
+/* eslint-disable typescript-eslint/promise-function-async -- fetch mock callbacks return Promise.resolve without being async */
+/**
+ * What the crawl asks obcan.justice.sk for, given the cursor it persisted.
+ *
+ * The endpoint numbers pages from one and clamps below it, so an adapter that
+ * believes otherwise still gets a plausible answer to every request: the
+ * counts add up, the cursors advance, and the walk quietly re-reads its first
+ * page every lap while every later page arrives one page behind the offset its
+ * cursor names. The stub below therefore clamps exactly as the publisher does
+ * — a stub numbered from zero would certify the bug.
+ */
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { skCourtsAdapter } from "@/api/handlers/case-law/ingestion/adapters/sk-courts";
+import { asFetchMock } from "@/api/tests/helpers/test-tool-set";
+
+const PAGE_SIZE = 100;
+
+/** How far the newest-first walk reaches before returning to the head. */
+const LIVE_WINDOW_ITEMS = 5000;
+
+/**
+ * Items shaped like the API answers: a two-UUID `guid`, a docket written the
+ * way the register writes it, and the deciding court by name.
+ */
+const listItem = (index: number) => ({
+  guid: `${index.toString(16).padStart(8, "0")}-0ea1-4249-be21-67f7c341c1f3:6fbcafd6-00b2-4448-bf87-73c5e64a43f5`,
+  spisovaZnacka: `${(index % 30) + 1}C/${index}/2020`,
+  identifikacneCislo: `13${String(index).padStart(9, "0")}`,
+  sud: { nazov: "Okresný súd Bratislava I", registreGuid: "court-guid" },
+  datumVydania: "14.05.2020",
+  formaRozhodnutia: "Rozsudok",
+});
+
+const CORPUS_SIZE = 6000;
+
+type Endpoint = {
+  requestedPages: number[];
+  restore: () => void;
+};
+
+const mockListEndpoint = (): Endpoint => {
+  const originalFetch = globalThis.fetch;
+  const requestedPages: number[] = [];
+
+  globalThis.fetch = asFetchMock(
+    (input: string | URL | Request): Promise<Response> => {
+      const url = new URL(input instanceof Request ? input.url : String(input));
+      const page = url.searchParams.get("page");
+      if (page === null) {
+        // A per-decision detail request; the crawl asks for one per item.
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({ ecli: "ECLI:SK:OSBA1:2020:1.C.1.2020" }),
+            {
+              headers: { "Content-Type": "application/json" },
+            },
+          ),
+        );
+      }
+      const requested = Number.parseInt(page, 10);
+      requestedPages.push(requested);
+      // Numbered from one, clamped below it: `page=0` answers `page=1`.
+      const ascending = url.searchParams.get("sortDirection") === "ASC";
+      const start = (Math.max(1, requested) - 1) * PAGE_SIZE;
+      const items = Array.from({ length: PAGE_SIZE }, (_, offset) => {
+        const position = start + offset;
+        return listItem(ascending ? position : CORPUS_SIZE - 1 - position);
+      }).slice(0, Math.max(0, Math.min(PAGE_SIZE, CORPUS_SIZE - start)));
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({ rozhodnutieList: items, numFound: CORPUS_SIZE }),
+          { headers: { "Content-Type": "application/json" } },
+        ),
+      );
+    },
+  );
+
+  return {
+    requestedPages,
+    restore: () => {
+      globalThis.fetch = originalFetch;
+    },
+  };
+};
+
+const fetchAt = async (cursor: string | null) => {
+  const result = await skCourtsAdapter.fetchPage(cursor, {});
+  if (result.isErr()) {
+    throw result.error;
+  }
+  return result.unwrap();
+};
+
+describe("sk-courts crawl pagination", () => {
+  let endpoint: Endpoint | undefined;
+
+  afterEach(() => {
+    endpoint?.restore();
+    endpoint = undefined;
+  });
+
+  test("a cursor's offset names the page that begins at it", async () => {
+    endpoint = mockListEndpoint();
+
+    const first = await fetchAt("backfill:0");
+    const second = await fetchAt("backfill:100");
+    const later = await fetchAt("backfill:1200");
+
+    // The first page of the collection is requested as the publisher's own
+    // first page, and every later offset one page further — never the same
+    // page twice, which is what the clamped `page=0` produced.
+    expect(endpoint.requestedPages).toEqual([1, 2, 13]);
+    expect(first.decisions.at(0)?.caseNumber).toBe(listItem(0).spisovaZnacka);
+    expect(second.decisions.at(0)?.caseNumber).toBe(
+      listItem(100).spisovaZnacka,
+    );
+    expect(later.decisions.at(0)?.caseNumber).toBe(
+      listItem(1200).spisovaZnacka,
+    );
+  });
+
+  test("cursors keep their grammar and their meaning across the walk", async () => {
+    endpoint = mockListEndpoint();
+
+    // An item offset in, an item offset out, under the same walk name: a
+    // cursor persisted before this fix still names the item it named then.
+    expect((await fetchAt("backfill:0")).nextCursor).toBe("backfill:100");
+    expect((await fetchAt("backfill:100")).nextCursor).toBe("backfill:200");
+    expect((await fetchAt("live:1200")).nextCursor).toBe("live:1300");
+    // A null cursor starts the first walk at its own beginning.
+    expect((await fetchAt(null)).nextCursor).toBe("backfill:100");
+  });
+
+  test("the live walk covers its whole window before turning back", async () => {
+    endpoint = mockListEndpoint();
+
+    const pages: number[] = [];
+    const collected: string[] = [];
+    let cursor: string | null = "live:0";
+    for (let step = 0; step < LIVE_WINDOW_ITEMS / PAGE_SIZE; step += 1) {
+      // oxlint-disable-next-line no-await-in-loop -- each step's cursor is the previous step's output; that dependency is the walk
+      const page = await fetchAt(cursor);
+      pages.push(...endpoint.requestedPages.splice(0));
+      collected.push(...page.decisions.map(({ caseNumber }) => caseNumber));
+      cursor = page.nextCursor;
+    }
+
+    // One lap reads the window exactly once: five thousand decisions, not
+    // forty-nine pages of them plus the first page over again.
+    expect(collected).toHaveLength(LIVE_WINDOW_ITEMS);
+    expect(new Set(collected).size).toBe(LIVE_WINDOW_ITEMS);
+    expect(collected.at(0)).toBe(listItem(CORPUS_SIZE - 1).spisovaZnacka);
+    expect(collected.at(-1)).toBe(
+      listItem(CORPUS_SIZE - LIVE_WINDOW_ITEMS).spisovaZnacka,
+    );
+    expect(pages).toHaveLength(LIVE_WINDOW_ITEMS / PAGE_SIZE);
+    expect(pages.at(0)).toBe(1);
+    expect(pages.at(-1)).toBe(LIVE_WINDOW_ITEMS / PAGE_SIZE);
+    // And then returns to the head, which is where the new decisions are.
+    expect(cursor).toBe("live:0");
+  }, 120_000);
+});

--- a/apps/api/src/handlers/case-law/ingestion/adapters/sk-courts.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/sk-courts.ts
@@ -40,13 +40,15 @@ import { isRecord } from "@/api/lib/type-guards";
 /**
  * Slovak Courts adapter.
  *
- * Fetches decisions from the obcan.justice.sk REST API.
- * Page-based pagination (0-indexed).
+ * Fetches decisions from the obcan.justice.sk REST API,
+ * whose pages are numbered from one (see {@link FIRST_PAGE}).
  *
  * Each list item is enriched with a detail fetch for
  * ECLI, document URL, and referenced legislation.
  *
- * Cursor format: item offset as string (e.g. "offset:100").
+ * Cursor format: the walk and an item offset within it
+ * ("backfill:1200", "live:0"); a bare "offset:100" predates
+ * the walks and restarts the first of them.
  *
  * The same list endpoint is addressable by a decision-date range, which is
  * what makes this source reconcilable: one date can be listed on its own,
@@ -55,6 +57,20 @@ import { isRecord } from "@/api/lib/type-guards";
 
 const BASE_URL =
   "https://obcan.justice.sk/pilot/api/ress-isu-service/v1/rozhodnutie";
+
+/**
+ * This endpoint numbers pages from one and clamps below it: `page=0` and
+ * `page=1` both answer the first hundred records, `page=2` the second hundred,
+ * and the response echoes `page` one lower than the request asked for.
+ *
+ * One statement for the whole adapter. The crawl and the slice listing walk
+ * the same endpoint, so a second statement of this fact is a second chance to
+ * state it differently — which is what happened: the crawl declared the
+ * endpoint zero-indexed, re-read the first page on every traversal and read
+ * every later page one hundred records behind its own cursor.
+ */
+const FIRST_PAGE = 1;
+
 const PAGE_SIZE = 100;
 const LEGACY_PAGE_SIZE = 100;
 const ITEM_CONCURRENCY = 10;
@@ -562,12 +578,11 @@ const SK_COURTS_TIP_WINDOW_DAYS = 140;
 const LISTING_PAGE_SIZE = 1000;
 
 /**
- * This endpoint numbers pages from one and clamps below it: `page=0` and
- * `page=1` both answer the first page, and the response echoes `page` one
- * lower than the request asked for. The contract numbers a slice's pages from
- * zero, so a page is requested one higher than it is named.
+ * A reconciliation slice numbers its pages from zero, so a page is requested
+ * one higher than it is named. Same endpoint fact as {@link FIRST_PAGE},
+ * stated through it rather than beside it.
  */
-const LISTING_FIRST_PAGE = 1;
+const LISTING_FIRST_PAGE = FIRST_PAGE;
 
 /**
  * Ordering for a slice listing. `guid` is unique and never reassigned, so it
@@ -813,7 +828,7 @@ export const skCourtsAdapter = defineSourceAdapter({
     adapterKey: ADAPTER_KEYS.SK_COURTS,
     pageSize: PAGE_SIZE,
     legacyPageSize: LEGACY_PAGE_SIZE,
-    zeroIndexed: true,
+    firstPage: FIRST_PAGE,
     listTimeoutMs: 60_000,
     itemConcurrency: ITEM_CONCURRENCY,
 

--- a/apps/api/src/handlers/case-law/ingestion/adapters/sk-us.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/sk-us.test.ts
@@ -17,7 +17,10 @@ import {
   SK_US_FIRST_SLICE,
 } from "@/api/handlers/case-law/ingestion/adapters/sk-us";
 import { tipWindowSlices } from "@/api/handlers/case-law/ingestion/reconciliation-plan";
-import { listingIdentityKey } from "@/api/lib/legal-search/ingestion-types";
+import {
+  listingIdentityKey,
+  SOURCE_DOCUMENT_ID_MAX_LENGTH,
+} from "@/api/lib/legal-search/ingestion-types";
 import { asFetchMock } from "@/api/tests/helpers/test-tool-set";
 
 const { reconciliation } = skUsAdapter;
@@ -276,15 +279,35 @@ describe("sk-us reconciliation slices", () => {
 });
 
 describe("sk-us listing identity", () => {
-  test("keys an item on its docket and language, as the crawl stores it", () => {
+  test("keys an item on the DMS document id, as the crawl stores it", () => {
     expect(skUsListingIdentity(PLENARY_OPINION)).toEqual({
-      type: "case-number",
-      caseNumber: "PL. ÚS 4/2020",
-      language: "sk",
+      type: "document",
+      sourceDocumentId: PLENARY_OPINION.documentId,
     });
     expect(listingIdentityKey(skUsListingIdentity(PLENARY_OPINION))).toBe(
-      "case-number:sk:PL. ÚS 4/2020",
+      `document:${PLENARY_OPINION.documentId}`,
     );
+  });
+
+  test("a docket's documents are separate identities, as the store now is", () => {
+    // The court publishes each opinion of a plenary decision as its own
+    // document under one docket; keyed on the docket they were one row.
+    const sibling = {
+      ...PLENARY_OPINION,
+      documentId: "9c2f0f01-6a2f-4a53-9a4e-2b6cf9a5f4d2",
+    };
+    expect(listingIdentityKey(skUsListingIdentity(sibling))).not.toBe(
+      listingIdentityKey(skUsListingIdentity(PLENARY_OPINION)),
+    );
+  });
+
+  test("an id the decision column cannot hold keys nothing", () => {
+    expect(
+      skUsListingIdentity({
+        ...PLENARY_OPINION,
+        documentId: "d".repeat(SOURCE_DOCUMENT_ID_MAX_LENGTH + 1),
+      }),
+    ).toEqual({ type: "unidentifiable" });
   });
 
   test("an item the crawl would drop is unidentifiable, not keyed on nothing", () => {
@@ -358,9 +381,8 @@ describe("sk-us listSlicePage", () => {
     expect(last.totalPages).toBe(4);
     expect(first.items).toHaveLength(1);
     expect(first.items.at(0)?.identity).toEqual({
-      type: "case-number",
-      caseNumber: "PL. ÚS 4/2020",
-      language: "sk",
+      type: "document",
+      sourceDocumentId: PLENARY_OPINION.documentId,
     });
   });
 
@@ -474,11 +496,28 @@ describe("sk-us buildDecision", () => {
     // short and re-fetches the same document forever.
     expect(
       listingIdentityKey({
-        type: "case-number",
-        caseNumber: outcome.decision.caseNumber,
-        language: outcome.decision.language,
+        type: "document",
+        sourceDocumentId: outcome.decision.sourceDocumentId ?? "",
       }),
     ).toBe(listingIdentityKey(skUsListingIdentity(PLENARY_OPINION)));
+  });
+
+  test("the built decision carries the URL its docket-keyed row was stored under", async () => {
+    mockFetch({ search: [] });
+
+    const outcome = await reconciliation.buildDecision(PLENARY_OPINION);
+    expect(outcome.type).toBe("built");
+    if (outcome.type !== "built") {
+      return;
+    }
+    // The hint the pipeline re-keys an existing null-id row by: it must be the
+    // URL that row carries, which is the one this build stores as `sourceUrl`.
+    expect(outcome.decision.legacySourceUrls).toEqual([
+      outcome.decision.sourceUrl ?? "",
+    ]);
+    expect(outcome.decision.sourceUrl).toBe(
+      `https://www.ustavnysud.sk/docDownload/${PLENARY_OPINION.documentId}`,
+    );
   });
 
   test("a document the court does not serve is never written", async () => {

--- a/apps/api/src/handlers/case-law/ingestion/adapters/sk-us.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/sk-us.ts
@@ -43,6 +43,7 @@ import type { DocumentAst } from "@/api/handlers/case-law/document-ast";
 import {
   defineSourceAdapter,
   EMPTY_AST,
+  isPersistableSourceDocumentId,
 } from "@/api/handlers/case-law/ingestion/adapter";
 import type {
   EmptyAst,
@@ -268,7 +269,10 @@ const skUsIdentityFields = (
     typeof caseNumber !== "string" ||
     caseNumber.length === 0 ||
     typeof documentId !== "string" ||
-    documentId.length === 0
+    // The id is now the stored identity, so one the column cannot hold is not
+    // a document this adapter can key: keeping it would hunt a row nothing can
+    // ever write.
+    !isPersistableSourceDocumentId(documentId)
   ) {
     return null;
   }
@@ -278,30 +282,23 @@ const skUsIdentityFields = (
 /**
  * The identity the ingest would store for this listing item.
  *
- * The docket and the language, never the DMS `documentId`: this adapter emits
- * no `sourceDocumentId`, so every row it has ever written is keyed on
- * `(caseNumber, language)` with a null document id. Keying the listing on the
- * id the publisher does supply would match no held row at all, and the loop
- * would read the entire archive as missing.
+ * The DMS `documentId`, which is what the publisher itself keys a document on:
+ * the court publishes each opinion of a plenary decision as its own document
+ * under one docket (19 documents under `PL. ÚS 4/2020` in March 2020 alone),
+ * so a `(caseNumber, language)` key names a docket rather than a document and
+ * collapses all of them onto one row.
  *
- * The cost of that is real and measurable — the court publishes each opinion
- * of a plenary decision as its own document under one docket (19 documents
- * under `PL. ÚS 4/2020` in March 2020 alone), and the crawl collapses them
- * into a single row. Recovering them is an identity migration of the source
- * (adopt `documentId` as `sourceDocumentId`, with the deterministic
- * `docDownload/{id}` URL as the `legacySourceUrls` hint that attaches it to
- * the right null-id row), not something a reconciliation pass may decide on
- * its own: until the stored rows carry that id, this is what "held" means.
+ * {@link buildSkUsDecision} stores that same id as `sourceDocumentId`, and
+ * rows written before it did are re-keyed by the deterministic
+ * `docDownload/{id}` URL they carry — see `legacySourceUrls` there. The two
+ * must state one rule: a walk that keyed items differently from the ingest
+ * would read stored decisions as missing and re-fetch them forever.
  */
 export const skUsListingIdentity = (doc: SearchDocument): ListingIdentity => {
   const fields = skUsIdentityFields(doc);
   return fields === null
     ? { type: "unidentifiable" }
-    : {
-        type: "case-number",
-        caseNumber: fields.caseNumber,
-        language: SK_US_LANGUAGE,
-      };
+    : { type: "document", sourceDocumentId: fields.documentId };
 };
 
 /**
@@ -375,9 +372,18 @@ export const buildSkUsDecision = async (
   }
 
   const rawHash = hashContent(JSON.stringify(doc));
+  const documentUrl = `${DOC_DOWNLOAD_URL}/${documentId}`;
 
   const decision: IngestionResult = {
     caseNumber,
+    sourceDocumentId: documentId,
+    // What every row this adapter wrote before it stated an id was stored
+    // under: one row per docket, carrying the download URL of whichever of the
+    // docket's documents was written last. The URL names one document exactly,
+    // so it re-keys that row to the document it was built from instead of
+    // inserting a second one beside it; the docket's other documents find no
+    // null-id row and are inserted, which is the collapse being undone.
+    legacySourceUrls: [documentUrl],
     ecli,
     court,
     country: "SVK",
@@ -388,8 +394,8 @@ export const buildSkUsDecision = async (
     // The listing proves the document exists; without its PDF this row carries
     // metadata only, and must never overwrite detail a later fetch recovered.
     ...(pdfBytes === undefined ? { isListingOnly: true } : {}),
-    sourceUrl: `${DOC_DOWNLOAD_URL}/${documentId}`,
-    documentUrl: `${DOC_DOWNLOAD_URL}/${documentId}`,
+    sourceUrl: documentUrl,
+    documentUrl,
     metadata: {
       caseNumber,
       ecli,
@@ -769,15 +775,10 @@ export const skUsAdapter = defineSourceAdapter({
     // `buildSkUsDecision` marks it `isListingOnly`; unset, that row would count
     // as held and its document would never be hunted again.
     //
-    // Heldness stays a statement about the docket rather than the document,
-    // because this source stores one row per `(caseNumber, language)` and emits
-    // no `sourceDocumentId` at all — see `skUsListingIdentity`. A docket whose
-    // row carries detail is therefore held even where a sibling document
-    // failed, and a walk hunts one representative per docket, not all of them.
-    // That bound belongs to the identity model, not to this flag: without the
-    // flag the docket is held whatever its row carries, and fetching siblings
-    // before the stored rows carry `documentId` would only have them overwrite
-    // one another in the single row that exists for the docket.
+    // Heldness is now a statement about the document, since the rows carry the
+    // DMS id — see `skUsListingIdentity`. A docket's documents are hunted one
+    // by one rather than through a representative, and a sibling whose PDF
+    // failed no longer hides behind one that succeeded.
     heldRequiresDetail: true,
     listSlicePage: listSkUsSlicePage,
     buildDecision: buildSkUsFromPayload,

--- a/apps/api/src/handlers/case-law/ingestion/publisher-document-identity.db.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/publisher-document-identity.db.test.ts
@@ -1,0 +1,446 @@
+/* eslint-disable typescript-eslint/promise-function-async -- fetch mock callbacks return Promise.resolve without being async */
+/**
+ * What happens to the rows a source already has when its adapter learns the
+ * publisher's document id.
+ *
+ * Four sources keyed their rows on `(caseNumber, language)`, which names a
+ * docket rather than a document: a docket that publishes several documents —
+ * a plenary decision's separate opinions, a judgment and an order under one
+ * case number, two courts numbering their files alike — kept one row, and
+ * each document stored replaced the last one silently.
+ *
+ * The migration has to hold two things at once, and neither is provable from
+ * the adapter alone:
+ *
+ *   1. A row already stored under the docket, with a null document id, is
+ *      re-keyed by the next observation of the document that wrote it. It
+ *      must be the same row — a new one beside it would double the corpus and
+ *      leave the old row unreachable.
+ *   2. Two documents under one docket become two rows from then on.
+ *
+ * So every case here runs the adapter's own build path against a stubbed
+ * publisher and feeds what it produces to the real pipeline. A hand-written
+ * `IngestionResult` would prove only that the pipeline works on the fields
+ * this file chose to give it.
+ */
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { eq, sql } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/bun-sql";
+
+import { authRelationsPart } from "@/api/db/auth-schema";
+import type { ScopedDb } from "@/api/db/safe-db";
+import { caseLawSources, relations } from "@/api/db/schema";
+import { ADAPTER_KEYS } from "@/api/handlers/case-law/consts";
+import type { AdapterKey } from "@/api/handlers/case-law/consts";
+import type { IngestionResult } from "@/api/handlers/case-law/ingestion/adapter";
+import { buildCzNsDecision } from "@/api/handlers/case-law/ingestion/adapters/cz-ns";
+import { buildCzNssDecision } from "@/api/handlers/case-law/ingestion/adapters/cz-nss";
+import type { ParsedRow } from "@/api/handlers/case-law/ingestion/adapters/cz-nss";
+import { euEcjAdapter } from "@/api/handlers/case-law/ingestion/adapters/eu-ecj";
+import { buildSkUsDecision } from "@/api/handlers/case-law/ingestion/adapters/sk-us";
+import { processDecision } from "@/api/handlers/case-law/ingestion/pipeline";
+import type { SafeId } from "@/api/lib/branded-types";
+import { isRecord } from "@/api/lib/type-guards";
+import { asFetchMock } from "@/api/tests/helpers/test-tool-set";
+
+const databaseUrl = process.env["DATABASE_URL"];
+const runPostgresTests = process.env["STELLA_RUN_POSTGRES_TESTS"] === "true";
+
+// ── Publisher stubs ──────────────────────────────────────
+
+/** A payload that opens like a real PDF; its body is not a parseable one. */
+const PDF_BYTES = new TextEncoder().encode("%PDF-1.4\n1 0 obj\n<<>>\n");
+
+const NS_DETAIL_PAGE = `<html><body>
+  <div>Rozsudek Nejvyššího soudu ze dne 28. 5. 2026, sp. zn. 30 Cdo 3000/2025.</div>
+</body></html>`;
+
+const NSS_SESSION_PAGE = `<html><body><form>
+  <input type="hidden" name="__RequestVerificationToken" value="identity-test" />
+</form></body></html>`;
+
+const NSS_DOCUMENT_PAGE = `<html><body>
+  <p>Nejvyšší správní soud rozhodl v senátě o kasační stížnosti.</p>
+  <p>Kasační stížnost se zamítá.</p>
+</body></html>`;
+
+const nssDetailPage = (ecli: string): string => `<html><body>
+  <div id="ecli"><span class="det-textval" title="${ecli}">${ecli}</span></div>
+  <div id="datumvydanirozhodnuti"><span class="det-textval">10.06.2026</span></div>
+</body></html>`;
+
+/**
+ * One stub for every publisher these cases touch, dispatching on the host each
+ * adapter builds its own URLs from. Bodies are the shortest thing each build
+ * path accepts: what is under test is which identity the result carries, not
+ * how well its document parses.
+ */
+const installPublisherStub = (): (() => void) => {
+  const originalFetch = globalThis.fetch;
+
+  globalThis.fetch = asFetchMock(
+    (input: string | URL | Request): Promise<Response> => {
+      const url = new URL(input instanceof Request ? input.url : String(input));
+      if (url.pathname.startsWith("/docDownload/")) {
+        return Promise.resolve(
+          new Response(PDF_BYTES, {
+            headers: { "Content-Type": "application/pdf" },
+          }),
+        );
+      }
+      if (url.pathname.includes("/WebPrint/")) {
+        // The print page is enrichment; without it the decision still carries
+        // the detail page's metadata, which is all these cases read.
+        return Promise.resolve(new Response(null, { status: 404 }));
+      }
+      if (url.pathname.includes("/WebSearch/")) {
+        return Promise.resolve(
+          new Response(NS_DETAIL_PAGE, {
+            headers: { "Content-Type": "text/html" },
+          }),
+        );
+      }
+      if (url.pathname.startsWith("/DokumentDetail/Index/")) {
+        const documentId = url.pathname.split("/").at(-1) ?? "";
+        return Promise.resolve(
+          new Response(nssDetailPage(`ECLI:CZ:NSS:2026:${documentId}`), {
+            headers: { "Content-Type": "text/html" },
+          }),
+        );
+      }
+      if (url.pathname.startsWith("/DokumentOriginal/")) {
+        return Promise.resolve(
+          new Response(NSS_DOCUMENT_PAGE, {
+            headers: { "Content-Type": "text/html" },
+          }),
+        );
+      }
+      if (url.hostname === "vyhledavac.nssoud.cz") {
+        return Promise.resolve(
+          new Response(NSS_SESSION_PAGE, {
+            headers: { "Content-Type": "text/html" },
+          }),
+        );
+      }
+      return Promise.resolve(
+        new Response(`unexpected request: ${url.toString()}`, { status: 500 }),
+      );
+    },
+  );
+
+  return () => {
+    globalThis.fetch = originalFetch;
+  };
+};
+
+// ── Per-source documents ─────────────────────────────────
+
+const NSS_SESSION = {
+  cookies: "",
+  token: "identity-test",
+  formFields: new Map<string, string>(),
+};
+
+const czNssRow = (documentId: string) =>
+  ({
+    caseNumber: "1 Az 4/2026",
+    decisionDate: "10.06.2026",
+    decisionType: "Rozsudek",
+    outcome: undefined,
+    documentUrl: `https://vyhledavac.nssoud.cz/DokumentDetail/Index/${documentId}`,
+    documentId,
+  }) as const satisfies ParsedRow;
+
+const ECJ_MANIFESTATION = new TextEncoder().encode(
+  "<html><body><p>The Court (First Chamber) rules as follows.</p></body></html>",
+);
+
+/** Rebuild one CJEU variant from a stored manifestation, as a re-parse does. */
+const ecjDecision = async (celex: string): Promise<IngestionResult> => {
+  const outcome = await euEcjAdapter.reparseStoredRaw?.({
+    raw: ECJ_MANIFESTATION,
+    contentType: "application/xhtml+xml",
+    caseNumber: "C-128/21",
+    sourceDocumentId: null,
+    language: "en",
+    court: "Court of Justice",
+    ecli: `ECLI:EU:C:2024:${celex.slice(-3)}`,
+    decisionDate: "2024-01-18",
+    decisionType: "judgment",
+    sourceUrl: `https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:${celex}`,
+    documentUrl: null,
+    metadata: { celex },
+  });
+  if (outcome?.type !== "parsed") {
+    throw new Error(`eu-ecj re-parse rejected ${celex}`);
+  }
+  return outcome.result;
+};
+
+const skUsDocument = (documentId: string, ecli: string) => ({
+  documentId,
+  mkDocumentType: "Rozhodnutie - Nález",
+  mkRSAPNumberOfFile: "PL. ÚS 4/2020",
+  mkECLI: ecli,
+  mkDateOfDecision: "03/12/2020 00:00:00",
+  mkFormOfDecision: "Nález",
+});
+
+/**
+ * Two documents one publisher files under one docket, built through the
+ * adapter that ingests them. The pair is the point: keyed on the docket they
+ * were one row, and the first of them is what the stored row was written from.
+ */
+type SourceCase = {
+  readonly adapterKey: AdapterKey;
+  readonly documents: readonly [
+    () => Promise<IngestionResult>,
+    () => Promise<IngestionResult>,
+  ];
+};
+
+const built = async (outcome: {
+  type: string;
+  decision?: IngestionResult;
+}): Promise<IngestionResult> => {
+  if (outcome.decision === undefined) {
+    throw new Error(`adapter produced no decision: ${outcome.type}`);
+  }
+  return await Promise.resolve(outcome.decision);
+};
+
+const SOURCE_CASES = [
+  {
+    adapterKey: ADAPTER_KEYS.SK_US,
+    documents: [
+      async () =>
+        await built(
+          await buildSkUsDecision(
+            skUsDocument(
+              "7964d54e-6708-48e9-92cc-5cc400aab1e3",
+              "ECLI:SK:USSR:2020:PL.US.4.2020.1",
+            ),
+          ),
+        ),
+      async () =>
+        await built(
+          await buildSkUsDecision(
+            skUsDocument(
+              "2d6903ee-0dd6-4281-8edc-8c814a52b0b1",
+              "ECLI:SK:USSR:2020:PL.US.4.2020.2",
+            ),
+          ),
+        ),
+    ],
+  },
+  {
+    adapterKey: ADAPTER_KEYS.CZ_NS,
+    documents: [
+      async () =>
+        await built(
+          await buildCzNsDecision({
+            unid: "05D11F4FB3ACC585C1258E27004D2F09",
+            caseNumber: "30 Cdo 3000/2025",
+          }),
+        ),
+      async () =>
+        await built(
+          await buildCzNsDecision({
+            unid: "137FECBC92321C61C1258E27004D2ECB",
+            caseNumber: "30 Cdo 3000/2025",
+          }),
+        ),
+    ],
+  },
+  {
+    adapterKey: ADAPTER_KEYS.CZ_NSS,
+    documents: [
+      async () =>
+        await built(
+          await buildCzNssDecision({
+            row: czNssRow("784237"),
+            session: NSS_SESSION,
+            signal: AbortSignal.timeout(30_000),
+          }),
+        ),
+      async () =>
+        await built(
+          await buildCzNssDecision({
+            row: czNssRow("783863"),
+            session: NSS_SESSION,
+            signal: AbortSignal.timeout(30_000),
+          }),
+        ),
+    ],
+  },
+  {
+    adapterKey: ADAPTER_KEYS.EU_ECJ,
+    documents: [
+      async () => await ecjDecision("62021CJ0128"),
+      async () => await ecjDecision("62021CO0128"),
+    ],
+  },
+] as const satisfies readonly SourceCase[];
+
+/**
+ * The raw payload is dropped before storing: object storage is not what these
+ * cases are about, and a failed upload would only add noise to them.
+ */
+const withoutRawPayload = (decision: IngestionResult): IngestionResult => ({
+  ...decision,
+  sourceRaw: undefined,
+  sourceRawBytes: undefined,
+  sourceRawContentType: undefined,
+});
+
+/**
+ * The row this adapter used to write for that document: everything it writes
+ * today, minus the identity it did not yet state.
+ */
+const asLegacyRow = (
+  decision: IngestionResult,
+  keepEcli: boolean,
+): IngestionResult => ({
+  ...withoutRawPayload(decision),
+  legacySourceUrls: undefined,
+  sourceDocumentId: undefined,
+  ...(keepEcli ? {} : { ecli: undefined }),
+});
+
+type StoredRow = { id: string; sourceDocumentId: string | null };
+
+if (!databaseUrl || !runPostgresTests) {
+  describe.skip("publisher document identity migration", () => {
+    test("requires STELLA_RUN_POSTGRES_TESTS=true and DATABASE_URL", () => {
+      expect(runPostgresTests && Boolean(databaseUrl)).toBe(false);
+    });
+  });
+} else {
+  describe("publisher document identity migration", () => {
+    const db = drizzle(databaseUrl, {
+      relations: { ...relations, ...authRelationsPart },
+    });
+    const scopedDb: ScopedDb = async (callback) =>
+      await db.transaction(async (tx) => await callback(tx));
+    const createdSourceIds: SafeId<"caseLawSource">[] = [];
+    let restoreFetch: (() => void) | undefined;
+
+    beforeAll(() => {
+      restoreFetch = installPublisherStub();
+    });
+
+    afterAll(async () => {
+      restoreFetch?.();
+      for (const sourceId of createdSourceIds) {
+        // oxlint-disable-next-line no-await-in-loop -- test teardown of a handful of source rows
+        await db.delete(caseLawSources).where(eq(caseLawSources.id, sourceId));
+      }
+    });
+
+    const createSource = async (
+      adapterKey: AdapterKey,
+    ): Promise<SafeId<"caseLawSource">> => {
+      const [source] = await db
+        .insert(caseLawSources)
+        .values({
+          adapterKey: `${adapterKey}-identity-${Bun.randomUUIDv7()}`,
+          name: `${adapterKey} identity migration`,
+          enabled: false,
+        })
+        .returning({ id: caseLawSources.id });
+      if (!source) {
+        throw new Error("expected source row");
+      }
+      createdSourceIds.push(source.id);
+      return source.id;
+    };
+
+    const storedRows = async (
+      sourceId: SafeId<"caseLawSource">,
+    ): Promise<StoredRow[]> => {
+      const rows = await db.execute(sql`
+        SELECT id::text AS id, source_document_id AS "sourceDocumentId"
+        FROM case_law_decisions
+        WHERE source_id = ${sourceId}
+        ORDER BY source_document_id
+      `);
+      const list = Array.isArray(rows) ? rows : [];
+      return list.map((row) => ({
+        id: isRecord(row) ? String(row["id"]) : "",
+        sourceDocumentId:
+          isRecord(row) && typeof row["sourceDocumentId"] === "string"
+            ? row["sourceDocumentId"]
+            : null,
+      }));
+    };
+
+    const store = async (
+      sourceId: SafeId<"caseLawSource">,
+      input: IngestionResult,
+      order: bigint,
+    ): Promise<void> => {
+      await processDecision({
+        input,
+        observationOrder: order,
+        sourceId,
+        scopedDb,
+        observedAt: new Date(`2026-08-11T12:00:0${String(order)}.000Z`),
+      });
+    };
+
+    for (const { adapterKey, documents } of SOURCE_CASES) {
+      // Both shapes a stored docket-keyed row comes in. The ECLI gives the
+      // pipeline a second way to recognise the document that wrote the row, so
+      // the row without one is what proves the adapter's URL hint carries the
+      // migration on its own.
+      for (const keepEcli of [true, false]) {
+        test(`${adapterKey}: a docket-keyed row is re-keyed by its own document${keepEcli ? "" : ", ECLI or no ECLI"}`, async () => {
+          const sourceId = await createSource(adapterKey);
+          const [firstDocument, secondDocument] = documents;
+          const first = withoutRawPayload(await firstDocument());
+          const second = withoutRawPayload(await secondDocument());
+
+          expect(first.sourceDocumentId).toBeDefined();
+          expect(second.sourceDocumentId).not.toBe(first.sourceDocumentId);
+          // The premise of the collapse: one docket, two published documents.
+          expect(second.caseNumber).toBe(first.caseNumber);
+          expect(second.language).toBe(first.language);
+
+          await store(sourceId, asLegacyRow(first, keepEcli), 1n);
+          const legacy = await storedRows(sourceId);
+          expect(legacy).toHaveLength(1);
+          expect(legacy.at(0)?.sourceDocumentId).toBeNull();
+
+          await store(sourceId, first, 2n);
+          const rekeyed = await storedRows(sourceId);
+          // Same row, now carrying the publisher's id: a second row here would
+          // double every docket in the corpus and orphan the first.
+          expect(rekeyed).toHaveLength(1);
+          expect(rekeyed.at(0)?.id).toBe(legacy.at(0)?.id ?? "");
+          expect(rekeyed.at(0)?.sourceDocumentId).toBe(
+            first.sourceDocumentId ?? "",
+          );
+
+          await store(sourceId, second, 3n);
+          const both = await storedRows(sourceId);
+          // And the docket's other document is now a row of its own, which is
+          // the collapse being undone.
+          expect(both).toHaveLength(2);
+          expect(both.map(({ sourceDocumentId }) => sourceDocumentId)).toEqual(
+            [
+              first.sourceDocumentId ?? "",
+              second.sourceDocumentId ?? "",
+            ].sort(),
+          );
+          expect(both.map(({ id }) => id)).toContain(legacy.at(0)?.id ?? "");
+
+          // Re-observing either document changes nothing: the crawl and the
+          // reconciliation both walk this source repeatedly.
+          await store(sourceId, first, 4n);
+          await store(sourceId, second, 5n);
+          expect(await storedRows(sourceId)).toEqual(both);
+        }, 60_000);
+      }
+    }
+  });
+}


### PR DESCRIPTION
Four sources stored rows keyed only on `(caseNumber, language)`, so distinct publisher documents sharing a docket collapsed into one row (measured instances: 19 DMS documents under one plenary docket; judgment and order under one CJEU number). This adopts each publisher's own document identity, with one shared mechanism and one migration story.

**Commit 1 — publisher document identities** (sk-us: DMS documentId; eu-ecj: CELEX+language; cz-ns: Domino unid; cz-nss: portal documentId). Each id flows through the source's single exported identity rule, used by the crawl and the reconciliation listing alike, and is bounded by `isPersistableSourceDocumentId` at the publisher boundary. Existing rows migrate in place: every build path passes the row's deterministic legacy URL via `legacySourceUrls`, so a re-observed docket-keyed row gains the id (same row, no duplicate) while a second document under the same docket becomes a second row. A table-driven db test proves the invariant per source through the real `processDecision` — including the ECLI-less case, which is what shows the URL hint alone carries the migration — and was verified non-vacuous (removing one source's hint fails its cases with a duplicate insert).

No bulk backfill: post-deploy, the reconciliation loop reads not-yet-re-keyed rows as missing and re-fetches each document once, which re-keys it; the settled-slice recheck walks all history on its standing cadence. This is a bounded, rate-limited, one-time re-observation per source, stated here deliberately as the expected traffic profile.

The eu-ecj `shared_identity` event is removed with its tests: it existed to measure this collapse, and under the new key it could only report zero.

**Commit 2 — page-origin correctness.** The sk-courts endpoint is 1-indexed and clamps below (verified live), while the crawl's paginated fetch was configured zero-indexed: every traversal re-read its first page and the live window covered 4,900 of its intended 5,000 items. Fixed at the class level: `zeroIndexed?: boolean` is replaced by a required `firstPage: 0 | 1` each adapter states exactly once, shared by its crawl and its listing walk — the defect was precisely that the two stated different origins. Persisted cursors keep their meaning (item offsets); the fix changes only the page computed from them, the crawl's position advances by exactly one page at cutover, and nothing re-walks. The single 100-item page a mid-run backfill walk would skip at the boundary is refilled by this source's per-date reconciliation ledger, which enumerates decision dates independently of the cursor. Tests drive the real adapter against a clamping stub (verified non-vacuous: under the old origin they fail, one exactly at 4,900 vs 5,000) and the conformance stub was corrected — it had modelled the bug.

Suites: adapters 214 green, postgres-gated ingestion 78 green, whole case-law handler tree 963 green. Ratchet and typecheck baselines untouched.
