### PR TITLE
chore(dx): cache affected pre-push checks

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -32,8 +32,8 @@ pre-push:
   parallel: false
   commands:
     code-check:
-      # One Oxc type-aware pass covers changed workspaces plus reverse
-      # dependants. Global compiler/lint inputs fall back to the full repo.
+      # Turbo caches lint and typecheck per affected workspace, including
+      # reverse dependants. Global inputs fall back to the full repo.
       run: bun run code-check:affected -- --base origin/main
     format:
       run: bun run format --concurrency=2 -- --check

--- a/scripts/code-check-affected.test.ts
+++ b/scripts/code-check-affected.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
 import { affectedCommands, planCheck } from "./code-check-affected";
+import { isChangedLintPath } from "./lint-paths";
 
 const WORKSPACES = new Set([
   "apps/api",
@@ -10,9 +11,14 @@ const WORKSPACES = new Set([
   "packages/ui",
 ]);
 
-const plan = (changedPaths: string[], affectedWorkspacePaths: string[]) =>
+const plan = (
+  changedPaths: string[],
+  affectedWorkspacePaths: string[],
+  presentChangedPaths = changedPaths,
+) =>
   planCheck({
     changedPaths,
+    presentChangedPaths,
     affectedWorkspacePaths,
     workspacePaths: WORKSPACES,
   });
@@ -27,7 +33,7 @@ describe("affected code-check planning", () => {
     ).toEqual({
       type: "affected",
       targets: ["apps/landing", "apps/web", "packages/ui"],
-      checkLanding: true,
+      rootLintPaths: [],
     });
   });
 
@@ -35,24 +41,48 @@ describe("affected code-check planning", () => {
     expect(plan(["README.md"], [])).toEqual({
       type: "affected",
       targets: [],
-      checkLanding: false,
+      rootLintPaths: [],
     });
   });
 
-  test("keeps lint and TypeScript diagnostics in one affected Oxc pass", () => {
+  test("caches lint and typecheck per affected workspace", () => {
     const commands = affectedCommands({
       type: "affected",
       targets: ["apps/web", "packages/ui"],
-      checkLanding: false,
+      rootLintPaths: [],
     });
-    // Root scripts belong to no workspace, so the guard must run regardless
-    // of which targets were affected.
-    expect(commands).toContainEqual(["bash", "scripts/lint-root-scripts.sh"]);
     expect(commands).toContainEqual(["bun", "run", "env:check"]);
+    expect(commands).toContainEqual([
+      "bun",
+      "--bun",
+      "turbo",
+      "run",
+      "lint",
+      "typecheck",
+      "--concurrency=2",
+      "--filter=./apps/web",
+      "--filter=./packages/ui",
+    ]);
+  });
+
+  test("lints changed root scripts outside Turbo workspaces", () => {
+    const commands = affectedCommands({
+      type: "affected",
+      targets: [],
+      rootLintPaths: ["scripts/guard.ts"],
+    });
+
     const oxc = commands.find((command) => command.includes("oxlint"));
     expect(oxc).toContain("--type-aware");
-    expect(oxc).toContain("--type-check");
-    expect(oxc?.slice(-2)).toEqual(["apps/web", "packages/ui"]);
+    expect(oxc?.at(-1)).toBe("scripts/guard.ts");
+  });
+
+  test("typechecks dependants without trying to lint a deleted source", () => {
+    expect(plan(["packages/ui/src/removed.ts"], ["packages/ui"], [])).toEqual({
+      type: "affected",
+      targets: ["packages/ui"],
+      rootLintPaths: [],
+    });
   });
 
   test.each([
@@ -60,6 +90,7 @@ describe("affected code-check planning", () => {
     "bun.lock",
     "bunfig.toml",
     "scripts/code-check-affected.ts",
+    "scripts/lint-paths.ts",
     "scripts/lint-oxlint-fixtures.sh",
     "scripts/lint-root-scripts.sh",
     "scripts/tsconfig.json",
@@ -93,5 +124,28 @@ describe("affected code-check planning", () => {
       type: "full",
       changedPath: "invalid Turbo workspace output",
     });
+  });
+});
+
+describe("changed lint path selection", () => {
+  test.each([
+    "apps/api/src/server.ts",
+    "apps/web/src/route.tsx",
+    "scripts/guard.mjs",
+    "scripts/worker.mts",
+    "packages/ui/vite.config.js",
+  ])("includes lintable source %s", (changedPath) => {
+    expect(isChangedLintPath(changedPath)).toBe(true);
+  });
+
+  test.each([
+    "README.md",
+    "apps/web/src/routeTree.gen.ts",
+    "apps/web/src/client.gen.mts",
+    "apps/api/src/generated/schema.ts",
+    "apps/api/src/not-real.mtsx",
+    "packages/ui/node_modules/library/index.js",
+  ])("excludes non-source or generated path %s", (changedPath) => {
+    expect(isChangedLintPath(changedPath)).toBe(false);
   });
 });

--- a/scripts/code-check-affected.ts
+++ b/scripts/code-check-affected.ts
@@ -3,14 +3,16 @@
 // Fast local code-quality gate.
 //
 // CI keeps the full repository-wide `code-check`. Pre-push uses this wrapper
-// to ask Turbo for changed workspaces plus reverse dependants, then runs one
-// shared Oxlint/tsgolint program over those complete workspace roots. Global
-// compiler, dependency-graph, and lint inputs conservatively fall back to the
-// full check.
+// to ask Turbo for changed workspaces plus reverse dependants, then caches each
+// workspace's complete lint and typecheck independently with bounded
+// concurrency. Root scripts sit outside Turbo, so only changed root sources are
+// linted directly. Global inputs conservatively fall back to the full check.
 
 import { panic } from "better-result";
 import { existsSync, readdirSync } from "node:fs";
 import path from "node:path";
+
+import { isChangedLintPath } from "./lint-paths";
 
 const REPO_ROOT = path.resolve(import.meta.dirname, "..");
 const DEFAULT_BASE = "origin/main";
@@ -23,6 +25,7 @@ const FULL_CHECK_FILES = new Set([
   "oxlint.config.ts",
   "package.json",
   "scripts/code-check-affected.ts",
+  "scripts/lint-paths.ts",
   "scripts/lint-oxlint-fixtures.sh",
   "scripts/lint-root-scripts.sh",
   "scripts/tsconfig.json",
@@ -42,10 +45,15 @@ const FULL_CHECK_PREFIXES = [
 
 type CheckPlan =
   | { type: "full"; changedPath: string }
-  | { type: "affected"; targets: string[]; checkLanding: boolean };
+  | {
+      type: "affected";
+      targets: string[];
+      rootLintPaths: string[];
+    };
 
 type PlanCheckOptions = {
   changedPaths: readonly string[];
+  presentChangedPaths: readonly string[];
   affectedWorkspacePaths: readonly string[];
   workspacePaths: ReadonlySet<string>;
 };
@@ -70,6 +78,7 @@ const requiresFullCheck = (file: string): boolean =>
 
 export const planCheck = ({
   changedPaths,
+  presentChangedPaths,
   affectedWorkspacePaths,
   workspacePaths,
 }: PlanCheckOptions): CheckPlan => {
@@ -98,7 +107,15 @@ export const planCheck = ({
   return {
     type: "affected",
     targets,
-    checkLanding: targetSet.has("apps/landing"),
+    rootLintPaths: [
+      ...new Set(
+        presentChangedPaths.filter(
+          (changedPath) =>
+            workspaceForPath(changedPath) === null &&
+            isChangedLintPath(changedPath),
+        ),
+      ),
+    ].sort(),
   };
 };
 
@@ -224,17 +241,8 @@ const affectedWorkspacePaths = (mergeBase: string): string[] => {
 export const affectedCommands = (
   plan: Extract<CheckPlan, { type: "affected" }>,
 ) => {
-  // Root scripts sit outside every workspace, so no affected target covers
-  // their cross-cutting checks. Run those guards unconditionally.
-  const commands: string[][] = [
-    ["bun", "run", "env:check"],
-    ["bash", "scripts/lint-root-scripts.sh"],
-  ];
-  if (plan.checkLanding) {
-    commands.push(["bun", "--cwd", "apps/landing", "typecheck"]);
-    commands.push(["bun", "apps/landing/scripts/check-logical-properties.ts"]);
-  }
-  if (plan.targets.length > 0) {
+  const commands: string[][] = [["bun", "run", "env:check"]];
+  if (plan.rootLintPaths.length > 0) {
     commands.push([
       "bun",
       "--bun",
@@ -244,8 +252,19 @@ export const affectedCommands = (
       "--report-unused-disable-directives-severity=error",
       "--deny-warnings",
       "--type-aware",
-      "--type-check",
-      ...plan.targets,
+      ...plan.rootLintPaths,
+    ]);
+  }
+  if (plan.targets.length > 0) {
+    commands.push([
+      "bun",
+      "--bun",
+      "turbo",
+      "run",
+      "lint",
+      "typecheck",
+      "--concurrency=2",
+      ...plan.targets.map((target) => `--filter=./${target}`),
     ]);
   }
   commands.push(["bun", "run", "typecheck:repo"]);
@@ -257,6 +276,9 @@ const main = () => {
   const changed = changedPaths(options.base);
   const plan = planCheck({
     changedPaths: changed.paths,
+    presentChangedPaths: changed.paths.filter((changedPath) =>
+      existsSync(path.join(REPO_ROOT, changedPath)),
+    ),
     affectedWorkspacePaths: affectedWorkspacePaths(changed.mergeBase),
     workspacePaths: workspacePaths(),
   });

--- a/scripts/lint-changed.ts
+++ b/scripts/lint-changed.ts
@@ -12,6 +12,8 @@
 import { $ } from "bun";
 import { existsSync } from "node:fs";
 
+import { isChangedLintPath } from "./lint-paths";
+
 const mergeBase = (
   await $`git merge-base origin/main HEAD`.quiet().nothrow()
 ).stdout
@@ -25,17 +27,12 @@ const [committed, worktree, untracked] = await Promise.all([
   $`git ls-files --others --exclude-standard`.quiet().nothrow(),
 ]);
 
-const LINTABLE = /\.(ts|tsx|js|jsx|mjs|cjs)$/u;
-// oxlint already ignores these via config, but skip early so an all-generated
-// diff doesn't spin up the type-aware engine for nothing.
-const SKIP = /(\.gen\.ts$|\/generated\/|\/node_modules\/|routeTree\.gen)/u;
-
 const files = [
   ...new Set(
     [committed, worktree, untracked]
       .flatMap((r) => r.stdout.toString().split("\n"))
       .map((f) => f.trim())
-      .filter((f) => f && LINTABLE.test(f) && !SKIP.test(f))
+      .filter((f) => f !== "" && isChangedLintPath(f))
       .filter((f) => existsSync(f)),
   ),
 ];

--- a/scripts/lint-paths.ts
+++ b/scripts/lint-paths.ts
@@ -1,0 +1,6 @@
+const LINTABLE_SOURCE = /\.(?:[cm]?[jt]s|[jt]sx)$/u;
+const GENERATED_OR_EXTERNAL =
+  /(?:\.gen\.(?:[cm]?[jt]s|[jt]sx)$|\/generated\/|\/node_modules\/|routeTree\.gen)/u;
+
+export const isChangedLintPath = (file: string): boolean =>
+  LINTABLE_SOURCE.test(file) && !GENERATED_OR_EXTERNAL.test(file);


### PR DESCRIPTION
## Summary

- run complete type-aware lint and typechecks for affected workspaces and reverse dependants through Turbo
- cache each workspace independently and cap execution at two concurrent packages
- lint changed root scripts directly because they sit outside Turbo workspaces
- retain full repository fallback when global lint or compiler inputs change

A cold API+web lint completed in 63 seconds locally; an unchanged repeat reused both workspace caches in 0.13 seconds. This PR itself exercises the conservative full fallback because it modifies the planner.

CC on behalf of artichoke