### PR TITLE
docs: prefer invariant guards in testing guidance

### DIFF
--- a/.agents/skills/conventions-testing/SKILL.md
+++ b/.agents/skills/conventions-testing/SKILL.md
@@ -54,7 +54,12 @@ enforcement, branded types) live in
   edge-case inputs, or isolating external services
 - Test tenant isolation and ownership-source rules at the
   highest meaningful layer, not only as pure helper tests
-- Every bug fix gets a regression test
+- Every bug fix needs a durable guard, but not necessarily an example test:
+  prefer types, derivation, schemas, lint rules, or broader invariants when they
+  eliminate the bug class
+- Guard the invariant, not the accident. Do not memorialize a one-off typo,
+  stale literal, or incidental implementation detail in a dedicated test when
+  structural coupling makes that failure impossible
 - Avoid "tests for tests' sake": don't add shallow examples
   just to increase coverage if a stronger invariant test would
   cover the same surface with more signal

--- a/.ai/local-skills/conventions-testing/SKILL.md
+++ b/.ai/local-skills/conventions-testing/SKILL.md
@@ -54,7 +54,12 @@ enforcement, branded types) live in
   edge-case inputs, or isolating external services
 - Test tenant isolation and ownership-source rules at the
   highest meaningful layer, not only as pure helper tests
-- Every bug fix gets a regression test
+- Every bug fix needs a durable guard, but not necessarily an example test:
+  prefer types, derivation, schemas, lint rules, or broader invariants when they
+  eliminate the bug class
+- Guard the invariant, not the accident. Do not memorialize a one-off typo,
+  stale literal, or incidental implementation detail in a dedicated test when
+  structural coupling makes that failure impossible
 - Avoid "tests for tests' sake": don't add shallow examples
   just to increase coverage if a stronger invariant test would
   cover the same surface with more signal

--- a/.claude/commands/conventions-testing.md
+++ b/.claude/commands/conventions-testing.md
@@ -49,7 +49,12 @@ enforcement, branded types) live in
   edge-case inputs, or isolating external services
 - Test tenant isolation and ownership-source rules at the
   highest meaningful layer, not only as pure helper tests
-- Every bug fix gets a regression test
+- Every bug fix needs a durable guard, but not necessarily an example test:
+  prefer types, derivation, schemas, lint rules, or broader invariants when they
+  eliminate the bug class
+- Guard the invariant, not the accident. Do not memorialize a one-off typo,
+  stale literal, or incidental implementation detail in a dedicated test when
+  structural coupling makes that failure impossible
 - Avoid "tests for tests' sake": don't add shallow examples
   just to increase coverage if a stronger invariant test would
   cover the same surface with more signal

--- a/apps/api/src/lib/observability/request-context.ts
+++ b/apps/api/src/lib/observability/request-context.ts
@@ -139,4 +139,5 @@ export const getCurrentRequestId = (): string | undefined =>
 export const runWithRequestId = <TResult>(
   requestId: string,
   fn: () => TResult,
-): TResult => requestIdStore.run({ current: requestId, isAiRequest: false }, fn);
+): TResult =>
+  requestIdStore.run({ current: requestId, isAiRequest: false }, fn);


### PR DESCRIPTION
## Summary

- replace the absolute regression-test rule with a durable guard requirement
- direct tests toward invariants instead of incidental typos, stale literals, or implementation details
- synchronize generated testing-convention copies
- normalize pre-existing formatter drift found by the required pre-push gate

CC on behalf of jan-kubica