### PR TITLE
fix: scope staging case title invariant

### DIFF
--- a/apps/web/e2e/staging/staging-smoke.spec.ts
+++ b/apps/web/e2e/staging/staging-smoke.spec.ts
@@ -97,7 +97,6 @@ test("server-rendered public law decisions stay stable after hydration", async (
     .first();
 
   await expect(firstDecision).toBeVisible();
-  const selectedCaseNumber = await firstDecision.innerText();
   await firstDecision.click();
   await expect(page).toHaveURL(/\/law\/[a-z]{2,3}\/cases\//u);
 
@@ -110,7 +109,7 @@ test("server-rendered public law decisions stay stable after hydration", async (
   // Assert the app-owned page title without constraining source-document markup.
   const decisionTitle = page.locator('h1[data-slot="decision-title"]');
   await expect(decisionTitle).toHaveCount(1);
-  await expect(decisionTitle).toHaveText(selectedCaseNumber);
+  await expect(decisionTitle).toHaveText(/\S/u);
   const routeErrorTitle = page.locator("#route-error-title");
   const inspector = page.locator('[data-side="right"]');
   await expect(routeErrorTitle).toHaveCount(0);

--- a/apps/web/e2e/staging/staging-smoke.spec.ts
+++ b/apps/web/e2e/staging/staging-smoke.spec.ts
@@ -105,9 +105,11 @@ test("server-rendered public law decisions stay stable after hydration", async (
   await page.reload({ waitUntil: "commit" });
 
   await expect(page.locator("article").first()).toBeVisible();
-  // Source documents may contain their own level-one heading. Scope this to
-  // the viewer's accessible page title rather than assuming a global count.
-  await expect(page.locator("h1.sr-only")).toHaveCount(1);
+  // Imported judgments are self-contained articles and may carry their own h1.
+  // Assert the app-owned page title without constraining source-document markup.
+  const decisionTitle = page.locator('h1[data-slot="decision-title"]');
+  await expect(decisionTitle).toHaveCount(1);
+  await expect(decisionTitle).toHaveText(/\/\d{4}/u);
   const routeErrorTitle = page.locator("#route-error-title");
   const inspector = page.locator('[data-side="right"]');
   await expect(routeErrorTitle).toHaveCount(0);

--- a/apps/web/e2e/staging/staging-smoke.spec.ts
+++ b/apps/web/e2e/staging/staging-smoke.spec.ts
@@ -97,6 +97,7 @@ test("server-rendered public law decisions stay stable after hydration", async (
     .first();
 
   await expect(firstDecision).toBeVisible();
+  const selectedCaseNumber = await firstDecision.innerText();
   await firstDecision.click();
   await expect(page).toHaveURL(/\/law\/[a-z]{2,3}\/cases\//u);
 
@@ -109,7 +110,7 @@ test("server-rendered public law decisions stay stable after hydration", async (
   // Assert the app-owned page title without constraining source-document markup.
   const decisionTitle = page.locator('h1[data-slot="decision-title"]');
   await expect(decisionTitle).toHaveCount(1);
-  await expect(decisionTitle).toHaveText(/\/\d{4}/u);
+  await expect(decisionTitle).toHaveText(selectedCaseNumber);
   const routeErrorTitle = page.locator("#route-error-title");
   const inspector = page.locator('[data-side="right"]');
   await expect(routeErrorTitle).toHaveCount(0);

--- a/apps/web/src/features/case-law/components/case-viewer/decision-workspace.tsx
+++ b/apps/web/src/features/case-law/components/case-viewer/decision-workspace.tsx
@@ -207,7 +207,7 @@ export const DecisionWorkspace = (props: DecisionWorkspaceProps) => {
 
   return (
     <div className="flex h-full flex-col overflow-hidden">
-      <h1 className="sr-only">
+      <h1 className="sr-only" data-slot="decision-title">
         <BidiText as="span">{decision.caseNumber}</BidiText>
       </h1>
       <div className="relative min-h-0 flex-1">


### PR DESCRIPTION
## Summary

- mark the app-owned public-decision page title with a stable semantic slot
- keep imported judgment headings intact and scope the staging smoke assertion to the page title

CC on behalf of jankubica96