### PR TITLE
fix(api): resolve completed-request status from the returned response

### DIFF
--- a/apps/api/src/lib/observability/response-status.test.ts
+++ b/apps/api/src/lib/observability/response-status.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "bun:test";
+import { Elysia, status } from "elysia";
+
+import { resolveResponseStatus } from "@/api/lib/observability/response-status";
+
+/**
+ * Each way a handler can settle a status, exercised through a real
+ * Elysia app: the invariant is that the status observed from
+ * `onAfterHandle` is the one the client is actually served, and a
+ * hand-built context would only assert what the stand-in was shaped to
+ * return rather than what the framework does.
+ */
+const EXPECTED_STATUS_BY_PATH = {
+  "/implicit-ok": 200,
+  "/set-status": 202,
+  "/status-helper-4xx": 403,
+  "/status-helper-5xx": 500,
+  "/status-helper-named": 404,
+  "/raw-response": 502,
+} as const;
+
+describe("resolveResponseStatus", () => {
+  it("reports the status the client is served, however the handler set it", async () => {
+    const observed = new Map<string, number>();
+
+    const app = new Elysia()
+      .onAfterHandle(({ path, responseValue, set }) => {
+        observed.set(
+          path,
+          resolveResponseStatus({ response: responseValue, set }),
+        );
+      })
+      .get("/implicit-ok", () => ({ ok: true }))
+      .get("/set-status", ({ set }) => {
+        set.status = 202;
+        return { queued: true };
+      })
+      .get("/status-helper-4xx", () => status(403, { code: "forbidden" }))
+      .get("/status-helper-5xx", () => status(500, { code: "internal" }))
+      .get("/status-helper-named", () => status("Not Found", { code: "gone" }))
+      .get("/raw-response", () => new Response("upstream", { status: 502 }));
+
+    const served = new Map<string, number>();
+    await Promise.all(
+      Object.keys(EXPECTED_STATUS_BY_PATH).map(async (path) => {
+        const response = await app.handle(
+          new Request(`http://localhost${path}`),
+        );
+        served.set(path, response.status);
+      }),
+    );
+
+    // Pins what the framework actually serves, so a change in Elysia's
+    // status handling fails here rather than silently redefining the
+    // invariant the second assertion checks.
+    expect(Object.fromEntries(served)).toEqual(EXPECTED_STATUS_BY_PATH);
+    expect(Object.fromEntries(observed)).toEqual(Object.fromEntries(served));
+  });
+});

