### PR TITLE
fix(api): durably enqueue extraction for copied documents

### DIFF
--- a/.oxlint-plugins/__fixtures__/no-unowned-file-version-write.fixture.ts
+++ b/.oxlint-plugins/__fixtures__/no-unowned-file-version-write.fixture.ts
@@ -11,7 +11,10 @@ import {
   // oxlint-disable-next-line no-unowned-file-version-write/no-unowned-file-version-write -- fixture: version numbering outside a reviewed owner must be rejected
   nextEntityVersionNumber,
 } from "@/api/lib/entity-versions/version-utils";
-import { requestNativeExtractionRun } from "@/api/lib/search/process-extraction";
+import {
+  requestNativeExtractionRun,
+  requestNativeExtractionRuns,
+} from "@/api/lib/search/process-extraction";
 
 import * as relativeSchema from "../../apps/api/src/db/schema.ts";
 import * as relativeVersionUtils from "../../apps/api/src/lib/entity-versions/version-utils.ts";
@@ -73,3 +76,9 @@ declare const extractionRequest: Parameters<
 >[0];
 // oxlint-disable-next-line no-unowned-file-version-write/no-unowned-file-version-write -- fixture: durable extraction requests outside a reviewed source writer must be rejected
 await requestNativeExtractionRun(extractionRequest);
+
+declare const extractionRequests: Parameters<
+  typeof requestNativeExtractionRuns
+>[0];
+// oxlint-disable-next-line no-unowned-file-version-write/no-unowned-file-version-write -- fixture: batched durable extraction requests outside a reviewed source writer must be rejected
+await requestNativeExtractionRuns(extractionRequests);

--- a/.oxlint-plugins/no-unowned-file-version-write.ts
+++ b/.oxlint-plugins/no-unowned-file-version-write.ts
@@ -28,6 +28,11 @@ const VERSION_WRITE_HELPERS = new Set([
   "nextEntityVersionNumber",
 ]);
 
+const NATIVE_EXTRACTION_REQUEST_HELPERS = new Set([
+  "requestNativeExtractionRun",
+  "requestNativeExtractionRuns",
+]);
+
 const isScopeIdentifier = (node: unknown): node is ESTree.IdentifierReference =>
   isIdentifier(node);
 
