### PR TITLE
fix(api): preserve document review topic order

### DIFF
--- a/apps/api/src/lib/document-review/reference-compare.test.ts
+++ b/apps/api/src/lib/document-review/reference-compare.test.ts
@@ -299,22 +299,32 @@ describe("reference review normalization", () => {
     ]);
   });
 
-  test("returns exactly one result for every confirmed topic", () => {
+  test("returns exactly one result per confirmed topic in confirmed order", () => {
     const secondTopicId = "22222222-2222-4222-8222-222222222222";
+    const confirmedTopics = [
+      ...topics,
+      {
+        type: "custom" as const,
+        topicId: secondTopicId,
+        title: "Notices",
+        context: "",
+        included: true,
+      },
+    ];
     const findings = normalizeReferenceReview({
       target,
       references: [reference],
-      topics: [
-        ...topics,
-        {
-          type: "custom",
-          topicId: secondTopicId,
-          title: "Notices",
-          context: "",
-          included: true,
-        },
-      ],
+      topics: confirmedTopics,
       rawFindings: [
+        {
+          topicId: secondTopicId,
+          assessment: "aligned",
+          consensus: "single",
+          rationale: "Comparable.",
+          targetCitations: [{ sourceKey: "F0", blockId: "target-2" }],
+          referenceCitations: [{ sourceKey: "F1", blockId: "reference-1" }],
+          proposedText: null,
+        },
         {
           topicId,
           assessment: "aligned",
@@ -336,9 +346,8 @@ describe("reference review normalization", () => {
       ],
     });
 
-    expect(findings.map((finding) => finding.topicId)).toEqual([
-      topicId,
-      secondTopicId,
-    ]);
+    expect(findings.map(({ topicId: id }) => id)).toEqual(
+      confirmedTopics.map(({ topicId: id }) => id),
+    );
   });
 });

--- a/apps/api/src/lib/document-review/reference-compare.ts
+++ b/apps/api/src/lib/document-review/reference-compare.ts
@@ -217,11 +217,28 @@ export const normalizeReferenceReview = ({
   );
   const findings: ReferenceReviewFinding[] = [];
   const topicById = new Map(topics.map((topic) => [topic.topicId, topic]));
-  const seenTopicIds = new Set<string>();
-
+  const rawFindingByTopicId = new Map<string, RawReferenceFinding>();
   for (const raw of rawFindings) {
-    const topic = topicById.get(raw.topicId);
-    if (!topic || seenTopicIds.has(topic.topicId)) {
+    if (!topicById.has(raw.topicId) || rawFindingByTopicId.has(raw.topicId)) {
+      continue;
+    }
+    rawFindingByTopicId.set(raw.topicId, raw);
+  }
+
+  for (const topic of topics) {
+    const raw = rawFindingByTopicId.get(topic.topicId);
+    if (!raw) {
+      findings.push({
+        findingId: `reference-${topic.topicId}`,
+        topicId: topic.topicId,
+        issue: topic.title,
+        assessment: "not-comparable",
+        consensus: references.length === 1 ? "single" : "consistent",
+        explanation: { type: "insufficient-evidence" },
+        targetCitations: [],
+        referenceCitations: [],
+        fix: null,
+      });
       continue;
     }
     const targetCitations = collectVerifiedCitations(
@@ -301,24 +318,6 @@ export const normalizeReferenceReview = ({
             targetCitations,
           })
         : null,
-    });
-    seenTopicIds.add(topic.topicId);
-  }
-
-  for (const topic of topics) {
-    if (seenTopicIds.has(topic.topicId)) {
-      continue;
-    }
-    findings.push({
-      findingId: `reference-${topic.topicId}`,
-      topicId: topic.topicId,
-      issue: topic.title,
-      assessment: "not-comparable",
-      consensus: references.length === 1 ? "single" : "consistent",
-      explanation: { type: "insufficient-evidence" },
-      targetCitations: [],
-      referenceCitations: [],
-      fix: null,
     });
   }
 


### PR DESCRIPTION
## Summary

- normalize findings in confirmed-topic order instead of provider response order
- retain the first valid finding per topic while ignoring duplicates and unknown topics
- keep missing topics represented as not comparable

CC on behalf of artichoke