### PR TITLE
feat(db): composite tenant references and constraint-name integrity

### DIFF
--- a/apps/api/drizzle/20260813100000_workspace_tenant_pair_fks/migration.sql
+++ b/apps/api/drizzle/20260813100000_workspace_tenant_pair_fks/migration.sql
@@ -1,0 +1,99 @@
+SET LOCAL lock_timeout = '1s';--> statement-breakpoint
+SET LOCAL statement_timeout = '5s';--> statement-breakpoint
+
+-- Give every remaining dual-column workspace table the composite reference
+-- time_entries, office_file_evidence, and ai_memories already carry:
+--
+--   (workspace_id, organization_id) -> workspaces (id, organization_id)
+--
+-- A table that persists both columns states the same tenancy twice. Until now
+-- only the two halves were checked separately: workspace_id had to name a real
+-- workspace and organization_id a real organization, but nothing required the
+-- workspace to belong to that organization. The pair reference makes the
+-- disagreement unrepresentable, one layer below the org-pinned policies added
+-- in 20260812110000 and the organization references added in 20260812170000.
+-- It narrows nothing the application relies on: every writer already supplies
+-- both scopes from the same scoped transaction (apps/api/src/db/scoped.ts).
+--
+-- The referenced side is workspaces_id_org_unq, the UNIQUE (id,
+-- organization_id) constraint attached in 20260808008000.
+--
+-- ON DELETE mirrors each table's existing single-column workspace reference so
+-- the pair never contradicts it: CASCADE where the workspace reference
+-- cascades, RESTRICT for the two chat tables, whose rows are removed
+-- explicitly before the workspace row (apps/api/src/handlers/workspaces/
+-- delete.ts). Four tables with both columns are deliberately excluded:
+--
+--   audit_logs
+--     The matter-delete transaction removes the workspace row and then records
+--     the DELETE audit event for it. A reference from audit_logs to workspaces
+--     would abort that insert, so the table carries no workspace reference at
+--     all and its history outlives the matter it describes.
+--
+--   buffer_object_cleanup_intents, entity_deletion_cleanup_requests
+--     Storage-erasure outboxes. Each row is the only surviving record of which
+--     objects still have to be erased, so they reference no ancestor by
+--     design. Guarded by apps/api/src/db/schema/entities.test.ts.
+--
+--   usage_events
+--     Organization-owned metering ledger whose workspace_id is nullable
+--     attribution: the single-column reference is ON DELETE SET NULL so a row
+--     survives the matter it was attributed to. The pair would need
+--     ON DELETE SET NULL (workspace_id), a column list drizzle 1.0.0-rc.4
+--     cannot declare, so the migration and the model would disagree. Adding it
+--     becomes correct once that column list is expressible.
+--
+-- Every constraint is NOT VALID here: the ADD then takes a brief ACCESS
+-- EXCLUSIVE lock and writes catalog rows without scanning, and enforcement is
+-- immediate for new and updated rows. The existing rows are validated by the
+-- separate migrations that follow, each in its own migrator transaction, so a
+-- scan that times out is retryable and localized to one table.
+--
+-- Constraint names are explicit rather than drizzle-generated, and every one
+-- fits PostgreSQL's 63-byte identifier limit. Each statement is one line
+-- because squawk anchors a suppression to the line directly above the
+-- statement it reports.
+
+ALTER TABLE "anonymization_allowlist_entries" ADD CONSTRAINT "anonymization_allowlist_entries_workspace_organization_fk" FOREIGN KEY ("workspace_id", "organization_id") REFERENCES "workspaces" ("id", "organization_id") ON DELETE CASCADE NOT VALID;--> statement-breakpoint
+
+ALTER TABLE "anonymization_blacklist_entries" ADD CONSTRAINT "anonymization_blacklist_entries_workspace_organization_fk" FOREIGN KEY ("workspace_id", "organization_id") REFERENCES "workspaces" ("id", "organization_id") ON DELETE CASCADE NOT VALID;--> statement-breakpoint
+
+ALTER TABLE "billing_codes" ADD CONSTRAINT "billing_codes_workspace_organization_fk" FOREIGN KEY ("workspace_id", "organization_id") REFERENCES "workspaces" ("id", "organization_id") ON DELETE CASCADE NOT VALID;--> statement-breakpoint
+
+ALTER TABLE "chat_threads" ADD CONSTRAINT "chat_threads_workspace_organization_fk" FOREIGN KEY ("workspace_id", "organization_id") REFERENCES "workspaces" ("id", "organization_id") ON DELETE RESTRICT NOT VALID;--> statement-breakpoint
+
+ALTER TABLE "chat_turns" ADD CONSTRAINT "chat_turns_workspace_organization_fk" FOREIGN KEY ("workspace_id", "organization_id") REFERENCES "workspaces" ("id", "organization_id") ON DELETE RESTRICT NOT VALID;--> statement-breakpoint
+
+ALTER TABLE "document_processing_runs" ADD CONSTRAINT "document_processing_runs_workspace_organization_fk" FOREIGN KEY ("workspace_id", "organization_id") REFERENCES "workspaces" ("id", "organization_id") ON DELETE CASCADE NOT VALID;--> statement-breakpoint
+
+ALTER TABLE "document_review_findings" ADD CONSTRAINT "document_review_findings_workspace_organization_fk" FOREIGN KEY ("workspace_id", "organization_id") REFERENCES "workspaces" ("id", "organization_id") ON DELETE CASCADE NOT VALID;--> statement-breakpoint
+
+ALTER TABLE "document_review_runs" ADD CONSTRAINT "document_review_runs_workspace_organization_fk" FOREIGN KEY ("workspace_id", "organization_id") REFERENCES "workspaces" ("id", "organization_id") ON DELETE CASCADE NOT VALID;--> statement-breakpoint
+
+ALTER TABLE "entity_version_ai_summaries" ADD CONSTRAINT "entity_version_ai_summaries_workspace_organization_fk" FOREIGN KEY ("workspace_id", "organization_id") REFERENCES "workspaces" ("id", "organization_id") ON DELETE CASCADE NOT VALID;--> statement-breakpoint
+
+ALTER TABLE "expenses" ADD CONSTRAINT "expenses_workspace_organization_fk" FOREIGN KEY ("workspace_id", "organization_id") REFERENCES "workspaces" ("id", "organization_id") ON DELETE CASCADE NOT VALID;--> statement-breakpoint
+
+ALTER TABLE "extracted_content" ADD CONSTRAINT "extracted_content_workspace_organization_fk" FOREIGN KEY ("workspace_id", "organization_id") REFERENCES "workspaces" ("id", "organization_id") ON DELETE CASCADE NOT VALID;--> statement-breakpoint
+
+ALTER TABLE "extraction_runs" ADD CONSTRAINT "extraction_runs_workspace_organization_fk" FOREIGN KEY ("workspace_id", "organization_id") REFERENCES "workspaces" ("id", "organization_id") ON DELETE CASCADE NOT VALID;--> statement-breakpoint
+
+ALTER TABLE "file_chat_threads" ADD CONSTRAINT "file_chat_threads_workspace_organization_fk" FOREIGN KEY ("workspace_id", "organization_id") REFERENCES "workspaces" ("id", "organization_id") ON DELETE CASCADE NOT VALID;--> statement-breakpoint
+
+ALTER TABLE "invoices" ADD CONSTRAINT "invoices_workspace_organization_fk" FOREIGN KEY ("workspace_id", "organization_id") REFERENCES "workspaces" ("id", "organization_id") ON DELETE CASCADE NOT VALID;--> statement-breakpoint
+
+ALTER TABLE "pending_uploads" ADD CONSTRAINT "pending_uploads_workspace_organization_fk" FOREIGN KEY ("workspace_id", "organization_id") REFERENCES "workspaces" ("id", "organization_id") ON DELETE CASCADE NOT VALID;--> statement-breakpoint
+
+ALTER TABLE "rate_tables" ADD CONSTRAINT "rate_tables_workspace_organization_fk" FOREIGN KEY ("workspace_id", "organization_id") REFERENCES "workspaces" ("id", "organization_id") ON DELETE CASCADE NOT VALID;--> statement-breakpoint
+
+ALTER TABLE "search_document_preview_passages" ADD CONSTRAINT "search_document_preview_passages_workspace_organization_fk" FOREIGN KEY ("workspace_id", "organization_id") REFERENCES "workspaces" ("id", "organization_id") ON DELETE CASCADE NOT VALID;--> statement-breakpoint
+
+ALTER TABLE "search_documents" ADD CONSTRAINT "search_documents_workspace_organization_fk" FOREIGN KEY ("workspace_id", "organization_id") REFERENCES "workspaces" ("id", "organization_id") ON DELETE CASCADE NOT VALID;--> statement-breakpoint
+
+ALTER TABLE "template_persistence_requests" ADD CONSTRAINT "template_persistence_requests_workspace_organization_fk" FOREIGN KEY ("workspace_id", "organization_id") REFERENCES "workspaces" ("id", "organization_id") ON DELETE CASCADE NOT VALID;--> statement-breakpoint
+
+ALTER TABLE "workspace_contacts" ADD CONSTRAINT "workspace_contacts_workspace_organization_fk" FOREIGN KEY ("workspace_id", "organization_id") REFERENCES "workspaces" ("id", "organization_id") ON DELETE CASCADE NOT VALID;--> statement-breakpoint
+
+ALTER TABLE "workspace_search_document_preview_passages" ADD CONSTRAINT "workspace_search_document_preview_passages_workspace_org_fk" FOREIGN KEY ("workspace_id", "organization_id") REFERENCES "workspaces" ("id", "organization_id") ON DELETE CASCADE NOT VALID;--> statement-breakpoint
+
+ALTER TABLE "workspace_search_documents" ADD CONSTRAINT "workspace_search_documents_workspace_organization_fk" FOREIGN KEY ("workspace_id", "organization_id") REFERENCES "workspaces" ("id", "organization_id") ON DELETE CASCADE NOT VALID;

