### PR TITLE
fix(playbooks): surface workflow start failures instead of reporting success

### DIFF
--- a/apps/api/src/handlers/playbooks/auto-run.test.ts
+++ b/apps/api/src/handlers/playbooks/auto-run.test.ts
@@ -1,0 +1,138 @@
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { toSafeId } from "@/api/lib/branded-types";
+import type { OpenPlaybookRunResult } from "@/api/lib/document-review/open-playbook-run";
+import { createTestHandlerContext } from "@/api/tests/helpers/handler-context";
+import { createScopedDbMock } from "@/api/tests/scoped-db-mock";
+
+const loadLatestApprovedVersionsMock = mock();
+const openPlaybookRunMock = mock();
+const resolveApplicablePlaybooksMock = mock();
+const startWorkflowMock = mock();
+
+const realApprovedVersions =
+  await import("@/api/lib/document-review/approved-playbook-versions");
+const realOpenPlaybookRun =
+  await import("@/api/lib/document-review/open-playbook-run");
+const realRoutePlaybooks = await import("@/api/lib/workflow/route-playbooks");
+const realWorkflowQueue = await import("@/api/lib/workflow-queue");
+
+void mock.module(
+  "@/api/lib/document-review/approved-playbook-versions",
+  () => ({
+    ...realApprovedVersions,
+    loadLatestApprovedVersions: loadLatestApprovedVersionsMock,
+  }),
+);
+
+void mock.module("@/api/lib/document-review/open-playbook-run", () => ({
+  ...realOpenPlaybookRun,
+  openPlaybookRun: openPlaybookRunMock,
+}));
+
+void mock.module("@/api/lib/workflow/route-playbooks", () => ({
+  ...realRoutePlaybooks,
+  resolveApplicablePlaybooks: resolveApplicablePlaybooksMock,
+}));
+
+void mock.module("@/api/lib/workflow-queue", () => ({
+  ...realWorkflowQueue,
+  startWorkflow: startWorkflowMock,
+}));
+
+const { default: autoRunPlaybooks } = await import("./auto-run");
+
+type AutoRunCtx = Parameters<typeof autoRunPlaybooks.handler>[0];
+
+const playbookId = toSafeId<"playbookDefinition">("pb_auto_run");
+const propertyId = toSafeId<"property">("property_auto_run");
+
+const opened = {
+  ok: true,
+  playbook: {
+    definitionId: playbookId,
+    versionId: null,
+    provenance: "draft",
+    definitionSnapshot: {
+      name: "Vendor agreement review",
+      positions: { version: 2, items: [] },
+    },
+  },
+  materializedPropertyIds: [propertyId],
+  tableRuns: {
+    runs: [
+      {
+        runId: toSafeId<"documentReviewRun">("dr_auto_run"),
+        entityId: toSafeId<"entity">("entity_auto_run"),
+      },
+    ],
+    skippedActiveCount: 0,
+    uncoveredCount: 0,
+    expectedFindingCount: 1,
+  },
+} satisfies OpenPlaybookRunResult;
+
+const runAutoRun = async () => {
+  const { scopedDb, safeDb } = createScopedDbMock({
+    query: { playbookDefinitions: { findMany: async () => [] } },
+  });
+  return await autoRunPlaybooks.handler(
+    createTestHandlerContext<AutoRunCtx>({ safeDb, scopedDb }),
+  );
+};
+
+describe("auto-run playbooks handler", () => {
+  beforeEach(() => {
+    loadLatestApprovedVersionsMock.mockReset();
+    loadLatestApprovedVersionsMock.mockResolvedValue(new Map());
+    openPlaybookRunMock.mockReset();
+    openPlaybookRunMock.mockResolvedValue(opened);
+    resolveApplicablePlaybooksMock.mockReset();
+    resolveApplicablePlaybooksMock.mockResolvedValue([
+      {
+        id: playbookId,
+        name: "Vendor agreement review",
+        positions: { version: 2, items: [] },
+        scope: null,
+      },
+    ]);
+    startWorkflowMock.mockReset();
+  });
+
+  afterAll(() => {
+    mock.restore();
+  });
+
+  test("a failed enqueue is answered as a failure, not as a batch of opened runs", async () => {
+    // The queue reports it in band rather than throwing, so nothing above
+    // catches it.
+    startWorkflowMock.mockResolvedValue({ status: "failed" });
+
+    const result = await runAutoRun();
+
+    if (!("code" in result)) {
+      throw new Error("Expected the failed start to return a status");
+    }
+    expect(result.code).toBe(500);
+    expect(result.response).toMatchObject({
+      message: "Failed to start the review.",
+    });
+    // The batch's columns stay materialized and its runs stay open, so the
+    // retry the user is now told to make maps back to the same ones.
+    expect(startWorkflowMock.mock.calls.at(0)?.[0]).toMatchObject({
+      propertyIds: [propertyId],
+    });
+  });
+
+  test("a deferred enqueue still reports the runs it opened", async () => {
+    // Nothing was queued because the plan had no work left; the columns are
+    // materialized and a later run grades them.
+    startWorkflowMock.mockResolvedValue({ status: "skipped" });
+
+    expect(await runAutoRun()).toEqual({
+      playbooksRun: 1,
+      runPropertyCount: 1,
+      documentRunCount: 1,
+    });
+  });
+});

--- a/apps/api/src/handlers/playbooks/auto-run.ts
+++ b/apps/api/src/handlers/playbooks/auto-run.ts
@@ -6,6 +6,10 @@ import type { SafeId } from "@/api/lib/branded-types";
 import { workspaceParams } from "@/api/lib/custom-schema";
 import { loadLatestApprovedVersions } from "@/api/lib/document-review/approved-playbook-versions";
 import { openPlaybookRun } from "@/api/lib/document-review/open-playbook-run";
