### PR TITLE
feat(db): org-pinned RLS for workspace tables carrying organization_id

### DIFF
--- a/apps/api/drizzle/20260812110000_org_pinned_workspace_policies/migration.sql
+++ b/apps/api/drizzle/20260812110000_org_pinned_workspace_policies/migration.sql
@@ -1,0 +1,603 @@
+SET LOCAL lock_timeout = '1s';--> statement-breakpoint
+SET LOCAL statement_timeout = '5s';--> statement-breakpoint
+
+-- Align every workspace-scoped table that also persists organization_id on the
+-- org-pinned policy form already used by time_entries, office_file_evidence,
+-- template_persistence_requests, and the document-review tables. The workspace
+-- pin alone authorizes a row by its workspace_id; adding the organization
+-- predicate means a row whose organization_id disagrees with the transaction's
+-- tenant is unreachable regardless of how its workspace was authorized. Both
+-- scopes are already set on every scoped transaction (apps/api/src/db/scoped.ts
+-- sets app.organization_id unconditionally), so this narrows nothing that the
+-- application relies on.
+--
+-- The predicate below is the exact rendering of wsOrganizationPolicies() from
+-- apps/api/src/db/rls.ts, so drizzle's declarative model and the live catalog
+-- agree and db:push reports no drift.
+--
+-- Each table's four DROPs and four CREATEs are contiguous and the statements
+-- are individually breakpointed, so a failure names the table it happened on.
+-- Policy DDL takes a brief ACCESS EXCLUSIVE lock per table; lock_timeout above
+-- keeps a blocked table from stalling the deployment. Nothing else runs here.
+
+-- stella-migration-safety: reviewed destructive-change - each listed table's four workspace-only policies are dropped and immediately recreated under the wsOrganizationPolicies names with the organization predicate added, inside the same transaction, so no table is ever left without a policy; rollback restores the prior names with the matching application revision.
+
+-- billing_codes
+DROP POLICY "workspace_select" ON "billing_codes";--> statement-breakpoint
+DROP POLICY "workspace_insert" ON "billing_codes";--> statement-breakpoint
+DROP POLICY "workspace_update" ON "billing_codes";--> statement-breakpoint
+DROP POLICY "workspace_delete" ON "billing_codes";--> statement-breakpoint
+CREATE POLICY "billing_codes_workspace_select"
+  ON "billing_codes" AS PERMISSIVE FOR SELECT TO stella
+  USING ((CASE
+    WHEN workspace_id = ANY(COALESCE(NULLIF((SELECT pg_catalog.current_setting(
+      'app.workspace_ids', true)), '')::uuid[], ARRAY[]::uuid[]))
+    THEN true
+    ELSE workspace_id IN (
+      SELECT aw.authorized_workspace_id
+      FROM public.stella_authorized_workspaces aw
+    )
+  END) AND organization_id = (SELECT current_setting(
+    'app.organization_id', true
+  )));--> statement-breakpoint
+CREATE POLICY "billing_codes_workspace_insert"
+  ON "billing_codes" AS PERMISSIVE FOR INSERT TO stella
+  WITH CHECK ((CASE
+    WHEN workspace_id = ANY(COALESCE(NULLIF((SELECT pg_catalog.current_setting(
+      'app.workspace_ids', true)), '')::uuid[], ARRAY[]::uuid[]))
+    THEN true
+    ELSE workspace_id IN (
+      SELECT aw.authorized_workspace_id
+      FROM public.stella_authorized_workspaces aw
+    )
+  END) AND organization_id = (SELECT current_setting(
+    'app.organization_id', true
+  )));--> statement-breakpoint
+CREATE POLICY "billing_codes_workspace_update"
+  ON "billing_codes" AS PERMISSIVE FOR UPDATE TO stella
+  USING ((CASE
+    WHEN workspace_id = ANY(COALESCE(NULLIF((SELECT pg_catalog.current_setting(
+      'app.workspace_ids', true)), '')::uuid[], ARRAY[]::uuid[]))
+    THEN true
+    ELSE workspace_id IN (
+      SELECT aw.authorized_workspace_id
+      FROM public.stella_authorized_workspaces aw
+    )
+  END) AND organization_id = (SELECT current_setting(
+    'app.organization_id', true
+  )));--> statement-breakpoint
+CREATE POLICY "billing_codes_workspace_delete"
+  ON "billing_codes" AS PERMISSIVE FOR DELETE TO stella
+  USING ((CASE
+    WHEN workspace_id = ANY(COALESCE(NULLIF((SELECT pg_catalog.current_setting(
+      'app.workspace_ids', true)), '')::uuid[], ARRAY[]::uuid[]))
+    THEN true
+    ELSE workspace_id IN (
+      SELECT aw.authorized_workspace_id
+      FROM public.stella_authorized_workspaces aw
+    )
+  END) AND organization_id = (SELECT current_setting(
+    'app.organization_id', true
+  )));--> statement-breakpoint
+
+-- rate_tables
+DROP POLICY "workspace_select" ON "rate_tables";--> statement-breakpoint
+DROP POLICY "workspace_insert" ON "rate_tables";--> statement-breakpoint
+DROP POLICY "workspace_update" ON "rate_tables";--> statement-breakpoint
+DROP POLICY "workspace_delete" ON "rate_tables";--> statement-breakpoint
+CREATE POLICY "rate_tables_workspace_select"
+  ON "rate_tables" AS PERMISSIVE FOR SELECT TO stella
+  USING ((CASE
+    WHEN workspace_id = ANY(COALESCE(NULLIF((SELECT pg_catalog.current_setting(
+      'app.workspace_ids', true)), '')::uuid[], ARRAY[]::uuid[]))
+    THEN true
+    ELSE workspace_id IN (
+      SELECT aw.authorized_workspace_id
+      FROM public.stella_authorized_workspaces aw
+    )
+  END) AND organization_id = (SELECT current_setting(
+    'app.organization_id', true
+  )));--> statement-breakpoint
+CREATE POLICY "rate_tables_workspace_insert"
+  ON "rate_tables" AS PERMISSIVE FOR INSERT TO stella
+  WITH CHECK ((CASE
+    WHEN workspace_id = ANY(COALESCE(NULLIF((SELECT pg_catalog.current_setting(
+      'app.workspace_ids', true)), '')::uuid[], ARRAY[]::uuid[]))
+    THEN true
+    ELSE workspace_id IN (
+      SELECT aw.authorized_workspace_id
+      FROM public.stella_authorized_workspaces aw
+    )
+  END) AND organization_id = (SELECT current_setting(
+    'app.organization_id', true
+  )));--> statement-breakpoint
+CREATE POLICY "rate_tables_workspace_update"
+  ON "rate_tables" AS PERMISSIVE FOR UPDATE TO stella
+  USING ((CASE
+    WHEN workspace_id = ANY(COALESCE(NULLIF((SELECT pg_catalog.current_setting(
+      'app.workspace_ids', true)), '')::uuid[], ARRAY[]::uuid[]))
+    THEN true
+    ELSE workspace_id IN (
+      SELECT aw.authorized_workspace_id
+      FROM public.stella_authorized_workspaces aw
+    )
+  END) AND organization_id = (SELECT current_setting(
+    'app.organization_id', true
+  )));--> statement-breakpoint
+CREATE POLICY "rate_tables_workspace_delete"
+  ON "rate_tables" AS PERMISSIVE FOR DELETE TO stella
+  USING ((CASE
+    WHEN workspace_id = ANY(COALESCE(NULLIF((SELECT pg_catalog.current_setting(
+      'app.workspace_ids', true)), '')::uuid[], ARRAY[]::uuid[]))
+    THEN true
+    ELSE workspace_id IN (
+      SELECT aw.authorized_workspace_id
+      FROM public.stella_authorized_workspaces aw
+    )
+  END) AND organization_id = (SELECT current_setting(
+    'app.organization_id', true
+  )));--> statement-breakpoint
+
+-- expenses
+DROP POLICY "workspace_select" ON "expenses";--> statement-breakpoint
+DROP POLICY "workspace_insert" ON "expenses";--> statement-breakpoint
+DROP POLICY "workspace_update" ON "expenses";--> statement-breakpoint
+DROP POLICY "workspace_delete" ON "expenses";--> statement-breakpoint
+CREATE POLICY "expenses_workspace_select"
+  ON "expenses" AS PERMISSIVE FOR SELECT TO stella
+  USING ((CASE
+    WHEN workspace_id = ANY(COALESCE(NULLIF((SELECT pg_catalog.current_setting(
+      'app.workspace_ids', true)), '')::uuid[], ARRAY[]::uuid[]))
+    THEN true
+    ELSE workspace_id IN (
+      SELECT aw.authorized_workspace_id
+      FROM public.stella_authorized_workspaces aw
+    )
+  END) AND organization_id = (SELECT current_setting(
+    'app.organization_id', true
+  )));--> statement-breakpoint
+CREATE POLICY "expenses_workspace_insert"
+  ON "expenses" AS PERMISSIVE FOR INSERT TO stella
+  WITH CHECK ((CASE
+    WHEN workspace_id = ANY(COALESCE(NULLIF((SELECT pg_catalog.current_setting(
+      'app.workspace_ids', true)), '')::uuid[], ARRAY[]::uuid[]))
+    THEN true
+    ELSE workspace_id IN (
+      SELECT aw.authorized_workspace_id
+      FROM public.stella_authorized_workspaces aw
+    )
+  END) AND organization_id = (SELECT current_setting(
+    'app.organization_id', true
+  )));--> statement-breakpoint
+CREATE POLICY "expenses_workspace_update"
+  ON "expenses" AS PERMISSIVE FOR UPDATE TO stella
+  USING ((CASE
+    WHEN workspace_id = ANY(COALESCE(NULLIF((SELECT pg_catalog.current_setting(
+      'app.workspace_ids', true)), '')::uuid[], ARRAY[]::uuid[]))
+    THEN true
+    ELSE workspace_id IN (
+      SELECT aw.authorized_workspace_id
+      FROM public.stella_authorized_workspaces aw
+    )
+  END) AND organization_id = (SELECT current_setting(
+    'app.organization_id', true
+  )));--> statement-breakpoint
+CREATE POLICY "expenses_workspace_delete"
+  ON "expenses" AS PERMISSIVE FOR DELETE TO stella
+  USING ((CASE
+    WHEN workspace_id = ANY(COALESCE(NULLIF((SELECT pg_catalog.current_setting(
+      'app.workspace_ids', true)), '')::uuid[], ARRAY[]::uuid[]))
+    THEN true
+    ELSE workspace_id IN (
+      SELECT aw.authorized_workspace_id
+      FROM public.stella_authorized_workspaces aw
+    )
+  END) AND organization_id = (SELECT current_setting(
+    'app.organization_id', true
+  )));--> statement-breakpoint
+
+-- invoices
+DROP POLICY "workspace_select" ON "invoices";--> statement-breakpoint
+DROP POLICY "workspace_insert" ON "invoices";--> statement-breakpoint
+DROP POLICY "workspace_update" ON "invoices";--> statement-breakpoint
+DROP POLICY "workspace_delete" ON "invoices";--> statement-breakpoint
+CREATE POLICY "invoices_workspace_select"
+  ON "invoices" AS PERMISSIVE FOR SELECT TO stella
+  USING ((CASE
+    WHEN workspace_id = ANY(COALESCE(NULLIF((SELECT pg_catalog.current_setting(
+      'app.workspace_ids', true)), '')::uuid[], ARRAY[]::uuid[]))
+    THEN true
+    ELSE workspace_id IN (
+      SELECT aw.authorized_workspace_id
+      FROM public.stella_authorized_workspaces aw
+    )
+  END) AND organization_id = (SELECT current_setting(
+    'app.organization_id', true
+  )));--> statement-breakpoint
+CREATE POLICY "invoices_workspace_insert"
+  ON "invoices" AS PERMISSIVE FOR INSERT TO stella
+  WITH CHECK ((CASE
+    WHEN workspace_id = ANY(COALESCE(NULLIF((SELECT pg_catalog.current_setting(
+      'app.workspace_ids', true)), '')::uuid[], ARRAY[]::uuid[]))
+    THEN true
+    ELSE workspace_id IN (
+      SELECT aw.authorized_workspace_id
+      FROM public.stella_authorized_workspaces aw
+    )
+  END) AND organization_id = (SELECT current_setting(
+    'app.organization_id', true
+  )));--> statement-breakpoint
+CREATE POLICY "invoices_workspace_update"
+  ON "invoices" AS PERMISSIVE FOR UPDATE TO stella
+  USING ((CASE
+    WHEN workspace_id = ANY(COALESCE(NULLIF((SELECT pg_catalog.current_setting(
+      'app.workspace_ids', true)), '')::uuid[], ARRAY[]::uuid[]))
+    THEN true
+    ELSE workspace_id IN (
+      SELECT aw.authorized_workspace_id
+      FROM public.stella_authorized_workspaces aw
+    )
+  END) AND organization_id = (SELECT current_setting(
+    'app.organization_id', true
+  )));--> statement-breakpoint
+CREATE POLICY "invoices_workspace_delete"
+  ON "invoices" AS PERMISSIVE FOR DELETE TO stella
+  USING ((CASE
+    WHEN workspace_id = ANY(COALESCE(NULLIF((SELECT pg_catalog.current_setting(
+      'app.workspace_ids', true)), '')::uuid[], ARRAY[]::uuid[]))
+    THEN true
+    ELSE workspace_id IN (
+      SELECT aw.authorized_workspace_id
+      FROM public.stella_authorized_workspaces aw
+    )
+  END) AND organization_id = (SELECT current_setting(
+    'app.organization_id', true
+  )));--> statement-breakpoint
+
+-- workspace_contacts
+DROP POLICY "workspace_select" ON "workspace_contacts";--> statement-breakpoint
+DROP POLICY "workspace_insert" ON "workspace_contacts";--> statement-breakpoint
+DROP POLICY "workspace_update" ON "workspace_contacts";--> statement-breakpoint
+DROP POLICY "workspace_delete" ON "workspace_contacts";--> statement-breakpoint
+CREATE POLICY "workspace_contacts_workspace_select"
+  ON "workspace_contacts" AS PERMISSIVE FOR SELECT TO stella
+  USING ((CASE
+    WHEN workspace_id = ANY(COALESCE(NULLIF((SELECT pg_catalog.current_setting(
+      'app.workspace_ids', true)), '')::uuid[], ARRAY[]::uuid[]))
+    THEN true
+    ELSE workspace_id IN (
+      SELECT aw.authorized_workspace_id
+      FROM public.stella_authorized_workspaces aw
+    )
+  END) AND organization_id = (SELECT current_setting(
+    'app.organization_id', true
+  )));--> statement-breakpoint
+CREATE POLICY "workspace_contacts_workspace_insert"
+  ON "workspace_contacts" AS PERMISSIVE FOR INSERT TO stella
+  WITH CHECK ((CASE
+    WHEN workspace_id = ANY(COALESCE(NULLIF((SELECT pg_catalog.current_setting(
+      'app.workspace_ids', true)), '')::uuid[], ARRAY[]::uuid[]))
+    THEN true
+    ELSE workspace_id IN (
+      SELECT aw.authorized_workspace_id
+      FROM public.stella_authorized_workspaces aw
+    )
+  END) AND organization_id = (SELECT current_setting(
+    'app.organization_id', true
+  )));--> statement-breakpoint
+CREATE POLICY "workspace_contacts_workspace_update"
+  ON "workspace_contacts" AS PERMISSIVE FOR UPDATE TO stella
+  USING ((CASE
+    WHEN workspace_id = ANY(COALESCE(NULLIF((SELECT pg_catalog.current_setting(
+      'app.workspace_ids', true)), '')::uuid[], ARRAY[]::uuid[]))
+    THEN true
+    ELSE workspace_id IN (
+      SELECT aw.authorized_workspace_id
+      FROM public.stella_authorized_workspaces aw
+    )
+  END) AND organization_id = (SELECT current_setting(
+    'app.organization_id', true
+  )));--> statement-breakpoint
+CREATE POLICY "workspace_contacts_workspace_delete"
+  ON "workspace_contacts" AS PERMISSIVE FOR DELETE TO stella
+  USING ((CASE
+    WHEN workspace_id = ANY(COALESCE(NULLIF((SELECT pg_catalog.current_setting(
+      'app.workspace_ids', true)), '')::uuid[], ARRAY[]::uuid[]))
+    THEN true
+    ELSE workspace_id IN (
+      SELECT aw.authorized_workspace_id
+      FROM public.stella_authorized_workspaces aw
+    )
+  END) AND organization_id = (SELECT current_setting(
+    'app.organization_id', true
+  )));--> statement-breakpoint
+
+-- entity_version_ai_summaries
+DROP POLICY "workspace_select" ON "entity_version_ai_summaries";--> statement-breakpoint
+DROP POLICY "workspace_insert" ON "entity_version_ai_summaries";--> statement-breakpoint
+DROP POLICY "workspace_update" ON "entity_version_ai_summaries";--> statement-breakpoint
+DROP POLICY "workspace_delete" ON "entity_version_ai_summaries";--> statement-breakpoint
+CREATE POLICY "entity_version_ai_summaries_workspace_select"
+  ON "entity_version_ai_summaries" AS PERMISSIVE FOR SELECT TO stella
+  USING ((CASE
+    WHEN workspace_id = ANY(COALESCE(NULLIF((SELECT pg_catalog.current_setting(
+      'app.workspace_ids', true)), '')::uuid[], ARRAY[]::uuid[]))
+    THEN true
+    ELSE workspace_id IN (
+      SELECT aw.authorized_workspace_id
+      FROM public.stella_authorized_workspaces aw
+    )
+  END) AND organization_id = (SELECT current_setting(
+    'app.organization_id', true
+  )));--> statement-breakpoint
+CREATE POLICY "entity_version_ai_summaries_workspace_insert"
+  ON "entity_version_ai_summaries" AS PERMISSIVE FOR INSERT TO stella
+  WITH CHECK ((CASE
+    WHEN workspace_id = ANY(COALESCE(NULLIF((SELECT pg_catalog.current_setting(
+      'app.workspace_ids', true)), '')::uuid[], ARRAY[]::uuid[]))
+    THEN true
+    ELSE workspace_id IN (
+      SELECT aw.authorized_workspace_id
+      FROM public.stella_authorized_workspaces aw
+    )
+  END) AND organization_id = (SELECT current_setting(
+    'app.organization_id', true
+  )));--> statement-breakpoint
+CREATE POLICY "entity_version_ai_summaries_workspace_update"
+  ON "entity_version_ai_summaries" AS PERMISSIVE FOR UPDATE TO stella
+  USING ((CASE
+    WHEN workspace_id = ANY(COALESCE(NULLIF((SELECT pg_catalog.current_setting(
+      'app.workspace_ids', true)), '')::uuid[], ARRAY[]::uuid[]))
+    THEN true
+    ELSE workspace_id IN (
+      SELECT aw.authorized_workspace_id
+      FROM public.stella_authorized_workspaces aw
+    )
+  END) AND organization_id = (SELECT current_setting(
+    'app.organization_id', true
+  )));--> statement-breakpoint
+CREATE POLICY "entity_version_ai_summaries_workspace_delete"
+  ON "entity_version_ai_summaries" AS PERMISSIVE FOR DELETE TO stella
+  USING ((CASE
+    WHEN workspace_id = ANY(COALESCE(NULLIF((SELECT pg_catalog.current_setting(
+      'app.workspace_ids', true)), '')::uuid[], ARRAY[]::uuid[]))
+    THEN true
+    ELSE workspace_id IN (
+      SELECT aw.authorized_workspace_id
+      FROM public.stella_authorized_workspaces aw
+    )
+  END) AND organization_id = (SELECT current_setting(
+    'app.organization_id', true
+  )));--> statement-breakpoint
+
+-- pending_uploads
+DROP POLICY "workspace_select" ON "pending_uploads";--> statement-breakpoint
+DROP POLICY "workspace_insert" ON "pending_uploads";--> statement-breakpoint
+DROP POLICY "workspace_update" ON "pending_uploads";--> statement-breakpoint
+DROP POLICY "workspace_delete" ON "pending_uploads";--> statement-breakpoint
+CREATE POLICY "pending_uploads_workspace_select"
+  ON "pending_uploads" AS PERMISSIVE FOR SELECT TO stella
+  USING ((CASE
+    WHEN workspace_id = ANY(COALESCE(NULLIF((SELECT pg_catalog.current_setting(
+      'app.workspace_ids', true)), '')::uuid[], ARRAY[]::uuid[]))
+    THEN true
+    ELSE workspace_id IN (
+      SELECT aw.authorized_workspace_id
+      FROM public.stella_authorized_workspaces aw
+    )
+  END) AND organization_id = (SELECT current_setting(
+    'app.organization_id', true
+  )));--> statement-breakpoint
+CREATE POLICY "pending_uploads_workspace_insert"
+  ON "pending_uploads" AS PERMISSIVE FOR INSERT TO stella
+  WITH CHECK ((CASE
+    WHEN workspace_id = ANY(COALESCE(NULLIF((SELECT pg_catalog.current_setting(
+      'app.workspace_ids', true)), '')::uuid[], ARRAY[]::uuid[]))
+    THEN true
+    ELSE workspace_id IN (
+      SELECT aw.authorized_workspace_id
+      FROM public.stella_authorized_workspaces aw
+    )
+  END) AND organization_id = (SELECT current_setting(
+    'app.organization_id', true
+  )));--> statement-breakpoint
+CREATE POLICY "pending_uploads_workspace_update"
+  ON "pending_uploads" AS PERMISSIVE FOR UPDATE TO stella
+  USING ((CASE
+    WHEN workspace_id = ANY(COALESCE(NULLIF((SELECT pg_catalog.current_setting(
+      'app.workspace_ids', true)), '')::uuid[], ARRAY[]::uuid[]))
+    THEN true
+    ELSE workspace_id IN (
+      SELECT aw.authorized_workspace_id
+      FROM public.stella_authorized_workspaces aw
+    )
+  END) AND organization_id = (SELECT current_setting(
+    'app.organization_id', true
+  )));--> statement-breakpoint
+CREATE POLICY "pending_uploads_workspace_delete"
+  ON "pending_uploads" AS PERMISSIVE FOR DELETE TO stella
+  USING ((CASE
+    WHEN workspace_id = ANY(COALESCE(NULLIF((SELECT pg_catalog.current_setting(
+      'app.workspace_ids', true)), '')::uuid[], ARRAY[]::uuid[]))
+    THEN true
+    ELSE workspace_id IN (
+      SELECT aw.authorized_workspace_id
+      FROM public.stella_authorized_workspaces aw
+    )
+  END) AND organization_id = (SELECT current_setting(
+    'app.organization_id', true
+  )));--> statement-breakpoint
+
+-- search_documents
+DROP POLICY "workspace_select" ON "search_documents";--> statement-breakpoint
+DROP POLICY "workspace_insert" ON "search_documents";--> statement-breakpoint
+DROP POLICY "workspace_update" ON "search_documents";--> statement-breakpoint
+DROP POLICY "workspace_delete" ON "search_documents";--> statement-breakpoint
+CREATE POLICY "search_documents_workspace_select"
+  ON "search_documents" AS PERMISSIVE FOR SELECT TO stella
+  USING ((CASE
+    WHEN workspace_id = ANY(COALESCE(NULLIF((SELECT pg_catalog.current_setting(
+      'app.workspace_ids', true)), '')::uuid[], ARRAY[]::uuid[]))
+    THEN true
+    ELSE workspace_id IN (
+      SELECT aw.authorized_workspace_id
+      FROM public.stella_authorized_workspaces aw
+    )
+  END) AND organization_id = (SELECT current_setting(
+    'app.organization_id', true
+  )));--> statement-breakpoint
+CREATE POLICY "search_documents_workspace_insert"
+  ON "search_documents" AS PERMISSIVE FOR INSERT TO stella
+  WITH CHECK ((CASE
+    WHEN workspace_id = ANY(COALESCE(NULLIF((SELECT pg_catalog.current_setting(
+      'app.workspace_ids', true)), '')::uuid[], ARRAY[]::uuid[]))
+    THEN true
+    ELSE workspace_id IN (
+      SELECT aw.authorized_workspace_id
+      FROM public.stella_authorized_workspaces aw
+    )
+  END) AND organization_id = (SELECT current_setting(
+    'app.organization_id', true
+  )));--> statement-breakpoint
+CREATE POLICY "search_documents_workspace_update"
+  ON "search_documents" AS PERMISSIVE FOR UPDATE TO stella
+  USING ((CASE
+    WHEN workspace_id = ANY(COALESCE(NULLIF((SELECT pg_catalog.current_setting(
+      'app.workspace_ids', true)), '')::uuid[], ARRAY[]::uuid[]))
+    THEN true
+    ELSE workspace_id IN (
+      SELECT aw.authorized_workspace_id
+      FROM public.stella_authorized_workspaces aw
+    )
+  END) AND organization_id = (SELECT current_setting(
+    'app.organization_id', true
+  )));--> statement-breakpoint
+CREATE POLICY "search_documents_workspace_delete"
+  ON "search_documents" AS PERMISSIVE FOR DELETE TO stella
+  USING ((CASE
+    WHEN workspace_id = ANY(COALESCE(NULLIF((SELECT pg_catalog.current_setting(
+      'app.workspace_ids', true)), '')::uuid[], ARRAY[]::uuid[]))
+    THEN true
+    ELSE workspace_id IN (
+      SELECT aw.authorized_workspace_id
+      FROM public.stella_authorized_workspaces aw
+    )
+  END) AND organization_id = (SELECT current_setting(
+    'app.organization_id', true
+  )));--> statement-breakpoint
+
+-- workspace_search_documents
+DROP POLICY "workspace_select" ON "workspace_search_documents";--> statement-breakpoint
+DROP POLICY "workspace_insert" ON "workspace_search_documents";--> statement-breakpoint
+DROP POLICY "workspace_update" ON "workspace_search_documents";--> statement-breakpoint
+DROP POLICY "workspace_delete" ON "workspace_search_documents";--> statement-breakpoint
+CREATE POLICY "workspace_search_documents_workspace_select"
+  ON "workspace_search_documents" AS PERMISSIVE FOR SELECT TO stella
+  USING ((CASE
+    WHEN workspace_id = ANY(COALESCE(NULLIF((SELECT pg_catalog.current_setting(
+      'app.workspace_ids', true)), '')::uuid[], ARRAY[]::uuid[]))
+    THEN true
+    ELSE workspace_id IN (
+      SELECT aw.authorized_workspace_id
+      FROM public.stella_authorized_workspaces aw
+    )
+  END) AND organization_id = (SELECT current_setting(
+    'app.organization_id', true
+  )));--> statement-breakpoint
+CREATE POLICY "workspace_search_documents_workspace_insert"
+  ON "workspace_search_documents" AS PERMISSIVE FOR INSERT TO stella
+  WITH CHECK ((CASE
+    WHEN workspace_id = ANY(COALESCE(NULLIF((SELECT pg_catalog.current_setting(
+      'app.workspace_ids', true)), '')::uuid[], ARRAY[]::uuid[]))
+    THEN true
+    ELSE workspace_id IN (
+      SELECT aw.authorized_workspace_id
+      FROM public.stella_authorized_workspaces aw
+    )
+  END) AND organization_id = (SELECT current_setting(
+    'app.organization_id', true
+  )));--> statement-breakpoint
+CREATE POLICY "workspace_search_documents_workspace_update"
+  ON "workspace_search_documents" AS PERMISSIVE FOR UPDATE TO stella
+  USING ((CASE
+    WHEN workspace_id = ANY(COALESCE(NULLIF((SELECT pg_catalog.current_setting(
+      'app.workspace_ids', true)), '')::uuid[], ARRAY[]::uuid[]))
+    THEN true
+    ELSE workspace_id IN (
+      SELECT aw.authorized_workspace_id
+      FROM public.stella_authorized_workspaces aw
+    )
+  END) AND organization_id = (SELECT current_setting(
+    'app.organization_id', true
+  )));--> statement-breakpoint
+CREATE POLICY "workspace_search_documents_workspace_delete"
+  ON "workspace_search_documents" AS PERMISSIVE FOR DELETE TO stella
+  USING ((CASE
+    WHEN workspace_id = ANY(COALESCE(NULLIF((SELECT pg_catalog.current_setting(
+      'app.workspace_ids', true)), '')::uuid[], ARRAY[]::uuid[]))
+    THEN true
+    ELSE workspace_id IN (
+      SELECT aw.authorized_workspace_id
+      FROM public.stella_authorized_workspaces aw
+    )
+  END) AND organization_id = (SELECT current_setting(
+    'app.organization_id', true
+  )));--> statement-breakpoint
+
+-- extracted_content
+DROP POLICY "workspace_select" ON "extracted_content";--> statement-breakpoint
+DROP POLICY "workspace_insert" ON "extracted_content";--> statement-breakpoint
+DROP POLICY "workspace_update" ON "extracted_content";--> statement-breakpoint
+DROP POLICY "workspace_delete" ON "extracted_content";--> statement-breakpoint
+CREATE POLICY "extracted_content_workspace_select"
+  ON "extracted_content" AS PERMISSIVE FOR SELECT TO stella
+  USING ((CASE
+    WHEN workspace_id = ANY(COALESCE(NULLIF((SELECT pg_catalog.current_setting(
+      'app.workspace_ids', true)), '')::uuid[], ARRAY[]::uuid[]))
+    THEN true
+    ELSE workspace_id IN (
+      SELECT aw.authorized_workspace_id
+      FROM public.stella_authorized_workspaces aw
+    )
+  END) AND organization_id = (SELECT current_setting(
+    'app.organization_id', true
+  )));--> statement-breakpoint
+CREATE POLICY "extracted_content_workspace_insert"
+  ON "extracted_content" AS PERMISSIVE FOR INSERT TO stella
+  WITH CHECK ((CASE
+    WHEN workspace_id = ANY(COALESCE(NULLIF((SELECT pg_catalog.current_setting(
+      'app.workspace_ids', true)), '')::uuid[], ARRAY[]::uuid[]))
+    THEN true
+    ELSE workspace_id IN (
+      SELECT aw.authorized_workspace_id
+      FROM public.stella_authorized_workspaces aw
+    )
+  END) AND organization_id = (SELECT current_setting(
+    'app.organization_id', true
+  )));--> statement-breakpoint
+CREATE POLICY "extracted_content_workspace_update"
+  ON "extracted_content" AS PERMISSIVE FOR UPDATE TO stella
+  USING ((CASE
+    WHEN workspace_id = ANY(COALESCE(NULLIF((SELECT pg_catalog.current_setting(
+      'app.workspace_ids', true)), '')::uuid[], ARRAY[]::uuid[]))
+    THEN true
+    ELSE workspace_id IN (
+      SELECT aw.authorized_workspace_id
+      FROM public.stella_authorized_workspaces aw
+    )
+  END) AND organization_id = (SELECT current_setting(
+    'app.organization_id', true
+  )));--> statement-breakpoint
+CREATE POLICY "extracted_content_workspace_delete"
+  ON "extracted_content" AS PERMISSIVE FOR DELETE TO stella
+  USING ((CASE
+    WHEN workspace_id = ANY(COALESCE(NULLIF((SELECT pg_catalog.current_setting(
+      'app.workspace_ids', true)), '')::uuid[], ARRAY[]::uuid[]))
+    THEN true
+    ELSE workspace_id IN (
+      SELECT aw.authorized_workspace_id
+      FROM public.stella_authorized_workspaces aw
+    )
+  END) AND organization_id = (SELECT current_setting(
+    'app.organization_id', true
+  )));

