### PR TITLE
fix: collapse matter navigation waterfall

### DIFF
--- a/apps/api/src/handlers/workspaces/read-navigation.test.ts
+++ b/apps/api/src/handlers/workspaces/read-navigation.test.ts
@@ -12,6 +12,9 @@ type ReadWorkspaceNavigationContext = Parameters<
 
 const workspaceRows = [
   {
+    defaultViewId: toSafeId<"workspaceView">(
+      "019c0c90-0000-7000-8000-000000000103",
+    ),
     id: toSafeId<"workspace">("019c0c90-0000-7000-8000-000000000003"),
     name: "Appeal",
     reference: "MAT-003",
@@ -24,6 +27,9 @@ const workspaceRows = [
     clientDisplayName: null,
   },
   {
+    defaultViewId: toSafeId<"workspaceView">(
+      "019c0c90-0000-7000-8000-000000000102",
+    ),
     id: toSafeId<"workspace">("019c0c90-0000-7000-8000-000000000002"),
     name: "Merger",
     reference: "MAT-002",
@@ -36,6 +42,7 @@ const workspaceRows = [
     clientDisplayName: "Northwind Holdings",
   },
   {
+    defaultViewId: null,
     id: toSafeId<"workspace">("019c0c90-0000-7000-8000-000000000001"),
     name: "Investigation",
     reference: "MAT-001",
@@ -57,16 +64,17 @@ const createContext = ({
   rows?: typeof workspaceRows;
 }) => {
   const limit = mock(async () => rows);
-  const { safeDb, scopedDb } = createScopedDbMock({
-    select: () => ({
-      from: () => ({
-        leftJoin: () => ({
-          where: () => ({
-            orderBy: () => ({ limit }),
-          }),
+  const select = mock((_selection?: unknown) => ({
+    from: () => ({
+      leftJoin: () => ({
+        where: () => ({
+          orderBy: () => ({ limit }),
         }),
       }),
     }),
+  }));
+  const { safeDb, scopedDb } = createScopedDbMock({
+    select,
   });
 
   return {
@@ -82,21 +90,29 @@ const createContext = ({
       user: { id: toSafeId<"user">("user_test123") },
     }),
     limit,
+    select,
   };
 };
 
 describe("workspace navigation pagination", () => {
   test("returns a cursor page while preserving active navigation fields", async () => {
-    const { context, limit } = createContext({
+    const { context, limit, select } = createContext({
       query: { limit: 2, statusScope: "active-and-archived" },
     });
 
     const result = await readWorkspaceNavigation.handler(context);
 
     expect(limit).toHaveBeenCalledWith(3);
+    expect(select).toHaveBeenCalledWith(
+      expect.objectContaining({ defaultViewId: expect.anything() }),
+    );
     expect(result).toEqual({
       items: [
-        expect.objectContaining({ name: "Appeal", status: "archived" }),
+        expect.objectContaining({
+          defaultViewId: "019c0c90-0000-7000-8000-000000000103",
+          name: "Appeal",
+          status: "archived",
+        }),
         expect.objectContaining({
           client: {
             id: "019c0c90-0000-7000-8000-000000000010",

--- a/apps/api/src/handlers/workspaces/read-navigation.ts
+++ b/apps/api/src/handlers/workspaces/read-navigation.ts
@@ -1,8 +1,8 @@
 import { Result } from "better-result";
-import { and, desc, eq, inArray } from "drizzle-orm";
+import { and, desc, eq, inArray, sql } from "drizzle-orm";
 import { t } from "elysia";
 
-import { contacts, workspaces } from "@/api/db/schema";
+import { contacts, workspaces, workspaceViews } from "@/api/db/schema";
 import { createSafeRootHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
 import { createTimestampIdCursorCodec } from "@/api/lib/db-pagination";
@@ -84,6 +84,13 @@ const readWorkspaceNavigation = createSafeRootHandler(
       safeDb((tx) =>
         tx
           .select({
+            defaultViewId: sql<typeof workspaceViews.$inferSelect.id | null>`(
+              select ${workspaceViews.id}
+              from ${workspaceViews}
+              where ${workspaceViews.workspaceId} = ${workspaces.id}
+              order by ${workspaceViews.position}, ${workspaceViews.id}
+              limit 1
+            )`.as("default_view_id"),
             id: workspaces.id,
             name: workspaces.name,
             reference: workspaces.reference,

--- a/apps/web/src/components/app-sidebar.logic.test.ts
+++ b/apps/web/src/components/app-sidebar.logic.test.ts
@@ -4,11 +4,40 @@ import {
   matterActivityIsKnownEmpty,
   resolveEntityActivityDestination,
   resolveAutomaticExpandedMatterId,
+  resolveMatterNavigationTarget,
   resolveSidebarWorkspaceId,
   selectRecentWorkspaces,
 } from "@/components/app-sidebar.logic";
 
 describe("sidebar matter context", () => {
+  test("opens a matter at its default view without an intermediate redirect", () => {
+    expect(
+      resolveMatterNavigationTarget({
+        defaultViewId: "view-1",
+        id: "matter-1",
+      }),
+    ).toEqual({
+      params: { viewId: "view-1", workspaceId: "matter-1" },
+      to: "/workspaces/$workspaceId/$viewId",
+    });
+  });
+
+  test("keeps the bare matter route as the no-view fallback", () => {
+    expect(
+      resolveMatterNavigationTarget({
+        defaultViewId: null,
+        id: "matter-1",
+      }),
+    ).toEqual({
+      params: { workspaceId: "matter-1" },
+      to: "/workspaces/$workspaceId",
+    });
+    expect(resolveMatterNavigationTarget({ id: "matter-1" })).toEqual({
+      params: { workspaceId: "matter-1" },
+      to: "/workspaces/$workspaceId",
+    });
+  });
+
   test("uses the matter from a workspace chat route", () => {
     expect(
       resolveSidebarWorkspaceId({

--- a/apps/web/src/components/app-sidebar.logic.ts
+++ b/apps/web/src/components/app-sidebar.logic.ts
@@ -10,6 +10,40 @@ export const resolveSidebarWorkspaceId = ({
   workspaceId: string | undefined;
 }): string | undefined => workspaceId ?? chatWorkspaceId;
 
+type MatterNavigationIdentity = {
+  // Optional while API and web revisions overlap during a rolling deploy.
+  // Remove once defaultViewId is part of the minimum supported API contract.
+  defaultViewId?: string | null;
+  id: string;
+};
+
+export type MatterNavigationTarget =
+  | {
+      params: { viewId: string; workspaceId: string };
+      to: "/workspaces/$workspaceId/$viewId";
+    }
+  | {
+      params: { workspaceId: string };
+      to: "/workspaces/$workspaceId";
+    };
+
+export const resolveMatterNavigationTarget = ({
+  defaultViewId,
+  id,
+}: MatterNavigationIdentity): MatterNavigationTarget => {
+  if (defaultViewId === null || defaultViewId === undefined) {
+    return {
+      params: { workspaceId: id },
+      to: "/workspaces/$workspaceId",
+    };
+  }
+
+  return {
+    params: { viewId: defaultViewId, workspaceId: id },
+    to: "/workspaces/$workspaceId/$viewId",
+  };
+};
+
 export const resolveAutomaticExpandedMatterId = ({
   activeMatterIsVisible,
   activeWorkspaceId,

--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -59,6 +59,7 @@ import {
   matterActivityIsKnownEmpty,
   resolveEntityActivityDestination,
   resolveAutomaticExpandedMatterId,
+  resolveMatterNavigationTarget,
   resolveSidebarWorkspaceId,
   selectRecentWorkspaces,
 } from "@/components/app-sidebar.logic";
@@ -375,10 +376,7 @@ export const AppSidebar = (props: AppSidebarProps) => {
     ),
     onClick: () => {
       detached(
-        navigate({
-          to: "/workspaces/$workspaceId",
-          params: { workspaceId: ws.id },
-        }),
+        navigate(resolveMatterNavigationTarget(ws)),
         "app-sidebar.navigate",
       );
     },
@@ -493,10 +491,7 @@ export const AppSidebar = (props: AppSidebarProps) => {
     ...pinned.slice(0, 3).map((ws): NavTarget => ({
       action: () => {
         detached(
-          navigate({
-            to: "/workspaces/$workspaceId",
-            params: { workspaceId: ws.id },
-          }),
+          navigate(resolveMatterNavigationTarget(ws)),
           "app-sidebar.navigate",
         );
       },
@@ -770,6 +765,7 @@ type MatterExpansion =
  * accept this type so `MatterIcon` always has a color.
  */
 type MatterIdentity = {
+  defaultViewId?: string | null;
   id: string;
   name: string;
   color: string | null;
@@ -1136,6 +1132,7 @@ const MatterItem = ({
   }, [ws.id, canDrag, handleReorder, handleEntityDrop]);
 
   const relTime = formatRelativeTime(ws.lastActivityAt);
+  const navigationTarget = resolveMatterNavigationTarget(ws);
 
   const startRename = () => {
     setMenuOpen(false);
@@ -1254,11 +1251,7 @@ const MatterItem = ({
             .filter(Boolean)
             .join(" — ")}
         >
-          <Link
-            activeProps={{ "data-active": true }}
-            params={{ workspaceId: ws.id }}
-            to="/workspaces/$workspaceId"
-          >
+          <Link activeProps={{ "data-active": true }} {...navigationTarget}>
             <MatterIcon
               className="size-4 shrink-0"
               matter={{ id: ws.id, color: ws.color }}

--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -671,6 +671,7 @@ export const AppSidebar = (props: AppSidebarProps) => {
                   {pinned.map((ws, i) => (
                     <MatterItem
                       activeOrganizationId={user.activeOrganizationId}
+                      isActive={activeWorkspaceId === ws.id}
                       isExpanded={!isCollapsed && expandedMatterId === ws.id}
                       isPinned
                       key={ws.id}
@@ -701,6 +702,7 @@ export const AppSidebar = (props: AppSidebarProps) => {
                   {recents.map((ws) => (
                     <MatterItem
                       activeOrganizationId={user.activeOrganizationId}
+                      isActive={activeWorkspaceId === ws.id}
                       isExpanded={!isCollapsed && expandedMatterId === ws.id}
                       key={ws.id}
                       onDeleted={handleMatterDeleted}
@@ -885,6 +887,7 @@ type MatterItemProps = {
     client?: { id: string; displayName: string } | null;
     lastActivityAt: Date;
   };
+  isActive: boolean;
   isPinned?: boolean;
   isExpanded: boolean;
   onExpandedChange: () => void;
@@ -961,6 +964,7 @@ const toCopyToMatterEntities = (raw: unknown): CopyToMatterEntity[] => {
 const MatterItem = ({
   activeOrganizationId,
   workspace: ws,
+  isActive,
   isExpanded,
   isPinned: _isPinnedProp,
   onTogglePin,
@@ -1251,7 +1255,7 @@ const MatterItem = ({
             .filter(Boolean)
             .join(" — ")}
         >
-          <Link activeProps={{ "data-active": true }} {...navigationTarget}>
+          <Link data-active={isActive || undefined} {...navigationTarget}>
             <MatterIcon
               className="size-4 shrink-0"
               matter={{ id: ws.id, color: ws.color }}

--- a/apps/web/src/lib/memory-api.test.ts
+++ b/apps/web/src/lib/memory-api.test.ts
@@ -99,6 +99,7 @@ const workspaceNavigationItem = {
   client: null,
   clientId: null,
   color: null,
+  defaultViewId: "view_1",
   id: "workspace_1",
   lastActivityAt: "2026-07-30T12:00:00.000Z",
   name: "Appeal",

--- a/apps/web/src/lib/workspaces/queries.logic.ts
+++ b/apps/web/src/lib/workspaces/queries.logic.ts
@@ -24,9 +24,9 @@ export const workspacesKeys = {
     "list",
     activeOrganizationId,
   ],
+  navigationAll: () => [...workspacesKeys.all, "navigation"],
   navigation: (activeOrganizationId: string) => [
-    ...workspacesKeys.all,
-    "navigation",
+    ...workspacesKeys.navigationAll(),
     activeOrganizationId,
   ],
   byId: (workspaceId: string) => [...workspacesKeys.all, workspaceId],

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-mutations/views.logic.test.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-mutations/views.logic.test.ts
@@ -143,7 +143,8 @@ describe("view reorder cache path", () => {
     expect(await cachedOrder(queryClient)).toEqual(second);
   });
 
-  test("invalidates every cached locale variant on settle", async () => {
+  test("invalidates every cached locale variant and navigation projection on settle", async () => {
+    const { workspacesKeys } = await import("@/lib/workspaces/queries.logic");
     const { viewsKeys } = await import("@/lib/workspaces/queries/views");
     const { viewOrderCache } = await import("./views.logic");
     const queryClient = await seededClient();
@@ -153,11 +154,19 @@ describe("view reorder cache path", () => {
     // a second literal, so the test still covers the prefix if the key changes.
     const otherLocaleKey = [...viewsKeys.all(WORKSPACE_ID), "xx-other"];
     queryClient.setQueryData(otherLocaleKey, CACHED_VIEWS);
+    const navigationKey = workspacesKeys.navigation("org_navigation");
+    const unrelatedWorkspaceListKey = workspacesKeys.list("org_navigation");
+    queryClient.setQueryData(navigationKey, { workspaces: [] });
+    queryClient.setQueryData(unrelatedWorkspaceListKey, { workspaces: [] });
 
     await viewOrderCache({ queryClient, workspaceId: WORKSPACE_ID }).settle();
 
     for (const key of [viewsKeys.localized(WORKSPACE_ID), otherLocaleKey]) {
       expect(queryClient.getQueryState(key)?.isInvalidated).toBe(true);
     }
+    expect(queryClient.getQueryState(navigationKey)?.isInvalidated).toBe(true);
+    expect(
+      queryClient.getQueryState(unrelatedWorkspaceListKey)?.isInvalidated,
+    ).toBe(false);
   });
 });

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-mutations/views.logic.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-mutations/views.logic.ts
@@ -1,7 +1,21 @@
 import type { QueryClient } from "@tanstack/react-query";
 
 import type { WorkspaceView } from "@/lib/types";
+import { workspacesKeys } from "@/lib/workspaces/queries.logic";
 import { viewsKeys } from "@/lib/workspaces/queries/views";
+
+export const invalidateViewDerivedQueries = async ({
+  queryClient,
+  workspaceId,
+}: ViewOrderCacheOptions) =>
+  await Promise.all([
+    queryClient.invalidateQueries({
+      queryKey: viewsKeys.all(workspaceId),
+    }),
+    queryClient.invalidateQueries({
+      queryKey: workspacesKeys.navigationAll(),
+    }),
+  ]);
 
 /**
  * Returns the cached view list in `viewIds` order, or `current` unchanged when
@@ -91,9 +105,7 @@ export const viewOrderCache = ({
     },
 
     settle: async () => {
-      await queryClient.invalidateQueries({
-        queryKey: viewsKeys.all(workspaceId),
-      });
+      await invalidateViewDerivedQueries({ queryClient, workspaceId });
     },
   };
 };

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-mutations/views.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-mutations/views.ts
@@ -13,7 +13,7 @@ import type {
 import { propertiesKeys } from "@/lib/workspaces/queries/properties";
 import { viewsKeys } from "@/lib/workspaces/queries/views";
 
-import { viewOrderCache } from "./views.logic";
+import { invalidateViewDerivedQueries, viewOrderCache } from "./views.logic";
 
 type CreateViewVars = {
   id: string;
@@ -35,9 +35,7 @@ export const useCreateView = (workspaceId: string) => {
     },
     onSuccess: async (_data, variables) => {
       const invalidations = [
-        queryClient.invalidateQueries({
-          queryKey: viewsKeys.all(workspaceId),
-        }),
+        invalidateViewDerivedQueries({ queryClient, workspaceId }),
       ];
       // Applying a template can create properties in this matter.
       // Without invalidating, the table renders with a stale property
@@ -194,9 +192,7 @@ export const useDeleteView = (workspaceId: string) => {
       return unwrapEden(response);
     },
     onSuccess: async () => {
-      await queryClient.invalidateQueries({
-        queryKey: viewsKeys.all(workspaceId),
-      });
+      await invalidateViewDerivedQueries({ queryClient, workspaceId });
     },
     onError: (error) => {
       analytics.captureError(error);

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-mutations/views.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-mutations/views.ts
@@ -34,24 +34,21 @@ export const useCreateView = (workspaceId: string) => {
       return unwrapEden(response);
     },
     onSuccess: async (_data, variables) => {
-      const invalidations = [
+      await Promise.all([
         invalidateViewDerivedQueries({ queryClient, workspaceId }),
-      ];
-      // Applying a template can create properties in this matter.
-      // Without invalidating, the table renders with a stale property
-      // list and TanStack silently strips the new column IDs from the
-      // newly-created view's columnOrder on the next layout update.
-      if (
-        variables.templateProperties &&
+        // Applying a template can create properties in this matter.
+        // Without invalidating, the table renders with a stale property
+        // list and TanStack silently strips the new column IDs from the
+        // newly-created view's columnOrder on the next layout update.
+        ...(variables.templateProperties &&
         variables.templateProperties.length > 0
-      ) {
-        invalidations.push(
-          queryClient.invalidateQueries({
-            queryKey: propertiesKeys.all(workspaceId),
-          }),
-        );
-      }
-      await Promise.all(invalidations);
+          ? [
+              queryClient.invalidateQueries({
+                queryKey: propertiesKeys.all(workspaceId),
+              }),
+            ]
+          : []),
+      ]);
     },
     onError: (error) => {
       analytics.captureError(error);

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-route-loader.logic.test.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-route-loader.logic.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "bun:test";
+
+import { loadWorkspaceRouteQueries } from "@/routes/_protected.workspaces/$workspaceId/-route-loader.logic";
+
+describe("matter route query startup", () => {
+  test("starts every non-blocking query before the workspace query resolves", async () => {
+    const workspace = Promise.withResolvers<string>();
+    const starts: string[] = [];
+
+    const result = loadWorkspaceRouteQueries({
+      loadWorkspace: async () => {
+        starts.push("workspace");
+        return await workspace.promise;
+      },
+      startPrefetches: [
+        () => {
+          starts.push("workflow");
+        },
+        () => {
+          starts.push("views");
+        },
+        () => {
+          starts.push("overview");
+        },
+        () => {
+          starts.push("properties");
+        },
+      ],
+    });
+
+    expect(starts).toEqual([
+      "workspace",
+      "workflow",
+      "views",
+      "overview",
+      "properties",
+    ]);
+
+    workspace.resolve("Matter B");
+    expect(await result).toBe("Matter B");
+  });
+});

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-route-loader.logic.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-route-loader.logic.ts
@@ -1,0 +1,18 @@
+type LoadWorkspaceRouteQueriesOptions<TWorkspace> = {
+  loadWorkspace: () => Promise<TWorkspace>;
+  startPrefetches: readonly (() => void)[];
+};
+
+// Start every independent request in the same loader turn. Awaiting the
+// breadcrumb query first turns otherwise parallel matter data into a network
+// waterfall on every cold navigation.
+export const loadWorkspaceRouteQueries = async <TWorkspace>({
+  loadWorkspace,
+  startPrefetches,
+}: LoadWorkspaceRouteQueriesOptions<TWorkspace>): Promise<TWorkspace> => {
+  const workspace = loadWorkspace();
+  for (const startPrefetch of startPrefetches) {
+    startPrefetch();
+  }
+  return await workspace;
+};

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/route.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/route.tsx
@@ -38,6 +38,7 @@ import { workflowOptions } from "@/lib/workspaces/queries/workspace";
 import { useWorkspaceStore } from "@/lib/workspaces/store";
 import { ReportExportTracker } from "@/routes/_protected.workspaces/$workspaceId/-components/view/report-export-tracker";
 import { WorkspaceDropZone } from "@/routes/_protected.workspaces/$workspaceId/-components/workspace-drop-zone";
+import { loadWorkspaceRouteQueries } from "@/routes/_protected.workspaces/$workspaceId/-route-loader.logic";
 
 const EXTRACTION_PREVIEW_CLIENT_TTL_MS = 5 * 60 * 1000;
 const ACTIVITY_INVALIDATION_DEBOUNCE_MS = 1000;
@@ -64,36 +65,41 @@ export const Route = createFileRoute("/_protected/workspaces/$workspaceId")({
     const wsId = params.workspaceId;
     const qc = context.queryClient;
 
-    // Only block on workspace name (breadcrumb). Everything else
-    // is prefetched — components use useSuspenseQuery which resolves
-    // from cache or shows granular loading states.
-    const workspace = await loadWorkspaceOrRedirect(qc, wsId);
-
     const onPrefetchError = (error: unknown) => {
       getAnalytics().captureError(error);
     };
-    detached(
-      prefetchRouteQuery(
-        qc,
-        workflowOptions({ key: { workspaceId: wsId } }),
-        onPrefetchError,
-      ),
-      "workspaces.prefetch",
-    );
-    detached(
-      prefetchRouteQuery(qc, viewsOptions(wsId), onPrefetchError),
-      "workspaces.prefetch",
-    );
-    detached(
-      prefetchRouteQuery(qc, overviewOptions(wsId), onPrefetchError),
-      "workspaces.prefetch",
-    );
-    detached(
-      prefetchRouteQuery(qc, propertiesOptions(wsId), onPrefetchError),
-      "workspaces.prefetch",
-    );
 
-    return workspace;
+    // Only the workspace name blocks the breadcrumb. Start every independent
+    // metadata request before awaiting it so they share the first network round.
+    return await loadWorkspaceRouteQueries({
+      loadWorkspace: async () => await loadWorkspaceOrRedirect(qc, wsId),
+      startPrefetches: [
+        () =>
+          detached(
+            prefetchRouteQuery(
+              qc,
+              workflowOptions({ key: { workspaceId: wsId } }),
+              onPrefetchError,
+            ),
+            "workspaces.prefetch",
+          ),
+        () =>
+          detached(
+            prefetchRouteQuery(qc, viewsOptions(wsId), onPrefetchError),
+            "workspaces.prefetch",
+          ),
+        () =>
+          detached(
+            prefetchRouteQuery(qc, overviewOptions(wsId), onPrefetchError),
+            "workspaces.prefetch",
+          ),
+        () =>
+          detached(
+            prefetchRouteQuery(qc, propertiesOptions(wsId), onPrefetchError),
+            "workspaces.prefetch",
+          ),
+      ],
+    });
   },
   head: ({ loaderData }) => ({
     meta: [


### PR DESCRIPTION
## Summary

- expose each matter’s default view in the bounded navigation response
- route sidebar matter opens directly to that view, with a rolling-deploy fallback
- start independent matter metadata queries concurrently and guard their startup ordering

CC on behalf of jankubica96

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Matter links now open the configured default view when available.
  - Navigation falls back to the main workspace when no default view is set.
  - Active navigation state is highlighted more accurately across pinned and recent items.

- **Performance**
  - Workspace pages begin loading related metadata earlier, helping content appear sooner.

- **Bug Fixes**
  - Navigation refreshes correctly after creating, deleting or reordering views.
  - Workspace navigation retains each matter’s default-view information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->