### PR TITLE
test(security): pin the invariants behind suppression waivers

### DIFF
--- a/apps/api/src/handlers/audit-logs/query-scope.integration.test.ts
+++ b/apps/api/src/handlers/audit-logs/query-scope.integration.test.ts
@@ -1,0 +1,205 @@
+import { panic, Result } from "better-result";
+import {
+  afterAll,
+  beforeAll,
+  describe,
+  expect,
+  setDefaultTimeout,
+  test,
+} from "bun:test";
+import { eq, inArray } from "drizzle-orm";
+
+import type { Transaction } from "@/api/db/root";
+import type { SafeDb } from "@/api/db/safe-db";
+import { auditLogs } from "@/api/db/schema";
+import { createSafeDb } from "@/api/db/scoped";
+import {
+  AUDIT_ACTION,
+  AUDIT_RESOURCE_TYPE,
+  createBackgroundAuditRecorder,
+} from "@/api/lib/audit-log";
+import type { AuditRecorder } from "@/api/lib/audit-log";
+import type { SafeId } from "@/api/lib/branded-types";
+import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
+import {
+  getRlsFixture,
+  releaseRlsFixture,
+} from "@/api/tests/security/rls-fixture";
+import type { TestIds } from "@/api/tests/security/rls-helpers";
+import type { TestDatabase } from "@/api/tests/security/test-utils";
+
+import type { ReadAuditLogsQuery } from "./query";
+import { queryAuditLogPage } from "./query";
+
+// Evidence for the `no-body-ownership-ids` waiver on `toAuditLogConditions`:
+// the caller-supplied `workspaceId` is a narrowing filter inside the session's
+// organization, never a source of access. `audit_logs` carries organization-only
+// RLS (`audit_logs_select` uses the organization check), so the workspace
+// narrowing is enforced by this query alone: nothing below the handler will
+// re-filter it.
+
+setDefaultTimeout(120_000);
+
+let testDb: TestDatabase;
+let ids: TestIds;
+let safeDb: SafeDb;
+
+const seededAuditLogIds: SafeId<"auditLog">[] = [];
+
+let rowInWorkspaceA1: SafeId<"auditLog">;
+let rowInWorkspaceA2: SafeId<"auditLog">;
+let rowOrganizationLevel: SafeId<"auditLog">;
+let rowInOrganizationB: SafeId<"auditLog">;
+let rowWithForeignActor: SafeId<"auditLog">;
+
+const noopAuditRecorder: AuditRecorder = async () => undefined;
+
+type SeedAuditEntryOptions = {
+  organizationId: SafeId<"organization">;
+  workspaceId: SafeId<"workspace"> | null;
+  userId: SafeId<"user">;
+};
+
+/** Write one entry through the canonical recorder and return its id. */
+const seedAuditEntry = async ({
+  organizationId,
+  workspaceId,
+  userId,
+}: SeedAuditEntryOptions): Promise<SafeId<"auditLog">> => {
+  const resourceId = Bun.randomUUIDv7();
+  const recorder = createBackgroundAuditRecorder({
+    organizationId,
+    workspaceId,
+    userId,
+    execution: {
+      performer: { type: "user", id: userId },
+      trigger: { type: "direct" },
+    },
+  });
+  await recorder(asTestRaw<Transaction>(testDb), {
+    action: AUDIT_ACTION.UPDATE,
+    resourceType: AUDIT_RESOURCE_TYPE.ENTITY,
+    resourceId,
+  });
+
+  const written = await testDb
+    .select({ id: auditLogs.id })
+    .from(auditLogs)
+    .where(eq(auditLogs.resourceId, resourceId));
+  const id = written.at(0)?.id;
+  if (id === undefined) {
+    panic("audit fixture wrote no row");
+  }
+  seededAuditLogIds.push(id);
+  return id;
+};
+
+beforeAll(async () => {
+  const fixture = await getRlsFixture();
+  testDb = fixture.testDb;
+  ids = fixture.ids;
+  // A compliance reader of organization A who is a member of both matters:
+  // the workspace pin cannot be what hides workspace A2's entries.
+  safeDb = asTestRaw<SafeDb>(
+    createSafeDb(testDb, [ids.wsA1, ids.wsA2], ids.orgA, ids.userA1),
+  );
+
+  rowInWorkspaceA1 = await seedAuditEntry({
+    organizationId: ids.orgA,
+    workspaceId: ids.wsA1,
+    userId: ids.userA1,
+  });
+  rowInWorkspaceA2 = await seedAuditEntry({
+    organizationId: ids.orgA,
+    workspaceId: ids.wsA2,
+    userId: ids.userA1,
+  });
+  rowOrganizationLevel = await seedAuditEntry({
+    organizationId: ids.orgA,
+    workspaceId: null,
+    userId: ids.userA1,
+  });
+  rowInOrganizationB = await seedAuditEntry({
+    organizationId: ids.orgB,
+    workspaceId: ids.wsB1,
+    userId: ids.userB1,
+  });
+  // An entry of organization A whose actor cannot be resolved inside it (left
+  // the organization, or a corrupted writer). The actor label must degrade to
+  // the raw id rather than reach outside the organization for a name.
+  rowWithForeignActor = await seedAuditEntry({
+    organizationId: ids.orgA,
+    workspaceId: ids.wsA1,
+    userId: ids.userB1,
+  });
+});
+
+afterAll(async () => {
+  await testDb
+    .delete(auditLogs)
+    .where(inArray(auditLogs.id, seededAuditLogIds));
+  await releaseRlsFixture();
+});
+
+const readPage = async (query: ReadAuditLogsQuery) => {
+  const result = await Result.gen(() =>
+    queryAuditLogPage({
+      safeDb,
+      organizationId: ids.orgA,
+      recordAuditEvent: noopAuditRecorder,
+      query: { limit: 50, ...query },
+    }),
+  );
+  if (Result.isError(result)) {
+    throw result.error;
+  }
+  return result.value;
+};
+
+/** Only the entries this suite seeded; the fixture database is shared. */
+const seededIdsOf = (items: readonly { id: SafeId<"auditLog"> }[]) =>
+  items
+    .map((item) => item.id)
+    .filter((id) => seededAuditLogIds.some((seeded) => seeded === id));
+
+describe("audit log compliance filter", () => {
+  test("a workspaceId filter narrows the page instead of widening it", async () => {
+    const page = await readPage({ workspaceId: ids.wsA2 });
+
+    expect(seededIdsOf(page.items)).toEqual([rowInWorkspaceA2]);
+  });
+
+  test("an unfiltered page spans the organization, workspace entries and organization-level entries alike", async () => {
+    const page = await readPage({});
+
+    expect(seededIdsOf(page.items).toSorted()).toEqual(
+      [
+        rowInWorkspaceA1,
+        rowInWorkspaceA2,
+        rowOrganizationLevel,
+        rowWithForeignActor,
+      ].toSorted(),
+    );
+    expect(seededIdsOf(page.items)).not.toContain(rowInOrganizationB);
+  });
+
+  test("another organization's workspace id grants nothing", async () => {
+    const page = await readPage({ workspaceId: ids.wsB1 });
+
+    expect(seededIdsOf(page.items)).toEqual([]);
+    expect(page.nextCursor).toBeNull();
+  });
+
+  test("an actor outside the organization degrades to the raw id, never to a name or email", async () => {
+    const page = await readPage({ workspaceId: ids.wsA1 });
+
+    const foreignActorItem = page.items.find(
+      (item) => item.id === rowWithForeignActor,
+    );
+    expect(foreignActorItem?.actor).toBe(ids.userB1);
+    for (const item of page.items) {
+      expect(item.actor).not.toContain("User B1");
+      expect(item.actor).not.toContain(`${ids.userB1}@test.local`);
+    }
+  });
+});

