### PR TITLE
fix(entities): abort partially copied trees instead of committing them

### DIFF
--- a/apps/api/src/db/safe-db.ts
+++ b/apps/api/src/db/safe-db.ts
@@ -3,7 +3,7 @@ import type { UnhandledException } from "better-result";
 
 import type { Transaction } from "@/api/db/root";
 import type { SafeDbRetryConfig as BaseSafeDbRetryConfig } from "@/api/db/scoped";
-import { DatabaseError } from "@/api/lib/errors/tagged-errors";
+import { DatabaseError, HandlerError } from "@/api/lib/errors/tagged-errors";
 import type { DatabaseRlsError } from "@/api/lib/errors/tagged-errors";
 import { PG_ERROR } from "@/api/lib/pg-error";
 
@@ -39,6 +39,21 @@ export type SafeDb = <T>(
 export type SafeDbOrTx =
   | { safeDb: SafeDb; tx?: undefined }
   | { safeDb?: undefined; tx: Transaction };
+
+/**
+ * Recover the failure a transaction callback threw to abort itself.
+ *
+ * Returning a failure value from a transaction callback commits everything the
+ * callback has already written, so a business failure found mid-transaction
+ * has to throw instead. The scoped factories wrap anything the callback throws
+ * that is not a driver error in `UnhandledException`, so the thrown
+ * `HandlerError` travels as its cause and this returns it unchanged; a genuine
+ * database failure passes through as the error it already was.
+ */
+export const transactionAbortError = (
+  error: SafeDbError,
+): HandlerError | SafeDbError =>
+  HandlerError.is(error.cause) ? error.cause : error;
 
 export const withScopedTx = async <T>(
   handle: SafeDbOrTx,

--- a/apps/api/src/handlers/entities/copy-to-workspace.test.ts
+++ b/apps/api/src/handlers/entities/copy-to-workspace.test.ts
@@ -19,8 +19,10 @@ const arrayBufferMock = mock(async () =>
   ),
 );
 const fileMock = mock(() => ({ arrayBuffer: arrayBufferMock }));
-const writeMock = mock(async () => undefined);
-const s3DeleteMock = mock(async () => undefined);
+// Typed by their first argument so a test can read back the object keys the
+// copy wrote and the keys the rollback returned.
+const writeMock = mock(async (_key: string) => undefined);
+const s3DeleteMock = mock(async (_key: string) => undefined);
 
 // Spread the real module: mock.module is process-global; a partial mock would delete s3's other exports for later test files.
 const realS3 = await import("@/api/lib/s3");
@@ -1487,6 +1489,93 @@ describe("copy-to-workspace", () => {
       });
       expect("placeholder" in copiedField.content).toBe(false);
     }
