### PR TITLE
fix(api): preserve valid OOXML metadata shapes

### DIFF
--- a/apps/api/src/lib/files/document-properties.test.ts
+++ b/apps/api/src/lib/files/document-properties.test.ts
@@ -364,7 +364,8 @@ describe("scrubDocumentProperties", () => {
       /<(?:cp:revision|cp:lastPrinted|dcterms:(?:created|modified))\b/u,
     );
     expect(scrubbedComments).toContain('x:author=""');
-    expect(scrubbedComments).not.toMatch(/x:(?:date|initials)=/u);
+    expect(scrubbedComments).toContain('x:initials=""');
+    expect(scrubbedComments).not.toMatch(/x:date=/u);
   });
 
   it("clears the OpenDocument meta part, statistics included", async () => {

--- a/apps/api/src/lib/files/document-properties.test.ts
+++ b/apps/api/src/lib/files/document-properties.test.ts
@@ -60,7 +60,8 @@ const CORE_XML = [
   '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>',
   '<cp:coreProperties xmlns:cp="http://schemas.openxmlformats.org/package/2006/metadata/core-properties"',
   ' xmlns:dc="http://purl.org/dc/elements/1.1/"',
-  ' xmlns:dcterms="http://purl.org/dc/terms/">',
+  ' xmlns:dcterms="http://purl.org/dc/terms/"',
+  ' xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">',
   "<dc:title>Series Seed SANE</dc:title>",
   "<dc:creator>Jane Novak &amp; Co.</dc:creator>",
   "<cp:lastModifiedBy>tomas</cp:lastModifiedBy>",
@@ -339,7 +340,7 @@ describe("scrubDocumentProperties", () => {
     assertNoTrace(result, ["Jane Novak", "Nov&#225;k Legal"]);
   });
 
-  it("scrubs collaboration authors and dates across Word XML parts", async () => {
+  it("keeps typed OOXML metadata schema-valid while removing its values", async () => {
     const comments =
       '<x:comments xmlns:x="http://schemas.openxmlformats.org/wordprocessingml/2006/main">' +
       '<x:comment x:author="Jane Novak" x:initials="JN" x:date="2024-01-01T00:00:00Z"/></x:comments>';
@@ -353,6 +354,17 @@ describe("scrubDocumentProperties", () => {
     );
 
     assertNoTrace(result, ["Jane Novak", "JN", "2024-01-01T00:00:00Z"]);
+    const archive = await new JSZip().loadAsync(result);
+    const core = await archive.file("docProps/core.xml")?.async("string");
+    const scrubbedComments = await archive
+      .file("word/comments.xml")
+      ?.async("string");
+
+    expect(core).not.toMatch(
+      /<(?:cp:revision|cp:lastPrinted|dcterms:(?:created|modified))\b/u,
+    );
+    expect(scrubbedComments).toContain('x:author=""');
+    expect(scrubbedComments).not.toMatch(/x:(?:date|initials)=/u);
   });
 
   it("clears the OpenDocument meta part, statistics included", async () => {

--- a/apps/api/src/lib/files/document-properties.ts
+++ b/apps/api/src/lib/files/document-properties.ts
@@ -434,7 +434,7 @@ const WORD_2012_NS = "http://schemas.microsoft.com/office/word/2012/wordml";
 
 type XmlElement = { namespace: string; localName: string };
 
-const OOXML_CORE_CLEARED = [
+const OOXML_CORE_TEXT_CLEARED = [
   { namespace: DC_NS, localName: "title" },
   { namespace: DC_NS, localName: "subject" },
   { namespace: DC_NS, localName: "creator" },
@@ -443,6 +443,13 @@ const OOXML_CORE_CLEARED = [
   { namespace: OOXML_CORE_NS, localName: "category" },
   { namespace: OOXML_CORE_NS, localName: "contentStatus" },
   { namespace: OOXML_CORE_NS, localName: "lastModifiedBy" },
+] as const satisfies readonly XmlElement[];
+
+/**
+ * Typed properties cannot be represented by an empty element. Remove them so
+ * the package does not retain an invalid date or revision lexical value.
+ */
+const OOXML_CORE_REMOVED = [
   { namespace: OOXML_CORE_NS, localName: "revision" },
   { namespace: OOXML_CORE_NS, localName: "lastPrinted" },
   { namespace: DCTERMS_NS, localName: "created" },
@@ -604,7 +611,10 @@ const scrubZipArchive = async (
   await prepare?.(archive);
   return {
     status: "scrubbed",
-    bytes: await archive.zip.generateAsync({ type: "uint8array" }),
+    bytes: await archive.zip.generateAsync({
+      type: "uint8array",
+      compression: "DEFLATE",
+    }),
   };
 };
 
@@ -621,17 +631,69 @@ const scrubCustomProperties = (xml: string): string =>
     },
   );
 
+type CollaborationAttributePolicies = {
+  author: "clear";
+  date: "remove";
+  initials: "remove";
+  providerId: "remove";
+  userId: "remove";
+};
+
+/**
+ * A closed policy keeps schema-required authors present while making it
+ * impossible to blank typed or optional collaboration attributes.
+ */
+const COLLABORATION_ATTRIBUTE_POLICIES = {
+  author: "clear",
+  date: "remove",
+  initials: "remove",
+  userId: "remove",
+  providerId: "remove",
+} as const satisfies CollaborationAttributePolicies;
+
+const removeNamespacedAttribute = (
+  xml: string,
+  element: XmlElement,
+): string => {
+  let scrubbed = xml;
+  for (const name of qualifiedNames(xml, element)) {
+    const regex = new RegExp(
+      `\\s${name}\\s*=\\s*(?<quote>["'])[^"']*\\k<quote>`,
+      "gu",
+    );
+    scrubbed = scrubbed.replace(regex, "");
+  }
+  return scrubbed;
+};
+
+const clearNamespacedAttribute = (xml: string, element: XmlElement): string => {
+  let scrubbed = xml;
+  for (const name of qualifiedNames(xml, element)) {
+    const regex = new RegExp(
+      `(?<prefix>\\s${name}\\s*=\\s*)(?<quote>["'])[^"']*\\k<quote>`,
+      "gu",
+    );
+    scrubbed = scrubbed.replace(regex, '$<prefix>""');
+  }
+  return scrubbed;
+};
+
 const scrubCollaborationAttributes = (xml: string): string => {
   let scrubbed = xml;
-  const attributeNames = ["author", "date", "initials", "userId", "providerId"];
   for (const namespace of [WORD_MAIN_NS, WORD_2012_NS]) {
-    for (const localName of attributeNames) {
-      for (const name of qualifiedNames(xml, { namespace, localName })) {
-        const regex = new RegExp(
-          `(?<prefix>\\s${name}\\s*=\\s*)(?<quote>["'])[^"']*\\k<quote>`,
-          "gu",
-        );
-        scrubbed = scrubbed.replace(regex, '$<prefix>""');
+    for (const [localName, action] of Object.entries(
+      COLLABORATION_ATTRIBUTE_POLICIES,
+    )) {
+      const element = { namespace, localName };
+      switch (action) {
+        case "clear":
+          scrubbed = clearNamespacedAttribute(scrubbed, element);
+          break;
+        case "remove":
+          scrubbed = removeNamespacedAttribute(scrubbed, element);
+          break;
+        default:
+          action satisfies never;
       }
     }
   }
@@ -659,7 +721,11 @@ const scrubOoxml = async (
             message: "Invalid OOXML core properties root",
           });
         }
-        return clearNamespacedElements(xml, OOXML_CORE_CLEARED);
+        let scrubbed = clearNamespacedElements(xml, OOXML_CORE_TEXT_CLEARED);
+        for (const element of OOXML_CORE_REMOVED) {
+          scrubbed = removeNamespacedElements(scrubbed, element);
+        }
+        return scrubbed;
       },
       propertyEntry: true,
       required: true,

--- a/apps/api/src/lib/files/document-properties.ts
+++ b/apps/api/src/lib/files/document-properties.ts
@@ -634,7 +634,7 @@ const scrubCustomProperties = (xml: string): string =>
 type CollaborationAttributePolicies = {
   author: "clear";
   date: "remove";
-  initials: "remove";
+  initials: "clear";
   providerId: "remove";
   userId: "remove";
 };
@@ -646,7 +646,7 @@ type CollaborationAttributePolicies = {
 const COLLABORATION_ATTRIBUTE_POLICIES = {
   author: "clear",
   date: "remove",
-  initials: "remove",
+  initials: "clear",
   userId: "remove",
   providerId: "remove",
 } as const satisfies CollaborationAttributePolicies;


### PR DESCRIPTION
## Summary

- remove typed OOXML properties instead of representing them with invalid empty lexical values
- preserve required anonymous authors while removing optional collaboration attributes through a closed policy
- keep rewritten ZIP-based documents compressed

## Validation

- `bun --filter @stll/api test -- src/lib/files/document-properties.test.ts`
- `bun --filter @stll/api typecheck`
- affected lint, formatting, i18n, and workspace checks via the pre-push hook
- Open XML SDK validation before and after scrubbing a representative DOCX; the transformed package adds no validation findings
- LibreOffice render of the transformed 150-page DOCX