### PR TITLE
fix(api): single import path for unvalidated id branding

### DIFF
--- a/apps/api/src/handlers/chat/chat-schema.ts
+++ b/apps/api/src/handlers/chat/chat-schema.ts
@@ -18,7 +18,6 @@ import {
   RESOURCE_TYPE,
   type ChatEditApplyMode,
   type ChatRunMode,
-  toSafeId,
   type DocxEditRepresentation,
 } from "@stll/api-contract";
 
@@ -52,6 +51,10 @@ import type { ChatToolMap } from "@/api/lib/chat/chat-tool-types";
 import { tSafeId } from "@/api/lib/custom-schema";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import { normalizeChatMessageHtml } from "@/api/lib/markdown/chat-message";
+import {
+  brandPersistedEntityId,
+  brandPersistedWorkspaceId,
+} from "@/api/lib/safe-id-boundaries";
 
 export {
   CHAT_EDIT_APPLY_MODE,
@@ -1070,7 +1073,7 @@ const parseMentionsMetadata = (
           parsedResource ??
           resourceRef({
             type: RESOURCE_TYPE.WORKSPACE,
-            id: toSafeId<"workspace">(id),
+            id: brandPersistedWorkspaceId(id),
           }),
       });
       continue;
@@ -1097,7 +1100,7 @@ const parseMentionsMetadata = (
         parsedResource ??
         resourceRef({
           type: RESOURCE_TYPE.ENTITY,
-          id: toSafeId<"entity">(id),
+          id: brandPersistedEntityId(id),
         }),
       workspaceId,
     });

--- a/apps/api/src/lib/document-processing-queue.ts
+++ b/apps/api/src/lib/document-processing-queue.ts
@@ -71,6 +71,7 @@ import {
   readTenantS3ArrayBuffer,
   writeTenantS3Object,
 } from "@/api/lib/s3-presign";
+import { brandPersistedFieldId } from "@/api/lib/safe-id-boundaries";
 import {
   executeNativeExtraction,
   requiresDurableNativeExtraction,
@@ -78,7 +79,6 @@ import {
 import { getSearchProvider } from "@/api/lib/search/provider";
 import { withTimeout } from "@/api/lib/with-timeout";
 import { PDF_MIME_TYPE } from "@/api/mime-types";
-import { toSafeId } from "@/api/types";
 
 const OCR_SOURCE_URL_TTL_SECONDS = 35 * 60;
 const WORKER_CONCURRENCY = 2;
@@ -1458,7 +1458,7 @@ export const readRepairScanCursor = async (
     label: "document OCR repair cursor read",
     timeoutMs,
   });
-  return cursor === null ? null : toSafeId<"field">(cursor);
+  return cursor === null ? null : brandPersistedFieldId(cursor);
 };
 
 export const writeRepairScanCursor = async ({

--- a/apps/api/src/lib/markdown/chat-message.test.ts
+++ b/apps/api/src/lib/markdown/chat-message.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, test } from "bun:test";
 import fc from "fast-check";
 
-import { resourceRef, RESOURCE_TYPE, toSafeId } from "@stll/api-contract";
+import { resourceRef, RESOURCE_TYPE } from "@stll/api-contract";
 import { propertyConfig } from "@stll/property-testing";
 
+import { toSafeId } from "@/api/lib/branded-types";
 import { normalizeChatMessageHtml } from "@/api/lib/markdown/chat-message";
 
 describe("chat message markdown serializer", () => {

--- a/apps/api/src/lib/markdown/chat-message.ts
+++ b/apps/api/src/lib/markdown/chat-message.ts
@@ -5,13 +5,17 @@ import {
   RESOURCE_TYPE,
   toChatMentionResourceHref,
   toChatResourceHref,
-  toSafeId,
   isChatMentionCategory,
   isChatReferenceCategory,
 } from "@stll/api-contract";
 
 import type { ChatMention, ChatMentionHref } from "@/api/lib/chat/references";
 import { htmlToMarkdown } from "@/api/lib/markdown/html-to-markdown";
+import {
+  brandPersistedCaseLawDecisionId,
+  brandPersistedEntityId,
+  brandPersistedWorkspaceId,
+} from "@/api/lib/safe-id-boundaries";
 
 const ALLOWED_TAGS = new Set([
   "a",
@@ -125,7 +129,7 @@ const toMentionHref = (mention: ChatMention): ChatMentionHref => {
               type: "workspace",
               workspace: resourceRef({
                 type: RESOURCE_TYPE.WORKSPACE,
-                id: toSafeId<"workspace">(mention.workspaceId),
+                id: brandPersistedWorkspaceId(mention.workspaceId),
               }),
             },
     });
@@ -142,7 +146,7 @@ const toDecisionReferenceHref = (id: string) =>
     type: RESOURCE_TYPE.CASE_LAW_DECISION,
     resource: resourceRef({
       type: RESOURCE_TYPE.CASE_LAW_DECISION,
-      id: toSafeId<"caseLawDecision">(id),
+      id: brandPersistedCaseLawDecisionId(id),
     }),
   });
 
@@ -221,7 +225,7 @@ const replaceMentionsWithAnchors = (
             label,
             resource: resourceRef({
               type: RESOURCE_TYPE.ENTITY,
-              id: toSafeId<"entity">(id),
+              id: brandPersistedEntityId(id),
             }),
             workspaceId: sourceWorkspaceId,
           }
@@ -231,7 +235,7 @@ const replaceMentionsWithAnchors = (
             label,
             resource: resourceRef({
               type: RESOURCE_TYPE.WORKSPACE,
-              id: toSafeId<"workspace">(id),
+              id: brandPersistedWorkspaceId(id),
             }),
           };
 

--- a/apps/api/src/lib/resource-policy.test.ts
+++ b/apps/api/src/lib/resource-policy.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, test } from "bun:test";
 