+  });
+
+  test("returns every object copied for an aborted cross-matter copy", async () => {
+    const insertedEntities: InsertedEntity[] = [];
+    const sourceEntity = {
+      id: documentId,
+      kind: "document" as const,
+      name: "Doc.pdf",
+      parentId: null,
+      readOnly: false,
+      currentVersion: {
+        id: toSafeId<"entityVersion">("v1"),
+        fields: [{ propertyId: sourceFilePropertyId, content: fileContent }],
+      },
+    };
+
+    // The handler reads the source first; the copy then reads the target
+    // parent, which turns out to be a document rather than a folder.
+    let entityReadCount = 0;
+    const tx = {
+      query: {
+        entities: {
+          findFirst: async () => {
+            entityReadCount += 1;
+            return entityReadCount === 1
+              ? sourceEntity
+              : { kind: "document" as const };
+          },
+          findMany: async () => [sourceEntity],
+        },
+        properties: {
+          findMany: async (opts: {
+            where: { workspaceId: { eq: string } };
+          }) => [
+            {
+              id:
+                opts.where.workspaceId.eq === sourceWorkspaceId
+                  ? sourceFilePropertyId
+                  : targetFilePropertyId,
+              name: "Source File",
+              content: filePropertyContent,
+              system: true,
+            },
+          ],
+        },
+        workspaces: { findFirst: async () => ({ reference: null }) },
+      },
+      $count: async () => 0,
+      select: () => ({ from: () => ({ where: async () => [] }) }),
+      insert: (table: unknown) => ({
+        values: (value: unknown) => {
+          if (table === entities && isInsertedEntity(value)) {
+            insertedEntities.push(value);
+          }
+          return undefined;
+        },
+      }),
+      update: () => ({ set: () => ({ where: async () => {} }) }),
+    };
+
+    const { safeDb } = createScopedDbMock(tx);
+    const result = await copyToWorkspace.handler(
+      createContext({
+        safeDb,
+        entityId: documentId,
+        targetParentId: folderId,
+      }),
+    );
+
+    // The abort travels as the same rejection the caller always answered.
+    expect(result).toMatchObject({
+      code: 400,
+      response: { message: "Target parent must be a folder" },
+    });
+    expect(insertedEntities).toHaveLength(0);
+
+    // No row survives the abort, so every object copied for it is an orphan
+    // and all of them go back.
+    const copiedKeys = writeMock.mock.calls.map(([key]) => key);
+    const deletedKeys = s3DeleteMock.mock.calls.map(([key]) => key);
+    expect(copiedKeys).toHaveLength(1);
+    expect(new Set(deletedKeys)).toEqual(new Set(copiedKeys));
+
+    // Nothing is indexed for copies that no longer exist.
+    expect(enqueueEntitySearchRepairsMock).not.toHaveBeenCalled();
+    expect(flushEntitySearchRepairsMock).not.toHaveBeenCalled();
+    expect(processExtractionMock).not.toHaveBeenCalled();
   });
 
   test("rejects copy to same workspace", async () => {

--- a/apps/api/src/handlers/entities/copy-to-workspace.ts
+++ b/apps/api/src/handlers/entities/copy-to-workspace.ts
@@ -6,6 +6,7 @@ import { t } from "elysia";
 import { RESOURCE_TYPE } from "@stll/api-contract";
 
 import type { SafeDb } from "@/api/db/safe-db";
+import { transactionAbortError } from "@/api/db/safe-db";
 import { entities, workspaces } from "@/api/db/schema";
 import {
   collectFileCopySources,
@@ -489,10 +490,6 @@ const copyToWorkspaceHandler = async function* ({
       deleteSource,
     });
 
-    if (!copyResult.ok) {
-      return copyResult;
-    }
-
     // For move operations, delete source entities in the same transaction
     if (deleteSource) {
       // Delete in reverse order (children first) to respect FK constraints.
@@ -526,19 +523,15 @@ const copyToWorkspaceHandler = async function* ({
     return copyResult;
   });
 
+  // An aborted copy leaves no rows in the target and no deletions in the
+  // source, so every object copied for it is an orphan and the whole set
+  // goes back.
   if (Result.isError(txResultResult)) {
     await rollbackS3Copies(copiedS3Keys);
-    return Result.err(txResultResult.error);
+    return Result.err(transactionAbortError(txResultResult.error));
   }
 
   const txResult = txResultResult.value;
-
-  if (!txResult.ok) {
-    await rollbackS3Copies(copiedS3Keys);
-    return Result.err(
-      new HandlerError({ status: txResult.status, message: txResult.message }),
-    );
-  }
 
   if (deleteSource) {
     await cleanupMovedSourceFiles({

--- a/apps/api/src/handlers/entities/copy-utils.db.test.ts
+++ b/apps/api/src/handlers/entities/copy-utils.db.test.ts
@@ -1,0 +1,242 @@
+import { Result } from "better-result";
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import { eq, inArray, sql } from "drizzle-orm";
+
+import { organization, user } from "@/api/db/auth-schema";
+import type { Transaction } from "@/api/db/root";
+import { transactionAbortError } from "@/api/db/safe-db";
+import {
+  entities,
+  entityVersions,
+  fields,
+  properties,
+  searchProjectionRepairQueue,
+  workspaces,
+} from "@/api/db/schema";
+import type { AuditRecorder } from "@/api/lib/audit-log";
+import { toSafeId } from "@/api/lib/branded-types";
+import type { SafeId } from "@/api/lib/branded-types";
+import { HandlerError } from "@/api/lib/errors/tagged-errors";
+import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
+import { getTestDb, releaseTestDb } from "@/api/tests/security/test-utils";
+import type {
+  TestDatabase,
+  TestDatabaseTransaction,
+} from "@/api/tests/security/test-utils";
+
+import { copyEntities } from "./copy-utils";
+import type { WritableEntitySnapshot } from "./copy-utils";
+
+/**
+ * `copyEntities` runs inside its caller's transaction, so how it reports a
+ * rejection decides what survives it: returning a failure commits every row
+ * written before the rejection, throwing aborts the transaction. Only a real
+ * transaction can tell the two apart, which is what this suite is for — a
+ * subtree that fails on its third entity must leave nothing behind, because
+ * the caller then deletes the storage objects those rows would point at.
+ */
+
+let testDb: TestDatabase;
+const seededOrganizationIds: SafeId<"organization">[] = [];
+
+beforeAll(
+  async () => {
+    testDb = await getTestDb();
+  },
+  { timeout: 30_000 },
+);
+
+afterAll(async () => {
+  if (seededOrganizationIds.length > 0) {
+    await testDb
+      .delete(organization)
+      .where(inArray(organization.id, seededOrganizationIds));
+  }
+  await releaseTestDb();
+});
+
+type SeededMatter = {
+  organizationId: SafeId<"organization">;
+  userId: SafeId<"user">;
+  workspaceId: SafeId<"workspace">;
+  propertyId: SafeId<"property">;
+};
+
+const seedMatter = async (): Promise<SeededMatter> => {
+  const organizationId = toSafeId<"organization">(`org_${Bun.randomUUIDv7()}`);
+  const userId = toSafeId<"user">(`user_${Bun.randomUUIDv7()}`);
+  const workspaceId = toSafeId<"workspace">(Bun.randomUUIDv7());
+  const propertyId = toSafeId<"property">(Bun.randomUUIDv7());
+
+  await testDb.transaction(async (tx: TestDatabaseTransaction) => {
+    await tx.execute(sql.raw("RESET ROLE"));
+    await tx.insert(organization).values({
+      id: organizationId,
+      name: "Copy abort matter",
+      slug: `copy-abort-${Bun.randomUUIDv7()}`,
+      createdAt: new Date(),
+    });
+    await tx.insert(user).values({
+      id: userId,
+      name: "Copy Abort User",
+      email: `${userId}@example.test`,
+    });
+    await tx.insert(workspaces).values({
+      id: workspaceId,
+      organizationId,
+      name: "Copy abort matter",
+      reference: Bun.randomUUIDv7().slice(0, 8),
+    });
+    await tx.insert(properties).values({
+      id: propertyId,
+      workspaceId,
+      name: "Summary",
+      content: { type: "text", version: 1 },
+      tool: { type: "manual-input", version: 1 },
+      status: "fresh",
+    });
+  });
+
+  seededOrganizationIds.push(organizationId);
+  return { organizationId, propertyId, userId, workspaceId };
+};
+
+const rootId = toSafeId<"entity">("source_root_folder");
+const documentId = toSafeId<"entity">("source_document");
+const lastId = toSafeId<"entity">("source_last_document");
+
+/**
+ * A three-entity subtree in copy order. `lastVersion: null` is the mid-loop
+ * rejection: the root and the document are already written when the third
+ * entity turns out to have no current version.
+ */
+const subtree = ({
+  propertyId,
+  lastVersion,
+}: {
+  propertyId: SafeId<"property">;
+  lastVersion: WritableEntitySnapshot["currentVersion"];
+}): WritableEntitySnapshot[] => [
+  {
+    id: rootId,
+    kind: "folder",
+    name: "Pleadings",
+    parentId: null,
+    currentVersion: { fields: [] },
+  },
+  {
+    id: documentId,
+    kind: "document",
+    name: "Statement of claim.docx",
+    parentId: rootId,
+    currentVersion: {
+      fields: [
+        {
+          propertyId,
+          content: { version: 1, type: "text", value: "Filed 2026-01-08" },
+        },
+      ],
+    },
+  },
+  {
+    id: lastId,
+    kind: "document",
+    name: "Exhibit A.docx",
+    parentId: rootId,
+    currentVersion: lastVersion,
+  },
+];
+
+const noAuditRows: AuditRecorder = async () => undefined;
+
+const runCopy = async (
+  matter: SeededMatter,
+  sources: WritableEntitySnapshot[],
+) =>
+  await Result.tryPromise(
+    async () =>
+      await testDb.transaction(async (tx: TestDatabaseTransaction) => {
+        await tx.execute(sql.raw("RESET ROLE"));
+        return await copyEntities({
+          tx: asTestRaw<Transaction>(tx),
+          targetWorkspaceId: matter.workspaceId,
+          targetParentId: null,
+          userId: matter.userId,
+          recordAuditEvent: noAuditRows,
+          sourceEntityId: rootId,
+          sourceEntities: sources,
+          deleteSource: false,
+        });
+      }),
+  );
+
+const persistedCounts = async (matter: SeededMatter) => ({
+  entities: await testDb.$count(
+    entities,
+    eq(entities.workspaceId, matter.workspaceId),
+  ),
+  entityVersions: await testDb.$count(
+    entityVersions,
+    eq(entityVersions.workspaceId, matter.workspaceId),
+  ),
+  fields: await testDb.$count(
+    fields,
+    eq(fields.workspaceId, matter.workspaceId),
+  ),
+  searchMarks: await testDb.$count(
+    searchProjectionRepairQueue,
+    eq(searchProjectionRepairQueue.organizationId, matter.organizationId),
+  ),
+});
+
+// The control: without it, "nothing was written" would also pass on a copy
+// that writes nothing at all.
+test("a complete subtree commits every copied row", async () => {
+  const matter = await seedMatter();
+
+  const outcome = await runCopy(
+    matter,
+    subtree({ propertyId: matter.propertyId, lastVersion: { fields: [] } }),
+  );
+
+  expect(Result.isOk(outcome)).toBe(true);
+  expect(await persistedCounts(matter)).toEqual({
+    entities: 3,
+    entityVersions: 3,
+    fields: 1,
+    searchMarks: 3,
+  });
+});
+
+test("a subtree that fails mid-loop persists no copy at all", async () => {
+  const matter = await seedMatter();
+
+  const outcome = await runCopy(
+    matter,
+    subtree({ propertyId: matter.propertyId, lastVersion: null }),
+  );
+
+  expect(Result.isError(outcome)).toBe(true);
+  if (!Result.isError(outcome)) {
+    throw new TypeError("Expected the copy transaction to abort");
+  }
+
+  // The rejection the handlers answer with is unchanged by the abort: it
+  // reaches them as the same 400 it always was.
+  const abort = transactionAbortError(outcome.error);
+  expect(HandlerError.is(abort)).toBe(true);
+  if (!HandlerError.is(abort)) {
+    throw new Error("Expected a HandlerError to abort the copy transaction");
+  }
+  expect(abort.status).toBe(400);
+  expect(abort.message).toBe("Entity has no current version");
+
+  // The two entities written before the rejection are gone with it, and so
+  // are their versions, fields, and search marks.
+  expect(await persistedCounts(matter)).toEqual({
+    entities: 0,
+    entityVersions: 0,
+    fields: 0,
+    searchMarks: 0,
+  });
+});

--- a/apps/api/src/handlers/entities/copy-utils.ts
+++ b/apps/api/src/handlers/entities/copy-utils.ts
@@ -11,6 +11,7 @@ import { createSafeId } from "@/api/lib/branded-types";
 import type { SafeId } from "@/api/lib/branded-types";
 import { allocateEntityStamp } from "@/api/lib/document-counter";
 import { lockWorkspacesForEntityCap } from "@/api/lib/entity-cap-lock";
+import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import { escapeLike } from "@/api/lib/escape-like";
 import {
   allocateFileObject,
@@ -456,14 +457,7 @@ export const getFolderSubtree = (
   return subtree;
 };
 
-type CopyEntitiesErrorResult = {
-  ok: false;
-  status: 400 | 404 | 500;
-  message: string;
-};
-
-type CopyEntitiesSuccessResult = {
-  ok: true;
+export type CopyEntitiesResult = {
   entityId: SafeId<"entity">;
   /**
    * The copies grouped by which mechanism writes their search projection.
@@ -476,10 +470,6 @@ type CopyEntitiesSuccessResult = {
   /** File fields that may need PDF derivative generation. */
   fileFields: CopiedFileField[];
 };
-
-export type CopyEntitiesResult =
-  | CopyEntitiesErrorResult
-  | CopyEntitiesSuccessResult;
 
 type CopyEntitiesProps = {
   tx: Transaction;
@@ -510,6 +500,15 @@ type CopyEntitiesProps = {
 /**
  * Copy entities to a target workspace. Used by both duplicate
  * (same workspace) and copy-to-workspace (cross-workspace).
+ *
+ * Every rejection throws a `HandlerError` rather than returning one. This runs
+ * inside the caller's transaction, and returning from a transaction callback
+ * commits whatever it has already written: a rejection raised part-way through
+ * the loop would persist a partially copied subtree, and the caller would then
+ * delete the copied objects those committed rows point at. Throwing aborts the
+ * transaction, so no copy survives and every copied object is an orphan the
+ * caller cleans up. Callers recover the thrown error with
+ * `transactionAbortError` and answer with it unchanged.
  */
 export const copyEntities = async ({
   tx,
@@ -546,11 +545,10 @@ export const copyEntities = async ({
   );
 
   if (entityCount + sourceEntities.length > LIMITS.entitiesCount) {
-    return {
-      ok: false,
+    throw new HandlerError({
       status: 400,
       message: "Entities limit reached",
-    };
+    });
   }
 
   // Validate target parent for cross-workspace copy only.
@@ -565,19 +563,17 @@ export const copyEntities = async ({
     });
 
     if (!parent) {
-      return {
-        ok: false,
+      throw new HandlerError({
         status: 400,
         message: "Target parent folder not found",
-      };
+      });
     }
 
     if (parent.kind !== "folder") {
-      return {
-        ok: false,
+      throw new HandlerError({
         status: 400,
         message: "Target parent must be a folder",
-      };
+      });
     }
   }
 
@@ -595,11 +591,10 @@ export const copyEntities = async ({
 
   for (const source of sourceEntities) {
     if (!source.currentVersion) {
-      return {
-        ok: false,
+      throw new HandlerError({
         status: 400,
         message: "Entity has no current version",
-      };
+      });
     }
 
     const newEntityId = createSafeId<"entity">();
@@ -614,11 +609,10 @@ export const copyEntities = async ({
       source.id === sourceEntityId ? targetParentId : mappedParentId;
 
     if (source.id !== sourceEntityId && newParentId === undefined) {
-      return {
-        ok: false,
+      throw new HandlerError({
         status: 500,
         message: "Copy parent was not created",
-      };
+      });
     }
 
     const copyName =
@@ -733,11 +727,10 @@ export const copyEntities = async ({
 
   const rootEntityId = idMap.get(sourceEntityId);
   if (!rootEntityId) {
-    return {
-      ok: false,
+    throw new HandlerError({
       status: 500,
       message: "Copy root was not created",
-    };
+    });
   }
 
   // Written here, inside the copy transaction: the mark commits or rolls back
@@ -748,7 +741,6 @@ export const copyEntities = async ({
   );
 
   return {
-    ok: true,
     entityId: rootEntityId,
     entityIdsBySearchIndexOwner: copiedEntityIds,
     copiedEntities,

--- a/apps/api/src/handlers/entities/duplicate.test.ts
+++ b/apps/api/src/handlers/entities/duplicate.test.ts
@@ -46,8 +46,10 @@ void mock.module("@/api/lib/search/projection-repair-queue", () => ({
 }));
 
 const fileMock = mock(() => ({}));
-const writeMock = mock(async () => undefined);
-const s3DeleteMock = mock(async () => undefined);
+// Typed by their first argument so a test can read back the object keys the
+// copy wrote and the keys the rollback returned.
+const writeMock = mock(async (_key: string) => undefined);
+const s3DeleteMock = mock(async (_key: string) => undefined);
 
 // Spread the real module: mock.module is process-global; a partial mock would delete s3's other exports for later test files.
 const realS3 = await import("@/api/lib/s3");
@@ -298,5 +300,76 @@ describe("duplicate entity", () => {
       nestedDuplicate.id,
     ]);
     expect(flushEntitySearchRepairsMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("returns every object copied for an aborted duplicate", async () => {
+    processExtractionMock.mockClear();
+    enqueueEntitySearchRepairsMock.mockClear();
+    flushEntitySearchRepairsMock.mockClear();
+    writeMock.mockClear();
+    s3DeleteMock.mockClear();
+
+    // The nested folder is the third entity in copy order, so the root and
+    // the document (and the document's copied object) are already written
+    // when the copy rejects.
+    const brokenSubtree = [
+      ...sourceEntities.slice(0, 2),
+      {
+        id: nestedFolderId,
+        kind: "folder" as const,
+        name: "Nested",
+        parentId: rootFolderId,
+        currentVersion: null,
+      },
+    ];
+
+    const tx = {
+      query: {
+        entities: {
+          findFirst: async () => brokenSubtree.at(0),
+          findMany: async () => brokenSubtree,
+        },
+        workspaces: { findFirst: async () => ({ reference: null }) },
+      },
+      $count: async () => brokenSubtree.length,
+      select: () => ({
+        from: () => ({
+          where: async () =>
+            brokenSubtree.map((entity) => ({ name: entity.name })),
+        }),
+      }),
+      insert: (table: unknown) => ({
+        values: () =>
+          table === documentCounters
+            ? {
+                onConflictDoUpdate: () => ({
+                  returning: async () => [{ lastValue: 1 }],
+                }),
+              }
+            : undefined,
+      }),
+      update: () => ({ set: () => ({ where: async () => {} }) }),
+    };
+
+    const { safeDb } = createScopedDbMock(tx);
+    const result = await duplicateEntity.handler(createContext({ safeDb }));
+
+    // The abort travels as the same rejection the caller always answered.
+    expect(result).toMatchObject({
+      code: 400,
+      response: { message: "Entity has no current version" },
+    });
+
+    // No row survives the abort, so every object copied for it is an orphan
+    // and all of them go back.
+    const copiedKeys = writeMock.mock.calls.map(([key]) => key);
+    const deletedKeys = s3DeleteMock.mock.calls.map(([key]) => key);
+    expect(copiedKeys).toHaveLength(1);
+    expect(new Set(deletedKeys)).toEqual(new Set(copiedKeys));
+
+    // Nothing is indexed for copies that no longer exist.
+    expect(enqueueEntitySearchRepairsMock).not.toHaveBeenCalled();
+    expect(flushEntitySearchRepairsMock).not.toHaveBeenCalled();
+    expect(processExtractionMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/handlers/entities/duplicate.ts
+++ b/apps/api/src/handlers/entities/duplicate.ts
@@ -3,6 +3,7 @@ import { t } from "elysia";
 import type { Static } from "elysia";
 
 import type { SafeDb } from "@/api/db/safe-db";
+import { transactionAbortError } from "@/api/db/safe-db";
 import {
   collectFileCopySources,
   copyEntities,
@@ -175,19 +176,14 @@ const duplicateEntityHandler = async function* ({
       }),
   );
 
+  // An aborted copy leaves no rows, so every object copied for it is an
+  // orphan and the whole set goes back.
   if (Result.isError(txResultResult)) {
     await rollbackS3Copies(copiedS3Keys);
-    return Result.err(txResultResult.error);
+    return Result.err(transactionAbortError(txResultResult.error));
   }
 
   const txResult = txResultResult.value;
-
-  if (!txResult.ok) {
-    await rollbackS3Copies(copiedS3Keys);
-    return Result.err(
-      new HandlerError({ status: txResult.status, message: txResult.message }),
-    );
-  }
 
   // Acceleration only: the marks are already committed, and the standing
   // drain repairs whatever a lost flush leaves behind.

--- a/apps/api/src/handlers/workspaces/duplicate.test.ts
+++ b/apps/api/src/handlers/workspaces/duplicate.test.ts
@@ -21,8 +21,10 @@ import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
 import { createScopedDbMock } from "@/api/tests/scoped-db-mock";
 
 const s3FileMock = mock((key: string) => ({ key }));
-const s3WriteMock = mock(async () => undefined);
-const s3DeleteMock = mock(async () => undefined);
+// Typed by their first argument so a test can read back the object keys the
+// duplicate wrote and the keys the cleanup returned.
+const s3WriteMock = mock(async (_key: string) => undefined);
+const s3DeleteMock = mock(async (_key: string) => undefined);
 
 // Spread the real module: mock.module is process-global; a partial mock would delete s3's other exports for later test files.
 const realS3 = await import("@/api/lib/s3");
@@ -769,6 +771,120 @@ describe("duplicateWorkspace", () => {
       copiedTaskId,
     ]);
     expect(processExtractionMock.mock.calls).toEqual([[copiedDocumentId]]);
+  });
+
+  test("returns every object copied for an aborted duplicate", async () => {
+    s3WriteMock.mockClear();
+    s3DeleteMock.mockClear();
+    enqueueEntitySearchRepairsMock.mockClear();
+    enqueueWorkspaceSearchRepairsMock.mockClear();
+
+    const filePropertyId = toSafeId<"property">("prop_file");
+    const insertedTables: unknown[] = [];
+
+    const { safeDb, scopedDb } = createScopedDbMock({
+      query: {
+        workspaces: {
+          findFirst: async () => ({
+            id: "ws_source123",
+            name: "Smith v Jones",
+            clientId: null,
+            billingReference: null,
+            color: null,
+            leadUserId: null,
+          }),
+        },
+        properties: {
+          findMany: async () => [
+            {
+              id: filePropertyId,
+              workspaceId: "ws_source123",
+              name: "Document",
+              status: "active",
+              content: { type: "file", version: 1 },
+              tool: null,
+              system: false,
+              kinds: ["document"],
+            },
+          ],
+        },
+        propertyDependencies: { findMany: async () => [] },
+        workspaceViews: { findMany: async () => [] },
+        workspaceMembers: { findMany: async () => [] },
+        workspaceContacts: { findMany: async () => [] },
+        organizationSettings: { findFirst: async () => null },
+        entities: {
+          findMany: async () => [
+            {
+              id: "entity_document",
+              kind: "document",
+              name: "evidence.png",
+              parentId: null,
+              currentVersion: {
+                id: "version_document",
+                fields: [
+                  {
+                    propertyId: filePropertyId,
+                    content: {
+                      type: "file",
+                      version: 1,
+                      id: "source-file-id",
+                      fileName: "evidence.png",
+                      mimeType: "image/png",
+                      sizeBytes: 1024,
+                      encrypted: false,
+                      sha256Hex: "a".repeat(64),
+                      pdfFileId: null,
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+      select: (selectedFields: Record<string, unknown>) =>
+        "total" in selectedFields
+          ? {
+              from: () => ({
+                where: async () => [{ total: LIMITS.workspacesCount }],
+              }),
+            }
+          : { from: () => ({ where: async () => [] }) },
+      insert: (table: unknown) => ({
+        values: () => {
+          insertedTables.push(table);
+          return {
+            onConflictDoUpdate: () => ({
+              returning: async () => [{ lastValue: 1 }],
+            }),
+          };
+        },
+      }),
+      update: () => ({ set: () => ({ where: async () => undefined }) }),
+      execute: async () => undefined,
+    });
+
+    const result = await duplicateWorkspace.handler(
+      createContext({ includeContent: true, safeDb, scopedDb }),
+    );
+
+    // The abort travels as the same rejection the caller always answered.
+    expect(result).toEqual({
+      code: 400,
+      response: { message: "Workspaces limit reached" },
+    });
+    expect(insertedTables).toEqual([]);
+
+    // No row survives the abort, so every object copied for it is an orphan
+    // and all of them go back.
+    const copiedKeys = s3WriteMock.mock.calls.map(([key]) => key);
+    const deletedKeys = s3DeleteMock.mock.calls.map(([key]) => key);
+    expect(copiedKeys).toHaveLength(1);
+    expect(new Set(deletedKeys)).toEqual(new Set(copiedKeys));
+
+    expect(enqueueEntitySearchRepairsMock).not.toHaveBeenCalled();
+    expect(enqueueWorkspaceSearchRepairsMock).not.toHaveBeenCalled();
   });
 
   test("rejects an oversized source before the duplicate writes anything", async () => {

--- a/apps/api/src/handlers/workspaces/duplicate.ts
+++ b/apps/api/src/handlers/workspaces/duplicate.ts
@@ -4,6 +4,7 @@ import { t } from "elysia";
 
 import { member } from "@/api/db/auth-schema";
 import { SETTING_WORKSPACE_IDS } from "@/api/db/rls";
+import { transactionAbortError } from "@/api/db/safe-db";
 import {
   entities,
   entityVersions,
@@ -496,10 +497,8 @@ const duplicateWorkspace = createSafeHandler(
       );
     }
 
-    // Checked before anything is written. The write transaction commits what
-    // it has already inserted when it returns a failure, so rejecting the
-    // source size from inside it would answer 400 and still leave the target
-    // matter, its properties, and its views behind.
+    // Checked before anything is written: the snapshot already carries the
+    // count, so the source size never has to reach the write transaction.
     if (snapshot.entities.length > LIMITS.entitiesCount) {
       return Result.err(
         new HandlerError({ status: 400, message: "Entities limit reached" }),
@@ -538,6 +537,10 @@ const duplicateWorkspace = createSafeHandler(
       }
     }
 
+    // Every rejection below throws rather than returning: returning from a
+    // transaction callback commits whatever it has already written, so a
+    // rejection raised part-way through would persist half a matter and then
+    // have the caller delete the objects those committed rows point at.
     const txResult = await safeDb(async (tx) => {
       const [countResult, duplicatedNames, settings, orgMembers] =
         await Promise.all([
@@ -582,19 +585,17 @@ const duplicateWorkspace = createSafeHandler(
 
       const activeCount = countResult.at(0)?.total ?? 0;
       if (activeCount >= LIMITS.workspacesCount) {
-        return {
-          ok: false as const,
-          status: 400 as const,
+        throw new HandlerError({
+          status: 400,
           message: "Workspaces limit reached",
-        };
+        });
       }
 
       if (orgMembers.length !== snapshot.members.length) {
-        return {
-          ok: false as const,
-          status: 400 as const,
+        throw new HandlerError({
+          status: 400,
           message: "Some users are not members of this organization",
-        };
+        });
       }
 
       const newName =
@@ -623,11 +624,10 @@ const duplicateWorkspace = createSafeHandler(
         .then((rows) => rows.at(0));
 
       if (!counter) {
-        return {
-          ok: false as const,
-          status: 500 as const,
+        throw new HandlerError({
+          status: 500,
           message: "Failed to create matter counter",
-        };
+        });
       }
 
       const reference = toReference({
@@ -757,11 +757,10 @@ const duplicateWorkspace = createSafeHandler(
       if (includeContent && entitiesToDuplicate.length > 0) {
         for (const source of entitiesToDuplicate) {
           if (!source.currentVersion) {
-            return {
-              ok: false as const,
-              status: 400 as const,
+            throw new HandlerError({
+              status: 400,
               message: "Entity has no current version",
-            };
+            });
           }
 
           const newEntityId = createSafeId<"entity">();
@@ -879,31 +878,19 @@ const duplicateWorkspace = createSafeHandler(
       await enqueueWorkspaceSearchRepairs(tx, [targetWorkspaceId]);
 
       return {
-        ok: true as const,
         workspaceId: targetWorkspaceId,
         entityIds: duplicatedEntityIds,
       };
     });
 
+    // An aborted duplicate leaves no target matter, so every object copied
+    // for it is an orphan and the whole set goes back.
     if (Result.isError(txResult)) {
       await cleanupCopiedS3Keys({
         copiedS3Keys,
         targetWorkspaceId,
       });
-      return Result.err(txResult.error);
-    }
-
-    if (!txResult.value.ok) {
-      await cleanupCopiedS3Keys({
-        copiedS3Keys,
-        targetWorkspaceId,
-      });
-      return Result.err(
-        new HandlerError({
-          status: txResult.value.status,
-          message: txResult.value.message,
-        }),
-      );
+      return Result.err(transactionAbortError(txResult.error));
     }
 
     // Both post-commit calls only accelerate what the transaction already


### PR DESCRIPTION
Returning a failure value from inside a transaction callback commits the transaction. `copyEntities` did this on three mid-loop paths (and its handlers on several pre-write checks), answering 400/500 while persisting a partially copied subtree whose storage objects the cleanup then deleted, leaving committed rows pointing at deleted bytes.

Failure paths inside the copy transactions now abort: they throw `HandlerError` (the established idiom, per the account-deletion transaction) and a shared `transactionAbortError` helper in `db/safe-db.ts` recovers the typed error from `safeDb`'s wrapper, so response shapes are unchanged. The failure branch is removed from `CopyEntitiesResult` entirely: the helper structurally cannot report a rejection except by aborting. The cleanup contract flips to correct: an abort persists nothing, so every copied object is an orphan and the existing full-set cleanup is now right where it previously deleted objects that committed rows referenced. The matter-duplicate handler gets the same treatment in a separate commit (hardening: its converted paths are unreachable today because null versions panic before the transaction opens; the commit message says so).

PGlite tests distinguish commit from rollback directly (control subtree commits 3/3/1/3 rows; mid-loop failure persists 0/0/0/0 with the response unchanged), and each handler suite pins that deleted keys equal copied keys on abort. Non-vacuity was probed both ways: catching the throw inside the callback fails the rollback test, and removing the recovery helper fails the response-mapping test.

A sweep found the same shape at eight more sites outside this subsystem (templates save/update, views create/update, properties create-batch, list acceptance, rates create, tasks update); they are recorded for a follow-up rather than widened into this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented partial workspace, entity and file copies when an operation fails.
  - Copied files are now fully removed when a duplication or cross-workspace copy is aborted.
  - Improved error handling so users receive the original, appropriate validation error.
  - Prevented search indexing and extraction tasks from being created for unsuccessful copies.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->