--- a/apps/api/src/db/schema/billing.ts
+++ b/apps/api/src/db/schema/billing.ts
@@ -138,7 +138,7 @@ export const billingCodes = p.pgTable(
     p
       .uniqueIndex("billing_codes_ws_type_code_uidx")
       .on(table.workspaceId, table.type, table.code),
-    ...wsPolicies(),
+    ...wsOrganizationPolicies("billing_codes"),
   ],
 );
 
@@ -164,7 +164,7 @@ export const rateTables = p.pgTable(
       .index("rate_tables_ws_default_idx")
       .on(table.workspaceId, table.isDefault),
     p.index("rate_tables_ws_client_idx").on(table.workspaceId, table.clientId),
-    ...wsPolicies(),
+    ...wsOrganizationPolicies("rate_tables"),
   ],
 );
 
@@ -239,7 +239,7 @@ export const expenses = p.pgTable(
       .on(table.workspaceId, table.userId, table.dateIncurred),
     p.index("expenses_invoice_idx").on(table.invoiceId),
     p.check("expenses_amount_positive_check", sql`${table.amount} > 0`),
-    ...wsPolicies(),
+    ...wsOrganizationPolicies("expenses"),
   ],
 );
 
@@ -277,6 +277,6 @@ export const invoices = p.pgTable(
     p
       .uniqueIndex("invoices_ws_number_uidx")
       .on(table.workspaceId, table.invoiceNumber),
-    ...wsPolicies(),
+    ...wsOrganizationPolicies("invoices"),
   ],
 );

