### PR TITLE
chore(test): spread real modules in partial capture mocks

### DIFF
--- a/apps/api/src/handlers/chat/stream-chat-model-ingress.test.ts
+++ b/apps/api/src/handlers/chat/stream-chat-model-ingress.test.ts
@@ -4,7 +4,9 @@ import { describe, expect, mock, test } from "bun:test";
 import { toSafeId } from "@/api/lib/branded-types";
 
 const captureErrorMock = mock();
+const realCapture = await import("@/api/lib/analytics/capture");
 void mock.module("@/api/lib/analytics/capture", () => ({
+  ...realCapture,
   captureError: captureErrorMock,
   captureRequestError: captureErrorMock,
 }));

--- a/apps/api/src/handlers/chat/tools/execute/chat-code-mode.test.ts
+++ b/apps/api/src/handlers/chat/tools/execute/chat-code-mode.test.ts
@@ -15,7 +15,9 @@ import { toSafeDbMock } from "@/api/tests/scoped-db-mock";
 registerSandboxTestHygiene();
 
 const captureErrorMock = mock();
+const realCapture = await import("@/api/lib/analytics/capture");
 void mock.module("@/api/lib/analytics/capture", () => ({
+  ...realCapture,
   captureError: captureErrorMock,
   captureRequestError: captureErrorMock,
 }));

--- a/apps/api/src/handlers/chat/tools/external-mcp-tools-discovery.test.ts
+++ b/apps/api/src/handlers/chat/tools/external-mcp-tools-discovery.test.ts
@@ -22,7 +22,9 @@ void mock.module("@/api/lib/mcp-upstream/connections", () => ({
   loadActiveMcpConnectionsForUser: loadActiveMcpConnectionsForUserMock,
 }));
 
+const realCapture = await import("@/api/lib/analytics/capture");
 void mock.module("@/api/lib/analytics/capture", () => ({
+  ...realCapture,
   captureError: captureErrorMock,
   captureRequestError: captureErrorMock,
 }));

