### PR TITLE
fix(case-law): keep an advancing cursor off the caught-up cadence

### DIFF
--- a/apps/legal-atlas-runner/src/runners/case-law-ingest.ts
+++ b/apps/legal-atlas-runner/src/runners/case-law-ingest.ts
@@ -697,6 +697,7 @@ const runOneCycle = async (
       inserted: 0,
       skipped: 0,
       pagesProcessed: 0,
+      cursorAdvanced: false,
     };
   }
   const { source } = sourceLease;
@@ -756,6 +757,7 @@ const runOneCycle = async (
   }
 
   const durationMs = Math.round(performance.now() - t0);
+  const cursorAfter = result !== null ? result.nextCursor : cursorBefore;
 
   // DB status column only supports "completed" | "failed";
   // timeouts are recorded as "completed" (progress was made).
@@ -771,7 +773,7 @@ const runOneCycle = async (
         searchVectorFailures: result?.searchVectorFailures ?? 0,
         pagesProcessed: result?.pagesProcessed ?? 0,
         cursorBefore,
-        cursorAfter: result !== null ? result.nextCursor : cursorBefore,
+        cursorAfter,
         durationMs,
         errorMessage,
         startedAt,
@@ -802,6 +804,7 @@ const runOneCycle = async (
     inserted: result?.inserted ?? 0,
     skipped: result?.skipped ?? 0,
     pagesProcessed: result?.pagesProcessed ?? 0,
+    cursorAdvanced: cursorAfter !== cursorBefore,
   };
 };
 

--- a/apps/legal-atlas-runner/src/runners/cycle-progress.test.ts
+++ b/apps/legal-atlas-runner/src/runners/cycle-progress.test.ts
@@ -23,17 +23,21 @@ const INSERTED = [0, 1, 250] as const;
 /** Decisions the dedup short-circuit dropped; 550 is a whole stored corpus. */
 const SKIPPED = [0, 1, 550] as const;
 const PAGES = [0, 1] as const;
+const CURSOR_ADVANCED = [false, true] as const;
 
 /** Every shape a returned cycle can take. */
 const CYCLES = OUTCOMES.flatMap((outcome) =>
   INSERTED.flatMap((inserted) =>
     SKIPPED.flatMap((skipped) =>
-      PAGES.map((pagesProcessed) => ({
-        outcome,
-        inserted,
-        skipped,
-        pagesProcessed,
-      })),
+      PAGES.flatMap((pagesProcessed) =>
+        CURSOR_ADVANCED.map((cursorAdvanced) => ({
+          outcome,
+          inserted,
+          skipped,
+          pagesProcessed,
+          cursorAdvanced,
+        })),
+      ),
     ),
   ),
 ) satisfies readonly CycleResult[];
@@ -48,6 +52,10 @@ const RESCAN_CYCLE = {
   inserted: 0,
   skipped: 550,
   pagesProcessed: 12,
+  // A re-scan walks forward through stored ground, so it moves the cursor too.
+  // The backoff must still hold: this is the case the hourly cadence is priced
+  // for, not one the cursor can talk its way out of.
+  cursorAdvanced: true,
 } satisfies CycleResult;
 
 /** The same adapter while it is genuinely writing rows, still too slow to finish. */
@@ -56,13 +64,31 @@ const SLOW_PRODUCTIVE_CYCLE = {
   inserted: 40,
   skipped: 510,
   pagesProcessed: 12,
+  cursorAdvanced: true,
 } satisfies CycleResult;
 
+/** A caught-up adapter re-returning its own cursor: a page walked, nowhere new. */
 const QUIET_CYCLE = {
   outcome: CYCLE_OUTCOME.COMPLETED,
   inserted: 0,
   skipped: 0,
   pagesProcessed: 1,
+  cursorAdvanced: false,
+} satisfies CycleResult;
+
+/**
+ * An enumeration crossing listing pages that hold no decisions for it.
+ *
+ * The shape a search-based historical walk takes while it re-lists a year to
+ * check the identities it collected: pages fetched, nothing to write, and a
+ * cursor that keeps moving because there is more of the source to cover.
+ */
+const ENUMERATION_CYCLE = {
+  outcome: CYCLE_OUTCOME.COMPLETED,
+  inserted: 0,
+  skipped: 0,
+  pagesProcessed: 10,
+  cursorAdvanced: true,
 } satisfies CycleResult;
 
 const INCONCLUSIVE_CYCLE = {
@@ -70,6 +96,7 @@ const INCONCLUSIVE_CYCLE = {
   inserted: 0,
   skipped: 0,
   pagesProcessed: 0,
+  cursorAdvanced: false,
 } satisfies CycleResult;
 
 const repeat = (cycle: CycleResult, times: number): CycleResult[] =>
@@ -126,6 +153,7 @@ describe("cycleMadeProgress", () => {
         inserted: 0,
         skipped: 0,
         pagesProcessed: 0,
+        cursorAdvanced: false,
       }),
     ).toBe(false);
     expect(cycleMadeProgress(INCONCLUSIVE_CYCLE)).toBe(false);
