### PR TITLE
fix(workspaces): read the matter cap from the contract, not the response

### DIFF
--- a/apps/api/src/handlers/workspaces/list.ts
+++ b/apps/api/src/handlers/workspaces/list.ts
@@ -209,10 +209,7 @@ const readWorkspaces = createSafeRootHandler(
       };
     });
 
-    return Result.ok({
-      workspaces,
-      workspacesCountLimit: LIMITS.workspacesCount,
-    });
+    return Result.ok({ workspaces });
   },
 );
 

--- a/apps/api/src/handlers/workspaces/read-navigation.test.ts
+++ b/apps/api/src/handlers/workspaces/read-navigation.test.ts
@@ -112,7 +112,6 @@ describe("workspace navigation pagination", () => {
         expect.objectContaining({ name: "Appeal", status: "archived" }),
         expect.objectContaining({ name: "Merger", status: "active" }),
       ],
-      workspacesCountLimit: 1000,
     });
   });
 

--- a/apps/api/src/handlers/workspaces/read-navigation.ts
+++ b/apps/api/src/handlers/workspaces/read-navigation.ts
@@ -135,10 +135,9 @@ const readWorkspaceNavigation = createSafeRootHandler(
       items,
       limit: page.limit,
       nextCursor: page.nextCursor,
-      // Compatibility fields for active navigation consumers. The memory
+      // Compatibility field for active navigation consumers. The memory
       // picker reads the standard page fields above and follows nextCursor.
       workspaces: items,
-      workspacesCountLimit: LIMITS.workspacesCount,
     });
   },
 );

--- a/apps/api/src/lib/limits.ts
+++ b/apps/api/src/lib/limits.ts
@@ -4,6 +4,7 @@ import {
   ENTITIES_PER_WORKSPACE_MAX,
   FLOW_RUN_INPUT_ENTITIES_MAX,
   PROPERTIES_PER_WORKSPACE_MAX,
+  WORKSPACES_PER_ORGANIZATION_MAX,
 } from "@stll/api-contract";
 import {
   CHAT_CONTEXT_FILE_MAX_BYTES,
@@ -28,7 +29,7 @@ export const LIMITS = {
   legalListGenerationRunsPageSizeMax: 100,
   legalListActivityPageSizeDefault: 50,
   legalListActivityPageSizeMax: 200,
-  workspacesCount: 1000,
+  workspacesCount: WORKSPACES_PER_ORGANIZATION_MAX,
   workspaceNavigationPageSizeDefault: 100,
   workspaceNavigationPageSizeMax: 1000,
   propertiesCount: PROPERTIES_PER_WORKSPACE_MAX,

--- a/apps/web/src/lib/memory-api.test.ts
+++ b/apps/web/src/lib/memory-api.test.ts
@@ -64,7 +64,6 @@ describe("memory API boundary", () => {
         limit: 100,
         nextCursor: null,
         workspaces: [workspaceNavigationItem],
-        workspacesCountLimit: 1000,
       }),
     );
 

--- a/apps/web/src/lib/workspaces/queries.ts
+++ b/apps/web/src/lib/workspaces/queries.ts
@@ -87,7 +87,6 @@ export const workspacesRouteOptions = (activeOrganizationId: string) =>
 
 type WorkspaceNavigationData = {
   workspaces: WorkspaceNavigationItem[];
-  workspacesCountLimit: number;
 };
 
 export const workspacesNavigationOptions = (activeOrganizationId: string) =>
@@ -99,10 +98,7 @@ export const workspacesNavigationOptions = (activeOrganizationId: string) =>
         statusScope: WORKSPACE_NAVIGATION_STATUS_SCOPE.ACTIVE,
       });
 
-      return {
-        workspaces: page.workspaces,
-        workspacesCountLimit: page.workspacesCountLimit,
-      } satisfies WorkspaceNavigationData;
+      return { workspaces: page.workspaces } satisfies WorkspaceNavigationData;
     },
     staleTime: ROUTE_QUERY_STALE_TIME_MS,
   });

--- a/apps/web/src/routes/_protected.workspaces/-components/matters-toolbar.tsx
+++ b/apps/web/src/routes/_protected.workspaces/-components/matters-toolbar.tsx
@@ -12,6 +12,7 @@ import {
 import { useTranslations } from "use-intl";
 import { useShallow } from "zustand/shallow";
 
+import { WORKSPACES_PER_ORGANIZATION_MAX } from "@stll/api-contract";
 import { Button } from "@stll/ui/components/button";
 import { Input } from "@stll/ui/components/input";
 import {
@@ -197,7 +198,8 @@ const CreateMatterPopover = ({ className }: CreateMatterPopoverProps) => {
     return null;
   }
 
-  const isLimitReached = data.workspaces.length >= data.workspacesCountLimit;
+  const isLimitReached =
+    data.workspaces.length >= WORKSPACES_PER_ORGANIZATION_MAX;
   if (isLimitReached) {
     return null;
   }

--- a/apps/web/src/routes/_protected.workspaces/index.tsx
+++ b/apps/web/src/routes/_protected.workspaces/index.tsx
@@ -15,6 +15,7 @@ import { useTranslations } from "use-intl";
 import * as v from "valibot";
 import { useShallow } from "zustand/shallow";
 
+import { WORKSPACES_PER_ORGANIZATION_MAX } from "@stll/api-contract";
 import { Button } from "@stll/ui/components/button";
 import { Frame } from "@stll/ui/components/frame";
 import { Input } from "@stll/ui/components/input";
@@ -171,7 +172,7 @@ const MattersContent = ({
 
   const workspaces = data.workspaces;
   const canOpenCreateMatter =
-    canCreateMatter && workspaces.length < data.workspacesCountLimit;
+    canCreateMatter && workspaces.length < WORKSPACES_PER_ORGANIZATION_MAX;
 
   const searched = workspaces.filter((w) => {
     if (!search.trim()) {

--- a/packages/api-contract/src/index.ts
+++ b/packages/api-contract/src/index.ts
@@ -167,6 +167,7 @@ export {
   ENTITIES_PER_WORKSPACE_MAX,
   FLOW_RUN_INPUT_ENTITIES_MAX,
   PROPERTIES_PER_WORKSPACE_MAX,
+  WORKSPACES_PER_ORGANIZATION_MAX,
 } from "./limits";
 export { GLOBAL_SEARCH_RESULT_TYPES } from "./search";
 export type { GlobalSearchResultType } from "./search";

--- a/packages/api-contract/src/limits.ts
+++ b/packages/api-contract/src/limits.ts
@@ -22,6 +22,12 @@ export const AGENT_SKILLS_CHAT_METADATA_MAX = 200;
 export const DOCX_SUGGESTIONS_PAGE_SIZE_MAX = 200;
 
 /**
+ * Per-organization cap on matters (workspaces), enforced on create. The client
+ * hides "new matter" surfaces at the cap.
+ */
+export const WORKSPACES_PER_ORGANIZATION_MAX = 1000;
+
+/**
  * Max properties (columns) one matter may define. The client disables the
  * add-column affordances at the cap; the server rejects past it.
  */


### PR DESCRIPTION
Completes what #1971 started: `workspacesCountLimit` was the last compile-time constant shipped in a response body (workspace list and navigation reads). The cap now lives in `@stll/api-contract` as `WORKSPACES_PER_ORGANIZATION_MAX` (matching the naming #1971 established), `LIMITS.workspacesCount` derives from it, both response builders drop the field, and the two client call sites import the constant. After this, no compile-time constant travels on the wire.