### PR TITLE
fix: use CLA system CA workflow

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -38,7 +38,7 @@ jobs:
           || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA'
         )
       )
-    uses: stella/.github/.github/workflows/cla.yml@719d2b11068a1e309b0abfa2e3850fff693d4897
+    uses: stella/.github/.github/workflows/cla.yml@80873456a2af7243e09228a08456250d1e938972
     with:
       allowlist: dependabot[bot],renovate[bot],github-actions[bot],google-labs-jules[bot],stella-provenance-updater[bot],cursoragent,claude
     secrets:


### PR DESCRIPTION
Advance the immutable shared CLA workflow reference to the revision that runs the archived action's forced Node 24 process with the runner system CA store. This activates strict certificate-verified TLS compatibility for CLA checks.

Validation:
- Verified the referenced reusable workflow contains `NODE_OPTIONS: "--use-system-ca"`
- Pre-push affected checks passed

CC on behalf of jan-kubica