### PR TITLE
feat(playbooks): one pinned path for every run surface

### DIFF
--- a/apps/api/drizzle/20260812160000_playbook_version_source/migration.sql
+++ b/apps/api/drizzle/20260812160000_playbook_version_source/migration.sql
@@ -1,0 +1,26 @@
+SET lock_timeout = '1s';--> statement-breakpoint
+SET statement_timeout = '5s';--> statement-breakpoint
+
+-- A version snapshot now names why it was written. A review run pins "the
+-- playbook's latest approved version", which until now was read as "the newest
+-- row" — sound only while approval is the only thing that writes one. A
+-- snapshot taken for another reason (an import, a restore, an autosave) would
+-- silently have become the standard a document was judged against.
+--
+-- Every existing row is an approval (`approve.ts` is the only writer to date),
+-- so the column lands with that as a transient default and then drops it: a new
+-- writer must state its source rather than inherit one.
+ALTER TABLE "playbook_definition_versions"
+  ADD COLUMN IF NOT EXISTS "source" text DEFAULT 'approval' NOT NULL;--> statement-breakpoint
+
+ALTER TABLE "playbook_definition_versions"
+  ALTER COLUMN "source" DROP DEFAULT;--> statement-breakpoint
+
+-- Added validating rather than NOT VALID + VALIDATE. The table holds one row
+-- per playbook approval, bounded per playbook by the version-history cap, so
+-- the scan is trivial; and the migrator wraps a migration in one transaction,
+-- so the split form would hold its locks to commit anyway.
+ALTER TABLE "playbook_definition_versions"
+  -- squawk-ignore constraint-missing-not-valid
+  ADD CONSTRAINT "playbook_def_versions_source_values_check"
+  CHECK ("source" IN ('approval'));