-import { resourceRef, RESOURCE_TYPE, toSafeId } from "@stll/api-contract";
+import { resourceRef, RESOURCE_TYPE } from "@stll/api-contract";
 
+import { toSafeId } from "@/api/lib/branded-types";
 import { getResourceAuthorizationDisposition } from "@/api/lib/resource-authorization";
 import { getResourceBacklinkDisposition } from "@/api/lib/resource-backlinks";
 import {

--- a/apps/api/src/scripts/corpus-column-trim.ts
+++ b/apps/api/src/scripts/corpus-column-trim.ts
@@ -46,6 +46,7 @@ import type {
 } from "@/api/lib/legal-search/document-types";
 import { LIMITS } from "@/api/lib/limits";
 import { getCorpusS3, refreshCorpusS3, refreshS3 } from "@/api/lib/s3";
+import { brandPersistedCaseLawDecisionId } from "@/api/lib/safe-id-boundaries";
 import { withTimeout } from "@/api/lib/with-timeout";
 import type { CorpusObjectState } from "@/api/scripts/corpus-column-trim-plan";
 import {
@@ -54,7 +55,6 @@ import {
   parseColumnTrimArgs,
   planColumnTrim,
 } from "@/api/scripts/corpus-column-trim-plan";
-import { toSafeId } from "@/api/types";
 
 const BATCH_SIZE = 50;
 const CONCURRENCY = 4;
@@ -102,7 +102,7 @@ console.log(`=== CORPUS COLUMN TRIM (${runLabel}) ===`);
 // statement timeout once enough rows are trimmed. The cursor rides on every
 // progress line, so a supervisor can pass the last one back in.
 let lastId: SafeId<"caseLawDecision"> | null =
-  after === null ? null : toSafeId<"caseLawDecision">(after);
+  after === null ? null : brandPersistedCaseLawDecisionId(after);
 let trimmed = 0;
 let skipped = 0;
 let failed = 0;

--- a/apps/api/src/scripts/replay-case-law-source.ts
+++ b/apps/api/src/scripts/replay-case-law-source.ts
@@ -44,7 +44,7 @@ import {
   refreshCorpusS3,
   refreshS3,
 } from "@/api/lib/s3";
-import { toSafeId } from "@/api/types";
+import { brandPersistedCaseLawDecisionId } from "@/api/lib/safe-id-boundaries";
 
 const DEFAULT_LIMIT = 100;
 const DEFAULT_PAGE_SIZE = 25;
@@ -111,7 +111,7 @@ const afterArgument = flagValue("after");
 const after =
   afterArgument === undefined
     ? null
-    : toSafeId<"caseLawDecision">(afterArgument);
+    : brandPersistedCaseLawDecisionId(afterArgument);
 
 const adapter = getAdapter(adapterKey);
 if (!adapter) {

--- a/apps/api/src/types.ts
+++ b/apps/api/src/types.ts
@@ -48,7 +48,6 @@ export type MemoriesAPI = Elysia<
   MemoriesRoutes
 >;
 
-export { toSafeId } from "@/api/lib/branded-types";
 export type { SafeId, SafeIdType } from "@/api/lib/branded-types";
 export type { LegalListSourceLocator } from "@/api/lib/lists/types";
 export type { Page } from "@/api/lib/pagination";

--- a/apps/web/src/components/chat-mention-extension.test.ts
+++ b/apps/web/src/components/chat-mention-extension.test.ts
@@ -1,10 +1,11 @@
 import { describe, expect, test } from "bun:test";
 
-import { resourceRef, RESOURCE_TYPE, toSafeId } from "@stll/api-contract";
+import { resourceRef, RESOURCE_TYPE } from "@stll/api-contract";
 
 import type { ChatMentionOption } from "@/components/chat-mention-extension";
 import { selectChatSuggestionItems } from "@/components/chat-mention-extension";
 import { toChatMentionNodeAttrs } from "@/components/chat-mention-node-attrs";
+import { toSafeId } from "@/lib/safe-id";
 
 const option = ({
   category = "entity",

--- a/apps/web/src/components/chat-mention-helpers.ts
+++ b/apps/web/src/components/chat-mention-helpers.ts
@@ -1,6 +1,6 @@
 import type { Editor } from "@tiptap/core";
 
-import { resourceRef, RESOURCE_TYPE, toSafeId } from "@stll/api-contract";
+import { resourceRef, RESOURCE_TYPE } from "@stll/api-contract";
 
 import type { ChatMentionOption } from "@/components/chat-mention-extension";
 import { toChatMentionNodeAttrs } from "@/components/chat-mention-node-attrs";
@@ -8,6 +8,7 @@ import {
   getEntityName,
   getFirstFile,
 } from "@/components/workspaces/entity-utils";
+import { toSafeId } from "@/lib/safe-id";
 import type { ConditionNode, WorkspaceEntity } from "@/lib/types";
 
 export const CHAT_MENTION_ENTITY_RESULT_LIMIT = 50;

--- a/apps/web/src/components/chat-mention-list.tsx
+++ b/apps/web/src/components/chat-mention-list.tsx
@@ -12,7 +12,7 @@ import {
 } from "lucide-react";
 import { useTranslations } from "use-intl";
 
-import { resourceRef, RESOURCE_TYPE, toSafeId } from "@stll/api-contract";
+import { resourceRef, RESOURCE_TYPE } from "@stll/api-contract";
 import { Button } from "@stll/ui/components/button";
 import { DirectionalIcon } from "@stll/ui/components/directional-icon";
 import { Popover, PopoverPopup } from "@stll/ui/components/popover";
@@ -28,6 +28,7 @@ import { MatterIcon } from "@/components/matter-icon";
 import { EntityIcon } from "@/components/workspaces/entity-kind-icon";
 import { useExternalSyncEffect } from "@/hooks/use-effect";
 import type { TranslationKey } from "@/i18n/types";
+import { toSafeId } from "@/lib/safe-id";
 
 export const ChatMentionList = ({
   items,

--- a/apps/web/src/components/chat/chat-mention-href.test.ts
+++ b/apps/web/src/components/chat/chat-mention-href.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, test } from "bun:test";
 
-import { resourceRef, RESOURCE_TYPE, toSafeId } from "@stll/api-contract";
+import { resourceRef, RESOURCE_TYPE } from "@stll/api-contract";
 
 import { parseStellaMentionHref } from "@/components/chat/chat-mention-href";
+import { toSafeId } from "@/lib/safe-id";
 
 describe("chat mention hrefs", () => {
   test("recognizes stable entity hrefs used by clickable document mentions", () => {

--- a/apps/web/src/components/search-dialog.logic.test.ts
+++ b/apps/web/src/components/search-dialog.logic.test.ts
@@ -1,12 +1,9 @@
 import { describe, expect, test } from "bun:test";
 
-import {
-  resourceRef,
-  RESOURCE_TYPE,
-  toResourceName,
-  toSafeId,
-} from "@stll/api-contract";
+import { resourceRef, RESOURCE_TYPE, toResourceName } from "@stll/api-contract";
 import type { GlobalSearchHit } from "@stll/api/types";
+
+import { toSafeId } from "@/lib/safe-id";
 
 import {
   createDialogCloseActionQueue,

--- a/apps/web/src/components/search-dialog.logic.ts
+++ b/apps/web/src/components/search-dialog.logic.ts
@@ -1,11 +1,7 @@
-import {
-  resourceRef,
-  RESOURCE_TYPE,
-  toResourceName,
-  toSafeId,
-} from "@stll/api-contract";
+import { resourceRef, RESOURCE_TYPE, toResourceName } from "@stll/api-contract";
 import type { GlobalSearchHit } from "@stll/api/types";
 
+import { toSafeId } from "@/lib/safe-id";
 import type { RecentFile } from "@/lib/search-recents";
 
 type ChatGlobalSearchHit = Extract<GlobalSearchHit, { type: "chat" }>;

--- a/apps/web/src/components/workspaces/tasks/task-links.logic.test.ts
+++ b/apps/web/src/components/workspaces/tasks/task-links.logic.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, test } from "bun:test";
 
-import { resourceRef, RESOURCE_TYPE, toSafeId } from "@stll/api-contract";
+import { resourceRef, RESOURCE_TYPE } from "@stll/api-contract";
 
 import { getEntityLinkResource } from "@/components/workspaces/tasks/task-links.logic";
+import { toSafeId } from "@/lib/safe-id";
 
 describe("task link resource identity", () => {
   test("upgrades a legacy entity ID at the client boundary", () => {

--- a/apps/web/src/components/workspaces/tasks/task-links.logic.ts
+++ b/apps/web/src/components/workspaces/tasks/task-links.logic.ts
@@ -4,9 +4,10 @@ import {
   parseResourceRef,
   resourceRef,
   RESOURCE_TYPE,
-  toSafeId,
   type ResourceRef,
 } from "@stll/api-contract";
+
+import { toSafeId } from "@/lib/safe-id";
 
 export type EntityLinkResourceInput = {
   id: string;

--- a/apps/web/src/features/chat/hooks/use-global-chat-mention-registration.ts
+++ b/apps/web/src/features/chat/hooks/use-global-chat-mention-registration.ts
@@ -1,4 +1,4 @@
-import { resourceRef, RESOURCE_TYPE, toSafeId } from "@stll/api-contract";
+import { resourceRef, RESOURCE_TYPE } from "@stll/api-contract";
 
 import { useChatEditorExtensions } from "@/components/chat-editor-provider";
 import type {
@@ -11,6 +11,7 @@ import { usePublicLawPreviewEnabled } from "@/hooks/use-public-law-preview";
 import { getAnalytics } from "@/lib/analytics/provider";
 import { api } from "@/lib/api";
 import { assertPublicLawApiData } from "@/lib/public-law-api";
+import { toSafeId } from "@/lib/safe-id";
 
 const GLOBAL_CHAT_MENTION_EXTENSION_ID = "global-chat:org-mentions";
 

--- a/apps/web/src/lib/chat-draft-store.test.ts
+++ b/apps/web/src/lib/chat-draft-store.test.ts
@@ -1,7 +1,7 @@
 import type { JSONContent } from "@tiptap/react";
 import { afterEach, describe, expect, test } from "bun:test";
 
-import { resourceRef, RESOURCE_TYPE, toSafeId } from "@stll/api-contract";
+import { resourceRef, RESOURCE_TYPE } from "@stll/api-contract";
 
 import type { ChatDraftAttachment } from "@/components/chat-editor-provider";
 import type { ChatMentionOption } from "@/components/chat-mention-extension";
@@ -15,6 +15,7 @@ import {
   useChatDraftStore,
 } from "@/lib/chat-draft-store";
 import { getChatThreadKey, toChatThreadId } from "@/lib/chat-thread-ref";
+import { toSafeId } from "@/lib/safe-id";
 
 const docWithText = (text: string): JSONContent => ({
   type: "doc",

--- a/apps/web/src/lib/safe-id.ts
+++ b/apps/web/src/lib/safe-id.ts
@@ -1,2 +1,14 @@
-export { toSafeId } from "@stll/api/types";
+import { toSafeId as brandSafeId } from "@stll/api-contract/safe-id";
+import type { SafeId, SafeIdType } from "@stll/api/types";
+
 export type { SafeId, SafeIdType } from "@stll/api/types";
+
+/**
+ * The one web-side entry point for branding a raw identifier. It narrows the
+ * portable contract helper to the id kinds the API declares, so a typo in the
+ * type argument fails to compile. The brand asserts format only: every request
+ * built from one is still authorized server-side.
+ */
+export const toSafeId = <TType extends SafeIdType>(
+  value: string,
+): SafeId<TType> => brandSafeId<TType>(value);

--- a/apps/web/src/lib/search.test.ts
+++ b/apps/web/src/lib/search.test.ts
@@ -1,13 +1,9 @@
 import { describe, expect, test } from "bun:test";
 
-import {
-  resourceRef,
-  RESOURCE_TYPE,
-  toResourceName,
-  toSafeId,
-} from "@stll/api-contract";
+import { resourceRef, RESOURCE_TYPE, toResourceName } from "@stll/api-contract";
 import type { GlobalSearchHit } from "@stll/api/types";
 
+import { toSafeId } from "@/lib/safe-id";
 import {
   getFirstSearchHighlightText,
   getNativeSearchDocumentPreviewTarget,

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -192,6 +192,16 @@ const apiSafeIdBrandingImport = {
     "Only approved boundary modules and tests may brand raw IDs with toSafeId.",
 };
 
+// The portable contract helper brands any string for any id kind, so reaching
+// it directly would route around both the sanctioned boundaries above and the
+// SafeIdType union. apps/web re-exports it once; apps/api never imports it.
+const apiPortableSafeIdBrandingImport = {
+  name: "@stll/api-contract/safe-id",
+  importNames: ["toSafeId"],
+  message:
+    "Brand ids through '@/api/lib/safe-id-boundaries', not the portable contract helper.",
+};
+
 export default defineConfig({
   extends: [core, react],
   rules: {
@@ -2161,7 +2171,13 @@ export default defineConfig({
       rules: {
         "no-restricted-imports": [
           "error",
-          { paths: [noZodImport, apiSafeIdBrandingImport] },
+          {
+            paths: [
+              noZodImport,
+              apiSafeIdBrandingImport,
+              apiPortableSafeIdBrandingImport,
+            ],
+          },
         ],
       },
     },
@@ -2207,10 +2223,12 @@ export default defineConfig({
         "apps/api/src/lib/auth.ts",
         "apps/api/src/lib/search/**",
         "apps/api/src/lib/safe-id-boundaries.ts",
-        "apps/api/src/types.ts",
       ],
       rules: {
-        "no-restricted-imports": ["error", { paths: [noZodImport] }],
+        "no-restricted-imports": [
+          "error",
+          { paths: [noZodImport, apiPortableSafeIdBrandingImport] },
+        ],
       },
     },
     {
@@ -2407,6 +2425,7 @@ export default defineConfig({
                 message:
                   "Handlers must receive SafeId from macros (workspaceAccessMacro, authMacro) or actor session validation, not construct it from raw strings.",
               },
+              apiPortableSafeIdBrandingImport,
               {
                 name: "@/api/db",
                 importNames: ["createScopedDb"],
@@ -2495,6 +2514,7 @@ export default defineConfig({
             paths: [
               noZodImport,
               apiSafeIdBrandingImport,
+              apiPortableSafeIdBrandingImport,
               {
                 name: "@/api/lib/api-handlers",
                 importNames: ["createHandler", "createRootHandler"],

--- a/packages/api-contract/package.json
+++ b/packages/api-contract/package.json
@@ -9,6 +9,7 @@
     ".": "./src/index.ts",
     "./chat": "./src/chat.ts",
     "./entity-options": "./src/entity-options.ts",
+    "./safe-id": "./src/safe-id.ts",
     "./time-entry-types": "./src/time-entry-types.ts",
     "./time-entries": "./src/time-entries.ts",
     "./workflow-status": "./src/workflow-status.ts"

--- a/packages/api-contract/src/index.ts
+++ b/packages/api-contract/src/index.ts
@@ -210,7 +210,10 @@ export {
   resourcesChangedRealtimeEvent,
 } from "./realtime-events";
 export { encodeRfc3986Component } from "./rfc3986";
-export { isSafeIdValue, toSafeId } from "./safe-id";
+// `toSafeId` is deliberately absent from this barrel: it stamps the SafeId
+// brand without any ownership check, so it stays behind the explicit
+// '@stll/api-contract/safe-id' entry point that each app re-exports once.
+export { isSafeIdValue } from "./safe-id";
 export type { SafeId } from "./safe-id";
 export { CONTACT_TYPES, WORKSPACE_CONTACT_ROLES } from "./workspace-contacts";
 export type { ContactType, WorkspaceContactRole } from "./workspace-contacts";

--- a/scripts/oxlint-override-union.test.ts
+++ b/scripts/oxlint-override-union.test.ts
@@ -48,7 +48,7 @@ const DELIBERATE_NARROWINGS = [
   {
     rule: "no-restricted-imports",
     scope:
-      "apps/api/src/lib/auth.ts, apps/api/src/lib/search/**, apps/api/src/lib/safe-id-boundaries.ts, apps/api/src/types.ts",
+      "apps/api/src/lib/auth.ts, apps/api/src/lib/search/**, apps/api/src/lib/safe-id-boundaries.ts",
     drops: ["path:@/api/lib/branded-types#toSafeId"],
     reason:
       "These are the sanctioned branding boundaries: they validate a raw id and hand back a SafeId, so they are the modules toSafeId exists for.",
@@ -64,6 +64,7 @@ const DELIBERATE_NARROWINGS = [
       "path:@/api/db/root#rlsDb,rootDb",
       "path:@/api/lib/api-handlers#createHandler,createRootHandler",
       "path:@/api/lib/branded-types#toSafeId",
+      "path:@stll/api-contract/safe-id#toSafeId",
     ],
     reason:
       "Tests build handler context and owner-level DB handles directly; that is the fixture surface the production restrictions exist to keep out of handlers.",


### PR DESCRIPTION
The `no-restricted-imports` ban on `toSafeId` (the unvalidated brand-minting escape hatch) named one module path, but the symbol was reachable through two others: a value re-export on the otherwise type-only `@/api/types` surface, and a second, wider implementation exported from the `@stll/api-contract` barrel. Five api production files imported through those paths with no suppression, and five web modules bypassed web's own `@/lib/safe-id` wrapper via the contract barrel.

Both paths are removed rather than banned: `@/api/types` exports types only; the contract's helper moved behind a `./safe-id` subpath (matching the package's existing subpath pattern) and left the barrel; web's `@/lib/safe-id` now owns the web-side wrapper, narrowing the portable helper's unconstrained type parameter to `SafeIdType`, so the five converted web modules gain kind-checking. A missing export is a type error, which is stronger than a lint ban; the new subpath is itself restricted across all four api override scopes per the override-union discipline, so creating it did not move the hole.

The five api sites all resolved to existing sanctioned helpers in `safe-id-boundaries.ts` (system-written cursor rehydration, two operator flags on global-corpus maintenance scripts, persisted-metadata re-parsing behind a format check, and markdown mention ids whose authority is the downstream workspace-access filter); zero new suppressions or named-file exemptions, and the now-dead `@/api/types` exemption was removed from the sanctioned-boundaries override.

Probes confirm each former path fails (two as type errors, the subpath and the original module as lint errors). Follow-ups recorded: a web-side restriction on the new subpath with `@/lib/safe-id` as the single exemption, and a naming pass on the `brandPersisted*` helpers, whose incumbent convention covers more than DB reads.
