### PR TITLE
fix(api): keep document processing status implementation-neutral

### DIFF
--- a/.changeset/neutral-document-processing.md
+++ b/.changeset/neutral-document-processing.md
@@ -1,0 +1,5 @@
+---
+"@stll/cli": patch
+---
+
+Describe document text processing with one implementation-neutral state in the generated MCP registry.

--- a/apps/api/src/lib/chat/projections.ts
+++ b/apps/api/src/lib/chat/projections.ts
@@ -1,6 +1,10 @@
 import * as v from "valibot";
 
 import { TIME_ENTRY_VISIBILITY } from "@/api/lib/billing-constants";
+import {
+  DOCUMENT_PROCESSING_KIND,
+  DOCUMENT_PROCESSING_REQUIRED_STATUS,
+} from "@/api/lib/document-processing-contract";
 
 import {
   chatEntityRef,
@@ -403,7 +407,7 @@ const readDocumentEntityId = () =>
 // accepting their former discriminator values so historical chats still load;
 // document-tools.ts emits only the generic values for new results.
 const documentProcessingKindProjection = v.picklist([
-  "document-processing",
+  DOCUMENT_PROCESSING_KIND,
   "native-extraction",
   "ocr",
 ]);
@@ -439,7 +443,7 @@ const documentContentStateProjection = v.variant("status", [
     sourceVersionId: passthroughId(),
   }),
   v.strictObject({
-    status: v.literal("requires_processing"),
+    status: v.literal(DOCUMENT_PROCESSING_REQUIRED_STATUS),
     sourceVersionId: passthroughId(),
     remediation: documentProcessingRemediationProjection,
   }),

--- a/apps/api/src/lib/chat/projections.ts
+++ b/apps/api/src/lib/chat/projections.ts
@@ -2,6 +2,7 @@ import * as v from "valibot";
 
 import { TIME_ENTRY_VISIBILITY } from "@/api/lib/billing-constants";
 import {
+  DOCUMENT_PROCESSING_FAILURE_CODE,
   DOCUMENT_PROCESSING_KIND,
   DOCUMENT_PROCESSING_REQUIRED_STATUS,
 } from "@/api/lib/document-processing-contract";
@@ -403,15 +404,6 @@ const documentVersionEntryProjection = v.strictObject({
 const readDocumentEntityId = () =>
   chatEntityRef({ from: "inputEntity", param: "entity_id" });
 
-// Stored tool results can predate the implementation-neutral MCP state. Keep
-// accepting their former discriminator values so historical chats still load;
-// document-tools.ts emits only the generic values for new results.
-const documentProcessingKindProjection = v.picklist([
-  DOCUMENT_PROCESSING_KIND,
-  "native-extraction",
-  "ocr",
-]);
-
 const documentProcessingRemediationProjection = v.variant("type", [
   v.strictObject({
     type: v.literal("action"),
@@ -438,7 +430,7 @@ const documentContentStateProjection = v.variant("status", [
   }),
   v.strictObject({
     status: v.literal("pending"),
-    processingKind: documentProcessingKindProjection,
+    processingKind: v.literal(DOCUMENT_PROCESSING_KIND),
     runId: v.nullable(passthroughId()),
     sourceVersionId: passthroughId(),
   }),
@@ -448,16 +440,11 @@ const documentContentStateProjection = v.variant("status", [
     remediation: documentProcessingRemediationProjection,
   }),
   v.strictObject({
-    status: v.literal("requires_ocr"),
-    sourceVersionId: passthroughId(),
-    remediation: documentProcessingRemediationProjection,
-  }),
-  v.strictObject({
     status: v.literal("failed"),
-    processingKind: documentProcessingKindProjection,
+    processingKind: v.literal(DOCUMENT_PROCESSING_KIND),
     runId: passthroughId(),
     sourceVersionId: passthroughId(),
-    errorCode: v.nullable(v.string()),
+    errorCode: v.literal(DOCUMENT_PROCESSING_FAILURE_CODE),
     retryable: v.literal(true),
   }),
   v.strictObject({

--- a/apps/api/src/lib/chat/projections.ts
+++ b/apps/api/src/lib/chat/projections.ts
@@ -399,6 +399,31 @@ const documentVersionEntryProjection = v.strictObject({
 const readDocumentEntityId = () =>
   chatEntityRef({ from: "inputEntity", param: "entity_id" });
 
+// Stored tool results can predate the implementation-neutral MCP state. Keep
+// accepting their former discriminator values so historical chats still load;
+// document-tools.ts emits only the generic values for new results.
+const documentProcessingKindProjection = v.picklist([
+  "document-processing",
+  "native-extraction",
+  "ocr",
+]);
+
+const documentProcessingRemediationProjection = v.variant("type", [
+  v.strictObject({
+    type: v.literal("action"),
+    tool: v.literal("invoke_capability"),
+    // Internal chat cannot invoke generic capabilities. Strip arguments
+    // defensively if this unreachable branch is ever returned.
+    arguments: strippedField(),
+  }),
+  v.strictObject({
+    type: v.literal("escalation"),
+    requiredScope: v.literal("stella:matters_write"),
+    requiredPermission: v.literal("entity:update"),
+    instruction: v.string(),
+  }),
+]);
+
 const documentContentStateProjection = v.variant("status", [
   v.strictObject({ status: v.literal("not_applicable") }),
   v.strictObject({
@@ -409,32 +434,23 @@ const documentContentStateProjection = v.variant("status", [
   }),
   v.strictObject({
     status: v.literal("pending"),
-    processingKind: v.picklist(["native-extraction", "ocr"]),
+    processingKind: documentProcessingKindProjection,
     runId: v.nullable(passthroughId()),
     sourceVersionId: passthroughId(),
   }),
   v.strictObject({
+    status: v.literal("requires_processing"),
+    sourceVersionId: passthroughId(),
+    remediation: documentProcessingRemediationProjection,
+  }),
+  v.strictObject({
     status: v.literal("requires_ocr"),
     sourceVersionId: passthroughId(),
-    remediation: v.variant("type", [
-      v.strictObject({
-        type: v.literal("action"),
-        tool: v.literal("invoke_capability"),
-        // Internal chat cannot invoke generic capabilities. Strip arguments
-        // defensively if this unreachable branch is ever returned.
-        arguments: strippedField(),
-      }),
-      v.strictObject({
-        type: v.literal("escalation"),
-        requiredScope: v.literal("stella:matters_write"),
-        requiredPermission: v.literal("entity:update"),
-        instruction: v.string(),
-      }),
-    ]),
+    remediation: documentProcessingRemediationProjection,
   }),
   v.strictObject({
     status: v.literal("failed"),
-    processingKind: v.picklist(["native-extraction", "ocr"]),
+    processingKind: documentProcessingKindProjection,
     runId: passthroughId(),
     sourceVersionId: passthroughId(),
     errorCode: v.nullable(v.string()),

--- a/apps/api/src/lib/document-processing-contract.ts
+++ b/apps/api/src/lib/document-processing-contract.ts
@@ -4,6 +4,11 @@ export const DOCUMENT_OCR_PROCESSOR_VERSION = 2;
 /** Persisted-output contract for sandboxed native text extraction. */
 export const DOCUMENT_NATIVE_EXTRACTION_PROCESSOR_VERSION = 1;
 
+/** Implementation-neutral document state exposed beyond the processing slice. */
+export const DOCUMENT_PROCESSING_KIND = "document-processing";
+export const DOCUMENT_PROCESSING_REQUIRED_STATUS = "requires_processing";
+export const DOCUMENT_PROCESSING_FAILURE_CODE = "document_processing_failed";
+
 export type DocumentOcrLine = {
   box: readonly [number, number, number, number];
   confidence: number;

--- a/apps/api/src/mcp/__snapshots__/registry-quality.test.ts.snap
+++ b/apps/api/src/mcp/__snapshots__/registry-quality.test.ts.snap
@@ -927,7 +927,7 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "name": "read_document",
     "scope": "stella:read",
     "access": "read",
-    "description": "Read a document's metadata and field values by entity ID. By default returns the current version's name, kind, and field/property values. The default response also reports contentState and searchIndexState, including an actionable remediation or escalation requirement when searchable-text OCR is required. Pass version_id to inspect a specific version instead. Pass version_id and compare_with_version_id to get a plain-text line diff between two versions. Pass include_versions to also return the version history. To read the document's extracted text content, use read_content_across_matters.",
+    "description": "Read a document's metadata and field values by entity ID. By default returns the current version's name, kind, and field/property values. The default response also reports contentState and searchIndexState, including an actionable remediation or escalation requirement when document text processing is required. Pass version_id to inspect a specific version instead. Pass version_id and compare_with_version_id to get a plain-text line diff between two versions. Pass include_versions to also return the version history. To read the document's extracted text content, use read_content_across_matters.",
     "annotations": {
       "title": "Read document",
       "readOnlyHint": true,
@@ -2936,7 +2936,7 @@ exports[`MCP registry quality (anonymized surface) tool surface snapshot (name, 
     "name": "read_document",
     "scope": "stella:read_anonymized",
     "access": "read",
-    "description": "Read a document's metadata and field values by entity ID. By default returns the current version's name, kind, and field/property values. The default response also reports contentState and searchIndexState, including an actionable remediation or escalation requirement when searchable-text OCR is required. Pass version_id to inspect a specific version instead. Pass version_id and compare_with_version_id to get a plain-text line diff between two versions. Pass include_versions to also return the version history. To read the document's extracted text content, use read_content_across_matters.",
+    "description": "Read a document's metadata and field values by entity ID. By default returns the current version's name, kind, and field/property values. The default response also reports contentState and searchIndexState, including an actionable remediation or escalation requirement when document text processing is required. Pass version_id to inspect a specific version instead. Pass version_id and compare_with_version_id to get a plain-text line diff between two versions. Pass include_versions to also return the version history. To read the document's extracted text content, use read_content_across_matters.",
     "annotations": {
       "title": "Read document",
       "readOnlyHint": true,

--- a/apps/api/src/mcp/document-tools.ts
+++ b/apps/api/src/mcp/document-tools.ts
@@ -537,7 +537,7 @@ export const DOCUMENT_TOOL_DEFINITIONS = [
       "returns the current version's name, kind, and field/property values. " +
       "The default response also reports contentState and searchIndexState, " +
       "including an actionable remediation or escalation requirement when " +
-      "searchable-text OCR is required. " +
+      "document text processing is required. " +
       "Pass version_id to inspect a specific version instead. Pass version_id " +
       "and compare_with_version_id to get a plain-text line diff between two " +
       "versions. Pass include_versions to also return the version history. To " +
@@ -1183,6 +1183,8 @@ type CurrentDocumentForState = {
   }[];
 };
 
+const DOCUMENT_PROCESSING_FAILURE_CODE = "document_processing_failed";
+
 type DocumentContentState =
   | { status: "not_applicable" }
   | {
@@ -1193,12 +1195,12 @@ type DocumentContentState =
     }
   | {
       status: "pending";
-      processingKind: "native-extraction" | "ocr";
+      processingKind: "document-processing";
       runId: SafeId<"documentProcessingRun"> | null;
       sourceVersionId: SafeId<"entityVersion">;
     }
   | {
-      status: "requires_ocr";
+      status: "requires_processing";
       sourceVersionId: SafeId<"entityVersion">;
       remediation:
         | {
@@ -1224,10 +1226,10 @@ type DocumentContentState =
     }
   | {
       status: "failed";
-      processingKind: "native-extraction" | "ocr";
+      processingKind: "document-processing";
       runId: SafeId<"documentProcessingRun">;
       sourceVersionId: SafeId<"entityVersion">;
-      errorCode: string | null;
+      errorCode: typeof DOCUMENT_PROCESSING_FAILURE_CODE;
       retryable: true;
     }
   | {
@@ -1456,10 +1458,10 @@ const loadDocumentProcessingStates = async ({
   ) {
     contentState = {
       status: "failed",
-      processingKind: "native-extraction",
+      processingKind: "document-processing",
       runId: nativeRun.id,
       sourceVersionId: current.currentVersionId,
-      errorCode: nativeRun.errorCode,
+      errorCode: DOCUMENT_PROCESSING_FAILURE_CODE,
       retryable: true,
     };
   } else if (!sourceFile.encrypted && sourceFile.mimeType === DOCX_MIME_TYPE) {
@@ -1482,16 +1484,16 @@ const loadDocumentProcessingStates = async ({
   ) {
     contentState = {
       status: "failed",
-      processingKind: "ocr",
+      processingKind: "document-processing",
       runId: ocrRun.id,
       sourceVersionId: current.currentVersionId,
-      errorCode: ocrRun.errorCode,
+      errorCode: DOCUMENT_PROCESSING_FAILURE_CODE,
       retryable: true,
     };
   } else if (ocrRun?.status === "queued" || ocrRun?.status === "running") {
     contentState = {
       status: "pending",
-      processingKind: "ocr",
+      processingKind: "document-processing",
       runId: ocrRun.id,
       sourceVersionId: current.currentVersionId,
     };
@@ -1502,7 +1504,8 @@ const loadDocumentProcessingStates = async ({
     contentState = {
       status: "unsupported",
       sourceVersionId: current.currentVersionId,
-      reason: "OCR is unavailable while the matter is not active.",
+      reason:
+        "Document processing is unavailable while the matter is not active.",
     };
   } else if (
     currentExtracted?.charCount === 0 &&
@@ -1512,7 +1515,7 @@ const loadDocumentProcessingStates = async ({
       "off"
   ) {
     contentState = {
-      status: "requires_ocr",
+      status: "requires_processing",
       sourceVersionId: current.currentVersionId,
       remediation: canQueueManualOcr
         ? {
@@ -1536,7 +1539,7 @@ const loadDocumentProcessingStates = async ({
             requiredScope: "stella:matters_write",
             requiredPermission: "entity:update",
             instruction:
-              "Ask a matter editor with stella:matters_write to invoke entities.ocr.create for this document field.",
+              "Ask a matter editor to start document processing for this field.",
           },
     };
   } else if (currentExtracted) {
@@ -1549,10 +1552,10 @@ const loadDocumentProcessingStates = async ({
   } else if (nativeRun?.status === "failed") {
     contentState = {
       status: "failed",
-      processingKind: "native-extraction",
+      processingKind: "document-processing",
       runId: nativeRun.id,
       sourceVersionId: current.currentVersionId,
-      errorCode: nativeRun.errorCode,
+      errorCode: DOCUMENT_PROCESSING_FAILURE_CODE,
       retryable: true,
     };
   } else if (sourceFile.encrypted) {
@@ -1570,7 +1573,7 @@ const loadDocumentProcessingStates = async ({
   } else {
     contentState = {
       status: "pending",
-      processingKind: "native-extraction",
+      processingKind: "document-processing",
       runId:
         nativeRun?.status === "queued" || nativeRun?.status === "running"
           ? nativeRun.id

--- a/apps/api/src/mcp/document-tools.ts
+++ b/apps/api/src/mcp/document-tools.ts
@@ -44,6 +44,11 @@ import { isUuid } from "@/api/lib/custom-schema";
 import { createTimestampIdCursorCodec } from "@/api/lib/db-pagination";
 import { selectCurrentExtractedContent } from "@/api/lib/document-content-provenance";
 import {
+  DOCUMENT_PROCESSING_FAILURE_CODE,
+  DOCUMENT_PROCESSING_KIND,
+  DOCUMENT_PROCESSING_REQUIRED_STATUS,
+} from "@/api/lib/document-processing-contract";
+import {
   entityListCursorCondition,
   entityListTimestampCursorExpr,
 } from "@/api/lib/entities/list-cursor";
@@ -1183,8 +1188,6 @@ type CurrentDocumentForState = {
   }[];
 };
 
-const DOCUMENT_PROCESSING_FAILURE_CODE = "document_processing_failed";
-
 type DocumentContentState =
   | { status: "not_applicable" }
   | {
@@ -1195,12 +1198,12 @@ type DocumentContentState =
     }
   | {
       status: "pending";
-      processingKind: "document-processing";
+      processingKind: typeof DOCUMENT_PROCESSING_KIND;
       runId: SafeId<"documentProcessingRun"> | null;
       sourceVersionId: SafeId<"entityVersion">;
     }
   | {
-      status: "requires_processing";
+      status: typeof DOCUMENT_PROCESSING_REQUIRED_STATUS;
       sourceVersionId: SafeId<"entityVersion">;
       remediation:
         | {
@@ -1226,7 +1229,7 @@ type DocumentContentState =
     }
   | {
       status: "failed";
-      processingKind: "document-processing";
+      processingKind: typeof DOCUMENT_PROCESSING_KIND;
       runId: SafeId<"documentProcessingRun">;
       sourceVersionId: SafeId<"entityVersion">;
       errorCode: typeof DOCUMENT_PROCESSING_FAILURE_CODE;
@@ -1458,7 +1461,7 @@ const loadDocumentProcessingStates = async ({
   ) {
     contentState = {
       status: "failed",
-      processingKind: "document-processing",
+      processingKind: DOCUMENT_PROCESSING_KIND,
       runId: nativeRun.id,
       sourceVersionId: current.currentVersionId,
       errorCode: DOCUMENT_PROCESSING_FAILURE_CODE,
@@ -1484,7 +1487,7 @@ const loadDocumentProcessingStates = async ({
   ) {
     contentState = {
       status: "failed",
-      processingKind: "document-processing",
+      processingKind: DOCUMENT_PROCESSING_KIND,
       runId: ocrRun.id,
       sourceVersionId: current.currentVersionId,
       errorCode: DOCUMENT_PROCESSING_FAILURE_CODE,
@@ -1493,7 +1496,7 @@ const loadDocumentProcessingStates = async ({
   } else if (ocrRun?.status === "queued" || ocrRun?.status === "running") {
     contentState = {
       status: "pending",
-      processingKind: "document-processing",
+      processingKind: DOCUMENT_PROCESSING_KIND,
       runId: ocrRun.id,
       sourceVersionId: current.currentVersionId,
     };
@@ -1515,7 +1518,7 @@ const loadDocumentProcessingStates = async ({
       "off"
   ) {
     contentState = {
-      status: "requires_processing",
+      status: DOCUMENT_PROCESSING_REQUIRED_STATUS,
       sourceVersionId: current.currentVersionId,
       remediation: canQueueManualOcr
         ? {
@@ -1552,7 +1555,7 @@ const loadDocumentProcessingStates = async ({
   } else if (nativeRun?.status === "failed") {
     contentState = {
       status: "failed",
-      processingKind: "document-processing",
+      processingKind: DOCUMENT_PROCESSING_KIND,
       runId: nativeRun.id,
       sourceVersionId: current.currentVersionId,
       errorCode: DOCUMENT_PROCESSING_FAILURE_CODE,
@@ -1573,7 +1576,7 @@ const loadDocumentProcessingStates = async ({
   } else {
     contentState = {
       status: "pending",
-      processingKind: "document-processing",
+      processingKind: DOCUMENT_PROCESSING_KIND,
       runId:
         nativeRun?.status === "queued" || nativeRun?.status === "running"
           ? nativeRun.id

--- a/apps/api/src/mcp/tools.test.ts
+++ b/apps/api/src/mcp/tools.test.ts
@@ -2614,9 +2614,9 @@ describe("OpenAI-compatible MCP tools", () => {
     expect(parseToolPayload(result)).toMatchObject({
       contentState: {
         status: "failed",
-        processingKind: "native-extraction",
+        processingKind: "document-processing",
         runId: "run_native",
-        errorCode: "processing_failed",
+        errorCode: "document_processing_failed",
         retryable: true,
       },
     });
@@ -2649,7 +2649,7 @@ describe("OpenAI-compatible MCP tools", () => {
 
     expect(parseToolPayload(result)).toMatchObject({
       contentState: {
-        status: "requires_ocr",
+        status: "requires_processing",
         sourceVersionId: "entity_version_1",
         remediation: {
           type: "action",
@@ -2715,7 +2715,7 @@ describe("OpenAI-compatible MCP tools", () => {
 
     expect(parseToolPayload(result)).toMatchObject({
       contentState: {
-        status: "requires_ocr",
+        status: "requires_processing",
         remediation: {
           type: "action",
           arguments: {
@@ -2768,7 +2768,7 @@ describe("OpenAI-compatible MCP tools", () => {
 
       expect(parseToolPayload(result)).toMatchObject({
         contentState: {
-          status: "requires_ocr",
+          status: "requires_processing",
           sourceVersionId: "entity_version_1",
           remediation: {
             type: "escalation",
@@ -2807,7 +2807,7 @@ describe("OpenAI-compatible MCP tools", () => {
 
     expect(parseToolPayload(result)).toMatchObject({
       contentState: {
-        status: "requires_ocr",
+        status: "requires_processing",
         remediation: { type: "escalation" },
       },
     });
@@ -2915,7 +2915,8 @@ describe("OpenAI-compatible MCP tools", () => {
     expect(parseToolPayload(result)).toMatchObject({
       contentState: {
         status: "unsupported",
-        reason: "OCR is unavailable while the matter is not active.",
+        reason:
+          "Document processing is unavailable while the matter is not active.",
       },
     });
   });
@@ -3046,7 +3047,7 @@ describe("OpenAI-compatible MCP tools", () => {
 
     expect(parseToolPayload(result)).toMatchObject({
       contentState: {
-        status: "requires_ocr",
+        status: "requires_processing",
         remediation: { type: "action" },
       },
       searchIndexState: {

--- a/packages/cli/src/generated/registry-snapshot.json
+++ b/packages/cli/src/generated/registry-snapshot.json
@@ -946,7 +946,7 @@
       "scope": "read"
     },
     "name": "read_document",
-    "description": "Read a document's metadata and field values by entity ID. By default returns the current version's name, kind, and field/property values. The default response also reports contentState and searchIndexState, including an actionable remediation or escalation requirement when searchable-text OCR is required. Pass version_id to inspect a specific version instead. Pass version_id and compare_with_version_id to get a plain-text line diff between two versions. Pass include_versions to also return the version history. To read the document's extracted text content, use read_content_across_matters.",
+    "description": "Read a document's metadata and field values by entity ID. By default returns the current version's name, kind, and field/property values. The default response also reports contentState and searchIndexState, including an actionable remediation or escalation requirement when document text processing is required. Pass version_id to inspect a specific version instead. Pass version_id and compare_with_version_id to get a plain-text line diff between two versions. Pass include_versions to also return the version history. To read the document's extracted text content, use read_content_across_matters.",
     "inputSchema": {
       "type": "object",
       "properties": {


### PR DESCRIPTION
## Summary

- expose one stable document-processing state across text extraction implementations
- return a generic retryable content-processing failure code
- retain validation support for historical tool results during chat reload

## Validation

- `bun --filter @stll/api typecheck`
- focused type-aware lint and format checks
- `bun test src/mcp/tools.test.ts` (105 pass)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added unified document-processing status reporting across document-reading tools.
  * Processing states now provide clearer status details, including processing type and source information.
* **Bug Fixes**
  * Standardised processing failure messages and error codes.
  * Updated remediation guidance to cover document processing beyond OCR.
  * Improved unsupported-document messaging for inactive matters.
* **Tests**
  * Updated document-reading coverage for unified processing statuses and error terminology.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->