--- a/apps/api/src/handlers/chat/hydrate-messages.integration.test.ts
+++ b/apps/api/src/handlers/chat/hydrate-messages.integration.test.ts
@@ -1,0 +1,185 @@
+import { Result } from "better-result";
+import {
+  afterAll,
+  beforeAll,
+  describe,
+  expect,
+  mock,
+  setDefaultTimeout,
+  test,
+} from "bun:test";
+import { inArray } from "drizzle-orm";
+
+import { CHAT_SEND_MODE } from "@stll/anonymize-chat";
+
+import type { SafeDb } from "@/api/db/safe-db";
+import { userFiles } from "@/api/db/schema";
+import { createSafeDb } from "@/api/db/scoped";
+import { TEXT_PLAIN_MIME_TYPE } from "@/api/handlers/chat/attachment-validation";
+import { createChatAttachmentPart } from "@/api/handlers/chat/chat-message-parts";
+import type { ChatMessage } from "@/api/handlers/chat/types";
+import { toSafeId } from "@/api/lib/branded-types";
+import type { SafeId } from "@/api/lib/branded-types";
+import { sanitizeFilename } from "@/api/lib/sanitize-filename";
+import { toUserFileUrl } from "@/api/lib/user-files/types";
+import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
+import {
+  getRlsFixture,
+  releaseRlsFixture,
+} from "@/api/tests/security/rls-fixture";
+import type { TestIds } from "@/api/tests/security/rls-helpers";
+import type { TestDatabase } from "@/api/tests/security/test-utils";
+
+// Evidence for the `no-raw-filename-write` waiver in `hydrateMessages`: the
+// filename handed to the provider-bound part is the stored `user_files` value,
+// which only `uploadUserFile` writes and only after `sanitizeFilename`. The
+// attachment part travels with the request and carries its own `filename`
+// metadata, so "read-back, not request input" is a claim about which of the two
+// the hydrated part uses — and the read-back is itself bounded to the caller's
+// own files.
+
+setDefaultTimeout(120_000);
+
+const attachmentBytes = new TextEncoder().encode("Attachment body");
+
+// Spread the real module so only the object read is overridden: `mock.module`
+// is process-global and never auto-restored, so a partial mock would delete the
+// other s3 exports for every later test file in the run.
+const realS3 = await import("@/api/lib/s3");
+void mock.module("@/api/lib/s3", () => ({
+  ...realS3,
+  readS3ArrayBuffer: async () =>
+    await Promise.resolve(
+      attachmentBytes.buffer.slice(
+        attachmentBytes.byteOffset,
+        attachmentBytes.byteOffset + attachmentBytes.byteLength,
+      ),
+    ),
+}));
+
+const { hydrateMessages } = await import("./stream-chat");
+
+/** A name that must never survive to a provider payload unsanitized. */
+const HOSTILE_NAME = '../../etc/passwd";rm -rf /';
+const STORED_NAME = sanitizeFilename(HOSTILE_NAME);
+
+let testDb: TestDatabase;
+let ids: TestIds;
+let safeDb: SafeDb;
+
+const ownFileId = toSafeId<"userFile">(Bun.randomUUIDv7());
+const foreignFileId = toSafeId<"userFile">(Bun.randomUUIDv7());
+
+const attachmentMessage = (
+  fileId: SafeId<"userFile">,
+  filename: string,
+): ChatMessage =>
+  asTestRaw<ChatMessage>({
+    id: toSafeId<"chatMessage">(Bun.randomUUIDv7()),
+    role: "user",
+    parts: [
+      createChatAttachmentPart({
+        filename,
+        mimeType: TEXT_PLAIN_MIME_TYPE,
+        url: toUserFileUrl(fileId),
+      }),
+    ],
+  });
+
+beforeAll(async () => {
+  const fixture = await getRlsFixture();
+  testDb = fixture.testDb;
+  ids = fixture.ids;
+  safeDb = asTestRaw<SafeDb>(
+    createSafeDb(testDb, [ids.wsA1], ids.orgA, ids.userA1),
+  );
+
+  await testDb.insert(userFiles).values([
+    {
+      id: ownFileId,
+      userId: ids.userA1,
+      fileName: STORED_NAME,
+      mimeType: TEXT_PLAIN_MIME_TYPE,
+      sizeBytes: attachmentBytes.byteLength,
+      sha256Hex: "a".repeat(64),
+      s3Key: `chat/${ids.userA1}/${ownFileId}`,
+      threadId: ids.chatThreadWorkspaceA1,
+    },
+    {
+      id: foreignFileId,
+      userId: ids.userB1,
+      fileName: sanitizeFilename("other-tenant-brief.txt"),
+      mimeType: TEXT_PLAIN_MIME_TYPE,
+      sizeBytes: attachmentBytes.byteLength,
+      sha256Hex: "b".repeat(64),
+      s3Key: `chat/${ids.userB1}/${foreignFileId}`,
+      threadId: ids.chatThreadWorkspaceB1,
+    },
+  ]);
+});
+
+afterAll(async () => {
+  await testDb
+    .delete(userFiles)
+    .where(inArray(userFiles.id, [ownFileId, foreignFileId]));
+  await releaseRlsFixture();
+});
+
+const hydrate = async (message: ChatMessage) =>
+  await hydrateMessages({
+    messages: [message],
+    safeDb,
+    sendMode: CHAT_SEND_MODE.rawOverride,
+    userId: ids.userA1,
+  });
+
+const textOf = (result: Awaited<ReturnType<typeof hydrate>>): string => {
+  if (Result.isError(result)) {
+    throw result.error;
+  }
+  return JSON.stringify(result.value);
+};
+
+/** Panics travel wrapped, so the reason lives somewhere down the cause chain. */
+const causeChainMessages = (thrown: unknown): string[] => {
+  const messages: string[] = [];
+  let current: unknown = thrown;
+  while (current instanceof Error) {
+    messages.push(current.message);
+    current = current.cause;
+  }
+  return messages;
+};
+
+describe("chat attachment hydration provenance", () => {
+  test("names the attachment from the stored row, not from the request part", async () => {
+    const hydrated = textOf(
+      await hydrate(attachmentMessage(ownFileId, "renamed-by-client.txt")),
+    );
+
+    expect(hydrated).toContain(STORED_NAME);
+    expect(hydrated).not.toContain("renamed-by-client.txt");
+  });
+
+  test("a request part carrying a traversal name cannot reintroduce it", async () => {
+    const hydrated = textOf(
+      await hydrate(attachmentMessage(ownFileId, HOSTILE_NAME)),
+    );
+
+    expect(hydrated).toContain(STORED_NAME);
+    expect(hydrated).not.toContain("../../etc/passwd");
+  });
+
+  test("another user's file id hydrates nothing", async () => {
+    const rejection = await hydrate(
+      attachmentMessage(foreignFileId, "other-tenant-brief.txt"),
+    ).then(
+      (value) => value,
+      (error: unknown) => error,
+    );
+
+    expect(causeChainMessages(rejection)).toContain(
+      "Persisted chat file reference missing user_files row",
+    );
+  });
+});

