### PR TITLE
fix(web): model provider validation states explicitly

### DIFF
--- a/apps/web/src/routes/onboarding/-components/steps/ai-step.logic.ts
+++ b/apps/web/src/routes/onboarding/-components/steps/ai-step.logic.ts
@@ -5,13 +5,16 @@ import type {
   ProviderValue,
 } from "@/components/ai-config-role-models.logic";
 
-export type RowState = {
-  status: ProviderRowStatus;
-  // Fingerprint of the key the user explicitly saved. The row
-  // becomes "saved" only if the current key matches; any edit
-  // resets the row to "idle".
-  savedKey?: string;
-};
+type FingerprintedRowStatus = Exclude<ProviderRowStatus, "idle" | "saved">;
+
+export type RowState =
+  | { status: "idle"; savedKey?: never }
+  | {
+      status: FingerprintedRowStatus;
+      // Fingerprint of the key this validation attempt checked. Any edit
+      // resets the row to "idle", which cannot retain a stale fingerprint.
+      savedKey: string;
+    };
 
 export type RowStateMap = Record<ProviderValue, RowState>;
 
@@ -22,12 +25,23 @@ export const createProviderPreview = (
   const items: ProviderPreview[] = [];
   for (const draft of providers) {
     const state = rowStates[draft.provider];
-    if (state.status === "checking" || state.status === "invalid") {
-      items.push({ provider: draft.provider, status: state.status });
-      continue;
-    }
-    if (state.status === "valid" || draft.apiKeyMasked !== undefined) {
-      items.push({ provider: draft.provider, status: "valid" });
+    switch (state.status) {
+      case "checking":
+      case "invalid":
+        items.push({ provider: draft.provider, status: state.status });
+        break;
+      case "valid":
+        items.push({ provider: draft.provider, status: "valid" });
+        break;
+      case "idle":
+        if (draft.apiKeyMasked !== undefined) {
+          items.push({ provider: draft.provider, status: "valid" });
+        }
+        break;
+      default: {
+        const unreachable: never = state;
+        return unreachable;
+      }
     }
   }
   return items;

--- a/apps/web/src/routes/onboarding/-components/steps/ai-step.test.ts
+++ b/apps/web/src/routes/onboarding/-components/steps/ai-step.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 
 import { createProviderCredentialDraft } from "@/components/ai-config-role-models.logic";
 import { createProviderPreview } from "@/routes/onboarding/-components/steps/ai-step.logic";
+import type { RowState } from "@/routes/onboarding/-components/steps/ai-step.logic";
 
 const idleRowStates = {
   google: { status: "idle" },
@@ -13,6 +14,25 @@ const idleRowStates = {
 } as const;
 
 describe("AI provider preview", () => {
+  test("binds key fingerprints to validation states", () => {
+    const fingerprintedStates = [
+      { status: "checking", savedKey: "checking-key" },
+      { status: "valid", savedKey: "valid-key" },
+      { status: "invalid", savedKey: "invalid-key" },
+    ] as const satisfies readonly RowState[];
+
+    // @ts-expect-error - a validation result must identify the key it checked.
+    const missingFingerprint: RowState = { status: "valid" };
+    // @ts-expect-error - idle rows must not retain a stale validated fingerprint.
+    const staleFingerprint: RowState = { status: "idle", savedKey: "stale" };
+
+    expect(
+      fingerprintedStates.every((state) => state.savedKey.length > 0),
+    ).toBe(true);
+    void missingFingerprint;
+    void staleFingerprint;
+  });
+
   test("publishes only actionable or confirmed provider rows", () => {
     const google = createProviderCredentialDraft("google");
     const openai = createProviderCredentialDraft("openai");

--- a/apps/web/src/routes/onboarding/-components/steps/ai-step.tsx
+++ b/apps/web/src/routes/onboarding/-components/steps/ai-step.tsx
@@ -96,7 +96,7 @@ export const AIStep = ({
   const allProvidersConfirmed = providers.every((draft) => {
     const fp = fingerprintDraft(draft);
     const state = rowStates[draft.provider];
-    if (state.status === "valid" && state.savedKey && state.savedKey === fp) {
+    if (state.status === "valid" && state.savedKey === fp) {
       return true;
     }
     if (!fp && draft.apiKeyMasked !== undefined) {
@@ -228,10 +228,9 @@ export const AIStep = ({
       const fingerprint = fingerprintDraft(draft);
       const state = nextRowStates[draft.provider];
       const changedSavedKey =
-        state.savedKey !== undefined &&
+        state.status !== "idle" &&
         fingerprint !== null &&
-        fingerprint !== state.savedKey &&
-        state.status !== "idle";
+        fingerprint !== state.savedKey;
       const clearedKey =
         fingerprint === null && state.status !== "idle" && !draft.apiKeyMasked;
       if (changedSavedKey || clearedKey) {


### PR DESCRIPTION
## Summary

- model onboarding provider validation as a discriminated union
- require validation fingerprints for active result states and forbid them for idle rows
- make provider preview projection exhaustive

CC on behalf of artichoke