### PR TITLE
fix: reduce navigation request latency

### DIFF
--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -258,6 +258,8 @@ const buildRequestLogDetails = ({
   return details;
 };
 
+const CORS_PREFLIGHT_MAX_AGE_SECONDS = 60 * 60;
+
 const api = new Elysia()
   .onRequest(async (context) => {
     const { request, set } = context;
@@ -329,6 +331,7 @@ const api = new Elysia()
         "Content-Disposition",
         REQUEST_ID_HEADER,
       ],
+      maxAge: CORS_PREFLIGHT_MAX_AGE_SECONDS,
     }),
   )
   .onError(({ error, set, code, request, route }) => {

--- a/apps/web/src/lib/react-query.test.ts
+++ b/apps/web/src/lib/react-query.test.ts
@@ -6,6 +6,7 @@ import {
   ROUTE_QUERY_STALE_TIME_MS,
   ensureCriticalQueryData,
   ensureRouteInfiniteQueryData,
+  prefetchNonCriticalInfiniteQuery,
   prefetchNonCriticalQuery,
   routeQueryOptions,
 } from "@/lib/react-query";
@@ -174,5 +175,45 @@ describe("prefetchNonCriticalQuery", () => {
     );
 
     expect(onError).not.toHaveBeenCalled();
+  });
+});
+
+describe("prefetchNonCriticalInfiniteQuery", () => {
+  test("reports every independently failing prefetch", async () => {
+    const queryClient = new QueryClient();
+    const firstError = new Error("first failure");
+    const secondError = new Error("second failure");
+    const onError = mock((_error: unknown): void => {});
+
+    await Promise.all([
+      prefetchNonCriticalInfiniteQuery(
+        queryClient,
+        {
+          getNextPageParam: () => undefined,
+          initialPageParam: 0,
+          queryKey: ["first-failing-infinite-query"],
+          queryFn: async () => {
+            throw firstError;
+          },
+        },
+        onError,
+      ),
+      prefetchNonCriticalInfiniteQuery(
+        queryClient,
+        {
+          getNextPageParam: () => undefined,
+          initialPageParam: 0,
+          queryKey: ["second-failing-infinite-query"],
+          queryFn: async () => {
+            throw secondError;
+          },
+        },
+        onError,
+      ),
+    ]);
+
+    expect(onError).toHaveBeenCalledTimes(2);
+    expect(onError).toHaveBeenCalledWith(firstError);
+    expect(onError).toHaveBeenCalledWith(secondError);
   });
 });

--- a/apps/web/src/lib/react-query.ts
+++ b/apps/web/src/lib/react-query.ts
@@ -123,6 +123,30 @@ export const prefetchNonCriticalQuery = async <
   }
 };
 
+export const prefetchNonCriticalInfiniteQuery = async <
+  TQueryFnData,
+  TError = Error,
+  TData = TQueryFnData,
+  TQueryKey extends QueryKey = QueryKey,
+  TPageParam = unknown,
+>(
+  queryClient: QueryClient,
+  options: FetchInfiniteQueryOptions<
+    TQueryFnData,
+    TError,
+    TData,
+    TQueryKey,
+    TPageParam
+  >,
+  onError: (error: unknown) => void,
+) => {
+  try {
+    await queryClient.fetchInfiniteQuery(options);
+  } catch (error) {
+    onError(error);
+  }
+};
+
 type RouteFreshenableQueryOptions = {
   staleTime?: unknown;
 };

--- a/apps/web/src/lib/react-query.ts
+++ b/apps/web/src/lib/react-query.ts
@@ -6,7 +6,7 @@ import type {
   QueryClient,
   QueryKey,
 } from "@tanstack/react-query";
-import { TaggedError } from "better-result";
+import { Result, TaggedError } from "better-result";
 
 import { STALE_TIME } from "@/lib/consts";
 import { detached } from "@/lib/detached";