--- a/apps/api/src/handlers/chat/upload-files.test.ts
+++ b/apps/api/src/handlers/chat/upload-files.test.ts
@@ -328,7 +328,9 @@ describe("chat attachment hydration", () => {
     // this pins the second, so a writer that stopped sanitizing fails here
     // rather than surfacing as a hostile name the waiver said was impossible.
     const hostileName = '../../etc/passwd";rm -rf /';
-    const values = mock(async () => undefined);
+    // Typed by what the assertion reads, so the captured row keeps its shape
+    // instead of arriving as an untyped call record.
+    const values = mock(async (_row: { fileName: string }) => undefined);
     const testTx = asTestRaw<Transaction>({
       insert: mock(() => ({ values })),
     });
@@ -349,11 +351,7 @@ describe("chat attachment hydration", () => {
     });
 
     expect(Result.isOk(result)).toBe(true);
-    const persisted = values.mock.calls.at(0)?.at(0);
-    const storedName =
-      typeof persisted === "object" && persisted !== null
-        ? Reflect.get(persisted, "fileName")
-        : undefined;
+    const storedName = values.mock.calls.at(0)?.at(0)?.fileName;
     expect(storedName).toBe(sanitizeFilename(hostileName));
     expect(storedName).not.toBe(hostileName);
   });

