### PR TITLE
feat(api): valkey scaling: facades, cluster-legal keys, outage degradation

### DIFF
--- a/.agents/skills/conventions-scale/SKILL.md
+++ b/.agents/skills/conventions-scale/SKILL.md
@@ -62,6 +62,46 @@ transactions.
 connector providers stay behind typed boundaries. Business logic must not
 depend on one provider's model names, pagination quirks, or retry semantics.
 
+## Valkey Usage Doctrine
+
+Valkey runs as a single node today. The code must already tolerate losing it
+and must already be legal on a cluster, so growing the deployment (managed
+Multi-AZ, then cluster mode) is a connection-module change, not an application
+rewrite. Two requirements, each with a named enforcement mechanism.
+
+**1. Valkey holds only ephemeral coordination.** Queue transport, pub/sub
+events, TTL'd counters and caches, short locks. Never a fact that exists
+nowhere else: every value must be reconstructible from PostgreSQL, object
+storage, or the request that produced it. A Valkey flush must degrade the
+system, never corrupt it, and every consumer must have a written degraded
+path (fail open, in-memory fallback, durable replay, or an explicit captured
+error).
+
+Enforced by: `no-restricted-imports` in `oxlint.config.ts` confines
+`@/api/lib/redis-client` to a named allowlist of coordination facades, so a
+new store cannot appear without review; and
+`apps/api/src/lib/redis-outage.test.ts` pins each facade's degraded behavior
+against a real client aimed at a closed port.
+
+**2. Every usage is cluster-legal.** Keys carry a `{hashtag}` naming the
+colocation unit; a multi-key command or Lua script may only touch keys that
+share one hashtag. No `KEYS`, no numbered databases, no `SELECT`. `SCAN` is
+per-node, so it may only ever be an optimization over a durable source of
+truth, never the only way to find something. Pub/sub carries no durability
+guarantee: a subscriber must tolerate lost, duplicated, and out-of-order
+messages, and reconcile from the database on reconnect.
+
+Enforced by: `apps/api/src/lib/redis-keys.ts` builds every non-queue key and
+brands the result, so a raw string cannot reach a key position; and the
+`require-coordination-key` oxlint rule rejects string literals in the key
+argument of a Valkey command outside that module.
+
+**Queue keys are the documented exception.** BullMQ owns its own key layout
+under a prefix, and changing that prefix strands every in-flight job. The
+prefix therefore flips only at the cluster migration itself, behind a queue
+drain. The decision and its drain step are recorded at the connection factory
+in `apps/api/src/lib/redis-client.ts`.
+
 ## Evidence Before Exceptions
 
 Do not keep a hand-maintained list of today's scale gaps in this skill; it

--- a/.ai/local-skills/conventions-scale/SKILL.md
+++ b/.ai/local-skills/conventions-scale/SKILL.md
@@ -62,6 +62,46 @@ transactions.
 connector providers stay behind typed boundaries. Business logic must not
 depend on one provider's model names, pagination quirks, or retry semantics.
 
+## Valkey Usage Doctrine
+
+Valkey runs as a single node today. The code must already tolerate losing it
+and must already be legal on a cluster, so growing the deployment (managed
+Multi-AZ, then cluster mode) is a connection-module change, not an application
+rewrite. Two requirements, each with a named enforcement mechanism.
+
+**1. Valkey holds only ephemeral coordination.** Queue transport, pub/sub
+events, TTL'd counters and caches, short locks. Never a fact that exists
+nowhere else: every value must be reconstructible from PostgreSQL, object
+storage, or the request that produced it. A Valkey flush must degrade the
+system, never corrupt it, and every consumer must have a written degraded
+path (fail open, in-memory fallback, durable replay, or an explicit captured
+error).
+
+Enforced by: `no-restricted-imports` in `oxlint.config.ts` confines
+`@/api/lib/redis-client` to a named allowlist of coordination facades, so a
+new store cannot appear without review; and
+`apps/api/src/lib/redis-outage.test.ts` pins each facade's degraded behavior
+against a real client aimed at a closed port.
+
+**2. Every usage is cluster-legal.** Keys carry a `{hashtag}` naming the
+colocation unit; a multi-key command or Lua script may only touch keys that
+share one hashtag. No `KEYS`, no numbered databases, no `SELECT`. `SCAN` is
+per-node, so it may only ever be an optimization over a durable source of
+truth, never the only way to find something. Pub/sub carries no durability
+guarantee: a subscriber must tolerate lost, duplicated, and out-of-order
+messages, and reconcile from the database on reconnect.
+
+Enforced by: `apps/api/src/lib/redis-keys.ts` builds every non-queue key and
+brands the result, so a raw string cannot reach a key position; and the
+`require-coordination-key` oxlint rule rejects string literals in the key
+argument of a Valkey command outside that module.
+
+**Queue keys are the documented exception.** BullMQ owns its own key layout
+under a prefix, and changing that prefix strands every in-flight job. The
+prefix therefore flips only at the cluster migration itself, behind a queue
+drain. The decision and its drain step are recorded at the connection factory
+in `apps/api/src/lib/redis-client.ts`.
+
 ## Evidence Before Exceptions
 
 Do not keep a hand-maintained list of today's scale gaps in this skill; it

--- a/.claude/commands/conventions-scale.md
+++ b/.claude/commands/conventions-scale.md
@@ -57,6 +57,46 @@ transactions.
 connector providers stay behind typed boundaries. Business logic must not
 depend on one provider's model names, pagination quirks, or retry semantics.
 
+## Valkey Usage Doctrine
+
+Valkey runs as a single node today. The code must already tolerate losing it
+and must already be legal on a cluster, so growing the deployment (managed
+Multi-AZ, then cluster mode) is a connection-module change, not an application
+rewrite. Two requirements, each with a named enforcement mechanism.
+
+**1. Valkey holds only ephemeral coordination.** Queue transport, pub/sub
+events, TTL'd counters and caches, short locks. Never a fact that exists
+nowhere else: every value must be reconstructible from PostgreSQL, object
+storage, or the request that produced it. A Valkey flush must degrade the
+system, never corrupt it, and every consumer must have a written degraded
+path (fail open, in-memory fallback, durable replay, or an explicit captured
+error).
+
+Enforced by: `no-restricted-imports` in `oxlint.config.ts` confines
+`@/api/lib/redis-client` to a named allowlist of coordination facades, so a
+new store cannot appear without review; and
+`apps/api/src/lib/redis-outage.test.ts` pins each facade's degraded behavior
+against a real client aimed at a closed port.
+
+**2. Every usage is cluster-legal.** Keys carry a `{hashtag}` naming the
+colocation unit; a multi-key command or Lua script may only touch keys that
+share one hashtag. No `KEYS`, no numbered databases, no `SELECT`. `SCAN` is
+per-node, so it may only ever be an optimization over a durable source of
+truth, never the only way to find something. Pub/sub carries no durability
+guarantee: a subscriber must tolerate lost, duplicated, and out-of-order
+messages, and reconcile from the database on reconnect.
+
+Enforced by: `apps/api/src/lib/redis-keys.ts` builds every non-queue key and
+brands the result, so a raw string cannot reach a key position; and the
+`require-coordination-key` oxlint rule rejects string literals in the key
+argument of a Valkey command outside that module.
+
+**Queue keys are the documented exception.** BullMQ owns its own key layout
+under a prefix, and changing that prefix strands every in-flight job. The
+prefix therefore flips only at the cluster migration itself, behind a queue
+drain. The decision and its drain step are recorded at the connection factory
+in `apps/api/src/lib/redis-client.ts`.
+
 ## Evidence Before Exceptions
 
 Do not keep a hand-maintained list of today's scale gaps in this skill; it

--- a/.oxlint-plugins/__fixtures__/confine-redis-client.fixture.ts
+++ b/.oxlint-plugins/__fixtures__/confine-redis-client.fixture.ts
@@ -1,0 +1,18 @@
+// Passive regression fixture for `confine-redis-client/confine-redis-client`.
+//
+// This file is deliberately absent from the rule's `allowedFiles` allowlist in
+// oxlint.config.ts, so every reference to the Valkey connection module here
+// must be rejected.
+
+// oxlint-disable-next-line confine-redis-client/confine-redis-client -- fixture proves a static import outside the allowlist is rejected
+import { createRedisClient } from "@/api/lib/redis-client";
+// oxlint-disable-next-line confine-redis-client/confine-redis-client -- fixture proves a type-only import still opens the module surface and is rejected
+import type { createBullMqConnection } from "@/api/lib/redis-client";
+
+const loadConnection = async () =>
+  // oxlint-disable-next-line confine-redis-client/confine-redis-client -- fixture proves a dynamic import is rejected
+  await import("@/api/lib/redis-client");
+
+void loadConnection;
+void createRedisClient;
+type _Connection = typeof createBullMqConnection;

--- a/.oxlint-plugins/__fixtures__/require-coordination-key.fixture.ts
+++ b/.oxlint-plugins/__fixtures__/require-coordination-key.fixture.ts
@@ -1,0 +1,62 @@
+// Passive regression fixture for
+// `require-coordination-key/require-coordination-key`.
+
+import { coordinationKey } from "@/api/lib/redis-keys";
+
+// Synchronous stub: the rule inspects the call shape, not the client.
+const redis = {
+  send: (_command: string, _args: string[]): unknown => null,
+};
+
+const SCRIPT = "return 1";
+const tenant = "ws-1";
+
+// MUST flag: a single-key command's first argument is a key position.
+// oxlint-disable-next-line require-coordination-key/require-coordination-key -- fixture: GET takes a key first
+export const read = () => redis.send("GET", ["workflow:ws-1:total"]);
+
+// MUST flag: a template literal is just as unhashtagged as a plain string.
+export const expire = () =>
+  redis.send("EXPIRE", [
+    // oxlint-disable-next-line require-coordination-key/require-coordination-key -- fixture: interpolated keys bypass the builder too
+    `workflow:${tenant}:running`,
+    "600",
+  ]);
+
+// MUST flag: every argument of a variadic key list is a key position, and a
+// multi-key DEL is exactly what a cluster rejects across slots.
+export const clear = () =>
+  redis.send("DEL", [
+    // oxlint-disable-next-line require-coordination-key/require-coordination-key -- fixture: DEL's first key
+    "workflow:ws-1:running",
+    // oxlint-disable-next-line require-coordination-key/require-coordination-key -- fixture: DEL's second key
+    "workflow:ws-1:total",
+  ]);
+
+// MUST flag: a script declares its key count, and each declared key counts.
+export const script = () =>
+  redis.send("EVAL", [
+    SCRIPT,
+    "2",
+    // oxlint-disable-next-line require-coordination-key/require-coordination-key -- fixture: KEYS[1]
+    "workflow:ws-1:request-id",
+    // oxlint-disable-next-line require-coordination-key/require-coordination-key -- fixture: KEYS[2]
+    "workflow:ws-1:running",
+    "argv-is-not-a-key",
+  ]);
+
+// Allowed: keys from the builder, and literals that sit in value or argument
+// positions rather than key positions.
+export const write = () =>
+  redis.send("SET", [
+    coordinationKey({ scope: "workflow-run", slot: tenant, suffix: "running" }),
+    "value-literal",
+    "EX",
+    "600",
+  ]);
+
+// Allowed: cursor-based and keyless commands carry no key position.
+export const scan = () =>
+  redis.send("SCAN", ["0", "MATCH", "workflow-run:{*}:running"]);
+
+export const ping = () => redis.send("PING", []);