+import {
+  PLAYBOOK_RUN_START_OUTCOME,
+  playbookRunStartOutcome,
+} from "@/api/lib/document-review/playbook-run-start";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import { LIMITS } from "@/api/lib/limits";
 import { startWorkflow } from "@/api/lib/workflow-queue";
@@ -109,7 +113,7 @@ const autoRunPlaybooks = createSafeHandler(
       });
     }
 
-    yield* Result.await(
+    const started = yield* Result.await(
       Result.tryPromise({
         try: async () =>
           await startWorkflow({
@@ -127,6 +131,21 @@ const autoRunPlaybooks = createSafeHandler(
           }),
       }),
     );
+    // Answering 200 on a start that never happened would leave the whole
+    // batch's columns with nothing to grade them. Nothing is unwound: the
+    // columns are upserted by playbook source id and left stale, so a retry
+    // maps back to the same ones instead of materializing a second set.
+    if (
+      playbookRunStartOutcome(started.status) ===
+      PLAYBOOK_RUN_START_OUTCOME.NOT_STARTED
+    ) {
+      return Result.err(
+        new HandlerError({
+          status: 500,
+          message: "Failed to start the review.",
+        }),
+      );
+    }
 
     return Result.ok({
       playbooksRun: txResult.playbooksRun,

--- a/apps/api/src/handlers/playbooks/run.test.ts
+++ b/apps/api/src/handlers/playbooks/run.test.ts
@@ -1,0 +1,157 @@
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { toSafeId } from "@/api/lib/branded-types";
+import type { OpenPlaybookRunResult } from "@/api/lib/document-review/open-playbook-run";
+import { PLAYBOOK_RUN_PROJECTION } from "@/api/lib/workflow/playbook-run-projection";
+import { createTestHandlerContext } from "@/api/tests/helpers/handler-context";
+import { createScopedDbMock } from "@/api/tests/scoped-db-mock";
+
+const loadLatestApprovedVersionMock = mock();
+const openPlaybookRunMock = mock();
+const startWorkflowMock = mock();
+
+const realApprovedVersions =
+  await import("@/api/lib/document-review/approved-playbook-versions");
+const realOpenPlaybookRun =
+  await import("@/api/lib/document-review/open-playbook-run");
+const realWorkflowQueue = await import("@/api/lib/workflow-queue");
+
+void mock.module(
+  "@/api/lib/document-review/approved-playbook-versions",
+  () => ({
+    ...realApprovedVersions,
+    loadLatestApprovedVersion: loadLatestApprovedVersionMock,
+  }),
+);
+
+void mock.module("@/api/lib/document-review/open-playbook-run", () => ({
+  ...realOpenPlaybookRun,
+  openPlaybookRun: openPlaybookRunMock,
+}));
+
+void mock.module("@/api/lib/workflow-queue", () => ({
+  ...realWorkflowQueue,
+  startWorkflow: startWorkflowMock,
+}));
+
+const { default: runPlaybook } = await import("./run");
+
+type RunPlaybookCtx = Parameters<typeof runPlaybook.handler>[0];
+
+const playbookId = toSafeId<"playbookDefinition">("pb_run");
+const propertyId = toSafeId<"property">("property_run");
+
+/** One run opened over one document, with the columns to extract for it. */
+const opened = {
+  ok: true,
+  playbook: {
+    definitionId: playbookId,
+    versionId: null,
+    provenance: "draft",
+    definitionSnapshot: {
+      name: "Vendor agreement review",
+      positions: { version: 2, items: [] },
+    },
+  },
+  materializedPropertyIds: [propertyId],
+  tableRuns: {
+    runs: [
+      {
+        runId: toSafeId<"documentReviewRun">("dr_run"),
+        entityId: toSafeId<"entity">("entity_run"),
+      },
+    ],
+    skippedActiveCount: 0,
+    uncoveredCount: 0,
+    expectedFindingCount: 1,
+  },
+} satisfies OpenPlaybookRunResult;
+
+const runColumnsProjection = async () => {
+  const { scopedDb, safeDb } = createScopedDbMock({
+    query: {
+      playbookDefinitions: {
+        findFirst: async () => ({
+          id: playbookId,
+          name: "Vendor agreement review",
+          positions: { version: 2, items: [] },
+          scope: null,
+        }),
+      },
+    },
+  });
+  return await runPlaybook.handler(
+    createTestHandlerContext<RunPlaybookCtx>({
+      body: { projection: PLAYBOOK_RUN_PROJECTION.COLUMNS },
+      params: { playbookId },
+      safeDb,
+      scopedDb,
+    }),
+  );
+};
+
+const successPayload = {
+  runPropertyCount: 1,
+  documentRunCount: 1,
+  documentsWithoutRun: 0,
+};
+
+describe("run playbook handler", () => {
+  beforeEach(() => {
+    loadLatestApprovedVersionMock.mockReset();
+    loadLatestApprovedVersionMock.mockResolvedValue(null);
+    openPlaybookRunMock.mockReset();
+    openPlaybookRunMock.mockResolvedValue(opened);
+    startWorkflowMock.mockReset();
+  });
+
+  afterAll(() => {
+    mock.restore();
+  });
+
+  test("a failed enqueue is answered as a failure, not as an opened run", async () => {
+    // The queue reports it in band rather than throwing, so nothing above
+    // catches it.
+    startWorkflowMock.mockResolvedValue({ status: "failed" });
+
+    const result = await runColumnsProjection();
+
+    if (!("code" in result)) {
+      throw new Error("Expected the failed start to return a status");
+    }
+    expect(result.code).toBe(500);
+    expect(result.response).toMatchObject({
+      message: "Failed to start the review.",
+    });
+  });
+
+  test("a deferred enqueue still reports the run it opened", async () => {
+    // A concurrent run holds the workspace. The columns this run materialized
+    // are stale ai-model columns that the in-flight run's catch-up still
+    // grades, so the review did start.
+    startWorkflowMock.mockResolvedValue({ status: "already-running" });
+
+    expect(await runColumnsProjection()).toEqual(successPayload);
+  });
+
+  test("a retry after a failed enqueue re-queues the same columns", async () => {
+    startWorkflowMock.mockResolvedValueOnce({ status: "failed" });
+    startWorkflowMock.mockResolvedValueOnce({ status: "started" });
+
+    const failed = await runColumnsProjection();
+    if (!("code" in failed)) {
+      throw new Error("Expected the failed start to return a status");
+    }
+    expect(failed.code).toBe(500);
+
+    // Nothing is unwound on the failure path: the columns stay materialized
+    // (`materializePlaybookRun` upserts by playbook source id) and the run rows
+    // this request opened stay claimed, so the retry drives the same property
+    // set rather than a second one.
+    expect(await runColumnsProjection()).toEqual(successPayload);
+    expect(startWorkflowMock).toHaveBeenCalledTimes(2);
+    for (const call of startWorkflowMock.mock.calls) {
+      expect(call.at(0)).toMatchObject({ propertyIds: [propertyId] });
+    }
+  });
+});

--- a/apps/api/src/handlers/playbooks/run.ts
+++ b/apps/api/src/handlers/playbooks/run.ts
@@ -9,6 +9,10 @@ import type { SafeId } from "@/api/lib/branded-types";
 import { tSafeId, workspaceParams } from "@/api/lib/custom-schema";
 import { loadLatestApprovedVersion } from "@/api/lib/document-review/approved-playbook-versions";
 import { openPlaybookRun } from "@/api/lib/document-review/open-playbook-run";
+import {
+  PLAYBOOK_RUN_START_OUTCOME,
+  playbookRunStartOutcome,
+} from "@/api/lib/document-review/playbook-run-start";
 import { enqueueDocumentReviewRuns } from "@/api/lib/document-review/run-queue";
 import { PLAYBOOK_RUN_DOCUMENTS_MAX } from "@/api/lib/document-review/table-run-create";
 import type { CreatePlaybookTableRunsResult } from "@/api/lib/document-review/table-run-create";
@@ -163,7 +167,7 @@ const runPlaybook = createSafeHandler(
     }
 
     if (txResult.materializedPropertyIds.length > 0) {
-      yield* Result.await(
+      const started = yield* Result.await(
         Result.tryPromise({
           try: async () =>
             await startWorkflow({
@@ -181,6 +185,21 @@ const runPlaybook = createSafeHandler(
             }),
         }),
       );
+      // Answering 200 on a start that never happened would leave a run
+      // nothing drives. Nothing is unwound: the columns are upserted by
+      // playbook source id and left stale, and the runs this request opened
+      // stay claimed, so a retry maps back to both.
+      if (
+        playbookRunStartOutcome(started.status) ===
+        PLAYBOOK_RUN_START_OUTCOME.NOT_STARTED
+      ) {
+        return Result.err(
+          new HandlerError({
+            status: 500,
+            message: "Failed to start the review.",
+          }),
+        );
+      }
     }
 
     return Result.ok({

--- a/apps/api/src/lib/document-review/open-playbook-run.test.ts
+++ b/apps/api/src/lib/document-review/open-playbook-run.test.ts
@@ -9,9 +9,11 @@
  * invisible because nothing connected the call sites.
  *
  * So the connection is asserted here: `openPlaybookRun` is the only caller of
- * the materializer and of the run creator, and every surface goes through it.
- * A fifth surface, or a regression in an existing one, fails this file rather
- * than quietly reviewing a matter against a different playbook.
+ * the materializer and of the run creator, every surface goes through it, and
+ * every surface classifies the workflow start it asks for afterwards. A fifth
+ * surface, or a regression in an existing one, fails this file rather than
+ * quietly reviewing a matter against a different playbook, or reporting a
+ * review whose extraction never started.
  */
 
 import { describe, expect, test } from "bun:test";
@@ -85,6 +87,19 @@ describe("starting a playbook run", () => {
         'from "@/api/lib/document-review/open-playbook-run"',
       );
       expect(source).toContain("openPlaybookRun({");
+    },
+  );
+
+  test.each(Object.entries(RUN_SURFACES))(
+    "%s (%s) classifies the workflow start it asks for",
+    (file) => {
+      // The other half of starting a review: the queue call each surface makes
+      // once its transaction commits. The queue reports an enqueue failure as
+      // a status rather than a throw, so a surface that reads the result
+      // without classifying it answers success for a review nothing grades.
+      const source = sourceOf(file);
+      expect(source).toContain("startWorkflow({");
+      expect(source).toContain("playbookRunStartOutcome(");
     },
   );
 

--- a/apps/api/src/lib/document-review/playbook-run-start.test.ts
+++ b/apps/api/src/lib/document-review/playbook-run-start.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  PLAYBOOK_RUN_START_OUTCOME,
+  playbookRunStartOutcome,
+} from "@/api/lib/document-review/playbook-run-start";
+import { WORKFLOW_START_STATUSES } from "@/api/lib/workflow-queue";
+
+const OUTCOMES = Object.values(PLAYBOOK_RUN_START_OUTCOME);
+
+describe("classifying a playbook run's workflow start", () => {
+  test("every status the queue can answer is classified", () => {
+    // Totality at runtime as well as in the type: a status the map missed
+    // would classify as undefined, and every caller's `=== NOT_STARTED` check
+    // would quietly pass it as a success.
+    for (const status of WORKFLOW_START_STATUSES) {
+      expect(OUTCOMES).toContain(playbookRunStartOutcome(status));
+    }
+  });
+
+  test("a failed enqueue is the only status a run surface must refuse", () => {
+    // The distinction the surfaces depend on, asserted over the whole status
+    // set rather than restating the map: anything but a failed enqueue leaves
+    // the materialized columns to an in-flight or later run, so reporting the
+    // review as started stays true.
+    expect(
+      WORKFLOW_START_STATUSES.filter(
+        (status) =>
+          playbookRunStartOutcome(status) ===
+          PLAYBOOK_RUN_START_OUTCOME.NOT_STARTED,
+      ),
+    ).toEqual(["failed"]);
+  });
+
+  test("a started workflow is the only status that queued anything", () => {
+    expect(
+      WORKFLOW_START_STATUSES.filter(
+        (status) =>
+          playbookRunStartOutcome(status) === PLAYBOOK_RUN_START_OUTCOME.QUEUED,
+      ),
+    ).toEqual(["started"]);
+  });
+});

--- a/apps/api/src/lib/document-review/playbook-run-start.ts
+++ b/apps/api/src/lib/document-review/playbook-run-start.ts
@@ -1,0 +1,49 @@
+/**
+ * What starting the extraction workflow means for a playbook run.
+ *
+ * `openPlaybookRun` owns the transaction half of starting a review: the pin,
+ * the columns, the durable runs. The other half happens after that
+ * transaction commits, when the surface asks the queue to extract the columns
+ * it just materialized. That call cannot move into the opener — jobs enqueued
+ * inside the transaction could be claimed before it commits — so what its
+ * result means lives here instead, in one place all four surfaces read.
+ *
+ * The distinction that matters: the queue reports an enqueue failure in band,
+ * as a status, not as a throw. A surface that only catches exceptions answers
+ * success for a review whose columns nothing will ever grade.
+ */
+
+import type { WorkflowStartStatus } from "@/api/lib/workflow-queue";
+
+/**
+ * `queued`: the columns the run materialized are being extracted now.
+ *
+ * `deferred`: nothing was queued this time, because a run already holds the
+ * workspace or the plan had no work left. The materialized columns are stale
+ * ai-model columns either way, so the run in flight (or the next one) still
+ * grades them, and reporting the review as started stays true.
+ *
+ * `not-started`: the enqueue failed. The columns exist and nothing is coming
+ * for them until someone asks again, so no surface may report success.
+ */
+export const PLAYBOOK_RUN_START_OUTCOME = {
+  QUEUED: "queued",
+  DEFERRED: "deferred",
+  NOT_STARTED: "not-started",
+} as const;
+
+export type PlaybookRunStartOutcome =
+  (typeof PLAYBOOK_RUN_START_OUTCOME)[keyof typeof PLAYBOOK_RUN_START_OUTCOME];
+
+const OUTCOME_BY_STATUS = {
+  started: PLAYBOOK_RUN_START_OUTCOME.QUEUED,
+  "already-running": PLAYBOOK_RUN_START_OUTCOME.DEFERRED,
+  skipped: PLAYBOOK_RUN_START_OUTCOME.DEFERRED,
+  failed: PLAYBOOK_RUN_START_OUTCOME.NOT_STARTED,
+} as const satisfies Record<WorkflowStartStatus, PlaybookRunStartOutcome>;
+
+/** Classify a start status. Total over the queue's statuses, so a new one
+ *  cannot be added without deciding what the run surfaces answer for it. */
+export const playbookRunStartOutcome = (
+  status: WorkflowStartStatus,
+): PlaybookRunStartOutcome => OUTCOME_BY_STATUS[status];

--- a/apps/api/src/lib/workflow-queue.ts
+++ b/apps/api/src/lib/workflow-queue.ts
@@ -437,11 +437,31 @@ export const startWorkflow = async ({
     return { status: "already-running" };
   }
 
-  await runStateStore.setRequestId({
-    requestId,
-    runLockTtlSec: RUNNING_LOCK_TTL_SEC,
-    workspaceId,
+  // Between the claim above and the try below, a throw would escape holding a
+  // lock nobody owns: the caller sees an exception, and its retry is answered
+  // `already-running` by the claim it orphaned, which reads as a run in
+  // flight. Report the same in-band failure the rest of the start path
+  // reports instead, releasing the claim first. Releasing is best-effort by
+  // necessity — the release travels the connection that just failed — and the
+  // hour-long TTL plus `reconcileOrphanedWorkflows` remain the backstop.
+  const requestIdSet = await Result.tryPromise({
+    try: async () =>
+      await runStateStore.setRequestId({
+        requestId,
+        runLockTtlSec: RUNNING_LOCK_TTL_SEC,
+        workspaceId,
+      }),
+    catch: (cause) => cause,
   });
+  if (Result.isError(requestIdSet)) {
+    await runStateStore
+      .clear(workspaceId)
+      .catch((clearError: unknown) =>
+        captureError(clearError, { workspaceId }),
+      );
+    captureError(requestIdSet.error, { workspaceId });
+    return { status: "failed" };
+  }
 
   const createdRunKey = await extractionRunStore
     .create({

--- a/apps/api/src/lib/workflow-queue.ts
+++ b/apps/api/src/lib/workflow-queue.ts
@@ -252,8 +252,23 @@ type StartWorkflowArgs = {
   serviceTier?: AIRequestServiceTier;
 };
 
+/**
+ * Every way a start attempt ends. Exported as a list so a caller can classify
+ * the whole set exhaustively instead of testing one status and treating the
+ * rest as success: `failed` in particular is an enqueue failure reported in
+ * band, not an exception, and reads as success to anyone who ignores it.
+ */
+export const WORKFLOW_START_STATUSES = [
+  "started",
+  "already-running",
+  "skipped",
+  "failed",
+] as const;
+
+export type WorkflowStartStatus = (typeof WORKFLOW_START_STATUSES)[number];
+
 type StartWorkflowResult = {
-  status: "started" | "already-running" | "skipped" | "failed";
+  status: WorkflowStartStatus;
 };
 
 const extractionRunScope = ({

--- a/apps/api/src/lib/workflow-queue.ts
+++ b/apps/api/src/lib/workflow-queue.ts
@@ -454,10 +454,14 @@ export const startWorkflow = async ({
     catch: (cause) => cause,
   });
   if (Result.isError(requestIdSet)) {
+    // Compare-and-delete on this request's own id: the release runs after a
+    // Valkey failure, so by the time it lands the claim's TTL may have lapsed
+    // and a replacement run may hold the workspace. Releasing that one would
+    // hand a third caller a workspace two runs believe they own.
     await runStateStore
-      .clear(workspaceId)
-      .catch((clearError: unknown) =>
-        captureError(clearError, { workspaceId }),
+      .releaseClaim({ requestId, workspaceId })
+      .catch((releaseError: unknown) =>
+        captureError(releaseError, { workspaceId }),
       );
     captureError(requestIdSet.error, { workspaceId });
     return { status: "failed" };

--- a/apps/api/src/lib/workflow-start-claim.test.ts
+++ b/apps/api/src/lib/workflow-start-claim.test.ts
@@ -16,22 +16,37 @@
 
 import { describe, expect, mock, test } from "bun:test";
 
+import type { ScopedDb } from "@/api/db/safe-db";
 import { toSafeId } from "@/api/lib/branded-types";
+import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
 
-const tryClaimMock = mock(async () => true);
+const claimedRequestIds: string[] = [];
+const releasedClaims: { requestId: string; workspaceId: string }[] = [];
+
+const tryClaimMock = mock(async ({ requestId }: { requestId: string }) => {
+  claimedRequestIds.push(requestId);
+  return await Promise.resolve(true);
+});
 const setRequestIdMock = mock(async () => {
   await Promise.resolve();
   throw new Error("valkey unreachable");
 });
+const releaseClaimMock = mock(
+  async (release: { requestId: string; workspaceId: string }) => {
+    releasedClaims.push(release);
+    return await Promise.resolve(true);
+  },
+);
 const clearMock = mock(async () => undefined);
 
-// Only the three members this path reaches. Spreading the real store here
-// would recurse: inside the factory, the module specifier resolves to this
-// mock, so the getter would call itself.
+// Only the members this path reaches. Spreading the real store here would
+// recurse: inside the factory, the module specifier resolves to this mock, so
+// the getter would call itself.
 void mock.module("@/api/lib/workflow/root-run-state-store", () => ({
   getRootWorkflowRunStateStore: () => ({
     tryClaim: tryClaimMock,
     setRequestId: setRequestIdMock,
+    releaseClaim: releaseClaimMock,
     clear: clearMock,
   }),
 }));
@@ -46,22 +61,44 @@ const ORGANIZATION_ID = toSafeId<"organization">(
 );
 const USER_ID = toSafeId<"user">("01931f4a-0000-7000-8000-000000000103");
 
+const startAfterFailedClaimWrite = async () =>
+  await startWorkflow({
+    workspaceId: WORKSPACE_ID,
+    organizationId: ORGANIZATION_ID,
+    userId: USER_ID,
+    scopedDb: asTestRaw<ScopedDb>(() => {
+      throw new Error("the plan must not be read after a failed claim");
+    }),
+  });
+
 describe("startWorkflow when the run state write fails after the claim", () => {
   test("releases the claim and reports the failure in band", async () => {
-    const result = await startWorkflow({
-      workspaceId: WORKSPACE_ID,
-      organizationId: ORGANIZATION_ID,
-      userId: USER_ID,
-      scopedDb: (() => {
-        throw new Error("the plan must not be read after a failed claim");
-      }) as never,
-    });
+    const result = await startAfterFailedClaimWrite();
 
     // In band, so the callers that now distinguish `failed` from `started`
     // surface it instead of receiving an exception they can only guess at.
     expect(result.status).toBe("failed");
     // Released, so the caller's retry is answered by a fresh claim rather than
     // by the orphan of the attempt that just failed.
-    expect(clearMock).toHaveBeenCalledWith(WORKSPACE_ID);
+    expect(releaseClaimMock).toHaveBeenCalledTimes(1);
+    expect(releasedClaims.at(0)?.workspaceId).toBe(WORKSPACE_ID);
+    // Never the blanket delete: it would take whatever holds the workspace at
+    // the time, not what this attempt claimed.
+    expect(clearMock).not.toHaveBeenCalled();
+  });
+
+  test("releases only the claim it made, never a replacement's", async () => {
+    // Two attempts, each with its own request id. The release runs after a
+    // Valkey failure, so a slow one can land after its lock's TTL lapsed and a
+    // later run claimed the workspace: what makes that harmless is that a
+    // release names the id it claimed with, and the store's compare-and-delete
+    // drops nothing when the ids differ.
+    await startAfterFailedClaimWrite();
+    await startAfterFailedClaimWrite();
+
+    expect(new Set(claimedRequestIds).size).toBe(claimedRequestIds.length);
+    expect(releasedClaims.map((release) => release.requestId)).toEqual(
+      claimedRequestIds,
+    );
   });
 });

--- a/apps/api/src/lib/workflow-start-claim.test.ts
+++ b/apps/api/src/lib/workflow-start-claim.test.ts
@@ -1,0 +1,67 @@
+/**
+ * `startWorkflow` must not answer an exception while still holding the run
+ * lock it just claimed.
+ *
+ * The claim is a `SET NX`, so a throw between claiming and the start path's
+ * own error handling leaves a lock nobody owns. The caller then sees a thrown
+ * error, and its retry is answered `already-running` by the very claim it
+ * orphaned, which every caller reads as a run in flight: a review that never
+ * started reported as one that did. The window is small (the lock's TTL and
+ * `reconcileOrphanedWorkflows` both close it eventually) but it is exactly the
+ * window a retryable error invites a caller into.
+ *
+ * Its own file because the mocks below replace the run-state store and the
+ * queue module process-wide.
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+
+import { toSafeId } from "@/api/lib/branded-types";
+
+const tryClaimMock = mock(async () => true);
+const setRequestIdMock = mock(async () => {
+  await Promise.resolve();
+  throw new Error("valkey unreachable");
+});
+const clearMock = mock(async () => undefined);
+
+// Only the three members this path reaches. Spreading the real store here
+// would recurse: inside the factory, the module specifier resolves to this
+// mock, so the getter would call itself.
+void mock.module("@/api/lib/workflow/root-run-state-store", () => ({
+  getRootWorkflowRunStateStore: () => ({
+    tryClaim: tryClaimMock,
+    setRequestId: setRequestIdMock,
+    clear: clearMock,
+  }),
+}));
+
+const { startWorkflow } = await import("@/api/lib/workflow-queue");
+
+const WORKSPACE_ID = toSafeId<"workspace">(
+  "01931f4a-0000-7000-8000-000000000101",
+);
+const ORGANIZATION_ID = toSafeId<"organization">(
+  "01931f4a-0000-7000-8000-000000000102",
+);
+const USER_ID = toSafeId<"user">("01931f4a-0000-7000-8000-000000000103");
+
+describe("startWorkflow when the run state write fails after the claim", () => {
+  test("releases the claim and reports the failure in band", async () => {
+    const result = await startWorkflow({
+      workspaceId: WORKSPACE_ID,
+      organizationId: ORGANIZATION_ID,
+      userId: USER_ID,
+      scopedDb: (() => {
+        throw new Error("the plan must not be read after a failed claim");
+      }) as never,
+    });
+
+    // In band, so the callers that now distinguish `failed` from `started`
+    // surface it instead of receiving an exception they can only guess at.
+    expect(result.status).toBe("failed");
+    // Released, so the caller's retry is answered by a fresh claim rather than
+    // by the orphan of the attempt that just failed.
+    expect(clearMock).toHaveBeenCalledWith(WORKSPACE_ID);
+  });
+});

--- a/apps/api/src/lib/workflow/route-playbooks.ts
+++ b/apps/api/src/lib/workflow/route-playbooks.ts
@@ -8,7 +8,12 @@ import { createBackgroundAuditRecorder } from "@/api/lib/audit-log";
 import type { SafeId } from "@/api/lib/branded-types";
 import { loadLatestApprovedVersions } from "@/api/lib/document-review/approved-playbook-versions";
 import { openPlaybookRun } from "@/api/lib/document-review/open-playbook-run";
+import {
+  PLAYBOOK_RUN_START_OUTCOME,
+  playbookRunStartOutcome,
+} from "@/api/lib/document-review/playbook-run-start";
 import { LIMITS } from "@/api/lib/limits";
+import type { WorkflowStartStatus } from "@/api/lib/workflow-queue";
 import type { DocTypeClassifier } from "@/api/lib/workflow/materialize-playbook-run";
 import { resolveDocTypeClassifier } from "@/api/lib/workflow/materialize-playbook-run";
 import type {
@@ -190,14 +195,16 @@ const ROUTED_AUDIT_METADATA = {
 
 // Injected rather than imported to avoid a static import cycle with
 // workflow-queue (which imports this module). Structurally matches
-// `startWorkflow`.
+// `startWorkflow`; the status union is imported as a type (erased, so no
+// cycle) rather than restated, since a hand-written copy could not tell this
+// path that a new status exists.
 type StartWorkflowFn = (args: {
   workspaceId: SafeId<"workspace">;
   organizationId: SafeId<"organization">;
   userId: SafeId<"user">;
   scopedDb: ScopedDb;
   propertyIds: SafeId<"property">[];
-}) => Promise<{ status: string }>;
+}) => Promise<{ status: WorkflowStartStatus }>;
 
 type RouteClassifiedDocumentsArgs = {
   workspaceId: SafeId<"workspace">;
@@ -331,10 +338,14 @@ export const routeClassifiedDocuments = async ({
     scopedDb,
     propertyIds: materializedPropertyIds,
   });
-  // A concurrent run may already hold the workspace lock; the materialized ASK
-  // columns are stale ai-model columns, so the in-flight run's straggler
-  // catch-up (or the next run) still grades them. Record the skip for context.
-  if (started.status !== "started") {
+  // Fire-and-forget: there is no caller to answer, so both a deferred start (a
+  // concurrent run holds the workspace; its straggler catch-up, or the next
+  // run, still grades these stale ASK columns) and a failed enqueue are
+  // recorded rather than surfaced.
+  if (
+    playbookRunStartOutcome(started.status) !==
+    PLAYBOOK_RUN_START_OUTCOME.QUEUED
+  ) {
     captureError(new Error("routeClassifiedDocuments.workflow_not_started"), {
       workspaceId,
       status: started.status,

--- a/apps/api/src/lib/workflow/run-state-store.test.ts
+++ b/apps/api/src/lib/workflow/run-state-store.test.ts
@@ -343,6 +343,47 @@ describe("workflow finalization state reads", () => {
     expect(await store.isCurrentRequest({ requestId, workspaceId })).toBe(true);
   });
 
+  test("releases a claim by comparing the request id, not by deleting the key", async () => {
+    const commands: { command: string; args: string[] }[] = [];
+    const store = createWorkflowRunStateStore({
+      send: async (command, args) => {
+        commands.push({ command, args });
+        return await Promise.resolve(1);
+      },
+    });
+
+    expect(await store.releaseClaim({ requestId, workspaceId })).toBe(true);
+
+    // One single-key script naming the running key and the id it may delete
+    // for. A bare DEL would drop whatever holds the workspace when it lands,
+    // which after a Valkey failure can be a replacement run's claim.
+    expect(commands).toEqual([
+      {
+        command: "EVAL",
+        args: [
+          expect.any(String),
+          "1",
+          `workflow-run:{${workspaceId}}:running`,
+          requestId,
+        ],
+      },
+    ]);
+    const script = commands.at(0)?.args.at(0) ?? "";
+    expect(script).toContain('redis.call("GET", KEYS[1])');
+    expect(script).toContain("ARGV[1]");
+    expect(script).toContain('redis.call("DEL", KEYS[1])');
+  });
+
+  test("reports a claim that had already moved on as not released", async () => {
+    const store = createWorkflowRunStateStore({
+      send: async () => await Promise.resolve(0),
+    });
+
+    // The compare failed: the lock's TTL lapsed and someone else owns the
+    // workspace now. Nothing was deleted, which is the point.
+    expect(await store.releaseClaim({ requestId, workspaceId })).toBe(false);
+  });
+
   test("returns stored missing and corrupt states without throwing", async () => {
     await Promise.all(
       (

--- a/apps/api/src/lib/workflow/run-state-store.ts
+++ b/apps/api/src/lib/workflow/run-state-store.ts
@@ -32,6 +32,18 @@ const RUNNING_LOCK_SCAN_PATTERN = coordinationKey({
   suffix: "running",
 });
 const RUNNING_LOCK_SCAN_COUNT = "200";
+// Compare-and-delete on one key: the claim is released only while it still
+// holds the releasing request's id. An unconditional DEL would be correct only
+// if no time passed between claiming and releasing, and this path runs after a
+// Valkey failure — long enough for the lock's TTL to lapse and a replacement
+// run to claim the workspace, whose claim the DEL would then drop.
+const RELEASE_CLAIM_SCRIPT = `
+local current = redis.call("GET", KEYS[1])
+if current == ARGV[1] then
+  return redis.call("DEL", KEYS[1])
+end
+return 0
+`;
 const RESERVE_RECOVERY_LOCK_SCRIPT = `
 local current = redis.call("GET", KEYS[1])
 if current == ARGV[1] then
@@ -552,6 +564,31 @@ export const createWorkflowRunStateStore = (redis: WorkflowRunStateRedis) => {
       ]);
       return Number(reply) === 1;
     },
+
+    /**
+     * Give up a claim this request made and never got to use. Answers whether
+     * the claim was still ours: `false` means the lock had already moved on
+     * (its TTL lapsed, or a reconciler reserved it), which is why the delete
+     * is conditional rather than a `clear`.
+     *
+     * Only the `running` key: a request that never started wrote nothing else,
+     * and the request-id write it was attempting carries the same TTL.
+     */
+    releaseClaim: async ({
+      requestId,
+      workspaceId,
+    }: {
+      requestId: string;
+      workspaceId: SafeId<"workspace">;
+    }): Promise<boolean> =>
+      Number(
+        await redis.send("EVAL", [
+          RELEASE_CLAIM_SCRIPT,
+          "1",
+          workflowKey(workspaceId, "running"),
+          requestId,
+        ]),
+      ) === 1,
 
     refreshActiveLease: async ({
       runLockTtlSec,

--- a/apps/api/src/mcp/knowledge-tools.test.ts
+++ b/apps/api/src/mcp/knowledge-tools.test.ts
@@ -300,7 +300,7 @@ describe("MCP knowledge tools", () => {
       uncoveredCount: 0,
       expectedFindingCount: 1,
     });
-    startWorkflowMock.mockResolvedValue(undefined);
+    startWorkflowMock.mockResolvedValue({ status: "started" });
 
     const result = await handleMcpToolCall({
       args: { matter_id: "ws_1", playbook_id: "pb_1" },
@@ -350,6 +350,46 @@ describe("MCP knowledge tools", () => {
     expect(startWorkflowMock.mock.calls.at(0)?.[0]).toMatchObject({
       propertyIds: [toSafeId<"property">("p1"), toSafeId<"property">("p2")],
       workspaceId: "ws_1",
+    });
+  });
+
+  test("run_playbook reports a workflow that never started instead of a run count", async () => {
+    loadLatestApprovedVersionMock.mockResolvedValue(null);
+    materializePlaybookRunMock.mockResolvedValue({
+      ok: true,
+      materializedPropertyIds: [toSafeId<"property">("p1")],
+    });
+    createPlaybookTableRunsMock.mockResolvedValue({
+      runs: [{ runId: toSafeId<"documentReviewRun">("run_1"), entityId: "e1" }],
+      skippedActiveCount: 0,
+      uncoveredCount: 0,
+      expectedFindingCount: 1,
+    });
+    // The queue reports an enqueue failure in-band rather than throwing.
+    startWorkflowMock.mockResolvedValue({ status: "failed" });
+
+    const result = await handleMcpToolCall({
+      args: { matter_id: "ws_1", playbook_id: "pb_1" },
+      context: createContext({
+        scopedDb: createPlaybookScopedDb({
+          id: PLAYBOOK_ID,
+          name: "Live draft name",
+          positions: positionsSaying("Never approved"),
+          scope: null,
+        }),
+      }),
+      toolName: "run_playbook",
+    });
+
+    expect(result.isError).toBe(true);
+    // Retryable by construction: the materialized columns survive, so calling
+    // the tool again maps back to them instead of materializing a second set.
+    expect(parseToolPayload(result)).toMatchObject({
+      error: {
+        code: "internal_error",
+        message: "Failed to start the review",
+        retryable: true,
+      },
     });
   });
 });

--- a/apps/api/src/mcp/knowledge-tools.ts
+++ b/apps/api/src/mcp/knowledge-tools.ts
@@ -35,6 +35,10 @@ import {
 } from "@/api/lib/clauses/types";
 import { loadLatestApprovedVersion } from "@/api/lib/document-review/approved-playbook-versions";
 import { openPlaybookRun } from "@/api/lib/document-review/open-playbook-run";
+import {
+  PLAYBOOK_RUN_START_OUTCOME,
+  playbookRunStartOutcome,
+} from "@/api/lib/document-review/playbook-run-start";
 import { LIMITS } from "@/api/lib/limits";
 import {
   brandPersistedClauseCategoryId,
@@ -64,6 +68,7 @@ import {
   errorResult,
   internalFailureResult,
   intProp,
+  MCP_INTERNAL_ERROR_HINT,
   nullableStringProp,
   stringProp,
   structuredErrorResult,
@@ -1476,6 +1481,20 @@ const runPlaybookArgsSchema = v.strictObject({
   playbook_id: v.pipe(v.string(), v.minLength(1)),
 });
 
+/**
+ * A review whose workflow never started. Retryable by construction: the
+ * materialized columns are upserted by playbook source id and left stale, so
+ * calling the tool again maps back to the same columns and re-queues them
+ * rather than materializing a second set.
+ */
+const workflowStartFailureResult = () =>
+  structuredErrorResult({
+    code: "internal_error",
+    message: "Failed to start the review",
+    hint: MCP_INTERNAL_ERROR_HINT,
+    retryable: true,
+  });
+
 const handleRunPlaybookTool: McpToolHandler = async ({ args, context }) => {
   if (!roles[context.memberRole].authorize({ playbook: ["apply"] }).success) {
     return errorResult("Forbidden");
@@ -1567,7 +1586,16 @@ const handleRunPlaybookTool: McpToolHandler = async ({ args, context }) => {
   });
   if (Result.isError(started)) {
     captureError(started.error, { workspaceId });
-    return errorResult("Failed to start playbook review");
+    return workflowStartFailureResult();
+  }
+  // The queue reports an enqueue failure in band (having already captured the
+  // cause), so a success envelope here would promise an agent a review nothing
+  // drives.
+  if (
+    playbookRunStartOutcome(started.value.status) ===
+    PLAYBOOK_RUN_START_OUTCOME.NOT_STARTED
+  ) {
+    return workflowStartFailureResult();
   }
 
   return textResult({


### PR DESCRIPTION
Three call sites committed materialized playbook properties, then discarded `startWorkflow`'s result and answered success: the playbook run and auto-run handlers and the MCP `run_playbook` tool. A `failed` start (anything thrown between the run-lock claim and the chunked enqueue; captured and lock-cleared inside `startWorkflow`, but never replayed since no start-request outbox exists) left the user watching a review that never produces findings, with no error anywhere.

All three now bind the result: `failed` answers an error (500 with the same message the unprojected review path already uses; the MCP tool returns a structured retryable `internal_error`, migrating its legacy code-less error branch to the documented envelope while there), while `skipped` and `already-running` stay successful, following the documented background-path rationale. The precedent is `cell-retry.ts`, the one existing call site that reads the status.

Materialized properties deliberately survive a failed start: the materializer upserts by source id at `status: "stale"` (retry maps to the same columns; deletion could strand a concurrent run's references), the pre-claimed table-run rows are exactly what a retried workflow writes findings into, and `reconcileStuckDocumentReviewRuns` ages abandoned rows to failed. Surfacing the error so the user retries is the durable-honesty fix; a start outbox would be new machinery no other caller has.

Tests: per handler, an outcome map `as const satisfies Record<WorkflowStartStatus, ...>` with the status union derived from `startWorkflow`'s return type, so adding a status forces a decision; retry-path assertions (failed → 500, second call re-queues the same property ids); fixtures pinned with `satisfies` against the materializer result types; one pre-existing mock updated to the real return shape.

The failure decision now lives once, in `lib/document-review/playbook-run-start.ts`, as a total `as const satisfies Record<WorkflowStartStatus, ...>` outcome map over `queued` / `deferred` / `not-started`, with `WORKFLOW_START_STATUSES` exported so a new start status cannot land without a decision, enforced by both the type and a test. Each surface then renders an outcome in its own idiom: 500 for the handlers, a retryable envelope for the MCP tool, `captureError` for the fire-and-forget classification trigger. The sole-caller structural test stays green and gained a per-surface assertion that every surface classifies. The claim release in `startWorkflow` is a compare-and-delete naming the request id, so a release after a Valkey failure can never drop a replacement run's claim.

Reported for follow-up, not taken: the same defect shape exists in the web flow (`workflow-start.ts` returns `{status:"failed"}` with HTTP 200 and `use-start-workflow.ts` discards it), deliberately out of scope here; and `already-running` maps to `deferred` rather than an error, following the documented classification-trigger rationale, while the straggler catch-up that justifies it skips scoped runs — a real staleness window, now a one-entry change in the outcome map whenever that decision is taken.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Playbook runs now report an error when workflow starting fails, rather than incorrectly indicating success.
  * Added retryable error responses for workflow start failures in knowledge tools.
  * Failed workflow starts now release any claimed locks, preventing stuck runs.
  * Successful, skipped and already-running workflows continue to return their expected results.

* **Tests**
  * Expanded coverage for workflow failure, retry, skipped and already-running scenarios.
  * Verified retries reuse the same prepared run data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