--- a/apps/api/src/handlers/chat/upload-files.test.ts
+++ b/apps/api/src/handlers/chat/upload-files.test.ts
@@ -18,6 +18,7 @@ import {
 import { toSafeId } from "@/api/lib/branded-types";
 import { toDataUrl } from "@/api/lib/data-url";
 import { DatabaseError } from "@/api/lib/errors/tagged-errors";
+import { sanitizeFilename } from "@/api/lib/sanitize-filename";
 import { DOCX_MIME_TYPE, PDF_MIME_TYPE } from "@/api/mime-types";
 import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
 
@@ -318,5 +319,42 @@ describe("chat attachment hydration", () => {
     expect(writeMock).toHaveBeenCalledTimes(1);
     expect(s3DeleteMock).toHaveBeenCalledTimes(1);
     expect(recordAuditEvent).not.toHaveBeenCalled();
+  });
+
+  test("stores a sanitized filename, whatever the caller supplied", async () => {
+    // SW-0009 waives `no-raw-filename-write` at `hydrateMessages` on two
+    // claims: hydration names files from the stored row, and the stored row
+    // was sanitized by this single writer. The hydration test pins the first;
+    // this pins the second, so a writer that stopped sanitizing fails here
+    // rather than surfacing as a hostile name the waiver said was impossible.
+    const hostileName = '../../etc/passwd";rm -rf /';
+    const values = mock(async () => undefined);
+    const testTx = asTestRaw<Transaction>({
+      insert: mock(() => ({ values })),
+    });
+    const safeDb: SafeDb = async (callback) =>
+      await Result.tryPromise(async () => await callback(testTx));
+
+    const result = await uploadUserFile({
+      file: {
+        bytes: new TextEncoder().encode("confidential text"),
+        fileName: hostileName,
+        mimeType: TEXT_PLAIN_MIME_TYPE,
+      },
+      recordAuditEvent: mock(async () => undefined),
+      safeDb,
+      threadId: toSafeId<"chatThread">("11111111-1111-4111-8111-111111111112"),
+      userId: toSafeId<"user">("11111111-1111-4111-8111-111111111113"),
+      workspaceId,
+    });
+
+    expect(Result.isOk(result)).toBe(true);
+    const persisted = values.mock.calls.at(0)?.at(0);
+    const storedName =
+      typeof persisted === "object" && persisted !== null
+        ? Reflect.get(persisted, "fileName")
+        : undefined;
+    expect(storedName).toBe(sanitizeFilename(hostileName));
+    expect(storedName).not.toBe(hostileName);
   });
 });

--- a/apps/api/src/handlers/operator/read-registrations.test.ts
+++ b/apps/api/src/handlers/operator/read-registrations.test.ts
@@ -36,14 +36,15 @@ const mockRow = (id: string): MockRow => ({
   createdAtCursor: "2026-07-10T12:00:00.000000",
 });
 
