### PR TITLE
test(api): pin the sse publish timeout against a silent peer

### DIFF
--- a/apps/api/scripts/run-tests.ts
+++ b/apps/api/scripts/run-tests.ts
@@ -160,14 +160,13 @@ const testPaths = [
   }),
 ].sort();
 
-// A path-shaped argument narrows each batch rather than joining it; see
+// A positional pattern narrows each batch rather than joining it; see
 // scripts/test-path-filters.ts for why appending would defeat the batcher.
-const { bunArguments, pathFilters } =
-  partitionRunnerArguments(forwardedArguments);
-const selectedTestPaths = selectTestPaths(testPaths, pathFilters);
+const { bunArguments, patterns } = partitionRunnerArguments(forwardedArguments);
+const selectedTestPaths = selectTestPaths(testPaths, patterns);
 
 if (selectedTestPaths?.size === 0) {
-  console.error(`No test files match: ${pathFilters.join(", ")}`);
+  console.error(`No test files match: ${patterns.join(", ")}`);
   process.exit(1);
 }
 

--- a/apps/api/scripts/run-tests.ts
+++ b/apps/api/scripts/run-tests.ts
@@ -7,6 +7,7 @@ import {
   readModuleMockMetadata,
   type ModuleMockTest,
 } from "../src/tests/module-mock-batching";
+import { partitionRunnerArguments, selectTestPaths } from "./test-path-filters";
 
 const PROPERTY_FLAG = "--property";
 const TEST_FILE_GLOB = "src/**/*.test.{ts,tsx}";
@@ -159,6 +160,23 @@ const testPaths = [
   }),
 ].sort();
 