--- a/apps/api/src/handlers/chat/tools/registry-adapter/follow-ups.test.ts
+++ b/apps/api/src/handlers/chat/tools/registry-adapter/follow-ups.test.ts
@@ -11,7 +11,9 @@ import {
 import type { McpRequestContext } from "@/api/mcp/context";
 import { createScopedDbMock } from "@/api/tests/scoped-db-mock";
 
+const realCapture = await import("@/api/lib/analytics/capture");
 void mock.module("@/api/lib/analytics/capture", () => ({
+  ...realCapture,
   captureError: mock(),
   captureRequestError: mock(),
 }));

--- a/apps/api/src/handlers/chat/tools/registry-adapter/projection-schema.test.ts
+++ b/apps/api/src/handlers/chat/tools/registry-adapter/projection-schema.test.ts
@@ -16,7 +16,9 @@ import type {
 // Mocked so the fail-closed tests can assert the exact telemetry contract
 // (paths only, never values) without touching the analytics client.
 const captureErrorMock = mock();
+const realCapture = await import("@/api/lib/analytics/capture");
 void mock.module("@/api/lib/analytics/capture", () => ({
+  ...realCapture,
   captureError: captureErrorMock,
   captureRequestError: captureErrorMock,
 }));

--- a/apps/api/src/handlers/chat/tools/registry-adapter/registry-projection-contract.test.ts
+++ b/apps/api/src/handlers/chat/tools/registry-adapter/registry-projection-contract.test.ts
@@ -57,7 +57,9 @@ import { READ_TOOL_REF_FIELD_MAP } from "./ref-field-map";
 // --- Module mocks (before dynamic imports, canary pattern) -------------------
 
 const captureErrorMock = mock();
+const realCapture = await import("@/api/lib/analytics/capture");
 void mock.module("@/api/lib/analytics/capture", () => ({
+  ...realCapture,
   captureError: captureErrorMock,
   captureRequestError: captureErrorMock,
 }));

--- a/apps/api/src/handlers/chat/tools/registry-adapter/run-registry-tool.test.ts
+++ b/apps/api/src/handlers/chat/tools/registry-adapter/run-registry-tool.test.ts
@@ -10,7 +10,9 @@ import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
 import { toSafeDbMock } from "@/api/tests/scoped-db-mock";
 
 const captureErrorMock = mock();
+const realCapture = await import("@/api/lib/analytics/capture");
 void mock.module("@/api/lib/analytics/capture", () => ({
+  ...realCapture,
   captureError: captureErrorMock,
   captureRequestError: captureErrorMock,
 }));

--- a/apps/api/src/handlers/chat/tools/registry-adapter/run-registry-write-tool.test.ts
+++ b/apps/api/src/handlers/chat/tools/registry-adapter/run-registry-write-tool.test.ts
@@ -11,7 +11,9 @@ import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
 import { toSafeDbMock } from "@/api/tests/scoped-db-mock";
 
 const captureErrorMock = mock();
+const realCapture = await import("@/api/lib/analytics/capture");
 void mock.module("@/api/lib/analytics/capture", () => ({
+  ...realCapture,
   captureError: captureErrorMock,
   captureRequestError: captureErrorMock,
 }));

--- a/apps/api/src/handlers/chat/tools/template-tools-suggest-fields-error.test.ts
+++ b/apps/api/src/handlers/chat/tools/template-tools-suggest-fields-error.test.ts
@@ -28,7 +28,9 @@ void mock.module("@/api/lib/templates/suggest-template-fields", () => ({
   suggestTemplateFields: suggestTemplateFieldsMock,
 }));
 
+const realCapture = await import("@/api/lib/analytics/capture");
 void mock.module("@/api/lib/analytics/capture", () => ({
+  ...realCapture,
   captureError: captureErrorMock,
   captureRequestError: captureErrorMock,
 }));

--- a/apps/api/src/handlers/chat/tools/tool-policy.test.ts
+++ b/apps/api/src/handlers/chat/tools/tool-policy.test.ts
@@ -4,7 +4,9 @@ import type { ChatTool, ChatToolMap } from "@/api/lib/chat/chat-tool-types";
 
 const captureErrorMock = mock();
 
+const realCapture = await import("@/api/lib/analytics/capture");
 void mock.module("@/api/lib/analytics/capture", () => ({
+  ...realCapture,
   captureError: captureErrorMock,
   captureRequestError: captureErrorMock,
 }));

--- a/apps/api/src/handlers/entities/copy-to-workspace.test.ts
+++ b/apps/api/src/handlers/entities/copy-to-workspace.test.ts
@@ -86,7 +86,9 @@ void mock.module("@/api/lib/search/projection-repair-queue", () => ({
 }));
 
 const captureErrorMock = mock(() => undefined);
+const realCapture = await import("@/api/lib/analytics/capture");
 void mock.module("@/api/lib/analytics/capture", () => ({
+  ...realCapture,
   captureError: captureErrorMock,
   captureRequestError: captureErrorMock,
 }));

--- a/apps/api/src/handlers/entities/translate.test.ts
+++ b/apps/api/src/handlers/entities/translate.test.ts
@@ -84,7 +84,9 @@ void mock.module("@/api/lib/file-derivative-queue", () => ({
   initFileDerivativeWorker: mock(() => undefined),
 }));
 
+const realCapture = await import("@/api/lib/analytics/capture");
 void mock.module("@/api/lib/analytics/capture", () => ({
+  ...realCapture,
   captureError: captureErrorMock,
   captureRequestError: mock(() => {}),
 }));

--- a/apps/api/src/lib/analytics/capture.test.ts
+++ b/apps/api/src/lib/analytics/capture.test.ts
@@ -9,7 +9,9 @@ import {
 
 const captured: { properties: Record<string, unknown> }[] = [];
 
+const realClient = await import("@/api/lib/analytics/client");
 void mock.module("@/api/lib/analytics/client", () => ({
+  ...realClient,
   getAnalytics: () => ({
     capture: (params: { properties: Record<string, unknown> }) => {
       captured.push(params);

--- a/apps/api/src/lib/chat/model-ingress-guard.test.ts
+++ b/apps/api/src/lib/chat/model-ingress-guard.test.ts
@@ -9,7 +9,9 @@ import type {
 } from "@/api/lib/chat/model-ingress-guard";
 
 const captureErrorMock = mock();
+const realCapture = await import("@/api/lib/analytics/capture");
 void mock.module("@/api/lib/analytics/capture", () => ({
+  ...realCapture,
   captureError: captureErrorMock,
   captureRequestError: captureErrorMock,
 }));

--- a/apps/api/src/lib/entity-versions/create-entity-version-from-buffer.test.ts
+++ b/apps/api/src/lib/entity-versions/create-entity-version-from-buffer.test.ts
@@ -66,7 +66,9 @@ void mock.module("@/api/lib/sse", () => ({
   broadcast: broadcastMock,
   broadcastToOrganization: mock(),
 }));
+const realCapture = await import("@/api/lib/analytics/capture");
 void mock.module("@/api/lib/analytics/capture", () => ({
+  ...realCapture,
   captureError: mock(),
   captureRequestError: mock(),
 }));

--- a/apps/api/src/lib/flows/flow-run-worker.integration.test.ts
+++ b/apps/api/src/lib/flows/flow-run-worker.integration.test.ts
@@ -84,7 +84,9 @@ void mock.module("@/api/lib/flows/flow-run-queue", () => ({
   enqueueFlowStep: enqueueFlowStepMock,
 }));
 
+const realFlowRunEvents = await import("@/api/lib/flows/flow-run-events");
 void mock.module("@/api/lib/flows/flow-run-events", () => ({
+  ...realFlowRunEvents,
   broadcastFlowRunUpdate: mock(() => undefined),
 }));
 

--- a/apps/api/src/lib/flows/load-input-documents.test.ts
+++ b/apps/api/src/lib/flows/load-input-documents.test.ts
@@ -35,7 +35,9 @@ void mock.module("@/api/lib/flows/flow-run-queue", () => ({
   FLOW_RUN_QUEUE_NAME: "flow-run",
   enqueueFlowStep: mock(async () => {}),
 }));
+const realFlowRunEvents = await import("@/api/lib/flows/flow-run-events");
 void mock.module("@/api/lib/flows/flow-run-events", () => ({
+  ...realFlowRunEvents,
   broadcastFlowRunUpdate: mock(() => undefined),
 }));
 void mock.module("@/api/lib/tanstack-ai-generate", () => ({

--- a/apps/api/src/lib/flows/start-automated-flow-run.authz.test.ts
+++ b/apps/api/src/lib/flows/start-automated-flow-run.authz.test.ts
@@ -40,7 +40,9 @@ void mock.module("@/api/lib/flows/flow-run-queue", () => ({
   ),
 }));
 
+const realFlowRunEvents = await import("@/api/lib/flows/flow-run-events");
 void mock.module("@/api/lib/flows/flow-run-events", () => ({
+  ...realFlowRunEvents,
   broadcastFlowRunUpdate: mock(() => undefined),
 }));
 

--- a/apps/api/src/lib/mcp-upstream/connections.test.ts
+++ b/apps/api/src/lib/mcp-upstream/connections.test.ts
@@ -79,7 +79,9 @@ void mock.module("@/api/lib/safe-outbound-fetch", () => ({
     Result.ok({ url: new URL(url) }),
 }));
 
+const realCapture = await import("@/api/lib/analytics/capture");
 void mock.module("@/api/lib/analytics/capture", () => ({
+  ...realCapture,
   captureError: (error: unknown) => {
     state.captured.push(error);
   },

--- a/apps/api/src/lib/scheduler/tasks/search-semantic-timestamps.test.ts
+++ b/apps/api/src/lib/scheduler/tasks/search-semantic-timestamps.test.ts
@@ -15,7 +15,9 @@ void mock.module("@/api/db/root", () => ({
   rootDb: { execute: executeMock },
 }));
 
+const realCapture = await import("@/api/lib/analytics/capture");
 void mock.module("@/api/lib/analytics/capture", () => ({
+  ...realCapture,
   captureError: captureErrorMock,
 }));
 

--- a/apps/api/src/lib/search/index-entity.test.ts
+++ b/apps/api/src/lib/search/index-entity.test.ts
@@ -107,7 +107,9 @@ void mock.module("@/api/db/root", () => ({
   },
 }));
 
+const realCapture = await import("@/api/lib/analytics/capture");
 void mock.module("@/api/lib/analytics/capture", () => ({
+  ...realCapture,
   captureError: captureErrorMock,
 }));
 

--- a/apps/api/src/lib/tanstack-ai-generate.test.ts
+++ b/apps/api/src/lib/tanstack-ai-generate.test.ts
@@ -48,7 +48,9 @@ void mock.module("@tanstack/ai", () => ({
 }));
 
 const captureErrorMock = mock();
+const realCapture = await import("@/api/lib/analytics/capture");
 void mock.module("@/api/lib/analytics/capture", () => ({
+  ...realCapture,
   captureError: captureErrorMock,
   captureRequestError: captureErrorMock,
 }));

--- a/apps/api/src/lib/usage/unit-model.test.ts
+++ b/apps/api/src/lib/usage/unit-model.test.ts
@@ -2,7 +2,9 @@ import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 
 const captureErrorMock = mock();
 
+const realCapture = await import("@/api/lib/analytics/capture");
 void mock.module("@/api/lib/analytics/capture", () => ({
+  ...realCapture,
   captureError: captureErrorMock,
   captureRequestError: captureErrorMock,
 }));

--- a/apps/api/src/mcp/gateway/skills.test.ts
+++ b/apps/api/src/mcp/gateway/skills.test.ts
@@ -14,7 +14,9 @@ import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
 // captureError; mock it so the failure test stays hermetic and can assert the
 // error is captured (not silently swallowed) rather than depending on PostHog.
 const captureErrorMock = mock();
+const realCapture = await import("@/api/lib/analytics/capture");
 void mock.module("@/api/lib/analytics/capture", () => ({
+  ...realCapture,
   captureError: captureErrorMock,
   captureRequestError: mock(),
 }));

--- a/apps/api/src/mcp/internal-failure-envelope.test.ts
+++ b/apps/api/src/mcp/internal-failure-envelope.test.ts
@@ -16,7 +16,9 @@ import { toSafeDbMock } from "@/api/tests/scoped-db-mock";
 const captureErrorMock = mock();
 const createTimeEntryHandlerMock = mock();
 
+const realCapture = await import("@/api/lib/analytics/capture");
 void mock.module("@/api/lib/analytics/capture", () => ({
+  ...realCapture,
   captureError: captureErrorMock,
   captureRequestError: captureErrorMock,
 }));

--- a/apps/api/src/mcp/onboarding.test.ts
+++ b/apps/api/src/mcp/onboarding.test.ts
@@ -12,7 +12,9 @@ const searchDecisionsHandlerMock = mock();
 const readDecisionHandlerMock = mock();
 const APP_BASE_URL = env.FRONTEND_URL.replace(/\/$/u, "");
 
+const realCapture = await import("@/api/lib/analytics/capture");
 void mock.module("@/api/lib/analytics/capture", () => ({
+  ...realCapture,
   captureError: captureErrorMock,
   captureRequestError: captureErrorMock,
 }));

--- a/apps/api/src/mcp/template-tools.test.ts
+++ b/apps/api/src/mcp/template-tools.test.ts
@@ -31,7 +31,9 @@ const loadAnonymizationGazetteerEntriesMock = mock();
 const realAnonymizationBlacklist =
   await import("@/api/lib/anonymization-blacklist");
 
+const realCapture = await import("@/api/lib/analytics/capture");
 void mock.module("@/api/lib/analytics/capture", () => ({
+  ...realCapture,
   captureError: captureErrorMock,
   captureRequestError: captureErrorMock,
 }));

--- a/apps/api/src/mcp/tools.test.ts
+++ b/apps/api/src/mcp/tools.test.ts
@@ -195,7 +195,9 @@ const normalizeAnonymizationBlacklistEntriesMock = (
   return Result.ok(normalized);
 };
 
+const realCapture = await import("@/api/lib/analytics/capture");
 void mock.module("@/api/lib/analytics/capture", () => ({
+  ...realCapture,
   captureError: captureErrorMock,
   captureRequestError: captureErrorMock,
 }));

--- a/apps/api/src/tests/security/oxlint-guardrails.test.ts
+++ b/apps/api/src/tests/security/oxlint-guardrails.test.ts
@@ -576,7 +576,7 @@ describe("custom oxlint guardrails", () => {
     // Committed baseline, may only DECREASE: fix mocks and lower it. Raising it
     // means a new mock started dropping exports, and needs the same
     // justification as the other committed baselines in this repo.
-    const EXPORT_DROPPING_MOCK_BASELINE = 86;
+    const EXPORT_DROPPING_MOCK_BASELINE = 55;
     const root = path.join(import.meta.dir, "../../../../..");
     const apiRoot = path.join(root, "apps/api");
     const exportsByModuleFile = new Map<string, Set<string>>();


### PR DESCRIPTION
The export-dropping mock baseline (decrease-only, seeded at 86 by the module-mock factory guard) had its largest cluster on `@/api/lib/analytics/capture`: 24 files replacing the module with only the exports they override, so any co-batched consumer of a dropped export breaks by bin-packing rather than by cause.

28 factories across 28 files now spread the real module (`const real = await import(...)` + `...real`, the documented pattern): the full capture cluster, one `analytics/client` mock, and three `flow-run-events` mocks that were hand-mirroring a constant. Selection criteria for what was safe to make real: the module's top level declares only constants and functions with clients constructed lazily; no transitive import of `@/api/db/root` or a queue/network client the suite deliberately mocks away; and the module is already imported for real elsewhere in the test tree. Everything failing those criteria stays counted, by named reason (live-pool transitives, auth/crypto/network surfaces, AI provider registries).

`EXPORT_DROPPING_MOCK_BASELINE` drops 86 → 55, exact with no slack: the guard now fails immediately on any new partial mock, naming offenders (probed at 54, fails listing all 55; restored, green). All 28 touched suites plus the three mock-guard suites pass individually under isolation with zero behavioral fixes needed — every suite already overrode the export it controls, so the real siblings are inert. The batching interaction was checked: the added import cannot narrow batches because the batcher already excludes co-residents of a mocked module.

Remaining largest cluster (`process-extraction`, 7 files) needs a db-handle injection refactor rather than a mock-shape change; recorded as its own follow-up.