@@ -138,6 +166,7 @@ describe("cycleMadeProgress", () => {
         inserted: 0,
         skipped: 0,
         pagesProcessed: 0,
+        cursorAdvanced: false,
       }),
     ).toBe(true);
   });
@@ -198,9 +227,28 @@ describe("classifyCycleProductivity", () => {
         (cycle) =>
           cycle.outcome === CYCLE_OUTCOME.COMPLETED &&
           cycle.inserted === 0 &&
-          cycle.skipped === 0,
+          cycle.skipped === 0 &&
+          !cycle.cursorAdvanced,
       ),
     ).toBe(true);
+  });
+
+  test("crossing empty listings is progress, not quiet", () => {
+    // Nothing to write does not mean nothing to do: the cursor moved, so the
+    // walk covered source it does not hold and has more ahead of it.
+    expect(classifyCycleProductivity(ENUMERATION_CYCLE)).toBe(
+      CYCLE_PRODUCTIVITY.PRODUCTIVE,
+    );
+
+    const misread = CYCLES.filter(
+      (cycle) =>
+        cycle.inserted === 0 && cycle.skipped === 0 && cycle.cursorAdvanced,
+    ).filter(
+      (cycle) =>
+        classifyCycleProductivity(cycle) !== CYCLE_PRODUCTIVITY.PRODUCTIVE,
+    );
+
+    expect(misread).toEqual([]);
   });
 });
 
@@ -292,6 +340,42 @@ describe("stepCadence", () => {
       CYCLE_CADENCE.CAUGHT_UP,
     ]);
     expect(steps.at(-1)?.unproductiveRescan).toBeNull();