@@ -116,10 +116,12 @@ export const prefetchNonCriticalQuery = async <
   options: FetchQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
   onError: (error: unknown) => void,
 ) => {
-  try {
-    await queryClient.fetchQuery(options);
-  } catch (error) {
-    onError(error);
+  const result = await Result.tryPromise({
+    try: async () => await queryClient.fetchQuery(options),
+    catch: (cause) => cause,
+  });
+  if (Result.isError(result)) {
+    onError(result.error);
   }
 };
 
@@ -140,10 +142,12 @@ export const prefetchNonCriticalInfiniteQuery = async <
   >,
   onError: (error: unknown) => void,
 ) => {
-  try {
-    await queryClient.fetchInfiniteQuery(options);
-  } catch (error) {
-    onError(error);
+  const result = await Result.tryPromise({
+    try: async () => await queryClient.fetchInfiniteQuery(options),
+    catch: (cause) => cause,
+  });
+  if (Result.isError(result)) {
+    onError(result.error);
   }
 };
 

--- a/apps/web/src/routes/_protected.chat/index.tsx
+++ b/apps/web/src/routes/_protected.chat/index.tsx
@@ -79,7 +79,10 @@ import { skillsOptions } from "@/lib/knowledge/queries";
 import { usePinnedStore } from "@/lib/pinned-store";
 import type { ChatPrompt } from "@/lib/prompts/types";
 import { useSavedPrompts } from "@/lib/prompts/use-saved-prompts";
-import { prefetchRouteQuery } from "@/lib/react-query";
+import {
+  prefetchNonCriticalInfiniteQuery,
+  prefetchRouteQuery,
+} from "@/lib/react-query";
 import { formatRelativeTime } from "@/lib/relative-time";
 import { runReservedChatCommand } from "@/lib/reserved-chat-commands";
 import { toSafeId } from "@/lib/safe-id";
@@ -101,11 +104,15 @@ export const Route = createFileRoute("/_protected/chat/")({
           workspacesNavigationOptions(activeOrganizationId),
           onPrefetchError,
         ),
-        context.queryClient.prefetchInfiniteQuery(
+        prefetchNonCriticalInfiniteQuery(
+          context.queryClient,
           groupedChatThreadsOptions({ activeOrganizationId }),
+          onPrefetchError,
         ),
-        context.queryClient.prefetchInfiniteQuery(
+        prefetchNonCriticalInfiniteQuery(
+          context.queryClient,
           skillsOptions(activeOrganizationId),
+          onPrefetchError,
         ),
       ]),
       "chat-index.prefetch",

--- a/apps/web/src/routes/_protected.chat/index.tsx
+++ b/apps/web/src/routes/_protected.chat/index.tsx
@@ -61,7 +61,7 @@ import {
 import { useExternalSyncEffect } from "@/hooks/use-effect";
 import { useLatestCallback } from "@/hooks/use-latest-callback";
 import { usePermissions } from "@/hooks/use-permissions";
-import { useAnalytics } from "@/lib/analytics/provider";
+import { getAnalytics, useAnalytics } from "@/lib/analytics/provider";
 import { ChatAnonymizationLayer } from "@/lib/anonymize/use-chat-anonymization-layer";
 import { api } from "@/lib/api";
 import {
@@ -75,9 +75,11 @@ import { useChatWebSearchPreferenceStore } from "@/lib/chat-web-search-store";
 import { ChromeHeaderActions } from "@/lib/chrome-header-actions";
 import { detached } from "@/lib/detached";
 import { unwrapEden } from "@/lib/errors/api";
+import { skillsOptions } from "@/lib/knowledge/queries";
 import { usePinnedStore } from "@/lib/pinned-store";
 import type { ChatPrompt } from "@/lib/prompts/types";
 import { useSavedPrompts } from "@/lib/prompts/use-saved-prompts";
+import { prefetchRouteQuery } from "@/lib/react-query";
 import { formatRelativeTime } from "@/lib/relative-time";
 import { runReservedChatCommand } from "@/lib/reserved-chat-commands";
 import { toSafeId } from "@/lib/safe-id";
@@ -86,6 +88,29 @@ import { workspacesNavigationOptions } from "@/lib/workspaces/queries";
 import { ThreadsSheet } from "@/routes/_protected.chat/-components/threads-sheet";
 
 export const Route = createFileRoute("/_protected/chat/")({
+  loader: ({ context }) => {
+    const activeOrganizationId = context.user.activeOrganizationId;
+    const onPrefetchError = (error: unknown) => {
+      getAnalytics().captureError(error);
+    };
+
+    detached(
+      Promise.all([
+        prefetchRouteQuery(
+          context.queryClient,
+          workspacesNavigationOptions(activeOrganizationId),
+          onPrefetchError,
+        ),
+        context.queryClient.prefetchInfiniteQuery(
+          groupedChatThreadsOptions({ activeOrganizationId }),
+        ),
+        context.queryClient.prefetchInfiniteQuery(
+          skillsOptions(activeOrganizationId),
+        ),
+      ]),
+      "chat-index.prefetch",
+    );
+  },
   component: ChatIndex,
 });
 

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-default-view-redirect.test.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-default-view-redirect.test.ts
@@ -1,0 +1,63 @@
+import { QueryClient } from "@tanstack/react-query";
+import { afterEach, beforeAll, describe, expect, mock, test } from "bun:test";
+
+import type { ViewLayout, WorkspaceView } from "@/lib/types";
+
+beforeAll(() => {
+  process.env["VITE_API_URL"] ??= "https://api.example.test";
+});
+
+const WORKSPACE_ID = "workspace-with-cached-views";
+const VIEW_ID = "cached-overview";
+const originalFetch = globalThis.fetch;
+
+const OVERVIEW_LAYOUT = {
+  filters: [],
+  hiddenProperties: [],
+  sorts: [],
+  type: "overview",
+  version: 1,
+} as const satisfies ViewLayout;
+
+const CACHED_VIEWS = [
+  {
+    version: 1,
+    id: VIEW_ID,
+    name: "Overview",
+    layout: OVERVIEW_LAYOUT,
+    position: 0,
+    createdAt: "2026-01-01T00:00:00.000Z",
+  },
+] satisfies WorkspaceView[];
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe("default workspace view redirect", () => {
+  test("reuses the route-prefetched view list", async () => {
+    const { resolveDefaultWorkspaceViewTarget } =
+      await import("./-default-view-redirect");
+    const { viewsOptions } = await import("@/lib/workspaces/queries/views");
+    const options = viewsOptions(WORKSPACE_ID);
+    const queryClient = new QueryClient();
+    queryClient.setQueryData(options.queryKey, CACHED_VIEWS);
+    const fetchMock = mock(async () => {
+      throw new Error("The cached view list should not be fetched again");
+    });
+    globalThis.fetch = Object.assign(fetchMock, {
+      preconnect: originalFetch.preconnect,
+    });
+
+    const target = await resolveDefaultWorkspaceViewTarget({
+      queryClient,
+      workspaceId: WORKSPACE_ID,
+    });
+
+    expect(target).toEqual({
+      to: "/workspaces/$workspaceId/$viewId",
+      params: { workspaceId: WORKSPACE_ID, viewId: VIEW_ID },
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-default-view-redirect.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-default-view-redirect.ts
@@ -25,15 +25,11 @@ type DefaultWorkspaceViewTarget =
 // router redirect so it can drive a mounted-component navigation: a beforeLoad
 // throw-redirect on this client-only route blanks the page on cold direct
 // loads (see the no-beforeload-redirect lint rule).
-const resolveDefaultWorkspaceViewTarget = async ({
+export const resolveDefaultWorkspaceViewTarget = async ({
   queryClient,
   workspaceId,
 }: DefaultWorkspaceViewInput): Promise<DefaultWorkspaceViewTarget> => {
   const options = viewsOptions(workspaceId);
-
-  // Avoid serving stale cache from a previous workspace that had no views.
-  await queryClient.invalidateQueries({ queryKey: options.queryKey });
-
   const views = await ensureRouteQueryData(queryClient, options);
   const firstView = views.at(0);
 


### PR DESCRIPTION
## Summary

- reuse route-prefetched workspace views instead of invalidating and refetching them during default-view navigation
- start chat landing queries in the route loader so they overlap shell loading
- cache successful CORS preflights for one hour to remove repeat navigation round trips
- format the request-context helper surfaced by repository verification

CC on behalf of jankubica96

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Chat pages now pre-load workspace navigation, chat threads and skills for a faster initial experience.
  - Workspace default views load more efficiently, reducing unnecessary repeat requests during navigation.
  - API preflight responses may be cached for up to one hour, improving responsiveness for supported integrations.

- **Reliability**
  - Background pre-loading issues are now recorded for improved monitoring without interrupting the chat experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->