### PR TITLE
fix: keep inspector chat route-independent

### DIFF
--- a/apps/web/e2e/marketing/product-screenshots.spec.ts
+++ b/apps/web/e2e/marketing/product-screenshots.spec.ts
@@ -206,6 +206,11 @@ test("capture landing product screenshots", async ({
         // click below hits the real analyze button, not the sign-in prompt.
         // eslint-disable-next-line no-await-in-loop -- see above
         await page.waitForLoadState("networkidle");
+        // The authenticated inspector is mounted beside this public route.
+        // Catch route-context crashes at their boundary instead of timing out
+        // later on whichever product control the error screen replaced.
+        // eslint-disable-next-line no-await-in-loop -- see above
+        await expect(page.locator("#route-error-title")).toHaveCount(0);
         // The structure/AI margin is generated on demand. These decisions
         // already have their analysis cached server-side, but the client
         // still needs one round trip to fetch it; trigger it explicitly and

--- a/apps/web/src/components/inspector/inspector-route-boundary.test.ts
+++ b/apps/web/src/components/inspector/inspector-route-boundary.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "bun:test";
+import nodePath from "node:path";
+
+const SHARED_INSPECTOR_MODULE_DIRS = [
+  "components/inspector",
+  "features/chat",
+] as const;
+const SOURCE_MODULE_GLOB = "**/*.{ts,tsx}";
+const PROTECTED_ROUTE_DEPENDENCY =
+  /(?:@\/routes\/_protected|getRouteApi\(\s*["']\/_protected["'])/u;
+
+describe("shared inspector route boundary", () => {
+  test("does not depend on protected route context", async () => {
+    const sourceRoot = nodePath.resolve(import.meta.dir, "../..");
+    const glob = new Bun.Glob(SOURCE_MODULE_GLOB);
+    const scannedPaths = (
+      await Promise.all(
+        SHARED_INSPECTOR_MODULE_DIRS.map(async (moduleDir) => {
+          const modulePaths: string[] = [];
+          for await (const relativePath of glob.scan({
+            cwd: nodePath.resolve(sourceRoot, moduleDir),
+          })) {
+            if (!relativePath.includes(".test.")) {
+              modulePaths.push(nodePath.join(moduleDir, relativePath));
+            }
+          }
+          return modulePaths;
+        }),
+      )
+    ).flat();
+
+    expect(scannedPaths).toContain(
+      "features/chat/hooks/use-rename-chat-thread.ts",
+    );
+    const matches = await Promise.all(
+      scannedPaths.map(async (sourcePath) => ({
+        sourcePath,
+        violates: PROTECTED_ROUTE_DEPENDENCY.test(
+          await Bun.file(nodePath.resolve(sourceRoot, sourcePath)).text(),
+        ),
+      })),
+    );
+    const violations = matches
+      .filter(({ violates }) => violates)
+      .map(({ sourcePath }) => sourcePath);
+    expect(violations).toEqual([]);
+  });
+});

--- a/apps/web/src/features/chat/hooks/use-rename-chat-thread.ts
+++ b/apps/web/src/features/chat/hooks/use-rename-chat-thread.ts
@@ -1,5 +1,4 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { getRouteApi } from "@tanstack/react-router";
 import { useTranslations } from "use-intl";
 
 import { stellaToast } from "@stll/ui/components/toast";
@@ -11,12 +10,11 @@ import {
 } from "@/features/chat/queries";
 import { getAnalytics } from "@/lib/analytics/provider";
 import { api } from "@/lib/api";
+import { useAuthenticatedUser } from "@/lib/authenticated-user-context";
 import type { ChatThreadRef } from "@/lib/chat-thread-ref";
 import { detached } from "@/lib/detached";
 import { unwrapEden } from "@/lib/errors/api";
 import { toSafeId } from "@/lib/safe-id";
-
-const protectedRoute = getRouteApi("/_protected");
 
 /**
  * The one web-side writer for a chat thread's title: PATCHes
@@ -29,9 +27,7 @@ const protectedRoute = getRouteApi("/_protected");
 export const useRenameChatThread = (threadRef: ChatThreadRef) => {
   const t = useTranslations();
   const queryClient = useQueryClient();
-  const activeOrganizationId = protectedRoute.useRouteContext({
-    select: (ctx) => ctx.user.activeOrganizationId,
-  });
+  const activeOrganizationId = useAuthenticatedUser().activeOrganizationId;
   const workspaceId =
     threadRef.scope === "workspace" ? threadRef.workspaceId : undefined;
   const threadId = threadRef.threadId;


### PR DESCRIPTION
## Summary

- read chat rename ownership from the authenticated-user provider shared by protected and public workspace shells
- prevent shared inspector and chat modules from depending on protected-route context
- make the marketing capture fail immediately when a route error replaces product controls