--- a/.oxlint-plugins/confine-redis-client.ts
+++ b/.oxlint-plugins/confine-redis-client.ts
@@ -1,0 +1,89 @@
+// Confine the Valkey/Redis connection module to the coordination facades.
+//
+// Valkey holds only ephemeral coordination (queue transport, pub/sub, TTL'd
+// counters, short locks), and every consumer owes a written degraded path for
+// the outage case. Both properties are reviewable only while the set of
+// modules that can open a connection stays small and named, so the allowlist
+// lives in `oxlint.config.ts` with a reason per entry.
+//
+// This is a dedicated rule rather than a `no-restricted-imports` path because
+// an oxlint override REPLACES a rule's whole config instead of merging it: an
+// `apps/api/src/**` entry would silently drop the handler-scoped DB import
+// restrictions that a later override installs for the same files.
+
+import { eslintCompatPlugin } from "@oxlint/plugins";
+
+import { filenameForContext, isAstNode, isStringLiteral } from "./utils.ts";
+
+const CONNECTION_MODULE = "@/api/lib/redis-client";
+const CONNECTION_MODULE_SUFFIX = "/lib/redis-client";
+
+const isConnectionModule = (source: unknown): boolean =>
+  typeof source === "string" &&
+  (source === CONNECTION_MODULE ||
+    source.endsWith(CONNECTION_MODULE_SUFFIX) ||
+    source.endsWith(`${CONNECTION_MODULE_SUFFIX}.ts`));
+
+const configuredAllowedFiles = (context: {
+  options?: readonly unknown[];
+}): readonly string[] => {
+  const options = context.options?.[0];
+  if (typeof options !== "object" || options === null) {
+    return [];
+  }
+  const allowedFiles = Reflect.get(options, "allowedFiles");
+  return Array.isArray(allowedFiles)
+    ? allowedFiles.filter((entry) => typeof entry === "string")
+    : [];
+};
+
+export default eslintCompatPlugin({
+  meta: { name: "confine-redis-client" },
+  rules: {
+    "confine-redis-client": {
+      meta: {
+        type: "problem",
+        messages: {
+          unconfinedImport:
+            "Only the allowlisted coordination facades may import the Valkey connection module. " +
+            "Go through the facade that owns this concern, or add this file to the allowlist in oxlint.config.ts with a reason. " +
+            "Valkey may hold only ephemeral coordination, and every consumer needs a degraded path for an outage.",
+        },
+        schema: [
+          {
+            type: "object",
+            properties: {
+              allowedFiles: { type: "array", items: { type: "string" } },
+            },
+            additionalProperties: false,
+          },
+        ],
+      },
+      createOnce(context) {
+        return {
+          before() {
+            const filename = filenameForContext(context);
+            return !configuredAllowedFiles(context).some((allowed) =>
+              filename.endsWith(allowed),
+            );
+          },
+          ImportDeclaration(node) {
+            if (!isConnectionModule(node.source?.value)) {
+              return;
+            }
+            context.report({ node, messageId: "unconfinedImport" });
+          },
+          ImportExpression(node) {
+            if (!isAstNode(node.source) || !isStringLiteral(node.source)) {
+              return;
+            }
+            if (!isConnectionModule(node.source.value)) {
+              return;
+            }
+            context.report({ node, messageId: "unconfinedImport" });
+          },
+        };
+      },
+    },
+  },
+});

--- a/.oxlint-plugins/require-coordination-key.ts
+++ b/.oxlint-plugins/require-coordination-key.ts
@@ -13,7 +13,8 @@
 
 import { eslintCompatPlugin } from "@oxlint/plugins";
 
