### PR TITLE
feat(case-law): require the adapter capability set

### DIFF
--- a/apps/api/src/handlers/case-law/ingestion/adapters/adapter-registry.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/adapter-registry.test.ts
@@ -10,7 +10,83 @@ import {
   listAdapterKeys as listLazyAdapterKeys,
   loadAdapterByKey,
 } from "@/api/handlers/case-law/ingestion/adapters/adapter-registry-lazy";
-import { ADAPTER_KEYS } from "@/api/lib/legal-search/ingestion-constants";
+import {
+  ADAPTER_KEYS,
+  type AdapterKey,
+} from "@/api/lib/legal-search/ingestion-constants";
+
+/**
+ * The adapters allowed to answer `reconciliation` with `unsupported`, as an
+ * exact list rather than a ceiling.
+ *
+ * Exact in both directions on purpose. A name appearing here that nobody put
+ * there means a new adapter shipped without the capability, and a name here
+ * that no longer declares `unsupported` means the capability landed and the
+ * exemption outlived it. Neither may pass quietly, so the test compares sets
+ * and prints the remedy for whichever side moved.
+ */
+const RECONCILIATION_UNSUPPORTED_ADAPTERS = [ADAPTER_KEYS.AT_COURTS] as const;
+
+describe("case-law adapter capabilities", () => {
+  test("every registered adapter exposes a total count", () => {
+    // The type makes an omission uncompilable; this is the registry-level
+    // half, so an adapter reaching the registry through a widened type still
+    // has to carry a callable.
+    const missing = listAdapters().flatMap((adapter) =>
+      typeof adapter.getTotalCount === "function"
+        ? []
+        : [
+            `${adapter.key} declares no getTotalCount; every adapter must implement it`,
+          ],
+    );
+    expect(missing).toEqual([]);
+  });
+
+  test("only the pinned adapters answer reconciliation with unsupported", () => {
+    const declaredUnsupported = listAdapters().flatMap((adapter) =>
+      adapter.reconciliation.type === "unsupported" ? [adapter.key] : [],
+    );
+    const pinned: readonly AdapterKey[] = RECONCILIATION_UNSUPPORTED_ADAPTERS;
+
+    const unexpected = declaredUnsupported.flatMap((key) =>
+      pinned.includes(key)
+        ? []
+        : [
+            `${key} declares reconciliation unsupported; a new adapter must implement the capability, not join this list`,
+          ],
+    );
+    expect(unexpected).toEqual([]);
+
+    const stale = pinned.flatMap((key) =>
+      declaredUnsupported.includes(key)
+        ? []
+        : [
+            `${key} now implements reconciliation; remove ${key} from this list and delete ReconciliationUnsupported if the list is empty`,
+          ],
+    );
+    expect(stale).toEqual([]);
+  });
+
+  test("every reconcilable adapter states a walkable slice order", () => {
+    for (const adapter of listAdapters()) {
+      const { reconciliation } = adapter;
+      if (reconciliation.type === "unsupported") {
+        expect(reconciliation.reason.length).toBeGreaterThan(0);
+        continue;
+      }
+      // Exercised, not merely present: a capability whose first slice does not
+      // sort before its tip has no walk order for the ledger to compare on.
+      expect(reconciliation.firstSlice.length).toBeGreaterThan(0);
+      expect(
+        reconciliation.previousSlice(reconciliation.firstSlice),
+      ).toBeNull();
+      expect(reconciliation.tipWindowDays).toBeGreaterThan(0);
+      expect(
+        reconciliation.sliceOf(new Date()) >= reconciliation.firstSlice,
+      ).toBe(true);
+    }
+  });
+});
 
 describe("case-law adapter registries", () => {
   test("eager and lazy registries expose the same closed adapter set", () => {

--- a/apps/api/src/handlers/case-law/ingestion/adapters/at-courts.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/at-courts.ts
@@ -6,6 +6,9 @@ import {
 import {
   defineSourceAdapter,
   EMPTY_AST,
+  SOURCE_TOTAL_PROBE_FAILURE,
+  sourceTotalProbeFailed,
+  sourceTotalRead,
 } from "@/api/handlers/case-law/ingestion/adapter";
 import type { IngestionResult } from "@/api/handlers/case-law/ingestion/adapter";
 import { createPagePaginatedFetch } from "@/api/handlers/case-law/ingestion/adapters/pagination";
@@ -18,6 +21,7 @@ import {
   stripHtml,
   toOptionalValue,
 } from "@/api/handlers/case-law/ingestion/adapters/utils";
+import { errorTag } from "@/api/lib/errors/utils";
 import { fetchWithTimeout } from "@/api/lib/fetch";
 import { logger } from "@/api/lib/observability/logger";
 import { restrictOutboundUrl } from "@/api/lib/restrict-outbound-url";
@@ -463,18 +467,20 @@ export const atCourtsAdapter = defineSourceAdapter({
         },
       );
       if (!response.ok) {
-        return null;
+        return sourceTotalProbeFailed(SOURCE_TOTAL_PROBE_FAILURE.HTTP_STATUS);
       }
       const json: unknown = await response.json();
       if (!isRisApiResponse(json)) {
-        return null;
+        return sourceTotalProbeFailed(
+          SOURCE_TOTAL_PROBE_FAILURE.UNREADABLE_PAYLOAD,
+        );
       }
       const raw = json.OgdSearchResult?.OgdDocumentResults?.Hits?.["#text"];
-      const parsed =
-        typeof raw === "string" ? Number.parseInt(raw, 10) : Number.NaN;
-      return Number.isNaN(parsed) || parsed <= 0 ? null : parsed;
-    } catch {
-      return null;
+      return typeof raw === "string"
+        ? sourceTotalRead(Number.parseInt(raw, 10))
+        : sourceTotalProbeFailed(SOURCE_TOTAL_PROBE_FAILURE.UNREADABLE_PAYLOAD);
+    } catch (error) {
+      return { type: "probe-failed", errorTag: errorTag(error) };
     }
   },
 

--- a/apps/api/src/handlers/case-law/ingestion/adapters/at-courts.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/at-courts.ts
@@ -478,6 +478,13 @@ export const atCourtsAdapter = defineSourceAdapter({
     }
   },
 
+  reconciliation: {
+    type: "unsupported",
+    reason:
+      "adapter exists but has not been validated in production yet, so it " +
+      "runs no crawl for a reconciliation loop to reconcile against",
+  },
+
   fetchPage: createPagePaginatedFetch<RisApiResponse>({
     adapterKey: ADAPTER_KEYS.AT_COURTS,
     pageSize: PAGE_SIZE,

--- a/apps/api/src/handlers/case-law/ingestion/adapters/cz-ns-reconciliation.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/cz-ns-reconciliation.test.ts
@@ -14,7 +14,6 @@ import {
   parseListingIdentityKey,
   SOURCE_DOCUMENT_ID_MAX_LENGTH,
 } from "@/api/handlers/case-law/ingestion/adapter";
-import type { SourceReconciliation } from "@/api/handlers/case-law/ingestion/adapter";
 import {
   CZ_NS_FIRST_SLICE,
   buildCzNsDecision,
@@ -22,16 +21,11 @@ import {
   czNsListingIdentity,
 } from "@/api/handlers/case-law/ingestion/adapters/cz-ns";
 import type { CzNsListingRow } from "@/api/handlers/case-law/ingestion/adapters/cz-ns";
+import { requireReconciliation } from "@/api/handlers/case-law/ingestion/adapters/test-utils";
 import { tipWindowSlices } from "@/api/handlers/case-law/ingestion/reconciliation-plan";
 import { asFetchMock } from "@/api/tests/helpers/test-tool-set";
 
-const reconciliation = ((): SourceReconciliation => {
-  const capability = czNsAdapter.reconciliation;
-  if (capability === undefined) {
-    throw new TypeError("cz-ns must declare the reconciliation capability");
-  }
-  return capability;
-})();
+const reconciliation = requireReconciliation(czNsAdapter);
 
 // ── Production-shaped fixtures ──────────────────────────────
 //

--- a/apps/api/src/handlers/case-law/ingestion/adapters/cz-ns.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/cz-ns.ts
@@ -10,6 +10,9 @@ import {
   defineSourceAdapter,
   EMPTY_AST,
   isPersistableSourceDocumentId,
+  SOURCE_TOTAL_PROBE_FAILURE,
+  sourceTotalProbeFailed,
+  sourceTotalRead,
 } from "@/api/handlers/case-law/ingestion/adapter";
 import type {
   EmptyAst,
@@ -34,6 +37,7 @@ import {
 import { parseNsDecisionHtml } from "@/api/handlers/case-law/ingestion/parsers/cz-ns";
 import { addUtcDays, isoCalendarDay, toUtcDateString } from "@/api/lib/dates";
 import { AdapterFetchError } from "@/api/lib/errors/tagged-errors";
+import { errorTag } from "@/api/lib/errors/utils";
 import { fetchWithTimeout } from "@/api/lib/fetch";
 import { logger } from "@/api/lib/observability/logger";
 import { isRecord } from "@/api/lib/type-guards";
@@ -775,22 +779,25 @@ export const czNsAdapter = defineSourceAdapter({
         timeoutMs: ADAPTER_TIMEOUT.REQUEST,
       });
       if (!response.ok) {
-        return null;
+        return sourceTotalProbeFailed(SOURCE_TOTAL_PROBE_FAILURE.HTTP_STATUS);
       }
 
       const json = await response.json();
       if (!isDominoViewResponse(json)) {
-        return null;
+        return sourceTotalProbeFailed(
+          SOURCE_TOTAL_PROBE_FAILURE.UNREADABLE_PAYLOAD,
+        );
       }
       const raw = json["@toplevelentries"];
       if (!raw) {
-        return null;
+        return sourceTotalProbeFailed(
+          SOURCE_TOTAL_PROBE_FAILURE.UNREADABLE_PAYLOAD,
+        );
       }
 
-      const parsed = Number.parseInt(raw, 10);
-      return Number.isNaN(parsed) ? null : parsed;
-    } catch {
-      return null;
+      return sourceTotalRead(Number.parseInt(raw, 10));
+    } catch (error) {
+      return { type: "probe-failed", errorTag: errorTag(error) };
     }
   },
 

--- a/apps/api/src/handlers/case-law/ingestion/adapters/cz-nss.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/cz-nss.test.ts
@@ -26,6 +26,7 @@ import {
   parseResultRows,
 } from "@/api/handlers/case-law/ingestion/adapters/cz-nss";
 import type { ParsedRow } from "@/api/handlers/case-law/ingestion/adapters/cz-nss";
+import { requireReconciliation } from "@/api/handlers/case-law/ingestion/adapters/test-utils";
 import { tipWindowSlices } from "@/api/handlers/case-law/ingestion/reconciliation-plan";
 import {
   listingIdentityKey,
@@ -33,10 +34,7 @@ import {
 } from "@/api/lib/legal-search/ingestion-types";
 import { asFetchMock } from "@/api/tests/helpers/test-tool-set";
 
-const { reconciliation } = czNssAdapter;
-if (reconciliation === undefined) {
-  throw new Error("cz-nss must declare a reconciliation capability");
-}
+const reconciliation = requireReconciliation(czNssAdapter);
 
 const BASE_URL = "https://vyhledavac.nssoud.cz";
 

--- a/apps/api/src/handlers/case-law/ingestion/adapters/cz-nss.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/cz-nss.ts
@@ -1445,12 +1445,6 @@ export const czNssAdapter = defineSourceAdapter({
           };
         }
 
-        // No coverage row here: the reconciliation loop owns this source's
-        // ledger. It keys the same `(source, YYYY-MM-DD)` rows but counts
-        // something else — keyable identities listed against identities held,
-        // not items one crawl page walked — so a crawl-side write would
-        // overwrite the loop's answer with a different question's.
-
         // No more pages; advance to next day
         const next = nextDay(date);
         return {

--- a/apps/api/src/handlers/case-law/ingestion/adapters/cz-nss.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/cz-nss.ts
@@ -10,6 +10,9 @@ import {
   defineSourceAdapter,
   EMPTY_AST,
   isPersistableSourceDocumentId,
+  SOURCE_TOTAL_PROBE_FAILURE,
+  sourceTotalProbeFailed,
+  sourceTotalRead,
 } from "@/api/handlers/case-law/ingestion/adapter";
 import type {
   EmptyAst,
@@ -29,6 +32,7 @@ import {
 import { parseNssDecisionHtml } from "@/api/handlers/case-law/ingestion/parsers/cz-nss";
 import { addUtcDays, isoCalendarDay, toUtcDateString } from "@/api/lib/dates";
 import { AdapterFetchError } from "@/api/lib/errors/tagged-errors";
+import { errorTag } from "@/api/lib/errors/utils";
 import { fetchWithTimeout } from "@/api/lib/fetch";
 import { logger } from "@/api/lib/observability/logger";
 import { isRecord } from "@/api/lib/type-guards";
@@ -1332,16 +1336,18 @@ export const czNssAdapter = defineSourceAdapter({
       });
 
       if (!response.ok) {
-        return null;
+        return sourceTotalProbeFailed(SOURCE_TOTAL_PROBE_FAILURE.HTTP_STATUS);
       }
 
-      const count = statedResultCount(await response.text());
-
       // A zero here is not a corpus of nothing; it is a search that did not
-      // run. The benchmark reports nothing rather than a false floor.
-      return count === null || count === 0 ? null : count;
-    } catch {
-      return null;
+      // run, which `sourceTotalRead` refuses along with every other value a
+      // total cannot be.
+      const count = statedResultCount(await response.text());
+      return count === null
+        ? sourceTotalProbeFailed(SOURCE_TOTAL_PROBE_FAILURE.UNREADABLE_PAYLOAD)
+        : sourceTotalRead(count);
+    } catch (error) {
+      return { type: "probe-failed", errorTag: errorTag(error) };
     }
   },
 

--- a/apps/api/src/handlers/case-law/ingestion/adapters/cz-regional.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/cz-regional.ts
@@ -11,6 +11,9 @@ import {
   defineSourceAdapter,
   EMPTY_AST,
   isPersistableSourceDocumentId,
+  SOURCE_TOTAL_PROBE_FAILURE,
+  sourceTotalProbeFailed,
+  sourceTotalRead,
 } from "@/api/handlers/case-law/ingestion/adapter";
 import type {
   EmptyAst,
@@ -945,14 +948,18 @@ export const czRegionalAdapter = defineSourceAdapter({
       );
       let total = 0;
       for (const sum of perYear) {
+        // One unreadable year makes the sum a floor rather than a total, and a
+        // floor recorded as a total reads as coverage the corpus does not have.
         if (sum === null) {
-          return null;
+          return sourceTotalProbeFailed(
+            SOURCE_TOTAL_PROBE_FAILURE.UNREADABLE_PAYLOAD,
+          );
         }
         total += sum;
       }
-      return total > 0 ? total : null;
-    } catch {
-      return null;
+      return sourceTotalRead(total);
+    } catch (error) {
+      return { type: "probe-failed", errorTag: errorTag(error) };
     }
   },
 

--- a/apps/api/src/handlers/case-law/ingestion/adapters/cz-us-reconciliation.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/cz-us-reconciliation.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable typescript-eslint/promise-function-async -- fetch mock callbacks return Promise.resolve without being async */
-import { Result, panic } from "better-result";
+import { Result } from "better-result";
 import {
   afterAll,
   afterEach,
@@ -18,13 +18,13 @@ import {
 import type {
   ReconciliationListingItem,
   ReconciliationSlicePage,
-  SourceReconciliation,
 } from "@/api/handlers/case-law/ingestion/adapter";
 import {
   czUsAdapter,
   czUsListingIdentity,
 } from "@/api/handlers/case-law/ingestion/adapters/cz-us";
 import type { ListedDecision } from "@/api/handlers/case-law/ingestion/adapters/cz-us";
+import { requireReconciliation } from "@/api/handlers/case-law/ingestion/adapters/test-utils";
 import { asFetchMock } from "@/api/tests/helpers/test-tool-set";
 
 /** Frozen so "the current year" and "yesterday" are the same in every test. */
@@ -32,8 +32,7 @@ const NOW = new Date("2026-08-08T12:00:00.000Z");
 const LATEST_CLOSED_DAY = "7.8.2026";
 const LISTING_PAGE_SIZE = 80;
 
-const reconciliation: SourceReconciliation =
-  czUsAdapter.reconciliation ?? panic("cz-us states no reconciliation");
+const reconciliation = requireReconciliation(czUsAdapter);
 
 // ── Publisher fixtures ───────────────────────────────────
 

--- a/apps/api/src/handlers/case-law/ingestion/adapters/cz-us.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/cz-us.test.ts
@@ -330,11 +330,9 @@ describe("czUsAdapter.fetchPage", () => {
     expect(page.nextCursor).toMatch(
       /^search:historical:2026-08-07:1993:verify:0:0:[a-f0-9]+$/u,
     );
-    expect(page.coverage).toBeUndefined();
 
     const verified = unwrap(await czUsAdapter.fetchPage(page.nextCursor, {}));
     expect(verified.nextCursor).toBe(historicalCursor(1994));
-    expect(verified.coverage).toBeUndefined();
   });
 
   test("keeps multiple published decisions under one docket distinct", async () => {
@@ -467,7 +465,6 @@ describe("czUsAdapter.fetchPage", () => {
     expect(first.nextCursor).toMatch(
       /^search:historical:\d{4}-\d{2}-\d{2}:2024:collect:1:[a-f0-9]+:-$/u,
     );
-    expect(first.coverage).toBeUndefined();
 
     installSearchMock({
       rows: [
@@ -488,7 +485,6 @@ describe("czUsAdapter.fetchPage", () => {
       reported: 42,
     });
     const last = unwrap(await czUsAdapter.fetchPage(first.nextCursor, {}));
-    expect(last.coverage).toBeUndefined();
     expect(last.nextCursor).toMatch(
       /^search:historical:\d{4}-\d{2}-\d{2}:2024:verify:0:0:[a-f0-9]+$/u,
     );
@@ -519,7 +515,6 @@ describe("czUsAdapter.fetchPage", () => {
       await czUsAdapter.fetchPage(verifyFirst.nextCursor, {}),
     );
     expect(verified.nextCursor).toBe(historicalCursor(2025));
-    expect(verified.coverage).toBeUndefined();
   });
 
   test("restarts a traversal when a saved result page disappears", async () => {
@@ -564,7 +559,6 @@ describe("czUsAdapter.fetchPage", () => {
     const collected = unwrap(
       await czUsAdapter.fetchPage(historicalCursor(2024), {}),
     );
-    expect(collected.coverage).toBeUndefined();
 
     installSearchMock({
       rows: [
@@ -581,7 +575,6 @@ describe("czUsAdapter.fetchPage", () => {
       await czUsAdapter.fetchPage(collected.nextCursor, {}),
     );
 
-    expect(changed.coverage).toBeUndefined();
     expect(changed.nextCursor).toBe(historicalCursor(2024));
   });
 
@@ -598,7 +591,6 @@ describe("czUsAdapter.fetchPage", () => {
 
     expect(submitted?.get("ctl00$MainContent$decidedFrom")).toBe("1.1.1993");
     expect(page.nextCursor).toBe(historicalCursor(1994));
-    expect(page.coverage).toBeUndefined();
   });
 
   test("finishing the current decision year hands over to availability polling", async () => {
@@ -643,7 +635,7 @@ describe("czUsAdapter.fetchPage", () => {
       },
     });
 
-    const page = unwrap(
+    unwrap(
       await czUsAdapter.fetchPage(recentCursor("2026-06-24", "2026-08-07"), {}),
     );
 
@@ -653,7 +645,6 @@ describe("czUsAdapter.fetchPage", () => {
     expect(submitted?.get("ctl00$MainContent$availableFrom")).toBe("24.6.2026");
     expect(submitted?.get("ctl00$MainContent$availableTo")).toBe("7.8.2026");
     expect(submitted?.get("ctl00$MainContent$decidedFrom")).toBeNull();
-    expect(page.coverage).toBeUndefined();
   });
 
   test("abstract failure does not drop a listed decision", async () => {

--- a/apps/api/src/handlers/case-law/ingestion/adapters/cz-us.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/cz-us.ts
@@ -11,6 +11,9 @@ import {
   defineSourceAdapter,
   EMPTY_AST,
   isPersistableSourceDocumentId,
+  SOURCE_TOTAL_PROBE_FAILURE,
+  sourceTotalProbeFailed,
+  sourceTotalRead,
 } from "@/api/handlers/case-law/ingestion/adapter";
 import type {
   EmptyAst,
@@ -28,6 +31,7 @@ import {
   stripHtml,
 } from "@/api/handlers/case-law/ingestion/adapters/utils";
 import { parseUsDecisionHtml } from "@/api/handlers/case-law/ingestion/parsers/cz-us";
+import { errorTag } from "@/api/lib/errors/utils";
 import { fetchWithTimeout } from "@/api/lib/fetch";
 import { isRecord, isUnknownArray } from "@/api/lib/type-guards";
 
@@ -1532,7 +1536,7 @@ export const czUsAdapter = defineSourceAdapter({
         timeoutMs: ADAPTER_TIMEOUT.REQUEST,
       });
       if (!first.ok) {
-        return null;
+        return sourceTotalProbeFailed(SOURCE_TOTAL_PROBE_FAILURE.HTTP_STATUS);
       }
       const cookies = first.headers
         .getSetCookie()
@@ -1549,7 +1553,9 @@ export const czUsAdapter = defineSourceAdapter({
       const generator = hidden("__VIEWSTATEGENERATOR");
       const validation = hidden("__EVENTVALIDATION");
       if (viewState === null || validation === null) {
-        return null;
+        return sourceTotalProbeFailed(
+          SOURCE_TOTAL_PROBE_FAILURE.UNREADABLE_PAYLOAD,
+        );
       }
       const form = new URLSearchParams({
         __VIEWSTATE: viewState,
@@ -1574,7 +1580,7 @@ export const czUsAdapter = defineSourceAdapter({
         body: form.toString(),
       });
       if (submit.status !== 302 && !submit.ok) {
-        return null;
+        return sourceTotalProbeFailed(SOURCE_TOTAL_PROBE_FAILURE.HTTP_STATUS);
       }
       const results = await fetchWithTimeout(
         "https://nalus.usoud.cz/Search/Results.aspx",
@@ -1586,16 +1592,16 @@ export const czUsAdapter = defineSourceAdapter({
         },
       );
       if (!results.ok) {
-        return null;
+        return sourceTotalProbeFailed(SOURCE_TOTAL_PROBE_FAILURE.HTTP_STATUS);
       }
       const total = /z celkem (?<n>\d+)/u.exec(await results.text())?.groups?.[
         "n"
       ];
-      const parsed =
-        total === undefined ? Number.NaN : Number.parseInt(total, 10);
-      return Number.isNaN(parsed) || parsed <= 0 ? null : parsed;
-    } catch {
-      return null;
+      return total === undefined
+        ? sourceTotalProbeFailed(SOURCE_TOTAL_PROBE_FAILURE.UNREADABLE_PAYLOAD)
+        : sourceTotalRead(Number.parseInt(total, 10));
+    } catch (error) {
+      return { type: "probe-failed", errorTag: errorTag(error) };
     }
   },
 

--- a/apps/api/src/handlers/case-law/ingestion/adapters/cz-us.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/cz-us.ts
@@ -1609,8 +1609,7 @@ export const czUsAdapter = defineSourceAdapter({
    * The search form answers a decision-date range on its own, so what a year
    * holds is answerable without the crawl cursor ever reaching it: list the
    * year, key each record the way the ingest would, and compare against what
-   * is held. This loop is the only writer of coverage for this source; the
-   * crawl states no `SliceCoverage`.
+   * is held. This loop is the only writer of coverage for this source.
    */
   reconciliation: {
     firstSlice: CZ_US_FIRST_SLICE,

--- a/apps/api/src/handlers/case-law/ingestion/adapters/eu-ecj.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/eu-ecj.test.ts
@@ -9,8 +9,8 @@ import {
   euEcjAdapter as ecjAdapter,
   SPARQL_LIMIT,
 } from "@/api/handlers/case-law/ingestion/adapters/eu-ecj";
+import { requireReconciliation } from "@/api/handlers/case-law/ingestion/adapters/test-utils";
 import { tipWindowSlices } from "@/api/handlers/case-law/ingestion/reconciliation-plan";
-import type { SourceReconciliation } from "@/api/lib/legal-search/ingestion-types";
 import {
   listingIdentityKey,
   parseListingIdentityKey,
@@ -486,13 +486,7 @@ describe("euEcjAdapter.fetchPage", () => {
  * here so every test below exercises the capability the adapter actually
  * publishes, not a copy of it.
  */
-const reconciliation = ((): SourceReconciliation => {
-  const capability = ecjAdapter.reconciliation;
-  if (capability === undefined) {
-    throw new TypeError("eu-ecj must declare the reconciliation capability");
-  }
-  return capability;
-})();
+const reconciliation = requireReconciliation(ecjAdapter);
 
 /**
  * bun-types declares `.rejects.toThrow` as void, so awaiting it trips

--- a/apps/api/src/handlers/case-law/ingestion/adapters/eu-ecj.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/eu-ecj.ts
@@ -11,6 +11,9 @@ import {
   EMPTY_AST,
   isPersistableSourceDocumentId,
   STORED_RAW_REPARSE_REJECTION,
+  SOURCE_TOTAL_PROBE_FAILURE,
+  sourceTotalProbeFailed,
+  sourceTotalRead,
 } from "@/api/handlers/case-law/ingestion/adapter";
 import type {
   EmptyAst,
@@ -40,6 +43,7 @@ import {
   AdapterFetchError,
   TelemetryError,
 } from "@/api/lib/errors/tagged-errors";
+import { errorTag } from "@/api/lib/errors/utils";
 import { fetchWithTimeout } from "@/api/lib/fetch";
 import type { DecisionSection } from "@/api/lib/legal-search/document-types";
 import { logger } from "@/api/lib/observability/logger";
@@ -1255,24 +1259,31 @@ WHERE {
         body: new URLSearchParams({ query }).toString(),
       });
       if (!response.ok) {
-        return null;
+        return sourceTotalProbeFailed(SOURCE_TOTAL_PROBE_FAILURE.HTTP_STATUS);
       }
       const json: unknown = await response.json();
       if (!isRecord(json)) {
-        return null;
+        return sourceTotalProbeFailed(
+          SOURCE_TOTAL_PROBE_FAILURE.UNREADABLE_PAYLOAD,
+        );
       }
       const results = json["results"];
       if (!isRecord(results) || !Array.isArray(results["bindings"])) {
-        return null;
+        return sourceTotalProbeFailed(
+          SOURCE_TOTAL_PROBE_FAILURE.UNREADABLE_PAYLOAD,
+        );
       }
       const binding: unknown = results["bindings"].at(0);
       if (!isRecord(binding) || !isRecord(binding["n"])) {
-        return null;
+        return sourceTotalProbeFailed(
+          SOURCE_TOTAL_PROBE_FAILURE.UNREADABLE_PAYLOAD,
+        );
       }
-      const parsed = Number.parseInt(String(binding["n"]["value"]), 10);
-      return Number.isNaN(parsed) || parsed <= 0 ? null : parsed;
-    } catch {
-      return null;
+      return sourceTotalRead(
+        Number.parseInt(String(binding["n"]["value"]), 10),
+      );
+    } catch (error) {
+      return { type: "probe-failed", errorTag: errorTag(error) };
     }
   },
 

--- a/apps/api/src/handlers/case-law/ingestion/adapters/pl-courts-reconciliation.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/pl-courts-reconciliation.test.ts
@@ -20,6 +20,7 @@ import {
   plCourtsAdapter,
   plCourtsListingIdentity,
 } from "@/api/handlers/case-law/ingestion/adapters/pl-courts";
+import { requireReconciliation } from "@/api/handlers/case-law/ingestion/adapters/test-utils";
 import { tipWindowSlices } from "@/api/handlers/case-law/ingestion/reconciliation-plan";
 import { toUtcDateString } from "@/api/lib/dates";
 import { AdapterFetchError } from "@/api/lib/errors/tagged-errors";
@@ -28,10 +29,7 @@ import {
   parseListingIdentityKey,
 } from "@/api/lib/legal-search/ingestion-types";
 
-const reconciliation = plCourtsAdapter.reconciliation;
-if (reconciliation === undefined) {
-  throw new Error("pl-courts must declare the reconciliation capability");
-}
+const reconciliation = requireReconciliation(plCourtsAdapter);
 
 const SEARCH_PATTERN = "/api/search/judgments";
 const DETAIL_PATTERN = "/api/judgments/";

--- a/apps/api/src/handlers/case-law/ingestion/adapters/pl-courts.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/pl-courts.ts
@@ -9,6 +9,9 @@ import {
   defineSourceAdapter,
   EMPTY_AST,
   isPersistableSourceDocumentId,
+  SOURCE_TOTAL_PROBE_FAILURE,
+  sourceTotalProbeFailed,
+  sourceTotalRead,
 } from "@/api/handlers/case-law/ingestion/adapter";
 import type {
   EmptyAst,
@@ -32,6 +35,7 @@ import {
 import { parsePlDecisionContent } from "@/api/handlers/case-law/ingestion/parsers/pl-courts";
 import { addUtcDays, isoCalendarDay, toUtcDateString } from "@/api/lib/dates";
 import { AdapterFetchError } from "@/api/lib/errors/tagged-errors";
+import { errorTag } from "@/api/lib/errors/utils";
 import { fetchWithTimeout } from "@/api/lib/fetch";
 import { isRecord } from "@/api/lib/type-guards";
 
@@ -1105,17 +1109,22 @@ export const plCourtsAdapter = defineSourceAdapter({
       );
 
       if (!response.ok) {
-        return null;
+        return sourceTotalProbeFailed(SOURCE_TOTAL_PROBE_FAILURE.HTTP_STATUS);
       }
 
       const json: unknown = await response.json();
       if (!isSaosSearchResponse(json)) {
-        return null;
+        return sourceTotalProbeFailed(
+          SOURCE_TOTAL_PROBE_FAILURE.UNREADABLE_PAYLOAD,
+        );
       }
 
-      return toOptionalValue(json.info?.totalResults) ?? null;
-    } catch {
-      return null;
+      const total = toOptionalValue(json.info?.totalResults);
+      return total === undefined
+        ? sourceTotalProbeFailed(SOURCE_TOTAL_PROBE_FAILURE.UNREADABLE_PAYLOAD)
+        : sourceTotalRead(total);
+    } catch (error) {
+      return { type: "probe-failed", errorTag: errorTag(error) };
     }
   },
 

--- a/apps/api/src/handlers/case-law/ingestion/adapters/sk-courts-reconciliation.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/sk-courts-reconciliation.test.ts
@@ -25,6 +25,7 @@ import {
   skCourtsAdapter,
   skCourtsListingIdentity,
 } from "@/api/handlers/case-law/ingestion/adapters/sk-courts";
+import { requireReconciliation } from "@/api/handlers/case-law/ingestion/adapters/test-utils";
 import { tipWindowSlices } from "@/api/handlers/case-law/ingestion/reconciliation-plan";
 import { toUtcDateString } from "@/api/lib/dates";
 import { AdapterFetchError } from "@/api/lib/errors/tagged-errors";
@@ -34,10 +35,7 @@ import {
 } from "@/api/lib/legal-search/ingestion-types";
 import { asFetchMock } from "@/api/tests/helpers/test-tool-set";
 
-const { reconciliation } = skCourtsAdapter;
-if (reconciliation === undefined) {
-  throw new Error("sk-courts must declare a reconciliation capability");
-}
+const reconciliation = requireReconciliation(skCourtsAdapter);
 
 const LIST_PATH = "/v1/rozhodnutie";
 const SLICE = "2026-06-10";

--- a/apps/api/src/handlers/case-law/ingestion/adapters/sk-courts.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/sk-courts.ts
@@ -9,6 +9,9 @@ import {
   defineSourceAdapter,
   EMPTY_AST,
   isPersistableSourceDocumentId,
+  SOURCE_TOTAL_PROBE_FAILURE,
+  sourceTotalProbeFailed,
+  sourceTotalRead,
 } from "@/api/handlers/case-law/ingestion/adapter";
 import type {
   IngestionResult,
@@ -798,14 +801,18 @@ export const skCourtsAdapter = defineSourceAdapter({
       },
     );
     if (!response.ok) {
-      return null;
+      return sourceTotalProbeFailed(SOURCE_TOTAL_PROBE_FAILURE.HTTP_STATUS);
     }
     const json: unknown = await response.json();
     if (!isRecord(json)) {
-      return null;
+      return sourceTotalProbeFailed(
+        SOURCE_TOTAL_PROBE_FAILURE.UNREADABLE_PAYLOAD,
+      );
     }
     const total = json["numFound"];
-    return typeof total === "number" && total > 0 ? total : null;
+    return typeof total === "number"
+      ? sourceTotalRead(total)
+      : sourceTotalProbeFailed(SOURCE_TOTAL_PROBE_FAILURE.UNREADABLE_PAYLOAD);
   },
 
   /**

--- a/apps/api/src/handlers/case-law/ingestion/adapters/sk-us.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/sk-us.test.ts
@@ -16,6 +16,7 @@ import {
   skUsListingIdentity,
   SK_US_FIRST_SLICE,
 } from "@/api/handlers/case-law/ingestion/adapters/sk-us";
+import { requireReconciliation } from "@/api/handlers/case-law/ingestion/adapters/test-utils";
 import { tipWindowSlices } from "@/api/handlers/case-law/ingestion/reconciliation-plan";
 import {
   listingIdentityKey,
@@ -23,10 +24,7 @@ import {
 } from "@/api/lib/legal-search/ingestion-types";
 import { asFetchMock } from "@/api/tests/helpers/test-tool-set";
 
-const { reconciliation } = skUsAdapter;
-if (reconciliation === undefined) {
-  throw new Error("sk-us must declare a reconciliation capability");
-}
+const reconciliation = requireReconciliation(skUsAdapter);
 
 const SEARCH_PATH = "/o/v1/dms/search";
 const DOWNLOAD_PREFIX = "/docDownload/";

--- a/apps/api/src/handlers/case-law/ingestion/adapters/sk-us.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/sk-us.ts
@@ -755,11 +755,10 @@ export const skUsAdapter = defineSourceAdapter({
    * when replayed with browser-identical headers and session state, so the
    * total it shows in a browser cannot be read from here. Coverage for this
    * source is benchmarked only by what the crawl itself reports.
-   */
-  /**
-   * The DMS exposes no count: its search answers a page of hits without ever
-   * stating how many the query matched. Stated statically rather than probed,
-   * because there is no request that could answer differently.
+   *
+   * Answered statically rather than probed: no request this adapter can make
+   * would answer differently, so there is no failure to distinguish from the
+   * absence.
    */
   async getTotalCount(_signal) {
     return await Promise.resolve({ type: "no-count-endpoint" });

--- a/apps/api/src/handlers/case-law/ingestion/adapters/sk-us.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/sk-us.ts
@@ -756,8 +756,13 @@ export const skUsAdapter = defineSourceAdapter({
    * total it shows in a browser cannot be read from here. Coverage for this
    * source is benchmarked only by what the crawl itself reports.
    */
+  /**
+   * The DMS exposes no count: its search answers a page of hits without ever
+   * stating how many the query matched. Stated statically rather than probed,
+   * because there is no request that could answer differently.
+   */
   async getTotalCount(_signal) {
-    return await Promise.resolve(null);
+    return await Promise.resolve({ type: "no-count-endpoint" });
   },
 
   /**

--- a/apps/api/src/handlers/case-law/ingestion/adapters/test-utils.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/test-utils.ts
@@ -26,6 +26,12 @@
  * ```
  */
 
+import { panic } from "better-result";
+
+import type {
+  SourceAdapter,
+  SourceReconciliation,
+} from "@/api/handlers/case-law/ingestion/adapter";
 import { fetchWithTimeout } from "@/api/lib/fetch";
 
 const FIXTURES_DIR = new URL("__fixtures__/", import.meta.url);
@@ -166,3 +172,20 @@ export const recordFixture = async (
   await saveFixture(filename, text);
   return text;
 };
+
+/**
+ * The reconciliation capability an adapter's own tests exist to exercise.
+ *
+ * Every adapter declares the field, so reaching the implementation means
+ * narrowing past `unsupported`. Shared rather than restated per adapter: a
+ * test that reached for the capability and found the source exempted is a
+ * broken test file, not a case to handle, and it should say so once.
+ */
+export const requireReconciliation = (
+  adapter: SourceAdapter,
+): SourceReconciliation =>
+  adapter.reconciliation.type === "unsupported"
+    ? panic(
+        `${adapter.key} declares reconciliation unsupported: ${adapter.reconciliation.reason}`,
+      )
+    : adapter.reconciliation;

--- a/apps/api/src/handlers/case-law/ingestion/parsers/eu-ecj.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/parsers/eu-ecj.test.ts
@@ -20,7 +20,7 @@
  */
 
 import { Glob } from "bun";
-import { describe, expect, test } from "bun:test";
+import { describe, expect, setDefaultTimeout, test } from "bun:test";
 
 import type { Block, Inline } from "@/api/handlers/case-law/document-ast";
 import {
@@ -41,6 +41,16 @@ import {
   manifestationStem,
   portalStem,
 } from "./__fixtures__/eu-ecj/corpus";
+
+/**
+ * Every test here gunzips and parses one of the largest fixtures in the repo,
+ * twice — once as XHTML and once as Formex — which runs for seconds, close
+ * enough to the 5s default that these fail on a loaded machine rather than on
+ * a defect. Stated once for the file because the cost is the file's, not one
+ * test's; a real hang still ends the run well inside the runner's own
+ * deadline.
+ */
+setDefaultTimeout(30_000);
 
 const FIXTURES_DIR = new URL("__fixtures__/eu-ecj/", import.meta.url);
 

--- a/apps/api/src/handlers/case-law/ingestion/pipeline-canonical.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/pipeline-canonical.test.ts
@@ -8,7 +8,6 @@ import {
   caseLawDecisions,
   caseLawSources,
 } from "@/api/db/schema";
-import { ADAPTER_KEYS } from "@/api/handlers/case-law/consts";
 import type { IngestionResult } from "@/api/handlers/case-law/ingestion/adapter";
 import { createSafeId } from "@/api/lib/branded-types";
 import {
@@ -18,6 +17,7 @@ import {
 } from "@/api/lib/errors/tagged-errors";
 import type { CaseLawSourceIngestionLease } from "@/api/lib/legal-search/case-law-source-ingestion-lease";
 import type { WriteCorpusResult } from "@/api/lib/legal-search/corpus-storage";
+import { caseLawSourceRow } from "@/api/tests/helpers/case-law-source-row";
 
 /**
  * `canonical` storage mode moves the payload out of Postgres, so what a
@@ -507,25 +507,7 @@ describe("runIngestionPipeline — canonical corpus write failure", () => {
       async () => await Promise.reject(new Error("bucket unreachable")),
     );
 
-    const source = {
-      id: createSafeId<"caseLawSource">(),
-      adapterKey: ADAPTER_KEYS.CZ_NS,
-      name: "Canonical source",
-      enabled: true,
-      syncCursor: "cursor-1",
-      lastSyncAt: null,
-      observationOrder: 0n,
-      checkpointObservationOrder: 0n,
-      ingestionLeaseToken: null,
-      ingestionLeaseExpiresAt: null,
-      config: {},
-      descriptor: null,
-      reportedTotal: null,
-      reportedTotalAsOf: null,
-      reportedTotalOrigin: null,
-      createdAt: new Date("2026-01-01T00:00:00.000Z"),
-      updatedAt: new Date("2026-01-01T00:00:00.000Z"),
-    } satisfies typeof caseLawSources.$inferSelect;
+    const source = caseLawSourceRow({ name: "Canonical source" });
 
     czNsAdapter.fetchPage = async () =>
       await Promise.resolve(
@@ -562,25 +544,7 @@ describe("runIngestionPipeline — canonical corpus write failure", () => {
     };
     mirrorSettlementApplied = false;
 
-    const source = {
-      id: createSafeId<"caseLawSource">(),
-      adapterKey: ADAPTER_KEYS.CZ_NS,
-      name: "Canonical source",
-      enabled: true,
-      syncCursor: "cursor-1",
-      lastSyncAt: null,
-      observationOrder: 0n,
-      checkpointObservationOrder: 0n,
-      ingestionLeaseToken: null,
-      ingestionLeaseExpiresAt: null,
-      config: {},
-      descriptor: null,
-      reportedTotal: null,
-      reportedTotalAsOf: null,
-      reportedTotalOrigin: null,
-      createdAt: new Date("2026-01-01T00:00:00.000Z"),
-      updatedAt: new Date("2026-01-01T00:00:00.000Z"),
-    } satisfies typeof caseLawSources.$inferSelect;
+    const source = caseLawSourceRow({ name: "Canonical source" });
 
     czNsAdapter.fetchPage = async () =>
       await Promise.resolve(

--- a/apps/api/src/handlers/case-law/ingestion/pipeline.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/pipeline.test.ts
@@ -4,7 +4,6 @@ import { afterEach, describe, expect, mock, test } from "bun:test";
 import type { Transaction } from "@/api/db/root";
 import type { ScopedDb } from "@/api/db/safe-db";
 import { caseLawDecisions, caseLawSources } from "@/api/db/schema";
-import { ADAPTER_KEYS } from "@/api/handlers/case-law/consts";
 import type { DocumentAst, Inline } from "@/api/handlers/case-law/document-ast";
 import {
   EMPTY_AST,
@@ -22,6 +21,7 @@ import { createSafeId } from "@/api/lib/branded-types";
 import { TimeoutError } from "@/api/lib/errors/tagged-errors";
 import type { CaseLawSourceIngestionLease } from "@/api/lib/legal-search/case-law-source-ingestion-lease";
 import { partialObservationFromMetadata } from "@/api/lib/legal-search/ingestion-normalization";
+import { caseLawSourceRow } from "@/api/tests/helpers/case-law-source-row";
 
 const concatInlineText = (inlines: Inline[]): string => {
   let out = "";
@@ -427,25 +427,7 @@ describe("sanitizeResult — documentAst text fields", () => {
 
 describe("runIngestionPipeline — database timeouts", () => {
   test("holds the source cursor when a decision DB operation times out", async () => {
-    const source = {
-      id: createSafeId<"caseLawSource">(),
-      adapterKey: ADAPTER_KEYS.CZ_NS,
-      name: "Timeout source",
-      enabled: true,
-      syncCursor: "cursor-1",
-      lastSyncAt: null,
-      observationOrder: 0n,
-      checkpointObservationOrder: 0n,
-      ingestionLeaseToken: null,
-      ingestionLeaseExpiresAt: null,
-      config: {},
-      descriptor: null,
-      reportedTotal: null,
-      reportedTotalAsOf: null,
-      reportedTotalOrigin: null,
-      createdAt: new Date("2026-01-01T00:00:00.000Z"),
-      updatedAt: new Date("2026-01-01T00:00:00.000Z"),
-    } satisfies typeof caseLawSources.$inferSelect;
+    const source = caseLawSourceRow({ name: "Timeout source" });
 
     const decision = baseResult({});
     czNsAdapter.fetchPage = async () =>
@@ -505,25 +487,7 @@ describe("runIngestionPipeline — database timeouts", () => {
 
 describe("runIngestionPipeline — empty-page cursor progress", () => {
   test("persists the fetched cursor when the cycle aborts on an empty page", async () => {
-    const source = {
-      id: createSafeId<"caseLawSource">(),
-      adapterKey: ADAPTER_KEYS.CZ_NS,
-      name: "Empty-page source",
-      enabled: true,
-      syncCursor: "cursor-1",
-      lastSyncAt: null,
-      observationOrder: 0n,
-      checkpointObservationOrder: 0n,
-      ingestionLeaseToken: null,
-      ingestionLeaseExpiresAt: null,
-      config: {},
-      descriptor: null,
-      reportedTotal: null,
-      reportedTotalAsOf: null,
-      reportedTotalOrigin: null,
-      createdAt: new Date("2026-01-01T00:00:00.000Z"),
-      updatedAt: new Date("2026-01-01T00:00:00.000Z"),
-    } satisfies typeof caseLawSources.$inferSelect;
+    const source = caseLawSourceRow({ name: "Empty-page source" });
 
     // The cycle deadline fires while the fetch is in flight; the page it
     // returns carries no decisions but real cursor progress. Acquiring the

--- a/apps/api/src/handlers/case-law/ingestion/pipeline.ts
+++ b/apps/api/src/handlers/case-law/ingestion/pipeline.ts
@@ -35,7 +35,6 @@ import {
   isSelfCitation,
 } from "@/api/handlers/case-law/ingestion/citation-extractor";
 import { publisherCitationGap } from "@/api/handlers/case-law/ingestion/citation-recall";
-import { recordSliceCoverage } from "@/api/handlers/case-law/ingestion/coverage-ledger";
 import { shouldSkipRefresh } from "@/api/handlers/case-law/ingestion/refresh-policy";
 import { segmentDecision } from "@/api/handlers/case-law/ingestion/segmenter";
 import { extractContext } from "@/api/handlers/case-law/polarity/context";
@@ -2130,17 +2129,6 @@ export const runIngestionPipeline = async ({
         // changes again.
         haltReason = `${pageS3Failures} corpus write failure(s); cursor held for retry`;
       }
-      // Record what the source said this slice holds against what the
-      // crawl produced. Written before the cursor advances, so a slice is
-      // never passed without leaving a row behind to reconcile against.
-      if (page.coverage) {
-        // oxlint-disable-next-line no-await-in-loop -- the row must land before this page's cursor advances, so it cannot be deferred past the loop
-        await recordSliceCoverage(scopedDb, {
-          sourceId: source.id,
-          coverage: page.coverage,
-        });
-      }
-
       logger.info("case_law.ingestion.pipeline_page_done", {
         adapterKey: adapter.key,
         cursor: cursor ?? "",

--- a/apps/api/src/handlers/case-law/ingestion/reconciliation-plan.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/reconciliation-plan.test.ts
@@ -18,6 +18,7 @@ import { describe, expect, test } from "bun:test";
 import { DAY_IN_MS } from "@stll/time";
 
 import { czRegionalAdapter } from "@/api/handlers/case-law/ingestion/adapters/cz-regional";
+import { requireReconciliation } from "@/api/handlers/case-law/ingestion/adapters/test-utils";
 import type {
   LedgerSlice,
   ShortSliceCandidate,
@@ -34,7 +35,6 @@ import {
   tipWindowSlices,
 } from "@/api/handlers/case-law/ingestion/reconciliation-plan";
 import { toUtcDateString } from "@/api/lib/dates";
-import type { SourceReconciliation } from "@/api/lib/legal-search/ingestion-types";
 import {
   listingIdentityKey,
   parseListingIdentityKey,
@@ -44,13 +44,7 @@ const NOW = new Date("2026-08-11T09:30:00.000Z");
 const FRESH = new Date("2026-08-11T06:00:00.000Z");
 const STALE = new Date("2026-08-08T06:00:00.000Z");
 
-const reconciliation = ((): SourceReconciliation => {
-  const capability = czRegionalAdapter.reconciliation;
-  if (capability === undefined) {
-    throw new Error("cz-regional must declare the reconciliation capability");
-  }
-  return capability;
-})();
+const reconciliation = requireReconciliation(czRegionalAdapter);
 
 const baseInput = (
   overrides: Partial<SelectReconciliationWorkUnitInput> = {},

--- a/apps/api/src/handlers/case-law/ingestion/replay-apply.db.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/replay-apply.db.test.ts
@@ -103,6 +103,13 @@ const stubAdapter = (
   fetchPage: async () => {
     throw new Error("a replay must never fetch from the publisher");
   },
+  getTotalCount: async () => {
+    throw new Error("a replay must never fetch from the publisher");
+  },
+  reconciliation: {
+    type: "unsupported",
+    reason: "replay stub: a replay never contacts the publisher",
+  },
   reparseStoredRaw: reparse,
 });
 

--- a/apps/api/src/handlers/case-law/ingestion/replay.db.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/replay.db.test.ts
@@ -275,6 +275,13 @@ const stubAdapter = ({ reparse }: StubAdapterOptions): SourceAdapter => ({
   fetchPage: async () => {
     throw new Error("a replay must never fetch from the publisher");
   },
+  getTotalCount: async () => {
+    throw new Error("a replay must never fetch from the publisher");
+  },
+  reconciliation: {
+    type: "unsupported",
+    reason: "replay stub: a replay never contacts the publisher",
+  },
   reparseStoredRaw: reparse,
 });
 

--- a/apps/api/src/lib/errors/error-tag.ts
+++ b/apps/api/src/lib/errors/error-tag.ts
@@ -1,0 +1,45 @@
+/**
+ * The structural error identifier, split out from `errors/utils`.
+ *
+ * `errors/utils` initializes the dev error logger at import time and reads
+ * `envBase` to do it, so importing it validates the whole API environment.
+ * Modules that only need to name an error — the runner's env-free sweep
+ * modules among them — import this instead and stay independent of that.
+ * `errors/utils` re-exports these, so existing callers are unaffected.
+ */
+
+import { isTaggedError } from "better-result";
+
+export const errorClassName = (error: Error): string => {
+  try {
+    const constructorValue: unknown = Reflect.get(error, "constructor");
+    if (typeof constructorValue !== "function") {
+      return "Error";
+    }
+    const name: unknown = Reflect.get(constructorValue, "name");
+    if (typeof name === "string" && name) {
+      return name;
+    }
+  } catch {
+    return "Error";
+  }
+  return "Error";
+};
+
+/**
+ * Extract a safe, structural error identifier for observability.
+ *
+ * Returns the TaggedError `_tag`, the Error constructor name, or
+ * "UnknownError". Never includes messages, causes, or stack
+ * traces; those may contain privileged document content, file
+ * names, or client data that must not reach analytics dashboards.
+ */
+export const errorTag = (error: unknown): string => {
+  if (isTaggedError(error)) {
+    return error._tag;
+  }
+  if (error instanceof Error) {
+    return errorClassName(error);
+  }
+  return "UnknownError";
+};

--- a/apps/api/src/lib/errors/utils.ts
+++ b/apps/api/src/lib/errors/utils.ts
@@ -5,25 +5,12 @@ import path from "node:path";
 import { createDevErrorLogger } from "@stll/errors";
 
 import { envBase } from "@/api/env-base";
+import { errorClassName, errorTag } from "@/api/lib/errors/error-tag";
 import { pgErrorFields } from "@/api/lib/pg-error";
 
-/**
- * Extract a safe, structural error identifier for observability.
- *
- * Returns the TaggedError `_tag`, the Error constructor name, or
- * "UnknownError". Never includes messages, causes, or stack
- * traces; those may contain privileged document content, file
- * names, or client data that must not reach analytics dashboards.
- */
-export const errorTag = (error: unknown): string => {
-  if (isTaggedError(error)) {
-    return error._tag;
-  }
-  if (error instanceof Error) {
-    return errorClassName(error);
-  }
-  return "UnknownError";
-};
+// Re-exported so callers keep one import path, while modules that must not
+// pay this file's import-time env read can take them from the split module.
+export { errorClassName, errorTag };
 
 /**
  * Non-PII connection/system fields for infra observability.
@@ -138,22 +125,6 @@ export const safeErrorCause = (error: Error): unknown => {
   } catch {
     return undefined;
   }
-};
-
-const errorClassName = (error: Error): string => {
-  try {
-    const constructorValue: unknown = Reflect.get(error, "constructor");
-    if (typeof constructorValue !== "function") {
-      return "Error";
-    }
-    const name: unknown = Reflect.get(constructorValue, "name");
-    if (typeof name === "string" && name) {
-      return name;
-    }
-  } catch {
-    return "Error";
-  }
-  return "Error";
 };
 
 export const safeErrorCode = (error: Error): string | undefined =>

--- a/apps/api/src/lib/legal-search/ingestion-types.ts
+++ b/apps/api/src/lib/legal-search/ingestion-types.ts
@@ -333,6 +333,12 @@ export type ReconciliationBuildOutcome =
  * compared without the loop knowing what a slice means to the adapter.
  */
 export type SourceReconciliation = {
+  /**
+   * The discriminant against `ReconciliationUnsupported`, absent here so an
+   * implemented capability is written plainly rather than wrapped. Declared so
+   * every reader narrows on one field instead of probing for another.
+   */
+  type?: undefined;
   /** First slice the publisher can list (e.g. the feed's first day). */
   firstSlice: string;
   /** Slice for a UTC instant (the tip). */
@@ -378,6 +384,21 @@ export type SourceReconciliation = {
     payload: unknown,
     signal?: AbortSignal,
   ) => Promise<ReconciliationBuildOutcome>;
+};
+
+/**
+ * An adapter that declares reconciliation and cannot do it.
+ *
+ * The capability is required rather than optional so that a new adapter has to
+ * answer for it: an omitted field is a decision nobody made, while this one is
+ * a decision written down with its reason. Discriminated against
+ * `SourceReconciliation`, which carries no `type`, so an implemented
+ * capability pays no wrapper and every reader narrows on the same field.
+ */
+export type ReconciliationUnsupported = {
+  type: "unsupported";
+  /** Why this source cannot be reconciled. Printed to operators. */
+  reason: string;
 };
 
 /**
@@ -434,22 +455,26 @@ export type SourceAdapter = {
     stored: StoredRawReparseInput,
   ) => StoredRawReparseOutcome | Promise<StoredRawReparseOutcome>;
   /**
-   * Fetch the total number of decisions available from
-   * the source. Returns null if the source doesn't expose
-   * a count endpoint or if the request fails.
+   * Ask the source how many decisions it holds, so held-vs-total coverage has
+   * a denominator the publisher itself states.
+   *
+   * Required: a source nobody can count is a source whose coverage nobody can
+   * report, and that has to be a stated property of the adapter rather than a
+   * field somebody forgot.
    */
-  getTotalCount?: (signal: AbortSignal) => Promise<number | null>;
+  getTotalCount: (signal: AbortSignal) => Promise<number | null>;
   /**
    * Ask the publisher what it lists for a slice, so the standing
    * reconciliation loop can compare that against what is held and ingest the
    * difference.
    *
-   * Optional. It exists only for sources that publish a listing addressable
-   * independently of the crawl cursor; where the only way to reach a decision
-   * is to walk the cursor forward, there is nothing to reconcile against and
-   * the adapter omits this rather than re-crawling under another name.
+   * Required, and answerable with `ReconciliationUnsupported`: it exists only
+   * for sources that publish a listing addressable independently of the crawl
+   * cursor, and where the only way to reach a decision is to walk the cursor
+   * forward there is nothing to reconcile against. Declaring that explicitly
+   * is what keeps "cannot" apart from "nobody looked".
    */
-  reconciliation?: SourceReconciliation | undefined;
+  reconciliation: SourceReconciliation | ReconciliationUnsupported;
 };
 
 /** Preserve an adapter's literal registry key while contextualizing its API. */

--- a/apps/api/src/lib/legal-search/ingestion-types.ts
+++ b/apps/api/src/lib/legal-search/ingestion-types.ts
@@ -113,24 +113,27 @@ export type IngestionResult = {
 };
 
 /**
- * What a source says it holds for the slice just crawled, against what the
- * crawl actually produced.
+ * What a source says it holds for a slice, against what is held for it.
  *
- * Coverage is otherwise unknowable: a crawl that silently stops early looks
- * exactly like a slice with fewer decisions in it. Reporting the source's
- * own count next to the collected count turns that into a number the
- * reconciliation pass can act on. Adapters whose source publishes no count
- * omit it, and their slices are simply not tracked.
+ * Coverage is otherwise unknowable: a walk that silently stops early looks
+ * exactly like a slice with fewer decisions in it. Recording the source's own
+ * count next to the collected count turns that into a number the ledger can
+ * select on.
+ *
+ * Written by the reconciliation loop alone. A crawl cannot state it honestly:
+ * a forward-only cursor does not know which slice it has finished, so a count
+ * taken mid-slice reads as a shortfall and a count taken at the end reads as
+ * complete whatever the crawl skipped.
  */
 export type SliceCoverage = {
   /**
-   * The crawl slice these counts describe — a calendar day for date-cursor
-   * adapters. Stable across re-crawls, since it keys the ledger row.
+   * The slice these counts describe — a calendar day for date-cursor
+   * adapters. Stable across re-walks, since it keys the ledger row.
    */
   slice: string;
   /** How many records the source says the slice contains. */
   reported: number;
-  /** How many this crawl produced for it. */
+  /** How many of them are held. */
   collected: number;
 };
 
@@ -138,8 +141,6 @@ export type SliceCoverage = {
 export type SyncPage = {
   decisions: IngestionResult[];
   nextCursor: string | null;
-  /** Present on the page that completes a slice; see `SliceCoverage`. */
-  coverage?: SliceCoverage | undefined;
 };
 
 /**

--- a/apps/api/src/lib/legal-search/ingestion-types.ts
+++ b/apps/api/src/lib/legal-search/ingestion-types.ts
@@ -387,6 +387,58 @@ export type SourceReconciliation = {
 };
 
 /**
+ * What asking a source how much it holds produced.
+ *
+ * Three answers rather than a nullable number. "The publisher exposes no
+ * count" is a permanent property of the source; "the probe did not complete"
+ * is a statement about one request and nothing about the source. A caller
+ * given only null has to guess which it got, and every caller guessed the
+ * same way: it reported both as "no count" and alarmed on neither.
+ *
+ * `errorTag` is a structural, non-PII identifier — an `errorTag(...)` result
+ * where the adapter caught a throw, and an adapter-authored tag naming the
+ * step where it did not (a refused status, an unreadable payload). Never a
+ * message: these tags reach logs and dashboards.
+ */
+export type SourceTotalCount =
+  | { type: "count"; total: number }
+  | { type: "no-count-endpoint" }
+  | { type: "probe-failed"; errorTag: string };
+
+/**
+ * Tags for the count probe failures an adapter detects without a throw.
+ * Alongside `errorTag(...)`, which names the ones it catches.
+ */
+export const SOURCE_TOTAL_PROBE_FAILURE = {
+  /** The count endpoint answered with a status the adapter refuses. */
+  HTTP_STATUS: "http-status",
+  /** The answer carried no count this adapter can read. */
+  UNREADABLE_PAYLOAD: "unreadable-payload",
+} as const;
+
+export type SourceTotalProbeFailure =
+  (typeof SOURCE_TOTAL_PROBE_FAILURE)[keyof typeof SOURCE_TOTAL_PROBE_FAILURE];
+
+/** A failure the adapter detected without a throw. */
+export const sourceTotalProbeFailed = (
+  failure: SourceTotalProbeFailure,
+): SourceTotalCount => ({ type: "probe-failed", errorTag: failure });
+
+/**
+ * The count answer for a number an adapter read out of a publisher's payload.
+ *
+ * One rule for every source: a total is a positive, finite integer, and
+ * anything else is a payload the adapter could not read rather than a corpus
+ * of nothing. Zero especially — no publisher here holds no decisions, so a
+ * zero is a query that did not run, and recording it would state a false floor
+ * that every coverage figure is then measured against.
+ */
+export const sourceTotalRead = (value: number): SourceTotalCount =>
+  Number.isSafeInteger(value) && value > 0
+    ? { type: "count", total: value }
+    : sourceTotalProbeFailed(SOURCE_TOTAL_PROBE_FAILURE.UNREADABLE_PAYLOAD);
+
+/**
  * An adapter that declares reconciliation and cannot do it.
  *
  * The capability is required rather than optional so that a new adapter has to
@@ -460,9 +512,10 @@ export type SourceAdapter = {
    *
    * Required: a source nobody can count is a source whose coverage nobody can
    * report, and that has to be a stated property of the adapter rather than a
-   * field somebody forgot.
+   * field somebody forgot. An adapter classifies its own answer, because only
+   * it knows whether its publisher states no total or its probe broke.
    */
-  getTotalCount: (signal: AbortSignal) => Promise<number | null>;
+  getTotalCount: (signal: AbortSignal) => Promise<SourceTotalCount>;
   /**
    * Ask the publisher what it lists for a slice, so the standing
    * reconciliation loop can compare that against what is held and ingest the

--- a/apps/api/src/lib/legal-search/reconciliation-store.db.test.ts
+++ b/apps/api/src/lib/legal-search/reconciliation-store.db.test.ts
@@ -368,6 +368,8 @@ test("the listing names what a source carries, in both states", async () => {
     limit: 10,
   });
 
+  // Identity-key order, which is what the cursor pages on: the docket key
+  // sorts before the document key.
   expect(
     listed.map(({ identityKey, status, slice, lastError }) => ({
       identityKey,
@@ -377,25 +379,25 @@ test("the listing names what a source carries, in both states", async () => {
     })),
   ).toEqual([
     {
-      identityKey: DOCUMENT_KEY,
-      status: RECONCILIATION_ITEM_STATUS.PARKED,
-      slice: SLICE,
-      lastError: "detail-unavailable",
-    },
-    {
       identityKey: DOCKET_KEY,
       status: RECONCILIATION_ITEM_STATUS.TERMINAL,
       slice: SLICE,
       lastError: "unkeyable",
     },
+    {
+      identityKey: DOCUMENT_KEY,
+      status: RECONCILIATION_ITEM_STATUS.PARKED,
+      slice: SLICE,
+      lastError: "detail-unavailable",
+    },
   ]);
 });
 
-test("the listing is bounded by its limit", async () => {
+test("paging the listing reaches every item exactly once", async () => {
   const sourceId = await seedSource();
   const now = new Date("2026-08-11T09:00:00.000Z");
-  for (const identityKey of [DOCUMENT_KEY, DOCKET_KEY]) {
-    // oxlint-disable-next-line no-await-in-loop -- two fixture rows whose insertion order is what the ordering assertion above rests on
+  for (const identityKey of [DOCKET_KEY, DOCUMENT_KEY]) {
+    // oxlint-disable-next-line no-await-in-loop -- fixture rows, written in sequence so the paging walk below has a fixed population
     await parkReconciliationItem(scopedDb, {
       sourceId,
       slice: SLICE,
@@ -406,9 +408,67 @@ test("the listing is bounded by its limit", async () => {
     });
   }
 
+  // The expectation comes from one unpaged read, not from sorting the keys
+  // here: the database orders by the column's collation and this process would
+  // order by UTF-16 code unit, and pinning the paged walk to the JS answer
+  // would make the test assert a collation rather than the paging.
+  const unpaged = (
+    await listReconciliationItems(scopedDb, { sourceId, limit: 10 })
+  ).map(({ identityKey }) => identityKey);
+  expect(unpaged).toHaveLength(2);
+
+  // One row per page, walked with the cursor the script prints. The property
+  // that matters is the one a limit-only listing cannot give: every row is
+  // reached, none twice, and the walk terminates.
+  const walked: string[] = [];
+  let after: string | undefined;
+  for (let page = 0; page < unpaged.length + 2; page += 1) {
+    // oxlint-disable-next-line no-await-in-loop -- a cursor walk is sequential by definition; each page's cursor comes from the last
+    const items = await listReconciliationItems(scopedDb, {
+      sourceId,
+      limit: 1,
+      ...(after === undefined ? {} : { after }),
+    });
+    if (items.length === 0) {
+      break;
+    }
+    expect(items).toHaveLength(1);
+    walked.push(...items.map(({ identityKey }) => identityKey));
+    after = items.at(-1)?.identityKey;
+  }
+
+  expect(walked).toEqual(unpaged);
+});
+
+test("the listing narrows to one slice", async () => {
+  const sourceId = await seedSource();
+  const now = new Date("2026-08-11T09:00:00.000Z");
+  await parkReconciliationItem(scopedDb, {
+    sourceId,
+    slice: SLICE,
+    identityKey: DOCUMENT_KEY,
+    payload: PAYLOAD,
+    errorTag: "detail-unavailable",
+    now,
+  });
+  await parkReconciliationItem(scopedDb, {
+    sourceId,
+    slice: "2026-08-05",
+    identityKey: DOCKET_KEY,
+    payload: PAYLOAD,
+    errorTag: "detail-unavailable",
+    now,
+  });
+
   expect(
-    await listReconciliationItems(scopedDb, { sourceId, limit: 1 }),
-  ).toHaveLength(1);
+    (
+      await listReconciliationItems(scopedDb, {
+        sourceId,
+        limit: 10,
+        slice: SLICE,
+      })
+    ).map(({ identityKey }) => identityKey),
+  ).toEqual([DOCUMENT_KEY]);
 });
 
 test("one source's items are invisible to another", async () => {

--- a/apps/api/src/lib/legal-search/reconciliation-store.db.test.ts
+++ b/apps/api/src/lib/legal-search/reconciliation-store.db.test.ts
@@ -19,6 +19,7 @@ import {
   RECONCILIATION_TERMINAL_ATTEMPTS,
   countReconciliationItems,
   countTerminalReconciliationItemsBySlice,
+  listReconciliationItems,
   parkReconciliationItem,
   resetTerminalReconciliationItems,
   resolveReconciliationItem,
@@ -300,6 +301,114 @@ test("a reset puts retired items back into the hunt, due immediately", async () 
       })
     ).map(({ identityKey }) => identityKey),
   ).toEqual([DOCUMENT_KEY]);
+});
+
+test("a sliced reset leaves the other slices retired", async () => {
+  const sourceId = await seedSource();
+  const now = new Date("2026-08-11T09:00:00.000Z");
+  const otherSlice = "2026-08-05";
+  await retireReconciliationItem(scopedDb, {
+    sourceId,
+    slice: SLICE,
+    identityKey: DOCUMENT_KEY,
+    payload: PAYLOAD,
+    errorTag: "unkeyable",
+    now,
+  });
+  await retireReconciliationItem(scopedDb, {
+    sourceId,
+    slice: otherSlice,
+    identityKey: DOCKET_KEY,
+    payload: PAYLOAD,
+    errorTag: "unkeyable",
+    now,
+  });
+
+  // The point of the narrowing: an operator who fixed one bad day re-hunts
+  // that day, not every identity the adapter has ever retired.
+  expect(
+    await resetTerminalReconciliationItems(scopedDb, {
+      sourceId,
+      now,
+      limit: 10,
+      slice: SLICE,
+    }),
+  ).toBe(1);
+
+  expect((await readRow(sourceId, DOCUMENT_KEY))?.status).toBe(
+    RECONCILIATION_ITEM_STATUS.PARKED,
+  );
+  expect((await readRow(sourceId, DOCKET_KEY))?.status).toBe(
+    RECONCILIATION_ITEM_STATUS.TERMINAL,
+  );
+});
+
+test("the listing names what a source carries, in both states", async () => {
+  const sourceId = await seedSource();
+  const now = new Date("2026-08-11T09:00:00.000Z");
+  await parkReconciliationItem(scopedDb, {
+    sourceId,
+    slice: SLICE,
+    identityKey: DOCUMENT_KEY,
+    payload: PAYLOAD,
+    errorTag: "detail-unavailable",
+    now,
+  });
+  await retireReconciliationItem(scopedDb, {
+    sourceId,
+    slice: SLICE,
+    identityKey: DOCKET_KEY,
+    payload: PAYLOAD,
+    errorTag: "unkeyable",
+    now,
+  });
+
+  const listed = await listReconciliationItems(scopedDb, {
+    sourceId,
+    limit: 10,
+  });
+
+  expect(
+    listed.map(({ identityKey, status, slice, lastError }) => ({
+      identityKey,
+      status,
+      slice,
+      lastError,
+    })),
+  ).toEqual([
+    {
+      identityKey: DOCUMENT_KEY,
+      status: RECONCILIATION_ITEM_STATUS.PARKED,
+      slice: SLICE,
+      lastError: "detail-unavailable",
+    },
+    {
+      identityKey: DOCKET_KEY,
+      status: RECONCILIATION_ITEM_STATUS.TERMINAL,
+      slice: SLICE,
+      lastError: "unkeyable",
+    },
+  ]);
+});
+
+test("the listing is bounded by its limit", async () => {
+  const sourceId = await seedSource();
+  const now = new Date("2026-08-11T09:00:00.000Z");
+  for (const identityKey of [DOCUMENT_KEY, DOCKET_KEY]) {
+    // oxlint-disable-next-line no-await-in-loop -- two fixture rows whose insertion order is what the ordering assertion above rests on
+    await parkReconciliationItem(scopedDb, {
+      sourceId,
+      slice: SLICE,
+      identityKey,
+      payload: PAYLOAD,
+      errorTag: "detail-unavailable",
+      now,
+    });
+  }
+
+  expect(
+    await listReconciliationItems(scopedDb, { sourceId, limit: 1 }),
+  ).toHaveLength(1);
 });
 
 test("one source's items are invisible to another", async () => {

--- a/apps/api/src/lib/legal-search/reconciliation-store.ts
+++ b/apps/api/src/lib/legal-search/reconciliation-store.ts
@@ -12,7 +12,7 @@
  * publisher; the payload is stored verbatim so a retry needs no listing walk.
  */
 
-import { and, count, eq, inArray, lte, sql } from "drizzle-orm";
+import { and, count, eq, gt, inArray, lte, sql } from "drizzle-orm";
 
 import { DAY_IN_MS } from "@stll/time";
 
@@ -594,11 +594,24 @@ export type ListReconciliationItemsInput = {
   sourceId: SafeId<"caseLawSource">;
   /** Rows returned per call. Bounds the read on a source with many items. */
   limit: number;
+  /** Narrow to one slice, the same way a reset does. */
+  slice?: string | undefined;
+  /** Resume after this identity key; see the ordering note below. */
+  after?: string | undefined;
 };
 
 /**
- * What one source is still carrying, oldest first, for an operator deciding
- * whether a terminal reset is warranted.
+ * What one source is still carrying, for an operator deciding whether a
+ * terminal reset is warranted.
+ *
+ * Ordered by identity key, and paged on it. That is not a presentation
+ * choice: `(source_id, identity_key)` is the table's unique index, so the key
+ * is the one column that totally orders a source's rows and never repeats,
+ * which makes it the only cursor that can page a backlog without skipping or
+ * repeating a row. `first_seen_at` would read better as "oldest first" and
+ * cannot page — it is not unique, and comparing a truncated timestamp against
+ * a boundary is the bug class this repo has a lint rule for. It is returned on
+ * every row instead, so age stays visible.
  *
  * No payload: the listing item is the publisher's own record, and an operator
  * asking which identities are stuck does not need its contents. Bounded like
@@ -606,7 +619,7 @@ export type ListReconciliationItemsInput = {
  */
 export const listReconciliationItems = async (
   scopedDb: ScopedDb,
-  { sourceId, limit }: ListReconciliationItemsInput,
+  { sourceId, limit, slice, after }: ListReconciliationItemsInput,
 ): Promise<ReconciliationItemListing[]> =>
   await scopedDb(
     async (tx) =>
@@ -622,8 +635,18 @@ export const listReconciliationItems = async (
           lastAttemptAt: caseLawReconciliationItems.lastAttemptAt,
         })
         .from(caseLawReconciliationItems)
-        .where(eq(caseLawReconciliationItems.sourceId, sourceId))
-        .orderBy(caseLawReconciliationItems.firstSeenAt)
+        .where(
+          and(
+            eq(caseLawReconciliationItems.sourceId, sourceId),
+            ...(slice === undefined
+              ? []
+              : [eq(caseLawReconciliationItems.slice, slice)]),
+            ...(after === undefined
+              ? []
+              : [gt(caseLawReconciliationItems.identityKey, after)]),
+          ),
+        )
+        .orderBy(caseLawReconciliationItems.identityKey)
         .limit(limit),
   );
 

--- a/apps/api/src/lib/legal-search/reconciliation-store.ts
+++ b/apps/api/src/lib/legal-search/reconciliation-store.ts
@@ -579,10 +579,64 @@ export const countTerminalReconciliationItemsBySlice = async (
   return new Map(rows.map(({ slice, total }) => [slice, total]));
 };
 
+export type ReconciliationItemListing = {
+  slice: string;
+  identityKey: string;
+  status: ReconciliationItemStatus;
+  attempts: number;
+  nextAttemptAt: Date | null;
+  lastError: string | null;
+  firstSeenAt: Date;
+  lastAttemptAt: Date | null;
+};
+
+export type ListReconciliationItemsInput = {
+  sourceId: SafeId<"caseLawSource">;
+  /** Rows returned per call. Bounds the read on a source with many items. */
+  limit: number;
+};
+
+/**
+ * What one source is still carrying, oldest first, for an operator deciding
+ * whether a terminal reset is warranted.
+ *
+ * No payload: the listing item is the publisher's own record, and an operator
+ * asking which identities are stuck does not need its contents. Bounded like
+ * every other read here, so a source with a bad week cannot be listed whole.
+ */
+export const listReconciliationItems = async (
+  scopedDb: ScopedDb,
+  { sourceId, limit }: ListReconciliationItemsInput,
+): Promise<ReconciliationItemListing[]> =>
+  await scopedDb(
+    async (tx) =>
+      await tx
+        .select({
+          slice: caseLawReconciliationItems.slice,
+          identityKey: caseLawReconciliationItems.identityKey,
+          status: caseLawReconciliationItems.status,
+          attempts: caseLawReconciliationItems.attempts,
+          nextAttemptAt: caseLawReconciliationItems.nextAttemptAt,
+          lastError: caseLawReconciliationItems.lastError,
+          firstSeenAt: caseLawReconciliationItems.firstSeenAt,
+          lastAttemptAt: caseLawReconciliationItems.lastAttemptAt,
+        })
+        .from(caseLawReconciliationItems)
+        .where(eq(caseLawReconciliationItems.sourceId, sourceId))
+        .orderBy(caseLawReconciliationItems.firstSeenAt)
+        .limit(limit),
+  );
+
 export type ResetTerminalReconciliationItemsInput = {
   sourceId: SafeId<"caseLawSource">;
   now: Date;
   limit: number;
+  /**
+   * Narrow the reset to one slice. An operator who fixed one publisher's bad
+   * day should be able to re-hunt that day without also re-hunting every
+   * identity the adapter has ever retired.
+   */
+  slice?: string | undefined;
 };
 
 /**
@@ -595,7 +649,7 @@ export type ResetTerminalReconciliationItemsInput = {
  */
 export const resetTerminalReconciliationItems = async (
   scopedDb: ScopedDb,
-  { sourceId, now, limit }: ResetTerminalReconciliationItemsInput,
+  { sourceId, now, limit, slice }: ResetTerminalReconciliationItemsInput,
 ): Promise<number> =>
   await scopedDb(async (tx) => {
     const due = await tx
@@ -608,6 +662,9 @@ export const resetTerminalReconciliationItems = async (
             caseLawReconciliationItems.status,
             RECONCILIATION_ITEM_STATUS.TERMINAL,
           ),
+          ...(slice === undefined
+            ? []
+            : [eq(caseLawReconciliationItems.slice, slice)]),
         ),
       )
       .orderBy(caseLawReconciliationItems.firstSeenAt)

--- a/apps/api/src/scripts/adapter-health.ts
+++ b/apps/api/src/scripts/adapter-health.ts
@@ -188,7 +188,7 @@ type SourceTotal = {
  * Fetch the total available decisions from each court
  * website via the adapter's `getTotalCount` method.
  * Each fetch is independent and has its own timeout.
- * Adapters without `getTotalCount` return null.
+ * A key with no registered adapter returns null.
  */
 const getSourceTotals = async (): Promise<SourceTotal[]> => {
   const keys = listAdapterKeys();
@@ -197,7 +197,7 @@ const getSourceTotals = async (): Promise<SourceTotal[]> => {
     keys.map(async (adapterKey: string) => {
       try {
         const adapter = await loadAdapterByKey(adapterKey);
-        if (!adapter?.getTotalCount) {
+        if (!adapter) {
           return { adapterKey, remoteTotal: null };
         }
         const signal = AbortSignal.timeout(SOURCE_TOTAL_TIMEOUT);

--- a/apps/api/src/scripts/adapter-health.ts
+++ b/apps/api/src/scripts/adapter-health.ts
@@ -14,6 +14,7 @@
  *   bun apps/api/src/scripts/adapter-health.ts --since 24h
  */
 
+import { panic } from "better-result";
 import { count, eq, gt, sql } from "drizzle-orm";
 
 import { rootDb } from "@/api/db/root";
@@ -27,6 +28,7 @@ import {
   listAdapterKeys,
   loadAdapterByKey,
 } from "@/api/handlers/case-law/ingestion/adapters/adapter-registry-lazy";
+import type { SourceTotalCount } from "@/api/lib/legal-search/ingestion-types";
 import { isRecord } from "@/api/lib/type-guards";
 
 // ── Types ───────────────────────────────────────────────
@@ -185,6 +187,29 @@ type SourceTotal = {
 };
 
 /**
+ * The denominator this report prints beside a held count, or null where there
+ * is none.
+ *
+ * Both non-count answers collapse here, and deliberately: a coverage
+ * percentage needs a denominator, and neither a publisher that states no total
+ * nor a probe that broke supplies one. The distinction is kept by the standing
+ * totals sweep, which acts on it; this report only renders what it has.
+ */
+const remoteTotalOf = (answer: SourceTotalCount): number | null => {
+  switch (answer.type) {
+    case "count":
+      return answer.total;
+    case "no-count-endpoint":
+    case "probe-failed":
+      return null;
+    default: {
+      const exhaustive: never = answer;
+      return panic(`Unhandled source total: ${JSON.stringify(exhaustive)}`);
+    }
+  }
+};
+
+/**
  * Fetch the total available decisions from each court
  * website via the adapter's `getTotalCount` method.
  * Each fetch is independent and has its own timeout.
@@ -201,8 +226,10 @@ const getSourceTotals = async (): Promise<SourceTotal[]> => {
           return { adapterKey, remoteTotal: null };
         }
         const signal = AbortSignal.timeout(SOURCE_TOTAL_TIMEOUT);
-        const remoteTotal = await adapter.getTotalCount(signal);
-        return { adapterKey, remoteTotal };
+        return {
+          adapterKey,
+          remoteTotal: remoteTotalOf(await adapter.getTotalCount(signal)),
+        };
       } catch {
         return { adapterKey, remoteTotal: null };
       }

--- a/apps/api/src/scripts/case-law-reconciliation-items.ts
+++ b/apps/api/src/scripts/case-law-reconciliation-items.ts
@@ -1,0 +1,188 @@
+import { eq } from "drizzle-orm";
+
+import { rlsDb } from "@/api/db/root";
+import { caseLawSources } from "@/api/db/schema";
+/**
+ * Read and un-retire the items the standing reconciliation loop is carrying.
+ *
+ * The loop parks an item it could not ingest, retries it on a widening
+ * schedule, and retires it to `terminal` once the schedule is exhausted. That
+ * is what lets a slice reach a fixed point instead of re-hunting the same
+ * unservable document forever — and it is a statement about the publisher and
+ * the adapter as they were when it was made. A fixed parser, or a publisher
+ * that finally serves the document, changes that, and nothing in the loop
+ * will ever look at those rows again.
+ *
+ * This is the operator entry that does. `--list` is the read that justifies a
+ * reset: it names the identities that are stuck, in which slice, on what
+ * error tag. `--reset-terminal` puts them back into the hunt as parked, due
+ * immediately, so the next work unit re-attempts them.
+ *
+ *   # what one source is carrying, oldest first
+ *   bun run src/scripts/case-law-reconciliation-items.ts --list --adapter cz-ns
+ *
+ *   # re-hunt everything this source retired
+ *   bun run src/scripts/case-law-reconciliation-items.ts \
+ *     --reset-terminal --adapter cz-ns
+ *
+ *   # re-hunt one slice, after fixing what made that day fail
+ *   bun run src/scripts/case-law-reconciliation-items.ts \
+ *     --reset-terminal --adapter cz-ns --slice 2026-06-10 --limit 200
+ *
+ * Not a scheduled job: a reset re-spends the publisher's rate limit on
+ * documents already proved unservable, so it runs under an operator who read
+ * the listing and fixed the cause.
+ */
+import { createIngestionDb } from "@/api/db/scoped";
+import { listAdapterKeys } from "@/api/handlers/case-law/ingestion/adapters/adapter-registry";
+import {
+  countReconciliationItems,
+  listReconciliationItems,
+  resetTerminalReconciliationItems,
+} from "@/api/lib/legal-search/reconciliation-store";
+
+/** Bounded by default: both modes read, and neither should scan a corpus. */
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 1000;
+
+const USAGE = `Usage: bun run src/scripts/case-law-reconciliation-items.ts <mode> --adapter <key> [options]
+
+Modes (exactly one):
+  --list                 Print the parked and terminal items this source
+                         carries, oldest first.
+  --reset-terminal       Return terminal items to parked, due now, so the
+                         loop re-hunts them.
+
+Options:
+  --adapter <key>        Required. The source to act on.
+  --slice <slice>        With --reset-terminal, reset only this slice.
+  --limit <n>            Rows read or reset (default ${DEFAULT_LIMIT}, max ${MAX_LIMIT}).
+
+Adapter keys: ${listAdapterKeys().join(", ")}`;
+
+const flagValue = (name: string): string | undefined => {
+  const index = process.argv.indexOf(`--${name}`);
+  if (index === -1) {
+    return undefined;
+  }
+  const value = process.argv[index + 1];
+  if (value === undefined || value.startsWith("--")) {
+    console.error(`--${name} requires a value`);
+    console.error(USAGE);
+    process.exit(1);
+  }
+  return value;
+};
+
+const hasFlag = (name: string): boolean => process.argv.includes(`--${name}`);
+
+const DECIMAL_INTEGER = /^\d+$/u;
+
+const list = hasFlag("list");
+const resetTerminal = hasFlag("reset-terminal");
+const adapterFlag = flagValue("adapter");
+const sliceFlag = flagValue("slice");
+const limitFlag = flagValue("limit");
+
+if ([list, resetTerminal].filter(Boolean).length !== 1) {
+  console.error("Exactly one of --list or --reset-terminal is required.");
+  console.error(USAGE);
+  process.exit(1);
+}
+
+if (adapterFlag === undefined) {
+  console.error("--adapter is required.");
+  console.error(USAGE);
+  process.exit(1);
+}
+
+const adapterKey = adapterFlag;
+if (!listAdapterKeys().some((candidate) => candidate === adapterKey)) {
+  console.error(`Unknown adapter: ${adapterKey}`);
+  console.error(USAGE);
+  process.exit(1);
+}
+
+// A slice narrows a reset; on a listing it would silently do nothing, which
+// reads as "this slice carries no items" rather than as a refused argument.
+if (sliceFlag !== undefined && !resetTerminal) {
+  console.error("--slice applies to --reset-terminal only.");
+  console.error(USAGE);
+  process.exit(1);
+}
+
+const limit = (() => {
+  if (limitFlag === undefined) {
+    return DEFAULT_LIMIT;
+  }
+  const parsed = DECIMAL_INTEGER.test(limitFlag)
+    ? Number.parseInt(limitFlag, 10)
+    : Number.NaN;
+  if (!Number.isSafeInteger(parsed) || parsed <= 0 || parsed > MAX_LIMIT) {
+    console.error(
+      `--limit must be an integer between 1 and ${MAX_LIMIT}, got: ${limitFlag}`,
+    );
+    process.exit(1);
+  }
+  return parsed;
+})();
+
+const ingestionDb = createIngestionDb(rlsDb);
+
+const source = (
+  await ingestionDb((tx) =>
+    tx
+      .select({ id: caseLawSources.id, name: caseLawSources.name })
+      .from(caseLawSources)
+      .where(eq(caseLawSources.adapterKey, adapterKey))
+      .limit(1),
+  )
+).at(0);
+
+if (!source) {
+  console.error(`No case-law source configured for adapter ${adapterKey}`);
+  process.exit(1);
+}
+
+const counts = await countReconciliationItems(ingestionDb, source.id);
+console.log(`=== RECONCILIATION ITEMS ${adapterKey} (${source.name}) ===`);
+console.log(`parked:    ${counts.parked}`);
+console.log(`terminal:  ${counts.terminal}`);
+
+if (list) {
+  const items = await listReconciliationItems(ingestionDb, {
+    sourceId: source.id,
+    limit,
+  });
+  console.log(
+    `--- oldest ${items.length} of ${counts.parked + counts.terminal} ---`,
+  );
+  for (const item of items) {
+    const attempts = String(item.attempts).padStart(2);
+    const next = item.nextAttemptAt?.toISOString() ?? "-";
+    console.log(
+      `${item.status.padEnd(8)} ${item.slice.padEnd(12)} attempts=${attempts} next=${next} lastError=${item.lastError ?? "-"} ${item.identityKey}`,
+    );
+  }
+  process.exit(0);
+}
+
+const reset = await resetTerminalReconciliationItems(ingestionDb, {
+  sourceId: source.id,
+  now: new Date(),
+  limit,
+  ...(sliceFlag === undefined ? {} : { slice: sliceFlag }),
+});
+
+const scope = sliceFlag === undefined ? "all slices" : `slice ${sliceFlag}`;
+console.log(`--- reset ---`);
+console.log(
+  `${adapterKey}: returned ${reset} terminal item(s) to parked (${scope})`,
+);
+// Bounded per run, so a source carrying more retired items than the limit
+// needs another pass; saying so beats an operator assuming the source is now
+// clear.
+if (reset === limit) {
+  console.log(`the limit of ${limit} was reached; run again to continue`);
+}
+process.exit(0);

--- a/apps/api/src/scripts/case-law-reconciliation-items.ts
+++ b/apps/api/src/scripts/case-law-reconciliation-items.ts
@@ -18,8 +18,14 @@ import { caseLawSources } from "@/api/db/schema";
  * error tag. `--reset-terminal` puts them back into the hunt as parked, due
  * immediately, so the next work unit re-attempts them.
  *
- *   # what one source is carrying, oldest first
+ *   # what one source is carrying
  *   bun run src/scripts/case-law-reconciliation-items.ts --list --adapter cz-ns
+ *
+ *   # the next page, and one slice on its own
+ *   bun run src/scripts/case-law-reconciliation-items.ts --list --adapter cz-ns \
+ *     --after 'document:2f0a1d6c-9c7f-4a58-bd4a-6c1e0f7a1b23'
+ *   bun run src/scripts/case-law-reconciliation-items.ts --list --adapter cz-ns \
+ *     --slice 2026-06-10
  *
  *   # re-hunt everything this source retired
  *   bun run src/scripts/case-law-reconciliation-items.ts \
@@ -49,13 +55,15 @@ const USAGE = `Usage: bun run src/scripts/case-law-reconciliation-items.ts <mode
 
 Modes (exactly one):
   --list                 Print the parked and terminal items this source
-                         carries, oldest first.
+                         carries, in identity-key order.
   --reset-terminal       Return terminal items to parked, due now, so the
                          loop re-hunts them.
 
 Options:
   --adapter <key>        Required. The source to act on.
-  --slice <slice>        With --reset-terminal, reset only this slice.
+  --slice <slice>        Narrow to one slice, in either mode.
+  --after <identityKey>  With --list, resume after this key. The last key a
+                         page printed is the next page's --after.
   --limit <n>            Rows read or reset (default ${DEFAULT_LIMIT}, max ${MAX_LIMIT}).
 
 Adapter keys: ${listAdapterKeys().join(", ")}`;
@@ -82,6 +90,7 @@ const list = hasFlag("list");
 const resetTerminal = hasFlag("reset-terminal");
 const adapterFlag = flagValue("adapter");
 const sliceFlag = flagValue("slice");
+const afterFlag = flagValue("after");
 const limitFlag = flagValue("limit");
 
 if ([list, resetTerminal].filter(Boolean).length !== 1) {
@@ -103,10 +112,11 @@ if (!listAdapterKeys().some((candidate) => candidate === adapterKey)) {
   process.exit(1);
 }
 
-// A slice narrows a reset; on a listing it would silently do nothing, which
-// reads as "this slice carries no items" rather than as a refused argument.
-if (sliceFlag !== undefined && !resetTerminal) {
-  console.error("--slice applies to --reset-terminal only.");
+// A cursor only means something against an ordering, and the reset selects
+// its own rows. Refused rather than ignored: an operator who paged a listing
+// and then reset would otherwise believe the reset resumed where they were.
+if (afterFlag !== undefined && !list) {
+  console.error("--after applies to --list only.");
   console.error(USAGE);
   process.exit(1);
 }
@@ -153,16 +163,27 @@ if (list) {
   const items = await listReconciliationItems(ingestionDb, {
     sourceId: source.id,
     limit,
+    ...(sliceFlag === undefined ? {} : { slice: sliceFlag }),
+    ...(afterFlag === undefined ? {} : { after: afterFlag }),
   });
+  const scope = sliceFlag === undefined ? "all slices" : `slice ${sliceFlag}`;
   console.log(
-    `--- oldest ${items.length} of ${counts.parked + counts.terminal} ---`,
+    `--- ${items.length} item(s), ${scope}, of ${counts.parked + counts.terminal} total ---`,
   );
   for (const item of items) {
     const attempts = String(item.attempts).padStart(2);
     const next = item.nextAttemptAt?.toISOString() ?? "-";
+    const seen = item.firstSeenAt.toISOString();
     console.log(
-      `${item.status.padEnd(8)} ${item.slice.padEnd(12)} attempts=${attempts} next=${next} lastError=${item.lastError ?? "-"} ${item.identityKey}`,
+      `${item.status.padEnd(8)} ${item.slice.padEnd(12)} attempts=${attempts} firstSeen=${seen} next=${next} lastError=${item.lastError ?? "-"} ${item.identityKey}`,
     );
+  }
+  // The whole backlog is reachable by walking this cursor, so a page that
+  // filled its limit says how to ask for the next one rather than leaving the
+  // operator to assume they have seen everything.
+  const lastKey = items.at(-1)?.identityKey;
+  if (items.length === limit && lastKey !== undefined) {
+    console.log(`next page: --after '${lastKey}'`);
   }
   process.exit(0);
 }

--- a/apps/api/src/scripts/case-law-source-total.ts
+++ b/apps/api/src/scripts/case-law-source-total.ts
@@ -182,11 +182,10 @@ if (totalFlag !== undefined) {
 const POLL_OUTCOME = {
   RECORDED: "recorded",
   /**
-   * The adapter states no total. Covers both an adapter that implements no
-   * `getTotalCount` and one whose implementation answers null because its
-   * publisher exposes no readable count — `SourceAdapter.getTotalCount`
-   * defines null as exactly that. Not a failure: a sweep over every adapter
-   * would otherwise always end in one, whatever the count-capable sources did.
+   * The adapter's implementation answers null because its publisher exposes
+   * no readable count — `SourceAdapter.getTotalCount` defines null as exactly
+   * that. Not a failure: a sweep over every adapter would otherwise always end
+   * in one, whatever the count-capable sources did.
    */
   NO_COUNT: "no-count",
   FAILED: "failed",
@@ -207,11 +206,11 @@ type PollResult = {
  */
 const pollOne = async (adapterKey: string): Promise<PollResult> => {
   const adapter = getAdapter(adapterKey);
-  if (!adapter?.getTotalCount) {
+  if (!adapter) {
     return {
       adapterKey,
-      outcome: POLL_OUTCOME.NO_COUNT,
-      line: `${adapterKey}: exposes no count, nothing recorded`,
+      outcome: POLL_OUTCOME.FAILED,
+      line: `${adapterKey}: no adapter registered, nothing recorded`,
     };
   }
 

--- a/apps/api/src/scripts/case-law-source-total.ts
+++ b/apps/api/src/scripts/case-law-source-total.ts
@@ -1,3 +1,5 @@
+import { panic } from "better-result";
+
 import { rlsDb } from "@/api/db/root";
 import { SOURCE_TOTAL_ORIGIN } from "@/api/db/schema";
 import { createIngestionDb } from "@/api/db/scoped";
@@ -20,11 +22,12 @@ import { isoCalendarDay } from "@/api/lib/dates";
  * and records it, with the origin kept alongside so a reader can tell a
  * measured number from a transcribed one.
  *
- * A poll that returns null or throws records NOTHING and says so. The
- * stored total is the last number the publisher actually stated, and a
- * failed probe is not evidence that it changed. Only a broken probe moves
- * the exit code: an adapter whose publisher simply states no total is
- * reported and passed over, so a full sweep is not permanently red.
+ * A poll that yields no count records NOTHING and says so. The stored total
+ * is the last number the publisher actually stated, and a failed probe is not
+ * evidence that it changed. Only a broken probe moves the exit code: an
+ * adapter whose publisher simply states no total is reported and passed over,
+ * so a full sweep is not permanently red. The adapter states which of the two
+ * it is, so the report names the failing step instead of guessing.
  *
  *   # what is recorded today
  *   bun run src/scripts/case-law-source-total.ts --list
@@ -214,13 +217,12 @@ const pollOne = async (adapterKey: string): Promise<PollResult> => {
     };
   }
 
-  // A throw is a failure of this probe; a null is the adapter's own answer
-  // that its publisher states no total. The two are kept apart so a broken
-  // probe still moves the exit code and a permanently countless source
-  // never does.
+  // The adapter classifies its own answer, so this reads a disposition rather
+  // than inferring one: a broken probe moves the exit code and a permanently
+  // countless source never does. A throw is this probe's own failure.
   const probe = await adapter
     .getTotalCount(AbortSignal.timeout(POLL_TIMEOUT_MS))
-    .then((total) => ({ ok: true, total }) as const)
+    .then((count) => ({ ok: true, count }) as const)
     .catch((error: unknown) => ({ ok: false, error }) as const);
   if (!probe.ok) {
     console.error(`${adapterKey}: poll failed —`, probe.error);
@@ -230,18 +232,32 @@ const pollOne = async (adapterKey: string): Promise<PollResult> => {
       line: `${adapterKey}: poll failed, nothing recorded`,
     };
   }
-  if (probe.total === null) {
-    return {
-      adapterKey,
-      outcome: POLL_OUTCOME.NO_COUNT,
-      line: `${adapterKey}: exposes no count, nothing recorded`,
-    };
+  const { count } = probe;
+  switch (count.type) {
+    case "no-count-endpoint":
+      return {
+        adapterKey,
+        outcome: POLL_OUTCOME.NO_COUNT,
+        line: `${adapterKey}: exposes no count, nothing recorded`,
+      };
+    case "probe-failed":
+      return {
+        adapterKey,
+        outcome: POLL_OUTCOME.FAILED,
+        line: `${adapterKey}: probe failed (${count.errorTag}), nothing recorded`,
+      };
+    case "count":
+      break;
+    default: {
+      const exhaustive: never = count;
+      return panic(`Unhandled source total: ${JSON.stringify(exhaustive)}`);
+    }
   }
   // The writer owns what counts as a usable number, so its rules are not
   // restated here — but its rejection must not escape. The probes run
   // together, so a throw would reject the whole batch and lose the result of
   // every other adapter, including the ones that succeeded.
-  const { total } = probe;
+  const { total } = count;
   const write = await setSourceReportedTotal({
     scopedDb: ingestionDb,
     adapterKey,

--- a/apps/api/src/tests/helpers/case-law-source-row.ts
+++ b/apps/api/src/tests/helpers/case-law-source-row.ts
@@ -1,0 +1,43 @@
+/**
+ * A `case_law_sources` row as the pipeline reads one.
+ *
+ * The pipeline takes a whole row, so every test that drives it has to supply
+ * one, and a hand-written literal per test means the next column lands in as
+ * many places as there are tests. Built here instead: the column set lives in
+ * one place, and `satisfies` binds the literal to the schema, so a column
+ * added, renamed or retyped fails to compile here rather than drifting.
+ */
+
+import type { caseLawSources } from "@/api/db/schema";
+import { createSafeId } from "@/api/lib/branded-types";
+import { ADAPTER_KEYS } from "@/api/lib/legal-search/ingestion-constants";
+
+type CaseLawSourceRow = typeof caseLawSources.$inferSelect;
+
+const FIXED_TIMESTAMP = new Date("2026-01-01T00:00:00.000Z");
+
+/** Fresh per call: the id is generated, so it cannot be a shared constant. */
+const defaultCaseLawSourceRow = () =>
+  ({
+    id: createSafeId<"caseLawSource">(),
+    adapterKey: ADAPTER_KEYS.CZ_NS,
+    name: "Test source",
+    enabled: true,
+    syncCursor: "cursor-1",
+    lastSyncAt: null,
+    observationOrder: 0n,
+    checkpointObservationOrder: 0n,
+    ingestionLeaseToken: null,
+    ingestionLeaseExpiresAt: null,
+    config: {},
+    descriptor: null,
+    reportedTotal: null,
+    reportedTotalAsOf: null,
+    reportedTotalOrigin: null,
+    createdAt: FIXED_TIMESTAMP,
+    updatedAt: FIXED_TIMESTAMP,
+  }) satisfies CaseLawSourceRow;
+
+export const caseLawSourceRow = (
+  overrides: Partial<CaseLawSourceRow> = {},
+): CaseLawSourceRow => ({ ...defaultCaseLawSourceRow(), ...overrides });

--- a/apps/legal-atlas-runner/src/runners/case-law-ingest.ts
+++ b/apps/legal-atlas-runner/src/runners/case-law-ingest.ts
@@ -1453,7 +1453,14 @@ export const runCaseLawIngest = async (
     const reconcilable: ReconciliationSource[] = [];
     for (const { adapterKey, name } of SOURCES) {
       const reconciliation = getAdapter(adapterKey)?.reconciliation;
-      if (!reconciliation) {
+      // Every adapter declares the capability, so the gate reads the
+      // declaration rather than the field's presence: a source that states it
+      // cannot be reconciled is skipped, and one that forgot to state anything
+      // no longer compiles.
+      if (
+        reconciliation === undefined ||
+        reconciliation.type === "unsupported"
+      ) {
         continue;
       }
       // oxlint-disable-next-line no-await-in-loop -- one bounded source lookup per configured source, at startup

--- a/apps/legal-atlas-runner/src/runners/case-law-ingest.ts
+++ b/apps/legal-atlas-runner/src/runners/case-law-ingest.ts
@@ -1596,7 +1596,7 @@ export const runCaseLawIngest = async (
             `noCount=${summary.noCount} ` +
             `failed=${summary.failed} ` +
             `unknownSource=${summary.unknownSource} ` +
-            `lastErrorType=${summary.lastError === undefined ? "none" : errorTag(summary.lastError)}`,
+            `lastErrorType=${summary.lastErrorTag ?? "none"}`,
         );
       },
       sleep: async (ms) => {

--- a/apps/legal-atlas-runner/src/runners/source-total-outcomes.test.ts
+++ b/apps/legal-atlas-runner/src/runners/source-total-outcomes.test.ts
@@ -14,7 +14,6 @@ import type { SourceAdapter } from "@/api/lib/legal-search/ingestion-types";
 import {
   SOURCE_TOTAL_POLL_OUTCOME,
   SOURCE_TOTAL_STALE_AFTER_MS,
-  selectCountingAdapters,
   selectDueCountingAdapters,
   tallySourceTotalPollOutcomes,
   type SourceTotalPollOutcome,
@@ -22,7 +21,7 @@ import {
 
 const adapter = (
   key: SourceAdapter["key"],
-  getTotalCount?: SourceAdapter["getTotalCount"],
+  getTotalCount: SourceAdapter["getTotalCount"] = async () => null,
 ): SourceAdapter => ({
   key,
   name: `${key} fixture`,
@@ -32,7 +31,11 @@ const adapter = (
   fetchPage: () => {
     throw new Error("fetchPage is not exercised by outcome selection");
   },
-  ...(getTotalCount && { getTotalCount }),
+  getTotalCount,
+  reconciliation: {
+    type: "unsupported",
+    reason: "fixture: outcome selection never reconciles",
+  },
 });
 
 const NOW = Date.UTC(2026, 7, 11, 12, 0, 0);
@@ -50,21 +53,25 @@ const recorded = (
     reportedTotalAsOf === null ? null : SOURCE_TOTAL_ORIGIN.ADAPTER_POLL,
 });
 
-describe("selectCountingAdapters", () => {
-  test("asks by capability, so a new implementer joins on its own", () => {
-    const counting = adapter(ADAPTER_KEYS.CZ_US, async () => 42);
-    const alsoCounting = adapter(ADAPTER_KEYS.PL_COURTS, async () => null);
-    const silent = adapter(ADAPTER_KEYS.CZ_NS);
+describe("selectDueCountingAdapters", () => {
+  test("asks every adapter, because every adapter can be asked", () => {
+    // The capability is required, so the sweep no longer selects on it: an
+    // adapter is either due or fresh, never exempt.
+    const adapters = [
+      adapter(ADAPTER_KEYS.CZ_US, async () => 42),
+      adapter(ADAPTER_KEYS.CZ_NS),
+      adapter(ADAPTER_KEYS.PL_COURTS, async () => null),
+    ];
 
     expect(
-      selectCountingAdapters([counting, silent, alsoCounting]).map(
-        ({ key }) => key,
-      ),
-    ).toEqual([ADAPTER_KEYS.CZ_US, ADAPTER_KEYS.PL_COURTS]);
-  });
-
-  test("an adapter stating no count is never probed", () => {
-    expect(selectCountingAdapters([adapter(ADAPTER_KEYS.CZ_NS)])).toEqual([]);
+      selectDueCountingAdapters({
+        adapters,
+        askedAt: NEVER_ASKED,
+        now: NOW,
+        staleAfterMs: SOURCE_TOTAL_STALE_AFTER_MS,
+        totals: [],
+      }).map(({ key }) => key),
+    ).toEqual([ADAPTER_KEYS.CZ_US, ADAPTER_KEYS.CZ_NS, ADAPTER_KEYS.PL_COURTS]);
   });
 });
 
@@ -124,7 +131,9 @@ describe("selectDueCountingAdapters", () => {
     ).toEqual([ADAPTER_KEYS.CZ_US, ADAPTER_KEYS.CZ_REGIONAL]);
   });
 
-  test("a stale total on an adapter that cannot count is not asked", () => {
+  test("a source carrying a row but no measurement is asked", () => {
+    // A row with a null date and a source with no row are the same case: the
+    // publisher has never stated a total, so the sweep has to ask.
     expect(
       selectDueCountingAdapters({
         adapters: [adapter(ADAPTER_KEYS.CZ_NS)],
@@ -132,8 +141,8 @@ describe("selectDueCountingAdapters", () => {
         now: NOW,
         staleAfterMs: SOURCE_TOTAL_STALE_AFTER_MS,
         totals: [recorded(ADAPTER_KEYS.CZ_NS, null)],
-      }),
-    ).toEqual([]);
+      }).map(({ key }) => key),
+    ).toEqual([ADAPTER_KEYS.CZ_NS]);
   });
 
   test("a source asked recently is not asked again, whatever it answered", () => {

--- a/apps/legal-atlas-runner/src/runners/source-total-outcomes.test.ts
+++ b/apps/legal-atlas-runner/src/runners/source-total-outcomes.test.ts
@@ -21,7 +21,9 @@ import {
 
 const adapter = (
   key: SourceAdapter["key"],
-  getTotalCount: SourceAdapter["getTotalCount"] = async () => null,
+  getTotalCount: SourceAdapter["getTotalCount"] = async () => ({
+    type: "no-count-endpoint",
+  }),
 ): SourceAdapter => ({
   key,
   name: `${key} fixture`,
@@ -58,9 +60,11 @@ describe("selectDueCountingAdapters", () => {
     // The capability is required, so the sweep no longer selects on it: an
     // adapter is either due or fresh, never exempt.
     const adapters = [
-      adapter(ADAPTER_KEYS.CZ_US, async () => 42),
+      adapter(ADAPTER_KEYS.CZ_US, async () => ({ type: "count", total: 42 })),
       adapter(ADAPTER_KEYS.CZ_NS),
-      adapter(ADAPTER_KEYS.PL_COURTS, async () => null),
+      adapter(ADAPTER_KEYS.PL_COURTS, async () => ({
+        type: "no-count-endpoint",
+      })),
     ];
 
     expect(
@@ -75,8 +79,14 @@ describe("selectDueCountingAdapters", () => {
   });
 });
 
-const czUs = adapter(ADAPTER_KEYS.CZ_US, async () => 1);
-const czRegional = adapter(ADAPTER_KEYS.CZ_REGIONAL, async () => 2);
+const czUs = adapter(ADAPTER_KEYS.CZ_US, async () => ({
+  type: "count",
+  total: 1,
+}));
+const czRegional = adapter(ADAPTER_KEYS.CZ_REGIONAL, async () => ({
+  type: "count",
+  total: 2,
+}));
 
 describe("selectDueCountingAdapters", () => {
   const capable = [czUs, czRegional];
@@ -146,10 +156,9 @@ describe("selectDueCountingAdapters", () => {
   });
 
   test("a source asked recently is not asked again, whatever it answered", () => {
-    // `getTotalCount` returns null both for a publisher exposing no count
-    // and for a request that failed, and neither persists a date. Gating on
-    // the recorded date alone would re-ask those sources every wake, hours
-    // apart, which no failure surfaces.
+    // Neither a publisher that exposes no count nor a request that failed
+    // persists a date. Gating on the recorded date alone would re-ask those
+    // sources every wake, hours apart, which no failure surfaces.
     expect(
       selectDueCountingAdapters({
         adapters: capable,

--- a/apps/legal-atlas-runner/src/runners/source-total-outcomes.ts
+++ b/apps/legal-atlas-runner/src/runners/source-total-outcomes.ts
@@ -31,10 +31,9 @@ export const SOURCE_TOTAL_POLL_OUTCOME = {
   /** The publisher stated a number and it is now the recorded total. */
   RECORDED: "recorded",
   /**
-   * The adapter yielded no number. `SourceAdapter.getTotalCount` returns null
-   * both for a publisher that exposes no readable count and for a request
-   * that failed, and the contract keeps no way to tell them apart, so this
-   * cannot mean "the publisher states no total" — only that none was read.
+   * The publisher exposes no readable count, as the adapter itself states.
+   * Exact rather than inferred: a probe that broke is a failure, and only the
+   * adapter can tell the two apart.
    *
    * Not tallied as a failure: several publishers permanently expose no count,
    * and a sweep over them would otherwise always end in one. What keeps a

--- a/apps/legal-atlas-runner/src/runners/source-total-outcomes.ts
+++ b/apps/legal-atlas-runner/src/runners/source-total-outcomes.ts
@@ -59,25 +59,6 @@ export type SourceTotalPollTally = {
   unknownSource: number;
 };
 
-/** An adapter whose publisher exposes a count it can read. */
-export type CountingSourceAdapter = SourceAdapter & {
-  getTotalCount: NonNullable<SourceAdapter["getTotalCount"]>;
-};
-
-/**
- * The adapters worth asking at all, by capability rather than by name. An
- * adapter that starts implementing `getTotalCount` joins the sweep on its
- * own; a hand-kept list would leave it out and report nothing about the
- * omission.
- */
-export const selectCountingAdapters = (
-  adapters: readonly SourceAdapter[],
-): CountingSourceAdapter[] =>
-  adapters.filter(
-    (adapter): adapter is CountingSourceAdapter =>
-      adapter.getTotalCount !== undefined,
-  );
-
 type SelectDueCountingAdaptersOptions = {
   adapters: readonly SourceAdapter[];
   /** When this process last asked each adapter, whatever it answered. */
@@ -89,8 +70,9 @@ type SelectDueCountingAdaptersOptions = {
 };
 
 /**
- * The adapters to ask on this wake: those that can answer, and that have
- * neither been recorded nor asked inside the window.
+ * The adapters to ask on this wake: those that have neither been recorded nor
+ * asked inside the window. Every adapter can be asked — the capability is
+ * required — so the only gate left is the cadence.
  *
  * The gate is the last ask, not the last success. A publisher that exposes
  * no count and one whose request failed both come back as null and persist
@@ -109,7 +91,7 @@ export const selectDueCountingAdapters = ({
   now,
   staleAfterMs,
   totals,
-}: SelectDueCountingAdaptersOptions): CountingSourceAdapter[] => {
+}: SelectDueCountingAdaptersOptions): SourceAdapter[] => {
   const recordedAt = new Map(
     totals.map(({ adapterKey, reportedTotalAsOf }) => [
       adapterKey,
@@ -117,7 +99,7 @@ export const selectDueCountingAdapters = ({
     ]),
   );
 
-  return selectCountingAdapters(adapters).filter((adapter) => {
+  return adapters.filter((adapter) => {
     const recorded = recordedAt.get(adapter.key)?.getTime();
     const asked = askedAt.get(adapter.key);
     // The later of the two is what the window runs from: a recorded total

--- a/apps/legal-atlas-runner/src/runners/source-total-poll.test.ts
+++ b/apps/legal-atlas-runner/src/runners/source-total-poll.test.ts
@@ -35,7 +35,9 @@ const NOW = Date.UTC(2026, 7, 11, 12, 0, 0);
 
 const adapter = (
   key: SourceAdapter["key"],
-  getTotalCount: SourceAdapter["getTotalCount"] = async () => null,
+  getTotalCount: SourceAdapter["getTotalCount"] = async () => ({
+    type: "no-count-endpoint",
+  }),
 ): SourceAdapter => ({
   key,
   name: `${key} fixture`,
@@ -131,7 +133,12 @@ describe("runSourceTotalPoll", () => {
   test("records what a publisher states, once, and stays quiet while it is fresh", async () => {
     const sweeps = 3;
     const { reports, slept, written } = await runHarness({
-      adapters: [adapter(ADAPTER_KEYS.CZ_US, async () => 8000)],
+      adapters: [
+        adapter(ADAPTER_KEYS.CZ_US, async () => ({
+          type: "count",
+          total: 8000,
+        })),
+      ],
       sweeps,
       totals: [unmeasured(ADAPTER_KEYS.CZ_US)],
     });
@@ -152,7 +159,7 @@ describe("runSourceTotalPoll", () => {
         noCount: 0,
         failed: 0,
         unknownSource: 0,
-        lastError: undefined,
+        lastErrorTag: undefined,
       },
     ]);
     // Sliced pacing: the gap between sweeps is the interval, not one sleep.
@@ -167,8 +174,9 @@ describe("runSourceTotalPoll", () => {
       adapters: [
         adapter(ADAPTER_KEYS.CZ_US, async () => {
           probes += 1;
-          // What a failed request looks like through the adapter contract.
-          return null;
+          // A publisher that exposes no count: nothing is persisted, so only
+          // the ask gate can stop the next wake re-probing it.
+          return { type: "no-count-endpoint" };
         }),
       ],
       sweeps: 4,
@@ -183,7 +191,12 @@ describe("runSourceTotalPoll", () => {
 
   test("a fresh total asks nobody and reports nothing", async () => {
     const { reports, written } = await runHarness({
-      adapters: [adapter(ADAPTER_KEYS.CZ_US, async () => 8000)],
+      adapters: [
+        adapter(ADAPTER_KEYS.CZ_US, async () => ({
+          type: "count",
+          total: 8000,
+        })),
+      ],
       sweeps: 2,
       totals: [measuredAt(ADAPTER_KEYS.CZ_US, new Date(NOW - DAY_IN_MS))],
     });
@@ -198,7 +211,9 @@ describe("runSourceTotalPoll", () => {
         adapter(ADAPTER_KEYS.CZ_US, async () => {
           throw new Error("publisher unreachable");
         }),
-        adapter(ADAPTER_KEYS.CZ_REGIONAL, async () => null),
+        adapter(ADAPTER_KEYS.CZ_REGIONAL, async () => ({
+          type: "no-count-endpoint",
+        })),
       ],
       sweeps: 1,
       totals: [
@@ -217,7 +232,7 @@ describe("runSourceTotalPoll", () => {
       failed: 1,
       unknownSource: 0,
     });
-    expect(reports.at(0)?.lastError).toBeInstanceOf(Error);
+    expect(reports.at(0)?.lastErrorTag).toBe("Error");
   });
 
   test("one publisher's failure does not lose another's answer", async () => {
@@ -226,7 +241,10 @@ describe("runSourceTotalPoll", () => {
         adapter(ADAPTER_KEYS.CZ_US, async () => {
           throw new Error("publisher unreachable");
         }),
-        adapter(ADAPTER_KEYS.CZ_REGIONAL, async () => 4321),
+        adapter(ADAPTER_KEYS.CZ_REGIONAL, async () => ({
+          type: "count",
+          total: 4321,
+        })),
       ],
       sweeps: 1,
       totals: [
@@ -244,7 +262,12 @@ describe("runSourceTotalPoll", () => {
   test("a write rejection is counted, not thrown, and the loop continues", async () => {
     const sweeps = 2;
     const { reports, slept } = await runHarness({
-      adapters: [adapter(ADAPTER_KEYS.CZ_US, async () => 8000)],
+      adapters: [
+        adapter(ADAPTER_KEYS.CZ_US, async () => ({
+          type: "count",
+          total: 8000,
+        })),
+      ],
       recordTotal: async () => {
         throw new TypeError("reported total must be a positive integer");
       },
@@ -262,7 +285,12 @@ describe("runSourceTotalPoll", () => {
 
   test("an adapter with no source row is counted as registry drift", async () => {
     const { reports } = await runHarness({
-      adapters: [adapter(ADAPTER_KEYS.CZ_US, async () => 8000)],
+      adapters: [
+        adapter(ADAPTER_KEYS.CZ_US, async () => ({
+          type: "count",
+          total: 8000,
+        })),
+      ],
       recordTotal: async () => false,
       sweeps: 1,
       totals: [unmeasured(ADAPTER_KEYS.CZ_US)],
@@ -278,7 +306,12 @@ describe("runSourceTotalPoll", () => {
   test("a failed read is reported rather than read as a fresh corpus", async () => {
     let reads = 0;
     const { reports } = await runHarness({
-      adapters: [adapter(ADAPTER_KEYS.CZ_US, async () => 8000)],
+      adapters: [
+        adapter(ADAPTER_KEYS.CZ_US, async () => ({
+          type: "count",
+          total: 8000,
+        })),
+      ],
       readTotals: async () => {
         reads += 1;
         throw new Error("database unreachable");
@@ -288,14 +321,19 @@ describe("runSourceTotalPoll", () => {
 
     expect(reads).toBeGreaterThan(0);
     expect(reports.at(0)).toMatchObject({ polled: 0, failed: 0 });
-    expect(reports.at(0)?.lastError).toBeInstanceOf(Error);
+    expect(reports.at(0)?.lastErrorTag).toBe("Error");
   });
 
   test("a draining process is not asked for a sweep", async () => {
     let reads = 0;
 
     await runSourceTotalPoll({
-      adapters: [adapter(ADAPTER_KEYS.CZ_US, async () => 8000)],
+      adapters: [
+        adapter(ADAPTER_KEYS.CZ_US, async () => ({
+          type: "count",
+          total: 8000,
+        })),
+      ],
       isDraining: () => true,
       now: () => NOW,
       readTotals: async () => {

--- a/apps/legal-atlas-runner/src/runners/source-total-poll.test.ts
+++ b/apps/legal-atlas-runner/src/runners/source-total-poll.test.ts
@@ -35,7 +35,7 @@ const NOW = Date.UTC(2026, 7, 11, 12, 0, 0);
 
 const adapter = (
   key: SourceAdapter["key"],
-  getTotalCount?: SourceAdapter["getTotalCount"],
+  getTotalCount: SourceAdapter["getTotalCount"] = async () => null,
 ): SourceAdapter => ({
   key,
   name: `${key} fixture`,
@@ -45,7 +45,11 @@ const adapter = (
   fetchPage: () => {
     throw new Error("fetchPage is not exercised by the poll");
   },
-  ...(getTotalCount && { getTotalCount }),
+  getTotalCount,
+  reconciliation: {
+    type: "unsupported",
+    reason: "fixture: the totals poll never reconciles",
+  },
 });
 
 const unmeasured = (adapterKey: SourceAdapter["key"]): SourceReportedTotal => ({

--- a/apps/legal-atlas-runner/src/runners/source-total-poll.ts
+++ b/apps/legal-atlas-runner/src/runners/source-total-poll.ts
@@ -27,7 +27,6 @@ import { DRAIN_CHECK_SLICE_MS } from "./sk-document-drain";
 import {
   SOURCE_TOTAL_POLL_OUTCOME,
   SOURCE_TOTAL_STALE_AFTER_MS,
-  type CountingSourceAdapter,
   type SourceTotalPollOutcome,
   type SourceTotalPollTally,
   selectDueCountingAdapters,
@@ -87,7 +86,7 @@ type SourceTotalProbe =
   | { status: "failed"; error: unknown };
 
 type ProbedSourceTotal = {
-  adapter: CountingSourceAdapter;
+  adapter: SourceAdapter;
   probe: SourceTotalProbe;
 };
 
@@ -97,7 +96,7 @@ type SettledSourceTotal = {
 };
 
 type ProbeSourceTotalOptions = {
-  adapter: CountingSourceAdapter;
+  adapter: SourceAdapter;
   timeoutMs: number;
 };
 

--- a/apps/legal-atlas-runner/src/runners/source-total-poll.ts
+++ b/apps/legal-atlas-runner/src/runners/source-total-poll.ts
@@ -2,10 +2,11 @@
  * The standing sweep over the totals publishers report holding.
  *
  * Held-vs-total coverage needs a denominator, and only some publishers
- * expose a cheap count. Those adapters implement `getTotalCount` and are
- * asked here; for the rest an operator records the publisher's own figure,
- * with the origin kept alongside so a reader can tell a measured number
- * from a transcribed one.
+ * expose a cheap count. Every adapter is asked, and answers with the count,
+ * with "my publisher exposes none", or with the probe that failed; where a
+ * publisher exposes none, an operator records its own stated figure, with the
+ * origin kept alongside so a reader can tell a measured number from a
+ * transcribed one.
  *
  * What decides a sweep is when each source was last recorded or asked, not
  * an interval this process has been awake for. The wake is frequent and
@@ -20,8 +21,14 @@
  * pacing can be exercised on their own.
  */
 
+import { panic } from "better-result";
+
 import type { SourceReportedTotal } from "@/api/handlers/case-law/ingestion/source-totals";
-import type { SourceAdapter } from "@/api/lib/legal-search/ingestion-types";
+import { errorTag } from "@/api/lib/errors/error-tag";
+import type {
+  SourceAdapter,
+  SourceTotalCount,
+} from "@/api/lib/legal-search/ingestion-types";
 
 import { DRAIN_CHECK_SLICE_MS } from "./sk-document-drain";
 import {
@@ -35,11 +42,12 @@ import {
 
 export type SourceTotalPollSummary = SourceTotalPollTally & {
   /**
-   * The most recent throw, so an error rate has a cause beside it. Left
-   * raw: the caller renders it, and it renders a tag rather than a message,
-   * because a message can carry more than an operator asked to see.
+   * The most recent failure's structural tag, so an error rate has a cause
+   * beside it. A tag rather than the error, reduced here rather than at the
+   * sink: a message can carry more than an operator asked to see, and a
+   * summary that never holds one cannot leak one.
    */
-  lastError: unknown;
+  lastErrorTag: string | undefined;
 };
 
 export type SourceTotalPollTiming = {
@@ -80,19 +88,14 @@ export type SourceTotalPollOptions = {
   timing: SourceTotalPollTiming;
 };
 
-type SourceTotalProbe =
-  | { status: "counted"; total: number }
-  | { status: "no-count" }
-  | { status: "failed"; error: unknown };
-
 type ProbedSourceTotal = {
   adapter: SourceAdapter;
-  probe: SourceTotalProbe;
+  count: SourceTotalCount;
 };
 
 type SettledSourceTotal = {
   outcome: SourceTotalPollOutcome;
-  error: unknown;
+  errorTag: string | undefined;
 };
 
 type ProbeSourceTotalOptions = {
@@ -101,24 +104,26 @@ type ProbeSourceTotalOptions = {
 };
 
 /**
- * One probe against one publisher. A throw is a failure of this probe; a
- * null is the adapter's own answer that its publisher states no total, so
- * the two are kept apart rather than collapsed into "no number".
+ * One probe against one publisher.
+ *
+ * The adapter classifies its own answer, so a publisher that states no total
+ * and a request that broke arrive here already apart; a throw is this probe's
+ * own failure and joins the second.
  */
 const probeSourceTotal = async ({
   adapter,
   timeoutMs,
 }: ProbeSourceTotalOptions): Promise<ProbedSourceTotal> => {
   try {
-    const total = await adapter.getTotalCount(AbortSignal.timeout(timeoutMs));
-
     return {
       adapter,
-      probe:
-        total === null ? { status: "no-count" } : { status: "counted", total },
+      count: await adapter.getTotalCount(AbortSignal.timeout(timeoutMs)),
     };
   } catch (error) {
-    return { adapter, probe: { status: "failed", error } };
+    return {
+      adapter,
+      count: { type: "probe-failed", errorTag: errorTag(error) },
+    };
   }
 };
 
@@ -136,22 +141,28 @@ type RecordProbedTotalOptions = {
  */
 const recordProbedTotal = async ({
   asOf,
-  probed: { adapter, probe },
+  probed: { adapter, count },
   recordTotal,
 }: RecordProbedTotalOptions): Promise<SettledSourceTotal> => {
-  switch (probe.status) {
-    case "no-count": {
-      return { outcome: SOURCE_TOTAL_POLL_OUTCOME.NO_COUNT, error: undefined };
+  switch (count.type) {
+    case "no-count-endpoint": {
+      return {
+        outcome: SOURCE_TOTAL_POLL_OUTCOME.NO_COUNT,
+        errorTag: undefined,
+      };
     }
-    case "failed": {
-      return { outcome: SOURCE_TOTAL_POLL_OUTCOME.FAILED, error: probe.error };
+    case "probe-failed": {
+      return {
+        outcome: SOURCE_TOTAL_POLL_OUTCOME.FAILED,
+        errorTag: count.errorTag,
+      };
     }
-    case "counted": {
+    case "count": {
       try {
         const applied = await recordTotal({
           adapterKey: adapter.key,
           asOf,
-          total: probe.total,
+          total: count.total,
         });
 
         // An adapter the sources table does not carry is registry drift: the
@@ -161,20 +172,20 @@ const recordProbedTotal = async ({
           outcome: applied
             ? SOURCE_TOTAL_POLL_OUTCOME.RECORDED
             : SOURCE_TOTAL_POLL_OUTCOME.UNKNOWN_SOURCE,
-          error: undefined,
+          errorTag: undefined,
         };
       } catch (error) {
-        return { outcome: SOURCE_TOTAL_POLL_OUTCOME.FAILED, error };
+        return {
+          outcome: SOURCE_TOTAL_POLL_OUTCOME.FAILED,
+          errorTag: errorTag(error),
+        };
       }
     }
     default: {
-      const exhaustive: never = probe;
-      return {
-        outcome: SOURCE_TOTAL_POLL_OUTCOME.FAILED,
-        error: new Error(
-          `unhandled source-total probe: ${JSON.stringify(exhaustive)}`,
-        ),
-      };
+      const exhaustive: never = count;
+      return panic(
+        `unhandled source-total answer: ${JSON.stringify(exhaustive)}`,
+      );
     }
   }
 };
@@ -203,7 +214,10 @@ const sweepSourceTotals = async ({
   } catch (error) {
     // A read that failed is not "everything is fresh", so it is reported
     // rather than passed over in silence.
-    return { ...tallySourceTotalPollOutcomes([]), lastError: error };
+    return {
+      ...tallySourceTotalPollOutcomes([]),
+      lastErrorTag: errorTag(error),
+    };
   }
 
   const askedAtSweepStart = now();
@@ -247,16 +261,16 @@ const sweepSourceTotals = async ({
     ),
   );
 
-  let lastError: unknown;
-  for (const { error } of settled) {
-    if (error !== undefined) {
-      lastError = error;
+  let lastErrorTag: string | undefined;
+  for (const settledTotal of settled) {
+    if (settledTotal.errorTag !== undefined) {
+      lastErrorTag = settledTotal.errorTag;
     }
   }
 
   return {
     ...tallySourceTotalPollOutcomes(settled.map(({ outcome }) => outcome)),
-    lastError,
+    lastErrorTag,
   };
 };
 

--- a/scripts/ratchet-baseline.json
+++ b/scripts/ratchet-baseline.json
@@ -204,7 +204,7 @@
     "files": {}
   },
   "lint-suppression-directives": {
-    "count": 774,
+    "count": 773,
     "files": {
       "apps/api/scripts/ai-provider-canary-config.ts": 1,
       "apps/api/scripts/ai-provider-canary.ts": 4,
@@ -248,7 +248,7 @@
       "apps/api/src/handlers/case-law/ingestion/adapters/sk-us.ts": 2,
       "apps/api/src/handlers/case-law/ingestion/adapters/update-fixtures.ts": 2,
       "apps/api/src/handlers/case-law/ingestion/parsers/cz-ns.ts": 1,
-      "apps/api/src/handlers/case-law/ingestion/pipeline.ts": 11,
+      "apps/api/src/handlers/case-law/ingestion/pipeline.ts": 10,
       "apps/api/src/handlers/case-law/ingestion/reconciliation-engine.ts": 10,
       "apps/api/src/handlers/case-law/polarity/classifier.ts": 2,
       "apps/api/src/handlers/case-law/polarity/rule-engine.ts": 1,


### PR DESCRIPTION
Makes the case-law adapter capability set structurally required, and closes the contract loose ends the capability wave surfaced. Seven commits, one concern each.

**Required capabilities.** `getTotalCount` and `reconciliation` are now required on `SourceAdapter`. `reconciliation` is `SourceReconciliation | ReconciliationUnsupported`, discriminated so the eight implementers needed no edit; the registry test pins the allowed-unsupported set to exactly `["at-courts"]` (its capability arrives in a separate in-flight change), with failure output spelling the remedy in both directions: a new adapter must implement, and when at-courts gains its capability the list must empty and the union collapse. Companion assertions check every adapter's count probe is callable and every declared slice order actually behaves (epoch reachable, tip window non-zero).

**The count probe answers honestly.** `getTotalCount` returns a discriminated result — a count, "no count endpoint", or "probe failed" with an error tag — instead of `number | null` conflating the last two. All consumers updated: the daemon totals poll's no-count/failed split becomes exact instead of inferred, the operator CLI names the failure, and adapter health states its projection explicitly. This also unified four inconsistent validity rules: all nine adapters now reject anything but a positive safe integer, and cz-regional refuses a partial year-sum rather than recording a floor as a total.

**Dead mechanism removed.** No adapter emits `SyncPage.coverage` anymore (the reconciliation loop is the ledger's single writer), so the field and its pipeline call site are gone; `recordSliceCoverage` stays as the engine's write path.

**Smaller items:** a shared test fixture builder replaces four hand-built 15-field source-row literals; a bounded operator script (`case-law-reconciliation-items.ts`) lists parked/terminal items and resets terminal ones after an operator fixes the underlying cause; the eu-ecj parser suite gets the same explicit timeout budget its two siblings received; and the lint-suppression ratchet baseline is tightened to the current floor.

One structural fix found on the way: importing `errorTag` pulled in `errors/utils.ts`, whose dev logger validates the entire API environment at module load — a trap for any non-API process. The pure tag helpers moved to `lib/errors/error-tag.ts` with a re-export, zero churn for existing importers.

Suites: runner 76, ingestion tree 839 (including the identity-wave tests passing unmodified against the new contract), scripts 81, registry conformance 6 — all green; both baselines at or below.