+// A path-shaped argument narrows each batch rather than joining it; see
+// scripts/test-path-filters.ts for why appending would defeat the batcher.
+const { bunArguments, pathFilters } =
+  partitionRunnerArguments(forwardedArguments);
+const selectedTestPaths = selectTestPaths(testPaths, pathFilters);
+
+if (selectedTestPaths?.size === 0) {
+  console.error(`No test files match: ${pathFilters.join(", ")}`);
+  process.exit(1);
+}
+
+/** Keep a batch's composition, run only the selection inside it. */
+const selectWithinBatch = (batch: string[]): string[] =>
+  selectedTestPaths === null
+    ? batch
+    : batch.filter((testPath) => selectedTestPaths.has(testPath));
+
 const classifiedTests = await Promise.all(
   testPaths.map(async (testPath) => ({
     source: await Bun.file(path.join(apiRoot, testPath)).text(),
@@ -285,7 +303,7 @@ const runTests = async ({
   if (isolate) {
     command.push("--isolate");
   }
-  command.push(...forwardedArguments, ...testFiles);
+  command.push(...bunArguments, ...testFiles);
 
   const child = Bun.spawn({
     cmd: command,
@@ -344,7 +362,9 @@ const runTestBatches = async ({
     return 0;
   }
 
-  const batch = testFiles.slice(batchStart, batchStart + batchSize);
+  const batch = selectWithinBatch(
+    testFiles.slice(batchStart, batchStart + batchSize),
+  );
   const exitCode = await runTests({ isolate, maxPeakRssMb, testFiles: batch });
   if (exitCode !== 0) {
     return exitCode;
@@ -380,7 +400,11 @@ const runPreparedTestBatches = async ({
   if (batch === undefined) {
     return 0;
   }
-  const exitCode = await runTests({ isolate, maxPeakRssMb, testFiles: batch });
+  const exitCode = await runTests({
+    isolate,
+    maxPeakRssMb,
+    testFiles: selectWithinBatch(batch),
+  });
   if (exitCode !== 0) {
     return exitCode;
   }

--- a/apps/api/scripts/test-path-filters.ts
+++ b/apps/api/scripts/test-path-filters.ts
@@ -1,0 +1,71 @@
+/**
+ * Path-shaped CLI arguments select which discovered test files to run.
+ *
+ * They must never be appended to the batches the runner builds. Appending adds
+ * the file to EVERY batch, including batches deliberately built to keep it away
+ * from a test that mocks a module it imports, which is the isolation the
+ * batcher exists to provide (see src/tests/module-mock-batching.ts). A local
+ * run would then fail, or pass, for reasons CI never reproduces.
+ *
+ * So a path filter narrows each batch instead of joining it: composition is
+ * decided by the batcher over every discovered file, and the filter only picks
+ * which of those files run.
+ */
+
+/**
+ * Whether an argument selects test files rather than configuring bun.
+ *
+ * Deliberately narrow: a flag and its value (`-t`, `--bail 2`) must reach bun
+ * untouched, so only an argument that looks like a path counts.
+ */
+export const isTestPathFilter = (argument: string): boolean =>
+  !argument.startsWith("-") &&
+  (argument.includes("/") ||
+    argument.endsWith(".ts") ||
+    argument.endsWith(".tsx"));
+
+export type PartitionedArguments = {
+  /** Arguments handed to bun unchanged. */
+  bunArguments: string[];
+  /** Path-shaped arguments selecting which discovered files run. */
+  pathFilters: string[];
+};
+
+export const partitionRunnerArguments = (
+  runnerArguments: readonly string[],
+): PartitionedArguments => {
+  const bunArguments: string[] = [];
+  const pathFilters: string[] = [];
+  for (const argument of runnerArguments) {
+    if (isTestPathFilter(argument)) {
+      pathFilters.push(argument);
+      continue;
+    }
+    bunArguments.push(argument);
+  }
+  return { bunArguments, pathFilters };
+};
+
+const LEADING_RELATIVE_PREFIX = /^\.?\//u;
+
+/**
+ * The discovered paths a filter set selects, matched by substring the way bun
+ * matches a bare path argument. `null` means no filter was given, which the
+ * caller reads as "run every file in the batch".
+ */
+export const selectTestPaths = (
+  testPaths: readonly string[],
+  pathFilters: readonly string[],
+): ReadonlySet<string> | null => {
+  if (pathFilters.length === 0) {
+    return null;
+  }
+  const normalized = pathFilters.map((filter) =>
+    filter.replace(LEADING_RELATIVE_PREFIX, ""),
+  );
+  return new Set(
+    testPaths.filter((testPath) =>
+      normalized.some((filter) => testPath.includes(filter)),
+    ),
+  );
+};

--- a/apps/api/scripts/test-path-filters.ts
+++ b/apps/api/scripts/test-path-filters.ts
@@ -1,5 +1,5 @@
 /**
- * Path-shaped CLI arguments select which discovered test files to run.
+ * Positional arguments select which discovered test files to run.
  *
  * They must never be appended to the batches the runner builds. Appending adds
  * the file to EVERY batch, including batches deliberately built to keep it away
@@ -7,65 +7,117 @@
  * batcher exists to provide (see src/tests/module-mock-batching.ts). A local
  * run would then fail, or pass, for reasons CI never reproduces.
  *
- * So a path filter narrows each batch instead of joining it: composition is
- * decided by the batcher over every discovered file, and the filter only picks
- * which of those files run.
+ * So a positional narrows each batch instead of joining it: composition is
+ * decided by the batcher over every discovered file, and the positional only
+ * picks which of those files run.
+ *
+ * Classification tracks option arity rather than guessing from the shape of a
+ * string. Bun's own grammar is `bun test [flags] [...patterns]`, where a
+ * pattern is matched against the file path as a substring, so `redis-outage`
+ * is as much a pattern as `src/lib/redis-outage.test.ts`; and a value-taking
+ * flag's value may look exactly like a path (`--reporter-outfile reports/api.xml`,
+ * `-t "GET /workspaces"`) while belonging to bun.
  */
+
+/** Flags whose value is the following argument, so it is never a pattern. */
+const VALUE_FLAGS = new Set([
+  "-c",
+  "--concurrency",
+  "--config",
+  "--coverage-dir",
+  "--coverage-reporter",
+  "--cwd",
+  "--env-file",
+  "--max-concurrency",
+  "--preload",
+  "-r",
+  "--reporter",
+  "--reporter-outfile",
+  "--rerun-each",
+  "--shard",
+  "-t",
+  "--test-name-pattern",
+  "--timeout",
+]);
 
 /**
- * Whether an argument selects test files rather than configuring bun.
- *
- * Deliberately narrow: a flag and its value (`-t`, `--bail 2`) must reach bun
- * untouched, so only an argument that looks like a path counts.
+ * Flags whose value is optional and numeric (`--bail`, `--bail 3`). Only a
+ * bare integer is taken as the value, so `--bail some-pattern` still selects.
  */
-export const isTestPathFilter = (argument: string): boolean =>
-  !argument.startsWith("-") &&
-  (argument.includes("/") ||
-    argument.endsWith(".ts") ||
-    argument.endsWith(".tsx"));
+const OPTIONAL_NUMERIC_FLAGS = new Set(["--bail"]);
+
+const INTEGER_PATTERN = /^\d+$/u;
+const FLAGS_TERMINATOR = "--";
 
 export type PartitionedArguments = {
-  /** Arguments handed to bun unchanged. */
+  /** Arguments handed to bun unchanged, values included. */
   bunArguments: string[];
-  /** Path-shaped arguments selecting which discovered files run. */
-  pathFilters: string[];
+  /** Positional patterns selecting which discovered files run. */
+  patterns: string[];
 };
 
 export const partitionRunnerArguments = (
   runnerArguments: readonly string[],
 ): PartitionedArguments => {
   const bunArguments: string[] = [];
-  const pathFilters: string[] = [];
-  for (const argument of runnerArguments) {
-    if (isTestPathFilter(argument)) {
-      pathFilters.push(argument);
+  const patterns: string[] = [];
+  let onlyPatternsRemain = false;
+
+  for (let index = 0; index < runnerArguments.length; index += 1) {
+    const argument = runnerArguments[index] ?? "";
+
+    if (onlyPatternsRemain) {
+      patterns.push(argument);
       continue;
     }
+    if (argument === FLAGS_TERMINATOR) {
+      onlyPatternsRemain = true;
+      bunArguments.push(argument);
+      continue;
+    }
+    // `--flag=value` carries its value in the same token, so nothing follows.
+    if (!argument.startsWith("-")) {
+      patterns.push(argument);
+      continue;
+    }
+
     bunArguments.push(argument);
+    const next = runnerArguments[index + 1];
+    if (next === undefined) {
+      continue;
+    }
+    const takesNext =
+      VALUE_FLAGS.has(argument) ||
+      (OPTIONAL_NUMERIC_FLAGS.has(argument) && INTEGER_PATTERN.test(next));
+    if (takesNext) {
+      bunArguments.push(next);
+      index += 1;
+    }
   }
-  return { bunArguments, pathFilters };
+
+  return { bunArguments, patterns };
 };
 
 const LEADING_RELATIVE_PREFIX = /^\.?\//u;
 
 /**
- * The discovered paths a filter set selects, matched by substring the way bun
- * matches a bare path argument. `null` means no filter was given, which the
- * caller reads as "run every file in the batch".
+ * The discovered paths a pattern set selects, matched as a substring of the
+ * path the way bun matches a positional. `null` means no pattern was given,
+ * which the caller reads as "run every file in the batch".
  */
 export const selectTestPaths = (
   testPaths: readonly string[],
-  pathFilters: readonly string[],
+  patterns: readonly string[],
 ): ReadonlySet<string> | null => {
-  if (pathFilters.length === 0) {
+  if (patterns.length === 0) {
     return null;
   }
-  const normalized = pathFilters.map((filter) =>
-    filter.replace(LEADING_RELATIVE_PREFIX, ""),
+  const normalized = patterns.map((pattern) =>
+    pattern.replace(LEADING_RELATIVE_PREFIX, ""),
   );
   return new Set(
     testPaths.filter((testPath) =>
-      normalized.some((filter) => testPath.includes(filter)),
+      normalized.some((pattern) => testPath.includes(pattern)),
     ),
   );
 };

--- a/apps/api/src/lib/sse-publish-timeout.test.ts
+++ b/apps/api/src/lib/sse-publish-timeout.test.ts
@@ -1,0 +1,120 @@
+/**
+ * SSE publish against a peer that answered once and then stopped replying.
+ *
+ * `redis-outage.test.ts` covers the refused-connection outage, which the
+ * publisher's `connectionTimeout` bounds and which `enableOfflineQueue: false`
+ * turns into an immediate rejection. This is the outage neither option can
+ * see: the socket is established and healthy from the client's side, so no
+ * connect timer is armed and nothing is queued offline, yet a partitioned or
+ * paused peer never answers the PUBLISH. Against the real client that promise
+ * stays pending indefinitely, which would strand the desktop-edit-session
+ * expiry task, since it awaits its publish before stamping the notification
+ * column and only then releases its lease.
+ *
+ * Its own file because it fixes the process-global REDIS_URL, as
+ * `redis-outage.test.ts` does with a different value, and the publisher is a
+ * module singleton created once per process: the two cannot share one. Mocking
+ * the same module as that suite is what keeps them apart — the runner's
+ * batcher never co-batches two files that mock the same module (see
+ * `tests/module-mock-batching.ts`).
+ */
+
+import { afterAll, describe, expect, mock, test } from "bun:test";
+
+import { resourceRef, RESOURCE_TYPE } from "@stll/api-contract";
+
+let peerAnswers = true;
+
+// Speaks just enough RESP to complete a handshake and acknowledge a PUBLISH,
+// so the client reaches a genuinely connected state. Once `peerAnswers` flips,
+// PUBLISH gets no reply: the connection stays open and the command has nothing
+// to settle against, which is the failure under test.
+const partitionedPeer = Bun.listen({
+  hostname: "127.0.0.1",
+  port: 0,
+  socket: {
+    data(socket, data) {
+      const isPublish = data.toString().includes("PUBLISH");
+      if (isPublish && !peerAnswers) {
+        return;
+      }
+      socket.write(isPublish ? ":0\r\n" : "+OK\r\n");
+    },
+  },
+});
+
+const realEnv = await import("@/api/env-document-processing-worker");
+void mock.module("@/api/env-document-processing-worker", () => ({
+  envDocumentProcessingWorker: {
+    ...realEnv.envDocumentProcessingWorker,
+    REDIS_URL: `redis://127.0.0.1:${partitionedPeer.port}`,
+  },
+}));
+
+const { publishWorkspaceEvent, SSEBroadcastError } =
+  await import("@/api/lib/sse-broadcast");
+const { resourceUpdatedRealtimeEvent } = await import("@stll/api-contract");
+const { brandPersistedWorkspaceId, brandPersistedEntityId } =
+  await import("@/api/lib/safe-id-boundaries");
+
+const WORKSPACE_ID = brandPersistedWorkspaceId(
+  "01931f4a-0000-7000-8000-000000000001",
+);
+const EVENT = resourceUpdatedRealtimeEvent(
+  resourceRef({
+    type: RESOURCE_TYPE.ENTITY,
+    id: brandPersistedEntityId("01931f4a-0000-7000-8000-000000000002"),
+  }),
+);
+
+// Well above the publisher's 2s command timeout, so a merely slow publish
+// still passes while one that never settles fails this test instead of
+// hanging the batch.
+const PUBLISH_DEADLINE_MS = 15_000;
+
+const CONNECT_POLL_MS = 50;
+const CONNECT_ATTEMPTS = 40;
+
+/**
+ * The publisher disables the offline queue, so a command issued before the
+ * client finishes connecting rejects at once while it connects in the
+ * background. Publish until one succeeds, so the command under test is issued
+ * on a live socket: a publish rejected for being offline would pass this test
+ * for entirely the wrong reason.
+ */
+const publishUntilConnected = async (attemptsLeft: number): Promise<void> => {
+  const published = await publishWorkspaceEvent(WORKSPACE_ID, EVENT).then(
+    () => true,
+    () => false,
+  );
+  if (published) {
+    return;
+  }
+  if (attemptsLeft <= 1) {
+    throw new Error("the publisher never reached the local peer");
+  }
+  await Bun.sleep(CONNECT_POLL_MS);
+  await publishUntilConnected(attemptsLeft - 1);
+};
+
+afterAll(() => {
+  partitionedPeer.stop(true);
+});
+
+describe("SSE publish against a peer that stops replying", () => {
+  test(
+    "rejects on the command timeout instead of waiting on the peer forever",
+    async () => {
+      await publishUntilConnected(CONNECT_ATTEMPTS);
+      peerAnswers = false;
+
+      const rejection = await publishWorkspaceEvent(WORKSPACE_ID, EVENT).then(
+        () => null,
+        (error: unknown) => error,
+      );
+
+      expect(SSEBroadcastError.is(rejection)).toBe(true);
+    },
+    PUBLISH_DEADLINE_MS,
+  );
+});

--- a/apps/api/src/tests/test-path-filters.test.ts
+++ b/apps/api/src/tests/test-path-filters.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  isTestPathFilter,
+  partitionRunnerArguments,
+  selectTestPaths,
+} from "../../scripts/test-path-filters";
+
+const TEST_PATHS = [
+  "src/lib/redis-outage.test.ts",
+  "src/lib/sse-publish-timeout.test.ts",
+  "src/handlers/workspaces/get.test.ts",
+] as const;
+
+describe("partitionRunnerArguments", () => {
+  test("routes path arguments to the selector and everything else to bun", () => {
+    const { bunArguments, pathFilters } = partitionRunnerArguments([
+      "--bail",
+      "-t",
+      "publishes",
+      "src/lib/sse-publish-timeout.test.ts",
+    ]);
+
+    // `publishes` is a `-t` value, not a file: forwarding it as a filter would
+    // silently run nothing, and treating it as a path would drop the pattern.
+    expect(bunArguments).toEqual(["--bail", "-t", "publishes"]);
+    expect(pathFilters).toEqual(["src/lib/sse-publish-timeout.test.ts"]);
+  });
+
+  test("treats a bare directory as a path filter", () => {
+    expect(isTestPathFilter("src/handlers")).toBe(true);
+    expect(isTestPathFilter("get.test.ts")).toBe(true);
+    expect(isTestPathFilter("--isolate")).toBe(false);
+    expect(isTestPathFilter("publishes")).toBe(false);
+  });
+});
+
+describe("selectTestPaths", () => {
+  // The regression this guards: with no filter the runner must run each batch
+  // whole. Returning an empty selection instead would silently run nothing.
+  test("returns null when no filter is given, meaning run everything", () => {
+    expect(selectTestPaths(TEST_PATHS, [])).toBeNull();
+  });
+
+  test("selects only discovered files, never adding the filter itself", () => {
+    const selected = selectTestPaths(TEST_PATHS, [
+      "./src/lib/sse-publish-timeout.test.ts",
+    ]);
+
+    // A leading `./` is how a shell completes a path; it must still match, and
+    // the result must be the discovered path, since a batch is filtered by
+    // identity against it.
+    expect([...(selected ?? [])]).toEqual([
+      "src/lib/sse-publish-timeout.test.ts",
+    ]);
+  });
+
+  test("matches a directory prefix across files, as bun does", () => {
+    expect([...(selectTestPaths(TEST_PATHS, ["src/lib/"]) ?? [])]).toEqual([
+      "src/lib/redis-outage.test.ts",
+      "src/lib/sse-publish-timeout.test.ts",
+    ]);
+  });
+
+  test("selects nothing for a filter matching no discovered file", () => {
+    expect(selectTestPaths(TEST_PATHS, ["src/nope/absent.test.ts"])?.size).toBe(
+      0,
+    );
+  });
+});

--- a/apps/api/src/tests/test-path-filters.test.ts
+++ b/apps/api/src/tests/test-path-filters.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
 import {
-  isTestPathFilter,
   partitionRunnerArguments,
   selectTestPaths,
 } from "../../scripts/test-path-filters";
@@ -13,56 +12,105 @@ const TEST_PATHS = [
 ] as const;
 
 describe("partitionRunnerArguments", () => {
-  test("routes path arguments to the selector and everything else to bun", () => {
-    const { bunArguments, pathFilters } = partitionRunnerArguments([
-      "--bail",
+  test("keeps a value-taking flag's value with the flag, however it looks", () => {
+    // Both values are shaped like the things they are not: one like a path,
+    // one containing a slash. Classifying by shape would steal them from bun
+    // and then select nothing.
+    const { bunArguments, patterns } = partitionRunnerArguments([
+      "--reporter-outfile",
+      "reports/api.xml",
       "-t",
-      "publishes",
-      "src/lib/sse-publish-timeout.test.ts",
+      "GET /workspaces",
     ]);
 
-    // `publishes` is a `-t` value, not a file: forwarding it as a filter would
-    // silently run nothing, and treating it as a path would drop the pattern.
-    expect(bunArguments).toEqual(["--bail", "-t", "publishes"]);
-    expect(pathFilters).toEqual(["src/lib/sse-publish-timeout.test.ts"]);
+    expect(bunArguments).toEqual([
+      "--reporter-outfile",
+      "reports/api.xml",
+      "-t",
+      "GET /workspaces",
+    ]);
+    expect(patterns).toEqual([]);
   });
 
-  test("treats a bare directory as a path filter", () => {
-    expect(isTestPathFilter("src/handlers")).toBe(true);
-    expect(isTestPathFilter("get.test.ts")).toBe(true);
-    expect(isTestPathFilter("--isolate")).toBe(false);
-    expect(isTestPathFilter("publishes")).toBe(false);
+  test("treats a bare positional as a pattern, as bun does", () => {
+    // `bun test redis-outage` is the ordinary way to run one file. Leaving it
+    // to bun would append it to every batch and defeat the isolation.
+    const { bunArguments, patterns } = partitionRunnerArguments([
+      "redis-outage",
+    ]);
+
+    expect(bunArguments).toEqual([]);
+    expect(patterns).toEqual(["redis-outage"]);
+  });
+
+  test("takes an optional numeric value only when it is a number", () => {
+    expect(partitionRunnerArguments(["--bail", "3"])).toEqual({
+      bunArguments: ["--bail", "3"],
+      patterns: [],
+    });
+    expect(partitionRunnerArguments(["--bail", "redis-outage"])).toEqual({
+      bunArguments: ["--bail"],
+      patterns: ["redis-outage"],
+    });
+  });
+
+  test("passes valueless and inline-value flags through untouched", () => {
+    const { bunArguments, patterns } = partitionRunnerArguments([
+      "--isolate",
+      "--timeout=5000",
+      "src/lib",
+    ]);
+
+    expect(bunArguments).toEqual(["--isolate", "--timeout=5000"]);
+    expect(patterns).toEqual(["src/lib"]);
+  });
+
+  test("treats everything after -- as a pattern", () => {
+    const { bunArguments, patterns } = partitionRunnerArguments([
+      "--",
+      "-t",
+      "redis-outage",
+    ]);
+
+    expect(bunArguments).toEqual(["--"]);
+    expect(patterns).toEqual(["-t", "redis-outage"]);
   });
 });
 
 describe("selectTestPaths", () => {
-  // The regression this guards: with no filter the runner must run each batch
+  // The regression this guards: with no pattern the runner must run each batch
   // whole. Returning an empty selection instead would silently run nothing.
-  test("returns null when no filter is given, meaning run everything", () => {
+  test("returns null when no pattern is given, meaning run everything", () => {
     expect(selectTestPaths(TEST_PATHS, [])).toBeNull();
   });
 
-  test("selects only discovered files, never adding the filter itself", () => {
+  test("matches a bare name as a substring of the path", () => {
+    expect([...(selectTestPaths(TEST_PATHS, ["redis-outage"]) ?? [])]).toEqual([
+      "src/lib/redis-outage.test.ts",
+    ]);
+  });
+
+  test("selects only discovered files, never adding the pattern itself", () => {
+    // A leading `./` is how a shell completes a path; it must still match, and
+    // the result must be the discovered path, since a batch is filtered by
+    // identity against it.
     const selected = selectTestPaths(TEST_PATHS, [
       "./src/lib/sse-publish-timeout.test.ts",
     ]);
 
-    // A leading `./` is how a shell completes a path; it must still match, and
-    // the result must be the discovered path, since a batch is filtered by
-    // identity against it.
     expect([...(selected ?? [])]).toEqual([
       "src/lib/sse-publish-timeout.test.ts",
     ]);
   });
 
-  test("matches a directory prefix across files, as bun does", () => {
+  test("matches a directory prefix across files", () => {
     expect([...(selectTestPaths(TEST_PATHS, ["src/lib/"]) ?? [])]).toEqual([
       "src/lib/redis-outage.test.ts",
       "src/lib/sse-publish-timeout.test.ts",
     ]);
   });
 
-  test("selects nothing for a filter matching no discovered file", () => {
+  test("selects nothing for a pattern matching no discovered file", () => {
     expect(selectTestPaths(TEST_PATHS, ["src/nope/absent.test.ts"])?.size).toBe(
       0,
     );


### PR DESCRIPTION
The SSE publish command timeout landed in #1975 without a regression test. This is that test, plus the runner defect that is why it was dropped.

**The outage the connection options cannot see.** `connectionTimeout` bounds reaching a peer, and `enableOfflineQueue: false` rejects commands issued while disconnected. Neither covers a peer that completes the handshake and then stops replying: the socket is established, so no connect timer is armed and nothing is queued. Measured against the real Bun client, the publish promise was still pending after 4s and never settled, which would strand the desktop-edit-session expiry task holding its lease, since it awaits its publish before stamping the notification column.

The test speaks just enough RESP to complete a handshake and acknowledge a PUBLISH, then goes silent, and asserts the publish rejects. It fails by timing out when the command timeout is removed, so it is not vacuous. It publishes until one succeeds first, because the publisher disables the offline queue and rejects until the client has connected in the background: a publish rejected for being offline would pass this test for the wrong reason. Its own file, because it fixes the process-global `REDIS_URL` that `redis-outage.test.ts` fixes to a different value, and the publisher is a per-process singleton; mocking the same module as that suite is what keeps the batcher from co-batching them.

**The runner defect.** `scripts/run-tests.ts` globs every test file itself, batches them so a file that mocks a module never shares a process with one that imports it, then appended any CLI path argument to every batch's command line. A file named on the command line therefore ran inside every batch, including the batches built to isolate it. Locally this test ran alongside `redis-outage.test.ts`, failed for that reason alone, and I concluded the isolation was impossible and dropped the test; CI would have batched it correctly.

A path-shaped argument now filters each batch and skips batches it does not touch, so composition still comes from the batcher and a filtered run means what it says. Everything else, a `-t` pattern and its value included, reaches bun untouched. The parsing and selection moved into `scripts/test-path-filters.ts` with tests rather than staying inline, since a silent failure mode deserves a guard rather than a comment.

Verified: `bun scripts/run-tests.ts src/lib/sse-publish-timeout.test.ts src/lib/redis-outage.test.ts` now runs two isolated batches of one file each and both pass; before, it ran 150 tests across 12 files in shared processes.
