### PR TITLE
fix: stabilize public law hydration on macOS

### DIFF
--- a/.oxlint-plugins/__fixtures__/no-ambient-hotkey-format.fixture.ts
+++ b/.oxlint-plugins/__fixtures__/no-ambient-hotkey-format.fixture.ts
@@ -1,0 +1,20 @@
+// Passive regression fixture for
+// `no-ambient-hotkey-format/no-ambient-hotkey-format`.
+
+// oxlint-disable-next-line no-ambient-hotkey-format/no-ambient-hotkey-format -- fixture: aliased ambient detection must be rejected
+import { detectPlatform as rawDetectPlatform } from "@tanstack/hotkeys";
+// Namespace imports could bypass named-export checks, so they must fail too.
+// oxlint-disable-next-line no-ambient-hotkey-format/no-ambient-hotkey-format -- fixture: raw namespace import must be rejected
+import * as rawHotkeys from "@tanstack/react-hotkeys";
+// oxlint-disable-next-line no-ambient-hotkey-format/no-ambient-hotkey-format -- fixture: aliased ambient formatting must be rejected
+import { formatForDisplay as rawFormat } from "@tanstack/react-hotkeys";
+import { useHotkey } from "@tanstack/react-hotkeys";
+import type { Hotkey } from "@tanstack/react-hotkeys";
+
+export const __noAmbientHotkeyFormatFixture: readonly unknown[] = [
+  rawHotkeys,
+  rawDetectPlatform,
+  rawFormat,
+  useHotkey,
+  undefined satisfies Hotkey | undefined,
+];

--- a/.oxlint-plugins/__fixtures__/no-ambient-hotkey-format.fixture.ts
+++ b/.oxlint-plugins/__fixtures__/no-ambient-hotkey-format.fixture.ts
@@ -4,9 +4,10 @@
 // Namespace imports could bypass named-export checks, so they must fail too.
 // oxlint-disable-next-line no-ambient-hotkey-format/no-ambient-hotkey-format -- fixture: raw namespace import must be rejected
 import * as rawHotkeys from "@tanstack/hotkeys";
-// oxlint-disable-next-line no-ambient-hotkey-format/no-ambient-hotkey-format -- fixture: aliased ambient formatting must be rejected
 import {
+  // oxlint-disable-next-line no-ambient-hotkey-format/no-ambient-hotkey-format -- fixture: aliased ambient detection must be rejected
   detectPlatform as rawPlatform,
+  // oxlint-disable-next-line no-ambient-hotkey-format/no-ambient-hotkey-format -- fixture: aliased ambient formatting must be rejected
   formatForDisplay as raw,
   useHotkey,
 } from "@tanstack/react-hotkeys";

--- a/.oxlint-plugins/__fixtures__/no-ambient-hotkey-format.fixture.ts
+++ b/.oxlint-plugins/__fixtures__/no-ambient-hotkey-format.fixture.ts
@@ -5,11 +5,16 @@
 // oxlint-disable-next-line no-ambient-hotkey-format/no-ambient-hotkey-format -- fixture: raw namespace import must be rejected
 import * as rawHotkeys from "@tanstack/hotkeys";
 // oxlint-disable-next-line no-ambient-hotkey-format/no-ambient-hotkey-format -- fixture: aliased ambient formatting must be rejected
-import { formatForDisplay as raw, useHotkey } from "@tanstack/react-hotkeys";
+import {
+  detectPlatform as rawPlatform,
+  formatForDisplay as raw,
+  useHotkey,
+} from "@tanstack/react-hotkeys";
 
 export const __noAmbientHotkeyFormatFixture: readonly unknown[] = [
   rawHotkeys,
   rawHotkeys.detectPlatform,
+  rawPlatform,
   raw,
   useHotkey,
 ];

--- a/.oxlint-plugins/__fixtures__/no-ambient-hotkey-format.fixture.ts
+++ b/.oxlint-plugins/__fixtures__/no-ambient-hotkey-format.fixture.ts
@@ -1,20 +1,15 @@
 // Passive regression fixture for
 // `no-ambient-hotkey-format/no-ambient-hotkey-format`.
 
-// oxlint-disable-next-line no-ambient-hotkey-format/no-ambient-hotkey-format -- fixture: aliased ambient detection must be rejected
-import { detectPlatform as rawDetectPlatform } from "@tanstack/hotkeys";
 // Namespace imports could bypass named-export checks, so they must fail too.
 // oxlint-disable-next-line no-ambient-hotkey-format/no-ambient-hotkey-format -- fixture: raw namespace import must be rejected
-import * as rawHotkeys from "@tanstack/react-hotkeys";
+import * as rawHotkeys from "@tanstack/hotkeys";
 // oxlint-disable-next-line no-ambient-hotkey-format/no-ambient-hotkey-format -- fixture: aliased ambient formatting must be rejected
-import { formatForDisplay as rawFormat } from "@tanstack/react-hotkeys";
-import { useHotkey } from "@tanstack/react-hotkeys";
-import type { Hotkey } from "@tanstack/react-hotkeys";
+import { formatForDisplay as raw, useHotkey } from "@tanstack/react-hotkeys";
 
 export const __noAmbientHotkeyFormatFixture: readonly unknown[] = [
   rawHotkeys,
-  rawDetectPlatform,
-  rawFormat,
+  rawHotkeys.detectPlatform,
+  raw,
   useHotkey,
-  undefined satisfies Hotkey | undefined,
 ];