@@ -286,8 +291,10 @@ export default eslintCompatPlugin({
                   processExtractionNamespaces.add(specifier.local.name);
                   continue;
                 }
+                const importedName = getImportedName(specifier);
                 if (
-                  getImportedName(specifier) === "requestNativeExtractionRun"
+                  importedName !== null &&
+                  NATIVE_EXTRACTION_REQUEST_HELPERS.has(importedName)
                 ) {
                   const localName = getImportLocalName(specifier);
                   if (localName !== null) {
@@ -387,8 +394,9 @@ export default eslintCompatPlugin({
               (callee?.type === "MemberExpression" &&
                 isIdentifier(callee.object) &&
                 processExtractionNamespaces.has(callee.object.name) &&
-                getPropertyName(callee.property) ===
-                  "requestNativeExtractionRun");
+                NATIVE_EXTRACTION_REQUEST_HELPERS.has(
+                  getPropertyName(callee.property) ?? "",
+                ));
             if (isNativeExtractionRequest) {
               claimCapability(
                 VERSION_WRITE_CAPABILITY.REQUEST_NATIVE_EXTRACTION,

--- a/apps/api/src/handlers/entities/copy-to-workspace.test.ts
+++ b/apps/api/src/handlers/entities/copy-to-workspace.test.ts
@@ -464,7 +464,9 @@ describe("copy-to-workspace", () => {
       throw new Error("Expected the copy to be inserted");
     }
     expect(requestNativeExtractionRunsMock).toHaveBeenCalledTimes(1);
-    expect(enqueueDocumentProcessingRunMock.mock.calls).toEqual([["run_0"]]);
+    expect(enqueueDocumentProcessingRunMock.mock.calls).toEqual([
+      [toSafeId<"documentProcessingRun">("run_0")],
+    ]);
     expect(enqueueEntitySearchRepairsMock.mock.calls.at(0)?.at(1)).toEqual([]);
   });
 

--- a/apps/api/src/handlers/entities/copy-to-workspace.test.ts
+++ b/apps/api/src/handlers/entities/copy-to-workspace.test.ts
@@ -72,7 +72,10 @@ void mock.module("@/api/lib/search/process-extraction", () => ({
 const enqueueDocumentProcessingRunMock = mock(
   async (_runId: SafeId<"documentProcessingRun">) => undefined,
 );
+const realDocumentProcessingEnqueue =
+  await import("@/api/lib/document-processing-enqueue");
 void mock.module("@/api/lib/document-processing-enqueue", () => ({
+  ...realDocumentProcessingEnqueue,
   enqueueDocumentProcessingRun: enqueueDocumentProcessingRunMock,
 }));
 

--- a/apps/api/src/handlers/entities/copy-to-workspace.test.ts
+++ b/apps/api/src/handlers/entities/copy-to-workspace.test.ts
@@ -57,11 +57,21 @@ void mock.module("@/api/lib/s3-presign", () => ({
 // split from here. Only the durable extraction request itself is replaced.
 const realProcessExtraction =
   await import("@/api/lib/search/process-extraction");
-const processExtractionMock = mock(async (_entityId: string) => undefined);
+const requestNativeExtractionRunsMock = mock(
+  async ({ requests }: { requests: readonly unknown[] }) =>
+    requests.map((_, index) =>
+      toSafeId<"documentProcessingRun">(`run_${index}`),
+    ),
+);
 void mock.module("@/api/lib/search/process-extraction", () => ({
   ...realProcessExtraction,
-  processExtraction: processExtractionMock,
   requestNativeExtractionRun: mock(async () => null),
+  requestNativeExtractionRuns: requestNativeExtractionRunsMock,
+}));
+
+const enqueueDocumentProcessingRunMock = mock(async () => undefined);
+void mock.module("@/api/lib/document-processing-enqueue", () => ({
+  enqueueDocumentProcessingRun: enqueueDocumentProcessingRunMock,
 }));
 
 const enqueueEntitySearchRepairsMock = mock(
@@ -225,7 +235,8 @@ beforeEach(() => {
   writeMock.mockClear();
   s3DeleteMock.mockClear();
   captureErrorMock.mockClear();
-  processExtractionMock.mockClear();
+  requestNativeExtractionRunsMock.mockClear();
+  enqueueDocumentProcessingRunMock.mockClear();
   enqueueEntitySearchRepairsMock.mockClear();
   flushEntitySearchRepairsMock.mockClear();
   syncWorkspaceSearchActivityMock.mockClear();
@@ -450,7 +461,8 @@ describe("copy-to-workspace", () => {
     if (!copiedEntity) {
       throw new Error("Expected the copy to be inserted");
     }
-    expect(processExtractionMock.mock.calls).toEqual([[copiedEntity.id]]);
+    expect(requestNativeExtractionRunsMock).toHaveBeenCalledTimes(1);
+    expect(enqueueDocumentProcessingRunMock.mock.calls).toEqual([["run_0"]]);
     expect(enqueueEntitySearchRepairsMock.mock.calls.at(0)?.at(1)).toEqual([]);
   });
 
@@ -1374,7 +1386,7 @@ describe("copy-to-workspace", () => {
     // Neither copy has a file for an extraction run to read, so both are
     // marked dirty inside the copy transaction and nothing else would index
     // them if the post-commit flush were lost.
-    expect(processExtractionMock).not.toHaveBeenCalled();
+    expect(enqueueDocumentProcessingRunMock).not.toHaveBeenCalled();
     expect(enqueueEntitySearchRepairsMock).toHaveBeenCalledTimes(1);
     expect(enqueueEntitySearchRepairsMock.mock.calls.at(0)?.at(1)).toEqual([
       copiedFolder?.id,
@@ -1592,7 +1604,7 @@ describe("copy-to-workspace", () => {
     // Nothing is indexed for copies that no longer exist.
     expect(enqueueEntitySearchRepairsMock).not.toHaveBeenCalled();
     expect(flushEntitySearchRepairsMock).not.toHaveBeenCalled();
-    expect(processExtractionMock).not.toHaveBeenCalled();
+    expect(enqueueDocumentProcessingRunMock).not.toHaveBeenCalled();
   });
 
   test("rejects copy to same workspace", async () => {

--- a/apps/api/src/handlers/entities/copy-to-workspace.test.ts
+++ b/apps/api/src/handlers/entities/copy-to-workspace.test.ts
@@ -69,7 +69,9 @@ void mock.module("@/api/lib/search/process-extraction", () => ({
   requestNativeExtractionRuns: requestNativeExtractionRunsMock,
 }));
 
-const enqueueDocumentProcessingRunMock = mock(async () => undefined);
+const enqueueDocumentProcessingRunMock = mock(
+  async (_runId: SafeId<"documentProcessingRun">) => undefined,
+);
 void mock.module("@/api/lib/document-processing-enqueue", () => ({
   enqueueDocumentProcessingRun: enqueueDocumentProcessingRunMock,
 }));

--- a/apps/api/src/handlers/entities/copy-to-workspace.ts
+++ b/apps/api/src/handlers/entities/copy-to-workspace.ts
@@ -25,7 +25,9 @@ import type { AuditRecorder } from "@/api/lib/audit-log";
 import { AUDIT_ACTION, AUDIT_RESOURCE_TYPE } from "@/api/lib/audit-log";
 import type { SafeId } from "@/api/lib/branded-types";
 import { tSafeId } from "@/api/lib/custom-schema";
-import { enqueueDocumentProcessingRun } from "@/api/lib/document-processing-enqueue";
+import {
+  handoffCommittedDocumentProcessingRuns,
+} from "@/api/lib/document-processing-handoff";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import {
   enqueueImageThumbnailOrMarkFailed,
@@ -549,9 +551,9 @@ const copyToWorkspaceHandler = async function* ({
   ).catch(captureError);
 
   // Acceleration only: each run already committed with its copied source.
-  for (const runId of txResult.nativeExtractionRunIds) {
-    enqueueDocumentProcessingRun(runId).catch(captureError);
-  }
+  handoffCommittedDocumentProcessingRuns({
+    runIds: txResult.nativeExtractionRunIds,
+  }).catch(captureError);
 
   // Enqueue PDF derivative generation for copied file fields
   for (const fileField of txResult.fileFields) {

--- a/apps/api/src/handlers/entities/copy-to-workspace.ts
+++ b/apps/api/src/handlers/entities/copy-to-workspace.ts
@@ -25,9 +25,7 @@ import type { AuditRecorder } from "@/api/lib/audit-log";
 import { AUDIT_ACTION, AUDIT_RESOURCE_TYPE } from "@/api/lib/audit-log";
 import type { SafeId } from "@/api/lib/branded-types";
 import { tSafeId } from "@/api/lib/custom-schema";
-import {
-  handoffCommittedDocumentProcessingRuns,
-} from "@/api/lib/document-processing-handoff";
+import { handoffCommittedDocumentProcessingRuns } from "@/api/lib/document-processing-handoff";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import {
   enqueueImageThumbnailOrMarkFailed,

--- a/apps/api/src/handlers/entities/copy-to-workspace.ts
+++ b/apps/api/src/handlers/entities/copy-to-workspace.ts
@@ -25,6 +25,7 @@ import type { AuditRecorder } from "@/api/lib/audit-log";
 import { AUDIT_ACTION, AUDIT_RESOURCE_TYPE } from "@/api/lib/audit-log";
 import type { SafeId } from "@/api/lib/branded-types";
 import { tSafeId } from "@/api/lib/custom-schema";
+import { enqueueDocumentProcessingRun } from "@/api/lib/document-processing-enqueue";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import {
   enqueueImageThumbnailOrMarkFailed,
@@ -40,10 +41,7 @@ import { LIMITS } from "@/api/lib/limits";
 import { DOCUMENT_TYPE_CLASSIFIER_ROLE } from "@/api/lib/properties/create-schema";
 import { broadcastWorkspaceResourceSetUpdated } from "@/api/lib/resource-realtime";
 import { syncWorkspaceSearchActivity } from "@/api/lib/search/index-global";
-import {
-  processExtraction,
-  SEARCH_INDEX_OWNER,
-} from "@/api/lib/search/process-extraction";
+import { SEARCH_INDEX_OWNER } from "@/api/lib/search/process-extraction";
 import { flushEntitySearchRepairs } from "@/api/lib/search/projection-repair-queue";
 
 const copyToWorkspaceBodySchema = t.Object({
@@ -479,6 +477,7 @@ const copyToWorkspaceHandler = async function* ({
   const sourceEntityIds = sourceEntities.map((e) => e.id);
   const txResultResult = await safeDb(async (tx) => {
     const copyResult = await copyEntities({
+      organizationId,
       tx,
       targetWorkspaceId,
       targetParentId,
@@ -549,11 +548,9 @@ const copyToWorkspaceHandler = async function* ({
     txResult.entityIdsBySearchIndexOwner[SEARCH_INDEX_OWNER.searchMark],
   ).catch(captureError);
 
-  // Request extraction for the copies a run indexes
-  for (const entityId of txResult.entityIdsBySearchIndexOwner[
-    SEARCH_INDEX_OWNER.durableExtraction
-  ]) {
-    processExtraction(entityId).catch(captureError);
+  // Acceleration only: each run already committed with its copied source.
+  for (const runId of txResult.nativeExtractionRunIds) {
+    enqueueDocumentProcessingRun(runId).catch(captureError);
   }
 
   // Enqueue PDF derivative generation for copied file fields

--- a/apps/api/src/handlers/entities/copy-utils.db.test.ts
+++ b/apps/api/src/handlers/entities/copy-utils.db.test.ts
@@ -6,6 +6,7 @@ import { organization, user } from "@/api/db/auth-schema";
 import type { Transaction } from "@/api/db/root";
 import { transactionAbortError } from "@/api/db/safe-db";
 import {
+  documentProcessingRuns,
   entities,
   entityVersions,
   fields,
@@ -91,7 +92,7 @@ const seedMatter = async (): Promise<SeededMatter> => {
       id: propertyId,
       workspaceId,
       name: "Summary",
-      content: { type: "text", version: 1 },
+      content: { type: "file", version: 1 },
       tool: { type: "manual-input", version: 1 },
       status: "fresh",
     });
@@ -133,7 +134,18 @@ const subtree = ({
       fields: [
         {
           propertyId,
-          content: { version: 1, type: "text", value: "Filed 2026-01-08" },
+          content: {
+            type: "file",
+            version: 1,
+            id: Bun.randomUUIDv7(),
+            fileName: "Statement of claim.docx",
+            mimeType:
+              "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            sizeBytes: 1024,
+            encrypted: false,
+            sha256Hex: "a".repeat(64),
+            pdfFileId: null,
+          },
         },
       ],
     },
@@ -158,6 +170,7 @@ const runCopy = async (
       await testDb.transaction(async (tx: TestDatabaseTransaction) => {
         await tx.execute(sql.raw("RESET ROLE"));
         return await copyEntities({
+          organizationId: matter.organizationId,
           tx: asTestRaw<Transaction>(tx),
           targetWorkspaceId: matter.workspaceId,
           targetParentId: null,
@@ -183,6 +196,10 @@ const persistedCounts = async (matter: SeededMatter) => ({
     fields,
     eq(fields.workspaceId, matter.workspaceId),
   ),
+  extractionRuns: await testDb.$count(
+    documentProcessingRuns,
+    eq(documentProcessingRuns.organizationId, matter.organizationId),
+  ),
   searchMarks: await testDb.$count(
     searchProjectionRepairQueue,
     eq(searchProjectionRepairQueue.organizationId, matter.organizationId),
@@ -200,11 +217,47 @@ test("a complete subtree commits every copied row", async () => {
   );
 
   expect(Result.isOk(outcome)).toBe(true);
+  if (!Result.isOk(outcome)) {
+    throw new TypeError("Expected the copy transaction to commit");
+  }
+  const copiedDocument = outcome.value.copiedEntities.find(
+    ({ sourceId }) => sourceId === documentId,
+  );
+  if (!copiedDocument) {
+    throw new TypeError("Expected the document copy to persist");
+  }
+  const runId = outcome.value.nativeExtractionRunIds.at(0);
+  if (!runId) {
+    throw new TypeError(
+      "Expected the copied document to create an extraction run",
+    );
+  }
+  const run = await testDb.query.documentProcessingRuns.findFirst({
+    where: { id: { eq: runId } },
+  });
+  if (!run) {
+    throw new TypeError("Expected the extraction run to persist");
+  }
+  const copiedField = await testDb.query.fields.findFirst({
+    where: { id: { eq: run.fieldId } },
+  });
+  if (!copiedField || copiedField.content.type !== "file") {
+    throw new TypeError("Expected the run to reference a copied file field");
+  }
+  expect(run).toMatchObject({
+    entityId: copiedDocument.entityId,
+    entityVersionId: copiedField.entityVersionId,
+    organizationId: matter.organizationId,
+    sourceFileId: copiedField.content.id,
+    sourceSha256Hex: copiedField.content.sha256Hex,
+    workspaceId: matter.workspaceId,
+  });
   expect(await persistedCounts(matter)).toEqual({
     entities: 3,
     entityVersions: 3,
+    extractionRuns: 1,
     fields: 1,
-    searchMarks: 3,
+    searchMarks: 2,
   });
 });
 
@@ -236,6 +289,43 @@ test("a subtree that fails mid-loop persists no copy at all", async () => {
   expect(await persistedCounts(matter)).toEqual({
     entities: 0,
     entityVersions: 0,
+    extractionRuns: 0,
+    fields: 0,
+    searchMarks: 0,
+  });
+});
+
+test("rolling back after the copy also removes its extraction runs", async () => {
+  const matter = await seedMatter();
+  const sources = subtree({
+    propertyId: matter.propertyId,
+    lastVersion: { fields: [] },
+  });
+
+  const outcome = await Result.tryPromise(
+    async () =>
+      await testDb.transaction(async (tx: TestDatabaseTransaction) => {
+        await tx.execute(sql.raw("RESET ROLE"));
+        await copyEntities({
+          organizationId: matter.organizationId,
+          tx: asTestRaw<Transaction>(tx),
+          targetWorkspaceId: matter.workspaceId,
+          targetParentId: null,
+          userId: matter.userId,
+          recordAuditEvent: noAuditRows,
+          sourceEntityId: rootId,
+          sourceEntities: sources,
+          deleteSource: false,
+        });
+        throw new HandlerError({ status: 500, message: "force rollback" });
+      }),
+  );
+
+  expect(Result.isError(outcome)).toBe(true);
+  expect(await persistedCounts(matter)).toEqual({
+    entities: 0,
+    entityVersions: 0,
+    extractionRuns: 0,
     fields: 0,
     searchMarks: 0,
   });

--- a/apps/api/src/handlers/entities/copy-utils.db.test.ts
+++ b/apps/api/src/handlers/entities/copy-utils.db.test.ts
@@ -18,6 +18,7 @@ import type { AuditRecorder } from "@/api/lib/audit-log";
 import { toSafeId } from "@/api/lib/branded-types";
 import type { SafeId } from "@/api/lib/branded-types";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
+import { allocateFileObject } from "@/api/lib/files/file-object-ids";
 import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
 import { getTestDb, releaseTestDb } from "@/api/tests/security/test-utils";
 import type {
@@ -137,7 +138,7 @@ const subtree = ({
           content: {
             type: "file",
             version: 1,
-            id: Bun.randomUUIDv7(),
+            id: allocateFileObject(),
             fileName: "Statement of claim.docx",
             mimeType:
               "application/vnd.openxmlformats-officedocument.wordprocessingml.document",

--- a/apps/api/src/handlers/entities/copy-utils.ts
+++ b/apps/api/src/handlers/entities/copy-utils.ts
@@ -26,10 +26,14 @@ import { LIMITS } from "@/api/lib/limits";
 import { getS3 } from "@/api/lib/s3";
 import { copyObject } from "@/api/lib/s3-presign";
 import {
+  nativeExtractionRunRequestForFields,
+  requestNativeExtractionRuns,
   SEARCH_INDEX_OWNER,
-  searchIndexOwnerForFields,
 } from "@/api/lib/search/process-extraction";
-import type { SearchIndexOwner } from "@/api/lib/search/process-extraction";
+import type {
+  NativeExtractionRunRequest,
+  SearchIndexOwner,
+} from "@/api/lib/search/process-extraction";
 import { enqueueEntitySearchRepairs } from "@/api/lib/search/projection-repair-queue";
 
 export type EntityFieldSnapshot = {
@@ -468,15 +472,18 @@ export type CopyEntitiesResult = {
    * The copies grouped by which mechanism writes their search projection.
    * `search-mark` copies already carry a dirty mark committed with this
    * transaction; the caller only flushes it. `durable-extraction` copies are
-   * indexed by the run the caller requests for them.
+   * indexed by the run committed with the copy.
    */
   entityIdsBySearchIndexOwner: Record<SearchIndexOwner, SafeId<"entity">[]>;
+  /** Newly created runs to hand to the queue after this transaction commits. */
+  nativeExtractionRunIds: SafeId<"documentProcessingRun">[];
   copiedEntities: CopiedEntity[];
   /** File fields that may need PDF derivative generation. */
   fileFields: CopiedFileField[];
 };
 
 type CopyEntitiesProps = {
+  organizationId: SafeId<"organization">;
   tx: Transaction;
   targetWorkspaceId: SafeId<"workspace">;
   targetParentId: SafeId<"entity"> | null;
@@ -516,6 +523,7 @@ type CopyEntitiesProps = {
  * `transactionAbortError` and answer with it unchanged.
  */
 export const copyEntities = async ({
+  organizationId,
   tx,
   targetWorkspaceId,
   targetParentId,
@@ -592,6 +600,7 @@ export const copyEntities = async ({
     [SEARCH_INDEX_OWNER.durableExtraction]: [],
     [SEARCH_INDEX_OWNER.searchMark]: [],
   };
+  const nativeExtractionRequests: NativeExtractionRunRequest[] = [];
   const fileFields: CopiedFileField[] = [];
 
   for (const source of sourceEntities) {
@@ -691,9 +700,22 @@ export const copyEntities = async ({
     }
 
     idMap.set(source.id, newEntityId);
-    // The field ids above are minted in insertion order, so the copy resolves
-    // the same extraction source `processExtraction` will resolve for it.
-    copiedEntityIds[searchIndexOwnerForFields(fieldInserts)].push(newEntityId);
+    // The field ids above are minted in insertion order, so this derives the
+    // same source the post-commit processor would select without re-reading
+    // each copied entity.
+    const extractionRequest = nativeExtractionRunRequestForFields({
+      entityId: newEntityId,
+      entityVersionId: newVersionId,
+      fields: fieldInserts,
+      organizationId,
+      workspaceId: targetWorkspaceId,
+    });
+    if (extractionRequest === null) {
+      copiedEntityIds[SEARCH_INDEX_OWNER.searchMark].push(newEntityId);
+    } else {
+      copiedEntityIds[SEARCH_INDEX_OWNER.durableExtraction].push(newEntityId);
+      nativeExtractionRequests.push(extractionRequest);
+    }
     copiedEntities.push({
       sourceId: source.id,
       entityId: newEntityId,
@@ -744,11 +766,16 @@ export const copyEntities = async ({
     tx,
     copiedEntityIds[SEARCH_INDEX_OWNER.searchMark],
   );
+  const nativeExtractionRunIds = await requestNativeExtractionRuns({
+    requests: nativeExtractionRequests,
+    tx,
+  });
 
   return {
     entityId: rootEntityId,
     entityIdsBySearchIndexOwner: copiedEntityIds,
     copiedEntities,
     fileFields,
+    nativeExtractionRunIds,
   };
 };

--- a/apps/api/src/handlers/entities/duplicate.test.ts
+++ b/apps/api/src/handlers/entities/duplicate.test.ts
@@ -18,11 +18,21 @@ import { createScopedDbMock } from "@/api/tests/scoped-db-mock";
 // split from here. Only the durable extraction request itself is replaced.
 const realProcessExtraction =
   await import("@/api/lib/search/process-extraction");
-const processExtractionMock = mock(async (_entityId: string) => undefined);
+const requestNativeExtractionRunsMock = mock(
+  async ({ requests }: { requests: readonly unknown[] }) =>
+    requests.map((_, index) =>
+      toSafeId<"documentProcessingRun">(`run_${index}`),
+    ),
+);
 void mock.module("@/api/lib/search/process-extraction", () => ({
   ...realProcessExtraction,
-  processExtraction: processExtractionMock,
   requestNativeExtractionRun: mock(async () => null),
+  requestNativeExtractionRuns: requestNativeExtractionRunsMock,
+}));
+
+const enqueueDocumentProcessingRunMock = mock(async () => undefined);
+void mock.module("@/api/lib/document-processing-enqueue", () => ({
+  enqueueDocumentProcessingRun: enqueueDocumentProcessingRunMock,
 }));
 
 const enqueueEntitySearchRepairsMock = mock(
@@ -220,7 +230,8 @@ const createContext = ({
 describe("duplicate entity", () => {
   test("duplicates folder trees instead of rejecting folders", async () => {
     copyObjectMock.mockClear();
-    processExtractionMock.mockClear();
+    requestNativeExtractionRunsMock.mockClear();
+    enqueueDocumentProcessingRunMock.mockClear();
     enqueueEntitySearchRepairsMock.mockClear();
     flushEntitySearchRepairsMock.mockClear();
 
@@ -336,7 +347,8 @@ describe("duplicate entity", () => {
     // The DOCX copy is indexed by the extraction run that reads it; the two
     // folder copies have no such run, so their marks are written inside the
     // copy transaction and only flushed afterwards.
-    expect(processExtractionMock.mock.calls).toEqual([[documentDuplicate.id]]);
+    expect(requestNativeExtractionRunsMock).toHaveBeenCalledTimes(1);
+    expect(enqueueDocumentProcessingRunMock.mock.calls).toEqual([["run_0"]]);
     expect(enqueueEntitySearchRepairsMock).toHaveBeenCalledTimes(1);
     expect(enqueueEntitySearchRepairsMock.mock.calls.at(0)?.at(1)).toEqual([
       rootDuplicate.id,
@@ -346,7 +358,8 @@ describe("duplicate entity", () => {
   });
 
   test("returns every object copied for an aborted duplicate", async () => {
-    processExtractionMock.mockClear();
+    requestNativeExtractionRunsMock.mockClear();
+    enqueueDocumentProcessingRunMock.mockClear();
     enqueueEntitySearchRepairsMock.mockClear();
     flushEntitySearchRepairsMock.mockClear();
     copyObjectMock.mockClear();
@@ -415,6 +428,6 @@ describe("duplicate entity", () => {
     // Nothing is indexed for copies that no longer exist.
     expect(enqueueEntitySearchRepairsMock).not.toHaveBeenCalled();
     expect(flushEntitySearchRepairsMock).not.toHaveBeenCalled();
-    expect(processExtractionMock).not.toHaveBeenCalled();
+    expect(enqueueDocumentProcessingRunMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/handlers/entities/duplicate.test.ts
+++ b/apps/api/src/handlers/entities/duplicate.test.ts
@@ -33,7 +33,10 @@ void mock.module("@/api/lib/search/process-extraction", () => ({
 const enqueueDocumentProcessingRunMock = mock(
   async (_runId: SafeId<"documentProcessingRun">) => undefined,
 );
+const realDocumentProcessingEnqueue =
+  await import("@/api/lib/document-processing-enqueue");
 void mock.module("@/api/lib/document-processing-enqueue", () => ({
+  ...realDocumentProcessingEnqueue,
   enqueueDocumentProcessingRun: enqueueDocumentProcessingRunMock,
 }));
 

--- a/apps/api/src/handlers/entities/duplicate.test.ts
+++ b/apps/api/src/handlers/entities/duplicate.test.ts
@@ -350,7 +350,9 @@ describe("duplicate entity", () => {
     // folder copies have no such run, so their marks are written inside the
     // copy transaction and only flushed afterwards.
     expect(requestNativeExtractionRunsMock).toHaveBeenCalledTimes(1);
-    expect(enqueueDocumentProcessingRunMock.mock.calls).toEqual([["run_0"]]);
+    expect(enqueueDocumentProcessingRunMock.mock.calls).toEqual([
+      [toSafeId<"documentProcessingRun">("run_0")],
+    ]);
     expect(enqueueEntitySearchRepairsMock).toHaveBeenCalledTimes(1);
     expect(enqueueEntitySearchRepairsMock.mock.calls.at(0)?.at(1)).toEqual([
       rootDuplicate.id,

--- a/apps/api/src/handlers/entities/duplicate.test.ts
+++ b/apps/api/src/handlers/entities/duplicate.test.ts
@@ -30,7 +30,9 @@ void mock.module("@/api/lib/search/process-extraction", () => ({
   requestNativeExtractionRuns: requestNativeExtractionRunsMock,
 }));
 
-const enqueueDocumentProcessingRunMock = mock(async () => undefined);
+const enqueueDocumentProcessingRunMock = mock(
+  async (_runId: SafeId<"documentProcessingRun">) => undefined,
+);
 void mock.module("@/api/lib/document-processing-enqueue", () => ({
   enqueueDocumentProcessingRun: enqueueDocumentProcessingRunMock,
 }));

--- a/apps/api/src/handlers/entities/duplicate.ts
+++ b/apps/api/src/handlers/entities/duplicate.ts
@@ -20,16 +20,14 @@ import type { HandlerConfig } from "@/api/lib/api-handlers";
 import type { AuditRecorder } from "@/api/lib/audit-log";
 import type { SafeId } from "@/api/lib/branded-types";
 import { tSafeId } from "@/api/lib/custom-schema";
+import { enqueueDocumentProcessingRun } from "@/api/lib/document-processing-enqueue";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import {
   enqueueImageThumbnailOrMarkFailed,
   enqueuePdfDerivativeOrMarkFailed,
 } from "@/api/lib/file-derivative-queue";
 import { LIMITS } from "@/api/lib/limits";
-import {
-  processExtraction,
-  SEARCH_INDEX_OWNER,
-} from "@/api/lib/search/process-extraction";
+import { SEARCH_INDEX_OWNER } from "@/api/lib/search/process-extraction";
 import { flushEntitySearchRepairs } from "@/api/lib/search/projection-repair-queue";
 
 const duplicateEntityBodySchema = t.Object({
@@ -163,6 +161,7 @@ const duplicateEntityHandler = async function* ({
   const txResultResult = await safeDb(
     async (tx) =>
       await copyEntities({
+        organizationId,
         tx,
         targetWorkspaceId: workspaceId,
         targetParentId: source.parentId,
@@ -191,10 +190,8 @@ const duplicateEntityHandler = async function* ({
     txResult.entityIdsBySearchIndexOwner[SEARCH_INDEX_OWNER.searchMark],
   ).catch(captureError);
 
-  for (const entityId of txResult.entityIdsBySearchIndexOwner[
-    SEARCH_INDEX_OWNER.durableExtraction
-  ]) {
-    processExtraction(entityId).catch(captureError);
+  for (const runId of txResult.nativeExtractionRunIds) {
+    enqueueDocumentProcessingRun(runId).catch(captureError);
   }
 
   // The copies reference fresh file IDs, so each needs its own

--- a/apps/api/src/handlers/entities/duplicate.ts
+++ b/apps/api/src/handlers/entities/duplicate.ts
@@ -20,7 +20,9 @@ import type { HandlerConfig } from "@/api/lib/api-handlers";
 import type { AuditRecorder } from "@/api/lib/audit-log";
 import type { SafeId } from "@/api/lib/branded-types";
 import { tSafeId } from "@/api/lib/custom-schema";
-import { enqueueDocumentProcessingRun } from "@/api/lib/document-processing-enqueue";
+import {
+  handoffCommittedDocumentProcessingRuns,
+} from "@/api/lib/document-processing-handoff";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import {
   enqueueImageThumbnailOrMarkFailed,
@@ -190,9 +192,9 @@ const duplicateEntityHandler = async function* ({
     txResult.entityIdsBySearchIndexOwner[SEARCH_INDEX_OWNER.searchMark],
   ).catch(captureError);
 
-  for (const runId of txResult.nativeExtractionRunIds) {
-    enqueueDocumentProcessingRun(runId).catch(captureError);
-  }
+  handoffCommittedDocumentProcessingRuns({
+    runIds: txResult.nativeExtractionRunIds,
+  }).catch(captureError);
 
   // The copies reference fresh file IDs, so each needs its own
   // PDF/thumbnail derivatives.

--- a/apps/api/src/handlers/entities/duplicate.ts
+++ b/apps/api/src/handlers/entities/duplicate.ts
@@ -20,9 +20,7 @@ import type { HandlerConfig } from "@/api/lib/api-handlers";
 import type { AuditRecorder } from "@/api/lib/audit-log";
 import type { SafeId } from "@/api/lib/branded-types";
 import { tSafeId } from "@/api/lib/custom-schema";
-import {
-  handoffCommittedDocumentProcessingRuns,
-} from "@/api/lib/document-processing-handoff";
+import { handoffCommittedDocumentProcessingRuns } from "@/api/lib/document-processing-handoff";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import {
   enqueueImageThumbnailOrMarkFailed,

--- a/apps/api/src/handlers/workspaces/duplicate.test.ts
+++ b/apps/api/src/handlers/workspaces/duplicate.test.ts
@@ -76,7 +76,9 @@ void mock.module("@/api/lib/search/process-extraction", () => ({
   requestNativeExtractionRuns: requestNativeExtractionRunsMock,
 }));
 
-const enqueueDocumentProcessingRunMock = mock(async () => undefined);
+const enqueueDocumentProcessingRunMock = mock(
+  async (_runId: SafeId<"documentProcessingRun">) => undefined,
+);
 void mock.module("@/api/lib/document-processing-enqueue", () => ({
   enqueueDocumentProcessingRun: enqueueDocumentProcessingRunMock,
 }));

--- a/apps/api/src/handlers/workspaces/duplicate.test.ts
+++ b/apps/api/src/handlers/workspaces/duplicate.test.ts
@@ -79,7 +79,10 @@ void mock.module("@/api/lib/search/process-extraction", () => ({
 const enqueueDocumentProcessingRunMock = mock(
   async (_runId: SafeId<"documentProcessingRun">) => undefined,
 );
+const realDocumentProcessingEnqueue =
+  await import("@/api/lib/document-processing-enqueue");
 void mock.module("@/api/lib/document-processing-enqueue", () => ({
+  ...realDocumentProcessingEnqueue,
   enqueueDocumentProcessingRun: enqueueDocumentProcessingRunMock,
 }));
 

--- a/apps/api/src/handlers/workspaces/duplicate.test.ts
+++ b/apps/api/src/handlers/workspaces/duplicate.test.ts
@@ -797,7 +797,9 @@ describe("duplicateWorkspace", () => {
       copiedTaskId,
     ]);
     expect(requestNativeExtractionRunsMock).toHaveBeenCalledTimes(1);
-    expect(enqueueDocumentProcessingRunMock.mock.calls).toEqual([["run_0"]]);
+    expect(enqueueDocumentProcessingRunMock.mock.calls).toEqual([
+      [toSafeId<"documentProcessingRun">("run_0")],
+    ]);
   });
 
   test("returns every object copied for an aborted duplicate", async () => {

--- a/apps/api/src/handlers/workspaces/duplicate.test.ts
+++ b/apps/api/src/handlers/workspaces/duplicate.test.ts
@@ -64,11 +64,21 @@ void mock.module("@/api/lib/s3-presign", () => ({
 // extraction request itself is replaced.
 const realProcessExtraction =
   await import("@/api/lib/search/process-extraction");
-const processExtractionMock = mock(async (_entityId: string) => undefined);
+const requestNativeExtractionRunsMock = mock(
+  async ({ requests }: { requests: readonly unknown[] }) =>
+    requests.map((_, index) =>
+      toSafeId<"documentProcessingRun">(`run_${index}`),
+    ),
+);
 void mock.module("@/api/lib/search/process-extraction", () => ({
   ...realProcessExtraction,
-  processExtraction: processExtractionMock,
   requestNativeExtractionRun: mock(async () => null),
+  requestNativeExtractionRuns: requestNativeExtractionRunsMock,
+}));
+
+const enqueueDocumentProcessingRunMock = mock(async () => undefined);
+void mock.module("@/api/lib/document-processing-enqueue", () => ({
+  enqueueDocumentProcessingRun: enqueueDocumentProcessingRunMock,
 }));
 
 const syncWorkspaceSearchActivityMock = mock(async () => undefined);
@@ -408,7 +418,8 @@ describe("duplicateWorkspace", () => {
     s3FileMock.mockClear();
     s3WriteMock.mockClear();
     s3DeleteMock.mockClear();
-    processExtractionMock.mockClear();
+    requestNativeExtractionRunsMock.mockClear();
+    enqueueDocumentProcessingRunMock.mockClear();
     syncWorkspaceSearchActivityMock.mockClear();
     enqueueWorkspaceSearchRepairsMock.mockClear();
     flushWorkspaceSearchRepairsMock.mockClear();
@@ -598,7 +609,8 @@ describe("duplicateWorkspace", () => {
   });
 
   test("marks the copies extraction will not index, inside the transaction", async () => {
-    processExtractionMock.mockClear();
+    requestNativeExtractionRunsMock.mockClear();
+    enqueueDocumentProcessingRunMock.mockClear();
     enqueueEntitySearchRepairsMock.mockClear();
     flushEntitySearchRepairsMock.mockClear();
 
@@ -782,7 +794,8 @@ describe("duplicateWorkspace", () => {
     expect(enqueueEntitySearchRepairsMock.mock.calls.at(0)?.at(1)).toEqual([
       copiedTaskId,
     ]);
-    expect(processExtractionMock.mock.calls).toEqual([[copiedDocumentId]]);
+    expect(requestNativeExtractionRunsMock).toHaveBeenCalledTimes(1);
+    expect(enqueueDocumentProcessingRunMock.mock.calls).toEqual([["run_0"]]);
   });
 
   test("returns every object copied for an aborted duplicate", async () => {

--- a/apps/api/src/handlers/workspaces/duplicate.ts
+++ b/apps/api/src/handlers/workspaces/duplicate.ts
@@ -29,7 +29,9 @@ import {
   remapNodePropertyIds,
 } from "@/api/lib/conditions/ast-utils";
 import { allocateEntityStamp } from "@/api/lib/document-counter";
-import { enqueueDocumentProcessingRun } from "@/api/lib/document-processing-enqueue";
+import {
+  handoffCommittedDocumentProcessingRuns,
+} from "@/api/lib/document-processing-handoff";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import { escapeLike } from "@/api/lib/escape-like";
 import { THUMBNAIL_MIME_TYPE } from "@/api/lib/files/image-derivative";
@@ -941,9 +943,9 @@ const duplicateWorkspace = createSafeHandler(
       txResult.value.entityIds[SEARCH_INDEX_OWNER.searchMark],
     ).catch(captureError);
 
-    for (const runId of txResult.value.nativeExtractionRunIds) {
-      enqueueDocumentProcessingRun(runId).catch(captureError);
-    }
+    handoffCommittedDocumentProcessingRuns({
+      runIds: txResult.value.nativeExtractionRunIds,
+    }).catch(captureError);
 
     return Result.ok({ workspaceId: txResult.value.workspaceId });
   },

--- a/apps/api/src/handlers/workspaces/duplicate.ts
+++ b/apps/api/src/handlers/workspaces/duplicate.ts
@@ -29,6 +29,7 @@ import {
   remapNodePropertyIds,
 } from "@/api/lib/conditions/ast-utils";
 import { allocateEntityStamp } from "@/api/lib/document-counter";
+import { enqueueDocumentProcessingRun } from "@/api/lib/document-processing-enqueue";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import { escapeLike } from "@/api/lib/escape-like";
 import { THUMBNAIL_MIME_TYPE } from "@/api/lib/files/image-derivative";
@@ -47,11 +48,14 @@ import {
 import { getS3 } from "@/api/lib/s3";
 import { copyObject } from "@/api/lib/s3-presign";
 import {
-  processExtraction,
+  nativeExtractionRunRequestForFields,
+  requestNativeExtractionRuns,
   SEARCH_INDEX_OWNER,
-  searchIndexOwnerForFields,
 } from "@/api/lib/search/process-extraction";
-import type { SearchIndexOwner } from "@/api/lib/search/process-extraction";
+import type {
+  NativeExtractionRunRequest,
+  SearchIndexOwner,
+} from "@/api/lib/search/process-extraction";
 import {
   enqueueEntitySearchRepairs,
   enqueueWorkspaceSearchRepairs,
@@ -767,6 +771,7 @@ const duplicateWorkspace = createSafeHandler(
           [SEARCH_INDEX_OWNER.durableExtraction]: [],
           [SEARCH_INDEX_OWNER.searchMark]: [],
         };
+      const nativeExtractionRequests: NativeExtractionRunRequest[] = [];
       const entitiesToDuplicate = orderEntitiesForDuplicate(snapshot.entities);
 
       if (includeContent && entitiesToDuplicate.length > 0) {
@@ -851,6 +856,7 @@ const duplicateWorkspace = createSafeHandler(
             }
             return [
               {
+                id: createSafeId<"field">(),
                 workspaceId: targetWorkspaceId,
                 propertyId,
                 entityVersionId: newVersionId,
@@ -864,12 +870,25 @@ const duplicateWorkspace = createSafeHandler(
           }
 
           entityIdMap.set(source.id, newEntityId);
-          // `newFields` is inserted in source field order and its ids are
-          // generated in that same order, so the copy resolves the same
-          // extraction source `processExtraction` will resolve for it.
-          duplicatedEntityIds[searchIndexOwnerForFields(newFields)].push(
-            newEntityId,
-          );
+          // IDs are minted in source field order, so the transactional run
+          // uses the same selected file the post-commit processor would read.
+          const extractionRequest = nativeExtractionRunRequestForFields({
+            entityId: newEntityId,
+            entityVersionId: newVersionId,
+            fields: newFields,
+            organizationId,
+            workspaceId: targetWorkspaceId,
+          });
+          if (extractionRequest === null) {
+            duplicatedEntityIds[SEARCH_INDEX_OWNER.searchMark].push(
+              newEntityId,
+            );
+          } else {
+            duplicatedEntityIds[SEARCH_INDEX_OWNER.durableExtraction].push(
+              newEntityId,
+            );
+            nativeExtractionRequests.push(extractionRequest);
+          }
         }
       }
 
@@ -890,11 +909,16 @@ const duplicateWorkspace = createSafeHandler(
         tx,
         duplicatedEntityIds[SEARCH_INDEX_OWNER.searchMark],
       );
+      const nativeExtractionRunIds = await requestNativeExtractionRuns({
+        requests: nativeExtractionRequests,
+        tx,
+      });
       await enqueueWorkspaceSearchRepairs(tx, [targetWorkspaceId]);
 
       return {
         workspaceId: targetWorkspaceId,
         entityIds: duplicatedEntityIds,
+        nativeExtractionRunIds,
       };
     });
 
@@ -908,10 +932,8 @@ const duplicateWorkspace = createSafeHandler(
       return Result.err(transactionAbortError(txResult.error));
     }
 
-    // Both post-commit calls only accelerate what the transaction already
-    // guarantees: the marked copies keep their queued row until a repair
-    // rebuilds their projection, and the documents keep the immutable source
-    // the bounded extraction repair scan requests a run for.
+    // These post-commit calls only accelerate work the transaction already
+    // made durable: projection marks and immutable-source extraction runs.
     flushWorkspaceSearchRepairs([txResult.value.workspaceId]).catch(
       captureError,
     );
@@ -919,10 +941,8 @@ const duplicateWorkspace = createSafeHandler(
       txResult.value.entityIds[SEARCH_INDEX_OWNER.searchMark],
     ).catch(captureError);
 
-    for (const entityId of txResult.value.entityIds[
-      SEARCH_INDEX_OWNER.durableExtraction
-    ]) {
-      processExtraction(entityId).catch(captureError);
+    for (const runId of txResult.value.nativeExtractionRunIds) {
+      enqueueDocumentProcessingRun(runId).catch(captureError);
     }
 
     return Result.ok({ workspaceId: txResult.value.workspaceId });

--- a/apps/api/src/handlers/workspaces/duplicate.ts
+++ b/apps/api/src/handlers/workspaces/duplicate.ts
@@ -29,9 +29,7 @@ import {
   remapNodePropertyIds,
 } from "@/api/lib/conditions/ast-utils";
 import { allocateEntityStamp } from "@/api/lib/document-counter";
-import {
-  handoffCommittedDocumentProcessingRuns,
-} from "@/api/lib/document-processing-handoff";
+import { handoffCommittedDocumentProcessingRuns } from "@/api/lib/document-processing-handoff";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import { escapeLike } from "@/api/lib/escape-like";
 import { THUMBNAIL_MIME_TYPE } from "@/api/lib/files/image-derivative";

--- a/apps/api/src/lib/document-processing-handoff.test.ts
+++ b/apps/api/src/lib/document-processing-handoff.test.ts
@@ -1,0 +1,67 @@
+import { expect, mock, test } from "bun:test";
+
+import { toSafeId } from "@/api/lib/branded-types";
+
+import {
+  DOCUMENT_PROCESSING_HANDOFF_CONCURRENCY,
+  handoffCommittedDocumentProcessingRuns,
+} from "./document-processing-handoff";
+
+const runIds = Array.from(
+  { length: DOCUMENT_PROCESSING_HANDOFF_CONCURRENCY * 2 + 1 },
+  (_, index) =>
+    toSafeId<"documentProcessingRun">(
+      `00000000-0000-0000-0000-${String(index).padStart(12, "0")}`,
+    ),
+);
+
+test("drains every committed run while bounding concurrent queue handoffs", async () => {
+  let active = 0;
+  let maxActive = 0;
+  const firstBatchGate = Promise.withResolvers<undefined>();
+  const firstBatchReady = Promise.withResolvers<undefined>();
+  const enqueue = mock(async () => {
+    active += 1;
+    maxActive = Math.max(maxActive, active);
+    if (active === DOCUMENT_PROCESSING_HANDOFF_CONCURRENCY) {
+      firstBatchReady.resolve(undefined);
+    }
+    await firstBatchGate.promise;
+    active -= 1;
+  });
+
+  const handoff = handoffCommittedDocumentProcessingRuns({
+    captureEnqueueError: mock(() => {}),
+    enqueue,
+    runIds,
+  });
+
+  await firstBatchReady.promise;
+  expect(maxActive).toBe(DOCUMENT_PROCESSING_HANDOFF_CONCURRENCY);
+  firstBatchGate.resolve(undefined);
+  await handoff;
+
+  expect(enqueue).toHaveBeenCalledTimes(runIds.length);
+  expect(maxActive).toBe(DOCUMENT_PROCESSING_HANDOFF_CONCURRENCY);
+});
+
+test("captures one failed handoff and continues draining committed runs", async () => {
+  const enqueueError = new Error("redis unavailable");
+  const enqueue = mock(async (runId: (typeof runIds)[number]) => {
+    if (runId === runIds.at(1)) {
+      throw enqueueError;
+    }
+  });
+  const captureEnqueueError = mock(() => {});
+
+  await handoffCommittedDocumentProcessingRuns({
+    captureEnqueueError,
+    enqueue,
+    runIds: runIds.slice(0, 3),
+  });
+
+  expect(enqueue).toHaveBeenCalledTimes(3);
+  expect(captureEnqueueError).toHaveBeenCalledWith(enqueueError, {
+    runId: runIds.at(1),
+  });
+});

--- a/apps/api/src/lib/document-processing-handoff.ts
+++ b/apps/api/src/lib/document-processing-handoff.ts
@@ -1,0 +1,57 @@
+import { Result } from "better-result";
+
+import { captureError } from "@/api/lib/analytics/capture";
+import type { SafeId } from "@/api/lib/branded-types";
+import { enqueueDocumentProcessingRun } from "@/api/lib/document-processing-enqueue";
+import { withTimeout } from "@/api/lib/with-timeout";
+
+export const DOCUMENT_PROCESSING_HANDOFF_CONCURRENCY = 4;
+const DOCUMENT_PROCESSING_HANDOFF_TIMEOUT_MS = 2000;
+const DOCUMENT_PROCESSING_HANDOFF_TIMEOUT_LABEL =
+  "document-processing.handoff";
+
+type DocumentProcessingHandoffOptions = {
+  captureEnqueueError?: typeof captureError;
+  enqueue?: typeof enqueueDocumentProcessingRun;
+  runIds: readonly SafeId<"documentProcessingRun">[];
+  timeoutMs?: number;
+};
+
+/**
+ * Best-effort acceleration after extraction runs commit. The repair scan owns
+ * eventual delivery; this helper bounds immediate Redis work and captures each
+ * failed handoff without rejecting the successful copy operation.
+ */
+export const handoffCommittedDocumentProcessingRuns = async ({
+  captureEnqueueError = captureError,
+  enqueue = enqueueDocumentProcessingRun,
+  runIds,
+  timeoutMs = DOCUMENT_PROCESSING_HANDOFF_TIMEOUT_MS,
+}: DocumentProcessingHandoffOptions): Promise<void> => {
+  for (
+    let start = 0;
+    start < runIds.length;
+    start += DOCUMENT_PROCESSING_HANDOFF_CONCURRENCY
+  ) {
+    const batch = runIds.slice(
+      start,
+      start + DOCUMENT_PROCESSING_HANDOFF_CONCURRENCY,
+    );
+    // oxlint-disable-next-line no-await-in-loop -- sequential batches cap concurrent Redis handoffs while draining every committed run ID
+    await Promise.all(
+      batch.map(async (runId) => {
+        const result = await Result.tryPromise({
+          try: async () =>
+            await withTimeout(async () => await enqueue(runId), {
+              label: DOCUMENT_PROCESSING_HANDOFF_TIMEOUT_LABEL,
+              timeoutMs,
+            }),
+          catch: (cause) => cause,
+        });
+        if (Result.isError(result)) {
+          captureEnqueueError(result.error, { runId });
+        }
+      }),
+    );
+  }
+};

--- a/apps/api/src/lib/document-processing-handoff.ts
+++ b/apps/api/src/lib/document-processing-handoff.ts
@@ -7,8 +7,7 @@ import { withTimeout } from "@/api/lib/with-timeout";
 
 export const DOCUMENT_PROCESSING_HANDOFF_CONCURRENCY = 4;
 const DOCUMENT_PROCESSING_HANDOFF_TIMEOUT_MS = 2000;
-const DOCUMENT_PROCESSING_HANDOFF_TIMEOUT_LABEL =
-  "document-processing.handoff";
+const DOCUMENT_PROCESSING_HANDOFF_TIMEOUT_LABEL = "document-processing.handoff";
 
 type DocumentProcessingHandoffOptions = {
   captureEnqueueError?: typeof captureError;

--- a/apps/api/src/lib/entity-versions/version-write-ownership-policy.ts
+++ b/apps/api/src/lib/entity-versions/version-write-ownership-policy.ts
@@ -22,6 +22,7 @@ export const REVIEWED_VERSION_MUTATION_OWNERS = {
   ],
   "handlers/entities/copy-utils.ts": [
     VERSION_WRITE_CAPABILITY.INSERT_VERSION_ROW,
+    VERSION_WRITE_CAPABILITY.REQUEST_NATIVE_EXTRACTION,
     VERSION_WRITE_CAPABILITY.SET_CURRENT_VERSION,
   ],
   "handlers/entities/create.ts": [
@@ -66,6 +67,7 @@ export const REVIEWED_VERSION_MUTATION_OWNERS = {
   ],
   "handlers/workspaces/duplicate.ts": [
     VERSION_WRITE_CAPABILITY.INSERT_VERSION_ROW,
+    VERSION_WRITE_CAPABILITY.REQUEST_NATIVE_EXTRACTION,
     VERSION_WRITE_CAPABILITY.SET_CURRENT_VERSION,
   ],
   "lib/entities/create-from-buffer.ts": [

--- a/apps/api/src/lib/search/process-extraction.ts
+++ b/apps/api/src/lib/search/process-extraction.ts
@@ -432,7 +432,8 @@ type ExtractionEntity = NonNullable<
   Awaited<ReturnType<typeof readExtractionEntity>>
 >;
 
-type NativeExtractionRunSource = {
+export type NativeExtractionRunRequest = {
+  entityId: SafeId<"entity">;
   entityVersionId: SafeId<"entityVersion">;
   fieldId: SafeId<"field">;
   fileField: Extract<FieldContent, { type: "file" }>;
@@ -440,51 +441,121 @@ type NativeExtractionRunSource = {
   workspaceId: SafeId<"workspace">;
 };
 
-/** `null` when a search mark, not a durable run, owns this projection. */
-const resolveNativeExtractionSource = (
-  entity: ExtractionEntity,
-  filePropertyId?: SafeId<"property">,
-): NativeExtractionRunSource | null => {
-  const workspace = entity.workspace ?? panic("Entity has no workspace");
-  const version =
-    entity.currentVersion ?? panic("Entity has no currentVersion");
-  const fileFieldRow = findExtractionFileFieldRow(
-    version.fields,
-    filePropertyId,
-  );
+type NativeExtractionRunRequestForFieldsOptions = {
+  entityId: SafeId<"entity">;
+  entityVersionId: SafeId<"entityVersion">;
+  fields: readonly {
+    content: FieldContent;
+    id: SafeId<"field">;
+    propertyId?: SafeId<"property"> | undefined;
+  }[];
+  organizationId: SafeId<"organization">;
+  workspaceId: SafeId<"workspace">;
+  filePropertyId?: SafeId<"property"> | undefined;
+};
+
+type NativeExtractionRunRequestForFieldsResult =
+  | NativeExtractionRunRequest
+  | null;
+
+/**
+ * Derive the exact immutable source identity from fields a transaction has
+ * persisted in stable creation order. A null result means the search-repair
+ * queue, not a document-processing run, owns the projection.
+ */
+export const nativeExtractionRunRequestForFields = ({
+  entityId,
+  entityVersionId,
+  fields,
+  organizationId,
+  workspaceId,
+  filePropertyId,
+}: NativeExtractionRunRequestForFieldsOptions): NativeExtractionRunRequestForFieldsResult => {
+  const fileFieldRow = findExtractionFileFieldRow(fields, filePropertyId);
   if (
     !fileFieldRow ||
     fileFieldRow.content.type !== "file" ||
-    searchIndexOwnerForFields(version.fields, filePropertyId) ===
+    searchIndexOwnerForFields(fields, filePropertyId) ===
       SEARCH_INDEX_OWNER.searchMark
   ) {
     return null;
   }
   return {
-    entityVersionId: version.id,
+    entityId,
+    entityVersionId,
     fieldId: fileFieldRow.id,
     fileField: fileFieldRow.content,
-    organizationId: toSafeId<"organization">(workspace.organizationId),
-    workspaceId: toSafeId<"workspace">(workspace.id),
+    organizationId,
+    workspaceId,
   };
 };
 
-const nativeExtractionRunValues = (
+/** `null` when a search mark, not a durable run, owns this projection. */
+const resolveNativeExtractionSource = (
   entityId: SafeId<"entity">,
-  source: NativeExtractionRunSource,
-) =>
+  entity: ExtractionEntity,
+  filePropertyId?: SafeId<"property">,
+): NativeExtractionRunRequest | null => {
+  const workspace = entity.workspace ?? panic("Entity has no workspace");
+  const version =
+    entity.currentVersion ?? panic("Entity has no currentVersion");
+  return nativeExtractionRunRequestForFields({
+    entityId,
+    entityVersionId: version.id,
+    fields: version.fields,
+    filePropertyId,
+    organizationId: toSafeId<"organization">(workspace.organizationId),
+    workspaceId: toSafeId<"workspace">(workspace.id),
+  });
+};
+
+const nativeExtractionRunValues = (request: NativeExtractionRunRequest) =>
   ({
     id: createSafeId<"documentProcessingRun">(),
     ...SCOPED_NATIVE_EXTRACTION_ENQUEUE,
-    entityId,
-    entityVersionId: source.entityVersionId,
-    fieldId: source.fieldId,
-    organizationId: source.organizationId,
+    entityId: request.entityId,
+    entityVersionId: request.entityVersionId,
+    fieldId: request.fieldId,
+    organizationId: request.organizationId,
     processorVersion: DOCUMENT_NATIVE_EXTRACTION_PROCESSOR_VERSION,
-    sourceFileId: source.fileField.id,
-    sourceSha256Hex: source.fileField.sha256Hex,
-    workspaceId: source.workspaceId,
+    sourceFileId: request.fileField.id,
+    sourceSha256Hex: request.fileField.sha256Hex,
+    workspaceId: request.workspaceId,
   }) satisfies typeof documentProcessingRuns.$inferInsert;
+
+// 250 rows keep the insert well below PostgreSQL's bound-parameter ceiling
+// while reducing a whole-matter copy from one request query per document to a
+// small, bounded number of statements.
+const NATIVE_EXTRACTION_RUN_INSERT_BATCH_SIZE = 250;
+
+/** Insert immutable-source requests in bounded batches on one transaction. */
+export const requestNativeExtractionRuns = async ({
+  requests,
+  tx,
+}: {
+  requests: readonly NativeExtractionRunRequest[];
+  tx: Transaction;
+}): Promise<SafeId<"documentProcessingRun">[]> => {
+  const insertedRunIds: SafeId<"documentProcessingRun">[] = [];
+  const insertFrom = async (start: number): Promise<void> => {
+    if (start >= requests.length) {
+      return;
+    }
+    const inserted = await tx
+      .insert(documentProcessingRuns)
+      .values(
+        requests
+          .slice(start, start + NATIVE_EXTRACTION_RUN_INSERT_BATCH_SIZE)
+          .map(nativeExtractionRunValues),
+      )
+      .onConflictDoNothing({ target: NATIVE_EXTRACTION_SOURCE_TARGET })
+      .returning({ id: documentProcessingRuns.id });
+    insertedRunIds.push(...inserted.map(({ id }) => id));
+    await insertFrom(start + NATIVE_EXTRACTION_RUN_INSERT_BATCH_SIZE);
+  };
+  await insertFrom(0);
+  return insertedRunIds;
+};
 
 /**
  * Commit the durable extraction request with the mutation that creates its
@@ -494,8 +565,9 @@ const nativeExtractionRunValues = (
  * admits for a scoped transaction: a queued, unattributed, upload-sourced
  * native-extraction request for a workspace the transaction already holds.
  * Everything after the insert (queue handoff, retries, state transitions)
- * remains root-writer work, so callers still run `processExtraction` after the
- * commit to accelerate what this row already guarantees.
+ * remains root-writer work. Callers enqueue the returned run id after commit,
+ * or call `processExtraction` when they do not retain it, to accelerate what
+ * this row already guarantees.
  *
  * Returns the run id this transaction created, or `null` when the entity needs
  * no durable extraction or an equivalent run already exists.
@@ -513,16 +585,19 @@ export const requestNativeExtractionRun = async ({
   if (!entity) {
     return null;
   }
-  const source = resolveNativeExtractionSource(entity, filePropertyId);
+  const source = resolveNativeExtractionSource(
+    entityId,
+    entity,
+    filePropertyId,
+  );
   if (!source) {
     return null;
   }
-  const inserted = await tx
-    .insert(documentProcessingRuns)
-    .values(nativeExtractionRunValues(entityId, source))
-    .onConflictDoNothing({ target: NATIVE_EXTRACTION_SOURCE_TARGET })
-    .returning({ id: documentProcessingRuns.id });
-  return inserted.at(0)?.id ?? null;
+  const inserted = await requestNativeExtractionRuns({
+    requests: [source],
+    tx,
+  });
+  return inserted.at(0) ?? null;
 };
 
 /**
@@ -543,7 +618,11 @@ export const processExtraction = async (
     return;
   }
 
-  const source = resolveNativeExtractionSource(entity, options?.filePropertyId);
+  const source = resolveNativeExtractionSource(
+    entityId,
+    entity,
+    options?.filePropertyId,
+  );
   if (!source) {
     await getSearchProvider().indexEntity(entityId);
     return;
@@ -553,7 +632,7 @@ export const processExtraction = async (
     source;
   const inserted = await rootDb
     .insert(documentProcessingRuns)
-    .values(nativeExtractionRunValues(entityId, source))
+    .values(nativeExtractionRunValues(source))
     .onConflictDoNothing({ target: NATIVE_EXTRACTION_SOURCE_TARGET })
     .returning({ id: documentProcessingRuns.id });
   const created = inserted.at(0);

--- a/apps/api/src/lib/search/process-extraction.ts
+++ b/apps/api/src/lib/search/process-extraction.ts
@@ -473,8 +473,7 @@ export const nativeExtractionRunRequestForFields = ({
   if (
     !fileFieldRow ||
     fileFieldRow.content.type !== "file" ||
-    searchIndexOwnerForFields(fields, filePropertyId) ===
-      SEARCH_INDEX_OWNER.searchMark
+    !requiresDurableNativeExtraction(fileFieldRow.content)
   ) {
     return null;
   }

--- a/apps/api/src/lib/search/process-extraction.ts
+++ b/apps/api/src/lib/search/process-extraction.ts
@@ -441,7 +441,7 @@ export type NativeExtractionRunRequest = {
   workspaceId: SafeId<"workspace">;
 };
 
-type NativeExtractionRunRequestForFieldsOptions = {
+type NativeExtractionRequestOptions = {
   entityId: SafeId<"entity">;
   entityVersionId: SafeId<"entityVersion">;
   fields: readonly {
@@ -454,9 +454,7 @@ type NativeExtractionRunRequestForFieldsOptions = {
   filePropertyId?: SafeId<"property"> | undefined;
 };
 
-type NativeExtractionRunRequestForFieldsResult =
-  | NativeExtractionRunRequest
-  | null;
+type NativeExtractionRequestResult = NativeExtractionRunRequest | null;
 
 /**
  * Derive the exact immutable source identity from fields a transaction has
@@ -470,7 +468,7 @@ export const nativeExtractionRunRequestForFields = ({
   organizationId,
   workspaceId,
   filePropertyId,
-}: NativeExtractionRunRequestForFieldsOptions): NativeExtractionRunRequestForFieldsResult => {
+}: NativeExtractionRequestOptions): NativeExtractionRequestResult => {
   const fileFieldRow = findExtractionFileFieldRow(fields, filePropertyId);
   if (
     !fileFieldRow ||


### PR DESCRIPTION
## Summary

- derive immutable extraction requests from the exact fields persisted by entity and workspace copy transactions
- insert durable runs in bounded batches under the scoped native-extraction policy, then drain post-commit queue handoffs with fixed concurrency and per-run error capture
- retain bounded repair recovery and extend the version-write ownership guard plus rollback/source-identity coverage

## Validation

- Local lint, typecheck, formatting, and tests intentionally not run; validation is delegated to GitHub CI.

Follow-up hardening for #1973 and #2003.

CC on behalf of jan-kubica

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * File and workspace copies and duplications now automatically create and queue document-processing runs for eligible files.
  * Processing requests are handled in batches, improving consistency when multiple files are copied or duplicated.

* **Bug Fixes**
  * Prevented processing runs from being created for folders without extractable files or for cancelled operations.
  * Improved cleanup so failed or rolled-back copies do not leave behind incomplete processing records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->