### PR TITLE
fix(api): keep the presign failure cause

### DIFF
--- a/apps/api/src/handlers/uploads/create.ts
+++ b/apps/api/src/handlers/uploads/create.ts
@@ -235,6 +235,7 @@ const presignUpload = createSafeHandler(
         new HandlerError({
           status: 500,
           message: "Failed to issue upload URL",
+          cause: presign.error,
         }),
       );
     }

--- a/apps/api/src/handlers/uploads/entity-create-tree.ts
+++ b/apps/api/src/handlers/uploads/entity-create-tree.ts
@@ -335,6 +335,7 @@ const prepareSignedFiles = async ({
         new HandlerError({
           status: 500,
           message: "Failed to issue upload URL",
+          cause: presign.error,
         }),
       );
     }

--- a/apps/api/src/lib/s3-presign.ts
+++ b/apps/api/src/lib/s3-presign.ts
@@ -167,6 +167,10 @@ const buildStsClient = async (): Promise<CachedStsClient> => {
  * resolution. Recycled every 50 minutes so STS session tokens are
  * refreshed before they expire — mirrors Bun's `getS3()` lifecycle
  * so both clients share the same credential horizon.
+ *
+ * A failed build clears the slot: credential resolution reaches the
+ * network, so caching its rejection would replay one transient
+ * failure to every later caller for the life of the process.
  */
 const getAwsS3Client = async (): Promise<AwsS3Client> => {
   if (_clientPromise) {
@@ -175,7 +179,10 @@ const getAwsS3Client = async (): Promise<AwsS3Client> => {
       return cached.client;
     }
   }
-  _clientPromise = buildAwsS3Client();
+  _clientPromise = buildAwsS3Client().catch((error: unknown) => {
+    _clientPromise = null;
+    throw error;
+  });
   const built = await _clientPromise;
   return built.client;
 };

--- a/apps/api/src/lib/s3-presign.ts
+++ b/apps/api/src/lib/s3-presign.ts
@@ -179,11 +179,14 @@ const getAwsS3Client = async (): Promise<AwsS3Client> => {
       return cached.client;
     }
   }
-  _clientPromise = buildAwsS3Client().catch((error: unknown) => {
-    _clientPromise = null;
+  const nextPromise = buildAwsS3Client().catch((error: unknown) => {
+    if (_clientPromise === nextPromise) {
+      _clientPromise = null;
+    }
     throw error;
   });
-  const built = await _clientPromise;
+  _clientPromise = nextPromise;
+  const built = await nextPromise;
   return built.client;
 };
 
@@ -195,11 +198,14 @@ const getStsClient = async (): Promise<STSClient> => {
     }
   }
 
-  _stsClientPromise = buildStsClient().catch((error: unknown) => {
-    _stsClientPromise = null;
+  const nextPromise = buildStsClient().catch((error: unknown) => {
+    if (_stsClientPromise === nextPromise) {
+      _stsClientPromise = null;
+    }
     throw error;
   });
-  const built = await _stsClientPromise;
+  _stsClientPromise = nextPromise;
+  const built = await nextPromise;
   return built.client;
 };
 


### PR DESCRIPTION
## Summary

- preserve typed presign causes for structured error reporting
- clear a rejected S3 client initialization so a later request can retry
- align the base client cache lifecycle with the existing STS and scoped-client caches

## Validation

- `bun test src/lib/s3-presign.test.ts`
- API typecheck, lint, and formatting checks

CC on behalf of jan-kubica