--- a/apps/api/drizzle/20260813100100_workspace_tenant_pair_validate_bounded/migration.sql
+++ b/apps/api/drizzle/20260813100100_workspace_tenant_pair_validate_bounded/migration.sql
@@ -1,0 +1,35 @@
+SET LOCAL lock_timeout = '1s';--> statement-breakpoint
+SET LOCAL statement_timeout = '30s';--> statement-breakpoint
+
+-- Validate the tenant-pair references added in 20260813100000 for the tables
+-- whose row count is bounded by tenant, matter, or billing-document count
+-- rather than by document volume. Eleven scans share one transaction because
+-- each is small; the tables that scale with the corpus get one migration each,
+-- so a timeout there names the table it happened on and is retried alone.
+--
+-- The split from the ADD is what matters: VALIDATE runs here in its own
+-- migrator transaction and takes SHARE UPDATE EXCLUSIVE, so it does not
+-- inherit the ACCESS EXCLUSIVE lock the ADD took and concurrent writers keep
+-- running. Same shape as 20260808008000 and 20260808009000 for ai_memories.
+
+ALTER TABLE "anonymization_allowlist_entries" VALIDATE CONSTRAINT "anonymization_allowlist_entries_workspace_organization_fk";--> statement-breakpoint
+
+ALTER TABLE "anonymization_blacklist_entries" VALIDATE CONSTRAINT "anonymization_blacklist_entries_workspace_organization_fk";--> statement-breakpoint
+
+ALTER TABLE "billing_codes" VALIDATE CONSTRAINT "billing_codes_workspace_organization_fk";--> statement-breakpoint
+
+ALTER TABLE "document_review_runs" VALIDATE CONSTRAINT "document_review_runs_workspace_organization_fk";--> statement-breakpoint
+
+ALTER TABLE "expenses" VALIDATE CONSTRAINT "expenses_workspace_organization_fk";--> statement-breakpoint
+
+ALTER TABLE "extraction_runs" VALIDATE CONSTRAINT "extraction_runs_workspace_organization_fk";--> statement-breakpoint
+
+ALTER TABLE "file_chat_threads" VALIDATE CONSTRAINT "file_chat_threads_workspace_organization_fk";--> statement-breakpoint
+
+ALTER TABLE "invoices" VALIDATE CONSTRAINT "invoices_workspace_organization_fk";--> statement-breakpoint
+
+ALTER TABLE "rate_tables" VALIDATE CONSTRAINT "rate_tables_workspace_organization_fk";--> statement-breakpoint
+
+ALTER TABLE "template_persistence_requests" VALIDATE CONSTRAINT "template_persistence_requests_workspace_organization_fk";--> statement-breakpoint
+
+ALTER TABLE "workspace_contacts" VALIDATE CONSTRAINT "workspace_contacts_workspace_organization_fk";

--- a/apps/api/drizzle/20260813100200_workspace_tenant_pair_validate_chat_threads/migration.sql
+++ b/apps/api/drizzle/20260813100200_workspace_tenant_pair_validate_chat_threads/migration.sql
@@ -1,0 +1,9 @@
+SET LOCAL lock_timeout = '5s';--> statement-breakpoint
+SET LOCAL statement_timeout = '5min';--> statement-breakpoint
+
+-- One row per conversation, across every user of every tenant, so the scan
+-- tracks chat use rather than tenant count. Its own migration: the scan runs
+-- in its own transaction under SHARE UPDATE EXCLUSIVE, and a timeout here
+-- fails this table alone and is retried by rerunning this migration.
+
+ALTER TABLE "chat_threads" VALIDATE CONSTRAINT "chat_threads_workspace_organization_fk";

--- a/apps/api/drizzle/20260813100300_workspace_tenant_pair_validate_chat_turns/migration.sql
+++ b/apps/api/drizzle/20260813100300_workspace_tenant_pair_validate_chat_turns/migration.sql
@@ -1,0 +1,9 @@
+SET LOCAL lock_timeout = '5s';--> statement-breakpoint
+SET LOCAL statement_timeout = '5min';--> statement-breakpoint
+
+-- One row per assistant turn, so it grows several times faster than
+-- chat_threads and is the largest chat table. Its own migration: the scan runs
+-- in its own transaction under SHARE UPDATE EXCLUSIVE, and a timeout here
+-- fails this table alone and is retried by rerunning this migration.
+
+ALTER TABLE "chat_turns" VALIDATE CONSTRAINT "chat_turns_workspace_organization_fk";

--- a/apps/api/drizzle/20260813100400_workspace_tenant_pair_validate_processing_runs/migration.sql
+++ b/apps/api/drizzle/20260813100400_workspace_tenant_pair_validate_processing_runs/migration.sql
@@ -1,0 +1,9 @@
+SET LOCAL lock_timeout = '5s';--> statement-breakpoint
+SET LOCAL statement_timeout = '5min';--> statement-breakpoint
+
+-- One row per OCR or native-extraction pass over a document, and a document
+-- can be reprocessed, so the scan tracks document volume. Its own migration:
+-- the scan runs in its own transaction under SHARE UPDATE EXCLUSIVE, and a
+-- timeout here fails this table alone and is retried by rerunning it.
+
+ALTER TABLE "document_processing_runs" VALIDATE CONSTRAINT "document_processing_runs_workspace_organization_fk";

--- a/apps/api/drizzle/20260813100500_workspace_tenant_pair_validate_review_findings/migration.sql
+++ b/apps/api/drizzle/20260813100500_workspace_tenant_pair_validate_review_findings/migration.sql
@@ -1,0 +1,10 @@
+SET LOCAL lock_timeout = '5s';--> statement-breakpoint
+SET LOCAL statement_timeout = '5min';--> statement-breakpoint
+
+-- One row per judgment per topic per check kind: a single review run writes
+-- many, so this table grows far faster than document_review_runs and is
+-- validated apart from it. Its own migration: the scan runs in its own
+-- transaction under SHARE UPDATE EXCLUSIVE, and a timeout here fails this
+-- table alone and is retried by rerunning it.
+
+ALTER TABLE "document_review_findings" VALIDATE CONSTRAINT "document_review_findings_workspace_organization_fk";

--- a/apps/api/drizzle/20260813100600_workspace_tenant_pair_validate_ai_summaries/migration.sql
+++ b/apps/api/drizzle/20260813100600_workspace_tenant_pair_validate_ai_summaries/migration.sql
@@ -1,0 +1,9 @@
+SET LOCAL lock_timeout = '5s';--> statement-breakpoint
+SET LOCAL statement_timeout = '5min';--> statement-breakpoint
+
+-- One row per document version per prompt version, so the scan tracks document
+-- volume multiplied by revision count. Its own migration: the scan runs in its
+-- own transaction under SHARE UPDATE EXCLUSIVE, and a timeout here fails this
+-- table alone and is retried by rerunning it.
+
+ALTER TABLE "entity_version_ai_summaries" VALIDATE CONSTRAINT "entity_version_ai_summaries_workspace_organization_fk";

--- a/apps/api/drizzle/20260813100700_workspace_tenant_pair_validate_extracted_content/migration.sql
+++ b/apps/api/drizzle/20260813100700_workspace_tenant_pair_validate_extracted_content/migration.sql
@@ -1,0 +1,10 @@
+SET LOCAL lock_timeout = '5s';--> statement-breakpoint
+SET LOCAL statement_timeout = '5min';--> statement-breakpoint
+
+-- One row per document, each carrying that document's encrypted text, so this
+-- is among the widest rows in the schema as well as one per corpus item. Its
+-- own migration: the scan runs in its own transaction under SHARE UPDATE
+-- EXCLUSIVE, and a timeout here fails this table alone and is retried by
+-- rerunning it.
+
+ALTER TABLE "extracted_content" VALIDATE CONSTRAINT "extracted_content_workspace_organization_fk";

--- a/apps/api/drizzle/20260813100800_workspace_tenant_pair_validate_pending_uploads/migration.sql
+++ b/apps/api/drizzle/20260813100800_workspace_tenant_pair_validate_pending_uploads/migration.sql
@@ -1,0 +1,10 @@
+SET LOCAL lock_timeout = '5s';--> statement-breakpoint
+SET LOCAL statement_timeout = '5min';--> statement-breakpoint
+
+-- One row per upload reservation, kept after finalization, so the table
+-- accumulates with every file ever uploaded rather than with the files that
+-- currently exist. Its own migration: the scan runs in its own transaction
+-- under SHARE UPDATE EXCLUSIVE, and a timeout here fails this table alone and
+-- is retried by rerunning it.
+
+ALTER TABLE "pending_uploads" VALIDATE CONSTRAINT "pending_uploads_workspace_organization_fk";

--- a/apps/api/drizzle/20260813100900_workspace_tenant_pair_validate_search_documents/migration.sql
+++ b/apps/api/drizzle/20260813100900_workspace_tenant_pair_validate_search_documents/migration.sql
@@ -1,0 +1,9 @@
+SET LOCAL lock_timeout = '5s';--> statement-breakpoint
+SET LOCAL statement_timeout = '5min';--> statement-breakpoint
+
+-- One row per indexed entity, so the scan tracks the whole tenant corpus. Its
+-- own migration: the scan runs in its own transaction under SHARE UPDATE
+-- EXCLUSIVE, and a timeout here fails this table alone and is retried by
+-- rerunning it.
+
+ALTER TABLE "search_documents" VALIDATE CONSTRAINT "search_documents_workspace_organization_fk";

--- a/apps/api/drizzle/20260813101000_workspace_tenant_pair_validate_preview_passages/migration.sql
+++ b/apps/api/drizzle/20260813101000_workspace_tenant_pair_validate_preview_passages/migration.sql
@@ -1,0 +1,10 @@
+SET LOCAL lock_timeout = '5s';--> statement-breakpoint
+SET LOCAL statement_timeout = '5min';--> statement-breakpoint
+
+-- One row per passage per indexed entity: the tenant corpus multiplied by
+-- passages per document, which makes this the largest table taking the pair
+-- reference. Its own migration: the scan runs in its own transaction under
+-- SHARE UPDATE EXCLUSIVE, and a timeout here fails this table alone and is
+-- retried by rerunning it.
+
+ALTER TABLE "search_document_preview_passages" VALIDATE CONSTRAINT "search_document_preview_passages_workspace_organization_fk";

