### PR TITLE
fix(lint): carry restriction unions through oxlint overrides

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -622,6 +622,20 @@ jobs:
         # local loop. Regenerate: `bun scripts/rc-bailouts.ts --write-baseline`.
         run: bun scripts/rc-bailouts.ts --check
 
+      - name: Oxlint override union guard
+        if: needs.ci-plan.outputs.package_checks_required == 'true'
+        # Oxlint resolves `overrides` by replacement: for a given file the last
+        # override that mentions a rule supplies that rule's whole
+        # configuration. For a list-of-restrictions rule
+        # (`no-restricted-imports` and friends) a scope that adds one ban
+        # therefore deletes every ban it inherited, and nothing fails — the
+        # forbidden import just stops being reported. This guard resolves the
+        # tracked rules against the real repository file list the way oxlint
+        # does and fails when a scope's effective restriction set is missing an
+        # inherited entry. Deliberate narrowings live in DELIBERATE_NARROWINGS
+        # with a reason and are checked in both directions.
+        run: bun test scripts/oxlint-override-union.test.ts
+
       - name: Ratchet guard
         if: needs.ci-plan.outputs.package_checks_required == 'true'
         # Whole-repo convention metrics (see RATCHET_METRICS in

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -139,6 +139,59 @@ const browserSurfaceFiles = [
   "packages/ui/src/**/*.{ts,tsx}",
 ] as const;
 