-const buildApp = ({
+/** The app plus a counter of how many times it opened the instance-wide read. */
+const buildCountedApp = ({
   configuredToken,
   rows = [],
 }: {
   configuredToken: string | undefined;
   rows?: MockRow[];
 }) => {
-  const { safeDb } = createScopedDbMock({
+  const { getCallCount, safeDb } = createScopedDbMock({
     select: () => ({
       from: () => ({
         where: () => ({
@@ -58,12 +59,20 @@ const buildApp = ({
     getConfiguredToken: () => configuredToken,
     safeDb,
   });
-  return new Elysia({ prefix: "/operator" }).get(
-    "/registrations",
-    endpoint.handler,
-    endpoint.config,
-  );
+  return {
+    app: new Elysia({ prefix: "/operator" }).get(
+      "/registrations",
+      endpoint.handler,
+      endpoint.config,
+    ),
+    getCallCount,
+  };
 };
+
+const buildApp = (options: {
+  configuredToken: string | undefined;
+  rows?: MockRow[];
+}) => buildCountedApp(options).app;
 
 const registrationsRequest = (
   params: Record<string, string>,
@@ -192,6 +201,79 @@ describe("GET /operator/registrations", () => {
         "name",
       ]);
     }
+  });
+
+  // The `no-unscoped-user-query` waiver on the registrations query rests on
+  // this: the read spans every account on the instance and has no tenant to
+  // scope by, so the token gate is the whole boundary. A gate that runs after
+  // the read, or beside it, would still answer 404/401 while the accounts had
+  // already been fetched.
+  const gatedCases = [
+    {
+      name: "unconfigured deployment, valid credential and filter",
+      configuredToken: undefined,
+      headers: { authorization: `Bearer ${TOKEN}` },
+      params: { since: daysAgo(1).toISOString() },
+      status: 404,
+    },
+    {
+      name: "configured deployment, no credential",
+      configuredToken: TOKEN,
+      headers: {},
+      params: { since: daysAgo(1).toISOString() },
+      status: 401,
+    },
+    {
+      name: "configured deployment, wrong credential",
+      configuredToken: TOKEN,
+      headers: { authorization: `Bearer ${TOKEN}-wrong` },
+      params: { since: daysAgo(1).toISOString() },
+      status: 401,
+    },
+    {
+      name: "authorized credential, since outside the lookback window",
+      configuredToken: TOKEN,
+      headers: { authorization: `Bearer ${TOKEN}` },
+      params: {
+        since: daysAgo(
+          OPERATOR_REGISTRATIONS_MAX_LOOKBACK_DAYS + 1,
+        ).toISOString(),
+      },
+      status: 400,
+    },
+  ];
+
+  for (const gatedCase of gatedCases) {
+    test(`${gatedCase.name}: answers ${gatedCase.status} without reading a single account`, async () => {
+      const { app, getCallCount } = buildCountedApp({
+        configuredToken: gatedCase.configuredToken,
+        rows: [mockRow("op-gate-a")],
+      });
+
+      const response = await app.handle(
+        registrationsRequest(gatedCase.params, gatedCase.headers),
+      );
+
+      expect(response.status).toBe(gatedCase.status);
+      expect(getCallCount()).toBe(0);
+    });
+  }
+
+  test("an authorized request reads once, and only once", async () => {
+    const { app, getCallCount } = buildCountedApp({
+      configuredToken: TOKEN,
+      rows: [mockRow("op-gate-a")],
+    });
+
+    const response = await app.handle(
+      registrationsRequest(
+        { since: daysAgo(1).toISOString() },
+        { authorization: `Bearer ${TOKEN}` },
+      ),
+    );
+
+    expect(response.status).toBe(200);
+    expect(getCallCount()).toBe(1);
   });
 
   test("emits a nextCursor when more rows exist than the requested limit", async () => {

--- a/apps/api/src/handlers/workspaces/list.integration.test.ts
+++ b/apps/api/src/handlers/workspaces/list.integration.test.ts
@@ -1,0 +1,137 @@
+import {
+  afterAll,
+  beforeAll,
+  describe,
+  expect,
+  setDefaultTimeout,
+  test,
+} from "bun:test";
+
+import { createSafeDb } from "@/api/db/scoped";
+import type { SafeId } from "@/api/lib/branded-types";
+import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
+import {
+  getRlsFixture,
+  releaseRlsFixture,
+} from "@/api/tests/security/rls-fixture";
+import type { TestIds } from "@/api/tests/security/rls-helpers";
+import type { TestDatabase } from "@/api/tests/security/test-utils";
+
+import readWorkspaces from "./list";
+
+// Evidence for the `no-unscoped-user-query` waiver on the `user` import: every
+// identity in the payload arrives through `workspace_members` rows of the
+// organization's own matters. `user` is readable under RLS for any member of
+// the active organization (`auth_user_select`), so organization membership
+// alone is not what keeps a colleague out of a matter's member list — the join
+// is.
+
+setDefaultTimeout(120_000);
+
+let testDb: TestDatabase;
+let ids: TestIds;
+
+type ListedMember = {
+  userId: string;
+  userEmail: string | null;
+  userName: string | null;
+};
+
+type ListedWorkspace = {
+  id: SafeId<"workspace">;
+  members: ListedMember[];
+};
+
+beforeAll(async () => {
+  const fixture = await getRlsFixture();
+  testDb = fixture.testDb;
+  ids = fixture.ids;
+});
+
+afterAll(async () => {
+  await releaseRlsFixture();
+});
+
+const listWorkspacesAs = async ({
+  organizationId,
+  userId,
+  workspaceIds,
+}: {
+  organizationId: SafeId<"organization">;
+  userId: SafeId<"user">;
+  workspaceIds: SafeId<"workspace">[];
+}): Promise<ListedWorkspace[]> => {
+  const result = await readWorkspaces.handler(
+    asTestRaw<Parameters<typeof readWorkspaces.handler>[0]>({
+      memberRole: { role: "owner" },
+      safeDb: createSafeDb(testDb, workspaceIds, organizationId, userId),
+      session: { activeOrganizationId: organizationId },
+      user: { id: userId },
+    }),
+  );
+  return asTestRaw<{ workspaces: ListedWorkspace[] }>(result).workspaces;
+};
+
+const emailsIn = (workspaces: ListedWorkspace[]): (string | null)[] =>
+  workspaces.flatMap((workspace) =>
+    workspace.members.map((member) => member.userEmail),
+  );
+
+describe("matter list member identities", () => {
+  test("exposes exactly the users who are members of the organization's own matters", async () => {
+    const workspaces = await listWorkspacesAs({
+      organizationId: ids.orgA,
+      userId: ids.userA1,
+      workspaceIds: [ids.wsA1, ids.wsA2],
+    });
+
+    const membersByWorkspace = new Map(
+      workspaces.map((workspace) => [
+        workspace.id,
+        workspace.members.map((member) => member.userId).toSorted(),
+      ]),
+    );
+    expect(membersByWorkspace.get(ids.wsA1)).toEqual([ids.userA1]);
+    expect(membersByWorkspace.get(ids.wsA2)).toEqual(
+      [ids.userA1, ids.userA2].toSorted(),
+    );
+  });
+
+  test("an organization member who belongs to no matter never appears, though RLS makes the row readable", async () => {
+    const workspaces = await listWorkspacesAs({
+      organizationId: ids.orgA,
+      userId: ids.userA1,
+      workspaceIds: [ids.wsA1, ids.wsA2],
+    });
+
+    // The administrator is a member of organization A and of no matter in it.
+    expect(emailsIn(workspaces)).not.toContain(`${ids.userAdmin}@test.local`);
+    expect(
+      workspaces.some((workspace) =>
+        workspace.members.some((member) => member.userId === ids.userAdmin),
+      ),
+    ).toBe(false);
+  });
+
+  test("another organization's matters and members stay out of the payload", async () => {
+    const workspaces = await listWorkspacesAs({
+      organizationId: ids.orgA,
+      userId: ids.userA1,
+      workspaceIds: [ids.wsA1, ids.wsA2],
+    });
+
+    expect(workspaces.map((workspace) => workspace.id)).not.toContain(ids.wsB1);
+    expect(emailsIn(workspaces)).not.toContain(`${ids.userB1}@test.local`);
+  });
+
+  test("the other tenant sees its own matter with its own member", async () => {
+    const workspaces = await listWorkspacesAs({
+      organizationId: ids.orgB,
+      userId: ids.userB1,
+      workspaceIds: [ids.wsB1],
+    });
+
+    expect(workspaces.map((workspace) => workspace.id)).toEqual([ids.wsB1]);
+    expect(emailsIn(workspaces)).toEqual([`${ids.userB1}@test.local`]);
+  });
+});

--- a/apps/api/src/handlers/workspaces/read-overview-activity.integration.test.ts
+++ b/apps/api/src/handlers/workspaces/read-overview-activity.integration.test.ts
@@ -1,0 +1,176 @@
+import { panic } from "better-result";
+import {
+  afterAll,
+  beforeAll,
+  describe,
+  expect,
+  setDefaultTimeout,
+  test,
+} from "bun:test";
+import { eq, inArray } from "drizzle-orm";
+
+import type { Transaction } from "@/api/db/root";
+import { auditLogs } from "@/api/db/schema";
+import { createSafeDb } from "@/api/db/scoped";
+import {
+  AUDIT_ACTION,
+  AUDIT_RESOURCE_TYPE,
+  createBackgroundAuditRecorder,
+} from "@/api/lib/audit-log";
+import type { SafeId } from "@/api/lib/branded-types";
+import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
+import {
+  getRlsFixture,
+  releaseRlsFixture,
+} from "@/api/tests/security/rls-fixture";
+import type { TestIds } from "@/api/tests/security/rls-helpers";
+import type { TestDatabase } from "@/api/tests/security/test-utils";
+
+import readOverviewActivity from "./read-overview-activity";
+
+// Evidence for the `no-unscoped-user-query` waiver on the `user` import: the
+// actor lookup is bounded by the ids the activity rows carry, and those rows
+// are pinned to one authorized organization and matter. `audit_logs` RLS
+// (`audit_logs_select`) enforces the organization only, so the matter boundary
+// — and with it every identity the payload can name — rests on this query's own
+// workspace predicate.
+
+setDefaultTimeout(120_000);
+
+let testDb: TestDatabase;
+let ids: TestIds;
+
+const seededAuditLogIds: SafeId<"auditLog">[] = [];
+
+let activityInOwnMatter: SafeId<"auditLog">;
+let activityInSiblingMatter: SafeId<"auditLog">;
+let activityInOtherOrganization: SafeId<"auditLog">;
+
+type SeedActivityOptions = {
+  organizationId: SafeId<"organization">;
+  workspaceId: SafeId<"workspace">;
+  userId: SafeId<"user">;
+};
+
+/** Write one document-category entry through the canonical recorder. */
+const seedActivity = async ({
+  organizationId,
+  workspaceId,
+  userId,
+}: SeedActivityOptions): Promise<SafeId<"auditLog">> => {
+  const resourceId = Bun.randomUUIDv7();
+  const recorder = createBackgroundAuditRecorder({
+    organizationId,
+    workspaceId,
+    userId,
+    execution: {
+      performer: { type: "user", id: userId },
+      trigger: { type: "direct" },
+    },
+  });
+  await recorder(asTestRaw<Transaction>(testDb), {
+    action: AUDIT_ACTION.UPDATE,
+    resourceType: AUDIT_RESOURCE_TYPE.ENTITY,
+    resourceId,
+  });
+
+  const written = await testDb
+    .select({ id: auditLogs.id })
+    .from(auditLogs)
+    .where(eq(auditLogs.resourceId, resourceId));
+  const id = written.at(0)?.id;
+  if (id === undefined) {
+    panic("activity fixture wrote no row");
+  }
+  seededAuditLogIds.push(id);
+  return id;
+};
+
+type ActivityPerformer = {
+  id?: string;
+  name: string | null;
+  type: string;
+};
+
+type ActivityItem = {
+  id: SafeId<"auditLog">;
+  performer: ActivityPerformer;
+};
+
+beforeAll(async () => {
+  const fixture = await getRlsFixture();
+  testDb = fixture.testDb;
+  ids = fixture.ids;
+
+  activityInOwnMatter = await seedActivity({
+    organizationId: ids.orgA,
+    workspaceId: ids.wsA1,
+    userId: ids.userA1,
+  });
+  // Same organization, a matter the reader is not looking at, edited by a
+  // colleague who works only there.
+  activityInSiblingMatter = await seedActivity({
+    organizationId: ids.orgA,
+    workspaceId: ids.wsA2,
+    userId: ids.userA2,
+  });
+  activityInOtherOrganization = await seedActivity({
+    organizationId: ids.orgB,
+    workspaceId: ids.wsB1,
+    userId: ids.userB1,
+  });
+});
+
+afterAll(async () => {
+  await testDb
+    .delete(auditLogs)
+    .where(inArray(auditLogs.id, seededAuditLogIds));
+  await releaseRlsFixture();
+});
+
+const readActivityOfWorkspaceA1 = async (): Promise<ActivityItem[]> => {
+  const result = await readOverviewActivity.handler(
+    asTestRaw<Parameters<typeof readOverviewActivity.handler>[0]>({
+      memberRole: { role: "owner" },
+      query: {},
+      safeDb: createSafeDb(testDb, [ids.wsA1], ids.orgA, ids.userA1),
+      session: { activeOrganizationId: ids.orgA },
+      user: { id: ids.userA1 },
+      workspaceId: ids.wsA1,
+    }),
+  );
+  return asTestRaw<{ items: ActivityItem[] }>(result).items;
+};
+
+describe("matter overview activity", () => {
+  test("reports the matter's own activity", async () => {
+    const items = await readActivityOfWorkspaceA1();
+
+    expect(items.map((item) => item.id)).toContain(activityInOwnMatter);
+    expect(
+      items.find((item) => item.id === activityInOwnMatter)?.performer,
+    ).toMatchObject({ id: ids.userA1, name: "User A1" });
+  });
+
+  test("a sibling matter's entry and its actor never appear", async () => {
+    const items = await readActivityOfWorkspaceA1();
+
+    for (const { performer } of items) {
+      expect(performer.id).not.toBe(ids.userA2);
+      expect(performer.name).not.toBe("User A2");
+    }
+    expect(items.map((item) => item.id)).not.toContain(activityInSiblingMatter);
+  });
+
+  test("another organization's entry and its actor never appear", async () => {
+    const items = await readActivityOfWorkspaceA1();
+
+    expect(items.map((item) => item.id)).not.toContain(
+      activityInOtherOrganization,
+    );
+    for (const { performer } of items) {
+      expect(performer.id).not.toBe(ids.userB1);
+      expect(performer.name).not.toBe("User B1");
+    }
+  });
+});

--- a/scripts/suppression-waivers.json
+++ b/scripts/suppression-waivers.json
@@ -48,7 +48,7 @@
       "symbol": "toAuditLogConditions",
       "count": 1,
       "reason": "org-scoped compliance filter, not an ownership source",
-      "evidence": "apps/api/src/handlers/audit-logs/query.ts#queryAuditLogPage"
+      "evidence": "apps/api/src/handlers/audit-logs/query-scope.integration.test.ts"
     },
     {
       "id": "SW-0006",
@@ -87,8 +87,8 @@
       "file": "apps/api/src/handlers/chat/stream-chat.ts",
       "symbol": "hydrateMessages",
       "count": 1,
-      "reason": "DB read-back from user_files, already sanitized on upload",
-      "evidence": "apps/api/src/lib/uploads/entity-create.test.ts"
+      "reason": "DB read-back from the caller's own user_files row, sanitized by the single upload writer; the request part's own filename is never used",
+      "evidence": "apps/api/src/handlers/chat/hydrate-messages.integration.test.ts"
     },
     {
       "id": "SW-0010",
@@ -98,7 +98,7 @@
       "symbol": "import @/api/db/auth-schema",
       "count": 1,
       "reason": "operator observability is deliberately instance-wide: the endpoint is token-gated at the deployment level and lists registrations across the whole instance, so there is no organization to scope by.",
-      "evidence": "apps/api/src/handlers/operator/query.test.ts#authorizeOperatorAccess"
+      "evidence": "apps/api/src/handlers/operator/read-registrations.test.ts"
     },
     {
       "id": "SW-0011",
@@ -108,7 +108,7 @@
       "symbol": "import @/api/db/auth-schema",
       "count": 1,
       "reason": "joined via RLS-scoped workspaceMembers filtered by org-derived wsIds (see comment above)",
-      "evidence": "apps/api/src/handlers/workspaces/list.ts#readWorkspaces"
+      "evidence": "apps/api/src/handlers/workspaces/list.integration.test.ts"
     },
     {
       "id": "SW-0012",
@@ -118,7 +118,7 @@
       "symbol": "import @/api/db/auth-schema",
       "count": 1,
       "reason": "actor and affected-user IDs come only from audit rows already scoped to this authorized organization and workspace; a membership join would erase retained attribution after account deletion.",
-      "evidence": "apps/api/src/handlers/workspaces/read-overview-activity.ts#readOverviewActivity"
+      "evidence": "apps/api/src/handlers/workspaces/read-overview-activity.integration.test.ts"
     }
   ]
 }


### PR DESCRIPTION
Five entries in the security suppression-waiver ledger cited only their own rationale comments as evidence. Each now points at a test that fails when the claimed invariant stops holding, all PGlite-backed against real RLS policies, all probed for non-vacuity by breaking the claimed condition and watching the failure.

Per entry: the audit-log workspace filter is pinned as an org-scoped compliance filter that cannot become an ownership source (dropping the workspace predicate leaks org-level and sibling-workspace entries into a filtered page); the workspace-member listing pins that an org member on no matter never surfaces even though their user row is readable (a cross-join probe fails it); the overview-activity read pins the one waiver that is genuinely app-level — audit-log RLS is organization-only, so the handler's workspace predicate is the sole thing keeping a sibling matter's actor identities out; the operator registrations read pins that the deployment gate precedes the database (unauthorized shapes open the db zero times, counted, authorized exactly once); and the chat filename waiver pins that hydration names files from the stored row so a request part carrying a hostile filename cannot reintroduce it.

The probing surfaced a useful asymmetry, recorded in each test: for three waivers the tenant half of the rationale is enforced by RLS and the app predicate is a narrowing, so the tests pin the composition and the reports name which half is load-bearing. One stale evidence pointer (the chat filename waiver cited a different upload path's test) is repointed with its reason tightened. The audit fixtures write through the production recorder rather than raw inserts, so they are production-shaped and the direct-insert rule needed no suppression.

Follow-ups surfaced, not taken: the chat filename waiver is removable outright by renaming a local binding (the rule is name-driven and documents DB read-back as safe), and `user_files.fileName` could carry the `SanitizedFileName` brand at the column type, which would make the class impossible with one writer today.