### PR TITLE
fix(workflow): run straggler catch-up after scoped runs

### DIFF
--- a/apps/api/src/lib/document-review/playbook-run-start.test.ts
+++ b/apps/api/src/lib/document-review/playbook-run-start.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import path from "node:path";
 
 import {
   PLAYBOOK_RUN_START_OUTCOME,
@@ -7,6 +9,23 @@ import {
 import { WORKFLOW_START_STATUSES } from "@/api/lib/workflow-queue";
 
 const OUTCOMES = Object.values(PLAYBOOK_RUN_START_OUTCOME);
+
+const API_ROOT = path.resolve(import.meta.dir, "../../..");
+const QUEUE_SOURCE = "src/lib/workflow-queue.ts";
+
+/** The finalizer's body: from its declaration to the closing brace in column
+ *  one, so only its own statements are read. */
+const finalizerSource = (): string => {
+  const source = readFileSync(path.join(API_ROOT, QUEUE_SOURCE), "utf-8");
+  const start = source.indexOf("const finishWorkflow = async (");
+  const end = source.indexOf("\n};", start);
+  if (start === -1 || end === -1) {
+    // A renamed or moved finalizer must fail loudly: an empty body would
+    // satisfy the assertion below without anything having been checked.
+    throw new Error(`${QUEUE_SOURCE} no longer declares finishWorkflow`);
+  }
+  return source.slice(start, end);
+};
 
 describe("classifying a playbook run's workflow start", () => {
   test("every status the queue can answer is classified", () => {
@@ -30,6 +49,25 @@ describe("classifying a playbook run's workflow start", () => {
           PLAYBOOK_RUN_START_OUTCOME.NOT_STARTED,
       ),
     ).toEqual(["failed"]);
+  });
+
+  test("a deferred start is benign only because every finished run catches up", () => {
+    // What `deferred` promises: the run holding the workspace grades the
+    // columns this start materialized. The finalizer kept that promise for a
+    // workspace-wide run and broke it for a cell-scoped one, which returned
+    // before the catch-up — so a review deferred by a cell retry waited for
+    // whatever workflow happened to run next. Any top-level early return ahead
+    // of the catch-up reopens that window.
+    const finalizer = finalizerSource();
+    // From the point the run is known to have finalization state (before it,
+    // returning is how the finalizer refuses a run it cannot read) to the
+    // catch-up.
+    const validAt = finalizer.indexOf("const manifest = manifestResult.value;");
+    const catchUpAt = finalizer.indexOf("startStragglerCatchUp({");
+
+    expect(validAt).toBeGreaterThan(-1);
+    expect(catchUpAt).toBeGreaterThan(validAt);
+    expect(finalizer.slice(validAt, catchUpAt)).not.toMatch(/^\s*return\b/mu);
   });
 
   test("a started workflow is the only status that queued anything", () => {

--- a/apps/api/src/lib/workflow-queue.ts
+++ b/apps/api/src/lib/workflow-queue.ts
@@ -102,6 +102,7 @@ import {
   WORKFLOW_ENTITY_JOB_BACKOFF_DELAY_MS,
 } from "@/api/lib/workflow/run-logic";
 import { requireWorkflowFinalizationManifest } from "@/api/lib/workflow/run-state-store";
+import { startStragglerCatchUp } from "@/api/lib/workflow/straggler-catchup";
 import type { PartialAnswerUpdate } from "@/api/lib/workflow/streaming-answer";
 import { prepareBatch } from "@/api/lib/workflow/utils";
 import { computeVerdictBatch } from "@/api/lib/workflow/verdict-engine";
@@ -2007,6 +2008,11 @@ const finishWorkflow = async (
   }
 
   const manifest = manifestResult.value;
+  // Scope gates freshening and nothing else. A cell-scoped run computed one
+  // column for a few entities, so declaring that column workspace-wide fresh
+  // would hide every cell it did not touch from the next sweep. What the
+  // workspace still owes is read from durable state below, which a scoped run
+  // narrows no more than any other.
   const wasScopedRun = manifest.freshnessScope === "cells";
   const { propertyIds: planPropertyIds, serviceTier } = manifest;
 
@@ -2060,43 +2066,18 @@ const finishWorkflow = async (
     planPropertyIds,
   }).catch((error: unknown) => captureError(error, { workspaceId }));
 
-  if (wasScopedRun) {
-    return;
-  }
-
-  // Catch up on any AI-model properties created mid-workflow. They
-  // were left stale by the partial freshen above; kick off a follow-up
-  // run so their cells get populated without the user having to nudge.
-  // The filter on `tool.type === 'ai-model'` is critical: manual
-  // properties may legitimately sit at status "stale" (e.g. after a
-  // type edit) and the planner intentionally skips them, so an
-  // unfiltered query would loop forever firing no-op workflows.
-  try {
-    const stragglers = await scopedDb((tx) =>
-      tx
-        .select({ id: properties.id })
-        .from(properties)
-        .where(
-          and(
-            eq(properties.workspaceId, workspaceId),
-            eq(properties.status, "stale"),
-            sql`${properties.tool}->>'type' = 'ai-model'`,
-          ),
-        )
-        .limit(1),
-    );
-    if (stragglers.length > 0) {
-      startWorkflow({
-        workspaceId,
-        organizationId,
-        userId,
-        scopedDb,
-        serviceTier,
-      }).catch((error: unknown) => captureError(error, { workspaceId }));
-    }
-  } catch (error: unknown) {
-    captureError(error, { workspaceId });
-  }
+  // Grade whatever the workspace still owes: columns created mid-run, and the
+  // columns of any start this run answered `already-running`. Unconditional by
+  // design: a start deferred by a cell-scoped run has nothing else coming for
+  // it (see `startStragglerCatchUp`).
+  await startStragglerCatchUp({
+    workspaceId,
+    organizationId,
+    userId,
+    scopedDb,
+    serviceTier,
+    startWorkflow,
+  });
 };
 
 // ── Helpers ────────────────────────────────────────────

--- a/apps/api/src/lib/workflow/get-execution-plan.test.ts
+++ b/apps/api/src/lib/workflow/get-execution-plan.test.ts
@@ -1,10 +1,12 @@
 import { Panic } from "better-result";
 import { describe, expect, test } from "bun:test";
 
+import { propertyToolSchema } from "@/api/db/schema-validators";
 import { toSafeId } from "@/api/lib/branded-types";
 import {
   buildDependencyGraph,
   buildLevelBatches,
+  COMPUTED_PROPERTY_TOOL_TYPES,
   getPropertyExecutionPlan,
 } from "@/api/lib/workflow/get-execution-plan";
 import type {
@@ -22,6 +24,17 @@ const aiModelTool = {
 const manualInputTool = {
   version: 1 as const,
   type: "manual-input" as const,
+};
+
+// The graded half of a playbook position: computed by the verdict engine
+// rather than the LLM extraction path, but planned like any other column.
+const verdictTool = {
+  version: 1 as const,
+  type: "playbook-verdict" as const,
+  askPropertyId: "01931f4a-0000-7000-8000-0000000000a5",
+  rule: { kind: "positionMatch" as const },
+  severity: "medium" as const,
+  tiers: { fallbacks: [], acceptableRules: [], notAcceptableRules: [] },
 };
 
 const textContent = {
@@ -547,5 +560,54 @@ describe("getPropertyExecutionPlan", () => {
     expect(() =>
       getPropertyExecutionPlan({ properties, dependencies }),
     ).toThrow(Panic);
+  });
+});
+
+describe("COMPUTED_PROPERTY_TOOL_TYPES", () => {
+  /** Every tool type a column can carry, read from the stored shape itself. */
+  const allToolTypes = propertyToolSchema.anyOf.map(
+    (member) => member.properties.type.const,
+  );
+  /** The rest: columns a person fills in, which sit stale legitimately. */
+  const USER_ENTERED_TOOL_TYPES = ["manual-input"] as const;
+
+  test("every tool type is either computed or user-entered", () => {
+    // Both directions, because the straggler catch-up asks this list whether a
+    // finished run left the workspace owing anything: a computed type missing
+    // from it is work nothing comes back for, and a user-entered type inside
+    // it is a follow-up run that fires forever.
+    expect(
+      [...COMPUTED_PROPERTY_TOOL_TYPES, ...USER_ENTERED_TOOL_TYPES].toSorted(),
+    ).toEqual(allToolTypes.toSorted());
+  });
+
+  test("the planner schedules exactly the tool types declared computed", () => {
+    // One column of every tool type, each reading the file column the way a
+    // materialized playbook column does (the plan drops its first level, which
+    // is the inputs themselves).
+    const properties: ExecutionPlanProperty[] = [
+      createProperty("F", { content: fileContent, tool: manualInputTool }),
+      createProperty("A", { tool: aiModelTool }),
+      createProperty("B", { tool: manualInputTool }),
+      createProperty("C", { tool: verdictTool }),
+    ];
+    const dependencies: PropertyDependency[] = [
+      propertyDependency("A", "F"),
+      propertyDependency("B", "F"),
+      propertyDependency("C", "F"),
+    ];
+
+    const scheduled = getPropertyExecutionPlan({
+      properties,
+      dependencies,
+    }).flatMap((level) =>
+      level.flatMap((batch) =>
+        batch.properties.map((property) => property.tool.type),
+      ),
+    );
+
+    expect(scheduled.toSorted()).toEqual(
+      [...COMPUTED_PROPERTY_TOOL_TYPES].toSorted(),
+    );
   });
 });

--- a/apps/api/src/lib/workflow/get-execution-plan.ts
+++ b/apps/api/src/lib/workflow/get-execution-plan.ts
@@ -68,6 +68,18 @@ export type VerdictBatchProperty = BatchPropertyBase & {
 
 export type BatchProperty = AIBatchProperty | VerdictBatchProperty;
 
+/**
+ * The tool types a run computes. `needsComputation` answers whether a column is
+ * owed work; this answers which kinds can be owed it, and the straggler
+ * catch-up reads the same list to decide whether a finished run left the
+ * workspace owing anything. Bound to the plan's own union, so a tool type the
+ * planner never schedules cannot be listed here.
+ */
+export const COMPUTED_PROPERTY_TOOL_TYPES = [
+  "ai-model",
+  "playbook-verdict",
+] as const satisfies readonly BatchProperty["tool"]["type"][];
+
 export type PropertyBatch = {
   id: string;
   inputs: SafeId<"property">[];

--- a/apps/api/src/lib/workflow/straggler-catchup.db.test.ts
+++ b/apps/api/src/lib/workflow/straggler-catchup.db.test.ts
@@ -1,0 +1,205 @@
+/**
+ * What a finished run owes the columns it never planned.
+ *
+ * A playbook start answered `already-running` materializes its columns and
+ * leaves the extraction to the run in flight, so the finalizer's catch-up is
+ * the only thing coming for them. Exercised against a real schema because the
+ * detector is a query: it reads the durable column state a concurrent start
+ * left behind, and the tool-type filter it leans on is what keeps a stale
+ * manual column from firing no-op workflows forever.
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { eq } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/pglite";
+
+import * as authSchema from "@/api/db/auth-schema";
+import type { ScopedDb } from "@/api/db/safe-db";
+import * as schema from "@/api/db/schema";
+import { properties } from "@/api/db/schema";
+import type { PropertyTool } from "@/api/db/schema-validators";
+import { toSafeId } from "@/api/lib/branded-types";
+import type { SafeId } from "@/api/lib/branded-types";
+import { startStragglerCatchUp } from "@/api/lib/workflow/straggler-catchup";
+import type { StragglerRunStarter } from "@/api/lib/workflow/straggler-catchup";
+import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
+import { createTestPglite } from "@/api/tests/pglite-test-db";
+
+type StartedRun = Parameters<StragglerRunStarter>[0];
+
+let client: Awaited<ReturnType<typeof createTestPglite>> | undefined;
+let db: ReturnType<typeof drizzle>;
+
+const ORG_ID = toSafeId<"organization">(Bun.randomUUIDv7());
+const USER_ID = "user_straggler_test";
+const CONTACT_ID = toSafeId<"contact">(Bun.randomUUIDv7());
+/** The workspace whose run just finished. */
+const WS_ID = toSafeId<"workspace">(Bun.randomUUIDv7());
+/** A second workspace, whose owed work is not this run's to start. */
+const OTHER_WS_ID = toSafeId<"workspace">(Bun.randomUUIDv7());
+
+/** The ASK column a playbook materializes: stale, and extracted by the model. */
+const ASK_TOOL = {
+  version: 1,
+  type: "ai-model",
+  prompt: "What is the notice period?",
+} as const satisfies PropertyTool;
+
+const MANUAL_TOOL = {
+  version: 1,
+  type: "manual-input",
+} as const satisfies PropertyTool;
+
+const seedProperty = async ({
+  status,
+  tool,
+  workspaceId,
+}: {
+  status: "fresh" | "stale";
+  tool: PropertyTool;
+  workspaceId: SafeId<"workspace">;
+}) => {
+  const id = toSafeId<"property">(Bun.randomUUIDv7());
+  await db.insert(properties).values({
+    id,
+    workspaceId,
+    name: "Termination notice",
+    status,
+    content: { version: 1, type: "text" },
+    tool,
+  });
+  return id;
+};
+
+const clearProperties = async () => {
+  await db.delete(properties).where(eq(properties.workspaceId, WS_ID));
+  await db.delete(properties).where(eq(properties.workspaceId, OTHER_WS_ID));
+};
+
+/** Run the catch-up over the seeded rows and report what it started. */
+const runCatchUp = async (): Promise<StartedRun[]> => {
+  const startedRuns: StartedRun[] = [];
+  await startStragglerCatchUp({
+    workspaceId: WS_ID,
+    organizationId: ORG_ID,
+    userId: toSafeId<"user">(USER_ID),
+    scopedDb: asTestRaw<ScopedDb>(
+      async (fn: (tx: unknown) => Promise<unknown>) => await fn(db),
+    ),
+    serviceTier: "flex",
+    startWorkflow: async (args) => {
+      startedRuns.push(args);
+      await Promise.resolve();
+    },
+  });
+  return startedRuns;
+};
+
+beforeAll(
+  async () => {
+    client = await createTestPglite();
+    db = drizzle({ client });
+
+    await db.insert(authSchema.user).values({
+      id: USER_ID,
+      name: "Straggler",
+      email: "straggler@test.local",
+    });
+    await db.insert(authSchema.organization).values({
+      id: ORG_ID,
+      name: "Straggler Org",
+      slug: "straggler-org",
+      createdAt: new Date(),
+    });
+    await db.insert(schema.contacts).values({
+      id: CONTACT_ID,
+      organizationId: ORG_ID,
+      type: "person",
+      displayName: "Straggler Contact",
+    });
+    await db.insert(schema.workspaces).values([
+      {
+        id: WS_ID,
+        organizationId: ORG_ID,
+        clientId: CONTACT_ID,
+        name: "Straggler WS",
+        reference: "REF-STRAGGLER",
+        status: "active",
+      },
+      {
+        id: OTHER_WS_ID,
+        organizationId: ORG_ID,
+        clientId: CONTACT_ID,
+        name: "Other WS",
+        reference: "REF-OTHER",
+        status: "active",
+      },
+    ]);
+  },
+  { timeout: 30_000 },
+);
+
+afterAll(async () => {
+  if (client !== undefined) {
+    await client.close();
+  }
+});
+
+describe("the catch-up a finished run owes", () => {
+  test("starts a follow-up run for a column a concurrent start left stale", async () => {
+    // The columns a playbook materialized while this workspace was busy: the
+    // start was answered `already-running`, so nothing else is coming.
+    await seedProperty({ status: "stale", tool: ASK_TOOL, workspaceId: WS_ID });
+    try {
+      const startedRuns = await runCatchUp();
+
+      expect(startedRuns).toHaveLength(1);
+      // Workspace-wide, and on the finished run's tier: the follow-up plans
+      // from durable state, not from what the finished run happened to target.
+      const started = startedRuns.at(0);
+      expect(started?.workspaceId).toBe(WS_ID);
+      expect(started?.organizationId).toBe(ORG_ID);
+      expect(started?.serviceTier).toBe("flex");
+    } finally {
+      await clearProperties();
+    }
+  });
+
+  test("starts nothing when every column is fresh", async () => {
+    await seedProperty({ status: "fresh", tool: ASK_TOOL, workspaceId: WS_ID });
+    try {
+      expect(await runCatchUp()).toEqual([]);
+    } finally {
+      await clearProperties();
+    }
+  });
+
+  test("ignores a stale manual column, which no run would compute", async () => {
+    // A manual column sits stale legitimately (a type edit does it) and the
+    // planner skips it, so treating it as owed work would fire no-op
+    // workflows forever, each one finishing and starting the next.
+    await seedProperty({
+      status: "stale",
+      tool: MANUAL_TOOL,
+      workspaceId: WS_ID,
+    });
+    try {
+      expect(await runCatchUp()).toEqual([]);
+    } finally {
+      await clearProperties();
+    }
+  });
+
+  test("ignores another workspace's owed work", async () => {
+    await seedProperty({
+      status: "stale",
+      tool: ASK_TOOL,
+      workspaceId: OTHER_WS_ID,
+    });
+    try {
+      expect(await runCatchUp()).toEqual([]);
+    } finally {
+      await clearProperties();
+    }
+  });
+});

--- a/apps/api/src/lib/workflow/straggler-catchup.db.test.ts
+++ b/apps/api/src/lib/workflow/straggler-catchup.db.test.ts
@@ -50,6 +50,16 @@ const MANUAL_TOOL = {
   type: "manual-input",
 } as const satisfies PropertyTool;
 
+/** The verdict half of a graded position, materialized stale beside its ASK. */
+const VERDICT_TOOL = {
+  version: 1,
+  type: "playbook-verdict",
+  askPropertyId: "01931f4a-0000-7000-8000-0000000000a5",
+  rule: { kind: "positionMatch" },
+  severity: "medium",
+  tiers: { fallbacks: [], acceptableRules: [], notAcceptableRules: [] },
+} as const satisfies PropertyTool;
+
 const seedProperty = async ({
   status,
   tool,
@@ -169,6 +179,23 @@ describe("the catch-up a finished run owes", () => {
     await seedProperty({ status: "fresh", tool: ASK_TOOL, workspaceId: WS_ID });
     try {
       expect(await runCatchUp()).toEqual([]);
+    } finally {
+      await clearProperties();
+    }
+  });
+
+  test("starts a follow-up run for a stale verdict column", async () => {
+    // A graded position whose ASK needs no extraction (an empty question
+    // materializes a manual, already-fresh ASK) leaves only its verdict column
+    // owed. The verdict engine grades it, so it is as much owed work as an
+    // extraction is.
+    await seedProperty({
+      status: "stale",
+      tool: VERDICT_TOOL,
+      workspaceId: WS_ID,
+    });
+    try {
+      expect(await runCatchUp()).toHaveLength(1);
     } finally {
       await clearProperties();
     }

--- a/apps/api/src/lib/workflow/straggler-catchup.ts
+++ b/apps/api/src/lib/workflow/straggler-catchup.ts
@@ -1,10 +1,11 @@
-import { and, eq, sql } from "drizzle-orm";
+import { and, eq, inArray, sql } from "drizzle-orm";
 
 import type { ScopedDb } from "@/api/db/safe-db";
 import { properties } from "@/api/db/schema";
 import type { AIRequestServiceTier } from "@/api/lib/ai-config";
 import { captureError } from "@/api/lib/analytics/capture";
 import type { SafeId } from "@/api/lib/branded-types";
+import { COMPUTED_PROPERTY_TOOL_TYPES } from "@/api/lib/workflow/get-execution-plan";
 
 /**
  * The starter the catch-up drives, narrowed to what it passes. Structural
@@ -32,7 +33,7 @@ type StragglerCatchUpArgs = {
  * Start a follow-up run for whatever the workspace still owes once a run
  * finishes.
  *
- * Two things leave a stale ai-model column behind a finished run: a column
+ * Two things leave a computed column stale behind a finished run: a column
  * created mid-run, which was never in that run's plan, and a start answered
  * `already-running`, whose caller materialized its columns and left the enqueue
  * to the run in flight. The playbook surfaces classify that answer as benign on
@@ -41,10 +42,12 @@ type StragglerCatchUpArgs = {
  * finished run performs it: the run a deferred start raced is as likely to be a
  * cell-scoped retry as a workspace-wide sweep.
  *
- * The filter on `tool.type = 'ai-model'` is what keeps this from looping.
- * Manual columns may legitimately sit stale (e.g. after a type edit) and the
- * planner skips them, so an unfiltered query would fire no-op workflows
- * forever.
+ * The tool-type filter is what keeps this from looping, and it asks the planner
+ * which types those are. Manual columns may legitimately sit stale (e.g. after
+ * a type edit) and no run computes them, so an unfiltered query would fire
+ * no-op workflows forever; a hand-listed filter would instead miss a computed
+ * type, which is how a graded playbook position with a manual ASK could
+ * materialize a stale verdict column nothing came back for.
  */
 export const startStragglerCatchUp = async ({
   workspaceId,
@@ -63,7 +66,9 @@ export const startStragglerCatchUp = async ({
           and(
             eq(properties.workspaceId, workspaceId),
             eq(properties.status, "stale"),
-            sql`${properties.tool}->>'type' = 'ai-model'`,
+            inArray(sql`${properties.tool}->>'type'`, [
+              ...COMPUTED_PROPERTY_TOOL_TYPES,
+            ]),
           ),
         )
         .limit(1),

--- a/apps/api/src/lib/workflow/straggler-catchup.ts
+++ b/apps/api/src/lib/workflow/straggler-catchup.ts
@@ -1,0 +1,86 @@
+import { and, eq, sql } from "drizzle-orm";
+
+import type { ScopedDb } from "@/api/db/safe-db";
+import { properties } from "@/api/db/schema";
+import type { AIRequestServiceTier } from "@/api/lib/ai-config";
+import { captureError } from "@/api/lib/analytics/capture";
+import type { SafeId } from "@/api/lib/branded-types";
+
+/**
+ * The starter the catch-up drives, narrowed to what it passes. Structural
+ * rather than imported from the queue: the queue owns this module, not the
+ * other way round, and the narrower type is also the test seam.
+ */
+export type StragglerRunStarter = (args: {
+  workspaceId: SafeId<"workspace">;
+  organizationId: SafeId<"organization">;
+  userId: SafeId<"user">;
+  scopedDb: ScopedDb;
+  serviceTier: AIRequestServiceTier;
+}) => Promise<unknown>;
+
+type StragglerCatchUpArgs = {
+  workspaceId: SafeId<"workspace">;
+  organizationId: SafeId<"organization">;
+  userId: SafeId<"user">;
+  scopedDb: ScopedDb;
+  serviceTier: AIRequestServiceTier;
+  startWorkflow: StragglerRunStarter;
+};
+
+/**
+ * Start a follow-up run for whatever the workspace still owes once a run
+ * finishes.
+ *
+ * Two things leave a stale ai-model column behind a finished run: a column
+ * created mid-run, which was never in that run's plan, and a start answered
+ * `already-running`, whose caller materialized its columns and left the enqueue
+ * to the run in flight. The playbook surfaces classify that answer as benign on
+ * exactly this promise (see `playbookRunStartOutcome`), so the catch-up reads
+ * durable state instead of anything the finished run remembers, and every
+ * finished run performs it: the run a deferred start raced is as likely to be a
+ * cell-scoped retry as a workspace-wide sweep.
+ *
+ * The filter on `tool.type = 'ai-model'` is what keeps this from looping.
+ * Manual columns may legitimately sit stale (e.g. after a type edit) and the
+ * planner skips them, so an unfiltered query would fire no-op workflows
+ * forever.
+ */
+export const startStragglerCatchUp = async ({
+  workspaceId,
+  organizationId,
+  userId,
+  scopedDb,
+  serviceTier,
+  startWorkflow,
+}: StragglerCatchUpArgs): Promise<void> => {
+  try {
+    const stragglers = await scopedDb((tx) =>
+      tx
+        .select({ id: properties.id })
+        .from(properties)
+        .where(
+          and(
+            eq(properties.workspaceId, workspaceId),
+            eq(properties.status, "stale"),
+            sql`${properties.tool}->>'type' = 'ai-model'`,
+          ),
+        )
+        .limit(1),
+    );
+    if (stragglers.length === 0) {
+      return;
+    }
+    // Not awaited: the follow-up run plans and enqueues on its own, and a
+    // finished run must not be held open (or failed) by the next one starting.
+    startWorkflow({
+      workspaceId,
+      organizationId,
+      userId,
+      scopedDb,
+      serviceTier,
+    }).catch((error: unknown) => captureError(error, { workspaceId }));
+  } catch (error: unknown) {
+    captureError(error, { workspaceId });
+  }
+};

--- a/apps/api/src/lib/workflow/straggler-catchup.ts
+++ b/apps/api/src/lib/workflow/straggler-catchup.ts
@@ -1,3 +1,4 @@
+import { TaggedError } from "better-result";
 import { and, eq, inArray, sql } from "drizzle-orm";
 
 import type { ScopedDb } from "@/api/db/safe-db";
@@ -5,7 +6,17 @@ import { properties } from "@/api/db/schema";
 import type { AIRequestServiceTier } from "@/api/lib/ai-config";
 import { captureError } from "@/api/lib/analytics/capture";
 import type { SafeId } from "@/api/lib/branded-types";
+import type { WorkflowStartStatus } from "@/api/lib/workflow-queue";
 import { COMPUTED_PROPERTY_TOOL_TYPES } from "@/api/lib/workflow/get-execution-plan";
+
+/** The one start status that means nothing was queued. */
+const WORKFLOW_START_FAILED = "failed" satisfies WorkflowStartStatus;
+
+/** The follow-up run this workspace was owed did not get queued. */
+class StragglerCatchUpError extends TaggedError("StragglerCatchUpError")<{
+  message: string;
+  workspaceId: SafeId<"workspace">;
+}> {}
 
 /**
  * The starter the catch-up drives, narrowed to what it passes. Structural
@@ -19,6 +30,18 @@ export type StragglerRunStarter = (args: {
   scopedDb: ScopedDb;
   serviceTier: AIRequestServiceTier;
 }) => Promise<unknown>;
+
+/**
+ * The starter reports an enqueue failure in band rather than by rejecting, so
+ * a lone `.catch()` would drop exactly the case worth knowing about: the
+ * follow-up this workspace was owed never got queued, and nothing retries it
+ * until some later run finishes.
+ */
+const startReportedFailure = (result: unknown): boolean =>
+  typeof result === "object" &&
+  result !== null &&
+  "status" in result &&
+  result.status === WORKFLOW_START_FAILED;
 
 type StragglerCatchUpArgs = {
   workspaceId: SafeId<"workspace">;
@@ -78,13 +101,29 @@ export const startStragglerCatchUp = async ({
     }
     // Not awaited: the follow-up run plans and enqueues on its own, and a
     // finished run must not be held open (or failed) by the next one starting.
+    // Both outcomes are still read: a rejection and an in-band `failed` mean
+    // the same thing here, work this workspace is owed that no longer has a
+    // successor coming.
     startWorkflow({
       workspaceId,
       organizationId,
       userId,
       scopedDb,
       serviceTier,
-    }).catch((error: unknown) => captureError(error, { workspaceId }));
+    })
+      .then((result) => {
+        if (startReportedFailure(result)) {
+          captureError(
+            new StragglerCatchUpError({
+              message: "Straggler catch-up could not start its follow-up run",
+              workspaceId,
+            }),
+            { workspaceId },
+          );
+        }
+        return result;
+      })
+      .catch((error: unknown) => captureError(error, { workspaceId }));
   } catch (error: unknown) {
     captureError(error, { workspaceId });
   }


### PR DESCRIPTION
The run finalizer skipped both freshening and straggler catch-up for scoped runs under one comment, but the two have different safety properties. Freshening after a scoped run genuinely hides stale cells (marking a column fresh after computing a few of its cells) and stays gated. The catch-up reads durable state only (`properties.status = 'stale'` plus tool type) and starts an unscoped run that re-plans from scratch; skipping it broke the contract the playbook surfaces rely on — `already-running` is classified benign precisely because "the run in flight still grades them" — so a playbook start racing a cell retry left its columns stale until some unrelated run happened.

The catch-up now runs unconditionally after the finalizer (moved to `lib/workflow/straggler-catchup.ts` with an injected starter as the test seam); `wasScopedRun` gates freshening only. Termination is unchanged (a run that plans a column freshens it; a start with no work returns skipped), and after an ordinary cell retry the detection query finds nothing, so the common path costs one indexed read.

Second gap fixed alongside: the detector matched only `ai-model` columns, but runs also compute `playbook-verdict` columns, so a graded position with an empty question (manual ASK, fresh; verdict, stale) was invisible to the catch-up. The computed-tool-type list now lives with the planner as `COMPUTED_PROPERTY_TOOL_TYPES`, bound with `satisfies` to the plan's own union and asserted total in both directions.

PGlite tests cover: one workspace-wide follow-up starts on the finished tier for a stale ai-model column and for a stale verdict column; fresh columns, stale manual columns, and other workspaces start nothing. A mutation-checked source guard pins that no early return sits between the finalizer's manifest check and the catch-up call.

Reviewer note on the deliberate behavior change: a cell retry can now be followed by a workspace-wide run when a stale computed column genuinely exists. That work was already owed and previously ran on the next unscoped start; the change moves it earlier, which is a new observable path for model spend after a single-cell action.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Completed workflows now automatically start follow-up processing for unfinished computed properties, including cell-scoped runs.
  * Added support for computed AI-model and playbook-verdict properties during workflow planning.

* **Bug Fixes**
  * Improved handling of deferred workflow starts so unfinished computed properties are not missed.
  * Follow-up processing now ignores fresh, manual, and unrelated workspace properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->