### PR TITLE
chore(case-law): treat letter-segment administrative č. j. references as benign in the citation probe

### DIFF
--- a/apps/api/src/scripts/citation-probe.ts
+++ b/apps/api/src/scripts/citation-probe.ts
@@ -209,6 +209,18 @@ const BENIGN: readonly RegExp[] = [
   // oversized final segment beyond the 6-digit cap) is never silently
   // truncated to a shorter benign-looking prefix.
   /[čc]\.\s{0,3}j\.:?\s{0,3}\d{1,6}(?:\/\d{1,6}){2,4}(?![\p{L}\d/])/u,
+  // The letter-segment form of the same administrative reference, where a
+  // department code sits in one of the slash-joined segments: "č. j.
+  // KK/547/DS/19-3" (regional authority), "č. j. 2194/OD/19-4/Rsz" (city
+  // transport department), "č. j. 5/OH/8433/01-Sa/533" (environmental
+  // inspectorate). Two properties separate these from a court docket: the
+  // reference carries no whitespace, and it joins four or more segments,
+  // while the widest court docket the extractor accepts
+  // (CASE_NUMBER_BODY_COMMA) reaches three. The leading lookahead keeps the
+  // no-whitespace chamber+registry spelling ("36Co/52/53/2023") out, and the
+  // trailing one prevents a longer or oversized reference from matching a
+  // benign-looking prefix of itself.
+  /[čc]\.\s{0,3}j\.:?\s{0,3}(?!\d{1,3}\p{L}{1,6}\/)[\p{L}\d-]{1,10}(?:\/[\p{L}\d-]{1,10}){3,5}(?![\p{L}\d/-])/u,
 ];
 
 const isBenign = (candidate: string): boolean =>


### PR DESCRIPTION
## Proposed change

`citation-probe.ts` already excludes an all-numeric multi-segment `č. j.` reference
(tax office, land registry) from its residual candidates. The same administrative
references also occur with a department code in one of the slash-joined segments, so
they still surface as residuals on essentially every sampled administrative-law
decision:

- `č. j. KK/547/DS/19-3` (regional authority, transport agenda)
- `č. j. 2194/OD/19-4/Rsz` (city transport department)
- `č. j. 5/OH/8433/01-Sa/533` (environmental inspectorate)

None of these is a court docket, and none ever will be, so this adds one benign
pattern rather than an extraction change.

Two properties separate the administrative form from a docket:

1. it carries no whitespace, and
2. it joins four or more slash-separated segments, while the widest docket the
   extractor accepts (`CASE_NUMBER_BODY_COMMA`) reaches three.

Both bounds are enforced with lookaheads so the filter cannot swallow a real
citation: the leading `(?!\d{1,3}\p{L}{1,6}/)` keeps the whitespace-free
chamber+registry spelling (`36Co/52/53/2023`) visible, and the trailing
`(?[\p{L}\d/-])` stops a longer or oversized reference from matching a
benign-looking prefix of itself, mirroring the existing numeric rule.

Quantifiers are bounded and every segment is separated by a literal `/`, so the scan
stays linear; a 400-segment pathological input matches in well under a millisecond.

Verified against the verbatim prose above plus negatives (`č. j. 57 A 103/2019`,
`č. j. T 217/97`, `č. j. 8C/18/2008`, `č. j. 1Cob/45/2019-32`, `č. j. 36Co/52/53/2023`,
`č. j. 30 Cdo 1234/2019-45`, `č. j. II.ÚS/251/04`).

Note for the reviewer: the fixtures are not committed as a test. `citation-probe.ts`
performs credential resolution and S3 sampling at module scope, so the benign list
cannot be imported by a test file without running the probe. Making these patterns
testable would mean splitting the list and `isBenign` out of the self-executing
script; that is a larger change than this one, and worth doing separately if the
benign list keeps growing.

## Checklist

- [x] **BUILD ASSURANCE** | Code builds correctly and without any errors or warnings.
- [x] **TESTING** | Regex verified against verbatim positive and negative fixtures; `citation-extractor.test.ts` (160 tests) still passes. Not applicable beyond that: this is a script-only change with no UI surface.
- [ ] DARK MODE SUPPORT | Not applicable, no UI change.
- [ ] ISSUE LINKED | No issue.
- [ ] SCREENSHOT INCLUDED | Not applicable, no UI change.

---
_Generated by [Claude Code](https://claude.ai/code/session_016bkzak8L5YxLY2L7dzfzKw)_