--- a/apps/api/drizzle/20260813101100_workspace_tenant_pair_validate_ws_search_docs/migration.sql
+++ b/apps/api/drizzle/20260813101100_workspace_tenant_pair_validate_ws_search_docs/migration.sql
@@ -1,0 +1,10 @@
+SET LOCAL lock_timeout = '5s';--> statement-breakpoint
+SET LOCAL statement_timeout = '5min';--> statement-breakpoint
+
+-- One row per matter across every tenant, and the repair queue rewrites the
+-- projection in bulk, so the scan competes with a background writer rather
+-- than with ordinary traffic. Its own migration: the scan runs in its own
+-- transaction under SHARE UPDATE EXCLUSIVE, and a timeout here fails this
+-- table alone and is retried by rerunning it.
+
+ALTER TABLE "workspace_search_documents" VALIDATE CONSTRAINT "workspace_search_documents_workspace_organization_fk";

--- a/apps/api/drizzle/20260813101200_workspace_tenant_pair_validate_ws_preview_passages/migration.sql
+++ b/apps/api/drizzle/20260813101200_workspace_tenant_pair_validate_ws_preview_passages/migration.sql
@@ -1,0 +1,10 @@
+SET LOCAL lock_timeout = '5s';--> statement-breakpoint
+SET LOCAL statement_timeout = '5min';--> statement-breakpoint
+
+-- Passages per matter, rewritten in bulk by the same repair queue that feeds
+-- workspace_search_documents, so it is both larger than its parent and subject
+-- to the same background writer. Its own migration: the scan runs in its own
+-- transaction under SHARE UPDATE EXCLUSIVE, and a timeout here fails this
+-- table alone and is retried by rerunning it.
+
+ALTER TABLE "workspace_search_document_preview_passages" VALIDATE CONSTRAINT "workspace_search_document_preview_passages_workspace_org_fk";

--- a/apps/api/drizzle/20260813110000_constraint_name_truncation_repair/migration.sql
+++ b/apps/api/drizzle/20260813110000_constraint_name_truncation_repair/migration.sql
@@ -1,0 +1,50 @@
+SET LOCAL lock_timeout = '1s';--> statement-breakpoint
+SET LOCAL statement_timeout = '5s';--> statement-breakpoint
+
+-- Give eleven constraints a name PostgreSQL can actually store.
+--
+-- PostgreSQL truncates any identifier past 63 bytes. Eleven migrations asked
+-- for a longer constraint name, so what the catalog holds is the first 63
+-- bytes and what the schema declares is the full string. Nothing failed: the
+-- constraints work, and each is enforced exactly as intended. What broke is
+-- the agreement between the declared schema and the catalog, which is what
+-- `db:push --explain` reads to report drift and what any future statement
+-- naming one of these constraints would rely on.
+--
+-- Every rename below is FROM the truncated name, because that is the name the
+-- database has. The new names are explicit and short, in the same
+-- `<table>_<subject>_fk` form already used for the constraints that were named
+-- by hand, and the schema declarations are updated to match in the same
+-- change. Renaming a constraint rewrites one catalog row: no lock beyond the
+-- brief ACCESS EXCLUSIVE on the table, no scan, no data touched.
+--
+-- The class is closed by the ≤63-byte assertion in
+-- apps/api/src/tests/security/schema-invariants.test.ts, which fails on any
+-- new declaration that PostgreSQL would silently shorten.
+--
+-- Each statement is one line because squawk anchors a suppression to the line
+-- directly above the statement it reports.
+
+-- stella-migration-safety: reviewed destructive-change - every statement is a constraint rename, not a drop: the constraint keeps its columns, referenced table, and delete action, and only its catalog name changes to the value the schema already intends. Rollback is the inverse rename with the matching application revision.
+
+ALTER TABLE "anonymization_allowlist_entries" RENAME CONSTRAINT "anonymization_allowlist_entries_organization_id_organization_id" TO "anonymization_allowlist_entries_organization_fk";--> statement-breakpoint
+
+ALTER TABLE "anonymization_blacklist_entries" RENAME CONSTRAINT "anonymization_blacklist_entries_organization_id_organization_id" TO "anonymization_blacklist_entries_organization_fk";--> statement-breakpoint
+
+ALTER TABLE "cell_metadata" RENAME CONSTRAINT "cell_metadata_property_id_workspace_id_properties_id_workspace_" TO "cell_metadata_property_workspace_fk";--> statement-breakpoint
+
+ALTER TABLE "chat_thread_compactions" RENAME CONSTRAINT "chat_thread_compactions_first_kept_message_id_chat_messages_id_" TO "chat_thread_compactions_first_kept_message_fk";--> statement-breakpoint
+
+ALTER TABLE "chat_thread_compactions" RENAME CONSTRAINT "chat_thread_compactions_first_summarized_message_id_chat_messag" TO "chat_thread_compactions_first_summarized_message_fk";--> statement-breakpoint
+
+ALTER TABLE "chat_thread_compactions" RENAME CONSTRAINT "chat_thread_compactions_last_summarized_message_id_chat_message" TO "chat_thread_compactions_last_summarized_message_fk";--> statement-breakpoint
+
+ALTER TABLE "desktop_edit_handoffs" RENAME CONSTRAINT "desktop_edit_handoffs_desktop_session_id_desktop_edit_sessions_" TO "desktop_edit_handoffs_desktop_session_fk";--> statement-breakpoint
+
+ALTER TABLE "file_chat_threads" RENAME CONSTRAINT "file_chat_threads_entity_id_workspace_id_entities_id_workspace_" TO "file_chat_threads_entity_workspace_fk";--> statement-breakpoint
+
+ALTER TABLE "file_chat_threads" RENAME CONSTRAINT "file_chat_threads_field_id_workspace_id_fields_id_workspace_id_" TO "file_chat_threads_field_workspace_fk";--> statement-breakpoint
+
+ALTER TABLE "folio_collab_sessions" RENAME CONSTRAINT "folio_collab_sessions_finalized_version_id_entity_versions_id_f" TO "folio_collab_sessions_finalized_version_fk";--> statement-breakpoint
+
+ALTER TABLE "template_chat_threads" RENAME CONSTRAINT "template_chat_threads_template_id_organization_id_templates_id_" TO "template_chat_threads_template_organization_fk";

