### PR TITLE
feat: support local read-only case-law corpus

### DIFF
--- a/.oxlint-plugins/__fixtures__/public-case-law-db-boundary.fixture.ts
+++ b/.oxlint-plugins/__fixtures__/public-case-law-db-boundary.fixture.ts
@@ -2,6 +2,8 @@
 
 // oxlint-disable-next-line public-case-law-db-boundary/public-case-law-db-boundary -- fixture: private schema import crosses the public case-law boundary
 import { caseLawDecisions, caseLawMatterLinks } from "@/api/db/schema";
+// oxlint-disable-next-line public-case-law-db-boundary/public-case-law-db-boundary -- fixture: namespace imports make the schema boundary unresolved
+import * as caseLawSchema from "@/api/db/schema";
 
 declare const tx: {
   query: {
@@ -10,9 +12,14 @@ declare const tx: {
   };
 };
 declare const sql: (parts: TemplateStringsArray) => unknown;
+declare const getRelationName: () => keyof typeof tx.query;
 
 // oxlint-disable-next-line public-case-law-db-boundary/public-case-law-db-boundary -- fixture: private relation query crosses the boundary
 export const privateQuery = tx.query.caseLawMatterLinks.findMany();
+// oxlint-disable-next-line typescript/dot-notation, public-case-law-db-boundary/public-case-law-db-boundary -- fixture: computed query access must not bypass the boundary
+export const computedPrivateQuery = tx["query"].caseLawMatterLinks.findMany();
+// oxlint-disable-next-line public-case-law-db-boundary/public-case-law-db-boundary -- fixture: dynamic relation access makes the query boundary unresolved
+export const dynamicQuery = tx.query[getRelationName()].findMany();
 // oxlint-disable-next-line public-case-law-db-boundary/public-case-law-db-boundary -- fixture: private table text cannot hide in a string
 export const privateSqlText = "select * from user";
 // oxlint-disable-next-line public-case-law-db-boundary/public-case-law-db-boundary -- fixture: private table text cannot hide in a template
@@ -22,3 +29,4 @@ export const publicQuery = tx.query.caseLawDecisions.findMany();
 export const publicSql = sql`select * from case_law_decisions`;
 void caseLawDecisions;
 void caseLawMatterLinks;
+void caseLawSchema;

--- a/.oxlint-plugins/__fixtures__/public-case-law-db-boundary.fixture.ts
+++ b/.oxlint-plugins/__fixtures__/public-case-law-db-boundary.fixture.ts
@@ -1,18 +1,18 @@
 // Passive regression fixture for public-case-law-db-boundary.
 
 // oxlint-disable-next-line public-case-law-db-boundary/public-case-law-db-boundary -- fixture: private schema import crosses the public case-law boundary
-import { caseLawDecisions, user } from "@/api/db/schema";
+import { caseLawDecisions, caseLawMatterLinks } from "@/api/db/schema";
 
 declare const tx: {
   query: {
     caseLawDecisions: { findMany: () => unknown };
-    user: { findMany: () => unknown };
+    caseLawMatterLinks: { findMany: () => unknown };
   };
 };
 declare const sql: (parts: TemplateStringsArray) => unknown;
 
 // oxlint-disable-next-line public-case-law-db-boundary/public-case-law-db-boundary -- fixture: private relation query crosses the boundary
-export const privateQuery = tx.query.user.findMany();
+export const privateQuery = tx.query.caseLawMatterLinks.findMany();
 // oxlint-disable-next-line public-case-law-db-boundary/public-case-law-db-boundary -- fixture: private table text cannot hide in a string
 export const privateSqlText = "select * from user";
 // oxlint-disable-next-line public-case-law-db-boundary/public-case-law-db-boundary -- fixture: private table text cannot hide in a template
@@ -21,4 +21,4 @@ export const privateSqlTemplate = sql`select * from matters`;
 export const publicQuery = tx.query.caseLawDecisions.findMany();
 export const publicSql = sql`select * from case_law_decisions`;
 void caseLawDecisions;
-void user;
+void caseLawMatterLinks;

--- a/.oxlint-plugins/no-facade-imports.ts
+++ b/.oxlint-plugins/no-facade-imports.ts
@@ -11,6 +11,7 @@ const ALLOWED_LEAF_IMPORTS = new Set([
   "@/api/db/auth-schema",
   "@/api/db/billing-validators",
   "@/api/db/columns",
+  "@/api/db/database-relations",
   "@/api/db/json-utils",
   "@/api/db/rls",
   "@/api/db/root",

--- a/.oxlint-plugins/public-case-law-db-boundary.ts
+++ b/.oxlint-plugins/public-case-law-db-boundary.ts
@@ -13,7 +13,13 @@ const isAstNode = (value: unknown): value is AstNode =>
   "type" in value &&
   typeof (value as { type: unknown }).type === "string";
 
-const isCaseLawName = (name: string): boolean => name.startsWith("caseLaw");
+const PUBLIC_CASE_LAW_SCHEMA_IMPORTS = new Set([
+  "caseLawCorpusIndexProjections",
+  "caseLawDecisions",
+  "caseLawSources",
+]);
+
+const PUBLIC_CASE_LAW_QUERY_RELATIONS = new Set(["caseLawDecisions"]);
 
 const isTxQueryMember = (node: unknown): boolean => {
   if (!isAstNode(node) || node.type !== "MemberExpression") {
@@ -53,9 +59,9 @@ export default eslintCompatPlugin({
         type: "problem",
         messages: {
           privateCaseLawImport:
-            "Public case-law data files may only import caseLaw* tables from '@/api/db/schema'.",
+            "Public case-law data files may only import the explicit public case-law table allowlist from '@/api/db/schema'.",
           privateTxQuery:
-            "Public case-law data files may only query tx.query.caseLaw* relations.",
+            "Public case-law data files may only use the explicit public tx.query relation allowlist.",
           privateSqlText:
             "Public case-law SQL must not mention private workspace, user, organization, matter, file, chat, task, or contact tables.",
         },
@@ -69,7 +75,10 @@ export default eslintCompatPlugin({
             const specifiers = node.specifiers;
             for (const specifier of specifiers) {
               const imported = getImportedName(specifier);
-              if (imported !== null && !isCaseLawName(imported)) {
+              if (
+                imported !== null &&
+                !PUBLIC_CASE_LAW_SCHEMA_IMPORTS.has(imported)
+              ) {
                 context.report({
                   node: specifier,
                   messageId: "privateCaseLawImport",
@@ -82,7 +91,10 @@ export default eslintCompatPlugin({
               return;
             }
             const propertyName = getPropertyName(node.property);
-            if (propertyName !== null && !isCaseLawName(propertyName)) {
+            if (
+              propertyName !== null &&
+              !PUBLIC_CASE_LAW_QUERY_RELATIONS.has(propertyName)
+            ) {
               context.report({ node, messageId: "privateTxQuery" });
             }
           },

--- a/.oxlint-plugins/public-case-law-db-boundary.ts
+++ b/.oxlint-plugins/public-case-law-db-boundary.ts
@@ -21,19 +21,21 @@ const PUBLIC_CASE_LAW_SCHEMA_IMPORTS = new Set([
 
 const PUBLIC_CASE_LAW_QUERY_RELATIONS = new Set(["caseLawDecisions"]);
 
-const isTxQueryMember = (node: unknown): boolean => {
+const getTxQueryObject = (node: unknown): AstNode | null => {
   if (!isAstNode(node) || node.type !== "MemberExpression") {
-    return false;
+    return null;
   }
   const object = node.object;
   if (!isAstNode(object) || object.type !== "MemberExpression") {
-    return false;
+    return null;
   }
-  return (
-    object.computed === false &&
-    isIdentifier(object.object, "tx") &&
-    isIdentifier(object.property, "query")
-  );
+  if (!isIdentifier(object.object, "tx")) {
+    return null;
+  }
+  if (object.computed !== false) {
+    return object;
+  }
+  return isIdentifier(object.property, "query") ? object : null;
 };
 
 const rawTemplateText = (node): string | null => {
@@ -76,7 +78,7 @@ export default eslintCompatPlugin({
             for (const specifier of specifiers) {
               const imported = getImportedName(specifier);
               if (
-                imported !== null &&
+                imported === null ||
                 !PUBLIC_CASE_LAW_SCHEMA_IMPORTS.has(imported)
               ) {
                 context.report({
@@ -87,12 +89,14 @@ export default eslintCompatPlugin({
             }
           },
           MemberExpression(node) {
-            if (!isTxQueryMember(node)) {
+            const queryObject = getTxQueryObject(node);
+            if (queryObject === null) {
               return;
             }
             const propertyName = getPropertyName(node.property);
             if (
-              propertyName !== null &&
+              queryObject.computed !== false ||
+              propertyName === null ||
               !PUBLIC_CASE_LAW_QUERY_RELATIONS.has(propertyName)
             ) {
               context.report({ node, messageId: "privateTxQuery" });

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -12,6 +12,14 @@
 # [internal] Optional. Stella ocr pdf font path.
 # STELLA_OCR_PDF_FONT_PATH=""
 
+# [secret] Optional. Local-development-only read-only Postgres URL for a
+# shared public case-law corpus. Unset uses DATABASE_URL.
+# CASE_LAW_DATABASE_URL=""
+
+# [internal] Optional with a default. Maximum connections in the optional
+# local read-only public case-law pool.
+# CASE_LAW_DATABASE_POOL_MAX="2"
+
 # [secret] Required. Valkey or Redis URL used for cross-instance broadcasts
 # and rate limits. Treated as secret because it may contain credentials.
 REDIS_URL="redis://localhost:6379"
@@ -203,8 +211,13 @@ S3_SCOPED_SIGNING_ROLE_ARN=""
 # [internal] Optional with a default. Legal search index generation.
 # LEGAL_SEARCH_INDEX_GENERATION="case_law_v1"
 
-# [internal] Conditionally required when LEGAL_SEARCH_PROVIDER is
-# corpus-index. Corpus index endpoint.
+# [internal] Conditionally required when LEGAL_SEARCH_PROVIDER is corpus-index
+# and CORPUS_INDEX_ENDPOINT is unset. Local-development-only search endpoint
+# for a shared corpus index. Unset uses CORPUS_INDEX_ENDPOINT; this endpoint
+# is never used for index mutations.
+# CORPUS_INDEX_SEARCH_ENDPOINT=""
+
+# [internal] Optional. Corpus index endpoint.
 # CORPUS_INDEX_ENDPOINT=""
 
 # [internal] Optional. Corpus index s3 bucket.

--- a/apps/api/src/db/database-relations.ts
+++ b/apps/api/src/db/database-relations.ts
@@ -1,0 +1,9 @@
+import { agentAuthRelationsPart } from "@/api/db/agent-auth-schema";
+import { authRelationsPart } from "@/api/db/auth-schema";
+import { relations } from "@/api/db/schema";
+
+export const databaseRelations = {
+  ...relations,
+  ...authRelationsPart,
+  ...agentAuthRelationsPart,
+};

--- a/apps/api/src/db/root.ts
+++ b/apps/api/src/db/root.ts
@@ -1,19 +1,11 @@
 import { SQL } from "bun";
 import { drizzle } from "drizzle-orm/bun-sql";
 
-import { agentAuthRelationsPart } from "@/api/db/agent-auth-schema";
-import { authRelationsPart } from "@/api/db/auth-schema";
-import { relations } from "@/api/db/schema";
+import { databaseRelations } from "@/api/db/database-relations";
 import { markRlsDatabase } from "@/api/db/scoped";
 import type { TransactionOf } from "@/api/db/scoped";
 import { envBase } from "@/api/env-base";
 import { queryCountLogger } from "@/api/lib/db-query-counter";
-
-const databaseRelations = {
-  ...relations,
-  ...authRelationsPart,
-  ...agentAuthRelationsPart,
-};
 
 // Per-request query counter feeds the `x-db-queries` response header for the
 // N+1 e2e guard. Local/CI only: deployed environments pass no logger at all,

--- a/apps/api/src/env-base-schema.ts
+++ b/apps/api/src/env-base-schema.ts
@@ -62,6 +62,16 @@ const databasePoolSecondsSchema = (fallback: string) =>
     fallback,
   );
 
+const postgresUrlSchema = () =>
+  v.pipe(
+    v.string(),
+    v.url(),
+    v.check((value) => {
+      const protocol = new URL(value).protocol;
+      return protocol === "postgres:" || protocol === "postgresql:";
+    }, "must use postgres:// or postgresql://."),
+  );
+
 type BoundedIntegerEnvOptions = {
   fallback: string;
   min: number;
@@ -91,7 +101,7 @@ export const envBaseServerSchema = {
   DATABASE_URL: v.pipe(v.string(), v.url()),
   DATABASE_ROOT_POOL_MAX: databasePoolMaxSchema(),
   DATABASE_RLS_POOL_MAX: databasePoolMaxSchema(),
-  CASE_LAW_DATABASE_URL: v.optional(v.pipe(v.string(), v.url())),
+  CASE_LAW_DATABASE_URL: v.optional(postgresUrlSchema()),
   CASE_LAW_DATABASE_POOL_MAX: databasePoolMaxSchema("2"),
   DATABASE_POOL_MAX_LIFETIME_S: databasePoolSecondsSchema("0"),
   DATABASE_POOL_IDLE_TIMEOUT_S: databasePoolSecondsSchema("0"),

--- a/apps/api/src/env-base-schema.ts
+++ b/apps/api/src/env-base-schema.ts
@@ -27,16 +27,17 @@ import { isTlsOrLoopbackUrl } from "@/api/lib/secure-service-url";
  */
 export const DEPLOYED_NODE_ENVS = new Set(["production", "staging"]);
 
-const databasePoolMaxSchema = v.optional(
-  v.pipe(
-    v.string(),
-    v.digits(),
-    v.transform(Number),
-    v.integer(),
-    v.minValue(1),
-  ),
-  "5",
-);
+const databasePoolMaxSchema = (fallback = "5") =>
+  v.optional(
+    v.pipe(
+      v.string(),
+      v.digits(),
+      v.transform(Number),
+      v.integer(),
+      v.minValue(1),
+    ),
+    fallback,
+  );
 
 const documentOcrBatchIntervalMinutesSchema = v.optional(
   v.pipe(
@@ -88,8 +89,10 @@ export const envBaseServerSchema = {
   SKIP_MIGRATION_CHECK: v.optional(v.pipe(v.string(), v.parseBoolean())),
   INGESTION_USER_AGENT: v.optional(v.string()),
   DATABASE_URL: v.pipe(v.string(), v.url()),
-  DATABASE_ROOT_POOL_MAX: databasePoolMaxSchema,
-  DATABASE_RLS_POOL_MAX: databasePoolMaxSchema,
+  DATABASE_ROOT_POOL_MAX: databasePoolMaxSchema(),
+  DATABASE_RLS_POOL_MAX: databasePoolMaxSchema(),
+  CASE_LAW_DATABASE_URL: v.optional(v.pipe(v.string(), v.url())),
+  CASE_LAW_DATABASE_POOL_MAX: databasePoolMaxSchema("2"),
   DATABASE_POOL_MAX_LIFETIME_S: databasePoolSecondsSchema("0"),
   DATABASE_POOL_IDLE_TIMEOUT_S: databasePoolSecondsSchema("0"),
   DOCUMENT_OCR_BATCH_INTERVAL_MINUTES: documentOcrBatchIntervalMinutesSchema,
@@ -123,6 +126,10 @@ export const envBaseServerSchema = {
   // (`<generation>_<country>`, e.g. case_law_v1_svk); bump the prefix to
   // rebuild all jurisdictions and flip to it.
   LEGAL_SEARCH_INDEX_GENERATION: v.optional(v.string(), "case_law_v1"),
+  // Local-development-only search endpoint for consuming a shared corpus.
+  // Request-path searches use it while mutations remain bound to the separate
+  // admin endpoint below, which shared-corpus mode requires to stay unset.
+  CORPUS_INDEX_SEARCH_ENDPOINT: v.optional(v.pipe(v.string(), v.url())),
   CORPUS_INDEX_ENDPOINT: v.optional(v.pipe(v.string(), v.url())),
   CORPUS_INDEX_S3_BUCKET: v.optional(v.string()),
   // Falls back to S3_BUCKET when unset (dev). Required when corpus
@@ -174,7 +181,9 @@ export const databaseComponentEnvSchema = {
 };
 
 type EnvBaseInvariantInput = {
+  CASE_LAW_DATABASE_URL?: string | undefined;
   CORPUS_INDEX_ENDPOINT?: string | undefined;
+  CORPUS_INDEX_SEARCH_ENDPOINT?: string | undefined;
   CORPUS_INDEXING_ENABLED: boolean;
   CORPUS_STORAGE_ENABLED: boolean;
   CORPUS_STORAGE_MODE?: CorpusStorageMode | undefined;
@@ -189,7 +198,9 @@ type EnvBaseInvariantInput = {
 };
 
 export const envBaseInvariantViolation = ({
+  CASE_LAW_DATABASE_URL,
   CORPUS_INDEX_ENDPOINT,
+  CORPUS_INDEX_SEARCH_ENDPOINT,
   CORPUS_INDEXING_ENABLED,
   CORPUS_STORAGE_ENABLED,
   CORPUS_STORAGE_MODE,
@@ -204,6 +215,48 @@ export const envBaseInvariantViolation = ({
 }: EnvBaseInvariantInput): string | null => {
   if (!isDev && !hasSecureDatabaseTransport(DATABASE_URL)) {
     return "DATABASE_URL must enable TLS outside loopback or Railway private networking.";
+  }
+  if (
+    CASE_LAW_DATABASE_URL !== undefined &&
+    !hasSecureDatabaseTransport(CASE_LAW_DATABASE_URL)
+  ) {
+    return "CASE_LAW_DATABASE_URL must enable TLS outside loopback or Railway private networking.";
+  }
+  if (!isDev && CASE_LAW_DATABASE_URL !== undefined) {
+    return "CASE_LAW_DATABASE_URL is only supported in local development.";
+  }
+  if (
+    CORPUS_INDEX_SEARCH_ENDPOINT !== undefined &&
+    !isTlsOrLoopbackUrl(CORPUS_INDEX_SEARCH_ENDPOINT, {
+      plaintextProtocol: "http:",
+      tlsProtocol: "https:",
+    })
+  ) {
+    return "CORPUS_INDEX_SEARCH_ENDPOINT must use HTTPS unless it targets a loopback address.";
+  }
+  if (!isDev && CORPUS_INDEX_SEARCH_ENDPOINT !== undefined) {
+    return "CORPUS_INDEX_SEARCH_ENDPOINT is only supported in local development.";
+  }
+  if (
+    CASE_LAW_DATABASE_URL !== undefined &&
+    LEGAL_SEARCH_PROVIDER !== "corpus-index"
+  ) {
+    return 'CASE_LAW_DATABASE_URL requires LEGAL_SEARCH_PROVIDER="corpus-index".';
+  }
+  if (
+    CASE_LAW_DATABASE_URL !== undefined &&
+    CORPUS_INDEX_SEARCH_ENDPOINT === undefined
+  ) {
+    return "CASE_LAW_DATABASE_URL requires CORPUS_INDEX_SEARCH_ENDPOINT.";
+  }
+  if (
+    CASE_LAW_DATABASE_URL !== undefined &&
+    CORPUS_INDEX_ENDPOINT !== undefined
+  ) {
+    return "CORPUS_INDEX_ENDPOINT must be unset when CASE_LAW_DATABASE_URL is configured.";
+  }
+  if (CASE_LAW_DATABASE_URL !== undefined && CORPUS_INDEXING_ENABLED) {
+    return "CORPUS_INDEXING_ENABLED must be false when CASE_LAW_DATABASE_URL is configured.";
   }
   if (
     !isDev &&
@@ -224,9 +277,10 @@ export const envBaseInvariantViolation = ({
   }
   if (
     LEGAL_SEARCH_PROVIDER === "corpus-index" &&
+    CORPUS_INDEX_SEARCH_ENDPOINT === undefined &&
     CORPUS_INDEX_ENDPOINT === undefined
   ) {
-    return "LEGAL_SEARCH_PROVIDER=corpus-index requires CORPUS_INDEX_ENDPOINT to be set.";
+    return "LEGAL_SEARCH_PROVIDER=corpus-index requires CORPUS_INDEX_SEARCH_ENDPOINT or CORPUS_INDEX_ENDPOINT to be set.";
   }
 
   return corpusStorageInvariantViolation({

--- a/apps/api/src/handlers/case-law/analysis/generate.ts
+++ b/apps/api/src/handlers/case-law/analysis/generate.ts
@@ -33,12 +33,14 @@ import { parseUsableDocumentAst } from "@stll/legal-ast/document-ast";
 import { rootDb } from "@/api/db/root";
 import type { ScopedDb } from "@/api/db/safe-db";
 import { caseLawDecisions } from "@/api/db/schema";
+import { envBase } from "@/api/env-base";
 import { resolveCaching, type OrgAIConfig } from "@/api/lib/ai-config";
 import { captureError } from "@/api/lib/analytics/capture";
 import { createTanStackAIAnalyticsCallbacks } from "@/api/lib/analytics/tanstack-ai";
 import { createSafeRootHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
 import type { SafeId } from "@/api/lib/branded-types";
+import { caseLawPublicReadDb } from "@/api/lib/case-law-public-read-db";
 import { formatDecisionForPrompt } from "@/api/lib/case-law/analysis-prompt";
 import { tSafeId } from "@/api/lib/custom-schema";
 import { detached } from "@/api/lib/detached";
@@ -212,20 +214,29 @@ export const generateAnalysis = async (
   promptCachingEnabled: boolean,
 ): Promise<Result<GenerateAnalysisResponse, HandlerError>> => {
   // audit: skip — background AI analysis output
-  const decision = await scopedDb((tx) =>
-    tx.query.caseLawDecisions.findFirst({
-      where: { id: { eq: decisionId } },
-      columns: {
-        id: true,
-        language: true,
-        court: true,
-        country: true,
-        decisionType: true,
-        documentAst: true,
-        analysis: true,
-      },
-    }),
-  );
+  const decisionColumns = {
+    id: true,
+    language: true,
+    court: true,
+    country: true,
+    decisionType: true,
+    documentAst: true,
+    analysis: true,
+  } as const;
+  const decision =
+    envBase.CASE_LAW_DATABASE_URL === undefined
+      ? await scopedDb((tx) =>
+          tx.query.caseLawDecisions.findFirst({
+            where: { id: { eq: decisionId } },
+            columns: decisionColumns,
+          }),
+        )
+      : await caseLawPublicReadDb((tx) =>
+          tx.query.caseLawDecisions.findFirst({
+            where: { id: { eq: decisionId } },
+            columns: decisionColumns,
+          }),
+        );
 
   if (!decision) {
     return Result.ok({ status: "error", error: "Decision not found" });
@@ -248,6 +259,16 @@ export const generateAnalysis = async (
     if (Date.now() - startedAt < SENTINEL_STALE_MS) {
       return Result.ok({ status: "generating" });
     }
+  }
+
+  // A shared corpus connection is deliberately read-only. It may serve an
+  // analysis already persisted by the owning environment, but this process
+  // must never try to create or update one in that database.
+  if (envBase.CASE_LAW_DATABASE_URL !== undefined) {
+    return Result.ok({
+      status: "error",
+      error: "Analysis is unavailable for this decision",
+    });
   }
 
   // AI availability is checked only on the path that actually invokes the

--- a/apps/api/src/handlers/case-law/decisions/get-deferred-document.ts
+++ b/apps/api/src/handlers/case-law/decisions/get-deferred-document.ts
@@ -11,6 +11,7 @@
  * `documentPending` instead; the fetch is wired in here.
  */
 
+import { envBase } from "@/api/env-base";
 import {
   isDeferredDocumentFetchable,
   readThroughDeferredDocument,
@@ -30,6 +31,14 @@ const hydrate = async (
   decision: ReadableDecision,
   recordDemand: boolean,
 ): Promise<ReadableDecision> => {
+  // The local shared-corpus mode is strictly read-side. An incomplete remote
+  // decision stays metadata-only instead of starting the ingestion path,
+  // which would otherwise crawl the publisher and write through the local
+  // ingestion database.
+  if (envBase.CASE_LAW_DATABASE_URL !== undefined) {
+    return decision;
+  }
+
   if (
     !isDeferredDocumentFetchable({
       adapterKey: decision.source.adapterKey,

--- a/apps/api/src/lib/case-law-public-read-db.test.ts
+++ b/apps/api/src/lib/case-law-public-read-db.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  assertCaseLawDatabaseRolePermissions,
+  PUBLIC_CASE_LAW_RELATIONS,
+} from "@/api/lib/case-law-public-read-db";
+
+describe("external public case-law database boundary", () => {
+  test("excludes tenant-scoped case-law relations", () => {
+    expect(PUBLIC_CASE_LAW_RELATIONS).not.toContain("case_law_matter_links");
+  });
+
+  test("accepts a case-law-only read role", () => {
+    expect(() =>
+      assertCaseLawDatabaseRolePermissions({
+        canReadCaseLaw: true,
+        canReadOtherData: false,
+        canWriteCaseLaw: false,
+      }),
+    ).not.toThrow();
+  });
+
+  test.each([
+    {
+      canReadCaseLaw: false,
+      canReadOtherData: false,
+      canWriteCaseLaw: false,
+    },
+    {
+      canReadCaseLaw: true,
+      canReadOtherData: false,
+      canWriteCaseLaw: true,
+    },
+    {
+      canReadCaseLaw: true,
+      canReadOtherData: true,
+      canWriteCaseLaw: false,
+    },
+  ])("rejects an over- or under-privileged role", (permissions) => {
+    expect(() => assertCaseLawDatabaseRolePermissions(permissions)).toThrow(
+      "CASE_LAW_DATABASE_URL must use a role that can only read the public case-law corpus",
+    );
+  });
+});

--- a/apps/api/src/lib/case-law-public-read-db.ts
+++ b/apps/api/src/lib/case-law-public-read-db.ts
@@ -10,6 +10,7 @@ import { envBase } from "@/api/env-base";
 import { queryCountLogger } from "@/api/lib/db-query-counter";
 
 const CASE_LAW_PUBLIC_READ_DB = Symbol("caseLawPublicReadDb");
+const EXTERNAL_CASE_LAW_CONNECTION_TIMEOUT_SECONDS = 10;
 
 export const PUBLIC_CASE_LAW_RELATIONS = [
   "case_law_citations",
@@ -53,13 +54,16 @@ export const assertCaseLawDatabaseRolePermissions = ({
 
 type ExternalCaseLawDatabase = {
   database: typeof rootDb;
-  roleValidation: Promise<void>;
+  roleValidation:
+    | { status: "idle" }
+    | { status: "pending"; promise: Promise<void> }
+    | { status: "validated" };
 };
 
 let externalCaseLawDatabase: ExternalCaseLawDatabase | null = null;
 
 const validateExternalCaseLawDatabase = async (
-  database: typeof rootDb,
+  database: Pick<Transaction, "execute">,
 ): Promise<void> => {
   const publicRelations = sql.join(
     PUBLIC_CASE_LAW_RELATIONS.map((name) => sql`${name}`),
@@ -112,6 +116,56 @@ const validateExternalCaseLawDatabase = async (
   assertCaseLawDatabaseRolePermissions(permissions);
 };
 
+const configureExternalReadTransaction = async (
+  tx: Transaction,
+): Promise<void> => {
+  await tx.execute(sql`SET TRANSACTION READ ONLY`);
+  await tx.execute(sql`SET LOCAL statement_timeout = '30s'`);
+  await tx.execute(sql`SET LOCAL lock_timeout = '1s'`);
+  await tx.execute(sql`SET LOCAL idle_in_transaction_session_timeout = '30s'`);
+};
+
+const startRoleValidation = async (
+  external: ExternalCaseLawDatabase,
+): Promise<void> => {
+  const promise = external.database
+    .transaction(async (tx) => {
+      await configureExternalReadTransaction(tx);
+      await validateExternalCaseLawDatabase(tx);
+    })
+    .then(
+      () => {
+        external.roleValidation = { status: "validated" };
+        return undefined;
+      },
+      (error: unknown) => {
+        external.roleValidation = { status: "idle" };
+        throw error;
+      },
+    );
+  external.roleValidation = { status: "pending", promise };
+  await promise;
+};
+
+const ensureRoleValidated = async (
+  external: ExternalCaseLawDatabase,
+): Promise<void> => {
+  switch (external.roleValidation.status) {
+    case "idle":
+      await startRoleValidation(external);
+      return;
+    case "pending":
+      await external.roleValidation.promise;
+      return;
+    case "validated":
+      return;
+    default: {
+      const unreachable: never = external.roleValidation;
+      panic("Unexpected case-law role validation state", unreachable);
+    }
+  }
+};
+
 const getCaseLawDatabase = async (): Promise<typeof rootDb> => {
   const url = envBase.CASE_LAW_DATABASE_URL;
   if (url === undefined) {
@@ -121,6 +175,7 @@ const getCaseLawDatabase = async (): Promise<typeof rootDb> => {
   if (externalCaseLawDatabase === null) {
     const client = new SQL({
       url,
+      connectionTimeout: EXTERNAL_CASE_LAW_CONNECTION_TIMEOUT_SECONDS,
       max: envBase.CASE_LAW_DATABASE_POOL_MAX,
       maxLifetime: envBase.DATABASE_POOL_MAX_LIFETIME_S,
       idleTimeout: envBase.DATABASE_POOL_IDLE_TIMEOUT_S,
@@ -132,11 +187,11 @@ const getCaseLawDatabase = async (): Promise<typeof rootDb> => {
     });
     externalCaseLawDatabase = {
       database,
-      roleValidation: validateExternalCaseLawDatabase(database),
+      roleValidation: { status: "idle" },
     };
   }
 
-  await externalCaseLawDatabase.roleValidation;
+  await ensureRoleValidated(externalCaseLawDatabase);
   return externalCaseLawDatabase.database;
 };
 
@@ -153,13 +208,10 @@ export const caseLawPublicReadDb: CaseLawPublicReadDb = Object.assign(
   ): Promise<T> => {
     const database = await getCaseLawDatabase();
     return await database.transaction(async (tx) => {
-      await tx.execute(sql`SET TRANSACTION READ ONLY`);
       if (envBase.CASE_LAW_DATABASE_URL !== undefined) {
-        await tx.execute(sql`SET LOCAL statement_timeout = '30s'`);
-        await tx.execute(sql`SET LOCAL lock_timeout = '1s'`);
-        await tx.execute(
-          sql`SET LOCAL idle_in_transaction_session_timeout = '30s'`,
-        );
+        await configureExternalReadTransaction(tx);
+      } else {
+        await tx.execute(sql`SET TRANSACTION READ ONLY`);
       }
 
       return await fn(tx);

--- a/apps/api/src/lib/case-law-public-read-db.ts
+++ b/apps/api/src/lib/case-law-public-read-db.ts
@@ -1,11 +1,24 @@
+import { panic } from "better-result";
+import { SQL } from "bun";
 import { sql } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/bun-sql";
 
+import { databaseRelations } from "@/api/db/database-relations";
 import { rootDb } from "@/api/db/root";
 import type { Transaction } from "@/api/db/root";
+import { envBase } from "@/api/env-base";
+import { queryCountLogger } from "@/api/lib/db-query-counter";
 
 const CASE_LAW_PUBLIC_READ_DB = Symbol("caseLawPublicReadDb");
 
-type CaseLawQueryKey = Extract<keyof Transaction["query"], `caseLaw${string}`>;
+export const PUBLIC_CASE_LAW_RELATIONS = [
+  "case_law_citations",
+  "case_law_corpus_index_projections",
+  "case_law_decisions",
+  "case_law_sources",
+] as const;
+
+type CaseLawQueryKey = Extract<keyof Transaction["query"], "caseLawDecisions">;
 
 export type CaseLawPublicReadTransaction = Pick<
   Transaction,
@@ -20,6 +33,113 @@ export type CaseLawPublicReadDb = (<T>(
   [CASE_LAW_PUBLIC_READ_DB]: true;
 };
 
+type CaseLawDatabaseRolePermissions = {
+  canReadCaseLaw: boolean;
+  canReadOtherData: boolean;
+  canWriteCaseLaw: boolean;
+};
+
+export const assertCaseLawDatabaseRolePermissions = ({
+  canReadCaseLaw,
+  canReadOtherData,
+  canWriteCaseLaw,
+}: CaseLawDatabaseRolePermissions): void => {
+  if (!canReadCaseLaw || canWriteCaseLaw || canReadOtherData) {
+    panic(
+      "CASE_LAW_DATABASE_URL must use a role that can only read the public case-law corpus",
+    );
+  }
+};
+
+type ExternalCaseLawDatabase = {
+  database: typeof rootDb;
+  roleValidation: Promise<void>;
+};
+
+let externalCaseLawDatabase: ExternalCaseLawDatabase | null = null;
+
+const validateExternalCaseLawDatabase = async (
+  database: typeof rootDb,
+): Promise<void> => {
+  const publicRelations = sql.join(
+    PUBLIC_CASE_LAW_RELATIONS.map((name) => sql`${name}`),
+    sql.raw(","),
+  );
+  const [permissions] = await database.execute<CaseLawDatabaseRolePermissions>(
+    sql`
+      SELECT
+        (
+          SELECT count(*) = ${PUBLIC_CASE_LAW_RELATIONS.length}
+            AND bool_and(
+              has_table_privilege(current_user, tables.oid, 'SELECT')
+            )
+          FROM pg_class AS tables
+          INNER JOIN pg_namespace AS schemas
+            ON schemas.oid = tables.relnamespace
+          WHERE schemas.nspname = 'public'
+            AND tables.relkind IN ('r', 'p', 'v', 'm', 'f')
+            AND tables.relname IN (${publicRelations})
+        ) AS "canReadCaseLaw",
+        EXISTS (
+          SELECT 1
+          FROM pg_class AS tables
+          INNER JOIN pg_namespace AS schemas
+            ON schemas.oid = tables.relnamespace
+          WHERE schemas.nspname = 'public'
+            AND tables.relkind IN ('r', 'p', 'v', 'm', 'f')
+            AND tables.relname NOT IN (${publicRelations})
+            AND has_table_privilege(current_user, tables.oid, 'SELECT')
+        ) AS "canReadOtherData",
+        EXISTS (
+          SELECT 1
+          FROM pg_class AS tables
+          INNER JOIN pg_namespace AS schemas
+            ON schemas.oid = tables.relnamespace
+          WHERE schemas.nspname = 'public'
+            AND tables.relkind IN ('r', 'p', 'v', 'm', 'f')
+            AND has_table_privilege(
+              current_user,
+              tables.oid,
+              'INSERT,UPDATE,DELETE,TRUNCATE,REFERENCES,TRIGGER'
+            )
+        ) AS "canWriteCaseLaw"
+    `,
+  );
+
+  if (permissions === undefined) {
+    panic("CASE_LAW_DATABASE_URL role validation returned no result");
+  }
+  assertCaseLawDatabaseRolePermissions(permissions);
+};
+
+const getCaseLawDatabase = async (): Promise<typeof rootDb> => {
+  const url = envBase.CASE_LAW_DATABASE_URL;
+  if (url === undefined) {
+    return rootDb;
+  }
+
+  if (externalCaseLawDatabase === null) {
+    const client = new SQL({
+      url,
+      max: envBase.CASE_LAW_DATABASE_POOL_MAX,
+      maxLifetime: envBase.DATABASE_POOL_MAX_LIFETIME_S,
+      idleTimeout: envBase.DATABASE_POOL_IDLE_TIMEOUT_S,
+    });
+    const database = drizzle({
+      client,
+      relations: databaseRelations,
+      logger: envBase.isDev ? queryCountLogger : undefined,
+    });
+    externalCaseLawDatabase = {
+      database,
+      roleValidation: validateExternalCaseLawDatabase(database),
+    };
+  }
+
+  await externalCaseLawDatabase.roleValidation;
+  return externalCaseLawDatabase.database;
+};
+
 /**
  * Read-only access boundary for public case-law data.
  *
@@ -28,11 +148,22 @@ export type CaseLawPublicReadDb = (<T>(
  * accidentally depending on authenticated route macros.
  */
 export const caseLawPublicReadDb: CaseLawPublicReadDb = Object.assign(
-  async <T>(fn: (tx: CaseLawPublicReadTransaction) => Promise<T>): Promise<T> =>
-    await rootDb.transaction(async (tx) => {
+  async <T>(
+    fn: (tx: CaseLawPublicReadTransaction) => Promise<T>,
+  ): Promise<T> => {
+    const database = await getCaseLawDatabase();
+    return await database.transaction(async (tx) => {
       await tx.execute(sql`SET TRANSACTION READ ONLY`);
+      if (envBase.CASE_LAW_DATABASE_URL !== undefined) {
+        await tx.execute(sql`SET LOCAL statement_timeout = '30s'`);
+        await tx.execute(sql`SET LOCAL lock_timeout = '1s'`);
+        await tx.execute(
+          sql`SET LOCAL idle_in_transaction_session_timeout = '30s'`,
+        );
+      }
 
       return await fn(tx);
-    }),
+    });
+  },
   { [CASE_LAW_PUBLIC_READ_DB]: true as const },
 );

--- a/apps/api/src/lib/legal-search/corpus-index-client.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-client.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, expect, test } from "bun:test";
 
+import { envBase } from "@/api/env-base";
 import { getCorpusIndexClient } from "@/api/lib/legal-search/corpus-index-client";
 import { readCorpusIndexSearchPage } from "@/api/lib/legal-search/corpus-index-pagination";
 
@@ -15,6 +16,8 @@ type RecordedRequest = { host: string; path: string; body: string };
 let requests: RecordedRequest[];
 let responseBody: unknown;
 const originalFetch = globalThis.fetch;
+const originalCorpusIndexEndpoint = envBase.CORPUS_INDEX_ENDPOINT;
+const originalCorpusIndexSearchEndpoint = envBase.CORPUS_INDEX_SEARCH_ENDPOINT;
 
 beforeEach(() => {
   requests = [];
@@ -47,6 +50,10 @@ beforeEach(() => {
 
 afterEach(() => {
   globalThis.fetch = originalFetch;
+  Object.assign(envBase, {
+    CORPUS_INDEX_ENDPOINT: originalCorpusIndexEndpoint,
+    CORPUS_INDEX_SEARCH_ENDPOINT: originalCorpusIndexSearchEndpoint,
+  });
 });
 
 test("search sends the documented sort_by parameter", async () => {
@@ -68,6 +75,23 @@ test("search sends the documented sort_by parameter", async () => {
   // The engine ignores unknown keys, so the old misnamed parameter would
   // silently fall back to document-id order.
   expect(body).not.toHaveProperty("sort_by_field");
+});
+
+test("search falls back to the shared corpus index endpoint", async () => {
+  responseBody = { num_hits: 0, hits: [], snippets: [] };
+  Object.assign(envBase, {
+    CORPUS_INDEX_ENDPOINT: "http://localhost:7290",
+    CORPUS_INDEX_SEARCH_ENDPOINT: undefined,
+  });
+
+  const result = await getCorpusIndexClient().search({
+    indexId: "legal_corpus_v1_cze",
+    query: "text:smlouva",
+    maxHits: 10,
+  });
+
+  expect(result.isOk()).toBe(true);
+  expect(requests.at(0)?.host).toBe("localhost:7290");
 });
 
 test("search rejects a malformed external response", async () => {

--- a/apps/api/src/lib/legal-search/corpus-index-client.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-client.test.ts
@@ -10,7 +10,7 @@ import { readCorpusIndexSearchPage } from "@/api/lib/legal-search/corpus-index-p
 // id-order results. These tests stub global fetch and assert on the
 // outgoing request, not on engine behaviour.
 
-type RecordedRequest = { path: string; body: string };
+type RecordedRequest = { host: string; path: string; body: string };
 
 let requests: RecordedRequest[];
 let responseBody: unknown;
@@ -32,8 +32,10 @@ beforeEach(() => {
     input: Parameters<typeof fetch>[0],
     init?: Parameters<typeof fetch>[1],
   ): Promise<Response> => {
+    const url = new URL(resolveUrl(input));
     requests.push({
-      path: new URL(resolveUrl(input)).pathname,
+      host: url.host,
+      path: url.pathname,
       body: typeof init?.body === "string" ? init.body : "",
     });
     return new Response(JSON.stringify(responseBody), { status: 200 });
@@ -59,6 +61,7 @@ test("search sends the documented sort_by parameter", async () => {
 
   expect(result.isOk()).toBe(true);
   const request = requests.at(0);
+  expect(request?.host).toBe("localhost:7281");
   expect(request?.path).toBe("/api/v1/legal_corpus_v1_cze/search");
   const body: Record<string, unknown> = JSON.parse(request?.body ?? "{}");
   expect(body["sort_by"]).toBe("_score");
@@ -174,6 +177,7 @@ test("delete-by-query posts one document-scoped delete task", async () => {
   // indexer never has to know how many documents a row previously emitted.
   expect(requests).toHaveLength(1);
   const request = requests.at(0);
+  expect(request?.host).toBe("localhost:7280");
   expect(request?.path).toBe("/api/v1/legal_corpus_v1_cze/delete-tasks");
   const body: Record<string, unknown> = JSON.parse(request?.body ?? "{}");
   expect(body["query"]).toBe('document_id:"dec-1"');

--- a/apps/api/src/lib/legal-search/corpus-index-client.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-client.ts
@@ -63,11 +63,20 @@ export type CorpusIndexClient = {
   ) => Promise<Result<void, CorpusIndexError>>;
 };
 
-const baseUrl = (): string => {
+const mutationBaseUrl = (): string => {
   const value = envBase.CORPUS_INDEX_ENDPOINT;
   if (value === undefined || value.length === 0) {
+    panic("CORPUS_INDEX_ENDPOINT is required for corpus index mutations");
+  }
+  return value.replace(/(?<!\/)\/+$/u, "");
+};
+
+const searchBaseUrl = (): string => {
+  const value =
+    envBase.CORPUS_INDEX_SEARCH_ENDPOINT ?? envBase.CORPUS_INDEX_ENDPOINT;
+  if (value === undefined || value.length === 0) {
     panic(
-      "CORPUS_INDEX_ENDPOINT is required when the corpus index search provider is selected",
+      "CORPUS_INDEX_SEARCH_ENDPOINT or CORPUS_INDEX_ENDPOINT is required when the corpus index search provider is selected",
     );
   }
   return value.replace(/(?<!\/)\/+$/u, "");
@@ -85,11 +94,12 @@ const toCorpusIndexError = (error: unknown): CorpusIndexError =>
       });
 
 const requestJson = async (
+  baseUrl: string,
   path: string,
   init: Omit<RequestInit, "signal">,
   timeoutMs: number,
 ): Promise<unknown> => {
-  const response = await fetchWithTimeout(`${baseUrl()}${path}`, {
+  const response = await fetchWithTimeout(`${baseUrl}${path}`, {
     ...init,
     timeoutMs,
   });
@@ -123,6 +133,7 @@ const buildClient = (): CorpusIndexClient => ({
     await Result.tryPromise({
       try: async () => {
         await requestJson(
+          mutationBaseUrl(),
           "/api/v1/indexes",
           {
             method: "POST",
@@ -139,6 +150,7 @@ const buildClient = (): CorpusIndexClient => ({
     await Result.tryPromise({
       try: async () => {
         await requestJson(
+          mutationBaseUrl(),
           `/api/v1/indexes/${indexId}`,
           { method: "DELETE" },
           ADMIN_TIMEOUT_MS,
@@ -151,7 +163,7 @@ const buildClient = (): CorpusIndexClient => ({
     await Result.tryPromise({
       try: async () => {
         const response = await fetchWithTimeout(
-          `${baseUrl()}/api/v1/indexes/${indexId}`,
+          `${mutationBaseUrl()}/api/v1/indexes/${indexId}`,
           {
             method: "GET",
             timeoutMs: ADMIN_TIMEOUT_MS,
@@ -178,6 +190,7 @@ const buildClient = (): CorpusIndexClient => ({
           .split("\n")
           .filter((line) => line.trim().length > 0).length;
         const response = await requestJson(
+          mutationBaseUrl(),
           `/api/v1/${indexId}/ingest?commit=auto`,
           {
             method: "POST",
@@ -242,6 +255,7 @@ const buildClient = (): CorpusIndexClient => ({
           body["snippet_fields"] = snippetFields.join(",");
         }
         const response = await requestJson(
+          searchBaseUrl(),
           `/api/v1/${indexId}/search`,
           {
             method: "POST",
@@ -282,6 +296,7 @@ const buildClient = (): CorpusIndexClient => ({
     await Result.tryPromise({
       try: async () => {
         await requestJson(
+          mutationBaseUrl(),
           `/api/v1/${indexId}/delete-tasks`,
           {
             method: "POST",

--- a/apps/api/src/lib/legal-search/corpus-index-provider.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-provider.ts
@@ -1,6 +1,5 @@
 import { and, eq, inArray, sql } from "drizzle-orm";
 
-import { rootDb } from "@/api/db/root";
 import {
   caseLawCorpusIndexProjections,
   caseLawDecisions,
@@ -8,6 +7,7 @@ import {
 } from "@/api/db/schema";
 // eslint-disable-next-line no-restricted-imports -- search boundary: brands document ids returned by the corpus index before re-hydrating from Postgres
 import { toSafeId } from "@/api/lib/branded-types";
+import { caseLawPublicReadDb } from "@/api/lib/case-law-public-read-db";
 import { redistributableCaseLawSource } from "@/api/lib/case-law/redistribution";
 import { isUuid } from "@/api/lib/custom-schema";
 import {
@@ -106,11 +106,13 @@ const search = async (query: LegalSearchQuery): Promise<LegalSearchResult> => {
 
   // Upper bound for the pagination early-stop: scanning may end only
   // once no unseen candidate could out-blend the page cursor.
-  const [authorityBound] = await rootDb
-    .select({
-      max: sql<number>`coalesce(max(${caseLawDecisions.citationAuthority}), 0)`,
-    })
-    .from(caseLawDecisions);
+  const [authorityBound] = await caseLawPublicReadDb((tx) =>
+    tx
+      .select({
+        max: sql<number>`coalesce(max(${caseLawDecisions.citationAuthority}), 0)`,
+      })
+      .from(caseLawDecisions),
+  );
   const maxAuthority = authorityBound?.max ?? 0;
 
   const searchPage = await readCorpusIndexSearchPage({
@@ -133,39 +135,41 @@ const search = async (query: LegalSearchQuery): Promise<LegalSearchResult> => {
       const rows =
         ids.length === 0
           ? []
-          : await rootDb
-              .select({
-                id: caseLawDecisions.id,
-                caseNumber: caseLawDecisions.caseNumber,
-                ecli: caseLawDecisions.ecli,
-                court: caseLawDecisions.court,
-                country: caseLawDecisions.country,
-                language: caseLawDecisions.language,
-                decisionDate: caseLawDecisions.decisionDate,
-                decisionType: caseLawDecisions.decisionType,
-                sourceUrl: caseLawDecisions.sourceUrl,
-                citationCount: caseLawDecisions.citationCount,
-                citationAuthority: caseLawDecisions.citationAuthority,
-                createdAt: caseLawDecisions.createdAt,
-              })
-              .from(caseLawDecisions)
-              .leftJoin(
-                caseLawCorpusIndexProjections,
-                caseLawCorpusProjectionJoin(generation),
-              )
-              .innerJoin(
-                caseLawSources,
-                eq(caseLawSources.id, caseLawDecisions.sourceId),
-              )
-              // Same gates as the public search rehydration: source
-              // policy, and only rows whose index state is current.
-              .where(
-                and(
-                  inArray(caseLawDecisions.id, ids),
-                  redistributableCaseLawSource,
-                  currentCaseLawCorpusProjection(generation),
+          : await caseLawPublicReadDb((tx) =>
+              tx
+                .select({
+                  id: caseLawDecisions.id,
+                  caseNumber: caseLawDecisions.caseNumber,
+                  ecli: caseLawDecisions.ecli,
+                  court: caseLawDecisions.court,
+                  country: caseLawDecisions.country,
+                  language: caseLawDecisions.language,
+                  decisionDate: caseLawDecisions.decisionDate,
+                  decisionType: caseLawDecisions.decisionType,
+                  sourceUrl: caseLawDecisions.sourceUrl,
+                  citationCount: caseLawDecisions.citationCount,
+                  citationAuthority: caseLawDecisions.citationAuthority,
+                  createdAt: caseLawDecisions.createdAt,
+                })
+                .from(caseLawDecisions)
+                .leftJoin(
+                  caseLawCorpusIndexProjections,
+                  caseLawCorpusProjectionJoin(generation),
+                )
+                .innerJoin(
+                  caseLawSources,
+                  eq(caseLawSources.id, caseLawDecisions.sourceId),
+                )
+                // Same gates as the public search rehydration: source
+                // policy, and only rows whose index state is current.
+                .where(
+                  and(
+                    inArray(caseLawDecisions.id, ids),
+                    redistributableCaseLawSource,
+                    currentCaseLawCorpusProjection(generation),
+                  ),
                 ),
-              );
+            );
 
       // Keyed by plain string id (candidate ids from corpus index are strings).
       const displayById = new Map(rows.map((row) => [String(row.id), row]));

--- a/apps/api/src/lib/legal-search/document-context.ts
+++ b/apps/api/src/lib/legal-search/document-context.ts
@@ -1,6 +1,6 @@
-import { rootDb } from "@/api/db/root";
 import { corpusStorageMode } from "@/api/env-base";
 import type { SafeId } from "@/api/lib/branded-types";
+import { caseLawPublicReadDb } from "@/api/lib/case-law-public-read-db";
 import {
   readCorpusAst,
   readCorpusPayloadOrFallback,
@@ -12,24 +12,27 @@ import type { LegalDocumentContext } from "@/api/lib/legal-search/types";
  * Canonical text + AST for a decision, for the AI reader. Prefers object
  * storage when enabled, degrading to the Postgres columns on a transient
  * S3 failure so a read is never harder than today. A row with no Postgres
- * copy has nothing to degrade to and surfaces the failure instead. Global
- * corpus data, so it reads via rootDb.
+ * copy has nothing to degrade to and surfaces the failure instead. The
+ * public-corpus read boundary may resolve to a separately credentialed,
+ * read-only database.
  */
 export const loadDocumentContext = async (
   decisionId: SafeId<"caseLawDecision">,
 ): Promise<LegalDocumentContext | null> => {
-  const decision = await rootDb.query.caseLawDecisions.findFirst({
-    where: { id: { eq: decisionId } },
-    columns: {
-      id: true,
-      caseNumber: true,
-      court: true,
-      documentAst: true,
-      fulltext: true,
-      astS3Key: true,
-      textS3Key: true,
-    },
-  });
+  const decision = await caseLawPublicReadDb((tx) =>
+    tx.query.caseLawDecisions.findFirst({
+      where: { id: { eq: decisionId } },
+      columns: {
+        id: true,
+        caseNumber: true,
+        court: true,
+        documentAst: true,
+        fulltext: true,
+        astS3Key: true,
+        textS3Key: true,
+      },
+    }),
+  );
 
   if (!decision) {
     return null;

--- a/apps/api/src/lib/observability/request-context.ts
+++ b/apps/api/src/lib/observability/request-context.ts
@@ -139,4 +139,5 @@ export const getCurrentRequestId = (): string | undefined =>
 export const runWithRequestId = <TResult>(
   requestId: string,
   fn: () => TResult,
-): TResult => requestIdStore.run({ current: requestId, isAiRequest: false }, fn);
+): TResult =>
+  requestIdStore.run({ current: requestId, isAiRequest: false }, fn);

--- a/apps/api/src/tests/security/case-law-public-route-invariants.test.ts
+++ b/apps/api/src/tests/security/case-law-public-route-invariants.test.ts
@@ -18,6 +18,8 @@ void scopedDbIsPublicReadDb;
 const ROUTES_FILE = "apps/api/src/handlers/case-law/public-routes.ts";
 const LIST_DECISIONS_FILE = "apps/api/src/handlers/case-law/decisions/list.ts";
 const READ_DECISION_FILE = "apps/api/src/handlers/case-law/decisions/get.ts";
+const DEFERRED_DOCUMENT_FILE =
+  "apps/api/src/handlers/case-law/decisions/get-deferred-document.ts";
 const FACETS_DECISIONS_FILE =
   "apps/api/src/handlers/case-law/decisions/facets.ts";
 const SEARCH_DECISIONS_FILE =
@@ -37,6 +39,8 @@ const readSource = async (path: string) =>
 const readRoutesSource = async () => await readSource(ROUTES_FILE);
 const readListSource = async () => await readSource(LIST_DECISIONS_FILE);
 const readDecisionSource = async () => await readSource(READ_DECISION_FILE);
+const readDeferredDocumentSource = async () =>
+  await readSource(DEFERRED_DOCUMENT_FILE);
 const readFacetsSource = async () => await readSource(FACETS_DECISIONS_FILE);
 const readSearchSource = async () => await readSource(SEARCH_DECISIONS_FILE);
 const readSearchSchemaSource = async () =>
@@ -89,18 +93,31 @@ describe("public case-law route boundary", () => {
     expect(source).toContain("SET TRANSACTION READ ONLY");
   });
 
+  test("shared-corpus reads cannot start document ingestion", async () => {
+    const source = await readDeferredDocumentSource();
+    const guard = source.indexOf("envBase.CASE_LAW_DATABASE_URL !== undefined");
+    const ingestionCall = source.indexOf("readThroughDeferredDocument({");
+
+    expect(guard).toBeGreaterThanOrEqual(0);
+    expect(ingestionCall).toBeGreaterThan(guard);
+  });
+
   test("public read transaction only exposes case-law relational queries", () => {
     type PublicQueryKeys = keyof CaseLawPublicReadTransaction["query"];
-    type PublicQueryKeysAreCaseLawOnly =
-      PublicQueryKeys extends `caseLaw${string}` ? true : false;
+    type PublicQueryKeysAreDecisionOnly =
+      PublicQueryKeys extends "caseLawDecisions" ? true : false;
     type PublicTxCanQueryCaseLawDecisions =
       "caseLawDecisions" extends PublicQueryKeys ? true : false;
+    type PublicTxCanQueryMatterLinks =
+      "caseLawMatterLinks" extends PublicQueryKeys ? true : false;
 
-    const publicQueryKeysAreCaseLawOnly: PublicQueryKeysAreCaseLawOnly = true;
+    const publicQueryKeysAreDecisionOnly: PublicQueryKeysAreDecisionOnly = true;
     const publicTxCanQueryCaseLawDecisions: PublicTxCanQueryCaseLawDecisions = true;
+    const publicTxCanQueryMatterLinks: PublicTxCanQueryMatterLinks = false;
 
-    expect(publicQueryKeysAreCaseLawOnly).toBe(true);
+    expect(publicQueryKeysAreDecisionOnly).toBe(true);
     expect(publicTxCanQueryCaseLawDecisions).toBe(true);
+    expect(publicTxCanQueryMatterLinks).toBe(false);
   });
 
   test("public read routes are not protected by auth middleware", async () => {

--- a/apps/api/src/tests/security/case-law-public-route-invariants.test.ts
+++ b/apps/api/src/tests/security/case-law-public-route-invariants.test.ts
@@ -93,6 +93,25 @@ describe("public case-law route boundary", () => {
     expect(source).toContain("SET TRANSACTION READ ONLY");
   });
 
+  test("external role validation is bounded and retries after failure", async () => {
+    const source = await readPublicReadDbSource();
+    const validation = source.slice(
+      source.indexOf("const startRoleValidation"),
+      source.indexOf("const ensureRoleValidated"),
+    );
+
+    expect(source).toContain(
+      "connectionTimeout: EXTERNAL_CASE_LAW_CONNECTION_TIMEOUT_SECONDS",
+    );
+    expect(validation).toContain(".transaction(async (tx) =>");
+    expect(
+      validation.indexOf("configureExternalReadTransaction(tx)"),
+    ).toBeLessThan(validation.indexOf("validateExternalCaseLawDatabase(tx)"));
+    expect(validation).toContain(
+      'external.roleValidation = { status: "idle" }',
+    );
+  });
+
   test("shared-corpus reads cannot start document ingestion", async () => {
     const source = await readDeferredDocumentSource();
     const guard = source.indexOf("envBase.CASE_LAW_DATABASE_URL !== undefined");

--- a/apps/api/src/tests/security/oxlint-guardrails.test.ts
+++ b/apps/api/src/tests/security/oxlint-guardrails.test.ts
@@ -180,7 +180,8 @@ describe("custom oxlint guardrails", () => {
     expect(pluginSource).toContain("privateCaseLawImport");
     expect(pluginSource).toContain("privateTxQuery");
     expect(pluginSource).toContain("privateSqlText");
-    expect(pluginSource).toContain("isCaseLawName");
+    expect(pluginSource).toContain("PUBLIC_CASE_LAW_SCHEMA_IMPORTS");
+    expect(pluginSource).toContain("PUBLIC_CASE_LAW_QUERY_RELATIONS");
     expect(pluginSource).toContain("tx.query");
     expect(pluginSource).toContain("workspace|workspaces");
     expect(pluginSource).toContain("organization|organizations");

--- a/apps/api/src/tests/setup-env.ts
+++ b/apps/api/src/tests/setup-env.ts
@@ -47,6 +47,7 @@ process.env["FRONTEND_URL"] ??= "http://localhost:3000";
 // Never reached by tests: corpus-index tests stub global fetch and only
 // assert on the request contract.
 process.env["CORPUS_INDEX_ENDPOINT"] ??= "http://localhost:7280";
+process.env["CORPUS_INDEX_SEARCH_ENDPOINT"] ??= "http://localhost:7281";
 process.env["GOTENBERG_URL"] ??= "http://localhost:3002";
 process.env["GOTENBERG_USERNAME"] ??= "test";
 process.env["GOTENBERG_PASSWORD"] ??= "test";

--- a/apps/web/e2e/marketing/product-screenshots.spec.ts
+++ b/apps/web/e2e/marketing/product-screenshots.spec.ts
@@ -200,10 +200,9 @@ test("capture landing product screenshots", async ({
         await expect(page.locator("article").first()).toBeVisible({
           timeout: COLD_COMPILE_TIMEOUT,
         });
-        // The reader briefly renders a logged-out "locked" AI button while
-        // the client-side session query settles (useClientAuthStatus), then
-        // swaps in the authenticated workspace. Wait for that swap so the
-        // click below hits the real analyze button, not the sign-in prompt.
+        // The reader briefly renders the logged-out workspace while the
+        // client-side session query settles, then swaps in the authenticated
+        // workspace. Wait for that swap before checking its generated outline.
         // eslint-disable-next-line no-await-in-loop -- see above
         await page.waitForLoadState("networkidle");
         // The authenticated inspector is mounted beside this public route.
@@ -211,18 +210,8 @@ test("capture landing product screenshots", async ({
         // later on whichever product control the error screen replaced.
         // eslint-disable-next-line no-await-in-loop -- see above
         await expect(page.locator("#route-error-title")).toHaveCount(0);
-        // The structure/AI margin is generated on demand. These decisions
-        // already have their analysis cached server-side, but the client
-        // still needs one round trip to fetch it; trigger it explicitly and
-        // wait for the outline rail so the capture never lands on the
-        // empty/loading margin state.
-        const analyzeButton = page.getByRole("button", {
-          name: "Analyze with AI",
-        });
-        // eslint-disable-next-line no-await-in-loop -- see above
-        await expect(analyzeButton).toBeVisible();
-        // eslint-disable-next-line no-await-in-loop -- see above
-        await analyzeButton.click();
+        // These decisions have analysis cached server-side. Wait for the
+        // automatic fetch so the capture never lands on the loading margin.
         // eslint-disable-next-line no-await-in-loop -- see above
         await expect(
           page.getByRole("group", { name: "Outline" }),

--- a/apps/web/e2e/staging/staging-smoke.spec.ts
+++ b/apps/web/e2e/staging/staging-smoke.spec.ts
@@ -97,6 +97,9 @@ test("server-rendered public law decisions stay stable after hydration", async (
   await page.reload({ waitUntil: "commit" });
 
   await expect(page.locator("article").first()).toBeVisible();
+  await expect(
+    page.getByRole("heading", { includeHidden: true, level: 1 }),
+  ).toHaveCount(1);
   const routeErrorTitle = page.locator("#route-error-title");
   const inspector = page.locator('[data-side="right"]');
   await expect(routeErrorTitle).toHaveCount(0);

--- a/apps/web/e2e/staging/staging-smoke.spec.ts
+++ b/apps/web/e2e/staging/staging-smoke.spec.ts
@@ -96,16 +96,14 @@ test("server-rendered public law decisions stay stable after hydration", async (
   // navigation alone would never exercise the hydration path that broke.
   await page.reload({ waitUntil: "commit" });
 
-  // Case numbers look like "6 Tdo 647/2017"; anchoring on the slash-year
-  // tail keeps the regex linear.
-  await expect(page.getByRole("heading", { name: /\/\d{4}/u })).toBeVisible();
+  await expect(page.locator("article").first()).toBeVisible();
   const routeErrorTitle = page.locator("#route-error-title");
   const inspector = page.locator('[data-side="right"]');
   await expect(routeErrorTitle).toHaveCount(0);
   await expect(inspector).toHaveAttribute("data-state", "expanded");
 
   // Authentication resolution and the lazy inspector graph settle after the
-  // decision heading appears. Keep observing long enough to catch a delayed
+  // decision body appears. Keep observing long enough to catch a delayed
   // remount, stale-chunk retry, or cross-tab store reconciliation.
   await page.waitForTimeout(5000);
   await expect(routeErrorTitle).toHaveCount(0);

--- a/apps/web/src/features/case-law/components/case-viewer/decision-workspace.tsx
+++ b/apps/web/src/features/case-law/components/case-viewer/decision-workspace.tsx
@@ -5,6 +5,7 @@ import { useTranslations } from "use-intl";
 import { useShallow } from "zustand/react/shallow";
 
 import { parseDocumentAst } from "@stll/legal-ast/document-ast";
+import { BidiText } from "@stll/ui/components/bidi-text";
 import { Button } from "@stll/ui/components/button";
 import { OutlineRail } from "@stll/ui/components/outline-rail";
 import type { OutlineItem } from "@stll/ui/components/outline-rail";
@@ -206,6 +207,9 @@ export const DecisionWorkspace = (props: DecisionWorkspaceProps) => {
 
   return (
     <div className="flex h-full flex-col overflow-hidden">
+      <h1 className="sr-only">
+        <BidiText as="span">{decision.caseNumber}</BidiText>
+      </h1>
       <div className="relative min-h-0 flex-1">
         {hasAnalysis && analysisTree.length > 0 && (
           <OutlineRail

--- a/apps/web/src/features/case-law/components/case-viewer/decision-workspace.tsx
+++ b/apps/web/src/features/case-law/components/case-viewer/decision-workspace.tsx
@@ -5,7 +5,6 @@ import { useTranslations } from "use-intl";
 import { useShallow } from "zustand/react/shallow";
 
 import { parseDocumentAst } from "@stll/legal-ast/document-ast";
-import { BidiText } from "@stll/ui/components/bidi-text";
 import { Button } from "@stll/ui/components/button";
 import { OutlineRail } from "@stll/ui/components/outline-rail";
 import type { OutlineItem } from "@stll/ui/components/outline-rail";
@@ -42,8 +41,6 @@ type DecisionWorkspaceBaseProps = {
 
 type LockedDecisionWorkspaceProps = DecisionWorkspaceBaseProps & {
   aiMode: "locked";
-  publicPath: string;
-  requestAuth: (redirectTo: string) => void;
 };
 
 type EnabledDecisionWorkspaceProps = DecisionWorkspaceBaseProps & {
@@ -69,8 +66,6 @@ export const DecisionWorkspace = (props: DecisionWorkspaceProps) => {
   const aiEnabled = props.aiMode === "enabled";
   const ensureAIAvailable =
     props.aiMode === "enabled" ? props.ensureAIAvailable : null;
-  const publicPath = props.aiMode === "locked" ? props.publicPath : undefined;
-  const requestAuth = props.aiMode === "locked" ? props.requestAuth : undefined;
   const ast = parseDocumentAst(decision.documentAst);
 
   const mainRef = useRef<HTMLDivElement>(null);
@@ -211,34 +206,6 @@ export const DecisionWorkspace = (props: DecisionWorkspaceProps) => {
 
   return (
     <div className="flex h-full flex-col overflow-hidden">
-      <header className="flex items-start justify-between gap-4 border-b px-6 py-4">
-        <div>
-          <p className="text-muted-foreground text-xs">{decision.court}</p>
-          <h1 className="text-xl font-semibold">
-            <BidiText>{decision.caseNumber}</BidiText>
-          </h1>
-        </div>
-        {aiEnabled ? (
-          <Button
-            onClick={() => {
-              detached(generate(), "decision-workspace.generate");
-            }}
-            size="sm"
-            variant="outline"
-          >
-            <SparklesIcon className="size-4" />
-            {t("ai.analyzeWithAI")}
-          </Button>
-        ) : (
-          <Button
-            onClick={() => requestAuth?.(publicPath ?? "/law/cases")}
-            size="sm"
-          >
-            <SparklesIcon className="size-4" />
-            {t("ai.analyzeWithAI")}
-          </Button>
-        )}
-      </header>
       <div className="relative min-h-0 flex-1">
         {hasAnalysis && analysisTree.length > 0 && (
           <OutlineRail

--- a/apps/web/src/i18n/langs/ar.json
+++ b/apps/web/src/i18n/langs/ar.json
@@ -28,7 +28,6 @@
     "title": "اربط وكيلك"
   },
   "ai": {
-    "analyzeWithAI": "التحليل باستخدام AI",
     "chooseRewriteInstruction": "خيارات إعادة الصياغة",
     "editWithAI": "التعديل باستخدام AI",
     "keyRequired": {

--- a/apps/web/src/i18n/langs/cs.json
+++ b/apps/web/src/i18n/langs/cs.json
@@ -28,7 +28,6 @@
     "title": "Připojte svého agenta"
   },
   "ai": {
-    "analyzeWithAI": "Analyzovat pomocí AI",
     "chooseRewriteInstruction": "Možnosti úpravy",
     "editWithAI": "Upravit pomocí AI",
     "keyRequired": {

--- a/apps/web/src/i18n/langs/de.json
+++ b/apps/web/src/i18n/langs/de.json
@@ -28,7 +28,6 @@
     "title": "Verbinden Sie Ihren Agenten"
   },
   "ai": {
-    "analyzeWithAI": "Mit KI analysieren",
     "chooseRewriteInstruction": "Optionen zur Überarbeitung",
     "editWithAI": "Mit KI bearbeiten",
     "keyRequired": {

--- a/apps/web/src/i18n/langs/en.json
+++ b/apps/web/src/i18n/langs/en.json
@@ -28,7 +28,6 @@
     "title": "Connect your agent"
   },
   "ai": {
-    "analyzeWithAI": "Analyze with AI",
     "chooseRewriteInstruction": "Rewrite options",
     "editWithAI": "Edit with AI",
     "keyRequired": {

--- a/apps/web/src/i18n/langs/es.json
+++ b/apps/web/src/i18n/langs/es.json
@@ -28,7 +28,6 @@
     "title": "Conecta tu agente"
   },
   "ai": {
-    "analyzeWithAI": "Analizar con IA",
     "chooseRewriteInstruction": "Opciones de reescritura",
     "editWithAI": "Editar con IA",
     "keyRequired": {

--- a/apps/web/src/i18n/langs/et.json
+++ b/apps/web/src/i18n/langs/et.json
@@ -28,7 +28,6 @@
     "title": "Ühenda oma agent"
   },
   "ai": {
-    "analyzeWithAI": "Analüüsi AI-ga",
     "chooseRewriteInstruction": "Ümberkirjutamise valikud",
     "editWithAI": "Muuda AI-ga",
     "keyRequired": {

--- a/apps/web/src/i18n/langs/fr.json
+++ b/apps/web/src/i18n/langs/fr.json
@@ -28,7 +28,6 @@
     "title": "Connectez votre agent"
   },
   "ai": {
-    "analyzeWithAI": "Analyser avec l’IA",
     "chooseRewriteInstruction": "Options de réécriture",
     "editWithAI": "Modifier avec l’IA",
     "keyRequired": {

--- a/apps/web/src/i18n/langs/hu.json
+++ b/apps/web/src/i18n/langs/hu.json
@@ -28,7 +28,6 @@
     "title": "Csatlakoztassa ügynökét"
   },
   "ai": {
-    "analyzeWithAI": "Elemzés AI-val",
     "chooseRewriteInstruction": "Átírási lehetőségek",
     "editWithAI": "Szerkesztés AI-val",
     "keyRequired": {

--- a/apps/web/src/i18n/langs/lt.json
+++ b/apps/web/src/i18n/langs/lt.json
@@ -28,7 +28,6 @@
     "title": "Prijunkite savo agentą"
   },
   "ai": {
-    "analyzeWithAI": "Analizuoti su DI",
     "chooseRewriteInstruction": "Perrašymo parinktys",
     "editWithAI": "Redaguoti su DI",
     "keyRequired": {

--- a/apps/web/src/i18n/langs/lv.json
+++ b/apps/web/src/i18n/langs/lv.json
@@ -28,7 +28,6 @@
     "title": "Savienojiet savu aģentu"
   },
   "ai": {
-    "analyzeWithAI": "Analizēt ar AI",
     "chooseRewriteInstruction": "Pārrakstīšanas iespējas",
     "editWithAI": "Rediģēt ar AI",
     "keyRequired": {

--- a/apps/web/src/i18n/langs/messages.gen.ts
+++ b/apps/web/src/i18n/langs/messages.gen.ts
@@ -31,7 +31,6 @@ type Messages = {
     "title": "Connect your agent";
   };
   "ai": {
-    "analyzeWithAI": "Analyze with AI";
     "chooseRewriteInstruction": "Rewrite options";
     "editWithAI": "Edit with AI";
     "keyRequired": {

--- a/apps/web/src/i18n/langs/pl.json
+++ b/apps/web/src/i18n/langs/pl.json
@@ -28,7 +28,6 @@
     "title": "Połącz swojego agenta"
   },
   "ai": {
-    "analyzeWithAI": "Analizuj z AI",
     "chooseRewriteInstruction": "Opcje przeredagowania",
     "editWithAI": "Edytuj z AI",
     "keyRequired": {

--- a/apps/web/src/i18n/langs/pt-BR.json
+++ b/apps/web/src/i18n/langs/pt-BR.json
@@ -28,7 +28,6 @@
     "title": "Conecte seu agente"
   },
   "ai": {
-    "analyzeWithAI": "Analisar com IA",
     "chooseRewriteInstruction": "Opções de reescrita",
     "editWithAI": "Editar com IA",
     "keyRequired": {

--- a/apps/web/src/i18n/langs/sk.json
+++ b/apps/web/src/i18n/langs/sk.json
@@ -28,7 +28,6 @@
     "title": "Pripojte svojho agenta"
   },
   "ai": {
-    "analyzeWithAI": "Analyzovať pomocou AI",
     "chooseRewriteInstruction": "Možnosti úpravy",
     "editWithAI": "Upraviť pomocou AI",
     "keyRequired": {

--- a/apps/web/src/routes/law/$country/cases/$court/$language/$slug.tsx
+++ b/apps/web/src/routes/law/$country/cases/$court/$language/$slug.tsx
@@ -32,14 +32,6 @@ export const Route = createFileRoute(
 });
 
 function PublicDecisionRoute() {
-  const params = Route.useParams({
-    select: ({ country, court, language, slug }) => ({
-      country,
-      court,
-      language,
-      slug,
-    }),
-  });
   const decision = Route.useLoaderData();
   const initialSearchQuery = Route.useSearch({ select: (search) => search.q });
 
@@ -47,7 +39,6 @@ function PublicDecisionRoute() {
     <PublicDecisionViewer
       decision={decision}
       initialSearchQuery={initialSearchQuery}
-      params={params}
     />
   );
 }

--- a/apps/web/src/routes/law/$country/cases/$court/$slug.tsx
+++ b/apps/web/src/routes/law/$country/cases/$court/$slug.tsx
@@ -30,13 +30,6 @@ export const Route = createFileRoute("/law/$country/cases/$court/$slug")({
 });
 
 function PublicDecisionRoute() {
-  const params = Route.useParams({
-    select: ({ country, court, slug }) => ({
-      country,
-      court,
-      slug,
-    }),
-  });
   const decision = Route.useLoaderData();
   const initialSearchQuery = Route.useSearch({ select: (search) => search.q });
 
@@ -44,7 +37,6 @@ function PublicDecisionRoute() {
     <PublicDecisionViewer
       decision={decision}
       initialSearchQuery={initialSearchQuery}
-      params={params}
     />
   );
 }

--- a/apps/web/src/routes/law/-case-detail.tsx
+++ b/apps/web/src/routes/law/-case-detail.tsx
@@ -1,12 +1,10 @@
-import { lazy, Suspense, useState } from "react";
+import { lazy, Suspense } from "react";
 
 import { DecisionWorkspace } from "@/features/case-law/components/case-viewer/decision-workspace";
 import { useClientAuthStatus } from "@/hooks/use-client-auth-status";
-import { createCaseLawDecisionPath } from "@/lib/case-law-route";
 import {
   extractId,
   type PublicCaseLawDecision,
-  type PublicDecisionRouteParams,
 } from "@/routes/law/-case-detail.logic";
 
 const AuthenticatedCaseLawWorkspace = lazy(async () => {
@@ -16,29 +14,17 @@ const AuthenticatedCaseLawWorkspace = lazy(async () => {
   };
 });
 
-const SignInDialog = lazy(async () => {
-  const module = await import("@/components/auth/sign-in-dialog");
-  return { default: module.SignInDialog };
-});
-
 type PublicDecisionViewerProps = {
   decision: PublicCaseLawDecision;
   initialSearchQuery?: string | undefined;
-  params: PublicDecisionRouteParams;
 };
 
 export function PublicDecisionViewer({
   decision,
   initialSearchQuery,
-  params,
 }: PublicDecisionViewerProps) {
   const decisionId = extractId(decision.id);
   const authStatus = useClientAuthStatus();
-  const [authRedirectTo, setAuthRedirectTo] = useState<string | null>(null);
-  const requestAuth = (redirectTo: string) => {
-    setAuthRedirectTo(redirectTo);
-  };
-  const publicPath = createCaseLawDecisionPath(params);
 
   return (
     <main className="flex min-h-0 flex-1 overflow-hidden">
@@ -51,8 +37,6 @@ export function PublicDecisionViewer({
                 decision={decision}
                 decisionId={decisionId}
                 initialSearchQuery={initialSearchQuery}
-                publicPath={publicPath}
-                requestAuth={requestAuth}
               />
             </div>
           }
@@ -71,23 +55,8 @@ export function PublicDecisionViewer({
             decision={decision}
             decisionId={decisionId}
             initialSearchQuery={initialSearchQuery}
-            publicPath={publicPath}
-            requestAuth={requestAuth}
           />
         </div>
-      )}
-      {authRedirectTo !== null && (
-        <Suspense fallback={null}>
-          <SignInDialog
-            onOpenChange={(open) => {
-              if (!open) {
-                setAuthRedirectTo(null);
-              }
-            }}
-            open
-            redirectTo={authRedirectTo}
-          />
-        </Suspense>
       )}
     </main>
   );

--- a/deploy/selfhost/.env.example
+++ b/deploy/selfhost/.env.example
@@ -18,6 +18,14 @@ STELLA_API_ENV_FILE="deploy/selfhost/.env"
 # [internal] Optional. Stella ocr pdf font path.
 # STELLA_OCR_PDF_FONT_PATH=""
 
+# [secret] Optional. Local-development-only read-only Postgres URL for a
+# shared public case-law corpus. Unset uses DATABASE_URL.
+# CASE_LAW_DATABASE_URL=""
+
+# [internal] Optional with a default. Maximum connections in the optional
+# local read-only public case-law pool.
+# CASE_LAW_DATABASE_POOL_MAX="2"
+
 # [secret] Required. Valkey or Redis URL used for cross-instance broadcasts
 # and rate limits. Treated as secret because it may contain credentials.
 REDIS_URL="rediss://valkey.example.internal:6379"
@@ -209,8 +217,13 @@ S3_REGION="us-east-1"
 # [internal] Optional with a default. Legal search index generation.
 # LEGAL_SEARCH_INDEX_GENERATION="case_law_v1"
 
-# [internal] Conditionally required when LEGAL_SEARCH_PROVIDER is
-# corpus-index. Corpus index endpoint.
+# [internal] Conditionally required when LEGAL_SEARCH_PROVIDER is corpus-index
+# and CORPUS_INDEX_ENDPOINT is unset. Local-development-only search endpoint
+# for a shared corpus index. Unset uses CORPUS_INDEX_ENDPOINT; this endpoint
+# is never used for index mutations.
+# CORPUS_INDEX_SEARCH_ENDPOINT=""
+
+# [internal] Optional. Corpus index endpoint.
 # CORPUS_INDEX_ENDPOINT=""
 
 # [internal] Optional. Corpus index s3 bucket.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -91,7 +91,8 @@ services:
   # Quickwit search engine for the legal-corpus benchmark. Opt-in:
   #   docker compose --profile dev --profile quickwit up
   # Stores its splits in the RustFS `stella-quickwit` bucket. This is a
-  # standalone benchmark service; the API has no Quickwit provider adapter.
+  # standalone opt-in service; select it with
+  # LEGAL_SEARCH_PROVIDER=corpus-index and CORPUS_INDEX_ENDPOINT.
   quickwit:
     profiles: [quickwit]
     image: quickwit/quickwit:0.9.0@sha256:1e6169bf4e98a489fca397105f1698c1d80a0f9779f3cf652973bac8a0c3b2bd

--- a/scripts/env-catalog.ts
+++ b/scripts/env-catalog.ts
@@ -73,11 +73,13 @@ const INTERNAL_SERVER_KEYS = new Set([
   "AZURE_RESOURCE_NAME",
   "BETTER_AUTH_COOKIE_PREFIX",
   "BETTER_AUTH_URL",
+  "CASE_LAW_DATABASE_POOL_MAX",
   "CORPUS_INDEXING_ENABLED",
   "CORPUS_INDEX_BATCH_SIZE",
   "CORPUS_INDEX_ENDPOINT",
   "CORPUS_INDEX_INTERVAL_MS",
   "CORPUS_INDEX_READ_CONCURRENCY",
+  "CORPUS_INDEX_SEARCH_ENDPOINT",
   "CORPUS_INDEX_S3_BUCKET",
   "CORPUS_STORAGE_ENABLED",
   "CORPUS_STORAGE_MODE",
@@ -239,6 +241,12 @@ const DESCRIPTION_OVERRIDES: Record<string, string> = {
     "Maximum RLS pool size. Keep its sum with DATABASE_ROOT_POOL_MAX within the process connection budget.",
   DATABASE_ROOT_POOL_MAX:
     "Maximum root pool size. Keep its sum with DATABASE_RLS_POOL_MAX within the process connection budget.",
+  CASE_LAW_DATABASE_POOL_MAX:
+    "Maximum connections in the optional local read-only public case-law pool.",
+  CASE_LAW_DATABASE_URL:
+    "Local-development-only read-only Postgres URL for a shared public case-law corpus. Unset uses DATABASE_URL.",
+  CORPUS_INDEX_SEARCH_ENDPOINT:
+    "Local-development-only search endpoint for a shared corpus index. Unset uses CORPUS_INDEX_ENDPOINT; this endpoint is never used for index mutations.",
   DATABASE_URL:
     "Postgres owner URL used by Drizzle. Requests downgrade to the stella role so row-level security applies.",
   DB_HOST:
@@ -374,7 +382,8 @@ const CONDITIONAL_REQUIREMENT_NOTES: Record<string, string> = {
   AGENT_SANDBOX_IMAGE: "AGENT_SANDBOX_RUNS_ENABLED is true",
   AGENT_SANDBOX_MCP_URL: "AGENT_SANDBOX_RUNS_ENABLED is true",
   CONTENT_ENCRYPTION_KEY: "NODE_ENV is production or staging",
-  CORPUS_INDEX_ENDPOINT: "LEGAL_SEARCH_PROVIDER is corpus-index",
+  CORPUS_INDEX_SEARCH_ENDPOINT:
+    "LEGAL_SEARCH_PROVIDER is corpus-index and CORPUS_INDEX_ENDPOINT is unset",
   LEGAL_CORPUS_S3_BUCKET: "corpus storage is enabled in a deployed environment",
   MICROSOFT_AUTH_TENANT_ID: "Microsoft OAuth credentials are configured",
   S3_ACCESS_KEY_ID: 'S3_CREDENTIALS_PROVIDER is "env"',

--- a/scripts/env-tool.test.ts
+++ b/scripts/env-tool.test.ts
@@ -343,7 +343,7 @@ describe("environment doctor output", () => {
     },
     {
       expected:
-        "LEGAL_SEARCH_PROVIDER=corpus-index requires CORPUS_INDEX_ENDPOINT to be set.",
+        "LEGAL_SEARCH_PROVIDER=corpus-index requires CORPUS_INDEX_SEARCH_ENDPOINT or CORPUS_INDEX_ENDPOINT to be set.",
       overrides: { LEGAL_SEARCH_PROVIDER: "corpus-index" },
     },
     {
@@ -383,6 +383,79 @@ describe("environment doctor output", () => {
         DATABASE_URL:
           "postgres://owner:password@db.example.com:5432/stella?sslmode=disable",
         NODE_ENV: "production",
+      },
+    },
+    {
+      expected:
+        "CASE_LAW_DATABASE_URL must enable TLS outside loopback or Railway private networking.",
+      overrides: {
+        CASE_LAW_DATABASE_URL:
+          "postgres://case_law_reader:password@db.example.com:5432/stella?sslmode=disable",
+        CONTENT_ENCRYPTION_KEY: "a".repeat(64),
+        NODE_ENV: "staging",
+      },
+    },
+    {
+      expected: "CASE_LAW_DATABASE_URL is only supported in local development.",
+      overrides: {
+        CASE_LAW_DATABASE_URL:
+          "postgres://case_law_reader:password@db.example.com:5432/stella?sslmode=require",
+        CONTENT_ENCRYPTION_KEY: "a".repeat(64),
+        NODE_ENV: "staging",
+      },
+    },
+    {
+      expected:
+        "CORPUS_INDEX_SEARCH_ENDPOINT must use HTTPS unless it targets a loopback address.",
+      overrides: {
+        CORPUS_INDEX_SEARCH_ENDPOINT: "http://search.example.com",
+      },
+    },
+    {
+      expected:
+        "CORPUS_INDEX_SEARCH_ENDPOINT is only supported in local development.",
+      overrides: {
+        CONTENT_ENCRYPTION_KEY: "a".repeat(64),
+        CORPUS_INDEX_SEARCH_ENDPOINT: "https://search.example.com",
+        NODE_ENV: "staging",
+      },
+    },
+    {
+      expected:
+        'CASE_LAW_DATABASE_URL requires LEGAL_SEARCH_PROVIDER="corpus-index".',
+      overrides: {
+        CASE_LAW_DATABASE_URL:
+          "postgres://case_law_reader:password@db.example.com:5432/stella?sslmode=require",
+      },
+    },
+    {
+      expected: "CASE_LAW_DATABASE_URL requires CORPUS_INDEX_SEARCH_ENDPOINT.",
+      overrides: {
+        CASE_LAW_DATABASE_URL:
+          "postgres://case_law_reader:password@db.example.com:5432/stella?sslmode=require",
+        LEGAL_SEARCH_PROVIDER: "corpus-index",
+      },
+    },
+    {
+      expected:
+        "CORPUS_INDEX_ENDPOINT must be unset when CASE_LAW_DATABASE_URL is configured.",
+      overrides: {
+        CASE_LAW_DATABASE_URL:
+          "postgres://case_law_reader:password@db.example.com:5432/stella?sslmode=require",
+        CORPUS_INDEX_ENDPOINT: "https://quickwit-admin.example.com",
+        CORPUS_INDEX_SEARCH_ENDPOINT: "https://quickwit-search.example.com",
+        LEGAL_SEARCH_PROVIDER: "corpus-index",
+      },
+    },
+    {
+      expected:
+        "CORPUS_INDEXING_ENABLED must be false when CASE_LAW_DATABASE_URL is configured.",
+      overrides: {
+        CASE_LAW_DATABASE_URL:
+          "postgres://case_law_reader:password@db.example.com:5432/stella?sslmode=require",
+        CORPUS_INDEXING_ENABLED: "true",
+        CORPUS_INDEX_SEARCH_ENDPOINT: "https://quickwit-search.example.com",
+        LEGAL_SEARCH_PROVIDER: "corpus-index",
       },
     },
     {

--- a/scripts/env-tool.test.ts
+++ b/scripts/env-tool.test.ts
@@ -335,6 +335,23 @@ describe("environment doctor output", () => {
     }
   });
 
+  test("rejects a non-PostgreSQL case-law database URL", () => {
+    const result = validateDoctorEnvironment({
+      app: "api",
+      input: {
+        ...validApiInput(),
+        CASE_LAW_DATABASE_URL: "https://db.example.com/stella?sslmode=require",
+      },
+    });
+
+    expect(result.status).toBe("invalid");
+    if (result.status === "invalid") {
+      expect(result.issues).toContain(
+        "CASE_LAW_DATABASE_URL: invalid secret value.",
+      );
+    }
+  });
+
   test.each([
     {
       expected:


### PR DESCRIPTION
## Summary

- remove the redundant decision-viewer header and manual analysis action
- allow local development to query a shared public case-law corpus without duplicating it
- separate corpus search from mutation endpoints and enforce local-only, TLS, read-only data-access boundaries

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for reading public case-law content from a dedicated read-only database.
  * Added separate search-endpoint configuration for corpus search services.

* **Improvements**
  * Public decisions now load analysis automatically without requiring an “Analyse with AI” action or sign-in prompt.
  * Decision pages display article content more consistently.

* **Bug Fixes**
  * Restricted public case-law access to approved read-only data and prevented unsupported analysis or document-fetch operations.
  * Improved validation for secure, compatible search and database configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->