--- a/apps/api/src/lib/observability/response-status.test.ts
+++ b/apps/api/src/lib/observability/response-status.test.ts
@@ -13,6 +13,7 @@ import { resolveResponseStatus } from "@/api/lib/observability/response-status";
 const EXPECTED_STATUS_BY_PATH = {
   "/implicit-ok": 200,
   "/set-status": 202,
+  "/set-status-named": 202,
   "/status-helper-4xx": 403,
   "/status-helper-5xx": 500,
   "/status-helper-named": 404,
@@ -33,6 +34,10 @@ describe("resolveResponseStatus", () => {
       .get("/implicit-ok", () => ({ ok: true }))
       .get("/set-status", ({ set }) => {
         set.status = 202;
+        return { queued: true };
+      })
+      .get("/set-status-named", ({ set }) => {
+        set.status = "Accepted";
         return { queued: true };
       })
       .get("/status-helper-4xx", () => status(403, { code: "forbidden" }))

--- a/apps/api/src/lib/observability/response-status.ts
+++ b/apps/api/src/lib/observability/response-status.ts
@@ -1,0 +1,41 @@
+import type { Context } from "elysia";
+import { ElysiaCustomStatusResponse } from "elysia/error";
+
+const DEFAULT_RESPONSE_STATUS = 200;
+
+type ResolveResponseStatusOptions = {
+  response: unknown;
+  set: Context["set"];
+};
+
+/**
+ * The status a reply is actually sent with, as seen from `onAfterHandle`.
+ *
+ * A handler can carry its status on the value it returns rather than on
+ * `set`: `status(code, body)` holds it on the returned wrapper, and a
+ * returned `Response` holds it on the response itself. Elysia applies
+ * either while mapping the response, which happens after `onAfterHandle`
+ * runs, so `set.status` still holds the default at that point. Reading
+ * `set` alone therefore reports every such reply as a 200, including the
+ * whole safe-handler error path and any upstream status a route forwards
+ * verbatim.
+ */
+export const resolveResponseStatus = ({
+  response,
+  set,
+}: ResolveResponseStatusOptions): number => {
+  // `code` is generic over the status the call site passed, so it only
+  // narrows to a number once the instance is checked.
+  if (
+    response instanceof ElysiaCustomStatusResponse &&
+    typeof response.code === "number"
+  ) {
+    return response.code;
+  }
+
+  if (response instanceof Response) {
+    return response.status;
+  }
+
+  return typeof set.status === "number" ? set.status : DEFAULT_RESPONSE_STATUS;
+};

--- a/apps/api/src/lib/observability/response-status.ts
+++ b/apps/api/src/lib/observability/response-status.ts
@@ -1,4 +1,4 @@
-import type { Context } from "elysia";
+import { StatusMap, type Context } from "elysia";
 import { ElysiaCustomStatusResponse } from "elysia/error";
 
 const DEFAULT_RESPONSE_STATUS = 200;
@@ -37,5 +37,13 @@ export const resolveResponseStatus = ({
     return response.status;
   }
 
-  return typeof set.status === "number" ? set.status : DEFAULT_RESPONSE_STATUS;
+  if (typeof set.status === "number") {
+    return set.status;
+  }
+
+  if (typeof set.status === "string") {
+    return StatusMap[set.status];
+  }
+
+  return DEFAULT_RESPONSE_STATUS;
 };

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -127,6 +127,7 @@ import {
 } from "@/api/lib/observability/request-context";
 import { emitRequestDurationMetric } from "@/api/lib/observability/request-metrics";
 import { runWithRequestScope } from "@/api/lib/observability/request-scope";
+import { resolveResponseStatus } from "@/api/lib/observability/response-status";
 import { createRedisRateLimit } from "@/api/lib/rate-limit/redis-context";
 import {
   isCorpusS3Stale,
@@ -401,7 +402,7 @@ const api = new Elysia()
     }
     return httpError("Internal server error");
   })
-  .onAfterHandle(async ({ request, route, set }) => {
+  .onAfterHandle(async ({ request, responseValue, route, set }) => {
     delete set.headers["X-Powered-By"];
     setDbQueryCountHeader(set);
 
@@ -410,7 +411,10 @@ const api = new Elysia()
 
     if (shouldLogRequest(path) && reqCtx) {
       const durationMs = performance.now() - reqCtx.startTime;
-      const statusCode = typeof set.status === "number" ? set.status : 200;
+      const statusCode = resolveResponseStatus({
+        response: responseValue,
+        set,
+      });
       const details = buildRequestLogDetails({
         durationMs,
         request,


### PR DESCRIPTION
## Proposed change

`onAfterHandle` derived the status it records from `set.status` alone. A handler can instead carry the status on the value it returns:

- `status(code, body)` holds it on the returned wrapper. `runSafeHandler` returns every error branch this way through `toSafeStatusResponse`, so the entire safe-handler error path is affected (400, 403, and 500 alike).
- A returned `Response` holds it on the response itself. `handleOAuthAuthorizationServerMetadataRequest` forwards an upstream status verbatim this way.

Elysia applies either while mapping the response, which happens after the hook runs, so `set.status` is still the default at that point. The client is served the correct status; only the hook's view of it was wrong.

That gave three wrong results, all inside the hook:

- `request.completed` recorded `http.status_code: 200` for those replies, so a failed request is indistinguishable from a successful one in that line.
- The `RequestDuration` EMF record carried `http.status_code: 200`, making that property useless for splitting latency by outcome.
- The hook's own severity split could never reach its `>= 400` (WARN) or `>= 500` (ERROR) branches, so every such reply was logged at INFO.

`resolveResponseStatus` now reads the returned value first and falls back to `set`. It lives in its own module rather than in `server.ts` because that file builds the app at import time, and the helper should be testable without paying for that.

The accompanying test drives a real Elysia app across all six ways a handler can settle a status and asserts two things: what the framework actually serves, and that the resolved status equals it in every case. Removing the fix fails it on four of the six.

## Validation

- `bun test src/lib/observability/response-status.test.ts`
- `bun --filter @stll/api typecheck`
- `bun --bun oxlint -c oxlint.config.ts --deny-warnings --type-aware --type-check` on the touched files
- `bun run format`

## Checklist

- [x] **BUILD ASSURANCE** | Code builds correctly and without any errors or warnings.
- [x] **TESTING** | Changes tested, including in different conditions (dark mode, language, narrow screen, etc).
- [ ] DARK MODE SUPPORT | Not applicable: API-only change, no user-facing surface.
- [ ] ISSUE LINKED | No existing issue.
- [ ] SCREENSHOT INCLUDED | Not applicable: no UI change.


---
_Generated by [Claude Code](https://claude.ai/code/session_01SBhzfbfAL54Z4ApNT9xwEy)_