+// Shared `no-restricted-imports` entries.
+//
+// Oxlint resolves overrides by replacement, not by merge: for a given file the
+// last override that mentions a rule supplies that rule's entire
+// configuration. A scope that adds one import restriction therefore has to
+// restate every restriction it inherits from the base rule and from the
+// broader overrides that also match its files, or those bans silently stop
+// being reported. Compose each scope from the groups below instead of
+// retyping them; `scripts/oxlint-override-union.test.ts` fails when a scope
+// drops an inherited entry without a declared reason.
+const noZodImport = {
+  name: "zod",
+  message: "Use 'valibot' instead of 'zod'.",
+};
+
+const webLocalApiImportGroup = ["@/api/*", "@/api/**/*"];
+
+const webProtectedRouteImportGroup = [
+  "@/routes/_protected",
+  "@/routes/_protected/**",
+  "@/routes/_protected.*",
+  "@/routes/_protected.*/**",
+];
+
+const webCrossWorkspaceImports = [
+  {
+    group: ["@stll/api", "@stll/api/**", "!@stll/api/types"],
+    message: "apps/web may only import the public '@stll/api/types' surface.",
+  },
+  {
+    group: [
+      "@stll/desktop",
+      "@stll/desktop/**",
+      "@stll/landing",
+      "@stll/landing/**",
+    ],
+    message: "apps/web must not import other app workspaces directly.",
+  },
+];
+
+const webDatePickerImport = {
+  group: ["@stll/ui/components/date-picker-popover"],
+  message:
+    "Use '@/components/date-picker-popover' so locale labels are injected.",
+};
+
+const apiSafeIdBrandingImport = {
+  name: "@/api/lib/branded-types",
+  importNames: ["toSafeId"],
+  message:
+    "Only approved boundary modules and tests may brand raw IDs with toSafeId.",
+};
+
 export default defineConfig({
   extends: [core, react],
   rules: {
@@ -233,17 +286,7 @@ export default defineConfig({
     // get/set pairs are essentially absent — so the rule fires on
     // nothing while taking ~10% of lint time.
     "eslint/grouped-accessor-pairs": "off",
-    "no-restricted-imports": [
-      "error",
-      {
-        paths: [
-          {
-            name: "zod",
-            message: "Use 'valibot' instead of 'zod'.",
-          },
-        ],
-      },
-    ],
+    "no-restricted-imports": ["error", { paths: [noZodImport] }],
     "no-bare-error/no-bare-error": "error",
     "ai-output-strict-schema/ai-output-strict-schema": "error",
     "no-coerced-optional-union-enum/no-coerced-optional-union-enum": "error",
@@ -1338,12 +1381,7 @@ export default defineConfig({
         "no-restricted-imports": [
           "error",
           {
-            paths: [
-              {
-                name: "zod",
-                message: "Use 'valibot' instead of 'zod'.",
-              },
-            ],
+            paths: [noZodImport],
             patterns: [
               {
                 group: ["@stll/*", "@stll/*/**", "!@stll/ui", "!@stll/ui/**"],
@@ -1444,37 +1482,14 @@ export default defineConfig({
         "no-restricted-imports": [
           "error",
           {
-            paths: [
-              {
-                name: "zod",
-                message: "Use 'valibot' instead of 'zod'.",
-              },
-            ],
+            paths: [noZodImport],
             patterns: [
               {
-                group: ["@/api/*", "@/api/**/*"],
+                group: webLocalApiImportGroup,
                 message: "Use '@stll/api/types' instead of '@/api/'.",
               },
-              {
-                group: ["@stll/api", "@stll/api/**", "!@stll/api/types"],
-                message:
-                  "apps/web may only import the public '@stll/api/types' surface.",
-              },
-              {
-                group: [
-                  "@stll/desktop",
-                  "@stll/desktop/**",
-                  "@stll/landing",
-                  "@stll/landing/**",
-                ],
-                message:
-                  "apps/web must not import other app workspaces directly.",
-              },
-              {
-                group: ["@stll/ui/components/date-picker-popover"],
-                message:
-                  "Use '@/components/date-picker-popover' so locale labels are injected.",
-              },
+              ...webCrossWorkspaceImports,
+              webDatePickerImport,
             ],
           },
         ],
@@ -1554,16 +1569,21 @@ export default defineConfig({
       },
     },
     {
+      // The locale-injecting wrapper around the UI date picker: the one web
+      // module that has to import the primitive it wraps. Every other
+      // apps/web import restriction still applies, so they are restated here.
       files: ["apps/web/src/components/date-picker-popover.tsx"],
       rules: {
         "no-restricted-imports": [
           "error",
           {
-            paths: [
+            paths: [noZodImport],
+            patterns: [
               {
-                name: "zod",
-                message: "Use 'valibot' instead of 'zod'.",
+                group: webLocalApiImportGroup,
+                message: "Use '@stll/api/types' instead of '@/api/'.",
               },
+              ...webCrossWorkspaceImports,
             ],
           },
         ],
@@ -1579,10 +1599,7 @@ export default defineConfig({
           "error",
           {
             paths: [
-              {
-                name: "zod",
-                message: "Use 'valibot' instead of 'zod'.",
-              },
+              noZodImport,
               {
                 name: "@tanstack/react-router",
                 importNames: ["getRouteApi", "useRouteContext"],
@@ -1592,29 +1609,11 @@ export default defineConfig({
             ],
             patterns: [
               {
-                group: ["@/api/*", "@/api/**/*"],
+                group: webLocalApiImportGroup,
                 message: "Use '@stll/api/types' instead of '@/api/'.",
               },
-              {
-                group: ["@stll/api", "@stll/api/**", "!@stll/api/types"],
-                message:
-                  "apps/web may only import the public '@stll/api/types' surface.",
-              },
-              {
-                group: [
-                  "@stll/desktop",
-                  "@stll/desktop/**",
-                  "@stll/landing",
-                  "@stll/landing/**",
-                ],
-                message:
-                  "apps/web must not import other app workspaces directly.",
-              },
-              {
-                group: ["@stll/ui/components/date-picker-popover"],
-                message:
-                  "Use '@/components/date-picker-popover' so locale labels are injected.",
-              },
+              ...webCrossWorkspaceImports,
+              webDatePickerImport,
             ],
           },
         ],
@@ -1630,27 +1629,19 @@ export default defineConfig({
         "no-restricted-imports": [
           "error",
           {
-            paths: [
-              {
-                name: "zod",
-                message: "Use 'valibot' instead of 'zod'.",
-              },
-            ],
+            paths: [noZodImport],
             patterns: [
               {
-                group: [
-                  "@/routes/_protected",
-                  "@/routes/_protected/**",
-                  "@/routes/_protected.*",
-                  "@/routes/_protected.*/**",
-                ],
+                group: webProtectedRouteImportGroup,
                 message:
                   "Public law routes and shared case-law modules must not import protected route code. Move public-safe code to '@/features/case-law' instead.",
               },
               {
-                group: ["@/api/*", "@/api/**/*"],
+                group: webLocalApiImportGroup,
                 message: "Use '@stll/api/types' instead of '@/api/'.",
               },
+              ...webCrossWorkspaceImports,
+              webDatePickerImport,
             ],
           },
         ],
@@ -1664,10 +1655,7 @@ export default defineConfig({
           "error",
           {
             paths: [
-              {
-                name: "zod",
-                message: "Use 'valibot' instead of 'zod'.",
-              },
+              noZodImport,
               {
                 name: "@/lib/api",
                 importNames: ["api"],
@@ -1677,19 +1665,16 @@ export default defineConfig({
             ],
             patterns: [
               {
-                group: [
-                  "@/routes/_protected",
-                  "@/routes/_protected/**",
-                  "@/routes/_protected.*",
-                  "@/routes/_protected.*/**",
-                ],
+                group: webProtectedRouteImportGroup,
                 message:
                   "Public law routes and shared case-law modules must not import protected route code. Move public-safe code to '@/features/case-law' instead.",
               },
               {
-                group: ["@/api/*", "@/api/**/*"],
+                group: webLocalApiImportGroup,
                 message: "Use '@stll/api/types' instead of '@/api/'.",
               },
+              ...webCrossWorkspaceImports,
+              webDatePickerImport,
             ],
           },
         ],
@@ -1707,10 +1692,7 @@ export default defineConfig({
           "error",
           {
             paths: [
-              {
-                name: "zod",
-                message: "Use 'valibot' instead of 'zod'.",
-              },
+              noZodImport,
               {
                 name: "@/routes/-auth-context",
                 message:
@@ -1729,20 +1711,17 @@ export default defineConfig({
             ],
             patterns: [
               {
-                group: [
-                  "@/routes/_protected",
-                  "@/routes/_protected/**",
-                  "@/routes/_protected.*",
-                  "@/routes/_protected.*/**",
-                ],
+                group: webProtectedRouteImportGroup,
                 message:
                   "Public SEO endpoints must not import protected route code.",
               },
               {
-                group: ["@/api/*", "@/api/**/*"],
+                group: webLocalApiImportGroup,
                 message:
                   "Public SEO endpoints must use the public case-law API response, not web-local API internals.",
               },
+              ...webCrossWorkspaceImports,
+              webDatePickerImport,
             ],
           },
         ],
@@ -2164,16 +2143,7 @@ export default defineConfig({
       rules: {
         "no-restricted-imports": [
           "error",
-          {
-            paths: [
-              {
-                name: "@/api/lib/branded-types",
-                importNames: ["toSafeId"],
-                message:
-                  "Only approved boundary modules and tests may brand raw IDs with toSafeId.",
-              },
-            ],
-          },
+          { paths: [noZodImport, apiSafeIdBrandingImport] },
         ],
       },
     },
@@ -2194,10 +2164,7 @@ export default defineConfig({
           "error",
           {
             paths: [
-              {
-                name: "zod",
-                message: "Use 'valibot' instead of 'zod'.",
-              },
+              noZodImport,
               {
                 name: "@/api/db/root",
                 message:
@@ -2215,13 +2182,18 @@ export default defineConfig({
       },
     },
     {
+      // The sanctioned branding boundaries: each validates a raw id and hands
+      // back a SafeId, so these are the modules `toSafeId` exists for. Only
+      // that restriction is lifted; the rest of the base set still applies.
       files: [
         "apps/api/src/lib/auth.ts",
         "apps/api/src/lib/search/**",
         "apps/api/src/lib/safe-id-boundaries.ts",
         "apps/api/src/types.ts",
       ],
-      rules: { "no-restricted-imports": "off" },
+      rules: {
+        "no-restricted-imports": ["error", { paths: [noZodImport] }],
+      },
     },
     {
       // YARA's compile/scan returns loosely-typed RuleMatch; the local
@@ -2404,10 +2376,7 @@ export default defineConfig({
           "error",
           {
             paths: [
-              {
-                name: "zod",
-                message: "Use 'valibot' instead of 'zod'.",
-              },
+              noZodImport,
               {
                 name: "@/api/lib/api-handlers",
                 importNames: ["createHandler", "createRootHandler"],
@@ -2450,12 +2419,17 @@ export default defineConfig({
       },
     },
     {
+      // Tests build handler context and owner-level DB handles directly: that
+      // fixture surface is exactly what the handler restrictions keep out of
+      // production code, so it is lifted here. The base set still applies.
       files: [
         "apps/api/src/tests/**",
         "apps/api/**/*.{test,spec}.{ts,tsx,js,jsx}",
         "apps/api/**/__tests__/**/*.{ts,tsx,js,jsx}",
       ],
-      rules: { "no-restricted-imports": "off" },
+      rules: {
+        "no-restricted-imports": ["error", { paths: [noZodImport] }],
+      },
     },
     {
       files: [
@@ -2501,9 +2475,13 @@ export default defineConfig({
           "error",
           {
             paths: [
+              noZodImport,
+              apiSafeIdBrandingImport,
               {
-                name: "zod",
-                message: "Use 'valibot' instead of 'zod'.",
+                name: "@/api/lib/api-handlers",
+                importNames: ["createHandler", "createRootHandler"],
+                message:
+                  "Use 'createSafeHandler' or 'createSafeRootHandler' instead.",
               },
               {
                 name: "@/api/lib/api-handlers",

--- a/scripts/oxlint-override-union.test.ts
+++ b/scripts/oxlint-override-union.test.ts
@@ -1,0 +1,411 @@
+// Guard: an oxlint override must not silently drop an inherited restriction.
+//
+// Oxlint resolves `overrides` by replacement, not by merge: for a given file
+// the last override that mentions a rule supplies that rule's entire
+// configuration, and everything the base rule or an earlier matching override
+// configured is discarded. For a severity-only rule that is harmless. For a
+// rule whose configuration is a *list of restrictions* (`no-restricted-imports`
+// and friends) it silently deletes bans, and nothing fails: the forbidden
+// import simply stops being reported.
+//
+// This guard resolves every tracked rule against the real repository file list
+// exactly the way oxlint does, then compares the effective restriction set of
+// each file with the union of every restriction that matched it. A missing
+// entry has to be listed in DELIBERATE_NARROWINGS with a reason, so narrowing a
+// scope stays possible but never accidental.
+
+import { expect, test } from "bun:test";
+import { fileURLToPath } from "node:url";
+
+import config from "../oxlint.config.ts";
+
+const repoRoot = fileURLToPath(new URL("..", import.meta.url));
+
+const LINTED_FILE_PATTERN = /\.(?:[cm]?[jt]sx?)$/u;
+
+// Rules whose configuration is a list of restrictions rather than a knob, so a
+// narrower scope is expected to inherit what a broader scope already forbids.
+// A `no-restricted-*` rule configured with options anywhere in the config but
+// missing here fails the totality test below.
+const TRACKED_RULES = [
+  "no-restricted-imports",
+  "no-restricted-globals",
+] as const;
+
+type UnionRule = (typeof TRACKED_RULES)[number];
+
+// Restrictions a scope drops on purpose. `scope` is the override's `files`
+// list joined with ", "; `drops` are the entry keys the guard reports. An
+// entry that no longer drops anything fails too, so the table cannot rot.
+const DELIBERATE_NARROWINGS = [
+  {
+    rule: "no-restricted-imports",
+    scope: "apps/web/src/components/date-picker-popover.tsx",
+    drops: ["pattern:@stll/ui/components/date-picker-popover"],
+    reason:
+      "This file is the locale-injecting wrapper around the UI primitive, so it is the one web module that has to import it.",
+  },
+  {
+    rule: "no-restricted-imports",
+    scope:
+      "apps/api/src/lib/auth.ts, apps/api/src/lib/search/**, apps/api/src/lib/safe-id-boundaries.ts, apps/api/src/types.ts",
+    drops: ["path:@/api/lib/branded-types#toSafeId"],
+    reason:
+      "These are the sanctioned branding boundaries: they validate a raw id and hand back a SafeId, so they are the modules toSafeId exists for.",
+  },
+  {
+    rule: "no-restricted-imports",
+    scope:
+      "apps/api/src/tests/**, apps/api/**/*.{test,spec}.{ts,tsx,js,jsx}, apps/api/**/__tests__/**/*.{ts,tsx,js,jsx}",
+    drops: [
+      "path:@/api/db#createSafeDb",
+      "path:@/api/db#createScopedDb",
+      "path:@/api/db#db",
+      "path:@/api/db/root#rlsDb,rootDb",
+      "path:@/api/lib/api-handlers#createHandler,createRootHandler",
+      "path:@/api/lib/branded-types#toSafeId",
+    ],
+    reason:
+      "Tests build handler context and owner-level DB handles directly; that is the fixture surface the production restrictions exist to keep out of handlers.",
+  },
+] as const;
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const stringArray = (value: unknown): string[] =>
+  Array.isArray(value)
+    ? value.filter((entry): entry is string => typeof entry === "string")
+    : [];
+
+const readString = (source: Record<string, unknown>, key: string) => {
+  const value = source[key];
+  return typeof value === "string" ? value : undefined;
+};
+
+/** `["error", …options]` → the options; anything else → no options. */
+const ruleOptions = (value: unknown): unknown[] =>
+  Array.isArray(value) ? value.slice(1) : [];
+
+const ruleIsOff = (value: unknown) => {
+  const severity = Array.isArray(value) ? value[0] : value;
+  return severity === "off" || severity === 0;
+};
+
+const pathKey = (name: string, importNames: string[]) =>
+  importNames.length === 0
+    ? `path:${name}`
+    : `path:${name}#${[...importNames].sort((a, b) => a.localeCompare(b)).join(",")}`;
+
+const restrictedImportKeys = (options: unknown): string[] => {
+  const keys: string[] = [];
+  const collectPath = (entry: unknown) => {
+    if (typeof entry === "string") {
+      keys.push(pathKey(entry, []));
+      return;
+    }
+    if (!isRecord(entry)) {
+      return;
+    }
+    const name = readString(entry, "name");
+    if (name === undefined) {
+      return;
+    }
+    keys.push(pathKey(name, stringArray(entry["importNames"])));
+  };
+  const collectPattern = (entry: unknown) => {
+    if (typeof entry === "string") {
+      keys.push(`pattern:${entry}`);
+      return;
+    }
+    if (!isRecord(entry)) {
+      return;
+    }
+    const group = stringArray(entry["group"]);
+    if (group.length > 0) {
+      keys.push(`pattern:${group.join("|")}`);
+      return;
+    }
+    const regex = readString(entry, "regex");
+    if (regex !== undefined) {
+      keys.push(`regex:${regex}`);
+    }
+  };
+
+  for (const option of ruleOptions(options)) {
+    if (typeof option === "string") {
+      collectPath(option);
+      continue;
+    }
+    if (!isRecord(option)) {
+      continue;
+    }
+    for (const entry of Array.isArray(option["paths"]) ? option["paths"] : []) {
+      collectPath(entry);
+    }
+    for (const entry of Array.isArray(option["patterns"])
+      ? option["patterns"]
+      : []) {
+      collectPattern(entry);
+    }
+  }
+  return keys;
+};
+
+const restrictedGlobalKeys = (options: unknown): string[] => {
+  const keys: string[] = [];
+  for (const option of ruleOptions(options)) {
+    if (typeof option === "string") {
+      keys.push(`global:${option}`);
+      continue;
+    }
+    if (!isRecord(option)) {
+      continue;
+    }
+    const name = readString(option, "name");
+    if (name !== undefined) {
+      keys.push(`global:${name}`);
+    }
+  }
+  return keys;
+};
+
+// One stable key per restriction entry, per tracked rule.
+const RESTRICTION_KEYS = {
+  "no-restricted-imports": restrictedImportKeys,
+  "no-restricted-globals": restrictedGlobalKeys,
+} as const satisfies Record<UnionRule, (options: unknown) => string[]>;
+
+// A whole-module ban subsumes an import-name-scoped ban on the same module:
+// forbidding `@/api/db` outright already covers `@/api/db#db`.
+const covers = (effective: ReadonlySet<string>, wanted: string) => {
+  if (effective.has(wanted)) {
+    return true;
+  }
+  const separator = wanted.indexOf("#");
+  return separator > 0 && effective.has(wanted.slice(0, separator));
+};
+
+type ScopeConfig = {
+  scope: string;
+  files: string[];
+  excludeFiles: string[];
+  rules: Record<string, unknown>;
+};
+
+const readScopes = (root: unknown): ScopeConfig[] => {
+  if (!isRecord(root)) {
+    return [];
+  }
+  const scopes: ScopeConfig[] = [];
+  const baseRules = root["rules"];
+  if (isRecord(baseRules)) {
+    scopes.push({
+      scope: "<base>",
+      files: ["**"],
+      excludeFiles: [],
+      rules: baseRules,
+    });
+  }
+  const overrides = Array.isArray(root["overrides"]) ? root["overrides"] : [];
+  for (const override of overrides) {
+    if (!isRecord(override)) {
+      continue;
+    }
+    const rules = override["rules"];
+    if (!isRecord(rules)) {
+      continue;
+    }
+    const files = stringArray(override["files"]);
+    if (files.length === 0) {
+      continue;
+    }
+    scopes.push({
+      scope: files.join(", "),
+      files,
+      excludeFiles: stringArray(override["excludeFiles"]),
+      rules,
+    });
+  }
+  return scopes;
+};
+
+const globCache = new Map<string, Bun.Glob>();
+const matches = (pattern: string, file: string) => {
+  const cached = globCache.get(pattern) ?? new Bun.Glob(pattern);
+  globCache.set(pattern, cached);
+  return cached.match(file);
+};
+
+const scopeMatches = (scope: ScopeConfig, file: string) =>
+  scope.files.some((pattern) => matches(pattern, file)) &&
+  !scope.excludeFiles.some((pattern) => matches(pattern, file));
+
+type Drop = { rule: string; scope: string; entry: string };
+
+const dropKey = (drop: Drop) => `${drop.rule} | ${drop.scope} | ${drop.entry}`;
+
+/**
+ * Resolve `rule` the way oxlint does — last matching scope wins outright — and
+ * report every restriction that some matching scope declared but the winning
+ * scope does not carry.
+ */
+const findDrops = (
+  root: unknown,
+  files: readonly string[],
+  rule: UnionRule,
+): Drop[] => {
+  const entryKeys = RESTRICTION_KEYS[rule];
+  const scopes = readScopes(root).filter((scope) => rule in scope.rules);
+  const drops = new Map<string, Drop>();
+
+  for (const file of files) {
+    const matching = scopes.filter((scope) => scopeMatches(scope, file));
+    const winner = matching.at(-1);
+    if (winner === undefined) {
+      continue;
+    }
+    const effective = new Set(
+      ruleIsOff(winner.rules[rule]) ? [] : entryKeys(winner.rules[rule]),
+    );
+    for (const scope of matching) {
+      if (scope === winner) {
+        continue;
+      }
+      for (const wanted of entryKeys(scope.rules[rule])) {
+        if (covers(effective, wanted)) {
+          continue;
+        }
+        const drop = { rule, scope: winner.scope, entry: wanted };
+        drops.set(dropKey(drop), drop);
+      }
+    }
+  }
+  return [...drops.values()];
+};
+
+const lintedRepoFiles = () => {
+  const result = Bun.spawnSync(["git", "ls-files", "-z"], { cwd: repoRoot });
+  if (!result.success) {
+    throw new Error("git ls-files failed; cannot resolve the override scopes");
+  }
+  const files = new TextDecoder()
+    .decode(result.stdout)
+    .split("\0")
+    .filter((file) => LINTED_FILE_PATTERN.test(file));
+  if (files.length === 0) {
+    throw new Error("git ls-files returned no lintable files");
+  }
+  return files;
+};
+
+test("resolves overrides by replacement, last match first", () => {
+  const synthetic = {
+    rules: { "no-restricted-imports": ["error", { paths: ["base"] }] },
+    overrides: [
+      {
+        files: ["src/**"],
+        rules: { "no-restricted-imports": ["error", { paths: ["broad"] }] },
+      },
+      {
+        files: ["src/narrow/**"],
+        excludeFiles: ["src/narrow/exempt.ts"],
+        rules: { "no-restricted-imports": ["error", { paths: ["narrow"] }] },
+      },
+    ],
+  };
+
+  expect(
+    findDrops(synthetic, ["src/narrow/a.ts"], "no-restricted-imports").map(
+      dropKey,
+    ),
+  ).toEqual([
+    "no-restricted-imports | src/narrow/** | path:base",
+    "no-restricted-imports | src/narrow/** | path:broad",
+  ]);
+  // excludeFiles hands the file back to the broader override, which still
+  // drops the base entry.
+  expect(
+    findDrops(synthetic, ["src/narrow/exempt.ts"], "no-restricted-imports").map(
+      dropKey,
+    ),
+  ).toEqual(["no-restricted-imports | src/** | path:base"]);
+});
+
+test("a whole-module ban subsumes an import-name ban on that module", () => {
+  const synthetic = {
+    rules: {},
+    overrides: [
+      {
+        files: ["src/**"],
+        rules: {
+          "no-restricted-imports": [
+            "error",
+            { paths: [{ name: "@/db", importNames: ["rootDb"] }] },
+          ],
+        },
+      },
+      {
+        files: ["src/public/**"],
+        rules: {
+          "no-restricted-imports": ["error", { paths: [{ name: "@/db" }] }],
+        },
+      },
+    ],
+  };
+
+  expect(
+    findDrops(synthetic, ["src/public/a.ts"], "no-restricted-imports"),
+  ).toEqual([]);
+});
+
+test("every restriction-shaped rule with options is tracked", () => {
+  const scopes = readScopes(config);
+  const configured = new Set<string>();
+  for (const scope of scopes) {
+    for (const [rule, value] of Object.entries(scope.rules)) {
+      if (!/(?:^|\/)no-restricted-/u.test(rule)) {
+        continue;
+      }
+      if (ruleOptions(value).length === 0) {
+        continue;
+      }
+      configured.add(rule);
+    }
+  }
+  const sorted = (names: Iterable<string>) =>
+    [...names].sort((a, b) => a.localeCompare(b));
+  expect(sorted(configured)).toEqual(sorted(TRACKED_RULES));
+});
+
+test("override scopes that configure a tracked rule are uniquely named", () => {
+  const scopes = readScopes(config);
+  for (const rule of TRACKED_RULES) {
+    const names = scopes
+      .filter((scope) => rule in scope.rules)
+      .map((scope) => scope.scope);
+    expect(new Set(names).size).toBe(names.length);
+  }
+});
+
+test("no override silently drops an inherited restriction", () => {
+  const files = lintedRepoFiles();
+  const observed = new Set<string>();
+  for (const rule of TRACKED_RULES) {
+    for (const drop of findDrops(config, files, rule)) {
+      observed.add(dropKey(drop));
+    }
+  }
+
+  const declared = new Set(
+    DELIBERATE_NARROWINGS.flatMap(({ rule, scope, drops }) =>
+      drops.map((entry) => dropKey({ rule, scope, entry })),
+    ),
+  );
+
+  const sorted = (values: Iterable<string>) =>
+    [...values].sort((a, b) => a.localeCompare(b));
+  // Both directions: an undeclared drop is the bug this guard exists for, and
+  // a declared drop that no longer happens means the table is stale.
+  expect(sorted(observed)).toEqual(sorted(declared));
+});

--- a/scripts/oxlint-override-union.test.ts
+++ b/scripts/oxlint-override-union.test.ts
@@ -97,6 +97,34 @@ const pathKey = (name: string, importNames: string[]) =>
     ? `path:${name}`
     : `path:${name}#${[...importNames].sort((a, b) => a.localeCompare(b)).join(",")}`;
 
+/**
+ * Fields the comparison keys above account for. `message` carries no
+ * enforcement, so it is known and ignored.
+ *
+ * Anything else is a field that can change what an entry forbids while leaving
+ * its key identical — `allowTypeImports` and `allowImportNames` weaken a ban
+ * in place, `caseSensitive` and `importNamePattern` change what it matches — so
+ * an override could relax an inherited restriction and still look like it
+ * carries it. The guard fails closed on an unknown field rather than compare
+ * on a key that no longer describes the entry: teach the key builder first.
+ */
+const KNOWN_PATH_FIELDS = new Set(["name", "importNames", "message"]);
+const KNOWN_PATTERN_FIELDS = new Set(["group", "regex", "message"]);
+
+const unhandledEntryFields: string[] = [];
+
+const recordUnhandledFields = (
+  entry: Record<string, unknown>,
+  known: ReadonlySet<string>,
+  shape: string,
+) => {
+  for (const field of Object.keys(entry)) {
+    if (!known.has(field)) {
+      unhandledEntryFields.push(`${shape}.${field}`);
+    }
+  }
+};
+
 const restrictedImportKeys = (options: unknown): string[] => {
   const keys: string[] = [];
   const collectPath = (entry: unknown) => {
@@ -107,6 +135,7 @@ const restrictedImportKeys = (options: unknown): string[] => {
     if (!isRecord(entry)) {
       return;
     }
+    recordUnhandledFields(entry, KNOWN_PATH_FIELDS, "paths");
     const name = readString(entry, "name");
     if (name === undefined) {
       return;
@@ -121,6 +150,7 @@ const restrictedImportKeys = (options: unknown): string[] => {
     if (!isRecord(entry)) {
       return;
     }
+    recordUnhandledFields(entry, KNOWN_PATTERN_FIELDS, "patterns");
     const group = stringArray(entry["group"]);
     if (group.length > 0) {
       keys.push(`pattern:${group.join("|")}`);
@@ -386,6 +416,23 @@ test("override scopes that configure a tracked rule are uniquely named", () => {
       .map((scope) => scope.scope);
     expect(new Set(names).size).toBe(names.length);
   }
+});
+
+test("every restriction field is accounted for in the comparison key", () => {
+  // Run the collectors over the whole config so every entry is visited, then
+  // fail on any field the keys do not encode. Without this the guard compares
+  // on a key that can describe two entries with different enforcement: an
+  // override adding `allowTypeImports` or `allowImportNames` weakens an
+  // inherited ban in place, and a key built from name and importNames alone
+  // still matches, so the weakening reads as carrying the restriction.
+  unhandledEntryFields.length = 0;
+  for (const scope of readScopes(config)) {
+    for (const rule of TRACKED_RULES) {
+      RESTRICTION_KEYS[rule](scope.rules[rule]);
+    }
+  }
+
+  expect([...new Set(unhandledEntryFields)].sort()).toEqual([]);
 });
 
 test("no override silently drops an inherited restriction", () => {

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -241,6 +241,8 @@ else
   run_step "Result consumption" bun run check:result-consumption -- --all
 fi
 run_step "React Compiler bailout guard" bun scripts/rc-bailouts.ts --check
+run_step "Oxlint override union guard" bun test \
+  scripts/oxlint-override-union.test.ts
 run_step "Ratchet guard" run_ratchet_guard
 run_step "Suppression waiver ledger" run_suppression_waiver_guard
 run_step "Crawl posture guard" run_crawl_posture_guard


### PR DESCRIPTION
oxlint overrides replace a rule's configuration rather than merging it, so every `no-restricted-imports` override silently dropped the restrictions of the scopes beneath it. The audit (each drop verified by an unflagged probe import) found 25 dropped entries across 8 effective scopes, 17 of them unintended. The most load-bearing: `handlers/**/public-routes.ts` could import `createHandler`/`createRootHandler` — precisely the constructors the sibling override bans — and two `"off"` overrides disabled the base zod ban entirely.

Every override now carries the explicit union, composed from named entry groups rather than repeated literals, and the two `"off"` scopes became explicit configs. This restatement pattern was already the incumbent (12 of 13 overrides restated the zod ban); the alternative dedicated-rule shape stays where it already lives.

The class is killed by `scripts/oxlint-override-union.test.ts` (wired into verify and `ci-checks`): it enumerates scopes against the real file corpus with last-match-wins semantics, reports any entry a matching scope declares that the winner drops, honors whole-module-subsumes-named-import, and pins deliberate narrowings in an annotated exception table asserted in both directions (an undeclared drop fails; a stale exception fails). A totality check makes any new options-carrying `no-restricted-*` rule require a tracking decision. Detection was mutation-tested (removing an entry fails; a stale exception fails), and the guard's pre-fix output matched the probe results exactly.

Re-enabling the dropped restrictions surfaced zero live violations, so this is guard repair with no behavioral fallout. Follow-up recorded separately: the `toSafeId` ban names one module path but the symbol is re-exported through two others that production code imports today; closing that is a re-export restructuring with per-call-site review.