--- a/apps/api/src/db/schema/contacts.ts
+++ b/apps/api/src/db/schema/contacts.ts
@@ -16,6 +16,7 @@ import {
   stella,
   user,
   workspaceIdCheck,
+  wsOrganizationPolicies,
   wsPolicies,
   timestamptz,
 } from "./common";
@@ -292,7 +293,7 @@ export const workspaceContacts = p.pgTable(
     p
       .uniqueIndex("workspace_contacts_ws_contact_role_uidx")
       .on(table.workspaceId, table.contactId, table.role),
-    ...wsPolicies(),
+    ...wsOrganizationPolicies("workspace_contacts"),
   ],
 );
 

--- a/apps/api/src/db/schema/entities.ts
+++ b/apps/api/src/db/schema/entities.ts
@@ -23,6 +23,7 @@ import {
   timestamptz,
   user,
   workspaceCheck,
+  wsOrganizationPolicies,
   wsPolicies,
 } from "./common";
 import type {
@@ -407,7 +408,7 @@ export const entityVersionAiSummaries = p.pgTable(
         foreignColumns: [entities.id, entities.workspaceId],
       })
       .onDelete("cascade"),
-    ...wsPolicies(),
+    ...wsOrganizationPolicies("entity_version_ai_summaries"),
   ],
 );
 