--- a/.oxlint-plugins/no-ambient-hotkey-format.ts
+++ b/.oxlint-plugins/no-ambient-hotkey-format.ts
@@ -1,0 +1,72 @@
+import { eslintCompatPlugin } from "@oxlint/plugins";
+
+import { getImportedName } from "./utils.ts";
+
+const HOTKEY_MODULES = new Set([
+  "@tanstack/hotkeys",
+  "@tanstack/react-hotkeys",
+]);
+
+const AMBIENT_EXPORTS = new Set(["detectPlatform", "formatForDisplay"]);
+
+const ALLOWED_FILES = [
+  "apps/web/src/lib/hotkeys.ts",
+  "apps/web/src/hooks/use-hydration-safe-hotkey-platform.ts",
+];
+
+const filenameForContext = (context) =>
+  (context.filename ?? context.getFilename?.() ?? "").replaceAll("\\", "/");
+
+const isAllowedFile = (context) => {
+  const filename = filenameForContext(context);
+  return ALLOWED_FILES.some((allowedFile) => filename.endsWith(allowedFile));
+};
+
+export default eslintCompatPlugin({
+  meta: { name: "no-ambient-hotkey-format" },
+  rules: {
+    "no-ambient-hotkey-format": {
+      meta: {
+        type: "problem",
+        messages: {
+          ambientHotkeyFormat:
+            "Ambient hotkey platform reads can differ between SSR and hydration. Use useHydrationSafeHotkeyPlatform() with formatHotkeyForPlatform().",
+        },
+      },
+      createOnce(context) {
+        return {
+          before() {
+            return !isAllowedFile(context);
+          },
+          ImportDeclaration(node) {
+            if (!HOTKEY_MODULES.has(node.source?.value)) {
+              return;
+            }
+
+            for (const specifier of node.specifiers) {
+              if (specifier.type === "ImportNamespaceSpecifier") {
+                context.report({
+                  node: specifier,
+                  messageId: "ambientHotkeyFormat",
+                });
+                continue;
+              }
+
+              if (specifier.type !== "ImportSpecifier") {
+                continue;
+              }
+
+              const importedName = getImportedName(specifier);
+              if (importedName !== null && AMBIENT_EXPORTS.has(importedName)) {
+                context.report({
+                  node: specifier,
+                  messageId: "ambientHotkeyFormat",
+                });
+              }
+            }
+          },
+        };
+      },
+    },
+  },
+});

--- a/apps/web/e2e/staging/staging-smoke.spec.ts
+++ b/apps/web/e2e/staging/staging-smoke.spec.ts
@@ -2,6 +2,14 @@ import { expect, test } from "@playwright/test";
 
 import { appShellNavigationLink } from "../helpers/app-shell";
 
+const MACOS_USER_AGENT =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) " +
+  "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/151.0.0.0 Safari/537.36";
+
+// The public shell is rendered on Linux and hydrated on the user's platform.
+// Emulating macOS catches ambient platform reads that Linux-only CI misses.
+test.use({ userAgent: MACOS_USER_AGENT });
+
 // The smoke user mirrors the production default state: org owner,
 // no usage entitlement row, no AI provider config. Regressions that
 // only appear in that state must fail here, not in front of a user.
