### PR TITLE
fix(workspaces): surface workflow start failures on the web path

### DIFF
--- a/apps/api/src/handlers/workspaces/workflow-start.test.ts
+++ b/apps/api/src/handlers/workspaces/workflow-start.test.ts
@@ -1,12 +1,17 @@
-import { describe, expect, mock, test } from "bun:test";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import { toSafeId } from "@/api/lib/branded-types";
-import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
+import { WORKFLOW_START_STATUSES } from "@/api/lib/workflow-queue";
+import type { WorkflowStartStatus } from "@/api/lib/workflow-queue";
+import { createTestHandlerContext } from "@/api/tests/helpers/handler-context";
 import { createScopedDbMock } from "@/api/tests/scoped-db-mock";
 
-const startWorkflowMock = mock(async () => ({ status: "started" as const }));
+const startWorkflowMock = mock();
+
+const realWorkflowQueue = await import("@/api/lib/workflow-queue");
 
 void mock.module("@/api/lib/workflow-queue", () => ({
+  ...realWorkflowQueue,
   startWorkflow: startWorkflowMock,
 }));
 
@@ -16,45 +21,39 @@ type WorkflowStartCtx = Parameters<typeof workflowStart.handler>[0];
 
 const organizationId = toSafeId<"organization">("org_test");
 const userId = toSafeId<"user">("user_test");
-const workspaceId = toSafeId<"workspace">("ws_test");
+const workspaceId = toSafeId<"workspace">("workspace_test");
 const entityId = toSafeId<"entity">("entity_test");
 const propertyId = toSafeId<"property">("property_test");
 