@@ -869,7 +870,7 @@ export const pendingUploads = p.pgTable(
           AND ${table.purpose} IN ('entity_create', 'entity_version')
           AND ${table.purposeData}->>'reservedFileId' IS NOT NULL`,
       ),
-    ...wsPolicies(),
+    ...wsOrganizationPolicies("pending_uploads"),
   ],
 );
 

--- a/apps/api/src/db/schema/templates.ts
+++ b/apps/api/src/db/schema/templates.ts
@@ -17,7 +17,6 @@ import {
   safeWorkspaceId,
   tsvector,
   user,
-  wsPolicies,
   wsOrganizationPolicies,
   wsOrganizationReadOnlyPolicies,
   timestamptz,
@@ -257,7 +256,7 @@ export const searchDocuments = p.pgTable(
       .index("search_documents_org_updated_id_idx")
       .on(table.organizationId, table.updatedAt.desc(), table.entityId.desc()),
     p.index("search_documents_tsv_idx").using("gin", table.tsv),
-    ...wsPolicies(),
+    ...wsOrganizationPolicies("search_documents"),
   ],
 );
 
@@ -383,7 +382,7 @@ export const workspaceSearchDocuments = p.pgTable(
         table.workspaceId.desc(),
       ),
     p.index("workspace_search_docs_tsv_idx").using("gin", table.tsv),
-    ...wsPolicies(),
+    ...wsOrganizationPolicies("workspace_search_documents"),
   ],
 );
 
@@ -545,6 +544,6 @@ export const extractedContent = p.pgTable(
         AND ${table.ocrPayloadIv} IS NOT NULL
       )`,
     ),