--- a/apps/api/src/db/schema/billing.ts
+++ b/apps/api/src/db/schema/billing.ts
@@ -133,6 +133,13 @@ export const billingCodes = p.pgTable(
   },
   (table) => [
     p
+      .foreignKey({
+        columns: [table.workspaceId, table.organizationId],
+        foreignColumns: [workspaces.id, workspaces.organizationId],
+        name: "billing_codes_workspace_organization_fk",
+      })
+      .onDelete("cascade"),
+    p
       .index("billing_codes_ws_type_active_idx")
       .on(table.workspaceId, table.type, table.active),
     p
@@ -160,6 +167,13 @@ export const rateTables = p.pgTable(
     updatedAt: timestamptz("updated_at").notNull().defaultNow(),
   },
   (table) => [
+    p
+      .foreignKey({
+        columns: [table.workspaceId, table.organizationId],
+        foreignColumns: [workspaces.id, workspaces.organizationId],
+        name: "rate_tables_workspace_organization_fk",
+      })
+      .onDelete("cascade"),
     p
       .index("rate_tables_ws_default_idx")
       .on(table.workspaceId, table.isDefault),
@@ -232,6 +246,13 @@ export const expenses = p.pgTable(
   },
   (table) => [
     p
+      .foreignKey({
+        columns: [table.workspaceId, table.organizationId],
+        foreignColumns: [workspaces.id, workspaces.organizationId],
+        name: "expenses_workspace_organization_fk",
+      })
+      .onDelete("cascade"),
+    p
       .index("expenses_ws_matter_status_idx")
       .on(table.workspaceId, table.matterId, table.status),
     p
@@ -273,6 +294,13 @@ export const invoices = p.pgTable(
     updatedAt: timestamptz("updated_at").notNull().defaultNow(),
   },
   (table) => [
+    p
+      .foreignKey({
+        columns: [table.workspaceId, table.organizationId],
+        foreignColumns: [workspaces.id, workspaces.organizationId],
+        name: "invoices_workspace_organization_fk",
+      })
+      .onDelete("cascade"),
     p.index("invoices_ws_status_idx").on(table.workspaceId, table.status),
     p
       .uniqueIndex("invoices_ws_number_uidx")

--- a/apps/api/src/db/schema/chat.ts
+++ b/apps/api/src/db/schema/chat.ts
@@ -566,12 +566,14 @@ export const fileChatThreads = p.pgTable(
       .foreignKey({
         columns: [table.entityId, table.workspaceId],
         foreignColumns: [entities.id, entities.workspaceId],
+        name: "file_chat_threads_entity_workspace_fk",
       })
       .onDelete("cascade"),
     p
       .foreignKey({
         columns: [table.fieldId, table.workspaceId],
         foreignColumns: [fields.id, fields.workspaceId],
+        name: "file_chat_threads_field_workspace_fk",
       })
       .onDelete("cascade"),
     ...fileChatThreadPolicies(),
@@ -616,6 +618,7 @@ export const templateChatThreads = p.pgTable(
       .foreignKey({
         columns: [table.templateId, table.organizationId],
         foreignColumns: [templates.id, templates.organizationId],
+        name: "template_chat_threads_template_organization_fk",
       })
       .onDelete("cascade"),
     ...templateChatThreadPolicies(),
@@ -706,17 +709,13 @@ export const chatThreadCompactions = p.pgTable(
     summaryMarkdown: p.text("summary_markdown").notNull(),
     firstSummarizedMessageId: safeUuid<"chatMessage">(
       "first_summarized_message_id",
-    )
-      .notNull()
-      .references(() => chatMessages.id, { onDelete: "cascade" }),
+    ).notNull(),
     lastSummarizedMessageId: safeUuid<"chatMessage">(
       "last_summarized_message_id",
-    )
-      .notNull()
-      .references(() => chatMessages.id, { onDelete: "cascade" }),
-    firstKeptMessageId: safeUuid<"chatMessage">("first_kept_message_id")
-      .notNull()
-      .references(() => chatMessages.id, { onDelete: "cascade" }),
+    ).notNull(),
+    firstKeptMessageId: safeUuid<"chatMessage">(
+      "first_kept_message_id",
+    ).notNull(),
     summarizedMessageCount: p.integer("summarized_message_count").notNull(),
     /**
      * Encoded `(created_at, id)` keyset cursor for the last message this
@@ -781,6 +780,30 @@ export const chatThreadCompactions = p.pgTable(
     createdAt: timestamptz("created_at").notNull().defaultNow(),
   },
   (table) => [
+    // The three message references are named explicitly: drizzle's generated
+    // names exceed PostgreSQL's 63-byte identifier limit and were silently
+    // truncated in the catalog until 20260813110000 renamed them.
+    p
+      .foreignKey({
+        columns: [table.firstSummarizedMessageId],
+        foreignColumns: [chatMessages.id],
+        name: "chat_thread_compactions_first_summarized_message_fk",
+      })
+      .onDelete("cascade"),
+    p
+      .foreignKey({
+        columns: [table.lastSummarizedMessageId],
+        foreignColumns: [chatMessages.id],
+        name: "chat_thread_compactions_last_summarized_message_fk",
+      })
+      .onDelete("cascade"),
+    p
+      .foreignKey({
+        columns: [table.firstKeptMessageId],
+        foreignColumns: [chatMessages.id],
+        name: "chat_thread_compactions_first_kept_message_fk",
+      })
+      .onDelete("cascade"),
     // Read off CHAT_COMPACTION_MEMORY_ELIGIBILITIES rather than re-listed: a
     // new eligibility value must reach the constraint and the column together,
     // and the extractability map beside the const is already total over it.

--- a/apps/api/src/db/schema/chat.ts
+++ b/apps/api/src/db/schema/chat.ts
@@ -216,6 +216,16 @@ export const chatThreads = p.pgTable(
       .$onUpdate(() => new Date()),
   },
   (table) => [
+    // RESTRICT mirrors the single-column workspace reference: a global thread
+    // (workspace_id NULL) is exempt under MATCH SIMPLE, and matter deletion
+    // removes threads explicitly before it removes the workspace.
+    p
+      .foreignKey({
+        columns: [table.workspaceId, table.organizationId],
+        foreignColumns: [workspaces.id, workspaces.organizationId],
+        name: "chat_threads_workspace_organization_fk",
+      })
+      .onDelete("restrict"),
     p
       .index("chat_threads_workspace_user_idx")
       .on(table.workspaceId, table.userId),
@@ -353,6 +363,15 @@ export const chatTurns = p.pgTable(
         foreignColumns: [chatMessages.id, chatMessages.threadId],
       })
       .onDelete("cascade"),
+    // RESTRICT mirrors the single-column workspace reference; a global turn
+    // (workspace_id NULL) is exempt under MATCH SIMPLE.
+    p
+      .foreignKey({
+        columns: [table.workspaceId, table.organizationId],
+        foreignColumns: [workspaces.id, workspaces.organizationId],
+        name: "chat_turns_workspace_organization_fk",
+      })
+      .onDelete("restrict"),
     p.check(
       "chat_turns_status_values_check",
       sql`${table.status} IN (${sql.join(CHAT_TURN_STATUS_SQL_VALUES, sql`, `)})`,
@@ -534,6 +553,13 @@ export const fileChatThreads = p.pgTable(
       .foreignKey({
         columns: [table.workspaceId],
         foreignColumns: [workspaces.id],
+      })
+      .onDelete("cascade"),
+    p
+      .foreignKey({
+        columns: [table.workspaceId, table.organizationId],
+        foreignColumns: [workspaces.id, workspaces.organizationId],
+        name: "file_chat_threads_workspace_organization_fk",
       })
       .onDelete("cascade"),
     p

--- a/apps/api/src/db/schema/contacts.ts
+++ b/apps/api/src/db/schema/contacts.ts
@@ -285,6 +285,13 @@ export const workspaceContacts = p.pgTable(
     createdAt: timestamptz("created_at").notNull().defaultNow(),
   },
   (table) => [
+    p
+      .foreignKey({
+        columns: [table.workspaceId, table.organizationId],
+        foreignColumns: [workspaces.id, workspaces.organizationId],
+        name: "workspace_contacts_workspace_organization_fk",
+      })
+      .onDelete("cascade"),
     p.index("workspace_contacts_workspace_id_idx").on(table.workspaceId),
     p.index("workspace_contacts_contact_id_idx").on(table.contactId),
     p

--- a/apps/api/src/db/schema/document-processing.ts
+++ b/apps/api/src/db/schema/document-processing.ts
@@ -191,6 +191,13 @@ export const documentProcessingRuns = p.pgTable(
       .onDelete("cascade"),
     p
       .foreignKey({
+        columns: [table.workspaceId, table.organizationId],
+        foreignColumns: [workspaces.id, workspaces.organizationId],
+        name: "document_processing_runs_workspace_organization_fk",
+      })
+      .onDelete("cascade"),
+    p
+      .foreignKey({
         columns: [table.fieldId, table.workspaceId],
         foreignColumns: [fields.id, fields.workspaceId],
       })

--- a/apps/api/src/db/schema/document-reviews.ts
+++ b/apps/api/src/db/schema/document-reviews.ts
@@ -171,6 +171,13 @@ export const documentReviewRuns = p.pgTable(
       "document_review_runs_pipeline_version_check",
       sql`${table.pipelineVersion} > 0`,
     ),
+    p
+      .foreignKey({
+        columns: [table.workspaceId, table.organizationId],
+        foreignColumns: [workspaces.id, workspaces.organizationId],
+        name: "document_review_runs_workspace_organization_fk",
+      })
+      .onDelete("cascade"),
     // Both scopes in every command: the run row carries an organization
     // discriminator, so a valid workspace pin must not authorize a row whose
     // organization_id came from anywhere else.
@@ -275,6 +282,13 @@ export const documentReviewFindings = p.pgTable(
       "document_review_findings_decision_timing_check",
       sql`(${table.decision} = ${OPEN_DECISION_SQL}) = (${table.decidedAt} IS NULL)`,
     ),
+    p
+      .foreignKey({
+        columns: [table.workspaceId, table.organizationId],
+        foreignColumns: [workspaces.id, workspaces.organizationId],
+        name: "document_review_findings_workspace_organization_fk",
+      })
+      .onDelete("cascade"),
     ...wsOrganizationPolicies("document_review_findings"),
   ],
 );

--- a/apps/api/src/db/schema/entities.ts
+++ b/apps/api/src/db/schema/entities.ts
@@ -579,9 +579,7 @@ export const desktopEditHandoffs = p.pgTable(
     forceTakeover: p.boolean("force_takeover").notNull().default(false),
     expiresAt: timestamptz("expires_at").notNull(),
     consumedAt: timestamptz("consumed_at"),
-    desktopSessionId: safeUuid<"desktopEditSession">(
-      "desktop_session_id",
-    ).references(() => desktopEditSessions.id, { onDelete: "set null" }),
+    desktopSessionId: safeUuid<"desktopEditSession">("desktop_session_id"),
     openedAt: timestamptz("opened_at"),
     createdAt: timestamptz("created_at").notNull().defaultNow(),
     updatedAt: timestamptz("updated_at")
@@ -596,6 +594,13 @@ export const desktopEditHandoffs = p.pgTable(
       .index("desktop_edit_handoffs_workspace_created_by_idx")
       .on(table.workspaceId, table.createdBy),
     p.uniqueIndex("desktop_edit_handoffs_token_hash_uidx").on(table.tokenHash),
+    p
+      .foreignKey({
+        columns: [table.desktopSessionId],
+        foreignColumns: [desktopEditSessions.id],
+        name: "desktop_edit_handoffs_desktop_session_fk",
+      })
+      .onDelete("set null"),
     p
       .foreignKey({
         columns: [table.entityId, table.workspaceId],
@@ -624,9 +629,7 @@ export const folioCollabSessions = p.pgTable(
     baseVersionId: safeUuid<"entityVersion">("base_version_id")
       .notNull()
       .references(() => entityVersions.id, { onDelete: "cascade" }),
-    finalizedVersionId: safeUuid<"entityVersion">(
-      "finalized_version_id",
-    ).references(() => entityVersions.id, { onDelete: "set null" }),
+    finalizedVersionId: safeUuid<"entityVersion">("finalized_version_id"),
     createdBy: p
       .text("created_by")
       .notNull()
@@ -669,6 +672,13 @@ export const folioCollabSessions = p.pgTable(
     p
       .index("folio_collab_sessions_base_version_id_idx")
       .on(table.baseVersionId),
+    p
+      .foreignKey({
+        columns: [table.finalizedVersionId],
+        foreignColumns: [entityVersions.id],
+        name: "folio_collab_sessions_finalized_version_fk",
+      })
+      .onDelete("set null"),
     p
       .uniqueIndex("folio_collab_sessions_open_uidx")
       .on(table.workspaceId, table.entityId, table.propertyId)
@@ -1039,6 +1049,7 @@ export const cellMetadata = p.pgTable(
       .foreignKey({
         columns: [table.propertyId, table.workspaceId],
         foreignColumns: [properties.id, properties.workspaceId],
+        name: "cell_metadata_property_workspace_fk",
       })
       .onDelete("cascade"),
     p.index("cell_metadata_workspace_id_idx").on(table.workspaceId),

--- a/apps/api/src/db/schema/entities.ts
+++ b/apps/api/src/db/schema/entities.ts
@@ -420,6 +420,13 @@ export const entityVersionAiSummaries = p.pgTable(
         foreignColumns: [entities.id, entities.workspaceId],
       })
       .onDelete("cascade"),
+    p
+      .foreignKey({
+        columns: [table.workspaceId, table.organizationId],
+        foreignColumns: [workspaces.id, workspaces.organizationId],
+        name: "entity_version_ai_summaries_workspace_organization_fk",
+      })
+      .onDelete("cascade"),
     ...wsOrganizationPolicies("entity_version_ai_summaries"),
   ],
 );
@@ -887,6 +894,13 @@ export const pendingUploads = p.pgTable(
         name: "pending_uploads_organization_fk",
         columns: [table.organizationId],
         foreignColumns: [organization.id],
+      })
+      .onDelete("cascade"),
+    p
+      .foreignKey({
+        columns: [table.workspaceId, table.organizationId],
+        foreignColumns: [workspaces.id, workspaces.organizationId],
+        name: "pending_uploads_workspace_organization_fk",
       })
       .onDelete("cascade"),
     ...wsOrganizationPolicies("pending_uploads"),

--- a/apps/api/src/db/schema/extraction-runs.ts
+++ b/apps/api/src/db/schema/extraction-runs.ts
@@ -102,6 +102,13 @@ export const extractionRuns = p.pgTable(
       "extraction_runs_completed_within_total_check",
       sql`${table.completed} <= ${table.total}`,
     ),
+    p
+      .foreignKey({
+        columns: [table.workspaceId, table.organizationId],
+        foreignColumns: [workspaces.id, workspaces.organizationId],
+        name: "extraction_runs_workspace_organization_fk",
+      })
+      .onDelete("cascade"),
     ...wsOrganizationReadOnlyPolicies("extraction_runs"),
   ],
 );

--- a/apps/api/src/db/schema/templates.ts
+++ b/apps/api/src/db/schema/templates.ts
@@ -189,6 +189,13 @@ export const templatePersistenceRequests = p.pgTable(
       "template_persistence_requests_state_check",
       sql`(${table.status} = ${TEMPLATE_PERSISTENCE_REQUEST_STATUS.PENDING} AND ${table.result} IS NULL AND ${table.completedAt} IS NULL) OR (${table.status} = ${TEMPLATE_PERSISTENCE_REQUEST_STATUS.COMPLETED} AND ${table.result} IS NOT NULL AND ${table.completedAt} IS NOT NULL)`,
     ),
+    p
+      .foreignKey({
+        columns: [table.workspaceId, table.organizationId],
+        foreignColumns: [workspaces.id, workspaces.organizationId],
+        name: "template_persistence_requests_workspace_organization_fk",
+      })
+      .onDelete("cascade"),
     ...wsOrganizationPolicies("template_persistence_requests"),
   ],
 );
@@ -256,6 +263,13 @@ export const searchDocuments = p.pgTable(
       .index("search_documents_org_updated_id_idx")
       .on(table.organizationId, table.updatedAt.desc(), table.entityId.desc()),
     p.index("search_documents_tsv_idx").using("gin", table.tsv),
+    p
+      .foreignKey({
+        columns: [table.workspaceId, table.organizationId],
+        foreignColumns: [workspaces.id, workspaces.organizationId],
+        name: "search_documents_workspace_organization_fk",
+      })
+      .onDelete("cascade"),
     ...wsOrganizationPolicies("search_documents"),
   ],
 );
@@ -295,6 +309,13 @@ export const searchDocumentPreviewPassages = p.pgTable(
         name: "search_document_preview_passages_organization_fk",
         columns: [table.organizationId],
         foreignColumns: [organization.id],
+      })
+      .onDelete("cascade"),
+    p
+      .foreignKey({
+        name: "search_document_preview_passages_workspace_organization_fk",
+        columns: [table.workspaceId, table.organizationId],
+        foreignColumns: [workspaces.id, workspaces.organizationId],
       })
       .onDelete("cascade"),
     ...wsOrganizationReadOnlyPolicies("search_document_preview_passages"),
@@ -398,6 +419,13 @@ export const workspaceSearchDocuments = p.pgTable(
         table.workspaceId.desc(),
       ),
     p.index("workspace_search_docs_tsv_idx").using("gin", table.tsv),
+    p
+      .foreignKey({
+        columns: [table.workspaceId, table.organizationId],
+        foreignColumns: [workspaces.id, workspaces.organizationId],
+        name: "workspace_search_documents_workspace_organization_fk",
+      })
+      .onDelete("cascade"),
     ...wsOrganizationPolicies("workspace_search_documents"),
   ],
 );
@@ -435,6 +463,16 @@ export const workspaceSearchDocumentPreviewPassages = p.pgTable(
         name: "workspace_search_document_preview_passages_organization_fk",
         columns: [table.organizationId],
         foreignColumns: [organization.id],
+      })
+      .onDelete("cascade"),
+    // `organization` is abbreviated to `org` here and nowhere else in this
+    // family: the table's own name leaves only 21 bytes before PostgreSQL's
+    // 63-byte identifier limit truncates the constraint.
+    p
+      .foreignKey({
+        name: "workspace_search_document_preview_passages_workspace_org_fk",
+        columns: [table.workspaceId, table.organizationId],
+        foreignColumns: [workspaces.id, workspaces.organizationId],
       })
       .onDelete("cascade"),
     ...wsOrganizationReadOnlyPolicies(
@@ -555,6 +593,13 @@ export const extractedContent = p.pgTable(
       .foreignKey({
         columns: [table.entityId, table.workspaceId],
         foreignColumns: [entities.id, entities.workspaceId],
+      })
+      .onDelete("cascade"),
+    p
+      .foreignKey({
+        columns: [table.workspaceId, table.organizationId],
+        foreignColumns: [workspaces.id, workspaces.organizationId],
+        name: "extracted_content_workspace_organization_fk",
       })
       .onDelete("cascade"),
     p.index("extracted_content_workspace_id_idx").on(table.workspaceId),

--- a/apps/api/src/db/schema/workspace-admin.ts
+++ b/apps/api/src/db/schema/workspace-admin.ts
@@ -235,6 +235,15 @@ export const anonymizationAllowlistEntries = p.pgTable(
     createdAt: timestamptz("created_at").notNull().defaultNow(),
   },
   (table) => [
+    // MATCH SIMPLE: an org-wide entry (workspace_id NULL) is exempt, a
+    // workspace-scoped one must name a workspace of its own organization.
+    p
+      .foreignKey({
+        columns: [table.workspaceId, table.organizationId],
+        foreignColumns: [workspaces.id, workspaces.organizationId],
+        name: "anonymization_allowlist_entries_workspace_organization_fk",
+      })
+      .onDelete("cascade"),
     p.index("anonymization_allowlist_entries_org_idx").on(table.organizationId),
     p
       .index("anonymization_allowlist_entries_workspace_idx")
@@ -296,6 +305,13 @@ export const anonymizationBlacklistEntries = p.pgTable(
       .$onUpdate(() => new Date()),
   },
   (table) => [
+    p
+      .foreignKey({
+        columns: [table.workspaceId, table.organizationId],
+        foreignColumns: [workspaces.id, workspaces.organizationId],
+        name: "anonymization_blacklist_entries_workspace_organization_fk",
+      })
+      .onDelete("cascade"),
     p
       .index("anonymization_blacklist_entries_org_enabled_idx")
       .on(table.organizationId, table.enabled),

--- a/apps/api/src/db/schema/workspace-admin.ts
+++ b/apps/api/src/db/schema/workspace-admin.ts
@@ -217,9 +217,7 @@ export const anonymizationAllowlistEntries = p.pgTable(
   "anonymization_allowlist_entries",
   {
     id: pUuid<"anonymizationAllowlistEntry">().primaryKey(),
-    organizationId: safeOrganizationId("organization_id")
-      .notNull()
-      .references(() => organization.id, { onDelete: "cascade" }),
+    organizationId: safeOrganizationId("organization_id").notNull(),
     workspaceId: safeWorkspaceId("workspace_id").references(
       () => workspaces.id,
       { onDelete: "cascade" },
@@ -235,6 +233,16 @@ export const anonymizationAllowlistEntries = p.pgTable(
     createdAt: timestamptz("created_at").notNull().defaultNow(),
   },
   (table) => [
+    // Named explicitly: drizzle's generated name exceeds PostgreSQL's 63-byte
+    // identifier limit and was silently truncated in the catalog until
+    // 20260813110000 renamed it.
+    p
+      .foreignKey({
+        columns: [table.organizationId],
+        foreignColumns: [organization.id],
+        name: "anonymization_allowlist_entries_organization_fk",
+      })
+      .onDelete("cascade"),
     // MATCH SIMPLE: an org-wide entry (workspace_id NULL) is exempt, a
     // workspace-scoped one must name a workspace of its own organization.
     p
@@ -275,9 +283,7 @@ export const anonymizationBlacklistEntries = p.pgTable(
   "anonymization_blacklist_entries",
   {
     id: pUuid<"anonymizationBlacklistEntry">().primaryKey(),
-    organizationId: safeOrganizationId("organization_id")
-      .notNull()
-      .references(() => organization.id, { onDelete: "cascade" }),
+    organizationId: safeOrganizationId("organization_id").notNull(),
     /**
      * When set, the entry is scoped to a single workspace
      * and is only consulted by detection runs for that
@@ -305,6 +311,13 @@ export const anonymizationBlacklistEntries = p.pgTable(
       .$onUpdate(() => new Date()),
   },
   (table) => [
+    p
+      .foreignKey({
+        columns: [table.organizationId],
+        foreignColumns: [organization.id],
+        name: "anonymization_blacklist_entries_organization_fk",
+      })
+      .onDelete("cascade"),
     p
       .foreignKey({
         columns: [table.workspaceId, table.organizationId],

--- a/apps/api/src/tests/security/rls-coverage.test.ts
+++ b/apps/api/src/tests/security/rls-coverage.test.ts
@@ -22,6 +22,7 @@ import {
   fetchStellaUserSelectColumnPrivileges,
   fetchStellaTablePrivileges,
   fetchStellaPolicies,
+  fetchWorkspaceTenantPairForeignKeys,
 } from "@/api/tests/security/rls-helpers";
 import type { TestDatabase } from "@/api/tests/security/test-utils";
 
@@ -282,6 +283,84 @@ describe("policy coverage", () => {
     }
 
     expect(unpinned).toEqual([]);
+  });
+
+  // The policy test above states the tenant pair as an authorization rule.
+  // This one states it as a storage rule: a row whose organization_id does not
+  // belong to its workspace_id cannot be written at all, whatever policy or
+  // handler produced it. Only three tables carried the reference before, so
+  // "the pattern exists somewhere" was not the same as "the class is closed".
+  //
+  // Exemptions are properties of the table, not waivers, and the assertions
+  // below run in both directions so one cannot outlive its reason.
+  const TENANT_PAIR_EXEMPT = new Map<string, string>([
+    [
+      "audit_logs",
+      "matter deletion records the DELETE event after removing the workspace row, so any reference to workspaces would abort it",
+    ],
+    [
+      "buffer_object_cleanup_intents",
+      "storage-erasure outbox: references no ancestor so cleanup survives owner deletion (apps/api/src/db/schema/entities.test.ts)",
+    ],
+    [
+      "entity_deletion_cleanup_requests",
+      "storage-erasure outbox: references no ancestor so cleanup survives owner deletion (apps/api/src/db/schema/entities.test.ts)",
+    ],
+    [
+      "usage_events",
+      "metering ledger whose workspace_id is nullable attribution surviving matter deletion; the pair needs ON DELETE SET NULL (workspace_id), which drizzle cannot declare",
+    ],
+  ]);
+
+  test("every table with workspace_id and organization_id references the pair", async () => {
+    const scoped = await fetchScopedTables(testDb);
+    const pairForeignKeys = await fetchWorkspaceTenantPairForeignKeys(testDb);
+
+    const byScope = new Map<string, Set<string>>();
+    for (const { table_name, scope } of scoped) {
+      const scopes = byScope.get(table_name) ?? new Set<string>();
+      scopes.add(scope);
+      byScope.set(table_name, scopes);
+    }
+
+    const dualScopeTables = [...byScope.entries()]
+      .filter(
+        ([, scopes]) => scopes.has("workspace") && scopes.has("organization"),
+      )
+      .map(([table]) => table);
+
+    // The class exists: an empty list would make every assertion below vacuous.
+    expect(dualScopeTables.length).toBeGreaterThan(0);
+
+    const referencing = new Map(
+      pairForeignKeys.map((foreignKey) => [foreignKey.table_name, foreignKey]),
+    );
+
+    expect(
+      dualScopeTables
+        .filter((table) => !TENANT_PAIR_EXEMPT.has(table))
+        .filter((table) => !referencing.has(table))
+        .toSorted(),
+    ).toEqual([]);
+
+    // A constraint left NOT VALID enforces new writes only, so a forgotten
+    // VALIDATE migration would leave the existing rows unchecked forever.
+    expect(
+      pairForeignKeys
+        .filter(({ validated }) => !validated)
+        .map(({ constraint_name }) => constraint_name)
+        .toSorted(),
+    ).toEqual([]);
+
+    // Stale exemptions fail too: a table that lost one of the two columns, or
+    // that has since taken the reference, no longer needs an entry.
+    expect(
+      [...TENANT_PAIR_EXEMPT.keys()]
+        .filter(
+          (table) => !dualScopeTables.includes(table) || referencing.has(table),
+        )
+        .toSorted(),
+    ).toEqual([]);
   });
 
   test("every table with organization_id (org-only) has org policies", async () => {

--- a/apps/api/src/tests/security/rls-helpers.ts
+++ b/apps/api/src/tests/security/rls-helpers.ts
@@ -1523,6 +1523,48 @@ export const fetchStellaIngestionColumnPrivileges = async (
   return rows.rows;
 };
 
+type WorkspaceTenantPairForeignKey = {
+  table_name: string;
+  constraint_name: string;
+  /** `false` while a constraint is still NOT VALID: existing rows unchecked. */
+  validated: boolean;
+};
+
+/**
+ * Fetch every foreign key whose referencing columns are exactly
+ * (workspace_id, organization_id) and whose target is `workspaces`: the
+ * reference that makes a workspace/organization mismatch unrepresentable.
+ */
+export const fetchWorkspaceTenantPairForeignKeys = async (
+  db: TestDatabase,
+): Promise<WorkspaceTenantPairForeignKey[]> => {
+  const [firstColumn, secondColumn] = [
+    entities.workspaceId.name,
+    workspaces.organizationId.name,
+  ].toSorted();
+
+  const rows = await db.execute<WorkspaceTenantPairForeignKey>(sql`
+    SELECT rel.relname AS table_name,
+           con.conname AS constraint_name,
+           con.convalidated AS validated
+    FROM pg_catalog.pg_constraint con
+    JOIN pg_catalog.pg_class rel ON rel.oid = con.conrelid
+    JOIN pg_catalog.pg_namespace nsp ON nsp.oid = rel.relnamespace
+    WHERE con.contype = 'f'
+      AND nsp.nspname = 'public'
+      AND con.confrelid = 'public.workspaces'::regclass
+      AND (
+        SELECT array_agg(att.attname ORDER BY att.attname)
+        FROM unnest(con.conkey) AS referencing(attnum)
+        JOIN pg_catalog.pg_attribute att
+          ON att.attrelid = con.conrelid
+         AND att.attnum = referencing.attnum
+      ) = ARRAY[${firstColumn}, ${secondColumn}]::name[]
+    ORDER BY rel.relname
+  `);
+  return rows.rows;
+};
+
 /**
  * Fetch all tables that have a workspace_id or
  * organization_id column, to verify policy coverage.

--- a/apps/api/src/tests/security/rls-helpers.ts
+++ b/apps/api/src/tests/security/rls-helpers.ts
@@ -141,10 +141,15 @@ export const createTestIds = () => ({
   chatThreadGlobalA1: id<"chatThread">(),
   chatThreadWorkspaceA1: id<"chatThread">(),
   chatThreadWorkspaceA2: id<"chatThread">(),
+  // Same organization and same matter as chatThreadWorkspaceA1, different
+  // owner. The user boundary is the only thing that can hide it from user A1,
+  // which is what the "different user in the same workspace" tests assert.
+  chatThreadWorkspaceA1UserA2: id<"chatThread">(),
   chatThreadWorkspaceB1: id<"chatThread">(),
   chatMessageGlobalA1: id<"chatMessage">(),
   chatMessageWorkspaceA1: id<"chatMessage">(),
   chatMessageWorkspaceA2: id<"chatMessage">(),
+  chatMessageWorkspaceA1UserA2: id<"chatMessage">(),
   chatMessageWorkspaceB1: id<"chatMessage">(),
   fileChatThreadA1: id<"fileChatThread">(),
   templateChatThreadA1: id<"templateChatThread">(),
@@ -1005,11 +1010,18 @@ export const setupRlsTestData = async (db: TestDatabase, ids: TestIds) => {
       workspaceId: ids.wsA2,
     },
     {
+      id: ids.chatThreadWorkspaceA1UserA2,
+      organizationId: ids.orgA,
+      userId: ids.userA2,
+      title: "Workspace thread A1 (user A2)",
+      workspaceId: ids.wsA1,
+    },
+    {
       id: ids.chatThreadWorkspaceB1,
       organizationId: ids.orgB,
       userId: ids.userB1,
       title: "Workspace thread B1",
-      workspaceId: ids.wsA1,
+      workspaceId: ids.wsB1,
     },
   ]);
 
@@ -1095,10 +1107,18 @@ export const setupRlsTestData = async (db: TestDatabase, ids: TestIds) => {
       content: chatContent("workspace-a2"),
     },
     {
+      id: ids.chatMessageWorkspaceA1UserA2,
+      threadId: ids.chatThreadWorkspaceA1UserA2,
+      userId: ids.userA2,
+      workspaceId: ids.wsA1,
+      role: "user",
+      content: chatContent("workspace-a1-user-a2"),
+    },
+    {
       id: ids.chatMessageWorkspaceB1,
       threadId: ids.chatThreadWorkspaceB1,
       userId: ids.userB1,
-      workspaceId: ids.wsA1,
+      workspaceId: ids.wsB1,
       role: "user",
       content: chatContent("workspace-b1"),
     },
@@ -1538,11 +1558,12 @@ type WorkspaceTenantPairForeignKey = {
 export const fetchWorkspaceTenantPairForeignKeys = async (
   db: TestDatabase,
 ): Promise<WorkspaceTenantPairForeignKey[]> => {
-  const [firstColumn, secondColumn] = [
-    entities.workspaceId.name,
-    workspaces.organizationId.name,
-  ].toSorted();
+  const workspaceColumn = entities.workspaceId.name;
+  const organizationColumn = workspaces.organizationId.name;
 
+  // Both sides are aggregated in the same column order, so the comparison is a
+  // set comparison and neither the declared column order nor the alphabetical
+  // order of the two names can decide the result.
   const rows = await db.execute<WorkspaceTenantPairForeignKey>(sql`
     SELECT rel.relname AS table_name,
            con.conname AS constraint_name,
@@ -1559,7 +1580,12 @@ export const fetchWorkspaceTenantPairForeignKeys = async (
         JOIN pg_catalog.pg_attribute att
           ON att.attrelid = con.conrelid
          AND att.attnum = referencing.attnum
-      ) = ARRAY[${firstColumn}, ${secondColumn}]::name[]
+      ) = (
+        SELECT array_agg(expected ORDER BY expected)
+        FROM unnest(
+          ARRAY[${workspaceColumn}, ${organizationColumn}]::name[]
+        ) AS pair(expected)
+      )
     ORDER BY rel.relname
   `);
   return rows.rows;

--- a/apps/api/src/tests/security/rls-negative.test.ts
+++ b/apps/api/src/tests/security/rls-negative.test.ts
@@ -218,12 +218,51 @@ describe("chat SELECT — wrong user or workspace", () => {
     expect(c).toBe(0);
   });
 
-  test("different user in the same workspace sees zero rows", async () => {
+  // The two tests above read a global thread, whose workspace_id is NULL, so
+  // the organization pin is the only predicate that can exclude it. This reads
+  // a thread that belongs to a matter, where the organization pin has to hold
+  // on its own even though the workspace predicate would also reject.
+  test("another organization's matter thread is unreadable", async () => {
     const c = await scopedQuery(
       [ids.wsA1],
       ids.orgA,
       (tx) =>
         tx.$count(chatThreads, eq(chatThreads.id, ids.chatThreadWorkspaceB1)),
+      ids.userA1,
+    );
+    expect(c).toBe(0);
+  });
+
+  // chat_messages carries no organization column of its own; its policy reaches
+  // the tenant through the owning thread. Reading that thread's message is what
+  // exercises the join rather than a column comparison.
+  test("another organization's matter message is unreadable", async () => {
+    const c = await scopedQuery(
+      [ids.wsA1],
+      ids.orgA,
+      (tx) =>
+        tx.$count(
+          chatMessages,
+          eq(chatMessages.id, ids.chatMessageWorkspaceB1),
+        ),
+      ids.userA1,
+    );
+    expect(c).toBe(0);
+  });
+
+  // The row shares this reader's organization and matter, so the user pin is
+  // the only predicate that can hide it. Reading another organization's thread
+  // here would pass on the organization pin whether or not the user pin works,
+  // which is what the "another organization" tests above already cover.
+  test("different user in the same workspace sees zero rows", async () => {
+    const c = await scopedQuery(
+      [ids.wsA1],
+      ids.orgA,
+      (tx) =>
+        tx.$count(
+          chatThreads,
+          eq(chatThreads.id, ids.chatThreadWorkspaceA1UserA2),
+        ),
       ids.userA1,
     );
     expect(c).toBe(0);
@@ -1614,7 +1653,7 @@ describe("chat mutations — wrong user", () => {
         tx
           .update(chatMessages)
           .set({ content: { version: 1 as const, data: [] } })
-          .where(eq(chatMessages.id, ids.chatMessageWorkspaceB1))
+          .where(eq(chatMessages.id, ids.chatMessageWorkspaceA1UserA2))
           .returning({ id: chatMessages.id }),
       ids.userA1,
     );
@@ -1628,7 +1667,7 @@ describe("chat mutations — wrong user", () => {
       (tx) =>
         tx
           .delete(chatThreads)
-          .where(eq(chatThreads.id, ids.chatThreadWorkspaceB1))
+          .where(eq(chatThreads.id, ids.chatThreadWorkspaceA1UserA2))
           .returning({ id: chatThreads.id }),
       ids.userA1,
     );

--- a/apps/api/src/tests/security/schema-invariants.test.ts
+++ b/apps/api/src/tests/security/schema-invariants.test.ts
@@ -212,11 +212,12 @@ describe("identifier length", () => {
   });
 
   test("drizzle-derived names over the limit are exactly the known set", () => {
+    const byCodepoint = (a: string, b: string) => (a < b ? -1 : a > b ? 1 : 0);
     expect(
       overLimit(names)
         .map(({ name }) => name)
-        .toSorted(),
-    ).toEqual(LEGACY_DERIVED_NAMES_OVER_LIMIT.toSorted());
+        .toSorted(byCodepoint),
+    ).toEqual(LEGACY_DERIVED_NAMES_OVER_LIMIT.toSorted(byCodepoint));
   });
 });
 

--- a/apps/api/src/tests/security/schema-invariants.test.ts
+++ b/apps/api/src/tests/security/schema-invariants.test.ts
@@ -5,13 +5,14 @@ import { PgDialect, PgTable, getTableConfig } from "drizzle-orm/pg-core";
 import * as agentAuthSchema from "@/api/db/agent-auth-schema";
 import * as authSchema from "@/api/db/auth-schema";
 import * as schema from "@/api/db/schema";
-import {
+import { POLARITY } from "@/api/handlers/case-law/polarity/consts";
+
+const {
   CASE_LAW_CORPUS_MIRROR_STATUS,
   caseLawCitations,
   caseLawDecisions,
   caseLawPolarityRules,
-} from "@/api/db/schema";
-import { POLARITY } from "@/api/handlers/case-law/polarity/consts";
+} = schema;
 
 /**
  * Allowed values of a CHECK constraint's IN list, read off the statement the
@@ -51,45 +52,85 @@ const POSTGRES_IDENTIFIER_LIMIT_BYTES = 63;
 
 type DeclaredName = {
   table: string;
-  name: string;
+  /** `undefined` when drizzle holds no name at all, so nothing can be measured. */
+  name: string | undefined;
   /** `false` for a name drizzle derived from the columns rather than one the schema chose. */
   explicit: boolean;
+};
+
+// `is()` is drizzle-orm's own runtime type guard (it checks the entity-kind tag
+// drizzle stamps on table instances), so this narrows `unknown` to `PgTable`
+// without an unsafe type assertion.
+const isPgTable = (value: unknown): value is PgTable => is(value, PgTable);
+
+// Spread into one annotated record rather than walking each namespace: the
+// annotation collapses the exports to `unknown` immediately, so neither the
+// traversal nor its inference has to build a union of every table type. The
+// three namespaces share no export name, so nothing is lost to a collision.
+const allSchemaExports: Record<string, unknown> = {
+  ...agentAuthSchema,
+  ...authSchema,
+  ...schema,
 };
 
 const declaredNames = (): DeclaredName[] => {
   const names: DeclaredName[] = [];
 
-  for (const value of [
-    ...Object.values(schema),
-    ...Object.values(authSchema),
-    ...Object.values(agentAuthSchema),
-  ]) {
-    if (!is(value, PgTable)) {
+  for (const value of Object.values(allSchemaExports)) {
+    if (!isPgTable(value)) {
       continue;
     }
     const config = getTableConfig(value);
     const table = config.name;
 
+    // `isNameExplicit` is drizzle's own record of whether the schema chose the
+    // name or drizzle derived it from the columns; every object kind below
+    // reports it, so this never has to guess from the shape of the string.
     for (const foreignKey of config.foreignKeys) {
       names.push({
         table,
         name: foreignKey.getName(),
-        explicit: foreignKey.reference().name !== undefined,
+        explicit: foreignKey.isNameExplicit(),
       });
     }
-    for (const name of [
-      ...config.indexes.map((index) => index.config.name),
-      ...config.uniqueConstraints.map((unique) => unique.name),
-      ...config.checks.map((check) => check.name),
-      ...config.primaryKeys.map((primaryKey) => primaryKey.getName()),
-      ...config.policies.map((policy) => policy.name),
-    ]) {
-      names.push({ table, name, explicit: true });
+    for (const index of config.indexes) {
+      names.push({
+        table,
+        name: index.config.name,
+        explicit: index.isNameExplicit,
+      });
+    }
+    for (const unique of config.uniqueConstraints) {
+      names.push({
+        table,
+        name: unique.getName(),
+        explicit: unique.isNameExplicit,
+      });
+    }
+    for (const primaryKey of config.primaryKeys) {
+      names.push({
+        table,
+        name: primaryKey.getName(),
+        explicit: primaryKey.isNameExplicit,
+      });
+    }
+    for (const check of config.checks) {
+      names.push({ table, name: check.name, explicit: true });
+    }
+    for (const policy of config.policies) {
+      names.push({ table, name: policy.name, explicit: true });
     }
   }
 
   return names;
 };
+
+const overLimit = (names: readonly DeclaredName[]): DeclaredName[] =>
+  names.filter(
+    ({ name }) =>
+      name !== undefined &&
+      Buffer.byteLength(name) > POSTGRES_IDENTIFIER_LIMIT_BYTES,
+  );
 
 /**
  * Foreign keys whose drizzle-derived name is longer than PostgreSQL can store.
@@ -146,17 +187,25 @@ describe("identifier length", () => {
   // A traversal that silently stopped finding constraints would make every
   // assertion below pass for the wrong reason.
   test("the schema declares the names this guard reads", () => {
-    expect(names.length).toBeGreaterThan(500);
+    expect(names.length).toBeGreaterThan(1000);
+  });
+
+  // An object drizzle holds no name for has nothing to measure, so it would
+  // slip past the length assertions entirely. There are none today; this keeps
+  // the guard total rather than merely broad.
+  test("every constraint and index carries a name to measure", () => {
+    expect(
+      names
+        .filter(({ name }) => name === undefined)
+        .map(({ table }) => table)
+        .toSorted(),
+    ).toEqual([]);
   });
 
   test("no name the schema chooses exceeds PostgreSQL's identifier limit", () => {
     expect(
-      names
+      overLimit(names)
         .filter(({ explicit }) => explicit)
-        .filter(
-          ({ name }) =>
-            Buffer.byteLength(name) > POSTGRES_IDENTIFIER_LIMIT_BYTES,
-        )
         .map(({ table, name }) => `${table}: ${name}`)
         .toSorted(),
     ).toEqual([]);
@@ -164,11 +213,7 @@ describe("identifier length", () => {
 
   test("drizzle-derived names over the limit are exactly the known set", () => {
     expect(
-      names
-        .filter(
-          ({ name }) =>
-            Buffer.byteLength(name) > POSTGRES_IDENTIFIER_LIMIT_BYTES,
-        )
+      overLimit(names)
         .map(({ name }) => name)
         .toSorted(),
     ).toEqual(LEGACY_DERIVED_NAMES_OVER_LIMIT.toSorted());

--- a/apps/api/src/tests/security/schema-invariants.test.ts
+++ b/apps/api/src/tests/security/schema-invariants.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from "bun:test";
-import { PgDialect, getTableConfig } from "drizzle-orm/pg-core";
+import { is } from "drizzle-orm";
+import { PgDialect, PgTable, getTableConfig } from "drizzle-orm/pg-core";
 
+import * as agentAuthSchema from "@/api/db/agent-auth-schema";
+import * as authSchema from "@/api/db/auth-schema";
+import * as schema from "@/api/db/schema";
 import {
   CASE_LAW_CORPUS_MIRROR_STATUS,
   caseLawCitations,
@@ -35,6 +39,141 @@ const extractCheckValues = (
 
   return inList.split(",").map((v) => v.trim().replace(/^'|'$/gu, ""));
 };
+
+/**
+ * PostgreSQL stores identifiers in a fixed 63-byte field and silently clips
+ * anything longer. A constraint or index whose declared name is longer is
+ * still created, still enforced, and still correct: what it is not is the name
+ * the schema says it has, which is what drift detection compares and what any
+ * later statement naming it has to spell.
+ */
+const POSTGRES_IDENTIFIER_LIMIT_BYTES = 63;
+
+type DeclaredName = {
+  table: string;
+  name: string;
+  /** `false` for a name drizzle derived from the columns rather than one the schema chose. */
+  explicit: boolean;
+};
+
+const declaredNames = (): DeclaredName[] => {
+  const names: DeclaredName[] = [];
+
+  for (const value of [
+    ...Object.values(schema),
+    ...Object.values(authSchema),
+    ...Object.values(agentAuthSchema),
+  ]) {
+    if (!is(value, PgTable)) {
+      continue;
+    }
+    const config = getTableConfig(value);
+    const table = config.name;
+
+    for (const foreignKey of config.foreignKeys) {
+      names.push({
+        table,
+        name: foreignKey.getName(),
+        explicit: foreignKey.reference().name !== undefined,
+      });
+    }
+    for (const name of [
+      ...config.indexes.map((index) => index.config.name),
+      ...config.uniqueConstraints.map((unique) => unique.name),
+      ...config.checks.map((check) => check.name),
+      ...config.primaryKeys.map((primaryKey) => primaryKey.getName()),
+      ...config.policies.map((policy) => policy.name),
+    ]) {
+      names.push({ table, name, explicit: true });
+    }
+  }
+
+  return names;
+};
+
+/**
+ * Foreign keys whose drizzle-derived name is longer than PostgreSQL can store.
+ * None of them reaches the database under this name: each was created by a
+ * migration that named it by hand or let PostgreSQL name it, so the truncation
+ * is latent rather than live. It stops being latent the moment one of these
+ * tables is created from the schema instead of from its migration.
+ *
+ * The set is asserted exactly, in both directions, so an entry cannot outlive
+ * the constraint it describes and a new long name cannot join it unnoticed.
+ * Fix an entry by naming the constraint in the schema and renaming it in a
+ * migration, the way 20260813110000 did for the eleven that were live.
+ */
+const LEGACY_DERIVED_NAMES_OVER_LIMIT = [
+  "case_law_citations_polarity_rule_id_case_law_polarity_rules_id_fk",
+  "case_law_decision_source_identities_source_id_case_law_sources_id_fk",
+  "case_law_search_document_preview_passages_decision_id_case_law_search_documents_decision_id_fk",
+  "chat_thread_search_preview_passages_thread_id_chat_thread_search_documents_thread_id_fk",
+  "clause_variants_clause_id_organization_id_clauses_id_organization_id_fk",
+  "clause_versions_clause_id_organization_id_clauses_id_organization_id_fk",
+  "contact_search_document_preview_passages_contact_id_contact_search_documents_contact_id_fk",
+  "desktop_edit_handoffs_entity_id_workspace_id_entities_id_workspace_id_fk",
+  "desktop_edit_handoffs_property_id_workspace_id_properties_id_workspace_id_fk",
+  "desktop_edit_sessions_entity_id_workspace_id_entities_id_workspace_id_fk",
+  "desktop_edit_sessions_finalized_version_id_entity_versions_id_fk",
+  "desktop_edit_sessions_property_id_workspace_id_properties_id_workspace_id_fk",
+  "document_processing_runs_entity_id_workspace_id_entities_id_workspace_id_fk",
+  "document_processing_runs_field_id_workspace_id_fields_id_workspace_id_fk",
+  "entity_version_ai_summaries_entity_id_workspace_id_entities_id_workspace_id_fk",
+  "entity_version_ai_summaries_entity_version_id_entity_versions_id_fk",
+  "entity_versions_entity_id_workspace_id_entities_id_workspace_id_fk",
+  "extracted_content_entity_id_workspace_id_entities_id_workspace_id_fk",
+  "extracted_content_source_entity_version_id_entity_versions_id_fk",
+  "folio_collab_session_tokens_session_id_folio_collab_sessions_id_fk",
+  "folio_collab_sessions_entity_id_workspace_id_entities_id_workspace_id_fk",
+  "folio_collab_sessions_property_id_workspace_id_properties_id_workspace_id_fk",
+  "legislation_search_documents_document_id_legislation_documents_id_fk",
+  "office_file_evidence_entity_id_workspace_id_entities_id_workspace_id_fk",
+  "office_file_evidence_field_id_workspace_id_fields_id_workspace_id_fk",
+  "property_dependencies_depends_on_property_id_workspace_id_properties_id_workspace_id_fk",
+  "property_dependencies_property_id_workspace_id_properties_id_workspace_id_fk",
+  "search_document_preview_passages_entity_id_search_documents_entity_id_fk",
+  "template_clauses_template_id_organization_id_templates_id_organization_id_fk",
+  "template_persistence_requests_organization_id_organization_id_fk",
+  "template_versions_template_id_organization_id_templates_id_organization_id_fk",
+  "work_obligation_events_obligation_entity_id_workspace_id_work_obligations_entity_id_workspace_id_fk",
+  "work_obligations_entity_id_workspace_id_entities_id_workspace_id_fk",
+  "workspace_search_document_preview_passages_workspace_id_workspace_search_documents_workspace_id_fk",
+];
+
+describe("identifier length", () => {
+  const names = declaredNames();
+
+  // A traversal that silently stopped finding constraints would make every
+  // assertion below pass for the wrong reason.
+  test("the schema declares the names this guard reads", () => {
+    expect(names.length).toBeGreaterThan(500);
+  });
+
+  test("no name the schema chooses exceeds PostgreSQL's identifier limit", () => {
+    expect(
+      names
+        .filter(({ explicit }) => explicit)
+        .filter(
+          ({ name }) =>
+            Buffer.byteLength(name) > POSTGRES_IDENTIFIER_LIMIT_BYTES,
+        )
+        .map(({ table, name }) => `${table}: ${name}`)
+        .toSorted(),
+    ).toEqual([]);
+  });
+
+  test("drizzle-derived names over the limit are exactly the known set", () => {
+    expect(
+      names
+        .filter(
+          ({ name }) =>
+            Buffer.byteLength(name) > POSTGRES_IDENTIFIER_LIMIT_BYTES,
+        )
+        .map(({ name }) => name)
+        .toSorted(),
+    ).toEqual(LEGACY_DERIVED_NAMES_OVER_LIMIT.toSorted());
+  });
+});
 
 describe("schema invariants", () => {
   const polarityValues = Object.values(POLARITY).toSorted();

--- a/apps/api/src/tests/security/schema-invariants.test.ts
+++ b/apps/api/src/tests/security/schema-invariants.test.ts
@@ -212,7 +212,17 @@ describe("identifier length", () => {
   });
 
   test("drizzle-derived names over the limit are exactly the known set", () => {
-    const byCodepoint = (a: string, b: string) => (a < b ? -1 : a > b ? 1 : 0);
+    const byCodepoint = (a: string | undefined, b: string | undefined) => {
+      const left = a ?? "";
+      const right = b ?? "";
+      if (left < right) {
+        return -1;
+      }
+      if (left > right) {
+        return 1;
+      }
+      return 0;
+    };
     expect(
       overLimit(names)
         .map(({ name }) => name)


### PR DESCRIPTION
Two structural consistency efforts for the tenant schema.

## Composite tenant references

Only three dual-column tables carried the composite `(workspace_id, organization_id) → workspaces(id, organization_id)` reference that makes a workspace/org pairing structurally impossible to mismatch. The other 22 eligible tables now carry it too, with `ON DELETE` mirroring each table's existing workspace reference so the pair never contradicts it. Four tables are excluded for table-specific reasons documented in the schema (the audit log records workspace deletion after the row is gone; the two storage-cleanup outboxes are deliberately reference-free tombstones; `usage_events` needs a column-list `SET NULL` the ORM cannot yet express).

Rollout is staged for zero-lock-risk: one migration adds every constraint `NOT VALID`; a shared migration validates the eleven tenant-bounded tables; the eleven corpus-scaled tables each validate in their own migration with lock and statement timeouts, so a timeout names one table and retries alone. A catalog-derived invariant test asserts the dual-column class is non-empty, every non-exempt member carries a validated pair reference, and the exemption list cannot go stale in either direction.

## Constraint-name integrity

Eleven committed constraints had names over PostgreSQL's 63-byte identifier limit, silently truncated in the live catalog — so the schema model and the database disagreed about their names. Each is renamed (from its truncated catalog name) to an explicit short name, with the schema declarations updated to match. A new schema invariant asserts no chosen name exceeds 63 bytes (zero exemptions) and freezes the remaining set of derived-name divergences as decrease-only, so the class is closed for new code and visible for old.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened workspace and organisation data isolation across billing, chat, documents, templates, contacts and administration records.
  * Prevented records from being associated with mismatched workspace and organisation combinations.
  * Clarified deletion behaviour, including safe cascading cleanup and protection for active chat records.
  * Improved database constraint naming and validation reliability without changing existing data.

* **Tests**
  * Expanded security checks covering tenant boundaries, chat access and schema integrity.
  * Added safeguards to detect missing or invalid data-relationship constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->