--- a/apps/api/src/db/schema/properties.ts
+++ b/apps/api/src/db/schema/properties.ts
@@ -1,3 +1,6 @@
+import { PLAYBOOK_VERSION_SOURCES } from "@/api/lib/workflow/playbook-positions";
+import type { PlaybookVersionSource } from "@/api/lib/workflow/playbook-positions";
+
 import {
   PROPERTY_ROLES,
   PROPERTY_STATUSES,
@@ -121,6 +124,13 @@ export const propertyDependencies = p.pgTable(
 
 // -- Playbook definitions --
 
+// The accepted `source` values, derived from the const the writers use, so the
+// column and the type cannot drift apart.
+const VERSION_SOURCE_SQL_VALUES = sql.join(
+  PLAYBOOK_VERSION_SOURCES.map((value) => sql.raw(`'${value}'`)),
+  sql`, `,
+);
+
 /**
  * An org-scoped playbook definition: a saved, reusable set of graded
  * Positions. It joins clauses and templates under the org-level
@@ -178,6 +188,13 @@ export const playbookDefinitions = p.pgTable(
  * one row per `(playbookDefinitionId, version)`, never updated in place.
  * `restore-version.ts` reads a row here and copies it back onto the
  * definition as a new draft; it never rewrites this table.
+ *
+ * Every row names why it was written (`source`). A review run pins "the
+ * playbook's latest approved version", which is a filter on that column, not
+ * the newest row: a snapshot taken for any other reason must not become the
+ * standard a document was judged against. The column has no default, so a new
+ * writer has to decide, and `PLAYBOOK_VERSION_SOURCES` has to grow before it
+ * can write anything but an approval.
  */
 export const playbookDefinitionVersions = p.pgTable(
   "playbook_definition_versions",
@@ -188,6 +205,7 @@ export const playbookDefinitionVersions = p.pgTable(
       "playbook_definition_id",
     ).notNull(),
     version: p.integer().notNull(),
+    source: p.text("source").notNull().$type<PlaybookVersionSource>(),
     name: p.varchar({ length: 256 }).notNull(),
     description: p.text(),
     scope: jsonb().$type<PlaybookScope>(),
@@ -215,6 +233,10 @@ export const playbookDefinitionVersions = p.pgTable(
     p
       .index("playbook_def_versions_organization_id_idx")
       .on(table.organizationId),
+    p.check(
+      "playbook_def_versions_source_values_check",
+      sql`${table.source} IN (${VERSION_SOURCE_SQL_VALUES})`,
+    ),
     ...orgPolicies(),
   ],
 );

--- a/apps/api/src/handlers/document-reviews/create-run.ts
+++ b/apps/api/src/handlers/document-reviews/create-run.ts
@@ -9,12 +9,9 @@
  */
 
 import { panic, Result } from "better-result";
-import { and, desc, eq, inArray } from "drizzle-orm";
+import { and, eq, inArray } from "drizzle-orm";
 
-import {
-  documentReviewRuns,
-  playbookDefinitionVersions,
-} from "@/api/db/schema";
+import { documentReviewRuns } from "@/api/db/schema";
 import { resolveReviewSelection } from "@/api/handlers/document-reviews/review-selection";
 import { validateReviewTopics } from "@/api/handlers/document-reviews/review-topics";
 import { createDocumentReviewRunBodySchema } from "@/api/handlers/document-reviews/schemas";
@@ -24,6 +21,7 @@ import type { HandlerConfig } from "@/api/lib/api-handlers";
 import { AUDIT_ACTION, AUDIT_RESOURCE_TYPE } from "@/api/lib/audit-log";
 import { createSafeId } from "@/api/lib/branded-types";
 import { workspaceParams } from "@/api/lib/custom-schema";
+import { loadLatestApprovedVersion } from "@/api/lib/document-review/approved-playbook-versions";
 import { resolvePlaybookPin } from "@/api/lib/document-review/resolve-playbook-pin";
 import { DOCUMENT_REVIEW_RUN_ACTIVE_STATUSES } from "@/api/lib/document-review/run-contract";
 import type {
@@ -148,25 +146,13 @@ const createDocumentReviewRun = createSafeHandler(
           if (!definition) {
             return null;
           }
-          const versions = await tx
-            .select({
-              id: playbookDefinitionVersions.id,
-              name: playbookDefinitionVersions.name,
-              positions: playbookDefinitionVersions.positions,
-            })
-            .from(playbookDefinitionVersions)
-            .where(
-              and(
-                eq(playbookDefinitionVersions.playbookDefinitionId, playbookId),
-                eq(playbookDefinitionVersions.organizationId, organizationId),
-              ),
-            )
-            .orderBy(desc(playbookDefinitionVersions.version))
-            .limit(1);
-          const latest = versions.at(0);
           return {
             definition,
-            latestApprovedVersion: latest ?? null,
+            latestApprovedVersion: await loadLatestApprovedVersion({
+              tx,
+              organizationId,
+              playbookDefinitionId: playbookId,
+            }),
           };
         }),
       );

--- a/apps/api/src/handlers/document-reviews/read-run.ts
+++ b/apps/api/src/handlers/document-reviews/read-run.ts
@@ -25,6 +25,7 @@ import {
   DOCUMENT_REVIEW_FINDINGS_PER_RUN_MAX,
 } from "@/api/lib/document-review/run-contract";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
+import { PLAYBOOK_VERSION_SOURCE } from "@/api/lib/workflow/playbook-positions";
 
 const config = {
   description:
@@ -122,6 +123,7 @@ const readDocumentReviewRun = createSafeHandler(
                   >`(SELECT ${playbookDefinitionVersions.id}
                        FROM ${playbookDefinitionVersions}
                       WHERE ${playbookDefinitionVersions.playbookDefinitionId} = ${playbookDefinitions.id}
+                        AND ${playbookDefinitionVersions.source} = ${PLAYBOOK_VERSION_SOURCE.APPROVAL}
                       ORDER BY ${playbookDefinitionVersions.version} DESC
                       LIMIT 1)`,
                 })

--- a/apps/api/src/handlers/playbooks/approve.ts
+++ b/apps/api/src/handlers/playbooks/approve.ts
@@ -15,6 +15,7 @@ import { AUDIT_ACTION, AUDIT_RESOURCE_TYPE } from "@/api/lib/audit-log";
 import { createSafeId } from "@/api/lib/branded-types";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import { assertUnchangedSince } from "@/api/lib/optimistic-concurrency";
+import { PLAYBOOK_VERSION_SOURCE } from "@/api/lib/workflow/playbook-positions";
 
 const config = {
   permissions: { playbook: ["approve"] },
@@ -95,6 +96,9 @@ const approvePlaybookDefinition = createSafeRootHandler(
           organizationId,
           playbookDefinitionId: playbookId,
           version: nextVersion,
+          // What a run's "latest approved version" filters on. Approval is the
+          // only reason this handler writes a snapshot.
+          source: PLAYBOOK_VERSION_SOURCE.APPROVAL,
           name: locked.name,
           description: locked.description,
           scope: locked.scope,

--- a/apps/api/src/handlers/playbooks/auto-run.ts
+++ b/apps/api/src/handlers/playbooks/auto-run.ts
@@ -4,10 +4,12 @@ import { createSafeHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
 import type { SafeId } from "@/api/lib/branded-types";
 import { workspaceParams } from "@/api/lib/custom-schema";
+import { loadLatestApprovedVersions } from "@/api/lib/document-review/approved-playbook-versions";
+import { openPlaybookRun } from "@/api/lib/document-review/open-playbook-run";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import { LIMITS } from "@/api/lib/limits";
 import { startWorkflow } from "@/api/lib/workflow-queue";
-import { materializePlaybookRun } from "@/api/lib/workflow/materialize-playbook-run";
+import { PLAYBOOK_RUN_PROJECTION } from "@/api/lib/workflow/playbook-run-projection";
 import { resolveApplicablePlaybooks } from "@/api/lib/workflow/route-playbooks";
 
 const config = {
@@ -24,9 +26,11 @@ const config = {
 //  - a doc-type-scoped playbook applies only when its type's LABEL is present
 //    among the workspace's "Document Type" classifier values, so we never
 //    materialize empty columns for types absent from the matter.
-// Each playbook stays gated to its own subset via `materializePlaybookRun`; a
-// per-playbook failure (e.g. the properties cap) skips that one and the batch
-// continues.
+// The table is the point here, so every playbook runs projected onto it. Each
+// stays gated to its own subset via `openPlaybookRun`, which pins the same
+// approved snapshot a single run pins and opens the same durable per-document
+// runs; a per-playbook failure (e.g. the properties cap) skips that one and the
+// batch continues.
 const autoRunPlaybooks = createSafeHandler(
   config,
   async function* ({
@@ -43,7 +47,12 @@ const autoRunPlaybooks = createSafeHandler(
       safeDb(async (tx) => {
         const playbooks = await tx.query.playbookDefinitions.findMany({
           where: { organizationId: { eq: organizationId } },
-          columns: { id: true, positions: true, scope: true },
+          columns: {
+            id: true,
+            name: true,
+            positions: true,
+            scope: true,
+          },
           limit: LIMITS.playbookDefinitionsCount,
         });
 
@@ -54,35 +63,50 @@ const autoRunPlaybooks = createSafeHandler(
           playbooks,
         });
 
+        // One read for the whole batch: a pin per playbook resolved separately
+        // would grow the round-trips with the org's library.
+        const approvedVersions = await loadLatestApprovedVersions({
+          tx,
+          organizationId,
+          playbookDefinitionIds: applicable.map((playbook) => playbook.id),
+        });
+
         const materializedPropertyIds: SafeId<"property">[] = [];
         let playbooksRun = 0;
+        let documentRunCount = 0;
 
-        for (const playbook of applicable) {
+        for (const definition of applicable) {
           // oxlint-disable-next-line no-await-in-loop -- one shared transaction: each run reads the cumulative property count to enforce the per-workspace cap, and a single tx cannot run writes in parallel
-          const result = await materializePlaybookRun({
+          const opened = await openPlaybookRun({
             tx,
             workspaceId,
             organizationId,
-            playbookId: playbook.id,
-            positions: playbook.positions.items,
-            scope: playbook.scope,
+            userId: user.id,
+            definition,
+            latestApprovedVersion: approvedVersions.get(definition.id) ?? null,
+            projection: PLAYBOOK_RUN_PROJECTION.COLUMNS,
             recordAuditEvent,
           });
           // Skip a playbook that hit a per-run limit; the rest of the batch
           // still materializes rather than failing the whole auto-run.
-          if (!result.ok || result.materializedPropertyIds.length === 0) {
+          if (!opened.ok || opened.materializedPropertyIds.length === 0) {
             continue;
           }
-          materializedPropertyIds.push(...result.materializedPropertyIds);
+          materializedPropertyIds.push(...opened.materializedPropertyIds);
+          documentRunCount += opened.tableRuns.runs.length;
           playbooksRun += 1;
         }
 
-        return { playbooksRun, materializedPropertyIds };
+        return { playbooksRun, materializedPropertyIds, documentRunCount };
       }),
     );
 
     if (txResult.materializedPropertyIds.length === 0) {
-      return Result.ok({ playbooksRun: 0, runPropertyCount: 0 });
+      return Result.ok({
+        playbooksRun: 0,
+        runPropertyCount: 0,
+        documentRunCount: 0,
+      });
     }
 
     yield* Result.await(
@@ -107,6 +131,7 @@ const autoRunPlaybooks = createSafeHandler(
     return Result.ok({
       playbooksRun: txResult.playbooksRun,
       runPropertyCount: txResult.materializedPropertyIds.length,
+      documentRunCount: txResult.documentRunCount,
     });
   },
 );

--- a/apps/api/src/handlers/playbooks/run.ts
+++ b/apps/api/src/handlers/playbooks/run.ts
@@ -1,29 +1,19 @@
 import { Result } from "better-result";
-import { and, desc, eq } from "drizzle-orm";
 import { t } from "elysia";
 
 import { PLAYBOOK_RUN_PROJECTIONS } from "@stll/api-contract";
 
-import { playbookDefinitionVersions } from "@/api/db/schema";
 import { createSafeHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
-import { AUDIT_ACTION, AUDIT_RESOURCE_TYPE } from "@/api/lib/audit-log";
 import type { SafeId } from "@/api/lib/branded-types";
 import { tSafeId, workspaceParams } from "@/api/lib/custom-schema";
-import { resolvePlaybookPin } from "@/api/lib/document-review/resolve-playbook-pin";
-import type { PinnedPlaybook } from "@/api/lib/document-review/run-contract";
+import { loadLatestApprovedVersion } from "@/api/lib/document-review/approved-playbook-versions";
+import { openPlaybookRun } from "@/api/lib/document-review/open-playbook-run";
 import { enqueueDocumentReviewRuns } from "@/api/lib/document-review/run-queue";
-import {
-  createPlaybookTableRuns,
-  PLAYBOOK_RUN_DOCUMENTS_MAX,
-} from "@/api/lib/document-review/table-run-create";
+import { PLAYBOOK_RUN_DOCUMENTS_MAX } from "@/api/lib/document-review/table-run-create";
 import type { CreatePlaybookTableRunsResult } from "@/api/lib/document-review/table-run-create";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import { startWorkflow } from "@/api/lib/workflow-queue";
-import {
-  materializePlaybookRun,
-  resolveScopedGate,
-} from "@/api/lib/workflow/materialize-playbook-run";
 import { PLAYBOOK_RUN_PROJECTION } from "@/api/lib/workflow/playbook-run-projection";
 
 const runPlaybookBodySchema = t.Object({
@@ -92,86 +82,29 @@ const runPlaybook = createSafeHandler(
           return { ok: false, status: 404, message: "Playbook not found" };
         }
 
-        // Findings are pinned to the version they were measured against, so a
-        // table run resolves the same approved snapshot a single-document
-        // review does rather than reading the live definition twice.
-        const versions = await tx
-          .select({
-            id: playbookDefinitionVersions.id,
-            name: playbookDefinitionVersions.name,
-            positions: playbookDefinitionVersions.positions,
-          })
-          .from(playbookDefinitionVersions)
-          .where(
-            and(
-              eq(
-                playbookDefinitionVersions.playbookDefinitionId,
-                params.playbookId,
-              ),
-              eq(playbookDefinitionVersions.organizationId, organizationId),
-            ),
-          )
-          .orderBy(desc(playbookDefinitionVersions.version))
-          .limit(1);
-        const playbook: PinnedPlaybook = resolvePlaybookPin({
-          definition,
-          latestApprovedVersion: versions.at(0) ?? null,
-        });
-
-        const gateResult = await resolveScopedGate({
-          tx,
-          workspaceId,
-          organizationId,
-          scope: definition.scope,
-        });
-        if (!gateResult.ok) {
-          return gateResult;
-        }
-
-        const materializedPropertyIds: SafeId<"property">[] = [];
-        if (projection === PLAYBOOK_RUN_PROJECTION.COLUMNS) {
-          const materialized = await materializePlaybookRun({
-            tx,
-            workspaceId,
-            organizationId,
-            playbookId: params.playbookId,
-            positions: playbook.definitionSnapshot.positions.items,
-            scope: definition.scope,
-            recordAuditEvent,
-            auditMetadata: { projection },
-          });
-          if (!materialized.ok) {
-            return materialized;
-          }
-          materializedPropertyIds.push(...materialized.materializedPropertyIds);
-        }
-
-        const tableRuns = await createPlaybookTableRuns({
+        const opened = await openPlaybookRun({
           tx,
           workspaceId,
           organizationId,
           userId: user.id,
-          playbook,
-          docTypeGate: gateResult.gate,
+          definition,
+          latestApprovedVersion: await loadLatestApprovedVersion({
+            tx,
+            organizationId,
+            playbookDefinitionId: params.playbookId,
+          }),
           projection,
+          recordAuditEvent,
         });
-
-        // A projected run is audited by the materializer; an unprojected one
-        // writes no column, so its execution is recorded here.
-        if (projection === PLAYBOOK_RUN_PROJECTION.NONE) {
-          await recordAuditEvent(tx, {
-            action: AUDIT_ACTION.EXECUTE,
-            resourceType: AUDIT_RESOURCE_TYPE.PLAYBOOK,
-            resourceId: params.playbookId,
-            metadata: {
-              documentRunCount: tableRuns.runs.length,
-              playbookProvenance: playbook.provenance,
-              projection,
-            },
-          });
+        if (!opened.ok) {
+          return opened;
         }
 
-        return { ok: true, materializedPropertyIds, tableRuns };
+        return {
+          ok: true,
+          materializedPropertyIds: opened.materializedPropertyIds,
+          tableRuns: opened.tableRuns,
+        };
       }),
     );
 

--- a/apps/api/src/lib/document-review/approved-playbook-versions.integration.test.ts
+++ b/apps/api/src/lib/document-review/approved-playbook-versions.integration.test.ts
@@ -1,0 +1,355 @@
+/**
+ * What "the playbook's latest approved version" means, exercised against a real
+ * schema because the schema is what makes it true:
+ *
+ *  - the single run reads one playbook's pin and the auto-run reads a batch of
+ *    them; both must land on the same pin for the same playbook, or one matter
+ *    would measure its documents against two standards depending on which
+ *    button opened the review,
+ *  - a snapshot names why it exists, and only an approval can be stored, so
+ *    "the newest row" and "the newest approved row" cannot come apart behind
+ *    the pin's back.
+ */
+
+import {
+  afterAll,
+  beforeAll,
+  describe,
+  expect,
+  setDefaultTimeout,
+  test,
+} from "bun:test";
+import { inArray, sql } from "drizzle-orm";
+
+import type { Transaction } from "@/api/db/root";
+import {
+  playbookDefinitions,
+  playbookDefinitionVersions,
+} from "@/api/db/schema";
+import { toSafeId } from "@/api/lib/branded-types";
+import type { SafeId } from "@/api/lib/branded-types";
+import {
+  loadLatestApprovedVersion,
+  loadLatestApprovedVersions,
+} from "@/api/lib/document-review/approved-playbook-versions";
+import { resolvePlaybookPin } from "@/api/lib/document-review/resolve-playbook-pin";
+import type { PlaybookDefinitionForPin } from "@/api/lib/document-review/resolve-playbook-pin";
+import { PLAYBOOK_VERSION_SOURCE } from "@/api/lib/workflow/playbook-positions";
+import type { PlaybookPositions } from "@/api/lib/workflow/playbook-positions";
+import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
+import {
+  getRlsFixture,
+  releaseRlsFixture,
+} from "@/api/tests/security/rls-fixture";
+import type { TestIds } from "@/api/tests/security/rls-helpers";
+import type { TestDatabase } from "@/api/tests/security/test-utils";
+
+setDefaultTimeout(120_000);
+
+let testDb: TestDatabase;
+let ids: TestIds;
+
+const seededDefinitionIds: SafeId<"playbookDefinition">[] = [];
+
+/** The constraint under test, named exactly as `db/schema/properties.ts`
+ *  declares it: a rename fails this assertion rather than quietly leaving the
+ *  rule untested. */
+const SOURCE_VALUES_CHECK = "playbook_def_versions_source_values_check";
+
+const POSITION_ID = "11111111-1111-4111-8111-111111111111";
+
+const positionsSaying = (issue: string): PlaybookPositions => ({
+  version: 2,
+  items: [
+    {
+      mode: "extract",
+      sourceId: POSITION_ID,
+      issue,
+      ask: {
+        question: "What is the notice period?",
+        content: { version: 1, type: "text" },
+      },
+      enabled: true,
+    },
+  ],
+});
+
+/** bun-types declares `.rejects.toThrow` as void, so awaiting it trips
+ *  type-aware lint; capture the rejection explicitly instead. */
+const rejectionOf = async (operation: Promise<unknown>): Promise<unknown> =>
+  await operation.then(
+    () => null,
+    (error: unknown) => error,
+  );
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null;
+
+const VIOLATION_FIELDS = ["message", "constraint", "detail"] as const;
+
+/** Everything a failure says about which rule it broke, walked through
+ *  `cause`, so "some error was thrown" cannot pass as proof. */
+const violationText = (error: unknown): string => {
+  const parts: string[] = [];
+  const seen = new Set<unknown>();
+  let current: unknown = error;
+  while (isRecord(current) && !seen.has(current)) {
+    seen.add(current);
+    for (const field of VIOLATION_FIELDS) {
+      const value = current[field];
+      if (typeof value === "string") {
+        parts.push(value);
+      }
+    }
+    current = current["cause"];
+  }
+  return parts.join(" | ");
+};
+
+const seedDefinition = async (
+  name: string,
+  positions: PlaybookPositions,
+): Promise<PlaybookDefinitionForPin> => {
+  const id = toSafeId<"playbookDefinition">(Bun.randomUUIDv7());
+  seededDefinitionIds.push(id);
+  await testDb.insert(playbookDefinitions).values({
+    id,
+    organizationId: ids.orgA,
+    name,
+    positions,
+  });
+  return { id, name, positions };
+};
+
+/** An approval snapshot, written exactly as `approve.ts` writes one. */
+const insertApproval = async ({
+  definitionId,
+  version,
+  name,
+  positions,
+}: {
+  definitionId: SafeId<"playbookDefinition">;
+  version: number;
+  name: string;
+  positions: PlaybookPositions;
+}): Promise<SafeId<"playbookDefinitionVersion">> => {
+  const id = toSafeId<"playbookDefinitionVersion">(Bun.randomUUIDv7());
+  await testDb.insert(playbookDefinitionVersions).values({
+    id,
+    organizationId: ids.orgA,
+    playbookDefinitionId: definitionId,
+    version,
+    source: PLAYBOOK_VERSION_SOURCE.APPROVAL,
+    name,
+    positions,
+    createdBy: ids.userA1,
+  });
+  return id;
+};
+
+/**
+ * A snapshot written past the drizzle schema, either claiming a source the
+ * pin does not recognize or naming none at all.
+ *
+ * Raw SQL on purpose: the column exists to constrain every writer, including
+ * a migration or a script that never sees the TypeScript type.
+ */
+const insertUntypedVersion = async ({
+  definitionId,
+  name,
+  source,
+}: {
+  definitionId: SafeId<"playbookDefinition">;
+  name: string;
+  source: string | null;
+}): Promise<void> => {
+  const id = toSafeId<"playbookDefinitionVersion">(Bun.randomUUIDv7());
+  const positions = sql`'{"version": 2, "items": []}'::jsonb`;
+  const statement =
+    source === null
+      ? sql`
+          INSERT INTO playbook_definition_versions
+            (id, organization_id, playbook_definition_id, version, name,
+             positions, created_by)
+          VALUES (${id}, ${ids.orgA}, ${definitionId}, 1, ${name},
+                  ${positions}, ${ids.userA1})
+        `
+      : sql`
+          INSERT INTO playbook_definition_versions
+            (id, organization_id, playbook_definition_id, version, source,
+             name, positions, created_by)
+          VALUES (${id}, ${ids.orgA}, ${definitionId}, 1, ${source}, ${name},
+                  ${positions}, ${ids.userA1})
+        `;
+  await testDb.execute(statement);
+};
+
+beforeAll(async () => {
+  const fixture = await getRlsFixture();
+  testDb = fixture.testDb;
+  ids = fixture.ids;
+});
+
+afterAll(async () => {
+  try {
+    if (seededDefinitionIds.length > 0) {
+      // The versions cascade with their definition.
+      await testDb
+        .delete(playbookDefinitions)
+        .where(inArray(playbookDefinitions.id, seededDefinitionIds));
+    }
+  } finally {
+    await releaseRlsFixture();
+  }
+});
+
+describe("resolving the pin a run is measured against", () => {
+  test("one playbook and a batch of them resolve the same pin", async () => {
+    const edited = await seedDefinition(
+      "Live draft name",
+      positionsSaying("Edited after approval"),
+    );
+    const other = await seedDefinition(
+      "Other playbook",
+      positionsSaying("Unrelated"),
+    );
+    await insertApproval({
+      definitionId: edited.id,
+      version: 1,
+      name: "Superseded name",
+      positions: positionsSaying("As first approved"),
+    });
+    const latestId = await insertApproval({
+      definitionId: edited.id,
+      version: 2,
+      name: "Approved name",
+      positions: positionsSaying("As approved"),
+    });
+    await insertApproval({
+      definitionId: other.id,
+      version: 1,
+      name: "Other approved name",
+      positions: positionsSaying("Someone else's standard"),
+    });
+
+    const tx = asTestRaw<Transaction>(testDb);
+    // What the single run reads.
+    const single = await loadLatestApprovedVersion({
+      tx,
+      organizationId: ids.orgA,
+      playbookDefinitionId: edited.id,
+    });
+    // What the auto-run and the classification trigger read, for the whole
+    // applicable set at once.
+    const batch = await loadLatestApprovedVersions({
+      tx,
+      organizationId: ids.orgA,
+      playbookDefinitionIds: [edited.id, other.id],
+    });
+
+    expect(single?.id).toBe(latestId);
+    expect(batch.get(edited.id)).toEqual(single);
+
+    const singlePin = resolvePlaybookPin({
+      definition: edited,
+      latestApprovedVersion: single,
+    });
+    const batchPin = resolvePlaybookPin({
+      definition: edited,
+      latestApprovedVersion: batch.get(edited.id) ?? null,
+    });
+
+    expect(batchPin).toEqual(singlePin);
+    // The pin both surfaces produce is the approved snapshot, not the live
+    // definition an author kept editing after approval.
+    expect(singlePin).toEqual({
+      definitionId: edited.id,
+      versionId: latestId,
+      provenance: "approved",
+      definitionSnapshot: {
+        name: "Approved name",
+        positions: positionsSaying("As approved"),
+      },
+    });
+    // And a batch resolves each playbook's own pin, never a neighbour's.
+    expect(batch.get(other.id)?.name).toBe("Other approved name");
+  });
+
+  test("a never-approved playbook pins its live draft on both paths", async () => {
+    const draft = await seedDefinition(
+      "Never approved",
+      positionsSaying("Still being written"),
+    );
+
+    const tx = asTestRaw<Transaction>(testDb);
+    const single = await loadLatestApprovedVersion({
+      tx,
+      organizationId: ids.orgA,
+      playbookDefinitionId: draft.id,
+    });
+    const batch = await loadLatestApprovedVersions({
+      tx,
+      organizationId: ids.orgA,
+      playbookDefinitionIds: [draft.id],
+    });
+
+    expect(single).toBeNull();
+    expect(batch.get(draft.id)).toBeUndefined();
+    expect(
+      resolvePlaybookPin({ definition: draft, latestApprovedVersion: single }),
+    ).toEqual({
+      definitionId: draft.id,
+      versionId: null,
+      provenance: "draft",
+      definitionSnapshot: {
+        name: "Never approved",
+        positions: positionsSaying("Still being written"),
+      },
+    });
+  });
+});
+
+describe("what a version snapshot may claim to be", () => {
+  test("refuses a snapshot taken for an unrecognized reason", async () => {
+    const definition = await seedDefinition(
+      "Guarded playbook",
+      positionsSaying("Guarded"),
+    );
+
+    // The failure mode the column exists for: a snapshot written for some
+    // other reason, which the pin would otherwise read as the approved
+    // standard because it happens to be the newest row.
+    expect(
+      violationText(
+        await rejectionOf(
+          insertUntypedVersion({
+            definitionId: definition.id,
+            name: "Restored from history",
+            source: "restore",
+          }),
+        ),
+      ),
+    ).toContain(SOURCE_VALUES_CHECK);
+  });
+
+  test("refuses a snapshot that names no reason at all", async () => {
+    const definition = await seedDefinition(
+      "Unnamed source",
+      positionsSaying("Unnamed"),
+    );
+
+    // No column default, so a future writer cannot inherit "approval" by
+    // saying nothing.
+    const violation = violationText(
+      await rejectionOf(
+        insertUntypedVersion({
+          definitionId: definition.id,
+          name: "Sourceless",
+          source: null,
+        }),
+      ),
+    );
+    expect(violation).toContain("source");
+    expect(violation).toContain("not-null");
+  });
+});

--- a/apps/api/src/lib/document-review/approved-playbook-versions.integration.test.ts
+++ b/apps/api/src/lib/document-review/approved-playbook-versions.integration.test.ts
@@ -247,7 +247,10 @@ describe("resolving the pin a run is measured against", () => {
       playbookDefinitionIds: [edited.id, other.id],
     });
 
-    expect(single?.id).toBe(latestId);
+    if (single === null) {
+      throw new Error("The edited playbook must resolve an approved version");
+    }
+    expect(single.id).toBe(latestId);
     expect(batch.get(edited.id)).toEqual(single);
 
     const singlePin = resolvePlaybookPin({

--- a/apps/api/src/lib/document-review/approved-playbook-versions.ts
+++ b/apps/api/src/lib/document-review/approved-playbook-versions.ts
@@ -1,0 +1,95 @@
+/**
+ * Reading the approved snapshot a run pins itself to.
+ *
+ * Every surface that starts a review — one document, one playbook over a
+ * table, the whole matter, the classification trigger — must resolve the same
+ * snapshot for the same playbook, or two reviews of one document would be
+ * measured against different standards. So the read lives here once instead of
+ * being restated per call site.
+ */
+
+import { and, desc, eq, inArray } from "drizzle-orm";
+
+import type { Transaction } from "@/api/db/root";
+import { playbookDefinitionVersions } from "@/api/db/schema";
+import type { SafeId } from "@/api/lib/branded-types";
+import type { PlaybookVersionForPin } from "@/api/lib/document-review/resolve-playbook-pin";
+
+type LoadArgs = {
+  tx: Transaction;
+  organizationId: SafeId<"organization">;
+};
+
+/**
+ * The newest approved snapshot of each requested playbook, by definition id.
+ *
+ * One `DISTINCT ON` rather than a query per playbook: the auto-run resolves a
+ * pin for every applicable playbook in the org, and a per-playbook read would
+ * grow the round-trips with the library. The result is bounded by the id list
+ * the caller passes.
+ */
+export const loadLatestApprovedVersions = async ({
+  tx,
+  organizationId,
+  playbookDefinitionIds,
+}: LoadArgs & {
+  playbookDefinitionIds: readonly SafeId<"playbookDefinition">[];
+}): Promise<Map<SafeId<"playbookDefinition">, PlaybookVersionForPin>> => {
+  const byDefinitionId = new Map<
+    SafeId<"playbookDefinition">,
+    PlaybookVersionForPin
+  >();
+  if (playbookDefinitionIds.length === 0) {
+    return byDefinitionId;
+  }
+
+  const rows = await tx
+    .selectDistinctOn([playbookDefinitionVersions.playbookDefinitionId], {
+      playbookDefinitionId: playbookDefinitionVersions.playbookDefinitionId,
+      id: playbookDefinitionVersions.id,
+      name: playbookDefinitionVersions.name,
+      positions: playbookDefinitionVersions.positions,
+    })
+    .from(playbookDefinitionVersions)
+    .where(
+      and(
+        inArray(playbookDefinitionVersions.playbookDefinitionId, [
+          ...playbookDefinitionIds,
+        ]),
+        eq(playbookDefinitionVersions.organizationId, organizationId),
+      ),
+    )
+    .orderBy(
+      playbookDefinitionVersions.playbookDefinitionId,
+      desc(playbookDefinitionVersions.version),
+    )
+    // `DISTINCT ON` already yields at most one row per requested playbook;
+    // stating it as a limit keeps the bound visible in the query itself.
+    .limit(playbookDefinitionIds.length);
+
+  for (const row of rows) {
+    byDefinitionId.set(row.playbookDefinitionId, {
+      id: row.id,
+      name: row.name,
+      positions: row.positions,
+    });
+  }
+  return byDefinitionId;
+};
+
+/** The newest approved snapshot of one playbook, or null when it has never
+ *  been approved. */
+export const loadLatestApprovedVersion = async ({
+  tx,
+  organizationId,
+  playbookDefinitionId,
+}: LoadArgs & {
+  playbookDefinitionId: SafeId<"playbookDefinition">;
+}): Promise<PlaybookVersionForPin | null> => {
+  const versions = await loadLatestApprovedVersions({
+    tx,
+    organizationId,
+    playbookDefinitionIds: [playbookDefinitionId],
+  });
+  return versions.get(playbookDefinitionId) ?? null;
+};

--- a/apps/api/src/lib/document-review/approved-playbook-versions.ts
+++ b/apps/api/src/lib/document-review/approved-playbook-versions.ts
@@ -14,6 +14,7 @@ import type { Transaction } from "@/api/db/root";
 import { playbookDefinitionVersions } from "@/api/db/schema";
 import type { SafeId } from "@/api/lib/branded-types";
 import type { PlaybookVersionForPin } from "@/api/lib/document-review/resolve-playbook-pin";
+import { PLAYBOOK_VERSION_SOURCE } from "@/api/lib/workflow/playbook-positions";
 
 type LoadArgs = {
   tx: Transaction;
@@ -57,6 +58,9 @@ export const loadLatestApprovedVersions = async ({
           ...playbookDefinitionIds,
         ]),
         eq(playbookDefinitionVersions.organizationId, organizationId),
+        // "Latest approved" is a filter, not an ordering: a snapshot written
+        // for any other reason must never become the pinned standard.
+        eq(playbookDefinitionVersions.source, PLAYBOOK_VERSION_SOURCE.APPROVAL),
       ),
     )
     .orderBy(

--- a/apps/api/src/lib/document-review/open-playbook-run.test.ts
+++ b/apps/api/src/lib/document-review/open-playbook-run.test.ts
@@ -1,0 +1,99 @@
+/**
+ * One way to start a playbook over a matter.
+ *
+ * Four surfaces open playbook runs: the single run a user picks, the auto-run
+ * over every applicable playbook, the classification trigger, and the MCP
+ * tool. They drifted once already — three of them materialized the live
+ * definition's columns and recorded no run at all, while the fourth pinned an
+ * approved snapshot and opened one run per document — and the drift was
+ * invisible because nothing connected the call sites.
+ *
+ * So the connection is asserted here: `openPlaybookRun` is the only caller of
+ * the materializer and of the run creator, and every surface goes through it.
+ * A fifth surface, or a regression in an existing one, fails this file rather
+ * than quietly reviewing a matter against a different playbook.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+const API_ROOT = path.resolve(import.meta.dir, "../../..");
+
+/** The one module allowed to drive a playbook run. */
+const OPENER = "src/lib/document-review/open-playbook-run.ts";
+
+/**
+ * The steps that turn a playbook into a review, and where each is defined.
+ * Anything that calls one of these without going through the opener is a
+ * second way to start a review.
+ */
+const RUN_STEPS = {
+  materializePlaybookRun: "src/lib/workflow/materialize-playbook-run.ts",
+  createPlaybookTableRuns: "src/lib/document-review/table-run-create.ts",
+} as const;
+
+/** Every surface that starts a playbook run, and what starts it there. */
+const RUN_SURFACES = {
+  "src/handlers/playbooks/run.ts": "the playbook a user picks",
+  "src/handlers/playbooks/auto-run.ts": "every applicable playbook at once",
+  "src/lib/workflow/route-playbooks.ts": "the classification trigger",
+  "src/mcp/knowledge-tools.ts": "the run_playbook MCP tool",
+} as const;
+
+const sources = new Map(
+  [...new Bun.Glob("src/**/*.ts").scanSync({ cwd: API_ROOT, onlyFiles: true })]
+    .filter((file) => !file.endsWith(".test.ts"))
+    .map((file) => [file, readFileSync(path.join(API_ROOT, file), "utf-8")]),
+);
+
+const sourceOf = (file: string): string => {
+  const source = sources.get(file);
+  if (source === undefined) {
+    // A moved or renamed surface must fail loudly here; an absent file read as
+    // empty text would satisfy every "no one else calls this" assertion below.
+    throw new Error(`${file} is not a source file under apps/api`);
+  }
+  return source;
+};
+
+/** Files that call `name({ ... })` somewhere other than where it is defined. */
+const callersOf = (name: string, declaredIn: string): string[] =>
+  [...sources]
+    .filter(
+      ([file, source]) => file !== declaredIn && source.includes(`${name}({`),
+    )
+    .map(([file]) => file);
+
+describe("starting a playbook run", () => {
+  test.each(Object.entries(RUN_STEPS))(
+    "%s is driven only by the shared opener",
+    (name, declaredIn) => {
+      // Both directions: the opener must actually call it (a step it stopped
+      // driving would otherwise pass by being called nowhere at all), and no
+      // one else may.
+      expect(sourceOf(OPENER)).toContain(`${name}({`);
+      expect(callersOf(name, declaredIn)).toEqual([OPENER]);
+    },
+  );
+
+  test.each(Object.entries(RUN_SURFACES))(
+    "%s (%s) opens its runs through the shared opener",
+    (file) => {
+      const source = sourceOf(file);
+      expect(source).toContain(
+        'from "@/api/lib/document-review/open-playbook-run"',
+      );
+      expect(source).toContain("openPlaybookRun({");
+    },
+  );
+
+  test("the surfaces named here are the ones that exist", () => {
+    // The declared list is only a guard while it is complete: a surface that
+    // calls the opener without being listed would never be checked for
+    // anything else this file asserts.
+    expect(callersOf("openPlaybookRun", OPENER).toSorted()).toEqual(
+      Object.keys(RUN_SURFACES).toSorted(),
+    );
+  });
+});

--- a/apps/api/src/lib/document-review/open-playbook-run.ts
+++ b/apps/api/src/lib/document-review/open-playbook-run.ts
@@ -1,0 +1,135 @@
+/**
+ * Starting one playbook over one matter's files table.
+ *
+ * Three surfaces do this: the single run a user picks, the auto-run over every
+ * applicable playbook, and the classification trigger. What they may differ in
+ * is which playbooks they select and what they do with a failure — never in
+ * which version of the playbook the review is measured against, nor in whether
+ * a durable run records it. So the whole sequence lives here: pin the approved
+ * snapshot, resolve the document-type gate, materialize the columns the
+ * projection asks for, and open one run per document against that same pin.
+ */
+
+import type { PlaybookRunProjection } from "@stll/api-contract";
+
+import type { Transaction } from "@/api/db/root";
+import { AUDIT_ACTION, AUDIT_RESOURCE_TYPE } from "@/api/lib/audit-log";
+import type { AuditRecorder } from "@/api/lib/audit-log";
+import type { SafeId } from "@/api/lib/branded-types";
+import { resolvePlaybookPin } from "@/api/lib/document-review/resolve-playbook-pin";
+import type {
+  PlaybookDefinitionForPin,
+  PlaybookVersionForPin,
+} from "@/api/lib/document-review/resolve-playbook-pin";
+import type { PinnedPlaybook } from "@/api/lib/document-review/run-contract";
+import { createPlaybookTableRuns } from "@/api/lib/document-review/table-run-create";
+import type { CreatePlaybookTableRunsResult } from "@/api/lib/document-review/table-run-create";
+import {
+  materializePlaybookRun,
+  resolveScopedGate,
+} from "@/api/lib/workflow/materialize-playbook-run";
+import type { PlaybookScope } from "@/api/lib/workflow/playbook-positions";
+import { PLAYBOOK_RUN_PROJECTION } from "@/api/lib/workflow/playbook-run-projection";
+
+/** The live definition a run starts from: what to pin when it was never
+ *  approved, plus the scope that gates which documents it reaches. */
+export type PlaybookDefinitionForRun = PlaybookDefinitionForPin & {
+  scope: PlaybookScope | null;
+};
+
+export type OpenPlaybookRunArgs = {
+  tx: Transaction;
+  workspaceId: SafeId<"workspace">;
+  organizationId: SafeId<"organization">;
+  userId: SafeId<"user">;
+  definition: PlaybookDefinitionForRun;
+  latestApprovedVersion: PlaybookVersionForPin | null;
+  projection: PlaybookRunProjection;
+  recordAuditEvent: AuditRecorder;
+  /** Extra context merged onto the EXECUTE audit row, e.g. the system/trigger
+   *  marker an auto-routed run carries. */
+  auditMetadata?: Record<string, unknown>;
+};
+
+export type OpenPlaybookRunResult =
+  | {
+      ok: true;
+      playbook: PinnedPlaybook;
+      materializedPropertyIds: SafeId<"property">[];
+      tableRuns: CreatePlaybookTableRunsResult;
+    }
+  | { ok: false; status: 400; message: string };
+
+export const openPlaybookRun = async ({
+  tx,
+  workspaceId,
+  organizationId,
+  userId,
+  definition,
+  latestApprovedVersion,
+  projection,
+  recordAuditEvent,
+  auditMetadata,
+}: OpenPlaybookRunArgs): Promise<OpenPlaybookRunResult> => {
+  // Findings are pinned to the version they were measured against, so every
+  // surface resolves the same approved snapshot rather than reading the live
+  // definition — and the columns below are materialized from that snapshot too,
+  // so a table cell and a finding never disagree about the standard.
+  const playbook = resolvePlaybookPin({ definition, latestApprovedVersion });
+
+  const gateResult = await resolveScopedGate({
+    tx,
+    workspaceId,
+    organizationId,
+    scope: definition.scope,
+  });
+  if (!gateResult.ok) {
+    return gateResult;
+  }
+
+  const materializedPropertyIds: SafeId<"property">[] = [];
+  if (projection === PLAYBOOK_RUN_PROJECTION.COLUMNS) {
+    const materialized = await materializePlaybookRun({
+      tx,
+      workspaceId,
+      organizationId,
+      playbookId: definition.id,
+      positions: playbook.definitionSnapshot.positions.items,
+      scope: definition.scope,
+      recordAuditEvent,
+      auditMetadata: { ...auditMetadata, projection },
+    });
+    if (!materialized.ok) {
+      return materialized;
+    }
+    materializedPropertyIds.push(...materialized.materializedPropertyIds);
+  }
+
+  const tableRuns = await createPlaybookTableRuns({
+    tx,
+    workspaceId,
+    organizationId,
+    userId,
+    playbook,
+    docTypeGate: gateResult.gate,
+    projection,
+  });
+
+  // A projected run is audited by the materializer; an unprojected one writes
+  // no column, so its execution is recorded here.
+  if (projection === PLAYBOOK_RUN_PROJECTION.NONE) {
+    await recordAuditEvent(tx, {
+      action: AUDIT_ACTION.EXECUTE,
+      resourceType: AUDIT_RESOURCE_TYPE.PLAYBOOK,
+      resourceId: definition.id,
+      metadata: {
+        ...auditMetadata,
+        documentRunCount: tableRuns.runs.length,
+        playbookProvenance: playbook.provenance,
+        projection,
+      },
+    });
+  }
+
+  return { ok: true, playbook, materializedPropertyIds, tableRuns };
+};

--- a/apps/api/src/lib/document-review/resolve-playbook-pin.ts
+++ b/apps/api/src/lib/document-review/resolve-playbook-pin.ts
@@ -9,7 +9,8 @@ export type PlaybookDefinitionForPin = {
   positions: PlaybookPositions;
 };
 
-/** The newest row in `playbook_definition_versions` for that definition. */
+/** The newest `playbook_definition_versions` row for that definition whose
+ *  `source` is an approval (see `loadLatestApprovedVersions`). */
 export type PlaybookVersionForPin = {
   id: SafeId<"playbookDefinitionVersion">;
   name: string;

--- a/apps/api/src/lib/workflow/playbook-positions.ts
+++ b/apps/api/src/lib/workflow/playbook-positions.ts
@@ -3,6 +3,7 @@ import type { Static } from "elysia";
 
 import { propertyContentSchema } from "@/api/db/schema-validators";
 import { tConditionNode } from "@/api/lib/conditions/contract";
+import type { ConstantMap } from "@/api/lib/constant-map";
 import {
   positionRuleSchema,
   positionSeveritySchema,
@@ -220,3 +221,17 @@ export const playbookDefinitionStatusSchema = t.Union([
 export type PlaybookDefinitionStatus = Static<
   typeof playbookDefinitionStatusSchema
 >;
+
+// ── Version provenance ────────────────────────────────────────────
+// Why a `playbook_definition_versions` row exists. Today approval is the only
+// reason one is written, and a run pins "the playbook's latest approved
+// version" by reading the newest row — which is only the same thing while that
+// stays true. The column says which it is instead of leaving the reader to
+// assume, so a future snapshot taken for another reason (an import, a restore,
+// an autosave) has to name itself and cannot be mistaken for an approval.
+// Deliberately no default: a writer must decide.
+export const PLAYBOOK_VERSION_SOURCES = ["approval"] as const;
+export type PlaybookVersionSource = (typeof PLAYBOOK_VERSION_SOURCES)[number];
+export const PLAYBOOK_VERSION_SOURCE = {
+  APPROVAL: "approval",
+} as const satisfies ConstantMap<PlaybookVersionSource>;

--- a/apps/api/src/lib/workflow/route-playbooks.ts
+++ b/apps/api/src/lib/workflow/route-playbooks.ts
@@ -6,17 +6,17 @@ import { documentTypes, fields } from "@/api/db/schema";
 import { captureError } from "@/api/lib/analytics/capture";
 import { createBackgroundAuditRecorder } from "@/api/lib/audit-log";
 import type { SafeId } from "@/api/lib/branded-types";
+import { loadLatestApprovedVersions } from "@/api/lib/document-review/approved-playbook-versions";
+import { openPlaybookRun } from "@/api/lib/document-review/open-playbook-run";
 import { LIMITS } from "@/api/lib/limits";
 import type { DocTypeClassifier } from "@/api/lib/workflow/materialize-playbook-run";
-import {
-  materializePlaybookRun,
-  resolveDocTypeClassifier,
-} from "@/api/lib/workflow/materialize-playbook-run";
+import { resolveDocTypeClassifier } from "@/api/lib/workflow/materialize-playbook-run";
 import type {
   PlaybookPositions,
   PlaybookScope,
   PlaybookTrigger,
 } from "@/api/lib/workflow/playbook-positions";
+import { PLAYBOOK_RUN_PROJECTION } from "@/api/lib/workflow/playbook-run-projection";
 
 // One shared routing seam. `resolveApplicablePlaybooks` narrows a set of org
 // playbooks to those that apply to a workspace's documents (workspace-wide, or
@@ -24,8 +24,12 @@ import type {
 // values). Both the manual files-table auto-run and the classification trigger
 // resolve through here so the applicability rules cannot drift between surfaces.
 
+// Everything routing needs to decide a playbook applies, plus what pinning it
+// needs when it has never been approved (`name`/`positions` are the draft
+// snapshot `resolvePlaybookPin` falls back to).
 export type RoutablePlaybook = {
   id: SafeId<"playbookDefinition">;
+  name: string;
   positions: PlaybookPositions;
   scope: PlaybookScope | null;
 };
@@ -87,7 +91,7 @@ export const classifierParticipatedInPlan = ({
 // Workspace-wide playbooks pass through; doc-type-scoped ones survive only when
 // their label is present among the classifier's values. One distinct query over
 // the candidate labels keeps the read bounded by the document-type count.
-export const resolveApplicablePlaybooks = async ({
+export const resolveApplicablePlaybooks = async <T extends RoutablePlaybook>({
   tx,
   workspaceId,
   organizationId,
@@ -97,12 +101,14 @@ export const resolveApplicablePlaybooks = async ({
   tx: Transaction;
   workspaceId: SafeId<"workspace">;
   organizationId: SafeId<"organization">;
-  playbooks: readonly RoutablePlaybook[];
+  // Generic over the row: applicability reads only `scope`, and a caller that
+  // selected more columns (the pinned name, say) keeps them on the way out.
+  playbooks: readonly T[];
   // The "Document Type" classifier, pre-resolved by a caller that already
   // fetched it (classification routing threads it in to avoid a duplicate
   // lookup). Omitted by the auto-run path, which resolves it internally below.
   classifier?: DocTypeClassifier | null;
-}): Promise<RoutablePlaybook[]> => {
+}): Promise<T[]> => {
   const scoped = playbooks.filter((playbook) =>
     Boolean(playbook.scope?.documentTypeKey),
   );
@@ -206,8 +212,10 @@ type RouteClassifiedDocumentsArgs = {
 };
 
 // Classification-driven routing: after the Document Type classifier resolves for
-// a workspace, materialize every applicable `onClassified` org playbook over the
-// files table and start one workflow across the union of materialized columns.
+// a workspace, run every applicable `onClassified` org playbook over the files
+// table — projected onto it, pinned to the same approved snapshot a manual run
+// pins, opening the same durable per-document runs — and start one workflow
+// across the union of materialized columns.
 // Idempotent by construction: materializePlaybookRun upserts by playbookSourceId,
 // so re-running over an already-materialized playbook maps back to the same
 // columns instead of duplicating them; already-graded verdict cells are only
@@ -233,7 +241,7 @@ export const routeClassifiedDocuments = async ({
         organizationId: { eq: organizationId },
         RAW: (table) => sql`${table.scope}->>'trigger' = 'onClassified'`,
       },
-      columns: { id: true, positions: true, scope: true },
+      columns: { id: true, name: true, positions: true, scope: true },
       limit: LIMITS.playbookDefinitionsCount,
     });
 
@@ -272,16 +280,24 @@ export const routeClassifiedDocuments = async ({
       userId,
     });
 
+    // One read for the whole batch rather than a pin per playbook.
+    const approvedVersions = await loadLatestApprovedVersions({
+      tx,
+      organizationId,
+      playbookDefinitionIds: applicable.map((playbook) => playbook.id),
+    });
+
     const ids: SafeId<"property">[] = [];
-    for (const playbook of applicable) {
+    for (const definition of applicable) {
       // oxlint-disable-next-line no-await-in-loop -- one shared transaction: each run reads the cumulative property count to enforce the per-workspace cap, and a single tx cannot run writes in parallel
-      const result = await materializePlaybookRun({
+      const result = await openPlaybookRun({
         tx,
         workspaceId,
         organizationId,
-        playbookId: playbook.id,
-        positions: playbook.positions.items,
-        scope: playbook.scope,
+        userId,
+        definition,
+        latestApprovedVersion: approvedVersions.get(definition.id) ?? null,
+        projection: PLAYBOOK_RUN_PROJECTION.COLUMNS,
         recordAuditEvent,
         auditMetadata: ROUTED_AUDIT_METADATA,
       });
@@ -291,7 +307,7 @@ export const routeClassifiedDocuments = async ({
         // hitting the properties cap) is not silently invisible.
         captureError(new Error(result.message), {
           workspaceId,
-          playbookId: playbook.id,
+          playbookId: definition.id,
           status: String(result.status),
         });
         continue;

--- a/apps/api/src/mcp/knowledge-tools.test.ts
+++ b/apps/api/src/mcp/knowledge-tools.test.ts
@@ -9,10 +9,19 @@ import { toSafeDbMock } from "@/api/tests/scoped-db-mock";
 
 const materializePlaybookRunMock = mock();
 const startWorkflowMock = mock();
+// The two database reads `openPlaybookRun` makes around the materializer. The
+// opener itself, and the pin resolution inside it, stay real: they are what
+// this suite checks the tool for.
+const loadLatestApprovedVersionMock = mock();
+const createPlaybookTableRunsMock = mock();
 
 const realMaterializeRun =
   await import("@/api/lib/workflow/materialize-playbook-run");
 const realWorkflowQueue = await import("@/api/lib/workflow-queue");
+const realApprovedVersions =
+  await import("@/api/lib/document-review/approved-playbook-versions");
+const realTableRunCreate =
+  await import("@/api/lib/document-review/table-run-create");
 
 void mock.module("@/api/lib/workflow/materialize-playbook-run", () => ({
   ...realMaterializeRun,
@@ -22,6 +31,19 @@ void mock.module("@/api/lib/workflow/materialize-playbook-run", () => ({
 void mock.module("@/api/lib/workflow-queue", () => ({
   ...realWorkflowQueue,
   startWorkflow: startWorkflowMock,
+}));
+
+void mock.module(
+  "@/api/lib/document-review/approved-playbook-versions",
+  () => ({
+    ...realApprovedVersions,
+    loadLatestApprovedVersion: loadLatestApprovedVersionMock,
+  }),
+);
+
+void mock.module("@/api/lib/document-review/table-run-create", () => ({
+  ...realTableRunCreate,
+  createPlaybookTableRuns: createPlaybookTableRunsMock,
 }));
 
 const { handleMcpToolCall, listMcpTools } = await import("@/api/mcp/tools");
@@ -51,6 +73,33 @@ const createClauseScopedDb = (rows: unknown[]) =>
       return await run(builder);
     }),
   );
+
+const PLAYBOOK_ID = toSafeId<"playbookDefinition">("pb_1");
+const APPROVED_VERSION_ID = toSafeId<"playbookDefinitionVersion">("pbv_1");
+
+/**
+ * A playbook's positions, tagged by the issue text so the approved snapshot and
+ * the live definition are told apart by every assertion below.
+ *
+ * A factory rather than a shared constant: `toMatchObject` walks the objects it
+ * is handed, and a fixture reused across assertions must not carry state from
+ * one into the next.
+ */
+const positionsSaying = (issue: string) => ({
+  version: 2,
+  items: [
+    {
+      mode: "extract",
+      sourceId: "11111111-1111-4111-8111-111111111111",
+      issue,
+      ask: {
+        question: "What is the notice period?",
+        content: { version: 1, type: "text" },
+      },
+      enabled: true,
+    },
+  ],
+});
 
 /** A scopedDb whose playbookDefinitions.findFirst resolves to `playbook`. */
 const createPlaybookScopedDb = (playbook: unknown) =>
@@ -104,6 +153,8 @@ describe("MCP knowledge tools", () => {
   beforeEach(() => {
     materializePlaybookRunMock.mockReset();
     startWorkflowMock.mockReset();
+    loadLatestApprovedVersionMock.mockReset();
+    createPlaybookTableRunsMock.mockReset();
   });
 
   afterAll(() => {
@@ -226,7 +277,16 @@ describe("MCP knowledge tools", () => {
     );
   });
 
-  test("run_playbook materializes columns and queues the review workflow", async () => {
+  test("run_playbook reviews the approved snapshot, opens its runs, and queues the workflow", async () => {
+    // The playbook was edited after it was approved. Everything the tool does
+    // must come from the approved snapshot: a review an agent started must be
+    // measured against the same standard the HTTP surfaces measure against,
+    // not against whatever the definition said at that moment.
+    loadLatestApprovedVersionMock.mockResolvedValue({
+      id: APPROVED_VERSION_ID,
+      name: "Approved name",
+      positions: positionsSaying("As approved"),
+    });
     materializePlaybookRunMock.mockResolvedValue({
       ok: true,
       materializedPropertyIds: [
@@ -234,13 +294,21 @@ describe("MCP knowledge tools", () => {
         toSafeId<"property">("p2"),
       ],
     });
+    createPlaybookTableRunsMock.mockResolvedValue({
+      runs: [{ runId: toSafeId<"documentReviewRun">("run_1"), entityId: "e1" }],
+      skippedActiveCount: 0,
+      uncoveredCount: 0,
+      expectedFindingCount: 1,
+    });
     startWorkflowMock.mockResolvedValue(undefined);
 
     const result = await handleMcpToolCall({
       args: { matter_id: "ws_1", playbook_id: "pb_1" },
       context: createContext({
         scopedDb: createPlaybookScopedDb({
-          positions: { version: 2, items: [] },
+          id: PLAYBOOK_ID,
+          name: "Live draft name",
+          positions: positionsSaying("Edited after approval"),
           scope: null,
         }),
       }),
@@ -249,7 +317,35 @@ describe("MCP knowledge tools", () => {
 
     expect(result.isError).toBeFalsy();
     expect(parseToolPayload(result)).toEqual({ runPropertyCount: 2 });
+
+    // Columns still materialize, but from the snapshot rather than the live
+    // definition: the cell a lawyer reads on the table and the finding the run
+    // records answer the same question.
     expect(materializePlaybookRunMock).toHaveBeenCalledTimes(1);
+    expect(materializePlaybookRunMock.mock.calls.at(0)?.[0]).toMatchObject({
+      playbookId: PLAYBOOK_ID,
+      positions: positionsSaying("As approved").items,
+    });
+
+    // And a durable run per document, pinned to the version it was measured
+    // against, projected onto the table the tool materialized into.
+    expect(createPlaybookTableRunsMock).toHaveBeenCalledTimes(1);
+    expect(createPlaybookTableRunsMock.mock.calls.at(0)?.[0]).toMatchObject({
+      workspaceId: "ws_1",
+      userId: "user_1",
+      projection: "columns",
+      docTypeGate: null,
+      playbook: {
+        definitionId: PLAYBOOK_ID,
+        versionId: APPROVED_VERSION_ID,
+        provenance: "approved",
+        definitionSnapshot: {
+          name: "Approved name",
+          positions: positionsSaying("As approved"),
+        },
+      },
+    });
+
     expect(startWorkflowMock).toHaveBeenCalledTimes(1);
     expect(startWorkflowMock.mock.calls.at(0)?.[0]).toMatchObject({
       propertyIds: [toSafeId<"property">("p1"), toSafeId<"property">("p2")],

--- a/apps/api/src/mcp/knowledge-tools.ts
+++ b/apps/api/src/mcp/knowledge-tools.ts
@@ -33,6 +33,8 @@ import {
   type ClauseRun,
   isClauseBody,
 } from "@/api/lib/clauses/types";
+import { loadLatestApprovedVersion } from "@/api/lib/document-review/approved-playbook-versions";
+import { openPlaybookRun } from "@/api/lib/document-review/open-playbook-run";
 import { LIMITS } from "@/api/lib/limits";
 import {
   brandPersistedClauseCategoryId,
@@ -41,8 +43,8 @@ import {
   brandPersistedPlaybookDefinitionId,
 } from "@/api/lib/safe-id-boundaries";
 import { startWorkflow } from "@/api/lib/workflow-queue";
-import { materializePlaybookRun } from "@/api/lib/workflow/materialize-playbook-run";
 import type { Position } from "@/api/lib/workflow/playbook-positions";
+import { PLAYBOOK_RUN_PROJECTION } from "@/api/lib/workflow/playbook-run-projection";
 import type { McpRequestContext } from "@/api/mcp/context";
 import {
   defineTextFieldSpec,
@@ -1503,32 +1505,38 @@ const handleRunPlaybookTool: McpToolHandler = async ({ args, context }) => {
   );
   const recordAuditEvent = bindWorkspaceRecorder(context, workspaceId);
 
-  // Mirror the HTTP run handler: resolve the org-scoped definition and
-  // materialize its columns in one transaction, then enqueue the workflow.
-  // Usage is metered downstream per extracted property by the workflow, not
-  // synchronously here (the HTTP route defers metering the same way).
+  // Mirror the HTTP run handler by calling exactly what it calls: pin the
+  // playbook's approved snapshot, materialize its columns, and open one
+  // durable review run per document, in one transaction. Usage is metered
+  // downstream per extracted property by the workflow, not synchronously here
+  // (the HTTP route defers metering the same way).
   const txResult = await context.safeDb(async (tx) => {
-    const playbook = await tx.query.playbookDefinitions.findFirst({
+    const definition = await tx.query.playbookDefinitions.findFirst({
       where: {
         id: { eq: playbookId },
         organizationId: { eq: organizationId },
       },
-      columns: { positions: true, scope: true },
+      columns: { id: true, name: true, positions: true, scope: true },
     });
-    if (!playbook) {
+    if (!definition) {
       return {
         ok: false as const,
         status: 404 as const,
         message: "Playbook not found",
       };
     }
-    return await materializePlaybookRun({
+    return await openPlaybookRun({
       tx,
       workspaceId,
       organizationId,
-      playbookId,
-      positions: playbook.positions.items,
-      scope: playbook.scope,
+      userId: context.userId,
+      definition,
+      latestApprovedVersion: await loadLatestApprovedVersion({
+        tx,
+        organizationId,
+        playbookDefinitionId: definition.id,
+      }),
+      projection: PLAYBOOK_RUN_PROJECTION.COLUMNS,
       recordAuditEvent,
     });
   });


### PR DESCRIPTION
Every way of starting a playbook run now goes through one pinned sequence, and version snapshots carry explicit provenance.

## One opener, four surfaces

`openPlaybookRun` in `lib/document-review/` owns the whole start-a-review sequence: resolve the approved-version pin, resolve the document-type gate, materialize the projection's columns from that pinned snapshot, create the per-document review runs against the same pin, audit. The four surfaces that previously each did some subset with their own rules — the run endpoint, auto-run, classification routing, and the MCP `run_playbook` tool (the last two still materialized live, unapproved positions and recorded no durable runs) — are now thin callers. A structural test asserts in both directions that the opener is the only caller of the materializer and run creator, and that the declared surface set equals the actual caller set.

Auto-run keeps its semantics (one shared transaction, sequential per-playbook loop with the documented cap re-read, silent per-playbook skip, one workflow start over the union) and always projects columns. Batch pin resolution is one `DISTINCT ON` query for all playbooks.

## Version provenance

`playbook_definition_versions` gains `source` (`approval`, CHECK-derived from the canonical const, no default): the "latest version row = approved snapshot" assumption previously held only because the approve handler was the sole inserter. Readers that resolve the pin now filter on it explicitly, so a future snapshot writer with a different purpose must declare itself and cannot silently become the version runs pin to. Existing rows backfill as approvals, which they all are.

Tests: pin equality between the batch and single loaders against an edited-after-approval definition, draft provenance for never-approved playbooks, the CHECK and NOT NULL rejections probed past the TypeScript types with raw SQL, and the caller-set structural test.
