### PR TITLE
fix(api): unify external preview URL validation

### DIFF
--- a/apps/api/src/handlers/external-preview/preview.test.ts
+++ b/apps/api/src/handlers/external-preview/preview.test.ts
@@ -11,6 +11,12 @@ import {
 } from "@/api/handlers/external-preview/preview";
 
 describe("external source preview", () => {
+  test("accepts public HTTP literals for preview fetching", async () => {
+    const result = await validatePreviewUrl("http://1.1.1.1/");
+
+    expect(Result.isOk(result)).toBe(true);
+  });
+
   test("rejects every non-public literal address through the shared SSRF boundary", async () => {
     const nonPublicUrls = [
       "http://198.18.0.1/benchmark",

--- a/apps/api/src/handlers/external-preview/preview.test.ts
+++ b/apps/api/src/handlers/external-preview/preview.test.ts
@@ -1,3 +1,4 @@
+import { Result } from "better-result";
 import { describe, expect, test } from "bun:test";
 
 import {
@@ -6,9 +7,25 @@ import {
   isPdfBytes,
   isPdfPreview,
   isPdfPreviewResponse,
+  validatePreviewUrl,
 } from "@/api/handlers/external-preview/preview";
 
 describe("external source preview", () => {
+  test("rejects every non-public literal address through the shared SSRF boundary", async () => {
+    const nonPublicUrls = [
+      "http://198.18.0.1/benchmark",
+      "http://198.51.100.1/documentation",
+      "http://[febf::1]/link-local",
+      "http://[ff02::1]/multicast",
+    ];
+
+    for (const url of nonPublicUrls) {
+      // oxlint-disable-next-line no-await-in-loop -- each literal must independently cross the async preview boundary
+      const result = await validatePreviewUrl(url);
+      expect(Result.isError(result), url).toBe(true);
+    }
+  });
+
   test("extracts readable text from the largest generic content block", () => {
     const text = extractReadableTextFromHtml(`
       <html>

--- a/apps/api/src/handlers/external-preview/preview.ts
+++ b/apps/api/src/handlers/external-preview/preview.ts
@@ -9,6 +9,7 @@ import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import { htmlToMarkdown } from "@/api/lib/markdown/html-to-markdown";
 import {
   fetchWithResolvedAddress,
+  OUTBOUND_PROTOCOL_POLICY,
   validateOutboundFetchTarget,
 } from "@/api/lib/safe-outbound-fetch";
 import type {
@@ -343,7 +344,7 @@ export const validatePreviewUrl = async (
 
   url.hash = "";
   const target = await validateOutboundFetchTarget(url, {
-    protocolPolicy: "http-and-https",
+    protocolPolicy: OUTBOUND_PROTOCOL_POLICY.HTTP_AND_HTTPS,
     timeoutMs: PREVIEW_TIMEOUT_MS,
   });
   if (Result.isError(target)) {

--- a/apps/api/src/handlers/external-preview/preview.ts
+++ b/apps/api/src/handlers/external-preview/preview.ts
@@ -2,14 +2,15 @@ import { Result } from "better-result";
 import * as cheerio from "cheerio";
 import type { Element } from "domhandler";
 import { t } from "elysia";
-import { lookup } from "node:dns/promises";
-import { isIP } from "node:net";
 
 import { createSafeRootHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import { htmlToMarkdown } from "@/api/lib/markdown/html-to-markdown";
-import { fetchWithResolvedAddress } from "@/api/lib/safe-outbound-fetch";
+import {
+  fetchWithResolvedAddress,
+  validateOutboundFetchTarget,
+} from "@/api/lib/safe-outbound-fetch";
 import type {
   SafeOutboundAddress,
   SafeOutboundFetchResponse,
@@ -322,7 +323,7 @@ const extractHtmlTitle = (html: string): string | null => {
   return normalized.length > 0 ? normalized : null;
 };
 
-const validatePreviewUrl = async (
+export const validatePreviewUrl = async (
   rawUrl: string,
 ): Promise<Result<ValidatedPreviewUrl, HandlerError>> => {
   if (rawUrl.length > MAX_URL_LENGTH) {
@@ -340,37 +341,22 @@ const validatePreviewUrl = async (
     );
   }
 
-  if (url.protocol !== "https:" && url.protocol !== "http:") {
-    return Result.err(
-      new HandlerError({
-        status: 400,
-        message: "Only HTTP and HTTPS sources can be previewed",
-      }),
-    );
-  }
-
-  if (url.username || url.password) {
-    return Result.err(
-      new HandlerError({
-        status: 400,
-        message: "Source URLs with credentials cannot be previewed",
-      }),
-    );
-  }
-
-  if (isBlockedHostname(url.hostname)) {
-    return Result.err(
-      new HandlerError({ status: 400, message: "Source host is not allowed" }),
-    );
-  }
-
-  const resolved = await resolvePublicAddresses(url.hostname);
-  if (Result.isError(resolved)) {
-    return Result.err(resolved.error);
-  }
-
   url.hash = "";
-  return Result.ok({ addresses: resolved.value, url });
+  const target = await validateOutboundFetchTarget(url, {
+    protocolPolicy: "http-and-https",
+    timeoutMs: PREVIEW_TIMEOUT_MS,
+  });
+  if (Result.isError(target)) {
+    return Result.err(
+      new HandlerError({
+        status: 400,
+        message: "Source URL is not allowed",
+        cause: target.error,
+      }),
+    );
+  }
+
+  return Result.ok(target.value);
 };
 
 type ValidatedPreviewUrl = {
@@ -484,101 +470,6 @@ const isRedirectStatus = (status: number): boolean =>
 
 const readResponseText = (response: SafeOutboundFetchResponse): string =>
   new TextDecoder().decode(response.body.slice(0, MAX_PREVIEW_BYTES));
-
-const resolvePublicAddresses = async (
-  hostname: string,
-): Promise<Result<SafeOutboundAddress[], HandlerError>> => {
-  const literalFamily = isIP(hostname);
-  if (literalFamily !== 0) {
-    return isPrivateAddress(hostname)
-      ? Result.err(
-          new HandlerError({
-            status: 400,
-            message: "Source host is not allowed",
-          }),
-        )
-      : Result.ok([
-          {
-            address: hostname,
-            family: literalFamily === 6 ? 6 : 4,
-          },
-        ]);
-  }
-
-  const addresses = await Result.tryPromise({
-    try: async () => await lookup(hostname, { all: true }),
-    catch: (cause) =>
-      new HandlerError({
-        status: 400,
-        message: "Source host could not be resolved",
-        cause,
-      }),
-  });
-
-  if (Result.isError(addresses)) {
-    return Result.err(addresses.error);
-  }
-
-  if (
-    addresses.value.length === 0 ||
-    addresses.value.some(({ address }) => isPrivateAddress(address))
-  ) {
-    return Result.err(
-      new HandlerError({ status: 400, message: "Source host is not allowed" }),
-    );
-  }
-
-  return Result.ok(
-    addresses.value.map(({ address, family }) => ({
-      address,
-      family: family === 6 ? 6 : 4,
-    })),
-  );
-};
-
-const isBlockedHostname = (hostname: string): boolean => {
-  const normalized = hostname.toLowerCase();
-  return normalized === "localhost" || normalized.endsWith(".localhost");
-};
-
-const isPrivateAddress = (address: string): boolean => {
-  if (address.startsWith("::ffff:")) {
-    return isPrivateAddress(address.slice("::ffff:".length));
-  }
-
-  if (isIP(address) === 6) {
-    const normalized = address.toLowerCase();
-    return (
-      normalized === "::" ||
-      normalized === "::1" ||
-      normalized.startsWith("fc") ||
-      normalized.startsWith("fd") ||
-      normalized.startsWith("fe80:")
-    );
-  }
-
-  const octets = address.split(".").map(Number);
-  if (octets.length !== 4 || octets.some((part) => !Number.isInteger(part))) {
-    return true;
-  }
-
-  const [a, b] = octets;
-  if (a === undefined || b === undefined) {
-    return true;
-  }
-
-  return (
-    a === 0 ||
-    a === 10 ||
-    a === 127 ||
-    (a === 100 && b >= 64 && b <= 127) ||
-    (a === 169 && b === 254) ||
-    (a === 172 && b >= 16 && b <= 31) ||
-    (a === 192 && b === 0) ||
-    (a === 192 && b === 168) ||
-    a >= 224
-  );
-};
 
 const getContentType = (headers: Headers): string | null => {
   const raw = headers.get("content-type");

--- a/apps/api/src/lib/safe-outbound-fetch.ts
+++ b/apps/api/src/lib/safe-outbound-fetch.ts
@@ -436,6 +436,14 @@ const abortReasonToError = (reason: unknown): Error => {
  */
 export const parseSafeOutboundUrl = (
   rawUrl: string,
+): Result<URL, SafeOutboundFetchError> =>
+  parseOutboundUrl(rawUrl, "https-only");
+
+type OutboundProtocolPolicy = "http-and-https" | "https-only";
+
+const parseOutboundUrl = (
+  rawUrl: string,
+  protocolPolicy: OutboundProtocolPolicy,
 ): Result<URL, SafeOutboundFetchError> => {
   const trimmed = rawUrl.trim();
   if (trimmed.length === 0 || trimmed.length > MAX_OUTBOUND_URL_LENGTH) {
@@ -460,9 +468,17 @@ export const parseSafeOutboundUrl = (
     );
   }
 
-  if (url.protocol !== "https:") {
+  const isAllowedProtocol =
+    url.protocol === "https:" ||
+    (protocolPolicy === "http-and-https" && url.protocol === "http:");
+  if (!isAllowedProtocol) {
     return Result.err(
-      new SafeOutboundFetchError({ message: "URL must use HTTPS" }),
+      new SafeOutboundFetchError({
+        message:
+          protocolPolicy === "https-only"
+            ? "URL must use HTTPS"
+            : "URL must use HTTP or HTTPS",
+      }),
     );
   }
 
@@ -537,8 +553,8 @@ type ResolveOutboundAddresses = (
 ) => Promise<Result<SafeOutboundAddress[], SafeOutboundFetchError>>;
 
 /**
- * Full SSRF check: parses the URL with `parseSafeOutboundUrl`, then
- * resolves DNS and rejects targets whose resolved addresses fall in
+ * Full SSRF check: applies the selected protocol policy, then resolves DNS
+ * and rejects targets whose resolved addresses fall in
  * any private, loopback, link-local, multicast, or reserved range.
  * The returned `addresses` are meant to be pinned into the actual
  * fetch (see `safeOutboundFetchBytes`) so DNS cannot be re-resolved
@@ -547,14 +563,16 @@ type ResolveOutboundAddresses = (
 export const validateOutboundFetchTarget = async (
   rawUrl: string | URL,
   {
+    protocolPolicy = "https-only",
     resolveAddresses = resolvePublicAddresses,
     timeoutMs = 0,
   }: {
+    protocolPolicy?: OutboundProtocolPolicy;
     resolveAddresses?: ResolveOutboundAddresses;
     timeoutMs?: number;
   } = {},
 ): Promise<Result<OutboundFetchTarget, SafeOutboundFetchError>> => {
-  const parsed = parseSafeOutboundUrl(rawUrl.toString());
+  const parsed = parseOutboundUrl(rawUrl.toString(), protocolPolicy);
   if (Result.isError(parsed)) {
     return Result.err(parsed.error);
   }

--- a/apps/api/src/lib/safe-outbound-fetch.ts
+++ b/apps/api/src/lib/safe-outbound-fetch.ts
@@ -437,9 +437,15 @@ const abortReasonToError = (reason: unknown): Error => {
 export const parseSafeOutboundUrl = (
   rawUrl: string,
 ): Result<URL, SafeOutboundFetchError> =>
-  parseOutboundUrl(rawUrl, "https-only");
+  parseOutboundUrl(rawUrl, OUTBOUND_PROTOCOL_POLICY.HTTPS_ONLY);
 
-type OutboundProtocolPolicy = "http-and-https" | "https-only";
+export const OUTBOUND_PROTOCOL_POLICY = {
+  HTTP_AND_HTTPS: "http-and-https",
+  HTTPS_ONLY: "https-only",
+} as const;
+
+type OutboundProtocolPolicy =
+  (typeof OUTBOUND_PROTOCOL_POLICY)[keyof typeof OUTBOUND_PROTOCOL_POLICY];
 
 const parseOutboundUrl = (
   rawUrl: string,
@@ -470,12 +476,13 @@ const parseOutboundUrl = (
 
   const isAllowedProtocol =
     url.protocol === "https:" ||
-    (protocolPolicy === "http-and-https" && url.protocol === "http:");
+    (protocolPolicy === OUTBOUND_PROTOCOL_POLICY.HTTP_AND_HTTPS &&
+      url.protocol === "http:");
   if (!isAllowedProtocol) {
     return Result.err(
       new SafeOutboundFetchError({
         message:
-          protocolPolicy === "https-only"
+          protocolPolicy === OUTBOUND_PROTOCOL_POLICY.HTTPS_ONLY
             ? "URL must use HTTPS"
             : "URL must use HTTP or HTTPS",
       }),
@@ -563,7 +570,7 @@ type ResolveOutboundAddresses = (
 export const validateOutboundFetchTarget = async (
   rawUrl: string | URL,
   {
-    protocolPolicy = "https-only",
+    protocolPolicy = OUTBOUND_PROTOCOL_POLICY.HTTPS_ONLY,
     resolveAddresses = resolvePublicAddresses,
     timeoutMs = 0,
   }: {


### PR DESCRIPTION
## Summary

- delegate external-preview URL checks to the shared DNS-pinned outbound validator
- keep HTTP support explicit to previews while preserving HTTPS-only defaults elsewhere
- cover reserved IPv4 and IPv6 address classes at the preview boundary

CC on behalf of artichoke

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Strengthened validation of external preview URLs to block unsafe destinations, including local, private, benchmark, documentation and multicast addresses.
  * Added consistent protection before outbound connections are made.

* **Bug Fixes**
  * External previews now support approved HTTP and HTTPS URLs while applying the configured request timeout.
  * Improved handling of invalid or potentially unsafe URL targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->