@@ -97,9 +105,9 @@ test("server-rendered public law decisions stay stable after hydration", async (
   await page.reload({ waitUntil: "commit" });
 
   await expect(page.locator("article").first()).toBeVisible();
-  await expect(
-    page.getByRole("heading", { includeHidden: true, level: 1 }),
-  ).toHaveCount(1);
+  // Source documents may contain their own level-one heading. Scope this to
+  // the viewer's accessible page title rather than assuming a global count.
+  await expect(page.locator("h1.sr-only")).toHaveCount(1);
   const routeErrorTitle = page.locator("#route-error-title");
   const inspector = page.locator('[data-side="right"]');
   await expect(routeErrorTitle).toHaveCount(0);

--- a/apps/web/src/components/ai-suggestions/review-bar.tsx
+++ b/apps/web/src/components/ai-suggestions/review-bar.tsx
@@ -30,10 +30,7 @@
 import { useRef } from "react";
 import type { RefObject } from "react";
 
-import {
-  formatForDisplay,
-  matchesKeyboardEvent,
-} from "@tanstack/react-hotkeys";
+import { matchesKeyboardEvent } from "@tanstack/react-hotkeys";
 import {
   CheckIcon,
   ChevronDownIcon,
@@ -68,8 +65,10 @@ import {
 import type { ReviewSuggestion } from "@/components/ai-suggestions/review-store";
 import { useReviewActions } from "@/components/ai-suggestions/use-review-actions";
 import { useExternalSyncEffect, useMountEffect } from "@/hooks/use-effect";
+import { useHydrationSafeHotkeyPlatform } from "@/hooks/use-hydration-safe-hotkey-platform";
 import { useLatestCallback } from "@/hooks/use-latest-callback";
 import { detached } from "@/lib/detached";
+import { formatHotkeyForPlatform } from "@/lib/hotkeys";
 import { useEffectiveHotkey } from "@/lib/use-effective-shortcuts";
 
 const EMPTY_SUGGESTIONS: readonly ReviewSuggestion[] = [];
@@ -94,6 +93,7 @@ export const ReviewBar = ({
   requestDocxEditMode,
 }: ReviewBarProps) => {
   const t = useTranslations();
+  const hotkeyPlatform = useHydrationSafeHotkeyPlatform();
   // Effective (user-rebindable) bindings for the four review shortcuts. The
   // capture-phase handler below matches against these, and the tooltips render
   // them, so a rebind changes both behavior and the discoverable hint. These
@@ -291,7 +291,10 @@ export const ReviewBar = ({
         disabled={activeIndex <= 0}
         onClick={goPrev}
         size="icon-sm"
-        tooltip={`${t("common.previous")} · ${formatForDisplay(prevHotkey)}`}
+        tooltip={`${t("common.previous")} · ${formatHotkeyForPlatform(
+          prevHotkey,
+          hotkeyPlatform,
+        )}`}
         variant="ghost"
       >
         <ChevronUpIcon className="size-4" />
@@ -301,7 +304,10 @@ export const ReviewBar = ({
         disabled={activeIndex >= suggestions.length - 1}
         onClick={goNext}
         size="icon-sm"
-        tooltip={`${t("common.next")} · ${formatForDisplay(nextHotkey)}`}
+        tooltip={`${t("common.next")} · ${formatHotkeyForPlatform(
+          nextHotkey,
+          hotkeyPlatform,
+        )}`}
         variant="ghost"
       >
         <ChevronDownIcon className="size-4" />
@@ -330,7 +336,10 @@ export const ReviewBar = ({
               detached(acceptAndAdvance(), "review-bar.accept-and-advance");
             }}
             size="sm"
-            tooltip={`${t("common.accept")} · ${formatForDisplay(acceptHotkey)}`}
+            tooltip={`${t("common.accept")} · ${formatHotkeyForPlatform(
+              acceptHotkey,
+              hotkeyPlatform,
+            )}`}
             variant="default"
           >
             <CheckIcon className="me-1 size-3.5 @max-[80rem]/file-viewer:me-0" />
@@ -343,7 +352,10 @@ export const ReviewBar = ({
             disabled={activeAction === "busy"}
             onClick={rejectAndAdvance}
             size="sm"
-            tooltip={`${t("docxReview.reject")} · ${formatForDisplay(rejectHotkey)}`}
+            tooltip={`${t("docxReview.reject")} · ${formatHotkeyForPlatform(
+              rejectHotkey,
+              hotkeyPlatform,
+            )}`}
             variant="outline"
           >
             <XIcon className="me-1 size-3.5 @max-[80rem]/file-viewer:me-0" />

--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -14,7 +14,7 @@ import {
   draggable,
   dropTargetForElements,
 } from "@atlaskit/pragmatic-drag-and-drop/element/adapter";
-import { formatForDisplay, useHotkey } from "@tanstack/react-hotkeys";
+import { useHotkey } from "@tanstack/react-hotkeys";
 import {
   hashKey,
   useInfiniteQuery,
@@ -109,6 +109,7 @@ import {
 import { useChromeQuery, useHasMounted } from "@/hooks/use-chrome-query";
 import { useExternalSyncEffect } from "@/hooks/use-effect";
 import { useGuidesPreviewEnabled } from "@/hooks/use-guides-preview";
+import { useHydrationSafeHotkeyPlatform } from "@/hooks/use-hydration-safe-hotkey-platform";
 import { useInlineRename } from "@/hooks/use-inline-rename";
 import { useLatestCallback } from "@/hooks/use-latest-callback";
 import { usePermissions } from "@/hooks/use-permissions";
@@ -119,7 +120,7 @@ import { useAuthenticatedUser } from "@/lib/authenticated-user-context";
 import { isPlaceholderThreadTitle } from "@/lib/chat-thread-title";
 import { SIDE_RAIL_ICON_BUTTON_SIZE } from "@/lib/consts";
 import { detached } from "@/lib/detached";
-import { NAV_KEY } from "@/lib/hotkeys";
+import { formatHotkeyForPlatform, NAV_KEY } from "@/lib/hotkeys";
 import { knowledgeSections } from "@/lib/knowledge/navigation";
 import { resolveMatterColor } from "@/lib/matter-colors";
 import { usePinnedStore } from "@/lib/pinned-store";
@@ -150,6 +151,7 @@ const GuideHelpDrawer = lazy(async () => {
 
 export const AppSidebar = (props: AppSidebarProps) => {
   const t = useTranslations();
+  const hotkeyPlatform = useHydrationSafeHotkeyPlatform();
   const navigate = routeApi.useNavigate();
   const canCreateMatter = usePermissions({ workspace: ["create"] });
   const canUseStyleSets = usePermissions({ styleSet: ["use"] });
@@ -630,7 +632,10 @@ export const AppSidebar = (props: AppSidebarProps) => {
                         return (
                           <SidebarMenuBadge>
                             <kbd className="text-muted-foreground text-[0.625rem]">
-                              {formatForDisplay(searchHotkey)}
+                              {formatHotkeyForPlatform(
+                                searchHotkey,
+                                hotkeyPlatform,
+                              )}
                             </kbd>
                           </SidebarMenuBadge>
                         );

--- a/apps/web/src/components/keyboard-shortcuts-dialog.tsx
+++ b/apps/web/src/components/keyboard-shortcuts-dialog.tsx
@@ -1,6 +1,6 @@
 import { useId, useState } from "react";
 
-import { formatForDisplay, useHotkeyRecorder } from "@tanstack/react-hotkeys";
+import { useHotkeyRecorder } from "@tanstack/react-hotkeys";
 import type { Hotkey } from "@tanstack/react-hotkeys";
 import { PencilIcon } from "lucide-react";
 import { useTranslations } from "use-intl";
@@ -18,9 +18,11 @@ import { stellaToast } from "@stll/ui/components/toast";
 import { cn } from "@stll/ui/lib/utils";
 
 import { useExternalSyncEffect } from "@/hooks/use-effect";
+import { useHydrationSafeHotkeyPlatform } from "@/hooks/use-hydration-safe-hotkey-platform";
 import { getAnalytics } from "@/lib/analytics/provider";
 import { detached } from "@/lib/detached";
 import {
+  formatHotkeyForPlatform,
   formatShortcutBinding,
   isEditableEventTarget,
   SHOW_SHORTCUTS_KEY,
@@ -159,6 +161,7 @@ const RebindableBinding = ({
   onReset,
 }: RebindableBindingProps) => {
   const t = useTranslations();
+  const hotkeyPlatform = useHydrationSafeHotkeyPlatform();
   const [pending, setPending] = useState<Hotkey | null>(null);
   const [rebindError, setRebindError] = useState<RebindError | null>(null);
   const [isBusy, setIsBusy] = useState(false);
@@ -243,7 +246,7 @@ const RebindableBinding = ({
         <div className="flex items-center gap-2">
           <kbd className="border-primary bg-muted text-foreground min-w-16 rounded border border-dashed px-1.5 py-0.5 text-center text-xs">
             {preview
-              ? formatForDisplay(preview)
+              ? formatHotkeyForPlatform(preview, hotkeyPlatform)
               : t("navigation.shortcutsDialog.pressKeys")}
           </kbd>
           <Button
@@ -282,7 +285,7 @@ const RebindableBinding = ({
         </Button>
       ) : null}
       <kbd className="border-border bg-muted text-muted-foreground rounded border px-1.5 py-0.5 text-xs">
-        {formatShortcutBinding({ type: "hotkey", hotkey })}
+        {formatShortcutBinding({ type: "hotkey", hotkey }, hotkeyPlatform)}
       </kbd>
       <Button
         // Quiet entry affordance: hidden until the row is hovered or receives

--- a/apps/web/src/components/public-workspace-shell.tsx
+++ b/apps/web/src/components/public-workspace-shell.tsx
@@ -1,7 +1,7 @@
 import { lazy, Suspense, useState } from "react";
 import type { ReactNode } from "react";
 
-import { formatForDisplay, useHotkey } from "@tanstack/react-hotkeys";
+import { useHotkey } from "@tanstack/react-hotkeys";
 import {
   Link,
   Outlet,
@@ -38,6 +38,7 @@ import {
 import { StellaWordmark } from "@/components/stella-wordmark";
 import Tooltip from "@/components/tooltip";
 import { getWorkspacePrimaryNavItems } from "@/components/workspace-primary-nav";
+import { useHasMounted } from "@/hooks/use-chrome-query";
 import { useClientAuthStatus } from "@/hooks/use-client-auth-status";
 import { getAnalytics } from "@/lib/analytics/provider";
 import { AuthenticatedUserProvider } from "@/lib/authenticated-user-context";
@@ -47,7 +48,7 @@ import {
   SIDE_RAIL_WIDTH,
   TOOLBAR_ROW_HEIGHT,
 } from "@/lib/consts";
-import { HOTKEYS } from "@/lib/hotkeys";
+import { formatHydrationSafeHotkey, HOTKEYS } from "@/lib/hotkeys";
 import { isPublicLawSsrRouteEnabled } from "@/lib/public-law-launch";
 import { isPublicToolsRouteEnabled } from "@/lib/public-tools-launch";
 import { useCreateMatterStore } from "@/lib/workspaces/create-matter-store";
@@ -169,6 +170,11 @@ const PublicSidebar = ({
   });
   const { state, toggleSidebar } = useSidebar();
   const isCollapsed = state === "collapsed";
+  const mounted = useHasMounted();
+  const searchHotkeyLabel = formatHydrationSafeHotkey({
+    hotkey: HOTKEYS.SEARCH,
+    mounted,
+  });
   const [searchOpen, setSearchOpen] = useState(false);
   // This shell is server-rendered; the localStorage-backed preview
   // toggle is browser-only and would mismatch hydration. The host/env
@@ -249,7 +255,7 @@ const PublicSidebar = ({
                     </SidebarMenuButton>
                     <SidebarMenuBadge>
                       <kbd className="text-muted-foreground text-[0.625rem]">
-                        {formatForDisplay(HOTKEYS.SEARCH)}
+                        {searchHotkeyLabel}
                       </kbd>
                     </SidebarMenuBadge>
                   </SidebarMenuItem>

--- a/apps/web/src/components/public-workspace-shell.tsx
+++ b/apps/web/src/components/public-workspace-shell.tsx
@@ -38,8 +38,8 @@ import {
 import { StellaWordmark } from "@/components/stella-wordmark";
 import Tooltip from "@/components/tooltip";
 import { getWorkspacePrimaryNavItems } from "@/components/workspace-primary-nav";
-import { useHasMounted } from "@/hooks/use-chrome-query";
 import { useClientAuthStatus } from "@/hooks/use-client-auth-status";
+import { useHydrationSafeHotkeyPlatform } from "@/hooks/use-hydration-safe-hotkey-platform";
 import { getAnalytics } from "@/lib/analytics/provider";
 import { AuthenticatedUserProvider } from "@/lib/authenticated-user-context";
 import {
@@ -48,7 +48,7 @@ import {
   SIDE_RAIL_WIDTH,
   TOOLBAR_ROW_HEIGHT,
 } from "@/lib/consts";
-import { formatHydrationSafeHotkey, HOTKEYS } from "@/lib/hotkeys";
+import { formatHotkeyForPlatform, HOTKEYS } from "@/lib/hotkeys";
 import { isPublicLawSsrRouteEnabled } from "@/lib/public-law-launch";
 import { isPublicToolsRouteEnabled } from "@/lib/public-tools-launch";
 import { useCreateMatterStore } from "@/lib/workspaces/create-matter-store";
@@ -170,11 +170,11 @@ const PublicSidebar = ({
   });
   const { state, toggleSidebar } = useSidebar();
   const isCollapsed = state === "collapsed";
-  const mounted = useHasMounted();
-  const searchHotkeyLabel = formatHydrationSafeHotkey({
-    hotkey: HOTKEYS.SEARCH,
-    mounted,
-  });
+  const hotkeyPlatform = useHydrationSafeHotkeyPlatform();
+  const searchHotkeyLabel = formatHotkeyForPlatform(
+    HOTKEYS.SEARCH,
+    hotkeyPlatform,
+  );
   const [searchOpen, setSearchOpen] = useState(false);
   // This shell is server-rendered; the localStorage-backed preview
   // toggle is browser-only and would mismatch hydration. The host/env

--- a/apps/web/src/components/shortcut-echo-hud.tsx
+++ b/apps/web/src/components/shortcut-echo-hud.tsx
@@ -2,6 +2,7 @@ import { useTranslations } from "use-intl";
 
 import { cn } from "@stll/ui/lib/utils";
 
+import { useHydrationSafeHotkeyPlatform } from "@/hooks/use-hydration-safe-hotkey-platform";
 import { formatShortcutBinding } from "@/lib/hotkeys";
 import { useEffectiveShortcutGroups } from "@/lib/use-effective-shortcuts";
 import {
@@ -19,6 +20,7 @@ import type { EchoCandidate } from "@/lib/use-shortcut-echo";
  */
 export const ShortcutEchoHud = () => {
   const t = useTranslations();
+  const hotkeyPlatform = useHydrationSafeHotkeyPlatform();
   const groups = useEffectiveShortcutGroups();
 
   const candidates: EchoCandidate[] = groups.flatMap((group) =>
@@ -55,7 +57,7 @@ export const ShortcutEchoHud = () => {
         key={echo.at}
       >
         <kbd className="border-border bg-muted text-muted-foreground rounded border px-1.5 py-0.5 text-xs">
-          {formatShortcutBinding(active.binding)}
+          {formatShortcutBinding(active.binding, hotkeyPlatform)}
         </kbd>
         <span className="text-foreground text-sm">·</span>
         <span className="text-foreground text-sm">{t(active.labelKey)}</span>

--- a/apps/web/src/hooks/use-hydration-safe-hotkey-platform.ts
+++ b/apps/web/src/hooks/use-hydration-safe-hotkey-platform.ts
@@ -5,7 +5,7 @@ import { detectPlatform } from "@tanstack/react-hotkeys";
 import { resolveHydrationSafeHotkeyPlatform } from "@/lib/hotkeys";
 import type { HotkeyPlatform } from "@/lib/hotkeys";
 
-const subscribeToPlatform = () => () => {};
+const subscribeToPlatform = (_onStoreChange: () => void) => () => undefined;
 
 const getServerPlatform = (): HotkeyPlatform =>
   resolveHydrationSafeHotkeyPlatform({
@@ -23,10 +23,9 @@ const getBrowserPlatform = (): HotkeyPlatform =>
  * Returns the canonical SSR platform through hydration, then the browser's
  * actual platform after mount. Use this for every shortcut rendered as text.
  */
-export const useHydrationSafeHotkeyPlatform = (): HotkeyPlatform => {
-  return useSyncExternalStore(
+export const useHydrationSafeHotkeyPlatform = (): HotkeyPlatform =>
+  useSyncExternalStore(
     subscribeToPlatform,
     getBrowserPlatform,
     getServerPlatform,
   );
-};

--- a/apps/web/src/hooks/use-hydration-safe-hotkey-platform.ts
+++ b/apps/web/src/hooks/use-hydration-safe-hotkey-platform.ts
@@ -1,0 +1,32 @@
+import { useSyncExternalStore } from "react";
+
+import { detectPlatform } from "@tanstack/react-hotkeys";
+
+import { resolveHydrationSafeHotkeyPlatform } from "@/lib/hotkeys";
+import type { HotkeyPlatform } from "@/lib/hotkeys";
+
+const subscribeToPlatform = () => () => {};
+
+const getServerPlatform = (): HotkeyPlatform =>
+  resolveHydrationSafeHotkeyPlatform({
+    status: "pre-mount",
+    detected: detectPlatform(),
+  });
+
+const getBrowserPlatform = (): HotkeyPlatform =>
+  resolveHydrationSafeHotkeyPlatform({
+    status: "mounted",
+    detected: detectPlatform(),
+  });
+
+/**
+ * Returns the canonical SSR platform through hydration, then the browser's
+ * actual platform after mount. Use this for every shortcut rendered as text.
+ */
+export const useHydrationSafeHotkeyPlatform = (): HotkeyPlatform => {
+  return useSyncExternalStore(
+    subscribeToPlatform,
+    getBrowserPlatform,
+    getServerPlatform,
+  );
+};

--- a/apps/web/src/lib/hotkeys.logic.test.ts
+++ b/apps/web/src/lib/hotkeys.logic.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  formatHydrationSafeHotkey,
   formatShortcutBinding,
+  HOTKEYS,
   SHORTCUT_CONTEXTS,
   SHORTCUT_GROUPS,
 } from "@/lib/hotkeys";
@@ -34,6 +36,31 @@ describe("shortcut registry is the single source of truth", () => {
   test("every registry shortcut has a unique, stable id", () => {
     const ids = allShortcuts.map((shortcut) => shortcut.id);
     expect(new Set(ids).size).toBe(ids.length);
+  });
+});
+
+describe("SSR-visible shortcut labels", () => {
+  test("keep the server and first macOS render identical", () => {
+    const serverLabel = formatHydrationSafeHotkey({
+      hotkey: HOTKEYS.SEARCH,
+      mounted: false,
+      platform: "linux",
+    });
+    const firstMacRenderLabel = formatHydrationSafeHotkey({
+      hotkey: HOTKEYS.SEARCH,
+      mounted: false,
+      platform: "mac",
+    });
+
+    expect(serverLabel).toBe("Ctrl+K");
+    expect(firstMacRenderLabel).toBe(serverLabel);
+    expect(
+      formatHydrationSafeHotkey({
+        hotkey: HOTKEYS.SEARCH,
+        mounted: true,
+        platform: "mac",
+      }),
+    ).toBe("⌘ K");
   });
 });
 

--- a/apps/web/src/lib/hotkeys.logic.test.ts
+++ b/apps/web/src/lib/hotkeys.logic.test.ts
@@ -1,16 +1,27 @@
 import { describe, expect, test } from "bun:test";
 
 import {
-  formatHydrationSafeHotkey,
+  formatHotkeyForPlatform,
   formatShortcutBinding,
   HOTKEYS,
+  resolveHydrationSafeHotkeyPlatform,
   SHORTCUT_CONTEXTS,
   SHORTCUT_GROUPS,
+  SSR_HOTKEY_PLATFORM,
 } from "@/lib/hotkeys";
+import type { HotkeyPlatform } from "@/lib/hotkeys";
 import {
   collectShortcutCandidates,
   findContextCollisions,
 } from "@/lib/shortcut-overrides";
+
+const HOTKEY_PLATFORM_BY_NAME = {
+  mac: "mac",
+  windows: "windows",
+  linux: "linux",
+} as const satisfies Record<HotkeyPlatform, HotkeyPlatform>;
+
+const HOTKEY_PLATFORMS = Object.values(HOTKEY_PLATFORM_BY_NAME);
 
 const allShortcuts = SHORTCUT_GROUPS.flatMap((group) =>
   group.shortcuts.map((shortcut) => ({
@@ -29,7 +40,11 @@ describe("shortcut registry is the single source of truth", () => {
     expect(new Set(rows).size).toBe(rows.length);
 
     for (const shortcut of allShortcuts) {
-      expect(formatShortcutBinding(shortcut.binding).length).toBeGreaterThan(0);
+      for (const platform of HOTKEY_PLATFORMS) {
+        expect(
+          formatShortcutBinding(shortcut.binding, platform).length,
+        ).toBeGreaterThan(0);
+      }
     }
   });
 
@@ -40,27 +55,54 @@ describe("shortcut registry is the single source of truth", () => {
 });
 
 describe("SSR-visible shortcut labels", () => {
-  test("keep the server and first macOS render identical", () => {
-    const serverLabel = formatHydrationSafeHotkey({
-      hotkey: HOTKEYS.SEARCH,
-      mounted: false,
-      platform: "linux",
-    });
-    const firstMacRenderLabel = formatHydrationSafeHotkey({
-      hotkey: HOTKEYS.SEARCH,
-      mounted: false,
-      platform: "mac",
-    });
+  test("stay identical for every registered shortcut and platform pair", () => {
+    const hotkeys = Object.values(HOTKEYS);
 
-    expect(serverLabel).toBe("Ctrl+K");
-    expect(firstMacRenderLabel).toBe(serverLabel);
-    expect(
-      formatHydrationSafeHotkey({
-        hotkey: HOTKEYS.SEARCH,
-        mounted: true,
-        platform: "mac",
-      }),
-    ).toBe("⌘ K");
+    for (const hotkey of hotkeys) {
+      for (const serverPlatform of HOTKEY_PLATFORMS) {
+        expect(
+          resolveHydrationSafeHotkeyPlatform({
+            status: "pre-mount",
+            detected: serverPlatform,
+          }),
+        ).toBe(SSR_HOTKEY_PLATFORM);
+        const serverLabel = formatHotkeyForPlatform(
+          hotkey,
+          resolveHydrationSafeHotkeyPlatform({
+            status: "pre-mount",
+            detected: serverPlatform,
+          }),
+        );
+
+        for (const clientPlatform of HOTKEY_PLATFORMS) {
+          expect(
+            resolveHydrationSafeHotkeyPlatform({
+              status: "mounted",
+              detected: clientPlatform,
+            }),
+          ).toBe(clientPlatform);
+          const firstClientLabel = formatHotkeyForPlatform(
+            hotkey,
+            resolveHydrationSafeHotkeyPlatform({
+              status: "pre-mount",
+              detected: clientPlatform,
+            }),
+          );
+          const mountedClientLabel = formatHotkeyForPlatform(
+            hotkey,
+            resolveHydrationSafeHotkeyPlatform({
+              status: "mounted",
+              detected: clientPlatform,
+            }),
+          );
+
+          expect(firstClientLabel).toBe(serverLabel);
+          expect(mountedClientLabel).toBe(
+            formatHotkeyForPlatform(hotkey, clientPlatform),
+          );
+        }
+      }
+    }
   });
 });
 

--- a/apps/web/src/lib/hotkeys.ts
+++ b/apps/web/src/lib/hotkeys.ts
@@ -191,6 +191,27 @@ export type ShortcutGroup = {
   readonly shortcuts: readonly ShortcutDescriptor[];
 };
 
+type HydrationSafeHotkeyOptions = {
+  hotkey: Hotkey;
+  mounted: boolean;
+  platform?: ReturnType<typeof detectPlatform>;
+};
+
+/**
+ * Format an SSR-visible shortcut without letting the server and the first
+ * browser render observe different operating systems. The browser switches to
+ * its real platform only after mount, when changing text can no longer break
+ * hydration.
+ */
+export const formatHydrationSafeHotkey = ({
+  hotkey,
+  mounted,
+  platform,
+}: HydrationSafeHotkeyOptions): string =>
+  formatForDisplay(hotkey, {
+    platform: mounted ? (platform ?? detectPlatform()) : "linux",
+  });
+
 /**
  * Format a shortcut's full, platform-correct key combo for display in the
  * cheatsheet (e.g. `⌘K` on macOS, `Ctrl+K` elsewhere).

--- a/apps/web/src/lib/hotkeys.ts
+++ b/apps/web/src/lib/hotkeys.ts
@@ -191,33 +191,39 @@ export type ShortcutGroup = {
   readonly shortcuts: readonly ShortcutDescriptor[];
 };
 
-type HydrationSafeHotkeyOptions = {
-  hotkey: Hotkey;
-  mounted: boolean;
-  platform?: ReturnType<typeof detectPlatform>;
-};
+export type HotkeyPlatform = ReturnType<typeof detectPlatform>;
+
+export const SSR_HOTKEY_PLATFORM: HotkeyPlatform = "linux";
+
+export type HotkeyPlatformState =
+  | { readonly status: "pre-mount"; readonly detected: HotkeyPlatform }
+  | { readonly status: "mounted"; readonly detected: HotkeyPlatform };
 
 /**
- * Format an SSR-visible shortcut without letting the server and the first
- * browser render observe different operating systems. The browser switches to
- * its real platform only after mount, when changing text can no longer break
- * hydration.
+ * The server and first browser render always use one canonical platform.
+ * Once mounted, labels can safely switch to the browser's detected platform.
  */
-export const formatHydrationSafeHotkey = ({
-  hotkey,
-  mounted,
-  platform,
-}: HydrationSafeHotkeyOptions): string =>
-  formatForDisplay(hotkey, {
-    platform: mounted ? (platform ?? detectPlatform()) : "linux",
-  });
+export const resolveHydrationSafeHotkeyPlatform = (
+  state: HotkeyPlatformState,
+): HotkeyPlatform =>
+  state.status === "mounted" ? state.detected : SSR_HOTKEY_PLATFORM;
+
+export const formatHotkeyForPlatform = (
+  hotkey: Hotkey,
+  platform: HotkeyPlatform,
+): string => formatForDisplay(hotkey, { platform });
 
 /**
- * Format a shortcut's full, platform-correct key combo for display in the
- * cheatsheet (e.g. `⌘K` on macOS, `Ctrl+K` elsewhere).
+ * Format a shortcut's full, platform-correct key combo for display. Callers
+ * must pass the platform returned by useHydrationSafeHotkeyPlatform().
  */
-export const formatShortcutBinding = (binding: ShortcutBinding): string =>
-  binding.type === "hotkey" ? formatForDisplay(binding.hotkey) : binding.char;
+export const formatShortcutBinding = (
+  binding: ShortcutBinding,
+  platform: HotkeyPlatform,
+): string =>
+  binding.type === "hotkey"
+    ? formatHotkeyForPlatform(binding.hotkey, platform)
+    : binding.char;
 
 /**
  * Whether a keyboard event originates from a text-entry control. Global

--- a/apps/web/src/routes/onboarding/-components/sidebar-preview.tsx
+++ b/apps/web/src/routes/onboarding/-components/sidebar-preview.tsx
@@ -1,7 +1,6 @@
 import type { ReactNode } from "react";
 import { useState } from "react";
 
-import { formatForDisplay } from "@tanstack/react-hotkeys";
 import {
   BookOpenIcon,
   MessageSquareIcon,
@@ -19,7 +18,8 @@ import { getProviderIcon } from "@/components/ai-provider-icons";
 import { MatterIcon, MattersNavIcon } from "@/components/matter-icon";
 import { StellaWordmark } from "@/components/stella-wordmark";
 import { useMountEffect } from "@/hooks/use-effect";
-import { HOTKEYS } from "@/lib/hotkeys";
+import { useHydrationSafeHotkeyPlatform } from "@/hooks/use-hydration-safe-hotkey-platform";
+import { formatHotkeyForPlatform, HOTKEYS } from "@/lib/hotkeys";
 
 type SidebarPreviewProps = {
   organizationName: string;
@@ -92,6 +92,7 @@ export const SidebarPreview = ({
 }: SidebarPreviewProps) => {
   const t = useTranslations();
   const tOrganization = useTranslations("organization");
+  const hotkeyPlatform = useHydrationSafeHotkeyPlatform();
   const showChatActive = chatActive || aiProviders.length > 0;
   // Single shared pulse state so every dot blinks in lockstep,
   // regardless of when each row mounted.
@@ -130,7 +131,7 @@ export const SidebarPreview = ({
           label={t("navigation.search")}
           trailing={
             <kbd className="text-foreground-strong-muted text-[0.625rem]">
-              {formatForDisplay(HOTKEYS.SEARCH)}
+              {formatHotkeyForPlatform(HOTKEYS.SEARCH, hotkeyPlatform)}
             </kbd>
           }
         />

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -48,6 +48,9 @@ const fixtureRuleOverrides = [
   fixtureRuleOverride("no-inline-style-colors.fixture.ts", [
     "no-inline-style-colors/no-inline-style-colors",
   ]),
+  fixtureRuleOverride("no-ambient-hotkey-format.fixture.ts", [
+    "no-ambient-hotkey-format/no-ambient-hotkey-format",
+  ]),
   fixtureRuleOverride("no-offset-pagination.fixture.ts", [
     "no-offset-pagination/no-offset-pagination",
   ]),
@@ -548,6 +551,7 @@ export default defineConfig({
     "./.oxlint-plugins/no-unformatted-number.ts",
     "./.oxlint-plugins/no-raw-foreground-opacity.ts",
     "./.oxlint-plugins/no-inline-style-colors.ts",
+    "./.oxlint-plugins/no-ambient-hotkey-format.ts",
     "./.oxlint-plugins/no-physical-properties.ts",
     "./.oxlint-plugins/no-body-ownership-ids.ts",
     "./.oxlint-plugins/no-raw-error-logging.ts",
@@ -1340,6 +1344,12 @@ export default defineConfig({
       ],
       rules: {
         "no-disabled-tooltip-trigger/no-disabled-tooltip-trigger": "error",
+      },
+    },
+    {
+      files: ["apps/web/src/**/*.{ts,tsx}"],
+      rules: {
+        "no-ambient-hotkey-format/no-ambient-hotkey-format": "error",
       },
     },
     {


### PR DESCRIPTION
Prevents OS-dependent shortcut labels from differing between the server render and browser hydration. A shared platform adapter now gives every render-time shortcut formatter a canonical server snapshot, then switches to macOS, Windows, or Linux after hydration.

Migrates every current shortcut-label surface and adds a lint guard that rejects future ambient `detectPlatform` or `formatForDisplay` imports outside the adapter. Regression coverage exercises every registered shortcut across all server/client platform pairs.

The public-law staging smoke now emulates macOS and scopes its accessible-title assertion so source documents may contain their own level-one heading.

CC on behalf of jan-kubica

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Keyboard shortcut labels now automatically use platform-appropriate formatting, including navigation, search, accept and reject actions.
  * Shortcut displays remain consistent during page loading and hydration across supported platforms.

* **Bug Fixes**
  * Resolved platform-specific hydration issues that could cause shortcut labels or headings to render inconsistently.

* **Tests**
  * Expanded coverage for platform-specific shortcut formatting and staging behaviour, including macOS scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->