### PR TITLE
fix(api): durable search projection for duplicated and copied entities

### DIFF
--- a/apps/api/src/handlers/entities/copy-to-workspace.test.ts
+++ b/apps/api/src/handlers/entities/copy-to-workspace.test.ts
@@ -41,9 +41,36 @@ void mock.module("@/api/lib/s3", () => ({
   },
 }));
 
-const processExtractionMock = mock(async () => {});
+// Spread the real module: the copy helper reads its search-index ownership
+// split from here. Only the durable extraction request itself is replaced.
+const realProcessExtraction =
+  await import("@/api/lib/search/process-extraction");
+const processExtractionMock = mock(async (_entityId: string) => undefined);
 void mock.module("@/api/lib/search/process-extraction", () => ({
+  ...realProcessExtraction,
   processExtraction: processExtractionMock,
+}));
+
+const enqueueEntitySearchRepairsMock = mock(
+  async (_tx: unknown, _entityIds: readonly string[]) => undefined,
+);
+const flushEntitySearchRepairsMock = mock(async () => ({
+  failed: 0,
+  repaired: 0,
+}));
+// The full export set, not just the two this suite asserts on: a partial
+// factory silently leaves the rest of the module real, so a consumer reaching
+// the queue through another entry point would open a transaction here.
+const idleRepairOutcome = async () => ({ failed: 0, repaired: 0 });
+void mock.module("@/api/lib/search/projection-repair-queue", () => ({
+  SEARCH_PROJECTION_REPAIR_BATCH_SIZE: 32,
+  drainSearchProjectionRepairQueue: idleRepairOutcome,
+  enqueueContactSearchRepairs: async () => undefined,
+  enqueueEntitySearchRepairs: enqueueEntitySearchRepairsMock,
+  enqueueWorkspaceSearchRepairs: async () => undefined,
+  flushContactSearchRepairs: idleRepairOutcome,
+  flushEntitySearchRepairs: flushEntitySearchRepairsMock,
+  flushWorkspaceSearchRepairs: idleRepairOutcome,
 }));
 
 const captureErrorMock = mock(() => undefined);