-import { filenameForContext, isStringLiteral } from "./utils.ts";
+import type { AstNode } from "./utils.ts";
+import { filenameForContext, isAstNode, isStringLiteral } from "./utils.ts";
 
 // Commands whose first argument is a key, and nothing after it is.
 const SINGLE_KEY_COMMANDS = new Set([
@@ -71,10 +72,10 @@ const KEY_BUILDER_MODULE = "apps/api/src/lib/redis-keys.ts";
 const commandName = (node: unknown): string | null =>
   isStringLiteral(node) ? node.value.toUpperCase() : null;
 
-const isTemplateLiteral = (node: unknown): boolean =>
-  typeof node === "object" &&
-  node !== null &&
-  Reflect.get(node, "type") === "TemplateLiteral";
+const isTemplateLiteral = (
+  node: unknown,
+): node is AstNode & { type: "TemplateLiteral" } =>
+  isAstNode(node) && node.type === "TemplateLiteral";
 
 // How many leading elements of the argument array are keys. Returns 0 for a
 // command this rule does not police.

--- a/.oxlint-plugins/require-coordination-key.ts
+++ b/.oxlint-plugins/require-coordination-key.ts
@@ -1,0 +1,164 @@
+// Keep Valkey key positions on the shared key builder.
+//
+// `lib/redis-keys.ts` is what makes a key cluster-legal: it puts a `{hashtag}`
+// on the colocation unit so a multi-key command or Lua script lands on one
+// slot, and it forces each scope to declare an expiry. A hand-written key
+// string bypasses both, and the failure only shows up on a cluster, long after
+// review. So a literal may not appear in the key position of a Valkey command.
+//
+// Scope: the `client.send("<COMMAND>", [...])` form, which is how every Lua
+// script and multi-key command in this codebase is issued. Typed client
+// methods (`redis.get`, `redis.set`) are covered instead by their signatures
+// taking `CoordinationKey`, which a raw string does not satisfy.
+
+import { eslintCompatPlugin } from "@oxlint/plugins";
+
+import { filenameForContext, isStringLiteral } from "./utils.ts";
+
+// Commands whose first argument is a key, and nothing after it is.
+const SINGLE_KEY_COMMANDS = new Set([
+  "DECR",
+  "DECRBY",
+  "EXPIRE",
+  "EXPIREAT",
+  "GET",
+  "GETDEL",
+  "GETEX",
+  "HDEL",
+  "HGET",
+  "HGETALL",
+  "HINCRBY",
+  "HSET",
+  "INCR",
+  "INCRBY",
+  "LPUSH",
+  "LRANGE",
+  "PERSIST",
+  "PEXPIRE",
+  "PTTL",
+  "RPUSH",
+  "SADD",
+  "SCARD",
+  "SET",
+  "SETEX",
+  "SETNX",
+  "SISMEMBER",
+  "SMEMBERS",
+  "SREM",
+  "TTL",
+  "ZADD",
+  "ZRANGE",
+  "ZREM",
+]);
+
+// Commands taking a variadic key list, so every argument is a key.
+const KEY_LIST_COMMANDS = new Set([
+  "DEL",
+  "EXISTS",
+  "MGET",
+  "TOUCH",
+  "UNLINK",
+  "WATCH",
+]);
+
+// Scripting: [script, numkeys, ...keys, ...argv].
+const SCRIPT_COMMANDS = new Set(["EVAL", "EVALSHA", "FCALL", "FCALL_RO"]);
+const SCRIPT_NUMKEYS_INDEX = 1;
+const SCRIPT_FIRST_KEY_INDEX = 2;
+
+const KEY_BUILDER_MODULE = "apps/api/src/lib/redis-keys.ts";
+
+const commandName = (node: unknown): string | null =>
+  isStringLiteral(node) ? node.value.toUpperCase() : null;
+
+const isTemplateLiteral = (node: unknown): boolean =>
+  typeof node === "object" &&
+  node !== null &&
+  Reflect.get(node, "type") === "TemplateLiteral";
+
+// How many leading elements of the argument array are keys. Returns 0 for a
+// command this rule does not police.
+const keyArgumentCount = (command: string, argumentCount: number): number => {
+  if (SINGLE_KEY_COMMANDS.has(command)) {
+    return Math.min(1, argumentCount);
+  }
+  if (KEY_LIST_COMMANDS.has(command)) {
+    return argumentCount;
+  }
+  return 0;
+};
+
+export default eslintCompatPlugin({
+  meta: { name: "require-coordination-key" },
+  rules: {
+    "require-coordination-key": {
+      meta: {
+        type: "problem",
+        messages: {
+          literalKey:
+            "Build Valkey keys with coordinationKey() from '@/api/lib/redis-keys' instead of a literal. " +
+            "The builder places the {hashtag} that keeps a multi-key command on one cluster slot and forces the scope to declare an expiry.",
+        },
+        schema: [],
+      },
+      createOnce(context) {
+        const reportLiteralKeys = (
+          elements: readonly unknown[],
+          from: number,
+          count: number,
+        ): void => {
+          for (const element of elements.slice(from, from + count)) {
+            if (isStringLiteral(element) || isTemplateLiteral(element)) {
+              context.report({ node: element, messageId: "literalKey" });
+            }
+          }
+        };
+
+        return {
+          before() {
+            return !filenameForContext(context).endsWith(KEY_BUILDER_MODULE);
+          },
+          CallExpression(node) {
+            const callee = node.callee;
+            if (
+              callee?.type !== "MemberExpression" ||
+              callee.computed ||
+              callee.property?.name !== "send"
+            ) {
+              return;
+            }
+            const [commandNode, argumentsNode] = node.arguments ?? [];
+            const command = commandName(commandNode);
+            if (command === null || argumentsNode?.type !== "ArrayExpression") {
+              return;
+            }
+            const elements = argumentsNode.elements ?? [];
+
+            if (SCRIPT_COMMANDS.has(command)) {
+              const declared = elements[SCRIPT_NUMKEYS_INDEX];
+              // A non-literal numkeys hides how many keys follow; police the
+              // first key position rather than trusting the call site.
+              const numberOfKeys = isStringLiteral(declared)
+                ? Number(declared.value)
+                : 1;
+              reportLiteralKeys(
+                elements,
+                SCRIPT_FIRST_KEY_INDEX,
+                Number.isSafeInteger(numberOfKeys) && numberOfKeys > 0
+                  ? numberOfKeys
+                  : 1,
+              );
+              return;
+            }
+
+            reportLiteralKeys(
+              elements,
+              0,
+              keyArgumentCount(command, elements.length),
+            );
+          },
+        };
+      },
+    },
+  },
+});

--- a/apps/api/src/handlers/feedback/intake-guards.ts
+++ b/apps/api/src/handlers/feedback/intake-guards.ts
@@ -22,6 +22,7 @@ import { errorTag } from "@/api/lib/errors/utils";
 import { logger } from "@/api/lib/observability/logger";
 import { withCommandTimeout } from "@/api/lib/rate-limit/redis-command-timeout";
 import { createRedisClient } from "@/api/lib/redis-client";
+import { coordinationKey, type CoordinationKey } from "@/api/lib/redis-keys";
 
 type RedisLike = {
   send: (command: string, args: string[]) => Promise<unknown>;
@@ -29,7 +30,19 @@ type RedisLike = {
 
 type CounterEntry = { count: number; expiresAt: number };
 
-const REDIS_KEY_PREFIX = "feedback:intake:";
+// The limited subject (IP, organization, content digest) is the colocation
+// unit; the bucket only separates the windows that ride on it. Each key is
+// read and written alone, so slotting by subject spreads the keyspace.
+const counterKey = ({ bucket, key }: { bucket: string; key: string }) =>
+  coordinationKey({
+    scope: "feedback-intake",
+    slot: key,
+    suffix: `counter:${bucket}`,
+  });
+
+const dedupKey = (key: string) =>
+  coordinationKey({ scope: "feedback-intake", slot: key, suffix: "dedup" });
+
 const REDIS_COMMAND_TIMEOUT_MS = 500;
 const FALLBACK_CLEANUP_THRESHOLD = 10_000;
 const FALLBACK_CLEANUP_INTERVAL_MS = 60_000;
@@ -115,7 +128,7 @@ export const createFeedbackIntakeGuards = ({
     try {
       const count = await evalCounter({
         commandTimeoutMs,
-        key: `${REDIS_KEY_PREFIX}${scoped}`,
+        key: counterKey({ bucket, key }),
         redis: getRedis(),
         windowMs,
       });
@@ -140,7 +153,7 @@ export const createFeedbackIntakeGuards = ({
     try {
       const reply = await withCommandTimeout({
         command: getRedis().send("SET", [
-          `${REDIS_KEY_PREFIX}dedup:${key}`,
+          dedupKey(key),
           "1",
           "NX",
           "PX",
@@ -168,7 +181,7 @@ export const createFeedbackIntakeGuards = ({
   }) => {
     try {
       await withCommandTimeout({
-        command: getRedis().send("DEL", [`${REDIS_KEY_PREFIX}dedup:${key}`]),
+        command: getRedis().send("DEL", [dedupKey(key)]),
         commandTimeoutMs,
         label: "feedback-intake-redis-command",
       });
@@ -188,7 +201,7 @@ export const createFeedbackIntakeGuards = ({
         command: getRedis().send("EVAL", [
           RELEASE_COUNTER_SCRIPT,
           "1",
-          `${REDIS_KEY_PREFIX}${scoped}`,
+          counterKey({ bucket, key }),
         ]),
         commandTimeoutMs,
         label: "feedback-intake-redis-command",
@@ -213,7 +226,7 @@ const evalCounter = async ({
   windowMs,
 }: {
   commandTimeoutMs: number;
-  key: string;
+  key: CoordinationKey;
   redis: RedisLike;
   windowMs: number;
 }): Promise<number> => {

--- a/apps/api/src/lib/document-processing-queue.ts
+++ b/apps/api/src/lib/document-processing-queue.ts
@@ -64,6 +64,7 @@ import {
   createBullMqConnection,
   createRedisClient,
 } from "@/api/lib/redis-client";
+import { unboundedCoordinationKey } from "@/api/lib/redis-keys";
 import { broadcastWorkspaceResourceUpdated } from "@/api/lib/resource-realtime";
 import {
   presignDownloadUrl,
@@ -97,7 +98,14 @@ const SEARCH_INDEX_REPLAY_BATCH_SIZE = SEARCH_INDEX_REPLAY_CONCURRENCY * 2;
 const SEARCH_INDEX_ATTEMPT_TIMEOUT_MS = 30_000;
 const SEARCH_INDEX_REPLAY_STATE_TRANSITION_TIMEOUT_MS = 5000;
 const REPAIR_SETTLE_DELAY_MS = 5 * 60 * 1000;
-const REPAIR_SCAN_CURSOR_KEY = "document-processing:repair-scan-cursor:v1";
+// Single compare-and-set slot for the repair sweep's resume position, so the
+// sweep is its own colocation unit. Declared unbounded in redis-keys.ts: the
+// CAS script below deliberately writes it without an expiry.
+const REPAIR_SCAN_CURSOR_KEY = unboundedCoordinationKey({
+  scope: "ocr-repair-cursor",
+  slot: "repair-scan",
+  suffix: "v1",
+});
 const REPAIR_SCAN_CURSOR_COMMAND_TIMEOUT_MS = 2000;
 const QUEUE_HANDOFF_TIMEOUT_MS = 2000;
 const REPAIR_SCAN_CURSOR_CAS_SCRIPT = `

--- a/apps/api/src/lib/document-processing-readiness.test.ts
+++ b/apps/api/src/lib/document-processing-readiness.test.ts
@@ -61,7 +61,7 @@ describe("document OCR worker readiness", () => {
     await refreshDocumentOcrWorkerReadiness(writeLease);
 
     expect(writeLease).toHaveBeenCalledWith(
-      "document-processing:ocr-worker-ready:v1",
+      "ocr-readiness:{ocr-worker}:v1",
       "ready",
       90,
     );

--- a/apps/api/src/lib/document-processing-readiness.ts
+++ b/apps/api/src/lib/document-processing-readiness.ts
@@ -3,10 +3,19 @@ import { Result } from "better-result";
 import { captureError } from "@/api/lib/analytics/capture";
 import { detached } from "@/api/lib/detached";
 import { createRedisClient } from "@/api/lib/redis-client";
+import {
+  coordinationKey,
+  coordinationSetArguments,
+  type CoordinationKey,
+} from "@/api/lib/redis-keys";
 import { withTimeout } from "@/api/lib/with-timeout";
 
-const DOCUMENT_OCR_WORKER_READINESS_KEY =
-  "document-processing:ocr-worker-ready:v1";
+// A single process-wide lease, so the worker role is its own colocation unit.
+const DOCUMENT_OCR_WORKER_READINESS_KEY = coordinationKey({
+  scope: "ocr-readiness",
+  slot: "ocr-worker",
+  suffix: "v1",
+});
 const DOCUMENT_OCR_WORKER_READINESS_VALUE = "ready";
 const DOCUMENT_OCR_WORKER_READINESS_TTL_SECONDS = 90;
 const DOCUMENT_OCR_WORKER_HEARTBEAT_INTERVAL_MS = 30_000;
@@ -52,7 +61,7 @@ export const isDocumentOcrWorkerAvailable = async (): Promise<boolean> => {
 
 export const refreshDocumentOcrWorkerReadiness = async (
   writeLease: (
-    key: string,
+    key: CoordinationKey,
     value: string,
     ttlSeconds: number,
   ) => Promise<unknown>,
@@ -77,7 +86,14 @@ export const startDocumentOcrWorkerReadiness = () => {
   let writeInFlight: Promise<unknown> | null = null;
   const refresh = async (): Promise<void> => {
     await refreshDocumentOcrWorkerReadiness(async (key, value, ttlSeconds) => {
-      const write = client.send("SET", [key, value, "EX", String(ttlSeconds)]);
+      const write = client.send(
+        "SET",
+        coordinationSetArguments({
+          key,
+          value,
+          ttl: { unit: "seconds", value: ttlSeconds },
+        }),
+      );
       writeInFlight = write;
       const markSettled = (): void => {
         if (writeInFlight === write) {

--- a/apps/api/src/lib/rate-limit/auth-storage.test.ts
+++ b/apps/api/src/lib/rate-limit/auth-storage.test.ts
@@ -129,7 +129,7 @@ describe("auth rate-limit storage", () => {
     redisDown = false;
 
     expect(await storage.get("ip:1.2.3.4")).toEqual(value(6, 2000));
-    expect(redisStore.get("auth:ratelimit:ip:1.2.3.4")).toBe(
+    expect(redisStore.get("auth-ratelimit:{ip:1.2.3.4}")).toBe(
       JSON.stringify(value(6, 2000)),
     );
   });

--- a/apps/api/src/lib/rate-limit/auth-storage.ts
+++ b/apps/api/src/lib/rate-limit/auth-storage.ts
@@ -17,7 +17,7 @@ import {
   withCommandTimeout,
 } from "@/api/lib/rate-limit/redis-command-timeout";
 import { createRedisClient } from "@/api/lib/redis-client";
-import { coordinationKey } from "@/api/lib/redis-keys";
+import { coordinationKey, type CoordinationKey } from "@/api/lib/redis-keys";
 
 type RateLimitValue = {
   key: string;
@@ -30,10 +30,14 @@ type AuthRateLimitStorage = {
   set: (key: string, value: RateLimitValue) => Promise<void>;
 };
 
+// The typed client methods are outside the `send(command, args)` shape the
+// `require-coordination-key` lint rule inspects, so the key position is held by
+// the type instead: a hand-written string does not satisfy `CoordinationKey`.
+// `expiryMode` is likewise non-optional, which is this path's TTL discipline.
 type AuthRateLimitRedisClient = {
-  get: (key: string) => Promise<string | null>;
+  get: (key: CoordinationKey) => Promise<string | null>;
   set: (
-    key: string,
+    key: CoordinationKey,
     value: string,
     expiryMode: "PX",
     ttlMs: number,

--- a/apps/api/src/lib/rate-limit/auth-storage.ts
+++ b/apps/api/src/lib/rate-limit/auth-storage.ts
@@ -17,6 +17,7 @@ import {
   withCommandTimeout,
 } from "@/api/lib/rate-limit/redis-command-timeout";
 import { createRedisClient } from "@/api/lib/redis-client";
+import { coordinationKey } from "@/api/lib/redis-keys";
 
 type RateLimitValue = {
   key: string;
@@ -49,7 +50,6 @@ type AuthRateLimitStorageOptions = {
   commandTimer?: CommandTimer;
 };
 
-const REDIS_KEY_PREFIX = "auth:ratelimit:";
 const FALLBACK_CLEANUP_INTERVAL_MS = 60_000;
 /**
  * Bound every Redis command so a slow or unreachable Redis cannot stall
@@ -62,6 +62,11 @@ const DEFAULT_COMMAND_TIMER: CommandTimer = {
   set: (callback, delayMs) => setTimeout(callback, delayMs),
   clear: (timeoutId) => clearTimeout(timeoutId),
 };
+
+// better-auth's key already identifies one limited client, so it is the
+// colocation unit; each key is read and written alone.
+const authRateLimitKey = (key: string) =>
+  coordinationKey({ scope: "auth-ratelimit", slot: key });
 
 const isRateLimitValue = (value: unknown): value is RateLimitValue =>
   typeof value === "object" &&
@@ -127,7 +132,7 @@ export const createAuthRateLimitStorage = (
   const writeRedis = async (key: string, value: RateLimitValue) => {
     await withCommandTimeout({
       command: redis.set(
-        `${REDIS_KEY_PREFIX}${key}`,
+        authRateLimitKey(key),
         JSON.stringify(value),
         "PX",
         ttlMs,
@@ -143,7 +148,7 @@ export const createAuthRateLimitStorage = (
       try {
         const fallbackValue = readFallback(key);
         const raw = await withCommandTimeout({
-          command: redis.get(`${REDIS_KEY_PREFIX}${key}`),
+          command: redis.get(authRateLimitKey(key)),
           commandTimeoutMs: COMMAND_TIMEOUT_MS,
           label: "auth-rate-limit-redis-command",
           scheduleTimeout,

--- a/apps/api/src/lib/rate-limit/rate-limit.test.ts
+++ b/apps/api/src/lib/rate-limit/rate-limit.test.ts
@@ -294,7 +294,7 @@ describe("RedisRateLimitContext", () => {
     expect((await context.increment(healthyRequest)).count).toBe(1);
     await context.decrement(healthyRequest);
 
-    expect(decrementedKeys).toEqual(["api:ratelimit:v2:api:healthy"]);
+    expect(decrementedKeys).toEqual(["api-ratelimit:{api:healthy}"]);
     context.kill();
   });
 

--- a/apps/api/src/lib/rate-limit/redis-context.ts
+++ b/apps/api/src/lib/rate-limit/redis-context.ts
@@ -14,8 +14,8 @@ import {
   withCommandTimeout,
 } from "@/api/lib/rate-limit/redis-command-timeout";
 import { createRedisClient } from "@/api/lib/redis-client";
+import { coordinationKey, type CoordinationKey } from "@/api/lib/redis-keys";
 
-const REDIS_KEY_PREFIX = "api:ratelimit:v2:";
 const REQUEST_KEY_SEPARATOR = "\u001f";
 const REDIS_COMMAND_TIMEOUT_MS = 500;
 const REFUND_PROVENANCE_CLEANUP_INTERVAL_MS = 60_000;
@@ -391,8 +391,11 @@ export const createRedisRateLimit = ({
   generator: requestScopedGenerator(scope, counterKeyGenerator),
 });
 
-const redisRateLimitKey = (counterKey: string): string =>
-  `${REDIS_KEY_PREFIX}${counterKey}`;
+// One key per counter, read and written alone, so the counter itself is the
+// colocation unit: the keyspace spreads across the ring instead of piling
+// every limiter onto one node.
+const redisRateLimitKey = (counterKey: string): CoordinationKey =>
+  coordinationKey({ scope: "api-ratelimit", slot: counterKey });
 
 const parseIncrementReply = (
   reply: unknown,

--- a/apps/api/src/lib/redis-client.ts
+++ b/apps/api/src/lib/redis-client.ts
@@ -132,6 +132,21 @@ const withColdStartConnectRetries = (
  * RedisClient. BullMQ's adapter assigns onconnect/onclose on the raw
  * client, so a wrapped connection must own its raw client — never share
  * one with code that uses the client directly.
+ *
+ * Queue keys deliberately keep BullMQ's default `bull:` prefix, which carries
+ * no hashtag and is therefore not cluster-legal. Every other key goes through
+ * `redis-keys.ts` and already is (see `/conventions-scale`); the prefix is the
+ * one documented exception, because a queue's keys ARE its jobs. Changing the
+ * prefix mid-flight does not migrate them: the workers would start reading an
+ * empty namespace and every queued, delayed, and retrying job under the old
+ * prefix would be stranded with nothing to replay it. Deploying the change now
+ * would therefore lose work silently, which no key-naming improvement is worth.
+ *
+ * The prefix flips at the cluster migration itself, as part of that cutover:
+ * stop producers, let every queue drain to empty (`getJobCounts` at zero for
+ * waiting/active/delayed/paused across all queues), then deploy the connection
+ * change with `prefix: "{stella}"` set here. Until that cutover, do not
+ * introduce a prefix, and do not add unhashtagged keys anywhere else.
  */
 export const createBullMqConnection = (
   overrides?: RedisOptions,

--- a/apps/api/src/lib/redis-keys.test.ts
+++ b/apps/api/src/lib/redis-keys.test.ts
@@ -9,7 +9,13 @@ import {
   type CoordinationScope,
 } from "@/api/lib/redis-keys";
 
-const SCOPES = Object.keys(COORDINATION_KEY_EXPIRY);
+const isCoordinationScope = (value: string): value is CoordinationScope =>
+  value in COORDINATION_KEY_EXPIRY;
+
+const SCOPES = Object.keys(COORDINATION_KEY_EXPIRY).filter(isCoordinationScope);
+
+/** Widen a built key so it can be compared against an expected literal. */
+const text = (key: string): string => key;
 
 const HASHTAG = /\{(?<slot>[^{}]*)\}/u;
 
@@ -29,12 +35,14 @@ const buildFor = (scope: CoordinationScope, slot: string, suffix?: string) =>
 
 describe("coordination key layout", () => {
   test("every declared scope builds a scope-prefixed, single-hashtag key", () => {
+    // The guard above must not have dropped a scope on the way in.
+    expect(SCOPES).toHaveLength(Object.keys(COORDINATION_KEY_EXPIRY).length);
     const built = new Set<string>();
     for (const scope of SCOPES) {
       const key = buildFor(scope, "slot-a", "field");
       built.add(scope);
       expect(key.startsWith(`${scope}:`)).toBe(true);
-      expect(key).toBe(`${scope}:{slot-a}:field`);
+      expect(text(key)).toBe(`${scope}:{slot-a}:field`);
       // Exactly one hashtag: a second pair would leave the cluster routing on
       // the first one while the reader assumes the last.
       expect(occurrences(key, "{")).toBe(1);
@@ -157,7 +165,7 @@ describe("scan globs", () => {
       slot: "*",
       suffix: "running",
     });
-    expect(pattern).toBe("workflow-run:{*}:running");
+    expect(text(pattern)).toBe("workflow-run:{*}:running");
 
     const lock = coordinationKey({
       scope: "workflow-run",

--- a/apps/api/src/lib/redis-keys.test.ts
+++ b/apps/api/src/lib/redis-keys.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  COORDINATION_KEY_EXPIRY,
+  coordinationExpireArguments,
+  coordinationKey,
+  coordinationSetArguments,
+  unboundedCoordinationKey,
+  type CoordinationScope,
+} from "@/api/lib/redis-keys";
+
+const SCOPES = Object.keys(COORDINATION_KEY_EXPIRY);
+
+const HASHTAG = /\{(?<slot>[^{}]*)\}/u;
+
+const hashtagOf = (key: string): string => {
+  const match = HASHTAG.exec(key);
+  expect(match?.groups?.["slot"]).toBeDefined();
+  return match?.groups?.["slot"] ?? "";
+};
+
+const occurrences = (haystack: string, needle: string): number =>
+  haystack.split(needle).length - 1;
+
+const buildFor = (scope: CoordinationScope, slot: string, suffix?: string) =>
+  COORDINATION_KEY_EXPIRY[scope] === "unbounded"
+    ? unboundedCoordinationKey({ scope, slot, suffix })
+    : coordinationKey({ scope, slot, suffix });
+
+describe("coordination key layout", () => {
+  test("every declared scope builds a scope-prefixed, single-hashtag key", () => {
+    const built = new Set<string>();
+    for (const scope of SCOPES) {
+      const key = buildFor(scope, "slot-a", "field");
+      built.add(scope);
+      expect(key.startsWith(`${scope}:`)).toBe(true);
+      expect(key).toBe(`${scope}:{slot-a}:field`);
+      // Exactly one hashtag: a second pair would leave the cluster routing on
+      // the first one while the reader assumes the last.
+      expect(occurrences(key, "{")).toBe(1);
+      expect(occurrences(key, "}")).toBe(1);
+    }
+    // Declared set equals exercised set, in both directions.
+    expect([...built].sort()).toEqual([...SCOPES].sort());
+  });
+
+  test("keys sharing a slot colocate and keys with distinct slots do not", () => {
+    const running = coordinationKey({
+      scope: "workflow-run",
+      slot: "ws-1",
+      suffix: "running",
+    });
+    const total = coordinationKey({
+      scope: "workflow-run",
+      slot: "ws-1",
+      suffix: "total",
+    });
+    const otherWorkspace = coordinationKey({
+      scope: "workflow-run",
+      slot: "ws-2",
+      suffix: "running",
+    });
+
+    expect(hashtagOf(running)).toBe(hashtagOf(total));
+    expect(hashtagOf(running)).not.toBe(hashtagOf(otherWorkspace));
+  });
+
+  test("the suffix stays outside the hashtag", () => {
+    const key = coordinationKey({
+      scope: "api-ratelimit",
+      slot: "scope:1.2.3.4",
+      suffix: "extra",
+    });
+    expect(hashtagOf(key)).toBe("scope:1.2.3.4");
+  });
+});
+
+describe("slot escaping", () => {
+  // Slots carry externally-derived values (client addresses, better-auth keys,
+  // content digests). A brace inside one would silently re-route the key, and
+  // a lossy escape would merge two clients into one counter.
+  const adversarialSlots = [
+    "plain",
+    "{",
+    "}",
+    "{}",
+    "%",
+    "%7B",
+    "%7D",
+    "a{b}c",
+    "a%7Bb%7Dc",
+    "{nested{deep}}",
+  ];
+
+  test("no escaped slot reintroduces a hashtag delimiter", () => {
+    for (const slot of adversarialSlots) {
+      expect(hashtagOf(coordinationKey({ scope: "api-ratelimit", slot }))).toBe(
+        hashtagOf(coordinationKey({ scope: "api-ratelimit", slot })),
+      );
+      expect(
+        hashtagOf(coordinationKey({ scope: "api-ratelimit", slot })),
+      ).not.toMatch(/[{}]/u);
+    }
+  });
+
+  test("escaping is injective, so distinct slots keep distinct keys", () => {
+    const keys = adversarialSlots.map((slot) =>
+      coordinationKey({ scope: "api-ratelimit", slot }),
+    );
+    expect(new Set(keys).size).toBe(adversarialSlots.length);
+  });
+
+  test("an empty slot is a programmer error, not an unrouted key", () => {
+    expect(() => coordinationKey({ scope: "api-ratelimit", slot: "" })).toThrow(
+      /empty slot/u,
+    );
+  });
+});
+
+describe("expiry discipline", () => {
+  test("a TTL scope cannot be built as unbounded and the reverse", () => {
+    expect(() =>
+      unboundedCoordinationKey({ scope: "api-ratelimit", slot: "x" }),
+    ).toThrow(/requires a TTL/u);
+    expect(() =>
+      coordinationKey({ scope: "ocr-repair-cursor", slot: "x" }),
+    ).toThrow(/unbounded/u);
+  });
+
+  test("SET arguments always carry an expiry token", () => {
+    const key = coordinationKey({ scope: "auth-ratelimit", slot: "ip" });
+    expect(
+      coordinationSetArguments({
+        key,
+        value: "v",
+        ttl: { unit: "seconds", value: 60 },
+      }),
+    ).toEqual([key, "v", "EX", "60"]);
+    expect(
+      coordinationSetArguments({
+        key,
+        value: "v",
+        ttl: { unit: "milliseconds", value: 500 },
+        onlyIfAbsent: true,
+      }),
+    ).toEqual([key, "v", "PX", "500", "NX"]);
+    expect(coordinationExpireArguments(key, 30)).toEqual([key, "30"]);
+  });
+});
+
+describe("scan globs", () => {
+  // The running-lock scan derives its glob from the same builder, so a key
+  // layout change cannot leave the scan matching the old shape.
+  test("a glob slot passes through unescaped and matches real keys", () => {
+    const pattern = coordinationKey({
+      scope: "workflow-run",
+      slot: "*",
+      suffix: "running",
+    });
+    expect(pattern).toBe("workflow-run:{*}:running");
+
+    const lock = coordinationKey({
+      scope: "workflow-run",
+      slot: "ws-1",
+      suffix: "running",
+    });
+    expect(new Bun.Glob(pattern).match(lock)).toBe(true);
+    expect(
+      new Bun.Glob(pattern).match(
+        coordinationKey({
+          scope: "workflow-run",
+          slot: "ws-1",
+          suffix: "total",
+        }),
+      ),
+    ).toBe(false);
+  });
+});

--- a/apps/api/src/lib/redis-keys.ts
+++ b/apps/api/src/lib/redis-keys.ts
@@ -73,7 +73,7 @@ type CoordinationKeyOptions = {
    */
   slot: string;
   /** Optional discriminator between keys within one slot. */
-  suffix?: string;
+  suffix?: string | undefined;
 };
 
 const buildKey = ({ scope, slot, suffix }: CoordinationKeyOptions) => {

--- a/apps/api/src/lib/redis-keys.ts
+++ b/apps/api/src/lib/redis-keys.ts
@@ -1,0 +1,154 @@
+/**
+ * Cluster-legal key construction for every non-queue Valkey key.
+ *
+ * Valkey runs as a single node today, but the code stays cluster-legal so the
+ * migration is a connection-module change (see `/conventions-scale`). Two
+ * properties this module owns:
+ *
+ * 1. Every key carries a `{hashtag}` slot. A cluster routes by the hashtag
+ *    alone, so keys that a multi-key command or Lua script touches together
+ *    must name the same slot; keys that are only ever read one at a time
+ *    should name their own natural unit so the keyspace spreads across the
+ *    ring instead of piling onto one node.
+ * 2. Every key has a declared expiry. Valkey holds only ephemeral
+ *    coordination, so an unbounded key is a decision, recorded in
+ *    `COORDINATION_KEY_EXPIRY` with its reason, not an oversight.
+ *
+ * BullMQ keys are deliberately out of scope: BullMQ owns its own layout under
+ * its prefix, and that prefix flips only at the cluster migration behind a
+ * queue drain (see `redis-client.ts`).
+ */
+
+import { panic } from "better-result";
+import * as v from "valibot";
+
+/**
+ * How a scope's keys stop existing. `ttl` means every write sets one, so a
+ * flush or a missed cleanup cannot leak the key forever. `unbounded` means the
+ * key outlives its writes on purpose and must say why.
+ */
+export const COORDINATION_KEY_EXPIRY = {
+  "api-ratelimit": "ttl",
+  "auth-ratelimit": "ttl",
+  "mcp-gateway-ratelimit": "ttl",
+  "feedback-intake": "ttl",
+  "security-canary": "ttl",
+  "ocr-readiness": "ttl",
+  "workflow-run": "ttl",
+  // The OCR repair sweep's resume cursor. A TTL would silently restart the
+  // sweep from the beginning of the field table whenever the sweep paused for
+  // longer than the window; the key is a single compare-and-set slot, is
+  // rewritten on every sweep tick, and losing it costs one redundant pass
+  // rather than any correctness.
+  "ocr-repair-cursor": "unbounded",
+} as const satisfies Record<string, CoordinationKeyExpiry>;
+
+type CoordinationKeyExpiry = "ttl" | "unbounded";
+
+export type CoordinationScope = keyof typeof COORDINATION_KEY_EXPIRY;
+
+const coordinationKeySchema = v.pipe(v.string(), v.brand("CoordinationKey"));
+
+/**
+ * A Valkey key built by this module. Command helpers accept only this type, so
+ * a hand-assembled string cannot reach a key position.
+ */
+export type CoordinationKey = v.InferOutput<typeof coordinationKeySchema>;
+
+// Hashtag delimiters are structural: a slot containing one would silently move
+// the key to a different slot than the caller named. Percent-escape them (and
+// the escape character itself) so distinct inputs stay distinct.
+const HASHTAG_DELIMITERS = /[%{}]/u;
+const escapeSlot = (slot: string): string =>
+  HASHTAG_DELIMITERS.test(slot)
+    ? slot.replaceAll("%", "%25").replaceAll("{", "%7B").replaceAll("}", "%7D")
+    : slot;
+
+type CoordinationKeyOptions = {
+  /** Namespace owning the key; also the ownership boundary for reviews. */
+  scope: CoordinationScope;
+  /**
+   * Colocation unit, emitted as the `{hashtag}`. Keys sharing a slot land on
+   * one cluster node and may be touched by one multi-key command or script.
+   */
+  slot: string;
+  /** Optional discriminator between keys within one slot. */
+  suffix?: string;
+};
+
+const buildKey = ({ scope, slot, suffix }: CoordinationKeyOptions) => {
+  if (slot.length === 0) {
+    panic(`Coordination key for scope "${scope}" was built with an empty slot`);
+  }
+  const base = `${scope}:{${escapeSlot(slot)}}`;
+  return v.parse(
+    coordinationKeySchema,
+    suffix === undefined ? base : `${base}:${suffix}`,
+  );
+};
+
+/** Build a key in a scope whose every write carries a TTL. */
+export const coordinationKey = (
+  options: CoordinationKeyOptions,
+): CoordinationKey => {
+  if (COORDINATION_KEY_EXPIRY[options.scope] === "unbounded") {
+    panic(
+      `Coordination scope "${options.scope}" is unbounded; use unboundedCoordinationKey`,
+    );
+  }
+  return buildKey(options);
+};
+
+/**
+ * Build a key in a scope declared `unbounded` above. Separate from
+ * `coordinationKey` so an expiry-free key is explicit at its call site rather
+ * than an omission the reader has to notice.
+ */
+export const unboundedCoordinationKey = (
+  options: CoordinationKeyOptions,
+): CoordinationKey => {
+  if (COORDINATION_KEY_EXPIRY[options.scope] !== "unbounded") {
+    panic(
+      `Coordination scope "${options.scope}" requires a TTL; use coordinationKey`,
+    );
+  }
+  return buildKey(options);
+};
+
+type CoordinationTtl = {
+  unit: "seconds" | "milliseconds";
+  value: number;
+};
+
+const ttlArguments = ({ unit, value }: CoordinationTtl): [string, string] => [
+  unit === "seconds" ? "EX" : "PX",
+  String(value),
+];
+
+type CoordinationSetOptions = {
+  key: CoordinationKey;
+  value: string;
+  ttl: CoordinationTtl;
+  /** `NX`: only set when the key does not already exist (lock acquisition). */
+  onlyIfAbsent?: boolean;
+};
+
+/**
+ * `SET` arguments for a coordination key. `ttl` is required: a coordination
+ * value that outlives its window is a fact living only in Valkey.
+ */
+export const coordinationSetArguments = ({
+  key,
+  value,
+  ttl,
+  onlyIfAbsent = false,
+}: CoordinationSetOptions): string[] =>
+  onlyIfAbsent
+    ? [key, value, ...ttlArguments(ttl), "NX"]
+    : [key, value, ...ttlArguments(ttl)];
+
+/** `EXPIRE` arguments; renews a lease without rewriting its value. */
+export const coordinationExpireArguments = (
+  key: CoordinationKey,
+  ttlSeconds: number,
+): string[] => [key, String(ttlSeconds)];

--- a/apps/api/src/lib/redis-outage.test.ts
+++ b/apps/api/src/lib/redis-outage.test.ts
@@ -1,0 +1,281 @@
+/**
+ * Valkey outage degradation.
+ *
+ * Valkey holds only ephemeral coordination, so losing it must degrade the API
+ * and never corrupt it (see `/conventions-scale`). Each consumer's degraded
+ * path is written down somewhere; this suite pins that the paths actually run,
+ * against the real Bun client aimed at a port nothing listens on. Substituting
+ * a fake client here would test the fake, not the failure: it is the real
+ * connect/timeout behavior that decides whether a request stalls, throws, or
+ * quietly falls back.
+ *
+ * Not covered here: BullMQ enqueue failure, whose contract differs per caller
+ * and per durable outbox, and which BullMQ's own retry loop makes slow and
+ * timing-dependent to exercise.
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+import type { Options as RateLimitOptions } from "elysia-rate-limit";
+
+import { resourceRef, RESOURCE_TYPE } from "@stll/api-contract";
+
+// Port 1 is privileged and unbound in every environment this runs in, so a
+// connect attempt fails immediately rather than hanging on a routing black
+// hole. Every consumer below caps its own commands anyway; a bounded failure
+// is exactly what is under test.
+const UNREACHABLE_REDIS_URL = "redis://127.0.0.1:1";
+
+const realEnv = await import("@/api/env-document-processing-worker");
+void mock.module("@/api/env-document-processing-worker", () => ({
+  envDocumentProcessingWorker: {
+    ...realEnv.envDocumentProcessingWorker,
+    REDIS_URL: UNREACHABLE_REDIS_URL,
+  },
+}));
+
+// Imported directly, not only through the facades. The batching runner pairs
+// test files by the modules they name, so naming the connection module here is
+// what keeps this suite out of any process where another file has mocked
+// `createRedisClient` and replaced the very failure under test.
+const { createRedisClient } = await import("@/api/lib/redis-client");
+const { RedisRateLimitContext } =
+  await import("@/api/lib/rate-limit/redis-context");
+const { createAuthRateLimitStorage } =
+  await import("@/api/lib/rate-limit/auth-storage");
+const { createMcpGatewayRateLimiter } =
+  await import("@/api/mcp/gateway/rate-limit");
+const { createFeedbackIntakeGuards } =
+  await import("@/api/handlers/feedback/intake-guards");
+const { createSecurityCanaryAlertDeduplicator } =
+  await import("@/api/lib/security-canary");
+const { publishWorkspaceEvent, SSEBroadcastError } =
+  await import("@/api/lib/sse-broadcast");
+const { broadcast } = await import("@/api/lib/sse");
+const { resourceUpdatedRealtimeEvent } = await import("@stll/api-contract");
+const { brandPersistedWorkspaceId, brandPersistedEntityId } =
+  await import("@/api/lib/safe-id-boundaries");
+
+// Long enough for a refused connection plus each consumer's own command
+// timeout (500ms in the limiters), short enough that a hang fails the test
+// rather than the suite.
+const SETTLE_BUDGET_MS = 5000;
+
+const RATE_LIMIT_WINDOW_MS = 60_000;
+const RATE_LIMIT_MAX = 10;
+const RATE_LIMIT_OPTIONS = {
+  countFailedRequest: false,
+  duration: RATE_LIMIT_WINDOW_MS,
+  errorResponse: "rate limit reached",
+  generator: () => "outage-client",
+  headers: true,
+  max: RATE_LIMIT_MAX,
+  scoping: "scoped",
+  skip: () => false,
+} as const satisfies Omit<RateLimitOptions, "context">;
+
+const WORKSPACE_ID = brandPersistedWorkspaceId(
+  "01930000-0000-7000-8000-000000000001",
+);
+const EVENT = resourceUpdatedRealtimeEvent(
+  resourceRef({
+    type: RESOURCE_TYPE.ENTITY,
+    id: brandPersistedEntityId("01930000-0000-7000-8000-000000000002"),
+  }),
+);
+
+/** Resolve to the settled outcome, or reject if the promise hangs. */
+const settle = async <T>(
+  promise: Promise<T>,
+): Promise<
+  { status: "ok"; value: T } | { status: "error"; error: unknown }
+> => {
+  const timeout = new Promise<never>((_resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new Error("Valkey consumer did not settle within its budget"));
+    }, SETTLE_BUDGET_MS);
+    timer.unref();
+  });
+  return await Promise.race([
+    promise.then(
+      (value): { status: "ok"; value: T } => ({ status: "ok", value }),
+      (error: unknown): { status: "error"; error: unknown } => ({
+        status: "error",
+        error,
+      }),
+    ),
+    timeout,
+  ]);
+};
+
+describe("the outage under test", () => {
+  // Without this the suite would be vacuous wherever a local Valkey happens to
+  // be running, or wherever the client has been mocked: every consumer below
+  // would succeed for the ordinary reason.
+  test("a real client cannot reach Valkey", async () => {
+    const { envDocumentProcessingWorker } =
+      await import("@/api/env-document-processing-worker");
+    expect(envDocumentProcessingWorker.REDIS_URL).toBe(UNREACHABLE_REDIS_URL);
+
+    const client = createRedisClient({
+      connectionTimeout: 500,
+      enableOfflineQueue: false,
+    });
+    const result = await settle(client.send("PING", []));
+    expect(result.status).toBe("error");
+    expect(() => {
+      client.close();
+    }).not.toThrow();
+  });
+});
+
+describe("rate limiting during a Valkey outage", () => {
+  test("the fail-open policy admits the request from a local counter", async () => {
+    const context = new RedisRateLimitContext({
+      failurePolicy: "fail_open_local",
+      onRedisError: () => undefined,
+    });
+    context.init(RATE_LIMIT_OPTIONS);
+
+    const first = await settle(
+      context.increment("outage-open", RATE_LIMIT_WINDOW_MS),
+    );
+    expect(first.status).toBe("ok");
+    // The local fallback counts this request, so the caller sees an admitted
+    // request rather than an error or an exhausted window.
+    expect(first.status === "ok" ? first.value.count : null).toBe(1);
+
+    const second = await settle(
+      context.increment("outage-open", RATE_LIMIT_WINDOW_MS),
+    );
+    expect(second.status === "ok" ? second.value.count : null).toBe(2);
+
+    // A refund against an unreachable Valkey must also settle, not throw into
+    // the request that is already failing.
+    expect((await settle(context.decrement("outage-open"))).status).toBe("ok");
+    context.kill();
+  });
+
+  test("the fail-closed policy exhausts the window instead of erroring", async () => {
+    const context = new RedisRateLimitContext({
+      failurePolicy: "fail_closed",
+      onRedisError: () => undefined,
+    });
+    context.init(RATE_LIMIT_OPTIONS);
+
+    const result = await settle(
+      context.increment("outage-closed", RATE_LIMIT_WINDOW_MS),
+    );
+    expect(result.status).toBe("ok");
+    // Same shape as the fail-open path: a counter, never a rejection. The
+    // policy shows up in the count, which is already past any configured max.
+    expect(result.status === "ok" ? result.value.count : 0).toBeGreaterThan(
+      RATE_LIMIT_MAX,
+    );
+    context.kill();
+  });
+
+  test("auth rate limiting keeps limiting from its per-process fallback", async () => {
+    const storage = createAuthRateLimitStorage(60_000);
+    const value = { key: "ip:203.0.113.1", count: 3, lastRequest: 1 };
+
+    expect((await settle(storage.set(value.key, value))).status).toBe("ok");
+
+    const read = await settle(storage.get(value.key));
+    expect(read.status).toBe("ok");
+    // Sign-in stays bounded: the write survived in-process, so the outage
+    // cannot be used to reset a brute-force counter by tipping Valkey over.
+    expect(read.status === "ok" ? read.value : null).toEqual(value);
+  });
+
+  test("the MCP gateway limiter admits and keeps counting locally", async () => {
+    const limiter = createMcpGatewayRateLimiter({
+      onRedisError: () => undefined,
+    });
+    const consume = async () =>
+      await settle(
+        limiter.consume({ connectorSlug: "slug", userId: "user-1" }),
+      );
+
+    const first = await consume();
+    expect(first.status === "ok" ? first.value : null).toBe(true);
+    // Still admitted, and still bounded: the fallback keeps counting rather
+    // than being bypassed, so the configured maximum stays enforceable.
+    const second = await consume();
+    expect(second.status === "ok" ? second.value : null).toBe(true);
+  });
+
+  test("the public feedback intake stays guarded by its local counters", async () => {
+    const guards = createFeedbackIntakeGuards({
+      onRedisError: () => undefined,
+    });
+
+    const admitted = await settle(
+      guards.consumeCounter({
+        bucket: "ip",
+        key: "203.0.113.2",
+        max: 1,
+        windowMs: 60_000,
+      }),
+    );
+    expect(admitted.status === "ok" ? admitted.value : null).toBe(true);
+
+    const exhausted = await settle(
+      guards.consumeCounter({
+        bucket: "ip",
+        key: "203.0.113.2",
+        max: 1,
+        windowMs: 60_000,
+      }),
+    );
+    // An unauthenticated write endpoint must not become unbounded because
+    // Valkey is down.
+    expect(exhausted.status === "ok" ? exhausted.value : null).toBe(false);
+
+    const claim = await settle(
+      guards.claimDedup({ key: "digest-1", ttlMs: 60_000 }),
+    );
+    expect(claim.status === "ok" ? claim.value : null).toBe(true);
+  });
+});
+
+describe("security alerting during a Valkey outage", () => {
+  test("a canary hit is emitted rather than suppressed", async () => {
+    const claimAlert = createSecurityCanaryAlertDeduplicator();
+    const decision = await settle(claimAlert());
+
+    expect(decision.status).toBe("ok");
+    if (decision.status !== "ok") {
+      return;
+    }
+    // Deduplication is an optimization; losing it must not lose the alert.
+    expect(decision.value.status).toBe("emit");
+    if (decision.value.status !== "emit") {
+      return;
+    }
+    expect(decision.value.reason).toBe("deduplication_unavailable");
+  });
+});
+
+describe("SSE fan-out during a Valkey outage", () => {
+  test("the request-path broadcast returns without throwing", () => {
+    // `broadcast` is the shape every handler call site uses: synchronous and
+    // void, so an outage cannot reach the HTTP response. Local clients are
+    // still served inline while no subscriber is attached.
+    expect(() => {
+      broadcast(WORKSPACE_ID, EVENT);
+    }).not.toThrow();
+  });
+
+  test("a direct publish fails fast as a tagged error", async () => {
+    const result = await settle(publishWorkspaceEvent(WORKSPACE_ID, EVENT));
+
+    // The publish must not hang. The desktop-edit-session expiry task awaits
+    // its publishes and only stamps the notification column after one
+    // succeeds, so it needs a bounded failure to retry and reschedule
+    // against; a buffered command that never settles would hold its lease.
+    expect(result.status).toBe("error");
+    expect(
+      result.status === "error" ? SSEBroadcastError.is(result.error) : false,
+    ).toBe(true);
+  });
+});

--- a/apps/api/src/lib/security-canary.test.ts
+++ b/apps/api/src/lib/security-canary.test.ts
@@ -214,7 +214,7 @@ describe("security canary alert deduplicator", () => {
     expect(send).toHaveBeenCalledWith("EVAL", [
       expect.stringContaining('redis.call("PTTL", KEYS[1])'),
       "1",
-      "security:canary:alert:machine-api-key",
+      "security-canary:{machine-api-key}:alert",
       "300000",
     ]);
   });

--- a/apps/api/src/lib/security-canary.ts
+++ b/apps/api/src/lib/security-canary.ts
@@ -12,12 +12,19 @@ import { logger } from "@/api/lib/observability/logger";
 import { getRequestId } from "@/api/lib/observability/request-context";
 import { withCommandTimeout } from "@/api/lib/rate-limit/redis-command-timeout";
 import { createRedisClient } from "@/api/lib/redis-client";
+import { coordinationKey } from "@/api/lib/redis-keys";
 
 const BEARER_SCHEME = "bearer";
 const SHA256_HEX_PATTERN = /^[a-f0-9]{64}$/u;
 const MACHINE_API_KEY_CREDENTIAL_LENGTH =
   MACHINE_API_KEY_PREFIX.length + MACHINE_API_KEY_LENGTH;
-const ALERT_DEDUP_KEY = "security:canary:alert:machine-api-key";
+// One key per canary kind, never read together with another, so the canary
+// kind is its own colocation unit.
+const ALERT_DEDUP_KEY = coordinationKey({
+  scope: "security-canary",
+  slot: "machine-api-key",
+  suffix: "alert",
+});
 const ALERT_DEDUP_WINDOW_MS = 5 * 60 * 1000;
 const REDIS_COMMAND_TIMEOUT_MS = 500;
 const CLAIM_ALERT_SCRIPT = `

--- a/apps/api/src/lib/sse-broadcast.ts
+++ b/apps/api/src/lib/sse-broadcast.ts
@@ -139,8 +139,26 @@ export const parseRedisPayload = (raw: string): RedisPayload | null => {
 
 let publisher: ReturnType<typeof createRedisClient> | null = null;
 
+/**
+ * Bound the publisher the way every other coordination facade is bounded. On
+ * the client's defaults an unreachable Valkey buffers the PUBLISH in the
+ * offline queue and the promise never settles, which turns a best-effort
+ * broadcast into an unbounded wait: the desktop-edit-session expiry task
+ * awaits its publishes, so it would hold its lease forever instead of failing
+ * and rescheduling, and `sse.ts` would accumulate one pending promise per
+ * event for the length of the outage.
+ *
+ * Refusing to buffer is the right trade here: pub/sub delivery is already
+ * best-effort, and `broadcast`/`broadcastToOrganization` deliver to this
+ * instance's own clients regardless of the publish outcome.
+ */
+const PUBLISH_CONNECT_TIMEOUT_MS = 2000;
+
 const getPublisher = (): ReturnType<typeof createRedisClient> => {
-  publisher ??= createRedisClient();
+  publisher ??= createRedisClient({
+    connectionTimeout: PUBLISH_CONNECT_TIMEOUT_MS,
+    enableOfflineQueue: false,
+  });
   return publisher;
 };
 

--- a/apps/api/src/lib/sse-broadcast.ts
+++ b/apps/api/src/lib/sse-broadcast.ts
@@ -12,7 +12,13 @@ import {
 import type { SafeId } from "@/api/lib/branded-types";
 import { createRedisClient } from "@/api/lib/redis-client";
 
-/** Redis pub/sub channel for cross-instance SSE broadcasts. */
+/**
+ * Redis pub/sub channel for cross-instance SSE broadcasts. A channel is not a
+ * key: `PUBLISH` reaches every subscriber cluster-wide regardless of slot, so
+ * this name carries no hashtag. Delivery is best-effort by design; receivers
+ * tolerate lost messages (`sse.ts` falls back to inline local delivery while
+ * its subscriber is detached).
+ */
 export const REDIS_CHANNEL = "sse:broadcast";
 
 export const INSTANCE_ID = `api:${process.pid}:${Bun.randomUUIDv7()}`;

--- a/apps/api/src/lib/sse-broadcast.ts
+++ b/apps/api/src/lib/sse-broadcast.ts
@@ -10,6 +10,7 @@ import {
 } from "@stll/api-contract";
 
 import type { SafeId } from "@/api/lib/branded-types";
+import { withCommandTimeout } from "@/api/lib/rate-limit/redis-command-timeout";
 import { createRedisClient } from "@/api/lib/redis-client";
 
 /**
@@ -154,6 +155,14 @@ let publisher: ReturnType<typeof createRedisClient> | null = null;
  */
 const PUBLISH_CONNECT_TIMEOUT_MS = 2000;
 
+/**
+ * The connection timeout only covers reaching a peer. A peer that accepts the
+ * connection and then stops replying (a partitioned node, a paused process)
+ * leaves the PUBLISH itself outstanding forever, which is the same unbounded
+ * wait by a different route, so the command is raced too.
+ */
+const PUBLISH_COMMAND_TIMEOUT_MS = 2000;
+
 const getPublisher = (): ReturnType<typeof createRedisClient> => {
   publisher ??= createRedisClient({
     connectionTimeout: PUBLISH_CONNECT_TIMEOUT_MS,
@@ -164,7 +173,11 @@ const getPublisher = (): ReturnType<typeof createRedisClient> => {
 
 const publishRedisPayload = async (payload: RedisPayload): Promise<void> => {
   try {
-    await getPublisher().publish(REDIS_CHANNEL, JSON.stringify(payload));
+    await withCommandTimeout({
+      command: getPublisher().publish(REDIS_CHANNEL, JSON.stringify(payload)),
+      commandTimeoutMs: PUBLISH_COMMAND_TIMEOUT_MS,
+      label: "SSE broadcast publish",
+    });
   } catch (error: unknown) {
     throw new SSEBroadcastError({
       message: "SSE broadcast publish failed.",

--- a/apps/api/src/lib/workflow/completion-tracking.test.ts
+++ b/apps/api/src/lib/workflow/completion-tracking.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, test } from "bun:test";
 
+import { coordinationKey } from "@/api/lib/redis-keys";
 import {
   COMPLETE_ENTITY_SCRIPT,
   parseEntityCompletionReply,
   recordEntityCompletion,
   resetCompletionState,
+  type WorkflowCompletionKeys,
 } from "@/api/lib/workflow/completion-tracking";
 
 describe("completion reply validation", () => {
@@ -109,14 +111,18 @@ const createFakeRedis = (state: FakeRedisState) => ({
 });
 
 describe("entity completion state", () => {
+  // Built through the shared key builder rather than spelled out, so the
+  // fixture cannot drift from the hashtag layout the script depends on.
+  const runKey = (suffix: string) =>
+    coordinationKey({ scope: "workflow-run", slot: "ws_1", suffix });
   const keys = {
-    requestId: "workflow:ws_1:request-id",
-    running: "workflow:ws_1:running",
-    completedEntities: "workflow:ws_1:completed-entities",
-    total: "workflow:ws_1:total",
-    transitionalCompleted: "workflow:ws_1:completed",
-    setMode: "workflow:ws_1:set-mode",
-  };
+    requestId: runKey("request-id"),
+    running: runKey("running"),
+    completedEntities: runKey("completed-entities"),
+    total: runKey("total"),
+    transitionalCompleted: runKey("completed"),
+    setMode: runKey("set-mode"),
+  } satisfies WorkflowCompletionKeys;
   const activeRequestId = "req_1";
   const transitionalRunningLockValue = "1";
 

--- a/apps/api/src/lib/workflow/completion-tracking.ts
+++ b/apps/api/src/lib/workflow/completion-tracking.ts
@@ -1,9 +1,19 @@
 // Pure helpers for the atomic entity-completion script. This module stays
-// free of Redis imports so its concurrency invariants are testable in-process.
+// free of Redis client imports so its concurrency invariants are testable
+// in-process; it takes keys, never a connection.
+
+import {
+  coordinationSetArguments,
+  type CoordinationKey,
+} from "@/api/lib/redis-keys";
 
 // Atomically verifies that a job still belongs to the active workflow, records
 // the entity once, and returns progress. Bundling the operations closes the
 // stale-run check/write race; SADD/SCARD makes retries idempotent per entity.
+//
+// All six keys must share one cluster slot, which the `workflow-run` hashtag
+// on the workspace id guarantees; a cluster rejects a script whose keys span
+// slots.
 //
 // KEYS[1] = request-id, KEYS[2] = running, KEYS[3] = completed-entities,
 // KEYS[4] = total, KEYS[5] = transitional completed counter,
@@ -88,12 +98,12 @@ type EntityCompletionRedis = {
 };
 
 export type WorkflowCompletionKeys = {
-  requestId: string;
-  running: string;
-  completedEntities: string;
-  total: string;
-  transitionalCompleted: string;
-  setMode: string;
+  requestId: CoordinationKey;
+  running: CoordinationKey;
+  completedEntities: CoordinationKey;
+  total: CoordinationKey;
+  transitionalCompleted: CoordinationKey;
+  setMode: CoordinationKey;
 };
 
 type RecordEntityCompletionArgs = {
@@ -143,11 +153,20 @@ export const resetCompletionState = async ({
   runStateTtlSec,
 }: {
   redis: EntityCompletionRedis;
-  completedEntitiesKey: string;
-  transitionalCompletedKey: string;
-  setModeKey: string;
+  completedEntitiesKey: CoordinationKey;
+  transitionalCompletedKey: CoordinationKey;
+  setModeKey: CoordinationKey;
   runStateTtlSec: number;
 }): Promise<void> => {
+  // Both keys carry the same workspace hashtag, so this multi-key DEL stays
+  // inside one cluster slot.
   await redis.send("DEL", [completedEntitiesKey, transitionalCompletedKey]);
-  await redis.send("SET", [setModeKey, "1", "EX", String(runStateTtlSec)]);
+  await redis.send(
+    "SET",
+    coordinationSetArguments({
+      key: setModeKey,
+      value: "1",
+      ttl: { unit: "seconds", value: runStateTtlSec },
+    }),
+  );
 };

--- a/apps/api/src/lib/workflow/orphan-recovery.test.ts
+++ b/apps/api/src/lib/workflow/orphan-recovery.test.ts
@@ -34,24 +34,26 @@ describe("selectExpiredStaleRunWorkspaceIds", () => {
 
 describe("parseRunningLockWorkspaceId", () => {
   test("extracts the workspace id from a running-lock key", () => {
-    expect(parseRunningLockWorkspaceId("workflow:ws-123:running")).toBe(
+    expect(parseRunningLockWorkspaceId("workflow-run:{ws-123}:running")).toBe(
       "ws-123",
     );
   });
 
   test("ignores sibling run-state keys so only locks are reconciled", () => {
     expect(
-      parseRunningLockWorkspaceId("workflow:ws-123:completed-entities"),
+      parseRunningLockWorkspaceId("workflow-run:{ws-123}:completed-entities"),
     ).toBeNull();
     expect(
-      parseRunningLockWorkspaceId("workflow:ws-123:request-id"),
+      parseRunningLockWorkspaceId("workflow-run:{ws-123}:request-id"),
     ).toBeNull();
-    expect(parseRunningLockWorkspaceId("workflow:ws-123:total")).toBeNull();
+    expect(
+      parseRunningLockWorkspaceId("workflow-run:{ws-123}:total"),
+    ).toBeNull();
   });
 
   test("ignores malformed keys", () => {
     expect(parseRunningLockWorkspaceId("running")).toBeNull();
-    expect(parseRunningLockWorkspaceId("workflow::running")).toBeNull();
+    expect(parseRunningLockWorkspaceId("workflow-run:{}:running")).toBeNull();
     expect(parseRunningLockWorkspaceId("other:ws-123:running")).toBeNull();
   });
 });

--- a/apps/api/src/lib/workflow/orphan-recovery.ts
+++ b/apps/api/src/lib/workflow/orphan-recovery.ts
@@ -2,10 +2,10 @@
 // Redis/DB/queue imports so the reconciler's logic is unit-testable and
 // importing it never triggers a connection or worker side effect.
 
-const RUNNING_LOCK_KEY = /^workflow:(?<workspaceId>[^:]+):running$/u;
+const RUNNING_LOCK_KEY = /^workflow-run:\{(?<workspaceId>[^{}]+)\}:running$/u;
 
 /**
- * Extract the workspace id from a `workflow:<workspaceId>:running` lock
+ * Extract the workspace id from a `workflow-run:{<workspaceId>}:running` lock
  * key. Returns null for any other workflow key (e.g. `:completed-entities`,
  * `:request-id`) or a malformed key, so only genuine locks are ever
  * considered for reconciliation.

--- a/apps/api/src/lib/workflow/run-state-store.test.ts
+++ b/apps/api/src/lib/workflow/run-state-store.test.ts
@@ -223,30 +223,30 @@ describe("workflow finalization state reads", () => {
       {
         command: "DEL",
         args: [
-          `workflow:${workspaceId}:completed-entities`,
-          `workflow:${workspaceId}:completed`,
+          `workflow-run:{${workspaceId}}:completed-entities`,
+          `workflow-run:{${workspaceId}}:completed`,
         ],
       },
       {
         command: "SET",
-        args: [`workflow:${workspaceId}:set-mode`, "1", "EX", "600"],
+        args: [`workflow-run:{${workspaceId}}:set-mode`, "1", "EX", "600"],
       },
       {
         command: "DEL",
         args: [
-          `workflow:${workspaceId}:plan-properties`,
-          `workflow:${workspaceId}:scoped`,
-          `workflow:${workspaceId}:service-tier`,
+          `workflow-run:{${workspaceId}}:plan-properties`,
+          `workflow-run:{${workspaceId}}:scoped`,
+          `workflow-run:{${workspaceId}}:service-tier`,
         ],
       },
       {
         command: "SET",
-        args: [`workflow:${workspaceId}:total`, "3", "EX", "600"],
+        args: [`workflow-run:{${workspaceId}}:total`, "3", "EX", "600"],
       },
       {
         command: "SET",
         args: [
-          `workflow:${workspaceId}:finalization-v1`,
+          `workflow-run:{${workspaceId}}:finalization-v1`,
           JSON.stringify(validManifest),
           "EX",
           "600",
@@ -277,9 +277,12 @@ describe("workflow finalization state reads", () => {
 
   test("reads and preserves the immediately previous release state", async () => {
     const values = new Map<string, string>([
-      [`workflow:${workspaceId}:plan-properties`, JSON.stringify([propertyId])],
-      [`workflow:${workspaceId}:scoped`, "1"],
-      [`workflow:${workspaceId}:service-tier`, "batch"],
+      [
+        `workflow-run:{${workspaceId}}:plan-properties`,
+        JSON.stringify([propertyId]),
+      ],
+      [`workflow-run:{${workspaceId}}:scoped`, "1"],
+      [`workflow-run:{${workspaceId}}:service-tier`, "batch"],
     ]);
     const store = createWorkflowRunStateStore({
       send: async (command, args) =>
@@ -320,17 +323,17 @@ describe("workflow finalization state reads", () => {
       workspaceId,
     });
 
-    expect(keys).toContain(`workflow:${workspaceId}:plan-properties`);
-    expect(keys).toContain(`workflow:${workspaceId}:scoped`);
-    expect(keys).toContain(`workflow:${workspaceId}:service-tier`);
-    expect(keys).toContain(`workflow:${workspaceId}:completed`);
-    expect(keys).toContain(`workflow:${workspaceId}:set-mode`);
+    expect(keys).toContain(`workflow-run:{${workspaceId}}:plan-properties`);
+    expect(keys).toContain(`workflow-run:{${workspaceId}}:scoped`);
+    expect(keys).toContain(`workflow-run:{${workspaceId}}:service-tier`);
+    expect(keys).toContain(`workflow-run:{${workspaceId}}:completed`);
+    expect(keys).toContain(`workflow-run:{${workspaceId}}:set-mode`);
   });
 
   test("recognizes a transitional constant-valued running lock", async () => {
     const values = new Map<string, string>([
-      [`workflow:${workspaceId}:request-id`, requestId],
-      [`workflow:${workspaceId}:running`, "1"],
+      [`workflow-run:{${workspaceId}}:request-id`, requestId],
+      [`workflow-run:{${workspaceId}}:running`, "1"],
     ]);
     const store = createWorkflowRunStateStore({
       send: async (command, args) =>

--- a/apps/api/src/lib/workflow/run-state-store.ts
+++ b/apps/api/src/lib/workflow/run-state-store.ts
@@ -4,6 +4,12 @@ import * as v from "valibot";
 import { USAGE_SERVICE_TIERS } from "@/api/db/schema";
 import type { AIRequestServiceTier } from "@/api/lib/ai-config";
 import type { SafeId } from "@/api/lib/branded-types";
+import {
+  coordinationExpireArguments,
+  coordinationKey,
+  coordinationSetArguments,
+  type CoordinationKey,
+} from "@/api/lib/redis-keys";
 import { brandPersistedPropertyId } from "@/api/lib/safe-id-boundaries";
 import {
   recordEntityCompletion,
@@ -16,10 +22,15 @@ import {
   selectRunningLockReservation,
 } from "@/api/lib/workflow/orphan-recovery";
 
-const WORKFLOW_KEY_PREFIX = "workflow";
+const WORKFLOW_RUN_SCOPE = "workflow-run";
 const FINALIZATION_MANIFEST_VERSION = 1;
 const TRANSITIONAL_RUNNING_LOCK_VALUE = "1";
-const RUNNING_LOCK_SCAN_PATTERN = `${WORKFLOW_KEY_PREFIX}:*:running`;
+// Derived from the key builder so the glob cannot drift from the key layout.
+const RUNNING_LOCK_SCAN_PATTERN = coordinationKey({
+  scope: WORKFLOW_RUN_SCOPE,
+  slot: "*",
+  suffix: "running",
+});
 const RUNNING_LOCK_SCAN_COUNT = "200";
 const RESERVE_RECOVERY_LOCK_SCRIPT = `
 local current = redis.call("GET", KEYS[1])
@@ -115,10 +126,20 @@ type WorkflowRunStateRedis = {
 
 type WorkflowRunStateField = (typeof WORKFLOW_RUN_STATE_FIELDS)[number];
 
+// The workspace is the colocation unit: `clear`, `initializeCompletion` and
+// COMPLETE_ENTITY_SCRIPT each touch several of these keys in one command, and
+// a cluster rejects a multi-key command whose keys span slots. Hashtagging the
+// workspace id keeps every field of one run on one node while distinct
+// workspaces still spread across the ring.
 const workflowKey = (
   workspaceId: SafeId<"workspace">,
   field: WorkflowRunStateField,
-): string => `${WORKFLOW_KEY_PREFIX}:${workspaceId}:${field}`;
+): CoordinationKey =>
+  coordinationKey({
+    scope: WORKFLOW_RUN_SCOPE,
+    slot: workspaceId,
+    suffix: field,
+  });
 
 const parseOptionalStringReply = (reply: unknown): string | null => {
   if (reply === null || typeof reply === "string") {
@@ -337,14 +358,20 @@ export const createWorkflowRunStateStore = (redis: WorkflowRunStateRedis) => {
       workspaceId: SafeId<"workspace">;
     }): Promise<void> => {
       await Promise.all([
-        redis.send("EXPIRE", [
-          workflowKey(workspaceId, "running"),
-          String(runLockTtlSec),
-        ]),
-        redis.send("EXPIRE", [
-          workflowKey(workspaceId, "request-id"),
-          String(runLockTtlSec),
-        ]),
+        redis.send(
+          "EXPIRE",
+          coordinationExpireArguments(
+            workflowKey(workspaceId, "running"),
+            runLockTtlSec,
+          ),
+        ),
+        redis.send(
+          "EXPIRE",
+          coordinationExpireArguments(
+            workflowKey(workspaceId, "request-id"),
+            runLockTtlSec,
+          ),
+        ),
       ]);
     },
 
@@ -383,18 +410,22 @@ export const createWorkflowRunStateStore = (redis: WorkflowRunStateRedis) => {
         ),
       );
       await Promise.all([
-        redis.send("SET", [
-          workflowKey(workspaceId, "total"),
-          String(targetCount),
-          "EX",
-          String(runLockTtlSec),
-        ]),
-        redis.send("SET", [
-          workflowKey(workspaceId, "finalization-v1"),
-          JSON.stringify(manifest),
-          "EX",
-          String(runLockTtlSec),
-        ]),
+        redis.send(
+          "SET",
+          coordinationSetArguments({
+            key: workflowKey(workspaceId, "total"),
+            value: String(targetCount),
+            ttl: { unit: "seconds", value: runLockTtlSec },
+          }),
+        ),
+        redis.send(
+          "SET",
+          coordinationSetArguments({
+            key: workflowKey(workspaceId, "finalization-v1"),
+            value: JSON.stringify(manifest),
+            ttl: { unit: "seconds", value: runLockTtlSec },
+          }),
+        ),
       ]);
     },
 
@@ -462,13 +493,15 @@ export const createWorkflowRunStateStore = (redis: WorkflowRunStateRedis) => {
     }): Promise<boolean> => {
       const runningKey = workflowKey(workspaceId, "running");
       const wasSet =
-        (await redis.send("SET", [
-          runningKey,
-          recoveryLockValue,
-          "EX",
-          String(runLockTtlSec),
-          "NX",
-        ])) === "OK";
+        (await redis.send(
+          "SET",
+          coordinationSetArguments({
+            key: runningKey,
+            value: recoveryLockValue,
+            ttl: { unit: "seconds", value: runLockTtlSec },
+            onlyIfAbsent: true,
+          }),
+        )) === "OK";
       if (wasSet) {
         const requestId = await getOptionalString(workspaceId, "request-id");
         if (requestId === expectedRequestId) {
@@ -518,10 +551,13 @@ export const createWorkflowRunStateStore = (redis: WorkflowRunStateRedis) => {
           (field) => field !== "completed-entities",
         ).map(
           async (field) =>
-            await redis.send("EXPIRE", [
-              workflowKey(workspaceId, field),
-              String(runLockTtlSec),
-            ]),
+            await redis.send(
+              "EXPIRE",
+              coordinationExpireArguments(
+                workflowKey(workspaceId, field),
+                runLockTtlSec,
+              ),
+            ),
         ),
       );
     },
@@ -535,14 +571,24 @@ export const createWorkflowRunStateStore = (redis: WorkflowRunStateRedis) => {
       runLockTtlSec: number;
       workspaceId: SafeId<"workspace">;
     }): Promise<void> => {
-      await redis.send("SET", [
-        workflowKey(workspaceId, "request-id"),
-        requestId,
-        "EX",
-        String(runLockTtlSec),
-      ]);
+      await redis.send(
+        "SET",
+        coordinationSetArguments({
+          key: workflowKey(workspaceId, "request-id"),
+          value: requestId,
+          ttl: { unit: "seconds", value: runLockTtlSec },
+        }),
+      );
     },
 
+    /**
+     * Running locks visible to this connection. A cluster scans one node per
+     * cursor, so this is a hint that accelerates reconciliation, never the
+     * only way an orphaned run is found: `reconcileOrphanedWorkflows` also
+     * derives candidates from pending cells and stale extraction-run rows in
+     * PostgreSQL, and those two durable sources are what make the reconciler
+     * complete.
+     */
     scanRunningWorkspaceIds: async (): Promise<string[]> => {
       const workspaceIds: string[] = [];
       let cursor = "0";
@@ -586,13 +632,15 @@ export const createWorkflowRunStateStore = (redis: WorkflowRunStateRedis) => {
       runLockTtlSec: number;
       workspaceId: SafeId<"workspace">;
     }): Promise<boolean> =>
-      (await redis.send("SET", [
-        workflowKey(workspaceId, "running"),
-        requestId,
-        "EX",
-        String(runLockTtlSec),
-        "NX",
-      ])) === "OK",
+      (await redis.send(
+        "SET",
+        coordinationSetArguments({
+          key: workflowKey(workspaceId, "running"),
+          value: requestId,
+          ttl: { unit: "seconds", value: runLockTtlSec },
+          onlyIfAbsent: true,
+        }),
+      )) === "OK",
   };
 };
 

--- a/apps/api/src/lib/workflow/run-state-store.ts
+++ b/apps/api/src/lib/workflow/run-state-store.ts
@@ -131,6 +131,20 @@ type WorkflowRunStateField = (typeof WORKFLOW_RUN_STATE_FIELDS)[number];
 // a cluster rejects a multi-key command whose keys span slots. Hashtagging the
 // workspace id keeps every field of one run on one node while distinct
 // workspaces still spread across the ring.
+//
+// Deploying this rename moves every lookup off `workflow:<workspaceId>:<field>`
+// with no transitional read, which is safe for run state but not free during a
+// rolling deploy. A run in flight across the deploy is recovered, not lost:
+// its jobs stop matching the request id, its cells stay pending, and the boot
+// pass of `reconcileOrphanedWorkflows` (`scanPendingCells: true`, which every
+// replica runs as it starts) rebuilds the workspace from PostgreSQL rather
+// than from the lock. What the rename does drop for the length of the rollout
+// is mutual exclusion between the two releases: a replica on the old code
+// holds the old `running` key while a replica on the new code claims the new
+// one, so a workspace with a pre-deploy run in flight can accept a second run
+// started in that window. The result is duplicated extraction work over the
+// same cells, not corrupted state, and the old keys expire on their own TTL.
+// Deploy while workflow runs are idle to avoid it entirely.
 const workflowKey = (
   workspaceId: SafeId<"workspace">,
   field: WorkflowRunStateField,

--- a/apps/api/src/mcp/gateway/rate-limit.ts
+++ b/apps/api/src/mcp/gateway/rate-limit.ts
@@ -3,6 +3,7 @@ import { LIMITS } from "@/api/lib/limits";
 import { logger } from "@/api/lib/observability/logger";
 import { withCommandTimeout } from "@/api/lib/rate-limit/redis-command-timeout";
 import { createRedisClient } from "@/api/lib/redis-client";
+import { coordinationKey, type CoordinationKey } from "@/api/lib/redis-keys";
 
 type RedisLike = {
   send: (command: string, args: string[]) => Promise<unknown>;
@@ -24,7 +25,6 @@ type McpGatewayRateLimiterOptions = {
   onRedisError?: (error: unknown) => void;
 };
 
-const REDIS_KEY_PREFIX = "mcp:gateway:ratelimit:";
 const REDIS_COMMAND_TIMEOUT_MS = 500;
 const FALLBACK_CLEANUP_THRESHOLD = 10_000;
 const FALLBACK_CLEANUP_INTERVAL_MS = 60_000;
@@ -71,7 +71,11 @@ export const createMcpGatewayRateLimiter = ({
     try {
       const count = await consumeRedis({
         commandTimeoutMs,
-        key: `${REDIS_KEY_PREFIX}${key}`,
+        key: coordinationKey({
+          scope: "mcp-gateway-ratelimit",
+          slot: userId,
+          suffix: connectorSlug,
+        }),
         redis: getRedis(),
       });
       return count <= LIMITS.mcpGatewayRateLimitMax;
@@ -95,7 +99,7 @@ const consumeRedis = async ({
   redis,
 }: {
   commandTimeoutMs: number;
-  key: string;
+  key: CoordinationKey;
   redis: RedisLike;
 }): Promise<number> => {
   const rawCount = await withCommandTimeout({

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -592,6 +592,7 @@ export default defineConfig({
     "./.oxlint-plugins/require-toast-error-capture.ts",
     "./.oxlint-plugins/no-swallowed-rejection.ts",
     "./.oxlint-plugins/no-awaited-builder-union.ts",
+    "./.oxlint-plugins/confine-redis-client.ts",
   ],
 
   overrides: [
@@ -2211,6 +2212,62 @@ export default defineConfig({
       rules: {
         "no-crypto-random-uuid/no-crypto-random-uuid": "error",
         "no-native-s3-object-read/no-native-s3-object-read": "error",
+      },
+    },
+    {
+      // Valkey usage doctrine (/conventions-scale): Valkey holds only
+      // ephemeral coordination, and every consumer owes a degraded path for
+      // an outage. Both stay reviewable only while the set of modules that
+      // can open a connection is named here. A new entry is a decision about
+      // what may live in Valkey, so each one carries its reason.
+      files: [
+        "apps/api/src/**/*.ts",
+        ".oxlint-plugins/__fixtures__/confine-redis-client.fixture.ts",
+      ],
+      excludeFiles: ["apps/api/src/**/*.test.ts", "apps/api/src/tests/**/*.ts"],
+      rules: {
+        "confine-redis-client/confine-redis-client": [
+          "error",
+          {
+            allowedFiles: [
+              // Queue transport. Each module owns one BullMQ queue's
+              // connection lifecycle; BullMQ owns the key layout under its
+              // own prefix (see redis-client.ts for the cluster cutover).
+              "apps/api/src/lib/document-processing-enqueue.ts",
+              "apps/api/src/lib/document-processing-queue.ts",
+              "apps/api/src/lib/workflow-queue.ts",
+              "apps/api/src/lib/file-derivative-queue.ts",
+              "apps/api/src/lib/entity-deletion-cleanup-queue.ts",
+              "apps/api/src/lib/account-deletion-cleanup-queue.ts",
+              "apps/api/src/lib/style-set-package-cleanup-queue.ts",
+              "apps/api/src/lib/document-review/run-queue.ts",
+              "apps/api/src/lib/flows/flow-run-queue.ts",
+              "apps/api/src/lib/flows/flow-run-worker.ts",
+              "apps/api/src/lib/scheduler/bullmq.ts",
+              "apps/api/src/handlers/reports/report-export-queue.ts",
+              // Cross-instance SSE fan-out: publisher and subscriber. Lost
+              // messages degrade to inline local delivery.
+              "apps/api/src/lib/sse-broadcast.ts",
+              "apps/api/src/lib/sse.ts",
+              // TTL'd rate-limit counters. Each degrades to a per-process
+              // fallback map when Valkey is unreachable.
+              "apps/api/src/lib/rate-limit/redis-context.ts",
+              "apps/api/src/lib/rate-limit/auth-storage.ts",
+              "apps/api/src/mcp/gateway/rate-limit.ts",
+              "apps/api/src/handlers/feedback/intake-guards.ts",
+              // TTL'd alert deduplication; an outage emits the alert rather
+              // than suppressing it.
+              "apps/api/src/lib/security-canary.ts",
+              // TTL'd OCR worker readiness lease; absence reads as unready.
+              "apps/api/src/lib/document-processing-readiness.ts",
+              // Workflow run locks and progress counters, rebuilt from the
+              // durable orphan reconciler when they are lost.
+              "apps/api/src/lib/workflow/root-run-state-store.ts",
+              // Liveness probe: PINGs the connection it is reporting on.
+              "apps/api/src/lib/health/readiness.ts",
+            ],
+          },
+        ],
       },
     },
     {

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -593,6 +593,7 @@ export default defineConfig({
     "./.oxlint-plugins/no-swallowed-rejection.ts",
     "./.oxlint-plugins/no-awaited-builder-union.ts",
     "./.oxlint-plugins/confine-redis-client.ts",
+    "./.oxlint-plugins/require-coordination-key.ts",
   ],
 
   overrides: [
@@ -2268,6 +2269,19 @@ export default defineConfig({
             ],
           },
         ],
+      },
+    },
+    {
+      // Valkey key positions belong to `lib/redis-keys.ts`, which owns the
+      // hashtag placement and the per-scope expiry policy. Tests are exempt so
+      // a fixture can pin a produced key shape as a literal.
+      files: [
+        "apps/api/src/**/*.ts",
+        ".oxlint-plugins/__fixtures__/require-coordination-key.fixture.ts",
+      ],
+      excludeFiles: ["apps/api/src/**/*.test.ts", "apps/api/src/tests/**/*.ts"],
+      rules: {
+        "require-coordination-key/require-coordination-key": "error",
       },
     },
     {


### PR DESCRIPTION
 One commit per change:

- **Doctrine** (`/conventions-scale`): Valkey holds only ephemeral coordination — queue transport, pub/sub events, TTL'd counters, short leases — never facts that exist nowhere else; and every usage must be cluster-legal (hashtag-scoped keys, no cross-slot multi-key ops, no KEYS, pub/sub tolerant of lost messages with resync from Postgres).
- **Facade confinement** (`confine-redis-client` lint rule): the redis client may only be imported by the 23 audited coordination modules, each allowlisted with a reason. A dedicated rule rather than `no-restricted-imports` because oxlint overrides replace rather than merge rule config — the existing `apps/api/src/**` override already silently drops a base restriction, which is flagged as a follow-up audit.
- **Cluster-scoped key builder with TTL discipline**: non-queue keys are `<scope>:{<slot>}[:<suffix>]` with percent-escaped slot values so distinct subjects cannot merge; workflow run-state keys colocate on the workspace slot, fixing the one pre-existing hard cluster-illegality (a six-key EVAL and multi-key DELs with no hashtag, guaranteed CROSSSLOT). Re-keying is safe because run state is reachable from durable Postgres state via the existing orphan reconciler. Setters require a TTL outside a named allowlist.
- **Key-builder enforcement** (`require-coordination-key`): literals in the key position of client commands are rejected, with per-command-family key-position resolution.
- **SSE publisher bounding**: the publisher was on connection defaults (offline queue on, no connect timeout), so a PUBLISH against a dead Valkey never settled — the desktop-edit expiry task would have held its lease indefinitely. Now `connectionTimeout: 2000, enableOfflineQueue: false`.
- **Outage degradation test**: against a real client pointed at an unreachable endpoint (with a control proving the outage), pins: API rate limiting fails open in its fail-open mode and exhausts in fail-closed, auth limiting keeps limiting from its local fallback, MCP gateway and feedback intake stay bounded, the security canary still emits, and broadcast returns without throwing.

**Deliberately unchanged: BullMQ prefixes.** No queue sets one today (default `bull:`, not cluster-legal), and a queue's keys are its jobs: flipping the prefix at deploy would strand every waiting/delayed/retrying job with nothing to replay them. The prefix flips at the actual cluster migration behind a drain-to-zero step; the procedure is recorded at `createBullMqConnection` and in the doctrine.

Follow-ups recorded, not taken: audit the `no-restricted-imports` override stack for silent drops; `file-derivative-queue` marks a derivative terminally failed on enqueue failure with no reconciler; `scanRunningWorkspaceIds` (SCAN) degrades to partial on a cluster and correctness already rests on the durable candidate sources (now documented); the flows reconciler runs at boot only; style-set cleanup can orphan one object. A silent-success defect in the playbooks run paths (workflow start failure discarded after commit) is confirmed and gets its own focused PR.

**Deploy note.** The workflow re-key lands with no transitional read. A run in flight across the deploy is recovered rather than lost, because every replica runs `reconcileOrphanedWorkflows({ scanPendingCells: true })` at startup and rebuilds the workspace from PostgreSQL. What does lapse for the length of a rolling deploy is mutual exclusion between the two releases: the old code holds `workflow:<workspaceId>:running` while the new code claims `workflow-run:{<workspaceId>}:running`, so a workspace with a pre-deploy run in flight can accept a second run started in that window, duplicating extraction work over the same cells without corrupting state. Deploy while workflow runs are idle to avoid it; the constraint is recorded at `workflowKey`.

**Publish bounding covers both outage shapes.** `connectionTimeout` and the disabled offline queue only handle a peer that cannot be reached. A peer that completes the handshake and then stops replying left the PUBLISH pending indefinitely (measured: still unsettled after 4s), so the command is raced against `withCommandTimeout` too. One consequence of the disabled offline queue worth knowing: the first publish on a cold client rejects while the client connects in the background, costing one cross-instance publish per process start.