-    ...wsPolicies(),
+    ...wsOrganizationPolicies("extracted_content"),
   ],
 );

--- a/apps/api/src/tests/security/rls-coverage.test.ts
+++ b/apps/api/src/tests/security/rls-coverage.test.ts
@@ -60,8 +60,6 @@ afterAll(async () => {
 describe("policy coverage", () => {
   // Tables exempt from RLS
   const EXEMPT = new Set([
-    "search_documents", // search index table, scoped by explicit org/workspace predicates
-    "extracted_content", // encrypted derivative table, scoped by explicit org/workspace predicates
     "invitation", // auth table, no RLS
     "member", // auth table, no RLS
     // The anonymization catalog tables carry a nullable workspace_id
@@ -235,6 +233,55 @@ describe("policy coverage", () => {
         expect(expr).not.toContain("stella_workspace_is_authorized");
       }
     }
+  });
+
+  // A table that persists an organization discriminator alongside its
+  // workspace must pin both in every permissive policy, whichever helper it
+  // uses. Pinning the workspace alone would let a row whose organization_id
+  // came from another tenant be reached through a legitimate workspace
+  // authorization. The schema side of this invariant is guarded by the
+  // workspace-only-rls-on-org-tables ratchet metric; this asserts the live
+  // catalog agrees, which is what actually enforces it. Deliberately without
+  // an exemption set: a dual-column table that cannot pin both is a design
+  // question, not a waiver.
+  test("every table with workspace_id and organization_id pins both scopes", async () => {
+    const scoped = await fetchScopedTables(testDb);
+    const policies = await fetchStellaPolicies(testDb);
+
+    const byScope = new Map<string, Set<string>>();
+    for (const { table_name, scope } of scoped) {
+      const scopes = byScope.get(table_name) ?? new Set<string>();
+      scopes.add(scope);
+      byScope.set(table_name, scopes);
+    }
+
+    const dualScopeTables = [...byScope.entries()]
+      .filter(
+        ([, scopes]) => scopes.has("workspace") && scopes.has("organization"),
+      )
+      .map(([table]) => table);
+
+    // The class exists: an empty list would make every assertion below vacuous.
+    expect(dualScopeTables.length).toBeGreaterThan(0);
+
+    const unpinned: string[] = [];
+    for (const table of dualScopeTables) {
+      for (const pol of policies.filter((p) => p.table_name === table)) {
+        if (!pol.permissive) {
+          continue;
+        }
+        const expr = pol.command === "a" ? pol.check_expr : pol.using_expr;
+        if (
+          expr === null ||
+          !expr.includes("organization_id") ||
+          !expr.includes(SETTING_ORGANIZATION_ID)
+        ) {
+          unpinned.push(`${table}.${pol.policy_name}`);
+        }
+      }
+    }
+
+    expect(unpinned).toEqual([]);
   });
 
   test("every table with organization_id (org-only) has org policies", async () => {

--- a/apps/api/src/tests/security/rls-negative.test.ts
+++ b/apps/api/src/tests/security/rls-negative.test.ts
@@ -1431,11 +1431,11 @@ describe("cross-org isolation", () => {
     const c = await scopedQuery([ids.wsA1, ids.wsA2], ids.orgB, (tx) =>
       tx.$count(entities),
     );
-    // workspace_select checks workspace_id = ANY(wsIds).
     // The wsIds are from org A but the session is org B.
-    // The rows are still visible because workspace
-    // policies only check workspace_id, not org_id.
-    // This is safe because workspace IDs are server-set.
+    // `entities` carries no organization_id, so its policies pin the
+    // workspace alone and the rows stay visible. This is safe because
+    // workspace IDs are server-set. Tables that do carry an
+    // organization_id pin both scopes; see the dual-scope block below.
     expect(c).toBeGreaterThan(0);
   });
 
@@ -1463,6 +1463,8 @@ describe("cross-org isolation", () => {
 // Dual-scope: correct ws but wrong org on dual-column tables
 // ════════════════════════════════════════════════════════
 
+// A row whose organization_id names another tenant is unreachable on every
+// table that carries the column, however its workspace was authorized.
 describe("dual-scope integrity (ws + org columns)", () => {
   test("INSERT timeEntry with correct ws but wrong org → policy violation", async () => {
     const error = await scopedQuery([ids.wsA1], ids.orgA, async (tx) =>
@@ -1486,34 +1488,40 @@ describe("dual-scope integrity (ws + org columns)", () => {
     expect(isPgError(error, PG_ERROR.INSUFFICIENT_PRIVILEGE)).toBe(true);
   });
 
-  test("INSERT expense with correct ws but wrong org → succeeds (ws policy only)", async () => {
-    await dryScopedQuery([ids.wsA1], ids.orgA, async (tx) => {
-      await tx.insert(expenses).values({
-        id: testId(),
-        organizationId: ids.orgB,
-        workspaceId: ids.wsA1,
-        userId: ids.userA1,
-        matterId: ids.entityA1,
-        dateIncurred: "2025-06-01",
-        amount: cents(50),
-        currency: "USD",
-        category: "filing_fee" as const,
-        description: "dual-scope test",
-      });
-    });
+  test("INSERT expense with correct ws but wrong org → policy violation", async () => {
+    const error = await scopedQuery([ids.wsA1], ids.orgA, async (tx) =>
+      tryCatch(async () =>
+        tx.insert(expenses).values({
+          id: testId(),
+          organizationId: ids.orgB,
+          workspaceId: ids.wsA1,
+          userId: ids.userA1,
+          matterId: ids.entityA1,
+          dateIncurred: "2025-06-01",
+          amount: cents(50),
+          currency: "USD",
+          category: "filing_fee" as const,
+          description: "dual-scope test",
+        }),
+      ),
+    );
+    expect(isPgError(error, PG_ERROR.INSUFFICIENT_PRIVILEGE)).toBe(true);
   });
 
-  test("INSERT invoice with correct ws but wrong org → succeeds (ws policy only)", async () => {
-    await dryScopedQuery([ids.wsA1], ids.orgA, async (tx) => {
-      await tx.insert(invoices).values({
-        id: testId(),
-        organizationId: ids.orgB,
-        workspaceId: ids.wsA1,
-        invoiceNumber: "DUAL-001",
-        invoiceDate: "2025-06-01",
-        currency: "USD",
-      });
-    });
+  test("INSERT invoice with correct ws but wrong org → policy violation", async () => {
+    const error = await scopedQuery([ids.wsA1], ids.orgA, async (tx) =>
+      tryCatch(async () =>
+        tx.insert(invoices).values({
+          id: testId(),
+          organizationId: ids.orgB,
+          workspaceId: ids.wsA1,
+          invoiceNumber: "DUAL-001",
+          invoiceDate: "2025-06-01",
+          currency: "USD",
+        }),
+      ),
+    );
+    expect(isPgError(error, PG_ERROR.INSUFFICIENT_PRIVILEGE)).toBe(true);
   });
 });
 

--- a/scripts/ratchet-baseline.json
+++ b/scripts/ratchet-baseline.json
@@ -612,5 +612,9 @@
   "cross-feature-imports": {
     "count": 0,
     "files": {}
+  },
+  "workspace-only-rls-on-org-tables": {
+    "count": 0,
+    "files": {}
   }
 }

--- a/scripts/ratchet.ts
+++ b/scripts/ratchet.ts
@@ -1018,6 +1018,66 @@ const countShadowedNamespaces = (content: string): number => {
   return block === undefined ? 0 : (block.match(/^[ \t]*"/gmu) ?? []).length;
 };
 
+const PG_TABLE_MARKER = "p.pgTable(";
+const WORKSPACE_ONLY_POLICIES_MARKER = "...wsPolicies()";
+const ORGANIZATION_ID_COLUMN_MARKER = "organizationId:";
+
+// Offsets of every occurrence of `marker`, left to right.
+const markerOffsets = (source: string, marker: string): number[] => {
+  const offsets: number[] = [];
+  let offset = source.indexOf(marker);
+  while (offset !== -1) {
+    offsets.push(offset);
+    offset = source.indexOf(marker, offset + marker.length);
+  }
+  return offsets;
+};
+
+// True when some occurrence of `marker` opens a line, i.e. only indentation
+// precedes it. Distinguishes a property declaration from the same identifier
+// appearing mid-expression.
+const hasLineLeadingMarker = (source: string, marker: string): boolean =>
+  markerOffsets(source, marker).some((offset) => {
+    let start = offset;
+    while (
+      start > 0 &&
+      (source[start - 1] === " " || source[start - 1] === "\t")
+    ) {
+      start -= 1;
+    }
+    return start === 0 || source[start - 1] === "\n";
+  });
+
+/**
+ * Tables that persist an `organization_id` alongside `workspace_id` but
+ * authorize rows with `wsPolicies()`, which pins only the workspace. The
+ * org-pinned form `wsOrganizationPolicies("<table>")` requires both scopes in
+ * every command, so a row whose `organization_id` disagrees with the
+ * transaction's tenant stays unreachable however its workspace was authorized.
+ * A table with no `organization_id` column has nothing to pin and is not
+ * counted; adding the column to such a table is a schema decision, not a
+ * policy one. Must stay at zero.
+ *
+ * Plain substring scanning throughout: the declaration boundaries and both
+ * markers are fixed strings, so no pattern here can backtrack.
+ */
+const countWorkspaceOnlyRlsOnOrgTables = (content: string): number => {
+  const source = stripComments(content);
+  const starts = markerOffsets(source, PG_TABLE_MARKER);
+
+  let count = 0;
+  for (const [index, start] of starts.entries()) {
+    const body = source.slice(start, starts[index + 1] ?? source.length);
+    if (
+      body.includes(WORKSPACE_ONLY_POLICIES_MARKER) &&
+      hasLineLeadingMarker(body, ORGANIZATION_ID_COLUMN_MARKER)
+    ) {
+      count += 1;
+    }
+  }
+  return count;
+};
+
 type FileCounter = (content: string, file: string) => number;
 
 type RatchetMetric = {
@@ -1317,6 +1377,14 @@ const RATCHET_METRICS: readonly RatchetMetric[] = [
     include: ["apps/web/src/features/**/*.{ts,tsx}"],
     exclude: isExcludedSource,
     count: countCrossSliceImports(crossesFeature),
+  },
+  {
+    id: "workspace-only-rls-on-org-tables",
+    description:
+      "drizzle tables declaring an organizationId column while authorizing rows with wsPolicies() (workspace pin only) instead of wsOrganizationPolicies(<table>) (workspace pin AND organization pin); at 0 — keep it there",
+    include: ["apps/api/src/db/schema/**/*.ts"],
+    exclude: isExcludedSource,
+    count: countWorkspaceOnlyRlsOnOrgTables,
   },
 ];
 
@@ -2122,6 +2190,64 @@ const SUPPRESSION_FIXTURE_LINES = [
 ];
 const SELF_TEST_SUPPRESSIONS = `${SUPPRESSION_FIXTURE_LINES.join("\n")}\n`;
 
+const WORKSPACE_ONLY_RLS_FIXTURE_LINES = [
+  "export const counted = p.pgTable(",
+  '  "counted",',
+  "  {",
+  '    organizationId: safeOrganizationId("organization_id").notNull(),',
+  '    workspaceId: safeWorkspaceId("workspace_id").notNull(),',
+  "  },",
+  "  (table) => [...wsPolicies()],",
+  ");",
+  "export const alsoCounted = p.pgTable(",
+  '  "also_counted",',
+  "  {",
+  '    organizationId: safeOrganizationId("organization_id").notNull(),',
+  '    workspaceId: safeWorkspaceId("workspace_id").notNull(),',
+  "  },",
+  "  (table) => [...wsPolicies()],",
+  ");",
+  "export const noOrgColumn = p.pgTable(",
+  '  "no_org_column",',
+  '  { workspaceId: safeWorkspaceId("workspace_id").notNull() },',
+  "  (table) => [...wsPolicies()],",
+  ");",
+  "export const alreadyPinned = p.pgTable(",
+  '  "already_pinned",',
+  "  {",
+  '    organizationId: safeOrganizationId("organization_id").notNull(),',
+  '    workspaceId: safeWorkspaceId("workspace_id").notNull(),',
+  "  },",
+  '  (table) => [...wsOrganizationPolicies("already_pinned")],',
+  ");",
+  "export const orgScoped = p.pgTable(",
+  '  "org_scoped",',
+  '  { organizationId: safeOrganizationId("organization_id").notNull() },',
+  "  (table) => [...orgPolicies()],",
+  ");",
+  "export const jsonPayloadOnly = p.pgTable(",
+  '  "json_payload_only",',
+  "  {",
+  '    workspaceId: safeWorkspaceId("workspace_id").notNull(),',
+  "    payload: jsonb().$type<{ organizationId: string }>(),",
+  "  },",
+  "  (table) => [...wsPolicies()],",
+  ");",
+  "// export const commented = p.pgTable(",
+  '//   "commented",',
+  '//   { organizationId: safeOrganizationId("organization_id").notNull() },',
+  "//   (table) => [...wsPolicies()],",
+  "// );",
+];
+const SELF_TEST_WORKSPACE_ONLY_RLS = `${WORKSPACE_ONLY_RLS_FIXTURE_LINES.join("\n")}\n`;
+// Expected: the two tables that declare organizationId AND spread wsPolicies().
+// Excluded: the workspace-only table with no organizationId column, the table
+// already on wsOrganizationPolicies, the org-only table, the table whose only
+// `organizationId:` sits mid-line inside a JSONB payload type rather than
+// opening a column declaration, and the fully commented-out declaration — the
+// last one proving the comment strip runs before the scan.
+const EXPECTED_WORKSPACE_ONLY_RLS = 2;
+
 const writeFixture = (root: string, rel: string, content: string): void => {
   const full = path.join(root, rel);
   mkdirSync(path.dirname(full), { recursive: true });
@@ -2376,6 +2502,11 @@ const runSelfTest = (): number => {
       root,
       "apps/web/src/features/alpha/uses-beta.ts",
       SELF_TEST_CROSS_FEATURE,
+    );
+    writeFixture(
+      root,
+      "apps/api/src/db/schema/workspace-only-rls.ts",
+      SELF_TEST_WORKSPACE_ONLY_RLS,
     );
     // Both mirrors, so each `include` glob is exercised rather than only the
     // first: the metric's whole point is that the two artifacts stay in step.
@@ -2663,6 +2794,16 @@ const runSelfTest = (): number => {
     if (crossFeatureMetric.count !== EXPECTED_CROSS_FEATURE) {
       failures.push(
         `cross-feature-imports counted ${crossFeatureMetric.count}, expected ${EXPECTED_CROSS_FEATURE}`,
+      );
+    }
+
+    const workspaceOnlyRlsMetric = requireSnapshot(
+      snapshot,
+      "workspace-only-rls-on-org-tables",
+    );
+    if (workspaceOnlyRlsMetric.count !== EXPECTED_WORKSPACE_ONLY_RLS) {
+      failures.push(
+        `workspace-only-rls-on-org-tables counted ${workspaceOnlyRlsMetric.count}, expected ${EXPECTED_WORKSPACE_ONLY_RLS}`,
       );
     }
 


### PR DESCRIPTION
Aligns the ten workspace-scoped tables that also carry an `organization_id` column on the org-pinned RLS policy form (`wsOrganizationPolicies`), matching the form the most recent schema work already uses (office evidence, billing, templates, document reviews). Both scopes must now agree for a row to be visible: the workspace pin and `organization_id = current_setting('app.organization_id')`. Every scoped transaction already sets both settings, so no live query changes behavior.

Converted: `billing_codes`, `rate_tables`, `expenses`, `invoices`, `workspace_contacts`, `entity_version_ai_summaries`, `pending_uploads`, `search_documents`, `workspace_search_documents`, `extracted_content`. The remaining `wsPolicies()` tables declare no `organization_id` column and are unchanged.

One migration drops and recreates the four policies per table (contiguous per-table statement groups, `lock_timeout`/`statement_timeout` guards), rendering the same SQL the declarative helpers emit so schema and catalog stay in agreement.

Two guards keep the class closed:

- a new ratchet metric (`workspace-only-rls-on-org-tables`, baseline 0) fails CI if a schema declaration ever pairs `wsPolicies()` with an `organizationId` column again;
- a new RLS test derives the dual-column table class from `pg_attribute` at runtime (asserting the class is non-empty so it cannot pass vacuously) and requires every permissive policy on those tables to reference the org setting.

Test updates: the two dual-scope negative tests that previously asserted a correct-workspace/foreign-org insert is accepted on `expenses`/`invoices` now assert it is rejected; `search_documents` and `extracted_content` leave the coverage exemption list and pass the generic workspace-policy checks.
