### PR TITLE
feat: add route crash recovery diagnostics

### DIFF
--- a/apps/web/src/components/inspector/inspector-rail.tsx
+++ b/apps/web/src/components/inspector/inspector-rail.tsx
@@ -87,7 +87,7 @@ export const InspectorRail = ({
   const t = useTranslations();
   const inspectorState = inspectorDiagnosticState(tabs.length, minimized);
   useExternalSyncEffect(
-    () => routeErrorLifecycle.updateInspectorState(inspectorState),
+    () => routeErrorLifecycle?.updateInspectorState(inspectorState),
     [routeErrorLifecycle, inspectorState],
   );
   const activeTab = tabs.find((tab) => tab.id === activeId);

--- a/apps/web/src/components/inspector/inspector-rail.tsx
+++ b/apps/web/src/components/inspector/inspector-rail.tsx
@@ -86,10 +86,10 @@ export const InspectorRail = ({
   });
   const t = useTranslations();
   const inspectorState = inspectorDiagnosticState(tabs.length, minimized);
-  useExternalSyncEffect(
-    () => routeErrorLifecycle?.updateInspectorState(inspectorState),
-    [routeErrorLifecycle, inspectorState],
-  );
+  useExternalSyncEffect(() => {
+    routeErrorLifecycle?.updateInspectorState(inspectorState);
+    return () => routeErrorLifecycle?.updateInspectorState("unavailable");
+  }, [routeErrorLifecycle, inspectorState]);
   const activeTab = tabs.find((tab) => tab.id === activeId);
   const activeOrganizationId = useAuthenticatedUser().activeOrganizationId;
   const { data: activeSkillCatalogueData } = useQuery({

--- a/apps/web/src/components/inspector/inspector-rail.tsx
+++ b/apps/web/src/components/inspector/inspector-rail.tsx
@@ -1,7 +1,7 @@
 import { useRef } from "react";
 
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { useNavigate, useRouteContext } from "@tanstack/react-router";
+import { useNavigate, useRouter } from "@tanstack/react-router";
 import {
   FileTextIcon,
   MessageSquareIcon,
@@ -53,15 +53,12 @@ export const InspectorRail = ({
   tabs,
   workspaceId,
 }: InspectorRailProps) => {
-  const routeErrorLifecycle = useRouteContext({
-    select: (context) => context.routeErrorLifecycle,
-    strict: false,
-  });
+  const routeErrorLifecycle = useRouter().options.context.routeErrorLifecycle;
   const t = useTranslations();
   const inspectorState = inspectorDiagnosticState(tabs.length, minimized);
   useExternalSyncEffect(() => {
-    routeErrorLifecycle?.updateInspectorState(inspectorState);
-    return () => routeErrorLifecycle?.updateInspectorState("unavailable");
+    routeErrorLifecycle.updateInspectorState(inspectorState);
+    return () => routeErrorLifecycle.updateInspectorState("unavailable");
   }, [routeErrorLifecycle, inspectorState]);
   const activeTab = tabs.find((tab) => tab.id === activeId);
   const activeOrganizationId = useAuthenticatedUser().activeOrganizationId;

--- a/apps/web/src/components/inspector/inspector-rail.tsx
+++ b/apps/web/src/components/inspector/inspector-rail.tsx
@@ -1,7 +1,7 @@
 import { useRef } from "react";
 
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { useNavigate } from "@tanstack/react-router";
+import { useNavigate, useRouteContext } from "@tanstack/react-router";
 import {
   FileTextIcon,
   MessageSquareIcon,
@@ -63,6 +63,13 @@ type InspectorRailProps = {
   workspaceId?: string | undefined;
 };
 
+const inspectorDiagnosticState = (tabCount: number, minimized: boolean) => {
+  if (tabCount === 0) {
+    return "empty";
+  }
+  return minimized ? "minimized" : "open";
+};
+
 export const InspectorRail = ({
   activeId,
   minimized,
@@ -73,7 +80,16 @@ export const InspectorRail = ({
   tabs,
   workspaceId,
 }: InspectorRailProps) => {
+  const routeErrorLifecycle = useRouteContext({
+    select: (context) => context.routeErrorLifecycle,
+    strict: false,
+  });
   const t = useTranslations();
+  const inspectorState = inspectorDiagnosticState(tabs.length, minimized);
+  useExternalSyncEffect(
+    () => routeErrorLifecycle.updateInspectorState(inspectorState),
+    [routeErrorLifecycle, inspectorState],
+  );
   const activeTab = tabs.find((tab) => tab.id === activeId);
   const activeOrganizationId = useAuthenticatedUser().activeOrganizationId;
   const { data: activeSkillCatalogueData } = useQuery({

--- a/apps/web/src/components/inspector/inspector-rail.tsx
+++ b/apps/web/src/components/inspector/inspector-rail.tsx
@@ -43,33 +43,6 @@ import {
 import { mcpConnectorsOptions } from "@/lib/knowledge/queries";
 import { catalogueOptions } from "@/lib/knowledge/queries/catalogue";
 
-type InspectorRailProps = {
-  activeId: string | null;
-  minimized: boolean;
-  onActivateTab: (tabId: string) => void;
-  onCloseTab: (tabId: string) => void;
-  onOpenChat: (
-    args?: Parameters<
-      (args?: {
-        label?: string;
-        workspaceId?: string | undefined;
-        contextMatterIds?: string[];
-        activeSkill?: ChatTab["activeSkill"];
-      }) => void
-    >[0],
-  ) => void;
-  onSetMinimized: (minimized: boolean) => void;
-  tabs: InspectorTab[];
-  workspaceId?: string | undefined;
-};
-
-const inspectorDiagnosticState = (tabCount: number, minimized: boolean) => {
-  if (tabCount === 0) {
-    return "empty";
-  }
-  return minimized ? "minimized" : "open";
-};
-
 export const InspectorRail = ({
   activeId,
   minimized,
@@ -219,6 +192,33 @@ export const InspectorRail = ({
       </div>
     </div>
   );
+};
+
+type InspectorRailProps = {
+  activeId: string | null;
+  minimized: boolean;
+  onActivateTab: (tabId: string) => void;
+  onCloseTab: (tabId: string) => void;
+  onOpenChat: (
+    args?: Parameters<
+      (args?: {
+        label?: string;
+        workspaceId?: string | undefined;
+        contextMatterIds?: string[];
+        activeSkill?: ChatTab["activeSkill"];
+      }) => void
+    >[0],
+  ) => void;
+  onSetMinimized: (minimized: boolean) => void;
+  tabs: InspectorTab[];
+  workspaceId?: string | undefined;
+};
+
+const inspectorDiagnosticState = (tabCount: number, minimized: boolean) => {
+  if (tabCount === 0) {
+    return "empty";
+  }
+  return minimized ? "minimized" : "open";
 };
 
 /** Extract a short abbreviation from a filename (stem, not extension). */

--- a/apps/web/src/components/inspector/inspector-rail.tsx
+++ b/apps/web/src/components/inspector/inspector-rail.tsx
@@ -1,7 +1,7 @@
 import { useRef } from "react";
 
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { useNavigate, useRouter } from "@tanstack/react-router";
+import { useNavigate } from "@tanstack/react-router";
 import {
   FileTextIcon,
   MessageSquareIcon,
@@ -34,6 +34,7 @@ import { MatterIcon } from "@/components/matter-icon";
 import Tooltip from "@/components/tooltip";
 import { EntityKindIcon } from "@/components/workspaces/entity-kind-icon";
 import { useExternalSyncEffect } from "@/hooks/use-effect";
+import { useRouteErrorLifecycle } from "@/lib/analytics/route-error-lifecycle-context";
 import { useAuthenticatedUser } from "@/lib/authenticated-user-context";
 import {
   SIDE_RAIL_CONTAINER_CLASS,
@@ -53,7 +54,7 @@ export const InspectorRail = ({
   tabs,
   workspaceId,
 }: InspectorRailProps) => {
-  const routeErrorLifecycle = useRouter().options.context.routeErrorLifecycle;
+  const routeErrorLifecycle = useRouteErrorLifecycle();
   const t = useTranslations();
   const inspectorState = inspectorDiagnosticState(tabs.length, minimized);
   useExternalSyncEffect(() => {

--- a/apps/web/src/components/route-components.logic.test.ts
+++ b/apps/web/src/components/route-components.logic.test.ts
@@ -34,7 +34,7 @@ describe("route error recovery", () => {
       error: new TypeError(
         "Failed to fetch dynamically imported module: https://example.test/chunk.js",
       ),
-      recordRetryStarted: () =>
+      recordRetryStarted: async () =>
         new Promise<void>((resolve) => {
           actions.push("record");
           finishRecording = resolve;
@@ -58,9 +58,8 @@ describe("route error recovery", () => {
 
     await recoverRouteError({
       error: new TypeError("Cannot read properties of null"),
-      recordRetryStarted: () => {
+      recordRetryStarted: async () => {
         actions.push("record");
-        return Promise.resolve();
       },
       reloadPage: () => {
         actions.push("reload");

--- a/apps/web/src/components/route-components.logic.test.ts
+++ b/apps/web/src/components/route-components.logic.test.ts
@@ -26,13 +26,19 @@ describe("route error recovery", () => {
     }
   });
 
-  test("hard reloads instead of retrying a cached rejected import", () => {
+  test("records the retry before reloading a cached rejected import", async () => {
     const actions: string[] = [];
+    let finishRecording: () => void = () => undefined;
 
-    recoverRouteError({
+    const recovery = recoverRouteError({
       error: new TypeError(
         "Failed to fetch dynamically imported module: https://example.test/chunk.js",
       ),
+      recordRetryStarted: () =>
+        new Promise<void>((resolve) => {
+          actions.push("record");
+          finishRecording = resolve;
+        }),
       reloadPage: () => {
         actions.push("reload");
       },
@@ -41,14 +47,21 @@ describe("route error recovery", () => {
       },
     });
 
-    expect(actions).toEqual(["reload"]);
+    expect(actions).toEqual(["record"]);
+    finishRecording();
+    await recovery;
+    expect(actions).toEqual(["record", "reload"]);
   });
 
-  test("keeps ordinary route errors on the in-app retry path", () => {
+  test("keeps ordinary route errors on the in-app retry path", async () => {
     const actions: string[] = [];
 
-    recoverRouteError({
+    await recoverRouteError({
       error: new TypeError("Cannot read properties of null"),
+      recordRetryStarted: () => {
+        actions.push("record");
+        return Promise.resolve();
+      },
       reloadPage: () => {
         actions.push("reload");
       },
@@ -57,7 +70,7 @@ describe("route error recovery", () => {
       },
     });
 
-    expect(actions).toEqual(["retry"]);
+    expect(actions).toEqual(["record", "retry"]);
   });
 });
 

--- a/apps/web/src/components/route-components.logic.ts
+++ b/apps/web/src/components/route-components.logic.ts
@@ -50,23 +50,29 @@ export const resolveRouteErrorRecovery = (
 
 type RecoverRouteErrorOptions = {
   error: unknown;
+  recordRetryStarted: (
+    recovery: RouteErrorRecovery["type"],
+  ) => Promise<void>;
   reloadPage: () => void;
   retryRoute: () => void;
 };
 
 export const recoverRouteError = ({
   error,
+  recordRetryStarted,
   reloadPage,
   retryRoute,
-}: RecoverRouteErrorOptions): void => {
+}: RecoverRouteErrorOptions): Promise<void> => {
   const recovery = resolveRouteErrorRecovery(error);
+  const retryDispatch = recordRetryStarted(recovery.type);
   switch (recovery.type) {
-    case "reload-page":
-      reloadPage();
-      return;
-    case "retry-route":
+    case "reload-page": {
+      return retryDispatch.then(reloadPage);
+    }
+    case "retry-route": {
       retryRoute();
-      return;
+      return retryDispatch;
+    }
     default: {
       const exhaustive: never = recovery;
       return exhaustive;

--- a/apps/web/src/components/route-components.logic.ts
+++ b/apps/web/src/components/route-components.logic.ts
@@ -50,14 +50,12 @@ export const resolveRouteErrorRecovery = (
 
 type RecoverRouteErrorOptions = {
   error: unknown;
-  recordRetryStarted: (
-    recovery: RouteErrorRecovery["type"],
-  ) => Promise<void>;
+  recordRetryStarted: (recovery: RouteErrorRecovery["type"]) => Promise<void>;
   reloadPage: () => void;
   retryRoute: () => void;
 };
 
-export const recoverRouteError = ({
+export const recoverRouteError = async ({
   error,
   recordRetryStarted,
   reloadPage,
@@ -67,11 +65,14 @@ export const recoverRouteError = ({
   const retryDispatch = recordRetryStarted(recovery.type);
   switch (recovery.type) {
     case "reload-page": {
-      return retryDispatch.then(reloadPage);
+      await retryDispatch;
+      reloadPage();
+      return;
     }
     case "retry-route": {
       retryRoute();
-      return retryDispatch;
+      await retryDispatch;
+      return;
     }
     default: {
       const exhaustive: never = recovery;

--- a/apps/web/src/components/route-components.tsx
+++ b/apps/web/src/components/route-components.tsx
@@ -1,7 +1,7 @@
 import { useState, useTransition } from "react";
 
 import { CancelledError, useQueryClient } from "@tanstack/react-query";
-import { Link, Navigate } from "@tanstack/react-router";
+import { Link, Navigate, useRouteContext } from "@tanstack/react-router";
 import type { ErrorComponentProps } from "@tanstack/react-router";
 import { CopyIcon, MailIcon, RefreshCcwIcon } from "lucide-react";
 import { useTranslations } from "use-intl";
@@ -15,6 +15,7 @@ import {
   buildErrorReportMailto,
   isNetworkError,
   recoverRouteError,
+  resolveRouteErrorRecovery,
   resolveRouteErrorSupport,
 } from "@/components/route-components.logic";
 import { StellaMark } from "@/components/stella-mark";
@@ -220,8 +221,13 @@ const UnexpectedRouteError = ({
   retry,
 }: UnexpectedRouteErrorProps) => {
   const analytics = useAnalytics();
+  const routeErrorLifecycle = useRouteContext({
+    from: "__root__",
+    select: (context) => context.routeErrorLifecycle,
+  });
   const t = useTranslations();
   const [errorReference] = useState(createErrorReference);
+  const recovery = resolveRouteErrorRecovery(routeError);
   const support = resolveRouteErrorSupport({
     deployment: env.VITE_SELFHOST ? "selfHosted" : "hosted",
     feedbackRecipient: env.VITE_FEEDBACK_EMAIL_TO,
@@ -243,12 +249,15 @@ const UnexpectedRouteError = ({
     }
   }
 
-  useExternalSyncEffect(() => {
-    analytics.captureError(routeError, {
-      type: "recovery",
-      reference: errorReference,
-    });
-  }, [analytics, routeError, errorReference]);
+  useExternalSyncEffect(
+    () =>
+      routeErrorLifecycle.shown({
+        error: routeError,
+        recovery: recovery.type,
+        reference: errorReference,
+      }),
+    [routeErrorLifecycle, routeError, errorReference, recovery.type],
+  );
 
   const handleCopyReference = async () => {
     try {
@@ -270,6 +279,7 @@ const UnexpectedRouteError = ({
       : null;
 
   const handleRecovery = () => {
+    routeErrorLifecycle.retryStarted(errorReference, recovery.type);
     recoverRouteError({
       error: routeError,
       reloadPage: () => window.location.reload(),

--- a/apps/web/src/components/route-components.tsx
+++ b/apps/web/src/components/route-components.tsx
@@ -1,7 +1,7 @@
 import { useState, useTransition } from "react";
 
 import { CancelledError, useQueryClient } from "@tanstack/react-query";
-import { Link, Navigate, useRouter } from "@tanstack/react-router";
+import { Link, Navigate } from "@tanstack/react-router";
 import type { ErrorComponentProps } from "@tanstack/react-router";
 import { CopyIcon, MailIcon, RefreshCcwIcon } from "lucide-react";
 import { useTranslations } from "use-intl";
@@ -25,6 +25,7 @@ import { useLatestCallback } from "@/hooks/use-latest-callback";
 import { useSignOut } from "@/hooks/use-sign-out";
 import { createErrorReference } from "@/lib/analytics/error-reference";
 import { useAnalytics } from "@/lib/analytics/provider";
+import { useRouteErrorLifecycle } from "@/lib/analytics/route-error-lifecycle-context";
 import { detached } from "@/lib/detached";
 import { isMemberError, isUnauthorizedError } from "@/lib/errors/auth";
 import { sanitizeHref } from "@/lib/sanitize-href";
@@ -221,7 +222,7 @@ const UnexpectedRouteError = ({
   retry,
 }: UnexpectedRouteErrorProps) => {
   const analytics = useAnalytics();
-  const routeErrorLifecycle = useRouter().options.context.routeErrorLifecycle;
+  const routeErrorLifecycle = useRouteErrorLifecycle();
   const t = useTranslations();
   const [errorReference] = useState(createErrorReference);
   const recovery = resolveRouteErrorRecovery(routeError);

--- a/apps/web/src/components/route-components.tsx
+++ b/apps/web/src/components/route-components.tsx
@@ -250,12 +250,13 @@ const UnexpectedRouteError = ({
   }
 
   useExternalSyncEffect(
-    () =>
+    () => {
       routeErrorLifecycle.shown({
         error: routeError,
         recovery: recovery.type,
         reference: errorReference,
-      }),
+      });
+    },
     [routeErrorLifecycle, routeError, errorReference, recovery.type],
   );
 
@@ -279,9 +280,10 @@ const UnexpectedRouteError = ({
       : null;
 
   const handleRecovery = () => {
-    routeErrorLifecycle.retryStarted(errorReference, recovery.type);
-    recoverRouteError({
+    void recoverRouteError({
       error: routeError,
+      recordRetryStarted: (recoveryType) =>
+        routeErrorLifecycle.retryStarted(errorReference, recoveryType),
       reloadPage: () => window.location.reload(),
       retryRoute: retry,
     });

--- a/apps/web/src/components/route-components.tsx
+++ b/apps/web/src/components/route-components.tsx
@@ -1,7 +1,7 @@
 import { useState, useTransition } from "react";
 
 import { CancelledError, useQueryClient } from "@tanstack/react-query";
-import { Link, Navigate, useRouteContext } from "@tanstack/react-router";
+import { Link, Navigate, useRouter } from "@tanstack/react-router";
 import type { ErrorComponentProps } from "@tanstack/react-router";
 import { CopyIcon, MailIcon, RefreshCcwIcon } from "lucide-react";
 import { useTranslations } from "use-intl";
@@ -221,10 +221,7 @@ const UnexpectedRouteError = ({
   retry,
 }: UnexpectedRouteErrorProps) => {
   const analytics = useAnalytics();
-  const routeErrorLifecycle = useRouteContext({
-    from: "__root__",
-    select: (context) => context.routeErrorLifecycle,
-  });
+  const routeErrorLifecycle = useRouter().options.context.routeErrorLifecycle;
   const t = useTranslations();
   const [errorReference] = useState(createErrorReference);
   const recovery = resolveRouteErrorRecovery(routeError);
@@ -249,16 +246,13 @@ const UnexpectedRouteError = ({
     }
   }
 
-  useExternalSyncEffect(
-    () => {
-      routeErrorLifecycle.shown({
-        error: routeError,
-        recovery: recovery.type,
-        reference: errorReference,
-      });
-    },
-    [routeErrorLifecycle, routeError, errorReference, recovery.type],
-  );
+  useExternalSyncEffect(() => {
+    routeErrorLifecycle.shown({
+      error: routeError,
+      recovery: recovery.type,
+      reference: errorReference,
+    });
+  }, [routeErrorLifecycle, routeError, errorReference, recovery.type]);
 
   const handleCopyReference = async () => {
     try {
@@ -280,13 +274,16 @@ const UnexpectedRouteError = ({
       : null;
 
   const handleRecovery = () => {
-    void recoverRouteError({
-      error: routeError,
-      recordRetryStarted: (recoveryType) =>
-        routeErrorLifecycle.retryStarted(errorReference, recoveryType),
-      reloadPage: () => window.location.reload(),
-      retryRoute: retry,
-    });
+    detached(
+      recoverRouteError({
+        error: routeError,
+        recordRetryStarted: async (recoveryType) =>
+          routeErrorLifecycle.retryStarted(errorReference, recoveryType),
+        reloadPage: () => window.location.reload(),
+        retryRoute: retry,
+      }),
+      "route-error.recover",
+    );
   };
 
   return (

--- a/apps/web/src/lib/analytics/error-diagnostics.test.ts
+++ b/apps/web/src/lib/analytics/error-diagnostics.test.ts
@@ -10,6 +10,15 @@ const errorWithStack = (message: string, stack: string) => {
 };
 
 describe("browser error diagnostics", () => {
+  test("emits the analytics fingerprint format", () => {
+    const error = errorWithStack(
+      "redacted",
+      "at https://staging.stll.app/assets/case-viewer-A1b2.js:42:7",
+    );
+
+    expect(fingerprintTelemetryError(error)).toMatch(/^ERRFP-[0-9A-F]{8}$/u);
+  });
+
   test("fingerprints a compiled asset frame without using the message", () => {
     const first = errorWithStack(
       "Client Smith privileged decision",

--- a/apps/web/src/lib/analytics/error-diagnostics.test.ts
+++ b/apps/web/src/lib/analytics/error-diagnostics.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "bun:test";
+
+import { telemetryErrorType } from "./error-diagnostics";
+import { fingerprintTelemetryError } from "./error-fingerprint";
+
+const errorWithStack = (message: string, stack: string) => {
+  const error = new TypeError(message);
+  error.stack = stack;
+  return error;
+};
+
+describe("browser error diagnostics", () => {
+  test("fingerprints a compiled asset frame without using the message", () => {
+    const first = errorWithStack(
+      "Client Smith privileged decision",
+      "TypeError: private\n at render (https://staging.stll.app/assets/case-viewer-A1b2.js:42:7)",
+    );
+    const second = errorWithStack(
+      "Different privileged decision",
+      "TypeError: other\n at render (https://staging.stll.app/assets/case-viewer-A1b2.js:42:7)",
+    );
+
+    expect(fingerprintTelemetryError(first)).toBe(
+      fingerprintTelemetryError(second),
+    );
+  });
+
+  test("distinguishes compiled asset positions", () => {
+    const first = errorWithStack(
+      "redacted",
+      "at https://staging.stll.app/assets/case-viewer-A1b2.js:42:7",
+    );
+    const second = errorWithStack(
+      "redacted",
+      "at https://staging.stll.app/assets/case-viewer-A1b2.js:43:7",
+    );
+
+    expect(fingerprintTelemetryError(first)).not.toBe(
+      fingerprintTelemetryError(second),
+    );
+  });
+
+  test("ignores private non-asset paths and normalizes custom names", () => {
+    const first = errorWithStack(
+      "redacted",
+      "at https://staging.stll.app/workspaces/private-matter/Client-Smith:42:7",
+    );
+    first.name = "Client Smith privileged dispute";
+    const second = errorWithStack(
+      "redacted",
+      "at https://staging.stll.app/workspaces/another-matter/Other-Client:1:2",
+    );
+    second.name = "Other Client secret";
+
+    expect(telemetryErrorType(first)).toBe("UnknownError");
+    expect(fingerprintTelemetryError(first)).toBe(
+      fingerprintTelemetryError(second),
+    );
+  });
+});

--- a/apps/web/src/lib/analytics/error-diagnostics.ts
+++ b/apps/web/src/lib/analytics/error-diagnostics.ts
@@ -1,0 +1,9 @@
+const SAFE_ERROR_TYPE = /^[A-Za-z][\w.-]{0,79}$/u;
+
+export const normalizeTelemetryErrorTypeName = (candidate: string): string =>
+  SAFE_ERROR_TYPE.test(candidate) ? candidate : "UnknownError";
+
+export const telemetryErrorType = (error: unknown): string => {
+  const candidate = error instanceof Error ? error.name : typeof error;
+  return normalizeTelemetryErrorTypeName(candidate);
+};

--- a/apps/web/src/lib/analytics/error-fingerprint.ts
+++ b/apps/web/src/lib/analytics/error-fingerprint.ts
@@ -1,0 +1,22 @@
+import { telemetryErrorType } from "@/lib/analytics/error-diagnostics";
+
+const FIRST_PARTY_ASSET_FRAME =
+  /\/assets\/([A-Za-z0-9._-]{1,160}\.(?:js|mjs)):(\d{1,7}):(\d{1,7})/u;
+
+const stableHash = (value: string): string => {
+  let hash = 0;
+  for (const character of value) {
+    hash = (hash * 31 + (character.codePointAt(0) ?? 0)) % 4_294_967_296;
+  }
+  return hash.toString(16).padStart(8, "0").toUpperCase();
+};
+
+/** Only an error type and compiled first-party asset position influence this hash. */
+export const fingerprintTelemetryError = (error: unknown): string => {
+  const stack = error instanceof Error ? error.stack : undefined;
+  const frame = stack?.slice(0, 20_000).match(FIRST_PARTY_ASSET_FRAME);
+  const safeFrame = frame
+    ? `${frame[1]}:${frame[2]}:${frame[3]}`
+    : "no-first-party-frame";
+  return `ERRFP-${stableHash(`${telemetryErrorType(error)}|${safeFrame}`)}`;
+};

--- a/apps/web/src/lib/analytics/noop.ts
+++ b/apps/web/src/lib/analytics/noop.ts
@@ -4,7 +4,7 @@ import type { Analytics, ErrorCaptureContext } from "@/lib/analytics/types";
 import { logDevError } from "@/lib/errors/utils";
 
 const noop = () => undefined;
-const noopAsync = () => Promise.resolve();
+const noopAsync = async () => undefined;
 
 const devErrorContext = (
   context: ErrorCaptureContext | undefined,

--- a/apps/web/src/lib/analytics/noop.ts
+++ b/apps/web/src/lib/analytics/noop.ts
@@ -4,6 +4,7 @@ import type { Analytics, ErrorCaptureContext } from "@/lib/analytics/types";
 import { logDevError } from "@/lib/errors/utils";
 
 const noop = () => undefined;
+const noopAsync = () => Promise.resolve();
 
 const devErrorContext = (
   context: ErrorCaptureContext | undefined,
@@ -33,7 +34,7 @@ export const noopAnalytics: Analytics = {
   },
   capturePageViewed: noop,
   captureGuideStepSkipped: noop,
-  captureRouteErrorLifecycle: noop,
+  captureRouteErrorLifecycle: noopAsync,
   identifyUser: noop,
   reset: noop,
 };

--- a/apps/web/src/lib/analytics/noop.ts
+++ b/apps/web/src/lib/analytics/noop.ts
@@ -33,6 +33,7 @@ export const noopAnalytics: Analytics = {
   },
   capturePageViewed: noop,
   captureGuideStepSkipped: noop,
+  captureRouteErrorLifecycle: noop,
   identifyUser: noop,
   reset: noop,
 };

--- a/apps/web/src/lib/analytics/noop.ts
+++ b/apps/web/src/lib/analytics/noop.ts
@@ -4,7 +4,9 @@ import type { Analytics, ErrorCaptureContext } from "@/lib/analytics/types";
 import { logDevError } from "@/lib/errors/utils";
 
 const noop = () => undefined;
-const noopAsync = async () => undefined;
+const noopAsync = async () => {
+  await Promise.resolve();
+};
 
 const devErrorContext = (
   context: ErrorCaptureContext | undefined,

--- a/apps/web/src/lib/analytics/posthog-route-error.ts
+++ b/apps/web/src/lib/analytics/posthog-route-error.ts
@@ -1,0 +1,79 @@
+import type { CaptureResult, PostHog } from "posthog-js";
+
+import { isErrorReference } from "@/lib/analytics/error-reference";
+import { WEB_ANALYTICS_EVENTS } from "@/lib/analytics/types";
+import type { RouteErrorLifecycleProperties } from "@/lib/analytics/types";
+
+const STATUS_PATTERN = /^(?:shown|retry_started|recurred)$/u;
+const RECOVERY_PATTERN = /^(?:reload-page|retry-route)$/u;
+const INSPECTOR_PATTERN = /^(?:empty|minimized|open|unavailable)$/u;
+const ROUTE_TEMPLATE_PATTERN = /^(?:unknown|\/[\w$./{}-]{0,299})$/u;
+const ERROR_FINGERPRINT_PATTERN = /^ERRFP-[0-9A-F]{8}$/u;
+const OPAQUE_SESSION_ID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/iu;
+
+const matches = (value: unknown, pattern: RegExp): value is string =>
+  typeof value === "string" && pattern.test(value);
+
+export const sanitizeRouteErrorLifecycleEvent = (
+  event: CaptureResult,
+): CaptureResult | null => {
+  const properties: Record<string, unknown> = event.properties;
+  const distinctId = properties["$distinct_id"];
+  const sessionId = properties["$session_id"];
+  const appCommit = properties["app_commit"];
+  const appVersion = properties["app_version"];
+  const reference = properties["error_reference"];
+  const incidentReference = properties["incident_reference"];
+  const inspectorState = properties["inspector_state"];
+  const errorFingerprint = properties["error_fingerprint"];
+  const recovery = properties["recovery"];
+  const routeTemplate = properties["route_template"];
+  const status = properties["status"];
+
+  if (
+    !isErrorReference(reference) ||
+    !isErrorReference(incidentReference) ||
+    !matches(inspectorState, INSPECTOR_PATTERN) ||
+    !matches(errorFingerprint, ERROR_FINGERPRINT_PATTERN) ||
+    !matches(recovery, RECOVERY_PATTERN) ||
+    !matches(routeTemplate, ROUTE_TEMPLATE_PATTERN) ||
+    !matches(status, STATUS_PATTERN)
+  ) {
+    return null;
+  }
+
+  return {
+    ...event,
+    properties: {
+      ...(typeof distinctId === "string" ? { $distinct_id: distinctId } : {}),
+      ...(matches(sessionId, OPAQUE_SESSION_ID_PATTERN)
+        ? { $session_id: sessionId }
+        : {}),
+      ...(typeof appCommit === "string" ? { app_commit: appCommit } : {}),
+      ...(typeof appVersion === "string" ? { app_version: appVersion } : {}),
+      error_reference: reference,
+      error_fingerprint: errorFingerprint,
+      incident_reference: incidentReference,
+      inspector_state: inspectorState,
+      recovery,
+      route_template: routeTemplate,
+      status,
+    },
+  };
+};
+
+export const captureRouteErrorLifecycle = (
+  client: Pick<PostHog, "capture">,
+  properties: RouteErrorLifecycleProperties,
+) => {
+  client.capture(WEB_ANALYTICS_EVENTS.routeErrorRecovery, {
+    error_reference: properties.reference,
+    error_fingerprint: properties.errorFingerprint,
+    incident_reference: properties.incidentReference,
+    inspector_state: properties.inspectorState,
+    recovery: properties.recovery,
+    route_template: properties.routeTemplate,
+    status: properties.status,
+  });
+};

--- a/apps/web/src/lib/analytics/posthog.test.ts
+++ b/apps/web/src/lib/analytics/posthog.test.ts
@@ -78,6 +78,8 @@ void mock.module("posthog-js", () => ({
 }));
 
 const { createPostHogAnalytics } = await import("./posthog");
+const { sanitizeRouteErrorLifecycleEvent } =
+  await import("./posthog-route-error");
 
 describe("PostHog browser analytics adapter", () => {
   beforeEach(() => {
@@ -240,6 +242,100 @@ describe("PostHog browser analytics adapter", () => {
     expect(captureExceptionMock.mock.calls.at(-1)?.[1]).toEqual({
       error_reference: "ERR-DEAD-BEEF-1234",
     });
+  });
+
+  test("captures route crash lifecycle properties", async () => {
+    const { analytics } = createPostHogAnalytics(
+      "phc_test",
+      "https://posthog.test",
+    );
+    analytics.captureRouteErrorLifecycle({
+      errorFingerprint: "ERRFP-1234ABCD",
+      incidentReference: "ERR-DEAD-BEEF-1234",
+      inspectorState: "open",
+      recovery: "retry-route",
+      reference: "ERR-DEAD-BEEF-1234",
+      routeTemplate: "/law/$country/cases/$court/$slug",
+      status: "recurred",
+    });
+    await Bun.sleep(0);
+
+    expect(captureMock).toHaveBeenCalledWith(
+      WEB_ANALYTICS_EVENTS.routeErrorRecovery,
+      {
+        error_reference: "ERR-DEAD-BEEF-1234",
+        error_fingerprint: "ERRFP-1234ABCD",
+        incident_reference: "ERR-DEAD-BEEF-1234",
+        inspector_state: "open",
+        recovery: "retry-route",
+        route_template: "/law/$country/cases/$court/$slug",
+        status: "recurred",
+      },
+    );
+  });
+
+  test("keeps only crash diagnostics from an SDK-enriched lifecycle event", () => {
+    createPostHogAnalytics("phc_test", "https://posthog.test");
+
+    expect(
+      sanitizeRouteErrorLifecycleEvent({
+        event: WEB_ANALYTICS_EVENTS.routeErrorRecovery,
+        properties: {
+          $current_url:
+            "https://staging.stll.app/workspaces/private-matter?document=secret#selection",
+          $distinct_id: "user_123",
+          $pathname: "/workspaces/private-matter",
+          $referrer: "https://mail.example.test/client-name",
+          $raw_user_agent: "private browser fingerprint",
+          $session_id: "018f9f0e-7b42-7cc8-9a5d-42db46f6842d",
+          app_commit: "abc123",
+          app_version: "test",
+          document_title: "Client Smith v Example",
+          error_reference: "ERR-FEED-FACE-5678",
+          error_fingerprint: "ERRFP-1234ABCD",
+          incident_reference: "ERR-DEAD-BEEF-1234",
+          inspector_state: "minimized",
+          privileged_content: "never retain me",
+          recovery: "retry-route",
+          route_template: "/law/$country/cases/$court/$slug",
+          status: "recurred",
+        },
+      }),
+    ).toEqual({
+      event: WEB_ANALYTICS_EVENTS.routeErrorRecovery,
+      properties: {
+        $distinct_id: "user_123",
+        $session_id: "018f9f0e-7b42-7cc8-9a5d-42db46f6842d",
+        app_commit: "abc123",
+        app_version: "test",
+        error_reference: "ERR-FEED-FACE-5678",
+        error_fingerprint: "ERRFP-1234ABCD",
+        incident_reference: "ERR-DEAD-BEEF-1234",
+        inspector_state: "minimized",
+        recovery: "retry-route",
+        route_template: "/law/$country/cases/$court/$slug",
+        status: "recurred",
+      },
+    });
+  });
+
+  test("drops malformed crash diagnostics", () => {
+    createPostHogAnalytics("phc_test", "https://posthog.test");
+
+    expect(
+      sanitizeRouteErrorLifecycleEvent({
+        event: WEB_ANALYTICS_EVENTS.routeErrorRecovery,
+        properties: {
+          error_reference: "ERR-DEAD-BEEF-1234",
+          error_fingerprint: "ERRFP-1234ABCD",
+          incident_reference: "ERR-DEAD-BEEF-1234",
+          inspector_state: "open",
+          recovery: "retry-route",
+          route_template: "/workspaces/private matter",
+          status: "shown",
+        },
+      }),
+    ).toBeNull();
   });
 
   test("before_send strips exception messages and stack frames", () => {

--- a/apps/web/src/lib/analytics/posthog.test.ts
+++ b/apps/web/src/lib/analytics/posthog.test.ts
@@ -300,6 +300,7 @@ describe("PostHog browser analytics adapter", () => {
           route_template: "/law/$country/cases/$court/$slug",
           status: "recurred",
         },
+        uuid: "enriched-route-error-event",
       }),
     ).toEqual({
       event: WEB_ANALYTICS_EVENTS.routeErrorRecovery,
@@ -316,6 +317,7 @@ describe("PostHog browser analytics adapter", () => {
         route_template: "/law/$country/cases/$court/$slug",
         status: "recurred",
       },
+      uuid: "enriched-route-error-event",
     });
   });
 
@@ -334,6 +336,7 @@ describe("PostHog browser analytics adapter", () => {
           route_template: "/workspaces/private matter",
           status: "shown",
         },
+        uuid: "malformed-route-error-event",
       }),
     ).toBeNull();
   });

--- a/apps/web/src/lib/analytics/posthog.test.ts
+++ b/apps/web/src/lib/analytics/posthog.test.ts
@@ -244,12 +244,12 @@ describe("PostHog browser analytics adapter", () => {
     });
   });
 
-  test("captures route crash lifecycle properties", async () => {
+  test("captures and sanitizes route crash lifecycle properties", async () => {
     const { analytics } = createPostHogAnalytics(
       "phc_test",
       "https://posthog.test",
     );
-    analytics.captureRouteErrorLifecycle({
+    await analytics.captureRouteErrorLifecycle({
       errorFingerprint: "ERRFP-1234ABCD",
       incidentReference: "ERR-DEAD-BEEF-1234",
       inspectorState: "open",
@@ -258,8 +258,6 @@ describe("PostHog browser analytics adapter", () => {
       routeTemplate: "/law/$country/cases/$court/$slug",
       status: "recurred",
     });
-    await Bun.sleep(0);
-
     expect(captureMock).toHaveBeenCalledWith(
       WEB_ANALYTICS_EVENTS.routeErrorRecovery,
       {
@@ -272,6 +270,41 @@ describe("PostHog browser analytics adapter", () => {
         status: "recurred",
       },
     );
+
+    expect(
+      initOptions?.before_send({
+        event: WEB_ANALYTICS_EVENTS.routeErrorRecovery,
+        properties: {
+          $current_url:
+            "https://staging.stll.app/workspaces/private-matter?document=secret#selection",
+          error_reference: "ERR-DEAD-BEEF-1234",
+          error_fingerprint: "ERRFP-1234ABCD",
+          incident_reference: "ERR-DEAD-BEEF-1234",
+          inspector_state: "open",
+          privileged_content: "never retain me",
+          recovery: "retry-route",
+          route_template: "/law/$country/cases/$court/$slug",
+          status: "shown",
+        },
+      }),
+    ).toEqual({
+      event: WEB_ANALYTICS_EVENTS.routeErrorRecovery,
+      properties: {
+        error_reference: "ERR-DEAD-BEEF-1234",
+        error_fingerprint: "ERRFP-1234ABCD",
+        incident_reference: "ERR-DEAD-BEEF-1234",
+        inspector_state: "open",
+        recovery: "retry-route",
+        route_template: "/law/$country/cases/$court/$slug",
+        status: "shown",
+      },
+    });
+    expect(
+      initOptions?.before_send({
+        event: WEB_ANALYTICS_EVENTS.routeErrorRecovery,
+        properties: { route_template: "/workspaces/private matter" },
+      }),
+    ).toBeNull();
   });
 
   test("keeps only crash diagnostics from an SDK-enriched lifecycle event", () => {

--- a/apps/web/src/lib/analytics/posthog.ts
+++ b/apps/web/src/lib/analytics/posthog.ts
@@ -106,8 +106,7 @@ const sanitizeExceptionEvent = (event: CaptureResult): CaptureResult => {
   };
 };
 
-type RouteErrorLifecycleSanitizer =
-  typeof sanitizeRouteErrorLifecycleEvent;
+type RouteErrorLifecycleSanitizer = typeof sanitizeRouteErrorLifecycleEvent;
 let routeErrorLifecycleSanitizer: RouteErrorLifecycleSanitizer | undefined;
 
 const errorContextProperties = (
@@ -235,8 +234,8 @@ export const createPostHogAnalytics = (
     captureGuideStepSkipped: (properties) => {
       posthog.capture(WEB_ANALYTICS_EVENTS.guideStepSkipped, properties);
     },
-    captureRouteErrorLifecycle: (properties) => {
-      return import("@/lib/analytics/posthog-route-error")
+    captureRouteErrorLifecycle: async (properties) =>
+      import("@/lib/analytics/posthog-route-error")
         .then((module) => {
           routeErrorLifecycleSanitizer =
             module.sanitizeRouteErrorLifecycleEvent;
@@ -247,8 +246,7 @@ export const createPostHogAnalytics = (
             operation: "posthog.route-error-lifecycle",
             type: "detached",
           });
-        });
-    },
+        }),
     identifyUser: (user) => {
       const distinctId = posthog.get_distinct_id();
 

--- a/apps/web/src/lib/analytics/posthog.ts
+++ b/apps/web/src/lib/analytics/posthog.ts
@@ -3,6 +3,10 @@ import { posthog } from "posthog-js";
 import type { CaptureResult } from "posthog-js";
 
 import { env } from "@/env";
+import {
+  normalizeTelemetryErrorTypeName,
+  telemetryErrorType,
+} from "@/lib/analytics/error-diagnostics";
 import { isErrorReference } from "@/lib/analytics/error-reference";
 import { WEB_ANALYTICS_EVENTS } from "@/lib/analytics/types";
 import type {
@@ -65,16 +69,6 @@ const isNoiseException = (event: {
   });
 };
 
-const TELEMETRY_ERROR_TYPE = /^[A-Za-z][\w.-]{0,79}$/u;
-
-const normalizeTelemetryErrorType = (candidate: string): string =>
-  TELEMETRY_ERROR_TYPE.test(candidate) ? candidate : "UnknownError";
-
-const telemetryErrorType = (error: unknown): string => {
-  const candidate = error instanceof Error ? error.name : typeof error;
-  return normalizeTelemetryErrorType(candidate);
-};
-
 const toRedactedTelemetryError = (error: unknown): Error => {
   // eslint-disable-next-line unicorn/error-message -- the original message is intentionally dropped so telemetry cannot leak PII from the underlying error; the error class is carried in `.name` instead.
   const redacted = new Error("");
@@ -93,7 +87,7 @@ const sanitizeExceptionEvent = (event: CaptureResult): CaptureResult => {
   const firstException: unknown = Array.isArray(exceptionList)
     ? exceptionList.at(0)
     : undefined;
-  const type = normalizeTelemetryErrorType(
+  const type = normalizeTelemetryErrorTypeName(
     readStringField(firstException, "type"),
   );
   return {
@@ -110,6 +104,11 @@ const sanitizeExceptionEvent = (event: CaptureResult): CaptureResult => {
     },
   };
 };
+
+type RouteErrorLifecycleSanitizer = (
+  event: CaptureResult,
+) => CaptureResult | null;
+let routeErrorLifecycleSanitizer: RouteErrorLifecycleSanitizer | undefined;
 
 const errorContextProperties = (
   context: ErrorCaptureContext | undefined,
@@ -195,6 +194,9 @@ export const createPostHogAnalytics = (
       if (event.event === WEB_ANALYTICS_EVENTS.exception) {
         return sanitizeExceptionEvent(event);
       }
+      if (event.event === WEB_ANALYTICS_EVENTS.routeErrorRecovery) {
+        return routeErrorLifecycleSanitizer?.(event) ?? null;
+      }
       return event;
     },
   });
@@ -232,6 +234,20 @@ export const createPostHogAnalytics = (
     },
     captureGuideStepSkipped: (properties) => {
       posthog.capture(WEB_ANALYTICS_EVENTS.guideStepSkipped, properties);
+    },
+    captureRouteErrorLifecycle: (properties) => {
+      import("@/lib/analytics/posthog-route-error")
+        .then((module) => {
+          routeErrorLifecycleSanitizer =
+            module.sanitizeRouteErrorLifecycleEvent;
+          return module.captureRouteErrorLifecycle(posthog, properties);
+        })
+        .catch((error: unknown) => {
+          analytics.captureError(error, {
+            operation: "posthog.route-error-lifecycle",
+            type: "detached",
+          });
+        });
     },
     identifyUser: (user) => {
       const distinctId = posthog.get_distinct_id();

--- a/apps/web/src/lib/analytics/posthog.ts
+++ b/apps/web/src/lib/analytics/posthog.ts
@@ -8,6 +8,7 @@ import {
   telemetryErrorType,
 } from "@/lib/analytics/error-diagnostics";
 import { isErrorReference } from "@/lib/analytics/error-reference";
+import type { sanitizeRouteErrorLifecycleEvent } from "@/lib/analytics/posthog-route-error";
 import { WEB_ANALYTICS_EVENTS } from "@/lib/analytics/types";
 import type {
   Analytics,
@@ -105,9 +106,8 @@ const sanitizeExceptionEvent = (event: CaptureResult): CaptureResult => {
   };
 };
 
-type RouteErrorLifecycleSanitizer = (
-  event: CaptureResult,
-) => CaptureResult | null;
+type RouteErrorLifecycleSanitizer =
+  typeof sanitizeRouteErrorLifecycleEvent;
 let routeErrorLifecycleSanitizer: RouteErrorLifecycleSanitizer | undefined;
 
 const errorContextProperties = (
@@ -236,7 +236,7 @@ export const createPostHogAnalytics = (
       posthog.capture(WEB_ANALYTICS_EVENTS.guideStepSkipped, properties);
     },
     captureRouteErrorLifecycle: (properties) => {
-      import("@/lib/analytics/posthog-route-error")
+      return import("@/lib/analytics/posthog-route-error")
         .then((module) => {
           routeErrorLifecycleSanitizer =
             module.sanitizeRouteErrorLifecycleEvent;

--- a/apps/web/src/lib/analytics/route-error-lifecycle-context.tsx
+++ b/apps/web/src/lib/analytics/route-error-lifecycle-context.tsx
@@ -1,0 +1,26 @@
+import { createContext, use } from "react";
+import type { PropsWithChildren } from "react";
+
+import { panic } from "better-result";
+
+import type { RouteErrorLifecycleController } from "@/lib/analytics/route-error-lifecycle";
+
+export const RouteErrorLifecycleProvider = ({
+  children,
+  controller,
+}: PropsWithChildren<{ controller: RouteErrorLifecycleController }>) => (
+  <RouteErrorLifecycleContext value={controller}>
+    {children}
+  </RouteErrorLifecycleContext>
+);
+
+const RouteErrorLifecycleContext =
+  createContext<RouteErrorLifecycleController | null>(null);
+
+export const useRouteErrorLifecycle = (): RouteErrorLifecycleController => {
+  const controller = use(RouteErrorLifecycleContext);
+  if (controller === null) {
+    return panic("Route error lifecycle context is unavailable");
+  }
+  return controller;
+};

--- a/apps/web/src/lib/analytics/route-error-lifecycle-loaded.ts
+++ b/apps/web/src/lib/analytics/route-error-lifecycle-loaded.ts
@@ -12,6 +12,7 @@ type RouteErrorLifecycleState =
   | { type: "idle" }
   | {
       type: "caught";
+      inspectorState: RouteErrorIncident["inspectorState"];
       routeTemplate: string;
       priorIncident?: RouteErrorIncident;
     }
@@ -36,8 +37,13 @@ export const createLoadedRouteErrorLifecycleController = (
   const caught = (routeTemplate: string) => {
     state =
       state.type === "retrying"
-        ? { priorIncident: state.incident, routeTemplate, type: "caught" }
-        : { routeTemplate, type: "caught" };
+        ? {
+            inspectorState: state.incident.inspectorState,
+            priorIncident: state.incident,
+            routeTemplate,
+            type: "caught",
+          }
+        : { inspectorState, routeTemplate, type: "caught" };
   };
 
   const shown = ({ error, recovery, reference }: ShowRouteErrorOptions) => {
@@ -50,13 +56,13 @@ export const createLoadedRouteErrorLifecycleController = (
     const incident: RouteErrorIncident = {
       errorFingerprint: fingerprintTelemetryError(error),
       incidentReference: priorIncident?.incidentReference ?? reference,
-      inspectorState,
+      inspectorState:
+        state.type === "caught" ? state.inspectorState : inspectorState,
       recovery,
       reference,
       routeTemplate,
     };
     state = { incident, type: "visible" };
-    analytics.captureError(error, { type: "recovery", reference });
     capture(incident, priorIncident ? "recurred" : "shown");
   };
 

--- a/apps/web/src/lib/analytics/route-error-lifecycle-loaded.ts
+++ b/apps/web/src/lib/analytics/route-error-lifecycle-loaded.ts
@@ -27,11 +27,11 @@ export const createLoadedRouteErrorLifecycleController = (
   let currentRouteTemplate = initial.routeTemplate;
   let inspectorState = initial.inspectorState;
 
-  const capture = (
+  const capture = async (
     incident: RouteErrorIncident,
     status: RouteErrorLifecycleProperties["status"],
   ) => {
-    analytics.captureRouteErrorLifecycle({ ...incident, status });
+    await analytics.captureRouteErrorLifecycle({ ...incident, status });
   };
 
   const caught = (routeTemplate: string) => {
@@ -63,10 +63,10 @@ export const createLoadedRouteErrorLifecycleController = (
       routeTemplate,
     };
     state = { incident, type: "visible" };
-    capture(incident, priorIncident ? "recurred" : "shown");
+    void capture(incident, priorIncident ? "recurred" : "shown");
   };
 
-  const retryStarted: RouteErrorLifecycleController["retryStarted"] = (
+  const retryStarted: RouteErrorLifecycleController["retryStarted"] = async (
     reference,
     recovery,
   ) => {
@@ -77,7 +77,7 @@ export const createLoadedRouteErrorLifecycleController = (
     if (recovery === "retry-route") {
       state = { incident, type: "retrying" };
     }
-    capture(incident, "retry_started");
+    await capture(incident, "retry_started");
   };
 
   const routeResolved = (routeTemplate: string) => {

--- a/apps/web/src/lib/analytics/route-error-lifecycle-loaded.ts
+++ b/apps/web/src/lib/analytics/route-error-lifecycle-loaded.ts
@@ -1,0 +1,93 @@
+import { fingerprintTelemetryError } from "@/lib/analytics/error-fingerprint";
+import type {
+  RouteErrorAnalytics,
+  RouteErrorIncident,
+  RouteErrorLifecycleController,
+  RouteErrorLifecycleSnapshot,
+  ShowRouteErrorOptions,
+} from "@/lib/analytics/route-error-lifecycle";
+import type { RouteErrorLifecycleProperties } from "@/lib/analytics/types";
+
+type RouteErrorLifecycleState =
+  | { type: "idle" }
+  | {
+      type: "caught";
+      routeTemplate: string;
+      priorIncident?: RouteErrorIncident;
+    }
+  | { type: "visible"; incident: RouteErrorIncident }
+  | { type: "retrying"; incident: RouteErrorIncident };
+
+export const createLoadedRouteErrorLifecycleController = (
+  analytics: RouteErrorAnalytics,
+  initial: RouteErrorLifecycleSnapshot,
+): RouteErrorLifecycleController => {
+  let state: RouteErrorLifecycleState = { type: "idle" };
+  let currentRouteTemplate = initial.routeTemplate;
+  let inspectorState = initial.inspectorState;
+
+  const capture = (
+    incident: RouteErrorIncident,
+    status: RouteErrorLifecycleProperties["status"],
+  ) => {
+    analytics.captureRouteErrorLifecycle({ ...incident, status });
+  };
+
+  const caught = (routeTemplate: string) => {
+    state =
+      state.type === "retrying"
+        ? { priorIncident: state.incident, routeTemplate, type: "caught" }
+        : { routeTemplate, type: "caught" };
+  };
+
+  const shown = ({ error, recovery, reference }: ShowRouteErrorOptions) => {
+    if (state.type === "visible" && state.incident.reference === reference) {
+      return;
+    }
+    const priorIncident = state.type === "caught" ? state.priorIncident : null;
+    const routeTemplate =
+      state.type === "caught" ? state.routeTemplate : currentRouteTemplate;
+    const incident: RouteErrorIncident = {
+      errorFingerprint: fingerprintTelemetryError(error),
+      incidentReference: priorIncident?.incidentReference ?? reference,
+      inspectorState,
+      recovery,
+      reference,
+      routeTemplate,
+    };
+    state = { incident, type: "visible" };
+    analytics.captureError(error, { type: "recovery", reference });
+    capture(incident, priorIncident ? "recurred" : "shown");
+  };
+
+  const retryStarted: RouteErrorLifecycleController["retryStarted"] = (
+    reference,
+    recovery,
+  ) => {
+    if (state.type !== "visible" || state.incident.reference !== reference) {
+      return;
+    }
+    const incident = { ...state.incident, recovery };
+    if (recovery === "retry-route") {
+      state = { incident, type: "retrying" };
+    }
+    capture(incident, "retry_started");
+  };
+
+  const routeResolved = (routeTemplate: string) => {
+    currentRouteTemplate = routeTemplate;
+    if (state.type === "retrying") {
+      state = { type: "idle" };
+    }
+  };
+
+  return {
+    caught,
+    retryStarted,
+    routeResolved,
+    shown,
+    updateInspectorState: (nextInspectorState) => {
+      inspectorState = nextInspectorState;
+    },
+  };
+};

--- a/apps/web/src/lib/analytics/route-error-lifecycle-loaded.ts
+++ b/apps/web/src/lib/analytics/route-error-lifecycle-loaded.ts
@@ -7,6 +7,7 @@ import type {
   ShowRouteErrorOptions,
 } from "@/lib/analytics/route-error-lifecycle";
 import type { RouteErrorLifecycleProperties } from "@/lib/analytics/types";
+import { detached } from "@/lib/detached";
 
 type RouteErrorLifecycleState =
   | { type: "idle" }
@@ -63,7 +64,10 @@ export const createLoadedRouteErrorLifecycleController = (
       routeTemplate,
     };
     state = { incident, type: "visible" };
-    void capture(incident, priorIncident ? "recurred" : "shown");
+    detached(
+      capture(incident, priorIncident ? "recurred" : "shown"),
+      "route-error.capture",
+    );
   };
 
   const retryStarted: RouteErrorLifecycleController["retryStarted"] = async (

--- a/apps/web/src/lib/analytics/route-error-lifecycle.test.ts
+++ b/apps/web/src/lib/analytics/route-error-lifecycle.test.ts
@@ -5,7 +5,10 @@ import type {
   RouteErrorLifecycleProperties,
 } from "@/lib/analytics/types";
 
-import { createRouteErrorLifecycleController } from "./route-error-lifecycle";
+import {
+  createRouteErrorLifecycleController,
+  resolveCaughtRouteTemplate,
+} from "./route-error-lifecycle";
 import { createLoadedRouteErrorLifecycleController } from "./route-error-lifecycle-loaded";
 
 const FIRST_REFERENCE = "ERR-DEAD-BEEF-1234" as const;
@@ -37,16 +40,28 @@ const setup = () => {
 
 describe("route error lifecycle diagnostics", () => {
   test("preserves call order while rare diagnostics load", async () => {
-    const { analytics, events } = setup();
+    const { analytics, errors, events } = setup();
     const controller = createRouteErrorLifecycleController(analytics);
+    const error = new TypeError("Privileged decision text");
     controller.caught(ROUTE_TEMPLATE);
     controller.shown({
-      error: new TypeError("Privileged decision text"),
+      error,
+      recovery: "retry-route",
+      reference: FIRST_REFERENCE,
+    });
+    controller.shown({
+      error,
       recovery: "retry-route",
       reference: FIRST_REFERENCE,
     });
     controller.retryStarted(FIRST_REFERENCE, "retry-route");
 
+    expect(errors).toEqual([
+      {
+        context: { reference: FIRST_REFERENCE, type: "recovery" },
+        error,
+      },
+    ]);
     await Bun.sleep(0);
 
     expect(events.map(({ status }) => status)).toEqual([
@@ -55,8 +70,18 @@ describe("route error lifecycle diagnostics", () => {
     ]);
   });
 
+  test("reads the attempted leaf route at catch time", () => {
+    expect(
+      resolveCaughtRouteTemplate([
+        { fullPath: "/" },
+        { fullPath: ROUTE_TEMPLATE },
+      ]),
+    ).toBe(ROUTE_TEMPLATE);
+    expect(resolveCaughtRouteTemplate([])).toBe("unknown");
+  });
+
   test("reports an in-app retry", () => {
-    const { controller, errors, events } = setup();
+    const { controller, events } = setup();
     const error = new TypeError("Privileged decision text");
     controller.caught(ROUTE_TEMPLATE);
     controller.shown({
@@ -67,12 +92,6 @@ describe("route error lifecycle diagnostics", () => {
 
     controller.retryStarted(FIRST_REFERENCE, "retry-route");
 
-    expect(errors).toEqual([
-      {
-        context: { type: "recovery", reference: FIRST_REFERENCE },
-        error,
-      },
-    ]);
     expect(events.map(({ status }) => status)).toEqual([
       "shown",
       "retry_started",
@@ -132,7 +151,7 @@ describe("route error lifecycle diagnostics", () => {
   });
 
   test("deduplicates React strict-effect observation", () => {
-    const { controller, errors, events } = setup();
+    const { controller, events } = setup();
     const error = new TypeError("Privileged decision text");
     controller.caught(ROUTE_TEMPLATE);
     controller.shown({
@@ -145,7 +164,6 @@ describe("route error lifecycle diagnostics", () => {
       recovery: "retry-route",
       reference: FIRST_REFERENCE,
     });
-    expect(errors).toHaveLength(1);
     expect(events.map(({ status }) => status)).toEqual(["shown"]);
   });
 
@@ -155,6 +173,7 @@ describe("route error lifecycle diagnostics", () => {
     controller.updateInspectorState("open");
     const error = new TypeError("redacted");
     controller.caught(ROUTE_TEMPLATE);
+    controller.updateInspectorState("unavailable");
     controller.shown({
       error,
       recovery: "retry-route",

--- a/apps/web/src/lib/analytics/route-error-lifecycle.test.ts
+++ b/apps/web/src/lib/analytics/route-error-lifecycle.test.ts
@@ -22,9 +22,8 @@ const setup = () => {
     captureError: mock((error, context) => {
       errors.push({ context, error });
     }),
-    captureRouteErrorLifecycle: mock((properties) => {
+    captureRouteErrorLifecycle: mock(async (properties) => {
       events.push(properties);
-      return Promise.resolve();
     }),
   } satisfies Pick<Analytics, "captureError" | "captureRouteErrorLifecycle">;
 

--- a/apps/web/src/lib/analytics/route-error-lifecycle.test.ts
+++ b/apps/web/src/lib/analytics/route-error-lifecycle.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, mock, test } from "bun:test";
+
+import type {
+  Analytics,
+  RouteErrorLifecycleProperties,
+} from "@/lib/analytics/types";
+
+import { createRouteErrorLifecycleController } from "./route-error-lifecycle";
+import { createLoadedRouteErrorLifecycleController } from "./route-error-lifecycle-loaded";
+
+const FIRST_REFERENCE = "ERR-DEAD-BEEF-1234" as const;
+const SECOND_REFERENCE = "ERR-FEED-FACE-5678" as const;
+const ROUTE_TEMPLATE = "/law/$country/cases/$court/$slug";
+
+const setup = () => {
+  const errors: { context: unknown; error: unknown }[] = [];
+  const events: RouteErrorLifecycleProperties[] = [];
+  const analytics = {
+    captureError: mock((error, context) => {
+      errors.push({ context, error });
+    }),
+    captureRouteErrorLifecycle: mock((properties) => {
+      events.push(properties);
+    }),
+  } satisfies Pick<Analytics, "captureError" | "captureRouteErrorLifecycle">;
+
+  return {
+    analytics,
+    controller: createLoadedRouteErrorLifecycleController(analytics, {
+      inspectorState: "unavailable",
+      routeTemplate: "unknown",
+    }),
+    errors,
+    events,
+  };
+};
+
+describe("route error lifecycle diagnostics", () => {
+  test("preserves call order while rare diagnostics load", async () => {
+    const { analytics, events } = setup();
+    const controller = createRouteErrorLifecycleController(analytics);
+    controller.caught(ROUTE_TEMPLATE);
+    controller.shown({
+      error: new TypeError("Privileged decision text"),
+      recovery: "retry-route",
+      reference: FIRST_REFERENCE,
+    });
+    controller.retryStarted(FIRST_REFERENCE, "retry-route");
+
+    await Bun.sleep(0);
+
+    expect(events.map(({ status }) => status)).toEqual([
+      "shown",
+      "retry_started",
+    ]);
+  });
+
+  test("reports an in-app retry", () => {
+    const { controller, errors, events } = setup();
+    const error = new TypeError("Privileged decision text");
+    controller.caught(ROUTE_TEMPLATE);
+    controller.shown({
+      error,
+      recovery: "retry-route",
+      reference: FIRST_REFERENCE,
+    });
+
+    controller.retryStarted(FIRST_REFERENCE, "retry-route");
+
+    expect(errors).toEqual([
+      {
+        context: { type: "recovery", reference: FIRST_REFERENCE },
+        error,
+      },
+    ]);
+    expect(events.map(({ status }) => status)).toEqual([
+      "shown",
+      "retry_started",
+    ]);
+  });
+
+  test("keeps one incident reference when the retry crashes again", () => {
+    const { controller, events } = setup();
+    const firstError = new TypeError("First privileged payload");
+    controller.caught(ROUTE_TEMPLATE);
+    controller.shown({
+      error: firstError,
+      recovery: "retry-route",
+      reference: FIRST_REFERENCE,
+    });
+    controller.retryStarted(FIRST_REFERENCE, "retry-route");
+
+    const secondError = new RangeError("Second privileged payload");
+    controller.caught(ROUTE_TEMPLATE);
+    controller.shown({
+      error: secondError,
+      recovery: "retry-route",
+      reference: SECOND_REFERENCE,
+    });
+    expect(events.map(({ status }) => status)).toEqual([
+      "shown",
+      "retry_started",
+      "recurred",
+    ]);
+    expect(events.at(-1)).toEqual({
+      errorFingerprint: expect.stringMatching(/^ERRFP-[0-9A-F]{8}$/u),
+      incidentReference: FIRST_REFERENCE,
+      inspectorState: "unavailable",
+      recovery: "retry-route",
+      reference: SECOND_REFERENCE,
+      routeTemplate: ROUTE_TEMPLATE,
+      status: "recurred",
+    });
+  });
+
+  test("does not claim that a page reload recovered", () => {
+    const { controller, events } = setup();
+    const error = new TypeError("Failed to fetch dynamically imported module");
+    controller.caught(ROUTE_TEMPLATE);
+    controller.shown({
+      error,
+      recovery: "reload-page",
+      reference: FIRST_REFERENCE,
+    });
+
+    controller.retryStarted(FIRST_REFERENCE, "reload-page");
+
+    expect(events.map(({ status }) => status)).toEqual([
+      "shown",
+      "retry_started",
+    ]);
+  });
+
+  test("deduplicates React strict-effect observation", () => {
+    const { controller, errors, events } = setup();
+    const error = new TypeError("Privileged decision text");
+    controller.caught(ROUTE_TEMPLATE);
+    controller.shown({
+      error,
+      recovery: "retry-route",
+      reference: FIRST_REFERENCE,
+    });
+    controller.shown({
+      error,
+      recovery: "retry-route",
+      reference: FIRST_REFERENCE,
+    });
+    expect(errors).toHaveLength(1);
+    expect(events.map(({ status }) => status)).toEqual(["shown"]);
+  });
+
+  test("snapshots inspector visibility for the matching route", () => {
+    const { controller, events } = setup();
+    controller.routeResolved(ROUTE_TEMPLATE);
+    controller.updateInspectorState("open");
+    const error = new TypeError("redacted");
+    controller.caught(ROUTE_TEMPLATE);
+    controller.shown({
+      error,
+      recovery: "retry-route",
+      reference: FIRST_REFERENCE,
+    });
+
+    expect(events.at(-1)?.inspectorState).toBe("open");
+  });
+});

--- a/apps/web/src/lib/analytics/route-error-lifecycle.test.ts
+++ b/apps/web/src/lib/analytics/route-error-lifecycle.test.ts
@@ -24,6 +24,7 @@ const setup = () => {
     }),
     captureRouteErrorLifecycle: mock((properties) => {
       events.push(properties);
+      return Promise.resolve();
     }),
   } satisfies Pick<Analytics, "captureError" | "captureRouteErrorLifecycle">;
 
@@ -43,6 +44,8 @@ describe("route error lifecycle diagnostics", () => {
     const { analytics, errors, events } = setup();
     const controller = createRouteErrorLifecycleController(analytics);
     const error = new TypeError("Privileged decision text");
+    controller.routeResolved(ROUTE_TEMPLATE);
+    controller.updateInspectorState("open");
     controller.caught(ROUTE_TEMPLATE);
     controller.shown({
       error,
@@ -54,7 +57,7 @@ describe("route error lifecycle diagnostics", () => {
       recovery: "retry-route",
       reference: FIRST_REFERENCE,
     });
-    controller.retryStarted(FIRST_REFERENCE, "retry-route");
+    await controller.retryStarted(FIRST_REFERENCE, "retry-route");
 
     expect(errors).toEqual([
       {
@@ -62,25 +65,34 @@ describe("route error lifecycle diagnostics", () => {
         error,
       },
     ]);
-    await Bun.sleep(0);
-
     expect(events.map(({ status }) => status)).toEqual([
       "shown",
       "retry_started",
     ]);
+    expect(events.at(0)).toMatchObject({
+      inspectorState: "open",
+      routeTemplate: ROUTE_TEMPLATE,
+    });
   });
 
-  test("reads the attempted leaf route at catch time", () => {
+  test("reads the errored route or attempted leaf at catch time", () => {
     expect(
       resolveCaughtRouteTemplate([
-        { fullPath: "/" },
-        { fullPath: ROUTE_TEMPLATE },
+        { fullPath: "/", status: "success" },
+        { fullPath: "/law/$country", status: "error" },
+        { fullPath: ROUTE_TEMPLATE, status: "pending" },
+      ]),
+    ).toBe("/law/$country");
+    expect(
+      resolveCaughtRouteTemplate([
+        { fullPath: "/", status: "success" },
+        { fullPath: ROUTE_TEMPLATE, status: "pending" },
       ]),
     ).toBe(ROUTE_TEMPLATE);
     expect(resolveCaughtRouteTemplate([])).toBe("unknown");
   });
 
-  test("reports an in-app retry", () => {
+  test("reports an in-app retry", async () => {
     const { controller, events } = setup();
     const error = new TypeError("Privileged decision text");
     controller.caught(ROUTE_TEMPLATE);
@@ -90,7 +102,7 @@ describe("route error lifecycle diagnostics", () => {
       reference: FIRST_REFERENCE,
     });
 
-    controller.retryStarted(FIRST_REFERENCE, "retry-route");
+    await controller.retryStarted(FIRST_REFERENCE, "retry-route");
 
     expect(events.map(({ status }) => status)).toEqual([
       "shown",
@@ -98,7 +110,7 @@ describe("route error lifecycle diagnostics", () => {
     ]);
   });
 
-  test("keeps one incident reference when the retry crashes again", () => {
+  test("keeps one incident reference when the retry crashes again", async () => {
     const { controller, events } = setup();
     const firstError = new TypeError("First privileged payload");
     controller.caught(ROUTE_TEMPLATE);
@@ -107,7 +119,7 @@ describe("route error lifecycle diagnostics", () => {
       recovery: "retry-route",
       reference: FIRST_REFERENCE,
     });
-    controller.retryStarted(FIRST_REFERENCE, "retry-route");
+    await controller.retryStarted(FIRST_REFERENCE, "retry-route");
 
     const secondError = new RangeError("Second privileged payload");
     controller.caught(ROUTE_TEMPLATE);
@@ -132,7 +144,7 @@ describe("route error lifecycle diagnostics", () => {
     });
   });
 
-  test("does not claim that a page reload recovered", () => {
+  test("does not claim that a page reload recovered", async () => {
     const { controller, events } = setup();
     const error = new TypeError("Failed to fetch dynamically imported module");
     controller.caught(ROUTE_TEMPLATE);
@@ -142,7 +154,7 @@ describe("route error lifecycle diagnostics", () => {
       reference: FIRST_REFERENCE,
     });
 
-    controller.retryStarted(FIRST_REFERENCE, "reload-page");
+    await controller.retryStarted(FIRST_REFERENCE, "reload-page");
 
     expect(events.map(({ status }) => status)).toEqual([
       "shown",

--- a/apps/web/src/lib/analytics/route-error-lifecycle.ts
+++ b/apps/web/src/lib/analytics/route-error-lifecycle.ts
@@ -23,7 +23,7 @@ export type RouteErrorLifecycleController = {
   retryStarted: (
     reference: ErrorReference,
     recovery: RouteErrorIncident["recovery"],
-  ) => void;
+  ) => Promise<void>;
   shown: (options: ShowRouteErrorOptions) => void;
   updateInspectorState: (
     inspectorState: RouteErrorIncident["inspectorState"],
@@ -36,8 +36,11 @@ export type RouteErrorLifecycleSnapshot = {
 };
 
 export const resolveCaughtRouteTemplate = (
-  matches: readonly { fullPath: string }[],
-): string => matches.at(-1)?.fullPath ?? "unknown";
+  matches: readonly { fullPath: string; status?: string }[],
+): string =>
+  matches.findLast(({ status }) => status === "error")?.fullPath ??
+  matches.at(-1)?.fullPath ??
+  "unknown";
 
 export const createRouteErrorLifecycleController = (
   analytics: RouteErrorAnalytics,
@@ -71,11 +74,12 @@ export const createRouteErrorLifecycleController = (
       type: "detached",
     });
   };
-  const run = (action: (controller: RouteErrorLifecycleController) => void) => {
+  const run = (
+    action: (controller: RouteErrorLifecycleController) => void | Promise<void>,
+  ): Promise<void> =>
     load()
       .then((controller) => (controller ? action(controller) : undefined))
       .catch(captureDispatchError);
-  };
   const runIfLoaded = (
     action: (controller: RouteErrorLifecycleController) => void,
   ) => {
@@ -86,14 +90,14 @@ export const createRouteErrorLifecycleController = (
 
   return {
     caught: (routeTemplate) => {
-      run((controller) => controller.caught(routeTemplate));
+      void run((controller) => controller.caught(routeTemplate));
     },
     routeResolved: (routeTemplate) => {
       snapshot = { ...snapshot, routeTemplate };
       runIfLoaded((controller) => controller.routeResolved(routeTemplate));
     },
     retryStarted: (reference, recovery) => {
-      run((controller) => controller.retryStarted(reference, recovery));
+      return run((controller) => controller.retryStarted(reference, recovery));
     },
     shown: (options) => {
       if (capturedReference !== options.reference) {
@@ -103,7 +107,7 @@ export const createRouteErrorLifecycleController = (
           type: "recovery",
         });
       }
-      run((controller) => controller.shown(options));
+      void run((controller) => controller.shown(options));
     },
     updateInspectorState: (inspectorState) => {
       snapshot = { ...snapshot, inspectorState };

--- a/apps/web/src/lib/analytics/route-error-lifecycle.ts
+++ b/apps/web/src/lib/analytics/route-error-lifecycle.ts
@@ -1,0 +1,100 @@
+import type { ErrorReference } from "@/lib/analytics/error-reference";
+import type {
+  Analytics,
+  RouteErrorLifecycleProperties,
+} from "@/lib/analytics/types";
+
+export type RouteErrorAnalytics = Pick<
+  Analytics,
+  "captureError" | "captureRouteErrorLifecycle"
+>;
+
+export type RouteErrorIncident = Omit<RouteErrorLifecycleProperties, "status">;
+
+export type ShowRouteErrorOptions = {
+  error: unknown;
+  recovery: RouteErrorIncident["recovery"];
+  reference: ErrorReference;
+};
+
+export type RouteErrorLifecycleController = {
+  caught: (routeTemplate: string) => void;
+  routeResolved: (routeTemplate: string) => void;
+  retryStarted: (
+    reference: ErrorReference,
+    recovery: RouteErrorIncident["recovery"],
+  ) => void;
+  shown: (options: ShowRouteErrorOptions) => void;
+  updateInspectorState: (
+    inspectorState: RouteErrorIncident["inspectorState"],
+  ) => void;
+};
+
+export type RouteErrorLifecycleSnapshot = {
+  inspectorState: RouteErrorIncident["inspectorState"];
+  routeTemplate: string;
+};
+
+export const createRouteErrorLifecycleController = (
+  analytics: RouteErrorAnalytics,
+): RouteErrorLifecycleController => {
+  let snapshot: RouteErrorLifecycleSnapshot = {
+    inspectorState: "unavailable",
+    routeTemplate: "unknown",
+  };
+  let loaded: Promise<RouteErrorLifecycleController | undefined> | undefined;
+  const load = async () => {
+    loaded ??= import("@/lib/analytics/route-error-lifecycle-loaded")
+      .then((module) =>
+        module.createLoadedRouteErrorLifecycleController(analytics, snapshot),
+      )
+      .catch((error: unknown) => {
+        analytics.captureError(error, {
+          operation: "route-error.load",
+          type: "detached",
+        });
+        return undefined;
+      });
+    return await loaded;
+  };
+  const captureDispatchError = (error: unknown) => {
+    analytics.captureError(error, {
+      operation: "route-error.dispatch",
+      type: "detached",
+    });
+  };
+  const run = (action: (controller: RouteErrorLifecycleController) => void) => {
+    load()
+      .then((controller) => (controller ? action(controller) : undefined))
+      .catch(captureDispatchError);
+  };
+  const runIfLoaded = (
+    action: (controller: RouteErrorLifecycleController) => void,
+  ) => {
+    loaded
+      ?.then((controller) => (controller ? action(controller) : undefined))
+      .catch(captureDispatchError);
+  };
+
+  return {
+    caught: (routeTemplate) => {
+      run((controller) => controller.caught(routeTemplate));
+    },
+    routeResolved: (routeTemplate) => {
+      snapshot = { ...snapshot, routeTemplate };
+      runIfLoaded((controller) => controller.routeResolved(routeTemplate));
+    },
+    retryStarted: (reference, recovery) => {
+      run((controller) => controller.retryStarted(reference, recovery));
+    },
+    shown: (options) => {
+      run((controller) => controller.shown(options));
+    },
+    updateInspectorState: (inspectorState) => {
+      snapshot = { ...snapshot, inspectorState };
+      runIfLoaded((controller) =>
+        controller.updateInspectorState(inspectorState),
+      );
+    },
+  };
+};

--- a/apps/web/src/lib/analytics/route-error-lifecycle.ts
+++ b/apps/web/src/lib/analytics/route-error-lifecycle.ts
@@ -3,6 +3,7 @@ import type {
   Analytics,
   RouteErrorLifecycleProperties,
 } from "@/lib/analytics/types";
+import { detached } from "@/lib/detached";
 
 export type RouteErrorAnalytics = Pick<
   Analytics,
@@ -74,11 +75,15 @@ export const createRouteErrorLifecycleController = (
       type: "detached",
     });
   };
-  const run = (
+  const run = async (
     action: (controller: RouteErrorLifecycleController) => void | Promise<void>,
   ): Promise<void> =>
     load()
-      .then((controller) => (controller ? action(controller) : undefined))
+      .then(async (controller) => {
+        if (controller) {
+          await action(controller);
+        }
+      })
       .catch(captureDispatchError);
   const runIfLoaded = (
     action: (controller: RouteErrorLifecycleController) => void,
@@ -90,15 +95,19 @@ export const createRouteErrorLifecycleController = (
 
   return {
     caught: (routeTemplate) => {
-      void run((controller) => controller.caught(routeTemplate));
+      detached(
+        run((controller) => controller.caught(routeTemplate)),
+        "route-error.caught",
+      );
     },
     routeResolved: (routeTemplate) => {
       snapshot = { ...snapshot, routeTemplate };
       runIfLoaded((controller) => controller.routeResolved(routeTemplate));
     },
-    retryStarted: (reference, recovery) => {
-      return run((controller) => controller.retryStarted(reference, recovery));
-    },
+    retryStarted: async (reference, recovery) =>
+      run(async (controller) => {
+        await controller.retryStarted(reference, recovery);
+      }),
     shown: (options) => {
       if (capturedReference !== options.reference) {
         capturedReference = options.reference;
@@ -107,7 +116,10 @@ export const createRouteErrorLifecycleController = (
           type: "recovery",
         });
       }
-      void run((controller) => controller.shown(options));
+      detached(
+        run((controller) => controller.shown(options)),
+        "route-error.shown",
+      );
     },
     updateInspectorState: (inspectorState) => {
       snapshot = { ...snapshot, inspectorState };

--- a/apps/web/src/lib/analytics/route-error-lifecycle.ts
+++ b/apps/web/src/lib/analytics/route-error-lifecycle.ts
@@ -35,6 +35,10 @@ export type RouteErrorLifecycleSnapshot = {
   routeTemplate: string;
 };
 
+export const resolveCaughtRouteTemplate = (
+  matches: readonly { fullPath: string }[],
+): string => matches.at(-1)?.fullPath ?? "unknown";
+
 export const createRouteErrorLifecycleController = (
   analytics: RouteErrorAnalytics,
 ): RouteErrorLifecycleController => {
@@ -43,18 +47,22 @@ export const createRouteErrorLifecycleController = (
     routeTemplate: "unknown",
   };
   let loaded: Promise<RouteErrorLifecycleController | undefined> | undefined;
+  let capturedReference: ErrorReference | undefined;
   const load = async () => {
-    loaded ??= import("@/lib/analytics/route-error-lifecycle-loaded")
-      .then((module) =>
-        module.createLoadedRouteErrorLifecycleController(analytics, snapshot),
-      )
-      .catch((error: unknown) => {
-        analytics.captureError(error, {
-          operation: "route-error.load",
-          type: "detached",
+    if (!loaded) {
+      const initial = snapshot;
+      loaded = import("@/lib/analytics/route-error-lifecycle-loaded")
+        .then((module) =>
+          module.createLoadedRouteErrorLifecycleController(analytics, initial),
+        )
+        .catch((error: unknown) => {
+          analytics.captureError(error, {
+            operation: "route-error.load",
+            type: "detached",
+          });
+          return undefined;
         });
-        return undefined;
-      });
+    }
     return await loaded;
   };
   const captureDispatchError = (error: unknown) => {
@@ -88,6 +96,13 @@ export const createRouteErrorLifecycleController = (
       run((controller) => controller.retryStarted(reference, recovery));
     },
     shown: (options) => {
+      if (capturedReference !== options.reference) {
+        capturedReference = options.reference;
+        analytics.captureError(options.error, {
+          reference: options.reference,
+          type: "recovery",
+        });
+      }
       run((controller) => controller.shown(options));
     },
     updateInspectorState: (inspectorState) => {

--- a/apps/web/src/lib/analytics/route-error-lifecycle.ts
+++ b/apps/web/src/lib/analytics/route-error-lifecycle.ts
@@ -77,14 +77,13 @@ export const createRouteErrorLifecycleController = (
   };
   const run = async (
     action: (controller: RouteErrorLifecycleController) => void | Promise<void>,
-  ): Promise<void> =>
-    load()
-      .then(async (controller) => {
-        if (controller) {
-          await action(controller);
-        }
-      })
-      .catch(captureDispatchError);
+  ): Promise<void> => {
+    const controller = await load();
+    if (!controller) {
+      return;
+    }
+    await Promise.resolve(action(controller)).catch(captureDispatchError);
+  };
   const runIfLoaded = (
     action: (controller: RouteErrorLifecycleController) => void,
   ) => {

--- a/apps/web/src/lib/analytics/types.ts
+++ b/apps/web/src/lib/analytics/types.ts
@@ -5,6 +5,7 @@ export const WEB_ANALYTICS_EVENTS = {
   identify: "$identify",
   pageViewed: "page_viewed",
   guideStepSkipped: "guide_step_skipped",
+  routeErrorRecovery: "route_error_recovery",
 } as const;
 
 export type WebAnalyticsEvent =
@@ -14,6 +15,9 @@ export type Analytics = {
   captureError: (error: unknown, context?: ErrorCaptureContext) => void;
   capturePageViewed: (properties: PageViewedProperties) => void;
   captureGuideStepSkipped: (properties: GuideStepSkippedProperties) => void;
+  captureRouteErrorLifecycle: (
+    properties: RouteErrorLifecycleProperties,
+  ) => void;
   identifyUser: (user: AnalyticsUserIdentity) => void;
   reset: (options?: AnalyticsResetOptions) => void;
 };
@@ -45,6 +49,19 @@ export type AnalyticsResetOptions = {
 
 export type PageViewedProperties = {
   path: string;
+};
+
+type RouteErrorLifecycleCommon = {
+  errorFingerprint: string;
+  incidentReference: ErrorReference;
+  inspectorState: "empty" | "minimized" | "open" | "unavailable";
+  recovery: "reload-page" | "retry-route";
+  reference: ErrorReference;
+  routeTemplate: string;
+};
+
+export type RouteErrorLifecycleProperties = RouteErrorLifecycleCommon & {
+  status: "shown" | "retry_started" | "recurred";
 };
 
 export type AnalyticsUserIdentity = {

--- a/apps/web/src/lib/analytics/types.ts
+++ b/apps/web/src/lib/analytics/types.ts
@@ -17,7 +17,7 @@ export type Analytics = {
   captureGuideStepSkipped: (properties: GuideStepSkippedProperties) => void;
   captureRouteErrorLifecycle: (
     properties: RouteErrorLifecycleProperties,
-  ) => void;
+  ) => Promise<void>;
   identifyUser: (user: AnalyticsUserIdentity) => void;
   reset: (options?: AnalyticsResetOptions) => void;
 };

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -10,7 +10,10 @@ import {
 } from "@/components/route-components";
 import { installChatRuntimeCleanup } from "@/features/chat/queries";
 import { createAnalyticsValue } from "@/lib/analytics/provider";
-import { createRouteErrorLifecycleController } from "@/lib/analytics/route-error-lifecycle";
+import {
+  createRouteErrorLifecycleController,
+  resolveCaughtRouteTemplate,
+} from "@/lib/analytics/route-error-lifecycle";
 import { STALE_TIME } from "@/lib/consts";
 import { installPDFDocumentCleanup } from "@/lib/pdf/hooks/use-pdf-document";
 import { routeTree } from "@/routeTree.gen";
@@ -31,14 +34,14 @@ export function getRouter() {
   });
   installPDFDocumentCleanup(queryClient);
   installChatRuntimeCleanup(queryClient);
-  let latestRouteTemplate = "unknown";
+  let readCaughtRouteTemplate = () => "unknown";
 
   const router = createRouter({
     routeTree,
     defaultPreload: "intent",
     context: { analyticsValue, queryClient, routeErrorLifecycle },
     defaultOnCatch: () => {
-      routeErrorLifecycle.caught(latestRouteTemplate);
+      routeErrorLifecycle.caught(readCaughtRouteTemplate());
     },
     // Keep browser scroll restoration after hydration, but avoid rendering
     // TanStack's restoration sibling during server streaming for client-only
@@ -55,6 +58,8 @@ export function getRouter() {
     defaultPendingMs: 500,
     defaultPendingMinMs: 300,
   });
+  readCaughtRouteTemplate = () =>
+    resolveCaughtRouteTemplate(router.state.matches);
 
   router.subscribe("onResolved", () => {
     // Report the matched route template (e.g. `/workspaces/$workspaceId`),
@@ -65,7 +70,6 @@ export function getRouter() {
     if (path === undefined) {
       return;
     }
-    latestRouteTemplate = path;
     routeErrorLifecycle.routeResolved(path);
     analyticsValue.analytics.capturePageViewed({ path });
   });

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/components/route-components";
 import { installChatRuntimeCleanup } from "@/features/chat/queries";
 import { createAnalyticsValue } from "@/lib/analytics/provider";
+import { createRouteErrorLifecycleController } from "@/lib/analytics/route-error-lifecycle";
 import { STALE_TIME } from "@/lib/consts";
 import { installPDFDocumentCleanup } from "@/lib/pdf/hooks/use-pdf-document";
 import { routeTree } from "@/routeTree.gen";
@@ -18,6 +19,9 @@ enableMapSet();
 
 export function getRouter() {
   const analyticsValue = createAnalyticsValue();
+  const routeErrorLifecycle = createRouteErrorLifecycleController(
+    analyticsValue.analytics,
+  );
   const queryClient = new QueryClient({
     defaultOptions: {
       queries: {
@@ -27,11 +31,15 @@ export function getRouter() {
   });
   installPDFDocumentCleanup(queryClient);
   installChatRuntimeCleanup(queryClient);
+  let latestRouteTemplate = "unknown";
 
   const router = createRouter({
     routeTree,
     defaultPreload: "intent",
-    context: { analyticsValue, queryClient },
+    context: { analyticsValue, queryClient, routeErrorLifecycle },
+    defaultOnCatch: () => {
+      routeErrorLifecycle.caught(latestRouteTemplate);
+    },
     // Keep browser scroll restoration after hydration, but avoid rendering
     // TanStack's restoration sibling during server streaming for client-only
     // top-level routes.
@@ -57,6 +65,8 @@ export function getRouter() {
     if (path === undefined) {
       return;
     }
+    latestRouteTemplate = path;
+    routeErrorLifecycle.routeResolved(path);
     analyticsValue.analytics.capturePageViewed({ path });
   });
 

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -16,6 +16,7 @@ import {
   DefaultPendingComponent,
 } from "@/components/route-components";
 import type { AnalyticsValue } from "@/lib/analytics/provider";
+import type { RouteErrorLifecycleController } from "@/lib/analytics/route-error-lifecycle";
 import "@/fonts.css";
 import { isPublicSsrPath } from "@/lib/public-ssr-paths";
 import "@stll/ui/globals.css";
@@ -28,6 +29,7 @@ const DevRoot = isDev
 export const Route = createRootRouteWithContext<{
   analyticsValue: AnalyticsValue;
   queryClient: QueryClient;
+  routeErrorLifecycle: RouteErrorLifecycleController;
 }>()({
   ssr: ({ location }) => isPublicSsrPath(location.pathname),
   shellComponent: RootDocument,

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -49,7 +49,9 @@ export const Route = createRootRouteWithContext<{
     ],
   }),
   pendingComponent: () => <DefaultPendingComponent className="h-dvh" />,
-  errorComponent: RootErrorComponent,
+  errorComponent: (props) => (
+    <DefaultErrorComponent className="h-dvh" {...props} />
+  ),
 });
 
 function RootComponent() {
@@ -57,37 +59,24 @@ function RootComponent() {
     select: (context) => ({
       analyticsValue: context.analyticsValue,
       queryClient: context.queryClient,
-      routeErrorLifecycle: context.routeErrorLifecycle,
     }),
   });
 
   return (
-    <RouteErrorLifecycleProvider controller={appContext.routeErrorLifecycle}>
-      <AppProviders
-        analyticsValue={appContext.analyticsValue}
-        queryClient={appContext.queryClient}
-      >
-        <RootApp />
-      </AppProviders>
-    </RouteErrorLifecycleProvider>
-  );
-}
-
-function RootErrorComponent(
-  props: Parameters<typeof DefaultErrorComponent>[0],
-) {
-  const routeErrorLifecycle = Route.useRouteContext({
-    select: (context) => context.routeErrorLifecycle,
-  });
-
-  return (
-    <RouteErrorLifecycleProvider controller={routeErrorLifecycle}>
-      <DefaultErrorComponent className="h-dvh" {...props} />
-    </RouteErrorLifecycleProvider>
+    <AppProviders
+      analyticsValue={appContext.analyticsValue}
+      queryClient={appContext.queryClient}
+    >
+      <RootApp />
+    </AppProviders>
   );
 }
 
 function RootDocument({ children }: Readonly<{ children: ReactNode }>) {
+  const routeErrorLifecycle = Route.useRouteContext({
+    select: (context) => context.routeErrorLifecycle,
+  });
+
   return (
     // prepaint-init.js mutates the html element's class, and for RTL
     // locales its lang/dir, before React hydrates the document, so the
@@ -103,7 +92,9 @@ function RootDocument({ children }: Readonly<{ children: ReactNode }>) {
         <script src="/prepaint-init.js" />
       </head>
       <body>
-        {children}
+        <RouteErrorLifecycleProvider controller={routeErrorLifecycle}>
+          {children}
+        </RouteErrorLifecycleProvider>
         <Scripts />
       </body>
     </html>

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -49,9 +49,7 @@ export const Route = createRootRouteWithContext<{
     ],
   }),
   pendingComponent: () => <DefaultPendingComponent className="h-dvh" />,
-  errorComponent: (props) => (
-    <DefaultErrorComponent className="h-dvh" {...props} />
-  ),
+  errorComponent: RootErrorComponent,
 });
 
 function RootComponent() {
@@ -59,24 +57,37 @@ function RootComponent() {
     select: (context) => ({
       analyticsValue: context.analyticsValue,
       queryClient: context.queryClient,
+      routeErrorLifecycle: context.routeErrorLifecycle,
     }),
   });
 
   return (
-    <AppProviders
-      analyticsValue={appContext.analyticsValue}
-      queryClient={appContext.queryClient}
-    >
-      <RootApp />
-    </AppProviders>
+    <RouteErrorLifecycleProvider controller={appContext.routeErrorLifecycle}>
+      <AppProviders
+        analyticsValue={appContext.analyticsValue}
+        queryClient={appContext.queryClient}
+      >
+        <RootApp />
+      </AppProviders>
+    </RouteErrorLifecycleProvider>
   );
 }
 
-function RootDocument({ children }: Readonly<{ children: ReactNode }>) {
+function RootErrorComponent(
+  props: Parameters<typeof DefaultErrorComponent>[0],
+) {
   const routeErrorLifecycle = Route.useRouteContext({
     select: (context) => context.routeErrorLifecycle,
   });
 
+  return (
+    <RouteErrorLifecycleProvider controller={routeErrorLifecycle}>
+      <DefaultErrorComponent className="h-dvh" {...props} />
+    </RouteErrorLifecycleProvider>
+  );
+}
+
+function RootDocument({ children }: Readonly<{ children: ReactNode }>) {
   return (
     // prepaint-init.js mutates the html element's class, and for RTL
     // locales its lang/dir, before React hydrates the document, so the
@@ -92,9 +103,7 @@ function RootDocument({ children }: Readonly<{ children: ReactNode }>) {
         <script src="/prepaint-init.js" />
       </head>
       <body>
-        <RouteErrorLifecycleProvider controller={routeErrorLifecycle}>
-          {children}
-        </RouteErrorLifecycleProvider>
+        {children}
         <Scripts />
       </body>
     </html>

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -17,6 +17,7 @@ import {
 } from "@/components/route-components";
 import type { AnalyticsValue } from "@/lib/analytics/provider";
 import type { RouteErrorLifecycleController } from "@/lib/analytics/route-error-lifecycle";
+import { RouteErrorLifecycleProvider } from "@/lib/analytics/route-error-lifecycle-context";
 import "@/fonts.css";
 import { isPublicSsrPath } from "@/lib/public-ssr-paths";
 import "@stll/ui/globals.css";
@@ -72,6 +73,10 @@ function RootComponent() {
 }
 
 function RootDocument({ children }: Readonly<{ children: ReactNode }>) {
+  const routeErrorLifecycle = Route.useRouteContext({
+    select: (context) => context.routeErrorLifecycle,
+  });
+
   return (
     // prepaint-init.js mutates the html element's class, and for RTL
     // locales its lang/dir, before React hydrates the document, so the
@@ -87,7 +92,9 @@ function RootDocument({ children }: Readonly<{ children: ReactNode }>) {
         <script src="/prepaint-init.js" />
       </head>
       <body>
-        {children}
+        <RouteErrorLifecycleProvider controller={routeErrorLifecycle}>
+          {children}
+        </RouteErrorLifecycleProvider>
         <Scripts />
       </body>
     </html>

--- a/scripts/bundle-baseline.json
+++ b/scripts/bundle-baseline.json
@@ -7,7 +7,7 @@
   "vendor-editor": 120547,
   "vendor-graphs": 189783,
   "vendor-react": 56623,
-  "vendor-tanstack": 506879,
+  "vendor-tanstack": 522598,
   "vendor-tanstack-server-fn": 1535,
   "wasm-vendor": 0
 }


### PR DESCRIPTION
## Summary

- capture route crash, retry, and recurrence lifecycle events in PostHog
- correlate occurrences with stable incident references, route templates, build/session metadata, and inspector state
- derive privacy-safe fingerprints from compiled first-party asset positions and reject unapproved event properties
- lazy-load the diagnostic pipeline so normal navigation does not pay its bundle cost
- record the combined TanStack vendor size after parallel dependency updates, each validated against the same earlier base, landed together; no entry or route budget changed

CC on behalf of sok0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added improved route-error lifecycle tracking for clearer diagnostics and recovery monitoring.
  - Inspector status now reflects whether route errors are open, minimised, or cleared.
  - Added stable error identification to support more consistent diagnostics across sessions.

- **Bug Fixes**
  - Improved handling of route-error retries, repeated incidents, and successfully resolved routes.
  - Added safeguards to prevent duplicate or malformed diagnostic events.

- **Tests**
  - Expanded coverage for route-error recovery, retries, recurrence, page reloads, and inspector state updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->