-describe("workflow start handler", () => {
-  test("threads workspace identity and explicit target filters into the workflow queue", async () => {
-    const { scopedDb, safeDb } = createScopedDbMock({});
-    const body = {
-      entityIds: [entityId],
-      entityIdsOrder: [entityId],
-      propertyIds: [propertyId],
-      serviceTier: "standard" as const,
-    };
+const body = {
+  entityIds: [entityId],
+  entityIdsOrder: [entityId],
+  propertyIds: [propertyId],
+  serviceTier: "standard" as const,
+};
 
-    const result = await workflowStart.handler(
-      asTestRaw<WorkflowStartCtx>({
-        getActiveWorkspaceIds: async () => [workspaceId],
-        getAccessibleWorkspaces: async () => [
-          { id: workspaceId, status: "active" },
-        ],
-        getWorkspaceAccess: async () => ({
-          id: workspaceId,
-          status: "active",
-        }),
-        body,
-        createAuditRecorder: () => async () => undefined,
-        memberRole: { role: "owner" },
-        orgAIConfig: null,
-        promptCachingEnabled: false,
-        recordAuditEvent: async () => undefined,
-        request: new Request(`https://example.test/workspaces/${workspaceId}`),
-        route: "/test/workflow-start",
-        safeDb,
-        scopedDb,
-        session: { activeOrganizationId: organizationId },
-        user: { id: userId },
-        workspaceId,
-      }),
-    );
+const { scopedDb, safeDb } = createScopedDbMock({});
+
+const startWorkspaceWorkflow = async () =>
+  await workflowStart.handler(
+    createTestHandlerContext<WorkflowStartCtx>({
+      body,
+      safeDb,
+      scopedDb,
+      session: { activeOrganizationId: organizationId },
+      user: { id: userId },
+      workspaceId,
+    }),
+  );
+
+describe("workflow start handler", () => {
+  beforeEach(() => {
+    startWorkflowMock.mockReset();
+    startWorkflowMock.mockResolvedValue({ status: "started" });
+  });
+
+  test("threads workspace identity and explicit target filters into the workflow queue", async () => {
+    const result = await startWorkspaceWorkflow();
 
     expect(result).toEqual({ status: "started" });
     expect(startWorkflowMock).toHaveBeenCalledWith({
@@ -67,5 +66,39 @@ describe("workflow start handler", () => {
       propertyIds: [propertyId],
       serviceTier: "standard",
     });
+  });
+
+  test("a failed enqueue is answered as an error status, never as a started workflow", async () => {
+    // Exercises the whole status set the queue can answer, so a new status
+    // cannot reach the wire without this test recording which side it took:
+    // clients read any 2xx as "the extraction is running".
+    // Sequential by construction: one shared queue mock answers one status per
+    // call.
+    const outcomes = await Array.fromAsync(
+      WORKFLOW_START_STATUSES,
+      async (status) => {
+        startWorkflowMock.mockResolvedValue({ status });
+        return { status, result: await startWorkspaceWorkflow() };
+      },
+    );
+
+    const rejected: WorkflowStartStatus[] = [];
+    for (const { status, result } of outcomes) {
+      if ("code" in result) {
+        expect(result.code).toBe(500);
+        rejected.push(status);
+        continue;
+      }
+      // Asserted from the queue's side: the success body's status type no
+      // longer admits `failed`, so it cannot be compared against the raw union.
+      expect(status).toBe(result.status);
+    }
+
+    expect(rejected).toEqual(["failed"]);
+    // Declared set equals exercised set: every status the queue can answer
+    // went through the handler above.
+    expect(outcomes.map(({ status }) => status)).toEqual([
+      ...WORKFLOW_START_STATUSES,
+    ]);
   });
 });

--- a/apps/api/src/handlers/workspaces/workflow-start.ts
+++ b/apps/api/src/handlers/workspaces/workflow-start.ts
@@ -8,6 +8,7 @@ import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import { LIMITS } from "@/api/lib/limits";
 import { isDeferredServiceTierAvailableForRole } from "@/api/lib/tanstack-ai-models";
 import { startWorkflow } from "@/api/lib/workflow-queue";
+import { isReportedWorkflowStartStatus } from "@/api/lib/workflow/workflow-start-disposition";
 
 const config = {
   permissions: { workspace: ["update"] },
@@ -47,7 +48,7 @@ const workflowStart = createSafeHandler(
       );
     }
 
-    const result = yield* Result.await(
+    const { status } = yield* Result.await(
       Result.tryPromise({
         try: async () =>
           await startWorkflow({
@@ -71,7 +72,18 @@ const workflowStart = createSafeHandler(
       }),
     );
 
-    return Result.ok(result);
+    // The queue answers a failed enqueue as a status, so returning it verbatim
+    // would report a workflow that will never run as a 200.
+    if (!isReportedWorkflowStartStatus(status)) {
+      return Result.err(
+        new HandlerError({
+          status: 500,
+          message: "Failed to start the workflow",
+        }),
+      );
+    }
+
+    return Result.ok({ status });
   },
 );
 

--- a/apps/api/src/lib/workflow/workflow-start-disposition.ts
+++ b/apps/api/src/lib/workflow/workflow-start-disposition.ts
@@ -1,0 +1,53 @@
+/**
+ * What the workspace workflow-start endpoint does with each way a start
+ * attempt can end.
+ *
+ * The queue reports an enqueue failure in band, as a status, not as a throw,
+ * so an endpoint that hands the queue's answer back verbatim replies 200 for a
+ * workflow nothing will ever run, and every client that reads a 2xx as success
+ * reports the extraction as started. Classifying the whole status set here
+ * keeps that decision in one place and forces a new queue status to pick a
+ * side before it can reach the wire.
+ */
+
+import type { WorkflowStartStatus } from "@/api/lib/workflow-queue";
+
+/**
+ * `report`: nothing failed, and the status itself is the answer. `started`
+ * queued the work. `already-running` and `skipped` queued nothing this time,
+ * because a run already holds the workspace or no stale cell was left to
+ * extract; either way the cells belong to the run in flight or the next one,
+ * so the caller has no failure to handle.
+ *
+ * `reject`: the enqueue failed. Nothing is coming for the cells until someone
+ * asks again, so the endpoint must answer an error status.
+ */
+const WORKFLOW_START_DISPOSITION = {
+  REPORT: "report",
+  REJECT: "reject",
+} as const;
+
+type WorkflowStartDisposition =
+  (typeof WORKFLOW_START_DISPOSITION)[keyof typeof WORKFLOW_START_DISPOSITION];
+
+const DISPOSITION_BY_STATUS = {
+  started: WORKFLOW_START_DISPOSITION.REPORT,
+  "already-running": WORKFLOW_START_DISPOSITION.REPORT,
+  skipped: WORKFLOW_START_DISPOSITION.REPORT,
+  failed: WORKFLOW_START_DISPOSITION.REJECT,
+} as const satisfies Record<WorkflowStartStatus, WorkflowStartDisposition>;
+
+/**
+ * The statuses a success body may carry, derived from the map so a status that
+ * changes disposition leaves the response type with it.
+ */
+type ReportedWorkflowStartStatus = {
+  [Status in WorkflowStartStatus]: (typeof DISPOSITION_BY_STATUS)[Status] extends typeof WORKFLOW_START_DISPOSITION.REPORT
+    ? Status
+    : never;
+}[WorkflowStartStatus];
+
+export const isReportedWorkflowStartStatus = (
+  status: WorkflowStartStatus,
+): status is ReportedWorkflowStartStatus =>
+  DISPOSITION_BY_STATUS[status] === WORKFLOW_START_DISPOSITION.REPORT;

--- a/apps/web/src/components/workspaces/hooks/use-start-workflow.logic.test.ts
+++ b/apps/web/src/components/workspaces/hooks/use-start-workflow.logic.test.ts
@@ -1,12 +1,15 @@
 import { describe, expect, test } from "bun:test";
 
+import { APIError, toAPIError } from "@/lib/errors/api";
 import { workflowTargetCountOptions } from "@/lib/workspaces/queries/workspace";
 
 import {
   estimateWorkflowTargetCount,
   LARGE_WORKFLOW_ENTITY_PROMPT_THRESHOLD,
+  performWorkflowStart,
   resolveWorkflowStartDecision,
   resolveWorkflowServiceTier,
+  WORKFLOW_START_FAILED,
 } from "./use-start-workflow.logic";
 import type { WorkflowTargetCountQueryClient } from "./use-start-workflow.logic";
 
@@ -193,5 +196,86 @@ describe("workflow start decision", () => {
     });
 
     expect(serviceTier).toBe("flex");
+  });
+});
+
+/** Records what the hook would show and capture for one start attempt. */
+const createWorkflowStartSurface = () => {
+  const captured: unknown[] = [];
+  const counts = { notified: 0, queued: 0 };
+
+  return {
+    captured,
+    counts,
+    ports: {
+      captureError: (error: unknown) => {
+        captured.push(error);
+      },
+      notifyFailure: () => {
+        counts.notified += 1;
+      },
+      onQueued: async () => {
+        counts.queued += 1;
+        await Promise.resolve();
+      },
+    },
+  };
+};
+
+describe("performing a workflow start", () => {
+  test("reports a rejected request instead of answering the caller with it", async () => {
+    const { captured, counts, ports } = createWorkflowStartSurface();
+    const requestError = new TypeError("Failed to fetch");
+
+    const result = await performWorkflowStart({
+      ...ports,
+      request: async () => {
+        throw requestError;
+      },
+    });
+
+    // Every call site but the column re-run drops this answer, so a failure
+    // only the return value carries is a workflow that silently never ran.
+    expect(result).toBe(WORKFLOW_START_FAILED);
+    expect(captured).toEqual([requestError]);
+    expect(counts).toEqual({ notified: 1, queued: 0 });
+  });
+
+  test("reports an error status and hands the typed error to telemetry", async () => {
+    const { captured, counts, ports } = createWorkflowStartSurface();
+
+    const result = await performWorkflowStart({
+      ...ports,
+      // What `unwrapEden` throws for the endpoint's failed-enqueue answer.
+      request: async () => {
+        throw toAPIError({
+          status: 500,
+          value: { message: "Failed to start the workflow" },
+        });
+      },
+    });
+
+    expect(result).toBe(WORKFLOW_START_FAILED);
+    expect(counts).toEqual({ notified: 1, queued: 0 });
+    const [capturedError] = captured;
+    if (!APIError.is(capturedError)) {
+      throw new Error("Expected the response error to reach telemetry typed");
+    }
+    expect(capturedError.status).toBe(500);
+  });
+
+  test("passes a reported status through once the workflow cache is refreshed", async () => {
+    const { captured, counts, ports } = createWorkflowStartSurface();
+
+    const result = await performWorkflowStart({
+      ...ports,
+      request: async () => ({ status: "already-running" as const }),
+    });
+
+    // A run already holds the workspace: nothing failed, so the caller gets
+    // the status and no failure is reported for it.
+    expect(result).toEqual({ status: "already-running" });
+    expect(counts).toEqual({ notified: 0, queued: 1 });
+    expect(captured).toEqual([]);
   });
 });

--- a/apps/web/src/components/workspaces/hooks/use-start-workflow.logic.ts
+++ b/apps/web/src/components/workspaces/hooks/use-start-workflow.logic.ts
@@ -1,3 +1,5 @@
+import { Result } from "better-result";
+
 import { workflowTargetCountOptions } from "@/lib/workspaces/queries/workspace";
 
 export type StartWorkflowArgs = {
@@ -92,4 +94,64 @@ export const resolveWorkflowServiceTier = async ({
   }
 
   return await promptForServiceTier({ entityCount });
+};
+
+/**
+ * Answered when the request never reached the queue. The failure is reported
+ * where it happens, because most call sites start a workflow as a side effect
+ * of another action and drop this answer; a caller that does read it must not
+ * treat it as a running workflow.
+ */
+export const WORKFLOW_START_FAILED = { status: "failed" } as const;
+
+/**
+ * Answered when the organization has no usable AI configuration, so no request
+ * was sent. Distinct from a failure: the workspace surface already prompts for
+ * a key, and the side-effect call sites fire on edits that may have nothing to
+ * extract, where a toast per edit would be noise.
+ */
+export const WORKFLOW_START_AI_UNAVAILABLE = {
+  status: "ai-unavailable",
+} as const;
+
+type PerformWorkflowStartArgs<TStatus extends string> = {
+  captureError: (error: unknown) => void;
+  notifyFailure: () => void;
+  onQueued: () => Promise<void>;
+  /** Sends the request and unwraps it, so an error response throws. */
+  request: () => Promise<{ status: TStatus }>;
+};
+
+type PerformWorkflowStartResult<TStatus extends string> =
+  | { status: TStatus }
+  | typeof WORKFLOW_START_FAILED;
+
+/**
+ * Send the start request and answer only a status the endpoint stands behind.
+ * A request that never reached the queue, whether it failed in transport or
+ * came back an error status, ends in telemetry and in front of the user here
+ * rather than in a return value the caller drops.
+ */
+export const performWorkflowStart = async <TStatus extends string>({
+  captureError,
+  notifyFailure,
+  onQueued,
+  request,
+}: PerformWorkflowStartArgs<TStatus>): Promise<
+  PerformWorkflowStartResult<TStatus>
+> => {
+  // Keep the thrown value itself rather than the wrapper `tryPromise` would
+  // otherwise build, so telemetry receives the original error.
+  const attempt = await Result.tryPromise({
+    try: request,
+    catch: (cause) => cause,
+  });
+  if (attempt.isErr()) {
+    captureError(attempt.error);
+    notifyFailure();
+    return WORKFLOW_START_FAILED;
+  }
+
+  await onQueued();
+  return attempt.value;
 };

--- a/apps/web/src/components/workspaces/hooks/use-start-workflow.ts
+++ b/apps/web/src/components/workspaces/hooks/use-start-workflow.ts
@@ -1,24 +1,36 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useRouteContext } from "@tanstack/react-router";
+import { useTranslations } from "use-intl";
+
+import { stellaToast } from "@stll/ui/components/toast";
 
 import {
   estimateWorkflowTargetCount,
+  performWorkflowStart,
   resolveWorkflowStartDecision,
   resolveWorkflowServiceTier,
+  WORKFLOW_START_AI_UNAVAILABLE,
+  WORKFLOW_START_FAILED,
 } from "@/components/workspaces/hooks/use-start-workflow.logic";
 import type { StartWorkflowArgs } from "@/components/workspaces/hooks/use-start-workflow.logic";
 import { useWorkflowServiceTierPrompt } from "@/components/workspaces/workflow-service-tier-prompt";
 import { useWorkflowStartConfirmationPrompt } from "@/components/workspaces/workflow-start-confirmation-prompt";
 import { useAnalytics } from "@/lib/analytics/provider";
 import { api } from "@/lib/api";
+import { unwrapEden } from "@/lib/errors/api";
 import { aiAvailabilityOptions } from "@/lib/organization/ai-config-queries";
 import { toSafeId } from "@/lib/safe-id";
 import { workspaceKeys } from "@/lib/workspaces/queries/workspace";
 
 /**
  * Returns a function that starts an AI extraction workflow via REST.
+ *
+ * Most call sites start the workflow as a side effect of another action and
+ * discard the answer, so a start that never reaches the queue is reported
+ * here rather than handed back for a caller to notice.
  */
 export const useStartWorkflow = (workspaceId: string) => {
+  const t = useTranslations();
   const queryClient = useQueryClient();
   const analytics = useAnalytics();
   const activeOrganizationId = useRouteContext({
@@ -32,12 +44,19 @@ export const useStartWorkflow = (workspaceId: string) => {
   const confirmLargeRun = useWorkflowStartConfirmationPrompt();
   const promptForServiceTier = useWorkflowServiceTierPrompt();
 
+  const notifyStartFailed = () => {
+    stellaToast.add({
+      title: t("errors.failedToStartWorkflow"),
+      type: "error",
+    });
+  };
+
   return async (args?: StartWorkflowArgs) => {
     try {
       const availability =
         aiAvailability ?? (await queryClient.fetchQuery(aiAvailabilityQuery));
       if (!availability.available) {
-        return { status: "failed" } as const;
+        return WORKFLOW_START_AI_UNAVAILABLE;
       }
 
       const entityCount = await estimateWorkflowTargetCount({
@@ -60,42 +79,50 @@ export const useStartWorkflow = (workspaceId: string) => {
         promptForServiceTier,
       });
 
-      const response = await api
-        .workspaces({ workspaceId: toSafeId<"workspace">(workspaceId) })
-        .workflow.start.post({
-          ...(args?.entityIds !== undefined &&
-            args.entityIds.length > 0 && {
-              entityIds: args.entityIds.map((id) => toSafeId<"entity">(id)),
-            }),
-          ...(args?.entityIdsOrder !== undefined &&
-            args.entityIdsOrder.length > 0 && {
-              entityIdsOrder: args.entityIdsOrder.map((id) =>
-                toSafeId<"entity">(id),
-              ),
-            }),
-          ...(args?.propertyIds !== undefined &&
-            args.propertyIds.length > 0 && {
-              propertyIds: args.propertyIds.map((id) =>
-                toSafeId<"property">(id),
-              ),
-            }),
-          serviceTier,
-        });
-
-      if (response.error) {
-        analytics.captureError(new Error("Failed to start workflow"));
-        return { status: "failed" } as const;
-      }
-
-      // Invalidate workflow status so UI shows "running"
-      await queryClient.invalidateQueries({
-        queryKey: workspaceKeys.workflow(workspaceId),
+      return await performWorkflowStart({
+        captureError: (error) => {
+          analytics.captureError(error);
+        },
+        notifyFailure: notifyStartFailed,
+        // Invalidate workflow status so UI shows "running"
+        onQueued: async () => {
+          await queryClient.invalidateQueries({
+            queryKey: workspaceKeys.workflow(workspaceId),
+          });
+        },
+        request: async () =>
+          unwrapEden(
+            await api
+              .workspaces({ workspaceId: toSafeId<"workspace">(workspaceId) })
+              .workflow.start.post({
+                ...(args?.entityIds !== undefined &&
+                  args.entityIds.length > 0 && {
+                    entityIds: args.entityIds.map((id) =>
+                      toSafeId<"entity">(id),
+                    ),
+                  }),
+                ...(args?.entityIdsOrder !== undefined &&
+                  args.entityIdsOrder.length > 0 && {
+                    entityIdsOrder: args.entityIdsOrder.map((id) =>
+                      toSafeId<"entity">(id),
+                    ),
+                  }),
+                ...(args?.propertyIds !== undefined &&
+                  args.propertyIds.length > 0 && {
+                    propertyIds: args.propertyIds.map((id) =>
+                      toSafeId<"property">(id),
+                    ),
+                  }),
+                serviceTier,
+              }),
+          ),
       });
-
-      return response.data;
     } catch (error) {
+      // The prompts and the target-count estimate run before the request; a
+      // failure here means nothing was started either.
       analytics.captureError(error);
-      return { status: "failed" } as const;
+      notifyStartFailed();
+      return WORKFLOW_START_FAILED;
     }
   };
 };

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/property-popover.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/property-popover.tsx
@@ -1,6 +1,7 @@
 import { useOptimistic, useRef, useState, useTransition } from "react";
 
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { panic } from "better-result";
 import {
   CheckCircle2Icon,
   EyeOffIcon,
@@ -252,31 +253,42 @@ export const PropertyPopover = ({
     if (!result) {
       return;
     }
-    if (result.status === "started") {
-      stellaToast.add({
-        title: t("workspaces.workflow.startedSuccessfully"),
-        type: "success",
-      });
-      return;
+    const { status } = result;
+    switch (status) {
+      case "started":
+        stellaToast.add({
+          title: t("workspaces.workflow.startedSuccessfully"),
+          type: "success",
+        });
+        return;
+      case "already-running":
+        stellaToast.add({
+          title: t("common.running"),
+          type: "info",
+        });
+        return;
+      case "skipped":
+        stellaToast.add({
+          title: t("workspaces.workflow.noFieldsToProcess"),
+          type: "info",
+        });
+        return;
+      case "ai-unavailable":
+        // Re-running a column is an explicit request, so say why nothing
+        // happened; the side-effect call sites stay quiet on this one.
+        stellaToast.add({
+          title: t("errors.failedToStartWorkflow"),
+          type: "error",
+        });
+        return;
+      case "failed":
+        // Already reported by `useStartWorkflow`, error included.
+        return;
+      default: {
+        const exhaustive: never = status;
+        panic(`Unhandled workflow start status: ${String(exhaustive)}`);
+      }
     }
-    if (result.status === "already-running") {
-      stellaToast.add({
-        title: t("common.running"),
-        type: "info",
-      });
-      return;
-    }
-    if (result.status === "skipped") {
-      stellaToast.add({
-        title: t("workspaces.workflow.noFieldsToProcess"),
-        type: "info",
-      });
-      return;
-    }
-    stellaToast.add({
-      title: t("errors.failedToStartWorkflow"),
-      type: "error",
-    });
   };
 
   return (


### PR DESCRIPTION
The last member of the discarded-start-result family: `POST /workspaces/:id/workflow/start` returned `{status:"failed"}` with HTTP 200, and the web hook returned the body to eight call sites of which seven discard it entirely, so a failed start was invisible everywhere.

**Handler**: a total disposition map over the queue's status union (new `lib/workflow/workflow-start-disposition.ts`) drives the response: `failed` becomes a 500 `HandlerError`; `started`, `already-running`, and `skipped` stay 200. `already-running` deliberately does not copy `cell-retry.ts`'s 409: the one consumer that reads the answer treats it as a benign info toast, and the in-flight run still grades the stale cells (the deferred rationale from the playbook classifier). The success body's status type is derived from the map by a mapped filter, so `failed` is structurally absent from the response type and the web's exhaustive switch cannot silently accept it.

**Web**: the hook unwraps errors and reports through one pure helper — capture plus error toast for both transport rejection and error status — for explicit re-runs and the seven fire-and-forget sites alike. AI-unavailable is its own outcome rather than a fold into failed: no request is sent, the table layout already opens the key dialog, and side-effect call sites fire on ordinary edits, so per-edit toasts would be noise on AI-less deployments.

Tests: exhaustive handler mapping (declared set equals exercised set; rejected set is exactly `failed`), and web logic tests asserting capture, exactly one notification, and no cache invalidation on failure. Fixed in passing: the handler test's whole-module workflow-queue mock now spreads the real module (it was dropping sibling exports for co-batched suites).

Reviewer notes: the 500 will appear in the route's error-rate metrics where it previously did not (that is the change working); and two related classifiers now exist over the same union (transport disposition vs review-surface outcome) plus a 409/200 divergence with cell-retry — both deliberate for their callers, recorded as a unification decision rather than blended here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Workflow start requests now reject unrecognised statuses instead of treating them as successful.
  * Failed workflow starts now consistently report an error and display a failure notification.
  * Workflow status refreshes occur after successfully queued workflows.
  * Property reruns now provide appropriate success, informational, and error feedback for each outcome.
* **Testing**
  * Added coverage for workflow queue statuses, API failures, unavailable AI configuration, notifications, telemetry, and successful refreshes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->