@@ -181,6 +208,8 @@ beforeEach(() => {
   s3DeleteMock.mockClear();
   captureErrorMock.mockClear();
   processExtractionMock.mockClear();
+  enqueueEntitySearchRepairsMock.mockClear();
+  flushEntitySearchRepairsMock.mockClear();
   syncWorkspaceSearchActivityMock.mockClear();
   enqueueImageThumbnailMock.mockClear();
   enqueueImageThumbnailOrMarkFailedMock.mockClear();
@@ -398,6 +427,14 @@ describe("copy-to-workspace", () => {
     // S3 file was copied
     expect(fileMock).toHaveBeenCalled();
     expect(writeMock).toHaveBeenCalled();
+
+    // The extraction run that reads the copied PDF indexes it, so the copy
+    // carries no mark of its own; marking it too would index it twice.
+    if (!copiedEntity) {
+      throw new Error("Expected the copy to be inserted");
+    }
+    expect(processExtractionMock.mock.calls).toEqual([[copiedEntity.id]]);
+    expect(enqueueEntitySearchRepairsMock.mock.calls.at(0)?.at(1)).toEqual([]);
   });
 
   test("maps document type classifier fields by role before name fallback", async () => {
@@ -1316,6 +1353,17 @@ describe("copy-to-workspace", () => {
     expect(copiedChild?.kind).toBe("document");
     expect(copiedChild?.name).toBe("Child.pdf");
     expect(copiedChild?.parentId).toBe(copiedFolder?.id);
+
+    // Neither copy has a file for an extraction run to read, so both are
+    // marked dirty inside the copy transaction and nothing else would index
+    // them if the post-commit flush were lost.
+    expect(processExtractionMock).not.toHaveBeenCalled();
+    expect(enqueueEntitySearchRepairsMock).toHaveBeenCalledTimes(1);
+    expect(enqueueEntitySearchRepairsMock.mock.calls.at(0)?.at(1)).toEqual([
+      copiedFolder?.id,
+      copiedChild?.id,
+    ]);
+    expect(flushEntitySearchRepairsMock).toHaveBeenCalledTimes(1);
   });
 
   test("remaps file IDs in field content for S3 copy", async () => {

--- a/apps/api/src/handlers/entities/copy-to-workspace.ts
+++ b/apps/api/src/handlers/entities/copy-to-workspace.ts
@@ -39,7 +39,11 @@ import { LIMITS } from "@/api/lib/limits";
 import { DOCUMENT_TYPE_CLASSIFIER_ROLE } from "@/api/lib/properties/create-schema";
 import { broadcastWorkspaceResourceSetUpdated } from "@/api/lib/resource-realtime";
 import { syncWorkspaceSearchActivity } from "@/api/lib/search/index-global";
-import { processExtraction } from "@/api/lib/search/process-extraction";
+import {
+  processExtraction,
+  SEARCH_INDEX_OWNER,
+} from "@/api/lib/search/process-extraction";
+import { flushEntitySearchRepairs } from "@/api/lib/search/projection-repair-queue";
 
 const copyToWorkspaceBodySchema = t.Object({
   entityId: tSafeId("entity"),
@@ -285,11 +289,17 @@ const copyToWorkspaceHandler = async function* ({
           currentVersion: {
             columns: { id: true },
             with: {
+              // Ascending field id is ascending creation order, the order
+              // `findExtractionFileField` requires, so the copy resolves the
+              // same extraction source as the entity it came from. At most
+              // one field per property bounds the read.
               fields: {
                 columns: {
                   propertyId: true,
                   content: true,
                 },
+                orderBy: { id: "asc" },
+                limit: LIMITS.propertiesCount,
               },
             },
           },
@@ -336,6 +346,8 @@ const copyToWorkspaceHandler = async function* ({
                     propertyId: true,
                     content: true,
                   },
+                  orderBy: { id: "asc" },
+                  limit: LIMITS.propertiesCount,
                 },
               },
             },
@@ -538,8 +550,16 @@ const copyToWorkspaceHandler = async function* ({
     });
   }
 
-  // Process search extraction for new entities
-  for (const entityId of txResult.entityIds) {
+  // Acceleration only: the marks are already committed, and the standing
+  // drain repairs whatever a lost flush leaves behind.
+  flushEntitySearchRepairs(
+    txResult.entityIdsBySearchIndexOwner[SEARCH_INDEX_OWNER.searchMark],
+  ).catch(captureError);
+
+  // Request extraction for the copies a run indexes
+  for (const entityId of txResult.entityIdsBySearchIndexOwner[
+    SEARCH_INDEX_OWNER.durableExtraction
+  ]) {
     processExtraction(entityId).catch(captureError);
   }
 
@@ -577,7 +597,7 @@ const copyToWorkspaceHandler = async function* ({
 
   return Result.ok({
     entityId: txResult.entityId,
-    entityIds: txResult.entityIds,
+    entityIds: txResult.copiedEntities.map(({ entityId }) => entityId),
   });
 };
 

--- a/apps/api/src/handlers/entities/copy-utils.ts
+++ b/apps/api/src/handlers/entities/copy-utils.ts
@@ -23,6 +23,12 @@ import { thumbnailDerivativeStateForFile } from "@/api/lib/files/image-derivativ
 import { createFileKey } from "@/api/lib/files/utils";
 import { LIMITS } from "@/api/lib/limits";
 import { getS3 } from "@/api/lib/s3";
+import {
+  SEARCH_INDEX_OWNER,
+  searchIndexOwnerForFields,
+} from "@/api/lib/search/process-extraction";
+import type { SearchIndexOwner } from "@/api/lib/search/process-extraction";
+import { enqueueEntitySearchRepairs } from "@/api/lib/search/projection-repair-queue";
 
 export type EntityFieldSnapshot = {
   propertyId: SafeId<"property">;
@@ -459,7 +465,13 @@ type CopyEntitiesErrorResult = {
 type CopyEntitiesSuccessResult = {
   ok: true;
   entityId: SafeId<"entity">;
-  entityIds: SafeId<"entity">[];
+  /**
+   * The copies grouped by which mechanism writes their search projection.
+   * `search-mark` copies already carry a dirty mark committed with this
+   * transaction; the caller only flushes it. `durable-extraction` copies are
+   * indexed by the run the caller requests for them.
+   */
+  entityIdsBySearchIndexOwner: Record<SearchIndexOwner, SafeId<"entity">[]>;
   copiedEntities: CopiedEntity[];
   /** File fields that may need PDF derivative generation. */
   fileFields: CopiedFileField[];
@@ -571,7 +583,14 @@ export const copyEntities = async ({
 
   const idMap = new Map<SafeId<"entity">, SafeId<"entity">>();
   const copiedEntities: CopiedEntity[] = [];
-  const copiedEntityIds: SafeId<"entity">[] = [];
+  // Split by which mechanism owns each copy's search projection, so every
+  // copy is covered exactly once: a durable extraction run indexes the
+  // documents it extracts, and a dirty mark committed with this transaction
+  // covers everything else.
+  const copiedEntityIds: Record<SearchIndexOwner, SafeId<"entity">[]> = {
+    [SEARCH_INDEX_OWNER.durableExtraction]: [],
+    [SEARCH_INDEX_OWNER.searchMark]: [],
+  };
   const fileFields: CopiedFileField[] = [];
 
   for (const source of sourceEntities) {
@@ -646,36 +665,36 @@ export const copyEntities = async ({
       .set({ currentVersionId: newVersionId })
       .where(eq(entities.id, newEntityId));
 
-    const sourceFields = source.currentVersion.fields;
-    if (sourceFields.length > 0) {
-      const fieldInserts = sourceFields.map((field) => {
-        const fieldId = createSafeId<"field">();
+    const fieldInserts = source.currentVersion.fields.map((field) => {
+      const fieldId = createSafeId<"field">();
 
-        // Track file fields for PDF derivative enqueueing
-        if (field.content.type === "file") {
-          fileFields.push({
-            entityId: newEntityId,
-            fieldId,
-            mimeType: field.content.mimeType,
-            encrypted: field.content.encrypted,
-          });
-        }
+      // Track file fields for PDF derivative enqueueing
+      if (field.content.type === "file") {
+        fileFields.push({
+          entityId: newEntityId,
+          fieldId,
+          mimeType: field.content.mimeType,
+          encrypted: field.content.encrypted,
+        });
+      }
 
-        return {
-          id: fieldId,
-          workspaceId: targetWorkspaceId,
-          propertyId: field.propertyId,
-          entityVersionId: newVersionId,
-          content: field.content,
-        };
-      });
-
+      return {
+        id: fieldId,
+        workspaceId: targetWorkspaceId,
+        propertyId: field.propertyId,
+        entityVersionId: newVersionId,
+        content: field.content,
+      };
+    });
+    if (fieldInserts.length > 0) {
       // oxlint-disable-next-line no-db-await-in-loop/no-db-await-in-loop, no-await-in-loop -- sequential field insert depends on the version created in this iteration
       await tx.insert(fields).values(fieldInserts);
     }
 
     idMap.set(source.id, newEntityId);
-    copiedEntityIds.push(newEntityId);
+    // The field ids above are minted in insertion order, so the copy resolves
+    // the same extraction source `processExtraction` will resolve for it.
+    copiedEntityIds[searchIndexOwnerForFields(fieldInserts)].push(newEntityId);
     copiedEntities.push({
       sourceId: source.id,
       entityId: newEntityId,
@@ -721,10 +740,17 @@ export const copyEntities = async ({
     };
   }
 
+  // Written here, inside the copy transaction: the mark commits or rolls back
+  // with the copies themselves, so a lost post-commit flush costs nothing.
+  await enqueueEntitySearchRepairs(
+    tx,
+    copiedEntityIds[SEARCH_INDEX_OWNER.searchMark],
+  );
+
   return {
     ok: true,
     entityId: rootEntityId,
-    entityIds: copiedEntityIds,
+    entityIdsBySearchIndexOwner: copiedEntityIds,
     copiedEntities,
     fileFields,
   };

--- a/apps/api/src/handlers/entities/duplicate.test.ts
+++ b/apps/api/src/handlers/entities/duplicate.test.ts
@@ -13,10 +13,36 @@ import type { SafeId } from "@/api/lib/branded-types";
 import { toSafeId } from "@/api/lib/branded-types";
 import { createScopedDbMock } from "@/api/tests/scoped-db-mock";
 
-const processExtractionMock = mock(async () => {});
-
+// Spread the real module: the copy helper reads its search-index ownership
+// split from here. Only the durable extraction request itself is replaced.
+const realProcessExtraction =
+  await import("@/api/lib/search/process-extraction");
+const processExtractionMock = mock(async (_entityId: string) => undefined);
 void mock.module("@/api/lib/search/process-extraction", () => ({
+  ...realProcessExtraction,
   processExtraction: processExtractionMock,
+}));
+
+const enqueueEntitySearchRepairsMock = mock(
+  async (_tx: unknown, _entityIds: readonly string[]) => undefined,
+);
+const flushEntitySearchRepairsMock = mock(async () => ({
+  failed: 0,
+  repaired: 0,
+}));
+// The full export set, not just the two this suite asserts on: a partial
+// factory silently leaves the rest of the module real, so a consumer reaching
+// the queue through another entry point would open a transaction here.
+const idleRepairOutcome = async () => ({ failed: 0, repaired: 0 });
+void mock.module("@/api/lib/search/projection-repair-queue", () => ({
+  SEARCH_PROJECTION_REPAIR_BATCH_SIZE: 32,
+  drainSearchProjectionRepairQueue: idleRepairOutcome,
+  enqueueContactSearchRepairs: async () => undefined,
+  enqueueEntitySearchRepairs: enqueueEntitySearchRepairsMock,
+  enqueueWorkspaceSearchRepairs: async () => undefined,
+  flushContactSearchRepairs: idleRepairOutcome,
+  flushEntitySearchRepairs: flushEntitySearchRepairsMock,
+  flushWorkspaceSearchRepairs: idleRepairOutcome,
 }));
 
 const fileMock = mock(() => ({}));
@@ -149,6 +175,10 @@ const createContext = ({
 
 describe("duplicate entity", () => {
   test("duplicates folder trees instead of rejecting folders", async () => {
+    processExtractionMock.mockClear();
+    enqueueEntitySearchRepairsMock.mockClear();
+    flushEntitySearchRepairsMock.mockClear();
+
     const insertedEntities: InsertedEntity[] = [];
     const insertedVersions: unknown[] = [];
     const insertedFields: unknown[] = [];
@@ -258,6 +288,15 @@ describe("duplicate entity", () => {
     expect(nestedDuplicate.kind).toBe("folder");
     expect(nestedDuplicate.name).toBe("Nested");
     expect(nestedDuplicate.parentId).toBe(rootDuplicate.id);
-    expect(processExtractionMock).toHaveBeenCalledTimes(3);
+    // The DOCX copy is indexed by the extraction run that reads it; the two
+    // folder copies have no such run, so their marks are written inside the
+    // copy transaction and only flushed afterwards.
+    expect(processExtractionMock.mock.calls).toEqual([[documentDuplicate.id]]);
+    expect(enqueueEntitySearchRepairsMock).toHaveBeenCalledTimes(1);
+    expect(enqueueEntitySearchRepairsMock.mock.calls.at(0)?.at(1)).toEqual([
+      rootDuplicate.id,
+      nestedDuplicate.id,
+    ]);
+    expect(flushEntitySearchRepairsMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/api/src/handlers/entities/duplicate.ts
+++ b/apps/api/src/handlers/entities/duplicate.ts
@@ -25,7 +25,11 @@ import {
   enqueuePdfDerivativeOrMarkFailed,
 } from "@/api/lib/file-derivative-queue";
 import { LIMITS } from "@/api/lib/limits";
-import { processExtraction } from "@/api/lib/search/process-extraction";
+import {
+  processExtraction,
+  SEARCH_INDEX_OWNER,
+} from "@/api/lib/search/process-extraction";
+import { flushEntitySearchRepairs } from "@/api/lib/search/projection-repair-queue";
 
 const duplicateEntityBodySchema = t.Object({
   entityId: tSafeId("entity"),
@@ -62,11 +66,17 @@ const duplicateEntityHandler = async function* ({
           currentVersion: {
             columns: { id: true },
             with: {
+              // Ascending field id is ascending creation order, the order
+              // `findExtractionFileField` requires, so the copy resolves the
+              // same extraction source as the entity it came from. At most
+              // one field per property bounds the read.
               fields: {
                 columns: {
                   propertyId: true,
                   content: true,
                 },
+                orderBy: { id: "asc" },
+                limit: LIMITS.propertiesCount,
               },
             },
           },
@@ -102,6 +112,8 @@ const duplicateEntityHandler = async function* ({
                     propertyId: true,
                     content: true,
                   },
+                  orderBy: { id: "asc" },
+                  limit: LIMITS.propertiesCount,
                 },
               },
             },
@@ -177,7 +189,15 @@ const duplicateEntityHandler = async function* ({
     );
   }
 
-  for (const entityId of txResult.entityIds) {
+  // Acceleration only: the marks are already committed, and the standing
+  // drain repairs whatever a lost flush leaves behind.
+  flushEntitySearchRepairs(
+    txResult.entityIdsBySearchIndexOwner[SEARCH_INDEX_OWNER.searchMark],
+  ).catch(captureError);
+
+  for (const entityId of txResult.entityIdsBySearchIndexOwner[
+    SEARCH_INDEX_OWNER.durableExtraction
+  ]) {
     processExtraction(entityId).catch(captureError);
   }
 

--- a/apps/api/src/handlers/workspaces/duplicate.test.ts
+++ b/apps/api/src/handlers/workspaces/duplicate.test.ts
@@ -46,8 +46,14 @@ void mock.module("@/api/lib/s3", () => ({
   },
 }));
 
-const processExtractionMock = mock(async () => undefined);
+// Spread the real module: the handler reads its search-index ownership split
+// from here, and that split is what these tests exercise. Only the durable
+// extraction request itself is replaced.
+const realProcessExtraction =
+  await import("@/api/lib/search/process-extraction");
+const processExtractionMock = mock(async (_entityId: string) => undefined);
 void mock.module("@/api/lib/search/process-extraction", () => ({
+  ...realProcessExtraction,
   processExtraction: processExtractionMock,
 }));
 
@@ -57,6 +63,13 @@ void mock.module("@/api/lib/search/index-global", () => ({
 }));
 
 const enqueueWorkspaceSearchRepairsMock = mock(async () => undefined);
+const enqueueEntitySearchRepairsMock = mock(
+  async (_tx: unknown, _entityIds: readonly string[]) => undefined,
+);
+const flushEntitySearchRepairsMock = mock(async () => ({
+  failed: 0,
+  repaired: 0,
+}));
 const flushWorkspaceSearchRepairsMock = mock(async () => ({
   failed: 0,
   repaired: 0,
@@ -69,10 +82,10 @@ void mock.module("@/api/lib/search/projection-repair-queue", () => ({
   SEARCH_PROJECTION_REPAIR_BATCH_SIZE: 32,
   drainSearchProjectionRepairQueue: idleRepairOutcome,
   enqueueContactSearchRepairs: async () => undefined,
-  enqueueEntitySearchRepairs: async () => undefined,
+  enqueueEntitySearchRepairs: enqueueEntitySearchRepairsMock,
   enqueueWorkspaceSearchRepairs: enqueueWorkspaceSearchRepairsMock,
   flushContactSearchRepairs: idleRepairOutcome,
-  flushEntitySearchRepairs: idleRepairOutcome,
+  flushEntitySearchRepairs: flushEntitySearchRepairsMock,
   flushWorkspaceSearchRepairs: flushWorkspaceSearchRepairsMock,
 }));
 
@@ -91,6 +104,16 @@ const isInsertedWorkspaceField = (
   value !== null &&
   "content" in value &&
   "propertyId" in value;
+
+const isInsertedEntity = (
+  value: unknown,
+): value is { id: string; name: string } =>
+  typeof value === "object" &&
+  value !== null &&
+  "id" in value &&
+  typeof value.id === "string" &&
+  "name" in value &&
+  typeof value.name === "string";
 
 const createContext = ({
   includeContent = false,
@@ -557,5 +580,193 @@ describe("duplicateWorkspace", () => {
     );
     expect(copiedContent.placeholder).toBe(imageContent.placeholder);
     expect(copiedContent.thumbnailDerivative).toEqual({ status: "ready" });
+  });
+
+  test("marks the copies extraction will not index, inside the transaction", async () => {
+    processExtractionMock.mockClear();
+    enqueueEntitySearchRepairsMock.mockClear();
+    flushEntitySearchRepairsMock.mockClear();
+
+    const filePropertyId = toSafeId<"property">("prop_file");
+    const notePropertyId = toSafeId<"property">("prop_note");
+    const documentContent: FieldContent = {
+      type: "file",
+      version: 1,
+      id: "source-file-id",
+      fileName: "evidence.png",
+      mimeType: "image/png",
+      sizeBytes: 1024,
+      encrypted: false,
+      sha256Hex: "a".repeat(64),
+      // The copy inherits a PDF rendering, so a durable run can read text
+      // from it and owns the copy's search projection.
+      pdfFileId: "source-pdf-id",
+      pdfDerivative: { status: "ready" },
+    };
+    const taskContent: FieldContent = {
+      type: "text",
+      version: 1,
+      value: "Draft the settlement offer",
+    };
+    const sourceEntity = {
+      parentId: null,
+      status: "open",
+      priority: null,
+      dueDate: null,
+      agendaKind: null,
+      startAt: null,
+      endAt: null,
+      occurredAt: null,
+      remindAt: null,
+      allDay: null,
+      timeZone: null,
+      location: null,
+      onlineMeetingUrl: null,
+      availability: null,
+      sensitivity: null,
+      organizer: null,
+      attendees: null,
+      recurrence: null,
+      agendaSource: null,
+      sortOrder: null,
+      metadata: null,
+    };
+    const insertedEntityIdsByName = new Map<string, string>();
+    let nextSequence = 0;
+
+    const { safeDb, scopedDb } = createScopedDbMock({
+      query: {
+        workspaces: {
+          findFirst: async () => ({
+            id: "ws_source123",
+            name: "Smith v Jones",
+            clientId: null,
+            billingReference: null,
+            color: null,
+            leadUserId: null,
+          }),
+        },
+        properties: {
+          findMany: async () => [
+            {
+              id: filePropertyId,
+              workspaceId: "ws_source123",
+              name: "Document",
+              status: "active",
+              content: { type: "file", version: 1 },
+              tool: null,
+              system: false,
+              kinds: ["document"],
+            },
+            {
+              id: notePropertyId,
+              workspaceId: "ws_source123",
+              name: "Notes",
+              status: "active",
+              content: { type: "text", version: 1 },
+              tool: null,
+              system: false,
+              kinds: ["task"],
+            },
+          ],
+        },
+        propertyDependencies: { findMany: async () => [] },
+        workspaceViews: { findMany: async () => [] },
+        workspaceMembers: { findMany: async () => [] },
+        workspaceContacts: { findMany: async () => [] },
+        organizationSettings: { findFirst: async () => null },
+        entities: {
+          findMany: async () => [
+            {
+              ...sourceEntity,
+              id: "entity_document",
+              kind: "document",
+              name: "evidence.png",
+              currentVersion: {
+                id: "version_document",
+                fields: [
+                  { propertyId: filePropertyId, content: documentContent },
+                ],
+              },
+            },
+            {
+              ...sourceEntity,
+              id: "entity_task",
+              kind: "task",
+              name: "Settlement offer",
+              currentVersion: {
+                id: "version_task",
+                fields: [{ propertyId: notePropertyId, content: taskContent }],
+              },
+            },
+          ],
+        },
+      },
+      select: (selectedFields: Record<string, unknown>) => {
+        if ("total" in selectedFields) {
+          return { from: () => ({ where: async () => [{ total: 0 }] }) };
+        }
+
+        if ("name" in selectedFields) {
+          return { from: () => ({ where: async () => [] }) };
+        }
+
+        throw new Error("Unexpected select fields");
+      },
+      insert: (table: unknown) => ({
+        values: (value: unknown) => {
+          if (table === documentCounters || table === matterCounters) {
+            return {
+              onConflictDoUpdate: () => ({
+                returning: async () => {
+                  nextSequence += 1;
+                  return [{ lastValue: nextSequence }];
+                },
+              }),
+            };
+          }
+
+          if (table === entities && isInsertedEntity(value)) {
+            insertedEntityIdsByName.set(value.name, value.id);
+            return undefined;
+          }
+
+          if (
+            table === auditLogs ||
+            table === entityVersions ||
+            table === fields ||
+            table === properties ||
+            table === workspaces
+          ) {
+            return undefined;
+          }
+
+          throw new Error("Unexpected insert table");
+        },
+      }),
+      update: () => ({ set: () => ({ where: async () => undefined }) }),
+      execute: async () => undefined,
+    });
+
+    const result = await duplicateWorkspace.handler(
+      createContext({ includeContent: true, safeDb, scopedDb }),
+    );
+
+    expect(result).toEqual({ workspaceId: expect.any(String) });
+
+    const copiedDocumentId = insertedEntityIdsByName.get("evidence.png");
+    const copiedTaskId = insertedEntityIdsByName.get("Settlement offer");
+    if (!(copiedDocumentId && copiedTaskId)) {
+      throw new Error("Expected both copies to be inserted");
+    }
+
+    // The task has no extraction run to index it, so its mark is written
+    // with the copies themselves; the document's projection arrives with the
+    // extraction that owns it, and marking it too would index it twice.
+    expect(enqueueEntitySearchRepairsMock).toHaveBeenCalledTimes(1);
+    expect(enqueueEntitySearchRepairsMock.mock.calls.at(0)?.at(1)).toEqual([
+      copiedTaskId,
+    ]);
+    expect(processExtractionMock.mock.calls).toEqual([[copiedDocumentId]]);
   });
 });

--- a/apps/api/src/handlers/workspaces/duplicate.test.ts
+++ b/apps/api/src/handlers/workspaces/duplicate.test.ts
@@ -16,6 +16,7 @@ import type { FieldContent, PropertyContent } from "@/api/db/schema-validators";
 import { createAuditRecorder } from "@/api/lib/audit-log";
 import { toSafeId } from "@/api/lib/branded-types";
 import type { SafeId } from "@/api/lib/branded-types";
+import { LIMITS } from "@/api/lib/limits";
 import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
 import { createScopedDbMock } from "@/api/tests/scoped-db-mock";
 
@@ -768,5 +769,61 @@ describe("duplicateWorkspace", () => {
       copiedTaskId,
     ]);
     expect(processExtractionMock.mock.calls).toEqual([[copiedDocumentId]]);
+  });
+
+  test("rejects an oversized source before the duplicate writes anything", async () => {
+    s3WriteMock.mockClear();
+
+    const { safeDb, scopedDb } = createScopedDbMock({
+      query: {
+        workspaces: {
+          findFirst: async () => ({
+            id: "ws_source123",
+            name: "Smith v Jones",
+            clientId: null,
+            billingReference: null,
+            color: null,
+            leadUserId: null,
+          }),
+        },
+        properties: { findMany: async () => [] },
+        propertyDependencies: { findMany: async () => [] },
+        workspaceViews: { findMany: async () => [] },
+        workspaceMembers: { findMany: async () => [] },
+        workspaceContacts: { findMany: async () => [] },
+        organizationSettings: { findFirst: async () => null },
+        entities: {
+          // One past the cap the source read allows through.
+          findMany: async () =>
+            Array.from(
+              { length: LIMITS.entitiesCount + 1 },
+              (_unused, index) => ({
+                id: `entity_${index}`,
+                kind: "task",
+                name: `Task ${index}`,
+                parentId: null,
+                currentVersion: { id: `version_${index}`, fields: [] },
+              }),
+            ),
+        },
+      },
+      select: () => {
+        throw new Error("Duplicate read the target matter before validating");
+      },
+      insert: () => {
+        throw new Error("Duplicate wrote before validating the source size");
+      },
+      execute: async () => undefined,
+    });
+
+    const result = await duplicateWorkspace.handler(
+      createContext({ includeContent: true, safeDb, scopedDb }),
+    );
+
+    expect(result).toEqual({
+      code: 400,
+      response: { message: "Entities limit reached" },
+    });
+    expect(s3WriteMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/handlers/workspaces/duplicate.ts
+++ b/apps/api/src/handlers/workspaces/duplicate.ts
@@ -496,6 +496,16 @@ const duplicateWorkspace = createSafeHandler(
       );
     }
 
+    // Checked before anything is written. The write transaction commits what
+    // it has already inserted when it returns a failure, so rejecting the
+    // source size from inside it would answer 400 and still leave the target
+    // matter, its properties, and its views behind.
+    if (snapshot.entities.length > LIMITS.entitiesCount) {
+      return Result.err(
+        new HandlerError({ status: 400, message: "Entities limit reached" }),
+      );
+    }
+
     const fileCopies = collectUniqueFileCopies(snapshot.entities);
     const fileIdMap = new Map(
       fileCopies.map((copy) => [copy.sourceFileId, copy.targetFileId]),
@@ -745,14 +755,6 @@ const duplicateWorkspace = createSafeHandler(
       const entitiesToDuplicate = orderEntitiesForDuplicate(snapshot.entities);
 
       if (includeContent && entitiesToDuplicate.length > 0) {
-        if (entitiesToDuplicate.length > LIMITS.entitiesCount) {
-          return {
-            ok: false as const,
-            status: 400 as const,
-            message: "Entities limit reached",
-          };
-        }
-
         for (const source of entitiesToDuplicate) {
           if (!source.currentVersion) {
             return {

--- a/apps/api/src/handlers/workspaces/duplicate.ts
+++ b/apps/api/src/handlers/workspaces/duplicate.ts
@@ -44,9 +44,16 @@ import {
   propertyDependencyReadLimit,
 } from "@/api/lib/properties/dependency-limits";
 import { getS3 } from "@/api/lib/s3";
-import { processExtraction } from "@/api/lib/search/process-extraction";
 import {
+  processExtraction,
+  SEARCH_INDEX_OWNER,
+  searchIndexOwnerForFields,
+} from "@/api/lib/search/process-extraction";
+import type { SearchIndexOwner } from "@/api/lib/search/process-extraction";
+import {
+  enqueueEntitySearchRepairs,
   enqueueWorkspaceSearchRepairs,
+  flushEntitySearchRepairs,
   flushWorkspaceSearchRepairs,
 } from "@/api/lib/search/projection-repair-queue";
 import type { ViewLayout } from "@/api/lib/views-schema";
@@ -445,11 +452,19 @@ const duplicateWorkspace = createSafeHandler(
                   currentVersion: {
                     columns: { id: true },
                     with: {
+                      // Ascending field id is ascending creation order, which
+                      // is the order `findExtractionFileField` requires: the
+                      // copy must select the same file field for extraction
+                      // that the source does. At most one field per property,
+                      // so the limit is the structural bound, stated for the
+                      // unbounded-read rule.
                       fields: {
                         columns: {
                           propertyId: true,
                           content: true,
                         },
+                        orderBy: { id: "asc" },
+                        limit: LIMITS.propertiesCount,
                       },
                     },
                   },
@@ -718,7 +733,15 @@ const duplicateWorkspace = createSafeHandler(
       }
 
       const entityIdMap = new Map<string, SafeId<"entity">>();
-      const duplicatedEntityIds: SafeId<"entity">[] = [];
+      // Split by which mechanism owns each copy's search projection, so every
+      // duplicated entity is covered exactly once: a durable extraction run
+      // indexes the documents it extracts, and a dirty mark committed with
+      // this transaction covers everything else.
+      const duplicatedEntityIds: Record<SearchIndexOwner, SafeId<"entity">[]> =
+        {
+          [SEARCH_INDEX_OWNER.durableExtraction]: [],
+          [SEARCH_INDEX_OWNER.searchMark]: [],
+        };
       const entitiesToDuplicate = orderEntitiesForDuplicate(snapshot.entities);
 
       if (includeContent && entitiesToDuplicate.length > 0) {
@@ -825,7 +848,12 @@ const duplicateWorkspace = createSafeHandler(
           }
 
           entityIdMap.set(source.id, newEntityId);
-          duplicatedEntityIds.push(newEntityId);
+          // `newFields` is inserted in source field order and its ids are
+          // generated in that same order, so the copy resolves the same
+          // extraction source `processExtraction` will resolve for it.
+          duplicatedEntityIds[searchIndexOwnerForFields(newFields)].push(
+            newEntityId,
+          );
         }
       }
 
@@ -842,6 +870,10 @@ const duplicateWorkspace = createSafeHandler(
         },
       });
 
+      await enqueueEntitySearchRepairs(
+        tx,
+        duplicatedEntityIds[SEARCH_INDEX_OWNER.searchMark],
+      );
       await enqueueWorkspaceSearchRepairs(tx, [targetWorkspaceId]);
 
       return {
@@ -872,11 +904,20 @@ const duplicateWorkspace = createSafeHandler(
       );
     }
 
+    // Both post-commit calls only accelerate what the transaction already
+    // guarantees: the marked copies keep their queued row until a repair
+    // rebuilds their projection, and the documents keep the immutable source
+    // the bounded extraction repair scan requests a run for.
     flushWorkspaceSearchRepairs([txResult.value.workspaceId]).catch(
       captureError,
     );
+    flushEntitySearchRepairs(
+      txResult.value.entityIds[SEARCH_INDEX_OWNER.searchMark],
+    ).catch(captureError);
 
-    for (const entityId of txResult.value.entityIds) {
+    for (const entityId of txResult.value.entityIds[
+      SEARCH_INDEX_OWNER.durableExtraction
+    ]) {
       processExtraction(entityId).catch(captureError);
     }
 

--- a/apps/api/src/lib/search/process-extraction.ts
+++ b/apps/api/src/lib/search/process-extraction.ts
@@ -86,6 +86,45 @@ export const requiresDurableNativeExtraction = (
   return canExtractMimeType(pickExtractionSource(fileField).extractionMimeType);
 };
 
+/**
+ * Which mechanism writes an entity's search projection once its current
+ * version is committed.
+ *
+ * `durable-extraction` means a document-processing run owns it: the run
+ * persists the extracted text and indexes the entity when it completes, so a
+ * search mark written beside it would index the same entity a second time
+ * with no text. `search-mark` means nothing else will write the projection,
+ * so the mutation must mark the entity dirty inside its own transaction.
+ *
+ * `processExtraction` reads this to pick its own branch, so a caller that
+ * splits its entities by owner cannot drift from what extraction actually
+ * does with them.
+ */
+export const SEARCH_INDEX_OWNER = {
+  durableExtraction: "durable-extraction",
+  searchMark: "search-mark",
+} as const;
+
+export type SearchIndexOwner =
+  (typeof SEARCH_INDEX_OWNER)[keyof typeof SEARCH_INDEX_OWNER];
+
+/**
+ * `fields` must arrive in the same stable order `findExtractionFileField`
+ * requires: ascending field id, which is ascending creation order.
+ */
+export const searchIndexOwnerForFields = (
+  fields: readonly {
+    content: FieldContent;
+    propertyId?: SafeId<"property"> | undefined;
+  }[],
+  filePropertyId?: SafeId<"property">,
+): SearchIndexOwner => {
+  const fileField = findExtractionFileField(fields, filePropertyId);
+  return fileField && requiresDurableNativeExtraction(fileField)
+    ? SEARCH_INDEX_OWNER.durableExtraction
+    : SEARCH_INDEX_OWNER.searchMark;
+};
+
 type NativeExtractionProjectionOptions = {
   charCount: number;
   ciphertext: Buffer;
@@ -387,7 +426,9 @@ export const processExtraction = async (
         field.propertyId === options.filePropertyId),
   );
   if (
-    !(fileField && fileFieldRow && requiresDurableNativeExtraction(fileField))
+    !(fileField && fileFieldRow) ||
+    searchIndexOwnerForFields(version.fields, options?.filePropertyId) ===
+      SEARCH_INDEX_OWNER.searchMark
   ) {
     await getSearchProvider().indexEntity(entityId);
     return;

--- a/apps/api/src/lib/search/search-index-ownership.db.test.ts
+++ b/apps/api/src/lib/search/search-index-ownership.db.test.ts
@@ -1,0 +1,255 @@
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  expect,
+  setDefaultTimeout,
+  test,
+} from "bun:test";
+import { sql } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/pglite";
+
+import { organization } from "@/api/db/auth-schema";
+import type { Transaction } from "@/api/db/root";
+import {
+  entities,
+  searchProjectionRepairQueue,
+  workspaces,
+} from "@/api/db/schema";
+import type { FieldContent } from "@/api/db/schema-validators";
+import { toSafeId } from "@/api/lib/branded-types";
+import type { SafeId } from "@/api/lib/branded-types";
+import {
+  SEARCH_INDEX_OWNER,
+  searchIndexOwnerForFields,
+} from "@/api/lib/search/process-extraction";
+import type { SearchIndexOwner } from "@/api/lib/search/process-extraction";
+import {
+  drainSearchProjectionRepairQueue,
+  enqueueEntitySearchRepairs,
+} from "@/api/lib/search/projection-repair-queue";
+import type { SearchProjectionRepairDeps } from "@/api/lib/search/projection-repair-queue";
+import { DOCX_MIME_TYPE } from "@/api/mime-types";
+import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
+import { createTestPglite } from "@/api/tests/pglite-test-db";
+
+setDefaultTimeout(120_000);
+
+// Copying entities into a new matter has to leave every copy reachable by
+// search without indexing any of them twice. Ownership decides that split:
+// a copy whose file a durable extraction run will read is indexed when that
+// run completes, and every other copy carries a dirty mark committed with
+// the copy itself. What is asserted here is the part no type can hold --
+// that the split covers each copy exactly once, that the mark shares the
+// fate of the transaction that wrote it, and that a drain then rebuilds
+// each marked projection once and never the extracted one.
+
+const ORGANIZATION_ID = "org-search-index-ownership";
+const SEED_AT = new Date("2026-01-01T00:00:00.000Z");
+const SHA256_HEX = "a".repeat(64);
+
+const uuid = (suffix: number): string =>
+  `00000000-0000-4000-8000-${String(suffix).padStart(12, "0")}`;
+
+const workspaceId = toSafeId<"workspace">(uuid(1));
+const entityId = (suffix: number): SafeId<"entity"> =>
+  toSafeId<"entity">(uuid(suffix));
+
+const fileContent = ({
+  mimeType,
+  pdfFileId = null,
+}: {
+  mimeType: string;
+  pdfFileId?: string | null;
+}): FieldContent => ({
+  version: 1,
+  type: "file",
+  id: uuid(900),
+  fileName: `source.${mimeType.split("/").at(-1) ?? "bin"}`,
+  mimeType,
+  sizeBytes: 1024,
+  encrypted: false,
+  sha256Hex: SHA256_HEX,
+  pdfFileId,
+});
+
+const textContent = (value: string): FieldContent => ({
+  version: 1,
+  type: "text",
+  value,
+});
+
+/**
+ * The copies one matter duplication writes: the field arrays are the ones
+ * the handler inserts, in the order it inserts them.
+ */
+const duplicatedCopies = [
+  {
+    entityId: entityId(10),
+    fields: [{ content: fileContent({ mimeType: DOCX_MIME_TYPE }) }],
+    label: "a copied document a run will extract",
+  },
+  {
+    entityId: entityId(11),
+    // Awaiting a PDF derivative that the copy has no run for yet: nothing
+    // else will index it, so the mark has to.
+    fields: [{ content: fileContent({ mimeType: "image/png" }) }],
+    label: "a copied image with no text layer yet",
+  },
+  {
+    entityId: entityId(12),
+    fields: [{ content: textContent("Kickoff call with the client") }],
+    label: "a copied task",
+  },
+  {
+    entityId: entityId(13),
+    fields: [],
+    label: "a copied folder",
+  },
+] as const;
+
+const copiesOwnedBy = (owner: SearchIndexOwner): SafeId<"entity">[] =>
+  duplicatedCopies
+    .filter((copy) => searchIndexOwnerForFields(copy.fields) === owner)
+    .map((copy) => copy.entityId);
+
+let client: Awaited<ReturnType<typeof createTestPglite>>;
+let db: ReturnType<typeof drizzle>;
+
+const asTx = () => asTestRaw<Transaction>(db);
+
+const queuedSourceIds = async () =>
+  (
+    await db
+      .select({ sourceId: searchProjectionRepairQueue.sourceId })
+      .from(searchProjectionRepairQueue)
+      .orderBy(searchProjectionRepairQueue.sourceId)
+  ).map(({ sourceId }) => sourceId);
+
+const recordingRepairDeps = (
+  repaired: string[],
+): SearchProjectionRepairDeps => {
+  const record = async (sourceId: string): Promise<void> => {
+    repaired.push(sourceId);
+  };
+  return {
+    db: asTestRaw<SearchProjectionRepairDeps["db"]>(db),
+    repair: { contact: record, entity: record, workspace: record },
+  };
+};
+
+beforeAll(async () => {
+  client = await createTestPglite();
+  db = drizzle({ client });
+}, 300_000);
+
+afterAll(async () => {
+  await client.close();
+});
+
+beforeEach(async () => {
+  await db.execute(
+    sql.raw(
+      'TRUNCATE TABLE "organization", "search_projection_repair_queue" CASCADE',
+    ),
+  );
+  await db.insert(organization).values({
+    createdAt: SEED_AT,
+    id: ORGANIZATION_ID,
+    name: "Search index ownership",
+    slug: ORGANIZATION_ID,
+  });
+  await db.insert(workspaces).values({
+    createdAt: SEED_AT,
+    id: workspaceId,
+    lastActivityAt: SEED_AT,
+    name: "Duplicated matter",
+    organizationId: toSafeId<"organization">(ORGANIZATION_ID),
+    reference: "2026-0001",
+  });
+  await db.insert(entities).values(
+    duplicatedCopies.map((copy) => ({
+      createdAt: SEED_AT,
+      id: copy.entityId,
+      name: copy.label,
+      updatedAt: SEED_AT,
+      workspaceId,
+    })),
+  );
+});
+
+test("every copy is owned exactly once, by extraction or by a mark", () => {
+  const owned = {
+    [SEARCH_INDEX_OWNER.durableExtraction]: copiesOwnedBy(
+      SEARCH_INDEX_OWNER.durableExtraction,
+    ),
+    [SEARCH_INDEX_OWNER.searchMark]: copiesOwnedBy(
+      SEARCH_INDEX_OWNER.searchMark,
+    ),
+  };
+
+  // Both directions: no copy is left unowned, none is claimed twice, and
+  // neither owner is exercised by an empty fixture.
+  expect(
+    [
+      ...owned[SEARCH_INDEX_OWNER.durableExtraction],
+      ...owned[SEARCH_INDEX_OWNER.searchMark],
+    ].sort(),
+  ).toEqual(duplicatedCopies.map((copy) => copy.entityId).sort());
+  expect(owned[SEARCH_INDEX_OWNER.durableExtraction]).toEqual([entityId(10)]);
+  expect(owned[SEARCH_INDEX_OWNER.searchMark]).toEqual([
+    entityId(11),
+    entityId(12),
+    entityId(13),
+  ]);
+});
+
+test("the copies' marks share the fate of the duplicate transaction", async () => {
+  const marked = copiesOwnedBy(SEARCH_INDEX_OWNER.searchMark);
+
+  // bun-types declares `.rejects.toThrow` as void, so awaiting it trips
+  // type-aware lint; capture the rejection explicitly instead.
+  const rejection: unknown = await db
+    .transaction(async (tx) => {
+      await enqueueEntitySearchRepairs(asTestRaw<Transaction>(tx), marked);
+      throw new Error("duplicate failed after the copies were written");
+    })
+    .then(
+      () => null,
+      (error: unknown) => error,
+    );
+
+  expect(rejection).toBeInstanceOf(Error);
+  expect(await queuedSourceIds()).toEqual([]);
+
+  await db.transaction(async (tx) => {
+    await enqueueEntitySearchRepairs(asTestRaw<Transaction>(tx), marked);
+  });
+
+  expect(await queuedSourceIds()).toEqual([...marked].sort());
+});
+
+test("a drain rebuilds each marked copy once and never the extracted one", async () => {
+  const marked = copiesOwnedBy(SEARCH_INDEX_OWNER.searchMark);
+  await enqueueEntitySearchRepairs(asTx(), marked);
+
+  const repaired: string[] = [];
+  const outcome = await drainSearchProjectionRepairQueue({
+    deps: recordingRepairDeps(repaired),
+  });
+
+  expect(outcome).toEqual({ failed: 0, repaired: marked.length });
+  expect([...repaired].sort()).toEqual([...marked].sort());
+  for (const extracted of copiesOwnedBy(SEARCH_INDEX_OWNER.durableExtraction)) {
+    expect(repaired).not.toContain(extracted);
+  }
+
+  // A second drain finds nothing: one repair per copy, not one per pass.
+  expect(await queuedSourceIds()).toEqual([]);
+  expect(
+    await drainSearchProjectionRepairQueue({
+      deps: recordingRepairDeps(repaired),
+    }),
+  ).toEqual({ failed: 0, repaired: 0 });
+  expect(repaired).toHaveLength(marked.length);
+});


### PR DESCRIPTION
Matter duplication and entity copy flows indexed their copies only through a post-commit `processExtraction(...).catch(captureError)`. For documents that is repaired eventually (the extraction recovery scan re-creates lost runs), but everything routed through the helper's other branch — tasks, events, notes, folders, encrypted and non-extractable files, i.e. most of a duplicated matter — had no backstop: a crash between commit and the call left those copies permanently unindexed.

**Ownership discriminator** (`SEARCH_INDEX_OWNER` + `searchIndexOwnerForFields` in `process-extraction.ts`): each copy is owned either by durable extraction (the worker indexes after extracting) or by a search mark. `processExtraction` reads the same predicate for its own branch, so the handler-side split cannot drift from what extraction actually does. Mark-owned copies get `enqueueEntitySearchRepairs` INSIDE the copying transaction (rolls back with the copies; drained by the standing scheduler task), with the post-commit flush and `processExtraction` as acceleration only, and no copy is indexed twice. The split lives once in `copyEntities`, so `entities/duplicate`, `entities/copy-to-workspace`, and any future caller inherit it; `CopyEntitiesSuccessResult` now returns ids grouped by owner (the flat list was a duplicate projection; response shapes unchanged).

Also fixed in passing, same files: source field reads now carry the `orderBy id asc` + properties bound that `findExtractionFileField` documents as mandatory (an unordered read could pick a different extraction source for the copy than the source entity used), and the matter-duplicate entity-cap check moved before the write transaction — it previously returned a failure from inside the callback, committing the partial matter shell while answering 400 and deleting the copied objects the rows pointed at.

PGlite tests pin the ownership partition in both directions, in-tx rollback of marks, drain-once semantics, and per-handler mark/extraction routing. Two partial `process-extraction` module mocks now spread the real module.

Follow-ups noted, not taken here: `copyEntities` has three mid-loop `{ ok: false }` returns with the same commit-on-failure shape (separate focused PR), and writing the extraction run row inside the caller's transaction would require relaxing the deliberate insert-block policy on `document_processing_runs`, which deserves its own review.