+  });
+
+  test("an enumeration crossing empty listings is never parked as caught up", () => {
+    // The production defect: a historical walk re-listing a year fetches no
+    // decisions per cycle, so three cycles in it took the caught-up cadence
+    // and dropped to one page budget a day, with most of the source still
+    // ahead of it. No run length may reach that cadence while the cursor
+    // keeps moving.
+    const steps = runCycles(repeat(ENUMERATION_CYCLE, 50));
+
+    expect(steps.filter((step) => step.cadence !== CYCLE_CADENCE.FAST)).toEqual(
+      [],
+    );
+
+    const parked = CYCLES.filter(
+      (cycle) =>
+        cycle.inserted === 0 && cycle.skipped === 0 && cycle.cursorAdvanced,
+    ).filter((cycle) =>
+      runCycles(repeat(cycle, QUIET_THRESHOLD + 2)).some(
+        (step) => step.cadence === CYCLE_CADENCE.CAUGHT_UP,
+      ),
+    );
+
+    expect(parked).toEqual([]);
+  });
+
+  test("an enumeration cycle ends a quiet streak", () => {
+    // A walk that reaches new ground after a lull has answered the question
+    // the quiet streak was accumulating: the source is not exhausted.
+    const step = lastStep([
+      ...repeat(QUIET_CYCLE, QUIET_THRESHOLD - 1),
+      ENUMERATION_CYCLE,
+    ]);
+
+    expect(step.cadence).toBe(CYCLE_CADENCE.FAST);
+    expect(step.streaks).toEqual({ quietCycles: 0, unproductiveCycles: 0 });
   });
 
   test("a quiet cycle ends a re-scan streak", () => {

--- a/apps/legal-atlas-runner/src/runners/cycle-progress.ts
+++ b/apps/legal-atlas-runner/src/runners/cycle-progress.ts
@@ -25,6 +25,15 @@ export type CycleResult = {
   /** Decisions the dedup short-circuit dropped as already stored, unchanged. */
   skipped: number;
   pagesProcessed: number;
+  /**
+   * Whether the persisted cursor ended the cycle somewhere new.
+   *
+   * Distance travelled, which `pagesProcessed` deliberately is not: an adapter
+   * that re-returns its current cursor walks a page per poll without moving
+   * (cz-nss yields `${today}:0` once it reaches today). Only this separates a
+   * source with nothing left from one still working through it.
+   */
+  cursorAdvanced: boolean;
 };
 
 /**
@@ -68,9 +77,15 @@ export const cycleMadeProgress = ({
  * source that is keeping up.
  */
 export const CYCLE_PRODUCTIVITY = {
-  /** Rows written. The source is moving, however the cycle ended. */
+  /**
+   * The source is moving, however the cycle ended: rows written, or the cursor
+   * carried forward over listings that yielded none.
+   */
   PRODUCTIVE: "productive",
-  /** Nothing fetched and nothing written: the source is caught up. */
+  /**
+   * Nothing fetched, nothing written, and the cursor stood still: the source
+   * is caught up.
+   */
   QUIET: "quiet",
   /**
    * Decisions fetched, none written: the adapter re-read ground it already
@@ -109,6 +124,16 @@ export const classifyCycleProductivity = (
   }
   if (cycleDecisionsProcessed(cycle) > 0) {
     return CYCLE_PRODUCTIVITY.UNPRODUCTIVE_RESCAN;
+  }
+  // Order matters: a cursor that advances while decisions are re-read is the
+  // forward re-ingest the re-scan backoff deliberately accepts a cost on, so
+  // the re-scan check stays ahead of this one. Reaching here means the cycle
+  // fetched no decisions at all, and a cursor that still moved covered listing
+  // ground with none to give: an enumeration walking a stretch of the source
+  // it does not hold. Reading that as caught up parks a running backfill on
+  // the daily cadence, where it advances one page budget per day.
+  if (cycle.cursorAdvanced) {
+    return CYCLE_PRODUCTIVITY.PRODUCTIVE;
   }
   return cycle.outcome === CYCLE_OUTCOME.COMPLETED
     ? CYCLE_PRODUCTIVITY.QUIET


### PR DESCRIPTION
## Proposed change

`classifyCycleProductivity` calls a cycle quiet when it wrote nothing and
fetched nothing, and `QUIET_THRESHOLD` consecutive quiet cycles move the
adapter to the daily cadence. Nothing in that path asks whether the cursor
moved.

A search-based enumeration has cycles of exactly that shape. `cz-us` walks
NALUS in two passes per year: `collect` stores the year's decisions, then
`verify` re-lists the same year and checks the identity digest against what
`collect` recorded. The `verify` pass exists to confirm identities, so it
fetches no decisions and writes no rows, but it does page forward, and its
cursor advances a page budget at a time. Three such cycles and the adapter is
classified caught up while most of the source is still ahead of it: from there
it advances one page budget per day, and a walk that covers years in hours
takes months.

Quiet now also requires the cursor to have stood still. `pagesProcessed`
cannot carry this, and the module already documents why: an adapter that
re-returns its own cursor walks a page per poll without moving, the way
`cz-nss` yields `${today}:0` once it reaches today. So `CycleResult` gains
`cursorAdvanced`. The runner already compared those two cursors for the
ingestion event row; that expression is hoisted and now feeds both, so the
event row and the classification cannot disagree.

The re-scan check keeps precedence over the new branch. A forward re-ingest
that re-reads stored decisions still classifies as `UNPRODUCTIVE_RESCAN` and
still backs off hourly, which is the trade `CYCLE_CADENCE_DELAY_MS` documents;
only a cycle that fetched no decisions at all can reach the cursor check.

Blast radius on adapters that are genuinely caught up is one cycle per cursor
roll. A rolling-date adapter advances its cursor on the cycle where the date
rolls, which resets the quiet streak; the following cycles re-return the same
cursor and it re-enters the daily cadence after `QUIET_THRESHOLD` cycles at
the fast delay.

### Tests

`CYCLES`, the exhaustive matrix the suite classifies over, gains
`cursorAdvanced` as a dimension, so the existing "the declared states are
exactly the reachable ones" and "the signal fires exactly when the cadence is
the unproductive backoff" invariants now cover both values. Three additions:

- crossing empty listings classifies as progress, over every matrix cycle that
  fetched nothing and moved.
- an enumeration is never parked as caught up, asserted over run lengths past
  the threshold rather than a single cycle: the defect is a streak reaching a
  threshold it should never reach, which no single-cycle assertion catches.
- an enumeration cycle ends a quiet streak.

Reverting the classifier hunk alone fails four tests in this file.

## Checklist

- [x] **BUILD ASSURANCE** | Code builds correctly and without any errors or warnings.
- [x] **TESTING** | Changes tested, including in different conditions (dark mode, language, narrow screen, etc).
- [ ] DARK MODE SUPPORT | User can use the webapp in dark mode. Make sure your changes are visible in both light and dark mode.
- [ ] ISSUE LINKED | Link an issue to this PR (not by mentioning it in the description, but by using the GitHub issue linking feature)
- [ ] SCREENSHOT INCLUDED | If relevant, please include a screenshot / video of the functionality added (allows for a quick check of minor ux changes)

<sub>Dark mode and screenshot are not applicable: the change is confined to the ingestion runner.</sub>

---
_Generated by [Claude Code](https://claude.ai/code/session_01GkMyMgD7NaVHtH1s7QPaYZ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved progress tracking when source cursors advance without producing new decisions.
  * Enumeration cycles are now recognised as productive, preventing unnecessary caught-up throttling.
  * Quiet streaks reset correctly when source progress is detected.

* **Tests**
  * Expanded coverage for re-scans, quiet cycles, cursor movement, productivity classification, and processing cadence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->