### PR TITLE
fix(api): anchor deletion effect settlement clocks

### DIFF
--- a/apps/api/src/lib/account-deletion-effect-store.ts
+++ b/apps/api/src/lib/account-deletion-effect-store.ts
@@ -142,14 +142,14 @@ const synchronizeParentProjection = async (
   await tx
     .update(accountDeletionRequests)
     .set({
-      completedAt: status === "completed" ? sql`CURRENT_TIMESTAMP` : null,
+      completedAt: status === "completed" ? sql`statement_timestamp()` : null,
       errorMessage: failed?.errorMessage ?? null,
       status,
       storageCleanup:
         status === "completed"
           ? { s3Keys: [] }
           : sql`${accountDeletionRequests.storageCleanup}`,
-      updatedAt: sql`CURRENT_TIMESTAMP`,
+      updatedAt: sql`statement_timestamp()`,
     })
     .where(eq(accountDeletionRequests.id, requestId));
 };
@@ -339,14 +339,14 @@ export const completeAccountDeletionEffectChunk = async (
       await tx
         .update(accountDeletionEffectChunks)
         .set({
-          completedAt: sql`CURRENT_TIMESTAMP`,
+          completedAt: sql`statement_timestamp()`,
           errorMessage: null,
           leaseExpiresAt: null,
           leaseToken: null,
           nextAttemptAt: null,
           s3Keys: [],
           status: "completed",
-          updatedAt: sql`CURRENT_TIMESTAMP`,
+          updatedAt: sql`statement_timestamp()`,
         })
         .where(
           and(

--- a/apps/api/src/lib/account-deletion-effect-store.ts
+++ b/apps/api/src/lib/account-deletion-effect-store.ts
@@ -142,14 +142,14 @@ const synchronizeParentProjection = async (
   await tx
     .update(accountDeletionRequests)
     .set({
-      completedAt: status === "completed" ? new Date() : null,
+      completedAt: status === "completed" ? sql`CURRENT_TIMESTAMP` : null,
       errorMessage: failed?.errorMessage ?? null,
       status,
       storageCleanup:
         status === "completed"
           ? { s3Keys: [] }
           : sql`${accountDeletionRequests.storageCleanup}`,
-      updatedAt: new Date(),
+      updatedAt: sql`CURRENT_TIMESTAMP`,
     })
     .where(eq(accountDeletionRequests.id, requestId));
 };
@@ -339,14 +339,14 @@ export const completeAccountDeletionEffectChunk = async (
       await tx
         .update(accountDeletionEffectChunks)
         .set({
-          completedAt: new Date(),
+          completedAt: sql`CURRENT_TIMESTAMP`,
           errorMessage: null,
           leaseExpiresAt: null,
           leaseToken: null,
           nextAttemptAt: null,
           s3Keys: [],
           status: "completed",
-          updatedAt: new Date(),
+          updatedAt: sql`CURRENT_TIMESTAMP`,
         })
         .where(
           and(

--- a/apps/api/src/lib/entity-deletion-effect-store.ts
+++ b/apps/api/src/lib/entity-deletion-effect-store.ts
@@ -127,7 +127,7 @@ const synchronizeParentProjection = async (
   await tx
     .update(entityDeletionCleanupRequests)
     .set({
-      completedAt: status === "completed" ? new Date() : null,
+      completedAt: status === "completed" ? sql`CURRENT_TIMESTAMP` : null,
       errorMessage: failed?.errorMessage ?? null,
       nextAttemptAt: failed?.nextAttemptAt ?? null,
       s3Keys:
@@ -135,7 +135,7 @@ const synchronizeParentProjection = async (
           ? []
           : sql`${entityDeletionCleanupRequests.s3Keys}`,
       status,
-      updatedAt: new Date(),
+      updatedAt: sql`CURRENT_TIMESTAMP`,
     })
     .where(eq(entityDeletionCleanupRequests.id, requestId));
 };
@@ -300,14 +300,14 @@ export const completeEntityDeletionEffectChunk = async (
       await tx
         .update(entityDeletionEffectChunks)
         .set({
-          completedAt: new Date(),
+          completedAt: sql`CURRENT_TIMESTAMP`,
           errorMessage: null,
           leaseExpiresAt: null,
           leaseToken: null,
           nextAttemptAt: null,
           s3Keys: [],
           status: "completed",
-          updatedAt: new Date(),
+          updatedAt: sql`CURRENT_TIMESTAMP`,
         })
         .where(
           and(

--- a/apps/api/src/lib/entity-deletion-effect-store.ts
+++ b/apps/api/src/lib/entity-deletion-effect-store.ts
@@ -127,7 +127,7 @@ const synchronizeParentProjection = async (
   await tx
     .update(entityDeletionCleanupRequests)
     .set({
-      completedAt: status === "completed" ? sql`CURRENT_TIMESTAMP` : null,
+      completedAt: status === "completed" ? sql`statement_timestamp()` : null,
       errorMessage: failed?.errorMessage ?? null,
       nextAttemptAt: failed?.nextAttemptAt ?? null,
       s3Keys:
@@ -135,7 +135,7 @@ const synchronizeParentProjection = async (
           ? []
           : sql`${entityDeletionCleanupRequests.s3Keys}`,
       status,
-      updatedAt: sql`CURRENT_TIMESTAMP`,
+      updatedAt: sql`statement_timestamp()`,
     })
     .where(eq(entityDeletionCleanupRequests.id, requestId));
 };
@@ -300,14 +300,14 @@ export const completeEntityDeletionEffectChunk = async (
       await tx
         .update(entityDeletionEffectChunks)
         .set({
-          completedAt: sql`CURRENT_TIMESTAMP`,
+          completedAt: sql`statement_timestamp()`,
           errorMessage: null,
           leaseExpiresAt: null,
           leaseToken: null,
           nextAttemptAt: null,
           s3Keys: [],
           status: "completed",
-          updatedAt: sql`CURRENT_TIMESTAMP`,
+          updatedAt: sql`statement_timestamp()`,
         })
         .where(
           and(


### PR DESCRIPTION
## Summary

- derive chunk completion timestamps from PostgreSQL rather than worker hosts
- derive account and entity parent projection progress from the same database clock
- preserve consistent stale-work fences and recovery ordering during mixed-version operation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the consistency and accuracy of timestamps recorded when account and entity deletion operations update their progress.
  * Preserved existing status, retry, lease, cleanup, and error-handling behaviour.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->